### PR TITLE
fix(prospects): source-aware signup activity text (was "Unknown QR")

### DIFF
--- a/backend/src/database/migrations/038-backfill-signup-activity-source.js
+++ b/backend/src/database/migrations/038-backfill-signup-activity-source.js
@@ -1,0 +1,73 @@
+/**
+ * Backfill: fix mislabeled "Prospect signed up …" activity descriptions.
+ *
+ * Until utils/sourceLabel.js, the "created" activity line hardcoded
+ *   `… campaign via {qrTag||'Unknown QR'} QR code`
+ * for EVERY lead, so ad/form/referral leads (no QR tag) read as
+ * "via Unknown QR QR code" — e.g. a TikTok ad lead showed "Unknown QR".
+ *
+ * This recomputes those descriptions with the same helper the live create path
+ * now uses, so historical rows match new ones ("via TikTok ad", "via web form",
+ * "via referral from …", or "via {name} QR code" for real scans).
+ *
+ * Scope: only `type='created'` rows whose description matches the old template.
+ * Retell rows ("Lead created from Retell AI call …") never match. Idempotent —
+ * a real QR row recomputes to identical text (skipped), and once a non-QR row
+ * is fixed it no longer ends in " QR code" so it can't be re-matched.
+ */
+import { signupActivityDescription } from '../../utils/sourceLabel.js';
+
+const PREFIX = 'Prospect signed up for ';
+
+export async function up(queryInterface) {
+  const sql = `
+    SELECT pa.id AS id,
+           pa.description AS description,
+           p."leadSource" AS "leadSource",
+           p."sourceMetadata" AS "sourceMetadata",
+           q.id AS "qrId",
+           q.name AS "qrName",
+           q.label AS "qrLabel"
+    FROM prospect_activities pa
+    JOIN prospects p ON p.id = pa."prospectId"
+    LEFT JOIN qr_tags q ON q.id = p."qrTagId"
+    WHERE pa.type = 'created'
+      AND pa.description LIKE 'Prospect signed up for %campaign via %QR code'
+  `;
+  const rows = await queryInterface.sequelize.query(sql, { type: 'SELECT' });
+
+  let updated = 0;
+  for (const row of rows) {
+    const desc = row.description || '';
+    // Key off the tag's existence (id), not its name — matches the live create
+    // path, which passes the QrTag object even when name/label are empty.
+    const qrTag = row.qrId ? { name: row.qrName, label: row.qrLabel } : null;
+
+    // Reconstruct the EXACT old suffix the buggy template produced for this row
+    // and strip it, instead of parsing the campaign name out with a regex. This
+    // is unambiguous even when a campaign name itself contains " campaign via "
+    // (a lazy/greedy capture would truncate it). If the suffix doesn't match,
+    // the row isn't the buggy template (or was already fixed) — skip it.
+    const oldQrPart = (qrTag && (qrTag.name || qrTag.label)) || 'Unknown QR';
+    const oldSuffix = ` campaign via ${oldQrPart} QR code`;
+    if (!desc.startsWith(PREFIX) || !desc.endsWith(oldSuffix)) continue;
+    const campaignName = desc.slice(PREFIX.length, desc.length - oldSuffix.length);
+
+    const next = signupActivityDescription(campaignName, {
+      leadSource: row.leadSource,
+      qrTag,
+      sourceMetadata: row.sourceMetadata,
+    });
+    if (next === desc) continue;
+    await queryInterface.sequelize.query(
+      'UPDATE "prospect_activities" SET description = ? WHERE id = ?',
+      { replacements: [next, row.id] }
+    );
+    updated += 1;
+  }
+  console.log(`038-backfill-signup-activity-source: scanned ${rows.length}, updated ${updated} description(s).`);
+}
+
+// Data-only backfill of free-text labels; the prior text is not recoverable and
+// has no schema impact, so down is a no-op (re-running up is safe + idempotent).
+export async function down() {}

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -27,6 +27,7 @@ import {
   sendTikTokCompleteRegistrationEvent,
 } from './tiktokEventsService.js';
 import { logger } from '../utils/logger.js';
+import { signupActivityDescription } from '../utils/sourceLabel.js';
 import {
   normalizePhone,
   buildLeadCreatedPayload,
@@ -550,8 +551,14 @@ export function makeProspectService(overrides = {}) {
       );
 
       const campaignName = sourceCampaign?.name || 'Unknown Campaign';
-      const qrTagName = sourceQrTag?.name || sourceQrTag?.label || 'Unknown QR';
-      const activityDescription = `Prospect signed up for ${campaignName} campaign via ${qrTagName} QR code`;
+      // Source-aware phrase ("via TikTok ad" / "via web form" / "via {name} QR
+      // code" …) instead of the old hardcoded "via {qr} QR code", which
+      // mislabeled every non-QR lead as "Unknown QR". See utils/sourceLabel.js.
+      const activityDescription = signupActivityDescription(campaignName, {
+        leadSource: incoming.leadSource,
+        qrTag: sourceQrTag,
+        sourceMetadata: incoming.sourceMetadata,
+      });
 
       // Activity: created
       await m.ProspectActivity.create(

--- a/backend/src/utils/sourceLabel.js
+++ b/backend/src/utils/sourceLabel.js
@@ -1,0 +1,88 @@
+/**
+ * Human-readable signup source phrase for a prospect's "created" activity line.
+ *
+ * The old template hardcoded `via {qrTag} QR code` for EVERY lead, so an ad- or
+ * form-sourced lead (no QR tag) rendered as "via Unknown QR QR code" even when
+ * its attribution clearly said TikTok/Meta. This derives the phrase from the
+ * lead's actual source instead.
+ *
+ * The vocabulary deliberately mirrors the frontend admin Source-column badge
+ * (`src/utils/normalizeProspect.js` → deriveAd / sourceDisplay) so the Activity
+ * History prose and the badge agree: utm_source pins the ad platform, a bare
+ * click-id is a "click" (organic links carry these too), and an explicit
+ * leadSource='referral' wins over circumstantial UTM/click capture.
+ *
+ * `sourceMetadata` shape (built in prospectService.createProspect):
+ *   { utm: { utm_source, ... }, ttclid, fbc, eventSourceUrl, referral: { referrerName } }
+ */
+
+const META_UTM_SOURCES = new Set(['facebook', 'fb', 'instagram', 'ig', 'meta']);
+const TIKTOK_UTM_SOURCES = new Set(['tiktok', 'tt', 'tiktokads', 'tiktok_ads', 'tiktok-ads']);
+
+/** utm_source -> ad platform display name (title-cased fallback for unknowns). */
+function adPlatformName(utmSource) {
+  const s = String(utmSource || '').toLowerCase();
+  if (META_UTM_SOURCES.has(s)) return 'Meta';
+  if (TIKTOK_UTM_SOURCES.has(s)) return 'TikTok';
+  // Unknown source: title-case it, but bound the length — utm_source is
+  // user-supplied (Joi caps it at 128) and feeds a STRING(255) column.
+  return s ? s.slice(0, 64).replace(/[_-]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()) : '';
+}
+
+/**
+ * Build the "via …" clause for a signup, given the lead's source signals.
+ * @param {object}  opts
+ * @param {string}  [opts.leadSource]      Prospect.leadSource (website|qr_code|call_bot|referral|…)
+ * @param {object}  [opts.qrTag]           the bound QrTag row (null when not a QR scan)
+ * @param {object}  [opts.sourceMetadata]  Prospect.sourceMetadata (utm/click ids/referral)
+ * @returns {string} e.g. "via TikTok ad", "via Marina Bay QR code", "via web form"
+ */
+export function signupSourcePhrase({ leadSource, qrTag, sourceMetadata } = {}) {
+  const meta = sourceMetadata || {};
+  const source = String(leadSource || '').toLowerCase();
+
+  // Explicit referral intent wins over any circumstantial (same-tab) attribution.
+  if (source === 'referral') {
+    const name = meta.referral?.referrerName;
+    return name ? `via referral from ${name}` : 'via referral';
+  }
+
+  // A bound QR tag is concrete evidence — prefer its name/label.
+  if (qrTag) {
+    const qrName = qrTag.name || qrTag.label;
+    return qrName ? `via ${qrName} QR code` : 'via QR code';
+  }
+  if (source === 'qr_code') return 'via QR code';
+
+  // Retell voice bot.
+  if (source === 'call_bot') return 'via voice call';
+
+  // Paid ad — a utm_source only appears on our ad URLs, so it pins the platform.
+  const utmSource = meta.utm?.utm_source;
+  if (utmSource) {
+    const name = adPlatformName(utmSource);
+    return name ? `via ${name} ad` : 'via ad';
+  }
+
+  // Click-id fingerprint only. Organic links carry these too, so this is
+  // "came via a {platform} click", not a paid ad. Meta is checked first.
+  const esu = meta.eventSourceUrl || '';
+  if (meta.fbc || /[?&]fbclid=/i.test(esu)) return 'via Meta click';
+  if (meta.ttclid || /[?&]ttclid=/i.test(esu)) return 'via TikTok click';
+
+  // Plain landing-page form, or any other/unknown source.
+  if (source === '' || source === 'website') return 'via web form';
+  return `via ${source.replace(/_/g, ' ')}`;
+}
+
+/** Full "created" activity description: "Prospect signed up for {campaign} campaign {phrase}". */
+export function signupActivityDescription(campaignName, opts = {}) {
+  const name = campaignName || 'Unknown Campaign';
+  const desc = `Prospect signed up for ${name} campaign ${signupSourcePhrase(opts)}`;
+  // ProspectActivity.description is STRING(255) NOT NULL. A long campaign name
+  // plus a long utm_source could overflow and throw inside the create
+  // transaction (losing the lead) — clamp to keep the insert safe.
+  return desc.length > 255 ? desc.slice(0, 255) : desc;
+}
+
+export default { signupSourcePhrase, signupActivityDescription };

--- a/backend/test/sourceLabel.test.js
+++ b/backend/test/sourceLabel.test.js
@@ -1,0 +1,135 @@
+import { signupSourcePhrase, signupActivityDescription } from '../src/utils/sourceLabel.js';
+
+describe('signupSourcePhrase', () => {
+  describe('QR scans', () => {
+    it('uses the QR tag name', () => {
+      expect(signupSourcePhrase({ leadSource: 'qr_code', qrTag: { name: 'Marina Bay' } })).toBe(
+        'via Marina Bay QR code'
+      );
+    });
+    it('falls back to the QR tag label', () => {
+      expect(signupSourcePhrase({ leadSource: 'qr_code', qrTag: { label: 'Booth A' } })).toBe(
+        'via Booth A QR code'
+      );
+    });
+    it('handles a bound tag with no name/label', () => {
+      expect(signupSourcePhrase({ leadSource: 'qr_code', qrTag: {} })).toBe('via QR code');
+    });
+    it('handles leadSource qr_code with no tag (deleted QR)', () => {
+      expect(signupSourcePhrase({ leadSource: 'qr_code', qrTag: null })).toBe('via QR code');
+    });
+  });
+
+  describe('referral', () => {
+    it('names the referrer when known', () => {
+      expect(
+        signupSourcePhrase({ leadSource: 'referral', sourceMetadata: { referral: { referrerName: 'Jane Tan' } } })
+      ).toBe('via referral from Jane Tan');
+    });
+    it('falls back to plain referral when name unknown', () => {
+      expect(signupSourcePhrase({ leadSource: 'referral', sourceMetadata: { referral: {} } })).toBe('via referral');
+    });
+    it('wins over a stale UTM capture (explicit intent)', () => {
+      expect(
+        signupSourcePhrase({
+          leadSource: 'referral',
+          sourceMetadata: { utm: { utm_source: 'tiktok' }, referral: { referrerName: 'Bob' } },
+        })
+      ).toBe('via referral from Bob');
+    });
+  });
+
+  describe('voice call', () => {
+    it('labels call_bot leads', () => {
+      expect(signupSourcePhrase({ leadSource: 'call_bot' })).toBe('via voice call');
+    });
+  });
+
+  describe('paid ads (utm_source)', () => {
+    it('TikTok (the reported bug — was "Unknown QR")', () => {
+      expect(signupSourcePhrase({ leadSource: 'website', sourceMetadata: { utm: { utm_source: 'tiktok' } } })).toBe(
+        'via TikTok ad'
+      );
+    });
+    it.each(['tt', 'tiktok_ads', 'tiktok-ads', 'TikTokAds'])('TikTok alias %s', (src) => {
+      expect(signupSourcePhrase({ leadSource: 'website', sourceMetadata: { utm: { utm_source: src } } })).toBe(
+        'via TikTok ad'
+      );
+    });
+    it.each(['facebook', 'fb', 'instagram', 'ig', 'meta'])('Meta alias %s', (src) => {
+      expect(signupSourcePhrase({ leadSource: 'website', sourceMetadata: { utm: { utm_source: src } } })).toBe(
+        'via Meta ad'
+      );
+    });
+    it('title-cases an unknown utm_source', () => {
+      expect(signupSourcePhrase({ leadSource: 'website', sourceMetadata: { utm: { utm_source: 'google' } } })).toBe(
+        'via Google ad'
+      );
+    });
+  });
+
+  describe('click-ids only (no utm) → "click", not "ad"', () => {
+    it('ttclid → TikTok click', () => {
+      expect(signupSourcePhrase({ leadSource: 'website', sourceMetadata: { ttclid: 'abc' } })).toBe('via TikTok click');
+    });
+    it('fbc → Meta click', () => {
+      expect(signupSourcePhrase({ leadSource: 'website', sourceMetadata: { fbc: 'fb.1.x' } })).toBe('via Meta click');
+    });
+    it('fbclid in eventSourceUrl → Meta click', () => {
+      expect(
+        signupSourcePhrase({ leadSource: 'website', sourceMetadata: { eventSourceUrl: 'https://redeem.sg/LeadCapture?fbclid=z' } })
+      ).toBe('via Meta click');
+    });
+    it('ttclid in eventSourceUrl → TikTok click', () => {
+      expect(
+        signupSourcePhrase({ leadSource: 'website', sourceMetadata: { eventSourceUrl: 'https://redeem.sg/LeadCapture?ttclid=z' } })
+      ).toBe('via TikTok click');
+    });
+    it('Meta wins when both click-ids present', () => {
+      expect(signupSourcePhrase({ leadSource: 'website', sourceMetadata: { fbc: 'fb.1.x', ttclid: 'abc' } })).toBe(
+        'via Meta click'
+      );
+    });
+    it('utm beats a bare click-id', () => {
+      expect(
+        signupSourcePhrase({ leadSource: 'website', sourceMetadata: { utm: { utm_source: 'tiktok' }, ttclid: 'abc' } })
+      ).toBe('via TikTok ad');
+    });
+  });
+
+  describe('plain form / fallback', () => {
+    it('website with no attribution → web form', () => {
+      expect(signupSourcePhrase({ leadSource: 'website' })).toBe('via web form');
+    });
+    it('missing leadSource → web form', () => {
+      expect(signupSourcePhrase({})).toBe('via web form');
+      expect(signupSourcePhrase()).toBe('via web form');
+    });
+    it('other source surfaces readably', () => {
+      expect(signupSourcePhrase({ leadSource: 'lead_import' })).toBe('via lead import');
+    });
+  });
+});
+
+describe('signupActivityDescription', () => {
+  it('builds the full line for the reported TikTok lead', () => {
+    expect(
+      signupActivityDescription('Redeem $10 Fairprice Voucher', {
+        leadSource: 'website',
+        sourceMetadata: { utm: { utm_source: 'tiktok' } },
+      })
+    ).toBe('Prospect signed up for Redeem $10 Fairprice Voucher campaign via TikTok ad');
+  });
+  it('falls back to Unknown Campaign', () => {
+    expect(signupActivityDescription(null, { leadSource: 'website' })).toBe(
+      'Prospect signed up for Unknown Campaign campaign via web form'
+    );
+  });
+  it('clamps to 255 chars (column is STRING(255)) for a long campaign + utm_source', () => {
+    const desc = signupActivityDescription('C'.repeat(100), {
+      leadSource: 'website',
+      sourceMetadata: { utm: { utm_source: 'x'.repeat(128) } },
+    });
+    expect(desc.length).toBeLessThanOrEqual(255);
+  });
+});


### PR DESCRIPTION
## Problem
A prospect's **Activity History** line read *"… via Unknown QR QR code"* even for leads that came via a TikTok/Meta ad or a plain web form. The "created" activity string was hardcoded to `via {qrTag||'Unknown QR'} QR code` for **every** lead, so any lead with no QR tag (i.e. all ad/form/referral leads) showed "Unknown QR" — despite correct attribution sitting in `sourceMetadata` (e.g. `utm_source=tiktok`, `ttclid`).

This is a **separate code path** from the admin Source-column badge (that already shows `TIKTOK AD` via `normalizeProspect.js`, merged in #49). This PR fixes the persisted activity text.

## Fix
- **`backend/src/utils/sourceLabel.js`** — new helper that derives a human phrase from `leadSource` / `qrTag` / `sourceMetadata`, mirroring the frontend Source-column vocabulary: `referral` > QR scan > voice call > `{platform} ad` (utm_source) > `{platform} click` (ttclid/fbc) > web form.
- **`prospectService.createProspect`** — builds the description via the helper.
- **Migration `038`** — backfills existing mislabeled rows using the same helper (auto-runs on deploy). Idempotent; never matches Retell `"Lead created from Retell AI call …"` rows; strips the exact reconstructed old suffix (no fragile regex).

## Safety / review
- Dry-ran the backfill **read-only against prod**: 41 rows → 28 Meta ad, 7 TikTok ad, 3 referral-named, 2 Meta click, 1 referral. Zero "Unknown QR" remain.
- 3 rounds of Codex review; 3 findings folded in (description `STRING(255)` overflow that could roll back a lead → clamped; unnamed-QR backfill consistency; campaign-name parse corruption → exact-suffix strip). Final pass clean.
- 31 new unit tests pass; frontend `normalizeProspect` 54/54; migration static checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)