### PR TITLE
fix(otp): always send SSIR-registered SMS sender ID from ap-southeast-1

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -79,8 +79,9 @@ EMAIL_PASSWORD=your-email-password-here
 AWS_ACCESS_KEY_ID=your-aws-access-key-id
 AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key
 AWS_REGION=ap-southeast-1
-# Optional alphanumeric sender ID (note: not supported for +65 SG numbers)
-# AWS_SNS_SENDER_ID=MKTR
+# AWS SNS sender ID — REQUIRED for +65 SG: must be the SSIR-registered ID (case-
+# sensitive) or SG telcos relabel the sender "Likely-SCAM". Code defaults to "MKTR".
+AWS_SNS_SENDER_ID=MKTR
 
 # Meta WhatsApp Cloud API — WhatsApp OTP channel (optional)
 # From WhatsApp Manager → API setup. Requires an APPROVED Authentication

--- a/backend/env.example
+++ b/backend/env.example
@@ -78,8 +78,9 @@ SYSTEM_AGENT_EMAIL=system@mktr.local
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_REGION=ap-southeast-1
-# Optional: Sender ID (e.g. "MKTR"). Leave blank to use shared/default routes.
-AWS_SNS_SENDER_ID=
+# AWS SNS sender ID. Must be your SSIR-registered ID (case-sensitive) or Singapore
+# telcos relabel it "Likely-SCAM". Code defaults to "MKTR" if unset; set explicitly.
+AWS_SNS_SENDER_ID=MKTR
 
 # Meta WhatsApp Cloud API
 WHATSAPP_PROVIDER=meta

--- a/backend/src/services/verificationService.js
+++ b/backend/src/services/verificationService.js
@@ -5,9 +5,18 @@ import { SNSClient, PublishCommand } from '@aws-sdk/client-sns';
 import { AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
 
+// AWS SNS SMS config. The region + sender ID must match our SSIR-registered
+// identity in AWS, or Singapore telcos relabel the sender as "Likely-SCAM".
+// "MKTR" is the SSIR-registered sender ID (Live, case-sensitive) and it is
+// registered in ap-southeast-1 — both are defaulted here so a missing env var
+// can't silently regress OTP SMS back to the scam label. Kept in lock-step with
+// lyfe-app's custom-sms-hook, which hardcodes the same "MKTR" / ap-southeast-1.
+const SMS_REGION = process.env.AWS_REGION || 'ap-southeast-1';
+const SMS_SENDER_ID = process.env.AWS_SNS_SENDER_ID || 'MKTR';
+
 // Initialize SNS Client
 const snsClient = new SNSClient({
-  region: process.env.AWS_REGION || 'us-east-1',
+  region: SMS_REGION,
   credentials: {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY
@@ -80,14 +89,11 @@ const sendWhatsAppOtpMeta = async (phone, code) => {
 // Helper to send OTP via SMS (AWS SNS)
 const sendSmsOtp = async (fullPhone, code) => {
   const messageAttributes = {
-    'AWS.SNS.SMS.SMSType': { DataType: 'String', StringValue: 'Transactional' }
+    'AWS.SNS.SMS.SMSType': { DataType: 'String', StringValue: 'Transactional' },
+    // Always attach the registered sender ID (defaults to "MKTR") so SG telcos
+    // don't relabel the message "Likely-SCAM". See SMS_SENDER_ID above.
+    'AWS.SNS.SMS.SenderID': { DataType: 'String', StringValue: SMS_SENDER_ID }
   };
-  if (process.env.AWS_SNS_SENDER_ID) {
-    messageAttributes['AWS.SNS.SMS.SenderID'] = {
-      DataType: 'String',
-      StringValue: process.env.AWS_SNS_SENDER_ID
-    };
-  }
   const command = new PublishCommand({
     PhoneNumber: fullPhone,
     Message: `Your verification code is: ${code}`,


### PR DESCRIPTION
OTP SMS via AWS SNS only attached AWS.SNS.SMS.SenderID when AWS_SNS_SENDER_ID was set, and defaulted the region to us-east-1. With either unset, Singapore telcos relabel the sender "Likely-SCAM" (an unregistered alphanumeric sender ID under the SG SSIR registry).

Default the sender ID to "MKTR" (our SSIR-registered, case-sensitive ID) and the region to ap-southeast-1 where it is registered, matching the lyfe-app custom-sms-hook, so a missing env var can no longer regress OTP SMS to the scam label. Env templates updated to match (the old .env.example wrongly claimed sender IDs are unsupported for +65 numbers).