### PR TITLE
feat(meta): email alert on redeemed-audience sync failure

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -202,6 +202,9 @@ REDEEMED_AUDIENCE_SYNC_MODE=add
 REDEEMED_AUDIENCE_REQUIRE_CONSENT=true
 # In-process schedule cadence (hours): initial run ~60s after boot, then every N hours. Default 24.
 REDEEMED_AUDIENCE_SYNC_INTERVAL_HOURS=24
+# Email for "bad run" alerts (hard failure or Meta-rejected records). Unset = no
+# email (log + Sentry only). Sender defaults to noreply@mktr.sg.
+REDEEMED_AUDIENCE_ALERT_EMAIL=
 # (Graph API version is shared via META_GRAPH_API_VERSION above; defaults v21.0.)
 
 # -----------------------------------------------------------------------------

--- a/backend/src/services/redeemedAudienceService.js
+++ b/backend/src/services/redeemedAudienceService.js
@@ -3,6 +3,7 @@ import { Op } from 'sequelize';
 import { Prospect } from '../models/index.js';
 import { hashEmail, hashPhone } from '../utils/piiHashing.js';
 import { logger } from '../utils/logger.js';
+import { sendEmail } from './mailer.js';
 
 /**
  * Redeemed-audience sync — pushes redeemers (hashed email + phone) from our own
@@ -31,7 +32,7 @@ const MAX_BATCH = 10000; // Meta cap: ≤10,000 users per /users request
 const AUDIENCE_SCHEMA = ['EMAIL', 'PHONE'];
 const SYNTHETIC_EMAIL_SUFFIX = '@calls.mktr.sg'; // Retell placeholder addresses
 
-const defaultDeps = { Prospect, fetch: globalThis.fetch };
+const defaultDeps = { Prospect, fetch: globalThis.fetch, sendEmail };
 
 /** Read the configured Graph API version at call time (env-overridable). */
 function graphVersion() {
@@ -142,8 +143,26 @@ export async function uploadBatch(
 }
 
 /**
+ * Email a "bad run" alert (hard failure, or Meta rejected records) to
+ * REDEEMED_AUDIENCE_ALERT_EMAIL when configured. Fire-and-forget: never throws,
+ * never blocks the sync result. Body carries counts + the error message only —
+ * never PII or invalid_entry_samples. Sender defaults to the mailer's
+ * noreply@mktr.sg.
+ */
+async function sendBadRunAlert(d, subject, body) {
+  const to = process.env.REDEEMED_AUDIENCE_ALERT_EMAIL;
+  if (!to) return;
+  try {
+    await d.sendEmail({ to, subject, text: body });
+    logger.info({ to }, 'redeemed_audience.sync.alert_sent');
+  } catch (err) {
+    logger.warn({ err: err.message }, 'redeemed_audience.sync.alert_failed');
+  }
+}
+
+/**
  * Orchestrate a full sync. Never throws — errors land in Sentry + structured
- * logs (counts only). Returns a summary object.
+ * logs (counts only) + an optional email alert. Returns a summary object.
  */
 export async function syncRedeemedAudience(deps = {}) {
   const d = { ...defaultDeps, ...deps };
@@ -200,10 +219,42 @@ export async function syncRedeemedAudience(deps = {}) {
       { eligible: rows.length, totalReceived, totalInvalid, mode },
       'redeemed_audience.sync.done'
     );
+    if (totalInvalid > 0) {
+      await sendBadRunAlert(
+        d,
+        `⚠️ MKTR redeemed-audience sync — ${totalInvalid} record(s) rejected`,
+        [
+          'The redeemed-audience sync completed but Meta rejected some records.',
+          '',
+          `Eligible:  ${rows.length}`,
+          `Received:  ${totalReceived}`,
+          `Invalid:   ${totalInvalid}`,
+          `Audience:  ${audienceId}`,
+          `Time:      ${new Date().toISOString()}`,
+          '',
+          'Check Render logs (mktr-backend-jo6r, search "redeemed_audience").',
+        ].join('\n')
+      );
+    }
     return { synced: true, eligible: rows.length, totalReceived, totalInvalid };
   } catch (err) {
     Sentry.captureException(err, { tags: { source: 'redeemed_audience_sync' } });
     logger.error({ err: err.message }, 'redeemed_audience.sync.failed');
+    await sendBadRunAlert(
+      d,
+      '⚠️ MKTR redeemed-audience sync FAILED',
+      [
+        'The redeemed-audience sync failed — no redeemers were uploaded this run.',
+        '',
+        `Error:     ${err.message}`,
+        `Audience:  ${process.env.META_REDEEMED_AUDIENCE_ID || '(unset)'}`,
+        `Mode:      ${process.env.REDEEMED_AUDIENCE_SYNC_MODE || 'add'}`,
+        `Time:      ${new Date().toISOString()}`,
+        '',
+        'It will retry on the next scheduled run (~24h) or next deploy.',
+        'Check Render logs (mktr-backend-jo6r, search "redeemed_audience") + Sentry (source:redeemed_audience_sync).',
+      ].join('\n')
+    );
     return { synced: false, error: err.message };
   }
 }

--- a/backend/test/redeemedAudienceService.test.js
+++ b/backend/test/redeemedAudienceService.test.js
@@ -35,6 +35,7 @@ const ENV_KEYS = [
   'META_GRAPH_API_VERSION',
   'REDEEMED_AUDIENCE_REQUIRE_CONSENT',
   'REDEEMED_AUDIENCE_SYNC_MODE',
+  'REDEEMED_AUDIENCE_ALERT_EMAIL',
 ];
 const envBackup = {};
 
@@ -262,5 +263,39 @@ describe('syncRedeemedAudience', () => {
     const result = await syncRedeemedAudience({ fetch: fetchSpy, Prospect });
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(result.eligible).toBe(1);
+  });
+
+  it('emails a failure alert when REDEEMED_AUDIENCE_ALERT_EMAIL is set', async () => {
+    process.env.REDEEMED_AUDIENCE_ALERT_EMAIL = 'ops@example.com';
+    const fetchSpy = jest.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
+    const Prospect = { findAll: jest.fn().mockResolvedValue([prospect()]) };
+    const sendEmail = jest.fn().mockResolvedValue({ success: true });
+    const result = await syncRedeemedAudience({ fetch: fetchSpy, Prospect, sendEmail });
+    expect(result.synced).toBe(false);
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    const arg = sendEmail.mock.calls[0][0];
+    expect(arg.to).toBe('ops@example.com');
+    expect(arg.subject).toMatch(/FAILED/);
+    expect(arg.text).toMatch(/HTTP 500/);
+  });
+
+  it('does NOT email when REDEEMED_AUDIENCE_ALERT_EMAIL is unset', async () => {
+    const fetchSpy = jest.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
+    const Prospect = { findAll: jest.fn().mockResolvedValue([prospect()]) };
+    const sendEmail = jest.fn();
+    await syncRedeemedAudience({ fetch: fetchSpy, Prospect, sendEmail });
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it('emails an alert when Meta rejects records (num_invalid_entries > 0)', async () => {
+    process.env.REDEEMED_AUDIENCE_ALERT_EMAIL = 'ops@example.com';
+    const fetchSpy = okFetch({ num_received: 1, num_invalid_entries: 1 });
+    const Prospect = { findAll: jest.fn().mockResolvedValue([prospect()]) };
+    const sendEmail = jest.fn().mockResolvedValue({ success: true });
+    const result = await syncRedeemedAudience({ fetch: fetchSpy, Prospect, sendEmail });
+    expect(result.synced).toBe(true);
+    expect(result.totalInvalid).toBe(1);
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(sendEmail.mock.calls[0][0].subject).toMatch(/rejected/);
   });
 });


### PR DESCRIPTION
## Summary
Email alert when a redeemed-audience sync run is **bad** — so you hear about failures without watching logs. Follow-up to #56.

A "bad run" = a hard failure (token / network / non-2xx from Meta) **or** Meta rejecting records (`num_invalid_entries > 0`). On either, it emails `REDEEMED_AUDIENCE_ALERT_EMAIL` via the existing mailer (sender `noreply@mktr.sg`).

- Fire-and-forget: never throws, never blocks/masks the sync result.
- Body = **counts + error message only** — no PII, no `invalid_entry_samples`.
- **Failure-only** (no email on healthy runs).
- Unset `REDEEMED_AUDIENCE_ALERT_EMAIL` → no email (log + Sentry only — unchanged).
- +3 unit tests (24 total, all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
