### PR TITLE
Add MKTR Leads privacy policy page

### DIFF
--- a/public/legal/mktr-leads-privacy.html
+++ b/public/legal/mktr-leads-privacy.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="robots" content="index,follow" />
+<title>MKTR Leads — Privacy Policy</title>
+<meta name="description" content="Privacy Policy for the MKTR Leads app, in line with Singapore's Personal Data Protection Act (PDPA)." />
+<style>
+  :root { --ink:#16130F; --muted:#5C544B; --line:#ECE7DF; --accent:#FF5A1F; --bg:#FBFAF8; }
+  * { box-sizing: border-box; }
+  body { margin:0; background:var(--bg); color:var(--ink);
+    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; line-height:1.65; }
+  .wrap { max-width:760px; margin:0 auto; padding:56px 22px 96px; }
+  .brand { display:flex; align-items:center; gap:10px; font-weight:700; letter-spacing:-0.02em; }
+  .dot { width:12px; height:12px; border-radius:3px; background:var(--accent); display:inline-block; }
+  h1 { font-size:32px; letter-spacing:-0.02em; margin:26px 0 6px; }
+  .meta { color:var(--muted); font-size:14px; margin-bottom:26px; }
+  h2 { font-size:19px; letter-spacing:-0.01em; margin:34px 0 8px; }
+  p, li { color:#2B2620; font-size:16px; }
+  a { color:var(--accent); text-decoration:none; }
+  a:hover { text-decoration:underline; }
+  hr { border:0; border-top:1px solid var(--line); margin:40px 0; }
+  .lead { font-size:17px; }
+  .foot { color:var(--muted); font-size:13.5px; margin-top:48px; }
+  strong { color:var(--ink); }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="brand"><span class="dot"></span> MKTR Leads</div>
+  <h1>Privacy Policy</h1>
+  <div class="meta">Last updated: 12 June 2026</div>
+
+  <p class="lead">MKTR Leads (&ldquo;the App&rdquo;) is a tool for verified insurance agents to receive and follow up on sales leads supplied by MKTR. This policy explains what personal data we handle and how, in line with Singapore&rsquo;s <strong>Personal Data Protection Act 2012 (PDPA)</strong>.</p>
+
+  <p><strong>Controller:</strong> MKTR PTE. LTD. (UEN 202507548M), Singapore (&ldquo;MKTR&rdquo;, &ldquo;we&rdquo;, &ldquo;us&rdquo;).<br/>
+  <strong>Contact / Data Protection Officer:</strong> <a href="mailto:admin@mktr.sg">admin@mktr.sg</a>.</p>
+
+  <h2>1. Who this policy is for</h2>
+  <ul>
+    <li><strong>Agents</strong> &mdash; people who sign in to the App to work leads.</li>
+    <li><strong>Leads / prospects</strong> &mdash; individuals whose contact details are delivered to an agent through the App after they engaged with a MKTR campaign (web form, QR code, or voice call).</li>
+  </ul>
+
+  <h2>2. What we collect</h2>
+  <p><strong>From agents:</strong> mobile number (for sign-in), name, email, agency, device push token, and the activity you log (call/WhatsApp outcomes, notes, follow-up tasks).</p>
+  <p><strong>About leads:</strong> name, mobile number, the product/campaign they responded to, and any notes/outcomes an agent records. This data is collected upstream at the point the individual engages with a MKTR campaign and is disclosed to the assigned agent in the App.</p>
+
+  <h2>3. Why we use it</h2>
+  <ul>
+    <li>Authenticate agents and secure access (invite-only, phone OTP).</li>
+    <li>Route each lead to the assigned agent and notify them.</li>
+    <li>Let agents contact and follow up with leads, and track lead status.</li>
+    <li>Operate, maintain, and improve the service; meet legal and record-keeping obligations.</li>
+  </ul>
+
+  <h2>4. Consent &amp; legal basis (PDPA)</h2>
+  <p>We collect, use and disclose personal data with consent, or where permitted or required by law. Leads are told at the point of capture that their details will be shared with a licensed insurance agent who will contact them, and they consent to that contact.</p>
+
+  <h2>5. Disclosure to third parties</h2>
+  <ul>
+    <li><strong>Assigned agents</strong> receive a lead&rsquo;s contact details to follow up, under their agent agreement with MKTR, which restricts use to that follow-up only &mdash; no resale or onward sharing.</li>
+    <li><strong>Service providers</strong> that host or process data on our behalf (for example: Supabase &mdash; database and notifications; Expo and Google Firebase Cloud Messaging &mdash; push delivery; SMS/messaging providers for sign-in codes).</li>
+    <li>We do <strong>not</strong> sell personal data or share it with advertising networks or data brokers.</li>
+  </ul>
+
+  <h2>6. Retention</h2>
+  <p>We keep personal data only as long as needed for the purposes above or as required by law, then delete or anonymise it. Leads may request deletion at any time (Section 8).</p>
+
+  <h2>7. Security</h2>
+  <p>Encryption in transit, access controls and row-level security so an agent sees only their own leads, and device-level protection (biometric sign-in, secure token storage). No method of transmission or storage is perfectly secure.</p>
+
+  <h2>8. Your rights (PDPA)</h2>
+  <p>You may <strong>access</strong> or <strong>correct</strong> your personal data, <strong>withdraw consent</strong>, or request <strong>deletion / erasure</strong> by contacting <a href="mailto:admin@mktr.sg">admin@mktr.sg</a>. Agents can also delete their account and associated data from within the App (Profile &rarr; Delete account). We will respond within the timeframe required by the PDPA. Withdrawing consent may mean we can no longer provide the service or contact a lead.</p>
+
+  <h2>9. Overseas transfer</h2>
+  <p>Where data is processed outside Singapore by our providers, we take steps to ensure protection comparable to the PDPA.</p>
+
+  <h2>10. Changes</h2>
+  <p>We may update this policy; the &ldquo;Last updated&rdquo; date will change, and material updates will be notified where appropriate.</p>
+
+  <h2>11. Contact</h2>
+  <p>MKTR PTE. LTD. &middot; <a href="mailto:admin@mktr.sg">admin@mktr.sg</a></p>
+
+  <hr/>
+  <div class="foot">&copy; 2026 MKTR PTE. LTD. (UEN 202507548M), Singapore. MKTR Leads is a service of MKTR PTE. LTD.</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Adds a static PDPA privacy policy for the **MKTR Leads** mobile app at `public/legal/mktr-leads-privacy.html` → **https://mktr.sg/legal/mktr-leads-privacy.html**.

Required for the Google Play listing + Data Safety declaration. Single isolated static file — no app/route/code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)