### PR TITLE
fix(web): "Viewed by {agent}" on the lead timeline (not "Updated")

### DIFF
--- a/src/utils/__tests__/leadTimeline.test.js
+++ b/src/utils/__tests__/leadTimeline.test.js
@@ -25,6 +25,12 @@ describe('leadTimeline — web normalizers (canonical model, parity with the app
     expect(normalizeLeadActivity({ id: 'a3', type: 'status', description: 'Marked as Disputed', created_at: 't' }).kind).toBe('disputed');
     expect(normalizeLeadActivity({ id: 'a4', type: 'unassignment', metadata: { returned_to_held: true }, created_at: 't' }).kind).toBe('returned');
     expect(normalizeLeadActivity({ id: 'a5', type: 'some_future_type', created_at: 't' }).kind).toBe('updated');
+    // a `viewed` engagement row → 'viewed' kind, titled with the actor from metadata.actor_name
+    expect(
+      normalizeLeadActivity({ id: 'a6', type: 'viewed', metadata: { actor_name: 'Lee Yi Heng' }, created_at: 't' }),
+    ).toMatchObject({ kind: 'viewed', title: 'Viewed by Lee Yi Heng' });
+    // …and a plain "Viewed" when no actor was resolved
+    expect(normalizeLeadActivity({ id: 'a7', type: 'viewed', created_at: 't' }).title).toBe('Viewed');
   });
 
   it('buildTimeline merges tagged rows by origin, preserving the backend order', () => {

--- a/src/utils/leadTimeline.js
+++ b/src/utils/leadTimeline.js
@@ -47,7 +47,14 @@ const LEAD_ACTIVITY_KIND = {
   account_deleted: 'account_deleted',
   archived: 'archived',
   unarchived: 'unarchived',
+  viewed: 'viewed',
 };
+
+/** The web is admin-only oversight, so a viewed row reads "Viewed by {agent}" — actor name comes
+ * from the export EF's `metadata.actor_name` (the app shows "Viewed by you" to the agent instead). */
+function viewedTitle(m) {
+  return typeof m.actor_name === 'string' && m.actor_name ? `Viewed by ${m.actor_name}` : KIND_TITLE.viewed;
+}
 
 /** Normalise ONE Supabase lead_activities row → canonical entry (or null for config rows). */
 export function normalizeLeadActivity(a) {
@@ -60,7 +67,7 @@ export function normalizeLeadActivity(a) {
   return {
     id: a.id,
     kind,
-    title: typeof m.title === 'string' ? m.title : KIND_TITLE[kind],
+    title: typeof m.title === 'string' ? m.title : kind === 'viewed' ? viewedTitle(m) : KIND_TITLE[kind],
     note: kind === 'lead_created' || kind === 'assigned' || kind === 'reassigned' ? null : a.description || null,
     outcome: typeof m.outcome === 'string' ? m.outcome : null,
     nextStep: typeof m.next_step === 'string' ? m.next_step : null,


### PR DESCRIPTION
## What
The mktr.sg Activity History rendered an agent's **viewed** engagement as **"Updated"** because the web's canonical timeline port (`src/utils/leadTimeline.js`) was missing `viewed` from its `LEAD_ACTIVITY_KIND` map — so it fell through to the generic `updated` kind.

This adds the mapping (→ "Viewed" + the existing `Eye` icon) and composes the actor name into the title, so the admin timeline reads **"Viewed by Lee Yi Heng"**.

## How the actor reaches the web
The `mktr-lead-activities-export` edge function (mktr-leads, already deployed) now resolves `agents.full_name` into `metadata.actor_name` — the one field the backend merge (`mergeProspectTimeline`) preserves on app rows. The web reads it via `metadata.actor_name`.

## Cross-repo pairing (mktr-leads, already shipped)
- App: a `viewed` row shows **"Viewed by you"** to the owning agent, **"Viewed by {agent}"** in the admin read-only view (OTA'd to both prod runtimes).
- Export EF: adds `metadata.actor_name` (deployed).

## Test
`src/utils/__tests__/leadTimeline.test.js` covers `viewed` → kind `viewed`, title `Viewed by {actor_name}`, and the plain `Viewed` fallback when no actor resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)