### PR TITLE
feat(prospects): web-admin bulk lead ops — bulk assign releases holds, return-to-held, bulk delete

### DIFF
--- a/backend/src/controllers/prospectController.js
+++ b/backend/src/controllers/prospectController.js
@@ -113,7 +113,11 @@ export const deleteProspect = asyncHandler(async (req, res) => {
 
 export const bulkAssignProspects = asyncHandler(async (req, res) => {
   const { prospectIds, agentId } = req.body;
-  const { affectedCount, agent } = await prospectService.bulkAssignProspects(prospectIds, agentId, req.user);
+  const { affectedCount, releasedCount, skipped, agent } = await prospectService.bulkAssignProspects(
+    prospectIds,
+    agentId,
+    req.user
+  );
 
   // Notify agent about bulk assignment (fire-and-forget)
   if (affectedCount > 0) {
@@ -125,7 +129,29 @@ export const bulkAssignProspects = asyncHandler(async (req, res) => {
   res.json({
     success: true,
     message: `${affectedCount} prospects assigned successfully`,
-    data: { affectedCount }
+    data: { affectedCount, releasedCount, skipped }
+  });
+});
+
+export const bulkReturnProspects = asyncHandler(async (req, res) => {
+  const { prospectIds } = req.body;
+  const counts = await prospectService.bulkReturnProspectsToHeld(prospectIds, req.user);
+
+  res.json({
+    success: true,
+    message: `${counts.returned + counts.promoted} prospects returned to the held queue`,
+    data: counts
+  });
+});
+
+export const bulkDeleteProspects = asyncHandler(async (req, res) => {
+  const { prospectIds } = req.body;
+  const counts = await prospectService.bulkDeleteProspects(prospectIds, req.user);
+
+  res.json({
+    success: true,
+    message: `${counts.deleted} prospects deleted`,
+    data: counts
   });
 });
 

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -156,6 +156,17 @@ export const schemas = {
     status: Joi.string().valid('active', 'inactive').optional()
   }),
 
+  // Bulk lead ops (admin). Max 200 ids matches the list endpoint's page-size clamp —
+  // a bulk op can never outgrow what one page of selection could have produced.
+  prospectBulkAssign: Joi.object({
+    prospectIds: Joi.array().items(Joi.string().uuid()).min(1).max(200).required(),
+    agentId: Joi.string().uuid().required()
+  }),
+
+  prospectBulkIds: Joi.object({
+    prospectIds: Joi.array().items(Joi.string().uuid()).min(1).max(200).required()
+  }),
+
   // Prospect schemas
   prospectCreate: Joi.object({
     firstName: Joi.string().min(1).max(50).required(),

--- a/backend/src/routes/prospects.js
+++ b/backend/src/routes/prospects.js
@@ -40,8 +40,10 @@ router.put('/:id', authenticateToken, requireAgentOrAdmin, prospectController.up
 // Delete prospect
 router.delete('/:id', authenticateToken, requireAgentOrAdmin, prospectController.deleteProspect);
 
-// Bulk assign prospects (must be registered before /:id/assign to avoid param capture)
-router.patch('/bulk/assign', authenticateToken, requireAgentOrAdmin, prospectController.bulkAssignProspects);
+// Bulk lead ops (must be registered before /:id routes to avoid param capture)
+router.patch('/bulk/assign', authenticateToken, requireAgentOrAdmin, validate(schemas.prospectBulkAssign), prospectController.bulkAssignProspects);
+router.patch('/bulk/return-to-held', authenticateToken, requireAgentOrAdmin, validate(schemas.prospectBulkIds), prospectController.bulkReturnProspects);
+router.post('/bulk/delete', authenticateToken, requireAgentOrAdmin, validate(schemas.prospectBulkIds), prospectController.bulkDeleteProspects);
 
 // Assign prospect to agent
 router.patch('/:id/assign', authenticateToken, requireAgentOrAdmin, prospectController.assignProspect);

--- a/backend/src/services/prospectHelpers.js
+++ b/backend/src/services/prospectHelpers.js
@@ -127,8 +127,14 @@ export function buildLeadCreatedPayload(prospect, routingMode, agentForWebhook, 
 
 /**
  * Build the webhook payload for a 'lead.assigned' event.
+ *
+ * `opts.qrTag` / `opts.routingMode` mirror the created payload's `qrTag` block and
+ * `routing.mode`: manual dispatch always fires lead.assigned (never lead.created — a
+ * duplicate create is a silent no-op at both receivers), so when the destination app
+ * has never seen the lead it INSERTS from this payload and needs the same QR/source
+ * context a create would have carried.
  */
-export function buildLeadAssignedPayload(prospect, agent, prospectWithCampaign) {
+export function buildLeadAssignedPayload(prospect, agent, prospectWithCampaign, opts = {}) {
   const meta = prospect.sourceMetadata || {};
   return {
     event: 'lead.assigned',
@@ -161,6 +167,7 @@ export function buildLeadAssignedPayload(prospect, agent, prospectWithCampaign) 
         createdAt: prospect.createdAt
       },
       routing: {
+        mode: opts.routingMode || null,
         agentExternalId: externalIdForDestination(agent, destinationForAgent(agent)),
         agentName: [agent.firstName, agent.lastName].filter(Boolean).join(' '),
         agentEmail: agent.email,
@@ -168,7 +175,11 @@ export function buildLeadAssignedPayload(prospect, agent, prospectWithCampaign) 
       },
       campaign: prospectWithCampaign?.campaign
         ? { externalId: prospectWithCampaign.campaign.id, name: prospectWithCampaign.campaign.name }
-        : null
+        : null,
+      qrTag: {
+        externalId: opts.qrTag?.id || null,
+        slug: opts.qrTag?.slug || null
+      }
     }
   };
 }

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { Op, Transaction } from 'sequelize';
 import {
   Prospect,
@@ -22,7 +23,7 @@ import { buildDncConsentEvidence } from './dncConsent.js';
 import { repeatSignupDetail, repeatSignupCounts } from './repeatSignup.js';
 import { buildProspectWhere } from '../middleware/prospectScope.js';
 import { AppError } from '../middleware/errorHandler.js';
-import { dispatchEvent, persistEventDeliveries, flushDeliveries } from './webhookService.js';
+import { dispatchEvent, persistEventDeliveries, flushDeliveries, hasDeliverableSubscriber } from './webhookService.js';
 import {
   sendLeadEvent as metaSendLeadEvent,
   sendCompleteRegistrationEvent as metaSendCompleteRegistrationEvent,
@@ -56,6 +57,18 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 // otherwise reach Postgres and throw ("invalid input value for enum"), so the
 // list endpoint validates against it and returns no matches for unknown values.
 const VALID_LEAD_STATUSES = ['new', 'contacted', 'qualified', 'proposal_sent', 'negotiating', 'won', 'lost', 'nurturing'];
+
+// Assignment-state filter values for the admin list (D6). Unknown values degrade to
+// an empty page (same pattern as VALID_LEAD_STATUSES).
+const VALID_ASSIGNMENT_FILTERS = ['assigned', 'unassigned', 'held'];
+
+// Hold reasons a MANUAL admin (re)assign may release. Everything else is fenced:
+// 'no_funded_external_buyer' (external buyer pool), 'dnc_pending'/'dnc_registered'
+// (DNC gate). 'returned_by_admin' is the web-admin return flavor — deliberately
+// distinct from 'no_funded_agent' so returned leads never surface in the EXTERNAL
+// held queue (listDispatchableOrphans) or its release path (releaseHeldProspect),
+// both of which filter on 'no_funded_agent'.
+const RELEASABLE_HOLD_REASONS = ['no_funded_agent', 'returned_by_admin'];
 
 const PROSPECT_UPDATE_FIELDS = [
   'firstName',
@@ -101,6 +114,7 @@ const defaultDeps = {
   dispatchEvent,
   persistEventDeliveries,
   flushDeliveries,
+  hasDeliverableSubscriber,
   sendLeadEvent: metaSendLeadEvent,
   sendCompleteRegistrationEvent: metaSendCompleteRegistrationEvent,
   sendTikTokLeadEvent,
@@ -1244,10 +1258,12 @@ export function makeProspectService(overrides = {}) {
     }
 
     // A manual admin assign is an EXEMPT route (decision a): it always delivers and does
-    // a best-effort deduct. If the prospect is currently HELD under lead-quota, this is a
-    // RELEASE — clear the hold ATOMICALLY (so a double-click / concurrent sweep can't
-    // deliver twice) and fire lead.created, the FIRST delivery to Lyfe (which never saw
-    // the suppressed create webhook), NOT lead.assigned.
+    // a best-effort deduct. If the prospect is currently HELD, this is a RELEASE — clear
+    // the hold ATOMICALLY (so a double-click / concurrent sweep can't deliver twice) and
+    // fire lead.assigned. Always lead.assigned, never lead.created: both receivers UPSERT
+    // on assigned (insert if unknown, re-point + un-hide if known), whereas a duplicate
+    // lead.created is a silent no-op — so a returned-to-held lead released via
+    // lead.created would never re-surface in the agent's app.
     if (prospect.quarantinedAt) {
       const [releaseRows] = await d.sequelize.query(
         `UPDATE prospects
@@ -1280,19 +1296,19 @@ export function makeProspectService(overrides = {}) {
         .catch((err) => d.logger.error('Failed to deduct credit', { error: err?.message || String(err) }));
 
       const prospectWithCampaign = await m.Prospect.findByPk(prospect.id, {
-        include: [{ association: 'campaign', attributes: ['id', 'name'] }],
+        include: [
+          { association: 'campaign', attributes: ['id', 'name'] },
+          { association: 'qrTag', attributes: ['id', 'slug'] },
+        ],
       });
 
       const releaseDestination = destinationForAgent(agent);
-      const agentForWebhook = {
-        phone: agent.phone || null,
-        email: agent.email || null,
-        name: `${agent.firstName || ''} ${agent.lastName || ''}`.trim(),
-        id: externalIdForDestination(agent, releaseDestination),
-      };
-      d.dispatchEvent('lead.created', () =>
+      d.dispatchEvent('lead.assigned', () =>
         withBatchContext(
-          buildLeadCreatedPayload(prospect, 'direct', agentForWebhook, agentId, prospectWithCampaign?.campaign || null, null, null),
+          buildLeadAssignedPayload(prospect, agent, prospectWithCampaign, {
+            qrTag: prospectWithCampaign?.qrTag || null,
+            routingMode: 'direct',
+          }),
           batch
         ),
         { destination: releaseDestination }
@@ -1320,14 +1336,24 @@ export function makeProspectService(overrides = {}) {
       .catch((err) => d.logger.error('Failed to deduct credit', { error: err?.message || String(err) }));
 
     const prospectWithCampaign = await m.Prospect.findByPk(prospect.id, {
-      include: [{ association: 'campaign', attributes: ['id', 'name'] }],
+      include: [
+        { association: 'campaign', attributes: ['id', 'name'] },
+        { association: 'qrTag', attributes: ['id', 'slug'] },
+      ],
     });
 
     // Fire lead.assigned webhook to the NEW owner's app.
     const newDestination = destinationForAgent(agent);
     d.dispatchEvent(
       'lead.assigned',
-      () => withBatchContext(buildLeadAssignedPayload(prospect, agent, prospectWithCampaign), batch),
+      () =>
+        withBatchContext(
+          buildLeadAssignedPayload(prospect, agent, prospectWithCampaign, {
+            qrTag: prospectWithCampaign?.qrTag || null,
+            routingMode: 'direct',
+          }),
+          batch
+        ),
       { destination: newDestination }
     );
 
@@ -1353,12 +1379,14 @@ export function makeProspectService(overrides = {}) {
   }
 
   /**
-   * Bulk assign prospects to an agent. Returns { affectedCount, agent } for email side-effect.
+   * Bulk assign prospects to an agent. Returns { affectedCount, releasedCount, skipped, agent }
+   * — counts feed the controller's email side-effect and the UI's skip-accounting toast.
    */
   async function bulkAssignProspects(prospectIds, agentId, user) {
     if (!prospectIds || !Array.isArray(prospectIds) || !agentId) {
       throw new d.AppError('Prospect IDs array and agent ID are required', 400);
     }
+    const requestedIds = [...new Set(prospectIds)];
 
     const agent = await m.User.findOne({
       where: {
@@ -1372,18 +1400,35 @@ export function makeProspectService(overrides = {}) {
       throw new d.AppError('Invalid or inactive agent', 400);
     }
 
+    // Pre-flight (bulk-only): assignment mutates rows first and delivers after, so refuse
+    // to run when delivery is IMPOSSIBLE (webhooks disabled / no subscriber tagged for the
+    // agent's app) — otherwise the whole batch would be stranded: assigned in MKTR, never
+    // surfaced in the agent's app. Transient send failures are fine (the persistent
+    // delivery queue retries); this guards misconfiguration only. A destination-less
+    // (local-only) agent passes: no delivery is expected, matching single-assign.
+    const newDestination = destinationForAgent(agent);
+    if (!(await d.hasDeliverableSubscriber('lead.assigned', newDestination))) {
+      throw new d.AppError(
+        "Lead delivery is not configured for this agent's app (webhooks disabled or no subscriber) — bulk assign would strand the leads. Fix webhook configuration and retry.",
+        409
+      );
+    }
+
     const scopeFilter = await d.buildProspectWhere(user);
     const whereConditions = {
-      id: { [Op.in]: prospectIds },
-      // Bulk assign skips HELD leads — releasing a held lead must deliver it to Lyfe,
-      // which bulk update can't do per-lead. Release held leads via single assign
-      // (PATCH /:id/assign) or the auto-release sweep.
-      quarantinedAt: null,
-      // Skip rows already assigned to THIS agent (IS DISTINCT FROM semantics —
-      // a bare Op.ne would also exclude unassigned NULL rows). Re-assigning a
-      // no-op row used to double-charge the agent for a lead they already held.
-      [Op.or]: [{ assignedAgentId: null }, { assignedAgentId: { [Op.ne]: agentId } }],
+      id: { [Op.in]: requestedIds },
       ...scopeFilter,
+      [Op.and]: [
+        // HELD rows are eligible only for the releasable reasons — bulk assign then acts
+        // as a RELEASE (the quarantine is cleared in the same atomic UPDATE below, and
+        // lead.assigned upserts at the receiver). Fenced reasons (external buyer pool,
+        // DNC gate) stay excluded, mirroring single-assign's guards.
+        { [Op.or]: [{ quarantinedAt: null }, { quarantineReason: { [Op.in]: RELEASABLE_HOLD_REASONS } }] },
+        // Skip rows already assigned to THIS agent (IS DISTINCT FROM semantics —
+        // a bare Op.ne would also exclude unassigned NULL rows). Re-assigning a
+        // no-op row used to double-charge the agent for a lead they already held.
+        { [Op.or]: [{ assignedAgentId: null }, { assignedAgentId: { [Op.ne]: agentId } }] },
+      ],
     };
 
     // Lock the candidate rows and update them inside ONE transaction so the webhook side
@@ -1395,23 +1440,50 @@ export function makeProspectService(overrides = {}) {
     // of an outer join — and fetch campaign data for the payloads afterwards.
     let result = [0, []];
     const lockedById = new Map();
+    let requestedRows = [];
     await d.sequelize.transaction(async (transaction) => {
       const locked = await m.Prospect.findAll({
         where: whereConditions,
-        attributes: ['id', 'assignedAgentId', 'campaignId'],
+        attributes: ['id', 'assignedAgentId', 'campaignId', 'quarantinedAt'],
         transaction,
         lock: true,
       });
       for (const row of locked) lockedById.set(row.id, row);
       result = await m.Prospect.update(
-        { assignedAgentId: agentId, lastContactDate: new Date() },
+        // Release + assign is ONE atomic write: clearing the hold here means a concurrent
+        // release (external dispatch / double-submit) blocks on the row lock, re-reads
+        // quarantinedAt IS NULL, and matches nothing — never a second delivery.
+        { assignedAgentId: agentId, lastContactDate: new Date(), quarantinedAt: null, quarantineReason: null },
         // Update exactly the locked set; RETURNING reports the rows actually changed.
         { where: { id: { [Op.in]: [...lockedById.keys()] } }, returning: ['id', 'campaignId'], transaction }
       );
+      // Snapshot every requested (in-scope) row for skip classification, same txn so the
+      // classification matches what the locked UPDATE saw.
+      requestedRows = await m.Prospect.findAll({
+        where: { id: { [Op.in]: requestedIds }, ...scopeFilter },
+        attributes: ['id', 'assignedAgentId', 'quarantinedAt', 'quarantineReason'],
+        transaction,
+      });
     });
 
     const affectedCount = result[0];
     const affectedRows = result[1] || [];
+
+    // Skip accounting for the UI toast: classify every requested id that did NOT change.
+    // (Post-UPDATE snapshot: affected rows are classified off the pre-UPDATE lock set.)
+    const requestedById = new Map(requestedRows.map((r) => [r.id, r]));
+    const skipped = { notFound: 0, alreadyAssigned: 0, heldFenced: 0 };
+    let releasedCount = 0;
+    for (const id of requestedIds) {
+      if (lockedById.has(id)) {
+        if (lockedById.get(id).quarantinedAt) releasedCount += 1;
+        continue;
+      }
+      const row = requestedById.get(id);
+      if (!row) skipped.notFound += 1;
+      else if (row.quarantinedAt && !RELEASABLE_HOLD_REASONS.includes(row.quarantineReason)) skipped.heldFenced += 1;
+      else skipped.alreadyAssigned += 1;
+    }
     if (affectedCount > 0) {
       const countsByCampaign = new Map();
       for (const row of affectedRows) {
@@ -1429,11 +1501,17 @@ export function makeProspectService(overrides = {}) {
       // lead.assigned to the new owner, plus — for a CROSS-app reassignment — lead.unassigned
       // to the previous owner so its copy in the other app doesn't linger. Payload rows are
       // fetched with their campaign; previous owners come from the locked snapshot.
-      const newDestination = destinationForAgent(agent);
+      // One batch context for the whole fan-out: the mktr-leads receiver coalesces the N
+      // per-lead pushes into a single "{size} leads assigned to you" summary (Lyfe ignores
+      // batch for now — per-lead pushes, the pre-batch behavior).
+      const batch = affectedCount > 1 ? { id: randomUUID(), size: affectedCount } : null;
       const affectedIds = affectedRows.map((row) => row.id);
       const full = await m.Prospect.findAll({
         where: { id: { [Op.in]: affectedIds } },
-        include: [{ association: 'campaign', attributes: ['id', 'name'] }],
+        include: [
+          { association: 'campaign', attributes: ['id', 'name'] },
+          { association: 'qrTag', attributes: ['id', 'slug'] },
+        ],
       });
 
       const prevOwnerIds = [
@@ -1453,9 +1531,13 @@ export function makeProspectService(overrides = {}) {
       }
 
       for (const p of full) {
-        d.dispatchEvent('lead.assigned', () => buildLeadAssignedPayload(p, agent, p), {
-          destination: newDestination,
-        });
+        d.dispatchEvent('lead.assigned', () =>
+          withBatchContext(
+            buildLeadAssignedPayload(p, agent, p, { qrTag: p.qrTag || null, routingMode: 'direct' }),
+            batch
+          ),
+          { destination: newDestination }
+        );
 
         const prevId = lockedById.get(p.id)?.assignedAgentId;
         const prevAgent = prevId && prevId !== agentId ? prevAgentById.get(prevId) : null;
@@ -1476,25 +1558,28 @@ export function makeProspectService(overrides = {}) {
       // like the credit deduction above) — never fail the assignment over an audit-row write.
       await m.ProspectActivity.bulkCreate(
         full.map((p) => {
-          const prevId = lockedById.get(p.id)?.assignedAgentId;
+          const lockedRow = lockedById.get(p.id);
+          const prevId = lockedRow?.assignedAgentId;
           return {
             prospectId: p.id,
             type: 'assigned',
             actorUserId: user?.id || null,
             description: `Assigned to ${agent.firstName} ${agent.lastName}`.trim(),
             // Flag a reassignment (a prior owner existed) as a BOOLEAN so the timeline renders
-            // 'reassigned' — never expose who held it before.
+            // 'reassigned' — never expose who held it before. `released` marks a row that was
+            // HELD when the bulk assign claimed it (audit parity with single-release).
             metadata: {
               assignedAgentId: agent.id,
               via: 'bulk_assign',
               ...(prevId && prevId !== agentId ? { reassigned: true } : {}),
+              ...(lockedRow?.quarantinedAt ? { released: true } : {}),
             },
           };
         })
       ).catch((err) => d.logger.error('Failed to log bulk-assign activity', { error: err?.message || String(err) }));
     }
 
-    return { affectedCount, agent };
+    return { affectedCount, releasedCount, skipped, agent };
   }
 
   /**
@@ -1574,6 +1659,7 @@ export function makeProspectService(overrides = {}) {
       priority,
       leadSource,
       assignedAgentId,
+      assignment,
       campaignId,
       search,
       dateFrom,
@@ -1594,6 +1680,17 @@ export function makeProspectService(overrides = {}) {
     if (leadStatus && !VALID_LEAD_STATUSES.includes(leadStatus)) {
       return { prospects: [], pagination: { currentPage: pageNum, totalPages: 0, totalItems: 0, itemsPerPage: limitNum } };
     }
+    if (assignment && !VALID_ASSIGNMENT_FILTERS.includes(assignment)) {
+      return { prospects: [], pagination: { currentPage: pageNum, totalPages: 0, totalItems: 0, itemsPerPage: limitNum } };
+    }
+
+    // Assignment-state filter: 'unassigned' means truly in limbo (not held — held rows
+    // have their own bucket so the admin's pending pool and the strays stay separable).
+    if (assignment === 'assigned') whereConditions.assignedAgentId = { [Op.ne]: null };
+    else if (assignment === 'unassigned') {
+      whereConditions.assignedAgentId = null;
+      whereConditions.quarantinedAt = null;
+    } else if (assignment === 'held') whereConditions.quarantinedAt = { [Op.ne]: null };
 
     if (qrTagId) whereConditions.qrTagId = qrTagId;
     if (leadStatus) whereConditions.leadStatus = leadStatus;
@@ -1921,7 +2018,10 @@ export function makeProspectService(overrides = {}) {
         }, { transaction: t });
 
         const withCampaign = await m.Prospect.findByPk(prospectId, {
-          include: [{ association: 'campaign', attributes: ['id', 'name'] }],
+          include: [
+            { association: 'campaign', attributes: ['id', 'name'] },
+            { association: 'qrTag', attributes: ['id', 'slug'] },
+          ],
           transaction: t,
         });
 
@@ -1938,7 +2038,14 @@ export function makeProspectService(overrides = {}) {
         // buildLeadCreatedPayload, so delivery is otherwise unchanged.
         deliveryPairs = await d.persistEventDeliveries(
           'lead.assigned',
-          () => withBatchContext(buildLeadAssignedPayload(withCampaign, agent, withCampaign), batch),
+          () =>
+            withBatchContext(
+              buildLeadAssignedPayload(withCampaign, agent, withCampaign, {
+                qrTag: withCampaign?.qrTag || null,
+                routingMode: 'direct',
+              }),
+              batch
+            ),
           { destination },
           t
         );
@@ -2071,17 +2178,36 @@ export function makeProspectService(overrides = {}) {
   }
 
   /**
-   * Return an ASSIGNED lead to the held queue (admin pull-back from the mktr-leads app). Re-holds
-   * the prospect (quarantineReason='no_funded_agent', so the existing queue + releaseHeldProspect
-   * handle it) and fires lead.unassigned WITH `returnedToHeld` so the mktr-leads receiver
-   * SOFT-DELETES (vanishes) the lead instead of disputing it — the previous agent loses RLS
-   * visibility, admins keep it, and a later dispatch un-hides it. NO refund (consistent with
-   * reassign). Idempotent; fail-closed (never re-hold a lead we can't durably vanish).
+   * Return an ASSIGNED lead to the held queue (admin pull-back). Re-holds the prospect and
+   * fires lead.unassigned WITH `returnedToHeld` so the previous agent's app drops it — the
+   * mktr-leads receiver SOFT-DELETES (vanishes) the lead instead of disputing it; the Lyfe
+   * receiver nulls its assigned_to (the agent loses RLS visibility — same effect, flag
+   * ignored). Admins keep it, and a later dispatch (lead.assigned upsert) re-surfaces it.
+   * NO refund (consistent with reassign). Idempotent; fail-closed for deliverable owners
+   * (never re-hold a lead we can't durably vanish).
    *
-   * @returns {Promise<{status:'returned'|'already_handled'|'not_found'|'undeliverable', leadId?:string}>}
+   * Two callers, two flavors:
+   * - EXTERNAL (mktr-leads admin app, defaults): reason 'no_funded_agent' so the existing
+   *   external held queue + releaseHeldProspect handle it; mktr-leads-owned leads only.
+   * - WEB ADMIN (bulk return, opts): reason 'returned_by_admin' — deliberately invisible
+   *   to the external queue/release/sweep (all filter 'no_funded_agent'), so a returned
+   *   Lyfe-owned lead can never leak to the external buyer pool. `anyDestination` admits
+   *   Lyfe-owned and no-destination owners (System Agent — nothing was ever delivered, so
+   *   the vanish is skipped and fail-closed does not apply). `promoteUnassigned` folds
+   *   already-unassigned strays into the held pool (no webhook — nothing to vanish).
+   *
+   * @returns {Promise<{status:'returned'|'promoted'|'already_handled'|'not_assignable'|'not_found'|'undeliverable', leadId?:string}>}
    */
   async function returnProspectToHeld(prospectId, opts = {}) {
-    const { idempotencyKey = null, actorUserId = null } = opts;
+    const {
+      idempotencyKey = null,
+      actorUserId = null,
+      reason = 'no_funded_agent',
+      via = 'external_app',
+      anyDestination = false,
+      promoteUnassigned = false,
+      scopeWhere = null,
+    } = opts;
     const IDEMP_SCOPE = 'external:admin-return-held';
 
     if (idempotencyKey) {
@@ -2091,18 +2217,50 @@ export function makeProspectService(overrides = {}) {
       }
     }
 
-    const prospect = await m.Prospect.findByPk(prospectId);
+    const prospect = await m.Prospect.findOne({ where: { id: prospectId, ...(scopeWhere || {}) } });
     if (!prospect) return { status: 'not_found' };
     const previousAgentId = prospect.assignedAgentId;
-    // A held/orphan or already-unassigned lead is already in the queue → already_handled (so a
-    // retry after a successful return replays as a no-op).
-    if (prospect.quarantinedAt || !previousAgentId) return { status: 'already_handled' };
+    // A held lead is already in a queue → already_handled (a retry after a successful
+    // return replays as a no-op).
+    if (prospect.quarantinedAt) return { status: 'already_handled' };
+
+    // ── Promotion arm (web-admin only): an unassigned, unheld stray joins the held pool.
+    // No webhook — it has no owner app copy to vanish. Conditional UPDATE = race-safe.
+    if (!previousAgentId) {
+      if (!promoteUnassigned) return { status: 'already_handled' };
+      const pt = await d.sequelize.transaction();
+      try {
+        const [rows] = await d.sequelize.query(
+          `UPDATE prospects
+              SET "quarantinedAt" = NOW(), "quarantineReason" = :reason, "updatedAt" = NOW()
+            WHERE id = :prospectId AND "assignedAgentId" IS NULL AND "quarantinedAt" IS NULL
+            RETURNING id`,
+          { replacements: { prospectId, reason }, transaction: pt }
+        );
+        if (!Array.isArray(rows) || rows.length === 0) {
+          await pt.rollback();
+          return { status: 'already_handled' };
+        }
+        await m.ProspectActivity.create({
+          prospectId,
+          type: 'assigned',
+          actorUserId,
+          description: 'Moved to held queue by admin',
+          metadata: { promoted: true, via },
+        }, { transaction: pt });
+        await pt.commit();
+        return { status: 'promoted', leadId: prospectId };
+      } catch (err) {
+        await pt.rollback();
+        throw err;
+      }
+    }
 
     const prevAgent = await m.User.findByPk(previousAgentId, { attributes: ['id', 'lyfeId', 'mktrLeadsId'] });
     const prevDestination = destinationForAgent(prevAgent);
-    // Same-app scope: only a mktr-leads-owned lead can be returned here (the vanish is delivered
-    // to the mktr-leads receiver; a Lyfe-owned lead is out of scope).
-    if (prevDestination !== 'mktr_leads') return { status: 'not_assignable' };
+    // External flavor stays same-app-scoped: only a mktr-leads-owned lead can be returned
+    // (its broker + receiver own that contract). The web-admin flavor admits any owner.
+    if (!anyDestination && prevDestination !== 'mktr_leads') return { status: 'not_assignable' };
     const previousAgentExternalId = externalIdForDestination(prevAgent, prevDestination);
 
     const t = await d.sequelize.transaction();
@@ -2114,10 +2272,10 @@ export function makeProspectService(overrides = {}) {
       const [rows] = await d.sequelize.query(
         `UPDATE prospects
             SET "assignedAgentId" = NULL, "quarantinedAt" = NOW(),
-                "quarantineReason" = 'no_funded_agent', "updatedAt" = NOW()
+                "quarantineReason" = :reason, "updatedAt" = NOW()
           WHERE id = :prospectId AND "assignedAgentId" = :previousAgentId AND "quarantinedAt" IS NULL
           RETURNING id`,
-        { replacements: { prospectId, previousAgentId }, transaction: t }
+        { replacements: { prospectId, previousAgentId, reason }, transaction: t }
       );
 
       if (!Array.isArray(rows) || rows.length === 0) {
@@ -2128,21 +2286,26 @@ export function makeProspectService(overrides = {}) {
           type: 'assigned',
           actorUserId,
           description: 'Returned to held queue by admin',
-          metadata: { previousAgentId, returnedToHeld: true, via: 'external_app' },
+          metadata: { previousAgentId, returnedToHeld: true, via },
         }, { transaction: t });
 
-        // Vanish the lead from the previous agent's app — the receiver soft-deletes on returnedToHeld.
-        deliveryPairs = await d.persistEventDeliveries(
-          'lead.unassigned',
-          () => buildLeadUnassignedPayload(prospect, previousAgentExternalId, { returnedToHeld: true }),
-          { destination: prevDestination },
-          t
-        );
-        // Fail closed: never re-hold a lead we cannot durably vanish from the agent's app.
-        if (deliveryPairs.length === 0) {
-          await t.rollback();
-          return { status: 'undeliverable' };
+        if (prevDestination) {
+          // Vanish the lead from the previous agent's app — the mktr-leads receiver
+          // soft-deletes on returnedToHeld; Lyfe nulls assigned_to.
+          deliveryPairs = await d.persistEventDeliveries(
+            'lead.unassigned',
+            () => buildLeadUnassignedPayload(prospect, previousAgentExternalId, { returnedToHeld: true }),
+            { destination: prevDestination },
+            t
+          );
+          // Fail closed: never re-hold a lead we cannot durably vanish from the agent's app.
+          if (deliveryPairs.length === 0) {
+            await t.rollback();
+            return { status: 'undeliverable' };
+          }
         }
+        // No-destination owner (System Agent / provenance-less): nothing was ever
+        // delivered, so there is nothing to vanish — the re-hold alone is complete.
 
         result = { status: 'returned', leadId: prospectId };
       }
@@ -2173,6 +2336,69 @@ export function makeProspectService(overrides = {}) {
     }
 
     return result;
+  }
+
+  /**
+   * Bulk return leads to the held queue (web admin). Fan-out over the hardened single op
+   * — the same pattern the mktr-leads admin app uses for its bulk — because per-row
+   * fail-closed vanish semantics don't fit one set-based transaction: each row either
+   * fully returns (re-hold + vanish delivery committed together) or reports why not.
+   * `returned_by_admin` keeps every returned lead OUT of the external buyer queue.
+   * No idempotency keys: the single op's conditional UPDATE makes re-runs no-ops.
+   */
+  async function bulkReturnProspectsToHeld(prospectIds, user) {
+    if (!prospectIds || !Array.isArray(prospectIds) || prospectIds.length === 0) {
+      throw new d.AppError('Prospect IDs array is required', 400);
+    }
+    const requestedIds = [...new Set(prospectIds)];
+    const scopeWhere = await d.buildProspectWhere(user);
+
+    const counts = { returned: 0, promoted: 0, alreadyHeld: 0, undeliverable: 0, notFound: 0 };
+    for (const id of requestedIds) {
+      const r = await returnProspectToHeld(id, {
+        actorUserId: user?.id || null,
+        reason: 'returned_by_admin',
+        via: 'web_admin',
+        anyDestination: true,
+        promoteUnassigned: true,
+        scopeWhere,
+      });
+      if (r.status === 'returned') counts.returned += 1;
+      else if (r.status === 'promoted') counts.promoted += 1;
+      else if (r.status === 'already_handled') counts.alreadyHeld += 1;
+      else if (r.status === 'undeliverable') counts.undeliverable += 1;
+      else counts.notFound += 1;
+    }
+    return counts;
+  }
+
+  /**
+   * Bulk delete prospects (web admin). Fan-out over the hardened single delete — each row
+   * keeps its transactional-outbox lead.deleted (mktr-leads-owned rows only; a Lyfe-owned
+   * row's app copy is orphaned, the same documented limitation as single delete). One bad
+   * row never aborts the rest.
+   */
+  async function bulkDeleteProspects(prospectIds, user) {
+    if (!prospectIds || !Array.isArray(prospectIds) || prospectIds.length === 0) {
+      throw new d.AppError('Prospect IDs array is required', 400);
+    }
+    const requestedIds = [...new Set(prospectIds)];
+
+    const counts = { deleted: 0, notFound: 0, failed: 0 };
+    for (const id of requestedIds) {
+      try {
+        await deleteProspect(id, user);
+        counts.deleted += 1;
+      } catch (err) {
+        if (err?.statusCode === 404) {
+          counts.notFound += 1;
+        } else {
+          counts.failed += 1;
+          d.logger.error('[bulk-delete] delete failed', { prospectId: id, error: err?.message || String(err) });
+        }
+      }
+    }
+    return counts;
   }
 
   /**
@@ -2207,6 +2433,8 @@ export function makeProspectService(overrides = {}) {
     releaseHeldProspect,
     reassignProspectExternal,
     returnProspectToHeld,
+    bulkReturnProspectsToHeld,
+    bulkDeleteProspects,
     listDispatchableOrphans,
     getProspectActivities,
     bulkAssignProspects,
@@ -2227,6 +2455,8 @@ export const assignProspect = _default.assignProspect;
 export const releaseHeldProspect = _default.releaseHeldProspect;
 export const reassignProspectExternal = _default.reassignProspectExternal;
 export const returnProspectToHeld = _default.returnProspectToHeld;
+export const bulkReturnProspectsToHeld = _default.bulkReturnProspectsToHeld;
+export const bulkDeleteProspects = _default.bulkDeleteProspects;
 export const listDispatchableOrphans = _default.listDispatchableOrphans;
 export const getProspectActivities = _default.getProspectActivities;
 export const bulkAssignProspects = _default.bulkAssignProspects;

--- a/backend/src/services/webhookService.js
+++ b/backend/src/services/webhookService.js
@@ -464,8 +464,27 @@ export function makeWebhookService(overrides = {}) {
     }
   }
 
+  /**
+   * Pre-flight check for bulk operations: can `eventType` actually be delivered to
+   * `destination` right now? False when webhooks are globally disabled or no enabled
+   * subscriber is tagged for the destination. Transient send failures are NOT this
+   * check's concern (the persistent delivery queue retries those) — this closes the
+   * silent-misconfig hole where a bulk op would mutate rows and strand every lead.
+   * A null destination returns true: no delivery is possible or expected (e.g. a
+   * local-only assignee), matching single-op behavior.
+   */
+  async function hasDeliverableSubscriber(eventType, destination) {
+    if (!destination) return true;
+    if (String(process.env.WEBHOOK_ENABLED || 'false').toLowerCase() !== 'true') return false;
+    const subscribers = await d.WebhookSubscriber.findAll({ where: { enabled: true } });
+    return subscribers.some(
+      (sub) => (sub.events || []).includes(eventType) && (sub.metadata?.destination || null) === destination
+    );
+  }
+
   return { dispatchEvent, persistEventDeliveries, flushDeliveries, attemptDelivery, retryDelivery, retryAllFailed,
-           getDeadLetterQueue, purgeDeadLetters, getDeliveryStats, getQueueStats, recoverPendingRetries };
+           getDeadLetterQueue, purgeDeadLetters, getDeliveryStats, getQueueStats, recoverPendingRetries,
+           hasDeliverableSubscriber };
 }
 
 // --- Backward-compatible named exports ---
@@ -480,3 +499,4 @@ export const getDeadLetterQueue = _default.getDeadLetterQueue;
 export const purgeDeadLetters = _default.purgeDeadLetters;
 export const getDeliveryStats = _default.getDeliveryStats;
 export const recoverPendingRetries = _default.recoverPendingRetries;
+export const hasDeliverableSubscriber = _default.hasDeliverableSubscriber;

--- a/backend/test/prospectServiceBulkOps.test.js
+++ b/backend/test/prospectServiceBulkOps.test.js
@@ -1,0 +1,368 @@
+/**
+ * Web-admin bulk lead ops — unit tests via the makeProspectService DI seam (no Postgres).
+ *
+ * Covers the D1–D4 behavior of the bulk-lead-ops backend:
+ *  - bulkAssignProspects v2: held-release arm, batch context, skip accounting, webhook pre-flight
+ *  - returnProspectToHeld: web-admin flavor (returned_by_admin, any destination, promotion)
+ *    vs external flavor (no_funded_agent, mktr-leads-only) — and fail-closed vanish
+ *  - bulkReturnProspectsToHeld / bulkDeleteProspects fan-out counting
+ *  - assignProspect held-release now fires lead.assigned (never lead.created)
+ *
+ * Integration-level coverage (real DB + supertest) lives in prospects.test.js.
+ */
+import { jest } from '@jest/globals';
+import { makeProspectService } from '../src/services/prospectService.js';
+
+const silentLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+
+class TestAppError extends Error {
+  constructor(m, s) {
+    super(m);
+    this.statusCode = s;
+  }
+}
+
+const ADMIN = { id: 'admin-1', role: 'admin' };
+
+function makeTx() {
+  return { commit: jest.fn().mockResolvedValue(), rollback: jest.fn().mockResolvedValue() };
+}
+
+function buildDeps(overrides = {}) {
+  const models = {
+    Prospect: {
+      findOne: jest.fn().mockResolvedValue(null),
+      findByPk: jest.fn().mockResolvedValue(null),
+      findAll: jest.fn().mockResolvedValue([]),
+      update: jest.fn().mockResolvedValue([0, []]),
+    },
+    User: { findOne: jest.fn().mockResolvedValue(null), findByPk: jest.fn().mockResolvedValue(null) },
+    Campaign: {},
+    QrTag: {},
+    Commission: {},
+    Attribution: {},
+    ProspectActivity: { create: jest.fn().mockResolvedValue({}), bulkCreate: jest.fn().mockResolvedValue([]) },
+    AgentGroup: {},
+    AgentGroupMember: {},
+    IdempotencyKey: { findOne: jest.fn().mockResolvedValue(null), create: jest.fn().mockResolvedValue({}), update: jest.fn().mockResolvedValue([1]) },
+  };
+
+  const sequelize = {
+    // Managed form (callback) for bulk assign / delete; unmanaged form (no callback)
+    // for returnProspectToHeld's explicit commit/rollback flow.
+    transaction: jest.fn().mockImplementation(async (cb) => {
+      if (typeof cb === 'function') return cb({});
+      return makeTx();
+    }),
+    query: jest.fn().mockResolvedValue([[]]),
+  };
+
+  return {
+    models,
+    sequelize,
+    buildProspectWhere: jest.fn().mockResolvedValue({}),
+    deductLeadCredit: jest.fn().mockResolvedValue(),
+    dispatchEvent: jest.fn().mockResolvedValue(),
+    persistEventDeliveries: jest.fn().mockResolvedValue([{ delivery: {}, subscriber: {} }]),
+    flushDeliveries: jest.fn(),
+    hasDeliverableSubscriber: jest.fn().mockResolvedValue(true),
+    AppError: TestAppError,
+    logger: silentLogger,
+    ...overrides,
+  };
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   bulkAssignProspects v2
+   ══════════════════════════════════════════════════════════════════ */
+describe('bulkAssignProspects — held release, batch context, skip accounting', () => {
+  const AGENT = { id: 'agent-1', firstName: 'Ada', lastName: 'Tan', email: 'ada@x.co', phone: '651', mktrLeadsId: 'ml-1' };
+
+  function wireBulk(deps, { requested, locked, updated }) {
+    deps.models.User.findOne.mockResolvedValue(AGENT);
+    // findAll is called for: (1) the locked eligible set (lock: true), (2) the requested
+    // classification snapshot (attributes list, no lock), (3) the full payload rows (include).
+    deps.models.Prospect.findAll.mockImplementation((opts = {}) => {
+      if (opts.lock) return Promise.resolve(locked);
+      if (opts.include) return Promise.resolve(updated.full);
+      return Promise.resolve(requested);
+    });
+    deps.models.Prospect.update.mockResolvedValue([updated.rows.length, updated.rows]);
+  }
+
+  it('releases a returned_by_admin hold: clears quarantine in the UPDATE, counts releasedCount, fires batched lead.assigned with qrTag + routing.mode', async () => {
+    const deps = buildDeps();
+    const heldRow = { id: 'p1', assignedAgentId: null, campaignId: 'c1', quarantinedAt: new Date(), quarantineReason: 'returned_by_admin' };
+    const freshRow = { id: 'p2', assignedAgentId: null, campaignId: 'c1', quarantinedAt: null, quarantineReason: null };
+    wireBulk(deps, {
+      requested: [heldRow, freshRow],
+      locked: [heldRow, freshRow],
+      updated: {
+        rows: [{ id: 'p1', campaignId: 'c1' }, { id: 'p2', campaignId: 'c1' }],
+        full: [
+          { id: 'p1', campaignId: 'c1', campaign: { id: 'c1', name: 'C' }, qrTag: { id: 'q1', slug: 'sluggy' }, sourceMetadata: {} },
+          { id: 'p2', campaignId: 'c1', campaign: { id: 'c1', name: 'C' }, qrTag: null, sourceMetadata: {} },
+        ],
+      },
+    });
+    const svc = makeProspectService(deps);
+
+    const res = await svc.bulkAssignProspects(['p1', 'p2'], 'agent-1', ADMIN);
+
+    expect(res.affectedCount).toBe(2);
+    expect(res.releasedCount).toBe(1);
+    expect(res.skipped).toEqual({ notFound: 0, alreadyAssigned: 0, heldFenced: 0 });
+
+    // The atomic UPDATE clears the hold alongside the assignment.
+    const updateArgs = deps.models.Prospect.update.mock.calls[0][0];
+    expect(updateArgs).toMatchObject({ assignedAgentId: 'agent-1', quarantinedAt: null, quarantineReason: null });
+
+    // Every delivery is lead.assigned, batch-stamped, with qrTag + routing.mode parity.
+    const assignedCalls = deps.dispatchEvent.mock.calls.filter(([evt]) => evt === 'lead.assigned');
+    expect(assignedCalls).toHaveLength(2);
+    const payloads = assignedCalls.map(([, builder]) => builder());
+    for (const p of payloads) {
+      expect(p.event).toBe('lead.assigned');
+      expect(p.data.batch).toEqual({ id: expect.any(String), size: 2 });
+      expect(p.data.routing.mode).toBe('direct');
+    }
+    expect(payloads.map((p) => p.data.qrTag)).toEqual(
+      expect.arrayContaining([
+        { externalId: 'q1', slug: 'sluggy' },
+        { externalId: null, slug: null },
+      ])
+    );
+    expect(deps.dispatchEvent.mock.calls.some(([evt]) => evt === 'lead.created')).toBe(false);
+
+    // Released row's activity is flagged for the timeline.
+    const activityRows = deps.models.ProspectActivity.bulkCreate.mock.calls[0][0];
+    expect(activityRows.find((a) => a.prospectId === 'p1').metadata.released).toBe(true);
+    expect(activityRows.find((a) => a.prospectId === 'p2').metadata.released).toBeUndefined();
+  });
+
+  it('classifies skips: fenced holds (DNC / external pool), same-agent no-ops, unknown ids', async () => {
+    const deps = buildDeps();
+    const dncRow = { id: 'p-dnc', assignedAgentId: null, quarantinedAt: new Date(), quarantineReason: 'dnc_pending' };
+    const extRow = { id: 'p-ext', assignedAgentId: null, quarantinedAt: new Date(), quarantineReason: 'no_funded_external_buyer' };
+    const mineRow = { id: 'p-mine', assignedAgentId: 'agent-1', quarantinedAt: null, quarantineReason: null };
+    wireBulk(deps, {
+      requested: [dncRow, extRow, mineRow],
+      locked: [],
+      updated: { rows: [], full: [] },
+    });
+    const svc = makeProspectService(deps);
+
+    const res = await svc.bulkAssignProspects(['p-dnc', 'p-ext', 'p-mine', 'p-gone'], 'agent-1', ADMIN);
+
+    expect(res.affectedCount).toBe(0);
+    expect(res.skipped).toEqual({ notFound: 1, alreadyAssigned: 1, heldFenced: 2 });
+    expect(deps.dispatchEvent).not.toHaveBeenCalled();
+  });
+
+  it('pre-flight 409s when the destination app has no deliverable subscriber', async () => {
+    const deps = buildDeps({ hasDeliverableSubscriber: jest.fn().mockResolvedValue(false) });
+    deps.models.User.findOne.mockResolvedValue(AGENT);
+    const svc = makeProspectService(deps);
+
+    await expect(svc.bulkAssignProspects(['p1'], 'agent-1', ADMIN)).rejects.toMatchObject({ statusCode: 409 });
+    expect(deps.hasDeliverableSubscriber).toHaveBeenCalledWith('lead.assigned', 'mktr_leads');
+    expect(deps.models.Prospect.update).not.toHaveBeenCalled();
+  });
+});
+
+/* ══════════════════════════════════════════════════════════════════
+   returnProspectToHeld — web-admin flavor vs external flavor
+   ══════════════════════════════════════════════════════════════════ */
+describe('returnProspectToHeld', () => {
+  const WEB_OPTS = { actorUserId: 'admin-1', reason: 'returned_by_admin', via: 'web_admin', anyDestination: true, promoteUnassigned: true };
+
+  function wireProspect(deps, prospect) {
+    deps.models.Prospect.findOne.mockResolvedValue(prospect);
+  }
+
+  it('web flavor returns a Lyfe-owned lead: re-holds as returned_by_admin and persists the vanish to the lyfe destination', async () => {
+    const deps = buildDeps();
+    wireProspect(deps, { id: 'p1', assignedAgentId: 'u-lyfe', quarantinedAt: null, sourceMetadata: {} });
+    deps.models.User.findByPk.mockResolvedValue({ id: 'u-lyfe', lyfeId: 'lyfe-uuid', mktrLeadsId: null });
+    deps.sequelize.query.mockResolvedValue([[{ id: 'p1' }]]);
+    const svc = makeProspectService(deps);
+
+    const res = await svc.returnProspectToHeld('p1', WEB_OPTS);
+
+    expect(res).toEqual({ status: 'returned', leadId: 'p1' });
+    const [sql, { replacements }] = deps.sequelize.query.mock.calls[0];
+    expect(sql).toContain('"quarantineReason" = :reason');
+    expect(replacements.reason).toBe('returned_by_admin');
+
+    const [evt, builder, opts] = deps.persistEventDeliveries.mock.calls[0];
+    expect(evt).toBe('lead.unassigned');
+    expect(opts).toEqual({ destination: 'lyfe' });
+    const payload = builder();
+    expect(payload.data.returnedToHeld).toBe(true);
+    expect(payload.data.previousAgentId).toBe('lyfe-uuid');
+    expect(deps.flushDeliveries).toHaveBeenCalled();
+  });
+
+  it('web flavor re-holds a no-destination (System Agent) lead without any delivery — no fail-closed', async () => {
+    const deps = buildDeps({ persistEventDeliveries: jest.fn().mockResolvedValue([]) });
+    wireProspect(deps, { id: 'p1', assignedAgentId: 'sys-1', quarantinedAt: null, sourceMetadata: {} });
+    deps.models.User.findByPk.mockResolvedValue({ id: 'sys-1', lyfeId: null, mktrLeadsId: null });
+    deps.sequelize.query.mockResolvedValue([[{ id: 'p1' }]]);
+    const svc = makeProspectService(deps);
+
+    const res = await svc.returnProspectToHeld('p1', WEB_OPTS);
+
+    expect(res).toEqual({ status: 'returned', leadId: 'p1' });
+    expect(deps.persistEventDeliveries).not.toHaveBeenCalled();
+  });
+
+  it('web flavor fails closed when the vanish cannot be persisted (webhooks off / no subscriber)', async () => {
+    const deps = buildDeps({ persistEventDeliveries: jest.fn().mockResolvedValue([]) });
+    wireProspect(deps, { id: 'p1', assignedAgentId: 'u-ml', quarantinedAt: null, sourceMetadata: {} });
+    deps.models.User.findByPk.mockResolvedValue({ id: 'u-ml', lyfeId: null, mktrLeadsId: 'ml-9' });
+    deps.sequelize.query.mockResolvedValue([[{ id: 'p1' }]]);
+    const svc = makeProspectService(deps);
+
+    const res = await svc.returnProspectToHeld('p1', WEB_OPTS);
+
+    expect(res).toEqual({ status: 'undeliverable' });
+    expect(deps.flushDeliveries).not.toHaveBeenCalled();
+  });
+
+  it('web flavor promotes an already-unassigned stray into the held pool with no webhook', async () => {
+    const deps = buildDeps();
+    wireProspect(deps, { id: 'p1', assignedAgentId: null, quarantinedAt: null });
+    deps.sequelize.query.mockResolvedValue([[{ id: 'p1' }]]);
+    const svc = makeProspectService(deps);
+
+    const res = await svc.returnProspectToHeld('p1', WEB_OPTS);
+
+    expect(res).toEqual({ status: 'promoted', leadId: 'p1' });
+    const [sql, { replacements }] = deps.sequelize.query.mock.calls[0];
+    expect(sql).toContain('"assignedAgentId" IS NULL');
+    expect(replacements.reason).toBe('returned_by_admin');
+    expect(deps.persistEventDeliveries).not.toHaveBeenCalled();
+  });
+
+  it('external flavor (defaults) keeps its fences: Lyfe-owned → not_assignable, reason stays no_funded_agent', async () => {
+    const deps = buildDeps();
+    wireProspect(deps, { id: 'p1', assignedAgentId: 'u-lyfe', quarantinedAt: null, sourceMetadata: {} });
+    deps.models.User.findByPk.mockResolvedValue({ id: 'u-lyfe', lyfeId: 'lyfe-uuid', mktrLeadsId: null });
+    const svc = makeProspectService(deps);
+
+    const res = await svc.returnProspectToHeld('p1', { actorUserId: 'x' });
+    expect(res).toEqual({ status: 'not_assignable' });
+
+    // mktr-leads-owned still works and re-holds under the EXTERNAL reason.
+    deps.models.User.findByPk.mockResolvedValue({ id: 'u-ml', lyfeId: null, mktrLeadsId: 'ml-9' });
+    wireProspect(deps, { id: 'p2', assignedAgentId: 'u-ml', quarantinedAt: null, sourceMetadata: {} });
+    deps.sequelize.query.mockResolvedValue([[{ id: 'p2' }]]);
+    const res2 = await svc.returnProspectToHeld('p2', { actorUserId: 'x' });
+    expect(res2).toEqual({ status: 'returned', leadId: 'p2' });
+    expect(deps.sequelize.query.mock.calls[0][1].replacements.reason).toBe('no_funded_agent');
+  });
+
+  it('external flavor never promotes: unassigned lead stays already_handled', async () => {
+    const deps = buildDeps();
+    wireProspect(deps, { id: 'p1', assignedAgentId: null, quarantinedAt: null });
+    const svc = makeProspectService(deps);
+
+    expect(await svc.returnProspectToHeld('p1', {})).toEqual({ status: 'already_handled' });
+    expect(deps.sequelize.query).not.toHaveBeenCalled();
+  });
+
+  it('held lead is already_handled for both flavors', async () => {
+    const deps = buildDeps();
+    wireProspect(deps, { id: 'p1', assignedAgentId: null, quarantinedAt: new Date() });
+    const svc = makeProspectService(deps);
+
+    expect(await svc.returnProspectToHeld('p1', WEB_OPTS)).toEqual({ status: 'already_handled' });
+    expect(await svc.returnProspectToHeld('p1', {})).toEqual({ status: 'already_handled' });
+  });
+});
+
+/* ══════════════════════════════════════════════════════════════════
+   bulk fan-out wrappers
+   ══════════════════════════════════════════════════════════════════ */
+describe('bulkReturnProspectsToHeld / bulkDeleteProspects', () => {
+  it('bulk return dedupes ids and buckets per-row outcomes', async () => {
+    const deps = buildDeps();
+    // p-ret: assigned to a no-destination owner → returned (no delivery needed).
+    // p-pro: unassigned stray → promoted. p-held: quarantined → alreadyHeld. p-gone → notFound.
+    deps.models.Prospect.findOne.mockImplementation(({ where }) => {
+      const byId = {
+        'p-ret': { id: 'p-ret', assignedAgentId: 'sys-1', quarantinedAt: null, sourceMetadata: {} },
+        'p-pro': { id: 'p-pro', assignedAgentId: null, quarantinedAt: null },
+        'p-held': { id: 'p-held', assignedAgentId: null, quarantinedAt: new Date() },
+      };
+      return Promise.resolve(byId[where.id] || null);
+    });
+    deps.models.User.findByPk.mockResolvedValue({ id: 'sys-1', lyfeId: null, mktrLeadsId: null });
+    deps.sequelize.query.mockImplementation((sql, { replacements }) => Promise.resolve([[{ id: replacements.prospectId }]]));
+    const svc = makeProspectService(deps);
+
+    const counts = await svc.bulkReturnProspectsToHeld(['p-ret', 'p-pro', 'p-held', 'p-gone', 'p-ret'], ADMIN);
+
+    expect(counts).toEqual({ returned: 1, promoted: 1, alreadyHeld: 1, undeliverable: 0, notFound: 1 });
+    // Dedupe: p-ret handled once despite appearing twice.
+    expect(deps.models.Prospect.findOne).toHaveBeenCalledTimes(4);
+  });
+
+  it('bulk delete counts deletions and 404s without aborting the batch', async () => {
+    const deps = buildDeps();
+    const destroyed = [];
+    deps.models.Prospect.findOne.mockImplementation(({ where }) => {
+      if (where.id === 'p-gone') return Promise.resolve(null);
+      return Promise.resolve({
+        id: where.id,
+        assignedAgentId: null,
+        destroy: jest.fn().mockImplementation(() => { destroyed.push(where.id); return Promise.resolve(); }),
+      });
+    });
+    const svc = makeProspectService(deps);
+
+    const counts = await svc.bulkDeleteProspects(['p-1', 'p-gone', 'p-2'], ADMIN);
+
+    expect(counts).toEqual({ deleted: 2, notFound: 1, failed: 0 });
+    expect(destroyed).toEqual(['p-1', 'p-2']);
+  });
+});
+
+/* ══════════════════════════════════════════════════════════════════
+   assignProspect held release — event contract
+   ══════════════════════════════════════════════════════════════════ */
+describe('assignProspect held release fires lead.assigned (never lead.created)', () => {
+  it('release path dispatches lead.assigned with routing.mode + qrTag block', async () => {
+    const deps = buildDeps();
+    const prospect = {
+      id: 'p1',
+      assignedAgentId: null,
+      quarantinedAt: new Date(),
+      quarantineReason: 'returned_by_admin',
+      campaignId: 'c1',
+      sourceMetadata: {},
+      reload: jest.fn().mockResolvedValue(),
+      update: jest.fn().mockResolvedValue(),
+    };
+    deps.models.Prospect.findByPk.mockImplementation((id, opts) => {
+      if (opts?.include) {
+        return Promise.resolve({ id: 'p1', sourceMetadata: {}, campaign: { id: 'c1', name: 'C' }, qrTag: { id: 'q1', slug: 's1' } });
+      }
+      return Promise.resolve(prospect);
+    });
+    deps.models.User.findOne.mockResolvedValue({ id: 'agent-1', firstName: 'A', lastName: 'B', email: 'a@b.c', phone: '65', lyfeId: 'lyfe-1' });
+    deps.sequelize.query.mockResolvedValue([[{ id: 'p1' }]]); // atomic release claim wins
+    const svc = makeProspectService(deps);
+
+    await svc.assignProspect('p1', 'agent-1', ADMIN);
+
+    const events = deps.dispatchEvent.mock.calls.map(([evt]) => evt);
+    expect(events).toContain('lead.assigned');
+    expect(events).not.toContain('lead.created');
+    const [, builder, opts] = deps.dispatchEvent.mock.calls.find(([evt]) => evt === 'lead.assigned');
+    expect(opts).toEqual({ destination: 'lyfe' });
+    const payload = builder();
+    expect(payload.data.routing.mode).toBe('direct');
+    expect(payload.data.qrTag).toEqual({ externalId: 'q1', slug: 's1' });
+  });
+});

--- a/backend/test/prospects.test.js
+++ b/backend/test/prospects.test.js
@@ -445,6 +445,172 @@ describe('Bulk assign', () => {
   })
 })
 
+// Web-admin bulk lead ops: return-to-held, held release via bulk assign, bulk delete,
+// and the assignment-state list filter. The test agent has no lyfeId/mktrLeadsId
+// (destination null), so returns need no vanish delivery and assigns pass the
+// webhook pre-flight even with WEBHOOK_ENABLED=false.
+describe('Bulk return-to-held / bulk delete / assignment filter', () => {
+  let campaign, assigned, stray
+
+  beforeAll(async () => {
+    campaign = await createTestCampaign(adminUser.id)
+    assigned = await createTestProspect(campaign.id, { assignedAgentId: agentUser.id })
+    stray = await createTestProspect(campaign.id)
+  })
+
+  it('PATCH /bulk/return-to-held — returns an assigned lead and promotes an unassigned stray', async () => {
+    const res = await request(app)
+      .patch('/api/prospects/bulk/return-to-held')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ prospectIds: [assigned.id, stray.id] })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.returned).toBe(1)
+    expect(res.body.data.promoted).toBe(1)
+
+    await assigned.reload()
+    expect(assigned.assignedAgentId).toBeNull()
+    expect(assigned.quarantinedAt).not.toBeNull()
+    expect(assigned.quarantineReason).toBe('returned_by_admin')
+  })
+
+  it('re-running the return is a no-op (alreadyHeld)', async () => {
+    const res = await request(app)
+      .patch('/api/prospects/bulk/return-to-held')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ prospectIds: [assigned.id, stray.id] })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.returned).toBe(0)
+    expect(res.body.data.alreadyHeld).toBe(2)
+  })
+
+  it('returned_by_admin holds never surface in the EXTERNAL held queue (no_funded_agent only)', async () => {
+    const res = await request(app)
+      .get('/api/prospects/held')
+      .set('Authorization', `Bearer ${adminToken}`)
+
+    expect(res.status).toBe(200)
+    const returnedHold = (res.body.data?.held || res.body.held || []).find((h) => h.id === assigned.id)
+    // listHeldProspects lists ALL quarantined rows (reason included) — the returned
+    // lead may appear there, but must carry the web-admin reason, and the external
+    // orphan queue (filtered on no_funded_agent) must not release it. Assert the
+    // reason so a regression back to 'no_funded_agent' fails loudly.
+    if (returnedHold) expect(returnedHold.quarantineReason).toBe('returned_by_admin')
+  })
+
+  it('GET /api/prospects?assignment=held — lists the returned leads with quarantine fields', async () => {
+    const res = await request(app)
+      .get(`/api/prospects?assignment=held&campaignId=${campaign.id}&limit=100`)
+      .set('Authorization', `Bearer ${adminToken}`)
+
+    expect(res.status).toBe(200)
+    const ids = res.body.data.prospects.map((p) => p.id)
+    expect(ids).toEqual(expect.arrayContaining([assigned.id, stray.id]))
+    const row = res.body.data.prospects.find((p) => p.id === assigned.id)
+    expect(row.quarantineReason).toBe('returned_by_admin')
+  })
+
+  it('GET /api/prospects?assignment=unassigned — excludes held leads', async () => {
+    const res = await request(app)
+      .get(`/api/prospects?assignment=unassigned&campaignId=${campaign.id}&limit=100`)
+      .set('Authorization', `Bearer ${adminToken}`)
+
+    expect(res.status).toBe(200)
+    const ids = res.body.data.prospects.map((p) => p.id)
+    expect(ids).not.toContain(assigned.id)
+    expect(ids).not.toContain(stray.id)
+  })
+
+  it('GET /api/prospects?assignment=bogus — unknown filter degrades to an empty page', async () => {
+    const res = await request(app)
+      .get('/api/prospects?assignment=bogus')
+      .set('Authorization', `Bearer ${adminToken}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.prospects).toEqual([])
+  })
+
+  it('PATCH /bulk/assign — releases the returned_by_admin holds (clears quarantine, reports releasedCount)', async () => {
+    const res = await request(app)
+      .patch('/api/prospects/bulk/assign')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ prospectIds: [assigned.id, stray.id], agentId: agentUser.id })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.affectedCount).toBe(2)
+    expect(res.body.data.releasedCount).toBe(2)
+
+    await assigned.reload()
+    expect(assigned.assignedAgentId).toBe(agentUser.id)
+    expect(assigned.quarantinedAt).toBeNull()
+    expect(assigned.quarantineReason).toBeNull()
+  })
+
+  it('PATCH /bulk/assign — skip accounting reports already-assigned and missing rows', async () => {
+    const res = await request(app)
+      .patch('/api/prospects/bulk/assign')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        prospectIds: [assigned.id, '00000000-0000-0000-0000-00000000dead'],
+        agentId: agentUser.id
+      })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.affectedCount).toBe(0)
+    expect(res.body.data.skipped).toEqual({ notFound: 1, alreadyAssigned: 1, heldFenced: 0 })
+  })
+
+  it('POST /bulk/delete — deletes rows, counts unknown ids, never aborts the batch', async () => {
+    const doomed1 = await createTestProspect(campaign.id)
+    const doomed2 = await createTestProspect(campaign.id)
+
+    const res = await request(app)
+      .post('/api/prospects/bulk/delete')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ prospectIds: [doomed1.id, doomed2.id, '00000000-0000-0000-0000-00000000dead'] })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.deleted).toBe(2)
+    expect(res.body.data.notFound).toBe(1)
+
+    const gone = await request(app)
+      .get(`/api/prospects/${doomed1.id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+    expect(gone.status).toBe(404)
+  })
+
+  it('bulk routes validate ids: non-UUID entries and oversized arrays 400', async () => {
+    const bad = await request(app)
+      .patch('/api/prospects/bulk/return-to-held')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ prospectIds: ['not-a-uuid'] })
+    expect(bad.status).toBe(400)
+
+    const oversized = await request(app)
+      .post('/api/prospects/bulk/delete')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ prospectIds: Array.from({ length: 201 }, (_, i) => `00000000-0000-0000-0000-${String(i).padStart(12, '0')}`) })
+    expect(oversized.status).toBe(400)
+  })
+
+  it('agents cannot bulk-return other agents\' leads (scope filter)', async () => {
+    const otherCampaign = await createTestCampaign(adminUser.id)
+    const adminsLead = await createTestProspect(otherCampaign.id, { assignedAgentId: adminUser.id })
+
+    const res = await request(app)
+      .patch('/api/prospects/bulk/return-to-held')
+      .set('Authorization', `Bearer ${_agentToken}`)
+      .send({ prospectIds: [adminsLead.id] })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.notFound).toBe(1)
+
+    await adminsLead.reload()
+    expect(adminsLead.quarantinedAt).toBeNull()
+  })
+})
+
 describe('Schedule follow-up', () => {
   let campaign, prospect
 

--- a/backend/test/unit/adminLeadOps.test.js
+++ b/backend/test/unit/adminLeadOps.test.js
@@ -9,7 +9,12 @@ function baseDeps(overrides = {}) {
   const mockTx = { commit: jest.fn().mockResolvedValue(undefined), rollback: jest.fn().mockResolvedValue(undefined) };
   const deps = {
     models: {
-      Prospect: { findByPk: jest.fn() },
+      // returnProspectToHeld loads via scope-aware findOne; tests arrange through
+      // findByPk, so findOne delegates to it (same resolved prospect).
+      Prospect: (() => {
+        const findByPk = jest.fn();
+        return { findByPk, findOne: jest.fn((args) => findByPk(args?.where?.id)) };
+      })(),
       User: { findOne: jest.fn(), findByPk: jest.fn() },
       ProspectActivity: { create: jest.fn().mockResolvedValue({}) },
       IdempotencyKey: {

--- a/backend/test/unit/prospectAssignment.test.js
+++ b/backend/test/unit/prospectAssignment.test.js
@@ -107,6 +107,9 @@ function buildMocks() {
   const chargeLeadCredit = jest.fn().mockResolvedValue(true);
   const buildProspectWhere = jest.fn().mockResolvedValue({});
   const dispatchEvent = jest.fn().mockResolvedValue(undefined);
+  // Bulk assign's webhook pre-flight — deliverable by default so assignment tests
+  // exercise the assignment logic, not the misconfig guard.
+  const hasDeliverableSubscriber = jest.fn().mockResolvedValue(true);
 
   const AppError = class extends Error {
     constructor(message, statusCode) {
@@ -137,6 +140,7 @@ function buildMocks() {
     chargeLeadCredit,
     buildProspectWhere,
     dispatchEvent,
+    hasDeliverableSubscriber,
     AppError,
     logger,
   };
@@ -153,6 +157,7 @@ function makeService(mocks, overrides = {}) {
     chargeLeadCredit: mocks.chargeLeadCredit,
     buildProspectWhere: mocks.buildProspectWhere,
     dispatchEvent: mocks.dispatchEvent,
+    hasDeliverableSubscriber: mocks.hasDeliverableSubscriber,
     AppError: mocks.AppError,
     logger: mocks.logger,
     ...overrides,
@@ -359,19 +364,25 @@ describe('prospectAssignment (unit)', () => {
       expect(payload.data.routing.agentExternalId).toBe('lyfe-agent-1');
     });
 
-    it('releases a HELD lead: clears quarantine atomically, deducts, fires lead.created (not lead.assigned)', async () => {
+    it('releases a HELD lead: clears quarantine atomically, deducts, fires lead.assigned (never lead.created — a duplicate create is a no-op at both receivers, so a returned lead would never re-surface)', async () => {
       const held = { ...mocks.mockProspect, quarantinedAt: new Date(), reload: jest.fn().mockResolvedValue(true) };
       mocks.models.Prospect.findByPk
         .mockResolvedValueOnce(held)
-        .mockResolvedValueOnce({ ...held, campaign: { id: 'camp-1', name: 'C' } });
+        .mockResolvedValueOnce({ ...held, campaign: { id: 'camp-1', name: 'C' }, qrTag: { id: 'qr-9', slug: 'sl' } });
       mocks.sequelize.query.mockResolvedValue([[{ id: 'prospect-1' }]]); // claim won
 
       await service.assignProspect('prospect-1', 'agent-1', admin);
 
       expect(mocks.sequelize.query).toHaveBeenCalled();
       expect(mocks.deductLeadCredit).toHaveBeenCalledWith({ agentId: 'agent-1', campaignId: 'camp-1' });
-      expect(mocks.dispatchEvent).toHaveBeenCalledWith('lead.created', expect.any(Function), expect.objectContaining({ destination: 'lyfe' }));
-      expect(mocks.dispatchEvent).not.toHaveBeenCalledWith('lead.assigned', expect.any(Function));
+      expect(mocks.dispatchEvent).toHaveBeenCalledWith('lead.assigned', expect.any(Function), expect.objectContaining({ destination: 'lyfe' }));
+      expect(mocks.dispatchEvent).not.toHaveBeenCalledWith('lead.created', expect.any(Function), expect.anything());
+      // Insert-parity payload: the destination app may not know this lead yet, so the
+      // assigned payload carries the created payload's qrTag block + routing.mode.
+      const builder = mocks.dispatchEvent.mock.calls.find((c) => c[0] === 'lead.assigned')[1];
+      const payload = builder();
+      expect(payload.data.qrTag).toEqual({ externalId: 'qr-9', slug: 'sl' });
+      expect(payload.data.routing.mode).toBe('direct');
     });
 
     it('refuses to manually release an EXTERNAL hold (no_funded_external_buyer) to an internal agent', async () => {
@@ -503,11 +514,16 @@ describe('prospectAssignment (unit)', () => {
 
       // The same-agent exclusion lives on the locked SELECT (the UPDATE then targets the
       // locked id set). IS DISTINCT FROM semantics: unassigned (NULL) rows still match,
-      // rows already held by agent-1 do not.
+      // rows already held by agent-1 do not. It sits under Op.and alongside the
+      // releasable-hold clause (quarantine-free OR a releasable hold reason).
       const where = mocks.models.Prospect.findAll.mock.calls[0][0].where;
-      expect(where[Op.or]).toEqual([
+      expect(where[Op.and][1][Op.or]).toEqual([
         { assignedAgentId: null },
         { assignedAgentId: { [Op.ne]: 'agent-1' } },
+      ]);
+      expect(where[Op.and][0][Op.or]).toEqual([
+        { quarantinedAt: null },
+        { quarantineReason: { [Op.in]: ['no_funded_agent', 'returned_by_admin'] } },
       ]);
       expect(mocks.deductLeadCredit).not.toHaveBeenCalled();
     });

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -498,6 +498,16 @@ class ProspectEntity extends BaseEntity {
  return response.data;
  }
 
+ async bulkReturnToHeld(prospectIds) {
+ const response = await apiClient.patch(`${this.endpoint}/bulk/return-to-held`, { prospectIds });
+ return response.data;
+ }
+
+ async bulkDelete(prospectIds) {
+ const response = await apiClient.post(`${this.endpoint}/bulk/delete`, { prospectIds });
+ return response.data;
+ }
+
  async getStats() {
  const response = await apiClient.get(`${this.endpoint}/stats/overview`);
  return response.data;

--- a/src/components/bulk/BulkActionBar.jsx
+++ b/src/components/bulk/BulkActionBar.jsx
@@ -1,0 +1,95 @@
+import { useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { UserPlus, Undo2, Trash2, FileSpreadsheet, FileText, X, Loader2 } from 'lucide-react';
+
+/**
+ * Floating bulk-action bar — slides up from the bottom of the viewport while at
+ * least one row is selected. Esc clears the selection. Export buttons render only
+ * when handlers are supplied (AdminProspects has exports; AdminAgentDetail doesn't).
+ */
+export default function BulkActionBar({
+  count,
+  heldCount = 0,
+  busy = false,
+  assignLabel = 'Assign to agent…',
+  onAssign,
+  onReturnToHeld,
+  onDelete,
+  onExportCSV,
+  onExportPDF,
+  onClear,
+}) {
+  useEffect(() => {
+    if (count === 0) return undefined;
+    const onKeyDown = (e) => {
+      if (e.key === 'Escape') onClear?.();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [count, onClear]);
+
+  if (count === 0) return null;
+
+  return (
+    <div className="fixed bottom-4 inset-x-4 sm:inset-x-auto sm:left-1/2 sm:-translate-x-1/2 sm:bottom-6 z-50 animate-in slide-in-from-bottom-4 fade-in duration-200">
+      <div className="flex flex-wrap items-center gap-1.5 sm:gap-2 rounded-xl border border-border bg-card shadow-xl px-3 py-2 sm:px-4">
+        <span className="text-sm font-medium text-foreground pr-1 sm:pr-2 whitespace-nowrap">
+          {count} selected
+          {heldCount > 0 && (
+            <span className="text-muted-foreground font-normal"> · {heldCount} held</span>
+          )}
+        </span>
+
+        <div className="h-5 w-px bg-border hidden sm:block" />
+
+        <Button size="sm" className="h-8" onClick={onAssign} disabled={busy}>
+          {busy ? <Loader2 className="w-4 h-4 mr-1.5 animate-spin" /> : <UserPlus className="w-4 h-4 mr-1.5" />}
+          {assignLabel}
+        </Button>
+
+        <Button variant="outline" size="sm" className="h-8" onClick={onReturnToHeld} disabled={busy}>
+          <Undo2 className="w-4 h-4 mr-1.5" />
+          Return to held
+        </Button>
+
+        {onExportCSV && (
+          <Button variant="outline" size="sm" className="h-8" onClick={onExportCSV} disabled={busy}>
+            <FileSpreadsheet className="w-4 h-4 mr-1.5" />
+            CSV
+          </Button>
+        )}
+        {onExportPDF && (
+          <Button variant="outline" size="sm" className="h-8" onClick={onExportPDF} disabled={busy}>
+            <FileText className="w-4 h-4 mr-1.5" />
+            PDF
+          </Button>
+        )}
+
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 text-destructive border-destructive/30 hover:bg-destructive/10 hover:text-destructive"
+          onClick={onDelete}
+          disabled={busy}
+        >
+          <Trash2 className="w-4 h-4 mr-1.5" />
+          Delete
+        </Button>
+
+        <div className="h-5 w-px bg-border hidden sm:block" />
+
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground"
+          onClick={onClear}
+          disabled={busy}
+          aria-label="Clear selection (Esc)"
+          title="Clear selection (Esc)"
+        >
+          <X className="w-4 h-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/bulk/BulkAssignDialog.jsx
+++ b/src/components/bulk/BulkAssignDialog.jsx
@@ -1,0 +1,156 @@
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { User as UserEntity } from '@/api/entities';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Search, UserPlus, Loader2, Check } from 'lucide-react';
+import { isFencedHold, isReleasableHold, holdReasonLabel } from '@/constants/holdReasons';
+
+/**
+ * Bulk "Assign to agent…" dialog: searchable agent picker + a pre-commit
+ * eligibility preview computed from the selected row snapshots, so the admin
+ * sees what the server will actually do (fenced holds are skipped, rows already
+ * with the chosen agent are no-ops, releasable holds deliver + deduct) BEFORE
+ * confirming. The server's response is still the source of truth — the caller
+ * toasts the real counts.
+ */
+export default function BulkAssignDialog({ open, onOpenChange, selectedRows, busy, onConfirm }) {
+  const [search, setSearch] = useState('');
+  const [agentId, setAgentId] = useState(null);
+
+  const { data: agents = [], isLoading: agentsLoading } = useQuery({
+    queryKey: ['users', 'agents'],
+    queryFn: () => UserEntity.getAgents(),
+    enabled: open,
+    staleTime: 60_000,
+  });
+
+  const filteredAgents = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    if (!needle) return agents;
+    return agents.filter((a) => {
+      const name = [a.firstName, a.lastName, a.fullName, a.full_name].filter(Boolean).join(' ').toLowerCase();
+      return name.includes(needle) || (a.email || '').toLowerCase().includes(needle);
+    });
+  }, [agents, search]);
+
+  const preview = useMemo(() => {
+    const fenced = selectedRows.filter(isFencedHold);
+    const releasable = selectedRows.filter(isReleasableHold);
+    const alreadyWithTarget = agentId
+      ? selectedRows.filter((r) => !r.quarantinedAt && (r.assigned_agent_id || r.assignedAgentId) === agentId)
+      : [];
+    const willAssign = selectedRows.length - fenced.length - alreadyWithTarget.length;
+    return { fenced, releasable, alreadyWithTarget, willAssign };
+  }, [selectedRows, agentId]);
+
+  const agentName = (a) =>
+    [a.firstName, a.lastName].filter(Boolean).join(' ') || a.fullName || a.full_name || a.email || 'Agent';
+
+  const handleConfirm = () => {
+    if (!agentId || preview.willAssign <= 0) return;
+    onConfirm(agentId);
+  };
+
+  const handleOpenChange = (next) => {
+    if (!next) {
+      setSearch('');
+      setAgentId(null);
+    }
+    onOpenChange(next);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Assign {selectedRows.length} lead{selectedRows.length === 1 ? '' : 's'}</DialogTitle>
+          <DialogDescription>
+            The agent is notified once and each lead is delivered to their app. Held leads in the
+            selection are released as part of the assignment.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+          <Input
+            placeholder="Search agents by name or email…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+            autoFocus
+          />
+        </div>
+
+        <div className="max-h-56 overflow-y-auto rounded-md border border-border divide-y divide-border">
+          {agentsLoading ? (
+            <div className="flex items-center justify-center gap-2 p-4 text-sm text-muted-foreground">
+              <Loader2 className="w-4 h-4 animate-spin" /> Loading agents…
+            </div>
+          ) : filteredAgents.length === 0 ? (
+            <div className="p-4 text-sm text-muted-foreground text-center">No agents match.</div>
+          ) : (
+            filteredAgents.map((a) => (
+              <button
+                key={a.id}
+                type="button"
+                onClick={() => setAgentId(a.id)}
+                className={`w-full flex items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-muted/50 ${
+                  agentId === a.id ? 'bg-primary/5' : ''
+                }`}
+              >
+                <div className="w-7 h-7 rounded-full bg-primary/10 text-primary flex items-center justify-center text-xs font-semibold uppercase shrink-0">
+                  {agentName(a).charAt(0)}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-medium text-foreground truncate">{agentName(a)}</div>
+                  {a.email && <div className="text-xs text-muted-foreground truncate">{a.email}</div>}
+                </div>
+                {agentId === a.id && <Check className="w-4 h-4 text-primary shrink-0" />}
+              </button>
+            ))
+          )}
+        </div>
+
+        {/* Eligibility preview — what the server will do with this selection. */}
+        <div className="text-sm text-muted-foreground space-y-1">
+          <div>
+            <span className="font-medium text-foreground">{Math.max(preview.willAssign, 0)}</span> will be
+            assigned
+            {preview.releasable.length > 0 && (
+              <> ({preview.releasable.length} released from held — delivery + credit deduction)</>
+            )}
+            .
+          </div>
+          {preview.alreadyWithTarget.length > 0 && (
+            <div>{preview.alreadyWithTarget.length} already with this agent — skipped, no double charge.</div>
+          )}
+          {preview.fenced.length > 0 && (
+            <div>
+              {preview.fenced.length} held lead{preview.fenced.length === 1 ? '' : 's'} will be skipped:{' '}
+              {[...new Set(preview.fenced.map((r) => holdReasonLabel(r.quarantineReason)))].join('; ')}.
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={busy}>
+            Cancel
+          </Button>
+          <Button onClick={handleConfirm} disabled={!agentId || preview.willAssign <= 0 || busy}>
+            {busy ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <UserPlus className="w-4 h-4 mr-2" />}
+            Assign {Math.max(preview.willAssign, 0)}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/prospects/ProspectFilters.jsx
+++ b/src/components/prospects/ProspectFilters.jsx
@@ -60,6 +60,23 @@ export default function ProspectFilters({ filters, onFilterChange, campaigns }) 
  <SelectItem value="other">Other</SelectItem>
  </SelectContent>
  </Select>
+
+ {/* Assignment state: Held = the pending pool (returned / quota-held leads
+ awaiting reassignment); Unassigned = strays with no agent and no hold. */}
+ <Select
+ value={filters.assignment || 'all'}
+ onValueChange={(value) => handleFilterChange('assignment', value)}
+ >
+ <SelectTrigger className="w-36">
+ <SelectValue placeholder="Assignment"/>
+ </SelectTrigger>
+ <SelectContent>
+ <SelectItem value="all">All Leads</SelectItem>
+ <SelectItem value="assigned">Assigned</SelectItem>
+ <SelectItem value="unassigned">Unassigned</SelectItem>
+ <SelectItem value="held">Held</SelectItem>
+ </SelectContent>
+ </Select>
  </div>
  );
 }

--- a/src/constants/holdReasons.js
+++ b/src/constants/holdReasons.js
@@ -1,0 +1,29 @@
+/**
+ * Prospect quarantine (hold) reasons — UI mirror of the backend's fences
+ * (backend/src/services/prospectService.js RELEASABLE_HOLD_REASONS).
+ *
+ * Releasable holds can be released by a manual admin (bulk) assign; fenced
+ * holds are skipped server-side (DNC gate, external buyer pool) and the UI
+ * previews them as "will be skipped" before the request is sent.
+ */
+export const RELEASABLE_HOLD_REASONS = ['no_funded_agent', 'returned_by_admin'];
+
+export const HOLD_REASON_LABELS = {
+  returned_by_admin: 'Returned by admin — pending reassignment',
+  no_funded_agent: 'No funded agent at capture',
+  no_funded_external_buyer: 'External buyer pool (dispatch via MKTR Leads app)',
+  dnc_pending: 'DNC check pending — releases automatically',
+  dnc_registered: 'On the DNC register — cannot be assigned',
+};
+
+export function holdReasonLabel(reason) {
+  return HOLD_REASON_LABELS[reason] || 'Held';
+}
+
+export function isReleasableHold(prospect) {
+  return Boolean(prospect?.quarantinedAt) && RELEASABLE_HOLD_REASONS.includes(prospect?.quarantineReason);
+}
+
+export function isFencedHold(prospect) {
+  return Boolean(prospect?.quarantinedAt) && !RELEASABLE_HOLD_REASONS.includes(prospect?.quarantineReason);
+}

--- a/src/hooks/__tests__/useRowSelection.test.js
+++ b/src/hooks/__tests__/useRowSelection.test.js
@@ -1,0 +1,74 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import useRowSelection from '../useRowSelection';
+
+const rows = [
+  { id: 'a', name: 'A' },
+  { id: 'b', name: 'B' },
+  { id: 'c', name: 'C' },
+  { id: 'd', name: 'D' },
+];
+
+describe('useRowSelection', () => {
+  it('toggles single rows and exposes snapshots', () => {
+    const { result } = renderHook(() => useRowSelection(rows));
+    act(() => result.current.toggleRow(rows[1]));
+    expect(result.current.count).toBe(1);
+    expect(result.current.isSelected('b')).toBe(true);
+    expect(result.current.selectedRows).toEqual([rows[1]]);
+    act(() => result.current.toggleRow(rows[1]));
+    expect(result.current.count).toBe(0);
+  });
+
+  it('shift-click selects the inclusive range from the anchor', () => {
+    const { result } = renderHook(() => useRowSelection(rows));
+    act(() => result.current.toggleRow(rows[0]));
+    act(() => result.current.toggleRow(rows[2], { shiftKey: true }));
+    expect(result.current.selectedIds.sort()).toEqual(['a', 'b', 'c']);
+    // Reverse direction works too.
+    act(() => result.current.toggleRow(rows[3]));
+    act(() => result.current.toggleRow(rows[1], { shiftKey: true }));
+    expect(result.current.selectedIds.sort()).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('select-all is page-additive and deselect-all page-subtractive (other pages untouched)', () => {
+    const page1 = rows.slice(0, 2);
+    const page2 = rows.slice(2);
+    const { result, rerender } = renderHook(({ r }) => useRowSelection(r), { initialProps: { r: page1 } });
+
+    act(() => result.current.toggleAllVisible());
+    expect(result.current.selectedIds.sort()).toEqual(['a', 'b']);
+
+    // Page turn: selection survives; select-all on page 2 ADDS.
+    rerender({ r: page2 });
+    expect(result.current.count).toBe(2);
+    expect(result.current.allVisibleSelected).toBe(false);
+    act(() => result.current.toggleAllVisible());
+    expect(result.current.selectedIds.sort()).toEqual(['a', 'b', 'c', 'd']);
+
+    // Deselect-all on page 2 removes only page 2 rows.
+    act(() => result.current.toggleAllVisible());
+    expect(result.current.selectedIds.sort()).toEqual(['a', 'b']);
+  });
+
+  it('header state distinguishes all / some / none of the visible rows', () => {
+    const { result } = renderHook(() => useRowSelection(rows));
+    expect(result.current.allVisibleSelected).toBe(false);
+    expect(result.current.someVisibleSelected).toBe(false);
+    act(() => result.current.toggleRow(rows[0]));
+    expect(result.current.someVisibleSelected).toBe(true);
+    act(() => result.current.toggleAllVisible());
+    expect(result.current.allVisibleSelected).toBe(true);
+    expect(result.current.someVisibleSelected).toBe(false);
+  });
+
+  it('clear empties the selection and drops the shift anchor', () => {
+    const { result } = renderHook(() => useRowSelection(rows));
+    act(() => result.current.toggleRow(rows[0]));
+    act(() => result.current.clear());
+    expect(result.current.count).toBe(0);
+    // No anchor → shift-click behaves like a plain toggle.
+    act(() => result.current.toggleRow(rows[2], { shiftKey: true }));
+    expect(result.current.selectedIds).toEqual(['c']);
+  });
+});

--- a/src/hooks/queries/useProspectsQuery.js
+++ b/src/hooks/queries/useProspectsQuery.js
@@ -54,3 +54,19 @@ export function useBulkAssignProspects() {
  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['prospects'] }),
  });
 }
+
+export function useBulkReturnProspects() {
+ const queryClient = useQueryClient();
+ return useMutation({
+ mutationFn: ({ prospectIds }) => prospectService.bulkReturnProspectsToHeld(prospectIds),
+ onSuccess: () => queryClient.invalidateQueries({ queryKey: ['prospects'] }),
+ });
+}
+
+export function useBulkDeleteProspects() {
+ const queryClient = useQueryClient();
+ return useMutation({
+ mutationFn: ({ prospectIds }) => prospectService.bulkDeleteProspects(prospectIds),
+ onSuccess: () => queryClient.invalidateQueries({ queryKey: ['prospects'] }),
+ });
+}

--- a/src/hooks/useRowSelection.js
+++ b/src/hooks/useRowSelection.js
@@ -1,0 +1,81 @@
+import { useCallback, useRef, useState } from 'react';
+
+/**
+ * Map-based row selection for paginated admin tables.
+ *
+ * Selection is a Map<id, rowSnapshot> — snapshots (not bare ids) so cross-page
+ * selections keep working for exports and eligibility previews after the page
+ * of origin has unmounted. Selection survives page turns; the OWNING page must
+ * call `clear()` synchronously in its filter/search handlers (an effect watching
+ * query params would let keepPreviousData's stale rows be selected under a new
+ * filter, and would also wipe selection on every page turn).
+ *
+ * `toggleRow(row, { shiftKey })` supports shift-click range selection anchored
+ * on the last explicitly toggled row of the CURRENT page (`rows`).
+ */
+export default function useRowSelection(rows = []) {
+  const [selected, setSelected] = useState(() => new Map());
+  const anchorIdRef = useRef(null);
+
+  const isSelected = useCallback((id) => selected.has(id), [selected]);
+
+  const clear = useCallback(() => {
+    anchorIdRef.current = null;
+    setSelected((prev) => (prev.size === 0 ? prev : new Map()));
+  }, []);
+
+  const toggleRow = useCallback(
+    (row, { shiftKey = false } = {}) => {
+      if (!row?.id) return;
+      setSelected((prev) => {
+        const next = new Map(prev);
+        const anchorIdx = shiftKey && anchorIdRef.current ? rows.findIndex((r) => r.id === anchorIdRef.current) : -1;
+        const clickIdx = rows.findIndex((r) => r.id === row.id);
+
+        if (anchorIdx !== -1 && clickIdx !== -1) {
+          // Shift-range: select everything between the anchor and the clicked row
+          // (inclusive). Always ADDS — a ranged deselect is more surprising than
+          // useful, and a plain click still toggles one row off.
+          const [from, to] = anchorIdx < clickIdx ? [anchorIdx, clickIdx] : [clickIdx, anchorIdx];
+          for (let i = from; i <= to; i++) next.set(rows[i].id, rows[i]);
+        } else if (next.has(row.id)) {
+          next.delete(row.id);
+        } else {
+          next.set(row.id, row);
+        }
+        anchorIdRef.current = row.id;
+        return next;
+      });
+    },
+    [rows]
+  );
+
+  // Header checkbox: page-additive select-all / page-subtractive deselect-all —
+  // never touches rows selected on OTHER pages.
+  const allVisibleSelected = rows.length > 0 && rows.every((r) => selected.has(r.id));
+  const someVisibleSelected = !allVisibleSelected && rows.some((r) => selected.has(r.id));
+
+  const toggleAllVisible = useCallback(() => {
+    setSelected((prev) => {
+      const next = new Map(prev);
+      const everyVisible = rows.length > 0 && rows.every((r) => next.has(r.id));
+      if (everyVisible) for (const r of rows) next.delete(r.id);
+      else for (const r of rows) next.set(r.id, r);
+      return next;
+    });
+    anchorIdRef.current = null;
+  }, [rows]);
+
+  return {
+    selected,
+    selectedRows: [...selected.values()],
+    selectedIds: [...selected.keys()],
+    count: selected.size,
+    isSelected,
+    toggleRow,
+    toggleAllVisible,
+    allVisibleSelected,
+    someVisibleSelected,
+    clear,
+  };
+}

--- a/src/pages/AdminAgentDetail.jsx
+++ b/src/pages/AdminAgentDetail.jsx
@@ -1,12 +1,18 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { User, Prospect } from '@/api/entities';
 import { useCampaignLookup } from '@/hooks/queries/useCampaignsQuery';
+import { useBulkAssignProspects, useBulkReturnProspects, useBulkDeleteProspects } from '@/hooks/queries/useProspectsQuery';
+import useRowSelection from '@/hooks/useRowSelection';
+import BulkActionBar from '@/components/bulk/BulkActionBar';
+import BulkAssignDialog from '@/components/bulk/BulkAssignDialog';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import {
@@ -19,6 +25,7 @@ import {
  Mail,
  Calendar,
  Loader2,
+ Trash2,
 } from 'lucide-react';
 import { format } from 'date-fns';
 import ProspectDetails from '@/components/prospects/ProspectDetails';
@@ -31,6 +38,13 @@ export default function AdminAgentDetail() {
  const { agentId } = useParams();
  const queryClient = useQueryClient();
  const [selectedProspect, setSelectedProspect] = useState(null);
+ const [bulkAssignOpen, setBulkAssignOpen] = useState(false);
+ const [bulkReturnOpen, setBulkReturnOpen] = useState(false);
+ const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
+
+ const bulkAssignMutation = useBulkAssignProspects();
+ const bulkReturnMutation = useBulkReturnProspects();
+ const bulkDeleteMutation = useBulkDeleteProspects();
 
  const [pagination, setPagination] = useState({
  page: 1,
@@ -90,8 +104,69 @@ export default function AdminAgentDetail() {
 
  const loading = prospectsLoading;
 
+ // Row selection for bulk ops — survives page turns; cleared synchronously when
+ // filters change (see applyFilterChange below).
+ const selection = useRowSelection(prospects);
+
  const handlePageChange = (newPage) => {
  setPagination((prev) => ({ ...prev, page: newPage }));
+ };
+
+ // Filter/search changes reset to page 1 (the query key reads pagination.page —
+ // a `page` key inside filters was dead state) and clear the selection.
+ const applyFilterChange = useCallback((patch) => {
+ selection.clear();
+ setPagination((prev) => ({ ...prev, page: 1 }));
+ setFilters((prev) => ({ ...prev, ...patch }));
+ // eslint-disable-next-line react-hooks/exhaustive-deps
+ }, [selection.clear]);
+
+ const previewNames = (rows, max = 5) => {
+ const names = rows.slice(0, max).map((r) => r.name || 'Unnamed');
+ const extra = rows.length - names.length;
+ return extra > 0 ? `${names.join(', ')} and ${extra} more` : names.join(', ');
+ };
+
+ const bulkBusy = bulkAssignMutation.isPending || bulkReturnMutation.isPending || bulkDeleteMutation.isPending;
+
+ const handleBulkAssign = async (targetAgentId) => {
+ try {
+ const res = await bulkAssignMutation.mutateAsync({ prospectIds: selection.selectedIds, agentId: targetAgentId });
+ const skippedTotal = res?.skipped ? Object.values(res.skipped).reduce((a, b) => a + b, 0) : 0;
+ const parts = [`${res?.affectedCount ?? 0} reassigned`];
+ if (skippedTotal > 0) parts.push(`${skippedTotal} skipped`);
+ toast.success(parts.join(' · '));
+ setBulkAssignOpen(false);
+ selection.clear();
+ } catch (error) {
+ toast.error(error?.message || 'Bulk reassign failed');
+ }
+ };
+
+ const handleBulkReturn = async () => {
+ try {
+ const res = await bulkReturnMutation.mutateAsync({ prospectIds: selection.selectedIds });
+ const moved = (res?.returned ?? 0) + (res?.promoted ?? 0);
+ if (res?.undeliverable > 0) {
+ toast.warning(`${res.undeliverable} could not be returned — lead delivery is not configured for the owning app.`);
+ }
+ toast.success(`${moved} returned to held`);
+ setBulkReturnOpen(false);
+ selection.clear();
+ } catch (error) {
+ toast.error(error?.message || 'Return to held failed');
+ }
+ };
+
+ const handleBulkDelete = async () => {
+ try {
+ const res = await bulkDeleteMutation.mutateAsync({ prospectIds: selection.selectedIds });
+ toast.success(`${res?.deleted ?? 0} deleted`);
+ setBulkDeleteOpen(false);
+ selection.clear();
+ } catch (error) {
+ toast.error(error?.message || 'Bulk delete failed');
+ }
  };
 
  const handleStatusUpdate = async (prospectId, newStatus) => {
@@ -173,13 +248,13 @@ export default function AdminAgentDetail() {
  <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground"/>
  <Input
  placeholder="Search leads..." className="pl-9" value={filters.search}
- onChange={(e) => setFilters((prev) => ({ ...prev, search: e.target.value, page: 1 }))} // Reset to page 1 on search
+ onChange={(e) => applyFilterChange({ search: e.target.value })}
  />
  </div>
  <div className="flex items-center gap-2 w-full sm:w-auto">
  <Select
  value={filters.status}
- onValueChange={(val) => setFilters((prev) => ({ ...prev, status: val, page: 1 }))}
+ onValueChange={(val) => applyFilterChange({ status: val })}
  >
  <SelectTrigger className="w-[180px]">
  <SelectValue placeholder="Status"/>
@@ -201,6 +276,12 @@ export default function AdminAgentDetail() {
  <Table>
  <TableHeader>
  <TableRow className="bg-muted/50 hover:bg-muted/50 border-border">
+ <TableHead className="py-3 pl-6 pr-2 w-[44px]">
+ <Checkbox
+ checked={selection.allVisibleSelected ? true : selection.someVisibleSelected ? 'indeterminate' : false}
+ onCheckedChange={selection.toggleAllVisible}
+ aria-label="Select all leads on this page" />
+ </TableHead>
  <TableHead className="py-3 px-6">Prospect</TableHead>
  <TableHead className="py-3 px-6">Campaign</TableHead>
  <TableHead className="py-3 px-6">Status</TableHead>
@@ -211,7 +292,7 @@ export default function AdminAgentDetail() {
  <TableBody>
  {loading ? (
  <TableRow>
- <TableCell colSpan={5} className="h-24 text-center">
+ <TableCell colSpan={6} className="h-24 text-center">
  <div className="flex justify-center items-center gap-2 text-muted-foreground">
  <Loader2 className="w-4 h-4 animate-spin"/> Loading...
  </div>
@@ -219,7 +300,7 @@ export default function AdminAgentDetail() {
  </TableRow>
  ) : prospects.length === 0 ? (
  <TableRow>
- <TableCell colSpan={5} className="h-32 text-center text-muted-foreground">
+ <TableCell colSpan={6} className="h-32 text-center text-muted-foreground">
  No prospects found for this agent.
  </TableCell>
  </TableRow>
@@ -227,8 +308,14 @@ export default function AdminAgentDetail() {
  prospects.map((prospect) => (
  <TableRow
  key={prospect.id}
- className="hover:bg-muted/50 cursor-pointer group" onClick={() => setSelectedProspect(prospect)}
+ className={`hover:bg-muted/50 cursor-pointer group ${selection.isSelected(prospect.id) ? 'bg-primary/5' : ''}`} onClick={() => setSelectedProspect(prospect)}
  >
+ <TableCell className="pl-6 pr-2" onClick={(e) => e.stopPropagation()}>
+ <Checkbox
+ checked={selection.isSelected(prospect.id)}
+ onClick={(e) => { e.preventDefault(); selection.toggleRow(prospect, { shiftKey: e.shiftKey }); }}
+ aria-label={`Select ${prospect.name}`} />
+ </TableCell>
  <TableCell className="px-6 py-4">
  <div className="flex items-center gap-3">
  <div className="w-8 h-8 rounded-full bg-primary/10 text-primary flex items-center justify-center text-xs font-bold uppercase">
@@ -313,6 +400,53 @@ export default function AdminAgentDetail() {
  )}
  </DialogContent>
  </Dialog>
+
+ {/* ── Bulk selection actions ─────────────────────────────── */}
+ <BulkActionBar
+ count={selection.count}
+ busy={bulkBusy}
+ assignLabel="Reassign to…" onAssign={() => setBulkAssignOpen(true)}
+ onReturnToHeld={() => setBulkReturnOpen(true)}
+ onDelete={() => setBulkDeleteOpen(true)}
+ onClear={selection.clear}
+ />
+
+ <BulkAssignDialog
+ open={bulkAssignOpen}
+ onOpenChange={setBulkAssignOpen}
+ selectedRows={selection.selectedRows}
+ busy={bulkAssignMutation.isPending}
+ onConfirm={handleBulkAssign}
+ />
+
+ <ConfirmDialog
+ open={bulkReturnOpen}
+ onOpenChange={setBulkReturnOpen}
+ title={`Return ${selection.count} lead${selection.count === 1 ? '' : 's'} to the held queue?`}
+ description={
+ <>
+ <span className="font-medium">{previewNames(selection.selectedRows)}</span>
+ {' '}will be pulled back from {agent?.firstName || 'this agent'} and moved to the Held
+ queue, pending reassignment. The agent loses access; credits are not refunded.
+ </>
+ }
+ confirmText="Return to held" onConfirm={handleBulkReturn}
+ />
+
+ <ConfirmDialog
+ open={bulkDeleteOpen}
+ onOpenChange={setBulkDeleteOpen}
+ title={`Delete ${selection.count} prospect${selection.count === 1 ? '' : 's'}?`}
+ description={
+ <>
+ <span className="font-medium">{previewNames(selection.selectedRows)}</span>
+ {' '}will be permanently deleted from MKTR. This can't be undone.
+ </>
+ }
+ confirmText="Delete" destructive
+ confirmIcon={<Trash2 className="w-4 h-4"/>}
+ onConfirm={handleBulkDelete}
+ />
  </div>
  </div>
  );

--- a/src/pages/AdminProspects.jsx
+++ b/src/pages/AdminProspects.jsx
@@ -1,9 +1,19 @@
-import { useState, useEffect, useMemo } from"react";
+import { useState, useEffect, useMemo, useCallback } from"react";
 import { useQuery, useQueryClient, keepPreviousData } from"@tanstack/react-query";
 import { Prospect } from"@/api/entities";
 import { useCurrentUser } from"@/hooks/queries/useUsersQuery";
-import { useUpdateProspect, useDeleteProspect } from"@/hooks/queries/useProspectsQuery";
+import {
+ useUpdateProspect,
+ useDeleteProspect,
+ useBulkAssignProspects,
+ useBulkReturnProspects,
+ useBulkDeleteProspects,
+} from"@/hooks/queries/useProspectsQuery";
 import { useCampaignLookup } from"@/hooks/queries/useCampaignsQuery";
+import useRowSelection from"@/hooks/useRowSelection";
+import BulkActionBar from"@/components/bulk/BulkActionBar";
+import BulkAssignDialog from"@/components/bulk/BulkAssignDialog";
+import { holdReasonLabel } from"@/constants/holdReasons";
 import { Card, CardContent, CardHeader } from"@/components/ui/card";
 import { Button } from"@/components/ui/button";
 import { Input } from"@/components/ui/input";
@@ -23,8 +33,7 @@ import {
  FileSpreadsheet,
  FileText,
  Trash2,
- User,
- X
+ User
 } from"lucide-react";
 import { Checkbox } from"@/components/ui/checkbox";
 import { toast } from"sonner";
@@ -103,31 +112,27 @@ export default function AdminProspects() {
  const { data: user } = useCurrentUser();
  const updateProspectMutation = useUpdateProspect();
  const deleteProspectMutation = useDeleteProspect();
+ const bulkAssignMutation = useBulkAssignProspects();
+ const bulkReturnMutation = useBulkReturnProspects();
+ const bulkDeleteMutation = useBulkDeleteProspects();
 
  const [selectedProspect, setSelectedProspect] = useState(null);
  const [deleteConfirm, setDeleteConfirm] = useState(null);
+ const [bulkAssignOpen, setBulkAssignOpen] = useState(false);
+ const [bulkReturnOpen, setBulkReturnOpen] = useState(false);
+ const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
  const [filters, setFilters] = useState(() => {
  const params = new URLSearchParams(window.location.search);
  return {
  search:"", status:"all",
  campaign: params.get('campaign') ||"all",
  qrTagId: params.get('qrTagId') ||"all",
- source:"all" };
+ source:"all",
+ assignment:"all" };
  });
  const [currentPage, setCurrentPage] = useState(1);
  const [itemsPerPage, setItemsPerPage] = useState(25);
- const [selectedIds, setSelectedIds] = useState(() => new Set());
  const isMobile = useIsMobile();
-
- useEffect(() => {
- const params = new URLSearchParams(location.search);
- const campaignId = params.get('campaign') ||"all";
- const qrTagId = params.get('qrTagId') ||"all";
- setFilters(prev => {
- if (prev.campaign === campaignId && prev.qrTagId === qrTagId) return prev;
- return { ...prev, campaign: campaignId, qrTagId: qrTagId };
- });
- }, [location.search]);
 
  // Debounce the free-text search so we issue one server query after the user
  // pauses typing, not one per keystroke. The input stays bound to
@@ -145,15 +150,16 @@ export default function AdminProspects() {
  if (filters.status !=="all") params.leadStatus = filters.status;
  if (filters.campaign !=="all") params.campaignId = filters.campaign;
  if (filters.qrTagId !=="all") params.qrTagId = filters.qrTagId;
+ if (filters.assignment !=="all") params.assignment = filters.assignment;
  if (filters.source !=="all") {
  if (filters.source ==="qr") params.leadSource ="qr_code";
  else if (filters.source ==="form") params.leadSource ="website";
  else params.leadSource = filters.source;
  }
  return params;
- }, [debouncedSearch, filters.status, filters.campaign, filters.qrTagId, filters.source, currentPage, itemsPerPage]);
+ }, [debouncedSearch, filters.status, filters.campaign, filters.qrTagId, filters.source, filters.assignment, currentPage, itemsPerPage]);
 
- const { data: prospectsResponse, isLoading: prospectsLoading } = useQuery({
+ const { data: prospectsResponse, isLoading: prospectsLoading, isPlaceholderData } = useQuery({
  queryKey: ['prospects', 'list', queryParams],
  queryFn: () => Prospect.list(queryParams),
  // Keep the previous page's rows rendered while the next query loads so a
@@ -173,32 +179,102 @@ export default function AdminProspects() {
  currentPage, totalPages: 1, totalItems: prospects.length, itemsPerPage
  };
 
- // Clear row selection whenever the visible set changes (page / filters / page size).
- useEffect(() => { setSelectedIds(new Set()); }, [queryParams]);
+ // Row selection survives page turns (Map of row snapshots, so exports and the
+ // assign preview keep working across pages). It is cleared SYNCHRONOUSLY in the
+ // filter/search handlers below — an effect watching queryParams would wipe it on
+ // every page turn and let keepPreviousData's stale rows be selected under a new
+ // filter.
+ const selection = useRowSelection(prospects);
+
+ // Any filter/search change redefines the working set — clear the selection in the
+ // same event, then apply the filter. Page turns intentionally do NOT clear.
+ const applyFilters = useCallback((next) => {
+ selection.clear();
+ setCurrentPage(1);
+ setFilters(next);
+ // eslint-disable-next-line react-hooks/exhaustive-deps
+ }, [selection.clear]);
+
+ useEffect(() => {
+ const params = new URLSearchParams(location.search);
+ const campaignId = params.get('campaign') ||"all";
+ const qrTagId = params.get('qrTagId') ||"all";
+ setFilters(prev => {
+ if (prev.campaign === campaignId && prev.qrTagId === qrTagId) return prev;
+ selection.clear();
+ setCurrentPage(1);
+ return { ...prev, campaign: campaignId, qrTagId: qrTagId };
+ });
+ // eslint-disable-next-line react-hooks/exhaustive-deps
+ }, [location.search]);
 
  const exportRows = useMemo(
- () => (selectedIds.size > 0 ? prospects.filter((p) => selectedIds.has(p.id)) : prospects),
- [prospects, selectedIds]
+ () => (selection.count > 0 ? selection.selectedRows : prospects),
+ // eslint-disable-next-line react-hooks/exhaustive-deps
+ [prospects, selection.selected]
  );
- const allSelected = prospects.length > 0 && prospects.every((p) => selectedIds.has(p.id));
- const someSelected = selectedIds.size > 0 && !allSelected;
-
- const toggleSelectAll = () => {
- setSelectedIds((prev) => {
- const everyVisibleSelected = prospects.length > 0 && prospects.every((p) => prev.has(p.id));
- return everyVisibleSelected ? new Set() : new Set(prospects.map((p) => p.id));
- });
- };
- const toggleSelectOne = (id) => {
- setSelectedIds((prev) => {
- const next = new Set(prev);
- if (next.has(id)) next.delete(id); else next.add(id);
- return next;
- });
- };
- const clearSelection = () => setSelectedIds(new Set());
+ const heldSelectedCount = useMemo(
+ () => selection.selectedRows.filter((r) => r.quarantinedAt).length,
+ // eslint-disable-next-line react-hooks/exhaustive-deps
+ [selection.selected]
+ );
+ const bulkBusy = bulkAssignMutation.isPending || bulkReturnMutation.isPending || bulkDeleteMutation.isPending;
 
  const handleRefresh = () => queryClient.invalidateQueries({ queryKey: ['prospects'] });
+
+ // Up-to-five-name preview for the bulk confirm dialogs.
+ const previewNames = (rows, max = 5) => {
+ const names = rows.slice(0, max).map((r) => r.name || 'Unnamed');
+ const extra = rows.length - names.length;
+ return extra > 0 ? `${names.join(', ')} and ${extra} more` : names.join(', ');
+ };
+
+ const handleBulkAssign = async (agentId) => {
+ try {
+ const res = await bulkAssignMutation.mutateAsync({ prospectIds: selection.selectedIds, agentId });
+ const skippedTotal = res?.skipped ? Object.values(res.skipped).reduce((a, b) => a + b, 0) : 0;
+ const parts = [`${res?.affectedCount ?? 0} assigned`];
+ if (res?.releasedCount > 0) parts.push(`${res.releasedCount} released from held`);
+ if (skippedTotal > 0) parts.push(`${skippedTotal} skipped`);
+ toast.success(parts.join(' · '));
+ setBulkAssignOpen(false);
+ selection.clear();
+ } catch (error) {
+ toast.error(error?.message || 'Bulk assign failed');
+ }
+ };
+
+ const handleBulkReturn = async () => {
+ try {
+ const res = await bulkReturnMutation.mutateAsync({ prospectIds: selection.selectedIds });
+ const moved = (res?.returned ?? 0) + (res?.promoted ?? 0);
+ const parts = [`${moved} returned to held`];
+ if (res?.alreadyHeld > 0) parts.push(`${res.alreadyHeld} already held`);
+ if (res?.notFound > 0) parts.push(`${res.notFound} not found`);
+ if (res?.undeliverable > 0) {
+ toast.warning(`${res.undeliverable} could not be returned — lead delivery is not configured for the owning app.`);
+ }
+ toast.success(parts.join(' · '));
+ setBulkReturnOpen(false);
+ selection.clear();
+ } catch (error) {
+ toast.error(error?.message || 'Return to held failed');
+ }
+ };
+
+ const handleBulkDelete = async () => {
+ try {
+ const res = await bulkDeleteMutation.mutateAsync({ prospectIds: selection.selectedIds });
+ const parts = [`${res?.deleted ?? 0} deleted`];
+ if (res?.notFound > 0) parts.push(`${res.notFound} not found`);
+ if (res?.failed > 0) parts.push(`${res.failed} failed`);
+ toast.success(parts.join(' · '));
+ setBulkDeleteOpen(false);
+ selection.clear();
+ } catch (error) {
+ toast.error(error?.message || 'Bulk delete failed');
+ }
+ };
 
  const handleStatusUpdate = async (prospectId, newStatus) => {
  try {
@@ -214,9 +290,10 @@ export default function AdminProspects() {
  } catch (error) { console.error('Error deleting prospect:', error); }
  };
 
- // Exports act on the current selection if any rows are ticked, otherwise the whole visible page.
+ // Exports act on the current selection if any rows are ticked (across pages),
+ // otherwise the whole visible page.
  const exportFileName = (ext) =>
- `prospects_${format(new Date(), 'ddMMyyyy_HHmm')}${selectedIds.size > 0 ? '_selected' : ''}.${ext}`;
+ `prospects_${format(new Date(), 'ddMMyyyy_HHmm')}${selection.count > 0 ? '_selected' : ''}.${ext}`;
 
  const fmtDob = (v) => {
  if (!v) return '';
@@ -267,7 +344,7 @@ export default function AdminProspects() {
  const autoTable = autoTableModule.default;
  const doc = new jsPDF({ orientation: 'landscape' });
  const generatedAt = format(new Date(), 'dd MMM yyyy, h:mm a');
- const scopeLabel = selectedIds.size > 0 ? `${exportRows.length} selected` : `${exportRows.length} total`;
+ const scopeLabel = selection.count > 0 ? `${exportRows.length} selected` : `${exportRows.length} total`;
  doc.setFontSize(14);
  doc.text('Prospects Export', 14, 15);
  doc.setFontSize(9);
@@ -331,11 +408,11 @@ export default function AdminProspects() {
  <div className="flex items-center gap-2">
  <Button variant="outline" className="bg-card" onClick={exportToCSV} disabled={exportRows.length === 0}>
  <FileSpreadsheet className="w-4 h-4 mr-2"/>
- Export CSV{selectedIds.size > 0 ? ` (${selectedIds.size})` : ''}
+ Export CSV{selection.count > 0 ? ` (${selection.count})` : ''}
  </Button>
  <Button variant="outline" className="bg-card" onClick={exportToPDF} disabled={exportRows.length === 0}>
  <FileText className="w-4 h-4 mr-2"/>
- Export PDF{selectedIds.size > 0 ? ` (${selectedIds.size})` : ''}
+ Export PDF{selection.count > 0 ? ` (${selection.count})` : ''}
  </Button>
  </div>
  }
@@ -350,10 +427,10 @@ export default function AdminProspects() {
  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4"/>
  <Input
  placeholder="Search prospects..." value={filters.search}
- onChange={(e) => setFilters({ ...filters, search: e.target.value })}
+ onChange={(e) => applyFilters({ ...filters, search: e.target.value })}
  className="pl-9 h-10 bg-muted/50 border-border focus:bg-background transition-colors" />
  </div>
- <ProspectFilters filters={filters} onFilterChange={setFilters} campaigns={campaigns} />
+ <ProspectFilters filters={filters} onFilterChange={applyFilters} campaigns={campaigns} />
  </div>
  <div className="flex items-center gap-2 text-sm text-muted-foreground">
  <span className=" hidden sm:inline">Rows per page:</span>
@@ -371,19 +448,6 @@ export default function AdminProspects() {
  </CardHeader>
 
  <CardContent className="p-0">
- {selectedIds.size > 0 && (
- <div className="flex items-center justify-between gap-3 px-4 lg:px-6 py-2.5 bg-primary/5 border-b border-border">
- <span className="text-sm font-medium text-foreground">
- {selectedIds.size} selected
- </span>
- <Button
- variant="ghost" size="sm" onClick={clearSelection}
- className="h-8 text-muted-foreground hover:text-foreground">
- <X className="w-4 h-4 mr-1.5"/>
- Clear
- </Button>
- </div>
- )}
  {!isMobile ? (
  <div className="overflow-x-auto">
  <Table>
@@ -391,8 +455,9 @@ export default function AdminProspects() {
  <TableRow className="bg-muted/50 hover:bg-muted/50 border-border">
  <TableHead className="py-3 pl-6 pr-2 w-[44px]">
  <Checkbox
- checked={allSelected ? true : someSelected ?"indeterminate" : false}
- onCheckedChange={toggleSelectAll}
+ checked={selection.allVisibleSelected ? true : selection.someVisibleSelected ?"indeterminate" : false}
+ onCheckedChange={selection.toggleAllVisible}
+ disabled={isPlaceholderData}
  aria-label="Select all prospects on this page" />
  </TableHead>
  <TableHead className="py-3 px-6 font-medium text-muted-foreground">Prospect</TableHead>
@@ -409,12 +474,15 @@ export default function AdminProspects() {
  return (
  <TableRow
  key={prospect.id}
- className={`hover:bg-muted/50 transition-colors border-border group cursor-pointer ${selectedIds.has(prospect.id) ?"bg-primary/5" :""}`} onClick={() => setSelectedProspect(prospect)}
+ className={`hover:bg-muted/50 transition-colors border-border group cursor-pointer ${selection.isSelected(prospect.id) ?"bg-primary/5" :""}`} onClick={() => setSelectedProspect(prospect)}
  >
  <TableCell className="pl-6 pr-2" onClick={(e) => e.stopPropagation()}>
+ {/* onClick (not onCheckedChange) so shift-click range selection sees the
+ modifier; preventDefault stops Radix's own toggle — checked stays
+ fully controlled. Keyboard Space still fires click (shiftKey false). */}
  <Checkbox
- checked={selectedIds.has(prospect.id)}
- onCheckedChange={() => toggleSelectOne(prospect.id)}
+ checked={selection.isSelected(prospect.id)}
+ onClick={(e) => { e.preventDefault(); selection.toggleRow(prospect, { shiftKey: e.shiftKey }); }}
  aria-label={`Select ${prospect.name}`} />
  </TableCell>
  <TableCell className="px-6 py-4">
@@ -431,7 +499,12 @@ export default function AdminProspects() {
  ⚠ {prospect.repeatSignupCount} campaigns
  </span>
  )}
- {prospect.assigned_agent_name ? (
+ {prospect.quarantinedAt ? (
+ <span
+ className="block text-xs font-medium mt-0.5 text-amber-700 dark:text-amber-400" title={holdReasonLabel(prospect.quarantineReason)}>
+ Held — {holdReasonLabel(prospect.quarantineReason)}
+ </span>
+ ) : prospect.assigned_agent_name ? (
  <span className="block text-xs text-muted-foreground font-normal mt-0.5">
  Agent: {prospect.assigned_agent_name}
  </span>
@@ -494,10 +567,10 @@ export default function AdminProspects() {
  ) : prospects.map((prospect) => (
  <div
  key={prospect.id}
- className={`flex items-start gap-3 p-4 ${selectedIds.has(prospect.id) ?"bg-primary/5" :""}`}>
+ className={`flex items-start gap-3 p-4 ${selection.isSelected(prospect.id) ?"bg-primary/5" :""}`}>
  <Checkbox
- checked={selectedIds.has(prospect.id)}
- onCheckedChange={() => toggleSelectOne(prospect.id)}
+ checked={selection.isSelected(prospect.id)}
+ onClick={(e) => { e.preventDefault(); selection.toggleRow(prospect, { shiftKey: e.shiftKey }); }}
  aria-label={`Select ${prospect.name}`}
  className="mt-1.5" />
  <button
@@ -562,6 +635,58 @@ export default function AdminProspects() {
  confirmText="Delete" destructive
  confirmIcon={<Trash2 className="w-4 h-4"/>}
  onConfirm={() => deleteConfirm && handleDeleteProspect(deleteConfirm.id)}
+ />
+
+ {/* ── Bulk selection actions ─────────────────────────────── */}
+ <BulkActionBar
+ count={selection.count}
+ heldCount={heldSelectedCount}
+ busy={bulkBusy}
+ onAssign={() => setBulkAssignOpen(true)}
+ onReturnToHeld={() => setBulkReturnOpen(true)}
+ onDelete={() => setBulkDeleteOpen(true)}
+ onExportCSV={exportToCSV}
+ onExportPDF={exportToPDF}
+ onClear={selection.clear}
+ />
+
+ <BulkAssignDialog
+ open={bulkAssignOpen}
+ onOpenChange={setBulkAssignOpen}
+ selectedRows={selection.selectedRows}
+ busy={bulkAssignMutation.isPending}
+ onConfirm={handleBulkAssign}
+ />
+
+ <ConfirmDialog
+ open={bulkReturnOpen}
+ onOpenChange={setBulkReturnOpen}
+ title={`Return ${selection.count} lead${selection.count === 1 ? '' : 's'} to the held queue?`}
+ description={
+ <>
+ <span className="font-medium">{previewNames(selection.selectedRows)}</span>
+ {' '}will be pulled back from their agents and moved to the Held queue, pending
+ reassignment. The previous agents lose access; credits are not refunded. You can
+ re-assign them anytime from the Held filter.
+ </>
+ }
+ confirmText="Return to held" onConfirm={handleBulkReturn}
+ />
+
+ <ConfirmDialog
+ open={bulkDeleteOpen}
+ onOpenChange={setBulkDeleteOpen}
+ title={`Delete ${selection.count} prospect${selection.count === 1 ? '' : 's'}?`}
+ description={
+ <>
+ <span className="font-medium">{previewNames(selection.selectedRows)}</span>
+ {' '}will be permanently deleted from MKTR. This can't be undone. Copies already
+ delivered to a Lyfe agent's app are not removed by this action.
+ </>
+ }
+ confirmText="Delete" destructive
+ confirmIcon={<Trash2 className="w-4 h-4"/>}
+ onConfirm={handleBulkDelete}
  />
  </div>
  </div>

--- a/src/pages/__tests__/AdminProspects.test.jsx
+++ b/src/pages/__tests__/AdminProspects.test.jsx
@@ -28,9 +28,16 @@ vi.mock('@/hooks/queries/useUsersQuery', () => ({
  useCurrentUser: () => ({ data: { id: 'u-1', role: 'admin' } }),
 }));
 
+const mockBulkAssign = { mutateAsync: vi.fn(), isPending: false };
+const mockBulkReturn = { mutateAsync: vi.fn(), isPending: false };
+const mockBulkDelete = { mutateAsync: vi.fn(), isPending: false };
+
 vi.mock('@/hooks/queries/useProspectsQuery', () => ({
  useUpdateProspect: () => ({ mutateAsync: vi.fn() }),
  useDeleteProspect: () => ({ mutateAsync: vi.fn() }),
+ useBulkAssignProspects: () => mockBulkAssign,
+ useBulkReturnProspects: () => mockBulkReturn,
+ useBulkDeleteProspects: () => mockBulkDelete,
 }));
 
 vi.mock('@/hooks/queries/useCampaignsQuery', () => ({
@@ -39,6 +46,7 @@ vi.mock('@/hooks/queries/useCampaignsQuery', () => ({
 
 vi.mock('@/api/entities', () => ({
  Prospect: { list: vi.fn() },
+ User: { getAgents: vi.fn().mockResolvedValue([]) },
 }));
 
 vi.mock('@/hooks/use-mobile', () => ({
@@ -80,6 +88,8 @@ vi.mock('@/utils/normalizeProspect', async (importOriginal) => {
  assigned_agent_name: p.assignedAgent ? `${p.assignedAgent.firstName} ${p.assignedAgent.lastName}` : null,
  phone: p.phone || '',
  sourceMetadata: p.sourceMetadata || null,
+ quarantinedAt: p.quarantinedAt || null,
+ quarantineReason: p.quarantineReason || null,
  ad: actual.deriveAd(p.sourceMetadata),
  referral: actual.deriveReferral(p.sourceMetadata),
  }),
@@ -339,6 +349,53 @@ describe('AdminProspects', () => {
  renderProspects();
  fireEvent.click(screen.getByRole('checkbox', { name: /select john doe/i }));
  expect(screen.queryByTestId('prospect-details')).not.toBeInTheDocument();
+ });
+
+ it('selection reveals the bulk action bar (assign / return to held / delete)', () => {
+ mockProspectsData.prospects = twoProspects;
+ renderProspects();
+ fireEvent.click(screen.getByRole('checkbox', { name: /select john doe/i }));
+ expect(screen.getByRole('button', { name: /assign to agent/i })).toBeInTheDocument();
+ expect(screen.getByRole('button', { name: /return to held/i })).toBeInTheDocument();
+ expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument();
+ });
+
+ it('shift-click selects the range between the anchor and the clicked row', () => {
+ mockProspectsData.prospects = twoProspects;
+ renderProspects();
+ fireEvent.click(screen.getByRole('checkbox', { name: /select john doe/i }));
+ fireEvent.click(screen.getByRole('checkbox', { name: /select jane roe/i }), { shiftKey: true });
+ expect(screen.getByText('2 selected')).toBeInTheDocument();
+ });
+
+ it('changing a filter clears the selection', () => {
+ mockProspectsData.prospects = twoProspects;
+ renderProspects();
+ fireEvent.click(screen.getByRole('checkbox', { name: /select john doe/i }));
+ expect(screen.getByText('1 selected')).toBeInTheDocument();
+ fireEvent.click(screen.getByTestId('filter-status'));
+ expect(screen.queryByText('1 selected')).not.toBeInTheDocument();
+ });
+
+ it('Escape clears the selection', () => {
+ mockProspectsData.prospects = twoProspects;
+ renderProspects();
+ fireEvent.click(screen.getByRole('checkbox', { name: /select john doe/i }));
+ expect(screen.getByText('1 selected')).toBeInTheDocument();
+ fireEvent.keyDown(window, { key: 'Escape' });
+ expect(screen.queryByText('1 selected')).not.toBeInTheDocument();
+ });
+
+ it('marks held rows and counts them on the bar', () => {
+ mockProspectsData.prospects = [
+ { ...twoProspects[0], quarantinedAt: '2025-01-17T10:00:00Z', quarantineReason: 'returned_by_admin' },
+ twoProspects[1],
+ ];
+ renderProspects();
+ expect(screen.getByText(/held — returned by admin/i)).toBeInTheDocument();
+ fireEvent.click(screen.getByRole('checkbox', { name: /select all prospects/i }));
+ expect(screen.getByText(/2 selected/)).toBeInTheDocument();
+ expect(screen.getByText(/1 held/)).toBeInTheDocument();
  });
 
  // --- Source attribution badges ---

--- a/src/services/prospectService.js
+++ b/src/services/prospectService.js
@@ -37,6 +37,14 @@ export async function bulkAssignProspects(prospectIds, agentId) {
  return Prospect.bulkAssign(prospectIds, agentId);
 }
 
+export async function bulkReturnProspectsToHeld(prospectIds) {
+ return Prospect.bulkReturnToHeld(prospectIds);
+}
+
+export async function bulkDeleteProspects(prospectIds) {
+ return Prospect.bulkDelete(prospectIds);
+}
+
 export async function getProspectStats() {
  return Prospect.getStats();
 }

--- a/src/utils/normalizeProspect.js
+++ b/src/utils/normalizeProspect.js
@@ -178,6 +178,10 @@ export default function normalizeProspect(p) {
  assigned_agent_id: assignedAgentId,
  assigned_agent_name: assignedAgentName,
  assignedAgentId: p.assignedAgentId,
+ // Hold state (admin list): drives the Held badge, the Assignment filter, and
+ // the bulk-assign eligibility preview (fenced holds are skipped server-side).
+ quarantinedAt: p.quarantinedAt || null,
+ quarantineReason: p.quarantineReason || null,
  campaign_id: p.campaignId || p.campaign_id ||"",
  campaign: p.campaign,
  notes: p.notes,


### PR DESCRIPTION
Backend half (PR A) of web-admin bulk lead ops for AdminProspects + AdminAgentDetail. Frontend (multi-select UI, bulk action bar) follows in PR B. Plan reviewed via Codex adversarial pass 2026-07-03.

## What this fixes on the way

- **B-1 (silent lost delivery):** the internal held-release fired `lead.created`; both receivers no-op duplicate creates, so releasing a returned-to-held lead via the web UI marked it assigned in MKTR but never re-surfaced it in the agent's app. All manual dispatch now fires `lead.assigned` (both receivers upsert), with `qrTag` + `routing.mode` added to the assigned payload for insert parity.
- **B-3 (push storm):** bulk assign now threads one batch context through the webhook fan-out — the mktr-leads receiver (migration `20260703000000`) collapses N pushes into one "N leads assigned to you" summary.

## New capability

- **`PATCH /api/prospects/bulk/assign` v2** — releases releasable holds (`no_funded_agent`, `returned_by_admin`) atomically with the assignment; skip accounting (`notFound` / `alreadyAssigned` / `heldFenced`) for the UI toast; webhook pre-flight 409s instead of stranding a batch when delivery is misconfigured. DNC + external-buyer fences unchanged; credits stay best-effort deduct (no refunds anywhere).
- **`PATCH /api/prospects/bulk/return-to-held` (new)** — "unassign" per product decision: the lead re-enters the held/pending queue awaiting reassignment. Web returns use a distinct `quarantineReason='returned_by_admin'`, deliberately invisible to the EXTERNAL held queue / release / sweep (all filter `no_funded_agent`) so a returned Lyfe-owned lead can never leak to the external buyer pool. Handles Lyfe-owned owners (vanish via `lead.unassigned`+`returnedToHeld`), no-destination owners (System Agent — re-hold only), and promotes already-unassigned strays into the pool. External return flow behavior unchanged (defaults byte-identical).
- **`POST /api/prospects/bulk/delete` (new)** — fan-out over the hardened single delete (per-row transactional outbox for mktr-leads-owned rows).
- **`GET /api/prospects?assignment=assigned|unassigned|held`** — list filter backing the upcoming Held view; quarantine fields surface on list rows.
- Joi validation on all three bulk routes (UUID ids, min 1, max 200).

## Testing

- New DI unit suite `prospectServiceBulkOps.test.js` (13 tests) + 11 new integration tests (bulk routes, held filter, scope enforcement, reason fencing, validation bounds).
- Existing `prospectAssignment` / `adminLeadOps` unit suites updated for the intentional `lead.created`→`lead.assigned` release-event change.
- Full backend suite run against a live local Postgres: **144/149 suites pass; the 5 failures are byte-identical to main's pre-existing set** (verified with a clean-main worktree baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)