### PR TITLE
fix(prospects): stop public lead-capture outage (consent_third_party) + drift-proof endpoint

### DIFF
--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -1,9 +1,18 @@
 import Joi from 'joi';
+import { logger } from '../utils/logger.js';
 
-// Validation middleware
-export const validate = (schema) => {
+// Validation middleware.
+//
+// Optional per-route Joi options (2nd arg) let a route opt into stripUnknown.
+// The PUBLIC lead-capture route (POST /prospects) uses { stripUnknown: true } so
+// an additive frontend field (frontend/backend contract drift) is DROPPED rather
+// than 400ing the whole submission and losing the lead — a recurring failure mode
+// for that revenue-critical endpoint, and a defence against a client injecting
+// server-controlled keys (e.g. consentMetadata) it must never set. Internal /
+// admin routes deliberately omit it so typos and stale clients keep failing loudly.
+export const validate = (schema, options = {}) => {
   return (req, res, next) => {
-    const { error } = schema.validate(req.body, { abortEarly: false });
+    const { error, value } = schema.validate(req.body, { abortEarly: false, ...options });
 
     if (error) {
       const details = error.details.map(detail => ({
@@ -17,6 +26,22 @@ export const validate = (schema) => {
         details: 'Invalid request data',
         errors: details
       });
+    }
+
+    // Only when a route explicitly opted into stripping do we swap in the
+    // sanitized body; every other route keeps the raw req.body untouched, so this
+    // change cannot alter Joi type-coercion behaviour for them.
+    if (options.stripUnknown && value && typeof value === 'object') {
+      const stripped = Object.keys(req.body || {}).filter((k) => !(k in value));
+      if (stripped.length > 0) {
+        // A stripped key almost always means frontend/backend contract drift.
+        // Warn so the next mismatch isn't silent now that it no longer 400s.
+        logger.warn(
+          { route: req.originalUrl, strippedKeys: stripped },
+          'validate(): dropped unknown request keys'
+        );
+      }
+      req.body = value;
     }
 
     next();

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -181,6 +181,13 @@ export const schemas = {
     // metaCapiService._buildPayload's `marketingConsent` check.
     consent_contact: Joi.boolean().optional(),
     consent_terms: Joi.boolean().optional(),
+    // Third-party-disclosure consent (separate opt-in checkbox added to the
+    // public form in a446577). Whitelisted so the submission stops 400ing on the
+    // unknown key. Turning it into the `consentMetadata.external` evidence that
+    // actually unlocks external/buyer-agent delivery is a follow-up — see
+    // services/externalConsent.hasValidExternalConsent; until then external stays
+    // inert and the flag is stripped server-side (prospectService) rather than persisted.
+    consent_third_party: Joi.boolean().optional(),
     // Quiz funnel: raw answers + an advisory client-computed result. The server
     // RE-SCORES authoritatively from campaign.design_config.quiz (see
     // prospectService.createProspect) and stashes the result in

--- a/backend/src/routes/prospects.js
+++ b/backend/src/routes/prospects.js
@@ -23,8 +23,10 @@ const leadCaptureLimit = rateLimit({
 // Get all prospects
 router.get('/', authenticateToken, prospectController.listProspects);
 
-// Create new prospect (lead capture) — rate-limited, no auth required
-router.post('/', leadCaptureLimit, validate(schemas.prospectCreate), prospectController.createProspect);
+// Create new prospect (lead capture) — rate-limited, no auth required.
+// stripUnknown: this public endpoint must never 400 (and lose a lead) over an
+// additive/unknown frontend field — see validate() in middleware/validation.js.
+router.post('/', leadCaptureLimit, validate(schemas.prospectCreate, { stripUnknown: true }), prospectController.createProspect);
 
 // Held (quarantined) lead-quota queue — must precede '/:id' so 'held' is not read as an id.
 router.get('/held', authenticateToken, requireAgentOrAdmin, prospectController.listHeldProspects);

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -135,7 +135,7 @@ export function makeProspectService(overrides = {}) {
     const {
       eventId: _e, fbp: _p, fbc: _c, eventSourceUrl: _u,
       registrationEventId: _re, ttclid: _tc, ttp: _tp,
-      consent_contact: _cc, consent_terms: _ct,
+      consent_contact: _cc, consent_terms: _ct, consent_third_party: _ctp,
       quizResult: _qr, referralRef: _rref,
       utm_source: _us, utm_medium: _um, utm_campaign: _ucmp, utm_content: _ucnt, utm_term: _utm,
       ...bodyWithoutMeta

--- a/backend/test/validation.test.js
+++ b/backend/test/validation.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
-import { schemas } from '../src/middleware/validation.js';
+import Joi from 'joi';
+import { schemas, validate } from '../src/middleware/validation.js';
 
 const valid = (schema, body) => {
   const { error, value } = schema.validate(body, { abortEarly: false });
@@ -284,5 +285,72 @@ describe('schemas.prospectCreate', () => {
 describe('schemas (regression — no driverCreate)', () => {
   it('does not export driverCreate (deleted as dead 2026-05-13)', () => {
     expect(schemas.driverCreate).toBeUndefined();
+  });
+});
+
+describe('validate() middleware — stripUnknown opt-in (public lead-capture hardening)', () => {
+  // Run the middleware with a fake req/res/next — no Express, no DB.
+  const run = (schema, body, options) => {
+    const req = { body, originalUrl: '/test' };
+    const res = {
+      statusCode: undefined,
+      payload: undefined,
+      status(code) { this.statusCode = code; return this; },
+      json(p) { this.payload = p; return this; },
+    };
+    let nexted = false;
+    validate(schema, options)(req, res, () => { nexted = true; });
+    return { req, res, nexted };
+  };
+
+  const sample = Joi.object({
+    a: Joi.string().required(),
+    b: Joi.number().optional(),
+  });
+
+  it('default (no options) rejects unknown keys with 400 — back-compat preserved', () => {
+    const { res, nexted } = run(sample, { a: 'x', junk: 1 });
+    expect(nexted).toBe(false);
+    expect(res.statusCode).toBe(400);
+    expect(res.payload.errors[0].field).toBe('junk');
+  });
+
+  it('default (no options) does NOT swap req.body (raw body preserved for other routes)', () => {
+    const body = { a: 'x', b: 2 };
+    const { req, nexted } = run(sample, body);
+    expect(nexted).toBe(true);
+    expect(req.body).toBe(body); // same reference — middleware did not reassign
+  });
+
+  it('stripUnknown:true drops unknown keys, calls next(), keeps known fields', () => {
+    const { req, res, nexted } = run(
+      sample,
+      { a: 'x', b: 2, junk: 1, consentMetadata: { external: {} } },
+      { stripUnknown: true },
+    );
+    expect(res.statusCode).toBeUndefined();
+    expect(nexted).toBe(true);
+    expect(req.body).toEqual({ a: 'x', b: 2 });
+    expect('junk' in req.body).toBe(false);
+    expect('consentMetadata' in req.body).toBe(false); // consent-forgery defence
+  });
+
+  it('stripUnknown:true still 400s on a real validation error (missing required)', () => {
+    const { res, nexted } = run(sample, { b: 2, junk: 1 }, { stripUnknown: true });
+    expect(nexted).toBe(false);
+    expect(res.statusCode).toBe(400);
+    expect(res.payload.errors.some((e) => e.field === 'a')).toBe(true);
+  });
+
+  it('prospectCreate + stripUnknown: an unknown future field is dropped, not rejected (no lead loss)', () => {
+    const { req, res, nexted } = run(
+      schemas.prospectCreate,
+      { firstName: 'Jane', email: 'jane@example.com', leadSource: 'website', some_future_field: true },
+      { stripUnknown: true },
+    );
+    expect(res.statusCode).toBeUndefined();
+    expect(nexted).toBe(true);
+    expect('some_future_field' in req.body).toBe(false);
+    expect(req.body.firstName).toBe('Jane');
   });
 });

--- a/backend/test/validation.test.js
+++ b/backend/test/validation.test.js
@@ -222,6 +222,65 @@ describe('schemas.leadPackageCreate', () => {
   });
 });
 
+describe('schemas.prospectCreate', () => {
+  // Minimal valid public lead-capture body (firstName/email/leadSource required).
+  const validBody = {
+    firstName: 'Jane',
+    email: 'jane@example.com',
+    leadSource: 'website',
+  };
+
+  it('accepts the minimal required body', () => {
+    const { ok } = valid(schemas.prospectCreate, validBody);
+    expect(ok).toBe(true);
+  });
+
+  // Regression for the production outage: the form ships consent_third_party as a
+  // boolean (un-ticked => false survives the client null/''/undefined filter), so
+  // every submit carried the key. Before it was whitelisted the schema rejected the
+  // whole request with `"consent_third_party" is not allowed` and the lead was lost.
+  it('accepts consent_third_party:false (un-ticked box — the failing case)', () => {
+    const { ok, error } = valid(schemas.prospectCreate, { ...validBody, consent_third_party: false });
+    expect(error).toBeUndefined();
+    expect(ok).toBe(true);
+  });
+
+  it('accepts consent_third_party:true (ticked box)', () => {
+    const { ok } = valid(schemas.prospectCreate, { ...validBody, consent_third_party: true });
+    expect(ok).toBe(true);
+  });
+
+  it('accepts all three consent flags together', () => {
+    const { ok } = valid(schemas.prospectCreate, {
+      ...validBody,
+      consent_contact: true,
+      consent_terms: true,
+      consent_third_party: false,
+    });
+    expect(ok).toBe(true);
+  });
+
+  it('omitting consent_third_party is fine (optional)', () => {
+    const { ok } = valid(schemas.prospectCreate, validBody);
+    expect(ok).toBe(true);
+  });
+
+  it('rejects a non-boolean consent_third_party', () => {
+    const { ok, error } = valid(schemas.prospectCreate, { ...validBody, consent_third_party: 'yes' });
+    expect(ok).toBe(false);
+    expect(error.details[0].path).toEqual(['consent_third_party']);
+  });
+
+  // Guard: the fix is surgical — whitelist THIS field only. Until the scoped
+  // stripUnknown hardening (Layer 2) ships, the schema must still reject genuinely
+  // unknown keys so contract drift on other fields keeps failing loudly.
+  it('still rejects a genuinely unknown field', () => {
+    const { ok, error } = valid(schemas.prospectCreate, { ...validBody, totally_unknown_field: true });
+    expect(ok).toBe(false);
+    expect(error.details[0].path).toEqual(['totally_unknown_field']);
+  });
+});
+
 describe('schemas (regression — no driverCreate)', () => {
   it('does not export driverCreate (deleted as dead 2026-05-13)', () => {
     expect(schemas.driverCreate).toBeUndefined();


### PR DESCRIPTION
## Production incident: public lead-capture was losing 100% of leads

Every submit on the redeem.sg / mktr.sg lead-capture form 400'd with
`Validation Error: consent_third_party: "consent_third_party" is not allowed`
→ the prospect was never created. Cause: a446577 added the `consent_third_party`
consent checkbox to the **frontend** form (sent as a boolean on every submit) but
never updated the **backend** — `schemas.prospectCreate` didn't whitelist it and
`validate()` runs Joi with the default `allowUnknown:false`, so the unknown key
rejected the whole request.

### Layer 1 — hotfix (`6832b48`): stop the bleeding
- `validation.js`: whitelist `consent_third_party: Joi.boolean().optional()`.
- `prospectService.js`: strip it alongside `consent_contact`/`consent_terms` so it
  never reaches Sequelize. Nothing consumes it yet (external delivery stays inert).
- Tests: `prospectCreate` coverage incl. the exact regression (`consent_third_party:false`).

### Layer 2 — hardening (`69430a8`): drift-proof the endpoint
- `validate()` takes per-route Joi options; `POST /prospects` opts into
  `{ stripUnknown: true }` so an additive/unknown frontend field is **dropped**, not
  rejected — leads are never lost to contract drift again (utm_* were lost this way
  before). Also blocks client-injected `consentMetadata` (consent-forgery defence).
  `req.body` is only swapped for opt-in routes; the other ~16 `validate()` callers are
  unaffected. Stripped keys are logged.
- DB-free `validate()` middleware unit tests added.

### Verification
- `backend/test/validation.test.js`: **42/42 pass**, eslint clean.
- Reviewed by Codex (gpt-5.5, xhigh); verified the diagnosis and that every field read
  off `req.body` in the create path is in the schema, so the stripUnknown body-swap is safe.
- DB-backed integration tests run in CI (local sandbox had no Postgres schema).

### Follow-up (not in this PR)
Layer 3: consume `consent_third_party===true` → write `consentMetadata.external`
(`{version, consentedAt, channels[], sourceUrl?}` per `hasValidExternalConsent()`),
which actually unlocks external/buyer delivery. Needs product input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
