### PR TITLE
feat(admin): multi-select bulk lead ops UI — AdminProspects + AdminAgentDetail

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -498,6 +498,16 @@ class ProspectEntity extends BaseEntity {
  return response.data;
  }
 
+ async bulkReturnToHeld(prospectIds) {
+ const response = await apiClient.patch(`${this.endpoint}/bulk/return-to-held`, { prospectIds });
+ return response.data;
+ }
+
+ async bulkDelete(prospectIds) {
+ const response = await apiClient.post(`${this.endpoint}/bulk/delete`, { prospectIds });
+ return response.data;
+ }
+
  async getStats() {
  const response = await apiClient.get(`${this.endpoint}/stats/overview`);
  return response.data;

--- a/src/components/bulk/BulkActionBar.jsx
+++ b/src/components/bulk/BulkActionBar.jsx
@@ -1,0 +1,95 @@
+import { useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { UserPlus, Undo2, Trash2, FileSpreadsheet, FileText, X, Loader2 } from 'lucide-react';
+
+/**
+ * Floating bulk-action bar — slides up from the bottom of the viewport while at
+ * least one row is selected. Esc clears the selection. Export buttons render only
+ * when handlers are supplied (AdminProspects has exports; AdminAgentDetail doesn't).
+ */
+export default function BulkActionBar({
+  count,
+  heldCount = 0,
+  busy = false,
+  assignLabel = 'Assign to agent…',
+  onAssign,
+  onReturnToHeld,
+  onDelete,
+  onExportCSV,
+  onExportPDF,
+  onClear,
+}) {
+  useEffect(() => {
+    if (count === 0) return undefined;
+    const onKeyDown = (e) => {
+      if (e.key === 'Escape') onClear?.();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [count, onClear]);
+
+  if (count === 0) return null;
+
+  return (
+    <div className="fixed bottom-4 inset-x-4 sm:inset-x-auto sm:left-1/2 sm:-translate-x-1/2 sm:bottom-6 z-50 animate-in slide-in-from-bottom-4 fade-in duration-200">
+      <div className="flex flex-wrap items-center gap-1.5 sm:gap-2 rounded-xl border border-border bg-card shadow-xl px-3 py-2 sm:px-4">
+        <span className="text-sm font-medium text-foreground pr-1 sm:pr-2 whitespace-nowrap">
+          {count} selected
+          {heldCount > 0 && (
+            <span className="text-muted-foreground font-normal"> · {heldCount} held</span>
+          )}
+        </span>
+
+        <div className="h-5 w-px bg-border hidden sm:block" />
+
+        <Button size="sm" className="h-8" onClick={onAssign} disabled={busy}>
+          {busy ? <Loader2 className="w-4 h-4 mr-1.5 animate-spin" /> : <UserPlus className="w-4 h-4 mr-1.5" />}
+          {assignLabel}
+        </Button>
+
+        <Button variant="outline" size="sm" className="h-8" onClick={onReturnToHeld} disabled={busy}>
+          <Undo2 className="w-4 h-4 mr-1.5" />
+          Return to held
+        </Button>
+
+        {onExportCSV && (
+          <Button variant="outline" size="sm" className="h-8" onClick={onExportCSV} disabled={busy}>
+            <FileSpreadsheet className="w-4 h-4 mr-1.5" />
+            CSV
+          </Button>
+        )}
+        {onExportPDF && (
+          <Button variant="outline" size="sm" className="h-8" onClick={onExportPDF} disabled={busy}>
+            <FileText className="w-4 h-4 mr-1.5" />
+            PDF
+          </Button>
+        )}
+
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 text-destructive border-destructive/30 hover:bg-destructive/10 hover:text-destructive"
+          onClick={onDelete}
+          disabled={busy}
+        >
+          <Trash2 className="w-4 h-4 mr-1.5" />
+          Delete
+        </Button>
+
+        <div className="h-5 w-px bg-border hidden sm:block" />
+
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground"
+          onClick={onClear}
+          disabled={busy}
+          aria-label="Clear selection (Esc)"
+          title="Clear selection (Esc)"
+        >
+          <X className="w-4 h-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/bulk/BulkAssignDialog.jsx
+++ b/src/components/bulk/BulkAssignDialog.jsx
@@ -1,0 +1,156 @@
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { User as UserEntity } from '@/api/entities';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Search, UserPlus, Loader2, Check } from 'lucide-react';
+import { isFencedHold, isReleasableHold, holdReasonLabel } from '@/constants/holdReasons';
+
+/**
+ * Bulk "Assign to agent…" dialog: searchable agent picker + a pre-commit
+ * eligibility preview computed from the selected row snapshots, so the admin
+ * sees what the server will actually do (fenced holds are skipped, rows already
+ * with the chosen agent are no-ops, releasable holds deliver + deduct) BEFORE
+ * confirming. The server's response is still the source of truth — the caller
+ * toasts the real counts.
+ */
+export default function BulkAssignDialog({ open, onOpenChange, selectedRows, busy, onConfirm }) {
+  const [search, setSearch] = useState('');
+  const [agentId, setAgentId] = useState(null);
+
+  const { data: agents = [], isLoading: agentsLoading } = useQuery({
+    queryKey: ['users', 'agents'],
+    queryFn: () => UserEntity.getAgents(),
+    enabled: open,
+    staleTime: 60_000,
+  });
+
+  const filteredAgents = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    if (!needle) return agents;
+    return agents.filter((a) => {
+      const name = [a.firstName, a.lastName, a.fullName, a.full_name].filter(Boolean).join(' ').toLowerCase();
+      return name.includes(needle) || (a.email || '').toLowerCase().includes(needle);
+    });
+  }, [agents, search]);
+
+  const preview = useMemo(() => {
+    const fenced = selectedRows.filter(isFencedHold);
+    const releasable = selectedRows.filter(isReleasableHold);
+    const alreadyWithTarget = agentId
+      ? selectedRows.filter((r) => !r.quarantinedAt && (r.assigned_agent_id || r.assignedAgentId) === agentId)
+      : [];
+    const willAssign = selectedRows.length - fenced.length - alreadyWithTarget.length;
+    return { fenced, releasable, alreadyWithTarget, willAssign };
+  }, [selectedRows, agentId]);
+
+  const agentName = (a) =>
+    [a.firstName, a.lastName].filter(Boolean).join(' ') || a.fullName || a.full_name || a.email || 'Agent';
+
+  const handleConfirm = () => {
+    if (!agentId || preview.willAssign <= 0) return;
+    onConfirm(agentId);
+  };
+
+  const handleOpenChange = (next) => {
+    if (!next) {
+      setSearch('');
+      setAgentId(null);
+    }
+    onOpenChange(next);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Assign {selectedRows.length} lead{selectedRows.length === 1 ? '' : 's'}</DialogTitle>
+          <DialogDescription>
+            The agent is notified once and each lead is delivered to their app. Held leads in the
+            selection are released as part of the assignment.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+          <Input
+            placeholder="Search agents by name or email…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+            autoFocus
+          />
+        </div>
+
+        <div className="max-h-56 overflow-y-auto rounded-md border border-border divide-y divide-border">
+          {agentsLoading ? (
+            <div className="flex items-center justify-center gap-2 p-4 text-sm text-muted-foreground">
+              <Loader2 className="w-4 h-4 animate-spin" /> Loading agents…
+            </div>
+          ) : filteredAgents.length === 0 ? (
+            <div className="p-4 text-sm text-muted-foreground text-center">No agents match.</div>
+          ) : (
+            filteredAgents.map((a) => (
+              <button
+                key={a.id}
+                type="button"
+                onClick={() => setAgentId(a.id)}
+                className={`w-full flex items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-muted/50 ${
+                  agentId === a.id ? 'bg-primary/5' : ''
+                }`}
+              >
+                <div className="w-7 h-7 rounded-full bg-primary/10 text-primary flex items-center justify-center text-xs font-semibold uppercase shrink-0">
+                  {agentName(a).charAt(0)}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-medium text-foreground truncate">{agentName(a)}</div>
+                  {a.email && <div className="text-xs text-muted-foreground truncate">{a.email}</div>}
+                </div>
+                {agentId === a.id && <Check className="w-4 h-4 text-primary shrink-0" />}
+              </button>
+            ))
+          )}
+        </div>
+
+        {/* Eligibility preview — what the server will do with this selection. */}
+        <div className="text-sm text-muted-foreground space-y-1">
+          <div>
+            <span className="font-medium text-foreground">{Math.max(preview.willAssign, 0)}</span> will be
+            assigned
+            {preview.releasable.length > 0 && (
+              <> ({preview.releasable.length} released from held — delivery + credit deduction)</>
+            )}
+            .
+          </div>
+          {preview.alreadyWithTarget.length > 0 && (
+            <div>{preview.alreadyWithTarget.length} already with this agent — skipped, no double charge.</div>
+          )}
+          {preview.fenced.length > 0 && (
+            <div>
+              {preview.fenced.length} held lead{preview.fenced.length === 1 ? '' : 's'} will be skipped:{' '}
+              {[...new Set(preview.fenced.map((r) => holdReasonLabel(r.quarantineReason)))].join('; ')}.
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={busy}>
+            Cancel
+          </Button>
+          <Button onClick={handleConfirm} disabled={!agentId || preview.willAssign <= 0 || busy}>
+            {busy ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <UserPlus className="w-4 h-4 mr-2" />}
+            Assign {Math.max(preview.willAssign, 0)}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/prospects/ProspectFilters.jsx
+++ b/src/components/prospects/ProspectFilters.jsx
@@ -60,6 +60,23 @@ export default function ProspectFilters({ filters, onFilterChange, campaigns }) 
  <SelectItem value="other">Other</SelectItem>
  </SelectContent>
  </Select>
+
+ {/* Assignment state: Held = the pending pool (returned / quota-held leads
+ awaiting reassignment); Unassigned = strays with no agent and no hold. */}
+ <Select
+ value={filters.assignment || 'all'}
+ onValueChange={(value) => handleFilterChange('assignment', value)}
+ >
+ <SelectTrigger className="w-36">
+ <SelectValue placeholder="Assignment"/>
+ </SelectTrigger>
+ <SelectContent>
+ <SelectItem value="all">All Leads</SelectItem>
+ <SelectItem value="assigned">Assigned</SelectItem>
+ <SelectItem value="unassigned">Unassigned</SelectItem>
+ <SelectItem value="held">Held</SelectItem>
+ </SelectContent>
+ </Select>
  </div>
  );
 }

--- a/src/constants/holdReasons.js
+++ b/src/constants/holdReasons.js
@@ -1,0 +1,29 @@
+/**
+ * Prospect quarantine (hold) reasons — UI mirror of the backend's fences
+ * (backend/src/services/prospectService.js RELEASABLE_HOLD_REASONS).
+ *
+ * Releasable holds can be released by a manual admin (bulk) assign; fenced
+ * holds are skipped server-side (DNC gate, external buyer pool) and the UI
+ * previews them as "will be skipped" before the request is sent.
+ */
+export const RELEASABLE_HOLD_REASONS = ['no_funded_agent', 'returned_by_admin'];
+
+export const HOLD_REASON_LABELS = {
+  returned_by_admin: 'Returned by admin — pending reassignment',
+  no_funded_agent: 'No funded agent at capture',
+  no_funded_external_buyer: 'External buyer pool (dispatch via MKTR Leads app)',
+  dnc_pending: 'DNC check pending — releases automatically',
+  dnc_registered: 'On the DNC register — cannot be assigned',
+};
+
+export function holdReasonLabel(reason) {
+  return HOLD_REASON_LABELS[reason] || 'Held';
+}
+
+export function isReleasableHold(prospect) {
+  return Boolean(prospect?.quarantinedAt) && RELEASABLE_HOLD_REASONS.includes(prospect?.quarantineReason);
+}
+
+export function isFencedHold(prospect) {
+  return Boolean(prospect?.quarantinedAt) && !RELEASABLE_HOLD_REASONS.includes(prospect?.quarantineReason);
+}

--- a/src/hooks/__tests__/useRowSelection.test.js
+++ b/src/hooks/__tests__/useRowSelection.test.js
@@ -1,0 +1,74 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import useRowSelection from '../useRowSelection';
+
+const rows = [
+  { id: 'a', name: 'A' },
+  { id: 'b', name: 'B' },
+  { id: 'c', name: 'C' },
+  { id: 'd', name: 'D' },
+];
+
+describe('useRowSelection', () => {
+  it('toggles single rows and exposes snapshots', () => {
+    const { result } = renderHook(() => useRowSelection(rows));
+    act(() => result.current.toggleRow(rows[1]));
+    expect(result.current.count).toBe(1);
+    expect(result.current.isSelected('b')).toBe(true);
+    expect(result.current.selectedRows).toEqual([rows[1]]);
+    act(() => result.current.toggleRow(rows[1]));
+    expect(result.current.count).toBe(0);
+  });
+
+  it('shift-click selects the inclusive range from the anchor', () => {
+    const { result } = renderHook(() => useRowSelection(rows));
+    act(() => result.current.toggleRow(rows[0]));
+    act(() => result.current.toggleRow(rows[2], { shiftKey: true }));
+    expect(result.current.selectedIds.sort()).toEqual(['a', 'b', 'c']);
+    // Reverse direction works too.
+    act(() => result.current.toggleRow(rows[3]));
+    act(() => result.current.toggleRow(rows[1], { shiftKey: true }));
+    expect(result.current.selectedIds.sort()).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('select-all is page-additive and deselect-all page-subtractive (other pages untouched)', () => {
+    const page1 = rows.slice(0, 2);
+    const page2 = rows.slice(2);
+    const { result, rerender } = renderHook(({ r }) => useRowSelection(r), { initialProps: { r: page1 } });
+
+    act(() => result.current.toggleAllVisible());
+    expect(result.current.selectedIds.sort()).toEqual(['a', 'b']);
+
+    // Page turn: selection survives; select-all on page 2 ADDS.
+    rerender({ r: page2 });
+    expect(result.current.count).toBe(2);
+    expect(result.current.allVisibleSelected).toBe(false);
+    act(() => result.current.toggleAllVisible());
+    expect(result.current.selectedIds.sort()).toEqual(['a', 'b', 'c', 'd']);
+
+    // Deselect-all on page 2 removes only page 2 rows.
+    act(() => result.current.toggleAllVisible());
+    expect(result.current.selectedIds.sort()).toEqual(['a', 'b']);
+  });
+
+  it('header state distinguishes all / some / none of the visible rows', () => {
+    const { result } = renderHook(() => useRowSelection(rows));
+    expect(result.current.allVisibleSelected).toBe(false);
+    expect(result.current.someVisibleSelected).toBe(false);
+    act(() => result.current.toggleRow(rows[0]));
+    expect(result.current.someVisibleSelected).toBe(true);
+    act(() => result.current.toggleAllVisible());
+    expect(result.current.allVisibleSelected).toBe(true);
+    expect(result.current.someVisibleSelected).toBe(false);
+  });
+
+  it('clear empties the selection and drops the shift anchor', () => {
+    const { result } = renderHook(() => useRowSelection(rows));
+    act(() => result.current.toggleRow(rows[0]));
+    act(() => result.current.clear());
+    expect(result.current.count).toBe(0);
+    // No anchor → shift-click behaves like a plain toggle.
+    act(() => result.current.toggleRow(rows[2], { shiftKey: true }));
+    expect(result.current.selectedIds).toEqual(['c']);
+  });
+});

--- a/src/hooks/queries/useProspectsQuery.js
+++ b/src/hooks/queries/useProspectsQuery.js
@@ -54,3 +54,19 @@ export function useBulkAssignProspects() {
  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['prospects'] }),
  });
 }
+
+export function useBulkReturnProspects() {
+ const queryClient = useQueryClient();
+ return useMutation({
+ mutationFn: ({ prospectIds }) => prospectService.bulkReturnProspectsToHeld(prospectIds),
+ onSuccess: () => queryClient.invalidateQueries({ queryKey: ['prospects'] }),
+ });
+}
+
+export function useBulkDeleteProspects() {
+ const queryClient = useQueryClient();
+ return useMutation({
+ mutationFn: ({ prospectIds }) => prospectService.bulkDeleteProspects(prospectIds),
+ onSuccess: () => queryClient.invalidateQueries({ queryKey: ['prospects'] }),
+ });
+}

--- a/src/hooks/useRowSelection.js
+++ b/src/hooks/useRowSelection.js
@@ -1,0 +1,81 @@
+import { useCallback, useRef, useState } from 'react';
+
+/**
+ * Map-based row selection for paginated admin tables.
+ *
+ * Selection is a Map<id, rowSnapshot> — snapshots (not bare ids) so cross-page
+ * selections keep working for exports and eligibility previews after the page
+ * of origin has unmounted. Selection survives page turns; the OWNING page must
+ * call `clear()` synchronously in its filter/search handlers (an effect watching
+ * query params would let keepPreviousData's stale rows be selected under a new
+ * filter, and would also wipe selection on every page turn).
+ *
+ * `toggleRow(row, { shiftKey })` supports shift-click range selection anchored
+ * on the last explicitly toggled row of the CURRENT page (`rows`).
+ */
+export default function useRowSelection(rows = []) {
+  const [selected, setSelected] = useState(() => new Map());
+  const anchorIdRef = useRef(null);
+
+  const isSelected = useCallback((id) => selected.has(id), [selected]);
+
+  const clear = useCallback(() => {
+    anchorIdRef.current = null;
+    setSelected((prev) => (prev.size === 0 ? prev : new Map()));
+  }, []);
+
+  const toggleRow = useCallback(
+    (row, { shiftKey = false } = {}) => {
+      if (!row?.id) return;
+      setSelected((prev) => {
+        const next = new Map(prev);
+        const anchorIdx = shiftKey && anchorIdRef.current ? rows.findIndex((r) => r.id === anchorIdRef.current) : -1;
+        const clickIdx = rows.findIndex((r) => r.id === row.id);
+
+        if (anchorIdx !== -1 && clickIdx !== -1) {
+          // Shift-range: select everything between the anchor and the clicked row
+          // (inclusive). Always ADDS — a ranged deselect is more surprising than
+          // useful, and a plain click still toggles one row off.
+          const [from, to] = anchorIdx < clickIdx ? [anchorIdx, clickIdx] : [clickIdx, anchorIdx];
+          for (let i = from; i <= to; i++) next.set(rows[i].id, rows[i]);
+        } else if (next.has(row.id)) {
+          next.delete(row.id);
+        } else {
+          next.set(row.id, row);
+        }
+        anchorIdRef.current = row.id;
+        return next;
+      });
+    },
+    [rows]
+  );
+
+  // Header checkbox: page-additive select-all / page-subtractive deselect-all —
+  // never touches rows selected on OTHER pages.
+  const allVisibleSelected = rows.length > 0 && rows.every((r) => selected.has(r.id));
+  const someVisibleSelected = !allVisibleSelected && rows.some((r) => selected.has(r.id));
+
+  const toggleAllVisible = useCallback(() => {
+    setSelected((prev) => {
+      const next = new Map(prev);
+      const everyVisible = rows.length > 0 && rows.every((r) => next.has(r.id));
+      if (everyVisible) for (const r of rows) next.delete(r.id);
+      else for (const r of rows) next.set(r.id, r);
+      return next;
+    });
+    anchorIdRef.current = null;
+  }, [rows]);
+
+  return {
+    selected,
+    selectedRows: [...selected.values()],
+    selectedIds: [...selected.keys()],
+    count: selected.size,
+    isSelected,
+    toggleRow,
+    toggleAllVisible,
+    allVisibleSelected,
+    someVisibleSelected,
+    clear,
+  };
+}

--- a/src/pages/AdminAgentDetail.jsx
+++ b/src/pages/AdminAgentDetail.jsx
@@ -1,12 +1,18 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { User, Prospect } from '@/api/entities';
 import { useCampaignLookup } from '@/hooks/queries/useCampaignsQuery';
+import { useBulkAssignProspects, useBulkReturnProspects, useBulkDeleteProspects } from '@/hooks/queries/useProspectsQuery';
+import useRowSelection from '@/hooks/useRowSelection';
+import BulkActionBar from '@/components/bulk/BulkActionBar';
+import BulkAssignDialog from '@/components/bulk/BulkAssignDialog';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import {
@@ -19,6 +25,7 @@ import {
  Mail,
  Calendar,
  Loader2,
+ Trash2,
 } from 'lucide-react';
 import { format } from 'date-fns';
 import ProspectDetails from '@/components/prospects/ProspectDetails';
@@ -31,6 +38,13 @@ export default function AdminAgentDetail() {
  const { agentId } = useParams();
  const queryClient = useQueryClient();
  const [selectedProspect, setSelectedProspect] = useState(null);
+ const [bulkAssignOpen, setBulkAssignOpen] = useState(false);
+ const [bulkReturnOpen, setBulkReturnOpen] = useState(false);
+ const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
+
+ const bulkAssignMutation = useBulkAssignProspects();
+ const bulkReturnMutation = useBulkReturnProspects();
+ const bulkDeleteMutation = useBulkDeleteProspects();
 
  const [pagination, setPagination] = useState({
  page: 1,
@@ -90,8 +104,69 @@ export default function AdminAgentDetail() {
 
  const loading = prospectsLoading;
 
+ // Row selection for bulk ops — survives page turns; cleared synchronously when
+ // filters change (see applyFilterChange below).
+ const selection = useRowSelection(prospects);
+
  const handlePageChange = (newPage) => {
  setPagination((prev) => ({ ...prev, page: newPage }));
+ };
+
+ // Filter/search changes reset to page 1 (the query key reads pagination.page —
+ // a `page` key inside filters was dead state) and clear the selection.
+ const applyFilterChange = useCallback((patch) => {
+ selection.clear();
+ setPagination((prev) => ({ ...prev, page: 1 }));
+ setFilters((prev) => ({ ...prev, ...patch }));
+ // eslint-disable-next-line react-hooks/exhaustive-deps
+ }, [selection.clear]);
+
+ const previewNames = (rows, max = 5) => {
+ const names = rows.slice(0, max).map((r) => r.name || 'Unnamed');
+ const extra = rows.length - names.length;
+ return extra > 0 ? `${names.join(', ')} and ${extra} more` : names.join(', ');
+ };
+
+ const bulkBusy = bulkAssignMutation.isPending || bulkReturnMutation.isPending || bulkDeleteMutation.isPending;
+
+ const handleBulkAssign = async (targetAgentId) => {
+ try {
+ const res = await bulkAssignMutation.mutateAsync({ prospectIds: selection.selectedIds, agentId: targetAgentId });
+ const skippedTotal = res?.skipped ? Object.values(res.skipped).reduce((a, b) => a + b, 0) : 0;
+ const parts = [`${res?.affectedCount ?? 0} reassigned`];
+ if (skippedTotal > 0) parts.push(`${skippedTotal} skipped`);
+ toast.success(parts.join(' · '));
+ setBulkAssignOpen(false);
+ selection.clear();
+ } catch (error) {
+ toast.error(error?.message || 'Bulk reassign failed');
+ }
+ };
+
+ const handleBulkReturn = async () => {
+ try {
+ const res = await bulkReturnMutation.mutateAsync({ prospectIds: selection.selectedIds });
+ const moved = (res?.returned ?? 0) + (res?.promoted ?? 0);
+ if (res?.undeliverable > 0) {
+ toast.warning(`${res.undeliverable} could not be returned — lead delivery is not configured for the owning app.`);
+ }
+ toast.success(`${moved} returned to held`);
+ setBulkReturnOpen(false);
+ selection.clear();
+ } catch (error) {
+ toast.error(error?.message || 'Return to held failed');
+ }
+ };
+
+ const handleBulkDelete = async () => {
+ try {
+ const res = await bulkDeleteMutation.mutateAsync({ prospectIds: selection.selectedIds });
+ toast.success(`${res?.deleted ?? 0} deleted`);
+ setBulkDeleteOpen(false);
+ selection.clear();
+ } catch (error) {
+ toast.error(error?.message || 'Bulk delete failed');
+ }
  };
 
  const handleStatusUpdate = async (prospectId, newStatus) => {
@@ -173,13 +248,13 @@ export default function AdminAgentDetail() {
  <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground"/>
  <Input
  placeholder="Search leads..." className="pl-9" value={filters.search}
- onChange={(e) => setFilters((prev) => ({ ...prev, search: e.target.value, page: 1 }))} // Reset to page 1 on search
+ onChange={(e) => applyFilterChange({ search: e.target.value })}
  />
  </div>
  <div className="flex items-center gap-2 w-full sm:w-auto">
  <Select
  value={filters.status}
- onValueChange={(val) => setFilters((prev) => ({ ...prev, status: val, page: 1 }))}
+ onValueChange={(val) => applyFilterChange({ status: val })}
  >
  <SelectTrigger className="w-[180px]">
  <SelectValue placeholder="Status"/>
@@ -201,6 +276,12 @@ export default function AdminAgentDetail() {
  <Table>
  <TableHeader>
  <TableRow className="bg-muted/50 hover:bg-muted/50 border-border">
+ <TableHead className="py-3 pl-6 pr-2 w-[44px]">
+ <Checkbox
+ checked={selection.allVisibleSelected ? true : selection.someVisibleSelected ? 'indeterminate' : false}
+ onCheckedChange={selection.toggleAllVisible}
+ aria-label="Select all leads on this page" />
+ </TableHead>
  <TableHead className="py-3 px-6">Prospect</TableHead>
  <TableHead className="py-3 px-6">Campaign</TableHead>
  <TableHead className="py-3 px-6">Status</TableHead>
@@ -211,7 +292,7 @@ export default function AdminAgentDetail() {
  <TableBody>
  {loading ? (
  <TableRow>
- <TableCell colSpan={5} className="h-24 text-center">
+ <TableCell colSpan={6} className="h-24 text-center">
  <div className="flex justify-center items-center gap-2 text-muted-foreground">
  <Loader2 className="w-4 h-4 animate-spin"/> Loading...
  </div>
@@ -219,7 +300,7 @@ export default function AdminAgentDetail() {
  </TableRow>
  ) : prospects.length === 0 ? (
  <TableRow>
- <TableCell colSpan={5} className="h-32 text-center text-muted-foreground">
+ <TableCell colSpan={6} className="h-32 text-center text-muted-foreground">
  No prospects found for this agent.
  </TableCell>
  </TableRow>
@@ -227,8 +308,14 @@ export default function AdminAgentDetail() {
  prospects.map((prospect) => (
  <TableRow
  key={prospect.id}
- className="hover:bg-muted/50 cursor-pointer group" onClick={() => setSelectedProspect(prospect)}
+ className={`hover:bg-muted/50 cursor-pointer group ${selection.isSelected(prospect.id) ? 'bg-primary/5' : ''}`} onClick={() => setSelectedProspect(prospect)}
  >
+ <TableCell className="pl-6 pr-2" onClick={(e) => e.stopPropagation()}>
+ <Checkbox
+ checked={selection.isSelected(prospect.id)}
+ onClick={(e) => { e.preventDefault(); selection.toggleRow(prospect, { shiftKey: e.shiftKey }); }}
+ aria-label={`Select ${prospect.name}`} />
+ </TableCell>
  <TableCell className="px-6 py-4">
  <div className="flex items-center gap-3">
  <div className="w-8 h-8 rounded-full bg-primary/10 text-primary flex items-center justify-center text-xs font-bold uppercase">
@@ -313,6 +400,53 @@ export default function AdminAgentDetail() {
  )}
  </DialogContent>
  </Dialog>
+
+ {/* ── Bulk selection actions ─────────────────────────────── */}
+ <BulkActionBar
+ count={selection.count}
+ busy={bulkBusy}
+ assignLabel="Reassign to…" onAssign={() => setBulkAssignOpen(true)}
+ onReturnToHeld={() => setBulkReturnOpen(true)}
+ onDelete={() => setBulkDeleteOpen(true)}
+ onClear={selection.clear}
+ />
+
+ <BulkAssignDialog
+ open={bulkAssignOpen}
+ onOpenChange={setBulkAssignOpen}
+ selectedRows={selection.selectedRows}
+ busy={bulkAssignMutation.isPending}
+ onConfirm={handleBulkAssign}
+ />
+
+ <ConfirmDialog
+ open={bulkReturnOpen}
+ onOpenChange={setBulkReturnOpen}
+ title={`Return ${selection.count} lead${selection.count === 1 ? '' : 's'} to the held queue?`}
+ description={
+ <>
+ <span className="font-medium">{previewNames(selection.selectedRows)}</span>
+ {' '}will be pulled back from {agent?.firstName || 'this agent'} and moved to the Held
+ queue, pending reassignment. The agent loses access; credits are not refunded.
+ </>
+ }
+ confirmText="Return to held" onConfirm={handleBulkReturn}
+ />
+
+ <ConfirmDialog
+ open={bulkDeleteOpen}
+ onOpenChange={setBulkDeleteOpen}
+ title={`Delete ${selection.count} prospect${selection.count === 1 ? '' : 's'}?`}
+ description={
+ <>
+ <span className="font-medium">{previewNames(selection.selectedRows)}</span>
+ {' '}will be permanently deleted from MKTR. This can't be undone.
+ </>
+ }
+ confirmText="Delete" destructive
+ confirmIcon={<Trash2 className="w-4 h-4"/>}
+ onConfirm={handleBulkDelete}
+ />
  </div>
  </div>
  );

--- a/src/pages/AdminProspects.jsx
+++ b/src/pages/AdminProspects.jsx
@@ -1,9 +1,19 @@
-import { useState, useEffect, useMemo } from"react";
+import { useState, useEffect, useMemo, useCallback } from"react";
 import { useQuery, useQueryClient, keepPreviousData } from"@tanstack/react-query";
 import { Prospect } from"@/api/entities";
 import { useCurrentUser } from"@/hooks/queries/useUsersQuery";
-import { useUpdateProspect, useDeleteProspect } from"@/hooks/queries/useProspectsQuery";
+import {
+ useUpdateProspect,
+ useDeleteProspect,
+ useBulkAssignProspects,
+ useBulkReturnProspects,
+ useBulkDeleteProspects,
+} from"@/hooks/queries/useProspectsQuery";
 import { useCampaignLookup } from"@/hooks/queries/useCampaignsQuery";
+import useRowSelection from"@/hooks/useRowSelection";
+import BulkActionBar from"@/components/bulk/BulkActionBar";
+import BulkAssignDialog from"@/components/bulk/BulkAssignDialog";
+import { holdReasonLabel } from"@/constants/holdReasons";
 import { Card, CardContent, CardHeader } from"@/components/ui/card";
 import { Button } from"@/components/ui/button";
 import { Input } from"@/components/ui/input";
@@ -23,8 +33,7 @@ import {
  FileSpreadsheet,
  FileText,
  Trash2,
- User,
- X
+ User
 } from"lucide-react";
 import { Checkbox } from"@/components/ui/checkbox";
 import { toast } from"sonner";
@@ -103,31 +112,27 @@ export default function AdminProspects() {
  const { data: user } = useCurrentUser();
  const updateProspectMutation = useUpdateProspect();
  const deleteProspectMutation = useDeleteProspect();
+ const bulkAssignMutation = useBulkAssignProspects();
+ const bulkReturnMutation = useBulkReturnProspects();
+ const bulkDeleteMutation = useBulkDeleteProspects();
 
  const [selectedProspect, setSelectedProspect] = useState(null);
  const [deleteConfirm, setDeleteConfirm] = useState(null);
+ const [bulkAssignOpen, setBulkAssignOpen] = useState(false);
+ const [bulkReturnOpen, setBulkReturnOpen] = useState(false);
+ const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
  const [filters, setFilters] = useState(() => {
  const params = new URLSearchParams(window.location.search);
  return {
  search:"", status:"all",
  campaign: params.get('campaign') ||"all",
  qrTagId: params.get('qrTagId') ||"all",
- source:"all" };
+ source:"all",
+ assignment:"all" };
  });
  const [currentPage, setCurrentPage] = useState(1);
  const [itemsPerPage, setItemsPerPage] = useState(25);
- const [selectedIds, setSelectedIds] = useState(() => new Set());
  const isMobile = useIsMobile();
-
- useEffect(() => {
- const params = new URLSearchParams(location.search);
- const campaignId = params.get('campaign') ||"all";
- const qrTagId = params.get('qrTagId') ||"all";
- setFilters(prev => {
- if (prev.campaign === campaignId && prev.qrTagId === qrTagId) return prev;
- return { ...prev, campaign: campaignId, qrTagId: qrTagId };
- });
- }, [location.search]);
 
  // Debounce the free-text search so we issue one server query after the user
  // pauses typing, not one per keystroke. The input stays bound to
@@ -145,15 +150,16 @@ export default function AdminProspects() {
  if (filters.status !=="all") params.leadStatus = filters.status;
  if (filters.campaign !=="all") params.campaignId = filters.campaign;
  if (filters.qrTagId !=="all") params.qrTagId = filters.qrTagId;
+ if (filters.assignment !=="all") params.assignment = filters.assignment;
  if (filters.source !=="all") {
  if (filters.source ==="qr") params.leadSource ="qr_code";
  else if (filters.source ==="form") params.leadSource ="website";
  else params.leadSource = filters.source;
  }
  return params;
- }, [debouncedSearch, filters.status, filters.campaign, filters.qrTagId, filters.source, currentPage, itemsPerPage]);
+ }, [debouncedSearch, filters.status, filters.campaign, filters.qrTagId, filters.source, filters.assignment, currentPage, itemsPerPage]);
 
- const { data: prospectsResponse, isLoading: prospectsLoading } = useQuery({
+ const { data: prospectsResponse, isLoading: prospectsLoading, isPlaceholderData } = useQuery({
  queryKey: ['prospects', 'list', queryParams],
  queryFn: () => Prospect.list(queryParams),
  // Keep the previous page's rows rendered while the next query loads so a
@@ -173,32 +179,102 @@ export default function AdminProspects() {
  currentPage, totalPages: 1, totalItems: prospects.length, itemsPerPage
  };
 
- // Clear row selection whenever the visible set changes (page / filters / page size).
- useEffect(() => { setSelectedIds(new Set()); }, [queryParams]);
+ // Row selection survives page turns (Map of row snapshots, so exports and the
+ // assign preview keep working across pages). It is cleared SYNCHRONOUSLY in the
+ // filter/search handlers below — an effect watching queryParams would wipe it on
+ // every page turn and let keepPreviousData's stale rows be selected under a new
+ // filter.
+ const selection = useRowSelection(prospects);
+
+ // Any filter/search change redefines the working set — clear the selection in the
+ // same event, then apply the filter. Page turns intentionally do NOT clear.
+ const applyFilters = useCallback((next) => {
+ selection.clear();
+ setCurrentPage(1);
+ setFilters(next);
+ // eslint-disable-next-line react-hooks/exhaustive-deps
+ }, [selection.clear]);
+
+ useEffect(() => {
+ const params = new URLSearchParams(location.search);
+ const campaignId = params.get('campaign') ||"all";
+ const qrTagId = params.get('qrTagId') ||"all";
+ setFilters(prev => {
+ if (prev.campaign === campaignId && prev.qrTagId === qrTagId) return prev;
+ selection.clear();
+ setCurrentPage(1);
+ return { ...prev, campaign: campaignId, qrTagId: qrTagId };
+ });
+ // eslint-disable-next-line react-hooks/exhaustive-deps
+ }, [location.search]);
 
  const exportRows = useMemo(
- () => (selectedIds.size > 0 ? prospects.filter((p) => selectedIds.has(p.id)) : prospects),
- [prospects, selectedIds]
+ () => (selection.count > 0 ? selection.selectedRows : prospects),
+ // eslint-disable-next-line react-hooks/exhaustive-deps
+ [prospects, selection.selected]
  );
- const allSelected = prospects.length > 0 && prospects.every((p) => selectedIds.has(p.id));
- const someSelected = selectedIds.size > 0 && !allSelected;
-
- const toggleSelectAll = () => {
- setSelectedIds((prev) => {
- const everyVisibleSelected = prospects.length > 0 && prospects.every((p) => prev.has(p.id));
- return everyVisibleSelected ? new Set() : new Set(prospects.map((p) => p.id));
- });
- };
- const toggleSelectOne = (id) => {
- setSelectedIds((prev) => {
- const next = new Set(prev);
- if (next.has(id)) next.delete(id); else next.add(id);
- return next;
- });
- };
- const clearSelection = () => setSelectedIds(new Set());
+ const heldSelectedCount = useMemo(
+ () => selection.selectedRows.filter((r) => r.quarantinedAt).length,
+ // eslint-disable-next-line react-hooks/exhaustive-deps
+ [selection.selected]
+ );
+ const bulkBusy = bulkAssignMutation.isPending || bulkReturnMutation.isPending || bulkDeleteMutation.isPending;
 
  const handleRefresh = () => queryClient.invalidateQueries({ queryKey: ['prospects'] });
+
+ // Up-to-five-name preview for the bulk confirm dialogs.
+ const previewNames = (rows, max = 5) => {
+ const names = rows.slice(0, max).map((r) => r.name || 'Unnamed');
+ const extra = rows.length - names.length;
+ return extra > 0 ? `${names.join(', ')} and ${extra} more` : names.join(', ');
+ };
+
+ const handleBulkAssign = async (agentId) => {
+ try {
+ const res = await bulkAssignMutation.mutateAsync({ prospectIds: selection.selectedIds, agentId });
+ const skippedTotal = res?.skipped ? Object.values(res.skipped).reduce((a, b) => a + b, 0) : 0;
+ const parts = [`${res?.affectedCount ?? 0} assigned`];
+ if (res?.releasedCount > 0) parts.push(`${res.releasedCount} released from held`);
+ if (skippedTotal > 0) parts.push(`${skippedTotal} skipped`);
+ toast.success(parts.join(' · '));
+ setBulkAssignOpen(false);
+ selection.clear();
+ } catch (error) {
+ toast.error(error?.message || 'Bulk assign failed');
+ }
+ };
+
+ const handleBulkReturn = async () => {
+ try {
+ const res = await bulkReturnMutation.mutateAsync({ prospectIds: selection.selectedIds });
+ const moved = (res?.returned ?? 0) + (res?.promoted ?? 0);
+ const parts = [`${moved} returned to held`];
+ if (res?.alreadyHeld > 0) parts.push(`${res.alreadyHeld} already held`);
+ if (res?.notFound > 0) parts.push(`${res.notFound} not found`);
+ if (res?.undeliverable > 0) {
+ toast.warning(`${res.undeliverable} could not be returned — lead delivery is not configured for the owning app.`);
+ }
+ toast.success(parts.join(' · '));
+ setBulkReturnOpen(false);
+ selection.clear();
+ } catch (error) {
+ toast.error(error?.message || 'Return to held failed');
+ }
+ };
+
+ const handleBulkDelete = async () => {
+ try {
+ const res = await bulkDeleteMutation.mutateAsync({ prospectIds: selection.selectedIds });
+ const parts = [`${res?.deleted ?? 0} deleted`];
+ if (res?.notFound > 0) parts.push(`${res.notFound} not found`);
+ if (res?.failed > 0) parts.push(`${res.failed} failed`);
+ toast.success(parts.join(' · '));
+ setBulkDeleteOpen(false);
+ selection.clear();
+ } catch (error) {
+ toast.error(error?.message || 'Bulk delete failed');
+ }
+ };
 
  const handleStatusUpdate = async (prospectId, newStatus) => {
  try {
@@ -214,9 +290,10 @@ export default function AdminProspects() {
  } catch (error) { console.error('Error deleting prospect:', error); }
  };
 
- // Exports act on the current selection if any rows are ticked, otherwise the whole visible page.
+ // Exports act on the current selection if any rows are ticked (across pages),
+ // otherwise the whole visible page.
  const exportFileName = (ext) =>
- `prospects_${format(new Date(), 'ddMMyyyy_HHmm')}${selectedIds.size > 0 ? '_selected' : ''}.${ext}`;
+ `prospects_${format(new Date(), 'ddMMyyyy_HHmm')}${selection.count > 0 ? '_selected' : ''}.${ext}`;
 
  const fmtDob = (v) => {
  if (!v) return '';
@@ -267,7 +344,7 @@ export default function AdminProspects() {
  const autoTable = autoTableModule.default;
  const doc = new jsPDF({ orientation: 'landscape' });
  const generatedAt = format(new Date(), 'dd MMM yyyy, h:mm a');
- const scopeLabel = selectedIds.size > 0 ? `${exportRows.length} selected` : `${exportRows.length} total`;
+ const scopeLabel = selection.count > 0 ? `${exportRows.length} selected` : `${exportRows.length} total`;
  doc.setFontSize(14);
  doc.text('Prospects Export', 14, 15);
  doc.setFontSize(9);
@@ -331,11 +408,11 @@ export default function AdminProspects() {
  <div className="flex items-center gap-2">
  <Button variant="outline" className="bg-card" onClick={exportToCSV} disabled={exportRows.length === 0}>
  <FileSpreadsheet className="w-4 h-4 mr-2"/>
- Export CSV{selectedIds.size > 0 ? ` (${selectedIds.size})` : ''}
+ Export CSV{selection.count > 0 ? ` (${selection.count})` : ''}
  </Button>
  <Button variant="outline" className="bg-card" onClick={exportToPDF} disabled={exportRows.length === 0}>
  <FileText className="w-4 h-4 mr-2"/>
- Export PDF{selectedIds.size > 0 ? ` (${selectedIds.size})` : ''}
+ Export PDF{selection.count > 0 ? ` (${selection.count})` : ''}
  </Button>
  </div>
  }
@@ -350,10 +427,10 @@ export default function AdminProspects() {
  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4"/>
  <Input
  placeholder="Search prospects..." value={filters.search}
- onChange={(e) => setFilters({ ...filters, search: e.target.value })}
+ onChange={(e) => applyFilters({ ...filters, search: e.target.value })}
  className="pl-9 h-10 bg-muted/50 border-border focus:bg-background transition-colors" />
  </div>
- <ProspectFilters filters={filters} onFilterChange={setFilters} campaigns={campaigns} />
+ <ProspectFilters filters={filters} onFilterChange={applyFilters} campaigns={campaigns} />
  </div>
  <div className="flex items-center gap-2 text-sm text-muted-foreground">
  <span className=" hidden sm:inline">Rows per page:</span>
@@ -371,19 +448,6 @@ export default function AdminProspects() {
  </CardHeader>
 
  <CardContent className="p-0">
- {selectedIds.size > 0 && (
- <div className="flex items-center justify-between gap-3 px-4 lg:px-6 py-2.5 bg-primary/5 border-b border-border">
- <span className="text-sm font-medium text-foreground">
- {selectedIds.size} selected
- </span>
- <Button
- variant="ghost" size="sm" onClick={clearSelection}
- className="h-8 text-muted-foreground hover:text-foreground">
- <X className="w-4 h-4 mr-1.5"/>
- Clear
- </Button>
- </div>
- )}
  {!isMobile ? (
  <div className="overflow-x-auto">
  <Table>
@@ -391,8 +455,9 @@ export default function AdminProspects() {
  <TableRow className="bg-muted/50 hover:bg-muted/50 border-border">
  <TableHead className="py-3 pl-6 pr-2 w-[44px]">
  <Checkbox
- checked={allSelected ? true : someSelected ?"indeterminate" : false}
- onCheckedChange={toggleSelectAll}
+ checked={selection.allVisibleSelected ? true : selection.someVisibleSelected ?"indeterminate" : false}
+ onCheckedChange={selection.toggleAllVisible}
+ disabled={isPlaceholderData}
  aria-label="Select all prospects on this page" />
  </TableHead>
  <TableHead className="py-3 px-6 font-medium text-muted-foreground">Prospect</TableHead>
@@ -409,12 +474,15 @@ export default function AdminProspects() {
  return (
  <TableRow
  key={prospect.id}
- className={`hover:bg-muted/50 transition-colors border-border group cursor-pointer ${selectedIds.has(prospect.id) ?"bg-primary/5" :""}`} onClick={() => setSelectedProspect(prospect)}
+ className={`hover:bg-muted/50 transition-colors border-border group cursor-pointer ${selection.isSelected(prospect.id) ?"bg-primary/5" :""}`} onClick={() => setSelectedProspect(prospect)}
  >
  <TableCell className="pl-6 pr-2" onClick={(e) => e.stopPropagation()}>
+ {/* onClick (not onCheckedChange) so shift-click range selection sees the
+ modifier; preventDefault stops Radix's own toggle — checked stays
+ fully controlled. Keyboard Space still fires click (shiftKey false). */}
  <Checkbox
- checked={selectedIds.has(prospect.id)}
- onCheckedChange={() => toggleSelectOne(prospect.id)}
+ checked={selection.isSelected(prospect.id)}
+ onClick={(e) => { e.preventDefault(); selection.toggleRow(prospect, { shiftKey: e.shiftKey }); }}
  aria-label={`Select ${prospect.name}`} />
  </TableCell>
  <TableCell className="px-6 py-4">
@@ -431,7 +499,12 @@ export default function AdminProspects() {
  ⚠ {prospect.repeatSignupCount} campaigns
  </span>
  )}
- {prospect.assigned_agent_name ? (
+ {prospect.quarantinedAt ? (
+ <span
+ className="block text-xs font-medium mt-0.5 text-amber-700 dark:text-amber-400" title={holdReasonLabel(prospect.quarantineReason)}>
+ Held — {holdReasonLabel(prospect.quarantineReason)}
+ </span>
+ ) : prospect.assigned_agent_name ? (
  <span className="block text-xs text-muted-foreground font-normal mt-0.5">
  Agent: {prospect.assigned_agent_name}
  </span>
@@ -494,10 +567,10 @@ export default function AdminProspects() {
  ) : prospects.map((prospect) => (
  <div
  key={prospect.id}
- className={`flex items-start gap-3 p-4 ${selectedIds.has(prospect.id) ?"bg-primary/5" :""}`}>
+ className={`flex items-start gap-3 p-4 ${selection.isSelected(prospect.id) ?"bg-primary/5" :""}`}>
  <Checkbox
- checked={selectedIds.has(prospect.id)}
- onCheckedChange={() => toggleSelectOne(prospect.id)}
+ checked={selection.isSelected(prospect.id)}
+ onClick={(e) => { e.preventDefault(); selection.toggleRow(prospect, { shiftKey: e.shiftKey }); }}
  aria-label={`Select ${prospect.name}`}
  className="mt-1.5" />
  <button
@@ -562,6 +635,58 @@ export default function AdminProspects() {
  confirmText="Delete" destructive
  confirmIcon={<Trash2 className="w-4 h-4"/>}
  onConfirm={() => deleteConfirm && handleDeleteProspect(deleteConfirm.id)}
+ />
+
+ {/* ── Bulk selection actions ─────────────────────────────── */}
+ <BulkActionBar
+ count={selection.count}
+ heldCount={heldSelectedCount}
+ busy={bulkBusy}
+ onAssign={() => setBulkAssignOpen(true)}
+ onReturnToHeld={() => setBulkReturnOpen(true)}
+ onDelete={() => setBulkDeleteOpen(true)}
+ onExportCSV={exportToCSV}
+ onExportPDF={exportToPDF}
+ onClear={selection.clear}
+ />
+
+ <BulkAssignDialog
+ open={bulkAssignOpen}
+ onOpenChange={setBulkAssignOpen}
+ selectedRows={selection.selectedRows}
+ busy={bulkAssignMutation.isPending}
+ onConfirm={handleBulkAssign}
+ />
+
+ <ConfirmDialog
+ open={bulkReturnOpen}
+ onOpenChange={setBulkReturnOpen}
+ title={`Return ${selection.count} lead${selection.count === 1 ? '' : 's'} to the held queue?`}
+ description={
+ <>
+ <span className="font-medium">{previewNames(selection.selectedRows)}</span>
+ {' '}will be pulled back from their agents and moved to the Held queue, pending
+ reassignment. The previous agents lose access; credits are not refunded. You can
+ re-assign them anytime from the Held filter.
+ </>
+ }
+ confirmText="Return to held" onConfirm={handleBulkReturn}
+ />
+
+ <ConfirmDialog
+ open={bulkDeleteOpen}
+ onOpenChange={setBulkDeleteOpen}
+ title={`Delete ${selection.count} prospect${selection.count === 1 ? '' : 's'}?`}
+ description={
+ <>
+ <span className="font-medium">{previewNames(selection.selectedRows)}</span>
+ {' '}will be permanently deleted from MKTR. This can't be undone. Copies already
+ delivered to a Lyfe agent's app are not removed by this action.
+ </>
+ }
+ confirmText="Delete" destructive
+ confirmIcon={<Trash2 className="w-4 h-4"/>}
+ onConfirm={handleBulkDelete}
  />
  </div>
  </div>

--- a/src/pages/__tests__/AdminProspects.test.jsx
+++ b/src/pages/__tests__/AdminProspects.test.jsx
@@ -28,9 +28,16 @@ vi.mock('@/hooks/queries/useUsersQuery', () => ({
  useCurrentUser: () => ({ data: { id: 'u-1', role: 'admin' } }),
 }));
 
+const mockBulkAssign = { mutateAsync: vi.fn(), isPending: false };
+const mockBulkReturn = { mutateAsync: vi.fn(), isPending: false };
+const mockBulkDelete = { mutateAsync: vi.fn(), isPending: false };
+
 vi.mock('@/hooks/queries/useProspectsQuery', () => ({
  useUpdateProspect: () => ({ mutateAsync: vi.fn() }),
  useDeleteProspect: () => ({ mutateAsync: vi.fn() }),
+ useBulkAssignProspects: () => mockBulkAssign,
+ useBulkReturnProspects: () => mockBulkReturn,
+ useBulkDeleteProspects: () => mockBulkDelete,
 }));
 
 vi.mock('@/hooks/queries/useCampaignsQuery', () => ({
@@ -39,6 +46,7 @@ vi.mock('@/hooks/queries/useCampaignsQuery', () => ({
 
 vi.mock('@/api/entities', () => ({
  Prospect: { list: vi.fn() },
+ User: { getAgents: vi.fn().mockResolvedValue([]) },
 }));
 
 vi.mock('@/hooks/use-mobile', () => ({
@@ -80,6 +88,8 @@ vi.mock('@/utils/normalizeProspect', async (importOriginal) => {
  assigned_agent_name: p.assignedAgent ? `${p.assignedAgent.firstName} ${p.assignedAgent.lastName}` : null,
  phone: p.phone || '',
  sourceMetadata: p.sourceMetadata || null,
+ quarantinedAt: p.quarantinedAt || null,
+ quarantineReason: p.quarantineReason || null,
  ad: actual.deriveAd(p.sourceMetadata),
  referral: actual.deriveReferral(p.sourceMetadata),
  }),
@@ -339,6 +349,53 @@ describe('AdminProspects', () => {
  renderProspects();
  fireEvent.click(screen.getByRole('checkbox', { name: /select john doe/i }));
  expect(screen.queryByTestId('prospect-details')).not.toBeInTheDocument();
+ });
+
+ it('selection reveals the bulk action bar (assign / return to held / delete)', () => {
+ mockProspectsData.prospects = twoProspects;
+ renderProspects();
+ fireEvent.click(screen.getByRole('checkbox', { name: /select john doe/i }));
+ expect(screen.getByRole('button', { name: /assign to agent/i })).toBeInTheDocument();
+ expect(screen.getByRole('button', { name: /return to held/i })).toBeInTheDocument();
+ expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument();
+ });
+
+ it('shift-click selects the range between the anchor and the clicked row', () => {
+ mockProspectsData.prospects = twoProspects;
+ renderProspects();
+ fireEvent.click(screen.getByRole('checkbox', { name: /select john doe/i }));
+ fireEvent.click(screen.getByRole('checkbox', { name: /select jane roe/i }), { shiftKey: true });
+ expect(screen.getByText('2 selected')).toBeInTheDocument();
+ });
+
+ it('changing a filter clears the selection', () => {
+ mockProspectsData.prospects = twoProspects;
+ renderProspects();
+ fireEvent.click(screen.getByRole('checkbox', { name: /select john doe/i }));
+ expect(screen.getByText('1 selected')).toBeInTheDocument();
+ fireEvent.click(screen.getByTestId('filter-status'));
+ expect(screen.queryByText('1 selected')).not.toBeInTheDocument();
+ });
+
+ it('Escape clears the selection', () => {
+ mockProspectsData.prospects = twoProspects;
+ renderProspects();
+ fireEvent.click(screen.getByRole('checkbox', { name: /select john doe/i }));
+ expect(screen.getByText('1 selected')).toBeInTheDocument();
+ fireEvent.keyDown(window, { key: 'Escape' });
+ expect(screen.queryByText('1 selected')).not.toBeInTheDocument();
+ });
+
+ it('marks held rows and counts them on the bar', () => {
+ mockProspectsData.prospects = [
+ { ...twoProspects[0], quarantinedAt: '2025-01-17T10:00:00Z', quarantineReason: 'returned_by_admin' },
+ twoProspects[1],
+ ];
+ renderProspects();
+ expect(screen.getByText(/held — returned by admin/i)).toBeInTheDocument();
+ fireEvent.click(screen.getByRole('checkbox', { name: /select all prospects/i }));
+ expect(screen.getByText(/2 selected/)).toBeInTheDocument();
+ expect(screen.getByText(/1 held/)).toBeInTheDocument();
  });
 
  // --- Source attribution badges ---

--- a/src/services/prospectService.js
+++ b/src/services/prospectService.js
@@ -37,6 +37,14 @@ export async function bulkAssignProspects(prospectIds, agentId) {
  return Prospect.bulkAssign(prospectIds, agentId);
 }
 
+export async function bulkReturnProspectsToHeld(prospectIds) {
+ return Prospect.bulkReturnToHeld(prospectIds);
+}
+
+export async function bulkDeleteProspects(prospectIds) {
+ return Prospect.bulkDelete(prospectIds);
+}
+
 export async function getProspectStats() {
  return Prospect.getStats();
 }

--- a/src/utils/normalizeProspect.js
+++ b/src/utils/normalizeProspect.js
@@ -178,6 +178,10 @@ export default function normalizeProspect(p) {
  assigned_agent_id: assignedAgentId,
  assigned_agent_name: assignedAgentName,
  assignedAgentId: p.assignedAgentId,
+ // Hold state (admin list): drives the Held badge, the Assignment filter, and
+ // the bulk-assign eligibility preview (fenced holds are skipped server-side).
+ quarantinedAt: p.quarantinedAt || null,
+ quarantineReason: p.quarantineReason || null,
  campaign_id: p.campaignId || p.campaign_id ||"",
  campaign: p.campaign,
  notes: p.notes,


### PR DESCRIPTION
Frontend half (PR B) of web-admin bulk lead ops — stacked on #87 (merge that first; this PR's base is `feat/bulk-lead-ops-backend` so the diff here is UI-only).

## What you get

- **Multi-select that behaves like a power tool**: selection survives page turns (row snapshots, not bare ids — so cross-page CSV/PDF export and the assign preview keep working), shift-click range select, page-additive select-all, `Esc` clears. Selection is cleared synchronously when filters/search change, so `keepPreviousData`'s stale rows can never be selected under a new filter.
- **Floating bulk action bar** while rows are selected: `N selected · M held` → **Assign to agent…** · **Return to held** · **CSV / PDF** · **Delete** · ✕.
- **Assign dialog** with searchable agent picker and a pre-commit eligibility preview: how many will assign, how many are held-and-released (delivery + credit deduction), how many are fenced (DNC / external buyer pool) and will be skipped, how many are already with the target. The result toast reports the server's actual counts.
- **Held queue visibility**: new Assignment filter (All / Assigned / Unassigned / **Held**) on AdminProspects + an amber `Held — <reason>` row state, so returned leads have a home and a workflow (select → reassign).
- **AdminAgentDetail**: selection column + **Reassign to… / Return to held / Delete** bar for an agent's leads.

## Bugs fixed on the way

- Cross-page export silently dropped selected rows that weren't on the visible page.
- AdminAgentDetail filter changes never reset pagination (dead `page: 1` written into `filters` while the query reads `pagination.page`).

## Testing

- New `useRowSelection` unit suite (range select, additive select-all across pages, anchor semantics).
- AdminProspects tests extended: bulk bar reveal, shift-click range, filter-change/Esc clearing, held badge + held count.
- Full SPA suite green: **91 files, 1111 tests**. ESLint 0 errors. `vite build` clean.
- Suggested manual QA after both PRs deploy: select a few leads → Return to held → confirm they appear under the Held filter → select them there → Assign to an agent → confirm the agent's app receives them once (single coalesced push for mktr-leads agents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)