### PR TITLE
fix(held): real source label (Instagram ad / Meta ad), not "Website"

### DIFF
--- a/backend/src/controllers/externalHeldLeadsController.js
+++ b/backend/src/controllers/externalHeldLeadsController.js
@@ -97,6 +97,7 @@ export async function listHeldLeads(req, res) {
       campaignId: o.campaignId,
       campaignName: o.campaignName,
       leadSource: o.leadSource,
+      sourceLabel: o.sourceLabel || null,
       reason: o.reason,
       since: o.since,
       createdAt: o.createdAt,

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -29,7 +29,7 @@ import {
   sendTikTokCompleteRegistrationEvent,
 } from './tiktokEventsService.js';
 import { logger } from '../utils/logger.js';
-import { signupActivityDescription } from '../utils/sourceLabel.js';
+import { signupActivityDescription, signupSourceLabel } from '../utils/sourceLabel.js';
 import {
   normalizePhone,
   buildLeadCreatedPayload,
@@ -1519,7 +1519,12 @@ export function makeProspectService(overrides = {}) {
 
     const { count, rows } = await m.Prospect.findAndCountAll({
       where,
-      include: [{ association: 'campaign', attributes: ['id', 'name'] }],
+      include: [
+        { association: 'campaign', attributes: ['id', 'name'] },
+        // qrTag drives the "QR code" source label for a bound-QR lead whose leadSource isn't
+        // 'qr_code' — full parity with the receiver's deriveLeadSource (slug/externalId only).
+        { association: 'qrTag', attributes: ['slug', 'externalId'] },
+      ],
       order: [['createdAt', 'ASC']], // FIFO by signup (held + unassigned interleaved)
       limit: lim,
     });
@@ -1531,6 +1536,10 @@ export function makeProspectService(overrides = {}) {
       phone: p.phone,
       email: p.email,
       leadSource: p.leadSource,
+      // Rich, delivered-lead-equivalent label ("Instagram ad", "Meta ad", "Web form", …)
+      // derived from sourceMetadata.utm — so the held queue reads the same source the lead
+      // will show once assigned, not the coarse capture channel.
+      sourceLabel: signupSourceLabel({ leadSource: p.leadSource, qrTag: p.qrTag, sourceMetadata: p.sourceMetadata }),
       campaignId: p.campaignId,
       campaignName: p.campaign?.name || null,
       reason: p.quarantinedAt ? 'no_funded_agent' : 'unassigned',

--- a/backend/src/utils/sourceLabel.js
+++ b/backend/src/utils/sourceLabel.js
@@ -85,4 +85,50 @@ export function signupActivityDescription(campaignName, opts = {}) {
   return desc.length > 255 ? desc.slice(0, 255) : desc;
 }
 
-export default { signupSourcePhrase, signupActivityDescription };
+// Held leads never pass through the mktr-leads receiver (deriveLeadSource), so derive the
+// SAME short label here for the admin dispatch queue — a held lead must read the same source
+// it'll show once delivered. Granular fb/ig split (signupSourcePhrase above lumps them as
+// "Meta"); an/msg/meta roll up to the Meta brand — matching receive-mktr-lead/leadSource.ts.
+const LABEL_FACEBOOK = new Set(['facebook', 'fb']);
+const LABEL_INSTAGRAM = new Set(['instagram', 'ig']);
+const LABEL_META = new Set(['meta', 'an', 'audience_network', 'audiencenetwork', 'msg', 'messenger']);
+const LABEL_TIKTOK = new Set(['tiktok', 'tt', 'tiktokads', 'tiktok_ads', 'tiktok-ads']);
+
+function adPlatformLabel(utmSource) {
+  const s = String(utmSource || '').toLowerCase();
+  if (LABEL_FACEBOOK.has(s)) return 'Facebook';
+  if (LABEL_INSTAGRAM.has(s)) return 'Instagram';
+  if (LABEL_META.has(s)) return 'Meta';
+  if (LABEL_TIKTOK.has(s)) return 'TikTok';
+  return s ? s.slice(0, 64).replace(/[_-]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()) : '';
+}
+
+/**
+ * Short source label ("Instagram ad", "Meta ad", "QR code", "Web form", …) for a prospect —
+ * mirrors the mktr-leads receiver's deriveLeadSource().label so a HELD lead's source reads
+ * identically to the same lead once it's delivered to an agent. Keep in sync with
+ * mktr-leads/supabase/functions/receive-mktr-lead/leadSource.ts.
+ */
+export function signupSourceLabel({ leadSource, qrTag, sourceMetadata } = {}) {
+  const meta = sourceMetadata || {};
+  const source = String(leadSource || '').toLowerCase();
+
+  if (source === 'referral') return 'Referral';
+  if ((qrTag && (qrTag.slug || qrTag.externalId)) || source === 'qr_code') return 'QR code';
+  if (source === 'call_bot') return 'Voice call';
+
+  const utmSource = meta.utm?.utm_source;
+  if (utmSource) {
+    const name = adPlatformLabel(utmSource);
+    return name ? `${name} ad` : 'Ad';
+  }
+
+  const esu = meta.eventSourceUrl || '';
+  if (meta.fbc || /[?&]fbclid=/i.test(esu)) return 'Meta click';
+  if (meta.ttclid || /[?&]ttclid=/i.test(esu)) return 'TikTok click';
+
+  if (source === '' || source === 'website') return 'Web form';
+  return source.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export default { signupSourcePhrase, signupActivityDescription, signupSourceLabel };

--- a/backend/test/sourceLabel.test.js
+++ b/backend/test/sourceLabel.test.js
@@ -1,4 +1,4 @@
-import { signupSourcePhrase, signupActivityDescription } from '../src/utils/sourceLabel.js';
+import { signupSourcePhrase, signupActivityDescription, signupSourceLabel } from '../src/utils/sourceLabel.js';
 
 describe('signupSourcePhrase', () => {
   describe('QR scans', () => {
@@ -131,5 +131,52 @@ describe('signupActivityDescription', () => {
       sourceMetadata: { utm: { utm_source: 'x'.repeat(128) } },
     });
     expect(desc.length).toBeLessThanOrEqual(255);
+  });
+});
+
+// Short label for the held-queue detail view. Mirrors the mktr-leads receiver's
+// deriveLeadSource().label so a held lead reads the SAME source it'll show once delivered.
+describe('signupSourceLabel', () => {
+  it('splits Facebook vs Instagram (the phrase helper lumps them as Meta)', () => {
+    expect(signupSourceLabel({ leadSource: 'website', sourceMetadata: { utm: { utm_source: 'fb' } } })).toBe('Facebook ad');
+    expect(signupSourceLabel({ leadSource: 'website', sourceMetadata: { utm: { utm_source: 'instagram' } } })).toBe(
+      'Instagram ad'
+    );
+  });
+
+  it.each(['meta', 'an', 'audience_network', 'msg', 'messenger'])('rolls Meta sub-network %s up to "Meta ad"', (src) => {
+    expect(signupSourceLabel({ leadSource: 'website', sourceMetadata: { utm: { utm_source: src } } })).toBe('Meta ad');
+  });
+
+  it.each(['tiktok', 'tt', 'tiktok_ads', 'TikTokAds'])('labels TikTok alias %s', (src) => {
+    expect(signupSourceLabel({ leadSource: 'website', sourceMetadata: { utm: { utm_source: src } } })).toBe('TikTok ad');
+  });
+
+  it('title-cases an unknown utm_source', () => {
+    expect(signupSourceLabel({ leadSource: 'website', sourceMetadata: { utm: { utm_source: 'google' } } })).toBe(
+      'Google ad'
+    );
+  });
+
+  it('click-ids only → "{platform} click", not an ad', () => {
+    expect(signupSourceLabel({ leadSource: 'website', sourceMetadata: { ttclid: 'x' } })).toBe('TikTok click');
+    expect(signupSourceLabel({ leadSource: 'website', sourceMetadata: { fbc: 'fb.1.x' } })).toBe('Meta click');
+  });
+
+  it('referral / QR / voice / web-form / unknown', () => {
+    expect(signupSourceLabel({ leadSource: 'referral' })).toBe('Referral');
+    expect(signupSourceLabel({ leadSource: 'qr_code' })).toBe('QR code');
+    // Bound QR tag wins even when leadSource is the coarse 'website' (receiver parity).
+    expect(signupSourceLabel({ leadSource: 'website', qrTag: { slug: 'booth-a' } })).toBe('QR code');
+    expect(signupSourceLabel({ leadSource: 'call_bot' })).toBe('Voice call');
+    expect(signupSourceLabel({ leadSource: 'website' })).toBe('Web form');
+    expect(signupSourceLabel({})).toBe('Web form');
+    expect(signupSourceLabel({ leadSource: 'lead_import' })).toBe('Lead Import');
+  });
+
+  it('the reported case: a "website" capture off an Instagram ad reads "Instagram ad", not "Website"', () => {
+    expect(signupSourceLabel({ leadSource: 'website', sourceMetadata: { utm: { utm_source: 'ig' } } })).toBe(
+      'Instagram ad'
+    );
   });
 });


### PR DESCRIPTION
The held-queue detail showed the coarse `Prospect.leadSource` ("Website"); delivered leads show a derived ad-platform label. New `signupSourceLabel()` mirrors the mktr-leads receiver's `deriveLeadSource().label` **exactly** (fb→Facebook, ig→Instagram, an/msg/meta→Meta, TikTok, click variants, QR/Referral/Voice/Web form), computed in `listDispatchableOrphans` from `leadSource` + `sourceMetadata` (+ `qrTag` for bound-QR parity) and returned as `sourceLabel` (additive). Existing `signupSourcePhrase`/`signupActivityDescription` untouched.

Codex-reviewed the diff (SOLID after closing a P3 bound-QR parity edge). +`signupSourceLabel` tests incl. the fb/ig split. Pairs with mktr-leads PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)