### PR TITLE
feat(agents): mirror mktr-leads agents into the local users pool (2nd source)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,3 +58,10 @@ LYFE_WEBHOOK_SECRET=           # Shared HMAC secret (must match MKTR_WEBHOOK_SEC
 # Lyfe Supabase (agent sync)
 LYFE_SUPABASE_URL=             # Supabase project URL
 LYFE_SUPABASE_SERVICE_ROLE_KEY= # Service-role key (bypasses RLS)
+
+# mktr-leads (second agent source — mirrored into `users` exactly like Lyfe).
+# All four OPTIONAL; unset = inert. Sync env-gated on MKTR_LEADS_SUPABASE_URL.
+MKTR_LEADS_SUPABASE_URL=             # Supabase project URL (mktr-leads `agents`)
+MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY= # Service-role key (bypasses RLS)
+MKTR_LEADS_WEBHOOK_URL=              # e.g. https://<project>.supabase.co/functions/v1/receive-mktr-lead
+MKTR_LEADS_WEBHOOK_SECRET=           # Shared HMAC secret (must match MKTR_WEBHOOK_SECRET in mktr-leads)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -214,6 +214,21 @@ LYFE_SUPABASE_URL=https://<project>.supabase.co
 LYFE_SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 # -----------------------------------------------------------------------------
+# mktr-leads (second agent source — mirrored into `users` exactly like Lyfe)
+# -----------------------------------------------------------------------------
+# All four are OPTIONAL: leave unset and mktr-leads is fully inert (no sync, no
+# subscriber). Set all four to enable. The agent sync is env-gated on
+# MKTR_LEADS_SUPABASE_URL; the outbound subscriber on the WEBHOOK_URL/SECRET pair.
+# Supabase project URL for fetching mktr-leads `agents` (role=agent, is_active)
+MKTR_LEADS_SUPABASE_URL=https://<project>.supabase.co
+# Service-role key (bypasses RLS — keep secret)
+MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+# Edge function URL for the mktr-leads receive-mktr-lead
+MKTR_LEADS_WEBHOOK_URL=https://<project>.supabase.co/functions/v1/receive-mktr-lead
+# Shared HMAC secret (must match MKTR_WEBHOOK_SECRET in the mktr-leads edge fn)
+MKTR_LEADS_WEBHOOK_SECRET=your-shared-webhook-secret
+
+# -----------------------------------------------------------------------------
 # Sentry Error Tracking (optional)
 # -----------------------------------------------------------------------------
 SENTRY_DSN=

--- a/backend/env.example
+++ b/backend/env.example
@@ -109,3 +109,10 @@ LYFE_WEBHOOK_SECRET=your-shared-webhook-secret
 # Lyfe Supabase (agent sync)
 LYFE_SUPABASE_URL=https://<project>.supabase.co
 LYFE_SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# mktr-leads (second agent source — mirrored into `users` exactly like Lyfe).
+# All four OPTIONAL; unset = inert. Sync env-gated on MKTR_LEADS_SUPABASE_URL.
+MKTR_LEADS_SUPABASE_URL=https://<project>.supabase.co
+MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+MKTR_LEADS_WEBHOOK_URL=https://<project>.supabase.co/functions/v1/receive-mktr-lead
+MKTR_LEADS_WEBHOOK_SECRET=your-shared-webhook-secret

--- a/backend/src/controllers/mktrLeadsAgentController.js
+++ b/backend/src/controllers/mktrLeadsAgentController.js
@@ -1,0 +1,25 @@
+import { asyncHandler, AppError } from '../middleware/errorHandler.js';
+import { syncAgentsFromMktrLeads } from '../services/agentSyncService.js';
+
+/**
+ * POST /api/mktr-leads/agents/sync
+ * Pull agents from the mktr-leads app into the local User table (mirrors the
+ * Lyfe sync). Admin-only. Returns 503 with a clear message when the mktr-leads
+ * env is not configured, instead of leaking the client's generic 500.
+ */
+export const syncAgents = asyncHandler(async (req, res) => {
+  if (!process.env.MKTR_LEADS_SUPABASE_URL || !process.env.MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY) {
+    throw new AppError(
+      'mktr-leads sync is not configured (set MKTR_LEADS_SUPABASE_URL and MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY)',
+      503
+    );
+  }
+  const { created, updated, deactivated, skipped, total, locked } = await syncAgentsFromMktrLeads();
+  res.json({
+    success: true,
+    message: locked === false
+      ? 'Another agent sync is already in progress — skipped'
+      : `Sync complete: ${created} created, ${updated} updated, ${deactivated} deactivated, ${skipped} unchanged`,
+    data: { created, updated, deactivated, skipped, total, locked: locked !== false },
+  });
+});

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -39,11 +39,16 @@ export async function bootstrapDatabase() {
     logger.info('System Agent ready', { systemId });
   });
   await safeRun('Lyfe webhook subscriber', ensureLyfeWebhookSubscriber);
+  await safeRun('mktr-leads webhook subscriber', ensureMktrLeadsWebhookSubscriber);
 
-  // Warn if Lyfe webhook is configured but delivery is disabled
+  // Warn if a destination webhook is configured but delivery is globally disabled
   const lyfeAdapter = adapterRegistry.get('lyfe');
   if (lyfeAdapter.outboundWebhookUrl?.() && String(process.env.WEBHOOK_ENABLED || 'false').toLowerCase() !== 'true') {
     logger.warn('⚠️ Lyfe webhook URL is set but WEBHOOK_ENABLED is not "true" — leads will NOT be delivered to Lyfe');
+  }
+  const mktrLeadsAdapter = adapterRegistry.get('mktr_leads');
+  if (mktrLeadsAdapter.outboundWebhookUrl?.() && String(process.env.WEBHOOK_ENABLED || 'false').toLowerCase() !== 'true') {
+    logger.warn('⚠️ mktr-leads webhook URL is set but WEBHOOK_ENABLED is not "true" — leads will NOT be delivered to mktr-leads');
   }
 
   await safeRun('Retell campaigns', ensureRetellCampaigns);
@@ -88,7 +93,19 @@ export async function bootstrapDatabase() {
           const { syncAgentsFromLyfe } = await import('../services/agentSyncService.js');
           await syncAgentsFromLyfe();
         } catch (err) {
-          logger.warn('[AgentSync] periodic sync failed (non-fatal)', { error: err?.message });
+          logger.warn('[AgentSync] periodic Lyfe sync failed (non-fatal)', { error: err?.message });
+        }
+        // mktr-leads is a second agent source — sync it too when configured.
+        // Run sequentially after Lyfe (not a separate timer) so the two never
+        // contend for the shared advisory lock; each has its own try/catch so a
+        // failure in one doesn't suppress the other.
+        if (process.env.MKTR_LEADS_SUPABASE_URL) {
+          try {
+            const { syncAgentsFromMktrLeads } = await import('../services/agentSyncService.js');
+            await syncAgentsFromMktrLeads();
+          } catch (err) {
+            logger.warn('[AgentSync] periodic mktr-leads sync failed (non-fatal)', { error: err?.message });
+          }
         }
       }, 10 * 60 * 1000); // every 10 min
       logger.info('[AgentSync] periodic sync scheduled (10 min interval)');
@@ -177,6 +194,60 @@ async function ensureLyfeWebhookSubscriber() {
   });
 
   logger.info('Lyfe webhook subscriber registered', { url });
+}
+
+/**
+ * Ensure the mktr-leads webhook subscriber exists so leads assigned to
+ * mktr-leads agents are forwarded to that app's receive-mktr-lead Edge
+ * Function. Tagged metadata.destination='mktr_leads' so the destination-aware
+ * dispatcher delivers ONLY mktr-leads-destined leads here. Env-gated: skips
+ * silently if the URL/secret aren't configured (mirrors the Lyfe subscriber).
+ */
+async function ensureMktrLeadsWebhookSubscriber() {
+  const adapter = adapterRegistry.get('mktr_leads');
+  const url = adapter.outboundWebhookUrl?.();
+  const secret = adapter.outboundWebhookSecret?.();
+
+  if (!url || !secret) {
+    logger.debug('mktr-leads webhook not configured (URL/secret missing on adapter), skipping.');
+    return;
+  }
+
+  const SUBSCRIBER_NAME = 'MKTR Leads App';
+  const requiredEvents = ['lead.created', 'lead.assigned', 'lead.unassigned'];
+
+  const existing = await WebhookSubscriber.findOne({ where: { name: SUBSCRIBER_NAME } });
+
+  if (existing) {
+    const needsUpdate = existing.url !== url || existing.secret !== secret || !existing.enabled
+      || JSON.stringify(existing.events?.sort()) !== JSON.stringify(requiredEvents.sort())
+      || existing.metadata?.destination !== 'mktr_leads';
+    if (needsUpdate) {
+      await existing.update({
+        url,
+        secret,
+        enabled: true,
+        events: requiredEvents,
+        metadata: { ...(existing.metadata || {}), destination: 'mktr_leads' },
+      });
+      logger.info('mktr-leads webhook subscriber updated', { url, events: requiredEvents });
+    } else {
+      logger.debug('mktr-leads webhook subscriber already registered', { url });
+    }
+    return;
+  }
+
+  await WebhookSubscriber.create({
+    name: SUBSCRIBER_NAME,
+    url,
+    secret,
+    events: requiredEvents,
+    enabled: true,
+    description: 'Forward leads to the mktr-leads app via Supabase Edge Function',
+    metadata: { destination: 'mktr_leads' },
+  });
+
+  logger.info('mktr-leads webhook subscriber registered', { url });
 }
 
 /**

--- a/backend/src/integrations/adapters/mktr-leads/MktrLeadsAdapter.js
+++ b/backend/src/integrations/adapters/mktr-leads/MktrLeadsAdapter.js
@@ -1,0 +1,52 @@
+/**
+ * @file MktrLeadsAdapter — implements PlatformAdapter for the mktr-leads
+ * Supabase project (a second agent source alongside Lyfe).
+ *
+ * Thin wrapper around mktrLeadsClient.js — same split as the Lyfe adapter so
+ * the wire layer (REST + breaker + cache) stays testable independently of the
+ * adapter contract.
+ *
+ * @see ../../PlatformAdapter.js for the interface.
+ */
+
+import * as mktrLeadsClient from './mktrLeadsClient.js';
+
+/** @type {import('../../PlatformAdapter.js').PlatformAdapter} */
+export const MktrLeadsAdapter = {
+  id: 'mktr_leads',
+
+  /**
+   * MKTR's local `users` table stores the mktr-leads upstream id (the
+   * `agents.mktr_user_id` text key) in the `mktrLeadsId` column. A DB CHECK
+   * keeps it mutually exclusive with `lyfeId` — one external source per user.
+   */
+  localIdField: 'mktrLeadsId',
+
+  async listAgents(filters) {
+    return mktrLeadsClient.fetchAgents(filters);
+  },
+
+  async getAgent(externalId) {
+    return mktrLeadsClient.fetchAgentById(externalId);
+  },
+
+  invalidateCache() {
+    mktrLeadsClient.invalidateCache();
+  },
+
+  /**
+   * Outbound webhook URL for the mktr-leads receive-mktr-lead edge function.
+   * Read from env each call so tests can override without re-importing.
+   */
+  outboundWebhookUrl() {
+    return process.env.MKTR_LEADS_WEBHOOK_URL || null;
+  },
+
+  /**
+   * HMAC-SHA256 secret for signing the outbound webhook body. Returns null if
+   * not configured; bootstrap treats null as "subscriber not configured, skip".
+   */
+  outboundWebhookSecret() {
+    return process.env.MKTR_LEADS_WEBHOOK_SECRET || null;
+  },
+};

--- a/backend/src/integrations/adapters/mktr-leads/index.js
+++ b/backend/src/integrations/adapters/mktr-leads/index.js
@@ -1,0 +1,16 @@
+/**
+ * @file mktr-leads adapter entry point.
+ *
+ * Importing this module side-effects: it self-registers `MktrLeadsAdapter` with
+ * `adapterRegistry`. Import from `backend/src/integrations/index.js` to ensure
+ * registration happens at app boot.
+ */
+
+import { adapterRegistry } from '../../AdapterRegistry.js';
+import { MktrLeadsAdapter } from './MktrLeadsAdapter.js';
+
+if (!adapterRegistry.has(MktrLeadsAdapter.id)) {
+  adapterRegistry.register(MktrLeadsAdapter);
+}
+
+export { MktrLeadsAdapter };

--- a/backend/src/integrations/adapters/mktr-leads/mktrLeadsClient.js
+++ b/backend/src/integrations/adapters/mktr-leads/mktrLeadsClient.js
@@ -1,0 +1,167 @@
+/**
+ * @file mktrLeadsClient — low-level mktr-leads Supabase REST + breaker + cache.
+ *
+ * mktr-leads is a second agent source alongside Lyfe (separate Supabase
+ * project). Its agents are lead-workers stored in a public `agents` table keyed
+ * by `mktr_user_id` (the id its receive-mktr-lead edge function matches on).
+ *
+ * Owns:
+ *   - MKTR_LEADS_SUPABASE_URL / MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY env reading
+ *   - Per-platform circuit breaker (failure threshold 5, reset 60s)
+ *   - 5-minute TTL cache on listAgents and getAgentById results
+ *   - mktr-leads `agents` row → ExternalAgent normalisation
+ *
+ * Mirrors lyfeClient.js. Higher-level orchestration (User upserts, deactivation,
+ * one-source-per-user safety) lives in agentSyncService.js — kept platform-
+ * agnostic via the generic runSync.
+ */
+
+import { CircuitBreaker } from '../../../utils/circuitBreaker.js';
+import { AppError } from '../../../middleware/errorHandler.js';
+import { logger } from '../../../utils/logger.js';
+
+// Per-platform breaker. Failures here don't trip Lyfe's breaker.
+const breaker = new CircuitBreaker(
+  async (url, headers) => {
+    const response = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(`mktr-leads Supabase error: ${response.status} ${body}`);
+    }
+    return response.json();
+  },
+  { name: 'mktr-leads-supabase', failureThreshold: 5, resetTimeoutMs: 60_000 }
+);
+
+// Per-platform TTL cache.
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const cache = new Map();
+
+function getCached(key) {
+  const entry = cache.get(key);
+  if (entry && Date.now() - entry.timestamp < CACHE_TTL_MS) return entry.data;
+  cache.delete(key);
+  return null;
+}
+
+function setCache(key, data) {
+  cache.set(key, { data, timestamp: Date.now() });
+}
+
+export function invalidateCache() {
+  cache.clear();
+}
+
+function getConfig() {
+  const url = process.env.MKTR_LEADS_SUPABASE_URL;
+  const key = process.env.MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new AppError(
+      'MKTR_LEADS_SUPABASE_URL and MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY must be configured',
+      500
+    );
+  }
+  return { url: url.replace(/\/$/, ''), key };
+}
+
+function authHeaders(key) {
+  return {
+    apikey: key,
+    Authorization: `Bearer ${key}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+/**
+ * Normalise an mktr-leads `agents` row into the platform-agnostic ExternalAgent
+ * shape defined by PlatformAdapter.
+ *
+ * externalId = `mktr_user_id` (NOT the auth `id`): that is the key the
+ * mktr-leads receiver matches `routing.agentExternalId` against.
+ */
+function toExternalAgent(row) {
+  return {
+    externalId: row.mktr_user_id,
+    fullName: row.full_name ?? null,
+    email: row.email ?? null,
+    phone: row.phone ?? null,
+    externalRole: row.role,
+    isActive: row.is_active !== false,
+    avatarUrl: null,
+    dateOfBirth: null,
+    createdAt: row.created_at ?? null,
+    raw: row,
+  };
+}
+
+const SELECT_COLUMNS = 'mktr_user_id,full_name,email,phone,role,is_active,created_at';
+
+/**
+ * Fetch all assignable mktr-leads agents.
+ *
+ * Filters `role=eq.agent` and `is_active=eq.true` AT THE SOURCE — this is
+ * mandatory, not cosmetic: the generic runSync trusts the returned list (it
+ * ignores `isActive`, creates local rows active), and mktr-leads has an `admin`
+ * role that must never become an assignable MKTR agent. An agent who goes
+ * inactive (or is promoted to admin) drops out of this list, so runSync's
+ * deactivation step retires the local row — exactly how Lyfe behaves.
+ */
+export async function fetchAgents() {
+  const cacheKey = 'agents';
+  const cached = getCached(cacheKey);
+  if (cached) return cached;
+
+  const { url, key } = getConfig();
+
+  let rows;
+  try {
+    rows = await breaker.fire(
+      `${url}/rest/v1/agents?role=eq.agent&is_active=eq.true&select=${SELECT_COLUMNS}&order=full_name`,
+      authHeaders(key)
+    );
+  } catch (err) {
+    logger.error({ err, breaker: breaker.getState() }, '[MktrLeadsAdapter] fetchAgents failed');
+    throw err;
+  }
+
+  const normalized = rows.map(toExternalAgent);
+  setCache(cacheKey, normalized);
+  return normalized;
+}
+
+/**
+ * Fetch one agent by externalId (mktr_user_id). Throws if not found. Uses cache.
+ *
+ * @param {string} externalId
+ */
+export async function fetchAgentById(externalId) {
+  const cacheKey = `agent:${externalId}`;
+  const cached = getCached(cacheKey);
+  if (cached) return cached;
+
+  const { url, key } = getConfig();
+
+  let rows;
+  try {
+    rows = await breaker.fire(
+      `${url}/rest/v1/agents?mktr_user_id=eq.${encodeURIComponent(externalId)}&select=${SELECT_COLUMNS}`,
+      authHeaders(key)
+    );
+  } catch (err) {
+    logger.error({ err, breaker: breaker.getState() }, '[MktrLeadsAdapter] fetchAgentById failed');
+    throw err;
+  }
+
+  if (!rows.length) throw new Error(`Agent not found in mktr-leads: ${externalId}`);
+  const normalized = toExternalAgent(rows[0]);
+  setCache(cacheKey, normalized);
+  return normalized;
+}
+
+/** Exposed for tests + observability. */
+export function _getBreakerState() {
+  return breaker.getState();
+}

--- a/backend/src/integrations/index.js
+++ b/backend/src/integrations/index.js
@@ -4,9 +4,11 @@
  * Import this once at app boot (server_internal.js or bootstrap.js) so all
  * adapters are registered before any service tries to look them up.
  *
- * Phase 1: only Lyfe is registered. Adding a platform = adding an import.
+ * Adding a platform = adding an import. mktr-leads self-registers regardless of
+ * env config; sync/dispatch for it stay no-ops until its env vars are set.
  */
 
 import './adapters/lyfe/index.js';
+import './adapters/mktr-leads/index.js';
 
 export { adapterRegistry } from './AdapterRegistry.js';

--- a/backend/src/middleware/internalRouteHostGuard.js
+++ b/backend/src/middleware/internalRouteHostGuard.js
@@ -18,6 +18,7 @@ const BLOCKED_PATH_PREFIXES = [
   '/api/devices',
   '/api/users',
   '/api/lyfe',
+  '/api/mktr-leads',
   '/api/webhooks',
   '/api/integrations',
 ];

--- a/backend/src/routes/mktrLeadsAgents.js
+++ b/backend/src/routes/mktrLeadsAgents.js
@@ -1,0 +1,15 @@
+import express from 'express';
+import { authenticateToken, requireAdmin } from '../middleware/auth.js';
+import { syncAgents } from '../controllers/mktrLeadsAgentController.js';
+
+export const meta = { path: '/api/mktr-leads' };
+
+const router = express.Router();
+
+router.use(authenticateToken, requireAdmin);
+
+// Manual on-demand sync of mktr-leads agents → local User table. The 10-min
+// cron in bootstrap covers the steady state; this is for first rollout + ops.
+router.post('/agents/sync', syncAgents);
+
+export default router;

--- a/backend/src/services/agentSyncService.js
+++ b/backend/src/services/agentSyncService.js
@@ -39,6 +39,17 @@ const SYNC_DRIFT_DEACTIVATION_RATIO = 0.2;
 // Per FMEA F09 — closes the read-then-delete race.
 const DELETE_GRACE_HOURS = 24;
 
+// Every external-provenance column on `users`. One source per user is enforced
+// by a DB CHECK (lyfeId IS NULL OR mktrLeadsId IS NULL); the sync reads BOTH so
+// it can detect a phone/email match that would cross sources and skip it.
+const PROVENANCE_FIELDS = ['lyfeId', 'mktrLeadsId'];
+
+// Single shared advisory lock across ALL agent syncs (Lyfe + mktr-leads). Both
+// mutate the same `users` table and the cross-source conflict check reads rows
+// owned by the other source, so the two syncs must never run concurrently — a
+// shared key (not per-adapter) serialises them. Stable across sessions, per-DB.
+const ADVISORY_LOCK_KEY = 'agent_sync';
+
 // ─── Backwards-compat exports ──────────────────────────────────────────────
 // Existing callers (lyfeAgentController, prospectService, etc.) import these
 // names directly. Keep them working as thin shims to the Lyfe adapter so we
@@ -85,32 +96,46 @@ function toLegacyShape(externalAgent) {
   };
 }
 
+/**
+ * One-source-per-user guard (pure). Given a local `users` row matched during a
+ * sync, return the name of a CONFLICTING provenance column — the other source's
+ * id is already set, so attaching this source's id would violate the
+ * single-provenance CHECK and create an ambiguous dual-source row — or null if
+ * the row is safe to attach.
+ *
+ * An externalId match is same-source and always safe (null). Only a phone/email
+ * match onto a row owned by a different source is a conflict.
+ *
+ * @param {object|null} existing               matched local user row
+ * @param {boolean}     matchedByExternalId     true if matched via this source's id
+ * @param {string[]}    otherProvenanceFields   provenance columns of OTHER sources
+ * @returns {string|null} conflicting field name, or null if safe to attach
+ */
+export function provenanceConflictField(existing, matchedByExternalId, otherProvenanceFields) {
+  if (!existing || matchedByExternalId) return null;
+  return otherProvenanceFields.find((f) => existing[f]) || null;
+}
+
 // ─── Sync orchestrator ─────────────────────────────────────────────────────
 
 /**
- * Sync agents from Lyfe into the local User table.
+ * Run one adapter's sync under the shared advisory lock.
  *
- * Find-or-creates local users (matched by lyfeId → phone → email),
- * updates stale records, deactivates agents no longer present upstream.
+ * ─── Concurrency guard (FMEA F08) ────────────────────────────────────
+ * Prevents two orchestrator runs from racing — e.g. the Lyfe cron firing while
+ * the mktr-leads cron (or a manual /api/.../agents/sync request) is in flight.
+ * The hashtext-based key is stable across sessions, scoped per-DB, and SHARED
+ * across all sources so the two syncs never mutate `users` concurrently.
+ * Returns cleanly with `locked:false` if another session holds it, so a
+ * cron-triggered run doesn't spam errors during manual ops.
  *
- * Phase 1: hard-coded to the 'lyfe' adapter. Phase 3 generalises this to
- * iterate over `adapterRegistry.list()` once a platform_id column exists
- * on `users` to disambiguate origin.
- *
- * @returns {Promise<{ created: number, updated: number, deactivated: number, skipped: number, total: number }>}
+ * @returns {Promise<{ created: number, updated: number, deactivated: number, hardDeleted: number, skipped: number, total: number, locked?: boolean }>}
  */
-export async function syncAgentsFromLyfe() {
-  const adapter = adapterRegistry.get('lyfe');
+async function syncWithLock(adapterId) {
+  const adapter = adapterRegistry.get(adapterId);
   const localIdField = adapter.localIdField;
   const startedAt = Date.now();
 
-  // ─── Concurrency guard (FMEA F08) ────────────────────────────────────
-  // Prevents two orchestrator runs from racing — e.g., the periodic cron
-  // firing while a manual /api/lyfe/agents/sync request is in flight. The
-  // hashtext-based key is stable across sessions, scoped per-DB.
-  // Returns false if another session holds the lock; we exit cleanly and
-  // log so the cron-triggered run doesn't spam errors during manual ops.
-  const ADVISORY_LOCK_KEY = 'agent_sync';
   const [{ locked }] = await sequelize.query(
     `SELECT pg_try_advisory_lock(hashtext(:key)) AS locked`,
     { replacements: { key: ADVISORY_LOCK_KEY }, type: sequelize.QueryTypes.SELECT }
@@ -137,6 +162,31 @@ export async function syncAgentsFromLyfe() {
 }
 
 /**
+ * Sync agents from Lyfe into the local User table.
+ *
+ * Find-or-creates local users (matched by lyfeId → phone → email),
+ * updates stale records, deactivates agents no longer present upstream.
+ *
+ * @returns {Promise<{ created: number, updated: number, deactivated: number, skipped: number, total: number }>}
+ */
+export async function syncAgentsFromLyfe() {
+  return syncWithLock('lyfe');
+}
+
+/**
+ * Sync agents from mktr-leads into the local User table — same contract as
+ * {@link syncAgentsFromLyfe}, keyed on `mktrLeadsId`. Shares the advisory lock
+ * so it never races the Lyfe sync. A phone/email match onto a Lyfe-owned row is
+ * SKIPPED (one source per user), never merged. Throws if the mktr-leads env is
+ * not configured (the client raises a 500) — callers env-gate before invoking.
+ *
+ * @returns {Promise<{ created: number, updated: number, deactivated: number, skipped: number, total: number }>}
+ */
+export async function syncAgentsFromMktrLeads() {
+  return syncWithLock('mktr_leads');
+}
+
+/**
  * Inner sync — assumes the caller already holds the advisory lock.
  * Split from `syncAgentsFromLyfe` so the outer wrapper can guarantee
  * lock release via try/finally without indenting 200 lines.
@@ -153,7 +203,9 @@ async function runSync(adapter, localIdField, startedAt) {
     allAgents = await User.findAll({
       where: { role: 'agent' },
       attributes: [
-        'id', localIdField, 'phone', 'email', 'firstName', 'lastName',
+        // Both provenance fields (not just localIdField) so the loop can detect
+        // a phone/email match that would cross sources and skip it.
+        'id', ...PROVENANCE_FIELDS, 'phone', 'email', 'firstName', 'lastName',
         'fullName', 'isActive', 'external_role', 'pending_deletion_at',
       ],
     });
@@ -168,11 +220,15 @@ async function runSync(adapter, localIdField, startedAt) {
     throw err;
   }
 
+  // byExternalId keys on THIS source's id only, so an externalId match is
+  // always same-source and safe to merge. The other source's column(s) are the
+  // ones a phone/email match must not collide with.
   const byExternalId = new Map(
     allAgents.filter((a) => a[localIdField]).map((a) => [a[localIdField], a])
   );
   const byPhone = new Map(allAgents.filter((a) => a.phone).map((a) => [a.phone, a]));
   const byEmail = new Map(allAgents.filter((a) => a.email).map((a) => [a.email.toLowerCase(), a]));
+  const otherProvenanceFields = PROVENANCE_FIELDS.filter((f) => f !== localIdField);
 
   let created = 0;
   let updated = 0;
@@ -185,10 +241,38 @@ async function runSync(adapter, localIdField, startedAt) {
     }
 
     const normalizedPhone = ea.phone ? String(ea.phone).replace(/\D/g, '') : null;
-    let existing =
-      (ea.externalId ? byExternalId.get(String(ea.externalId)) : null) ||
+    const externalIdMatch = ea.externalId ? byExternalId.get(String(ea.externalId)) : null;
+    const phoneEmailMatch =
       (normalizedPhone ? byPhone.get(normalizedPhone) : null) ||
       (ea.email ? byEmail.get(ea.email.toLowerCase()) : null);
+    let existing = externalIdMatch || phoneEmailMatch;
+
+    // One-source-per-user (Codex review): a phone/email match that lands on a
+    // row already owned by a DIFFERENT external source must NOT be merged — it
+    // would violate the single-provenance CHECK and create an ambiguous
+    // dual-source row that each sync could then fight over (cross-source
+    // deactivation). An externalId match is same-source and exempt. Skip +
+    // structured-alert so the collision is visible without blocking the run.
+    const conflictingField = provenanceConflictField(existing, Boolean(externalIdMatch), otherProvenanceFields);
+    if (conflictingField) {
+      skipped++;
+      logger.warn(
+        {
+          event: 'agent_sync_provenance_conflict',
+          adapter: adapter.id,
+          localIdField,
+          conflictingField,
+          matchedUserId: existing.id,
+        },
+        `[AgentSync] upstream agent's phone/email matches a ${conflictingField}-owned user — skipping to preserve one-source-per-user`
+      );
+      Sentry.captureMessage('agent_sync_provenance_conflict', {
+        level: 'warning',
+        tags: { component: 'agent_sync', adapter: adapter.id },
+        extra: { conflictingField, matchedUserId: existing.id, localIdField },
+      });
+      continue;
+    }
 
     if (existing) {
       const updateData = {};

--- a/backend/test/integration/mktrLeadsAgentSync.test.js
+++ b/backend/test/integration/mktrLeadsAgentSync.test.js
@@ -1,0 +1,116 @@
+import { getApp, closeDb, createTestUser } from '../helpers.js';
+import { User } from '../../src/models/index.js';
+import { adapterRegistry } from '../../src/integrations/AdapterRegistry.js';
+import { syncAgentsFromMktrLeads } from '../../src/services/agentSyncService.js';
+
+/**
+ * Integration: mirror mktr-leads agents into local `users` (the second agent
+ * source). Requires Postgres (advisory lock + CHECK constraint + raw-SQL
+ * deactivation) — runs in CI alongside the other integration suites.
+ *
+ * One snapshot exercises every branch of the one-source-per-user sync:
+ *   - brand-new mktr-leads agent          → created with mktrLeadsId
+ *   - phone collision with a Lyfe agent    → SKIPPED, never merged (the flagged
+ *                                            safety: no dual-source row)
+ *   - already-mirrored agent (id match)    → kept active, not duplicated
+ *   - mirrored agent gone from upstream    → deactivated (only its own source)
+ *   - the Lyfe agent                       → untouched by the mktr-leads sync
+ */
+
+const RUN = String(Date.now()).slice(-6);
+const ID = {
+  keep: `M_keep_${RUN}`,
+  stale: `M_stale_${RUN}`,
+  fresh: `M_new_${RUN}`,
+  conflict: `M_conflict_${RUN}`,
+  lyfe: `L_${RUN}`,
+};
+const PHONE = {
+  lyfe: `6591${RUN}`, // the conflict agent reuses this
+  keep: `6593${RUN}`,
+  stale: `6592${RUN}`,
+  fresh: `6594${RUN}`,
+};
+
+let lyfeAgent, staleAgent, keepAgent;
+
+// Fake adapter: returns exactly the upstream snapshot we want, no network.
+const fakeAdapter = {
+  id: 'mktr_leads',
+  localIdField: 'mktrLeadsId',
+  invalidateCache() {},
+  async getAgent() {
+    return null;
+  },
+  async listAgents() {
+    return [
+      { externalId: ID.keep, fullName: 'Keep Agent', email: `keep-${RUN}@ml.test`, phone: PHONE.keep, externalRole: 'agent', isActive: true },
+      { externalId: ID.fresh, fullName: 'Fresh Agent', email: `fresh-${RUN}@ml.test`, phone: PHONE.fresh, externalRole: 'agent', isActive: true },
+      // Same phone as the Lyfe agent below → must be SKIPPED, not merged.
+      { externalId: ID.conflict, fullName: 'Conflict Agent', email: `conflict-${RUN}@ml.test`, phone: PHONE.lyfe, externalRole: 'agent', isActive: true },
+    ];
+  },
+};
+
+let result;
+
+beforeAll(async () => {
+  process.env.WEBHOOK_ENABLED = 'false';
+  await getApp();
+
+  // A Lyfe-owned agent — the conflict agent shares its phone.
+  ({ user: lyfeAgent } = await createTestUser({ role: 'agent', lyfeId: ID.lyfe, phone: PHONE.lyfe, firstName: 'Lyfe', lastName: 'Owned' }));
+  // An mktr-leads agent that upstream no longer returns → should deactivate.
+  ({ user: staleAgent } = await createTestUser({ role: 'agent', mktrLeadsId: ID.stale, phone: PHONE.stale, firstName: 'Stale', lastName: 'Mktr' }));
+  // An mktr-leads agent the snapshot still returns (externalId match).
+  ({ user: keepAgent } = await createTestUser({ role: 'agent', mktrLeadsId: ID.keep, phone: PHONE.keep, firstName: 'Keep', lastName: 'Mktr' }));
+
+  adapterRegistry.replace(fakeAdapter);
+  result = await syncAgentsFromMktrLeads();
+}, 30000);
+
+afterAll(async () => {
+  await closeDb();
+});
+
+describe('syncAgentsFromMktrLeads', () => {
+  it('creates a brand-new mktr-leads agent with mktrLeadsId set (and no lyfeId)', async () => {
+    const row = await User.findOne({ where: { mktrLeadsId: ID.fresh } });
+    expect(row).not.toBeNull();
+    expect(row.role).toBe('agent');
+    expect(row.lyfeId).toBeNull();
+    expect(row.isActive).toBe(true);
+  });
+
+  it('SKIPS a phone collision with a Lyfe agent — never merges (one source per user)', async () => {
+    // The Lyfe row keeps its provenance and gains NO mktrLeadsId.
+    const lyfe = await User.findByPk(lyfeAgent.id);
+    expect(lyfe.lyfeId).toBe(ID.lyfe);
+    expect(lyfe.mktrLeadsId).toBeNull();
+    // And no separate row was created for the conflicting upstream id.
+    const conflictRow = await User.findOne({ where: { mktrLeadsId: ID.conflict } });
+    expect(conflictRow).toBeNull();
+  });
+
+  it('keeps an already-mirrored agent active and does not duplicate it', async () => {
+    const rows = await User.findAll({ where: { mktrLeadsId: ID.keep } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(keepAgent.id);
+    expect(rows[0].isActive).toBe(true);
+  });
+
+  it('deactivates an mktr-leads agent that vanished upstream', async () => {
+    const stale = await User.findByPk(staleAgent.id);
+    expect(stale.isActive).toBe(false);
+  });
+
+  it('does NOT deactivate the Lyfe agent (cross-source isolation)', async () => {
+    const lyfe = await User.findByPk(lyfeAgent.id);
+    expect(lyfe.isActive).toBe(true);
+  });
+
+  it('reports the skip in its result counts', () => {
+    expect(result.locked).not.toBe(false);
+    expect(result.skipped).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/backend/test/unit/agentSyncProvenance.test.js
+++ b/backend/test/unit/agentSyncProvenance.test.js
@@ -1,0 +1,43 @@
+import '../setup.js';
+import { provenanceConflictField } from '../../src/services/agentSyncService.js';
+
+/**
+ * One-source-per-user guard (the Codex-flagged safety). When syncing one source
+ * (say mktr-leads, localIdField='mktrLeadsId'), the "other" provenance fields
+ * are ['lyfeId']. A phone/email match onto a row that already has lyfeId set is
+ * a conflict — attaching mktrLeadsId would create an ambiguous dual-source row.
+ */
+describe('provenanceConflictField', () => {
+  const OTHER = ['lyfeId']; // syncing mktr_leads → the other source is lyfe
+
+  it('flags a phone/email match onto a row owned by another source', () => {
+    const existing = { id: 'u1', lyfeId: 'L1', mktrLeadsId: null };
+    expect(provenanceConflictField(existing, false, OTHER)).toBe('lyfeId');
+  });
+
+  it('does NOT flag an externalId (same-source) match — that is safe to merge', () => {
+    const existing = { id: 'u1', lyfeId: 'L1', mktrLeadsId: null };
+    expect(provenanceConflictField(existing, true, OTHER)).toBeNull();
+  });
+
+  it('does NOT flag a clean (sourceless) phone/email match — safe to attach', () => {
+    const existing = { id: 'u1', lyfeId: null, mktrLeadsId: null };
+    expect(provenanceConflictField(existing, false, OTHER)).toBeNull();
+  });
+
+  it('does NOT flag a row that already belongs to THIS source', () => {
+    // Syncing mktr_leads, matched a row that already has mktrLeadsId but no
+    // lyfeId — not a cross-source conflict (the other-fields list excludes ours).
+    const existing = { id: 'u1', lyfeId: null, mktrLeadsId: 'M1' };
+    expect(provenanceConflictField(existing, false, OTHER)).toBeNull();
+  });
+
+  it('returns null when there is no match at all', () => {
+    expect(provenanceConflictField(null, false, OTHER)).toBeNull();
+  });
+
+  it('is symmetric — syncing lyfe flags an mktrLeadsId-owned row', () => {
+    const existing = { id: 'u1', lyfeId: null, mktrLeadsId: 'M1' };
+    expect(provenanceConflictField(existing, false, ['mktrLeadsId'])).toBe('mktrLeadsId');
+  });
+});

--- a/backend/test/unit/mktrLeadsAdapter.test.js
+++ b/backend/test/unit/mktrLeadsAdapter.test.js
@@ -1,0 +1,133 @@
+import { jest } from '@jest/globals';
+import '../setup.js';
+import * as client from '../../src/integrations/adapters/mktr-leads/mktrLeadsClient.js';
+import { MktrLeadsAdapter } from '../../src/integrations/adapters/mktr-leads/MktrLeadsAdapter.js';
+
+// mktr-leads `agents` rows as PostgREST would return them.
+const ROWS = [
+  {
+    mktr_user_id: 'mu_1',
+    full_name: 'Ada Tan',
+    email: 'ada@example.com',
+    phone: '6591234567',
+    role: 'agent',
+    is_active: true,
+    created_at: '2026-06-01T00:00:00Z',
+  },
+  {
+    mktr_user_id: 'mu_2',
+    full_name: 'Ben Lim',
+    email: null,
+    phone: '6598765432',
+    role: 'agent',
+    is_active: true,
+    created_at: '2026-06-02T00:00:00Z',
+  },
+];
+
+describe('mktrLeadsClient', () => {
+  const realFetch = global.fetch;
+  let fetchMock;
+
+  beforeEach(() => {
+    process.env.MKTR_LEADS_SUPABASE_URL = 'https://proj.supabase.co';
+    process.env.MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY = 'svc-key';
+    client.invalidateCache();
+    fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ROWS,
+      text: async () => '',
+    });
+    global.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    delete process.env.MKTR_LEADS_SUPABASE_URL;
+    delete process.env.MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY;
+  });
+
+  it('fetchAgents filters role=agent + is_active at the source and normalizes', async () => {
+    const agents = await client.fetchAgents();
+
+    const url = fetchMock.mock.calls[0][0];
+    expect(url).toContain('/rest/v1/agents?');
+    expect(url).toContain('role=eq.agent');
+    expect(url).toContain('is_active=eq.true');
+    expect(url).toContain('select=mktr_user_id,full_name,email,phone,role,is_active,created_at');
+
+    expect(agents).toHaveLength(2);
+    expect(agents[0]).toMatchObject({
+      externalId: 'mu_1', // the mktr_user_id, NOT an auth id
+      fullName: 'Ada Tan',
+      email: 'ada@example.com',
+      phone: '6591234567',
+      externalRole: 'agent',
+      isActive: true,
+      avatarUrl: null,
+      dateOfBirth: null,
+      createdAt: '2026-06-01T00:00:00Z',
+    });
+    expect(agents[1].email).toBeNull(); // do NOT synthesize
+  });
+
+  it('caches list results within TTL (no second fetch)', async () => {
+    await client.fetchAgents();
+    await client.fetchAgents();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetchAgentById queries by mktr_user_id and returns the normalized agent', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => [ROWS[0]], text: async () => '' });
+    const agent = await client.fetchAgentById('mu_1');
+    expect(fetchMock.mock.calls[0][0]).toContain('mktr_user_id=eq.mu_1');
+    expect(agent.externalId).toBe('mu_1');
+  });
+
+  it('fetchAgentById throws when the agent is absent', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => [], text: async () => '' });
+    await expect(client.fetchAgentById('nope')).rejects.toThrow(/not found in mktr-leads/);
+  });
+
+  it('throws a clear error when env is not configured', async () => {
+    delete process.env.MKTR_LEADS_SUPABASE_URL;
+    client.invalidateCache();
+    await expect(client.fetchAgents()).rejects.toThrow(/MKTR_LEADS_SUPABASE_URL/);
+  });
+});
+
+describe('MktrLeadsAdapter contract', () => {
+  const realFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    delete process.env.MKTR_LEADS_WEBHOOK_URL;
+    delete process.env.MKTR_LEADS_WEBHOOK_SECRET;
+  });
+
+  it('declares the mktr_leads identity and provenance column', () => {
+    expect(MktrLeadsAdapter.id).toBe('mktr_leads');
+    expect(MktrLeadsAdapter.localIdField).toBe('mktrLeadsId');
+  });
+
+  it('reads outbound webhook url/secret from env each call', () => {
+    expect(MktrLeadsAdapter.outboundWebhookUrl()).toBeNull();
+    expect(MktrLeadsAdapter.outboundWebhookSecret()).toBeNull();
+    process.env.MKTR_LEADS_WEBHOOK_URL = 'https://proj.supabase.co/functions/v1/receive-mktr-lead';
+    process.env.MKTR_LEADS_WEBHOOK_SECRET = 'shh';
+    expect(MktrLeadsAdapter.outboundWebhookUrl()).toBe('https://proj.supabase.co/functions/v1/receive-mktr-lead');
+    expect(MktrLeadsAdapter.outboundWebhookSecret()).toBe('shh');
+  });
+
+  it('listAgents delegates to the client', async () => {
+    process.env.MKTR_LEADS_SUPABASE_URL = 'https://proj.supabase.co';
+    process.env.MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY = 'svc-key';
+    client.invalidateCache();
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ROWS, text: async () => '' });
+    const agents = await MktrLeadsAdapter.listAgents();
+    expect(agents.map((a) => a.externalId)).toEqual(['mu_1', 'mu_2']);
+    delete process.env.MKTR_LEADS_SUPABASE_URL;
+    delete process.env.MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY;
+  });
+});


### PR DESCRIPTION
## Why

mktr-platform is a routing hub that **owns no agents** — it mirrors them from external apps into `users` (today only Lyfe). This adds **mktr-leads** (a separate Expo app + Supabase project) as a **second agent source**, treated **identically to Lyfe** per the confirmed decision: its agents join the same `users` agent pool, hold lead packages + round-robin the same way, credits deducted the same way, and their leads deliver to the **mktr-leads** app. This is **not** the external-buyer marketplace (that scaffolding stays unused).

**Stacked on #33** (destination-aware delivery) — this PR is the **A** half (mirror agents); #33 is the **B** half (route each lead to the right app). B must ship first so there's never a PII-broadcast window. Review/merge #33 first; GitHub will retarget this PR's base to `main` automatically.

## What

**Adapter** (mirrors the Lyfe adapter, behind the existing `PlatformAdapter`/`AdapterRegistry` abstraction):
- `integrations/adapters/mktr-leads/{MktrLeadsAdapter,mktrLeadsClient,index}.js`. Reads mktr-leads `agents` via service-role REST, filtering `role=eq.agent & is_active=eq.true` **at the source** — mandatory, because the generic `runSync` trusts the list (creates rows active, ignores `isActive`) and mktr-leads has an `admin` role that must never become an assignable agent. `externalId = mktr_user_id` (the key its `receive-mktr-lead` matches `routing.agentExternalId` against), **not** the auth id. Own circuit breaker + 5-min cache.
- Self-registers via `integrations/index.js` (id `mktr_leads`).

**Sync — one-source-per-user safety** (`agentSyncService.js`):
- `syncAgentsFromMktrLeads()` reuses the generic `runSync`, keyed on `mktrLeadsId`.
- A single **shared** advisory lock (`'agent_sync'`) now wraps **both** the Lyfe and mktr-leads syncs (`syncWithLock` helper), so they never mutate `users` concurrently.
- `provenanceConflictField()`: a phone/email match onto a row already owned by a **different** source is **skipped + structured-alerted, never merged** — prevents an ambiguous dual-source row (backed by the migration-036 CHECK from #33). An externalId match is same-source and exempt. `runSync` now loads **both** provenance columns to detect this.
- `bootstrap`: 10-min cron runs the mktr-leads sync **sequentially after Lyfe** (env-gated on `MKTR_LEADS_SUPABASE_URL`); admin `POST /api/mktr-leads/agents/sync` for on-demand runs; `/api/mktr-leads` added to `internalRouteHostGuard` (redeem.sg → 403, parity with `/api/lyfe`).

**Delivery**:
- `ensureMktrLeadsWebhookSubscriber` (`metadata.destination='mktr_leads'`, env-gated) so #33's destination-aware dispatcher routes mktr-leads-destined leads **here only**.

**Env** (all optional; unset = fully inert — no sync, no subscriber): `MKTR_LEADS_SUPABASE_URL`, `MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY`, `MKTR_LEADS_WEBHOOK_URL`, `MKTR_LEADS_WEBHOOK_SECRET` — documented in all three `env.example` files.

## Test

- `mktrLeadsAdapter.test.js` — client normalization (externalId=mktr_user_id, no email synthesis), URL filters (`role=eq.agent`, `is_active=eq.true`, select columns), caching, not-found, env-missing error; adapter contract + delegation. **Runs locally — passing.**
- `agentSyncProvenance.test.js` — the conflict guard in both directions (lyfe↔mktr_leads), same-source exemption, clean attach. **Runs locally — passing.**
- `test/integration/mktrLeadsAgentSync.test.js` — DB-backed snapshot covering create / phone-conflict-skip / externalId-match-no-dup / deactivate / cross-source isolation. **Requires Postgres → runs in CI** alongside the other integration suites (not runnable in this sandbox; verified import/compile-clean).

Full unit suite failing set is **identical to `main`'s pre-existing baseline** (5 chronically-red suites, unrelated) — no new regressions.

## mktr-leads repo
No code change — its agents are read via service-role REST and its existing `receive-mktr-lead` is reused. Cross-repo coupling = shared secrets only.

## Rollout
1. Merge #33 (filtering + Lyfe tagging), verify Lyfe delivery, run the preflight (count prospects whose assignee has no provenance → would default-deny; confirm only System-Agent/orphans).
2. Merge this PR.
3. Set the 4 `MKTR_LEADS_*` env vars → sync runs + the subscriber registers (ensure the #33 deploy is fully live first).
4. Lead-package an mktr-leads agent + verify E2E (test lead round-robins to them → `webhook_deliveries` shows dispatch ONLY to the mktr-leads subscriber → lands in mktr-leads `leads`; a Lyfe agent's lead still goes only to Lyfe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)