### PR TITLE
feat: migrate JWT from localStorage to httpOnly cookies (Sprint 6)

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -3,6 +3,7 @@ import { asyncHandler, AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
 import * as authService from '../services/authService.js';
 import * as onboardingService from '../services/onboardingService.js';
+import { setAuthCookie, clearAuthCookie } from '../utils/authCookie.js';
 
 const googleClient = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 
@@ -14,7 +15,7 @@ export const googleLogin = async (req, res) => {
     if (!credential) {
       return res.status(400).json({
         success: false,
-        message: 'Missing Google credential'
+        message: 'Missing Google credential',
       });
     }
 
@@ -30,7 +31,7 @@ export const googleLogin = async (req, res) => {
     if (!email || !googleSub) {
       return res.status(401).json({
         success: false,
-        message: 'Invalid Google token payload'
+        message: 'Invalid Google token payload',
       });
     }
 
@@ -39,9 +40,10 @@ export const googleLogin = async (req, res) => {
       email,
       googleSub,
       name: payload.name,
-      picture: payload.picture
+      picture: payload.picture,
     });
 
+    setAuthCookie(res, result.token);
     return res.json({
       success: true,
       message: 'Google authentication successful',
@@ -56,7 +58,7 @@ export const googleLogin = async (req, res) => {
           lastName: result.user.lastName,
           avatarUrl: result.user.avatarUrl,
           isActive: result.user.isActive,
-          lastLogin: result.user.lastLogin
+          lastLogin: result.user.lastLogin,
         },
       },
     });
@@ -67,14 +69,14 @@ export const googleLogin = async (req, res) => {
     if (err.message && err.message.includes('Token used too late')) {
       return res.status(401).json({
         success: false,
-        message: 'Google token has expired. Please try again.'
+        message: 'Google token has expired. Please try again.',
       });
     }
 
     if (err.message && err.message.includes('Wrong recipient')) {
       return res.status(401).json({
         success: false,
-        message: 'Invalid Google token audience.'
+        message: 'Invalid Google token audience.',
       });
     }
 
@@ -82,13 +84,13 @@ export const googleLogin = async (req, res) => {
     if (err.statusCode && err.statusCode !== 500) {
       return res.status(err.statusCode).json({
         success: false,
-        message: err.message
+        message: err.message,
       });
     }
 
     return res.status(401).json({
       success: false,
-      message: 'Google authentication failed. Please try again.'
+      message: 'Google authentication failed. Please try again.',
     });
   }
 };
@@ -124,16 +126,17 @@ export const register = asyncHandler(async (req, res) => {
     lastName,
     fullName: fullName || full_name || undefined,
     phone,
-    role
+    role,
   });
 
+  setAuthCookie(res, result.token);
   res.status(201).json({
     success: true,
     message: 'User registered successfully',
     data: {
       user: result.user.toJSON(),
-      token: result.token
-    }
+      token: result.token,
+    },
   });
 });
 
@@ -142,13 +145,14 @@ export const login = asyncHandler(async (req, res) => {
 
   const result = await authService.login(email, password);
 
+  setAuthCookie(res, result.token);
   res.json({
     success: true,
     message: 'Login successful',
     data: {
       user: result.user.toJSON(),
-      token: result.token
-    }
+      token: result.token,
+    },
   });
 });
 
@@ -157,7 +161,7 @@ export const getProfile = asyncHandler(async (req, res) => {
 
   res.json({
     success: true,
-    data: { user }
+    data: { user },
   });
 });
 
@@ -165,13 +169,19 @@ export const updateProfile = asyncHandler(async (req, res) => {
   const { firstName, lastName, phone, avatar, dateOfBirth, companyName, email } = req.body;
 
   const user = await authService.updateProfile(req.user, {
-    firstName, lastName, phone, avatar, dateOfBirth, companyName, email
+    firstName,
+    lastName,
+    phone,
+    avatar,
+    dateOfBirth,
+    companyName,
+    email,
   });
 
   res.json({
     success: true,
     message: 'Profile updated successfully',
-    data: { user: user.toJSON() }
+    data: { user: user.toJSON() },
   });
 });
 
@@ -182,17 +192,18 @@ export const changePassword = asyncHandler(async (req, res) => {
 
   res.json({
     success: true,
-    message: 'Password changed successfully'
+    message: 'Password changed successfully',
   });
 });
 
 export const refreshToken = asyncHandler(async (req, res) => {
   const result = authService.refreshToken(req.user.id);
 
+  setAuthCookie(res, result.token);
   res.json({
     success: true,
     message: 'Token refreshed successfully',
-    data: { token: result.token }
+    data: { token: result.token },
   });
 });
 
@@ -211,13 +222,14 @@ export const googleOAuthCallback = asyncHandler(async (req, res) => {
     const origin = req.get('origin');
     const result = await authService.googleOAuthCallback(code, origin);
 
+    setAuthCookie(res, result.token);
     res.json({
       success: true,
       message: 'Google authentication successful',
       data: {
         user: result.user.toJSON(),
-        token: result.token
-      }
+        token: result.token,
+      },
     });
   } catch (error) {
     logger.error('Google OAuth callback error', { error: error?.message || String(error) });
@@ -228,7 +240,7 @@ export const googleOAuthCallback = asyncHandler(async (req, res) => {
 export const googleConfigCheck = (req, res) => {
   res.json({
     success: true,
-    data: { googleClientId: !!process.env.GOOGLE_CLIENT_ID }
+    data: { googleClientId: !!process.env.GOOGLE_CLIENT_ID },
   });
 };
 
@@ -239,7 +251,7 @@ export const verifyEmail = asyncHandler(async (req, res) => {
 
   res.json({
     success: true,
-    message: 'Email verified successfully'
+    message: 'Email verified successfully',
   });
 });
 
@@ -252,7 +264,7 @@ export const forgotPassword = asyncHandler(async (req, res) => {
   // Use a generic message to prevent email enumeration
   res.json({
     success: true,
-    message: 'If an account with that email exists, a password reset link has been sent.'
+    message: 'If an account with that email exists, a password reset link has been sent.',
   });
 });
 
@@ -264,7 +276,7 @@ export const resetPassword = asyncHandler(async (req, res) => {
 
   res.json({
     success: true,
-    message: 'Password reset successfully'
+    message: 'Password reset successfully',
   });
 });
 
@@ -275,7 +287,7 @@ export const getInviteInfo = asyncHandler(async (req, res) => {
 
   res.json({
     success: true,
-    data: info
+    data: info,
   });
 });
 
@@ -288,20 +300,22 @@ export const acceptInvite = asyncHandler(async (req, res) => {
     password,
     fullName: full_name,
     phone,
-    dateOfBirth
+    dateOfBirth,
   });
 
+  setAuthCookie(res, result.token);
   res.json({
     success: true,
     message: 'Invitation accepted',
-    data: { user: result.user.toJSON(), token: result.token }
+    data: { user: result.user.toJSON(), token: result.token },
   });
 });
 
 export const logout = asyncHandler(async (req, res) => {
+  clearAuthCookie(res);
   res.json({
     success: true,
-    message: 'Logged out successfully'
+    message: 'Logged out successfully',
   });
 });
 
@@ -319,7 +333,10 @@ export const savePayout = asyncHandler(async (req, res) => {
   const { method, paynowId, bankName, bankAccount } = req.body;
 
   const payout = await onboardingService.savePayout(req.user.id, {
-    method, paynowId, bankName, bankAccount
+    method,
+    paynowId,
+    bankName,
+    bankAccount,
   });
 
   res.json({ success: true, data: { payout } });

--- a/backend/src/controllers/commissionController.js
+++ b/backend/src/controllers/commissionController.js
@@ -12,7 +12,7 @@ export async function createCommission(req, res) {
   res.status(201).json({
     success: true,
     message: 'Commission created successfully',
-    data: { commission }
+    data: { commission },
   });
 }
 
@@ -41,17 +41,17 @@ export async function updateCommission(req, res) {
   res.json({
     success: true,
     message: 'Commission updated successfully',
-    data: { commission }
+    data: { commission },
   });
 }
 
 // Approve commission
 export async function approveCommission(req, res) {
-  const commission = await commissionService.approveCommission(req.params.id, req.user.id, req.body.notes);
+  const commission = await commissionService.approveCommission(req.params.id, req.user.id, req.body?.notes);
   res.json({
     success: true,
     message: 'Commission approved successfully',
-    data: { commission }
+    data: { commission },
   });
 }
 
@@ -61,18 +61,20 @@ export async function payCommission(req, res) {
   res.json({
     success: true,
     message: 'Commission marked as paid successfully',
-    data: { commission }
+    data: { commission },
   });
 }
 
 // Bulk approve commissions
 export async function bulkApproveCommissions(req, res) {
   const affectedCount = await commissionService.bulkApproveCommissions(
-    req.body.commissionIds, req.user.id, req.body.notes
+    req.body.commissionIds,
+    req.user.id,
+    req.body.notes
   );
   res.json({
     success: true,
     message: `${affectedCount} commissions approved successfully`,
-    data: { affectedCount }
+    data: { affectedCount },
   });
 }

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -3,6 +3,7 @@ import { User } from '../models/index.js';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 import { DEFAULT_TENANT_ID } from './tenant.js';
 import { logger } from '../utils/logger.js';
+import { COOKIE_NAME } from '../utils/authCookie.js';
 
 // Hard check: JWT_SECRET must be set or all token operations fail-safe
 function getJwtSecret() {
@@ -70,7 +71,7 @@ async function mapJwtToUser(payload) {
       fullName: payload.name || null,
       role: 'customer',
       isActive: true,
-      emailVerified: true
+      emailVerified: true,
     });
   }
   if (user) {
@@ -83,8 +84,11 @@ async function mapJwtToUser(payload) {
 // Verify JWT token
 export const authenticateToken = async (req, res, next) => {
   try {
+    // Read token: cookie first, then Authorization header
+    const cookieToken = req.cookies?.[COOKIE_NAME];
     const authHeader = req.headers.authorization;
-    const token = authHeader && authHeader.split(' ')[1]; // Bearer TOKEN
+    const bearerToken = authHeader && authHeader.split(' ')[1];
+    const token = cookieToken || bearerToken;
 
     if (!token) {
       return res.status(401).json({ success: false, message: 'Access token required' });
@@ -94,7 +98,7 @@ export const authenticateToken = async (req, res, next) => {
       try {
         const { payload } = await jwtVerify(token, getRemoteJwks(), {
           issuer: getExpectedIssuer() || undefined,
-          audience: getExpectedAudience() || undefined
+          audience: getExpectedAudience() || undefined,
         });
         const user = await mapJwtToUser(payload);
         if (!user || !user.isActive) {
@@ -102,7 +106,7 @@ export const authenticateToken = async (req, res, next) => {
         }
         // Debounce lastLogin writes — only update if stale by 5+ minutes
         const fiveMinutes = 5 * 60 * 1000;
-        if (!user.lastLogin || (Date.now() - new Date(user.lastLogin).getTime()) > fiveMinutes) {
+        if (!user.lastLogin || Date.now() - new Date(user.lastLogin).getTime() > fiveMinutes) {
           user.lastLogin = new Date();
           user.save().catch(() => {}); // fire-and-forget, don't block the request
         }
@@ -120,7 +124,7 @@ export const authenticateToken = async (req, res, next) => {
     }
     // Debounce lastLogin writes — only update if stale by 5+ minutes
     const fiveMinutes = 5 * 60 * 1000;
-    if (!legacyUser.lastLogin || (Date.now() - new Date(legacyUser.lastLogin).getTime()) > fiveMinutes) {
+    if (!legacyUser.lastLogin || Date.now() - new Date(legacyUser.lastLogin).getTime() > fiveMinutes) {
       legacyUser.lastLogin = new Date();
       legacyUser.save().catch(() => {}); // fire-and-forget, don't block the request
     }
@@ -140,14 +144,14 @@ export const requireRole = (...roles) => {
     if (!req.user) {
       return res.status(401).json({
         success: false,
-        message: 'Authentication required'
+        message: 'Authentication required',
       });
     }
 
     if (!roles.includes(req.user.role)) {
       return res.status(403).json({
         success: false,
-        message: 'Insufficient permissions'
+        message: 'Insufficient permissions',
       });
     }
 
@@ -167,8 +171,11 @@ export const requireFleetOwnerOrAdmin = requireRole('fleet_owner', 'admin');
 // Optional authentication (doesn't fail if no token)
 export const optionalAuth = async (req, res, next) => {
   try {
+    // Read token: cookie first, then Authorization header
+    const cookieToken = req.cookies?.[COOKIE_NAME];
     const authHeader = req.headers.authorization;
-    const token = authHeader && authHeader.split(' ')[1];
+    const bearerToken = authHeader && authHeader.split(' ')[1];
+    const token = cookieToken || bearerToken;
 
     if (token) {
       let user = null;
@@ -176,16 +183,20 @@ export const optionalAuth = async (req, res, next) => {
         try {
           const { payload } = await jwtVerify(token, getRemoteJwks(), {
             issuer: getExpectedIssuer() || undefined,
-            audience: getExpectedAudience() || undefined
+            audience: getExpectedAudience() || undefined,
           });
           user = await mapJwtToUser(payload);
-        } catch (_) { /* expected: token verification may fail */ }
+        } catch (_) {
+          /* expected: token verification may fail */
+        }
       }
       if (!user) {
         try {
           const decoded = jwt.verify(token, getJwtSecret());
           user = await User.findByPk(decoded.userId);
-        } catch (_) { /* expected: token verification may fail */ }
+        } catch (_) {
+          /* expected: token verification may fail */
+        }
       }
       if (user && user.isActive) req.user = user;
     }
@@ -199,11 +210,7 @@ export const optionalAuth = async (req, res, next) => {
 
 // Generate JWT token
 export const generateToken = (userId) => {
-  return jwt.sign(
-    { userId },
-    getJwtSecret(),
-    { expiresIn: process.env.JWT_EXPIRES_IN || '7d' }
-  );
+  return jwt.sign({ userId }, getJwtSecret(), { expiresIn: process.env.JWT_EXPIRES_IN || '7d' });
 };
 
 // Verify email token

--- a/backend/src/utils/authCookie.js
+++ b/backend/src/utils/authCookie.js
@@ -1,0 +1,19 @@
+const COOKIE_NAME = 'mktr_token';
+
+const cookieOptions = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
+  path: '/',
+  maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days (matches JWT_EXPIRES_IN default)
+};
+
+export function setAuthCookie(res, token) {
+  res.cookie(COOKIE_NAME, token, cookieOptions);
+}
+
+export function clearAuthCookie(res) {
+  res.clearCookie(COOKIE_NAME, { path: '/', httpOnly: true, secure: cookieOptions.secure, sameSite: cookieOptions.sameSite });
+}
+
+export { COOKIE_NAME };

--- a/src/api/__tests__/client.test.js
+++ b/src/api/__tests__/client.test.js
@@ -5,9 +5,15 @@ const localStorageMock = (() => {
   let store = {};
   return {
     getItem: vi.fn((key) => store[key] ?? null),
-    setItem: vi.fn((key, value) => { store[key] = String(value); }),
-    removeItem: vi.fn((key) => { delete store[key]; }),
-    clear: vi.fn(() => { store = {}; }),
+    setItem: vi.fn((key, value) => {
+      store[key] = String(value);
+    }),
+    removeItem: vi.fn((key) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
   };
 })();
 Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true });
@@ -46,32 +52,25 @@ describe('auth module', () => {
   });
 
   describe('auth.login', () => {
-    it('stores token and user in localStorage on success', async () => {
+    it('stores user in localStorage on success (token via httpOnly cookie)', async () => {
       const user = { id: 'u-1', email: 'a@b.com' };
-      fetchMock.mockResolvedValueOnce(
-        fakeResponse({ success: true, data: { token: 'tok-1', user } })
-      );
+      fetchMock.mockResolvedValueOnce(fakeResponse({ success: true, data: { token: 'tok-1', user } }));
 
       const result = await auth.login('a@b.com', 'pass');
 
       expect(result.success).toBe(true);
-      expect(localStorageMock.setItem).toHaveBeenCalledWith('mktr_auth_token', 'tok-1');
+      // Token is now set as httpOnly cookie by the server, not stored in localStorage
       expect(localStorageMock.setItem).toHaveBeenCalledWith('mktr_user', JSON.stringify(user));
     });
 
     it('does not store token when login fails', async () => {
-      fetchMock.mockResolvedValueOnce(
-        fakeResponse({ success: false, message: 'Invalid credentials' })
-      );
+      fetchMock.mockResolvedValueOnce(fakeResponse({ success: false, message: 'Invalid credentials' }));
 
       const result = await auth.login('a@b.com', 'wrong');
 
       expect(result.success).toBe(false);
       // setItem should not have been called for token
-      expect(localStorageMock.setItem).not.toHaveBeenCalledWith(
-        'mktr_auth_token',
-        expect.anything()
-      );
+      expect(localStorageMock.setItem).not.toHaveBeenCalledWith('mktr_auth_token', expect.anything());
     });
   });
 
@@ -124,9 +123,7 @@ describe('APIClient request auth headers', () => {
   it('includes Authorization header when token exists', async () => {
     apiClient.setToken('my-token');
 
-    fetchMock.mockResolvedValueOnce(
-      fakeResponse({ success: true, data: {} })
-    );
+    fetchMock.mockResolvedValueOnce(fakeResponse({ success: true, data: {} }));
 
     await apiClient.get('/test');
 
@@ -135,9 +132,7 @@ describe('APIClient request auth headers', () => {
   });
 
   it('omits Authorization header when no token', async () => {
-    fetchMock.mockResolvedValueOnce(
-      fakeResponse({ success: true, data: {} })
-    );
+    fetchMock.mockResolvedValueOnce(fakeResponse({ success: true, data: {} }));
 
     await apiClient.get('/test');
 
@@ -154,9 +149,7 @@ describe('APIClient 401 handling', () => {
   });
 
   it('clears auth and throws on 401 response', async () => {
-    fetchMock.mockResolvedValueOnce(
-      fakeResponse({ message: 'Unauthorized' }, { status: 401 })
-    );
+    fetchMock.mockResolvedValueOnce(fakeResponse({ message: 'Unauthorized' }, { status: 401 }));
 
     await expect(apiClient.get('/protected')).rejects.toThrow('Authentication required');
 

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -11,22 +11,25 @@ if (!baseURL) {
 
 const API_CONFIG = {
   baseURL: baseURL || 'http://localhost:3001/api',
-  timeout: 30000
+  timeout: 30000,
 };
 
 // Storage keys
 const STORAGE_KEYS = {
   TOKEN: 'mktr_auth_token',
-  USER: 'mktr_user'
+  USER: 'mktr_user',
 };
 
 /**
- * Read the auth token directly from localStorage on every call.
- * This eliminates stale module-level variables and keeps localStorage
- * as the single persistence layer (Zustand store is the React source of truth).
+ * Read a real JWT from localStorage (backward compat fallback).
+ * With httpOnly cookie auth the stored value is typically 'authenticated'
+ * (a UI-only flag), which we skip — only return an actual JWT so the
+ * Authorization header is not sent with a bogus value.
  */
 function getToken() {
-  return localStorage.getItem(STORAGE_KEYS.TOKEN);
+  const val = localStorage.getItem(STORAGE_KEYS.TOKEN);
+  // 'authenticated' is the UI-only flag, not a real JWT
+  return val && val !== 'authenticated' ? val : null;
 }
 
 function getStoredUser() {
@@ -73,11 +76,11 @@ class APIClient {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
-        ...((token && !options.skipAuth) && { Authorization: `Bearer ${token}` }),
-        ...options.headers
+        ...(token && !options.skipAuth && { Authorization: `Bearer ${token}` }),
+        ...options.headers,
       },
       credentials: 'include',
-      ...options
+      ...options,
     };
 
     // Add body for POST/PUT/PATCH requests
@@ -88,9 +91,9 @@ class APIClient {
     try {
       const response = await fetch(url, config);
 
-      // Handle authentication errors
+      // Handle authentication errors — cookie is server-managed, just clear UI state
       if (response.status === 401 && !options.skipAuth) {
-        this.setToken(null);
+        localStorage.removeItem(STORAGE_KEYS.TOKEN);
         localStorage.removeItem(STORAGE_KEYS.USER);
 
         if (typeof window !== 'undefined') {
@@ -117,7 +120,7 @@ class APIClient {
         console.error('API Error Details:', {
           status: response.status,
           statusText: response.statusText,
-          data: data
+          data: data,
         });
 
         // For validation errors, include the validation details
@@ -130,9 +133,9 @@ class APIClient {
 
           // Check errors field first (where actual validation details are)
           if (data.errors && Array.isArray(data.errors)) {
-            validationErrors = data.errors.map(err => `${err.field}: ${err.message}`).join(', ');
+            validationErrors = data.errors.map((err) => `${err.field}: ${err.message}`).join(', ');
           } else if (Array.isArray(data.details)) {
-            validationErrors = data.details.map(err => err.message || err).join(', ');
+            validationErrors = data.details.map((err) => err.message || err).join(', ');
           } else if (typeof data.details === 'string') {
             validationErrors = data.details;
           } else if (data.details?.message) {
@@ -165,7 +168,7 @@ class APIClient {
   // HTTP method shortcuts
   async get(endpoint, params = {}) {
     // Guard against non-object params (e.g., strings like '-created_date')
-    const safeParams = (params && typeof params === 'object' && !Array.isArray(params)) ? params : {};
+    const safeParams = params && typeof params === 'object' && !Array.isArray(params) ? params : {};
     const queryString = new URLSearchParams(safeParams).toString();
     const url = queryString ? `${endpoint}?${queryString}` : endpoint;
     return this.request(url);
@@ -195,17 +198,19 @@ class APIClient {
     const config = {
       method: 'POST',
       headers: {
-        ...(token && { Authorization: `Bearer ${token}` })
+        ...(token && { Authorization: `Bearer ${token}` }),
         // Don't set Content-Type for FormData - browser will set it with boundary
       },
-      body: formData
+      credentials: 'include',
+      body: formData,
     };
 
     try {
       const response = await fetch(url, config);
 
       if (response.status === 401) {
-        this.setToken(null);
+        localStorage.removeItem(STORAGE_KEYS.TOKEN);
+        localStorage.removeItem(STORAGE_KEYS.USER);
         throw new Error('Authentication required');
       }
 
@@ -230,24 +235,22 @@ export const apiClient = new APIClient();
  * Authentication API
  */
 export const auth = {
-  // Login user
+  // Login user — token now set as httpOnly cookie by the server
   async login(email, password) {
     const response = await apiClient.post('/auth/login', { email, password });
 
-    if (response.success && response.data.token) {
-      apiClient.setToken(response.data.token);
+    if (response.success && response.data.user) {
       localStorage.setItem(STORAGE_KEYS.USER, JSON.stringify(response.data.user));
     }
 
     return response;
   },
 
-  // Google OAuth login
+  // Google OAuth login — token now set as httpOnly cookie by the server
   async googleLogin(credential) {
     const response = await apiClient.post('/auth/google', { credential });
 
-    if (response.success && response.data.token) {
-      apiClient.setToken(response.data.token);
+    if (response.success && response.data.user) {
       localStorage.setItem(STORAGE_KEYS.USER, JSON.stringify(response.data.user));
     } else {
       console.error('AUTH: Google login failed:', response);
@@ -256,12 +259,11 @@ export const auth = {
     return response;
   },
 
-  // Register user
+  // Register user — token now set as httpOnly cookie by the server
   async register(userData) {
     const response = await apiClient.post('/auth/register', userData);
 
-    if (response.success && response.data.token) {
-      apiClient.setToken(response.data.token);
+    if (response.success && response.data.user) {
       localStorage.setItem(STORAGE_KEYS.USER, JSON.stringify(response.data.user));
     }
 
@@ -271,10 +273,14 @@ export const auth = {
   // Accept agent invite
   async acceptInvite({ token, email, password, full_name, dateOfBirth, phone }) {
     const response = await apiClient.post('/auth/accept-invite', {
-      token, email, password, full_name, dateOfBirth, phone
+      token,
+      email,
+      password,
+      full_name,
+      dateOfBirth,
+      phone,
     });
-    if (response.success && response.data?.token) {
-      apiClient.setToken(response.data.token);
+    if (response.success && response.data?.user) {
       localStorage.setItem(STORAGE_KEYS.USER, JSON.stringify(response.data.user));
     }
     return response;
@@ -332,9 +338,10 @@ export const auth = {
     }
   },
 
-  // Logout
+  // Logout — server clears the httpOnly cookie; we just clean up localStorage
   logout() {
-    apiClient.setToken(null);
+    // Best-effort POST to clear the httpOnly cookie server-side
+    apiClient.post('/auth/logout', {}).catch(() => {});
     localStorage.removeItem(STORAGE_KEYS.USER);
     localStorage.removeItem(STORAGE_KEYS.TOKEN);
 
@@ -343,18 +350,20 @@ export const auth = {
       if (typeof window !== 'undefined' && window.google?.accounts?.id) {
         window.google.accounts.id.disableAutoSelect();
       }
-    } catch (_) { /* Google SDK may not be loaded */ }
+    } catch (_) {
+      /* Google SDK may not be loaded */
+    }
   },
 
-  // Check if user is authenticated
+  // Check if user is authenticated (checks for either a real JWT or the UI flag)
   isAuthenticated() {
-    return !!getToken();
+    return !!localStorage.getItem(STORAGE_KEYS.TOKEN);
   },
 
   // Get current user without API call — reads from localStorage only
   getUser() {
     return getStoredUser();
-  }
+  },
 };
 
 /**
@@ -628,7 +637,7 @@ export const entities = {
   FleetOwner: new FleetOwnerEntity(),
   Driver: new DriverEntity(),
   LeadPackage: new LeadPackageEntity(),
-  User: new UserEntity()
+  User: new UserEntity(),
 };
 
 /**
@@ -649,7 +658,7 @@ export const functions = {
   // Increment scan count
   async incrementScanCount(qrTagId, metadata = {}) {
     return entities.QrTag.recordScan(qrTagId, metadata);
-  }
+  },
 };
 
 /**
@@ -688,8 +697,8 @@ export const integrations = {
     async InvokeLLM(prompt, options = {}) {
       console.warn('InvokeLLM integration not implemented - use your AI service');
       return { success: false, message: 'LLM integration not implemented' };
-    }
-  }
+    },
+  },
 };
 
 /**
@@ -704,7 +713,7 @@ export const dashboard = {
   async getAnalytics(type, period = '30d') {
     const response = await apiClient.get('/dashboard/analytics', { type, period });
     return response.data;
-  }
+  },
 };
 
 /**
@@ -717,7 +726,7 @@ export const notifications = {
     if (since) params.since = since;
     const response = await apiClient.get('/notifications', params);
     return response.data?.notifications || [];
-  }
+  },
 };
 
 /**
@@ -757,7 +766,7 @@ export const agents = {
   async getLeaderboard(params = {}) {
     const response = await apiClient.get('/agents/leaderboard/performance', params);
     return response.data;
-  }
+  },
 };
 
 /**
@@ -767,16 +776,16 @@ export const fleet = {
   async getStats() {
     const response = await apiClient.get('/fleet/stats/overview');
     return response.data;
-  }
+  },
 };
 
-// Initialize authentication on module load — validate stored token
+// Initialize authentication on module load — validate session via cookie
 if (typeof window !== 'undefined') {
-  const token = getToken();
-  if (token) {
-    // Token is already in localStorage; verify it's still valid by loading user
-    auth.getCurrentUser().catch(() => {
-      // Silently clear local auth if token is invalid
+  const storedUser = getStoredUser();
+  if (storedUser) {
+    // User cached in localStorage; verify cookie is still valid by fetching profile
+    auth.getCurrentUser(true).catch(() => {
+      // Cookie expired or invalid — clear local UI state
       localStorage.removeItem(STORAGE_KEYS.USER);
       localStorage.removeItem(STORAGE_KEYS.TOKEN);
     });
@@ -793,7 +802,7 @@ export const mktrAPI = {
   notifications,
   agents,
   fleet,
-  client: apiClient
+  client: apiClient,
 };
 
 // Default export for convenience

--- a/src/pages/AdminDeviceLogs.jsx
+++ b/src/pages/AdminDeviceLogs.jsx
@@ -4,301 +4,291 @@ import { apiClient as api } from '../api/client';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
 import { Button } from '../components/ui/button';
 import { Badge } from '../components/ui/badge';
-import {
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow,
-} from "../components/ui/table";
-import {
-    ChevronLeft,
-    RefreshCcw,
-    Battery,
-    HardDrive,
-    Activity,
-    Eye,
-    PlayCircle
-} from 'lucide-react';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table';
+import { ChevronLeft, RefreshCcw, Battery, HardDrive, Activity, Eye, PlayCircle } from 'lucide-react';
 import { format } from 'date-fns';
 import {
-    Pagination,
-    PaginationContent,
-    PaginationItem,
-    PaginationLink,
-    PaginationNext,
-    PaginationPrevious,
-} from "@/components/ui/pagination";
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/ui/pagination';
 
 export default function AdminDeviceLogs() {
-    const { id } = useParams();
-    const navigate = useNavigate();
-    const [logs, setLogs] = useState([]);
-    const [pagination, setPagination] = useState({ page: 1, total: 0, pages: 1 });
-    const [loading, setLoading] = useState(true);
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [logs, setLogs] = useState([]);
+  const [pagination, setPagination] = useState({ page: 1, total: 0, pages: 1 });
+  const [loading, setLoading] = useState(true);
 
-    const [streamStatus, setStreamStatus] = useState('disconnected');
-    const [deviceStatus, setDeviceStatus] = useState('unknown'); // active vs inactive
+  const [streamStatus, setStreamStatus] = useState('disconnected');
+  const [deviceStatus, setDeviceStatus] = useState('unknown'); // active vs inactive
 
-    useEffect(() => {
-        fetchLogs(1);
-    }, [id]);
+  useEffect(() => {
+    fetchLogs(1);
+  }, [id]);
 
-    useEffect(() => {
-        const token = localStorage.getItem('mktr_auth_token');
-        if (!token) return;
+  useEffect(() => {
+    // SSE auth via httpOnly cookie (withCredentials sends cookies cross-origin)
+    setStreamStatus('connecting');
+    const url = `${api.baseURL}/devices/events/${id}/logs/stream`;
+    const eventSource = new EventSource(url, { withCredentials: true });
 
-        // Use standard EventSource with token in Query
-        // (Backend has middleware to promote this to Header)
-        // Path matches server.js mount: /api/devices/events + /:id/logs/stream
-        setStreamStatus('connecting');
-        const url = `${api.baseURL}/devices/events/${id}/logs/stream?token=${token}`;
-        const eventSource = new EventSource(url);
-
-        eventSource.onopen = () => {
-            setStreamStatus('connected');
-        };
-
-        eventSource.addEventListener('status_change', (e) => {
-            try {
-                const data = JSON.parse(e.data);
-                setDeviceStatus(data.status);
-            } catch (err) { console.error(err); }
-        });
-
-        eventSource.addEventListener('log', (e) => {
-            try {
-                const newLog = JSON.parse(e.data);
-                // Prepend new log and keep limit (e.g. 50 + buffer)
-                setLogs(prev => {
-                    const updated = [newLog, ...prev];
-                    return updated.slice(0, 100); // Keep memory sane
-                });
-            } catch (err) {
-                console.error('[Logs] Parse error', err);
-            }
-        });
-
-        eventSource.addEventListener('connected', (e) => {
-            setStreamStatus('connected');
-        });
-
-        eventSource.onerror = (err) => {
-            // console.warn('[Logs] Stream disconnected', err);
-            setStreamStatus('error');
-            eventSource.close();
-
-            // Auto-reconnect happens natively for network errors, 
-            // but for explicit close/auth fail, we might need manual retry logic
-            // simple exponential backoff?
-            // For now, let's just let user refresh if it dies hard.
-            // Native EventSource retries automatically.
-        };
-
-        return () => {
-            eventSource.close();
-            setStreamStatus('disconnected');
-        };
-    }, [id]);
-
-    const fetchLogs = async (page) => {
-        try {
-            setLoading(true);
-            const res = await api.get(`/devices/${id}/logs?page=${page}&limit=50`);
-            setLogs(res.data);
-            if (res.pagination) {
-                setPagination(res.pagination);
-            }
-            // Also try to get current status
-            const devRes = await api.get(`/devices/${id}`);
-            if (devRes.data?.status) setDeviceStatus(devRes.data.status);
-
-        } catch (err) {
-            console.error(err);
-        } finally {
-            setLoading(false);
-        }
+    eventSource.onopen = () => {
+      setStreamStatus('connected');
     };
 
-    return (
-        <div className="p-6 lg:p-8 min-h-screen bg-gray-50/50 dark:bg-gray-900/50">
-            <div className="max-w-[1200px] mx-auto space-y-6">
-                {/* Header */}
-                <div className="flex items-center gap-4">
-                    <Button variant="ghost" size="icon" onClick={() => navigate('/AdminDevices')}>
-                        <ChevronLeft className="h-5 w-5" />
-                    </Button>
-                    <div>
-                        <h1 className="text-2xl font-bold flex items-center gap-2">
-                            Device Logs
-                            <span className="text-sm font-mono font-normal text-muted-foreground bg-muted px-2 py-0.5 rounded">
-                                {id}
-                            </span>
-                            {streamStatus === 'connected' && (
-                                (deviceStatus === 'inactive' || deviceStatus === 'offline') ? (
-                                    <Badge variant="outline" className="ml-2 bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-700">
-                                        <span className="w-2 h-2 rounded-full bg-gray-400 dark:bg-gray-500 mr-2"></span>
-                                        OFFLINE
-                                    </Badge>
-                                ) : (deviceStatus === 'standby' || deviceStatus === 'idle') ? (
-                                    <Badge variant="outline" className="ml-2 bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800 animate-pulse">
-                                        <span className="w-2 h-2 rounded-full bg-blue-500 mr-2"></span>
-                                        READY
-                                    </Badge>
-                                ) : (deviceStatus === 'active' || deviceStatus === 'playing') ? (
-                                    <Badge variant="outline" className="ml-2 bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800 animate-pulse">
-                                        <span className="w-2 h-2 rounded-full bg-green-500 mr-2"></span>
-                                        LIVE
-                                    </Badge>
-                                ) : null
-                            )}
-                            {streamStatus === 'connecting' && (
-                                <Badge variant="outline" className="ml-2 bg-yellow-50 dark:bg-yellow-950/30 text-yellow-700 dark:text-yellow-400 border-yellow-200 dark:border-yellow-800">
-                                    <span className="w-2 h-2 rounded-full bg-yellow-500 mr-2 animate-bounce"></span>
-                                    Connecting...
-                                </Badge>
-                            )}
-                            {streamStatus === 'error' && (
-                                <Badge variant="outline" className="ml-2 bg-red-50 dark:bg-red-950/30 text-red-700 dark:text-red-400 border-red-200 dark:border-red-800">
-                                    <span className="w-2 h-2 rounded-full bg-red-500 mr-2"></span>
-                                    Stream Error
-                                </Badge>
-                            )}
-                        </h1>
-                        <p className="text-sm text-muted-foreground">
-                            Full history of heartbeats and beacon events.
-                        </p>
-                    </div>
-                    <div className="ml-auto">
-                        <Button variant="outline" size="sm" onClick={() => fetchLogs(pagination.page)}>
-                            <RefreshCcw className="h-4 w-4 mr-2" />
-                            Refresh
-                        </Button>
-                    </div>
-                </div>
+    eventSource.addEventListener('status_change', (e) => {
+      try {
+        const data = JSON.parse(e.data);
+        setDeviceStatus(data.status);
+      } catch (err) {
+        console.error(err);
+      }
+    });
 
-                <Card>
-                    <CardHeader>
-                        <CardTitle className="text-sm font-medium text-muted-foreground">
-                            Showing page {pagination.page} of {pagination.pages} ({pagination.total} events)
-                        </CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                        <div className="overflow-hidden rounded-md border border-gray-100 dark:border-gray-700">
-                            <Table>
-                                <TableHeader>
-                                    <TableRow className="bg-gray-50/50 dark:bg-gray-800/50">
-                                        <TableHead className="w-[180px]">Timestamp</TableHead>
-                                        <TableHead className="w-[120px]">Type</TableHead>
-                                        <TableHead>Payload Details</TableHead>
-                                    </TableRow>
-                                </TableHeader>
-                                <TableBody>
-                                    {loading ? (
-                                        <TableRow>
-                                            <TableCell colSpan={3} className="h-24 text-center">Loading logs...</TableCell>
-                                        </TableRow>
-                                    ) : logs.length === 0 ? (
-                                        <TableRow>
-                                            <TableCell colSpan={3} className="h-24 text-center">No logs found.</TableCell>
-                                        </TableRow>
-                                    ) : (
-                                        logs.map((log) => (
-                                            <TableRow key={log.id}>
-                                                <TableCell className="font-mono text-xs text-muted-foreground">
-                                                    {format(new Date(log.createdAt), 'MMM d, yyyy HH:mm:ss')}
-                                                </TableCell>
-                                                <TableCell>
-                                                    <Badge variant="outline" className="text-[10px] font-mono">
-                                                        {log.type}
-                                                    </Badge>
-                                                </TableCell>
-                                                <TableCell>
-                                                    {log.type === 'HEARTBEAT' ? (
-                                                        <div className="flex gap-4 text-xs font-mono text-muted-foreground">
-                                                            {log.payload?.source === 'manifest_fetch' ? (
-                                                                <span className="flex items-center gap-1.5 text-blue-600">
-                                                                    <RefreshCcw className="h-3 w-3" /> Manifest Refresh (Manual)
-                                                                </span>
-                                                            ) : (
-                                                                <>
-                                                                    <span className="flex items-center gap-1.5">
-                                                                        <Activity className="h-3 w-3 text-blue-500" />
-                                                                        Status: <span className="text-foreground">{log.payload?.status?.toUpperCase()}</span>
-                                                                    </span>
-                                                                    <span className="flex items-center gap-1.5">
-                                                                        <Battery className="h-3 w-3 text-green-500" />
-                                                                        {typeof log.payload?.batteryLevel === 'number'
-                                                                            ? `${(log.payload.batteryLevel * 100).toFixed(0)}%`
-                                                                            : '--%'}
-                                                                    </span>
-                                                                    <span className="flex items-center gap-1.5">
-                                                                        <HardDrive className="h-3 w-3 text-orange-500" />
-                                                                        {log.payload?.storageUsed || '--'}
-                                                                    </span>
-                                                                </>
-                                                            )}
-                                                        </div>
-                                                    ) : log.type === 'IMPRESSIONS' ? (
-                                                        <span className="flex items-center gap-1.5 text-purple-600 text-xs font-mono">
-                                                            <Eye className="h-3 w-3" /> Uploaded {log.payload?.count} Impressions
-                                                        </span>
-                                                    ) : log.type === 'PLAYBACK' ? (
-                                                        <span className="flex items-center gap-1.5 text-teal-600 font-medium text-xs font-mono">
-                                                            <PlayCircle className="h-3 w-3" />
-                                                            Played {log.payload?.assetId}
-                                                            <span className="text-muted-foreground ml-2">
-                                                                ({log.payload?.campaignName})
-                                                            </span>
-                                                            <span className="text-xs text-gray-400 dark:text-gray-500 ml-auto">
-                                                                {log.payload?.durationMs ? `${(log.payload.durationMs / 1000).toFixed(1)}s` : ''}
-                                                            </span>
-                                                        </span>
-                                                    ) : (
-                                                        <pre className="text-[10px] text-muted-foreground whitespace-pre-wrap max-w-[600px] overflow-hidden">
-                                                            {JSON.stringify(log.payload)}
-                                                        </pre>
-                                                    )}
-                                                </TableCell>
-                                            </TableRow>
-                                        ))
-                                    )}
-                                </TableBody>
-                            </Table>
-                        </div>
+    eventSource.addEventListener('log', (e) => {
+      try {
+        const newLog = JSON.parse(e.data);
+        // Prepend new log and keep limit (e.g. 50 + buffer)
+        setLogs((prev) => {
+          const updated = [newLog, ...prev];
+          return updated.slice(0, 100); // Keep memory sane
+        });
+      } catch (err) {
+        console.error('[Logs] Parse error', err);
+      }
+    });
 
-                        {/* Pagination */}
-                        <div className="mt-4 flex justify-center">
-                            <Pagination>
-                                <PaginationContent>
-                                    {pagination.page > 1 && (
-                                        <PaginationItem>
-                                            <PaginationPrevious
-                                                onClick={() => fetchLogs(pagination.page - 1)}
-                                                className="cursor-pointer"
-                                            />
-                                        </PaginationItem>
-                                    )}
+    eventSource.addEventListener('connected', (e) => {
+      setStreamStatus('connected');
+    });
 
-                                    <PaginationItem>
-                                        <PaginationLink isActive>{pagination.page}</PaginationLink>
-                                    </PaginationItem>
+    eventSource.onerror = (err) => {
+      // console.warn('[Logs] Stream disconnected', err);
+      setStreamStatus('error');
+      eventSource.close();
 
-                                    {pagination.page < pagination.pages && (
-                                        <PaginationItem>
-                                            <PaginationNext
-                                                onClick={() => fetchLogs(pagination.page + 1)}
-                                                className="cursor-pointer"
-                                            />
-                                        </PaginationItem>
-                                    )}
-                                </PaginationContent>
-                            </Pagination>
-                        </div>
-                    </CardContent>
-                </Card>
-            </div>
+      // Auto-reconnect happens natively for network errors,
+      // but for explicit close/auth fail, we might need manual retry logic
+      // simple exponential backoff?
+      // For now, let's just let user refresh if it dies hard.
+      // Native EventSource retries automatically.
+    };
+
+    return () => {
+      eventSource.close();
+      setStreamStatus('disconnected');
+    };
+  }, [id]);
+
+  const fetchLogs = async (page) => {
+    try {
+      setLoading(true);
+      const res = await api.get(`/devices/${id}/logs?page=${page}&limit=50`);
+      setLogs(res.data);
+      if (res.pagination) {
+        setPagination(res.pagination);
+      }
+      // Also try to get current status
+      const devRes = await api.get(`/devices/${id}`);
+      if (devRes.data?.status) setDeviceStatus(devRes.data.status);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-6 lg:p-8 min-h-screen bg-gray-50/50 dark:bg-gray-900/50">
+      <div className="max-w-[1200px] mx-auto space-y-6">
+        {/* Header */}
+        <div className="flex items-center gap-4">
+          <Button variant="ghost" size="icon" onClick={() => navigate('/AdminDevices')}>
+            <ChevronLeft className="h-5 w-5" />
+          </Button>
+          <div>
+            <h1 className="text-2xl font-bold flex items-center gap-2">
+              Device Logs
+              <span className="text-sm font-mono font-normal text-muted-foreground bg-muted px-2 py-0.5 rounded">
+                {id}
+              </span>
+              {streamStatus === 'connected' &&
+                (deviceStatus === 'inactive' || deviceStatus === 'offline' ? (
+                  <Badge
+                    variant="outline"
+                    className="ml-2 bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-700"
+                  >
+                    <span className="w-2 h-2 rounded-full bg-gray-400 dark:bg-gray-500 mr-2"></span>
+                    OFFLINE
+                  </Badge>
+                ) : deviceStatus === 'standby' || deviceStatus === 'idle' ? (
+                  <Badge
+                    variant="outline"
+                    className="ml-2 bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800 animate-pulse"
+                  >
+                    <span className="w-2 h-2 rounded-full bg-blue-500 mr-2"></span>
+                    READY
+                  </Badge>
+                ) : deviceStatus === 'active' || deviceStatus === 'playing' ? (
+                  <Badge
+                    variant="outline"
+                    className="ml-2 bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800 animate-pulse"
+                  >
+                    <span className="w-2 h-2 rounded-full bg-green-500 mr-2"></span>
+                    LIVE
+                  </Badge>
+                ) : null)}
+              {streamStatus === 'connecting' && (
+                <Badge
+                  variant="outline"
+                  className="ml-2 bg-yellow-50 dark:bg-yellow-950/30 text-yellow-700 dark:text-yellow-400 border-yellow-200 dark:border-yellow-800"
+                >
+                  <span className="w-2 h-2 rounded-full bg-yellow-500 mr-2 animate-bounce"></span>
+                  Connecting...
+                </Badge>
+              )}
+              {streamStatus === 'error' && (
+                <Badge
+                  variant="outline"
+                  className="ml-2 bg-red-50 dark:bg-red-950/30 text-red-700 dark:text-red-400 border-red-200 dark:border-red-800"
+                >
+                  <span className="w-2 h-2 rounded-full bg-red-500 mr-2"></span>
+                  Stream Error
+                </Badge>
+              )}
+            </h1>
+            <p className="text-sm text-muted-foreground">Full history of heartbeats and beacon events.</p>
+          </div>
+          <div className="ml-auto">
+            <Button variant="outline" size="sm" onClick={() => fetchLogs(pagination.page)}>
+              <RefreshCcw className="h-4 w-4 mr-2" />
+              Refresh
+            </Button>
+          </div>
         </div>
-    );
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Showing page {pagination.page} of {pagination.pages} ({pagination.total} events)
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-hidden rounded-md border border-gray-100 dark:border-gray-700">
+              <Table>
+                <TableHeader>
+                  <TableRow className="bg-gray-50/50 dark:bg-gray-800/50">
+                    <TableHead className="w-[180px]">Timestamp</TableHead>
+                    <TableHead className="w-[120px]">Type</TableHead>
+                    <TableHead>Payload Details</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {loading ? (
+                    <TableRow>
+                      <TableCell colSpan={3} className="h-24 text-center">
+                        Loading logs...
+                      </TableCell>
+                    </TableRow>
+                  ) : logs.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={3} className="h-24 text-center">
+                        No logs found.
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    logs.map((log) => (
+                      <TableRow key={log.id}>
+                        <TableCell className="font-mono text-xs text-muted-foreground">
+                          {format(new Date(log.createdAt), 'MMM d, yyyy HH:mm:ss')}
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="outline" className="text-[10px] font-mono">
+                            {log.type}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
+                          {log.type === 'HEARTBEAT' ? (
+                            <div className="flex gap-4 text-xs font-mono text-muted-foreground">
+                              {log.payload?.source === 'manifest_fetch' ? (
+                                <span className="flex items-center gap-1.5 text-blue-600">
+                                  <RefreshCcw className="h-3 w-3" /> Manifest Refresh (Manual)
+                                </span>
+                              ) : (
+                                <>
+                                  <span className="flex items-center gap-1.5">
+                                    <Activity className="h-3 w-3 text-blue-500" />
+                                    Status:{' '}
+                                    <span className="text-foreground">{log.payload?.status?.toUpperCase()}</span>
+                                  </span>
+                                  <span className="flex items-center gap-1.5">
+                                    <Battery className="h-3 w-3 text-green-500" />
+                                    {typeof log.payload?.batteryLevel === 'number'
+                                      ? `${(log.payload.batteryLevel * 100).toFixed(0)}%`
+                                      : '--%'}
+                                  </span>
+                                  <span className="flex items-center gap-1.5">
+                                    <HardDrive className="h-3 w-3 text-orange-500" />
+                                    {log.payload?.storageUsed || '--'}
+                                  </span>
+                                </>
+                              )}
+                            </div>
+                          ) : log.type === 'IMPRESSIONS' ? (
+                            <span className="flex items-center gap-1.5 text-purple-600 text-xs font-mono">
+                              <Eye className="h-3 w-3" /> Uploaded {log.payload?.count} Impressions
+                            </span>
+                          ) : log.type === 'PLAYBACK' ? (
+                            <span className="flex items-center gap-1.5 text-teal-600 font-medium text-xs font-mono">
+                              <PlayCircle className="h-3 w-3" />
+                              Played {log.payload?.assetId}
+                              <span className="text-muted-foreground ml-2">({log.payload?.campaignName})</span>
+                              <span className="text-xs text-gray-400 dark:text-gray-500 ml-auto">
+                                {log.payload?.durationMs ? `${(log.payload.durationMs / 1000).toFixed(1)}s` : ''}
+                              </span>
+                            </span>
+                          ) : (
+                            <pre className="text-[10px] text-muted-foreground whitespace-pre-wrap max-w-[600px] overflow-hidden">
+                              {JSON.stringify(log.payload)}
+                            </pre>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+
+            {/* Pagination */}
+            <div className="mt-4 flex justify-center">
+              <Pagination>
+                <PaginationContent>
+                  {pagination.page > 1 && (
+                    <PaginationItem>
+                      <PaginationPrevious onClick={() => fetchLogs(pagination.page - 1)} className="cursor-pointer" />
+                    </PaginationItem>
+                  )}
+
+                  <PaginationItem>
+                    <PaginationLink isActive>{pagination.page}</PaginationLink>
+                  </PaginationItem>
+
+                  {pagination.page < pagination.pages && (
+                    <PaginationItem>
+                      <PaginationNext onClick={() => fetchLogs(pagination.page + 1)} className="cursor-pointer" />
+                    </PaginationItem>
+                  )}
+                </PaginationContent>
+              </Pagination>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
 }

--- a/src/pages/AdminDevices.jsx
+++ b/src/pages/AdminDevices.jsx
@@ -5,442 +5,468 @@ import { apiClient as api } from '../api/client';
 import { formatDistanceToNow, format } from 'date-fns';
 // import { AssignCampaignDialog } from '../components/devices/AssignCampaignDialog'; // Moved to Vehicle level
 import { Badge } from '../components/ui/badge';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../components/ui/dialog';
 import {
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow,
-} from "../components/ui/table";
-import {
-    Dialog,
-    DialogContent,
-    DialogHeader,
-    DialogTitle,
-} from "../components/ui/dialog";
-import {
-    Activity,
-    ChevronDown,
-    ChevronUp,
-    ExternalLink,
-    Battery,
-    HardDrive,
-    RefreshCcw,
-    Eye,
-    MapPin
+  Activity,
+  ChevronDown,
+  ChevronUp,
+  ExternalLink,
+  Battery,
+  HardDrive,
+  RefreshCcw,
+  Eye,
+  MapPin,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 export default function AdminDevices() {
-    const navigate = useNavigate();
-    const [devices, setDevices] = useState([]);
-    const [loading, setLoading] = useState(true);
-    const [selectedDevice, setSelectedDevice] = useState(null);
+  const navigate = useNavigate();
+  const [devices, setDevices] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedDevice, setSelectedDevice] = useState(null);
 
-    // Logs Preview State
-    const [expandedDeviceId, setExpandedDeviceId] = useState(null);
-    const [previewLogs, setPreviewLogs] = useState([]);
-    const [previewLoading, setPreviewLoading] = useState(false);
+  // Logs Preview State
+  const [expandedDeviceId, setExpandedDeviceId] = useState(null);
+  const [previewLogs, setPreviewLogs] = useState([]);
+  const [previewLoading, setPreviewLoading] = useState(false);
 
-    // Location Map Dialog State
-    const [mapDevice, setMapDevice] = useState(null);
-    const mapRef = useRef(null);
-    const googleMapRef = useRef(null);
-    const markerRef = useRef(null);
+  // Location Map Dialog State
+  const [mapDevice, setMapDevice] = useState(null);
+  const mapRef = useRef(null);
+  const googleMapRef = useRef(null);
+  const markerRef = useRef(null);
 
-    useEffect(() => {
-        loadDevices();
-    }, []);
+  useEffect(() => {
+    loadDevices();
+  }, []);
 
-    // Fleet Status Stream (SSE)
-    useEffect(() => {
-        const token = localStorage.getItem('mktr_auth_token');
-        if (!token) return;
+  // Fleet Status Stream (SSE)
+  useEffect(() => {
+    const url = `${import.meta.env.VITE_API_URL}/devices/events/fleet/stream`;
+    const sse = new EventSource(url, { withCredentials: true });
 
-        const url = `${import.meta.env.VITE_API_URL}/devices/events/fleet/stream?token=${token}`;
-        const sse = new EventSource(url);
+    sse.onopen = () => {};
 
-        sse.onopen = () => {};
-
-        sse.addEventListener('status_change', (e) => {
-            try {
-                const data = JSON.parse(e.data);
-                // Update local state for immediate feedback
-                setDevices(prev => prev.map(d => {
-                    if (d.id === data.deviceId) {
-                        return { ...d, status: data.status, lastSeenAt: data.lastSeenAt };
-                    }
-                    return d;
-                }));
-            } catch (err) {
-                console.error('Failed to parse status_change', err);
+    sse.addEventListener('status_change', (e) => {
+      try {
+        const data = JSON.parse(e.data);
+        // Update local state for immediate feedback
+        setDevices((prev) =>
+          prev.map((d) => {
+            if (d.id === data.deviceId) {
+              return { ...d, status: data.status, lastSeenAt: data.lastSeenAt };
             }
-        });
+            return d;
+          })
+        );
+      } catch (err) {
+        console.error('Failed to parse status_change', err);
+      }
+    });
 
-        // Listen for location updates
-        sse.addEventListener('location_update', (e) => {
-            try {
-                const data = JSON.parse(e.data);
-                setDevices(prev => prev.map(d => {
-                    if (d.id === data.deviceId) {
-                        return { ...d, latitude: data.latitude, longitude: data.longitude, locationUpdatedAt: data.timestamp };
-                    }
-                    return d;
-                }));
-            } catch (err) {
-                console.error('Failed to parse location_update', err);
+    // Listen for location updates
+    sse.addEventListener('location_update', (e) => {
+      try {
+        const data = JSON.parse(e.data);
+        setDevices((prev) =>
+          prev.map((d) => {
+            if (d.id === data.deviceId) {
+              return { ...d, latitude: data.latitude, longitude: data.longitude, locationUpdatedAt: data.timestamp };
             }
-        });
+            return d;
+          })
+        );
+      } catch (err) {
+        console.error('Failed to parse location_update', err);
+      }
+    });
 
-        sse.onerror = (err) => {
-            // Let EventSource auto-reconnect - don't close the connection!
-            console.warn('⚠️ Fleet Stream error - auto-reconnecting...', err);
-        };
-
-        return () => sse.close();
-    }, []);
-
-    const loadDevices = async () => {
-        try {
-            setLoading(true);
-            const res = await api.get('/devices');
-
-            // Defensive check for devices array
-            let devicesList = [];
-            if (Array.isArray(res.data)) {
-                devicesList = res.data;
-            } else if (res.data && Array.isArray(res.data.devices)) {
-                devicesList = res.data.devices;
-            } else {
-                console.warn('⚠️ AdminDevices: Unexpected response, defaulting to empty array', res);
-            }
-
-            setDevices(devicesList);
-
-            // Refetch logs if a row is open
-            if (expandedDeviceId) {
-                const logsRes = await api.get(`/devices/${expandedDeviceId}/logs?limit=5`);
-                setPreviewLogs(logsRes.data);
-            }
-        } catch (err) {
-            console.error(err);
-        } finally {
-            setLoading(false);
-        }
+    sse.onerror = (err) => {
+      // Let EventSource auto-reconnect - don't close the connection!
+      console.warn('⚠️ Fleet Stream error - auto-reconnecting...', err);
     };
 
-    // Live Logs Stream (Ephemeral) for Expanded Row
-    useEffect(() => {
-        if (!expandedDeviceId) return;
+    return () => sse.close();
+  }, []);
 
-        const token = localStorage.getItem('mktr_auth_token');
-        const url = `${import.meta.env.VITE_API_URL}/devices/events/${expandedDeviceId}/logs/stream?token=${token}`;
-        const sse = new EventSource(url);
+  const loadDevices = async () => {
+    try {
+      setLoading(true);
+      const res = await api.get('/devices');
 
-        sse.onopen = () => {};
+      // Defensive check for devices array
+      let devicesList = [];
+      if (Array.isArray(res.data)) {
+        devicesList = res.data;
+      } else if (res.data && Array.isArray(res.data.devices)) {
+        devicesList = res.data.devices;
+      } else {
+        console.warn('⚠️ AdminDevices: Unexpected response, defaulting to empty array', res);
+      }
 
-        sse.addEventListener('log', (e) => {
-            try {
-                const newLog = JSON.parse(e.data);
-                // Prepend and keep top 5
-                setPreviewLogs(prev => [newLog, ...prev].slice(0, 5));
-            } catch (err) {
-                console.error('[Preview] Parse error', err);
-            }
-        });
+      setDevices(devicesList);
 
-        // We don't need status_change here (Fleet Stream handles it), 
-        // but no harm if we ignore it. The backend sends it on this channel too.
+      // Refetch logs if a row is open
+      if (expandedDeviceId) {
+        const logsRes = await api.get(`/devices/${expandedDeviceId}/logs?limit=5`);
+        setPreviewLogs(logsRes.data);
+      }
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
 
-        sse.onerror = (e) => {
-            // console.warn('[Preview] Stream error', e);
-            sse.close();
-        };
+  // Live Logs Stream (Ephemeral) for Expanded Row
+  useEffect(() => {
+    if (!expandedDeviceId) return;
 
-        return () => {
-            sse.close();
-        };
-    }, [expandedDeviceId]);
+    const url = `${import.meta.env.VITE_API_URL}/devices/events/${expandedDeviceId}/logs/stream`;
+    const sse = new EventSource(url, { withCredentials: true });
 
-    const toggleExpandLogs = async (deviceId) => {
-        if (expandedDeviceId === deviceId) {
-            setExpandedDeviceId(null);
-            setPreviewLogs([]);
-            return;
-        }
+    sse.onopen = () => {};
 
-        setExpandedDeviceId(deviceId);
-        setPreviewLoading(true);
-        try {
-            // Fetch only last 5 logs for preview
-            const res = await api.get(`/devices/${deviceId}/logs?limit=5`);
-            setPreviewLogs(res.data);
-        } catch (err) {
-            console.error(err);
-        } finally {
-            setPreviewLoading(false);
-        }
+    sse.addEventListener('log', (e) => {
+      try {
+        const newLog = JSON.parse(e.data);
+        // Prepend and keep top 5
+        setPreviewLogs((prev) => [newLog, ...prev].slice(0, 5));
+      } catch (err) {
+        console.error('[Preview] Parse error', err);
+      }
+    });
+
+    // We don't need status_change here (Fleet Stream handles it),
+    // but no harm if we ignore it. The backend sends it on this channel too.
+
+    sse.onerror = (e) => {
+      // console.warn('[Preview] Stream error', e);
+      sse.close();
     };
 
+    return () => {
+      sse.close();
+    };
+  }, [expandedDeviceId]);
 
+  const toggleExpandLogs = async (deviceId) => {
+    if (expandedDeviceId === deviceId) {
+      setExpandedDeviceId(null);
+      setPreviewLogs([]);
+      return;
+    }
 
-    return (
-        <div className="p-6 lg:p-8 min-h-screen bg-gray-50/50 dark:bg-gray-900/50">
-            <div className="max-w-[1600px] mx-auto space-y-6">
-                <div className="flex justify-between items-center">
-                    <h1 className="text-2xl font-bold">Device Management</h1>
-                    <Button variant="outline" onClick={loadDevices}>Refresh</Button>
-                </div>
+    setExpandedDeviceId(deviceId);
+    setPreviewLoading(true);
+    try {
+      // Fetch only last 5 logs for preview
+      const res = await api.get(`/devices/${deviceId}/logs?limit=5`);
+      setPreviewLogs(res.data);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setPreviewLoading(false);
+    }
+  };
 
-                <Card>
-                    <CardHeader>
-                        <CardTitle>Fleet Overview ({devices.length})</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                        {loading ? (
-                            <div className="text-center py-4">Loading fleet status...</div>
-                        ) : devices.length === 0 ? (
-                            <div className="text-center py-8 text-gray-500 dark:text-gray-400">
-                                No devices registered yet. Turn on a tablet to auto-enroll.
+  return (
+    <div className="p-6 lg:p-8 min-h-screen bg-gray-50/50 dark:bg-gray-900/50">
+      <div className="max-w-[1600px] mx-auto space-y-6">
+        <div className="flex justify-between items-center">
+          <h1 className="text-2xl font-bold">Device Management</h1>
+          <Button variant="outline" onClick={loadDevices}>
+            Refresh
+          </Button>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Fleet Overview ({devices.length})</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {loading ? (
+              <div className="text-center py-4">Loading fleet status...</div>
+            ) : devices.length === 0 ? (
+              <div className="text-center py-8 text-gray-500 dark:text-gray-400">
+                No devices registered yet. Turn on a tablet to auto-enroll.
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow className="bg-gray-50/50 dark:bg-gray-800/50 hover:bg-gray-50/50 dark:hover:bg-gray-800/50 border-gray-100 dark:border-gray-700">
+                      <TableHead className="w-[50px]"></TableHead> {/* Expand Trigger */}
+                      <TableHead className="py-3 px-6 font-medium text-gray-500 dark:text-gray-400">
+                        Device Details
+                      </TableHead>
+                      <TableHead className="py-3 px-6 font-medium text-gray-500 dark:text-gray-400">Status</TableHead>
+                      <TableHead className="py-3 px-6 font-medium text-gray-500 dark:text-gray-400">
+                        Assigned Campaign
+                      </TableHead>
+                      <TableHead className="py-3 px-6 font-medium text-gray-500 dark:text-gray-400">
+                        Last Seen
+                      </TableHead>
+                      <TableHead className="py-3 px-6 font-medium text-gray-500 dark:text-gray-400 text-right">
+                        Actions
+                      </TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {devices.map((device) => (
+                      <React.Fragment key={device.id}>
+                        {/* Main Row */}
+                        <TableRow
+                          className={`hover:bg-gray-50/50 dark:hover:bg-gray-800/50 transition-colors border-gray-100 dark:border-gray-700 ${expandedDeviceId === device.id ? 'bg-muted/30' : ''}`}
+                        >
+                          <TableCell>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8"
+                              onClick={() => toggleExpandLogs(device.id)}
+                            >
+                              {expandedDeviceId === device.id ? (
+                                <ChevronUp className="h-4 w-4" />
+                              ) : (
+                                <ChevronDown className="h-4 w-4" />
+                              )}
+                            </Button>
+                          </TableCell>
+                          <TableCell className="px-6 py-4 font-medium">
+                            <div className="flex flex-col gap-1">
+                              <span className="text-base font-semibold text-gray-900 dark:text-gray-100">
+                                {device.model || 'Generic Device'}
+                              </span>
+                              <div
+                                className="flex items-center gap-1.5 text-xs text-blue-600/80 font-mono cursor-pointer hover:underline w-fit"
+                                onClick={() => navigator.clipboard.writeText(device.id)}
+                                title="Click to copy ID"
+                              >
+                                ID: {device.id.substring(0, 8)}...
+                              </div>
                             </div>
-                        ) : (
-                            <div className="overflow-x-auto">
-                                <Table>
-                                    <TableHeader>
-                                        <TableRow className="bg-gray-50/50 dark:bg-gray-800/50 hover:bg-gray-50/50 dark:hover:bg-gray-800/50 border-gray-100 dark:border-gray-700">
-                                            <TableHead className="w-[50px]"></TableHead> {/* Expand Trigger */}
-                                            <TableHead className="py-3 px-6 font-medium text-gray-500 dark:text-gray-400">Device Details</TableHead>
-                                            <TableHead className="py-3 px-6 font-medium text-gray-500 dark:text-gray-400">Status</TableHead>
-                                            <TableHead className="py-3 px-6 font-medium text-gray-500 dark:text-gray-400">Assigned Campaign</TableHead>
-                                            <TableHead className="py-3 px-6 font-medium text-gray-500 dark:text-gray-400">Last Seen</TableHead>
-                                            <TableHead className="py-3 px-6 font-medium text-gray-500 dark:text-gray-400 text-right">Actions</TableHead>
-                                        </TableRow>
-                                    </TableHeader>
-                                    <TableBody>
-                                        {devices.map(device => (
-                                            <React.Fragment key={device.id}>
-                                                {/* Main Row */}
-                                                <TableRow className={`hover:bg-gray-50/50 dark:hover:bg-gray-800/50 transition-colors border-gray-100 dark:border-gray-700 ${expandedDeviceId === device.id ? 'bg-muted/30' : ''}`}>
-                                                    <TableCell>
-                                                        <Button
-                                                            variant="ghost"
-                                                            size="icon"
-                                                            className="h-8 w-8"
-                                                            onClick={() => toggleExpandLogs(device.id)}
-                                                        >
-                                                            {expandedDeviceId === device.id ? (
-                                                                <ChevronUp className="h-4 w-4" />
-                                                            ) : (
-                                                                <ChevronDown className="h-4 w-4" />
-                                                            )}
-                                                        </Button>
-                                                    </TableCell>
-                                                    <TableCell className="px-6 py-4 font-medium">
-                                                        <div className="flex flex-col gap-1">
-                                                            <span className="text-base font-semibold text-gray-900 dark:text-gray-100">{device.model || 'Generic Device'}</span>
-                                                            <div
-                                                                className="flex items-center gap-1.5 text-xs text-blue-600/80 font-mono cursor-pointer hover:underline w-fit"
-                                                                onClick={() => navigator.clipboard.writeText(device.id)}
-                                                                title="Click to copy ID"
-                                                            >
-                                                                ID: {device.id.substring(0, 8)}...
-                                                            </div>
-                                                        </div>
-                                                    </TableCell>
-                                                    <TableCell className="px-6 py-4">
-                                                        {(() => {
-                                                            // Logic unified with AdminDeviceLogs.jsx
-                                                            const isStale = !device.lastSeenAt || (Date.now() - new Date(device.lastSeenAt).getTime() > 5 * 60 * 1000);
-                                                            const status = device.status;
-                                                            // Normalize 'offline' from Android app or 'inactive' from backend
-                                                            if (status === 'inactive' || status === 'offline' || isStale) {
-                                                                return (
-                                                                    <div className="flex flex-col gap-1">
-                                                                        <Badge variant="outline" className="bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-700 w-fit">
-                                                                            <span className="w-2 h-2 rounded-full bg-gray-400 dark:bg-gray-500 mr-2"></span>
-                                                                            OFFLINE
-                                                                        </Badge>
-                                                                        <span className="text-xs text-gray-400 dark:text-gray-500">
-                                                                            {device.lastSeenAt ? formatDistanceToNow(new Date(device.lastSeenAt), { addSuffix: true }) : 'Never seen'}
-                                                                        </span>
-                                                                    </div>
-                                                                );
-                                                            }
-                                                            if (status === 'standby' || status === 'idle') {
-                                                                return (
-                                                                    <Badge variant="outline" className="bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800">
-                                                                        <span className="w-2 h-2 rounded-full bg-blue-500 mr-2"></span>
-                                                                        READY
-                                                                    </Badge>
-                                                                );
-                                                            }
-                                                            if (status === 'playing' || status === 'active') {
-                                                                return (
-                                                                    <Badge variant="outline" className="bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800 animate-pulse">
-                                                                        <span className="w-2 h-2 rounded-full bg-green-500 mr-2"></span>
-                                                                        LIVE
-                                                                    </Badge>
-                                                                );
-                                                            }
-                                                            // Fallback
-                                                            return <Badge variant="outline">{status?.toUpperCase() || 'UNKNOWN'}</Badge>;
-                                                        })()}
-                                                    </TableCell>
-                                                    <TableCell className="px-6 py-4">
-                                                        {device.campaigns && device.campaigns.length > 0 ? (
-                                                            <div className="flex flex-wrap gap-1">
-                                                                {device.campaigns.map(c => (
-                                                                    <span key={c.id} className="font-medium text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/30 px-2 py-1 rounded text-sm whitespace-nowrap">
-                                                                        {c.name}
-                                                                    </span>
-                                                                ))}
-                                                            </div>
-                                                        ) : (
-                                                            <span className="text-gray-400 dark:text-gray-500 italic text-sm">Unassigned</span>
-                                                        )}
-                                                    </TableCell>
-                                                    <TableCell className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
-                                                        {device.latitude && device.longitude ? (
-                                                            <Button
-                                                                variant="ghost"
-                                                                size="sm"
-                                                                className="h-6 px-2 text-xs text-blue-600 hover:text-blue-700"
-                                                                onClick={() => setMapDevice(device)}
-                                                            >
-                                                                <MapPin className="h-3 w-3 mr-1" />
-                                                                View Map
-                                                            </Button>
-                                                        ) : (
-                                                            <span className="text-gray-400 dark:text-gray-500 text-xs">No GPS</span>
-                                                        )}
-                                                    </TableCell>
-                                                    <TableCell className="px-6 py-4 text-right">
-                                                        <Button
-                                                            variant="outline"
-                                                            size="sm"
-                                                            onClick={() => navigate('/AdminVehicles')}
-                                                            className="h-8"
-                                                        >
-                                                            Manage
-                                                        </Button>
-                                                    </TableCell>
-                                                </TableRow>
-
-                                                {/* Expanded Row (Logs Preview) */}
-                                                {expandedDeviceId === device.id && (
-                                                    <TableRow className="bg-muted/10">
-                                                        <TableCell colSpan={6} className="p-0">
-                                                            <div className="p-4 border-b border-gray-100 dark:border-gray-700 bg-slate-50/50 dark:bg-gray-800/50">
-                                                                <div className="flex justify-between items-center mb-3 px-2">
-                                                                    <h4 className="text-sm font-semibold flex items-center gap-2">
-                                                                        <Activity className="h-4 w-4 text-primary" />
-                                                                        Recent Logs (Last 5)
-                                                                    </h4>
-                                                                    <Button
-                                                                        variant="link"
-                                                                        size="sm"
-                                                                        className="h-auto p-0 text-blue-600"
-                                                                        onClick={() => navigate(`/admin/devices/${device.id}/logs`)}
-                                                                    >
-                                                                        See Full History <ExternalLink className="ml-1 h-3 w-3" />
-                                                                    </Button>
-                                                                </div>
-
-                                                                {previewLoading ? (
-                                                                    <div className="text-xs text-muted-foreground p-4">Loading logs...</div>
-                                                                ) : previewLogs.length === 0 ? (
-                                                                    <div className="text-xs text-muted-foreground p-4">No logs found.</div>
-                                                                ) : (
-                                                                    <div className="space-y-2">
-                                                                        {previewLogs.map((log) => (
-                                                                            <div key={log.id} className="grid grid-cols-[140px_100px_1fr] gap-4 text-xs p-2 rounded bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-700 items-center">
-                                                                                <span className="text-muted-foreground">
-                                                                                    {format(new Date(log.createdAt), 'MMM d, HH:mm:ss')}
-                                                                                </span>
-                                                                                <Badge variant="outline" className="w-fit text-[10px] h-5">
-                                                                                    {log.type}
-                                                                                </Badge>
-                                                                                <div className="truncate text-muted-foreground font-mono">
-                                                                                    {log.type === 'HEARTBEAT' ? (
-                                                                                        log.payload?.source === 'manifest_fetch' ? (
-                                                                                            <span className="flex items-center gap-1.5 text-blue-600">
-                                                                                                <RefreshCcw className="h-3 w-3" /> Manifest Refresh (Manual)
-                                                                                            </span>
-                                                                                        ) : (
-                                                                                            <span className="flex gap-3">
-                                                                                                <span className="flex items-center gap-1">
-                                                                                                    <Battery className="h-3 w-3" />
-                                                                                                    {typeof log.payload?.batteryLevel === 'number'
-                                                                                                        ? `${(log.payload.batteryLevel * 100).toFixed(0)}%`
-                                                                                                        : '--%'}
-                                                                                                </span>
-                                                                                                <span className="flex items-center gap-1">
-                                                                                                    <HardDrive className="h-3 w-3" />
-                                                                                                    {log.payload?.storageUsed || '--'}
-                                                                                                </span>
-                                                                                            </span>
-                                                                                        )
-                                                                                    ) : log.type === 'IMPRESSIONS' ? (
-                                                                                        <span className="flex items-center gap-1.5 text-purple-600">
-                                                                                            <Eye className="h-3 w-3" /> Uploaded {log.payload?.count} Impressions
-                                                                                        </span>
-                                                                                    ) : (
-                                                                                        JSON.stringify(log.payload)
-                                                                                    )}
-                                                                                </div>
-                                                                            </div>
-                                                                        ))}
-                                                                    </div>
-                                                                )}
-                                                            </div>
-                                                        </TableCell>
-                                                    </TableRow>
-                                                )}
-                                            </React.Fragment>
-                                        ))}
-                                    </TableBody>
-                                </Table>
-                            </div>
-                        )}
-                    </CardContent>
-                </Card>
-
-                {/* Campaign Assignment moved to AdminVehicles */}
-
-                {/* Location Map Dialog */}
-
-                {/* Location Map Dialog */}
-                <Dialog open={!!mapDevice} onOpenChange={(open) => !open && setMapDevice(null)}>
-                    <DialogContent className="max-w-2xl">
-                        <DialogHeader>
-                            <DialogTitle className="flex items-center gap-2">
-                                <MapPin className="h-5 w-5 text-blue-600" />
-                                Device Location - {mapDevice?.model || 'Device'}
-                            </DialogTitle>
-                        </DialogHeader>
-                        <div className="space-y-3">
-                            <div className="text-sm text-muted-foreground">
-                                <p>📍 Coordinates: {mapDevice?.latitude?.toFixed(6)}, {mapDevice?.longitude?.toFixed(6)}</p>
-                                <p>🕐 Last updated: {mapDevice?.locationUpdatedAt ? formatDistanceToNow(new Date(mapDevice.locationUpdatedAt), { addSuffix: true }) : 'Unknown'}</p>
-                            </div>
-                            {mapDevice?.latitude && mapDevice?.longitude && (
-                                <div className="h-[400px] rounded-lg overflow-hidden border">
-                                    <iframe
-                                        width="100%"
-                                        height="100%"
-                                        style={{ border: 0 }}
-                                        loading="lazy"
-                                        allowFullScreen
-                                        referrerPolicy="no-referrer-when-downgrade"
-                                        src={`https://www.google.com/maps/embed/v1/place?key=${import.meta.env.VITE_GOOGLE_MAPS_API_KEY}&q=${mapDevice.latitude},${mapDevice.longitude}&zoom=16`}
-                                    />
-                                </div>
+                          </TableCell>
+                          <TableCell className="px-6 py-4">
+                            {(() => {
+                              // Logic unified with AdminDeviceLogs.jsx
+                              const isStale =
+                                !device.lastSeenAt ||
+                                Date.now() - new Date(device.lastSeenAt).getTime() > 5 * 60 * 1000;
+                              const status = device.status;
+                              // Normalize 'offline' from Android app or 'inactive' from backend
+                              if (status === 'inactive' || status === 'offline' || isStale) {
+                                return (
+                                  <div className="flex flex-col gap-1">
+                                    <Badge
+                                      variant="outline"
+                                      className="bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-700 w-fit"
+                                    >
+                                      <span className="w-2 h-2 rounded-full bg-gray-400 dark:bg-gray-500 mr-2"></span>
+                                      OFFLINE
+                                    </Badge>
+                                    <span className="text-xs text-gray-400 dark:text-gray-500">
+                                      {device.lastSeenAt
+                                        ? formatDistanceToNow(new Date(device.lastSeenAt), { addSuffix: true })
+                                        : 'Never seen'}
+                                    </span>
+                                  </div>
+                                );
+                              }
+                              if (status === 'standby' || status === 'idle') {
+                                return (
+                                  <Badge
+                                    variant="outline"
+                                    className="bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800"
+                                  >
+                                    <span className="w-2 h-2 rounded-full bg-blue-500 mr-2"></span>
+                                    READY
+                                  </Badge>
+                                );
+                              }
+                              if (status === 'playing' || status === 'active') {
+                                return (
+                                  <Badge
+                                    variant="outline"
+                                    className="bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800 animate-pulse"
+                                  >
+                                    <span className="w-2 h-2 rounded-full bg-green-500 mr-2"></span>
+                                    LIVE
+                                  </Badge>
+                                );
+                              }
+                              // Fallback
+                              return <Badge variant="outline">{status?.toUpperCase() || 'UNKNOWN'}</Badge>;
+                            })()}
+                          </TableCell>
+                          <TableCell className="px-6 py-4">
+                            {device.campaigns && device.campaigns.length > 0 ? (
+                              <div className="flex flex-wrap gap-1">
+                                {device.campaigns.map((c) => (
+                                  <span
+                                    key={c.id}
+                                    className="font-medium text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/30 px-2 py-1 rounded text-sm whitespace-nowrap"
+                                  >
+                                    {c.name}
+                                  </span>
+                                ))}
+                              </div>
+                            ) : (
+                              <span className="text-gray-400 dark:text-gray-500 italic text-sm">Unassigned</span>
                             )}
-                        </div>
-                    </DialogContent>
-                </Dialog>
+                          </TableCell>
+                          <TableCell className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
+                            {device.latitude && device.longitude ? (
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                className="h-6 px-2 text-xs text-blue-600 hover:text-blue-700"
+                                onClick={() => setMapDevice(device)}
+                              >
+                                <MapPin className="h-3 w-3 mr-1" />
+                                View Map
+                              </Button>
+                            ) : (
+                              <span className="text-gray-400 dark:text-gray-500 text-xs">No GPS</span>
+                            )}
+                          </TableCell>
+                          <TableCell className="px-6 py-4 text-right">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => navigate('/AdminVehicles')}
+                              className="h-8"
+                            >
+                              Manage
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+
+                        {/* Expanded Row (Logs Preview) */}
+                        {expandedDeviceId === device.id && (
+                          <TableRow className="bg-muted/10">
+                            <TableCell colSpan={6} className="p-0">
+                              <div className="p-4 border-b border-gray-100 dark:border-gray-700 bg-slate-50/50 dark:bg-gray-800/50">
+                                <div className="flex justify-between items-center mb-3 px-2">
+                                  <h4 className="text-sm font-semibold flex items-center gap-2">
+                                    <Activity className="h-4 w-4 text-primary" />
+                                    Recent Logs (Last 5)
+                                  </h4>
+                                  <Button
+                                    variant="link"
+                                    size="sm"
+                                    className="h-auto p-0 text-blue-600"
+                                    onClick={() => navigate(`/admin/devices/${device.id}/logs`)}
+                                  >
+                                    See Full History <ExternalLink className="ml-1 h-3 w-3" />
+                                  </Button>
+                                </div>
+
+                                {previewLoading ? (
+                                  <div className="text-xs text-muted-foreground p-4">Loading logs...</div>
+                                ) : previewLogs.length === 0 ? (
+                                  <div className="text-xs text-muted-foreground p-4">No logs found.</div>
+                                ) : (
+                                  <div className="space-y-2">
+                                    {previewLogs.map((log) => (
+                                      <div
+                                        key={log.id}
+                                        className="grid grid-cols-[140px_100px_1fr] gap-4 text-xs p-2 rounded bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-700 items-center"
+                                      >
+                                        <span className="text-muted-foreground">
+                                          {format(new Date(log.createdAt), 'MMM d, HH:mm:ss')}
+                                        </span>
+                                        <Badge variant="outline" className="w-fit text-[10px] h-5">
+                                          {log.type}
+                                        </Badge>
+                                        <div className="truncate text-muted-foreground font-mono">
+                                          {log.type === 'HEARTBEAT' ? (
+                                            log.payload?.source === 'manifest_fetch' ? (
+                                              <span className="flex items-center gap-1.5 text-blue-600">
+                                                <RefreshCcw className="h-3 w-3" /> Manifest Refresh (Manual)
+                                              </span>
+                                            ) : (
+                                              <span className="flex gap-3">
+                                                <span className="flex items-center gap-1">
+                                                  <Battery className="h-3 w-3" />
+                                                  {typeof log.payload?.batteryLevel === 'number'
+                                                    ? `${(log.payload.batteryLevel * 100).toFixed(0)}%`
+                                                    : '--%'}
+                                                </span>
+                                                <span className="flex items-center gap-1">
+                                                  <HardDrive className="h-3 w-3" />
+                                                  {log.payload?.storageUsed || '--'}
+                                                </span>
+                                              </span>
+                                            )
+                                          ) : log.type === 'IMPRESSIONS' ? (
+                                            <span className="flex items-center gap-1.5 text-purple-600">
+                                              <Eye className="h-3 w-3" /> Uploaded {log.payload?.count} Impressions
+                                            </span>
+                                          ) : (
+                                            JSON.stringify(log.payload)
+                                          )}
+                                        </div>
+                                      </div>
+                                    ))}
+                                  </div>
+                                )}
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        )}
+                      </React.Fragment>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Campaign Assignment moved to AdminVehicles */}
+
+        {/* Location Map Dialog */}
+
+        {/* Location Map Dialog */}
+        <Dialog open={!!mapDevice} onOpenChange={(open) => !open && setMapDevice(null)}>
+          <DialogContent className="max-w-2xl">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <MapPin className="h-5 w-5 text-blue-600" />
+                Device Location - {mapDevice?.model || 'Device'}
+              </DialogTitle>
+            </DialogHeader>
+            <div className="space-y-3">
+              <div className="text-sm text-muted-foreground">
+                <p>
+                  📍 Coordinates: {mapDevice?.latitude?.toFixed(6)}, {mapDevice?.longitude?.toFixed(6)}
+                </p>
+                <p>
+                  🕐 Last updated:{' '}
+                  {mapDevice?.locationUpdatedAt
+                    ? formatDistanceToNow(new Date(mapDevice.locationUpdatedAt), { addSuffix: true })
+                    : 'Unknown'}
+                </p>
+              </div>
+              {mapDevice?.latitude && mapDevice?.longitude && (
+                <div className="h-[400px] rounded-lg overflow-hidden border">
+                  <iframe
+                    width="100%"
+                    height="100%"
+                    style={{ border: 0 }}
+                    loading="lazy"
+                    allowFullScreen
+                    referrerPolicy="no-referrer-when-downgrade"
+                    src={`https://www.google.com/maps/embed/v1/place?key=${import.meta.env.VITE_GOOGLE_MAPS_API_KEY}&q=${mapDevice.latitude},${mapDevice.longitude}&zoom=16`}
+                  />
+                </div>
+              )}
             </div>
-        </div >
-    );
+          </DialogContent>
+        </Dialog>
+      </div>
+    </div>
+  );
 }

--- a/src/pages/AdminFleetMap.jsx
+++ b/src/pages/AdminFleetMap.jsx
@@ -13,362 +13,361 @@ const DEFAULT_ZOOM = 12;
 
 // Status to color mapping
 const getStatusColor = (status, isStale) => {
-    if (status === 'inactive' || status === 'offline' || isStale) {
-        return '#6B7280'; // Gray
-    }
-    if (status === 'standby' || status === 'idle') {
-        return '#3B82F6'; // Blue
-    }
-    if (status === 'playing' || status === 'active') {
-        return '#22C55E'; // Green
-    }
-    return '#6B7280'; // Default gray
+  if (status === 'inactive' || status === 'offline' || isStale) {
+    return '#6B7280'; // Gray
+  }
+  if (status === 'standby' || status === 'idle') {
+    return '#3B82F6'; // Blue
+  }
+  if (status === 'playing' || status === 'active') {
+    return '#22C55E'; // Green
+  }
+  return '#6B7280'; // Default gray
 };
 
 const getStatusLabel = (status, isStale) => {
-    if (status === 'inactive' || status === 'offline' || isStale) return 'OFFLINE';
-    if (status === 'standby' || status === 'idle') return 'READY';
-    if (status === 'playing' || status === 'active') return 'LIVE';
-    return status?.toUpperCase() || 'UNKNOWN';
+  if (status === 'inactive' || status === 'offline' || isStale) return 'OFFLINE';
+  if (status === 'standby' || status === 'idle') return 'READY';
+  if (status === 'playing' || status === 'active') return 'LIVE';
+  return status?.toUpperCase() || 'UNKNOWN';
 };
 
 export default function AdminFleetMap() {
-    const navigate = useNavigate();
-    const mapRef = useRef(null);
-    const googleMapRef = useRef(null);
-    const markersRef = useRef({});
-    const [devices, setDevices] = useState([]);
-    const [loading, setLoading] = useState(true);
-    const [mapLoaded, setMapLoaded] = useState(false);
-    const [selectedDevice, setSelectedDevice] = useState(null);
-    const [sseConnected, setSseConnected] = useState(false);
+  const navigate = useNavigate();
+  const mapRef = useRef(null);
+  const googleMapRef = useRef(null);
+  const markersRef = useRef({});
+  const [devices, setDevices] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [mapLoaded, setMapLoaded] = useState(false);
+  const [selectedDevice, setSelectedDevice] = useState(null);
+  const [sseConnected, setSseConnected] = useState(false);
 
-    // Load devices
-    const loadDevices = useCallback(async () => {
-        try {
-            setLoading(true);
-            const res = await api.get('/devices');
-            let devicesList = Array.isArray(res.data) ? res.data : res.data?.devices || [];
-            setDevices(devicesList);
-        } catch (err) {
-            console.error('Failed to load devices', err);
-        } finally {
-            setLoading(false);
-        }
-    }, []);
+  // Load devices
+  const loadDevices = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await api.get('/devices');
+      let devicesList = Array.isArray(res.data) ? res.data : res.data?.devices || [];
+      setDevices(devicesList);
+    } catch (err) {
+      console.error('Failed to load devices', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
-    // Initialize Google Maps
-    useEffect(() => {
-        // Check if Google Maps API is already loaded
-        if (window.google && window.google.maps) {
-            initializeMap();
-            return;
-        }
+  // Initialize Google Maps
+  useEffect(() => {
+    // Check if Google Maps API is already loaded
+    if (window.google && window.google.maps) {
+      initializeMap();
+      return;
+    }
 
-        // Load Google Maps script
-        const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
-        if (!apiKey) {
-            console.error('Google Maps API key not configured. Set VITE_GOOGLE_MAPS_API_KEY');
-            return;
-        }
+    // Load Google Maps script
+    const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+    if (!apiKey) {
+      console.error('Google Maps API key not configured. Set VITE_GOOGLE_MAPS_API_KEY');
+      return;
+    }
 
-        const script = document.createElement('script');
-        script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=marker`;
-        script.async = true;
-        script.onload = () => initializeMap();
-        document.head.appendChild(script);
+    const script = document.createElement('script');
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=marker`;
+    script.async = true;
+    script.onload = () => initializeMap();
+    document.head.appendChild(script);
 
-        return () => {
-            // Cleanup markers
-            Object.values(markersRef.current).forEach(marker => marker?.setMap?.(null));
-        };
-    }, []);
+    return () => {
+      // Cleanup markers
+      Object.values(markersRef.current).forEach((marker) => marker?.setMap?.(null));
+    };
+  }, []);
 
-    const initializeMap = () => {
-        if (!mapRef.current || googleMapRef.current) return;
+  const initializeMap = () => {
+    if (!mapRef.current || googleMapRef.current) return;
 
-        googleMapRef.current = new window.google.maps.Map(mapRef.current, {
-            center: SINGAPORE_CENTER,
-            zoom: DEFAULT_ZOOM,
-            mapTypeControl: false,
-            streetViewControl: false,
-            fullscreenControl: true,
-            styles: [
-                { featureType: "poi", stylers: [{ visibility: "off" }] },
-                { featureType: "transit", stylers: [{ visibility: "simplified" }] }
-            ]
-        });
+    googleMapRef.current = new window.google.maps.Map(mapRef.current, {
+      center: SINGAPORE_CENTER,
+      zoom: DEFAULT_ZOOM,
+      mapTypeControl: false,
+      streetViewControl: false,
+      fullscreenControl: true,
+      styles: [
+        { featureType: 'poi', stylers: [{ visibility: 'off' }] },
+        { featureType: 'transit', stylers: [{ visibility: 'simplified' }] },
+      ],
+    });
 
-        setMapLoaded(true);
+    setMapLoaded(true);
+  };
+
+  // Update markers when devices or map changes
+  useEffect(() => {
+    if (!mapLoaded || !googleMapRef.current) return;
+
+    devices.forEach((device) => {
+      if (device.latitude && device.longitude) {
+        updateMarker(device);
+      }
+    });
+
+    // Remove old markers for devices no longer in list
+    const deviceIds = new Set(devices.map((d) => d.id));
+    Object.keys(markersRef.current).forEach((id) => {
+      if (!deviceIds.has(id)) {
+        markersRef.current[id]?.setMap?.(null);
+        delete markersRef.current[id];
+      }
+    });
+  }, [devices, mapLoaded]);
+
+  const updateMarker = (device) => {
+    const isStale = !device.lastSeenAt || Date.now() - new Date(device.lastSeenAt).getTime() > 5 * 60 * 1000;
+    const color = getStatusColor(device.status, isStale);
+    const position = { lat: device.latitude, lng: device.longitude };
+
+    if (markersRef.current[device.id]) {
+      // Update existing marker position
+      markersRef.current[device.id].setPosition(position);
+    } else {
+      // Create new marker
+      const marker = new window.google.maps.Marker({
+        position,
+        map: googleMapRef.current,
+        title: device.model || device.id,
+        icon: {
+          path: window.google.maps.SymbolPath.CIRCLE,
+          fillColor: color,
+          fillOpacity: 1,
+          strokeColor: '#ffffff',
+          strokeWeight: 2,
+          scale: 10,
+        },
+      });
+
+      marker.addListener('click', () => {
+        setSelectedDevice(device);
+      });
+
+      markersRef.current[device.id] = marker;
+    }
+
+    // Update marker color
+    markersRef.current[device.id]?.setIcon({
+      path: window.google.maps.SymbolPath.CIRCLE,
+      fillColor: color,
+      fillOpacity: 1,
+      strokeColor: '#ffffff',
+      strokeWeight: 2,
+      scale: 10,
+    });
+  };
+
+  // Load devices on mount
+  useEffect(() => {
+    loadDevices();
+  }, [loadDevices]);
+
+  // SSE for real-time location updates
+  useEffect(() => {
+    const url = `${import.meta.env.VITE_API_URL}/devices/events/fleet/stream`;
+    const sse = new EventSource(url, { withCredentials: true });
+
+    sse.onopen = () => {
+      setSseConnected(true);
     };
 
-    // Update markers when devices or map changes
-    useEffect(() => {
-        if (!mapLoaded || !googleMapRef.current) return;
-
-        devices.forEach(device => {
-            if (device.latitude && device.longitude) {
-                updateMarker(device);
+    // Handle location updates
+    sse.addEventListener('location_update', (e) => {
+      try {
+        const data = JSON.parse(e.data);
+        setDevices((prev) =>
+          prev.map((d) => {
+            if (d.id === data.deviceId) {
+              return {
+                ...d,
+                latitude: data.latitude,
+                longitude: data.longitude,
+                locationUpdatedAt: data.timestamp,
+              };
             }
-        });
+            return d;
+          })
+        );
+      } catch (err) {
+        console.error('Failed to parse location_update', err);
+      }
+    });
 
-        // Remove old markers for devices no longer in list
-        const deviceIds = new Set(devices.map(d => d.id));
-        Object.keys(markersRef.current).forEach(id => {
-            if (!deviceIds.has(id)) {
-                markersRef.current[id]?.setMap?.(null);
-                delete markersRef.current[id];
+    // Handle status changes
+    sse.addEventListener('status_change', (e) => {
+      try {
+        const data = JSON.parse(e.data);
+        setDevices((prev) =>
+          prev.map((d) => {
+            if (d.id === data.deviceId) {
+              return { ...d, status: data.status, lastSeenAt: data.lastSeenAt };
             }
-        });
-    }, [devices, mapLoaded]);
+            return d;
+          })
+        );
+      } catch (err) {
+        console.error('Failed to parse status_change', err);
+      }
+    });
 
-    const updateMarker = (device) => {
-        const isStale = !device.lastSeenAt ||
-            (Date.now() - new Date(device.lastSeenAt).getTime() > 5 * 60 * 1000);
-        const color = getStatusColor(device.status, isStale);
-        const position = { lat: device.latitude, lng: device.longitude };
-
-        if (markersRef.current[device.id]) {
-            // Update existing marker position
-            markersRef.current[device.id].setPosition(position);
-        } else {
-            // Create new marker
-            const marker = new window.google.maps.Marker({
-                position,
-                map: googleMapRef.current,
-                title: device.model || device.id,
-                icon: {
-                    path: window.google.maps.SymbolPath.CIRCLE,
-                    fillColor: color,
-                    fillOpacity: 1,
-                    strokeColor: '#ffffff',
-                    strokeWeight: 2,
-                    scale: 10
-                }
-            });
-
-            marker.addListener('click', () => {
-                setSelectedDevice(device);
-            });
-
-            markersRef.current[device.id] = marker;
-        }
-
-        // Update marker color
-        markersRef.current[device.id]?.setIcon({
-            path: window.google.maps.SymbolPath.CIRCLE,
-            fillColor: color,
-            fillOpacity: 1,
-            strokeColor: '#ffffff',
-            strokeWeight: 2,
-            scale: 10
-        });
+    sse.onerror = () => {
+      console.warn('⚠️ Fleet Map SSE error');
+      setSseConnected(false);
     };
 
-    // Load devices on mount
-    useEffect(() => {
-        loadDevices();
-    }, [loadDevices]);
+    return () => sse.close();
+  }, []);
 
-    // SSE for real-time location updates
-    useEffect(() => {
-        const token = localStorage.getItem('mktr_auth_token');
-        if (!token) return;
+  // Stats
+  const devicesWithLocation = devices.filter((d) => d.latitude && d.longitude);
+  const liveDevices = devices.filter(
+    (d) =>
+      (d.status === 'playing' || d.status === 'active') &&
+      d.lastSeenAt &&
+      Date.now() - new Date(d.lastSeenAt).getTime() < 5 * 60 * 1000
+  );
 
-        const url = `${import.meta.env.VITE_API_URL}/devices/events/fleet/stream?token=${token}`;
-        const sse = new EventSource(url);
-
-        sse.onopen = () => {
-            setSseConnected(true);
-        };
-
-        // Handle location updates
-        sse.addEventListener('location_update', (e) => {
-            try {
-                const data = JSON.parse(e.data);
-                setDevices(prev => prev.map(d => {
-                    if (d.id === data.deviceId) {
-                        return {
-                            ...d,
-                            latitude: data.latitude,
-                            longitude: data.longitude,
-                            locationUpdatedAt: data.timestamp
-                        };
-                    }
-                    return d;
-                }));
-            } catch (err) {
-                console.error('Failed to parse location_update', err);
-            }
-        });
-
-        // Handle status changes
-        sse.addEventListener('status_change', (e) => {
-            try {
-                const data = JSON.parse(e.data);
-                setDevices(prev => prev.map(d => {
-                    if (d.id === data.deviceId) {
-                        return { ...d, status: data.status, lastSeenAt: data.lastSeenAt };
-                    }
-                    return d;
-                }));
-            } catch (err) {
-                console.error('Failed to parse status_change', err);
-            }
-        });
-
-        sse.onerror = () => {
-            console.warn('⚠️ Fleet Map SSE error');
-            setSseConnected(false);
-        };
-
-        return () => sse.close();
-    }, []);
-
-    // Stats
-    const devicesWithLocation = devices.filter(d => d.latitude && d.longitude);
-    const liveDevices = devices.filter(d =>
-        (d.status === 'playing' || d.status === 'active') &&
-        d.lastSeenAt &&
-        (Date.now() - new Date(d.lastSeenAt).getTime() < 5 * 60 * 1000)
-    );
-
-    return (
-        <div className="p-6 lg:p-8 min-h-screen bg-gray-50/50">
-            <div className="max-w-[1600px] mx-auto space-y-4">
-                {/* Header */}
-                <div className="flex justify-between items-center">
-                    <div>
-                        <h1 className="text-2xl font-bold flex items-center gap-2">
-                            <MapPin className="h-6 w-6 text-primary" />
-                            Fleet Map
-                        </h1>
-                        <p className="text-sm text-muted-foreground mt-1">
-                            Real-time location of all tablet devices
-                        </p>
-                    </div>
-                    <div className="flex items-center gap-3">
-                        <Badge variant="outline" className={sseConnected ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-500'}>
-                            {sseConnected ? <Wifi className="h-3 w-3 mr-1" /> : <WifiOff className="h-3 w-3 mr-1" />}
-                            {sseConnected ? 'Live' : 'Offline'}
-                        </Badge>
-                        <Button variant="outline" size="sm" onClick={loadDevices}>
-                            <RefreshCcw className="h-4 w-4 mr-2" />
-                            Refresh
-                        </Button>
-                    </div>
-                </div>
-
-                {/* Stats Cards */}
-                <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-                    <Card>
-                        <CardContent className="pt-4">
-                            <div className="text-2xl font-bold">{devices.length}</div>
-                            <div className="text-sm text-muted-foreground">Total Devices</div>
-                        </CardContent>
-                    </Card>
-                    <Card>
-                        <CardContent className="pt-4">
-                            <div className="text-2xl font-bold text-green-600">{liveDevices.length}</div>
-                            <div className="text-sm text-muted-foreground">Currently Live</div>
-                        </CardContent>
-                    </Card>
-                    <Card>
-                        <CardContent className="pt-4">
-                            <div className="text-2xl font-bold text-blue-600">{devicesWithLocation.length}</div>
-                            <div className="text-sm text-muted-foreground">With GPS Location</div>
-                        </CardContent>
-                    </Card>
-                    <Card>
-                        <CardContent className="pt-4">
-                            <div className="text-2xl font-bold text-gray-600">{devices.length - devicesWithLocation.length}</div>
-                            <div className="text-sm text-muted-foreground">No Location Data</div>
-                        </CardContent>
-                    </Card>
-                </div>
-
-                {/* Map */}
-                <Card className="overflow-hidden">
-                    <CardHeader className="pb-2">
-                        <CardTitle className="text-lg">Singapore Fleet Overview</CardTitle>
-                    </CardHeader>
-                    <CardContent className="p-0">
-                        {!import.meta.env.VITE_GOOGLE_MAPS_API_KEY ? (
-                            <div className="h-[500px] flex items-center justify-center bg-gray-100 text-gray-500">
-                                <div className="text-center">
-                                    <MapPin className="h-12 w-12 mx-auto mb-3 opacity-50" />
-                                    <p className="font-medium">Google Maps API Key Required</p>
-                                    <p className="text-sm mt-1">Set VITE_GOOGLE_MAPS_API_KEY in your environment</p>
-                                </div>
-                            </div>
-                        ) : (
-                            <div
-                                ref={mapRef}
-                                className="h-[500px] w-full"
-                                style={{ minHeight: '500px' }}
-                            />
-                        )}
-                    </CardContent>
-                </Card>
-
-                {/* Selected Device Info */}
-                {selectedDevice && (
-                    <Card>
-                        <CardContent className="pt-4">
-                            <div className="flex items-center justify-between">
-                                <div>
-                                    <h3 className="font-semibold">{selectedDevice.model || 'Unknown Device'}</h3>
-                                    <p className="text-sm text-muted-foreground font-mono">{selectedDevice.id}</p>
-                                    <p className="text-sm mt-2">
-                                        📍 {selectedDevice.latitude?.toFixed(4)}, {selectedDevice.longitude?.toFixed(4)}
-                                    </p>
-                                    <p className="text-sm text-muted-foreground">
-                                        Last seen: {selectedDevice.lastSeenAt ? formatDistanceToNow(new Date(selectedDevice.lastSeenAt), { addSuffix: true }) : 'Never'}
-                                    </p>
-                                </div>
-                                <div className="flex gap-2">
-                                    <Badge variant="outline" className={
-                                        selectedDevice.status === 'playing' ? 'bg-green-50 text-green-700' :
-                                            selectedDevice.status === 'standby' ? 'bg-blue-50 text-blue-700' :
-                                                'bg-gray-100 text-gray-500'
-                                    }>
-                                        {getStatusLabel(selectedDevice.status, false)}
-                                    </Badge>
-                                    <Button
-                                        size="sm"
-                                        onClick={() => navigate(`/admin/devices/${selectedDevice.id}/logs`)}
-                                    >
-                                        View Logs
-                                    </Button>
-                                    <Button
-                                        size="sm"
-                                        variant="outline"
-                                        onClick={() => setSelectedDevice(null)}
-                                    >
-                                        Close
-                                    </Button>
-                                </div>
-                            </div>
-                        </CardContent>
-                    </Card>
-                )}
-
-                {/* Legend */}
-                <div className="flex items-center gap-6 text-sm text-muted-foreground">
-                    <div className="flex items-center gap-2">
-                        <span className="w-3 h-3 rounded-full bg-green-500"></span>
-                        Live (Playing)
-                    </div>
-                    <div className="flex items-center gap-2">
-                        <span className="w-3 h-3 rounded-full bg-blue-500"></span>
-                        Ready (Standby)
-                    </div>
-                    <div className="flex items-center gap-2">
-                        <span className="w-3 h-3 rounded-full bg-gray-400"></span>
-                        Offline
-                    </div>
-                </div>
-            </div>
+  return (
+    <div className="p-6 lg:p-8 min-h-screen bg-gray-50/50">
+      <div className="max-w-[1600px] mx-auto space-y-4">
+        {/* Header */}
+        <div className="flex justify-between items-center">
+          <div>
+            <h1 className="text-2xl font-bold flex items-center gap-2">
+              <MapPin className="h-6 w-6 text-primary" />
+              Fleet Map
+            </h1>
+            <p className="text-sm text-muted-foreground mt-1">Real-time location of all tablet devices</p>
+          </div>
+          <div className="flex items-center gap-3">
+            <Badge
+              variant="outline"
+              className={sseConnected ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-500'}
+            >
+              {sseConnected ? <Wifi className="h-3 w-3 mr-1" /> : <WifiOff className="h-3 w-3 mr-1" />}
+              {sseConnected ? 'Live' : 'Offline'}
+            </Badge>
+            <Button variant="outline" size="sm" onClick={loadDevices}>
+              <RefreshCcw className="h-4 w-4 mr-2" />
+              Refresh
+            </Button>
+          </div>
         </div>
-    );
+
+        {/* Stats Cards */}
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+          <Card>
+            <CardContent className="pt-4">
+              <div className="text-2xl font-bold">{devices.length}</div>
+              <div className="text-sm text-muted-foreground">Total Devices</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-4">
+              <div className="text-2xl font-bold text-green-600">{liveDevices.length}</div>
+              <div className="text-sm text-muted-foreground">Currently Live</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-4">
+              <div className="text-2xl font-bold text-blue-600">{devicesWithLocation.length}</div>
+              <div className="text-sm text-muted-foreground">With GPS Location</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-4">
+              <div className="text-2xl font-bold text-gray-600">{devices.length - devicesWithLocation.length}</div>
+              <div className="text-sm text-muted-foreground">No Location Data</div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Map */}
+        <Card className="overflow-hidden">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-lg">Singapore Fleet Overview</CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            {!import.meta.env.VITE_GOOGLE_MAPS_API_KEY ? (
+              <div className="h-[500px] flex items-center justify-center bg-gray-100 text-gray-500">
+                <div className="text-center">
+                  <MapPin className="h-12 w-12 mx-auto mb-3 opacity-50" />
+                  <p className="font-medium">Google Maps API Key Required</p>
+                  <p className="text-sm mt-1">Set VITE_GOOGLE_MAPS_API_KEY in your environment</p>
+                </div>
+              </div>
+            ) : (
+              <div ref={mapRef} className="h-[500px] w-full" style={{ minHeight: '500px' }} />
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Selected Device Info */}
+        {selectedDevice && (
+          <Card>
+            <CardContent className="pt-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <h3 className="font-semibold">{selectedDevice.model || 'Unknown Device'}</h3>
+                  <p className="text-sm text-muted-foreground font-mono">{selectedDevice.id}</p>
+                  <p className="text-sm mt-2">
+                    📍 {selectedDevice.latitude?.toFixed(4)}, {selectedDevice.longitude?.toFixed(4)}
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    Last seen:{' '}
+                    {selectedDevice.lastSeenAt
+                      ? formatDistanceToNow(new Date(selectedDevice.lastSeenAt), { addSuffix: true })
+                      : 'Never'}
+                  </p>
+                </div>
+                <div className="flex gap-2">
+                  <Badge
+                    variant="outline"
+                    className={
+                      selectedDevice.status === 'playing'
+                        ? 'bg-green-50 text-green-700'
+                        : selectedDevice.status === 'standby'
+                          ? 'bg-blue-50 text-blue-700'
+                          : 'bg-gray-100 text-gray-500'
+                    }
+                  >
+                    {getStatusLabel(selectedDevice.status, false)}
+                  </Badge>
+                  <Button size="sm" onClick={() => navigate(`/admin/devices/${selectedDevice.id}/logs`)}>
+                    View Logs
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={() => setSelectedDevice(null)}>
+                    Close
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Legend */}
+        <div className="flex items-center gap-6 text-sm text-muted-foreground">
+          <div className="flex items-center gap-2">
+            <span className="w-3 h-3 rounded-full bg-green-500"></span>
+            Live (Playing)
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="w-3 h-3 rounded-full bg-blue-500"></span>
+            Ready (Standby)
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="w-3 h-3 rounded-full bg-gray-400"></span>
+            Offline
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/pages/AdminVehicles.jsx
+++ b/src/pages/AdminVehicles.jsx
@@ -7,775 +7,749 @@ import { Input } from '../components/ui/input';
 import { apiClient as api } from '../api/client';
 import { formatDistanceToNow } from 'date-fns';
 import { Badge } from '../components/ui/badge';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '../components/ui/dialog';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select';
 import {
-    Dialog,
-    DialogContent,
-    DialogHeader,
-    DialogTitle,
-    DialogFooter,
-} from "../components/ui/dialog";
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "../components/ui/select";
-import {
-    Car,
-    Plus,
-    Link2,
-    Unlink,
-    Settings,
-    Trash2,
-    RefreshCcw,
-    MonitorSmartphone,
-    Pencil,
-    Volume2
+  Car,
+  Plus,
+  Link2,
+  Unlink,
+  Settings,
+  Trash2,
+  RefreshCcw,
+  MonitorSmartphone,
+  Pencil,
+  Volume2,
 } from 'lucide-react';
 import { toast } from 'sonner';
 
 export default function AdminVehicles() {
-    const navigate = useNavigate();
-    const [vehicles, setVehicles] = useState([]);
-    const [devices, setDevices] = useState([]);
-    const [loading, setLoading] = useState(true);
-    const [campaigns, setCampaigns] = useState([]);
+  const navigate = useNavigate();
+  const [vehicles, setVehicles] = useState([]);
+  const [devices, setDevices] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [campaigns, setCampaigns] = useState([]);
 
-    // Dialogs
-    const [showCreateDialog, setShowCreateDialog] = useState(false);
-    const [showPairDialog, setShowPairDialog] = useState(false);
-    const [showAssignDialog, setShowAssignDialog] = useState(false);
-    const [selectedVehicle, setSelectedVehicle] = useState(null);
+  // Dialogs
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [showPairDialog, setShowPairDialog] = useState(false);
+  const [showAssignDialog, setShowAssignDialog] = useState(false);
+  const [selectedVehicle, setSelectedVehicle] = useState(null);
 
-    // Form state
-    const [newCarplate, setNewCarplate] = useState('');
-    const [pairMasterId, setPairMasterId] = useState('');
-    const [pairSlaveId, setPairSlaveId] = useState('');
-    const [selectedCampaignIds, setSelectedCampaignIds] = useState([]);
+  // Form state
+  const [newCarplate, setNewCarplate] = useState('');
+  const [pairMasterId, setPairMasterId] = useState('');
+  const [pairSlaveId, setPairSlaveId] = useState('');
+  const [selectedCampaignIds, setSelectedCampaignIds] = useState([]);
 
-    // Volume Control State
-    const [showVolumeDialog, setShowVolumeDialog] = useState(false);
-    const [volumeLevel, setVolumeLevel] = useState([0]);
+  // Volume Control State
+  const [showVolumeDialog, setShowVolumeDialog] = useState(false);
+  const [volumeLevel, setVolumeLevel] = useState([0]);
 
-    useEffect(() => {
-        loadData();
-    }, []);
+  useEffect(() => {
+    loadData();
+  }, []);
 
-    const loadData = async () => {
-        try {
-            setLoading(true);
-            const [vehiclesRes, devicesRes, campaignsRes] = await Promise.all([
-                api.get('/vehicles'),
-                api.get('/devices'),
-                api.get('/campaigns?limit=100')
-            ]);
+  const loadData = async () => {
+    try {
+      setLoading(true);
+      const [vehiclesRes, devicesRes, campaignsRes] = await Promise.all([
+        api.get('/vehicles'),
+        api.get('/devices'),
+        api.get('/campaigns?limit=100'),
+      ]);
 
-            // Extract devices list
-            let devicesList = [];
-            if (Array.isArray(devicesRes.data)) {
-                devicesList = devicesRes.data;
-            } else if (devicesRes.data?.data) {
-                devicesList = devicesRes.data.data;
-            }
-            setDevices(devicesList);
+      // Extract devices list
+      let devicesList = [];
+      if (Array.isArray(devicesRes.data)) {
+        devicesList = devicesRes.data;
+      } else if (devicesRes.data?.data) {
+        devicesList = devicesRes.data.data;
+      }
+      setDevices(devicesList);
 
-            // Merge live device data into vehicles
-            const vehiclesData = vehiclesRes.data?.data || vehiclesRes.data || [];
+      // Merge live device data into vehicles
+      const vehiclesData = vehiclesRes.data?.data || vehiclesRes.data || [];
 
-            // Map the latest device status to the vehicle's devices
-            const updatedVehicles = vehiclesData.map(v => {
-                const master = devicesList.find(d => d.id === v.masterDeviceId);
-                const slave = devicesList.find(d => d.id === v.slaveDeviceId);
-                return {
-                    ...v,
-                    masterDevice: master || v.masterDevice,
-                    slaveDevice: slave || v.slaveDevice
-                };
-            });
-
-            setVehicles(updatedVehicles);
-
-            // Get PHV campaigns
-            let campaignsList = [];
-            if (campaignsRes.data?.campaigns && Array.isArray(campaignsRes.data.campaigns)) {
-                campaignsList = campaignsRes.data.campaigns;
-            } else if (Array.isArray(campaignsRes.data)) {
-                campaignsList = campaignsRes.data;
-            }
-
-            // Filter for PHV campaigns only (brand_awareness or video_ad)
-            // Exclude 'lead_generation' which are regular agent campaigns
-            setCampaigns(campaignsList.filter(c => ['brand_awareness', 'video_ad'].includes(c.type)));
-        } catch (err) {
-            console.error('Failed to load data:', err);
-            toast.error('Failed to load vehicles');
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    // Live Fleet Status Stream (SSE)
-    useEffect(() => {
-        const token = localStorage.getItem('mktr_auth_token');
-        if (!token) return;
-
-        const url = `${import.meta.env.VITE_API_URL}/devices/events/fleet/stream?token=${token}`;
-        const sse = new EventSource(url);
-
-        sse.onopen = () => {};
-
-        sse.addEventListener('status_change', (e) => {
-            try {
-                const data = JSON.parse(e.data);
-
-                // Update devices state
-                setDevices(prevDevices => prevDevices.map(d => {
-                    if (d.id === data.deviceId) {
-                        return { ...d, status: data.status, lastSeenAt: data.lastSeenAt };
-                    }
-                    return d;
-                }));
-
-                // Update vehicles state (nested devices)
-                setVehicles(prevVehicles => prevVehicles.map(v => {
-                    let updated = false;
-                    let newMaster = v.masterDevice;
-                    let newSlave = v.slaveDevice;
-
-                    if (v.masterDeviceId === data.deviceId) {
-                        newMaster = { ...v.masterDevice, status: data.status, lastSeenAt: data.lastSeenAt };
-                        updated = true;
-                    }
-                    if (v.slaveDeviceId === data.deviceId) {
-                        newSlave = { ...v.slaveDevice, status: data.status, lastSeenAt: data.lastSeenAt };
-                        updated = true;
-                    }
-
-                    if (updated) {
-                        return { ...v, masterDevice: newMaster, slaveDevice: newSlave };
-                    }
-                    return v;
-                }));
-
-            } catch (err) {
-                console.error('Failed to parse status_change', err);
-            }
-        });
-
-        sse.onerror = (err) => {
-            console.warn('⚠️ Fleet Stream error - auto-reconnecting...', err);
+      // Map the latest device status to the vehicle's devices
+      const updatedVehicles = vehiclesData.map((v) => {
+        const master = devicesList.find((d) => d.id === v.masterDeviceId);
+        const slave = devicesList.find((d) => d.id === v.slaveDeviceId);
+        return {
+          ...v,
+          masterDevice: master || v.masterDevice,
+          slaveDevice: slave || v.slaveDevice,
         };
+      });
 
-        return () => sse.close();
-    }, []);
+      setVehicles(updatedVehicles);
 
-    const handleCreateVehicle = async () => {
-        if (!newCarplate.trim()) {
-            toast.error('Carplate is required');
-            return;
-        }
+      // Get PHV campaigns
+      let campaignsList = [];
+      if (campaignsRes.data?.campaigns && Array.isArray(campaignsRes.data.campaigns)) {
+        campaignsList = campaignsRes.data.campaigns;
+      } else if (Array.isArray(campaignsRes.data)) {
+        campaignsList = campaignsRes.data;
+      }
 
-        try {
-            await api.post('/vehicles', { carplate: newCarplate.trim() });
-            toast.success('Vehicle created');
-            setShowCreateDialog(false);
-            setNewCarplate('');
-            loadData();
-        } catch (err) {
-            toast.error(err.response?.data?.message || 'Failed to create vehicle');
-        }
+      // Filter for PHV campaigns only (brand_awareness or video_ad)
+      // Exclude 'lead_generation' which are regular agent campaigns
+      setCampaigns(campaignsList.filter((c) => ['brand_awareness', 'video_ad'].includes(c.type)));
+    } catch (err) {
+      console.error('Failed to load data:', err);
+      toast.error('Failed to load vehicles');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Live Fleet Status Stream (SSE)
+  useEffect(() => {
+    const url = `${import.meta.env.VITE_API_URL}/devices/events/fleet/stream`;
+    const sse = new EventSource(url, { withCredentials: true });
+
+    sse.onopen = () => {};
+
+    sse.addEventListener('status_change', (e) => {
+      try {
+        const data = JSON.parse(e.data);
+
+        // Update devices state
+        setDevices((prevDevices) =>
+          prevDevices.map((d) => {
+            if (d.id === data.deviceId) {
+              return { ...d, status: data.status, lastSeenAt: data.lastSeenAt };
+            }
+            return d;
+          })
+        );
+
+        // Update vehicles state (nested devices)
+        setVehicles((prevVehicles) =>
+          prevVehicles.map((v) => {
+            let updated = false;
+            let newMaster = v.masterDevice;
+            let newSlave = v.slaveDevice;
+
+            if (v.masterDeviceId === data.deviceId) {
+              newMaster = { ...v.masterDevice, status: data.status, lastSeenAt: data.lastSeenAt };
+              updated = true;
+            }
+            if (v.slaveDeviceId === data.deviceId) {
+              newSlave = { ...v.slaveDevice, status: data.status, lastSeenAt: data.lastSeenAt };
+              updated = true;
+            }
+
+            if (updated) {
+              return { ...v, masterDevice: newMaster, slaveDevice: newSlave };
+            }
+            return v;
+          })
+        );
+      } catch (err) {
+        console.error('Failed to parse status_change', err);
+      }
+    });
+
+    sse.onerror = (err) => {
+      console.warn('⚠️ Fleet Stream error - auto-reconnecting...', err);
     };
 
-    const handlePairDevices = async () => {
-        if (!selectedVehicle) return;
+    return () => sse.close();
+  }, []);
 
-        try {
-            await api.put(`/vehicles/${selectedVehicle.id}/pair`, {
-                masterDeviceId: pairMasterId || undefined,
-                slaveDeviceId: pairSlaveId || undefined
-            });
-            toast.success('Devices paired');
-            setShowPairDialog(false);
-            setPairMasterId('');
-            setPairSlaveId('');
-            loadData();
-        } catch (err) {
-            toast.error(err.response?.data?.message || 'Failed to pair devices');
-        }
-    };
+  const handleCreateVehicle = async () => {
+    if (!newCarplate.trim()) {
+      toast.error('Carplate is required');
+      return;
+    }
 
-    const handleUnpair = async (vehicleId) => {
-        try {
-            await api.delete(`/vehicles/${vehicleId}/pair`);
-            toast.success('Devices unpaired');
-            loadData();
-        } catch (err) {
-            toast.error('Failed to unpair devices');
-        }
-    };
+    try {
+      await api.post('/vehicles', { carplate: newCarplate.trim() });
+      toast.success('Vehicle created');
+      setShowCreateDialog(false);
+      setNewCarplate('');
+      loadData();
+    } catch (err) {
+      toast.error(err.response?.data?.message || 'Failed to create vehicle');
+    }
+  };
 
-    const handleAssignCampaigns = async () => {
-        if (!selectedVehicle) return;
+  const handlePairDevices = async () => {
+    if (!selectedVehicle) return;
 
-        try {
-            await api.patch(`/vehicles/${selectedVehicle.id}`, {
-                campaignIds: selectedCampaignIds
-            });
-            toast.success('Campaigns assigned');
-            setShowAssignDialog(false);
-            setSelectedCampaignIds([]);
-            loadData();
-        } catch (err) {
-            toast.error('Failed to assign campaigns');
-        }
-    };
+    try {
+      await api.put(`/vehicles/${selectedVehicle.id}/pair`, {
+        masterDeviceId: pairMasterId || undefined,
+        slaveDeviceId: pairSlaveId || undefined,
+      });
+      toast.success('Devices paired');
+      setShowPairDialog(false);
+      setPairMasterId('');
+      setPairSlaveId('');
+      loadData();
+    } catch (err) {
+      toast.error(err.response?.data?.message || 'Failed to pair devices');
+    }
+  };
 
-    const handleDeleteVehicle = async (vehicleId) => {
-        if (!confirm('Delete this vehicle? Devices will be unpaired.')) return;
+  const handleUnpair = async (vehicleId) => {
+    try {
+      await api.delete(`/vehicles/${vehicleId}/pair`);
+      toast.success('Devices unpaired');
+      loadData();
+    } catch (err) {
+      toast.error('Failed to unpair devices');
+    }
+  };
 
-        try {
-            await api.delete(`/vehicles/${vehicleId}`);
-            toast.success('Vehicle deleted');
-            loadData();
-        } catch (err) {
-            toast.error('Failed to delete vehicle');
-        }
-    };
+  const handleAssignCampaigns = async () => {
+    if (!selectedVehicle) return;
 
-    const handleSetVolume = async () => {
-        if (!selectedVehicle) return;
+    try {
+      await api.patch(`/vehicles/${selectedVehicle.id}`, {
+        campaignIds: selectedCampaignIds,
+      });
+      toast.success('Campaigns assigned');
+      setShowAssignDialog(false);
+      setSelectedCampaignIds([]);
+      loadData();
+    } catch (err) {
+      toast.error('Failed to assign campaigns');
+    }
+  };
 
-        try {
-            await api.put(`/vehicles/${selectedVehicle.id}/volume`, {
-                volume: volumeLevel[0]
-            });
-            toast.success(`Volume command sent (${volumeLevel[0]}%)`);
-            loadData(); // Assuming fetchVehicles is loadData based on context
-            setShowVolumeDialog(false);
-        } catch (err) {
-            toast.error(err.response?.data?.message || 'Failed to set volume');
-        }
-    };
+  const handleDeleteVehicle = async (vehicleId) => {
+    if (!confirm('Delete this vehicle? Devices will be unpaired.')) return;
 
-    const getDeviceStatus = (device) => {
-        if (!device) return { label: 'Empty', color: 'gray' };
-        const isStale = !device.lastSeenAt || (Date.now() - new Date(device.lastSeenAt).getTime() > 5 * 60 * 1000);
-        if (device.status === 'inactive' || device.status === 'offline' || isStale) {
-            return { label: 'OFFLINE', color: 'gray' };
-        }
-        if (device.status === 'playing' || device.status === 'active') {
-            return { label: 'LIVE', color: 'green' };
-        }
-        return { label: 'READY', color: 'blue' };
-    };
+    try {
+      await api.delete(`/vehicles/${vehicleId}`);
+      toast.success('Vehicle deleted');
+      loadData();
+    } catch (err) {
+      toast.error('Failed to delete vehicle');
+    }
+  };
 
-    // [FIX] Include devices already assigned to the CURRENT selected vehicle, plus all unpaired ones.
-    const availableDevices = devices.filter(d =>
-        !d.vehicleId || (selectedVehicle && d.vehicleId === selectedVehicle.id)
-    );
+  const handleSetVolume = async () => {
+    if (!selectedVehicle) return;
 
-    return (
-        <div className="p-6 lg:p-8 min-h-screen bg-gray-50/50 dark:bg-gray-900/50">
-            <div className="max-w-[1600px] mx-auto space-y-6">
-                <div className="flex justify-between items-center">
+    try {
+      await api.put(`/vehicles/${selectedVehicle.id}/volume`, {
+        volume: volumeLevel[0],
+      });
+      toast.success(`Volume command sent (${volumeLevel[0]}%)`);
+      loadData(); // Assuming fetchVehicles is loadData based on context
+      setShowVolumeDialog(false);
+    } catch (err) {
+      toast.error(err.response?.data?.message || 'Failed to set volume');
+    }
+  };
+
+  const getDeviceStatus = (device) => {
+    if (!device) return { label: 'Empty', color: 'gray' };
+    const isStale = !device.lastSeenAt || Date.now() - new Date(device.lastSeenAt).getTime() > 5 * 60 * 1000;
+    if (device.status === 'inactive' || device.status === 'offline' || isStale) {
+      return { label: 'OFFLINE', color: 'gray' };
+    }
+    if (device.status === 'playing' || device.status === 'active') {
+      return { label: 'LIVE', color: 'green' };
+    }
+    return { label: 'READY', color: 'blue' };
+  };
+
+  // [FIX] Include devices already assigned to the CURRENT selected vehicle, plus all unpaired ones.
+  const availableDevices = devices.filter(
+    (d) => !d.vehicleId || (selectedVehicle && d.vehicleId === selectedVehicle.id)
+  );
+
+  return (
+    <div className="p-6 lg:p-8 min-h-screen bg-gray-50/50 dark:bg-gray-900/50">
+      <div className="max-w-[1600px] mx-auto space-y-6">
+        <div className="flex justify-between items-center">
+          <div>
+            <h1 className="text-2xl font-bold">Vehicle Fleet</h1>
+            <p className="text-muted-foreground">Manage paired tablets by vehicle</p>
+          </div>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={loadData}>
+              <RefreshCcw className="h-4 w-4 mr-2" />
+              Refresh
+            </Button>
+            <Button onClick={() => setShowCreateDialog(true)}>
+              <Plus className="h-4 w-4 mr-2" />
+              Add Vehicle
+            </Button>
+          </div>
+        </div>
+
+        {loading ? (
+          <Card>
+            <CardContent className="py-8 text-center text-muted-foreground">Loading vehicles...</CardContent>
+          </Card>
+        ) : vehicles.length === 0 ? (
+          <Card>
+            <CardContent className="py-12 text-center">
+              <Car className="h-12 w-12 mx-auto text-gray-300 dark:text-gray-600 mb-4" />
+              <h3 className="text-lg font-medium mb-2">No Vehicles Yet</h3>
+              <p className="text-muted-foreground mb-4">Create a vehicle to start pairing tablets</p>
+              <Button onClick={() => setShowCreateDialog(true)}>
+                <Plus className="h-4 w-4 mr-2" />
+                Add First Vehicle
+              </Button>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="grid gap-4">
+            {vehicles.map((vehicle) => (
+              <Card key={vehicle.id} className="overflow-hidden">
+                <CardHeader className="bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-950/30 dark:to-indigo-950/30 border-b py-4">
+                  <div className="flex justify-between items-start">
+                    <div className="flex items-center gap-3">
+                      <div className="p-2 bg-blue-100 dark:bg-blue-900/50 rounded-lg">
+                        <Car className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+                      </div>
+                      <div>
+                        <CardTitle className="text-lg">{vehicle.carplate}</CardTitle>
+                        <p className="text-xs text-muted-foreground font-mono mt-0.5">WiFi: {vehicle.hotspotSsid}</p>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          setSelectedVehicle(vehicle);
+                          setVolumeLevel([Number(vehicle.volume) || 0]);
+                          setShowVolumeDialog(true);
+                        }}
+                        title="Volume Control"
+                      >
+                        <Volume2 className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          setSelectedVehicle(vehicle);
+                          setSelectedCampaignIds(vehicle.campaignIds || []);
+                          setShowAssignDialog(true);
+                        }}
+                      >
+                        <Settings className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-red-600 dark:text-red-400 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950/30"
+                        onClick={() => handleDeleteVehicle(vehicle.id)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                </CardHeader>
+                <CardContent className="p-4">
+                  <div className="grid md:grid-cols-2 gap-4">
+                    {/* Master Device */}
+                    <div className="border rounded-lg p-4 bg-white dark:bg-gray-900">
+                      <div className="flex items-center justify-between mb-3">
+                        <div className="flex items-center gap-2">
+                          <Badge
+                            variant="outline"
+                            className="bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800"
+                          >
+                            MASTER
+                          </Badge>
+                          <span className="text-xs text-muted-foreground">Left Screen</span>
+                        </div>
+                        {vehicle.masterDevice && (
+                          <Badge
+                            variant="outline"
+                            className={
+                              getDeviceStatus(vehicle.masterDevice).color === 'green'
+                                ? 'bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800'
+                                : getDeviceStatus(vehicle.masterDevice).color === 'blue'
+                                  ? 'bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800'
+                                  : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-700'
+                            }
+                          >
+                            {getDeviceStatus(vehicle.masterDevice).label}
+                          </Badge>
+                        )}
+                      </div>
+                      {vehicle.masterDevice ? (
+                        <div className="space-y-1">
+                          <p className="font-medium">{vehicle.masterDevice.model || 'Tablet'}</p>
+                          <p className="text-xs text-muted-foreground font-mono">
+                            {vehicle.masterDevice.id.substring(0, 8)}...
+                          </p>
+                          {vehicle.masterDevice.lastSeenAt && (
+                            <p className="text-xs text-muted-foreground">
+                              Seen {formatDistanceToNow(new Date(vehicle.masterDevice.lastSeenAt), { addSuffix: true })}
+                            </p>
+                          )}
+                        </div>
+                      ) : (
+                        <div className="text-center py-4 text-muted-foreground">
+                          <MonitorSmartphone className="h-8 w-8 mx-auto mb-2 opacity-30" />
+                          <p className="text-sm">No device paired</p>
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Slave Device */}
+                    <div className="border rounded-lg p-4 bg-white dark:bg-gray-900">
+                      <div className="flex items-center justify-between mb-3">
+                        <div className="flex items-center gap-2">
+                          <Badge variant="outline" className="bg-amber-50 text-amber-700 border-amber-200">
+                            SLAVE
+                          </Badge>
+                          <span className="text-xs text-muted-foreground">Right Screen</span>
+                        </div>
+                        {vehicle.slaveDevice && (
+                          <Badge
+                            variant="outline"
+                            className={
+                              getDeviceStatus(vehicle.slaveDevice).color === 'green'
+                                ? 'bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800'
+                                : getDeviceStatus(vehicle.slaveDevice).color === 'blue'
+                                  ? 'bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800'
+                                  : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-700'
+                            }
+                          >
+                            {getDeviceStatus(vehicle.slaveDevice).label}
+                          </Badge>
+                        )}
+                      </div>
+                      {vehicle.slaveDevice ? (
+                        <div className="space-y-1">
+                          <p className="font-medium">{vehicle.slaveDevice.model || 'Tablet'}</p>
+                          <p className="text-xs text-muted-foreground font-mono">
+                            {vehicle.slaveDevice.id.substring(0, 8)}...
+                          </p>
+                          {vehicle.slaveDevice.lastSeenAt && (
+                            <p className="text-xs text-muted-foreground">
+                              Seen {formatDistanceToNow(new Date(vehicle.slaveDevice.lastSeenAt), { addSuffix: true })}
+                            </p>
+                          )}
+                        </div>
+                      ) : (
+                        <div className="text-center py-4 text-muted-foreground">
+                          <MonitorSmartphone className="h-8 w-8 mx-auto mb-2 opacity-30" />
+                          <p className="text-sm">No device paired</p>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Campaign & Actions */}
+                  <div className="mt-4 pt-4 border-t flex justify-between items-center">
                     <div>
-                        <h1 className="text-2xl font-bold">Vehicle Fleet</h1>
-                        <p className="text-muted-foreground">Manage paired tablets by vehicle</p>
+                      <span className="text-sm text-muted-foreground mr-2">Campaigns:</span>
+                      {vehicle.campaigns && vehicle.campaigns.length > 0 ? (
+                        <div className="inline-flex flex-wrap gap-1">
+                          {vehicle.campaigns.map((c) => (
+                            <Badge key={c.id} variant="secondary" className="text-xs">
+                              {c.name}
+                            </Badge>
+                          ))}
+                        </div>
+                      ) : (
+                        <span className="text-sm text-gray-400 dark:text-gray-500 italic">None assigned</span>
+                      )}
                     </div>
                     <div className="flex gap-2">
-                        <Button variant="outline" onClick={loadData}>
-                            <RefreshCcw className="h-4 w-4 mr-2" />
-                            Refresh
+                      {(!vehicle.masterDevice || !vehicle.slaveDevice) && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => {
+                            setSelectedVehicle(vehicle);
+                            setPairMasterId(vehicle.masterDeviceId || '');
+                            setPairSlaveId(vehicle.slaveDeviceId || '');
+                            setShowPairDialog(true);
+                          }}
+                        >
+                          <Link2 className="h-4 w-4 mr-1" />
+                          Pair Devices
                         </Button>
-                        <Button onClick={() => setShowCreateDialog(true)}>
-                            <Plus className="h-4 w-4 mr-2" />
-                            Add Vehicle
+                      )}
+                      {(vehicle.masterDevice || vehicle.slaveDevice) && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="text-orange-600 hover:text-orange-700"
+                          onClick={() => handleUnpair(vehicle.id)}
+                        >
+                          <Unlink className="h-4 w-4 mr-1" />
+                          Unpair
                         </Button>
+                      )}
                     </div>
-                </div>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
 
-                {loading ? (
-                    <Card>
-                        <CardContent className="py-8 text-center text-muted-foreground">
-                            Loading vehicles...
-                        </CardContent>
-                    </Card>
-                ) : vehicles.length === 0 ? (
-                    <Card>
-                        <CardContent className="py-12 text-center">
-                            <Car className="h-12 w-12 mx-auto text-gray-300 dark:text-gray-600 mb-4" />
-                            <h3 className="text-lg font-medium mb-2">No Vehicles Yet</h3>
-                            <p className="text-muted-foreground mb-4">
-                                Create a vehicle to start pairing tablets
-                            </p>
-                            <Button onClick={() => setShowCreateDialog(true)}>
-                                <Plus className="h-4 w-4 mr-2" />
-                                Add First Vehicle
-                            </Button>
-                        </CardContent>
-                    </Card>
-                ) : (
-                    <div className="grid gap-4">
-                        {vehicles.map(vehicle => (
-                            <Card key={vehicle.id} className="overflow-hidden">
-                                <CardHeader className="bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-950/30 dark:to-indigo-950/30 border-b py-4">
-                                    <div className="flex justify-between items-start">
-                                        <div className="flex items-center gap-3">
-                                            <div className="p-2 bg-blue-100 dark:bg-blue-900/50 rounded-lg">
-                                                <Car className="h-5 w-5 text-blue-600 dark:text-blue-400" />
-                                            </div>
-                                            <div>
-                                                <CardTitle className="text-lg">{vehicle.carplate}</CardTitle>
-                                                <p className="text-xs text-muted-foreground font-mono mt-0.5">
-                                                    WiFi: {vehicle.hotspotSsid}
-                                                </p>
-                                            </div>
-                                        </div>
-                                        <div className="flex items-center gap-2">
-                                            <Button
-                                                variant="ghost"
-                                                size="sm"
-                                                onClick={() => {
-                                                    setSelectedVehicle(vehicle);
-                                                    setVolumeLevel([Number(vehicle.volume) || 0]);
-                                                    setShowVolumeDialog(true);
-                                                }}
-                                                title="Volume Control"
-                                            >
-                                                <Volume2 className="h-4 w-4" />
-                                            </Button>
-                                            <Button
-                                                variant="ghost"
-                                                size="sm"
-                                                onClick={() => {
-                                                    setSelectedVehicle(vehicle);
-                                                    setSelectedCampaignIds(vehicle.campaignIds || []);
-                                                    setShowAssignDialog(true);
-                                                }}
-                                            >
-                                                <Settings className="h-4 w-4" />
-                                            </Button>
-                                            <Button
-                                                variant="ghost"
-                                                size="sm"
-                                                className="text-red-600 dark:text-red-400 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950/30"
-                                                onClick={() => handleDeleteVehicle(vehicle.id)}
-                                            >
-                                                <Trash2 className="h-4 w-4" />
-                                            </Button>
-                                        </div>
-                                    </div>
-                                </CardHeader>
-                                <CardContent className="p-4">
-                                    <div className="grid md:grid-cols-2 gap-4">
-                                        {/* Master Device */}
-                                        <div className="border rounded-lg p-4 bg-white dark:bg-gray-900">
-                                            <div className="flex items-center justify-between mb-3">
-                                                <div className="flex items-center gap-2">
-                                                    <Badge variant="outline" className="bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800">
-                                                        MASTER
-                                                    </Badge>
-                                                    <span className="text-xs text-muted-foreground">Left Screen</span>
-                                                </div>
-                                                {vehicle.masterDevice && (
-                                                    <Badge
-                                                        variant="outline"
-                                                        className={
-                                                            getDeviceStatus(vehicle.masterDevice).color === 'green'
-                                                                ? 'bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800'
-                                                                : getDeviceStatus(vehicle.masterDevice).color === 'blue'
-                                                                    ? 'bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800'
-                                                                    : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-700'
-                                                        }
-                                                    >
-                                                        {getDeviceStatus(vehicle.masterDevice).label}
-                                                    </Badge>
-                                                )}
-                                            </div>
-                                            {vehicle.masterDevice ? (
-                                                <div className="space-y-1">
-                                                    <p className="font-medium">{vehicle.masterDevice.model || 'Tablet'}</p>
-                                                    <p className="text-xs text-muted-foreground font-mono">
-                                                        {vehicle.masterDevice.id.substring(0, 8)}...
-                                                    </p>
-                                                    {vehicle.masterDevice.lastSeenAt && (
-                                                        <p className="text-xs text-muted-foreground">
-                                                            Seen {formatDistanceToNow(new Date(vehicle.masterDevice.lastSeenAt), { addSuffix: true })}
-                                                        </p>
-                                                    )}
-                                                </div>
-                                            ) : (
-                                                <div className="text-center py-4 text-muted-foreground">
-                                                    <MonitorSmartphone className="h-8 w-8 mx-auto mb-2 opacity-30" />
-                                                    <p className="text-sm">No device paired</p>
-                                                </div>
-                                            )}
-                                        </div>
-
-                                        {/* Slave Device */}
-                                        <div className="border rounded-lg p-4 bg-white dark:bg-gray-900">
-                                            <div className="flex items-center justify-between mb-3">
-                                                <div className="flex items-center gap-2">
-                                                    <Badge variant="outline" className="bg-amber-50 text-amber-700 border-amber-200">
-                                                        SLAVE
-                                                    </Badge>
-                                                    <span className="text-xs text-muted-foreground">Right Screen</span>
-                                                </div>
-                                                {vehicle.slaveDevice && (
-                                                    <Badge
-                                                        variant="outline"
-                                                        className={
-                                                            getDeviceStatus(vehicle.slaveDevice).color === 'green'
-                                                                ? 'bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800'
-                                                                : getDeviceStatus(vehicle.slaveDevice).color === 'blue'
-                                                                    ? 'bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800'
-                                                                    : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-700'
-                                                        }
-                                                    >
-                                                        {getDeviceStatus(vehicle.slaveDevice).label}
-                                                    </Badge>
-                                                )}
-                                            </div>
-                                            {vehicle.slaveDevice ? (
-                                                <div className="space-y-1">
-                                                    <p className="font-medium">{vehicle.slaveDevice.model || 'Tablet'}</p>
-                                                    <p className="text-xs text-muted-foreground font-mono">
-                                                        {vehicle.slaveDevice.id.substring(0, 8)}...
-                                                    </p>
-                                                    {vehicle.slaveDevice.lastSeenAt && (
-                                                        <p className="text-xs text-muted-foreground">
-                                                            Seen {formatDistanceToNow(new Date(vehicle.slaveDevice.lastSeenAt), { addSuffix: true })}
-                                                        </p>
-                                                    )}
-                                                </div>
-                                            ) : (
-                                                <div className="text-center py-4 text-muted-foreground">
-                                                    <MonitorSmartphone className="h-8 w-8 mx-auto mb-2 opacity-30" />
-                                                    <p className="text-sm">No device paired</p>
-                                                </div>
-                                            )}
-                                        </div>
-                                    </div>
-
-                                    {/* Campaign & Actions */}
-                                    <div className="mt-4 pt-4 border-t flex justify-between items-center">
-                                        <div>
-                                            <span className="text-sm text-muted-foreground mr-2">Campaigns:</span>
-                                            {vehicle.campaigns && vehicle.campaigns.length > 0 ? (
-                                                <div className="inline-flex flex-wrap gap-1">
-                                                    {vehicle.campaigns.map(c => (
-                                                        <Badge key={c.id} variant="secondary" className="text-xs">
-                                                            {c.name}
-                                                        </Badge>
-                                                    ))}
-                                                </div>
-                                            ) : (
-                                                <span className="text-sm text-gray-400 dark:text-gray-500 italic">None assigned</span>
-                                            )}
-                                        </div>
-                                        <div className="flex gap-2">
-                                            {(!vehicle.masterDevice || !vehicle.slaveDevice) && (
-                                                <Button
-                                                    variant="outline"
-                                                    size="sm"
-                                                    onClick={() => {
-                                                        setSelectedVehicle(vehicle);
-                                                        setPairMasterId(vehicle.masterDeviceId || '');
-                                                        setPairSlaveId(vehicle.slaveDeviceId || '');
-                                                        setShowPairDialog(true);
-                                                    }}
-                                                >
-                                                    <Link2 className="h-4 w-4 mr-1" />
-                                                    Pair Devices
-                                                </Button>
-                                            )}
-                                            {(vehicle.masterDevice || vehicle.slaveDevice) && (
-                                                <Button
-                                                    variant="outline"
-                                                    size="sm"
-                                                    className="text-orange-600 hover:text-orange-700"
-                                                    onClick={() => handleUnpair(vehicle.id)}
-                                                >
-                                                    <Unlink className="h-4 w-4 mr-1" />
-                                                    Unpair
-                                                </Button>
-                                            )}
-                                        </div>
-                                    </div>
-                                </CardContent>
-                            </Card>
-                        ))}
+        {/* Unpaired Devices Section */}
+        {devices.filter((d) => !d.vehicleId).length > 0 && (
+          <Card className="border-dashed">
+            <CardHeader>
+              <CardTitle className="text-base flex items-center gap-2">
+                <MonitorSmartphone className="h-5 w-5 text-muted-foreground" />
+                Unpaired Devices ({devices.filter((d) => !d.vehicleId).length})
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-2 md:grid-cols-2 lg:grid-cols-3">
+                {devices
+                  .filter((d) => !d.vehicleId)
+                  .map((device) => (
+                    <div key={device.id} className="p-3 border rounded-lg bg-gray-50/50 dark:bg-gray-800/50">
+                      <p className="font-medium text-sm">{device.model || 'Tablet'}</p>
+                      <p className="text-xs text-muted-foreground font-mono">{device.id.substring(0, 8)}...</p>
+                      <Badge
+                        variant="outline"
+                        className={
+                          getDeviceStatus(device).color === 'green'
+                            ? 'bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800 mt-2'
+                            : getDeviceStatus(device).color === 'blue'
+                              ? 'bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800 mt-2'
+                              : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-700 mt-2'
+                        }
+                      >
+                        {getDeviceStatus(device).label}
+                      </Badge>
                     </div>
-                )}
+                  ))}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </div>
 
-                {/* Unpaired Devices Section */}
-                {devices.filter(d => !d.vehicleId).length > 0 && (
-                    <Card className="border-dashed">
-                        <CardHeader>
-                            <CardTitle className="text-base flex items-center gap-2">
-                                <MonitorSmartphone className="h-5 w-5 text-muted-foreground" />
-                                Unpaired Devices ({devices.filter(d => !d.vehicleId).length})
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent>
-                            <div className="grid gap-2 md:grid-cols-2 lg:grid-cols-3">
-                                {devices.filter(d => !d.vehicleId).map(device => (
-                                    <div key={device.id} className="p-3 border rounded-lg bg-gray-50/50 dark:bg-gray-800/50">
-                                        <p className="font-medium text-sm">{device.model || 'Tablet'}</p>
-                                        <p className="text-xs text-muted-foreground font-mono">
-                                            {device.id.substring(0, 8)}...
-                                        </p>
-                                        <Badge
-                                            variant="outline"
-                                            className={
-                                                getDeviceStatus(device).color === 'green'
-                                                    ? 'bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800 mt-2'
-                                                    : getDeviceStatus(device).color === 'blue'
-                                                        ? 'bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800 mt-2'
-                                                        : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-700 mt-2'
-                                            }
-                                        >
-                                            {getDeviceStatus(device).label}
-                                        </Badge>
-                                    </div>
-                                ))}
-                            </div>
-                        </CardContent>
-                    </Card>
-                )}
+      {/* Create Vehicle Dialog */}
+      <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add New Vehicle</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div>
+              <label className="text-sm font-medium">Carplate Number</label>
+              <Input
+                placeholder="e.g. SGX1234A"
+                value={newCarplate}
+                onChange={(e) => setNewCarplate(e.target.value.toUpperCase())}
+                className="mt-1"
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                WiFi hotspot will be auto-generated as MKTR-{newCarplate || 'CARPLATE'}
+              </p>
             </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowCreateDialog(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleCreateVehicle}>Create Vehicle</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
-            {/* Create Vehicle Dialog */}
-            <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
-                <DialogContent>
-                    <DialogHeader>
-                        <DialogTitle>Add New Vehicle</DialogTitle>
-                    </DialogHeader>
-                    <div className="space-y-4 py-4">
-                        <div>
-                            <label className="text-sm font-medium">Carplate Number</label>
-                            <Input
-                                placeholder="e.g. SGX1234A"
-                                value={newCarplate}
-                                onChange={(e) => setNewCarplate(e.target.value.toUpperCase())}
-                                className="mt-1"
-                            />
-                            <p className="text-xs text-muted-foreground mt-1">
-                                WiFi hotspot will be auto-generated as MKTR-{newCarplate || 'CARPLATE'}
-                            </p>
-                        </div>
-                    </div>
-                    <DialogFooter>
-                        <Button variant="outline" onClick={() => setShowCreateDialog(false)}>
-                            Cancel
-                        </Button>
-                        <Button onClick={handleCreateVehicle}>
-                            Create Vehicle
-                        </Button>
-                    </DialogFooter>
-                </DialogContent>
-            </Dialog>
+      {/* Pair Devices Dialog */}
+      <Dialog open={showPairDialog} onOpenChange={setShowPairDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Pair Devices to {selectedVehicle?.carplate}</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div>
+              <label className="text-sm font-medium">Master Device (Left Screen)</label>
+              <Select
+                value={pairMasterId || '_none'}
+                onValueChange={(val) => setPairMasterId(val === '_none' ? '' : val)}
+              >
+                <SelectTrigger className="mt-1">
+                  <SelectValue placeholder="Select master device" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="_none">None</SelectItem>
+                  {availableDevices
+                    .filter((d) => d.id !== pairSlaveId)
+                    .map((device) => (
+                      <SelectItem key={device.id} value={device.id}>
+                        {device.model || 'Tablet'} ({device.id.substring(0, 8)}...)
+                      </SelectItem>
+                    ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <label className="text-sm font-medium">Slave Device (Right Screen)</label>
+              <Select
+                value={pairSlaveId || '_none'}
+                onValueChange={(val) => setPairSlaveId(val === '_none' ? '' : val)}
+              >
+                <SelectTrigger className="mt-1">
+                  <SelectValue placeholder="Select slave device" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="_none">None</SelectItem>
+                  {availableDevices
+                    .filter((d) => d.id !== pairMasterId)
+                    .map((device) => (
+                      <SelectItem key={device.id} value={device.id}>
+                        {device.model || 'Tablet'} ({device.id.substring(0, 8)}...)
+                      </SelectItem>
+                    ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowPairDialog(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handlePairDevices} disabled={!pairMasterId && !pairSlaveId}>
+              <Link2 className="h-4 w-4 mr-2" />
+              Pair Devices
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
-            {/* Pair Devices Dialog */}
-            <Dialog open={showPairDialog} onOpenChange={setShowPairDialog}>
-                <DialogContent>
-                    <DialogHeader>
-                        <DialogTitle>Pair Devices to {selectedVehicle?.carplate}</DialogTitle>
-                    </DialogHeader>
-                    <div className="space-y-4 py-4">
-                        <div>
-                            <label className="text-sm font-medium">Master Device (Left Screen)</label>
-                            <Select value={pairMasterId || '_none'} onValueChange={(val) => setPairMasterId(val === '_none' ? '' : val)}>
-                                <SelectTrigger className="mt-1">
-                                    <SelectValue placeholder="Select master device" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    <SelectItem value="_none">None</SelectItem>
-                                    {availableDevices
-                                        .filter(d => d.id !== pairSlaveId)
-                                        .map(device => (
-                                            <SelectItem key={device.id} value={device.id}>
-                                                {device.model || 'Tablet'} ({device.id.substring(0, 8)}...)
-                                            </SelectItem>
-                                        ))}
-                                </SelectContent>
-                            </Select>
-                        </div>
-                        <div>
-                            <label className="text-sm font-medium">Slave Device (Right Screen)</label>
-                            <Select value={pairSlaveId || '_none'} onValueChange={(val) => setPairSlaveId(val === '_none' ? '' : val)}>
-                                <SelectTrigger className="mt-1">
-                                    <SelectValue placeholder="Select slave device" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    <SelectItem value="_none">None</SelectItem>
-                                    {availableDevices
-                                        .filter(d => d.id !== pairMasterId)
-                                        .map(device => (
-                                            <SelectItem key={device.id} value={device.id}>
-                                                {device.model || 'Tablet'} ({device.id.substring(0, 8)}...)
-                                            </SelectItem>
-                                        ))}
-                                </SelectContent>
-                            </Select>
-                        </div>
-                    </div>
-                    <DialogFooter>
-                        <Button variant="outline" onClick={() => setShowPairDialog(false)}>
-                            Cancel
-                        </Button>
-                        <Button onClick={handlePairDevices} disabled={!pairMasterId && !pairSlaveId}>
-                            <Link2 className="h-4 w-4 mr-2" />
-                            Pair Devices
-                        </Button>
-                    </DialogFooter>
-                </DialogContent>
-            </Dialog>
+      {/* Assign Campaigns Dialog */}
+      <Dialog open={showAssignDialog} onOpenChange={setShowAssignDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Assign Campaigns to {selectedVehicle?.carplate}</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <p className="text-sm text-muted-foreground">Select campaigns to play on both screens of this vehicle.</p>
+            <div className="space-y-2 max-h-[300px] overflow-y-auto">
+              {campaigns.length === 0 ? (
+                <p className="text-sm text-muted-foreground py-4 text-center">No PHV campaigns available</p>
+              ) : (
+                campaigns.map((campaign) => {
+                  // Calculate total media duration
+                  const playlist = campaign.ad_playlist || [];
+                  let totalDuration = 0;
+                  let mediaCount = 0;
 
-            {/* Assign Campaigns Dialog */}
-            <Dialog open={showAssignDialog} onOpenChange={setShowAssignDialog}>
-                <DialogContent>
-                    <DialogHeader>
-                        <DialogTitle>Assign Campaigns to {selectedVehicle?.carplate}</DialogTitle>
-                    </DialogHeader>
-                    <div className="space-y-4 py-4">
-                        <p className="text-sm text-muted-foreground">
-                            Select campaigns to play on both screens of this vehicle.
-                        </p>
-                        <div className="space-y-2 max-h-[300px] overflow-y-auto">
-                            {campaigns.length === 0 ? (
-                                <p className="text-sm text-muted-foreground py-4 text-center">
-                                    No PHV campaigns available
-                                </p>
-                            ) : (
-                                campaigns.map(campaign => {
-                                    // Calculate total media duration
-                                    const playlist = campaign.ad_playlist || [];
-                                    let totalDuration = 0;
-                                    let mediaCount = 0;
+                  playlist.forEach((item) => {
+                    mediaCount++;
+                    if (item.type === 'image') {
+                      totalDuration += 10; // Default 10s for images
+                    } else if (item.type === 'video' && item.duration) {
+                      totalDuration += item.duration;
+                    }
+                  });
 
-                                    playlist.forEach(item => {
-                                        mediaCount++;
-                                        if (item.type === 'image') {
-                                            totalDuration += 10; // Default 10s for images
-                                        } else if (item.type === 'video' && item.duration) {
-                                            totalDuration += item.duration;
-                                        }
-                                    });
+                  // Format campaign type for display
+                  const typeLabels = {
+                    brand_awareness: 'Brand Awareness',
+                    lead_generation: 'Lead Gen',
+                    video_ad: 'Video Ad',
+                  };
+                  const typeLabel = typeLabels[campaign.type] || campaign.type;
 
-                                    // Format campaign type for display
-                                    const typeLabels = {
-                                        'brand_awareness': 'Brand Awareness',
-                                        'lead_generation': 'Lead Gen',
-                                        'video_ad': 'Video Ad'
-                                    };
-                                    const typeLabel = typeLabels[campaign.type] || campaign.type;
-
-                                    return (
-                                        <div
-                                            key={campaign.id}
-                                            className={`flex items-center gap-2 p-3 border rounded-lg transition-colors ${selectedCampaignIds.includes(campaign.id)
-                                                ? 'bg-blue-50 dark:bg-blue-950/30 border-blue-300 dark:border-blue-800'
-                                                : 'hover:bg-gray-50 dark:hover:bg-gray-800 border-gray-200 dark:border-gray-700'
-                                                }`}
-                                        >
-                                            <label className="flex items-start gap-3 flex-1 cursor-pointer">
-                                                <input
-                                                    type="checkbox"
-                                                    checked={selectedCampaignIds.includes(campaign.id)}
-                                                    onChange={(e) => {
-                                                        if (e.target.checked) {
-                                                            setSelectedCampaignIds([...selectedCampaignIds, campaign.id]);
-                                                        } else {
-                                                            setSelectedCampaignIds(selectedCampaignIds.filter(id => id !== campaign.id));
-                                                        }
-                                                    }}
-                                                    className="h-4 w-4 rounded border-gray-300 mt-0.5"
-                                                />
-                                                <div className="flex-1">
-                                                    <div className="flex items-center gap-2 mb-1">
-                                                        <p className="font-medium text-sm">{campaign.name}</p>
-                                                        <Badge
-                                                            variant="outline"
-                                                            className="text-xs bg-purple-50 text-purple-700 border-purple-200"
-                                                        >
-                                                            {typeLabel}
-                                                        </Badge>
-                                                    </div>
-                                                    <div className="flex items-center gap-3 text-xs text-muted-foreground">
-                                                        <span className="flex items-center gap-1">
-                                                            <MonitorSmartphone className="h-3 w-3" />
-                                                            {mediaCount} media
-                                                        </span>
-                                                        {totalDuration > 0 && (
-                                                            <span className="flex items-center gap-1">
-                                                                ⏱️ {totalDuration}s loop
-                                                            </span>
-                                                        )}
-                                                        <span className={`${campaign.status === 'active' ? 'text-green-600 dark:text-green-400' : 'text-gray-500 dark:text-gray-400'}`}>
-                                                            {campaign.status}
-                                                        </span>
-                                                    </div>
-                                                </div>
-                                            </label>
-                                            <Button
-                                                variant="ghost"
-                                                size="sm"
-                                                className="h-8 w-8 p-0"
-                                                onClick={() => navigate(`/admin/campaigns/${campaign.id}/edit`)}
-                                                title="Edit Campaign"
-                                            >
-                                                <Pencil className="h-4 w-4 text-muted-foreground hover:text-primary" />
-                                            </Button>
-                                        </div>
-                                    );
-                                })
-                            )}
-                        </div>
-                    </div>
-                    <DialogFooter>
-                        <Button variant="outline" onClick={() => setShowAssignDialog(false)}>
-                            Cancel
-                        </Button>
-                        <Button onClick={handleAssignCampaigns}>
-                            Save Assignments
-                        </Button>
-                    </DialogFooter>
-                </DialogContent>
-            </Dialog>
-
-            {/* Volume Control Dialog */}
-            <Dialog open={showVolumeDialog} onOpenChange={setShowVolumeDialog}>
-                <DialogContent>
-                    <DialogHeader>
-                        <DialogTitle>Volume Control</DialogTitle>
-                    </DialogHeader>
-                    <div className="py-6 space-y-6">
-                        <div className="flex items-center justify-between">
-                            <span className="text-sm font-medium">Volume Level</span>
-                            <span className="text-sm text-muted-foreground">{volumeLevel[0]}%</span>
-                        </div>
-                        <Slider
-                            value={volumeLevel}
-                            onValueChange={setVolumeLevel}
-                            max={100}
-                            step={1}
+                  return (
+                    <div
+                      key={campaign.id}
+                      className={`flex items-center gap-2 p-3 border rounded-lg transition-colors ${
+                        selectedCampaignIds.includes(campaign.id)
+                          ? 'bg-blue-50 dark:bg-blue-950/30 border-blue-300 dark:border-blue-800'
+                          : 'hover:bg-gray-50 dark:hover:bg-gray-800 border-gray-200 dark:border-gray-700'
+                      }`}
+                    >
+                      <label className="flex items-start gap-3 flex-1 cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={selectedCampaignIds.includes(campaign.id)}
+                          onChange={(e) => {
+                            if (e.target.checked) {
+                              setSelectedCampaignIds([...selectedCampaignIds, campaign.id]);
+                            } else {
+                              setSelectedCampaignIds(selectedCampaignIds.filter((id) => id !== campaign.id));
+                            }
+                          }}
+                          className="h-4 w-4 rounded border-gray-300 mt-0.5"
                         />
-                        <p className="text-xs text-muted-foreground text-center">
-                            This will set the volume for both screens on {selectedVehicle?.carplate}
-                        </p>
+                        <div className="flex-1">
+                          <div className="flex items-center gap-2 mb-1">
+                            <p className="font-medium text-sm">{campaign.name}</p>
+                            <Badge variant="outline" className="text-xs bg-purple-50 text-purple-700 border-purple-200">
+                              {typeLabel}
+                            </Badge>
+                          </div>
+                          <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                            <span className="flex items-center gap-1">
+                              <MonitorSmartphone className="h-3 w-3" />
+                              {mediaCount} media
+                            </span>
+                            {totalDuration > 0 && (
+                              <span className="flex items-center gap-1">⏱️ {totalDuration}s loop</span>
+                            )}
+                            <span
+                              className={`${campaign.status === 'active' ? 'text-green-600 dark:text-green-400' : 'text-gray-500 dark:text-gray-400'}`}
+                            >
+                              {campaign.status}
+                            </span>
+                          </div>
+                        </div>
+                      </label>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0"
+                        onClick={() => navigate(`/admin/campaigns/${campaign.id}/edit`)}
+                        title="Edit Campaign"
+                      >
+                        <Pencil className="h-4 w-4 text-muted-foreground hover:text-primary" />
+                      </Button>
                     </div>
-                    <DialogFooter>
-                        <Button variant="outline" onClick={() => setShowVolumeDialog(false)}>
-                            Cancel
-                        </Button>
-                        <Button onClick={handleSetVolume}>
-                            Set Volume
-                        </Button>
-                    </DialogFooter>
-                </DialogContent>
-            </Dialog>
-        </div>
-    );
+                  );
+                })
+              )}
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowAssignDialog(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleAssignCampaigns}>Save Assignments</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Volume Control Dialog */}
+      <Dialog open={showVolumeDialog} onOpenChange={setShowVolumeDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Volume Control</DialogTitle>
+          </DialogHeader>
+          <div className="py-6 space-y-6">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">Volume Level</span>
+              <span className="text-sm text-muted-foreground">{volumeLevel[0]}%</span>
+            </div>
+            <Slider value={volumeLevel} onValueChange={setVolumeLevel} max={100} step={1} />
+            <p className="text-xs text-muted-foreground text-center">
+              This will set the volume for both screens on {selectedVehicle?.carplate}
+            </p>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowVolumeDialog(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSetVolume}>Set Volume</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
 }

--- a/src/stores/__tests__/authStore.test.js
+++ b/src/stores/__tests__/authStore.test.js
@@ -18,9 +18,15 @@ const localStorageMock = (() => {
   let store = {};
   return {
     getItem: vi.fn((key) => store[key] ?? null),
-    setItem: vi.fn((key, value) => { store[key] = String(value); }),
-    removeItem: vi.fn((key) => { delete store[key]; }),
-    clear: vi.fn(() => { store = {}; }),
+    setItem: vi.fn((key, value) => {
+      store[key] = String(value);
+    }),
+    removeItem: vi.fn((key) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
     _store: () => store,
   };
 })();
@@ -56,7 +62,7 @@ describe('authStore', () => {
 
     expect(result.success).toBe(true);
     expect(useAuthStore.getState().user).toEqual(fakeUser);
-    expect(useAuthStore.getState().token).toBe('tok-abc');
+    expect(useAuthStore.getState().token).toBe('authenticated');
   });
 
   it('login does not set state when API returns failure', async () => {
@@ -83,8 +89,8 @@ describe('authStore', () => {
     useAuthStore.getState().setAuth(user, 'tok-xyz');
 
     expect(useAuthStore.getState().user).toEqual(user);
-    expect(useAuthStore.getState().token).toBe('tok-xyz');
-    expect(localStorageMock.setItem).toHaveBeenCalledWith('mktr_auth_token', 'tok-xyz');
+    expect(useAuthStore.getState().token).toBe('authenticated');
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('mktr_auth_token', 'authenticated');
     expect(localStorageMock.setItem).toHaveBeenCalledWith('mktr_user', JSON.stringify(user));
   });
 
@@ -115,7 +121,7 @@ describe('authStore', () => {
     await useAuthStore.getState().register({ email: 'dave@test.com', password: 'secret' });
 
     expect(useAuthStore.getState().user).toEqual(fakeUser);
-    expect(useAuthStore.getState().token).toBe('tok-reg');
+    expect(useAuthStore.getState().token).toBe('authenticated');
   });
 
   it('googleLogin sets user and token on success', async () => {
@@ -128,6 +134,6 @@ describe('authStore', () => {
     await useAuthStore.getState().googleLogin('google-cred');
 
     expect(useAuthStore.getState().user).toEqual(fakeUser);
-    expect(useAuthStore.getState().token).toBe('tok-google');
+    expect(useAuthStore.getState().token).toBe('authenticated');
   });
 });

--- a/src/stores/authStore.js
+++ b/src/stores/authStore.js
@@ -9,11 +9,10 @@ const STORAGE_KEYS = {
 /**
  * Zustand auth store — single source of truth for authentication state.
  *
- * Flow:
- *   Zustand store  ←→  localStorage  ←  API client reads token per-request
- *
- * The store writes to localStorage on every state change so the API client
- * (which reads localStorage on each request) always has the latest token.
+ * With httpOnly cookie auth, the real JWT lives in the cookie (not accessible
+ * from JS). The `token` field in this store is a boolean-like flag
+ * ('authenticated' | null) used only for the `isAuthenticated` UI check.
+ * The cookie handles actual auth transport via `credentials: 'include'`.
  */
 export const useAuthStore = create((set, get) => ({
   user: JSON.parse(localStorage.getItem(STORAGE_KEYS.USER) || 'null'),
@@ -25,11 +24,12 @@ export const useAuthStore = create((set, get) => ({
 
   login: async (email, password) => {
     const response = await auth.login(email, password);
-    if (response.success && response.data.token) {
-      // auth.login() already wrote to localStorage; sync Zustand
+    if (response.success && response.data.user) {
+      // Server sets httpOnly cookie; store flag for UI
+      localStorage.setItem(STORAGE_KEYS.TOKEN, 'authenticated');
       set({
         user: response.data.user,
-        token: response.data.token
+        token: 'authenticated'
       });
     }
     return response;
@@ -37,10 +37,11 @@ export const useAuthStore = create((set, get) => ({
 
   googleLogin: async (credential) => {
     const response = await auth.googleLogin(credential);
-    if (response.success && response.data.token) {
+    if (response.success && response.data.user) {
+      localStorage.setItem(STORAGE_KEYS.TOKEN, 'authenticated');
       set({
         user: response.data.user,
-        token: response.data.token
+        token: 'authenticated'
       });
     }
     return response;
@@ -48,10 +49,11 @@ export const useAuthStore = create((set, get) => ({
 
   register: async (userData) => {
     const response = await auth.register(userData);
-    if (response.success && response.data.token) {
+    if (response.success && response.data.user) {
+      localStorage.setItem(STORAGE_KEYS.TOKEN, 'authenticated');
       set({
         user: response.data.user,
-        token: response.data.token
+        token: 'authenticated'
       });
     }
     return response;
@@ -59,10 +61,11 @@ export const useAuthStore = create((set, get) => ({
 
   acceptInvite: async (inviteData) => {
     const response = await auth.acceptInvite(inviteData);
-    if (response.success && response.data?.token) {
+    if (response.success && response.data?.user) {
+      localStorage.setItem(STORAGE_KEYS.TOKEN, 'authenticated');
       set({
         user: response.data.user,
-        token: response.data.token
+        token: 'authenticated'
       });
     }
     return response;
@@ -70,16 +73,16 @@ export const useAuthStore = create((set, get) => ({
 
   /** Atomically set both user and token (used by OAuth callback flows). */
   setAuth: (user, token) => {
-    // Write to localStorage so API client picks it up
+    // Store flag (not real JWT) for UI auth check
     if (token) {
-      localStorage.setItem(STORAGE_KEYS.TOKEN, token);
+      localStorage.setItem(STORAGE_KEYS.TOKEN, 'authenticated');
     } else {
       localStorage.removeItem(STORAGE_KEYS.TOKEN);
     }
     if (user) {
       localStorage.setItem(STORAGE_KEYS.USER, JSON.stringify(user));
     }
-    set({ user, token });
+    set({ user, token: token ? 'authenticated' : null });
   },
 
   setUser: (user) => {


### PR DESCRIPTION
## Summary

Moves JWT token storage from client-side localStorage to server-managed httpOnly cookies, eliminating the XSS token theft vector.

**Backend changes:**
- New `authCookie.js` helper — sets httpOnly, secure, sameSite cookie
- Auth middleware reads token from cookie first, falls back to Bearer header
- All auth endpoints (login, register, Google OAuth, invite, refresh) set cookie
- Logout clears cookie server-side

**Frontend changes:**
- API client no longer stores JWT in localStorage
- Relies on `credentials: 'include'` for automatic cookie transport
- Auth store `token` field is now a boolean flag (cookie handles persistence)
- Bearer header still sent as fallback if localStorage token exists (migration period)

## Deferred
- Refresh token rotation (#33) — separate PR, requires DB table + more complexity

## Test plan

- [ ] 138 frontend tests pass
- [ ] 11 backend auth integration tests pass
- [ ] Login flow works (email + Google OAuth)
- [ ] Page refresh maintains session (cookie persists)
- [ ] Logout clears session (cookie cleared)
- [ ] Cross-tab logout works (cookie cleared globally)
- [ ] CORS credentials work in production (sameSite: none + secure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)