### PR TITLE
feat(agents-ui): manage mktr-leads agents from the AdminAgents dashboard

### DIFF
--- a/src/components/agents/AgentFormDialog.jsx
+++ b/src/components/agents/AgentFormDialog.jsx
@@ -17,7 +17,12 @@ import SubmitButton from"@/components/common/SubmitButton";
 import { agentInviteSchema } from"@/schemas/agent";
 
 const formatSgPhone = (raw) => {
- const digits = String(raw ||"").replace(/\D/g,"").slice(0, 8);
+ let digits = String(raw ||"").replace(/\D/g,"");
+ // Stored canonical form is 65XXXXXXXX — strip the country code instead of
+ // truncating the trailing digits (the old slice(0,8) mangled"6591234567"
+ // into"6591 2345").
+ if (digits.length === 10 && digits.startsWith("65")) digits = digits.slice(2);
+ digits = digits.slice(0, 8);
  if (digits.length <= 4) return digits;
  return `${digits.slice(0, 4)} ${digits.slice(4)}`;
 };

--- a/src/components/agents/AgentTable.jsx
+++ b/src/components/agents/AgentTable.jsx
@@ -35,11 +35,17 @@ import {
  UserCheck,
 } from"lucide-react";
 import { format } from"date-fns";
+import { sourceBadge, isLyfeAgent, isMktrLeadsAgent, isLocalAgent } from"@/lib/agentSource";
 
 /**
  * Determines whether an agent is in a"pending registration"state.
+ * Only meaningful for LOCAL rows: mirrored agents (Lyfe / MKTR Leads) have no
+ * local password and emailVerified=false by construction, so without the
+ * source guard every mirrored agent rendered as"Invited"with a Resend item —
+ * hiding the Activate/Deactivate action entirely.
  */
 const isPending = (agent) =>
+ isLocalAgent(agent) &&
  agent?.isActive === true &&
  (agent?.status ==="pending_registration"||
  !!agent?.invitationToken ||
@@ -102,11 +108,14 @@ export default function AgentTable({
  <TableHeader>
  <TableRow className="bg-muted/50 hover:bg-muted/50 border-border">
  <TableHead className="w-12 h-12 px-4 text-center">
+ {/* Selection exists only for bulk-DELETE, which is a local-row concept:
+ mirrored agents are owned by their source app. */}
  <Checkbox
  checked={
- agents.length > 0 &&
- selectedAgentIds.length === agents.length
+ agents.some(isLocalAgent) &&
+ selectedAgentIds.length === agents.filter(isLocalAgent).length
  }
+ disabled={!agents.some(isLocalAgent)}
  onCheckedChange={onSelectAll}
  aria-label="Select all" />
  </TableHead>
@@ -115,6 +124,9 @@ export default function AgentTable({
  </TableHead>
  <TableHead className="py-3 px-6 font-medium text-muted-foreground min-w-[250px]">
  Contact
+ </TableHead>
+ <TableHead className="py-3 px-6 font-medium text-muted-foreground min-w-[110px]">
+ Source
  </TableHead>
  <TableHead className="py-3 px-6 font-medium text-muted-foreground min-w-[140px]">
  Status
@@ -133,7 +145,7 @@ export default function AgentTable({
  <TableBody>
  {agents.length === 0 ? (
  <TableEmpty
- colSpan={7}
+ colSpan={8}
  icon={UserCheck}
  title="No agents found"
  description="Try adjusting your filters, or invite a new agent to get started." />
@@ -187,6 +199,10 @@ const AgentRow = React.memo(function AgentRow({
  agent.approvalStatus ==="pending"|| agent.status ==="pending_approval";
  const pendingRegistration = isPending(agent);
  const isActive = agent.isActive && !pendingApproval && !pendingRegistration;
+ const lyfe = isLyfeAgent(agent);
+ const mktrLeads = isMktrLeadsAgent(agent);
+ const local = isLocalAgent(agent);
+ const source = sourceBadge(agent);
 
  const renderStatusBadge = () => {
  if (pendingApproval)
@@ -223,10 +239,11 @@ const AgentRow = React.memo(function AgentRow({
  className={`hover:bg-muted/50 border-border ${
  isSelected ?"bg-primary/10":"" }`}
  >
- {/* Checkbox */}
+ {/* Checkbox — selection drives bulk-delete, a local-row concept */}
  <TableCell className="px-4 text-center">
  <Checkbox
  checked={isSelected}
+ disabled={!local}
  onCheckedChange={(checked) => onSelect(agent.id, checked)}
  aria-label={`Select ${agent.fullName}`}
  />
@@ -266,6 +283,13 @@ const AgentRow = React.memo(function AgentRow({
  </div>
  )}
  </div>
+ </TableCell>
+
+ {/* Source */}
+ <TableCell className="px-6 py-4">
+ <Badge variant="outline" className={`${source.className} hover:bg-transparent whitespace-nowrap`}>
+ {source.label}
+ </Badge>
  </TableCell>
 
  {/* Status */}
@@ -316,8 +340,8 @@ const AgentRow = React.memo(function AgentRow({
  <UserCheck className="mr-2 h-4 w-4"/> View Assigned Leads
  </Link>
  </DropdownMenuItem>
- <DropdownMenuItem onClick={() => onEditAgent(agent)}>
- <Edit className="mr-2 h-4 w-4"/> Edit Profile
+ <DropdownMenuItem onClick={() => onEditAgent(agent)} disabled={lyfe}>
+ <Edit className="mr-2 h-4 w-4"/> {lyfe ?"Edit (managed in Lyfe)":"Edit Profile"}
  </DropdownMenuItem>
  <DropdownMenuSeparator />
  <DropdownMenuItem onClick={() => onManagePackages(agent)}>
@@ -346,23 +370,29 @@ const AgentRow = React.memo(function AgentRow({
  <Mail className="mr-2 h-4 w-4"/> Resend Invite
  </DropdownMenuItem>
  ) : (
- <DropdownMenuItem onClick={() => onToggleStatus(agent)}>
+ <DropdownMenuItem onClick={() => onToggleStatus(agent)} disabled={lyfe}>
  {agent.isActive ? (
  <>
- <ShieldAlert className="mr-2 h-4 w-4"/> Deactivate
+ <ShieldAlert className="mr-2 h-4 w-4"/>
+ {lyfe ?"Deactivate (in Lyfe)": mktrLeads ?"Deactivate in MKTR Leads":"Deactivate"}
  </>
  ) : (
  <>
- <CheckCircle className="mr-2 h-4 w-4"/> Activate
+ <CheckCircle className="mr-2 h-4 w-4"/>
+ {lyfe ?"Activate (in Lyfe)": mktrLeads ?"Reactivate in MKTR Leads":"Activate"}
  </>
  )}
  </DropdownMenuItem>
  )}
  <DropdownMenuSeparator />
+ {/* Delete is a local-row concept; mirrored agents are owned by their
+ source app — retire them by deactivating instead. */}
  <DropdownMenuItem
  onClick={() => onDeleteAgent(agent)}
+ disabled={!local}
  className="text-destructive" >
- <Trash2 className="mr-2 h-4 w-4"/> Delete Agent
+ <Trash2 className="mr-2 h-4 w-4"/>
+ {local ?"Delete Agent": lyfe ?"Delete (managed in Lyfe)":"Delete (deactivate instead)"}
  </DropdownMenuItem>
  </DropdownMenuContent>
  </DropdownMenu>

--- a/src/components/agents/MktrLeadsAgentDialog.jsx
+++ b/src/components/agents/MktrLeadsAgentDialog.jsx
@@ -1,0 +1,117 @@
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import Save from "lucide-react/icons/save";
+import FormRow from "@/components/common/FormRow";
+import SubmitButton from "@/components/common/SubmitButton";
+import { mktrLeadsInviteSchema, mktrLeadsEditSchema } from "@/schemas/mktrLeadsAgent";
+
+/**
+ * Invite (agent === null) or edit (agent with mktrLeadsId) an MKTR Leads agent.
+ *
+ * MKTR Leads is the source of truth: invites create a pending invitation in
+ * that app (the person signs in there with their phone via OTP, which creates
+ * the agent account; it mirrors here within ~10 minutes), and edits write back
+ * to that app before refreshing the local mirror. Phone is identity in MKTR
+ * Leads, so it is required on invite and not editable afterwards.
+ */
+export default function MktrLeadsAgentDialog({ open, onOpenChange, agent, onSubmit }) {
+  const isEdit = !!agent;
+  const {
+    register,
+    handleSubmit,
+    reset,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm({
+    resolver: zodResolver(isEdit ? mktrLeadsEditSchema : mktrLeadsInviteSchema),
+    defaultValues: { phone: "", full_name: "", email: "", agency: "" },
+  });
+
+  useEffect(() => {
+    if (open) {
+      reset({
+        phone: "",
+        full_name: agent ? agent.fullName || `${agent.firstName || ""} ${agent.lastName || ""}`.trim() : "",
+        email: agent?.email || "",
+        agency: agent?.companyName || "",
+      });
+    }
+  }, [agent, open, reset]);
+
+  const onFormSubmit = async (data) => {
+    try {
+      await onSubmit(data, agent);
+      onOpenChange(false);
+    } catch (err) {
+      setError("root", { message: err?.message || "Failed to save agent" });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? "Edit MKTR Leads Agent" : "Invite MKTR Leads Agent"}</DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? "Changes are saved in the MKTR Leads app (the source of truth) and mirrored here."
+              : "They'll sign into the MKTR Leads app with this number via OTP to activate, then appear here within ~10 minutes."}
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onFormSubmit)} className="space-y-4 py-4">
+          {!isEdit && (
+            <FormRow label="Mobile Number" required error={errors.phone?.message}>
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-muted-foreground shrink-0">+65</span>
+                <Input type="tel" placeholder="9123 4567" {...register("phone")} />
+              </div>
+            </FormRow>
+          )}
+
+          <FormRow label="Full Name" required={isEdit} error={errors.full_name?.message}>
+            <Input placeholder="Agent's full name" {...register("full_name")} />
+          </FormRow>
+
+          <FormRow label="Email Address" error={errors.email?.message}>
+            <Input type="email" placeholder="agent@company.com (optional)" {...register("email")} />
+          </FormRow>
+
+          <FormRow label="Agency" error={errors.agency?.message}>
+            <Input placeholder="Agency / company (optional)" {...register("agency")} />
+          </FormRow>
+
+          {errors.root && (
+            <div className="text-destructive text-sm bg-destructive/10 p-3 rounded" role="alert">
+              {errors.root.message}
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <SubmitButton
+              pending={isSubmitting}
+              pendingText={isEdit ? "Saving..." : "Inviting..."}
+              className="bg-primary hover:bg-primary/90"
+            >
+              <Save className="w-4 h-4" />
+              {isEdit ? "Save Agent" : "Send Invite"}
+            </SubmitButton>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/hooks/__tests__/useAgentActions.test.js
+++ b/src/hooks/__tests__/useAgentActions.test.js
@@ -20,6 +20,7 @@ vi.mock('@/api/client', () => ({
  },
  apiClient: {
  post: vi.fn(),
+ patch: vi.fn(),
  delete: vi.fn(),
  },
 }));
@@ -49,9 +50,15 @@ describe('useAgentActions', () => {
 
  // --- handleSyncFromLyfe ---
 
- it('handleSyncFromLyfe success: shows toast and invalidates queries', async () => {
- apiClient.post.mockResolvedValue({
- data: { created: 2, updated: 1, deactivated: 0, skipped: 3 },
+ it('handleSyncFromLyfe success: syncs BOTH sources, aggregates the toast, invalidates queries', async () => {
+ apiClient.post.mockImplementation((url) => {
+ if (url === '/lyfe/agents/sync') {
+ return Promise.resolve({ data: { created: 2, updated: 1, deactivated: 0, skipped: 3 } });
+ }
+ if (url === '/mktr-leads/agents/sync') {
+ return Promise.resolve({ data: { created: 1, updated: 0, deactivated: 0, skipped: 2 } });
+ }
+ return Promise.reject(new Error(`unexpected ${url}`));
  });
 
  const { result } = renderHook(() => useAgentActions({ queryClient }));
@@ -61,10 +68,29 @@ describe('useAgentActions', () => {
  });
 
  expect(apiClient.post).toHaveBeenCalledWith('/lyfe/agents/sync');
- expect(toast.success).toHaveBeenCalledWith('2 added, 1 updated, 3 unchanged');
+ expect(apiClient.post).toHaveBeenCalledWith('/mktr-leads/agents/sync');
+ expect(toast.success).toHaveBeenCalledWith('3 added, 1 updated, 5 unchanged');
  expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['agents'] });
  expect(result.current.syncing).toBe(false);
  expect(result.current.lastSyncTime).toBeTruthy();
+ });
+
+ it('handleSyncFromLyfe tolerates an unconfigured MKTR Leads source (503) silently', async () => {
+ apiClient.post.mockImplementation((url) => {
+ if (url === '/lyfe/agents/sync') {
+ return Promise.resolve({ data: { created: 2, updated: 0, deactivated: 0, skipped: 0 } });
+ }
+ return Promise.reject(Object.assign(new Error('not configured'), { status: 503 }));
+ });
+
+ const { result } = renderHook(() => useAgentActions({ queryClient }));
+
+ await act(async () => {
+ await result.current.handleSyncFromLyfe();
+ });
+
+ expect(toast.success).toHaveBeenCalledWith('2 added');
+ expect(toast.error).not.toHaveBeenCalled();
  });
 
  it('handleSyncFromLyfe error: shows error toast', async () => {
@@ -300,5 +326,107 @@ describe('useAgentActions', () => {
 
  expect(result.current.editingAssignmentId).toBeNull();
  expect(result.current.editLeadCount).toBe('');
+ });
+
+ // --- MKTR Leads management (source-of-truth write-backs) ---
+
+ describe('handleMktrLeadsSubmit', () => {
+ it('invites via POST /mktr-leads/agents/invite when no agent', async () => {
+ apiClient.post.mockResolvedValue({ success: true });
+ const { result } = renderHook(() => useAgentActions({ queryClient }));
+
+ await act(async () => {
+ await result.current.handleMktrLeadsSubmit(
+ { phone: '91234567', full_name: 'Ada Tan', email: '', agency: 'Acme' },
+ null,
+ );
+ });
+
+ expect(apiClient.post).toHaveBeenCalledWith('/mktr-leads/agents/invite', {
+ phone: '91234567',
+ full_name: 'Ada Tan',
+ email: null,
+ agency: 'Acme',
+ });
+ expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['agents'] });
+ });
+
+ it('edits via PATCH /mktr-leads/agents/:mktrLeadsId for an owned agent', async () => {
+ apiClient.patch.mockResolvedValue({ success: true });
+ const { result } = renderHook(() => useAgentActions({ queryClient }));
+
+ await act(async () => {
+ await result.current.handleMktrLeadsSubmit(
+ { full_name: 'New Name', email: 'new@x.com', agency: '' },
+ { id: 'u1', mktrLeadsId: 'mu_12345678' },
+ );
+ });
+
+ expect(apiClient.patch).toHaveBeenCalledWith('/mktr-leads/agents/mu_12345678', {
+ full_name: 'New Name',
+ email: 'new@x.com',
+ agency: null,
+ });
+ });
+ });
+
+ describe('handleToggleStatus (source-aware)', () => {
+ it('MKTR Leads agent: confirms (with app-lockout warning) then POSTs deactivate', async () => {
+ apiClient.post.mockResolvedValue({ success: true });
+ const { result } = renderHook(() => useAgentActions({ queryClient }));
+ const agent = { id: 'u1', mktrLeadsId: 'mu_12345678', isActive: true, fullName: 'Ada' };
+
+ await act(async () => {
+ await result.current.handleToggleStatus(agent);
+ });
+ expect(result.current.confirmDialog.open).toBe(true);
+ expect(result.current.confirmDialog.title).toMatch(/deactivate/i);
+ expect(result.current.confirmDialog.description).toMatch(/no longer be able to sign into/i);
+ expect(result.current.confirmDialog.confirmText).toBe('Deactivate');
+
+ await act(async () => {
+ await result.current.confirmDialog.onConfirm();
+ });
+ expect(apiClient.post).toHaveBeenCalledWith('/mktr-leads/agents/mu_12345678/deactivate');
+ expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['agents'] });
+ });
+
+ it('MKTR Leads agent: reactivate path POSTs activate', async () => {
+ apiClient.post.mockResolvedValue({ success: true });
+ const { result } = renderHook(() => useAgentActions({ queryClient }));
+ const agent = { id: 'u1', mktrLeadsId: 'mu_12345678', isActive: false, fullName: 'Ada' };
+
+ await act(async () => {
+ await result.current.handleToggleStatus(agent);
+ });
+ expect(result.current.confirmDialog.confirmText).toBe('Reactivate');
+ await act(async () => {
+ await result.current.confirmDialog.onConfirm();
+ });
+ expect(apiClient.post).toHaveBeenCalledWith('/mktr-leads/agents/mu_12345678/activate');
+ });
+
+ it('Lyfe agent: refuses with an error toast (managed in Lyfe)', async () => {
+ const { result } = renderHook(() => useAgentActions({ queryClient }));
+
+ await act(async () => {
+ await result.current.handleToggleStatus({ id: 'u1', lyfeId: 'L1', isActive: true });
+ });
+
+ expect(toast.error).toHaveBeenCalledWith('This agent is managed in the Lyfe app');
+ expect(User.update).not.toHaveBeenCalled();
+ expect(apiClient.post).not.toHaveBeenCalled();
+ });
+
+ it('legacy local agent: keeps the original User.update path', async () => {
+ User.update.mockResolvedValue({ success: true });
+ const { result } = renderHook(() => useAgentActions({ queryClient }));
+
+ await act(async () => {
+ await result.current.handleToggleStatus({ id: 'u1', isActive: true });
+ });
+
+ expect(User.update).toHaveBeenCalledWith('u1', { isActive: false });
+ });
  });
 });

--- a/src/hooks/useAgentActions.js
+++ b/src/hooks/useAgentActions.js
@@ -2,12 +2,18 @@ import { useState, useCallback } from 'react';
 import { User } from '@/api/entities';
 import { LeadPackage } from '@/api/entities';
 import { agents as agentsAPI, apiClient } from '@/api/client';
+import { isMktrLeadsAgent, isLyfeAgent } from '@/lib/agentSource';
 import { toast } from 'sonner';
 
 /**
  * Custom hook encapsulating all agent CRUD operations:
  * sync, invite/edit, delete, bulk delete, toggle status, resend invite,
  * and package management (open, delete, update assignments).
+ *
+ * Source-awareness: Lyfe-owned agents are read-only here (managed in the Lyfe
+ * app); MKTR-Leads-owned agents are managed via the /mktr-leads/agents/*
+ * write-back endpoints (that app is the source of truth); legacy local rows
+ * keep the original local behaviour.
  */
 export default function useAgentActions({ queryClient }) {
  const [syncing, setSyncing] = useState(false);
@@ -20,10 +26,11 @@ export default function useAgentActions({ queryClient }) {
  description: '',
  onConfirm: null,
  destructive: false,
+ confirmText: null,
  });
 
- const openConfirm = useCallback(({ title, description, onConfirm, destructive = true }) => {
- setConfirmDialog({ open: true, title, description, onConfirm, destructive });
+ const openConfirm = useCallback(({ title, description, onConfirm, destructive = true, confirmText = null }) => {
+ setConfirmDialog({ open: true, title, description, onConfirm, destructive, confirmText });
  }, []);
 
  const closeConfirm = useCallback(() => {
@@ -36,12 +43,28 @@ export default function useAgentActions({ queryClient }) {
  const [editingAssignmentId, setEditingAssignmentId] = useState(null);
  const [editLeadCount, setEditLeadCount] = useState('');
 
- // ---- Lyfe sync ----
+ // ---- Agent sync (both sources: Lyfe + MKTR Leads) ----
  const handleSyncFromLyfe = async () => {
  setSyncing(true);
  try {
  const res = await apiClient.post('/lyfe/agents/sync');
- const { created, updated, deactivated, skipped } = res.data || {};
+ const totals = { ...(res.data || {}) };
+
+ // MKTR Leads is the second agent source. A 503 means it simply isn't
+ // configured on this deployment — not an error worth surfacing.
+ try {
+ const mlRes = await apiClient.post('/mktr-leads/agents/sync');
+ for (const k of ['created', 'updated', 'deactivated', 'skipped']) {
+ totals[k] = (totals[k] || 0) + (mlRes.data?.[k] || 0);
+ }
+ } catch (mlError) {
+ if (mlError?.status !== 503 && mlError?.response?.status !== 503) {
+ console.error('Error syncing from MKTR Leads:', mlError);
+ toast.error(mlError?.message || 'Could not sync MKTR Leads agents');
+ }
+ }
+
+ const { created, updated, deactivated, skipped } = totals;
  const parts = [];
  if (created) parts.push(`${created} added`);
  if (updated) parts.push(`${updated} updated`);
@@ -86,6 +109,30 @@ export default function useAgentActions({ queryClient }) {
  queryClient.invalidateQueries({ queryKey: ['agents'] });
  };
 
+ // ---- MKTR Leads invite / edit (writes to the source app, then mirrors) ----
+ const handleMktrLeadsSubmit = async (formData, agent) => {
+ if (agent?.mktrLeadsId) {
+ await apiClient.patch(`/mktr-leads/agents/${encodeURIComponent(agent.mktrLeadsId)}`, {
+ full_name: (formData.full_name || '').trim(),
+ email: (formData.email || '').trim() || null,
+ agency: (formData.agency || '').trim() || null,
+ });
+ toast.success('Agent updated in MKTR Leads');
+ } else {
+ await apiClient.post('/mktr-leads/agents/invite', {
+ phone: formData.phone,
+ full_name: (formData.full_name || '').trim() || null,
+ email: (formData.email || '').trim() || null,
+ agency: (formData.agency || '').trim() || null,
+ });
+ toast.success(
+ 'Invitation created — they sign into the MKTR Leads app with this number via OTP, then appear here within ~10 minutes',
+ { duration: 8000 },
+ );
+ }
+ queryClient.invalidateQueries({ queryKey: ['agents'] });
+ };
+
  // ---- Delete single agent ----
  const handleDeleteAgent = (agent) => {
  if (!agent) return;
@@ -127,9 +174,47 @@ export default function useAgentActions({ queryClient }) {
  });
  };
 
- // ---- Toggle active/inactive ----
+ // ---- Toggle active/inactive (source-aware) ----
  const handleToggleStatus = async (agent) => {
  if (!agent) return;
+
+ // Lyfe-owned rows are read-only here (the menu disables this, but guard anyway).
+ if (isLyfeAgent(agent)) {
+ toast.error('This agent is managed in the Lyfe app');
+ return;
+ }
+
+ // MKTR-Leads-owned: write back to the source app. Deactivation also locks
+ // them out of the MKTR Leads app (the OTP gate), so confirm with the real
+ // effect spelled out.
+ if (isMktrLeadsAgent(agent)) {
+ const deactivating = !!agent.isActive;
+ const name = agent.fullName || agent.email || agent.phone || 'this agent';
+ openConfirm({
+ title: deactivating ? 'Deactivate MKTR Leads Agent' : 'Reactivate MKTR Leads Agent',
+ description: deactivating
+ ? `Deactivate ${name}? They will no longer be able to sign into the MKTR Leads app and will stop receiving leads. You can reactivate them later.`
+ : `Reactivate ${name}? They will regain access to the MKTR Leads app and can receive leads again.`,
+ destructive: deactivating,
+ confirmText: deactivating ? 'Deactivate' : 'Reactivate',
+ onConfirm: async () => {
+ try {
+ await apiClient.post(
+ `/mktr-leads/agents/${encodeURIComponent(agent.mktrLeadsId)}/${deactivating ? 'deactivate' : 'activate'}`,
+ );
+ toast.success(deactivating ? 'Agent deactivated in MKTR Leads' : 'Agent reactivated in MKTR Leads');
+ queryClient.invalidateQueries({ queryKey: ['agents'] });
+ } catch (error) {
+ console.error('Error toggling MKTR Leads agent:', error);
+ toast.error(error?.message || 'Failed to update agent in MKTR Leads');
+ }
+ closeConfirm();
+ },
+ });
+ return;
+ }
+
+ // Legacy local rows keep the original behaviour.
  try {
  await User.update(agent.id, { isActive: !agent.isActive });
  queryClient.invalidateQueries({ queryKey: ['agents'] });
@@ -248,6 +333,7 @@ export default function useAgentActions({ queryClient }) {
 
  // Agent CRUD
  handleFormSubmit,
+ handleMktrLeadsSubmit,
  handleDeleteAgent,
  handleBulkDelete,
  handleToggleStatus,

--- a/src/lib/__tests__/agentSource.test.js
+++ b/src/lib/__tests__/agentSource.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import {
+  agentSource,
+  isLyfeAgent,
+  isMktrLeadsAgent,
+  isLocalAgent,
+  sourceBadge,
+  AGENT_SOURCES,
+} from '../agentSource';
+
+describe('agentSource', () => {
+  it('maps lyfeId → lyfe', () => {
+    expect(agentSource({ lyfeId: 'L1' })).toBe(AGENT_SOURCES.LYFE);
+    expect(isLyfeAgent({ lyfeId: 'L1' })).toBe(true);
+  });
+
+  it('maps mktrLeadsId → mktr_leads', () => {
+    expect(agentSource({ mktrLeadsId: 'M1' })).toBe(AGENT_SOURCES.MKTR_LEADS);
+    expect(isMktrLeadsAgent({ mktrLeadsId: 'M1' })).toBe(true);
+  });
+
+  it('maps no provenance → local (incl. null/undefined agent)', () => {
+    expect(agentSource({ id: 'u1' })).toBe(AGENT_SOURCES.LOCAL);
+    expect(agentSource(null)).toBe(AGENT_SOURCES.LOCAL);
+    expect(isLocalAgent({ id: 'u1', lyfeId: null, mktrLeadsId: null })).toBe(true);
+  });
+
+  it('sourceBadge labels each source distinctly', () => {
+    expect(sourceBadge({ lyfeId: 'L1' }).label).toBe('Lyfe');
+    expect(sourceBadge({ mktrLeadsId: 'M1' }).label).toBe('MKTR Leads');
+    expect(sourceBadge({}).label).toBe('Local');
+  });
+});

--- a/src/lib/agentSource.js
+++ b/src/lib/agentSource.js
@@ -1,0 +1,39 @@
+/**
+ * Agent provenance helpers — which external app owns a mirrored agent row.
+ *
+ * mktr-platform mirrors agents from two source apps into its local users
+ * table; the provenance columns are mutually exclusive (DB CHECK):
+ *   lyfeId       → the Lyfe mobile app owns the agent (read-only here)
+ *   mktrLeadsId  → the MKTR Leads app owns the agent (managed here via the
+ *                  /api/mktr-leads/agents/* write-back endpoints)
+ *   neither      → a legacy local row (pre-mirror invites, System Agent)
+ */
+
+export const AGENT_SOURCES = {
+  LYFE: 'lyfe',
+  MKTR_LEADS: 'mktr_leads',
+  LOCAL: 'local',
+};
+
+export function agentSource(agent) {
+  if (!agent) return AGENT_SOURCES.LOCAL;
+  if (agent.lyfeId) return AGENT_SOURCES.LYFE;
+  if (agent.mktrLeadsId) return AGENT_SOURCES.MKTR_LEADS;
+  return AGENT_SOURCES.LOCAL;
+}
+
+export const isLyfeAgent = (agent) => agentSource(agent) === AGENT_SOURCES.LYFE;
+export const isMktrLeadsAgent = (agent) => agentSource(agent) === AGENT_SOURCES.MKTR_LEADS;
+export const isLocalAgent = (agent) => agentSource(agent) === AGENT_SOURCES.LOCAL;
+
+/** Display metadata for the Source badge. */
+export function sourceBadge(agent) {
+  switch (agentSource(agent)) {
+    case AGENT_SOURCES.LYFE:
+      return { label: 'Lyfe', className: 'bg-info/10 text-info border-info/30' };
+    case AGENT_SOURCES.MKTR_LEADS:
+      return { label: 'MKTR Leads', className: 'bg-primary/10 text-primary border-primary/30' };
+    default:
+      return { label: 'Local', className: 'bg-muted text-muted-foreground border-border' };
+  }
+}

--- a/src/pages/AdminAgents.jsx
+++ b/src/pages/AdminAgents.jsx
@@ -28,9 +28,11 @@ import AgentFilters from '../components/agents/AgentFilters';
 import AgentTable from '../components/agents/AgentTable';
 import ManagePackagesDialog from '../components/agents/ManagePackagesDialog';
 import InviteAgentDialog from '../components/agents/InviteAgentDialog';
+import MktrLeadsAgentDialog from '../components/agents/MktrLeadsAgentDialog';
 import AgentDetailsDialog from '../components/agents/AgentDetailsDialog';
 import AssignPackageDialog from '../components/agents/AssignPackageDialog';
 import useAgentActions from '@/hooks/useAgentActions';
+import { isMktrLeadsAgent, isLocalAgent } from '@/lib/agentSource';
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
 
@@ -68,6 +70,7 @@ export default function AdminAgents() {
  // --- Local UI state ---
  const [selectedAgentIds, setSelectedAgentIds] = useState([]);
  const [isFormOpen, setIsFormOpen] = useState(false);
+ const [isMktrFormOpen, setIsMktrFormOpen] = useState(false);
  const [isDetailsOpen, setIsDetailsOpen] = useState(false);
  const [isPackageDialogOpen, setIsPackageDialogOpen] = useState(false);
  const [selectedAgent, setSelectedAgent] = useState(null);
@@ -88,7 +91,11 @@ export default function AdminAgents() {
 
  let matchesStatus = true;
  if (statusFilter !== 'all') {
+ // Pending = locally-invited awaiting registration. Mirrored rows (Lyfe /
+ // MKTR Leads) have no local password + emailVerified=false by
+ // construction, so they must be excluded or they all read as pending.
  const isPending =
+ isLocalAgent(agent) &&
  agent?.isActive === true &&
  (agent?.status === 'pending_registration' || !!agent?.invitationToken || agent?.emailVerified === false);
  if (statusFilter === 'pending') matchesStatus = isPending;
@@ -121,8 +128,10 @@ export default function AdminAgents() {
  const showingTo = Math.min(safePage * pageSize, filteredAgents.length);
 
  // --- Selection handlers ---
+ // Selection drives bulk-delete, which only applies to legacy LOCAL rows —
+ // mirrored agents are owned by their source app (rows render disabled boxes).
  const handleSelectAll = (checked) => {
- setSelectedAgentIds(checked ? filteredAgents.map((a) => a.id) : []);
+ setSelectedAgentIds(checked ? filteredAgents.filter(isLocalAgent).map((a) => a.id) : []);
  };
 
  const handleSelectAgent = (agentId, checked) => {
@@ -130,9 +139,17 @@ export default function AdminAgents() {
  };
 
  // --- Dialog openers ---
+ // Inviting a NEW agent always goes through MKTR Leads (the local invite
+ // minted rows no app could deliver leads to). Editing routes by source:
+ // MKTR-Leads-owned rows use the write-back dialog; legacy local rows keep
+ // the original form. (Lyfe rows: Edit is disabled in the table.)
  const handleOpenForm = (agent = null) => {
  setSelectedAgent(agent);
+ if (!agent || isMktrLeadsAgent(agent)) {
+ setIsMktrFormOpen(true);
+ } else {
  setIsFormOpen(true);
+ }
  };
 
  const handleOpenDetails = (agent) => {
@@ -150,7 +167,7 @@ export default function AdminAgents() {
  actions.openManagePackagesDialog(agent);
  };
 
- // --- Form submit wrapper ---
+ // --- Form submit wrappers ---
  const handleFormSubmit = async (formData) => {
  try {
  await actions.handleFormSubmit(formData, selectedAgent);
@@ -158,6 +175,17 @@ export default function AdminAgents() {
  setSelectedAgent(null);
  } catch (error) {
  console.error('Error saving agent:', error);
+ throw error;
+ }
+ };
+
+ const handleMktrFormSubmit = async (formData, agent) => {
+ try {
+ await actions.handleMktrLeadsSubmit(formData, agent);
+ setIsMktrFormOpen(false);
+ setSelectedAgent(null);
+ } catch (error) {
+ console.error('Error saving MKTR Leads agent:', error);
  throw error;
  }
  };
@@ -198,7 +226,7 @@ export default function AdminAgents() {
  )}
  <Button variant="outline" onClick={actions.handleSyncFromLyfe} disabled={actions.syncing}>
  <RefreshCw className={`w-4 h-4 mr-2 ${actions.syncing ? 'animate-spin' : ''}`} />
- {actions.syncing ? 'Syncing...' : 'Sync from Lyfe'}
+ {actions.syncing ? 'Syncing...' : 'Sync Agents'}
  </Button>
  <Button onClick={() => handleOpenForm()} className="bg-primary hover:bg-primary/90">
  <Plus className="w-5 h-5 mr-2"/>
@@ -323,6 +351,13 @@ export default function AdminAgents() {
  onSubmit={handleFormSubmit}
  />
 
+ <MktrLeadsAgentDialog
+ open={isMktrFormOpen}
+ onOpenChange={setIsMktrFormOpen}
+ agent={selectedAgent && isMktrLeadsAgent(selectedAgent) ? selectedAgent : null}
+ onSubmit={handleMktrFormSubmit}
+ />
+
  <AgentDetailsDialog open={isDetailsOpen} onOpenChange={setIsDetailsOpen} agent={selectedAgent} />
 
  <AssignPackageDialog
@@ -355,7 +390,7 @@ export default function AdminAgents() {
  title={actions.confirmDialog.title}
  description={actions.confirmDialog.description}
  onConfirm={actions.confirmDialog.onConfirm}
- confirmText={actions.confirmDialog.destructive ? 'Delete' : 'OK'}
+ confirmText={actions.confirmDialog.confirmText || (actions.confirmDialog.destructive ? 'Delete' : 'OK')}
  destructive={actions.confirmDialog.destructive}
  />
  </div>

--- a/src/pages/__tests__/AdminAgents.test.jsx
+++ b/src/pages/__tests__/AdminAgents.test.jsx
@@ -114,6 +114,10 @@ vi.mock('@/components/agents/InviteAgentDialog', () => ({
  default: ({ open }) => (open ? <div data-testid="invite-dialog">Invite Agent Dialog</div> : null),
 }));
 
+vi.mock('@/components/agents/MktrLeadsAgentDialog', () => ({
+ default: ({ open }) => (open ? <div data-testid="mktr-leads-dialog">MKTR Leads Agent Dialog</div> : null),
+}));
+
 vi.mock('@/components/agents/AgentDetailsDialog', () => ({
  default: ({ open, agent }) => (open ? <div data-testid="details-dialog">{agent?.fullName}</div> : null),
 }));
@@ -175,21 +179,22 @@ describe('AdminAgents', () => {
  expect(screen.getByRole('button', { name: /invite agent/i })).toBeInTheDocument();
  });
 
- it('opens invite dialog when Invite Agent is clicked', () => {
+ it('opens the MKTR Leads invite dialog when Invite Agent is clicked (new agents are invited via MKTR Leads)', () => {
  renderAgents();
  fireEvent.click(screen.getByRole('button', { name: /invite agent/i }));
- expect(screen.getByTestId('invite-dialog')).toBeInTheDocument();
+ expect(screen.getByTestId('mktr-leads-dialog')).toBeInTheDocument();
+ expect(screen.queryByTestId('invite-dialog')).not.toBeInTheDocument();
  });
 
- // --- Sync button ---
- it('renders Sync from Lyfe button', () => {
+ // --- Sync button (covers BOTH agent sources) ---
+ it('renders Sync Agents button', () => {
  renderAgents();
- expect(screen.getByRole('button', { name: /sync from lyfe/i })).toBeInTheDocument();
+ expect(screen.getByRole('button', { name: /sync agents/i })).toBeInTheDocument();
  });
 
  it('calls sync handler when Sync button is clicked', () => {
  renderAgents();
- fireEvent.click(screen.getByRole('button', { name: /sync from lyfe/i }));
+ fireEvent.click(screen.getByRole('button', { name: /sync agents/i }));
  expect(mockHandleSyncFromLyfe).toHaveBeenCalled();
  });
 

--- a/src/schemas/mktrLeadsAgent.ts
+++ b/src/schemas/mktrLeadsAgent.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+// 8-digit SG mobile starting 8/9. Entry-form shape only — the mktr-leads edge
+// function owns canonical normalization (it also accepts +65/65 prefixes), so
+// keep this permissive about separators and strict about the digits.
+const sgMobile = z
+  .string()
+  .min(1, 'Phone is required')
+  .transform((v) => v.replace(/[\s()-]/g, ''))
+  .refine((v) => /^(\+?65)?[89]\d{7}$/.test(v), 'Enter a Singapore mobile (8 digits starting 8 or 9)');
+
+export const mktrLeadsInviteSchema = z.object({
+  phone: sgMobile,
+  full_name: z.string().max(120).optional().or(z.literal('')),
+  email: z.string().email('Please enter a valid email').optional().or(z.literal('')),
+  agency: z.string().max(120).optional().or(z.literal('')),
+});
+
+export const mktrLeadsEditSchema = z.object({
+  full_name: z.string().min(1, 'Full name is required').max(120),
+  email: z.string().email('Please enter a valid email').optional().or(z.literal('')),
+  agency: z.string().max(120).optional().or(z.literal('')),
+});
+
+export type MktrLeadsInviteInput = z.infer<typeof mktrLeadsInviteSchema>;
+export type MktrLeadsEditInput = z.infer<typeof mktrLeadsEditSchema>;


### PR DESCRIPTION
## Why

Part 3 of 3 — the UI for the mktr-leads agent management built in #37/#38/#39. The Agents page becomes **source-aware**: every row shows where the agent is managed, and actions route accordingly.

## What you'll see

- **Source badge** per row: `Lyfe` / `MKTR Leads` / `Local`.
- **Invite Agent** → the new **MKTR Leads invite dialog** (phone-first: required 8-digit SG mobile with +65 prefix; name/email/agency optional). Copy explains the real flow: *they sign into the MKTR Leads app with this number via OTP, then appear here within ~10 minutes.* The old local invite minted rows **no app could deliver leads to** — replaced per the agreed decision. (Legacy form remains for editing local rows.)
- **Edit** routes by source: MKTR Leads rows → write-back dialog (name/email/agency saved in the source app, mirrored back); Lyfe rows → disabled *"managed in Lyfe"*.
- **Activate/Deactivate** for MKTR Leads rows confirms with the real effect spelled out (**deactivation also locks them out of the MKTR Leads app** — OTP gate) and calls the write-back endpoints. Confirm button says Deactivate/Reactivate (new `confirmText` override), not "Delete".
- **Delete / bulk-delete** are local-row concepts → disabled with hints for mirrored rows; selection checkboxes likewise.
- **Sync Agents** button now syncs **both sources**, aggregates the toast, and silently tolerates a 503 (source not configured).

## Bug fixes encountered

- **All 11 mirrored agents rendered as "Invited" with a Resend item** (verified against prod data): the pending-registration heuristic keys on no-password + `emailVerified=false`, which is true for every mirrored row by construction. Scoped it to local rows — without this, the Activate/Deactivate action was unreachable for every mirrored agent.
- `formatSgPhone` truncated canonical `6591234567` to "6591 2345" — now strips the 65-prefix instead.

## Test

Full vitest suite **1013/1013** (main baseline: 1002/1002 — +11 new): source helper, both-sources sync aggregation + 503 tolerance, mktr-leads invite/edit payloads, source-aware toggle (confirm copy, endpoints, Lyfe refusal, local fallback), updated AdminAgents specs. Production build clean.

## After merge

Deploy → eyeball the page: badges per source, invite the next real agent by phone, deactivate/reactivate the App Review Tester from the dashboard (full E2E of the #37 sync mirroring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)