### PR TITLE
fix(prospects): drop empty Company column from CSV/PDF export

### DIFF
--- a/src/pages/AdminProspects.jsx
+++ b/src/pages/AdminProspects.jsx
@@ -158,7 +158,7 @@ export default function AdminProspects() {
  const d = new Date(v);
  return isNaN(d.getTime()) ? '' : format(d, 'dd/MM/yyyy');
  };
- const exportColumns = ['Created Date', 'Campaign', 'Name', 'Phone', 'Email', 'Date of Birth', 'Postal Code', 'Company', 'Status', 'Assigned To', 'Source'];
+ const exportColumns = ['Created Date', 'Campaign', 'Name', 'Phone', 'Email', 'Date of Birth', 'Postal Code', 'Status', 'Assigned To', 'Source'];
  const exportRowValues = (p) => {
  const campaign = campaigns.find((c) => c.id === p.campaign_id);
  return [
@@ -169,7 +169,6 @@ export default function AdminProspects() {
  p.email || '',
  fmtDob(p.date_of_birth),
  p.postal_code || '',
- p.company || '',
  statusLabels[p.status] || p.status || '',
  p.assigned_agent_name || '',
  (p.source || '').toUpperCase(),


### PR DESCRIPTION
Follow-up to #31. The exported PDF/CSV included a **Company** column that is empty for lead-capture prospects (verified against a real 19-row export — every Company cell was blank), so it was just dead weight.

## Change
Remove the Company column from both the CSV and PDF exports (shared column builder). Final columns:

> Created Date · Campaign · Name · Phone · Email · Date of Birth · Postal Code · Status · Assigned To · Source

Date of Birth and Postal Code (added in #31) stay and are confirmed populating correctly.

## Verify
- ESLint clean · 25 AdminProspects tests pass · production build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)