### PR TITLE
feat(mktr-leads): W1b — external no-buyer HOLD + airtight release fence

### DIFF
--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -217,6 +217,8 @@ export function makeProspectService(overrides = {}) {
     //   - everyone else (the live path) → internal-only resolveLeadRouting, unchanged.
     let assignedAgentId = null;
     let externalAgentId = null;
+    let externalHold = false; // external-eligible + consented, but no funded buyer → HOLD
+    let externalHoldReason = null;
     let routeVia;
     if (allowExternal) {
       const r = await d.resolveLeadAssignment({
@@ -229,6 +231,11 @@ export function makeProspectService(overrides = {}) {
       routeVia = r.via;
       if (r.kind === 'external') {
         externalAgentId = r.externalAgentId; // assignedAgentId stays null (mutually exclusive)
+      } else if (r.kind === 'hold') {
+        // No funded buyer AND no funded internal pool agent — never hand a monetized,
+        // consented lead to the free System Agent. Quarantine it (held) below.
+        externalHold = true;
+        externalHoldReason = r.holdReason || 'no_funded_external_buyer';
       } else {
         assignedAgentId = r.internalAgentId ?? null;
       }
@@ -434,7 +441,12 @@ export function makeProspectService(overrides = {}) {
       // leads default to a plain "assign" directive so the shared activity/deduct
       // code below stays correct (external is charged authoritatively, not metered).
       let decision = { action: 'assign', assignedAgentId, charged: false, via: routeVia };
-      if (!externalAgentId) {
+      if (externalHold) {
+        // External-eligible + consented but no funded buyer → HOLD (never System Agent,
+        // never charged). The distinct quarantineReason fences this lead off from the
+        // internal release sweep so it can never be delivered to Lyfe.
+        decision = { action: 'quarantine', quarantineReason: externalHoldReason, charged: false, via: routeVia };
+      } else if (!externalAgentId) {
         decision = await d.decideAssignment({
           campaign: sourceCampaign,
           routing: { agentId: assignedAgentId, via: routeVia },
@@ -484,7 +496,10 @@ export function makeProspectService(overrides = {}) {
             prospectId: newProspect.id,
             type: 'updated',
             actorUserId: user?.id || null,
-            description: 'Held — no funded agent (lead quota)',
+            description:
+              decision.quarantineReason === 'no_funded_external_buyer'
+                ? 'Held — no funded MKTR Leads (external) buyer'
+                : 'Held — no funded agent (lead quota)',
             metadata: { quarantined: true, reason: decision.quarantineReason, via: routeVia },
           },
           { transaction: t }
@@ -821,6 +836,17 @@ export function makeProspectService(overrides = {}) {
 
     if (!agent) {
       throw new d.AppError('Invalid or inactive agent', 400);
+    }
+
+    // An external hold (no funded MKTR Leads buyer) must NEVER be manually released to an
+    // internal agent / Lyfe — it was captured for the external buyer pool and can only be
+    // delivered via the external channel (or a dedicated conversion flow, not built yet).
+    // The auto release-sweep is already fenced off these holds; close the manual path too.
+    if (prospect.quarantineReason === 'no_funded_external_buyer') {
+      throw new d.AppError(
+        'This lead is held for the MKTR Leads (external) buyer pool and cannot be manually assigned to an internal agent.',
+        409
+      );
     }
 
     // A manual admin assign is an EXEMPT route (decision a): it always delivers and does

--- a/backend/src/services/releaseSweep.js
+++ b/backend/src/services/releaseSweep.js
@@ -41,9 +41,12 @@ export function makeReleaseSweep(overrides = {}) {
 
     let released = 0;
     for (let i = 0; i < MAX_RELEASE_PER_SWEEP; i++) {
-      // Oldest held lead for this campaign (FIFO).
+      // Oldest held lead for this campaign (FIFO). Only INTERNAL lead-quota holds
+      // (quarantineReason 'no_funded_agent') are eligible — external holds
+      // ('no_funded_external_buyer') must NEVER be released to Lyfe by this internal
+      // sweep; they can only ever be delivered via the external (MKTR Leads) channel.
       const held = await d.Prospect.findOne({
-        where: { campaignId, quarantinedAt: { [Op.ne]: null } },
+        where: { campaignId, quarantinedAt: { [Op.ne]: null }, quarantineReason: 'no_funded_agent' },
         order: [['quarantinedAt', 'ASC']],
       });
       if (!held) break; // queue drained
@@ -123,7 +126,8 @@ export function makeReleaseSweep(overrides = {}) {
   async function sweepAll() {
     const rows = await d.Prospect.findAll({
       attributes: ['campaignId'],
-      where: { quarantinedAt: { [Op.ne]: null }, campaignId: { [Op.ne]: null } },
+      // Internal lead-quota holds only — external holds are not releasable here.
+      where: { quarantinedAt: { [Op.ne]: null }, quarantineReason: 'no_funded_agent', campaignId: { [Op.ne]: null } },
       group: ['campaignId'],
     });
     let total = 0;

--- a/backend/src/services/systemAgent.js
+++ b/backend/src/services/systemAgent.js
@@ -293,8 +293,14 @@ export async function resolveLeadAssignment({ reqUser, requestedAgentId, campaig
     }
   }
 
-  // 5) Fallback → System Agent (internal). NOTE: the cutover must NOT let an
-  //    external-only campaign reach here — no eligible paid buyer => quarantine.
+  // 5) Fallback. For an external-eligible (allowExternal) lead with no funded buyer AND
+  //    no funded internal pool agent, HOLD it — never hand a monetized, consented lead to
+  //    the free System Agent (plan §0.7). The caller quarantines it; the internal release
+  //    sweep is fenced off from these holds. Internal-only callers (allowExternal=false,
+  //    e.g. resolveAssignedAgentId/retell/meta) keep the System-Agent fallback unchanged.
+  if (allowExternal) {
+    return { kind: 'hold', via: 'fallback', holdReason: 'no_funded_external_buyer' };
+  }
   const systemId = await getSystemAgentId();
   return { kind: 'internal', internalAgentId: systemId, via: 'fallback' };
 }

--- a/backend/test/unit/prospectAssignment.test.js
+++ b/backend/test/unit/prospectAssignment.test.js
@@ -334,6 +334,23 @@ describe('prospectAssignment (unit)', () => {
       expect(mocks.dispatchEvent).not.toHaveBeenCalledWith('lead.assigned', expect.any(Function));
     });
 
+    it('refuses to manually release an EXTERNAL hold (no_funded_external_buyer) to an internal agent', async () => {
+      const extHeld = {
+        ...mocks.mockProspect,
+        quarantinedAt: new Date(),
+        quarantineReason: 'no_funded_external_buyer',
+        reload: jest.fn().mockResolvedValue(true),
+      };
+      mocks.models.Prospect.findByPk.mockResolvedValue(extHeld);
+
+      await expect(service.assignProspect('prospect-1', 'agent-1', admin)).rejects.toThrow(/MKTR Leads/);
+
+      // No release, no charge, no Lyfe delivery — the external-hold fence holds on the manual path too.
+      expect(mocks.sequelize.query).not.toHaveBeenCalled();
+      expect(mocks.deductLeadCredit).not.toHaveBeenCalled();
+      expect(mocks.dispatchEvent).not.toHaveBeenCalledWith('lead.created', expect.any(Function));
+    });
+
     it('release race lost (claim returns 0 rows) → no deduct, no double delivery', async () => {
       const held = { ...mocks.mockProspect, quarantinedAt: new Date(), reload: jest.fn().mockResolvedValue(true) };
       mocks.models.Prospect.findByPk.mockResolvedValue(held);
@@ -598,5 +615,44 @@ describe('createProspect — single-pass external routing (W1)', () => {
 
     expect(mocks.resolveLeadRouting).toHaveBeenCalledTimes(1);
     expect(resolveLeadAssignment).not.toHaveBeenCalled();
+  });
+
+  it('external-eligible + consented but NO funded buyer → HELD (quarantined), not assigned, not charged, webhook suppressed', async () => {
+    const mocks = buildMocks();
+    mocks.mockCampaign.externalEligible = true;
+    const resolveLeadAssignment = jest
+      .fn()
+      .mockResolvedValue({ kind: 'hold', via: 'fallback', holdReason: 'no_funded_external_buyer' });
+    const deductExternalLeadBalance = jest.fn();
+    const service = makeService(mocks, {
+      hasValidExternalConsent: () => true,
+      resolveLeadAssignment,
+      deductExternalLeadBalance,
+    });
+
+    await service.createProspect(
+      {
+        firstName: 'Held',
+        campaignId: 'camp-1',
+        consentMetadata: { external: { version: 'v1', consentedAt: '2026-01-01T00:00:00Z', channels: ['phone'] } },
+      },
+      admin,
+      {}
+    );
+
+    // Held: quarantined, neither assignee set, distinct external reason.
+    expect(mocks.models.Prospect.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assignedAgentId: null,
+        externalAgentId: null,
+        quarantineReason: 'no_funded_external_buyer',
+      }),
+      expect.anything()
+    );
+    expect(mocks.models.Prospect.create.mock.calls[0][0].quarantinedAt).toBeInstanceOf(Date);
+    // Never charged (no buyer), internal quota gate skipped, Lyfe webhook suppressed.
+    expect(deductExternalLeadBalance).not.toHaveBeenCalled();
+    expect(mocks.chargeLeadCredit).not.toHaveBeenCalled();
+    expect(mocks.dispatchEvent).not.toHaveBeenCalled();
   });
 });

--- a/backend/test/unit/releaseSweep.test.js
+++ b/backend/test/unit/releaseSweep.test.js
@@ -36,6 +36,18 @@ describe('releaseSweep.sweepCampaign (unit)', () => {
     expect(deps.Prospect.findOne).not.toHaveBeenCalled();
   });
 
+  it('fences off external holds: the FIFO query matches only internal quota holds', async () => {
+    const { deps } = buildMocks();
+    deps.Prospect.findOne.mockResolvedValue(null); // empty queue — we only inspect the query shape
+    await makeReleaseSweep(deps).sweepCampaign('camp-1');
+    expect(deps.Prospect.findOne).toHaveBeenCalled();
+    // Must filter to the internal reason so external holds ('no_funded_external_buyer')
+    // can never be released to Lyfe by this internal sweep.
+    expect(deps.Prospect.findOne.mock.calls[0][0].where).toMatchObject({
+      quarantineReason: 'no_funded_agent',
+    });
+  });
+
   it('drains the held queue FIFO: releases each funded lead, charges, fires lead.created', async () => {
     const { deps, mockTx } = buildMocks();
     deps.Prospect.findOne

--- a/backend/test/unit/resolveLeadRouting.test.js
+++ b/backend/test/unit/resolveLeadRouting.test.js
@@ -133,4 +133,12 @@ describe('resolveLeadAssignment (unit) — via labels + external pool', () => {
     expect(r.via).toBe('fallback');
     expect(ExternalCampaignAgent.findAll).not.toHaveBeenCalled();
   });
+
+  it('tier 5 — allowExternal + no funded internal/external pool → {kind:hold} (never System Agent)', async () => {
+    LeadPackageAssignment.findAll.mockResolvedValue([]); // no funded internal pool
+    User.findAll.mockResolvedValue([]);
+    ExternalCampaignAgent.findAll.mockResolvedValue([]); // no funded external buyer
+    const r = await resolveLeadAssignment({ campaignId: 'c-empty', allowExternal: true });
+    expect(r).toEqual({ kind: 'hold', via: 'fallback', holdReason: 'no_funded_external_buyer' });
+  });
 });


### PR DESCRIPTION
Continues W1 (#26) toward MKTR_LEADS_PLAN.md §0.7. **Inert in prod** (external path unreachable);
**behavior-preserving** for the live internal path.

- `resolveLeadAssignment`: when `allowExternal` and the funded ring is empty (no funded internal
  pool agent AND no funded external buyer), returns `{kind:'hold'}` instead of the System-Agent
  fallback — never hands a monetized, consented lead to a free internal agent. Internal-only
  callers keep the System-Agent fallback.
- `createProspect`: a `hold` result quarantines the lead (`quarantineReason 'no_funded_external_buyer'`),
  bypassing the internal quota gate; not charged; Lyfe webhook suppressed.
- **Release fence — an external hold can never reach Lyfe via any internal path:** auto release-sweep
  (FIFO + sweepAll) match only internal `no_funded_agent` holds; bulk assign filters `quarantinedAt:null`;
  and manual `assignProspect` now 409s on an external hold (the hole the W1b Codex review flagged).

**Verification:** +4 unit tests (resolver hold; createProspect hold; sweep fence; manual-assign fence).
1074+ unit tests pass; the 14 remaining failures (5 suites) are pre-existing on main. lead-quota
integration suite is DB-only and CI-safe. Codex-reviewed (`CODEX_REVIEW_W1B_ROUTING.md`); its one
should-fix (manual release) is fixed here.

Deferred follow-up: QR round-robin-group / legacy `assignedAgentPhone` parity in the unified resolver
(needs a shared QR-resolution helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)