### PR TITLE
feat(mktr-leads): W1 — single-pass lead routing (behavior-preserving foundation)

### DIFF
--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -195,17 +195,53 @@ export function makeProspectService(overrides = {}) {
       }
     }
 
-    // Resolve secure assignment (agent/admin override -> qr owner -> campaign -> system).
-    // resolveLeadRouting also reports the route taken (via), which lead-quota uses to
-    // tell exempt (self/admin) from gated (qr/package/fallback) delivery.
-    const routing = await d.resolveLeadRouting({
-      reqUser: user,
-      requestedAgentId: body.assignedAgentId,
-      campaignId: incoming.campaignId,
-      qrTagId: incoming.qrTagId,
-    });
-    let assignedAgentId = routing.agentId;
-    let routeVia = routing.via;
+    // Pre-load campaign + QR tag (needed for routing below, the age gate, and quiz scoring).
+    const [sourceCampaign, sourceQrTag] = await Promise.all([
+      incoming.campaignId ? m.Campaign.findByPk(incoming.campaignId) : null,
+      incoming.qrTagId ? m.QrTag.findByPk(incoming.qrTagId) : null,
+    ]);
+
+    // External (MKTR Leads) eligibility. INERT until per-source consent capture writes
+    // consentMetadata.external — hasValidExternalConsent returns false for all current
+    // data, so allowExternal is false and routing takes the internal-only path below,
+    // byte-for-byte as before.
+    const allowExternal =
+      sourceCampaign?.externalEligible === true &&
+      d.hasValidExternalConsent({ consentMetadata: incoming.consentMetadata });
+
+    // SINGLE routing pass — exactly one resolver runs, so the per-campaign round-robin
+    // cursor advances once and routeVia is never stale:
+    //   - external-eligible + consented → unified resolveLeadAssignment (internal +
+    //     external pools); it also owns the self/admin/qr tiers, so the QR-override
+    //     block below is skipped for these leads.
+    //   - everyone else (the live path) → internal-only resolveLeadRouting, unchanged.
+    let assignedAgentId = null;
+    let externalAgentId = null;
+    let routeVia;
+    if (allowExternal) {
+      const r = await d.resolveLeadAssignment({
+        reqUser: user,
+        requestedAgentId: body.assignedAgentId,
+        campaignId: incoming.campaignId,
+        qrTagId: incoming.qrTagId,
+        allowExternal: true,
+      });
+      routeVia = r.via;
+      if (r.kind === 'external') {
+        externalAgentId = r.externalAgentId; // assignedAgentId stays null (mutually exclusive)
+      } else {
+        assignedAgentId = r.internalAgentId ?? null;
+      }
+    } else {
+      const routing = await d.resolveLeadRouting({
+        reqUser: user,
+        requestedAgentId: body.assignedAgentId,
+        campaignId: incoming.campaignId,
+        qrTagId: incoming.qrTagId,
+      });
+      assignedAgentId = routing.agentId;
+      routeVia = routing.via;
+    }
 
     // Normalize phone to E.164 format
     if (incoming.phone) {
@@ -281,12 +317,6 @@ export function makeProspectService(overrides = {}) {
       if (body.monthly_income) incoming.demographics.income = body.monthly_income;
     }
 
-    // Pre-load campaign and QR tag for routing resolution
-    const [sourceCampaign, sourceQrTag] = await Promise.all([
-      incoming.campaignId ? m.Campaign.findByPk(incoming.campaignId) : null,
-      incoming.qrTagId ? m.QrTag.findByPk(incoming.qrTagId) : null,
-    ]);
-
     // --- Quiz funnel: re-score server-side (anti-tamper) and stash on the lead ---
     // The client sends raw answers (+ an advisory result we ignore). We recompute
     // the authoritative profile/readiness/leadScore from the campaign's own quiz
@@ -331,7 +361,10 @@ export function makeProspectService(overrides = {}) {
     let resolvedAgent = null;
     let agentGroup = null;
 
-    if (sourceQrTag?.agentAssignmentMode === 'round_robin') {
+    // QR-level routing refines the INTERNAL path only; external-eligible leads were
+    // already routed by resolveLeadAssignment above (it includes the QR tier), so
+    // re-running QR routing here would double-route them.
+    if (!allowExternal && sourceQrTag?.agentAssignmentMode === 'round_robin') {
       routingMode = 'round_robin';
 
       // Query members from join table, ordered by sortOrder
@@ -361,11 +394,11 @@ export function makeProspectService(overrides = {}) {
           name: selectedMember.name,
         };
       }
-    } else if (sourceQrTag?.assignedAgentId) {
+    } else if (!allowExternal && sourceQrTag?.assignedAgentId) {
       // Direct FK lookup — faster than phone-based search
       assignedAgentId = sourceQrTag.assignedAgentId;
       routeVia = 'qr';
-    } else if (sourceQrTag?.assignedAgentPhone) {
+    } else if (!allowExternal && sourceQrTag?.assignedAgentPhone) {
       // Fallback for QR tags not yet backfilled
       resolvedAgent = {
         phone: sourceQrTag.assignedAgentPhone,
@@ -382,30 +415,6 @@ export function makeProspectService(overrides = {}) {
       if (agentByPhone) {
         assignedAgentId = agentByPhone.id;
         routeVia = 'qr';
-      }
-    }
-
-    // External (MKTR Leads) routing decision. INERT until per-source consent
-    // capture writes consentMetadata.external — hasValidExternalConsent returns
-    // false for all current data, so allowExternal is false and this whole block
-    // is skipped, leaving the internal path byte-for-byte unchanged.
-    let externalAgentId = null;
-    const allowExternal =
-      sourceCampaign?.externalEligible === true &&
-      d.hasValidExternalConsent({ consentMetadata: incoming.consentMetadata });
-    if (allowExternal) {
-      const extDecision = await d.resolveLeadAssignment({
-        reqUser: user,
-        requestedAgentId: body.assignedAgentId,
-        campaignId: incoming.campaignId,
-        qrTagId: incoming.qrTagId,
-        allowExternal: true,
-      });
-      if (extDecision?.kind === 'external') {
-        externalAgentId = extDecision.externalAgentId;
-        assignedAgentId = null; // mutually exclusive (DB CHECK enforces this)
-      } else if (extDecision?.kind === 'internal' && extDecision.internalAgentId) {
-        assignedAgentId = extDecision.internalAgentId;
       }
     }
 

--- a/backend/src/services/systemAgent.js
+++ b/backend/src/services/systemAgent.js
@@ -202,18 +202,29 @@ export async function resolveAssignedAgentId(ctx) {
  * behavior. This is the fail-safe that keeps the live pipeline unchanged until a
  * caller opts a consented, external-eligible lead in.
  *
- *   returns { kind: 'internal', internalAgentId } | { kind: 'external', externalAgentId }
+ * Every return also carries `via` (self | admin | qr | package | external | fallback)
+ * so the caller threads a consistent route label into the lead-quota gate.
+ *
+ *   returns { kind: 'internal', internalAgentId, via } | { kind: 'external', externalAgentId, via }
+ *
+ * NOTE (external-activation parity, tracked in MKTR_LEADS_ACTIVATION_PLAN.md): the QR tier
+ * here only covers direct assignedAgentId/ownerUserId — NOT QR round-robin groups or the
+ * legacy assignedAgentPhone fallback that createProspect's QR-override block handles. Since
+ * createProspect skips that block for external-eligible leads, QR round-robin/phone routing
+ * must be folded into this resolver (or the block re-enabled per-tier) before external goes
+ * live. Likewise, tier-5 still falls back to the System Agent; an external-eligible campaign
+ * with no funded buyer must HOLD (W1b), not deliver internally.
  */
 export async function resolveLeadAssignment({ reqUser, requestedAgentId, campaignId, qrTagId, allowExternal = false }) {
   // 1) Requester is an agent → self-assign (internal)
   if (reqUser && reqUser.role === 'agent') {
-    return { kind: 'internal', internalAgentId: reqUser.id };
+    return { kind: 'internal', internalAgentId: reqUser.id, via: 'self' };
   }
 
   // 2) Admin-requested explicit agent (internal)
   if (reqUser && reqUser.role === 'admin' && requestedAgentId) {
     const valid = await User.findOne({ where: { id: requestedAgentId, role: 'agent', isActive: true } });
-    if (valid) return { kind: 'internal', internalAgentId: valid.id };
+    if (valid) return { kind: 'internal', internalAgentId: valid.id, via: 'admin' };
   }
 
   // 3) QR directly assigned to an internal agent
@@ -222,7 +233,7 @@ export async function resolveLeadAssignment({ reqUser, requestedAgentId, campaig
     const candidateId = qr?.assignedAgentId || qr?.ownerUserId;
     if (candidateId) {
       const agent = await User.findOne({ where: { id: candidateId, role: 'agent', isActive: true } });
-      if (agent) return { kind: 'internal', internalAgentId: agent.id };
+      if (agent) return { kind: 'internal', internalAgentId: agent.id, via: 'qr' };
     }
   }
 
@@ -263,8 +274,8 @@ export async function resolveLeadAssignment({ reqUser, requestedAgentId, campaig
     }
 
     const ring = [
-      ...internalActive.map((id) => ({ kind: 'internal', internalAgentId: id })),
-      ...externalActive.map((id) => ({ kind: 'external', externalAgentId: id })),
+      ...internalActive.map((id) => ({ kind: 'internal', internalAgentId: id, via: 'package' })),
+      ...externalActive.map((id) => ({ kind: 'external', externalAgentId: id, via: 'external' })),
     ];
 
     if (ring.length > 0) {
@@ -285,7 +296,7 @@ export async function resolveLeadAssignment({ reqUser, requestedAgentId, campaig
   // 5) Fallback → System Agent (internal). NOTE: the cutover must NOT let an
   //    external-only campaign reach here — no eligible paid buyer => quarantine.
   const systemId = await getSystemAgentId();
-  return { kind: 'internal', internalAgentId: systemId };
+  return { kind: 'internal', internalAgentId: systemId, via: 'fallback' };
 }
 
 

--- a/backend/test/unit/prospectAssignment.test.js
+++ b/backend/test/unit/prospectAssignment.test.js
@@ -140,7 +140,7 @@ function buildMocks() {
   };
 }
 
-function makeService(mocks) {
+function makeService(mocks, overrides = {}) {
   return makeProspectService({
     models: mocks.models,
     sequelize: mocks.sequelize,
@@ -153,6 +153,7 @@ function makeService(mocks) {
     dispatchEvent: mocks.dispatchEvent,
     AppError: mocks.AppError,
     logger: mocks.logger,
+    ...overrides,
   });
 }
 
@@ -542,5 +543,60 @@ describe('prospectAssignment (unit)', () => {
       expect(calls[1][0].type).toBe('updated');
       expect(calls[1][0].metadata.quarantined).toBe(true);
     });
+  });
+});
+
+describe('createProspect — single-pass external routing (W1)', () => {
+  const admin = { id: 'admin-1', role: 'admin', firstName: 'Admin' };
+
+  it('external-eligible + consented lead routes via resolveLeadAssignment ONLY (no resolveLeadRouting double-pass), writes externalAgentId, and suppresses the Lyfe webhook', async () => {
+    const mocks = buildMocks();
+    mocks.mockCampaign.externalEligible = true; // Campaign.findByPk returns this row
+    const resolveLeadAssignment = jest
+      .fn()
+      .mockResolvedValue({ kind: 'external', externalAgentId: 'ext-1', via: 'external' });
+    const deductExternalLeadBalance = jest.fn().mockResolvedValue(true);
+    const service = makeService(mocks, {
+      hasValidExternalConsent: () => true,
+      resolveLeadAssignment,
+      deductExternalLeadBalance,
+    });
+
+    await service.createProspect(
+      {
+        firstName: 'Ext',
+        campaignId: 'camp-1',
+        consentMetadata: { external: { version: 'v1', consentedAt: '2026-01-01T00:00:00Z', channels: ['phone'] } },
+      },
+      admin,
+      {}
+    );
+
+    // Exactly one routing pass: the unified resolver, never the internal-only one.
+    expect(resolveLeadAssignment).toHaveBeenCalledTimes(1);
+    expect(mocks.resolveLeadRouting).not.toHaveBeenCalled();
+    // Written as an external lead (mutually exclusive with assignedAgentId).
+    expect(mocks.models.Prospect.create).toHaveBeenCalledWith(
+      expect.objectContaining({ externalAgentId: 'ext-1', assignedAgentId: null }),
+      expect.anything()
+    );
+    // Paid external buyer charged authoritatively; the internal quota gate is skipped.
+    expect(deductExternalLeadBalance).toHaveBeenCalledWith('ext-1', 1, expect.anything());
+    expect(mocks.chargeLeadCredit).not.toHaveBeenCalled();
+    // External leads must NOT fire the Lyfe lead.created webhook.
+    expect(mocks.dispatchEvent).not.toHaveBeenCalled();
+  });
+
+  it('non-external-eligible lead still routes via resolveLeadRouting only (live path unchanged)', async () => {
+    const mocks = buildMocks();
+    mocks.mockCampaign.externalEligible = false;
+    const resolveLeadAssignment = jest.fn();
+    const service = makeService(mocks, { hasValidExternalConsent: () => true, resolveLeadAssignment });
+    mocks.resolveLeadRouting.mockResolvedValue({ agentId: 'agent-1', via: 'admin' });
+
+    await service.createProspect({ firstName: 'Int', campaignId: 'camp-1' }, admin, {});
+
+    expect(mocks.resolveLeadRouting).toHaveBeenCalledTimes(1);
+    expect(resolveLeadAssignment).not.toHaveBeenCalled();
   });
 });

--- a/backend/test/unit/resolveLeadRouting.test.js
+++ b/backend/test/unit/resolveLeadRouting.test.js
@@ -22,7 +22,7 @@ jest.unstable_mockModule('../../src/utils/logger.js', () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
 }));
 
-const { resolveLeadRouting } = await import('../../src/services/systemAgent.js');
+const { resolveLeadRouting, resolveLeadAssignment } = await import('../../src/services/systemAgent.js');
 
 describe('resolveLeadRouting (unit) — route labelling for quota gating', () => {
   beforeEach(() => jest.clearAllMocks());
@@ -77,5 +77,60 @@ describe('resolveLeadRouting (unit) — route labelling for quota gating', () =>
     User.findOne.mockResolvedValue({ id: 'system', email: 'system@mktr.local', role: 'agent', isActive: true });
     const r = await resolveLeadRouting({ campaignId: 'camp-empty' });
     expect(r.via).toBe('fallback');
+  });
+});
+
+describe('resolveLeadAssignment (unit) — via labels + external pool', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('tier 1 — agent self → {kind:internal, via:self}', async () => {
+    const r = await resolveLeadAssignment({ reqUser: { id: 'me', role: 'agent' } });
+    expect(r).toEqual({ kind: 'internal', internalAgentId: 'me', via: 'self' });
+  });
+
+  it('tier 2 — admin explicit agent → {kind:internal, via:admin}', async () => {
+    User.findOne.mockResolvedValue({ id: 'tgt' });
+    const r = await resolveLeadAssignment({ reqUser: { role: 'admin' }, requestedAgentId: 'tgt' });
+    expect(r).toEqual({ kind: 'internal', internalAgentId: 'tgt', via: 'admin' });
+  });
+
+  it('tier 3 — QR-owner agent → {kind:internal, via:qr}', async () => {
+    QrTag.findByPk.mockResolvedValue({ assignedAgentId: 'qr-owner' });
+    User.findOne.mockResolvedValue({ id: 'qr-owner' });
+    const r = await resolveLeadAssignment({ qrTagId: 'qr-1' });
+    expect(r).toEqual({ kind: 'internal', internalAgentId: 'qr-owner', via: 'qr' });
+  });
+
+  it('tier 4 internal — package agent → {kind:internal, via:package}', async () => {
+    LeadPackageAssignment.findAll.mockResolvedValue([{ agentId: 'pkg-agent' }]);
+    User.findAll.mockResolvedValue([{ id: 'pkg-agent' }]);
+    ExternalCampaignAgent.findAll.mockResolvedValue([]);
+    RoundRobinCursor.findOrCreate.mockResolvedValue([{ campaignId: 'c1', cursor: 0 }, false]);
+    RoundRobinCursor.update.mockResolvedValue([1, [{ cursor: 1 }]]);
+    const r = await resolveLeadAssignment({ campaignId: 'c1', allowExternal: true });
+    expect(r).toEqual({ kind: 'internal', internalAgentId: 'pkg-agent', via: 'package' });
+  });
+
+  it('tier 4 external — funded external buyer (allowExternal) → {kind:external, via:external}', async () => {
+    LeadPackageAssignment.findAll.mockResolvedValue([]); // no internal pool
+    User.findAll.mockResolvedValue([]);
+    ExternalCampaignAgent.findAll.mockResolvedValue([
+      { externalAgent: { id: 'ext-1', createdAt: '2026-01-01T00:00:00Z' } },
+    ]);
+    RoundRobinCursor.findOrCreate.mockResolvedValue([{ campaignId: 'c1', cursor: 0 }, false]);
+    RoundRobinCursor.update.mockResolvedValue([1, [{ cursor: 1 }]]);
+    const r = await resolveLeadAssignment({ campaignId: 'c1', allowExternal: true });
+    expect(r).toEqual({ kind: 'external', externalAgentId: 'ext-1', via: 'external' });
+  });
+
+  it('external pool is NOT queried when allowExternal is false', async () => {
+    LeadPackageAssignment.findAll.mockResolvedValue([]);
+    User.findAll.mockResolvedValue([]);
+    process.env.DEFAULT_AGENT_ID = '';
+    User.findOne.mockResolvedValue({ id: 'system', email: 'system@mktr.local', role: 'agent', isActive: true });
+    const r = await resolveLeadAssignment({ campaignId: 'c1', allowExternal: false });
+    expect(r.kind).toBe('internal');
+    expect(r.via).toBe('fallback');
+    expect(ExternalCampaignAgent.findAll).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Foundation (W1) for activating the still-inert MKTR Leads external-buyer marketplace.

**Behavior-preserving for the live INTERNAL path** — `allowExternal` is always false in prod
(no writer populates `consentMetadata.external`; validation rejects it), so internal leads keep
flowing through `resolveLeadRouting` + the QR-override block exactly as before. Only the inert
external path changes.

**Fix (Codex-flagged blocker):** `createProspect` routed twice for external-eligible leads
(`resolveLeadRouting` → `resolveLeadAssignment`), double-advancing the per-campaign round-robin
cursor and leaving `routeVia` stale for the lead-quota gate.
- `resolveLeadAssignment` now returns `{ kind, agentId, via }` on every tier.
- `createProspect` does a SINGLE routing pass; the QR-override block is skipped for external-eligible
  leads (the unified resolver owns the self/admin/qr tiers).

**Verification:** +8 unit tests (via-labels incl. external-pool gating; single-pass proof —
external lead routes once, writes `externalAgentId`, charges the buyer, suppresses the Lyfe webhook).
1071 unit tests pass; the 14 remaining failures (5 suites) are PRE-EXISTING on main.

**Codex review** (`CODEX_REVIEW_W1_ROUTING.md`): *no merge-blocking live-path regression; safe to
merge as a behavior-preserving foundation.* Two before-activation follow-ups (W1b) tracked in code +
`MKTR_LEADS_ACTIVATION_PLAN.md`: QR round-robin/phone parity in the unified resolver, and the
no-funded-buyer HOLD semantics (vs. today's System-Agent fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)