### PR TITLE
fix(agents): authenticate mktr-leads invites via dedicated x-service-secret header

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,3 +65,4 @@ MKTR_LEADS_SUPABASE_URL=             # Supabase project URL (mktr-leads `agents`
 MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY= # Service-role key (bypasses RLS)
 MKTR_LEADS_WEBHOOK_URL=              # e.g. https://<project>.supabase.co/functions/v1/receive-mktr-lead
 MKTR_LEADS_WEBHOOK_SECRET=           # Shared HMAC secret (must match MKTR_WEBHOOK_SECRET in mktr-leads)
+MKTR_LEADS_INVITE_SECRET=            # Admin-invite secret (must match the EF's MKTR_PLATFORM_INVITE_SECRET)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -227,6 +227,9 @@ MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 MKTR_LEADS_WEBHOOK_URL=https://<project>.supabase.co/functions/v1/receive-mktr-lead
 # Shared HMAC secret (must match MKTR_WEBHOOK_SECRET in the mktr-leads edge fn)
 MKTR_LEADS_WEBHOOK_SECRET=your-shared-webhook-secret
+# Dedicated secret for admin invites via the mktr-leads create-ext-agent-invite
+# edge fn (must match its MKTR_PLATFORM_INVITE_SECRET function secret)
+MKTR_LEADS_INVITE_SECRET=your-invite-service-secret
 
 # -----------------------------------------------------------------------------
 # Sentry Error Tracking (optional)

--- a/backend/env.example
+++ b/backend/env.example
@@ -116,3 +116,4 @@ MKTR_LEADS_SUPABASE_URL=https://<project>.supabase.co
 MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 MKTR_LEADS_WEBHOOK_URL=https://<project>.supabase.co/functions/v1/receive-mktr-lead
 MKTR_LEADS_WEBHOOK_SECRET=your-shared-webhook-secret
+MKTR_LEADS_INVITE_SECRET=your-invite-service-secret

--- a/backend/src/integrations/adapters/mktr-leads/mktrLeadsClient.js
+++ b/backend/src/integrations/adapters/mktr-leads/mktrLeadsClient.js
@@ -174,16 +174,26 @@ const WRITE_TIMEOUT_MS = 10_000;
 
 /**
  * Create a pending invitation by calling mktr-leads' own create-ext-agent-invite
- * edge function with the service-role bearer — the EF is the single owner of
- * invitation semantics (canonical SG phone normalization, agent-exists guard,
- * revoke-then-insert re-invite, optional email). Returns { status, body } for
- * the caller to map; non-2xx is NOT thrown (409/400 carry meaning).
+ * edge function — the EF is the single owner of invitation semantics (canonical
+ * SG phone normalization, agent-exists guard, revoke-then-insert re-invite,
+ * optional email). Returns { status, body } for the caller to map; non-2xx is
+ * NOT thrown (409/400 carry meaning).
+ *
+ * Auth is two-part: the service-role bearer passes the platform verify_jwt
+ * gate, and the dedicated `x-service-secret` (MKTR_LEADS_INVITE_SECRET, equal
+ * to the EF's MKTR_PLATFORM_INVITE_SECRET) is what the EF actually trusts —
+ * the runtime-injected SUPABASE_SERVICE_ROLE_KEY is not string-comparable
+ * across Supabase key formats, so a dedicated rotatable secret is used instead.
  */
 export async function createInvitation({ phone, fullName, email, agency }) {
   const { url, key } = getConfig();
+  const inviteSecret = process.env.MKTR_LEADS_INVITE_SECRET;
+  if (!inviteSecret) {
+    throw new AppError('MKTR_LEADS_INVITE_SECRET must be configured for mktr-leads invites', 500);
+  }
   const response = await fetch(`${url}/functions/v1/create-ext-agent-invite`, {
     method: 'POST',
-    headers: authHeaders(key),
+    headers: { ...authHeaders(key), 'x-service-secret': inviteSecret },
     body: JSON.stringify({
       phone,
       full_name: fullName || null,

--- a/backend/src/services/mktrLeadsAgentManagementService.js
+++ b/backend/src/services/mktrLeadsAgentManagementService.js
@@ -77,6 +77,14 @@ export function makeMktrLeadsAgentManagementService(overrides = {}) {
    */
   async function inviteAgent({ phone, fullName, email, agency }, adminUser) {
     ensureConfigured();
+    // The invite path additionally needs the dedicated EF secret (the EF's
+    // MKTR_PLATFORM_INVITE_SECRET) — activate/edit go via PostgREST and don't.
+    if (!process.env.MKTR_LEADS_INVITE_SECRET) {
+      throw new AppError(
+        'mktr-leads invites are not configured (set MKTR_LEADS_INVITE_SECRET to the value of the create-ext-agent-invite function secret MKTR_PLATFORM_INVITE_SECRET)',
+        503
+      );
+    }
     const { status, body } = await d.client.createInvitation({ phone, fullName, email, agency });
 
     if (status === 200) {

--- a/backend/test/unit/mktrLeadsAgentManagement.test.js
+++ b/backend/test/unit/mktrLeadsAgentManagement.test.js
@@ -10,6 +10,7 @@ describe('mktrLeadsAgentManagementService', () => {
   beforeEach(() => {
     process.env.MKTR_LEADS_SUPABASE_URL = 'https://proj.supabase.co';
     process.env.MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY = 'svc-key';
+    process.env.MKTR_LEADS_INVITE_SECRET = 'invite-secret';
     client = {
       createInvitation: jest.fn(),
       setAgentActive: jest.fn(),
@@ -24,12 +25,22 @@ describe('mktrLeadsAgentManagementService', () => {
   afterEach(() => {
     delete process.env.MKTR_LEADS_SUPABASE_URL;
     delete process.env.MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY;
+    delete process.env.MKTR_LEADS_INVITE_SECRET;
   });
 
   describe('configuration gate', () => {
     it('throws 503 when env is unset', async () => {
       delete process.env.MKTR_LEADS_SUPABASE_URL;
       await expect(svc.inviteAgent({ phone: '91234567' }, admin)).rejects.toMatchObject({ statusCode: 503 });
+      expect(client.createInvitation).not.toHaveBeenCalled();
+    });
+
+    it('invite throws 503 with a setup hint when MKTR_LEADS_INVITE_SECRET is unset', async () => {
+      delete process.env.MKTR_LEADS_INVITE_SECRET;
+      await expect(svc.inviteAgent({ phone: '91234567' }, admin)).rejects.toMatchObject({
+        statusCode: 503,
+        message: expect.stringContaining('MKTR_LEADS_INVITE_SECRET'),
+      });
       expect(client.createInvitation).not.toHaveBeenCalled();
     });
   });

--- a/backend/test/unit/mktrLeadsClientWrites.test.js
+++ b/backend/test/unit/mktrLeadsClientWrites.test.js
@@ -9,6 +9,7 @@ describe('mktrLeadsClient write-backs', () => {
   beforeEach(() => {
     process.env.MKTR_LEADS_SUPABASE_URL = 'https://proj.supabase.co';
     process.env.MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY = 'svc-key';
+    process.env.MKTR_LEADS_INVITE_SECRET = 'invite-secret';
     client.invalidateCache();
     fetchMock = jest.fn();
     global.fetch = fetchMock;
@@ -18,10 +19,11 @@ describe('mktrLeadsClient write-backs', () => {
     global.fetch = realFetch;
     delete process.env.MKTR_LEADS_SUPABASE_URL;
     delete process.env.MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY;
+    delete process.env.MKTR_LEADS_INVITE_SECRET;
   });
 
   describe('createInvitation', () => {
-    it('POSTs to the create-ext-agent-invite EF with the service bearer and snake_case body', async () => {
+    it('POSTs to the create-ext-agent-invite EF with the service bearer + dedicated x-service-secret and snake_case body', async () => {
       fetchMock.mockResolvedValue({ status: 200, json: async () => ({ success: true, invitation_id: 'inv1', email_sent: true }) });
 
       const res = await client.createInvitation({ phone: '91234567', fullName: 'Ada Tan', email: 'ada@x.com', agency: 'Acme' });
@@ -29,9 +31,16 @@ describe('mktrLeadsClient write-backs', () => {
       const [url, opts] = fetchMock.mock.calls[0];
       expect(url).toBe('https://proj.supabase.co/functions/v1/create-ext-agent-invite');
       expect(opts.method).toBe('POST');
-      expect(opts.headers.Authorization).toBe('Bearer svc-key');
+      expect(opts.headers.Authorization).toBe('Bearer svc-key'); // passes the platform verify_jwt gate
+      expect(opts.headers['x-service-secret']).toBe('invite-secret'); // what the EF actually trusts
       expect(JSON.parse(opts.body)).toEqual({ phone: '91234567', full_name: 'Ada Tan', email: 'ada@x.com', agency: 'Acme' });
       expect(res).toEqual({ status: 200, body: { success: true, invitation_id: 'inv1', email_sent: true } });
+    });
+
+    it('throws a clear config error when MKTR_LEADS_INVITE_SECRET is unset (no network call)', async () => {
+      delete process.env.MKTR_LEADS_INVITE_SECRET;
+      await expect(client.createInvitation({ phone: '91234567' })).rejects.toThrow(/MKTR_LEADS_INVITE_SECRET/);
+      expect(fetchMock).not.toHaveBeenCalled();
     });
 
     it('returns non-2xx statuses with their body instead of throwing (409/400 carry meaning)', async () => {


### PR DESCRIPTION
## Why

Follow-up to #38. The invite EF's service auth originally compared the bearer against the runtime-injected \`SUPABASE_SERVICE_ROLE_KEY\`, but on the mktr-leads project (new \`sb_secret\` API keys enabled) the injected value differs from the legacy JWT key we send — verified live: every service call 401'd. The EF now trusts a **dedicated \`x-service-secret\`** (mktr-leads [#3](https://github.com/slzwei/mktr-leads/pull/3), already deployed + probe-verified: correct secret → 400 validation; wrong/missing → 401).

## What

- \`mktrLeadsClient.createInvitation\` sends \`x-service-secret\` from **\`MKTR_LEADS_INVITE_SECRET\`** (same value as the EF's \`MKTR_PLATFORM_INVITE_SECRET\` function secret, already set on the project) alongside the service-role bearer (which still passes the platform verify_jwt gate). Clear 500 if unset, before any network call.
- \`inviteAgent\` pre-checks the env with a 503 setup hint (activate/edit go via PostgREST and don't need it).
- Env examples ×3; tests for the header, the missing-secret client error, and the 503 gate. 31/31 locally.

## Deploy
Render env needs \`MKTR_LEADS_INVITE_SECRET\` (value provisioned during the EF deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)