### PR TITLE
fix(held): dispatched leads record an "assigned" timeline entry

### DIFF
--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -1553,13 +1553,15 @@ export function makeProspectService(overrides = {}) {
 
   /**
    * Assign an ORPHANED prospect (a no_funded_agent HOLD, or a lead parked on the phantom
-   * System Agent fallback) to a mktr-leads agent and deliver it via a fresh lead.created.
+   * System Agent fallback) to a mktr-leads agent and deliver it via a fresh `lead.assigned`
+   * — the lead is new to the destination app, so the receiver INSERTs it from that payload
+   * AND records an explicit "assigned @ now" activity in the lead's timeline.
    *
    * The held-only counterpart to assignProspect, purpose-built for the external
    * mktr-leads admin dispatch endpoint. Unlike assignProspect it can NEVER fall
    * into the normal-reassignment path: a request that arrives after the lead is
    * already released returns `already_handled` (no second charge, no second
-   * `lead.assigned`). The release UPDATE and the `lead.created` delivery row are
+   * delivery). The release UPDATE and the `lead.assigned` delivery row are
    * written in ONE transaction (outbox), so a crash can never leave a lead
    * un-held yet undelivered (recoverPendingRetries flushes the row on restart).
    *
@@ -1643,19 +1645,19 @@ export function makeProspectService(overrides = {}) {
         });
 
         // Destination is mktr_leads (agent has mktrLeadsId set); the receiver matches
-        // `routing.agentExternalId` against agents.mktr_user_id, so the webhook id MUST
-        // be externalIdForDestination(agent,'mktr_leads') === agent.mktrLeadsId.
+        // `routing.agentExternalId` against agents.mktr_user_id. buildLeadAssignedPayload sets
+        // that id via externalIdForDestination(agent,'mktr_leads') === agent.mktrLeadsId.
         const destination = destinationForAgent(agent);
-        const agentForWebhook = {
-          phone: agent.phone || null,
-          email: agent.email || null,
-          name: `${agent.firstName || ''} ${agent.lastName || ''}`.trim(),
-          id: externalIdForDestination(agent, destination),
-        };
 
+        // Fire lead.assigned (NOT lead.created) so the mktr-leads receiver records an explicit
+        // "assigned @ now" activity on top of "received @ signup" — the dispatched lead's timeline
+        // then shows the assignment AND its time, matching the MKTR-side activity logged above.
+        // The lead is brand-new to the destination app, so the receiver INSERTs it from this
+        // payload (the proven lead.assigned-inserts-new path); the lead block is identical to
+        // buildLeadCreatedPayload, so delivery is otherwise unchanged.
         deliveryPairs = await d.persistEventDeliveries(
-          'lead.created',
-          () => buildLeadCreatedPayload(withCampaign, 'direct', agentForWebhook, agent.id, withCampaign?.campaign || null, null, null),
+          'lead.assigned',
+          () => buildLeadAssignedPayload(withCampaign, agent, withCampaign),
           { destination },
           t
         );

--- a/backend/test/unit/releaseHeldProspect.test.js
+++ b/backend/test/unit/releaseHeldProspect.test.js
@@ -45,7 +45,7 @@ function buildMocks() {
 const svc = (deps) => makeProspectService(deps);
 
 describe('releaseHeldProspect (unit)', () => {
-  it('rescues a System-Agent orphan (not held): reassigns + delivers via lead.created', async () => {
+  it('rescues a System-Agent orphan (not held): reassigns + delivers via lead.assigned', async () => {
     const { deps, mockTx } = buildMocks();
     deps.models.Prospect.findByPk = jest.fn()
       .mockResolvedValueOnce({ id: 'p-1', campaignId: 'camp-1', quarantineReason: null, quarantinedAt: null, assignedAgentId: 'system-agent-id' })
@@ -55,7 +55,7 @@ describe('releaseHeldProspect (unit)', () => {
     const res = await svc(deps).releaseHeldProspect('p-1', 'app-agent-1', {});
 
     expect(res).toMatchObject({ status: 'assigned', leadId: 'p-1' });
-    expect(deps.persistEventDeliveries).toHaveBeenCalledWith('lead.created', expect.any(Function), { destination: 'mktr_leads' }, mockTx);
+    expect(deps.persistEventDeliveries).toHaveBeenCalledWith('lead.assigned', expect.any(Function), { destination: 'mktr_leads' }, mockTx);
     expect(mockTx.commit).toHaveBeenCalled();
   });
 
@@ -73,7 +73,7 @@ describe('releaseHeldProspect (unit)', () => {
     expect(deps.sequelize.query).toHaveBeenCalled();
     // Delivery row persisted INSIDE the tx (outbox), destination-scoped to mktr_leads.
     expect(deps.persistEventDeliveries).toHaveBeenCalledWith(
-      'lead.created', expect.any(Function), { destination: 'mktr_leads' }, mockTx,
+      'lead.assigned', expect.any(Function), { destination: 'mktr_leads' }, mockTx,
     );
     expect(mockTx.commit).toHaveBeenCalled();
     // Post-commit: best-effort campaign-scoped deduct + flush of the persisted delivery.


### PR DESCRIPTION
**Reported via Li Ching** (assigned to Ng Hui Xin, but the lead's app-side history never showed the assignment or its time).

**Root cause:** `releaseHeldProspect` fired `lead.created`. The mktr-leads receiver logs an `assignment` activity only for `lead.assigned`, and anchors the `created` activity at the prospect's original signup — so a dispatched held lead showed only "Lead received from MKTR @ signup", never "assigned @ dispatch time".

**Fix:** fire `lead.assigned` instead. The held lead is new to the destination app, so the receiver's proven "lead.assigned inserts a new lead" path INSERTs it **and** logs both "received @ signup" + "assigned @ now" — matching the normal reassign and the MKTR-side dispatch activity.

- Lead block identical to `buildLeadCreatedPayload`; agent resolution (`routing.agentExternalId`), fail-closed rollback, idempotency replay, credit deduct all unchanged.
- Scope: `releaseHeldProspect` only. `assignProspect` (generic/Lyfe) and `releaseSweep` (disabled) untouched.
- Backend-only — no EF, no app OTA (the receiver already handles `lead.assigned`).

Codex-reviewed the diff (SOLID; only P3 doc-drift, fixed). `releaseHeldProspect.test.js` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)