### PR TITLE
feat(web-timeline): unified Activity Timeline on mktr.sg (Phase 2)

### DIFF
--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -40,6 +40,7 @@ import {
   destinationForAgent,
   externalIdForDestination,
 } from './prospectHelpers.js';
+import { fetchLeadActivitiesFromSupabase, mergeProspectTimeline } from './webLeadTimelineService.js';
 import { scoreQuiz } from './quizScoringService.js';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -866,9 +867,28 @@ export function makeProspectService(overrides = {}) {
     // Admin-only: cross-campaign repeat-signup visibility (flag, not block).
     // Omitted entirely for non-admins (this endpoint is shared with the agent
     // detail modal). Resilient — a failed enrichment never breaks the view.
+    // Admin-only enrichments. The unified `timeline` merges the agent-engagement half (Supabase
+    // lead_activities) with this prospect's ProspectActivity so the web Activity Timeline matches
+    // the mktr-leads app. ADMIN-GATED on purpose: the engagement is the external buyer's private
+    // notes, which must not surface to a non-admin web user (agents can open the same detail modal).
+    // Gated additionally on the export-EF URL (deploy-inert until set). Run in PARALLEL with the
+    // repeat-signup lookup so neither blocks the other; both are resilient (a miss never breaks the
+    // view, and the timeline degrades to ProspectActivity-only on a Supabase miss).
     if (user?.role === 'admin') {
-      const repeatSignup = await repeatSignupDetail(d.sequelize, { phone: prospect.phone, email: prospect.email }).catch(() => null);
+      const wantTimeline = !!process.env.SUPABASE_LEAD_ACTIVITIES_URL;
+      const [repeatSignup, timelineFetch] = await Promise.all([
+        repeatSignupDetail(d.sequelize, { phone: prospect.phone, email: prospect.email }).catch(() => null),
+        wantTimeline
+          ? fetchLeadActivitiesFromSupabase(prospect.id).catch(() => ({ rows: [], ok: false }))
+          : Promise.resolve(null),
+      ]);
       if (repeatSignup) prospect.setDataValue('repeatSignup', repeatSignup);
+      if (timelineFetch) {
+        prospect.setDataValue(
+          'timeline',
+          mergeProspectTimeline(prospect.activities || [], timelineFetch.rows, { ok: timelineFetch.ok }),
+        );
+      }
     }
 
     return prospect;

--- a/backend/src/services/webLeadTimelineService.js
+++ b/backend/src/services/webLeadTimelineService.js
@@ -1,0 +1,82 @@
+/**
+ * Web unified-timeline helpers (Phase 2). Lets the mktr.sg web Activity Timeline show the SAME
+ * merged history as the mktr-leads app: MKTR ProspectActivity (lifecycle) + the lead's Supabase
+ * lead_activities (agent engagement), deduped across the cross-mirror tags.
+ *
+ * The merge mirrors the mktr-leads `mktr-lead-timeline` edge function, but in the OTHER direction —
+ * here the MKTR backend pulls the Supabase half (via the mktr-lead-activities-export EF) and merges.
+ * The web normalises each tagged row client-side (src/utils/leadTimeline.js), same canonical model.
+ */
+import crypto from 'crypto';
+
+/**
+ * Fetch a lead's Supabase lead_activities via the HMAC-authed export EF. Never throws — a miss
+ * (no URL, timeout, non-2xx) returns `{ rows: [], ok: false }` so the caller degrades to
+ * ProspectActivity-only. `ok` gates the cross-mirror dedup (only dedup when BOTH stores answered).
+ */
+export async function fetchLeadActivitiesFromSupabase(externalId, { timeoutMs = 2500 } = {}) {
+  const url = process.env.SUPABASE_LEAD_ACTIVITIES_URL;
+  const secret = process.env.EXTERNAL_APP_SECRET;
+  if (!url || !secret || !externalId) return { rows: [], ok: false };
+
+  const payload = JSON.stringify({ timestamp: new Date().toISOString(), externalId });
+  const signature = crypto.createHmac('sha256', secret).update(payload).digest('hex');
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Webhook-Signature': `sha256=${signature}` },
+      body: payload,
+      signal: controller.signal,
+    });
+    if (!resp.ok) return { rows: [], ok: false };
+    const body = await resp.json().catch(() => ({}));
+    // Only treat it as "Supabase answered" when we actually got the array — a non-2xx (incl. the
+    // EF's 500 on a query error) or a malformed body keeps ok=false so dedup never drops MKTR rows.
+    if (!Array.isArray(body.activities)) return { rows: [], ok: false };
+    return { rows: body.activities, ok: true };
+  } catch {
+    return { rows: [], ok: false };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const tsOf = (x) => {
+  const v = x.origin === 'mktr' ? x.row.createdAt : x.row.created_at;
+  const t = Date.parse(v);
+  return Number.isNaN(t) ? 0 : t;
+};
+
+/**
+ * Merge ProspectActivity (lifecycle) + lead_activities (engagement) into ONE newest-first list of
+ * `{ origin, row }`. Dedup the cross-mirror rows on BOTH sides — but ONLY when the Supabase half
+ * actually answered (`ok`); on a miss, keep all ProspectActivity (incl. its outcome mirrors) so the
+ * web never loses lifecycle. id tie-break for cross-DB clock ties.
+ */
+export function mergeProspectTimeline(prospectActivities, leadActivities, { ok = true } = {}) {
+  const mktr = (prospectActivities || []).map((a) => ({
+    id: a.id,
+    type: a.type,
+    description: a.description ?? null,
+    actorUserId: a.actorUserId ?? null,
+    metadata: a.metadata ?? null,
+    createdAt: a.createdAt,
+  }));
+  const app = (leadActivities || []).map((a) => ({
+    id: a.id,
+    type: a.type,
+    description: a.description ?? null,
+    metadata: a.metadata ?? null,
+    created_at: a.created_at,
+  }));
+
+  const mktrRows = ok ? mktr.filter((r) => r.metadata?.source !== 'mktr-leads') : mktr;
+  const appRows = ok ? app.filter((r) => r.metadata?.source !== 'mktr') : app;
+
+  return [
+    ...mktrRows.map((row) => ({ origin: 'mktr', row })),
+    ...appRows.map((row) => ({ origin: 'app', row })),
+  ].sort((a, b) => tsOf(b) - tsOf(a) || String(b.row.id).localeCompare(String(a.row.id)));
+}

--- a/backend/test/unit/webLeadTimelineService.test.js
+++ b/backend/test/unit/webLeadTimelineService.test.js
@@ -1,0 +1,44 @@
+/**
+ * Unit tests for the web unified-timeline merge (Phase 2). mergeProspectTimeline is pure —
+ * it dedups the cross-mirror rows (both directions) ONLY when the Supabase half answered, and
+ * sorts newest-first with a deterministic id tie-break.
+ */
+import { mergeProspectTimeline } from '../../src/services/webLeadTimelineService.js';
+
+const mktr = [
+  { id: 'm1', type: 'created', description: 'Signed up', metadata: {}, createdAt: '2026-06-28T08:00:00Z' },
+  // app→MKTR outcome mirror (tagged source='mktr-leads') — a dup of the app's own status/won row.
+  { id: 'm2', type: 'updated', description: 'Marked won', metadata: { source: 'mktr-leads' }, createdAt: '2026-06-28T11:00:00Z' },
+];
+const app = [
+  { id: 'a1', type: 'call', description: 'Spoke', metadata: { outcome: 'Interested' }, created_at: '2026-06-28T09:00:00Z' },
+  // MKTR→app mirror (tagged source='mktr') — a dup of MKTR's own created/assigned row.
+  { id: 'a2', type: 'created', description: 'Lead received from MKTR', metadata: { source: 'mktr' }, created_at: '2026-06-28T08:00:01Z' },
+];
+
+describe('mergeProspectTimeline', () => {
+  it('dedups BOTH cross-mirror directions and sorts newest-first when both stores answered', () => {
+    const merged = mergeProspectTimeline(mktr, app, { ok: true });
+    // m2 (source=mktr-leads) + a2 (source=mktr) dropped → engagement call + MKTR created remain.
+    expect(merged.map((x) => [x.origin, x.row.id])).toEqual([
+      ['app', 'a1'], // 09:00
+      ['mktr', 'm1'], // 08:00
+    ]);
+  });
+
+  it('keeps ALL ProspectActivity (incl. outcome mirrors) when the Supabase half missed (degrade)', () => {
+    const merged = mergeProspectTimeline(mktr, [], { ok: false });
+    expect(merged.map((x) => x.row.id)).toEqual(['m2', 'm1']); // both kept, newest-first
+  });
+
+  it('breaks same-instant cross-DB ties deterministically by id', () => {
+    const a = [{ id: 'aa', type: 'note', metadata: {}, created_at: '2026-06-28T10:00:00Z' }];
+    const m = [{ id: 'zz', type: 'viewed', metadata: {}, createdAt: '2026-06-28T10:00:00Z' }];
+    expect(mergeProspectTimeline(m, a, { ok: true }).map((x) => x.row.id)).toEqual(['zz', 'aa']);
+  });
+
+  it('tolerates empty / nullish inputs', () => {
+    expect(mergeProspectTimeline(null, null, {})).toEqual([]);
+    expect(mergeProspectTimeline([], [], { ok: true })).toEqual([]);
+  });
+});

--- a/src/components/prospects/details/ActivityTimeline.jsx
+++ b/src/components/prospects/details/ActivityTimeline.jsx
@@ -1,75 +1,113 @@
-import { format } from"date-fns";
-import { Clock, User, FileText, CheckCircle2, Edit2 } from"lucide-react";
+import { format } from "date-fns";
+import {
+  CheckCircle2,
+  UserPlus,
+  RefreshCw,
+  Undo2,
+  Hourglass,
+  Phone,
+  MessageCircle,
+  Users,
+  Mail,
+  FileText,
+  Flag,
+  Trophy,
+  AlertCircle,
+  Archive,
+  ArchiveRestore,
+  Trash2,
+  UserX,
+  Eye,
+  Circle,
+  Clock,
+} from "lucide-react";
+import { buildTimeline } from "@/utils/leadTimeline";
+
+// Canonical kind → icon + tint. SAME vocabulary as the mktr-leads app (lib/leadMeta), rendered
+// with lucide (the app uses Ionicons) so the two surfaces read the same.
+const KIND_META = {
+  lead_created: { Icon: CheckCircle2, color: "text-success" },
+  assigned: { Icon: UserPlus, color: "text-plum" },
+  reassigned: { Icon: RefreshCw, color: "text-plum" },
+  returned: { Icon: Undo2, color: "text-amber-500" },
+  unassigned: { Icon: Undo2, color: "text-amber-500" },
+  held: { Icon: Hourglass, color: "text-amber-500" },
+  call: { Icon: Phone, color: "text-primary" },
+  whatsapp: { Icon: MessageCircle, color: "text-green-500" },
+  meeting: { Icon: Users, color: "text-primary" },
+  email: { Icon: Mail, color: "text-primary" },
+  note: { Icon: FileText, color: "text-muted-foreground" },
+  status_changed: { Icon: Flag, color: "text-primary" },
+  won: { Icon: Trophy, color: "text-success" },
+  disputed: { Icon: AlertCircle, color: "text-red-500" },
+  archived: { Icon: Archive, color: "text-muted-foreground" },
+  unarchived: { Icon: ArchiveRestore, color: "text-muted-foreground" },
+  deleted: { Icon: Trash2, color: "text-red-500" },
+  account_deleted: { Icon: UserX, color: "text-red-500" },
+  viewed: { Icon: Eye, color: "text-muted-foreground" },
+  updated: { Icon: Circle, color: "text-muted-foreground" },
+};
 
 export default function ActivityTimeline({ details, prospect, campaign }) {
- return (
- <section>
- <h3 className="text-lg font-semibold text-foreground mb-4">Activity History</h3>
- <div className="relative pl-6 space-y-6">
- <div className="absolute left-[11px] top-2 bottom-4 w-px bg-muted"/>
+  const entries = buildTimeline(details);
 
- {(!details?.activities || details.activities.length === 0) ? (
- <div className="relative flex items-center gap-3">
- <div className="h-6 w-6 rounded-full bg-muted border-2 border-white ring-1 ring-border dark:ring-border flex items-center justify-center z-10">
- <Clock className="w-3 h-3 text-muted-foreground"/>
- </div>
- <p className="text-sm text-muted-foreground">No activity recorded yet.</p>
- </div>
- ) : (
- details.activities.map((a, idx) => {
- const when = a.createdAt ? format(new Date(a.createdAt), 'MMM d, h:mm a') : '';
- let text = a.description || a.type;
- let icon = <FileText className="w-3 h-3 text-muted-foreground"/>;
+  return (
+    <section>
+      <h3 className="text-lg font-semibold text-foreground mb-4">Activity History</h3>
+      <div className="relative pl-6 space-y-6">
+        <div className="absolute left-[11px] top-2 bottom-4 w-px bg-muted" />
 
- if (a.type === 'assigned') {
- text ="Assigned to agent";
- icon = <User className="w-3 h-3 text-plum"/>;
- } else if (a.type === 'created') {
- // Use backend description if it's the new rich format, otherwise fallback
- if (a.description && a.description.includes('Prospect signed up')) {
- text = a.description;
- } else {
- text ="Prospect created";
- }
- icon = <CheckCircle2 className="w-3 h-3 text-success"/>;
- } else if (a.type === 'lead_status_updated') {
- text = `Status updated to ${a.description || 'new status'}`;
- icon = <Edit2 className="w-3 h-3 text-primary"/>;
- }
+        {entries.length === 0 ? (
+          <div className="relative flex items-center gap-3">
+            <div className="h-6 w-6 rounded-full bg-muted border-2 border-white ring-1 ring-border dark:ring-border flex items-center justify-center z-10">
+              <Clock className="w-3 h-3 text-muted-foreground" />
+            </div>
+            <p className="text-sm text-muted-foreground">No activity recorded yet.</p>
+          </div>
+        ) : (
+          entries.map((e, idx) => {
+            const meta = KIND_META[e.kind] || KIND_META.updated;
+            const Icon = meta.Icon;
+            const d = e.at ? new Date(e.at) : null;
+            const when = d && !Number.isNaN(d.getTime()) ? format(d, "MMM d, h:mm a") : "";
+            return (
+              <div key={e.id || idx} className="relative group">
+                <div className="flex items-start gap-4">
+                  <div className="absolute -left-[24px] mt-0.5">
+                    <div className="h-6 w-6 rounded-full bg-card border-2 border-border ring-1 ring-border dark:ring-border flex items-center justify-center z-10 shadow-sm">
+                      <Icon className={`w-3 h-3 ${meta.color}`} />
+                    </div>
+                  </div>
+                  <div className="flex-1 bg-muted/50 rounded-lg p-3 border border-border">
+                    <p className="text-sm font-medium text-foreground">{e.title}</p>
+                    {e.outcome && <p className="text-xs font-semibold text-primary mt-0.5">{e.outcome}</p>}
+                    {e.note && <p className="text-xs text-muted-foreground mt-0.5">{e.note}</p>}
+                    {e.nextStep && <p className="text-xs text-muted-foreground mt-0.5">Next: {e.nextStep}</p>}
+                    {e.kind === "lead_created" && (
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        via {prospect.source}, campaign: {campaign?.name}
+                      </p>
+                    )}
+                    <p className="text-xs text-muted-foreground mt-2">{when}</p>
+                  </div>
+                </div>
+              </div>
+            );
+          })
+        )}
 
- return (
- <div key={idx} className="relative group">
- <div className="flex items-start gap-4">
- <div className="absolute -left-[24px] mt-0.5">
- <div className="h-6 w-6 rounded-full bg-card border-2 border-border ring-1 ring-border dark:ring-border flex items-center justify-center z-10 shadow-sm">
- {icon}
- </div>
- </div>
- <div className="flex-1 bg-muted/50 rounded-lg p-3 border border-border">
- <p className="text-sm font-medium text-foreground">{text}</p>
- {a.type === 'assigned' && <p className="text-xs text-muted-foreground mt-0.5">{a.description || 'System assignment'}</p>}
- {a.type === 'created' && <p className="text-xs text-muted-foreground mt-0.5">via {prospect.source}, campaign: {campaign?.name}</p>}
- <p className="text-xs text-muted-foreground mt-2">{when}</p>
- </div>
- </div>
- </div>
- );
- })
- )}
-
- {/* Origin Marker */}
- <div className="relative flex items-center gap-4">
- <div className="absolute -left-[24px]">
- <div className="h-6 w-6 rounded-full bg-muted border-2 border-white ring-1 ring-border dark:ring-border flex items-center justify-center z-10">
- <div className="w-1.5 h-1.5 rounded-full bg-muted-foreground"/>
- </div>
- </div>
- <div>
- <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Start of History</span>
- </div>
- </div>
-
- </div>
- </section>
- );
+        {/* Origin Marker */}
+        <div className="relative flex items-center gap-4">
+          <div className="absolute -left-[24px]">
+            <div className="h-6 w-6 rounded-full bg-muted border-2 border-white ring-1 ring-border dark:ring-border flex items-center justify-center z-10">
+              <div className="w-1.5 h-1.5 rounded-full bg-muted-foreground" />
+            </div>
+          </div>
+          <div>
+            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Start of History</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
 }

--- a/src/components/prospects/details/__tests__/ActivityTimeline.test.jsx
+++ b/src/components/prospects/details/__tests__/ActivityTimeline.test.jsx
@@ -1,0 +1,33 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import ActivityTimeline from '../ActivityTimeline';
+
+afterEach(cleanup);
+
+describe('ActivityTimeline (unified web feed)', () => {
+  it('renders the merged timeline — MKTR lifecycle + agent engagement — with titles, notes, outcome', () => {
+    const details = {
+      timeline: [
+        { origin: 'app', row: { id: 'a1', type: 'call', description: 'Spoke briefly', metadata: { outcome: 'Interested' }, created_at: '2026-06-28T09:00:00Z' } },
+        { origin: 'mktr', row: { id: 'm1', type: 'created', description: 'Signed up via Instagram ad', metadata: {}, createdAt: '2026-06-28T08:00:00Z' } },
+      ],
+    };
+    render(<ActivityTimeline details={details} prospect={{ source: 'Instagram' }} campaign={{ name: 'June' }} />);
+    expect(screen.getByText('Signed up via Instagram ad')).toBeTruthy(); // MKTR created
+    expect(screen.getByText('Call')).toBeTruthy(); // canonical title for the agent call
+    expect(screen.getByText('Spoke briefly')).toBeTruthy(); // its note
+    expect(screen.getByText('Interested')).toBeTruthy(); // its outcome
+    expect(screen.getByText('Start of History')).toBeTruthy();
+  });
+
+  it('shows the empty state when there is no activity', () => {
+    render(<ActivityTimeline details={{ timeline: [] }} prospect={{}} campaign={{}} />);
+    expect(screen.getByText('No activity recorded yet.')).toBeTruthy();
+  });
+
+  it('falls back to ProspectActivity-only when the backend merge is absent', () => {
+    const details = { activities: [{ id: 'm1', type: 'created', description: 'Prospect signed up', metadata: {}, createdAt: '2026-06-28T08:00:00Z' }] };
+    render(<ActivityTimeline details={details} prospect={{ source: 'QR' }} campaign={{ name: 'X' }} />);
+    expect(screen.getByText('Prospect signed up')).toBeTruthy();
+  });
+});

--- a/src/utils/__tests__/leadTimeline.test.js
+++ b/src/utils/__tests__/leadTimeline.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { buildTimeline, normalizeLeadActivity, normalizeProspectActivity } from '../leadTimeline';
+
+describe('leadTimeline — web normalizers (canonical model, parity with the app)', () => {
+  it('maps ProspectActivity kinds (created/assigned/reassigned/returned/held/viewed)', () => {
+    expect(normalizeProspectActivity({ id: 'm1', type: 'created', description: 'Signed up', createdAt: 't' }).kind).toBe('lead_created');
+    expect(normalizeProspectActivity({ id: 'm2', type: 'assigned', description: 'Assigned to X', createdAt: 't' }).kind).toBe('assigned');
+    // real single reassign logs previousAgentId (no flag) — still 'reassigned'
+    expect(normalizeProspectActivity({ id: 'm3', type: 'assigned', metadata: { previousAgentId: 'a' }, description: 'x', createdAt: 't' }).kind).toBe('reassigned');
+    expect(normalizeProspectActivity({ id: 'm4', type: 'assigned', metadata: { returnedToHeld: true }, description: 'x', createdAt: 't' }).kind).toBe('returned');
+    expect(normalizeProspectActivity({ id: 'm5', type: 'updated', description: 'Held — no funded agent', createdAt: 't' }).kind).toBe('held');
+    expect(normalizeProspectActivity({ id: 'm6', type: 'viewed', description: '', createdAt: 't' }).kind).toBe('viewed');
+    // description is the title; falls back to the kind label when absent
+    expect(normalizeProspectActivity({ id: 'm6', type: 'viewed', description: '', createdAt: 't' }).title).toBe('Viewed');
+  });
+
+  it('maps lead_activities kinds, keeps note/outcome, drops config rows', () => {
+    expect(normalizeLeadActivity({ id: 'a1', type: 'follow_up', created_at: 't' })).toBeNull();
+    expect(normalizeLeadActivity({ id: 'k', type: 'key_facts', created_at: 't' })).toBeNull();
+    expect(normalizeLeadActivity({ id: 'a2', type: 'call', description: 'Spoke', metadata: { outcome: 'Interested' }, created_at: 't' })).toMatchObject({
+      kind: 'call',
+      note: 'Spoke',
+      outcome: 'Interested',
+    });
+    expect(normalizeLeadActivity({ id: 'a3', type: 'status', description: 'Marked as Disputed', created_at: 't' }).kind).toBe('disputed');
+    expect(normalizeLeadActivity({ id: 'a4', type: 'unassignment', metadata: { returned_to_held: true }, created_at: 't' }).kind).toBe('returned');
+    expect(normalizeLeadActivity({ id: 'a5', type: 'some_future_type', created_at: 't' }).kind).toBe('updated');
+  });
+
+  it('buildTimeline merges tagged rows by origin, preserving the backend order', () => {
+    const details = {
+      timeline: [
+        { origin: 'mktr', row: { id: 'm1', type: 'updated', description: 'Held — out', metadata: { quarantined: true }, createdAt: 't2' } },
+        { origin: 'app', row: { id: 'a1', type: 'call', description: 'Spoke', metadata: {}, created_at: 't1' } },
+      ],
+    };
+    expect(buildTimeline(details).map((e) => [e.kind, e.id])).toEqual([
+      ['held', 'm1'],
+      ['call', 'a1'],
+    ]);
+  });
+
+  it('buildTimeline falls back to ProspectActivity-only when no merged timeline is present', () => {
+    const details = { activities: [{ id: 'm1', type: 'created', description: 'Signed up', createdAt: 't' }] };
+    expect(buildTimeline(details).map((e) => e.kind)).toEqual(['lead_created']);
+    expect(buildTimeline(null)).toEqual([]);
+  });
+});

--- a/src/utils/leadTimeline.js
+++ b/src/utils/leadTimeline.js
@@ -1,0 +1,112 @@
+/**
+ * Canonical lead-timeline model for the web — a JS port of the mktr-leads app's lib/leadMeta
+ * normalizers, so the mktr.sg Activity Timeline renders the SAME kinds/labels/order as the app.
+ *
+ * The backend merges MKTR ProspectActivity + Supabase lead_activities into `details.timeline`
+ * (`[{ origin:'mktr'|'app', row }]`, newest-first, deduped). This normalises each row to a
+ * canonical entry. If the merge isn't present (EF off / older backend), it falls back to
+ * `details.activities` (ProspectActivity only) — what the web showed before.
+ */
+
+/** Per-kind fallback title when a row carries no explicit title/description. */
+export const KIND_TITLE = {
+  lead_created: 'Lead created',
+  assigned: 'Assigned',
+  reassigned: 'Reassigned',
+  returned: 'Returned to the queue',
+  unassigned: 'Unassigned',
+  held: 'Held',
+  call: 'Call',
+  whatsapp: 'WhatsApp',
+  meeting: 'Meeting',
+  email: 'Email',
+  note: 'Note',
+  status_changed: 'Status updated',
+  won: 'Marked as Won',
+  disputed: 'Marked as Disputed',
+  archived: 'Archived',
+  unarchived: 'Restored from archive',
+  deleted: 'Lead deleted',
+  account_deleted: 'Agent account deleted',
+  viewed: 'Viewed',
+  updated: 'Updated',
+};
+
+const LEAD_ACTIVITY_KIND = {
+  call: 'call',
+  whatsapp: 'whatsapp',
+  meeting: 'meeting',
+  email: 'email',
+  note: 'note',
+  won: 'won',
+  status: 'status_changed',
+  created: 'lead_created',
+  assignment: 'assigned',
+  unassignment: 'unassigned',
+  deleted_by_agent: 'deleted',
+  account_deleted: 'account_deleted',
+  archived: 'archived',
+  unarchived: 'unarchived',
+};
+
+/** Normalise ONE Supabase lead_activities row → canonical entry (or null for config rows). */
+export function normalizeLeadActivity(a) {
+  if (!a || a.type === 'follow_up' || a.type === 'key_facts') return null;
+  const m = a.metadata || {};
+  let kind = LEAD_ACTIVITY_KIND[a.type] || 'updated';
+  if (kind === 'assigned' && (m.reassigned === true || m.previous_agent_id)) kind = 'reassigned';
+  if (kind === 'unassigned' && (m.returnedToHeld === true || m.returned_to_held === true)) kind = 'returned';
+  if (kind === 'status_changed' && /disputed/i.test(a.description || '')) kind = 'disputed';
+  return {
+    id: a.id,
+    kind,
+    title: typeof m.title === 'string' ? m.title : KIND_TITLE[kind],
+    note: kind === 'lead_created' || kind === 'assigned' || kind === 'reassigned' ? null : a.description || null,
+    outcome: typeof m.outcome === 'string' ? m.outcome : null,
+    nextStep: typeof m.next_step === 'string' ? m.next_step : null,
+    at: a.created_at,
+  };
+}
+
+/** Normalise ONE MKTR ProspectActivity row → canonical entry. */
+export function normalizeProspectActivity(a) {
+  if (!a) return null;
+  const m = a.metadata || {};
+  const desc = (a.description || '').trim();
+  let kind;
+  switch (a.type) {
+    case 'created':
+      kind = 'lead_created';
+      break;
+    case 'assigned':
+      kind =
+        m.returnedToHeld === true || m.returned_to_held === true
+          ? 'returned'
+          : m.reassigned === true || m.previousAgentId || m.previous_agent_id || /re-?assign/i.test(desc)
+            ? 'reassigned'
+            : 'assigned';
+      break;
+    case 'updated':
+      kind = m.quarantined === true || /^held\b/i.test(desc) ? 'held' : 'updated';
+      break;
+    case 'viewed':
+      kind = 'viewed';
+      break;
+    default:
+      kind = 'updated';
+  }
+  return { id: a.id, kind, title: desc || KIND_TITLE[kind], note: null, outcome: null, nextStep: null, at: a.createdAt };
+}
+
+/**
+ * Build the unified, newest-first entry list for the web Activity Timeline from a prospect detail.
+ * Prefers the merged `details.timeline` (tagged rows); falls back to ProspectActivity-only.
+ */
+export function buildTimeline(details) {
+  if (Array.isArray(details?.timeline)) {
+    return details.timeline
+      .map((x) => (x?.origin === 'app' ? normalizeLeadActivity(x.row) : normalizeProspectActivity(x?.row)))
+      .filter(Boolean);
+  }
+  return (details?.activities || []).map(normalizeProspectActivity).filter(Boolean);
+}


### PR DESCRIPTION
## What
**Phase 2** of the unified lead timeline — the **mktr.sg web** Activity Timeline now matches the mktr-leads app: it merges MKTR `ProspectActivity` (lifecycle) with the lead's Supabase `lead_activities` (agent engagement) into one canonical feed.

- **`webLeadTimelineService`**: signed fetch of the new `mktr-lead-activities-export` Supabase EF (2.5s timeout, graceful degrade) + `mergeProspectTimeline` (dedup **both** cross-mirror directions, but only when the Supabase half answered; id tie-break). Wired into `getProspect` → `details.timeline`.
- **Admin-gated** on purpose (the engagement is the external buyer's private notes — must not reach a non-admin web user; agents can open the same detail modal) **and** gated on `SUPABASE_LEAD_ACTIVITIES_URL` (deploy-inert until set). Runs in **parallel** with the repeat-signup lookup (no added blocking).
- **`src/utils/leadTimeline.js`**: JS port of the app's canonical normalizers (same kinds + dedup).
- **`ActivityTimeline.jsx`**: rebuilt to the canonical model with lucide icons; renders the merged feed, falls back to ProspectActivity-only when the merge is absent; safe timestamp guard.

## Codex-reviewed
gpt-5.5/xhigh, no criticals; folded in: admin-gate, EF 500-on-query-error + fetcher `ok:false` unless array, parallel fetch, safe date, `nextStep` parity.

## Deploy
Needs the Supabase EF (already deployed) + `SUPABASE_LEAD_ACTIVITIES_URL` on the Render backend. `EXTERNAL_APP_SECRET` already shared. Until the env is set, `getProspect` returns ProspectActivity-only (current web behavior).

## Tests
backend merge 4✓; web util 4✓ + component 3✓ (web suite green); lint clean. (`prospects.test.js` needs local PG — pre-existing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)