### PR TITLE
feat(held-leads): external held-lead dispatch API (real code — supersedes #63)

### DIFF
--- a/backend/src/controllers/externalHeldLeadsController.js
+++ b/backend/src/controllers/externalHeldLeadsController.js
@@ -81,10 +81,13 @@ export async function listHeldLeads(req, res) {
 
   try {
     const { campaignId } = req.body || {};
-    // `{ role: 'admin' }` → buildProspectWhere returns {} (fleet-wide). Only
-    // no_funded_agent holds are assignable to internal agents; external-buyer
-    // holds are filtered out (assignHeldLead would 409 them anyway).
-    const { held } = await listHeldProspects({ role: 'admin' }, { campaignId, limit: 50 });
+    // `{ role: 'admin' }` → buildProspectWhere returns {} (fleet-wide). The reason
+    // filter is applied IN the query (before the 50-row limit) so assignable holds
+    // are never hidden behind a page of external-buyer holds.
+    const { held } = await listHeldProspects(
+      { role: 'admin' },
+      { campaignId, quarantineReason: 'no_funded_agent', limit: 50 },
+    );
     const rows = (held || [])
       .filter((h) => h.quarantineReason === 'no_funded_agent')
       .map((h) => ({
@@ -113,11 +116,16 @@ export async function assignHeldLead(req, res) {
   if (!prospectId || !agentMktrUserId) {
     return res.status(400).json({ success: false, error: 'prospectId and agentMktrUserId are required' });
   }
+  // Mandatory so an exact retry replays the original result (the broker EF always
+  // sends one). HMAC + held-only release still guarantee no double effect without it.
+  if (!idempotencyKey || typeof idempotencyKey !== 'string') {
+    return res.status(400).json({ success: false, error: 'idempotencyKey is required' });
+  }
 
   try {
     // agentMktrUserId is the app's agents.mktr_user_id (== MKTR users.mktrLeadsId).
     const result = await releaseHeldProspect(prospectId, agentMktrUserId, {
-      idempotencyKey: idempotencyKey || null,
+      idempotencyKey,
       actorUserId: null,
     });
     const codeByStatus = {
@@ -126,6 +134,7 @@ export async function assignHeldLead(req, res) {
       invalid_agent: 400,
       not_found: 404,
       not_assignable_external: 409,
+      undeliverable: 503,
     };
     const code = codeByStatus[result.status] || 500;
     return res.status(code).json({ success: code < 400, ...result });

--- a/backend/src/controllers/externalHeldLeadsController.js
+++ b/backend/src/controllers/externalHeldLeadsController.js
@@ -1,0 +1,136 @@
+/**
+ * @file externalHeldLeadsController — the MKTR Leads buyer app's admin "held queue".
+ *
+ * ── Endpoints (mounted at /api/external/held-leads) ─────────────────────────
+ *   POST /                 → list held (no_funded_agent) leads, fleet-wide, FIFO
+ *   POST /assign           → release a held lead to a mktr-leads agent + deliver
+ *
+ * ── Auth ────────────────────────────────────────────────────────────────────
+ * HMAC-SHA256 over the RAW BODY using EXTERNAL_APP_SECRET — the SAME scheme as
+ * /api/external/lead-outcomes (header `X-Webhook-Signature: sha256=<hex>`,
+ * freshness gated on the signed body `timestamp`, ±5 min). NOT the platform JWT.
+ * The mktr-leads broker edge function (admin-JWT gated, holds the secret
+ * server-side) is the only intended caller. The whole route is gated behind the
+ * HELD_LEADS_EXTERNAL_ENABLED flag, so it stays unmounted until provisioned.
+ */
+
+import crypto from 'crypto';
+import { logger } from '../utils/logger.js';
+import { listHeldProspects, releaseHeldProspect } from '../services/prospectService.js';
+
+const MAX_AGE_MS = 5 * 60 * 1000;
+const MAX_FUTURE_MS = 2 * 60 * 1000; // tolerate clock skew
+const MAX_BODY_BYTES = 64 * 1024;
+
+function timingSafeHexEq(receivedHex, expectedHex) {
+  if (typeof receivedHex !== 'string' || typeof expectedHex !== 'string') return false;
+  if (receivedHex.length !== expectedHex.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(receivedHex, 'hex'), Buffer.from(expectedHex, 'hex'));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verify HMAC + freshness. Returns null on success, or { code, error } to send.
+ * Mirrors externalLeadOutcomeController so the two external channels share one
+ * wire contract (rawBody is captured by the /api/external/ verify hook).
+ */
+function verifyExternalHmac(req) {
+  const secret = process.env.EXTERNAL_APP_SECRET;
+  if (!secret) {
+    logger.error('[external-held] EXTERNAL_APP_SECRET not configured');
+    return { code: 500, error: 'Server misconfigured' };
+  }
+  if (!req.rawBody || !Buffer.isBuffer(req.rawBody)) {
+    logger.error('[external-held] req.rawBody missing — verify hook not wired for this path');
+    return { code: 500, error: 'Server misconfigured' };
+  }
+  if (req.rawBody.length > MAX_BODY_BYTES) return { code: 413, error: 'Payload too large' };
+
+  const sigHeader = req.headers['x-webhook-signature'] || '';
+  if (typeof sigHeader !== 'string' || !sigHeader.startsWith('sha256=')) {
+    return { code: 401, error: 'Unauthorized' };
+  }
+  const expectedHex = crypto.createHmac('sha256', secret).update(req.rawBody).digest('hex');
+  if (!timingSafeHexEq(sigHeader.slice(7), expectedHex)) {
+    return { code: 401, error: 'Unauthorized' };
+  }
+
+  const tsMs = typeof req.body?.timestamp === 'string' ? Date.parse(req.body.timestamp) : NaN;
+  if (Number.isNaN(tsMs)) return { code: 401, error: 'Unauthorized' };
+  const ageMs = Date.now() - tsMs;
+  if (ageMs > MAX_AGE_MS || ageMs < -MAX_FUTURE_MS) return { code: 401, error: 'Unauthorized' };
+
+  return null;
+}
+
+// PII is minimised for the queue view — the admin dispatches by name + campaign,
+// and does not need to contact the lead from this surface.
+function maskPhone(phone) {
+  if (!phone || typeof phone !== 'string') return null;
+  const digits = phone.replace(/\D/g, '');
+  if (digits.length < 4) return '••••';
+  return `••••${digits.slice(-4)}`;
+}
+
+export async function listHeldLeads(req, res) {
+  const authErr = verifyExternalHmac(req);
+  if (authErr) return res.status(authErr.code).json({ success: false, error: authErr.error });
+
+  try {
+    const { campaignId } = req.body || {};
+    // `{ role: 'admin' }` → buildProspectWhere returns {} (fleet-wide). Only
+    // no_funded_agent holds are assignable to internal agents; external-buyer
+    // holds are filtered out (assignHeldLead would 409 them anyway).
+    const { held } = await listHeldProspects({ role: 'admin' }, { campaignId, limit: 50 });
+    const rows = (held || [])
+      .filter((h) => h.quarantineReason === 'no_funded_agent')
+      .map((h) => ({
+        id: h.id,
+        firstName: h.firstName || null,
+        lastInitial: h.lastName ? String(h.lastName).trim().charAt(0).toUpperCase() : null,
+        maskedPhone: maskPhone(h.phone),
+        campaignId: h.campaignId,
+        campaignName: h.campaignName,
+        leadSource: h.leadSource,
+        quarantinedAt: h.quarantinedAt,
+        createdAt: h.createdAt,
+      }));
+    return res.json({ success: true, count: rows.length, held: rows });
+  } catch (err) {
+    logger.error('[external-held] list failed', { error: err?.message || String(err) });
+    return res.status(500).json({ success: false, error: 'Failed to list held leads' });
+  }
+}
+
+export async function assignHeldLead(req, res) {
+  const authErr = verifyExternalHmac(req);
+  if (authErr) return res.status(authErr.code).json({ success: false, error: authErr.error });
+
+  const { prospectId, agentMktrUserId, idempotencyKey } = req.body || {};
+  if (!prospectId || !agentMktrUserId) {
+    return res.status(400).json({ success: false, error: 'prospectId and agentMktrUserId are required' });
+  }
+
+  try {
+    // agentMktrUserId is the app's agents.mktr_user_id (== MKTR users.mktrLeadsId).
+    const result = await releaseHeldProspect(prospectId, agentMktrUserId, {
+      idempotencyKey: idempotencyKey || null,
+      actorUserId: null,
+    });
+    const codeByStatus = {
+      assigned: 200,
+      already_handled: 200,
+      invalid_agent: 400,
+      not_found: 404,
+      not_assignable_external: 409,
+    };
+    const code = codeByStatus[result.status] || 500;
+    return res.status(code).json({ success: code < 400, ...result });
+  } catch (err) {
+    logger.error('[external-held] assign failed', { error: err?.message || String(err) });
+    return res.status(500).json({ success: false, error: 'Failed to assign held lead' });
+  }
+}

--- a/backend/src/routes/externalHeldLeads.js
+++ b/backend/src/routes/externalHeldLeads.js
@@ -1,0 +1,24 @@
+/**
+ * MKTR Leads (external buyer app) → held-lead dispatch queue.
+ *
+ * Mounted at `/api/external/held-leads`. Auth is HMAC-SHA256 over the raw body
+ * (EXTERNAL_APP_SECRET) — see externalHeldLeadsController. rawBody capture and the
+ * rate-limiter exemption for the `/api/external/` prefix are wired in
+ * server_internal.js, same as /api/external/lead-outcomes.
+ *
+ * Gated behind HELD_LEADS_EXTERNAL_ENABLED so the route stays UNMOUNTED until the
+ * secret + the mktr-leads broker edge function are provisioned (deploy-inert).
+ */
+import express from 'express';
+import { listHeldLeads, assignHeldLead } from '../controllers/externalHeldLeadsController.js';
+
+const router = express.Router();
+
+export const meta = { path: '/api/external/held-leads', flag: 'HELD_LEADS_EXTERNAL_ENABLED', flagDefault: 'false' };
+
+// POST (not GET) so the body carries the signed `timestamp` the HMAC freshness
+// check reads — consistent with /api/external/lead-outcomes.
+router.post('/', listHeldLeads);
+router.post('/assign', assignHeldLead);
+
+export default router;

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -1618,6 +1618,13 @@ export function makeProspectService(overrides = {}) {
       await t.commit();
     } catch (err) {
       await t.rollback();
+      // A concurrent request with the SAME idempotency key won the unique PK — replay
+      // its recorded result instead of surfacing a 500 (the held-only release already
+      // guaranteed no double effect).
+      if (idempotencyKey && (err?.name === 'SequelizeUniqueConstraintError' || err?.original?.code === '23505')) {
+        const winner = await m.IdempotencyKey.findOne({ where: { key: idempotencyKey, scope: IDEMP_SCOPE } });
+        if (winner?.responseBody) return winner.responseBody;
+      }
       throw err;
     }
 

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -9,6 +9,7 @@ import {
   ProspectActivity,
   AgentGroup,
   AgentGroupMember,
+  IdempotencyKey,
   sequelize,
 } from '../models/index.js';
 import { resolveAssignedAgentId, resolveLeadRouting, getSystemAgentId, resolveLeadAssignment } from './systemAgent.js';
@@ -18,7 +19,7 @@ import { hasValidExternalConsent, buildExternalConsentEvidence } from './externa
 import { repeatSignupDetail, repeatSignupCounts } from './repeatSignup.js';
 import { buildProspectWhere } from '../middleware/prospectScope.js';
 import { AppError } from '../middleware/errorHandler.js';
-import { dispatchEvent } from './webhookService.js';
+import { dispatchEvent, persistEventDeliveries, flushDeliveries } from './webhookService.js';
 import {
   sendLeadEvent as metaSendLeadEvent,
   sendCompleteRegistrationEvent as metaSendCompleteRegistrationEvent,
@@ -69,7 +70,7 @@ const PROSPECT_UPDATE_FIELDS = [
 ];
 
 const defaultDeps = {
-  models: { Prospect, User, Campaign, QrTag, Commission, Attribution, ProspectActivity, AgentGroup, AgentGroupMember },
+  models: { Prospect, User, Campaign, QrTag, Commission, Attribution, ProspectActivity, AgentGroup, AgentGroupMember, IdempotencyKey },
   sequelize,
   resolveAssignedAgentId,
   resolveLeadRouting,
@@ -83,6 +84,8 @@ const defaultDeps = {
   decideAssignment,
   buildProspectWhere,
   dispatchEvent,
+  persistEventDeliveries,
+  flushDeliveries,
   sendLeadEvent: metaSendLeadEvent,
   sendCompleteRegistrationEvent: metaSendCompleteRegistrationEvent,
   sendTikTokLeadEvent,
@@ -1486,12 +1489,141 @@ export function makeProspectService(overrides = {}) {
     return { count, held };
   }
 
+  /**
+   * Release a HELD (quarantined) prospect to a mktr-leads agent and deliver it.
+   *
+   * The held-only counterpart to assignProspect, purpose-built for the external
+   * mktr-leads admin dispatch endpoint. Unlike assignProspect it can NEVER fall
+   * into the normal-reassignment path: a request that arrives after the lead is
+   * already released returns `already_handled` (no second charge, no second
+   * `lead.assigned`). The release UPDATE and the `lead.created` delivery row are
+   * written in ONE transaction (outbox), so a crash can never leave a lead
+   * un-held yet undelivered (recoverPendingRetries flushes the row on restart).
+   *
+   * Agent identity is resolved by `mktrLeadsId` ONLY — never by phone, which can
+   * resolve a Lyfe-owned or provenance-less user whose webhook destination would
+   * not be mktr_leads. A manual admin assign is an explicit override: it always
+   * delivers and only best-effort deducts a campaign credit (the lead was held
+   * precisely because nobody was funded).
+   *
+   * @returns {Promise<{status:'assigned'|'already_handled'|'invalid_agent'|'not_found'|'not_assignable_external', leadId?:string, agent?:object}>}
+   */
+  async function releaseHeldProspect(prospectId, agentMktrLeadsId, opts = {}) {
+    const { idempotencyKey = null, actorUserId = null } = opts;
+    const IDEMP_SCOPE = 'external:held-assign';
+
+    // Replay: a retried request with the same key returns the first result verbatim.
+    if (idempotencyKey) {
+      const existing = await m.IdempotencyKey.findOne({ where: { key: idempotencyKey, scope: IDEMP_SCOPE } });
+      if (existing && existing.expiresAt > new Date() && existing.responseBody) {
+        return existing.responseBody;
+      }
+    }
+
+    // Resolve the destination agent by mktrLeadsId ONLY (phone is unsafe — it can
+    // resolve a Lyfe-owned / provenance-less user whose destination ≠ mktr_leads).
+    const agent = agentMktrLeadsId
+      ? await m.User.findOne({ where: { mktrLeadsId: agentMktrLeadsId, role: 'agent', isActive: true } })
+      : null;
+    if (!agent) return { status: 'invalid_agent' };
+
+    const prospect = await m.Prospect.findByPk(prospectId);
+    if (!prospect) return { status: 'not_found' };
+    // External-buyer holds can never be manually released to an internal agent.
+    if (prospect.quarantineReason === 'no_funded_external_buyer') {
+      return { status: 'not_assignable_external' };
+    }
+
+    // Atomic release + delivery intent (transactional outbox).
+    const t = await d.sequelize.transaction();
+    let result;
+    let deliveryPairs = [];
+    try {
+      // Held-only conditional release: gated on the row STILL being a no_funded_agent
+      // hold, so a racing duplicate or the auto sweep loses the row lock and sees
+      // `quarantinedAt IS NULL` → 0 rows → already_handled (never a second delivery).
+      const [rows] = await d.sequelize.query(
+        `UPDATE prospects
+            SET "assignedAgentId" = :agentId, "lastContactDate" = NOW(),
+                "quarantinedAt" = NULL, "quarantineReason" = NULL, "updatedAt" = NOW()
+          WHERE id = :prospectId AND "quarantinedAt" IS NOT NULL
+            AND "quarantineReason" = 'no_funded_agent'
+          RETURNING id`,
+        { replacements: { agentId: agent.id, prospectId }, transaction: t }
+      );
+
+      if (!Array.isArray(rows) || rows.length === 0) {
+        result = { status: 'already_handled' };
+      } else {
+        await m.ProspectActivity.create({
+          prospectId,
+          type: 'assigned',
+          actorUserId,
+          description: `Released from hold and assigned to ${agent.firstName} ${agent.lastName}`.trim(),
+          metadata: { assignedAgentId: agent.id, released: true, via: 'external_app' },
+        }, { transaction: t });
+
+        const withCampaign = await m.Prospect.findByPk(prospectId, {
+          include: [{ association: 'campaign', attributes: ['id', 'name'] }],
+          transaction: t,
+        });
+
+        // Destination is mktr_leads (agent has mktrLeadsId set); the receiver matches
+        // `routing.agentExternalId` against agents.mktr_user_id, so the webhook id MUST
+        // be externalIdForDestination(agent,'mktr_leads') === agent.mktrLeadsId.
+        const destination = destinationForAgent(agent);
+        const agentForWebhook = {
+          phone: agent.phone || null,
+          email: agent.email || null,
+          name: `${agent.firstName || ''} ${agent.lastName || ''}`.trim(),
+          id: externalIdForDestination(agent, destination),
+        };
+
+        deliveryPairs = await d.persistEventDeliveries(
+          'lead.created',
+          () => buildLeadCreatedPayload(withCampaign, 'direct', agentForWebhook, agent.id, withCampaign?.campaign || null, null, null),
+          { destination },
+          t
+        );
+
+        result = { status: 'assigned', leadId: prospectId, agent: { firstName: agent.firstName, lastName: agent.lastName } };
+      }
+
+      await t.commit();
+    } catch (err) {
+      await t.rollback();
+      throw err;
+    }
+
+    // Post-commit side-effects — never block or roll back the durable release.
+    if (result.status === 'assigned') {
+      await d.deductLeadCredit({ agentId: agent.id, campaignId: prospect.campaignId || null })
+        .catch((err) => d.logger.error('[releaseHeldProspect] credit deduct failed', { error: err?.message || String(err) }));
+      d.flushDeliveries(deliveryPairs);
+    }
+
+    // Best-effort idempotency record (held-only semantics already guarantee
+    // correctness; this just lets an exact retry replay the same response).
+    if (idempotencyKey && (result.status === 'assigned' || result.status === 'already_handled')) {
+      await m.IdempotencyKey.create({
+        key: idempotencyKey,
+        scope: IDEMP_SCOPE,
+        responseBody: result,
+        responseCode: 200,
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      }).catch(() => { /* duplicate key / race — the winning row stands */ });
+    }
+
+    return result;
+  }
+
   return {
     createProspect,
     getProspect,
     updateProspect,
     deleteProspect,
     assignProspect,
+    releaseHeldProspect,
     bulkAssignProspects,
     getProspectStats,
     listProspects,
@@ -1507,6 +1639,7 @@ export const getProspect = _default.getProspect;
 export const updateProspect = _default.updateProspect;
 export const deleteProspect = _default.deleteProspect;
 export const assignProspect = _default.assignProspect;
+export const releaseHeldProspect = _default.releaseHeldProspect;
 export const bulkAssignProspects = _default.bulkAssignProspects;
 export const getProspectStats = _default.getProspectStats;
 export const listProspects = _default.listProspects;

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -1459,11 +1459,14 @@ export function makeProspectService(overrides = {}) {
    * existing assignProspect (PATCH /:id/assign) or the auto-release sweep on top-up.
    */
   async function listHeldProspects(user, params = {}) {
-    const { campaignId } = params;
+    const { campaignId, quarantineReason } = params;
     const limit = Math.min(parseInt(params.limit, 10) || 100, 500);
     const scopeFilter = await d.buildProspectWhere(user);
     const where = { ...scopeFilter, quarantinedAt: { [Op.ne]: null } };
     if (campaignId) where.campaignId = campaignId;
+    // Filter by reason IN the query (before the limit) so assignable holds are never
+    // hidden behind a page of external-buyer holds.
+    if (quarantineReason) where.quarantineReason = quarantineReason;
 
     const { count, rows } = await m.Prospect.findAndCountAll({
       where,
@@ -1520,19 +1523,22 @@ export function makeProspectService(overrides = {}) {
       }
     }
 
-    // Resolve the destination agent by mktrLeadsId ONLY (phone is unsafe — it can
-    // resolve a Lyfe-owned / provenance-less user whose destination ≠ mktr_leads).
-    const agent = agentMktrLeadsId
-      ? await m.User.findOne({ where: { mktrLeadsId: agentMktrLeadsId, role: 'agent', isActive: true } })
-      : null;
-    if (!agent) return { status: 'invalid_agent' };
-
+    // Load the prospect FIRST so a retry after a successful release reports
+    // already_handled — not invalid_agent if the chosen agent was since deactivated.
     const prospect = await m.Prospect.findByPk(prospectId);
     if (!prospect) return { status: 'not_found' };
     // External-buyer holds can never be manually released to an internal agent.
     if (prospect.quarantineReason === 'no_funded_external_buyer') {
       return { status: 'not_assignable_external' };
     }
+    if (!prospect.quarantinedAt) return { status: 'already_handled' };
+
+    // Resolve the destination agent by mktrLeadsId ONLY (phone is unsafe — it can
+    // resolve a Lyfe-owned / provenance-less user whose destination ≠ mktr_leads).
+    const agent = agentMktrLeadsId
+      ? await m.User.findOne({ where: { mktrLeadsId: agentMktrLeadsId, role: 'agent', isActive: true } })
+      : null;
+    if (!agent) return { status: 'invalid_agent' };
 
     // Atomic release + delivery intent (transactional outbox).
     const t = await d.sequelize.transaction();
@@ -1585,8 +1591,28 @@ export function makeProspectService(overrides = {}) {
           { destination },
           t
         );
+        // Fail closed: NEVER release a lead we cannot durably deliver. An empty set
+        // means webhooks are disabled or no subscriber is tagged for this
+        // destination — roll back so the lead stays held instead of vanishing.
+        if (deliveryPairs.length === 0) {
+          await t.rollback();
+          return { status: 'undeliverable' };
+        }
 
         result = { status: 'assigned', leadId: prospectId, agent: { firstName: agent.firstName, lastName: agent.lastName } };
+      }
+
+      // Record idempotency atomically with the release so an exact retry replays this
+      // result verbatim. A concurrent same-key duplicate loses the unique PK and rolls
+      // back — harmless, since the held-only release already prevents any double effect.
+      if (idempotencyKey) {
+        await m.IdempotencyKey.create({
+          key: idempotencyKey,
+          scope: IDEMP_SCOPE,
+          responseBody: result,
+          responseCode: 200,
+          expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        }, { transaction: t });
       }
 
       await t.commit();
@@ -1600,18 +1626,6 @@ export function makeProspectService(overrides = {}) {
       await d.deductLeadCredit({ agentId: agent.id, campaignId: prospect.campaignId || null })
         .catch((err) => d.logger.error('[releaseHeldProspect] credit deduct failed', { error: err?.message || String(err) }));
       d.flushDeliveries(deliveryPairs);
-    }
-
-    // Best-effort idempotency record (held-only semantics already guarantee
-    // correctness; this just lets an exact retry replay the same response).
-    if (idempotencyKey && (result.status === 'assigned' || result.status === 'already_handled')) {
-      await m.IdempotencyKey.create({
-        key: idempotencyKey,
-        scope: IDEMP_SCOPE,
-        responseBody: result,
-        responseCode: 200,
-        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
-      }).catch(() => { /* duplicate key / race — the winning row stands */ });
     }
 
     return result;

--- a/backend/src/services/releaseSweep.js
+++ b/backend/src/services/releaseSweep.js
@@ -2,8 +2,8 @@ import { Op } from 'sequelize';
 import { Prospect, ProspectActivity, Campaign, User, sequelize } from '../models/index.js';
 import { resolveLeadRouting } from './systemAgent.js';
 import { chargeLeadCredit } from './leadCredits.js';
-import { dispatchEvent } from './webhookService.js';
-import { buildLeadCreatedPayload } from './prospectHelpers.js';
+import { persistEventDeliveries, flushDeliveries } from './webhookService.js';
+import { buildLeadCreatedPayload, destinationForAgent, externalIdForDestination } from './prospectHelpers.js';
 import { logger } from '../utils/logger.js';
 
 /**
@@ -23,7 +23,8 @@ import { logger } from '../utils/logger.js';
 
 const defaultDeps = {
   Prospect, ProspectActivity, Campaign, User, sequelize,
-  resolveLeadRouting, chargeLeadCredit, dispatchEvent, buildLeadCreatedPayload, logger,
+  resolveLeadRouting, chargeLeadCredit, persistEventDeliveries, flushDeliveries,
+  buildLeadCreatedPayload, destinationForAgent, externalIdForDestination, logger,
 };
 
 // Safety bound so a single sweep can never loop unboundedly.
@@ -58,6 +59,7 @@ export function makeReleaseSweep(overrides = {}) {
       const agentId = routing.agentId;
       const t = await d.sequelize.transaction();
       let didRelease = false;
+      let deliveryPairs = [];
       try {
         // Atomic claim — exactly one releaser wins this held prospect.
         const [claimRows] = await d.sequelize.query(
@@ -78,6 +80,44 @@ export function makeReleaseSweep(overrides = {}) {
           await t.rollback();
           break; // credits exhausted — stop the sweep
         }
+
+        await d.ProspectActivity.create({
+          prospectId: held.id,
+          type: 'assigned',
+          actorUserId: null,
+          description: 'Auto-released from hold (lead-quota top-up) and assigned',
+          metadata: { assignedAgentId: agentId, released: true, via: 'auto_sweep' },
+        }, { transaction: t });
+
+        // Destination-aware delivery: load the agent's provenance (lyfeId AND
+        // mktrLeadsId) so the lead.created routes to the agent's OWN app with the
+        // correct external id — NOT a legacy event-type broadcast to every subscriber,
+        // which would leak a mktr-leads lead's PII to Lyfe and carry the wrong id.
+        const agent = await d.User.findByPk(agentId, {
+          attributes: ['id', 'lyfeId', 'mktrLeadsId', 'phone', 'email', 'firstName', 'lastName'],
+          transaction: t,
+        });
+        const destination = agent ? d.destinationForAgent(agent) : null;
+        const agentForWebhook = agent ? {
+          phone: agent.phone || null,
+          email: agent.email || null,
+          name: `${agent.firstName || ''} ${agent.lastName || ''}`.trim(),
+          id: d.externalIdForDestination(agent, destination),
+        } : null;
+        const withCampaign = await d.Prospect.findByPk(held.id, {
+          include: [{ association: 'campaign', attributes: ['id', 'name'] }],
+          transaction: t,
+        });
+
+        // Persist the first lead.created delivery row INSIDE the tx (outbox) so a
+        // crash after commit can't strand a released, charged lead that was never queued.
+        deliveryPairs = await d.persistEventDeliveries(
+          'lead.created',
+          () => d.buildLeadCreatedPayload(withCampaign, 'direct', agentForWebhook, agentId, withCampaign?.campaign || null, null, null),
+          { destination },
+          t
+        );
+
         await t.commit();
         didRelease = true;
       } catch (err) {
@@ -88,33 +128,7 @@ export function makeReleaseSweep(overrides = {}) {
 
       if (didRelease) {
         released++;
-        await held.reload().catch(() => {});
-
-        await d.ProspectActivity.create({
-          prospectId: held.id,
-          type: 'assigned',
-          actorUserId: null,
-          description: 'Auto-released from hold (lead-quota top-up) and assigned',
-          metadata: { assignedAgentId: agentId, released: true, via: 'auto_sweep' },
-        }).catch(() => {});
-
-        const agent = await d.User.findByPk(agentId, {
-          attributes: ['id', 'lyfeId', 'phone', 'email', 'firstName', 'lastName'],
-        });
-        const agentForWebhook = agent ? {
-          phone: agent.phone || null,
-          email: agent.email || null,
-          name: `${agent.firstName || ''} ${agent.lastName || ''}`.trim(),
-          id: agent.lyfeId || agent.id,
-        } : null;
-        const withCampaign = await d.Prospect.findByPk(held.id, {
-          include: [{ association: 'campaign', attributes: ['id', 'name'] }],
-        });
-
-        // First delivery to Lyfe (held leads never fired a create webhook).
-        d.dispatchEvent('lead.created', () =>
-          d.buildLeadCreatedPayload(held, 'direct', agentForWebhook, agentId, withCampaign?.campaign || null, null, null)
-        ).catch((err) => d.logger.error('[ReleaseSweep] webhook error', { error: err?.message || String(err) }));
+        d.flushDeliveries(deliveryPairs);
       }
     }
 

--- a/backend/src/services/releaseSweep.js
+++ b/backend/src/services/releaseSweep.js
@@ -117,6 +117,14 @@ export function makeReleaseSweep(overrides = {}) {
           { destination },
           t
         );
+        // Fail closed: never release a CHARGED lead we cannot durably deliver. No
+        // subscriber for this destination (or webhooks disabled) → roll back the
+        // claim + charge (re-hold) and stop; every lead here would hit the same wall.
+        if (deliveryPairs.length === 0) {
+          await t.rollback();
+          d.logger.warn('[ReleaseSweep] no delivery subscriber — re-holding', { campaignId, prospectId: held.id, destination });
+          break;
+        }
 
         await t.commit();
         didRelease = true;

--- a/backend/src/services/webhookService.js
+++ b/backend/src/services/webhookService.js
@@ -66,67 +66,100 @@ export function makeWebhookService(overrides = {}) {
   }
 
   /**
-   * Dispatch an event to all active webhook subscribers.
-   * Fire-and-forget — does not throw.
+   * Persist the `webhook_deliveries` rows for an event WITHOUT sending them.
+   *
+   * When a `transaction` is supplied the delivery rows are created inside it, so a
+   * caller can make a state change and its delivery INTENT atomic (transactional
+   * outbox): either the state change and the pending delivery rows both commit, or
+   * neither does. This closes the window where a process could clear a row's hold
+   * and then crash before the delivery row exists, stranding a lead that is no
+   * longer held yet was never queued for delivery. The actual send is deferred —
+   * hand the returned pairs to flushDeliveries() AFTER the transaction commits;
+   * recoverPendingRetries() is the backstop if the process dies before the flush.
+   *
+   * Returns an array of { delivery, subscriber } (empty when webhooks are disabled
+   * or nothing matches). Honours the same destination-aware filtering as before.
    */
-  async function dispatchEvent(eventType, payloadBuilder, options = {}) {
+  async function persistEventDeliveries(eventType, payloadBuilder, options = {}, transaction = null) {
     if (String(process.env.WEBHOOK_ENABLED || 'false').toLowerCase() !== 'true') {
-      return;
+      return [];
     }
 
-    try {
-      const subscribers = await d.WebhookSubscriber.findAll({
-        where: { enabled: true }
-      });
+    const subscribers = await d.WebhookSubscriber.findAll({
+      where: { enabled: true },
+      transaction,
+    });
 
-      // Filter to subscribers interested in this event type
-      let matched = subscribers.filter(sub => {
-        const events = sub.events || [];
-        return events.includes(eventType);
-      });
+    // Filter to subscribers interested in this event type
+    let matched = subscribers.filter(sub => {
+      const events = sub.events || [];
+      return events.includes(eventType);
+    });
 
-      // Destination-aware delivery: when a caller passes `destination`, deliver
-      // ONLY to subscribers tagged for that app (metadata.destination) so a lead's
-      // PII never crosses apps. A null/unknown destination is DEFAULT-DENIED (e.g.
-      // an assignee with no Lyfe/mktr-leads provenance, like the System Agent).
-      // Callers that omit `destination` keep the legacy event-type-only behaviour.
-      if ('destination' in options) {
-        const { destination } = options;
-        const eventMatchCount = matched.length;
-        matched = destination
-          ? matched.filter(sub => (sub.metadata?.destination || null) === destination)
-          : [];
-        if (eventMatchCount > 0 && matched.length === 0) {
-          d.logger.warn('[Webhook] lead_webhook_default_denied', {
-            event: 'lead_webhook_default_denied',
-            eventType,
-            destination: destination || null,
-          });
-        }
-      }
-
-      if (matched.length === 0) {
-        d.logger.debug('[Webhook] No active subscribers for event', { eventType });
-        return;
-      }
-
-      // Build payload once
-      const payload = payloadBuilder();
-
-      for (const subscriber of matched) {
-        const deliveryId = crypto.randomUUID();
-
-        const delivery = await d.WebhookDelivery.create({
-          subscriberId: subscriber.id,
-          deliveryId,
+    // Destination-aware delivery: when a caller passes `destination`, deliver
+    // ONLY to subscribers tagged for that app (metadata.destination) so a lead's
+    // PII never crosses apps. A null/unknown destination is DEFAULT-DENIED (e.g.
+    // an assignee with no Lyfe/mktr-leads provenance, like the System Agent).
+    // Callers that omit `destination` keep the legacy event-type-only behaviour.
+    if ('destination' in options) {
+      const { destination } = options;
+      const eventMatchCount = matched.length;
+      matched = destination
+        ? matched.filter(sub => (sub.metadata?.destination || null) === destination)
+        : [];
+      if (eventMatchCount > 0 && matched.length === 0) {
+        d.logger.warn('[Webhook] lead_webhook_default_denied', {
+          event: 'lead_webhook_default_denied',
           eventType,
-          payload: { ...payload, deliveryId },
-          status: 'pending'
+          destination: destination || null,
         });
-
-        // Fire-and-forget with concurrency limit
-        enqueueDelivery(delivery, subscriber);
       }
+    }
+
+    if (matched.length === 0) {
+      d.logger.debug('[Webhook] No active subscribers for event', { eventType });
+      return [];
+    }
+
+    // Build payload once
+    const payload = payloadBuilder();
+
+    const pairs = [];
+    for (const subscriber of matched) {
+      const deliveryId = crypto.randomUUID();
+
+      const delivery = await d.WebhookDelivery.create({
+        subscriberId: subscriber.id,
+        deliveryId,
+        eventType,
+        payload: { ...payload, deliveryId },
+        status: 'pending'
+      }, { transaction });
+
+      pairs.push({ delivery, subscriber });
+    }
+    return pairs;
+  }
+
+  /**
+   * Kick off the (fire-and-forget, concurrency-limited) sends for delivery rows
+   * already persisted by persistEventDeliveries(). Call this AFTER the owning
+   * transaction (if any) has committed.
+   */
+  function flushDeliveries(pairs) {
+    for (const { delivery, subscriber } of (pairs || [])) {
+      enqueueDelivery(delivery, subscriber);
+    }
+  }
+
+  /**
+   * Dispatch an event to all active webhook subscribers.
+   * Fire-and-forget — does not throw. (persist immediately, then flush.)
+   */
+  async function dispatchEvent(eventType, payloadBuilder, options = {}) {
+    try {
+      const pairs = await persistEventDeliveries(eventType, payloadBuilder, options);
+      flushDeliveries(pairs);
     } catch (err) {
       d.logger.error('[Webhook] dispatchEvent error', { eventType, error: err.message });
     }
@@ -431,13 +464,15 @@ export function makeWebhookService(overrides = {}) {
     }
   }
 
-  return { dispatchEvent, attemptDelivery, retryDelivery, retryAllFailed,
+  return { dispatchEvent, persistEventDeliveries, flushDeliveries, attemptDelivery, retryDelivery, retryAllFailed,
            getDeadLetterQueue, purgeDeadLetters, getDeliveryStats, getQueueStats, recoverPendingRetries };
 }
 
 // --- Backward-compatible named exports ---
 const _default = makeWebhookService();
 export const dispatchEvent = _default.dispatchEvent;
+export const persistEventDeliveries = _default.persistEventDeliveries;
+export const flushDeliveries = _default.flushDeliveries;
 export const attemptDelivery = _default.attemptDelivery;
 export const retryDelivery = _default.retryDelivery;
 export const retryAllFailed = _default.retryAllFailed;

--- a/backend/test/externalHeldLeadsController.test.js
+++ b/backend/test/externalHeldLeadsController.test.js
@@ -114,16 +114,25 @@ describe('externalHeldLeadsController.assignHeldLead', () => {
     ['invalid_agent', 400],
     ['not_found', 404],
     ['not_assignable_external', 409],
+    ['undeliverable', 503],
   ])('maps %s → %i', async (status, code) => {
     releaseMock.mockResolvedValue({ status });
-    const req = makeReq({ timestamp: new Date().toISOString(), prospectId: 'p1', agentMktrUserId: 'a1' });
+    const req = makeReq({ timestamp: new Date().toISOString(), prospectId: 'p1', agentMktrUserId: 'a1', idempotencyKey: 'k' });
     const res = makeRes();
     await assignHeldLead(req, res);
     expect(res.statusCode).toBe(code);
   });
 
   it('400s when prospectId or agentMktrUserId is missing', async () => {
-    const req = makeReq({ timestamp: new Date().toISOString(), prospectId: 'p1' });
+    const req = makeReq({ timestamp: new Date().toISOString(), prospectId: 'p1', idempotencyKey: 'k' });
+    const res = makeRes();
+    await assignHeldLead(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(releaseMock).not.toHaveBeenCalled();
+  });
+
+  it('400s when idempotencyKey is missing (mandatory replay contract)', async () => {
+    const req = makeReq({ timestamp: new Date().toISOString(), prospectId: 'p1', agentMktrUserId: 'a1' });
     const res = makeRes();
     await assignHeldLead(req, res);
     expect(res.statusCode).toBe(400);

--- a/backend/test/externalHeldLeadsController.test.js
+++ b/backend/test/externalHeldLeadsController.test.js
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for the external (MKTR Leads) held-lead dispatch controller.
+ *
+ * Tests HMAC (body-only) auth + freshness, the held-list PII masking, and the
+ * assign status→HTTP-code mapping in isolation: prospectService + logger are
+ * mocked and we drive the handlers with hand-built req/res objects (no DB), the
+ * way req.rawBody is set by the /api/external/ verify hook in prod.
+ */
+import { jest } from '@jest/globals';
+import crypto from 'crypto';
+
+const SECRET = 'test-external-app-secret';
+
+const listHeldMock = jest.fn();
+const releaseMock = jest.fn();
+
+jest.unstable_mockModule('../src/services/prospectService.js', () => ({
+  listHeldProspects: listHeldMock,
+  releaseHeldProspect: releaseMock,
+}));
+jest.unstable_mockModule('../src/utils/logger.js', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+let listHeldLeads, assignHeldLead;
+
+beforeAll(async () => {
+  ({ listHeldLeads, assignHeldLead } = await import('../src/controllers/externalHeldLeadsController.js'));
+});
+
+beforeEach(() => {
+  process.env.EXTERNAL_APP_SECRET = SECRET;
+  listHeldMock.mockReset();
+  releaseMock.mockReset();
+});
+
+function makeRes() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.body = payload; return this; },
+  };
+}
+
+function makeReq(bodyObj, { secret = SECRET, signOverride } = {}) {
+  const raw = Buffer.from(JSON.stringify(bodyObj));
+  const sig = signOverride ?? crypto.createHmac('sha256', secret).update(raw).digest('hex');
+  return { rawBody: raw, body: bodyObj, headers: { 'x-webhook-signature': `sha256=${sig}` } };
+}
+
+describe('externalHeldLeadsController — auth', () => {
+  it('rejects a bad signature with 401', async () => {
+    const req = makeReq({ timestamp: new Date().toISOString() }, { signOverride: 'sha256=deadbeef' });
+    const res = makeRes();
+    await listHeldLeads(req, res);
+    expect(res.statusCode).toBe(401);
+    expect(listHeldMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a stale timestamp with 401', async () => {
+    const req = makeReq({ timestamp: new Date(Date.now() - 10 * 60 * 1000).toISOString() });
+    const res = makeRes();
+    await assignHeldLead(req, res);
+    expect(res.statusCode).toBe(401);
+    expect(releaseMock).not.toHaveBeenCalled();
+  });
+
+  it('500s when the secret is not configured', async () => {
+    delete process.env.EXTERNAL_APP_SECRET;
+    const req = makeReq({ timestamp: new Date().toISOString() });
+    const res = makeRes();
+    await listHeldLeads(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+});
+
+describe('externalHeldLeadsController.listHeldLeads', () => {
+  it('returns only no_funded_agent holds, masked', async () => {
+    listHeldMock.mockResolvedValue({
+      count: 2,
+      held: [
+        { id: 'p1', firstName: 'Jane', lastName: 'Doe', phone: '6591234567', email: 'j@x', leadSource: 'meta', campaignId: 'c1', campaignName: 'Cab', quarantineReason: 'no_funded_agent', quarantinedAt: 't', createdAt: 't' },
+        { id: 'p2', firstName: 'Ext', lastName: 'Buyer', phone: '6599999999', quarantineReason: 'no_funded_external_buyer', campaignId: 'c1' },
+      ],
+    });
+    const req = makeReq({ timestamp: new Date().toISOString() });
+    const res = makeRes();
+    await listHeldLeads(req, res);
+
+    expect(res.statusCode).toBe(null); // res.json without status() → 200 default
+    expect(res.body.count).toBe(1); // external-buyer hold filtered out
+    const row = res.body.held[0];
+    expect(row).toMatchObject({ id: 'p1', firstName: 'Jane', lastInitial: 'D', maskedPhone: '••••4567', campaignName: 'Cab' });
+    expect(row.email).toBeUndefined(); // email not exposed
+    expect(row.lastName).toBeUndefined(); // full surname not exposed
+  });
+});
+
+describe('externalHeldLeadsController.assignHeldLead', () => {
+  it('maps service statuses to HTTP codes and passes the idempotency key', async () => {
+    releaseMock.mockResolvedValue({ status: 'assigned', leadId: 'p1', agent: { firstName: 'Hui', lastName: 'Xin' } });
+    const req = makeReq({ timestamp: new Date().toISOString(), prospectId: 'p1', agentMktrUserId: 'app-agent-1', idempotencyKey: 'k1' });
+    const res = makeRes();
+    await assignHeldLead(req, res);
+
+    expect(releaseMock).toHaveBeenCalledWith('p1', 'app-agent-1', { idempotencyKey: 'k1', actorUserId: null });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ success: true, status: 'assigned', leadId: 'p1' });
+  });
+
+  it.each([
+    ['already_handled', 200],
+    ['invalid_agent', 400],
+    ['not_found', 404],
+    ['not_assignable_external', 409],
+  ])('maps %s → %i', async (status, code) => {
+    releaseMock.mockResolvedValue({ status });
+    const req = makeReq({ timestamp: new Date().toISOString(), prospectId: 'p1', agentMktrUserId: 'a1' });
+    const res = makeRes();
+    await assignHeldLead(req, res);
+    expect(res.statusCode).toBe(code);
+  });
+
+  it('400s when prospectId or agentMktrUserId is missing', async () => {
+    const req = makeReq({ timestamp: new Date().toISOString(), prospectId: 'p1' });
+    const res = makeRes();
+    await assignHeldLead(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(releaseMock).not.toHaveBeenCalled();
+  });
+});

--- a/backend/test/unit/releaseHeldProspect.test.js
+++ b/backend/test/unit/releaseHeldProspect.test.js
@@ -1,0 +1,135 @@
+import { jest } from '@jest/globals';
+import '../setup.js';
+import { makeProspectService } from '../../src/services/prospectService.js';
+
+// releaseHeldProspect — held-only release for the external mktr-leads dispatch
+// endpoint. destinationForAgent / externalIdForDestination / buildLeadCreatedPayload
+// are the REAL pure helpers (not overridable via deps), so destination routing is
+// genuinely exercised. persistEventDeliveries/flushDeliveries/deductLeadCredit ARE
+// overridden (they would otherwise hit the DB / real webhook layer).
+function buildMocks() {
+  const mockTx = { commit: jest.fn().mockResolvedValue(undefined), rollback: jest.fn().mockResolvedValue(undefined) };
+  // An mktr-leads agent: mktrLeadsId set, lyfeId null → destination 'mktr_leads'.
+  const agent = {
+    id: 'mktr-user-1', lyfeId: null, mktrLeadsId: 'app-agent-1',
+    role: 'agent', isActive: true, firstName: 'Hui', lastName: 'Xin', phone: '6585337192', email: 'h@x',
+  };
+  const heldProspect = { id: 'p-1', campaignId: 'camp-1', quarantineReason: 'no_funded_agent' };
+
+  const models = {
+    Prospect: {
+      findByPk: jest.fn()
+        .mockResolvedValueOnce(heldProspect) // pre-txn read (reason / campaignId)
+        .mockResolvedValue({ ...heldProspect, campaign: { id: 'camp-1', name: 'C' } }), // withCampaign (in txn)
+    },
+    User: { findOne: jest.fn().mockResolvedValue(agent) },
+    ProspectActivity: { create: jest.fn().mockResolvedValue({}) },
+    IdempotencyKey: { findOne: jest.fn().mockResolvedValue(null), create: jest.fn().mockResolvedValue({}) },
+  };
+
+  const deps = {
+    models,
+    sequelize: {
+      transaction: jest.fn().mockResolvedValue(mockTx),
+      query: jest.fn().mockResolvedValue([[{ id: 'p-1' }]]), // conditional release won
+    },
+    persistEventDeliveries: jest.fn().mockResolvedValue([{ delivery: { id: 'd' }, subscriber: { id: 's' } }]),
+    flushDeliveries: jest.fn(),
+    deductLeadCredit: jest.fn().mockResolvedValue(true),
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+  };
+  return { deps, mockTx, agent, heldProspect };
+}
+
+const svc = (deps) => makeProspectService(deps);
+
+describe('releaseHeldProspect (unit)', () => {
+  it('releases a held lead: atomic release, mktr_leads-scoped delivery persisted IN the tx, post-commit deduct + flush', async () => {
+    const { deps, mockTx } = buildMocks();
+
+    const res = await svc(deps).releaseHeldProspect('p-1', 'app-agent-1', {});
+
+    expect(res).toMatchObject({ status: 'assigned', leadId: 'p-1' });
+    // Resolved by mktrLeadsId ONLY (active agent).
+    expect(deps.models.User.findOne).toHaveBeenCalledWith({
+      where: { mktrLeadsId: 'app-agent-1', role: 'agent', isActive: true },
+    });
+    // Held-only conditional release ran in the tx.
+    expect(deps.sequelize.query).toHaveBeenCalled();
+    // Delivery row persisted INSIDE the tx (outbox), destination-scoped to mktr_leads.
+    expect(deps.persistEventDeliveries).toHaveBeenCalledWith(
+      'lead.created', expect.any(Function), { destination: 'mktr_leads' }, mockTx,
+    );
+    expect(mockTx.commit).toHaveBeenCalled();
+    // Post-commit: best-effort campaign-scoped deduct + flush of the persisted delivery.
+    expect(deps.deductLeadCredit).toHaveBeenCalledWith({ agentId: 'mktr-user-1', campaignId: 'camp-1' });
+    expect(deps.flushDeliveries).toHaveBeenCalledWith(expect.arrayContaining([expect.any(Object)]));
+  });
+
+  it('webhook external id is the agent mktrLeadsId (so the mktr-leads receiver matches it)', async () => {
+    const { deps } = buildMocks();
+    await svc(deps).releaseHeldProspect('p-1', 'app-agent-1', {});
+    const builder = deps.persistEventDeliveries.mock.calls[0][1];
+    const payload = builder();
+    expect(payload.data.routing.agentExternalId).toBe('app-agent-1');
+  });
+
+  it('unknown / inactive agent → invalid_agent, no release', async () => {
+    const { deps } = buildMocks();
+    deps.models.User.findOne.mockResolvedValue(null);
+
+    const res = await svc(deps).releaseHeldProspect('p-1', 'ghost', {});
+
+    expect(res.status).toBe('invalid_agent');
+    expect(deps.sequelize.query).not.toHaveBeenCalled();
+  });
+
+  it('missing prospect → not_found', async () => {
+    const { deps } = buildMocks();
+    deps.models.Prospect.findByPk = jest.fn().mockResolvedValue(null);
+
+    const res = await svc(deps).releaseHeldProspect('gone', 'app-agent-1', {});
+
+    expect(res.status).toBe('not_found');
+    expect(deps.sequelize.query).not.toHaveBeenCalled();
+  });
+
+  it('external-buyer hold can never be released to an internal agent → not_assignable_external', async () => {
+    const { deps } = buildMocks();
+    deps.models.Prospect.findByPk = jest.fn().mockResolvedValue({
+      id: 'p-1', campaignId: 'camp-1', quarantineReason: 'no_funded_external_buyer',
+    });
+
+    const res = await svc(deps).releaseHeldProspect('p-1', 'app-agent-1', {});
+
+    expect(res.status).toBe('not_assignable_external');
+    expect(deps.sequelize.query).not.toHaveBeenCalled();
+  });
+
+  it('retry after release (conditional update matches 0 rows) → already_handled, no second charge/delivery', async () => {
+    const { deps, mockTx } = buildMocks();
+    deps.sequelize.query.mockResolvedValue([[]]); // lost the race / already released
+
+    const res = await svc(deps).releaseHeldProspect('p-1', 'app-agent-1', {});
+
+    expect(res.status).toBe('already_handled');
+    expect(mockTx.commit).toHaveBeenCalled();
+    expect(deps.persistEventDeliveries).not.toHaveBeenCalled();
+    expect(deps.deductLeadCredit).not.toHaveBeenCalled();
+    expect(deps.flushDeliveries).not.toHaveBeenCalled();
+  });
+
+  it('idempotency replay: a stored key returns the first result verbatim, no reprocessing', async () => {
+    const { deps } = buildMocks();
+    deps.models.IdempotencyKey.findOne.mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      responseBody: { status: 'assigned', leadId: 'p-1' },
+    });
+
+    const res = await svc(deps).releaseHeldProspect('p-1', 'app-agent-1', { idempotencyKey: 'k-1' });
+
+    expect(res).toEqual({ status: 'assigned', leadId: 'p-1' });
+    expect(deps.models.User.findOne).not.toHaveBeenCalled();
+    expect(deps.sequelize.query).not.toHaveBeenCalled();
+  });
+});

--- a/backend/test/unit/releaseHeldProspect.test.js
+++ b/backend/test/unit/releaseHeldProspect.test.js
@@ -166,4 +166,17 @@ describe('releaseHeldProspect (unit)', () => {
       { transaction: mockTx },
     );
   });
+
+  it('concurrent same-key: a unique-violation on the key create replays the winner result (no 500)', async () => {
+    const { deps, mockTx } = buildMocks();
+    deps.models.IdempotencyKey.create.mockRejectedValue(Object.assign(new Error('dup'), { name: 'SequelizeUniqueConstraintError' }));
+    deps.models.IdempotencyKey.findOne
+      .mockResolvedValueOnce(null) // top replay check: key not yet visible
+      .mockResolvedValueOnce({ expiresAt: new Date(Date.now() + 60_000), responseBody: { status: 'assigned', leadId: 'p-1' } }); // catch: winner's row
+
+    const res = await svc(deps).releaseHeldProspect('p-1', 'app-agent-1', { idempotencyKey: 'k-1' });
+
+    expect(res).toEqual({ status: 'assigned', leadId: 'p-1' });
+    expect(mockTx.rollback).toHaveBeenCalled();
+  });
 });

--- a/backend/test/unit/releaseHeldProspect.test.js
+++ b/backend/test/unit/releaseHeldProspect.test.js
@@ -14,7 +14,7 @@ function buildMocks() {
     id: 'mktr-user-1', lyfeId: null, mktrLeadsId: 'app-agent-1',
     role: 'agent', isActive: true, firstName: 'Hui', lastName: 'Xin', phone: '6585337192', email: 'h@x',
   };
-  const heldProspect = { id: 'p-1', campaignId: 'camp-1', quarantineReason: 'no_funded_agent' };
+  const heldProspect = { id: 'p-1', campaignId: 'camp-1', quarantineReason: 'no_funded_agent', quarantinedAt: new Date() };
 
   const models = {
     Prospect: {
@@ -131,5 +131,39 @@ describe('releaseHeldProspect (unit)', () => {
     expect(res).toEqual({ status: 'assigned', leadId: 'p-1' });
     expect(deps.models.User.findOne).not.toHaveBeenCalled();
     expect(deps.sequelize.query).not.toHaveBeenCalled();
+  });
+
+  it('FAILS CLOSED: no delivery row persisted (webhooks off / no subscriber) → undeliverable, rolls back', async () => {
+    const { deps, mockTx } = buildMocks();
+    deps.persistEventDeliveries.mockResolvedValue([]); // nothing to deliver to
+
+    const res = await svc(deps).releaseHeldProspect('p-1', 'app-agent-1', {});
+
+    expect(res.status).toBe('undeliverable');
+    expect(mockTx.rollback).toHaveBeenCalled(); // the release is rolled back — lead stays held
+    expect(mockTx.commit).not.toHaveBeenCalled();
+    expect(deps.deductLeadCredit).not.toHaveBeenCalled();
+    expect(deps.flushDeliveries).not.toHaveBeenCalled();
+  });
+
+  it('already-released prospect (quarantinedAt null) → already_handled BEFORE agent resolution', async () => {
+    const { deps } = buildMocks();
+    deps.models.Prospect.findByPk = jest.fn().mockResolvedValue({ id: 'p-1', campaignId: 'camp-1', quarantineReason: null, quarantinedAt: null });
+
+    const res = await svc(deps).releaseHeldProspect('p-1', 'app-agent-1', {});
+
+    expect(res.status).toBe('already_handled');
+    expect(deps.models.User.findOne).not.toHaveBeenCalled(); // no invalid_agent on a handled lead
+    expect(deps.sequelize.query).not.toHaveBeenCalled();
+  });
+
+  it('records the idempotency key INSIDE the release transaction', async () => {
+    const { deps, mockTx } = buildMocks();
+    await svc(deps).releaseHeldProspect('p-1', 'app-agent-1', { idempotencyKey: 'k-1' });
+
+    expect(deps.models.IdempotencyKey.create).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'k-1', scope: 'external:held-assign', responseBody: expect.objectContaining({ status: 'assigned' }) }),
+      { transaction: mockTx },
+    );
   });
 });

--- a/backend/test/unit/releaseSweep.test.js
+++ b/backend/test/unit/releaseSweep.test.js
@@ -2,10 +2,14 @@ import { jest } from '@jest/globals';
 import '../setup.js';
 import { makeReleaseSweep } from '../../src/services/releaseSweep.js';
 
+// NOTE: destinationForAgent / externalIdForDestination are intentionally NOT
+// overridden — the real (pure) helpers run, so these tests verify the ACTUAL
+// destination routing (the P0-4 fix), not a mock's echo.
 function buildMocks(campaignOverrides = {}) {
   const mockTx = { commit: jest.fn().mockResolvedValue(undefined), rollback: jest.fn().mockResolvedValue(undefined) };
   const campaign = { id: 'camp-1', enforceLeadQuota: true, ...campaignOverrides };
-  const agent = { id: 'a1', lyfeId: 'lyfe-a1', phone: '+65', email: 'a@x', firstName: 'A', lastName: 'B' };
+  // Default agent is a Lyfe agent (lyfeId set) → destination 'lyfe'.
+  const agent = { id: 'a1', lyfeId: 'lyfe-a1', mktrLeadsId: null, phone: '+65', email: 'a@x', firstName: 'A', lastName: 'B' };
 
   const deps = {
     Campaign: { findByPk: jest.fn().mockResolvedValue(campaign) },
@@ -19,7 +23,8 @@ function buildMocks(campaignOverrides = {}) {
     sequelize: { transaction: jest.fn().mockResolvedValue(mockTx), query: jest.fn().mockResolvedValue([[{ id: 'h' }]]) },
     resolveLeadRouting: jest.fn().mockResolvedValue({ agentId: 'a1', via: 'package' }),
     chargeLeadCredit: jest.fn().mockResolvedValue(true),
-    dispatchEvent: jest.fn().mockResolvedValue(undefined),
+    persistEventDeliveries: jest.fn().mockResolvedValue([{ delivery: { id: 'd' }, subscriber: { id: 's' } }]),
+    flushDeliveries: jest.fn(),
     buildLeadCreatedPayload: jest.fn(() => ({})),
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
   };
@@ -41,14 +46,12 @@ describe('releaseSweep.sweepCampaign (unit)', () => {
     deps.Prospect.findOne.mockResolvedValue(null); // empty queue — we only inspect the query shape
     await makeReleaseSweep(deps).sweepCampaign('camp-1');
     expect(deps.Prospect.findOne).toHaveBeenCalled();
-    // Must filter to the internal reason so external holds ('no_funded_external_buyer')
-    // can never be released to Lyfe by this internal sweep.
     expect(deps.Prospect.findOne.mock.calls[0][0].where).toMatchObject({
       quarantineReason: 'no_funded_agent',
     });
   });
 
-  it('drains the held queue FIFO: releases each funded lead, charges, fires lead.created', async () => {
+  it('drains the held queue FIFO: releases each funded lead, charges, persists+flushes lead.created', async () => {
     const { deps, mockTx } = buildMocks();
     deps.Prospect.findOne
       .mockResolvedValueOnce(held('h1'))
@@ -62,8 +65,29 @@ describe('releaseSweep.sweepCampaign (unit)', () => {
     expect(n).toBe(2);
     expect(deps.chargeLeadCredit).toHaveBeenCalledTimes(2);
     expect(deps.chargeLeadCredit).toHaveBeenCalledWith('a1', 'camp-1', mockTx);
-    expect(deps.dispatchEvent).toHaveBeenCalledTimes(2);
-    expect(deps.dispatchEvent).toHaveBeenCalledWith('lead.created', expect.any(Function));
+    // Transactional outbox: the delivery row is persisted INSIDE the tx, then flushed.
+    expect(deps.persistEventDeliveries).toHaveBeenCalledTimes(2);
+    expect(deps.persistEventDeliveries).toHaveBeenCalledWith(
+      'lead.created', expect.any(Function), { destination: 'lyfe' }, mockTx
+    );
+    expect(deps.flushDeliveries).toHaveBeenCalledTimes(2);
+  });
+
+  it('mktr-leads agent: routes lead.created to mktr_leads (destination-scoped) — never a broadcast (P0-4)', async () => {
+    const { deps, mockTx } = buildMocks();
+    const mktrAgent = { id: 'a1', lyfeId: null, mktrLeadsId: 'ml-a1', phone: '65', email: 'a@x', firstName: 'A', lastName: 'B' };
+    deps.User.findByPk.mockResolvedValue(mktrAgent);
+    deps.Prospect.findOne.mockResolvedValueOnce(held('h1')).mockResolvedValue(null);
+    deps.sequelize.query.mockResolvedValue([[{ id: 'claimed' }]]);
+    deps.chargeLeadCredit.mockResolvedValue(true);
+
+    await makeReleaseSweep(deps).sweepCampaign('camp-1');
+
+    // Destination MUST be present (mktr_leads) so delivery is scoped to the agent's
+    // own app — not the legacy event-type-only broadcast that leaked PII to Lyfe.
+    expect(deps.persistEventDeliveries).toHaveBeenCalledWith(
+      'lead.created', expect.any(Function), { destination: 'mktr_leads' }, mockTx
+    );
   });
 
   it('stops when no funded agent is available (via=fallback) — releases nothing', async () => {
@@ -75,7 +99,8 @@ describe('releaseSweep.sweepCampaign (unit)', () => {
 
     expect(n).toBe(0);
     expect(deps.chargeLeadCredit).not.toHaveBeenCalled();
-    expect(deps.dispatchEvent).not.toHaveBeenCalled();
+    expect(deps.persistEventDeliveries).not.toHaveBeenCalled();
+    expect(deps.flushDeliveries).not.toHaveBeenCalled();
   });
 
   it('credits run out mid-drain: charge fails → rolls back the claim and stops', async () => {
@@ -89,7 +114,8 @@ describe('releaseSweep.sweepCampaign (unit)', () => {
     expect(n).toBe(0);
     expect(mockTx.rollback).toHaveBeenCalledTimes(1);
     expect(mockTx.commit).not.toHaveBeenCalled();
-    expect(deps.dispatchEvent).not.toHaveBeenCalled();
+    expect(deps.persistEventDeliveries).not.toHaveBeenCalled();
+    expect(deps.flushDeliveries).not.toHaveBeenCalled();
   });
 
   it('lost the claim race (0 rows) → rolls back, skips, no double delivery', async () => {
@@ -102,6 +128,7 @@ describe('releaseSweep.sweepCampaign (unit)', () => {
     expect(n).toBe(0);
     expect(mockTx.rollback).toHaveBeenCalled();
     expect(deps.chargeLeadCredit).not.toHaveBeenCalled();
-    expect(deps.dispatchEvent).not.toHaveBeenCalled();
+    expect(deps.persistEventDeliveries).not.toHaveBeenCalled();
+    expect(deps.flushDeliveries).not.toHaveBeenCalled();
   });
 });

--- a/backend/test/unit/webhookDispatch.test.js
+++ b/backend/test/unit/webhookDispatch.test.js
@@ -158,12 +158,15 @@ describe('webhookDispatch (unit)', () => {
       const payloadBuilder = jest.fn().mockReturnValue({ event: 'lead.created' });
       await service.dispatchEvent('lead.created', payloadBuilder);
 
+      // dispatchEvent persists with no transaction (the txn-aware path is
+      // persistEventDeliveries, used by the held-release outbox callers).
       expect(mocks.WebhookDelivery.create).toHaveBeenCalledWith(
         expect.objectContaining({
           subscriberId: 'sub-1',
           eventType: 'lead.created',
           status: 'pending',
-        })
+        }),
+        { transaction: null }
       );
     });
 


### PR DESCRIPTION
The actual held-lead dispatch backend. PR #63 accidentally carried only a CLAUDE.md change; this is the real code. Codex 5.5 (xhigh) ×2 reviewed → no P0/P1; 198 unit tests green.

Files: webhookService (txn outbox), prospectService (`releaseHeldProspect`), releaseSweep (PII/destination fix), externalHeldLeadsController + routes/externalHeldLeads (HMAC, flag-gated by `HELD_LEADS_EXTERNAL_ENABLED`), + tests.

Deploy: `EXTERNAL_APP_SECRET` + `HELD_LEADS_EXTERNAL_ENABLED=true` are already set on Render — merging this + a deploy mounts the endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)