### PR TITLE
feat(held-leads): catch-all dispatch queue (System-Agent orphans)

### DIFF
--- a/backend/src/controllers/externalHeldLeadsController.js
+++ b/backend/src/controllers/externalHeldLeadsController.js
@@ -16,7 +16,7 @@
 
 import crypto from 'crypto';
 import { logger } from '../utils/logger.js';
-import { listHeldProspects, releaseHeldProspect } from '../services/prospectService.js';
+import { listDispatchableOrphans, releaseHeldProspect } from '../services/prospectService.js';
 
 const MAX_AGE_MS = 5 * 60 * 1000;
 const MAX_FUTURE_MS = 2 * 60 * 1000; // tolerate clock skew
@@ -81,26 +81,21 @@ export async function listHeldLeads(req, res) {
 
   try {
     const { campaignId } = req.body || {};
-    // `{ role: 'admin' }` → buildProspectWhere returns {} (fleet-wide). The reason
-    // filter is applied IN the query (before the 50-row limit) so assignable holds
-    // are never hidden behind a page of external-buyer holds.
-    const { held } = await listHeldProspects(
-      { role: 'admin' },
-      { campaignId, quarantineReason: 'no_funded_agent', limit: 50 },
-    );
-    const rows = (held || [])
-      .filter((h) => h.quarantineReason === 'no_funded_agent')
-      .map((h) => ({
-        id: h.id,
-        firstName: h.firstName || null,
-        lastInitial: h.lastName ? String(h.lastName).trim().charAt(0).toUpperCase() : null,
-        maskedPhone: maskPhone(h.phone),
-        campaignId: h.campaignId,
-        campaignName: h.campaignName,
-        leadSource: h.leadSource,
-        quarantinedAt: h.quarantinedAt,
-        createdAt: h.createdAt,
-      }));
+    // Fleet-wide orphans = no_funded_agent HOLDS + leads parked on the phantom System
+    // Agent (soft-campaign fallback). Both need a real owner; the queue surfaces both.
+    const { orphans } = await listDispatchableOrphans({ campaignId, limit: 50 });
+    const rows = (orphans || []).map((o) => ({
+      id: o.id,
+      firstName: o.firstName || null,
+      lastInitial: o.lastName ? String(o.lastName).trim().charAt(0).toUpperCase() : null,
+      maskedPhone: maskPhone(o.phone),
+      campaignId: o.campaignId,
+      campaignName: o.campaignName,
+      leadSource: o.leadSource,
+      reason: o.reason,
+      since: o.since,
+      createdAt: o.createdAt,
+    }));
     return res.json({ success: true, count: rows.length, held: rows });
   } catch (err) {
     logger.error('[external-held] list failed', { error: err?.message || String(err) });

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -1492,6 +1492,17 @@ export function makeProspectService(overrides = {}) {
     return { count, held };
   }
 
+  // The System-Agent routing fallback is only a true orphan marker when it has NO delivery
+  // destination (no lyfeId / mktrLeadsId) — its leads were never delivered anywhere. If
+  // DEFAULT_AGENT_ID ever points at a REAL fallback agent (whose leads DO get delivered),
+  // this returns null so those leads can never be mistaken for orphans (Codex B/P1).
+  async function orphanSystemAgentId() {
+    const id = await d.getSystemAgentId();
+    if (!id) return null;
+    const u = await m.User.findByPk(id, { attributes: ['id', 'lyfeId', 'mktrLeadsId'] });
+    return u && !u.lyfeId && !u.mktrLeadsId ? id : null;
+  }
+
   /**
    * Fleet-wide list of dispatchable ORPHANS for the external admin queue: no_funded_agent
    * HOLDS *and* leads parked on the phantom System Agent (the soft-campaign fallback,
@@ -1499,14 +1510,11 @@ export function makeProspectService(overrides = {}) {
    * ('no_funded_agent' | 'unassigned') and a `since` timestamp.
    */
   async function listDispatchableOrphans({ campaignId = null, limit } = {}) {
-    const systemAgentId = await d.getSystemAgentId();
+    const systemAgentId = await orphanSystemAgentId();
     const lim = Math.min(parseInt(limit, 10) || 50, 200);
-    const where = {
-      [Op.or]: [
-        { quarantinedAt: { [Op.ne]: null }, quarantineReason: 'no_funded_agent' },
-        { assignedAgentId: systemAgentId, quarantinedAt: null },
-      ],
-    };
+    const orphanClauses = [{ quarantinedAt: { [Op.ne]: null }, quarantineReason: 'no_funded_agent' }];
+    if (systemAgentId) orphanClauses.push({ assignedAgentId: systemAgentId, quarantinedAt: null });
+    const where = { [Op.or]: orphanClauses };
     if (campaignId) where.campaignId = campaignId;
 
     const { count, rows } = await m.Prospect.findAndCountAll({
@@ -1575,9 +1583,9 @@ export function makeProspectService(overrides = {}) {
     // An orphan = a lead with no real owner: a no_funded_agent HOLD, or one parked on
     // the phantom System Agent (the soft-campaign fallback — never delivered anywhere).
     // Anything else is a real assigned lead and must not be touched here.
-    const systemAgentId = await d.getSystemAgentId();
+    const systemAgentId = await orphanSystemAgentId();
     const isHeld = !!prospect.quarantinedAt && prospect.quarantineReason === 'no_funded_agent';
-    const isUnassigned = !prospect.quarantinedAt && prospect.assignedAgentId === systemAgentId;
+    const isUnassigned = !prospect.quarantinedAt && !!systemAgentId && prospect.assignedAgentId === systemAgentId;
     if (!isHeld && !isUnassigned) return { status: 'already_handled' };
 
     // Resolve the destination agent by mktrLeadsId ONLY (phone is unsafe — it can

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -1493,7 +1493,48 @@ export function makeProspectService(overrides = {}) {
   }
 
   /**
-   * Release a HELD (quarantined) prospect to a mktr-leads agent and deliver it.
+   * Fleet-wide list of dispatchable ORPHANS for the external admin queue: no_funded_agent
+   * HOLDS *and* leads parked on the phantom System Agent (the soft-campaign fallback,
+   * which has no phone so they were never delivered). Each row is tagged with `reason`
+   * ('no_funded_agent' | 'unassigned') and a `since` timestamp.
+   */
+  async function listDispatchableOrphans({ campaignId = null, limit } = {}) {
+    const systemAgentId = await d.getSystemAgentId();
+    const lim = Math.min(parseInt(limit, 10) || 50, 200);
+    const where = {
+      [Op.or]: [
+        { quarantinedAt: { [Op.ne]: null }, quarantineReason: 'no_funded_agent' },
+        { assignedAgentId: systemAgentId, quarantinedAt: null },
+      ],
+    };
+    if (campaignId) where.campaignId = campaignId;
+
+    const { count, rows } = await m.Prospect.findAndCountAll({
+      where,
+      include: [{ association: 'campaign', attributes: ['id', 'name'] }],
+      order: [['createdAt', 'ASC']], // FIFO by signup (held + unassigned interleaved)
+      limit: lim,
+    });
+
+    const orphans = rows.map((p) => ({
+      id: p.id,
+      firstName: p.firstName,
+      lastName: p.lastName,
+      phone: p.phone,
+      leadSource: p.leadSource,
+      campaignId: p.campaignId,
+      campaignName: p.campaign?.name || null,
+      reason: p.quarantinedAt ? 'no_funded_agent' : 'unassigned',
+      since: p.quarantinedAt || p.createdAt,
+      createdAt: p.createdAt,
+    }));
+
+    return { count, orphans };
+  }
+
+  /**
+   * Assign an ORPHANED prospect (a no_funded_agent HOLD, or a lead parked on the phantom
+   * System Agent fallback) to a mktr-leads agent and deliver it via a fresh lead.created.
    *
    * The held-only counterpart to assignProspect, purpose-built for the external
    * mktr-leads admin dispatch endpoint. Unlike assignProspect it can NEVER fall
@@ -1531,7 +1572,13 @@ export function makeProspectService(overrides = {}) {
     if (prospect.quarantineReason === 'no_funded_external_buyer') {
       return { status: 'not_assignable_external' };
     }
-    if (!prospect.quarantinedAt) return { status: 'already_handled' };
+    // An orphan = a lead with no real owner: a no_funded_agent HOLD, or one parked on
+    // the phantom System Agent (the soft-campaign fallback — never delivered anywhere).
+    // Anything else is a real assigned lead and must not be touched here.
+    const systemAgentId = await d.getSystemAgentId();
+    const isHeld = !!prospect.quarantinedAt && prospect.quarantineReason === 'no_funded_agent';
+    const isUnassigned = !prospect.quarantinedAt && prospect.assignedAgentId === systemAgentId;
+    if (!isHeld && !isUnassigned) return { status: 'already_handled' };
 
     // Resolve the destination agent by mktrLeadsId ONLY (phone is unsafe — it can
     // resolve a Lyfe-owned / provenance-less user whose destination ≠ mktr_leads).
@@ -1552,10 +1599,12 @@ export function makeProspectService(overrides = {}) {
         `UPDATE prospects
             SET "assignedAgentId" = :agentId, "lastContactDate" = NOW(),
                 "quarantinedAt" = NULL, "quarantineReason" = NULL, "updatedAt" = NOW()
-          WHERE id = :prospectId AND "quarantinedAt" IS NOT NULL
-            AND "quarantineReason" = 'no_funded_agent'
+          WHERE id = :prospectId AND (
+            ("quarantinedAt" IS NOT NULL AND "quarantineReason" = 'no_funded_agent')
+            OR ("assignedAgentId" = :systemAgentId AND "quarantinedAt" IS NULL)
+          )
           RETURNING id`,
-        { replacements: { agentId: agent.id, prospectId }, transaction: t }
+        { replacements: { agentId: agent.id, prospectId, systemAgentId }, transaction: t }
       );
 
       if (!Array.isArray(rows) || rows.length === 0) {
@@ -1565,8 +1614,8 @@ export function makeProspectService(overrides = {}) {
           prospectId,
           type: 'assigned',
           actorUserId,
-          description: `Released from hold and assigned to ${agent.firstName} ${agent.lastName}`.trim(),
-          metadata: { assignedAgentId: agent.id, released: true, via: 'external_app' },
+          description: `Assigned to ${agent.firstName} ${agent.lastName} via the dispatch queue`.trim(),
+          metadata: { assignedAgentId: agent.id, released: true, via: 'external_app', fromSystemAgent: isUnassigned },
         }, { transaction: t });
 
         const withCampaign = await m.Prospect.findByPk(prospectId, {
@@ -1645,6 +1694,7 @@ export function makeProspectService(overrides = {}) {
     deleteProspect,
     assignProspect,
     releaseHeldProspect,
+    listDispatchableOrphans,
     bulkAssignProspects,
     getProspectStats,
     listProspects,
@@ -1661,6 +1711,7 @@ export const updateProspect = _default.updateProspect;
 export const deleteProspect = _default.deleteProspect;
 export const assignProspect = _default.assignProspect;
 export const releaseHeldProspect = _default.releaseHeldProspect;
+export const listDispatchableOrphans = _default.listDispatchableOrphans;
 export const bulkAssignProspects = _default.bulkAssignProspects;
 export const getProspectStats = _default.getProspectStats;
 export const listProspects = _default.listProspects;

--- a/backend/test/externalHeldLeadsController.test.js
+++ b/backend/test/externalHeldLeadsController.test.js
@@ -11,11 +11,11 @@ import crypto from 'crypto';
 
 const SECRET = 'test-external-app-secret';
 
-const listHeldMock = jest.fn();
+const orphansMock = jest.fn();
 const releaseMock = jest.fn();
 
 jest.unstable_mockModule('../src/services/prospectService.js', () => ({
-  listHeldProspects: listHeldMock,
+  listDispatchableOrphans: orphansMock,
   releaseHeldProspect: releaseMock,
 }));
 jest.unstable_mockModule('../src/utils/logger.js', () => ({
@@ -30,7 +30,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   process.env.EXTERNAL_APP_SECRET = SECRET;
-  listHeldMock.mockReset();
+  orphansMock.mockReset();
   releaseMock.mockReset();
 });
 
@@ -55,7 +55,7 @@ describe('externalHeldLeadsController — auth', () => {
     const res = makeRes();
     await listHeldLeads(req, res);
     expect(res.statusCode).toBe(401);
-    expect(listHeldMock).not.toHaveBeenCalled();
+    expect(orphansMock).not.toHaveBeenCalled();
   });
 
   it('rejects a stale timestamp with 401', async () => {
@@ -76,12 +76,12 @@ describe('externalHeldLeadsController — auth', () => {
 });
 
 describe('externalHeldLeadsController.listHeldLeads', () => {
-  it('returns only no_funded_agent holds, masked', async () => {
-    listHeldMock.mockResolvedValue({
+  it('surfaces held + System-Agent orphans, masked, with reason/since', async () => {
+    orphansMock.mockResolvedValue({
       count: 2,
-      held: [
-        { id: 'p1', firstName: 'Jane', lastName: 'Doe', phone: '6591234567', email: 'j@x', leadSource: 'meta', campaignId: 'c1', campaignName: 'Cab', quarantineReason: 'no_funded_agent', quarantinedAt: 't', createdAt: 't' },
-        { id: 'p2', firstName: 'Ext', lastName: 'Buyer', phone: '6599999999', quarantineReason: 'no_funded_external_buyer', campaignId: 'c1' },
+      orphans: [
+        { id: 'p1', firstName: 'Jane', lastName: 'Doe', phone: '6591234567', leadSource: 'meta', campaignId: 'c1', campaignName: 'Cab', reason: 'no_funded_agent', since: 't1', createdAt: 't1' },
+        { id: 'p2', firstName: 'Sam', lastName: 'Lim', phone: '6599999999', leadSource: 'meta', campaignId: 'c1', campaignName: 'Cab', reason: 'unassigned', since: 't2', createdAt: 't2' },
       ],
     });
     const req = makeReq({ timestamp: new Date().toISOString() });
@@ -89,11 +89,13 @@ describe('externalHeldLeadsController.listHeldLeads', () => {
     await listHeldLeads(req, res);
 
     expect(res.statusCode).toBe(null); // res.json without status() → 200 default
-    expect(res.body.count).toBe(1); // external-buyer hold filtered out
-    const row = res.body.held[0];
-    expect(row).toMatchObject({ id: 'p1', firstName: 'Jane', lastInitial: 'D', maskedPhone: '••••4567', campaignName: 'Cab' });
-    expect(row.email).toBeUndefined(); // email not exposed
-    expect(row.lastName).toBeUndefined(); // full surname not exposed
+    expect(orphansMock).toHaveBeenCalledWith({ campaignId: undefined, limit: 50 });
+    expect(res.body.count).toBe(2);
+    const [a, b] = res.body.held;
+    expect(a).toMatchObject({ id: 'p1', firstName: 'Jane', lastInitial: 'D', maskedPhone: '••••4567', campaignName: 'Cab', reason: 'no_funded_agent', since: 't1' });
+    expect(b).toMatchObject({ id: 'p2', reason: 'unassigned' });
+    expect(a.email).toBeUndefined(); // email not exposed
+    expect(a.lastName).toBeUndefined(); // full surname not exposed
   });
 });
 

--- a/backend/test/unit/releaseHeldProspect.test.js
+++ b/backend/test/unit/releaseHeldProspect.test.js
@@ -22,7 +22,7 @@ function buildMocks() {
         .mockResolvedValueOnce(heldProspect) // pre-txn read (reason / campaignId)
         .mockResolvedValue({ ...heldProspect, campaign: { id: 'camp-1', name: 'C' } }), // withCampaign (in txn)
     },
-    User: { findOne: jest.fn().mockResolvedValue(agent) },
+    User: { findOne: jest.fn().mockResolvedValue(agent), findByPk: jest.fn().mockResolvedValue({ id: 'system-agent-id', lyfeId: null, mktrLeadsId: null }) },
     ProspectActivity: { create: jest.fn().mockResolvedValue({}) },
     IdempotencyKey: { findOne: jest.fn().mockResolvedValue(null), create: jest.fn().mockResolvedValue({}) },
   };

--- a/backend/test/unit/releaseHeldProspect.test.js
+++ b/backend/test/unit/releaseHeldProspect.test.js
@@ -36,6 +36,7 @@ function buildMocks() {
     persistEventDeliveries: jest.fn().mockResolvedValue([{ delivery: { id: 'd' }, subscriber: { id: 's' } }]),
     flushDeliveries: jest.fn(),
     deductLeadCredit: jest.fn().mockResolvedValue(true),
+    getSystemAgentId: jest.fn().mockResolvedValue('system-agent-id'),
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
   };
   return { deps, mockTx, agent, heldProspect };
@@ -44,6 +45,20 @@ function buildMocks() {
 const svc = (deps) => makeProspectService(deps);
 
 describe('releaseHeldProspect (unit)', () => {
+  it('rescues a System-Agent orphan (not held): reassigns + delivers via lead.created', async () => {
+    const { deps, mockTx } = buildMocks();
+    deps.models.Prospect.findByPk = jest.fn()
+      .mockResolvedValueOnce({ id: 'p-1', campaignId: 'camp-1', quarantineReason: null, quarantinedAt: null, assignedAgentId: 'system-agent-id' })
+      .mockResolvedValue({ id: 'p-1', campaignId: 'camp-1', campaign: { id: 'camp-1', name: 'C' } });
+    deps.sequelize.query.mockResolvedValue([[{ id: 'p-1' }]]); // conditional reassign matched
+
+    const res = await svc(deps).releaseHeldProspect('p-1', 'app-agent-1', {});
+
+    expect(res).toMatchObject({ status: 'assigned', leadId: 'p-1' });
+    expect(deps.persistEventDeliveries).toHaveBeenCalledWith('lead.created', expect.any(Function), { destination: 'mktr_leads' }, mockTx);
+    expect(mockTx.commit).toHaveBeenCalled();
+  });
+
   it('releases a held lead: atomic release, mktr_leads-scoped delivery persisted IN the tx, post-commit deduct + flush', async () => {
     const { deps, mockTx } = buildMocks();
 


### PR DESCRIPTION
Option B — the dispatch queue also surfaces leads parked on the phantom System Agent (soft-campaign fallback), not just no_funded_agent holds. Codex 5.5 xhigh reviewed → 1 P1 (DEFAULT_AGENT_ID fence) fixed. ~112+ unit tests green. Flag-gated (HELD_LEADS_EXTERNAL_ENABLED, already on). 🤖 Generated with [Claude Code](https://claude.com/claude-code)