### PR TITLE
feat(dnc): consumer DNC consent gate + pre-go-live safety fixes

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -146,3 +146,5 @@ DNC_BACKFILL_INTERVAL_MINUTES=30
 DNC_REVALIDATE_DAYS=5
 # Per-call timeout (ms).
 DNC_TIMEOUT_MS=5000
+# Hourly credit budget — safety cap below EVERY paid DNC call (create/Retell/backfill/form).
+DNC_HOURLY_BUDGET=1000

--- a/backend/src/controllers/dncController.js
+++ b/backend/src/controllers/dncController.js
@@ -1,0 +1,17 @@
+import { asyncHandler } from '../middleware/errorHandler.js';
+import * as dncCheckService from '../services/dncCheckService.js';
+
+/**
+ * POST /api/dnc/check — the lead-capture form's DNC consent-gate lookup.
+ *
+ * Public + rate-limited (no auth — it rides the public form). Returns ONLY
+ * `{ success, data: { registered } }`. The service fails open (registered:false) on every
+ * gate miss / error, so this handler never needs to 4xx for a bad/garbage body — a missing
+ * or un-opted-in campaign, a non-SG number, or an unverified phone all resolve to
+ * registered:false and simply show no gate.
+ */
+export const checkDnc = asyncHandler(async (req, res) => {
+  const { phone, countryCode, campaignId } = req.body || {};
+  const result = await dncCheckService.checkDncForForm({ phone, countryCode, campaignId });
+  res.json({ success: true, data: { registered: result.registered === true } });
+});

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -213,6 +213,14 @@ export const schemas = {
     // services/externalConsent.hasValidExternalConsent; until then external stays
     // inert and the flag is stripped server-side (prospectService) rather than persisted.
     consent_third_party: Joi.boolean().optional(),
+    // DNC (Do Not Call) consent — the explicit opt-in the consent gate shows ONLY when
+    // the prospect's OTP-verified number is on Singapore's DNC Registry. Whitelisted so
+    // the public submit (stripUnknown) keeps it instead of dropping it. The server BUILDS
+    // the authoritative consentMetadata.dnc evidence from this intent boolean
+    // (prospectService) — the DNC *fact* comes from the server-side check, never the
+    // client; this flag only records that the person ticked the box. That evidence is what
+    // releases an otherwise-held DNC-registered lead (services/dncConsent.hasValidDncConsent).
+    consent_dnc: Joi.boolean().optional(),
     // Quiz funnel: raw answers + an advisory client-computed result. The server
     // RE-SCORES authoritatively from campaign.design_config.quiz (see
     // prospectService.createProspect) and stashes the result in

--- a/backend/src/routes/dnc.js
+++ b/backend/src/routes/dnc.js
@@ -1,0 +1,24 @@
+import express from 'express';
+import rateLimit from 'express-rate-limit';
+import * as ctrl from '../controllers/dncController.js';
+
+export const meta = { path: '/api/dnc' };
+
+const router = express.Router();
+
+// Public, IP rate-limited. The form fires one check per OTP-verified number, so a tight
+// per-IP cap is plenty and blunts any attempt to grind the endpoint (the OTP-verified gate
+// in the service is the real abuse control; this is defence-in-depth). Disabled under test.
+const dncCheckLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === 'test',
+  message: { success: false, message: 'Too many DNC checks from this IP, please try again later.' },
+});
+
+// POST /api/dnc/check — OTP-gated DNC lookup for the consent gate (returns { registered }).
+router.post('/check', dncCheckLimiter, ctrl.checkDnc);
+
+export default router;

--- a/backend/src/services/dncCheckService.js
+++ b/backend/src/services/dncCheckService.js
@@ -1,0 +1,136 @@
+import crypto from 'crypto';
+import { Campaign } from '../models/index.js';
+import { logger } from '../utils/logger.js';
+import { formatDncNumber, checkNumbers as dncCheckNumbers, dncReady, dncConfig } from './dncService.js';
+import { isPhoneRecentlyVerified } from './verifiedPhoneStore.js';
+
+/**
+ * dncCheckService — the backend behind the lead-capture form's DNC consent gate
+ * (POST /api/dnc/check). It answers ONE question, minimally: is this OTP-verified Singapore
+ * number on the Do Not Call register? Returns only `{ registered: boolean }`.
+ *
+ * Cost + abuse model (docs/plans/dnc-consent-gate.md §2): every check costs a real prepaid
+ * DNC credit, so this fails CLOSED on spend (any gate miss → no API call) and fails OPEN on
+ * UX (any error/over-budget → registered:false → no gate → the create-path scrub backstops).
+ *
+ * Gates, in order — ALL must pass before a credit is spent:
+ *   1. DNC ready (configured + DNC_API_ENABLED) — inert when DNC is off.
+ *   2. Campaign opted in (design_config.dncCheckAtSubmit === true) — scopes spend to opted-in
+ *      campaigns AND stops the endpoint being a DNC oracle via some other campaign.
+ *   3. SG number (formatDncNumber) — non-SG is out of DNC scope.
+ *   4. The number was OTP-verified recently (verifiedPhoneStore) — proves control of the
+ *      number, so the endpoint can't be used to look up arbitrary numbers' DNC status.
+ * Then: a per-number server cache (so repeat checks don't re-bill) → dncService.checkNumbers
+ * (the hourly budget guard, the serialising advisory lock, and the egress proxy all live
+ * INSIDE checkNumbers, so every caller shares one budget + one outbound channel).
+ */
+
+// Per-number DNC result cache. Single-instance backend → in-memory is sufficient (same
+// assumption as dncService's budget guard). Keyed by a SHA-256 of the 8-digit number — never
+// the raw number — so a heap dump doesn't leak which numbers were checked. value =
+// { registered, expiresAt }. A repeat check for the same number within the TTL reuses the
+// cached answer and never re-bills a prepaid credit.
+const resultCache = new Map();
+
+const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000; // 1h — short enough that DNC status can't go stale for long
+
+function cacheTtlMs() {
+  const v = Number(process.env.DNC_CHECK_CACHE_TTL_MS);
+  return Number.isFinite(v) && v > 0 ? v : DEFAULT_CACHE_TTL_MS;
+}
+
+function cacheKey(number) {
+  return crypto.createHash('sha256').update(String(number)).digest('hex');
+}
+
+function getCached(number, now = Date.now()) {
+  const hit = resultCache.get(cacheKey(number));
+  if (!hit) return undefined;
+  if (hit.expiresAt <= now) {
+    resultCache.delete(cacheKey(number));
+    return undefined;
+  }
+  return hit.registered;
+}
+
+function setCached(number, registered, now = Date.now()) {
+  resultCache.set(cacheKey(number), { registered, expiresAt: now + cacheTtlMs() });
+}
+
+/** Test helper — clear the per-number result cache. */
+export function _resetDncCheckCache() {
+  resultCache.clear();
+}
+
+/**
+ * Form-time DNC lookup for the consent gate. NEVER throws and ALWAYS resolves to
+ * `{ registered: boolean }`; every gate miss / error / over-budget yields
+ * `{ registered: false }` (fail-open) so an errored check can never block a non-registered
+ * user.
+ *
+ * @param {{ phone?: string, countryCode?: string, campaignId?: string }} input
+ *   phone: the local digits (the SPA sends `formData.phone`, 8 digits); countryCode: '+65'.
+ * @param {object} [deps] - injectable for tests (Campaign, dncReady, formatDncNumber,
+ *   checkNumbers, isPhoneRecentlyVerified, cfg, logger).
+ * @returns {Promise<{registered: boolean}>}
+ */
+export async function checkDncForForm({ phone, countryCode = '+65', campaignId } = {}, deps = {}) {
+  const log = deps.logger || logger;
+  const cfg = deps.cfg || dncConfig();
+  const CampaignModel = deps.Campaign || Campaign;
+  const ready = deps.dncReady || dncReady;
+  const fmt = deps.formatDncNumber || formatDncNumber;
+  const checkNums = deps.checkNumbers || dncCheckNumbers;
+  const isVerified = deps.isPhoneRecentlyVerified || isPhoneRecentlyVerified;
+
+  try {
+    // Gate 1: DNC must be configured + enabled. When off, there's nothing to check and no
+    // credit to spend — the whole feature is inert.
+    if (!ready(cfg)) return { registered: false };
+
+    // Gate 2: the campaign must have opted into the submit-time DNC check.
+    if (!campaignId) return { registered: false };
+    const campaign = await CampaignModel.findByPk(campaignId, { attributes: ['id', 'design_config'] });
+    if (campaign?.design_config?.dncCheckAtSubmit !== true) return { registered: false };
+
+    // Gate 3: Singapore number only (the DNC register covers SG numbers).
+    const fullPhone = `${countryCode || '+65'}${phone || ''}`;
+    const number = fmt(fullPhone);
+    if (!number) return { registered: false };
+
+    // Gate 4: the number must have passed OTP verification recently. This is the oracle
+    // fix — without it the endpoint leaks "is X on DNC?" for any number.
+    if (!isVerified(fullPhone)) return { registered: false };
+
+    // Per-number cache — a repeat check (e.g. the user re-sent OTP) within the TTL reuses
+    // the prior answer and does not re-bill.
+    const cached = getCached(number);
+    if (cached !== undefined) return { registered: cached };
+
+    // Live check — budget guard + advisory lock + egress proxy all live inside checkNumbers.
+    const result = await checkNums([number], { cfg }, deps);
+
+    if (result?.budgetExceeded) {
+      log.warn({ campaign_id: campaignId }, 'dnc.form_check.budget_exceeded');
+      return { registered: false };
+    }
+    // Only S000 carries an authoritative per-number answer. Any other status (auth /
+    // bad-request / insufficient-credits / transport hiccup that still returned JSON) means
+    // we don't truly know → fail-open and don't cache a guess.
+    if (result?.statusCode !== 'S000') {
+      log.warn({ campaign_id: campaignId, status_code: result?.statusCode || null }, 'dnc.form_check.no_result');
+      return { registered: false };
+    }
+
+    const r = (Array.isArray(result.results) && result.results[0]) || {};
+    const registered = !!(r.noVoiceCall || r.noTextMessage || r.noFax);
+    setCached(number, registered);
+    log.info({ campaign_id: campaignId, dnc_registered: registered }, 'dnc.form_check.recorded');
+    return { registered };
+  } catch (err) {
+    log.error({ err: err?.message || String(err) }, 'dnc.form_check.error');
+    return { registered: false };
+  }
+}
+
+export default { checkDncForForm, _resetDncCheckCache };

--- a/backend/src/services/dncConsent.js
+++ b/backend/src/services/dncConsent.js
@@ -1,0 +1,142 @@
+/**
+ * DNC (Do Not Call) consent contract — the consumer-facing half of DNC compliance.
+ *
+ * The backend create-path scrub (dncService/dncGate) HOLDS a lead whose number is on
+ * Singapore's DNC Registry for voice (no-voice-call register) — agents may not cold-call
+ * it. A person can lawfully be contacted anyway if they gave documented consent at the
+ * point of opt-in. The lead-capture form's consent gate captures exactly that: when the
+ * OTP-verified number is registered, the prospect must tick "I consent to be contacted"
+ * before they can submit. This module turns that tick into the evidence the gate reads to
+ * RELEASE the otherwise-held lead.
+ *
+ * Mirrors externalConsent.js deliberately: SERVER-BUILT evidence only (never trust the
+ * client's consentMetadata), default-OFF (no tick => null => nothing written => the
+ * registered lead stays held — the fail-safe), and a strict validator the gate calls.
+ *
+ * Distinct from `consent_contact` — that marketing-consent box defaults TICKED in the form
+ * (CampaignSignupForm), so reusing it would silently override DNC for everyone. DNC consent
+ * is its own granular, default-unticked opt-in that only ever appears for a registered
+ * number, so its presence is meaningful.
+ *
+ * Evidence shape (consentMetadata.dnc):
+ *   {
+ *     consented:   true            — the affirmative tick (the gate checks === true)
+ *     version:     string          — disclosure-copy version the person agreed to
+ *     consentedAt: string          — ISO timestamp (parseable)
+ *     channels:    string[]        — DNC channels the consent covers
+ *     sourceUrl?:  string          — capture-page URL (audit breadcrumb)
+ *     dncTransactionId?: string    — the PDPC check's transaction id, if known at build time
+ *   }
+ */
+
+/**
+ * Current DNC-consent disclosure-copy version. A label tying each recorded consent to the
+ * exact wording shown on the consent gate. BUMP IT (to the date the copy changes) whenever
+ * the DNC consent disclosure on the lead-capture form (DncConsentGate / CampaignSignupForm)
+ * is edited.
+ */
+export const DNC_CONSENT_VERSION = '2026-06-30';
+
+/**
+ * DNC channels the consent covers. The PDPC register has three sub-registers
+ * (no_voice_call / no_text_message / no_fax); the gate's block trigger is voice, but the
+ * documented "you may contact me about this offer" consent is recorded against all three
+ * so the evidence reflects the full scope the person agreed to. Frozen so a caller can't
+ * mutate the shared constant.
+ */
+export const DNC_CONSENT_CHANNELS = Object.freeze(['voice', 'text', 'fax']);
+
+/**
+ * Pull the `consentMetadata.dnc` block from any accepted input shape (a Prospect instance,
+ * a plain prospect-like object, or a bare consentMetadata object). Returns null when absent.
+ */
+export function extractDncConsent(prospectOrMeta) {
+  if (!prospectOrMeta || typeof prospectOrMeta !== 'object') return null;
+
+  // Already a bare consentMetadata object?
+  if (prospectOrMeta.dnc && !prospectOrMeta.consentMetadata && !prospectOrMeta.sourceMetadata) {
+    return prospectOrMeta.dnc;
+  }
+
+  // Sequelize instance: prefer get(), fall back to direct property.
+  const meta = typeof prospectOrMeta.get === 'function'
+    ? (prospectOrMeta.get('consentMetadata') ?? prospectOrMeta.consentMetadata)
+    : prospectOrMeta.consentMetadata;
+
+  if (meta && typeof meta === 'object' && meta.dnc) return meta.dnc;
+  return null;
+}
+
+/**
+ * @param {object|null|undefined} prospectOrMeta - a Prospect instance, plain prospect-like
+ *   object, or a bare consentMetadata object.
+ * @returns {boolean} true ONLY when complete, well-formed DNC consent evidence exists AND
+ *   the person affirmatively consented (consented === true).
+ */
+export function hasValidDncConsent(prospectOrMeta) {
+  const dnc = extractDncConsent(prospectOrMeta);
+  if (!dnc || typeof dnc !== 'object') return false;
+
+  // The affirmative tick is the gate. Strict === true (a stale client sending "true"/1
+  // through some other path can't satisfy it; the evidence is server-built anyway).
+  if (dnc.consented !== true) return false;
+
+  const versionOk = typeof dnc.version === 'string' && dnc.version.trim().length > 0;
+  const channelsOk = Array.isArray(dnc.channels) && dnc.channels.length > 0
+    && dnc.channels.every((c) => typeof c === 'string' && c.trim().length > 0);
+
+  let timestampOk = false;
+  if (typeof dnc.consentedAt === 'string' && dnc.consentedAt.trim().length > 0) {
+    timestampOk = !Number.isNaN(Date.parse(dnc.consentedAt));
+  }
+
+  return versionOk && channelsOk && timestampOk;
+}
+
+/**
+ * Build the `consentMetadata.dnc` evidence for a lead-capture submission.
+ *
+ * Returns the evidence ONLY when the person affirmatively ticked the DNC consent box
+ * (consented === true). For an unticked / missing / non-true box it returns null so NOTHING
+ * is written — absence is the fail-safe (no evidence => the registered lead stays held). The
+ * returned object is guaranteed to satisfy hasValidDncConsent().
+ *
+ * @param {boolean} consented - the consent_dnc flag from the form.
+ * @param {{ sourceUrl?: string, at?: string, transactionId?: string }} [opts]
+ *   sourceUrl: capture-page URL (audit breadcrumb); at: ISO timestamp (missing/unparseable
+ *   falls back to now); transactionId: the PDPC check's id, if already known.
+ * @returns {{consented:true,version:string,consentedAt:string,channels:string[],sourceUrl?:string,dncTransactionId?:string}|null}
+ */
+export function buildDncConsentEvidence(consented, opts = {}) {
+  if (consented !== true) return null;
+
+  // Use a caller-supplied timestamp only if it actually parses; otherwise fall back to
+  // now — so the returned evidence is ALWAYS valid per hasValidDncConsent().
+  const at = typeof opts.at === 'string' ? opts.at.trim() : '';
+  const consentedAt = at && !Number.isNaN(Date.parse(at)) ? at : new Date().toISOString();
+  const sourceUrl =
+    typeof opts.sourceUrl === 'string' && opts.sourceUrl.trim().length > 0
+      ? opts.sourceUrl.trim()
+      : undefined;
+  const dncTransactionId =
+    typeof opts.transactionId === 'string' && opts.transactionId.trim().length > 0
+      ? opts.transactionId.trim()
+      : undefined;
+
+  return {
+    consented: true,
+    version: DNC_CONSENT_VERSION,
+    consentedAt,
+    channels: [...DNC_CONSENT_CHANNELS],
+    ...(sourceUrl ? { sourceUrl } : {}),
+    ...(dncTransactionId ? { dncTransactionId } : {}),
+  };
+}
+
+export default {
+  DNC_CONSENT_VERSION,
+  DNC_CONSENT_CHANNELS,
+  extractDncConsent,
+  hasValidDncConsent,
+  buildDncConsentEvidence,
+};

--- a/backend/src/services/dncGate.js
+++ b/backend/src/services/dncGate.js
@@ -3,6 +3,7 @@ import { chargeLeadCredit } from './leadCredits.js';
 import { persistEventDeliveries, flushDeliveries } from './webhookService.js';
 import { buildLeadCreatedPayload, destinationForAgent, externalIdForDestination } from './prospectHelpers.js';
 import { checkAndRecord as dncCheckAndRecord } from './dncService.js';
+import { hasValidDncConsent } from './dncConsent.js';
 import { logger } from '../utils/logger.js';
 
 /**
@@ -24,6 +25,7 @@ const defaultDeps = {
   destinationForAgent,
   externalIdForDestination,
   checkAndRecord: dncCheckAndRecord,
+  hasValidDncConsent,
   logger,
   // Injectable so gateHeldDncLead can be unit-tested without the release tx (the real
   // function is hoisted and bound below).
@@ -129,7 +131,9 @@ export async function releaseDncClearedLead({ prospect, agentId, alreadyCharged 
 /**
  * Post-commit gate for a lead born held `dnc_pending`. Runs the DNC check, then:
  *   - clear, OR registered but voice-clear → release to the intended agent (first lead.created)
- *   - registered on voice → keep held, relabel `dnc_registered`
+ *   - registered on voice + documented DNC consent → release (the consent override — the
+ *     consumer ticked the consent gate, evidence in consentMetadata.dnc)
+ *   - registered on voice + NO consent → keep held, relabel `dnc_registered`
  *   - pending/error → stays `dnc_pending`; the backfill retries.
  * Never throws. Returns { outcome: 'released'|'held', status }.
  */
@@ -147,12 +151,29 @@ export async function gateHeldDncLead(prospect, overrides = {}) {
     return { outcome: 'held', status: 'error' };
   }
 
-  // Voice is the channel agents use; registered-on-voice is the block trigger. A lead
-  // registered only on text/fax (voice clear) is still deliverable, with flags in the payload.
-  const deliver = result.status === 'clear' || (result.status === 'registered' && !result.noVoiceCall);
+  // Voice is the channel agents use; registered-on-voice is the block trigger. A lead is
+  // delivered when ANY of:
+  //   - clear (not on the register), OR
+  //   - registered only on text/fax (voice clear) — still deliverable, flags in the payload, OR
+  //   - registered on voice BUT the consumer gave documented DNC consent at opt-in (the
+  //     consent gate) — the lawful override. The evidence (consentMetadata.dnc) is
+  //     server-built at capture, so a forged client flag can never reach here.
+  const consentOverride = result.status === 'registered' && d.hasValidDncConsent(prospect);
+  const deliver =
+    result.status === 'clear' ||
+    (result.status === 'registered' && !result.noVoiceCall) ||
+    consentOverride;
   if (deliver) {
+    if (consentOverride) {
+      d.logger.info('[DNC] registered lead released on documented consent (override)', { prospectId: prospect.id });
+    }
     const rel = await d.releaseDncClearedLead({ prospect, agentId: intendedAgentId, alreadyCharged }, overrides);
-    return { outcome: rel.released ? 'released' : 'held', status: result.status, release: rel };
+    return {
+      outcome: rel.released ? 'released' : 'held',
+      status: result.status,
+      release: rel,
+      ...(consentOverride ? { consentOverride: true } : {}),
+    };
   }
   if (result.status === 'registered') {
     await prospect.update({ quarantineReason: 'dnc_registered' }).catch(() => {});

--- a/backend/src/services/dncService.js
+++ b/backend/src/services/dncService.js
@@ -29,6 +29,30 @@ export function nextTimestamp(now = Date.now()) {
   return lastTs;
 }
 
+// In-process hourly credit budget — a safety cap that sits BELOW every paid DNC call
+// (create, Retell, backfill, and the form /dnc/check) so no single caller can drain
+// prepaid credits. Resets hourly; single-instance backend → in-memory is sufficient.
+let budgetWindowStart = Date.now();
+let budgetSpent = 0;
+
+function withinBudget(count) {
+  const now = Date.now();
+  if (now - budgetWindowStart > 3_600_000) {
+    budgetWindowStart = now;
+    budgetSpent = 0;
+  }
+  const cap = Number(process.env.DNC_HOURLY_BUDGET) || 1000;
+  if (budgetSpent + count > cap) return false;
+  budgetSpent += count;
+  return true;
+}
+
+/** Test helper — reset the hourly budget window. */
+export function _resetDncBudget() {
+  budgetWindowStart = Date.now();
+  budgetSpent = 0;
+}
+
 // ── Config ────────────────────────────────────────────────────────────────────
 
 /** PEM private keys are often stored with literal "\n"; restore real newlines. */
@@ -191,6 +215,11 @@ export async function checkNumbers(numbers, opts = {}, deps = {}) {
   const fetchImpl = deps.fetch || nodeFetch;
   const checkOnBehalf = opts.checkOnBehalf || cfg.checkOnBehalf;
 
+  // Budget guard — refuse (fail-open) rather than bill beyond the hourly cap.
+  if (!deps.skipBudget && !(deps.withinBudget || withinBudget)(numbers.length)) {
+    return { budgetExceeded: true, statusCode: null, results: [], validUntil: null, transactionId: null, createdTime: null, rawMsg: null };
+  }
+
   const doCall = async () => {
     const timestamp = (deps.nextTimestamp || nextTimestamp)();
     const baseString = buildBaseString({ orgCode: cfg.orgCode, eServiceId: cfg.eServiceId, timestamp });
@@ -295,7 +324,13 @@ export async function checkAndRecord(prospect, deps = {}) {
   }
 
   if (hasFreshDnc(prospect)) {
-    return { status: prospect.dncStatus, cached: true };
+    return {
+      status: prospect.dncStatus,
+      noVoiceCall: prospect.dncNoVoiceCall === true,
+      noTextMessage: prospect.dncNoTextMessage === true,
+      noFax: prospect.dncNoFax === true,
+      cached: true,
+    };
   }
 
   let result;
@@ -306,6 +341,12 @@ export async function checkAndRecord(prospect, deps = {}) {
     log.error({ err: err.message, prospect_id: prospect.id }, 'dnc.check.error');
     await persistDnc(prospect, { dncStatus: 'pending' }, deps).catch(() => {});
     return { status: 'pending', error: err.message };
+  }
+
+  if (result.budgetExceeded) {
+    log.warn({ prospect_id: prospect.id }, 'dnc.check.budget_exceeded');
+    await persistDnc(prospect, { dncStatus: 'pending' }, deps).catch(() => {});
+    return { status: 'pending', reason: 'budget_exceeded' };
   }
 
   const mapped = mapStatusCode(result.statusCode);

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -338,7 +338,10 @@ export function makeProspectService(overrides = {}) {
     // DNC (Do Not Call) scrubbing mode for this lead. 'off' unless scrubbing is configured
     // AND the number is in DNC scope (Singapore). block → born held pending a check;
     // flag → checked post-commit, result attached to the payload. docs/plans/dnc-scrubbing.md.
-    const dncMode = d.dncEnforcement();
+    // Per-campaign gate: only campaigns that opted in (design_config.dncCheckAtSubmit) ever
+    // hit the paid DNC API — scopes credit spend (and the public create endpoint's exposure)
+    // to opted-in campaigns. The global enforcement mode (block/flag) still applies on top.
+    const dncMode = sourceCampaign?.design_config?.dncCheckAtSubmit === true ? d.dncEnforcement() : 'off';
     const dncNumber = dncMode !== 'off' && incoming.phone ? d.formatDncNumber(incoming.phone) : null;
     const dncBlockApplies = dncMode === 'block' && !!dncNumber;
     const dncFlagApplies = dncMode === 'flag' && !!dncNumber;

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -18,6 +18,7 @@ import { decideAssignment } from './leadQuota.js';
 import { dncEnforcement, formatDncNumber, checkAndRecord as dncCheckAndRecord } from './dncService.js';
 import { gateHeldDncLead } from './dncGate.js';
 import { hasValidExternalConsent, buildExternalConsentEvidence } from './externalConsent.js';
+import { buildDncConsentEvidence } from './dncConsent.js';
 import { repeatSignupDetail, repeatSignupCounts } from './repeatSignup.js';
 import { buildProspectWhere } from '../middleware/prospectScope.js';
 import { AppError } from '../middleware/errorHandler.js';
@@ -85,6 +86,7 @@ const defaultDeps = {
   deductExternalLeadBalance,
   hasValidExternalConsent,
   buildExternalConsentEvidence,
+  buildDncConsentEvidence,
   chargeLeadCredit,
   decideAssignment,
   dncEnforcement,
@@ -133,6 +135,12 @@ export function makeProspectService(overrides = {}) {
     // (MKTR Leads buyer-agent) delivery. Distinct from the marketing booleans above;
     // recorded as consentMetadata.external evidence below, never as a CAPI signal.
     const consentThirdParty = safeBody.consent_third_party;
+    // DNC (Do Not Call) consent — the opt-in the consent gate shows only when the verified
+    // number is on Singapore's DNC Registry. Intent boolean only; the server BUILDS the
+    // authoritative consentMetadata.dnc evidence from it below (the DNC fact itself comes
+    // from the server-side check, never the client). Recorded as consentMetadata.dnc, never
+    // a CAPI signal.
+    const consentDnc = safeBody.consent_dnc;
 
     // Quiz funnel submission (re-scored server-side after the campaign loads),
     // ad attribution (UTM) and referral identity (the sharer's prospect UUID from
@@ -152,7 +160,7 @@ export function makeProspectService(overrides = {}) {
     const {
       eventId: _e, fbp: _p, fbc: _c, eventSourceUrl: _u,
       registrationEventId: _re, ttclid: _tc, ttp: _tp,
-      consent_contact: _cc, consent_terms: _ct, consent_third_party: _ctp,
+      consent_contact: _cc, consent_terms: _ct, consent_third_party: _ctp, consent_dnc: _cd,
       // consentMetadata is SERVER-authoritative — the third-party-consent evidence is
       // built below from consent_third_party. Drop any client-supplied value so external
       // consent can never be forged via the body (defence-in-depth beyond route stripUnknown).
@@ -190,6 +198,18 @@ export function makeProspectService(overrides = {}) {
     });
     if (externalConsent) {
       incoming.consentMetadata = { ...(incoming.consentMetadata || {}), external: externalConsent };
+    }
+
+    // DNC (Do Not Call) consent evidence. Written ONLY when the prospect ticked the consent
+    // box the gate shows when their OTP-verified number is on Singapore's DNC Registry. This
+    // is the documented opt-in the post-commit DNC gate (gateHeldDncLead) reads to RELEASE an
+    // otherwise-held registered lead — PDPA evidence that a DNC-registered person agreed to be
+    // contacted by this advertiser. SERVER-built from the consent_dnc intent boolean (the
+    // client's consentMetadata is dropped above, so this can't be forged); unticked/absent =>
+    // null => nothing written => the registered lead stays held (the fail-safe).
+    const dncConsent = d.buildDncConsentEvidence(consentDnc, { sourceUrl: eventSourceUrl });
+    if (dncConsent) {
+      incoming.consentMetadata = { ...(incoming.consentMetadata || {}), dnc: dncConsent };
     }
 
     // Capture the campaign the caller explicitly asked for (e.g. a bare

--- a/backend/src/services/retellService.js
+++ b/backend/src/services/retellService.js
@@ -259,7 +259,8 @@ export function makeRetellService(overrides = {}) {
     // DNC scrubbing mode for this lead (number from the Retell call). docs/plans/dnc-scrubbing.md.
     // NOTE: scrubs prospect.phone (= to_number), the number an agent calls back. If Retell calls
     // are inbound, the consumer is from_number — confirm the mapping (design §8.8).
-    const dncMode = d.dncEnforcement();
+    // Per-campaign gate — only campaigns opted into design_config.dncCheckAtSubmit hit the API.
+    const dncMode = campaign?.design_config?.dncCheckAtSubmit === true ? d.dncEnforcement() : 'off';
     const dncNumber = dncMode !== 'off' && to_number ? d.formatDncNumber(to_number) : null;
     const dncBlockApplies = dncMode === 'block' && !!dncNumber;
     const dncFlagApplies = dncMode === 'flag' && !!dncNumber;

--- a/backend/src/services/verificationService.js
+++ b/backend/src/services/verificationService.js
@@ -4,6 +4,7 @@ import { Campaign, Verification } from '../models/index.js';
 import { SNSClient, PublishCommand } from '@aws-sdk/client-sns';
 import { AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
+import { markPhoneVerified } from './verifiedPhoneStore.js';
 
 // AWS SNS SMS config. The region + sender ID must match our SSIR-registered
 // identity in AWS, or Singapore telcos relabel the sender as "Likely-SCAM".
@@ -224,7 +225,11 @@ export async function checkVerificationCode({ phone, code, countryCode = '+65' }
     };
   }
 
-  // Valid — destroy record to prevent reuse
+  // Valid — stamp a short-lived "recently verified" marker (BEFORE destroying the
+  // single-use row) so the DNC consent-gate check (POST /api/dnc/check) can confirm the
+  // caller controls this number without re-reading the now-destroyed row. See
+  // verifiedPhoneStore.js. Then destroy the row to prevent code reuse.
+  markPhoneVerified(fullPhone);
   await record.destroy();
 
   return {

--- a/backend/src/services/verifiedPhoneStore.js
+++ b/backend/src/services/verifiedPhoneStore.js
@@ -1,0 +1,73 @@
+/**
+ * verifiedPhoneStore — a short-lived, in-memory record of phones that just passed OTP
+ * verification. It exists ONLY to bridge OTP verification → the DNC consent-gate check.
+ *
+ * Why it's needed (the oracle fix): POST /api/dnc/check must reveal a number's DNC status
+ * ONLY after the caller proved control of that number via OTP — otherwise the endpoint is a
+ * free "is X on Singapore's Do Not Call register?" lookup for any number. But
+ * verificationService.checkVerificationCode DESTROYS the single-use Verification row on a
+ * successful verify, so "was this phone just verified?" can no longer be answered from the
+ * DB afterwards. So on a successful verify we stamp a marker here, and /api/dnc/check
+ * requires a live marker for the phone.
+ *
+ * In-memory is sufficient and consistent with the rest of the DNC feature (dncService's
+ * hourly budget guard + the /dnc/check result cache are also in-memory) because the backend
+ * is single-instance. Losing the markers on restart is fail-open by design: no marker =>
+ * /dnc/check returns registered:false => no consent gate shows => the create-path DNC scrub
+ * still backstops. It is never a security downgrade — a missing marker only HIDES the gate,
+ * it can never wrongly reveal a status.
+ *
+ * Keyed by the FULL phone (e.g. "+6591234567"), matching how both /verify/check and
+ * /dnc/check assemble it (`${countryCode}${phone}`), so the two agree on the key.
+ */
+
+const verifiedPhones = new Map(); // fullPhone -> expiry epoch ms
+
+const DEFAULT_TTL_MS = 10 * 60 * 1000; // 10 min — the gate check fires seconds after verify
+const SWEEP_THRESHOLD = 5000; // opportunistic prune ceiling so the map can't grow unbounded
+
+function ttlMs() {
+  const v = Number(process.env.DNC_VERIFIED_MARKER_TTL_MS);
+  return Number.isFinite(v) && v > 0 ? v : DEFAULT_TTL_MS;
+}
+
+/** Drop expired entries. Cheap (Map iteration); only invoked when the map gets large. */
+function prune(now) {
+  for (const [phone, exp] of verifiedPhones) {
+    if (exp <= now) verifiedPhones.delete(phone);
+  }
+}
+
+/**
+ * Stamp `fullPhone` as recently verified. Called from verificationService on a successful
+ * OTP check. No-op for a falsy phone.
+ */
+export function markPhoneVerified(fullPhone, now = Date.now()) {
+  if (!fullPhone) return;
+  // Bound memory: a non-DNC campaign never reads these back, so they'd otherwise linger
+  // until expiry. Sweep when the map grows large rather than on every call.
+  if (verifiedPhones.size >= SWEEP_THRESHOLD) prune(now);
+  verifiedPhones.set(fullPhone, now + ttlMs());
+}
+
+/**
+ * True iff `fullPhone` has a live (non-expired) verification marker. Self-prunes the entry
+ * when it has expired.
+ */
+export function isPhoneRecentlyVerified(fullPhone, now = Date.now()) {
+  if (!fullPhone) return false;
+  const exp = verifiedPhones.get(fullPhone);
+  if (!exp) return false;
+  if (exp <= now) {
+    verifiedPhones.delete(fullPhone);
+    return false;
+  }
+  return true;
+}
+
+/** Test helper — clear all markers. */
+export function _resetVerifiedPhones() {
+  verifiedPhones.clear();
+}
+
+export default { markPhoneVerified, isPhoneRecentlyVerified, _resetVerifiedPhones };

--- a/backend/test/unit/dncCheckService.test.js
+++ b/backend/test/unit/dncCheckService.test.js
@@ -1,0 +1,167 @@
+import { jest } from '@jest/globals';
+
+// Mocks BEFORE importing the SUT (Jest ESM pattern) — importing dncCheckService transitively
+// loads dncService → models/index.js; mock it so no DB connection is opened.
+jest.unstable_mockModule('@sentry/node', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+  init: jest.fn(),
+  setTag: jest.fn(),
+}));
+jest.unstable_mockModule('../../src/utils/logger.js', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+jest.unstable_mockModule('../../src/models/index.js', () => ({
+  Prospect: { update: jest.fn() },
+  ProspectActivity: { create: jest.fn() },
+  Campaign: { findByPk: jest.fn() },
+  sequelize: { transaction: jest.fn(), query: jest.fn() },
+}));
+
+let svc;
+beforeAll(async () => {
+  svc = await import('../../src/services/dncCheckService.js');
+});
+
+const baseLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+
+// Sensible all-pass deps; each test overrides exactly what it exercises.
+function mkDeps(over = {}) {
+  return {
+    Campaign: { findByPk: jest.fn().mockResolvedValue({ id: 'c1', design_config: { dncCheckAtSubmit: true } }) },
+    dncReady: jest.fn().mockReturnValue(true),
+    formatDncNumber: jest.fn().mockReturnValue('91234567'),
+    checkNumbers: jest.fn().mockResolvedValue({
+      statusCode: 'S000',
+      results: [{ noVoiceCall: false, noTextMessage: false, noFax: false }],
+    }),
+    isPhoneRecentlyVerified: jest.fn().mockReturnValue(true),
+    cfg: { enabled: true, orgCode: 'O', eServiceId: 'E', privateKey: 'K' },
+    logger: baseLogger,
+    ...over,
+  };
+}
+
+const input = { phone: '91234567', countryCode: '+65', campaignId: 'c1' };
+
+beforeEach(() => svc._resetDncCheckCache());
+
+describe('checkDncForForm — gates (no spend when a gate fails)', () => {
+  it('Gate 1: DNC not ready → registered:false, no campaign lookup, no API call', async () => {
+    const deps = mkDeps({ dncReady: jest.fn().mockReturnValue(false) });
+    const out = await svc.checkDncForForm(input, deps);
+    expect(out).toEqual({ registered: false });
+    expect(deps.Campaign.findByPk).not.toHaveBeenCalled();
+    expect(deps.checkNumbers).not.toHaveBeenCalled();
+  });
+
+  it('Gate 2a: missing campaignId → registered:false, no API call', async () => {
+    const deps = mkDeps();
+    const out = await svc.checkDncForForm({ phone: '91234567', countryCode: '+65' }, deps);
+    expect(out).toEqual({ registered: false });
+    expect(deps.checkNumbers).not.toHaveBeenCalled();
+  });
+
+  it('Gate 2b: campaign has NOT opted in (dncCheckAtSubmit !== true) → registered:false, no API call', async () => {
+    const deps = mkDeps({
+      Campaign: { findByPk: jest.fn().mockResolvedValue({ id: 'c1', design_config: { dncCheckAtSubmit: false } }) },
+    });
+    const out = await svc.checkDncForForm(input, deps);
+    expect(out).toEqual({ registered: false });
+    expect(deps.checkNumbers).not.toHaveBeenCalled();
+  });
+
+  it('Gate 2c: unknown campaign → registered:false', async () => {
+    const deps = mkDeps({ Campaign: { findByPk: jest.fn().mockResolvedValue(null) } });
+    const out = await svc.checkDncForForm(input, deps);
+    expect(out).toEqual({ registered: false });
+    expect(deps.checkNumbers).not.toHaveBeenCalled();
+  });
+
+  it('Gate 3: non-SG number → registered:false, no API call', async () => {
+    const deps = mkDeps({ formatDncNumber: jest.fn().mockReturnValue(null) });
+    const out = await svc.checkDncForForm(input, deps);
+    expect(out).toEqual({ registered: false });
+    expect(deps.checkNumbers).not.toHaveBeenCalled();
+  });
+
+  it('Gate 4: phone NOT recently OTP-verified → registered:false, no API call (oracle fix)', async () => {
+    const deps = mkDeps({ isPhoneRecentlyVerified: jest.fn().mockReturnValue(false) });
+    const out = await svc.checkDncForForm(input, deps);
+    expect(out).toEqual({ registered: false });
+    expect(deps.checkNumbers).not.toHaveBeenCalled();
+  });
+});
+
+describe('checkDncForForm — happy path', () => {
+  it('all gates pass + registered (voice) → registered:true', async () => {
+    const deps = mkDeps({
+      checkNumbers: jest.fn().mockResolvedValue({ statusCode: 'S000', results: [{ noVoiceCall: true, noTextMessage: false, noFax: false }] }),
+    });
+    const out = await svc.checkDncForForm(input, deps);
+    expect(out).toEqual({ registered: true });
+    expect(deps.checkNumbers).toHaveBeenCalledTimes(1);
+    expect(deps.checkNumbers.mock.calls[0][0]).toEqual(['91234567']);
+  });
+
+  it('all gates pass + clear → registered:false', async () => {
+    const deps = mkDeps();
+    const out = await svc.checkDncForForm(input, deps);
+    expect(out).toEqual({ registered: false });
+    expect(deps.checkNumbers).toHaveBeenCalledTimes(1);
+  });
+
+  it('registered on text only (voice clear) still counts as registered for the gate', async () => {
+    const deps = mkDeps({
+      checkNumbers: jest.fn().mockResolvedValue({ statusCode: 'S000', results: [{ noVoiceCall: false, noTextMessage: true, noFax: false }] }),
+    });
+    const out = await svc.checkDncForForm(input, deps);
+    expect(out).toEqual({ registered: true });
+  });
+});
+
+describe('checkDncForForm — per-number cache (no re-bill)', () => {
+  it('a repeat check for the same number reuses the cached result (one API call total)', async () => {
+    const deps = mkDeps({
+      checkNumbers: jest.fn().mockResolvedValue({ statusCode: 'S000', results: [{ noVoiceCall: true, noTextMessage: false, noFax: false }] }),
+    });
+    const first = await svc.checkDncForForm(input, deps);
+    const second = await svc.checkDncForForm(input, deps);
+    expect(first).toEqual({ registered: true });
+    expect(second).toEqual({ registered: true });
+    expect(deps.checkNumbers).toHaveBeenCalledTimes(1); // second served from cache
+  });
+
+  it('a fail-open (non-S000) result is NOT cached → a later check retries', async () => {
+    const fail = jest.fn().mockResolvedValue({ statusCode: 'S301', results: [] });
+    const ok = jest.fn().mockResolvedValue({ statusCode: 'S000', results: [{ noVoiceCall: true }] });
+    expect(await svc.checkDncForForm(input, mkDeps({ checkNumbers: fail }))).toEqual({ registered: false });
+    // second call (different deps, same number) hits the API again because nothing was cached
+    expect(await svc.checkDncForForm(input, mkDeps({ checkNumbers: ok }))).toEqual({ registered: true });
+    expect(ok).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('checkDncForForm — fail-open', () => {
+  it('over budget → registered:false', async () => {
+    const deps = mkDeps({ checkNumbers: jest.fn().mockResolvedValue({ budgetExceeded: true, statusCode: null, results: [] }) });
+    const out = await svc.checkDncForForm(input, deps);
+    expect(out).toEqual({ registered: false });
+  });
+
+  it('non-S000 status → registered:false', async () => {
+    const deps = mkDeps({ checkNumbers: jest.fn().mockResolvedValue({ statusCode: 'S401', results: [] }) });
+    expect(await svc.checkDncForForm(input, deps)).toEqual({ registered: false });
+  });
+
+  it('checkNumbers throws → registered:false', async () => {
+    const deps = mkDeps({ checkNumbers: jest.fn().mockRejectedValue(new Error('proxy down')) });
+    expect(await svc.checkDncForForm(input, deps)).toEqual({ registered: false });
+  });
+
+  it('Campaign lookup throws → registered:false (caught)', async () => {
+    const deps = mkDeps({ Campaign: { findByPk: jest.fn().mockRejectedValue(new Error('db down')) } });
+    expect(await svc.checkDncForForm(input, deps)).toEqual({ registered: false });
+    expect(deps.checkNumbers).not.toHaveBeenCalled();
+  });
+});

--- a/backend/test/unit/dncConsent.test.js
+++ b/backend/test/unit/dncConsent.test.js
@@ -1,0 +1,115 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  buildDncConsentEvidence,
+  hasValidDncConsent,
+  extractDncConsent,
+  DNC_CONSENT_VERSION,
+  DNC_CONSENT_CHANNELS,
+} from '../../src/services/dncConsent.js';
+
+describe('buildDncConsentEvidence', () => {
+  it('returns null when the box was NOT ticked (fail-safe — nothing written, lead stays held)', () => {
+    expect(buildDncConsentEvidence(false)).toBeNull();
+    expect(buildDncConsentEvidence(undefined)).toBeNull();
+    expect(buildDncConsentEvidence(null)).toBeNull();
+  });
+
+  it('only true counts — truthy-but-not-true values are rejected', () => {
+    expect(buildDncConsentEvidence('true')).toBeNull();
+    expect(buildDncConsentEvidence(1)).toBeNull();
+  });
+
+  it('builds the full evidence when ticked (consented + version + channels + timestamp + sourceUrl)', () => {
+    const ev = buildDncConsentEvidence(true, {
+      sourceUrl: 'https://redeem.sg/LeadCapture?campaign_id=abc',
+      at: '2026-06-30T08:11:00.000Z',
+    });
+    expect(ev).toEqual({
+      consented: true,
+      version: DNC_CONSENT_VERSION,
+      consentedAt: '2026-06-30T08:11:00.000Z',
+      channels: ['voice', 'text', 'fax'],
+      sourceUrl: 'https://redeem.sg/LeadCapture?campaign_id=abc',
+    });
+  });
+
+  it('includes dncTransactionId when supplied', () => {
+    const ev = buildDncConsentEvidence(true, { transactionId: 'TXN-123' });
+    expect(ev.dncTransactionId).toBe('TXN-123');
+  });
+
+  it('defaults consentedAt to now (parseable ISO) when no timestamp given', () => {
+    const before = Date.now();
+    const ev = buildDncConsentEvidence(true, { sourceUrl: 'https://mktr.sg/LeadCapture' });
+    const t = Date.parse(ev.consentedAt);
+    expect(Number.isNaN(t)).toBe(false);
+    expect(t).toBeGreaterThanOrEqual(before - 1000);
+  });
+
+  it('ignores an unparseable `at` and falls back to now (keeps evidence valid)', () => {
+    const ev = buildDncConsentEvidence(true, { at: 'not-a-date' });
+    expect(Number.isNaN(Date.parse(ev.consentedAt))).toBe(false);
+    expect(hasValidDncConsent({ consentMetadata: { dnc: ev } })).toBe(true);
+  });
+
+  it('omits sourceUrl / dncTransactionId cleanly when absent or blank (still valid evidence)', () => {
+    const ev = buildDncConsentEvidence(true, {});
+    expect('sourceUrl' in ev).toBe(false);
+    expect('dncTransactionId' in ev).toBe(false);
+    expect(buildDncConsentEvidence(true, { sourceUrl: '   ', transactionId: '  ' })).not.toHaveProperty('sourceUrl');
+    expect(buildDncConsentEvidence(true, { sourceUrl: '   ', transactionId: '  ' })).not.toHaveProperty('dncTransactionId');
+  });
+
+  it('does not share the channels constant by reference (caller cannot mutate it)', () => {
+    const ev = buildDncConsentEvidence(true);
+    expect(ev.channels).toEqual([...DNC_CONSENT_CHANNELS]);
+    expect(ev.channels).not.toBe(DNC_CONSENT_CHANNELS);
+  });
+});
+
+describe('hasValidDncConsent', () => {
+  const goodEv = () => buildDncConsentEvidence(true, { sourceUrl: 'https://redeem.sg/LeadCapture' });
+
+  it('accepts well-formed, consented evidence (Prospect-like, bare meta, and Sequelize get())', () => {
+    const ev = goodEv();
+    expect(hasValidDncConsent({ consentMetadata: { dnc: ev } })).toBe(true); // plain prospect-like
+    expect(hasValidDncConsent({ dnc: ev })).toBe(true); // bare consentMetadata object
+    expect(hasValidDncConsent({ get: (k) => (k === 'consentMetadata' ? { dnc: ev } : undefined) })).toBe(true);
+  });
+
+  it('rejects when consented !== true even if the rest is well-formed', () => {
+    const ev = { ...goodEv(), consented: false };
+    expect(hasValidDncConsent({ consentMetadata: { dnc: ev } })).toBe(false);
+  });
+
+  it('rejects missing / malformed evidence', () => {
+    expect(hasValidDncConsent(null)).toBe(false);
+    expect(hasValidDncConsent({})).toBe(false);
+    expect(hasValidDncConsent({ consentMetadata: {} })).toBe(false);
+    expect(hasValidDncConsent({ consentMetadata: { dnc: { consented: true } } })).toBe(false); // no version/channels/ts
+    expect(hasValidDncConsent({ consentMetadata: { dnc: { consented: true, version: '', channels: ['voice'], consentedAt: '2026-06-30T00:00:00Z' } } })).toBe(false);
+    expect(hasValidDncConsent({ consentMetadata: { dnc: { consented: true, version: 'v', channels: [], consentedAt: '2026-06-30T00:00:00Z' } } })).toBe(false);
+    expect(hasValidDncConsent({ consentMetadata: { dnc: { consented: true, version: 'v', channels: ['voice'], consentedAt: 'nope' } } })).toBe(false);
+  });
+});
+
+describe('extractDncConsent', () => {
+  it('pulls .dnc from each accepted shape, null otherwise', () => {
+    const dnc = { consented: true };
+    expect(extractDncConsent({ consentMetadata: { dnc } })).toBe(dnc);
+    expect(extractDncConsent({ dnc })).toBe(dnc);
+    expect(extractDncConsent({ get: (k) => (k === 'consentMetadata' ? { dnc } : undefined) })).toBe(dnc);
+    expect(extractDncConsent(null)).toBeNull();
+    expect(extractDncConsent({ consentMetadata: { external: {} } })).toBeNull();
+  });
+});
+
+describe('build ↔ hasValid round-trip contract', () => {
+  it('ticked evidence is accepted; unticked => null => rejected', () => {
+    const dnc = buildDncConsentEvidence(true);
+    expect(hasValidDncConsent({ consentMetadata: { dnc } })).toBe(true);
+    const none = buildDncConsentEvidence(false);
+    expect(none).toBeNull();
+    expect(hasValidDncConsent({ consentMetadata: none ? { dnc: none } : {} })).toBe(false);
+  });
+});

--- a/backend/test/unit/dncGate.test.js
+++ b/backend/test/unit/dncGate.test.js
@@ -59,6 +59,56 @@ describe('gateHeldDncLead', () => {
     expect(release).toHaveBeenCalled();
   });
 
+  it('REGISTERED on voice + documented consent → RELEASED (consent override)', async () => {
+    const release = jest.fn().mockResolvedValue({ released: true });
+    const checkAndRecord = jest.fn().mockResolvedValue({ status: 'registered', noVoiceCall: true });
+    const update = jest.fn();
+    const prospect = { id: 'p6', dncMetadata: { intendedAgentId: 'a1' }, update };
+    const out = await gate.gateHeldDncLead(prospect, {
+      checkAndRecord,
+      releaseDncClearedLead: release,
+      hasValidDncConsent: jest.fn().mockReturnValue(true),
+      logger: baseLogger,
+    });
+    expect(out).toMatchObject({ outcome: 'released', status: 'registered', consentOverride: true });
+    expect(release).toHaveBeenCalledWith({ prospect, agentId: 'a1', alreadyCharged: false }, expect.anything());
+    expect(update).not.toHaveBeenCalled(); // never relabeled dnc_registered
+  });
+
+  it('REGISTERED on voice + NO consent → kept held (override does not fire)', async () => {
+    const release = jest.fn();
+    const checkAndRecord = jest.fn().mockResolvedValue({ status: 'registered', noVoiceCall: true });
+    const update = jest.fn().mockResolvedValue();
+    const prospect = { id: 'p7', dncMetadata: { intendedAgentId: 'a1' }, update };
+    const out = await gate.gateHeldDncLead(prospect, {
+      checkAndRecord,
+      releaseDncClearedLead: release,
+      hasValidDncConsent: jest.fn().mockReturnValue(false),
+      logger: baseLogger,
+    });
+    expect(out).toMatchObject({ outcome: 'held', status: 'registered' });
+    expect(out.consentOverride).toBeUndefined();
+    expect(update).toHaveBeenCalledWith({ quarantineReason: 'dnc_registered' });
+    expect(release).not.toHaveBeenCalled();
+  });
+
+  it('REGISTERED on voice + REAL consentMetadata.dnc evidence → released (end-to-end with the real validator)', async () => {
+    // No hasValidDncConsent override → exercises the real services/dncConsent validator.
+    const release = jest.fn().mockResolvedValue({ released: true });
+    const checkAndRecord = jest.fn().mockResolvedValue({ status: 'registered', noVoiceCall: true });
+    const prospect = {
+      id: 'p8',
+      dncMetadata: { intendedAgentId: 'a1' },
+      consentMetadata: {
+        dnc: { consented: true, version: '2026-06-30', consentedAt: '2026-06-30T08:00:00.000Z', channels: ['voice', 'text', 'fax'] },
+      },
+      update: jest.fn(),
+    };
+    const out = await gate.gateHeldDncLead(prospect, { checkAndRecord, releaseDncClearedLead: release, logger: baseLogger });
+    expect(out).toMatchObject({ outcome: 'released', status: 'registered', consentOverride: true });
+    expect(release).toHaveBeenCalled();
+  });
+
   it('PENDING → stays held, no release, no relabel', async () => {
     const release = jest.fn();
     const update = jest.fn();

--- a/backend/test/unit/dncRoute.test.js
+++ b/backend/test/unit/dncRoute.test.js
@@ -1,0 +1,45 @@
+import { jest } from '@jest/globals';
+import express from 'express';
+import request from 'supertest';
+
+// Mock the service so the route → controller → service wiring is exercised in isolation
+// (no DB, no real DNC call). Mocking dncCheckService also replaces its transitive
+// models/index.js import, so importing the route never opens a DB connection.
+jest.unstable_mockModule('../../src/services/dncCheckService.js', () => ({
+  checkDncForForm: jest.fn(),
+  _resetDncCheckCache: jest.fn(),
+}));
+
+const { checkDncForForm } = await import('../../src/services/dncCheckService.js');
+const dncRouter = (await import('../../src/routes/dnc.js')).default;
+const dncMeta = (await import('../../src/routes/dnc.js')).meta;
+
+const app = express();
+app.use(express.json());
+app.use('/api/dnc', dncRouter);
+
+describe('POST /api/dnc/check (route + controller)', () => {
+  beforeEach(() => checkDncForForm.mockReset());
+
+  it('mounts at /api/dnc (auto-loader contract: meta.path + default export)', () => {
+    expect(dncMeta).toEqual({ path: '/api/dnc' });
+    expect(typeof dncRouter).toBe('function');
+  });
+
+  it('passes phone/countryCode/campaignId through and returns { success, data:{ registered } }', async () => {
+    checkDncForForm.mockResolvedValue({ registered: true });
+    const res = await request(app)
+      .post('/api/dnc/check')
+      .send({ phone: '91234567', countryCode: '+65', campaignId: 'c1' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true, data: { registered: true } });
+    expect(checkDncForForm).toHaveBeenCalledWith({ phone: '91234567', countryCode: '+65', campaignId: 'c1' });
+  });
+
+  it('coerces a falsy/odd service result to registered:false and never 4xx on an empty body', async () => {
+    checkDncForForm.mockResolvedValue({ registered: false });
+    const res = await request(app).post('/api/dnc/check').send({});
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true, data: { registered: false } });
+  });
+});

--- a/backend/test/unit/dncService.test.js
+++ b/backend/test/unit/dncService.test.js
@@ -233,7 +233,7 @@ describe('checkAndRecord (mock fetch + models)', () => {
     const deps = mkDeps({});
     const future = new Date(Date.now() + 86400000);
     const out = await dnc.checkAndRecord({ id: 'p4', phone: '90000001', dncStatus: 'clear', dncValidUntil: future }, deps);
-    expect(out).toEqual({ status: 'clear', cached: true });
+    expect(out).toEqual({ status: 'clear', noVoiceCall: false, noTextMessage: false, noFax: false, cached: true });
     expect(deps.fetch).not.toHaveBeenCalled();
   });
 
@@ -252,5 +252,56 @@ describe('checkAndRecord (mock fetch + models)', () => {
     const out = await dnc.checkAndRecord({ id: 'p6', phone: '90000001' }, deps);
     expect(out.status).toBe('disabled');
     expect(deps.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('budget guard (checkNumbers)', () => {
+  const { privateKey } = keypair();
+  const cfg = {
+    enabled: true, baseUrl: 'https://x/realtime', orgCode: 'O', eServiceId: 'E',
+    privateKey, checkOnBehalf: 'N', proxy: null, timeoutMs: 5000,
+  };
+  const okFetch = () => jest.fn().mockResolvedValue({ status: 200, json: async () => ({ status_code: 'S000', numbers: [] }) });
+
+  beforeEach(() => dnc._resetDncBudget());
+
+  it('refuses (budgetExceeded, no network) once over the hourly cap', async () => {
+    const prev = process.env.DNC_HOURLY_BUDGET;
+    process.env.DNC_HOURLY_BUDGET = '2';
+    const fetch = okFetch();
+    const r1 = await dnc.checkNumbers(['90000001', '90000002'], { cfg }, { fetch, skipLock: true });
+    expect(r1.budgetExceeded).toBeFalsy();
+    const r2 = await dnc.checkNumbers(['90000003'], { cfg }, { fetch, skipLock: true });
+    expect(r2.budgetExceeded).toBe(true);
+    expect(fetch).toHaveBeenCalledTimes(1); // the over-budget call never hit the network
+    process.env.DNC_HOURLY_BUDGET = prev;
+  });
+
+  it('skipBudget bypasses the cap', async () => {
+    const prev = process.env.DNC_HOURLY_BUDGET;
+    process.env.DNC_HOURLY_BUDGET = '0';
+    const fetch = okFetch();
+    const r = await dnc.checkNumbers(['90000001'], { cfg }, { fetch, skipLock: true, skipBudget: true });
+    expect(r.budgetExceeded).toBeFalsy();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    process.env.DNC_HOURLY_BUDGET = prev;
+  });
+});
+
+describe('checkAndRecord cache hit returns channel flags', () => {
+  const { privateKey } = keypair();
+  const cfg = {
+    enabled: true, baseUrl: 'https://x/realtime', orgCode: 'O', eServiceId: 'E',
+    privateKey, checkOnBehalf: 'N', proxy: null, timeoutMs: 5000,
+  };
+  it('reuses stored channel flags without calling the API', async () => {
+    const fetch = jest.fn();
+    const future = new Date(Date.now() + 86400000);
+    const out = await dnc.checkAndRecord(
+      { id: 'p', phone: '90000001', dncStatus: 'registered', dncValidUntil: future, dncNoVoiceCall: true, dncNoTextMessage: false, dncNoFax: false },
+      { fetch, skipLock: true, cfg, Prospect: { update: jest.fn() }, ProspectActivity: { create: jest.fn() } }
+    );
+    expect(out).toEqual({ status: 'registered', noVoiceCall: true, noTextMessage: false, noFax: false, cached: true });
+    expect(fetch).not.toHaveBeenCalled();
   });
 });

--- a/backend/test/unit/verifiedPhoneStore.test.js
+++ b/backend/test/unit/verifiedPhoneStore.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import {
+  markPhoneVerified,
+  isPhoneRecentlyVerified,
+  _resetVerifiedPhones,
+} from '../../src/services/verifiedPhoneStore.js';
+
+describe('verifiedPhoneStore', () => {
+  beforeEach(() => _resetVerifiedPhones());
+
+  it('marked phone is recently verified; unmarked is not', () => {
+    expect(isPhoneRecentlyVerified('+6591234567')).toBe(false);
+    markPhoneVerified('+6591234567');
+    expect(isPhoneRecentlyVerified('+6591234567')).toBe(true);
+    // a different number stays false (no cross-talk)
+    expect(isPhoneRecentlyVerified('+6598765432')).toBe(false);
+  });
+
+  it('marker expires after the TTL (and self-prunes on read)', () => {
+    const t0 = 1_000_000;
+    markPhoneVerified('+6591234567', t0);
+    expect(isPhoneRecentlyVerified('+6591234567', t0 + 60_000)).toBe(true); // within TTL
+    // default TTL is 10 min; 11 min later it is expired
+    expect(isPhoneRecentlyVerified('+6591234567', t0 + 11 * 60_000)).toBe(false);
+    // and a fresh check at the same later time still false (entry was pruned)
+    expect(isPhoneRecentlyVerified('+6591234567', t0 + 11 * 60_000)).toBe(false);
+  });
+
+  it('honors DNC_VERIFIED_MARKER_TTL_MS override', () => {
+    const prev = process.env.DNC_VERIFIED_MARKER_TTL_MS;
+    process.env.DNC_VERIFIED_MARKER_TTL_MS = '1000';
+    const t0 = 5_000_000;
+    markPhoneVerified('+6590000000', t0);
+    expect(isPhoneRecentlyVerified('+6590000000', t0 + 500)).toBe(true);
+    expect(isPhoneRecentlyVerified('+6590000000', t0 + 1500)).toBe(false);
+    process.env.DNC_VERIFIED_MARKER_TTL_MS = prev;
+  });
+
+  it('no-ops for falsy phone', () => {
+    markPhoneVerified('');
+    markPhoneVerified(null);
+    expect(isPhoneRecentlyVerified('')).toBe(false);
+    expect(isPhoneRecentlyVerified(null)).toBe(false);
+  });
+
+  it('reset clears all markers', () => {
+    markPhoneVerified('+6591234567');
+    _resetVerifiedPhones();
+    expect(isPhoneRecentlyVerified('+6591234567')).toBe(false);
+  });
+});

--- a/docs/plans/dnc-consent-gate.md
+++ b/docs/plans/dnc-consent-gate.md
@@ -1,0 +1,107 @@
+# DNC consent gate on the lead-capture form — design
+
+**Status:** DRAFT (for Codex xhigh review, then implementation)
+**Date:** 2026-06-30
+**Relationship:** This is the **consumer-facing** half of DNC compliance. The backend scrubbing (`docs/plans/dnc-scrubbing.md`, shipped dark in PR #81) is the compliance *backstop*; this captures **documented consent at the point of opt-in** so a DNC-registered prospect can be lawfully contacted — i.e. it produces the evidence that powers the backend's consent override.
+
+---
+
+## 1. What it does
+
+Per-campaign toggle. When ON, the lead-capture form checks the entered phone against the DNC Registry **concurrently with the OTP send**, and:
+- **Not on DNC →** the prospect sees **nothing different** (zero UX change).
+- **On DNC →** a consent checkbox **slides out** under the phone/OTP field with a disclosure ("Your number is on Singapore's Do Not Call Registry. Tick to consent to being contacted by {advertiser} about this offer."). Until it's ticked, **all other fields are locked and Submit is disabled**. Ticking it unlocks the form. The consent (+ the DNC result) is recorded as evidence on the lead.
+
+Composition with the backend: a consented registered lead carries `consentMetadata.dnc` → the backend block-mode gate **releases** it (consent override) instead of holding it. An un-consented registered lead can't be submitted here, and even if forged, the backend still holds it (defence in depth).
+
+---
+
+## 2. Why the cost/abuse model is the crux
+
+**Every DNC check costs a real prepaid credit** — and (Codex P0, verified) **the public `POST /api/prospects` create path already bills one**: it's public, IP-limited only (10/min), and does **no** OTP verification (OTP is frontend-only; `routes/prospects.js:29`), and `createProspect` already calls the DNC gate. So once `DNC_API_ENABLED=true`, the *create endpoint itself* is the cheapest drain — cheaper than the new check endpoint. **The cost defence therefore cannot live on the new endpoint; it must sit at the backend, below every caller:**
+
+1. **Per-campaign gate (master control).** Both the form-time check AND the backend create-time scrub run **only** when `campaign.design_config.dncCheck === true` — one toggle scopes all DNC spend to opted-in campaigns. *This requires changing the shipped backend, which currently scrubs on the GLOBAL `DNC_ENFORCEMENT` — see §9.*
+2. **Budget guard inside `dncService.checkNumbers`** (not the endpoint) — a global hourly credit cap every caller (create, Retell, backfill, form) passes through. Over budget → fail-open, backend block-mode still backstops.
+3. **Server-side per-number cache** (hashed, TTL ≤ validity) — repeat checks don't re-bill, and capture reuses it (no double-bill, §5).
+4. **SG-only** (`formatDncNumber` null → skip); **IP + per-number rate limits**; **never expose the API to the browser** (private key + proxy backend-only).
+5. **No DNC-status oracle:** reveal `registered` to the browser **only after OTP is verified** (proving control of the number) — otherwise the endpoint leaks "is X on DNC?" for any number.
+
+---
+
+## 3. UX flow (CampaignSignupForm.jsx)
+
+The form already has the OTP state machine (`otpState: idle→pending→verified`, `handleSendOtp → POST /verify/send`, `OTPVerification` component). The DNC check rides the OTP-entry latency:
+
+1. User enters phone → taps "Send OTP". `handleSendOtp` fires `/verify/send` **and** (if `dncCheck` on + SG number) fires `POST /api/dnc/check` **concurrently** (fire-and-forget; sets `dncState: 'checking'`).
+2. While the user types the 6-digit code (~seconds), the check returns. New state: `dncState ∈ {idle, checking, clear, registered, error}` + `dncConsent: boolean`.
+3. `registered` → render `<DncConsentSlideout>` (mirrors the existing `ConsentSection`; animated reveal) under the OTP block; set `formLocked = true`.
+4. `formLocked` → every `FieldRenderer` field gets `disabled`, Submit `disabled`. Ticking the consent box (default **unticked**) sets `dncConsent=true` → `formLocked=false`.
+5. `clear` / `error` / non-SG → no slideout, form behaves exactly as today (**fail-open**: an errored check must never block a non-registered user; the backend is the net).
+6. **Number changed after a check →** reset `dncState=idle`, `dncConsent=false`; a new OTP send re-checks the new number (the consent is bound to the checked number).
+7. On submit: include `consent_dnc` + the opaque check token (§5) so the backend ties consent to the server-known result.
+8. **Preview/demo (`/p/:slug`)** stubs all network — DNC check simulated locally (configurable "pretend registered" so admins can preview the slideout), never bills.
+
+---
+
+## 4. Campaign designer toggle (ContentPanel.jsx)
+
+Mirror the `sgPrOnly` toggle (`ContentPanel.jsx:435`): a `FieldToggle` "Check Do Not Call (DNC) at submit" with helper text, bound to `currentDesign.dncCheck` via `onDesignChange('dncCheck', checked)`. Stored in `campaign.design_config.dncCheck` (boolean, default false). Optional: an editable disclosure-copy field (else a sensible default + the advertiser name). `campaignService.updateCampaign` already persists `design_config`; add `dncCheck` to any clamp/allowlist.
+
+---
+
+## 5. Backend endpoint + no-double-bill + consent → override
+
+**`POST /api/dnc/check`** (new; public, like `/verify/send`):
+- Body: `{ phone, campaignId, otpRef }`. 
+- Gates: campaign `dncCheck` on → valid live OTP session for `phone` → SG number → rate/budget OK.
+- Reuses `dncService.checkNumbers([number])` through the egress proxy.
+- Caches the result server-side by `hashPhone(number)` (TTL ≤ validity) and returns a **minimal** body: `{ registered: boolean, token }` — `token` is an opaque, signed, short-TTL handle to the cached result (the browser never sees channels/transactionId).
+- Returns `{ registered:false }` fail-open on error/over-budget.
+
+**No double-bill / authoritative result:** on prospect creation, `createProspect` resolves the form `token` (or re-looks-up the number cache) → reuses the **server-known** DNC result (no second API call, no second credit) → writes it to the `dnc*` columns. So the form-time credit IS the capture credit. The client-sent `consent_dnc` is recorded, but the *registered* fact comes from the server cache (client can't forge "not registered").
+
+**Consent → backend override:** `createProspect` writes `consentMetadata.dnc = { consented, consentedAt, disclosureVersion, dncTransactionId, sourceUrl }`. The born-held-pending gate then: registered **+ consented** → release (override); registered **+ not consented** → hold `dnc_registered` as today. This is the evidence-backed path the backend's `DNC_CONSENT_OVERRIDES` referenced — so that env flag's "must be evidence-backed" condition is now satisfiable.
+
+---
+
+## 6. Trust, fail-safe, edge cases
+
+- **Server-authoritative registered fact** (browser gets only a boolean + opaque token) → a tampered client can't claim "clear" to skip the gate (backend re-derives from cache; absent cache → backend checks at capture, still gates).
+- **Fail-open at the form, fail-safe at the backend.** Form-time errors never block; the backend born-held-pending gate is the compliance backstop.
+- **Consent default OFF** (PDPA active opt-in); unticking re-locks.
+- **i18n / a11y:** the disclosure is regulatory copy — needs the brand's regulatory styling, screen-reader association (`aria-describedby`), and focus moved to the consent box on reveal.
+- **Composition with `sgPrOnly`:** both can be on; DNC slideout is independent of the SG/PR screening card.
+
+---
+
+## 7. Testing
+
+- Frontend (`CampaignSignupForm.test.jsx`): not-registered → no UI change; registered → slideout + locked fields + disabled submit; tick → unlocks; number change → resets; error → fail-open; preview → stub, no network.
+- Backend: `/api/dnc/check` gating (campaign off / no OTP session / non-SG / over-budget → no spend), cache reuse (no double-bill), token round-trip, consent → override in `createProspect`.
+- Designer: toggle persists `design_config.dncCheck`.
+
+## 8. Open decisions
+
+1. **OTP-session gate mechanism** — reuse the existing OTP store to prove a live session, or a dedicated short-lived nonce returned by `/verify/send`?
+2. **Budget cap** value + behavior on exceed (fail-open vs queue).
+3. **Disclosure copy** — fixed default vs per-campaign editable; advertiser name source.
+4. **Cache store** — in-memory (single-instance, simplest) vs Redis (already used elsewhere?).
+5. **Token vs re-lookup** at capture — signed token in the submit, or backend re-reads the number cache by phone?
+6. Whether to **also** surface the per-channel flags to the agent app (needs the lyfe-app receiver change already deferred in the backend plan §10).
+
+---
+
+## 9. Codex xhigh review (2026-06-30) — verified against code, folded in
+
+**P0 (reshaped the design):**
+- **The public create path is the real credit-drain — not the new endpoint.** `POST /api/prospects` is public + IP-limited only + does NO server-side OTP check (`routes/prospects.js:29`; verified zero OTP/verification in the create controller/service), and `createProspect` already calls the DNC gate. So the cost defence moved to the backend (§2): per-campaign gate + a budget guard inside `checkNumbers`. **⚠️ Action item for the SHIPPED backend (PR #81), before `DNC_API_ENABLED=true`: (a) gate create-time DNC on `campaign.design_config.dncCheck` — it currently scrubs on the global `DNC_ENFORCEMENT` — and (b) add the budget guard in `checkNumbers`. Otherwise the live create endpoint drains credits.**
+- **OTP store can't prove a live session + oracle risk.** `Verification` is keyed by phone only, `/verify/send` returns no ref + is IP-limited, verify destroys the row (`verificationService.js:171,227`). 'Send-only' proves nothing, and returning `registered` pre-verify leaks DNC status → reveal the result **only after OTP verify**; treat the form check as best-effort UX, the backend as authoritative.
+- **Consent override isn't implemented.** `dncGate.js:150-157` always holds registered-on-voice → add a **server-built** DNC-consent evidence validator that releases `registered + consented`. **Do NOT reuse `consent_contact`** — it defaults `true` in the form (`CampaignSignupForm.jsx:74`), so it would auto-override everyone. Follow the `consentThirdParty` / `externalConsent.js:97` pattern (separate, default-OFF, server-built evidence).
+
+**P1 (folded in):**
+- No-double-bill needs a real injection point: `gateHeldDncLead` hard-calls `checkAndRecord` (`dncGate.js:144`); add a gate variant that accepts a pre-known result. AND fix `checkAndRecord`'s cache-hit return — it omits channel flags (`dncService.js:297`), so a reused `registered` result has `noVoiceCall===undefined` → `dncGate.js:152` would mis-treat it as deliverable.
+- `consent_dnc` + any token are stripped by the route + schema + `createProspect`'s drop of client `consentMetadata` (correct defensively) → DNC evidence must be **server-built**; the client sends only the intent boolean.
+- Submit can fire before DNC returns (OTP auto-verifies on the 6th digit, `OTPVerification.jsx:49`; DNC ~5s) → **disable submit while `dncState==='checking'`** for DNC campaigns.
+- Toggle persistence: add `dncCheck` to `DesignEditor.jsx`'s explicit `currentDesign` init + save (it whitelists keys, `:58`), not just `ContentPanel`.
+
+**P2 (folded in):** `FieldRenderer` needs a `disabled` prop (only phone is OTP-locked today, `:209`); mirror the inline `ConsentCheckbox` (`CampaignSignupForm.jsx:926`), not `ConsentSection` (just a terms link); a11y (focus the revealed checkbox, `aria-describedby`, announce the disclosure); add a preview 'pretend registered' state.

--- a/src/components/campaigns/CampaignSignupForm.jsx
+++ b/src/components/campaigns/CampaignSignupForm.jsx
@@ -1,8 +1,9 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, Fragment } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { apiClient } from '@/api/client';
 import FieldRenderer from '@/components/campaigns/signup/FieldRenderer';
 import OTPVerification from '@/components/campaigns/signup/OTPVerification';
+import DncConsentGate from '@/components/campaigns/signup/DncConsentGate';
 import MarketingConsentDialog from '@/components/legal/MarketingConsentDialog';
 import { TOKENS, RADIUS } from '@/components/campaigns/LeadCaptureLayout';
 import { heroFontStack } from '@/lib/heroFonts';
@@ -40,6 +41,7 @@ export default function CampaignSignupForm({
   const headingFont = heroFontStack(campaign?.design_config?.heroFont);
   const sgPrOnly = campaign?.design_config?.sgPrOnly === true;
   const excludeAdvisors = campaign?.design_config?.excludeAdvisors === true;
+  const dncCheckAtSubmit = campaign?.design_config?.dncCheckAtSubmit === true;
 
   const [formData, setFormData] = useState({
     name: '',
@@ -52,6 +54,9 @@ export default function CampaignSignupForm({
   });
   const [otp, setOtp] = useState('');
   const [otpState, setOtpState] = useState('idle');
+  // DNC consent gate (inert unless dncCheckAtSubmit). 'unknown' | 'checking' | 'on_dnc' | 'clear'.
+  const [dncStatus, setDncStatus] = useState('unknown');
+  const [dncConsent, setDncConsent] = useState(false);
   const [loading, setLoading] = useState(null);
   const [error, setError] = useState('');
   const [previewNotice, setPreviewNotice] = useState('');
@@ -205,6 +210,8 @@ export default function CampaignSignupForm({
     setOtpState('idle');
     setOtp('');
     setError('');
+    setDncStatus('unknown');
+    setDncConsent(false);
     setResendCooldown(0);
   };
 
@@ -281,6 +288,9 @@ export default function CampaignSignupForm({
       consent_contact: consentContact,
       consent_terms: consentTerms,
       consent_third_party: consentThirdParty,
+      // DNC consent intent (the server builds the authoritative evidence). Only sent when
+      // the gate was actually shown for this lead.
+      ...(dncCheckAtSubmit && dncStatus === 'on_dnc' ? { consent_dnc: dncConsent } : {}),
     };
 
     // Preview: stop here — never call onSubmit (which would create a real
@@ -312,6 +322,18 @@ export default function CampaignSignupForm({
   const handleOtpVerified = () => {
     setOtpState('verified');
     setShowSuccessTick(false);
+    // DNC check — fired only AFTER OTP is verified (so the result can't be used as an
+    // "is X on DNC?" oracle) and only when the campaign opted in. Fail-open: any error /
+    // non-SG / preview leaves dncStatus 'clear' so no gate appears (the backend scrub is
+    // the compliance net).
+    if (dncCheckAtSubmit && !previewMode) {
+      setDncStatus('checking');
+      setDncConsent(false);
+      apiClient
+        .post('/dnc/check', { phone: formData.phone, countryCode: '+65', campaignId }, { skipAuth: true })
+        .then((res) => setDncStatus(res?.data?.registered ? 'on_dnc' : 'clear'))
+        .catch(() => setDncStatus('clear'));
+    }
   };
 
   // Inline verification panel — slides down beneath the phone field (no modal).
@@ -352,7 +374,28 @@ export default function CampaignSignupForm({
     phoneOtpPanel,
   };
 
-  const renderField = (fieldId) => <FieldRenderer key={fieldId} fieldId={fieldId} {...fieldRendererProps} />;
+  // DNC consent gate: rendered beneath the verified phone field when the campaign opted in
+  // and the verified number is on the registry. While open and not consented, the other
+  // fields lock and submit is disabled. Entirely inert when dncCheckAtSubmit is off.
+  const dncGateOpen = dncCheckAtSubmit && dncStatus === 'on_dnc';
+  const gateLocked = dncGateOpen && !dncConsent;
+  const renderField = (fieldId) => {
+    if (fieldId === 'phone') {
+      return (
+        <Fragment key="phone">
+          <FieldRenderer fieldId="phone" {...fieldRendererProps} />
+          {dncGateOpen && (
+            <DncConsentGate
+              consented={dncConsent}
+              onGiveConsent={() => setDncConsent(true)}
+              onRevoke={() => setDncConsent(false)}
+            />
+          )}
+        </Fragment>
+      );
+    }
+    return <FieldRenderer key={fieldId} fieldId={fieldId} {...fieldRendererProps} locked={gateLocked} />;
+  };
 
   const submitDisabled =
     otpState !== 'verified' ||
@@ -360,7 +403,9 @@ export default function CampaignSignupForm({
     ageError !== '' ||
     dobIncomplete ||
     !isValidEmail(formData.email) ||
-    !consentTerms;
+    !consentTerms ||
+    (dncCheckAtSubmit && dncStatus === 'checking') ||
+    gateLocked;
 
   // SG/PR eligibility gate (campaign.design_config.sgPrOnly): a Yes/No screening
   // card shown before the form. "Yes" reveals + animates the form in; "No" shows a

--- a/src/components/campaigns/DesignEditor.jsx
+++ b/src/components/campaigns/DesignEditor.jsx
@@ -73,6 +73,7 @@ export default function DesignEditor({ campaign, onSave, heightClass = 'h-[calc(
  requiredFields: design.requiredFields || {},
     sgPrOnly: design.sgPrOnly === true,
     excludeAdvisors: design.excludeAdvisors === true,
+    dncCheckAtSubmit: design.dncCheckAtSubmit === true,
     // Per-campaign customer host: 'redeem' (default) or 'mktr' — drives the
     // customer-facing brand/domain for this campaign's links + confirmation email.
     customerHost: design.customerHost === 'mktr' ? 'mktr' : 'redeem',

--- a/src/components/campaigns/editor/ContentPanel.jsx
+++ b/src/components/campaigns/editor/ContentPanel.jsx
@@ -460,6 +460,23 @@ export default function ContentPanel({ currentDesign, onDesignChange }) {
           </div>
         </div>
 
+        {/* Compliance — DNC check at submit */}
+        <div className="space-y-3 pt-4 border-t">
+          <Label className="text-sm font-semibold text-foreground">Compliance</Label>
+          <p className="text-xs text-muted-foreground -mt-1">Runs automatically when the prospect submits.</p>
+          <div className="flex items-center justify-between gap-3 py-1">
+            <div className="flex flex-col">
+              <span className="text-sm text-foreground">Check Do Not Call (DNC) at submit</span>
+              <span className="text-xs text-muted-foreground">Checks each number against Singapore&apos;s DNC Registry. If the number is registered, the prospect must give explicit consent before they can submit.</span>
+            </div>
+            <Switch
+              aria-label="Check Do Not Call (DNC) at submit"
+              checked={currentDesign.dncCheckAtSubmit === true}
+              onCheckedChange={(checked) => onDesignChange('dncCheckAtSubmit', checked)}
+            />
+          </div>
+        </div>
+
         {/* Terms & Conditions */}
  <div className="space-y-3 pt-4 border-t">
  <Label className="text-sm font-semibold text-foreground">Terms & Conditions</Label>

--- a/src/components/campaigns/signup/DncConsentGate.jsx
+++ b/src/components/campaigns/signup/DncConsentGate.jsx
@@ -1,0 +1,173 @@
+import { Shield, ShieldCheck, Pencil } from 'lucide-react';
+import { TOKENS } from '@/components/campaigns/LeadCaptureLayout';
+
+/**
+ * DNC consent gate — C3 "editorial seal" (design_handoff_dnc_consent_gate/README.md, authoritative).
+ * Rendered beneath the verified phone/OTP block when the campaign has `dncCheckAtSubmit` ON AND the
+ * verified number is on Singapore's DNC Registry. Two states driven by `consented`:
+ *   notice (cream)  → gives the consent action; while it shows, the form fields stay locked.
+ *   confirmed (sage) → records consent; Edit revokes it.
+ * Reveal slides in from the left; honors prefers-reduced-motion.
+ *
+ * `{Advertiser}` is kept as a LITERAL interpolation token (mono chip) per the handoff — the real
+ * advertiser name is interpolated later.
+ */
+
+const FRAUNCES = 'Fraunces, serif';
+const ALBERT = '"Albert Sans", sans-serif';
+const MONO = '"JetBrains Mono", monospace';
+
+function AdvertiserChip({ advertiser, tone }) {
+  const sage = tone === 'sage';
+  return (
+    <span
+      style={{
+        fontFamily: MONO,
+        fontSize: '0.9em',
+        background: sage ? 'rgba(94,112,73,.14)' : 'rgba(176,128,30,.14)',
+        color: sage ? '#566A3D' : '#8A6418',
+        borderRadius: 5,
+        padding: '1px 5px',
+      }}
+    >
+      {advertiser}
+    </span>
+  );
+}
+
+const KEYFRAMES = `
+  @keyframes dncSlideIn { from { opacity: 0; transform: translateX(-32px); } to { opacity: 1; transform: translateX(0); } }
+  @keyframes dncFadeIn { from { opacity: 0; } to { opacity: 1; } }
+  .dnc-gate-notice { animation: dncSlideIn 460ms cubic-bezier(0.16, 1, 0.3, 1) both; }
+  .dnc-gate-confirmed { animation: dncFadeIn 300ms ease both; }
+  @media (prefers-reduced-motion: reduce) {
+    .dnc-gate-notice, .dnc-gate-confirmed { animation: none; }
+  }
+`;
+
+export default function DncConsentGate({ advertiser = '{Advertiser}', consented, onGiveConsent, onRevoke }) {
+  if (consented) {
+    return (
+      <div
+        className="dnc-gate-confirmed"
+        role="status"
+        style={{
+          background: '#F6F8EF',
+          border: '1px solid #CDD9B6',
+          borderRadius: 18,
+          padding: '18px 18px 16px',
+          textAlign: 'center',
+          boxShadow: '0 2px 8px rgba(60,70,40,.06)',
+          margin: '14px 0',
+        }}
+      >
+        <style>{KEYFRAMES}</style>
+        <div
+          style={{
+            width: 42,
+            height: 42,
+            borderRadius: '50%',
+            background: '#DCE6C8',
+            border: '1.5px solid #BFD0A2',
+            margin: '0 auto 11px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <ShieldCheck size={20} style={{ stroke: '#5E7049' }} aria-hidden="true" />
+        </div>
+        <div style={{ fontFamily: FRAUNCES, fontSize: 19, fontWeight: 700, letterSpacing: '-.01em', color: TOKENS.ink }}>
+          Consent recorded
+        </div>
+        <p style={{ fontFamily: ALBERT, fontSize: 12.5, lineHeight: 1.55, color: '#5C6845', maxWidth: 262, margin: '6px auto 12px' }}>
+          You&apos;ve agreed to be contacted by <AdvertiserChip advertiser={advertiser} tone="sage" />. You can change this anytime.
+        </p>
+        <button
+          type="button"
+          onClick={onRevoke}
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            color: '#5E7049',
+            textDecoration: 'underline',
+            textUnderlineOffset: 3,
+            fontFamily: ALBERT,
+            fontSize: 13.5,
+            fontWeight: 600,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+          }}
+        >
+          <Pencil size={13} style={{ stroke: '#5E7049' }} aria-hidden="true" /> Edit consent
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="dnc-gate-notice"
+      role="group"
+      aria-label="Do Not Call consent"
+      style={{
+        background: '#FFFCF6',
+        border: '1px solid #EAD6A6',
+        borderRadius: 18,
+        padding: '18px 18px 16px',
+        textAlign: 'center',
+        boxShadow: '0 12px 26px -12px rgba(120,80,20,.22), 0 3px 10px rgba(120,80,20,.10)',
+        margin: '14px 0',
+      }}
+    >
+      <style>{KEYFRAMES}</style>
+      <div
+        style={{
+          width: 42,
+          height: 42,
+          borderRadius: '50%',
+          background: '#F7E9C8',
+          border: '1.5px solid #E3C879',
+          margin: '0 auto 11px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Shield size={20} style={{ stroke: '#B0801E' }} aria-hidden="true" />
+      </div>
+      <div style={{ fontFamily: FRAUNCES, fontSize: 19, fontWeight: 700, letterSpacing: '-.01em', color: '#3D1F0B' }}>
+        A quick consent
+      </div>
+      <p style={{ fontFamily: ALBERT, fontSize: 12.5, lineHeight: 1.55, color: '#6E5631', maxWidth: 262, margin: '6px auto 14px' }}>
+        This number is on Singapore&apos;s Do Not Call Registry. To receive <AdvertiserChip advertiser={advertiser} />
+        &apos;s offer and updates about it, please confirm below.
+      </p>
+      <button
+        type="button"
+        onClick={onGiveConsent}
+        style={{
+          width: '100%',
+          height: 48,
+          borderRadius: 999,
+          background: '#fff',
+          border: '1.5px solid #D17029',
+          color: '#D17029',
+          fontFamily: ALBERT,
+          fontSize: 14.5,
+          fontWeight: 600,
+          cursor: 'pointer',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 9,
+        }}
+      >
+        <span aria-hidden="true" style={{ width: 19, height: 19, border: '1.5px solid #D17029', borderRadius: 5, display: 'inline-block' }} />
+        I consent to be contacted
+      </button>
+    </div>
+  );
+}

--- a/src/components/campaigns/signup/FieldRenderer.jsx
+++ b/src/components/campaigns/signup/FieldRenderer.jsx
@@ -1,5 +1,18 @@
+import { Lock } from 'lucide-react';
 import { TOKENS, RADIUS } from '@/components/campaigns/LeadCaptureLayout';
 import { readableTextOn } from '@/lib/contrast';
+
+// Greyed, non-editable field treatment used while the DNC consent gate is open.
+// !important overrides the inputs' inline styles; pointer-events:none blocks editing.
+const LOCKED_FIELD_CSS = `
+  .lc-field-locked input, .lc-field-locked select {
+    background-color: #F0E7D4 !important;
+    border-color: #E2D6BC !important;
+    color: #A8916E !important;
+    pointer-events: none;
+  }
+  .lc-field-locked select { cursor: default !important; }
+`;
 
 /**
  * Per-field renderer for the public lead-capture form.
@@ -115,6 +128,9 @@ export default function FieldRenderer({
   dobIncomplete,
   ageError,
   renderAgeRestrictionHint,
+  // When true, the field renders locked (greyed + lock icon, non-editable) — used by the
+  // DNC consent gate until the prospect consents.
+  locked,
 }) {
   // name / email / phone are always visible. Phone is the lead pipeline's
   // identity/dedup key (phone+OTP), so it can never be hidden via config.
@@ -130,7 +146,8 @@ export default function FieldRenderer({
     return { required: true, optional: false };
   };
 
-  switch (fieldId) {
+  const node = (() => {
+    switch (fieldId) {
     case 'name':
       return (
         <div style={{ marginBottom: 20 }}>
@@ -408,7 +425,21 @@ export default function FieldRenderer({
 
     default:
       return null;
-  }
+    }
+  })();
+
+  if (!locked) return node;
+  return (
+    <div className="lc-field-locked" aria-disabled="true" style={{ position: 'relative', opacity: 0.5 }}>
+      <style>{LOCKED_FIELD_CSS}</style>
+      {node}
+      <Lock
+        size={14}
+        aria-hidden="true"
+        style={{ position: 'absolute', right: 18, top: 42, stroke: '#B6A07C', pointerEvents: 'none' }}
+      />
+    </div>
+  );
 }
 
 function SelectChevron() {


### PR DESCRIPTION
**Draft** — the consumer DNC consent gate. Frontend + the pre-go-live backend safety fixes are done; two backend pieces remain (see below). Ships **dark / inert** — safe to keep open.

## What
A per-campaign **"Check Do Not Call (DNC) at submit"** gate on the lead-capture form (PDPA consent capture at opt-in): when the campaign opts in and the verified number is on the DNC Registry, a consent card slides out, the other fields lock, and Submit is disabled until the prospect consents. Invisible if the number isn't on the registry. Composes with the shipped backend scrubbing (PR #81) — the captured consent is what lets the backend release an otherwise-held registered lead.

## ✅ Done (this PR)
**Frontend** (`dfadfe6`) — inert when `design_config.dncCheckAtSubmit` is off, fail-open if the check errors; existing **31 `CampaignSignupForm` tests pass** (no live-form regression):
- `ContentPanel` "Compliance" toggle → `design_config.dncCheckAtSubmit`; persisted via `DesignEditor`
- `signup/DncConsentGate.jsx` — C3 "editorial seal" (notice→confirmed, slide-in + `prefers-reduced-motion`, `{Advertiser}` literal mono chip), exact handoff tokens
- `FieldRenderer` `locked` state (greyed + lock, non-editable; one CSS override covers all field types)
- `CampaignSignupForm` — DNC check **after OTP verify** (oracle-safe), gate beneath the phone field, lock fields + gate submit, `consent_dnc` payload

**Backend pre-go-live safety** (`308adcc`) — the three Codex xhigh P0s, tested (**41 dncService tests**; prospect + retell suites green):
- Budget guard in `checkNumbers` (`DNC_HOURLY_BUDGET`, fail-open) below every caller — caps the public-create credit-drain
- Per-campaign gate — create-time DNC runs only for `dncCheckAtSubmit` campaigns
- `checkAndRecord` cache-hit return now includes channel flags (latent mis-deliver bug)

## ⏳ Remaining (next session — feature completion, not safety-critical)
1. **Consent override** — server-built `consentMetadata.dnc` (`externalConsent` pattern, *not* `consent_contact`) + `consent_dnc` in the create schema + `dncGate` releasing `registered + consented`.
2. **`POST /api/dnc/check`** — the form's lookup backend (OTP-verified-gated, per-campaign, reveal-only-after-verify, cached, fail-open).

The system is **safe without these**: DNC is dark, the safety trio is in place, and the frontend fail-opens (no consumer gate shown) → the backend scrub still backstops any registered lead.

## Docs
- Design + Codex xhigh review: `docs/plans/dnc-consent-gate.md` (§9 = verified findings)
- Design handoff (not committed): `design_handoff_dnc_consent_gate/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
