### PR TITLE
feat(external): /api/external/agent-packages for mktr-leads "My Packages"

### DIFF
--- a/backend/src/controllers/externalAgentPackagesController.js
+++ b/backend/src/controllers/externalAgentPackagesController.js
@@ -1,0 +1,94 @@
+/**
+ * @file externalAgentPackagesController — the MKTR Leads buyer app's "My Packages".
+ *
+ * ── Endpoint (mounted at /api/external/agent-packages) ──────────────────────
+ *   POST /   → an agent's OWN lead-package assignments (remaining/total, status,
+ *              quality, derived commission + expiry). Read-only.
+ *
+ * ── Auth ────────────────────────────────────────────────────────────────────
+ * HMAC-SHA256 over the RAW BODY using EXTERNAL_APP_SECRET — the SAME scheme as
+ * /api/external/held-leads + /api/external/lead-outcomes (header
+ * `X-Webhook-Signature: sha256=<hex>`, freshness gated on the signed body
+ * `timestamp`, ±5 min). NOT the platform JWT. The mktr-leads `mktr-agent-packages`
+ * broker edge function (agent-JWT gated, self-scopes the CALLER's own mktr_user_id,
+ * holds the secret server-side) is the only intended caller. The whole route is
+ * gated behind AGENT_PACKAGES_EXTERNAL_ENABLED so it stays unmounted until the
+ * secret + the broker are provisioned.
+ *
+ * Self-scoping is enforced twice: the broker only ever sends the caller's own id,
+ * and getExternalAgentPackages resolves by mktrLeadsId + role='agent' + isActive.
+ */
+
+import crypto from 'crypto';
+import { logger } from '../utils/logger.js';
+import { getExternalAgentPackages } from '../services/leadPackageService.js';
+
+const MAX_AGE_MS = 5 * 60 * 1000;
+const MAX_FUTURE_MS = 2 * 60 * 1000; // tolerate clock skew
+const MAX_BODY_BYTES = 64 * 1024;
+
+function timingSafeHexEq(receivedHex, expectedHex) {
+  if (typeof receivedHex !== 'string' || typeof expectedHex !== 'string') return false;
+  if (receivedHex.length !== expectedHex.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(receivedHex, 'hex'), Buffer.from(expectedHex, 'hex'));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verify HMAC + freshness. Returns null on success, or { code, error } to send.
+ * Mirrors externalHeldLeadsController / externalLeadOutcomeController so all three
+ * external channels share one wire contract (rawBody is captured by the
+ * /api/external/ verify hook in server_internal.js).
+ */
+function verifyExternalHmac(req) {
+  const secret = process.env.EXTERNAL_APP_SECRET;
+  if (!secret) {
+    logger.error('[external-packages] EXTERNAL_APP_SECRET not configured');
+    return { code: 500, error: 'Server misconfigured' };
+  }
+  if (!req.rawBody || !Buffer.isBuffer(req.rawBody)) {
+    logger.error('[external-packages] req.rawBody missing — verify hook not wired for this path');
+    return { code: 500, error: 'Server misconfigured' };
+  }
+  if (req.rawBody.length > MAX_BODY_BYTES) return { code: 413, error: 'Payload too large' };
+
+  const sigHeader = req.headers['x-webhook-signature'] || '';
+  if (typeof sigHeader !== 'string' || !sigHeader.startsWith('sha256=')) {
+    return { code: 401, error: 'Unauthorized' };
+  }
+  const expectedHex = crypto.createHmac('sha256', secret).update(req.rawBody).digest('hex');
+  if (!timingSafeHexEq(sigHeader.slice(7), expectedHex)) {
+    return { code: 401, error: 'Unauthorized' };
+  }
+
+  const tsMs = typeof req.body?.timestamp === 'string' ? Date.parse(req.body.timestamp) : NaN;
+  if (Number.isNaN(tsMs)) return { code: 401, error: 'Unauthorized' };
+  const ageMs = Date.now() - tsMs;
+  if (ageMs > MAX_AGE_MS || ageMs < -MAX_FUTURE_MS) return { code: 401, error: 'Unauthorized' };
+
+  return null;
+}
+
+export async function listAgentPackages(req, res) {
+  const authErr = verifyExternalHmac(req);
+  if (authErr) return res.status(authErr.code).json({ success: false, error: authErr.error });
+
+  const { agentMktrUserId } = req.body || {};
+  if (!agentMktrUserId || typeof agentMktrUserId !== 'string') {
+    return res.status(400).json({ success: false, error: 'agentMktrUserId is required' });
+  }
+
+  try {
+    // agentMktrUserId is the app's agents.mktr_user_id (== MKTR users.mktrLeadsId).
+    // The service self-scopes (role='agent' + isActive) and returns an empty list for
+    // any unknown / ineligible id — so this surface can neither leak nor cross-read.
+    const { packages } = await getExternalAgentPackages(agentMktrUserId);
+    return res.json({ success: true, count: packages.length, packages });
+  } catch (err) {
+    logger.error('[external-packages] list failed', { error: err?.message || String(err) });
+    return res.status(500).json({ success: false, error: 'Failed to list agent packages' });
+  }
+}

--- a/backend/src/routes/externalAgentPackages.js
+++ b/backend/src/routes/externalAgentPackages.js
@@ -1,0 +1,27 @@
+/**
+ * MKTR Leads (external buyer app) → an agent's own lead-package balances ("My Packages").
+ *
+ * Mounted at `/api/external/agent-packages`. Auth is HMAC-SHA256 over the raw body
+ * (EXTERNAL_APP_SECRET) — see externalAgentPackagesController. rawBody capture and the
+ * rate-limiter exemption for the `/api/external/` prefix are wired in server_internal.js,
+ * same as /api/external/held-leads + /api/external/lead-outcomes.
+ *
+ * Gated behind AGENT_PACKAGES_EXTERNAL_ENABLED so the route stays UNMOUNTED until the
+ * secret + the mktr-leads broker edge function are provisioned (deploy-inert).
+ */
+import express from 'express';
+import { listAgentPackages } from '../controllers/externalAgentPackagesController.js';
+
+const router = express.Router();
+
+export const meta = {
+  path: '/api/external/agent-packages',
+  flag: 'AGENT_PACKAGES_EXTERNAL_ENABLED',
+  flagDefault: 'false'
+};
+
+// POST (not GET) so the body carries the signed `timestamp` the HMAC freshness check
+// reads — consistent with /api/external/held-leads + /api/external/lead-outcomes.
+router.post('/', listAgentPackages);
+
+export default router;

--- a/backend/src/services/leadPackageService.js
+++ b/backend/src/services/leadPackageService.js
@@ -192,7 +192,11 @@ export async function getExternalAgentPackages(mktrLeadsId) {
   if (!agent) return { packages: [] };
 
   const assignments = await LeadPackageAssignment.findAll({
-    where: { agentId: agent.id },
+    // Only states an agent's "My Packages" view should reflect: 'active' = still
+    // receivable, 'completed'/'exhausted' = ran dry (shown as the OUT-OF-LEADS card).
+    // 'cancelled'/'expired' are dead — never receivable — so excluding them keeps a
+    // stale assignment with leftover credits from inflating the headline.
+    where: { agentId: agent.id, status: ['active', 'completed', 'exhausted'] },
     include: [
       {
         model: LeadPackage,

--- a/backend/src/services/leadPackageService.js
+++ b/backend/src/services/leadPackageService.js
@@ -172,6 +172,72 @@ export async function getAgentAssignments({ agentId, requesterId, requesterRole 
 }
 
 /**
+ * External (mktr-leads buyer app) → an agent's OWN lead-package assignments.
+ *
+ * Self-scoping by design: resolves the agent by `mktrLeadsId` AND `role:'agent'` AND
+ * `isActive:true` — the SAME guard as releaseHeldProspect's destination resolver, so a
+ * stale / cross-source / non-agent id can never read someone's packages. An unknown or
+ * ineligible id returns an empty list (never throws, never leaks existence). Returns a
+ * flat, display-ready DTO; the only id exposed is the assignment's own.
+ *
+ * Called by externalAgentPackagesController (HMAC + AGENT_PACKAGES_EXTERNAL_ENABLED gated).
+ */
+export async function getExternalAgentPackages(mktrLeadsId) {
+  if (!mktrLeadsId || typeof mktrLeadsId !== 'string') return { packages: [] };
+
+  const agent = await User.findOne({
+    where: { mktrLeadsId, role: 'agent', isActive: true },
+    attributes: ['id']
+  });
+  if (!agent) return { packages: [] };
+
+  const assignments = await LeadPackageAssignment.findAll({
+    where: { agentId: agent.id },
+    include: [
+      {
+        model: LeadPackage,
+        as: 'package',
+        attributes: ['name', 'type', 'qualityScore', 'currency', 'commissionStructure', 'validityPeriod'],
+        include: [{ model: Campaign, as: 'campaign', attributes: ['name'] }]
+      }
+    ],
+    order: [['purchaseDate', 'DESC']]
+  });
+
+  const packages = assignments.map((a) => {
+    const pkg = a.package || null;
+    const validityDays = pkg?.validityPeriod ?? null;
+    const purchasedAt = a.purchaseDate ? new Date(a.purchaseDate) : null;
+    // Expiry is derived, not stored — only when the package carries a validity window.
+    const expiresAt =
+      purchasedAt && Number.isFinite(validityDays) && validityDays > 0
+        ? new Date(purchasedAt.getTime() + validityDays * 86400000).toISOString()
+        : null;
+    // commissionStructure is JSON ({ agentCommission, ... }), default 0. Pass the agent's
+    // per-lead cut through only when it's a positive number — the UI hides it otherwise so
+    // a default/absent value never renders as a misleading "$0/lead".
+    const agentCommission = pkg?.commissionStructure?.agentCommission;
+    return {
+      id: a.id,
+      name: pkg?.name || 'Lead package',
+      type: pkg?.type || null,
+      status: a.status,
+      leadsRemaining: a.leadsRemaining,
+      leadsTotal: a.leadsTotal,
+      qualityScore: pkg?.qualityScore ?? null,
+      commissionPerLead: typeof agentCommission === 'number' && agentCommission > 0 ? agentCommission : null,
+      currency: pkg?.currency || 'USD',
+      campaignName: pkg?.campaign?.name || null,
+      purchaseDate: purchasedAt ? purchasedAt.toISOString() : null,
+      validityDays,
+      expiresAt
+    };
+  });
+
+  return { packages };
+}
+
+/**
  * Delete a package assignment by ID.
  */
 export async function deleteAssignment(id) {

--- a/backend/test/unit/leadPackageService.test.js
+++ b/backend/test/unit/leadPackageService.test.js
@@ -368,7 +368,10 @@ describe('leadPackageService (unit)', () => {
         role: 'agent',
         isActive: true,
       });
-      expect(LeadPackageAssignment.findAll.mock.calls[0][0].where).toEqual({ agentId: 'agent-1' });
+      expect(LeadPackageAssignment.findAll.mock.calls[0][0].where).toEqual({
+        agentId: 'agent-1',
+        status: ['active', 'completed', 'exhausted'],
+      });
     });
 
     it('returns an empty list for an unknown / ineligible id — no throw, no DB read for assignments', async () => {

--- a/backend/test/unit/leadPackageService.test.js
+++ b/backend/test/unit/leadPackageService.test.js
@@ -53,6 +53,7 @@ const LeadPackageAssignment = {
 
 const User = {
   findByPk: jest.fn().mockResolvedValue(mockAgent),
+  findOne: jest.fn().mockResolvedValue(mockAgent),
 };
 
 const Campaign = {
@@ -101,6 +102,7 @@ const {
   updatePackage,
   assignPackage,
   getAgentAssignments,
+  getExternalAgentPackages,
   deleteAssignment,
   updateAssignment,
   deletePackage,
@@ -329,6 +331,106 @@ describe('leadPackageService (unit)', () => {
         requesterId: 'agent-1',
         requesterRole: 'agent',
       })).rejects.toThrow('Access denied');
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // getExternalAgentPackages (mktr-leads "My Packages")
+  // ────────────────────────────────────────────────
+
+  describe('getExternalAgentPackages', () => {
+    const assignmentWithPkg = {
+      id: 'assign-1',
+      agentId: 'agent-1',
+      status: 'active',
+      leadsRemaining: 37,
+      leadsTotal: 100,
+      purchaseDate: new Date('2026-06-01T00:00:00.000Z'),
+      package: {
+        name: 'Premium SG Leads',
+        type: 'premium',
+        qualityScore: 8,
+        currency: 'SGD',
+        commissionStructure: { agentCommission: 12, referralBonus: 0, tierBonuses: {} },
+        validityPeriod: 30,
+        campaign: { name: 'Retirement Income' },
+      },
+    };
+
+    it('self-scopes: resolves the agent by mktrLeadsId + role=agent + isActive, then scopes assignments to that id', async () => {
+      User.findOne.mockResolvedValue({ id: 'agent-1' });
+      LeadPackageAssignment.findAll.mockResolvedValue([assignmentWithPkg]);
+
+      await getExternalAgentPackages('mktr-user-123');
+
+      expect(User.findOne.mock.calls[0][0].where).toEqual({
+        mktrLeadsId: 'mktr-user-123',
+        role: 'agent',
+        isActive: true,
+      });
+      expect(LeadPackageAssignment.findAll.mock.calls[0][0].where).toEqual({ agentId: 'agent-1' });
+    });
+
+    it('returns an empty list for an unknown / ineligible id — no throw, no DB read for assignments', async () => {
+      User.findOne.mockResolvedValue(null);
+      LeadPackageAssignment.findAll.mockClear();
+
+      const result = await getExternalAgentPackages('not-an-agent');
+
+      expect(result).toEqual({ packages: [] });
+      expect(LeadPackageAssignment.findAll).not.toHaveBeenCalled();
+    });
+
+    it('returns an empty list for a blank id without touching the DB', async () => {
+      User.findOne.mockClear();
+      const result = await getExternalAgentPackages('');
+      expect(result).toEqual({ packages: [] });
+      expect(User.findOne).not.toHaveBeenCalled();
+    });
+
+    it('maps assignment + package to a flat DTO with a derived expiry (purchase + validity days)', async () => {
+      User.findOne.mockResolvedValue({ id: 'agent-1' });
+      LeadPackageAssignment.findAll.mockResolvedValue([assignmentWithPkg]);
+
+      const { packages } = await getExternalAgentPackages('mktr-user-123');
+
+      expect(packages).toHaveLength(1);
+      expect(packages[0]).toMatchObject({
+        id: 'assign-1',
+        name: 'Premium SG Leads',
+        type: 'premium',
+        status: 'active',
+        leadsRemaining: 37,
+        leadsTotal: 100,
+        qualityScore: 8,
+        commissionPerLead: 12,
+        currency: 'SGD',
+        campaignName: 'Retirement Income',
+        validityDays: 30,
+      });
+      expect(packages[0].expiresAt).toBe(new Date('2026-07-01T00:00:00.000Z').toISOString());
+    });
+
+    it('hides a zero/absent commission and null validity (no misleading $0, no fake expiry)', async () => {
+      User.findOne.mockResolvedValue({ id: 'agent-1' });
+      LeadPackageAssignment.findAll.mockResolvedValue([
+        {
+          ...assignmentWithPkg,
+          package: {
+            ...assignmentWithPkg.package,
+            commissionStructure: { agentCommission: 0 },
+            validityPeriod: null,
+            qualityScore: null,
+          },
+        },
+      ]);
+
+      const { packages } = await getExternalAgentPackages('mktr-user-123');
+
+      expect(packages[0].commissionPerLead).toBeNull();
+      expect(packages[0].qualityScore).toBeNull();
+      expect(packages[0].validityDays).toBeNull();
+      expect(packages[0].expiresAt).toBeNull();
     });
   });
 


### PR DESCRIPTION
Flag-gated external endpoint returning an agent's own lead-package assignments to the mktr-leads `mktr-agent-packages` broker EF. Mirrors the held-leads broker wire contract.

## Changes
- `routes/externalAgentPackages.js` — `POST /`, `meta` flag-gated `AGENT_PACKAGES_EXTERNAL_ENABLED` (default off → route unmounted, deploy-inert)
- `controllers/externalAgentPackagesController.js` — HMAC-SHA256 over raw body (`EXTERNAL_APP_SECRET`), ±5min freshness — identical scheme to `/api/external/held-leads`
- `leadPackageService.getExternalAgentPackages()` — self-scoped resolver (`mktrLeadsId + role='agent' + isActive`, mirrors `releaseHeldProspect`); unknown/ineligible id → empty list (never throws/leaks); returns only `active`/`completed`/`exhausted` assignments so dead ones can't inflate the balance

## Tests
+5 unit tests (self-scoping guard, empty cases, DTO + derived expiry, status filter). Codex-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)