### PR TITLE
feat(external): bulk batch context → coalesced delivery pushes

### DIFF
--- a/backend/src/controllers/externalAdminLeadOpsController.js
+++ b/backend/src/controllers/externalAdminLeadOpsController.js
@@ -17,6 +17,7 @@
 import crypto from 'crypto';
 import { logger } from '../utils/logger.js';
 import { reassignProspectExternal, returnProspectToHeld } from '../services/prospectService.js';
+import { parseBatchContext } from '../services/prospectHelpers.js';
 
 const MAX_AGE_MS = 5 * 60 * 1000;
 const MAX_FUTURE_MS = 2 * 60 * 1000; // tolerate clock skew
@@ -77,10 +78,17 @@ export async function reassignLead(req, res) {
   if (!idempotencyKey || typeof idempotencyKey !== 'string') {
     return res.status(400).json({ success: false, error: 'idempotencyKey is required' });
   }
+  // Optional bulk batch context — echoed into the delivery webhook so the receiver
+  // coalesces N per-lead pushes into one summary. Malformed → null (per-lead pushes).
+  const batch = parseBatchContext(req.body?.batch);
 
   try {
     // agentMktrUserId is the app's agents.mktr_user_id (== MKTR users.mktrLeadsId).
-    const result = await reassignProspectExternal(prospectId, agentMktrUserId, { idempotencyKey, actorUserId: null });
+    const result = await reassignProspectExternal(prospectId, agentMktrUserId, {
+      idempotencyKey,
+      actorUserId: null,
+      batch,
+    });
     const codeByStatus = { reassigned: 200, invalid_agent: 400, not_found: 404, not_assignable: 409 };
     const code = codeByStatus[result.status] || 500;
     return res.status(code).json({ success: code < 400, ...result });

--- a/backend/src/controllers/externalHeldLeadsController.js
+++ b/backend/src/controllers/externalHeldLeadsController.js
@@ -17,6 +17,7 @@
 import crypto from 'crypto';
 import { logger } from '../utils/logger.js';
 import { listDispatchableOrphans, releaseHeldProspect } from '../services/prospectService.js';
+import { parseBatchContext } from '../services/prospectHelpers.js';
 
 const MAX_AGE_MS = 5 * 60 * 1000;
 const MAX_FUTURE_MS = 2 * 60 * 1000; // tolerate clock skew
@@ -136,11 +137,16 @@ export async function assignHeldLead(req, res) {
     return res.status(400).json({ success: false, error: 'idempotencyKey is required' });
   }
 
+  // Optional bulk batch context — echoed into the delivery webhook so the receiver
+  // coalesces N per-lead pushes into one summary. Malformed → null (per-lead pushes).
+  const batch = parseBatchContext(req.body?.batch);
+
   try {
     // agentMktrUserId is the app's agents.mktr_user_id (== MKTR users.mktrLeadsId).
     const result = await releaseHeldProspect(prospectId, agentMktrUserId, {
       idempotencyKey,
       actorUserId: null,
+      batch,
     });
     const codeByStatus = {
       assigned: 200,

--- a/backend/src/services/prospectHelpers.js
+++ b/backend/src/services/prospectHelpers.js
@@ -301,3 +301,25 @@ export function buildHeldLeadEnrichment(prospect) {
 
   return { birthday, details };
 }
+
+/**
+ * Validate a bulk batch context ({ id, size }) from an external request body.
+ * The mktr-leads admin app fans a bulk op out as N single-lead calls, each
+ * carrying the SAME batch — MKTR echoes it into every per-lead webhook so the
+ * receiver can coalesce the N pushes into one summary ("14 leads assigned to
+ * you"). Malformed shapes return null (per-lead pushes, the pre-bulk behavior)
+ * rather than erroring: the batch is a delivery-UX hint, never a correctness input.
+ */
+export function parseBatchContext(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const { id, size } = raw;
+  if (typeof id !== 'string' || id.length < 8 || id.length > 64) return null;
+  if (!Number.isInteger(size) || size < 1 || size > 500) return null;
+  return { id, size };
+}
+
+/** Echo a validated batch context into a webhook payload's data block (no-op when null). */
+export function withBatchContext(payload, batch) {
+  if (!batch) return payload;
+  return { ...payload, data: { ...payload.data, batch } };
+}

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -2057,10 +2057,15 @@ export function makeProspectService(overrides = {}) {
         await assignProspect(prospectId, agent.id, { id: actorUserId }, { batch });
       }
     } catch (err) {
-      // assignProspect isn't transactional; record the failure so a retry replays it (no re-charge),
-      // then surface to the controller.
-      await record({ status: 'error', error: 'reassign_failed' });
-      throw err;
+      // assignProspect isn't transactional; record the failure so a retry replays it (no
+      // re-charge) and RETURN it as a typed result — a throw surfaces as a generic 500 and
+      // the caller's app would misbucket the FIRST response as a retryable transport
+      // failure instead of the sticky needs-attention state the recorded replay enforces.
+      d.logger.error('[external-reassign] assignProspect failed', {
+        prospectId,
+        error: err?.message || String(err),
+      });
+      return record({ status: 'error', error: 'reassign_failed' });
     }
     return record({ status: 'reassigned', leadId: prospectId, agent: agentBrief });
   }

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -45,6 +45,7 @@ import {
   buildHeldLeadEnrichment,
   destinationForAgent,
   externalIdForDestination,
+  withBatchContext,
 } from './prospectHelpers.js';
 import { fetchLeadActivitiesFromSupabase, mergeProspectTimeline } from './webLeadTimelineService.js';
 import { scoreQuiz } from './quizScoringService.js';
@@ -1164,8 +1165,11 @@ export function makeProspectService(overrides = {}) {
 
   /**
    * Assign a single prospect to an agent. Returns { prospect, agent } for email side-effect.
+   * `opts.batch` ({ id, size }, pre-validated) rides into the delivery webhooks so the
+   * receiving app can coalesce a bulk fan-out's pushes into one summary.
    */
-  async function assignProspect(prospectId, agentId, user) {
+  async function assignProspect(prospectId, agentId, user, opts = {}) {
+    const { batch = null } = opts;
     const prospect = await m.Prospect.findByPk(prospectId);
     if (!prospect) {
       throw new d.AppError('Prospect not found', 404);
@@ -1287,7 +1291,10 @@ export function makeProspectService(overrides = {}) {
         id: externalIdForDestination(agent, releaseDestination),
       };
       d.dispatchEvent('lead.created', () =>
-        buildLeadCreatedPayload(prospect, 'direct', agentForWebhook, agentId, prospectWithCampaign?.campaign || null, null, null),
+        withBatchContext(
+          buildLeadCreatedPayload(prospect, 'direct', agentForWebhook, agentId, prospectWithCampaign?.campaign || null, null, null),
+          batch
+        ),
         { destination: releaseDestination }
       );
 
@@ -1318,9 +1325,11 @@ export function makeProspectService(overrides = {}) {
 
     // Fire lead.assigned webhook to the NEW owner's app.
     const newDestination = destinationForAgent(agent);
-    d.dispatchEvent('lead.assigned', () => buildLeadAssignedPayload(prospect, agent, prospectWithCampaign), {
-      destination: newDestination,
-    });
+    d.dispatchEvent(
+      'lead.assigned',
+      () => withBatchContext(buildLeadAssignedPayload(prospect, agent, prospectWithCampaign), batch),
+      { destination: newDestination }
+    );
 
     // Cross-app reassignment: if the PREVIOUS owner lived in a different app, that app
     // still holds a copy of this lead that would otherwise linger. Tell it to release the
@@ -1846,7 +1855,7 @@ export function makeProspectService(overrides = {}) {
    * @returns {Promise<{status:'assigned'|'already_handled'|'invalid_agent'|'not_found'|'not_assignable_external', leadId?:string, agent?:object}>}
    */
   async function releaseHeldProspect(prospectId, agentMktrLeadsId, opts = {}) {
-    const { idempotencyKey = null, actorUserId = null } = opts;
+    const { idempotencyKey = null, actorUserId = null, batch = null } = opts;
     const IDEMP_SCOPE = 'external:held-assign';
 
     // Replay: a retried request with the same key returns the first result verbatim.
@@ -1929,7 +1938,7 @@ export function makeProspectService(overrides = {}) {
         // buildLeadCreatedPayload, so delivery is otherwise unchanged.
         deliveryPairs = await d.persistEventDeliveries(
           'lead.assigned',
-          () => buildLeadAssignedPayload(withCampaign, agent, withCampaign),
+          () => withBatchContext(buildLeadAssignedPayload(withCampaign, agent, withCampaign), batch),
           { destination },
           t
         );
@@ -1990,7 +1999,7 @@ export function makeProspectService(overrides = {}) {
    * @returns {Promise<{status:'reassigned'|'invalid_agent'|'not_found'|'not_assignable', leadId?:string, agent?:object}>}
    */
   async function reassignProspectExternal(prospectId, agentMktrLeadsId, opts = {}) {
-    const { idempotencyKey = null, actorUserId = null } = opts;
+    const { idempotencyKey = null, actorUserId = null, batch = null } = opts;
     const IDEMP_SCOPE = 'external:admin-reassign';
 
     // Claim the idempotency key FIRST (unique PK) so concurrent / retried same-key requests can
@@ -2045,7 +2054,7 @@ export function makeProspectService(overrides = {}) {
     try {
       // Already with the target → no-op so a retry / re-pick never double-charges the agent.
       if (prospect.assignedAgentId !== agent.id) {
-        await assignProspect(prospectId, agent.id, { id: actorUserId });
+        await assignProspect(prospectId, agent.id, { id: actorUserId }, { batch });
       }
     } catch (err) {
       // assignProspect isn't transactional; record the failure so a retry replays it (no re-charge),

--- a/backend/test/unit/batchContext.test.js
+++ b/backend/test/unit/batchContext.test.js
@@ -1,0 +1,48 @@
+/**
+ * parseBatchContext / withBatchContext — the bulk-op batch plumbing
+ * (prospectHelpers). The batch context is a delivery-UX hint the mktr-leads
+ * admin app threads through per-lead calls so the receiver can coalesce N
+ * pushes into one summary; these pin the validation envelope and the payload
+ * echo (data.batch) without disturbing the rest of the payload.
+ */
+import '../setup.js';
+import { parseBatchContext, withBatchContext } from '../../src/services/prospectHelpers.js';
+
+describe('parseBatchContext', () => {
+  const valid = { id: 'b'.repeat(12), size: 30 };
+
+  it('accepts a well-formed { id, size }', () => {
+    expect(parseBatchContext(valid)).toEqual(valid);
+  });
+
+  it('rejects malformed shapes with null (never throws)', () => {
+    expect(parseBatchContext(undefined)).toBeNull();
+    expect(parseBatchContext(null)).toBeNull();
+    expect(parseBatchContext('batch')).toBeNull();
+    expect(parseBatchContext({})).toBeNull();
+    expect(parseBatchContext({ id: 'short', size: 3 })).toBeNull(); // id < 8 chars
+    expect(parseBatchContext({ id: 'x'.repeat(65), size: 3 })).toBeNull(); // id > 64 chars
+    expect(parseBatchContext({ id: valid.id, size: 0 })).toBeNull();
+    expect(parseBatchContext({ id: valid.id, size: 501 })).toBeNull();
+    expect(parseBatchContext({ id: valid.id, size: 2.5 })).toBeNull();
+    expect(parseBatchContext({ id: valid.id, size: '3' })).toBeNull();
+  });
+});
+
+describe('withBatchContext', () => {
+  const payload = { event: 'lead.assigned', timestamp: 't', data: { lead: { externalId: 'p1' } } };
+
+  it('echoes the batch into data.batch without touching anything else', () => {
+    const batch = { id: 'b'.repeat(12), size: 4 };
+    const out = withBatchContext(payload, batch);
+    expect(out.data.batch).toEqual(batch);
+    expect(out.data.lead).toEqual(payload.data.lead);
+    expect(out.event).toBe('lead.assigned');
+    // Original payload is not mutated.
+    expect(payload.data.batch).toBeUndefined();
+  });
+
+  it('is a no-op passthrough when batch is null', () => {
+    expect(withBatchContext(payload, null)).toBe(payload);
+  });
+});


### PR DESCRIPTION
## What

The mktr-leads admin app now supports bulk reassign / bulk held-assign, fanned out as N single-lead calls to the existing `/api/external/admin-lead-ops/reassign` + `/api/external/held-leads/assign` endpoints. Each call carries an optional `batch: { id, size }`.

This PR:
- validates it (`parseBatchContext`, 8–64-char id, size 1–500; malformed → null, never an error) and
- echoes it into the per-lead `lead.assigned` / `lead.created` webhook payloads (`withBatchContext`) via `assignProspect` / `reassignProspectExternal` / `releaseHeldProspect` opts,

so the mktr-leads receiver can coalesce a 30-lead batch's 30 pushes into one "30 leads assigned to you" summary (receiver half already live: migration `20260703000000` + `receive-mktr-lead`/`mktr-held-leads` EF deploys).

Also: `reassignProspectExternal` now RETURNS the recorded `{ status: 'error', error: 'reassign_failed' }` instead of throwing — a throw surfaced as a generic 500 and the app misbucketed the first response as retryable-transport instead of the sticky needs-attention state the recorded idempotency replay enforces (codex review F6).

## Compatibility

- No batch on the wire → byte-identical existing behavior (all params optional).
- Old receiver + new sender: unknown `data.batch` field is ignored.
- Unit test: `test/unit/batchContext.test.js`. Full unit suite green except the pre-existing `shortlinkService` failures (identical on clean main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)