### PR TITLE
fix(held): orphan-queue 500 — QrTag has no externalId column

### DIFF
--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -1522,8 +1522,9 @@ export function makeProspectService(overrides = {}) {
       include: [
         { association: 'campaign', attributes: ['id', 'name'] },
         // qrTag drives the "QR code" source label for a bound-QR lead whose leadSource isn't
-        // 'qr_code' — full parity with the receiver's deriveLeadSource (slug/externalId only).
-        { association: 'qrTag', attributes: ['slug', 'externalId'] },
+        // 'qr_code'. Select only REAL columns — QrTag has `slug` but NO `externalId` (that field
+        // exists on the webhook payload's qrTag, not the model), so signupSourceLabel keys off slug.
+        { association: 'qrTag', attributes: ['id', 'slug'] },
       ],
       order: [['createdAt', 'ASC']], // FIFO by signup (held + unassigned interleaved)
       limit: lim,


### PR DESCRIPTION
**Hotfix — admin Pending queue is down.** #71 added `attributes: ['slug', 'externalId']` to the `listDispatchableOrphans` qrTag include, but `QrTag` has no `externalId` column (it's a webhook-payload field, not a model column) → Sequelize throws → `/api/external/held-leads` 500s → "Couldn't load the queue".

Fix: select `['id', 'slug']` (both real, matching the other qrTag includes). `signupSourceLabel` keys off `slug`. Unit tests mock the DB so they didn't catch it; no pg-backed integration test covers this query path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)