### PR TITLE
feat(agents): admin endpoints to manage mktr-leads agents (invite/activate/deactivate/edit)

### DIFF
--- a/backend/src/controllers/mktrLeadsAgentController.js
+++ b/backend/src/controllers/mktrLeadsAgentController.js
@@ -1,5 +1,6 @@
 import { asyncHandler, AppError } from '../middleware/errorHandler.js';
 import { syncAgentsFromMktrLeads } from '../services/agentSyncService.js';
+import * as mgmt from '../services/mktrLeadsAgentManagementService.js';
 
 /**
  * POST /api/mktr-leads/agents/sync
@@ -22,4 +23,54 @@ export const syncAgents = asyncHandler(async (req, res) => {
       : `Sync complete: ${created} created, ${updated} updated, ${deactivated} deactivated, ${skipped} unchanged`,
     data: { created, updated, deactivated, skipped, total, locked: locked !== false },
   });
+});
+
+/**
+ * POST /api/mktr-leads/agents/invite
+ * Create a pending invitation IN MKTR-LEADS (its create-ext-agent-invite EF
+ * owns the semantics). The invitee signs into the MKTR Leads app with this
+ * phone via OTP; the agents row created on signup syncs here within ~10 min.
+ */
+export const inviteAgent = asyncHandler(async (req, res) => {
+  const { phone, full_name, email, agency } = req.body;
+  const result = await mgmt.inviteAgent({ phone, fullName: full_name, email, agency }, req.user);
+  res.status(201).json({
+    success: true,
+    message:
+      'Invitation created — the agent signs into the MKTR Leads app with this number to activate. They will appear in this list within ~10 minutes of signing up.',
+    data: result,
+  });
+});
+
+/**
+ * POST /api/mktr-leads/agents/:mktrUserId/activate
+ * POST /api/mktr-leads/agents/:mktrUserId/deactivate
+ * Write is_active to mktr-leads (source of truth), then mirror locally.
+ * Deactivation also locks the agent out of the mktr-leads app (OTP gate).
+ */
+export const activateAgent = asyncHandler(async (req, res) => {
+  const agent = await mgmt.setAgentActive(req.params.mktrUserId, true, req.user);
+  res.json({ success: true, message: 'Agent reactivated in mktr-leads', data: { agent } });
+});
+
+export const deactivateAgent = asyncHandler(async (req, res) => {
+  const agent = await mgmt.setAgentActive(req.params.mktrUserId, false, req.user);
+  res.json({
+    success: true,
+    message: 'Agent deactivated in mktr-leads — they can no longer sign into the MKTR Leads app and will stop receiving leads',
+    data: { agent },
+  });
+});
+
+/**
+ * PATCH /api/mktr-leads/agents/:mktrUserId
+ * Update profile fields (full_name/email/agency) in mktr-leads, then mirror.
+ */
+export const updateAgent = asyncHandler(async (req, res) => {
+  const fields = {};
+  for (const key of ['full_name', 'email', 'agency']) {
+    if (key in req.body) fields[key] = req.body[key];
+  }
+  const agent = await mgmt.updateAgentFields(req.params.mktrUserId, fields, req.user);
+  res.json({ success: true, message: 'Agent profile updated in mktr-leads', data: { agent } });
 });

--- a/backend/src/integrations/adapters/mktr-leads/mktrLeadsClient.js
+++ b/backend/src/integrations/adapters/mktr-leads/mktrLeadsClient.js
@@ -166,6 +166,78 @@ export async function fetchAgentById(externalId) {
   return normalized;
 }
 
+// ── Management write-backs (mktr-leads is the source of truth) ──────────────
+// Plain fetch, NOT the read breaker: a tripped sync breaker must not block an
+// admin action, and a failed admin action must not trip the sync breaker.
+
+const WRITE_TIMEOUT_MS = 10_000;
+
+/**
+ * Create a pending invitation by calling mktr-leads' own create-ext-agent-invite
+ * edge function with the service-role bearer — the EF is the single owner of
+ * invitation semantics (canonical SG phone normalization, agent-exists guard,
+ * revoke-then-insert re-invite, optional email). Returns { status, body } for
+ * the caller to map; non-2xx is NOT thrown (409/400 carry meaning).
+ */
+export async function createInvitation({ phone, fullName, email, agency }) {
+  const { url, key } = getConfig();
+  const response = await fetch(`${url}/functions/v1/create-ext-agent-invite`, {
+    method: 'POST',
+    headers: authHeaders(key),
+    body: JSON.stringify({
+      phone,
+      full_name: fullName || null,
+      email: email || null,
+      agency: agency || null,
+    }),
+    signal: AbortSignal.timeout(WRITE_TIMEOUT_MS),
+  });
+  const body = await response.json().catch(() => ({}));
+  return { status: response.status, body };
+}
+
+/**
+ * PATCH one mktr-leads agent row. The `role=eq.agent` filter is a hard guard:
+ * admin rows can never be touched from here, whatever the caller passes.
+ * Returns the updated row, or null when nothing matched (unknown id / admin).
+ */
+async function patchAgent(mktrUserId, payload) {
+  const { url, key } = getConfig();
+  const response = await fetch(
+    `${url}/rest/v1/agents?mktr_user_id=eq.${encodeURIComponent(mktrUserId)}&role=eq.agent`,
+    {
+      method: 'PATCH',
+      headers: { ...authHeaders(key), Prefer: 'return=representation' },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(WRITE_TIMEOUT_MS),
+    }
+  );
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`mktr-leads agents PATCH failed: ${response.status} ${text}`);
+  }
+  const rows = await response.json();
+  invalidateCache(); // the follow-up sync must see the fresh state
+  return rows[0] ?? null;
+}
+
+/** Flip is_active. NOTE: false also locks the agent out of the mktr-leads app (OTP gate). */
+export async function setAgentActive(mktrUserId, isActive) {
+  return patchAgent(mktrUserId, { is_active: isActive === true });
+}
+
+/**
+ * Update profile fields. `fields` may contain full_name / email / agency —
+ * only provided keys are sent (controller validates shape).
+ */
+export async function updateAgentFields(mktrUserId, fields) {
+  const payload = {};
+  if ('full_name' in fields) payload.full_name = fields.full_name || null;
+  if ('email' in fields) payload.email = fields.email || null;
+  if ('agency' in fields) payload.agency = fields.agency || null;
+  return patchAgent(mktrUserId, payload);
+}
+
 /** Exposed for tests + observability. */
 export function _getBreakerState() {
   return breaker.getState();

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -242,5 +242,23 @@ export const schemas = {
     description: Joi.string().allow('', null).optional(),
     isPublic: Joi.boolean().optional(),
     status: Joi.string().valid('active', 'inactive', 'draft', 'archived').optional()
-  })
+  }),
+
+  // mktr-leads agent management (admin dashboard → mktr-leads source of truth).
+  // Phone is a loose charset pre-check only — the mktr-leads edge function owns
+  // canonical SG normalization (normalize_sg_phone); duplicating it here would
+  // risk drift between what we accept and what links on signup.
+  mktrLeadsAgentInvite: Joi.object({
+    phone: Joi.string().trim().pattern(/^\+?[0-9 ()-]{8,16}$/).required()
+      .messages({ 'string.pattern.base': 'phone must be a Singapore mobile number' }),
+    full_name: Joi.string().trim().max(120).allow('', null).optional(),
+    email: Joi.string().trim().email().allow('', null).optional(),
+    agency: Joi.string().trim().max(120).allow('', null).optional()
+  }),
+
+  mktrLeadsAgentUpdate: Joi.object({
+    full_name: Joi.string().trim().min(1).max(120).optional(),
+    email: Joi.string().trim().email().allow('', null).optional(),
+    agency: Joi.string().trim().max(120).allow('', null).optional()
+  }).min(1)
 };

--- a/backend/src/routes/mktrLeadsAgents.js
+++ b/backend/src/routes/mktrLeadsAgents.js
@@ -1,6 +1,13 @@
 import express from 'express';
 import { authenticateToken, requireAdmin } from '../middleware/auth.js';
-import { syncAgents } from '../controllers/mktrLeadsAgentController.js';
+import { validate, schemas } from '../middleware/validation.js';
+import {
+  syncAgents,
+  inviteAgent,
+  activateAgent,
+  deactivateAgent,
+  updateAgent,
+} from '../controllers/mktrLeadsAgentController.js';
 
 export const meta = { path: '/api/mktr-leads' };
 
@@ -11,5 +18,12 @@ router.use(authenticateToken, requireAdmin);
 // Manual on-demand sync of mktr-leads agents → local User table. The 10-min
 // cron in bootstrap covers the steady state; this is for first rollout + ops.
 router.post('/agents/sync', syncAgents);
+
+// Management — mktr-leads is the source of truth; every action writes there
+// first, then mirrors locally (see mktrLeadsAgentManagementService).
+router.post('/agents/invite', validate(schemas.mktrLeadsAgentInvite), inviteAgent);
+router.post('/agents/:mktrUserId/activate', activateAgent);
+router.post('/agents/:mktrUserId/deactivate', deactivateAgent);
+router.patch('/agents/:mktrUserId', validate(schemas.mktrLeadsAgentUpdate), updateAgent);
 
 export default router;

--- a/backend/src/services/mktrLeadsAgentManagementService.js
+++ b/backend/src/services/mktrLeadsAgentManagementService.js
@@ -1,0 +1,175 @@
+/**
+ * @file mktrLeadsAgentManagementService — admin management of mktr-leads agents
+ * FROM the mktr-platform dashboard, with mktr-leads as the source of truth.
+ *
+ * Every action writes to mktr-leads FIRST (via mktrLeadsClient), then refreshes
+ * the local mirror by re-running the mktr-leads sync under the BLOCKING
+ * advisory-lock variant — serializing behind any in-flight cron sync so the
+ * response reflects the write (a try-lock skip would leave the dashboard stale
+ * for up to 10 minutes). The sync owns all matching/one-source-per-user rules,
+ * so there is no bespoke local upsert here.
+ *
+ * Invite is the exception twice over: it calls mktr-leads' own
+ * create-ext-agent-invite edge function (the single owner of invitation
+ * semantics — canonical phone normalization, agent-exists guard, re-invite
+ * dedup), and it does NOT refresh locally — no agents row exists until the
+ * invitee's first OTP sign-up creates one (the cron mirrors it within ~10 min).
+ */
+
+import * as defaultClient from '../integrations/adapters/mktr-leads/mktrLeadsClient.js';
+import { syncAgentsFromMktrLeads as defaultSync } from './agentSyncService.js';
+import DefaultUser from '../models/User.js';
+import { AppError } from '../middleware/errorHandler.js';
+import { logger as defaultLogger } from '../utils/logger.js';
+
+const MKTR_USER_ID_RE = /^[A-Za-z0-9_-]{8,64}$/;
+
+export function makeMktrLeadsAgentManagementService(overrides = {}) {
+  const d = {
+    client: defaultClient,
+    syncAgentsFromMktrLeads: defaultSync,
+    User: DefaultUser,
+    logger: defaultLogger,
+    ...overrides,
+  };
+
+  function ensureConfigured() {
+    if (!process.env.MKTR_LEADS_SUPABASE_URL || !process.env.MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY) {
+      throw new AppError(
+        'mktr-leads management is not configured (set MKTR_LEADS_SUPABASE_URL and MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY)',
+        503
+      );
+    }
+  }
+
+  function assertMktrUserId(mktrUserId) {
+    if (typeof mktrUserId !== 'string' || !MKTR_USER_ID_RE.test(mktrUserId)) {
+      throw new AppError('Invalid mktr-leads agent id', 400);
+    }
+  }
+
+  /**
+   * The upstream write SUCCEEDED when this runs — so a refresh failure (e.g.
+   * the 15s lock_timeout while a cron sync holds the lock, SQLSTATE 55P03)
+   * must not read as a failed action. Surface 503 with the honest state: the
+   * change is saved in mktr-leads and the cron will mirror it within ~10 min.
+   */
+  async function refreshAndLoad(mktrUserId) {
+    try {
+      await d.syncAgentsFromMktrLeads({ wait: true });
+    } catch (err) {
+      d.logger.warn(
+        { event: 'mktr_leads_mgmt_refresh_failed', mktrUserId, error: err?.message },
+        '[MktrLeadsMgmt] post-write sync refresh failed — cron will reconcile'
+      );
+      throw new AppError(
+        'Saved in mktr-leads, but the local refresh timed out — the change will appear here within ~10 minutes',
+        503
+      );
+    }
+    return d.User.findOne({ where: { mktrLeadsId: mktrUserId } });
+  }
+
+  /**
+   * Create a pending mktr-leads invitation. Status mapping is the contract with
+   * the EF (see its 409 enrichment): agent_exists + is_active drives the
+   * "reactivate instead" hint for deactivated agents.
+   */
+  async function inviteAgent({ phone, fullName, email, agency }, adminUser) {
+    ensureConfigured();
+    const { status, body } = await d.client.createInvitation({ phone, fullName, email, agency });
+
+    if (status === 200) {
+      d.logger.info(
+        {
+          event: 'mktr_leads_agent_invited',
+          adminId: adminUser?.id || null,
+          invitationId: body.invitation_id || null,
+          emailSent: body.email_sent === true,
+        },
+        '[MktrLeadsMgmt] invitation created'
+      );
+      return { invitationId: body.invitation_id || null, emailSent: body.email_sent === true };
+    }
+
+    if (status === 409) {
+      if (body.agent_exists) {
+        throw new AppError(
+          body.is_active
+            ? 'This phone already belongs to an active mktr-leads agent'
+            : 'This phone belongs to a deactivated mktr-leads agent — reactivate them instead of re-inviting',
+          409
+        );
+      }
+      throw new AppError(body.error || 'An invitation for this phone is already pending', 409);
+    }
+    if (status === 400) {
+      throw new AppError(body.error || 'mktr-leads rejected the phone number', 400);
+    }
+    if (status === 401 || status === 403) {
+      // Old EF still deployed (no service-auth branch) or key mismatch.
+      throw new AppError(
+        'mktr-leads rejected the service credentials — is the updated create-ext-agent-invite deployed?',
+        502
+      );
+    }
+    throw new AppError('mktr-leads invite failed', 502);
+  }
+
+  /** Flip is_active in mktr-leads, then mirror locally. false = app lockout (OTP gate). */
+  async function setAgentActive(mktrUserId, isActive, adminUser) {
+    ensureConfigured();
+    assertMktrUserId(mktrUserId);
+
+    const row = await d.client.setAgentActive(mktrUserId, isActive === true);
+    if (!row) {
+      // Unknown id — or an admin row, which the client's role=eq.agent filter
+      // refuses to touch by construction.
+      throw new AppError('mktr-leads agent not found (admins cannot be managed from here)', 404);
+    }
+
+    d.logger.info(
+      {
+        event: 'mktr_leads_agent_managed',
+        action: isActive ? 'activate' : 'deactivate',
+        mktrUserId,
+        adminId: adminUser?.id || null,
+      },
+      `[MktrLeadsMgmt] agent ${isActive ? 'activated' : 'deactivated'}`
+    );
+
+    return refreshAndLoad(mktrUserId);
+  }
+
+  /** Update profile fields (full_name/email/agency) in mktr-leads, then mirror locally. */
+  async function updateAgentFields(mktrUserId, fields, adminUser) {
+    ensureConfigured();
+    assertMktrUserId(mktrUserId);
+
+    const row = await d.client.updateAgentFields(mktrUserId, fields);
+    if (!row) {
+      throw new AppError('mktr-leads agent not found (admins cannot be managed from here)', 404);
+    }
+
+    d.logger.info(
+      {
+        event: 'mktr_leads_agent_managed',
+        action: 'update',
+        mktrUserId,
+        fields: Object.keys(fields),
+        adminId: adminUser?.id || null,
+      },
+      '[MktrLeadsMgmt] agent profile updated'
+    );
+
+    return refreshAndLoad(mktrUserId);
+  }
+
+  return { inviteAgent, setAgentActive, updateAgentFields };
+}
+
+// --- Backward-compatible named exports (house pattern) ---
+const _default = makeMktrLeadsAgentManagementService();
+export const inviteAgent = _default.inviteAgent;
+export const setAgentActive = _default.setAgentActive;
+export const updateAgentFields = _default.updateAgentFields;

--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -22,6 +22,11 @@ export const logger = pino({
       'access_token',
       'accessToken',
       'meta_capi_access_token',
+      // Supabase service-role credentials (Lyfe + mktr-leads adapters) — never
+      // let a logged request/err object leak them.
+      'apikey',
+      'headers.apikey',
+      'serviceRoleKey',
     ],
     censor: '[REDACTED]',
   },

--- a/backend/test/unit/mktrLeadsAgentManagement.test.js
+++ b/backend/test/unit/mktrLeadsAgentManagement.test.js
@@ -1,0 +1,148 @@
+import { jest } from '@jest/globals';
+import '../setup.js';
+import { makeMktrLeadsAgentManagementService } from '../../src/services/mktrLeadsAgentManagementService.js';
+
+describe('mktrLeadsAgentManagementService', () => {
+  let client, sync, User, logger, svc;
+  const admin = { id: 'admin-1' };
+  const localRow = { id: 'u1', mktrLeadsId: 'mu_12345678', isActive: true };
+
+  beforeEach(() => {
+    process.env.MKTR_LEADS_SUPABASE_URL = 'https://proj.supabase.co';
+    process.env.MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY = 'svc-key';
+    client = {
+      createInvitation: jest.fn(),
+      setAgentActive: jest.fn(),
+      updateAgentFields: jest.fn(),
+    };
+    sync = jest.fn().mockResolvedValue({ locked: true });
+    User = { findOne: jest.fn().mockResolvedValue(localRow) };
+    logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+    svc = makeMktrLeadsAgentManagementService({ client, syncAgentsFromMktrLeads: sync, User, logger });
+  });
+
+  afterEach(() => {
+    delete process.env.MKTR_LEADS_SUPABASE_URL;
+    delete process.env.MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY;
+  });
+
+  describe('configuration gate', () => {
+    it('throws 503 when env is unset', async () => {
+      delete process.env.MKTR_LEADS_SUPABASE_URL;
+      await expect(svc.inviteAgent({ phone: '91234567' }, admin)).rejects.toMatchObject({ statusCode: 503 });
+      expect(client.createInvitation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('inviteAgent — EF status mapping', () => {
+    it('200 → returns invitationId + emailSent and audit-logs', async () => {
+      client.createInvitation.mockResolvedValue({ status: 200, body: { invitation_id: 'inv1', email_sent: true } });
+      const res = await svc.inviteAgent({ phone: '91234567', fullName: 'Ada' }, admin);
+      expect(res).toEqual({ invitationId: 'inv1', emailSent: true });
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'mktr_leads_agent_invited', adminId: 'admin-1' }),
+        expect.any(String)
+      );
+    });
+
+    it('409 agent_exists ACTIVE → 409 "already an active agent"', async () => {
+      client.createInvitation.mockResolvedValue({ status: 409, body: { agent_exists: true, is_active: true } });
+      await expect(svc.inviteAgent({ phone: '91234567' }, admin)).rejects.toMatchObject({
+        statusCode: 409,
+        message: expect.stringContaining('active mktr-leads agent'),
+      });
+    });
+
+    it('409 agent_exists INACTIVE → 409 with the "reactivate instead" hint', async () => {
+      client.createInvitation.mockResolvedValue({ status: 409, body: { agent_exists: true, is_active: false } });
+      await expect(svc.inviteAgent({ phone: '91234567' }, admin)).rejects.toMatchObject({
+        statusCode: 409,
+        message: expect.stringContaining('reactivate'),
+      });
+    });
+
+    it('409 pending-invite → 409 passthrough', async () => {
+      client.createInvitation.mockResolvedValue({ status: 409, body: { error: 'An invitation for this phone is already pending' } });
+      await expect(svc.inviteAgent({ phone: '91234567' }, admin)).rejects.toMatchObject({
+        statusCode: 409,
+        message: expect.stringContaining('already pending'),
+      });
+    });
+
+    it('400 → 400 (EF rejected the phone)', async () => {
+      client.createInvitation.mockResolvedValue({ status: 400, body: { error: 'Valid SG phone required' } });
+      await expect(svc.inviteAgent({ phone: '12345678' }, admin)).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it('401 (old EF without service auth) → 502 with a deploy hint', async () => {
+      client.createInvitation.mockResolvedValue({ status: 401, body: { error: 'Invalid session' } });
+      await expect(svc.inviteAgent({ phone: '91234567' }, admin)).rejects.toMatchObject({
+        statusCode: 502,
+        message: expect.stringContaining('create-ext-agent-invite deployed'),
+      });
+    });
+  });
+
+  describe('setAgentActive', () => {
+    it('writes to mktr-leads, then refreshes via BLOCKING sync, then returns the local row', async () => {
+      client.setAgentActive.mockResolvedValue({ mktr_user_id: 'mu_12345678', is_active: false });
+
+      const res = await svc.setAgentActive('mu_12345678', false, admin);
+
+      expect(client.setAgentActive).toHaveBeenCalledWith('mu_12345678', false);
+      expect(sync).toHaveBeenCalledWith({ wait: true });
+      expect(User.findOne).toHaveBeenCalledWith({ where: { mktrLeadsId: 'mu_12345678' } });
+      expect(res).toBe(localRow);
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'mktr_leads_agent_managed', action: 'deactivate', adminId: 'admin-1' }),
+        expect.any(String)
+      );
+    });
+
+    it('404s when the PATCH matched nothing (unknown id / admin row)', async () => {
+      client.setAgentActive.mockResolvedValue(null);
+      await expect(svc.setAgentActive('mu_ghost', true, admin)).rejects.toMatchObject({ statusCode: 404 });
+      expect(sync).not.toHaveBeenCalled();
+    });
+
+    it('rejects malformed ids before any network call', async () => {
+      await expect(svc.setAgentActive('bad id!', true, admin)).rejects.toMatchObject({ statusCode: 400 });
+      expect(client.setAgentActive).not.toHaveBeenCalled();
+    });
+
+    it('maps a refresh failure (lock timeout) to 503 WITHOUT failing the upstream write', async () => {
+      client.setAgentActive.mockResolvedValue({ mktr_user_id: 'mu_12345678', is_active: false });
+      sync.mockRejectedValue(Object.assign(new Error('canceling statement due to lock timeout'), { original: { code: '55P03' } }));
+
+      await expect(svc.setAgentActive('mu_12345678', false, admin)).rejects.toMatchObject({
+        statusCode: 503,
+        message: expect.stringContaining('Saved in mktr-leads'),
+      });
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'mktr_leads_mgmt_refresh_failed' }),
+        expect.any(String)
+      );
+    });
+  });
+
+  describe('updateAgentFields', () => {
+    it('writes the fields, refreshes, returns the local row, audit-logs the changed keys', async () => {
+      client.updateAgentFields.mockResolvedValue({ mktr_user_id: 'mu_12345678' });
+
+      const res = await svc.updateAgentFields('mu_12345678', { full_name: 'New Name', agency: 'Acme' }, admin);
+
+      expect(client.updateAgentFields).toHaveBeenCalledWith('mu_12345678', { full_name: 'New Name', agency: 'Acme' });
+      expect(sync).toHaveBeenCalledWith({ wait: true });
+      expect(res).toBe(localRow);
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'mktr_leads_agent_managed', action: 'update', fields: ['full_name', 'agency'] }),
+        expect.any(String)
+      );
+    });
+
+    it('404s when nothing matched', async () => {
+      client.updateAgentFields.mockResolvedValue(null);
+      await expect(svc.updateAgentFields('mu_ghost', { full_name: 'X' }, admin)).rejects.toMatchObject({ statusCode: 404 });
+    });
+  });
+});

--- a/backend/test/unit/mktrLeadsClientWrites.test.js
+++ b/backend/test/unit/mktrLeadsClientWrites.test.js
@@ -1,0 +1,91 @@
+import { jest } from '@jest/globals';
+import '../setup.js';
+import * as client from '../../src/integrations/adapters/mktr-leads/mktrLeadsClient.js';
+
+describe('mktrLeadsClient write-backs', () => {
+  const realFetch = global.fetch;
+  let fetchMock;
+
+  beforeEach(() => {
+    process.env.MKTR_LEADS_SUPABASE_URL = 'https://proj.supabase.co';
+    process.env.MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY = 'svc-key';
+    client.invalidateCache();
+    fetchMock = jest.fn();
+    global.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    delete process.env.MKTR_LEADS_SUPABASE_URL;
+    delete process.env.MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY;
+  });
+
+  describe('createInvitation', () => {
+    it('POSTs to the create-ext-agent-invite EF with the service bearer and snake_case body', async () => {
+      fetchMock.mockResolvedValue({ status: 200, json: async () => ({ success: true, invitation_id: 'inv1', email_sent: true }) });
+
+      const res = await client.createInvitation({ phone: '91234567', fullName: 'Ada Tan', email: 'ada@x.com', agency: 'Acme' });
+
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://proj.supabase.co/functions/v1/create-ext-agent-invite');
+      expect(opts.method).toBe('POST');
+      expect(opts.headers.Authorization).toBe('Bearer svc-key');
+      expect(JSON.parse(opts.body)).toEqual({ phone: '91234567', full_name: 'Ada Tan', email: 'ada@x.com', agency: 'Acme' });
+      expect(res).toEqual({ status: 200, body: { success: true, invitation_id: 'inv1', email_sent: true } });
+    });
+
+    it('returns non-2xx statuses with their body instead of throwing (409/400 carry meaning)', async () => {
+      fetchMock.mockResolvedValue({ status: 409, json: async () => ({ error: 'Phone already belongs to an agent', agent_exists: true, is_active: false }) });
+      const res = await client.createInvitation({ phone: '91234567' });
+      expect(res.status).toBe(409);
+      expect(res.body.agent_exists).toBe(true);
+      expect(res.body.is_active).toBe(false);
+    });
+
+    it('nulls out omitted optional fields', async () => {
+      fetchMock.mockResolvedValue({ status: 200, json: async () => ({}) });
+      await client.createInvitation({ phone: '91234567' });
+      expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ phone: '91234567', full_name: null, email: null, agency: null });
+    });
+  });
+
+  describe('setAgentActive / updateAgentFields (PATCH agents)', () => {
+    const okRow = { mktr_user_id: 'mu_1', is_active: false };
+
+    it('PATCHes with the role=eq.agent hard guard and an ENCODED id, returns the row', async () => {
+      fetchMock.mockResolvedValue({ ok: true, json: async () => [okRow], text: async () => '' });
+
+      const row = await client.setAgentActive('mu/1 weird', false);
+
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toContain('/rest/v1/agents?');
+      expect(url).toContain(`mktr_user_id=eq.${encodeURIComponent('mu/1 weird')}`);
+      expect(url).toContain('role=eq.agent'); // admins untouchable by construction
+      expect(opts.method).toBe('PATCH');
+      expect(opts.headers.Prefer).toBe('return=representation');
+      expect(JSON.parse(opts.body)).toEqual({ is_active: false });
+      expect(row).toEqual(okRow);
+    });
+
+    it('returns null when nothing matched (unknown id or admin row)', async () => {
+      fetchMock.mockResolvedValue({ ok: true, json: async () => [], text: async () => '' });
+      const row = await client.setAgentActive('mu_admin', true);
+      expect(row).toBeNull();
+    });
+
+    it('throws on a non-ok PATCH response', async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 500, json: async () => ({}), text: async () => 'boom' });
+      await expect(client.setAgentActive('mu_1', true)).rejects.toThrow(/PATCH failed: 500/);
+    });
+
+    it('updateAgentFields sends ONLY the provided keys (empty-string → null)', async () => {
+      fetchMock.mockResolvedValue({ ok: true, json: async () => [okRow], text: async () => '' });
+
+      await client.updateAgentFields('mu_1', { full_name: 'New Name', agency: '' });
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body).toEqual({ full_name: 'New Name', agency: null });
+      expect('email' in body).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Why

Part 2 of 3 of the mktr-leads agent-management feature ([plan reviewed by Codex, re-verified](https://github.com/slzwei/mktr-platform/pull/37)). mktr-leads has no admin UI of its own, so the mktr-platform dashboard manages its agents — with **mktr-leads as the source of truth**: every action writes there first, then refreshes the local mirror by re-running the sync under PR #37's **blocking** advisory-lock variant (`{wait:true}`), serializing behind any in-flight cron sync. No bespoke local upsert — the sync owns matching + one-source-per-user rules.

## Endpoints (admin-only, `/api/mktr-leads` — already in the redeem.sg blocklist)

| Endpoint | Behavior |
|---|---|
| `POST /agents/invite` | Proxies mktr-leads' own `create-ext-agent-invite` EF (single owner of invitation semantics) with the service-role bearer. No local write — the agents row appears on the invitee's first OTP signup, syncs in ≤10 min. |
| `POST /agents/:mktrUserId/activate` / `deactivate` | PATCH `is_active` upstream → blocking sync → return refreshed local row. Deactivate response states the real effect: **app lockout** (OTP gate) + no more leads. |
| `PATCH /agents/:mktrUserId` | `full_name`/`email`/`agency` upstream (agency → `users.companyName` via #37's authoritative profile) → same refresh. |

**Invite status mapping:** 409 `agent_exists` + `is_active:false` → "reactivate instead of re-inviting" (a re-invite can never resurrect an account — `handle_new_user` only fires on first signup); 401/403 → 502 *"is the updated create-ext-agent-invite deployed?"* (depends on [mktr-leads #2](https://github.com/slzwei/mktr-leads/pull/2), merged — **deploy pending**).

## Hardening (per the Codex plan review)

- Client PATCHes always carry **`role=eq.agent`** — admin rows untouchable by construction; ids `encodeURIComponent`'d; writes use plain fetch (10s timeout), **not** the read breaker (a tripped sync breaker must not block admin actions and vice versa); client cache invalidated post-write.
- Joi schemas (loose phone charset only — the EF owns canonical normalization, zero drift); `:mktrUserId` validated before any network call.
- Refresh failure (15s lock timeout) → **503 with the honest state**: saved upstream, cron reconciles in ≤10 min — never reads as a failed action.
- Structured audit logs (`mktr_leads_agent_managed`: admin id, action, changed fields). Pino redaction extended (`apikey`, service-role paths).

## Test

`mktrLeadsClientWrites` (EF call shape, role-guard, encoding, only-provided-keys, null-out, non-ok throw) + `mktrLeadsAgentManagement` DI suite (env gate, all 5 EF status mappings, 404 no-match, pre-network id validation, write→blocking-sync→load order, lock-timeout→503). **40/40 locally; full unit suite failing set identical to main's baseline.**

## Deploy notes
- Works for activate/deactivate/edit immediately (PR #37 is live).
- The **invite** path returns 502-with-hint until mktr-leads #2 is deployed (`supabase db push` + `supabase functions deploy create-ext-agent-invite`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)