### PR TITLE
feat(lead-timeline): MKTR ProspectActivity endpoint + bulk-assign logging

### DIFF
--- a/backend/src/controllers/externalLeadActivitiesController.js
+++ b/backend/src/controllers/externalLeadActivitiesController.js
@@ -1,0 +1,82 @@
+/**
+ * @file externalLeadActivitiesController — a lead's MKTR ProspectActivity history for the
+ * mktr-leads app's unified timeline (the admin held detail merges this with the lead's
+ * Supabase lead_activities).
+ *
+ * ── Endpoint (mounted at /api/external/lead-activities) ──────────────────────
+ *   POST /   { prospectId } → { success, count, activities: [{ id, type, description,
+ *                              actorUserId, metadata, createdAt }] } (oldest-first)
+ *
+ * ── Auth ────────────────────────────────────────────────────────────────────
+ * HMAC-SHA256 over the RAW BODY using EXTERNAL_APP_SECRET — the SAME scheme as
+ * /api/external/held-leads + /api/external/lead-outcomes (header
+ * `X-Webhook-Signature: sha256=<hex>`, freshness on the signed body `timestamp`, ±5min).
+ * The mktr-leads broker EF (admin-JWT gated, holds the secret) is the only caller.
+ * Gated behind LEAD_TIMELINE_EXTERNAL_ENABLED so the route stays unmounted until provisioned.
+ */
+
+import crypto from 'crypto';
+import { logger } from '../utils/logger.js';
+import { getProspectActivities } from '../services/prospectService.js';
+
+const MAX_AGE_MS = 5 * 60 * 1000;
+const MAX_FUTURE_MS = 2 * 60 * 1000; // tolerate clock skew
+const MAX_BODY_BYTES = 64 * 1024;
+
+function timingSafeHexEq(receivedHex, expectedHex) {
+  if (typeof receivedHex !== 'string' || typeof expectedHex !== 'string') return false;
+  if (receivedHex.length !== expectedHex.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(receivedHex, 'hex'), Buffer.from(expectedHex, 'hex'));
+  } catch {
+    return false;
+  }
+}
+
+/** Verify HMAC + freshness. Returns null on success, or { code, error } to send. */
+function verifyExternalHmac(req) {
+  const secret = process.env.EXTERNAL_APP_SECRET;
+  if (!secret) {
+    logger.error('[external-lead-activities] EXTERNAL_APP_SECRET not configured');
+    return { code: 500, error: 'Server misconfigured' };
+  }
+  if (!req.rawBody || !Buffer.isBuffer(req.rawBody)) {
+    logger.error('[external-lead-activities] req.rawBody missing — verify hook not wired for this path');
+    return { code: 500, error: 'Server misconfigured' };
+  }
+  if (req.rawBody.length > MAX_BODY_BYTES) return { code: 413, error: 'Payload too large' };
+
+  const sigHeader = req.headers['x-webhook-signature'] || '';
+  if (typeof sigHeader !== 'string' || !sigHeader.startsWith('sha256=')) {
+    return { code: 401, error: 'Unauthorized' };
+  }
+  const expectedHex = crypto.createHmac('sha256', secret).update(req.rawBody).digest('hex');
+  if (!timingSafeHexEq(sigHeader.slice(7), expectedHex)) {
+    return { code: 401, error: 'Unauthorized' };
+  }
+
+  const tsMs = typeof req.body?.timestamp === 'string' ? Date.parse(req.body.timestamp) : NaN;
+  if (Number.isNaN(tsMs)) return { code: 401, error: 'Unauthorized' };
+  const ageMs = Date.now() - tsMs;
+  if (ageMs > MAX_AGE_MS || ageMs < -MAX_FUTURE_MS) return { code: 401, error: 'Unauthorized' };
+
+  return null;
+}
+
+export async function listLeadActivities(req, res) {
+  const authErr = verifyExternalHmac(req);
+  if (authErr) return res.status(authErr.code).json({ success: false, error: authErr.error });
+
+  const { prospectId } = req.body || {};
+  if (!prospectId || typeof prospectId !== 'string') {
+    return res.status(400).json({ success: false, error: 'prospectId is required' });
+  }
+
+  try {
+    const activities = await getProspectActivities(prospectId);
+    return res.json({ success: true, count: activities.length, activities });
+  } catch (err) {
+    logger.error('[external-lead-activities] list failed', { error: err?.message || String(err) });
+    return res.status(500).json({ success: false, error: 'Failed to list lead activities' });
+  }
+}

--- a/backend/src/routes/externalLeadActivities.js
+++ b/backend/src/routes/externalLeadActivities.js
@@ -1,0 +1,22 @@
+/**
+ * MKTR Leads (external buyer app) → a lead's MKTR activity history.
+ *
+ * Mounted at `/api/external/lead-activities`. Auth is HMAC-SHA256 over the raw body
+ * (EXTERNAL_APP_SECRET) — see externalLeadActivitiesController. rawBody capture + the
+ * rate-limiter exemption for `/api/external/` are wired in server_internal.js, same as
+ * /api/external/held-leads.
+ *
+ * Gated behind LEAD_TIMELINE_EXTERNAL_ENABLED so the route stays UNMOUNTED until the
+ * mktr-leads broker edge function is provisioned (deploy-inert).
+ */
+import express from 'express';
+import { listLeadActivities } from '../controllers/externalLeadActivitiesController.js';
+
+const router = express.Router();
+
+export const meta = { path: '/api/external/lead-activities', flag: 'LEAD_TIMELINE_EXTERNAL_ENABLED', flagDefault: 'false' };
+
+// POST so the body carries the signed `timestamp` the HMAC freshness check reads.
+router.post('/', listLeadActivities);
+
+export default router;

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -1241,6 +1241,29 @@ export function makeProspectService(overrides = {}) {
           }
         }
       }
+
+      // Log a ProspectActivity per newly-assigned lead so BULK assignment lands on the unified
+      // timeline too — single-assign already logs (assignProspect), this path historically wrote
+      // none, so bulk-assigned leads were missing their "assigned" event. Best-effort (post-commit,
+      // like the credit deduction above) — never fail the assignment over an audit-row write.
+      await m.ProspectActivity.bulkCreate(
+        full.map((p) => {
+          const prevId = lockedById.get(p.id)?.assignedAgentId;
+          return {
+            prospectId: p.id,
+            type: 'assigned',
+            actorUserId: user?.id || null,
+            description: `Assigned to ${agent.firstName} ${agent.lastName}`.trim(),
+            // Flag a reassignment (a prior owner existed) as a BOOLEAN so the timeline renders
+            // 'reassigned' — never expose who held it before.
+            metadata: {
+              assignedAgentId: agent.id,
+              via: 'bulk_assign',
+              ...(prevId && prevId !== agentId ? { reassigned: true } : {}),
+            },
+          };
+        })
+      ).catch((err) => d.logger.error('Failed to log bulk-assign activity', { error: err?.message || String(err) }));
     }
 
     return { affectedCount, agent };
@@ -1919,6 +1942,29 @@ export function makeProspectService(overrides = {}) {
     return result;
   }
 
+  /**
+   * All ProspectActivity rows for a prospect (oldest-first), with actorUserId explicitly
+   * selected (the getProspect include omits it). Read-only; powers the external lead-timeline
+   * endpoint that feeds the mktr-leads held detail's merged history.
+   */
+  async function getProspectActivities(prospectId, { limit = 200 } = {}) {
+    if (!prospectId) return [];
+    const rows = await m.ProspectActivity.findAll({
+      where: { prospectId },
+      attributes: ['id', 'type', 'description', 'actorUserId', 'metadata', 'createdAt'],
+      order: [['createdAt', 'ASC']],
+      limit: Math.min(parseInt(limit, 10) || 200, 500),
+    });
+    return rows.map((a) => ({
+      id: a.id,
+      type: a.type,
+      description: a.description,
+      actorUserId: a.actorUserId,
+      metadata: a.metadata,
+      createdAt: a.createdAt,
+    }));
+  }
+
   return {
     createProspect,
     getProspect,
@@ -1929,6 +1975,7 @@ export function makeProspectService(overrides = {}) {
     reassignProspectExternal,
     returnProspectToHeld,
     listDispatchableOrphans,
+    getProspectActivities,
     bulkAssignProspects,
     getProspectStats,
     listProspects,
@@ -1948,6 +1995,7 @@ export const releaseHeldProspect = _default.releaseHeldProspect;
 export const reassignProspectExternal = _default.reassignProspectExternal;
 export const returnProspectToHeld = _default.returnProspectToHeld;
 export const listDispatchableOrphans = _default.listDispatchableOrphans;
+export const getProspectActivities = _default.getProspectActivities;
 export const bulkAssignProspects = _default.bulkAssignProspects;
 export const getProspectStats = _default.getProspectStats;
 export const listProspects = _default.listProspects;

--- a/backend/test/externalLeadActivitiesController.test.js
+++ b/backend/test/externalLeadActivitiesController.test.js
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for the external (MKTR Leads) lead-activities controller — HMAC (body-only)
+ * auth + freshness, prospectId validation, and the activities pass-through. prospectService
+ * + logger are mocked; handlers are driven with hand-built req/res (no DB), the way
+ * req.rawBody is set by the /api/external/ verify hook in prod.
+ */
+import { jest } from '@jest/globals';
+import crypto from 'crypto';
+
+const SECRET = 'test-external-app-secret';
+const activitiesMock = jest.fn();
+
+jest.unstable_mockModule('../src/services/prospectService.js', () => ({
+  getProspectActivities: activitiesMock,
+}));
+jest.unstable_mockModule('../src/utils/logger.js', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+let listLeadActivities;
+
+beforeAll(async () => {
+  ({ listLeadActivities } = await import('../src/controllers/externalLeadActivitiesController.js'));
+});
+
+beforeEach(() => {
+  process.env.EXTERNAL_APP_SECRET = SECRET;
+  activitiesMock.mockReset();
+});
+
+function makeRes() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.body = payload; return this; },
+  };
+}
+
+function makeReq(bodyObj, { secret = SECRET, signOverride } = {}) {
+  const raw = Buffer.from(JSON.stringify(bodyObj));
+  const sig = signOverride ?? crypto.createHmac('sha256', secret).update(raw).digest('hex');
+  return { rawBody: raw, body: bodyObj, headers: { 'x-webhook-signature': `sha256=${sig}` } };
+}
+
+describe('externalLeadActivitiesController.listLeadActivities', () => {
+  it('rejects a bad signature with 401', async () => {
+    const req = makeReq({ timestamp: new Date().toISOString(), prospectId: 'p1' }, { signOverride: 'sha256=deadbeef' });
+    const res = makeRes();
+    await listLeadActivities(req, res);
+    expect(res.statusCode).toBe(401);
+    expect(activitiesMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a stale timestamp with 401', async () => {
+    const req = makeReq({ timestamp: new Date(Date.now() - 10 * 60 * 1000).toISOString(), prospectId: 'p1' });
+    const res = makeRes();
+    await listLeadActivities(req, res);
+    expect(res.statusCode).toBe(401);
+    expect(activitiesMock).not.toHaveBeenCalled();
+  });
+
+  it('400s when prospectId is missing', async () => {
+    const req = makeReq({ timestamp: new Date().toISOString() });
+    const res = makeRes();
+    await listLeadActivities(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(activitiesMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the prospect activities on a valid signed request', async () => {
+    activitiesMock.mockResolvedValue([
+      { id: 'a1', type: 'created', description: 'Signed up via Instagram ad', actorUserId: null, metadata: {}, createdAt: 't1' },
+      { id: 'a2', type: 'updated', description: 'Held — no funded agent', actorUserId: null, metadata: { quarantined: true }, createdAt: 't2' },
+    ]);
+    const req = makeReq({ timestamp: new Date().toISOString(), prospectId: 'p1' });
+    const res = makeRes();
+    await listLeadActivities(req, res);
+
+    expect(activitiesMock).toHaveBeenCalledWith('p1');
+    expect(res.statusCode).toBe(null); // res.json without status() → 200 default
+    expect(res.body).toMatchObject({ success: true, count: 2 });
+    expect(res.body.activities[0]).toMatchObject({ id: 'a1', type: 'created' });
+    expect(res.body.activities[1]).toMatchObject({ id: 'a2', type: 'updated' });
+  });
+
+  it('500s when the secret is not configured', async () => {
+    delete process.env.EXTERNAL_APP_SECRET;
+    const req = makeReq({ timestamp: new Date().toISOString(), prospectId: 'p1' });
+    const res = makeRes();
+    await listLeadActivities(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+});

--- a/backend/test/unit/prospectAssignment.test.js
+++ b/backend/test/unit/prospectAssignment.test.js
@@ -83,7 +83,7 @@ function buildMocks() {
 
   const Commission = { create: jest.fn().mockResolvedValue({}) };
   const Attribution = { findOne: jest.fn().mockResolvedValue(null) };
-  const ProspectActivity = { create: jest.fn().mockResolvedValue({}) };
+  const ProspectActivity = { create: jest.fn().mockResolvedValue({}), bulkCreate: jest.fn().mockResolvedValue([]) };
   const AgentGroup = { findByPk: jest.fn().mockResolvedValue(null) };
   const AgentGroupMember = { findAll: jest.fn().mockResolvedValue([]) };
 
@@ -446,6 +446,24 @@ describe('prospectAssignment (unit)', () => {
       const assignedCalls = mocks.dispatchEvent.mock.calls.filter((c) => c[0] === 'lead.assigned');
       expect(assignedCalls).toHaveLength(2);
       expect(mocks.dispatchEvent).toHaveBeenCalledWith('lead.assigned', expect.any(Function), expect.objectContaining({ destination: 'lyfe' }));
+    });
+
+    it('logs a ProspectActivity per bulk-assigned lead (so bulk assignment is on the timeline)', async () => {
+      mocks.models.Prospect.findAll.mockResolvedValue([
+        { id: 'p-1', firstName: 'A', assignedAgentId: null, campaignId: 'camp-1', campaign: mocks.mockCampaign },
+        { id: 'p-2', firstName: 'B', assignedAgentId: null, campaignId: 'camp-1', campaign: mocks.mockCampaign },
+      ]);
+      mocks.models.Prospect.update.mockResolvedValue([2, [
+        { id: 'p-1', campaignId: 'camp-1' },
+        { id: 'p-2', campaignId: 'camp-1' },
+      ]]);
+
+      await service.bulkAssignProspects(['p-1', 'p-2'], 'agent-1', admin);
+
+      expect(mocks.models.ProspectActivity.bulkCreate).toHaveBeenCalledTimes(1);
+      const rows = mocks.models.ProspectActivity.bulkCreate.mock.calls[0][0];
+      expect(rows).toHaveLength(2);
+      expect(rows[0]).toMatchObject({ prospectId: 'p-1', type: 'assigned', metadata: { via: 'bulk_assign' } });
     });
 
     it('deducts lead credits per campaign from the RETURNING rows', async () => {


### PR DESCRIPTION
## What
Backend half of the **unified lead timeline** (Phase 1 — app surfaces). Lets the mktr-leads admin **held detail** show a lead's full MKTR lifecycle history.

- **New** `POST /api/external/lead-activities` (HMAC over raw body, same scheme as `/api/external/held-leads`; flag `LEAD_TIMELINE_EXTERNAL_ENABLED`, default off → unmounted until provisioned). Returns a prospect's `ProspectActivity[]` (`id,type,description,actorUserId,metadata,createdAt`, oldest-first). Consumed by the new `mktr-lead-timeline` broker EF.
- `getProspectActivities()` in `prospectService` — explicit `actorUserId` select (the `getProspect` include omits it).
- `bulkAssignProspects` now writes a `ProspectActivity` per assigned lead (it fired webhooks but logged **no** activity → bulk-assigned leads were missing their "assigned" event). Reassignment flagged as a **boolean** only (no prior-owner id exposed).

## Safety
- Purely additive; flag-gated off by default (deploy-inert until `LEAD_TIMELINE_EXTERNAL_ENABLED=true` + the EF is provisioned).
- Bulk-assign logging is post-commit best-effort (mirrors the credit-deduction pattern) — never fails the assignment.

## Tests
- `externalLeadActivitiesController.test.js` (HMAC reject/stale/missing-id/success/misconfig).
- `prospectAssignment.test.js` extended: bulk-assign now logs `ProspectActivity` per lead.
- Touched suites: 44 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)