### PR TITLE
feat(sync): mktr-leads mirror keeps managers (Phase 0 manager-role compat)

### DIFF
--- a/backend/src/integrations/adapters/mktr-leads/mktrLeadsClient.js
+++ b/backend/src/integrations/adapters/mktr-leads/mktrLeadsClient.js
@@ -103,9 +103,12 @@ const SELECT_COLUMNS = 'mktr_user_id,full_name,email,phone,role,is_active,agency
 /**
  * Fetch ALL mktr-leads agents — active AND inactive.
  *
- * `role=eq.agent` is filtered AT THE SOURCE and is mandatory: mktr-leads has an
- * `admin` role that must never become an assignable MKTR agent (a promotion to
- * admin drops the row from this list → the sync retires it locally).
+ * `role=in.(agent,manager)` is filtered AT THE SOURCE and is mandatory: mktr-leads
+ * has an `admin` role that must never become an assignable MKTR agent (a promotion
+ * to admin drops the row from this list → the sync retires it locally). Managers
+ * ARE lead buyers — they hold their own leads — so an agent→manager promotion keeps
+ * the row IN this feed and must never trip the two-phase retirement (FMEA F09);
+ * the upstream role rides `externalRole` while the local users row stays role=agent.
  *
  * `is_active` is intentionally NOT filtered (unlike Lyfe): the adapter declares
  * `mirrorsIsActive`, so runSync mirrors each row's is_active directly. Fetching
@@ -124,7 +127,7 @@ export async function fetchAgents() {
   let rows;
   try {
     rows = await breaker.fire(
-      `${url}/rest/v1/agents?role=eq.agent&select=${SELECT_COLUMNS}&order=full_name`,
+      `${url}/rest/v1/agents?role=in.(agent,manager)&select=${SELECT_COLUMNS}&order=full_name`,
       authHeaders(key)
     );
   } catch (err) {
@@ -207,14 +210,14 @@ export async function createInvitation({ phone, fullName, email, agency }) {
 }
 
 /**
- * PATCH one mktr-leads agent row. The `role=eq.agent` filter is a hard guard:
- * admin rows can never be touched from here, whatever the caller passes.
+ * PATCH one mktr-leads agent row. The `role=in.(agent,manager)` filter is a hard
+ * guard: admin rows can never be touched from here, whatever the caller passes.
  * Returns the updated row, or null when nothing matched (unknown id / admin).
  */
 async function patchAgent(mktrUserId, payload) {
   const { url, key } = getConfig();
   const response = await fetch(
-    `${url}/rest/v1/agents?mktr_user_id=eq.${encodeURIComponent(mktrUserId)}&role=eq.agent`,
+    `${url}/rest/v1/agents?mktr_user_id=eq.${encodeURIComponent(mktrUserId)}&role=in.(agent,manager)`,
     {
       method: 'PATCH',
       headers: { ...authHeaders(key), Prefer: 'return=representation' },

--- a/backend/src/services/mktrLeadsAgentManagementService.js
+++ b/backend/src/services/mktrLeadsAgentManagementService.js
@@ -131,8 +131,8 @@ export function makeMktrLeadsAgentManagementService(overrides = {}) {
 
     const row = await d.client.setAgentActive(mktrUserId, isActive === true);
     if (!row) {
-      // Unknown id — or an admin row, which the client's role=eq.agent filter
-      // refuses to touch by construction.
+      // Unknown id — or an admin row, which the client's role=in.(agent,manager)
+      // filter refuses to touch by construction (managers ARE manageable here).
       throw new AppError('mktr-leads agent not found (admins cannot be managed from here)', 404);
     }
 

--- a/backend/test/unit/mktrLeadsAdapter.test.js
+++ b/backend/test/unit/mktrLeadsAdapter.test.js
@@ -36,6 +36,18 @@ const ROWS = [
     agency: 'Acme Advisory',
     created_at: '2026-06-03T00:00:00Z',
   },
+  {
+    // Manager — a lead buyer like any agent; must stay in the feed (F09) and
+    // carry role='manager' through externalRole.
+    mktr_user_id: 'mu_4',
+    full_name: 'Dan Koh',
+    email: 'dan@example.com',
+    phone: '6581112222',
+    role: 'manager',
+    is_active: true,
+    agency: 'Acme Advisory',
+    created_at: '2026-06-04T00:00:00Z',
+  },
 ];
 
 describe('mktrLeadsClient', () => {
@@ -61,18 +73,20 @@ describe('mktrLeadsClient', () => {
     delete process.env.MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY;
   });
 
-  it('fetchAgents filters role=agent at the source (NOT is_active — inactive rows are mirrored) and normalizes', async () => {
+  it('fetchAgents filters role to agent+manager at the source (NOT is_active — inactive rows are mirrored) and normalizes', async () => {
     const agents = await client.fetchAgents();
 
     const url = fetchMock.mock.calls[0][0];
     expect(url).toContain('/rest/v1/agents?');
-    expect(url).toContain('role=eq.agent');
+    // Managers are lead buyers and must stay in the feed — leaving it trips the
+    // two-phase retirement (F09). Admins remain excluded at the source.
+    expect(url).toContain('role=in.(agent,manager)');
     // Deactivated agents must stay in the fetched set: absence means DELETED
     // upstream (two-phase hard-delete). is_active is mirrored row-wise instead.
     expect(url).not.toContain('is_active=eq.true');
     expect(url).toContain('select=mktr_user_id,full_name,email,phone,role,is_active,agency,created_at');
 
-    expect(agents).toHaveLength(3);
+    expect(agents).toHaveLength(4);
     expect(agents[0]).toMatchObject({
       externalId: 'mu_1', // the mktr_user_id, NOT an auth id
       fullName: 'Ada Tan',
@@ -88,6 +102,9 @@ describe('mktrLeadsClient', () => {
     expect(agents[1].email).toBeNull(); // do NOT synthesize
     // Inactive rows pass through with isActive=false for row-wise mirroring.
     expect(agents[2]).toMatchObject({ externalId: 'mu_3', isActive: false });
+    // Managers normalize like agents, with the upstream role on externalRole —
+    // agentSync stores it as users.external_role while local role stays 'agent'.
+    expect(agents[3]).toMatchObject({ externalId: 'mu_4', externalRole: 'manager', isActive: true });
   });
 
   it('caches list results within TTL (no second fetch)', async () => {
@@ -149,7 +166,7 @@ describe('MktrLeadsAdapter contract', () => {
     client.invalidateCache();
     global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ROWS, text: async () => '' });
     const agents = await MktrLeadsAdapter.listAgents();
-    expect(agents.map((a) => a.externalId)).toEqual(['mu_1', 'mu_2', 'mu_3']);
+    expect(agents.map((a) => a.externalId)).toEqual(['mu_1', 'mu_2', 'mu_3', 'mu_4']);
     delete process.env.MKTR_LEADS_SUPABASE_URL;
     delete process.env.MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY;
   });

--- a/backend/test/unit/mktrLeadsClientWrites.test.js
+++ b/backend/test/unit/mktrLeadsClientWrites.test.js
@@ -61,7 +61,7 @@ describe('mktrLeadsClient write-backs', () => {
   describe('setAgentActive / updateAgentFields (PATCH agents)', () => {
     const okRow = { mktr_user_id: 'mu_1', is_active: false };
 
-    it('PATCHes with the role=eq.agent hard guard and an ENCODED id, returns the row', async () => {
+    it('PATCHes with the role=in.(agent,manager) hard guard and an ENCODED id, returns the row', async () => {
       fetchMock.mockResolvedValue({ ok: true, json: async () => [okRow], text: async () => '' });
 
       const row = await client.setAgentActive('mu/1 weird', false);
@@ -69,7 +69,7 @@ describe('mktrLeadsClient write-backs', () => {
       const [url, opts] = fetchMock.mock.calls[0];
       expect(url).toContain('/rest/v1/agents?');
       expect(url).toContain(`mktr_user_id=eq.${encodeURIComponent('mu/1 weird')}`);
-      expect(url).toContain('role=eq.agent'); // admins untouchable by construction
+      expect(url).toContain('role=in.(agent,manager)'); // admins untouchable by construction
       expect(opts.method).toBe('PATCH');
       expect(opts.headers.Prefer).toBe('return=representation');
       expect(JSON.parse(opts.body)).toEqual({ is_active: false });


### PR DESCRIPTION
Phase 0 of the mktr-leads **manager role** (plan: `mktr-leads/MANAGER_ROLE_PLAN.md` v3, 2× Codex-reviewed).

## Why first
An agent→manager promotion upstream would otherwise drop the row from the `role=eq.agent` mirror feed → the FMEA F09 absence logic **deactivates the MKTR buyer (round-robin stops), then hard-deletes** the user if they own no prospects. Managers hold their own leads, so they must stay in the feed.

## Changes
- `mktrLeadsClient.fetchAgents`: source filter `role=eq.agent` → `role=in.(agent,manager)`; upstream role continues to ride `externalRole` → `users.external_role` (local `users.role` stays `agent` — buyer identity, routing, billing untouched).
- `patchAgent` write-back hard guard widened identically (admins still untouchable).
- `mktrLeadsAgentManagementService`: comment truth-up (managers manageable from the web admin).
- Tests: manager fixture row flows through with `externalRole='manager'`; URL assertions updated. **47/47 pass** across the 5 adapter/sync suites.

**Inert until the first `role='manager'` row exists upstream** (none yet — the DB migration that allows the role ships next, and the app UI to promote after that).

⚠️ After merge: **Render Manual Deploy** on `mktr-backend-jo6r` (auto-deploy drops pushes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)