### PR TITLE
feat(redeem-ops): V1 — Partner CRM + outreach operations (Phases 2+3)

### DIFF
--- a/backend/src/controllers/redeemOps/partnersController.js
+++ b/backend/src/controllers/redeemOps/partnersController.js
@@ -1,0 +1,190 @@
+import Joi from 'joi';
+import { asyncHandler, AppError } from '../../middleware/errorHandler.js';
+import partnerService from '../../services/redeemOps/partnerService.js';
+import { makeClaimService } from '../../services/redeemOps/claimService.js';
+import { makeDedupeService } from '../../services/redeemOps/dedupeService.js';
+
+const claimService = makeClaimService();
+const dedupeService = makeDedupeService();
+
+const partnerBodySchema = Joi.object({
+  legalName: Joi.string().max(160).allow('', null),
+  tradingName: Joi.string().max(160).allow('', null),
+  brandName: Joi.string().max(120).allow('', null),
+  uen: Joi.string().max(16).allow('', null),
+  website: Joi.string().max(255).allow('', null),
+  primaryPhone: Joi.string().pattern(/^\+[1-9]\d{9,14}$/).allow('', null)
+    .messages({ 'string.pattern.base': 'primaryPhone must be E.164, e.g. +6591234567' }),
+  primaryEmail: Joi.string().email().max(160).allow('', null),
+  instagramHandle: Joi.string().max(120).allow('', null),
+  tiktokHandle: Joi.string().max(120).allow('', null),
+  facebookUrl: Joi.string().max(255).allow('', null),
+  linkedinUrl: Joi.string().max(255).allow('', null),
+  category: Joi.string().max(64).allow('', null),
+  subcategory: Joi.string().max(64).allow('', null),
+  source: Joi.string().max(64).allow('', null),
+  tags: Joi.array().items(Joi.string().max(48)).max(20),
+  notes: Joi.string().max(5000).allow('', null),
+  overrideReason: Joi.string().max(255).allow('', null),
+});
+
+function validateBody(schema, body) {
+  const { error, value } = schema.validate(body, { abortEarly: false });
+  if (error) throw new AppError(error.details.map((x) => x.message).join(', '), 400);
+  return value;
+}
+
+/** Coerce '' → null so blanks never collide on partial unique indexes. */
+function blanksToNull(obj) {
+  const out = {};
+  for (const [k, v] of Object.entries(obj)) out[k] = v === '' ? null : v;
+  return out;
+}
+
+export const listPartners = asyncHandler(async (req, res) => {
+  const data = await partnerService.listPartners(req.query, req.user);
+  res.json({ success: true, data });
+});
+
+export const checkDuplicates = asyncHandler(async (req, res) => {
+  const duplicates = await dedupeService.findDuplicates(req.query, req.query.excludeId || null);
+  res.json({ success: true, data: { duplicates } });
+});
+
+export const createPartner = asyncHandler(async (req, res) => {
+  const body = blanksToNull(validateBody(partnerBodySchema, req.body));
+  const { partner, warnings } = await partnerService.createPartner(body, req.user, req.id);
+  res.status(201).json({ success: true, data: { partner, warnings } });
+});
+
+export const getPartner = asyncHandler(async (req, res) => {
+  const partner = await partnerService.getPartner(req.params.id);
+  res.json({ success: true, data: { partner } });
+});
+
+export const updatePartner = asyncHandler(async (req, res) => {
+  const body = blanksToNull(validateBody(partnerBodySchema, req.body));
+  const partner = await partnerService.updatePartner(req.params.id, body, req.user, req.id);
+  res.json({ success: true, data: { partner } });
+});
+
+export const claimPartner = asyncHandler(async (req, res) => {
+  const result = await claimService.claimPartner(req.params.id, req.user, req.id);
+  res.json({ success: true, message: 'Business claimed', data: result });
+});
+
+export const releasePartner = asyncHandler(async (req, res) => {
+  await claimService.releasePartner(req.params.id, req.user, req.body?.reason || null, req.id);
+  res.json({ success: true, message: 'Business released' });
+});
+
+export const assignPartner = asyncHandler(async (req, res) => {
+  const schema = Joi.object({
+    toUserId: Joi.string().uuid().required(),
+    reason: Joi.string().max(255).allow('', null),
+  });
+  const body = validateBody(schema, req.body);
+  const partner = await claimService.assignPartner(req.params.id, body.toUserId, req.user, body.reason || null, req.id);
+  res.json({ success: true, data: { partner } });
+});
+
+export const changeStage = asyncHandler(async (req, res) => {
+  const schema = Joi.object({
+    toStage: Joi.string().max(32).required(),
+    reason: Joi.string().max(255).allow('', null),
+  });
+  const body = validateBody(schema, req.body);
+  const partner = await partnerService.changeStage(req.params.id, body.toStage, req.user, body.reason || null, req.id);
+  res.json({ success: true, data: { partner } });
+});
+
+export const mergePartners = asyncHandler(async (req, res) => {
+  const schema = Joi.object({
+    duplicateId: Joi.string().uuid().required(),
+    reason: Joi.string().max(255).allow('', null),
+  });
+  const body = validateBody(schema, req.body);
+  const survivor = await partnerService.mergePartners(req.params.id, body.duplicateId, req.user, body.reason || null, req.id);
+  res.json({ success: true, message: 'Merged', data: { partner: survivor } });
+});
+
+export const getTimeline = asyncHandler(async (req, res) => {
+  const data = await partnerService.getTimeline(req.params.id, req.query);
+  res.json({ success: true, data });
+});
+
+export const logActivity = asyncHandler(async (req, res) => {
+  const schema = Joi.object({
+    type: Joi.string().max(32).required(),
+    direction: Joi.string().valid('outbound', 'inbound', 'internal'),
+    summary: Joi.string().max(255).required(),
+    details: Joi.string().max(10000).allow('', null),
+    outcome: Joi.string().max(64).allow('', null),
+    occurredAt: Joi.date().iso(),
+    contactId: Joi.string().uuid().allow(null),
+  });
+  const body = validateBody(schema, req.body);
+  const activity = await partnerService.logActivity(req.params.id, body, req.user, req.id);
+  res.status(201).json({ success: true, data: { activity } });
+});
+
+export const editActivity = asyncHandler(async (req, res) => {
+  const activity = await partnerService.editActivity(req.params.activityId, req.body || {}, req.user, req.id);
+  res.json({ success: true, data: { activity } });
+});
+
+export const voidActivity = asyncHandler(async (req, res) => {
+  await partnerService.voidActivity(req.params.activityId, req.user, req.body?.reason, req.id);
+  res.json({ success: true, message: 'Activity voided' });
+});
+
+const contactSchema = Joi.object({
+  name: Joi.string().max(120).required(),
+  roleTitle: Joi.string().max(80).allow('', null),
+  mobile: Joi.string().max(20).allow('', null),
+  whatsapp: Joi.string().max(20).allow('', null),
+  email: Joi.string().email().max(160).allow('', null),
+  preferredChannel: Joi.string().valid('call', 'whatsapp', 'email', 'instagram', 'other').allow(null),
+  isPrimary: Joi.boolean(),
+  notes: Joi.string().max(2000).allow('', null),
+});
+
+export const addContact = asyncHandler(async (req, res) => {
+  const body = blanksToNull(validateBody(contactSchema, req.body));
+  const contact = await partnerService.addContact(req.params.id, body, req.user);
+  res.status(201).json({ success: true, data: { contact } });
+});
+
+export const updateContact = asyncHandler(async (req, res) => {
+  const body = blanksToNull(validateBody(contactSchema.fork(['name'], (s) => s.optional()), req.body));
+  const contact = await partnerService.updateContact(req.params.contactId, body, req.user);
+  res.json({ success: true, data: { contact } });
+});
+
+export const archiveContact = asyncHandler(async (req, res) => {
+  await partnerService.archiveContact(req.params.contactId, req.user);
+  res.json({ success: true, message: 'Contact archived' });
+});
+
+const locationSchema = Joi.object({
+  name: Joi.string().max(120).allow('', null),
+  addressLine: Joi.string().max(255).allow('', null),
+  postalCode: Joi.string().pattern(/^\d{6}$/).allow('', null)
+    .messages({ 'string.pattern.base': 'postalCode must be 6 digits' }),
+  area: Joi.string().max(64).allow('', null),
+  phone: Joi.string().max(20).allow('', null),
+  isActive: Joi.boolean(),
+  notes: Joi.string().max(2000).allow('', null),
+});
+
+export const addLocation = asyncHandler(async (req, res) => {
+  const body = blanksToNull(validateBody(locationSchema, req.body));
+  const location = await partnerService.addLocation(req.params.id, body, req.user);
+  res.status(201).json({ success: true, data: { location } });
+});
+
+export const updateLocation = asyncHandler(async (req, res) => {
+  const body = blanksToNull(validateBody(locationSchema, req.body));
+  const location = await partnerService.updateLocation(req.params.locationId, body, req.user);
+  res.json({ success: true, data: { location } });
+});

--- a/backend/src/controllers/redeemOps/workController.js
+++ b/backend/src/controllers/redeemOps/workController.js
@@ -1,0 +1,90 @@
+import Joi from 'joi';
+import { asyncHandler, AppError } from '../../middleware/errorHandler.js';
+import taskService from '../../services/redeemOps/taskService.js';
+import poolService from '../../services/redeemOps/poolService.js';
+import queueService from '../../services/redeemOps/queueService.js';
+
+function validateBody(schema, body) {
+  const { error, value } = schema.validate(body, { abortEarly: false });
+  if (error) throw new AppError(error.details.map((x) => x.message).join(', '), 400);
+  return value;
+}
+
+export const getMyQueue = asyncHandler(async (req, res) => {
+  const data = await queueService.getMyQueue(req.user);
+  res.json({ success: true, data });
+});
+
+export const getTeamPipeline = asyncHandler(async (req, res) => {
+  const data = await queueService.getTeamPipeline();
+  res.json({ success: true, data });
+});
+
+// ── Tasks ──────────────────────────────────────────────────────────────────
+
+const taskSchema = Joi.object({
+  title: Joi.string().max(160).required(),
+  partnerOrganisationId: Joi.string().uuid().required(),
+  contactId: Joi.string().uuid().allow(null),
+  assigneeUserId: Joi.string().uuid(),
+  dueAt: Joi.date().iso().required(),
+  hasTime: Joi.boolean(),
+  priority: Joi.string().valid('low', 'medium', 'high'),
+  type: Joi.string().valid('follow_up', 'call', 'meeting', 'proposal', 'admin', 'other'),
+  description: Joi.string().max(5000).allow('', null),
+});
+
+export const listTasks = asyncHandler(async (req, res) => {
+  const data = await taskService.listTasks(req.query, req.user);
+  res.json({ success: true, data });
+});
+
+export const createTask = asyncHandler(async (req, res) => {
+  const body = validateBody(taskSchema, req.body);
+  const task = await taskService.createTask(body, req.user);
+  res.status(201).json({ success: true, data: { task } });
+});
+
+export const updateTask = asyncHandler(async (req, res) => {
+  const task = await taskService.updateTask(req.params.taskId, req.body || {}, req.user);
+  res.json({ success: true, data: { task } });
+});
+
+// ── Pools ──────────────────────────────────────────────────────────────────
+
+export const listPools = asyncHandler(async (req, res) => {
+  const pools = await poolService.listPools();
+  res.json({ success: true, data: { pools } });
+});
+
+export const createPool = asyncHandler(async (req, res) => {
+  const schema = Joi.object({
+    name: Joi.string().max(120).required(),
+    description: Joi.string().max(2000).allow('', null),
+    category: Joi.string().max(64).allow('', null),
+    area: Joi.string().max(64).allow('', null),
+  });
+  const body = validateBody(schema, req.body);
+  const pool = await poolService.createPool(body, req.user);
+  res.status(201).json({ success: true, data: { pool } });
+});
+
+export const updatePool = asyncHandler(async (req, res) => {
+  const pool = await poolService.updatePool(req.params.poolId, req.body || {}, req.user);
+  res.json({ success: true, data: { pool } });
+});
+
+export const addPoolMembers = asyncHandler(async (req, res) => {
+  const schema = Joi.object({ partnerIds: Joi.array().items(Joi.string().uuid()).min(1).max(500).required() });
+  const body = validateBody(schema, req.body);
+  const result = await poolService.addMembers(req.params.poolId, body.partnerIds, req.user);
+  res.json({ success: true, data: result });
+});
+
+export const claimNext = asyncHandler(async (req, res) => {
+  const partnerId = await poolService.claimNext(req.params.poolId, req.user);
+  if (!partnerId) {
+    return res.status(200).json({ success: true, message: 'Pool exhausted — no eligible prospects left', data: { partnerId: null } });
+  }
+  res.json({ success: true, message: 'Prospect claimed', data: { partnerId } });
+});

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -149,6 +149,24 @@ export async function bootstrapDatabase() {
       logger.info(`[RedeemedAudience] periodic sync scheduled (${intervalHours}h interval)`);
     }
 
+    // Redeem Ops claim-inactivity sweep (docs/redeem-ops/ERD.md §6). Flags
+    // at-risk (48h no first outreach) and stale (14d no meaningful activity)
+    // partners — NEVER auto-releases; managers act on the flags. In-process like
+    // the sweeps above; a dark deploy (flag off) schedules nothing.
+    if (String(process.env.REDEEM_OPS_ENABLED || 'false').toLowerCase() === 'true') {
+      const runRedeemOpsSweepSafe = async () => {
+        try {
+          const { runRedeemOpsStaleSweep } = await import('../services/redeemOps/staleSweep.js');
+          await runRedeemOpsStaleSweep();
+        } catch (err) {
+          logger.warn('[RedeemOps] stale sweep failed (non-fatal)', { error: err?.message });
+        }
+      };
+      setTimeout(runRedeemOpsSweepSafe, 120_000);
+      setInterval(runRedeemOpsSweepSafe, 30 * 60 * 1000); // every 30 min
+      logger.info('[RedeemOps] stale sweep scheduled (30m interval)');
+    }
+
     // DNC re-scrub / retry backfill — recovers dnc_pending leads whose check errored or
     // timed out at capture (releases on clear). In-process, gated by DNC_BACKFILL_ENABLED;
     // the re-entrancy guard + DB job lock live in the service (paid API → no double-fire).

--- a/backend/src/database/migrations/046-redeem-ops-partner-crm.js
+++ b/backend/src/database/migrations/046-redeem-ops-partner-crm.js
@@ -1,0 +1,191 @@
+/**
+ * Redeem Ops Phase 2 — Partner CRM tables (docs/redeem-ops/ERD.md §3.1–3.6).
+ * partner_organisations, partner_locations, partner_contacts,
+ * partner_assignment_events, partner_stage_events, outreach_activities.
+ *
+ * pg_trgm is attempted for fuzzy-name duplicate detection; failure is non-fatal
+ * (dedupeService falls back to prefix matching — ERD.md §5). Every step is
+ * guarded so a partial re-run and NODE_ENV=test (sync-first) are both safe.
+ */
+export async function up(queryInterface, Sequelize) {
+  // Fuzzy-match support (optional). CREATE EXTENSION needs no transaction here —
+  // the runner is non-transactional. Requires the DB role to allow it; Render
+  // Postgres does. Failure only disables trigram matching, never the migration.
+  try {
+    await queryInterface.sequelize.query('CREATE EXTENSION IF NOT EXISTS pg_trgm');
+  } catch (err) {
+    console.warn('[046] pg_trgm unavailable — dedupe falls back to prefix matching:', err.message);
+  }
+
+  const tables = await queryInterface.showAllTables();
+  const UUID = Sequelize.UUID;
+  const ts = () => ({
+    createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+  });
+  const userFk = (allowNull = true) => ({
+    type: UUID, allowNull, references: { model: 'users', key: 'id' }, onDelete: 'SET NULL',
+  });
+
+  if (!tables.includes('partner_organisations')) {
+    await queryInterface.createTable('partner_organisations', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      legalName: { type: Sequelize.STRING(160) },
+      tradingName: { type: Sequelize.STRING(160) },
+      brandName: { type: Sequelize.STRING(120) },
+      normalizedName: { type: Sequelize.STRING(160), allowNull: false },
+      uen: { type: Sequelize.STRING(16) },
+      website: { type: Sequelize.STRING(255) },
+      websiteDomain: { type: Sequelize.STRING(160) },
+      primaryPhone: { type: Sequelize.STRING(20) },
+      primaryEmail: { type: Sequelize.STRING(160) },
+      instagramHandle: { type: Sequelize.STRING(64) },
+      tiktokHandle: { type: Sequelize.STRING(64) },
+      facebookUrl: { type: Sequelize.STRING(255) },
+      facebookHandle: { type: Sequelize.STRING(120) },
+      linkedinUrl: { type: Sequelize.STRING(255) },
+      category: { type: Sequelize.STRING(64) },
+      subcategory: { type: Sequelize.STRING(64) },
+      source: { type: Sequelize.STRING(64) },
+      tags: { type: Sequelize.JSONB, allowNull: false, defaultValue: [] },
+      notes: { type: Sequelize.TEXT },
+      pipelineStage: { type: Sequelize.STRING(32), allowNull: false, defaultValue: 'UNCLAIMED' },
+      availability: { type: Sequelize.STRING(24), allowNull: false, defaultValue: 'available' },
+      ownerUserId: userFk(),
+      claimedAt: { type: Sequelize.DATE },
+      firstOutreachAt: { type: Sequelize.DATE },
+      lastActivityAt: { type: Sequelize.DATE },
+      nextTaskAt: { type: Sequelize.DATE },
+      atRiskFlag: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+      staleFlag: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+      mergedIntoId: { type: UUID, references: { model: 'partner_organisations', key: 'id' }, onDelete: 'SET NULL' },
+      archivedAt: { type: Sequelize.DATE },
+      createdBy: { type: UUID, allowNull: false, references: { model: 'users', key: 'id' }, onDelete: 'RESTRICT' },
+      ...ts(),
+    });
+  }
+
+  if (!tables.includes('partner_locations')) {
+    await queryInterface.createTable('partner_locations', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      partnerOrganisationId: { type: UUID, allowNull: false, references: { model: 'partner_organisations', key: 'id' }, onDelete: 'CASCADE' },
+      name: { type: Sequelize.STRING(120) },
+      addressLine: { type: Sequelize.STRING(255) },
+      postalCode: { type: Sequelize.STRING(6) },
+      postalDistrict: { type: Sequelize.STRING(2) },
+      area: { type: Sequelize.STRING(64) },
+      phone: { type: Sequelize.STRING(20) },
+      isActive: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: true },
+      notes: { type: Sequelize.TEXT },
+      ...ts(),
+    });
+  }
+
+  if (!tables.includes('partner_contacts')) {
+    await queryInterface.createTable('partner_contacts', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      partnerOrganisationId: { type: UUID, allowNull: false, references: { model: 'partner_organisations', key: 'id' }, onDelete: 'CASCADE' },
+      name: { type: Sequelize.STRING(120), allowNull: false },
+      roleTitle: { type: Sequelize.STRING(80) },
+      mobile: { type: Sequelize.STRING(20) },
+      whatsapp: { type: Sequelize.STRING(20) },
+      email: { type: Sequelize.STRING(160) },
+      preferredChannel: { type: Sequelize.STRING(24) },
+      isPrimary: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+      notes: { type: Sequelize.TEXT },
+      archivedAt: { type: Sequelize.DATE },
+      ...ts(),
+    });
+  }
+
+  if (!tables.includes('partner_assignment_events')) {
+    await queryInterface.createTable('partner_assignment_events', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      partnerOrganisationId: { type: UUID, allowNull: false, references: { model: 'partner_organisations', key: 'id' }, onDelete: 'CASCADE' },
+      kind: { type: Sequelize.STRING(24), allowNull: false },
+      fromUserId: userFk(),
+      toUserId: userFk(),
+      actorUserId: userFk(),
+      reason: { type: Sequelize.STRING(255) },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    });
+  }
+
+  if (!tables.includes('partner_stage_events')) {
+    await queryInterface.createTable('partner_stage_events', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      partnerOrganisationId: { type: UUID, allowNull: false, references: { model: 'partner_organisations', key: 'id' }, onDelete: 'CASCADE' },
+      fromStage: { type: Sequelize.STRING(32) },
+      toStage: { type: Sequelize.STRING(32), allowNull: false },
+      actorUserId: userFk(),
+      reason: { type: Sequelize.STRING(255) },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    });
+  }
+
+  // partner_organisations indexes — ALWAYS run, IF NOT EXISTS (independent of the
+  // table-exists branch so a crashed partial run can't skip them; 045 pattern).
+  const idx = (sql) => queryInterface.sequelize.query(sql);
+  await idx('CREATE UNIQUE INDEX IF NOT EXISTS uq_po_uen ON partner_organisations ("uen") WHERE "uen" IS NOT NULL');
+  await idx('CREATE UNIQUE INDEX IF NOT EXISTS uq_po_phone ON partner_organisations ("primaryPhone") WHERE "primaryPhone" IS NOT NULL');
+  await idx('CREATE UNIQUE INDEX IF NOT EXISTS uq_po_instagram ON partner_organisations ("instagramHandle") WHERE "instagramHandle" IS NOT NULL');
+  await idx('CREATE UNIQUE INDEX IF NOT EXISTS uq_po_tiktok ON partner_organisations ("tiktokHandle") WHERE "tiktokHandle" IS NOT NULL');
+  await idx('CREATE INDEX IF NOT EXISTS idx_po_normalized_name ON partner_organisations ("normalizedName")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_po_domain ON partner_organisations ("websiteDomain")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_po_owner_stage ON partner_organisations ("ownerUserId", "pipelineStage")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_po_stage ON partner_organisations ("pipelineStage")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_po_availability ON partner_organisations ("availability")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_po_category ON partner_organisations ("category")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_po_last_activity ON partner_organisations ("lastActivityAt")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_po_next_task ON partner_organisations ("nextTaskAt")');
+  // Trigram index only when the extension made it in (best-effort)
+  try {
+    await idx('CREATE INDEX IF NOT EXISTS idx_po_name_trgm ON partner_organisations USING gin ("normalizedName" gin_trgm_ops)');
+  } catch (err) {
+    console.warn('[046] trigram index skipped:', err.message);
+  }
+
+  if (!tables.includes('outreach_activities')) {
+    await queryInterface.createTable('outreach_activities', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      partnerOrganisationId: { type: UUID, allowNull: false, references: { model: 'partner_organisations', key: 'id' }, onDelete: 'CASCADE' },
+      contactId: { type: UUID, references: { model: 'partner_contacts', key: 'id' }, onDelete: 'SET NULL' },
+      type: { type: Sequelize.STRING(32), allowNull: false },
+      direction: { type: Sequelize.STRING(12), allowNull: false, defaultValue: 'outbound' },
+      summary: { type: Sequelize.STRING(255), allowNull: false },
+      details: { type: Sequelize.TEXT },
+      outcome: { type: Sequelize.STRING(64) },
+      occurredAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      actorUserId: userFk(),
+      editedAt: { type: Sequelize.DATE },
+      editedBy: { type: UUID },
+      voidedAt: { type: Sequelize.DATE },
+      voidReason: { type: Sequelize.STRING(255) },
+      ...ts(),
+    });
+  }
+
+  // Child-table indexes — same always-run IF NOT EXISTS treatment.
+  await idx('CREATE INDEX IF NOT EXISTS idx_pl_partner ON partner_locations ("partnerOrganisationId")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_pl_postal ON partner_locations ("postalCode")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_pc_partner ON partner_contacts ("partnerOrganisationId")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_pae_partner_created ON partner_assignment_events ("partnerOrganisationId", "createdAt")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_pse_partner_created ON partner_stage_events ("partnerOrganisationId", "createdAt")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_oa_partner_occurred ON outreach_activities ("partnerOrganisationId", "occurredAt")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_oa_actor_occurred ON outreach_activities ("actorUserId", "occurredAt")');
+}
+
+export async function down(queryInterface) {
+  // Reverse dependency order; CASCADE clears FK references defensively.
+  for (const table of [
+    'outreach_activities',
+    'partner_stage_events',
+    'partner_assignment_events',
+    'partner_contacts',
+    'partner_locations',
+    'partner_organisations',
+  ]) {
+    await queryInterface.sequelize.query(`DROP TABLE IF EXISTS ${table} CASCADE`);
+  }
+  // pg_trgm extension is left installed (shared, harmless).
+}

--- a/backend/src/database/migrations/047-redeem-ops-outreach-work.js
+++ b/backend/src/database/migrations/047-redeem-ops-outreach-work.js
@@ -1,0 +1,73 @@
+/**
+ * Redeem Ops Phase 3 — tasks, prospecting pools (docs/redeem-ops/ERD.md §3.7–3.9).
+ * Guarded for partial re-runs and NODE_ENV=test sync-first, like 045/046.
+ */
+export async function up(queryInterface, Sequelize) {
+  const tables = await queryInterface.showAllTables();
+  const UUID = Sequelize.UUID;
+  const ts = () => ({
+    createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+  });
+
+  if (!tables.includes('outreach_tasks')) {
+    await queryInterface.createTable('outreach_tasks', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      title: { type: Sequelize.STRING(160), allowNull: false },
+      partnerOrganisationId: { type: UUID, allowNull: false, references: { model: 'partner_organisations', key: 'id' }, onDelete: 'CASCADE' },
+      contactId: { type: UUID, references: { model: 'partner_contacts', key: 'id' }, onDelete: 'SET NULL' },
+      assigneeUserId: { type: UUID, allowNull: false, references: { model: 'users', key: 'id' }, onDelete: 'CASCADE' },
+      createdBy: { type: UUID, allowNull: false, references: { model: 'users', key: 'id' }, onDelete: 'RESTRICT' },
+      dueAt: { type: Sequelize.DATE, allowNull: false },
+      hasTime: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+      priority: { type: Sequelize.STRING(12), allowNull: false, defaultValue: 'medium' },
+      type: { type: Sequelize.STRING(24), allowNull: false, defaultValue: 'follow_up' },
+      status: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'open' },
+      description: { type: Sequelize.TEXT },
+      completedAt: { type: Sequelize.DATE },
+      completedBy: { type: UUID },
+      ...ts(),
+    });
+  }
+
+  if (!tables.includes('prospecting_pools')) {
+    await queryInterface.createTable('prospecting_pools', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      name: { type: Sequelize.STRING(120), allowNull: false, unique: true },
+      description: { type: Sequelize.TEXT },
+      category: { type: Sequelize.STRING(64) },
+      area: { type: Sequelize.STRING(64) },
+      isActive: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: true },
+      createdBy: { type: UUID, allowNull: false, references: { model: 'users', key: 'id' }, onDelete: 'RESTRICT' },
+      ...ts(),
+    });
+  }
+
+  if (!tables.includes('prospecting_pool_members')) {
+    await queryInterface.createTable('prospecting_pool_members', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      poolId: { type: UUID, allowNull: false, references: { model: 'prospecting_pools', key: 'id' }, onDelete: 'CASCADE' },
+      partnerOrganisationId: { type: UUID, allowNull: false, references: { model: 'partner_organisations', key: 'id' }, onDelete: 'CASCADE' },
+      status: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'available' },
+      addedBy: { type: UUID, allowNull: false, references: { model: 'users', key: 'id' }, onDelete: 'RESTRICT' },
+      claimedBy: { type: UUID },
+      claimedAt: { type: Sequelize.DATE },
+      ...ts(),
+    });
+  }
+
+  // Indexes — always-run IF NOT EXISTS (independent of table-exists branches;
+  // the runner is non-transactional, 045/046 pattern).
+  const idx = (sql) => queryInterface.sequelize.query(sql);
+  await idx('CREATE INDEX IF NOT EXISTS idx_ot_assignee_status_due ON outreach_tasks ("assigneeUserId", "status", "dueAt")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_ot_partner_status ON outreach_tasks ("partnerOrganisationId", "status")');
+  await idx(`CREATE INDEX IF NOT EXISTS idx_ot_due_open ON outreach_tasks ("dueAt") WHERE "status" IN ('open', 'in_progress')`);
+  await idx('CREATE UNIQUE INDEX IF NOT EXISTS uq_ppm_pool_partner ON prospecting_pool_members ("poolId", "partnerOrganisationId")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_ppm_pool_status ON prospecting_pool_members ("poolId", "status")');
+}
+
+export async function down(queryInterface) {
+  for (const table of ['prospecting_pool_members', 'prospecting_pools', 'outreach_tasks']) {
+    await queryInterface.sequelize.query(`DROP TABLE IF EXISTS ${table} CASCADE`);
+  }
+}

--- a/backend/src/models/OutreachActivity.js
+++ b/backend/src/models/OutreachActivity.js
@@ -1,0 +1,37 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Outreach touchpoint on a partner (docs/redeem-ops/ERD.md §3.6). No destructive
+ * delete — corrections update in place (audited before/after via auditService) and
+ * removals set voidedAt. "Meaningful" types (everything except internal_note) bump
+ * the partner's lastActivityAt and stamp firstOutreachAt (partnerService.logActivity).
+ */
+const OutreachActivity = sequelize.define('OutreachActivity', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  partnerOrganisationId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'partner_organisations', key: 'id' }
+  },
+  contactId: { type: DataTypes.UUID, allowNull: true, references: { model: 'partner_contacts', key: 'id' } },
+  type: { type: DataTypes.STRING(32), allowNull: false, comment: 'ACTIVITY_TYPES in services/redeemOps/constants.js' },
+  direction: { type: DataTypes.STRING(12), allowNull: false, defaultValue: 'outbound', comment: 'outbound|inbound|internal' },
+  summary: { type: DataTypes.STRING(255), allowNull: false },
+  details: { type: DataTypes.TEXT, allowNull: true },
+  outcome: { type: DataTypes.STRING(64), allowNull: true },
+  occurredAt: { type: DataTypes.DATE, allowNull: false, defaultValue: DataTypes.NOW },
+  actorUserId: { type: DataTypes.UUID, allowNull: true, references: { model: 'users', key: 'id' } },
+  editedAt: { type: DataTypes.DATE, allowNull: true },
+  editedBy: { type: DataTypes.UUID, allowNull: true },
+  voidedAt: { type: DataTypes.DATE, allowNull: true },
+  voidReason: { type: DataTypes.STRING(255), allowNull: true }
+}, {
+  tableName: 'outreach_activities',
+  indexes: [
+    { fields: ['partnerOrganisationId', 'occurredAt'], name: 'idx_oa_partner_occurred' },
+    { fields: ['actorUserId', 'occurredAt'], name: 'idx_oa_actor_occurred' }
+  ]
+});
+
+export default OutreachActivity;

--- a/backend/src/models/OutreachTask.js
+++ b/backend/src/models/OutreachTask.js
@@ -1,0 +1,33 @@
+import { DataTypes, Op } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/** Structured follow-up/task (docs/redeem-ops/ERD.md §3.7) — never just a note. */
+const OutreachTask = sequelize.define('OutreachTask', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  title: { type: DataTypes.STRING(160), allowNull: false },
+  partnerOrganisationId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'partner_organisations', key: 'id' }
+  },
+  contactId: { type: DataTypes.UUID, allowNull: true, references: { model: 'partner_contacts', key: 'id' } },
+  assigneeUserId: { type: DataTypes.UUID, allowNull: false, references: { model: 'users', key: 'id' } },
+  createdBy: { type: DataTypes.UUID, allowNull: false, references: { model: 'users', key: 'id' } },
+  dueAt: { type: DataTypes.DATE, allowNull: false },
+  hasTime: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false, comment: 'false = date-only rendering' },
+  priority: { type: DataTypes.STRING(12), allowNull: false, defaultValue: 'medium', comment: 'low|medium|high' },
+  type: { type: DataTypes.STRING(24), allowNull: false, defaultValue: 'follow_up', comment: 'follow_up|call|meeting|proposal|admin|other' },
+  status: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'open', comment: 'open|in_progress|completed|cancelled' },
+  description: { type: DataTypes.TEXT, allowNull: true },
+  completedAt: { type: DataTypes.DATE, allowNull: true },
+  completedBy: { type: DataTypes.UUID, allowNull: true }
+}, {
+  tableName: 'outreach_tasks',
+  indexes: [
+    { fields: ['assigneeUserId', 'status', 'dueAt'], name: 'idx_ot_assignee_status_due' },
+    { fields: ['partnerOrganisationId', 'status'], name: 'idx_ot_partner_status' },
+    { fields: ['dueAt'], name: 'idx_ot_due_open', where: { status: { [Op.in]: ['open', 'in_progress'] } } }
+  ]
+});
+
+export default OutreachTask;

--- a/backend/src/models/PartnerAssignmentEvent.js
+++ b/backend/src/models/PartnerAssignmentEvent.js
@@ -1,0 +1,26 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/** Append-only ownership history (docs/redeem-ops/ERD.md §3.4). Never updated or deleted. */
+const PartnerAssignmentEvent = sequelize.define('PartnerAssignmentEvent', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  partnerOrganisationId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'partner_organisations', key: 'id' }
+  },
+  kind: { type: DataTypes.STRING(24), allowNull: false, comment: 'claim|assign|reassign|release|restrict|disqualify|merge' },
+  fromUserId: { type: DataTypes.UUID, allowNull: true, references: { model: 'users', key: 'id' } },
+  toUserId: { type: DataTypes.UUID, allowNull: true, references: { model: 'users', key: 'id' } },
+  actorUserId: { type: DataTypes.UUID, allowNull: true, references: { model: 'users', key: 'id' } },
+  reason: { type: DataTypes.STRING(255), allowNull: true }
+}, {
+  tableName: 'partner_assignment_events',
+  timestamps: true,
+  updatedAt: false,
+  indexes: [
+    { fields: ['partnerOrganisationId', 'createdAt'], name: 'idx_pae_partner_created' }
+  ]
+});
+
+export default PartnerAssignmentEvent;

--- a/backend/src/models/PartnerContact.js
+++ b/backend/src/models/PartnerContact.js
@@ -1,0 +1,28 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/** Person at a partner organisation (docs/redeem-ops/ERD.md §3.3). */
+const PartnerContact = sequelize.define('PartnerContact', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  partnerOrganisationId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'partner_organisations', key: 'id' }
+  },
+  name: { type: DataTypes.STRING(120), allowNull: false },
+  roleTitle: { type: DataTypes.STRING(80), allowNull: true },
+  mobile: { type: DataTypes.STRING(20), allowNull: true },
+  whatsapp: { type: DataTypes.STRING(20), allowNull: true, comment: 'Only when different from mobile' },
+  email: { type: DataTypes.STRING(160), allowNull: true },
+  preferredChannel: { type: DataTypes.STRING(24), allowNull: true, comment: 'call|whatsapp|email|instagram|other' },
+  isPrimary: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+  notes: { type: DataTypes.TEXT, allowNull: true },
+  archivedAt: { type: DataTypes.DATE, allowNull: true }
+}, {
+  tableName: 'partner_contacts',
+  indexes: [
+    { fields: ['partnerOrganisationId'], name: 'idx_pc_partner' }
+  ]
+});
+
+export default PartnerContact;

--- a/backend/src/models/PartnerLocation.js
+++ b/backend/src/models/PartnerLocation.js
@@ -1,0 +1,28 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/** Outlet of a partner organisation (docs/redeem-ops/ERD.md §3.2). */
+const PartnerLocation = sequelize.define('PartnerLocation', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  partnerOrganisationId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'partner_organisations', key: 'id' }
+  },
+  name: { type: DataTypes.STRING(120), allowNull: true },
+  addressLine: { type: DataTypes.STRING(255), allowNull: true },
+  postalCode: { type: DataTypes.STRING(6), allowNull: true },
+  postalDistrict: { type: DataTypes.STRING(2), allowNull: true, comment: 'First 2 digits of SG postal — same-area duplicate heuristics' },
+  area: { type: DataTypes.STRING(64), allowNull: true },
+  phone: { type: DataTypes.STRING(20), allowNull: true },
+  isActive: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+  notes: { type: DataTypes.TEXT, allowNull: true }
+}, {
+  tableName: 'partner_locations',
+  indexes: [
+    { fields: ['partnerOrganisationId'], name: 'idx_pl_partner' },
+    { fields: ['postalCode'], name: 'idx_pl_postal' }
+  ]
+});
+
+export default PartnerLocation;

--- a/backend/src/models/PartnerOrganisation.js
+++ b/backend/src/models/PartnerOrganisation.js
@@ -1,0 +1,84 @@
+import { DataTypes, Op } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * A business we prospect / partner with for reward supply (docs/redeem-ops/ERD.md §3.1).
+ * Display values (legalName/tradingName/…) are stored separately from normalized
+ * matching keys (normalizedName, websiteDomain, handles) — services/redeemOps/normalizers.js
+ * derives the keys; duplicate detection lives in dedupeService.js.
+ */
+const PartnerOrganisation = sequelize.define('PartnerOrganisation', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+
+  // Display identity — at least one name required (service-enforced)
+  legalName: { type: DataTypes.STRING(160), allowNull: true },
+  tradingName: { type: DataTypes.STRING(160), allowNull: true },
+  brandName: { type: DataTypes.STRING(120), allowNull: true },
+
+  // Normalized matching keys (never rendered)
+  normalizedName: { type: DataTypes.STRING(160), allowNull: false },
+  uen: { type: DataTypes.STRING(16), allowNull: true, comment: 'Uppercased ACRA UEN' },
+  website: { type: DataTypes.STRING(255), allowNull: true },
+  websiteDomain: { type: DataTypes.STRING(160), allowNull: true },
+  primaryPhone: {
+    type: DataTypes.STRING(20),
+    allowNull: true,
+    validate: {
+      isE164(value) {
+        if (value && !/^\+[1-9]\d{9,14}$/.test(value)) {
+          throw new Error('Phone must be in E.164 format (e.g. +6591234567)');
+        }
+      }
+    }
+  },
+  primaryEmail: { type: DataTypes.STRING(160), allowNull: true },
+  instagramHandle: { type: DataTypes.STRING(64), allowNull: true },
+  tiktokHandle: { type: DataTypes.STRING(64), allowNull: true },
+  facebookUrl: { type: DataTypes.STRING(255), allowNull: true },
+  facebookHandle: { type: DataTypes.STRING(120), allowNull: true },
+  linkedinUrl: { type: DataTypes.STRING(255), allowNull: true },
+
+  category: { type: DataTypes.STRING(64), allowNull: true },
+  subcategory: { type: DataTypes.STRING(64), allowNull: true },
+  source: { type: DataTypes.STRING(64), allowNull: true },
+  tags: { type: DataTypes.JSONB, allowNull: false, defaultValue: [] },
+  notes: { type: DataTypes.TEXT, allowNull: true },
+
+  // Pipeline + ownership (constants: services/redeemOps/constants.js — STRING not ENUM, house style)
+  pipelineStage: { type: DataTypes.STRING(32), allowNull: false, defaultValue: 'UNCLAIMED' },
+  availability: {
+    type: DataTypes.STRING(24),
+    allowNull: false,
+    defaultValue: 'available',
+    comment: 'available|owned|follow_up_later|restricted|disqualified — the claim gate'
+  },
+  ownerUserId: { type: DataTypes.UUID, allowNull: true, references: { model: 'users', key: 'id' } },
+  claimedAt: { type: DataTypes.DATE, allowNull: true },
+  firstOutreachAt: { type: DataTypes.DATE, allowNull: true },
+  lastActivityAt: { type: DataTypes.DATE, allowNull: true, comment: 'Denormalized for queue/stale queries' },
+  nextTaskAt: { type: DataTypes.DATE, allowNull: true, comment: 'Denormalized from open tasks (Phase 3)' },
+  atRiskFlag: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false, comment: 'Claimed >48h, no first outreach (sweep-set)' },
+  staleFlag: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false, comment: 'No meaningful activity >14d (sweep-set)' },
+
+  mergedIntoId: { type: DataTypes.UUID, allowNull: true, references: { model: 'partner_organisations', key: 'id' }, comment: 'Set on merge; row retained, hidden from lists' },
+  archivedAt: { type: DataTypes.DATE, allowNull: true },
+  createdBy: { type: DataTypes.UUID, allowNull: false, references: { model: 'users', key: 'id' } }
+}, {
+  tableName: 'partner_organisations',
+  indexes: [
+    { unique: true, fields: ['uen'], where: { uen: { [Op.ne]: null } }, name: 'uq_po_uen' },
+    { unique: true, fields: ['primaryPhone'], where: { primaryPhone: { [Op.ne]: null } }, name: 'uq_po_phone' },
+    { unique: true, fields: ['instagramHandle'], where: { instagramHandle: { [Op.ne]: null } }, name: 'uq_po_instagram' },
+    { unique: true, fields: ['tiktokHandle'], where: { tiktokHandle: { [Op.ne]: null } }, name: 'uq_po_tiktok' },
+    { fields: ['normalizedName'], name: 'idx_po_normalized_name' },
+    { fields: ['websiteDomain'], name: 'idx_po_domain' },
+    { fields: ['ownerUserId', 'pipelineStage'], name: 'idx_po_owner_stage' },
+    { fields: ['pipelineStage'], name: 'idx_po_stage' },
+    { fields: ['availability'], name: 'idx_po_availability' },
+    { fields: ['category'], name: 'idx_po_category' },
+    { fields: ['lastActivityAt'], name: 'idx_po_last_activity' },
+    { fields: ['nextTaskAt'], name: 'idx_po_next_task' }
+  ]
+});
+
+export default PartnerOrganisation;

--- a/backend/src/models/PartnerStageEvent.js
+++ b/backend/src/models/PartnerStageEvent.js
@@ -1,0 +1,25 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/** Append-only pipeline-stage history (docs/redeem-ops/ERD.md §3.5). */
+const PartnerStageEvent = sequelize.define('PartnerStageEvent', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  partnerOrganisationId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'partner_organisations', key: 'id' }
+  },
+  fromStage: { type: DataTypes.STRING(32), allowNull: true },
+  toStage: { type: DataTypes.STRING(32), allowNull: false },
+  actorUserId: { type: DataTypes.UUID, allowNull: true, references: { model: 'users', key: 'id' } },
+  reason: { type: DataTypes.STRING(255), allowNull: true }
+}, {
+  tableName: 'partner_stage_events',
+  timestamps: true,
+  updatedAt: false,
+  indexes: [
+    { fields: ['partnerOrganisationId', 'createdAt'], name: 'idx_pse_partner_created' }
+  ]
+});
+
+export default PartnerStageEvent;

--- a/backend/src/models/ProspectingPool.js
+++ b/backend/src/models/ProspectingPool.js
@@ -1,0 +1,17 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/** Manager-curated prospect list, e.g. "Pet Groomers — East" (docs/redeem-ops/ERD.md §3.8). */
+const ProspectingPool = sequelize.define('ProspectingPool', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  name: { type: DataTypes.STRING(120), allowNull: false, unique: true },
+  description: { type: DataTypes.TEXT, allowNull: true },
+  category: { type: DataTypes.STRING(64), allowNull: true },
+  area: { type: DataTypes.STRING(64), allowNull: true },
+  isActive: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+  createdBy: { type: DataTypes.UUID, allowNull: false, references: { model: 'users', key: 'id' } }
+}, {
+  tableName: 'prospecting_pools'
+});
+
+export default ProspectingPool;

--- a/backend/src/models/ProspectingPoolMember.js
+++ b/backend/src/models/ProspectingPoolMember.js
@@ -1,0 +1,25 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/** Pool membership (docs/redeem-ops/ERD.md §3.9). claim-next consumes 'available' rows. */
+const ProspectingPoolMember = sequelize.define('ProspectingPoolMember', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  poolId: { type: DataTypes.UUID, allowNull: false, references: { model: 'prospecting_pools', key: 'id' } },
+  partnerOrganisationId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'partner_organisations', key: 'id' }
+  },
+  status: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'available', comment: 'available|claimed|removed' },
+  addedBy: { type: DataTypes.UUID, allowNull: false, references: { model: 'users', key: 'id' } },
+  claimedBy: { type: DataTypes.UUID, allowNull: true },
+  claimedAt: { type: DataTypes.DATE, allowNull: true }
+}, {
+  tableName: 'prospecting_pool_members',
+  indexes: [
+    { unique: true, fields: ['poolId', 'partnerOrganisationId'], name: 'uq_ppm_pool_partner' },
+    { fields: ['poolId', 'status'], name: 'idx_ppm_pool_status' }
+  ]
+});
+
+export default ProspectingPoolMember;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -164,10 +164,45 @@ function defineAssociations() {
   AgentGroupMember.belongsTo(AgentGroup, { foreignKey: 'agentGroupId', as: 'group' });
   AgentGroupMember.belongsTo(User, { foreignKey: 'userId', as: 'user', onDelete: 'SET NULL' });
 
-  // Redeem Ops associations (Phase 1 — docs/redeem-ops/ERD.md §3.19). Audit rows
-  // are append-only and must survive actor deletion: SET NULL, never cascade.
-  const { RedeemOpsAuditEvent } = models;
+  // Redeem Ops associations (docs/redeem-ops/ERD.md). Append-only history/audit
+  // rows must survive actor deletion: SET NULL, never cascade from users.
+  const {
+    RedeemOpsAuditEvent, PartnerOrganisation, PartnerLocation, PartnerContact,
+    PartnerAssignmentEvent, PartnerStageEvent, OutreachActivity,
+  } = models;
   RedeemOpsAuditEvent.belongsTo(User, { foreignKey: 'actorUserId', as: 'actor', onDelete: 'SET NULL' });
+
+  // Partner CRM (Phase 2)
+  PartnerOrganisation.belongsTo(User, { foreignKey: 'ownerUserId', as: 'owner', onDelete: 'SET NULL' });
+  PartnerOrganisation.belongsTo(User, { foreignKey: 'createdBy', as: 'creator', onDelete: 'RESTRICT' });
+  PartnerOrganisation.belongsTo(PartnerOrganisation, { foreignKey: 'mergedIntoId', as: 'mergedInto', onDelete: 'SET NULL' });
+  PartnerOrganisation.hasMany(PartnerLocation, { foreignKey: 'partnerOrganisationId', as: 'locations', onDelete: 'CASCADE' });
+  PartnerLocation.belongsTo(PartnerOrganisation, { foreignKey: 'partnerOrganisationId', as: 'partner' });
+  PartnerOrganisation.hasMany(PartnerContact, { foreignKey: 'partnerOrganisationId', as: 'contacts', onDelete: 'CASCADE' });
+  PartnerContact.belongsTo(PartnerOrganisation, { foreignKey: 'partnerOrganisationId', as: 'partner' });
+  PartnerOrganisation.hasMany(PartnerAssignmentEvent, { foreignKey: 'partnerOrganisationId', as: 'assignmentEvents', onDelete: 'CASCADE' });
+  PartnerAssignmentEvent.belongsTo(PartnerOrganisation, { foreignKey: 'partnerOrganisationId', as: 'partner' });
+  PartnerAssignmentEvent.belongsTo(User, { foreignKey: 'actorUserId', as: 'actor', onDelete: 'SET NULL' });
+  PartnerAssignmentEvent.belongsTo(User, { foreignKey: 'fromUserId', as: 'fromUser', onDelete: 'SET NULL' });
+  PartnerAssignmentEvent.belongsTo(User, { foreignKey: 'toUserId', as: 'toUser', onDelete: 'SET NULL' });
+  PartnerOrganisation.hasMany(PartnerStageEvent, { foreignKey: 'partnerOrganisationId', as: 'stageEvents', onDelete: 'CASCADE' });
+  PartnerStageEvent.belongsTo(PartnerOrganisation, { foreignKey: 'partnerOrganisationId', as: 'partner' });
+  PartnerStageEvent.belongsTo(User, { foreignKey: 'actorUserId', as: 'actor', onDelete: 'SET NULL' });
+  PartnerOrganisation.hasMany(OutreachActivity, { foreignKey: 'partnerOrganisationId', as: 'activities', onDelete: 'CASCADE' });
+  OutreachActivity.belongsTo(PartnerOrganisation, { foreignKey: 'partnerOrganisationId', as: 'partner' });
+  OutreachActivity.belongsTo(PartnerContact, { foreignKey: 'contactId', as: 'contact', onDelete: 'SET NULL' });
+  OutreachActivity.belongsTo(User, { foreignKey: 'actorUserId', as: 'actor', onDelete: 'SET NULL' });
+
+  // Outreach work (Phase 3)
+  const { OutreachTask, ProspectingPool, ProspectingPoolMember } = models;
+  PartnerOrganisation.hasMany(OutreachTask, { foreignKey: 'partnerOrganisationId', as: 'tasks', onDelete: 'CASCADE' });
+  OutreachTask.belongsTo(PartnerOrganisation, { foreignKey: 'partnerOrganisationId', as: 'partner' });
+  OutreachTask.belongsTo(PartnerContact, { foreignKey: 'contactId', as: 'contact', onDelete: 'SET NULL' });
+  OutreachTask.belongsTo(User, { foreignKey: 'assigneeUserId', as: 'assignee', onDelete: 'CASCADE' });
+  OutreachTask.belongsTo(User, { foreignKey: 'createdBy', as: 'creator', onDelete: 'RESTRICT' });
+  ProspectingPool.hasMany(ProspectingPoolMember, { foreignKey: 'poolId', as: 'members', onDelete: 'CASCADE' });
+  ProspectingPoolMember.belongsTo(ProspectingPool, { foreignKey: 'poolId', as: 'pool' });
+  ProspectingPoolMember.belongsTo(PartnerOrganisation, { foreignKey: 'partnerOrganisationId', as: 'partner', onDelete: 'CASCADE' });
 }
 
 defineAssociations();
@@ -201,7 +236,9 @@ export const {
   Vehicle, WebhookSubscriber, WebhookDelivery, AgentGroup,
   AgentGroupMember, DeviceCampaignAssignment, VehicleCampaignAssignment,
   CampaignMediaItem, CampaignAgentAssignment, ExternalAgent, ExternalCampaignAgent,
-  WaitlistSignup, RedeemOpsAuditEvent
+  WaitlistSignup, RedeemOpsAuditEvent, PartnerOrganisation, PartnerLocation,
+  PartnerContact, PartnerAssignmentEvent, PartnerStageEvent, OutreachActivity,
+  OutreachTask, ProspectingPool, ProspectingPoolMember
 } = models;
 
 export { sequelize };

--- a/backend/src/routes/redeemOpsPartners.js
+++ b/backend/src/routes/redeemOpsPartners.js
@@ -1,0 +1,52 @@
+import express from 'express';
+import { requireRedeemOps } from '../middleware/redeemOpsAuth.js';
+import * as ctrl from '../controllers/redeemOps/partnersController.js';
+
+/**
+ * Redeem Ops Phase 2 — Partner CRM (docs/redeem-ops/ROUTE_MAP.md §1).
+ * Same flag + host-guard posture as redeemOpsAdmin.js. Capability names map to
+ * docs/redeem-ops/PERMISSION_MATRIX.md; row-level "own" scoping is enforced in
+ * partnerService/claimService, not here.
+ */
+export const meta = {
+  path: '/api/redeem-ops',
+  flag: 'REDEEM_OPS_ENABLED',
+  flagDefault: 'false',
+};
+
+const router = express.Router();
+
+// Partners
+router.get('/partners', requireRedeemOps('partners.view'), ctrl.listPartners);
+router.get('/partners/check-duplicates', requireRedeemOps('partners.create'), ctrl.checkDuplicates);
+router.post('/partners', requireRedeemOps('partners.create'), ctrl.createPartner);
+router.get('/partners/:id', requireRedeemOps('partners.view'), ctrl.getPartner);
+router.put('/partners/:id', requireRedeemOps('partners.edit'), ctrl.updatePartner);
+
+// Ownership
+router.post('/partners/:id/claim', requireRedeemOps('partners.claim'), ctrl.claimPartner);
+router.post('/partners/:id/release', requireRedeemOps('partners.release'), ctrl.releasePartner);
+router.post('/partners/:id/assign', requireRedeemOps('partners.reassign'), ctrl.assignPartner);
+
+// Pipeline
+router.patch('/partners/:id/stage', requireRedeemOps('pipeline.move'), ctrl.changeStage);
+
+// Merge (destructive-adjacent — ops_admin+)
+router.post('/partners/:id/merge', requireRedeemOps('partners.merge'), ctrl.mergePartners);
+
+// Timeline + activities
+router.get('/partners/:id/timeline', requireRedeemOps('partners.view'), ctrl.getTimeline);
+router.post('/partners/:id/activities', requireRedeemOps('activities.log'), ctrl.logActivity);
+router.patch('/activities/:activityId', requireRedeemOps('activities.edit'), ctrl.editActivity);
+router.post('/activities/:activityId/void', requireRedeemOps('activities.edit'), ctrl.voidActivity);
+
+// Contacts
+router.post('/partners/:id/contacts', requireRedeemOps('contacts.manage'), ctrl.addContact);
+router.patch('/contacts/:contactId', requireRedeemOps('contacts.manage'), ctrl.updateContact);
+router.post('/contacts/:contactId/archive', requireRedeemOps('contacts.manage'), ctrl.archiveContact);
+
+// Locations
+router.post('/partners/:id/locations', requireRedeemOps('locations.manage'), ctrl.addLocation);
+router.patch('/locations/:locationId', requireRedeemOps('locations.manage'), ctrl.updateLocation);
+
+export default router;

--- a/backend/src/routes/redeemOpsWork.js
+++ b/backend/src/routes/redeemOpsWork.js
@@ -1,0 +1,35 @@
+import express from 'express';
+import { requireRedeemOps } from '../middleware/redeemOpsAuth.js';
+import * as ctrl from '../controllers/redeemOps/workController.js';
+
+/**
+ * Redeem Ops Phase 3 — queue, tasks, pools, team pipeline
+ * (docs/redeem-ops/ROUTE_MAP.md §1). Flag + host-guard posture as siblings.
+ */
+export const meta = {
+  path: '/api/redeem-ops',
+  flag: 'REDEEM_OPS_ENABLED',
+  flagDefault: 'false',
+};
+
+const router = express.Router();
+
+// My Outreach Queue — every ops principal has a queue
+router.get('/queue', requireRedeemOps('analytics.view_own'), ctrl.getMyQueue);
+
+// Team pipeline board (managers/analysts)
+router.get('/team/pipeline', requireRedeemOps('pipeline.view_team'), ctrl.getTeamPipeline);
+
+// Tasks (row-level own/team scoping inside taskService)
+router.get('/tasks', requireRedeemOps('tasks.manage'), ctrl.listTasks);
+router.post('/tasks', requireRedeemOps('tasks.manage'), ctrl.createTask);
+router.patch('/tasks/:taskId', requireRedeemOps('tasks.manage'), ctrl.updateTask);
+
+// Prospecting pools — reading + claim-next for execs; management for bdm+
+router.get('/pools', requireRedeemOps('pools.claim_next'), ctrl.listPools);
+router.post('/pools', requireRedeemOps('pools.manage'), ctrl.createPool);
+router.patch('/pools/:poolId', requireRedeemOps('pools.manage'), ctrl.updatePool);
+router.post('/pools/:poolId/members', requireRedeemOps('pools.manage'), ctrl.addPoolMembers);
+router.post('/pools/:poolId/claim-next', requireRedeemOps('pools.claim_next'), ctrl.claimNext);
+
+export default router;

--- a/backend/src/services/redeemOps/claimService.js
+++ b/backend/src/services/redeemOps/claimService.js
@@ -1,4 +1,3 @@
-import { QueryTypes } from 'sequelize';
 import { PartnerOrganisation, PartnerAssignmentEvent, PartnerStageEvent, User, sequelize } from '../../models/index.js';
 import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';

--- a/backend/src/services/redeemOps/claimService.js
+++ b/backend/src/services/redeemOps/claimService.js
@@ -1,0 +1,170 @@
+import { QueryTypes } from 'sequelize';
+import { PartnerOrganisation, PartnerAssignmentEvent, PartnerStageEvent, User, sequelize } from '../../models/index.js';
+import { AppError } from '../../middleware/errorHandler.js';
+import { logger } from '../../utils/logger.js';
+import { makeRedeemOpsAuditService } from './auditService.js';
+
+/**
+ * Business claiming / ownership (docs/redeem-ops/ERD.md §4.1, brief §15).
+ *
+ * The claim is ONE conditional UPDATE (house pattern: deductExternalLeadBalance) —
+ * two simultaneous claimers can never both win, regardless of instance count.
+ * 0 rows updated → typed 409 telling the loser who has it. History rows
+ * (assignment + stage events) and the audit entry commit atomically with the claim.
+ */
+export function makeClaimService(overrides = {}) {
+  const d = {
+    PartnerOrganisation, PartnerAssignmentEvent, PartnerStageEvent, User, sequelize, logger,
+    audit: makeRedeemOpsAuditService(), ...overrides,
+  };
+
+  async function conflictPayload(partnerId) {
+    const row = await d.PartnerOrganisation.findByPk(partnerId, {
+      attributes: ['id', 'availability', 'pipelineStage', 'ownerUserId', 'archivedAt', 'mergedIntoId'],
+      include: [{ model: d.User, as: 'owner', attributes: ['id', 'fullName'] }],
+    });
+    return row ? {
+      availability: row.availability,
+      pipelineStage: row.pipelineStage,
+      claimedBy: row.owner ? { id: row.owner.id, fullName: row.owner.fullName } : null,
+      archived: !!row.archivedAt,
+      merged: !!row.mergedIntoId,
+    } : null;
+  }
+
+  /**
+   * The atomic claim WITHIN a caller-owned transaction. Returns the updated row
+   * or null when the conditional UPDATE matched nothing (already owned /
+   * restricted / archived / merged). Shared by the direct claim endpoint and
+   * the Phase 3 pool claim-next loop.
+   */
+  async function claimPartnerTx(partnerId, user, t, via = 'claim') {
+    const [rows] = await d.sequelize.query(
+      `UPDATE partner_organisations
+          SET "ownerUserId" = :userId,
+              "claimedAt" = NOW(),
+              availability = 'owned',
+              "pipelineStage" = CASE WHEN "pipelineStage" = 'UNCLAIMED' THEN 'CLAIMED' ELSE "pipelineStage" END,
+              "updatedAt" = NOW()
+        WHERE id = :partnerId
+          AND "ownerUserId" IS NULL
+          AND availability = 'available'
+          AND "archivedAt" IS NULL
+          AND "mergedIntoId" IS NULL
+        RETURNING id, "pipelineStage"`,
+      { replacements: { partnerId, userId: user.id }, transaction: t }
+    );
+    if (!Array.isArray(rows) || rows.length === 0) return null;
+
+    await d.PartnerAssignmentEvent.create(
+      { partnerOrganisationId: partnerId, kind: 'claim', toUserId: user.id, actorUserId: user.id, reason: via === 'claim' ? null : via },
+      { transaction: t }
+    );
+    await d.PartnerStageEvent.create(
+      { partnerOrganisationId: partnerId, fromStage: 'UNCLAIMED', toStage: rows[0].pipelineStage, actorUserId: user.id, reason: via },
+      { transaction: t }
+    );
+    await d.audit.recordAuditEvent({
+      actorUser: user, action: 'partner.claimed', entityType: 'partner_organisation',
+      entityId: partnerId, reason: via === 'claim' ? null : via, transaction: t,
+    });
+    return rows[0];
+  }
+
+  /** Atomic claim: available + unowned + live → owned by `user`. 409 with state on loss. */
+  async function claimPartner(partnerId, user, requestId = null) {
+    return d.sequelize.transaction(async (t) => {
+      const claimed = await claimPartnerTx(partnerId, user, t);
+      if (!claimed) {
+        const state = await conflictPayload(partnerId);
+        if (!state) throw new AppError('Partner not found', 404);
+        const err = new AppError(
+          state.claimedBy
+            ? 'This business has just been claimed by another team member.'
+            : 'This business is not available to claim.',
+          409
+        );
+        err.data = state;
+        throw err;
+      }
+      return claimed;
+    });
+  }
+
+  /** Owner releases their claim back to the pool (row-level own check here). */
+  async function releasePartner(partnerId, user, reason = null, requestId = null) {
+    return d.sequelize.transaction(async (t) => {
+      const [rows] = await d.sequelize.query(
+        `UPDATE partner_organisations
+            SET "ownerUserId" = NULL,
+                availability = 'available',
+                "atRiskFlag" = FALSE,
+                "updatedAt" = NOW()
+          WHERE id = :partnerId
+            AND "ownerUserId" = :userId
+            AND "archivedAt" IS NULL
+            AND "mergedIntoId" IS NULL
+          RETURNING id`,
+        { replacements: { partnerId, userId: user.id }, transaction: t }
+      );
+      if (!Array.isArray(rows) || rows.length === 0) {
+        throw new AppError('You can only release a business you currently own.', 403);
+      }
+      await d.PartnerAssignmentEvent.create(
+        { partnerOrganisationId: partnerId, kind: 'release', fromUserId: user.id, actorUserId: user.id, reason },
+        { transaction: t }
+      );
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'partner.released', entityType: 'partner_organisation',
+        entityId: partnerId, reason, requestId, transaction: t,
+      });
+      return rows[0];
+    });
+  }
+
+  /** Manager assign/reassign to any active staff member (capability-gated at the route). */
+  async function assignPartner(partnerId, toUserId, actor, reason = null, requestId = null) {
+    const target = await d.User.findByPk(toUserId);
+    if (!target || !target.isActive || !(target.role === 'redeem_ops' || target.role === 'admin' || target.redeemOpsRole)) {
+      throw new AppError('Assignee must be an active Redeem Ops staff member', 400);
+    }
+    return d.sequelize.transaction(async (t) => {
+      const partner = await d.PartnerOrganisation.findByPk(partnerId, { transaction: t, lock: t.LOCK.UPDATE });
+      if (!partner || partner.archivedAt || partner.mergedIntoId) {
+        throw new AppError('Partner not found', 404);
+      }
+      const fromUserId = partner.ownerUserId;
+      await partner.update(
+        {
+          ownerUserId: toUserId,
+          availability: 'owned',
+          claimedAt: partner.claimedAt || new Date(),
+          atRiskFlag: false,
+          pipelineStage: partner.pipelineStage === 'UNCLAIMED' ? 'CLAIMED' : partner.pipelineStage,
+        },
+        { transaction: t }
+      );
+      await d.PartnerAssignmentEvent.create(
+        {
+          partnerOrganisationId: partnerId,
+          kind: fromUserId ? 'reassign' : 'assign',
+          fromUserId, toUserId, actorUserId: actor.id, reason,
+        },
+        { transaction: t }
+      );
+      await d.audit.recordAuditEvent({
+        actorUser: actor, action: 'partner.reassigned', entityType: 'partner_organisation',
+        entityId: partnerId, before: { ownerUserId: fromUserId }, after: { ownerUserId: toUserId },
+        reason, requestId, transaction: t,
+      });
+      return partner;
+    });
+  }
+
+  return { claimPartner, claimPartnerTx, releasePartner, assignPartner };
+}
+
+const _default = makeClaimService();
+export const claimPartner = _default.claimPartner;
+export const releasePartner = _default.releasePartner;
+export const assignPartner = _default.assignPartner;

--- a/backend/src/services/redeemOps/constants.js
+++ b/backend/src/services/redeemOps/constants.js
@@ -24,6 +24,35 @@ export const PIPELINE_STAGES = [
 
 export const PARTNER_AVAILABILITY = ['available', 'owned', 'follow_up_later', 'restricted', 'disqualified'];
 
+/**
+ * Allowed pipeline transitions (docs/redeem-ops/ERD.md §6). Server-enforced in
+ * partnerService.changeStage — drag-and-drop or API, same rules. super_admin /
+ * ops_admin may force any transition (audited with a required reason).
+ */
+export const STAGE_TRANSITIONS = {
+  UNCLAIMED: ['CLAIMED'],
+  CLAIMED: ['RESEARCHING', 'CONTACTED', 'FOLLOW_UP_LATER', 'NO_RESPONSE', 'NOT_INTERESTED', 'DISQUALIFIED'],
+  RESEARCHING: ['CONTACTED', 'FOLLOW_UP_LATER', 'NOT_INTERESTED', 'DISQUALIFIED'],
+  CONTACTED: ['REPLIED', 'NO_RESPONSE', 'FOLLOW_UP_LATER', 'NOT_INTERESTED', 'DISQUALIFIED'],
+  REPLIED: ['MEETING_BOOKED', 'PROPOSAL_SENT', 'FOLLOW_UP_LATER', 'NOT_INTERESTED', 'DISQUALIFIED'],
+  MEETING_BOOKED: ['MEETING_COMPLETED', 'NO_RESPONSE', 'FOLLOW_UP_LATER', 'NOT_INTERESTED'],
+  MEETING_COMPLETED: ['PROPOSAL_SENT', 'NEGOTIATING', 'PARTNERED', 'FOLLOW_UP_LATER', 'NOT_INTERESTED'],
+  PROPOSAL_SENT: ['NEGOTIATING', 'PARTNERED', 'NO_RESPONSE', 'FOLLOW_UP_LATER', 'NOT_INTERESTED'],
+  NEGOTIATING: ['PARTNERED', 'PROPOSAL_SENT', 'FOLLOW_UP_LATER', 'NOT_INTERESTED'],
+  PARTNERED: ['FOLLOW_UP_LATER'],
+  FOLLOW_UP_LATER: ['CONTACTED', 'REPLIED', 'MEETING_BOOKED', 'PROPOSAL_SENT', 'NEGOTIATING', 'NOT_INTERESTED', 'DISQUALIFIED'],
+  NO_RESPONSE: ['CONTACTED', 'FOLLOW_UP_LATER', 'NOT_INTERESTED', 'DISQUALIFIED'],
+  NOT_INTERESTED: ['FOLLOW_UP_LATER', 'CONTACTED'],
+  DISQUALIFIED: [],
+};
+
+/** Activity types that count as real outreach (bump lastActivityAt / clear flags). */
+export const MEANINGFUL_ACTIVITY_TYPES = [
+  'call_attempt', 'call_connected', 'whatsapp_sent', 'whatsapp_reply', 'email_sent',
+  'email_reply', 'instagram_dm', 'facebook_message', 'meeting_booked',
+  'meeting_completed', 'proposal_sent', 'follow_up',
+];
+
 export const ACTIVITY_TYPES = [
   'call_attempt',
   'call_connected',
@@ -69,6 +98,7 @@ export const SUB_ROLE_LABELS = {
 export function publicConstants() {
   return {
     pipelineStages: PIPELINE_STAGES,
+    stageTransitions: STAGE_TRANSITIONS,
     partnerAvailability: PARTNER_AVAILABILITY,
     activityTypes: ACTIVITY_TYPES,
     rewardTypes: REWARD_TYPES,

--- a/backend/src/services/redeemOps/dedupeService.js
+++ b/backend/src/services/redeemOps/dedupeService.js
@@ -1,0 +1,133 @@
+import { QueryTypes, Op } from 'sequelize';
+import { PartnerOrganisation, User, sequelize } from '../../models/index.js';
+import { logger } from '../../utils/logger.js';
+import { normalizeBusinessName, normalizeDomain, normalizeHandle, normalizeUen } from './normalizers.js';
+
+/**
+ * Duplicate business detection (docs/redeem-ops/ERD.md §5, brief §14).
+ *
+ * Tiers:
+ *  - EXACT  — same UEN / phone / website domain / social handle / normalized name.
+ *             Creating over an exact match requires an explicit overrideReason.
+ *  - POTENTIAL — similar normalized name (pg_trgm similarity ≥ 0.55 when the
+ *             extension is available, else shared 12-char prefix), surfaced as a
+ *             warning with owner/stage/last-activity so the user can decide
+ *             (open existing / add as location / continue with reason).
+ *
+ * Merged and archived rows never match (they're not contactable records).
+ */
+export function makeDedupeService(overrides = {}) {
+  const d = { PartnerOrganisation, User, sequelize, logger, ...overrides };
+
+  let _trgmAvailable = null;
+  async function trgmAvailable() {
+    if (_trgmAvailable !== null) return _trgmAvailable;
+    try {
+      const rows = await d.sequelize.query(
+        `SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm'`,
+        { type: QueryTypes.SELECT }
+      );
+      _trgmAvailable = rows.length > 0;
+    } catch {
+      _trgmAvailable = false;
+    }
+    return _trgmAvailable;
+  }
+
+  const LIVE = { mergedIntoId: null, archivedAt: null };
+  const MATCH_ATTRS = [
+    'id', 'legalName', 'tradingName', 'brandName', 'pipelineStage', 'availability',
+    'ownerUserId', 'lastActivityAt', 'category', 'uen', 'primaryPhone',
+    'websiteDomain', 'instagramHandle', 'tiktokHandle',
+  ];
+
+  function toMatch(row, reason, tier) {
+    return { tier, reason, partner: row };
+  }
+
+  /**
+   * @param {object} probe  Raw form values (un-normalized OK — normalized here)
+   * @param {string|null} excludeId  The record being edited (skip self-matches)
+   * @returns {{ exact: Match[], potential: Match[] }}
+   */
+  async function findDuplicates(probe, excludeId = null) {
+    const uen = normalizeUen(probe.uen);
+    const phone = probe.primaryPhone && String(probe.primaryPhone).trim() ? String(probe.primaryPhone).trim() : null;
+    const domain = normalizeDomain(probe.website) || (probe.websiteDomain ? String(probe.websiteDomain).toLowerCase() : null);
+    const instagram = normalizeHandle(probe.instagramHandle);
+    const tiktok = normalizeHandle(probe.tiktokHandle);
+    const name = normalizeBusinessName(probe.tradingName || probe.brandName || probe.legalName || probe.name || '');
+
+    const exact = [];
+    const seen = new Set(excludeId ? [excludeId] : []);
+    const include = [{ model: d.User, as: 'owner', attributes: ['id', 'fullName'] }];
+
+    const exactChecks = [
+      [uen, { uen }, 'Same UEN'],
+      [phone, { primaryPhone: phone }, 'Same phone number'],
+      [domain, { websiteDomain: domain }, 'Same website domain'],
+      [instagram, { instagramHandle: instagram }, 'Same Instagram handle'],
+      [tiktok, { tiktokHandle: tiktok }, 'Same TikTok handle'],
+      [name, { normalizedName: name }, 'Same business name (normalized)'],
+    ];
+    for (const [value, where, reason] of exactChecks) {
+      if (!value) continue;
+      const rows = await d.PartnerOrganisation.findAll({
+        where: { ...where, ...LIVE }, attributes: MATCH_ATTRS, include, limit: 5,
+      });
+      for (const row of rows) {
+        if (seen.has(row.id)) continue;
+        seen.add(row.id);
+        exact.push(toMatch(row, reason, 'exact'));
+      }
+    }
+
+    // Potential tier — fuzzy name
+    const potential = [];
+    if (name) {
+      let rows = [];
+      if (await trgmAvailable()) {
+        rows = await d.sequelize.query(
+          `SELECT id FROM partner_organisations
+            WHERE "mergedIntoId" IS NULL AND "archivedAt" IS NULL
+              AND similarity("normalizedName", :name) >= 0.55
+              AND "normalizedName" <> :name
+            ORDER BY similarity("normalizedName", :name) DESC
+            LIMIT 5`,
+          { replacements: { name }, type: QueryTypes.SELECT }
+        );
+      } else if (name.length >= 12) {
+        rows = await d.PartnerOrganisation.findAll({
+          where: {
+            ...LIVE,
+            normalizedName: { [Op.like]: `${name.slice(0, 12)}%`, [Op.ne]: name },
+          },
+          attributes: ['id'],
+          limit: 5,
+        });
+      }
+      const ids = rows.map((r) => r.id).filter((id) => !seen.has(id));
+      if (ids.length) {
+        const full = await d.PartnerOrganisation.findAll({
+          where: { id: ids }, attributes: MATCH_ATTRS, include,
+        });
+        for (const row of full) {
+          seen.add(row.id);
+          const sameCategory = probe.category && row.category === probe.category;
+          potential.push(toMatch(
+            row,
+            `Similar business name${sameCategory ? ` in the same category (${row.category})` : ''}`,
+            'potential'
+          ));
+        }
+      }
+    }
+
+    return { exact, potential };
+  }
+
+  return { findDuplicates, trgmAvailable };
+}
+
+const _default = makeDedupeService();
+export const findDuplicates = _default.findDuplicates;

--- a/backend/src/services/redeemOps/normalizers.js
+++ b/backend/src/services/redeemOps/normalizers.js
@@ -1,0 +1,95 @@
+/**
+ * Normalization for partner matching (docs/redeem-ops/ERD.md §5, brief §34).
+ * Display values are stored as entered; these derive the SEPARATE matching keys.
+ * Dependency-free on purpose (unit-tested without a DB).
+ */
+
+/** Legal suffixes stripped ONLY from the end of a name, longest first. */
+const LEGAL_SUFFIXES = [
+  'private limited', 'pte ltd', 'pte. ltd.', 'pte. ltd', 'pte ltd.',
+  'limited', 'llp', 'llc', 'ltd', 'pl', 'inc',
+];
+
+/** Lowercase, strip punctuation, collapse whitespace, cautiously strip a trailing legal suffix. */
+export function normalizeBusinessName(input) {
+  if (!input || typeof input !== 'string') return null;
+  let s = input
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ') // punctuation → space (keeps unicode letters/digits)
+    .replace(/\s+/g, ' ')
+    .trim();
+  for (const suffix of LEGAL_SUFFIXES) {
+    const clean = suffix.replace(/[^\p{L}\p{N}\s]/gu, ' ').replace(/\s+/g, ' ').trim();
+    if (s.endsWith(` ${clean}`)) {
+      s = s.slice(0, -clean.length - 1).trim();
+      break; // strip at most one suffix — never mid-name tokens
+    }
+  }
+  return s || null;
+}
+
+/** Host key for a website: lowercase, strip scheme/www/path/port. */
+export function normalizeDomain(input) {
+  if (!input || typeof input !== 'string') return null;
+  let s = input.trim().toLowerCase();
+  if (!s) return null;
+  if (!/^[a-z][a-z0-9+.-]*:\/\//.test(s)) s = `https://${s}`;
+  try {
+    let host = new URL(s).hostname;
+    if (host.startsWith('www.')) host = host.slice(4);
+    return host || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Social handle key: accepts '@handle', 'handle', or a profile URL
+ * ('instagram.com/nailbliss.sg' → 'nailbliss.sg'). Lowercased, no '@'.
+ */
+export function normalizeHandle(input) {
+  if (!input || typeof input !== 'string') return null;
+  let s = input.trim().toLowerCase();
+  if (!s) return null;
+  if (s.includes('/')) {
+    if (!/^[a-z][a-z0-9+.-]*:\/\//.test(s)) s = `https://${s}`;
+    try {
+      const path = new URL(s).pathname.split('/').filter(Boolean);
+      s = path[0] === 'p' || path[0] === 'reel' ? '' : (path[0] || '');
+    } catch {
+      return null;
+    }
+  }
+  s = s.replace(/^@/, '').replace(/[?#].*$/, '').trim();
+  return s || null;
+}
+
+/** UEN: uppercase, alphanumeric only. */
+export function normalizeUen(input) {
+  if (!input || typeof input !== 'string') return null;
+  const s = input.toUpperCase().replace(/[^A-Z0-9]/g, '');
+  return s || null;
+}
+
+/** First two digits of a 6-digit SG postal code (district-ish area key). */
+export function postalDistrictOf(postalCode) {
+  if (!postalCode) return null;
+  const s = String(postalCode).trim();
+  return /^\d{6}$/.test(s) ? s.slice(0, 2) : null;
+}
+
+/**
+ * Derive all matching keys from a partner payload (used on create AND update so
+ * keys can never drift from display values).
+ */
+export function deriveMatchingKeys(body) {
+  const displayName = body.tradingName || body.brandName || body.legalName || '';
+  return {
+    normalizedName: normalizeBusinessName(displayName),
+    uen: normalizeUen(body.uen),
+    websiteDomain: normalizeDomain(body.website),
+    instagramHandle: normalizeHandle(body.instagramHandle),
+    tiktokHandle: normalizeHandle(body.tiktokHandle),
+    facebookHandle: normalizeHandle(body.facebookUrl || body.facebookHandle),
+  };
+}

--- a/backend/src/services/redeemOps/partnerService.js
+++ b/backend/src/services/redeemOps/partnerService.js
@@ -1,0 +1,517 @@
+import { Op } from 'sequelize';
+import {
+  PartnerOrganisation, PartnerLocation, PartnerContact, PartnerAssignmentEvent,
+  PartnerStageEvent, OutreachActivity, User, sequelize,
+} from '../../models/index.js';
+import { AppError } from '../../middleware/errorHandler.js';
+import { logger } from '../../utils/logger.js';
+import { makeRedeemOpsAuditService } from './auditService.js';
+import { makeDedupeService } from './dedupeService.js';
+import { hasCapability } from './permissions.js';
+import { deriveMatchingKeys, postalDistrictOf } from './normalizers.js';
+import {
+  PIPELINE_STAGES, STAGE_TRANSITIONS, PARTNER_AVAILABILITY,
+  ACTIVITY_TYPES, MEANINGFUL_ACTIVITY_TYPES,
+} from './constants.js';
+
+/**
+ * Partner CRM core (docs/redeem-ops/ERD.md §3.1–3.6, brief §13–§18).
+ * Row-level "own" scoping lives HERE (not in middleware): outreach_execs act only
+ * on partners they own; managers (bdm/ops_admin/super_admin/admin) act on any.
+ */
+export function makePartnerService(overrides = {}) {
+  const d = {
+    PartnerOrganisation, PartnerLocation, PartnerContact, PartnerAssignmentEvent,
+    PartnerStageEvent, OutreachActivity, User, sequelize, logger,
+    audit: makeRedeemOpsAuditService(),
+    dedupe: makeDedupeService(),
+    // PARTNERED hook — Phase 4 injects the onboarding-checklist seed here
+    // (changeStage guards on typeof, so null = no-op until then).
+    onPartnered: null,
+    ...overrides,
+  };
+
+  const LIVE = { mergedIntoId: null };
+  const OWNER_INCLUDE = { model: d.User, as: 'owner', attributes: ['id', 'fullName', 'email'] };
+
+  /** Managers act on any row; everyone else must own it. */
+  function canActOnRow(user, partner) {
+    if (!user) return false;
+    if (user.role === 'admin') return true;
+    if (['super_admin', 'ops_admin', 'bdm'].includes(user.redeemOpsRole)) return true;
+    return partner.ownerUserId === user.id;
+  }
+
+  async function getLivePartner(id, options = {}) {
+    const partner = await d.PartnerOrganisation.findByPk(id, options);
+    if (!partner || partner.mergedIntoId) throw new AppError('Partner not found', 404);
+    return partner;
+  }
+
+  // ── List / detail ────────────────────────────────────────────────────────
+
+  async function listPartners(query, user) {
+    const page = Math.max(1, parseInt(query.page, 10) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(query.limit, 10) || 25));
+
+    const where = { ...LIVE };
+    if (query.includeArchived !== 'true') {
+      where.archivedAt = null;
+    }
+    if (query.stage && PIPELINE_STAGES.includes(query.stage)) where.pipelineStage = query.stage;
+    if (query.availability && PARTNER_AVAILABILITY.includes(query.availability)) where.availability = query.availability;
+    if (query.category) where.category = String(query.category);
+    if (query.owner === 'me') where.ownerUserId = user.id;
+    else if (query.owner === 'none') where.ownerUserId = null;
+    else if (query.ownerUserId) where.ownerUserId = String(query.ownerUserId);
+    if (query.flag === 'at_risk') where.atRiskFlag = true;
+    if (query.flag === 'stale') where.staleFlag = true;
+
+    if (query.search) {
+      const s = String(query.search).trim();
+      const like = `%${s}%`;
+      where[Op.or] = [
+        { tradingName: { [Op.iLike]: like } },
+        { legalName: { [Op.iLike]: like } },
+        { brandName: { [Op.iLike]: like } },
+        { primaryPhone: s },
+        { uen: s.toUpperCase() },
+        { instagramHandle: s.toLowerCase().replace(/^@/, '') },
+        { websiteDomain: { [Op.iLike]: like } },
+      ];
+    }
+
+    const { rows, count } = await d.PartnerOrganisation.findAndCountAll({
+      where,
+      include: [OWNER_INCLUDE],
+      order: [
+        [d.sequelize.literal('"lastActivityAt" IS NULL'), 'ASC'],
+        ['lastActivityAt', 'DESC'],
+        ['createdAt', 'DESC'],
+      ],
+      limit,
+      offset: (page - 1) * limit,
+    });
+
+    return {
+      partners: rows,
+      pagination: { page, limit, total: count, totalPages: Math.ceil(count / limit) },
+    };
+  }
+
+  async function getPartner(id) {
+    const partner = await getLivePartner(id, {
+      include: [
+        OWNER_INCLUDE,
+        { model: d.PartnerContact, as: 'contacts', where: { archivedAt: null }, required: false },
+        { model: d.PartnerLocation, as: 'locations', required: false },
+      ],
+    });
+    return partner;
+  }
+
+  // ── Create / update (dedupe-gated) ───────────────────────────────────────
+
+  function displayNameOf(body) {
+    return body.tradingName || body.brandName || body.legalName || null;
+  }
+
+  async function createPartner(body, user, requestId = null) {
+    if (!displayNameOf(body)) {
+      throw new AppError('At least one of tradingName, brandName, or legalName is required', 400);
+    }
+    const keys = deriveMatchingKeys(body);
+    if (!keys.normalizedName) throw new AppError('Business name is required', 400);
+
+    const { exact, potential } = await d.dedupe.findDuplicates(body);
+    const overrideReason = body.overrideReason && String(body.overrideReason).trim();
+    if (exact.length > 0 && !overrideReason) {
+      const err = new AppError(
+        'A business with the same identifier already exists. Provide overrideReason to create anyway.',
+        409
+      );
+      err.data = { duplicates: { exact, potential } };
+      throw err;
+    }
+
+    const partner = await d.sequelize.transaction(async (t) => {
+      const created = await d.PartnerOrganisation.create(
+        {
+          legalName: body.legalName || null,
+          tradingName: body.tradingName || null,
+          brandName: body.brandName || null,
+          ...keys,
+          website: body.website || null,
+          primaryPhone: body.primaryPhone || null,
+          primaryEmail: body.primaryEmail ? String(body.primaryEmail).toLowerCase() : null,
+          facebookUrl: body.facebookUrl || null,
+          linkedinUrl: body.linkedinUrl || null,
+          category: body.category || null,
+          subcategory: body.subcategory || null,
+          source: body.source || 'manual',
+          tags: Array.isArray(body.tags) ? body.tags : [],
+          notes: body.notes || null,
+          createdBy: user.id,
+        },
+        { transaction: t }
+      );
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'partner.created', entityType: 'partner_organisation',
+        entityId: created.id,
+        after: { name: displayNameOf(body), category: body.category || null },
+        reason: overrideReason || null, requestId, transaction: t,
+      });
+      return created;
+    });
+
+    return { partner, warnings: potential };
+  }
+
+  const EDITABLE_FIELDS = [
+    'legalName', 'tradingName', 'brandName', 'uen', 'website', 'primaryPhone', 'primaryEmail',
+    'instagramHandle', 'tiktokHandle', 'facebookUrl', 'linkedinUrl', 'category', 'subcategory',
+    'source', 'tags', 'notes',
+  ];
+
+  async function updatePartner(id, body, user, requestId = null) {
+    const partner = await getLivePartner(id);
+    if (!canActOnRow(user, partner)) {
+      throw new AppError('You can only edit businesses you own', 403);
+    }
+    const updates = {};
+    for (const f of EDITABLE_FIELDS) if (body[f] !== undefined) updates[f] = body[f];
+    // Re-derive matching keys from the merged view so they never drift
+    const merged = { ...partner.toJSON(), ...updates };
+    Object.assign(updates, deriveMatchingKeys(merged));
+    if (!updates.normalizedName) throw new AppError('Business name is required', 400);
+
+    const before = {};
+    for (const k of Object.keys(updates)) before[k] = partner.get(k);
+
+    await d.sequelize.transaction(async (t) => {
+      await partner.update(updates, { transaction: t });
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'partner.edited', entityType: 'partner_organisation',
+        entityId: id, before, after: updates, requestId, transaction: t,
+      });
+    });
+    return partner;
+  }
+
+  // ── Stage machine ────────────────────────────────────────────────────────
+
+  async function changeStage(id, toStage, user, reason = null, requestId = null) {
+    if (!PIPELINE_STAGES.includes(toStage)) throw new AppError('Unknown stage', 400);
+    const partner = await getLivePartner(id);
+    if (!canActOnRow(user, partner)) {
+      throw new AppError('You can only move businesses you own', 403);
+    }
+    const fromStage = partner.pipelineStage;
+    if (fromStage === toStage) return partner;
+
+    const allowed = STAGE_TRANSITIONS[fromStage] || [];
+    const isForcer = user.role === 'admin' || ['super_admin', 'ops_admin'].includes(user.redeemOpsRole);
+    if (!allowed.includes(toStage)) {
+      if (!isForcer) {
+        throw new AppError(`Cannot move from ${fromStage} to ${toStage}`, 400);
+      }
+      if (!reason) throw new AppError('A reason is required to force a non-standard stage change', 400);
+    }
+
+    const availability =
+      toStage === 'FOLLOW_UP_LATER' ? 'follow_up_later'
+      : toStage === 'DISQUALIFIED' ? 'disqualified'
+      : partner.ownerUserId ? 'owned' : 'available';
+
+    await d.sequelize.transaction(async (t) => {
+      await partner.update({ pipelineStage: toStage, availability, staleFlag: false }, { transaction: t });
+      await d.PartnerStageEvent.create(
+        { partnerOrganisationId: id, fromStage, toStage, actorUserId: user.id, reason },
+        { transaction: t }
+      );
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'stage.changed', entityType: 'partner_organisation',
+        entityId: id, before: { stage: fromStage }, after: { stage: toStage },
+        reason, requestId, transaction: t,
+      });
+      // PARTNERED → onboarding checklist seeding hooks in here (Phase 4).
+      if (toStage === 'PARTNERED' && typeof d.onPartnered === 'function') {
+        await d.onPartnered(partner, user, t);
+      }
+    });
+    return partner;
+  }
+
+  // ── Timeline & activities ────────────────────────────────────────────────
+
+  async function getTimeline(id, query = {}) {
+    await getLivePartner(id, { attributes: ['id', 'mergedIntoId'] });
+    const limit = Math.min(100, Math.max(1, parseInt(query.limit, 10) || 50));
+    const [activities, stageEvents, assignmentEvents] = await Promise.all([
+      d.OutreachActivity.findAll({
+        where: { partnerOrganisationId: id, voidedAt: null },
+        include: [
+          { model: d.User, as: 'actor', attributes: ['id', 'fullName'] },
+          { model: d.PartnerContact, as: 'contact', attributes: ['id', 'name'] },
+        ],
+        order: [['occurredAt', 'DESC']],
+        limit,
+      }),
+      d.PartnerStageEvent.findAll({
+        where: { partnerOrganisationId: id },
+        include: [{ model: d.User, as: 'actor', attributes: ['id', 'fullName'] }],
+        order: [['createdAt', 'DESC']],
+        limit,
+      }),
+      d.PartnerAssignmentEvent.findAll({
+        where: { partnerOrganisationId: id },
+        include: [
+          { model: d.User, as: 'actor', attributes: ['id', 'fullName'] },
+          { model: d.User, as: 'toUser', attributes: ['id', 'fullName'] },
+          { model: d.User, as: 'fromUser', attributes: ['id', 'fullName'] },
+        ],
+        order: [['createdAt', 'DESC']],
+        limit,
+      }),
+    ]);
+
+    const entries = [
+      ...activities.map((a) => ({ kind: 'activity', at: a.occurredAt, data: a })),
+      ...stageEvents.map((e) => ({ kind: 'stage', at: e.createdAt, data: e })),
+      ...assignmentEvents.map((e) => ({ kind: 'assignment', at: e.createdAt, data: e })),
+    ].sort((x, y) => new Date(y.at) - new Date(x.at)).slice(0, limit);
+
+    return { entries };
+  }
+
+  async function logActivity(id, body, user, requestId = null) {
+    if (!ACTIVITY_TYPES.includes(body.type)) throw new AppError('Unknown activity type', 400);
+    if (!body.summary || !String(body.summary).trim()) throw new AppError('Summary is required', 400);
+    const partner = await getLivePartner(id);
+    if (!canActOnRow(user, partner) && !hasCapability(user, 'partners.reassign')) {
+      // redemption_ops may log notes on any partner (fulfilment context)
+      if (!(user.redeemOpsRole === 'redemption_ops' && hasCapability(user, 'activities.log'))) {
+        throw new AppError('You can only log activity on businesses you own', 403);
+      }
+    }
+
+    const meaningful = MEANINGFUL_ACTIVITY_TYPES.includes(body.type);
+    return d.sequelize.transaction(async (t) => {
+      const activity = await d.OutreachActivity.create(
+        {
+          partnerOrganisationId: id,
+          contactId: body.contactId || null,
+          type: body.type,
+          direction: ['outbound', 'inbound', 'internal'].includes(body.direction) ? body.direction : 'outbound',
+          summary: String(body.summary).trim(),
+          details: body.details || null,
+          outcome: body.outcome || null,
+          occurredAt: body.occurredAt ? new Date(body.occurredAt) : new Date(),
+          actorUserId: user.id,
+        },
+        { transaction: t }
+      );
+      if (meaningful) {
+        await partner.update(
+          {
+            lastActivityAt: activity.occurredAt,
+            firstOutreachAt: partner.firstOutreachAt || activity.occurredAt,
+            atRiskFlag: false,
+            staleFlag: false,
+          },
+          { transaction: t }
+        );
+      }
+      return activity;
+    });
+  }
+
+  async function editActivity(activityId, body, user, requestId = null) {
+    const activity = await d.OutreachActivity.findByPk(activityId);
+    if (!activity || activity.voidedAt) throw new AppError('Activity not found', 404);
+    const isManager = user.role === 'admin' || ['super_admin', 'ops_admin', 'bdm'].includes(user.redeemOpsRole);
+    if (!isManager && activity.actorUserId !== user.id) {
+      throw new AppError('You can only edit your own activities', 403);
+    }
+    const updates = {};
+    for (const f of ['summary', 'details', 'outcome', 'type', 'direction', 'occurredAt', 'contactId']) {
+      if (body[f] !== undefined) updates[f] = body[f];
+    }
+    if (updates.type && !ACTIVITY_TYPES.includes(updates.type)) throw new AppError('Unknown activity type', 400);
+    const before = {};
+    for (const k of Object.keys(updates)) before[k] = activity.get(k);
+
+    await d.sequelize.transaction(async (t) => {
+      await activity.update({ ...updates, editedAt: new Date(), editedBy: user.id }, { transaction: t });
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'activity.edited', entityType: 'outreach_activity',
+        entityId: activityId, before, after: updates, requestId, transaction: t,
+      });
+    });
+    return activity;
+  }
+
+  async function voidActivity(activityId, user, reason, requestId = null) {
+    if (!reason || !String(reason).trim()) throw new AppError('A reason is required to void an activity', 400);
+    const activity = await d.OutreachActivity.findByPk(activityId);
+    if (!activity || activity.voidedAt) throw new AppError('Activity not found', 404);
+    const isManager = user.role === 'admin' || ['super_admin', 'ops_admin', 'bdm'].includes(user.redeemOpsRole);
+    if (!isManager && activity.actorUserId !== user.id) {
+      throw new AppError('You can only void your own activities', 403);
+    }
+    await d.sequelize.transaction(async (t) => {
+      await activity.update({ voidedAt: new Date(), voidReason: String(reason).trim() }, { transaction: t });
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'activity.voided', entityType: 'outreach_activity',
+        entityId: activityId, reason: String(reason).trim(), requestId, transaction: t,
+      });
+    });
+    return activity;
+  }
+
+  // ── Contacts & locations ─────────────────────────────────────────────────
+
+  async function addContact(id, body, user) {
+    const partner = await getLivePartner(id);
+    if (!canActOnRow(user, partner)) throw new AppError('You can only edit businesses you own', 403);
+    if (!body.name || !String(body.name).trim()) throw new AppError('Contact name is required', 400);
+    return d.sequelize.transaction(async (t) => {
+      if (body.isPrimary) {
+        await d.PartnerContact.update(
+          { isPrimary: false },
+          { where: { partnerOrganisationId: id }, transaction: t }
+        );
+      }
+      return d.PartnerContact.create(
+        {
+          partnerOrganisationId: id,
+          name: String(body.name).trim(),
+          roleTitle: body.roleTitle || null,
+          mobile: body.mobile || null,
+          whatsapp: body.whatsapp || null,
+          email: body.email ? String(body.email).toLowerCase() : null,
+          preferredChannel: body.preferredChannel || null,
+          isPrimary: !!body.isPrimary,
+          notes: body.notes || null,
+        },
+        { transaction: t }
+      );
+    });
+  }
+
+  async function updateContact(contactId, body, user) {
+    const contact = await d.PartnerContact.findByPk(contactId);
+    if (!contact || contact.archivedAt) throw new AppError('Contact not found', 404);
+    const partner = await getLivePartner(contact.partnerOrganisationId);
+    if (!canActOnRow(user, partner)) throw new AppError('You can only edit businesses you own', 403);
+    const updates = {};
+    for (const f of ['name', 'roleTitle', 'mobile', 'whatsapp', 'email', 'preferredChannel', 'isPrimary', 'notes']) {
+      if (body[f] !== undefined) updates[f] = body[f];
+    }
+    return d.sequelize.transaction(async (t) => {
+      if (updates.isPrimary === true) {
+        await d.PartnerContact.update(
+          { isPrimary: false },
+          { where: { partnerOrganisationId: contact.partnerOrganisationId }, transaction: t }
+        );
+      }
+      await contact.update(updates, { transaction: t });
+      return contact;
+    });
+  }
+
+  async function archiveContact(contactId, user) {
+    const contact = await d.PartnerContact.findByPk(contactId);
+    if (!contact || contact.archivedAt) throw new AppError('Contact not found', 404);
+    const partner = await getLivePartner(contact.partnerOrganisationId);
+    if (!canActOnRow(user, partner)) throw new AppError('You can only edit businesses you own', 403);
+    await contact.update({ archivedAt: new Date(), isPrimary: false });
+    return contact;
+  }
+
+  async function addLocation(id, body, user) {
+    const partner = await getLivePartner(id);
+    if (!canActOnRow(user, partner)) throw new AppError('You can only edit businesses you own', 403);
+    return d.PartnerLocation.create({
+      partnerOrganisationId: id,
+      name: body.name || null,
+      addressLine: body.addressLine || null,
+      postalCode: body.postalCode || null,
+      postalDistrict: postalDistrictOf(body.postalCode),
+      area: body.area || null,
+      phone: body.phone || null,
+      isActive: body.isActive !== false,
+      notes: body.notes || null,
+    });
+  }
+
+  async function updateLocation(locationId, body, user) {
+    const location = await d.PartnerLocation.findByPk(locationId);
+    if (!location) throw new AppError('Location not found', 404);
+    const partner = await getLivePartner(location.partnerOrganisationId);
+    if (!canActOnRow(user, partner)) throw new AppError('You can only edit businesses you own', 403);
+    const updates = {};
+    for (const f of ['name', 'addressLine', 'postalCode', 'area', 'phone', 'isActive', 'notes']) {
+      if (body[f] !== undefined) updates[f] = body[f];
+    }
+    if (updates.postalCode !== undefined) updates.postalDistrict = postalDistrictOf(updates.postalCode);
+    await location.update(updates);
+    return location;
+  }
+
+  // ── Merge ────────────────────────────────────────────────────────────────
+
+  /**
+   * Merge `duplicateId` INTO `survivorId`. Re-points children, marks the loser
+   * merged+archived, preserves all history (brief §14). Extend REPOINT_TARGETS as
+   * later phases add child tables (tasks, offers, activations, pool members).
+   */
+  const REPOINT_TARGETS = () => [
+    [d.PartnerContact, 'partnerOrganisationId'],
+    [d.PartnerLocation, 'partnerOrganisationId'],
+    [d.OutreachActivity, 'partnerOrganisationId'],
+    [d.PartnerAssignmentEvent, 'partnerOrganisationId'],
+    [d.PartnerStageEvent, 'partnerOrganisationId'],
+  ];
+
+  async function mergePartners(survivorId, duplicateId, user, reason = null, requestId = null) {
+    if (survivorId === duplicateId) throw new AppError('Cannot merge a business into itself', 400);
+    return d.sequelize.transaction(async (t) => {
+      const survivor = await getLivePartner(survivorId, { transaction: t, lock: t.LOCK.UPDATE });
+      const duplicate = await getLivePartner(duplicateId, { transaction: t, lock: t.LOCK.UPDATE });
+
+      for (const [Model, fk] of REPOINT_TARGETS()) {
+        await Model.update({ [fk]: survivorId }, { where: { [fk]: duplicateId }, transaction: t });
+      }
+
+      const duplicateSnapshot = duplicate.toJSON();
+      await duplicate.update(
+        { mergedIntoId: survivorId, archivedAt: new Date(), ownerUserId: null, availability: 'restricted' },
+        { transaction: t }
+      );
+      await d.PartnerAssignmentEvent.create(
+        {
+          partnerOrganisationId: survivorId, kind: 'merge',
+          actorUserId: user.id, reason: reason || `merged ${duplicateId} into ${survivorId}`,
+        },
+        { transaction: t }
+      );
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'partner.merged', entityType: 'partner_organisation',
+        entityId: survivorId, before: { duplicate: duplicateSnapshot }, after: { survivorId },
+        reason, requestId, transaction: t,
+      });
+      return survivor;
+    });
+  }
+
+  return {
+    listPartners, getPartner, createPartner, updatePartner, changeStage,
+    getTimeline, logActivity, editActivity, voidActivity,
+    addContact, updateContact, archiveContact, addLocation, updateLocation,
+    mergePartners, canActOnRow,
+  };
+}
+
+const _default = makePartnerService();
+export default _default;

--- a/backend/src/services/redeemOps/poolService.js
+++ b/backend/src/services/redeemOps/poolService.js
@@ -1,0 +1,142 @@
+import { Op, QueryTypes } from 'sequelize';
+import {
+  ProspectingPool, ProspectingPoolMember, PartnerOrganisation, sequelize,
+} from '../../models/index.js';
+import { AppError } from '../../middleware/errorHandler.js';
+import { logger } from '../../utils/logger.js';
+import { makeClaimService } from './claimService.js';
+
+/**
+ * Prospecting pools + Claim Next (docs/redeem-ops/ERD.md §3.8–3.9, brief §21).
+ * claim-next picks the oldest available member with FOR UPDATE SKIP LOCKED
+ * (house pattern: chargeLeadCredit) so concurrent staff get DIFFERENT prospects,
+ * then runs the same atomic partner claim as the direct claim path. A partner
+ * that was claimed outside the pool between listing and claiming is skipped and
+ * its membership marked removed.
+ */
+export function makePoolService(overrides = {}) {
+  const d = {
+    ProspectingPool, ProspectingPoolMember, PartnerOrganisation, sequelize, logger,
+    claims: makeClaimService(), ...overrides,
+  };
+
+  async function createPool(body, user) {
+    if (!body.name || !String(body.name).trim()) throw new AppError('Pool name is required', 400);
+    return d.ProspectingPool.create({
+      name: String(body.name).trim(),
+      description: body.description || null,
+      category: body.category || null,
+      area: body.area || null,
+      createdBy: user.id,
+    });
+  }
+
+  async function listPools() {
+    const pools = await d.ProspectingPool.findAll({ where: { isActive: true }, order: [['createdAt', 'DESC']] });
+    const counts = await d.ProspectingPoolMember.findAll({
+      attributes: ['poolId', 'status', [d.sequelize.fn('COUNT', '*'), 'count']],
+      group: ['poolId', 'status'],
+      raw: true,
+    });
+    const byPool = {};
+    for (const c of counts) {
+      byPool[c.poolId] = byPool[c.poolId] || {};
+      byPool[c.poolId][c.status] = Number(c.count);
+    }
+    return pools.map((p) => ({ ...p.toJSON(), memberCounts: byPool[p.id] || {} }));
+  }
+
+  async function updatePool(poolId, body, user) {
+    const pool = await d.ProspectingPool.findByPk(poolId);
+    if (!pool) throw new AppError('Pool not found', 404);
+    const updates = {};
+    for (const f of ['name', 'description', 'category', 'area', 'isActive']) {
+      if (body[f] !== undefined) updates[f] = body[f];
+    }
+    await pool.update(updates);
+    return pool;
+  }
+
+  /** Bulk-add partners; ineligible (merged/archived/disqualified/restricted) are skipped. */
+  async function addMembers(poolId, partnerIds, user) {
+    const pool = await d.ProspectingPool.findByPk(poolId);
+    if (!pool || !pool.isActive) throw new AppError('Pool not found', 404);
+    if (!Array.isArray(partnerIds) || partnerIds.length === 0) {
+      throw new AppError('partnerIds array is required', 400);
+    }
+    const eligible = await d.PartnerOrganisation.findAll({
+      where: {
+        id: { [Op.in]: partnerIds },
+        mergedIntoId: null,
+        archivedAt: null,
+        availability: { [Op.notIn]: ['disqualified', 'restricted'] },
+      },
+      attributes: ['id'],
+    });
+    let added = 0;
+    for (const p of eligible) {
+      const [, created] = await d.ProspectingPoolMember.findOrCreate({
+        where: { poolId, partnerOrganisationId: p.id },
+        defaults: { poolId, partnerOrganisationId: p.id, addedBy: user.id },
+      });
+      if (created) added += 1;
+    }
+    return { requested: partnerIds.length, eligible: eligible.length, added };
+  }
+
+  /**
+   * Claim the next eligible prospect from the pool for `user`.
+   * Returns the claimed partner id, or null when the pool is exhausted.
+   */
+  async function claimNext(poolId, user) {
+    const pool = await d.ProspectingPool.findByPk(poolId);
+    if (!pool || !pool.isActive) throw new AppError('Pool not found', 404);
+
+    // Bounded retry: a SKIP LOCKED candidate can still lose the partner-level
+    // conditional UPDATE to a direct (non-pool) claim — skip it and try the next.
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const result = await d.sequelize.transaction(async (t) => {
+        const candidates = await d.sequelize.query(
+          `SELECT m.id AS "memberId", m."partnerOrganisationId" AS "partnerId"
+             FROM prospecting_pool_members m
+             JOIN partner_organisations p ON p.id = m."partnerOrganisationId"
+            WHERE m."poolId" = :poolId
+              AND m.status = 'available'
+              AND p."ownerUserId" IS NULL
+              AND p.availability = 'available'
+              AND p."archivedAt" IS NULL
+              AND p."mergedIntoId" IS NULL
+            ORDER BY m."createdAt" ASC
+            LIMIT 1
+            FOR UPDATE OF m SKIP LOCKED`,
+          { replacements: { poolId }, type: QueryTypes.SELECT, transaction: t }
+        );
+        if (candidates.length === 0) return { done: true, partnerId: null };
+
+        const { memberId, partnerId } = candidates[0];
+        const claimed = await d.claims.claimPartnerTx(partnerId, user, t, 'pool_claim_next');
+        if (!claimed) {
+          // Lost the partner to a concurrent direct claim — retire the membership
+          // so the pool doesn't keep offering an owned business.
+          await d.ProspectingPoolMember.update(
+            { status: 'removed' },
+            { where: { id: memberId }, transaction: t }
+          );
+          return { done: false, partnerId: null };
+        }
+        await d.ProspectingPoolMember.update(
+          { status: 'claimed', claimedBy: user.id, claimedAt: new Date() },
+          { where: { id: memberId }, transaction: t }
+        );
+        return { done: true, partnerId };
+      });
+      if (result.done) return result.partnerId;
+    }
+    return null;
+  }
+
+  return { createPool, listPools, updatePool, addMembers, claimNext };
+}
+
+const _default = makePoolService();
+export default _default;

--- a/backend/src/services/redeemOps/queueService.js
+++ b/backend/src/services/redeemOps/queueService.js
@@ -1,0 +1,108 @@
+import { Op, QueryTypes } from 'sequelize';
+import {
+  OutreachTask, OutreachActivity, PartnerOrganisation, PartnerContact, User, sequelize,
+} from '../../models/index.js';
+import { sgtDayWindow } from './taskService.js';
+
+const PARTNER_LITE = ['id', 'tradingName', 'legalName', 'brandName', 'pipelineStage', 'category', 'lastActivityAt', 'claimedAt'];
+const BUCKET_LIMIT = 10;
+
+/**
+ * "My Outreach Queue" — the start-of-day worklist (brief §20). One aggregated
+ * read; each bucket capped at 10 with a total count so the page renders fast.
+ */
+export function makeQueueService(overrides = {}) {
+  const d = { OutreachTask, OutreachActivity, PartnerOrganisation, PartnerContact, User, sequelize, ...overrides };
+
+  async function getMyQueue(user) {
+    const { start, end } = sgtDayWindow();
+    const taskInclude = [
+      { model: d.PartnerOrganisation, as: 'partner', attributes: PARTNER_LITE },
+      { model: d.PartnerContact, as: 'contact', attributes: ['id', 'name'] },
+    ];
+    const openTasks = { assigneeUserId: user.id, status: { [Op.in]: ['open', 'in_progress'] } };
+    const myLivePartners = { ownerUserId: user.id, mergedIntoId: null, archivedAt: null };
+
+    const [
+      overdueTasks, overdueCount,
+      dueTodayTasks, dueTodayCount,
+      upcomingTasks,
+      awaitingFirstOutreach, awaitingCount,
+      stalePartners, staleCount,
+      recentReplies,
+    ] = await Promise.all([
+      d.OutreachTask.findAll({ where: { ...openTasks, dueAt: { [Op.lt]: start } }, include: taskInclude, order: [['dueAt', 'ASC']], limit: BUCKET_LIMIT }),
+      d.OutreachTask.count({ where: { ...openTasks, dueAt: { [Op.lt]: start } } }),
+      d.OutreachTask.findAll({ where: { ...openTasks, dueAt: { [Op.gte]: start, [Op.lt]: end } }, include: taskInclude, order: [['dueAt', 'ASC']], limit: BUCKET_LIMIT }),
+      d.OutreachTask.count({ where: { ...openTasks, dueAt: { [Op.gte]: start, [Op.lt]: end } } }),
+      d.OutreachTask.findAll({
+        where: { ...openTasks, dueAt: { [Op.gte]: end, [Op.lt]: new Date(end.getTime() + 3 * 24 * 3600 * 1000) } },
+        include: taskInclude, order: [['dueAt', 'ASC']], limit: BUCKET_LIMIT,
+      }),
+      d.PartnerOrganisation.findAll({
+        where: { ...myLivePartners, firstOutreachAt: null, availability: 'owned' },
+        attributes: [...PARTNER_LITE, 'atRiskFlag'],
+        order: [['claimedAt', 'ASC']], limit: BUCKET_LIMIT,
+      }),
+      d.PartnerOrganisation.count({ where: { ...myLivePartners, firstOutreachAt: null, availability: 'owned' } }),
+      d.PartnerOrganisation.findAll({
+        where: { ...myLivePartners, staleFlag: true },
+        attributes: [...PARTNER_LITE, 'staleFlag'],
+        order: [['lastActivityAt', 'ASC']], limit: BUCKET_LIMIT,
+      }),
+      d.PartnerOrganisation.count({ where: { ...myLivePartners, staleFlag: true } }),
+      // Inbound replies on my partners in the last 7 days
+      d.sequelize.query(
+        `SELECT a.id, a.type, a.summary, a."occurredAt",
+                p.id AS "partnerId", COALESCE(p."tradingName", p."brandName", p."legalName") AS "partnerName"
+           FROM outreach_activities a
+           JOIN partner_organisations p ON p.id = a."partnerOrganisationId"
+          WHERE p."ownerUserId" = :userId
+            AND a.direction = 'inbound'
+            AND a."voidedAt" IS NULL
+            AND a."occurredAt" > NOW() - INTERVAL '7 days'
+          ORDER BY a."occurredAt" DESC
+          LIMIT ${BUCKET_LIMIT}`,
+        { replacements: { userId: user.id }, type: QueryTypes.SELECT }
+      ),
+    ]);
+
+    return {
+      overdueTasks: { items: overdueTasks, total: overdueCount },
+      dueTodayTasks: { items: dueTodayTasks, total: dueTodayCount },
+      upcomingTasks: { items: upcomingTasks },
+      awaitingFirstOutreach: { items: awaitingFirstOutreach, total: awaitingCount },
+      stalePartners: { items: stalePartners, total: staleCount },
+      recentReplies: { items: recentReplies },
+    };
+  }
+
+  /** Manager board: stage × owner counts + per-stage partner lists. */
+  async function getTeamPipeline() {
+    const rows = await d.sequelize.query(
+      `SELECT p."pipelineStage" AS stage,
+              p."ownerUserId" AS "ownerUserId",
+              COALESCE(u."fullName", 'Unowned') AS "ownerName",
+              COUNT(*)::int AS count
+         FROM partner_organisations p
+         LEFT JOIN users u ON u.id = p."ownerUserId"
+        WHERE p."mergedIntoId" IS NULL AND p."archivedAt" IS NULL
+        GROUP BY p."pipelineStage", p."ownerUserId", u."fullName"
+        ORDER BY count DESC`,
+      { type: QueryTypes.SELECT }
+    );
+    const partners = await d.PartnerOrganisation.findAll({
+      where: { mergedIntoId: null, archivedAt: null },
+      attributes: [...PARTNER_LITE, 'ownerUserId', 'atRiskFlag', 'staleFlag'],
+      include: [{ model: d.User, as: 'owner', attributes: ['id', 'fullName'] }],
+      order: [['lastActivityAt', 'DESC']],
+      limit: 500,
+    });
+    return { counts: rows, partners };
+  }
+
+  return { getMyQueue, getTeamPipeline };
+}
+
+const _default = makeQueueService();
+export default _default;

--- a/backend/src/services/redeemOps/staleSweep.js
+++ b/backend/src/services/redeemOps/staleSweep.js
@@ -1,0 +1,53 @@
+import { sequelize } from '../../models/index.js';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Claim-inactivity sweep (brief §16, docs/redeem-ops/ERD.md §6). Flags only —
+ * records are NEVER auto-released; managers act on the flags (queue + pipeline
+ * views). Runs in-process on the bootstrap interval (house pattern: releaseSweep).
+ *
+ *  - atRiskFlag: claimed >48h ago, still no first outreach.
+ *  - staleFlag:  no meaningful activity for >14 days — EXCEPT a FOLLOW_UP_LATER
+ *    partner with a future open task (that's a deliberate parked state), and
+ *    terminal stages (PARTNERED/NOT_INTERESTED/DISQUALIFIED).
+ *
+ * Both flags are cleared automatically when real activity is logged
+ * (partnerService.logActivity).
+ */
+export async function runRedeemOpsStaleSweep() {
+  const [, atRisk] = await sequelize.query(
+    `UPDATE partner_organisations
+        SET "atRiskFlag" = TRUE, "updatedAt" = NOW()
+      WHERE "ownerUserId" IS NOT NULL
+        AND "firstOutreachAt" IS NULL
+        AND "claimedAt" < NOW() - INTERVAL '48 hours'
+        AND "atRiskFlag" = FALSE
+        AND "archivedAt" IS NULL AND "mergedIntoId" IS NULL`
+  );
+
+  const [, stale] = await sequelize.query(
+    `UPDATE partner_organisations p
+        SET "staleFlag" = TRUE, "updatedAt" = NOW()
+      WHERE p."ownerUserId" IS NOT NULL
+        AND COALESCE(p."lastActivityAt", p."claimedAt") < NOW() - INTERVAL '14 days'
+        AND p."staleFlag" = FALSE
+        AND p."archivedAt" IS NULL AND p."mergedIntoId" IS NULL
+        AND p."pipelineStage" NOT IN ('PARTNERED', 'NOT_INTERESTED', 'DISQUALIFIED')
+        AND NOT (
+          p."pipelineStage" = 'FOLLOW_UP_LATER'
+          AND EXISTS (
+            SELECT 1 FROM outreach_tasks t
+             WHERE t."partnerOrganisationId" = p.id
+               AND t.status IN ('open', 'in_progress')
+               AND t."dueAt" > NOW()
+          )
+        )`
+  );
+
+  const atRiskCount = atRisk?.rowCount ?? 0;
+  const staleCount = stale?.rowCount ?? 0;
+  if (atRiskCount > 0 || staleCount > 0) {
+    logger.info('redeem_ops.stale_sweep.done', { atRiskFlagged: atRiskCount, staleFlagged: staleCount });
+  }
+  return { atRiskFlagged: atRiskCount, staleFlagged: staleCount };
+}

--- a/backend/src/services/redeemOps/taskService.js
+++ b/backend/src/services/redeemOps/taskService.js
@@ -1,0 +1,156 @@
+import { Op } from 'sequelize';
+import {
+  OutreachTask, PartnerOrganisation, PartnerContact, User, sequelize,
+} from '../../models/index.js';
+import { AppError } from '../../middleware/errorHandler.js';
+import { logger } from '../../utils/logger.js';
+import { TASK_STATUSES, TASK_PRIORITIES } from './constants.js';
+
+const TASK_TYPES = ['follow_up', 'call', 'meeting', 'proposal', 'admin', 'other'];
+
+/** "Today" in Singapore time regardless of server TZ. */
+export function sgtDayWindow(now = new Date()) {
+  const SGT_OFFSET_MS = 8 * 60 * 60 * 1000;
+  const sgt = new Date(now.getTime() + SGT_OFFSET_MS);
+  const startUtcMs = Date.UTC(sgt.getUTCFullYear(), sgt.getUTCMonth(), sgt.getUTCDate()) - SGT_OFFSET_MS;
+  return { start: new Date(startUtcMs), end: new Date(startUtcMs + 24 * 60 * 60 * 1000) };
+}
+
+/**
+ * Tasks & follow-ups (docs/redeem-ops/ERD.md §3.7, brief §19). Row-level rule:
+ * managers (admin/super_admin/ops_admin/bdm) act on any task; everyone else only
+ * on tasks they are assigned to or created. Task changes recompute the partner's
+ * denormalized nextTaskAt.
+ */
+export function makeTaskService(overrides = {}) {
+  const d = { OutreachTask, PartnerOrganisation, PartnerContact, User, sequelize, logger, ...overrides };
+
+  const isManager = (user) =>
+    user.role === 'admin' || ['super_admin', 'ops_admin', 'bdm'].includes(user.redeemOpsRole);
+
+  async function recomputeNextTaskAt(partnerOrganisationId, transaction = null) {
+    const next = await d.OutreachTask.min('dueAt', {
+      where: { partnerOrganisationId, status: { [Op.in]: ['open', 'in_progress'] } },
+      transaction,
+    });
+    await d.PartnerOrganisation.update(
+      { nextTaskAt: next || null },
+      { where: { id: partnerOrganisationId }, transaction }
+    );
+  }
+
+  async function createTask(body, user) {
+    if (!body.title || !String(body.title).trim()) throw new AppError('Title is required', 400);
+    if (!body.partnerOrganisationId) throw new AppError('partnerOrganisationId is required', 400);
+    if (!body.dueAt || Number.isNaN(new Date(body.dueAt).getTime())) throw new AppError('A valid dueAt is required', 400);
+    if (body.priority && !TASK_PRIORITIES.includes(body.priority)) throw new AppError('Unknown priority', 400);
+    if (body.type && !TASK_TYPES.includes(body.type)) throw new AppError('Unknown task type', 400);
+
+    const partner = await d.PartnerOrganisation.findByPk(body.partnerOrganisationId);
+    if (!partner || partner.mergedIntoId) throw new AppError('Partner not found', 404);
+
+    const assigneeUserId = body.assigneeUserId || user.id;
+    if (assigneeUserId !== user.id && !isManager(user)) {
+      throw new AppError('Only managers can assign tasks to others', 403);
+    }
+    const assignee = await d.User.findByPk(assigneeUserId);
+    if (!assignee || !assignee.isActive || !(assignee.role === 'redeem_ops' || assignee.role === 'admin' || assignee.redeemOpsRole)) {
+      throw new AppError('Assignee must be an active Redeem Ops staff member', 400);
+    }
+
+    return d.sequelize.transaction(async (t) => {
+      const task = await d.OutreachTask.create(
+        {
+          title: String(body.title).trim(),
+          partnerOrganisationId: body.partnerOrganisationId,
+          contactId: body.contactId || null,
+          assigneeUserId,
+          createdBy: user.id,
+          dueAt: new Date(body.dueAt),
+          hasTime: !!body.hasTime,
+          priority: body.priority || 'medium',
+          type: body.type || 'follow_up',
+          description: body.description || null,
+        },
+        { transaction: t }
+      );
+      await recomputeNextTaskAt(body.partnerOrganisationId, t);
+      return task;
+    });
+  }
+
+  async function listTasks(query, user) {
+    const page = Math.max(1, parseInt(query.page, 10) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(query.limit, 10) || 25));
+
+    const where = {};
+    // Scope: managers may look across the team; everyone else sees their own.
+    if (isManager(user) && query.assigneeUserId) where.assigneeUserId = String(query.assigneeUserId);
+    else if (isManager(user) && query.scope === 'team') { /* no assignee filter */ }
+    else where.assigneeUserId = user.id;
+
+    if (query.partnerId) where.partnerOrganisationId = String(query.partnerId);
+    if (query.status && TASK_STATUSES.includes(query.status)) where.status = query.status;
+    else if (!query.status) where.status = { [Op.in]: ['open', 'in_progress'] };
+    else if (query.status === 'all') delete where.status;
+
+    const { start, end } = sgtDayWindow();
+    if (query.due === 'today') where.dueAt = { [Op.gte]: start, [Op.lt]: end };
+    if (query.due === 'overdue') where.dueAt = { [Op.lt]: start };
+    if (query.due === 'upcoming') where.dueAt = { [Op.gte]: end };
+
+    const { rows, count } = await d.OutreachTask.findAndCountAll({
+      where,
+      include: [
+        { model: d.PartnerOrganisation, as: 'partner', attributes: ['id', 'tradingName', 'legalName', 'brandName'] },
+        { model: d.User, as: 'assignee', attributes: ['id', 'fullName'] },
+        { model: d.PartnerContact, as: 'contact', attributes: ['id', 'name'] },
+      ],
+      order: [['dueAt', 'ASC']],
+      limit,
+      offset: (page - 1) * limit,
+    });
+    return { tasks: rows, pagination: { page, limit, total: count, totalPages: Math.ceil(count / limit) } };
+  }
+
+  async function updateTask(taskId, body, user) {
+    const task = await d.OutreachTask.findByPk(taskId);
+    if (!task) throw new AppError('Task not found', 404);
+    if (!isManager(user) && task.assigneeUserId !== user.id && task.createdBy !== user.id) {
+      throw new AppError('You can only update your own tasks', 403);
+    }
+
+    const updates = {};
+    for (const f of ['title', 'description', 'dueAt', 'hasTime', 'priority', 'type', 'contactId']) {
+      if (body[f] !== undefined) updates[f] = body[f];
+    }
+    if (body.assigneeUserId !== undefined) {
+      if (!isManager(user)) throw new AppError('Only managers can reassign tasks', 403);
+      updates.assigneeUserId = body.assigneeUserId;
+    }
+    if (body.status !== undefined) {
+      if (!TASK_STATUSES.includes(body.status)) throw new AppError('Unknown status', 400);
+      updates.status = body.status;
+      if (body.status === 'completed') {
+        updates.completedAt = new Date();
+        updates.completedBy = user.id;
+      }
+      if (body.status === 'open' || body.status === 'in_progress') {
+        updates.completedAt = null;
+        updates.completedBy = null;
+      }
+    }
+    if (updates.priority && !TASK_PRIORITIES.includes(updates.priority)) throw new AppError('Unknown priority', 400);
+
+    return d.sequelize.transaction(async (t) => {
+      await task.update(updates, { transaction: t });
+      await recomputeNextTaskAt(task.partnerOrganisationId, t);
+      return task;
+    });
+  }
+
+  return { createTask, listTasks, updateTask, recomputeNextTaskAt, isManager };
+}
+
+const _default = makeTaskService();
+export default _default;

--- a/backend/test/redeemOpsNormalizers.test.js
+++ b/backend/test/redeemOpsNormalizers.test.js
@@ -1,0 +1,80 @@
+/** Pure unit tests — no DB. docs/redeem-ops/ERD.md §5 normalization contract. */
+import {
+  normalizeBusinessName, normalizeDomain, normalizeHandle, normalizeUen,
+  postalDistrictOf, deriveMatchingKeys,
+} from '../src/services/redeemOps/normalizers.js';
+
+describe('normalizeBusinessName', () => {
+  test('lowercases, strips punctuation, collapses whitespace', () => {
+    expect(normalizeBusinessName('  Nail   Bliss!  ')).toBe('nail bliss');
+    expect(normalizeBusinessName('Café & Co.')).toBe('café co');
+  });
+  test('strips a single trailing legal suffix, never mid-name tokens', () => {
+    expect(normalizeBusinessName('Nail Bliss Pte Ltd')).toBe('nail bliss');
+    expect(normalizeBusinessName('Nail Bliss Pte. Ltd.')).toBe('nail bliss');
+    expect(normalizeBusinessName('Nail Bliss Private Limited')).toBe('nail bliss');
+    expect(normalizeBusinessName('Limited Edition Nails')).toBe('limited edition nails');
+    expect(normalizeBusinessName('PL Grooming LLP')).toBe('pl grooming');
+  });
+  test('null-safe', () => {
+    expect(normalizeBusinessName('')).toBeNull();
+    expect(normalizeBusinessName(null)).toBeNull();
+  });
+});
+
+describe('normalizeDomain', () => {
+  test('strips scheme, www, path', () => {
+    expect(normalizeDomain('https://www.nailbliss.sg/booking?x=1')).toBe('nailbliss.sg');
+    expect(normalizeDomain('nailbliss.sg')).toBe('nailbliss.sg');
+    expect(normalizeDomain('WWW.NailBliss.SG')).toBe('nailbliss.sg');
+  });
+  test('garbage → null', () => {
+    expect(normalizeDomain('   ')).toBeNull();
+    expect(normalizeDomain(null)).toBeNull();
+  });
+});
+
+describe('normalizeHandle', () => {
+  test('accepts @handle, handle, and profile URLs', () => {
+    expect(normalizeHandle('@NailBliss.sg')).toBe('nailbliss.sg');
+    expect(normalizeHandle('nailbliss.sg')).toBe('nailbliss.sg');
+    expect(normalizeHandle('https://instagram.com/NailBliss.sg')).toBe('nailbliss.sg');
+    expect(normalizeHandle('instagram.com/nailbliss.sg/')).toBe('nailbliss.sg');
+  });
+  test('post/reel URLs do not become handles', () => {
+    expect(normalizeHandle('https://instagram.com/p/Cxyz123')).toBeNull();
+  });
+});
+
+describe('normalizeUen / postalDistrictOf', () => {
+  test('uen uppercased alnum', () => {
+    expect(normalizeUen(' 202507548m ')).toBe('202507548M');
+    expect(normalizeUen(null)).toBeNull();
+  });
+  test('postal district = first 2 digits of a valid 6-digit code', () => {
+    expect(postalDistrictOf('520123')).toBe('52');
+    expect(postalDistrictOf('1234')).toBeNull();
+  });
+});
+
+describe('deriveMatchingKeys', () => {
+  test('derives all keys from display fields, preferring tradingName', () => {
+    const keys = deriveMatchingKeys({
+      tradingName: 'Nail Bliss Pte Ltd',
+      legalName: 'NB Holdings Pte Ltd',
+      uen: '202507548m',
+      website: 'https://www.nailbliss.sg/x',
+      instagramHandle: '@nailbliss.sg',
+      tiktokHandle: null,
+      facebookUrl: 'https://facebook.com/NailBlissSG',
+    });
+    expect(keys).toEqual({
+      normalizedName: 'nail bliss',
+      uen: '202507548M',
+      websiteDomain: 'nailbliss.sg',
+      instagramHandle: 'nailbliss.sg',
+      tiktokHandle: null,
+      facebookHandle: 'nailblisssg',
+    });
+  });
+});

--- a/backend/test/redeemOpsPartners.test.js
+++ b/backend/test/redeemOpsPartners.test.js
@@ -1,0 +1,285 @@
+/**
+ * Phase 2 Partner CRM — DB-backed tests (brief §37 Claiming + Dedupe).
+ * Covers: create with dedupe gates, SIMULTANEOUS CLAIMS → one winner, release,
+ * unauthorized reassign, stage machine, activity → lastActivity stamping,
+ * merge preserving children, and second-outlet (add-as-location) legitimacy.
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+
+import request from 'supertest';
+import { getApp, closeDb, createTestUser } from './helpers.js';
+import {
+  PartnerOrganisation, PartnerContact, OutreachActivity, sequelize,
+} from '../src/models/index.js';
+import { makeClaimService } from '../src/services/redeemOps/claimService.js';
+
+let app;
+let admin, execA, execB, bdm;
+
+beforeAll(async () => {
+  app = await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  execA = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
+  execB = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
+  bdm = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'bdm' });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+const auth = (t) => ({ Authorization: `Bearer ${t}` });
+
+async function createPartner(token, body) {
+  return request(app).post('/api/redeem-ops/partners').set(auth(token)).send(body);
+}
+
+describe('create + duplicate detection', () => {
+  test('create succeeds and derives matching keys', async () => {
+    const res = await createPartner(execA.token, {
+      tradingName: 'Nail Bliss Pte Ltd',
+      category: 'Nail Salon',
+      primaryPhone: '+6591230001',
+      website: 'https://www.nailbliss-test.sg',
+      instagramHandle: '@nailbliss.test',
+      uen: '202500001N',
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.data.partner.normalizedName).toBe('nail bliss');
+    expect(res.body.data.partner.websiteDomain).toBe('nailbliss-test.sg');
+  });
+
+  test.each([
+    ['same UEN', { tradingName: 'Different Name Spa', uen: '202500001N' }],
+    ['same phone', { tradingName: 'Other Salon', primaryPhone: '+6591230001' }],
+    ['same domain', { tradingName: 'Third Salon', website: 'nailbliss-test.sg' }],
+    ['same instagram', { tradingName: 'Fourth Salon', instagramHandle: 'nailbliss.test' }],
+    ['same normalized name', { tradingName: 'NAIL   BLISS!!' }],
+  ])('exact duplicate (%s) → 409 without overrideReason', async (_label, body) => {
+    const res = await createPartner(execA.token, body);
+    expect(res.status).toBe(409);
+    expect(res.body.data.duplicates.exact.length).toBeGreaterThan(0);
+  });
+
+  test('exact duplicate + overrideReason → created (audited path)', async () => {
+    const res = await createPartner(execA.token, {
+      tradingName: 'NAIL BLISS',
+      overrideReason: 'Different outlet, confirmed separate owner',
+    });
+    expect(res.status).toBe(201);
+  });
+
+  test('check-duplicates probe surfaces owner + stage for the UI', async () => {
+    const res = await request(app)
+      .get('/api/redeem-ops/partners/check-duplicates')
+      .query({ uen: '202500001N' })
+      .set(auth(execB.token));
+    expect(res.status).toBe(200);
+    expect(res.body.data.duplicates.exact[0].partner.uen).toBe('202500001N');
+  });
+
+  test('legitimate second outlet: add as location instead of new business', async () => {
+    const partner = await PartnerOrganisation.findOne({ where: { uen: '202500001N' } });
+    const res = await request(app)
+      .post(`/api/redeem-ops/partners/${partner.id}/locations`)
+      .set(auth(admin.token))
+      .send({ name: 'Tampines Outlet', postalCode: '520123' });
+    expect(res.status).toBe(201);
+    expect(res.body.data.location.postalDistrict).toBe('52');
+  });
+});
+
+describe('claiming (concurrency-safe)', () => {
+  let partnerId;
+  beforeAll(async () => {
+    const res = await createPartner(admin.token, { tradingName: 'Claim Target Studio' });
+    partnerId = res.body.data.partner.id;
+  });
+
+  test('SIMULTANEOUS claims → exactly one winner, loser gets 409 with claimedBy', async () => {
+    const claimService = makeClaimService();
+    const results = await Promise.allSettled([
+      claimService.claimPartner(partnerId, execA.user),
+      claimService.claimPartner(partnerId, execB.user),
+      claimService.claimPartner(partnerId, bdm.user),
+    ]);
+    const wins = results.filter((r) => r.status === 'fulfilled');
+    const losses = results.filter((r) => r.status === 'rejected');
+    expect(wins).toHaveLength(1);
+    expect(losses).toHaveLength(2);
+    for (const loss of losses) {
+      expect(loss.reason.statusCode).toBe(409);
+      expect(loss.reason.data.claimedBy).toBeTruthy();
+    }
+    const row = await PartnerOrganisation.findByPk(partnerId);
+    expect(row.availability).toBe('owned');
+    expect(row.pipelineStage).toBe('CLAIMED');
+  });
+
+  test('claiming an owned business over HTTP → 409', async () => {
+    const res = await request(app)
+      .post(`/api/redeem-ops/partners/${partnerId}/claim`)
+      .set(auth(execB.token));
+    expect(res.status).toBe(409);
+  });
+
+  test('non-owner cannot release; owner can', async () => {
+    const row = await PartnerOrganisation.findByPk(partnerId);
+    const ownerToken = [execA, execB, bdm].find((u) => u.user.id === row.ownerUserId).token;
+    const nonOwner = [execA, execB].find((u) => u.user.id !== row.ownerUserId);
+
+    const denied = await request(app)
+      .post(`/api/redeem-ops/partners/${partnerId}/release`)
+      .set(auth(nonOwner.token));
+    expect(denied.status).toBe(403);
+
+    const ok = await request(app)
+      .post(`/api/redeem-ops/partners/${partnerId}/release`)
+      .set(auth(ownerToken));
+    expect(ok.status).toBe(200);
+    await row.reload();
+    expect(row.ownerUserId).toBeNull();
+    expect(row.availability).toBe('available');
+  });
+
+  test('outreach exec cannot reassign; bdm can', async () => {
+    const denied = await request(app)
+      .post(`/api/redeem-ops/partners/${partnerId}/assign`)
+      .set(auth(execA.token))
+      .send({ toUserId: execB.user.id });
+    expect(denied.status).toBe(403);
+
+    const ok = await request(app)
+      .post(`/api/redeem-ops/partners/${partnerId}/assign`)
+      .set(auth(bdm.token))
+      .send({ toUserId: execB.user.id, reason: 'territory' });
+    expect(ok.status).toBe(200);
+    const row = await PartnerOrganisation.findByPk(partnerId);
+    expect(row.ownerUserId).toBe(execB.user.id);
+  });
+});
+
+describe('stage machine + activities + row-level ownership', () => {
+  let partnerId;
+  beforeAll(async () => {
+    const res = await createPartner(admin.token, { tradingName: 'Stagecraft Fitness' });
+    partnerId = res.body.data.partner.id;
+    await request(app).post(`/api/redeem-ops/partners/${partnerId}/claim`).set(auth(execA.token));
+  });
+
+  test('invalid transition rejected for exec; forced by admin only with reason', async () => {
+    const bad = await request(app)
+      .patch(`/api/redeem-ops/partners/${partnerId}/stage`)
+      .set(auth(execA.token))
+      .send({ toStage: 'PARTNERED' }); // CLAIMED → PARTNERED is not allowed
+    expect(bad.status).toBe(400);
+
+    const forcedNoReason = await request(app)
+      .patch(`/api/redeem-ops/partners/${partnerId}/stage`)
+      .set(auth(admin.token))
+      .send({ toStage: 'PARTNERED' });
+    expect(forcedNoReason.status).toBe(400);
+
+    const forced = await request(app)
+      .patch(`/api/redeem-ops/partners/${partnerId}/stage`)
+      .set(auth(admin.token))
+      .send({ toStage: 'PARTNERED', reason: 'signed at event' });
+    expect(forced.status).toBe(200);
+  });
+
+  test('non-owner exec cannot move stage or log activity on someone else’s partner', async () => {
+    const move = await request(app)
+      .patch(`/api/redeem-ops/partners/${partnerId}/stage`)
+      .set(auth(execB.token))
+      .send({ toStage: 'FOLLOW_UP_LATER' });
+    expect(move.status).toBe(403);
+
+    const log = await request(app)
+      .post(`/api/redeem-ops/partners/${partnerId}/activities`)
+      .set(auth(execB.token))
+      .send({ type: 'call_attempt', summary: 'tried calling' });
+    expect(log.status).toBe(403);
+  });
+
+  test('meaningful activity stamps firstOutreachAt/lastActivityAt; internal note does not', async () => {
+    const note = await request(app)
+      .post(`/api/redeem-ops/partners/${partnerId}/activities`)
+      .set(auth(execA.token))
+      .send({ type: 'internal_note', summary: 'research notes', direction: 'internal' });
+    expect(note.status).toBe(201);
+    let row = await PartnerOrganisation.findByPk(partnerId);
+    expect(row.firstOutreachAt).toBeNull();
+
+    const call = await request(app)
+      .post(`/api/redeem-ops/partners/${partnerId}/activities`)
+      .set(auth(execA.token))
+      .send({ type: 'call_connected', summary: 'spoke to owner', outcome: 'positive' });
+    expect(call.status).toBe(201);
+    row = await PartnerOrganisation.findByPk(partnerId);
+    expect(row.firstOutreachAt).not.toBeNull();
+    expect(row.lastActivityAt).not.toBeNull();
+  });
+
+  test('timeline merges activities + stage + assignment events, newest first', async () => {
+    const res = await request(app)
+      .get(`/api/redeem-ops/partners/${partnerId}/timeline`)
+      .set(auth(execA.token));
+    expect(res.status).toBe(200);
+    const kinds = new Set(res.body.data.entries.map((e) => e.kind));
+    expect(kinds.has('activity')).toBe(true);
+    expect(kinds.has('stage')).toBe(true);
+    expect(kinds.has('assignment')).toBe(true);
+  });
+});
+
+describe('merge preserves everything', () => {
+  test('children re-point to survivor; loser hidden from lists but retained', async () => {
+    const a = await createPartner(admin.token, { tradingName: 'Merge Survivor Grooming' });
+    const b = await createPartner(admin.token, { tradingName: 'Merge Duplicate Grooming', overrideReason: 'test twin' });
+    const survivorId = a.body.data.partner.id;
+    const duplicateId = b.body.data.partner.id;
+
+    await request(app)
+      .post(`/api/redeem-ops/partners/${duplicateId}/contacts`)
+      .set(auth(admin.token))
+      .send({ name: 'Dup Contact' });
+    await request(app)
+      .post(`/api/redeem-ops/partners/${duplicateId}/claim`)
+      .set(auth(execA.token));
+    await request(app)
+      .post(`/api/redeem-ops/partners/${duplicateId}/activities`)
+      .set(auth(execA.token))
+      .send({ type: 'email_sent', summary: 'intro email' });
+
+    const denied = await request(app)
+      .post(`/api/redeem-ops/partners/${survivorId}/merge`)
+      .set(auth(execA.token))
+      .send({ duplicateId });
+    expect(denied.status).toBe(403); // outreach_exec lacks partners.merge
+
+    const res = await request(app)
+      .post(`/api/redeem-ops/partners/${survivorId}/merge`)
+      .set(auth(admin.token))
+      .send({ duplicateId, reason: 'same business' });
+    expect(res.status).toBe(200);
+
+    const contacts = await PartnerContact.findAll({ where: { partnerOrganisationId: survivorId } });
+    expect(contacts.map((c) => c.name)).toContain('Dup Contact');
+    const activities = await OutreachActivity.findAll({ where: { partnerOrganisationId: survivorId } });
+    expect(activities.length).toBeGreaterThan(0);
+
+    const loser = await PartnerOrganisation.findByPk(duplicateId);
+    expect(loser.mergedIntoId).toBe(survivorId);
+
+    const list = await request(app)
+      .get('/api/redeem-ops/partners')
+      .query({ search: 'Merge Duplicate' })
+      .set(auth(admin.token));
+    expect(list.body.data.partners.map((p) => p.id)).not.toContain(duplicateId);
+
+    const detail = await request(app)
+      .get(`/api/redeem-ops/partners/${duplicateId}`)
+      .set(auth(admin.token));
+    expect(detail.status).toBe(404);
+  });
+});

--- a/backend/test/redeemOpsWork.test.js
+++ b/backend/test/redeemOpsWork.test.js
@@ -1,0 +1,224 @@
+/**
+ * Phase 3 — tasks, pools, queue (brief §37 Tasks + pool claim-next concurrency).
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+
+import request from 'supertest';
+import { getApp, closeDb, createTestUser } from './helpers.js';
+import { PartnerOrganisation, OutreachTask, ProspectingPoolMember, sequelize } from '../src/models/index.js';
+import { makePoolService } from '../src/services/redeemOps/poolService.js';
+import { runRedeemOpsStaleSweep } from '../src/services/redeemOps/staleSweep.js';
+import { sgtDayWindow } from '../src/services/redeemOps/taskService.js';
+
+let app;
+let admin, bdm, execA, execB;
+
+beforeAll(async () => {
+  app = await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  bdm = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'bdm' });
+  execA = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
+  execB = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+const auth = (t) => ({ Authorization: `Bearer ${t}` });
+
+async function makePartner(name) {
+  const res = await request(app)
+    .post('/api/redeem-ops/partners')
+    .set(auth(admin.token))
+    .send({ tradingName: name });
+  return res.body.data.partner;
+}
+
+describe('tasks', () => {
+  let partner;
+  beforeAll(async () => {
+    partner = await makePartner('Task Target Cafe');
+  });
+
+  test('create → nextTaskAt denormalized onto the partner', async () => {
+    const due = new Date(Date.now() + 24 * 3600 * 1000).toISOString();
+    const res = await request(app)
+      .post('/api/redeem-ops/tasks')
+      .set(auth(execA.token))
+      .send({ title: 'Follow up on 1 Sept', partnerOrganisationId: partner.id, dueAt: due });
+    expect(res.status).toBe(201);
+    const row = await PartnerOrganisation.findByPk(partner.id);
+    expect(new Date(row.nextTaskAt).toISOString()).toBe(due);
+  });
+
+  test('exec cannot assign a task to someone else; manager can', async () => {
+    const due = new Date(Date.now() + 48 * 3600 * 1000).toISOString();
+    const denied = await request(app)
+      .post('/api/redeem-ops/tasks')
+      .set(auth(execA.token))
+      .send({ title: 'For B', partnerOrganisationId: partner.id, dueAt: due, assigneeUserId: execB.user.id });
+    expect(denied.status).toBe(403);
+
+    const ok = await request(app)
+      .post('/api/redeem-ops/tasks')
+      .set(auth(bdm.token))
+      .send({ title: 'For B', partnerOrganisationId: partner.id, dueAt: due, assigneeUserId: execB.user.id });
+    expect(ok.status).toBe(201);
+  });
+
+  test('due-state buckets respect the SGT day window', async () => {
+    const { start } = sgtDayWindow();
+    await OutreachTask.create({
+      title: 'Overdue thing', partnerOrganisationId: partner.id,
+      assigneeUserId: execA.user.id, createdBy: execA.user.id,
+      dueAt: new Date(start.getTime() - 3600 * 1000),
+    });
+    const res = await request(app)
+      .get('/api/redeem-ops/tasks')
+      .query({ due: 'overdue' })
+      .set(auth(execA.token));
+    expect(res.status).toBe(200);
+    expect(res.body.data.tasks.some((t) => t.title === 'Overdue thing')).toBe(true);
+    // exec's list never contains someone else's tasks
+    expect(res.body.data.tasks.every((t) => t.assigneeUserId === execA.user.id)).toBe(true);
+  });
+
+  test('completion stamps completedAt/By and clears nextTaskAt when none remain', async () => {
+    const solo = await makePartner('Solo Task Studio');
+    const created = await request(app)
+      .post('/api/redeem-ops/tasks')
+      .set(auth(execA.token))
+      .send({ title: 'One and done', partnerOrganisationId: solo.id, dueAt: new Date().toISOString() });
+    const taskId = created.body.data.task.id;
+
+    const notMine = await request(app)
+      .patch(`/api/redeem-ops/tasks/${taskId}`)
+      .set(auth(execB.token))
+      .send({ status: 'completed' });
+    expect(notMine.status).toBe(403);
+
+    const done = await request(app)
+      .patch(`/api/redeem-ops/tasks/${taskId}`)
+      .set(auth(execA.token))
+      .send({ status: 'completed' });
+    expect(done.status).toBe(200);
+    expect(done.body.data.task.completedBy).toBe(execA.user.id);
+
+    const row = await PartnerOrganisation.findByPk(solo.id);
+    expect(row.nextTaskAt).toBeNull();
+  });
+});
+
+describe('pools + claim-next concurrency', () => {
+  let poolId;
+  const partnerIds = [];
+
+  beforeAll(async () => {
+    const poolRes = await request(app)
+      .post('/api/redeem-ops/pools')
+      .set(auth(bdm.token))
+      .send({ name: `Nail Salons Central ${Date.now()}` });
+    poolId = poolRes.body.data.pool.id;
+    for (let i = 0; i < 3; i += 1) {
+      const p = await makePartner(`Pool Prospect ${Date.now()}-${i}`);
+      partnerIds.push(p.id);
+    }
+    const add = await request(app)
+      .post(`/api/redeem-ops/pools/${poolId}/members`)
+      .set(auth(bdm.token))
+      .send({ partnerIds });
+    expect(add.body.data.added).toBe(3);
+  });
+
+  test('exec cannot create pools or add members', async () => {
+    const denied = await request(app)
+      .post('/api/redeem-ops/pools')
+      .set(auth(execA.token))
+      .send({ name: 'Nope' });
+    expect(denied.status).toBe(403);
+  });
+
+  test('CONCURRENT claim-next → different partners, no double-claim', async () => {
+    const pools = makePoolService();
+    const [a, b] = await Promise.all([
+      pools.claimNext(poolId, execA.user),
+      pools.claimNext(poolId, execB.user),
+    ]);
+    expect(a).toBeTruthy();
+    expect(b).toBeTruthy();
+    expect(a).not.toBe(b);
+
+    const rows = await PartnerOrganisation.findAll({ where: { id: [a, b] } });
+    const owners = rows.map((r) => r.ownerUserId).sort();
+    expect(owners).toEqual([execA.user.id, execB.user.id].sort());
+  });
+
+  test('a partner claimed OUTSIDE the pool never surfaces via claim-next (pool exhausted)', async () => {
+    const remaining = await ProspectingPoolMember.findOne({ where: { poolId, status: 'available' } });
+    // Claim it directly (outside the pool) — the claim-next join now filters it out
+    await request(app)
+      .post(`/api/redeem-ops/partners/${remaining.partnerOrganisationId}/claim`)
+      .set(auth(bdm.token));
+
+    const pools = makePoolService();
+    const next = await pools.claimNext(poolId, execA.user);
+    expect(next).toBeNull(); // pool had only that one left → exhausted, never re-offered
+
+    const viaHttp = await request(app)
+      .post(`/api/redeem-ops/pools/${poolId}/claim-next`)
+      .set(auth(execA.token));
+    expect(viaHttp.status).toBe(200);
+    expect(viaHttp.body.data.partnerId).toBeNull();
+  });
+});
+
+describe('stale sweep', () => {
+  test('flags at-risk + stale, but spares FOLLOW_UP_LATER with a future task', async () => {
+    const old = new Date(Date.now() - 20 * 24 * 3600 * 1000);
+
+    const atRisk = await makePartner('AtRisk Barber');
+    await PartnerOrganisation.update(
+      { ownerUserId: execA.user.id, availability: 'owned', claimedAt: new Date(Date.now() - 72 * 3600 * 1000) },
+      { where: { id: atRisk.id } }
+    );
+
+    const stale = await makePartner('Stale Bakery');
+    await PartnerOrganisation.update(
+      { ownerUserId: execA.user.id, availability: 'owned', claimedAt: old, firstOutreachAt: old, lastActivityAt: old, pipelineStage: 'CONTACTED' },
+      { where: { id: stale.id } }
+    );
+
+    const parked = await makePartner('Parked Gym');
+    await PartnerOrganisation.update(
+      { ownerUserId: execA.user.id, availability: 'follow_up_later', claimedAt: old, firstOutreachAt: old, lastActivityAt: old, pipelineStage: 'FOLLOW_UP_LATER' },
+      { where: { id: parked.id } }
+    );
+    await OutreachTask.create({
+      title: 'Revisit in Q4', partnerOrganisationId: parked.id,
+      assigneeUserId: execA.user.id, createdBy: execA.user.id,
+      dueAt: new Date(Date.now() + 30 * 24 * 3600 * 1000),
+    });
+
+    await runRedeemOpsStaleSweep();
+
+    expect((await PartnerOrganisation.findByPk(atRisk.id)).atRiskFlag).toBe(true);
+    expect((await PartnerOrganisation.findByPk(stale.id)).staleFlag).toBe(true);
+    expect((await PartnerOrganisation.findByPk(parked.id)).staleFlag).toBe(false);
+  });
+});
+
+describe('queue', () => {
+  test('my queue aggregates buckets for the signed-in user', async () => {
+    const res = await request(app).get('/api/redeem-ops/queue').set(auth(execA.token));
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveProperty('overdueTasks');
+    expect(res.body.data).toHaveProperty('awaitingFirstOutreach');
+    expect(res.body.data.overdueTasks.total).toBeGreaterThan(0);
+  });
+
+  test('team pipeline is manager/analyst-gated', async () => {
+    expect((await request(app).get('/api/redeem-ops/team/pipeline').set(auth(execA.token))).status).toBe(403);
+    expect((await request(app).get('/api/redeem-ops/team/pipeline').set(auth(bdm.token))).status).toBe(200);
+  });
+});

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -34,4 +34,108 @@ export const redeemOpsApi = {
     const res = await apiClient.get('/redeem-ops/meta/constants');
     return res.data;
   },
+
+  // ── Partner CRM (Phase 2) ──────────────────────────────────────────────
+  async listPartners(params = {}) {
+    const res = await apiClient.get('/redeem-ops/partners', params);
+    return res.data;
+  },
+  async checkDuplicates(params = {}) {
+    const res = await apiClient.get('/redeem-ops/partners/check-duplicates', params);
+    return res.data?.duplicates || { exact: [], potential: [] };
+  },
+  async createPartner(body) {
+    const res = await apiClient.post('/redeem-ops/partners', body);
+    return res.data;
+  },
+  async getPartner(id) {
+    const res = await apiClient.get(`/redeem-ops/partners/${id}`);
+    return res.data?.partner;
+  },
+  async updatePartner(id, body) {
+    const res = await apiClient.put(`/redeem-ops/partners/${id}`, body);
+    return res.data?.partner;
+  },
+  async claimPartner(id) {
+    const res = await apiClient.post(`/redeem-ops/partners/${id}/claim`, {});
+    return res.data;
+  },
+  async releasePartner(id, reason) {
+    const res = await apiClient.post(`/redeem-ops/partners/${id}/release`, { reason });
+    return res.data;
+  },
+  async assignPartner(id, toUserId, reason) {
+    const res = await apiClient.post(`/redeem-ops/partners/${id}/assign`, { toUserId, reason });
+    return res.data;
+  },
+  async changeStage(id, toStage, reason) {
+    const res = await apiClient.patch(`/redeem-ops/partners/${id}/stage`, { toStage, reason });
+    return res.data;
+  },
+  async getTimeline(id, params = {}) {
+    const res = await apiClient.get(`/redeem-ops/partners/${id}/timeline`, params);
+    return res.data?.entries || [];
+  },
+  async logActivity(id, body) {
+    const res = await apiClient.post(`/redeem-ops/partners/${id}/activities`, body);
+    return res.data?.activity;
+  },
+  async addContact(id, body) {
+    const res = await apiClient.post(`/redeem-ops/partners/${id}/contacts`, body);
+    return res.data?.contact;
+  },
+  async updateContact(contactId, body) {
+    const res = await apiClient.patch(`/redeem-ops/contacts/${contactId}`, body);
+    return res.data?.contact;
+  },
+  async archiveContact(contactId) {
+    const res = await apiClient.post(`/redeem-ops/contacts/${contactId}/archive`, {});
+    return res.data;
+  },
+  async addLocation(id, body) {
+    const res = await apiClient.post(`/redeem-ops/partners/${id}/locations`, body);
+    return res.data?.location;
+  },
+  async updateLocation(locationId, body) {
+    const res = await apiClient.patch(`/redeem-ops/locations/${locationId}`, body);
+    return res.data?.location;
+  },
+
+  // ── Queue, tasks, pools (Phase 3) ──────────────────────────────────────
+  async getMyQueue() {
+    const res = await apiClient.get('/redeem-ops/queue');
+    return res.data;
+  },
+  async getTeamPipeline() {
+    const res = await apiClient.get('/redeem-ops/team/pipeline');
+    return res.data;
+  },
+  async listTasks(params = {}) {
+    const res = await apiClient.get('/redeem-ops/tasks', params);
+    return res.data;
+  },
+  async createTask(body) {
+    const res = await apiClient.post('/redeem-ops/tasks', body);
+    return res.data?.task;
+  },
+  async updateTask(taskId, body) {
+    const res = await apiClient.patch(`/redeem-ops/tasks/${taskId}`, body);
+    return res.data?.task;
+  },
+  async listPools() {
+    const res = await apiClient.get('/redeem-ops/pools');
+    return res.data?.pools || [];
+  },
+  async createPool(body) {
+    const res = await apiClient.post('/redeem-ops/pools', body);
+    return res.data?.pool;
+  },
+  async addPoolMembers(poolId, partnerIds) {
+    const res = await apiClient.post(`/redeem-ops/pools/${poolId}/members`, { partnerIds });
+    return res.data;
+  },
+  async claimNextFromPool(poolId) {
+    const res = await apiClient.post(`/redeem-ops/pools/${poolId}/claim-next`, {});
+    return res.data;
+  },
 };

--- a/src/components/layout/DashboardLayout.jsx
+++ b/src/components/layout/DashboardLayout.jsx
@@ -15,6 +15,7 @@ import {
  Package,
  Search,
 } from 'lucide-react';
+import { hasCapability as hasRedeemOpsCapability } from '@/lib/redeemOpsPermissions';
 import NotificationBell from './NotificationBell.jsx';
 import CommandPalette from './CommandPalette.jsx';
 import ThemeToggle from './ThemeToggle.jsx';
@@ -96,14 +97,20 @@ const getNavigationItems = (user) => {
  ];
 
  // Redeem Ops — flag-gated internal staff surface (docs/redeem-ops/ROUTE_MAP.md §2).
+ // Items carry the capability their page requires; the nav mirrors the server
+ // gate so nobody sees a link the API would 403 (Codex P1 review finding 6).
  const REDEEM_OPS_UI = import.meta.env.VITE_REDEEM_OPS_ENABLED === 'true';
  const redeemOpsSections = [
  {
  label: 'Redeem Ops',
  items: [
- { title: 'Overview', url: '/redeem-ops', icon: LayoutDashboard },
- { title: 'Team', url: '/redeem-ops/team', icon: Users },
- ],
+ { title: 'My Queue', url: '/redeem-ops/queue', icon: LayoutDashboard },
+ { title: 'Partners', url: '/redeem-ops/partners', icon: Users, capability: 'partners.view' },
+ { title: 'Pipeline', url: '/redeem-ops/pipeline', icon: Settings, capability: 'pipeline.view_team' },
+ { title: 'Tasks', url: '/redeem-ops/tasks', icon: FileText, capability: 'tasks.manage' },
+ { title: 'Pools', url: '/redeem-ops/pools', icon: Package, capability: 'pools.claim_next' },
+ { title: 'Team', url: '/redeem-ops/team', icon: Users, capability: 'analytics.view_team' },
+ ].filter((item) => !item.capability || hasRedeemOpsCapability(user, item.capability)),
  },
  ];
 

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -78,6 +78,12 @@ const AgentProfile = lazy(() => import('./AgentProfile'));
 const REDEEM_OPS_ENABLED = import.meta.env.VITE_REDEEM_OPS_ENABLED === 'true';
 const RedeemOpsHome = lazy(() => import('./redeemops/RedeemOpsHome'));
 const RedeemOpsTeam = lazy(() => import('./redeemops/RedeemOpsTeam'));
+const RedeemOpsPartnersList = lazy(() => import('./redeemops/PartnersList'));
+const RedeemOpsPartnerDetail = lazy(() => import('./redeemops/PartnerDetail'));
+const RedeemOpsMyQueue = lazy(() => import('./redeemops/MyQueue'));
+const RedeemOpsTasks = lazy(() => import('./redeemops/TasksPage'));
+const RedeemOpsPools = lazy(() => import('./redeemops/PoolsPage'));
+const RedeemOpsTeamPipeline = lazy(() => import('./redeemops/TeamPipeline'));
 
 function PagesContent() {
  const navigate = useNavigate();
@@ -450,9 +456,75 @@ function PagesContent() {
  {REDEEM_OPS_ENABLED && (
  <Route
  path="/redeem-ops/team" element={
- <RedeemOpsRoute>
+ <RedeemOpsRoute capability="analytics.view_team">
  <DashboardLayout>
  <RedeemOpsTeam />
+ </DashboardLayout>
+ </RedeemOpsRoute>
+ }
+ />
+ )}
+ {REDEEM_OPS_ENABLED && (
+ <Route
+ path="/redeem-ops/partners" element={
+ <RedeemOpsRoute capability="partners.view">
+ <DashboardLayout>
+ <RedeemOpsPartnersList />
+ </DashboardLayout>
+ </RedeemOpsRoute>
+ }
+ />
+ )}
+ {REDEEM_OPS_ENABLED && (
+ <Route
+ path="/redeem-ops/partners/:id" element={
+ <RedeemOpsRoute capability="partners.view">
+ <DashboardLayout>
+ <RedeemOpsPartnerDetail />
+ </DashboardLayout>
+ </RedeemOpsRoute>
+ }
+ />
+ )}
+ {REDEEM_OPS_ENABLED && (
+ <Route
+ path="/redeem-ops/queue" element={
+ <RedeemOpsRoute>
+ <DashboardLayout>
+ <RedeemOpsMyQueue />
+ </DashboardLayout>
+ </RedeemOpsRoute>
+ }
+ />
+ )}
+ {REDEEM_OPS_ENABLED && (
+ <Route
+ path="/redeem-ops/tasks" element={
+ <RedeemOpsRoute capability="tasks.manage">
+ <DashboardLayout>
+ <RedeemOpsTasks />
+ </DashboardLayout>
+ </RedeemOpsRoute>
+ }
+ />
+ )}
+ {REDEEM_OPS_ENABLED && (
+ <Route
+ path="/redeem-ops/pools" element={
+ <RedeemOpsRoute capability="pools.claim_next">
+ <DashboardLayout>
+ <RedeemOpsPools />
+ </DashboardLayout>
+ </RedeemOpsRoute>
+ }
+ />
+ )}
+ {REDEEM_OPS_ENABLED && (
+ <Route
+ path="/redeem-ops/pipeline" element={
+ <RedeemOpsRoute capability="pipeline.view_team">
+ <DashboardLayout>
+ <RedeemOpsTeamPipeline />
  </DashboardLayout>
  </RedeemOpsRoute>
  }

--- a/src/pages/redeemops/MyQueue.jsx
+++ b/src/pages/redeemops/MyQueue.jsx
@@ -1,0 +1,166 @@
+import { Link } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { redeemOpsApi } from '@/api/redeemOps';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+
+function partnerName(p) {
+  return p?.tradingName || p?.brandName || p?.legalName || 'Business';
+}
+
+function TaskRow({ task, onComplete, completing }) {
+  return (
+    <div className="flex items-center justify-between gap-2 py-2 border-b border-border last:border-0">
+      <div className="min-w-0">
+        <p className="text-sm font-medium truncate">{task.title}</p>
+        <p className="text-xs text-muted-foreground truncate">
+          <Link to={`/redeem-ops/partners/${task.partner?.id}`} className="underline">
+            {partnerName(task.partner)}
+          </Link>
+          {' · due '}
+          {new Date(task.dueAt).toLocaleDateString()}
+          {task.contact?.name ? ` · ${task.contact.name}` : ''}
+        </p>
+      </div>
+      <Button size="sm" variant="outline" disabled={completing} onClick={() => onComplete(task.id)}>
+        Done
+      </Button>
+    </div>
+  );
+}
+
+function PartnerRow({ partner, note }) {
+  return (
+    <div className="py-2 border-b border-border last:border-0">
+      <p className="text-sm font-medium">
+        <Link to={`/redeem-ops/partners/${partner.id}`} className="underline">
+          {partnerName(partner)}
+        </Link>
+      </p>
+      <p className="text-xs text-muted-foreground">{note}</p>
+    </div>
+  );
+}
+
+function Bucket({ title, description, count, children, tone }) {
+  return (
+    <Card className={tone === 'warn' ? 'border-amber-300' : undefined}>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base flex items-center gap-2">
+          {title}
+          {count > 0 && <Badge variant={tone === 'warn' ? 'destructive' : 'secondary'}>{count}</Badge>}
+        </CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
+  );
+}
+
+export default function MyQueue() {
+  const queryClient = useQueryClient();
+  const queueQuery = useQuery({ queryKey: ['redeem-ops', 'queue'], queryFn: redeemOpsApi.getMyQueue });
+
+  const completeMutation = useMutation({
+    mutationFn: (taskId) => redeemOpsApi.updateTask(taskId, { status: 'completed' }),
+    onSuccess: () => {
+      toast.success('Task completed');
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'queue'] });
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'tasks'] });
+    },
+    onError: (err) => toast.error('Could not complete task', { description: err.message }),
+  });
+
+  const q = queueQuery.data;
+  if (queueQuery.isLoading) return <div className="p-6 text-muted-foreground">Loading your queue…</div>;
+  if (!q) return <div className="p-6 text-muted-foreground">Queue unavailable.</div>;
+
+  const empty =
+    q.overdueTasks.items.length + q.dueTodayTasks.items.length + q.awaitingFirstOutreach.items.length +
+    q.stalePartners.items.length + q.recentReplies.items.length + q.upcomingTasks.items.length === 0;
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto space-y-4">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">My queue</h1>
+        <p className="text-sm text-muted-foreground mt-1">Start here — this is your day, in order of urgency.</p>
+      </div>
+
+      {empty && (
+        <Card>
+          <CardContent className="py-10 text-center text-muted-foreground">
+            Queue clear 🎉 — grab a new prospect from a <Link to="/redeem-ops/pools" className="underline">pool</Link> or
+            search <Link to="/redeem-ops/partners" className="underline">Partners</Link>.
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {q.overdueTasks.items.length > 0 && (
+          <Bucket title="Overdue" description="Follow-ups past their due date" count={q.overdueTasks.total} tone="warn">
+            {q.overdueTasks.items.map((t) => (
+              <TaskRow key={t.id} task={t} onComplete={completeMutation.mutate} completing={completeMutation.isPending} />
+            ))}
+          </Bucket>
+        )}
+        {q.dueTodayTasks.items.length > 0 && (
+          <Bucket title="Due today" description="Scheduled for today" count={q.dueTodayTasks.total}>
+            {q.dueTodayTasks.items.map((t) => (
+              <TaskRow key={t.id} task={t} onComplete={completeMutation.mutate} completing={completeMutation.isPending} />
+            ))}
+          </Bucket>
+        )}
+        {q.awaitingFirstOutreach.items.length > 0 && (
+          <Bucket
+            title="Awaiting first outreach"
+            description="Claimed but not yet contacted — reach out within 48h"
+            count={q.awaitingFirstOutreach.total}
+            tone="warn"
+          >
+            {q.awaitingFirstOutreach.items.map((p) => (
+              <PartnerRow
+                key={p.id}
+                partner={p}
+                note={`Claimed ${p.claimedAt ? new Date(p.claimedAt).toLocaleDateString() : 'recently'}${p.atRiskFlag ? ' · AT RISK' : ''}`}
+              />
+            ))}
+          </Bucket>
+        )}
+        {q.recentReplies.items.length > 0 && (
+          <Bucket title="Recent replies" description="They responded — keep the momentum" count={q.recentReplies.items.length}>
+            {q.recentReplies.items.map((r) => (
+              <div key={r.id} className="py-2 border-b border-border last:border-0">
+                <p className="text-sm font-medium">
+                  <Link to={`/redeem-ops/partners/${r.partnerId}`} className="underline">{r.partnerName}</Link>
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {r.type.replaceAll('_', ' ')} · {r.summary} · {new Date(r.occurredAt).toLocaleDateString()}
+                </p>
+              </div>
+            ))}
+          </Bucket>
+        )}
+        {q.upcomingTasks.items.length > 0 && (
+          <Bucket title="Coming up (3 days)" description="What's next after today">
+            {q.upcomingTasks.items.map((t) => (
+              <TaskRow key={t.id} task={t} onComplete={completeMutation.mutate} completing={completeMutation.isPending} />
+            ))}
+          </Bucket>
+        )}
+        {q.stalePartners.items.length > 0 && (
+          <Bucket title="Gone quiet" description="No activity in 14+ days — revive or release" count={q.stalePartners.total} tone="warn">
+            {q.stalePartners.items.map((p) => (
+              <PartnerRow
+                key={p.id}
+                partner={p}
+                note={`Last activity ${p.lastActivityAt ? new Date(p.lastActivityAt).toLocaleDateString() : 'never'} · ${p.pipelineStage.replaceAll('_', ' ')}`}
+              />
+            ))}
+          </Bucket>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/redeemops/PartnerDetail.jsx
+++ b/src/pages/redeemops/PartnerDetail.jsx
@@ -1,0 +1,369 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { redeemOpsApi } from '@/api/redeemOps';
+import { useAuthStore } from '@/stores/authStore';
+import { hasCapability } from '@/lib/redeemOpsPermissions';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import { Textarea } from '@/components/ui/textarea';
+import Phone from 'lucide-react/icons/phone';
+import Globe from 'lucide-react/icons/globe';
+import Instagram from 'lucide-react/icons/instagram';
+
+function TimelineEntry({ entry }) {
+  const at = new Date(entry.at).toLocaleString();
+  if (entry.kind === 'activity') {
+    const a = entry.data;
+    return (
+      <div className="border-l-2 border-border pl-3 pb-4">
+        <p className="text-sm font-medium">
+          {a.type.replaceAll('_', ' ')}
+          {a.contact?.name ? ` · with ${a.contact.name}` : ''}
+        </p>
+        <p className="text-sm text-muted-foreground">{a.summary}</p>
+        {a.outcome && <p className="text-xs text-muted-foreground">Outcome: {a.outcome}</p>}
+        <p className="text-xs text-muted-foreground mt-0.5">{a.actor?.fullName || 'System'} · {at}</p>
+      </div>
+    );
+  }
+  if (entry.kind === 'stage') {
+    const e = entry.data;
+    return (
+      <div className="border-l-2 border-primary/40 pl-3 pb-4">
+        <p className="text-sm">
+          Stage: <span className="font-medium">{(e.fromStage || '—').replaceAll('_', ' ')}</span>
+          {' → '}
+          <span className="font-medium">{e.toStage.replaceAll('_', ' ')}</span>
+        </p>
+        <p className="text-xs text-muted-foreground mt-0.5">{e.actor?.fullName || 'System'} · {at}{e.reason ? ` · ${e.reason}` : ''}</p>
+      </div>
+    );
+  }
+  const e = entry.data;
+  return (
+    <div className="border-l-2 border-border pl-3 pb-4">
+      <p className="text-sm">
+        Ownership: <span className="font-medium">{e.kind}</span>
+        {e.toUser ? ` → ${e.toUser.fullName}` : ''}
+      </p>
+      <p className="text-xs text-muted-foreground mt-0.5">{e.actor?.fullName || 'System'} · {at}{e.reason ? ` · ${e.reason}` : ''}</p>
+    </div>
+  );
+}
+
+const EMPTY_ACTIVITY = { type: 'call_attempt', summary: '', details: '', outcome: '', contactId: '' };
+const EMPTY_CONTACT = { name: '', roleTitle: '', mobile: '', email: '', preferredChannel: '' };
+const EMPTY_LOCATION = { name: '', addressLine: '', postalCode: '', phone: '' };
+
+export default function PartnerDetail() {
+  const { id } = useParams();
+  const user = useAuthStore((s) => s.user);
+  const queryClient = useQueryClient();
+
+  const partnerQuery = useQuery({
+    queryKey: ['redeem-ops', 'partner', id],
+    queryFn: () => redeemOpsApi.getPartner(id),
+  });
+  const timelineQuery = useQuery({
+    queryKey: ['redeem-ops', 'partner', id, 'timeline'],
+    queryFn: () => redeemOpsApi.getTimeline(id),
+  });
+  const constants = useQuery({
+    queryKey: ['redeem-ops', 'constants'],
+    queryFn: redeemOpsApi.getConstants,
+    staleTime: Infinity,
+  });
+  const teamQuery = useQuery({
+    queryKey: ['redeem-ops', 'team'],
+    queryFn: redeemOpsApi.getTeam,
+    enabled: hasCapability(user, 'partners.reassign'),
+  });
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partner', id] });
+    queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partners'] });
+  };
+
+  const useSimpleMutation = (fn, okMsg) => useMutation({
+    mutationFn: fn,
+    onSuccess: () => { toast.success(okMsg); invalidate(); },
+    onError: (err) => toast.error(err.message, { description: err.data?.claimedBy ? `Claimed by ${err.data.claimedBy.fullName}` : undefined }),
+  });
+
+  const claimMutation = useSimpleMutation(() => redeemOpsApi.claimPartner(id), 'Business claimed — it’s yours');
+  const releaseMutation = useSimpleMutation(() => redeemOpsApi.releasePartner(id), 'Released back to the pool');
+  const stageMutation = useMutation({
+    mutationFn: ({ toStage, reason }) => redeemOpsApi.changeStage(id, toStage, reason),
+    onSuccess: () => { toast.success('Stage updated'); invalidate(); },
+    onError: (err) => toast.error('Stage change rejected', { description: err.message }),
+  });
+  const assignMutation = useMutation({
+    mutationFn: ({ toUserId }) => redeemOpsApi.assignPartner(id, toUserId),
+    onSuccess: () => { toast.success('Reassigned'); invalidate(); },
+    onError: (err) => toast.error('Reassign failed', { description: err.message }),
+  });
+
+  const [activityOpen, setActivityOpen] = useState(false);
+  const [activity, setActivity] = useState(EMPTY_ACTIVITY);
+  const activityMutation = useMutation({
+    mutationFn: () => redeemOpsApi.logActivity(id, {
+      ...activity,
+      contactId: activity.contactId || null,
+      details: activity.details || null,
+      outcome: activity.outcome || null,
+    }),
+    onSuccess: () => {
+      toast.success('Activity logged');
+      setActivityOpen(false); setActivity(EMPTY_ACTIVITY);
+      invalidate();
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partner', id, 'timeline'] });
+    },
+    onError: (err) => toast.error('Could not log activity', { description: err.message }),
+  });
+
+  const [contactForm, setContactForm] = useState(EMPTY_CONTACT);
+  const contactMutation = useMutation({
+    mutationFn: () => redeemOpsApi.addContact(id, contactForm),
+    onSuccess: () => { toast.success('Contact added'); setContactForm(EMPTY_CONTACT); invalidate(); },
+    onError: (err) => toast.error('Could not add contact', { description: err.message }),
+  });
+
+  const [locationForm, setLocationForm] = useState(EMPTY_LOCATION);
+  const locationMutation = useMutation({
+    mutationFn: () => redeemOpsApi.addLocation(id, locationForm),
+    onSuccess: () => { toast.success('Location added'); setLocationForm(EMPTY_LOCATION); invalidate(); },
+    onError: (err) => toast.error('Could not add location', { description: err.message }),
+  });
+
+  const partner = partnerQuery.data;
+  if (partnerQuery.isLoading) {
+    return <div className="p-6 text-muted-foreground">Loading…</div>;
+  }
+  if (!partner) {
+    return <div className="p-6 text-muted-foreground">Business not found.</div>;
+  }
+
+  const name = partner.tradingName || partner.brandName || partner.legalName;
+  const isOwner = partner.ownerUserId === user?.id;
+  const isUnowned = !partner.ownerUserId;
+  const canReassign = hasCapability(user, 'partners.reassign');
+  const allowedNext = constants.data?.stageTransitions?.[partner.pipelineStage] || [];
+  const activityTypes = constants.data?.activityTypes || [];
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto space-y-4">
+      <Card>
+        <CardContent className="pt-5">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="space-y-1 min-w-0">
+              <h1 className="text-xl font-semibold tracking-tight">{name}</h1>
+              <p className="text-sm text-muted-foreground">
+                {partner.category || 'Uncategorised'}
+                {partner.legalName && partner.legalName !== name ? ` · ${partner.legalName}` : ''}
+                {partner.uen ? ` · UEN ${partner.uen}` : ''}
+              </p>
+              <div className="flex flex-wrap gap-3 text-sm text-muted-foreground pt-1">
+                {partner.primaryPhone && <span className="flex items-center gap-1"><Phone className="w-3.5 h-3.5" aria-hidden="true" />{partner.primaryPhone}</span>}
+                {partner.websiteDomain && <span className="flex items-center gap-1"><Globe className="w-3.5 h-3.5" aria-hidden="true" />{partner.websiteDomain}</span>}
+                {partner.instagramHandle && <span className="flex items-center gap-1"><Instagram className="w-3.5 h-3.5" aria-hidden="true" />@{partner.instagramHandle}</span>}
+              </div>
+            </div>
+
+            <div className="flex flex-col items-end gap-2">
+              <div className="flex items-center gap-2">
+                <Badge variant="secondary">{partner.pipelineStage.replaceAll('_', ' ')}</Badge>
+                {partner.owner
+                  ? <Badge variant="outline">Owner: {partner.owner.fullName}</Badge>
+                  : <Badge variant="outline">Unowned</Badge>}
+              </div>
+              <div className="flex items-center gap-2">
+                {isUnowned && hasCapability(user, 'partners.claim') && (
+                  <Button size="sm" onClick={() => claimMutation.mutate()} disabled={claimMutation.isPending}>
+                    {claimMutation.isPending ? 'Claiming…' : 'Claim business'}
+                  </Button>
+                )}
+                {isOwner && (
+                  <Button size="sm" variant="outline" onClick={() => releaseMutation.mutate()}>
+                    Release
+                  </Button>
+                )}
+                {canReassign && (
+                  <Select onValueChange={(toUserId) => assignMutation.mutate({ toUserId })}>
+                    <SelectTrigger className="w-44 h-9"><SelectValue placeholder="Assign to…" /></SelectTrigger>
+                    <SelectContent>
+                      {(teamQuery.data || []).filter((m) => m.isActive).map((m) => (
+                        <SelectItem key={m.id} value={m.id}>{m.fullName || m.email}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+                {(isOwner || canReassign) && allowedNext.length > 0 && (
+                  <Select onValueChange={(toStage) => stageMutation.mutate({ toStage })}>
+                    <SelectTrigger className="w-48 h-9"><SelectValue placeholder="Move stage…" /></SelectTrigger>
+                    <SelectContent>
+                      {allowedNext.map((s) => (
+                        <SelectItem key={s} value={s}>{s.replaceAll('_', ' ')}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Tabs defaultValue="timeline">
+        <TabsList>
+          <TabsTrigger value="timeline">Timeline</TabsTrigger>
+          <TabsTrigger value="contacts">Contacts ({partner.contacts?.length || 0})</TabsTrigger>
+          <TabsTrigger value="locations">Locations ({partner.locations?.length || 0})</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="timeline">
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+              <CardTitle className="text-base">Activity timeline</CardTitle>
+              {(isOwner || canReassign) && (
+                <Button size="sm" onClick={() => setActivityOpen(true)}>Log activity</Button>
+              )}
+            </CardHeader>
+            <CardContent>
+              {(timelineQuery.data || []).length === 0 && (
+                <p className="text-sm text-muted-foreground">No activity yet — claim it and make the first touch.</p>
+              )}
+              {(timelineQuery.data || []).map((entry, i) => (
+                <TimelineEntry key={`${entry.kind}-${entry.data.id || i}`} entry={entry} />
+              ))}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="contacts">
+          <Card>
+            <CardContent className="pt-5 space-y-4">
+              {(partner.contacts || []).map((c) => (
+                <div key={c.id} className="flex items-start justify-between border-b border-border pb-3 last:border-0">
+                  <div>
+                    <p className="text-sm font-medium">
+                      {c.name} {c.isPrimary && <Badge variant="secondary" className="ml-1">Primary</Badge>}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {[c.roleTitle, c.mobile, c.email].filter(Boolean).join(' · ') || '—'}
+                    </p>
+                  </div>
+                </div>
+              ))}
+              {(isOwner || canReassign) && (
+                <div className="grid grid-cols-2 gap-2 pt-2">
+                  <Input placeholder="Name *" value={contactForm.name} onChange={(e) => setContactForm((f) => ({ ...f, name: e.target.value }))} />
+                  <Input placeholder="Role (e.g. Owner)" value={contactForm.roleTitle} onChange={(e) => setContactForm((f) => ({ ...f, roleTitle: e.target.value }))} />
+                  <Input placeholder="Mobile" value={contactForm.mobile} onChange={(e) => setContactForm((f) => ({ ...f, mobile: e.target.value }))} />
+                  <Input placeholder="Email" value={contactForm.email} onChange={(e) => setContactForm((f) => ({ ...f, email: e.target.value }))} />
+                  <Button
+                    size="sm"
+                    className="col-span-2 justify-self-start"
+                    disabled={!contactForm.name.trim() || contactMutation.isPending}
+                    onClick={() => contactMutation.mutate()}
+                  >
+                    Add contact
+                  </Button>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="locations">
+          <Card>
+            <CardContent className="pt-5 space-y-4">
+              {(partner.locations || []).map((l) => (
+                <div key={l.id} className="border-b border-border pb-3 last:border-0">
+                  <p className="text-sm font-medium">{l.name || 'Outlet'}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {[l.addressLine, l.postalCode && `S${l.postalCode}`, l.phone].filter(Boolean).join(' · ') || '—'}
+                  </p>
+                </div>
+              ))}
+              {(isOwner || canReassign) && (
+                <div className="grid grid-cols-2 gap-2 pt-2">
+                  <Input placeholder="Outlet name" value={locationForm.name} onChange={(e) => setLocationForm((f) => ({ ...f, name: e.target.value }))} />
+                  <Input placeholder="Postal code" value={locationForm.postalCode} onChange={(e) => setLocationForm((f) => ({ ...f, postalCode: e.target.value }))} />
+                  <Input placeholder="Address" className="col-span-2" value={locationForm.addressLine} onChange={(e) => setLocationForm((f) => ({ ...f, addressLine: e.target.value }))} />
+                  <Button
+                    size="sm"
+                    className="col-span-2 justify-self-start"
+                    disabled={locationMutation.isPending}
+                    onClick={() => locationMutation.mutate()}
+                  >
+                    Add location
+                  </Button>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+
+      <Dialog open={activityOpen} onOpenChange={setActivityOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Log activity</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3 py-2">
+            <div className="space-y-1.5">
+              <Label>Type</Label>
+              <Select value={activity.type} onValueChange={(type) => setActivity((a) => ({ ...a, type }))}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {activityTypes.map((t) => (
+                    <SelectItem key={t} value={t}>{t.replaceAll('_', ' ')}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label>Summary *</Label>
+              <Input value={activity.summary} onChange={(e) => setActivity((a) => ({ ...a, summary: e.target.value }))} placeholder="Spoke to owner, interested in Oct slot" />
+            </div>
+            {(partner.contacts || []).length > 0 && (
+              <div className="space-y-1.5">
+                <Label>Contact</Label>
+                <Select value={activity.contactId} onValueChange={(contactId) => setActivity((a) => ({ ...a, contactId }))}>
+                  <SelectTrigger><SelectValue placeholder="(optional)" /></SelectTrigger>
+                  <SelectContent>
+                    {partner.contacts.map((c) => <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>)}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+            <div className="space-y-1.5">
+              <Label>Details</Label>
+              <Textarea rows={3} value={activity.details} onChange={(e) => setActivity((a) => ({ ...a, details: e.target.value }))} />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              onClick={() => activityMutation.mutate()}
+              disabled={!activity.summary.trim() || activityMutation.isPending}
+            >
+              {activityMutation.isPending ? 'Saving…' : 'Log it'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/redeemops/PartnersList.jsx
+++ b/src/pages/redeemops/PartnersList.jsx
@@ -1,0 +1,314 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { redeemOpsApi } from '@/api/redeemOps';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table';
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import Plus from 'lucide-react/icons/plus';
+import AlertTriangle from 'lucide-react/icons/alert-triangle';
+
+const STAGE_BADGE = {
+  PARTNERED: 'default',
+  DISQUALIFIED: 'destructive',
+  NOT_INTERESTED: 'destructive',
+};
+
+function useDebounced(value, ms = 300) {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), ms);
+    return () => clearTimeout(t);
+  }, [value, ms]);
+  return debounced;
+}
+
+const EMPTY_FORM = {
+  tradingName: '', legalName: '', category: '', primaryPhone: '', primaryEmail: '',
+  website: '', instagramHandle: '', uen: '', notes: '',
+};
+
+export default function PartnersList() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const [search, setSearch] = useState('');
+  const [stage, setStage] = useState('all');
+  const [owner, setOwner] = useState('all');
+  const [page, setPage] = useState(1);
+  const debouncedSearch = useDebounced(search);
+
+  const constants = useQuery({
+    queryKey: ['redeem-ops', 'constants'],
+    queryFn: redeemOpsApi.getConstants,
+    staleTime: Infinity,
+  });
+
+  const params = {
+    page, limit: 25,
+    ...(debouncedSearch ? { search: debouncedSearch } : {}),
+    ...(stage !== 'all' ? { stage } : {}),
+    ...(owner !== 'all' ? { owner } : {}),
+  };
+  const listQuery = useQuery({
+    queryKey: ['redeem-ops', 'partners', params],
+    queryFn: () => redeemOpsApi.listPartners(params),
+    placeholderData: keepPreviousData,
+  });
+
+  // ── Duplicate-aware create flow ────────────────────────────────────────
+  const [createOpen, setCreateOpen] = useState(false);
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [duplicates, setDuplicates] = useState(null); // null = not checked yet
+  const [overrideReason, setOverrideReason] = useState('');
+
+  const set = (k) => (e) => setForm((f) => ({ ...f, [k]: e.target.value }));
+
+  const createMutation = useMutation({
+    mutationFn: (body) => redeemOpsApi.createPartner(body),
+    onSuccess: (data) => {
+      toast.success('Business added');
+      setCreateOpen(false);
+      setForm(EMPTY_FORM); setDuplicates(null); setOverrideReason('');
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partners'] });
+      if (data?.partner?.id) navigate(`/redeem-ops/partners/${data.partner.id}`);
+    },
+    onError: (err) => {
+      if (err.status === 409 && err.data?.duplicates) {
+        setDuplicates(err.data.duplicates);
+        toast.warning('Possible duplicate found', { description: 'Review the matches below.' });
+      } else {
+        toast.error('Could not add business', { description: err.message });
+      }
+    },
+  });
+
+  const handleCreate = async () => {
+    if (!form.tradingName.trim()) {
+      toast.error('Business name is required');
+      return;
+    }
+    // Pre-check so the user sees matches BEFORE submitting (server re-checks anyway)
+    if (duplicates === null) {
+      const found = await redeemOpsApi.checkDuplicates(form).catch(() => ({ exact: [], potential: [] }));
+      if (found.exact.length > 0 || found.potential.length > 0) {
+        setDuplicates(found);
+        return;
+      }
+    }
+    createMutation.mutate({
+      ...form,
+      ...(duplicates?.exact?.length ? { overrideReason } : {}),
+    });
+  };
+
+  const partners = listQuery.data?.partners || [];
+  const pagination = listQuery.data?.pagination;
+  const stages = constants.data?.pipelineStages || [];
+  const needsOverride = (duplicates?.exact?.length || 0) > 0;
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto space-y-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Partners</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            The shared business database — search before you add, claim before you contact.
+          </p>
+        </div>
+        <Button size="sm" onClick={() => { setCreateOpen(true); setDuplicates(null); }}>
+          <Plus className="w-4 h-4 mr-2" aria-hidden="true" /> Add business
+        </Button>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Input
+          placeholder="Search name, phone, UEN, @handle, domain…"
+          value={search}
+          onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+          className="max-w-sm"
+        />
+        <Select value={stage} onValueChange={(v) => { setStage(v); setPage(1); }}>
+          <SelectTrigger className="w-48"><SelectValue placeholder="Stage" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All stages</SelectItem>
+            {stages.map((s) => <SelectItem key={s} value={s}>{s.replaceAll('_', ' ')}</SelectItem>)}
+          </SelectContent>
+        </Select>
+        <Select value={owner} onValueChange={(v) => { setOwner(v); setPage(1); }}>
+          <SelectTrigger className="w-40"><SelectValue placeholder="Owner" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Any owner</SelectItem>
+            <SelectItem value="me">My partners</SelectItem>
+            <SelectItem value="none">Unowned</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <Card>
+        <CardContent className="pt-4">
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Business</TableHead>
+                  <TableHead>Category</TableHead>
+                  <TableHead>Stage</TableHead>
+                  <TableHead>Owner</TableHead>
+                  <TableHead>Last activity</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {partners.map((p) => (
+                  <TableRow
+                    key={p.id}
+                    className="cursor-pointer"
+                    onClick={() => navigate(`/redeem-ops/partners/${p.id}`)}
+                  >
+                    <TableCell className="font-medium">
+                      <span className="flex items-center gap-2">
+                        {p.tradingName || p.brandName || p.legalName}
+                        {(p.atRiskFlag || p.staleFlag) && (
+                          <AlertTriangle className="w-3.5 h-3.5 text-amber-500" aria-label={p.atRiskFlag ? 'At risk — no first outreach' : 'Stale'} />
+                        )}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">{p.category || '—'}</TableCell>
+                    <TableCell>
+                      <Badge variant={STAGE_BADGE[p.pipelineStage] || 'secondary'}>
+                        {p.pipelineStage.replaceAll('_', ' ')}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">{p.owner?.fullName || '—'}</TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {p.lastActivityAt ? new Date(p.lastActivityAt).toLocaleDateString() : 'Never'}
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {!listQuery.isLoading && partners.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={5} className="text-center text-muted-foreground py-10">
+                      No businesses match. Add the first one.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+          {pagination && pagination.totalPages > 1 && (
+            <div className="flex items-center justify-end gap-2 pt-3">
+              <span className="text-xs text-muted-foreground">
+                Page {pagination.page} of {pagination.totalPages} · {pagination.total} businesses
+              </span>
+              <Button variant="outline" size="sm" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>Prev</Button>
+              <Button variant="outline" size="sm" disabled={page >= pagination.totalPages} onClick={() => setPage((p) => p + 1)}>Next</Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={createOpen} onOpenChange={(open) => { setCreateOpen(open); if (!open) { setDuplicates(null); setOverrideReason(''); } }}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Add business</DialogTitle>
+            <DialogDescription>
+              The system checks for duplicates before creating — one business, one owner.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid grid-cols-2 gap-3 py-2">
+            <div className="col-span-2 space-y-1.5">
+              <Label>Business name *</Label>
+              <Input value={form.tradingName} onChange={set('tradingName')} placeholder="Nail Bliss" />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Category</Label>
+              <Input value={form.category} onChange={set('category')} placeholder="Nail Salon" />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Phone (+65…)</Label>
+              <Input value={form.primaryPhone} onChange={set('primaryPhone')} placeholder="+6591234567" />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Instagram</Label>
+              <Input value={form.instagramHandle} onChange={set('instagramHandle')} placeholder="@nailbliss.sg" />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Website</Label>
+              <Input value={form.website} onChange={set('website')} placeholder="nailbliss.sg" />
+            </div>
+            <div className="space-y-1.5">
+              <Label>UEN</Label>
+              <Input value={form.uen} onChange={set('uen')} placeholder="202507548M" />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Email</Label>
+              <Input value={form.primaryEmail} onChange={set('primaryEmail')} placeholder="hello@nailbliss.sg" />
+            </div>
+          </div>
+
+          {duplicates && (duplicates.exact.length > 0 || duplicates.potential.length > 0) && (
+            <div className="rounded-lg border border-amber-300 bg-amber-50 dark:bg-amber-950/30 p-3 space-y-2 text-sm">
+              <p className="font-medium flex items-center gap-2">
+                <AlertTriangle className="w-4 h-4 text-amber-500" aria-hidden="true" />
+                {duplicates.exact.length > 0 ? 'This business may already exist' : 'Similar businesses found'}
+              </p>
+              {[...duplicates.exact, ...duplicates.potential].slice(0, 4).map((m) => (
+                <div key={m.partner.id} className="flex items-center justify-between gap-2">
+                  <span>
+                    <Link
+                      to={`/redeem-ops/partners/${m.partner.id}`}
+                      className="underline font-medium"
+                      onClick={() => setCreateOpen(false)}
+                    >
+                      {m.partner.tradingName || m.partner.legalName}
+                    </Link>{' '}
+                    <span className="text-muted-foreground">
+                      — {m.reason} · {m.partner.pipelineStage.replaceAll('_', ' ')}
+                      {m.partner.owner ? ` · owned by ${m.partner.owner.fullName}` : ' · unowned'}
+                    </span>
+                  </span>
+                </div>
+              ))}
+              {needsOverride && (
+                <div className="space-y-1.5 pt-1">
+                  <Label>Reason to create anyway (required for exact matches)</Label>
+                  <Input
+                    value={overrideReason}
+                    onChange={(e) => setOverrideReason(e.target.value)}
+                    placeholder="e.g. separate outlet with different owner"
+                  />
+                </div>
+              )}
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button
+              onClick={handleCreate}
+              disabled={createMutation.isPending || (needsOverride && !overrideReason.trim())}
+            >
+              {createMutation.isPending
+                ? 'Saving…'
+                : duplicates === null
+                  ? 'Check & create'
+                  : needsOverride ? 'Create anyway' : 'Create'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/redeemops/PoolsPage.jsx
+++ b/src/pages/redeemops/PoolsPage.jsx
@@ -1,0 +1,140 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { redeemOpsApi } from '@/api/redeemOps';
+import { useAuthStore } from '@/stores/authStore';
+import { hasCapability } from '@/lib/redeemOpsPermissions';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import Plus from 'lucide-react/icons/plus';
+
+export default function PoolsPage() {
+  const user = useAuthStore((s) => s.user);
+  const canManage = hasCapability(user, 'pools.manage');
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const poolsQuery = useQuery({ queryKey: ['redeem-ops', 'pools'], queryFn: redeemOpsApi.listPools });
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [form, setForm] = useState({ name: '', description: '', category: '', area: '' });
+
+  const createMutation = useMutation({
+    mutationFn: () => redeemOpsApi.createPool(form),
+    onSuccess: () => {
+      toast.success('Pool created');
+      setCreateOpen(false);
+      setForm({ name: '', description: '', category: '', area: '' });
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'pools'] });
+    },
+    onError: (err) => toast.error('Could not create pool', { description: err.message }),
+  });
+
+  const claimMutation = useMutation({
+    mutationFn: (poolId) => redeemOpsApi.claimNextFromPool(poolId),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'pools'] });
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partners'] });
+      if (data?.partnerId) {
+        toast.success('Prospect claimed — it’s yours');
+        navigate(`/redeem-ops/partners/${data.partnerId}`);
+      } else {
+        toast.info('Pool exhausted', { description: 'No eligible prospects left in this pool.' });
+      }
+    },
+    onError: (err) => toast.error('Claim failed', { description: err.message }),
+  });
+
+  const pools = poolsQuery.data || [];
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto space-y-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Prospecting pools</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Curated prospect lists — hit “Claim next” to pull your next business, no cherry-picking, no collisions.
+          </p>
+        </div>
+        {canManage && (
+          <Button size="sm" onClick={() => setCreateOpen(true)}>
+            <Plus className="w-4 h-4 mr-2" aria-hidden="true" /> New pool
+          </Button>
+        )}
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {pools.map((pool) => {
+          const available = pool.memberCounts?.available || 0;
+          const claimed = pool.memberCounts?.claimed || 0;
+          return (
+            <Card key={pool.id}>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base">{pool.name}</CardTitle>
+                <CardDescription>
+                  {[pool.category, pool.area].filter(Boolean).join(' · ') || pool.description || '—'}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="flex items-center justify-between">
+                <div className="flex gap-2">
+                  <Badge variant="secondary">{available} available</Badge>
+                  <Badge variant="outline">{claimed} claimed</Badge>
+                </div>
+                <Button
+                  size="sm"
+                  disabled={claimMutation.isPending || available === 0}
+                  onClick={() => claimMutation.mutate(pool.id)}
+                >
+                  {claimMutation.isPending ? 'Claiming…' : 'Claim next'}
+                </Button>
+              </CardContent>
+            </Card>
+          );
+        })}
+        {!poolsQuery.isLoading && pools.length === 0 && (
+          <Card className="sm:col-span-2">
+            <CardContent className="py-10 text-center text-muted-foreground">
+              No pools yet{canManage ? ' — create one and add businesses from the Partners list.' : '.'}
+            </CardContent>
+          </Card>
+        )}
+      </div>
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New prospecting pool</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3 py-2">
+            <div className="space-y-1.5">
+              <Label>Name *</Label>
+              <Input value={form.name} onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))} placeholder="Pet Groomers — East" />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label>Category</Label>
+                <Input value={form.category} onChange={(e) => setForm((f) => ({ ...f, category: e.target.value }))} placeholder="Pet Grooming" />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Area</Label>
+                <Input value={form.area} onChange={(e) => setForm((f) => ({ ...f, area: e.target.value }))} placeholder="East" />
+              </div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button disabled={!form.name.trim() || createMutation.isPending} onClick={() => createMutation.mutate()}>
+              {createMutation.isPending ? 'Creating…' : 'Create pool'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/redeemops/RedeemOpsHome.jsx
+++ b/src/pages/redeemops/RedeemOpsHome.jsx
@@ -14,6 +14,7 @@ import Building2 from 'lucide-react/icons/building-2';
 export default function RedeemOpsHome() {
   const user = useAuthStore((s) => s.user);
   const canManageTeam = hasCapability(user, 'team.manage_access');
+  const canSeeTeam = hasCapability(user, 'analytics.view_team');
 
   return (
     <div className="p-6 max-w-5xl mx-auto space-y-6">
@@ -25,36 +26,48 @@ export default function RedeemOpsHome() {
       </div>
 
       <div className="grid gap-4 sm:grid-cols-2">
+        {canSeeTeam && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Users className="w-4 h-4" aria-hidden="true" />
+                Team &amp; access
+              </CardTitle>
+              <CardDescription>
+                {canManageTeam
+                  ? 'Invite outreach staff and manage Redeem Ops sub-roles.'
+                  : 'See who is on the Redeem Ops team.'}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button asChild size="sm">
+                <Link to="/redeem-ops/team">Open Team</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2 text-base">
-              <Users className="w-4 h-4" aria-hidden="true" />
-              Team &amp; access
-            </CardTitle>
-            <CardDescription>
-              {canManageTeam
-                ? 'Invite outreach staff and manage Redeem Ops sub-roles.'
-                : 'See who is on the Redeem Ops team.'}
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Button asChild size="sm">
-              <Link to="/redeem-ops/team">Open Team</Link>
-            </Button>
-          </CardContent>
-        </Card>
-
-        <Card className="border-dashed">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-base text-muted-foreground">
               <Building2 className="w-4 h-4" aria-hidden="true" />
               Partner CRM
             </CardTitle>
             <CardDescription>
-              Business search, duplicate-safe claiming, activity timeline, and the partner
-              pipeline arrive in Phase 2.
+              Search the shared business database, claim prospects, log outreach, move the pipeline.
             </CardDescription>
           </CardHeader>
+          <CardContent className="flex gap-2">
+            <Button asChild size="sm">
+              <Link to="/redeem-ops/queue">My queue</Link>
+            </Button>
+            <Button asChild size="sm" variant="outline">
+              <Link to="/redeem-ops/partners">Partners</Link>
+            </Button>
+            <Button asChild size="sm" variant="outline">
+              <Link to="/redeem-ops/pools">Pools</Link>
+            </Button>
+          </CardContent>
         </Card>
       </div>
     </div>

--- a/src/pages/redeemops/TasksPage.jsx
+++ b/src/pages/redeemops/TasksPage.jsx
@@ -1,0 +1,137 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { redeemOpsApi } from '@/api/redeemOps';
+import { useAuthStore } from '@/stores/authStore';
+import { hasCapability } from '@/lib/redeemOpsPermissions';
+import { Card, CardContent } from '@/components/ui/card';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+
+const VIEWS = [
+  { key: 'today', label: 'Due today', params: { due: 'today' } },
+  { key: 'overdue', label: 'Overdue', params: { due: 'overdue' } },
+  { key: 'upcoming', label: 'Upcoming', params: { due: 'upcoming' } },
+  { key: 'mine', label: 'All mine', params: {} },
+  { key: 'team', label: 'Team', params: { scope: 'team' }, managerOnly: true },
+];
+
+const PRIORITY_BADGE = { high: 'destructive', medium: 'secondary', low: 'outline' };
+
+export default function TasksPage() {
+  const user = useAuthStore((s) => s.user);
+  const isManager = hasCapability(user, 'pipeline.view_team');
+  const queryClient = useQueryClient();
+  const [view, setView] = useState('today');
+
+  const activeView = VIEWS.find((v) => v.key === view) || VIEWS[0];
+  const tasksQuery = useQuery({
+    queryKey: ['redeem-ops', 'tasks', activeView.params],
+    queryFn: () => redeemOpsApi.listTasks({ ...activeView.params, limit: 50 }),
+    placeholderData: keepPreviousData,
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ taskId, body }) => redeemOpsApi.updateTask(taskId, body),
+    onSuccess: () => {
+      toast.success('Task updated');
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'tasks'] });
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'queue'] });
+    },
+    onError: (err) => toast.error('Update failed', { description: err.message }),
+  });
+
+  const tasks = tasksQuery.data?.tasks || [];
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto space-y-4">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Tasks</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Follow-ups are tasks, not notes — create them from a partner's page.
+        </p>
+      </div>
+
+      <Tabs value={view} onValueChange={setView}>
+        <TabsList>
+          {VIEWS.filter((v) => !v.managerOnly || isManager).map((v) => (
+            <TabsTrigger key={v.key} value={v.key}>{v.label}</TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      <Card>
+        <CardContent className="pt-4">
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Task</TableHead>
+                  <TableHead>Business</TableHead>
+                  <TableHead>Due</TableHead>
+                  <TableHead>Priority</TableHead>
+                  {view === 'team' && <TableHead>Assignee</TableHead>}
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {tasks.map((t) => (
+                  <TableRow key={t.id}>
+                    <TableCell className="font-medium">{t.title}</TableCell>
+                    <TableCell>
+                      <Link to={`/redeem-ops/partners/${t.partner?.id}`} className="underline text-sm">
+                        {t.partner?.tradingName || t.partner?.brandName || t.partner?.legalName || '—'}
+                      </Link>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-sm">
+                      {new Date(t.dueAt).toLocaleDateString()}
+                      {t.hasTime ? ` ${new Date(t.dueAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}` : ''}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={PRIORITY_BADGE[t.priority] || 'secondary'}>{t.priority}</Badge>
+                    </TableCell>
+                    {view === 'team' && (
+                      <TableCell className="text-muted-foreground text-sm">{t.assignee?.fullName || '—'}</TableCell>
+                    )}
+                    <TableCell className="text-right space-x-1">
+                      {t.status !== 'completed' && (
+                        <Button
+                          size="sm" variant="outline"
+                          disabled={updateMutation.isPending}
+                          onClick={() => updateMutation.mutate({ taskId: t.id, body: { status: 'completed' } })}
+                        >
+                          Complete
+                        </Button>
+                      )}
+                      {t.status === 'open' && (
+                        <Button
+                          size="sm" variant="ghost"
+                          disabled={updateMutation.isPending}
+                          onClick={() => updateMutation.mutate({ taskId: t.id, body: { status: 'cancelled' } })}
+                        >
+                          Cancel
+                        </Button>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {!tasksQuery.isLoading && tasks.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={view === 'team' ? 6 : 5} className="text-center text-muted-foreground py-10">
+                      Nothing here.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/redeemops/TeamPipeline.jsx
+++ b/src/pages/redeemops/TeamPipeline.jsx
@@ -1,0 +1,83 @@
+import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { redeemOpsApi } from '@/api/redeemOps';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import AlertTriangle from 'lucide-react/icons/alert-triangle';
+
+/**
+ * Manager board: pipeline stages as columns, partner cards inside. Stage moves
+ * happen on the partner detail page (server-validated transitions) — this board
+ * is the team-wide visibility surface (brief §17: table/board view; server-side
+ * rules regardless of UI).
+ */
+export default function TeamPipeline() {
+  const constants = useQuery({
+    queryKey: ['redeem-ops', 'constants'],
+    queryFn: redeemOpsApi.getConstants,
+    staleTime: Infinity,
+  });
+  const boardQuery = useQuery({
+    queryKey: ['redeem-ops', 'team-pipeline'],
+    queryFn: redeemOpsApi.getTeamPipeline,
+  });
+
+  const stages = (constants.data?.pipelineStages || []).filter((s) => s !== 'UNCLAIMED');
+  const partners = boardQuery.data?.partners || [];
+  const byStage = {};
+  for (const p of partners) {
+    byStage[p.pipelineStage] = byStage[p.pipelineStage] || [];
+    byStage[p.pipelineStage].push(p);
+  }
+
+  return (
+    <div className="p-6 space-y-4">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Team pipeline</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Everyone's opportunities by stage. Click a business to act on it.
+        </p>
+      </div>
+
+      <div className="flex gap-3 overflow-x-auto pb-4">
+        {stages.map((stage) => {
+          const items = byStage[stage] || [];
+          if (items.length === 0 && ['NO_RESPONSE', 'NOT_INTERESTED', 'DISQUALIFIED'].includes(stage)) return null;
+          return (
+            <Card key={stage} className="min-w-64 w-64 shrink-0">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm flex items-center justify-between">
+                  {stage.replaceAll('_', ' ')}
+                  <Badge variant="secondary">{items.length}</Badge>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {items.slice(0, 30).map((p) => (
+                  <Link
+                    key={p.id}
+                    to={`/redeem-ops/partners/${p.id}`}
+                    className="block rounded-md border border-border p-2 hover:bg-accent transition-colors"
+                  >
+                    <p className="text-sm font-medium flex items-center gap-1.5">
+                      {p.tradingName || p.brandName || p.legalName}
+                      {(p.atRiskFlag || p.staleFlag) && (
+                        <AlertTriangle className="w-3 h-3 text-amber-500" aria-hidden="true" />
+                      )}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {p.owner?.fullName || 'Unowned'}
+                      {p.category ? ` · ${p.category}` : ''}
+                    </p>
+                  </Link>
+                ))}
+                {items.length === 0 && (
+                  <p className="text-xs text-muted-foreground py-2">Empty</p>
+                )}
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What this is

**Redeem Ops V1** — the first-usable-milestone from `docs/redeem-ops/IMPLEMENTATION_PLAN.md`: three outreach staff can search the shared business database, get duplicate warnings, claim businesses concurrency-safely, log activity, schedule follow-ups as real tasks, run their day from a queue, and managers can monitor the whole pipeline and reassign. Ships **dark** behind `REDEEM_OPS_ENABLED` / `VITE_REDEEM_OPS_ENABLED` (same posture as #94).

## Phase 2 — Partner CRM
- **Migration 046**: `partner_organisations` (display values + normalized matching keys, partial-unique identity indexes on UEN/phone/handles), locations, contacts, append-only assignment + stage events, `outreach_activities`. `pg_trgm` attempted with graceful prefix fallback. Always-run `IF NOT EXISTS` indexes + `down()`.
- **Duplicate prevention**: exact tier (UEN / phone / domain / IG / TikTok / normalized name) → 409 with match details unless `overrideReason`; potential tier (trigram ≥0.55 or prefix) → warnings with owner/stage/last-activity. `GET /partners/check-duplicates` probe for the pre-save dialog.
- **Claiming**: ONE conditional `UPDATE … RETURNING` — simultaneous claims produce exactly one winner (tested with `Promise.allSettled`), losers get 409 + `claimedBy`. Release (owner-only) and assign/reassign (manager capability) with full history.
- **Stage machine**: server-validated transitions; ops_admin+ may force with a mandatory reason; PARTNERED hook reserved for Phase 4's onboarding seed.
- **Timeline**: activities + stage events + ownership events merged; meaningful activities stamp `firstOutreachAt`/`lastActivityAt` and clear flags; edits audited, voids non-destructive.
- **Merge**: re-points contacts/locations/activities/history to the survivor, marks the loser `mergedIntoId`+archived, audits with a full before-snapshot.

## Phase 3 — Outreach operations
- **Migration 047**: `outreach_tasks` (partner `nextTaskAt` denormalization), `prospecting_pools` + members (unique membership).
- **Tasks**: SGT-correct due windows, own/team row scoping, completion stamps, manager-only cross-assignment.
- **Claim Next**: `FOR UPDATE SKIP LOCKED` + bounded retry — concurrent staff get different prospects; a business claimed outside the pool is never re-offered.
- **My Queue**: overdue / due-today / awaiting-first-outreach / recent replies / upcoming / gone-quiet buckets in one aggregated read.
- **Stale sweep** (in-process, module-flag-gated): flags 48h-no-first-outreach and 14d-no-activity; `FOLLOW_UP_LATER` with a future task is exempt; **never auto-releases**.
- **SPA**: PartnersList (duplicate-aware create), PartnerDetail, MyQueue, Tasks, Pools, TeamPipeline board — nav + routes capability-gated (closes Codex P1 finding 6).

## Verification
- ✅ 25 pure unit tests green locally (normalizers, capability matrix, host-guard policy)
- ⏳ 2 new DB suites in CI: `redeemOpsPartners.test.js` (dedupe tiers, simultaneous-claim race, authz, stage machine, merge preservation) + `redeemOpsWork.test.js` (task authz/buckets, concurrent claim-next, sweep exemption)
- ✅ Vite build + eslint clean
- Known-red baseline: `test/unit/shortlinkService.test.js` fails identically on main

## Acceptance criteria (brief §40)
1–13 all covered (login/search/dedupe/single-owner/concurrency-safe claim/locations+contacts/activity/follow-ups/queue/pipeline/manager-visibility/reassign/history-intact); 14–15 hold by construction (no campaign builder, no lead DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)