### PR TITLE
SG/PR eligibility gate + prospect DOB fix + fbp tracking hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,43 @@ Nameservers at Cloudflare (`chance.ns.cloudflare.com`, `liv.ns.cloudflare.com`) 
 - mktr-platform Static Site (Render): `VITE_BRAND=mktr` (or unset — defaults to mktr), `VITE_API_URL=https://api.mktr.sg/api` (absolute — pre-rebrand setup, cross-origin to api.mktr.sg works because cookies live on parent `.mktr.sg`).
 - redeem-frontend Static Site (Render): `VITE_BRAND=redeem`, `VITE_API_URL=/api` (relative — Render rewrites `/api/*` → `https://api.mktr.sg/api/*` so cookies live on `.redeem.sg`). Vite plugin emits brand-aware `robots.txt` + `sitemap.xml` per build.
 
+## Meta Ads — Advertising Account, Pixel & CAPI
+
+Paid acquisition (Facebook/Instagram) for the lead-capture funnel. All assets live under one Meta **business portfolio**. Topology verified 2026-06-04:
+
+| Asset | ID | Notes |
+|---|---|---|
+| Business portfolio | `645399914612858` ("VoxaLabs AI") | Owns the ad account, Pixel, and Page below. |
+| **Ad account — advertise from this** | `2170132703771607` ("MKTR", SGD) | `act_2170132703771607` for the Graph API. The only ad account the team should use. Payment method (MasterCard) attached. |
+| Pixel / Dataset | `1402034528611431` ("MKTR Lead Capture") | Browser Pixel **+** CAPI, both live on `redeem.sg` and receiving events. Connected to the ad account. |
+| Facebook Page | `1162230786970311` ("MKTR Campaigns") | The advertiser identity prospects see in-feed. |
+
+**Gotcha — billing ID ≠ ad-account ID:** the MKTR ad account's **billing/payment-account ID is `6976122706429`**. It is the *same account* as `2170132703771607`, not a second one — it appears only in Billing-hub URLs, is **absent from the Ads Manager account picker**, and the Graph API returns `could not resolve ad account` for it. Always use `2170132703771607` in Ads Manager and the API.
+
+**Ignore these accounts:** an empty portfolio "SG Health" (0 ad accounts), and the personal ad account `1931760067413088` ("Shawn Lee") — wrong identity for brand ads; don't attach the card or run campaigns there.
+
+**Brand identity:** ads currently run as the "MKTR Campaigns" Page. Per the operator-vs-customer split, consider a **Redeem**-branded Page so consumer ads match the `redeem.sg` landing page. Link an Instagram professional account to the Page for IG placements.
+
+**Tracking code:**
+- `src/lib/metaPixel.js` — Pixel init + `ViewContent`/`Lead` with stable event IDs for Pixel⇄CAPI dedup; captures `_fbc` from `fbclid` and reads/synthesizes `_fbp` (`ensureFbp()` mints a first-party `_fbp` cookie when the Pixel hasn't set one yet, so server `Lead` events carry it). `shouldTrack` suppresses preview/demo/test-data routes and dev-without-test-code.
+- `index.html` — base Pixel loader, gated on `VITE_META_PIXEL_ID`.
+- `backend/src/services/metaCapiService.js` — fire-and-forget CAPI `Lead` (`sendLeadEvent`), gated by `shouldFireCapi` (skips Retell + Meta-Lead-Ads-origin prospects to avoid double-counting); per-campaign override via `Campaign.metaPixelId`, else `META_PIXEL_ID`.
+- Full design: `docs/plans/meta-tracking-implementation.md`.
+
+**Env vars** (pixel/page IDs are public — embedded in page source; the access token is the only secret):
+
+| Var | Component | Value / Notes |
+|---|---|---|
+| `VITE_META_PIXEL_ID` | Frontend build | `1402034528611431` |
+| `META_PIXEL_ID` | Backend (CAPI) | `1402034528611431` |
+| `META_CAPI_ENABLED` | Backend | Must be `"true"` to fire CAPI |
+| `META_CAPI_ACCESS_TOKEN` | Backend | **Secret** — Pino-redacted, never commit |
+| `META_TEST_EVENT_CODE` / `VITE_META_TEST_EVENT_CODE` | Both | Routes events to Test Events (staging/dev) |
+
+`redeem.sg` is domain-verified in Meta (see the `facebook-domain-verification` TXT in the DNS section above).
+
+**Running a paid campaign** (drives clicks into the existing round-robin pipeline): objective **Leads** (`OUTCOME_LEADS`), conversion location **Website**, optimize for the **Lead** event; destination = a `redeem.sg/LeadCapture?campaign_id={id}` link for the specific MKTR campaign so leads attribute + auto-assign. No native Meta Lead Forms — the funnel uses the `redeem.sg` landing page.
+
 ## Architecture — Full Data Flow
 
 ```

--- a/src/components/campaigns/CampaignSignupForm.jsx
+++ b/src/components/campaigns/CampaignSignupForm.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
 import { apiClient } from '@/api/client';
 import FieldRenderer from '@/components/campaigns/signup/FieldRenderer';
 import OTPVerification from '@/components/campaigns/signup/OTPVerification';
@@ -37,6 +38,7 @@ export default function CampaignSignupForm({
   const fieldOrder = campaign?.design_config?.fieldOrder || ['name', 'phone', 'email', 'dob', 'postal_code', 'education_level', 'monthly_income'];
   const otpChannel = campaign?.design_config?.otpChannel || 'sms';
   const headingFont = heroFontStack(campaign?.design_config?.heroFont);
+  const sgPrOnly = campaign?.design_config?.sgPrOnly === true;
 
   const [formData, setFormData] = useState({
     name: '',
@@ -56,6 +58,8 @@ export default function CampaignSignupForm({
   const [dobIncomplete, setDobIncomplete] = useState(false);
   const [resendCooldown, setResendCooldown] = useState(0);
   const [showSuccessTick, setShowSuccessTick] = useState(false);
+  // SG/PR eligibility gate: null = not answered, 'eligible' = show form, 'no' = blocked.
+  const [eligibility, setEligibility] = useState(null);
 
   // Two PDPA consent checkboxes — campaign T&C is required (opt-in), contact
   // consent defaults to ticked (opt-out). The opt-out path is documented in
@@ -350,8 +354,148 @@ export default function CampaignSignupForm({
     !isValidEmail(formData.email) ||
     !consentTerms;
 
+  // SG/PR eligibility gate (campaign.design_config.sgPrOnly): a Yes/No screening
+  // card shown before the form. "Yes" reveals + animates the form in; "No" shows a
+  // polite, reversible ineligible message. No gate when sgPrOnly is off.
+  if (sgPrOnly && eligibility !== 'eligible') {
+    return (
+      <AnimatePresence mode="wait">
+        {eligibility === 'no' ? (
+          <motion.div
+            key="ineligible"
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.3, ease: 'easeOut' }}
+          >
+            <h2
+              style={{
+                fontFamily: headingFont,
+                fontWeight: 800,
+                fontSize: 'clamp(24px, 5.5vw, 30px)',
+                lineHeight: 1.15,
+                color: TOKENS.ink,
+                margin: 0,
+                marginBottom: 12,
+              }}
+            >
+              Thanks for your interest
+            </h2>
+            <p
+              style={{
+                fontFamily: 'Albert Sans, system-ui, sans-serif',
+                fontSize: 16,
+                lineHeight: 1.55,
+                color: TOKENS.body,
+                margin: 0,
+                marginBottom: 20,
+              }}
+            >
+              This promotion is only open to Singapore Citizens and Permanent Residents.
+            </p>
+            <button
+              type="button"
+              onClick={() => setEligibility(null)}
+              style={{
+                background: 'none',
+                border: 'none',
+                padding: 0,
+                cursor: 'pointer',
+                color: TOKENS.muted,
+                fontSize: 14,
+                fontFamily: 'Albert Sans, system-ui, sans-serif',
+                textDecoration: 'underline',
+                textUnderlineOffset: 3,
+              }}
+            >
+              ← I picked the wrong option
+            </button>
+          </motion.div>
+        ) : (
+          <motion.div
+            key="gate"
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -10 }}
+            transition={{ duration: 0.3, ease: 'easeOut' }}
+          >
+            <h2
+              style={{
+                fontFamily: headingFont,
+                fontWeight: 800,
+                fontSize: 'clamp(24px, 5.5vw, 30px)',
+                lineHeight: 1.15,
+                color: TOKENS.ink,
+                margin: 0,
+                marginBottom: 10,
+              }}
+            >
+              Quick question first
+            </h2>
+            <p
+              style={{
+                fontFamily: 'Albert Sans, system-ui, sans-serif',
+                fontSize: 16,
+                lineHeight: 1.55,
+                color: TOKENS.body,
+                margin: 0,
+                marginBottom: 24,
+              }}
+            >
+              Are you a Singapore Citizen or Permanent Resident?
+            </p>
+            <div style={{ display: 'flex', gap: 12 }}>
+              <button
+                type="button"
+                onClick={() => setEligibility('eligible')}
+                style={{
+                  flex: 1,
+                  height: 56,
+                  borderRadius: RADIUS.pill,
+                  backgroundColor: accent,
+                  color: '#ffffff',
+                  border: 'none',
+                  cursor: 'pointer',
+                  fontFamily: 'Albert Sans, system-ui, sans-serif',
+                  fontWeight: 600,
+                  fontSize: 16,
+                  boxShadow: '0 4px 14px rgba(209, 112, 41, 0.18)',
+                }}
+              >
+                Yes, I am
+              </button>
+              <button
+                type="button"
+                onClick={() => setEligibility('no')}
+                style={{
+                  flex: 1,
+                  height: 56,
+                  borderRadius: RADIUS.pill,
+                  backgroundColor: '#ffffff',
+                  color: TOKENS.body,
+                  border: `1px solid ${TOKENS.hairline}`,
+                  cursor: 'pointer',
+                  fontFamily: 'Albert Sans, system-ui, sans-serif',
+                  fontWeight: 600,
+                  fontSize: 16,
+                }}
+              >
+                No
+              </button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    );
+  }
+
   return (
     <>
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.35, ease: 'easeOut' }}
+      >
       <form onSubmit={handleSubmit}>
         {/* Heavy-serif heading */}
         <h2
@@ -540,6 +684,7 @@ export default function CampaignSignupForm({
           {loading === 'submitting' ? 'Submitting…' : ctaLabel || 'Submit Now'}
         </button>
       </form>
+      </motion.div>
 
       {/* Marketing consent modal */}
       <MarketingConsentDialog

--- a/src/components/campaigns/DesignEditor.jsx
+++ b/src/components/campaigns/DesignEditor.jsx
@@ -71,6 +71,7 @@ export default function DesignEditor({ campaign, onSave }) {
  formWidth: design.formWidth || 400,
  visibleFields: { ...(design.visibleFields || { dob: true, postal_code: true }), phone: true },
  requiredFields: design.requiredFields || {},
+    sgPrOnly: design.sgPrOnly === true,
  fieldOrder: normalizeFieldOrder(design.fieldOrder),
  otpChannel: design.otpChannel ||"sms",
  mediaType: design.mediaType || (design.imageUrl ? 'image' : 'none'),

--- a/src/components/campaigns/__tests__/CampaignSignupForm.test.jsx
+++ b/src/components/campaigns/__tests__/CampaignSignupForm.test.jsx
@@ -117,3 +117,128 @@ describe('CampaignSignupForm — previewMode sends no network traffic', () => {
     expect(apiClient.post).not.toHaveBeenCalled();
   });
 });
+
+describe('CampaignSignupForm — SG/PR eligibility gate', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows the form directly when sgPrOnly is off (default)', () => {
+    renderForm();
+    expect(screen.getByRole('button', { name: 'Submit Now' })).toBeInTheDocument();
+    expect(screen.queryByText(/Singapore Citizen or Permanent Resident/i)).toBeNull();
+  });
+
+  it('gates the form behind a Yes/No screening question when sgPrOnly is on', () => {
+    renderForm({ design: { sgPrOnly: true } });
+    expect(screen.getByText('Are you a Singapore Citizen or Permanent Resident?')).toBeInTheDocument();
+    // Form stays hidden until they answer Yes.
+    expect(screen.queryByRole('button', { name: 'Submit Now' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Yes, I am' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'No' })).toBeInTheDocument();
+  });
+
+  it('reveals the form after answering Yes', async () => {
+    const user = userEvent.setup();
+    renderForm({ design: { sgPrOnly: true } });
+    await user.click(screen.getByRole('button', { name: 'Yes, I am' }));
+    expect(await screen.findByRole('button', { name: 'Submit Now' })).toBeInTheDocument();
+    expect(screen.queryByText('Are you a Singapore Citizen or Permanent Resident?')).toBeNull();
+  });
+
+  it('blocks the form with an ineligible message after answering No, and is reversible', async () => {
+    const user = userEvent.setup();
+    renderForm({ design: { sgPrOnly: true } });
+    await user.click(screen.getByRole('button', { name: 'No' }));
+    expect(await screen.findByText(/only open to Singapore Citizens/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Submit Now' })).toBeNull();
+    // Mis-tap recovery: back to the screening question.
+    await user.click(screen.getByRole('button', { name: /picked the wrong option/i }));
+    expect(await screen.findByText('Are you a Singapore Citizen or Permanent Resident?')).toBeInTheDocument();
+  });
+});
+
+describe('CampaignSignupForm — SG/PR gate edge cases & integration', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('does not gate when sgPrOnly is explicitly false', () => {
+    renderForm({ design: { sgPrOnly: false } });
+    expect(screen.getByRole('button', { name: 'Submit Now' })).toBeInTheDocument();
+    expect(screen.queryByText('Are you a Singapore Citizen or Permanent Resident?')).toBeNull();
+  });
+
+  it('only gates on boolean true — a stale string "true" must NOT gate', () => {
+    renderForm({ design: { sgPrOnly: 'true' } });
+    expect(screen.getByRole('button', { name: 'Submit Now' })).toBeInTheDocument();
+    expect(screen.queryByText('Are you a Singapore Citizen or Permanent Resident?')).toBeNull();
+  });
+
+  it('only gates on boolean true — a numeric 1 must NOT gate', () => {
+    renderForm({ design: { sgPrOnly: 1 } });
+    expect(screen.getByRole('button', { name: 'Submit Now' })).toBeInTheDocument();
+  });
+
+  it('screening buttons are type="button" so they never submit the form', () => {
+    renderForm({ design: { sgPrOnly: true } });
+    expect(screen.getByRole('button', { name: 'Yes, I am' })).toHaveAttribute('type', 'button');
+    expect(screen.getByRole('button', { name: 'No' })).toHaveAttribute('type', 'button');
+  });
+
+  it('uses the campaign theme color on the Yes button', () => {
+    renderForm({ design: { sgPrOnly: true } });
+    expect(screen.getByRole('button', { name: 'Yes, I am' })).toHaveStyle({ backgroundColor: '#D17029' });
+  });
+
+  it('renders none of the form internals while gated (phone/name/submit hidden)', () => {
+    renderForm({ design: { sgPrOnly: true } });
+    expect(screen.queryByPlaceholderText('9123 4567')).toBeNull();
+    expect(screen.queryByPlaceholderText('John Tan')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Submit Now' })).toBeNull();
+  });
+
+  it('keeps the form hidden after answering No', async () => {
+    const user = userEvent.setup();
+    renderForm({ design: { sgPrOnly: true } });
+    await user.click(screen.getByRole('button', { name: 'No' }));
+    expect(await screen.findByText(/only open to Singapore Citizens/i)).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('9123 4567')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Submit Now' })).toBeNull();
+  });
+
+  it('supports the full recovery path: No → wrong option → Yes → form', async () => {
+    const user = userEvent.setup();
+    renderForm({ design: { sgPrOnly: true } });
+    await user.click(screen.getByRole('button', { name: 'No' }));
+    await user.click(await screen.findByRole('button', { name: /picked the wrong option/i }));
+    await user.click(await screen.findByRole('button', { name: 'Yes, I am' }));
+    expect(await screen.findByRole('button', { name: 'Submit Now' })).toBeInTheDocument();
+  });
+
+  it('shows the gate in previewMode (designer / admin preview)', () => {
+    renderForm({ previewMode: true, design: { sgPrOnly: true } });
+    expect(screen.getByText('Are you a Singapore Citizen or Permanent Resident?')).toBeInTheDocument();
+  });
+
+  it('gate ON + previewMode: Yes reveals the form and the full submit flow still works', async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderForm({ previewMode: true, design: { sgPrOnly: true } });
+
+    await user.click(screen.getByRole('button', { name: 'Yes, I am' }));
+
+    await user.type(await screen.findByPlaceholderText('John Tan'), 'Jane Tan');
+    await user.type(screen.getByPlaceholderText('you@example.com'), 'jane@example.com');
+    await user.type(screen.getByPlaceholderText('9123 4567'), '91234567');
+    await user.click(screen.getByRole('button', { name: 'Verify' }));
+
+    const otpInput = await screen.findByPlaceholderText('6-digit code');
+    await user.type(otpInput, '123456');
+    await waitFor(() => expect(screen.getByText('Verified')).toBeInTheDocument(), { timeout: 2500 });
+
+    fireEvent.click(document.getElementById('consent_terms'));
+    const submit = screen.getByRole('button', { name: 'Submit Now' });
+    await waitFor(() => expect(submit).toBeEnabled(), { timeout: 2500 });
+    await user.click(submit);
+
+    expect(await screen.findByText('Preview — your details were not submitted.')).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(apiClient.post).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/campaigns/__tests__/DesignEditor.test.jsx
+++ b/src/components/campaigns/__tests__/DesignEditor.test.jsx
@@ -47,3 +47,47 @@ describe('DesignEditor — save failure keeps the dirty state', () => {
     expect(screen.queryByText('Unsaved changes')).not.toBeInTheDocument();
   });
 });
+
+describe('DesignEditor — SG/PR only toggle persistence', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders the SG/PR only toggle, off by default', () => {
+    render(<DesignEditor campaign={campaign} onSave={vi.fn()} />);
+    expect(screen.getByText('SG / PR only')).toBeInTheDocument();
+    expect(screen.getByRole('switch')).not.toBeChecked();
+  });
+
+  it('persists sgPrOnly:false when the toggle is left off', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<DesignEditor campaign={campaign} onSave={onSave} />);
+    // Dirty the design without touching the toggle.
+    await user.type(screen.getByPlaceholderText('e.g., Get Started Now!'), '!');
+    await user.click(screen.getByRole('button', { name: /Save Design/i }));
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(onSave.mock.calls[0][0]).toMatchObject({ sgPrOnly: false });
+  });
+
+  it('persists sgPrOnly:true after switching it on', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<DesignEditor campaign={campaign} onSave={onSave} />);
+    await user.click(screen.getByRole('switch'));
+    expect(screen.getByRole('switch')).toBeChecked();
+    await user.click(screen.getByRole('button', { name: /Save Design/i }));
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(onSave.mock.calls[0][0]).toMatchObject({ sgPrOnly: true });
+  });
+
+  it('initializes the toggle ON for a campaign with sgPrOnly:true and preserves it on save', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const gated = { id: 'camp-2', name: 'Gated', design_config: { formHeadline: 'Hi', sgPrOnly: true } };
+    render(<DesignEditor campaign={gated} onSave={onSave} />);
+    expect(screen.getByRole('switch')).toBeChecked();
+    await user.type(screen.getByPlaceholderText('e.g., Get Started Now!'), '!');
+    await user.click(screen.getByRole('button', { name: /Save Design/i }));
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(onSave.mock.calls[0][0]).toMatchObject({ sgPrOnly: true });
+  });
+});

--- a/src/components/campaigns/editor/ContentPanel.jsx
+++ b/src/components/campaigns/editor/ContentPanel.jsx
@@ -5,6 +5,7 @@ import { Label } from"@/components/ui/label";
 import { Textarea } from"@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from"@/components/ui/select";
 import { Button } from"@/components/ui/button";
+import { Switch } from"@/components/ui/switch";
 import { UploadFile } from"@/api/integrations";
 import {
  Upload,
@@ -402,7 +403,23 @@ export default function ContentPanel({ currentDesign, onDesignChange }) {
  </div>
  </div>
 
- {/* Terms & Conditions */}
+ {/* Eligibility — SG/PR screening gate */}
+        <div className="space-y-3 pt-4 border-t">
+          <Label className="text-sm font-semibold text-foreground">Eligibility</Label>
+          <p className="text-xs text-muted-foreground -mt-1">Screen visitors before the form appears.</p>
+          <div className="flex items-center justify-between gap-3 py-1">
+            <div className="flex flex-col">
+              <span className="text-sm text-foreground">SG / PR only</span>
+              <span className="text-xs text-muted-foreground">Adds a Singapore Citizen / PR question before the form — only Yes reveals it.</span>
+            </div>
+            <Switch
+              checked={currentDesign.sgPrOnly === true}
+              onCheckedChange={(checked) => onDesignChange('sgPrOnly', checked)}
+            />
+          </div>
+        </div>
+
+        {/* Terms & Conditions */}
  <div className="space-y-3 pt-4 border-t">
  <Label className="text-sm font-semibold text-foreground">Terms & Conditions</Label>
  <p className="text-xs text-muted-foreground -mt-1">Customize the legal text displayed in the consent dialog.</p>

--- a/src/components/forms/__tests__/CampaignForm.test.jsx
+++ b/src/components/forms/__tests__/CampaignForm.test.jsx
@@ -127,9 +127,9 @@ describe('AdminCampaignForm', () => {
  expect(screen.getByText('Commissions')).toBeInTheDocument();
  });
 
- it('renders Default Assignment Mode card', () => {
+ it('no longer renders the (removed) Default Assignment Mode card — assignment moved to QR tags', () => {
  renderForm();
- expect(screen.getByText('Default Assignment Mode')).toBeInTheDocument();
+ expect(screen.queryByText('Default Assignment Mode')).not.toBeInTheDocument();
  });
 
  it('allows entering campaign name', () => {

--- a/src/lib/__tests__/metaPixel.test.js
+++ b/src/lib/__tests__/metaPixel.test.js
@@ -5,6 +5,7 @@ import {
   captureFbcFromUrl,
   readFbc,
   readFbp,
+  ensureFbp,
   initPixel,
   trackEvent,
   trackLead,
@@ -196,6 +197,42 @@ describe('readFbp', () => {
       configurable: true,
     });
     expect(readFbp()).toBe(null);
+  });
+});
+
+describe('ensureFbp', () => {
+  let originalCookieDescriptor;
+
+  beforeEach(() => {
+    originalCookieDescriptor = Object.getOwnPropertyDescriptor(Document.prototype, 'cookie');
+  });
+
+  afterEach(() => {
+    if (originalCookieDescriptor) {
+      Object.defineProperty(Document.prototype, 'cookie', originalCookieDescriptor);
+    }
+  });
+
+  it('returns the existing _fbp without overwriting it', () => {
+    Object.defineProperty(document, 'cookie', {
+      value: '_fbp=fb.1.999888.7777; otherKey=value',
+      writable: true,
+      configurable: true,
+    });
+    expect(ensureFbp()).toBe('fb.1.999888.7777');
+    // unchanged — no new cookie written over the existing one
+    expect(document.cookie).toBe('_fbp=fb.1.999888.7777; otherKey=value');
+  });
+
+  it('generates and persists a fb.1.{ts}.{rand} cookie when _fbp is absent', () => {
+    Object.defineProperty(document, 'cookie', {
+      value: '',
+      writable: true,
+      configurable: true,
+    });
+    const result = ensureFbp();
+    expect(result).toMatch(/^fb\.1\.\d+\.\d+$/);
+    expect(document.cookie).toContain(`_fbp=${result}`);
   });
 });
 

--- a/src/lib/metaPixel.js
+++ b/src/lib/metaPixel.js
@@ -80,6 +80,30 @@ export function readFbp() {
   return match ? match[1] : null;
 }
 
+/**
+ * Returns the Meta browser id (`_fbp`), creating a durable first-party cookie
+ * when the Pixel hasn't set one yet. Mirrors fbevents.js's own format
+ * (`fb.1.{creationTime}.{random}`) and 90-day TTL, and is host-scoped (no
+ * explicit domain) so it works on whichever public host renders the flow.
+ *
+ * Guarantees the server-side CAPI Lead event carries an `fbp` even when the
+ * form is submitted before fbevents.js has written its cookie (fast submits,
+ * slow or blocked pixel load). fbevents.js adopts an existing valid `_fbp`, so
+ * the browser Pixel and the CAPI event stay in sync on the same id.
+ */
+export function ensureFbp() {
+  const existing = readFbp();
+  if (existing) return existing;
+  if (typeof document === 'undefined') return null;
+  try {
+    const fbp = `fb.1.${Date.now()}.${Math.floor(Math.random() * 1e16)}`;
+    document.cookie = `_fbp=${fbp}; path=/; max-age=7776000; SameSite=Lax`;
+    return fbp;
+  } catch {
+    return null;
+  }
+}
+
 export function initPixel(pixelId) {
   if (!pixelId) return;
   if (typeof window === 'undefined' || typeof window.fbq !== 'function') return;

--- a/src/pages/LeadCapture.jsx
+++ b/src/pages/LeadCapture.jsx
@@ -17,6 +17,7 @@ import {
   captureFbcFromUrl,
   readFbc,
   readFbp,
+  ensureFbp,
   initPixel,
   trackEvent,
   trackLead,
@@ -59,6 +60,9 @@ export default function LeadCapture() {
     const pixelId = campaign.metaPixelId || import.meta.env.VITE_META_PIXEL_ID;
     if (!pixelId) return;
     initPixel(pixelId);
+    // Establish _fbp now (gated by shouldTrack above) so the Lead submit — and
+    // the matching CAPI event — reliably carry it, even on a fast submit.
+    ensureFbp();
     trackEvent(
       'ViewContent',
       {

--- a/src/utils/normalizeProspect.js
+++ b/src/utils/normalizeProspect.js
@@ -34,7 +34,7 @@ export default function normalizeProspect(p) {
  email: p.email ||"",
  company: p.company ||"",
  postal_code: p.location?.zipCode || p.postal_code ||"",
- date_of_birth: p.dateOfBirth || p.date_of_birth || null,
+ date_of_birth: p.dateOfBirth || p.date_of_birth || p.demographics?.dateOfBirth || null,
  status,
  leadStatus: status,
  created_date: createdDate,


### PR DESCRIPTION
## What

Today's mktr-platform work, split into 5 reviewable commits:

1. **fix(prospects)** — admin prospect detail showed DOB as `—`. It's stored in `demographics.dateOfBirth`, but the normalizer only read the top level. Fixed. No data was lost — every existing lead's DOB is intact.
2. **feat(meta-capi)** — `ensureFbp()` mints a first-party `_fbp` cookie when the Pixel hasn't set one yet, so server-side CAPI `Lead` events always carry `fbp` (previously missing on fast submits → dragged Event Match Quality down). +2 unit tests.
3. **feat(lead-capture)** — **SG/PR eligibility gate.** When a campaign's `design_config.sgPrOnly` is on, the public form first shows an animated Yes/No *"Are you a Singapore Citizen or Permanent Resident?"* card; **Yes** animates the form in, **No** shows a polite, reversible ineligible message. Adds a **"SG / PR only"** toggle in the campaign designer (persists the flag). +18 tests.
4. **test(campaigns)** — fix a pre-existing stale test that asserted the long-removed "Default Assignment Mode" card (removed in `dfa0287`; assignment moved to per-QR routing).
5. **docs(mktr)** — document the Meta Ads account / pixel / Page topology + the billing-ID-vs-ad-account-ID gotcha.

## Tests

Full frontend suite green: **968/968**. ESLint clean on all touched files.

## Notes

- **Base is `feat/mktr-quiz-campaign-phase1`, not `main`** — these changes build on that branch's unmerged quiz work (e.g. `LeadCapture.jsx` quiz wiring), so they can't sit on `main` yet. Retarget once the feature branch merges.
- The SG/PR gate is a **self-declaration** — it filters intent, it does not verify citizenship.
- Deliberately left untouched: the in-progress lead-quota planning docs (`LEAD_PACKAGE_QUOTA_PLAN.md`, `CODEX_REVIEW_LEAD_QUOTA.md`) — a separate workstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
