### PR TITLE
fix(credits): campaign-scope the best-effort deduction (no more cross-campaign bleed)

### DIFF
--- a/backend/src/services/agentService.js
+++ b/backend/src/services/agentService.js
@@ -6,11 +6,11 @@ import { sendRoleInvitation } from './invitationService.js';
 import { getAgentInviteEmail, getAgentInviteSubject, getAgentInviteText } from './emailTemplates.js';
 
 // Re-export helpers from focused modules so existing `import * as agentService` still works
-export { getAssignedCampaignCounts, computeAgentStats, computeAgentStatsFromCounts } from './agentStatsHelpers.js';
+export { getAssignedCampaignCounts, getAgentPackageBreakdowns, computeAgentStats, computeAgentStatsFromCounts } from './agentStatsHelpers.js';
 export { getAgentMonthlyPerformance, getCommissionLeaderboard, getConversionLeaderboard, getProspectLeaderboard, getLeaderboard } from './agentLeaderboardService.js';
 
 // Internal imports used by functions in this file
-import { getAssignedCampaignCounts, computeAgentStatsFromCounts } from './agentStatsHelpers.js';
+import { getAssignedCampaignCounts, getAgentPackageBreakdowns, computeAgentStatsFromCounts } from './agentStatsHelpers.js';
 import { getAgentMonthlyPerformance } from './agentLeaderboardService.js';
 
 // ---------------------------------------------------------------------------
@@ -110,11 +110,16 @@ export async function listAgents(query) {
     ]
   });
 
-  // Compute counts of campaigns where agents have active lead packages
-  const assignedCounts = await getAssignedCampaignCounts();
+  // Compute counts of campaigns where agents have active lead packages,
+  // plus the per-campaign remaining-credit breakdown (separate grouped query —
+  // not a deeper include on this paginated findAndCountAll).
+  const [assignedCounts, packageBreakdowns] = await Promise.all([
+    getAssignedCampaignCounts(),
+    getAgentPackageBreakdowns(),
+  ]);
 
   // Calculate agent statistics from subquery counts
-  const agentsWithStats = agents.map(agent => computeAgentStatsFromCounts(agent, assignedCounts));
+  const agentsWithStats = agents.map(agent => computeAgentStatsFromCounts(agent, assignedCounts, packageBreakdowns));
 
   return {
     agents: agentsWithStats,

--- a/backend/src/services/agentStatsHelpers.js
+++ b/backend/src/services/agentStatsHelpers.js
@@ -1,5 +1,5 @@
 import { Op } from 'sequelize';
-import { LeadPackage, LeadPackageAssignment } from '../models/index.js';
+import { LeadPackage, LeadPackageAssignment, sequelize } from '../models/index.js';
 
 /**
  * Fetch counts of unique campaigns each agent is assigned to via active lead packages.
@@ -30,6 +30,40 @@ export async function getAssignedCampaignCounts() {
   });
 
   return assignedCounts;
+}
+
+/**
+ * Per-agent, per-campaign remaining-credit breakdown for the agent listing.
+ * One grouped aggregate query (NOT a deeper include on the paginated
+ * findAndCountAll — hasMany includes there risk row duplication; Codex review).
+ * Returns { [agentId]: [{ campaignId, campaignName, leadsRemaining }] }.
+ */
+export async function getAgentPackageBreakdowns() {
+  const rows = await sequelize.query(
+    `SELECT a."agentId",
+            p."campaignId",
+            c.name AS "campaignName",
+            SUM(a."leadsRemaining")::int AS "leadsRemaining"
+       FROM lead_package_assignments a
+       JOIN lead_packages p ON p.id = a."leadPackageId"
+       LEFT JOIN campaigns c ON c.id = p."campaignId"
+      WHERE a.status = 'active' AND a."leadsRemaining" > 0
+      GROUP BY a."agentId", p."campaignId", c.name
+      ORDER BY c.name NULLS LAST`,
+    { type: sequelize.QueryTypes.SELECT }
+  );
+
+  const breakdowns = {};
+  for (const row of rows) {
+    const agentId = String(row.agentId);
+    if (!breakdowns[agentId]) breakdowns[agentId] = [];
+    breakdowns[agentId].push({
+      campaignId: row.campaignId || null,
+      campaignName: row.campaignName || null,
+      leadsRemaining: row.leadsRemaining,
+    });
+  }
+  return breakdowns;
 }
 
 /**
@@ -77,7 +111,7 @@ export function computeAgentStats(agent, assignedCounts) {
  * Compute stats for a single agent using pre-computed subquery counts (listAgents).
  * Avoids loading all prospects/commissions into memory.
  */
-export function computeAgentStatsFromCounts(agent, assignedCounts) {
+export function computeAgentStatsFromCounts(agent, assignedCounts, packageBreakdowns = {}) {
   const plain = agent.toJSON();
   const totalProspects = parseInt(plain.prospectCount) || 0;
   const convertedProspects = parseInt(plain.convertedCount) || 0;
@@ -99,6 +133,9 @@ export function computeAgentStatsFromCounts(agent, assignedCounts) {
     ...plain,
     owed_leads_count: totalLeadsOwed,
     owed_leads_manual_count: manualLeads,
+    // Per-campaign split of the package portion — credits are campaign-scoped
+    // ledgers, so the UI must be able to show more than one merged number.
+    owed_leads_breakdown: packageBreakdowns[String(agent.id)] || [],
     stats: {
       totalProspects,
       convertedProspects,

--- a/backend/src/services/leadCredits.js
+++ b/backend/src/services/leadCredits.js
@@ -1,37 +1,83 @@
-import { User, LeadPackageAssignment, sequelize } from '../models/index.js';
+import { User, LeadPackageAssignment, LeadPackage, sequelize } from '../models/index.js';
 import { Op } from 'sequelize';
 import { logger } from '../utils/logger.js';
 
 /**
- * Deducts lead credits from an agent's account.
- * Prioritizes active Lead Package Assignments (FIFO), then User.owed_leads_count.
- * @param {string} agentId - UUID of the agent
- * @param {number} amount - Number of leads to deduct (default 1)
- * @returns {Promise<boolean>} - True if deduction occurred (fully or partially)
+ * Lead-credit accounting. DI factory (house pattern) so the REAL implementation
+ * is unit-testable — the previous test file re-implemented deductLeadCredit
+ * inside itself and protected nothing (Codex review finding).
  */
-export async function deductLeadCredit(agentId, amount = 1, externalTransaction = null) {
-    if (!agentId || amount <= 0) return false;
+export function makeLeadCreditsService(overrides = {}) {
+  const d = { User, LeadPackageAssignment, LeadPackage, sequelize, logger, ...overrides };
 
-    // If caller passed a transaction, use it (no nested transaction).
-    // Otherwise create our own.
-    const ownTransaction = !externalTransaction;
-    const t = externalTransaction || await sequelize.transaction();
+  /**
+   * Best-effort deduction of lead credits from an agent's account, scoped to a
+   * campaign. Draws FIFO (by purchaseDate) from the agent's active package
+   * assignments **belonging to `campaignId`** — credits bought for campaign A
+   * can never be drained by a campaign-B (or campaignless) lead. Falls back to
+   * the campaign-agnostic manual `users.owed_leads_count` bucket, mirroring
+   * chargeLeadCredit's two-tier semantics.
+   *
+   * `campaignId: null` (campaignless lead) skips package deduction entirely —
+   * packages are purchased FOR a campaign — and only the manual bucket pays.
+   *
+   * Options-object signature (NOT positional): a legacy-style call like
+   * deductLeadCredit(agentId, 1, t) would have silently read `1` as a campaign
+   * and the transaction as an amount. Non-object input is rejected with a
+   * structured log + false — this stays best-effort and never throws into
+   * callers.
+   *
+   * Locking note: campaign scoping is two-step — an unlocked read of the
+   * campaign's package ids (static rows), then the original single-table
+   * `FOR UPDATE` on assignments filtered by those ids. No join under the lock,
+   * so none of the FOR-UPDATE-across-join pitfalls apply.
+   *
+   * @param {object} opts
+   * @param {string} opts.agentId
+   * @param {string|null} [opts.campaignId]  Campaign whose packages may pay.
+   * @param {number} [opts.amount=1]
+   * @param {import('sequelize').Transaction|null} [opts.transaction]
+   * @returns {Promise<boolean>} true if any deduction occurred
+   */
+  async function deductLeadCredit(opts) {
+    if (!opts || typeof opts !== 'object' || Array.isArray(opts)) {
+      d.logger.error('deductLeadCredit called with positional args — options object required', {
+        receivedType: Array.isArray(opts) ? 'array' : typeof opts,
+      });
+      return false;
+    }
+    const { agentId, campaignId = null, amount = 1, transaction = null } = opts;
+    if (!agentId || typeof agentId !== 'string' || !(amount > 0)) return false;
+
+    const ownTransaction = !transaction;
+    const t = transaction || await d.sequelize.transaction();
     try {
-        let remainingToDeduct = amount;
+      let remainingToDeduct = amount;
 
-        // 1. Try to deduct from Lead Assignments first (FIFO)
-        const assignments = await LeadPackageAssignment.findAll({
+      // 1. FIFO from THIS campaign's package assignments (skipped entirely
+      //    when the lead has no campaign).
+      if (campaignId) {
+        const campaignPackages = await d.LeadPackage.findAll({
+          where: { campaignId },
+          attributes: ['id'],
+          transaction: t,
+        });
+        const packageIds = campaignPackages.map((p) => p.id);
+
+        if (packageIds.length > 0) {
+          const assignments = await d.LeadPackageAssignment.findAll({
             where: {
-                agentId,
-                status: 'active',
-                leadsRemaining: { [Op.gt]: 0 }
+              agentId,
+              status: 'active',
+              leadsRemaining: { [Op.gt]: 0 },
+              leadPackageId: { [Op.in]: packageIds },
             },
             order: [['purchaseDate', 'ASC']],
             transaction: t,
-            lock: t.LOCK.UPDATE
-        });
+            lock: t.LOCK.UPDATE,
+          });
 
-        for (const assignment of assignments) {
+          for (const assignment of assignments) {
             if (remainingToDeduct <= 0) break;
 
             const available = assignment.leadsRemaining;
@@ -41,170 +87,178 @@ export async function deductLeadCredit(agentId, amount = 1, externalTransaction 
             remainingToDeduct -= deduction;
 
             if (assignment.leadsRemaining === 0) {
-                assignment.status = 'completed';
+              assignment.status = 'completed';
             }
 
             await assignment.save({ transaction: t });
+          }
         }
+      }
 
-        // 2. If packages didn't cover it, try owed_leads_count on User
-        if (remainingToDeduct > 0) {
-            const agent = await User.findByPk(agentId, {
-                transaction: t,
-                lock: t.LOCK.UPDATE
-            });
+      // 2. If packages didn't cover it, the campaign-agnostic manual bucket.
+      if (remainingToDeduct > 0) {
+        const agent = await d.User.findByPk(agentId, {
+          transaction: t,
+          lock: t.LOCK.UPDATE,
+        });
 
-            if (agent && agent.owed_leads_count > 0) {
-                const available = agent.owed_leads_count;
-                const deduction = Math.min(available, remainingToDeduct);
+        if (agent && agent.owed_leads_count > 0) {
+          const available = agent.owed_leads_count;
+          const deduction = Math.min(available, remainingToDeduct);
 
-                agent.owed_leads_count -= deduction;
-                remainingToDeduct -= deduction;
+          agent.owed_leads_count -= deduction;
+          remainingToDeduct -= deduction;
 
-                await agent.save({ transaction: t });
-            }
+          await agent.save({ transaction: t });
         }
+      }
 
-        if (ownTransaction) await t.commit();
+      if (ownTransaction) await t.commit();
 
-        // Log if we couldn't deduct full amount (unpaid lead?)
-        if (remainingToDeduct > 0 && remainingToDeduct < amount) {
-            // Partial deduction
-        } else if (remainingToDeduct === amount) {
-            // No deduction possible
-            return false;
-        }
+      // No credit source could pay anything.
+      if (remainingToDeduct === amount) {
+        return false;
+      }
 
-        return true;
+      return true;
 
     } catch (error) {
-        if (ownTransaction) await t.rollback();
-        logger.error('Error deducting lead credits', { error: error?.message || String(error) });
-        // Don't throw, just return false so we don't break the prospect creation flow
-        return false;
+      if (ownTransaction) await t.rollback();
+      d.logger.error('Error deducting lead credits', { error: error?.message || String(error) });
+      // Don't throw, just return false so we don't break the prospect creation flow
+      return false;
     }
-}
+  }
 
-/**
- * Atomically deduct `amount` from an external agent's GLOBAL prepaid balance.
- *
- * The check-and-decrement is a single conditional UPDATE (... WHERE
- * "leadBalance" >= amount RETURNING id), so it is race-safe under concurrent
- * assignments and across multiple backend instances. Returns true only if the
- * balance was actually decremented.
- *
- * IMPORTANT: unlike deductLeadCredit (internal, best-effort), a `false` here
- * MUST block delivery to that buyer — external leads are paid, so a lead is
- * never handed to a buyer whose balance we could not charge.
- *
- * @param {string} externalAgentId
- * @param {number} amount
- * @param {import('sequelize').Transaction|null} externalTransaction
- * @returns {Promise<boolean>}
- */
-export async function deductExternalLeadBalance(externalAgentId, amount = 1, externalTransaction = null) {
+  /**
+   * Atomically deduct `amount` from an external agent's GLOBAL prepaid balance.
+   *
+   * The check-and-decrement is a single conditional UPDATE (... WHERE
+   * "leadBalance" >= amount RETURNING id), so it is race-safe under concurrent
+   * assignments and across multiple backend instances. Returns true only if the
+   * balance was actually decremented.
+   *
+   * IMPORTANT: unlike deductLeadCredit (internal, best-effort), a `false` here
+   * MUST block delivery to that buyer — external leads are paid, so a lead is
+   * never handed to a buyer whose balance we could not charge.
+   *
+   * @param {string} externalAgentId
+   * @param {number} amount
+   * @param {import('sequelize').Transaction|null} externalTransaction
+   * @returns {Promise<boolean>}
+   */
+  async function deductExternalLeadBalance(externalAgentId, amount = 1, externalTransaction = null) {
     if (!externalAgentId || amount <= 0) return false;
 
     const ownTransaction = !externalTransaction;
-    const t = externalTransaction || await sequelize.transaction();
+    const t = externalTransaction || await d.sequelize.transaction();
     try {
-        const [rows] = await sequelize.query(
-            `UPDATE external_agents
-                SET "leadBalance" = "leadBalance" - :amount, "updatedAt" = NOW()
-              WHERE id = :id AND "leadBalance" >= :amount
-              RETURNING id`,
-            { replacements: { id: externalAgentId, amount }, transaction: t }
-        );
-        const ok = Array.isArray(rows) && rows.length > 0;
+      const [rows] = await d.sequelize.query(
+        `UPDATE external_agents
+            SET "leadBalance" = "leadBalance" - :amount, "updatedAt" = NOW()
+          WHERE id = :id AND "leadBalance" >= :amount
+          RETURNING id`,
+        { replacements: { id: externalAgentId, amount }, transaction: t }
+      );
+      const ok = Array.isArray(rows) && rows.length > 0;
 
-        if (ownTransaction) await t.commit();
-        return ok;
+      if (ownTransaction) await t.commit();
+      return ok;
     } catch (error) {
-        if (ownTransaction) await t.rollback();
-        logger.error('Error deducting external lead balance', { error: error?.message || String(error) });
-        return false;
+      if (ownTransaction) await t.rollback();
+      d.logger.error('Error deducting external lead balance', { error: error?.message || String(error) });
+      return false;
     }
-}
+  }
 
-/**
- * Authoritatively charge ONE lead credit to an agent, scoped to a campaign.
- *
- * This is the GATE for hard-quota campaigns. Unlike `deductLeadCredit` (best-effort,
- * campaign-agnostic, returns true even on a partial/zero charge), this:
- *   - draws ONLY from packages tied to `campaignId` (so the charge matches the
- *     campaign that made the agent eligible in the round-robin),
- *   - is atomic & race-safe: a CTE picks the oldest eligible package
- *     `FOR UPDATE SKIP LOCKED` and decrements it in one statement, so the last credit
- *     is never double-spent and `leadsRemaining` never goes negative,
- *   - returns true ONLY if a full credit was charged. A `false` MUST block delivery —
- *     the caller quarantines the lead rather than hand it out unpaid.
- *
- * Falls back to the agent's campaign-agnostic `owed_leads_count` bucket. When a caller
- * transaction is passed it is used (NOT committed); otherwise this owns its own.
- * A clean "no credit" outcome returns false WITHOUT poisoning the caller's transaction
- * (the guarded UPDATEs simply match zero rows); only real DB errors propagate.
- *
- * @param {string} agentId
- * @param {string} campaignId
- * @param {import('sequelize').Transaction|null} externalTransaction
- * @returns {Promise<boolean>} true iff exactly one credit was charged
- */
-export async function chargeLeadCredit(agentId, campaignId, externalTransaction = null) {
+  /**
+   * Authoritatively charge ONE lead credit to an agent, scoped to a campaign.
+   *
+   * This is the GATE for hard-quota campaigns. Unlike `deductLeadCredit` (best-effort,
+   * returns true even on a partial charge), this:
+   *   - draws ONLY from packages tied to `campaignId` (so the charge matches the
+   *     campaign that made the agent eligible in the round-robin),
+   *   - is atomic & race-safe: a CTE picks the oldest eligible package
+   *     `FOR UPDATE SKIP LOCKED` and decrements it in one statement, so the last credit
+   *     is never double-spent and `leadsRemaining` never goes negative,
+   *   - returns true ONLY if a full credit was charged. A `false` MUST block delivery —
+   *     the caller quarantines the lead rather than hand it out unpaid.
+   *
+   * Falls back to the agent's campaign-agnostic `owed_leads_count` bucket. When a caller
+   * transaction is passed it is used (NOT committed); otherwise this owns its own.
+   * A clean "no credit" outcome returns false WITHOUT poisoning the caller's transaction
+   * (the guarded UPDATEs simply match zero rows); only real DB errors propagate.
+   *
+   * @param {string} agentId
+   * @param {string} campaignId
+   * @param {import('sequelize').Transaction|null} externalTransaction
+   * @returns {Promise<boolean>} true iff exactly one credit was charged
+   */
+  async function chargeLeadCredit(agentId, campaignId, externalTransaction = null) {
     if (!agentId || !campaignId) return false;
 
     const ownTransaction = !externalTransaction;
-    const t = externalTransaction || await sequelize.transaction();
+    const t = externalTransaction || await d.sequelize.transaction();
     try {
-        // 1) Oldest active package for THIS campaign that still has a credit.
-        //    SKIP LOCKED so concurrent charges pick different rows (or skip) — the
-        //    last credit is taken by exactly one caller, never double-spent.
-        const [pkgRows] = await sequelize.query(
-            `WITH picked AS (
-                 SELECT a.id
-                   FROM lead_package_assignments a
-                   JOIN lead_packages p ON p.id = a."leadPackageId"
-                  WHERE a."agentId" = :agentId
-                    AND a.status = 'active'
-                    AND a."leadsRemaining" >= 1
-                    AND p."campaignId" = :campaignId
-                  ORDER BY a."purchaseDate" ASC
-                  LIMIT 1
-                  FOR UPDATE OF a SKIP LOCKED
-             )
-             UPDATE lead_package_assignments lpa
-                SET "leadsRemaining" = lpa."leadsRemaining" - 1,
-                    status = CASE WHEN lpa."leadsRemaining" - 1 = 0 THEN 'completed' ELSE lpa.status END,
-                    "updatedAt" = NOW()
-               FROM picked
-              WHERE lpa.id = picked.id
-              RETURNING lpa.id`,
-            { replacements: { agentId, campaignId }, transaction: t }
+      // 1) Oldest active package for THIS campaign that still has a credit.
+      //    SKIP LOCKED so concurrent charges pick different rows (or skip) — the
+      //    last credit is taken by exactly one caller, never double-spent.
+      const [pkgRows] = await d.sequelize.query(
+        `WITH picked AS (
+             SELECT a.id
+               FROM lead_package_assignments a
+               JOIN lead_packages p ON p.id = a."leadPackageId"
+              WHERE a."agentId" = :agentId
+                AND a.status = 'active'
+                AND a."leadsRemaining" >= 1
+                AND p."campaignId" = :campaignId
+              ORDER BY a."purchaseDate" ASC
+              LIMIT 1
+              FOR UPDATE OF a SKIP LOCKED
+         )
+         UPDATE lead_package_assignments lpa
+            SET "leadsRemaining" = lpa."leadsRemaining" - 1,
+                status = CASE WHEN lpa."leadsRemaining" - 1 = 0 THEN 'completed' ELSE lpa.status END,
+                "updatedAt" = NOW()
+           FROM picked
+          WHERE lpa.id = picked.id
+          RETURNING lpa.id`,
+        { replacements: { agentId, campaignId }, transaction: t }
+      );
+
+      let charged = Array.isArray(pkgRows) && pkgRows.length > 0;
+
+      // 2) Fallback: the agent's campaign-agnostic owed_leads_count bucket.
+      if (!charged) {
+        const [owedRows] = await d.sequelize.query(
+          `UPDATE users
+              SET owed_leads_count = owed_leads_count - 1, "updatedAt" = NOW()
+            WHERE id = :agentId AND owed_leads_count >= 1
+            RETURNING id`,
+          { replacements: { agentId }, transaction: t }
         );
+        charged = Array.isArray(owedRows) && owedRows.length > 0;
+      }
 
-        let charged = Array.isArray(pkgRows) && pkgRows.length > 0;
-
-        // 2) Fallback: the agent's campaign-agnostic owed_leads_count bucket.
-        if (!charged) {
-            const [owedRows] = await sequelize.query(
-                `UPDATE users
-                    SET owed_leads_count = owed_leads_count - 1, "updatedAt" = NOW()
-                  WHERE id = :agentId AND owed_leads_count >= 1
-                  RETURNING id`,
-                { replacements: { agentId }, transaction: t }
-            );
-            charged = Array.isArray(owedRows) && owedRows.length > 0;
-        }
-
-        if (ownTransaction) await t.commit();
-        return charged;
+      if (ownTransaction) await t.commit();
+      return charged;
     } catch (error) {
-        logger.error('Error charging lead credit', { error: error?.message || String(error), agentId, campaignId });
-        if (ownTransaction) {
-            await t.rollback().catch(() => {});
-            return false;
-        }
-        // Caller owns the transaction — surface the error so it rolls back rather than
-        // continuing on a poisoned transaction.
-        throw error;
+      d.logger.error('Error charging lead credit', { error: error?.message || String(error), agentId, campaignId });
+      if (ownTransaction) {
+        await t.rollback().catch(() => {});
+        return false;
+      }
+      // Caller owns the transaction — surface the error so it rolls back rather than
+      // continuing on a poisoned transaction.
+      throw error;
     }
+  }
+
+  return { deductLeadCredit, deductExternalLeadBalance, chargeLeadCredit };
 }
+
+// --- Backward-compatible named exports (house pattern) ---
+const _default = makeLeadCreditsService();
+export const deductLeadCredit = _default.deductLeadCredit;
+export const deductExternalLeadBalance = _default.deductExternalLeadBalance;
+export const chargeLeadCredit = _default.chargeLeadCredit;

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -535,7 +535,7 @@ export function makeProspectService(overrides = {}) {
           }
         } else if (finalAgentId && decision.charged !== true) {
           await d
-            .deductLeadCredit(finalAgentId, 1, t)
+            .deductLeadCredit({ agentId: finalAgentId, campaignId: newProspect.campaignId || null, transaction: t })
             .catch((err) => d.logger.error('Failed to deduct credit', { error: err?.message || String(err) }));
         }
       }
@@ -897,7 +897,7 @@ export function makeProspectService(overrides = {}) {
       });
 
       await d
-        .deductLeadCredit(agentId)
+        .deductLeadCredit({ agentId, campaignId: prospect.campaignId || null })
         .catch((err) => d.logger.error('Failed to deduct credit', { error: err?.message || String(err) }));
 
       const prospectWithCampaign = await m.Prospect.findByPk(prospect.id, {
@@ -934,7 +934,7 @@ export function makeProspectService(overrides = {}) {
     });
 
     await d
-      .deductLeadCredit(agentId)
+      .deductLeadCredit({ agentId, campaignId: prospect.campaignId || null })
       .catch((err) => d.logger.error('Failed to deduct credit', { error: err?.message || String(err) }));
 
     const prospectWithCampaign = await m.Prospect.findByPk(prospect.id, {
@@ -976,6 +976,10 @@ export function makeProspectService(overrides = {}) {
       // which bulk update can't do per-lead. Release held leads via single assign
       // (PATCH /:id/assign) or the auto-release sweep.
       quarantinedAt: null,
+      // Skip rows already assigned to THIS agent (IS DISTINCT FROM semantics —
+      // a bare Op.ne would also exclude unassigned NULL rows). Re-assigning a
+      // no-op row used to double-charge the agent for a lead they already held.
+      [Op.or]: [{ assignedAgentId: null }, { assignedAgentId: { [Op.ne]: agentId } }],
       ...scopeFilter,
     };
 
@@ -984,14 +988,25 @@ export function makeProspectService(overrides = {}) {
         assignedAgentId: agentId,
         lastContactDate: new Date(),
       },
-      { where: whereConditions }
+      // RETURNING gives the exact affected rows (no select-then-update race) so
+      // credits can be deducted PER CAMPAIGN — a bulk set can span campaigns,
+      // and campaign-A leads must never drain campaign-B credits.
+      { where: whereConditions, returning: ['id', 'campaignId'] }
     );
 
     const affectedCount = result[0];
+    const affectedRows = result[1] || [];
     if (affectedCount > 0) {
-      await d
-        .deductLeadCredit(agentId, affectedCount)
-        .catch((err) => d.logger.error('Failed to deduct credits', { error: err?.message || String(err) }));
+      const countsByCampaign = new Map();
+      for (const row of affectedRows) {
+        const cId = row.campaignId || null;
+        countsByCampaign.set(cId, (countsByCampaign.get(cId) || 0) + 1);
+      }
+      for (const [cId, count] of countsByCampaign) {
+        await d
+          .deductLeadCredit({ agentId, campaignId: cId, amount: count })
+          .catch((err) => d.logger.error('Failed to deduct credits', { error: err?.message || String(err) }));
+      }
     }
 
     return { affectedCount, agent };

--- a/backend/test/integration/leadCreditScoping.test.js
+++ b/backend/test/integration/leadCreditScoping.test.js
@@ -1,0 +1,75 @@
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestLeadPackage, createTestLeadPackageAssignment } from '../helpers.js';
+import { LeadPackageAssignment, User } from '../../src/models/index.js';
+import { deductLeadCredit } from '../../src/services/leadCredits.js';
+
+/**
+ * Integration: campaign-scoped best-effort deduction against real Postgres
+ * (exercises the two-step package-id + FOR UPDATE SQL the unit mocks can't).
+ *
+ * Invariant: campaign A's leads can only consume campaign A's credits — never
+ * campaign B's (the production bug), then the manual owed_leads_count bucket.
+ */
+
+let admin, agent, campaignA, campaignB, assignA, assignB;
+
+beforeAll(async () => {
+  process.env.WEBHOOK_ENABLED = 'false';
+  await getApp();
+
+  ({ user: admin } = await createTestUser({ role: 'admin' }));
+  ({ user: agent } = await createTestUser({ role: 'agent', owed_leads_count: 2 }));
+
+  campaignA = await createTestCampaign(admin.id, { name: `Scope A ${Date.now()}` });
+  campaignB = await createTestCampaign(admin.id, { name: `Scope B ${Date.now()}` });
+
+  const pkgA = await createTestLeadPackage(campaignA.id, admin.id, { name: 'Pkg A' });
+  const pkgB = await createTestLeadPackage(campaignB.id, admin.id, { name: 'Pkg B' });
+
+  assignA = await createTestLeadPackageAssignment(agent.id, pkgA.id, { leadsRemaining: 2, leadsTotal: 2 });
+  assignB = await createTestLeadPackageAssignment(agent.id, pkgB.id, { leadsRemaining: 3, leadsTotal: 3 });
+}, 30000);
+
+afterAll(async () => {
+  await closeDb();
+});
+
+const remaining = async (id) => (await LeadPackageAssignment.findByPk(id)).leadsRemaining;
+const owed = async () => (await User.findByPk(agent.id)).owed_leads_count;
+
+describe('deductLeadCredit — campaign scoping (real SQL)', () => {
+  it('a campaign-A deduction decrements ONLY campaign A', async () => {
+    const ok = await deductLeadCredit({ agentId: agent.id, campaignId: campaignA.id });
+    expect(ok).toBe(true);
+    expect(await remaining(assignA.id)).toBe(1);
+    expect(await remaining(assignB.id)).toBe(3); // untouched — the old code would have FIFO'd into whichever was older
+  });
+
+  it('exhausting campaign A falls back to the MANUAL bucket — never campaign B', async () => {
+    const ok = await deductLeadCredit({ agentId: agent.id, campaignId: campaignA.id, amount: 2 });
+    expect(ok).toBe(true);
+    expect(await remaining(assignA.id)).toBe(0);
+    const a = await LeadPackageAssignment.findByPk(assignA.id);
+    expect(a.status).toBe('completed');
+    expect(await remaining(assignB.id)).toBe(3); // still untouched
+    expect(await owed()).toBe(1); // manual bucket paid the overflow (2 -> 1)
+  });
+
+  it('a campaignless deduction touches no package at all', async () => {
+    const ok = await deductLeadCredit({ agentId: agent.id, campaignId: null });
+    expect(ok).toBe(true);
+    expect(await remaining(assignB.id)).toBe(3);
+    expect(await owed()).toBe(0);
+  });
+
+  it('returns false when neither the campaign nor the manual bucket can pay', async () => {
+    const ok = await deductLeadCredit({ agentId: agent.id, campaignId: campaignA.id });
+    expect(ok).toBe(false);
+    expect(await remaining(assignB.id)).toBe(3); // campaign B remains sacrosanct
+  });
+
+  it('campaign B still pays out normally when actually targeted', async () => {
+    const ok = await deductLeadCredit({ agentId: agent.id, campaignId: campaignB.id });
+    expect(ok).toBe(true);
+    expect(await remaining(assignB.id)).toBe(2);
+  });
+});

--- a/backend/test/unit/agentStatsHelpers.test.js
+++ b/backend/test/unit/agentStatsHelpers.test.js
@@ -5,6 +5,10 @@ import '../setup.js';
 jest.unstable_mockModule('../../src/models/index.js', () => ({
   LeadPackage: {},
   LeadPackageAssignment: { findAll: jest.fn().mockResolvedValue([]) },
+  sequelize: {
+    query: jest.fn().mockResolvedValue([]),
+    QueryTypes: { SELECT: 'SELECT' },
+  },
 }));
 
 const { getAssignedCampaignCounts, computeAgentStats, computeAgentStatsFromCounts } =

--- a/backend/test/unit/chargeLeadCredit.test.js
+++ b/backend/test/unit/chargeLeadCredit.test.js
@@ -14,6 +14,7 @@ jest.unstable_mockModule('../../src/models/index.js', () => ({
     transaction: jest.fn().mockResolvedValue(ownTx),
   },
   LeadPackageAssignment: {},
+  LeadPackage: {},
   User: {},
 }));
 

--- a/backend/test/unit/leadCredits.test.js
+++ b/backend/test/unit/leadCredits.test.js
@@ -1,347 +1,176 @@
 import { jest } from '@jest/globals';
 import '../setup.js';
 import { Op } from 'sequelize';
+import { makeLeadCreditsService } from '../../src/services/leadCredits.js';
 
-// ── Helpers ──
+/**
+ * Tests the REAL deductLeadCredit via the DI factory. (The previous version of
+ * this file re-implemented the function inside the test and asserted against
+ * the copy — it protected nothing and silently drifted; Codex review finding.)
+ *
+ * Core invariant under test: deduction is CAMPAIGN-SCOPED — campaign A's leads
+ * can only consume campaign A's package credits (then the campaign-agnostic
+ * manual owed_leads_count bucket). Cross-campaign bleed was the production bug.
+ */
 
-function buildMocks() {
-  const mockAssignment1 = {
-    id: 'assign-1',
-    agentId: 'agent-1',
-    leadsRemaining: 5,
-    status: 'active',
-    purchaseDate: new Date('2025-01-01'),
-    save: jest.fn().mockResolvedValue(true),
-  };
-
-  const mockAssignment2 = {
-    id: 'assign-2',
-    agentId: 'agent-1',
-    leadsRemaining: 3,
-    status: 'active',
-    purchaseDate: new Date('2025-02-01'),
-    save: jest.fn().mockResolvedValue(true),
-  };
-
-  const mockAgent = {
-    id: 'agent-1',
-    owed_leads_count: 10,
-    save: jest.fn().mockResolvedValue(true),
-  };
-
+function buildMocks({ packages = [], assignments = [], agent = null } = {}) {
   const mockTransaction = {
     commit: jest.fn().mockResolvedValue(undefined),
     rollback: jest.fn().mockResolvedValue(undefined),
     LOCK: { UPDATE: 'UPDATE' },
   };
-
-  const User = {
-    findByPk: jest.fn().mockResolvedValue(mockAgent),
-  };
-
-  const LeadPackageAssignment = {
-    findAll: jest.fn().mockResolvedValue([]),
-  };
-
-  const sequelize = {
-    transaction: jest.fn().mockResolvedValue(mockTransaction),
-  };
-
-  const logger = {
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-    debug: jest.fn(),
-  };
-
   return {
-    mockAssignment1,
-    mockAssignment2,
-    mockAgent,
     mockTransaction,
-    models: { User, LeadPackageAssignment },
-    sequelize,
-    logger,
+    LeadPackage: { findAll: jest.fn().mockResolvedValue(packages) },
+    LeadPackageAssignment: { findAll: jest.fn().mockResolvedValue(assignments) },
+    User: { findByPk: jest.fn().mockResolvedValue(agent) },
+    sequelize: { transaction: jest.fn().mockResolvedValue(mockTransaction) },
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
   };
 }
 
-/**
- * Build a deductLeadCredit function that uses the provided mocks instead
- * of the real model imports.  This mirrors the makeProspectService DI pattern.
- */
-function makeService(mocks) {
-  const { User, LeadPackageAssignment } = mocks.models;
-  const { sequelize, logger } = mocks;
+const makeAssignment = (over = {}) => ({
+  id: 'assign-1',
+  agentId: 'agent-1',
+  leadsRemaining: 5,
+  status: 'active',
+  purchaseDate: new Date('2025-01-01'),
+  save: jest.fn().mockResolvedValue(true),
+  ...over,
+});
 
-  async function deductLeadCredit(agentId, amount = 1, externalTransaction = null) {
-    if (!agentId || amount <= 0) return false;
+const makeAgent = (owed = 10) => ({
+  id: 'agent-1',
+  owed_leads_count: owed,
+  save: jest.fn().mockResolvedValue(true),
+});
 
-    const ownTransaction = !externalTransaction;
-    const t = externalTransaction || await sequelize.transaction();
-    try {
-      let remainingToDeduct = amount;
+describe('leadCredits – deductLeadCredit (real implementation, DI)', () => {
+  it('rejects positional (legacy-style) calls with a structured log, never throws', async () => {
+    const m = buildMocks();
+    const svc = makeLeadCreditsService(m);
 
-      // 1. FIFO from lead package assignments
-      const assignments = await LeadPackageAssignment.findAll({
-        where: {
-          agentId,
-          status: 'active',
-          leadsRemaining: { [Op.gt]: 0 },
-        },
-        order: [['purchaseDate', 'ASC']],
-        transaction: t,
-        lock: t.LOCK.UPDATE,
-      });
+    // The old signature was (agentId, amount, tx) — must not be silently misread.
+    const result = await svc.deductLeadCredit('agent-1');
 
-      for (const assignment of assignments) {
-        if (remainingToDeduct <= 0) break;
-
-        const available = assignment.leadsRemaining;
-        const deduction = Math.min(available, remainingToDeduct);
-
-        assignment.leadsRemaining -= deduction;
-        remainingToDeduct -= deduction;
-
-        if (assignment.leadsRemaining === 0) {
-          assignment.status = 'completed';
-        }
-
-        await assignment.save({ transaction: t });
-      }
-
-      // 2. Fallback to User.owed_leads_count
-      if (remainingToDeduct > 0) {
-        const agent = await User.findByPk(agentId, {
-          transaction: t,
-          lock: t.LOCK.UPDATE,
-        });
-
-        if (agent && agent.owed_leads_count > 0) {
-          const available = agent.owed_leads_count;
-          const deduction = Math.min(available, remainingToDeduct);
-
-          agent.owed_leads_count -= deduction;
-          remainingToDeduct -= deduction;
-
-          await agent.save({ transaction: t });
-        }
-      }
-
-      if (ownTransaction) await t.commit();
-
-      if (remainingToDeduct > 0 && remainingToDeduct < amount) {
-        // partial
-      } else if (remainingToDeduct === amount) {
-        return false;
-      }
-
-      return true;
-    } catch (error) {
-      if (ownTransaction) await t.rollback();
-      logger.error('Error deducting lead credits', { error: error?.message || String(error) });
-      return false;
-    }
-  }
-
-  return { deductLeadCredit };
-}
-
-// ── Tests ──
-
-describe('leadCredits – deductLeadCredit (unit)', () => {
-  let mocks, service;
-
-  beforeEach(() => {
-    mocks = buildMocks();
-    service = makeService(mocks);
+    expect(result).toBe(false);
+    expect(m.logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('options object required'),
+      expect.any(Object)
+    );
+    expect(m.sequelize.transaction).not.toHaveBeenCalled();
   });
 
-  // ────────────────────────────────────────────────
-  // FIFO deduction from LeadPackageAssignment
-  // ────────────────────────────────────────────────
+  it('returns false for missing agentId or non-positive amount', async () => {
+    const m = buildMocks();
+    const svc = makeLeadCreditsService(m);
+    expect(await svc.deductLeadCredit({ campaignId: 'camp-1' })).toBe(false);
+    expect(await svc.deductLeadCredit({ agentId: 'agent-1', amount: 0 })).toBe(false);
+  });
 
-  it('deducts from the earliest package first (FIFO)', async () => {
-    mocks.models.LeadPackageAssignment.findAll.mockResolvedValue([
-      mocks.mockAssignment1, // 5 remaining, earlier date
-      mocks.mockAssignment2, // 3 remaining, later date
-    ]);
+  it("scopes package deduction to the campaign: only that campaign's package ids are queried", async () => {
+    const a1 = makeAssignment({ leadsRemaining: 3 });
+    const m = buildMocks({ packages: [{ id: 'pkg-A' }], assignments: [a1], agent: makeAgent(0) });
+    const svc = makeLeadCreditsService(m);
 
-    const result = await service.deductLeadCredit('agent-1', 3);
+    const result = await svc.deductLeadCredit({ agentId: 'agent-1', campaignId: 'camp-A', amount: 2 });
 
     expect(result).toBe(true);
-    expect(mocks.mockAssignment1.leadsRemaining).toBe(2);
-    expect(mocks.mockAssignment1.save).toHaveBeenCalled();
-    expect(mocks.mockAssignment2.save).not.toHaveBeenCalled();
+    // Step 1: the campaign's packages were looked up…
+    expect(m.LeadPackage.findAll).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { campaignId: 'camp-A' } })
+    );
+    // …step 2: assignments are filtered to those package ids (single-table lock, no join).
+    const q = m.LeadPackageAssignment.findAll.mock.calls[0][0];
+    expect(q.where.leadPackageId).toEqual({ [Op.in]: ['pkg-A'] });
+    expect(q.lock).toBe('UPDATE');
+    expect(a1.leadsRemaining).toBe(1);
   });
 
-  it('deducts across multiple packages when first is insufficient', async () => {
-    const assign1 = { ...mocks.mockAssignment1, leadsRemaining: 2, save: jest.fn().mockResolvedValue(true) };
-    const assign2 = { ...mocks.mockAssignment2, leadsRemaining: 5, save: jest.fn().mockResolvedValue(true) };
-    mocks.models.LeadPackageAssignment.findAll.mockResolvedValue([assign1, assign2]);
+  it('drains FIFO across multiple assignments within the campaign and completes emptied ones', async () => {
+    const older = makeAssignment({ id: 'a-old', leadsRemaining: 2, purchaseDate: new Date('2025-01-01') });
+    const newer = makeAssignment({ id: 'a-new', leadsRemaining: 5, purchaseDate: new Date('2025-02-01') });
+    const m = buildMocks({ packages: [{ id: 'pkg-A' }], assignments: [older, newer], agent: makeAgent(0) });
+    const svc = makeLeadCreditsService(m);
 
-    const result = await service.deductLeadCredit('agent-1', 4);
+    const result = await svc.deductLeadCredit({ agentId: 'agent-1', campaignId: 'camp-A', amount: 3 });
 
     expect(result).toBe(true);
-    expect(assign1.leadsRemaining).toBe(0);
-    expect(assign1.status).toBe('completed');
-    expect(assign2.leadsRemaining).toBe(3);
-    expect(assign1.save).toHaveBeenCalled();
-    expect(assign2.save).toHaveBeenCalled();
+    expect(older.leadsRemaining).toBe(0);
+    expect(older.status).toBe('completed');
+    expect(newer.leadsRemaining).toBe(4);
   });
 
-  it('marks assignment as completed when remaining hits 0', async () => {
-    const assign = { ...mocks.mockAssignment1, leadsRemaining: 3, save: jest.fn().mockResolvedValue(true) };
-    mocks.models.LeadPackageAssignment.findAll.mockResolvedValue([assign]);
+  it('campaign with NO matching packages: package phase skipped, manual bucket pays', async () => {
+    const agent = makeAgent(5);
+    const m = buildMocks({ packages: [], assignments: [], agent });
+    const svc = makeLeadCreditsService(m);
 
-    await service.deductLeadCredit('agent-1', 3);
-
-    expect(assign.leadsRemaining).toBe(0);
-    expect(assign.status).toBe('completed');
-  });
-
-  it('does not mark assignment as completed when remaining > 0', async () => {
-    const assign = { ...mocks.mockAssignment1, leadsRemaining: 5, status: 'active', save: jest.fn().mockResolvedValue(true) };
-    mocks.models.LeadPackageAssignment.findAll.mockResolvedValue([assign]);
-
-    await service.deductLeadCredit('agent-1', 2);
-
-    expect(assign.leadsRemaining).toBe(3);
-    expect(assign.status).toBe('active');
-  });
-
-  // ────────────────────────────────────────────────
-  // Fallback to User.owed_leads_count
-  // ────────────────────────────────────────────────
-
-  it('deducts from owed_leads_count when no packages exist', async () => {
-    mocks.models.LeadPackageAssignment.findAll.mockResolvedValue([]);
-    const agent = { ...mocks.mockAgent, owed_leads_count: 10, save: jest.fn().mockResolvedValue(true) };
-    mocks.models.User.findByPk.mockResolvedValue(agent);
-
-    const result = await service.deductLeadCredit('agent-1', 3);
+    const result = await svc.deductLeadCredit({ agentId: 'agent-1', campaignId: 'camp-B', amount: 2 });
 
     expect(result).toBe(true);
-    expect(agent.owed_leads_count).toBe(7);
-    expect(agent.save).toHaveBeenCalled();
+    // No package ids → assignment query never runs (nothing to lock).
+    expect(m.LeadPackageAssignment.findAll).not.toHaveBeenCalled();
+    expect(agent.owed_leads_count).toBe(3);
   });
 
-  it('deducts remaining from owed_leads_count when packages are exhausted', async () => {
-    const assign = { ...mocks.mockAssignment1, leadsRemaining: 2, save: jest.fn().mockResolvedValue(true) };
-    mocks.models.LeadPackageAssignment.findAll.mockResolvedValue([assign]);
-    const agent = { ...mocks.mockAgent, owed_leads_count: 10, save: jest.fn().mockResolvedValue(true) };
-    mocks.models.User.findByPk.mockResolvedValue(agent);
+  it('campaignless lead (campaignId null): NEVER touches packages, only the manual bucket', async () => {
+    const agent = makeAgent(4);
+    const m = buildMocks({ packages: [{ id: 'pkg-A' }], assignments: [makeAssignment()], agent });
+    const svc = makeLeadCreditsService(m);
 
-    const result = await service.deductLeadCredit('agent-1', 5);
+    const result = await svc.deductLeadCredit({ agentId: 'agent-1', campaignId: null });
 
     expect(result).toBe(true);
-    expect(assign.leadsRemaining).toBe(0);
-    expect(assign.status).toBe('completed');
-    expect(agent.owed_leads_count).toBe(7); // 10 - 3 remaining
+    expect(m.LeadPackage.findAll).not.toHaveBeenCalled();
+    expect(m.LeadPackageAssignment.findAll).not.toHaveBeenCalled();
+    expect(agent.owed_leads_count).toBe(3);
   });
 
-  // ────────────────────────────────────────────────
-  // Edge cases: zero remaining, no credits
-  // ────────────────────────────────────────────────
+  it('falls back to the manual bucket only for the REMAINDER the campaign packages could not cover', async () => {
+    const a1 = makeAssignment({ leadsRemaining: 1 });
+    const agent = makeAgent(10);
+    const m = buildMocks({ packages: [{ id: 'pkg-A' }], assignments: [a1], agent });
+    const svc = makeLeadCreditsService(m);
 
-  it('returns false when both packages and owed_leads_count are zero', async () => {
-    mocks.models.LeadPackageAssignment.findAll.mockResolvedValue([]);
-    const agent = { ...mocks.mockAgent, owed_leads_count: 0, save: jest.fn().mockResolvedValue(true) };
-    mocks.models.User.findByPk.mockResolvedValue(agent);
+    const result = await svc.deductLeadCredit({ agentId: 'agent-1', campaignId: 'camp-A', amount: 3 });
 
-    const result = await service.deductLeadCredit('agent-1', 1);
+    expect(result).toBe(true);
+    expect(a1.leadsRemaining).toBe(0);
+    expect(agent.owed_leads_count).toBe(8); // paid the remaining 2
+  });
+
+  it('returns false when no source can pay anything', async () => {
+    const m = buildMocks({ packages: [], assignments: [], agent: makeAgent(0) });
+    const svc = makeLeadCreditsService(m);
+
+    const result = await svc.deductLeadCredit({ agentId: 'agent-1', campaignId: 'camp-A' });
 
     expect(result).toBe(false);
   });
 
-  it('returns false when agent not found and no packages', async () => {
-    mocks.models.LeadPackageAssignment.findAll.mockResolvedValue([]);
-    mocks.models.User.findByPk.mockResolvedValue(null);
+  it("owns + commits its transaction when none is passed; uses the caller's when passed (no commit)", async () => {
+    const agent = makeAgent(2);
+    const m = buildMocks({ packages: [], assignments: [], agent });
+    const svc = makeLeadCreditsService(m);
 
-    const result = await service.deductLeadCredit('agent-1', 1);
+    await svc.deductLeadCredit({ agentId: 'agent-1', campaignId: null });
+    expect(m.mockTransaction.commit).toHaveBeenCalledTimes(1);
+
+    m.mockTransaction.commit.mockClear();
+    await svc.deductLeadCredit({ agentId: 'agent-1', campaignId: null, transaction: m.mockTransaction });
+    expect(m.mockTransaction.commit).not.toHaveBeenCalled();
+  });
+
+  it('rolls back its own transaction and returns false on a DB error (best-effort: never throws)', async () => {
+    const m = buildMocks({ agent: makeAgent(1) });
+    m.LeadPackage.findAll.mockRejectedValue(new Error('db down'));
+    const svc = makeLeadCreditsService(m);
+
+    const result = await svc.deductLeadCredit({ agentId: 'agent-1', campaignId: 'camp-A' });
 
     expect(result).toBe(false);
-  });
-
-  it('returns true for partial deduction (some credits available, less than requested)', async () => {
-    mocks.models.LeadPackageAssignment.findAll.mockResolvedValue([]);
-    const agent = { ...mocks.mockAgent, owed_leads_count: 2, save: jest.fn().mockResolvedValue(true) };
-    mocks.models.User.findByPk.mockResolvedValue(agent);
-
-    const result = await service.deductLeadCredit('agent-1', 5);
-
-    expect(result).toBe(true); // partial deduction still returns true
-    expect(agent.owed_leads_count).toBe(0);
-  });
-
-  // ────────────────────────────────────────────────
-  // Validation
-  // ────────────────────────────────────────────────
-
-  it('returns false when agentId is null', async () => {
-    const result = await service.deductLeadCredit(null, 1);
-
-    expect(result).toBe(false);
-    expect(mocks.models.LeadPackageAssignment.findAll).not.toHaveBeenCalled();
-  });
-
-  it('returns false when amount is 0', async () => {
-    const result = await service.deductLeadCredit('agent-1', 0);
-    expect(result).toBe(false);
-  });
-
-  it('returns false when amount is negative', async () => {
-    const result = await service.deductLeadCredit('agent-1', -5);
-    expect(result).toBe(false);
-  });
-
-  // ────────────────────────────────────────────────
-  // Transaction handling
-  // ────────────────────────────────────────────────
-
-  it('uses external transaction when provided (no commit/rollback)', async () => {
-    const extTx = {
-      LOCK: { UPDATE: 'UPDATE' },
-      commit: jest.fn(),
-      rollback: jest.fn(),
-    };
-    mocks.models.LeadPackageAssignment.findAll.mockResolvedValue([]);
-    const agent = { ...mocks.mockAgent, owed_leads_count: 5, save: jest.fn().mockResolvedValue(true) };
-    mocks.models.User.findByPk.mockResolvedValue(agent);
-
-    await service.deductLeadCredit('agent-1', 1, extTx);
-
-    expect(mocks.sequelize.transaction).not.toHaveBeenCalled();
-    expect(extTx.commit).not.toHaveBeenCalled();
-    expect(extTx.rollback).not.toHaveBeenCalled();
-  });
-
-  it('commits own transaction on success', async () => {
-    mocks.models.LeadPackageAssignment.findAll.mockResolvedValue([]);
-    const agent = { ...mocks.mockAgent, owed_leads_count: 5, save: jest.fn().mockResolvedValue(true) };
-    mocks.models.User.findByPk.mockResolvedValue(agent);
-
-    await service.deductLeadCredit('agent-1', 1);
-
-    expect(mocks.mockTransaction.commit).toHaveBeenCalled();
-  });
-
-  it('rolls back own transaction on error', async () => {
-    mocks.models.LeadPackageAssignment.findAll.mockRejectedValue(new Error('DB error'));
-
-    const result = await service.deductLeadCredit('agent-1', 1);
-
-    expect(result).toBe(false);
-    expect(mocks.mockTransaction.rollback).toHaveBeenCalled();
-    expect(mocks.logger.error).toHaveBeenCalled();
-  });
-
-  it('passes FOR UPDATE lock to findAll', async () => {
-    mocks.models.LeadPackageAssignment.findAll.mockResolvedValue([]);
-    mocks.models.User.findByPk.mockResolvedValue(null);
-
-    await service.deductLeadCredit('agent-1', 1);
-
-    const findAllArg = mocks.models.LeadPackageAssignment.findAll.mock.calls[0][0];
-    expect(findAllArg.lock).toBe('UPDATE');
+    expect(m.mockTransaction.rollback).toHaveBeenCalled();
+    expect(m.logger.error).toHaveBeenCalledWith('Error deducting lead credits', expect.any(Object));
   });
 });

--- a/backend/test/unit/prospectAssignment.test.js
+++ b/backend/test/unit/prospectAssignment.test.js
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals';
 import '../setup.js';
+import { Op } from 'sequelize';
 import { makeProspectService } from '../../src/services/prospectService.js';
 
 // ── Helpers ──
@@ -232,7 +233,7 @@ describe('prospectAssignment (unit)', () => {
 
       await service.assignProspect('prospect-1', 'agent-1', admin);
 
-      expect(mocks.deductLeadCredit).toHaveBeenCalledWith('agent-1');
+      expect(mocks.deductLeadCredit).toHaveBeenCalledWith({ agentId: 'agent-1', campaignId: 'camp-1' });
     });
 
     it('does not deduct lead credit on unassignment', async () => {
@@ -329,7 +330,7 @@ describe('prospectAssignment (unit)', () => {
       await service.assignProspect('prospect-1', 'agent-1', admin);
 
       expect(mocks.sequelize.query).toHaveBeenCalled();
-      expect(mocks.deductLeadCredit).toHaveBeenCalledWith('agent-1');
+      expect(mocks.deductLeadCredit).toHaveBeenCalledWith({ agentId: 'agent-1', campaignId: 'camp-1' });
       expect(mocks.dispatchEvent).toHaveBeenCalledWith('lead.created', expect.any(Function), expect.objectContaining({ destination: 'lyfe' }));
       expect(mocks.dispatchEvent).not.toHaveBeenCalledWith('lead.assigned', expect.any(Function));
     });
@@ -379,7 +380,11 @@ describe('prospectAssignment (unit)', () => {
 
   describe('bulkAssignProspects', () => {
     it('assigns multiple prospects to an agent via bulk update', async () => {
-      mocks.models.Prospect.update.mockResolvedValue([3]);
+      mocks.models.Prospect.update.mockResolvedValue([3, [
+        { id: 'p-1', campaignId: 'camp-1' },
+        { id: 'p-2', campaignId: 'camp-1' },
+        { id: 'p-3', campaignId: 'camp-1' },
+      ]]);
 
       const result = await service.bulkAssignProspects(['p-1', 'p-2', 'p-3'], 'agent-1', admin);
 
@@ -387,12 +392,49 @@ describe('prospectAssignment (unit)', () => {
       expect(result.agent).toBeDefined();
     });
 
-    it('deducts lead credits for affected count', async () => {
-      mocks.models.Prospect.update.mockResolvedValue([2]);
+    it('deducts lead credits per campaign from the RETURNING rows', async () => {
+      mocks.models.Prospect.update.mockResolvedValue([2, [
+        { id: 'p-1', campaignId: 'camp-1' },
+        { id: 'p-2', campaignId: 'camp-1' },
+      ]]);
 
       await service.bulkAssignProspects(['p-1', 'p-2'], 'agent-1', admin);
 
-      expect(mocks.deductLeadCredit).toHaveBeenCalledWith('agent-1', 2);
+      expect(mocks.deductLeadCredit).toHaveBeenCalledWith({ agentId: 'agent-1', campaignId: 'camp-1', amount: 2 });
+    });
+
+    it('splits the deduction per campaign when the bulk set spans campaigns (incl. campaignless)', async () => {
+      mocks.models.Prospect.update.mockResolvedValue([4, [
+        { id: 'p-1', campaignId: 'camp-1' },
+        { id: 'p-2', campaignId: 'camp-2' },
+        { id: 'p-3', campaignId: 'camp-1' },
+        { id: 'p-4', campaignId: null },
+      ]]);
+
+      await service.bulkAssignProspects(['p-1', 'p-2', 'p-3', 'p-4'], 'agent-1', admin);
+
+      // Campaign-A leads must never drain campaign-B credits: one scoped
+      // deduction per campaign, and the campaignless lead hits only the
+      // manual bucket (campaignId: null).
+      expect(mocks.deductLeadCredit).toHaveBeenCalledTimes(3);
+      expect(mocks.deductLeadCredit).toHaveBeenCalledWith({ agentId: 'agent-1', campaignId: 'camp-1', amount: 2 });
+      expect(mocks.deductLeadCredit).toHaveBeenCalledWith({ agentId: 'agent-1', campaignId: 'camp-2', amount: 1 });
+      expect(mocks.deductLeadCredit).toHaveBeenCalledWith({ agentId: 'agent-1', campaignId: null, amount: 1 });
+    });
+
+    it('excludes rows already assigned to the SAME agent (no re-assign double-charge)', async () => {
+      mocks.models.Prospect.update.mockResolvedValue([0, []]);
+
+      await service.bulkAssignProspects(['p-1'], 'agent-1', admin);
+
+      const where = mocks.models.Prospect.update.mock.calls[0][1].where;
+      // IS DISTINCT FROM semantics: unassigned (NULL) rows still match, rows
+      // already held by agent-1 do not.
+      expect(where[Op.or]).toEqual([
+        { assignedAgentId: null },
+        { assignedAgentId: { [Op.ne]: 'agent-1' } },
+      ]);
+      expect(mocks.deductLeadCredit).not.toHaveBeenCalled();
     });
 
     it('throws when agentId is missing', async () => {
@@ -446,11 +488,11 @@ describe('prospectAssignment (unit)', () => {
       const body = { firstName: 'Test', campaignId: 'camp-1' };
       await service.createProspect(body, admin, {});
 
-      expect(mocks.deductLeadCredit).toHaveBeenCalledWith(
-        'agent-1',
-        1,
-        mocks.mockTransaction
-      );
+      expect(mocks.deductLeadCredit).toHaveBeenCalledWith({
+        agentId: 'agent-1',
+        campaignId: 'camp-1',
+        transaction: mocks.mockTransaction,
+      });
     });
 
     it('dispatches lead.created webhook', async () => {
@@ -545,7 +587,11 @@ describe('prospectAssignment (unit)', () => {
       const createArg = mocks.models.Prospect.create.mock.calls[0][0];
       expect(createArg.assignedAgentId).toBe('agent-1');
       expect(mocks.chargeLeadCredit).not.toHaveBeenCalled();
-      expect(mocks.deductLeadCredit).toHaveBeenCalledWith('agent-1', 1, mocks.mockTransaction);
+      expect(mocks.deductLeadCredit).toHaveBeenCalledWith({
+        agentId: 'agent-1',
+        campaignId: 'camp-1',
+        transaction: mocks.mockTransaction,
+      });
       expect(mocks.dispatchEvent).toHaveBeenCalledWith('lead.created', expect.any(Function), expect.objectContaining({ destination: 'lyfe' }));
     });
 

--- a/backend/test/unit/prospectService.test.js
+++ b/backend/test/unit/prospectService.test.js
@@ -524,11 +524,11 @@ describe('prospectService (unit)', () => {
 
       await service.createProspect(body, user, {});
 
-      expect(mocks.deductLeadCredit).toHaveBeenCalledWith(
-        'agent-1',
-        1,
-        mocks.mockTransaction
-      );
+      expect(mocks.deductLeadCredit).toHaveBeenCalledWith({
+        agentId: 'agent-1',
+        campaignId: 'camp-1',
+        transaction: mocks.mockTransaction,
+      });
     });
 
     it('does not deduct lead credit when no agent is assigned', async () => {
@@ -687,7 +687,7 @@ describe('prospectService (unit)', () => {
 
       await service.assignProspect('prospect-1', 'agent-1', user);
 
-      expect(mocks.deductLeadCredit).toHaveBeenCalledWith('agent-1');
+      expect(mocks.deductLeadCredit).toHaveBeenCalledWith({ agentId: 'agent-1', campaignId: 'camp-1' });
     });
 
     it('creates ProspectActivity record for unassignment', async () => {

--- a/src/components/agents/AgentTable.jsx
+++ b/src/components/agents/AgentTable.jsx
@@ -295,7 +295,8 @@ const AgentRow = React.memo(function AgentRow({
  {/* Status */}
  <TableCell className="px-6 py-4">{renderStatusBadge()}</TableCell>
 
- {/* Leads owed */}
+ {/* Leads owed — credits are per-campaign ledgers, so when an agent holds
+ more than one bucket the split is shown under the total. */}
  <TableCell className="px-6 py-4">
  <div className="flex items-center gap-2">
  <Badge
@@ -308,6 +309,26 @@ const AgentRow = React.memo(function AgentRow({
  <Plus className="w-3 h-3 mr-1"/> Assign
  </Button>
  </div>
+ {(() => {
+ const breakdown = agent.owed_leads_breakdown || [];
+ const manual = agent.owed_leads_manual_count || 0;
+ const buckets = breakdown.length + (manual > 0 ? 1 : 0);
+ if (buckets <= 1) return null;
+ return (
+ <div className="mt-1 space-y-0.5">
+ {breakdown.map((b) => (
+ <p key={b.campaignId || 'none'} className="text-[11px] leading-tight text-muted-foreground whitespace-nowrap">
+ {b.campaignName || 'No campaign'} · {b.leadsRemaining}
+ </p>
+ ))}
+ {manual > 0 && (
+ <p className="text-[11px] leading-tight text-muted-foreground whitespace-nowrap">
+ Manual · {manual}
+ </p>
+ )}
+ </div>
+ );
+ })()}
  </TableCell>
 
  {/* Joined date */}


### PR DESCRIPTION
## Why

Credits are **per-campaign ledgers**: round-robin eligibility is campaign-scoped, the authoritative charge (hard-quota) is campaign-scoped — but the best-effort `deductLeadCredit` (the path every **soft-campaign** web/manual assignment takes; soft is the production default) deducted **FIFO across ALL the agent's packages, ignoring campaign**. With packages on 2 campaigns, a campaign-A lead silently drains the campaign-B balance. Surfaced by Shawn asking why "Leads Owed" is one merged number.

**Process:** plan → Codex CLI adversarial review (verdict: *bug real, don't build as written*) → plan v2 with all 5 must-fixes → this PR. Plan: `~/.claude/plans/campaign-scoped-deduction.md`.

## What

**`leadCredits`** — DI factory (the old test file *re-implemented the function inside itself* and asserted against the copy — Codex finding; now the real code is tested). `deductLeadCredit({agentId, campaignId, amount, transaction})` (options object — positional was silently misusable), campaign scoping via **two-step single-table lock** (package ids first, then the original `FOR UPDATE` filtered by them — no join under the lock), FIFO within campaign, manual `owed_leads_count` fallback unchanged. `campaignId: null` → packages never touched.

**`prospectService`** — all 4 callsites pass the prospect's campaign. `bulkAssignProspects` handles **multi-campaign sets**: `returning: ['id','campaignId']` → per-campaign deduction; plus fixes a pre-existing **double-charge** (rows already assigned to the same agent were re-counted — now excluded, IS-DISTINCT-FROM semantics).

**Leads Owed UI** — `getAgentPackageBreakdowns()` (separate grouped query, not a deeper include on the paginated list — Codex) → `owed_leads_breakdown` per agent; AgentTable shows the per-campaign split under the total **only when** an agent holds >1 bucket. Today's single-package rows render unchanged.

## Invariant after this PR

Campaign A's leads can only consume Campaign A's credits (then the manual bucket) on **every** path: eligibility ✓ authoritative charge ✓ best-effort deduction ✓ — and the UI shows the split.

## Test

- `leadCredits.test.js` rewritten against the real factory: positional-guard, scoping (package-id filter + lock), FIFO + completed-at-0, null-campaign, remainder→manual fallback, own-vs-caller tx, rollback. 
- New integration `leadCreditScoping.test.js` (real SQL): A never drains B; manual fallback; campaignless; B still pays when targeted.
- Bulk: per-campaign split (incl. campaignless) + same-agent exclusion.
- Backend unit failing set **identical to main's baseline** (+21 net new passing); vitest **1013/1013**; build clean.

No migration, no env. Behavior identical for today's data (each funded agent holds one single-campaign package); the invariant matters from the second campaign onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)