### PR TITLE
fix(lead-packages): accept isPublic + status in create-package validation

### DIFF
--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -229,14 +229,18 @@ export const schemas = {
   // ever added, define a fresh schema next to it.
 
   // Lead Package schemas — fields match `leadPackageController.createPackage`
-  // destructure. `description` is accepted because the admin form sends it
-  // (silently dropped by the controller).
+  // destructure. `description`, `isPublic` and `status` are accepted because the
+  // admin "Create Package Template" form sends them; the controller drops them
+  // (the service forces status:'active'), but this strict Joi object would
+  // otherwise 400 with `"isPublic"/"status" is not allowed`.
   leadPackageCreate: Joi.object({
     name: Joi.string().min(1).max(100).required(),
     price: Joi.number().min(0).required(),
     leadCount: Joi.number().integer().min(1).required(),
     campaignId: Joi.string().uuid().required(),
     type: Joi.string().valid('basic', 'premium', 'enterprise', 'custom').optional(),
-    description: Joi.string().allow('', null).optional()
+    description: Joi.string().allow('', null).optional(),
+    isPublic: Joi.boolean().optional(),
+    status: Joi.string().valid('active', 'inactive', 'draft', 'archived').optional()
   })
 };


### PR DESCRIPTION
## Problem (blocking, prod)
Creating a lead package via **Admin → Lead Packages → Create Package** fails with:

> Validation Error: isPublic: "isPublic" is not allowed, status: "status" is not allowed

`LeadPackageTemplateDialog` posts `isPublic` + `status`, but `schemas.leadPackageCreate` is a strict Joi object (name/price/leadCount/campaignId/type/description only) and `validate()` runs Joi in reject-unknown mode. So **no lead package can be created through the UI at all.**

Downstream impact: with zero packages, round-robin has no agents to assign to, so **every campaign lead falls through to the phoneless System Agent → `receive-mktr-lead` returns 422 → the lead is dropped** (19 paid leads stranded since Jun 4, none delivered to Lyfe).

## Fix
Accept `isPublic` + `status` in `leadPackageCreate` (accept-and-ignore, exactly like `description` already is). No behavior change: `createPackage` doesn't destructure them and the service hardcodes `status: 'active'`. This only stops the 400.

- One file, additive, low-risk.
- `/assign` has no Joi validation, so it's unaffected.

## After merge → deploy
Render redeploys `api.mktr.sg`, then: create a package for the **Redeem $20 NTUC Fairprice Vouchers** campaign → assign to real agents → leads start delivering (and the stranded backlog can be reassigned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
