### PR TITLE
feat(held-leads): ping the admin when a lead is held pending assignment

### DIFF
--- a/backend/src/controllers/externalHeldLeadsController.js
+++ b/backend/src/controllers/externalHeldLeadsController.js
@@ -82,10 +82,19 @@ export async function listHeldLeads(req, res) {
   if (authErr) return res.status(authErr.code).json({ success: false, error: authErr.error });
 
   try {
-    const { campaignId } = req.body || {};
+    const { campaignId, summary } = req.body || {};
     // Fleet-wide orphans = no_funded_agent HOLDS + leads parked on the phantom System
     // Agent (soft-campaign fallback). Both need a real owner; the queue surfaces both.
     const { orphans } = await listDispatchableOrphans({ campaignId, limit: 50 });
+
+    // NON-PII summary projection for the server-side safety-net sweep
+    // (sweep-held-leads): ids + campaign + age ONLY. Lead phone/email/name never
+    // enter the cron path — the sweep only needs the dedup id + campaign for the ping.
+    if (summary === true) {
+      const held = (orphans || []).map((o) => ({ id: o.id, campaignName: o.campaignName, since: o.since }));
+      return res.json({ success: true, count: held.length, held });
+    }
+
     const rows = (orphans || []).map((o) => ({
       id: o.id,
       firstName: o.firstName || null,

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -240,7 +240,10 @@ async function ensureMktrLeadsWebhookSubscriber() {
   }
 
   const SUBSCRIBER_NAME = 'MKTR Leads App';
-  const requiredEvents = ['lead.created', 'lead.assigned', 'lead.unassigned'];
+  // lead.held → the admin held-queue ping (only the mktr-leads app has that surface;
+  // the Lyfe subscriber intentionally does NOT subscribe to it). The events-diff in
+  // the update guard below self-heals this onto the existing subscriber on deploy.
+  const requiredEvents = ['lead.created', 'lead.assigned', 'lead.unassigned', 'lead.held'];
 
   const existing = await WebhookSubscriber.findOne({ where: { name: SUBSCRIBER_NAME } });
 

--- a/backend/src/services/metaLeadService.js
+++ b/backend/src/services/metaLeadService.js
@@ -8,7 +8,7 @@ import { dispatchEvent } from './webhookService.js';
 import { sendLeadAssignmentEmail } from './mailer.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
-import { destinationForAgent, externalIdForDestination } from './prospectHelpers.js';
+import { destinationForAgent, externalIdForDestination, buildLeadHeldPayload } from './prospectHelpers.js';
 
 const IDEMPOTENCY_SCOPE = 'meta:lead';
 const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -344,6 +344,16 @@ export function makeMetaLeadService(overrides = {}) {
           campaign: campaign ? { externalId: campaign.id, name: campaign.name } : null
         }
       }), { destination: metaDestination });
+
+      // Held → ping the mktr-leads admin held queue so a pending lead is never silent.
+      // Explicitly require no_funded_agent (the only reason that lands in that queue) so
+      // a future decideAssignment reason can never leak the wrong hold. Gated by
+      // HELD_LEAD_PING_ENABLED; the sweep is the completeness net.
+      if (quarantined && decision.quarantineReason === 'no_funded_agent' && String(process.env.HELD_LEAD_PING_ENABLED || 'false').toLowerCase() === 'true') {
+        d.dispatchEvent('lead.held', () => buildLeadHeldPayload(prospect, campaign, decision.quarantineReason), {
+          destination: 'mktr_leads',
+        }).catch((err) => d.logger.error('[Webhook] lead.held dispatch error', { error: err?.message || String(err) }));
+      }
 
       // ── Email notification (fire-and-forget) ──
       const notifyAgent = quarantined

--- a/backend/src/services/prospectHelpers.js
+++ b/backend/src/services/prospectHelpers.js
@@ -179,3 +179,27 @@ export function buildLeadUnassignedPayload(prospect, previousAgentLyfeId, opts =
     }
   };
 }
+
+/**
+ * Build the payload for a 'lead.held' event — fired when a lead is QUARANTINED as
+ * `no_funded_agent` and lands in the mktr-leads admin held / pending-assignment
+ * queue. It has NO owner agent, so unlike lead.created it carries NO routing and
+ * only the minimum the receiver needs to ping the admin fleet (no lead PII beyond
+ * what the held queue already shows the admin): the prospect id (the dedup key the
+ * sweep also uses), the campaign, and the hold reason. Delivered ONLY to the
+ * destination='mktr_leads' subscriber.
+ */
+export function buildLeadHeldPayload(prospect, campaign, reason) {
+  return {
+    event: 'lead.held',
+    timestamp: new Date().toISOString(),
+    data: {
+      lead: {
+        externalId: prospect.id
+      },
+      campaign: campaign ? { externalId: campaign.id, name: campaign.name } : null,
+      reason: reason || 'no_funded_agent',
+      heldAt: new Date().toISOString()
+    }
+  };
+}

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -33,6 +33,7 @@ import { signupActivityDescription, signupSourceLabel } from '../utils/sourceLab
 import {
   normalizePhone,
   buildLeadCreatedPayload,
+  buildLeadHeldPayload,
   buildLeadAssignedPayload,
   buildLeadUnassignedPayload,
   destinationForAgent,
@@ -545,6 +546,7 @@ export function makeProspectService(overrides = {}) {
     //     (charged:true ⇒ skip the best-effort deduct below to avoid double-charging).
     //     Soft/exempt routes are unchanged: assign + best-effort deduct.
     let quarantined = false;
+    let heldReason = null;
     let finalAgentId = assignedAgentId;
     const prospect = await d.sequelize.transaction(async (t) => {
       // The internal quota gate applies ONLY to the internal path. For external
@@ -566,6 +568,7 @@ export function makeProspectService(overrides = {}) {
         });
       }
       quarantined = decision.action === 'quarantine';
+      heldReason = quarantined ? decision.quarantineReason : null;
       finalAgentId = quarantined ? null : (decision.assignedAgentId ?? null);
 
       const newProspect = await m.Prospect.create(
@@ -722,6 +725,22 @@ export function makeProspectService(overrides = {}) {
         { destination: leadDestination }
       ).catch((err) => {
         d.logger.error('[Webhook] dispatch error', { error: err?.message || String(err) });
+      });
+    }
+
+    // Held (no_funded_agent) → ping the mktr-leads admin held queue so a pending
+    // lead is never silent. ONLY this reason: the external (no_funded_external_buyer)
+    // hold is a DIFFERENT, fenced pool that is NOT in that admin queue, so it must
+    // not ping. Gated by HELD_LEAD_PING_ENABLED; the sweep is the completeness net.
+    if (
+      quarantined &&
+      heldReason === 'no_funded_agent' &&
+      String(process.env.HELD_LEAD_PING_ENABLED || 'false').toLowerCase() === 'true'
+    ) {
+      d.dispatchEvent('lead.held', () => buildLeadHeldPayload(prospect, sourceCampaign, heldReason), {
+        destination: 'mktr_leads',
+      }).catch((err) => {
+        d.logger.error('[Webhook] lead.held dispatch error', { error: err?.message || String(err) });
       });
     }
 

--- a/backend/src/services/retellService.js
+++ b/backend/src/services/retellService.js
@@ -9,7 +9,7 @@ import { sendLeadAssignmentEmail } from './mailer.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
 import { CircuitBreaker } from '../utils/circuitBreaker.js';
-import { destinationForAgent, externalIdForDestination } from './prospectHelpers.js';
+import { destinationForAgent, externalIdForDestination, buildLeadHeldPayload } from './prospectHelpers.js';
 
 const IDEMPOTENCY_SCOPE = 'retell:call';
 const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -376,6 +376,16 @@ export function makeRetellService(overrides = {}) {
           campaign: campaign ? { externalId: campaign.id, name: campaign.name } : null
         }
       }), { destination: retellDestination });
+
+      // Held → ping the mktr-leads admin held queue so a pending lead is never silent.
+      // Explicitly require no_funded_agent (the only reason that lands in that queue) so
+      // a future decideAssignment reason can never leak the wrong hold. Gated by
+      // HELD_LEAD_PING_ENABLED; the sweep is the completeness net.
+      if (quarantined && decision.quarantineReason === 'no_funded_agent' && String(process.env.HELD_LEAD_PING_ENABLED || 'false').toLowerCase() === 'true') {
+        d.dispatchEvent('lead.held', () => buildLeadHeldPayload(prospect, campaign, decision.quarantineReason), {
+          destination: 'mktr_leads',
+        }).catch((err) => d.logger.error('[Webhook] lead.held dispatch error', { error: err?.message || String(err) }));
+      }
 
       // ── Email notification (fire-and-forget) ──
       const notifyAgent = quarantined

--- a/backend/test/externalHeldLeadsController.test.js
+++ b/backend/test/externalHeldLeadsController.test.js
@@ -98,6 +98,28 @@ describe('externalHeldLeadsController.listHeldLeads', () => {
     expect(a).toMatchObject({ lastName: 'Doe', phone: '6591234567', email: 'jane@example.com' });
     expect(a.maskedPhone).toBe('••••4567'); // masked field retained for back-compat
   });
+
+  it('summary mode returns ids + campaign + since ONLY (no PII enters the sweep path)', async () => {
+    orphansMock.mockResolvedValue({
+      count: 1,
+      orphans: [
+        { id: 'p1', firstName: 'Jane', lastName: 'Doe', phone: '6591234567', email: 'jane@example.com', leadSource: 'meta', campaignId: 'c1', campaignName: 'Cab', reason: 'no_funded_agent', since: 't1', createdAt: 't1' },
+      ],
+    });
+    const req = makeReq({ timestamp: new Date().toISOString(), summary: true });
+    const res = makeRes();
+    await listHeldLeads(req, res);
+
+    expect(res.body.count).toBe(1);
+    const [a] = res.body.held;
+    expect(a).toEqual({ id: 'p1', campaignName: 'Cab', since: 't1' });
+    // The cron sweep must never receive lead PII.
+    expect(a.firstName).toBeUndefined();
+    expect(a.lastName).toBeUndefined();
+    expect(a.phone).toBeUndefined();
+    expect(a.maskedPhone).toBeUndefined();
+    expect(a.email).toBeUndefined();
+  });
 });
 
 describe('externalHeldLeadsController.assignHeldLead', () => {

--- a/backend/test/unit/prospectHelpers.test.js
+++ b/backend/test/unit/prospectHelpers.test.js
@@ -4,6 +4,7 @@ import {
   buildLeadCreatedPayload,
   buildLeadAssignedPayload,
   buildLeadUnassignedPayload,
+  buildLeadHeldPayload,
 } from '../../src/services/prospectHelpers.js';
 
 describe('prospectHelpers', () => {
@@ -283,6 +284,56 @@ describe('prospectHelpers', () => {
       const payload = buildLeadUnassignedPayload(prospect, 'lyfe-prev-agent');
       expect(() => new Date(payload.timestamp)).not.toThrow();
       expect(new Date(payload.timestamp).toISOString()).toBe(payload.timestamp);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // buildLeadHeldPayload
+  // ──────────────────────────────────────────────
+
+  describe('buildLeadHeldPayload', () => {
+    const prospect = {
+      id: 'p-held-1',
+      firstName: 'Jane',
+      lastName: 'Doe',
+      phone: '+6591234567',
+      email: 'jane@test.com',
+    };
+    const campaign = { id: 'c-1', name: 'Test Campaign' };
+
+    it('sets event to lead.held with the prospect id as the dedup key', () => {
+      const payload = buildLeadHeldPayload(prospect, campaign, 'no_funded_agent');
+      expect(payload.event).toBe('lead.held');
+      expect(payload.data.lead.externalId).toBe('p-held-1');
+    });
+
+    it('carries NO lead PII — only the externalId (lock-screen / cron safe)', () => {
+      const payload = buildLeadHeldPayload(prospect, campaign, 'no_funded_agent');
+      expect(Object.keys(payload.data.lead)).toEqual(['externalId']);
+      expect(payload.data.lead.firstName).toBeUndefined();
+      expect(payload.data.lead.phone).toBeUndefined();
+      expect(payload.data.lead.email).toBeUndefined();
+    });
+
+    it('includes campaign externalId + name when provided', () => {
+      const payload = buildLeadHeldPayload(prospect, campaign, 'no_funded_agent');
+      expect(payload.data.campaign).toEqual({ externalId: 'c-1', name: 'Test Campaign' });
+    });
+
+    it('emits null campaign when none is provided', () => {
+      const payload = buildLeadHeldPayload(prospect, null, 'no_funded_agent');
+      expect(payload.data.campaign).toBeNull();
+    });
+
+    it('defaults reason to no_funded_agent', () => {
+      const payload = buildLeadHeldPayload(prospect, campaign, undefined);
+      expect(payload.data.reason).toBe('no_funded_agent');
+    });
+
+    it('has valid ISO timestamp + heldAt', () => {
+      const payload = buildLeadHeldPayload(prospect, campaign, 'no_funded_agent');
+      expect(new Date(payload.timestamp).toISOString()).toBe(payload.timestamp);
+      expect(new Date(payload.data.heldAt).toISOString()).toBe(payload.data.heldAt);
     });
   });
 });


### PR DESCRIPTION
## What
A lead that can't be placed on an agent (held — `no_funded_agent`) lands in the mktr-leads admin held queue but creates no local row, so the existing `new_lead_admin` trigger never fires — it sits silently. This emits a new **`lead.held`** webhook so the admin is pinged.

## Changes (backend)
- `buildLeadHeldPayload` (no PII beyond the prospect id the held queue already shows).
- Emit `lead.held` (destination `mktr_leads`) at all three `no_funded_agent` hold sites (prospectService / metaLeadService / retellService), each explicitly checking the reason and gated by **`HELD_LEAD_PING_ENABLED`** (dormant until set).
- `bootstrap`: subscribe the mktr-leads app to `lead.held` (self-heals on deploy; Lyfe subscriber unchanged).
- `externalHeldLeadsController`: non-PII `summary` mode for the safety-net sweep (ids + campaign only).

## Deploy
Ships **flag OFF** — no behavioural change until `HELD_LEAD_PING_ENABLED=true`, which is flipped only **after** the mktr-leads receiver understands `lead.held`. Pairs with mktr-leads (migration + EFs).

## Tests
`prospectHelpers` (incl. no-PII assertion) + `externalHeldLeadsController` summary mode — 45 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)