### PR TITLE
fix(prospects): label TikTok-sourced leads as TIKTOK AD

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ Nameservers at Cloudflare (`chance.ns.cloudflare.com`, `liv.ns.cloudflare.com`) 
 
 - mktr-platform Static Site (Render): `VITE_BRAND=mktr` (or unset — defaults to mktr), `VITE_API_URL=https://api.mktr.sg/api` (absolute — pre-rebrand setup, cross-origin to api.mktr.sg works because cookies live on parent `.mktr.sg`).
 - redeem-frontend Static Site (Render): `VITE_BRAND=redeem`, `VITE_API_URL=/api` (relative — Render rewrites `/api/*` → `https://api.mktr.sg/api/*` so cookies live on `.redeem.sg`). Vite plugin emits brand-aware `robots.txt` + `sitemap.xml` per build.
+- Both static sites bake the public pixel IDs at build time: `VITE_META_PIXEL_ID=1402034528611431` and `VITE_TIKTOK_PIXEL_ID=D8GJ6T3C77UDLID6746G` (TikTok added to `mktr-platform`/mktr.sg on 2026-06-17 to match redeem.sg). `VITE_*` vars are baked into `dist` at build, so changing a pixel id requires a redeploy.
 
 ## Meta Ads — Advertising Account, Pixel & CAPI
 
@@ -140,6 +141,32 @@ Paid acquisition (Facebook/Instagram) for the lead-capture funnel. All assets li
 **Lead-quality controls** (who can actually convert — the `$20 voucher` hook attracts low-intent/freebie traffic, so two layers filter it):
 - **Per-campaign SG/PR gate** — `design_config.sgPrOnly` (shipped `622fd2e`). When on, `CampaignSignupForm.jsx` renders a Yes/No "Singapore Citizen or PR?" screening card before the form ("No" blocks); toggle it in the campaign designer's **Content** panel. It is **client-side and self-declared** (the answer is not POSTed to the backend): it deters honest non-residents and — because the Pixel `Lead` event only fires on a completed submit — keeps unqualified people out of CAPI + Meta's conversion optimization, but won't stop a motivated false answer.
 - **Meta-side audience filters** (ad-account config, not in this repo): Meta offers no occupation/citizenship targeting, so the ad set instead targets **"people who live in Singapore"** (`geo_locations.location_types:["home"]`, not the default "everyone in this location"), bounds age, and **excludes a customer-list Custom Audience** of known industry contacts/advisors (plus a lookalike of it). Under **Advantage+ Audience**, excluded custom audiences are the *only* hard filter Meta honors — interest/inclusion targeting is treated as a suggestion. Specific audience IDs live in the ad account.
+
+## TikTok Ads — Pixel & Events API
+
+The TikTok counterpart of the Meta funnel above — a browser **Pixel** (`ttq`) plus a server-side **Events API** (TikTok's CAPI equivalent). Built for the quiz/lead-capture funnel and **live in production** (shipped via PRs **#21** quiz-funnel + tracking and **#22** audit fixes; migration `034-add-campaign-tiktok-pixel-id.js` applied 2026-06-04). Deliberately mirrors `metaPixel.js` / `metaCapiService.js` so the two platforms behave identically (stable shared `event_id` → Pixel⇄server dedup, consent-gated PII, origin-gated dispatch).
+
+**Pixel:** TikTok pixel code `D8GJ6T3C77UDLID6746G`. Browser Pixel **+** Events API, both receiving events. (The TikTok ad-account / Business Center topology is not yet documented here — only the pixel + code path is confirmed.)
+
+**Tracking code:**
+- `index.html` — `ttq` base stub, gated on `VITE_TIKTOK_PIXEL_ID` (defines the queue + `ttq.load` injector but does NOT call `ttq.load()`/`ttq.page()`; the guard `PIXEL_ID.charAt(0)==='%'` no-ops cleanly when the var is unset, so an unset host shows no broken pixel).
+- `src/lib/tiktokPixel.js` — `initTikTokPixel` (injects the SDK only on the live `/LeadCapture` page), `ViewContent` / `CompleteRegistration` / `Lead` trackers carrying the stable `event_id` for Pixel⇄Events-API dedup; `captureTtclidFromUrl` (persists `ttclid`), `readTtp` (reads the `_ttp` cookie). Suppression via shared `src/lib/pixelSuppression.js` (`isTrackableLeadCapture`, kept in lock-step with the Meta pixel).
+- `backend/src/services/tiktokEventsService.js` — fire-and-forget `sendConversionEvent` (wrappers `sendTikTokLeadEvent` / `sendTikTokCompleteRegistrationEvent`) → `POST business-api.tiktok.com/open_api/v1.3/event/track/`. Guard `shouldFireTikTok` skips Retell + Meta-Lead-Ads-origin prospects (mirrors `shouldFireCapi`). Hashed email/phone/external_id via `backend/src/utils/piiHashing.js` — email/phone only with marketing consent (`sourceMetadata.consent_contact === true`); `ttclid`/`ttp`/ip/ua always sent. TikTok returns HTTP 200 with a non-zero `code` on logical failure, so success requires `res.ok && body.code === 0` (logged as `tiktok.lead.sent` / `tiktok.complete_registration.sent`).
+- Wiring: `prospectService.js` fires both senders post-commit alongside the Meta senders, with `pixelIdOverride: sourceCampaign?.tiktokPixelId`; `prospectController.js` threads `ttclid`/`ttp` from `req.body`. Per-campaign override = `Campaign.tiktokPixelId` (column `tiktok_pixel_id`, migration 034), else the env pixel id.
+
+**Env vars** (pixel id is public — embedded in page source; the access token is the only secret):
+
+| Var | Component | Value / Notes |
+|---|---|---|
+| `VITE_TIKTOK_PIXEL_ID` | Frontend build (both static sites) | `D8GJ6T3C77UDLID6746G` — on `redeem-frontend` and (2026-06-17) `mktr-platform` |
+| `TIKTOK_PIXEL_ID` | Backend (Events API) | `D8GJ6T3C77UDLID6746G` — per-campaign `Campaign.tiktokPixelId` overrides |
+| `TIKTOK_ACCESS_TOKEN` | Backend | **Secret** — never commit |
+| `TIKTOK_EVENTS_API_ENABLED` | Backend | Must be `"true"` to dispatch |
+| `TIKTOK_TEST_EVENT_CODE` / `VITE_TIKTOK_TEST_EVENT_CODE` | Both | Routes events to Test Events (staging/dev) |
+
+**Live status (verified 2026-06-17):** browser Pixel live on **redeem.sg** and **mktr.sg** (both static sites bake `VITE_TIKTOK_PIXEL_ID`); backend Events API firing `Lead` + `CompleteRegistration` successfully — `tiktok.lead.sent` appears continuously in `mktr-backend-jo6r` Render logs (2026-06-04 → 2026-06-16). Note: `.env.example` ships `TIKTOK_EVENTS_API_ENABLED=false` + blank ids — that is the example default, NOT prod state; check the live deploy/logs.
+
+**TODO:** add TikTok's **domain verification** for `redeem.sg` in TikTok Events Manager (the Meta `facebook-domain-verification` TXT is already present in the DNS section; TikTok needs its own record). Not required for the Events API to fire, but it improves pixel attribution / event match quality. No native TikTok lead forms — same `redeem.sg/LeadCapture?campaign_id={id}` landing-page funnel as Meta; optimize the ad for the `Lead` event.
 
 ## Architecture — Full Data Flow
 

--- a/src/pages/AdminProspects.jsx
+++ b/src/pages/AdminProspects.jsx
@@ -61,7 +61,7 @@ import {
 function SourceTag({ prospect, compact = false }) {
  const d = sourceDisplay(prospect);
  const badgeClass = `text-xs px-1.5 py-0.5 rounded border uppercase ${
- d.label ==="META AD"
+ d.label.endsWith(" AD")
  ?"bg-primary/10 text-primary border-primary/30"
  :"bg-muted text-muted-foreground border-border"
  }`;

--- a/src/utils/__tests__/normalizeProspect.test.js
+++ b/src/utils/__tests__/normalizeProspect.test.js
@@ -207,6 +207,30 @@ describe('deriveAd', () => {
  expect(deriveAd({ fbp: 'fb.1.1718000000.12345' })).toBeNull();
  });
 
+ it.each(['tiktok', 'tt', 'tiktokads', 'tiktok_ads', 'tiktok-ads', 'TikTok'])(
+ 'recognises tiktok utm_source alias %s',
+ (alias) => {
+ expect(deriveAd({ utm: { utm_source: alias } }).platform).toBe('tiktok');
+ }
+ );
+
+ it('ttclid-only → tier "click" (TikTok click, not paid-ad evidence)', () => {
+ expect(deriveAd({ ttclid: 'EAAtt.123' })).toMatchObject({ platform: 'tiktok', tier: 'click' });
+ });
+
+ it('ttclid in eventSourceUrl → tier "click"', () => {
+ const ad = deriveAd({ eventSourceUrl: 'https://redeem.sg/LeadCapture?campaign_id=c1&ttclid=XYZ' });
+ expect(ad).toMatchObject({ platform: 'tiktok', tier: 'click' });
+ });
+
+ it('_ttp alone is NOT ad evidence (minted for every tracked visitor)', () => {
+ expect(deriveAd({ ttp: 'tt.1.1718000000.12345' })).toBeNull();
+ });
+
+ it('meta click id wins when both fbc and ttclid are present', () => {
+ expect(deriveAd({ fbc: 'fb.1.1.X', ttclid: 'EAAtt.123' }).platform).toBe('meta');
+ });
+
  it('returns null for empty/absent metadata', () => {
  expect(deriveAd(null)).toBeNull();
  expect(deriveAd({})).toBeNull();
@@ -305,11 +329,35 @@ describe('sourceDisplay', () => {
  expect(d.detail).toBe('IG Push');
  });
 
- it('non-meta ad platforms do not get the meta badge', () => {
+ it('TIKTOK AD with campaign detail from utm_source=tiktok', () => {
  const d = sourceDisplay(
- normalizeProspect({ id: '1', leadSource: 'website', sourceMetadata: { utm: { utm_source: 'tiktok' } } })
+ normalizeProspect({
+ id: '1',
+ leadSource: 'website',
+ sourceMetadata: { utm: { utm_source: 'tiktok', utm_campaign: 'Q2 Quiz', utm_term: 'adgroup-1' } },
+ })
  );
- expect(d.label).toBe('FORM');
+ expect(d.label).toBe('TIKTOK AD');
+ expect(d.detail).toBe('Q2 Quiz');
+ expect(d.tooltip).toBe('Campaign: Q2 Quiz · Ad set: adgroup-1');
+ expect(d.attribution).toBe('TikTok ad: Q2 Quiz');
+ });
+
+ it('TIKTOK CLICK for ttclid-only rows (no UTMs on the ad URL)', () => {
+ const d = sourceDisplay(
+ normalizeProspect({ id: '1', leadSource: 'website', sourceMetadata: { ttclid: 'EAAtt.123' } })
+ );
+ expect(d.label).toBe('TIKTOK CLICK');
+ expect(d.detail).toBe('');
+ expect(d.attribution).toBe('TikTok click');
+ });
+
+ it('unknown ad platform surfaces the raw source as an AD badge', () => {
+ const d = sourceDisplay(
+ normalizeProspect({ id: '1', leadSource: 'website', sourceMetadata: { utm: { utm_source: 'google' } } })
+ );
+ expect(d.label).toBe('GOOGLE AD');
+ expect(d.attribution).toBe('GOOGLE ad');
  });
 });
 

--- a/src/utils/normalizeProspect.js
+++ b/src/utils/normalizeProspect.js
@@ -8,18 +8,40 @@
  */
 
 const META_UTM_SOURCES = new Set(["facebook", "fb", "instagram", "ig", "meta"]);
+const TIKTOK_UTM_SOURCES = new Set(["tiktok", "tt", "tiktokads", "tiktok_ads", "tiktok-ads"]);
+
+// Ad-platform display labels: badge text (uppercase) vs prose name (title case).
+// An unknown-but-present utm_source surfaces raw (uppercased for the badge).
+const AD_PLATFORM_BADGE = { meta: "META", tiktok: "TIKTOK" };
+const AD_PLATFORM_NAME = { meta: "Meta", tiktok: "TikTok" };
+
+function adPlatformFor(utmSource) {
+ if (META_UTM_SOURCES.has(utmSource)) return "meta";
+ if (TIKTOK_UTM_SOURCES.has(utmSource)) return "tiktok";
+ return utmSource;
+}
+
+function adPlatformBadge(platform) {
+ return AD_PLATFORM_BADGE[platform] || String(platform || "").toUpperCase();
+}
+
+function adPlatformName(platform) {
+ return AD_PLATFORM_NAME[platform] || String(platform || "").toUpperCase();
+}
 
 /**
  * Derive ad attribution from Prospect.sourceMetadata (stashed by the backend
  * at create time — see prospectService.createProspect).
  *
- * tier "ad"    — UTM evidence. UTMs only exist on our paid-ad URLs, so
- *                utm_source ∈ META_UTM_SOURCES is proof of a Meta ad;
+ * tier "ad"    — UTM evidence. UTMs only exist on our paid-ad URLs, so a known
+ *                utm_source pins the platform (META_UTM_SOURCES → meta,
+ *                TIKTOK_UTM_SOURCES → tiktok; anything else surfaces raw);
  *                campaign/adset/ad come from utm_campaign/utm_term/utm_content.
- * tier "click" — fbclid fingerprint only (`fbc`, or an fbclid in the landing
- *                URL). Organic Facebook/Instagram clicks carry these too, so
- *                this is "came via Meta", not "came via a paid ad".
- * Never uses fbp: ensureFbp() mints that for every tracked visitor.
+ * tier "click" — click-id fingerprint only: Meta `fbc`/fbclid, or TikTok
+ *                `ttclid`. Organic clicks carry these too, so this is "came via
+ *                {platform}", not a paid ad. Meta is checked first.
+ * Never uses fbp/_ttp: those are minted for every tracked visitor, not just ad
+ * clickers, so they are not attribution evidence.
  */
 export function deriveAd(sourceMetadata) {
  const meta = sourceMetadata || {};
@@ -27,7 +49,7 @@ export function deriveAd(sourceMetadata) {
  const utmSource = String(utm.utm_source || "").toLowerCase();
  if (utmSource) {
  return {
- platform: META_UTM_SOURCES.has(utmSource) ? "meta" : utmSource,
+ platform: adPlatformFor(utmSource),
  tier: "ad",
  campaign: utm.utm_campaign || "",
  adset: utm.utm_term || "",
@@ -37,6 +59,9 @@ export function deriveAd(sourceMetadata) {
  }
  if (meta.fbc || /[?&]fbclid=/.test(meta.eventSourceUrl || "")) {
  return { platform: "meta", tier: "click", campaign: "", adset: "", adName: "", utmSource: "" };
+ }
+ if (meta.ttclid || /[?&]ttclid=/.test(meta.eventSourceUrl || "")) {
+ return { platform: "tiktok", tier: "click", campaign: "", adset: "", adName: "", utmSource: "" };
  }
  return null;
 }
@@ -81,7 +106,9 @@ export function sourceDisplay(p) {
  };
  }
 
- if (ad && ad.platform === "meta") {
+ if (ad && ad.platform) {
+ const badge = adPlatformBadge(ad.platform);
+ const name = adPlatformName(ad.platform);
  if (ad.tier === "ad") {
  const parts = [
  ad.campaign ? `Campaign: ${ad.campaign}` : "",
@@ -89,17 +116,18 @@ export function sourceDisplay(p) {
  ad.adName ? `Ad: ${ad.adName}` : "",
  ].filter(Boolean);
  return {
- label: "META AD",
+ label: `${badge} AD`,
  detail: ad.campaign,
- tooltip: parts.join(" · ") || "Meta ad (no campaign name in UTMs)",
- attribution: ad.campaign ? `Meta ad: ${ad.campaign}` : "Meta ad",
+ tooltip: parts.join(" · ") || `${name} ad (no campaign name in UTMs)`,
+ attribution: ad.campaign ? `${name} ad: ${ad.campaign}` : `${name} ad`,
  };
  }
+ const clickChannel = ad.platform === "meta" ? "Meta (Facebook/Instagram)" : name;
  return {
- label: "META CLICK",
+ label: `${badge} CLICK`,
  detail: "",
- tooltip: "Came via a Meta (Facebook/Instagram) click — no ad UTM data",
- attribution: "Meta click",
+ tooltip: `Came via a ${clickChannel} click — no ad UTM data`,
+ attribution: `${name} click`,
  };
  }
 


### PR DESCRIPTION
## What
Label TikTok-sourced leads as `TIKTOK AD` in the admin Prospects **Source** column. They currently show the generic `FORM`.

## Why
Source attribution (`src/utils/normalizeProspect.js`) recognized only Meta + Referral, so TikTok leads (`utm_source=tiktok` / `ttclid`) fell through to the default `FORM` label. Verified against live prod data — tonight's TikTok leads (Wong, khairudin, Wan, Alex; all `utm_source=tiktok` + `ttclid` on the `Lead generation20260617213349` campaign) were mislabeled `FORM`.

## Change
- `deriveAd()` / `sourceDisplay()` generalized to any ad platform via a badge/name map; `TIKTOK_UTM_SOURCES` → `TIKTOK AD`, plus a `ttclid` click tier.
- `AdminProspects` badge highlight keys off `label.endsWith(" AD")` so `TIKTOK AD` gets the same styling as `META AD`.
- Meta output unchanged. **54/54** `normalizeProspect` unit tests pass.
- Also persists the pending TikTok Pixel/Events API documentation in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zocrGGinStf16y9nGe7cQ