### PR TITLE
fix(legal): terms page links Privacy Policy with trailing slash

### DIFF
--- a/public/leads/terms.html
+++ b/public/leads/terms.html
@@ -48,7 +48,7 @@
   <p>These four obligations are the ones summarised on the in-app consent screen.</p>
 
   <h2>3. PDPA compliance</h2>
-  <p>You are independently responsible for complying with the Personal Data Protection Act 2012 (PDPA) in your handling of lead data, including the Do-Not-Call registry provisions and any obligations arising from your insurer or agency appointment. MKTR&rsquo;s handling of personal data is described in the <a href="https://mktr.sg/leads/privacy">Privacy Policy</a>.</p>
+  <p>You are independently responsible for complying with the Personal Data Protection Act 2012 (PDPA) in your handling of lead data, including the Do-Not-Call registry provisions and any obligations arising from your insurer or agency appointment. MKTR&rsquo;s handling of personal data is described in the <a href="https://mktr.sg/leads/privacy/">Privacy Policy</a>.</p>
 
   <h2>4. Account and security</h2>
   <p>Your account is personal: keep your sign-in (phone OTP) and device secure, and do not let anyone else access leads through it. Tell us promptly at <a href="mailto:admin@mktr.sg">admin@mktr.sg</a> if you suspect unauthorised access. We may suspend or deactivate accounts to protect lead data.</p>

--- a/public/leads/terms/index.html
+++ b/public/leads/terms/index.html
@@ -48,7 +48,7 @@
   <p>These four obligations are the ones summarised on the in-app consent screen.</p>
 
   <h2>3. PDPA compliance</h2>
-  <p>You are independently responsible for complying with the Personal Data Protection Act 2012 (PDPA) in your handling of lead data, including the Do-Not-Call registry provisions and any obligations arising from your insurer or agency appointment. MKTR&rsquo;s handling of personal data is described in the <a href="https://mktr.sg/leads/privacy">Privacy Policy</a>.</p>
+  <p>You are independently responsible for complying with the Personal Data Protection Act 2012 (PDPA) in your handling of lead data, including the Do-Not-Call registry provisions and any obligations arising from your insurer or agency appointment. MKTR&rsquo;s handling of personal data is described in the <a href="https://mktr.sg/leads/privacy/">Privacy Policy</a>.</p>
 
   <h2>4. Account and security</h2>
   <p>Your account is personal: keep your sign-in (phone OTP) and device secure, and do not let anyone else access leads through it. Tell us promptly at <a href="mailto:admin@mktr.sg">admin@mktr.sg</a> if you suspect unauthorised access. We may suspend or deactivate accounts to protect lead data.</p>


### PR DESCRIPTION
The bare /leads/privacy path falls through to the SPA rewrite; only the
trailing-slash form serves the policy.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
