### PR TITLE
feat(capi): external (mktr-leads) outcome path fires ConfirmedResident/ClosedWon

### DIFF
--- a/backend/src/services/externalLeadOutcomeService.js
+++ b/backend/src/services/externalLeadOutcomeService.js
@@ -42,6 +42,7 @@
 
 import { sequelize, Prospect, ProspectActivity, IdempotencyKey, User } from '../models/index.js';
 import { logger } from '../utils/logger.js';
+import { processLeadOutcome as defaultProcessLeadOutcome } from './leadOutcomeService.js';
 
 export const IDEMPOTENCY_SCOPE = 'external:outcome';
 const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
@@ -75,6 +76,10 @@ const defaultDeps = {
   sequelize,
   models: { Prospect, ProspectActivity, IdempotencyKey, User },
   logger,
+  // Reused from the Lyfe path so the external path fires the SAME down-funnel
+  // CAPI events (ConfirmedResident/ClosedWon) with identical dedup/event_id/
+  // back-date/per-campaign-pixel semantics. Injected for testability.
+  processLeadOutcome: defaultProcessLeadOutcome,
 };
 
 export function makeExternalLeadOutcomeService(overrides = {}) {
@@ -91,24 +96,40 @@ export function makeExternalLeadOutcomeService(overrides = {}) {
    *   outcome_reported_at only on 2xx, so non-2xx keeps the outcome visible as
    *   unreported (and the mktr-leads sweep will re-fire it).
    */
+  /**
+   * Fire the down-funnel CAPI for a mirrored prospect, reusing the Lyfe path's
+   * sender (deterministic event_id, mark-on-success dedup, per-campaign pixel;
+   * Meta event_id is the concurrency guard). Only SC/PR-confirmed statuses emit
+   * events. Returns { retryable }: true ONLY on a genuine transient (5xx/network)
+   * failure → caller returns non-2xx so the mktr-leads sweep re-fires. `guarded`
+   * (CAPI off) and `permanent` (4xx) are NOT retryable (no sweep storm).
+   */
+  async function fireCapi(prospect, mapped, occurredAt) {
+    if (mapped !== 'qualified' && mapped !== 'won') return { retryable: false };
+    try {
+      const r = await d.processLeadOutcome({
+        external_id: prospect.id,
+        new_status: mapped,
+        occurred_at: occurredAt,
+      });
+      return { retryable: (r?.transientFailed?.length ?? 0) > 0 };
+    } catch (err) {
+      d.logger.error(
+        { event: 'external_outcome_capi_error', prospect_id: prospect.id, error: err?.message || String(err) },
+        '[external-outcome] CAPI dispatch threw — treating as retryable'
+      );
+      return { retryable: true };
+    }
+  }
+
   async function processExternalLeadOutcome(payload) {
-    const { eventId, data } = payload;
+    const { eventId, data, timestamp } = payload;
     const { externalId, deliveryId, mktrLeadsStatus } = data;
     const key = `${IDEMPOTENCY_SCOPE}:${eventId}`;
+    const mapped = STATUS_MAP[mktrLeadsStatus] ?? null;
 
-    // Replay fast-path. Expired rows linger until the hourly purge — take them
-    // over so a re-occurrence after the TTL (status flapped back) is processed.
-    const existing = await m.IdempotencyKey.findOne({ where: { key } });
-    if (existing) {
-      if (new Date(existing.expiresAt).getTime() > Date.now()) {
-        return {
-          statusCode: existing.responseCode ?? 200,
-          body: existing.responseBody ?? { success: true, replay: true },
-        };
-      }
-      await existing.destroy();
-    }
-
+    // Load up front — the prospect is needed for CAPI on BOTH fresh and replay
+    // paths (a previously-failed send must be re-attempted by the sweep).
     const prospect = await m.Prospect.findByPk(externalId, {
       include: [{ model: m.User, as: 'assignedAgent', attributes: ['id', 'mktrLeadsId'] }],
     });
@@ -129,7 +150,26 @@ export function makeExternalLeadOutcomeService(overrides = {}) {
       return { statusCode: 422, body: { success: false, error: 'not_a_mktr_leads_prospect' } };
     }
 
-    const mapped = STATUS_MAP[mktrLeadsStatus] ?? null;
+    // Fold the CAPI retry decision into the HTTP status. The status mirror is
+    // already durable; non-2xx is returned ONLY when a transient CAPI failure
+    // should be re-driven by the mktr-leads sweep (re-fires while
+    // status_changed_at > outcome_reported_at). guarded/permanent stay 2xx.
+    const withCapi = async (code, body) => {
+      const { retryable } = await fireCapi(prospect, mapped, timestamp);
+      return { statusCode: retryable ? 503 : code, body };
+    };
+
+    // Replay fast-path: the mirror was already applied. Still (re)attempt CAPI so
+    // a previously-failed send is retried. Expired rows linger until the hourly
+    // purge — take them over so a re-occurrence after the TTL is processed.
+    const existing = await m.IdempotencyKey.findOne({ where: { key } });
+    if (existing) {
+      if (new Date(existing.expiresAt).getTime() > Date.now()) {
+        return withCapi(existing.responseCode ?? 200, existing.responseBody ?? { success: true, replay: true });
+      }
+      await existing.destroy();
+    }
+
     const previousLeadStatus = prospect.leadStatus;
 
     try {
@@ -189,12 +229,14 @@ export function makeExternalLeadOutcomeService(overrides = {}) {
         return responseBody;
       });
 
-      return { statusCode: 200, body };
+      // Mirror committed → fire CAPI post-commit and fold into the status code.
+      return withCapi(200, body);
     } catch (err) {
       // Concurrent duplicate: another request claimed the key mid-flight and
-      // (by claim-last ordering) has already applied the same event.
+      // (by claim-last ordering) has already applied the same event. Still
+      // (re)attempt CAPI so the send is not skipped.
       if (err?.name === 'SequelizeUniqueConstraintError') {
-        return { statusCode: 200, body: { success: true, replay: true } };
+        return withCapi(200, { success: true, replay: true });
       }
       throw err;
     }

--- a/backend/src/services/leadOutcomeService.js
+++ b/backend/src/services/leadOutcomeService.js
@@ -125,7 +125,12 @@ export function makeLeadOutcomeService(overrides = {}) {
 
     const dispatched = [];
     const duplicate = [];
-    const failed = [];
+    const failed = []; // back-compat: union of all not-sent (incl. guarded)
+    // Granular classification so callers (e.g. the external path) can decide
+    // whether a not-sent result is worth retrying.
+    const guarded = []; // CAPI disabled / ineligible — never retry
+    const transientFailed = []; // 5xx / network — retryable
+    const permanentFailed = []; // 4xx (or unknown not-sent) — do not auto-retry
 
     for (const key of keys) {
       const { markerKey } = EVENTS[key];
@@ -156,6 +161,13 @@ export function makeLeadOutcomeService(overrides = {}) {
       } else {
         // Not marked → reconciliation / next trigger can retry. (`guarded` = CAPI off.)
         failed.push(eventName);
+        if (result?.reason === 'guarded') {
+          guarded.push(eventName);
+        } else if (result?.error != null || (typeof result?.status === 'number' && result.status >= 500)) {
+          transientFailed.push(eventName);
+        } else {
+          permanentFailed.push(eventName);
+        }
         d.logger.warn(
           { prospect_id: prospect.id, event_name: eventName, reason: result?.reason, status: result?.status },
           '[lead-outcome] dispatch not sent (left re-tryable)'
@@ -163,7 +175,7 @@ export function makeLeadOutcomeService(overrides = {}) {
       }
     }
 
-    return { dispatched, duplicate, failed };
+    return { dispatched, duplicate, failed, guarded, transientFailed, permanentFailed };
   }
 
   return { processLeadOutcome };

--- a/backend/test/externalLeadOutcomeService.test.js
+++ b/backend/test/externalLeadOutcomeService.test.js
@@ -33,12 +33,26 @@ function buildDeps(overrides = {}) {
     create: jest.fn().mockResolvedValue(undefined),
   };
   const sequelize = { transaction: jest.fn((fn) => fn('tx')) };
+  // Stub the reused Lyfe CAPI sender. Default = a clean send (no transientFailed)
+  // so the HTTP code reflects the mirror outcome; override per-test to exercise
+  // the guarded / transient / permanent classification.
+  const processLeadOutcome =
+    overrides.processLeadOutcome ??
+    jest.fn().mockResolvedValue({
+      dispatched: [],
+      duplicate: [],
+      failed: [],
+      guarded: [],
+      transientFailed: [],
+      permanentFailed: [],
+    });
   const service = makeExternalLeadOutcomeService({
     sequelize,
     models: { Prospect, ProspectActivity, IdempotencyKey, User: {} },
     logger: silentLogger,
+    processLeadOutcome,
   });
-  return { service, prospect, Prospect, ProspectActivity, IdempotencyKey, sequelize };
+  return { service, prospect, Prospect, ProspectActivity, IdempotencyKey, sequelize, processLeadOutcome };
 }
 
 function payload(overrides = {}) {
@@ -154,18 +168,24 @@ describe('processExternalLeadOutcome', () => {
     expect(result.statusCode).toBe(200);
   });
 
-  it('replays the stored response for a live idempotency key without touching the prospect', async () => {
+  it('replays the stored mirror body but STILL re-attempts CAPI (lets the sweep retry a failed send)', async () => {
     const existingKey = {
       expiresAt: new Date(Date.now() + 60 * 60 * 1000),
       responseCode: 200,
       responseBody: { success: true, appliedLeadStatus: 'won' },
       destroy: jest.fn(),
     };
-    const { service, Prospect } = buildDeps({ existingKey });
+    const { service, Prospect, ProspectActivity, processLeadOutcome } = buildDeps({ existingKey });
     const result = await service.processExternalLeadOutcome(payload());
+    // Cached mirror body returned; mirror NOT re-applied.
     expect(result).toEqual({ statusCode: 200, body: { success: true, appliedLeadStatus: 'won' } });
-    expect(Prospect.findByPk).not.toHaveBeenCalled();
+    expect(ProspectActivity.create).not.toHaveBeenCalled();
     expect(existingKey.destroy).not.toHaveBeenCalled();
+    // But the prospect IS loaded and CAPI re-attempted (marker-gated dedup).
+    expect(Prospect.findByPk).toHaveBeenCalled();
+    expect(processLeadOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({ external_id: 'prospect-uuid-1', new_status: 'won' })
+    );
   });
 
   it('takes over an expired idempotency key and processes the event anew', async () => {
@@ -197,5 +217,72 @@ describe('processExternalLeadOutcome', () => {
     const { service, ProspectActivity } = buildDeps();
     ProspectActivity.create.mockRejectedValue(new Error('db down'));
     await expect(service.processExternalLeadOutcome(payload())).rejects.toThrow('db down');
+  });
+
+  // ── Down-funnel CAPI (ConfirmedResident / ClosedWon) ──────────────────────
+  it('fires CAPI for qualified (ConfirmedResident) via the reused Lyfe sender', async () => {
+    const prospect = makeProspect({ leadStatus: 'contacted' });
+    const { service, processLeadOutcome } = buildDeps({ prospect });
+    const result = await service.processExternalLeadOutcome(
+      payload({ eventId: 'lead-uuid-1:qualified', data: { mktrLeadsStatus: 'qualified' } })
+    );
+    expect(result.statusCode).toBe(200);
+    expect(processLeadOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({ external_id: 'prospect-uuid-1', new_status: 'qualified' })
+    );
+  });
+
+  it('does NOT fire CAPI for non-SC/PR statuses (e.g. lost)', async () => {
+    const prospect = makeProspect({ leadStatus: 'contacted' });
+    const { service, processLeadOutcome } = buildDeps({ prospect });
+    await service.processExternalLeadOutcome(
+      payload({ eventId: 'lead-uuid-1:lost', data: { mktrLeadsStatus: 'lost' } })
+    );
+    expect(processLeadOutcome).not.toHaveBeenCalled();
+  });
+
+  it('returns 503 on a transient CAPI failure so the sweep re-fires', async () => {
+    const processLeadOutcome = jest.fn().mockResolvedValue({
+      dispatched: [], duplicate: [], failed: ['ConfirmedResident'],
+      guarded: [], transientFailed: ['ConfirmedResident'], permanentFailed: [],
+    });
+    const { service } = buildDeps({ processLeadOutcome });
+    const result = await service.processExternalLeadOutcome(
+      payload({ eventId: 'lead-uuid-1:qualified', data: { mktrLeadsStatus: 'qualified' } })
+    );
+    expect(result.statusCode).toBe(503);
+  });
+
+  it('stays 2xx when CAPI is guarded (disabled) — no sweep storm', async () => {
+    const processLeadOutcome = jest.fn().mockResolvedValue({
+      dispatched: [], duplicate: [], failed: ['ConfirmedResident'],
+      guarded: ['ConfirmedResident'], transientFailed: [], permanentFailed: [],
+    });
+    const { service } = buildDeps({ processLeadOutcome });
+    const result = await service.processExternalLeadOutcome(
+      payload({ eventId: 'lead-uuid-1:qualified', data: { mktrLeadsStatus: 'qualified' } })
+    );
+    expect(result.statusCode).toBe(200);
+  });
+
+  it('stays 2xx on a permanent (4xx) CAPI failure — not auto-retried', async () => {
+    const processLeadOutcome = jest.fn().mockResolvedValue({
+      dispatched: [], duplicate: [], failed: ['ConfirmedResident'],
+      guarded: [], transientFailed: [], permanentFailed: ['ConfirmedResident'],
+    });
+    const { service } = buildDeps({ processLeadOutcome });
+    const result = await service.processExternalLeadOutcome(
+      payload({ eventId: 'lead-uuid-1:qualified', data: { mktrLeadsStatus: 'qualified' } })
+    );
+    expect(result.statusCode).toBe(200);
+  });
+
+  it('returns 503 if the CAPI sender throws (treated as transient)', async () => {
+    const processLeadOutcome = jest.fn().mockRejectedValue(new Error('db blip'));
+    const { service } = buildDeps({ processLeadOutcome });
+    const result = await service.processExternalLeadOutcome(
+      payload({ eventId: 'lead-uuid-1:qualified', data: { mktrLeadsStatus: 'qualified' } })
+    );
+    expect(result.statusCode).toBe(503);
   });
 });

--- a/backend/test/leadOutcomeService.test.js
+++ b/backend/test/leadOutcomeService.test.js
@@ -56,7 +56,7 @@ describe('leadOutcomeService.processLeadOutcome', () => {
 
     const result = await svc.processLeadOutcome(QUALIFIED);
 
-    expect(result).toEqual({ dispatched: ['ConfirmedResident'], duplicate: [], failed: [] });
+    expect(result).toMatchObject({ dispatched: ['ConfirmedResident'], duplicate: [], failed: [] });
     expect(sendConversionEvent).toHaveBeenCalledTimes(1);
     const [, ctx, options] = sendConversionEvent.mock.calls[0];
     expect(ctx.eventId).toBe('confirmed_resident:prospect-uuid-1');
@@ -91,7 +91,7 @@ describe('leadOutcomeService.processLeadOutcome', () => {
 
     const result = await svc.processLeadOutcome({ ...QUALIFIED, new_status: 'won' });
 
-    expect(result).toEqual({ dispatched: ['ClosedWon'], duplicate: ['ConfirmedResident'], failed: [] });
+    expect(result).toMatchObject({ dispatched: ['ClosedWon'], duplicate: ['ConfirmedResident'], failed: [] });
     expect(sendConversionEvent).toHaveBeenCalledTimes(1);
     expect(sendConversionEvent.mock.calls[0][2].eventName).toBe('ClosedWon');
   });
@@ -117,7 +117,7 @@ describe('leadOutcomeService.processLeadOutcome', () => {
 
     const result = await svc.processLeadOutcome(QUALIFIED);
 
-    expect(result).toEqual({ dispatched: [], duplicate: [], failed: ['ConfirmedResident'] });
+    expect(result).toMatchObject({ dispatched: [], duplicate: [], failed: ['ConfirmedResident'] });
     expect(prospect.sourceMetadata.capi).toBeUndefined();
     expect(prospect.save).not.toHaveBeenCalled();
   });
@@ -171,7 +171,7 @@ describe('leadOutcomeService.processLeadOutcome', () => {
 
     const result = await svc.processLeadOutcome(QUALIFIED);
 
-    expect(result).toEqual({ dispatched: [], duplicate: ['ConfirmedResident'], failed: [] });
+    expect(result).toMatchObject({ dispatched: [], duplicate: ['ConfirmedResident'], failed: [] });
     expect(sendConversionEvent).not.toHaveBeenCalled();
     expect(prospect.save).not.toHaveBeenCalled();
   });

--- a/docs/plans/mktr-leads-confirmedresident.md
+++ b/docs/plans/mktr-leads-confirmedresident.md
@@ -1,0 +1,108 @@
+# Plan v2 — mktr-leads SC/PR confirmation → Meta ConfirmedResident (full fix)
+
+> Revised after Codex review #1 (changelog at bottom). Two-repo change.
+> Motivating blocker (found independently by Codex + Claude): the external (mktr-leads) outcome path mirrors status but **does not fire CAPI**, so the SC/PR card alone would send nothing to Meta.
+
+## Goal
+When an **mktr-leads agent confirms a lead is SG Citizen/PR on the first call**, fire **ConfirmedResident** to Meta (and **ClosedWon** on `won`), same as the Lyfe path, early enough to land in the 7-day click window.
+
+## The gap (why Part 2 is needed)
+- Lyfe path: status change → `leadOutcomeService.js` → **fires ConfirmedResident/ClosedWon** (deterministic `event_id`, mark-on-success dedup, back-dated, per-campaign pixel).
+- External (mktr-leads) path: status change → `report-lead-outcome` EF → `POST /api/external/lead-outcomes` → `externalLeadOutcomeService.js`, which **only mirrors `Prospect.leadStatus` + writes an activity** and is explicitly *"separate … does NOT fire CAPI"* (`externalLeadOutcomeService.js:13-15`). That note predates the **2026-06-10 pivot** (mktr-leads = a second agent team, not external buyers); post-pivot those leads come from the same Meta campaigns and should feed Meta.
+
+---
+
+## Part 1 — mktr-leads UI (ships via Expo OTA)
+File: `app/(tabs)/leads/[leadId].tsx` (+ styles). UI only; reuses the existing status→outcome pipeline.
+- **"Singapore Citizen / PR?"** card right after the Call/WhatsApp CTAs.
+- **Yes — SC/PR** → `changeStatus('qualified')` (existing path; fires ConfirmedResident once Part 2 ships).
+- **No** → `addLeadActivity(leadId, userId, 'note', 'Marked not Singapore Citizen / PR', { sc_pr: false })` + confirm Alert + `load()`. No status change, no Meta event.
+- **Visibility:** show only when `!readOnly && !lead.deleted_at && !lead.archived_at && (lead.status === 'new' || lead.status === 'contacted')`.
+- **"No" visible state:** if a `note` activity with `metadata.sc_pr === false` exists and status is still new/contacted, collapse to "Marked not SC/PR · Change" (Change re-opens the prompt).
+- Verified: `'note'` ∈ `ActivityType` (`lib/leads.ts:115`); `lead_activities.metadata` is `jsonb` (`20260601000001_init_schema.sql:118`); `lead_activities_insert_own` RLS + grant exist; theme tokens exist (`constants/theme.ts`).
+
+## Part 2 — mktr-platform backend: external path fires CAPI (ships via Render deploy)
+Files: `backend/src/services/leadOutcomeService.js` (enrich return), `backend/src/services/externalLeadOutcomeService.js` (fire CAPI), + Jest tests. **Reuse `leadOutcomeService`, don't duplicate.**
+
+### 2a. Enrich `processLeadOutcome` return — additive, Lyfe-safe
+Today it returns `{ dispatched, duplicate, failed }` and **collapses guarded / 4xx / 5xx / network into `failed`** (`leadOutcomeService.js:156`) — so a caller can't tell "CAPI disabled" from "retryable failure". `dispatchWithRetry` already classifies internally (`reason === 'guarded'`; transient = `error != null || status >= 500`). Surface it:
+```
+{ dispatched:[...], duplicate:[...], guarded:[...], transientFailed:[...], permanentFailed:[...],
+  failed:[...] /* = transient+permanent, kept for back-compat */ }
+```
+Firing behavior unchanged → the Lyfe caller (`lyfeLeadOutcomeController`, which ignores the return beyond logging) is unaffected.
+
+### 2b. External service fires CAPI on EVERY outcome path (marker-gated)
+`processExternalLeadOutcome` must attempt CAPI on all three branches, not just fresh:
+1. **Fresh event:** after the status-mirror txn commits, call CAPI (post-commit).
+2. **Idempotency replay** (`externalLeadOutcomeService.js:101`): currently returns before loading the prospect — must still load + attempt CAPI.
+3. **Unique-constraint conflict** (`externalLeadOutcomeService.js:193`): currently returns 200 — must still attempt CAPI.
+
+CAPI call (post-commit / no open txn; `processLeadOutcome` re-`findByPk`s + self-saves the marker, never throws):
+```js
+const capi = isCapiEligible(mapped)   // mapped === 'qualified' || 'won'
+  ? await leadOutcomeService.processLeadOutcome({
+      external_id: prospect.id,
+      new_status: mapped,
+      occurred_at: payload.timestamp,   // dispatch time — see 2c
+    })
+  : null;
+```
+Marker (`sourceMetadata.capi.{confirmedResidentAt|closedWonAt}`) + Meta `event_id` dedup ⇒ safe to call on every replay/sweep with no double-count.
+
+### 2c. Response classification (drives the mktr-leads sweep, fixes blocker ①)
+The mktr-leads sweep re-fires outcomes whose `status_changed_at > outcome_reported_at`; the EF stamps `outcome_reported_at` only on a `resp.ok` (2xx). So:
+- **2xx** when: status mirror ok AND CAPI result is `sent` / `duplicate` (already-marked) / `guarded` (CAPI off) / `permanentFailed` (4xx — retrying won't help; log for investigation, leave marker unset) / not CAPI-eligible.
+- **non-2xx** (e.g. 503) ONLY when `capi.transientFailed` is non-empty (5xx/network) → EF doesn't stamp → sweep re-fires (re-signs fresh timestamp) → retried, bounded by the sweep's 48-attempt cap.
+
+This never retry-storms on guarded/permanent, and gives at-least-once on transient via the existing sweep.
+
+### 2c-note. event_time = dispatch time (blocker ② → accepted for v1)
+`payload.timestamp` is the EF's dispatch time, not the DB `status_changed_at`. In the happy path the trigger dispatches within seconds of the agent tapping Yes, so it ≈ confirmation time and always lands in Meta's 7-day window (the goal). **Precise fix (send `status_changed_at` from the mktr-leads `_shared/outcome.ts` EF and use it for `event_time`) is a follow-up — it requires redeploying the mktr-leads edge function (separate Supabase project, user-deployed).** Not blocking the goal.
+
+### 2d. Eligibility (intended behavior, not a bug)
+`shouldFireCapi` (`metaCapiService.js:23`) returns true for normal web/QR mktr-leads prospects, and intentionally **skips** `call_bot`/`retellCallId` (Retell) and `sourceMetadata.metaLeadgenId` (native Meta Lead Ads). Those origins shouldn't emit a web-CAPI ConfirmedResident. Documented, no change.
+
+### Config (no new secrets)
+Reuses `META_CAPI_ENABLED`, `META_CAPI_ACCESS_TOKEN`, `META_PIXEL_ID` (+ per-campaign `Campaign.metaPixelId`), `META_EVENT_QUALIFIED`/`META_EVENT_WON`. Match keys come from the prospect's `sourceMetadata` inside `metaCapiService`.
+
+## Testing
+- **Backend Jest** (DI factories `makeExternalLeadOutcomeService` + `makeLeadOutcomeService` with a stub `sendConversionEvent`):
+  - `qualified → ConfirmedResident`; `won → ConfirmedResident + ClosedWon`; `proposed/lost/invalid/disputed → no CAPI`.
+  - classification: `guarded → 2xx` (no sweep); `transientFailed → non-2xx` (sweep retries); `permanentFailed(4xx) → 2xx` + logged, marker unset; `sent/duplicate → 2xx`.
+  - replay branch + unique-conflict branch BOTH attempt CAPI; already-marked ⇒ `duplicate`, no resend.
+  - status-mirror idempotency unchanged (no duplicate activities).
+  - `leadOutcomeService` enriched-return unit test; confirm Lyfe path behavior unchanged.
+- **mktr-leads:** `npm run lint` + `npx tsc --noEmit`; existing `lib/__tests__` green; manual matrix (new/contacted → card; Yes → Qualified + ConfirmedResident in logs; No → note only; readOnly/deleted/archived → no card).
+
+## Rollout (order) + rollback
+1. **Backend first** (mktr-platform → main → Render). Then *every* mktr-leads `qualified`/`won` transition fires CAPI (card is just a faster UI).
+2. **Then mktr-leads OTA** (EAS Update, production channel).
+- Rollback: revert backend commit + redeploy (CAPI stops; mirror unaffected); roll back / re-publish OTA. Independently reversible.
+
+## Risks / watch
+- Response-classification correctness (2c) — the core reliability logic.
+- Double-fire → marker + Meta `event_id` dedup (same as Lyfe).
+- Permanent (4xx) CAPI errors are dropped (2xx, unmarked) pending a future reconciliation backfill — acceptable, matches Lyfe's current posture.
+- event_time precision (2c-note) — dispatch-time for v1.
+
+## Changelog — after Codex review #1
+- **Blocker ① (can't classify guarded vs transient):** fixed by enriching `processLeadOutcome`'s return (2a) and classifying the HTTP response (2c). Guarded/permanent → 2xx (no storm); transient → non-2xx (sweep retries).
+- **Blocker ② (occurred_at ≠ status-change time):** accepted for v1 (dispatch-time ≈ confirmation time, in-window); precise `status_changed_at` fix deferred (needs mktr-leads EF redeploy) (2c-note).
+- **Should-fix ③ (replay coverage):** CAPI now fired on fresh + idempotency-replay + unique-conflict branches (2b).
+- **Should-fix ④ (skips Retell/Meta-Lead-Ads):** confirmed intended; documented (2d).
+- **Nice-to-have ⑤ (same-status flap within 24h TTL):** pre-existing external-service behavior; out of scope.
+
+## Changelog — after Codex review #2 (resolutions baked into the build)
+- **Blocker (marker race):** accepted as benign — Meta `event_id` dedup is the real concurrency guard (double-send deduped, no double-count); a clobbered marker self-heals via the next sweep; the per-status idempotency key + sweep 10-min grace make true concurrency unlikely. Shared Lyfe service persistence left unchanged (re-architecting it is disproportionate risk). Plan wording corrected: `event_id` is the guard, marker is best-effort.
+- **Should-fix (additive return):** `failed` stays = all-not-sent (incl. guarded) so the existing test + Lyfe behavior are unchanged; `guarded`/`transientFailed`/`permanentFailed` added ALONGSIDE. External path classifies on the new fields.
+- **Should-fix (sweep retries current status):** documented v1 limitation — if `qualified` CAPI transient-fails and the lead moves to `lost` before retry, the signal is lost (pre-existing status-based-pipeline property). Robust fix = event-stable outcomes, bundled with the mktr-leads-EF follow-up.
+- **Nit (unguarded throws):** the external service wraps the `processLeadOutcome` call in try/catch → a throw is treated as transient (non-2xx → sweep retries).
+
+## For Codex (review #2 — in depth)
+1. Is the enriched-return classification (2a) faithful to what `dispatchWithRetry`/`sendConversionEvent` actually return (guarded vs 4xx vs 5xx vs network)? Any result shape that would be misclassified?
+2. Is the 2c response mapping correct and storm-proof in all cases (esp. guarded-when-CAPI-off, and permanent 4xx)? Does returning non-2xx interact correctly with the controller's HMAC/freshness + the EF's `outcome_reported_at` stamping + the 48-attempt sweep cap?
+3. Are the replay + unique-conflict branches (2b) safe to fire CAPI from (no open txn, fresh prospect, no double activity)? Any branch still missed?
+4. Any correctness issue with calling a shared `processLeadOutcome` from two controllers concurrently (same prospect marker writes)?
+5. Lyfe regression: is enriching the return truly additive (does `lyfeLeadOutcomeController` rely on the exact shape)?
+6. Anything else that breaks build/prod, or a materially cleaner approach.


### PR DESCRIPTION
## What
Leads worked by the **mktr-leads agent team** (a second team since the 2026-06-10 pivot, sourced from the same Meta campaigns) previously mirrored status onto the Prospect but fired **no Meta CAPI**. So an agent confirming SC/PR sent nothing to Meta for ad optimization. This wires the external outcome path to fire **ConfirmedResident** (on `qualified`) and **ClosedWon** (on `won`), reusing the Lyfe path's sender.

## How
- `leadOutcomeService.processLeadOutcome`: enriched return with `guarded` / `transientFailed` / `permanentFailed` (additive — `failed` kept as the all-not-sent union; Lyfe caller unaffected).
- `externalLeadOutcomeService`: after mirroring status, reuse `processLeadOutcome` → identical `event_id` / mark-on-success dedup / back-date / per-campaign pixel. Fires CAPI on **all** branches (fresh + idempotency-replay + unique-conflict) so the mktr-leads reconcile sweep can retry a failed send. **Response: non-2xx only on a transient (5xx/network) CAPI failure** (sweep re-fires); `guarded` (CAPI off) and `permanent` (4xx) stay 2xx (no storm); a throw is treated as transient.
- Concurrency guard is Meta `event_id` dedup (marker best-effort); shared Lyfe persistence unchanged. `event_time` = dispatch-time for v1 (≈ confirmation, in-window).

## Reviewed
Two in-depth Codex 5.5 xhigh passes + my reconciliation (plan: `docs/plans/mktr-leads-confirmedresident.md`). Blockers found & resolved across the passes (the original "external path fires no CAPI" gap; classification of guarded-vs-transient; replay coverage; additive return).

## Tests
`externalLeadOutcomeService.test.js` (new CAPI classification: guarded/transient/permanent/throw/replay) + `leadOutcomeService.test.js` (enriched return) + `externalLeadOutcomeController.test.js` ✓. The `externalLeadOutcomesRoute` integration suite needs a local Postgres (pre-existing chronic-red).

## Pairs with
mktr-leads PR (the SC/PR card). **Deploy this backend FIRST**, then the mktr-leads OTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)