### PR TITLE
feat(external): receive lead outcomes from the MKTR Leads buyer app

### DIFF
--- a/backend/src/controllers/externalLeadOutcomeController.js
+++ b/backend/src/controllers/externalLeadOutcomeController.js
@@ -1,0 +1,140 @@
+/**
+ * @file externalLeadOutcomeController — receives lead-outcome events from the
+ * MKTR Leads buyer app (its report-lead-outcome Supabase edge function).
+ *
+ * ── Wire format (sender: mktr-leads supabase/functions/report-lead-outcome) ─
+ *
+ *   POST /api/external/lead-outcomes
+ *   Content-Type: application/json
+ *   X-Webhook-Event: lead.outcome
+ *   X-Webhook-Timestamp: <ISO 8601, informational — the SIGNED copy is in the body>
+ *   X-Webhook-Signature: sha256=<hex hmac of the raw body using EXTERNAL_OUTCOME_WEBHOOK_SECRET>
+ *   {
+ *     "event": "lead.outcome",
+ *     "eventId": "<leadId>:<status>",          // stable across re-fires → idempotency key
+ *     "timestamp": "<ISO 8601>",               // signed; freshness is gated on THIS
+ *     "data": { "externalId", "sourceName", "deliveryId", "mktrLeadsStatus" }
+ *   }
+ *
+ * ── Auth ────────────────────────────────────────────────────────────────────
+ *
+ * HMAC-SHA256 over the RAW BODY ONLY (MKTR_LEADS_PLAN.md §0.8 — matches the
+ * lead-delivery direction, NOT the Lyfe lead-outcome channel which signs
+ * `${ts}.${body}` with a different secret). Freshness is gated on the signed
+ * body `timestamp` (±5 min): a re-fire from the mktr-leads reconciliation
+ * sweep re-signs with a fresh timestamp, so only true replays are rejected.
+ *
+ * ── Response contract ───────────────────────────────────────────────────────
+ *
+ * The sender stamps leads.outcome_reported_at only on 2xx and does NOT
+ * auto-retry on failure (pg_net is fire-and-forget; a bounded DB sweep
+ * re-invokes unreported outcomes). So unlike the Lyfe channel there is no
+ * retry-storm risk, and non-2xx answers are honest: 401 bad auth, 400
+ * malformed, 413 oversized, 422 unknown / non-MKTR-Leads prospect, 500
+ * transient processing failure (the sweep retries it later).
+ */
+
+import crypto from 'crypto';
+import * as Sentry from '@sentry/node';
+import { logger } from '../utils/logger.js';
+import { processExternalLeadOutcome, MKTR_LEADS_STATUSES } from '../services/externalLeadOutcomeService.js';
+
+const MAX_AGE_MS = 5 * 60 * 1000;
+const MAX_FUTURE_MS = 2 * 60 * 1000; // tolerate clock skew
+// The global JSON parser accepts 1mb, so enforce this endpoint's budget on the
+// captured raw body (a route-level express.json limit would never run — the
+// body is already parsed by the time routes mount).
+const MAX_BODY_BYTES = 64 * 1024;
+
+function unauthorized(res, reason) {
+  logger.warn({ event: 'external_outcome_unauthorized', reason }, '[external-outcome] auth failed');
+  return res.status(401).json({ success: false, error: 'Unauthorized' });
+}
+
+function badRequest(res, reason) {
+  return res.status(400).json({ success: false, error: reason });
+}
+
+function timingSafeHexEq(receivedHex, expectedHex) {
+  if (typeof receivedHex !== 'string' || typeof expectedHex !== 'string') return false;
+  if (receivedHex.length !== expectedHex.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(receivedHex, 'hex'), Buffer.from(expectedHex, 'hex'));
+  } catch {
+    return false;
+  }
+}
+
+export async function handleExternalLeadOutcome(req, res) {
+  const secret = process.env.EXTERNAL_OUTCOME_WEBHOOK_SECRET;
+  if (!secret) {
+    logger.error('[external-outcome] EXTERNAL_OUTCOME_WEBHOOK_SECRET not configured');
+    return res.status(500).json({ success: false, error: 'Server misconfigured' });
+  }
+
+  // rawBody is captured by the verify hook in server_internal.js for paths
+  // under /api/external/.
+  if (!req.rawBody || !Buffer.isBuffer(req.rawBody)) {
+    logger.error('[external-outcome] req.rawBody missing — verify hook not wired for this path');
+    return res.status(500).json({ success: false, error: 'Server misconfigured' });
+  }
+  if (req.rawBody.length > MAX_BODY_BYTES) {
+    return res.status(413).json({ success: false, error: 'Payload too large' });
+  }
+
+  // ── Auth: HMAC-SHA256 over the raw body only ─────────────────────────
+  const sigHeader = req.headers['x-webhook-signature'] || '';
+  if (typeof sigHeader !== 'string' || !sigHeader.startsWith('sha256=')) {
+    return unauthorized(res, 'missing_or_malformed_signature');
+  }
+  const receivedHex = sigHeader.slice(7);
+  const expectedHex = crypto.createHmac('sha256', secret).update(req.rawBody).digest('hex');
+  if (!timingSafeHexEq(receivedHex, expectedHex)) {
+    return unauthorized(res, 'bad_signature');
+  }
+
+  // ── Freshness on the signed body timestamp ───────────────────────────
+  const { event, eventId, timestamp, data } = req.body || {};
+  const tsMs = typeof timestamp === 'string' ? Date.parse(timestamp) : NaN;
+  if (Number.isNaN(tsMs)) {
+    return unauthorized(res, 'invalid_timestamp');
+  }
+  const ageMs = Date.now() - tsMs;
+  if (ageMs > MAX_AGE_MS) {
+    return unauthorized(res, 'timestamp_too_old');
+  }
+  if (ageMs < -MAX_FUTURE_MS) {
+    return unauthorized(res, 'timestamp_in_future');
+  }
+
+  // ── Payload validation ───────────────────────────────────────────────
+  if (event !== 'lead.outcome') return badRequest(res, 'unsupported event');
+  if (typeof eventId !== 'string' || !eventId) return badRequest(res, 'missing eventId');
+  if (!data || typeof data !== 'object') return badRequest(res, 'missing data');
+  if (!data.externalId) return badRequest(res, 'missing data.externalId');
+  if (!MKTR_LEADS_STATUSES.includes(data.mktrLeadsStatus)) {
+    // A status outside the shared contract is a cross-repo drift bug — fail
+    // loudly (the sender won't stamp, so the outcome stays visibly unreported).
+    return badRequest(res, 'unknown mktrLeadsStatus');
+  }
+
+  try {
+    const { statusCode, body } = await processExternalLeadOutcome({ event, eventId, timestamp, data });
+    logger.info(
+      { event: 'external_outcome_processed', eventId, statusCode, ...body },
+      `[external-outcome] ${data.mktrLeadsStatus} ${data.externalId} → ${statusCode}`
+    );
+    return res.status(statusCode).json(body);
+  } catch (err) {
+    logger.error(
+      { event: 'external_outcome_failed', eventId, err },
+      '[external-outcome] failed to process outcome'
+    );
+    Sentry.captureException(err, {
+      tags: { component: 'external_lead_outcome', service: 'mktr-backend' },
+      extra: { eventId, externalId: data?.externalId, mktrLeadsStatus: data?.mktrLeadsStatus },
+    });
+    // 500 → sender does not stamp; the mktr-leads sweep re-fires it later.
+    return res.status(500).json({ success: false, error: 'Processing failed' });
+  }
+}

--- a/backend/src/routes/externalLeadOutcomes.js
+++ b/backend/src/routes/externalLeadOutcomes.js
@@ -1,0 +1,26 @@
+/**
+ * MKTR Leads (external buyer app) → MKTR push channel for lead outcomes.
+ *
+ * Mounted at `/api/external/lead-outcomes` (POST). Auth is HMAC-SHA256 over the
+ * raw body (EXTERNAL_OUTCOME_WEBHOOK_SECRET), NOT the platform JWT — the caller
+ * is the mktr-leads report-lead-outcome edge function, fired by a Postgres
+ * trigger on that project's `leads.status`. Raw-body capture and the
+ * rate-limiter exemption for the `/api/external/` prefix are wired in
+ * server_internal.js.
+ *
+ * Kept separate from `/api/integrations/lyfe/lead-outcome`: that channel is the
+ * Lyfe (internal-agent) app driving Meta CAPI conversions, with a different
+ * secret and signature scheme. This one mirrors buyer status onto the Prospect
+ * for billing/dispute reconciliation.
+ */
+
+import express from 'express';
+import { handleExternalLeadOutcome } from '../controllers/externalLeadOutcomeController.js';
+
+export const meta = { path: '/api/external' };
+
+const router = express.Router();
+
+router.post('/lead-outcomes', express.json({ limit: '64kb' }), handleExternalLeadOutcome);
+
+export default router;

--- a/backend/src/server_internal.js
+++ b/backend/src/server_internal.js
@@ -104,10 +104,14 @@ export const init = async (app) => {
         ? parseInt(process.env.RATE_LIMIT_MAX_REQUESTS) || 200
         : parseInt(process.env.RATE_LIMIT_MAX_REQUESTS) || 1000000;
     },
-    // Exempt server-to-server webhooks under /api/integrations/lyfe/ — they are
-    // HMAC-authenticated (not IP-based), and a Supabase pg_net burst or a
-    // reconciliation backfill must not be throttled by the public IP limiter.
-    skip: (req) => !isProd || req.originalUrl.startsWith('/api/integrations/lyfe/'),
+    // Exempt server-to-server webhooks under /api/integrations/lyfe/ and
+    // /api/external/ — they are HMAC-authenticated (not IP-based), and a
+    // Supabase pg_net burst or a reconciliation backfill must not be throttled
+    // by the public IP limiter.
+    skip: (req) =>
+      !isProd ||
+      req.originalUrl.startsWith('/api/integrations/lyfe/') ||
+      req.originalUrl.startsWith('/api/external/'),
     message: 'Too many requests from this IP, please try again later.',
   });
   // Ensure we decode JWT (if present) before limiter so skip() can see admin
@@ -131,6 +135,7 @@ export const init = async (app) => {
   //   - /api/retell/         — Retell AI call webhooks (HMAC-signed)
   //   - /api/meta/           — Meta CAPI signed callbacks
   //   - /api/integrations/lyfe/ — Lyfe→MKTR push (notify_mktr_user_change trigger; HMAC since 2026-05-12)
+  //   - /api/external/       — MKTR Leads buyer app → lead outcomes (HMAC, body-only)
   app.use(
     express.json({
       limit: '1mb',
@@ -138,7 +143,8 @@ export const init = async (app) => {
         if (
           req.originalUrl.startsWith('/api/retell/') ||
           req.originalUrl.startsWith('/api/meta/') ||
-          req.originalUrl.startsWith('/api/integrations/lyfe/')
+          req.originalUrl.startsWith('/api/integrations/lyfe/') ||
+          req.originalUrl.startsWith('/api/external/')
         ) {
           req.rawBody = buf;
         }

--- a/backend/src/services/externalLeadOutcomeService.js
+++ b/backend/src/services/externalLeadOutcomeService.js
@@ -1,0 +1,206 @@
+/**
+ * @file externalLeadOutcomeService — applies a lead-outcome event from the
+ * MKTR Leads buyer app to the originating Prospect.
+ *
+ * The return half of the external (paid-buyer) lead loop: MKTR delivers a lead
+ * to the mktr-leads app; when the buyer later moves the lead's status, a
+ * Postgres trigger in the mktr-leads Supabase project fires its
+ * report-lead-outcome edge function, which POSTs here. We mirror the buyer's
+ * status onto Prospect.leadStatus and write a ProspectActivity so admins can
+ * see what buyers did with the leads they paid for (billing / refund / dispute
+ * reconciliation).
+ *
+ * Deliberately separate from leadOutcomeService (Lyfe → Meta CAPI conversions):
+ * different sender, different secret, different purpose — this one mirrors
+ * status and does NOT fire CAPI events.
+ *
+ * ── Status mapping (MKTR_LEADS_PLAN.md §2, against the real enum) ───────
+ *
+ * Prospect.leadStatus enum: new, contacted, qualified, proposal_sent,
+ * negotiating, won, lost, nurturing. `invalid`/`disputed` have no counterpart
+ * BY DESIGN: they are quality/dispute signals, so the prospect's status is
+ * preserved and the activity is flagged (`metadata.qualitySignal`) instead.
+ *
+ * ── Side-effects on `won` ────────────────────────────────────────────────
+ *
+ * Internal wins (prospectService.updateProspect) create a Commission for the
+ * assigned agent and stamp conversionDate. An external win stamps
+ * conversionDate (it IS a conversion for reporting) but creates NO commission:
+ * the "assigned agent" on a buyer-delivered prospect is the buyer's mirror
+ * users row (users.mktrLeadsId) — buyers pay for leads, they don't earn
+ * internal commissions.
+ *
+ * ── Idempotency ──────────────────────────────────────────────────────────
+ *
+ * The sender's eventId is `${leadId}:${status}` — stable across re-fires of
+ * the same status change (pg_net has no retry; a DB sweep re-invokes unreported
+ * outcomes). The key is claimed in the SAME transaction as the prospect update
+ * + activity insert, so a failed apply leaves the event re-processable and a
+ * processed event replays its stored response. Expired keys (purge is hourly)
+ * are taken over so a genuine re-occurrence after the TTL is processed anew.
+ */
+
+import { sequelize, Prospect, ProspectActivity, IdempotencyKey, User } from '../models/index.js';
+import { logger } from '../utils/logger.js';
+
+export const IDEMPOTENCY_SCOPE = 'external:outcome';
+const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** Statuses the mktr-leads app can send (its leads.status CHECK constraint). */
+export const MKTR_LEADS_STATUSES = Object.freeze([
+  'new',
+  'contacted',
+  'qualified',
+  'proposed',
+  'won',
+  'lost',
+  'invalid',
+  'disputed',
+]);
+
+// MKTR Leads status → Prospect.leadStatus. null = preserve status, record a
+// flagged activity (quality/dispute signal).
+const STATUS_MAP = Object.freeze({
+  new: 'new',
+  contacted: 'contacted',
+  qualified: 'qualified',
+  proposed: 'proposal_sent',
+  won: 'won',
+  lost: 'lost',
+  invalid: null,
+  disputed: null,
+});
+
+const defaultDeps = {
+  sequelize,
+  models: { Prospect, ProspectActivity, IdempotencyKey, User },
+  logger,
+};
+
+export function makeExternalLeadOutcomeService(overrides = {}) {
+  const d = { ...defaultDeps, ...overrides };
+  const m = { ...defaultDeps.models, ...(overrides.models || {}) };
+
+  /**
+   * Apply one lead-outcome event. The controller has already authenticated the
+   * request and validated the payload shape + status membership.
+   *
+   * @param {object} payload { event, eventId, timestamp, data: { externalId,
+   *   sourceName, deliveryId, mktrLeadsStatus } }
+   * @returns {Promise<{statusCode: number, body: object}>} — the sender stamps
+   *   outcome_reported_at only on 2xx, so non-2xx keeps the outcome visible as
+   *   unreported (and the mktr-leads sweep will re-fire it).
+   */
+  async function processExternalLeadOutcome(payload) {
+    const { eventId, data } = payload;
+    const { externalId, deliveryId, mktrLeadsStatus } = data;
+    const key = `${IDEMPOTENCY_SCOPE}:${eventId}`;
+
+    // Replay fast-path. Expired rows linger until the hourly purge — take them
+    // over so a re-occurrence after the TTL (status flapped back) is processed.
+    const existing = await m.IdempotencyKey.findOne({ where: { key } });
+    if (existing) {
+      if (new Date(existing.expiresAt).getTime() > Date.now()) {
+        return {
+          statusCode: existing.responseCode ?? 200,
+          body: existing.responseBody ?? { success: true, replay: true },
+        };
+      }
+      await existing.destroy();
+    }
+
+    const prospect = await m.Prospect.findByPk(externalId, {
+      include: [{ model: m.User, as: 'assignedAgent', attributes: ['id', 'mktrLeadsId'] }],
+    });
+    if (!prospect) {
+      return { statusCode: 422, body: { success: false, error: 'unknown_prospect' } };
+    }
+
+    // Ownership gate: only prospects actually delivered to the MKTR Leads app
+    // may be mutated by it — either the external_agents path (future) or the
+    // mirror-user path (current: assignedAgent carries users.mktrLeadsId).
+    const isMktrLeadsProspect =
+      prospect.externalAgentId != null || prospect.assignedAgent?.mktrLeadsId != null;
+    if (!isMktrLeadsProspect) {
+      d.logger.warn(
+        { event: 'external_outcome_rejected', prospect_id: prospect.id, eventId },
+        '[external-outcome] prospect is not MKTR Leads-delivered'
+      );
+      return { statusCode: 422, body: { success: false, error: 'not_a_mktr_leads_prospect' } };
+    }
+
+    const mapped = STATUS_MAP[mktrLeadsStatus] ?? null;
+    const previousLeadStatus = prospect.leadStatus;
+
+    try {
+      const body = await d.sequelize.transaction(async (t) => {
+        if (mapped && mapped !== previousLeadStatus) {
+          prospect.leadStatus = mapped;
+          if (mapped === 'won' && !prospect.conversionDate) {
+            prospect.conversionDate = new Date();
+          }
+          await prospect.save({ transaction: t });
+        }
+
+        const description = mapped
+          ? `MKTR Leads buyer marked lead as ${mktrLeadsStatus}` +
+            (mapped !== mktrLeadsStatus ? ` (leadStatus → ${mapped})` : '')
+          : `MKTR Leads buyer flagged lead as ${mktrLeadsStatus} (status preserved — quality/dispute signal)`;
+
+        await m.ProspectActivity.create(
+          {
+            prospectId: prospect.id,
+            type: 'updated',
+            actorUserId: null,
+            description,
+            metadata: {
+              source: 'mktr-leads',
+              eventId,
+              deliveryId: deliveryId ?? null,
+              mktrLeadsStatus,
+              previousLeadStatus,
+              ...(mapped ? {} : { qualitySignal: true }),
+            },
+          },
+          { transaction: t }
+        );
+
+        const responseBody = {
+          success: true,
+          externalId: prospect.id,
+          mktrLeadsStatus,
+          appliedLeadStatus: mapped ?? previousLeadStatus,
+          qualitySignal: mapped == null,
+        };
+
+        // Claimed last, inside the transaction: a rollback (failed apply)
+        // leaves the event re-processable.
+        await m.IdempotencyKey.create(
+          {
+            key,
+            scope: IDEMPOTENCY_SCOPE,
+            responseBody,
+            responseCode: 200,
+            expiresAt: new Date(Date.now() + IDEMPOTENCY_TTL_MS),
+          },
+          { transaction: t }
+        );
+
+        return responseBody;
+      });
+
+      return { statusCode: 200, body };
+    } catch (err) {
+      // Concurrent duplicate: another request claimed the key mid-flight and
+      // (by claim-last ordering) has already applied the same event.
+      if (err?.name === 'SequelizeUniqueConstraintError') {
+        return { statusCode: 200, body: { success: true, replay: true } };
+      }
+      throw err;
+    }
+  }
+
+  return { processExternalLeadOutcome };
+}
+
+export const { processExternalLeadOutcome } = makeExternalLeadOutcomeService();

--- a/backend/test/externalLeadOutcomeController.test.js
+++ b/backend/test/externalLeadOutcomeController.test.js
@@ -1,0 +1,213 @@
+/**
+ * Unit tests for the external (MKTR Leads) lead-outcome webhook controller.
+ *
+ * Tests HMAC (body-only) auth, freshness on the signed body timestamp, payload
+ * validation, the raw-body size budget, and status-code passthrough in
+ * isolation: the externalLeadOutcomeService and Sentry/logger are mocked, and
+ * we drive handleExternalLeadOutcome with hand-built req/res objects (no DB,
+ * no supertest), mirroring how req.rawBody is set by the verify hook in prod.
+ */
+import { jest } from '@jest/globals';
+import crypto from 'crypto';
+
+const SECRET = 'test-external-outcome-secret';
+
+const processOutcomeMock = jest.fn();
+const captureExceptionMock = jest.fn();
+
+jest.unstable_mockModule('../src/services/externalLeadOutcomeService.js', () => ({
+  processExternalLeadOutcome: processOutcomeMock,
+  MKTR_LEADS_STATUSES: ['new', 'contacted', 'qualified', 'proposed', 'won', 'lost', 'invalid', 'disputed'],
+}));
+jest.unstable_mockModule('@sentry/node', () => ({
+  captureException: captureExceptionMock,
+  init: jest.fn(),
+  setTag: jest.fn(),
+}));
+jest.unstable_mockModule('../src/utils/logger.js', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+let handleExternalLeadOutcome;
+
+beforeAll(async () => {
+  ({ handleExternalLeadOutcome } = await import('../src/controllers/externalLeadOutcomeController.js'));
+});
+
+beforeEach(() => {
+  process.env.EXTERNAL_OUTCOME_WEBHOOK_SECRET = SECRET;
+  processOutcomeMock
+    .mockReset()
+    .mockResolvedValue({ statusCode: 200, body: { success: true, appliedLeadStatus: 'won' } });
+  captureExceptionMock.mockClear();
+});
+
+function makeRes() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.body = payload; return this; },
+  };
+}
+
+// Signs the body-only scheme (MKTR_LEADS_PLAN.md §0.8).
+function makeReq(bodyObj, { secret = SECRET, signOverride } = {}) {
+  const raw = Buffer.from(JSON.stringify(bodyObj));
+  const sig = signOverride ?? crypto.createHmac('sha256', secret).update(raw).digest('hex');
+  return {
+    rawBody: raw,
+    body: bodyObj,
+    headers: { 'x-webhook-signature': `sha256=${sig}` },
+  };
+}
+
+function validBody(overrides = {}) {
+  return {
+    event: 'lead.outcome',
+    eventId: 'lead-uuid-1:won',
+    timestamp: new Date().toISOString(),
+    data: {
+      externalId: 'prospect-uuid-1',
+      sourceName: 'mktr',
+      deliveryId: 'delivery-uuid-1',
+      mktrLeadsStatus: 'won',
+      ...(overrides.data || {}),
+    },
+    ...Object.fromEntries(Object.entries(overrides).filter(([k]) => k !== 'data')),
+  };
+}
+
+describe('handleExternalLeadOutcome', () => {
+  it('500s when the secret is not configured', async () => {
+    delete process.env.EXTERNAL_OUTCOME_WEBHOOK_SECRET;
+    const res = makeRes();
+    await handleExternalLeadOutcome(makeReq(validBody()), res);
+    expect(res.statusCode).toBe(500);
+    expect(processOutcomeMock).not.toHaveBeenCalled();
+  });
+
+  it('500s when rawBody is missing (verify hook not wired)', async () => {
+    const req = makeReq(validBody());
+    delete req.rawBody;
+    const res = makeRes();
+    await handleExternalLeadOutcome(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it('413s an oversized raw body before any other work', async () => {
+    const req = makeReq(validBody());
+    req.rawBody = Buffer.alloc(64 * 1024 + 1, 0x7b);
+    const res = makeRes();
+    await handleExternalLeadOutcome(req, res);
+    expect(res.statusCode).toBe(413);
+    expect(processOutcomeMock).not.toHaveBeenCalled();
+  });
+
+  it('401s on a missing signature header', async () => {
+    const req = makeReq(validBody());
+    delete req.headers['x-webhook-signature'];
+    const res = makeRes();
+    await handleExternalLeadOutcome(req, res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('401s on a signature made with the wrong secret', async () => {
+    const res = makeRes();
+    await handleExternalLeadOutcome(makeReq(validBody(), { secret: 'wrong-secret' }), res);
+    expect(res.statusCode).toBe(401);
+    expect(processOutcomeMock).not.toHaveBeenCalled();
+  });
+
+  it('401s on a tampered body', async () => {
+    const body = validBody();
+    const req = makeReq(body);
+    req.body = { ...body, data: { ...body.data, mktrLeadsStatus: 'lost' } };
+    req.rawBody = Buffer.from(JSON.stringify(req.body)); // re-serialized, signature now stale
+    const res = makeRes();
+    await handleExternalLeadOutcome(req, res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('401s a stale signed timestamp (> 5 min old)', async () => {
+    const res = makeRes();
+    await handleExternalLeadOutcome(
+      makeReq(validBody({ timestamp: new Date(Date.now() - 6 * 60 * 1000).toISOString() })),
+      res
+    );
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('401s a far-future signed timestamp', async () => {
+    const res = makeRes();
+    await handleExternalLeadOutcome(
+      makeReq(validBody({ timestamp: new Date(Date.now() + 3 * 60 * 1000).toISOString() })),
+      res
+    );
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('401s a malformed timestamp', async () => {
+    const res = makeRes();
+    await handleExternalLeadOutcome(makeReq(validBody({ timestamp: 'not-a-date' })), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('400s an unsupported event', async () => {
+    const res = makeRes();
+    await handleExternalLeadOutcome(makeReq(validBody({ event: 'lead.created' })), res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('400s a missing eventId', async () => {
+    const res = makeRes();
+    await handleExternalLeadOutcome(makeReq(validBody({ eventId: '' })), res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('400s a missing data.externalId', async () => {
+    const res = makeRes();
+    await handleExternalLeadOutcome(makeReq(validBody({ data: { externalId: null } })), res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('400s a status outside the shared contract', async () => {
+    const res = makeRes();
+    await handleExternalLeadOutcome(makeReq(validBody({ data: { mktrLeadsStatus: 'negotiating' } })), res);
+    expect(res.statusCode).toBe(400);
+    expect(processOutcomeMock).not.toHaveBeenCalled();
+  });
+
+  it('dispatches a valid request and returns the service status/body', async () => {
+    const body = validBody();
+    const res = makeRes();
+    await handleExternalLeadOutcome(makeReq(body), res);
+    expect(processOutcomeMock).toHaveBeenCalledWith({
+      event: body.event,
+      eventId: body.eventId,
+      timestamp: body.timestamp,
+      data: body.data,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ success: true, appliedLeadStatus: 'won' });
+  });
+
+  it('passes through a 422 from the service (unknown prospect stays unstamped)', async () => {
+    processOutcomeMock.mockResolvedValue({
+      statusCode: 422,
+      body: { success: false, error: 'unknown_prospect' },
+    });
+    const res = makeRes();
+    await handleExternalLeadOutcome(makeReq(validBody()), res);
+    expect(res.statusCode).toBe(422);
+    expect(res.body.error).toBe('unknown_prospect');
+  });
+
+  it('500s and reports to Sentry when the service throws', async () => {
+    processOutcomeMock.mockRejectedValue(new Error('db down'));
+    const res = makeRes();
+    await handleExternalLeadOutcome(makeReq(validBody()), res);
+    expect(res.statusCode).toBe(500);
+    expect(captureExceptionMock).toHaveBeenCalled();
+  });
+});

--- a/backend/test/externalLeadOutcomeService.test.js
+++ b/backend/test/externalLeadOutcomeService.test.js
@@ -1,0 +1,201 @@
+/**
+ * Unit tests for externalLeadOutcomeService.processExternalLeadOutcome — the
+ * MKTR Leads buyer-outcome → Prospect status mirror.
+ *
+ * Uses the makeExternalLeadOutcomeService dependency-injection seam so we run
+ * without a live Postgres: sequelize.transaction and the Prospect /
+ * ProspectActivity / IdempotencyKey models are stubbed.
+ */
+import { jest } from '@jest/globals';
+import { makeExternalLeadOutcomeService, IDEMPOTENCY_SCOPE } from '../src/services/externalLeadOutcomeService.js';
+
+const silentLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+
+function makeProspect(overrides = {}) {
+  return {
+    id: 'prospect-uuid-1',
+    leadStatus: 'contacted',
+    conversionDate: null,
+    externalAgentId: null,
+    // Current delivery path: buyer's mirror users row carries mktrLeadsId.
+    assignedAgent: { id: 'user-uuid-1', mktrLeadsId: 'mktr-leads-agent-uuid-1' },
+    save: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function buildDeps(overrides = {}) {
+  const prospect = 'prospect' in overrides ? overrides.prospect : makeProspect();
+  const Prospect = { findByPk: jest.fn().mockResolvedValue(prospect) };
+  const ProspectActivity = { create: jest.fn().mockResolvedValue(undefined) };
+  const IdempotencyKey = {
+    findOne: jest.fn().mockResolvedValue(overrides.existingKey ?? null),
+    create: jest.fn().mockResolvedValue(undefined),
+  };
+  const sequelize = { transaction: jest.fn((fn) => fn('tx')) };
+  const service = makeExternalLeadOutcomeService({
+    sequelize,
+    models: { Prospect, ProspectActivity, IdempotencyKey, User: {} },
+    logger: silentLogger,
+  });
+  return { service, prospect, Prospect, ProspectActivity, IdempotencyKey, sequelize };
+}
+
+function payload(overrides = {}) {
+  return {
+    event: 'lead.outcome',
+    eventId: 'lead-uuid-1:won',
+    timestamp: new Date().toISOString(),
+    data: {
+      externalId: 'prospect-uuid-1',
+      sourceName: 'mktr',
+      deliveryId: 'delivery-uuid-1',
+      mktrLeadsStatus: 'won',
+      ...(overrides.data || {}),
+    },
+    ...Object.fromEntries(Object.entries(overrides).filter(([k]) => k !== 'data')),
+  };
+}
+
+describe('processExternalLeadOutcome', () => {
+  it('422s an unknown prospect (sender must not stamp outcome_reported_at)', async () => {
+    const { service } = buildDeps({ prospect: null });
+    const result = await service.processExternalLeadOutcome(payload());
+    expect(result.statusCode).toBe(422);
+    expect(result.body.error).toBe('unknown_prospect');
+  });
+
+  it('422s a prospect that was never delivered to MKTR Leads', async () => {
+    const internal = makeProspect({ externalAgentId: null, assignedAgent: { id: 'u', mktrLeadsId: null } });
+    const { service, ProspectActivity } = buildDeps({ prospect: internal });
+    const result = await service.processExternalLeadOutcome(payload());
+    expect(result.statusCode).toBe(422);
+    expect(result.body.error).toBe('not_a_mktr_leads_prospect');
+    expect(internal.save).not.toHaveBeenCalled();
+    expect(ProspectActivity.create).not.toHaveBeenCalled();
+  });
+
+  it('accepts a future external_agents-path prospect (externalAgentId set, no mirror user)', async () => {
+    const external = makeProspect({ externalAgentId: 'ext-agent-uuid-1', assignedAgent: null });
+    const { service } = buildDeps({ prospect: external });
+    const result = await service.processExternalLeadOutcome(payload());
+    expect(result.statusCode).toBe(200);
+  });
+
+  it('applies won: maps status, stamps conversionDate, writes activity, claims the key in-transaction', async () => {
+    const { service, prospect, ProspectActivity, IdempotencyKey, sequelize } = buildDeps();
+    const result = await service.processExternalLeadOutcome(payload());
+
+    expect(result.statusCode).toBe(200);
+    expect(result.body).toMatchObject({ success: true, appliedLeadStatus: 'won', qualitySignal: false });
+    expect(prospect.leadStatus).toBe('won');
+    expect(prospect.conversionDate).toBeInstanceOf(Date);
+    expect(prospect.save).toHaveBeenCalledWith({ transaction: 'tx' });
+    expect(sequelize.transaction).toHaveBeenCalledTimes(1);
+
+    const activity = ProspectActivity.create.mock.calls[0][0];
+    expect(ProspectActivity.create).toHaveBeenCalledWith(expect.anything(), { transaction: 'tx' });
+    expect(activity).toMatchObject({
+      prospectId: 'prospect-uuid-1',
+      type: 'updated',
+      actorUserId: null,
+      metadata: expect.objectContaining({
+        source: 'mktr-leads',
+        eventId: 'lead-uuid-1:won',
+        mktrLeadsStatus: 'won',
+        previousLeadStatus: 'contacted',
+      }),
+    });
+    expect(activity.description.length).toBeLessThanOrEqual(255);
+
+    const keyRow = IdempotencyKey.create.mock.calls[0][0];
+    expect(IdempotencyKey.create).toHaveBeenCalledWith(expect.anything(), { transaction: 'tx' });
+    expect(keyRow.key).toBe(`${IDEMPOTENCY_SCOPE}:lead-uuid-1:won`);
+    expect(keyRow.scope).toBe(IDEMPOTENCY_SCOPE);
+    expect(keyRow.responseCode).toBe(200);
+    expect(keyRow.expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('does not overwrite an existing conversionDate on a repeat won', async () => {
+    const firstWon = new Date('2026-06-01T00:00:00Z');
+    const prospect = makeProspect({ leadStatus: 'lost', conversionDate: firstWon });
+    const { service } = buildDeps({ prospect });
+    await service.processExternalLeadOutcome(payload());
+    expect(prospect.conversionDate).toBe(firstWon);
+  });
+
+  it('maps proposed → proposal_sent (enum-verified rename)', async () => {
+    const { service, prospect } = buildDeps();
+    const result = await service.processExternalLeadOutcome(
+      payload({ eventId: 'lead-uuid-1:proposed', data: { mktrLeadsStatus: 'proposed' } })
+    );
+    expect(prospect.leadStatus).toBe('proposal_sent');
+    expect(result.body.appliedLeadStatus).toBe('proposal_sent');
+  });
+
+  it('preserves leadStatus for disputed and flags the activity as a quality signal', async () => {
+    const { service, prospect, ProspectActivity } = buildDeps();
+    const result = await service.processExternalLeadOutcome(
+      payload({ eventId: 'lead-uuid-1:disputed', data: { mktrLeadsStatus: 'disputed' } })
+    );
+    expect(result.statusCode).toBe(200);
+    expect(result.body).toMatchObject({ appliedLeadStatus: 'contacted', qualitySignal: true });
+    expect(prospect.leadStatus).toBe('contacted');
+    expect(prospect.save).not.toHaveBeenCalled();
+    expect(ProspectActivity.create.mock.calls[0][0].metadata.qualitySignal).toBe(true);
+  });
+
+  it('skips the save but still writes the activity when the status is unchanged', async () => {
+    const prospect = makeProspect({ leadStatus: 'won', conversionDate: new Date() });
+    const { service, ProspectActivity } = buildDeps({ prospect });
+    const result = await service.processExternalLeadOutcome(payload());
+    expect(prospect.save).not.toHaveBeenCalled();
+    expect(ProspectActivity.create).toHaveBeenCalled();
+    expect(result.statusCode).toBe(200);
+  });
+
+  it('replays the stored response for a live idempotency key without touching the prospect', async () => {
+    const existingKey = {
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      responseCode: 200,
+      responseBody: { success: true, appliedLeadStatus: 'won' },
+      destroy: jest.fn(),
+    };
+    const { service, Prospect } = buildDeps({ existingKey });
+    const result = await service.processExternalLeadOutcome(payload());
+    expect(result).toEqual({ statusCode: 200, body: { success: true, appliedLeadStatus: 'won' } });
+    expect(Prospect.findByPk).not.toHaveBeenCalled();
+    expect(existingKey.destroy).not.toHaveBeenCalled();
+  });
+
+  it('takes over an expired idempotency key and processes the event anew', async () => {
+    const existingKey = {
+      expiresAt: new Date(Date.now() - 60 * 1000),
+      responseCode: 200,
+      responseBody: { success: true },
+      destroy: jest.fn().mockResolvedValue(undefined),
+    };
+    const { service, prospect, IdempotencyKey } = buildDeps({ existingKey });
+    const result = await service.processExternalLeadOutcome(payload());
+    expect(existingKey.destroy).toHaveBeenCalled();
+    expect(prospect.leadStatus).toBe('won');
+    expect(IdempotencyKey.create).toHaveBeenCalled();
+    expect(result.statusCode).toBe(200);
+  });
+
+  it('treats a concurrent key conflict as a replay', async () => {
+    const { service, IdempotencyKey } = buildDeps();
+    const conflict = new Error('duplicate key');
+    conflict.name = 'SequelizeUniqueConstraintError';
+    IdempotencyKey.create.mockRejectedValue(conflict);
+    const result = await service.processExternalLeadOutcome(payload());
+    expect(result.statusCode).toBe(200);
+    expect(result.body.replay).toBe(true);
+  });
+
+  it('propagates a transaction failure so the controller can 500 (event stays re-processable)', async () => {
+    const { service, ProspectActivity } = buildDeps();
+    ProspectActivity.create.mockRejectedValue(new Error('db down'));
+    await expect(service.processExternalLeadOutcome(payload())).rejects.toThrow('db down');
+  });
+});

--- a/backend/test/externalLeadOutcomesRoute.test.js
+++ b/backend/test/externalLeadOutcomesRoute.test.js
@@ -1,0 +1,127 @@
+/**
+ * Route-level integration tests for POST /api/external/lead-outcomes.
+ *
+ * What the unit suites can't prove: that the route auto-mounts (meta.path),
+ * that server_internal.js captures req.rawBody for the /api/external/ prefix
+ * (a missing capture surfaces as 500, distinguishing it from 401 auth
+ * failures), and that the full apply path writes the Prospect /
+ * ProspectActivity / IdempotencyKey rows against a real schema.
+ *
+ * Needs the local test Postgres (see docker-compose.test.yml / test/setup.js).
+ */
+import crypto from 'crypto';
+import request from 'supertest';
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect } from './helpers.js';
+import { ProspectActivity, IdempotencyKey } from '../src/models/index.js';
+
+const SECRET = 'test-external-outcome-secret';
+
+let app;
+
+beforeAll(async () => {
+  process.env.EXTERNAL_OUTCOME_WEBHOOK_SECRET = SECRET;
+  app = await getApp();
+}, 15000);
+
+afterAll(async () => {
+  await closeDb();
+});
+
+function sign(rawBody, secret = SECRET) {
+  return 'sha256=' + crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+}
+
+function outcomeBody(externalId, mktrLeadsStatus, overrides = {}) {
+  return JSON.stringify({
+    event: 'lead.outcome',
+    eventId: `${overrides.leadId || 'lead-1'}:${mktrLeadsStatus}`,
+    timestamp: new Date().toISOString(),
+    data: { externalId, sourceName: 'mktr', deliveryId: null, mktrLeadsStatus },
+    ...overrides.top,
+  });
+}
+
+function post(rawBody, headers = {}) {
+  return request(app)
+    .post('/api/external/lead-outcomes')
+    .set('Content-Type', 'application/json')
+    .set('X-Webhook-Signature', headers.signature ?? sign(rawBody))
+    .send(rawBody);
+}
+
+describe('POST /api/external/lead-outcomes', () => {
+  it('mounts and rejects an unsigned request with 401 (not 404, not 500)', async () => {
+    const raw = outcomeBody('11111111-1111-4111-8111-111111111111', 'won');
+    const res = await post(raw, { signature: 'sha256=deadbeef' });
+    expect(res.status).toBe(401);
+  });
+
+  it('verifies the signature over the captured raw body and 422s an unknown prospect', async () => {
+    const raw = outcomeBody('11111111-1111-4111-8111-111111111111', 'won');
+    const res = await post(raw);
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe('unknown_prospect');
+  });
+
+  it('applies an outcome end-to-end for a mirror-delivered prospect', async () => {
+    const { user } = await createTestUser({ role: 'agent', mktrLeadsId: crypto.randomUUID() });
+    const campaign = await createTestCampaign(user.id);
+    const prospect = await createTestProspect(campaign.id, {
+      assignedAgentId: user.id,
+      leadStatus: 'contacted',
+    });
+
+    const raw = outcomeBody(prospect.id, 'won', { leadId: prospect.id });
+    const res = await post(raw);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ success: true, appliedLeadStatus: 'won', qualitySignal: false });
+
+    await prospect.reload();
+    expect(prospect.leadStatus).toBe('won');
+    expect(prospect.conversionDate).not.toBeNull();
+
+    const activity = await ProspectActivity.findOne({
+      where: { prospectId: prospect.id, type: 'updated' },
+      order: [['createdAt', 'DESC']],
+    });
+    expect(activity).not.toBeNull();
+    expect(activity.metadata).toMatchObject({ source: 'mktr-leads', mktrLeadsStatus: 'won' });
+
+    const key = await IdempotencyKey.findByPk(`external:outcome:${prospect.id}:won`);
+    expect(key).not.toBeNull();
+    expect(key.scope).toBe('external:outcome');
+
+    // Replay: same eventId returns the stored response without a second activity.
+    const replay = await post(outcomeBody(prospect.id, 'won', { leadId: prospect.id }));
+    expect(replay.status).toBe(200);
+    const activityCount = await ProspectActivity.count({ where: { prospectId: prospect.id, type: 'updated' } });
+    expect(activityCount).toBe(1);
+  });
+
+  it('422s a prospect that was never delivered to MKTR Leads (internal agent, no mirror id)', async () => {
+    const { user } = await createTestUser({ role: 'agent' });
+    const campaign = await createTestCampaign(user.id);
+    const prospect = await createTestProspect(campaign.id, { assignedAgentId: user.id });
+
+    const res = await post(outcomeBody(prospect.id, 'won', { leadId: prospect.id }));
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe('not_a_mktr_leads_prospect');
+  });
+
+  it('preserves the prospect status for a disputed signal', async () => {
+    const { user } = await createTestUser({ role: 'agent', mktrLeadsId: crypto.randomUUID() });
+    const campaign = await createTestCampaign(user.id);
+    const prospect = await createTestProspect(campaign.id, {
+      assignedAgentId: user.id,
+      leadStatus: 'qualified',
+    });
+
+    const res = await post(outcomeBody(prospect.id, 'disputed', { leadId: prospect.id }));
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ appliedLeadStatus: 'qualified', qualitySignal: true });
+
+    await prospect.reload();
+    expect(prospect.leadStatus).toBe('qualified');
+  });
+});


### PR DESCRIPTION
The return half of the external lead loop (MKTR_LEADS_PLAN.md §2, mktr-leads audit M1): `POST /api/external/lead-outcomes` receives buyer status changes from the mktr-leads `report-lead-outcome` edge function and mirrors them onto the originating Prospect.

- Body-only HMAC (`EXTERNAL_OUTCOME_WEBHOOK_SECRET`, already set on Render); freshness on the signed body timestamp (±5 min); raw-body capture + rate-limit exemption for `/api/external/`.
- Status mapping verified against the real `Prospect.leadStatus` enum: `proposed→proposal_sent`; `invalid`/`disputed` preserve the status and land as `qualitySignal` activities (they are not enum values).
- `won` stamps `conversionDate`, deliberately creates NO commission (buyers pay for leads, they don't earn commissions).
- Ownership gate: only MKTR Leads-delivered prospects (`externalAgentId` or assigned mirror-user's `mktrLeadsId`) can be mutated — others 422.
- Idempotent via `IdempotencyKey` scope `external:outcome`, claimed inside the apply transaction; stored-response replay; expired-key takeover.
- Endpoint is inert until the secret env is set (already done).

Tests: 28 unit + 5 route-level integration, all passing. Existing suites: identical pass/fail counts with and without this change (local failures are pre-existing env issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)