### PR TITLE
fix(sweep): held leads are MANUAL-ONLY (disable auto-release)

### DIFF
--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -111,8 +111,9 @@ export async function bootstrapDatabase() {
       logger.info('[AgentSync] periodic sync scheduled (10 min interval)');
     }
 
-    // Lead-quota safety net: drain held queues every 2 minutes in case a package
-    // top-up did not fire its inline release sweep.
+    // Lead-quota safety net: periodic held-queue sweep (every 2 min). NOTE: auto-release
+    // is currently DISABLED (held leads are manual-only), so sweepAll no-ops today —
+    // retained as the periodic hook in case auto-release is re-enabled.
     setInterval(async () => {
       try {
         const { sweepAll } = await import('../services/releaseSweep.js');

--- a/backend/src/services/leadPackageService.js
+++ b/backend/src/services/leadPackageService.js
@@ -117,8 +117,9 @@ export async function assignPackage({ agentId, packageId }) {
     purchaseDate: new Date()
   });
 
-  // New funded package → drain any held lead-quota queue for its campaign (async,
-  // fire-and-forget; the assignment response must not wait on the sweep).
+  // New funded package → trigger the held-queue sweep for its campaign (async,
+  // fire-and-forget). NOTE: auto-release is currently DISABLED (held leads are
+  // manual-only) so this sweep no-ops — retained as the hook to re-enable it.
   if (pkg.campaignId) {
     // Dynamic import keeps releaseSweep (and its systemAgent/webhook graph) out of this
     // module's static dependency graph — avoids coupling and keeps unit-test mocks lean.
@@ -203,7 +204,8 @@ export async function updateAssignment(id, { leadsRemaining }) {
       status: newCount === 0 ? 'exhausted' : 'active'
     });
 
-    // Top-up (credits increased) → drain the held queue for this assignment's campaign.
+    // Top-up (credits increased) → trigger the held-queue sweep for this campaign.
+    // NOTE: auto-release is DISABLED (held leads are manual-only) — this sweep no-ops today.
     if (newCount > prevCount) {
       const pkg = await LeadPackage.findByPk(assignment.leadPackageId, { attributes: ['campaignId'] });
       if (pkg?.campaignId) {

--- a/backend/src/services/releaseSweep.js
+++ b/backend/src/services/releaseSweep.js
@@ -7,7 +7,9 @@ import { buildLeadCreatedPayload, destinationForAgent, externalIdForDestination 
 import { logger } from '../utils/logger.js';
 
 /**
- * Auto-release sweep for lead-quota held queues.
+ * Auto-release sweep for lead-quota held queues. DISABLED BY DEFAULT
+ * (AUTO_RELEASE_ENABLED = false): held leads are manual-only — an admin assigns them from
+ * the dispatch queue (Leads tab). The mechanics below apply only if it is re-enabled.
  *
  * When an agent's credits increase (package assigned / topped up), the held queue for
  * that campaign is drained FIFO (oldest quarantinedAt first), releasing leads to funded
@@ -21,51 +23,46 @@ import { logger } from '../utils/logger.js';
  * to Lyfe (it never saw the suppressed create webhook).
  */
 
+// Held leads are MANUAL-ONLY: once a lead lands in the held queue it must be assigned by
+// an admin from the dispatch queue (the Leads tab) — it is NEVER auto-released to an agent
+// (not on credit top-up, not on startup, regardless of age). This switch disables the
+// auto-release sweep entirely. Flip to true only to restore the old top-up auto-release.
+const AUTO_RELEASE_ENABLED = false;
+
 const defaultDeps = {
   Prospect, ProspectActivity, Campaign, User, sequelize,
   resolveLeadRouting, chargeLeadCredit, persistEventDeliveries, flushDeliveries,
   buildLeadCreatedPayload, destinationForAgent, externalIdForDestination, logger,
+  autoReleaseEnabled: AUTO_RELEASE_ENABLED,
 };
 
 // Safety bound so a single sweep can never loop unboundedly.
 const MAX_RELEASE_PER_SWEEP = 500;
-
-// A lead that signed up more than this many days ago is NEVER auto-released to an
-// agent — it must wait in the admin dispatch queue for a human to decide. (A stale
-// lead must not silently buzz an agent as if it were fresh.) The dispatch queue
-// surfaces these with NO age cap, so nothing is lost — only the *automatic* path is gated.
-const AUTO_RELEASE_MAX_AGE_DAYS = 7;
 
 export function makeReleaseSweep(overrides = {}) {
   const d = { ...defaultDeps, ...overrides };
 
   async function sweepCampaign(campaignId) {
     if (!campaignId) return 0;
+    // Auto-release is disabled: held leads are manual-only (an admin assigns them from the
+    // dispatch queue / Leads tab). The sweep is retained but no-ops unless re-enabled.
+    if (!d.autoReleaseEnabled) return 0;
 
     // Only quota-enforced campaigns ever hold leads; skip everything else cheaply.
     const campaign = await d.Campaign.findByPk(campaignId);
     if (!campaign || campaign.enforceLeadQuota !== true) return 0;
 
-    // Only auto-release leads that are still FRESH; stale ones wait for the admin.
-    const freshCutoff = new Date(Date.now() - AUTO_RELEASE_MAX_AGE_DAYS * 24 * 60 * 60 * 1000);
     let released = 0;
     for (let i = 0; i < MAX_RELEASE_PER_SWEEP; i++) {
       // Oldest held lead for this campaign (FIFO). Only INTERNAL lead-quota holds
       // (quarantineReason 'no_funded_agent') are eligible — external holds
       // ('no_funded_external_buyer') must NEVER be released to Lyfe by this internal
       // sweep; they can only ever be delivered via the external (MKTR Leads) channel.
-      // Stale leads (signed up before freshCutoff) are skipped — they must be dispatched
-      // by an admin from the queue, never auto-released here.
       const held = await d.Prospect.findOne({
-        where: {
-          campaignId,
-          quarantinedAt: { [Op.ne]: null },
-          quarantineReason: 'no_funded_agent',
-          createdAt: { [Op.gt]: freshCutoff },
-        },
+        where: { campaignId, quarantinedAt: { [Op.ne]: null }, quarantineReason: 'no_funded_agent' },
         order: [['quarantinedAt', 'ASC']],
       });
-      if (!held) break; // no fresh held leads left to auto-release
+      if (!held) break; // queue drained
 
       // Pick a funded agent (round-robin among campaign package agents with credits).
       const routing = await d.resolveLeadRouting({ reqUser: null, requestedAgentId: null, campaignId, qrTagId: null });
@@ -161,18 +158,12 @@ export function makeReleaseSweep(overrides = {}) {
 
   /** Periodic backstop: sweep every quota campaign that currently has held leads. */
   async function sweepAll() {
-    // Only consider campaigns with at least one FRESH held lead; campaigns whose holds
-    // are all stale have nothing auto-releasable (those wait for an admin to dispatch).
-    const freshCutoff = new Date(Date.now() - AUTO_RELEASE_MAX_AGE_DAYS * 24 * 60 * 60 * 1000);
+    // Auto-release is disabled: held leads are manual-only. No-op unless re-enabled.
+    if (!d.autoReleaseEnabled) return 0;
     const rows = await d.Prospect.findAll({
       attributes: ['campaignId'],
       // Internal lead-quota holds only — external holds are not releasable here.
-      where: {
-        quarantinedAt: { [Op.ne]: null },
-        quarantineReason: 'no_funded_agent',
-        campaignId: { [Op.ne]: null },
-        createdAt: { [Op.gt]: freshCutoff },
-      },
+      where: { quarantinedAt: { [Op.ne]: null }, quarantineReason: 'no_funded_agent', campaignId: { [Op.ne]: null } },
       group: ['campaignId'],
     });
     let total = 0;

--- a/backend/test/leadQuota.test.js
+++ b/backend/test/leadQuota.test.js
@@ -250,24 +250,25 @@ describe('updateProspect reassign leak (closed)', () => {
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
-describe('auto-release sweep', () => {
-  it('drains held leads to a newly-funded agent, credit-bounded (partial top-up)', async () => {
+// Auto-release is DISABLED — held leads are MANUAL-ONLY: the sweep never assigns a held
+// lead to an agent, and a credit top-up does not drain the held queue. Held leads wait in
+// the dispatch queue for an admin to assign them.
+describe('held leads are manual-only (auto-release disabled)', () => {
+  it('sweepCampaign never releases — held leads stay held even with a funded agent', async () => {
     const c = await quotaCampaign();
     const r1 = await postLead(c.id);
     const r2 = await postLead(c.id);
     const r3 = await postLead(c.id); // 3 held (unfunded)
 
-    const { agent } = await fundedAgent(c.id, 2); // only 2 credits
+    await fundedAgent(c.id, 2); // a funded agent exists, but auto-release is OFF
 
-    const released = await sweepCampaign(c.id);
-    expect(released).toBe(2);
+    expect(await sweepCampaign(c.id)).toBe(0); // the sweep is a no-op
 
     const ps = await Promise.all([r1, r2, r3].map(prospectFromRes));
-    expect(ps.filter((p) => p.quarantinedAt === null && p.assignedAgentId === agent.id)).toHaveLength(2);
-    expect(ps.filter((p) => p.quarantinedAt !== null)).toHaveLength(1); // 1 stays held (credits exhausted)
+    expect(ps.filter((p) => p.quarantinedAt !== null)).toHaveLength(3); // all 3 stay held
   });
 
-  it('releases nothing for a campaign with no funded agent', async () => {
+  it('is a no-op for a campaign with no funded agent', async () => {
     const c = await quotaCampaign();
     await postLead(c.id); // held
     expect(await sweepCampaign(c.id)).toBe(0);
@@ -278,7 +279,7 @@ describe('auto-release sweep', () => {
     expect(await sweepCampaign(c.id)).toBe(0);
   });
 
-  it('a credit top-up via PATCH /assignments/:id auto-triggers a release (end-to-end)', async () => {
+  it('a credit top-up does NOT auto-release a held lead — it stays held for manual dispatch', async () => {
     const c = await quotaCampaign();
     const r = await postLead(c.id); // held (no funded agent yet)
     const heldId = r.body.data.prospect.id;
@@ -293,14 +294,11 @@ describe('auto-release sweep', () => {
       .send({ leadsRemaining: 3 });
     expect(up.status).toBe(200);
 
-    // The sweep is fire-and-forget; poll briefly (≤3s) for the auto-release.
-    let p;
-    for (let i = 0; i < 30; i++) {
-      p = await Prospect.findByPk(heldId);
-      if (p.quarantinedAt === null) break;
-      await new Promise((res) => setTimeout(res, 100));
-    }
-    expect(p.quarantinedAt).toBeNull();
-    expect(p.assignedAgentId).toBe(agent.id);
+    // The top-up fires the (now-disabled) sweep fire-and-forget; give it a beat, then
+    // confirm the lead is STILL held — auto-release is off, so it waits for manual dispatch.
+    await new Promise((res) => setTimeout(res, 500));
+    const p = await Prospect.findByPk(heldId);
+    expect(p.quarantinedAt).not.toBeNull();       // still held
+    expect(p.assignedAgentId).not.toBe(agent.id); // never auto-assigned
   }, 15000);
 });

--- a/backend/test/unit/releaseSweep.test.js
+++ b/backend/test/unit/releaseSweep.test.js
@@ -1,5 +1,4 @@
 import { jest } from '@jest/globals';
-import { Op } from 'sequelize';
 import '../setup.js';
 import { makeReleaseSweep } from '../../src/services/releaseSweep.js';
 
@@ -28,6 +27,7 @@ function buildMocks(campaignOverrides = {}) {
     flushDeliveries: jest.fn(),
     buildLeadCreatedPayload: jest.fn(() => ({})),
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+    autoReleaseEnabled: true, // these tests exercise the release path; production default is false
   };
   return { deps, mockTx, agent };
 }
@@ -52,17 +52,18 @@ describe('releaseSweep.sweepCampaign (unit)', () => {
     });
   });
 
-  it('auto-releases only FRESH leads: the FIFO query caps lead age at a ~7-day createdAt cutoff', async () => {
+  it('auto-release is OFF by default (held leads are MANUAL-only): the sweep is a complete no-op', async () => {
     const { deps } = buildMocks();
-    deps.Prospect.findOne.mockResolvedValue(null); // empty queue — inspect the query shape only
-    const before = Date.now();
-    await makeReleaseSweep(deps).sweepCampaign('camp-1');
-    const cutoff = deps.Prospect.findOne.mock.calls[0][0].where.createdAt[Op.gt];
-    expect(cutoff).toBeInstanceOf(Date);
-    // Stale leads (signed up before the cutoff) are excluded from the auto-release path.
-    const windowMs = before - cutoff.getTime();
-    expect(windowMs).toBeGreaterThanOrEqual(7 * 24 * 60 * 60 * 1000 - 5000);
-    expect(windowMs).toBeLessThanOrEqual(7 * 24 * 60 * 60 * 1000 + 5000);
+    delete deps.autoReleaseEnabled; // fall through to the production default (AUTO_RELEASE_ENABLED = false)
+    const sweep = makeReleaseSweep(deps);
+    expect(await sweep.sweepCampaign('camp-1')).toBe(0);
+    expect(await sweep.sweepAll()).toBe(0);
+    // Nothing is read, charged, or delivered — held leads simply stay in the queue.
+    expect(deps.Campaign.findByPk).not.toHaveBeenCalled();
+    expect(deps.Prospect.findOne).not.toHaveBeenCalled();
+    expect(deps.Prospect.findAll).not.toHaveBeenCalled();
+    expect(deps.chargeLeadCredit).not.toHaveBeenCalled();
+    expect(deps.persistEventDeliveries).not.toHaveBeenCalled();
   });
 
   it('drains the held queue FIFO: releases each funded lead, charges, persists+flushes lead.created', async () => {


### PR DESCRIPTION
Any lead that lands in the held queue must be assigned manually by an admin from the dispatch queue (Leads tab) — never auto-released (not on credit top-up, not on startup, regardless of age). Gated at the sweep functions (one switch covers all 4 trigger sites). Reverts the 7-day freshness gate (superseded). Codex 5.5 xhigh: runtime verified correct; P1 (stale integration test) + P3 (call-site comments) fixed. 1174 unit tests green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)