### PR TITLE
fix(tiktok): close 4 audit findings (per-campaign pixel, guard order, E.164 phone hash, strict code===0)

### DIFF
--- a/backend/src/services/campaignPreviewService.js
+++ b/backend/src/services/campaignPreviewService.js
@@ -86,7 +86,7 @@ export async function getPublicCampaign(id) {
   // out-of-range birthdates client-side. The backend also re-checks on
   // submit in prospectService to prevent bypass.
   const campaign = await Campaign.findByPk(id, {
-    attributes: ['id', 'name', 'design_config', 'is_active', 'metaPixelId', 'min_age', 'max_age']
+    attributes: ['id', 'name', 'design_config', 'is_active', 'metaPixelId', 'tiktokPixelId', 'min_age', 'max_age']
   });
 
   if (!campaign) {

--- a/backend/src/services/tiktokEventsService.js
+++ b/backend/src/services/tiktokEventsService.js
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/node';
-import { hashEmail, hashPhone, hashExternalId } from '../utils/piiHashing.js';
+import { hashEmail, hashPhoneE164, hashExternalId } from '../utils/piiHashing.js';
 import { logger } from '../utils/logger.js';
 
 // TikTok Events API ("Events API 2.0"). Mirror of metaCapiService.js — the
@@ -10,8 +10,8 @@ const TIKTOK_API_BASE = 'https://business-api.tiktok.com/open_api/v1.3/event/tra
 /**
  * Guard: which prospects are eligible for TikTok Events API dispatch?
  *
- * Mirrors shouldFireCapi exactly — origin gates dispatch, not the funnel event:
- *   - Master switch off / missing credentials (token, pixel id)
+ * Mirrors shouldFireCapi in spirit — origin gates dispatch, not the funnel event:
+ *   - Master switch off / missing access token
  *   - Retell-source prospects (no ad-attribution chain)
  *   - Meta Lead Ads-source prospects (originated inside Meta, not TikTok)
  *
@@ -23,7 +23,6 @@ const TIKTOK_API_BASE = 'https://business-api.tiktok.com/open_api/v1.3/event/tra
 export function shouldFireTikTok(prospect) {
   if (process.env.TIKTOK_EVENTS_API_ENABLED !== 'true') return false;
   if (!process.env.TIKTOK_ACCESS_TOKEN) return false;
-  if (!process.env.TIKTOK_PIXEL_ID) return false;
   if (!prospect) return false;
   if (prospect.leadSource === 'call_bot') return false;
   if (prospect.retellCallId) return false;
@@ -61,7 +60,7 @@ export function _buildPayload(prospect, ctx, options) {
 
   if (marketingConsent) {
     user.email = hashEmail(prospect.email);
-    user.phone = hashPhone(prospect.phone);
+    user.phone = hashPhoneE164(prospect.phone);
   }
 
   // Strip undefined/null/empty so we don't send placeholder hashes / empty ids
@@ -118,6 +117,14 @@ export async function sendConversionEvent(prospect, ctx = {}, options = {}, deps
     return { sent: false, reason: 'guarded' };
   }
 
+  // Resolve the pixel id: per-campaign override first, then env. A campaign-level
+  // tiktokPixelId can fire even when env TIKTOK_PIXEL_ID is unset; bail only if
+  // neither is present (mirrors the browser's campaign.tiktokPixelId || env).
+  const pixelId = ctx.pixelIdOverride || process.env.TIKTOK_PIXEL_ID;
+  if (!pixelId) {
+    return { sent: false, reason: 'no_pixel_id' };
+  }
+
   const accessToken = process.env.TIKTOK_ACCESS_TOKEN;
   const testEventCode = process.env.TIKTOK_TEST_EVENT_CODE || undefined;
   const payload = _buildPayload(prospect, ctx, { testEventCode, eventName });
@@ -129,8 +136,10 @@ export async function sendConversionEvent(prospect, ctx = {}, options = {}, deps
       body: JSON.stringify(payload),
     });
     const body = await res.json().catch(() => ({}));
-    // TikTok signals logical errors via a non-zero `code` even on HTTP 200.
-    const ok = res.ok && (body.code === 0 || body.code === undefined);
+    // TikTok signals logical errors via a non-zero `code` even on HTTP 200, so
+    // success requires HTTP 2xx AND body.code === 0 (a missing/unparseable code
+    // is treated as a failure).
+    const ok = res.ok && body.code === 0;
 
     if (!ok) {
       Sentry.captureException(new Error(`TikTok Events API failed: HTTP ${res.status} code ${body.code}`), {

--- a/backend/src/utils/piiHashing.js
+++ b/backend/src/utils/piiHashing.js
@@ -16,6 +16,19 @@ export function hashPhone(phone) {
   return sha256Hex(digits);
 }
 
+/**
+ * Hash a phone number in E.164 form, keeping the leading `+` (e.g.
+ * SHA256('+6591234567')). TikTok's Events API expects E.164 with the `+`,
+ * unlike Meta CAPI which wants digits-only (`hashPhone`). Input is assumed
+ * already normalized to E.164 with a country code (prospects store `+65…`).
+ */
+export function hashPhoneE164(phone) {
+  if (!phone || typeof phone !== 'string') return undefined;
+  const digits = phone.replace(/\D/g, '');
+  if (!digits) return undefined;
+  return sha256Hex(`+${digits}`);
+}
+
 export function hashExternalId(id) {
   if (id === null || id === undefined || id === '') return undefined;
   return sha256Hex(String(id));

--- a/backend/test/piiHashing.test.js
+++ b/backend/test/piiHashing.test.js
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-import { hashEmail, hashPhone, hashExternalId } from '../src/utils/piiHashing.js';
+import { hashEmail, hashPhone, hashPhoneE164, hashExternalId } from '../src/utils/piiHashing.js';
 
 const sha256Hex = (s) => crypto.createHash('sha256').update(s).digest('hex');
 
@@ -51,6 +51,26 @@ describe('piiHashing.hashPhone', () => {
   });
   it('matches reference SHA-256 over digit-only normalized phone', () => {
     expect(hashPhone('+65 8123 4567')).toBe(sha256Hex('6581234567'));
+  });
+});
+
+describe('piiHashing.hashPhoneE164 (TikTok — keeps the leading +)', () => {
+  it('returns undefined for null/empty/non-string and no-digit input', () => {
+    expect(hashPhoneE164(null)).toBeUndefined();
+    expect(hashPhoneE164('')).toBeUndefined();
+    expect(hashPhoneE164(65812345)).toBeUndefined();
+    expect(hashPhoneE164('+')).toBeUndefined();
+  });
+  it('hashes E.164 WITH the leading + (differs from digit-only hashPhone)', () => {
+    expect(hashPhoneE164('+6581234567')).toBe(sha256Hex('+6581234567'));
+    expect(hashPhoneE164('+6581234567')).not.toBe(hashPhone('+6581234567'));
+  });
+  it('normalizes separators and ensures the + form', () => {
+    expect(hashPhoneE164('+65 8123 4567')).toBe(sha256Hex('+6581234567'));
+    expect(hashPhoneE164('6581234567')).toBe(sha256Hex('+6581234567'));
+  });
+  it('returns a 64-char hex string', () => {
+    expect(hashPhoneE164('+6581234567')).toMatch(/^[a-f0-9]{64}$/);
   });
 });
 

--- a/backend/test/tiktokEventsService.test.js
+++ b/backend/test/tiktokEventsService.test.js
@@ -72,9 +72,9 @@ describe('shouldFireTikTok', () => {
     expect(shouldFireTikTok(webProspect())).toBe(false);
   });
 
-  it('returns false when TIKTOK_PIXEL_ID is missing', () => {
+  it('stays eligible without env TIKTOK_PIXEL_ID (a per-campaign override may supply it; the sender resolves the id and bails if neither is present)', () => {
     delete process.env.TIKTOK_PIXEL_ID;
-    expect(shouldFireTikTok(webProspect())).toBe(false);
+    expect(shouldFireTikTok(webProspect())).toBe(true);
   });
 
   it('returns false for null/undefined prospect', () => {
@@ -223,6 +223,29 @@ describe('sendTikTokLeadEvent', () => {
     const result = await sendTikTokLeadEvent(webProspect(), { eventId: 'evt-1' }, { fetch: fetchSpy });
     expect(result.sent).toBe(false);
     expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a 200 with a missing/unparseable code as a failure (strict code===0)', async () => {
+    const fetchSpy = jest.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({}) });
+    const result = await sendTikTokLeadEvent(webProspect(), { eventId: 'evt-1' }, { fetch: fetchSpy });
+    expect(result.sent).toBe(false);
+  });
+
+  it('does NOT send when no pixel id is resolvable (env unset + no override)', async () => {
+    delete process.env.TIKTOK_PIXEL_ID;
+    const fetchSpy = okFetch();
+    const result = await sendTikTokLeadEvent(webProspect(), { eventId: 'evt-1' }, { fetch: fetchSpy });
+    expect(result).toEqual({ sent: false, reason: 'no_pixel_id' });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('sends with ctx.pixelIdOverride even when env TIKTOK_PIXEL_ID is unset (per-campaign pixel)', async () => {
+    delete process.env.TIKTOK_PIXEL_ID;
+    const fetchSpy = okFetch();
+    await sendTikTokLeadEvent(webProspect(), { eventId: 'evt-1', pixelIdOverride: 'CAMP_PIXEL' }, { fetch: fetchSpy });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(body.event_source_id).toBe('CAMP_PIXEL');
   });
 
   it('returns { sent: false } and captures Sentry on non-2xx', async () => {

--- a/src/pages/LeadCapture.jsx
+++ b/src/pages/LeadCapture.jsx
@@ -104,7 +104,7 @@ export default function LeadCapture() {
     }
 
     if (!ttViewContentFiredRef.current && shouldTrackTikTok(trackCtx)) {
-      const ttPixelId = import.meta.env.VITE_TIKTOK_PIXEL_ID;
+      const ttPixelId = campaign?.tiktokPixelId || import.meta.env.VITE_TIKTOK_PIXEL_ID;
       if (ttPixelId) {
         initTikTokPixel(ttPixelId);
         trackTikTokViewContent(
@@ -136,7 +136,7 @@ export default function LeadCapture() {
     }
 
     if (shouldTrackTikTok(trackCtx)) {
-      const ttPixelId = import.meta.env.VITE_TIKTOK_PIXEL_ID;
+      const ttPixelId = campaign?.tiktokPixelId || import.meta.env.VITE_TIKTOK_PIXEL_ID;
       if (ttPixelId) {
         initTikTokPixel(ttPixelId);
         trackTikTokCompleteRegistration(
@@ -329,7 +329,7 @@ export default function LeadCapture() {
           }
         }
         if (shouldTrackTikTok(trackCtx)) {
-          const ttPixelId = import.meta.env.VITE_TIKTOK_PIXEL_ID;
+          const ttPixelId = campaign?.tiktokPixelId || import.meta.env.VITE_TIKTOK_PIXEL_ID;
           if (ttPixelId) {
             initTikTokPixel(ttPixelId);
             trackTikTokLead(


### PR DESCRIPTION
Fixes the 4 issues from the gpt-5.5 audit of the TikTok/Meta conversion integration. None broke the current single-pixel setup; these close the gaps.

1. **Per-campaign TikTok pixel, end-to-end (Med):** expose `tiktok_pixel_id` in the public campaign API + browser uses `campaign.tiktokPixelId || VITE_TIKTOK_PIXEL_ID` (mirrors Meta). Browser + server now use the same pixel → dedup/attribution holds under overrides.
2. **Guard order (Med):** `shouldFireTikTok` no longer hard-requires env `TIKTOK_PIXEL_ID`; the sender resolves `ctx.pixelIdOverride || env` and bails (`no_pixel_id`) only if neither is set.
3. **E.164 phone hash (Low):** TikTok now hashes phone in E.164 with leading `+` (`hashPhoneE164`), per TikTok docs; Meta keeps digit-only.
4. **Strict success (Low):** TikTok success is now `res.ok && body.code === 0` (missing/unparseable code = failure).

Tests: backend 142 pass (incl. new no_pixel_id/override/strict-code/hashPhoneE164 cases), frontend 82 pass, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)