### PR TITLE
feat(webhooks): destination-aware lead delivery (route per agent provenance)

### DIFF
--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -149,9 +149,16 @@ async function ensureLyfeWebhookSubscriber() {
 
   if (existing) {
     const needsUpdate = existing.url !== url || existing.secret !== secret || !existing.enabled
-      || JSON.stringify(existing.events?.sort()) !== JSON.stringify(requiredEvents.sort());
+      || JSON.stringify(existing.events?.sort()) !== JSON.stringify(requiredEvents.sort())
+      || existing.metadata?.destination !== 'lyfe';
     if (needsUpdate) {
-      await existing.update({ url, secret, enabled: true, events: requiredEvents });
+      await existing.update({
+        url,
+        secret,
+        enabled: true,
+        events: requiredEvents,
+        metadata: { ...(existing.metadata || {}), destination: 'lyfe' },
+      });
       logger.info('Lyfe webhook subscriber updated', { url, events: requiredEvents });
     } else {
       logger.debug('Lyfe webhook subscriber already registered', { url });
@@ -165,7 +172,8 @@ async function ensureLyfeWebhookSubscriber() {
     secret,
     events: ['lead.created', 'lead.assigned', 'lead.unassigned'],
     enabled: true,
-    description: 'Forward leads to Lyfe mobile app via Supabase Edge Function'
+    description: 'Forward leads to Lyfe mobile app via Supabase Edge Function',
+    metadata: { destination: 'lyfe' },
   });
 
   logger.info('Lyfe webhook subscriber registered', { url });

--- a/backend/src/database/migrations/036-add-user-mktr-leads-id.js
+++ b/backend/src/database/migrations/036-add-user-mktr-leads-id.js
@@ -1,0 +1,48 @@
+/**
+ * Add users.mktrLeadsId — provenance marker for agents mirrored from the
+ * mktr-leads app (a second agent source alongside Lyfe). Stores the mktr-leads
+ * `agents.mktr_user_id` (the key its receiver matches on).
+ *
+ * Mirrors the lyfeId pattern (nullable, unique). A CHECK enforces ONE external
+ * provenance per user — lyfeId and mktrLeadsId are mutually exclusive — so the
+ * two source syncs can never corrupt each other into an ambiguous dual-source
+ * row. Additive + nullable → safe rollback.
+ *
+ * IMPORTANT: deploy the code that reads/writes mktrLeadsId (destination routing +
+ * the mktr-leads adapter) alongside/after this migration. Old code ignores it.
+ */
+export async function up(queryInterface, Sequelize) {
+  await queryInterface
+    .addColumn('users', 'mktrLeadsId', {
+      type: Sequelize.DataTypes.STRING,
+      allowNull: true,
+    })
+    .catch(() => {});
+
+  // Partial unique index — many NULLs allowed; each mktr-leads agent id unique.
+  await queryInterface
+    .addIndex('users', ['mktrLeadsId'], {
+      name: 'users_mktr_leads_id_uniq',
+      unique: true,
+      where: { mktrLeadsId: { [Sequelize.Op.ne]: null } },
+    })
+    .catch(() => {});
+
+  // One external provenance per user: lyfeId XOR mktrLeadsId (both-null allowed
+  // for local-only users like the System Agent).
+  await queryInterface.sequelize
+    .query(
+      'ALTER TABLE "users" ADD CONSTRAINT "users_single_provenance_chk" CHECK ("lyfeId" IS NULL OR "mktrLeadsId" IS NULL)'
+    )
+    .catch((err) => {
+      console.warn('[migration 036] could not add users_single_provenance_chk:', err?.message);
+    });
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize
+    .query('ALTER TABLE "users" DROP CONSTRAINT IF EXISTS "users_single_provenance_chk"')
+    .catch(() => {});
+  await queryInterface.removeIndex('users', 'users_mktr_leads_id_uniq').catch(() => {});
+  await queryInterface.removeColumn('users', 'mktrLeadsId').catch(() => {});
+}

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -132,6 +132,14 @@ const User = sequelize.define('User', {
     allowNull: true,
     unique: true
   },
+  // Provenance marker for agents mirrored from the mktr-leads app (a second
+  // agent source). Stores mktr-leads `agents.mktr_user_id`. Mutually exclusive
+  // with lyfeId (DB CHECK users_single_provenance_chk) — one source per user.
+  mktrLeadsId: {
+    type: DataTypes.STRING,
+    allowNull: true,
+    unique: true
+  },
   // Phase 2 — preserves upstream platform role (agent|manager|director).
   // Internal MKTR `role` keeps using 'agent' for permission purposes;
   // external_role is the lossless mirror for read-side filtering.

--- a/backend/src/services/metaLeadService.js
+++ b/backend/src/services/metaLeadService.js
@@ -8,6 +8,7 @@ import { dispatchEvent } from './webhookService.js';
 import { sendLeadAssignmentEmail } from './mailer.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
+import { destinationForAgent, externalIdForDestination } from './prospectHelpers.js';
 
 const IDEMPOTENCY_SCOPE = 'meta:lead';
 const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -299,16 +300,18 @@ export function makeMetaLeadService(overrides = {}) {
 
       // ── Fire outgoing webhooks (post-commit, fire-and-forget) ──
       let agentForWebhook = null;
+      let metaDestination = null;
       if (assignedAgentId) {
         const agentRecord = await d.User.findByPk(assignedAgentId, {
-          attributes: ['id', 'lyfeId', 'phone', 'email', 'firstName', 'lastName'],
+          attributes: ['id', 'lyfeId', 'mktrLeadsId', 'phone', 'email', 'firstName', 'lastName'],
         });
         if (agentRecord) {
+          metaDestination = destinationForAgent(agentRecord);
           agentForWebhook = {
             phone: agentRecord.phone || null,
             email: agentRecord.email || null,
             name: `${agentRecord.firstName || ''} ${agentRecord.lastName || ''}`.trim(),
-            id: agentRecord.lyfeId || agentRecord.id,
+            id: externalIdForDestination(agentRecord, metaDestination),
           };
         }
       }
@@ -340,7 +343,7 @@ export function makeMetaLeadService(overrides = {}) {
           source: 'meta_webhook',
           campaign: campaign ? { externalId: campaign.id, name: campaign.name } : null
         }
-      }));
+      }), { destination: metaDestination });
 
       // ── Email notification (fire-and-forget) ──
       const notifyAgent = quarantined

--- a/backend/src/services/prospectHelpers.js
+++ b/backend/src/services/prospectHelpers.js
@@ -30,6 +30,33 @@ export function normalizePhone(phone) {
 }
 
 /**
+ * Destination app for a mirrored agent, derived from its provenance columns.
+ *   lyfeId set       -> 'lyfe'
+ *   mktrLeadsId set  -> 'mktr_leads'
+ *   neither          -> null  (local-only, e.g. System Agent → not deliverable)
+ * The DB CHECK (users_single_provenance_chk) guarantees at most one is set.
+ */
+export function destinationForAgent(agent) {
+  if (!agent) return null;
+  if (agent.lyfeId) return 'lyfe';
+  if (agent.mktrLeadsId) return 'mktr_leads';
+  return null;
+}
+
+/**
+ * The external agent id the destination app's receiver matches on.
+ * NEVER falls back to the internal MKTR users.id — that id is meaningless to the
+ * receivers (Lyfe matches users.id by lyfeId; mktr-leads by mktr_user_id), so a
+ * fallback would guarantee a 422 and a dropped lead.
+ */
+export function externalIdForDestination(agent, destination) {
+  if (!agent) return null;
+  if (destination === 'lyfe') return agent.lyfeId || null;
+  if (destination === 'mktr_leads') return agent.mktrLeadsId || null;
+  return null;
+}
+
+/**
  * Build the webhook payload for a 'lead.created' event.
  */
 export function buildLeadCreatedPayload(prospect, routingMode, agentForWebhook, assignedAgentId, sourceCampaign, sourceQrTag, agentGroup) {
@@ -104,7 +131,7 @@ export function buildLeadAssignedPayload(prospect, agent, prospectWithCampaign) 
         createdAt: prospect.createdAt
       },
       routing: {
-        agentExternalId: agent.lyfeId || agent.id,
+        agentExternalId: externalIdForDestination(agent, destinationForAgent(agent)),
         agentName: [agent.firstName, agent.lastName].filter(Boolean).join(' '),
         agentEmail: agent.email,
         agentPhone: agent.phone

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -32,6 +32,8 @@ import {
   buildLeadCreatedPayload,
   buildLeadAssignedPayload,
   buildLeadUnassignedPayload,
+  destinationForAgent,
+  externalIdForDestination,
 } from './prospectHelpers.js';
 import { scoreQuiz } from './quizScoringService.js';
 
@@ -565,18 +567,22 @@ export function makeProspectService(overrides = {}) {
     assignedAgentId = finalAgentId;
 
     // --- Webhook dispatch (AFTER transaction commits, fire-and-forget) ---
-    // Load assigned agent record if we have an assignedAgentId but no resolvedAgent
-    let agentForWebhook = resolvedAgent;
-    if (!agentForWebhook && assignedAgentId) {
+    // Always load the assigned agent's provenance (lyfeId/mktrLeadsId) by id — NOT
+    // the possibly-partial resolvedAgent from QR/group routing, which lacks it — so
+    // we route to the right app and send the destination-correct external id.
+    let agentForWebhook = null;
+    let leadDestination = null;
+    if (assignedAgentId) {
       const agentRecord = await m.User.findByPk(assignedAgentId, {
-        attributes: ['id', 'lyfeId', 'phone', 'email', 'firstName', 'lastName'],
+        attributes: ['id', 'lyfeId', 'mktrLeadsId', 'phone', 'email', 'firstName', 'lastName'],
       });
       if (agentRecord) {
+        leadDestination = destinationForAgent(agentRecord);
         agentForWebhook = {
-          phone: agentRecord.phone || null,
-          email: agentRecord.email || null,
-          name: `${agentRecord.firstName || ''} ${agentRecord.lastName || ''}`.trim(),
-          id: agentRecord.lyfeId || agentRecord.id,
+          phone: agentRecord.phone || resolvedAgent?.phone || null,
+          email: agentRecord.email || resolvedAgent?.email || null,
+          name: `${agentRecord.firstName || ''} ${agentRecord.lastName || ''}`.trim() || resolvedAgent?.name || null,
+          id: externalIdForDestination(agentRecord, leadDestination),
         };
       }
     }
@@ -598,7 +604,8 @@ export function makeProspectService(overrides = {}) {
           sourceCampaign,
           sourceQrTag,
           agentGroup
-        )
+        ),
+        { destination: leadDestination }
       ).catch((err) => {
         d.logger.error('[Webhook] dispatch error', { error: err?.message || String(err) });
       });
@@ -818,12 +825,20 @@ export function makeProspectService(overrides = {}) {
       // received a lead.created for it (the create webhook was suppressed), so an
       // unassigned event would reference a lead Lyfe does not know about.
       if (!prospect.quarantinedAt) {
-        let previousAgentLyfeId = previousAgentId;
+        // Destination + external id come from the PREVIOUS agent (the assignment
+        // is already null). Sourceless previous agent -> null -> default-denied.
+        let prevDestination = null;
+        let previousAgentExternalId = null;
         if (previousAgentId) {
-          const prevAgent = await m.User.findByPk(previousAgentId, { attributes: ['lyfeId'] });
-          if (prevAgent?.lyfeId) previousAgentLyfeId = prevAgent.lyfeId;
+          const prevAgent = await m.User.findByPk(previousAgentId, {
+            attributes: ['id', 'lyfeId', 'mktrLeadsId'],
+          });
+          prevDestination = destinationForAgent(prevAgent);
+          previousAgentExternalId = externalIdForDestination(prevAgent, prevDestination);
         }
-        d.dispatchEvent('lead.unassigned', () => buildLeadUnassignedPayload(prospect, previousAgentLyfeId));
+        d.dispatchEvent('lead.unassigned', () => buildLeadUnassignedPayload(prospect, previousAgentExternalId), {
+          destination: prevDestination,
+        });
       }
 
       return { prospect, agent: null, prospectWithCampaign: prospect };
@@ -889,14 +904,16 @@ export function makeProspectService(overrides = {}) {
         include: [{ association: 'campaign', attributes: ['id', 'name'] }],
       });
 
+      const releaseDestination = destinationForAgent(agent);
       const agentForWebhook = {
         phone: agent.phone || null,
         email: agent.email || null,
         name: `${agent.firstName || ''} ${agent.lastName || ''}`.trim(),
-        id: agent.lyfeId || agent.id,
+        id: externalIdForDestination(agent, releaseDestination),
       };
       d.dispatchEvent('lead.created', () =>
-        buildLeadCreatedPayload(prospect, 'direct', agentForWebhook, agentId, prospectWithCampaign?.campaign || null, null, null)
+        buildLeadCreatedPayload(prospect, 'direct', agentForWebhook, agentId, prospectWithCampaign?.campaign || null, null, null),
+        { destination: releaseDestination }
       );
 
       return { prospect, agent, prospectWithCampaign };
@@ -925,7 +942,9 @@ export function makeProspectService(overrides = {}) {
     });
 
     // Fire lead.assigned webhook
-    d.dispatchEvent('lead.assigned', () => buildLeadAssignedPayload(prospect, agent, prospectWithCampaign));
+    d.dispatchEvent('lead.assigned', () => buildLeadAssignedPayload(prospect, agent, prospectWithCampaign), {
+      destination: destinationForAgent(agent),
+    });
 
     return { prospect, agent, prospectWithCampaign };
   }

--- a/backend/src/services/retellService.js
+++ b/backend/src/services/retellService.js
@@ -9,6 +9,7 @@ import { sendLeadAssignmentEmail } from './mailer.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
 import { CircuitBreaker } from '../utils/circuitBreaker.js';
+import { destinationForAgent, externalIdForDestination } from './prospectHelpers.js';
 
 const IDEMPOTENCY_SCOPE = 'retell:call';
 const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -323,16 +324,18 @@ export function makeRetellService(overrides = {}) {
       // ── Fire outgoing webhooks (post-commit, fire-and-forget) ──
       // Look up assigned agent for routing info
       let agentForWebhook = null;
+      let retellDestination = null;
       if (assignedAgentId) {
         const agentRecord = await d.User.findByPk(assignedAgentId, {
-          attributes: ['id', 'lyfeId', 'phone', 'email', 'firstName', 'lastName'],
+          attributes: ['id', 'lyfeId', 'mktrLeadsId', 'phone', 'email', 'firstName', 'lastName'],
         });
         if (agentRecord) {
+          retellDestination = destinationForAgent(agentRecord);
           agentForWebhook = {
             phone: agentRecord.phone || null,
             email: agentRecord.email || null,
             name: `${agentRecord.firstName || ''} ${agentRecord.lastName || ''}`.trim(),
-            id: agentRecord.lyfeId || agentRecord.id,
+            id: externalIdForDestination(agentRecord, retellDestination),
           };
         }
       }
@@ -366,7 +369,7 @@ export function makeRetellService(overrides = {}) {
           source: 'retell_webhook',
           campaign: campaign ? { externalId: campaign.id, name: campaign.name } : null
         }
-      }));
+      }), { destination: retellDestination });
 
       // ── Email notification (fire-and-forget) ──
       const notifyAgent = quarantined

--- a/backend/src/services/webhookService.js
+++ b/backend/src/services/webhookService.js
@@ -69,7 +69,7 @@ export function makeWebhookService(overrides = {}) {
    * Dispatch an event to all active webhook subscribers.
    * Fire-and-forget — does not throw.
    */
-  async function dispatchEvent(eventType, payloadBuilder) {
+  async function dispatchEvent(eventType, payloadBuilder, options = {}) {
     if (String(process.env.WEBHOOK_ENABLED || 'false').toLowerCase() !== 'true') {
       return;
     }
@@ -80,10 +80,30 @@ export function makeWebhookService(overrides = {}) {
       });
 
       // Filter to subscribers interested in this event type
-      const matched = subscribers.filter(sub => {
+      let matched = subscribers.filter(sub => {
         const events = sub.events || [];
         return events.includes(eventType);
       });
+
+      // Destination-aware delivery: when a caller passes `destination`, deliver
+      // ONLY to subscribers tagged for that app (metadata.destination) so a lead's
+      // PII never crosses apps. A null/unknown destination is DEFAULT-DENIED (e.g.
+      // an assignee with no Lyfe/mktr-leads provenance, like the System Agent).
+      // Callers that omit `destination` keep the legacy event-type-only behaviour.
+      if ('destination' in options) {
+        const { destination } = options;
+        const eventMatchCount = matched.length;
+        matched = destination
+          ? matched.filter(sub => (sub.metadata?.destination || null) === destination)
+          : [];
+        if (eventMatchCount > 0 && matched.length === 0) {
+          d.logger.warn('[Webhook] lead_webhook_default_denied', {
+            event: 'lead_webhook_default_denied',
+            eventType,
+            destination: destination || null,
+          });
+        }
+      }
 
       if (matched.length === 0) {
         d.logger.debug('[Webhook] No active subscribers for event', { eventType });

--- a/backend/test/unit/inboundLeadQuota.test.js
+++ b/backend/test/unit/inboundLeadQuota.test.js
@@ -68,7 +68,7 @@ describe('retellService.processRetellCall (lead quota)', () => {
 
     expect(deps.Prospect.create.mock.calls[0][0]).toMatchObject({ assignedAgentId: 'agent-1', quarantinedAt: null });
     expect(deps.chargeLeadCredit).toHaveBeenCalledWith('agent-1', 'camp-1', deps.mockTx);
-    expect(deps.dispatchEvent).toHaveBeenCalledWith('lead.created', expect.any(Function));
+    expect(deps.dispatchEvent).toHaveBeenCalledWith('lead.created', expect.any(Function), expect.objectContaining({ destination: 'lyfe' }));
     expect(res.status).toBe('created');
   });
 
@@ -96,7 +96,7 @@ describe('retellService.processRetellCall (lead quota)', () => {
 
     expect(deps.Prospect.create.mock.calls[0][0].assignedAgentId).toBe('agent-1');
     expect(deps.chargeLeadCredit).not.toHaveBeenCalled();
-    expect(deps.dispatchEvent).toHaveBeenCalledWith('lead.created', expect.any(Function));
+    expect(deps.dispatchEvent).toHaveBeenCalledWith('lead.created', expect.any(Function), expect.objectContaining({ destination: 'lyfe' }));
     expect(res.status).toBe('created');
   });
 });
@@ -133,7 +133,7 @@ describe('metaLeadService.processMetaLead (lead quota)', () => {
 
     expect(deps.Prospect.create.mock.calls[0][0]).toMatchObject({ assignedAgentId: 'agent-1', quarantinedAt: null });
     expect(deps.chargeLeadCredit).toHaveBeenCalledWith('agent-1', 'camp-1', deps.mockTx);
-    expect(deps.dispatchEvent).toHaveBeenCalledWith('lead.created', expect.any(Function));
+    expect(deps.dispatchEvent).toHaveBeenCalledWith('lead.created', expect.any(Function), expect.objectContaining({ destination: 'lyfe' }));
     expect(res.status).toBe('created');
   });
 
@@ -160,7 +160,7 @@ describe('metaLeadService.processMetaLead (lead quota)', () => {
 
     expect(deps.Prospect.create.mock.calls[0][0].assignedAgentId).toBe('agent-1');
     expect(deps.chargeLeadCredit).not.toHaveBeenCalled();
-    expect(deps.dispatchEvent).toHaveBeenCalledWith('lead.created', expect.any(Function));
+    expect(deps.dispatchEvent).toHaveBeenCalledWith('lead.created', expect.any(Function), expect.objectContaining({ destination: 'lyfe' }));
     expect(res.status).toBe('created');
   });
 });

--- a/backend/test/unit/prospectAssignment.test.js
+++ b/backend/test/unit/prospectAssignment.test.js
@@ -204,7 +204,7 @@ describe('prospectAssignment (unit)', () => {
 
       await service.assignProspect('prospect-1', 'agent-1', admin);
 
-      expect(mocks.dispatchEvent).toHaveBeenCalledWith('lead.assigned', expect.any(Function));
+      expect(mocks.dispatchEvent).toHaveBeenCalledWith('lead.assigned', expect.any(Function), expect.objectContaining({ destination: 'lyfe' }));
     });
 
     it('fires lead.unassigned when agentId is null', async () => {
@@ -218,7 +218,7 @@ describe('prospectAssignment (unit)', () => {
 
       await service.assignProspect('prospect-1', null, admin);
 
-      expect(mocks.dispatchEvent).toHaveBeenCalledWith('lead.unassigned', expect.any(Function));
+      expect(mocks.dispatchEvent).toHaveBeenCalledWith('lead.unassigned', expect.any(Function), expect.objectContaining({ destination: 'lyfe' }));
     });
 
     it('deducts lead credit on assignment', async () => {
@@ -330,7 +330,7 @@ describe('prospectAssignment (unit)', () => {
 
       expect(mocks.sequelize.query).toHaveBeenCalled();
       expect(mocks.deductLeadCredit).toHaveBeenCalledWith('agent-1');
-      expect(mocks.dispatchEvent).toHaveBeenCalledWith('lead.created', expect.any(Function));
+      expect(mocks.dispatchEvent).toHaveBeenCalledWith('lead.created', expect.any(Function), expect.objectContaining({ destination: 'lyfe' }));
       expect(mocks.dispatchEvent).not.toHaveBeenCalledWith('lead.assigned', expect.any(Function));
     });
 
@@ -457,7 +457,7 @@ describe('prospectAssignment (unit)', () => {
       const body = { firstName: 'Test', campaignId: 'camp-1' };
       await service.createProspect(body, admin, {});
 
-      expect(mocks.dispatchEvent).toHaveBeenCalledWith('lead.created', expect.any(Function));
+      expect(mocks.dispatchEvent).toHaveBeenCalledWith('lead.created', expect.any(Function), expect.objectContaining({ destination: 'lyfe' }));
     });
 
     it('creates activity records for created + assigned', async () => {
@@ -509,7 +509,7 @@ describe('prospectAssignment (unit)', () => {
       expect(createArg.quarantinedAt).toBeNull();
       expect(mocks.chargeLeadCredit).toHaveBeenCalledWith('agent-1', 'camp-1', mocks.mockTransaction);
       expect(mocks.deductLeadCredit).not.toHaveBeenCalled(); // no double-charge
-      expect(mocks.dispatchEvent).toHaveBeenCalledWith('lead.created', expect.any(Function));
+      expect(mocks.dispatchEvent).toHaveBeenCalledWith('lead.created', expect.any(Function), expect.objectContaining({ destination: 'lyfe' }));
     });
 
     it('gated route + charge fails → quarantines: no agent, quarantinedAt set, no webhook, no deduct', async () => {
@@ -546,7 +546,7 @@ describe('prospectAssignment (unit)', () => {
       expect(createArg.assignedAgentId).toBe('agent-1');
       expect(mocks.chargeLeadCredit).not.toHaveBeenCalled();
       expect(mocks.deductLeadCredit).toHaveBeenCalledWith('agent-1', 1, mocks.mockTransaction);
-      expect(mocks.dispatchEvent).toHaveBeenCalledWith('lead.created', expect.any(Function));
+      expect(mocks.dispatchEvent).toHaveBeenCalledWith('lead.created', expect.any(Function), expect.objectContaining({ destination: 'lyfe' }));
     });
 
     it('logs a held activity (type updated) when quarantined', async () => {

--- a/backend/test/unit/prospectHelpers.test.js
+++ b/backend/test/unit/prospectHelpers.test.js
@@ -188,10 +188,11 @@ describe('prospectHelpers', () => {
       expect(payload.data.routing.agentExternalId).not.toBe('internal-id-123');
     });
 
-    it('falls back to agent.id when lyfeId is absent', () => {
+    it('returns null agentExternalId when the agent has no external provenance (never falls back to internal id)', () => {
       const agent = {
         id: 'internal-id-123',
         lyfeId: null,
+        mktrLeadsId: null,
         firstName: 'Agent',
         lastName: 'Smith',
         email: 'agent@test.com',
@@ -199,7 +200,25 @@ describe('prospectHelpers', () => {
       };
       const payload = buildLeadAssignedPayload(prospect, agent, null);
 
-      expect(payload.data.routing.agentExternalId).toBe('internal-id-123');
+      // The internal users.id is meaningless to receivers (→ guaranteed 422),
+      // so destination-aware routing emits null rather than falling back to it.
+      expect(payload.data.routing.agentExternalId).toBeNull();
+      expect(payload.data.routing.agentExternalId).not.toBe('internal-id-123');
+    });
+
+    it('uses mktrLeadsId as agentExternalId for an mktr-leads agent', () => {
+      const agent = {
+        id: 'internal-id-456',
+        lyfeId: null,
+        mktrLeadsId: 'ml-agent-9',
+        firstName: 'Ben',
+        lastName: 'Lim',
+        email: 'ben@test.com',
+        phone: '+6590000002',
+      };
+      const payload = buildLeadAssignedPayload(prospect, agent, null);
+
+      expect(payload.data.routing.agentExternalId).toBe('ml-agent-9');
     });
 
     it('constructs agentName from firstName + lastName', () => {

--- a/backend/test/unit/prospectService.test.js
+++ b/backend/test/unit/prospectService.test.js
@@ -548,7 +548,8 @@ describe('prospectService (unit)', () => {
 
       expect(mocks.dispatchEvent).toHaveBeenCalledWith(
         'lead.created',
-        expect.any(Function)
+        expect.any(Function),
+        expect.any(Object)
       );
 
       // Verify webhook payload structure
@@ -616,7 +617,8 @@ describe('prospectService (unit)', () => {
 
       expect(mocks.dispatchEvent).toHaveBeenCalledWith(
         'lead.assigned',
-        expect.any(Function)
+        expect.any(Function),
+        expect.objectContaining({ destination: 'lyfe' })
       );
 
       // Verify the payload uses lyfeId
@@ -645,7 +647,8 @@ describe('prospectService (unit)', () => {
 
       expect(mocks.dispatchEvent).toHaveBeenCalledWith(
         'lead.unassigned',
-        expect.any(Function)
+        expect.any(Function),
+        expect.objectContaining({ destination: 'lyfe' })
       );
 
       const builder = mocks.dispatchEvent.mock.calls[0][1];

--- a/backend/test/unit/retellService.test.js
+++ b/backend/test/unit/retellService.test.js
@@ -410,7 +410,8 @@ describe('retellService (unit)', () => {
 
       expect(mocks.dispatchEvent).toHaveBeenCalledWith(
         'lead.created',
-        expect.any(Function)
+        expect.any(Function),
+        expect.objectContaining({ destination: 'lyfe' })
       );
 
       // Invoke the payload builder to verify its structure

--- a/backend/test/unit/webhookDestinationRouting.test.js
+++ b/backend/test/unit/webhookDestinationRouting.test.js
@@ -1,0 +1,84 @@
+import { jest } from '@jest/globals';
+import '../setup.js';
+import { makeWebhookService } from '../../src/services/webhookService.js';
+import { destinationForAgent, externalIdForDestination } from '../../src/services/prospectHelpers.js';
+
+// ── Pure helpers ──
+describe('destinationForAgent / externalIdForDestination', () => {
+  it('maps lyfeId -> lyfe and returns the lyfeId', () => {
+    expect(destinationForAgent({ lyfeId: 'L1' })).toBe('lyfe');
+    expect(externalIdForDestination({ lyfeId: 'L1', id: 'U1' }, 'lyfe')).toBe('L1');
+  });
+
+  it('maps mktrLeadsId -> mktr_leads and returns the mktrLeadsId', () => {
+    expect(destinationForAgent({ mktrLeadsId: 'M1' })).toBe('mktr_leads');
+    expect(externalIdForDestination({ mktrLeadsId: 'M1', id: 'U1' }, 'mktr_leads')).toBe('M1');
+  });
+
+  it('returns null for a sourceless agent and NEVER falls back to the internal id', () => {
+    expect(destinationForAgent({ id: 'U1' })).toBeNull();
+    expect(destinationForAgent(null)).toBeNull();
+    expect(externalIdForDestination({ id: 'U1' }, null)).toBeNull();
+    expect(externalIdForDestination({ id: 'U1', lyfeId: null }, 'lyfe')).toBeNull();
+    expect(externalIdForDestination({ id: 'U1', mktrLeadsId: null }, 'mktr_leads')).toBeNull();
+  });
+});
+
+// ── dispatchEvent destination routing ──
+describe('dispatchEvent destination routing', () => {
+  const originalEnv = process.env.WEBHOOK_ENABLED;
+  let WebhookSubscriber, WebhookDelivery, logger, service;
+
+  const lyfeSub = { id: 'lyfe', name: 'Lyfe App', url: 'https://lyfe', secret: 's1', events: ['lead.created', 'lead.assigned', 'lead.unassigned'], enabled: true, metadata: { destination: 'lyfe' } };
+  const mktrSub = { id: 'mktr', name: 'MKTR Leads App', url: 'https://mktr', secret: 's2', events: ['lead.created', 'lead.assigned', 'lead.unassigned'], enabled: true, metadata: { destination: 'mktr_leads' } };
+
+  const builder = () => ({ event: 'lead.created', data: {} });
+
+  beforeEach(() => {
+    jest.useFakeTimers({ legacyFakeTimers: true });
+    process.env.WEBHOOK_ENABLED = 'true';
+    WebhookSubscriber = { findAll: jest.fn().mockResolvedValue([lyfeSub, mktrSub]) };
+    WebhookDelivery = { create: jest.fn().mockImplementation(async (data) => ({ ...data, update: jest.fn().mockResolvedValue(true) })) };
+    logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200, text: async () => 'ok', json: async () => ({}) });
+    service = makeWebhookService({ WebhookSubscriber, WebhookDelivery, logger, fetch: fetchMock });
+  });
+
+  afterEach(() => {
+    process.env.WEBHOOK_ENABLED = originalEnv;
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('delivers a lyfe-destined lead ONLY to the lyfe subscriber', async () => {
+    await service.dispatchEvent('lead.created', builder, { destination: 'lyfe' });
+    expect(WebhookDelivery.create).toHaveBeenCalledTimes(1);
+    expect(WebhookDelivery.create.mock.calls[0][0].subscriberId).toBe('lyfe');
+  });
+
+  it('delivers an mktr_leads-destined lead ONLY to the mktr-leads subscriber', async () => {
+    await service.dispatchEvent('lead.created', builder, { destination: 'mktr_leads' });
+    expect(WebhookDelivery.create).toHaveBeenCalledTimes(1);
+    expect(WebhookDelivery.create.mock.calls[0][0].subscriberId).toBe('mktr');
+  });
+
+  it('default-denies (no delivery + logs) when destination is null', async () => {
+    await service.dispatchEvent('lead.created', builder, { destination: null });
+    expect(WebhookDelivery.create).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[Webhook] lead_webhook_default_denied',
+      expect.objectContaining({ event: 'lead_webhook_default_denied', eventType: 'lead.created' })
+    );
+  });
+
+  it('omitting destination preserves legacy broadcast to all event-type matches', async () => {
+    await service.dispatchEvent('lead.created', builder); // no options object at all
+    expect(WebhookDelivery.create).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not deliver to a subscriber tagged for a different destination', async () => {
+    WebhookSubscriber.findAll.mockResolvedValue([lyfeSub]); // only Lyfe present
+    await service.dispatchEvent('lead.created', builder, { destination: 'mktr_leads' });
+    expect(WebhookDelivery.create).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Why

Today `dispatchEvent` broadcasts every lead webhook to **every** subscriber by event type alone. A second agent source is coming (mktr-leads agents mirrored into the same `users` pool, like Lyfe). With more than one downstream app subscribed, the current broadcast would deliver a lead's **PII to the wrong app**. This PR makes delivery destination-aware **without changing Lyfe's behaviour** — it ships first, ahead of the mktr-leads mirror, so there is never a PII-broadcast window.

This is **Part B** of the mktr-leads agent-mirror feature. Part A (the adapter + sync that actually populates `mktrLeadsId` and registers the mktr-leads subscriber) lands in a follow-up PR and is env-gated.

## What

- **`prospectHelpers`** — two pure helpers:
  - `destinationForAgent(user)` → `lyfeId` ? `'lyfe'` : `mktrLeadsId` ? `'mktr_leads'` : `null`
  - `externalIdForDestination(user, dest)` → the id the receiver matches on; **never** falls back to the internal `users.id` (which would guarantee a 422 + dropped lead at the receiver).
- **`webhookService.dispatchEvent(type, builder, { destination })`** — when `destination` is passed, deliver **only** to subscribers whose `metadata.destination` matches. A `null` destination is **default-denied** with a `lead_webhook_default_denied` warn log (e.g. an assignee with no provenance, like the System Agent). Callers that omit `destination` keep the legacy broadcast — fully backward-compatible.
- **All six dispatch sites** load the agent's provenance and thread `destination` + the destination-correct external id:
  - `prospectService` lead.created (round-robin **and** direct release), lead.assigned (reassign), lead.unassigned (derived from the **previous** agent, since the assignment is already null)
  - `retellService`, `metaLeadService`
- **`bootstrap`** — tag the Lyfe subscriber `metadata.destination = 'lyfe'` in **both** the create and update paths (the updater previously ignored `metadata`).
- **`User` model + migration 036** — add nullable unique `users.mktrLeadsId` with a CHECK `(lyfeId IS NULL OR mktrLeadsId IS NULL)` — one external provenance per user, so the two source syncs can't corrupt each other into an ambiguous dual-source row. Additive + nullable → safe rollback.

## Test

New `webhookDestinationRouting.test.js`:
- helper mapping (lyfe / mktr_leads / sourceless → null, no id fallback)
- dispatch filtering: lyfe-destined → only Lyfe sub; mktr_leads → only mktr-leads sub; null → no delivery + default-deny log; omitted → legacy broadcast; cross-destination → none.

`prospectService` + `retellService` dispatch assertions updated for the new options arg. Full affected-suite run: **121/122 pass**; the 1 failure (`verifyRetellSignature`) is **pre-existing on `main`** (confirmed against a clean `origin/main` checkout — unrelated HMAC test, part of the chronically-red CI), not a regression from this PR.

## Rollout note

Behaviour-preserving for Lyfe on its own. Before relying on a second destination: deploy this (filtering + Lyfe tagging) fully, run the preflight (count prospects whose assignee has no provenance → would now default-deny; confirm it's only System-Agent/orphans), then ship Part A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)