### PR TITLE
feat(held-leads): full lead detail (DOB + demographics) on the admin held queue

### DIFF
--- a/backend/src/controllers/externalHeldLeadsController.js
+++ b/backend/src/controllers/externalHeldLeadsController.js
@@ -103,6 +103,10 @@ export async function listHeldLeads(req, res) {
       phone: o.phone || null,
       maskedPhone: maskPhone(o.phone),
       email: o.email || null,
+      // Full personal / firmographic detail for the admin lead view (DOB raw → app formats
+      // it; `details` is the ordered display-ready enrichment). Admin-only surface.
+      birthday: o.birthday || null,
+      details: Array.isArray(o.details) ? o.details : [],
       campaignId: o.campaignId,
       campaignName: o.campaignName,
       leadSource: o.leadSource,

--- a/backend/src/services/prospectHelpers.js
+++ b/backend/src/services/prospectHelpers.js
@@ -203,3 +203,64 @@ export function buildLeadHeldPayload(prospect, campaign, reason) {
     }
   };
 }
+
+/** Format a budget object ({ min, max, currency, timeframe }) into one display string, or null. */
+function formatBudget(budget) {
+  if (!budget || typeof budget !== 'object') return null;
+  const { min, max, currency, timeframe } = budget;
+  if (min == null && max == null) return null;
+  const cur = currency ? ` ${currency}` : '';
+  const range =
+    min != null && max != null
+      ? `${min} – ${max}${cur}`
+      : max != null
+        ? `Up to ${max}${cur}`
+        : `From ${min}${cur}`;
+  return timeframe ? `${range} · ${timeframe}` : range;
+}
+
+/**
+ * Derive the held-lead enrichment the admin detail view shows for an orphan prospect —
+ * the SAME personal / firmographic data a delivered lead surfaces, plus the extra
+ * demographics the receiver's note-enrichment happens to drop. Returns:
+ *   { birthday, details }
+ * where `birthday` is the RAW date-of-birth string (the app owns its DD/MM/YYYY
+ * formatting, so birthday formatting lives in exactly one place) and `details` is an
+ * ordered, display-ready [{ label, value }] list of every OTHER populated field.
+ * Campaign / source / email are NOT included here — they are already discrete DTO
+ * fields the queue + detail view render directly.
+ */
+export function buildHeldLeadEnrichment(prospect) {
+  if (!prospect) return { birthday: null, details: [] };
+  const demo = prospect.demographics && typeof prospect.demographics === 'object' ? prospect.demographics : {};
+  const loc = prospect.location && typeof prospect.location === 'object' ? prospect.location : {};
+
+  const birthday = typeof demo.dateOfBirth === 'string' && demo.dateOfBirth.trim() ? demo.dateOfBirth.trim() : null;
+
+  const details = [];
+  const push = (label, value) => {
+    if (value == null) return;
+    const s = String(value).trim();
+    if (s) details.push({ label, value: s });
+  };
+
+  // Personal — birthday is intentionally omitted (carried discretely, formatted app-side).
+  push('Age', demo.age);
+  push('Gender', demo.gender);
+  push('Marital status', demo.maritalStatus);
+  push('Monthly income', demo.income);
+  push('Education', demo.education);
+  // Location
+  push('Postal code', loc.postalCode || loc.zipCode);
+  push('Address', loc.address);
+  // Firmographic
+  push('Company', prospect.company);
+  push('Job title', prospect.jobTitle);
+  push('Industry', prospect.industry);
+  // Intent
+  const interests = Array.isArray(prospect.interests) ? prospect.interests.filter(Boolean) : [];
+  if (interests.length) push('Interests', interests.join(', '));
+  push('Budget', formatBudget(prospect.budget));
+
+  return { birthday, details };
+}

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -36,6 +36,7 @@ import {
   buildLeadHeldPayload,
   buildLeadAssignedPayload,
   buildLeadUnassignedPayload,
+  buildHeldLeadEnrichment,
   destinationForAgent,
   externalIdForDestination,
 } from './prospectHelpers.js';
@@ -1549,23 +1550,33 @@ export function makeProspectService(overrides = {}) {
       limit: lim,
     });
 
-    const orphans = rows.map((p) => ({
-      id: p.id,
-      firstName: p.firstName,
-      lastName: p.lastName,
-      phone: p.phone,
-      email: p.email,
-      leadSource: p.leadSource,
-      // Rich, delivered-lead-equivalent label ("Instagram ad", "Meta ad", "Web form", …)
-      // derived from sourceMetadata.utm — so the held queue reads the same source the lead
-      // will show once assigned, not the coarse capture channel.
-      sourceLabel: signupSourceLabel({ leadSource: p.leadSource, qrTag: p.qrTag, sourceMetadata: p.sourceMetadata }),
-      campaignId: p.campaignId,
-      campaignName: p.campaign?.name || null,
-      reason: p.quarantinedAt ? 'no_funded_agent' : 'unassigned',
-      since: p.quarantinedAt || p.createdAt,
-      createdAt: p.createdAt,
-    }));
+    const orphans = rows.map((p) => {
+      // Full personal / firmographic data the admin detail view shows (DOB, postal,
+      // company, …) — parity with a delivered lead, plus the demographics it drops.
+      const { birthday, details } = buildHeldLeadEnrichment(p);
+      return {
+        id: p.id,
+        firstName: p.firstName,
+        lastName: p.lastName,
+        phone: p.phone,
+        email: p.email,
+        leadSource: p.leadSource,
+        // Rich, delivered-lead-equivalent label ("Instagram ad", "Meta ad", "Web form", …)
+        // derived from sourceMetadata.utm — so the held queue reads the same source the lead
+        // will show once assigned, not the coarse capture channel.
+        sourceLabel: signupSourceLabel({ leadSource: p.leadSource, qrTag: p.qrTag, sourceMetadata: p.sourceMetadata }),
+        // Raw DOB string — the buyer app formats it to DD/MM/YYYY (one formatter, app-side).
+        birthday,
+        // Ordered, display-ready [{ label, value }] enrichment rows (no PII beyond what the
+        // admin-only detail view already shows; never enters the non-PII summary projection).
+        details,
+        campaignId: p.campaignId,
+        campaignName: p.campaign?.name || null,
+        reason: p.quarantinedAt ? 'no_funded_agent' : 'unassigned',
+        since: p.quarantinedAt || p.createdAt,
+        createdAt: p.createdAt,
+      };
+    });
 
     return { count, orphans };
   }

--- a/backend/test/externalHeldLeadsController.test.js
+++ b/backend/test/externalHeldLeadsController.test.js
@@ -80,7 +80,7 @@ describe('externalHeldLeadsController.listHeldLeads', () => {
     orphansMock.mockResolvedValue({
       count: 2,
       orphans: [
-        { id: 'p1', firstName: 'Jane', lastName: 'Doe', phone: '6591234567', email: 'jane@example.com', leadSource: 'meta', campaignId: 'c1', campaignName: 'Cab', reason: 'no_funded_agent', since: 't1', createdAt: 't1' },
+        { id: 'p1', firstName: 'Jane', lastName: 'Doe', phone: '6591234567', email: 'jane@example.com', birthday: '1990-04-12', details: [{ label: 'Postal code', value: '530123' }], leadSource: 'meta', campaignId: 'c1', campaignName: 'Cab', reason: 'no_funded_agent', since: 't1', createdAt: 't1' },
         { id: 'p2', firstName: 'Sam', lastName: 'Lim', phone: '6599999999', leadSource: 'meta', campaignId: 'c1', campaignName: 'Cab', reason: 'unassigned', since: 't2', createdAt: 't2' },
       ],
     });
@@ -97,13 +97,17 @@ describe('externalHeldLeadsController.listHeldLeads', () => {
     // Full PII is now returned ADDITIVELY (admin-only surface) alongside the masked fields.
     expect(a).toMatchObject({ lastName: 'Doe', phone: '6591234567', email: 'jane@example.com' });
     expect(a.maskedPhone).toBe('••••4567'); // masked field retained for back-compat
+    // Full personal / firmographic detail flows through for the admin lead view.
+    expect(a).toMatchObject({ birthday: '1990-04-12', details: [{ label: 'Postal code', value: '530123' }] });
+    // An orphan without enrichment degrades to safe empties (never undefined).
+    expect(b).toMatchObject({ birthday: null, details: [] });
   });
 
   it('summary mode returns ids + campaign + since ONLY (no PII enters the sweep path)', async () => {
     orphansMock.mockResolvedValue({
       count: 1,
       orphans: [
-        { id: 'p1', firstName: 'Jane', lastName: 'Doe', phone: '6591234567', email: 'jane@example.com', leadSource: 'meta', campaignId: 'c1', campaignName: 'Cab', reason: 'no_funded_agent', since: 't1', createdAt: 't1' },
+        { id: 'p1', firstName: 'Jane', lastName: 'Doe', phone: '6591234567', email: 'jane@example.com', birthday: '1990-04-12', details: [{ label: 'Postal code', value: '530123' }], leadSource: 'meta', campaignId: 'c1', campaignName: 'Cab', reason: 'no_funded_agent', since: 't1', createdAt: 't1' },
       ],
     });
     const req = makeReq({ timestamp: new Date().toISOString(), summary: true });
@@ -112,6 +116,7 @@ describe('externalHeldLeadsController.listHeldLeads', () => {
 
     expect(res.body.count).toBe(1);
     const [a] = res.body.held;
+    // toEqual (exact) proves the personal enrichment (birthday/details) is stripped too.
     expect(a).toEqual({ id: 'p1', campaignName: 'Cab', since: 't1' });
     // The cron sweep must never receive lead PII.
     expect(a.firstName).toBeUndefined();

--- a/backend/test/unit/prospectHelpers.test.js
+++ b/backend/test/unit/prospectHelpers.test.js
@@ -5,6 +5,7 @@ import {
   buildLeadAssignedPayload,
   buildLeadUnassignedPayload,
   buildLeadHeldPayload,
+  buildHeldLeadEnrichment,
 } from '../../src/services/prospectHelpers.js';
 
 describe('prospectHelpers', () => {
@@ -334,6 +335,63 @@ describe('prospectHelpers', () => {
       const payload = buildLeadHeldPayload(prospect, campaign, 'no_funded_agent');
       expect(new Date(payload.timestamp).toISOString()).toBe(payload.timestamp);
       expect(new Date(payload.data.heldAt).toISOString()).toBe(payload.data.heldAt);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // buildHeldLeadEnrichment
+  // ──────────────────────────────────────────────
+  describe('buildHeldLeadEnrichment', () => {
+    it('returns the RAW birthday plus an ordered, display-ready details list', () => {
+      const { birthday, details } = buildHeldLeadEnrichment({
+        demographics: { dateOfBirth: '1990-04-12', age: 35, gender: 'Female', maritalStatus: 'Married', income: '$5,000', education: "Bachelor's" },
+        location: { postalCode: '530123', address: '1 Marina Blvd' },
+        company: 'Acme Pte Ltd',
+        jobTitle: 'Director',
+        industry: 'F&B',
+        interests: ['Savings', 'Protection'],
+        budget: { min: 200, max: 500, currency: 'SGD', timeframe: 'monthly' },
+      });
+      // Birthday is carried raw — the app owns DD/MM/YYYY formatting.
+      expect(birthday).toBe('1990-04-12');
+      // …and is NOT duplicated inside details.
+      expect(details.find((r) => /birth/i.test(r.label))).toBeUndefined();
+      expect(details).toEqual([
+        { label: 'Age', value: '35' },
+        { label: 'Gender', value: 'Female' },
+        { label: 'Marital status', value: 'Married' },
+        { label: 'Monthly income', value: '$5,000' },
+        { label: 'Education', value: "Bachelor's" },
+        { label: 'Postal code', value: '530123' },
+        { label: 'Address', value: '1 Marina Blvd' },
+        { label: 'Company', value: 'Acme Pte Ltd' },
+        { label: 'Job title', value: 'Director' },
+        { label: 'Industry', value: 'F&B' },
+        { label: 'Interests', value: 'Savings, Protection' },
+        { label: 'Budget', value: '200 – 500 SGD · monthly' },
+      ]);
+    });
+
+    it('falls back to location.zipCode for postal and omits empty / default fields', () => {
+      const { birthday, details } = buildHeldLeadEnrichment({
+        demographics: { age: null, gender: '', dateOfBirth: '' },
+        location: { zipCode: '049315', address: '' },
+        company: '  ',
+        interests: [],
+        budget: { min: null, max: null, currency: 'USD', timeframe: '' },
+      });
+      expect(birthday).toBeNull(); // blank DOB → null, never ''
+      expect(details).toEqual([{ label: 'Postal code', value: '049315' }]);
+    });
+
+    it('formats an open-ended budget and trims whitespace into omission', () => {
+      const { details } = buildHeldLeadEnrichment({ budget: { max: 1000, currency: 'SGD' } });
+      expect(details).toEqual([{ label: 'Budget', value: 'Up to 1000 SGD' }]);
+    });
+
+    it('returns a safe empty shape for a null / empty prospect', () => {
+      expect(buildHeldLeadEnrichment(null)).toEqual({ birthday: null, details: [] });
+      expect(buildHeldLeadEnrichment({})).toEqual({ birthday: null, details: [] });
     });
   });
 });


### PR DESCRIPTION
## What
Enriches the admin **held / pending-assignment** lead DTO so the admin can see the **full** lead data (DOB etc.), matching what a delivered lead shows — plus the demographics the receiver's note-enrichment drops.

- `buildHeldLeadEnrichment(prospect)` (prospectHelpers.js) → `{ birthday, details }`. Birthday stays **raw** (the buyer app formats it to DD/MM/YYYY in one place); `details` is an ordered, display-ready `[{label,value}]` list (age, gender, marital status, income, education, postal code, address, company, job title, industry, interests, budget).
- `listDispatchableOrphans` attaches them; `externalHeldLeadsController` surfaces `birthday` + `details` on the **admin-only list DTO only** — never the non-PII summary/sweep projection.

## Safety
- Purely **additive**: existing fields, phone masking, and the safety-net sweep path are unchanged.
- The broker EF passes the list response through verbatim, so no edge-function change is needed.

## Tests
- `prospectHelpers.test.js`: new `buildHeldLeadEnrichment` block (ordering, raw birthday excluded from details, zipCode fallback, budget formatting, empty/null prospect).
- `externalHeldLeadsController.test.js`: asserts `birthday`/`details` pass-through **and** that the summary projection strips them.
- Full unit run: 49 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)