### PR TITLE
feat(admin-packages): external admin lead-package endpoints

### DIFF
--- a/backend/src/controllers/externalAdminPackagesController.js
+++ b/backend/src/controllers/externalAdminPackagesController.js
@@ -1,0 +1,249 @@
+/**
+ * @file externalAdminPackagesController — the MKTR Leads admin app's "Lead Packages".
+ *
+ * ── Endpoints (mounted at /api/external/admin-packages) ─────────────────────
+ *   POST /catalog               → list the package catalog (full fields + assignmentCount)
+ *   POST /catalog/create        → create a package template
+ *   POST /catalog/update        → update a package template
+ *   POST /catalog/delete        → archive-if-assignments-else-hard-delete
+ *   POST /assignments           → one agent's assignments (admin DTO, all statuses)
+ *   POST /assignments/assign    → assign an ACTIVE package to a mktr-leads agent
+ *   POST /assignments/topup     → delta top-up (add N) / absolute correction
+ *   POST /assignments/cancel    → cancel an assignment (status → cancelled)
+ *   POST /assignments/remove    → destroy an assignment (history lost)
+ *   POST /campaigns             → campaign picker list
+ *
+ * ── Auth ────────────────────────────────────────────────────────────────────
+ * HMAC-SHA256 over the RAW BODY using EXTERNAL_APP_SECRET — the SAME scheme as
+ * /api/external/held-leads + /api/external/admin-lead-ops (header
+ * `X-Webhook-Signature: sha256=<hex>`, freshness on the signed body `timestamp`,
+ * ±5 min). NOT the platform JWT. The mktr-leads `mktr-admin-packages` broker edge
+ * function (admin-JWT gated, re-checks the live admin role, holds the secret
+ * server-side) is the only intended caller. The whole route is gated behind
+ * ADMIN_PACKAGES_EXTERNAL_ENABLED so it stays unmounted until provisioned.
+ *
+ * ── Scope ───────────────────────────────────────────────────────────────────
+ * Catalog ops are GLOBAL (the same catalog the MKTR web admin manages — by design).
+ * Assignment ops are SCOPED in the service to mktr-leads-sourced agents
+ * (User.mktrLeadsId NOT NULL), so an mktr-leads admin can never mutate a
+ * Lyfe/internal assignment by a guessed UUID.
+ */
+
+import crypto from 'crypto';
+import { logger } from '../utils/logger.js';
+import {
+  getExternalAdminCatalog,
+  createPackage,
+  updatePackage,
+  deletePackage,
+  resolveCreator,
+  getExternalAdminAgentAssignments,
+  assignPackageExternal,
+  topUpAssignment,
+  cancelAssignment,
+  removeAssignmentExternal,
+  listCampaignsForPicker,
+} from '../services/leadPackageService.js';
+
+const MAX_AGE_MS = 5 * 60 * 1000;
+const MAX_FUTURE_MS = 2 * 60 * 1000; // tolerate clock skew
+const MAX_BODY_BYTES = 64 * 1024;
+
+function timingSafeHexEq(receivedHex, expectedHex) {
+  if (typeof receivedHex !== 'string' || typeof expectedHex !== 'string') return false;
+  if (receivedHex.length !== expectedHex.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(receivedHex, 'hex'), Buffer.from(expectedHex, 'hex'));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verify HMAC + freshness. Returns null on success, or { code, error } to send.
+ * Mirrors externalAdminLeadOpsController so all external channels share one wire
+ * contract (rawBody is captured by the /api/external/ verify hook in server_internal.js).
+ */
+function verifyExternalHmac(req) {
+  const secret = process.env.EXTERNAL_APP_SECRET;
+  if (!secret) {
+    logger.error('[external-admin-packages] EXTERNAL_APP_SECRET not configured');
+    return { code: 500, error: 'Server misconfigured' };
+  }
+  if (!req.rawBody || !Buffer.isBuffer(req.rawBody)) {
+    logger.error('[external-admin-packages] req.rawBody missing — verify hook not wired for this path');
+    return { code: 500, error: 'Server misconfigured' };
+  }
+  if (req.rawBody.length > MAX_BODY_BYTES) return { code: 413, error: 'Payload too large' };
+
+  const sigHeader = req.headers['x-webhook-signature'] || '';
+  if (typeof sigHeader !== 'string' || !sigHeader.startsWith('sha256=')) {
+    return { code: 401, error: 'Unauthorized' };
+  }
+  const expectedHex = crypto.createHmac('sha256', secret).update(req.rawBody).digest('hex');
+  if (!timingSafeHexEq(sigHeader.slice(7), expectedHex)) {
+    return { code: 401, error: 'Unauthorized' };
+  }
+
+  const tsMs = typeof req.body?.timestamp === 'string' ? Date.parse(req.body.timestamp) : NaN;
+  if (Number.isNaN(tsMs)) return { code: 401, error: 'Unauthorized' };
+  const ageMs = Date.now() - tsMs;
+  if (ageMs > MAX_AGE_MS || ageMs < -MAX_FUTURE_MS) return { code: 401, error: 'Unauthorized' };
+
+  return null;
+}
+
+/** Express middleware form — apply once on the router so every handler is gated. */
+export function requireExternalHmac(req, res, next) {
+  const authErr = verifyExternalHmac(req);
+  if (authErr) return res.status(authErr.code).json({ success: false, error: authErr.error });
+  next();
+}
+
+/** Map a thrown error to a safe response (AppError → its code/message; else 500 generic). */
+function sendError(res, err, op) {
+  const status = err?.statusCode && err.statusCode < 500 ? err.statusCode : 500;
+  const message = status < 500 ? err.message : 'Internal server error';
+  logger.error(`[external-admin-packages] ${op} failed`, { error: err?.message || String(err) });
+  return res.status(status).json({ success: false, error: message });
+}
+
+// ── Catalog ───────────────────────────────────────────────────────────────────
+
+export async function catalogList(req, res) {
+  try {
+    const data = await getExternalAdminCatalog();
+    return res.json({ success: true, ...data });
+  } catch (err) {
+    return sendError(res, err, 'catalog.list');
+  }
+}
+
+export async function catalogCreate(req, res) {
+  const { actorMktrUserId, name, price, leadCount, campaignId, type, status, description, isPublic, qualityScore, validityPeriod, agentCommission } =
+    req.body || {};
+  if (!name || price === undefined || price === null || leadCount === undefined || leadCount === null) {
+    return res.status(400).json({ success: false, error: 'name, price and leadCount are required' });
+  }
+  try {
+    const createdBy = await resolveCreator(actorMktrUserId);
+    const data = await createPackage({
+      name, price, leadCount, campaignId: campaignId ?? null, type,
+      status, description, isPublic, qualityScore, validityPeriod, agentCommission, createdBy,
+    });
+    return res.status(201).json({ success: true, ...data });
+  } catch (err) {
+    return sendError(res, err, 'catalog.create');
+  }
+}
+
+export async function catalogUpdate(req, res) {
+  const { id, ...fields } = req.body || {};
+  if (!id || typeof id !== 'string') {
+    return res.status(400).json({ success: false, error: 'id is required' });
+  }
+  try {
+    const data = await updatePackage(id, fields);
+    return res.json({ success: true, ...data });
+  } catch (err) {
+    return sendError(res, err, 'catalog.update');
+  }
+}
+
+/** Archive-if-assignments-else-hard-delete. Both catalog.archive and catalog.delete map here. */
+export async function catalogDelete(req, res) {
+  const { id } = req.body || {};
+  if (!id || typeof id !== 'string') {
+    return res.status(400).json({ success: false, error: 'id is required' });
+  }
+  try {
+    const data = await deletePackage(id);
+    return res.json({ success: true, ...data });
+  } catch (err) {
+    return sendError(res, err, 'catalog.delete');
+  }
+}
+
+// ── Assignments ─────────────────────────────────────────────────────────────
+
+export async function assignmentsList(req, res) {
+  const { agentMktrUserId } = req.body || {};
+  if (!agentMktrUserId || typeof agentMktrUserId !== 'string') {
+    return res.status(400).json({ success: false, error: 'agentMktrUserId is required' });
+  }
+  try {
+    const data = await getExternalAdminAgentAssignments(agentMktrUserId);
+    return res.json({ success: true, ...data });
+  } catch (err) {
+    return sendError(res, err, 'assignment.list');
+  }
+}
+
+export async function assignmentsAssign(req, res) {
+  const { agentMktrUserId, packageId, leadsTotalOverride } = req.body || {};
+  if (!agentMktrUserId || !packageId) {
+    return res.status(400).json({ success: false, error: 'agentMktrUserId and packageId are required' });
+  }
+  try {
+    const result = await assignPackageExternal({ agentMktrUserId, packageId, leadsTotalOverride });
+    const codeByStatus = { assigned: 201, exists: 200, package_inactive: 409, invalid_agent: 400 };
+    const code = codeByStatus[result.status] || 500;
+    return res.status(code).json({ success: code < 400, ...result });
+  } catch (err) {
+    return sendError(res, err, 'assignment.assign');
+  }
+}
+
+export async function assignmentsTopup(req, res) {
+  const { assignmentId, addLeads, setRemaining } = req.body || {};
+  if (!assignmentId) {
+    return res.status(400).json({ success: false, error: 'assignmentId is required' });
+  }
+  if (addLeads === undefined && setRemaining === undefined) {
+    return res.status(400).json({ success: false, error: 'addLeads or setRemaining is required' });
+  }
+  try {
+    const data = await topUpAssignment({ assignmentId, addLeads, setRemaining });
+    return res.json({ success: true, ...data });
+  } catch (err) {
+    return sendError(res, err, 'assignment.topup');
+  }
+}
+
+export async function assignmentsCancel(req, res) {
+  const { assignmentId } = req.body || {};
+  if (!assignmentId) {
+    return res.status(400).json({ success: false, error: 'assignmentId is required' });
+  }
+  try {
+    const data = await cancelAssignment(assignmentId);
+    return res.json({ success: true, ...data });
+  } catch (err) {
+    return sendError(res, err, 'assignment.cancel');
+  }
+}
+
+export async function assignmentsRemove(req, res) {
+  const { assignmentId } = req.body || {};
+  if (!assignmentId) {
+    return res.status(400).json({ success: false, error: 'assignmentId is required' });
+  }
+  try {
+    const data = await removeAssignmentExternal(assignmentId);
+    return res.json({ success: true, ...data });
+  } catch (err) {
+    return sendError(res, err, 'assignment.remove');
+  }
+}
+
+// ── Campaigns ─────────────────────────────────────────────────────────────────
+
+export async function campaignsList(req, res) {
+  const { selectedId } = req.body || {};
+  try {
+    const data = await listCampaignsForPicker(typeof selectedId === 'string' ? selectedId : null);
+    return res.json({ success: true, ...data });
+  } catch (err) {
+    return sendError(res, err, 'campaigns.list');
+  }
+}

--- a/backend/src/routes/externalAdminPackages.js
+++ b/backend/src/routes/externalAdminPackages.js
@@ -1,0 +1,53 @@
+/**
+ * MKTR Leads admin app → lead-packages (catalog + per-agent assignments).
+ *
+ * Mounted at `/api/external/admin-packages`. Auth is HMAC-SHA256 over the raw body
+ * (EXTERNAL_APP_SECRET) — see externalAdminPackagesController. rawBody capture and the
+ * rate-limiter exemption for the `/api/external/` prefix are wired in server_internal.js,
+ * same as /api/external/held-leads + /api/external/admin-lead-ops.
+ *
+ * Gated behind ADMIN_PACKAGES_EXTERNAL_ENABLED so the route stays UNMOUNTED until the
+ * secret + the mktr-leads broker edge function are provisioned (deploy-inert). The
+ * route auto-loader (routes/index.js) only mounts modules exporting BOTH `meta` and a
+ * default router.
+ */
+import express from 'express';
+import {
+  requireExternalHmac,
+  catalogList,
+  catalogCreate,
+  catalogUpdate,
+  catalogDelete,
+  assignmentsList,
+  assignmentsAssign,
+  assignmentsTopup,
+  assignmentsCancel,
+  assignmentsRemove,
+  campaignsList,
+} from '../controllers/externalAdminPackagesController.js';
+
+const router = express.Router();
+
+export const meta = {
+  path: '/api/external/admin-packages',
+  flag: 'ADMIN_PACKAGES_EXTERNAL_ENABLED',
+  flagDefault: 'false',
+};
+
+// Shared HMAC + freshness gate for every action below.
+router.use(requireExternalHmac);
+
+// POST (not GET) so the body carries the signed `timestamp` the HMAC freshness check
+// reads — consistent with the other /api/external/ surfaces.
+router.post('/catalog', catalogList);
+router.post('/catalog/create', catalogCreate);
+router.post('/catalog/update', catalogUpdate);
+router.post('/catalog/delete', catalogDelete); // archive-if-assignments-else-delete
+router.post('/assignments', assignmentsList);
+router.post('/assignments/assign', assignmentsAssign);
+router.post('/assignments/topup', assignmentsTopup);
+router.post('/assignments/cancel', assignmentsCancel);
+router.post('/assignments/remove', assignmentsRemove);
+router.post('/campaigns', campaignsList);
+
+export default router;

--- a/backend/src/services/leadPackageService.js
+++ b/backend/src/services/leadPackageService.js
@@ -32,22 +32,62 @@ export async function listPackages({ status, campaignId, userRole }) {
   return { packages };
 }
 
+// ── Admin-package field normalizers ──────────────────────────────────────────
+// Shared by create + update. `null` clears an optional field; a `0`/absent
+// commission means "no commission" (the DTO hides non-positive so it never renders
+// a misleading "$0/lead"). Kept module-local + exported for unit tests.
+export function normalizeQuality(q) {
+  if (q === null || q === undefined || q === '') return null;
+  const n = parseInt(q, 10);
+  if (!Number.isFinite(n)) return null;
+  return Math.min(10, Math.max(1, n));
+}
+export function normalizeValidity(d) {
+  if (d === null || d === undefined || d === '') return null;
+  const n = Number(d);
+  return Number.isFinite(n) && n >= 1 ? Math.round(n) : null;
+}
+export function normalizeCommission(c) {
+  const n = Number(c);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
 /**
  * Create a new lead package template.
+ *
+ * Backward-compatible with the internal (web) controller, which passes only
+ * { name, price, leadCount, campaignId, type, createdBy } — the rest default.
+ * The external admin surface (HMAC) passes the full payload incl. the net-new
+ * fields. `createdBy` is a non-null FK to users.id — the caller (controller)
+ * supplies a concrete id (web: req.user.id; external: resolveCreator). campaignId
+ * is now nullable; currency is forced SGD (SG market; non-editable in the UI).
  */
-export async function createPackage({ name, price, leadCount, campaignId, type, createdBy }) {
-  if (!name || price === undefined || price === null || !leadCount || !campaignId) {
+export async function createPackage({
+  name, price, leadCount, campaignId = null, type, createdBy,
+  status, description, isPublic, qualityScore, validityPeriod, agentCommission,
+}) {
+  if (!name || price === undefined || price === null || !leadCount) {
     throw new AppError('Missing required fields', 400);
   }
+  // createdBy is a non-null FK enforced at the DB + supplied by every caller
+  // (web: req.user.id; external: resolveCreator). Kept lenient here — the original
+  // contract — so the existing unit tests that omit it stay valid.
 
+  const ALLOWED_CREATE_STATUS = ['draft', 'active', 'inactive'];
   const pkg = await LeadPackage.create({
     name,
     price,
     leadCount,
-    campaignId,
+    campaignId: campaignId ?? null,
     type: type || 'basic',
     createdBy,
-    status: 'active'
+    status: ALLOWED_CREATE_STATUS.includes(status) ? status : 'active',
+    description: description ?? null,
+    isPublic: isPublic === undefined ? true : !!isPublic,
+    currency: 'SGD',
+    qualityScore: normalizeQuality(qualityScore),
+    validityPeriod: normalizeValidity(validityPeriod),
+    commissionStructure: { agentCommission: normalizeCommission(agentCommission), referralBonus: 0, tierBonuses: {} },
   });
 
   return { package: pkg };
@@ -64,12 +104,25 @@ export async function updatePackage(id, fields) {
     throw new AppError('Package not found', 404);
   }
 
+  // NOTE: `currency` is deliberately absent — it is forced SGD at create and is
+  // never editable (length-only validation on the column would otherwise accept
+  // any 3-char string). `campaignId: null` IS honoured (null !== undefined) so the
+  // UI's "No campaign" clears it.
   const ALLOWED = ['name', 'description', 'price', 'leadCount', 'campaignId', 'type', 'isPublic', 'status'];
   const updates = {};
   for (const key of ALLOWED) {
     if (fields[key] !== undefined) {
       updates[key] = fields[key];
     }
+  }
+  // Optional/clearable numeric fields — normalize (null clears).
+  if (fields.qualityScore !== undefined) updates.qualityScore = normalizeQuality(fields.qualityScore);
+  if (fields.validityPeriod !== undefined) updates.validityPeriod = normalizeValidity(fields.validityPeriod);
+  // agentCommission lives inside the commissionStructure JSON — MERGE so a partial
+  // update never clobbers referralBonus / tierBonuses.
+  if (fields.agentCommission !== undefined) {
+    const prev = pkg.commissionStructure || {};
+    updates.commissionStructure = { ...prev, agentCommission: normalizeCommission(fields.agentCommission) };
   }
 
   if (Object.keys(updates).length > 0) {
@@ -246,6 +299,270 @@ export async function getExternalAgentPackages(mktrLeadsId) {
   return { packages };
 }
 
+// ════════════════════════════════════════════════════════════════════════════
+// External admin surface (mktr-leads admin app → /api/external/admin-packages).
+// HMAC-authed (no JWT user). Catalog ops are GLOBAL (same catalog as the web
+// admin, by design). Assignment ops are SCOPED to mktr-leads-sourced agents
+// (User.mktrLeadsId NOT NULL) so an mktr-leads admin can never mutate a
+// Lyfe/internal assignment by a guessed UUID.
+// ════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Resolve a non-null `createdBy` (FK → users.id) for an externally-created package.
+ * Prefer the acting admin when they're a synced MKTR user (auditable); else a
+ * configured system creator. Throws if neither resolves (deploy-inert until set).
+ */
+export async function resolveCreator(actorMktrUserId) {
+  if (actorMktrUserId && typeof actorMktrUserId === 'string') {
+    const u = await User.findOne({ where: { mktrLeadsId: actorMktrUserId }, attributes: ['id'] });
+    if (u) return u.id;
+  }
+  const fallback = process.env.ADMIN_PACKAGES_CREATOR_USER_ID;
+  if (fallback) return fallback;
+  // Last resort: attribute to the oldest active MKTR admin (the web package creator
+  // always exists), so catalog.create works even without the env override set.
+  const admin = await User.findOne({
+    where: { role: 'admin', isActive: true },
+    order: [['createdAt', 'ASC']],
+    attributes: ['id'],
+  });
+  if (admin) return admin.id;
+  throw new AppError('No package creator available (no actor, env, or admin user)', 500);
+}
+
+/** Catalog list for the admin app — full fields + per-package assignmentCount (Archive vs Delete). */
+export async function getExternalAdminCatalog() {
+  const packages = await LeadPackage.findAll({
+    include: [{ model: Campaign, as: 'campaign', attributes: ['id', 'name', 'status'] }],
+    order: [['createdAt', 'DESC']],
+  });
+  // One grouped COUNT (avoid N+1). `sequelize.fn/col` — the bare `fn` is not imported.
+  const counts = await LeadPackageAssignment.findAll({
+    attributes: ['leadPackageId', [sequelize.fn('COUNT', sequelize.col('id')), 'n']],
+    group: ['leadPackageId'],
+    raw: true,
+  });
+  const countBy = new Map(counts.map((c) => [c.leadPackageId, Number(c.n)]));
+  return {
+    packages: packages.map((p) => ({
+      id: p.id,
+      name: p.name,
+      type: p.type,
+      status: p.status,
+      description: p.description ?? null,
+      price: Number(p.price),
+      leadCount: p.leadCount,
+      currency: p.currency || 'SGD',
+      qualityScore: p.qualityScore ?? null,
+      commissionPerLead:
+        typeof p.commissionStructure?.agentCommission === 'number' && p.commissionStructure.agentCommission > 0
+          ? p.commissionStructure.agentCommission
+          : null,
+      validityDays: p.validityPeriod ?? null,
+      campaignId: p.campaignId ?? null,
+      campaignName: p.campaign?.name ?? null,
+      campaignStatus: p.campaign?.status ?? null,
+      isPublic: p.isPublic,
+      assignmentCount: countBy.get(p.id) ?? 0,
+    })),
+  };
+}
+
+/** Campaign picker for the create/edit form — active campaigns + (when editing) the still-selected one. */
+export async function listCampaignsForPicker(selectedId) {
+  const active = await Campaign.findAll({
+    where: { is_active: true },
+    attributes: ['id', 'name', 'status'],
+    order: [['name', 'ASC']],
+  });
+  const out = active.map((c) => ({ id: c.id, name: c.name, status: c.status }));
+  if (selectedId && !out.some((c) => c.id === selectedId)) {
+    const sel = await Campaign.findByPk(selectedId, { attributes: ['id', 'name', 'status'] });
+    if (sel) out.unshift({ id: sel.id, name: sel.name, status: sel.status });
+  }
+  return { campaigns: out };
+}
+
+/**
+ * One mktr-leads agent's assignments for the admin per-agent screen. Self-scoped
+ * resolution (mktrLeadsId + role:'agent' + isActive) like getExternalAgentPackages,
+ * but returns ALL four statuses (so the app groups Past), adds priceSnapshot, and
+ * caps at 100 newest (cancelled history is unbounded). No agent identity — the app
+ * already holds the AgentRow locally.
+ */
+export async function getExternalAdminAgentAssignments(mktrLeadsId) {
+  if (!mktrLeadsId || typeof mktrLeadsId !== 'string') return { packages: [] };
+  const agent = await User.findOne({ where: { mktrLeadsId, role: 'agent', isActive: true }, attributes: ['id'] });
+  if (!agent) return { packages: [] };
+
+  const assignments = await LeadPackageAssignment.findAll({
+    where: { agentId: agent.id },
+    include: [
+      {
+        model: LeadPackage,
+        as: 'package',
+        attributes: ['name', 'type', 'qualityScore', 'currency', 'commissionStructure', 'validityPeriod'],
+        include: [{ model: Campaign, as: 'campaign', attributes: ['name'] }],
+      },
+    ],
+    order: [['purchaseDate', 'DESC']],
+    limit: 100,
+  });
+
+  const packages = assignments.map((a) => {
+    const pkg = a.package || null;
+    const validityDays = pkg?.validityPeriod ?? null;
+    const purchasedAt = a.purchaseDate ? new Date(a.purchaseDate) : null;
+    const expiresAt =
+      purchasedAt && Number.isFinite(validityDays) && validityDays > 0
+        ? new Date(purchasedAt.getTime() + validityDays * 86400000).toISOString()
+        : null;
+    const agentCommission = pkg?.commissionStructure?.agentCommission;
+    return {
+      id: a.id,
+      name: pkg?.name || 'Lead package',
+      type: pkg?.type || null,
+      status: a.status,
+      leadsRemaining: a.leadsRemaining,
+      leadsTotal: a.leadsTotal,
+      qualityScore: pkg?.qualityScore ?? null,
+      commissionPerLead: typeof agentCommission === 'number' && agentCommission > 0 ? agentCommission : null,
+      currency: pkg?.currency || 'SGD',
+      campaignName: pkg?.campaign?.name || null,
+      purchaseDate: purchasedAt ? purchasedAt.toISOString() : null,
+      validityDays,
+      expiresAt,
+      priceSnapshot: a.priceSnapshot != null ? Number(a.priceSnapshot) : null,
+    };
+  });
+  return { packages };
+}
+
+/** Load an assignment ONLY if its agent is mktr-leads-sourced (write-scope guard). */
+async function loadMktrLeadsAssignment(assignmentId) {
+  if (!assignmentId || typeof assignmentId !== 'string') return null;
+  return LeadPackageAssignment.findOne({
+    where: { id: assignmentId },
+    include: [
+      {
+        model: User,
+        as: 'agent',
+        attributes: ['id', 'mktrLeadsId'],
+        where: { mktrLeadsId: { [Op.ne]: null } },
+        required: true,
+      },
+    ],
+  });
+}
+
+/**
+ * Assign an ACTIVE catalog package to a mktr-leads agent. Active-only guard +
+ * duplicate guard under the same per-package advisory lock bulkAssignPackage uses
+ * (no unique (agentId,leadPackageId) index). Optional custom leadsTotal override.
+ * Returns a typed status: assigned | exists | package_inactive | invalid_agent.
+ */
+export async function assignPackageExternal({ agentMktrUserId, packageId, leadsTotalOverride }) {
+  if (!agentMktrUserId || !packageId) throw new AppError('agentMktrUserId and packageId are required', 400);
+
+  const agent = await User.findOne({
+    where: { mktrLeadsId: agentMktrUserId, role: 'agent', isActive: true },
+    attributes: ['id'],
+  });
+  if (!agent) return { status: 'invalid_agent' };
+
+  const pkg = await LeadPackage.findByPk(packageId);
+  if (!pkg) throw new AppError('Package not found', 404);
+  if (pkg.status !== 'active') return { status: 'package_inactive' };
+
+  const result = await sequelize.transaction(async (t) => {
+    await sequelize.query('SELECT pg_advisory_xact_lock(hashtext(:k))', {
+      replacements: { k: `lpa:${packageId}` },
+      transaction: t,
+    });
+    const existing = await LeadPackageAssignment.findOne({
+      where: { leadPackageId: packageId, agentId: agent.id, status: 'active' },
+      transaction: t,
+    });
+    if (existing) return { status: 'exists', assignmentId: existing.id };
+
+    const override = Number(leadsTotalOverride);
+    const total = Number.isFinite(override) && override >= 1 ? Math.round(override) : pkg.leadCount;
+    const a = await LeadPackageAssignment.create(
+      {
+        agentId: agent.id,
+        leadPackageId: packageId,
+        leadsTotal: total,
+        leadsRemaining: total,
+        priceSnapshot: pkg.price,
+        status: 'active',
+        purchaseDate: new Date(),
+      },
+      { transaction: t }
+    );
+    return { status: 'assigned', assignmentId: a.id };
+  });
+
+  // New funded package → campaign sweep (no-op today; retained as the re-enable hook).
+  if (result.status === 'assigned' && pkg.campaignId) {
+    import('./releaseSweep.js')
+      .then((m) => m.sweepCampaign(pkg.campaignId))
+      .catch((err) => logger.error('[ReleaseSweep] assignPackageExternal trigger failed', { error: err?.message || String(err) }));
+  }
+  return result;
+}
+
+/**
+ * Top up an assignment. Delta ("add N") increments BOTH leadsRemaining and
+ * leadsTotal (so the ratio never exceeds 100% — fixes the 150/100 bug). An
+ * advanced absolute `setRemaining` correction is also supported. Never resurrects
+ * a cancelled/expired row.
+ */
+export async function topUpAssignment({ assignmentId, addLeads, setRemaining }) {
+  const a = await loadMktrLeadsAssignment(assignmentId);
+  if (!a) throw new AppError('Assignment not found', 404);
+  if (a.status !== 'active' && a.status !== 'completed') {
+    throw new AppError('Cannot modify a cancelled or expired assignment', 409);
+  }
+
+  const prevRemaining = a.leadsRemaining;
+  if (setRemaining !== undefined) {
+    const n = parseInt(setRemaining, 10);
+    if (isNaN(n) || n < 0) throw new AppError('Invalid lead count', 400);
+    await a.update({ leadsRemaining: n, status: n === 0 ? 'completed' : 'active' });
+  } else {
+    const add = parseInt(addLeads, 10);
+    if (isNaN(add) || add < 1) throw new AppError('Invalid amount', 400);
+    await a.update({ leadsRemaining: a.leadsRemaining + add, leadsTotal: a.leadsTotal + add, status: 'active' });
+  }
+
+  if (a.leadsRemaining > prevRemaining) {
+    const pkg = await LeadPackage.findByPk(a.leadPackageId, { attributes: ['campaignId'] });
+    if (pkg?.campaignId) {
+      import('./releaseSweep.js')
+        .then((m) => m.sweepCampaign(pkg.campaignId))
+        .catch((err) => logger.error('[ReleaseSweep] topUpAssignment trigger failed', { error: err?.message || String(err) }));
+    }
+  }
+  return { assignment: a };
+}
+
+/** Cancel an assignment → status:'cancelled' (preferred stop; preserves row + history). Idempotent. */
+export async function cancelAssignment(assignmentId) {
+  const a = await loadMktrLeadsAssignment(assignmentId);
+  if (!a) throw new AppError('Assignment not found', 404);
+  if (a.status === 'cancelled') return { assignment: a };
+  await a.update({ status: 'cancelled' });
+  return { assignment: a };
+}
+
+/** Remove an assignment → destroys the row (history lost). Scoped to mktr-leads agents. */
+export async function removeAssignmentExternal(assignmentId) {
+  const a = await loadMktrLeadsAssignment(assignmentId);
+  if (!a) throw new AppError('Assignment not found', 404);
+  await a.destroy();
+  return { ok: true };
+}
+
 /**
  * Delete a package assignment by ID.
  */
@@ -314,6 +631,7 @@ export async function deletePackage(id) {
     await pkg.update({ status: 'archived' });
     return {
       archived: true,
+      assignmentCount,
       message: 'Package archived (assignments exist)',
       package: pkg
     };
@@ -321,9 +639,15 @@ export async function deletePackage(id) {
     await pkg.destroy();
     return {
       archived: false,
+      assignmentCount: 0,
       message: 'Package deleted successfully'
     };
   }
+}
+
+/** Live assignment count for a package — drives the UI's Archive-vs-Delete label (A10). */
+export async function getPackageAssignmentCount(id) {
+  return LeadPackageAssignment.count({ where: { leadPackageId: id } });
 }
 
 /**

--- a/backend/test/unit/leadPackageService.test.js
+++ b/backend/test/unit/leadPackageService.test.js
@@ -525,9 +525,10 @@ describe('leadPackageService (unit)', () => {
         .rejects.toThrow('Missing required fields');
     });
 
-    it('throws when campaignId is missing', async () => {
-      await expect(createPackage({ name: 'Test', price: 100, leadCount: 10 }))
-        .rejects.toThrow('Missing required fields');
+    it('allows a null campaign (campaignId is now optional — admin "No campaign")', async () => {
+      await createPackage({ name: 'Test', price: 100, leadCount: 10, createdBy: 'admin-1' });
+      const createArg = LeadPackage.create.mock.calls[0][0];
+      expect(createArg.campaignId).toBeNull();
     });
 
     it('accepts custom type', async () => {

--- a/backend/test/unit/leadPackageServiceAdmin.test.js
+++ b/backend/test/unit/leadPackageServiceAdmin.test.js
@@ -1,0 +1,299 @@
+import { jest } from '@jest/globals';
+import '../setup.js';
+
+// Isolated mocks for the external admin surface (catalog + assignment ops).
+const LeadPackage = { findAll: jest.fn(), findByPk: jest.fn(), create: jest.fn() };
+const LeadPackageAssignment = {
+  findAll: jest.fn(),
+  findByPk: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  count: jest.fn(),
+};
+const User = { findByPk: jest.fn(), findOne: jest.fn() };
+const Campaign = { findByPk: jest.fn(), findAll: jest.fn() };
+const Prospect = { count: jest.fn() };
+const sequelize = {
+  transaction: jest.fn(async (cb) => cb({})),
+  query: jest.fn().mockResolvedValue([]),
+  fn: jest.fn((f, c) => ({ _fn: f, _col: c })),
+  col: jest.fn((c) => ({ _col: c })),
+};
+
+jest.unstable_mockModule('../../src/models/index.js', () => ({
+  LeadPackage,
+  LeadPackageAssignment,
+  User,
+  Campaign,
+  Prospect,
+  sequelize,
+}));
+jest.unstable_mockModule('../../src/middleware/errorHandler.js', () => ({
+  AppError: class AppError extends Error {
+    constructor(message, statusCode) {
+      super(message);
+      this.statusCode = statusCode;
+    }
+  },
+}));
+jest.unstable_mockModule('../../src/utils/logger.js', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+// releaseSweep is dynamically imported (fire-and-forget) — mock so the no-op sweep is deterministic.
+jest.unstable_mockModule('../../src/services/releaseSweep.js', () => ({
+  sweepCampaign: jest.fn().mockResolvedValue(undefined),
+}));
+
+const {
+  normalizeQuality,
+  normalizeValidity,
+  normalizeCommission,
+  getExternalAdminCatalog,
+  listCampaignsForPicker,
+  getExternalAdminAgentAssignments,
+  assignPackageExternal,
+  topUpAssignment,
+  cancelAssignment,
+  removeAssignmentExternal,
+  resolveCreator,
+} = await import('../../src/services/leadPackageService.js');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('field normalizers', () => {
+  it('quality clamps 1..10, null when empty/invalid', () => {
+    expect(normalizeQuality(8)).toBe(8);
+    expect(normalizeQuality(0)).toBe(1);
+    expect(normalizeQuality(99)).toBe(10);
+    expect(normalizeQuality(null)).toBeNull();
+    expect(normalizeQuality('')).toBeNull();
+    expect(normalizeQuality('abc')).toBeNull();
+  });
+  it('validity ≥1 days, null when empty/<1', () => {
+    expect(normalizeValidity(30)).toBe(30);
+    expect(normalizeValidity('60')).toBe(60);
+    expect(normalizeValidity(0)).toBeNull();
+    expect(normalizeValidity(null)).toBeNull();
+  });
+  it('commission is a positive number, else 0', () => {
+    expect(normalizeCommission(12)).toBe(12);
+    expect(normalizeCommission(0)).toBe(0);
+    expect(normalizeCommission(-5)).toBe(0);
+    expect(normalizeCommission('x')).toBe(0);
+  });
+});
+
+describe('getExternalAdminCatalog', () => {
+  it('maps full fields + a per-package assignmentCount from one grouped COUNT', async () => {
+    LeadPackage.findAll.mockResolvedValue([
+      {
+        id: 'pkg-1', name: 'Starter', type: 'basic', status: 'active', description: null,
+        price: '150.00', leadCount: 50, currency: 'SGD', qualityScore: 7,
+        commissionStructure: { agentCommission: 3 }, validityPeriod: 30,
+        campaignId: 'camp-1', isPublic: true, campaign: { id: 'camp-1', name: 'Retire', status: 'active' },
+      },
+    ]);
+    LeadPackageAssignment.findAll.mockResolvedValue([{ leadPackageId: 'pkg-1', n: '4' }]);
+
+    const { packages } = await getExternalAdminCatalog();
+
+    expect(sequelize.fn).toHaveBeenCalledWith('COUNT', expect.anything());
+    expect(packages[0]).toMatchObject({
+      id: 'pkg-1', price: 150, leadCount: 50, currency: 'SGD', qualityScore: 7,
+      commissionPerLead: 3, validityDays: 30, campaignName: 'Retire', assignmentCount: 4,
+    });
+  });
+
+  it('hides a zero commission and reports 0 assignments when none', async () => {
+    LeadPackage.findAll.mockResolvedValue([
+      { id: 'pkg-2', name: 'X', type: 'basic', status: 'draft', price: '0.00', leadCount: 1,
+        currency: 'SGD', commissionStructure: { agentCommission: 0 }, validityPeriod: null, isPublic: false, campaign: null },
+    ]);
+    LeadPackageAssignment.findAll.mockResolvedValue([]);
+
+    const { packages } = await getExternalAdminCatalog();
+    expect(packages[0].commissionPerLead).toBeNull();
+    expect(packages[0].assignmentCount).toBe(0);
+    expect(packages[0].campaignName).toBeNull();
+  });
+});
+
+describe('listCampaignsForPicker', () => {
+  it('returns active campaigns and appends a still-selected inactive one', async () => {
+    Campaign.findAll.mockResolvedValue([{ id: 'c1', name: 'Active', status: 'active' }]);
+    Campaign.findByPk.mockResolvedValue({ id: 'c9', name: 'Paused', status: 'inactive' });
+
+    const { campaigns } = await listCampaignsForPicker('c9');
+
+    expect(Campaign.findAll.mock.calls[0][0].where).toEqual({ is_active: true });
+    expect(campaigns.map((c) => c.id)).toEqual(['c9', 'c1']);
+  });
+
+  it('does not double-add the selected campaign when already active', async () => {
+    Campaign.findAll.mockResolvedValue([{ id: 'c1', name: 'Active', status: 'active' }]);
+    const { campaigns } = await listCampaignsForPicker('c1');
+    expect(campaigns).toHaveLength(1);
+    expect(Campaign.findByPk).not.toHaveBeenCalled();
+  });
+});
+
+describe('getExternalAdminAgentAssignments', () => {
+  it('returns ALL statuses incl. priceSnapshot, capped at 100, for a synced agent', async () => {
+    User.findOne.mockResolvedValue({ id: 'agent-1' });
+    LeadPackageAssignment.findAll.mockResolvedValue([
+      {
+        id: 'a1', status: 'cancelled', leadsRemaining: 0, leadsTotal: 50, priceSnapshot: '150.00',
+        purchaseDate: new Date('2026-06-01T00:00:00.000Z'),
+        package: { name: 'Starter', type: 'basic', qualityScore: 7, currency: 'SGD',
+          commissionStructure: { agentCommission: 0 }, validityPeriod: null, campaign: { name: 'Retire' } },
+      },
+    ]);
+
+    const { packages } = await getExternalAdminAgentAssignments('mktr-1');
+
+    expect(LeadPackageAssignment.findAll.mock.calls[0][0].where).toEqual({ agentId: 'agent-1' });
+    expect(LeadPackageAssignment.findAll.mock.calls[0][0].limit).toBe(100);
+    expect(packages[0]).toMatchObject({ id: 'a1', status: 'cancelled', priceSnapshot: 150, commissionPerLead: null });
+  });
+
+  it('returns empty for an unknown agent without querying assignments', async () => {
+    User.findOne.mockResolvedValue(null);
+    const result = await getExternalAdminAgentAssignments('nope');
+    expect(result).toEqual({ packages: [] });
+    expect(LeadPackageAssignment.findAll).not.toHaveBeenCalled();
+  });
+});
+
+describe('assignPackageExternal', () => {
+  const activePkg = { id: 'pkg-1', status: 'active', leadCount: 50, price: 100, campaignId: 'camp-1' };
+
+  it('assigns and snapshots price; inherits leadCount', async () => {
+    User.findOne.mockResolvedValue({ id: 'agent-1' });
+    LeadPackage.findByPk.mockResolvedValue(activePkg);
+    LeadPackageAssignment.findOne.mockResolvedValue(null);
+    LeadPackageAssignment.create.mockResolvedValue({ id: 'new-1' });
+
+    const result = await assignPackageExternal({ agentMktrUserId: 'mktr-1', packageId: 'pkg-1' });
+
+    expect(result).toEqual({ status: 'assigned', assignmentId: 'new-1' });
+    const createArg = LeadPackageAssignment.create.mock.calls[0][0];
+    expect(createArg).toMatchObject({ leadsTotal: 50, leadsRemaining: 50, priceSnapshot: 100, status: 'active' });
+  });
+
+  it('honours a custom leadsTotalOverride', async () => {
+    User.findOne.mockResolvedValue({ id: 'agent-1' });
+    LeadPackage.findByPk.mockResolvedValue(activePkg);
+    LeadPackageAssignment.findOne.mockResolvedValue(null);
+    LeadPackageAssignment.create.mockResolvedValue({ id: 'new-1' });
+
+    await assignPackageExternal({ agentMktrUserId: 'mktr-1', packageId: 'pkg-1', leadsTotalOverride: 25 });
+    const createArg = LeadPackageAssignment.create.mock.calls[0][0];
+    expect(createArg).toMatchObject({ leadsTotal: 25, leadsRemaining: 25 });
+  });
+
+  it('returns exists when the agent already holds an active assignment (dup guard)', async () => {
+    User.findOne.mockResolvedValue({ id: 'agent-1' });
+    LeadPackage.findByPk.mockResolvedValue(activePkg);
+    LeadPackageAssignment.findOne.mockResolvedValue({ id: 'existing-1' });
+
+    const result = await assignPackageExternal({ agentMktrUserId: 'mktr-1', packageId: 'pkg-1' });
+    expect(result).toEqual({ status: 'exists', assignmentId: 'existing-1' });
+    expect(LeadPackageAssignment.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-active package', async () => {
+    User.findOne.mockResolvedValue({ id: 'agent-1' });
+    LeadPackage.findByPk.mockResolvedValue({ ...activePkg, status: 'draft' });
+    const result = await assignPackageExternal({ agentMktrUserId: 'mktr-1', packageId: 'pkg-1' });
+    expect(result).toEqual({ status: 'package_inactive' });
+  });
+
+  it('rejects an unknown/inactive agent', async () => {
+    User.findOne.mockResolvedValue(null);
+    const result = await assignPackageExternal({ agentMktrUserId: 'ghost', packageId: 'pkg-1' });
+    expect(result).toEqual({ status: 'invalid_agent' });
+  });
+});
+
+describe('topUpAssignment', () => {
+  it('delta adds to BOTH remaining and total (fixes the 150/100 bug)', async () => {
+    const a = { id: 'a1', status: 'active', leadsRemaining: 10, leadsTotal: 100, leadPackageId: 'pkg-1', update: jest.fn().mockResolvedValue(true) };
+    LeadPackageAssignment.findOne.mockResolvedValue(a);
+
+    await topUpAssignment({ assignmentId: 'a1', addLeads: 50 });
+    expect(a.update).toHaveBeenCalledWith({ leadsRemaining: 60, leadsTotal: 150, status: 'active' });
+  });
+
+  it('absolute setRemaining correction sets status by count', async () => {
+    const a = { id: 'a1', status: 'completed', leadsRemaining: 0, leadsTotal: 100, leadPackageId: 'pkg-1', update: jest.fn().mockResolvedValue(true) };
+    LeadPackageAssignment.findOne.mockResolvedValue(a);
+
+    await topUpAssignment({ assignmentId: 'a1', setRemaining: 5 });
+    expect(a.update).toHaveBeenCalledWith({ leadsRemaining: 5, status: 'active' });
+  });
+
+  it('refuses to resurrect a cancelled/expired assignment', async () => {
+    LeadPackageAssignment.findOne.mockResolvedValue({ id: 'a1', status: 'cancelled', leadsRemaining: 0, leadsTotal: 10, update: jest.fn() });
+    await expect(topUpAssignment({ assignmentId: 'a1', addLeads: 5 })).rejects.toThrow('cancelled or expired');
+  });
+
+  it('404s when the assignment is not a mktr-leads one (scope guard returns null)', async () => {
+    LeadPackageAssignment.findOne.mockResolvedValue(null);
+    await expect(topUpAssignment({ assignmentId: 'x', addLeads: 5 })).rejects.toThrow('Assignment not found');
+  });
+});
+
+describe('cancelAssignment', () => {
+  it('sets status cancelled', async () => {
+    const a = { id: 'a1', status: 'active', update: jest.fn().mockResolvedValue(true) };
+    LeadPackageAssignment.findOne.mockResolvedValue(a);
+    await cancelAssignment('a1');
+    expect(a.update).toHaveBeenCalledWith({ status: 'cancelled' });
+  });
+  it('is idempotent (already cancelled → no update)', async () => {
+    const a = { id: 'a1', status: 'cancelled', update: jest.fn() };
+    LeadPackageAssignment.findOne.mockResolvedValue(a);
+    await cancelAssignment('a1');
+    expect(a.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('removeAssignmentExternal', () => {
+  it('destroys the row when scoped to a mktr-leads agent', async () => {
+    const a = { id: 'a1', destroy: jest.fn().mockResolvedValue(true) };
+    LeadPackageAssignment.findOne.mockResolvedValue(a);
+    await removeAssignmentExternal('a1');
+    expect(a.destroy).toHaveBeenCalled();
+  });
+  it('404s when not a mktr-leads assignment', async () => {
+    LeadPackageAssignment.findOne.mockResolvedValue(null);
+    await expect(removeAssignmentExternal('x')).rejects.toThrow('Assignment not found');
+  });
+});
+
+describe('resolveCreator', () => {
+  const ORIGINAL = process.env.ADMIN_PACKAGES_CREATOR_USER_ID;
+  afterEach(() => { process.env.ADMIN_PACKAGES_CREATOR_USER_ID = ORIGINAL; });
+
+  it('prefers the acting admin when synced', async () => {
+    User.findOne.mockResolvedValue({ id: 'mktr-admin-uuid' });
+    expect(await resolveCreator('actor-mktr-1')).toBe('mktr-admin-uuid');
+  });
+  it('falls back to the configured system creator', async () => {
+    User.findOne.mockResolvedValue(null);
+    process.env.ADMIN_PACKAGES_CREATOR_USER_ID = 'sys-creator';
+    expect(await resolveCreator('actor-mktr-1')).toBe('sys-creator');
+  });
+  it('falls back to the oldest admin when no actor and no env', async () => {
+    delete process.env.ADMIN_PACKAGES_CREATOR_USER_ID;
+    User.findOne.mockResolvedValue({ id: 'web-admin' });
+    expect(await resolveCreator(null)).toBe('web-admin');
+  });
+  it('throws when nothing resolves (no actor, no env, no admin)', async () => {
+    User.findOne.mockResolvedValue(null);
+    delete process.env.ADMIN_PACKAGES_CREATOR_USER_ID;
+    await expect(resolveCreator(null)).rejects.toThrow('No package creator');
+  });
+});


### PR DESCRIPTION
Net-new HMAC surface `/api/external/admin-packages` (catalog + per-agent assignments) for the mktr-leads admin app, behind **`ADMIN_PACKAGES_EXTERNAL_ENABLED`** (route auto-loader gates it → **deploy-inert** until the flag is set).

- `externalAdminPackages` controller + route (grouped sub-paths, shared HMAC middleware, `export default`).
- `leadPackageService`: create/update parity + new fields (quality/validity/agentCommission), nullable campaign, **SGD**; admin catalog DTO (+assignmentCount); admin assignment DTO (all statuses + priceSnapshot); `assignPackageExternal` (active-only + advisory-lock dup guard); delta `topUpAssignment` (both counts, guards cancelled/expired); `cancelAssignment`; **mktrLeadsId-scoped** assignment writes (IDOR guard); `resolveCreator` (actor → env → oldest admin).
- 63 unit tests. Existing web admin unaffected (it never sends the new fields; already labels price SGD).

**To go live after merge:** set `ADMIN_PACKAGES_EXTERNAL_ENABLED=true` on the backend service. (`ADMIN_PACKAGES_CREATOR_USER_ID` is now optional — falls back to the oldest admin.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)