### PR TITLE
fix(agents): mirror mktr-leads is_active instead of treating inactive as deleted

### DIFF
--- a/backend/src/integrations/PlatformAdapter.js
+++ b/backend/src/integrations/PlatformAdapter.js
@@ -57,6 +57,9 @@
  * @property {boolean} isActive      Upstream active flag. Inactive agents
  *                                   are still listed so the orchestrator
  *                                   can deactivate locally.
+ * @property {string|null} [agency]  Upstream agency/company name (mktr-leads).
+ *                                   Mirrored to users.companyName by adapters
+ *                                   that declare `authoritativeProfile`.
  * @property {string|null} avatarUrl
  * @property {string|null} dateOfBirth
  * @property {string|null} createdAt ISO timestamp; informational.
@@ -83,6 +86,19 @@
  * @property {(externalId: string) => Promise<ExternalAgent>} getAgent
  *   Fetches one agent. Throws if not found. Used by lead-routing on the
  *   hot path; should be cached aggressively (TTL ~5 min).
+ *
+ * @property {boolean} [mirrorsIsActive]
+ *   Optional. When true, listAgents() returns active AND inactive rows and the
+ *   sync mirrors each row's isActive locally; only rows truly absent from the
+ *   list are treated as deleted (deactivation/two-phase delete). When falsy
+ *   (Lyfe legacy), listAgents() returns the active roster only and absence
+ *   implies inactive.
+ *
+ * @property {boolean} [authoritativeProfile]
+ *   Optional. When true, the sync OVERWRITES profile fields (fullName + derived
+ *   first/last, email, companyName←agency) on this adapter's rows so upstream
+ *   edits propagate. When falsy (Lyfe legacy), the sync only fills null/
+ *   placeholder fields.
  *
  * @property {() => void} [invalidateCache]
  *   Optional. Clears any internal cache. Called after manual sync runs.

--- a/backend/src/integrations/adapters/mktr-leads/MktrLeadsAdapter.js
+++ b/backend/src/integrations/adapters/mktr-leads/MktrLeadsAdapter.js
@@ -22,6 +22,22 @@ export const MktrLeadsAdapter = {
    */
   localIdField: 'mktrLeadsId',
 
+  /**
+   * listAgents returns ACTIVE AND INACTIVE rows; runSync mirrors each row's
+   * is_active locally instead of treating "not in the fetched set" as gone.
+   * Without this, deactivating an agent in mktr-leads would look like deletion
+   * → two-phase hard-delete → CASCADE wipes their lead-package assignments.
+   */
+  mirrorsIsActive: true,
+
+  /**
+   * mktr-leads is the source of truth for agent profile fields: runSync
+   * OVERWRITES fullName/email/companyName(agency) on its rows (vs the Lyfe
+   * fill-only-when-null behaviour), so edits made in mktr-leads — including via
+   * the admin write-back endpoints — propagate and self-heal.
+   */
+  authoritativeProfile: true,
+
   async listAgents(filters) {
     return mktrLeadsClient.fetchAgents(filters);
   },

--- a/backend/src/integrations/adapters/mktr-leads/mktrLeadsClient.js
+++ b/backend/src/integrations/adapters/mktr-leads/mktrLeadsClient.js
@@ -90,6 +90,7 @@ function toExternalAgent(row) {
     phone: row.phone ?? null,
     externalRole: row.role,
     isActive: row.is_active !== false,
+    agency: row.agency ?? null,
     avatarUrl: null,
     dateOfBirth: null,
     createdAt: row.created_at ?? null,
@@ -97,17 +98,21 @@ function toExternalAgent(row) {
   };
 }
 
-const SELECT_COLUMNS = 'mktr_user_id,full_name,email,phone,role,is_active,created_at';
+const SELECT_COLUMNS = 'mktr_user_id,full_name,email,phone,role,is_active,agency,created_at';
 
 /**
- * Fetch all assignable mktr-leads agents.
+ * Fetch ALL mktr-leads agents — active AND inactive.
  *
- * Filters `role=eq.agent` and `is_active=eq.true` AT THE SOURCE — this is
- * mandatory, not cosmetic: the generic runSync trusts the returned list (it
- * ignores `isActive`, creates local rows active), and mktr-leads has an `admin`
- * role that must never become an assignable MKTR agent. An agent who goes
- * inactive (or is promoted to admin) drops out of this list, so runSync's
- * deactivation step retires the local row — exactly how Lyfe behaves.
+ * `role=eq.agent` is filtered AT THE SOURCE and is mandatory: mktr-leads has an
+ * `admin` role that must never become an assignable MKTR agent (a promotion to
+ * admin drops the row from this list → the sync retires it locally).
+ *
+ * `is_active` is intentionally NOT filtered (unlike Lyfe): the adapter declares
+ * `mirrorsIsActive`, so runSync mirrors each row's is_active directly. Fetching
+ * active-only would make a deactivated agent look DELETED upstream — the sync's
+ * two-phase deletion would then hard-delete the local row after the grace
+ * window, cascading away its lead-package assignments. Only rows truly absent
+ * from this list (account deleted / promoted to admin) may be retired.
  */
 export async function fetchAgents() {
   const cacheKey = 'agents';
@@ -119,7 +124,7 @@ export async function fetchAgents() {
   let rows;
   try {
     rows = await breaker.fire(
-      `${url}/rest/v1/agents?role=eq.agent&is_active=eq.true&select=${SELECT_COLUMNS}&order=full_name`,
+      `${url}/rest/v1/agents?role=eq.agent&select=${SELECT_COLUMNS}&order=full_name`,
       authHeaders(key)
     );
   } catch (err) {

--- a/backend/src/services/agentSyncService.js
+++ b/backend/src/services/agentSyncService.js
@@ -116,6 +116,90 @@ export function provenanceConflictField(existing, matchedByExternalId, otherProv
   return otherProvenanceFields.find((f) => existing[f]) || null;
 }
 
+/** Split a display name into firstName/lastName the way the create path does. */
+function splitFullName(fullName) {
+  const nameParts = (fullName || '').trim().split(/\s+/);
+  return {
+    firstName: nameParts[0] || null,
+    lastName: nameParts.slice(1).join(' ') || null,
+  };
+}
+
+/**
+ * Compute the update payload for one matched (existing local row, upstream
+ * agent) pair — pure, so the per-adapter semantics are unit-testable without a
+ * DB. Two adapter flags branch the behaviour:
+ *
+ *   authoritativeProfile — upstream OWNS profile fields: overwrite fullName
+ *     (+ re-derived firstName/lastName), email, and companyName←agency when
+ *     they differ. Never null-out email (upstream null ≠ "clear it"). Legacy
+ *     (Lyfe) keeps fill-only-when-null + @placeholder.local replacement.
+ *
+ *   mirrorsIsActive — upstream rows carry a meaningful isActive: mirror flips
+ *     both ways (deactivate AND reactivate). Legacy adapters fetch active-only
+ *     rosters, so absence — handled by the deactivation phase — is their only
+ *     inactive signal.
+ *
+ * Phone is fill-only for everyone: it's a matching key and unique locally.
+ * pending_deletion_at clears whenever the agent is present upstream at all.
+ */
+export function computeSyncUpdate({ adapter, existing, ea, normalizedPhone }) {
+  const authoritative = adapter.authoritativeProfile === true;
+  const updateData = {};
+
+  if (ea.externalId && !existing[adapter.localIdField]) {
+    updateData[adapter.localIdField] = String(ea.externalId);
+  }
+
+  if (ea.fullName && (authoritative ? existing.fullName !== ea.fullName : !existing.fullName)) {
+    updateData.fullName = ea.fullName;
+    if (authoritative) {
+      const { firstName, lastName } = splitFullName(ea.fullName);
+      updateData.firstName = firstName;
+      updateData.lastName = lastName;
+    }
+  }
+
+  // Backfill upstream role onto pre-Phase-2 rows (external_role was null
+  // before migration 025). Once set, sync keeps it in sync if upstream
+  // changes role.
+  if (ea.externalRole && existing.external_role !== ea.externalRole) {
+    updateData.external_role = ea.externalRole;
+  }
+
+  // Legacy: fill when null or replace synthetic @placeholder.local emails.
+  // Authoritative: overwrite on any difference (but never null-out).
+  if (
+    ea.email &&
+    (authoritative
+      ? existing.email !== ea.email
+      : !existing.email || existing.email.endsWith('@placeholder.local'))
+  ) {
+    updateData.email = ea.email;
+  }
+
+  if (ea.phone && !existing.phone) {
+    updateData.phone = normalizedPhone;
+  }
+
+  // agency → companyName. Sync-owned for authoritative rows, so mirroring a
+  // cleared upstream agency (null) is intentional.
+  if (authoritative && ea.agency !== undefined && (ea.agency || null) !== (existing.companyName || null)) {
+    updateData.companyName = ea.agency || null;
+  }
+
+  if (adapter.mirrorsIsActive === true && typeof ea.isActive === 'boolean' && existing.isActive !== ea.isActive) {
+    updateData.isActive = ea.isActive;
+  }
+
+  // Present upstream (in any state) → cancel a pending deletion.
+  if (existing.pending_deletion_at) {
+    updateData.pending_deletion_at = null;
+  }
+
+  return updateData;
+}
+
 // ─── Sync orchestrator ─────────────────────────────────────────────────────
 
 /**
@@ -139,24 +223,39 @@ export function provenanceConflictField(existing, matchedByExternalId, otherProv
  * use pool connections (committed independently); lockTx exists only to hold the
  * lock for the duration.
  *
+ * `options.wait = true` switches from try-lock (skip when held — right for the
+ * cron, where the next tick retries) to a BLOCKING `pg_advisory_xact_lock`
+ * bounded by lock_timeout. Management actions use this: after writing to the
+ * source app they re-sync to refresh the local mirror, and a silent skip there
+ * would leave the dashboard stale for up to 10 minutes. On timeout Postgres
+ * aborts the wait (SQLSTATE 55P03) and the error propagates to the caller.
+ *
  * @returns {Promise<{ created: number, updated: number, deactivated: number, hardDeleted: number, skipped: number, total: number, locked?: boolean }>}
  */
-async function syncWithLock(adapterId) {
+async function syncWithLock(adapterId, { wait = false } = {}) {
   const adapter = adapterRegistry.get(adapterId);
   const localIdField = adapter.localIdField;
   const startedAt = Date.now();
 
   return await sequelize.transaction(async (lockTx) => {
-    const [{ locked }] = await sequelize.query(
-      `SELECT pg_try_advisory_xact_lock(hashtext(:key)) AS locked`,
-      { replacements: { key: ADVISORY_LOCK_KEY }, type: sequelize.QueryTypes.SELECT, transaction: lockTx }
-    );
-    if (!locked) {
-      logger.info(
-        { event: 'agent_sync_skipped', adapter: adapter.id, reason: 'lock_held' },
-        '[AgentSync] another sync run is in progress — skipping'
+    if (wait) {
+      await sequelize.query(`SET LOCAL lock_timeout = '15s'`, { transaction: lockTx });
+      await sequelize.query(
+        `SELECT pg_advisory_xact_lock(hashtext(:key))`,
+        { replacements: { key: ADVISORY_LOCK_KEY }, transaction: lockTx }
       );
-      return { created: 0, updated: 0, deactivated: 0, hardDeleted: 0, skipped: 0, total: 0, locked: false };
+    } else {
+      const [{ locked }] = await sequelize.query(
+        `SELECT pg_try_advisory_xact_lock(hashtext(:key)) AS locked`,
+        { replacements: { key: ADVISORY_LOCK_KEY }, type: sequelize.QueryTypes.SELECT, transaction: lockTx }
+      );
+      if (!locked) {
+        logger.info(
+          { event: 'agent_sync_skipped', adapter: adapter.id, reason: 'lock_held' },
+          '[AgentSync] another sync run is in progress — skipping'
+        );
+        return { created: 0, updated: 0, deactivated: 0, hardDeleted: 0, skipped: 0, total: 0, locked: false };
+      }
     }
 
     // Lock auto-releases when this transaction commits (or rolls back on throw).
@@ -172,8 +271,8 @@ async function syncWithLock(adapterId) {
  *
  * @returns {Promise<{ created: number, updated: number, deactivated: number, skipped: number, total: number }>}
  */
-export async function syncAgentsFromLyfe() {
-  return syncWithLock('lyfe');
+export async function syncAgentsFromLyfe(options = {}) {
+  return syncWithLock('lyfe', options);
 }
 
 /**
@@ -185,8 +284,8 @@ export async function syncAgentsFromLyfe() {
  *
  * @returns {Promise<{ created: number, updated: number, deactivated: number, skipped: number, total: number }>}
  */
-export async function syncAgentsFromMktrLeads() {
-  return syncWithLock('mktr_leads');
+export async function syncAgentsFromMktrLeads(options = {}) {
+  return syncWithLock('mktr_leads', options);
 }
 
 /**
@@ -209,7 +308,7 @@ async function runSync(adapter, localIdField, startedAt) {
         // Both provenance fields (not just localIdField) so the loop can detect
         // a phone/email match that would cross sources and skip it.
         'id', ...PROVENANCE_FIELDS, 'phone', 'email', 'firstName', 'lastName',
-        'fullName', 'isActive', 'external_role', 'pending_deletion_at',
+        'fullName', 'companyName', 'isActive', 'external_role', 'pending_deletion_at',
       ],
     });
   } catch (err) {
@@ -277,74 +376,77 @@ async function runSync(adapter, localIdField, startedAt) {
       continue;
     }
 
-    if (existing) {
-      const updateData = {};
-      if (ea.externalId && !existing[localIdField]) updateData[localIdField] = String(ea.externalId);
-      if (ea.fullName && !existing.fullName) updateData.fullName = ea.fullName;
-      // Backfill upstream role onto pre-Phase-2 rows (external_role was
-      // null before migration 025). Once set, sync keeps it in sync if
-      // upstream changes role.
-      if (ea.externalRole && existing.external_role !== ea.externalRole) {
-        updateData.external_role = ea.externalRole;
-      }
-      // Replace synthetic @placeholder.local emails (legacy from pre-Phase-2)
-      // when upstream now provides a real one. Don't overwrite a real email.
-      if (ea.email && (!existing.email || existing.email.endsWith('@placeholder.local'))) {
-        updateData.email = ea.email;
-      }
-      if (ea.phone && !existing.phone) {
-        updateData.phone = normalizedPhone;
-      }
-      // If the agent had been marked for deletion and is back in the
-      // upstream set, clear the timer.
-      if (existing.pending_deletion_at) {
-        updateData.pending_deletion_at = null;
-      }
+    try {
+      if (existing) {
+        // Per-adapter fill-vs-overwrite + is_active mirroring semantics live in
+        // the pure helper (see its doc block).
+        const updateData = computeSyncUpdate({ adapter, existing, ea, normalizedPhone });
 
-      if (Object.keys(updateData).length > 0) {
-        await existing.update(updateData);
-        updated++;
+        if (Object.keys(updateData).length > 0) {
+          await existing.update(updateData);
+          updated++;
+        } else {
+          skipped++;
+        }
       } else {
-        skipped++;
-      }
-    } else {
-      const nameParts = (ea.fullName || '').trim().split(/\s+/);
-      const firstName = nameParts[0] || null;
-      const lastName = nameParts.slice(1).join(' ') || null;
+        const { firstName, lastName } = splitFullName(ea.fullName);
 
-      await User.create({
-        [localIdField]: ea.externalId ? String(ea.externalId) : null,
-        // Post-migration 025 email is nullable. Don't fabricate
-        // @placeholder.local — leave NULL so downstream UIs render '(no
-        // email)' instead of a synthetic value that looks real.
-        email: ea.email || null,
-        firstName,
-        lastName,
-        fullName: ea.fullName || null,
-        phone: normalizedPhone,
-        role: 'agent',
-        external_role: ea.externalRole || null,
-        isActive: true,
-        emailVerified: false,
-        approvalStatus: 'approved',
-      });
-      created++;
+        await User.create({
+          [localIdField]: ea.externalId ? String(ea.externalId) : null,
+          // Post-migration 025 email is nullable. Don't fabricate
+          // @placeholder.local — leave NULL so downstream UIs render '(no
+          // email)' instead of a synthetic value that looks real.
+          email: ea.email || null,
+          firstName,
+          lastName,
+          fullName: ea.fullName || null,
+          phone: normalizedPhone,
+          role: 'agent',
+          external_role: ea.externalRole || null,
+          companyName: adapter.authoritativeProfile === true ? ea.agency || null : null,
+          // Mirroring adapters list inactive rows too — honour their state.
+          // Legacy adapters send active-only rosters, so created = active.
+          isActive: adapter.mirrorsIsActive === true ? ea.isActive !== false : true,
+          emailVerified: false,
+          approvalStatus: 'approved',
+        });
+        created++;
+      }
+    } catch (err) {
+      // One bad row (e.g. a unique-constraint collision on an authoritative
+      // email overwrite) must not abort the rest of the run.
+      skipped++;
+      logger.error(
+        { event: 'agent_sync_row_failed', adapter: adapter.id, externalId: ea.externalId, err },
+        '[AgentSync] row upsert failed — skipping'
+      );
     }
   }
 
   // ─── Two-phase delete-aware deactivation (FMEA F09) ────────────────────
+  // Keyed on ABSENCE from the fetched upstream set. What absence means is
+  // adapter-dependent:
+  //   - legacy active-only adapters (Lyfe): the set is the ACTIVE roster, so a
+  //     deactivated upstream agent is "absent" → deactivated (and eventually
+  //     deleted) locally. Their only inactive signal is absence.
+  //   - mirrorsIsActive adapters (mktr-leads): the set contains active AND
+  //     inactive rows — is_active flips are mirrored row-wise in the upsert
+  //     loop above, and only truly-gone rows (account deleted, role promoted
+  //     to admin) reach this block. A merely-deactivated agent is present
+  //     upstream, so it is never pending-deleted — protecting its CASCADE-
+  //     linked lead_package_assignments from silent destruction.
   // Phase 1: deactivate agents missing upstream. If they have no attached
   // prospects, also mark pending_deletion_at = NOW().
   // Phase 2: agents whose pending_deletion_at is older than DELETE_GRACE_MS
   // AND still missing upstream AND still no prospects → hard DELETE.
   // Agents with attached prospects are NEVER hard-deleted; they remain
   // inactive forever to preserve lead-history FK integrity.
-  const activeExternalIds = externalAgents.map((a) => String(a.externalId)).filter(Boolean);
+  const upstreamExternalIds = externalAgents.map((a) => String(a.externalId)).filter(Boolean);
   let deactivated = 0;
   let hardDeleted = 0;
 
   try {
-    if (activeExternalIds.length > 0) {
+    if (upstreamExternalIds.length > 0) {
       // 1. Bulk-deactivate currently-active agents missing from upstream.
       const [deactivatedCount] = await User.update(
         { isActive: false },
@@ -352,7 +454,7 @@ async function runSync(adapter, localIdField, startedAt) {
           where: {
             role: 'agent',
             isActive: true,
-            [localIdField]: { [Op.notIn]: activeExternalIds, [Op.ne]: null },
+            [localIdField]: { [Op.notIn]: upstreamExternalIds, [Op.ne]: null },
           },
         }
       );
@@ -366,10 +468,10 @@ async function runSync(adapter, localIdField, startedAt) {
           WHERE role = 'agent'
             AND "isActive" = false
             AND "${localIdField}" IS NOT NULL
-            AND "${localIdField}" NOT IN (:activeExternalIds)
+            AND "${localIdField}" NOT IN (:upstreamExternalIds)
             AND pending_deletion_at IS NULL
             AND id NOT IN (SELECT DISTINCT "assignedAgentId" FROM prospects WHERE "assignedAgentId" IS NOT NULL)`,
-        { replacements: { activeExternalIds } }
+        { replacements: { upstreamExternalIds } }
       );
 
       // 3. Hard-delete agents whose grace window expired AND still no
@@ -381,14 +483,14 @@ async function runSync(adapter, localIdField, startedAt) {
              WHERE role = 'agent'
                AND "isActive" = false
                AND "${localIdField}" IS NOT NULL
-               AND "${localIdField}" NOT IN (:activeExternalIds)
+               AND "${localIdField}" NOT IN (:upstreamExternalIds)
                AND pending_deletion_at IS NOT NULL
                AND pending_deletion_at < NOW() - INTERVAL '${DELETE_GRACE_HOURS} hours'
                AND id NOT IN (SELECT DISTINCT "assignedAgentId" FROM prospects WHERE "assignedAgentId" IS NOT NULL)
             RETURNING id
          )
          SELECT COUNT(*)::int AS count FROM deleted`,
-        { replacements: { activeExternalIds }, type: sequelize.QueryTypes.SELECT }
+        { replacements: { upstreamExternalIds }, type: sequelize.QueryTypes.SELECT }
       );
       hardDeleted = deletedCount || 0;
     }

--- a/backend/test/integration/mktrLeadsAgentSync.test.js
+++ b/backend/test/integration/mktrLeadsAgentSync.test.js
@@ -1,5 +1,6 @@
 import { getApp, closeDb, createTestUser } from '../helpers.js';
 import { User } from '../../src/models/index.js';
+import { sequelize } from '../../src/database/connection.js';
 import { adapterRegistry } from '../../src/integrations/AdapterRegistry.js';
 import { syncAgentsFromMktrLeads } from '../../src/services/agentSyncService.js';
 
@@ -8,13 +9,16 @@ import { syncAgentsFromMktrLeads } from '../../src/services/agentSyncService.js'
  * source). Requires Postgres (advisory lock + CHECK constraint + raw-SQL
  * deactivation) — runs in CI alongside the other integration suites.
  *
- * One snapshot exercises every branch of the one-source-per-user sync:
- *   - brand-new mktr-leads agent          → created with mktrLeadsId
- *   - phone collision with a Lyfe agent    → SKIPPED, never merged (the flagged
- *                                            safety: no dual-source row)
- *   - already-mirrored agent (id match)    → kept active, not duplicated
- *   - mirrored agent gone from upstream    → deactivated (only its own source)
- *   - the Lyfe agent                       → untouched by the mktr-leads sync
+ * mktr-leads semantics under test (mirrorsIsActive + authoritativeProfile):
+ *   - brand-new active agent            → created with mktrLeadsId
+ *   - phone collision with a Lyfe agent → SKIPPED, never merged (one source per user)
+ *   - present agent (externalId match)  → kept, profile OVERWRITTEN from upstream
+ *   - upstream-DEACTIVATED agent        → mirrored inactive, NOT pending-deleted
+ *     (regression: active-only fetch made deactivation look like deletion →
+ *      24h hard-delete → CASCADE destroyed lead_package_assignments)
+ *   - upstream-reactivated agent        → mirrored back to active
+ *   - truly ABSENT agent (deleted)      → deactivated + pending-deleted (two-phase)
+ *   - the Lyfe agent                    → untouched by the mktr-leads sync
  */
 
 const RUN = String(Date.now()).slice(-6);
@@ -23,6 +27,8 @@ const ID = {
   stale: `M_stale_${RUN}`,
   fresh: `M_new_${RUN}`,
   conflict: `M_conflict_${RUN}`,
+  deact: `M_deact_${RUN}`,
+  react: `M_react_${RUN}`,
   lyfe: `L_${RUN}`,
 };
 const PHONE = {
@@ -30,24 +36,36 @@ const PHONE = {
   keep: `6593${RUN}`,
   stale: `6592${RUN}`,
   fresh: `6594${RUN}`,
+  deact: `6595${RUN}`,
+  react: `6596${RUN}`,
 };
 
-let lyfeAgent, staleAgent, keepAgent;
+let lyfeAgent, staleAgent, keepAgent, deactAgent, reactAgent;
 
 // Fake adapter: returns exactly the upstream snapshot we want, no network.
+// Declares the same semantics as the real MktrLeadsAdapter.
 const fakeAdapter = {
   id: 'mktr_leads',
   localIdField: 'mktrLeadsId',
+  mirrorsIsActive: true,
+  authoritativeProfile: true,
   invalidateCache() {},
   async getAgent() {
     return null;
   },
   async listAgents() {
     return [
-      { externalId: ID.keep, fullName: 'Keep Agent', email: `keep-${RUN}@ml.test`, phone: PHONE.keep, externalRole: 'agent', isActive: true },
-      { externalId: ID.fresh, fullName: 'Fresh Agent', email: `fresh-${RUN}@ml.test`, phone: PHONE.fresh, externalRole: 'agent', isActive: true },
+      // Present + active, with CHANGED name/agency → authoritative overwrite.
+      { externalId: ID.keep, fullName: 'Keep Renamed', email: `keep-${RUN}@ml.test`, phone: PHONE.keep, externalRole: 'agent', isActive: true, agency: 'Acme Advisory' },
+      // Brand new.
+      { externalId: ID.fresh, fullName: 'Fresh Agent', email: `fresh-${RUN}@ml.test`, phone: PHONE.fresh, externalRole: 'agent', isActive: true, agency: null },
       // Same phone as the Lyfe agent below → must be SKIPPED, not merged.
-      { externalId: ID.conflict, fullName: 'Conflict Agent', email: `conflict-${RUN}@ml.test`, phone: PHONE.lyfe, externalRole: 'agent', isActive: true },
+      { externalId: ID.conflict, fullName: 'Conflict Agent', email: `conflict-${RUN}@ml.test`, phone: PHONE.lyfe, externalRole: 'agent', isActive: true, agency: null },
+      // Present but DEACTIVATED upstream → mirror inactive, never pending-delete.
+      { externalId: ID.deact, fullName: 'Deact Mktr', email: `deact-${RUN}@ml.test`, phone: PHONE.deact, externalRole: 'agent', isActive: false, agency: null },
+      // Present and reactivated upstream (local row starts inactive).
+      { externalId: ID.react, fullName: 'React Mktr', email: `react-${RUN}@ml.test`, phone: PHONE.react, externalRole: 'agent', isActive: true, agency: null },
+      // ID.stale is intentionally ABSENT — simulates a deleted account.
     ];
   },
 };
@@ -60,10 +78,14 @@ beforeAll(async () => {
 
   // A Lyfe-owned agent — the conflict agent shares its phone.
   ({ user: lyfeAgent } = await createTestUser({ role: 'agent', lyfeId: ID.lyfe, phone: PHONE.lyfe, firstName: 'Lyfe', lastName: 'Owned' }));
-  // An mktr-leads agent that upstream no longer returns → should deactivate.
+  // An mktr-leads agent upstream no longer returns AT ALL → absent → two-phase delete path.
   ({ user: staleAgent } = await createTestUser({ role: 'agent', mktrLeadsId: ID.stale, phone: PHONE.stale, firstName: 'Stale', lastName: 'Mktr' }));
-  // An mktr-leads agent the snapshot still returns (externalId match).
-  ({ user: keepAgent } = await createTestUser({ role: 'agent', mktrLeadsId: ID.keep, phone: PHONE.keep, firstName: 'Keep', lastName: 'Mktr' }));
+  // An mktr-leads agent the snapshot still returns (externalId match) with changed profile.
+  ({ user: keepAgent } = await createTestUser({ role: 'agent', mktrLeadsId: ID.keep, phone: PHONE.keep, firstName: 'Keep', lastName: 'Mktr', fullName: 'Keep Mktr' }));
+  // Active locally, deactivated upstream.
+  ({ user: deactAgent } = await createTestUser({ role: 'agent', mktrLeadsId: ID.deact, phone: PHONE.deact, firstName: 'Deact', lastName: 'Mktr' }));
+  // Inactive locally, reactivated upstream.
+  ({ user: reactAgent } = await createTestUser({ role: 'agent', mktrLeadsId: ID.react, phone: PHONE.react, firstName: 'React', lastName: 'Mktr', isActive: false }));
 
   adapterRegistry.replace(fakeAdapter);
   result = await syncAgentsFromMktrLeads();
@@ -83,46 +105,68 @@ describe('syncAgentsFromMktrLeads', () => {
   });
 
   it('SKIPS a phone collision with a Lyfe agent — never merges (one source per user)', async () => {
-    // The Lyfe row keeps its provenance and gains NO mktrLeadsId.
     const lyfe = await User.findByPk(lyfeAgent.id);
     expect(lyfe.lyfeId).toBe(ID.lyfe);
     expect(lyfe.mktrLeadsId).toBeNull();
-    // And no separate row was created for the conflicting upstream id.
     const conflictRow = await User.findOne({ where: { mktrLeadsId: ID.conflict } });
     expect(conflictRow).toBeNull();
   });
 
-  it('keeps an already-mirrored agent active and does not duplicate it', async () => {
+  it('authoritatively overwrites profile fields from upstream (name + derived parts + agency→companyName)', async () => {
     const rows = await User.findAll({ where: { mktrLeadsId: ID.keep } });
     expect(rows).toHaveLength(1);
     expect(rows[0].id).toBe(keepAgent.id);
+    expect(rows[0].fullName).toBe('Keep Renamed');
+    expect(rows[0].firstName).toBe('Keep');
+    expect(rows[0].lastName).toBe('Renamed');
+    expect(rows[0].companyName).toBe('Acme Advisory');
     expect(rows[0].isActive).toBe(true);
   });
 
-  it('deactivates an mktr-leads agent that vanished upstream', async () => {
-    const stale = await User.findByPk(staleAgent.id);
-    expect(stale.isActive).toBe(false);
+  it('mirrors an upstream-DEACTIVATED agent inactive WITHOUT marking it for deletion (regression)', async () => {
+    const deact = await User.findByPk(deactAgent.id);
+    expect(deact.isActive).toBe(false);
+    // The old active-only fetch made this row look DELETED upstream →
+    // pending_deletion → 24h hard-delete → CASCADE wiped its lead-package
+    // assignments. Present-but-inactive must never enter the deletion path.
+    expect(deact.pending_deletion_at).toBeNull();
   });
 
-  it('does NOT deactivate the Lyfe agent (cross-source isolation)', async () => {
+  it('mirrors an upstream-reactivated agent back to active', async () => {
+    const react = await User.findByPk(reactAgent.id);
+    expect(react.isActive).toBe(true);
+  });
+
+  it('still deactivates + pending-deletes an agent that is truly ABSENT upstream', async () => {
+    const stale = await User.findByPk(staleAgent.id);
+    expect(stale.isActive).toBe(false);
+    expect(stale.pending_deletion_at).not.toBeNull();
+  });
+
+  it('does NOT touch the Lyfe agent (cross-source isolation)', async () => {
     const lyfe = await User.findByPk(lyfeAgent.id);
     expect(lyfe.isActive).toBe(true);
   });
 
-  it('reports the skip in its result counts', () => {
+  it('reports the conflict skip in its result counts', () => {
     expect(result.locked).not.toBe(false);
     expect(result.skipped).toBeGreaterThanOrEqual(1);
   });
 
-  it('runs back-to-back without the advisory lock leaking (regression: lock_held skip)', async () => {
-    // Under the old session-level pg_advisory_lock, the acquire and the manual
-    // pg_advisory_unlock could land on different pooled connections, so the lock
-    // leaked and a sync running immediately after another (the Lyfe→mktr-leads
-    // cron pattern) skipped with locked:false. The transaction-scoped
-    // pg_try_advisory_xact_lock auto-releases on commit, so both runs acquire.
-    const first = await syncAgentsFromMktrLeads();
-    const second = await syncAgentsFromMktrLeads();
-    expect(first.locked).not.toBe(false);
-    expect(second.locked).not.toBe(false);
-  });
+  it('try-lock skips while held; {wait:true} blocks behind the holder and then runs', async () => {
+    // Hold the shared advisory lock from a separate transaction.
+    const holder = await sequelize.transaction();
+    await sequelize.query(`SELECT pg_advisory_xact_lock(hashtext('agent_sync'))`, { transaction: holder });
+
+    // Cron semantics: try-lock → clean skip.
+    const skippedRun = await syncAgentsFromMktrLeads();
+    expect(skippedRun.locked).toBe(false);
+
+    // Management semantics: wait for the lock instead of skipping.
+    const waiting = syncAgentsFromMktrLeads({ wait: true });
+    await new Promise((r) => setTimeout(r, 300));
+    await holder.commit(); // releases the xact lock
+    const res = await waiting;
+    expect(res.locked).not.toBe(false);
+  }, 20000);
 });

--- a/backend/test/unit/agentSyncUpdate.test.js
+++ b/backend/test/unit/agentSyncUpdate.test.js
@@ -1,0 +1,165 @@
+import '../setup.js';
+import { computeSyncUpdate } from '../../src/services/agentSyncService.js';
+
+/**
+ * Pure tests for the per-adapter update semantics:
+ *   - Lyfe (legacy): fill-only-when-null, @placeholder.local replacement,
+ *     NO isActive key ever (absence-based deactivation handles it).
+ *   - mktr-leads (mirrorsIsActive + authoritativeProfile): is_active mirrored
+ *     both ways; fullName/email/companyName overwritten from upstream.
+ */
+
+const LYFE = { id: 'lyfe', localIdField: 'lyfeId' };
+const MKTR_LEADS = {
+  id: 'mktr_leads',
+  localIdField: 'mktrLeadsId',
+  mirrorsIsActive: true,
+  authoritativeProfile: true,
+};
+
+const baseExisting = {
+  id: 'u1',
+  lyfeId: null,
+  mktrLeadsId: 'M1',
+  phone: '6591234567',
+  email: 'old@x.com',
+  firstName: 'Old',
+  lastName: 'Name',
+  fullName: 'Old Name',
+  companyName: null,
+  isActive: true,
+  external_role: 'agent',
+  pending_deletion_at: null,
+};
+
+describe('computeSyncUpdate — legacy (Lyfe) fill-only semantics', () => {
+  const existing = { ...baseExisting, lyfeId: 'L1', mktrLeadsId: null };
+
+  it('does NOT overwrite an existing fullName or real email', () => {
+    const upd = computeSyncUpdate({
+      adapter: LYFE,
+      existing,
+      ea: { externalId: 'L1', fullName: 'New Name', email: 'new@x.com', externalRole: 'agent', isActive: true },
+      normalizedPhone: '6591234567',
+    });
+    expect(upd.fullName).toBeUndefined();
+    expect(upd.email).toBeUndefined();
+  });
+
+  it('fills a null fullName and replaces @placeholder.local emails', () => {
+    const upd = computeSyncUpdate({
+      adapter: LYFE,
+      existing: { ...existing, fullName: null, email: 'x@placeholder.local' },
+      ea: { externalId: 'L1', fullName: 'New Name', email: 'real@x.com', isActive: true },
+      normalizedPhone: '6591234567',
+    });
+    expect(upd.fullName).toBe('New Name');
+    expect(upd.email).toBe('real@x.com');
+    // Legacy fill never re-derives first/last (pre-existing behaviour).
+    expect(upd.firstName).toBeUndefined();
+  });
+
+  it('never emits isActive (absence-based deactivation owns it)', () => {
+    const upd = computeSyncUpdate({
+      adapter: LYFE,
+      existing: { ...existing, isActive: false },
+      ea: { externalId: 'L1', fullName: 'Old Name', isActive: true },
+      normalizedPhone: '6591234567',
+    });
+    expect(upd.isActive).toBeUndefined();
+  });
+});
+
+describe('computeSyncUpdate — mktr-leads mirror + authoritative semantics', () => {
+  it('mirrors is_active=false (deactivation) and =true (reactivation)', () => {
+    const deact = computeSyncUpdate({
+      adapter: MKTR_LEADS,
+      existing: baseExisting,
+      ea: { externalId: 'M1', fullName: 'Old Name', email: 'old@x.com', isActive: false },
+      normalizedPhone: '6591234567',
+    });
+    expect(deact.isActive).toBe(false);
+
+    const react = computeSyncUpdate({
+      adapter: MKTR_LEADS,
+      existing: { ...baseExisting, isActive: false },
+      ea: { externalId: 'M1', fullName: 'Old Name', email: 'old@x.com', isActive: true },
+      normalizedPhone: '6591234567',
+    });
+    expect(react.isActive).toBe(true);
+  });
+
+  it('overwrites fullName (re-deriving first/last) and email when upstream differs', () => {
+    const upd = computeSyncUpdate({
+      adapter: MKTR_LEADS,
+      existing: baseExisting,
+      ea: { externalId: 'M1', fullName: 'Ada Mei Tan', email: 'ada@x.com', isActive: true },
+      normalizedPhone: '6591234567',
+    });
+    expect(upd.fullName).toBe('Ada Mei Tan');
+    expect(upd.firstName).toBe('Ada');
+    expect(upd.lastName).toBe('Mei Tan');
+    expect(upd.email).toBe('ada@x.com');
+  });
+
+  it('never nulls-out email even when authoritative (upstream null ≠ clear)', () => {
+    const upd = computeSyncUpdate({
+      adapter: MKTR_LEADS,
+      existing: baseExisting,
+      ea: { externalId: 'M1', fullName: 'Old Name', email: null, isActive: true },
+      normalizedPhone: '6591234567',
+    });
+    expect(upd.email).toBeUndefined();
+  });
+
+  it('mirrors agency → companyName, including clearing it', () => {
+    const set = computeSyncUpdate({
+      adapter: MKTR_LEADS,
+      existing: baseExisting,
+      ea: { externalId: 'M1', fullName: 'Old Name', email: 'old@x.com', agency: 'Acme', isActive: true },
+      normalizedPhone: '6591234567',
+    });
+    expect(set.companyName).toBe('Acme');
+
+    const clear = computeSyncUpdate({
+      adapter: MKTR_LEADS,
+      existing: { ...baseExisting, companyName: 'Acme' },
+      ea: { externalId: 'M1', fullName: 'Old Name', email: 'old@x.com', agency: null, isActive: true },
+      normalizedPhone: '6591234567',
+    });
+    expect(clear.companyName).toBeNull();
+  });
+
+  it('keeps phone fill-only even when authoritative (matching key)', () => {
+    const upd = computeSyncUpdate({
+      adapter: MKTR_LEADS,
+      existing: baseExisting,
+      ea: { externalId: 'M1', fullName: 'Old Name', email: 'old@x.com', phone: '6599999999', isActive: true },
+      normalizedPhone: '6599999999',
+    });
+    expect(upd.phone).toBeUndefined();
+  });
+
+  it('clears pending_deletion_at whenever the agent is present upstream (even inactive)', () => {
+    const upd = computeSyncUpdate({
+      adapter: MKTR_LEADS,
+      existing: { ...baseExisting, isActive: false, pending_deletion_at: new Date() },
+      ea: { externalId: 'M1', fullName: 'Old Name', email: 'old@x.com', isActive: false },
+      normalizedPhone: '6591234567',
+    });
+    expect(upd.pending_deletion_at).toBeNull();
+  });
+
+  it('returns {} when nothing differs (counted as skipped, no write)', () => {
+    const upd = computeSyncUpdate({
+      adapter: MKTR_LEADS,
+      existing: baseExisting,
+      ea: {
+        externalId: 'M1', fullName: 'Old Name', email: 'old@x.com',
+        externalRole: 'agent', agency: null, isActive: true, phone: '6591234567',
+      },
+      normalizedPhone: '6591234567',
+    });
+    expect(upd).toEqual({});
+  });
+});

--- a/backend/test/unit/mktrLeadsAdapter.test.js
+++ b/backend/test/unit/mktrLeadsAdapter.test.js
@@ -12,6 +12,7 @@ const ROWS = [
     phone: '6591234567',
     role: 'agent',
     is_active: true,
+    agency: 'Acme Advisory',
     created_at: '2026-06-01T00:00:00Z',
   },
   {
@@ -21,7 +22,19 @@ const ROWS = [
     phone: '6598765432',
     role: 'agent',
     is_active: true,
+    agency: null,
     created_at: '2026-06-02T00:00:00Z',
+  },
+  {
+    // Deactivated agent — must be returned (mirrored), not filtered out.
+    mktr_user_id: 'mu_3',
+    full_name: 'Cara Goh',
+    email: 'cara@example.com',
+    phone: '6587654321',
+    role: 'agent',
+    is_active: false,
+    agency: 'Acme Advisory',
+    created_at: '2026-06-03T00:00:00Z',
   },
 ];
 
@@ -48,16 +61,18 @@ describe('mktrLeadsClient', () => {
     delete process.env.MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY;
   });
 
-  it('fetchAgents filters role=agent + is_active at the source and normalizes', async () => {
+  it('fetchAgents filters role=agent at the source (NOT is_active — inactive rows are mirrored) and normalizes', async () => {
     const agents = await client.fetchAgents();
 
     const url = fetchMock.mock.calls[0][0];
     expect(url).toContain('/rest/v1/agents?');
     expect(url).toContain('role=eq.agent');
-    expect(url).toContain('is_active=eq.true');
-    expect(url).toContain('select=mktr_user_id,full_name,email,phone,role,is_active,created_at');
+    // Deactivated agents must stay in the fetched set: absence means DELETED
+    // upstream (two-phase hard-delete). is_active is mirrored row-wise instead.
+    expect(url).not.toContain('is_active=eq.true');
+    expect(url).toContain('select=mktr_user_id,full_name,email,phone,role,is_active,agency,created_at');
 
-    expect(agents).toHaveLength(2);
+    expect(agents).toHaveLength(3);
     expect(agents[0]).toMatchObject({
       externalId: 'mu_1', // the mktr_user_id, NOT an auth id
       fullName: 'Ada Tan',
@@ -65,11 +80,14 @@ describe('mktrLeadsClient', () => {
       phone: '6591234567',
       externalRole: 'agent',
       isActive: true,
+      agency: 'Acme Advisory',
       avatarUrl: null,
       dateOfBirth: null,
       createdAt: '2026-06-01T00:00:00Z',
     });
     expect(agents[1].email).toBeNull(); // do NOT synthesize
+    // Inactive rows pass through with isActive=false for row-wise mirroring.
+    expect(agents[2]).toMatchObject({ externalId: 'mu_3', isActive: false });
   });
 
   it('caches list results within TTL (no second fetch)', async () => {
@@ -111,6 +129,11 @@ describe('MktrLeadsAdapter contract', () => {
     expect(MktrLeadsAdapter.localIdField).toBe('mktrLeadsId');
   });
 
+  it('declares mirror semantics: is_active mirrored row-wise, profile fields source-authoritative', () => {
+    expect(MktrLeadsAdapter.mirrorsIsActive).toBe(true);
+    expect(MktrLeadsAdapter.authoritativeProfile).toBe(true);
+  });
+
   it('reads outbound webhook url/secret from env each call', () => {
     expect(MktrLeadsAdapter.outboundWebhookUrl()).toBeNull();
     expect(MktrLeadsAdapter.outboundWebhookSecret()).toBeNull();
@@ -126,7 +149,7 @@ describe('MktrLeadsAdapter contract', () => {
     client.invalidateCache();
     global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ROWS, text: async () => '' });
     const agents = await MktrLeadsAdapter.listAgents();
-    expect(agents.map((a) => a.externalId)).toEqual(['mu_1', 'mu_2']);
+    expect(agents.map((a) => a.externalId)).toEqual(['mu_1', 'mu_2', 'mu_3']);
     delete process.env.MKTR_LEADS_SUPABASE_URL;
     delete process.env.MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY;
   });


### PR DESCRIPTION
## Why (latent data-loss bug — prerequisite for the admin deactivate control)

The mktr-leads sync fetches `is_active=eq.true` rows only and keys deactivation/deletion on **absence** from that set. So a merely-**deactivated** agent is indistinguishable from a **deleted** one:

deactivate in mktr-leads → local row looks "missing upstream" → `pending_deletion_at` marked (if no prospects) → **hard-DELETE after the 24h grace** — and `lead_package_assignments.agentId` is **ON DELETE CASCADE** (verified on the live DB), so the agent's funded package assignments are silently destroyed with the row.

Flagged by the Codex plan review of the upcoming agent-management feature (must-fix #2); severity upgraded after verifying the CASCADE. This must land before any deactivate button exists. Part 1 of 3 (next: mktr-leads invite EF service-auth; then management endpoints + UI per `~/.claude/plans/mktr-leads-agent-management.md`).

## What

- **`mktrLeadsClient.fetchAgents`**: drop the `is_active` filter (**keep** `role=eq.agent` — admins must never become assignable agents); select + normalize `agency`.
- **Adapter capability flags** (documented in `PlatformAdapter`):
  - `mirrorsIsActive` — the fetched list includes inactive rows; `runSync` mirrors each row's `is_active` both ways (deactivate **and** reactivate). Only truly-absent rows (account deleted / promoted to admin) reach the two-phase deletion block.
  - `authoritativeProfile` — upstream owns profile fields: overwrite `fullName` (+ re-derived first/last), `email` (never null-out), `companyName`←`agency`, so edits made in mktr-leads propagate and self-heal. **Lyfe is unchanged** (fill-only, active-only roster, absence-based deactivation).
- **`computeSyncUpdate()`**: the per-adapter update semantics extracted as a pure, unit-testable helper.
- **Per-row error isolation**: one bad row (e.g. a unique-email collision on an authoritative overwrite) skips + structured-logs (`agent_sync_row_failed`) instead of aborting the whole run.
- **`syncWithLock(adapterId, {wait:true})`**: blocking `pg_advisory_xact_lock` variant (15s `lock_timeout`) for the upcoming management endpoints — their post-write refresh must serialize **behind** an in-flight cron sync rather than silently skip like the try-lock cron path.
- `activeExternalIds` → `upstreamExternalIds` (the set is no longer active-only).

## Test

- New pure suite `agentSyncUpdate.test.js`: Lyfe fill-only vs mktr-leads mirror/authoritative — is_active both directions, name overwrite + first/last derivation, never-null-out email, agency↔companyName incl. clearing, phone stays fill-only, pending-deletion cleared when present upstream, no-op diff. **Runs locally — passing.**
- `mktrLeadsAdapter.test.js` updated: no `is_active` filter in the URL, `agency` in select + normalization, inactive-row passthrough, capability flags. **Passing.**
- Integration `mktrLeadsAgentSync.test.js` rewritten: **deactivated-upstream → mirrored inactive + `pending_deletion_at` NULL (the regression)**, reactivation, authoritative overwrite, truly-absent → still deactivated + pending-deleted, one-source conflict skip, Lyfe isolation, and try-lock-skip vs `{wait:true}`-blocks lock behavior. (Postgres-only; note CI currently halts before the integration step on the pre-existing red unit baseline — validated by deploy/observation.)
- Full unit suite failing set **identical to main's pre-existing baseline** (5 chronically-red suites) — no new regressions; +11 net new passing tests.

## After merge

Deploy, then live-verify: flip the App Review Tester `is_active` in mktr-leads → next sync mirrors inactive locally with NO `pending_deletion_at`; flip back → reactivates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)