### PR TITLE
fix(agents): hold agent-sync advisory lock in a transaction (was leaking across pool connections)

### DIFF
--- a/backend/src/services/agentSyncService.js
+++ b/backend/src/services/agentSyncService.js
@@ -129,6 +129,16 @@ export function provenanceConflictField(existing, matchedByExternalId, otherProv
  * Returns cleanly with `locked:false` if another session holds it, so a
  * cron-triggered run doesn't spam errors during manual ops.
  *
+ * The lock is held for the lifetime of a TRANSACTION (`pg_try_advisory_xact_lock`)
+ * so it is bound to a single connection and auto-released on commit/rollback.
+ * The previous session-level `pg_advisory_lock` + manual `pg_advisory_unlock`
+ * leaked under Sequelize's connection pool: the unlock frequently ran on a
+ * DIFFERENT pooled connection than the acquire, so it was a no-op and the lock
+ * stayed held. That made the mktr-leads sync skip with `lock_held` when it ran
+ * right after the Lyfe sync on the same cron tick. runSync's own reads/writes
+ * use pool connections (committed independently); lockTx exists only to hold the
+ * lock for the duration.
+ *
  * @returns {Promise<{ created: number, updated: number, deactivated: number, hardDeleted: number, skipped: number, total: number, locked?: boolean }>}
  */
 async function syncWithLock(adapterId) {
@@ -136,29 +146,22 @@ async function syncWithLock(adapterId) {
   const localIdField = adapter.localIdField;
   const startedAt = Date.now();
 
-  const [{ locked }] = await sequelize.query(
-    `SELECT pg_try_advisory_lock(hashtext(:key)) AS locked`,
-    { replacements: { key: ADVISORY_LOCK_KEY }, type: sequelize.QueryTypes.SELECT }
-  );
-  if (!locked) {
-    logger.info(
-      { event: 'agent_sync_skipped', adapter: adapter.id, reason: 'lock_held' },
-      '[AgentSync] another sync run is in progress — skipping'
+  return await sequelize.transaction(async (lockTx) => {
+    const [{ locked }] = await sequelize.query(
+      `SELECT pg_try_advisory_xact_lock(hashtext(:key)) AS locked`,
+      { replacements: { key: ADVISORY_LOCK_KEY }, type: sequelize.QueryTypes.SELECT, transaction: lockTx }
     );
-    return { created: 0, updated: 0, deactivated: 0, hardDeleted: 0, skipped: 0, total: 0, locked: false };
-  }
+    if (!locked) {
+      logger.info(
+        { event: 'agent_sync_skipped', adapter: adapter.id, reason: 'lock_held' },
+        '[AgentSync] another sync run is in progress — skipping'
+      );
+      return { created: 0, updated: 0, deactivated: 0, hardDeleted: 0, skipped: 0, total: 0, locked: false };
+    }
 
-  try {
+    // Lock auto-releases when this transaction commits (or rolls back on throw).
     return await runSync(adapter, localIdField, startedAt);
-  } finally {
-    // Always release the advisory lock, even if runSync throws.
-    await sequelize.query(
-      `SELECT pg_advisory_unlock(hashtext(:key))`,
-      { replacements: { key: ADVISORY_LOCK_KEY } }
-    ).catch((err) => {
-      logger.warn({ err, lockKey: ADVISORY_LOCK_KEY }, '[AgentSync] failed to release advisory lock');
-    });
-  }
+  });
 }
 
 /**

--- a/backend/test/integration/mktrLeadsAgentSync.test.js
+++ b/backend/test/integration/mktrLeadsAgentSync.test.js
@@ -113,4 +113,16 @@ describe('syncAgentsFromMktrLeads', () => {
     expect(result.locked).not.toBe(false);
     expect(result.skipped).toBeGreaterThanOrEqual(1);
   });
+
+  it('runs back-to-back without the advisory lock leaking (regression: lock_held skip)', async () => {
+    // Under the old session-level pg_advisory_lock, the acquire and the manual
+    // pg_advisory_unlock could land on different pooled connections, so the lock
+    // leaked and a sync running immediately after another (the Lyfe→mktr-leads
+    // cron pattern) skipped with locked:false. The transaction-scoped
+    // pg_try_advisory_xact_lock auto-releases on commit, so both runs acquire.
+    const first = await syncAgentsFromMktrLeads();
+    const second = await syncAgentsFromMktrLeads();
+    expect(first.locked).not.toBe(false);
+    expect(second.locked).not.toBe(false);
+  });
 });


### PR DESCRIPTION
## Symptom

After deploying the mktr-leads agent mirror (#35), the mktr-leads sync **skipped every cron tick** with `lock_held`, so its agents never mirrored into `users`. Logs:

```
10:54:51.382  agent_sync_complete  adapter=lyfe        (9 agents)
10:54:51.555  agent_sync_skipped   adapter=mktr_leads  reason=lock_held  ← never read its agents
```

## Root cause

`syncWithLock` used a **session-level** `pg_advisory_lock` + a manual `pg_advisory_unlock` in `finally`. Under Sequelize's connection **pool**, each `sequelize.query` checks out an arbitrary connection — so the unlock frequently ran on a *different* connection than the acquire, making it a no-op (session advisory locks only release on the owning session). The lock **leaked** on the acquiring session.

The Lyfe sync got away with it because the next run is 10 min later (connection recycled by then). But this PR's parent chained the mktr-leads sync to run **immediately after** the Lyfe sync on the same cron tick — so the leaked lock was still held 170ms later, and mktr-leads skipped before it ever called its adapter.

## Fix

Hold the lock for the lifetime of a **transaction** via `pg_try_advisory_xact_lock`, which binds it to a single connection and **auto-releases on commit/rollback** — no manual unlock, no cross-connection leak. `runSync`'s own reads/writes still run on pool connections (committed independently); the transaction exists only to hold the lock. Applies to both the Lyfe and mktr-leads syncs (shared helper).

Pool is `max: 10`, so holding one connection for the ~sub-second sync is comfortable.

## Test

Adds an integration regression: two back-to-back `syncAgentsFromMktrLeads()` calls must both acquire the lock (`locked !== false`). Under the old session-lock the second skipped. Unit suites unchanged + green.

## After merge
Deploy → the next cron tick (or a manual `POST /api/mktr-leads/agents/sync`) will actually read mktr-leads and mirror its active agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)