### PR TITLE
feat(prospects): bulk-select prospects with CSV/PDF export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,8 @@
         "embla-carousel-react": "^8.5.2",
         "framer-motion": "^12.4.7",
         "input-otp": "^1.4.2",
+        "jspdf": "^2.5.2",
+        "jspdf-autotable": "^3.8.4",
         "lucide-react": "^0.475.0",
         "next-themes": "^0.4.4",
         "react": "^18.2.0",
@@ -4015,6 +4017,13 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
@@ -4539,6 +4548,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -4598,6 +4619,16 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",
@@ -4675,6 +4706,18 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/call-bind": {
@@ -4766,6 +4809,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -5069,6 +5132,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5081,6 +5156,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -6199,6 +6284,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -6733,6 +6824,20 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -7561,6 +7666,40 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jspdf": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.2.tgz",
+      "integrity": "sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.5.4",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf-autotable": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-3.8.4.tgz",
+      "integrity": "sha512-rSffGoBsJYX83iTRv8Ft7FhqfgEL2nLpGAIiqruEQQ3e4r0qdLFbPUB7N9HAle0I3XgpisvyW751VHCqKUVOgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jspdf": "^2.5.1"
+      }
+    },
+    "node_modules/jspdf/node_modules/dompurify": {
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.9.tgz",
+      "integrity": "sha512-i6mvVmWN4xo9LrhCOZrDgSs9noW6nOahbrmzjRbPF36YPyj5Ue5lgok0MHDWkG7xzpWFO2OYttXdzM7rJxHvNA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
@@ -8485,6 +8624,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8857,6 +9003,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -9172,6 +9328,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -9274,6 +9437,16 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
     },
     "node_modules/rollup": {
       "version": "4.59.0",
@@ -9767,6 +9940,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/std-env": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
@@ -10065,6 +10248,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -10146,6 +10339,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/thenify": {
@@ -10572,6 +10775,16 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/vaul": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "embla-carousel-react": "^8.5.2",
     "framer-motion": "^12.4.7",
     "input-otp": "^1.4.2",
+    "jspdf": "^2.5.2",
+    "jspdf-autotable": "^3.8.4",
     "lucide-react": "^0.475.0",
     "next-themes": "^0.4.4",
     "react": "^18.2.0",

--- a/src/pages/AdminProspects.jsx
+++ b/src/pages/AdminProspects.jsx
@@ -20,10 +20,14 @@ import { useLocation } from"react-router-dom";
 import { format } from"date-fns";
 import {
  Search,
- Download,
+ FileSpreadsheet,
+ FileText,
  Trash2,
- User
+ User,
+ X
 } from"lucide-react";
+import { Checkbox } from"@/components/ui/checkbox";
+import { toast } from"sonner";
 import { useIsMobile } from"@/hooks/use-mobile";
 import {
  Select,
@@ -62,6 +66,7 @@ export default function AdminProspects() {
  });
  const [currentPage, setCurrentPage] = useState(1);
  const [itemsPerPage, setItemsPerPage] = useState(25);
+ const [selectedIds, setSelectedIds] = useState(() => new Set());
  const isMobile = useIsMobile();
 
  useEffect(() => {
@@ -103,6 +108,31 @@ export default function AdminProspects() {
  currentPage, totalPages: 1, totalItems: prospects.length, itemsPerPage
  };
 
+ // Clear row selection whenever the visible set changes (page / filters / page size).
+ useEffect(() => { setSelectedIds(new Set()); }, [queryParams]);
+
+ const exportRows = useMemo(
+ () => (selectedIds.size > 0 ? prospects.filter((p) => selectedIds.has(p.id)) : prospects),
+ [prospects, selectedIds]
+ );
+ const allSelected = prospects.length > 0 && prospects.every((p) => selectedIds.has(p.id));
+ const someSelected = selectedIds.size > 0 && !allSelected;
+
+ const toggleSelectAll = () => {
+ setSelectedIds((prev) => {
+ const everyVisibleSelected = prospects.length > 0 && prospects.every((p) => prev.has(p.id));
+ return everyVisibleSelected ? new Set() : new Set(prospects.map((p) => p.id));
+ });
+ };
+ const toggleSelectOne = (id) => {
+ setSelectedIds((prev) => {
+ const next = new Set(prev);
+ if (next.has(id)) next.delete(id); else next.add(id);
+ return next;
+ });
+ };
+ const clearSelection = () => setSelectedIds(new Set());
+
  const handleRefresh = () => queryClient.invalidateQueries({ queryKey: ['prospects'] });
 
  const handleStatusUpdate = async (prospectId, newStatus) => {
@@ -119,26 +149,69 @@ export default function AdminProspects() {
  } catch (error) { console.error('Error deleting prospect:', error); }
  };
 
- const exportToCSV = () => {
- const headers = ['Created Date', 'Campaign', 'Name', 'Phone', 'Status', 'Assigned To', 'Source'];
- const csvData = prospects.map(p => {
- const campaign = campaigns.find(c => (c.id === p.campaign_id));
+ // Exports act on the current selection if any rows are ticked, otherwise the whole visible page.
+ const exportFileName = (ext) =>
+ `prospects_${format(new Date(), 'ddMMyyyy_HHmm')}${selectedIds.size > 0 ? '_selected' : ''}.${ext}`;
+
+ const exportColumns = ['Created Date', 'Campaign', 'Name', 'Phone', 'Email', 'Status', 'Assigned To', 'Source'];
+ const exportRowValues = (p) => {
+ const campaign = campaigns.find((c) => c.id === p.campaign_id);
  return [
  format(new Date(p.created_date), 'dd/MM/yyyy HH:mm'),
- campaign?.name || '', p.name, p.phone,
- statusLabels[p.status] || p.status,
- p.assigned_agent_name || '', (p.source || '').toUpperCase()
+ campaign?.name || '',
+ p.name || '',
+ p.phone || '',
+ p.email || '',
+ statusLabels[p.status] || p.status || '',
+ p.assigned_agent_name || '',
+ (p.source || '').toUpperCase(),
  ];
- });
- const csvContent = [headers, ...csvData]
- .map(row => row.map(field => '"' + String(field).replace(/"/g, '"') + '"').join(',')).join('\n');
- const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+ };
+
+ const exportToCSV = () => {
+ if (exportRows.length === 0) return;
+ const csvData = exportRows.map(exportRowValues);
+ const csvContent = [exportColumns, ...csvData]
+ .map((row) => row.map((field) => '"' + String(field ?? '').replace(/"/g, '""') + '"').join(',')).join('\n');
+ const blob = new Blob(['\ufeff' + csvContent], { type: 'text/csv;charset=utf-8;' });
  const link = document.createElement('a');
  link.setAttribute('href', URL.createObjectURL(blob));
- link.setAttribute('download', `prospects_${format(new Date(), 'ddMMyyyy_HHmm')}.csv`);
+ link.setAttribute('download', exportFileName('csv'));
  document.body.appendChild(link);
  link.click();
  document.body.removeChild(link);
+ };
+
+ const exportToPDF = async () => {
+ if (exportRows.length === 0) return;
+ try {
+ const [{ jsPDF }, autoTableModule] = await Promise.all([
+ import('jspdf'),
+ import('jspdf-autotable'),
+ ]);
+ const autoTable = autoTableModule.default;
+ const doc = new jsPDF({ orientation: 'landscape' });
+ const generatedAt = format(new Date(), 'dd MMM yyyy, h:mm a');
+ const scopeLabel = selectedIds.size > 0 ? `${exportRows.length} selected` : `${exportRows.length} total`;
+ doc.setFontSize(14);
+ doc.text('Prospects Export', 14, 15);
+ doc.setFontSize(9);
+ doc.setTextColor(110);
+ doc.text(`${scopeLabel} • Generated ${generatedAt}`, 14, 21);
+ autoTable(doc, {
+ startY: 26,
+ head: [exportColumns],
+ body: exportRows.map(exportRowValues),
+ styles: { fontSize: 8, cellPadding: 2, overflow: 'linebreak' },
+ headStyles: { fillColor: [30, 41, 59], textColor: 255, fontStyle: 'bold' },
+ alternateRowStyles: { fillColor: [245, 247, 250] },
+ margin: { left: 14, right: 14 },
+ });
+ doc.save(exportFileName('pdf'));
+ } catch (err) {
+ console.error('Error generating PDF:', err);
+ toast.error('Could not generate PDF. Please try again.');
+ }
  };
 
  if (prospectsLoading) {
@@ -180,10 +253,16 @@ export default function AdminProspects() {
  <div className="max-w-[1400px] mx-auto space-y-6">
  <PageHeader
  title="Prospects" description="Manage and track your sales prospects across all campaigns." actions={
- <Button variant="outline" className="bg-card" onClick={exportToCSV} disabled={prospects.length === 0}>
- <Download className="w-4 h-4 mr-2"/>
- Export CSV
+ <div className="flex items-center gap-2">
+ <Button variant="outline" className="bg-card" onClick={exportToCSV} disabled={exportRows.length === 0}>
+ <FileSpreadsheet className="w-4 h-4 mr-2"/>
+ Export CSV{selectedIds.size > 0 ? ` (${selectedIds.size})` : ''}
  </Button>
+ <Button variant="outline" className="bg-card" onClick={exportToPDF} disabled={exportRows.length === 0}>
+ <FileText className="w-4 h-4 mr-2"/>
+ Export PDF{selectedIds.size > 0 ? ` (${selectedIds.size})` : ''}
+ </Button>
+ </div>
  }
  />
 
@@ -217,11 +296,30 @@ export default function AdminProspects() {
  </CardHeader>
 
  <CardContent className="p-0">
+ {selectedIds.size > 0 && (
+ <div className="flex items-center justify-between gap-3 px-4 lg:px-6 py-2.5 bg-primary/5 border-b border-border">
+ <span className="text-sm font-medium text-foreground">
+ {selectedIds.size} selected
+ </span>
+ <Button
+ variant="ghost" size="sm" onClick={clearSelection}
+ className="h-8 text-muted-foreground hover:text-foreground">
+ <X className="w-4 h-4 mr-1.5"/>
+ Clear
+ </Button>
+ </div>
+ )}
  {!isMobile ? (
  <div className="overflow-x-auto">
  <Table>
  <TableHeader>
  <TableRow className="bg-muted/50 hover:bg-muted/50 border-border">
+ <TableHead className="py-3 pl-6 pr-2 w-[44px]">
+ <Checkbox
+ checked={allSelected ? true : someSelected ?"indeterminate" : false}
+ onCheckedChange={toggleSelectAll}
+ aria-label="Select all prospects on this page" />
+ </TableHead>
  <TableHead className="py-3 px-6 font-medium text-muted-foreground">Prospect</TableHead>
  <TableHead className="py-3 px-6 font-medium text-muted-foreground">Campaign</TableHead>
  <TableHead className="py-3 px-6 font-medium text-muted-foreground">Status</TableHead>
@@ -236,8 +334,14 @@ export default function AdminProspects() {
  return (
  <TableRow
  key={prospect.id}
- className="hover:bg-muted/50 transition-colors border-border group cursor-pointer" onClick={() => setSelectedProspect(prospect)}
+ className={`hover:bg-muted/50 transition-colors border-border group cursor-pointer ${selectedIds.has(prospect.id) ?"bg-primary/5" :""}`} onClick={() => setSelectedProspect(prospect)}
  >
+ <TableCell className="pl-6 pr-2" onClick={(e) => e.stopPropagation()}>
+ <Checkbox
+ checked={selectedIds.has(prospect.id)}
+ onCheckedChange={() => toggleSelectOne(prospect.id)}
+ aria-label={`Select ${prospect.name}`} />
+ </TableCell>
  <TableCell className="px-6 py-4">
  <div className="flex items-center gap-3">
  <div className="w-8 h-8 rounded-full bg-primary/10 text-primary flex items-center justify-center text-xs font-semibold uppercase">
@@ -294,7 +398,7 @@ export default function AdminProspects() {
  })}
  {prospects.length === 0 && (
  <TableEmpty
- colSpan={6}
+ colSpan={7}
  icon={Search}
  title="No prospects found"
  description="Try adjusting your filters or search terms." />
@@ -310,12 +414,19 @@ export default function AdminProspects() {
  title="No prospects found"
  description="Try adjusting your filters or search terms." />
  ) : prospects.map((prospect) => (
- <button
+ <div
  key={prospect.id}
+ className={`flex items-start gap-3 p-4 ${selectedIds.has(prospect.id) ?"bg-primary/5" :""}`}>
+ <Checkbox
+ checked={selectedIds.has(prospect.id)}
+ onCheckedChange={() => toggleSelectOne(prospect.id)}
+ aria-label={`Select ${prospect.name}`}
+ className="mt-1.5" />
+ <button
  type="button"
  onClick={() => setSelectedProspect(prospect)}
  aria-label={`View prospect ${prospect.name}`}
- className="w-full text-left p-4 active:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset">
+ className="flex-1 min-w-0 text-left active:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset rounded-md">
  <div className="flex justify-between items-start mb-2">
  <div className="flex items-center gap-3">
  <div className="w-10 h-10 rounded-full bg-primary/10 text-primary flex items-center justify-center text-sm font-bold">
@@ -334,6 +445,7 @@ export default function AdminProspects() {
  <span>{campaigns.find(c => c.id === prospect.campaign_id)?.name || 'Unknown Campaign'}</span>
  </div>
  </button>
+ </div>
  ))}
  </div>
  )}

--- a/src/pages/__tests__/AdminProspects.test.jsx
+++ b/src/pages/__tests__/AdminProspects.test.jsx
@@ -274,4 +274,61 @@ describe('AdminProspects', () => {
  renderProspects();
  expect(screen.getByText(/rows per page/i)).toBeInTheDocument();
  });
+
+ // --- Selection & export ---
+ const twoProspects = [
+ { id: 'p-1', firstName: 'John', lastName: 'Doe', leadStatus: 'new', createdAt: '2025-01-15T10:00:00Z' },
+ { id: 'p-2', firstName: 'Jane', lastName: 'Roe', leadStatus: 'new', createdAt: '2025-01-16T10:00:00Z' },
+ ];
+
+ it('renders Export PDF button', () => {
+ renderProspects();
+ expect(screen.getByRole('button', { name: /export pdf/i })).toBeInTheDocument();
+ });
+
+ it('renders a select-all checkbox plus one checkbox per row', () => {
+ mockProspectsData.prospects = twoProspects;
+ renderProspects();
+ // 1 header select-all + 2 row checkboxes
+ expect(screen.getAllByRole('checkbox')).toHaveLength(3);
+ });
+
+ it('selecting a row reveals the selection bar with a count and clear action', () => {
+ mockProspectsData.prospects = twoProspects;
+ renderProspects();
+ fireEvent.click(screen.getByRole('checkbox', { name: /select john doe/i }));
+ expect(screen.getByText('1 selected')).toBeInTheDocument();
+ expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument();
+ });
+
+ it('reflects the selection count on the export buttons', () => {
+ mockProspectsData.prospects = twoProspects;
+ renderProspects();
+ fireEvent.click(screen.getByRole('checkbox', { name: /select john doe/i }));
+ expect(screen.getByRole('button', { name: /export csv \(1\)/i })).toBeInTheDocument();
+ expect(screen.getByRole('button', { name: /export pdf \(1\)/i })).toBeInTheDocument();
+ });
+
+ it('select-all selects every visible row', () => {
+ mockProspectsData.prospects = twoProspects;
+ renderProspects();
+ fireEvent.click(screen.getByRole('checkbox', { name: /select all prospects/i }));
+ expect(screen.getByText('2 selected')).toBeInTheDocument();
+ });
+
+ it('clear button resets the selection', () => {
+ mockProspectsData.prospects = twoProspects;
+ renderProspects();
+ fireEvent.click(screen.getByRole('checkbox', { name: /select john doe/i }));
+ expect(screen.getByText('1 selected')).toBeInTheDocument();
+ fireEvent.click(screen.getByRole('button', { name: /clear/i }));
+ expect(screen.queryByText(/selected/i)).not.toBeInTheDocument();
+ });
+
+ it('ticking a row checkbox does not open the detail view', () => {
+ mockProspectsData.prospects = twoProspects;
+ renderProspects();
+ fireEvent.click(screen.getByRole('checkbox', { name: /select john doe/i }));
+ expect(screen.queryByTestId('prospect-details')).not.toBeInTheDocument();
+ });
 });


### PR DESCRIPTION
## What
Adds bulk selection + CSV/PDF export to **Admin → Prospects** (`/AdminProspects`).

- **Checkboxes** on every row (desktop table) and card (mobile), plus a **select-all** header checkbox.
- **Export CSV** and **Export PDF** are selection-aware: they export the ticked rows, or the whole current page when nothing is ticked. Buttons show a live count (e.g. `Export CSV (3)`).
- A **selection bar** ("N selected" + Clear) appears when rows are ticked; selection resets on page/filter/page-size change.
- **PDF** is generated client-side via `jspdf` + `jspdf-autotable`, **dynamically imported** so they code-split into on-demand chunks (page bundle stays ~17 KB; PDF libs only download on first Export PDF click).
- **CSV** improvements: adds an Email column, fixes quote-escaping (the old `"` → `"` replace was a no-op), and prepends a UTF-8 BOM for Excel.

## Columns
Created Date, Campaign, Name, Phone, Email, Status, Assigned To, Source.

## Scope note
Like the previous Export button, this acts on the **currently loaded page** of prospects (the list is server-paginated). A true "export every prospect across all pages" would need a separate backend export endpoint — happy to add if wanted.

## Tests / build
- 7 new tests in `AdminProspects.test.jsx` (checkbox rendering, select-all, live count, clear, no-detail-open on tick).
- Full frontend suite: **991 passing**. ESLint clean. Production build verified (jspdf emits as separate on-demand chunks).

## Notes
- New deps: `jspdf@^2.5.2`, `jspdf-autotable@^3.8.4` (Render installs on deploy).
- Branch cut from current `main` (`5a6675a`, post-#28) and contains **only** this feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)