### PR TITLE
fix(lead-packages): write 'completed' not 'exhausted' when zeroing assignment credits

### DIFF
--- a/backend/src/models/LeadPackageAssignment.js
+++ b/backend/src/models/LeadPackageAssignment.js
@@ -24,7 +24,7 @@ const LeadPackageAssignment = sequelize.define('LeadPackageAssignment', {
         }
     },
     status: {
-        type: DataTypes.ENUM('active', 'completed', 'cancelled', 'expired', 'exhausted'),
+        type: DataTypes.ENUM('active', 'completed', 'cancelled', 'expired'),
         defaultValue: 'active'
     },
     leadsRemaining: {

--- a/backend/src/services/leadPackageService.js
+++ b/backend/src/services/leadPackageService.js
@@ -201,7 +201,10 @@ export async function updateAssignment(id, { leadsRemaining }) {
     const prevCount = assignment.leadsRemaining;
     await assignment.update({
       leadsRemaining: newCount,
-      status: newCount === 0 ? 'exhausted' : 'active'
+      // 'completed' is the terminal "no credits left" status used everywhere else
+      // (leadCredits.js natural drain). 'exhausted' is NOT in the live Postgres enum
+      // (enum_lead_package_assignments_status) so writing it throws a DatabaseError.
+      status: newCount === 0 ? 'completed' : 'active'
     });
 
     // Top-up (credits increased) → trigger the held-queue sweep for this campaign.

--- a/backend/test/leadPackages.test.js
+++ b/backend/test/leadPackages.test.js
@@ -421,7 +421,7 @@ describe('LeadPackage assignment', () => {
     expect(res.body.data.assignment.status).toBe('active')
   })
 
-  it('PATCH /api/lead-packages/assignments/:id — setting leadsRemaining to 0 sets status to exhausted', async () => {
+  it('PATCH /api/lead-packages/assignments/:id — setting leadsRemaining to 0 sets status to completed', async () => {
     const res = await request(app)
       .patch(`/api/lead-packages/assignments/${assignmentId}`)
       .set('Authorization', `Bearer ${adminToken}`)
@@ -429,7 +429,7 @@ describe('LeadPackage assignment', () => {
 
     expect(res.status).toBe(200)
     expect(res.body.data.assignment.leadsRemaining).toBe(0)
-    expect(res.body.data.assignment.status).toBe('exhausted')
+    expect(res.body.data.assignment.status).toBe('completed')
   })
 
   it('PATCH /api/lead-packages/assignments/:id — rejects negative leadsRemaining', async () => {

--- a/backend/test/unit/leadPackageService.test.js
+++ b/backend/test/unit/leadPackageService.test.js
@@ -348,14 +348,14 @@ describe('leadPackageService (unit)', () => {
       );
     });
 
-    it('sets status to exhausted when leadsRemaining is 0', async () => {
+    it('sets status to completed when leadsRemaining is 0', async () => {
       const assignment = { ...mockAssignment, update: jest.fn().mockResolvedValue(true) };
       LeadPackageAssignment.findByPk.mockResolvedValue(assignment);
 
       await updateAssignment('assign-1', { leadsRemaining: 0 });
 
       expect(assignment.update).toHaveBeenCalledWith(
-        expect.objectContaining({ leadsRemaining: 0, status: 'exhausted' })
+        expect.objectContaining({ leadsRemaining: 0, status: 'completed' })
       );
     });
 

--- a/src/components/agents/ManagePackagesDialog.jsx
+++ b/src/components/agents/ManagePackagesDialog.jsx
@@ -77,7 +77,7 @@ export default function ManagePackagesDialog({
  ${
  assignment.status ==="active" ?"bg-success/10 text-success border-success/30" :"" }
  ${
- assignment.status ==="exhausted" ?"bg-muted text-muted-foreground border-border" :"" }
+ assignment.status ==="completed" ?"bg-muted text-muted-foreground border-border" :"" }
  ${
  assignment.status ==="expired" ?"bg-warning/10 text-warning border-warning/30" :"" }
  `}


### PR DESCRIPTION
## Problem

Setting an agent's lead-package assignment **leadsRemaining to 0** in the admin Packages dialog (`PATCH /api/lead-packages/assignments/:id`) failed with a generic **"Database Error"** toast. Sentry:

```
SequelizeDatabaseError: invalid input value for enum
  enum_lead_package_assignments_status: "exhausted"
    leadPackageService.js:202 (updateAssignment)
```

## Root cause

`updateAssignment` wrote `status: 'exhausted'` when credits hit 0. `'exhausted'` was added to the **JS model ENUM** but **never migrated into the live Postgres enum**, which only contains `{active, completed, cancelled, expired}`. Verified against prod DB.

It stayed dormant because it only fires at *exactly* 0, and the natural lead-consumption path (`leadCredits.js`) already uses `'completed'` for that terminal state — only the manual admin edit hit the bad value.

## Fix

- `leadPackageService.updateAssignment`: `'exhausted'` → **`'completed'`** (aligns with `leadCredits.js`)
- `LeadPackageAssignment` model: drop the unused `'exhausted'` so the model matches the live DB (removes the footgun)
- `ManagePackagesDialog`: give `'completed'` the muted badge styling
- Update 2 tests that asserted the buggy `'exhausted'` (they passed only because mocks/test-DB never hit the real enum)

Round-robin eligibility unaffected (`systemAgent` filters on `status='active'` + `leadsRemaining>0`). **No data migration needed** — prod has 0 rows with `'exhausted'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)