### PR TITLE
fix(splash): suppress operator mktr_ splash on customer + redirect surfaces

### DIFF
--- a/src/lib/__tests__/splash.test.js
+++ b/src/lib/__tests__/splash.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { shouldSuppressSplash, safeSessionGet, safeSessionSet } from '@/lib/splash';
+
+// Default test env has no VITE_BRAND → isRedeem() === false (mktr build).
+describe('shouldSuppressSplash — mktr (operator) build', () => {
+  it('suppresses on redirect shims + public lead-capture / preview surfaces', () => {
+    expect(shouldSuppressSplash('/t/abc123')).toBe(true);
+    expect(shouldSuppressSplash('/share/xyz')).toBe(true);
+    expect(shouldSuppressSplash('/p/some-slug')).toBe(true);
+    expect(shouldSuppressSplash('/LeadCapture')).toBe(true);
+    expect(shouldSuppressSplash('/lead-capture')).toBe(true);
+  });
+
+  it('keeps the splash on admin / marketing routes', () => {
+    expect(shouldSuppressSplash('/AdminDashboard')).toBe(false);
+    expect(shouldSuppressSplash('/')).toBe(false);
+    expect(shouldSuppressSplash('/Homepage')).toBe(false);
+    expect(shouldSuppressSplash('/admin/campaigns/123/workspace')).toBe(false);
+  });
+});
+
+describe('shouldSuppressSplash — redeem (customer) build', () => {
+  afterEach(() => {
+    vi.doUnmock('@/lib/brand');
+    vi.resetModules();
+  });
+
+  it('always suppresses, even on admin/apex routes', async () => {
+    vi.resetModules();
+    vi.doMock('@/lib/brand', () => ({ isRedeem: () => true }));
+    const { shouldSuppressSplash: suppress } = await import('@/lib/splash');
+    expect(suppress('/AdminDashboard')).toBe(true);
+    expect(suppress('/')).toBe(true);
+  });
+});
+
+describe('safe session storage helpers', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('swallow errors when storage is blocked (private mode)', () => {
+    vi.stubGlobal('sessionStorage', {
+      getItem: () => {
+        throw new Error('blocked');
+      },
+      setItem: () => {
+        throw new Error('blocked');
+      },
+    });
+    expect(() => safeSessionSet('k', '1')).not.toThrow();
+    expect(safeSessionGet('k')).toBe(null);
+  });
+});

--- a/src/lib/splash.js
+++ b/src/lib/splash.js
@@ -1,0 +1,47 @@
+import { isRedeem } from '@/lib/brand';
+
+// Boot splash (the `mktr_` typing animation) helpers. Extracted from main.jsx so
+// the suppression logic is unit-testable without triggering main.jsx's
+// ReactDOM.createRoot side effect.
+
+export const SPLASH_KEY = 'mktr_splash_shown';
+
+// sessionStorage can throw (private mode / blocked storage). A throw inside the
+// hide timer would also strand the splash (setShowSplash never runs), so guard both.
+export function safeSessionGet(key) {
+  try {
+    return sessionStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function safeSessionSet(key, value) {
+  try {
+    sessionStorage.setItem(key, value);
+  } catch {
+    /* storage blocked — non-fatal */
+  }
+}
+
+/**
+ * The operator `mktr_` splash must never appear on customer-facing or
+ * redirect-shim surfaces:
+ *  - the entire redeem (customer) build, and
+ *  - the QR/share redirect shims (`/t/`, `/share/`) + public lead-capture /
+ *    preview pages (`/p/`, `/LeadCapture`) on ANY build.
+ * Those surfaces do rapid full-page navigations (a QR scan is
+ * `/t/:slug` → backend 302 → `/LeadCapture`), so the splash would replay on each
+ * boot and flash the operator brand at customers. The mktr admin app keeps its
+ * once-per-session splash.
+ */
+export function shouldSuppressSplash(pathname = window.location.pathname) {
+  if (isRedeem()) return true;
+  return (
+    pathname.startsWith('/t/') ||
+    pathname.startsWith('/share/') ||
+    pathname.startsWith('/p/') ||
+    pathname === '/LeadCapture' ||
+    pathname === '/lead-capture'
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -8,6 +8,7 @@ import '@/index.css'
 import { queryClient } from '@/lib/queryClient'
 import { scrubEvent, scrubBreadcrumb } from '@/lib/sentryScrub'
 import MKTRAnimatedLogo from '@/components/MKTRAnimatedLogo'
+import { SPLASH_KEY, safeSessionGet, safeSessionSet, shouldSuppressSplash } from '@/lib/splash'
 
 // Initialize Sentry
 const sentryDsn = import.meta.env.VITE_SENTRY_DSN
@@ -24,18 +25,19 @@ if (sentryDsn) {
 }
 
 function Boot() {
- const [showSplash, setShowSplash] = useState(() => sessionStorage.getItem('mktr_splash_shown') !== '1')
+ const [showSplash, setShowSplash] = useState(
+ () => !shouldSuppressSplash() && safeSessionGet(SPLASH_KEY) !== '1'
+ )
  useEffect(() => {
- // API client now reads token from localStorage on each request — no manual setToken needed
  if (showSplash) {
  const minSplashMs = 1500
  const timer = setTimeout(() => {
- sessionStorage.setItem('mktr_splash_shown', '1')
+ safeSessionSet(SPLASH_KEY, '1')
  setShowSplash(false)
  }, minSplashMs)
  return () => clearTimeout(timer)
  }
- }, [])
+ }, [showSplash])
  return showSplash ? <MKTRAnimatedLogo /> : <App />
 }
 


### PR DESCRIPTION
## Problem
Scanning a redeem.sg QR (`/t/:slug`) replayed the `mktr_` typing splash several times, and showed the **operator** brand on the **customer** (redeem.sg) lead-capture page.

## Root cause (corrected via Codex review)
The splash mounts once per full SPA boot. The QR flow does 2+ full-page boots (`/t/:slug` → backend 302 → `/LeadCapture`), and the per-origin `sessionStorage` "shown" flag doesn't suppress replays across them. (An earlier theory — the redirect beating the 1500ms flag write — was wrong: `Boot()` renders only the splash, not `<App/>`/`TrackRedirect`, until the timer fires, so the flag is always written first. Codex caught this.)

## Fix
Never show the splash on customer-facing / redirect-shim surfaces:
- the **entire redeem build**, and
- `/t/`, `/share/`, `/p/`, `/LeadCapture`, `/lead-capture` on **any** build.

The **mktr admin** app keeps its once-per-session splash. Logic extracted to `src/lib/splash.js` (unit-tested) with **safe sessionStorage helpers** (guards private-mode throws, per Codex). Resolves the symptom regardless of the exact boot count.

## Tests
- New Vitest: `src/lib/__tests__/splash.test.js` (4 tests — mktr suppress paths, mktr keep-admin, redeem-always-suppress, storage-throw safety) ✓
- Build ✓ · lint 0 errors.

> Not addressed here (separate, optional): a possible redeem→mktr cross-host hop in the tracker redirect, and a Render edge-rewrite of `/t/*` for latency. This fix makes the splash a non-issue either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)