### PR TITLE
feat(redeem-ops): Phase 1 foundation — role model, capabilities, audit, flagged shell

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ VITE_API_URL=http://localhost:3001/api
 # Google OAuth client ID (must match the backend GOOGLE_CLIENT_ID)
 VITE_GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 
+# Redeem Ops internal surface (dark-launch — docs/redeem-ops/). Gates the
+# /redeem-ops/* route group + nav in the SPA build. Backend counterpart below.
+VITE_REDEEM_OPS_ENABLED=false
+
 # =============================================================================
 # Backend Environment Variables
 # =============================================================================
@@ -47,6 +51,10 @@ META_CAPI_ENABLED=false        # Master switch — set to "true" to dispatch Lea
 META_PIXEL_ID=                 # Pixel ID from Meta Business Manager (15-16 digits)
 META_CAPI_ACCESS_TOKEN=        # Access token from Pixel → Settings → Conversions API
 META_TEST_EVENT_CODE=          # Test Event code from Pixel → Test Events tab (staging only)
+
+# Redeem Ops module (docs/redeem-ops/) — the /api/redeem-ops/* routes stay
+# UNMOUNTED until this is "true" (route auto-loader flag gating)
+REDEEM_OPS_ENABLED=false
 
 # Webhook system
 WEBHOOK_ENABLED=false          # Master switch — MUST be "true" for leads to reach Lyfe

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -56,6 +56,10 @@ export const googleLogin = async (req, res) => {
           id: result.user.id,
           email: result.user.email,
           role: result.user.role,
+          // Redeem Ops sub-role — frontend capability checks read this
+          // (src/lib/redeemOpsPermissions.js); the other auth flows return
+          // toJSON() which includes it, so this hand-built shape must too.
+          redeemOpsRole: result.user.redeemOpsRole,
           full_name: result.user.fullName,
           firstName: result.user.firstName,
           lastName: result.user.lastName,

--- a/backend/src/controllers/redeemOps/adminController.js
+++ b/backend/src/controllers/redeemOps/adminController.js
@@ -54,26 +54,34 @@ export const inviteTeamMember = asyncHandler(async (req, res) => {
   const { email, full_name, redeemOpsRole } = value;
   const roleLabel = `Redeem Ops — ${SUB_ROLE_LABELS[redeemOpsRole]}`;
 
-  const { user, inviteLink } = await sendRoleInvitation({
-    email,
-    fullName: full_name,
-    role: 'redeem_ops',
-    inviterEmail: req.user?.email,
-    extraFields: { redeemOpsRole },
-    getEmailContent: ({ firstName, inviteLink: link, companyName, companyUrl, expiryDays }) => ({
-      subject: getRoleInviteSubject({ companyName, roleLabel }),
-      html: getRoleInviteEmail({ firstName, inviteLink: link, companyName, companyUrl, expiryDays, roleLabel }),
-      text: getRoleInviteText({ firstName, inviteLink: link, companyName, expiryDays, roleLabel }),
-    }),
-  });
-
-  await recordAuditEvent({
-    actorUser: req.user,
-    action: 'access.invited',
-    entityType: 'user',
-    entityId: user.id,
-    after: { email, redeemOpsRole },
-    requestId: req.id || null,
+  // Access grant + its audit row commit atomically (Codex review finding 4):
+  // a persisted invite without an audit trail must be impossible. The invite
+  // email is best-effort inside the service; a rolled-back tx just leaves a
+  // dead token link, never an unaudited account.
+  const { user, inviteLink } = await sequelize.transaction(async (t) => {
+    const result = await sendRoleInvitation({
+      email,
+      fullName: full_name,
+      role: 'redeem_ops',
+      inviterEmail: req.user?.email,
+      extraFields: { redeemOpsRole },
+      transaction: t,
+      getEmailContent: ({ firstName, inviteLink: link, companyName, companyUrl, expiryDays }) => ({
+        subject: getRoleInviteSubject({ companyName, roleLabel }),
+        html: getRoleInviteEmail({ firstName, inviteLink: link, companyName, companyUrl, expiryDays, roleLabel }),
+        text: getRoleInviteText({ firstName, inviteLink: link, companyName, expiryDays, roleLabel }),
+      }),
+    });
+    await recordAuditEvent({
+      actorUser: req.user,
+      action: 'access.invited',
+      entityType: 'user',
+      entityId: result.user.id,
+      after: { email, redeemOpsRole },
+      requestId: req.id || null,
+      transaction: t,
+    });
+    return result;
   });
 
   res.status(201).json({

--- a/backend/src/controllers/redeemOps/adminController.js
+++ b/backend/src/controllers/redeemOps/adminController.js
@@ -1,0 +1,151 @@
+import { Op } from 'sequelize';
+import Joi from 'joi';
+import { asyncHandler, AppError } from '../../middleware/errorHandler.js';
+import { User, RedeemOpsAuditEvent, sequelize } from '../../models/index.js';
+import { sendRoleInvitation } from '../../services/invitationService.js';
+import {
+  getRoleInviteSubject,
+  getRoleInviteEmail,
+  getRoleInviteText,
+} from '../../services/emailTemplates.js';
+import { REDEEM_OPS_SUB_ROLES } from '../../services/redeemOps/permissions.js';
+import { SUB_ROLE_LABELS, publicConstants } from '../../services/redeemOps/constants.js';
+import { recordAuditEvent } from '../../services/redeemOps/auditService.js';
+
+const TEAM_ATTRIBUTES = [
+  'id', 'email', 'firstName', 'lastName', 'fullName',
+  'role', 'redeemOpsRole', 'isActive', 'lastLogin', 'createdAt',
+];
+
+// Internal admin surface — loud-fail Joi (no stripUnknown), matching house convention
+// for non-public routes (middleware/validation.js header comment).
+const inviteSchema = Joi.object({
+  email: Joi.string().email().required(),
+  full_name: Joi.string().min(1).max(100).required(),
+  redeemOpsRole: Joi.string().valid(...REDEEM_OPS_SUB_ROLES).required(),
+});
+
+const setRoleSchema = Joi.object({
+  redeemOpsRole: Joi.string().valid(...REDEEM_OPS_SUB_ROLES).allow(null).required(),
+});
+
+/** GET /api/redeem-ops/team — everyone holding Redeem Ops access. */
+export const listTeam = asyncHandler(async (req, res) => {
+  const team = await User.findAll({
+    where: {
+      [Op.or]: [{ role: 'redeem_ops' }, { redeemOpsRole: { [Op.ne]: null } }],
+    },
+    attributes: TEAM_ATTRIBUTES,
+    order: [['createdAt', 'ASC']],
+  });
+  res.json({ success: true, data: { team } });
+});
+
+/**
+ * POST /api/redeem-ops/team/invite — invite an outreach/ops staff member.
+ * Creates a `role='redeem_ops'` user with the sub-role and sends the standard
+ * role-invite email (invitationService + emailTemplates, same flow as /api/users/invite).
+ */
+export const inviteTeamMember = asyncHandler(async (req, res) => {
+  const { error, value } = inviteSchema.validate(req.body, { abortEarly: false });
+  if (error) {
+    throw new AppError(error.details.map((d) => d.message).join(', '), 400);
+  }
+  const { email, full_name, redeemOpsRole } = value;
+  const roleLabel = `Redeem Ops — ${SUB_ROLE_LABELS[redeemOpsRole]}`;
+
+  const { user, inviteLink } = await sendRoleInvitation({
+    email,
+    fullName: full_name,
+    role: 'redeem_ops',
+    inviterEmail: req.user?.email,
+    extraFields: { redeemOpsRole },
+    getEmailContent: ({ firstName, inviteLink: link, companyName, companyUrl, expiryDays }) => ({
+      subject: getRoleInviteSubject({ companyName, roleLabel }),
+      html: getRoleInviteEmail({ firstName, inviteLink: link, companyName, companyUrl, expiryDays, roleLabel }),
+      text: getRoleInviteText({ firstName, inviteLink: link, companyName, expiryDays, roleLabel }),
+    }),
+  });
+
+  await recordAuditEvent({
+    actorUser: req.user,
+    action: 'access.invited',
+    entityType: 'user',
+    entityId: user.id,
+    after: { email, redeemOpsRole },
+    requestId: req.id || null,
+  });
+
+  res.status(201).json({
+    success: true,
+    message: `${roleLabel} invited`,
+    data: { user: user.toJSON(), inviteLink },
+  });
+});
+
+/**
+ * PATCH /api/redeem-ops/team/:userId/role — grant, change, or revoke (null) a sub-role.
+ * Only `redeem_ops` staff and `admin` users may hold one (PERMISSION_MATRIX.md §1);
+ * granting to agents/drivers/customers is rejected. Update + audit are atomic.
+ */
+export const setTeamRole = asyncHandler(async (req, res) => {
+  const { error, value } = setRoleSchema.validate(req.body, { abortEarly: false });
+  if (error) {
+    throw new AppError(error.details.map((d) => d.message).join(', '), 400);
+  }
+  const target = await User.findByPk(req.params.userId);
+  if (!target) throw new AppError('User not found', 404);
+  if (!['redeem_ops', 'admin'].includes(target.role)) {
+    throw new AppError('Only Redeem Ops staff or admins can hold a Redeem Ops sub-role', 400);
+  }
+
+  const before = { redeemOpsRole: target.redeemOpsRole };
+  await sequelize.transaction(async (t) => {
+    await target.update({ redeemOpsRole: value.redeemOpsRole }, { transaction: t });
+    await recordAuditEvent({
+      actorUser: req.user,
+      action: value.redeemOpsRole ? 'access.role_granted' : 'access.role_revoked',
+      entityType: 'user',
+      entityId: target.id,
+      before,
+      after: { redeemOpsRole: value.redeemOpsRole },
+      requestId: req.id || null,
+      transaction: t,
+    });
+  });
+
+  res.json({ success: true, data: { user: target.toJSON() } });
+});
+
+/** GET /api/redeem-ops/audit — filterable, paginated audit trail (newest first). */
+export const listAudit = asyncHandler(async (req, res) => {
+  const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+  const limit = Math.min(100, Math.max(1, parseInt(req.query.limit, 10) || 25));
+
+  const where = {};
+  if (req.query.entityType) where.entityType = String(req.query.entityType);
+  if (req.query.entityId) where.entityId = String(req.query.entityId);
+  if (req.query.actorUserId) where.actorUserId = String(req.query.actorUserId);
+  if (req.query.action) where.action = String(req.query.action);
+
+  const { rows, count } = await RedeemOpsAuditEvent.findAndCountAll({
+    where,
+    include: [{ model: User, as: 'actor', attributes: ['id', 'fullName', 'email'] }],
+    order: [['createdAt', 'DESC']],
+    limit,
+    offset: (page - 1) * limit,
+  });
+
+  res.json({
+    success: true,
+    data: {
+      events: rows,
+      pagination: { page, limit, total: count, totalPages: Math.ceil(count / limit) },
+    },
+  });
+});
+
+/** GET /api/redeem-ops/meta/constants — stages/types/roles/capabilities for the SPA. */
+export const getConstants = asyncHandler(async (req, res) => {
+  res.json({ success: true, data: publicConstants() });
+});

--- a/backend/src/database/migrations/045-redeem-ops-foundation.js
+++ b/backend/src/database/migrations/045-redeem-ops-foundation.js
@@ -55,8 +55,29 @@ export async function up(queryInterface, Sequelize) {
         defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
       },
     });
-    await queryInterface.addIndex('redeem_ops_audit_events', ['entityType', 'entityId', 'createdAt'], { name: 'idx_roae_entity' });
-    await queryInterface.addIndex('redeem_ops_audit_events', ['actorUserId', 'createdAt'], { name: 'idx_roae_actor' });
-    await queryInterface.addIndex('redeem_ops_audit_events', ['action', 'createdAt'], { name: 'idx_roae_action' });
   }
+
+  // Indexes OUTSIDE the table-exists branch (Codex review): the runner is
+  // non-transactional, so a crash between createTable and an index must not
+  // leave a rerun that skips index creation. IF NOT EXISTS makes each step
+  // independently idempotent.
+  await queryInterface.sequelize.query(
+    'CREATE INDEX IF NOT EXISTS idx_roae_entity ON redeem_ops_audit_events ("entityType", "entityId", "createdAt")'
+  );
+  await queryInterface.sequelize.query(
+    'CREATE INDEX IF NOT EXISTS idx_roae_actor ON redeem_ops_audit_events ("actorUserId", "createdAt")'
+  );
+  await queryInterface.sequelize.query(
+    'CREATE INDEX IF NOT EXISTS idx_roae_action ON redeem_ops_audit_events ("action", "createdAt")'
+  );
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query('DROP TABLE IF EXISTS redeem_ops_audit_events CASCADE');
+  const usersTable = await queryInterface.describeTable('users');
+  if (usersTable.redeemOpsRole) {
+    await queryInterface.removeColumn('users', 'redeemOpsRole');
+  }
+  // Postgres cannot remove an enum value without recreating the type; the
+  // 'redeem_ops' role value stays as a harmless no-op (029 precedent).
 }

--- a/backend/src/database/migrations/045-redeem-ops-foundation.js
+++ b/backend/src/database/migrations/045-redeem-ops-foundation.js
@@ -1,0 +1,62 @@
+/**
+ * Redeem Ops Phase 1 foundation — docs/redeem-ops/IMPLEMENTATION_PLAN.md (Phase 1),
+ * docs/redeem-ops/ERD.md §2 + §3.19.
+ *
+ *  1. users.role gains 'redeem_ops' — dedicated internal ops staff. Deliberately a NEW
+ *     enum value so these users are invisible to every existing requireRole gate, to
+ *     agent-sync sweeps (scoped to role='agent'), and to lead routing.
+ *  2. users."redeemOpsRole" — nullable sub-role read by the capability map
+ *     (services/redeemOps/permissions.js). NULL = no Redeem Ops access; role='admin'
+ *     is an implicit super_admin in middleware regardless of this column.
+ *  3. redeem_ops_audit_events — append-only audit trail for the redeem-ops module
+ *     (the platform has no generic audit infra; REPOSITORY_DISCOVERY.md §6).
+ *
+ * ADD VALUE IF NOT EXISTS requires PG 12+ (migration 029 precedent). The runner applies
+ * migrations non-transactionally (runMigrations.js), so every step below is guarded to
+ * be idempotent-safe across a partial re-run. In NODE_ENV=test, sequelize.sync() creates
+ * everything from the models first and each guard no-ops.
+ */
+export async function up(queryInterface, Sequelize) {
+  await queryInterface.sequelize.query(
+    `ALTER TYPE "enum_users_role" ADD VALUE IF NOT EXISTS 'redeem_ops'`
+  );
+
+  const usersTable = await queryInterface.describeTable('users');
+  if (!usersTable.redeemOpsRole) {
+    await queryInterface.addColumn('users', 'redeemOpsRole', {
+      type: Sequelize.STRING(32),
+      allowNull: true,
+    });
+  }
+
+  const tables = await queryInterface.showAllTables();
+  if (!tables.includes('redeem_ops_audit_events')) {
+    await queryInterface.createTable('redeem_ops_audit_events', {
+      id: { type: Sequelize.UUID, primaryKey: true, allowNull: false },
+      actorUserId: {
+        type: Sequelize.UUID,
+        allowNull: true,
+        references: { model: 'users', key: 'id' },
+        onDelete: 'SET NULL',
+      },
+      // staff | agent | partner_user | consumer | system (ERD.md §3.19)
+      actorType: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'staff' },
+      // dot-namespaced, e.g. access.role_granted, partner.claimed
+      action: { type: Sequelize.STRING(64), allowNull: false },
+      entityType: { type: Sequelize.STRING(32), allowNull: false },
+      entityId: { type: Sequelize.UUID, allowNull: true },
+      before: { type: Sequelize.JSONB, allowNull: true },
+      after: { type: Sequelize.JSONB, allowNull: true },
+      reason: { type: Sequelize.STRING(255), allowNull: true },
+      requestId: { type: Sequelize.STRING(64), allowNull: true },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    });
+    await queryInterface.addIndex('redeem_ops_audit_events', ['entityType', 'entityId', 'createdAt'], { name: 'idx_roae_entity' });
+    await queryInterface.addIndex('redeem_ops_audit_events', ['actorUserId', 'createdAt'], { name: 'idx_roae_actor' });
+    await queryInterface.addIndex('redeem_ops_audit_events', ['action', 'createdAt'], { name: 'idx_roae_action' });
+  }
+}

--- a/backend/src/middleware/internalRouteHostGuard.js
+++ b/backend/src/middleware/internalRouteHostGuard.js
@@ -1,10 +1,17 @@
-import { publicHostFromRequest, isRedeemHost } from '../utils/publicHost.js';
+import { publicHostFromRequest, isRedeemHost, isOpsHost } from '../utils/publicHost.js';
 import { logger } from '../utils/logger.js';
 
 // D13: auth / admin / agent / driver flows must not be reachable from the
 // public redeem.sg static site. Render route rules redirect those at the
 // edge; this middleware is the backend belt-and-braces — if the redirect
 // is bypassed or misconfigured, the API call is rejected here.
+//
+// ops.redeem.sg (the internal Redeem Ops surface — docs/redeem-ops/
+// RECOMMENDED_ARCHITECTURE.md §5) sits on the redeem apex but is NOT a
+// consumer host: it gets a NARROW allowlist (staff auth, the redeem-ops
+// namespace, notifications) and stays blocked from every other internal
+// prefix at the host layer. Host policy is defence-in-depth only — role +
+// capability middleware remain the real gates.
 //
 // We compare against the *validated* public host (allowlist-checked),
 // never raw `req.hostname` or unfiltered headers. Requests that don't
@@ -21,14 +28,25 @@ const BLOCKED_PATH_PREFIXES = [
   '/api/mktr-leads',
   '/api/webhooks',
   '/api/integrations',
+  '/api/redeem-ops',
 ];
 
-function isBlockedPath(pathname) {
+const OPS_ALLOWED_PREFIXES = [
+  '/api/auth',
+  '/api/redeem-ops',
+  '/api/notifications',
+];
+
+function matchesPrefix(pathname, prefixes) {
   if (!pathname) return false;
-  for (const prefix of BLOCKED_PATH_PREFIXES) {
+  for (const prefix of prefixes) {
     if (pathname === prefix || pathname.startsWith(`${prefix}/`)) return true;
   }
   return false;
+}
+
+function isBlockedPath(pathname) {
+  return matchesPrefix(pathname, BLOCKED_PATH_PREFIXES);
 }
 
 export function blockRedeemForInternalRoutes(req, res, next) {
@@ -46,6 +64,18 @@ export function blockRedeemForInternalRoutes(req, res, next) {
     return res.status(403).json({
       success: false,
       message: 'Internal admin/auth/agent/driver APIs are only available on mktr.sg.',
+    });
+  }
+
+  if (isOpsHost(publicHost) && !matchesPrefix(pathname, OPS_ALLOWED_PREFIXES)) {
+    logger.warn('Blocked internal API call from ops.redeem.sg', {
+      path: pathname,
+      publicHost,
+      origin: req.get('origin') || null,
+    });
+    return res.status(403).json({
+      success: false,
+      message: 'This API is not available on ops.redeem.sg.',
     });
   }
 

--- a/backend/src/middleware/internalRouteHostGuard.js
+++ b/backend/src/middleware/internalRouteHostGuard.js
@@ -52,9 +52,29 @@ function isBlockedPath(pathname) {
 export function blockRedeemForInternalRoutes(req, res, next) {
   // Only check API requests (this middleware mounts on /api in server_internal).
   const pathname = req.originalUrl ? req.originalUrl.split('?')[0] : req.path;
+  const publicHost = publicHostFromRequest(req);
+
+  // ops.redeem.sg is a STRICT-allowlist internal surface: only staff auth, the
+  // redeem-ops namespace, and notifications exist there — EVERY other /api path
+  // 403s at the host layer, including public capture endpoints and any future
+  // namespace not on the blocklist (Codex Phase-1 review, finding 1).
+  if (isOpsHost(publicHost)) {
+    if (!matchesPrefix(pathname, OPS_ALLOWED_PREFIXES)) {
+      logger.warn('Blocked API call from ops.redeem.sg (outside allowlist)', {
+        path: pathname,
+        publicHost,
+        origin: req.get('origin') || null,
+      });
+      return res.status(403).json({
+        success: false,
+        message: 'This API is not available on ops.redeem.sg.',
+      });
+    }
+    return next();
+  }
+
   if (!isBlockedPath(pathname)) return next();
 
-  const publicHost = publicHostFromRequest(req);
   if (isRedeemHost(publicHost)) {
     logger.warn('Blocked internal API call from redeem.sg', {
       path: pathname,
@@ -64,18 +84,6 @@ export function blockRedeemForInternalRoutes(req, res, next) {
     return res.status(403).json({
       success: false,
       message: 'Internal admin/auth/agent/driver APIs are only available on mktr.sg.',
-    });
-  }
-
-  if (isOpsHost(publicHost) && !matchesPrefix(pathname, OPS_ALLOWED_PREFIXES)) {
-    logger.warn('Blocked internal API call from ops.redeem.sg', {
-      path: pathname,
-      publicHost,
-      origin: req.get('origin') || null,
-    });
-    return res.status(403).json({
-      success: false,
-      message: 'This API is not available on ops.redeem.sg.',
     });
   }
 

--- a/backend/src/middleware/redeemOpsAuth.js
+++ b/backend/src/middleware/redeemOpsAuth.js
@@ -1,0 +1,37 @@
+import { authenticateToken } from './auth.js';
+import { hasCapability, isRedeemOpsUser } from '../services/redeemOps/permissions.js';
+
+/**
+ * Capability gate for the Redeem Ops namespace (docs/redeem-ops/PERMISSION_MATRIX.md §3).
+ *
+ *   router.get('/team', requireRedeemOps('analytics.view_team'), handler)
+ *
+ * Semantics:
+ *   - role='admin'            → pass (implicit super_admin)
+ *   - role='redeem_ops' or a granted redeemOpsRole → pass iff EVERY named capability
+ *     is in the user's sub-role capability set (permissions.js)
+ *   - anyone else             → 403
+ *
+ * Zero capabilities (`requireRedeemOps()`) = "any authenticated Redeem Ops principal"
+ * (used by /meta/constants). Row-level "own" scoping is enforced in services, not here.
+ * Existing MKTR gates (requireRole/requireAdmin) are untouched — this middleware can
+ * only ever be MORE restrictive than authenticateToken, never looser.
+ */
+export const requireRedeemOps = (...capabilities) => [
+  authenticateToken,
+  (req, res, next) => {
+    const user = req.user;
+    if (!user) {
+      return res.status(401).json({ success: false, message: 'Authentication required' });
+    }
+    if (user.role === 'admin') return next();
+    if (!isRedeemOpsUser(user)) {
+      return res.status(403).json({ success: false, message: 'Redeem Ops access required' });
+    }
+    const denied = capabilities.find((c) => !hasCapability(user, c));
+    if (denied) {
+      return res.status(403).json({ success: false, message: 'Insufficient permissions' });
+    }
+    return next();
+  },
+];

--- a/backend/src/models/RedeemOpsAuditEvent.js
+++ b/backend/src/models/RedeemOpsAuditEvent.js
@@ -1,0 +1,70 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Append-only audit trail for the Redeem Ops module (docs/redeem-ops/ERD.md §3.19).
+ * Rows are written via services/redeemOps/auditService.js — there is deliberately no
+ * update/delete code path; corrections happen on the subject row with before/after
+ * captured here.
+ */
+const RedeemOpsAuditEvent = sequelize.define('RedeemOpsAuditEvent', {
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    primaryKey: true
+  },
+  actorUserId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    references: {
+      model: 'users',
+      key: 'id'
+    }
+  },
+  actorType: {
+    type: DataTypes.STRING(16),
+    allowNull: false,
+    defaultValue: 'staff',
+    comment: 'staff | agent | partner_user | consumer | system'
+  },
+  action: {
+    type: DataTypes.STRING(64),
+    allowNull: false,
+    comment: 'Dot-namespaced action, e.g. access.role_granted, partner.claimed'
+  },
+  entityType: {
+    type: DataTypes.STRING(32),
+    allowNull: false
+  },
+  entityId: {
+    type: DataTypes.UUID,
+    allowNull: true
+  },
+  before: {
+    type: DataTypes.JSONB,
+    allowNull: true
+  },
+  after: {
+    type: DataTypes.JSONB,
+    allowNull: true
+  },
+  reason: {
+    type: DataTypes.STRING(255),
+    allowNull: true
+  },
+  requestId: {
+    type: DataTypes.STRING(64),
+    allowNull: true
+  }
+}, {
+  tableName: 'redeem_ops_audit_events',
+  timestamps: true,
+  updatedAt: false, // append-only — rows are never updated
+  indexes: [
+    { fields: ['entityType', 'entityId', 'createdAt'], name: 'idx_roae_entity' },
+    { fields: ['actorUserId', 'createdAt'], name: 'idx_roae_actor' },
+    { fields: ['action', 'createdAt'], name: 'idx_roae_action' }
+  ]
+});
+
+export default RedeemOpsAuditEvent;

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -44,9 +44,20 @@ const User = sequelize.define('User', {
     }
   },
   role: {
-    type: DataTypes.ENUM('admin', 'agent', 'fleet_owner', 'driver_partner', 'customer'),
+    // 'redeem_ops' (migration 045) = internal Redeem Ops staff. Deliberately a
+    // separate value so these users are invisible to every requireRole gate,
+    // to agent-sync sweeps (scoped to role='agent'), and to lead routing.
+    type: DataTypes.ENUM('admin', 'agent', 'fleet_owner', 'driver_partner', 'customer', 'redeem_ops'),
     allowNull: false,
     defaultValue: 'customer'
+  },
+  // Redeem Ops sub-role (docs/redeem-ops/PERMISSION_MATRIX.md): super_admin |
+  // ops_admin | bdm | outreach_exec | campaign_ops | redemption_ops | analyst.
+  // NULL = no Redeem Ops access; role='admin' is an implicit super_admin in
+  // middleware/redeemOpsAuth.js regardless of this column.
+  redeemOpsRole: {
+    type: DataTypes.STRING(32),
+    allowNull: true
   },
   phone: {
     type: DataTypes.STRING,

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -163,6 +163,11 @@ function defineAssociations() {
   AgentGroup.hasMany(AgentGroupMember, { foreignKey: 'agentGroupId', as: 'members', onDelete: 'CASCADE' });
   AgentGroupMember.belongsTo(AgentGroup, { foreignKey: 'agentGroupId', as: 'group' });
   AgentGroupMember.belongsTo(User, { foreignKey: 'userId', as: 'user', onDelete: 'SET NULL' });
+
+  // Redeem Ops associations (Phase 1 — docs/redeem-ops/ERD.md §3.19). Audit rows
+  // are append-only and must survive actor deletion: SET NULL, never cascade.
+  const { RedeemOpsAuditEvent } = models;
+  RedeemOpsAuditEvent.belongsTo(User, { foreignKey: 'actorUserId', as: 'actor', onDelete: 'SET NULL' });
 }
 
 defineAssociations();
@@ -196,7 +201,7 @@ export const {
   Vehicle, WebhookSubscriber, WebhookDelivery, AgentGroup,
   AgentGroupMember, DeviceCampaignAssignment, VehicleCampaignAssignment,
   CampaignMediaItem, CampaignAgentAssignment, ExternalAgent, ExternalCampaignAgent,
-  WaitlistSignup
+  WaitlistSignup, RedeemOpsAuditEvent
 } = models;
 
 export { sequelize };

--- a/backend/src/routes/redeemOpsAdmin.js
+++ b/backend/src/routes/redeemOpsAdmin.js
@@ -1,0 +1,32 @@
+import express from 'express';
+import { requireRedeemOps } from '../middleware/redeemOpsAuth.js';
+import * as ctrl from '../controllers/redeemOps/adminController.js';
+
+/**
+ * Redeem Ops Phase 1 — team access, audit trail, domain constants
+ * (docs/redeem-ops/ROUTE_MAP.md §1). DARK by default: the route auto-loader only
+ * mounts this when REDEEM_OPS_ENABLED="true" (house pattern: BILLING_ENABLED on
+ * externalBilling.js). The namespace is additionally host-guarded — blocked from
+ * consumer redeem.sg, allow-listed for ops.redeem.sg
+ * (middleware/internalRouteHostGuard.js).
+ */
+export const meta = {
+  path: '/api/redeem-ops',
+  flag: 'REDEEM_OPS_ENABLED',
+  flagDefault: 'false',
+};
+
+const router = express.Router();
+
+// Team & access
+router.get('/team', requireRedeemOps('analytics.view_team'), ctrl.listTeam);
+router.post('/team/invite', requireRedeemOps('team.manage_access'), ctrl.inviteTeamMember);
+router.patch('/team/:userId/role', requireRedeemOps('team.manage_access'), ctrl.setTeamRole);
+
+// Audit trail
+router.get('/audit', requireRedeemOps('audit.view'), ctrl.listAudit);
+
+// Domain constants (any authenticated Redeem Ops principal)
+router.get('/meta/constants', requireRedeemOps(), ctrl.getConstants);
+
+export default router;

--- a/backend/src/server_internal.js
+++ b/backend/src/server_internal.js
@@ -73,6 +73,9 @@ export const init = async (app) => {
     'https://www.mktr.sg',
     'https://redeem.sg',
     'https://www.redeem.sg',
+    // Internal Redeem Ops surface (defence-in-depth: it proxies /api same-origin,
+    // so CORS rarely applies — docs/redeem-ops/RECOMMENDED_ARCHITECTURE.md §5).
+    'https://ops.redeem.sg',
   ];
   const envOrigins = process.env.CORS_ORIGIN ? process.env.CORS_ORIGIN.split(',').map((origin) => origin.trim()) : [];
 

--- a/backend/src/services/invitationService.js
+++ b/backend/src/services/invitationService.js
@@ -26,7 +26,9 @@ export async function sendRoleInvitation({ email, fullName, role, inviterEmail, 
   }
 
   // Check for existing user
-  const existing = await User.findOne({ where: { email }, transaction });
+  const existing = await User.findOne(
+    transaction ? { where: { email }, transaction } : { where: { email } }
+  );
   if (existing) {
     throw new AppError('A user with this email already exists. Permanently delete the existing user first to send a new invitation.', 400);
   }
@@ -40,10 +42,11 @@ export async function sendRoleInvitation({ email, fullName, role, inviterEmail, 
   const invitationToken = uuidv4();
   const invitationExpires = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
 
-  // Create user record. Optional caller transaction (additive — existing callers
-  // unchanged) lets access grants commit atomically with their audit row
-  // (redeem-ops invite: user + access.invited audit are all-or-nothing).
-  const user = await User.create({
+  // Create user record. Optional caller transaction (additive — the call shape
+  // for existing callers stays byte-identical) lets access grants commit
+  // atomically with their audit row (redeem-ops invite: user + access.invited
+  // audit are all-or-nothing).
+  const userPayload = {
     email,
     firstName,
     lastName,
@@ -53,7 +56,10 @@ export async function sendRoleInvitation({ email, fullName, role, inviterEmail, 
     invitationToken,
     invitationExpires,
     ...extraFields
-  }, { transaction });
+  };
+  const user = transaction
+    ? await User.create(userPayload, { transaction })
+    : await User.create(userPayload);
 
   // Build invite link
   const frontendBase = process.env.FRONTEND_BASE_URL || 'http://localhost:5173';

--- a/backend/src/services/invitationService.js
+++ b/backend/src/services/invitationService.js
@@ -60,7 +60,13 @@ export async function sendRoleInvitation({ email, fullName, role, inviterEmail, 
   // Get email content from caller-provided template function and send
   const companyName = process.env.COMPANY_NAME || 'MKTR';
   const companyUrl = process.env.COMPANY_URL || process.env.FRONTEND_BASE_URL || 'http://localhost:5173';
-  const roleLabel = role === 'agent' ? 'Agent' : role === 'fleet_owner' ? 'Fleet Owner' : 'Driver Partner';
+  const ROLE_LABELS = {
+    agent: 'Agent',
+    fleet_owner: 'Fleet Owner',
+    driver_partner: 'Driver Partner',
+    redeem_ops: 'Redeem Ops',
+  };
+  const roleLabel = ROLE_LABELS[role] || 'User';
 
   const { subject, html, text } = getEmailContent({
     firstName,

--- a/backend/src/services/invitationService.js
+++ b/backend/src/services/invitationService.js
@@ -15,7 +15,7 @@ import { logger } from '../utils/logger.js';
  * @param {Function} params.getEmailContent - function({ firstName, inviteLink, companyName, companyUrl, expiryDays, roleLabel }) => { subject, html, text }
  * @returns {Promise<{ user: Object, inviteLink: string }>}
  */
-export async function sendRoleInvitation({ email, fullName, role, inviterEmail, extraFields = {}, getEmailContent }) {
+export async function sendRoleInvitation({ email, fullName, role, inviterEmail, extraFields = {}, getEmailContent, transaction = null }) {
   if (!email || !fullName) {
     throw new AppError('email and full_name are required', 400);
   }
@@ -26,7 +26,7 @@ export async function sendRoleInvitation({ email, fullName, role, inviterEmail, 
   }
 
   // Check for existing user
-  const existing = await User.findOne({ where: { email } });
+  const existing = await User.findOne({ where: { email }, transaction });
   if (existing) {
     throw new AppError('A user with this email already exists. Permanently delete the existing user first to send a new invitation.', 400);
   }
@@ -40,7 +40,9 @@ export async function sendRoleInvitation({ email, fullName, role, inviterEmail, 
   const invitationToken = uuidv4();
   const invitationExpires = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
 
-  // Create user record
+  // Create user record. Optional caller transaction (additive — existing callers
+  // unchanged) lets access grants commit atomically with their audit row
+  // (redeem-ops invite: user + access.invited audit are all-or-nothing).
   const user = await User.create({
     email,
     firstName,
@@ -51,7 +53,7 @@ export async function sendRoleInvitation({ email, fullName, role, inviterEmail, 
     invitationToken,
     invitationExpires,
     ...extraFields
-  });
+  }, { transaction });
 
   // Build invite link
   const frontendBase = process.env.FRONTEND_BASE_URL || 'http://localhost:5173';

--- a/backend/src/services/redeemOps/auditService.js
+++ b/backend/src/services/redeemOps/auditService.js
@@ -1,0 +1,74 @@
+import { RedeemOpsAuditEvent } from '../../models/index.js';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Append-only audit writer for the Redeem Ops module (docs/redeem-ops/PERMISSION_MATRIX.md §4).
+ * DI factory (house pattern) so services/tests can inject fakes.
+ */
+export function makeRedeemOpsAuditService(overrides = {}) {
+  const d = { RedeemOpsAuditEvent, logger, ...overrides };
+
+  /**
+   * Record one audit event.
+   *
+   * Pass `transaction` when the audit row must be atomic with the mutation it
+   * describes (role grants, merges, overrides) — a failure then rolls back the
+   * whole mutation. Without a transaction the write is best-effort: it logs and
+   * returns null rather than failing the caller.
+   *
+   * @param {object} evt
+   * @param {object|null} [evt.actorUser]  req.user (id read off it)
+   * @param {string} [evt.actorType]       staff|agent|partner_user|consumer|system
+   * @param {string} evt.action            dot-namespaced, e.g. access.role_granted
+   * @param {string} evt.entityType
+   * @param {string|null} [evt.entityId]
+   * @param {object|null} [evt.before]
+   * @param {object|null} [evt.after]
+   * @param {string|null} [evt.reason]
+   * @param {string|null} [evt.requestId]
+   * @param {import('sequelize').Transaction|null} [evt.transaction]
+   */
+  async function recordAuditEvent({
+    actorUser = null,
+    actorType = 'staff',
+    action,
+    entityType,
+    entityId = null,
+    before = null,
+    after = null,
+    reason = null,
+    requestId = null,
+    transaction = null,
+  }) {
+    try {
+      return await d.RedeemOpsAuditEvent.create(
+        {
+          actorUserId: actorUser?.id || null,
+          actorType,
+          action,
+          entityType,
+          entityId,
+          before,
+          after,
+          reason,
+          requestId,
+        },
+        { transaction }
+      );
+    } catch (err) {
+      if (transaction) throw err; // atomic with a mutation — surface so it rolls back
+      d.logger.error('redeem_ops.audit.write_failed', {
+        action,
+        entityType,
+        entityId,
+        error: err?.message || String(err),
+      });
+      return null;
+    }
+  }
+
+  return { recordAuditEvent };
+}
+
+const _default = makeRedeemOpsAuditService();
+export const recordAuditEvent = _default.recordAuditEvent;

--- a/backend/src/services/redeemOps/constants.js
+++ b/backend/src/services/redeemOps/constants.js
@@ -1,0 +1,82 @@
+/**
+ * Redeem Ops domain constants (docs/redeem-ops/ERD.md §5–6). STRING columns +
+ * app-level constant lists are the house style for evolving states (not DB enums).
+ * Served to the SPA via GET /api/redeem-ops/meta/constants so UI and API can't drift.
+ */
+import { REDEEM_OPS_SUB_ROLES, CAPABILITIES, ROLE_CAPABILITIES } from './permissions.js';
+
+export const PIPELINE_STAGES = [
+  'UNCLAIMED',
+  'CLAIMED',
+  'RESEARCHING',
+  'CONTACTED',
+  'REPLIED',
+  'MEETING_BOOKED',
+  'MEETING_COMPLETED',
+  'PROPOSAL_SENT',
+  'NEGOTIATING',
+  'PARTNERED',
+  'FOLLOW_UP_LATER',
+  'NO_RESPONSE',
+  'NOT_INTERESTED',
+  'DISQUALIFIED',
+];
+
+export const PARTNER_AVAILABILITY = ['available', 'owned', 'follow_up_later', 'restricted', 'disqualified'];
+
+export const ACTIVITY_TYPES = [
+  'call_attempt',
+  'call_connected',
+  'whatsapp_sent',
+  'whatsapp_reply',
+  'email_sent',
+  'email_reply',
+  'instagram_dm',
+  'facebook_message',
+  'meeting_booked',
+  'meeting_completed',
+  'proposal_sent',
+  'follow_up',
+  'internal_note',
+  'other',
+];
+
+export const REWARD_TYPES = [
+  'free_service',
+  'free_product',
+  'free_trial',
+  'voucher',
+  'credit',
+  'discount',
+  'experience',
+  'other',
+];
+
+export const TASK_STATUSES = ['open', 'in_progress', 'completed', 'cancelled'];
+export const TASK_PRIORITIES = ['low', 'medium', 'high'];
+
+export const SUB_ROLE_LABELS = {
+  super_admin: 'Super Admin',
+  ops_admin: 'Ops Admin',
+  bdm: 'Business Development Manager',
+  outreach_exec: 'Outreach Executive',
+  campaign_ops: 'Campaign Ops',
+  redemption_ops: 'Redemption Ops',
+  analyst: 'Analyst',
+};
+
+/** Payload for GET /api/redeem-ops/meta/constants. */
+export function publicConstants() {
+  return {
+    pipelineStages: PIPELINE_STAGES,
+    partnerAvailability: PARTNER_AVAILABILITY,
+    activityTypes: ACTIVITY_TYPES,
+    rewardTypes: REWARD_TYPES,
+    taskStatuses: TASK_STATUSES,
+    taskPriorities: TASK_PRIORITIES,
+    subRoles: REDEEM_OPS_SUB_ROLES,
+    subRoleLabels: SUB_ROLE_LABELS,
+    capabilities: CAPABILITIES,
+    roleCapabilities: ROLE_CAPABILITIES,
+  };
+}

--- a/backend/src/services/redeemOps/permissions.js
+++ b/backend/src/services/redeemOps/permissions.js
@@ -1,0 +1,164 @@
+/**
+ * Redeem Ops capability model — the SINGLE SOURCE OF TRUTH for authorization.
+ * Mirrors docs/redeem-ops/PERMISSION_MATRIX.md §2 exactly.
+ *
+ * The frontend keeps a copy in src/lib/redeemOpsPermissions.js for nav/UI gating only;
+ * a vitest drift test (src/lib/__tests__/redeemOpsPermissionsDrift.test.js) imports BOTH
+ * files and fails the build if they diverge. Keep this module dependency-free so both
+ * test runners (jest + vitest) can import it directly.
+ *
+ * "Own"-scoped grants in the matrix (e.g. outreach_exec editing only partners they own)
+ * are row-level checks enforced in services — a capability here answers "may this
+ * sub-role ever perform the action"; the service answers "on this row?".
+ */
+
+export const REDEEM_OPS_SUB_ROLES = [
+  'super_admin',
+  'ops_admin',
+  'bdm',
+  'outreach_exec',
+  'campaign_ops',
+  'redemption_ops',
+  'analyst',
+];
+
+export const CAPABILITIES = [
+  'partners.view',
+  'partners.create',
+  'partners.edit',
+  'partners.claim',
+  'partners.release',
+  'partners.reassign',
+  'partners.restrict_disqualify',
+  'partners.merge',
+  'partners.import',
+  'contacts.manage',
+  'locations.manage',
+  'activities.log',
+  'activities.edit',
+  'pipeline.move',
+  'pipeline.view_team',
+  'tasks.manage',
+  'pools.manage',
+  'pools.claim_next',
+  'onboarding.manage',
+  'rewards.view',
+  'rewards.manage',
+  'inventory.adjust',
+  'activations.view',
+  'activations.manage',
+  'activations.link_campaign',
+  'activations.allocate_inventory',
+  'campaigns.read_reference',
+  'entitlements.view',
+  'entitlements.issue_manual',
+  'redemptions.verify',
+  'redemptions.override',
+  'analytics.view_own',
+  'analytics.view_team',
+  'exports.run',
+  'audit.view',
+  'team.manage_access',
+];
+
+const ALL = [...CAPABILITIES];
+
+export const ROLE_CAPABILITIES = {
+  super_admin: ALL,
+  ops_admin: ALL.filter((c) => c !== 'team.manage_access'),
+  bdm: [
+    'partners.view',
+    'partners.create',
+    'partners.edit',
+    'partners.claim',
+    'partners.release',
+    'partners.reassign',
+    'partners.restrict_disqualify',
+    'partners.import',
+    'contacts.manage',
+    'locations.manage',
+    'activities.log',
+    'activities.edit',
+    'pipeline.move',
+    'pipeline.view_team',
+    'tasks.manage',
+    'pools.manage',
+    'pools.claim_next',
+    'onboarding.manage',
+    'rewards.view',
+    'activations.view',
+    'campaigns.read_reference',
+    'analytics.view_own',
+    'analytics.view_team',
+    'exports.run',
+  ],
+  outreach_exec: [
+    'partners.view',
+    'partners.create',
+    'partners.edit',
+    'partners.claim',
+    'partners.release',
+    'contacts.manage',
+    'locations.manage',
+    'activities.log',
+    'activities.edit',
+    'pipeline.move',
+    'tasks.manage',
+    'pools.claim_next',
+    'onboarding.manage',
+    'rewards.view',
+    'analytics.view_own',
+  ],
+  campaign_ops: [
+    'partners.view',
+    'pipeline.view_team',
+    'rewards.view',
+    'activations.view',
+    'activations.manage',
+    'activations.link_campaign',
+    'activations.allocate_inventory',
+    'campaigns.read_reference',
+    'entitlements.view',
+    'analytics.view_own',
+    'analytics.view_team',
+  ],
+  redemption_ops: [
+    'partners.view',
+    'activities.log',
+    'rewards.view',
+    'activations.view',
+    'entitlements.view',
+    'entitlements.issue_manual',
+    'redemptions.verify',
+    'redemptions.override',
+    'analytics.view_own',
+    'analytics.view_team',
+  ],
+  analyst: [
+    'partners.view',
+    'pipeline.view_team',
+    'rewards.view',
+    'activations.view',
+    'campaigns.read_reference',
+    'entitlements.view',
+    'analytics.view_own',
+    'analytics.view_team',
+    'exports.run',
+  ],
+};
+
+/**
+ * Does this user hold the capability? `role='admin'` is an implicit super_admin
+ * (PERMISSION_MATRIX.md §1) — always true.
+ */
+export function hasCapability(user, capability) {
+  if (!user) return false;
+  if (user.role === 'admin') return true;
+  const caps = ROLE_CAPABILITIES[user.redeemOpsRole];
+  return Array.isArray(caps) && caps.includes(capability);
+}
+
+/** Is this user any kind of Redeem Ops principal (admin implicit)? */
+export function isRedeemOpsUser(user) {
+  return !!user && (user.role === 'admin' || user.role === 'redeem_ops' || !!user.redeemOpsRole);
+}

--- a/backend/src/services/userService.js
+++ b/backend/src/services/userService.js
@@ -143,9 +143,13 @@ export async function inviteUser(email, fullName, role, owedLeadsCount, inviterE
     throw new AppError('email, full_name and role are required', 400);
   }
 
-  const allowedRoles = ['agent', 'fleet_owner', 'driver_partner'];
+  // 'redeem_ops' arrives WITHOUT a sub-role via this generic path — the user is
+  // created capability-less until a super admin grants one (the dedicated
+  // POST /api/redeem-ops/team/invite sets the sub-role at invite time and is the
+  // preferred flow — docs/redeem-ops/PERMISSION_MATRIX.md).
+  const allowedRoles = ['agent', 'fleet_owner', 'driver_partner', 'redeem_ops'];
   if (!allowedRoles.includes(role)) {
-    throw new AppError('Invalid role. Must be one of agent, fleet_owner, driver_partner', 400);
+    throw new AppError('Invalid role. Must be one of agent, fleet_owner, driver_partner, redeem_ops', 400);
   }
 
   const extraFields = {};

--- a/backend/src/utils/publicHost.js
+++ b/backend/src/utils/publicHost.js
@@ -14,6 +14,11 @@ const ALLOWED_PUBLIC_HOSTS = new Set([
   'www.mktr.sg',
   'redeem.sg',
   'www.redeem.sg',
+  // Internal Redeem Ops staff surface (docs/redeem-ops/RECOMMENDED_ARCHITECTURE.md §5).
+  // NOT a redeem-consumer host: isRedeemHost() deliberately excludes it, and the host
+  // guard gives it a narrow internal allowlist instead of the consumer block. Auth
+  // cookies stay host-only here (cookieDomainForPublicHost returns undefined).
+  'ops.redeem.sg',
 ]);
 
 /**
@@ -70,6 +75,12 @@ export function isRedeemHost(host) {
   if (!host) return false;
   const h = String(host).toLowerCase();
   return h === 'redeem.sg' || h === 'www.redeem.sg';
+}
+
+/** The internal Redeem Ops staff surface — never a consumer redeem host. */
+export function isOpsHost(host) {
+  if (!host) return false;
+  return String(host).toLowerCase() === 'ops.redeem.sg';
 }
 
 export function isMktrHost(host) {

--- a/backend/test/redeemOpsAdminRoutes.test.js
+++ b/backend/test/redeemOpsAdminRoutes.test.js
@@ -1,0 +1,169 @@
+/**
+ * Redeem Ops Phase 1 route + authorization tests (DB-backed, house harness).
+ * Covers the Phase 1 gate in docs/redeem-ops/IMPLEMENTATION_PLAN.md:
+ *   - capability enforcement (admin bypass, sub-role grant/deny, non-ops 403)
+ *   - team invite + role grant with atomic audit rows
+ *   - redeem_ops users cannot reach existing admin surfaces
+ *   - redeem_ops users are invisible to role='agent' scopes (agent-sync guardrail)
+ */
+process.env.REDEEM_OPS_ENABLED = 'true'; // must be set before getApp() mounts routes
+
+import request from 'supertest';
+import { getApp, closeDb, createTestUser } from './helpers.js';
+import { User, RedeemOpsAuditEvent } from '../src/models/index.js';
+
+let app;
+let admin, bdm, exec, agent;
+
+beforeAll(async () => {
+  app = await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  bdm = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'bdm' });
+  exec = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
+  agent = await createTestUser({ role: 'agent' });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+const auth = (t) => ({ Authorization: `Bearer ${t}` });
+
+describe('flag + mounting', () => {
+  test('namespace is mounted when REDEEM_OPS_ENABLED=true', async () => {
+    const res = await request(app).get('/api/redeem-ops/meta/constants').set(auth(admin.token));
+    expect(res.status).toBe(200);
+    expect(res.body.data.subRoles).toContain('outreach_exec');
+    expect(res.body.data.pipelineStages).toContain('PARTNERED');
+  });
+});
+
+describe('capability enforcement', () => {
+  test('unauthenticated → 401', async () => {
+    const res = await request(app).get('/api/redeem-ops/team');
+    expect(res.status).toBe(401);
+  });
+
+  test('admin bypass: implicit super_admin can list team', async () => {
+    const res = await request(app).get('/api/redeem-ops/team').set(auth(admin.token));
+    expect(res.status).toBe(200);
+    const emails = res.body.data.team.map((u) => u.email);
+    expect(emails).toEqual(expect.arrayContaining([bdm.user.email, exec.user.email]));
+    expect(emails).not.toContain(agent.user.email);
+  });
+
+  test('bdm holds analytics.view_team → 200; outreach_exec does not → 403', async () => {
+    expect((await request(app).get('/api/redeem-ops/team').set(auth(bdm.token))).status).toBe(200);
+    expect((await request(app).get('/api/redeem-ops/team').set(auth(exec.token))).status).toBe(403);
+  });
+
+  test('a plain agent is not a Redeem Ops principal → 403', async () => {
+    const res = await request(app).get('/api/redeem-ops/meta/constants').set(auth(agent.token));
+    expect(res.status).toBe(403);
+  });
+
+  test('redeem_ops users cannot reach existing admin surfaces (requireAdmin untouched)', async () => {
+    const res = await request(app).get('/api/users').set(auth(bdm.token));
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('team invite', () => {
+  test('super admin invites an outreach exec → redeem_ops user with sub-role + audit row', async () => {
+    const email = `invitee-${Date.now()}@test.com`;
+    const res = await request(app)
+      .post('/api/redeem-ops/team/invite')
+      .set(auth(admin.token))
+      .send({ email, full_name: 'New Outreach', redeemOpsRole: 'outreach_exec' });
+    expect(res.status).toBe(201);
+    expect(res.body.data.inviteLink).toContain('/auth/accept-invite');
+
+    const created = await User.findOne({ where: { email } });
+    expect(created.role).toBe('redeem_ops');
+    expect(created.redeemOpsRole).toBe('outreach_exec');
+
+    const audit = await RedeemOpsAuditEvent.findOne({
+      where: { action: 'access.invited', entityId: created.id },
+    });
+    expect(audit).not.toBeNull();
+    expect(audit.actorUserId).toBe(admin.user.id);
+  });
+
+  test('invalid sub-role → 400; non-super-admin → 403', async () => {
+    const bad = await request(app)
+      .post('/api/redeem-ops/team/invite')
+      .set(auth(admin.token))
+      .send({ email: `x-${Date.now()}@test.com`, full_name: 'X', redeemOpsRole: 'warlord' });
+    expect(bad.status).toBe(400);
+
+    const forbidden = await request(app)
+      .post('/api/redeem-ops/team/invite')
+      .set(auth(bdm.token))
+      .send({ email: `y-${Date.now()}@test.com`, full_name: 'Y', redeemOpsRole: 'analyst' });
+    expect(forbidden.status).toBe(403);
+  });
+});
+
+describe('role grant / revoke', () => {
+  test('super admin changes a sub-role atomically with an audit row', async () => {
+    const res = await request(app)
+      .patch(`/api/redeem-ops/team/${exec.user.id}/role`)
+      .set(auth(admin.token))
+      .send({ redeemOpsRole: 'bdm' });
+    expect(res.status).toBe(200);
+
+    await exec.user.reload();
+    expect(exec.user.redeemOpsRole).toBe('bdm');
+
+    const audit = await RedeemOpsAuditEvent.findOne({
+      where: { action: 'access.role_granted', entityId: exec.user.id },
+      order: [['createdAt', 'DESC']],
+    });
+    expect(audit).not.toBeNull();
+    expect(audit.before).toEqual({ redeemOpsRole: 'outreach_exec' });
+    expect(audit.after).toEqual({ redeemOpsRole: 'bdm' });
+
+    // restore for other tests
+    await exec.user.update({ redeemOpsRole: 'outreach_exec' });
+  });
+
+  test('cannot grant a sub-role to an agent; non-super-admin cannot grant at all', async () => {
+    const toAgent = await request(app)
+      .patch(`/api/redeem-ops/team/${agent.user.id}/role`)
+      .set(auth(admin.token))
+      .send({ redeemOpsRole: 'analyst' });
+    expect(toAgent.status).toBe(400);
+
+    const byBdm = await request(app)
+      .patch(`/api/redeem-ops/team/${exec.user.id}/role`)
+      .set(auth(bdm.token))
+      .send({ redeemOpsRole: 'analyst' });
+    expect(byBdm.status).toBe(403);
+  });
+});
+
+describe('audit listing', () => {
+  test('audit is capability-gated and filterable', async () => {
+    expect((await request(app).get('/api/redeem-ops/audit').set(auth(exec.token))).status).toBe(403);
+
+    const res = await request(app)
+      .get('/api/redeem-ops/audit')
+      .query({ action: 'access.role_granted', limit: 10 })
+      .set(auth(admin.token));
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data.events)).toBe(true);
+    for (const evt of res.body.data.events) {
+      expect(evt.action).toBe('access.role_granted');
+    }
+  });
+});
+
+describe('agent-sync guardrail', () => {
+  test("redeem_ops users are invisible to role='agent' scopes (sync sweeps, routing pools)", async () => {
+    const agents = await User.findAll({ where: { role: 'agent' }, attributes: ['id'] });
+    const ids = agents.map((u) => u.id);
+    expect(ids).toContain(agent.user.id);
+    expect(ids).not.toContain(bdm.user.id);
+    expect(ids).not.toContain(exec.user.id);
+  });
+});

--- a/backend/test/redeemOpsFlagOff.test.js
+++ b/backend/test/redeemOpsFlagOff.test.js
@@ -1,0 +1,30 @@
+/**
+ * Dark-launch guarantee: with REDEEM_OPS_ENABLED unset, the entire
+ * /api/redeem-ops namespace does not exist (auto-loader skips the mount —
+ * routes/index.js flag gating). This is the "flag-off → production unchanged"
+ * assertion from docs/redeem-ops/IMPLEMENTATION_PLAN.md Phase 1.
+ */
+delete process.env.REDEEM_OPS_ENABLED; // must be unset before getApp() mounts routes
+
+import request from 'supertest';
+import { getApp, closeDb, createTestUser } from './helpers.js';
+
+let app;
+
+beforeAll(async () => {
+  app = await getApp();
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+describe('REDEEM_OPS_ENABLED unset', () => {
+  test('the namespace is unmounted — 404 even for an admin', async () => {
+    const { token } = await createTestUser({ role: 'admin' });
+    const res = await request(app)
+      .get('/api/redeem-ops/meta/constants')
+      .set({ Authorization: `Bearer ${token}` });
+    expect(res.status).toBe(404);
+  });
+});

--- a/backend/test/redeemOpsHostGuard.test.js
+++ b/backend/test/redeemOpsHostGuard.test.js
@@ -43,11 +43,15 @@ describe('internalRouteHostGuard — redeem-ops + ops-host policy', () => {
     expect(run('/api/notifications', 'ops.redeem.sg').nextCalled).toBe(true);
   });
 
-  test('ops.redeem.sg is blocked from the other internal prefixes at the host layer', () => {
+  test('ops.redeem.sg is STRICT-allowlist: every other /api path 403s, blocklisted or not', () => {
     expect(run('/api/admin/campaigns', 'ops.redeem.sg').statusCode).toBe(403);
     expect(run('/api/users', 'ops.redeem.sg').statusCode).toBe(403);
     expect(run('/api/agents', 'ops.redeem.sg').statusCode).toBe(403);
     expect(run('/api/webhooks/stats', 'ops.redeem.sg').statusCode).toBe(403);
+    // Not on the blocklist — still refused on the ops surface (strict allowlist)
+    expect(run('/api/campaigns', 'ops.redeem.sg').statusCode).toBe(403);
+    expect(run('/api/prospects', 'ops.redeem.sg').statusCode).toBe(403);
+    expect(run('/api/verify/send', 'ops.redeem.sg').statusCode).toBe(403);
   });
 
   test('mktr.sg passes everything at the host layer', () => {
@@ -60,8 +64,8 @@ describe('internalRouteHostGuard — redeem-ops + ops-host policy', () => {
     expect(run('/api/integrations/lyfe/lead-outcome', null).nextCalled).toBe(true);
   });
 
-  test('non-internal public paths are never touched', () => {
+  test('public capture paths stay open on the consumer host', () => {
     expect(run('/api/prospects', 'redeem.sg').nextCalled).toBe(true);
-    expect(run('/api/verify/send', 'ops.redeem.sg').nextCalled).toBe(true);
+    expect(run('/api/verify/send', 'redeem.sg').nextCalled).toBe(true);
   });
 });

--- a/backend/test/redeemOpsHostGuard.test.js
+++ b/backend/test/redeemOpsHostGuard.test.js
@@ -1,0 +1,67 @@
+/**
+ * Pure unit tests for the extended host guard — no DB required.
+ * Pins docs/redeem-ops/RECOMMENDED_ARCHITECTURE.md §5:
+ *   - consumer redeem.sg is blocked from /api/redeem-ops (and the existing internal list)
+ *   - ops.redeem.sg gets a NARROW allowlist (/api/auth, /api/redeem-ops, /api/notifications)
+ *     and is blocked from the rest of the internal prefixes
+ *   - mktr.sg and host-less (server-to-server) traffic pass through unchanged
+ */
+import { blockRedeemForInternalRoutes } from '../src/middleware/internalRouteHostGuard.js';
+
+function run(originalUrl, originHost) {
+  const req = {
+    originalUrl,
+    get: (h) => {
+      if (originHost && h.toLowerCase() === 'origin') return `https://${originHost}`;
+      return undefined;
+    },
+  };
+  let statusCode = null;
+  let nextCalled = false;
+  const res = {
+    status(code) { statusCode = code; return this; },
+    json() { return this; },
+  };
+  blockRedeemForInternalRoutes(req, res, () => { nextCalled = true; });
+  return { statusCode, nextCalled };
+}
+
+describe('internalRouteHostGuard — redeem-ops + ops-host policy', () => {
+  test('consumer redeem.sg is blocked from /api/redeem-ops/*', () => {
+    expect(run('/api/redeem-ops/team', 'redeem.sg')).toEqual({ statusCode: 403, nextCalled: false });
+    expect(run('/api/redeem-ops', 'www.redeem.sg')).toEqual({ statusCode: 403, nextCalled: false });
+  });
+
+  test('consumer redeem.sg keeps its existing blocks (auth/admin)', () => {
+    expect(run('/api/auth/login', 'redeem.sg').statusCode).toBe(403);
+    expect(run('/api/admin/campaigns', 'redeem.sg').statusCode).toBe(403);
+  });
+
+  test('ops.redeem.sg may reach auth, redeem-ops, and notifications', () => {
+    expect(run('/api/auth/login', 'ops.redeem.sg').nextCalled).toBe(true);
+    expect(run('/api/redeem-ops/team', 'ops.redeem.sg').nextCalled).toBe(true);
+    expect(run('/api/notifications', 'ops.redeem.sg').nextCalled).toBe(true);
+  });
+
+  test('ops.redeem.sg is blocked from the other internal prefixes at the host layer', () => {
+    expect(run('/api/admin/campaigns', 'ops.redeem.sg').statusCode).toBe(403);
+    expect(run('/api/users', 'ops.redeem.sg').statusCode).toBe(403);
+    expect(run('/api/agents', 'ops.redeem.sg').statusCode).toBe(403);
+    expect(run('/api/webhooks/stats', 'ops.redeem.sg').statusCode).toBe(403);
+  });
+
+  test('mktr.sg passes everything at the host layer', () => {
+    expect(run('/api/redeem-ops/team', 'mktr.sg').nextCalled).toBe(true);
+    expect(run('/api/admin/campaigns', 'mktr.sg').nextCalled).toBe(true);
+  });
+
+  test('host-less (server-to-server) requests pass through unchanged', () => {
+    expect(run('/api/redeem-ops/team', null).nextCalled).toBe(true);
+    expect(run('/api/integrations/lyfe/lead-outcome', null).nextCalled).toBe(true);
+  });
+
+  test('non-internal public paths are never touched', () => {
+    expect(run('/api/prospects', 'redeem.sg').nextCalled).toBe(true);
+    expect(run('/api/verify/send', 'ops.redeem.sg').nextCalled).toBe(true);
+  });
+});

--- a/backend/test/redeemOpsPermissions.test.js
+++ b/backend/test/redeemOpsPermissions.test.js
@@ -1,0 +1,78 @@
+/**
+ * Pure unit tests for the Redeem Ops capability map — no DB required.
+ * Pins docs/redeem-ops/PERMISSION_MATRIX.md §2 invariants.
+ */
+import {
+  CAPABILITIES,
+  ROLE_CAPABILITIES,
+  REDEEM_OPS_SUB_ROLES,
+  hasCapability,
+  isRedeemOpsUser,
+} from '../src/services/redeemOps/permissions.js';
+
+describe('redeemOps permissions map', () => {
+  test('every sub-role in the map is a declared sub-role and vice versa', () => {
+    expect(Object.keys(ROLE_CAPABILITIES).sort()).toEqual([...REDEEM_OPS_SUB_ROLES].sort());
+  });
+
+  test('every granted capability is a declared capability, with no duplicates', () => {
+    for (const [role, caps] of Object.entries(ROLE_CAPABILITIES)) {
+      const unknown = caps.filter((c) => !CAPABILITIES.includes(c));
+      expect({ role, unknown }).toEqual({ role, unknown: [] });
+      expect(new Set(caps).size).toBe(caps.length);
+    }
+  });
+
+  test('super_admin holds everything; ops_admin holds everything except team.manage_access', () => {
+    expect([...ROLE_CAPABILITIES.super_admin].sort()).toEqual([...CAPABILITIES].sort());
+    expect(ROLE_CAPABILITIES.ops_admin).not.toContain('team.manage_access');
+    expect([...ROLE_CAPABILITIES.ops_admin].sort()).toEqual(
+      CAPABILITIES.filter((c) => c !== 'team.manage_access').sort()
+    );
+  });
+
+  test('outreach_exec can claim/log but cannot reassign, merge, manage rewards, or view audit', () => {
+    const caps = ROLE_CAPABILITIES.outreach_exec;
+    expect(caps).toEqual(expect.arrayContaining(['partners.claim', 'partners.create', 'activities.log', 'pools.claim_next']));
+    for (const denied of ['partners.reassign', 'partners.merge', 'rewards.manage', 'inventory.adjust', 'audit.view', 'team.manage_access', 'analytics.view_team']) {
+      expect(caps).not.toContain(denied);
+    }
+  });
+
+  test('analyst is read/export only — no mutating capabilities', () => {
+    const mutating = CAPABILITIES.filter((c) =>
+      /\.(create|edit|claim|release|reassign|restrict_disqualify|merge|import|manage|log|move|adjust|link_campaign|allocate_inventory|issue_manual|verify|override|manage_access)$/.test(c)
+    );
+    for (const cap of ROLE_CAPABILITIES.analyst) {
+      expect(mutating).not.toContain(cap);
+    }
+  });
+
+  test('campaign_ops manages activations + campaign references but never campaign building or partner CRM writes', () => {
+    const caps = ROLE_CAPABILITIES.campaign_ops;
+    expect(caps).toEqual(
+      expect.arrayContaining(['activations.manage', 'activations.link_campaign', 'campaigns.read_reference'])
+    );
+    for (const denied of ['partners.create', 'partners.claim', 'rewards.manage', 'redemptions.override']) {
+      expect(caps).not.toContain(denied);
+    }
+  });
+
+  test('hasCapability: admin is implicit super_admin; sub-roles resolve; null-sub-role users hold nothing', () => {
+    expect(hasCapability({ role: 'admin' }, 'team.manage_access')).toBe(true);
+    expect(hasCapability({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' }, 'partners.claim')).toBe(true);
+    expect(hasCapability({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' }, 'partners.merge')).toBe(false);
+    expect(hasCapability({ role: 'redeem_ops', redeemOpsRole: null }, 'partners.view')).toBe(false);
+    expect(hasCapability(null, 'partners.view')).toBe(false);
+    expect(hasCapability({ role: 'agent' }, 'partners.view')).toBe(false);
+  });
+
+  test('isRedeemOpsUser: admin, redeem_ops role, or granted sub-role — nothing else', () => {
+    expect(isRedeemOpsUser({ role: 'admin' })).toBe(true);
+    expect(isRedeemOpsUser({ role: 'redeem_ops' })).toBe(true);
+    expect(isRedeemOpsUser({ role: 'admin', redeemOpsRole: 'analyst' })).toBe(true);
+    expect(isRedeemOpsUser({ role: 'agent' })).toBe(false);
+    expect(isRedeemOpsUser({ role: 'customer' })).toBe(false);
+    expect(isRedeemOpsUser(null)).toBe(false);
+  });
+});

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -1,0 +1,37 @@
+import { apiClient } from './client';
+
+/**
+ * Redeem Ops API (Phase 1 — docs/redeem-ops/ROUTE_MAP.md). Thin wrappers over the
+ * shared APIClient; every endpoint is flag-mounted server-side (REDEEM_OPS_ENABLED)
+ * and capability-gated (middleware/redeemOpsAuth.js).
+ */
+export const redeemOpsApi = {
+  async getTeam() {
+    const res = await apiClient.get('/redeem-ops/team');
+    return res.data?.team || [];
+  },
+
+  async inviteTeamMember({ email, fullName, redeemOpsRole }) {
+    const res = await apiClient.post('/redeem-ops/team/invite', {
+      email,
+      full_name: fullName,
+      redeemOpsRole,
+    });
+    return res.data;
+  },
+
+  async setTeamRole(userId, redeemOpsRole) {
+    const res = await apiClient.patch(`/redeem-ops/team/${userId}/role`, { redeemOpsRole });
+    return res.data;
+  },
+
+  async getAudit(params = {}) {
+    const res = await apiClient.get('/redeem-ops/audit', params);
+    return res.data;
+  },
+
+  async getConstants() {
+    const res = await apiClient.get('/redeem-ops/meta/constants');
+    return res.data;
+  },
+};

--- a/src/components/auth/RedeemOpsRoute.jsx
+++ b/src/components/auth/RedeemOpsRoute.jsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useAuthStore } from '@/stores/authStore';
+import Loader2 from 'lucide-react/icons/loader-2';
+import { getDefaultRouteForRole } from '@/lib/utils';
+import { IS_REDEEM_BUILD, MktrOnlyRedirect } from '@/components/auth/BrandRouteGuards';
+import { isRedeemOpsUser, hasCapability } from '@/lib/redeemOpsPermissions';
+
+/**
+ * Route guard for /redeem-ops/* (docs/redeem-ops/ROUTE_MAP.md §2). Client-side
+ * convenience only — the API enforces capabilities server-side regardless.
+ * Mirrors ProtectedRoute's shape: on the redeem consumer build the whole
+ * component is swapped for the mktr.sg redirect so no auth logic runs there.
+ */
+function RedeemOpsRouteImpl({ children, capability = null }) {
+  const { user, token } = useAuthStore();
+  const [isLoading, setIsLoading] = useState(true);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (token && user) {
+      const status = user.approvalStatus || user.status;
+      if (status === 'pending' || status === 'pending_approval') {
+        navigate('/PendingApproval');
+        return;
+      }
+      if (!isRedeemOpsUser(user)) {
+        navigate(getDefaultRouteForRole(user.role));
+        return;
+      }
+      if (capability && !hasCapability(user, capability)) {
+        navigate('/redeem-ops');
+        return;
+      }
+    } else {
+      navigate('/CustomerLogin', { state: { from: location } });
+      return;
+    }
+
+    setIsLoading(false);
+  }, [navigate, capability, location, token, user]);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="text-center">
+          <Loader2 className="w-8 h-8 animate-spin mx-auto mb-4 text-primary" />
+          <p className="text-muted-foreground">Checking authentication...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!token) {
+    return null;
+  }
+
+  return children;
+}
+
+export default function RedeemOpsRoute(props) {
+  if (IS_REDEEM_BUILD) return <MktrOnlyRedirect />;
+  return <RedeemOpsRouteImpl {...props} />;
+}

--- a/src/components/layout/DashboardLayout.jsx
+++ b/src/components/layout/DashboardLayout.jsx
@@ -95,7 +95,22 @@ const getNavigationItems = (user) => {
  { title: 'Payslip', url: '/DriverPayslip', icon: FileText },
  ];
 
- if (user.role === 'admin') return adminSections;
+ // Redeem Ops — flag-gated internal staff surface (docs/redeem-ops/ROUTE_MAP.md §2).
+ const REDEEM_OPS_UI = import.meta.env.VITE_REDEEM_OPS_ENABLED === 'true';
+ const redeemOpsSections = [
+ {
+ label: 'Redeem Ops',
+ items: [
+ { title: 'Overview', url: '/redeem-ops', icon: LayoutDashboard },
+ { title: 'Team', url: '/redeem-ops/team', icon: Users },
+ ],
+ },
+ ];
+
+ if (user.role === 'admin') {
+ return REDEEM_OPS_UI ? [...adminSections, ...redeemOpsSections] : adminSections;
+ }
+ if (user.role === 'redeem_ops') return REDEEM_OPS_UI ? redeemOpsSections : [];
 
  // Non-admin roles: wrap flat items in a single section with no label
  const wrapFlat = (items) => [{ label: null, items }];
@@ -111,6 +126,7 @@ const getUserDisplayRole = (user) => {
  if (user.role === 'agent') return 'Sales Agent';
  if (user.role === 'fleet_owner') return 'Fleet Owner';
  if (user.role === 'driver_partner') return 'Driver Partner';
+ if (user.role === 'redeem_ops') return 'Redeem Ops';
  return 'User';
 };
 
@@ -120,6 +136,7 @@ const getUserDisplayRole = (user) => {
 const getPortalRole = (role) => {
  if (role === 'admin') return 'Admin';
  if (role === 'agent') return 'Agent';
+ if (role === 'redeem_ops') return 'Redeem Ops';
  return 'Portal';
 };
 

--- a/src/lib/__tests__/redeemOpsPermissionsDrift.test.js
+++ b/src/lib/__tests__/redeemOpsPermissionsDrift.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+// The backend module is deliberately dependency-free so this cross-package import
+// works — see the header comment in backend/src/services/redeemOps/permissions.js.
+import * as backend from '../../../backend/src/services/redeemOps/permissions.js';
+import * as mirror from '../redeemOpsPermissions.js';
+
+describe('redeem-ops permissions drift guard', () => {
+  it('frontend mirror matches the backend source of truth exactly', () => {
+    expect(mirror.REDEEM_OPS_SUB_ROLES).toEqual(backend.REDEEM_OPS_SUB_ROLES);
+    expect(mirror.CAPABILITIES).toEqual(backend.CAPABILITIES);
+    expect(mirror.ROLE_CAPABILITIES).toEqual(backend.ROLE_CAPABILITIES);
+  });
+
+  it('helper semantics agree on representative users', () => {
+    const cases = [
+      [{ role: 'admin' }, 'team.manage_access'],
+      [{ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' }, 'partners.claim'],
+      [{ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' }, 'partners.merge'],
+      [{ role: 'redeem_ops', redeemOpsRole: null }, 'partners.view'],
+      [{ role: 'agent' }, 'partners.view'],
+      [null, 'partners.view'],
+    ];
+    for (const [user, cap] of cases) {
+      expect(mirror.hasCapability(user, cap)).toBe(backend.hasCapability(user, cap));
+      expect(mirror.isRedeemOpsUser(user)).toBe(backend.isRedeemOpsUser(user));
+    }
+  });
+});

--- a/src/lib/redeemOpsPermissions.js
+++ b/src/lib/redeemOpsPermissions.js
@@ -1,0 +1,155 @@
+/**
+ * Redeem Ops capability model — FRONTEND MIRROR for nav/UI gating only.
+ *
+ * The backend copy (backend/src/services/redeemOps/permissions.js) is the source
+ * of truth and the only enforcement point; this mirror exists so the SPA can hide
+ * controls the API would reject. A vitest drift test
+ * (src/lib/__tests__/redeemOpsPermissionsDrift.test.js) imports BOTH files and
+ * fails if they diverge — edit them together.
+ */
+
+export const REDEEM_OPS_SUB_ROLES = [
+  'super_admin',
+  'ops_admin',
+  'bdm',
+  'outreach_exec',
+  'campaign_ops',
+  'redemption_ops',
+  'analyst',
+];
+
+export const CAPABILITIES = [
+  'partners.view',
+  'partners.create',
+  'partners.edit',
+  'partners.claim',
+  'partners.release',
+  'partners.reassign',
+  'partners.restrict_disqualify',
+  'partners.merge',
+  'partners.import',
+  'contacts.manage',
+  'locations.manage',
+  'activities.log',
+  'activities.edit',
+  'pipeline.move',
+  'pipeline.view_team',
+  'tasks.manage',
+  'pools.manage',
+  'pools.claim_next',
+  'onboarding.manage',
+  'rewards.view',
+  'rewards.manage',
+  'inventory.adjust',
+  'activations.view',
+  'activations.manage',
+  'activations.link_campaign',
+  'activations.allocate_inventory',
+  'campaigns.read_reference',
+  'entitlements.view',
+  'entitlements.issue_manual',
+  'redemptions.verify',
+  'redemptions.override',
+  'analytics.view_own',
+  'analytics.view_team',
+  'exports.run',
+  'audit.view',
+  'team.manage_access',
+];
+
+const ALL = [...CAPABILITIES];
+
+export const ROLE_CAPABILITIES = {
+  super_admin: ALL,
+  ops_admin: ALL.filter((c) => c !== 'team.manage_access'),
+  bdm: [
+    'partners.view',
+    'partners.create',
+    'partners.edit',
+    'partners.claim',
+    'partners.release',
+    'partners.reassign',
+    'partners.restrict_disqualify',
+    'partners.import',
+    'contacts.manage',
+    'locations.manage',
+    'activities.log',
+    'activities.edit',
+    'pipeline.move',
+    'pipeline.view_team',
+    'tasks.manage',
+    'pools.manage',
+    'pools.claim_next',
+    'onboarding.manage',
+    'rewards.view',
+    'activations.view',
+    'campaigns.read_reference',
+    'analytics.view_own',
+    'analytics.view_team',
+    'exports.run',
+  ],
+  outreach_exec: [
+    'partners.view',
+    'partners.create',
+    'partners.edit',
+    'partners.claim',
+    'partners.release',
+    'contacts.manage',
+    'locations.manage',
+    'activities.log',
+    'activities.edit',
+    'pipeline.move',
+    'tasks.manage',
+    'pools.claim_next',
+    'onboarding.manage',
+    'rewards.view',
+    'analytics.view_own',
+  ],
+  campaign_ops: [
+    'partners.view',
+    'pipeline.view_team',
+    'rewards.view',
+    'activations.view',
+    'activations.manage',
+    'activations.link_campaign',
+    'activations.allocate_inventory',
+    'campaigns.read_reference',
+    'entitlements.view',
+    'analytics.view_own',
+    'analytics.view_team',
+  ],
+  redemption_ops: [
+    'partners.view',
+    'activities.log',
+    'rewards.view',
+    'activations.view',
+    'entitlements.view',
+    'entitlements.issue_manual',
+    'redemptions.verify',
+    'redemptions.override',
+    'analytics.view_own',
+    'analytics.view_team',
+  ],
+  analyst: [
+    'partners.view',
+    'pipeline.view_team',
+    'rewards.view',
+    'activations.view',
+    'campaigns.read_reference',
+    'entitlements.view',
+    'analytics.view_own',
+    'analytics.view_team',
+    'exports.run',
+  ],
+};
+
+export function hasCapability(user, capability) {
+  if (!user) return false;
+  if (user.role === 'admin') return true;
+  const caps = ROLE_CAPABILITIES[user.redeemOpsRole];
+  return Array.isArray(caps) && caps.includes(capability);
+}
+
+export function isRedeemOpsUser(user) {
+  return !!user && (user.role === 'admin' || user.role === 'redeem_ops' || !!user.redeemOpsRole);
+}

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -15,6 +15,8 @@ export function getDefaultRouteForRole(role) {
  return '/FleetOwnerDashboard'
  case 'driver_partner':
  return '/DriverDashboard'
+ case 'redeem_ops':
+ return '/redeem-ops'
  case 'customer':
  return '/Onboarding'
  default:

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useEffect } from 'react';
 import ProtectedRoute from '@/components/auth/ProtectedRoute';
+import RedeemOpsRoute from '@/components/auth/RedeemOpsRoute';
 import DashboardLayout from '@/components/layout/DashboardLayout';
 import { BrowserRouter as Router, Route, Routes, useNavigate } from 'react-router-dom';
 import ErrorBoundary from './ErrorBoundary';
@@ -71,6 +72,12 @@ const DriverPayslip = lazy(() => import('./DriverPayslip'));
 const MyProspects = lazy(() => import('./MyProspects'));
 const ProspectDetailPage = lazy(() => import('./ProspectDetailPage'));
 const AgentProfile = lazy(() => import('./AgentProfile'));
+
+// Redeem Ops — flag-gated internal staff surface (docs/redeem-ops/ROUTE_MAP.md §2).
+// Dark until VITE_REDEEM_OPS_ENABLED=true is baked into the build.
+const REDEEM_OPS_ENABLED = import.meta.env.VITE_REDEEM_OPS_ENABLED === 'true';
+const RedeemOpsHome = lazy(() => import('./redeemops/RedeemOpsHome'));
+const RedeemOpsTeam = lazy(() => import('./redeemops/RedeemOpsTeam'));
 
 function PagesContent() {
  const navigate = useNavigate();
@@ -427,6 +434,30 @@ function PagesContent() {
  </ProtectedRoute>
  }
  />
+
+ {/* Redeem Ops — flag-gated internal staff surface */}
+ {REDEEM_OPS_ENABLED && (
+ <Route
+ path="/redeem-ops" element={
+ <RedeemOpsRoute>
+ <DashboardLayout>
+ <RedeemOpsHome />
+ </DashboardLayout>
+ </RedeemOpsRoute>
+ }
+ />
+ )}
+ {REDEEM_OPS_ENABLED && (
+ <Route
+ path="/redeem-ops/team" element={
+ <RedeemOpsRoute>
+ <DashboardLayout>
+ <RedeemOpsTeam />
+ </DashboardLayout>
+ </RedeemOpsRoute>
+ }
+ />
+ )}
 
  {/* Other protected routes */}
  <Route

--- a/src/pages/redeemops/RedeemOpsHome.jsx
+++ b/src/pages/redeemops/RedeemOpsHome.jsx
@@ -1,0 +1,62 @@
+import { Link } from 'react-router-dom';
+import { useAuthStore } from '@/stores/authStore';
+import { hasCapability } from '@/lib/redeemOpsPermissions';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import Users from 'lucide-react/icons/users';
+import Building2 from 'lucide-react/icons/building-2';
+
+/**
+ * Redeem Ops overview (Phase 1 shell). Deliberately honest about what exists:
+ * modules that haven't shipped are named with their phase, not faked as
+ * functional placeholders (docs/redeem-ops/ROUTE_MAP.md §2).
+ */
+export default function RedeemOpsHome() {
+  const user = useAuthStore((s) => s.user);
+  const canManageTeam = hasCapability(user, 'team.manage_access');
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Redeem Ops</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Partner prospecting, rewards, and redemption operations.
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Users className="w-4 h-4" aria-hidden="true" />
+              Team &amp; access
+            </CardTitle>
+            <CardDescription>
+              {canManageTeam
+                ? 'Invite outreach staff and manage Redeem Ops sub-roles.'
+                : 'See who is on the Redeem Ops team.'}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild size="sm">
+              <Link to="/redeem-ops/team">Open Team</Link>
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card className="border-dashed">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base text-muted-foreground">
+              <Building2 className="w-4 h-4" aria-hidden="true" />
+              Partner CRM
+            </CardTitle>
+            <CardDescription>
+              Business search, duplicate-safe claiming, activity timeline, and the partner
+              pipeline arrive in Phase 2.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/redeemops/RedeemOpsTeam.jsx
+++ b/src/pages/redeemops/RedeemOpsTeam.jsx
@@ -1,0 +1,211 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { redeemOpsApi } from '@/api/redeemOps';
+import { useAuthStore } from '@/stores/authStore';
+import { hasCapability } from '@/lib/redeemOpsPermissions';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table';
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import UserPlus from 'lucide-react/icons/user-plus';
+
+const TEAM_KEY = ['redeem-ops', 'team'];
+
+export default function RedeemOpsTeam() {
+  const currentUser = useAuthStore((s) => s.user);
+  const canManage = hasCapability(currentUser, 'team.manage_access');
+  const queryClient = useQueryClient();
+
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [invite, setInvite] = useState({ email: '', fullName: '', redeemOpsRole: '' });
+
+  const teamQuery = useQuery({ queryKey: TEAM_KEY, queryFn: redeemOpsApi.getTeam });
+  const constantsQuery = useQuery({
+    queryKey: ['redeem-ops', 'constants'],
+    queryFn: redeemOpsApi.getConstants,
+    staleTime: Infinity,
+  });
+
+  const subRoles = constantsQuery.data?.subRoles || [];
+  const subRoleLabels = constantsQuery.data?.subRoleLabels || {};
+
+  const inviteMutation = useMutation({
+    mutationFn: redeemOpsApi.inviteTeamMember,
+    onSuccess: () => {
+      toast.success('Invitation sent', { description: 'They will receive an email with an accept link.' });
+      setInviteOpen(false);
+      setInvite({ email: '', fullName: '', redeemOpsRole: '' });
+      queryClient.invalidateQueries({ queryKey: TEAM_KEY });
+    },
+    onError: (err) => toast.error('Invite failed', { description: err.message }),
+  });
+
+  const roleMutation = useMutation({
+    mutationFn: ({ userId, redeemOpsRole }) => redeemOpsApi.setTeamRole(userId, redeemOpsRole),
+    onSuccess: () => {
+      toast.success('Role updated');
+      queryClient.invalidateQueries({ queryKey: TEAM_KEY });
+    },
+    onError: (err) => toast.error('Role change failed', { description: err.message }),
+  });
+
+  const team = teamQuery.data || [];
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Team &amp; access</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Redeem Ops staff and their sub-roles. Admins are implicit super admins.
+          </p>
+        </div>
+        {canManage && (
+          <Dialog open={inviteOpen} onOpenChange={setInviteOpen}>
+            <DialogTrigger asChild>
+              <Button size="sm">
+                <UserPlus className="w-4 h-4 mr-2" aria-hidden="true" />
+                Invite staff
+              </Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Invite Redeem Ops staff</DialogTitle>
+                <DialogDescription>
+                  They will receive an email invitation and set their password via the accept link.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-4 py-2">
+                <div className="space-y-1.5">
+                  <Label htmlFor="ro-invite-name">Full name</Label>
+                  <Input
+                    id="ro-invite-name"
+                    value={invite.fullName}
+                    onChange={(e) => setInvite((v) => ({ ...v, fullName: e.target.value }))}
+                    placeholder="Sarah Tan"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="ro-invite-email">Email</Label>
+                  <Input
+                    id="ro-invite-email"
+                    type="email"
+                    value={invite.email}
+                    onChange={(e) => setInvite((v) => ({ ...v, email: e.target.value }))}
+                    placeholder="sarah@mktr.sg"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label>Sub-role</Label>
+                  <Select
+                    value={invite.redeemOpsRole}
+                    onValueChange={(redeemOpsRole) => setInvite((v) => ({ ...v, redeemOpsRole }))}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select a sub-role" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {subRoles.map((r) => (
+                        <SelectItem key={r} value={r}>{subRoleLabels[r] || r}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              <DialogFooter>
+                <Button
+                  onClick={() => inviteMutation.mutate(invite)}
+                  disabled={
+                    inviteMutation.isPending ||
+                    !invite.email || !invite.fullName || !invite.redeemOpsRole
+                  }
+                >
+                  {inviteMutation.isPending ? 'Sending…' : 'Send invite'}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        )}
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Members</CardTitle>
+          <CardDescription>
+            {teamQuery.isLoading ? 'Loading…' : `${team.length} member${team.length === 1 ? '' : 's'}`}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Email</TableHead>
+                  <TableHead>Sub-role</TableHead>
+                  <TableHead>Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {team.map((member) => (
+                  <TableRow key={member.id}>
+                    <TableCell className="font-medium">
+                      {member.fullName || [member.firstName, member.lastName].filter(Boolean).join(' ') || '—'}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">{member.email}</TableCell>
+                    <TableCell>
+                      {canManage && member.id !== currentUser?.id ? (
+                        <Select
+                          value={member.redeemOpsRole || ''}
+                          onValueChange={(redeemOpsRole) =>
+                            roleMutation.mutate({ userId: member.id, redeemOpsRole })
+                          }
+                        >
+                          <SelectTrigger className="w-56">
+                            <SelectValue placeholder="No sub-role" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {subRoles.map((r) => (
+                              <SelectItem key={r} value={r}>{subRoleLabels[r] || r}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      ) : (
+                        <Badge variant="secondary">
+                          {subRoleLabels[member.redeemOpsRole] || member.redeemOpsRole || '—'}
+                        </Badge>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={member.isActive ? 'default' : 'outline'}>
+                        {member.isActive ? 'Active' : 'Inactive'}
+                      </Badge>
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {!teamQuery.isLoading && team.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={4} className="text-center text-muted-foreground py-8">
+                      No Redeem Ops staff yet{canManage ? ' — send the first invite.' : '.'}
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## What this is

**Phase 1 of Redeem Ops** per the architecture in #93 (`docs/redeem-ops/IMPLEMENTATION_PLAN.md`). Ships completely **dark**: the `/api/redeem-ops/*` namespace stays unmounted until `REDEEM_OPS_ENABLED=true` (route auto-loader flag gating, `BILLING_ENABLED` precedent) and the SPA route group is gated on `VITE_REDEEM_OPS_ENABLED`. With flags off, production behaviour is byte-identical — pinned by a test asserting 404 on the whole namespace.

## Backend

- **Migration 045**: `users.role` + `'redeem_ops'` (`ADD VALUE IF NOT EXISTS`, PG12+, 029 precedent), `users.redeemOpsRole` sub-role column, `redeem_ops_audit_events` (append-only; the platform had no generic audit infra). All code-side enum touchpoints landed together: `User.js`, `userService` invite allowlist, `invitationService` role label, `getDefaultRouteForRole`.
- **Authorization**: `services/redeemOps/permissions.js` — the capability matrix from `PERMISSION_MATRIX.md` as a dependency-free module (single source of truth) + `requireRedeemOps(...caps)` middleware. `role='admin'` = implicit super_admin; existing MKTR gates untouched (a `redeem_ops` user gets 403 on `/api/users` exactly like any non-admin — tested).
- **Routes**: `/api/redeem-ops` → `/team`, `/team/invite` (reuses `sendRoleInvitation` + role email templates, sets sub-role at invite), `/team/:userId/role` (atomic update + audit in one transaction), `/audit` (filterable), `/meta/constants`.
- **Host plumbing**: `/api/redeem-ops` added to the D13 blocklist (consumer redeem.sg → 403) **plus the new ops-host allow-policy** — `ops.redeem.sg` may reach only `/api/auth`, `/api/redeem-ops`, `/api/notifications`; every other internal prefix 403s at the host layer. `ops.redeem.sg` allowlisted in `publicHost.js` (NOT as a redeem-consumer host) + CORS defaults.

## Frontend (mktr build, flag-gated)

- `/redeem-ops` (overview shell) + `/redeem-ops/team` behind a new `RedeemOpsRoute` guard (redeem consumer build gets `MktrOnlyRedirect`, mirroring `ProtectedRoute`).
- Team page: member list, invite dialog (sub-role picker fed by `/meta/constants`), inline sub-role changes for super admins.
- `DashboardLayout` nav branch for `redeem_ops` users; admins see a "Redeem Ops" section when the flag is on.
- `src/lib/redeemOpsPermissions.js` mirror for UI gating with a **vitest drift test that imports the backend source of truth** — the two files cannot diverge silently.

## Verification

- ✅ 15 pure unit tests passing locally (capability-matrix invariants; host-guard policy incl. ops-host allowlist and server-to-server passthrough)
- ✅ Vite production build + eslint clean; backend module-chain import smoke passed
- ⏳ 2 DB-backed suites run in CI against postgres:15 (routes/authz, invite + audit rows, role grant/revoke, flag-off 404, and the agent-sync guardrail: `redeem_ops` users invisible to `role='agent'` scopes)

## Not in this PR

Partner CRM (Phase 2), queue/tasks/pools (Phase 3), the ops.redeem.sg static site (created at Phase 3 exit per `RECOMMENDED_ARCHITECTURE.md` §5). No MKTR behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)