### PR TITLE
docs(redeem-ops): Phase 0 discovery + architecture (Codex-reviewed)

### DIFF
--- a/docs/redeem-ops/ARCHITECTURE_OPTIONS.md
+++ b/docs/redeem-ops/ARCHITECTURE_OPTIONS.md
@@ -1,0 +1,140 @@
+# Redeem Ops — Architecture Options
+
+> Phase 0 deliverable. Options are constrained to what the repository actually is (see
+> `REPOSITORY_DISCOVERY.md`): a single Express+Sequelize backend on one Postgres, a single React SPA
+> compiled into multiple Render static sites by build flag, no queue infra, no workspace tooling.
+> The intended user surfaces (mktr.sg operators, ops.redeem.sg internal staff, future
+> partners.redeem.sg, consumer redeem.sg) are product boundaries — evaluated here for how each
+> option realizes them, not taken as a mandate for physical separation.
+
+## Option A — Redeem Ops as a new surface of the existing application
+
+New backend module namespace (`/api/redeem-ops/*`, flag-mounted) + new SPA route group
+(`/redeem-ops/*`) in the same codebase. Exposure in two steps: dark on mktr.sg behind flags for
+dogfooding, then a **third Render static site at `ops.redeem.sg`** built from the same commit with
+a surface flag (exact mechanism the repo already uses for redeem.sg).
+
+- **Advantages**
+  - Reuses everything that is already proven: auth (`authenticateToken`), Joi validation,
+    error/log/Sentry plumbing, route auto-loader with env-flag dark-launch, migration runner,
+    DI-factory testing, shadcn UI kit, TanStack Query, DashboardLayout shell.
+  - Direct FKs to `campaigns.id`, `prospects.id`, `users.id` — referential integrity and
+    server-side joins instead of sync/projection code.
+  - Zero new operational surface area until cutover; one deploy pipeline; single Sentry/logging.
+  - The two-brand precedent (`VITE_BRAND`) means the ops.redeem.sg surface is configuration, not
+    architecture: one Render static site + DNS + allowlist entries.
+  - Smallest possible diff to reach the V1 goal (3 outreach staff working daily).
+- **Disadvantages**
+  - Monolith grows (~15 more models, ~8 route files); model/route dirs are flat by auto-loader
+    constraint, so boundary discipline is by naming convention + review, not filesystem walls.
+  - Shared blast radius: a bad Redeem Ops migration runs in the same boot path as production MKTR
+    (mitigated: migrations are additive-only new tables; flag-gated routes).
+  - Backend rate limiter / CORS / host-guard lists need deliberate updates for the new namespace
+    and host.
+- **Deployment impact**: none initially (flags off); later +1 static site + DNS records.
+- **Authentication**: reuse JWT cookie identity unchanged; per-host sessions come free
+  (host-only cookie). No new login system.
+- **Authorization**: additive — new `redeem_ops` role value + `redeemOpsRole` sub-role +
+  capability middleware; existing MKTR role gates untouched.
+- **Database ownership**: same Postgres; Redeem Ops owns its tables (clear prefix set), touches
+  MKTR tables only via FKs and read-only queries.
+- **API coupling**: in-process service calls where needed (campaign projection, entitlement hook);
+  no HTTP hop between "systems".
+- **Development complexity**: low — one repo, one dev server pair, existing test harness.
+- **Operational complexity**: low — one backend instance, in-process sweeps per house pattern.
+- **Migration risk**: low — additive tables, flag-gated mounts, no changes to capture path until
+  Phase 6 (and then post-commit + reconciliation only).
+- **Long-term maintainability**: good if the module boundary is enforced by convention (namespaced
+  files, `services/redeemOps/`, its own audit + permission modules). If Redeem Ops one day needs
+  independent scaling/teams, the namespaced module + its table set is the extraction seam.
+
+## Option B — Sibling frontend application in the repository, shared backend
+
+A second Vite app (e.g. `ops-app/` with its own `package.json`, router, layout, design baseline),
+still calling the same backend; backend work identical to Option A.
+
+- **Advantages**
+  - Hard bundle isolation: ops UI cannot leak into consumer/admin bundles and vice versa; freedom
+    to diverge visually (denser B2B chrome) without touching MKTR pages.
+  - Clear future home for a partner portal as a third sibling app.
+- **Disadvantages**
+  - Duplicates the entire frontend substrate: API client, auth store, query client, UI kit config,
+    Tailwind/design tokens, Sentry init, test setup — either copied (drift) or extracted into a
+    shared package (which drags in workspace tooling the repo deliberately does not have).
+  - Two `node_modules`/build pipelines in one repo without workspace management is the worst of
+    both worlds; introducing pnpm/Turbo contradicts the "only if justified" constraint — and it
+    isn't: the existing `VITE_BRAND` mechanism already achieves per-surface bundles with tree-shaken
+    route gating (verified: redeem build excludes admin code).
+  - Slower V1: substrate duplication before any partner CRM value ships.
+- **Deployment impact**: +1 static site (same as A eventually) but with its own build config.
+- **Auth/Authorization/DB/API coupling**: identical to A (same backend).
+- **Development complexity**: medium-high (double frontend maintenance).
+- **Operational complexity**: medium (second build to keep green).
+- **Migration risk**: low for MKTR, but higher chance of half-finished shared-code extraction.
+- **Long-term maintainability**: only pays off if the ops UI must diverge radically; the existing
+  brand-flag mechanism gives 90% of the isolation at 10% of the cost.
+
+## Option C — Separate application (own repo/service) with an internal API to MKTR
+
+Standalone Redeem Ops service (own backend + frontend + DB or schema), talking to MKTR over
+HTTP/webhooks for campaign lookup and lead references.
+
+- **Advantages**
+  - Maximum isolation: independent deploys, independent failure domains, freedom of stack.
+  - Cleanest story if Redeem Ops were ever a separately sold product or separately staffed team.
+- **Disadvantages**
+  - Duplicates by necessity everything the brief forbids duplicating: second auth system (or an
+    SSO layer the repo doesn't have — the JWKS/auth-service spike is dormant and unproven in prod),
+    second DB + credentials, second Sentry/CI/deploy, HMAC internal APIs for campaign search and
+    lead reference, sync jobs and eventual-consistency handling for what would otherwise be a
+    foreign key.
+  - The entitlement flow (lead → entitlement) becomes a cross-service webhook with retry/dedup
+    machinery — MKTR's webhook engine could serve it, but that's real new surface area for zero
+    user value.
+  - Two-sided changes for every integration tweak; slowest V1 by far.
+  - Contradicts observed reality: this team runs one backend instance and consolidates (the
+    microservices spike in `services/` was abandoned, in-process crons chosen over separate
+    Render crons for exactly the credential/duplication reasons documented in `bootstrap.js`).
+- **Deployment impact**: +2–3 services, +DB, +secrets management.
+- **Authentication**: new system or federation — highest-risk element.
+- **Authorization**: greenfield (no reuse).
+- **Database ownership**: clean separation but loses FKs; PII references require API contracts.
+- **API coupling**: high (every campaign/lead touch is a network call with auth).
+- **Dev complexity**: high. **Ops complexity**: high. **Migration risk**: low for MKTR code, high
+  for delivery. **Maintainability**: good isolation, poor economy at this team size.
+
+## Comparison summary
+
+| Dimension | A — new surface (same app) | B — sibling frontend | C — separate service |
+|---|---|---|---|
+| Time to V1 (3 staff daily use) | **Fastest** | Medium | Slowest |
+| Reuse of proven infra | **Maximal** | Backend only | Minimal |
+| Campaign/Lead integrity | **DB FKs** | DB FKs | API contracts + sync |
+| New auth work | **None** | None | New system |
+| Deploy/ops overhead | **None → +1 static site** | +1 build pipeline | +2–3 services |
+| Boundary enforcement | Convention + review | Filesystem | Network |
+| Extraction path later | Module seam exists | Same seam | Already extracted |
+| Fits repo precedent | **Yes (two-brand pattern)** | Partially | No (spike abandoned) |
+
+## Recommendation
+
+**Option A**, with these boundary commitments (detailed in `RECOMMENDED_ARCHITECTURE.md`):
+
+1. Backend namespace `redeemOps*` (routes flat per auto-loader; controllers/services under
+   `controllers/redeemOps/` and `services/redeemOps/`), all mounts flagged `REDEEM_OPS_ENABLED`
+   (default off).
+2. Own table set (partner_*, reward_*, activations, redemptions, redeem_ops_audit_events) —
+   MKTR tables referenced by FK, never written except via existing MKTR services.
+3. Own authorization layer (`redeemOpsRole` + capability middleware) that cannot loosen any
+   existing MKTR gate.
+4. Surface exposure via the existing brand/surface build mechanism, targeting **ops.redeem.sg**
+   as a third static site; mktr.sg `/redeem-ops/*` used only as the flagged dogfood entry before
+   cutover.
+5. Option C's seam is preserved deliberately: if extraction is ever justified, the module +
+   its tables + `/api/redeem-ops/*` contract lift out; nothing in Phase 1–6 may blur that seam
+   (e.g. no MKTR service importing Redeem Ops services — dependency direction is one-way,
+   Redeem Ops → MKTR).
+
+Option B is rejected as premature duplication; Option C is rejected as infrastructure the product
+does not need and the team's own history argues against. Do not implement until
+`RECOMMENDED_ARCHITECTURE.md` is accepted.

--- a/docs/redeem-ops/CODEX_REVIEW_PHASE0.md
+++ b/docs/redeem-ops/CODEX_REVIEW_PHASE0.md
@@ -1,0 +1,41 @@
+# Codex Review — Redeem Ops Phase 0 Docs (2026-07-08)
+
+Reviewer: Codex CLI 0.135.0 (`codex exec`, read-only sandbox) against the working tree.
+Verdict as issued: **REWORK** — "resolve the surface/host/auth boundary model, redesign entitlement
+issuance so it is server-verified and durable, and tighten the role/migration/schema plan."
+
+Per house workflow, every finding was **verified against the actual code before folding in**.
+All accepted fixes are documentation/design-detail changes; none reversed the recommended
+architecture (Option A). Post-fix status: all 14 findings dispositioned; docs updated in place.
+
+| # | Sev (Codex) | Finding | Verification | Disposition |
+|---|---|---|---|---|
+| 1 | BLOCKER | "One-way dependency rule" contradicted by the Phase 6 hook (MKTR calls Redeem Ops at runtime) | Wording critique — the DI-seam design already avoided imports, but the rule text was absolute and self-contradictory | **Accepted (as wording fix, not redesign)**: rule restated as a one-way *import* rule with the hook as explicit dependency inversion (no-op default callback, wired at bootstrap). `RECOMMENDED_ARCHITECTURE.md` §1/§10.6, `MKTR_INTEGRATION.md` §2 |
+| 2 | BLOCKER | Entitlement issuance would trust the SPA-only OTP gate — `POST /api/prospects` is public/unverified, so `lead.created` is forgeable (fake-reward + inventory-exhaustion vectors) | CONFIRMED: `routes/prospects.js` (no auth/verification), OTP client-side in `CampaignSignupForm.jsx:129-185`, server marker only used by DNC (`verificationService.js:228-233`) | **Accepted**: issuance precondition added — backend stamps `sourceMetadata.phoneVerifiedAt` at create (from `verifiedPhoneStore`, same DI-seam change); hook AND sweep issue only for stamped prospects; anti-farming test added. `MKTR_INTEGRATION.md` §2.0, `IMPLEMENTATION_PLAN.md` Phase 6 + risk register |
+| 3 | MAJOR | Admin rate-limit bypass functionally dead for cookie sessions (`optionalAuth` mounted before `cookieParser`) | CONFIRMED: `server_internal.js:120` vs `:159`; `auth.js:174` reads `req.cookies`; SPA sends no Bearer (`client.js:29`) | **Accepted** — this is a **pre-existing MKTR bug**, now documented in `REPOSITORY_DISCOVERY.md` §4 and the risk register (fix ordering before relying on any `redeem_ops` bypass) |
+| 4 | MAJOR | Ops host could reach `/api/admin/*` at the host layer (guard only blocks redeem hosts) | CONFIRMED: `internalRouteHostGuard.js:39-40`, `publicHost.js:69-73` | **Accepted**: explicit ops-host allow-policy specified (`isOpsHost()` → only `/api/auth`, `/api/redeem-ops`, `/api/notifications`; 403 other internal prefixes). `RECOMMENDED_ARCHITECTURE.md` §5, `USER_SURFACES…` §2, `IMPLEMENTATION_PLAN.md` Phase 1 |
+| 5 | MAJOR | Future consumer claim endpoint at `/api/redeem-ops/fulfilment/claim` contradicts blocking that prefix from consumer redeem.sg | CONFIRMED contradiction within `ROUTE_MAP.md` | **Accepted**: consumer claim moved to a separate public namespace `POST /api/reward-claim`; surface matrix updated. `ROUTE_MAP.md` |
+| 6 | MAJOR | `VITE_SURFACE` described as a verified mechanism; it doesn't exist (only `VITE_BRAND` does) | CONFIRMED: `vite.config.js:6-9` | **Accepted (precision)**: `VITE_SURFACE` re-labelled as proposed Phase 1 work replicating the verified `VITE_BRAND` precedent. `RECOMMENDED_ARCHITECTURE.md` §5, `USER_SURFACES…` §3 |
+| 7 | MAJOR | Duplicate-signup 409 not race-safe: a lost concurrent insert hits the unique index and returns generic 400 | CONFIRMED: pre-check 409 at `prospectService.js:406-420`; `errorHandler.js:48-55` maps `SequelizeUniqueConstraintError` → 400; index from migration 010 | **Accepted (doc precision)**: nuance documented in `REPOSITORY_DISCOVERY.md` §9; optional MKTR fix noted in risk register. Pre-existing MKTR behaviour, not a Redeem Ops defect |
+| 8 | MAJOR | Enum-migration guidance imprecise (runner has no implicit transaction; 029's comment wrong) and the role change omitted code touchpoints (`User.js` enum list, `userService.js:146` invite allowlist) | CONFIRMED: `runMigrations.js:52-63` non-transactional; `userService.js:146` allows only 3 roles; 029 comment claims "implicit transaction" | **Accepted**: exact touchpoint checklist added (model ENUM, invite allowlist, roleLabel, Joi schemas, `getDefaultRouteForRole`); transaction wording corrected. `ERD.md` §2, `IMPLEMENTATION_PLAN.md` Phase 1 + risk register, `REPOSITORY_DISCOVERY.md` §6 |
+| 9 | MAJOR | `UNIQUE (activationId, prospectId)` incomplete: nullable `prospectId` → Postgres allows multiple NULLs | CONFIRMED Postgres semantics; NULL only arises post-deletion (no NULL-at-issuance path), so the practical risk was narrow | **Accepted**: changed to partial unique `WHERE prospectId IS NOT NULL` with rationale. `ERD.md` §3.16, `MKTR_INTEGRATION.md` §2 |
+| 10 | MAJOR | `redemptions.entitlementId UNIQUE` conflicts with `status='reversed'` re-redemption | Design tension confirmed | **Accepted**: reversal declared **terminal** (re-fulfilment = cancel entitlement + manual re-issue); partial-unique escape hatch documented. `ERD.md` §3.17 |
+| 11 | MAJOR | ERD under-indexed for 10k+ partner list workflows | Partially fair; the brief (§36) explicitly forbids speculative indexes | **Accepted in modified form**: hot-path indexes stay; list-view composites deferred to Phase 2, finalized via EXPLAIN on seeded data (measure-then-index note added). `ERD.md` §3.1 |
+| 12 | MINOR | Inventory counts wrong (38 models not 39; migrations start 002; runner discovers only `.js`) | CONFIRMED by recount/listing | **Accepted**: counts corrected. `REPOSITORY_DISCOVERY.md` §2/§6 |
+| 13 | MINOR | Post-commit fan-out overstated — assignment/confirmation emails fire from the controller, not the service | CONFIRMED: `prospectController.js:58-72` | **Accepted**: description split into service-level fan-out vs controller-level emails. `REPOSITORY_DISCOVERY.md` §9, `MKTR_INTEGRATION.md` §2 |
+| 14 | MINOR | Render topology (3 services, rewrites) unverifiable from source — no `render.yaml` | CONFIRMED (topology is operational knowledge from the Render dashboard/MCP + CLAUDE.md) | **Accepted**: provenance note added marking deployment topology as operational knowledge. `REPOSITORY_DISCOVERY.md` §7 |
+
+## Net assessment after fixes
+
+- Codex's REWORK verdict rested on three themes; all are now addressed **without changing the
+  chosen architecture**: (1) surface/host/auth boundary made explicit (ops-host allow-policy,
+  VITE_SURFACE labelled as new work, public claim namespace split out); (2) entitlement issuance
+  made server-verified and durable (verification stamp + partial-unique anchor + terminal-reversal
+  policy); (3) role/migration plan made mechanical (touchpoint checklist, corrected transaction
+  semantics).
+- Bonus outcomes for MKTR itself (pre-existing, surfaced by this review): the dead admin
+  rate-limit bypass for cookie sessions (`optionalAuth` before `cookieParser`), the
+  duplicate-race 400-instead-of-409, and migration 029's inaccurate "implicit transaction"
+  comment. None block Redeem Ops; the limiter ordering should be fixed before any bypass is
+  extended to ops staff.
+- Raw Codex output: session scratchpad (`codex_review_output.md`); this file is the durable record.

--- a/docs/redeem-ops/DOMAIN_OWNERSHIP.md
+++ b/docs/redeem-ops/DOMAIN_OWNERSHIP.md
@@ -1,0 +1,64 @@
+# Redeem Ops — Domain Ownership Map
+
+> Phase 0 deliverable. Purpose: prevent accidental domain duplication. "MKTR" below means the
+> existing monolith's acquisition domains (same repo, same DB); "Redeem Ops" means the new module
+> namespace defined in `RECOMMENDED_ARCHITECTURE.md`. Integration methods reference
+> `MKTR_INTEGRATION.md`.
+
+## Ownership table
+
+| Domain | Current Owner (system of record) | Future Owner | Integration Method | Notes / canonical artifact |
+|---|---|---|---|---|
+| Campaign | MKTR — `campaigns` table | **MKTR (unchanged)** | FK reference (`activations.campaignId`) + read-only projection endpoint | `backend/src/models/Campaign.js`, `campaignService.js`. Redeem Ops never writes campaigns. |
+| Campaign Builder | MKTR — designer/workspace UI | **MKTR (unchanged)** | Deep link only (`/admin/campaigns/:id/workspace` on mktr.sg) | `src/pages/AdminCampaignDesigner.jsx`, `AdminCampaignWorkspace.jsx`. No second builder. |
+| Landing Page | MKTR — `Campaign.design_config` rendered by `LeadCapture.jsx` | **MKTR (unchanged)** | None (Redeem Ops displays the public URL only) | Host-aware URLs via `src/lib/brand.js` helpers. |
+| Lead | MKTR — `prospects` table | **MKTR (unchanged)** | FK reference (`reward_entitlements.prospectId`) + server-side joined reads | `backend/src/models/Prospect.js`. Redeem Ops stores no lead PII copies. |
+| OTP Verification | MKTR — `verifications` + `verificationService.js` | **MKTR (unchanged)** | None in V1; Phase 6 redemption may *reuse the service* for consumer phone checks (no new OTP system) | AWS SNS / WhatsApp; SG-only. |
+| Consent | MKTR — `prospects.consentMetadata` + `sourceMetadata.consent_*` | **MKTR (unchanged)** | Read-only interpretation when issuing entitlements / partner disclosure | `externalConsent.js` is the interpretation precedent. |
+| Attribution | MKTR — `attributions`, `qr_scans`, `session_visits`, `sourceMetadata` | **MKTR (unchanged)** | Not consumed by Redeem Ops V1; activation analytics read campaign aggregates only | `trackerService.js`, `leadCaptureBind.js`. |
+| Lead Routing | MKTR — `systemAgent.js` round-robin, quota, held queue | **MKTR (unchanged)** | None. Reward entitlement issuance is post-capture and must never influence routing | `resolveLeadRouting` / `resolveLeadAssignment`. |
+| Agent/Advisor Assignment | MKTR — `prospects.assignedAgentId` / `externalAgentId` | **MKTR (unchanged)** | Read-only display where relevant (e.g. entitlement context) | Agent sources synced from Lyfe/mktr-leads. |
+| Financial-planning outcomes | MKTR/Lyfe — `leadStatus`, down-funnel CAPI | **MKTR (unchanged)** | Not exposed to partners; internal analytics may read aggregates | `leadOutcomeService.js`. Privacy rule §35.2. |
+| Partner Organisation | none | **Redeem Ops** | native | New `partner_organisations` (greenfield — verified no existing model). |
+| Partner Location | none | **Redeem Ops** | native | New `partner_locations`. |
+| Partner Contact | none | **Redeem Ops** | native | New `partner_contacts`. Distinct from MKTR consumer `prospects` and from `contact.js` (public contact-us form). |
+| Outreach Activity | none | **Redeem Ops** | native | New `outreach_activities`. Pattern precedent: `prospect_activities`. |
+| Task / Follow-up | none | **Redeem Ops** | native | New `outreach_tasks`. `Prospect.nextFollowUpDate` is a lead field, not a task system — do not overload it. |
+| Partner Pipeline (stages) | none | **Redeem Ops** | native | New `partner_organisations.pipelineStage` + `partner_stage_events` history. |
+| Business Claiming / Ownership | none | **Redeem Ops** | native | New `ownerUserId` + `partner_assignment_events`; concurrency via conditional UPDATE (house pattern). |
+| Prospecting Pool | none | **Redeem Ops** | native | New `prospecting_pools` + members; claim-next via `FOR UPDATE SKIP LOCKED` (pattern: `chargeLeadCredit`). |
+| Partner Onboarding | none | **Redeem Ops** | native | New `partner_onboarding_items` (templated checklist). |
+| Reward Offer | none | **Redeem Ops** | native | New `reward_offers`. NOT the campaign `gift*` columns (migration 044 — MKTR→agent gift purchase; different domain, stays with MKTR billing). |
+| Reward Terms | none | **Redeem Ops** | native | New `reward_terms_versions` (versioned structured + free-text). |
+| Reward Inventory | none | **Redeem Ops** | native | New `reward_inventory_events` ledger + guarded counters. Precedent to follow for safety (not for shape): `lead_package_assignments.leadsRemaining` counters. |
+| Reward Allocation | none | **Redeem Ops** | native | Ledger `allocated`/`deallocated` events bound to an Activation. |
+| Activation | none | **Redeem Ops** | native + FK to `campaigns.id` | New `activations`. Explicitly NOT a campaign: no design_config, no forms, no pixels, no routing. |
+| Campaign Link (Activation↔Campaign) | none | **Redeem Ops** | FK + read-only campaign projection | Unique active activation per campaign (see `ERD.md`). |
+| Reward Entitlement | none | **Redeem Ops** | native + FK to `prospects.id` | New `reward_entitlements`; idempotent on `(activationId, prospectId)`. |
+| Redemption | none | **Redeem Ops** | native | New `redemptions` + `redemption_events`; random token, server-validated, double-redemption-proof. |
+| Partner Analytics | none | **Redeem Ops** | native (Redeem data) + read-only MKTR aggregates | Acquisition numbers always sourced from MKTR (`computeCampaignMetrics`), never re-counted. |
+| Partner Renewal | none | **Redeem Ops** | native | Renewal outcome recorded on Activation + follow-up task; no new scheduling infra. |
+| Identity / Login (internal staff) | MKTR — `users` + JWT cookie | **MKTR (shared)** | Same `authenticateToken`; new sub-role column + capability middleware | See `PERMISSION_MATRIX.md`. No second auth system. |
+| Identity (future partner portal users) | none | **Redeem Ops (future)** | Separate `partner_users` principal table, same JWT infra, distinct token scope | Designed-not-built; see `RECOMMENDED_ARCHITECTURE.md` §7. |
+| Audit Log (Redeem Ops actions) | none (no generic infra exists) | **Redeem Ops** | native | New `redeem_ops_audit_events`, append-only. |
+| Notifications / Email | MKTR — `mailer.js` (brand-aware senders) | **MKTR (shared)** | Direct service reuse for task/assignment emails (later) | `resolveEmailFrom(context)` already supports per-surface senders. |
+| File uploads | MKTR — `uploadService.js` → `backend/uploads/` | **MKTR (shared)** | Direct reuse if partner logos/docs needed (later) | |
+
+## Duplication tripwires (things that look adjacent but must stay separate)
+
+1. **Partner Organisation vs `users`/`external_agents`** — partners are businesses we sell rewards
+   *from*; users are staff/agents. Never model partner businesses as users. (Future partner-portal
+   *people* get their own principal table.)
+2. **Outreach pipeline vs lead pipeline** — `Prospect.leadStatus` (`new…won`) is consumer-lead
+   lifecycle; the partner pipeline (`UNCLAIMED…PARTNERED`) is a different state machine on a
+   different entity. No shared enum.
+3. **Reward Offer vs Campaign gift (migration 044)** — the gift catalog is a *billing* feature
+   (agents buy a gift from MKTR). Reward Offers are partner-funded supply with inventory and
+   redemption. If the business later unifies them, that is a product decision — not assumed here.
+4. **Activation vs Campaign** — an Activation *references* a campaign; activating/pausing a
+   campaign remains `setCampaignLaunchState` in MKTR. Activation status is operational
+   (reward-side) only.
+5. **Redemption vs lead outcome** — redeeming a reward is not `leadStatus=won`; neither writes the
+   other automatically in V1.
+6. **Outreach tasks vs Lyfe candidate/interview machinery** — Lyfe's recruitment domain lives in a
+   different product entirely; nothing here touches Supabase.

--- a/docs/redeem-ops/ERD.md
+++ b/docs/redeem-ops/ERD.md
@@ -1,0 +1,360 @@
+# Redeem Ops — ERD & Schema Design
+
+> Phase 0 deliverable. All tables are NEW except two additive columns on `users`. Conventions
+> follow the repo (see `REPOSITORY_DISCOVERY.md` §6): UUID v4 PKs, snake_case plural table names,
+> Sequelize-default camelCase columns + `createdAt`/`updatedAt`, explicit associations in
+> `models/index.js`, `STRING(n)` + app-level constant lists instead of `DataTypes.ENUM` for
+> evolving states (house drift, e.g. `Prospect.dncStatus`). Migrations begin at **045**.
+
+## 1. Entity-relationship diagram
+
+```mermaid
+erDiagram
+    users ||--o{ partner_organisations : "owns (ownerUserId)"
+    partner_organisations ||--o{ partner_locations : has
+    partner_organisations ||--o{ partner_contacts : has
+    partner_organisations ||--o{ partner_assignment_events : "ownership history"
+    partner_organisations ||--o{ partner_stage_events : "stage history"
+    partner_organisations ||--o{ outreach_activities : timeline
+    partner_organisations ||--o{ outreach_tasks : tasks
+    partner_organisations ||--o{ partner_onboarding_items : checklist
+    partner_organisations ||--o{ reward_offers : supplies
+    partner_organisations ||--o{ prospecting_pool_members : "pooled as"
+    prospecting_pools ||--o{ prospecting_pool_members : contains
+    partner_contacts ||--o{ outreach_activities : "with contact"
+    partner_contacts ||--o{ outreach_tasks : "about contact"
+    reward_offers ||--o{ reward_terms_versions : "versioned terms"
+    reward_offers ||--o{ reward_offer_locations : "participating at"
+    partner_locations ||--o{ reward_offer_locations : ""
+    reward_offers ||--o{ reward_inventory_events : ledger
+    reward_offers ||--o{ activations : "used in"
+    campaigns ||--o{ activations : "referenced by (FK, read-only)"
+    activations ||--o{ reward_entitlements : issues
+    reward_offers ||--o{ reward_entitlements : ""
+    prospects ||--o{ reward_entitlements : "canonical lead ref"
+    reward_entitlements ||--o| redemptions : "at most one"
+    redemptions ||--o{ redemption_events : history
+    activations ||--o{ reward_inventory_events : "allocation ref"
+    users ||--o{ redeem_ops_audit_events : actor
+```
+
+`campaigns`, `prospects`, `users` are the existing MKTR tables — referenced, never redefined.
+
+## 2. Changes to existing tables (migration 045)
+
+`users` (additive only):
+- `role` enum: `ALTER TYPE "enum_users_role" ADD VALUE IF NOT EXISTS 'redeem_ops'`
+  (idempotent, PG 12+; precedent: migration 029. The custom runner does **not** wrap migrations in
+  a transaction — `runMigrations.js:52-63` — so no transaction caveats apply; 029's comment saying
+  otherwise is wrong). The enum value is unusable until every code-side touchpoint lands in the
+  same change: `User.js:47` role ENUM list, `userService.inviteUser` `allowedRoles`
+  (`backend/src/services/userService.js:146` — currently `agent|fleet_owner|driver_partner` only),
+  `invitationService` roleLabel (`invitationService.js:63`), the Joi user/invite schemas
+  (`middleware/validation.js`), and `getDefaultRouteForRole` (`src/lib/utils.js:8`).
+- `redeemOpsRole` STRING(32) NULL — sub-role: `super_admin|ops_admin|bdm|outreach_exec|campaign_ops|redemption_ops|analyst`.
+
+## 3. Tables
+
+### 3.1 `partner_organisations` (model `PartnerOrganisation`)
+
+| Column | Type | Notes |
+|---|---|---|
+| id | UUID PK | |
+| legalName / tradingName / brandName | STRING(160) / STRING(160) / STRING(120) | display values; at least one required |
+| normalizedName | STRING(160) NOT NULL | matching key (see §5 normalization) |
+| uen | STRING(16) NULL | uppercased; **unique partial index** WHERE uen IS NOT NULL |
+| website | STRING(255) NULL | as entered |
+| websiteDomain | STRING(160) NULL | normalized eTLD+1-ish key; indexed |
+| primaryPhone | STRING(20) NULL | E.164 (+65…) — same validation shape as `Prospect.phone`; **unique partial index** |
+| primaryEmail | STRING(160) NULL | lowercased for match |
+| instagramHandle / tiktokHandle | STRING(64) NULL | normalized (no @, lowercase); unique partial per column |
+| facebookUrl / linkedinUrl | STRING(255) NULL | plus `facebookHandle` STRING(120) normalized, indexed |
+| category / subcategory | STRING(64) / STRING(64) | e.g. Pet Grooming / Cat Grooming |
+| source | STRING(64) | manual, import batch ref, pool, referral |
+| tags | JSONB default [] | |
+| notes | TEXT | |
+| pipelineStage | STRING(32) NOT NULL default 'UNCLAIMED' | see §6 stage list |
+| availability | STRING(24) NOT NULL default 'available' | `available|owned|follow_up_later|restricted|disqualified` (claim gate) |
+| ownerUserId | UUID NULL FK→users **SET NULL** | current owner; NULL = unowned |
+| claimedAt | DATE NULL | |
+| firstOutreachAt | DATE NULL | stamped by first qualifying activity |
+| lastActivityAt | DATE NULL | denormalized for queue/stale queries |
+| nextTaskAt | DATE NULL | denormalized from open tasks |
+| atRiskFlag / staleFlag | BOOLEAN default false | set by sweep, cleared by activity |
+| mergedIntoId | UUID NULL self-FK | set when merged; row retained, hidden from lists |
+| archivedAt | DATE NULL | soft archive |
+| createdBy | UUID FK→users **RESTRICT** | |
+
+Indexes: `(ownerUserId, pipelineStage)`, `(pipelineStage)`, `(availability)`, `(category)`,
+`(lastActivityAt)`, `(nextTaskAt)`, `(normalizedName)`, `(websiteDomain)`, uniques above.
+These cover the claim/queue/stale hot paths from day one; further list-view composites (e.g.
+stage+category+lastActivity combinations, archived/merged partial filters) are **deliberately
+deferred to Phase 2**, finalized with EXPLAIN against the real filter combinations on seeded data —
+the brief (§36) forbids speculative indexes, so the plan is measure-then-index, not guess.
+If `pg_trgm` is available (attempted `CREATE EXTENSION IF NOT EXISTS` inside a try/catch in the
+migration — the custom runner permits it), add `GIN (normalizedName gin_trgm_ops)`; otherwise
+fuzzy matching falls back to prefix + postal heuristics (§5).
+
+### 3.2 `partner_locations` (`PartnerLocation`)
+
+id; partnerOrganisationId FK **CASCADE**; name STRING(120); addressLine STRING(255);
+postalCode STRING(6) (indexed); postalDistrict STRING(2) (derived from first 2 digits — SG district
+matching); area STRING(64); phone STRING(20) E.164 NULL; isActive BOOLEAN default true; notes TEXT.
+Index: `(partnerOrganisationId)`, `(postalCode)`.
+
+### 3.3 `partner_contacts` (`PartnerContact`)
+
+id; partnerOrganisationId FK **CASCADE**; name STRING(120) NOT NULL; roleTitle STRING(80);
+mobile STRING(20) E.164 NULL (indexed partial); whatsapp STRING(20) NULL; email STRING(160) NULL
+(lowercased, indexed partial); preferredChannel STRING(24) (`call|whatsapp|email|instagram|other`);
+isPrimary BOOLEAN default false; notes TEXT; archivedAt DATE NULL.
+
+### 3.4 `partner_assignment_events` (`PartnerAssignmentEvent`) — append-only
+
+id; partnerOrganisationId FK **CASCADE**; kind STRING(24)
+(`claim|assign|reassign|release|restrict|disqualify|merge`); fromUserId / toUserId UUID NULL FK→users
+SET NULL; actorUserId UUID NULL FK SET NULL; reason STRING(255); createdAt.
+Index `(partnerOrganisationId, createdAt)`.
+
+### 3.5 `partner_stage_events` (`PartnerStageEvent`) — append-only
+
+id; partnerOrganisationId FK **CASCADE**; fromStage/toStage STRING(32); actorUserId FK SET NULL;
+reason STRING(255) NULL; createdAt. Index `(partnerOrganisationId, createdAt)`.
+
+### 3.6 `outreach_activities` (`OutreachActivity`)
+
+id; partnerOrganisationId FK **CASCADE**; contactId UUID NULL FK→partner_contacts **SET NULL**;
+type STRING(32) (`call_attempt|call_connected|whatsapp_sent|whatsapp_reply|email_sent|email_reply|
+instagram_dm|facebook_message|meeting_booked|meeting_completed|proposal_sent|follow_up|
+internal_note|other`); direction STRING(12) (`outbound|inbound|internal`); summary STRING(255)
+NOT NULL; details TEXT; outcome STRING(64) NULL; occurredAt DATE NOT NULL default now;
+actorUserId FK→users SET NULL; editedAt DATE NULL + editedBy UUID NULL (corrections audited, row
+updated in place — original captured in audit `before`); voidedAt DATE NULL + voidReason (no
+destructive delete). "Meaningful" activity types (everything except `internal_note`) bump
+`partner_organisations.lastActivityAt` and stamp `firstOutreachAt` if null.
+Indexes: `(partnerOrganisationId, occurredAt DESC)`, `(actorUserId, occurredAt)`.
+
+### 3.7 `outreach_tasks` (`OutreachTask`)
+
+id; title STRING(160) NOT NULL; partnerOrganisationId FK **CASCADE**; contactId NULL FK SET NULL;
+assigneeUserId FK→users NOT NULL; createdBy FK→users; dueAt DATE NOT NULL; hasTime BOOLEAN default
+false (renders date-only vs timed); priority STRING(12) default 'medium'; type STRING(24)
+(`follow_up|call|meeting|proposal|admin|other`); status STRING(16) default 'open'
+(`open|in_progress|completed|cancelled`); description TEXT; completedAt DATE; completedBy UUID.
+Completing/cancelling recomputes the partner's `nextTaskAt`.
+Indexes: `(assigneeUserId, status, dueAt)`, `(partnerOrganisationId, status)`, `(dueAt)` partial
+WHERE status IN ('open','in_progress').
+
+### 3.8 `prospecting_pools` (`ProspectingPool`)
+
+id; name STRING(120) unique; description TEXT; category STRING(64) NULL; area STRING(64) NULL;
+isActive BOOLEAN default true; createdBy FK→users.
+
+### 3.9 `prospecting_pool_members` (`ProspectingPoolMember`)
+
+id; poolId FK **CASCADE**; partnerOrganisationId FK **CASCADE**; status STRING(16) default
+'available' (`available|claimed|removed|exhausted`); addedBy FK; claimedBy UUID NULL; claimedAt.
+**Unique (poolId, partnerOrganisationId).** Index `(poolId, status)`.
+
+### 3.10 `partner_onboarding_items` (`PartnerOnboardingItem`)
+
+id; partnerOrganisationId FK **CASCADE**; itemKey STRING(48) (template key, §22 checklist);
+label STRING(160); sortOrder INT; status STRING(16) default 'pending' (`pending|in_progress|done|na`);
+assigneeUserId NULL FK; completedAt; notes TEXT. Unique `(partnerOrganisationId, itemKey)`.
+
+### 3.11 `reward_offers` (`RewardOffer`)
+
+| Column | Type | Notes |
+|---|---|---|
+| id | UUID PK | |
+| partnerOrganisationId | FK **RESTRICT** | a partner with offers can't be hard-deleted |
+| title / publicTitle / internalRef | STRING(160)/(160)/(64) | |
+| description | TEXT | |
+| category | STRING(64) | |
+| rewardType | STRING(24) | `free_service|free_product|free_trial|voucher|credit|discount|experience|other` |
+| retailValue | DECIMAL(10,2) NULL | public value |
+| fulfilmentCost | DECIMAL(10,2) NULL | if known |
+| currency | STRING(3) default 'SGD' | |
+| fundingSource | STRING(24) default 'partner' | `partner|mktr|shared` |
+| committedQuantity | INT NOT NULL default 0 | total supply committed |
+| allocatedQuantity / issuedQuantity / redeemedQuantity | INT NOT NULL default 0 | **guarded counters** (§4) — ledger is the audit truth |
+| validityStart / validityEnd | DATE NULL | |
+| claimExpiryDays / redemptionExpiryDays | INT NULL | drive entitlement `expiresAt` |
+| fulfilmentMethod | STRING(24) | `unique_code|qr|partner_verification|manual_booking|external_link|physical_voucher` |
+| externalBookingUrl | STRING(255) NULL | |
+| status | STRING(16) default 'draft' | `draft|active|paused|ended` |
+| currentTermsVersion | INT default 0 | |
+| createdBy | FK→users | |
+
+Index `(partnerOrganisationId, status)`.
+
+### 3.12 `reward_terms_versions` (`RewardTermsVersion`) — append-only
+
+id; rewardOfferId FK **CASCADE**; version INT; structured JSONB (e.g. `{firstTimeOnly, minAge,
+appointmentRequired, validDays[], locationsLimited}` — deliberately open; not boolean-per-condition);
+freeText TEXT; createdBy; createdAt. **Unique (rewardOfferId, version).**
+
+### 3.13 `reward_offer_locations` — join
+
+id; rewardOfferId FK **CASCADE**; partnerLocationId FK **CASCADE**; unique pair.
+
+### 3.14 `reward_inventory_events` (`RewardInventoryEvent`) — append-only ledger
+
+id; rewardOfferId FK **RESTRICT**; activationId UUID NULL FK SET NULL; entitlementId UUID NULL;
+redemptionId UUID NULL; type STRING(24)
+(`committed|increased|decreased|allocated|deallocated|issued|issue_reversed|redeemed|expired|
+cancelled|manual_adjustment`); quantity INT NOT NULL CHECK (quantity > 0) — direction is carried
+by `type`, keeping rows self-describing; actorType STRING(16) default 'staff'
+(`staff|partner_user|consumer|system`); actorUserId UUID NULL; reason STRING(255) NULL.
+Indexes: `(rewardOfferId, createdAt)`, `(activationId)`.
+
+### 3.15 `activations` (`Activation`)
+
+| Column | Type | Notes |
+|---|---|---|
+| id | UUID PK | |
+| partnerOrganisationId | FK **RESTRICT** | |
+| rewardOfferId | FK **RESTRICT** | |
+| campaignId | UUID NULL FK→**campaigns** **SET NULL** | canonical MKTR reference; the only cross-module FK besides prospectId/users |
+| campaignNameSnapshot | STRING(160) NULL | display survives campaign deletion (Payment-snapshot precedent) |
+| allocatedQuantity | INT NOT NULL default 0 | ≤ offer remaining at allocation time (§4) |
+| issuedCount / redeemedCount | INT NOT NULL default 0 | guarded counters, ledger-audited |
+| status | STRING(16) default 'draft' | `draft|preparing|active|paused|completed|cancelled` |
+| startDate / endDate | DATE NULL | |
+| internalNotes | TEXT | |
+| unlockPolicy | STRING(16) default 'agent_unlock' | `on_capture` (voucher live at signup) \| `agent_unlock` (signup creates a locked reservation; the lead's consultant unlocks it at the physical meeting — the default for review-gated funnels) |
+| createdBy | FK→users | |
+
+Indexes: `(partnerOrganisationId)`, `(rewardOfferId)`, `(status)`; **unique partial**
+`(campaignId) WHERE status IN ('preparing','active','paused')` — one live activation per campaign,
+which makes Phase 6 entitlement issuance deterministic.
+
+Explicitly NOT here: design/builder config, forms, OTP, pixels, routing (see brief §25).
+
+### 3.16 `reward_entitlements` (`RewardEntitlement`)
+
+id; rewardOfferId FK **RESTRICT**; activationId FK **RESTRICT**; prospectId UUID NULL
+FK→**prospects** **SET NULL** (bulk lead-delete exists; entitlement survives PII removal);
+status STRING(16) default 'eligible' (`eligible|issued|claimed|redeemed|expired|cancelled|blocked`
+— semantics: `eligible` = **reserved/locked** (inventory held, no voucher exists yet), `issued` =
+**unlocked**, voucher live); reservedAt NOT NULL; unlockedAt NULL; unlockedByUserId NULL FK→users
+SET NULL (the consultant); unlockedVia STRING(16) NULL (`agent_scan|agent_button|auto_on_capture|manual`);
+expiresAt NULL (state-dependent: while `eligible` it is the **reservation window** from
+`reward_offers.claimExpiryDays` — attend the review within N days or inventory returns to pool;
+re-stamped at unlock to the **redemption window** from `redemptionExpiryDays`).
+**Two tokens, one consumer link** (both random 32-byte base64url, SHA-256 at rest, shown once,
+never sequential ids): `presentationTokenHash STRING(64) unique NOT NULL` — the **reservation-pass**
+token minted at capture; its QR is what the client shows the consultant, and salon verify REJECTS
+it with a typed error. `tokenHash STRING(64) unique NULL` — the **redemption voucher** token,
+**minted only at unlock** (cannot leak or be redeemed while locked). The consumer link
+`/r/:presentationToken` is stable across the whole journey: it renders the reservation pass while
+locked and the salon voucher once unlocked.
+tokenHint STRING(8) (last 4 for support); issuedVia STRING(16) (`hook|sweep|manual`); createdBy NULL.
+**Partial unique index `(activationId, prospectId) WHERE prospectId IS NOT NULL`** — the
+idempotency anchor for hook+sweep issuance. Partial, because Postgres unique indexes treat NULLs
+as distinct: a plain unique would silently stop deduplicating once prospect deletions SET-NULL old
+rows. There is no NULL-at-issuance path (manual issuance requires a prospectId too — `ROUTE_MAP.md`);
+NULL only ever appears after prospect deletion, where dedup is moot.
+Indexes: `(activationId, status)`, `(prospectId)`, `(expiresAt)` partial WHERE status='issued'.
+
+### 3.17 `redemptions` (`Redemption`)
+
+id; entitlementId FK **RESTRICT** + **UNIQUE** (double-redemption impossible at the schema level);
+rewardOfferId / activationId / partnerOrganisationId FKs RESTRICT; locationId NULL FK SET NULL;
+redeemedAt NOT NULL; method STRING(24) (`code|qr|partner_verification|manual_override`);
+status STRING(16) default 'completed' (`completed|reversed|flagged`); actorType STRING(16);
+actorUserId NULL; notes TEXT. Index `(partnerOrganisationId, redeemedAt)`.
+
+**Reversal policy (deliberate, because of the UNIQUE)**: a `reversed` redemption is **terminal**
+for its entitlement — re-fulfilment requires cancelling the entitlement and manually issuing a new
+one (`entitlements.issue_manual`), which keeps the audit chain unambiguous. If operations later
+need in-place re-redemption, the escape hatch is swapping the plain UNIQUE for a partial unique
+over `status IN ('completed','flagged')` — recorded now so the constraint isn't discovered as a
+blocker mid-incident.
+
+### 3.18 `redemption_events` (`RedemptionEvent`) — append-only
+
+id; entitlementId FK **CASCADE**; redemptionId NULL FK CASCADE; type STRING(24)
+(`reserved|unlocked|claim_viewed|verify_attempt|verified|redeemed|rejected|expired|manual_override|reversed`);
+metadata JSONB; actorType STRING(16) (`staff|agent|partner_user|consumer|system` — `agent` = the
+lead's consultant acting from the Lyfe / mktr-leads app, still a `users` row so actorUserId
+resolves); actorUserId NULL; createdAt.
+Index `(entitlementId, createdAt)`.
+
+### 3.19 `redeem_ops_audit_events` (`RedeemOpsAuditEvent`) — append-only
+
+id; actorUserId NULL FK SET NULL; actorType STRING(16) default 'staff'; action STRING(64)
+(dot-namespaced: `partner.created`, `partner.claimed`, `partner.reassigned`, `partner.merged`,
+`stage.changed`, `activity.edited`, `reward.created`, `inventory.adjusted`,
+`activation.campaign_linked`, `entitlement.issued_manual`, `redemption.overridden`,
+`access.role_granted`, …); entityType STRING(32); entityId UUID; before JSONB NULL;
+after JSONB NULL; reason STRING(255) NULL; requestId STRING(64) NULL (from `requestId` middleware).
+Indexes: `(entityType, entityId, createdAt)`, `(actorUserId, createdAt)`, `(action, createdAt)`.
+
+### 3.20 Future (designed, not in V1 migrations)
+
+`partner_import_batches` + `partner_import_rows` (CSV import, brief §32);
+`partner_users` (portal principals — see `RECOMMENDED_ARCHITECTURE.md` §7).
+
+## 4. Integrity & concurrency invariants (with house-pattern citations)
+
+1. **Claim is one atomic statement** —
+   `UPDATE partner_organisations SET "ownerUserId"=:me, "claimedAt"=now(), availability='owned',
+   "pipelineStage"='CLAIMED' WHERE id=:id AND "ownerUserId" IS NULL AND availability='available'
+   RETURNING id` → 0 rows = 409 "just claimed by another team member". Assignment-event +
+   audit rows insert in the same transaction. (Pattern: `deductExternalLeadBalance`,
+   `backend/src/services/leadCredits.js:156-161`.)
+2. **Claim-next-from-pool** — `SELECT … FROM prospecting_pool_members JOIN partner_organisations …
+   WHERE pool member available AND partner unowned/eligible ORDER BY … LIMIT 1 FOR UPDATE SKIP
+   LOCKED`, then the §4.1 claim UPDATE in the same transaction. (Pattern: `chargeLeadCredit` CTE,
+   `leadCredits.js:206-227`.)
+3. **Inventory can never oversubscribe** — every quantity move is
+   (a) guarded counter UPDATE, e.g. allocation:
+   `UPDATE reward_offers SET "allocatedQuantity"="allocatedQuantity"+:q WHERE id=:id AND
+   "committedQuantity" - "allocatedQuantity" >= :q RETURNING id`, plus
+   (b) a `reward_inventory_events` insert, in one transaction; 0 rows updated → typed 409.
+   Issuance/redemption decrement/increment analogously through `activations` counters.
+   Ledger↔counter reconciliation is a test-time (and later cron) assertion.
+4. **One live activation per campaign** — partial unique index (schema-enforced), §3.15.
+5. **Entitlement idempotency** — unique `(activationId, prospectId)`; unique-violation treated as
+   success-duplicate (pattern: Retell 23505 handling).
+6. **Double redemption impossible** — unique `redemptions.entitlementId` + status transition
+   `issued→redeemed` executed as a conditional UPDATE on `reward_entitlements`
+   (`WHERE status='issued' AND "expiresAt">now()`); replays get a typed "already redeemed"
+   response (idempotent verify API).
+7. **Append-only means append-only** — assignment/stage/ledger/redemption-event/audit tables have
+   no UPDATE/DELETE code paths; corrections happen on the subject row with `before/after` captured
+   in audit.
+8. **Merge preserves everything** — merge re-points children (contacts, activities, tasks, pool
+   memberships, offers, activations) to the survivor in one transaction, stamps
+   `mergedIntoId`+`archivedAt` on the loser, writes assignment event (`kind:'merge'`) + audit with
+   full `before` snapshot. Fuzzy matches are never auto-merged (capability-gated, §PERMISSION_MATRIX).
+
+## 5. Normalization & duplicate detection (brief §14, §34)
+
+Utilities in `services/redeemOps/normalizers.js` (display value always stored separately from the
+match key):
+- **Phone**: reuse the platform's E.164 `+65` convention (`Prospect.phone` validation shape;
+  SG-normalization precedents in `prospectHelpers.js` / `verificationService.js`).
+- **Website** → `websiteDomain`: lowercase host, strip `www.`, strip path/query.
+- **Socials** → handle: strip URL/`@`, lowercase (`instagram.com/nailbliss.sg` → `nailbliss.sg`).
+- **Business name** → `normalizedName`: lowercase → strip punctuation → collapse whitespace →
+  strip legal suffixes (`pte ltd`, `llp`, `pl`) cautiously (suffix-only, never mid-name tokens).
+- **Postal** → `postalDistrict` (first 2 digits) for same-area heuristics.
+
+Detection tiers (server-side, on create/import and via `GET …/partners/check-duplicates`):
+- **Exact** (hard warn, create requires explicit override reason): same `uen`, `primaryPhone`,
+  `websiteDomain`, `instagramHandle`/`tiktokHandle`/`facebookHandle`, or exact `normalizedName`.
+- **Potential** (soft warn): trigram similarity ≥ 0.55 on `normalizedName` (when `pg_trgm`
+  available; else shared-prefix ≥ 12 chars) — AND-boosted by same `postalDistrict` or same
+  `category`. Response includes existing record, owner, stage, match reason, last activity — the
+  data the UI needs for "open existing / add as location / continue with reason / merge".
+
+## 6. Pipeline stages (constants, not DB enum)
+
+`UNCLAIMED, CLAIMED, RESEARCHING, CONTACTED, REPLIED, MEETING_BOOKED, MEETING_COMPLETED,
+PROPOSAL_SENT, NEGOTIATING, PARTNERED, FOLLOW_UP_LATER, NO_RESPONSE, NOT_INTERESTED, DISQUALIFIED`
+— defined once in `services/redeemOps/constants.js` with an allowed-transition map enforced in
+`partnerService.changeStage` (server-side, drag-and-drop included). Stale rules (brief §16):
+sweep flags `atRiskFlag` when claimed >48h with `firstOutreachAt IS NULL`; `staleFlag` when
+`lastActivityAt` >14d — except stage `FOLLOW_UP_LATER` with a future open task. No auto-release.

--- a/docs/redeem-ops/IMPLEMENTATION_PLAN.md
+++ b/docs/redeem-ops/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,167 @@
+# Redeem Ops — Implementation Plan
+
+> Phase 0 deliverable. Sequencing for Phases 1–7 (brief §38) against this repo's realities.
+> Phase 0 (this document set) is complete when these docs are accepted. **No application code
+> before that.** Every phase ships dark behind `REDEEM_OPS_ENABLED` /
+> `VITE_REDEEM_OPS_ENABLED`; production MKTR behaviour is unchanged until flags flip.
+
+## Ground rules (from discovery)
+
+- Migrations: start at **045**; coordinate with uncommitted `044-…` on
+  `feat/campaign-store-catalog` (merge that branch first or renumber at rebase). Runner is
+  up-only — every migration must be additive and idempotent-safe.
+- Route/model files flat (auto-loader); controllers/services nested under `redeemOps/`.
+- Work in small vertical slices: migration → model+associations → service (DI factory) →
+  route+controller → SPA page → tests, per slice. Run `cd backend && npm test` (needs local
+  Postgres + `JWT_SECRET`) and targeted Vitest after each slice; CI has 5 chronically-red
+  pre-existing suites — regressions are judged against that baseline.
+- Dependency direction: `redeemOps → MKTR` only. The single MKTR-side edit (Phase 6 hook) goes
+  through the `makeProspectService` DI seam.
+
+## Phase 1 — Foundation (boundary, auth, audit, shell)
+
+**Backend**
+1. Migration 045: `ALTER TYPE "enum_users_role" ADD VALUE IF NOT EXISTS 'redeem_ops'` +
+   `users.redeemOpsRole` column + `redeem_ops_audit_events` table — landed in the SAME change as
+   every code-side enum touchpoint (else the value is dead): `User.js:47` ENUM list,
+   `userService.inviteUser` `allowedRoles` (`userService.js:146`), `invitationService` roleLabel,
+   Joi user/invite schemas, `getDefaultRouteForRole` (`src/lib/utils.js:8`).
+2. `services/redeemOps/permissions.js` (capability map) +
+   `middleware/redeemOpsAuth.js` (`requireRedeemOps`) + `services/redeemOps/auditService.js`.
+3. `routes/redeemOpsAdmin.js` (flag-mounted): `/team`, `/team/invite` (extend
+   `invitationService.sendRoleInvitation` role allowlist + label), `/team/:userId/role`,
+   `/audit`, `/meta/constants`.
+4. Plumbing edits: add `/api/redeem-ops` to `internalRouteHostGuard` **and implement the ops-host
+   allow-policy** (`isOpsHost()` → only `/api/auth`, `/api/redeem-ops`, `/api/notifications`
+   pass; other internal prefixes 403 — see `RECOMMENDED_ARCHITECTURE.md` §5); add `ops.redeem.sg`
+   to `publicHost.js` allowlist + CORS defaults (inert until the site exists).
+**Frontend**
+5. `VITE_REDEEM_OPS_ENABLED` route group `/redeem-ops/*` + `RedeemOpsRoute` guard +
+   `DashboardLayout` nav branch; Team page; shared data-table + filter components; query hooks
+   scaffold (`src/hooks/queries/redeemops/`).
+**Tests (gate to merge)**
+- requireRedeemOps: admin bypass; sub-role capability grant/deny; `redeem_ops` user 403 on
+  `/api/admin/*`; flag-off → 404 on every redeem-ops route.
+- Host guard: consumer redeem.sg → 403 on `/api/redeem-ops/*`; ops.redeem.sg host → `/api/auth`
+  and `/api/redeem-ops` reachable but `/api/admin/*` / `/api/users/*` etc. → 403 (ops-host
+  allow-policy).
+- Agent-sync regression: a `role='redeem_ops'` user survives `syncAgentsFromLyfe` sweeps.
+**Exit**: an invited outreach user logs in on the flagged surface, sees an empty shell, audit rows
+write. MKTR untouched with flags off.
+
+## Phase 2 — Partner CRM (most important milestone)
+
+1. Migration 046: `partner_organisations`, `partner_locations`, `partner_contacts`,
+   `partner_assignment_events`, `partner_stage_events`, `outreach_activities` (+ pg_trgm attempt).
+2. `normalizers.js` + `dedupeService.js` (exact + potential tiers) — pure functions first, fully
+   unit-tested.
+3. `partnerService.js` (CRUD, stage machine, timeline), `claimService.js` (atomic claim/release/
+   assign per `ERD.md` §4.1), activity logging with lastActivity/firstOutreach stamping.
+4. `routes/redeemOpsPartners.js` + controller; Joi schemas (loud-fail, no stripUnknown — internal
+   surface).
+5. SPA: PartnersList (server-side pagination/filter/debounced search), PartnerDetail
+   (claim button with 409 conflict toast, timeline lazy-load, contacts/locations editors),
+   duplicate-aware create dialog (open-existing / add-as-location / continue-with-reason / merge
+   for authorized roles).
+**Tests** (brief §37 Claiming + Dedupe): available→claimed; claimed→409 for second user;
+**parallel simultaneous claims → exactly one winner** (integration, real Postgres — precedent
+style: `test/integration/agentAssignment.test.js`); unauthorized reassign 403; same
+UEN/phone/domain/handle exact-match behaviour; fuzzy name+postal potential match; legitimate
+second outlet → add-as-location path; merge preserves contacts/activities/history/ownership.
+**Exit**: staff can search, create-with-dedupe, claim, log activity, move stages; managers reassign;
+history intact — brief §40 criteria 2–7, 10–13.
+
+## Phase 3 — Outreach operations (V1 complete at exit)
+
+1. Migration 047: `outreach_tasks`, `prospecting_pools`, `prospecting_pool_members`.
+2. `taskService`, `poolService` (claim-next via SKIP LOCKED), `queueService` (aggregated My Queue);
+   staleness sweep interval in `bootstrap.js` (flag-gated; sets atRisk/stale flags only).
+3. Routes `redeemOpsWork.js`; SPA MyQueue, Tasks, Pools, TeamPipeline (Kanban with
+   server-validated transitions), OpsOverview.
+**Tests**: task ownership/authorization; due-state calc (today/overdue boundaries, SGT);
+completion; claim-next concurrency (two parallel calls → different partners; exhausted pool →
+204); stale sweep respects FOLLOW_UP_LATER-with-future-task exception.
+**Exit = V1 acceptance (brief §11/§40)**: three outreach staff run their day entirely in the
+system. → **Cut over surface: create `ops.redeem.sg` static site (`VITE_SURFACE=ops`, relative
+`/api` + rewrite), DNS CNAME, flip `REDEEM_OPS_ENABLED=true`** per
+`RECOMMENDED_ARCHITECTURE.md` §5.
+
+## Phase 4 — Onboarding & rewards
+
+1. Migration 048: `partner_onboarding_items`, `reward_offers`, `reward_terms_versions`,
+   `reward_offer_locations`, `reward_inventory_events`.
+2. `onboardingService` (template seed on PARTNERED), `rewardService`, `inventoryService`
+   (guarded counters + ledger in one transaction).
+3. Routes `redeemOpsRewards.js`; SPA Rewards pages + onboarding tab.
+**Tests** (brief §37 Inventory): committed/adjust ledger entries; cannot allocate beyond
+committed; **concurrent allocations cannot oversubscribe** (parallel guarded UPDATEs);
+counter↔ledger reconciliation assertion.
+
+## Phase 5 — Activations & MKTR linkage
+
+1. Migration 049: `activations` (+ partial unique on live campaignId).
+2. `activationService` (status machine, allocation via inventory service),
+   `campaignProjection.js` (attribute-allowlisted read + `computeCampaignMetrics` reuse).
+3. Routes `redeemOpsActivations.js`; SPA Activations pages (link picker, read-only campaign card,
+   metrics, "Open in MKTR" deep link to `/admin/campaigns/:id/workspace`).
+**Tests**: cannot link archived campaign; second live activation on same campaign → 409 (DB
+enforced); allocation respects offer remaining; projection never leaks `design_config`.
+
+## Phase 6 — Entitlements & redemptions
+
+1. Migration 050: `reward_entitlements`, `redemptions`, `redemption_events`.
+2. `entitlementService` (token mint SHA-256-at-rest, idempotent issue, expiry sweep,
+   `partnerView()` projection), `redemptionService` (verify/complete/override — conditional-UPDATE
+   state transitions).
+3. Capture hook via `makeProspectService` DI (flag `REDEEM_OPS_ENTITLEMENTS_ENABLED`) **plus the
+   server-side verification stamp** (`sourceMetadata.phoneVerifiedAt` from `verifiedPhoneStore` at
+   create — same DI-seam change) + reconciliation sweep (`MKTR_INTEGRATION.md` §2). Default
+   `unlockPolicy='agent_unlock'`: capture creates a locked reservation, not a live voucher. Routes
+   `redeemOpsFulfilment.js`; SPA Redemptions console. (Consumer `redeem.sg/r/:token` page + public
+   `/api/reward-claim` namespace: separate follow-on slice.)
+4. **Agent-mediated unlock (cross-repo slice)**: unlock endpoints on the existing HMAC surfaces
+   (`POST /api/external/entitlements/unlock`, `POST /api/integrations/lyfe/entitlement-unlock`) +
+   a "scan client's QR / unlock voucher" screen in the mktr-leads app and the Lyfe app (separate
+   repos — coordinate like the lead-outcome rollout); voucher SMS/email on unlock via the existing
+   SNS sender + `mailer.js`.
+**Tests** (brief §37 Entitlements): valid/expired/cancelled paths; duplicate issuance (hook+sweep
+race) → single row; **double redemption → exactly one success, idempotent replay response**;
+token validated server-side (garbage/foreign tokens rejected); **a raw unverified
+`POST /api/prospects` (no OTP) creates a lead but never an entitlement** (anti-farming
+precondition); unlock: only the lead's assigned consultant can unlock (wrong agent → 403;
+admin override audited), scan and button paths idempotent (replay → "already unlocked"),
+**a reservation-pass QR is rejected by salon verify**, expired reservations return inventory to
+the pool; capture path unaffected when Redeem Ops errors (hook failure swallowed, lead still
+created — regression test on `createProspect`).
+
+## Phase 7 — Analytics & renewal
+
+Aggregation endpoints (SQL over own tables + `computeCampaignMetrics` for acquisition numbers —
+no fake metrics where instrumentation doesn't exist), Analytics SPA, renewal outcome on
+Activation + auto follow-up task. CSV import (brief §32) slots here or earlier if prospect-list
+loading becomes the bottleneck — batch tables are already designed (`ERD.md` §3.20).
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| Migration 044 numbering collision (uncommitted branch) | Land/renumber before 045; `migrations.test.js` covers runner behaviour |
+| Enum `ADD VALUE` forgotten code touchpoints (model ENUM list, invite allowlist, Joi, default routes) | Phase 1 step 1 checklist; the runner is non-transactional (`runMigrations.js:52`) so `IF NOT EXISTS` on PG12+ is the whole DB-side story — verify on CI's postgres:15 |
+| Route flag misconfig exposes namespace early | Flag default `'false'` in `meta`; test asserts 404 when unset |
+| Ops staff hit the 200 req/15 min public limiter | Monitor in Phase 3 dogfood. NOTE (Codex-verified): the existing admin bypass is **broken for cookie sessions** — `optionalAuth` mounts before `cookieParser()` (`server_internal.js:120` vs `:159`) so the limiter never sees a role; any `redeem_ops` bypass requires fixing that ordering first (pre-existing MKTR bug, worth fixing regardless) |
+| Reward farming via the public, OTP-optional `POST /api/prospects` (Phase 6) | Issuance precondition: server-stamped `phoneVerifiedAt` + quarantine/DNC checks + finite activation allocation (`MKTR_INTEGRATION.md` §2.0); test pins it |
+| Duplicate-signup race returns 400 not 409 (pre-existing: `errorHandler.js:48` unique-violation mapping) | Not a Redeem Ops blocker; optional MKTR fix — map `prospects_campaign_id_phone` violations to the 409 shape |
+| SPA bundle growth on mktr build | All redeem-ops pages `lazy()` like existing routes; ops build excludes admin pages symmetrically |
+| `users` sweep interactions (agent sync, two-phase delete) | Pinned by Phase 1 regression test; ops staff carry no `lyfeId`/`mktrLeadsId` |
+| Backend restarts lose in-process sweep timing | Sweeps are stateless scans (house pattern); no persistent scheduler needed |
+| Single-instance assumptions (in-process claim queue not needed — all claims are single-statement SQL) | Concurrency safety lives in SQL, correct even multi-instance (chargeLeadCredit precedent) |
+
+## Definition of done — first major release (brief §40 mapping)
+
+1–2. Staff login + central search → Phases 1–2. 3. Duplicate surfacing → Phase 2 dedupe.
+4–5. Single active owner + concurrency-safe claim → Phase 2 (DB-enforced). 6–9. Locations,
+contacts, activities, follow-ups, daily queue → Phases 2–3. 10. Pipeline moves → Phases 2–3.
+11–12. Manager visibility + reassign → Phases 2–3. 13. History intact → append-only tables +
+audit. 14. No second campaign builder → enforced by `RECOMMENDED_ARCHITECTURE.md` §10 +
+projection-only campaign access. 15. No duplicate lead DB → entitlements reference `prospects.id`
+only.

--- a/docs/redeem-ops/MKTR_INTEGRATION.md
+++ b/docs/redeem-ops/MKTR_INTEGRATION.md
@@ -1,0 +1,203 @@
+# Redeem Ops ↔ MKTR Integration
+
+> Phase 0 deliverable. Defines the ONLY sanctioned touchpoints between the Redeem Ops module and
+> the canonical MKTR acquisition domains. Everything else is out of bounds (see
+> `RECOMMENDED_ARCHITECTURE.md` §10).
+
+## 1. Campaign integration
+
+### Canonical model & ID
+
+- Model: `backend/src/models/Campaign.js` → table `campaigns`, PK `id` (UUID v4). This UUID is the
+  **only** campaign reference Redeem Ops stores (`activations.campaignId`).
+- Status source of truth: `campaigns.status` (`draft|active|paused|completed|archived`) +
+  `is_active` — displayed read-only in Redeem Ops; changed only via MKTR
+  (`setCampaignLaunchState`, `backend/src/services/campaignService.js:311`).
+
+### How Redeem Ops searches campaigns (link picker)
+
+New read-only projection endpoint inside the Redeem Ops namespace (so host-guard + capability
+gating applies, and MKTR's `/api/campaigns` admin surface stays untouched):
+
+```
+GET /api/redeem-ops/campaigns?search=&status=&page=&limit=
+→ { campaigns: [{ id, name, status, type, isActive, customerHost, publicUrl,
+                  createdAt, linkedActivationId | null }], pagination }
+```
+
+Implementation: `services/redeemOps/campaignProjection.js` queries the `Campaign` model directly
+with a **fixed attribute allowlist** (`id,name,status,type,is_active,design_config→customerHost,
+createdAt`) — never returns `design_config` wholesale (it contains builder internals). `publicUrl`
+is computed with the existing host helpers (`resolveCustomerHost` semantics; backend equivalent in
+`backend/src/utils/customerHost.js:customerHostOrigin`) → `…/LeadCapture?campaign_id={id}`.
+`linkedActivationId` is a LEFT JOIN on `activations` (status ∈ preparing/active/paused) so the
+picker can show "already linked".
+
+### How a campaign is linked / unlinked
+
+- `POST /api/redeem-ops/activations` and `PATCH …/:id/campaign` set `campaignId` after validating:
+  campaign exists; not `archived`; not already linked to another live activation (**partial unique
+  index** `activations(campaignId) WHERE status IN ('preparing','active','paused')` — DB-enforced,
+  not just app-checked). A `campaignNameSnapshot` is stored for display resilience
+  (`SET NULL` FK — see `ERD.md`).
+- Link/unlink writes `redeem_ops_audit_events` (`action: activation.campaign_linked`).
+
+### Campaign display, metrics, and hand-off
+
+- Read-only detail card on the Activation page: name, status badge, type, public URL
+  (copyable), customer host.
+- Metrics: reuse `computeCampaignMetrics(campaignId)`
+  (`backend/src/services/campaignService.js:12`) and, where needed, the analytics aggregation
+  (`getCampaignAnalytics`, line 456) — surfaced via
+  `GET /api/redeem-ops/activations/:id/campaign-metrics`. **No re-counting in Redeem Ops**;
+  registrations/verified-lead numbers always come from these MKTR functions.
+- "Open in MKTR" deep link: `https://mktr.sg/admin/campaigns/{id}/workspace` (route exists in
+  `src/pages/index.jsx`). Redeem Ops renders it as an external link; campaign editing never
+  happens on the ops surface.
+
+### What is forbidden
+
+Redeem Ops must never: create/update/archive campaigns, mutate `design_config`, generate QR/short
+links, or touch delivery-pool/lead-package state. (Enforced by code review + the absence of any
+write path in `campaignProjection.js`.)
+
+## 2. Lead integration
+
+### Canonical model & ID
+
+Model `backend/src/models/Prospect.js` → table `prospects`, PK `id` (UUID). Redeem Ops stores this
+UUID **only** on `reward_entitlements.prospectId`.
+
+### Minimum data Redeem Ops needs (and how it gets it)
+
+| Need | Mechanism | Notes |
+|---|---|---|
+| Entitlement identity | `prospectId` FK (`ON DELETE SET NULL`) | Prospect bulk-delete exists (`prospectService` bulk ops) — entitlement rows survive with PII gone. |
+| Staff display (fulfilment screens) | Server-side JOIN at read time → `{ firstName, lastName, phoneMasked }` | Full phone visible only under the `redemptions.verify` capability (needed to confirm identity at fulfilment); nothing persisted in Redeem Ops tables. |
+| Eligibility inputs (Phase 6) | Read `prospect.campaignId`, `quarantinedAt`, `dncStatus`, consent flags at issuance time | Rules in `entitlementService`; consent interpretation mirrors `externalConsent.js` precedent. |
+
+**No projection/copy tables.** Same-database joins make read-time access cheap and keep exactly one
+PII location (privacy §35.8: no unnecessary personal-data duplication; PDPA erasure on `prospects`
+automatically propagates because nothing is copied).
+
+### How entitlement creation is triggered (Phase 6 design)
+
+Chosen mechanism: **in-process post-commit hook + reconciliation sweep** (at-least-once with a
+DB idempotency anchor). Rationale: same process, no broker, matches how CAPI/TikTok/webhooks
+already hang off capture (`prospectService.js` post-commit block, ~lines 843–930; note the
+assignment/confirmation *emails* are controller-level, `prospectController.js:58-72` — the hook
+follows the service-level precedent, not the email one).
+
+0. **Server-verified prospect precondition (anti-farming — Codex review finding, accepted)**:
+   `POST /api/prospects` is public and OTP is SPA-orchestrated; the API accepts unverified
+   submissions (`REPOSITORY_DISCOVERY.md` §9). `lead.created` alone is therefore a **forgeable
+   signal that must never mint reward value**. Fix: at capture, the backend stamps durable
+   verification evidence onto the prospect — `sourceMetadata.phoneVerifiedAt`, set server-side iff
+   `verifiedPhoneStore.isPhoneVerified(phone)` at create time (the same short-lived marker the DNC
+   consent gate already consumes, stamped by `verificationService.checkVerificationCode`,
+   `verificationService.js:228-233`). This stamp ships in the same DI-seam change as the hook.
+   Both the hook and the sweep issue entitlements **only** for prospects carrying the stamp.
+   Unverified/forged submissions still capture as leads (capture behaviour unchanged); they simply
+   never earn an entitlement — closing both the fake-reward vector and the
+   inventory-exhaustion-DoS vector.
+1. **Hook**: at the end of `createProspect`'s post-commit fan-out, one guarded call:
+   `redeemOpsEntitlements.onLeadCaptured(prospect)` — flag-gated (`REDEEM_OPS_ENABLED` +
+   `REDEEM_OPS_ENTITLEMENTS_ENABLED`), wrapped in try/catch, **fire-and-forget** (a Redeem Ops
+   failure must never fail or slow lead capture). It checks: verification stamp present (§0),
+   prospect not quarantined, DNC not blocking, campaign has an `active` activation with remaining
+   allocation → creates the entitlement per the activation's `unlockPolicy`: `on_capture` →
+   voucher live immediately; `agent_unlock` (**the default** for review-gated funnels) → a
+   **locked reservation** (`status='eligible'`: inventory held, reservation-pass QR delivered to
+   the consumer, no voucher token exists yet).
+2. **Idempotency anchor**: partial unique index `reward_entitlements(activationId, prospectId)
+   WHERE prospectId IS NOT NULL` — the hook and the sweep can both fire; exactly one row wins
+   (house pattern: unique-constraint-as-dedup, cf. `retellCallId`; partial because deleted
+   prospects SET-NULL and Postgres treats NULLs as distinct — see `ERD.md` §3.16).
+3. **Reconciliation sweep**: in-process interval (bootstrap pattern) selecting recent prospects on
+   activation-linked campaigns lacking an entitlement — catches hook failures, deploy gaps, and
+   quarantine→release transitions. Also expires entitlements past `expiresAt`.
+4. **Inventory coupling**: issuance decrements activation allocation via the guarded-counter +
+   ledger transaction (`ERD.md` §Integrity); when allocation is exhausted the hook stops issuing
+   (leads still capture normally — reward exhaustion must never block acquisition).
+
+Rejected alternatives: registering Redeem Ops as a `WebhookSubscriber` pointed at our own API
+(adds HMAC/HTTP/retry surface for an in-process call — the webhook engine exists for *external*
+destinations); DB triggers (invisible to the codebase, against house style); queues (no broker
+infra, explicitly discouraged).
+
+### How the voucher unlocks at the physical meeting (agent-mediated, `unlockPolicy='agent_unlock'`)
+
+The business rule: the consumer must complete the financial review with their consultant before
+the reward becomes redeemable. The unlock is therefore an **explicit action by the lead's assigned
+consultant during the meeting**, with two equivalent paths:
+
+- **Scan (preferred — proves presence)**: the client opens their reservation link
+  (`/r/:presentationToken`, delivered at signup) which shows a QR of the reservation-pass token;
+  the consultant scans it in their app. Possession of the client's QR + an authenticated
+  consultant is strong evidence the meeting actually happened.
+- **Button (fallback)**: the consultant opens the lead in their app and taps "Unlock voucher"
+  (client's phone dead, email lost, etc.). Same server checks, minus the presence proof — audited
+  with `unlockedVia='agent_button'`.
+
+**Where the endpoints live**: consultants are NOT Redeem Ops staff and their apps are external
+(Lyfe mobile app; mktr-leads app), so the unlock does not go through `/api/redeem-ops/*`. It rides
+the two authenticated server-to-server surfaces that already exist and are rate-limit-exempt:
+`POST /api/external/entitlements/unlock` (mktr-leads app — `requireExternalHmac` precedent, cf.
+`externalBillingController`) and `POST /api/integrations/lyfe/entitlement-unlock` (Lyfe app —
+lead-outcome HMAC precedent). Payload: presentation token (scan) or prospect id (button) + the
+acting agent reference; the backend resolves the agent through the existing provenance mapping
+(`users.mktrLeadsId` / `users.lyfeId`).
+
+**Server-side checks (single conditional-UPDATE state transition, idempotent)**: entitlement is
+`eligible` and unexpired; the acting agent **is the lead's assigned consultant**
+(`prospect.assignedAgentId` / `externalAgentId`; admin override audited); activation still live.
+On success: status → `issued`, voucher token minted, `expiresAt` re-stamped to the redemption
+window, ledger + `redemption_events('unlocked')` written, and the consumer is notified
+immediately (SMS via the existing SNS sender + brand-aware email via `mailer.js`). The voucher
+email carries the code in **three redundant forms**: (a) the voucher **QR as an inline-attached
+PNG** (CID attachment, not a remote image URL — displays even when mail clients block remote
+images, and keeps the token out of image-proxy/CDN logs; generated with the `qrcode` dependency
+already used by `qrCodeService.js`), (b) the **short code as plain text** for manual entry when
+scanning fails, and (c) the **live `/r/…` link**, which now renders the voucher. The email is a
+static snapshot — it can never show "already redeemed" — which is fine because a QR is only a
+picture of the token: the merchant-side verify call is the actual gate, so unlimited copies
+(email, screenshot, printout) change nothing; the first server-confirmed redemption wins. A
+replayed scan returns "already unlocked" (success shape), and salon verify rejects
+reservation-pass tokens with a typed error, so the meeting QR can never be redeemed at the
+partner.
+
+**No-show handling**: if the reservation expires before any unlock, the sweep marks it `expired`
+and returns the unit to the activation pool (ledger event) — no-shows never consume partner supply.
+
+### The one MKTR-side code change (and how it respects the one-way rule)
+
+Phase 6 makes exactly one edit to MKTR code (`prospectService.js`), with two parts: (a) stamp
+`sourceMetadata.phoneVerifiedAt` when the verified-phone marker is present at create (§0), and
+(b) invoke an injected `onLeadCaptured` callback post-commit. The one-way rule
+(`RECOMMENDED_ARCHITECTURE.md` §1) is an **import/module rule, not a runtime-call rule**: MKTR
+never imports Redeem Ops code — `makeProspectService` already takes injected collaborators
+(`prospectService.js:107-121`), so the callback default is a no-op and bootstrap (the composition
+root) injects the real Redeem Ops implementation. This is ordinary dependency inversion: the seam
+stays extractable (delete the bootstrap wiring and MKTR is byte-identical to today).
+
+## 3. Identity/user integration
+
+- Staff: shared `users` table; new enum value + `redeemOpsRole` column (see
+  `PERMISSION_MATRIX.md`). Redeem Ops reads `users` for assignee pickers (id, fullName, role,
+  redeemOpsRole, isActive) — no writes outside invite/role-grant endpoints.
+- Guardrail (verified): agent-sync sweeps operate on `role='agent'` rows with platform provenance
+  (`agentSyncService.js:306,404,426-438`) — `redeem_ops` users are outside the sweep. A regression
+  test pins this.
+
+## 4. Consistency & privacy implications (summary)
+
+- **Consistency**: FKs give hard integrity for campaign/lead references; the only eventual
+  consistency introduced is entitlement issuance (hook + sweep), bounded by the sweep interval and
+  made safe by the unique anchor. Inventory counters + append-only ledger reconcile exactly
+  (transactional writes).
+- **Privacy**: no PII copies; partner-facing projections exclude lead identity entirely
+  (`entitlementService.partnerView()` contract); consent and DNC interpretation stay in MKTR
+  semantics; masked-by-default display with capability-gated unmasking; every manual override
+  audited.
+- **Failure isolation**: Redeem Ops outage cannot break capture (hook is fire-and-forget), cannot
+  break routing (no coupling), and flag-off returns the platform to today's behaviour byte-for-byte.

--- a/docs/redeem-ops/PERMISSION_MATRIX.md
+++ b/docs/redeem-ops/PERMISSION_MATRIX.md
@@ -1,0 +1,104 @@
+# Redeem Ops — Permission Matrix
+
+> Phase 0 deliverable. Authorization is **additive** to the existing system: `users.role` keeps its
+> current five values plus one new value `redeem_ops`; fine-grained access is a nullable
+> `users.redeemOpsRole` sub-role mapped to capabilities. Enforcement is server-side middleware;
+> UI hiding is convenience only. See `RECOMMENDED_ARCHITECTURE.md` §4 for storage design.
+
+## 1. Principals
+
+| Sub-role (`redeemOpsRole`) | Intended person | Platform `role` |
+|---|---|---|
+| `super_admin` | Shawn / platform owners. **Implicit for every `role='admin'` user** (middleware override); grantable explicitly too | `admin` or `redeem_ops` |
+| `ops_admin` | Senior ops running partners+rewards+redemptions day-to-day | `redeem_ops` |
+| `bdm` | Business Development Manager — team lead over outreach | `redeem_ops` |
+| `outreach_exec` | The three V1 outreach staff | `redeem_ops` |
+| `campaign_ops` | Activation/reward-allocation operator. **NOT an MKTR campaign builder** — links existing campaigns only (addendum §4); campaign create/edit stays behind MKTR `requireRole('admin')` on mktr.sg | `redeem_ops` |
+| `redemption_ops` | Fulfilment/verification staff | `redeem_ops` |
+| `analyst` | Read-only reporting | `redeem_ops` |
+| *(future)* partner portal user | External business staff — **separate principal table** (`partner_users`) + separate token scope; never holds any capability below | n/a |
+
+## 2. Capabilities → roles
+
+Legend: ✓ full · O = own/owned-records only · — = no.
+
+| Capability | super_admin | ops_admin | bdm | outreach_exec | campaign_ops | redemption_ops | analyst |
+|---|---|---|---|---|---|---|---|
+| `partners.view` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ (fulfilment context) | ✓ |
+| `partners.create` | ✓ | ✓ | ✓ | ✓ | — | — | — |
+| `partners.edit` | ✓ | ✓ | ✓ | O | — | — | — |
+| `partners.claim` | ✓ | ✓ | ✓ | ✓ | — | — | — |
+| `partners.release` (own claim) | ✓ | ✓ | ✓ | O | — | — | — |
+| `partners.reassign` (any owner) | ✓ | ✓ | ✓ | — | — | — | — |
+| `partners.restrict_disqualify` | ✓ | ✓ | ✓ | — | — | — | — |
+| `partners.merge` | ✓ | ✓ | — | — | — | — | — |
+| `partners.import` | ✓ | ✓ | ✓ | — | — | — | — |
+| `contacts.manage` | ✓ | ✓ | ✓ | O | — | — | — |
+| `locations.manage` | ✓ | ✓ | ✓ | O | — | — | — |
+| `activities.log` | ✓ | ✓ | ✓ | O | — | ✓ (redemption notes) | — |
+| `activities.edit` | ✓ | ✓ | own | own | — | — | — |
+| `pipeline.move` | ✓ | ✓ | ✓ | O (permitted transitions) | — | — | — |
+| `pipeline.view_team` | ✓ | ✓ | ✓ | — (own only) | ✓ (read) | — | ✓ (read) |
+| `tasks.manage` | ✓ | ✓ | team | O | — | — | — |
+| `pools.manage` | ✓ | ✓ | ✓ | — | — | — | — |
+| `pools.claim_next` | ✓ | ✓ | ✓ | ✓ | — | — | — |
+| `onboarding.manage` | ✓ | ✓ | ✓ | O | — | — | — |
+| `rewards.view` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `rewards.manage` (offers+terms) | ✓ | ✓ | — | — | — | — | — |
+| `inventory.adjust` (manual ledger) | ✓ | ✓ | — | — | — | — | — |
+| `activations.view` | ✓ | ✓ | ✓ | — | ✓ | ✓ | ✓ |
+| `activations.manage` | ✓ | ✓ | — | — | ✓ | — | — |
+| `activations.link_campaign` | ✓ | ✓ | — | — | ✓ | — | — |
+| `activations.allocate_inventory` | ✓ | ✓ | — | — | ✓ | — | — |
+| `campaigns.read_reference` (projection + metrics) | ✓ | ✓ | ✓ | — | ✓ | — | ✓ |
+| `entitlements.view` | ✓ | ✓ | — | — | ✓ | ✓ | ✓ (aggregates) |
+| `entitlements.issue_manual` / `cancel` | ✓ | ✓ | — | — | — | ✓ | — |
+| `redemptions.verify` (incl. unmasked lead contact at fulfilment) | ✓ | ✓ | — | — | — | ✓ | — |
+| `redemptions.override` (manual exception; reason required) | ✓ | ✓ | — | — | — | ✓ | — |
+| `analytics.view_own` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `analytics.view_team` | ✓ | ✓ | ✓ | — | ✓ | ✓ | ✓ |
+| `exports.run` | ✓ | ✓ | ✓ | — | — | — | ✓ |
+| `audit.view` | ✓ | ✓ | — | — | — | — | — |
+| `team.manage_access` (grant sub-roles, invite staff) | ✓ | — | — | — | — | — | — |
+
+"O (own)" is a **row-level** check: `partner_organisations.ownerUserId === req.user.id`
+(or task `assigneeUserId`). Implemented in services, not just middleware.
+
+## 3. Enforcement design
+
+```js
+// backend/src/middleware/redeemOpsAuth.js
+requireRedeemOps(...caps)   // = authenticateToken →
+                            //   role==='admin' → pass (implicit super_admin)
+                            //   role==='redeem_ops' || redeemOpsRole set →
+                            //     caps ⊆ ROLE_CAPABILITIES[user.redeemOpsRole] → pass
+                            //   else 403
+```
+
+- `ROLE_CAPABILITIES` lives in `backend/src/services/redeemOps/permissions.js` — single source of
+  truth, exported for tests and for the SPA (mirrored constant for nav/UI gating; drift caught by a
+  unit test comparing both).
+- Row-level "own" checks live in services (`claimService`, `taskService`) so bulk endpoints can't
+  bypass them.
+- Every route in `ROUTE_MAP.md` names its capability; a route without one fails review.
+- Existing MKTR gates are untouched. A `redeem_ops` user hitting `/api/admin/*` fails
+  `requireAdmin` exactly as a `customer` would today.
+- API-level tests (not nav-hiding) are the acceptance bar — brief §37 "Permissions".
+
+## 4. Audited actions (minimum set → `redeem_ops_audit_events`)
+
+`partner.created / edited / claimed / released / reassigned / restricted / disqualified / merged`,
+`stage.changed`, `contact.created / edited`, `activity.edited / voided`, `task.reassigned`,
+`pool.created / member_added`, `reward.created / edited / status_changed`, `terms.versioned`,
+`inventory.adjusted` (any manual ledger entry), `activation.created / status_changed /
+campaign_linked / campaign_unlinked / allocation_changed`, `entitlement.issued_manual / cancelled`,
+`redemption.completed / overridden / reversed`, `access.role_granted / revoked`, `export.ran`.
+
+## 5. Future partner-portal scoping (design constraint, not V1 code)
+
+Portal principals get **none** of the capabilities above. Their future namespace
+(`/api/partner-portal/*`) authorizes by token scope (`partnerOrgId`) + a tiny portal-role set
+(`owner|staff`), and every query is forced through `WHERE partnerOrganisationId = token.partnerOrgId`
+(+ location scoping for multi-outlet). The V1 schema already keys all reward/redemption data by
+`partnerOrganisationId`, so this is additive. Lead PII is excluded by the
+`entitlementService.partnerView()` projection contract (`MKTR_INTEGRATION.md` §4).

--- a/docs/redeem-ops/RECOMMENDED_ARCHITECTURE.md
+++ b/docs/redeem-ops/RECOMMENDED_ARCHITECTURE.md
@@ -1,0 +1,219 @@
+# Redeem Ops — Recommended Architecture
+
+> Phase 0 deliverable. This is the blueprint for the accepted option (Option A in
+> `ARCHITECTURE_OPTIONS.md`): Redeem Ops as a namespaced module of the existing monolith, exposed
+> as its own internal surface (target: `ops.redeem.sg`). Companion docs: `MKTR_INTEGRATION.md`
+> (campaign/lead touchpoints), `ERD.md` (schema), `PERMISSION_MATRIX.md` (authz),
+> `ROUTE_MAP.md` (surfaces), `USER_SURFACES_AND_DEPLOYMENT_BOUNDARIES.md` (who sees what, where),
+> `IMPLEMENTATION_PLAN.md` (sequencing).
+
+## 1. Shape of the system
+
+```text
+                 ┌────────────────────────────────────────────────────────────┐
+                 │                 mktr-backend (api.mktr.sg)                 │
+                 │                                                            │
+   mktr.sg ────▶ │  /api/auth, /api/campaigns, /api/prospects, /api/admin, …  │
+ (operators)     │                        │ (unchanged)                       │
+                 │                        ▼                                   │
+ ops.redeem.sg ▶ │  /api/redeem-ops/*  ──▶ services/redeemOps/* ──▶ new       │
+ (Redeem staff)  │  (flag: REDEEM_OPS_ENABLED)         │           tables     │
+                 │                                     │ one-way deps         │
+                 │                 reads Campaign/Prospect/User via FK &      │
+                 │                 existing services (never writes them)      │
+                 │                                                            │
+ redeem.sg ────▶ │  /api/prospects, /api/verify, /t/:slug   (unchanged)       │
+ (consumers)     │  future: /api/redeem-ops/fulfilment/claim (Phase 6)        │
+                 └────────────────────────────────────────────────────────────┘
+                                    one PostgreSQL (Render)
+```
+
+One backend, one database, one SPA codebase. Redeem Ops is a **module with a hard one-way import
+rule**: `redeemOps` code may import MKTR models/services (FKs, read-only calls); **no MKTR file
+may import from `redeemOps/`**. The rule governs module imports, not runtime calls — the single
+sanctioned reverse-direction touchpoint (the Phase 6 capture hook) is dependency-inverted:
+`makeProspectService` already takes injected collaborators, so bootstrap (the composition root)
+injects the entitlement callback and lead capture calls an injected function whose default is a
+no-op (see `MKTR_INTEGRATION.md` §2). That rule is the future extraction seam: remove the
+bootstrap wiring and MKTR is byte-identical to today.
+
+## 2. Backend module layout
+
+Constraints from the auto-loaders (`routes/index.js`, `models/index.js` read only their own
+top-level directory) dictate flat placement for routes and models; everything else nests.
+
+```text
+backend/src/
+├── routes/                      # FLAT (auto-loader) — all export meta.flag REDEEM_OPS_ENABLED
+│   ├── redeemOpsPartners.js     #   /api/redeem-ops/partners (+contacts/locations/claim/stages/activities nested)
+│   ├── redeemOpsWork.js         #   /api/redeem-ops/tasks, /queue, /pools
+│   ├── redeemOpsRewards.js      #   /api/redeem-ops/rewards (+terms, inventory)
+│   ├── redeemOpsActivations.js  #   /api/redeem-ops/activations (+campaign search projection)
+│   ├── redeemOpsFulfilment.js   #   /api/redeem-ops/entitlements, /redemptions
+│   └── redeemOpsAdmin.js        #   /api/redeem-ops/team, /audit, /settings
+├── controllers/redeemOps/       # nested (imported by routes, not auto-discovered)
+├── services/redeemOps/          # nested; DI-factory pattern (`makePartnerService(overrides)`)
+│   ├── permissions.js           #   ROLE_CAPABILITIES map (single source of truth)
+│   ├── auditService.js          #   append-only writer for redeem_ops_audit_events
+│   ├── partnerService.js, dedupeService.js, claimService.js, taskService.js,
+│   │   poolService.js, onboardingService.js, rewardService.js, inventoryService.js,
+│   │   activationService.js, entitlementService.js, redemptionService.js,
+│   │   campaignProjection.js    #   the ONLY file that reads MKTR campaign internals
+│   └── normalizers.js           #   business-name/domain/social/postal normalization
+├── middleware/redeemOpsAuth.js  # requireRedeemOps(...caps) — see PERMISSION_MATRIX.md
+└── models/                      # FLAT (auto-loader) — PartnerOrganisation.js, PartnerLocation.js,
+                                 # PartnerContact.js, PartnerAssignmentEvent.js, PartnerStageEvent.js,
+                                 # OutreachActivity.js, OutreachTask.js, ProspectingPool.js,
+                                 # ProspectingPoolMember.js, PartnerOnboardingItem.js, RewardOffer.js,
+                                 # RewardTermsVersion.js, RewardInventoryEvent.js, Activation.js,
+                                 # RewardEntitlement.js, Redemption.js, RedemptionEvent.js,
+                                 # RedeemOpsAuditEvent.js
+```
+
+Association wiring goes in `models/index.js` alongside the existing explicit block, grouped under a
+`// Redeem Ops` banner, with the same deliberate `onDelete` discipline (see `ERD.md`).
+
+**Dark launch**: every route file exports
+`meta = { path: '/api/redeem-ops/…', flag: 'REDEEM_OPS_ENABLED', flagDefault: 'false' }` — the
+namespace does not exist in production until the env var flips (house precedent:
+`BILLING_ENABLED` on `routes/externalBilling.js`).
+
+## 3. Authentication — reuse, no changes to mechanics
+
+- Redeem Ops staff are rows in the existing `users` table and log in through the existing
+  `/api/auth/*` (email+password or Google) with the same httpOnly `mktr_token` cookie.
+- Staff onboarding reuses `invitationService.sendRoleInvitation` extended to the new role (Phase 1).
+- Sessions are per-host (host-only cookie, SameSite=strict) — an ops.redeem.sg login is isolated
+  from mktr.sg and redeem.sg. No SSO work needed or wanted for V1.
+- **Do not** revive the `services/auth-service` JWKS spike for this.
+
+## 4. Authorization — additive two-level model
+
+Existing `requireRole` stays untouched. Redeem Ops adds:
+
+1. **Platform role value** `redeem_ops` appended to the `users.role` enum (migration 045;
+   precedent: enum extension in migration 029). Dedicated outreach staff get this role; it is
+   invisible to every existing `requireRole('admin'|'agent'|…)` gate, to agent-sync (scoped to
+   `role='agent'`), and to lead routing.
+2. **Sub-role column** `users.redeemOpsRole` (STRING(32), nullable):
+   `super_admin | ops_admin | bdm | outreach_exec | campaign_ops | redemption_ops | analyst`.
+   Nullable so an existing MKTR `admin` can also be granted a Redeem Ops sub-role; users with
+   `role='admin'` are implicitly `super_admin` (override in middleware).
+3. **Capability map + middleware**: `services/redeemOps/permissions.js` defines
+   `ROLE_CAPABILITIES`; `middleware/redeemOpsAuth.js` exports
+   `requireRedeemOps(...capabilities)` = `authenticateToken` + (admin bypass ∨ capability check).
+   All enforcement server-side; the SPA only *hides* what the API already forbids.
+   Full matrix in `PERMISSION_MATRIX.md`.
+
+**Campaign Ops clarification** (per addendum §4): the `campaign_ops` sub-role manages
+*Activations* — search/link an existing MKTR campaign, allocate reward inventory, monitor
+availability, view read-only campaign metrics. It grants **zero** MKTR campaign-builder access;
+campaign creation/edit remains `requireRole('admin')` on the existing `/api/campaigns` +
+`/api/admin/campaigns` surfaces on mktr.sg.
+
+## 5. Surface & host plumbing (what actually changes)
+
+| Change | File | Detail |
+|---|---|---|
+| Allowlist the ops host | `backend/src/utils/publicHost.js:12-17` | Add `ops.redeem.sg` to `ALLOWED_PUBLIC_HOSTS`; add `isOpsHost()`; **do not** widen `isRedeemHost` (that predicate means "consumer redeem brand" and drives the D13 block + email/CAPI branching). |
+| Protect the new namespace | `backend/src/middleware/internalRouteHostGuard.js:13-24` | Add `/api/redeem-ops` to `BLOCKED_PATH_PREFIXES` (blocks consumer redeem.sg/www). ops.redeem.sg passes because it is not a redeem-consumer host. Also block the internal namespace from any *future* partner host. |
+| **Ops-host allow-policy (Codex finding, accepted)** | same guard | Today the guard only *blocks redeem hosts* (`isRedeemHost` check at `internalRouteHostGuard.js:40`), so an allowlisted ops.redeem.sg would reach `/api/admin/*` etc. at the host layer, leaving role checks as the only gate. Extend the guard with a per-surface policy: for `isOpsHost()` requests, **allow only** `/api/auth`, `/api/redeem-ops`, `/api/notifications` and 403 the other internal prefixes. Host policy is defence-in-depth; capabilities remain the primary gate. |
+| CORS | `backend/src/server_internal.js:70-79` | Add `https://ops.redeem.sg` to default origins (defence-in-depth; the surface uses the same-origin proxy anyway). |
+| Auth-route guard nuance | same guard | `/api/auth` stays blocked for redeem.sg but must be reachable from ops.redeem.sg — satisfied automatically because the block tests `isRedeemHost(publicHost)` only. Add a regression test. |
+| Rate limiter | `backend/src/server_internal.js:99-116` | Outreach staff are normal IP-limited users (200 req/15 min prod). Extend the admin bypass to `role='redeem_ops'` **or** raise via `RATE_LIMIT_MAX_REQUESTS` if queue polling gets throttled — decide with real usage in Phase 3, not preemptively. |
+
+**Frontend surface**: introduce a **new** `VITE_SURFACE=ops` build flag (to be built in Phase 1 —
+`vite.config.js:6-9` currently resolves only `VITE_BRAND`; that mechanism is the proven precedent
+this replicates, not something that exists today):
+
+- `ops` build: mounts ONLY `/redeem-ops/*` routes + login + minimal chrome (everything else →
+  redirect to mktr.sg), analogous to how the redeem build swaps `ProtectedRoute` wholesale.
+- `mktr` build: additionally mounts `/redeem-ops/*` behind `VITE_REDEEM_OPS_ENABLED`
+  (dogfood path; precedent: `VITE_CAMPAIGN_WORKSPACE_ENABLED`).
+- `redeem` (consumer) build: never contains ops routes.
+
+Render deployment for cutover (mirrors `redeem-frontend` exactly): new static site from the same
+repo, `VITE_SURFACE=ops`, `VITE_API_URL=/api` + rewrite `/api/* → https://api.mktr.sg/api/*`,
+custom domain `ops.redeem.sg` (Cloudflare CNAME), backend env `REDEEM_OPS_ENABLED=true`.
+
+## 6. Data layer standards (details in `ERD.md`)
+
+- New tables only; **no ALTERs to MKTR tables** except the two `users` columns above.
+  Migrations start at **045** (044 is uncommitted on `feat/campaign-store-catalog` — merge-order
+  coordination required).
+- Conventions: UUID v4 PKs, snake_case plural table names, Sequelize-default camelCase columns,
+  explicit associations in `models/index.js`, `STRING(n)` + app-level constants for evolving
+  states (house drift away from `DataTypes.ENUM`), display values preserved separately from
+  normalized matching columns.
+- Delete discipline: append-only history/ledger tables never cascade from their subject
+  (`RESTRICT` or `SET NULL` + snapshots — the `Payment` precedent); operational children
+  (contacts/locations) cascade with their partner; MKTR references are `SET NULL` + name snapshot.
+- Concurrency: claim = single conditional `UPDATE … WHERE "ownerUserId" IS NULL … RETURNING`;
+  pool-next = `FOR UPDATE SKIP LOCKED`; inventory = guarded counter UPDATE + ledger insert in one
+  transaction. All three have existing exemplars cited in `ERD.md` §Integrity.
+
+## 7. Future Partner Portal (`partners.redeem.sg`) — designed now, built later
+
+Decisions made now so the portal needs **no data-model rewrite**:
+
+1. **Row-level partner scoping is structural**: every reward/activation/entitlement/redemption row
+   carries `partnerOrganisationId` (and `locationId` where relevant) — partner scoping is a WHERE
+   clause, not a refactor.
+2. **Separate principal table** for external users: future `partner_users`
+   (email, credential/OTP, `partnerOrganisationId`, portal role) — external identities never enter
+   `users` (keeps them out of staff RBAC, agent-sync sweeps, and admin UIs). They authenticate via
+   the same jsonwebtoken infra but with a **distinct token audience/claim**
+   (`scope:'partner'`, `partnerOrgId`) verified by a dedicated `partnerPortalAuth` middleware on a
+   dedicated `/api/partner-portal/*` namespace. Internal staff tokens are never valid there and
+   vice versa.
+3. **Actor polymorphism in histories now**: `redemption_events` and `redeem_ops_audit_events`
+   record `actorType` (`staff | agent | partner_user | consumer | system`) + `actorUserId`
+   (nullable) so both a consultant-performed unlock and a future partner-performed verification
+   are representable without schema change.
+4. **Verification endpoints designed dual-audience**: redemption verify/complete logic lives in
+   `redemptionService` with the acting principal passed in — Phase 6 exposes it to staff; the
+   portal later exposes the same service under partner auth with location scoping.
+5. **Data minimisation contract** (privacy §35): the partner-visible projection of an entitlement
+   is `{ tokenHint, status, rewardTitle, expiry }` — never lead PII, never campaign/lead
+   management data, never financial-planning signals. Encoded as a projection function from day
+   one (`entitlementService.partnerView()`), even though only staff call it in V1.
+
+## 8. Consumer surface (redeem.sg) — Phase 6 touchpoint only
+
+The consumer claim/redemption journey (e.g. `redeem.sg/r/:token` showing a reward voucher +
+partner instructions) is a **new consumer-build route** rendered from Redeem Ops fulfilment APIs.
+It is deliberately out of V1; the path and API are reserved in `ROUTE_MAP.md`. Nothing existing on
+redeem.sg moves.
+
+## 9. Observability, audit, jobs
+
+- **Audit**: `redeem_ops_audit_events` (append-only, actor + action + entity + before/after JSONB +
+  `requestId` from the existing `requestId` middleware). Written by `auditService` inside the same
+  transaction as the mutation for the actions listed in `PERMISSION_MATRIX.md` §Audited actions.
+- **Jobs**: staleness sweeps (first-outreach 48h flag, 14-day stale flag) run as an in-process
+  interval in `bootstrap.js` gated by `REDEEM_OPS_ENABLED`, following the release-sweep pattern —
+  flags set on rows; **no auto-release** of claims in V1 (matches brief §16).
+- **Logging/Sentry**: pino + existing Sentry init; log keys prefixed `redeem_ops.` (house style:
+  `redeemed_audience.sync.done`).
+
+## 10. What Redeem Ops will NOT do (enforced review checklist)
+
+1. No second Campaign model, builder, landing-page config, form config, pixel config, or campaign
+   URL generation — campaign work happens on mktr.sg.
+2. No writes to `campaigns`, `prospects`, `qr_tags`, `lead_packages`, or routing/quota state.
+3. No copies of lead PII into Redeem Ops tables (FK + server-side join only).
+4. No second auth system, no JWKS revival, no workspace tooling, no message broker.
+5. No repository restructuring; no moving existing directories.
+6. No MKTR code importing from `services/redeemOps/` (one-way **import** rule; the Phase 6 hook is
+   injected at the bootstrap composition root — a no-op-by-default callback, never an import).
+7. No consumer-facing exposure of internal ops APIs (host guard + capability checks are both
+   mandatory on every route).
+
+## 11. Open decisions (tracked, non-blocking)
+
+| # | Decision | Default until decided |
+|---|---|---|
+| 1 | Ship dogfood on mktr.sg `/redeem-ops` first vs. straight to ops.redeem.sg | Dogfood first (zero DNS/Render work; flag-gated) |
+| 2 | `pg_trgm` for fuzzy-name duplicate detection | Attempt `CREATE EXTENSION IF NOT EXISTS pg_trgm` in migration with graceful fallback to normalized-prefix matching (see `ERD.md`) |
+| 3 | Rate-limiter treatment for ops staff | Leave default; revisit with Phase 3 usage data |
+| 4 | Email notifications for task assignment | Defer past V1 (reuse `mailer.js` when added) |

--- a/docs/redeem-ops/REPOSITORY_DISCOVERY.md
+++ b/docs/redeem-ops/REPOSITORY_DISCOVERY.md
@@ -1,0 +1,431 @@
+# Redeem Ops — Repository Discovery
+
+> Phase 0 deliverable. Everything below was verified against the working tree on branch
+> `feat/campaign-store-catalog` (2026-07-08). File references are exact paths; line numbers are
+> approximate anchors, not contracts.
+
+## 1. Executive summary
+
+- **This repository is a two-part monolith**: a single React 18 + Vite SPA (`src/`) and a single
+  Express 5 + Sequelize backend (`backend/`), deployed as **three Render services** — two static
+  sites built from the *same* SPA source (branched by `VITE_BRAND`) and one backend
+  (`api.mktr.sg`). It is **not** a workspace monorepo (no pnpm/Nx/Turbo); root `package.json` is
+  the SPA, `backend/package.json` is the API.
+- **The canonical Campaign model is `backend/src/models/Campaign.js`** (`campaigns` table) and the
+  **canonical Lead model is `backend/src/models/Prospect.js`** (`prospects` table). Both are UUID-keyed
+  Sequelize models in one PostgreSQL database (Render-hosted).
+- **"Redeem" today is a consumer brand skin, not a domain.** `redeem.sg` serves the same SPA with
+  `VITE_BRAND=redeem` (lead-capture surfaces only). There is **no partner, reward, voucher,
+  entitlement, or redemption model anywhere in the codebase** — searched broadly (`reward`,
+  `voucher`, `redeem`, `gift`, `booking`, `appointment`); hits are marketing copy, the
+  `RedeemPlaceholder` page, the Meta ad-exclusion sync (`redeemedAudienceService.js`), and the
+  in-flight "campaign gift" store-catalog fields (migration 044 — an MKTR→agent gift purchase,
+  unrelated to partner rewards).
+- Auth is a **single JWT identity system** (httpOnly cookie `mktr_token` + Bearer fallback) with a
+  flat 5-value role enum and per-route `requireRole(...)` middleware. There is **no generic audit
+  log**; per-domain history tables (`prospect_activities`, `webhook_deliveries`, `payments`) are the
+  existing pattern.
+- The repo has strong, reusable house patterns Redeem Ops should adopt: route auto-loading with
+  env-flag gating, DI-factory services, Joi validation middleware, atomic conditional-UPDATE
+  concurrency (`FOR UPDATE SKIP LOCKED`, `UPDATE … WHERE … RETURNING`), in-process schedulers, and
+  host-aware multi-surface serving.
+
+## 2. Repository structure (as it actually is)
+
+```text
+mktr-platform/
+├── src/                          # React 18 + Vite SPA (both mktr.sg and redeem.sg builds)
+│   ├── pages/                    # Route components (flat; subdirs: preview/, public/, __tests__)
+│   │   └── index.jsx             # THE route table (react-router-dom v7, declarative)
+│   ├── components/               # ui/ (shadcn/radix), auth/, layout/, campaigns/, prospects/, …
+│   ├── api/                      # client.js (API client + entity classes), entities.js re-exports
+│   ├── stores/                   # zustand: authStore.js (the only store)
+│   ├── hooks/queries/            # TanStack Query hooks (useCampaignsQuery, useProspectsQuery, …)
+│   ├── lib/                      # brand.js + brandConfigs/, metaPixel.js, tiktokPixel.js, utils.js
+│   ├── design/                   # design tokens (tropic.css, colors.ts, typography.ts) — in-flight refactor on this branch
+│   └── schemas/, services/, utils/, constants/, config/, data/, dev/, test/
+├── backend/
+│   ├── src/
+│   │   ├── server.js             # "shell" that listens immediately, then imports server_internal.js
+│   │   ├── server_internal.js    # middleware chain + route auto-load + bootstrap
+│   │   ├── routes/               # 44 route files; auto-mounted via `export const meta`
+│   │   ├── controllers/          # 38 controllers (thin; res.json envelopes)
+│   │   ├── services/             # 60+ services (business logic; DI-factory pattern)
+│   │   ├── models/               # 38 Sequelize models + index.js (auto-load + explicit associations)
+│   │   ├── middleware/            # auth.js, validation.js (Joi), internalRouteHostGuard.js, …
+│   │   ├── database/             # connection.js, bootstrap.js, runMigrations.js, migrations/ (002–044)
+│   │   ├── integrations/         # AdapterRegistry + platform adapters (lyfe, mktr_leads)
+│   │   ├── utils/                # publicHost.js, authCookie.js, customerHost.js, piiHashing.js, …
+│   │   └── config/               # envValidation, swagger
+│   ├── test/                     # Jest unit suites (~40) + test/integration/ (7 suites)
+│   ├── scripts/, load/, uploads/
+├── services/                     # DORMANT microservices spike: auth-service, gateway, leadgen-service
+│   └── …                        #   (own Dockerfiles; run via infra/docker-compose.yml; NOT deployed)
+├── infra/docker-compose.yml      # local compose for the spike above
+├── tablet-app/                   # Android (Kotlin) in-car tablet ad player — separate surface, out of scope
+├── e2e/                          # Playwright specs (admin dashboard, campaigns, prospects, auth, …)
+├── docs/                         # plans/ (design docs), audit/, dnc/, + this directory (redeem-ops/)
+├── public/                       # static assets for the SPA builds
+├── .github/workflows/ci.yml      # CI: backend Jest against postgres:15 service container
+├── vite.config.js                # VITE_BRAND resolved at config time → aliases @brand-config
+└── package.json                  # SPA deps/scripts (backend has its own package.json)
+```
+
+Root-level `*_PLAN.md` / `CODEX_REVIEW_*.md` files are working design documents, matching the
+`docs/plans/` convention.
+
+## 3. Frontend
+
+| Concern | What exists | Where |
+|---|---|---|
+| Framework | React 18.2, Vite 6, JS + JSX (TS only in `src/design/`) | `package.json` |
+| Routing | react-router-dom **7.2**, one declarative route table | `src/pages/index.jsx` |
+| State | zustand 5 (`authStore` only) + TanStack Query 5 for server state | `src/stores/authStore.js`, `src/lib/queryClient.js`, `src/hooks/queries/` |
+| API client | Hand-rolled `APIClient` (fetch, `credentials:'include'`, JSON envelope parsing) + Base44-style entity classes (`CampaignEntity`, `ProspectEntity`, …) | `src/api/client.js` (845 lines), `src/api/entities.js` |
+| UI kit | shadcn/ui on Radix primitives + Tailwind 3.4; `components.json` present | `src/components/ui/` |
+| Design tokens | `src/design/` (tropic.css, colors, typography, semantic) — being refactored on the current branch (uncommitted) | `src/design/` |
+| Forms | react-hook-form + zod resolvers | e.g. `src/components/forms/` |
+| Auth handling | `useAuthStore` (user + `'authenticated'` flag in localStorage; real JWT is httpOnly cookie) | `src/stores/authStore.js` |
+| Authorization | `<ProtectedRoute requiredRole="admin">` — client-side single-role check, redirect via `getDefaultRouteForRole()` | `src/components/auth/ProtectedRoute.jsx`, `src/lib/utils.js:8` |
+| Admin shell | `DashboardLayout` — role-switched sidebar nav (admin sections / agent / fleet_owner / driver_partner), CommandPalette (⌘K), NotificationBell, ThemeToggle | `src/components/layout/DashboardLayout.jsx:39` |
+| Brand split | `vite.config.js` resolves `VITE_BRAND` (`mktr` default, `redeem`) at build time → aliases `@brand-config` to `src/lib/brandConfigs/{mktr,redeem}.js`; route gates `brand.show*`, `IS_REDEEM_BUILD` guards | `vite.config.js:6-9,118`, `src/lib/brand.js`, `src/components/auth/BrandRouteGuards.jsx` |
+| Existing admin pages | AdminDashboard, AdminProspects, AdminCampaigns (+Form/Designer/Workspace), AdminQRCodes, AdminAgents(+Detail), AdminAgentGroups, AdminUsers, AdminLeadPackages, AdminCommissions, AdminShortLinks, AdminFleet/Vehicles/FleetMap/Devices, AdminApkManager | `src/pages/Admin*.jsx` |
+
+Frontend tests: Vitest + Testing Library (`npm test` at root); Playwright e2e in `e2e/`.
+
+## 4. Backend
+
+### Boot & middleware chain (`backend/src/server_internal.js`)
+
+Order matters and is load-bearing:
+`requestId` → helmet → compression → CORS (allowlist: mktr.sg/www/redeem.sg/www + `CORS_ORIGIN` env) →
+rate limiter on `/api` (prod: 200 req/15 min per IP; admins nominally 2000, `/api/integrations/lyfe/`
+and `/api/external/` exempt — HMAC-authed. ⚠️ **Pre-existing bug found during this review**: the
+admin bypass is dead for cookie sessions — `optionalAuth` is mounted *before* `cookieParser()`
+(`server_internal.js:120` vs `:159`), so `req.cookies` is empty when the limiter's role check runs;
+only Bearer-token admins are actually exempted, and the SPA sends no Bearer token
+(`src/api/client.js:29`)) → `blockRedeemForInternalRoutes` (host guard, see below) →
+pino-http → `express.json` with **rawBody capture** for HMAC paths (`/api/retell/`, `/api/meta/`,
+`/api/integrations/lyfe/`, `/api/external/`) → cookieParser → `/uploads` static → health endpoints →
+Swagger (non-prod) → `leadCaptureBind` (attribution cookies) → **route auto-loader** → 404 → Sentry →
+`errorHandler`. Then `bootstrapDatabase()` (migrations + seeds + in-process schedulers).
+
+### Route auto-loading + feature flags (`backend/src/routes/index.js`)
+
+Every file in `backend/src/routes/` exporting `meta` **and** a default router is mounted
+automatically. `meta` supports `path`, `priority`, multiple `mounts`, and — critically —
+**env-flag gating**: `{ path: '/api/external/billing', flag: 'BILLING_ENABLED', flagDefault: 'false' }`
+leaves a route **unmounted** until the env var is `"true"` (`backend/src/routes/externalBilling.js:28-32`
+is the exemplar). This is the house mechanism for shipping features dark.
+
+### Layering & conventions
+
+- **routes → controllers → services → models.** Controllers are thin
+  (`res.status(...).json({ success, message, data })`); services own logic.
+- **DI-factory service pattern**: `makeProspectService(overrides)`, `makeLeadCreditsService(overrides)`,
+  `makeBillingService(overrides)` — dependencies injected for unit tests, with backward-compatible
+  named exports (`backend/src/services/leadCredits.js:10,260`).
+- **Validation**: Joi via `validate(schema, options)` middleware; public lead-capture opts into
+  `stripUnknown` so contract drift never 400s a lead; internal routes fail loudly
+  (`backend/src/middleware/validation.js`).
+- **Errors**: `AppError(message, statusCode)` + central `errorHandler`; `asyncHandler` wrapper.
+- **Logging**: pino structured logger (`backend/src/utils/logger.js`); Sentry via shared
+  `sentryInit.js` with PII scrubbing.
+- **OpenAPI**: swagger-jsdoc annotations inline in route files, served at `/api-docs` (non-prod).
+
+### AuthN middleware (`backend/src/middleware/auth.js`)
+
+- `authenticateToken`: reads httpOnly cookie `mktr_token` first, then `Authorization: Bearer`.
+  Verifies with local `JWT_SECRET` (24h expiry, `generateToken(userId)`); optional JWKS path
+  (`AUTH_JWKS_URL`) exists for the dormant central-auth spike and falls through to legacy.
+  Loads `req.user` from `users` and debounces `lastLogin` writes.
+- `optionalAuth` (used before the rate limiter so admin bypass can see the role).
+
+### AuthZ middleware
+
+- `requireRole(...roles)` — flat string check against `users.role`
+  (`backend/src/middleware/auth.js:142-160`); prebuilt `requireAdmin`, `requireAgentOrAdmin`,
+  `requireFleetOwnerOrAdmin`. Roles are the ENUM
+  `('admin','agent','fleet_owner','driver_partner','customer')` (`backend/src/models/User.js:47`).
+  **There is no capability/permission layer** — authorization is role-list-per-route.
+- `prospectScope.js` middleware scopes lead queries by role.
+- Server-to-server surfaces use **HMAC**, not JWT: `requireExternalHmac`
+  (`EXTERNAL_APP_SECRET`, raw-body signature) on `/api/external/*`; timestamp-signed HMAC on
+  `/api/integrations/lyfe/*`; Retell/Meta webhook signatures on their paths.
+
+### Host guard (three-layer brand isolation)
+
+`backend/src/middleware/internalRouteHostGuard.js` returns 403 when the **validated** public host is
+redeem.sg for prefixes: `/api/auth`, `/api/admin`, `/api/agents`, `/api/fleet`, `/api/devices`,
+`/api/users`, `/api/lyfe`, `/api/mktr-leads`, `/api/webhooks`, `/api/integrations`. Host validation
+is allowlist-based in `backend/src/utils/publicHost.js:12-17` (`mktr.sg`, `www.mktr.sg`, `redeem.sg`,
+`www.redeem.sg`); unknown hosts (server-to-server) pass through. **Any new internal API namespace
+must be added to this blocklist, and any new public subdomain to the allowlist.**
+
+### Background jobs — in-process only (no queue infrastructure)
+
+All recurring work runs inside the single backend instance via `setInterval` in
+`backend/src/database/bootstrap.js`: webhook retry recovery (60s), idempotency-key purge (1h),
+agent sync from Lyfe + mktr-leads (10m), lead-quota release sweep (2m), Meta redeemed-audience sync
+(24h, flag-gated), DNC backfill (30m, flag-gated). Outbound events use the **DB-persisted webhook
+engine** (`webhookService.js`: `WebhookSubscriber`/`WebhookDelivery`, HMAC-signed, 3 retries with
+backoff, startup recovery, max 3 concurrent). There is no Kafka/RabbitMQ/pg-boss/BullMQ.
+
+### Integrations
+
+`backend/src/integrations/AdapterRegistry.js` + `adapters/` — platform adapters (`lyfe`,
+`mktr_leads`) abstract agent sources and webhook destinations. Meta CAPI
+(`metaCapiService.js`) and TikTok Events (`tiktokEventsService.js`) fire post-commit,
+fire-and-forget from `prospectService`.
+
+## 5. Authentication & sessions — multi-subdomain deep-dive
+
+(Requested explicitly in the Phase 0 addendum.)
+
+- **Login methods** (`backend/src/controllers/authController.js`): email+password (`/api/auth/login`),
+  Google Identity Services (`/api/auth/google`, `googleLogin` at line 16, plus OAuth-callback flow),
+  registration, and **role-based invites** — `invitationService.sendRoleInvitation` supports
+  `agent | fleet_owner | driver_partner` with a token link to `/auth/accept-invite`
+  (`backend/src/services/invitationService.js:12`, admin-only `POST /api/users/invite`).
+  New users default `approvalStatus='pending'` → frontend routes them to `/PendingApproval`.
+- **Session storage**: the JWT is set as **httpOnly cookie `mktr_token`** —
+  `secure` (prod), **`SameSite=strict`**, `path=/`, 24h, and **no `Domain` attribute → host-only**
+  (`backend/src/utils/authCookie.js:1-9`). The SPA additionally keeps a UI-only
+  `'authenticated'` flag + cached user JSON in localStorage (`src/stores/authStore.js:12-16`).
+  Bearer-token fallback exists for legacy/localStorage JWTs.
+- **How it works per surface today**:
+  - **mktr.sg** calls `https://api.mktr.sg/api` **cross-origin** (`VITE_API_URL` absolute) with
+    `credentials:'include'`. `api.mktr.sg` and `mktr.sg` share eTLD+1 → SameSite=strict still sends
+    the cookie (same-*site*, cross-*origin*), and CORS allows the origin with credentials.
+    The cookie itself lives host-only on `api.mktr.sg`.
+  - **redeem.sg** uses a **relative `/api`** with a Render edge rewrite to the backend, so requests
+    are same-origin in the browser and the cookie is host-only on `redeem.sg`. (Auth routes are
+    blocked for redeem.sg by the host guard anyway.)
+- **Consequences for new subdomains** (e.g. `ops.redeem.sg`):
+  1. Sessions are **naturally per-host** (no shared parent-domain auth cookie) — an ops.redeem.sg
+     session cannot leak to redeem.sg or mktr.sg. Staff working across surfaces log in per surface.
+  2. The Render-proxy (relative `/api`) pattern gives same-origin auth with zero CORS work; the
+     absolute-URL pattern requires adding the origin to the CORS allowlist
+     (`backend/src/server_internal.js:70-79`).
+  3. `publicHostFromRequest` returns `undefined` for hosts not in the allowlist — host-aware
+     branching (cookie domain for *attribution* cookies, email links, host guard) silently falls to
+     defaults. **A new public subdomain must be added to `ALLOWED_PUBLIC_HOSTS`** and classified
+     (internal vs consumer) in `isRedeemHost`/guard logic deliberately.
+  4. `cookieDomainForPublicHost` (parent-domain `.mktr.sg`/`.redeem.sg`) is used only for
+     **attribution/session cookies** (`sid`/`atk` via `trackerController.js`/`leadCaptureBind.js`),
+     not the auth cookie.
+- **Reuse verdict**: the existing identity system supports internal Redeem Ops staff without
+  modification to token mechanics. What it lacks is (a) role values for ops staff, (b) any
+  fine-grained permission layer, and (c) a separation story for future **external** partner users —
+  all addressed in `PERMISSION_MATRIX.md` and `RECOMMENDED_ARCHITECTURE.md`.
+
+## 6. Database
+
+- **Engine**: PostgreSQL on Render (`mktr-db`, `dpg-d2s2h7nfte5s739gnl7g-a`); `pg` + **Sequelize 6**
+  (`backend/src/database/connection.js`). One database for everything.
+- **Migrations**: custom, minimal runner (`backend/src/database/runMigrations.js`) — tracks applied
+  files by name in a `_migrations` table; files run in filename sort order; **up-only** (no down);
+  run automatically on boot (`bootstrapDatabase()`) and via `npm run migrate`. Files live in
+  `backend/src/database/migrations/` named `NNN-description.js` (**002–044**; the runner discovers
+  only `.js` files, so the two stray legacy `.sql` files are ignored). ⚠️
+  `044-add-campaign-gift-and-package-recommended.js` is **uncommitted on the current branch** —
+  new work must start at 045 and coordinate merge order. Note: the runner does **not** wrap
+  migrations in a transaction (`runMigrations.js:52-63` — plain `mod.up()` then a tracking INSERT);
+  migration 029's comment claiming an "implicit transaction" is inaccurate.
+- **Naming conventions**: snake_case plural table names (`lead_packages`, `qr_tags`,
+  `external_agents`); **camelCase column names by default** (Sequelize default, quoted —
+  `"createdAt"`, `"leadsRemaining"`); newer columns sometimes snake_case via explicit
+  `field:` mapping (`meta_pixel_id`, `gift_name`). UUID v4 primary keys everywhere; timestamps on.
+- **Enum strategy drift**: older models use `DataTypes.ENUM`; newer columns deliberately use
+  `STRING(n)` + comments/app-level validation (e.g. `Prospect.dncStatus STRING(16)`,
+  `quarantineReason STRING(64)`) because enum migrations are painful with the custom runner.
+- **Soft deletion**: no `paranoid` mode. Conventions are per-domain: status enums with
+  `'archived'` + explicit `permanentDelete` endpoints (campaigns), `isActive` flags (users, QR),
+  timestamp markers (`quarantinedAt`, `pending_deletion_at`), and immutable financial rows with
+  `ON DELETE SET NULL` + display snapshots (`Payment` — `backend/src/models/Payment.js:4-15`).
+- **Auditing**: **no generic audit table.** Existing trails: `prospect_activities`
+  (enum `created|assigned|updated|viewed`, actor, metadata JSON), `webhook_deliveries`,
+  `payments` (immutable), `qr_scans`/`attributions`/`session_visits` (attribution evidence).
+- **Concurrency patterns already proven here** (reuse for claiming/inventory):
+  - Atomic counter: `RoundRobinCursor.update({ cursor: literal('"cursor"+1') }, { returning: true })`
+    (`backend/src/services/systemAgent.js:153-165`).
+  - Single-winner conditional update: `UPDATE external_agents SET "leadBalance"="leadBalance"-:n
+    WHERE id=:id AND "leadBalance">=:n RETURNING id` (`backend/src/services/leadCredits.js:156-161`).
+  - `FOR UPDATE SKIP LOCKED` CTE pick-and-decrement (`chargeLeadCredit`,
+    `backend/src/services/leadCredits.js:206-227`).
+  - Idempotency: `IdempotencyKey` table (Retell), unique partial indexes, payment row
+    `pending→paid` conditional flip (`billingService.js`).
+- **Model inventory** (38): User, Campaign, CampaignAgentAssignment, CampaignMediaItem,
+  CampaignPreview, Prospect, ProspectActivity, QrTag, QrScan, Attribution, SessionVisit, ShortLink,
+  ShortLinkClick, LeadPackage, LeadPackageAssignment, Payment, Commission, UserPayout, AgentGroup,
+  AgentGroupMember, ExternalAgent, ExternalCampaignAgent, RoundRobinCursor, IdempotencyKey,
+  Verification, WebhookSubscriber, WebhookDelivery, WaitlistSignup, Car, FleetOwner, Driver,
+  Vehicle, Device, DeviceCampaignAssignment, VehicleCampaignAssignment, BeaconEvent, Impression,
+  ProvisioningSession, + `index.js` association hub (associations are explicit, with deliberate
+  `onDelete` rules — `backend/src/models/index.js:23-166`).
+
+## 7. Deployment
+
+| Service (Render) | Domain | Source | Notes |
+|---|---|---|---|
+| `mktr-platform` static site (`srv-d2s3che3jp1c738qlgjg`) | mktr.sg | `vite build` with `VITE_BRAND=mktr` (default) | Operator/admin brand; absolute `VITE_API_URL=https://api.mktr.sg/api` |
+| `redeem-frontend` static site (`srv-d88qhph9rddc738nk0d0`) | redeem.sg | same commit, `VITE_BRAND=redeem` | Consumer brand; relative `VITE_API_URL=/api` + Render rewrite to backend; 16 edge redirect rules bounce internal paths to mktr.sg |
+| `mktr-backend-jo6r` (`srv-d2s9p0emcj7s73acd9lg`) | api.mktr.sg | `node src/server.js` | Single instance; runs migrations on boot; in-process schedulers |
+
+- ⚠️ Provenance: the Render topology above (service names/ids, per-site env, proxy rewrites) is
+  **operational knowledge** (Render dashboard/MCP + `CLAUDE.md`), not derivable from source — there
+  is no `render.yaml` in the repo. Source evidence covers only the CORS defaults and middleware
+  behaviour (`backend/src/server_internal.js:70-128`).
+- All three auto-deploy from `main`. Cloudflare fronts both apex domains (`index.html` edge-cached
+  ~5 min). Env conventions: `VITE_*` baked at build; backend flags are string `"true"`/`"false"`
+  master switches (`WEBHOOK_ENABLED`, `META_CAPI_ENABLED`, `BILLING_ENABLED`, `DNC_API_ENABLED`, …)
+  documented in `.env.example`.
+- **CI** (`.github/workflows/ci.yml`): backend Jest (unit + integration) against a
+  `postgres:15-alpine` service container; npm audit (non-blocking). Known chronically-red suites
+  pre-exist on main.
+- The `services/` microservices (auth-service, gateway, leadgen-service) and
+  `infra/docker-compose.yml` are a **dormant spike** — not deployed; the JWKS branch in
+  `middleware/auth.js` is their only production trace. Do not build on them.
+- `tablet-app/` is the Android ad-player for in-car tablets (deviceEvents/adtech routes serve it).
+
+## 8. MKTR Campaign System (canonical)
+
+- **Model**: `backend/src/models/Campaign.js` — `campaigns` table. Key fields: `name`, `status`
+  ENUM(`draft|active|paused|completed|archived`), `type` ENUM(includes `quiz`), `is_active`,
+  `design_config` **JSON blob** (the entire landing-page/designer configuration incl.
+  `customerHost` (`redeem|mktr`), `otpChannel`, `sgPrOnly`, quiz config, referral gate),
+  `metaPixelId`, `tiktokPixelId`, `externalEligible`, `enforceLeadQuota`, commission amounts, and
+  the in-flight gift fields (`giftName`, `giftPriceFromMktr`, `giftNote`, `agentNotes` — migration 044).
+- **Service**: `backend/src/services/campaignService.js` — `createCampaign` (line 171),
+  `updateCampaign` (236; clamps `design_config.customerHost` via
+  `backend/src/utils/customerHost.js`), `setCampaignLaunchState` (311; readiness-gated
+  activate/pause), archive/restore/permanentDelete, `duplicateCampaign`,
+  `computeCampaignMetrics` (12) and `getCampaignAnalytics` (456) — metrics are **computed, not
+  stored**. `campaignReadinessService.js` gates launch.
+- **Routes**: `backend/src/routes/campaigns.js` (`/api/campaigns`, role-scoped) and
+  `backend/src/routes/adminCampaigns.js` (`/api/admin/campaigns` — launch workspace: delivery pool,
+  bulk assign, launch state). Controller: `backend/src/controllers/campaignController.js`.
+- **Builder UI**: `src/pages/AdminCampaignForm.jsx` (create/edit),
+  `src/pages/AdminCampaignDesigner.jsx` (landing-page designer writing `design_config`),
+  `src/pages/AdminCampaignWorkspace.jsx` (unified launch workspace), listing in
+  `src/pages/AdminCampaigns.jsx`; designer components under `src/components/campaigns/`.
+- **Public URL generation**: customer links are host-aware helpers in `src/lib/brand.js:37-81`
+  (`resolveCustomerHost`, `customerLeadCaptureUrl`, `customerPreviewUrl`, `publicTrackingUrl`,
+  `publicShareUrl`); QR images bake the host at generation
+  (`backend/src/services/qrCodeService.js:128-134` + `QrTag.targetHost`); short links + `/t/:slug`
+  tracker redirects (`trackerController.js`, `shortlinkService.js`).
+- **Landing page rendering**: `src/pages/LeadCapture.jsx` (+ `src/components/campaigns/…`,
+  quiz components) reads the campaign's `design_config` client-side; preview via
+  `/p/:slug` (`campaignPreviewService.js`).
+- **Tracking**: browser pixels `src/lib/metaPixel.js` / `src/lib/tiktokPixel.js`
+  (suppression in `src/lib/pixelSuppression.js`); server CAPI `backend/src/services/metaCapiService.js`
+  and `tiktokEventsService.js`; down-funnel outcomes via `/api/integrations/lyfe/lead-outcome`
+  (`leadOutcomeService.js`) and the external buyer path (`externalLeadOutcomeService.js`).
+- **Reporting**: `dashboardService.js`, `analyticsService.js`, `quizAnalyticsService.js`,
+  `agentLeaderboardService.js`; frontend `src/hooks/queries/useDashboardQuery.js`.
+
+## 9. MKTR Lead System (canonical)
+
+- **Model**: `backend/src/models/Prospect.js` — `prospects` table. Identity (name/email/phone
+  E.164), `leadSource` ENUM(`qr_code|website|referral|social_media|advertisement|direct|call_bot|other`),
+  `leadStatus` ENUM(`new|contacted|qualified|proposal_sent|negotiating|won|lost|nurturing`),
+  `priority`, `campaignId` FK, `assignedAgentId` FK (users), `externalAgentId` FK (external_agents,
+  mutually exclusive), `qrTagId`/`attributionId`/`sessionId` (attribution),
+  `sourceMetadata` JSON (utm/fbclid/ttclid/referral evidence), `consentMetadata` JSONB
+  (third-party-disclosure consent; `.external` gates buyer delivery), quarantine
+  (`quarantinedAt`/`quarantineReason`), DNC columns (`dncStatus`, register flags, `dncMetadata`).
+- **Creation flow**: `POST /api/prospects` (public, Joi `stripUnknown`) →
+  `backend/src/controllers/prospectController.js` → `makeProspectService().createProspect`
+  (`backend/src/services/prospectService.js:127` — 2,489 lines). In order: consent flags captured →
+  per-campaign duplicate gate (pre-check on `(campaignId, phone)` → **409** with canonical share
+  link; nuance: a request that loses a concurrent-insert race instead hits the DB unique index —
+  migration 010 — and surfaces as a generic **400** via the global unique-violation mapping,
+  `errorHandler.js:48-55`) → quiz scoring (server-verified) → routing
+  (`systemAgent.js:resolveLeadRouting` / cross-pool `resolveLeadAssignment`: self → admin-explicit →
+  QR-assigned → package round-robin → external buyer ring → System-Agent fallback or **quarantine**
+  under `enforceLeadQuota`/no-funded-buyer/DNC-pending) → credit charge (`leadCredits.js`) → single
+  transaction commit → **service-level post-commit fan-out**: `dispatchEvent('lead.created'|'lead.held')`
+  webhooks, Meta CAPI + TikTok events (`prospectService.js` ~843–930). Assignment + lead
+  confirmation emails fire afterwards from the **controller**, not the service
+  (`prospectController.js:58-72`; `mailer.js` brand-aware by campaign `customerHost`).
+- **OTP**: `POST /api/verify/send` / `/check` (`backend/src/routes/verify.js`, rate-limited 10/15min)
+  → `backend/src/services/verificationService.js` — AWS SNS SMS (SSIR sender "MKTR") or WhatsApp
+  (Meta Graph, per-campaign `design_config.otpChannel`), 6-digit code in `verifications` table
+  (PK=phone, 10-min TTL, max 5 attempts, single-use). ⚠️ **Finding**: OTP is orchestrated by the
+  SPA *before* submit; `POST /api/prospects` does **not** itself demand proof of verification —
+  only the DNC consent-gate flow consumes the short-lived verified-phone marker
+  (`verifiedPhoneStore.js`). Server-side phone possession is therefore a UX gate, not an API
+  invariant.
+- **Consent storage**: `consent_contact`/`consent_terms`/`consent_third_party`/`consent_dnc` from the
+  form → `sourceMetadata` + `consentMetadata` (server-controlled; client cannot inject —
+  stripUnknown). External-delivery consent logic in `backend/src/services/externalConsent.js`;
+  DNC gate in `dncGate.js`/`dncConsent.js`.
+- **Attribution**: QR scan → `/t/:slug` (`trackerController.js`) sets `sid`/`atk` cookies
+  (host-aware domains) → `leadCaptureBind.js` binds session → `attributions` row (first/last touch,
+  `qr_scans`, `session_visits`) → `prospect.attributionId`; ad-click ids (`fbclid`→`_fbc`,
+  `ttclid`) captured client-side and threaded through; source labeling in
+  `backend/src/utils/sourceLabel.js` + `src/lib/agentSource.js`.
+- **Duplicate prevention**: per-campaign unique partial index on `(campaignId, phone)` (409 at
+  capture); Retell idempotency via `idempotency_keys` + unique `retellCallId`; cross-campaign
+  repeat-signup **detection** (read-time admin flag, never blocks) in
+  `backend/src/services/repeatSignup.js` backed by migration 039 indexes.
+- **Assignment/routing**: `backend/src/services/systemAgent.js` (round-robin cursor, per-campaign
+  in-process queue), lead packages (`lead_packages` + `lead_package_assignments.leadsRemaining`
+  credits), quota gate `leadQuota.js` + `chargeLeadCredit`, held-queue release sweep
+  (`releaseSweep.js`), bulk ops (`prospectService` bulk assign/return-to-held/delete).
+- **Delivery**: webhook engine → Lyfe Supabase edge function and/or mktr-leads app (destination-aware
+  subscribers, `bootstrap.js:195-298`); `lead.deleted` propagation.
+- **Reporting**: `prospects/stats/overview`, dashboard queries, `webLeadTimelineService.js`
+  (per-lead timeline merging app + web activities).
+
+## 10. Existing "Redeem" implementation (what the word means in this repo today)
+
+| Artifact | What it is | Where |
+|---|---|---|
+| `redeem` brand build | Consumer skin of the same SPA (lead-capture only), served at redeem.sg | `src/lib/brandConfigs/redeem.js`, `vite.config.js` |
+| `RedeemPlaceholder.jsx` | Minimal apex `/` page on the redeem build | `src/pages/RedeemPlaceholder.jsx` |
+| Per-campaign customer host | Campaign chooses redeem.sg vs mktr.sg for its public links (`design_config.customerHost`, QR `targetHost`) | `src/lib/brand.js`, `backend/src/utils/customerHost.js`, migration 037 |
+| Host guard / brand isolation | redeem.sg cannot reach internal APIs/routes | `backend/src/middleware/internalRouteHostGuard.js`, `src/components/auth/BrandRouteGuards.jsx` |
+| `redeemedAudienceService.js` | Meta customer-list **ad exclusion** sync ("already redeemed" = already submitted a lead) | `backend/src/services/redeemedAudienceService.js` |
+| Campaign "gift" (migration 044, uncommitted) | Store-catalog fields: a physical gift the **buying agent purchases from MKTR** to hand to the prospect. Not a partner reward, no inventory, no entitlement, no redemption | `backend/src/models/Campaign.js:186-211`, `backend/src/services/billingService.js:49-61` |
+| "$20 voucher" et al. | Marketing copy in campaign content and consent dialog | `src/components/legal/MarketingConsentDialog.jsx`, `src/pages/LeadCaptureDemo.jsx` |
+
+**Conclusion**: partner organisations, partner CRM, reward offers, reward inventory, activations,
+entitlements, and redemptions are **greenfield domains**. Nothing needs migrating; nothing risks
+duplication except the *concepts* around campaigns/leads, which stay canonical in MKTR.
+
+## 11. Test infrastructure
+
+- **Backend**: Jest 29 (`backend/jest.config.js` — `maxWorkers: 1` against a real Postgres,
+  `test/setup.js` env). ~40 unit suites in `backend/test/`, 7 integration suites in
+  `backend/test/integration/` (incl. `pipelineE2E.test.js`, `agentAssignment.test.js`,
+  `leadCreditScoping.test.js` — concurrency-style tests exist as precedent). Route tests use
+  supertest; services tested via DI factories.
+- **Frontend**: Vitest + Testing Library (`src/**/__tests__/`); Playwright e2e in `e2e/`.
+- **Local note**: running backend tests needs a local Postgres + `JWT_SECRET`; ~5 suites are
+  chronically red on main (documented, inherited).
+
+## 12. Key findings & constraints that shape Redeem Ops
+
+1. **One backend, one DB, one SPA, three deploys** — the cheapest correct integration is inside
+   this monolith, exposed as a new surface, not a new system.
+2. **Route flags are the house dark-launch mechanism** — Redeem Ops can mount everything behind
+   `REDEEM_OPS_ENABLED` with zero risk to production.
+3. **Auto-loader constraints**: route files must sit flat in `backend/src/routes/`; model files flat
+   in `backend/src/models/`. Services/controllers may nest (`services/email-templates/` precedent).
+4. **RBAC is coarse** (role-list per route). Redeem Ops needs sub-roles/capabilities — additive,
+   without touching the shared `users.role` semantics that agent-sync, routing, and billing rely on
+   (`role='agent'` is load-bearing in `systemAgent.js`, `agentSyncService.js`, `billingService.js`).
+5. **No generic audit infrastructure** — Redeem Ops must bring its own append-only audit table
+   (pattern precedent: `prospect_activities` + immutable `payments`).
+6. **Concurrency-safe primitives already exist and are tested** — claiming, pool-next, and
+   inventory must use the conditional-UPDATE / SKIP LOCKED patterns, not app-level checks.
+7. **No queue infra; in-process schedulers are the norm** — stale-claim sweeps etc. follow
+   `bootstrap.js` patterns; do not introduce brokers.
+8. **Auth cookie is host-only, SameSite=strict** — new subdomains get isolated sessions for free;
+   the Render-proxy relative-`/api` pattern avoids CORS entirely. New public hosts must be added to
+   `ALLOWED_PUBLIC_HOSTS` and the host guard deliberately.
+9. **Migration numbering starts at 045** (044 is uncommitted on `feat/campaign-store-catalog`).
+10. **users table is synced/swept by external sources** — Lyfe + mktr-leads agent sync
+    creates/deactivates/deletes `role='agent'` rows on timers. New staff roles must be outside that
+    blast radius (they are, as long as their `role` ≠ `agent` and they carry no `lyfeId`/`mktrLeadsId`).

--- a/docs/redeem-ops/ROUTE_MAP.md
+++ b/docs/redeem-ops/ROUTE_MAP.md
@@ -1,0 +1,143 @@
+# Redeem Ops — Route Map
+
+> Phase 0 deliverable. Backend routes mount via the auto-loader
+> (`export const meta = { path, flag: 'REDEEM_OPS_ENABLED', flagDefault: 'false' }`) and each names
+> its capability from `PERMISSION_MATRIX.md`. `/api/redeem-ops` is added to
+> `internalRouteHostGuard.BLOCKED_PATH_PREFIXES` (unreachable from consumer redeem.sg). Phases
+> refer to `IMPLEMENTATION_PLAN.md`.
+
+## 1. Backend API (`/api/redeem-ops/*`)
+
+### Partners — `routes/redeemOpsPartners.js` (Phase 2)
+
+| Method & path | Capability | Purpose |
+|---|---|---|
+| GET `/partners` | partners.view | Paginated list; server-side filters: search (name/phone/uen/handle), stage, owner, category, availability, flags. Sort: lastActivityAt, createdAt. |
+| POST `/partners` | partners.create | Create; runs dedupe; `409`-style structured response with matches unless `overrideReason` supplied (exact matches always require it). |
+| GET `/partners/check-duplicates` | partners.create | Pre-save duplicate probe (name/uen/phone/domain/socials/postal) → matches with owner, stage, reason, last activity. |
+| GET `/partners/:id` | partners.view | Detail incl. contacts, locations, open tasks, stage, owner. |
+| PUT `/partners/:id` | partners.edit (own) / ops_admin+ | Update display fields; recomputes normalized keys. |
+| POST `/partners/:id/claim` | partners.claim | **Atomic claim** (conditional UPDATE); `409 { claimedBy }` on loss. |
+| POST `/partners/:id/release` | partners.release (own) | Release back to available. |
+| POST `/partners/:id/assign` | partners.reassign | Manager assign/reassign `{ toUserId, reason }`. |
+| PATCH `/partners/:id/stage` | pipeline.move | Validated transition; writes stage event. |
+| POST `/partners/:id/merge` | partners.merge | `{ duplicateId, reason }` — re-points children, audits. |
+| GET `/partners/:id/timeline` | partners.view | Activities + stage events + assignment events, chronological, paginated (lazy-load). |
+| POST `/partners/:id/activities` | activities.log | Log outreach activity (type/direction/summary/outcome/occurredAt/contactId). |
+| PATCH `/activities/:id` | activities.edit (own) | Correction (audited before/after); DELETE not exposed — `POST /activities/:id/void`. |
+| GET/POST `/partners/:id/contacts`, PATCH/`archive` `/contacts/:id` | contacts.manage | |
+| GET/POST `/partners/:id/locations`, PATCH `/locations/:id` | locations.manage | |
+| GET/PATCH `/partners/:id/onboarding` | onboarding.manage | Checklist read/update (Phase 4). |
+
+### Work queue, tasks, pools — `routes/redeemOpsWork.js` (Phase 3)
+
+| Method & path | Capability | Purpose |
+|---|---|---|
+| GET `/queue` | analytics.view_own | **My Outreach Queue**: overdue, due-today, newly assigned, awaiting-first-outreach, recently replied, follow-ups soon, stale — one aggregated endpoint. |
+| GET `/tasks` | tasks.manage (own scope) | Filters: assignee (bdm+ may query others), status, due window (`today|overdue|upcoming`), partner. |
+| POST `/tasks` | tasks.manage | Create (title, partnerId, contactId?, assignee, dueAt, priority, type). |
+| PATCH `/tasks/:id` | tasks.manage (own/team) | Edit / status transitions; completion stamps completedAt/By. |
+| GET `/pools` · POST `/pools` · PATCH `/pools/:id` | pools.manage (GET: claim_next) | Pool CRUD. |
+| POST `/pools/:id/members` | pools.manage | Add partners (bulk ids). |
+| POST `/pools/:id/claim-next` | pools.claim_next | **SKIP LOCKED** next eligible prospect → atomic claim; `204` when pool exhausted. |
+| GET `/team/pipeline` | pipeline.view_team | Manager board: stage × owner counts + drill-down list. |
+
+### Rewards & inventory — `routes/redeemOpsRewards.js` (Phase 4)
+
+| Method & path | Capability |
+|---|---|
+| GET `/rewards` · GET `/rewards/:id` | rewards.view |
+| POST `/rewards` · PUT `/rewards/:id` · PATCH `/rewards/:id/status` | rewards.manage |
+| POST `/rewards/:id/terms` (new version) · GET `/rewards/:id/terms` | rewards.manage / rewards.view |
+| POST `/rewards/:id/inventory` (`{type: committed_increase|decrease|manual_adjustment, quantity, reason}`) | inventory.adjust |
+| GET `/rewards/:id/ledger` | rewards.view |
+
+### Activations & campaign reference — `routes/redeemOpsActivations.js` (Phase 5)
+
+| Method & path | Capability |
+|---|---|
+| GET `/campaigns` (read-only MKTR projection; search for link picker) | campaigns.read_reference |
+| GET `/activations` · GET `/activations/:id` | activations.view |
+| POST `/activations` · PATCH `/activations/:id` | activations.manage |
+| PATCH `/activations/:id/campaign` (link/unlink) | activations.link_campaign |
+| PATCH `/activations/:id/allocation` (guarded ± via ledger) | activations.allocate_inventory |
+| PATCH `/activations/:id/status` | activations.manage |
+| GET `/activations/:id/campaign-metrics` (read-only, via `computeCampaignMetrics`) | campaigns.read_reference |
+
+### Entitlements & redemptions — `routes/redeemOpsFulfilment.js` (Phase 6)
+
+| Method & path | Capability |
+|---|---|
+| GET `/entitlements` (filters: activation, status, expiring) | entitlements.view |
+| POST `/entitlements` (manual issue `{activationId, prospectId}`) | entitlements.issue_manual |
+| PATCH `/entitlements/:id/cancel` | entitlements.issue_manual |
+| POST `/redemptions/verify` (`{token}` → entitlement summary + validity; idempotent) | redemptions.verify |
+| POST `/redemptions/complete` (`{token, locationId?, method}` → atomic issued→redeemed) | redemptions.verify |
+| POST `/redemptions/:id/override` (`{action, reason}` — manual exception) | redemptions.override |
+| GET `/redemptions` | entitlements.view |
+
+**Agent-mediated unlock (Phase 6, `unlockPolicy='agent_unlock'`)**: the consultant's unlock action
+does NOT go through `/api/redeem-ops/*` (consultants aren't ops staff; their apps are external).
+It rides the existing HMAC server-to-server surfaces: `POST /api/external/entitlements/unlock`
+(mktr-leads app) and `POST /api/integrations/lyfe/entitlement-unlock` (Lyfe app) — payload =
+scanned presentation token (QR path) or prospect id (button path); the resolved agent must be the
+lead's assigned consultant; idempotent; audited as `redemption_events('unlocked')`. See
+`MKTR_INTEGRATION.md` §2.
+
+Future (not V1): the consumer claim endpoint lives in a **separate public namespace** —
+`POST /api/reward-claim` (public; entitlement token + phone-OTP validated; rate-limited) backing
+`redeem.sg/r/:token`. It must NOT sit under `/api/redeem-ops/*`, which is host-blocked from
+consumer redeem.sg (Codex finding, accepted — a claim route inside the internal namespace would
+contradict the guard). Also future: `/api/partner-portal/*` namespace (separate auth — see
+`RECOMMENDED_ARCHITECTURE.md` §7).
+
+### Team, audit, meta — `routes/redeemOpsAdmin.js` (Phase 1)
+
+| Method & path | Capability |
+|---|---|
+| GET `/team` (staff with sub-roles) | team.manage_access (list: analytics.view_team) |
+| POST `/team/invite` · PATCH `/team/:userId/role` | team.manage_access |
+| GET `/audit` (filter by entity/actor/action/date) | audit.view |
+| GET `/meta/constants` (stages, activity types, reward types — the constants module, so SPA and API can't drift) | any authenticated redeem-ops user |
+
+## 2. SPA pages (`src/pages/redeemops/`, routes in `src/pages/index.jsx`)
+
+Included in `mktr` build behind `VITE_REDEEM_OPS_ENABLED` (dogfood) and in the `VITE_SURFACE=ops`
+build as the whole app; never in the consumer `redeem` build. All wrapped in
+`<RedeemOpsRoute capability="…">` (ProtectedRoute variant checking sub-role/capability client-side
+— server remains the real gate).
+
+| Route | Page | Phase | Nav section |
+|---|---|---|---|
+| `/redeem-ops` | OpsOverview (my queue summary + team snapshot for managers) | 3 | Overview |
+| `/redeem-ops/partners` | PartnersList (table, filters, saved views; duplicate-aware create dialog) | 2 | Partners |
+| `/redeem-ops/partners/:id` | PartnerDetail (header w/ owner+stage+claim button; tabs: Timeline, Contacts, Locations, Tasks, Onboarding, Rewards) | 2 | Partners |
+| `/redeem-ops/pipeline` | TeamPipeline (table + Kanban; dnd via existing `@dnd-kit`, server-validated) | 3 | Outreach |
+| `/redeem-ops/queue` | MyQueue (start-of-day worklist) | 3 | Outreach |
+| `/redeem-ops/tasks` | Tasks (My/Due Today/Overdue/Upcoming/Team) | 3 | Outreach |
+| `/redeem-ops/pools` (+`/:id`) | ProspectingPools (+ Claim Next) | 3 | Outreach |
+| `/redeem-ops/rewards` (+`/:id`) | Rewards (offer editor, terms versions, inventory ledger) | 4 | Rewards |
+| `/redeem-ops/activations` (+`/:id`) | Activations (campaign link picker, allocation, read-only campaign card + "Open in MKTR") | 5 | Rewards |
+| `/redeem-ops/redemptions` | Redemptions (verify console + history) | 6 | Fulfilment |
+| `/redeem-ops/analytics` | Analytics (outreach/category/reward/activation) | 7 | Insights |
+| `/redeem-ops/team` | Team & access | 1 | Admin |
+| `/redeem-ops/audit` | Audit log | 1 (write) / 2 (UI) | Admin |
+| `/redeem-ops/settings` | Settings (stale thresholds display; config later) | later | Admin |
+
+Not-yet-built modules stay **out of the nav** (brief §30) rather than shipping as placeholders.
+
+Shell: reuse `DashboardLayout` with a `redeem_ops` nav branch
+(`src/components/layout/DashboardLayout.jsx:39` `getNavigationItems`) + an admin-visible
+"Redeem Ops" section when the flag is on; shared table/filters built on the existing shadcn
+`ui/` kit + TanStack Query hooks under `src/hooks/queries/redeemops/`.
+
+## 3. Surface exposure matrix
+
+| Namespace / route group | mktr.sg | ops.redeem.sg | redeem.sg (consumer) | partners.redeem.sg (future) |
+|---|---|---|---|---|
+| `/api/redeem-ops/*` | ✓ (flagged) | ✓ | ✗ 403 (host guard) | ✗ 403 |
+| `/redeem-ops/*` SPA | ✓ (flag, dogfood) | ✓ (whole app) | ✗ (not in bundle + guard) | ✗ |
+| Existing admin (`/Admin*`, `/api/admin/*`) | ✓ | ✗ (not in ops bundle; 403 via ops-host allow-policy; role-gated on top) | ✗ | ✗ |
+| Lead capture (`/LeadCapture`, `/t/:slug`, `/api/prospects`, `/api/verify`) | ✓ (per-campaign) | ✗ | ✓ | ✗ |
+| Future `/r/:token` claim page + public `/api/reward-claim` | — | — | ✓ (Phase 6+) | — |
+| Future `/api/partner-portal/*` | ✗ | ✗ | ✗ | ✓ |

--- a/docs/redeem-ops/USER_SURFACES_AND_DEPLOYMENT_BOUNDARIES.md
+++ b/docs/redeem-ops/USER_SURFACES_AND_DEPLOYMENT_BOUNDARIES.md
@@ -1,0 +1,67 @@
+# Redeem Ops — User Surfaces and Deployment Boundaries
+
+> Phase 0 deliverable (addendum §5). The domains below are **intended product boundaries**. The
+> technical realization — one SPA codebase compiled per surface, one backend, one database — is
+> deliberately shared; see `ARCHITECTURE_OPTIONS.md` for why domain separation here does not mean
+> repository/service separation.
+
+## 1. Surface map
+
+| User Type | Intended Surface | Responsibilities | Canonical Data Access |
+|---|---|---|---|
+| MKTR Campaign Operator | Existing MKTR Platform (`mktr.sg`) | Create/manage campaigns, designer, launch workspace, QR/short links, tracking & pixel config | MKTR Campaign domain (full R/W via `requireRole('admin')`) |
+| MKTR Lead Ops | Existing MKTR Platform (`mktr.sg`) | Lead management, routing, held queue, packages, agents, commissions | MKTR Lead domain (full R/W via existing role gates) |
+| Redeem Internal Staff | **`ops.redeem.sg`** (new; interim dogfood at `mktr.sg/redeem-ops`) | Partner prospecting/CRM, claiming, tasks, pipeline, onboarding, Reward Offers, inventory, Activations, entitlement/redemption ops, partner analytics, renewal | Redeem Ops domains (R/W per capability) + **limited read-only MKTR references** (campaign projection, lead reference for entitlements) |
+| External Partner Business | **`partners.redeem.sg`** (future — designed, not built) | View own org/offers/locations/quantities, verify redemptions, limited performance, renewal requests | **Strictly partner-scoped** Redeem data via separate principal table + token scope; zero MKTR access; zero lead PII |
+| Consumer | `redeem.sg` (existing; per-campaign `mktr.sg` opt-in) | Campaign participation, lead capture, OTP, (future) reward claim/redemption journey | Public/consumer-scoped flows only (`/LeadCapture`, `/t/:slug`, `/p/:slug`; future `/r/:token`) |
+
+## 2. How each surface is served (technical realization)
+
+| Surface | Serving mechanism | Build flag | API path allowance (enforced server-side) |
+|---|---|---|---|
+| mktr.sg | Existing Render static site `mktr-platform` | `VITE_BRAND=mktr` (+ `VITE_REDEEM_OPS_ENABLED` for the interim `/redeem-ops` dogfood group) | Everything except future partner-portal namespace |
+| ops.redeem.sg | **New third Render static site**, same repo/commit, relative `/api` proxy → api.mktr.sg | `VITE_SURFACE=ops` (new flag, built in Phase 1) | `/api/auth/*`, `/api/redeem-ops/*`, notifications; `/api/admin/*` and other internal namespaces **403 at the host layer** via the extended guard's ops-host allow-policy (`RECOMMENDED_ARCHITECTURE.md` §5) — roles/capabilities remain the primary gate |
+| redeem.sg | Existing Render static site `redeem-frontend` | `VITE_BRAND=redeem` | Public capture/verify/tracker only — internal APIs 403 via `internalRouteHostGuard` (extended with `/api/redeem-ops`) |
+| partners.redeem.sg (future) | Future static site (same mechanism) | future `VITE_SURFACE=partner` | Only future `/api/partner-portal/*` (distinct token scope); all internal namespaces blocked |
+| api.mktr.sg | Single existing backend `mktr-backend-jo6r` | — | Serves all of the above; host + role + capability are three independent gates |
+
+## 3. Boundary enforcement layers (per surface pair)
+
+Reusing the proven D13 three-layer pattern:
+
+1. **Build-time**: a surface's bundle only contains its own routes. `VITE_BRAND` is the **verified**
+   mechanism (the redeem build demonstrably excludes admin code); `VITE_SURFACE` is **proposed new
+   work** that replicates it for the ops surface (`vite.config.js` resolves only `VITE_BRAND`
+   today).
+2. **Edge**: Render redirect rules on consumer/partner sites bounce internal paths (as
+   redeem-frontend does today with 16 rules).
+3. **Backend**: `internalRouteHostGuard` (host allowlist) + `authenticateToken` +
+   `requireRedeemOps(capability)` / `requireRole` — the only layers that actually count for
+   security. Host checks never *grant* access, they only narrow exposure; capabilities are the
+   real gate.
+
+## 4. Data-access boundaries (canonical statements)
+
+- **Campaign data** crosses into Redeem Ops only as: `activations.campaignId` FK, the read-only
+  projection endpoint (id, name, status, type, customer URL, created), and read-only metric
+  aggregates (`computeCampaignMetrics`). Editing links back to mktr.sg
+  (`/admin/campaigns/:id/workspace`).
+- **Lead data** crosses into Redeem Ops only as: `reward_entitlements.prospectId` FK and
+  server-side joined display fields (name, masked contact) for staff with the relevant capability.
+  No lead PII is stored in Redeem Ops tables; partners never see lead datasets.
+- **Financial-planning information** (lead outcomes, `leadStatus` progression, CAPI signals) is
+  never exposed on ops partner views or the future partner portal.
+- **Consent** stays owned by MKTR capture (`prospects.consentMetadata`); Redeem Ops reads it when
+  issuing entitlements (Phase 6) and never mutates it.
+- **Redeem Ops data** (partners, rewards, redemptions) is invisible to MKTR surfaces in V1; the
+  future partner portal sees only rows where `partnerOrganisationId` matches its token scope.
+
+## 5. Session/identity boundaries
+
+- Internal staff (MKTR operators and Redeem staff) share one identity system (`users` + JWT
+  cookie). Cookies are host-only + SameSite=strict, so each surface has an independent session;
+  authorization — not the session — decides what a user can do (`PERMISSION_MATRIX.md`).
+- Future partner users are a **separate principal population** (`partner_users`, distinct token
+  scope) — a partner credential can never authenticate against staff namespaces, and staff tokens
+  are not honoured by the partner namespace.
+- Consumers are unauthenticated (phone-OTP-verified per submission, not sessioned).


### PR DESCRIPTION
## What this is

Phase 0 for **Redeem Ops** — the internal operations platform for partner prospecting/CRM, reward offers & inventory, Activations (linked to canonical MKTR campaigns), entitlements, and redemptions. **Documentation only — no application code.**

## Contents (`docs/redeem-ops/`)

- `REPOSITORY_DISCOVERY.md` — how the existing system actually works (grounded, file:line cited)
- `DOMAIN_OWNERSHIP.md` — system-of-record per domain; anti-duplication tripwires
- `ARCHITECTURE_OPTIONS.md` + `RECOMMENDED_ARCHITECTURE.md` — Option A: namespaced module in the monolith, flag-mounted `/api/redeem-ops/*`, ops.redeem.sg as a third static site
- `USER_SURFACES_AND_DEPLOYMENT_BOUNDARIES.md` — mktr.sg / ops.redeem.sg / redeem.sg / future partners.redeem.sg
- `MKTR_INTEGRATION.md` — campaign projection (read-only), entitlement issuance via DI-seam hook + reconciliation sweep, agent-mediated voucher unlock at the physical meeting
- `ERD.md` — 17 new tables; concurrency invariants reuse house patterns (conditional UPDATE…RETURNING, SKIP LOCKED)
- `PERMISSION_MATRIX.md` — `redeem_ops` role + sub-role capability model, server-enforced
- `ROUTE_MAP.md`, `IMPLEMENTATION_PLAN.md` — phases 1–7; V1 = 3 outreach staff working fully in the system

## Review

Codex review ran against the working tree: 14 findings, each verified against real code and dispositioned in `CODEX_REVIEW_PHASE0.md`. Also surfaced two pre-existing platform bugs (admin rate-limit bypass dead for cookie sessions; duplicate-signup race returns 400 not 409) — documented, not fixed here.

## Next

Phase 1 (foundation: role/capability model, audit table, flagged shell) follows in a separate PR — everything dark behind `REDEEM_OPS_ENABLED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)