### PR TITLE
feat(campaigns): Campaign Launch Workspace + campaign-first credits (dark-launched)

### DIFF
--- a/backend/src/controllers/campaignController.js
+++ b/backend/src/controllers/campaignController.js
@@ -1,5 +1,6 @@
-import { asyncHandler } from '../middleware/errorHandler.js';
+import { asyncHandler, AppError } from '../middleware/errorHandler.js';
 import * as campaignService from '../services/campaignService.js';
+import * as leadPackageService from '../services/leadPackageService.js';
 import { loadCampaignReadiness } from '../services/campaignReadinessService.js';
 import { loadQuizAnalytics } from '../services/quizAnalyticsService.js';
 
@@ -56,6 +57,50 @@ export const getCampaignReadiness = asyncHandler(async (req, res) => {
   const readiness = await loadCampaignReadiness(req.params.id);
 
   res.json({ success: true, data: { readiness } });
+});
+
+// --- Campaign Launch Workspace (admin, mounted under /api/admin/campaigns) ---
+
+export const getDeliveryPool = asyncHandler(async (req, res) => {
+  const data = await leadPackageService.getCampaignDeliveryPool(req.params.id);
+  res.json({ success: true, data });
+});
+
+export const bulkAssignDeliveryPool = asyncHandler(async (req, res) => {
+  const { packageId, agentIds } = req.body;
+  const data = await leadPackageService.bulkAssignPackage({
+    campaignId: req.params.id,
+    packageId,
+    agentIds,
+  });
+  res.status(201).json({ success: true, message: 'Package assigned to agents', data });
+});
+
+export const setLaunchState = asyncHandler(async (req, res) => {
+  const { state, force } = req.body;
+  if (!['active', 'paused'].includes(state)) {
+    throw new AppError('state must be "active" or "paused"', 400);
+  }
+
+  // Readiness gate on activate: block go-live when the campaign would drop
+  // leads (empty funded pool / webhook off), unless explicitly forced.
+  if (state === 'active' && !force) {
+    const readiness = await loadCampaignReadiness(req.params.id);
+    if (readiness.applicable && !readiness.ready) {
+      return res.status(409).json({
+        success: false,
+        message: 'Campaign is not ready to go live. Resolve the issues or force activation.',
+        data: { readiness },
+      });
+    }
+  }
+
+  const campaign = await campaignService.setCampaignLaunchState(req.params.id, state, req);
+  res.json({
+    success: true,
+    message: state === 'active' ? 'Campaign activated' : 'Campaign paused',
+    data: { campaign },
+  });
 });
 
 export const getCampaignQuizAnalytics = asyncHandler(async (req, res) => {

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -78,7 +78,9 @@ export const schemas = {
     commission_amount_fleet: Joi.number().min(0).optional().allow(null),
     defaultAssignmentMode: Joi.string().valid('direct', 'round_robin').optional(),
     ad_playlist: Joi.array().items(Joi.object()).optional(),
-    enforceLeadQuota: Joi.boolean().optional()
+    enforceLeadQuota: Joi.boolean().optional(),
+    metaPixelId: Joi.string().max(64).optional().allow(null, ''),
+    tiktokPixelId: Joi.string().max(64).optional().allow(null, '')
   }),
 
   campaignUpdate: Joi.object({
@@ -95,7 +97,9 @@ export const schemas = {
     commission_amount_fleet: Joi.number().min(0).optional().allow(null),
     defaultAssignmentMode: Joi.string().valid('direct', 'round_robin').optional(),
     ad_playlist: Joi.array().items(Joi.object()).optional(),
-    enforceLeadQuota: Joi.boolean().optional()
+    enforceLeadQuota: Joi.boolean().optional(),
+    metaPixelId: Joi.string().max(64).optional().allow(null, ''),
+    tiktokPixelId: Joi.string().max(64).optional().allow(null, '')
   }).min(1),
 
   // Car schemas

--- a/backend/src/routes/adminCampaigns.js
+++ b/backend/src/routes/adminCampaigns.js
@@ -1,0 +1,22 @@
+import express from 'express';
+import { authenticateToken, requireAdmin } from '../middleware/auth.js';
+import * as campaignController from '../controllers/campaignController.js';
+
+// Campaign Launch Workspace APIs. Mounted under /api/admin/campaigns so
+// internalRouteHostGuard (which blocks the /api/admin prefix) keeps these
+// admin-only endpoints unreachable from the redeem.sg public site. Auto-loaded
+// by routes/index.js via this meta export.
+export const meta = { path: '/api/admin/campaigns' };
+
+const router = express.Router();
+
+// Campaign-first delivery pool: funded agents + remaining credits + held count.
+router.get('/:id/delivery-pool', authenticateToken, requireAdmin, campaignController.getDeliveryPool);
+
+// Bulk-assign one campaign package to many agents (idempotent, one release sweep).
+router.post('/:id/delivery-pool/assign', authenticateToken, requireAdmin, campaignController.bulkAssignDeliveryPool);
+
+// Activate / pause a campaign (readiness-gated on activate; preserves status semantics).
+router.patch('/:id/launch-state', authenticateToken, requireAdmin, campaignController.setLaunchState);
+
+export default router;

--- a/backend/src/services/campaignService.js
+++ b/backend/src/services/campaignService.js
@@ -182,6 +182,8 @@ export async function createCampaign(body, user) {
   if (commission_amount_fleet !== undefined) campaignData.commission_amount_fleet = commission_amount_fleet;
   if (defaultAssignmentMode !== undefined) campaignData.defaultAssignmentMode = defaultAssignmentMode;
   if (enforceLeadQuota !== undefined) campaignData.enforceLeadQuota = enforceLeadQuota;
+  if (body.metaPixelId !== undefined) campaignData.metaPixelId = body.metaPixelId || null;
+  if (body.tiktokPixelId !== undefined) campaignData.tiktokPixelId = body.tiktokPixelId || null;
 
   const campaign = await Campaign.create(campaignData);
 
@@ -244,6 +246,8 @@ export async function updateCampaign(id, body, req) {
   if (commission_amount_fleet !== undefined) updateData.commission_amount_fleet = commission_amount_fleet;
   if (defaultAssignmentMode !== undefined) updateData.defaultAssignmentMode = defaultAssignmentMode;
   if (enforceLeadQuota !== undefined) updateData.enforceLeadQuota = enforceLeadQuota;
+  if (body.metaPixelId !== undefined) updateData.metaPixelId = body.metaPixelId || null;
+  if (body.tiktokPixelId !== undefined) updateData.tiktokPixelId = body.tiktokPixelId || null;
 
   await campaign.update(updateData);
 
@@ -274,6 +278,37 @@ export async function updateCampaign(id, body, req) {
   plain.ad_playlist = mediaItemsToPlaylist(plain.mediaItems);
   plain.assigned_agents = agentRows.map(r => r.agentId);
   return plain;
+}
+
+/**
+ * Set a campaign's launch state to 'active' or 'paused'.
+ *
+ * Dedicated path (NOT updateCampaign) so we never trip its is_active→draft
+ * mapping: pausing sets status='paused' (not 'draft'). Rejects archived
+ * campaigns (status changes there go through restore/archive), and fans out a
+ * device manifest refresh exactly like updateCampaign — PHV tablets only serve
+ * status:'active' campaigns, so activate/pause must re-notify devices.
+ * Readiness gating (block activate when not ready) is enforced by the caller
+ * (controller) so it can return the readiness payload on a 409.
+ */
+export async function setCampaignLaunchState(id, state, req) {
+  if (!['active', 'paused'].includes(state)) {
+    throw new AppError('Invalid launch state', 400);
+  }
+  const where = buildOwnerWhere(req, { id });
+  const campaign = await Campaign.findOne({ where });
+  if (!campaign) throw new AppError('Campaign not found or access denied', 404);
+  if (campaign.status === 'archived') {
+    throw new AppError('Archived campaigns cannot be activated or paused. Restore it first.', 400);
+  }
+
+  const isActive = state === 'active';
+  await campaign.update({ is_active: isActive, status: isActive ? 'active' : 'paused' });
+
+  // Fan-out: refresh device manifests (same as updateCampaign content changes).
+  await notifyDevices(id);
+
+  return campaign.toJSON();
 }
 
 /**

--- a/backend/src/services/leadPackageService.js
+++ b/backend/src/services/leadPackageService.js
@@ -1,4 +1,5 @@
-import { LeadPackage, LeadPackageAssignment, User, Campaign } from '../models/index.js';
+import { Op } from 'sequelize';
+import { LeadPackage, LeadPackageAssignment, User, Campaign, Prospect, sequelize } from '../models/index.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
 
@@ -243,4 +244,184 @@ export async function deletePackage(id) {
       message: 'Package deleted successfully'
     };
   }
+}
+
+/**
+ * Pure aggregation of active package assignments into per-agent delivery-pool
+ * rows (sum remaining credits, list assignments, track last assignment). Kept
+ * pure + exported so it unit-tests without a DB. Accepts Sequelize instances or
+ * plain objects (reads `.agent`, `.leadsRemaining`, `.leadPackageId`, etc.).
+ */
+export function aggregateDeliveryPoolAgents(assignments = []) {
+  const byAgent = new Map();
+  for (const a of assignments) {
+    const agent = a.agent;
+    if (!agent) continue;
+    const entry = byAgent.get(agent.id) || {
+      agentId: agent.id,
+      fullName: agent.fullName || `${agent.firstName || ''} ${agent.lastName || ''}`.trim() || null,
+      email: agent.email || null,
+      phone: agent.phone || null,
+      remainingCredits: 0,
+      lastPackageAssignedAt: null,
+      assignments: [],
+    };
+    entry.remainingCredits += a.leadsRemaining;
+    entry.assignments.push({
+      id: a.id,
+      packageId: a.leadPackageId,
+      packageName: a.package?.name || null,
+      leadsRemaining: a.leadsRemaining,
+      leadsTotal: a.leadsTotal,
+      purchaseDate: a.purchaseDate,
+    });
+    if (!entry.lastPackageAssignedAt || new Date(a.purchaseDate) > new Date(entry.lastPackageAssignedAt)) {
+      entry.lastPackageAssignedAt = a.purchaseDate;
+    }
+    byAgent.set(agent.id, entry);
+  }
+  return [...byAgent.values()];
+}
+
+/**
+ * Campaign-first delivery pool: the agents actually in this campaign's lead
+ * round-robin, with remaining credits. Mirrors the live routing pool
+ * (systemAgent.resolveLeadRouting step 4 / campaignReadinessService): active
+ * LeadPackageAssignments for packages whose campaignId = :campaignId, restricted
+ * to active role:'agent' users. NOT CampaignAgentAssignment (which the router
+ * never consults).
+ */
+export async function getCampaignDeliveryPool(campaignId) {
+  const campaign = await Campaign.findByPk(campaignId, {
+    attributes: ['id', 'name', 'is_active', 'status', 'enforceLeadQuota'],
+  });
+  if (!campaign) throw new AppError('Campaign not found', 404);
+
+  const packages = await LeadPackage.findAll({
+    where: { campaignId },
+    attributes: ['id', 'name', 'leadCount', 'price', 'status'],
+    order: [['createdAt', 'DESC']],
+  });
+  const packageIds = packages.map((p) => p.id);
+
+  let agents = [];
+  if (packageIds.length > 0) {
+    const assignments = await LeadPackageAssignment.findAll({
+      where: { leadPackageId: { [Op.in]: packageIds }, status: 'active' },
+      include: [
+        {
+          model: User,
+          as: 'agent',
+          where: { role: 'agent', isActive: true },
+          required: true,
+          attributes: ['id', 'firstName', 'lastName', 'fullName', 'email', 'phone'],
+        },
+        { model: LeadPackage, as: 'package', attributes: ['id', 'name'] },
+      ],
+      order: [['purchaseDate', 'DESC']],
+    });
+
+    agents = aggregateDeliveryPoolAgents(assignments);
+  }
+
+  const remainingCredits = agents.reduce((sum, ag) => sum + ag.remainingCredits, 0);
+  const fundedAgents = agents.filter((a) => a.remainingCredits > 0).length;
+
+  // Internally-releasable holds only — external-buyer holds
+  // (no_funded_external_buyer) must never release to Lyfe, so they don't count
+  // toward this internal delivery pool.
+  const heldLeads = await Prospect.count({
+    where: { campaignId, quarantinedAt: { [Op.ne]: null }, quarantineReason: 'no_funded_agent' },
+  });
+
+  return {
+    campaign: {
+      id: campaign.id,
+      name: campaign.name,
+      is_active: campaign.is_active,
+      status: campaign.status,
+      enforceLeadQuota: campaign.enforceLeadQuota,
+    },
+    totals: { fundedAgents, remainingCredits, heldLeads },
+    packages: packages.map((p) => p.toJSON()),
+    agents,
+  };
+}
+
+/**
+ * Bulk-assign one campaign package to many agents (campaign-first funding).
+ * Race-safe: a per-package advisory xact lock serializes concurrent admin
+ * assigns so the skip-existing read + insert can't duplicate active assignments
+ * (no unique (agentId,leadPackageId) index exists). Idempotent — agents already
+ * holding an active assignment for this package are skipped, not duplicated.
+ * Fires exactly ONE releaseSweep after commit (not per agent).
+ */
+export async function bulkAssignPackage({ campaignId, packageId, agentIds }) {
+  if (!campaignId || !packageId || !Array.isArray(agentIds) || agentIds.length === 0) {
+    throw new AppError('campaignId, packageId and a non-empty agentIds array are required', 400);
+  }
+  const uniqueAgentIds = [...new Set(agentIds)];
+
+  const pkg = await LeadPackage.findByPk(packageId);
+  if (!pkg) throw new AppError('Package not found', 404);
+  if (String(pkg.campaignId) !== String(campaignId)) {
+    throw new AppError('Package does not belong to this campaign', 400);
+  }
+
+  const validAgents = await User.findAll({
+    where: { id: { [Op.in]: uniqueAgentIds }, role: 'agent', isActive: true },
+    attributes: ['id'],
+  });
+  const validIds = validAgents.map((a) => a.id);
+  const invalid = uniqueAgentIds.filter((id) => !validIds.includes(id));
+
+  let assignedIds = [];
+  let skipped = [];
+  if (validIds.length > 0) {
+    await sequelize.transaction(async (t) => {
+      await sequelize.query('SELECT pg_advisory_xact_lock(hashtext(:k))', {
+        replacements: { k: `lpa:${packageId}` },
+        transaction: t,
+      });
+
+      const existing = await LeadPackageAssignment.findAll({
+        where: { leadPackageId: packageId, agentId: { [Op.in]: validIds }, status: 'active' },
+        attributes: ['agentId'],
+        transaction: t,
+      });
+      const existingIds = new Set(existing.map((e) => e.agentId));
+      skipped = validIds.filter((id) => existingIds.has(id));
+      assignedIds = validIds.filter((id) => !existingIds.has(id));
+
+      if (assignedIds.length > 0) {
+        await LeadPackageAssignment.bulkCreate(
+          assignedIds.map((agentId) => ({
+            agentId,
+            leadPackageId: packageId,
+            leadsTotal: pkg.leadCount,
+            leadsRemaining: pkg.leadCount,
+            priceSnapshot: pkg.price,
+            status: 'active',
+            purchaseDate: new Date(),
+          })),
+          { transaction: t }
+        );
+      }
+    });
+  }
+
+  if (assignedIds.length > 0 && pkg.campaignId) {
+    import('./releaseSweep.js')
+      .then((m) => m.sweepCampaign(pkg.campaignId))
+      .catch((err) => logger.error('[ReleaseSweep] bulkAssignPackage trigger failed', { error: err?.message || String(err) }));
+  }
+
+  return {
+    assigned: assignedIds.length,
+    assignedAgentIds: assignedIds,
+    skipped,
+    invalid,
+    leadsPerAgent: pkg.leadCount,
+    packageName: pkg.name,
+  };
 }

--- a/backend/src/services/trackerService.js
+++ b/backend/src/services/trackerService.js
@@ -159,7 +159,7 @@ export async function resolveSession(sid, atkCookie) {
     // — the QR-scan path (this fn) and the direct campaign_id link path both
     // hydrate the same form.
     campaign = await Campaign.findByPk(qrTag.campaignId, {
-      attributes: ['id', 'name', 'design_config', 'is_active', 'metaPixelId', 'min_age', 'max_age']
+      attributes: ['id', 'name', 'design_config', 'is_active', 'metaPixelId', 'tiktokPixelId', 'min_age', 'max_age']
     });
   }
 

--- a/backend/src/tests/deliveryPool.test.js
+++ b/backend/src/tests/deliveryPool.test.js
@@ -1,0 +1,59 @@
+import { aggregateDeliveryPoolAgents } from '../services/leadPackageService.js';
+
+// Pure aggregation logic for the campaign-first delivery pool — DB-free.
+describe('leadPackageService.aggregateDeliveryPoolAgents', () => {
+  const mk = (over = {}) => ({
+    id: 'x1',
+    leadPackageId: 'p1',
+    leadsRemaining: 10,
+    leadsTotal: 10,
+    purchaseDate: '2026-01-01T00:00:00.000Z',
+    agent: { id: 'agent1', firstName: 'A', lastName: 'B', email: 'a@b.com', phone: '6512345678' },
+    package: { name: 'Gold' },
+    ...over,
+  });
+
+  it('returns an empty array for no assignments', () => {
+    expect(aggregateDeliveryPoolAgents([])).toEqual([]);
+    expect(aggregateDeliveryPoolAgents()).toEqual([]);
+  });
+
+  it("sums remaining credits across one agent's assignments", () => {
+    const out = aggregateDeliveryPoolAgents([
+      mk({ id: 'x1', leadsRemaining: 10 }),
+      mk({ id: 'x2', leadsRemaining: 5, leadPackageId: 'p2' }),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].remainingCredits).toBe(15);
+    expect(out[0].assignments).toHaveLength(2);
+  });
+
+  it('groups multiple agents separately', () => {
+    const out = aggregateDeliveryPoolAgents([
+      mk({ agent: { id: 'agentA' } }),
+      mk({ agent: { id: 'agentB' } }),
+    ]);
+    expect(out.map((a) => a.agentId).sort()).toEqual(['agentA', 'agentB']);
+  });
+
+  it('tracks the latest purchaseDate as lastPackageAssignedAt', () => {
+    const out = aggregateDeliveryPoolAgents([
+      mk({ id: 'old', purchaseDate: '2026-01-01T00:00:00.000Z' }),
+      mk({ id: 'new', purchaseDate: '2026-03-01T00:00:00.000Z' }),
+    ]);
+    expect(new Date(out[0].lastPackageAssignedAt).toISOString()).toBe('2026-03-01T00:00:00.000Z');
+  });
+
+  it('skips rows with no agent', () => {
+    const out = aggregateDeliveryPoolAgents([mk({ agent: null }), mk({ agent: { id: 'agentX' } })]);
+    expect(out).toHaveLength(1);
+    expect(out[0].agentId).toBe('agentX');
+  });
+
+  it('derives fullName from first/last when fullName is absent', () => {
+    const out = aggregateDeliveryPoolAgents([
+      mk({ agent: { id: 'agentY', firstName: 'Jane', lastName: 'Doe' } }),
+    ]);
+    expect(out[0].fullName).toBe('Jane Doe');
+  });
+});

--- a/docs/plans/campaign-launch-workspace.md
+++ b/docs/plans/campaign-launch-workspace.md
@@ -1,0 +1,86 @@
+# Plan — Campaign Launch Workspace + Campaign-First Credits
+
+> Status: planning. Source: audit (2026-06-20) + Codex 5.5 xhigh plan, reviewed against the codebase by Claude. This doc is the build spec.
+
+## Goal
+Replace today's fragmented 5-page campaign launch flow (`AdminCampaigns` → `AdminCampaignForm` → `AdminCampaignDesigner` → `AdminLeadPackages` → `AdminAgents`) with **one tabbed "Launch a Campaign" workspace**, and make lead **credits campaign-first** (the campaign shows its own funded-agent pool + remaining credits + bulk top-up).
+
+## Guiding constraints
+- **`main` deploys mktr.sg to production.** Ship **dark**: workspace routes always mounted, but list/nav entry points gated behind `VITE_CAMPAIGN_WORKSPACE_ENABLED` (default OFF). Flipping the flag on the `mktr-platform` static site + redeploy makes it live. Old pages stay fully functional → trivial rollback.
+- **Additive only.** No destructive DB drops. Live routing/credits model (`systemAgent.resolveLeadRouting`, `LeadPackageAssignment.leadsRemaining`) is untouched.
+- New admin APIs live under **`/api/admin/campaigns`** so `internalRouteHostGuard` (blocks `/api/admin/*` from redeem.sg) protects them automatically. Auto-loaded via `export const meta = { path: '/api/admin/campaigns' }`.
+
+## 1. Current-state map (verified)
+| Flow | Code | Disposition |
+|---|---|---|
+| List + type picker | `AdminCampaigns.jsx:90` (`CampaignTypeSelectionDialog` → `/admin/campaigns/new?type=`) | Keep list; repoint create/edit/design actions to workspace (flag-gated) |
+| Basic form | `AdminCampaignForm.jsx:27/141` (name/type/dates/age/commission/PHV media) | Extract field UI into Details tab; keep page mounted for rollback |
+| Designer | `AdminCampaignDesigner.jsx:17` (`DesignEditor` + `CampaignReadinessBanner` + preview) | Reuse `DesignEditor`/`CampaignReadinessBanner` in Design + Launch tabs; keep page for rollback |
+| Package templates | `AdminLeadPackages.jsx:40` + `LeadPackageTemplateDialog` | Keep as global template CRUD; reuse dialog with `campaignId`/`lockCampaign` |
+| Agent funding | `AdminAgents.jsx:160` → `AssignPackageDialog` (single agent, `POST /lead-packages/assign`) | Keep as agent-maintenance; add campaign-first bulk pool in workspace |
+| Routing/credits | `systemAgent.js:88/114`, `LeadPackageAssignment.leadsRemaining` | Untouched. Pool aggregates `LeadPackageAssignment` by `LeadPackage.campaignId`, **not** `CampaignAgentAssignment` |
+
+## 2. Target UX — `AdminCampaignWorkspace.jsx`
+Routes: `/admin/campaigns/new` (create mode) and `/admin/campaigns/:id/workspace?tab=` (edit mode), `ProtectedRoute requiredRole="admin"`.
+Tabs (non-Details tabs disabled until the campaign has an `id`):
+1. **Details** — reuse `AdminCampaignForm` field set (name, dates, age, commissions, PHV media) + new: `enforceLeadQuota` toggle, `metaPixelId`, `tiktokPixelId`. **Create saves `is_active:false` (draft)** so a campaign never goes live before it's funded. On first save → navigate to `/admin/campaigns/:id/workspace?tab=design`.
+2. **Design** — embed `DesignEditor` (new optional `heightClass` prop so it fits the tab) + keep preview action from `AdminCampaignDesigner`.
+3. **Delivery Pool** *(headline)* — new `CampaignDeliveryPoolTab`: table of funded agents (remaining credits, last package assigned, held count), **multi-select agents + pick/create a campaign-locked package → bulk assign**, per-agent top-up (reuse `PATCH /lead-packages/assignments/:id`).
+4. **Sources** — embed `CampaignQRManager` (new `embedded` prop hides Back + page chrome) + copy LeadCapture link via `customerLeadCaptureUrl(campaignId, …, resolveCustomerHost(design_config.customerHost))`.
+5. **Launch** — reuse `CampaignReadinessBanner` + Activate/Pause buttons (calls launch-state endpoint; blocks activate when not ready unless forced).
+
+**Scope note:** `externalEligible` (MKTR-Leads external-buyer path) is intentionally **not** surfaced — that pool is inert/not live; exposing it would mislead. Deferred.
+
+## 3. Backend changes
+New file `backend/src/routes/adminCampaigns.js`, `export const meta = { path: '/api/admin/campaigns' }`, all routes `authenticateToken` + `requireAdmin`.
+
+1. **`GET /api/admin/campaigns/:id/delivery-pool`** → `campaignController.getDeliveryPool` → `leadPackageService.getCampaignDeliveryPool(campaignId)`.
+   - Aggregate active `LeadPackageAssignment` (leadsRemaining>0) whose `LeadPackage.campaignId = :id`, grouped by agent (active `role:'agent'` only — mirror `campaignReadinessService:128`). Include campaign packages, totals (`fundedAgents`, `remainingCredits`, `heldLeads = Prospect.count({campaignId, quarantinedAt≠null})`).
+2. **`POST /api/admin/campaigns/:id/delivery-pool/assign`** → `bulkAssignPackage({ campaignId, packageId, agentIds[] })`.
+   - Validate package.campaignId === :id; validate each agent active `role:'agent'`; bulk-create assignments (`leadsTotal=leadsRemaining=pkg.leadCount`, `priceSnapshot`); **one** `sweepCampaign(campaignId)` post-commit (not per-agent). All-or-none in a transaction. Skip agents who already have an active assignment for that package (idempotent) — report skipped.
+3. **`PATCH /api/admin/campaigns/:id/launch-state`** → `{ state: 'active'|'paused', force?:bool }` → `campaignService.setCampaignLaunchState`.
+   - On `active`: `loadCampaignReadiness(id)`; if not `ready` and not `force` → 409 `{ readiness }`. Else set `is_active=true,status='active'`. On `paused`: `is_active=false,status='paused'` (dedicated method — do **not** reuse `Campaign.update`, which maps inactive→draft).
+4. **Persist pixels:** extend `schemas.campaignCreate`/`campaignUpdate` (`validation.js`) + `campaignService.createCampaign`/`updateCampaign` to accept/persist `metaPixelId`, `tiktokPixelId` (string≤64, nullable). `enforceLeadQuota` already wired.
+5. *(Optional bonus)* `trackerService` QR-session hydration: add `tiktokPixelId` alongside `metaPixelId`.
+
+## 4. Frontend changes
+1. `src/pages/AdminCampaignWorkspace.jsx` + lazy import + routes in `index.jsx` (always mounted).
+2. `CampaignEntity` (client.js:435): `getDeliveryPool(id)`, `bulkAssignDeliveryPool(id, payload)`, `setLaunchState(id, payload)` → call `/admin/campaigns/:id/...`.
+3. Hooks (`useCampaignsQuery.js`): `useCampaignDeliveryPool(id)`, `useBulkAssignCampaignPackage(id)`, `useSetCampaignLaunchState(id)`; invalidate `['campaignDeliveryPool',id]`, `['campaigns']`, `['leadPackages']`, `['agents']`.
+4. `CampaignDeliveryPoolTab.jsx` (new). Reuse `LeadPackageTemplateDialog` (+`campaignId`/`lockCampaign`), `ManagePackages`-style credit edit.
+5. Embedding props: `DesignEditor` `heightClass?`, `CampaignQRManager` `embedded?`.
+6. Nav (flag-gated, `VITE_CAMPAIGN_WORKSPACE_ENABLED`): `AdminCampaigns` create/edit/design actions → workspace tabs when ON; unchanged when OFF.
+
+## 5. Migration / coexistence
+No DB migration (quota/pixels/external already shipped + nullable/defaulted). Lead capture (`POST /api/prospects`) and routing unchanged. Brand split intact: SPA `ProtectedRoute` redirects redeem builds; backend `/api/admin/*` host-guarded. Old pages remain mounted.
+
+## 6. Phasing (one branch, commit per phase)
+1. Backend: pool read + bulk assign + launch-state + pixel persistence + Jest tests.
+2. Workspace shell + Details + Design tabs (routes always on; nav still old).
+3. Delivery Pool tab + API client + hooks.
+4. Sources + Launch tabs.
+5. Flag-gated nav switch in `AdminCampaigns` + Vitest tests.
+
+## 7. Testing
+- Backend Jest: pool aggregation (active-only, campaign-scoped, inactive agents excluded, held count); bulk assign (package/campaign mismatch → error, inactive/missing agents, all-or-none, exactly one sweep, idempotent skip); launch-state (not-ready→409, force→active, pause→paused).
+- Frontend Vitest: tabs render + non-Details disabled w/o id; Details payload carries `enforceLeadQuota`/pixels; pool multi-select calls `bulkAssignDeliveryPool`; QR embedded hides Back.
+- Manual: draft → design → fund 3 agents → activate → submit leads → round-robin + credit decrement; hard-quota hold → top-up release.
+- CI is chronically red on pre-existing suites; will report only the suites I touch, won't claim full green.
+
+## 8. Risks & rollback
+- **Prod exposure:** mitigated by `VITE_CAMPAIGN_WORKSPACE_ENABLED` default OFF (code ships dark) + old pages alive.
+- **Bulk assign over-sweeping:** one post-commit sweep, not per-agent.
+- **Launch semantics drift:** dedicated launch-state method; never touch `Campaign.update`'s inactive→draft mapping.
+- **Rollback:** unset/leave flag OFF, or revert the nav commit. Backend endpoints are additive + unused when nav is off.
+
+## 9. Review fixes (Codex review of this plan — incorporated)
+1. **launch-state side effects (BLOCKER):** `setCampaignLaunchState` must reject `status==='archived'` (400), set only `active`/`paused` (never draft), and call `notifyDevices(campaignId)` after the status change (PHV tablets serve only `status:'active'`; manifest refresh would otherwise be skipped). `notifyDevices` is already in `campaignService.js` — call it directly.
+2. **DesignEditor unmount drops unsaved edits:** Radix `TabsContent` unmounts inactive tabs by default. Use `forceMount` on the **Design** tab so `DesignEditor` stays mounted (keeps its internal dirty/`beforeunload` state); hide via CSS when inactive. Add `heightClass` prop that **replaces** the hard-coded `h-[calc(100vh-8rem)]` root class at `DesignEditor.jsx:137` (default preserves current value).
+3. **Bulk-assign race-safety:** `LeadPackageAssignment` has no unique `(agentId,leadPackageId)` index. Do NOT add a unique index (existing rows may already duplicate → migration risk). Instead wrap bulk-assign in a transaction holding a `pg_advisory_xact_lock(hashtext('lpa:'||:packageId))`, then re-read existing active assignments for that package and skip agents already assigned, then `bulkCreate` the rest. Report `skipped`.
+4. **Held count:** count only internally-releasable holds: `Prospect.count({ campaignId, quarantinedAt: { [Op.ne]: null }, quarantineReason: 'no_funded_agent' })` (exclude `no_funded_external_buyer`).
+5. **Frontend service layer:** add `getCampaignDeliveryPool`/`bulkAssignCampaignPackage`/`setCampaignLaunchState` to `src/services/campaignService.js` (the hooks import that module, not the entity directly), each delegating to the new `CampaignEntity` methods.
+6. **Locked package dialog + draft campaigns:** `LeadPackageTemplateDialog` fetches only ACTIVE campaigns, but workspace campaigns start as drafts. In `lockCampaign` mode: prefill `campaignId` from props, hide/disable the campaign select, and don't depend on the active-campaign list.
+7. **TikTok QR hydration:** add `tiktokPixelId` to the tracker QR-session campaign attributes (`trackerService.js:161`) — `LeadCapture` reads `campaign.tiktokPixelId` for browser events; QR-sourced traffic currently misses it. (Promoted from optional to should-fix.)
+8. **Preserve campaign type on create:** workspace create mode must read `?type=` from search params and submit it on the first draft save, else backend silently defaults to `lead_generation`.
+
+Verdict accepted: not shippable as originally written; sections above resolve the blocker + should-fixes before implementation.

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -461,6 +461,22 @@ class CampaignEntity extends BaseEntity {
  const response = await apiClient.delete(`${this.endpoint}/${id}/permanent`);
  return response.data;
  }
+
+ // --- Campaign Launch Workspace (admin-only, /api/admin/campaigns) ---
+ async getDeliveryPool(id) {
+ const response = await apiClient.get(`/admin/campaigns/${id}/delivery-pool`);
+ return response.data?.data || response.data;
+ }
+
+ async bulkAssignDeliveryPool(id, payload) {
+ const response = await apiClient.post(`/admin/campaigns/${id}/delivery-pool/assign`, payload);
+ return response.data?.data || response.data;
+ }
+
+ async setLaunchState(id, payload) {
+ const response = await apiClient.patch(`/admin/campaigns/${id}/launch-state`, payload);
+ return response.data;
+ }
 }
 
 // Prospect Entity

--- a/src/components/campaigns/DesignEditor.jsx
+++ b/src/components/campaigns/DesignEditor.jsx
@@ -43,7 +43,7 @@ const TABS = [
  { id: 'quiz', label: 'Quiz', icon: ListChecks }
 ];
 
-export default function DesignEditor({ campaign, onSave }) {
+export default function DesignEditor({ campaign, onSave, heightClass = 'h-[calc(100vh-8rem)]' }) {
  const [activeTab, setActiveTab] = useState('content');
  const [panelOpen, setPanelOpen] = useState(true);
 
@@ -134,7 +134,7 @@ export default function DesignEditor({ campaign, onSave }) {
  };
 
  return (
- <div className="flex h-[calc(100vh-8rem)] gap-0">
+ <div className={`flex ${heightClass} gap-0`}>
  {/* Editor Panel */}
  <div className={`${panelOpen ? 'w-[380px] min-w-[380px]' : 'w-0 min-w-0 overflow-hidden'} transition-colors duration-300 flex flex-col border-r border-border bg-card`}>
  {/* Tab Bar */}

--- a/src/components/campaigns/workspace/CampaignDeliveryPoolTab.jsx
+++ b/src/components/campaigns/workspace/CampaignDeliveryPoolTab.jsx
@@ -1,0 +1,218 @@
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { agents as agentsAPI } from '@/api/client';
+import { LeadPackage } from '@/api/entities';
+import {
+  useCampaignDeliveryPool,
+  useBulkAssignCampaignPackage,
+} from '@/hooks/queries/useCampaignsQuery';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Loader2, Plus, Users, Coins, PauseCircle } from 'lucide-react';
+import { toast } from 'sonner';
+import LeadPackageTemplateDialog from '@/components/lead-packages/LeadPackageTemplateDialog';
+
+/**
+ * Delivery Pool tab — the campaign-first credits surface. Shows which agents are
+ * actually in this campaign's lead round-robin (with remaining credits), and lets
+ * an admin bulk-fund many agents with a campaign package in one action.
+ */
+export default function CampaignDeliveryPoolTab({ campaignId, campaignName }) {
+  const queryClient = useQueryClient();
+  const { data: pool, isLoading } = useCampaignDeliveryPool(campaignId);
+  const { data: agentsData } = useQuery({ queryKey: ['agents', 'list'], queryFn: () => agentsAPI.getAll() });
+  const bulkAssign = useBulkAssignCampaignPackage(campaignId);
+
+  const [selectedPackageId, setSelectedPackageId] = useState('');
+  const [selectedAgentIds, setSelectedAgentIds] = useState([]);
+  const [pkgDialogOpen, setPkgDialogOpen] = useState(false);
+
+  const packages = pool?.packages || [];
+  const poolAgents = pool?.agents || [];
+  const totals = pool?.totals || { fundedAgents: 0, remainingCredits: 0, heldLeads: 0 };
+  const allAgents = (agentsData?.agents || []).filter(
+    (a) => (a.role === 'agent' || !a.role) && a.isActive !== false
+  );
+
+  const toggleAgent = (id, checked) =>
+    setSelectedAgentIds((prev) => (checked ? [...prev, id] : prev.filter((x) => x !== id)));
+
+  const handleAssign = async () => {
+    if (!selectedPackageId || selectedAgentIds.length === 0) return;
+    try {
+      const res = await bulkAssign.mutateAsync({ packageId: selectedPackageId, agentIds: selectedAgentIds });
+      const parts = [`${res.assigned} agent(s) funded`];
+      if (res.skipped?.length) parts.push(`${res.skipped.length} already had this package`);
+      if (res.invalid?.length) parts.push(`${res.invalid.length} skipped (not active agents)`);
+      toast.success(parts.join(' · '));
+      setSelectedAgentIds([]);
+    } catch (e) {
+      toast.error(e?.response?.data?.message || e.message || 'Failed to assign package');
+    }
+  };
+
+  const handleCreatePackage = async (data) => {
+    await LeadPackage.create({ ...data, campaignId });
+    queryClient.invalidateQueries({ queryKey: ['campaignDeliveryPool', campaignId] });
+    queryClient.invalidateQueries({ queryKey: ['leadPackages'] });
+    toast.success('Package created');
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Loader2 className="w-6 h-6 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <StatCard icon={Users} label="Funded agents" value={totals.fundedAgents} />
+        <StatCard icon={Coins} label="Remaining credits" value={totals.remainingCredits} />
+        <StatCard
+          icon={PauseCircle}
+          label="Held leads"
+          value={totals.heldLeads}
+          tone={totals.heldLeads > 0 ? 'warn' : undefined}
+        />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Fund agents for this campaign</CardTitle>
+          <CardDescription>
+            Pick a lead package and the agents to give it to. Each funded agent joins this
+            campaign&apos;s round-robin and spends one credit per delivered lead.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-col sm:flex-row gap-3 sm:items-end">
+            <div className="flex-1 space-y-1">
+              <label className="text-sm font-medium">Lead package</label>
+              <Select value={selectedPackageId} onValueChange={setSelectedPackageId}>
+                <SelectTrigger>
+                  <SelectValue placeholder={packages.length ? 'Select a package' : 'No packages yet — create one'} />
+                </SelectTrigger>
+                <SelectContent>
+                  {packages.map((p) => (
+                    <SelectItem key={p.id} value={p.id}>
+                      {p.name} ({p.leadCount} leads)
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <Button variant="outline" onClick={() => setPkgDialogOpen(true)}>
+              <Plus className="w-4 h-4 mr-2" /> New package
+            </Button>
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm font-medium">Agents ({selectedAgentIds.length} selected)</label>
+            <ScrollArea className="h-48 rounded-md border border-border p-2">
+              {allAgents.length === 0 ? (
+                <p className="text-sm text-muted-foreground p-2">No active agents found.</p>
+              ) : (
+                allAgents.map((a) => (
+                  <label
+                    key={a.id}
+                    className="flex items-center gap-2 py-1.5 px-1 cursor-pointer hover:bg-muted/50 rounded"
+                  >
+                    <Checkbox
+                      checked={selectedAgentIds.includes(a.id)}
+                      onCheckedChange={(c) => toggleAgent(a.id, !!c)}
+                    />
+                    <span className="text-sm">{a.fullName || a.full_name || a.email}</span>
+                    <span className="text-xs text-muted-foreground">{a.phone}</span>
+                  </label>
+                ))
+              )}
+            </ScrollArea>
+          </div>
+
+          <div className="flex justify-end">
+            <Button
+              onClick={handleAssign}
+              disabled={!selectedPackageId || selectedAgentIds.length === 0 || bulkAssign.isPending}
+            >
+              {bulkAssign.isPending && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+              Assign to {selectedAgentIds.length || ''} agent{selectedAgentIds.length === 1 ? '' : 's'}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Delivery pool</CardTitle>
+          <CardDescription>Agents currently receiving this campaign&apos;s leads.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {poolAgents.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-6 text-center">
+              No funded agents yet. Assign a package above to start delivering leads.
+            </p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Agent</TableHead>
+                  <TableHead>Phone</TableHead>
+                  <TableHead className="text-right">Remaining credits</TableHead>
+                  <TableHead>Last funded</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {poolAgents.map((a) => (
+                  <TableRow key={a.agentId}>
+                    <TableCell className="font-medium">{a.fullName || a.email}</TableCell>
+                    <TableCell className="text-muted-foreground">{a.phone || '—'}</TableCell>
+                    <TableCell className="text-right">
+                      <Badge className={a.remainingCredits > 0 ? 'bg-success/15 text-success' : 'bg-muted text-foreground'}>
+                        {a.remainingCredits}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-sm">
+                      {a.lastPackageAssignedAt ? new Date(a.lastPackageAssignedAt).toLocaleDateString() : '—'}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <LeadPackageTemplateDialog
+        open={pkgDialogOpen}
+        onOpenChange={setPkgDialogOpen}
+        onSubmit={handleCreatePackage}
+        lockCampaignId={campaignId}
+        lockCampaignName={campaignName}
+      />
+    </div>
+  );
+}
+
+function StatCard({ icon: Icon, label, value, tone }) {
+  return (
+    <Card>
+      <CardContent className="flex items-center gap-3 py-4">
+        <div className={`p-2 rounded-lg ${tone === 'warn' ? 'bg-warning/15 text-warning' : 'bg-primary/10 text-primary'}`}>
+          <Icon className="w-5 h-5" />
+        </div>
+        <div>
+          <div className="text-2xl font-bold">{value}</div>
+          <div className="text-xs text-muted-foreground">{label}</div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/campaigns/workspace/CampaignDetailsTab.jsx
+++ b/src/components/campaigns/workspace/CampaignDetailsTab.jsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
+import { Loader2 } from 'lucide-react';
+
+const toDateInput = (v) => {
+  if (!v) return '';
+  const d = new Date(v);
+  return Number.isNaN(d.getTime()) ? '' : d.toISOString().slice(0, 10);
+};
+
+/**
+ * Details tab — core campaign metadata + the previously-hidden delivery controls
+ * (enforceLeadQuota) and per-campaign tracking pixels. Controlled form; the
+ * workspace owns create-vs-update. PHV tablet media stays in the classic editor.
+ */
+export default function CampaignDetailsTab({ initial, type, isEdit, saving, onSubmit }) {
+  const campaignType = initial?.type || type || 'lead_generation';
+  const [form, setForm] = useState({
+    name: initial?.name || '',
+    min_age: initial?.min_age ?? 18,
+    max_age: initial?.max_age ?? 65,
+    start_date: toDateInput(initial?.start_date) || toDateInput(new Date()),
+    end_date: toDateInput(initial?.end_date),
+    commission_amount_driver: initial?.commission_amount_driver ?? '',
+    commission_amount_fleet: initial?.commission_amount_fleet ?? '',
+    enforceLeadQuota: initial?.enforceLeadQuota === true,
+    metaPixelId: initial?.metaPixelId || '',
+    tiktokPixelId: initial?.tiktokPixelId || '',
+  });
+  const set = (k, v) => setForm((f) => ({ ...f, [k]: v }));
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!form.name.trim()) return;
+    onSubmit({
+      name: form.name.trim(),
+      type: campaignType,
+      min_age: Number(form.min_age) || 18,
+      max_age: Number(form.max_age) || 65,
+      start_date: form.start_date ? new Date(form.start_date).toISOString() : undefined,
+      end_date: form.end_date ? new Date(form.end_date).toISOString() : undefined,
+      commission_amount_driver: form.commission_amount_driver === '' ? null : Number(form.commission_amount_driver),
+      commission_amount_fleet: form.commission_amount_fleet === '' ? null : Number(form.commission_amount_fleet),
+      enforceLeadQuota: form.enforceLeadQuota,
+      metaPixelId: form.metaPixelId.trim() || null,
+      tiktokPixelId: form.tiktokPixelId.trim() || null,
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6 max-w-3xl">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Campaign details</CardTitle>
+          <CardDescription>The basics. New campaigns start as a draft until you launch them.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="name">Campaign name</Label>
+            <Input id="name" value={form.name} onChange={(e) => set('name', e.target.value)} placeholder="e.g. CareShield CPF — June" required />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2"><Label htmlFor="start_date">Start date</Label><Input id="start_date" type="date" value={form.start_date} onChange={(e) => set('start_date', e.target.value)} /></div>
+            <div className="space-y-2"><Label htmlFor="end_date">End date</Label><Input id="end_date" type="date" value={form.end_date} onChange={(e) => set('end_date', e.target.value)} /></div>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2"><Label htmlFor="min_age">Min age</Label><Input id="min_age" type="number" value={form.min_age} onChange={(e) => set('min_age', e.target.value)} /></div>
+            <div className="space-y-2"><Label htmlFor="max_age">Max age</Label><Input id="max_age" type="number" value={form.max_age} onChange={(e) => set('max_age', e.target.value)} /></div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader><CardTitle className="text-base">Lead delivery</CardTitle></CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <Label htmlFor="quota" className="cursor-pointer">Enforce paid lead quota</Label>
+              <p className="text-xs text-muted-foreground mt-1">
+                When on, a lead is only delivered if a funded agent credit can be charged; otherwise it is held (never delivered free). Leave off for soft delivery.
+              </p>
+            </div>
+            <Switch id="quota" checked={form.enforceLeadQuota} onCheckedChange={(c) => set('enforceLeadQuota', c)} />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2"><Label htmlFor="cad">Driver commission (SGD)</Label><Input id="cad" type="number" step="0.01" min="0" value={form.commission_amount_driver} onChange={(e) => set('commission_amount_driver', e.target.value)} placeholder="0.00" /></div>
+            <div className="space-y-2"><Label htmlFor="caf">Fleet commission (SGD)</Label><Input id="caf" type="number" step="0.01" min="0" value={form.commission_amount_fleet} onChange={(e) => set('commission_amount_fleet', e.target.value)} placeholder="0.00" /></div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Tracking pixels</CardTitle>
+          <CardDescription>Optional per-campaign overrides for Meta / TikTok. Leave blank to use the site default.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2"><Label htmlFor="meta">Meta Pixel ID</Label><Input id="meta" value={form.metaPixelId} onChange={(e) => set('metaPixelId', e.target.value)} placeholder="e.g. 1402034528611431" /></div>
+          <div className="space-y-2"><Label htmlFor="tt">TikTok Pixel ID</Label><Input id="tt" value={form.tiktokPixelId} onChange={(e) => set('tiktokPixelId', e.target.value)} placeholder="e.g. D8GJ6T3C77UDLID6746G" /></div>
+        </CardContent>
+      </Card>
+
+      <div className="flex justify-end">
+        <Button type="submit" disabled={saving || !form.name.trim()}>
+          {saving && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+          {isEdit ? 'Save details' : 'Create draft & continue'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/campaigns/workspace/CampaignLaunchTab.jsx
+++ b/src/components/campaigns/workspace/CampaignLaunchTab.jsx
@@ -1,0 +1,43 @@
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Loader2, Play, Pause } from 'lucide-react';
+import CampaignReadinessBanner from '@/components/campaigns/CampaignReadinessBanner';
+
+/**
+ * Launch tab — reuses the existing readiness banner and adds activate/pause.
+ * The backend readiness-gates activation (409 with issues) unless forced; the
+ * workspace surfaces that as a toast.
+ */
+export default function CampaignLaunchTab({ campaign, onSetState, saving }) {
+  const isActive = campaign?.status === 'active' || campaign?.is_active === true;
+
+  return (
+    <div className="space-y-6 max-w-3xl">
+      <CampaignReadinessBanner campaignId={campaign.id} />
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            Launch status
+            <Badge className={isActive ? 'bg-success/15 text-success' : 'bg-muted text-foreground'}>
+              {campaign?.status || (isActive ? 'active' : 'draft')}
+            </Badge>
+          </CardTitle>
+          <CardDescription>
+            Activating makes this campaign live and starts routing leads to your funded agents. We&apos;ll
+            warn you if it isn&apos;t ready.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex gap-3">
+          <Button onClick={() => onSetState('active')} disabled={saving || isActive}>
+            {saving ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <Play className="w-4 h-4 mr-2" />}
+            Activate
+          </Button>
+          <Button variant="outline" onClick={() => onSetState('paused')} disabled={saving || !isActive}>
+            <Pause className="w-4 h-4 mr-2" /> Pause
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/campaigns/workspace/__tests__/CampaignDetailsTab.test.jsx
+++ b/src/components/campaigns/workspace/__tests__/CampaignDetailsTab.test.jsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import CampaignDetailsTab from '../CampaignDetailsTab';
+
+afterEach(cleanup);
+
+describe('CampaignDetailsTab', () => {
+  it('submits a payload carrying type, enforceLeadQuota and pixel ids', () => {
+    const onSubmit = vi.fn();
+    render(
+      <CampaignDetailsTab initial={null} type="quiz" isEdit={false} saving={false} onSubmit={onSubmit} />
+    );
+
+    fireEvent.change(screen.getByLabelText('Campaign name'), { target: { value: 'My Campaign' } });
+    fireEvent.change(screen.getByLabelText('Meta Pixel ID'), { target: { value: '123' } });
+    fireEvent.change(screen.getByLabelText('TikTok Pixel ID'), { target: { value: 'TT9' } });
+    fireEvent.click(screen.getByRole('switch')); // enforce quota on
+
+    fireEvent.click(screen.getByRole('button', { name: /Create draft/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({
+      name: 'My Campaign',
+      type: 'quiz',
+      enforceLeadQuota: true,
+      metaPixelId: '123',
+      tiktokPixelId: 'TT9',
+    });
+  });
+
+  it('preserves the existing type in edit mode and shows Save details', () => {
+    const onSubmit = vi.fn();
+    render(
+      <CampaignDetailsTab
+        initial={{ name: 'Existing', type: 'lead_generation', enforceLeadQuota: false }}
+        isEdit
+        saving={false}
+        onSubmit={onSubmit}
+      />
+    );
+
+    const saveBtn = screen.getByRole('button', { name: /Save details/i });
+    expect(saveBtn).toBeTruthy();
+    fireEvent.click(saveBtn);
+
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({
+      name: 'Existing',
+      type: 'lead_generation',
+      enforceLeadQuota: false,
+    });
+  });
+
+  it('does not submit when the name is empty', () => {
+    const onSubmit = vi.fn();
+    render(<CampaignDetailsTab initial={null} type="lead_generation" isEdit={false} saving={false} onSubmit={onSubmit} />);
+    fireEvent.click(screen.getByRole('button', { name: /Create draft/i }));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/lead-packages/LeadPackageTemplateDialog.jsx
+++ b/src/components/lead-packages/LeadPackageTemplateDialog.jsx
@@ -11,7 +11,7 @@ import Loader2 from"lucide-react/icons/loader-2";
 import { Campaign } from"@/api/entities";
 import { leadPackageTemplateSchema } from"@/schemas/leadPackage";
 
-export default function LeadPackageTemplateDialog({ open, onOpenChange, onSubmit, editingPackage = null }) {
+export default function LeadPackageTemplateDialog({ open, onOpenChange, onSubmit, editingPackage = null, lockCampaignId = null, lockCampaignName = null }) {
  const [campaigns, setCampaigns] = useState([]);
 
  const {
@@ -37,12 +37,14 @@ export default function LeadPackageTemplateDialog({ open, onOpenChange, onSubmit
 
  useEffect(() => {
  if (open) {
- loadCampaigns();
+ // In locked mode the campaign is fixed by the workspace (and may be a
+ // draft, which the active-only list would exclude), so skip the fetch.
+ if (!lockCampaignId) loadCampaigns();
  reset(editingPackage
  ? {
  name: editingPackage.name ||"",
  description: editingPackage.description ||"",
- campaignId: editingPackage.campaignId ||"",
+ campaignId: lockCampaignId || editingPackage.campaignId ||"",
  type: editingPackage.type ||"basic",
  leadCount: editingPackage.leadCount || 100,
  price: editingPackage.price || 0,
@@ -52,7 +54,7 @@ export default function LeadPackageTemplateDialog({ open, onOpenChange, onSubmit
  : {
  name:"",
  description:"",
- campaignId:"",
+ campaignId: lockCampaignId ||"",
  type:"basic",
  leadCount: 100,
  price: 0,
@@ -61,7 +63,7 @@ export default function LeadPackageTemplateDialog({ open, onOpenChange, onSubmit
  }
  );
  }
- }, [open, editingPackage, reset]);
+ }, [open, editingPackage, reset, lockCampaignId]);
 
  const loadCampaigns = async () => {
  try {
@@ -108,6 +110,9 @@ export default function LeadPackageTemplateDialog({ open, onOpenChange, onSubmit
 
  <div className="space-y-2">
  <Label htmlFor="campaign">Campaign *</Label>
+ {lockCampaignId ? (
+ <Input value={lockCampaignName || 'This campaign'} disabled readOnly />
+ ) : (
  <Controller
  name="campaignId" control={control}
  render={({ field }) => (
@@ -125,6 +130,7 @@ export default function LeadPackageTemplateDialog({ open, onOpenChange, onSubmit
  </Select>
  )}
  />
+ )}
  {errors.campaignId && (
  <p className="text-destructive text-xs mt-1">{errors.campaignId.message}</p>
  )}

--- a/src/components/qrcodes/CampaignQRManager.jsx
+++ b/src/components/qrcodes/CampaignQRManager.jsx
@@ -12,7 +12,7 @@ import ExistingQRCodes from"./ExistingQRCodes";
 import PromotionalQRForm from"./PromotionalQRForm";
 import CarQRDirectory from"./CarQRDirectory";
 
-export default function CampaignQRManager({ campaign, onBack }) {
+export default function CampaignQRManager({ campaign, onBack, embedded = false }) {
  const [qrTags, setQrTags] = useState([]);
  const [loading, setLoading] = useState(true);
  const [activeTab, setActiveTab] = useState("existing");
@@ -59,8 +59,9 @@ export default function CampaignQRManager({ campaign, onBack }) {
  const carQRs = qrTags.filter(qr => qr.type === 'car');
 
  return (
- <div className="p-6 lg:p-8 bg-muted min-h-screen">
- <div className="max-w-7xl mx-auto">
+ <div className={embedded ? "" : "p-6 lg:p-8 bg-muted min-h-screen"}>
+ <div className={embedded ? "" : "max-w-7xl mx-auto"}>
+ {!embedded && (
  <div className="flex items-center gap-4 mb-8">
  <Button variant="outline" onClick={onBack}>
  <ArrowLeft className="w-4 h-4 mr-2"/>
@@ -82,6 +83,7 @@ export default function CampaignQRManager({ campaign, onBack }) {
  </div>
  </div>
  </div>
+ )}
 
  <Tabs value={activeTab} onValueChange={setActiveTab}>
  <TabsList className="grid w-full grid-cols-3 mb-8">

--- a/src/hooks/queries/useCampaignsQuery.js
+++ b/src/hooks/queries/useCampaignsQuery.js
@@ -87,3 +87,36 @@ export function useUpdateCampaign() {
  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['campaigns'] }),
  });
 }
+
+// --- Campaign Launch Workspace ---
+
+export function useCampaignDeliveryPool(id) {
+ return useQuery({
+ queryKey: ['campaignDeliveryPool', id],
+ queryFn: () => campaignService.getCampaignDeliveryPool(id),
+ enabled: !!id,
+ });
+}
+
+export function useBulkAssignCampaignPackage(id) {
+ const queryClient = useQueryClient();
+ return useMutation({
+ mutationFn: (payload) => campaignService.bulkAssignCampaignPackage(id, payload),
+ onSuccess: () => {
+ queryClient.invalidateQueries({ queryKey: ['campaignDeliveryPool', id] });
+ queryClient.invalidateQueries({ queryKey: ['leadPackages'] });
+ queryClient.invalidateQueries({ queryKey: ['agents'] });
+ },
+ });
+}
+
+export function useSetCampaignLaunchState(id) {
+ const queryClient = useQueryClient();
+ return useMutation({
+ mutationFn: (payload) => campaignService.setCampaignLaunchState(id, payload),
+ onSuccess: () => {
+ queryClient.invalidateQueries({ queryKey: ['campaigns'] });
+ queryClient.invalidateQueries({ queryKey: ['campaignDeliveryPool', id] });
+ },
+ });
+}

--- a/src/pages/AdminCampaignWorkspace.jsx
+++ b/src/pages/AdminCampaignWorkspace.jsx
@@ -1,0 +1,243 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
+import { Campaign } from '@/api/entities';
+import { apiClient } from '@/api/client';
+import { useCampaign, useSetCampaignLaunchState } from '@/hooks/queries/useCampaignsQuery';
+import { queryClient } from '@/lib/queryClient';
+import { customerLeadCaptureUrl, customerPublicUrl, resolveCustomerHost } from '@/lib/brand';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { ArrowLeft, Eye, Copy, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import DesignEditor from '@/components/campaigns/DesignEditor';
+import CampaignQRManager from '@/components/qrcodes/CampaignQRManager';
+import CampaignDetailsTab from '@/components/campaigns/workspace/CampaignDetailsTab';
+import CampaignDeliveryPoolTab from '@/components/campaigns/workspace/CampaignDeliveryPoolTab';
+import CampaignLaunchTab from '@/components/campaigns/workspace/CampaignLaunchTab';
+
+const TABS = [
+  { id: 'details', label: 'Details' },
+  { id: 'design', label: 'Design' },
+  { id: 'pool', label: 'Delivery Pool' },
+  { id: 'sources', label: 'Sources' },
+  { id: 'launch', label: 'Launch' },
+];
+const TAB_IDS = TABS.map((t) => t.id);
+
+export default function AdminCampaignWorkspace() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const isCreate = !id;
+  const typeParam = searchParams.get('type') || 'lead_generation';
+  const tabParam = searchParams.get('tab');
+
+  const [activeTab, setActiveTab] = useState(
+    !isCreate && TAB_IDS.includes(tabParam) ? tabParam : 'details'
+  );
+  const [savingDetails, setSavingDetails] = useState(false);
+
+  const { data: campaign, isLoading } = useCampaign(id);
+  const launchMutation = useSetCampaignLaunchState(id);
+
+  useEffect(() => {
+    if (!isCreate && tabParam && TAB_IDS.includes(tabParam)) setActiveTab(tabParam);
+  }, [tabParam, isCreate]);
+
+  const goTab = (t) => {
+    if (isCreate && t !== 'details') return; // other tabs need a saved campaign
+    setActiveTab(t);
+    if (!isCreate) {
+      const next = new URLSearchParams(searchParams);
+      next.set('tab', t);
+      setSearchParams(next, { replace: true });
+    }
+  };
+
+  const handleSaveDetails = async (payload) => {
+    setSavingDetails(true);
+    try {
+      if (isCreate) {
+        // New campaigns are created as a DRAFT (is_active:false) so they never go
+        // live before being funded; the operator launches from the Launch tab.
+        const created = await Campaign.create({ ...payload, is_active: false });
+        const newId = created?.id || created?.campaign?.id;
+        queryClient.invalidateQueries({ queryKey: ['campaigns'] });
+        toast.success('Draft created');
+        if (newId) navigate(`/admin/campaigns/${newId}/workspace?tab=design`);
+        else navigate('/AdminCampaigns');
+      } else {
+        await Campaign.update(id, payload);
+        queryClient.invalidateQueries({ queryKey: ['campaigns'] });
+        queryClient.invalidateQueries({ queryKey: ['campaigns', 'detail', id] });
+        toast.success('Details saved');
+      }
+    } catch (e) {
+      toast.error(e?.response?.data?.message || e.message || 'Failed to save campaign');
+    } finally {
+      setSavingDetails(false);
+    }
+  };
+
+  const handleSaveDesign = async (designData) => {
+    await Campaign.update(id, { design_config: designData });
+    queryClient.invalidateQueries({ queryKey: ['campaigns', 'detail', id] });
+    toast.success('Design saved');
+  };
+
+  const handlePreview = async () => {
+    if (!campaign) return;
+    try {
+      const res = await apiClient.post(`/campaigns/${campaign.id}/preview`, {});
+      const urlPath = res?.data?.url || (res?.data?.slug ? `/p/${res.data.slug}` : null);
+      if (!urlPath) {
+        toast.error('Failed to generate preview link');
+        return;
+      }
+      const host = resolveCustomerHost(campaign?.design_config?.customerHost);
+      window.open(customerPublicUrl(urlPath, host), '_blank');
+    } catch (e) {
+      console.error('Failed to create preview:', e);
+      toast.error('Failed to create preview');
+    }
+  };
+
+  const handleCopyLink = async () => {
+    if (!campaign) return;
+    const host = resolveCustomerHost(campaign?.design_config?.customerHost);
+    const url = customerLeadCaptureUrl(campaign.id, {}, host);
+    try {
+      await navigator.clipboard.writeText(url);
+      toast.success('Lead capture link copied');
+    } catch {
+      toast.error('Could not copy link');
+    }
+  };
+
+  const handleSetLaunchState = async (state) => {
+    try {
+      await launchMutation.mutateAsync({ state });
+      toast.success(state === 'active' ? 'Campaign activated' : 'Campaign paused');
+    } catch (e) {
+      // apiClient throws Error(message) with .status (not an axios-style .response).
+      // The backend's 409 message already explains "not ready"; the Readiness banner
+      // on this same tab shows the specific blockers.
+      toast.error(e?.message || 'Failed to update launch state');
+    }
+  };
+
+  if (!isCreate && isLoading) {
+    return (
+      <div className="flex items-center justify-center h-[60vh]">
+        <Loader2 className="w-8 h-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (!isCreate && !campaign) {
+    return (
+      <div className="p-8 text-center">
+        <h2 className="text-lg font-semibold mb-2">Campaign not found</h2>
+        <Button variant="outline" onClick={() => navigate('/AdminCampaigns')}>Back to campaigns</Button>
+      </div>
+    );
+  }
+
+  const status = campaign?.status || (isCreate ? 'new' : 'draft');
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-4rem)]">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 lg:px-6 py-3 border-b border-border bg-card shrink-0">
+        <div className="flex items-center gap-3 min-w-0">
+          <Button variant="ghost" size="icon" aria-label="Back to campaigns" onClick={() => navigate('/AdminCampaigns')}>
+            <ArrowLeft className="w-5 h-5" />
+          </Button>
+          <div className="min-w-0">
+            <h1 className="text-lg font-semibold truncate">
+              {isCreate ? 'New campaign' : campaign?.name || 'Campaign'}
+            </h1>
+            <Badge className="mt-0.5 bg-muted text-foreground text-[11px]">{status}</Badge>
+          </div>
+        </div>
+        {!isCreate && (
+          <div className="flex items-center gap-2">
+            <Button variant="outline" size="sm" onClick={handleCopyLink}>
+              <Copy className="w-4 h-4 mr-1.5" /> Copy link
+            </Button>
+            <Button variant="outline" size="sm" onClick={handlePreview}>
+              <Eye className="w-4 h-4 mr-1.5" /> Preview
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {/* Tab bar */}
+      <div className="flex items-center gap-1 px-4 lg:px-6 border-b border-border bg-card shrink-0 overflow-x-auto">
+        {TABS.map((t) => {
+          const disabled = isCreate && t.id !== 'details';
+          return (
+            <button
+              key={t.id}
+              type="button"
+              disabled={disabled}
+              onClick={() => goTab(t.id)}
+              className={`px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors whitespace-nowrap ${
+                activeTab === t.id
+                  ? 'border-primary text-primary'
+                  : 'border-transparent text-muted-foreground hover:text-foreground'
+              } ${disabled ? 'opacity-40 cursor-not-allowed' : ''}`}
+            >
+              {t.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Tab content */}
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        {activeTab === 'details' && (
+          <div className="p-4 lg:p-6">
+            <CampaignDetailsTab
+              initial={isCreate ? null : campaign}
+              type={typeParam}
+              isEdit={!isCreate}
+              saving={savingDetails}
+              onSubmit={handleSaveDetails}
+            />
+          </div>
+        )}
+
+        {/* Design stays mounted (CSS-hidden) so DesignEditor keeps unsaved edits + its unload guard across tab switches. */}
+        {!isCreate && campaign && (
+          <div className={activeTab === 'design' ? 'h-full' : 'hidden'}>
+            <DesignEditor
+              key={campaign.id}
+              campaign={campaign}
+              onSave={handleSaveDesign}
+              heightClass="h-[calc(100vh-13rem)]"
+            />
+          </div>
+        )}
+
+        {activeTab === 'pool' && !isCreate && (
+          <div className="p-4 lg:p-6">
+            <CampaignDeliveryPoolTab campaignId={campaign.id} campaignName={campaign.name} />
+          </div>
+        )}
+
+        {activeTab === 'sources' && !isCreate && (
+          <div className="p-4 lg:p-6">
+            <CampaignQRManager campaign={campaign} embedded />
+          </div>
+        )}
+
+        {activeTab === 'launch' && !isCreate && (
+          <div className="p-4 lg:p-6">
+            <CampaignLaunchTab campaign={campaign} onSetState={handleSetLaunchState} saving={launchMutation.isPending} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/AdminCampaigns.jsx
+++ b/src/pages/AdminCampaigns.jsx
@@ -89,7 +89,11 @@ export default function AdminCampaigns() {
 
  const handleCreateCampaign = (type) => {
  setIsTypeSelectionOpen(false);
- navigate(`/admin/campaigns/new?type=${type}`);
+ // Flag-gated: route new campaigns into the unified workspace when enabled,
+ // else the classic create form. Ships dark (flag off) until set on the
+ // mktr-platform static site.
+ const workspace = import.meta.env.VITE_CAMPAIGN_WORKSPACE_ENABLED === 'true';
+ navigate(workspace ? `/admin/campaigns/workspace?type=${type}` : `/admin/campaigns/new?type=${type}`);
  };
 
  const handleCopyLink = (campaign) => {
@@ -187,14 +191,14 @@ export default function AdminCampaigns() {
  <span className="ml-2">{copiedId === c.id ? 'Copied!' : 'Copy Link'}</span>
  </DropdownMenuItem>
  <DropdownMenuItem asChild>
- <Link to={`/AdminCampaignDesigner?campaign_id=${c.id}`} className="flex items-center">
+ <Link to={import.meta.env.VITE_CAMPAIGN_WORKSPACE_ENABLED === 'true' ? `/admin/campaigns/${c.id}/workspace?tab=design` : `/AdminCampaignDesigner?campaign_id=${c.id}`} className="flex items-center">
  <Palette className="w-4 h-4"/>
  <span className="ml-2">Design</span>
  </Link>
  </DropdownMenuItem>
 
  <DropdownMenuItem asChild>
- <Link to={`/admin/campaigns/${c.id}/edit`}>
+ <Link to={import.meta.env.VITE_CAMPAIGN_WORKSPACE_ENABLED === 'true' ? `/admin/campaigns/${c.id}/workspace?tab=details` : `/admin/campaigns/${c.id}/edit`}>
  <Edit className="w-4 h-4"/>
  <span className="ml-2">Edit</span>
  </Link>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -49,6 +49,7 @@ const AdminAgentDetail = lazy(() => import('./AdminAgentDetail'));
 const AdminUsers = lazy(() => import('./AdminUsers'));
 const AdminFleet = lazy(() => import('./AdminFleet'));
 const AdminCampaignDesigner = lazy(() => import('./AdminCampaignDesigner'));
+const AdminCampaignWorkspace = lazy(() => import('./AdminCampaignWorkspace'));
 const AdminCommissions = lazy(() => import('./AdminCommissions'));
 const AdminShortLinks = lazy(() => import('./AdminShortLinks'));
 const AdminLeadPackages = lazy(() => import('./AdminLeadPackages'));
@@ -181,6 +182,25 @@ function PagesContent() {
  <ProtectedRoute requiredRole="admin">
  <DashboardLayout>
  <AdminCampaignForm />
+ </DashboardLayout>
+ </ProtectedRoute>
+ }
+ />
+ {/* Campaign Launch Workspace — unified create/edit/design/pool/sources/launch. */}
+ <Route
+ path="/admin/campaigns/workspace" element={
+ <ProtectedRoute requiredRole="admin">
+ <DashboardLayout>
+ <AdminCampaignWorkspace />
+ </DashboardLayout>
+ </ProtectedRoute>
+ }
+ />
+ <Route
+ path="/admin/campaigns/:id/workspace" element={
+ <ProtectedRoute requiredRole="admin">
+ <DashboardLayout>
+ <AdminCampaignWorkspace />
  </DashboardLayout>
  </ProtectedRoute>
  }

--- a/src/services/campaignService.js
+++ b/src/services/campaignService.js
@@ -40,3 +40,16 @@ export async function permanentDeleteCampaign(id) {
 export async function getCampaignAnalytics(id) {
  return Campaign.getAnalytics(id);
 }
+
+// --- Campaign Launch Workspace ---
+export async function getCampaignDeliveryPool(id) {
+ return Campaign.getDeliveryPool(id);
+}
+
+export async function bulkAssignCampaignPackage(id, payload) {
+ return Campaign.bulkAssignDeliveryPool(id, payload);
+}
+
+export async function setCampaignLaunchState(id, payload) {
+ return Campaign.setLaunchState(id, payload);
+}

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -1,1 +1,11 @@
 import '@testing-library/jest-dom';
+
+// jsdom lacks ResizeObserver, which Radix UI primitives (Switch, Slider, …)
+// reference on mount. Provide a no-op polyfill so component tests can render them.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}


### PR DESCRIPTION
## What
Unified admin **Campaign Launch Workspace** that replaces the 5-page launch flow (Campaigns → Form → Designer → Lead Packages → Agents), plus **campaign-first credits** (a campaign shows its own funded-agent pool + remaining credits + bulk assign).

One page, five tabs: **Details** (incl. now-surfaced `enforceLeadQuota` + Meta/TikTok pixel IDs) · **Design** (embeds existing `DesignEditor`) · **Delivery Pool** (bulk-fund many agents with one package; remaining credits; held-lead count) · **Sources** (embedded QR manager + copy lead-capture link) · **Launch** (readiness banner + activate/pause).

## Ships DARK 🌑
Workspace routes are always mounted, but `AdminCampaigns` only points create/edit/design actions at the workspace when **`VITE_CAMPAIGN_WORKSPACE_ENABLED=true`** (unset by default). **Merging to main changes nothing in prod** until that env var is set on the `mktr-platform` static site + redeploy. Old form/designer/lead-package/agent pages stay fully intact → trivial rollback (revert the nav, or leave the flag off).

## Backend (additive, host-guarded)
New `/api/admin/campaigns` router (blocked from redeem.sg by `internalRouteHostGuard`):
- `GET /:id/delivery-pool` — funded agents + remaining credits + internally-releasable held count
- `POST /:id/delivery-pool/assign` — bulk-assign one package to many agents (advisory-lock + idempotent skip; **one** release sweep)
- `PATCH /:id/launch-state` — activate/pause; readiness-gated activate (409 unless ready); rejects archived; refreshes device manifests
- `campaignService`/`validation`: persist `metaPixelId`/`tiktokPixelId`; `trackerService` hydrates `tiktokPixelId` for QR traffic.

No DB migration. Live routing/credits model untouched.

## Tests
- Backend Jest: `aggregateDeliveryPoolAgents` pure-helper (6) ✓
- Frontend Vitest: `CampaignDetailsTab` payload (3) ✓ (+ ResizeObserver polyfill for Radix)
- Production build ✓ · lint clean (0 errors) · 74 existing campaign-component tests still pass.

> Note: repo CI is chronically red on pre-existing suites; only the suites touched here were run/asserted.

Plan + review trail: `docs/plans/campaign-launch-workspace.md` (Codex 5.5 xhigh draft → Claude review → Codex re-review → Claude final, all folded in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)