### PR TITLE
feat(external): full held-lead PII (additive) for the admin detail view

### DIFF
--- a/backend/src/controllers/externalHeldLeadsController.js
+++ b/backend/src/controllers/externalHeldLeadsController.js
@@ -66,8 +66,10 @@ function verifyExternalHmac(req) {
   return null;
 }
 
-// PII is minimised for the queue view — the admin dispatches by name + campaign,
-// and does not need to contact the lead from this surface.
+// The list keeps the masked fields (firstName + lastInitial + maskedPhone) for the queue row
+// and back-compat with older app builds, AND additively returns the FULL name / phone / email
+// so the admin can open a held lead and contact/qualify it. This surface is admin-only — the
+// broker EF re-checks the LIVE admin role — so the unmasked PII never reaches a non-admin.
 function maskPhone(phone) {
   if (!phone || typeof phone !== 'string') return null;
   const digits = phone.replace(/\D/g, '');
@@ -87,8 +89,11 @@ export async function listHeldLeads(req, res) {
     const rows = (orphans || []).map((o) => ({
       id: o.id,
       firstName: o.firstName || null,
+      lastName: o.lastName || null,
       lastInitial: o.lastName ? String(o.lastName).trim().charAt(0).toUpperCase() : null,
+      phone: o.phone || null,
       maskedPhone: maskPhone(o.phone),
+      email: o.email || null,
       campaignId: o.campaignId,
       campaignName: o.campaignName,
       leadSource: o.leadSource,

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -1529,6 +1529,7 @@ export function makeProspectService(overrides = {}) {
       firstName: p.firstName,
       lastName: p.lastName,
       phone: p.phone,
+      email: p.email,
       leadSource: p.leadSource,
       campaignId: p.campaignId,
       campaignName: p.campaign?.name || null,

--- a/backend/test/externalHeldLeadsController.test.js
+++ b/backend/test/externalHeldLeadsController.test.js
@@ -76,11 +76,11 @@ describe('externalHeldLeadsController — auth', () => {
 });
 
 describe('externalHeldLeadsController.listHeldLeads', () => {
-  it('surfaces held + System-Agent orphans, masked, with reason/since', async () => {
+  it('surfaces held + System-Agent orphans with masked + full PII and reason/since', async () => {
     orphansMock.mockResolvedValue({
       count: 2,
       orphans: [
-        { id: 'p1', firstName: 'Jane', lastName: 'Doe', phone: '6591234567', leadSource: 'meta', campaignId: 'c1', campaignName: 'Cab', reason: 'no_funded_agent', since: 't1', createdAt: 't1' },
+        { id: 'p1', firstName: 'Jane', lastName: 'Doe', phone: '6591234567', email: 'jane@example.com', leadSource: 'meta', campaignId: 'c1', campaignName: 'Cab', reason: 'no_funded_agent', since: 't1', createdAt: 't1' },
         { id: 'p2', firstName: 'Sam', lastName: 'Lim', phone: '6599999999', leadSource: 'meta', campaignId: 'c1', campaignName: 'Cab', reason: 'unassigned', since: 't2', createdAt: 't2' },
       ],
     });
@@ -94,8 +94,9 @@ describe('externalHeldLeadsController.listHeldLeads', () => {
     const [a, b] = res.body.held;
     expect(a).toMatchObject({ id: 'p1', firstName: 'Jane', lastInitial: 'D', maskedPhone: '••••4567', campaignName: 'Cab', reason: 'no_funded_agent', since: 't1' });
     expect(b).toMatchObject({ id: 'p2', reason: 'unassigned' });
-    expect(a.email).toBeUndefined(); // email not exposed
-    expect(a.lastName).toBeUndefined(); // full surname not exposed
+    // Full PII is now returned ADDITIVELY (admin-only surface) alongside the masked fields.
+    expect(a).toMatchObject({ lastName: 'Doe', phone: '6591234567', email: 'jane@example.com' });
+    expect(a.maskedPhone).toBe('••••4567'); // masked field retained for back-compat
   });
 });
 


### PR DESCRIPTION
`listHeldLeads` now returns full `lastName` + `phone` + `email` **alongside** the existing masked fields (`firstName`/`lastInitial`/`maskedPhone`) so the mktr-leads admin can open a held lead and contact it.

- Additive → older app builds keep rendering masked through the rollout window.
- Admin-only: the broker EF re-checks the live admin role, so unmasked PII never reaches a non-admin.
- `listDispatchableOrphans` now includes `email` on the orphan object.

## Tests
+ updated controller tests assert additive exposure (full surname/phone/email) and that the masked fields are retained. Plan codex-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)