### PR TITLE
feat(prospects): capture third-party-disclosure consent (consentMetadata.external)

### DIFF
--- a/backend/src/services/externalConsent.js
+++ b/backend/src/services/externalConsent.js
@@ -64,3 +64,52 @@ export function extractExternalConsent(prospectOrMeta) {
   if (meta && typeof meta === 'object' && meta.external) return meta.external;
   return null;
 }
+
+/**
+ * Current third-party-disclosure consent wording version. A label tying each
+ * recorded consent to the exact copy the person agreed to. BUMP IT (to the date
+ * the copy changes) whenever the consent_third_party checkbox wording on the
+ * lead-capture form (CampaignSignupForm.jsx) is edited.
+ */
+export const THIRD_PARTY_CONSENT_VERSION = '2026-06-26';
+
+/**
+ * Contact channels the third-party-disclosure consent covers. Recorded on every
+ * captured consent so a downstream buyer-agent knows how the person agreed to be
+ * reached. Keep in sync with what the privacy policy / consent copy actually says.
+ */
+export const THIRD_PARTY_CONSENT_CHANNELS = Object.freeze(['phone', 'whatsapp', 'email']);
+
+/**
+ * Build the `consentMetadata.external` evidence for a lead-capture submission.
+ *
+ * Returns the evidence ONLY when the person affirmatively ticked the third-party
+ * disclosure box (consented === true). For an unticked / missing / non-true box it
+ * returns null so NOTHING is written — absence is the fail-safe (no evidence =>
+ * never external => no competitor-PII leak). The returned object is guaranteed to
+ * satisfy hasValidExternalConsent().
+ *
+ * @param {boolean} consented - the consent_third_party flag from the form.
+ * @param {{ sourceUrl?: string, at?: string }} [opts] - sourceUrl: capture-page URL
+ *   (audit breadcrumb); at: ISO timestamp (missing/unparseable falls back to now).
+ * @returns {{version:string,consentedAt:string,channels:string[],sourceUrl?:string}|null}
+ */
+export function buildExternalConsentEvidence(consented, opts = {}) {
+  if (consented !== true) return null;
+
+  // Use a caller-supplied timestamp only if it actually parses; otherwise fall back to
+  // now — so the returned evidence is ALWAYS valid per hasValidExternalConsent().
+  const at = typeof opts.at === 'string' ? opts.at.trim() : '';
+  const consentedAt = at && !Number.isNaN(Date.parse(at)) ? at : new Date().toISOString();
+  const sourceUrl =
+    typeof opts.sourceUrl === 'string' && opts.sourceUrl.trim().length > 0
+      ? opts.sourceUrl.trim()
+      : undefined;
+
+  return {
+    version: THIRD_PARTY_CONSENT_VERSION,
+    consentedAt,
+    channels: [...THIRD_PARTY_CONSENT_CHANNELS],
+    ...(sourceUrl ? { sourceUrl } : {}),
+  };
+}

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -14,7 +14,7 @@ import {
 import { resolveAssignedAgentId, resolveLeadRouting, getSystemAgentId, resolveLeadAssignment } from './systemAgent.js';
 import { deductLeadCredit, chargeLeadCredit, deductExternalLeadBalance } from './leadCredits.js';
 import { decideAssignment } from './leadQuota.js';
-import { hasValidExternalConsent } from './externalConsent.js';
+import { hasValidExternalConsent, buildExternalConsentEvidence } from './externalConsent.js';
 import { repeatSignupDetail, repeatSignupCounts } from './repeatSignup.js';
 import { buildProspectWhere } from '../middleware/prospectScope.js';
 import { AppError } from '../middleware/errorHandler.js';
@@ -78,6 +78,7 @@ const defaultDeps = {
   deductLeadCredit,
   deductExternalLeadBalance,
   hasValidExternalConsent,
+  buildExternalConsentEvidence,
   chargeLeadCredit,
   decideAssignment,
   buildProspectWhere,
@@ -116,6 +117,10 @@ export function makeProspectService(overrides = {}) {
     // Consent flags: preserve explicit `false` (user opted out) via !== undefined check.
     const consentContact = safeBody.consent_contact;
     const consentTerms = safeBody.consent_terms;
+    // Third-party-disclosure consent — the explicit opt-in that gates EXTERNAL
+    // (MKTR Leads buyer-agent) delivery. Distinct from the marketing booleans above;
+    // recorded as consentMetadata.external evidence below, never as a CAPI signal.
+    const consentThirdParty = safeBody.consent_third_party;
 
     // Quiz funnel submission (re-scored server-side after the campaign loads),
     // ad attribution (UTM) and referral identity (the sharer's prospect UUID from
@@ -136,6 +141,10 @@ export function makeProspectService(overrides = {}) {
       eventId: _e, fbp: _p, fbc: _c, eventSourceUrl: _u,
       registrationEventId: _re, ttclid: _tc, ttp: _tp,
       consent_contact: _cc, consent_terms: _ct, consent_third_party: _ctp,
+      // consentMetadata is SERVER-authoritative — the third-party-consent evidence is
+      // built below from consent_third_party. Drop any client-supplied value so external
+      // consent can never be forged via the body (defence-in-depth beyond route stripUnknown).
+      consentMetadata: _cm,
       quizResult: _qr, referralRef: _rref,
       utm_source: _us, utm_medium: _um, utm_campaign: _ucmp, utm_content: _ucnt, utm_term: _utm,
       ...bodyWithoutMeta
@@ -158,6 +167,17 @@ export function makeProspectService(overrides = {}) {
     };
     if (Object.keys(capiSourceMetadata).length > 0) {
       incoming.sourceMetadata = { ...(incoming.sourceMetadata || {}), ...capiSourceMetadata };
+    }
+
+    // Third-party-disclosure consent evidence. Written ONLY when the person ticked
+    // the box (=> consentMetadata.external), which — together with the campaign's
+    // externalEligible flag — unlocks external delivery via the allowExternal gate
+    // below (hasValidExternalConsent). Unticked => null => nothing written => never external.
+    const externalConsent = d.buildExternalConsentEvidence(consentThirdParty, {
+      sourceUrl: eventSourceUrl,
+    });
+    if (externalConsent) {
+      incoming.consentMetadata = { ...(incoming.consentMetadata || {}), external: externalConsent };
     }
 
     // Capture the campaign the caller explicitly asked for (e.g. a bare

--- a/backend/test/externalConsent.test.js
+++ b/backend/test/externalConsent.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  buildExternalConsentEvidence,
+  hasValidExternalConsent,
+  THIRD_PARTY_CONSENT_VERSION,
+  THIRD_PARTY_CONSENT_CHANNELS,
+} from '../src/services/externalConsent.js';
+
+describe('buildExternalConsentEvidence', () => {
+  it('returns null when the box was NOT ticked (fail-safe — nothing written)', () => {
+    expect(buildExternalConsentEvidence(false)).toBeNull();
+    expect(buildExternalConsentEvidence(undefined)).toBeNull();
+    expect(buildExternalConsentEvidence(null)).toBeNull();
+  });
+
+  it('only true counts — truthy-but-not-true values are rejected', () => {
+    // Guards against a stale client sending "true"/1 instead of a real boolean.
+    expect(buildExternalConsentEvidence('true')).toBeNull();
+    expect(buildExternalConsentEvidence(1)).toBeNull();
+  });
+
+  it('builds the full evidence when ticked (version + channels + timestamp + sourceUrl)', () => {
+    const ev = buildExternalConsentEvidence(true, {
+      sourceUrl: 'https://redeem.sg/t/some-campaign',
+      at: '2026-06-26T08:11:00.000Z',
+    });
+    expect(ev).toEqual({
+      version: THIRD_PARTY_CONSENT_VERSION,
+      consentedAt: '2026-06-26T08:11:00.000Z',
+      channels: ['phone', 'whatsapp', 'email'],
+      sourceUrl: 'https://redeem.sg/t/some-campaign',
+    });
+  });
+
+  it('defaults consentedAt to now (parseable ISO) when no timestamp given', () => {
+    const before = Date.now();
+    const ev = buildExternalConsentEvidence(true, { sourceUrl: 'https://mktr.sg/LeadCapture' });
+    const t = Date.parse(ev.consentedAt);
+    expect(Number.isNaN(t)).toBe(false);
+    expect(t).toBeGreaterThanOrEqual(before - 1000);
+  });
+
+  it('ignores an unparseable `at` and falls back to now (keeps evidence valid)', () => {
+    const ev = buildExternalConsentEvidence(true, { at: 'not-a-date' });
+    expect(Number.isNaN(Date.parse(ev.consentedAt))).toBe(false);
+    expect(hasValidExternalConsent({ consentMetadata: { external: ev } })).toBe(true);
+  });
+
+  it('omits sourceUrl cleanly when absent or blank (still valid evidence)', () => {
+    const ev = buildExternalConsentEvidence(true, {});
+    expect('sourceUrl' in ev).toBe(false);
+    expect(buildExternalConsentEvidence(true, { sourceUrl: '   ' })).not.toHaveProperty('sourceUrl');
+  });
+
+  it('does not share the channels constant by reference (caller cannot mutate it)', () => {
+    const ev = buildExternalConsentEvidence(true);
+    expect(ev.channels).toEqual([...THIRD_PARTY_CONSENT_CHANNELS]);
+    expect(ev.channels).not.toBe(THIRD_PARTY_CONSENT_CHANNELS);
+  });
+});
+
+describe('buildExternalConsentEvidence ↔ hasValidExternalConsent (round-trip contract)', () => {
+  it('ticked evidence is accepted by the gate', () => {
+    const external = buildExternalConsentEvidence(true, { sourceUrl: 'https://redeem.sg/t/x' });
+    expect(hasValidExternalConsent({ consentMetadata: { external } })).toBe(true);
+  });
+
+  it('ticked evidence with no sourceUrl is still accepted (sourceUrl is optional)', () => {
+    const external = buildExternalConsentEvidence(true);
+    expect(hasValidExternalConsent({ consentMetadata: { external } })).toBe(true);
+  });
+
+  it('unticked => null => gate stays false (never external)', () => {
+    const external = buildExternalConsentEvidence(false);
+    expect(external).toBeNull();
+    expect(hasValidExternalConsent({ consentMetadata: external ? { external } : {} })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Layer 3 — capture third-party-disclosure consent

Completes the `consent_third_party` feature (PRs after #61). When a lead-capture
submit has the third-party box ticked, the backend records the consent evidence
that `hasValidExternalConsent()` requires, so a consented lead on an
`externalEligible` campaign can flow to external (MKTR Leads buyer-agent) delivery.

- `externalConsent.js`: `THIRD_PARTY_CONSENT_VERSION` (`2026-06-26`) +
  `THIRD_PARTY_CONSENT_CHANNELS` (`phone/whatsapp/email`) + a pure
  `buildExternalConsentEvidence()` returning the evidence **only** for `consented === true`
  (else `null`); an unparseable `at` falls back to now so the output is always valid.
- `prospectService.createProspect`: builds the evidence (sourceUrl = capture-page URL,
  consentedAt = now) and writes `consentMetadata.external` before the `allowExternal` gate.
- **Anti-forgery:** `consentMetadata` is stripped from the inbound body in the service, so
  external consent can never be supplied via the request body (defence-in-depth beyond the
  route's `stripUnknown`).
- Tests: 10 pure builder + round-trip tests (no DB), all passing; eslint clean.

### Safety
- **Inert on merge:** external delivery also requires `campaign.externalEligible === true`
  (off by default), so this shares nothing until a campaign is explicitly opted in.
- **Fail-safe:** untick → nothing written → never external.

Reviewed by Codex (gpt-5.5, xhigh); its blocking finding (service-level `consentMetadata`
strip) and a builder `at`-validation bug are both fixed here.

### Policy note (before enabling `externalEligible` anywhere)
This records the OTP-gated form's checkbox as consent; the public API can't *prove* a human
ticked it (same trust model as the existing `consent_contact`/`consent_terms`). Decide
whether self-attestation is sufficient before turning on external sharing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
