### PR TITLE
fix(timeline): render the EF-supplied canonical entry; stop re-deriving the kind

### DIFF
--- a/backend/src/services/webLeadTimelineService.js
+++ b/backend/src/services/webLeadTimelineService.js
@@ -70,6 +70,9 @@ export function mergeProspectTimeline(prospectActivities, leadActivities, { ok =
     description: a.description ?? null,
     metadata: a.metadata ?? null,
     created_at: a.created_at,
+    // Canonical entry precomputed by the export EF (mktr-leads owns the kind contract). Carried
+    // through so the web renders it directly instead of re-deriving the kind from a local copy.
+    entry: a.entry ?? null,
   }));
 
   const mktrRows = ok ? mktr.filter((r) => r.metadata?.source !== 'mktr-leads') : mktr;
@@ -77,6 +80,7 @@ export function mergeProspectTimeline(prospectActivities, leadActivities, { ok =
 
   return [
     ...mktrRows.map((row) => ({ origin: 'mktr', row })),
-    ...appRows.map((row) => ({ origin: 'app', row })),
+    // Split `entry` out as a sibling so `row` stays the raw row (the dedup above keyed on its metadata).
+    ...appRows.map(({ entry, ...row }) => ({ origin: 'app', row, entry })),
   ].sort((a, b) => tsOf(b) - tsOf(a) || String(b.row.id).localeCompare(String(a.row.id)));
 }

--- a/backend/test/unit/webLeadTimelineService.test.js
+++ b/backend/test/unit/webLeadTimelineService.test.js
@@ -41,4 +41,13 @@ describe('mergeProspectTimeline', () => {
     expect(mergeProspectTimeline(null, null, {})).toEqual([]);
     expect(mergeProspectTimeline([], [], { ok: true })).toEqual([]);
   });
+
+  it('carries the EF-precomputed entry as a sibling, keeping row raw', () => {
+    const entry = { id: 'a1', kind: 'viewed', title: 'Viewed by Lee Yi Heng', at: '2026-06-28T09:00:00Z' };
+    const a = [{ id: 'a1', type: 'viewed', metadata: {}, created_at: '2026-06-28T09:00:00Z', entry }];
+    const [item] = mergeProspectTimeline([], a, { ok: true });
+    expect(item).toMatchObject({ origin: 'app', entry });
+    expect(item.row).not.toHaveProperty('entry'); // row stays the raw row
+    expect(item.row).toMatchObject({ id: 'a1', type: 'viewed' });
+  });
 });

--- a/src/utils/__tests__/leadTimeline.test.js
+++ b/src/utils/__tests__/leadTimeline.test.js
@@ -46,6 +46,19 @@ describe('leadTimeline — web normalizers (canonical model, parity with the app
     ]);
   });
 
+  it('prefers the EF-supplied canonical entry for app rows (no local re-derivation)', () => {
+    const entry = { id: 'a1', kind: 'viewed', title: 'Viewed by Lee Yi Heng', note: null, outcome: null, nextStep: null, at: 't1' };
+    const details = { timeline: [{ origin: 'app', row: { id: 'a1', type: 'viewed', metadata: {}, created_at: 't1' }, entry }] };
+    expect(buildTimeline(details)).toEqual([entry]);
+  });
+
+  it('falls back to local normalize when an app row lacks entry (older backend)', () => {
+    const details = {
+      timeline: [{ origin: 'app', row: { id: 'a2', type: 'viewed', metadata: { actor_name: 'Lee Yi Heng' }, created_at: 't' } }],
+    };
+    expect(buildTimeline(details)[0]).toMatchObject({ kind: 'viewed', title: 'Viewed by Lee Yi Heng' });
+  });
+
   it('buildTimeline falls back to ProspectActivity-only when no merged timeline is present', () => {
     const details = { activities: [{ id: 'm1', type: 'created', description: 'Signed up', createdAt: 't' }] };
     expect(buildTimeline(details).map((e) => e.kind)).toEqual(['lead_created']);

--- a/src/utils/leadTimeline.js
+++ b/src/utils/leadTimeline.js
@@ -112,7 +112,13 @@ export function normalizeProspectActivity(a) {
 export function buildTimeline(details) {
   if (Array.isArray(details?.timeline)) {
     return details.timeline
-      .map((x) => (x?.origin === 'app' ? normalizeLeadActivity(x.row) : normalizeProspectActivity(x?.row)))
+      .map((x) =>
+        x?.origin === 'app'
+          ? // Prefer the EF-computed canonical entry (single source of truth, parity-tested against
+            // the app). Fall back to the local normalizer only for older backends that omit `entry`.
+            (x.entry ?? normalizeLeadActivity(x.row))
+          : normalizeProspectActivity(x?.row),
+      )
       .filter(Boolean);
   }
   return (details?.activities || []).map(normalizeProspectActivity).filter(Boolean);


### PR DESCRIPTION
## Why
The mktr.sg web kept its **own hand-copied** `lead_activities` type→kind map (`src/utils/leadTimeline.js`). When mktr-leads added a new `viewed` type, the web silently fell through to "Updated" — classic cross-repo drift. (Reviewed with gpt-5.5/xhigh; this is the agreed structural fix.)

## What
Move normalization to the **data owner**. The `mktr-lead-activities-export` EF (mktr-leads, already deployed) now ships a precomputed canonical **`entry`** for each app row, derived from a pure normalizer that's **parity-tested against the app's `lib/leadMeta.ts`** (so the kind contract can't drift within that repo). This PR makes the web consume it:

- **`webLeadTimelineService.js`** — `mergeProspectTimeline` carries the entry through as `{ origin, row, entry }`. `row` stays the raw row so the cross-mirror dedup (which keys on `metadata.source`) is unchanged.
- **`leadTimeline.js`** — `buildTimeline` prefers `x.entry` for app rows, falling back to the local `normalizeLeadActivity` only for older backends that don't send `entry` yet.

Net: the web no longer re-derives app-activity kinds, so it **can't** mislabel them again. The local normalizer remains as a safe fallback.

## Backward-compat / deploy safety
The EF emits `entry` **alongside** the raw row (+ `metadata.actor_name`), so the previously deployed web kept working before this PR. Either deploy order is safe.

## Tests
- web (vitest): `buildTimeline` prefers `entry`; falls back when absent. (6 pass)
- backend (jest): `mergeProspectTimeline` carries `entry` as a sibling, `row` stays raw, dedup intact. (5 pass)

Pairs with mktr-leads commit `798f397` (shared normalizer + EF `entry` + parity test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)