### PR TITLE
feat(billing): HitPay lead-package checkout backend (deploy-inert)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -264,3 +264,17 @@ MKTR_LEADS_INVITE_SECRET=your-invite-service-secret
 # Sentry Error Tracking (optional)
 # -----------------------------------------------------------------------------
 SENTRY_DSN=
+
+# -----------------------------------------------------------------------------
+# Lead-package billing (HitPay) — DEPLOY-INERT until BILLING_ENABLED=true
+# -----------------------------------------------------------------------------
+BILLING_ENABLED=false
+# App-Store kill switch surfaced on the catalog: in_app | web | off
+BILLING_CHECKOUT_MODE=in_app
+HITPAY_API_KEY=                              # secret
+HITPAY_WEBHOOK_SALT=                         # secret — webhook signature key
+HITPAY_API_BASE=https://api.hit-pay.com/v1  # sandbox: https://api.sandbox.hit-pay.com/v1
+HITPAY_PAYMENT_METHODS=paynow_online,card
+HITPAY_WEBHOOK_URL=                          # full URL to /api/external/billing/hitpay-webhook (optional if dashboard-configured)
+HITPAY_REDIRECT_URL=                         # app deep link back after pay (optional; webhook is source of truth)
+# NOTE: EXTERNAL_APP_SECRET (set above) also authenticates the agent-facing billing routes.

--- a/backend/src/controllers/externalBillingController.js
+++ b/backend/src/controllers/externalBillingController.js
@@ -1,0 +1,151 @@
+/**
+ * @file externalBillingController — the MKTR Leads buyer app's lead-package PURCHASE flow.
+ *
+ * ── Endpoints (mounted at /api/external/billing, gated by BILLING_ENABLED) ──────
+ *   POST /catalog        → buyable packages + checkoutMode (kill switch)
+ *   POST /checkout       → create a HitPay payment → { checkoutUrl, purchaseId }
+ *   POST /status         → poll one of the agent's purchases → { status }
+ *   POST /history        → the agent's purchase history → { purchases }
+ *   POST /hitpay-webhook → HitPay settlement → fulfill (grant the LeadPackageAssignment)
+ *
+ * ── Auth ────────────────────────────────────────────────────────────────────
+ * The four agent-facing actions use the SAME HMAC-SHA256-over-rawBody scheme as the
+ * other /api/external/ surfaces (header `X-Webhook-Signature: sha256=<hex>`, freshness
+ * on the signed body `timestamp`, ±5 min) keyed by EXTERNAL_APP_SECRET — the mktr-leads
+ * `mktr-agent-store` broker edge function (agent-JWT gated, self-scopes the caller's own
+ * mktr_user_id, holds the secret) is the only intended caller. The webhook is authed
+ * separately by HitPay's own signature (hitpayClient.verifyWebhook). rawBody capture +
+ * the rate-limiter exemption for `/api/external/` are wired in server_internal.js.
+ */
+import crypto from 'crypto';
+import { logger } from '../utils/logger.js';
+import { verifyWebhook as verifyHitpayWebhook } from '../services/hitpayClient.js';
+import { getCatalog, createCheckout, getPurchaseStatus, getHistory, fulfillFromWebhook } from '../services/billingService.js';
+
+const MAX_AGE_MS = 5 * 60 * 1000;
+const MAX_FUTURE_MS = 2 * 60 * 1000; // tolerate clock skew
+const MAX_BODY_BYTES = 64 * 1024;
+
+function timingSafeHexEq(receivedHex, expectedHex) {
+  if (typeof receivedHex !== 'string' || typeof expectedHex !== 'string') return false;
+  if (receivedHex.length !== expectedHex.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(receivedHex, 'hex'), Buffer.from(expectedHex, 'hex'));
+  } catch {
+    return false;
+  }
+}
+
+/** Verify HMAC + freshness. Returns null on success, or { code, error } to send. */
+function verifyExternalHmac(req) {
+  const secret = process.env.EXTERNAL_APP_SECRET;
+  if (!secret) {
+    logger.error('[external-billing] EXTERNAL_APP_SECRET not configured');
+    return { code: 500, error: 'Server misconfigured' };
+  }
+  if (!req.rawBody || !Buffer.isBuffer(req.rawBody)) {
+    logger.error('[external-billing] req.rawBody missing — verify hook not wired for this path');
+    return { code: 500, error: 'Server misconfigured' };
+  }
+  if (req.rawBody.length > MAX_BODY_BYTES) return { code: 413, error: 'Payload too large' };
+
+  const sigHeader = req.headers['x-webhook-signature'] || '';
+  if (typeof sigHeader !== 'string' || !sigHeader.startsWith('sha256=')) {
+    return { code: 401, error: 'Unauthorized' };
+  }
+  const expectedHex = crypto.createHmac('sha256', secret).update(req.rawBody).digest('hex');
+  if (!timingSafeHexEq(sigHeader.slice(7), expectedHex)) {
+    return { code: 401, error: 'Unauthorized' };
+  }
+
+  const tsMs = typeof req.body?.timestamp === 'string' ? Date.parse(req.body.timestamp) : NaN;
+  if (Number.isNaN(tsMs)) return { code: 401, error: 'Unauthorized' };
+  const ageMs = Date.now() - tsMs;
+  if (ageMs > MAX_AGE_MS || ageMs < -MAX_FUTURE_MS) return { code: 401, error: 'Unauthorized' };
+
+  return null;
+}
+
+/** Express middleware — apply on the agent-facing routes (NOT the HitPay webhook). */
+export function requireExternalHmac(req, res, next) {
+  const authErr = verifyExternalHmac(req);
+  if (authErr) return res.status(authErr.code).json({ success: false, error: authErr.error });
+  next();
+}
+
+function sendError(res, err, op) {
+  logger.error(`[external-billing] ${op} failed`, { error: err?.message || String(err) });
+  return res.status(500).json({ success: false, error: 'Internal server error' });
+}
+
+// ── Catalog ─────────────────────────────────────────────────────────────────────
+export async function catalog(req, res) {
+  try {
+    const data = await getCatalog();
+    return res.json({ success: true, ...data });
+  } catch (err) {
+    return sendError(res, err, 'catalog');
+  }
+}
+
+// ── Checkout (create purchase) ────────────────────────────────────────────────
+export async function checkout(req, res) {
+  const { agentMktrUserId, packageId } = req.body || {};
+  if (!agentMktrUserId || !packageId) {
+    return res.status(400).json({ success: false, error: 'agentMktrUserId and packageId are required' });
+  }
+  try {
+    const r = await createCheckout({ agentMktrUserId, packageId });
+    if (r.status === 'created') {
+      return res.status(201).json({ success: true, checkoutUrl: r.url, purchaseId: r.purchaseId });
+    }
+    const codeByStatus = { invalid_agent: 400, package_inactive: 409, package_unpriced: 409, provider_error: 502 };
+    const code = codeByStatus[r.status] || 500;
+    return res.status(code).json({ success: false, status: r.status });
+  } catch (err) {
+    return sendError(res, err, 'checkout');
+  }
+}
+
+// ── Status ────────────────────────────────────────────────────────────────────
+export async function status(req, res) {
+  const { agentMktrUserId, purchaseId } = req.body || {};
+  if (!agentMktrUserId || !purchaseId) {
+    return res.status(400).json({ success: false, error: 'agentMktrUserId and purchaseId are required' });
+  }
+  try {
+    const r = await getPurchaseStatus({ agentMktrUserId, purchaseId });
+    return res.json({ success: true, status: r.status });
+  } catch (err) {
+    return sendError(res, err, 'status');
+  }
+}
+
+// ── History ───────────────────────────────────────────────────────────────────
+export async function history(req, res) {
+  const { agentMktrUserId } = req.body || {};
+  if (!agentMktrUserId) {
+    return res.status(400).json({ success: false, error: 'agentMktrUserId is required' });
+  }
+  try {
+    const r = await getHistory({ agentMktrUserId });
+    return res.json({ success: true, purchases: r.purchases });
+  } catch (err) {
+    return sendError(res, err, 'history');
+  }
+}
+
+// ── HitPay webhook (settlement → fulfillment) ─────────────────────────────────
+export async function hitpayWebhook(req, res) {
+  const payload = verifyHitpayWebhook(req);
+  if (!payload) return res.status(401).json({ success: false, error: 'invalid signature' });
+  try {
+    const r = await fulfillFromWebhook(payload);
+    // 200 on any DURABLE outcome (fulfilled / replay / rejected / ignored / unknown / not_pending)
+    // so HitPay stops retrying. A thrown error below is transient → 5xx → HitPay retries.
+    return res.status(200).json({ success: true, status: r.status });
+  } catch (err) {
+    logger.error('[external-billing] webhook fulfillment error (transient → 5xx for retry)', { error: err?.message || String(err) });
+    return res.status(500).json({ success: false, error: 'processing error' });
+  }
+}

--- a/backend/src/database/migrations/040-create-payments.js
+++ b/backend/src/database/migrations/040-create-payments.js
@@ -1,0 +1,100 @@
+/**
+ * Migration 040 — create payments.
+ *
+ * Immutable financial records for agent lead-package purchases (HitPay one-time
+ * checkout). FKs are ON DELETE SET NULL (never CASCADE) so a deleted agent /
+ * package / assignment never erases a payment — the snapshots on the row preserve
+ * the audit. Partial unique indexes on the HitPay provider ids (and the linked
+ * assignment) ensure one request / payment / grant maps to at most one row.
+ *
+ * This is a CRITICAL financial table, so DDL errors are NOT blanket-swallowed: only
+ * "already exists" (idempotent re-run) is ignored — any other failure re-throws so
+ * the runner never records a half-applied migration as done. A post-up assertion
+ * verifies the table + the unique guards actually exist.
+ */
+function ignoreExists(e) {
+  const msg = String(e?.message || e || '');
+  if (!/already exists|duplicate/i.test(msg)) throw e;
+}
+
+export async function up(queryInterface, Sequelize) {
+  const { DataTypes } = Sequelize;
+
+  await queryInterface
+    .createTable('payments', {
+      id: { type: DataTypes.UUID, primaryKey: true, defaultValue: DataTypes.UUIDV4 },
+      agentId: {
+        type: DataTypes.UUID, allowNull: true,
+        references: { model: 'users', key: 'id' }, onDelete: 'SET NULL', onUpdate: 'CASCADE',
+      },
+      leadPackageId: {
+        type: DataTypes.UUID, allowNull: true,
+        references: { model: 'lead_packages', key: 'id' }, onDelete: 'SET NULL', onUpdate: 'CASCADE',
+      },
+      leadPackageAssignmentId: {
+        type: DataTypes.UUID, allowNull: true,
+        references: { model: 'lead_package_assignments', key: 'id' }, onDelete: 'SET NULL', onUpdate: 'CASCADE',
+      },
+      provider: { type: DataTypes.STRING, allowNull: false, defaultValue: 'hitpay' },
+      providerRequestId: { type: DataTypes.STRING, allowNull: true },
+      providerPaymentId: { type: DataTypes.STRING, allowNull: true },
+      amount: { type: DataTypes.DECIMAL(10, 2), allowNull: false },
+      currency: { type: DataTypes.STRING(3), allowNull: false, defaultValue: 'SGD' },
+      leadCount: { type: DataTypes.INTEGER, allowNull: false },
+      packageName: { type: DataTypes.STRING, allowNull: true },
+      campaignName: { type: DataTypes.STRING, allowNull: true },
+      status: {
+        type: DataTypes.ENUM('pending', 'paid', 'failed', 'expired', 'refunded', 'comp'),
+        allowNull: false, defaultValue: 'pending',
+      },
+      source: {
+        type: DataTypes.ENUM('mktr_leads_app', 'web', 'admin_comp'),
+        allowNull: false, defaultValue: 'mktr_leads_app',
+      },
+      rawWebhook: { type: DataTypes.JSON, allowNull: true },
+      createdAt: { type: DataTypes.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
+      updatedAt: { type: DataTypes.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
+    })
+    .catch(ignoreExists);
+
+  await queryInterface.addIndex('payments', ['agentId', 'status'], { name: 'idx_payments_agent_status' }).catch(ignoreExists);
+  await queryInterface.addIndex('payments', ['status'], { name: 'idx_payments_status' }).catch(ignoreExists);
+  await queryInterface
+    .addIndex('payments', ['providerRequestId'], {
+      unique: true, name: 'uniq_payments_provider_request',
+      where: Sequelize.literal('"providerRequestId" IS NOT NULL'),
+    })
+    .catch(ignoreExists);
+  await queryInterface
+    .addIndex('payments', ['providerPaymentId'], {
+      unique: true, name: 'uniq_payments_provider_payment',
+      where: Sequelize.literal('"providerPaymentId" IS NOT NULL'),
+    })
+    .catch(ignoreExists);
+  // One assignment ↔ at most one payment (belt-and-suspenders on the row-lock idempotency).
+  await queryInterface
+    .addIndex('payments', ['leadPackageAssignmentId'], {
+      unique: true, name: 'uniq_payments_assignment',
+      where: Sequelize.literal('"leadPackageAssignmentId" IS NOT NULL'),
+    })
+    .catch(ignoreExists);
+
+  // Post-assertion — money table: fail loudly rather than record a half-applied migration.
+  const [tblRows] = await queryInterface.sequelize.query("SELECT to_regclass('public.payments') AS t");
+  if (!tblRows?.[0]?.t) throw new Error('migration 040: payments table was not created');
+  const [idxRows] = await queryInterface.sequelize.query(
+    `SELECT indexname FROM pg_indexes WHERE tablename = 'payments'
+       AND indexname IN ('uniq_payments_provider_request', 'uniq_payments_provider_payment')`,
+  );
+  if (!Array.isArray(idxRows) || idxRows.length < 2) {
+    throw new Error('migration 040: provider-id unique indexes were not created');
+  }
+}
+
+export async function down(queryInterface) {
+  await queryInterface.dropTable('payments').catch(() => {});
+  // Postgres ENUM types persist after dropTable — drop them so a re-run recreates cleanly.
+  for (const t of ['enum_payments_status', 'enum_payments_source']) {
+    await queryInterface.sequelize.query(`DROP TYPE IF EXISTS "${t}"`).catch(() => {});
+  }
+}

--- a/backend/src/models/Payment.js
+++ b/backend/src/models/Payment.js
@@ -1,0 +1,101 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Payment — an immutable financial record for an agent's lead-package PURCHASE
+ * (one-time HitPay checkout). The money-path source of truth: fulfillment grants
+ * credits from THIS row's snapshots (leadCount/amount/...), never from webhook
+ * fields. `id` doubles as the HitPay `reference_number` we send, so the webhook
+ * correlates back by primary key (the idempotency anchor — see billingService:
+ * the conditional pending→paid UPDATE WHERE id=:ref).
+ *
+ * FKs are ON DELETE SET NULL (set in migration 040) — payments outlive the agent /
+ * package / assignment they reference, so a deleted parent never erases the
+ * financial record. The snapshots preserve the audit when parents vanish.
+ */
+const Payment = sequelize.define('Payment', {
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    primaryKey: true,
+  },
+  agentId: {
+    type: DataTypes.UUID,
+    allowNull: true, // SET NULL on user delete — keep the financial record
+    references: { model: 'users', key: 'id' },
+  },
+  leadPackageId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    references: { model: 'lead_packages', key: 'id' },
+  },
+  leadPackageAssignmentId: {
+    type: DataTypes.UUID,
+    allowNull: true, // null until fulfillment creates the assignment
+    references: { model: 'lead_package_assignments', key: 'id' },
+  },
+  provider: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    defaultValue: 'hitpay',
+  },
+  /** HitPay payment_request id (returned at checkout-create). */
+  providerRequestId: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
+  /** HitPay payment id (arrives on settlement). */
+  providerPaymentId: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
+  amount: {
+    type: DataTypes.DECIMAL(10, 2),
+    allowNull: false,
+    validate: { min: 0.01 },
+  },
+  currency: {
+    type: DataTypes.STRING(3),
+    allowNull: false,
+    defaultValue: 'SGD',
+  },
+  // ── Immutable snapshots (fulfillment reads THESE, never the webhook) ──────────
+  leadCount: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    validate: { min: 1 },
+  },
+  packageName: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
+  campaignName: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
+  status: {
+    type: DataTypes.ENUM('pending', 'paid', 'failed', 'expired', 'refunded', 'comp'),
+    allowNull: false,
+    defaultValue: 'pending',
+  },
+  source: {
+    type: DataTypes.ENUM('mktr_leads_app', 'web', 'admin_comp'),
+    allowNull: false,
+    defaultValue: 'mktr_leads_app',
+  },
+  /** Raw provider webhook payload, for audit. May contain PII (email/phone) — see retention policy. */
+  rawWebhook: {
+    type: DataTypes.JSON,
+    allowNull: true,
+  },
+}, {
+  tableName: 'payments',
+  indexes: [
+    { fields: ['agentId', 'status'], name: 'idx_payments_agent_status' },
+    { fields: ['status'] },
+    { fields: ['providerRequestId'] },
+    { fields: ['providerPaymentId'] },
+  ],
+});
+
+export default Payment;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -24,7 +24,7 @@ for (const file of modelFiles) {
 function defineAssociations() {
   const {
     User, Campaign, Car, FleetOwner, Driver, Prospect, QrTag,
-    Commission, LeadPackage, LeadPackageAssignment, CampaignPreview,
+    Commission, LeadPackage, LeadPackageAssignment, Payment, CampaignPreview,
     QrScan, Attribution, SessionVisit, ProspectActivity, UserPayout,
     Device, BeaconEvent, Impression, ShortLink, ShortLinkClick,
     Vehicle, WebhookSubscriber, WebhookDelivery, AgentGroup,
@@ -116,6 +116,15 @@ function defineAssociations() {
   LeadPackageAssignment.belongsTo(User, { foreignKey: 'agentId', as: 'agent', onDelete: 'CASCADE' });
   LeadPackageAssignment.belongsTo(LeadPackage, { foreignKey: 'leadPackageId', as: 'package', onDelete: 'CASCADE' });
 
+  // Payment associations — immutable financial records. SET NULL on parent delete
+  // (never cascade): a deleted agent/package/assignment must not erase a payment.
+  User.hasMany(Payment, { foreignKey: 'agentId', as: 'payments', onDelete: 'SET NULL' });
+  Payment.belongsTo(User, { foreignKey: 'agentId', as: 'agent', onDelete: 'SET NULL' });
+  LeadPackage.hasMany(Payment, { foreignKey: 'leadPackageId', as: 'payments', onDelete: 'SET NULL' });
+  Payment.belongsTo(LeadPackage, { foreignKey: 'leadPackageId', as: 'package', onDelete: 'SET NULL' });
+  LeadPackageAssignment.hasOne(Payment, { foreignKey: 'leadPackageAssignmentId', as: 'payment', onDelete: 'SET NULL' });
+  Payment.belongsTo(LeadPackageAssignment, { foreignKey: 'leadPackageAssignmentId', as: 'assignment', onDelete: 'SET NULL' });
+
   // Device associations
   Device.hasMany(BeaconEvent, { foreignKey: 'deviceId', as: 'events', onDelete: 'CASCADE' });
   Device.hasMany(Impression, { foreignKey: 'deviceId', as: 'impressions', onDelete: 'CASCADE' });
@@ -180,7 +189,7 @@ for (const [modelName, alias] of criticalAssociations) {
 // Named exports (destructured from models object for backward compatibility)
 export const {
   User, Campaign, Car, FleetOwner, Driver, Prospect, QrTag,
-  Commission, LeadPackage, LeadPackageAssignment, CampaignPreview,
+  Commission, LeadPackage, LeadPackageAssignment, Payment, CampaignPreview,
   QrScan, Attribution, SessionVisit, ProspectActivity, UserPayout,
   Device, BeaconEvent, Impression, IdempotencyKey, ShortLink,
   ShortLinkClick, RoundRobinCursor, Verification, ProvisioningSession,

--- a/backend/src/routes/externalBilling.js
+++ b/backend/src/routes/externalBilling.js
@@ -1,0 +1,40 @@
+/**
+ * MKTR Leads buyer app → lead-package PURCHASE (HitPay checkout).
+ *
+ * Mounted at `/api/external/billing`. The four agent-facing actions are HMAC-SHA256
+ * over the raw body (EXTERNAL_APP_SECRET); `/hitpay-webhook` is authed by HitPay's own
+ * signature inside the handler. rawBody capture + the rate-limiter exemption for the
+ * `/api/external/` prefix are wired in server_internal.js (same as the other external surfaces).
+ *
+ * Gated behind BILLING_ENABLED so the route stays UNMOUNTED until HitPay + the broker are
+ * provisioned (deploy-inert). The route auto-loader (routes/index.js) only mounts modules
+ * exporting BOTH `meta` and a default router.
+ */
+import express from 'express';
+import {
+  requireExternalHmac,
+  catalog,
+  checkout,
+  status,
+  history,
+  hitpayWebhook,
+} from '../controllers/externalBillingController.js';
+
+const router = express.Router();
+
+export const meta = {
+  path: '/api/external/billing',
+  flag: 'BILLING_ENABLED',
+  flagDefault: 'false',
+};
+
+// Agent-facing (broker, HMAC). POST so the body carries the signed `timestamp`.
+router.post('/catalog', requireExternalHmac, catalog);
+router.post('/checkout', requireExternalHmac, checkout);
+router.post('/status', requireExternalHmac, status);
+router.post('/history', requireExternalHmac, history);
+
+// HitPay settlement — authed by HitPay's signature inside the handler (NOT EXTERNAL_APP_SECRET).
+router.post('/hitpay-webhook', hitpayWebhook);
+
+export default router;

--- a/backend/src/services/billingService.js
+++ b/backend/src/services/billingService.js
@@ -1,0 +1,282 @@
+/**
+ * Lead-package billing (HitPay one-time checkout). Puts a PAID, idempotent gate in
+ * front of LeadPackageAssignment creation — drawdown (chargeLeadCredit) is untouched.
+ *
+ * Money-path invariants:
+ *  1. Fulfillment grants from OUR Payment row's snapshots, never from webhook fields.
+ *  2. Idempotent: the webhook locks the Payment row (FOR UPDATE) and only a pending
+ *     row is flipped → exactly one assignment; replays return the existing one.
+ *  3. Server-side amount/currency guard, snapshot vs webhook compared in integer cents.
+ *  4. The caller returns 200 only on a durable outcome; a thrown error → 5xx → HitPay retries.
+ *
+ * DI-factory (house pattern) so it unit-tests without a DB or network.
+ */
+import { Payment, LeadPackage, LeadPackageAssignment, User, Campaign, sequelize } from '../models/index.js';
+import * as hitpay from './hitpayClient.js';
+import { logger } from '../utils/logger.js';
+
+const VALID_CHECKOUT_MODES = ['in_app', 'web', 'off'];
+
+/**
+ * Strict money string → integer cents. Rejects non-canonical input (exponent, >2 decimals,
+ * sign, NaN, missing) by returning NaN so it FAILS the equality guard — never float-rounds a
+ * fractional cent into a match (e.g. '199.995' must NOT equal '200.00'). The snapshot we write
+ * is always canonical ('200.00'); the webhook must be too.
+ */
+function toCents(v) {
+  const s = String(v ?? '').trim();
+  if (!/^\d+(\.\d{1,2})?$/.test(s)) return NaN;
+  const [whole, frac = ''] = s.split('.');
+  return Number(whole) * 100 + Number((frac + '00').slice(0, 2));
+}
+
+/** Internal Payment.status → the app's PurchaseStatus (pending|paid|failed|...). */
+function toPurchaseStatus(s) {
+  if (s === 'paid') return 'paid';
+  if (s === 'pending') return 'pending';
+  if (s === 'refunded') return 'refunded';
+  return 'failed'; // failed | expired | comp
+}
+
+export function makeBillingService(overrides = {}) {
+  const d = { Payment, LeadPackage, LeadPackageAssignment, User, Campaign, sequelize, hitpay, logger, ...overrides };
+
+  /** Server-controlled in-app-checkout kill switch (App-Store mitigation). */
+  function checkoutMode() {
+    const m = String(process.env.BILLING_CHECKOUT_MODE || 'in_app').toLowerCase();
+    return VALID_CHECKOUT_MODES.includes(m) ? m : 'in_app';
+  }
+
+  /**
+   * Resolve the buying agent — the SAME proven self-scope guard as the rest of the
+   * mktr-leads surface (getExternalAgentPackages / assignPackageExternal): mktrLeadsId
+   * + role:'agent' + isActive. To enforce "approved only", add approvalStatus:'approved'
+   * once the mktr-leads mirror is confirmed to stamp it (else it blocks the cohort).
+   */
+  async function resolveAgent(agentMktrUserId) {
+    if (!agentMktrUserId || typeof agentMktrUserId !== 'string') return null;
+    return d.User.findOne({
+      where: { mktrLeadsId: agentMktrUserId, role: 'agent', isActive: true },
+      attributes: ['id', 'firstName', 'lastName', 'fullName', 'email'],
+    });
+  }
+
+  /** Buyable catalog (active + public + priced in SGD) + the checkout kill switch. */
+  async function getCatalog() {
+    const packages = await d.LeadPackage.findAll({
+      where: { status: 'active', isPublic: true },
+      include: [{ model: d.Campaign, as: 'campaign', attributes: ['name'] }],
+      order: [['createdAt', 'DESC']],
+    });
+    const buyable = packages
+      .filter((p) => Number(p.price) > 0 && (p.currency || 'SGD') === 'SGD')
+      .map((p) => ({
+        id: p.id,
+        name: p.name,
+        type: p.type ?? null,
+        leadCount: p.leadCount,
+        price: Number(p.price),
+        currency: p.currency || 'SGD',
+        campaignName: p.campaign?.name ?? null,
+        // false until the admin-flag column ships (catalog still works — app hides "featured" when none).
+        isRecommended: p.isRecommended === true,
+      }));
+    return { packages: buyable, checkoutMode: checkoutMode() };
+  }
+
+  /**
+   * Create a pending Payment + a HitPay payment request. The Payment.id is the HitPay
+   * reference_number, so the webhook correlates back by PK. Typed outcomes:
+   * created | invalid_agent | package_inactive | package_unpriced | provider_error.
+   */
+  async function createCheckout({ agentMktrUserId, packageId }) {
+    if (!agentMktrUserId || !packageId) return { status: 'invalid_agent' };
+    const agent = await resolveAgent(agentMktrUserId);
+    if (!agent) return { status: 'invalid_agent' };
+
+    const pkg = await d.LeadPackage.findByPk(packageId, {
+      include: [{ model: d.Campaign, as: 'campaign', attributes: ['name'] }],
+    });
+    if (!pkg || pkg.status !== 'active' || !pkg.isPublic) return { status: 'package_inactive' };
+    const price = Number(pkg.price);
+    if (!(price > 0) || (pkg.currency || 'SGD') !== 'SGD') return { status: 'package_unpriced' };
+
+    // Pending Payment first so its id is the HitPay reference_number + the idempotency anchor.
+    const payment = await d.Payment.create({
+      agentId: agent.id,
+      leadPackageId: pkg.id,
+      provider: 'hitpay',
+      amount: price,
+      currency: 'SGD',
+      leadCount: pkg.leadCount,
+      packageName: pkg.name,
+      campaignName: pkg.campaign?.name ?? null,
+      status: 'pending',
+      source: 'mktr_leads_app',
+    });
+
+    try {
+      const { id, url } = await d.hitpay.createPaymentRequest({
+        amount: price,
+        referenceNumber: payment.id,
+        name: agent.fullName || `${agent.firstName || ''} ${agent.lastName || ''}`.trim() || undefined,
+        email: agent.email || undefined,
+        redirectUrl: process.env.HITPAY_REDIRECT_URL || undefined,
+        webhookUrl: process.env.HITPAY_WEBHOOK_URL || undefined,
+        purpose: pkg.name,
+      });
+      await payment.update({ providerRequestId: id });
+      d.logger.info('[billing] checkout.created', { purchaseId: payment.id, agentId: agent.id, packageId: pkg.id, amount: price });
+      return { status: 'created', url, purchaseId: payment.id };
+    } catch (err) {
+      await payment.update({ status: 'failed' }).catch(() => {});
+      d.logger.error('[billing] checkout HitPay create failed', { purchaseId: payment.id, error: err?.message || String(err) });
+      return { status: 'provider_error' };
+    }
+  }
+
+  /** Poll one of the agent's OWN purchases (self-scoped). */
+  async function getPurchaseStatus({ agentMktrUserId, purchaseId }) {
+    const agent = await resolveAgent(agentMktrUserId);
+    if (!agent || !purchaseId) return { status: 'failed' };
+    const payment = await d.Payment.findOne({ where: { id: purchaseId, agentId: agent.id }, attributes: ['status'] });
+    if (!payment) return { status: 'failed' };
+    return { status: toPurchaseStatus(payment.status) };
+  }
+
+  /** The agent's OWN purchase history (self-scoped, newest 50). */
+  async function getHistory({ agentMktrUserId }) {
+    const agent = await resolveAgent(agentMktrUserId);
+    if (!agent) return { purchases: [] };
+    const rows = await d.Payment.findAll({ where: { agentId: agent.id }, order: [['createdAt', 'DESC']], limit: 50 });
+    const purchases = rows.map((p) => ({
+      id: p.id,
+      packageName: p.packageName || 'Lead package',
+      leadCount: p.leadCount,
+      amount: Number(p.amount),
+      currency: p.currency || 'SGD',
+      status: toPurchaseStatus(p.status),
+      createdAt: (p.createdAt instanceof Date ? p.createdAt : new Date(p.createdAt)).toISOString(),
+    }));
+    return { purchases };
+  }
+
+  /**
+   * Fulfill a verified, completed HitPay webhook. One transaction; the Payment row is
+   * the idempotency anchor (FOR UPDATE lock + only-pending flip). Grants from snapshots.
+   * Returns a typed status so the caller can pick 200 (durable) vs 5xx (retryable).
+   */
+  async function fulfillFromWebhook(payload) {
+    const ref = payload?.reference_number ?? payload?.referenceNumber ?? null;
+    const providerRequestId = payload?.payment_request_id ?? payload?.id ?? null;
+    const providerPaymentId = payload?.payment_id ?? payload?.id ?? null;
+    const rawStatus = String(payload?.status ?? '').toLowerCase();
+    const completed = ['completed', 'paid', 'succeeded'].includes(rawStatus);
+    const wAmount = payload?.amount;
+    const wCurrency = String(payload?.currency ?? 'SGD').toUpperCase();
+
+    if (!ref) {
+      d.logger.warn('[billing] webhook missing reference_number');
+      return { status: 'ignored' };
+    }
+    if (!completed) {
+      d.logger.info('[billing] webhook non-completed status', { ref, rawStatus });
+      return { status: 'ignored' };
+    }
+
+    const result = await d.sequelize.transaction(async (t) => {
+      const payment = await d.Payment.findOne({ where: { id: ref }, transaction: t, lock: t.LOCK.UPDATE });
+      if (!payment) {
+        d.logger.warn('[billing] webhook unknown reference', { ref });
+        return { status: 'unknown_reference' };
+      }
+      if (payment.status === 'paid') {
+        d.logger.info('[billing] webhook.replay', { ref, assignmentId: payment.leadPackageAssignmentId });
+        return { status: 'replay', assignmentId: payment.leadPackageAssignmentId };
+      }
+      if (payment.status !== 'pending') {
+        d.logger.warn('[billing] webhook for non-pending payment', { ref, status: payment.status });
+        return { status: 'not_pending' };
+      }
+
+      // Anti-tamper: grant ONLY when the webhook matches the snapshot we wrote at checkout.
+      // If we stored a providerRequestId, the webhook's MUST exist and match (no fail-open on a
+      // missing webhook id). The rare null-stored case (checkout write-back didn't land) is allowed
+      // — the signed reference (our UUID) + the amount guard still protect it — but logged.
+      let providerOk;
+      if (payment.providerRequestId) {
+        providerOk = String(payment.providerRequestId) === String(providerRequestId ?? '');
+      } else {
+        providerOk = true;
+        d.logger.warn('[billing] fulfilling a payment with no stored providerRequestId', { ref });
+      }
+      const snapCents = toCents(payment.amount);
+      const amountOk = Number.isFinite(snapCents) && toCents(wAmount) === snapCents;
+      const currencyOk = wCurrency === String(payment.currency).toUpperCase();
+      if (!providerOk || !amountOk || !currencyOk) {
+        await payment.update({ status: 'failed', rawWebhook: payload }, { transaction: t });
+        d.logger.error('[billing] amount.mismatch', { ref, providerOk, amountOk, currencyOk, webhookAmount: wAmount, snapshotAmount: payment.amount });
+        return { status: 'rejected' };
+      }
+
+      // Parent (agent/package) deleted between checkout and settlement → can't build the assignment
+      // (NOT NULL FKs). Don't 500 forever: record the money as PAID (truthful) but UNFULFILLED, for
+      // manual review / the Phase-2 reconciliation sweep (paid-without-assignment).
+      if (!payment.agentId || !payment.leadPackageId) {
+        await payment.update(
+          { status: 'paid', providerPaymentId: providerPaymentId ? String(providerPaymentId) : payment.providerPaymentId, rawWebhook: payload },
+          { transaction: t },
+        );
+        d.logger.error('[billing] fulfillment.unfulfillable — paid but agent/package missing; manual review', { ref, agentId: payment.agentId, leadPackageId: payment.leadPackageId });
+        return { status: 'paid_unfulfilled' };
+      }
+
+      const assignment = await d.LeadPackageAssignment.create(
+        {
+          agentId: payment.agentId,
+          leadPackageId: payment.leadPackageId,
+          leadsTotal: payment.leadCount,
+          leadsRemaining: payment.leadCount,
+          priceSnapshot: payment.amount,
+          status: 'active',
+          purchaseDate: new Date(),
+        },
+        { transaction: t },
+      );
+
+      await payment.update(
+        {
+          status: 'paid',
+          providerPaymentId: providerPaymentId ? String(providerPaymentId) : payment.providerPaymentId,
+          leadPackageAssignmentId: assignment.id,
+          rawWebhook: payload,
+        },
+        { transaction: t },
+      );
+
+      d.logger.info('[billing] fulfillment.paid', { ref, agentId: payment.agentId, assignmentId: assignment.id, leadCount: payment.leadCount });
+      return { status: 'fulfilled', assignmentId: assignment.id, leadPackageId: payment.leadPackageId };
+    });
+
+    // Post-commit: new funded package → campaign sweep (no-op today; retained as the re-enable hook).
+    if (result.status === 'fulfilled' && result.leadPackageId) {
+      const pkg = await d.LeadPackage.findByPk(result.leadPackageId, { attributes: ['campaignId'] }).catch(() => null);
+      if (pkg?.campaignId) {
+        import('./releaseSweep.js')
+          .then((m) => m.sweepCampaign(pkg.campaignId))
+          .catch((e) => d.logger.error('[billing] releaseSweep trigger failed', { error: e?.message || String(e) }));
+      }
+    }
+    return result;
+  }
+
+  return { getCatalog, createCheckout, getPurchaseStatus, getHistory, fulfillFromWebhook, checkoutMode };
+}
+
+// --- Backward-compatible named exports (house pattern) ---
+const _default = makeBillingService();
+export const getCatalog = _default.getCatalog;
+export const createCheckout = _default.createCheckout;
+export const getPurchaseStatus = _default.getPurchaseStatus;
+export const getHistory = _default.getHistory;
+export const fulfillFromWebhook = _default.fulfillFromWebhook;

--- a/backend/src/services/hitpayClient.js
+++ b/backend/src/services/hitpayClient.js
@@ -1,0 +1,128 @@
+/**
+ * HitPay provider adapter — the ONLY place that knows HitPay's wire format, so the
+ * exact contract (which is a SANDBOX-CONFIRM item — see below) is a one-file change.
+ * Two operations:
+ *   - createPaymentRequest(): outbound, creates a hosted checkout, returns { id, url }
+ *   - verifyWebhook(): inbound, verifies the settlement webhook and returns the payload
+ *
+ * Env: HITPAY_API_KEY (secret), HITPAY_WEBHOOK_SALT (secret), HITPAY_API_BASE
+ *      (prod https://api.hit-pay.com/v1 · sandbox https://api.sandbox.hit-pay.com/v1),
+ *      HITPAY_PAYMENT_METHODS (default "paynow_online,card").
+ */
+import crypto from 'crypto';
+import { logger } from '../utils/logger.js';
+
+const DEFAULT_BASE = 'https://api.hit-pay.com/v1';
+const DEFAULT_METHODS = 'paynow_online,card';
+
+function apiBase() {
+  return (process.env.HITPAY_API_BASE || DEFAULT_BASE).replace(/\/+$/, '');
+}
+function paymentMethods() {
+  return (process.env.HITPAY_PAYMENT_METHODS || DEFAULT_METHODS)
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function timingSafeHexEq(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string' || a.length !== b.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(a, 'hex'), Buffer.from(b, 'hex'));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Create a HitPay payment request → { id, url }. `referenceNumber` is OUR Payment.id,
+ * so the webhook correlates back to the row we wrote.
+ *
+ * ⚠️ SANDBOX-CONFIRM: HitPay's create contract (form-encoded vs JSON, the exact field
+ * names, `paynow_online` slug, and the response shape) was not doc-verifiable (docs
+ * 403 to automated fetch). Implemented per the documented v1 form-encoded style;
+ * confirm against the HitPay sandbox before go-live.
+ */
+export async function createPaymentRequest({ amount, referenceNumber, name, email, redirectUrl, webhookUrl, purpose }) {
+  const apiKey = process.env.HITPAY_API_KEY;
+  if (!apiKey) throw new Error('HITPAY_API_KEY not configured');
+  if (!(Number(amount) > 0) || !referenceNumber) throw new Error('createPaymentRequest: amount and referenceNumber required');
+
+  const body = new URLSearchParams();
+  body.set('amount', String(amount));
+  body.set('currency', 'SGD');
+  body.set('reference_number', String(referenceNumber));
+  if (purpose) body.set('purpose', String(purpose));
+  if (name) body.set('name', String(name));
+  if (email) body.set('email', String(email));
+  if (redirectUrl) body.set('redirect_url', String(redirectUrl));
+  if (webhookUrl) body.set('webhook', String(webhookUrl));
+  for (const m of paymentMethods()) body.append('payment_methods[]', m);
+
+  let res;
+  try {
+    res = await fetch(`${apiBase()}/payment-requests`, {
+      method: 'POST',
+      headers: {
+        'X-BUSINESS-API-KEY': apiKey,
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+      body,
+    });
+  } catch (err) {
+    logger.error('[hitpay] createPaymentRequest network error', { error: err?.message || String(err) });
+    throw new Error('HitPay request failed (network)');
+  }
+
+  const text = await res.text();
+  let json = null;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    /* non-JSON body */
+  }
+  if (!res.ok || !json?.id || !json?.url) {
+    logger.error('[hitpay] createPaymentRequest failed', { status: res.status, body: text?.slice(0, 500) });
+    throw new Error(`HitPay payment-request failed (${res.status})`);
+  }
+  return { id: String(json.id), url: String(json.url) };
+}
+
+/**
+ * Verify an inbound HitPay webhook. Returns the parsed JSON payload on success, or
+ * null on any failure (bad/absent signature, missing salt, unparseable body).
+ *
+ * ⚠️ SANDBOX-CONFIRM: HitPay has TWO webhook styles and the docs weren't fetchable.
+ * LEGACY per-request scheme (what the `webhook` param we pass to createPaymentRequest triggers,
+ * keyed by the account SALT): an `application/x-www-form-urlencoded` POST with an `hmac` field that
+ * is HMAC-SHA256 over the OTHER fields sorted by key and concatenated as `key1value1key2value2...`,
+ * keyed by HITPAY_WEBHOOK_SALT. The body is the PARSED form (`req.body`, via the global
+ * express.urlencoded) — no rawBody needed. Confirm the exact field set against a real HitPay
+ * webhook before go-live; the verifier is isolated so the scheme is a one-function change.
+ */
+export function verifyWebhook(req) {
+  const salt = process.env.HITPAY_WEBHOOK_SALT;
+  if (!salt) {
+    logger.error('[hitpay] HITPAY_WEBHOOK_SALT not configured');
+    return null;
+  }
+  const body = req?.body;
+  if (!body || typeof body !== 'object' || Array.isArray(body) || typeof body.hmac !== 'string') {
+    logger.error('[hitpay] webhook body missing or unsigned (no hmac field)');
+    return null;
+  }
+  const { hmac, ...fields } = body;
+  const concatenated = Object.keys(fields)
+    .sort()
+    .map((k) => `${k}${fields[k] ?? ''}`)
+    .join('');
+  const expected = crypto.createHmac('sha256', salt).update(concatenated).digest('hex');
+  if (!timingSafeHexEq(hmac, expected)) {
+    logger.warn('[hitpay] webhook signature mismatch');
+    return null;
+  }
+  return fields;
+}
+
+export default { createPaymentRequest, verifyWebhook };

--- a/backend/test/migrations.test.js
+++ b/backend/test/migrations.test.js
@@ -125,6 +125,7 @@ describe('Migration idempotency (requires DB)', () => {
     '016-drop-unused-json-columns.js',
     '017-drop-campaign-metrics-json.js',
     '024-drop-agent-group-json-columns.js',
+    '040-create-payments.js', // createTable + partial unique indexes + post-assertion (financial table)
   ];
 
   for (const file of representativeMigrations) {

--- a/backend/test/unit/billingService.test.js
+++ b/backend/test/unit/billingService.test.js
@@ -1,0 +1,243 @@
+import { jest } from '@jest/globals';
+import '../setup.js';
+import { makeBillingService } from '../../src/services/billingService.js';
+
+/**
+ * Money-path tests for the REAL billingService via the DI factory.
+ * The invariants under test:
+ *   - fulfillment grants from the Payment SNAPSHOT, never the webhook fields;
+ *   - it is idempotent (a paid row replays the existing assignment, no double-grant);
+ *   - an amount/provider-id mismatch is REJECTED (no assignment, payment → failed);
+ *   - checkout validates eligibility + price/currency before taking money.
+ */
+
+function fakePayment(over = {}) {
+  const row = {
+    id: 'pay-1',
+    agentId: 'agent-1',
+    leadPackageId: 'pkg-1',
+    leadCount: 20,
+    amount: '200.00', // DECIMAL → string, as Sequelize returns it
+    currency: 'SGD',
+    providerRequestId: 'hp-req-1',
+    providerPaymentId: null,
+    leadPackageAssignmentId: null,
+    status: 'pending',
+    ...over,
+  };
+  row.update = jest.fn(async (u) => Object.assign(row, u));
+  return row;
+}
+
+function build({
+  agent = null,
+  pkg = null,
+  payment = null,
+  assignment = { id: 'asg-1' },
+  hitpayThrows = false,
+  hitpayResult = { id: 'hp-req-1', url: 'https://hit-pay.com/pay/abc' },
+} = {}) {
+  const createdPayments = [];
+  const Payment = {
+    create: jest.fn(async (attrs) => {
+      const row = { ...attrs, id: attrs.id || 'pay-1', update: jest.fn(async (u) => Object.assign(row, u)) };
+      createdPayments.push(row);
+      return row;
+    }),
+    findOne: jest.fn(async () => payment),
+    findAll: jest.fn(async () => []),
+  };
+  const LeadPackage = { findByPk: jest.fn(async () => pkg) };
+  const LeadPackageAssignment = { create: jest.fn(async () => assignment) };
+  const User = { findOne: jest.fn(async () => agent) };
+  const Campaign = {};
+  const sequelize = { transaction: jest.fn(async (cb) => cb({ LOCK: { UPDATE: 'UPDATE' } })) };
+  const hitpay = {
+    createPaymentRequest: jest.fn(async () => {
+      if (hitpayThrows) throw new Error('hitpay down');
+      return hitpayResult;
+    }),
+  };
+  const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+  const svc = makeBillingService({ Payment, LeadPackage, LeadPackageAssignment, User, Campaign, sequelize, hitpay, logger });
+  return { svc, Payment, LeadPackage, LeadPackageAssignment, User, hitpay, logger, createdPayments };
+}
+
+const activePkg = (over = {}) => ({
+  id: 'pkg-1', name: 'SG Motor — Premium', type: 'premium', status: 'active', isPublic: true,
+  price: '200.00', currency: 'SGD', leadCount: 20, campaign: { name: 'Q3 Motor Switch' }, ...over,
+});
+const okAgent = { id: 'agent-1', firstName: 'A', lastName: 'B', fullName: 'A B', email: 'a@b.co' };
+
+describe('billingService.createCheckout', () => {
+  test('invalid_agent when no synced active agent', async () => {
+    const { svc, hitpay } = build({ agent: null });
+    const r = await svc.createCheckout({ agentMktrUserId: 'm1', packageId: 'pkg-1' });
+    expect(r).toEqual({ status: 'invalid_agent' });
+    expect(hitpay.createPaymentRequest).not.toHaveBeenCalled();
+  });
+
+  test('package_inactive when package missing / not active / not public', async () => {
+    expect((await build({ agent: okAgent, pkg: null }).svc.createCheckout({ agentMktrUserId: 'm1', packageId: 'x' })).status).toBe('package_inactive');
+    expect((await build({ agent: okAgent, pkg: activePkg({ status: 'draft' }) }).svc.createCheckout({ agentMktrUserId: 'm1', packageId: 'x' })).status).toBe('package_inactive');
+    expect((await build({ agent: okAgent, pkg: activePkg({ isPublic: false }) }).svc.createCheckout({ agentMktrUserId: 'm1', packageId: 'x' })).status).toBe('package_inactive');
+  });
+
+  test('package_unpriced when price ≤ 0 or non-SGD', async () => {
+    expect((await build({ agent: okAgent, pkg: activePkg({ price: '0' }) }).svc.createCheckout({ agentMktrUserId: 'm1', packageId: 'x' })).status).toBe('package_unpriced');
+    expect((await build({ agent: okAgent, pkg: activePkg({ currency: 'USD' }) }).svc.createCheckout({ agentMktrUserId: 'm1', packageId: 'x' })).status).toBe('package_unpriced');
+  });
+
+  test('created — Payment pending written, HitPay called with referenceNumber=payment.id', async () => {
+    const { svc, Payment, hitpay, createdPayments } = build({ agent: okAgent, pkg: activePkg() });
+    const r = await svc.createCheckout({ agentMktrUserId: 'm1', packageId: 'pkg-1' });
+    expect(r.status).toBe('created');
+    expect(r.url).toBe('https://hit-pay.com/pay/abc');
+    expect(r.purchaseId).toBe(createdPayments[0].id);
+    // snapshot written
+    expect(Payment.create).toHaveBeenCalledWith(expect.objectContaining({
+      agentId: 'agent-1', leadPackageId: 'pkg-1', amount: 200, currency: 'SGD', leadCount: 20,
+      packageName: 'SG Motor — Premium', campaignName: 'Q3 Motor Switch', status: 'pending', source: 'mktr_leads_app',
+    }));
+    // HitPay reference = our payment id; providerRequestId stamped back
+    expect(hitpay.createPaymentRequest).toHaveBeenCalledWith(expect.objectContaining({ amount: 200, referenceNumber: createdPayments[0].id }));
+    expect(createdPayments[0].update).toHaveBeenCalledWith({ providerRequestId: 'hp-req-1' });
+  });
+
+  test('provider_error marks the pending Payment failed (no dangling pending)', async () => {
+    const { svc, createdPayments } = build({ agent: okAgent, pkg: activePkg(), hitpayThrows: true });
+    const r = await svc.createCheckout({ agentMktrUserId: 'm1', packageId: 'pkg-1' });
+    expect(r.status).toBe('provider_error');
+    expect(createdPayments[0].update).toHaveBeenCalledWith({ status: 'failed' });
+  });
+});
+
+describe('billingService.fulfillFromWebhook', () => {
+  const completed = (over = {}) => ({ reference_number: 'pay-1', payment_request_id: 'hp-req-1', payment_id: 'hp-pay-1', status: 'completed', amount: '200.00', currency: 'SGD', ...over });
+
+  test('ignored when missing reference or not completed', async () => {
+    const { svc } = build();
+    expect((await svc.fulfillFromWebhook({ status: 'completed' })).status).toBe('ignored');
+    expect((await svc.fulfillFromWebhook(completed({ status: 'pending' }))).status).toBe('ignored');
+  });
+
+  test('unknown_reference when no payment row', async () => {
+    const { svc } = build({ payment: null });
+    expect((await svc.fulfillFromWebhook(completed())).status).toBe('unknown_reference');
+  });
+
+  test('fulfilled — creates ONE assignment from the snapshot, links + marks paid', async () => {
+    const payment = fakePayment();
+    const { svc, LeadPackageAssignment, LeadPackage } = build({ payment, assignment: { id: 'asg-9' } });
+    LeadPackage.findByPk.mockResolvedValue({ campaignId: null }); // post-commit sweep lookup → skip
+    const r = await svc.fulfillFromWebhook(completed());
+    expect(r).toMatchObject({ status: 'fulfilled', assignmentId: 'asg-9' });
+    // assignment built from the PAYMENT snapshot (leadCount/amount), not the webhook
+    expect(LeadPackageAssignment.create).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: 'agent-1', leadPackageId: 'pkg-1', leadsTotal: 20, leadsRemaining: 20, priceSnapshot: '200.00', status: 'active' }),
+      expect.anything(),
+    );
+    expect(payment.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'paid', providerPaymentId: 'hp-pay-1', leadPackageAssignmentId: 'asg-9' }),
+      expect.anything(),
+    );
+  });
+
+  test('idempotent replay — an already-paid payment grants NOTHING new', async () => {
+    const payment = fakePayment({ status: 'paid', leadPackageAssignmentId: 'asg-existing' });
+    const { svc, LeadPackageAssignment } = build({ payment });
+    const r = await svc.fulfillFromWebhook(completed());
+    expect(r).toEqual({ status: 'replay', assignmentId: 'asg-existing' });
+    expect(LeadPackageAssignment.create).not.toHaveBeenCalled();
+  });
+
+  test('amount tamper — webhook amount ≠ snapshot → REJECTED, no assignment, payment failed', async () => {
+    const payment = fakePayment();
+    const { svc, LeadPackageAssignment } = build({ payment });
+    const r = await svc.fulfillFromWebhook(completed({ amount: '1.00' }));
+    expect(r.status).toBe('rejected');
+    expect(LeadPackageAssignment.create).not.toHaveBeenCalled();
+    expect(payment.update).toHaveBeenCalledWith(expect.objectContaining({ status: 'failed' }), expect.anything());
+  });
+
+  test('provider-id tamper — webhook payment_request_id ≠ snapshot → REJECTED', async () => {
+    const payment = fakePayment();
+    const { svc, LeadPackageAssignment } = build({ payment });
+    const r = await svc.fulfillFromWebhook(completed({ payment_request_id: 'someone-elses' }));
+    expect(r.status).toBe('rejected');
+    expect(LeadPackageAssignment.create).not.toHaveBeenCalled();
+  });
+
+  test('not_pending — a failed payment is never resurrected', async () => {
+    const payment = fakePayment({ status: 'failed' });
+    const { svc, LeadPackageAssignment } = build({ payment });
+    expect((await svc.fulfillFromWebhook(completed())).status).toBe('not_pending');
+    expect(LeadPackageAssignment.create).not.toHaveBeenCalled();
+  });
+
+  test('strict amount — non-canonical (199.995 / 200.001 / 2e2 / "" / -200) is REJECTED', async () => {
+    for (const bad of ['199.995', '200.001', '2e2', '', '-200.00']) {
+      const payment = fakePayment();
+      const { svc, LeadPackageAssignment } = build({ payment });
+      const r = await svc.fulfillFromWebhook(completed({ amount: bad }));
+      expect(r.status).toBe('rejected');
+      expect(LeadPackageAssignment.create).not.toHaveBeenCalled();
+    }
+  });
+
+  test('strict amount — "200" is the same money as the "200.00" snapshot → fulfils', async () => {
+    const payment = fakePayment();
+    const { svc, LeadPackage } = build({ payment, assignment: { id: 'asg-200' } });
+    LeadPackage.findByPk.mockResolvedValue({ campaignId: null }); // skip post-commit sweep
+    expect((await svc.fulfillFromWebhook(completed({ amount: '200' }))).status).toBe('fulfilled');
+  });
+
+  test('provider guard — payment HAS providerRequestId but webhook omits it → REJECTED (no fail-open)', async () => {
+    const payment = fakePayment(); // providerRequestId: 'hp-req-1'
+    const { svc, LeadPackageAssignment } = build({ payment });
+    const r = await svc.fulfillFromWebhook(completed({ payment_request_id: undefined, payment_id: undefined }));
+    expect(r.status).toBe('rejected');
+    expect(LeadPackageAssignment.create).not.toHaveBeenCalled();
+  });
+
+  test('paid_unfulfilled — agent/package deleted mid-flight → PAID (truthful) but no assignment, durable', async () => {
+    const payment = fakePayment({ agentId: null }); // FK SET NULL on parent delete
+    const { svc, LeadPackageAssignment } = build({ payment });
+    const r = await svc.fulfillFromWebhook(completed());
+    expect(r.status).toBe('paid_unfulfilled');
+    expect(LeadPackageAssignment.create).not.toHaveBeenCalled();
+    expect(payment.update).toHaveBeenCalledWith(expect.objectContaining({ status: 'paid' }), expect.anything());
+  });
+});
+
+describe('billingService status/history/catalog', () => {
+  test('getPurchaseStatus maps internal status + self-scopes by agent', async () => {
+    const payment = { status: 'paid' };
+    const { svc, Payment } = build({ agent: okAgent, payment });
+    const r = await svc.getPurchaseStatus({ agentMktrUserId: 'm1', purchaseId: 'pay-1' });
+    expect(r).toEqual({ status: 'paid' });
+    expect(Payment.findOne).toHaveBeenCalledWith(expect.objectContaining({ where: { id: 'pay-1', agentId: 'agent-1' }, attributes: ['status'] }));
+  });
+
+  test('getPurchaseStatus → failed for unknown agent', async () => {
+    const { svc } = build({ agent: null });
+    expect((await svc.getPurchaseStatus({ agentMktrUserId: 'm1', purchaseId: 'pay-1' })).status).toBe('failed');
+  });
+
+  test('catalog filters to active/public/priced-SGD and exposes checkoutMode', async () => {
+    const { svc, LeadPackage } = build();
+    LeadPackage.findAll = jest.fn(async () => [
+      { id: 'p1', name: 'A', type: 'premium', leadCount: 20, price: '200.00', currency: 'SGD', isPublic: true, campaign: { name: 'C' } },
+      { id: 'p2', name: 'B', type: 'basic', leadCount: 10, price: '0', currency: 'SGD', isPublic: true, campaign: null }, // unpriced → dropped
+      { id: 'p3', name: 'C', type: 'basic', leadCount: 5, price: '90', currency: 'USD', isPublic: true, campaign: null }, // non-SGD → dropped
+    ]);
+    const svc2 = makeBillingService({
+      LeadPackage, Campaign: {}, Payment: {}, LeadPackageAssignment: {}, User: {},
+      sequelize: {}, hitpay: {}, logger: { info() {}, warn() {}, error() {} },
+    });
+    const r = await svc2.getCatalog();
+    expect(r.packages.map((p) => p.id)).toEqual(['p1']);
+    expect(r.packages[0]).toMatchObject({ name: 'A', leadCount: 20, price: 200, currency: 'SGD', campaignName: 'C', isRecommended: false });
+    expect(['in_app', 'web', 'off']).toContain(r.checkoutMode);
+  });
+});

--- a/backend/test/unit/hitpayClient.test.js
+++ b/backend/test/unit/hitpayClient.test.js
@@ -1,0 +1,67 @@
+import '../setup.js';
+import crypto from 'crypto';
+import { verifyWebhook } from '../../src/services/hitpayClient.js';
+
+/**
+ * verifyWebhook is the inbound auth gate for HitPay settlements. LEGACY scheme: the
+ * urlencoded webhook carries an `hmac` field = HMAC-SHA256 over the OTHER fields sorted
+ * by key (concatenated key1value1key2value2…), keyed by HITPAY_WEBHOOK_SALT. Body is the
+ * PARSED form (req.body). These vectors lock the implemented scheme.
+ */
+const SALT = 'test-webhook-salt';
+function sign(fields, salt = SALT) {
+  const concatenated = Object.keys(fields)
+    .sort()
+    .map((k) => `${k}${fields[k] ?? ''}`)
+    .join('');
+  return crypto.createHmac('sha256', salt).update(concatenated).digest('hex');
+}
+const req = (body) => ({ body });
+const FIELDS = {
+  reference_number: 'pay-1',
+  payment_request_id: 'hp-req-1',
+  payment_id: 'hp-pay-1',
+  status: 'completed',
+  amount: '200.00',
+  currency: 'sgd',
+};
+
+describe('hitpayClient.verifyWebhook (legacy salt scheme)', () => {
+  beforeEach(() => {
+    process.env.HITPAY_WEBHOOK_SALT = SALT;
+  });
+  afterEach(() => {
+    delete process.env.HITPAY_WEBHOOK_SALT;
+  });
+
+  test('valid hmac → returns the fields, without hmac', () => {
+    const out = verifyWebhook(req({ ...FIELDS, hmac: sign(FIELDS) }));
+    expect(out).toEqual(FIELDS);
+    expect(out).not.toHaveProperty('hmac');
+  });
+
+  test('tampered field (same hmac) → null', () => {
+    const hmac = sign(FIELDS);
+    expect(verifyWebhook(req({ ...FIELDS, amount: '1.00', hmac }))).toBeNull();
+  });
+
+  test('hmac from a different salt → null', () => {
+    expect(verifyWebhook(req({ ...FIELDS, hmac: sign(FIELDS, 'attacker-salt') }))).toBeNull();
+  });
+
+  test('missing salt config → null', () => {
+    const hmac = sign(FIELDS);
+    delete process.env.HITPAY_WEBHOOK_SALT;
+    expect(verifyWebhook(req({ ...FIELDS, hmac }))).toBeNull();
+  });
+
+  test('no hmac field (unsigned) → null', () => {
+    expect(verifyWebhook(req({ ...FIELDS }))).toBeNull();
+  });
+
+  test('missing / non-object body → null', () => {
+    expect(verifyWebhook({ body: null })).toBeNull();
+    expect(verifyWebhook({})).toBeNull();
+    expect(verifyWebhook({ body: 'nope' })).toBeNull();
+  });
+});


### PR DESCRIPTION
The MKTR backend for agent self-serve lead-package purchase (mktr-leads app first) — HitPay one-time checkout. The MKTR half of the Buy Leads flow.

## What's in it
- `Payment` model + migration `040` (FK ON DELETE SET NULL; partial-unique provider-id + one-assignment-per-payment indexes; strict-failure DDL with a post-assertion).
- `hitpayClient` — `createPaymentRequest` + `verifyWebhook` (legacy salt/urlencoded scheme, isolated for a one-function swap).
- `billingService` — catalog/checkout/status/history + idempotent `fulfillFromWebhook` (row-lock pending→paid, grant from the Payment snapshot only, strict-cents anti-tamper, provider-id guard, paid-but-unfulfillable durable handling).
- `/api/external/billing` routes (HMAC for the agent actions, HitPay-signature for the webhook), gated by `BILLING_ENABLED`, shaped to the app's `lib/store` contract. `.env.example` documented.

## Safety
- **Deploy-inert**: `BILLING_ENABLED` defaults false → routes stay unmounted until enabled. Migration `040` runs on boot (creates `payments`; additive, no impact on existing tables).
- Money path adversarially reviewed by Codex (gpt-5.5 xhigh); must-fixes folded.
- 65 suites / 1236 unit tests pass.

## To activate (post-merge)
Set `HITPAY_*` + `BILLING_ENABLED=true` on Render, deploy the `mktr-agent-store` broker edge fn (mktr-leads), flip `USE_STUB=false` in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)