### PR TITLE
feat(billing): beneficiary purchases — manager buy-for-team (Phase 4a)

### DIFF
--- a/backend/src/controllers/externalBillingController.js
+++ b/backend/src/controllers/externalBillingController.js
@@ -82,7 +82,10 @@ function sendError(res, err, op) {
 export async function catalog(req, res) {
   try {
     const data = await getCatalog();
-    return res.json({ success: true, ...data });
+    // beneficiarySupported = the capability flag the app's buy-for-team UI gates on:
+    // a deployed backend that understands beneficiaryMktrUserId advertises it here,
+    // so an OTA'd app can never send a beneficiary this server would silently drop.
+    return res.json({ success: true, beneficiarySupported: true, ...data });
   } catch (err) {
     return sendError(res, err, 'catalog');
   }
@@ -90,16 +93,16 @@ export async function catalog(req, res) {
 
 // ── Checkout (create purchase) ────────────────────────────────────────────────
 export async function checkout(req, res) {
-  const { agentMktrUserId, packageId } = req.body || {};
+  const { agentMktrUserId, packageId, beneficiaryMktrUserId } = req.body || {};
   if (!agentMktrUserId || !packageId) {
     return res.status(400).json({ success: false, error: 'agentMktrUserId and packageId are required' });
   }
   try {
-    const r = await createCheckout({ agentMktrUserId, packageId });
+    const r = await createCheckout({ agentMktrUserId, packageId, beneficiaryMktrUserId });
     if (r.status === 'created') {
-      return res.status(201).json({ success: true, checkoutUrl: r.url, purchaseId: r.purchaseId });
+      return res.status(201).json({ success: true, checkoutUrl: r.url, purchaseId: r.purchaseId, beneficiarySupported: true });
     }
-    const codeByStatus = { invalid_agent: 400, package_inactive: 409, package_unpriced: 409, provider_error: 502 };
+    const codeByStatus = { invalid_agent: 400, invalid_beneficiary: 400, package_inactive: 409, package_unpriced: 409, provider_error: 502 };
     const code = codeByStatus[r.status] || 500;
     return res.status(code).json({ success: false, status: r.status });
   } catch (err) {

--- a/backend/src/database/migrations/043-add-payment-beneficiary.js
+++ b/backend/src/database/migrations/043-add-payment-beneficiary.js
@@ -1,0 +1,76 @@
+/**
+ * Migration 043 — payments beneficiary (manager "buy for team", MANAGER_ROLE_PLAN §6.2).
+ *
+ * A mktr-leads MANAGER can buy a lead package FOR a team member: the manager pays,
+ * the member's balance is credited. Three columns on the money record:
+ *
+ *   beneficiaryUserId  UUID FK → users, SET NULL on delete (payments outlive people,
+ *                      like every other payment FK — migration 040 precedent).
+ *                      NULL = self purchase, OR the beneficiary was deleted before
+ *                      settlement (disambiguated by forTeam).
+ *   forTeam            BOOLEAN NOT NULL DEFAULT false — the IMMUTABLE team-purchase
+ *                      marker. It survives the FK SET NULL, so fulfillment can refuse
+ *                      the silent payer-credit fallback: an explicit team purchase
+ *                      whose beneficiary vanished lands paid_unfulfilled (manual
+ *                      review), never a grant to the payer.
+ *   beneficiaryName    STRING snapshot at checkout — history labels outlive deletion.
+ *
+ * Idempotent re-runs: describeTable guard + only "already exists" swallowed (042
+ * discipline); a post-up assertion verifies all three columns landed.
+ */
+function ignoreExists(e) {
+  const msg = String(e?.message || e || '');
+  if (!/already exists|duplicate/i.test(msg)) throw e;
+}
+
+export async function up(queryInterface, Sequelize) {
+  const { DataTypes } = Sequelize;
+  const table = await queryInterface.describeTable('payments').catch(() => ({}));
+
+  if (!table.beneficiaryUserId) {
+    await queryInterface
+      .addColumn('payments', 'beneficiaryUserId', {
+        type: DataTypes.UUID,
+        allowNull: true,
+        references: { model: 'users', key: 'id' },
+        onDelete: 'SET NULL',
+        onUpdate: 'CASCADE',
+        comment:
+          'Grantee of a manager team purchase. NULL = self purchase OR beneficiary deleted pre-settlement (see forTeam).',
+      })
+      .catch(ignoreExists);
+  }
+
+  if (!table.forTeam) {
+    await queryInterface
+      .addColumn('payments', 'forTeam', {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+        comment:
+          'Immutable team-purchase marker; survives beneficiary FK SET NULL so fulfillment never falls back to crediting the payer.',
+      })
+      .catch(ignoreExists);
+  }
+
+  if (!table.beneficiaryName) {
+    await queryInterface
+      .addColumn('payments', 'beneficiaryName', {
+        type: DataTypes.STRING,
+        allowNull: true,
+        comment: 'Display snapshot of the beneficiary at checkout — history labels outlive deletion.',
+      })
+      .catch(ignoreExists);
+  }
+
+  const after = await queryInterface.describeTable('payments');
+  if (!after.beneficiaryUserId || !after.forTeam || !after.beneficiaryName) {
+    throw new Error('043: payments beneficiary columns did not land');
+  }
+}
+
+export async function down(queryInterface) {
+  await queryInterface.removeColumn('payments', 'beneficiaryName').catch(() => {});
+  await queryInterface.removeColumn('payments', 'forTeam').catch(() => {});
+  await queryInterface.removeColumn('payments', 'beneficiaryUserId').catch(() => {});
+}

--- a/backend/src/models/Payment.js
+++ b/backend/src/models/Payment.js
@@ -24,6 +24,28 @@ const Payment = sequelize.define('Payment', {
     allowNull: true, // SET NULL on user delete — keep the financial record
     references: { model: 'users', key: 'id' },
   },
+  /**
+   * Manager "buy for team" (migration 043): the GRANTEE when forTeam. NULL = self
+   * purchase, or the beneficiary was deleted before settlement — forTeam
+   * disambiguates, and fulfillment then records paid-without-assignment instead
+   * of silently crediting the payer.
+   */
+  beneficiaryUserId: {
+    type: DataTypes.UUID,
+    allowNull: true, // SET NULL on user delete — keep the financial record
+    references: { model: 'users', key: 'id' },
+  },
+  /** Immutable team-purchase marker — survives beneficiary FK SET NULL. */
+  forTeam: {
+    type: DataTypes.BOOLEAN,
+    allowNull: false,
+    defaultValue: false,
+  },
+  /** Display snapshot of the beneficiary at checkout (history labels outlive deletion). */
+  beneficiaryName: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
   leadPackageId: {
     type: DataTypes.UUID,
     allowNull: true,

--- a/backend/src/services/billingService.js
+++ b/backend/src/services/billingService.js
@@ -11,6 +11,7 @@
  *
  * DI-factory (house pattern) so it unit-tests without a DB or network.
  */
+import { Op } from 'sequelize';
 import { Payment, LeadPackage, LeadPackageAssignment, User, Campaign, sequelize } from '../models/index.js';
 import * as hitpay from './hitpayClient.js';
 import { logger } from '../utils/logger.js';
@@ -87,12 +88,25 @@ export function makeBillingService(overrides = {}) {
   /**
    * Create a pending Payment + a HitPay payment request. The Payment.id is the HitPay
    * reference_number, so the webhook correlates back by PK. Typed outcomes:
-   * created | invalid_agent | package_inactive | package_unpriced | provider_error.
+   * created | invalid_agent | invalid_beneficiary | package_inactive | package_unpriced
+   * | provider_error.
+   *
+   * beneficiaryMktrUserId (optional): a mktr-leads MANAGER buying FOR a team member —
+   * the payer stays agentMktrUserId, the grant goes to the beneficiary. Team membership
+   * is validated by the mktr-agent-store broker (the only caller with the Supabase
+   * truth); here both parties just have to be live local buyers.
    */
-  async function createCheckout({ agentMktrUserId, packageId }) {
+  async function createCheckout({ agentMktrUserId, packageId, beneficiaryMktrUserId }) {
     if (!agentMktrUserId || !packageId) return { status: 'invalid_agent' };
     const agent = await resolveAgent(agentMktrUserId);
     if (!agent) return { status: 'invalid_agent' };
+
+    // Same-person "beneficiary" collapses to a plain self purchase.
+    let beneficiary = null;
+    if (beneficiaryMktrUserId && beneficiaryMktrUserId !== agentMktrUserId) {
+      beneficiary = await resolveAgent(beneficiaryMktrUserId);
+      if (!beneficiary) return { status: 'invalid_beneficiary' };
+    }
 
     const pkg = await d.LeadPackage.findByPk(packageId, {
       include: [{ model: d.Campaign, as: 'campaign', attributes: ['name'] }],
@@ -102,8 +116,15 @@ export function makeBillingService(overrides = {}) {
     if (!(price > 0) || (pkg.currency || 'SGD') !== 'SGD') return { status: 'package_unpriced' };
 
     // Pending Payment first so its id is the HitPay reference_number + the idempotency anchor.
+    // Beneficiary is SNAPSHOTTED here (id + immutable forTeam marker + display name):
+    // fulfillment grants from these fields, never from webhook input.
     const payment = await d.Payment.create({
       agentId: agent.id,
+      beneficiaryUserId: beneficiary ? beneficiary.id : null,
+      forTeam: !!beneficiary,
+      beneficiaryName: beneficiary
+        ? beneficiary.fullName || `${beneficiary.firstName || ''} ${beneficiary.lastName || ''}`.trim() || null
+        : null,
       leadPackageId: pkg.id,
       provider: 'hitpay',
       amount: price,
@@ -126,7 +147,7 @@ export function makeBillingService(overrides = {}) {
         purpose: pkg.name,
       });
       await payment.update({ providerRequestId: id });
-      d.logger.info('[billing] checkout.created', { purchaseId: payment.id, agentId: agent.id, packageId: pkg.id, amount: price });
+      d.logger.info('[billing] checkout.created', { purchaseId: payment.id, agentId: agent.id, beneficiaryId: beneficiary?.id ?? null, packageId: pkg.id, amount: price });
       return { status: 'created', url, purchaseId: payment.id };
     } catch (err) {
       await payment.update({ status: 'failed' }).catch(() => {});
@@ -144,20 +165,55 @@ export function makeBillingService(overrides = {}) {
     return { status: toPurchaseStatus(payment.status) };
   }
 
-  /** The agent's OWN purchase history (self-scoped, newest 50). */
+  /**
+   * The caller's purchase history (newest 50): rows they PAID for plus team
+   * purchases that CREDITED them. Each row carries a direction so the app can
+   * label it — 'self' | 'for_team' (payer view, + beneficiaryName snapshot) |
+   * 'from_manager' (grantee view, + payerName resolved best-effort).
+   */
   async function getHistory({ agentMktrUserId }) {
     const agent = await resolveAgent(agentMktrUserId);
     if (!agent) return { purchases: [] };
-    const rows = await d.Payment.findAll({ where: { agentId: agent.id }, order: [['createdAt', 'DESC']], limit: 50 });
-    const purchases = rows.map((p) => ({
-      id: p.id,
-      packageName: p.packageName || 'Lead package',
-      leadCount: p.leadCount,
-      amount: Number(p.amount),
-      currency: p.currency || 'SGD',
-      status: toPurchaseStatus(p.status),
-      createdAt: (p.createdAt instanceof Date ? p.createdAt : new Date(p.createdAt)).toISOString(),
-    }));
+    const rows = await d.Payment.findAll({
+      where: { [Op.or]: [{ agentId: agent.id }, { beneficiaryUserId: agent.id }] },
+      order: [['createdAt', 'DESC']],
+      limit: 50,
+    });
+
+    // Payer names for the rows that credited the caller (manager-funded).
+    const payerIds = [
+      ...new Set(
+        rows
+          .filter((p) => p.forTeam && String(p.beneficiaryUserId) === String(agent.id) && p.agentId)
+          .map((p) => p.agentId),
+      ),
+    ];
+    const payerNames = new Map();
+    if (payerIds.length > 0) {
+      const payers = await d.User.findAll({
+        where: { id: payerIds },
+        attributes: ['id', 'firstName', 'lastName', 'fullName'],
+      }).catch(() => []);
+      for (const u of payers) {
+        payerNames.set(String(u.id), u.fullName || `${u.firstName || ''} ${u.lastName || ''}`.trim() || null);
+      }
+    }
+
+    const purchases = rows.map((p) => {
+      const direction = !p.forTeam ? 'self' : String(p.agentId) === String(agent.id) ? 'for_team' : 'from_manager';
+      return {
+        id: p.id,
+        packageName: p.packageName || 'Lead package',
+        leadCount: p.leadCount,
+        amount: Number(p.amount),
+        currency: p.currency || 'SGD',
+        status: toPurchaseStatus(p.status),
+        createdAt: (p.createdAt instanceof Date ? p.createdAt : new Date(p.createdAt)).toISOString(),
+        direction,
+        beneficiaryName: direction === 'for_team' ? (p.beneficiaryName ?? null) : null,
+        payerName: direction === 'from_manager' ? (payerNames.get(String(p.agentId)) ?? null) : null,
+      };
+    });
     return { purchases };
   }
 
@@ -219,21 +275,27 @@ export function makeBillingService(overrides = {}) {
         return { status: 'rejected' };
       }
 
-      // Parent (agent/package) deleted between checkout and settlement → can't build the assignment
-      // (NOT NULL FKs). Don't 500 forever: record the money as PAID (truthful) but UNFULFILLED, for
-      // manual review / the Phase-2 reconciliation sweep (paid-without-assignment).
-      if (!payment.agentId || !payment.leadPackageId) {
+      // The GRANTEE: the snapshotted beneficiary for a team purchase, else the payer.
+      // forTeam is immutable and survives the beneficiary FK SET NULL, so an explicit
+      // team purchase NEVER silently falls back to crediting the payer.
+      const granteeId = payment.forTeam ? payment.beneficiaryUserId : payment.agentId;
+
+      // Parent (grantee/package) deleted between checkout and settlement → can't build the
+      // assignment (NOT NULL FKs) — or a team purchase's beneficiary vanished. Don't 500
+      // forever: record the money as PAID (truthful) but UNFULFILLED, for manual review /
+      // the reconciliation sweep (paid-without-assignment).
+      if (!granteeId || !payment.leadPackageId) {
         await payment.update(
           { status: 'paid', providerPaymentId: providerPaymentId ? String(providerPaymentId) : payment.providerPaymentId, rawWebhook: payload },
           { transaction: t },
         );
-        d.logger.error('[billing] fulfillment.unfulfillable — paid but agent/package missing; manual review', { ref, agentId: payment.agentId, leadPackageId: payment.leadPackageId });
+        d.logger.error('[billing] fulfillment.unfulfillable — paid but grantee/package missing; manual review', { ref, agentId: payment.agentId, beneficiaryUserId: payment.beneficiaryUserId, forTeam: payment.forTeam === true, leadPackageId: payment.leadPackageId });
         return { status: 'paid_unfulfilled' };
       }
 
       const assignment = await d.LeadPackageAssignment.create(
         {
-          agentId: payment.agentId,
+          agentId: granteeId,
           leadPackageId: payment.leadPackageId,
           leadsTotal: payment.leadCount,
           leadsRemaining: payment.leadCount,
@@ -254,7 +316,7 @@ export function makeBillingService(overrides = {}) {
         { transaction: t },
       );
 
-      d.logger.info('[billing] fulfillment.paid', { ref, agentId: payment.agentId, assignmentId: assignment.id, leadCount: payment.leadCount });
+      d.logger.info('[billing] fulfillment.paid', { ref, agentId: payment.agentId, granteeId, forTeam: payment.forTeam === true, assignmentId: assignment.id, leadCount: payment.leadCount });
       return { status: 'fulfilled', assignmentId: assignment.id, leadPackageId: payment.leadPackageId };
     });
 

--- a/backend/test/unit/billingService.test.js
+++ b/backend/test/unit/billingService.test.js
@@ -36,6 +36,10 @@ function build({
   assignment = { id: 'asg-1' },
   hitpayThrows = false,
   hitpayResult = { id: 'hp-req-1', url: 'https://hit-pay.com/pay/abc' },
+  // Beneficiary tests: resolveAgent is called per party — map mktrLeadsId → user row.
+  usersByMktrId = null,
+  // History payer-name lookups (User.findAll).
+  payerRows = [],
 } = {}) {
   const createdPayments = [];
   const Payment = {
@@ -49,7 +53,10 @@ function build({
   };
   const LeadPackage = { findByPk: jest.fn(async () => pkg) };
   const LeadPackageAssignment = { create: jest.fn(async () => assignment) };
-  const User = { findOne: jest.fn(async () => agent) };
+  const User = {
+    findOne: jest.fn(async (q) => (usersByMktrId ? (usersByMktrId[q?.where?.mktrLeadsId] ?? null) : agent)),
+    findAll: jest.fn(async () => payerRows),
+  };
   const Campaign = {};
   const sequelize = { transaction: jest.fn(async (cb) => cb({ LOCK: { UPDATE: 'UPDATE' } })) };
   const hitpay = {
@@ -239,5 +246,102 @@ describe('billingService status/history/catalog', () => {
     expect(r.packages.map((p) => p.id)).toEqual(['p1']);
     expect(r.packages[0]).toMatchObject({ name: 'A', leadCount: 20, price: 200, currency: 'SGD', campaignName: 'C', isRecommended: false });
     expect(['in_app', 'web', 'off']).toContain(r.checkoutMode);
+  });
+});
+
+describe('billingService — beneficiary purchases (manager buy-for-team, migration 043)', () => {
+  const okManager = { id: 'mgr-1', firstName: 'M', lastName: 'G', fullName: 'M G', email: 'm@g.co' };
+  const okMember = { id: 'ben-1', firstName: 'B', lastName: 'N', fullName: 'Ben N', email: 'b@n.co' };
+
+  it('snapshots beneficiary + forTeam + name at checkout', async () => {
+    const { svc, createdPayments } = build({
+      pkg: activePkg(),
+      usersByMktrId: { 'mu-mgr': okManager, 'mu-ben': okMember },
+    });
+    const r = await svc.createCheckout({
+      agentMktrUserId: 'mu-mgr',
+      packageId: 'pkg-1',
+      beneficiaryMktrUserId: 'mu-ben',
+    });
+    expect(r.status).toBe('created');
+    expect(createdPayments[0]).toMatchObject({
+      agentId: 'mgr-1',
+      beneficiaryUserId: 'ben-1',
+      forTeam: true,
+      beneficiaryName: 'Ben N',
+    });
+  });
+
+  it('rejects an unknown beneficiary (typed, before any Payment row exists)', async () => {
+    const { svc, Payment } = build({ pkg: activePkg(), usersByMktrId: { 'mu-mgr': okManager } });
+    const r = await svc.createCheckout({
+      agentMktrUserId: 'mu-mgr',
+      packageId: 'pkg-1',
+      beneficiaryMktrUserId: 'mu-ghost',
+    });
+    expect(r.status).toBe('invalid_beneficiary');
+    expect(Payment.create).not.toHaveBeenCalled();
+  });
+
+  it('a same-person beneficiary collapses to a plain self purchase', async () => {
+    const { svc, createdPayments } = build({ pkg: activePkg(), usersByMktrId: { 'mu-mgr': okManager } });
+    const r = await svc.createCheckout({
+      agentMktrUserId: 'mu-mgr',
+      packageId: 'pkg-1',
+      beneficiaryMktrUserId: 'mu-mgr',
+    });
+    expect(r.status).toBe('created');
+    expect(createdPayments[0]).toMatchObject({ forTeam: false, beneficiaryUserId: null, beneficiaryName: null });
+  });
+
+  it('fulfillment grants the assignment to the BENEFICIARY, never the payer', async () => {
+    const payment = fakePayment({ agentId: 'mgr-1', beneficiaryUserId: 'ben-1', forTeam: true });
+    const { svc, LeadPackageAssignment } = build({ payment });
+    const r = await svc.fulfillFromWebhook({
+      reference_number: 'pay-1',
+      payment_request_id: 'hp-req-1',
+      status: 'completed',
+      amount: '200.00',
+      currency: 'SGD',
+    });
+    expect(r.status).toBe('fulfilled');
+    expect(LeadPackageAssignment.create).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: 'ben-1' }),
+      expect.anything(),
+    );
+  });
+
+  it('a team purchase whose beneficiary vanished lands paid_unfulfilled — NO payer fallback', async () => {
+    // forTeam survives the FK SET NULL: the marker is what blocks the silent payer credit.
+    const payment = fakePayment({ agentId: 'mgr-1', beneficiaryUserId: null, forTeam: true });
+    const { svc, LeadPackageAssignment } = build({ payment });
+    const r = await svc.fulfillFromWebhook({
+      reference_number: 'pay-1',
+      payment_request_id: 'hp-req-1',
+      status: 'completed',
+      amount: '200.00',
+      currency: 'SGD',
+    });
+    expect(r.status).toBe('paid_unfulfilled');
+    expect(LeadPackageAssignment.create).not.toHaveBeenCalled();
+    expect(payment.status).toBe('paid'); // the money is recorded truthfully
+  });
+
+  it('history carries directions: self / for_team (+beneficiaryName) / from_manager (+payerName)', async () => {
+    const rows = [
+      { id: 'p1', agentId: 'mgr-1', forTeam: false, beneficiaryUserId: null, beneficiaryName: null, packageName: 'A', leadCount: 10, amount: '90.00', currency: 'SGD', status: 'paid', createdAt: new Date('2026-07-01') },
+      { id: 'p2', agentId: 'mgr-1', forTeam: true, beneficiaryUserId: 'ben-1', beneficiaryName: 'Ben N', packageName: 'B', leadCount: 20, amount: '200.00', currency: 'SGD', status: 'paid', createdAt: new Date('2026-07-02') },
+      { id: 'p3', agentId: 'boss-9', forTeam: true, beneficiaryUserId: 'mgr-1', beneficiaryName: 'M G', packageName: 'C', leadCount: 5, amount: '50.00', currency: 'SGD', status: 'paid', createdAt: new Date('2026-07-03') },
+    ];
+    const { svc, Payment } = build({
+      usersByMktrId: { 'mu-mgr': okManager },
+      payerRows: [{ id: 'boss-9', fullName: 'Big Boss', firstName: 'Big', lastName: 'Boss' }],
+    });
+    Payment.findAll.mockResolvedValue(rows);
+    const r = await svc.getHistory({ agentMktrUserId: 'mu-mgr' });
+    const byId = Object.fromEntries(r.purchases.map((p) => [p.id, p]));
+    expect(byId.p1).toMatchObject({ direction: 'self', beneficiaryName: null, payerName: null });
+    expect(byId.p2).toMatchObject({ direction: 'for_team', beneficiaryName: 'Ben N' });
+    expect(byId.p3).toMatchObject({ direction: 'from_manager', payerName: 'Big Boss' });
   });
 });


### PR DESCRIPTION
Phase 4a of the mktr-leads manager role (plan: `mktr-leads/MANAGER_ROLE_PLAN.md` v3). **Backend ships FIRST** — the app's buy-for-team UI (4b) gates on the `beneficiarySupported` capability these responses now advertise, because today's checkout whitelist silently drops unknown fields (a wrong-beneficiary real-money bug if the app shipped first).

- Migration 043: `payments.beneficiaryUserId` (FK SET NULL) + `forTeam` immutable marker (survives FK nulling) + `beneficiaryName` snapshot
- `createCheckout(+beneficiaryMktrUserId?)`: typed `invalid_beneficiary`; same-person → self; snapshot-at-checkout
- Fulfillment grants to the snapshot grantee; beneficiary-gone team purchase → `paid_unfulfilled` (never payer fallback)
- History: payer + grantee rows with `direction`/`beneficiaryName`/`payerName`
- 25/25 unit tests (6 new)

⚠️ After merge: **Render Manual Deploy** on `mktr-backend-jo6r` (also carries #89's mirror widenings). The deploy runs migration 043 on boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)