### PR TITLE
feat(dnc): PDPC DNC Registry scrubbing — backend (ships dark)

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -139,9 +139,10 @@ DNC_CHECK_ON_BEHALF=N
 DNC_ENFORCEMENT=block
 # Allow recorded consent to override a DNC hit (default false; must be evidence-backed if enabled).
 DNC_CONSENT_OVERRIDES=false
-# Background re-scrub / retry job.
+# Background re-scrub / retry job (recovers dnc_pending leads whose check errored/timed out).
 DNC_BACKFILL_ENABLED=false
-# Re-check this many days before a result's validity expires.
+DNC_BACKFILL_INTERVAL_MINUTES=30
+# Re-check this many days before a result's validity expires (revalidation — not yet wired).
 DNC_REVALIDATE_DAYS=5
 # Per-call timeout (ms).
 DNC_TIMEOUT_MS=5000

--- a/backend/env.example
+++ b/backend/env.example
@@ -118,3 +118,30 @@ MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 MKTR_LEADS_WEBHOOK_URL=https://<project>.supabase.co/functions/v1/receive-mktr-lead
 MKTR_LEADS_WEBHOOK_SECRET=your-shared-webhook-secret
 MKTR_LEADS_INVITE_SECRET=your-invite-service-secret
+
+# ── DNC Registry (Singapore PDPC "Do Not Call") scrubbing ────────────────────
+# See docs/plans/dnc-scrubbing.md. All OPTIONAL; unset/false = inert (no scrubbing).
+# Master switch — must be "true" to make any DNC API call.
+DNC_API_ENABLED=false
+# UAT: https://uat.dnc.gov.sg/realtime   Prod: https://www.dnc.gov.sg/realtime
+DNC_BASE_URL=https://uat.dnc.gov.sg/realtime
+# Assigned by PDPC after org-account onboarding.
+DNC_ORG_CODE=
+DNC_ESERVICE_ID=
+# RSA private key (PEM) matching the X.509 cert submitted to PDPC. SECRET — never commit.
+# A literal "\n" in the value is auto-restored to real newlines.
+DNC_PRIVATE_KEY=
+# "Y" to check on behalf of another org (changes onboarding); default "N".
+DNC_CHECK_ON_BEHALF=N
+# Fixed-IP egress proxy for the DNC call (PDPC allowlists its IP). See docs/dnc/egress-proxy-runbook.md.
+# DNC_HTTPS_PROXY=http://user:pass@dnc-egress-host:8888
+# block = withhold DNC-registered leads (recommended for Prudential); flag = deliver with a Do-Not-Call flag.
+DNC_ENFORCEMENT=block
+# Allow recorded consent to override a DNC hit (default false; must be evidence-backed if enabled).
+DNC_CONSENT_OVERRIDES=false
+# Background re-scrub / retry job.
+DNC_BACKFILL_ENABLED=false
+# Re-check this many days before a result's validity expires.
+DNC_REVALIDATE_DAYS=5
+# Per-call timeout (ms).
+DNC_TIMEOUT_MS=5000

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -22,6 +22,7 @@
         "google-auth-library": "^9.0.0",
         "helmet": "^7.1.0",
         "http-proxy-middleware": "^3.0.0",
+        "https-proxy-agent": "^5.0.1",
         "joi": "^17.11.0",
         "jose": "^5.2.0",
         "jsonwebtoken": "^9.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,6 +38,7 @@
     "google-auth-library": "^9.0.0",
     "helmet": "^7.1.0",
     "http-proxy-middleware": "^3.0.0",
+    "https-proxy-agent": "^5.0.1",
     "joi": "^17.11.0",
     "jose": "^5.2.0",
     "jsonwebtoken": "^9.0.2",

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -148,6 +148,24 @@ export async function bootstrapDatabase() {
       setInterval(runRedeemedAudienceSync, intervalHours * 60 * 60 * 1000);
       logger.info(`[RedeemedAudience] periodic sync scheduled (${intervalHours}h interval)`);
     }
+
+    // DNC re-scrub / retry backfill — recovers dnc_pending leads whose check errored or
+    // timed out at capture (releases on clear). In-process, gated by DNC_BACKFILL_ENABLED;
+    // the re-entrancy guard + DB job lock live in the service (paid API → no double-fire).
+    if (String(process.env.DNC_BACKFILL_ENABLED || 'false').toLowerCase() === 'true') {
+      const intervalMin = Math.max(5, Number(process.env.DNC_BACKFILL_INTERVAL_MINUTES) || 30);
+      const runDncBackfillSafe = async () => {
+        try {
+          const { runDncBackfill } = await import('../services/dncBackfillService.js');
+          await runDncBackfill();
+        } catch (err) {
+          logger.warn('[DNC] backfill run failed (non-fatal)', { error: err?.message });
+        }
+      };
+      setTimeout(runDncBackfillSafe, 90_000);
+      setInterval(runDncBackfillSafe, intervalMin * 60 * 1000);
+      logger.info(`[DNC] backfill scheduled (${intervalMin}m interval)`);
+    }
   }
 
   logger.info('Database bootstrap complete.');

--- a/backend/src/database/migrations/041-add-prospect-dnc.js
+++ b/backend/src/database/migrations/041-add-prospect-dnc.js
@@ -1,0 +1,106 @@
+/**
+ * Migration 041 — prospects DNC (Do Not Call) scrubbing columns.
+ *
+ * Records the result of checking each lead's Singapore number against PDPC's DNC
+ * Registry (see docs/plans/dnc-scrubbing.md). Discrete columns for the fields we
+ * FILTER on (status + validity) + a JSONB evidence blob for the compliance audit.
+ *
+ *   dncStatus        pending | clear | registered | error | skipped   (indexed)
+ *   dncNoVoiceCall   true = registered (R) on the no-voice-call register → do NOT call
+ *   dncNoTextMessage true = registered on the no-text-message register
+ *   dncNoFax         true = registered on the no-fax register
+ *   dncCheckedAt     timestamp of the last successful check
+ *   dncValidUntil    result validity end date (from the API `msg`) — cache + re-scrub trigger (indexed)
+ *   dncMetadata      { transactionId, createdTime, rawMsg, statusCode, checkOnBehalf, numberChecked }
+ *
+ * Compliance-critical, so DDL errors are NOT blanket-swallowed (cf. migration 040):
+ * only "already exists" is ignored (idempotent re-run); anything else re-throws so the
+ * runner never records a half-applied migration as done. A post-`up` assertion verifies
+ * every column landed. All columns are nullable with no default => no-op for existing rows.
+ */
+function ignoreExists(e) {
+  const msg = String(e?.message || e || '');
+  if (!/already exists|duplicate/i.test(msg)) throw e;
+}
+
+export async function up(queryInterface, Sequelize) {
+  const { DataTypes } = Sequelize;
+  const table = await queryInterface.describeTable('prospects').catch(() => ({}));
+
+  const defs = {
+    dncStatus: {
+      type: DataTypes.STRING(16),
+      allowNull: true,
+      comment: 'DNC check state: pending|clear|registered|error|skipped. NULL = never checked.',
+    },
+    dncNoVoiceCall: {
+      type: DataTypes.BOOLEAN,
+      allowNull: true,
+      comment: 'true = registered on the DNC no-voice-call register (do NOT call).',
+    },
+    dncNoTextMessage: {
+      type: DataTypes.BOOLEAN,
+      allowNull: true,
+      comment: 'true = registered on the DNC no-text-message register.',
+    },
+    dncNoFax: {
+      type: DataTypes.BOOLEAN,
+      allowNull: true,
+      comment: 'true = registered on the DNC no-fax register.',
+    },
+    dncCheckedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      comment: 'Timestamp of the last successful DNC check.',
+    },
+    dncValidUntil: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      comment: 'DNC result validity end date (from API msg). Cache hit while now() < this; re-scrub trigger.',
+    },
+    dncMetadata: {
+      type: DataTypes.JSONB,
+      allowNull: true,
+      comment: 'DNC check evidence: transactionId, createdTime, rawMsg, statusCode, checkOnBehalf, numberChecked.',
+    },
+  };
+
+  for (const [name, def] of Object.entries(defs)) {
+    if (!table[name]) {
+      await queryInterface.addColumn('prospects', name, def).catch(ignoreExists);
+    }
+  }
+
+  // Indexes live here (not in the model / not the defunct ensurePostgresIndexes):
+  // dncStatus drives the admin "show DNC-held" filter; dncValidUntil drives the backfill's
+  // near-expiry sweep.
+  await queryInterface
+    .addIndex('prospects', ['dncStatus'], { name: 'idx_prospects_dnc_status' })
+    .catch(ignoreExists);
+  await queryInterface
+    .addIndex('prospects', ['dncValidUntil'], { name: 'idx_prospects_dnc_valid_until' })
+    .catch(ignoreExists);
+
+  // Post-up assertion — fail loudly if a compliance column didn't land.
+  const after = await queryInterface.describeTable('prospects');
+  const missing = Object.keys(defs).filter((c) => !after[c]);
+  if (missing.length) {
+    throw new Error(`041-add-prospect-dnc: columns missing after up(): ${missing.join(', ')}`);
+  }
+}
+
+export async function down(queryInterface) {
+  await queryInterface.removeIndex('prospects', 'idx_prospects_dnc_status').catch(() => {});
+  await queryInterface.removeIndex('prospects', 'idx_prospects_dnc_valid_until').catch(() => {});
+  for (const name of [
+    'dncStatus',
+    'dncNoVoiceCall',
+    'dncNoTextMessage',
+    'dncNoFax',
+    'dncCheckedAt',
+    'dncValidUntil',
+    'dncMetadata',
+  ]) {
+    await queryInterface.removeColumn('prospects', name).catch(() => {});
+  }
+}

--- a/backend/src/models/Prospect.js
+++ b/backend/src/models/Prospect.js
@@ -238,7 +238,45 @@ const Prospect = sequelize.define('Prospect', {
   quarantineReason: {
     type: DataTypes.STRING(64),
     allowNull: true,
-    comment: 'Why the lead was quarantined, e.g. no_funded_agent.'
+    comment: 'Why the lead was quarantined, e.g. no_funded_agent. DNC adds dnc_pending / dnc_registered.'
+  },
+  // --- DNC (Do Not Call) scrubbing — see docs/plans/dnc-scrubbing.md + migration 041 ---
+  // Discrete columns for the fields we filter on; full evidence in dncMetadata.
+  // Indexes (dncStatus, dncValidUntil) are created in migration 041, not here.
+  dncStatus: {
+    type: DataTypes.STRING(16),
+    allowNull: true,
+    comment: 'DNC check state: pending|clear|registered|error|skipped. NULL = never checked.'
+  },
+  dncNoVoiceCall: {
+    type: DataTypes.BOOLEAN,
+    allowNull: true,
+    comment: 'true = registered on the DNC no-voice-call register (do NOT call).'
+  },
+  dncNoTextMessage: {
+    type: DataTypes.BOOLEAN,
+    allowNull: true,
+    comment: 'true = registered on the DNC no-text-message register.'
+  },
+  dncNoFax: {
+    type: DataTypes.BOOLEAN,
+    allowNull: true,
+    comment: 'true = registered on the DNC no-fax register.'
+  },
+  dncCheckedAt: {
+    type: DataTypes.DATE,
+    allowNull: true,
+    comment: 'Timestamp of the last successful DNC check.'
+  },
+  dncValidUntil: {
+    type: DataTypes.DATE,
+    allowNull: true,
+    comment: 'DNC result validity end date (from API msg). Cache hit while now() < this.'
+  },
+  dncMetadata: {
+    type: DataTypes.JSONB,
+    allowNull: true,
+    comment: 'DNC check evidence (transactionId, createdTime, rawMsg, statusCode, checkOnBehalf, numberChecked).'
   }
 }, {
   tableName: 'prospects',

--- a/backend/src/services/dncBackfillService.js
+++ b/backend/src/services/dncBackfillService.js
@@ -1,0 +1,94 @@
+import { Op } from 'sequelize';
+import { sequelize, Prospect } from '../models/index.js';
+import { gateHeldDncLead } from './dncGate.js';
+import { dncReady } from './dncService.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * dncBackfillService — recovers leads held `dnc_pending` whose DNC check errored or timed out
+ * at capture, by re-running the gate (re-check → release-on-clear / keep-held). This is the
+ * fail-safe net behind the synchronous create-path gate: an outage at capture degrades to
+ * "held pending", and this job drains the backlog once the API is reachable again.
+ *
+ * Design: docs/plans/dnc-scrubbing.md §5.5. Because it spends paid credits, it is NOT the bare
+ * redeemed-audience scheduler — it adds an in-process re-entrancy guard + a DB advisory JOB
+ * lock (so a slow run can't overlap the next tick, and only one instance runs it).
+ *
+ * Reuse note: per-lead it calls gateHeldDncLead, which itself serializes outbound calls on the
+ * 'dnc_call' advisory lock and releases via the crash-safe outbox. For a `dnc_pending` lead the
+ * intended agent is still on dncMetadata (checkAndRecord only overwrites it on a SUCCESSFUL
+ * check, i.e. the lead is leaving `dnc_pending` anyway), so the release has its agent.
+ *
+ * Scoped to the self-contained recovery. Deferred (needs more wiring — see §5.5/§10):
+ *   - revalidation of clear/registered results before `dncValidUntil`
+ *   - reverse flip of long-held `dnc_registered` leads (needs agent re-resolution)
+ *   - `lead.updated` for already-delivered leads that flip (needs the lyfe-app receiver)
+ */
+
+const JOB_LOCK_KEY = 'dnc_backfill';
+const MAX_PER_RUN = 200;
+
+// In-process guard: never let two runs (e.g. an overlapping interval tick) overlap.
+let running = false;
+
+async function processPendingHolds(d) {
+  // Held `dnc_pending` leads on contactable (non-terminal) leads, oldest first.
+  const candidates = await d.Prospect.findAll({
+    where: {
+      quarantineReason: 'dnc_pending',
+      quarantinedAt: { [Op.ne]: null },
+      leadStatus: { [Op.notIn]: ['won', 'lost'] },
+    },
+    order: [['quarantinedAt', 'ASC']],
+    limit: MAX_PER_RUN,
+  });
+
+  let released = 0;
+  let held = 0;
+  let errors = 0;
+  for (const prospect of candidates) {
+    const r = await d.gateHeldDncLead(prospect); // never throws
+    if (r.outcome === 'released') released++;
+    else if (r.status === 'error' || r.status === 'pending') errors++;
+    else held++;
+  }
+
+  d.logger.info({ released, held, errors, total: candidates.length }, 'dnc.backfill.done');
+  return { ran: true, released, held, errors, total: candidates.length };
+}
+
+/**
+ * Run one backfill pass. Never throws. Returns a summary (or a skip reason).
+ */
+export async function runDncBackfill(overrides = {}) {
+  const d = { sequelize, Prospect, gateHeldDncLead, dncReady, logger, ...overrides };
+
+  if (!d.dncReady()) return { ran: false, reason: 'not_ready' };
+  if (running) {
+    d.logger.info('[DNC] backfill skip — previous run still in progress');
+    return { ran: false, reason: 'already_running' };
+  }
+  running = true;
+  try {
+    // DB advisory JOB lock — held for the whole pass (auto-released on tx end), so a slow
+    // run can't overlap the next tick and only one instance processes the backlog.
+    return await d.sequelize.transaction(async (lockTx) => {
+      const [{ locked }] = await d.sequelize.query(
+        `SELECT pg_try_advisory_xact_lock(hashtext(:k)) AS locked`,
+        { replacements: { k: JOB_LOCK_KEY }, type: d.sequelize.QueryTypes.SELECT, transaction: lockTx }
+      );
+      if (!locked) {
+        d.logger.info('[DNC] backfill skip — job lock held elsewhere');
+        return { ran: false, reason: 'lock_held' };
+      }
+      return processPendingHolds(d);
+    });
+  } catch (err) {
+    d.logger.error('[DNC] backfill failed', { error: err?.message || String(err) });
+    return { ran: false, reason: 'error', error: err?.message };
+  } finally {
+    running = false;
+  }
+}
+
+export default { runDncBackfill };

--- a/backend/src/services/dncGate.js
+++ b/backend/src/services/dncGate.js
@@ -1,0 +1,166 @@
+import { sequelize, Prospect, ProspectActivity, User } from '../models/index.js';
+import { chargeLeadCredit } from './leadCredits.js';
+import { persistEventDeliveries, flushDeliveries } from './webhookService.js';
+import { buildLeadCreatedPayload, destinationForAgent, externalIdForDestination } from './prospectHelpers.js';
+import { checkAndRecord as dncCheckAndRecord } from './dncService.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * dncGate — the "born-held-pending, release-on-clear" state machine for the create path.
+ * Design: docs/plans/dnc-scrubbing.md §5.3–§5.5. Modeled on releaseSweep.js (atomic
+ * reason-scoped claim + in-tx authoritative charge + persistEventDeliveries outbox + flush),
+ * NOT assignProspect (whose release claim is reason-blind and would misfire lead.assigned).
+ */
+
+const defaultDeps = {
+  sequelize,
+  Prospect,
+  ProspectActivity,
+  User,
+  chargeLeadCredit,
+  persistEventDeliveries,
+  flushDeliveries,
+  buildLeadCreatedPayload,
+  destinationForAgent,
+  externalIdForDestination,
+  checkAndRecord: dncCheckAndRecord,
+  logger,
+  // Injectable so gateHeldDncLead can be unit-tested without the release tx (the real
+  // function is hoisted and bound below).
+  releaseDncClearedLead: (...args) => releaseDncClearedLead(...args),
+};
+
+/**
+ * Release a lead that was held `dnc_pending` and has now come back deliverable, assigning it
+ * to `agentId` and firing its FIRST lead.created. One transaction: a reason-scoped atomic
+ * claim (so a concurrent release/backfill can't deliver twice), an authoritative charge
+ * (rolled back → re-held if the agent has no credit, unless already charged at capture),
+ * and the delivery row persisted in the SAME tx (crash-safe outbox). Never throws.
+ */
+export async function releaseDncClearedLead({ prospect, agentId, alreadyCharged = false }, overrides = {}) {
+  const d = { ...defaultDeps, ...overrides };
+  if (!agentId) {
+    d.logger.warn('[DNC] cleared lead has no intended agent — left held for backfill/admin', { prospectId: prospect.id });
+    return { released: false, reason: 'no_intended_agent' };
+  }
+
+  const t = await d.sequelize.transaction();
+  try {
+    // Atomic, reason-scoped claim — the 'dnc_pending' scope IS the fence (assignProspect's
+    // claim is reason-blind, so we don't reuse it).
+    const [claim] = await d.sequelize.query(
+      `UPDATE prospects
+          SET "assignedAgentId" = :agentId, "lastContactDate" = NOW(),
+              "quarantinedAt" = NULL, "quarantineReason" = NULL, "updatedAt" = NOW()
+        WHERE id = :id AND "quarantineReason" = 'dnc_pending' AND "quarantinedAt" IS NOT NULL
+        RETURNING id`,
+      { replacements: { agentId, id: prospect.id }, transaction: t }
+    );
+    if (!Array.isArray(claim) || claim.length === 0) {
+      await t.rollback();
+      return { released: false, reason: 'lost_claim' };
+    }
+
+    // Authoritative charge (skip if capture-time decideAssignment already charged this lead).
+    if (!alreadyCharged) {
+      const charged = await d.chargeLeadCredit(agentId, prospect.campaignId || null, t);
+      if (!charged) {
+        await t.rollback();
+        d.logger.warn('[DNC] release: agent has no credit — re-holding', { prospectId: prospect.id, agentId });
+        return { released: false, reason: 'no_credit' };
+      }
+    }
+
+    await d.ProspectActivity.create(
+      {
+        prospectId: prospect.id,
+        type: 'assigned',
+        actorUserId: null,
+        description: `Released after DNC clear and assigned to agent ${agentId}`,
+        metadata: { assignedAgentId: agentId, released: true, via: 'dnc_clear' },
+      },
+      { transaction: t }
+    );
+
+    const agent = await d.User.findByPk(agentId, {
+      attributes: ['id', 'lyfeId', 'mktrLeadsId', 'phone', 'email', 'firstName', 'lastName'],
+      transaction: t,
+    });
+    const destination = agent ? d.destinationForAgent(agent) : null;
+    const agentForWebhook = agent
+      ? {
+          phone: agent.phone || null,
+          email: agent.email || null,
+          name: `${agent.firstName || ''} ${agent.lastName || ''}`.trim(),
+          id: d.externalIdForDestination(agent, destination),
+        }
+      : null;
+    const withCampaign = await d.Prospect.findByPk(prospect.id, {
+      include: [{ association: 'campaign', attributes: ['id', 'name'] }],
+      transaction: t,
+    });
+
+    // Persist the first lead.created delivery INSIDE the tx (outbox) so a crash after commit
+    // can't strand a released, charged lead that was never queued.
+    const deliveryPairs = await d.persistEventDeliveries(
+      'lead.created',
+      () => d.buildLeadCreatedPayload(withCampaign, 'direct', agentForWebhook, agentId, withCampaign?.campaign || null, null, null),
+      { destination },
+      t
+    );
+    // Fail closed: never release a CHARGED lead we can't durably deliver.
+    if (!deliveryPairs || deliveryPairs.length === 0) {
+      await t.rollback();
+      d.logger.warn('[DNC] release: no delivery subscriber — re-holding', { prospectId: prospect.id, destination });
+      return { released: false, reason: 'no_subscriber' };
+    }
+
+    await t.commit();
+    d.flushDeliveries(deliveryPairs);
+    await prospect.reload().catch(() => {});
+    return { released: true };
+  } catch (err) {
+    await t.rollback().catch(() => {});
+    d.logger.error('[DNC] release failed', { prospectId: prospect.id, error: err?.message || String(err) });
+    return { released: false, error: err?.message };
+  }
+}
+
+/**
+ * Post-commit gate for a lead born held `dnc_pending`. Runs the DNC check, then:
+ *   - clear, OR registered but voice-clear → release to the intended agent (first lead.created)
+ *   - registered on voice → keep held, relabel `dnc_registered`
+ *   - pending/error → stays `dnc_pending`; the backfill retries.
+ * Never throws. Returns { outcome: 'released'|'held', status }.
+ */
+export async function gateHeldDncLead(prospect, overrides = {}) {
+  const d = { ...defaultDeps, ...overrides };
+  // Captured BEFORE checkAndRecord overwrites dncMetadata with the result blob.
+  const intendedAgentId = prospect.dncMetadata?.intendedAgentId || null;
+  const alreadyCharged = prospect.dncMetadata?.alreadyCharged === true;
+
+  let result;
+  try {
+    result = await d.checkAndRecord(prospect);
+  } catch (err) {
+    d.logger.error('[DNC] gate check failed (left held)', { prospectId: prospect.id, error: err?.message || String(err) });
+    return { outcome: 'held', status: 'error' };
+  }
+
+  // Voice is the channel agents use; registered-on-voice is the block trigger. A lead
+  // registered only on text/fax (voice clear) is still deliverable, with flags in the payload.
+  const deliver = result.status === 'clear' || (result.status === 'registered' && !result.noVoiceCall);
+  if (deliver) {
+    const rel = await d.releaseDncClearedLead({ prospect, agentId: intendedAgentId, alreadyCharged }, overrides);
+    return { outcome: rel.released ? 'released' : 'held', status: result.status, release: rel };
+  }
+  if (result.status === 'registered') {
+    await prospect.update({ quarantineReason: 'dnc_registered' }).catch(() => {});
+    d.logger.info('[DNC] lead held — registered on the no-voice-call register', { prospectId: prospect.id });
+    return { outcome: 'held', status: 'registered' };
+  }
+  // pending / error → leave dnc_pending for the backfill to retry.
+  return { outcome: 'held', status: result.status };
+}
+
+export default { releaseDncClearedLead, gateHeldDncLead };

--- a/backend/src/services/dncService.js
+++ b/backend/src/services/dncService.js
@@ -1,0 +1,354 @@
+import crypto from 'crypto';
+import nodeFetch from 'node-fetch';
+import * as Sentry from '@sentry/node';
+import { Prospect, ProspectActivity, sequelize } from '../models/index.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * dncService — checks Singapore numbers against PDPC's DNC Registry realtime API.
+ * Design + threat model: docs/plans/dnc-scrubbing.md. Egress proxy: docs/dnc/egress-proxy-runbook.md.
+ *
+ * Transport: plain HTTPS (1-way TLS) + an RSA-SHA256 `appSignature` header PDPC verifies
+ * against our submitted X.509 cert. Never throws to callers (mirrors metaCapiService); all
+ * failures land in Sentry + structured logs and degrade fail-safe (lead stays unchecked → held).
+ */
+
+const ENDPOINT = 'check/registry';
+const DEFAULT_BASE_URL = 'https://uat.dnc.gov.sg/realtime';
+const DNC_CALL_LOCK_KEY = 'dnc_call'; // shared by request-path + backfill so all calls serialize
+const DEFAULT_TIMEOUT_MS = 5000;
+
+// Process-local monotonic clock. The advisory lock (below) guarantees one call at a
+// time; this guarantees the epoch-ms timestamp never repeats or regresses WITHIN a
+// process. Single-instance backend (verified) → sufficient. For a multi-instance future,
+// persist lastTs in the lock tx (the lock already serialises the read-modify-write).
+let lastTs = 0;
+
+export function nextTimestamp(now = Date.now()) {
+  lastTs = Math.max(now, lastTs + 1);
+  return lastTs;
+}
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+/** PEM private keys are often stored with literal "\n"; restore real newlines. */
+function normalizePem(pem) {
+  if (!pem) return pem;
+  return pem.includes('\\n') ? pem.replace(/\\n/g, '\n') : pem;
+}
+
+export function dncConfig() {
+  return {
+    enabled: process.env.DNC_API_ENABLED === 'true',
+    baseUrl: (process.env.DNC_BASE_URL || DEFAULT_BASE_URL).replace(/\/+$/, ''),
+    orgCode: process.env.DNC_ORG_CODE || '',
+    eServiceId: process.env.DNC_ESERVICE_ID || '',
+    privateKey: normalizePem(process.env.DNC_PRIVATE_KEY || ''),
+    checkOnBehalf: (process.env.DNC_CHECK_ON_BEHALF || 'N').toUpperCase() === 'Y' ? 'Y' : 'N',
+    proxy: process.env.DNC_HTTPS_PROXY || null,
+    timeoutMs: Number(process.env.DNC_TIMEOUT_MS) || DEFAULT_TIMEOUT_MS,
+  };
+}
+
+/** True when the API is enabled AND fully credentialed — gates every outbound call. */
+export function dncReady(cfg = dncConfig()) {
+  return !!(cfg.enabled && cfg.orgCode && cfg.eServiceId && cfg.privateKey);
+}
+
+/**
+ * Effective enforcement mode for the create path:
+ *   'off'   — scrubbing disabled/unconfigured → existing pipeline behaviour, untouched
+ *   'block' — born-held-pending; DNC-registered (voice) leads are withheld
+ *   'flag'  — delivered with the DNC result attached to the payload
+ */
+export function dncEnforcement(cfg = dncConfig()) {
+  if (!dncReady(cfg)) return 'off';
+  return (process.env.DNC_ENFORCEMENT || 'block').toLowerCase() === 'flag' ? 'flag' : 'block';
+}
+
+// ── Pure helpers (exported for tests) ───────────────────────────────────────────
+
+/**
+ * Normalise a phone to the DNC wire format: 8 local digits starting 3/6/8/9.
+ * Returns null for non-SG / malformed numbers (DNC only covers Singapore) → caller
+ * marks the lead `skipped`.
+ */
+export function formatDncNumber(phone) {
+  if (!phone) return null;
+  let d = String(phone).replace(/\D/g, '');
+  if (d.length === 11 && d.startsWith('65')) d = d.slice(2); // 65XXXXXXXX
+  else if (d.length === 10 && d.startsWith('65')) d = d.slice(2);
+  if (d.length !== 8) return null;
+  if (!/^[3689]\d{7}$/.test(d)) return null;
+  return d;
+}
+
+/** Signature base string — order is fixed and must match the header timestamp exactly. */
+export function buildBaseString({ orgCode, eServiceId, timestamp }) {
+  return `orgCode=${orgCode}&eServiceId=${eServiceId}&timestamp=${timestamp}`;
+}
+
+/** RSA-SHA256 over the base string, strict base64 (no line breaks). */
+export function signRequest(baseString, privateKeyPem) {
+  const signer = crypto.createSign('RSA-SHA256');
+  signer.update(baseString, 'utf8');
+  signer.end();
+  return signer.sign(normalizePem(privateKeyPem), 'base64');
+}
+
+/** Authorization header value — field order is critical (orgCode, eServiceId, timestamp, appSignature). */
+export function buildAuthHeader({ orgCode, eServiceId, timestamp, appSignature }) {
+  return `orgCode=${orgCode}&eServiceId=${eServiceId}&timestamp=${timestamp}&appSignature=${appSignature}`;
+}
+
+/** Map an Annex-A status code → handling. */
+export function mapStatusCode(code) {
+  switch (code) {
+    case 'S000': return { ok: true };
+    // No credits: keep the lead retriable (→ pending) so the backfill recovers it after top-up,
+    // and alert so a human tops up. Held leads stay fail-safe meanwhile.
+    case 'S301': return { ok: false, retriable: true, alert: true, reason: 'insufficient_credits' };
+    case 'S401':
+    case 'S402':
+    case 'S404': return { ok: false, retriable: false, alert: true, reason: 'auth' };
+    case 'S403': return { ok: false, retriable: false, alert: true, reason: 'bad_timestamp' };
+    case 'S101':
+    case 'S102':
+    case 'S405': return { ok: false, retriable: false, alert: true, reason: 'bad_request' };
+    case 'S501': return { ok: false, retriable: true, reason: 'dnc_internal' };
+    default: return { ok: false, retriable: true, reason: 'unknown' };
+  }
+}
+
+/** Pull the validity end date out of the human-readable `msg` ("…valid until 06-Nov-2020"). */
+export function parseValidUntil(msg) {
+  if (!msg) return null;
+  const m = String(msg).match(/(\d{1,2})[-\s]([A-Za-z]{3})[-\s](\d{4})/);
+  if (!m) return null;
+  const d = new Date(`${m[1]} ${m[2]} ${m[3]} 23:59:59 GMT+0800`);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/** Normalise the DNC response JSON → typed result. Exported for tests. */
+export function parseResponse(json) {
+  const statusCode = json?.status_code || null;
+  const results = Array.isArray(json?.numbers)
+    ? json.numbers.map((n) => ({
+        number: n.number,
+        noVoiceCall: n.no_voice_call === 'R',
+        noTextMessage: n.no_text_message === 'R',
+        noFax: n.no_fax === 'R',
+      }))
+    : [];
+  return {
+    statusCode,
+    results,
+    validUntil: parseValidUntil(json?.msg),
+    transactionId: json?.transactionid || null,
+    createdTime: json?.created_time || null,
+    rawMsg: json?.msg || null,
+  };
+}
+
+// ── Proxy + call lock ───────────────────────────────────────────────────────────
+
+/** Lazily build a CONNECT proxy agent only when DNC_HTTPS_PROXY is set. */
+async function buildProxyAgent(proxyUrl) {
+  if (!proxyUrl) return undefined;
+  const mod = await import('https-proxy-agent');
+  const HttpsProxyAgent = mod.HttpsProxyAgent || mod.default || mod;
+  return new HttpsProxyAgent(proxyUrl);
+}
+
+/**
+ * Serialise ALL outbound DNC calls (request-path + backfill) through one transaction-scoped
+ * advisory lock — NOT a session lock (those leaked under Sequelize's pool, see
+ * agentSyncService.js:216). The lock + connection are held only for the single sign+send, so
+ * fresh request-path checks never queue behind a large backfill batch. Blocking acquire
+ * (bounded by lock_timeout) so a queued call waits its turn rather than being dropped.
+ */
+async function runWithDncCallLock(fn, deps = {}) {
+  const seq = deps.sequelize || sequelize;
+  return seq.transaction(async (lockTx) => {
+    await seq.query(`SET LOCAL lock_timeout = '30s'`, { transaction: lockTx });
+    await seq.query(`SELECT pg_advisory_xact_lock(hashtext(:key))`, {
+      replacements: { key: DNC_CALL_LOCK_KEY },
+      transaction: lockTx,
+    });
+    return fn();
+  });
+}
+
+// ── API call ────────────────────────────────────────────────────────────────────
+
+/**
+ * Check up to 100 SG numbers against the DNC Registry. Serialised via the call lock.
+ * Returns the parsed response. Throws only on transport/timeout (caller catches).
+ * @param {string[]} numbers  8-digit local numbers (caller pre-validates with formatDncNumber)
+ */
+export async function checkNumbers(numbers, opts = {}, deps = {}) {
+  const cfg = opts.cfg || dncConfig();
+  const fetchImpl = deps.fetch || nodeFetch;
+  const checkOnBehalf = opts.checkOnBehalf || cfg.checkOnBehalf;
+
+  const doCall = async () => {
+    const timestamp = (deps.nextTimestamp || nextTimestamp)();
+    const baseString = buildBaseString({ orgCode: cfg.orgCode, eServiceId: cfg.eServiceId, timestamp });
+    const appSignature = signRequest(baseString, cfg.privateKey);
+    const authHeader = buildAuthHeader({ orgCode: cfg.orgCode, eServiceId: cfg.eServiceId, timestamp, appSignature });
+    const body = JSON.stringify({ numbers, total: numbers.length, checkOnBehalf });
+    const agent = await buildProxyAgent(cfg.proxy);
+
+    const res = await fetchImpl(`${cfg.baseUrl}/${ENDPOINT}`, {
+      method: 'POST',
+      headers: { Authorization: authHeader, 'Content-Type': 'application/json' },
+      body,
+      agent,
+      signal: AbortSignal.timeout(cfg.timeoutMs),
+    });
+    const json = await res.json().catch(() => ({}));
+    return { httpStatus: res.status, ...parseResponse(json) };
+  };
+
+  // Tests inject deps.skipLock to bypass the DB transaction.
+  return deps.skipLock ? doCall() : runWithDncCallLock(doCall, deps);
+}
+
+// ── Check + persist + audit (single lead) ─────────────────────────────────────────
+
+function dncFieldsFromResult(result, number, checkOnBehalf) {
+  const r = result.results[0] || {};
+  const registered = r.noVoiceCall || r.noTextMessage || r.noFax;
+  return {
+    dncStatus: registered ? 'registered' : 'clear',
+    dncNoVoiceCall: !!r.noVoiceCall,
+    dncNoTextMessage: !!r.noTextMessage,
+    dncNoFax: !!r.noFax,
+    dncCheckedAt: new Date(),
+    dncValidUntil: result.validUntil || null,
+    dncMetadata: {
+      transactionId: result.transactionId,
+      createdTime: result.createdTime,
+      rawMsg: result.rawMsg,
+      statusCode: result.statusCode,
+      checkOnBehalf,
+      numberChecked: number,
+    },
+  };
+}
+
+async function persistDnc(prospect, fields, deps) {
+  const Model = deps.Prospect || Prospect;
+  if (typeof prospect.update === 'function') return prospect.update(fields);
+  return Model.update(fields, { where: { id: prospect.id } });
+}
+
+async function auditDnc(prospect, fields, deps) {
+  const Activity = deps.ProspectActivity || ProspectActivity;
+  const f = (b) => (b ? 'R' : 'NR');
+  const valid = fields.dncValidUntil ? ` · valid until ${new Date(fields.dncValidUntil).toISOString().slice(0, 10)}` : '';
+  const txn = fields.dncMetadata?.transactionId ? ` · txn ${fields.dncMetadata.transactionId}` : '';
+  await Activity.create({
+    prospectId: prospect.id,
+    type: 'updated',
+    actorUserId: null,
+    description: `DNC check: voice=${f(fields.dncNoVoiceCall)} text=${f(fields.dncNoTextMessage)} fax=${f(fields.dncNoFax)}${valid}${txn}`,
+    metadata: {
+      dnc: {
+        status: fields.dncStatus,
+        noVoiceCall: fields.dncNoVoiceCall,
+        noTextMessage: fields.dncNoTextMessage,
+        noFax: fields.dncNoFax,
+        validUntil: fields.dncValidUntil,
+        statusCode: fields.dncMetadata?.statusCode,
+        transactionId: fields.dncMetadata?.transactionId,
+      },
+    },
+  }).catch((err) => deps.logger?.warn?.('[DNC] audit activity failed', { error: err?.message }) ?? logger.warn('[DNC] audit activity failed', { error: err?.message }));
+}
+
+/** True when this prospect still has a valid cached result (skip the paid re-check). */
+export function hasFreshDnc(prospect, now = new Date()) {
+  return (
+    (prospect?.dncStatus === 'clear' || prospect?.dncStatus === 'registered') &&
+    prospect?.dncValidUntil != null &&
+    new Date(prospect.dncValidUntil) > now
+  );
+}
+
+/**
+ * Check ONE lead and record the result on its row (+ a ProspectActivity audit line).
+ * Does NOT make the release/hold decision — that's the integration layer (born-held-pending).
+ * Never throws. Returns { status, noVoiceCall?, noTextMessage?, noFax?, cached? }.
+ */
+export async function checkAndRecord(prospect, deps = {}) {
+  const log = deps.logger || logger;
+  const cfg = deps.cfg || dncConfig();
+
+  if (!dncReady(cfg)) return { status: 'disabled' };
+
+  const number = formatDncNumber(prospect.phone);
+  if (!number) {
+    // Non-SG / malformed → out of DNC scope; record skipped so it isn't re-tried.
+    await persistDnc(prospect, { dncStatus: 'skipped', dncCheckedAt: new Date() }, deps).catch(() => {});
+    return { status: 'skipped' };
+  }
+
+  if (hasFreshDnc(prospect)) {
+    return { status: prospect.dncStatus, cached: true };
+  }
+
+  let result;
+  try {
+    result = await checkNumbers([number], { cfg, checkOnBehalf: cfg.checkOnBehalf }, deps);
+  } catch (err) {
+    Sentry.captureException(err, { tags: { source: 'dnc' }, extra: { prospect_id: prospect.id } });
+    log.error({ err: err.message, prospect_id: prospect.id }, 'dnc.check.error');
+    await persistDnc(prospect, { dncStatus: 'pending' }, deps).catch(() => {});
+    return { status: 'pending', error: err.message };
+  }
+
+  const mapped = mapStatusCode(result.statusCode);
+  if (!mapped.ok) {
+    if (mapped.alert) {
+      Sentry.captureMessage(`DNC ${result.statusCode} (${mapped.reason})`, {
+        level: 'error',
+        tags: { source: 'dnc', status_code: result.statusCode },
+        extra: { prospect_id: prospect.id },
+      });
+    }
+    const status = mapped.retriable ? 'pending' : 'error';
+    log.warn({ status_code: result.statusCode, reason: mapped.reason, prospect_id: prospect.id }, 'dnc.check.rejected');
+    await persistDnc(prospect, { dncStatus: status }, deps).catch(() => {});
+    return { status, statusCode: result.statusCode, reason: mapped.reason };
+  }
+
+  const fields = dncFieldsFromResult(result, number, cfg.checkOnBehalf);
+  await persistDnc(prospect, fields, deps);
+  await auditDnc(prospect, fields, deps);
+  log.info({ prospect_id: prospect.id, dnc_status: fields.dncStatus, txn: fields.dncMetadata.transactionId }, 'dnc.check.recorded');
+
+  return {
+    status: fields.dncStatus,
+    noVoiceCall: fields.dncNoVoiceCall,
+    noTextMessage: fields.dncNoTextMessage,
+    noFax: fields.dncNoFax,
+    validUntil: fields.dncValidUntil,
+  };
+}
+
+export default {
+  nextTimestamp,
+  dncConfig,
+  dncReady,
+  formatDncNumber,
+  buildBaseString,
+  signRequest,
+  buildAuthHeader,
+  mapStatusCode,
+  parseValidUntil,
+  parseResponse,
+  checkNumbers,
+  checkAndRecord,
+  hasFreshDnc,
+};

--- a/backend/src/services/prospectHelpers.js
+++ b/backend/src/services/prospectHelpers.js
@@ -57,6 +57,23 @@ export function externalIdForDestination(agent, destination) {
 }
 
 /**
+ * The DNC scrubbing block carried on a delivered lead so the agent app can flag / disable
+ * outbound contact per channel. Returns null when the lead has no DNC data (scrubbing off
+ * or not yet checked), so payloads are byte-for-byte unchanged when DNC is disabled.
+ */
+export function dncPayloadBlock(prospect) {
+  if (!prospect || prospect.dncStatus == null) return null;
+  return {
+    status: prospect.dncStatus,
+    noVoiceCall: prospect.dncNoVoiceCall === true,
+    noTextMessage: prospect.dncNoTextMessage === true,
+    noFax: prospect.dncNoFax === true,
+    checkedAt: prospect.dncCheckedAt || null,
+    validUntil: prospect.dncValidUntil || null,
+  };
+}
+
+/**
  * Build the webhook payload for a 'lead.created' event.
  */
 export function buildLeadCreatedPayload(prospect, routingMode, agentForWebhook, assignedAgentId, sourceCampaign, sourceQrTag, agentGroup) {
@@ -84,6 +101,7 @@ export function buildLeadCreatedPayload(prospect, routingMode, agentForWebhook, 
         sourceMetadata: prospect.sourceMetadata,
         recordingUrl: prospect.sourceMetadata?.recordingUrl || null,
         transcript: prospect.sourceMetadata?.retellCallId ? prospect.notes : null,
+        dnc: dncPayloadBlock(prospect),
         createdAt: prospect.createdAt
       },
       routing: {
@@ -139,6 +157,7 @@ export function buildLeadAssignedPayload(prospect, agent, prospectWithCampaign) 
         sourceMetadata: meta,
         recordingUrl: meta.recordingUrl || null,
         transcript: meta.retellCallId ? prospect.notes : null,
+        dnc: dncPayloadBlock(prospect),
         createdAt: prospect.createdAt
       },
       routing: {

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -15,6 +15,8 @@ import {
 import { resolveAssignedAgentId, resolveLeadRouting, getSystemAgentId, resolveLeadAssignment } from './systemAgent.js';
 import { deductLeadCredit, chargeLeadCredit, deductExternalLeadBalance } from './leadCredits.js';
 import { decideAssignment } from './leadQuota.js';
+import { dncEnforcement, formatDncNumber, checkAndRecord as dncCheckAndRecord } from './dncService.js';
+import { gateHeldDncLead } from './dncGate.js';
 import { hasValidExternalConsent, buildExternalConsentEvidence } from './externalConsent.js';
 import { repeatSignupDetail, repeatSignupCounts } from './repeatSignup.js';
 import { buildProspectWhere } from '../middleware/prospectScope.js';
@@ -85,6 +87,10 @@ const defaultDeps = {
   buildExternalConsentEvidence,
   chargeLeadCredit,
   decideAssignment,
+  dncEnforcement,
+  formatDncNumber,
+  dncCheckAndRecord,
+  gateHeldDncLead,
   buildProspectWhere,
   dispatchEvent,
   persistEventDeliveries,
@@ -329,6 +335,15 @@ export function makeProspectService(overrides = {}) {
       incoming.phone = normalizePhone(incoming.phone);
     }
 
+    // DNC (Do Not Call) scrubbing mode for this lead. 'off' unless scrubbing is configured
+    // AND the number is in DNC scope (Singapore). block → born held pending a check;
+    // flag → checked post-commit, result attached to the payload. docs/plans/dnc-scrubbing.md.
+    const dncMode = d.dncEnforcement();
+    const dncNumber = dncMode !== 'off' && incoming.phone ? d.formatDncNumber(incoming.phone) : null;
+    const dncBlockApplies = dncMode === 'block' && !!dncNumber;
+    const dncFlagApplies = dncMode === 'flag' && !!dncNumber;
+    const dncWillCheck = dncBlockApplies || dncFlagApplies;
+
     // Enforce: a phone can register once per campaign, but can register for different campaigns
     if (incoming.phone && incoming.campaignId) {
       const existing = await m.Prospect.findOne({
@@ -550,6 +565,10 @@ export function makeProspectService(overrides = {}) {
     let quarantined = false;
     let heldReason = null;
     let finalAgentId = assignedAgentId;
+    // DNC block-mode hold bookkeeping — set inside the tx, consumed post-commit.
+    let dncHeld = false;
+    let dncIntendedAgentId = null;
+    let dncAlreadyCharged = false;
     const prospect = await d.sequelize.transaction(async (t) => {
       // The internal quota gate applies ONLY to the internal path. For external
       // leads default to a plain "assign" directive so the shared activity/deduct
@@ -569,6 +588,18 @@ export function makeProspectService(overrides = {}) {
           charge: d.chargeLeadCredit,
         });
       }
+
+      // DNC block-mode gate: a normally-assignable INTERNAL lead is HELD pending a DNC
+      // check (released post-commit on clear). Never overrides an existing quarantine
+      // (quota / external) or an external-buyer route. The credit is charged on release
+      // (unless decideAssignment already charged a funded gated route → dncAlreadyCharged).
+      if (dncBlockApplies && decision.action !== 'quarantine' && !externalAgentId) {
+        dncIntendedAgentId = decision.assignedAgentId ?? assignedAgentId ?? null;
+        dncAlreadyCharged = decision.charged === true;
+        dncHeld = true;
+        decision = { action: 'quarantine', quarantineReason: 'dnc_pending', charged: dncAlreadyCharged, via: routeVia };
+      }
+
       quarantined = decision.action === 'quarantine';
       heldReason = quarantined ? decision.quarantineReason : null;
       finalAgentId = quarantined ? null : (decision.assignedAgentId ?? null);
@@ -580,6 +611,10 @@ export function makeProspectService(overrides = {}) {
           externalAgentId,
           quarantinedAt: quarantined ? new Date() : null,
           quarantineReason: quarantined ? decision.quarantineReason : null,
+          // DNC: mark pending up-front (crash-safe — the backfill finds a stranded row);
+          // stash the intended agent so the post-commit clear-release knows who to deliver to.
+          ...(dncWillCheck ? { dncStatus: 'pending' } : {}),
+          ...(dncHeld ? { dncMetadata: { intendedAgentId: dncIntendedAgentId, alreadyCharged: dncAlreadyCharged } } : {}),
         },
         { transaction: t }
       );
@@ -620,7 +655,9 @@ export function makeProspectService(overrides = {}) {
             description:
               decision.quarantineReason === 'no_funded_external_buyer'
                 ? 'Held — no funded MKTR Leads (external) buyer'
-                : 'Held — no funded agent (lead quota)',
+                : decision.quarantineReason === 'dnc_pending'
+                  ? 'Held — pending DNC (Do Not Call) check'
+                  : 'Held — no funded agent (lead quota)',
             metadata: { quarantined: true, reason: decision.quarantineReason, via: routeVia },
           },
           { transaction: t }
@@ -684,6 +721,21 @@ export function makeProspectService(overrides = {}) {
     // Reflect the committed outcome (null when quarantined) for the rest of the
     // function — webhook dispatch, agent load, and the returned payload.
     assignedAgentId = finalAgentId;
+
+    // --- DNC scrubbing (post-commit, synchronous before dispatch) ---
+    // Block mode: the lead was born held (dnc_pending). Check, then release-on-clear (which
+    // fires its own first lead.created) or keep held (dnc_registered) — so the normal
+    // lead.created below stays suppressed (quarantined). Flag mode: check + record so the
+    // lead.created payload below carries the result; the lead delivers regardless.
+    if (dncHeld) {
+      await d.gateHeldDncLead(prospect).catch((err) =>
+        d.logger.error('[DNC] gate error', { error: err?.message || String(err) })
+      );
+    } else if (dncFlagApplies) {
+      await d
+        .dncCheckAndRecord(prospect)
+        .catch((err) => d.logger.error('[DNC] check error', { error: err?.message || String(err) }));
+    }
 
     // --- Webhook dispatch (AFTER transaction commits, fire-and-forget) ---
     // Always load the assigned agent's provenance (lyfeId/mktrLeadsId) by id — NOT
@@ -1036,6 +1088,17 @@ export function makeProspectService(overrides = {}) {
     if (prospect.quarantineReason === 'no_funded_external_buyer') {
       throw new d.AppError(
         'This lead is held for the MKTR Leads (external) buyer pool and cannot be manually assigned to an internal agent.',
+        409
+      );
+    }
+
+    // DNC fence: a lead held by the DNC gate must NOT be manually released (that would
+    // bypass scrubbing and hand a Do-Not-Call number to an adviser). It releases itself
+    // automatically once the DNC check clears (gate / backfill). assignProspect's claim
+    // below is reason-blind, so this guard is the fence.
+    if (prospect.quarantineReason === 'dnc_pending' || prospect.quarantineReason === 'dnc_registered') {
+      throw new d.AppError(
+        'This lead is held by the DNC (Do Not Call) gate and cannot be manually assigned — it releases automatically once the DNC check clears.',
         409
       );
     }

--- a/backend/src/services/retellService.js
+++ b/backend/src/services/retellService.js
@@ -9,7 +9,9 @@ import { sendLeadAssignmentEmail } from './mailer.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
 import { CircuitBreaker } from '../utils/circuitBreaker.js';
-import { destinationForAgent, externalIdForDestination, buildLeadHeldPayload } from './prospectHelpers.js';
+import { destinationForAgent, externalIdForDestination, buildLeadHeldPayload, dncPayloadBlock } from './prospectHelpers.js';
+import { dncEnforcement, formatDncNumber, checkAndRecord as dncCheckAndRecord } from './dncService.js';
+import { gateHeldDncLead } from './dncGate.js';
 
 const IDEMPOTENCY_SCOPE = 'retell:call';
 const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -38,6 +40,10 @@ const defaultDeps = {
   resolveLeadRouting,
   chargeLeadCredit,
   decideAssignment,
+  dncEnforcement,
+  formatDncNumber,
+  dncCheckAndRecord,
+  gateHeldDncLead,
   dispatchEvent,
   sendLeadAssignmentEmail,
   AppError,
@@ -250,6 +256,15 @@ export function makeRetellService(overrides = {}) {
       routeVia = routing.via;
     }
 
+    // DNC scrubbing mode for this lead (number from the Retell call). docs/plans/dnc-scrubbing.md.
+    // NOTE: scrubs prospect.phone (= to_number), the number an agent calls back. If Retell calls
+    // are inbound, the consumer is from_number — confirm the mapping (design §8.8).
+    const dncMode = d.dncEnforcement();
+    const dncNumber = dncMode !== 'off' && to_number ? d.formatDncNumber(to_number) : null;
+    const dncBlockApplies = dncMode === 'block' && !!dncNumber;
+    const dncFlagApplies = dncMode === 'flag' && !!dncNumber;
+    const dncWillCheck = dncBlockApplies || dncFlagApplies;
+
     // ── Create prospect in a transaction (with idempotency key) ──
     // Lead-quota gate: decideAssignment charges authoritatively for a funded gated
     // route, or quarantines (held) when no funded agent. Retell never best-effort
@@ -266,7 +281,22 @@ export function makeRetellService(overrides = {}) {
         charge: d.chargeLeadCredit,
       });
       quarantined = decision.action === 'quarantine';
+      let heldReason = quarantined ? decision.quarantineReason : null;
       assignedAgentId = quarantined ? null : (decision.assignedAgentId ?? null);
+
+      // DNC block-mode gate (mirrors prospectService.createProspect): a normally-assignable
+      // lead is HELD pending the DNC check; released post-commit on clear.
+      let dncHeld = false;
+      let dncIntendedAgentId = null;
+      let dncAlreadyCharged = false;
+      if (dncBlockApplies && !quarantined) {
+        dncIntendedAgentId = assignedAgentId;
+        dncAlreadyCharged = decision.charged === true;
+        dncHeld = true;
+        quarantined = true;
+        heldReason = 'dnc_pending';
+        assignedAgentId = null;
+      }
 
       const prospect = await d.Prospect.create({
         firstName,
@@ -281,7 +311,9 @@ export function makeRetellService(overrides = {}) {
         campaignId,
         assignedAgentId,
         quarantinedAt: quarantined ? new Date() : null,
-        quarantineReason: quarantined ? decision.quarantineReason : null,
+        quarantineReason: quarantined ? heldReason : null,
+        ...(dncWillCheck ? { dncStatus: 'pending' } : {}),
+        ...(dncHeld ? { dncMetadata: { intendedAgentId: dncIntendedAgentId, alreadyCharged: dncAlreadyCharged } } : {}),
         preferences: {
           contactMethod: 'phone',
           contactTime: '',
@@ -327,6 +359,19 @@ export function makeRetellService(overrides = {}) {
 
       await t.commit();
 
+      // ── DNC scrubbing (post-commit) ──
+      // Block: gate the held lead (release-on-clear → first lead.created, or keep held).
+      // Flag: check + record so the inline lead.created below carries the DNC result.
+      if (dncHeld) {
+        await d.gateHeldDncLead(prospect).catch((err) =>
+          d.logger.error('[DNC] retell gate error', { error: err?.message || String(err) })
+        );
+      } else if (dncFlagApplies) {
+        await d.dncCheckAndRecord(prospect).catch((err) =>
+          d.logger.error('[DNC] retell check error', { error: err?.message || String(err) })
+        );
+      }
+
       // ── Fire outgoing webhooks (post-commit, fire-and-forget) ──
       // Look up assigned agent for routing info
       let agentForWebhook = null;
@@ -363,6 +408,7 @@ export function makeRetellService(overrides = {}) {
             sourceMetadata: prospect.sourceMetadata,
             recordingUrl: recording_url || null,
             transcript: prospect.notes,
+            dnc: dncPayloadBlock(prospect),
             createdAt: prospect.createdAt
           },
           routing: {

--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -27,6 +27,13 @@ export const logger = pino({
       'apikey',
       'headers.apikey',
       'serviceRoleKey',
+      // DNC Registry: the RSA signing key + the signed request signature/header.
+      'privateKey',
+      'DNC_PRIVATE_KEY',
+      'appSignature',
+      'signature',
+      'authorization',
+      'secret',
     ],
     censor: '[REDACTED]',
   },

--- a/backend/src/utils/sentryScrub.js
+++ b/backend/src/utils/sentryScrub.js
@@ -3,7 +3,7 @@
 // patterns. Substring-based, case-insensitive match on key names so
 // `agentPhone`, `lead_email`, `staff_full_name`, etc. all get redacted.
 
-const PII_KEY_PATTERN = /phone|email|nric|name|token|jwt|address|otp|password/i;
+const PII_KEY_PATTERN = /phone|email|nric|name|token|jwt|address|otp|password|signature|secret|private_?key|authorization/i;
 
 export function scrubObject(input) {
   if (input == null || typeof input !== 'object') return input;

--- a/backend/test/unit/dncBackfillService.test.js
+++ b/backend/test/unit/dncBackfillService.test.js
@@ -1,0 +1,64 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('@sentry/node', () => ({ captureException: jest.fn() }));
+jest.unstable_mockModule('../../src/utils/logger.js', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.unstable_mockModule('../../src/models/index.js', () => ({ sequelize: {}, Prospect: { findAll: jest.fn() } }));
+jest.unstable_mockModule('../../src/services/dncGate.js', () => ({ gateHeldDncLead: jest.fn() }));
+jest.unstable_mockModule('../../src/services/dncService.js', () => ({ dncReady: jest.fn() }));
+
+let svc;
+beforeAll(async () => {
+  svc = await import('../../src/services/dncBackfillService.js');
+});
+
+const mkDeps = (over = {}) => ({
+  dncReady: jest.fn(() => true),
+  sequelize: {
+    QueryTypes: { SELECT: 'SELECT' },
+    transaction: jest.fn(async (cb) => cb({})),
+    query: jest.fn().mockResolvedValue([{ locked: true }]),
+  },
+  Prospect: { findAll: jest.fn().mockResolvedValue([]) },
+  gateHeldDncLead: jest.fn(),
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  ...over,
+});
+
+describe('runDncBackfill', () => {
+  it('skips when DNC is not configured', async () => {
+    const deps = mkDeps({ dncReady: jest.fn(() => false) });
+    const r = await svc.runDncBackfill(deps);
+    expect(r).toEqual({ ran: false, reason: 'not_ready' });
+    expect(deps.Prospect.findAll).not.toHaveBeenCalled();
+  });
+
+  it('skips when the job lock is held elsewhere', async () => {
+    const deps = mkDeps();
+    deps.sequelize.query.mockResolvedValue([{ locked: false }]);
+    const r = await svc.runDncBackfill(deps);
+    expect(r).toMatchObject({ ran: false, reason: 'lock_held' });
+    expect(deps.Prospect.findAll).not.toHaveBeenCalled();
+  });
+
+  it('processes held pending leads and tallies outcomes', async () => {
+    const deps = mkDeps();
+    deps.Prospect.findAll.mockResolvedValue([{ id: 'a' }, { id: 'b' }, { id: 'c' }]);
+    deps.gateHeldDncLead
+      .mockResolvedValueOnce({ outcome: 'released', status: 'clear' })
+      .mockResolvedValueOnce({ outcome: 'held', status: 'registered' })
+      .mockResolvedValueOnce({ outcome: 'held', status: 'pending' });
+    const r = await svc.runDncBackfill(deps);
+    expect(r).toMatchObject({ ran: true, released: 1, held: 1, errors: 1, total: 3 });
+    expect(deps.gateHeldDncLead).toHaveBeenCalledTimes(3);
+  });
+
+  it('selects only dnc_pending, contactable (non-terminal) leads', async () => {
+    const deps = mkDeps();
+    await svc.runDncBackfill(deps);
+    const where = deps.Prospect.findAll.mock.calls[0][0].where;
+    expect(where.quarantineReason).toBe('dnc_pending');
+    expect(where.leadStatus).toBeDefined(); // Op.notIn ['won','lost']
+  });
+});

--- a/backend/test/unit/dncGate.test.js
+++ b/backend/test/unit/dncGate.test.js
@@ -1,0 +1,148 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('@sentry/node', () => ({ captureException: jest.fn(), captureMessage: jest.fn(), init: jest.fn() }));
+jest.unstable_mockModule('../../src/utils/logger.js', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+jest.unstable_mockModule('../../src/models/index.js', () => ({
+  sequelize: { transaction: jest.fn(), query: jest.fn() },
+  Prospect: { findByPk: jest.fn() },
+  ProspectActivity: { create: jest.fn() },
+  User: { findByPk: jest.fn() },
+}));
+jest.unstable_mockModule('../../src/services/leadCredits.js', () => ({ chargeLeadCredit: jest.fn() }));
+jest.unstable_mockModule('../../src/services/webhookService.js', () => ({
+  persistEventDeliveries: jest.fn(),
+  flushDeliveries: jest.fn(),
+}));
+jest.unstable_mockModule('../../src/services/prospectHelpers.js', () => ({
+  buildLeadCreatedPayload: jest.fn(() => ({ event: 'lead.created' })),
+  destinationForAgent: jest.fn(() => 'lyfe'),
+  externalIdForDestination: jest.fn(() => 'L1'),
+}));
+jest.unstable_mockModule('../../src/services/dncService.js', () => ({ checkAndRecord: jest.fn() }));
+
+let gate;
+beforeAll(async () => {
+  gate = await import('../../src/services/dncGate.js');
+});
+
+const baseLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+
+describe('gateHeldDncLead', () => {
+  it('CLEAR → releases to the intended agent captured from dncMetadata', async () => {
+    const release = jest.fn().mockResolvedValue({ released: true });
+    const checkAndRecord = jest.fn().mockResolvedValue({ status: 'clear', noVoiceCall: false });
+    const prospect = { id: 'p1', dncMetadata: { intendedAgentId: 'a1', alreadyCharged: false } };
+    const out = await gate.gateHeldDncLead(prospect, { checkAndRecord, releaseDncClearedLead: release, logger: baseLogger });
+    expect(out.outcome).toBe('released');
+    expect(release).toHaveBeenCalledWith({ prospect, agentId: 'a1', alreadyCharged: false }, expect.anything());
+  });
+
+  it('REGISTERED on voice → kept held, reason relabeled dnc_registered, no release', async () => {
+    const release = jest.fn();
+    const checkAndRecord = jest.fn().mockResolvedValue({ status: 'registered', noVoiceCall: true });
+    const update = jest.fn().mockResolvedValue();
+    const prospect = { id: 'p2', dncMetadata: { intendedAgentId: 'a1' }, update };
+    const out = await gate.gateHeldDncLead(prospect, { checkAndRecord, releaseDncClearedLead: release, logger: baseLogger });
+    expect(out).toMatchObject({ outcome: 'held', status: 'registered' });
+    expect(update).toHaveBeenCalledWith({ quarantineReason: 'dnc_registered' });
+    expect(release).not.toHaveBeenCalled();
+  });
+
+  it('REGISTERED on text only (voice clear) → still released', async () => {
+    const release = jest.fn().mockResolvedValue({ released: true });
+    const checkAndRecord = jest.fn().mockResolvedValue({ status: 'registered', noVoiceCall: false, noTextMessage: true });
+    const prospect = { id: 'p3', dncMetadata: { intendedAgentId: 'a1' } };
+    const out = await gate.gateHeldDncLead(prospect, { checkAndRecord, releaseDncClearedLead: release, logger: baseLogger });
+    expect(out.outcome).toBe('released');
+    expect(release).toHaveBeenCalled();
+  });
+
+  it('PENDING → stays held, no release, no relabel', async () => {
+    const release = jest.fn();
+    const update = jest.fn();
+    const checkAndRecord = jest.fn().mockResolvedValue({ status: 'pending' });
+    const out = await gate.gateHeldDncLead({ id: 'p4', dncMetadata: {}, update }, { checkAndRecord, releaseDncClearedLead: release, logger: baseLogger });
+    expect(out).toMatchObject({ outcome: 'held', status: 'pending' });
+    expect(release).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('check throws → left held with status error', async () => {
+    const checkAndRecord = jest.fn().mockRejectedValue(new Error('boom'));
+    const out = await gate.gateHeldDncLead({ id: 'p5', dncMetadata: {} }, { checkAndRecord, releaseDncClearedLead: jest.fn(), logger: baseLogger });
+    expect(out).toMatchObject({ outcome: 'held', status: 'error' });
+  });
+});
+
+describe('releaseDncClearedLead', () => {
+  const mkDeps = (over = {}) => {
+    const tx = { commit: jest.fn().mockResolvedValue(), rollback: jest.fn().mockResolvedValue() };
+    return {
+      tx,
+      deps: {
+        sequelize: { transaction: jest.fn().mockResolvedValue(tx), query: jest.fn().mockResolvedValue([[{ id: 'p1' }]]) },
+        Prospect: { findByPk: jest.fn().mockResolvedValue({ id: 'p1', campaign: { id: 'c1', name: 'C' } }) },
+        ProspectActivity: { create: jest.fn().mockResolvedValue({}) },
+        User: { findByPk: jest.fn().mockResolvedValue({ id: 'a1', lyfeId: 'L1', phone: 'p', email: 'e', firstName: 'F', lastName: 'G' }) },
+        chargeLeadCredit: jest.fn().mockResolvedValue(true),
+        persistEventDeliveries: jest.fn().mockResolvedValue([{ delivery: {}, subscriber: {} }]),
+        flushDeliveries: jest.fn(),
+        buildLeadCreatedPayload: jest.fn(() => ({ event: 'lead.created' })),
+        destinationForAgent: jest.fn(() => 'lyfe'),
+        externalIdForDestination: jest.fn(() => 'L1'),
+        logger: baseLogger,
+        ...over,
+      },
+    };
+  };
+  const prospect = () => ({ id: 'p1', campaignId: 'c1', reload: jest.fn().mockResolvedValue() });
+
+  it('happy path → claims, charges, persists outbox, commits, flushes', async () => {
+    const { tx, deps } = mkDeps();
+    const res = await gate.releaseDncClearedLead({ prospect: prospect(), agentId: 'a1', alreadyCharged: false }, deps);
+    expect(res).toEqual({ released: true });
+    expect(deps.chargeLeadCredit).toHaveBeenCalledWith('a1', 'c1', tx);
+    expect(deps.persistEventDeliveries).toHaveBeenCalled();
+    expect(tx.commit).toHaveBeenCalled();
+    expect(deps.flushDeliveries).toHaveBeenCalled();
+  });
+
+  it('no intended agent → not released, no transaction opened', async () => {
+    const { deps } = mkDeps();
+    const res = await gate.releaseDncClearedLead({ prospect: prospect(), agentId: null }, deps);
+    expect(res).toMatchObject({ released: false, reason: 'no_intended_agent' });
+    expect(deps.sequelize.transaction).not.toHaveBeenCalled();
+  });
+
+  it('lost claim (already released) → rolls back', async () => {
+    const { tx, deps } = mkDeps();
+    deps.sequelize.query.mockResolvedValue([[]]);
+    const res = await gate.releaseDncClearedLead({ prospect: prospect(), agentId: 'a1' }, deps);
+    expect(res).toMatchObject({ released: false, reason: 'lost_claim' });
+    expect(tx.rollback).toHaveBeenCalled();
+    expect(deps.chargeLeadCredit).not.toHaveBeenCalled();
+  });
+
+  it('no credit → rolls back (re-held)', async () => {
+    const { tx, deps } = mkDeps({ chargeLeadCredit: jest.fn().mockResolvedValue(false) });
+    const res = await gate.releaseDncClearedLead({ prospect: prospect(), agentId: 'a1' }, deps);
+    expect(res).toMatchObject({ released: false, reason: 'no_credit' });
+    expect(tx.rollback).toHaveBeenCalled();
+  });
+
+  it('alreadyCharged → skips the charge', async () => {
+    const { deps } = mkDeps();
+    const res = await gate.releaseDncClearedLead({ prospect: prospect(), agentId: 'a1', alreadyCharged: true }, deps);
+    expect(res).toEqual({ released: true });
+    expect(deps.chargeLeadCredit).not.toHaveBeenCalled();
+  });
+
+  it('no delivery subscriber → rolls back (fail closed)', async () => {
+    const { tx, deps } = mkDeps({ persistEventDeliveries: jest.fn().mockResolvedValue([]) });
+    const res = await gate.releaseDncClearedLead({ prospect: prospect(), agentId: 'a1' }, deps);
+    expect(res).toMatchObject({ released: false, reason: 'no_subscriber' });
+    expect(tx.rollback).toHaveBeenCalled();
+  });
+});

--- a/backend/test/unit/dncService.test.js
+++ b/backend/test/unit/dncService.test.js
@@ -1,0 +1,256 @@
+import { jest } from '@jest/globals';
+import crypto from 'crypto';
+
+// Mocks BEFORE importing the SUT (Jest ESM pattern).
+jest.unstable_mockModule('@sentry/node', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+  init: jest.fn(),
+  setTag: jest.fn(),
+}));
+jest.unstable_mockModule('../../src/utils/logger.js', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+// Mock models/index.js so importing the SUT does NOT open a DB connection.
+jest.unstable_mockModule('../../src/models/index.js', () => ({
+  Prospect: { update: jest.fn() },
+  ProspectActivity: { create: jest.fn().mockResolvedValue({}) },
+  sequelize: { transaction: jest.fn(), query: jest.fn() },
+}));
+
+let dnc;
+beforeAll(async () => {
+  dnc = await import('../../src/services/dncService.js');
+});
+
+function keypair() {
+  return crypto.generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+}
+
+describe('formatDncNumber', () => {
+  it.each([
+    ['+65 9123 4567', '91234567'],
+    ['6591234567', '91234567'],
+    ['91234567', '91234567'],
+    ['+6581234567', '81234567'],
+    ['31234567', '31234567'],
+    ['61234567', '61234567'],
+  ])('%s -> %s', (input, expected) => {
+    expect(dnc.formatDncNumber(input)).toBe(expected);
+  });
+
+  it.each([['21234567'], ['+14155550123'], ['1234'], [''], [null], [undefined]])(
+    'rejects %s',
+    (input) => {
+      expect(dnc.formatDncNumber(input)).toBeNull();
+    }
+  );
+});
+
+describe('buildBaseString / buildAuthHeader', () => {
+  it('base string is in the fixed order', () => {
+    expect(
+      dnc.buildBaseString({ orgCode: 'ORGF000000000071', eServiceId: 'dncmyinfo', timestamp: 1602225459377 })
+    ).toBe('orgCode=ORGF000000000071&eServiceId=dncmyinfo&timestamp=1602225459377');
+  });
+  it('auth header appends appSignature last', () => {
+    expect(dnc.buildAuthHeader({ orgCode: 'O', eServiceId: 'E', timestamp: 123, appSignature: 'SIG' })).toBe(
+      'orgCode=O&eServiceId=E&timestamp=123&appSignature=SIG'
+    );
+  });
+});
+
+describe('signRequest', () => {
+  it('produces an RSA-SHA256 signature verifiable with the public key, no line breaks', () => {
+    const { privateKey, publicKey } = keypair();
+    const base = dnc.buildBaseString({ orgCode: 'O', eServiceId: 'E', timestamp: 123 });
+    const sig = dnc.signRequest(base, privateKey);
+    expect(typeof sig).toBe('string');
+    expect(sig).not.toMatch(/\n/);
+    const v = crypto.createVerify('RSA-SHA256');
+    v.update(base, 'utf8');
+    v.end();
+    expect(v.verify(publicKey, sig, 'base64')).toBe(true);
+  });
+
+  it('handles PEM stored with literal \\n', () => {
+    const { privateKey, publicKey } = keypair();
+    const escaped = privateKey.replace(/\n/g, '\\n');
+    const base = 'orgCode=O&eServiceId=E&timestamp=1';
+    const sig = dnc.signRequest(base, escaped);
+    const v = crypto.createVerify('RSA-SHA256');
+    v.update(base);
+    v.end();
+    expect(v.verify(publicKey, sig, 'base64')).toBe(true);
+  });
+});
+
+describe('mapStatusCode', () => {
+  it('S000 ok', () => expect(dnc.mapStatusCode('S000')).toEqual({ ok: true }));
+  it('S301 insufficient credits → retriable + alert', () =>
+    expect(dnc.mapStatusCode('S301')).toMatchObject({ ok: false, retriable: true, alert: true, reason: 'insufficient_credits' }));
+  it('S501 retriable', () => expect(dnc.mapStatusCode('S501')).toMatchObject({ ok: false, retriable: true }));
+  it.each(['S401', 'S402', 'S404'])('%s → auth, not retriable, alert', (c) =>
+    expect(dnc.mapStatusCode(c)).toMatchObject({ reason: 'auth', retriable: false, alert: true }));
+  it('unknown → retriable', () =>
+    expect(dnc.mapStatusCode('S999')).toMatchObject({ ok: false, retriable: true, reason: 'unknown' }));
+});
+
+describe('parseValidUntil', () => {
+  it('parses the PDPC msg', () => {
+    const d = dnc.parseValidUntil('These results are valid until 06-Nov-2020');
+    expect(d).toBeInstanceOf(Date);
+    expect(d.getUTCFullYear()).toBe(2020);
+    expect(d.getUTCMonth()).toBe(10); // November
+  });
+  it('null on no date', () => expect(dnc.parseValidUntil('no date here')).toBeNull());
+});
+
+describe('parseResponse', () => {
+  it('maps R/NR to booleans and extracts metadata', () => {
+    const json = {
+      msg: 'These results are valid until 06-Nov-2020',
+      numbers: [
+        { number: '90000001', no_voice_call: 'R', no_text_message: 'NR', no_fax: 'NR' },
+        { number: '90000002', no_voice_call: 'NR', no_text_message: 'NR', no_fax: 'NR' },
+      ],
+      transactionid: '5506778',
+      created_time: '2020-10-07 17:34:53',
+      status_code: 'S000',
+    };
+    const r = dnc.parseResponse(json);
+    expect(r.statusCode).toBe('S000');
+    expect(r.transactionId).toBe('5506778');
+    expect(r.results[0]).toEqual({ number: '90000001', noVoiceCall: true, noTextMessage: false, noFax: false });
+    expect(r.results[1].noVoiceCall).toBe(false);
+    expect(r.validUntil).toBeInstanceOf(Date);
+  });
+});
+
+describe('nextTimestamp', () => {
+  it('is strictly monotonic even when the clock regresses', () => {
+    const a = dnc.nextTimestamp(1000);
+    const b = dnc.nextTimestamp(1000);
+    const c = dnc.nextTimestamp(500);
+    expect(b).toBeGreaterThan(a);
+    expect(c).toBeGreaterThan(b);
+  });
+});
+
+describe('hasFreshDnc', () => {
+  const future = new Date(Date.now() + 86400000);
+  const past = new Date(Date.now() - 86400000);
+  it('clear + future = fresh', () => expect(dnc.hasFreshDnc({ dncStatus: 'clear', dncValidUntil: future })).toBe(true));
+  it('registered + future = fresh', () =>
+    expect(dnc.hasFreshDnc({ dncStatus: 'registered', dncValidUntil: future })).toBe(true));
+  it('expired = stale', () => expect(dnc.hasFreshDnc({ dncStatus: 'clear', dncValidUntil: past })).toBe(false));
+  it('pending = stale', () => expect(dnc.hasFreshDnc({ dncStatus: 'pending', dncValidUntil: future })).toBe(false));
+});
+
+describe('checkNumbers (mock fetch, skipLock)', () => {
+  it('posts a signed request to the endpoint and parses the response', async () => {
+    const { privateKey } = keypair();
+    const cfg = {
+      enabled: true, baseUrl: 'https://uat.dnc.gov.sg/realtime', orgCode: 'ORG', eServiceId: 'ESVC',
+      privateKey, checkOnBehalf: 'N', proxy: null, timeoutMs: 5000,
+    };
+    const fetchMock = jest.fn().mockResolvedValue({
+      status: 200,
+      json: async () => ({
+        msg: 'valid until 06-Nov-2020',
+        numbers: [{ number: '90000001', no_voice_call: 'NR', no_text_message: 'NR', no_fax: 'NR' }],
+        transactionid: 'T1',
+        status_code: 'S000',
+      }),
+    });
+    const res = await dnc.checkNumbers(['90000001'], { cfg }, { fetch: fetchMock, skipLock: true });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://uat.dnc.gov.sg/realtime/check/registry');
+    expect(opts.method).toBe('POST');
+    expect(opts.headers.Authorization).toMatch(/^orgCode=ORG&eServiceId=ESVC&timestamp=\d+&appSignature=.+/);
+    expect(JSON.parse(opts.body)).toEqual({ numbers: ['90000001'], total: 1, checkOnBehalf: 'N' });
+    expect(res.statusCode).toBe('S000');
+    expect(res.results[0].noVoiceCall).toBe(false);
+  });
+});
+
+describe('checkAndRecord (mock fetch + models)', () => {
+  const { privateKey } = keypair();
+  const cfg = {
+    enabled: true, baseUrl: 'https://x/realtime', orgCode: 'O', eServiceId: 'E',
+    privateKey, checkOnBehalf: 'N', proxy: null, timeoutMs: 5000,
+  };
+  const mkDeps = (json) => {
+    const Prospect = { update: jest.fn().mockResolvedValue([1]) };
+    const ProspectActivity = { create: jest.fn().mockResolvedValue({}) };
+    const fetch = jest.fn().mockResolvedValue({ status: 200, json: async () => json });
+    return { fetch, skipLock: true, Prospect, ProspectActivity, cfg, logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() } };
+  };
+
+  it('records a clear number', async () => {
+    const deps = mkDeps({
+      msg: 'valid until 06-Nov-2030',
+      numbers: [{ number: '90000001', no_voice_call: 'NR', no_text_message: 'NR', no_fax: 'NR' }],
+      transactionid: 'T1', status_code: 'S000',
+    });
+    const out = await dnc.checkAndRecord({ id: 'p1', phone: '+6590000001' }, deps);
+    expect(out.status).toBe('clear');
+    const [fields] = deps.Prospect.update.mock.calls[0];
+    expect(fields.dncStatus).toBe('clear');
+    expect(fields.dncNoVoiceCall).toBe(false);
+    expect(deps.ProspectActivity.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('records a registered number (voice)', async () => {
+    const deps = mkDeps({
+      msg: 'valid until 06-Nov-2030',
+      numbers: [{ number: '90000001', no_voice_call: 'R', no_text_message: 'NR', no_fax: 'NR' }],
+      transactionid: 'T2', status_code: 'S000',
+    });
+    const out = await dnc.checkAndRecord({ id: 'p2', phone: '90000001' }, deps);
+    expect(out.status).toBe('registered');
+    expect(out.noVoiceCall).toBe(true);
+    const [fields] = deps.Prospect.update.mock.calls[0];
+    expect(fields.dncStatus).toBe('registered');
+    expect(fields.dncNoVoiceCall).toBe(true);
+  });
+
+  it('skips a non-SG number without calling the API', async () => {
+    const deps = mkDeps({});
+    const out = await dnc.checkAndRecord({ id: 'p3', phone: '+14155550123' }, deps);
+    expect(out.status).toBe('skipped');
+    expect(deps.fetch).not.toHaveBeenCalled();
+    const [fields] = deps.Prospect.update.mock.calls[0];
+    expect(fields.dncStatus).toBe('skipped');
+  });
+
+  it('uses the cache (no API call) when a fresh result exists', async () => {
+    const deps = mkDeps({});
+    const future = new Date(Date.now() + 86400000);
+    const out = await dnc.checkAndRecord({ id: 'p4', phone: '90000001', dncStatus: 'clear', dncValidUntil: future }, deps);
+    expect(out).toEqual({ status: 'clear', cached: true });
+    expect(deps.fetch).not.toHaveBeenCalled();
+  });
+
+  it('marks pending on S301 (insufficient credits)', async () => {
+    const deps = mkDeps({ status_code: 'S301', numbers: [] });
+    const out = await dnc.checkAndRecord({ id: 'p5', phone: '90000001' }, deps);
+    expect(out.status).toBe('pending');
+    const [fields] = deps.Prospect.update.mock.calls[0];
+    expect(fields.dncStatus).toBe('pending');
+    expect(deps.ProspectActivity.create).not.toHaveBeenCalled();
+  });
+
+  it('returns disabled when not configured', async () => {
+    const deps = mkDeps({});
+    deps.cfg = { ...cfg, enabled: false };
+    const out = await dnc.checkAndRecord({ id: 'p6', phone: '90000001' }, deps);
+    expect(out.status).toBe('disabled');
+    expect(deps.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/docs/dnc/egress-proxy-runbook.md
+++ b/docs/dnc/egress-proxy-runbook.md
@@ -1,0 +1,254 @@
+# DNC egress proxy — DigitalOcean Singapore (runbook)
+
+**Purpose:** give the MKTR backend ONE permanent outbound IP for PDPC DNC API calls. PDPC firewall-allowlists this IP. Only DNC calls route through the proxy (via `DNC_HTTPS_PROXY`); all other backend traffic is unaffected.
+
+**Decision:** DigitalOcean droplet in Singapore (SGP1) running **tinyproxy** as an HTTP `CONNECT` proxy. ~USD 4/mo.
+
+> **PROVISIONED 2026-06-29.** Droplet `dnc-egress` (SGP1, Ubuntu 24.04). **Egress IP = `159.89.201.126`** (verified — this is the IP to give PDPC). tinyproxy live on `:8888` with Basic auth + DNC-only filter (verified: `dnc.gov.sg` → 302, everything else → blocked). SSH key-only, root login disabled, admin user `mktr` (passwordless sudo), `ufw` + `fail2ban` active. Proxy credentials saved locally at `~/dnc-keys/proxy-credentials.txt`. **Still TODO:** (1) restrict port 8888 to the 3 Render egress IPs via DO Cloud Firewall (currently open to the internet but gated by Basic auth + filter); (2) optional stunnel TLS (§4) before heavy prod.
+
+---
+
+## Architecture
+
+```
+Render backend (mktr-backend-jo6r, shared egress)
+      │  HTTPS CONNECT  (only DNC calls, via DNC_HTTPS_PROXY)
+      ▼
+DO droplet "dnc-egress"  (Singapore, fixed primary IPv4)  ── tinyproxy :8888
+      │  TLS tunnel (end-to-end to DNC)
+      ▼
+https://www.dnc.gov.sg/realtime/check/registry   (prod)   |   https://uat.dnc.gov.sg/... (UAT)
+```
+
+- The proxy uses HTTP **`CONNECT`**, so TLS is negotiated **end-to-end between the backend and DNC**. The proxy only sees `CONNECT www.dnc.gov.sg:443` — **never the phone-number payload**.
+- **The IP you give PDPC = the droplet's PRIMARY public IPv4.** It is static for the life of the droplet.
+
+> ⚠️ **Gotcha — do NOT use a Reserved/Floating IP for this.** DO Reserved IPs are **inbound-only**; a droplet's *outbound* traffic egresses from its **primary** public IP by default, not the Reserved IP (that needs SNAT gymnastics). Since we care about *egress*, submit the droplet's **primary** IPv4 to PDPC and skip the Reserved IP. (Reserved-IP-as-egress via SNAT is an optional DR enhancement — see §8.)
+
+---
+
+## 0. Prerequisites
+
+- A DigitalOcean account; optionally `doctl` (`brew install doctl && doctl auth init`).
+- An SSH keypair (`~/.ssh/id_ed25519.pub`).
+- The **3 Render outbound IPs** for `mktr-backend-jo6r` — dashboard → the service → **Connect** (or Settings) → **Outbound IP Addresses**. Needed for the firewall allowlist.
+
+---
+
+## 1. Provision the droplet
+
+Dashboard: **Create → Droplet**
+- **Region:** Singapore (SGP1)
+- **Image:** Ubuntu 24.04 LTS
+- **Type:** Basic → Regular → **$4–6/mo** (512 MB–1 GB; tinyproxy is tiny)
+- **Auth:** SSH key (no password)
+- **Hostname:** `dnc-egress`
+
+Or via `doctl`:
+```bash
+doctl compute droplet create dnc-egress \
+  --region sgp1 --image ubuntu-24-04-x64 --size s-1vcpu-512mb-10gb \
+  --ssh-keys "$(doctl compute ssh-key list --format ID --no-header | head -1)" \
+  --wait
+doctl compute droplet get dnc-egress --format PublicIPv4 --no-header
+```
+
+**Record the PRIMARY public IPv4** that prints — this is the IP you submit to PDPC.
+
+---
+
+## 2. Lock down the box
+
+SSH in (`ssh root@<droplet-ip>`), then:
+
+```bash
+# Non-root sudo user
+adduser --disabled-password --gecos "" mktr
+usermod -aG sudo mktr
+echo 'mktr ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/mktr && chmod 440 /etc/sudoers.d/mktr
+install -d -m 700 -o mktr -g mktr /home/mktr/.ssh
+cp /root/.ssh/authorized_keys /home/mktr/.ssh/ && chown mktr:mktr /home/mktr/.ssh/authorized_keys && chmod 600 /home/mktr/.ssh/authorized_keys
+
+# SSH: keys only, no root login
+sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin no/; s/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+systemctl restart ssh
+
+# Auto security patches
+apt update && apt -y install unattended-upgrades fail2ban
+dpkg-reconfigure -f noninteractive unattended-upgrades
+
+# Host firewall (ufw) — SSH + proxy port only
+ufw default deny incoming && ufw default allow outgoing
+ufw allow 22/tcp
+ufw allow 8888/tcp
+ufw --force enable
+```
+
+**DigitalOcean Cloud Firewall** (dashboard → Networking → Firewalls, or `doctl`): attach to `dnc-egress`.
+- **Inbound:**
+  - SSH `22` — from your admin IP only (tighten later).
+  - Proxy `8888` — from the **3 Render egress IPs only**.
+- **Outbound:** `443` to all (or restrict to DNC — see §3 filter).
+
+> ⚠️ Render egress IPs are **shared across Render tenants**, so an IP allowlist alone is not enough — anyone else on those IPs could reach port 8888. That's why **Basic auth + a destination filter** (next step) are mandatory, not optional.
+
+---
+
+## 3. Install + configure tinyproxy
+
+```bash
+apt -y install tinyproxy
+```
+
+Edit `/etc/tinyproxy/tinyproxy.conf` — set/replace these directives:
+
+```conf
+User tinyproxy
+Group tinyproxy
+Port 8888
+Timeout 600
+Listen 0.0.0.0
+# Identity (defence-in-depth alongside the cloud firewall)
+BasicAuth dncproxy CHANGE_ME_TO_A_LONG_RANDOM_SECRET
+# Only allow CONNECT to 443 (drop the default 563/8443 lines)
+ConnectPort 443
+# Whitelist destinations — DNC only, even if creds leak (no open relay)
+FilterDefaultDeny Yes
+FilterExtended Yes
+Filter "/etc/tinyproxy/dnc-allow.filter"
+# Hygiene
+DisableViaHeader Yes
+# Optional: also IP-restrict at the app layer (mirror the 3 Render egress IPs)
+# Allow 1.2.3.4
+# Allow 5.6.7.8
+# Allow 9.10.11.12
+```
+
+Destination whitelist `/etc/tinyproxy/dnc-allow.filter`:
+```
+dnc\.gov\.sg$
+```
+(Matches `www.dnc.gov.sg` and `uat.dnc.gov.sg`; blocks everything else.)
+
+```bash
+# Generate a strong proxy password and drop it into the config
+PROXY_PASS="$(openssl rand -base64 24)"
+sed -i "s|CHANGE_ME_TO_A_LONG_RANDOM_SECRET|${PROXY_PASS}|" /etc/tinyproxy/tinyproxy.conf
+echo "Proxy password (store in your secret manager): ${PROXY_PASS}"
+
+systemctl restart tinyproxy && systemctl enable tinyproxy
+```
+
+---
+
+## 4. (Recommended) Encrypt the proxy hop — stunnel TLS
+
+`CONNECT` already encrypts the DNC payload end-to-end. TLS to the proxy additionally protects the **Basic-auth credentials** and the destination metadata on the Render→DO hop. For a government-PII integration, do this before heavy production use.
+
+**Option A — real subdomain + Let's Encrypt (no client-side CA needed).**
+1. Point `dnc-egress.mktr.sg` (A record) at the droplet IP.
+2. `apt -y install stunnel4 certbot && certbot certonly --standalone -d dnc-egress.mktr.sg` (temporarily open 80).
+3. `/etc/stunnel/dnc.conf`:
+   ```conf
+   [dnc-proxy]
+   accept = 0.0.0.0:8443
+   connect = 127.0.0.1:8888
+   cert = /etc/letsencrypt/live/dnc-egress.mktr.sg/fullchain.pem
+   key  = /etc/letsencrypt/live/dnc-egress.mktr.sg/privkey.pem
+   ```
+4. `systemctl enable --now stunnel4`; open `8443` (firewall) and **close `8888`** to the internet (bind tinyproxy `Listen 127.0.0.1`). Backend then uses `https://…@dnc-egress.mktr.sg:8443`.
+
+**Option B — self-signed cert pinned in the backend.** Generate a cert on the droplet, point stunnel at it, and pin it in the backend via undici `proxyTls.ca` (see §5). Avoids needing a public DNS record.
+
+For a v1 / UAT you may run plain `:8888` (firewall + auth + filter) and add TLS before prod.
+
+---
+
+## 5. Wire into the backend
+
+**Env var on `mktr-backend-jo6r`** (Render → Environment):
+```
+# plain (v1 / UAT):
+DNC_HTTPS_PROXY=http://dncproxy:<PROXY_PASS>@<droplet-ip>:8888
+# with stunnel TLS (prod):
+DNC_HTTPS_PROXY=https://dncproxy:<PROXY_PASS>@dnc-egress.mktr.sg:8443
+```
+
+**In `dncService.js`** — route only the DNC fetch through the proxy with undici's `ProxyAgent` (Node 18+ `fetch` does **not** honour `*_PROXY` env vars automatically):
+```js
+import { ProxyAgent } from 'undici';
+
+function dncDispatcher() {
+  const uri = process.env.DNC_HTTPS_PROXY;
+  if (!uri) return undefined; // no proxy → direct (UAT-on-allowlisted-IP / tests)
+  const u = new URL(uri);
+  const token =
+    u.username ? 'Basic ' + Buffer.from(`${decodeURIComponent(u.username)}:${decodeURIComponent(u.password)}`).toString('base64') : undefined;
+  return new ProxyAgent({
+    uri: `${u.protocol}//${u.host}`,
+    ...(token ? { token } : {}),
+    // Option B (self-signed proxy cert) only:
+    // proxyTls: { ca: process.env.DNC_PROXY_CA },
+  });
+}
+
+const res = await fetch(`${baseUrl}/check/registry`, {
+  method: 'POST',
+  headers: { Authorization: authHeader, 'Content-Type': 'application/json' },
+  body: JSON.stringify(payload),
+  dispatcher: dncDispatcher(),
+  signal: AbortSignal.timeout(5000),
+});
+```
+
+---
+
+## 6. Verify the egress IP (do this BEFORE submitting to PDPC)
+
+```bash
+# On the droplet — its own egress IP:
+curl -s https://ifconfig.me ; echo
+
+# Through the proxy (from your laptop, temporarily allowed in the firewall):
+curl -s -x "http://dncproxy:<PROXY_PASS>@<droplet-ip>:8888" https://ifconfig.me ; echo
+#   → MUST print the droplet's PRIMARY IPv4 (that's the IP PDPC will see).
+
+# Filter works — DNC allowed, everything else blocked:
+curl -s -o /dev/null -w '%{http_code}\n' -x "http://dncproxy:<PROXY_PASS>@<droplet-ip>:8888" https://uat.dnc.gov.sg   # connects
+curl -s -x "http://dncproxy:<PROXY_PASS>@<droplet-ip>:8888" https://example.com                                       # blocked/filtered
+```
+
+The IP printed by the proxy test is the value to submit to PDPC.
+
+---
+
+## 7. Submit to PDPC
+
+Give PDPC, for **both UAT and Production** onboarding:
+- **Public IP:** the droplet's primary IPv4 (same proxy serves UAT + prod — only the DNC base URL differs, not the egress IP).
+- **Hostname:** `dnc-egress.mktr.sg` (if you set the DNS record) or the droplet's reverse-DNS.
+- The **X.509 cert** `~/dnc-keys/mycert.cer` (self-signed, already generated).
+
+---
+
+## 8. Operations & failure mode
+
+- **Fail-safe:** if the droplet/proxy is down, DNC checks error → leads go `pending`/held, **never delivered un-scrubbed**. Surfaced via `dnc.check.error` logs + Sentry. So an outage degrades safely.
+- **Monitoring:** DO droplet "down" alert + backend Sentry alert on DNC errors.
+- **Patching:** `unattended-upgrades` handles security patches; reboot occasionally (`needrestart`).
+- **Cost:** ~USD 4–6/mo droplet. No Reserved IP needed.
+- **Disaster recovery:** rebuilding the droplet yields a **new** primary IP → re-submit to PDPC (a paperwork hop). To make the IP portable across rebuilds, attach a **Reserved IP and route egress through it via SNAT** (`iptables -t nat -A POSTROUTING -o eth0 -j SNAT --to <reserved-ip>` + DO's anchor-IP setup) — advanced; only worth it once you're tired of re-submitting. Snapshot the droplet weekly regardless.
+
+---
+
+## Checklist
+
+- [ ] Droplet in SGP1, primary IPv4 recorded
+- [ ] Non-root user, SSH keys only, root/password login disabled
+- [ ] `unattended-upgrades` + `fail2ban` + `ufw`
+- [ ] DO Cloud Firewall: SSH from admin IP, 8888/8443 from Render egress IPs only
+- [ ] tinyproxy: `BasicAuth`, `ConnectPort 443` only, `FilterDefaultDeny Yes` → DNC-only
+- [ ] (prod) stunnel TLS, port 8888 closed to the internet
+- [ ] `DNC_HTTPS_PROXY` set on `mktr-backend-jo6r`; `ProxyAgent` wired in `dncService`
+- [ ] Verified the proxy egress IP == droplet primary IPv4
+- [ ] Submitted IP + hostname + `mycert.cer` to PDPC (UAT + prod)

--- a/docs/plans/dnc-scrubbing.md
+++ b/docs/plans/dnc-scrubbing.md
@@ -1,0 +1,376 @@
+# DNC Registry auto-scrubbing — design
+
+**Status:** DRAFT — Codex-reviewed 2026-06-29 (full-doc pass + a focused **xhigh** deep-review of §5.5); findings verified against code + folded in (see §9). Ready for implementation once the open decisions in §8 are settled.
+**Author:** Shawn / Claude
+**Date:** 2026-06-29
+**Driver:** Prudential "Leads to Success" (LTS) vendor onboarding requires every lead be scrubbed against Singapore's PDPC Do Not Call (DNC) Registry before it reaches an adviser who will contact it.
+
+---
+
+## 1. Goal
+
+When a lead is captured (web form, QR, or Retell voice bot), automatically check the lead's Singapore phone number against the PDPC **DNC Registry API** and record, per channel (voice / SMS / fax), whether the number is **Registered (`R`)** or **Not Registered (`NR`)**. Use that result to **suppress or flag outbound contact on DNC-registered channels** before the lead is actionable by an agent, and to produce an **audit trail** that satisfies a Prudential/PDPC compliance review.
+
+Non-goals (this iteration): a self-service DNC console UI; scrubbing of historical prospects beyond an optional one-off backfill; non-Singapore numbers (out of DNC scope).
+
+---
+
+## 2. What the DNC API actually is (from the PDPC spec v1.1 + FAQ)
+
+- **Endpoint:** `POST {BASE}/check/registry`
+  - UAT: `https://uat.dnc.gov.sg/realtime`
+  - Prod: `https://www.dnc.gov.sg/realtime`
+- **Transport:** plain HTTPS (1-way TLS). **No client cert at the TLS layer.** Caller authenticity + integrity is via an **RSA-SHA256 signature** in the `Authorization` header, which PDPC verifies against the **X.509 public cert we submit at onboarding**. Access is additionally gated by **IP allowlisting** at PDPC's firewall.
+- **Batch:** up to **100 numbers per call**, results returned synchronously ("immediately").
+- **Cost:** **1 prepaid credit per number checked**, deducted from MKTR's org DNC account.
+- **Validity:** each response carries a human-readable validity end date in `msg` (PDPC's worked example = ~30 days). We can rely on a result until that date → **cache, don't re-check inside the window** (saves credits).
+- **Three registers** returned per number: `no_voice_call`, `no_text_message`, `no_fax`, each `R` or `NR`.
+
+### 2.1 Authorization header (order-sensitive)
+
+The `Authorization` header value is four `&`-joined fields **in this exact order**:
+
+```
+orgCode=<ORG_CODE>&eServiceId=<ESERVICE_ID>&timestamp=<EPOCH_MS>&appSignature=<BASE64_SIG>
+```
+
+- `orgCode`, `eServiceId` — fixed values PDPC assigns at onboarding.
+- `timestamp` — epoch **milliseconds**, must be a positive integer and **monotonically non-decreasing** across our requests (`>=` previous).
+- `appSignature` — see below.
+
+### 2.2 Signature
+
+```
+baseString = "orgCode=<ORG_CODE>&eServiceId=<ESERVICE_ID>&timestamp=<EPOCH_MS>"
+sig        = RSA-SHA256(baseString) signed with our PEM private key
+appSignature = base64(sig)          # strict base64, NO line breaks
+```
+
+The `timestamp` inside `baseString` **must be the same value** sent in the header. Node reference (matches the spec's worked example):
+
+```js
+const signer = crypto.createSign('RSA-SHA256');
+signer.update(baseString);
+const appSignature = signer.sign(privateKeyPem, 'base64');
+```
+
+### 2.3 Request body
+
+```json
+{ "numbers": ["90000001", "90000002"], "total": 2, "checkOnBehalf": "N" }
+```
+
+- `numbers` — **8-digit** local SG numbers, each starting `3` / `6` / `8` / `9`, max 100.
+- `total` — must equal `numbers.length`. (Spec table says `String`; both worked examples show a JSON number — **verify the accepted type in UAT**.)
+- `checkOnBehalf` — `"Y"` to check on behalf of another organisation, else `"N"` (default). See §3 for why this matters.
+
+### 2.4 Response body
+
+```json
+{
+  "msg": "These results are valid until 06-Nov-2020",
+  "numbers": [
+    { "number": "90000001", "no_voice_call": "NR", "no_text_message": "NR", "no_fax": "NR" }
+  ],
+  "transactionid": "5506778",
+  "created_time": "2020-10-07 17:34:53",
+  "status_code": "S000"
+}
+```
+
+### 2.5 Status codes (Annex A)
+
+| Code | Meaning | Our handling |
+|---|---|---|
+| `S000` | Success | Persist per-number result + `dnc_valid_until` from `msg`. |
+| `S101` | numbers array size ≠ `total` | Bug in our request → Sentry, do not retry as-is. |
+| `S102` | > 100 numbers | Bug (we batch ≤100) → Sentry. |
+| `S301` | Insufficient credits | **Alert admin**, mark `pending`, stop further calls until topped up. |
+| `S401` | Unauthorized | Config/onboarding issue → Sentry + alert. |
+| `S402` | Bad orgCode / eServiceId | Config issue → Sentry + alert. |
+| `S403` | Bad timestamp format | Code bug → Sentry. |
+| `S404` | Auth failed, no mapping for eServiceId | Config/onboarding issue → Sentry + alert. |
+| `S405` | HTTP method not allowed | Code bug → Sentry. |
+| `S501` | DNC internal error | Transient → retry with backoff, then `pending`. |
+
+---
+
+## 3. Compliance model (decisions that gate the build)
+
+> These are **business/compliance** decisions, not code decisions. The recommended defaults below are encoded as config so they can change without a redeploy. **Confirm with Prudential compliance + PDPC before go-live.**
+
+### 3.1 Who is the "caller"? → `checkOnBehalf` + whose account
+
+Under the PDPA the DNC duty falls on whoever *sends* the marketing message. In the LTS model a **Prudential adviser** makes the call, so the duty is theirs. Two operating models:
+
+- **(Recommended) Scrub-as-data-quality.** MKTR checks under its *own* DNC account (`checkOnBehalf="N"`), suppresses/flags DNC-registered channels, and hands over **clean** leads. This is almost certainly what LTS wants — MKTR delivers leads an adviser can safely contact.
+- **Check-on-behalf.** If PDPC/Prudential require the check to be attributable to Prudential as the eventual caller, set `checkOnBehalf="Y"`. This changes onboarding (whose org account, whose credits).
+
+→ **Encoded as `DNC_CHECK_ON_BEHALF` (default `N`).** Decision owner: Shawn, after Prudential confirmation.
+
+### 3.2 Consent interplay
+
+Clear, unambiguous, recorded consent *can* be a lawful basis to contact a DNC-registered number. The lead form already captures `sourceMetadata.consent_contact`. **But** Prudential will likely require scrubbing regardless. So:
+
+- Always check + store the DNC result **and** the consent (we already store consent).
+- **Default: suppress voice contact to a `no_voice_call="R"` number even when consent is present**, unless Prudential explicitly accepts documented consent as an override.
+- → Encoded as `DNC_CONSENT_OVERRIDES` (default `false`). **If ever enabled it must be per-campaign and evidence-backed** — `sourceMetadata.consent_contact` is only marketing-contact consent and is *not* sufficient for a DNC override on its own; an override needs recorded, unambiguous consent evidence in the `consentMetadata.external` shape (`prospectService.js:178`). Not legal advice; confirm with Prudential/PDPC.
+
+### 3.3 Fail-safe default
+
+If the check errors, times out, or is pending, treat the number as **"unknown — do not contact until cleared"** (fail safe). An outage degrades to *held-pending-scrub*, never *delivered-un-scrubbed*.
+
+### 3.4 Enforcement: hard-block vs flag (per channel)
+
+DNC status is **per channel**. Enforcement is configurable:
+
+- **`flag`** — deliver the lead with prominent per-channel flags ("⛔ Do Not Call", "✅ SMS OK"). Agent-friendly; relies on adviser discipline.
+- **`block`** — withhold delivery on a registered channel. For the Prudential pipeline (advisers phone leads), the strongest posture is **block voice when `no_voice_call="R"`** while still allowing the lead through on clear channels.
+
+→ Encoded as `DNC_ENFORCEMENT` (`flag` | `block`, default `block`). Recommended: `block` for the Prudential campaign(s), `flag` elsewhere — can be per-campaign later.
+
+---
+
+## 4. PDPC onboarding prerequisites (parallel track, has lead time)
+
+The code can't hit even UAT until PDPC issues `orgCode` + `eServiceId`. In progress / to-do:
+
+1. **[in progress]** Terminate the **individual** DNC account (Shawn applied 2026-06-29).
+2. Register an **organisation** DNC account for MKTR PTE. LTD. via **Corppass**; assign the "DNC Registry" e-Service to the DNC user's Corppass. *(New-account fees apply.)*
+3. Buy **prepaid DNC credits** (size to lead volume × ~1 credit/number/30 days).
+4. Generate an **RSA keypair**; submit the **X.509 public cert** (`mycert.cer`) to PDPC for **both UAT and Prod**. Keep `privatekey.key` as a backend secret.
+   - **DECIDED: self-signed X.509** (RSA-2048, used with RSA-SHA256). Cryptographically sufficient because PDPC uses the cert only to verify our request signature — not for TLS trust — so a CA chain buys nothing here. Generated locally at `~/dnc-keys/` (`mycert.cer` = public, submit to PDPC; `privatekey.key` = secret → Render `DNC_PRIVATE_KEY`). Only fall back to a CA cert if PDPC's UAT explicitly rejects self-signed.
+5. Provide PDPC the **public egress IP** + **fully-resolved hostname** of our backend for UAT + Prod, and open our firewall to `uat.dnc.gov.sg` / `www.dnc.gov.sg`.
+6. Complete **UAT** with PDPC (mandatory) → receive prod creds → go live.
+
+### 4.1 ⚠️ Egress IP is the #1 infra risk
+
+The backend (`mktr-backend-jo6r`) runs on Render. PDPC allowlists the IP our requests come **from**.
+
+- **Checked 2026-06-29:** `mktr-backend-jo6r` = `srv-d2s9p0emcj7s73acd9lg` — **Singapore** region, **starter** plan (paid), **1 instance**. Render's static **outbound IPs are NOT exposed via the API/MCP**; read them from the dashboard (service → Connect / Settings → "Outbound IP Addresses", a set of ~3). They're static per Render but are **shared Render egress IPs that can change** with infra updates — awkward for a government firewall allowlist that's painful to re-submit.
+- **DECIDED: dedicated DigitalOcean Singapore droplet** running a tinyproxy `CONNECT` proxy (~USD 4–6/mo). The fixed egress = the droplet's **primary public IPv4** (submit *that* to PDPC — NOT a Reserved/Floating IP, which is inbound-only). Only DNC calls route through it via `DNC_HTTPS_PROXY`. Full setup: **`docs/dnc/egress-proxy-runbook.md`**.
+- → `DNC_HTTPS_PROXY` (optional) lets `dncService` route through the proxy without touching the rest of the backend's egress.
+
+---
+
+## 5. Architecture
+
+```
+lead capture ──► createProspect / retellService ──► (post-commit) dncService.checkAndRecord(prospect)
+                                                          │
+                                  ┌───────────────────────┼───────────────────────┐
+                                  ▼                        ▼                        ▼
+                         sign + POST DNC API      persist result on prospect   ProspectActivity audit
+                         (RSA-SHA256, ≤100)       (columns + dncMetadata)      ("DNC check: voice=NR…")
+                                  │
+                                  ▼
+                 enforcement gate decides what the lead.created webhook carries / whether it fires
+                                  │
+                                  ▼
+                 receive-mktr-lead (Lyfe)  ──►  agent app shows per-channel DNC flags
+
+  bootstrap scheduler ──► dncBackfill: retry `pending` + re-check rows nearing dnc_valid_until
+```
+
+### 5.1 New service: `backend/src/services/dncService.js`
+
+Mirrors `metaCapiService.js` (pure builders + injectable `fetch`, never throws to caller, Pino + Sentry on failure).
+
+```
+formatDncNumber(phone) -> "8-digit" | null     // reuse normalizePhone, strip +65, validate ^[3689]\d{7}$
+buildBaseString({ orgCode, eServiceId, timestamp }) -> string   // exported, unit-tested vs spec example
+signRequest(baseString, privateKeyPem) -> base64                // exported
+buildAuthHeader({ orgCode, eServiceId, timestamp, appSignature }) -> string
+checkNumbers(numbers[], { checkOnBehalf }, deps) -> { statusCode, validUntil, results[], transactionId }
+checkAndRecord(prospect, deps) -> { dncStatus, ... }            // single-number convenience; persists + audits
+nextTimestamp() -> ms                                            // monotonic guard: max(Date.now(), last+1)
+```
+
+- **Monotonic timestamp (process-wide, restart-safe):** don't rely on the single-instance assumption alone — the `setInterval` backfill can overlap request-path checks, and restarts/replicas can regress the wall clock. Serialize ALL outbound DNC calls (request-path **and** backfill) through ONE lock using **`pg_try_advisory_xact_lock`** — transaction-scoped, pinned to one connection, auto-released — **not** session-level `pg_advisory_lock`, which leaked under Sequelize's pool (the unlock ran on a different pooled connection; lesson documented at `agentSyncService.js:216`). Scope the lock **per DNC API call** (sign+send), not the whole backfill run, so a fresh lead never queues behind a refresh batch. Persist `lastTimestampMs` so `nextTimestamp()` returns `max(Date.now(), lastUsed+1)` across restarts. Strictly increasing timestamps then hold regardless of concurrency/instances (avoids `S403`).
+- **Timeout:** ~5s per call (the FAQ promises real-time); on timeout → `pending` + backfill retry.
+- **Secrets:** private key from `DNC_PRIVATE_KEY` (PEM). Redaction today does NOT cover it — extend **both**: add `DNC_PRIVATE_KEY` / `privateKey` / `appSignature` / `signature` / `secret` / `authorization` to `logger.js` `redact.paths` (`logger.js:14`) **and** widen the `sentryScrub.js` `PII_KEY_PATTERN` regex (`sentryScrub.js:6`, currently `phone|email|nric|name|token|jwt|address|otp|password`). Never log the key, the `Authorization` header, or the full signature.
+
+### 5.2 Data model — migration `041-add-prospect-dnc.js`
+
+Follow the idempotent `describeTable` guard convention (see `032-add-prospect-consent-metadata.js`). Hybrid: **discrete columns for the things we filter on** + a **JSONB blob for the full evidence**.
+
+| Column | Type | Purpose |
+|---|---|---|
+| `dncStatus` | `STRING(16)` (indexed) | `pending` \| `clear` \| `registered` \| `error` \| `skipped` (non-SG). The thing admin queues filter on. |
+| `dncNoVoiceCall` | `BOOLEAN` null | `true` = registered (R) on voice. Drives voice block/flag. |
+| `dncNoTextMessage` | `BOOLEAN` null | text register. |
+| `dncNoFax` | `BOOLEAN` null | fax register. |
+| `dncCheckedAt` | `DATE` null | last successful check. |
+| `dncValidUntil` | `DATE` null (indexed) | from response `msg`; cache-skip + backfill trigger. |
+| `dncMetadata` | `JSONB` null | full evidence: `{ transactionId, createdTime, rawMsg, statusCode, checkOnBehalf, numberChecked }` for audit. |
+
+(Indexes on `dncStatus` and `dncValidUntil` go **in the migration** — `ensurePostgresIndexes()` no longer exists (replaced by migration `010-add-postgres-indexes.js`; the `retellCallId` comment in `Prospect.js:249` is stale). Use migration `040`'s compliance-grade style: an `ignoreExists` helper that swallows only "already exists"/"duplicate" and re-throws everything else, plus a post-`up` assertion — **not** blanket `.catch(() => {})`, since this is a compliance table.)
+
+### 5.3 Integration points
+
+**The leakage problem (P0).** Suppressing only the `lead.created` webhook is *not* enough. An actionable lead also leaks via (i) the controller's `sendLeadAssignmentEmail`, fired on the returned `assignedAgentId`/`assignedAgent` (`prospectController.js:59`), and (ii) the local `quarantined`/`assignedAgentId` variables, which a *post-commit* mutation does not retroactively change. And a bare "check after commit" leaves no crash-safe record if the process dies between commit and check.
+
+**Chosen model — born-held-pending, release-on-clear.** Reuses the existing hold→release machinery, is crash-safe, and never holds a DB transaction open across an HTTP call:
+
+1. **Inside the create transaction**, set `dncStatus='pending'` durably. Under `DNC_ENFORCEMENT=block`, also create the lead **non-deliverable from birth**: `assignedAgentId=null`, `quarantinedAt=now`, `quarantineReason='dnc_pending'`. Because it is born held with no agent, the existing `!quarantined && !externalAgentId` guard at `prospectService.js:716` suppresses the webhook **and** the controller's `if (assignedAgentId && assignedAgent)` email gate (`prospectController.js:59`) is naturally false — **both leak paths close with no bolt-on suppression logic.** (Do NOT call the DNC API inside the transaction — that would pin a DB connection across an external request.)
+2. **Post-commit**, run `dncService.checkAndRecord(prospect)`:
+   - **Clear** (or registered only on non-enforced channels) → set `dncStatus='clear'` and **release via the existing release path** (`prospectService.js:1048`: atomic clear of `quarantinedAt`, credit deduct, fire the first `lead.created`). That release is the single delivery — it cannot double-fire.
+   - **Registered on an enforced channel** → keep held, set `quarantineReason='dnc_registered'`.
+   - **Error/timeout** → stays `dnc_pending`; the backfill (§5.5) retries. Fail-safe holds.
+3. Under `DNC_ENFORCEMENT=flag`, skip the birth-hold: create normally, check post-commit, carry the result as flags in the payload (§5.4). A flag-mode lead can momentarily dispatch before the check lands — acceptable only because `flag` explicitly trades strictness for agent UX.
+
+**Retell — `retellService.js`.** Same born-held-pending hook, mirrored in its inline create (`:271`) + dispatch (`:350`). ⚠️ **Confirm a pre-existing bug first:** the lead's number is stored as `phone: to_number`, with `from_number` only in `sourceMetadata.fromNumber` (`retellService.js:275,296`). DNC must scrub *the number an agent will dial back* — for an **inbound** consumer→bot call that is `from_number`, not `to_number` (the MKTR DDI). Confirm Retell call direction and fix the mapping before scrubbing Retell leads; scrubbing the wrong number is compliance theatre.
+
+### 5.4 Enforcement gate + webhook payload
+
+Add a `dnc` block to **every** delivery payload — not only `buildLeadCreatedPayload` (`prospectHelpers.js:62`), but also `buildLeadAssignedPayload` (`:113`, used when a held lead is released/reassigned) and Retell's **inline** payload (`retellService.js:350`, which doesn't use the helper):
+
+```js
+dnc: {
+  status: prospect.dncStatus,
+  noVoiceCall: prospect.dncNoVoiceCall,   // true = do NOT call
+  noTextMessage: prospect.dncNoTextMessage,
+  noFax: prospect.dncNoFax,
+  checkedAt: prospect.dncCheckedAt,
+  validUntil: prospect.dncValidUntil,
+}
+```
+
+- `DNC_ENFORCEMENT=flag` → always dispatch; Lyfe renders per-channel flags (needs a **lyfe-app repo** change: `receive-mktr-lead` + UI read `data.lead.dnc`, show a "Do Not Call" badge / disable the call button).
+- `DNC_ENFORCEMENT=block` → enforced via the born-held-pending model (§5.3), **not** a post-hoc suppression. `dnc_pending` and `dnc_registered` become **first-class hold reasons** that must be FENCED like `no_funded_external_buyer`:
+  - `assignProspect` today blocks manual release of ONLY `no_funded_external_buyer` (`prospectService.js:1036`) and releases any other quarantined row + fires `lead.created` (`:1048`). **Add `dnc_pending`/`dnc_registered` to that block** (with an explicit, audited admin-override capability for `dnc_registered` if the business wants one) — otherwise an admin can manually push a DNC-registered lead to an adviser.
+  - The auto release-sweep (`releaseSweep.js`) must also skip these reasons. Its claim is currently **reason-blind** (filters only on `quarantinedAt IS NOT NULL`, `:81`), so it WILL grab `dnc_*` holds unless its candidate query + claim are made reason-aware — add the fence; don't assume it already filters.
+  - The **only** sanctioned release of `dnc_pending` is the DNC-clear transition in §5.3 / the backfill.
+- Fail-safe: `pending`/`error` ⇒ blocked-until-cleared under `block`.
+
+### 5.5 Caching, re-scrub & release — the DNC state machine
+
+§5.5 is a **paid, mutating background job**, so it's specified as a reason-fenced, row-claimed, DB-locked, bounded, resumable state machine — not "caching prose." (Hardened via Codex xhigh review; verified against `releaseSweep.js` and the `agentSyncService` lock lesson — see §9.)
+
+- **Cache.** Skip a fresh API call when `dncStatus IN ('clear','registered')` and `now() < dncValidUntil` (the check is the only thing that costs a credit).
+
+- **Eligibility (credit-burn scope).** Re-validation/retries select ONLY contactable leads — **exclude terminal `leadStatus IN ('won','lost')`** (real enum: `new/contacted/qualified/proposal_sent/negotiating/won/lost/nurturing`, `Prospect.js:67`; "dead" is not an enum) and inactive/archived campaigns. Held `dnc_registered` rows are re-checked at most once per validity window and bounded by age/status, so a permanently-held lead isn't re-billed forever.
+
+- **DNC-clear release (a `dnc_pending` lead comes back CLEAR).** Mirror `releaseSweep.js:77–152`, **NOT** `assignProspect` (which is fenced against `dnc_*` and would otherwise fire `lead.assigned` instead of the first `lead.created`). In ONE transaction: (1) **atomic, reason-scoped claim** — `UPDATE … SET assignedAgentId=:agent, quarantinedAt=NULL, quarantineReason=NULL, dnc…=:result WHERE id=:id AND quarantineReason='dnc_pending' AND quarantinedAt IS NOT NULL RETURNING id` (exactly one releaser wins; the reason scope IS the fence — `assignProspect`'s claim at `:1048` is reason-blind, so we can't reuse it); (2) authoritative `chargeLeadCredit(agent, campaign, t)`, rollback→re-hold on failure; (3) `persistEventDeliveries('lead.created', …, t)` — the **outbox inside the tx** (the `releaseSweep`/`webhookService.js:68` crash-safety guarantee), fail-closed if no subscriber; (4) commit, then `flushDeliveries`.
+
+- **Crash-safety / no-API release backlog.** Recording the clear result and releasing must be **atomic (same tx)** — a crash between "write `dncStatus='clear'`" and "release" would strand the lead, because the cache rule then skips it forever while it stays `dnc_pending`. Belt-and-suspenders: the job also sweeps `dncStatus='clear' AND quarantineReason='dnc_pending' AND quarantinedAt IS NOT NULL` as a **no-API** release backlog (re-drives stranded leads, zero extra credits).
+
+- **Scheduler (NOT the bare redeemed-audience pattern).** That `setInterval` has no re-entrancy guard and is "idempotent" only because Meta dedups (`bootstrap.js:137`) — duplicate DNC runs each burn a credit. The DNC job needs: (a) an in-process `running` flag, (b) a **DB job lock** so a slow run can't overlap the next tick, and (c) `SELECT … FOR UPDATE SKIP LOCKED` row claims so concurrent selection never double-processes a row. Batch ≤100 numbers/call.
+
+- **Outbound-call serialization (shared with §5.1).** Every DNC API call — request-path **and** backfill — goes through `dncService` so they share ONE call lock: `pg_try_advisory_xact_lock` (txn-scoped, one connection, auto-released), **scoped per call** (sign+send), so a fresh lead never queues behind a big refresh batch.
+
+- **`lead.updated` (forward flip — a clear lead later becomes registered).** New event, currently **UNWIRED**: the Lyfe subscriber is seeded with only created/assigned/unassigned (`bootstrap.js:191`), the receiver rejects unknown events (`receive-mktr-lead/index.ts:127`), and lyfe-app has no DNC fields. Wiring needs subscriber + receiver + lyfe-app handler (DNC fields → disable/enable the call affordance). Dispatch via `persistEventDeliveries` (outbox) in the same tx as the state change — not fire-and-forget `dispatchEvent`. Target the lead's **current** owner/destination; idempotent if the Lyfe lead is missing/deleted; skip terminal leads.
+
+- **Reverse flip (registered → clear).** Required and symmetric (else rechecking held rows just burns credits): a held `dnc_registered` lead that becomes clear AND is still contactable runs the same DNC-clear release; a flag-mode lead already delivered gets a `lead.updated` re-enabling the call.
+
+### 5.6 Config / env (Render backend)
+
+| Var | Default | Purpose |
+|---|---|---|
+| `DNC_API_ENABLED` | `false` | Master switch. |
+| `DNC_BASE_URL` | `https://uat.dnc.gov.sg/realtime` | UAT → flip to prod at go-live. |
+| `DNC_ORG_CODE` | — | Assigned by PDPC. |
+| `DNC_ESERVICE_ID` | — | Assigned by PDPC. |
+| `DNC_PRIVATE_KEY` | — | **Secret** PEM. Pino-redacted, never committed. |
+| `DNC_CHECK_ON_BEHALF` | `N` | §3.1. |
+| `DNC_ENFORCEMENT` | `block` | `flag` \| `block` (§3.4). |
+| `DNC_CONSENT_OVERRIDES` | `false` | §3.2. |
+| `DNC_HTTPS_PROXY` | — | Optional fixed-IP egress proxy (§4.1). |
+| `DNC_BACKFILL_ENABLED` | `false` | Re-scrub/retry scheduler. |
+| `DNC_REVALIDATE_DAYS` | `5` | Re-check this many days before `dncValidUntil`. |
+
+### 5.7 Observability & audit
+
+- Pino: `dnc.check.sent` / `dnc.check.blocked` / `dnc.check.error` / `dnc.backfill.done` (mirror `capi.*`, `redeemed_audience.sync.done`).
+- Sentry on `S301`/`S401`/`S402`/`S404`/`S501` and transport errors.
+- **`ProspectActivity`** per check — the compliance evidence Prudential/PDPC will ask for: `"DNC check: voice=NR text=R fax=NR · valid until 2026-07-29 · txn 5506778"`.
+
+---
+
+## 6. Testing
+
+Mirror `metaCapiService.test.js` / `redeemedAudienceService.test.js` (mock `fetch`):
+
+- **Signature** (freeze before UAT): `buildBaseString` exact-match the spec example; build the `Authorization` header by **raw string concatenation in the documented order** (never `URLSearchParams`, which may reorder/encode); `crypto.createSign('RSA-SHA256')` over UTF-8 input; **normalize PEM newlines** from the env var (`\n` → real newlines); round-trip verify the base64 signature with the public key. Cover `total` as **both string and number** until UAT confirms which PDPC accepts.
+- **Vendor the spec as test vectors:** the realtime API contract (100-batch limit, header, status codes) isn't publicly documented, so commit the PDPC spec PDF + a sample request/response under `docs/dnc/` and drive the signature/parse tests from those fixtures.
+- **Number formatting**: `+65 9123 4567` / `6591234567` / `91234567` → `91234567`; non-SG / landline-not-`3689` → `null` → `skipped`.
+- **Status codes**: each Annex-A code → correct `dncStatus` + side-effect.
+- **Caching**: in-window → no API call.
+- **Enforcement**: `block` + `noVoiceCall` → quarantined / voice suppressed; `flag` → dispatched with `dnc` block; `pending` → fail-safe blocked.
+- **Backfill**: picks `pending`/`error` + near-expiry; batches ≤100.
+- Run with the project's jest setup (sandbox off + inline `JWT_SECRET`); the ~5 DB-dependent suites that need local Postgres are expected to ECONNREFUSED locally.
+
+---
+
+## 7. Rollout sequence
+
+1. **Parallel now:** PDPC onboarding (§4) — org account, credits, keypair/cert, IP/firewall, UAT booking.
+2. **Resolve egress IP** (§4.1) before submitting an IP to PDPC.
+3. Build behind `DNC_API_ENABLED=false`: migration, `dncService`, integration hooks, payload extension, backfill, tests. Ships dark.
+4. Point at **UAT** creds; complete PDPC UAT.
+5. lyfe-app change (read `data.lead.dnc`, render flags / disable call) — separate repo, coordinate.
+6. Flip to **prod** creds + `DNC_API_ENABLED=true` for the Prudential campaign(s); start `flag`, then `block`.
+7. Optional one-off backfill of recent open leads.
+
+---
+
+## 8. Open decisions (need Shawn / Prudential / PDPC)
+
+1. **Who is the caller** → `checkOnBehalf` + whose DNC account/credits (§3.1).
+2. **Consent override** allowed? → `DNC_CONSENT_OVERRIDES` (§3.2).
+3. **Enforcement**: `block` vs `flag`, globally or per-campaign (§3.4).
+4. ~~Egress~~ → **DECIDED: DigitalOcean SG droplet `CONNECT` proxy**; submit the droplet's primary public IPv4 to PDPC (`docs/dnc/egress-proxy-runbook.md`, §4.1).
+5. ~~Cert: self-signed vs CA~~ → **DECIDED: self-signed X.509** (RSA-2048), generated at `~/dnc-keys/` (§4 step 4).
+6. **Sync-before-dispatch vs async+pending** webhook (§5.3).
+7. **`total`** field type (string vs number) — verify in UAT (§2.3).
+8. **Retell number mapping**: is `prospect.phone` (`to_number`) the consumer's number or the MKTR DDI (inbound)? Fix before scrubbing Retell leads (§5.3).
+
+---
+
+## 9. Revision log — Codex review (2026-06-29, verified against code)
+
+All findings below were verified against the actual source before folding in.
+
+**P0 (correctness/compliance — reworked the design):**
+- **Webhook suppression alone leaks the lead.** The controller emails the adviser on the returned `assignedAgentId` (`prospectController.js:59`), and a post-commit mutation doesn't change the local `quarantined` state. → Replaced "await-then-suppress" with the **born-held-pending, release-on-clear** model (§5.3), which closes both the webhook and email leak paths via existing machinery.
+- **Quarantine reuse collided with manual release.** `assignProspect` releases any held row except `no_funded_external_buyer` (`:1036`/`:1048`). → `dnc_pending`/`dnc_registered` are now first-class **fenced** hold reasons in `assignProspect` + `releaseSweep.js` (§5.4).
+- **No crash-safe pending record.** → `dncStatus='pending'` is written **inside the create transaction**; the backfill re-drives anything stuck (§5.3/§5.5).
+
+**P1 (folded in):**
+- Retell scrubs `to_number`, which may be the MKTR DDI, not the consumer (§5.3, §8.8).
+- `dnc` block must extend `buildLeadAssignedPayload` + Retell's inline payload, not just `buildLeadCreatedPayload` (§5.4).
+- Indexes belong in the migration (`ensurePostgresIndexes` is gone); use `040`'s `ignoreExists`+assert style (§5.2).
+- Monotonic timestamp must be process-wide (advisory lock + persisted `lastTimestampMs`), not "single-instance" hand-waving (§5.1).
+- Redaction doesn't cover the key/signature/secret — extend `logger.js` + `sentryScrub.js` (§5.1).
+- `consent_contact` is not strong enough to override DNC; require evidence-backed per-campaign consent (§3.2).
+
+**P2 (folded in):** raw-order signing tests + PEM-newline normalization + `total` string/number (§6); vendor the spec PDF as test fixtures (§6); `lead.updated` downstream-flip path for re-scrub (§5.5); structured per-check audit via `ProspectActivity`, not a latest-only blob (§5.2/§5.7).
+
+### §5.5 deep-review — Codex xhigh (2026-06-29, verified against code, folded into §5.5 + §5.1)
+
+§5.5 was rewritten from "caching prose" into a reason-fenced release/revalidation **state machine**:
+- **Release path = mirror `releaseSweep.js:77–152`, not `assignProspect`.** Verified `assignProspect`'s release claim is **reason-blind** (`:1048`, `WHERE quarantinedAt IS NOT NULL`), so reusing it would both hit the new `dnc_*` fence and misfire `lead.assigned` instead of the first `lead.created`. The release uses an atomic reason-scoped claim + in-tx `chargeLeadCredit` + `persistEventDeliveries` outbox + `flushDeliveries`.
+- **Crash-safety:** record-clear and release must be atomic, else a crash strands the lead (cache rule then skips it forever); added a no-API `clear ∧ dnc_pending ∧ quarantined` release-backlog sweep.
+- **Scheduler:** the redeemed-audience `setInterval` has **no re-entrancy guard** (`bootstrap.js:137`) and is credit-unsafe for a paid API → running-flag + DB job lock + `FOR UPDATE SKIP LOCKED` row claims.
+- **Timestamp lock:** `pg_try_advisory_xact_lock` **per call**, not session-level `pg_advisory_lock` — verified the latter leaked under Sequelize pooling and was already replaced (`agentSyncService.js:216`). §5.1 corrected.
+- **Credit-burn scope:** exclude terminal `won`/`lost` (verified enum, `Prospect.js:67`; no "dead") + archived campaigns; bound held re-checks.
+- **`lead.updated` is unwired:** verified the subscriber seeds only created/assigned/unassigned (`bootstrap.js:191`) and the Lyfe receiver rejects unknown events (`receive-mktr-lead/index.ts:127`); needs subscriber + receiver + lyfe-app work, dispatched via the outbox (not `dispatchEvent`).
+- **Reverse flip (registered→clear)** added as a required symmetric path.
+
+---
+
+## 10. Implementation status — build on `feat/dnc-scrubbing` (2026-06-30)
+
+**Done + unit-tested** (49 DNC tests; 124 incl. existing `prospectAssignment`/`prospectHelpers` suites all green → no live-pipeline regression):
+- Migration `041-add-prospect-dnc.js` + 7 `Prospect` columns (§5.2).
+- `dncService.js` — RSA-SHA256 signing (PEM-newline-safe, verified against a public key in tests), number formatting, Annex-A status map, `parseResponse`, monotonic `nextTimestamp`, `pg_try_advisory_xact_lock` per-call serialization, `node-fetch` + lazy `https-proxy-agent`, `checkNumbers`, `checkAndRecord`, validity cache (§2, §5.1).
+- `dncGate.js` — born-held-pending state machine: `releaseDncClearedLead` (releaseSweep-style atomic reason-scoped claim + in-tx authoritative charge + `persistEventDeliveries` outbox + flush) and `gateHeldDncLead` (§5.3, §5.5).
+- `createProspect` (web/QR) — block-mode born-held + post-commit gate; flag-mode check+record (§5.3).
+- `assignProspect` DNC fence; `dnc` payload block on `buildLeadCreatedPayload` + `buildLeadAssignedPayload` (§5.4). `releaseSweep` is already candidate-scoped to `no_funded_agent`, so it's DNC-safe as-is.
+- Config (`env.example`) + redaction (`logger.js`, `sentryScrub.js`) + `https-proxy-agent` dep declared.
+- Everything is behind `DNC_API_ENABLED` (`dncEnforcement → 'off'`) → **ships dark**; the existing pipeline is byte-for-byte unchanged when DNC is disabled.
+
+**Remaining:**
+- **Retell source** (`retellService.js`) — the born-held-pending hook is not yet wired there. The web/QR funnel (redeem.sg/LeadCapture) is the Prudential path; Retell is a secondary source. Until wired, Retell leads aren't scrubbed even when DNC is on.
+- **Backfill** (`dncBackfillService.js` + bootstrap) — re-scrub/retry job, no-API release backlog, reverse flip, and the `lead.updated` event (needs Lyfe subscriber + receiver + a lyfe-app handler). Until done: error/timeout-held leads aren't auto-retried and results aren't revalidated before expiry.
+- `https-proxy-agent` is declared in `package.json` + lockfile; the proxy path dynamic-imports it only when `DNC_HTTPS_PROXY` is set.

--- a/docs/plans/dnc-scrubbing.md
+++ b/docs/plans/dnc-scrubbing.md
@@ -368,9 +368,11 @@ All findings below were verified against the actual source before folding in.
 - `createProspect` (web/QR) — block-mode born-held + post-commit gate; flag-mode check+record (§5.3).
 - `assignProspect` DNC fence; `dnc` payload block on `buildLeadCreatedPayload` + `buildLeadAssignedPayload` (§5.4). `releaseSweep` is already candidate-scoped to `no_funded_agent`, so it's DNC-safe as-is.
 - Config (`env.example`) + redaction (`logger.js`, `sentryScrub.js`) + `https-proxy-agent` dep declared.
+- `retellService.js` — same born-held-pending hook for the voice-bot source (27 retell unit tests green; inert when DNC off).
+- `dncBackfillService.js` + `bootstrap.js` — recovery job for `dnc_pending` held leads (error/timeout retry + no-API release backlog via `gateHeldDncLead`), in-process re-entrancy guard + `pg_try_advisory_xact_lock` job lock, excludes terminal `won`/`lost`, gated by `DNC_BACKFILL_ENABLED` (4 tests).
 - Everything is behind `DNC_API_ENABLED` (`dncEnforcement → 'off'`) → **ships dark**; the existing pipeline is byte-for-byte unchanged when DNC is disabled.
 
-**Remaining:**
-- **Retell source** (`retellService.js`) — the born-held-pending hook is not yet wired there. The web/QR funnel (redeem.sg/LeadCapture) is the Prudential path; Retell is a secondary source. Until wired, Retell leads aren't scrubbed even when DNC is on.
-- **Backfill** (`dncBackfillService.js` + bootstrap) — re-scrub/retry job, no-API release backlog, reverse flip, and the `lead.updated` event (needs Lyfe subscriber + receiver + a lyfe-app handler). Until done: error/timeout-held leads aren't auto-retried and results aren't revalidated before expiry.
+**Deferred (next iteration — design §5.5 / §8.8):**
+- Advanced backfill: revalidation of clear/registered results before `dncValidUntil`; reverse-flip release of long-held `dnc_registered` leads (needs agent re-resolution — `dncMetadata.intendedAgentId` is overwritten on a successful check); `lead.updated` for already-delivered leads that flip clear→registered (needs a lyfe-app receiver + the subscriber event). The shipped backfill covers the critical error/timeout recovery + the no-API release backlog.
+- Retell call direction (§8.8): currently scrubs `prospect.phone` (= `to_number`); if Retell calls are inbound, the consumer is `from_number` — confirm and fix the mapping.
 - `https-proxy-agent` is declared in `package.json` + lockfile; the proxy path dynamic-imports it only when `DNC_HTTPS_PROXY` is set.


### PR DESCRIPTION
## What

Singapore PDPC **Do Not Call (DNC) Registry** scrubbing for the lead pipeline, required for **Prudential LTS vendor onboarding**. Every Singapore lead is checked against the DNC Registry before it reaches an agent; DNC-registered (voice) leads are withheld.

**Ships dark** — gated behind `DNC_API_ENABLED` (+ `DNC_BACKFILL_ENABLED`), both default off. When disabled, `dncEnforcement()` returns `off` and the existing pipeline is byte-for-byte unchanged (verified by the existing prospect/retell suites passing).

## How it works (when enabled)

A web/QR or Retell lead with an SG number → **born held `dnc_pending`** inside the create transaction (closes both the webhook and the agent-email leak paths) → post-commit DNC check via a fixed-IP egress proxy → **clear → released** to the intended agent (first `lead.created`, charged, crash-safe outbox) · **voice-registered → stays held** `dnc_registered` (admin can't manually release) · **error/timeout → stays pending**, retried by the backfill.

## Components

- **Migration 041** + 7 `Prospect` DNC columns (status / per-channel / validity + evidence)
- **`dncService.js`** — RSA-SHA256 signed `checkNumbers`/`checkAndRecord`, SG number formatting, Annex-A status map, validity cache, monotonic timestamp, `pg_try_advisory_xact_lock` per-call serialization, `node-fetch` + lazy `https-proxy-agent` egress
- **`dncGate.js`** — born-held-pending release state machine (atomic reason-scoped claim + in-tx charge + `persistEventDeliveries` outbox + flush; modeled on `releaseSweep`)
- **`createProspect` + `retellService`** — born-held / post-commit gate (block) + check-and-record (flag)
- **`assignProspect` DNC fence**; `dnc` block on `lead.created` / `lead.assigned` payloads
- **`dncBackfillService.js` + bootstrap** — recovery job for `dnc_pending` held leads (error/timeout retry + no-API release backlog), re-entrancy guard + advisory job lock, gated by `DNC_BACKFILL_ENABLED`
- Config (`env.example`) + secret redaction (`logger`, `sentryScrub`)

## Tests

- **53 DNC unit tests** (signing verified against a public key, number formatting, status codes, cache, gate state machine, release-tx branches, backfill)
- Existing **`prospectAssignment` / `prospectHelpers` / `retellService`** unit suites green → **no regression** (new paths inert when DNC off)

DB-backed integration suites (e.g. `retell.test.js`) need a local Postgres and fail with `ECONNREFUSED` the same as before this branch — not introduced here.

## Deferred (doc §10 — follow-ups, not blockers)

- Advanced backfill: pre-expiry revalidation, reverse-flip of long-held `dnc_registered`, and `lead.updated` for already-delivered leads (needs a **lyfe-app** receiver change)
- Confirm Retell `to_number` vs `from_number` (§8.8)

## Docs

- Design (Codex + xhigh-reviewed): `docs/plans/dnc-scrubbing.md`
- Egress proxy runbook: `docs/dnc/egress-proxy-runbook.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
