### PR TITLE
feat(prospects): emit lead.deleted so a deleted prospect clears the mktr-leads mirror

### DIFF
--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -261,7 +261,7 @@ async function ensureMktrLeadsWebhookSubscriber() {
   // lead.held → the admin held-queue ping (only the mktr-leads app has that surface;
   // the Lyfe subscriber intentionally does NOT subscribe to it). The events-diff in
   // the update guard below self-heals this onto the existing subscriber on deploy.
-  const requiredEvents = ['lead.created', 'lead.assigned', 'lead.unassigned', 'lead.held'];
+  const requiredEvents = ['lead.created', 'lead.assigned', 'lead.unassigned', 'lead.held', 'lead.deleted'];
 
   const existing = await WebhookSubscriber.findOne({ where: { name: SUBSCRIBER_NAME } });
 

--- a/backend/src/services/prospectHelpers.js
+++ b/backend/src/services/prospectHelpers.js
@@ -223,6 +223,24 @@ export function buildLeadHeldPayload(prospect, campaign, reason) {
   };
 }
 
+/**
+ * Build the payload for a 'lead.deleted' event — fired when an admin deletes a
+ * prospect on MKTR so the mktr-leads mirror can soft-delete its copy. Minimal
+ * (like lead.held): the receiver looks the lead up by externalId, so no other PII
+ * crosses the wire. Delivered ONLY to the destination='mktr_leads' subscriber.
+ */
+export function buildLeadDeletedPayload(prospect) {
+  return {
+    event: 'lead.deleted',
+    timestamp: new Date().toISOString(),
+    data: {
+      lead: {
+        externalId: prospect.id
+      }
+    }
+  };
+}
+
 /** Format a budget object ({ min, max, currency, timeframe }) into one display string, or null. */
 function formatBudget(budget) {
   if (!budget || typeof budget !== 'object') return null;

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -1,4 +1,4 @@
-import { Op } from 'sequelize';
+import { Op, Transaction } from 'sequelize';
 import {
   Prospect,
   User,
@@ -39,6 +39,7 @@ import {
   normalizePhone,
   buildLeadCreatedPayload,
   buildLeadHeldPayload,
+  buildLeadDeletedPayload,
   buildLeadAssignedPayload,
   buildLeadUnassignedPayload,
   buildHeldLeadEnrichment,
@@ -1106,15 +1107,59 @@ export function makeProspectService(overrides = {}) {
    */
   async function deleteProspect(id, user) {
     const scopeFilter = await d.buildProspectWhere(user);
-    const whereConditions = { id, ...scopeFilter };
 
-    const prospect = await m.Prospect.findOne({ where: whereConditions });
+    // Fire lead.deleted to the mktr-leads mirror so the deletion propagates (the
+    // receiver soft-deletes its copy; otherwise the lead is orphaned on the
+    // agent's page). Transactional outbox: persist the delivery row INSIDE the
+    // same (managed) txn as the destroy so they commit together — no crash window
+    // that re-creates the orphan. The prospect is row-locked for the txn so a
+    // concurrent reassignment can't shift the destination under us. The managed
+    // txn auto-commits on resolve / auto-rolls-back (and rethrows) on a throw, so
+    // a hard error => delete fails + admin retries, with NO orphan/partial state.
+    let deliveryPairs = [];
+    await d.sequelize.transaction(async (t) => {
+      const prospect = await m.Prospect.findOne({
+        where: { id, ...scopeFilter },
+        transaction: t,
+        lock: Transaction.LOCK.UPDATE,
+      });
+      if (!prospect) {
+        throw new d.AppError('Prospect not found or access denied', 404);
+      }
 
-    if (!prospect) {
-      throw new d.AppError('Prospect not found or access denied', 404);
-    }
+      // Only the mktr-leads receiver handles lead.deleted. Held / unassigned /
+      // System-Agent (no assignee) or a non-mktr_leads destination => no mirrored
+      // row to clean => skip the emit.
+      let destination = null;
+      if (prospect.assignedAgentId) {
+        const agent = await m.User.findByPk(prospect.assignedAgentId, {
+          attributes: ['id', 'lyfeId', 'mktrLeadsId'],
+          transaction: t,
+        });
+        destination = destinationForAgent(agent);
+      }
 
-    await prospect.destroy();
+      if (destination === 'mktr_leads') {
+        deliveryPairs = await d.persistEventDeliveries(
+          'lead.deleted',
+          () => buildLeadDeletedPayload(prospect),
+          { destination },
+          t
+        );
+        // BEST-EFFORT (unlike releaseHeldProspect's fail-closed rollback): an empty
+        // set means webhooks are disabled or no subscriber is tagged. Deleting is an
+        // admin cleanup action that must NOT be blocked on mirror delivery — proceed.
+        if (deliveryPairs.length === 0) {
+          d.logger.warn('[Webhook] lead.deleted not queued (webhooks off / no subscriber) — deleting anyway', {
+            prospectId: prospect.id,
+          });
+        }
+      }
+
+      await prospect.destroy({ transaction: t });
+    });
+
+    d.flushDeliveries(deliveryPairs); // post-commit, fire-and-forget
   }
 
   /**


### PR DESCRIPTION
## What

`deleteProspect` destroyed the prospect but fired no webhook, so the mirrored lead in the **mktr-leads** app was orphaned on the agent's page forever (e.g. a deleted test lead stuck on the consultant's list).

Emit a minimal `lead.deleted` to the `mktr_leads` destination via a transactional outbox: the delivery row + the destroy commit together inside one row-locked managed txn (no crash window that re-creates the orphan), then flush post-commit. **Best-effort, not fail-closed** — an empty delivery set (webhooks off / no subscriber) still deletes; an admin cleanup must not be blocked on mirror delivery.

Add `lead.deleted` to the mktr-leads subscriber's bootstrap `requiredEvents` so it self-heals onto the live subscriber on deploy (a DB-only update is overwritten by bootstrap's events-diff).

## Receiver side (separate repo)

The mktr-leads receiver — a `(source_name, external_id)` tombstone table + a `BEFORE INSERT/UPDATE` trigger that makes the deletion terminal (no out-of-order/retried create/assign can resurrect it) + the `lead.deleted` handler — is already deployed (migration applied, EFs deployed).

## Review / tests

- codex gpt-5.5/xhigh reviewed 3 passes (REWORK → REWORK → SHIP-WITH-FIXES, all findings addressed).
- `prospectService` unit suite green (43/43), incl. the existing `deleteProspect` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)