### PR TITLE
feat(legal): serve MKTR Leads privacy + agent terms at canonical /leads/* URLs

### DIFF
--- a/public/leads/privacy/index.html
+++ b/public/leads/privacy/index.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="robots" content="index,follow" />
+<title>MKTR Leads — Privacy Policy</title>
+<meta name="description" content="Privacy Policy for the MKTR Leads app, in line with Singapore's Personal Data Protection Act (PDPA)." />
+<style>
+  :root { --ink:#16130F; --muted:#5C544B; --line:#ECE7DF; --accent:#FF5A1F; --bg:#FBFAF8; }
+  * { box-sizing: border-box; }
+  body { margin:0; background:var(--bg); color:var(--ink);
+    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; line-height:1.65; }
+  .wrap { max-width:760px; margin:0 auto; padding:56px 22px 96px; }
+  .brand { display:flex; align-items:center; gap:10px; font-weight:700; letter-spacing:-0.02em; }
+  .dot { width:12px; height:12px; border-radius:3px; background:var(--accent); display:inline-block; }
+  h1 { font-size:32px; letter-spacing:-0.02em; margin:26px 0 6px; }
+  .meta { color:var(--muted); font-size:14px; margin-bottom:26px; }
+  h2 { font-size:19px; letter-spacing:-0.01em; margin:34px 0 8px; }
+  p, li { color:#2B2620; font-size:16px; }
+  a { color:var(--accent); text-decoration:none; }
+  a:hover { text-decoration:underline; }
+  hr { border:0; border-top:1px solid var(--line); margin:40px 0; }
+  .lead { font-size:17px; }
+  .foot { color:var(--muted); font-size:13.5px; margin-top:48px; }
+  strong { color:var(--ink); }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="brand"><span class="dot"></span> MKTR Leads</div>
+  <h1>Privacy Policy</h1>
+  <div class="meta">Last updated: 12 June 2026</div>
+
+  <p class="lead">MKTR Leads (&ldquo;the App&rdquo;) is a tool for verified insurance agents to receive and follow up on sales leads supplied by MKTR. This policy explains what personal data we handle and how, in line with Singapore&rsquo;s <strong>Personal Data Protection Act 2012 (PDPA)</strong>.</p>
+
+  <p><strong>Controller:</strong> MKTR PTE. LTD. (UEN 202507548M), Singapore (&ldquo;MKTR&rdquo;, &ldquo;we&rdquo;, &ldquo;us&rdquo;).<br/>
+  <strong>Contact / Data Protection Officer:</strong> <a href="mailto:admin@mktr.sg">admin@mktr.sg</a>.</p>
+
+  <h2>1. Who this policy is for</h2>
+  <ul>
+    <li><strong>Agents</strong> &mdash; people who sign in to the App to work leads.</li>
+    <li><strong>Leads / prospects</strong> &mdash; individuals whose contact details are delivered to an agent through the App after they engaged with a MKTR campaign (web form, QR code, or voice call).</li>
+  </ul>
+
+  <h2>2. What we collect</h2>
+  <p><strong>From agents:</strong> mobile number (for sign-in), name, email, agency, device push token, and the activity you log (call/WhatsApp outcomes, notes, follow-up tasks).</p>
+  <p><strong>About leads:</strong> name, mobile number, the product/campaign they responded to, and any notes/outcomes an agent records. This data is collected upstream at the point the individual engages with a MKTR campaign and is disclosed to the assigned agent in the App.</p>
+
+  <h2>3. Why we use it</h2>
+  <ul>
+    <li>Authenticate agents and secure access (invite-only, phone OTP).</li>
+    <li>Route each lead to the assigned agent and notify them.</li>
+    <li>Let agents contact and follow up with leads, and track lead status.</li>
+    <li>Operate, maintain, and improve the service; meet legal and record-keeping obligations.</li>
+  </ul>
+
+  <h2>4. Consent &amp; legal basis (PDPA)</h2>
+  <p>We collect, use and disclose personal data with consent, or where permitted or required by law. Leads are told at the point of capture that their details will be shared with a licensed insurance agent who will contact them, and they consent to that contact.</p>
+
+  <h2>5. Disclosure to third parties</h2>
+  <ul>
+    <li><strong>Assigned agents</strong> receive a lead&rsquo;s contact details to follow up, under their agent agreement with MKTR, which restricts use to that follow-up only &mdash; no resale or onward sharing.</li>
+    <li><strong>Service providers</strong> that host or process data on our behalf (for example: Supabase &mdash; database and notifications; Expo and Google Firebase Cloud Messaging &mdash; push delivery; SMS/messaging providers for sign-in codes).</li>
+    <li>We do <strong>not</strong> sell personal data or share it with advertising networks or data brokers.</li>
+  </ul>
+
+  <h2>6. Retention</h2>
+  <p>We keep personal data only as long as needed for the purposes above or as required by law, then delete or anonymise it. Leads may request deletion at any time (Section 8).</p>
+
+  <h2>7. Security</h2>
+  <p>Encryption in transit, access controls and row-level security so an agent sees only their own leads, and device-level protection (biometric sign-in, secure token storage). No method of transmission or storage is perfectly secure.</p>
+
+  <h2>8. Your rights (PDPA)</h2>
+  <p>You may <strong>access</strong> or <strong>correct</strong> your personal data, <strong>withdraw consent</strong>, or request <strong>deletion / erasure</strong> by contacting <a href="mailto:admin@mktr.sg">admin@mktr.sg</a>. Agents can also delete their account and associated data from within the App (Profile &rarr; Delete account). We will respond within the timeframe required by the PDPA. Withdrawing consent may mean we can no longer provide the service or contact a lead.</p>
+
+  <h2>9. Overseas transfer</h2>
+  <p>Where data is processed outside Singapore by our providers, we take steps to ensure protection comparable to the PDPA.</p>
+
+  <h2>10. Changes</h2>
+  <p>We may update this policy; the &ldquo;Last updated&rdquo; date will change, and material updates will be notified where appropriate.</p>
+
+  <h2>11. Contact</h2>
+  <p>MKTR PTE. LTD. &middot; <a href="mailto:admin@mktr.sg">admin@mktr.sg</a></p>
+
+  <hr/>
+  <div class="foot">&copy; 2026 MKTR PTE. LTD. (UEN 202507548M), Singapore. MKTR Leads is a service of MKTR PTE. LTD.</div>
+</div>
+</body>
+</html>

--- a/public/leads/terms/index.html
+++ b/public/leads/terms/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="robots" content="index,follow" />
+<title>MKTR Leads — External Agent Terms of Use</title>
+<meta name="description" content="Terms of Use for licensed insurance agents receiving leads through the MKTR Leads app." />
+<style>
+  :root { --ink:#16130F; --muted:#5C544B; --line:#ECE7DF; --accent:#FF5A1F; --bg:#FBFAF8; }
+  * { box-sizing: border-box; }
+  body { margin:0; background:var(--bg); color:var(--ink);
+    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; line-height:1.65; }
+  .wrap { max-width:760px; margin:0 auto; padding:56px 22px 96px; }
+  .brand { display:flex; align-items:center; gap:10px; font-weight:700; letter-spacing:-0.02em; }
+  .dot { width:12px; height:12px; border-radius:3px; background:var(--accent); display:inline-block; }
+  h1 { font-size:32px; letter-spacing:-0.02em; margin:26px 0 6px; }
+  .meta { color:var(--muted); font-size:14px; margin-bottom:26px; }
+  h2 { font-size:19px; letter-spacing:-0.01em; margin:34px 0 8px; }
+  p, li { color:#2B2620; font-size:16px; }
+  a { color:var(--accent); text-decoration:none; }
+  a:hover { text-decoration:underline; }
+  hr { border:0; border-top:1px solid var(--line); margin:40px 0; }
+  .lead { font-size:17px; }
+  .foot { color:var(--muted); font-size:13.5px; margin-top:48px; }
+  strong { color:var(--ink); }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="brand"><span class="dot"></span> MKTR Leads</div>
+  <h1>External Agent Terms of Use</h1>
+  <div class="meta">Version 2026-06-12 &middot; Last updated: 12 June 2026</div>
+
+  <p class="lead">These terms are between MKTR PTE. LTD. (UEN 202507548M), Singapore (&ldquo;MKTR&rdquo;, &ldquo;we&rdquo;, &ldquo;us&rdquo;) and you, the licensed insurance agent accepting them in the MKTR Leads app (&ldquo;you&rdquo;). They govern your use of the app and of the personal data in each lead.</p>
+
+  <h2>1. The service</h2>
+  <p>MKTR runs marketing campaigns (QR codes, web enquiry forms, AI-assisted phone calls) that produce consented consumer enquiries (&ldquo;leads&rdquo;) for insurance products. Under a separate business arrangement, MKTR delivers leads assigned to you into the MKTR Leads app, where you can view each lead, contact the prospect, and log outcomes.</p>
+
+  <h2>2. Permitted use of lead data</h2>
+  <p>Each lead contains personal data of an individual who consented to be contacted about insurance by a licensed agent. You agree to:</p>
+  <ol>
+    <li><strong>Purpose limitation.</strong> Use a lead&rsquo;s personal data <strong>only</strong> to contact that individual about insurance products, and to record your follow-up in the app. No other use &mdash; no marketing lists, no profiling, no unrelated offers.</li>
+    <li><strong>No onward transfer.</strong> Not share, sell, resell, license, or otherwise disclose a lead&rsquo;s personal data to any other person or organisation, including colleagues, agencies, or data brokers.</li>
+    <li><strong>Do-Not-Call and withdrawal.</strong> Comply with Singapore&rsquo;s Do-Not-Call provisions and stop contacting a lead immediately if they ask you to or withdraw consent, and record that outcome in the app.</li>
+    <li><strong>Deletion.</strong> Delete a lead&rsquo;s personal data from any device or record outside the app when the individual requests it, when MKTR instructs you to, or when you no longer need it for the permitted purpose above.</li>
+  </ol>
+  <p>These four obligations are the ones summarised on the in-app consent screen.</p>
+
+  <h2>3. PDPA compliance</h2>
+  <p>You are independently responsible for complying with the Personal Data Protection Act 2012 (PDPA) in your handling of lead data, including the Do-Not-Call registry provisions and any obligations arising from your insurer or agency appointment. MKTR&rsquo;s handling of personal data is described in the <a href="https://mktr.sg/leads/privacy">Privacy Policy</a>.</p>
+
+  <h2>4. Account and security</h2>
+  <p>Your account is personal: keep your sign-in (phone OTP) and device secure, and do not let anyone else access leads through it. Tell us promptly at <a href="mailto:admin@mktr.sg">admin@mktr.sg</a> if you suspect unauthorised access. We may suspend or deactivate accounts to protect lead data.</p>
+
+  <h2>5. Accuracy and no guarantee</h2>
+  <p>Leads are enquiries from real individuals, supplied as received. MKTR does not guarantee a lead&rsquo;s accuracy, contactability, intent, or any sales outcome. Handling of invalid or disputed leads (including any replacement or credit) is governed by your commercial arrangement with MKTR.</p>
+
+  <h2>6. Suspension and termination</h2>
+  <p>We may suspend or terminate your access if you breach these terms &mdash; in particular the permitted-use obligations in Section 2 &mdash; or where required to protect individuals&rsquo; data or comply with law. On termination you must stop using and delete any lead data held outside the app. Sections 2, 3, and 7&ndash;9 survive termination.</p>
+
+  <h2>7. Liability</h2>
+  <p>The app and all leads are provided &ldquo;as is&rdquo;. To the maximum extent permitted by law, MKTR is not liable for any indirect or consequential loss, loss of profit, or loss of business arising from the app or any lead, and MKTR&rsquo;s total liability under these terms is limited to the fees you paid MKTR for lead-generation services in the three (3) months before the event giving rise to the claim. You will indemnify MKTR against claims, penalties, and losses (including regulatory enforcement under the PDPA) arising from your breach of Section 2 or your misuse of lead data.</p>
+
+  <h2>8. Changes</h2>
+  <p>We may update these terms. Material changes will be presented in the app for re-acceptance before you continue working leads (the app records the version you accepted and when).</p>
+
+  <h2>9. Governing law</h2>
+  <p>These terms are governed by the laws of Singapore, and the courts of Singapore have exclusive jurisdiction over any dispute arising from them.</p>
+
+  <h2>10. Contact</h2>
+  <p>MKTR PTE. LTD. &middot; <a href="mailto:admin@mktr.sg">admin@mktr.sg</a></p>
+
+  <hr/>
+  <div class="foot">&copy; 2026 MKTR PTE. LTD. (UEN 202507548M), Singapore. MKTR Leads is a service of MKTR PTE. LTD.</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Why
`https://mktr.sg/leads/privacy` is the privacy URL declared in the MKTR Leads app's `store.config.json` (App Store Connect `privacyPolicyUrl`) and `https://mktr.sg/leads/terms` is linked from the app's consent screen — but both fell through to the SPA homepage rewrite. Static files win over the rewrite (verified with existing `public/` assets), so this serves both as static pages.

## What
- `public/leads/privacy/index.html` — identical content to `/legal/mktr-leads-privacy.html` (PR #42), now also at the canonical URL.
- `public/leads/terms/index.html` — External Agent Terms of Use, version 2026-06-12. This is the document the app's versioned consent gate records acceptance against (`agents.terms_version`).

No SPA/backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)