### PR TITLE
feat(redeem-ops): Phases 4+5 — rewards + inventory ledger + Activations with MKTR campaign linkage

### DIFF
--- a/backend/src/controllers/redeemOps/activationsController.js
+++ b/backend/src/controllers/redeemOps/activationsController.js
@@ -1,0 +1,89 @@
+import Joi from 'joi';
+import { asyncHandler, AppError } from '../../middleware/errorHandler.js';
+import activationService from '../../services/redeemOps/activationService.js';
+import campaignProjection from '../../services/redeemOps/campaignProjection.js';
+
+function validateBody(schema, body) {
+  const { error, value } = schema.validate(body, { abortEarly: false });
+  if (error) throw new AppError(error.details.map((x) => x.message).join(', '), 400);
+  return value;
+}
+
+export const searchCampaigns = asyncHandler(async (req, res) => {
+  const campaigns = await campaignProjection.searchCampaigns(req.query);
+  res.json({ success: true, data: { campaigns } });
+});
+
+export const listActivations = asyncHandler(async (req, res) => {
+  const activations = await activationService.listActivations(req.query);
+  res.json({ success: true, data: { activations } });
+});
+
+export const getActivation = asyncHandler(async (req, res) => {
+  const activation = await activationService.getActivation(req.params.id);
+  let campaignRef = null;
+  if (activation.campaignId) {
+    campaignRef = await campaignProjection.getCampaignReference(activation.campaignId).catch(() => null);
+  }
+  res.json({ success: true, data: { activation, campaign: campaignRef } });
+});
+
+export const createActivation = asyncHandler(async (req, res) => {
+  const body = validateBody(
+    Joi.object({
+      rewardOfferId: Joi.string().uuid().required(),
+      allocatedQuantity: Joi.number().integer().min(0),
+      unlockPolicy: Joi.string().valid('on_capture', 'agent_unlock'),
+      startDate: Joi.date().iso().allow(null),
+      endDate: Joi.date().iso().allow(null),
+      internalNotes: Joi.string().max(5000).allow('', null),
+    }),
+    req.body
+  );
+  const activation = await activationService.createActivation(body, req.user, req.id);
+  res.status(201).json({ success: true, data: { activation } });
+});
+
+export const linkCampaign = asyncHandler(async (req, res) => {
+  const body = validateBody(
+    Joi.object({ campaignId: Joi.string().uuid().allow(null).required() }),
+    req.body
+  );
+  const activation = await activationService.linkCampaign(req.params.id, body.campaignId, req.user, req.id);
+  res.json({ success: true, data: { activation } });
+});
+
+export const changeAllocation = asyncHandler(async (req, res) => {
+  const body = validateBody(
+    Joi.object({
+      delta: Joi.number().integer().invalid(0).required(),
+      reason: Joi.string().max(255).allow('', null),
+    }),
+    req.body
+  );
+  const activation = await activationService.changeAllocation(req.params.id, body.delta, req.user, body.reason || null, req.id);
+  res.json({ success: true, data: { activation } });
+});
+
+export const setStatus = asyncHandler(async (req, res) => {
+  const body = validateBody(Joi.object({ status: Joi.string().required() }), req.body);
+  const activation = await activationService.setStatus(req.params.id, body.status, req.user, req.id);
+  res.json({ success: true, data: { activation } });
+});
+
+export const getCampaignMetrics = asyncHandler(async (req, res) => {
+  const activation = await activationService.getActivation(req.params.id);
+  if (!activation.campaignId) throw new AppError('No campaign linked to this activation', 400);
+  const metrics = await campaignProjection.getCampaignMetrics(activation.campaignId);
+  res.json({
+    success: true,
+    data: {
+      acquisition: metrics, // MKTR's own numbers — never re-counted (MKTR_INTEGRATION.md §1)
+      reward: {
+        allocatedQuantity: activation.allocatedQuantity,
+        issuedCount: activation.issuedCount,
+        redeemedCount: activation.redeemedCount,
+      },
+    },
+  });
+});

--- a/backend/src/controllers/redeemOps/rewardsController.js
+++ b/backend/src/controllers/redeemOps/rewardsController.js
@@ -1,0 +1,115 @@
+import Joi from 'joi';
+import { asyncHandler, AppError } from '../../middleware/errorHandler.js';
+import rewardService from '../../services/redeemOps/rewardService.js';
+import onboardingService from '../../services/redeemOps/onboardingService.js';
+
+function validateBody(schema, body) {
+  const { error, value } = schema.validate(body, { abortEarly: false });
+  if (error) throw new AppError(error.details.map((x) => x.message).join(', '), 400);
+  return value;
+}
+
+const offerSchema = Joi.object({
+  partnerOrganisationId: Joi.string().uuid(),
+  title: Joi.string().max(160),
+  publicTitle: Joi.string().max(160).allow('', null),
+  internalRef: Joi.string().max(64).allow('', null),
+  description: Joi.string().max(5000).allow('', null),
+  category: Joi.string().max(64).allow('', null),
+  rewardType: Joi.string().max(24),
+  retailValue: Joi.number().min(0).allow(null),
+  fulfilmentCost: Joi.number().min(0).allow(null),
+  fundingSource: Joi.string().valid('partner', 'mktr', 'shared'),
+  committedQuantity: Joi.number().integer().min(0),
+  validityStart: Joi.date().iso().allow(null),
+  validityEnd: Joi.date().iso().allow(null),
+  claimExpiryDays: Joi.number().integer().min(1).allow(null),
+  redemptionExpiryDays: Joi.number().integer().min(1).allow(null),
+  fulfilmentMethod: Joi.string().max(24),
+  externalBookingUrl: Joi.string().max(255).allow('', null),
+  terms: Joi.object({ structured: Joi.object(), freeText: Joi.string().max(10000).allow('', null) }),
+});
+
+export const listOffers = asyncHandler(async (req, res) => {
+  const offers = await rewardService.listOffers(req.query);
+  res.json({ success: true, data: { offers } });
+});
+
+export const getOffer = asyncHandler(async (req, res) => {
+  const data = await rewardService.getOffer(req.params.id);
+  res.json({ success: true, data });
+});
+
+export const createOffer = asyncHandler(async (req, res) => {
+  const body = validateBody(
+    offerSchema.fork(['partnerOrganisationId', 'title'], (s) => s.required()),
+    req.body
+  );
+  const offer = await rewardService.createOffer(body, req.user, req.id);
+  res.status(201).json({ success: true, data: { offer } });
+});
+
+export const updateOffer = asyncHandler(async (req, res) => {
+  const body = validateBody(offerSchema, req.body);
+  const offer = await rewardService.updateOffer(req.params.id, body, req.user, req.id);
+  res.json({ success: true, data: { offer } });
+});
+
+export const setOfferStatus = asyncHandler(async (req, res) => {
+  const body = validateBody(Joi.object({ status: Joi.string().required() }), req.body);
+  const offer = await rewardService.setOfferStatus(req.params.id, body.status, req.user, req.id);
+  res.json({ success: true, data: { offer } });
+});
+
+export const addTermsVersion = asyncHandler(async (req, res) => {
+  const body = validateBody(
+    Joi.object({ structured: Joi.object(), freeText: Joi.string().max(10000).allow('', null) }),
+    req.body
+  );
+  const terms = await rewardService.addTermsVersion(req.params.id, body, req.user, req.id);
+  res.status(201).json({ success: true, data: { terms } });
+});
+
+export const setLocations = asyncHandler(async (req, res) => {
+  const body = validateBody(
+    Joi.object({ partnerLocationIds: Joi.array().items(Joi.string().uuid()).max(100).required() }),
+    req.body
+  );
+  const locations = await rewardService.setLocations(req.params.id, body.partnerLocationIds, req.user);
+  res.json({ success: true, data: { locations } });
+});
+
+export const adjustInventory = asyncHandler(async (req, res) => {
+  const body = validateBody(
+    Joi.object({
+      type: Joi.string().valid('committed_increase', 'committed_decrease').required(),
+      quantity: Joi.number().integer().min(1).required(),
+      reason: Joi.string().max(255).required(),
+    }),
+    req.body
+  );
+  const result = await rewardService.adjustInventory(req.params.id, body, req.user, req.id);
+  res.json({ success: true, data: result });
+});
+
+export const getLedger = asyncHandler(async (req, res) => {
+  const events = await rewardService.getLedger(req.params.id, req.query);
+  res.json({ success: true, data: { events } });
+});
+
+// ── Onboarding checklist (brief §22) ───────────────────────────────────────
+
+export const getOnboarding = asyncHandler(async (req, res) => {
+  let items = await onboardingService.getChecklist(req.params.id);
+  if (items.length === 0) {
+    // Lazily seed for partners that hit PARTNERED before Phase 4 shipped
+    await onboardingService.seedChecklist(req.params.id);
+    items = await onboardingService.getChecklist(req.params.id);
+  }
+  res.json({ success: true, data: { items } });
+});
+
+export const updateOnboardingItem = asyncHandler(async (req, res) => {
+  const item = await onboardingService.updateItem(req.params.itemId, req.body || {}, req.user);
+  res.json({ success: true, data: { item } });
+});

--- a/backend/src/database/migrations/048-redeem-ops-rewards.js
+++ b/backend/src/database/migrations/048-redeem-ops-rewards.js
@@ -1,0 +1,116 @@
+/**
+ * Redeem Ops Phase 4 — onboarding checklist, reward offers, versioned terms,
+ * participating locations, inventory ledger (docs/redeem-ops/ERD.md §3.10–3.14).
+ * Guarded + always-run IF NOT EXISTS indexes (045/046/047 pattern).
+ */
+export async function up(queryInterface, Sequelize) {
+  const tables = await queryInterface.showAllTables();
+  const UUID = Sequelize.UUID;
+  const ts = () => ({
+    createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+  });
+
+  if (!tables.includes('partner_onboarding_items')) {
+    await queryInterface.createTable('partner_onboarding_items', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      partnerOrganisationId: { type: UUID, allowNull: false, references: { model: 'partner_organisations', key: 'id' }, onDelete: 'CASCADE' },
+      itemKey: { type: Sequelize.STRING(48), allowNull: false },
+      label: { type: Sequelize.STRING(160), allowNull: false },
+      sortOrder: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 0 },
+      status: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'pending' },
+      assigneeUserId: { type: UUID, references: { model: 'users', key: 'id' }, onDelete: 'SET NULL' },
+      completedAt: { type: Sequelize.DATE },
+      notes: { type: Sequelize.TEXT },
+      ...ts(),
+    });
+  }
+
+  if (!tables.includes('reward_offers')) {
+    await queryInterface.createTable('reward_offers', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      partnerOrganisationId: { type: UUID, allowNull: false, references: { model: 'partner_organisations', key: 'id' }, onDelete: 'RESTRICT' },
+      title: { type: Sequelize.STRING(160), allowNull: false },
+      publicTitle: { type: Sequelize.STRING(160) },
+      internalRef: { type: Sequelize.STRING(64) },
+      description: { type: Sequelize.TEXT },
+      category: { type: Sequelize.STRING(64) },
+      rewardType: { type: Sequelize.STRING(24), allowNull: false, defaultValue: 'free_service' },
+      retailValue: { type: Sequelize.DECIMAL(10, 2) },
+      fulfilmentCost: { type: Sequelize.DECIMAL(10, 2) },
+      currency: { type: Sequelize.STRING(3), allowNull: false, defaultValue: 'SGD' },
+      fundingSource: { type: Sequelize.STRING(24), allowNull: false, defaultValue: 'partner' },
+      committedQuantity: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 0 },
+      allocatedQuantity: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 0 },
+      issuedQuantity: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 0 },
+      redeemedQuantity: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 0 },
+      validityStart: { type: Sequelize.DATE },
+      validityEnd: { type: Sequelize.DATE },
+      claimExpiryDays: { type: Sequelize.INTEGER },
+      redemptionExpiryDays: { type: Sequelize.INTEGER },
+      fulfilmentMethod: { type: Sequelize.STRING(24), allowNull: false, defaultValue: 'partner_verification' },
+      externalBookingUrl: { type: Sequelize.STRING(255) },
+      status: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'draft' },
+      currentTermsVersion: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 0 },
+      createdBy: { type: UUID, allowNull: false, references: { model: 'users', key: 'id' }, onDelete: 'RESTRICT' },
+      ...ts(),
+    });
+  }
+
+  if (!tables.includes('reward_terms_versions')) {
+    await queryInterface.createTable('reward_terms_versions', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      rewardOfferId: { type: UUID, allowNull: false, references: { model: 'reward_offers', key: 'id' }, onDelete: 'CASCADE' },
+      version: { type: Sequelize.INTEGER, allowNull: false },
+      structured: { type: Sequelize.JSONB, allowNull: false, defaultValue: {} },
+      freeText: { type: Sequelize.TEXT },
+      createdBy: { type: UUID, allowNull: false, references: { model: 'users', key: 'id' }, onDelete: 'RESTRICT' },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    });
+  }
+
+  if (!tables.includes('reward_offer_locations')) {
+    await queryInterface.createTable('reward_offer_locations', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      rewardOfferId: { type: UUID, allowNull: false, references: { model: 'reward_offers', key: 'id' }, onDelete: 'CASCADE' },
+      partnerLocationId: { type: UUID, allowNull: false, references: { model: 'partner_locations', key: 'id' }, onDelete: 'CASCADE' },
+      ...ts(),
+    });
+  }
+
+  if (!tables.includes('reward_inventory_events')) {
+    await queryInterface.createTable('reward_inventory_events', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      rewardOfferId: { type: UUID, allowNull: false, references: { model: 'reward_offers', key: 'id' }, onDelete: 'RESTRICT' },
+      activationId: { type: UUID },
+      entitlementId: { type: UUID },
+      redemptionId: { type: UUID },
+      type: { type: Sequelize.STRING(24), allowNull: false },
+      quantity: { type: Sequelize.INTEGER, allowNull: false },
+      actorType: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'staff' },
+      actorUserId: { type: UUID, references: { model: 'users', key: 'id' }, onDelete: 'SET NULL' },
+      reason: { type: Sequelize.STRING(255) },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    });
+  }
+
+  const idx = (sql) => queryInterface.sequelize.query(sql);
+  await idx('CREATE UNIQUE INDEX IF NOT EXISTS uq_poi_partner_key ON partner_onboarding_items ("partnerOrganisationId", "itemKey")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_ro_partner_status ON reward_offers ("partnerOrganisationId", "status")');
+  await idx('CREATE UNIQUE INDEX IF NOT EXISTS uq_rtv_offer_version ON reward_terms_versions ("rewardOfferId", "version")');
+  await idx('CREATE UNIQUE INDEX IF NOT EXISTS uq_rol_offer_location ON reward_offer_locations ("rewardOfferId", "partnerLocationId")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_rie_offer_created ON reward_inventory_events ("rewardOfferId", "createdAt")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_rie_activation ON reward_inventory_events ("activationId")');
+}
+
+export async function down(queryInterface) {
+  for (const table of [
+    'reward_inventory_events',
+    'reward_offer_locations',
+    'reward_terms_versions',
+    'reward_offers',
+    'partner_onboarding_items',
+  ]) {
+    await queryInterface.sequelize.query(`DROP TABLE IF EXISTS ${table} CASCADE`);
+  }
+}

--- a/backend/src/database/migrations/049-redeem-ops-activations.js
+++ b/backend/src/database/migrations/049-redeem-ops-activations.js
@@ -1,0 +1,42 @@
+/**
+ * Redeem Ops Phase 5 — Activations (docs/redeem-ops/ERD.md §3.15). The bridge
+ * between a partner's Reward Offer and ONE canonical MKTR campaign. Partial
+ * unique index enforces one LIVE activation per campaign at the schema level.
+ */
+export async function up(queryInterface, Sequelize) {
+  const tables = await queryInterface.showAllTables();
+  const UUID = Sequelize.UUID;
+
+  if (!tables.includes('activations')) {
+    await queryInterface.createTable('activations', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      partnerOrganisationId: { type: UUID, allowNull: false, references: { model: 'partner_organisations', key: 'id' }, onDelete: 'RESTRICT' },
+      rewardOfferId: { type: UUID, allowNull: false, references: { model: 'reward_offers', key: 'id' }, onDelete: 'RESTRICT' },
+      campaignId: { type: UUID, references: { model: 'campaigns', key: 'id' }, onDelete: 'SET NULL' },
+      campaignNameSnapshot: { type: Sequelize.STRING(160) },
+      allocatedQuantity: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 0 },
+      issuedCount: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 0 },
+      redeemedCount: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 0 },
+      status: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'draft' },
+      unlockPolicy: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'agent_unlock' },
+      startDate: { type: Sequelize.DATE },
+      endDate: { type: Sequelize.DATE },
+      internalNotes: { type: Sequelize.TEXT },
+      renewalOutcome: { type: Sequelize.STRING(24) },
+      createdBy: { type: UUID, allowNull: false, references: { model: 'users', key: 'id' }, onDelete: 'RESTRICT' },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    });
+  }
+
+  const idx = (sql) => queryInterface.sequelize.query(sql);
+  await idx('CREATE INDEX IF NOT EXISTS idx_act_partner ON activations ("partnerOrganisationId")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_act_offer ON activations ("rewardOfferId")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_act_status ON activations ("status")');
+  await idx(`CREATE UNIQUE INDEX IF NOT EXISTS uq_act_live_campaign ON activations ("campaignId")
+             WHERE "status" IN ('preparing', 'active', 'paused') AND "campaignId" IS NOT NULL`);
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query('DROP TABLE IF EXISTS activations CASCADE');
+}

--- a/backend/src/models/Activation.js
+++ b/backend/src/models/Activation.js
@@ -1,0 +1,65 @@
+import { DataTypes, Op } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * The operational use of a Reward Offer in connection with ONE canonical MKTR
+ * campaign (docs/redeem-ops/ERD.md §3.15, brief §25). An Activation is NOT a
+ * campaign: it owns no design config, forms, pixels, or routing — `campaignId`
+ * is a read-only reference and campaign editing stays on mktr.sg.
+ */
+const Activation = sequelize.define('Activation', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  partnerOrganisationId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'partner_organisations', key: 'id' }
+  },
+  rewardOfferId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'reward_offers', key: 'id' }
+  },
+  campaignId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    references: { model: 'campaigns', key: 'id' },
+    comment: 'Canonical MKTR campaign reference — SET NULL on campaign delete; snapshot below keeps display alive'
+  },
+  campaignNameSnapshot: { type: DataTypes.STRING(160), allowNull: true },
+  allocatedQuantity: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  issuedCount: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0, comment: 'Guarded counter (Phase 6 issuance)' },
+  redeemedCount: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  status: {
+    type: DataTypes.STRING(16),
+    allowNull: false,
+    defaultValue: 'draft',
+    comment: 'draft|preparing|active|paused|completed|cancelled'
+  },
+  unlockPolicy: {
+    type: DataTypes.STRING(16),
+    allowNull: false,
+    defaultValue: 'agent_unlock',
+    comment: 'on_capture = voucher live at signup; agent_unlock = consultant unlocks at the meeting (default)'
+  },
+  startDate: { type: DataTypes.DATE, allowNull: true },
+  endDate: { type: DataTypes.DATE, allowNull: true },
+  internalNotes: { type: DataTypes.TEXT, allowNull: true },
+  renewalOutcome: { type: DataTypes.STRING(24), allowNull: true, comment: 'renewed|not_renewed|pending (Phase 7)' },
+  createdBy: { type: DataTypes.UUID, allowNull: false, references: { model: 'users', key: 'id' } }
+}, {
+  tableName: 'activations',
+  indexes: [
+    { fields: ['partnerOrganisationId'], name: 'idx_act_partner' },
+    { fields: ['rewardOfferId'], name: 'idx_act_offer' },
+    { fields: ['status'], name: 'idx_act_status' },
+    // ONE live activation per campaign — makes Phase 6 issuance deterministic
+    {
+      unique: true,
+      fields: ['campaignId'],
+      name: 'uq_act_live_campaign',
+      where: { status: { [Op.in]: ['preparing', 'active', 'paused'] }, campaignId: { [Op.ne]: null } }
+    }
+  ]
+});
+
+export default Activation;

--- a/backend/src/models/PartnerOnboardingItem.js
+++ b/backend/src/models/PartnerOnboardingItem.js
@@ -1,0 +1,26 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/** Templated onboarding checklist item (docs/redeem-ops/ERD.md §3.10, brief §22). */
+const PartnerOnboardingItem = sequelize.define('PartnerOnboardingItem', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  partnerOrganisationId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'partner_organisations', key: 'id' }
+  },
+  itemKey: { type: DataTypes.STRING(48), allowNull: false },
+  label: { type: DataTypes.STRING(160), allowNull: false },
+  sortOrder: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  status: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'pending', comment: 'pending|in_progress|done|na' },
+  assigneeUserId: { type: DataTypes.UUID, allowNull: true, references: { model: 'users', key: 'id' } },
+  completedAt: { type: DataTypes.DATE, allowNull: true },
+  notes: { type: DataTypes.TEXT, allowNull: true }
+}, {
+  tableName: 'partner_onboarding_items',
+  indexes: [
+    { unique: true, fields: ['partnerOrganisationId', 'itemKey'], name: 'uq_poi_partner_key' }
+  ]
+});
+
+export default PartnerOnboardingItem;

--- a/backend/src/models/RewardInventoryEvent.js
+++ b/backend/src/models/RewardInventoryEvent.js
@@ -1,0 +1,43 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Append-only inventory ledger (docs/redeem-ops/ERD.md §3.14). Quantities are
+ * always POSITIVE — direction lives in `type`. Counters on reward_offers /
+ * activations are the fast path; this ledger is the auditable truth. The two are
+ * written in the SAME transaction by inventoryService.
+ */
+const RewardInventoryEvent = sequelize.define('RewardInventoryEvent', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  rewardOfferId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'reward_offers', key: 'id' }
+  },
+  activationId: { type: DataTypes.UUID, allowNull: true },
+  entitlementId: { type: DataTypes.UUID, allowNull: true },
+  redemptionId: { type: DataTypes.UUID, allowNull: true },
+  type: {
+    type: DataTypes.STRING(24),
+    allowNull: false,
+    comment: 'committed|increased|decreased|allocated|deallocated|issued|issue_reversed|redeemed|expired|cancelled|manual_adjustment'
+  },
+  quantity: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    validate: { min: 1 }
+  },
+  actorType: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'staff' },
+  actorUserId: { type: DataTypes.UUID, allowNull: true, references: { model: 'users', key: 'id' } },
+  reason: { type: DataTypes.STRING(255), allowNull: true }
+}, {
+  tableName: 'reward_inventory_events',
+  timestamps: true,
+  updatedAt: false,
+  indexes: [
+    { fields: ['rewardOfferId', 'createdAt'], name: 'idx_rie_offer_created' },
+    { fields: ['activationId'], name: 'idx_rie_activation' }
+  ]
+});
+
+export default RewardInventoryEvent;

--- a/backend/src/models/RewardOffer.js
+++ b/backend/src/models/RewardOffer.js
@@ -1,0 +1,60 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * A partner-funded reward (docs/redeem-ops/ERD.md §3.11). Quantity counters are
+ * GUARDED — mutated only via inventoryService's conditional UPDATEs, each paired
+ * with an append-only reward_inventory_events ledger row in the same transaction.
+ * Invariants: committed ≥ allocated ≥ issued ≥ redeemed.
+ */
+const RewardOffer = sequelize.define('RewardOffer', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  partnerOrganisationId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'partner_organisations', key: 'id' }
+  },
+  title: { type: DataTypes.STRING(160), allowNull: false },
+  publicTitle: { type: DataTypes.STRING(160), allowNull: true, comment: 'Consumer-facing name; falls back to title' },
+  internalRef: { type: DataTypes.STRING(64), allowNull: true },
+  description: { type: DataTypes.TEXT, allowNull: true },
+  category: { type: DataTypes.STRING(64), allowNull: true },
+  rewardType: {
+    type: DataTypes.STRING(24),
+    allowNull: false,
+    defaultValue: 'free_service',
+    comment: 'REWARD_TYPES in services/redeemOps/constants.js'
+  },
+  retailValue: { type: DataTypes.DECIMAL(10, 2), allowNull: true },
+  fulfilmentCost: { type: DataTypes.DECIMAL(10, 2), allowNull: true },
+  currency: { type: DataTypes.STRING(3), allowNull: false, defaultValue: 'SGD' },
+  fundingSource: { type: DataTypes.STRING(24), allowNull: false, defaultValue: 'partner', comment: 'partner|mktr|shared' },
+
+  committedQuantity: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  allocatedQuantity: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  issuedQuantity: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  redeemedQuantity: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+
+  validityStart: { type: DataTypes.DATE, allowNull: true },
+  validityEnd: { type: DataTypes.DATE, allowNull: true },
+  claimExpiryDays: { type: DataTypes.INTEGER, allowNull: true, comment: 'Reservation window: attend the review within N days' },
+  redemptionExpiryDays: { type: DataTypes.INTEGER, allowNull: true, comment: 'Redeem-at-partner window, from unlock' },
+
+  fulfilmentMethod: {
+    type: DataTypes.STRING(24),
+    allowNull: false,
+    defaultValue: 'partner_verification',
+    comment: 'unique_code|qr|partner_verification|manual_booking|external_link|physical_voucher'
+  },
+  externalBookingUrl: { type: DataTypes.STRING(255), allowNull: true },
+  status: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'draft', comment: 'draft|active|paused|ended' },
+  currentTermsVersion: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  createdBy: { type: DataTypes.UUID, allowNull: false, references: { model: 'users', key: 'id' } }
+}, {
+  tableName: 'reward_offers',
+  indexes: [
+    { fields: ['partnerOrganisationId', 'status'], name: 'idx_ro_partner_status' }
+  ]
+});
+
+export default RewardOffer;

--- a/backend/src/models/RewardOfferLocation.js
+++ b/backend/src/models/RewardOfferLocation.js
@@ -1,0 +1,24 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/** Participating outlets for a reward (docs/redeem-ops/ERD.md §3.13). */
+const RewardOfferLocation = sequelize.define('RewardOfferLocation', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  rewardOfferId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'reward_offers', key: 'id' }
+  },
+  partnerLocationId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'partner_locations', key: 'id' }
+  }
+}, {
+  tableName: 'reward_offer_locations',
+  indexes: [
+    { unique: true, fields: ['rewardOfferId', 'partnerLocationId'], name: 'uq_rol_offer_location' }
+  ]
+});
+
+export default RewardOfferLocation;

--- a/backend/src/models/RewardTermsVersion.js
+++ b/backend/src/models/RewardTermsVersion.js
@@ -1,0 +1,30 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/** Versioned reward terms (docs/redeem-ops/ERD.md §3.12) — append-only. */
+const RewardTermsVersion = sequelize.define('RewardTermsVersion', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  rewardOfferId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'reward_offers', key: 'id' }
+  },
+  version: { type: DataTypes.INTEGER, allowNull: false },
+  structured: {
+    type: DataTypes.JSONB,
+    allowNull: false,
+    defaultValue: {},
+    comment: 'Open shape: {firstTimeOnly, minAge, appointmentRequired, validDays[], …} — never boolean-per-condition'
+  },
+  freeText: { type: DataTypes.TEXT, allowNull: true },
+  createdBy: { type: DataTypes.UUID, allowNull: false, references: { model: 'users', key: 'id' } }
+}, {
+  tableName: 'reward_terms_versions',
+  timestamps: true,
+  updatedAt: false,
+  indexes: [
+    { unique: true, fields: ['rewardOfferId', 'version'], name: 'uq_rtv_offer_version' }
+  ]
+});
+
+export default RewardTermsVersion;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -193,6 +193,30 @@ function defineAssociations() {
   OutreachActivity.belongsTo(PartnerContact, { foreignKey: 'contactId', as: 'contact', onDelete: 'SET NULL' });
   OutreachActivity.belongsTo(User, { foreignKey: 'actorUserId', as: 'actor', onDelete: 'SET NULL' });
 
+  // Rewards, onboarding, activations (Phases 4–5)
+  const {
+    RewardOffer, RewardTermsVersion, RewardOfferLocation, RewardInventoryEvent,
+    PartnerOnboardingItem, Activation,
+  } = models;
+  PartnerOrganisation.hasMany(RewardOffer, { foreignKey: 'partnerOrganisationId', as: 'rewardOffers', onDelete: 'RESTRICT' });
+  RewardOffer.belongsTo(PartnerOrganisation, { foreignKey: 'partnerOrganisationId', as: 'partner', onDelete: 'RESTRICT' });
+  RewardOffer.hasMany(RewardTermsVersion, { foreignKey: 'rewardOfferId', as: 'termsVersions', onDelete: 'CASCADE' });
+  RewardTermsVersion.belongsTo(RewardOffer, { foreignKey: 'rewardOfferId', as: 'offer' });
+  RewardOffer.hasMany(RewardOfferLocation, { foreignKey: 'rewardOfferId', as: 'offerLocations', onDelete: 'CASCADE' });
+  RewardOfferLocation.belongsTo(RewardOffer, { foreignKey: 'rewardOfferId', as: 'offer' });
+  RewardOfferLocation.belongsTo(PartnerLocation, { foreignKey: 'partnerLocationId', as: 'location', onDelete: 'CASCADE' });
+  RewardOffer.hasMany(RewardInventoryEvent, { foreignKey: 'rewardOfferId', as: 'inventoryEvents', onDelete: 'RESTRICT' });
+  RewardInventoryEvent.belongsTo(RewardOffer, { foreignKey: 'rewardOfferId', as: 'offer' });
+  RewardInventoryEvent.belongsTo(User, { foreignKey: 'actorUserId', as: 'actor', onDelete: 'SET NULL' });
+  PartnerOrganisation.hasMany(PartnerOnboardingItem, { foreignKey: 'partnerOrganisationId', as: 'onboardingItems', onDelete: 'CASCADE' });
+  PartnerOnboardingItem.belongsTo(PartnerOrganisation, { foreignKey: 'partnerOrganisationId', as: 'partner' });
+  PartnerOnboardingItem.belongsTo(User, { foreignKey: 'assigneeUserId', as: 'assignee', onDelete: 'SET NULL' });
+  PartnerOrganisation.hasMany(Activation, { foreignKey: 'partnerOrganisationId', as: 'activations', onDelete: 'RESTRICT' });
+  Activation.belongsTo(PartnerOrganisation, { foreignKey: 'partnerOrganisationId', as: 'partner', onDelete: 'RESTRICT' });
+  RewardOffer.hasMany(Activation, { foreignKey: 'rewardOfferId', as: 'activations', onDelete: 'RESTRICT' });
+  Activation.belongsTo(RewardOffer, { foreignKey: 'rewardOfferId', as: 'rewardOffer', onDelete: 'RESTRICT' });
+  Activation.belongsTo(Campaign, { foreignKey: 'campaignId', as: 'campaign', onDelete: 'SET NULL' });
+
   // Outreach work (Phase 3)
   const { OutreachTask, ProspectingPool, ProspectingPoolMember } = models;
   PartnerOrganisation.hasMany(OutreachTask, { foreignKey: 'partnerOrganisationId', as: 'tasks', onDelete: 'CASCADE' });
@@ -238,7 +262,9 @@ export const {
   CampaignMediaItem, CampaignAgentAssignment, ExternalAgent, ExternalCampaignAgent,
   WaitlistSignup, RedeemOpsAuditEvent, PartnerOrganisation, PartnerLocation,
   PartnerContact, PartnerAssignmentEvent, PartnerStageEvent, OutreachActivity,
-  OutreachTask, ProspectingPool, ProspectingPoolMember
+  OutreachTask, ProspectingPool, ProspectingPoolMember, RewardOffer,
+  RewardTermsVersion, RewardOfferLocation, RewardInventoryEvent,
+  PartnerOnboardingItem, Activation
 } = models;
 
 export { sequelize };

--- a/backend/src/routes/redeemOpsActivations.js
+++ b/backend/src/routes/redeemOpsActivations.js
@@ -1,0 +1,31 @@
+import express from 'express';
+import { requireRedeemOps } from '../middleware/redeemOpsAuth.js';
+import * as ctrl from '../controllers/redeemOps/activationsController.js';
+
+/**
+ * Redeem Ops Phase 5 — Activations + read-only MKTR campaign reference
+ * (docs/redeem-ops/ROUTE_MAP.md §1, MKTR_INTEGRATION.md §1). Campaign editing
+ * never happens here — the projection is attribute-allowlisted and the UI
+ * deep-links back to mktr.sg for management.
+ */
+export const meta = {
+  path: '/api/redeem-ops',
+  flag: 'REDEEM_OPS_ENABLED',
+  flagDefault: 'false',
+};
+
+const router = express.Router();
+
+// Read-only MKTR campaign projection (link picker + detail card)
+router.get('/campaigns', requireRedeemOps('campaigns.read_reference'), ctrl.searchCampaigns);
+
+// Activations
+router.get('/activations', requireRedeemOps('activations.view'), ctrl.listActivations);
+router.post('/activations', requireRedeemOps('activations.manage'), ctrl.createActivation);
+router.get('/activations/:id', requireRedeemOps('activations.view'), ctrl.getActivation);
+router.patch('/activations/:id/campaign', requireRedeemOps('activations.link_campaign'), ctrl.linkCampaign);
+router.patch('/activations/:id/allocation', requireRedeemOps('activations.allocate_inventory'), ctrl.changeAllocation);
+router.patch('/activations/:id/status', requireRedeemOps('activations.manage'), ctrl.setStatus);
+router.get('/activations/:id/campaign-metrics', requireRedeemOps('campaigns.read_reference'), ctrl.getCampaignMetrics);
+
+export default router;

--- a/backend/src/routes/redeemOpsRewards.js
+++ b/backend/src/routes/redeemOpsRewards.js
@@ -1,0 +1,37 @@
+import express from 'express';
+import { requireRedeemOps } from '../middleware/redeemOpsAuth.js';
+import * as ctrl from '../controllers/redeemOps/rewardsController.js';
+
+/**
+ * Redeem Ops Phase 4 — reward offers, versioned terms, inventory ledger,
+ * onboarding checklist (docs/redeem-ops/ROUTE_MAP.md §1). Flag + host-guard
+ * posture as siblings.
+ */
+export const meta = {
+  path: '/api/redeem-ops',
+  flag: 'REDEEM_OPS_ENABLED',
+  flagDefault: 'false',
+};
+
+const router = express.Router();
+
+// Reward offers
+router.get('/rewards', requireRedeemOps('rewards.view'), ctrl.listOffers);
+router.post('/rewards', requireRedeemOps('rewards.manage'), ctrl.createOffer);
+router.get('/rewards/:id', requireRedeemOps('rewards.view'), ctrl.getOffer);
+router.put('/rewards/:id', requireRedeemOps('rewards.manage'), ctrl.updateOffer);
+router.patch('/rewards/:id/status', requireRedeemOps('rewards.manage'), ctrl.setOfferStatus);
+
+// Versioned terms + participating locations (recent terms ship with getOffer)
+router.post('/rewards/:id/terms', requireRedeemOps('rewards.manage'), ctrl.addTermsVersion);
+router.put('/rewards/:id/locations', requireRedeemOps('rewards.manage'), ctrl.setLocations);
+
+// Inventory (manual movements are ops_admin+; ledger visible to reward viewers)
+router.post('/rewards/:id/inventory', requireRedeemOps('inventory.adjust'), ctrl.adjustInventory);
+router.get('/rewards/:id/ledger', requireRedeemOps('rewards.view'), ctrl.getLedger);
+
+// Partner onboarding checklist
+router.get('/partners/:id/onboarding', requireRedeemOps('onboarding.manage'), ctrl.getOnboarding);
+router.patch('/onboarding/:itemId', requireRedeemOps('onboarding.manage'), ctrl.updateOnboardingItem);
+
+export default router;

--- a/backend/src/services/redeemOps/activationService.js
+++ b/backend/src/services/redeemOps/activationService.js
@@ -1,0 +1,205 @@
+import {
+  Activation, RewardOffer, PartnerOrganisation, Campaign, sequelize,
+} from '../../models/index.js';
+import { AppError } from '../../middleware/errorHandler.js';
+import { logger } from '../../utils/logger.js';
+import { makeRedeemOpsAuditService } from './auditService.js';
+import { makeInventoryService } from './inventoryService.js';
+
+const ACTIVATION_STATUSES = ['draft', 'preparing', 'active', 'paused', 'completed', 'cancelled'];
+const LIVE_STATUSES = ['preparing', 'active', 'paused'];
+const STATUS_TRANSITIONS = {
+  draft: ['preparing', 'cancelled'],
+  preparing: ['active', 'cancelled'],
+  active: ['paused', 'completed', 'cancelled'],
+  paused: ['active', 'completed', 'cancelled'],
+  completed: [],
+  cancelled: [],
+};
+const UNLOCK_POLICIES = ['on_capture', 'agent_unlock'];
+
+/**
+ * Activations (docs/redeem-ops/ERD.md §3.15, brief §25): the operational bridge
+ * between a partner's Reward Offer and ONE canonical MKTR campaign. Owns
+ * allocation + status + unlock policy; owns NOTHING of the campaign itself —
+ * linking validates against `campaigns` read-only, and the partial unique index
+ * (one LIVE activation per campaign) is the DB-level backstop.
+ */
+export function makeActivationService(overrides = {}) {
+  const d = {
+    Activation, RewardOffer, PartnerOrganisation, Campaign, sequelize, logger,
+    audit: makeRedeemOpsAuditService(),
+    inventory: makeInventoryService(),
+    ...overrides,
+  };
+
+  const INCLUDES = [
+    { model: PartnerOrganisation, as: 'partner', attributes: ['id', 'tradingName', 'legalName', 'brandName'] },
+    { model: RewardOffer, as: 'rewardOffer', attributes: ['id', 'title', 'rewardType', 'committedQuantity', 'allocatedQuantity', 'issuedQuantity', 'redeemedQuantity', 'claimExpiryDays', 'redemptionExpiryDays', 'status'] },
+  ];
+
+  async function listActivations(query = {}) {
+    const where = {};
+    if (query.status && ACTIVATION_STATUSES.includes(query.status)) where.status = query.status;
+    if (query.partnerOrganisationId) where.partnerOrganisationId = String(query.partnerOrganisationId);
+    return d.Activation.findAll({ where, include: INCLUDES, order: [['createdAt', 'DESC']], limit: 200 });
+  }
+
+  async function getActivation(id) {
+    const activation = await d.Activation.findByPk(id, { include: INCLUDES });
+    if (!activation) throw new AppError('Activation not found', 404);
+    return activation;
+  }
+
+  async function createActivation(body, user, requestId = null) {
+    const offer = await d.RewardOffer.findByPk(body.rewardOfferId);
+    if (!offer) throw new AppError('Reward offer not found', 404);
+    if (body.unlockPolicy && !UNLOCK_POLICIES.includes(body.unlockPolicy)) {
+      throw new AppError('Unknown unlockPolicy', 400);
+    }
+
+    return d.sequelize.transaction(async (t) => {
+      const activation = await d.Activation.create(
+        {
+          partnerOrganisationId: offer.partnerOrganisationId,
+          rewardOfferId: offer.id,
+          allocatedQuantity: 0,
+          unlockPolicy: body.unlockPolicy || 'agent_unlock',
+          startDate: body.startDate || null,
+          endDate: body.endDate || null,
+          internalNotes: body.internalNotes || null,
+          createdBy: user.id,
+        },
+        { transaction: t }
+      );
+      const qty = parseInt(body.allocatedQuantity, 10) || 0;
+      if (qty > 0) {
+        await d.inventory.allocate({
+          offerId: offer.id, activationId: activation.id, quantity: qty,
+          actorUser: user, reason: 'initial allocation', transaction: t,
+        });
+        await activation.update({ allocatedQuantity: qty }, { transaction: t });
+      }
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'activation.created', entityType: 'activation',
+        entityId: activation.id,
+        after: { rewardOfferId: offer.id, allocatedQuantity: qty },
+        requestId, transaction: t,
+      });
+      return activation;
+    });
+  }
+
+  /** Link (or unlink with campaignId=null) the canonical MKTR campaign. */
+  async function linkCampaign(id, campaignId, user, requestId = null) {
+    const activation = await getActivation(id);
+
+    if (campaignId === null) {
+      const before = { campaignId: activation.campaignId };
+      await d.sequelize.transaction(async (t) => {
+        await activation.update({ campaignId: null, campaignNameSnapshot: null }, { transaction: t });
+        await d.audit.recordAuditEvent({
+          actorUser: user, action: 'activation.campaign_unlinked', entityType: 'activation',
+          entityId: id, before, requestId, transaction: t,
+        });
+      });
+      return activation;
+    }
+
+    const campaign = await d.Campaign.findByPk(campaignId, { attributes: ['id', 'name', 'status'] });
+    if (!campaign) throw new AppError('Campaign not found', 404);
+    if (campaign.status === 'archived') {
+      throw new AppError('Cannot link an archived campaign', 400);
+    }
+
+    const before = { campaignId: activation.campaignId };
+    try {
+      await d.sequelize.transaction(async (t) => {
+        await activation.update(
+          { campaignId: campaign.id, campaignNameSnapshot: campaign.name },
+          { transaction: t }
+        );
+        await d.audit.recordAuditEvent({
+          actorUser: user, action: 'activation.campaign_linked', entityType: 'activation',
+          entityId: id, before, after: { campaignId: campaign.id, campaignName: campaign.name },
+          requestId, transaction: t,
+        });
+      });
+    } catch (err) {
+      if (err?.name === 'SequelizeUniqueConstraintError' || err?.original?.constraint === 'uq_act_live_campaign') {
+        throw new AppError('Another live activation is already linked to this campaign', 409);
+      }
+      throw err;
+    }
+    return activation;
+  }
+
+  /** Change ± allocation through the inventory ledger (never a bare counter write). */
+  async function changeAllocation(id, delta, user, reason = null, requestId = null) {
+    if (!Number.isInteger(delta) || delta === 0) throw new AppError('delta must be a non-zero integer', 400);
+    const activation = await getActivation(id);
+
+    return d.sequelize.transaction(async (t) => {
+      if (delta > 0) {
+        await d.inventory.allocate({
+          offerId: activation.rewardOfferId, activationId: id, quantity: delta,
+          actorUser: user, reason, transaction: t,
+        });
+      } else {
+        const q = -delta;
+        if (activation.allocatedQuantity - q < activation.issuedCount) {
+          throw new AppError('Cannot reduce allocation below what has been issued', 409);
+        }
+        await d.inventory.deallocate({
+          offerId: activation.rewardOfferId, activationId: id, quantity: q,
+          actorUser: user, reason, transaction: t,
+        });
+      }
+      await activation.update(
+        { allocatedQuantity: activation.allocatedQuantity + delta },
+        { transaction: t }
+      );
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'activation.allocation_changed', entityType: 'activation',
+        entityId: id, after: { delta, allocatedQuantity: activation.allocatedQuantity },
+        reason, requestId, transaction: t,
+      });
+      return activation;
+    });
+  }
+
+  async function setStatus(id, status, user, requestId = null) {
+    if (!ACTIVATION_STATUSES.includes(status)) throw new AppError('Unknown status', 400);
+    const activation = await getActivation(id);
+    const from = activation.status;
+    if (from === status) return activation;
+    if (!(STATUS_TRANSITIONS[from] || []).includes(status)) {
+      throw new AppError(`Cannot move activation from ${from} to ${status}`, 400);
+    }
+    // Going LIVE requires a linked campaign and a live reward offer
+    if (LIVE_STATUSES.includes(status) && !activation.campaignId && status !== 'preparing') {
+      throw new AppError('Link an MKTR campaign before activating', 400);
+    }
+
+    try {
+      await d.sequelize.transaction(async (t) => {
+        await activation.update({ status }, { transaction: t });
+        await d.audit.recordAuditEvent({
+          actorUser: user, action: 'activation.status_changed', entityType: 'activation',
+          entityId: id, before: { status: from }, after: { status }, requestId, transaction: t,
+        });
+      });
+    } catch (err) {
+      if (err?.name === 'SequelizeUniqueConstraintError' || err?.original?.constraint === 'uq_act_live_campaign') {
+        throw new AppError('Another live activation is already linked to this campaign', 409);
+      }
+      throw err;
+    }
+    return activation;
+  }
+
+  return { listActivations, getActivation, createActivation, linkCampaign, changeAllocation, setStatus };
+}
+
+const _default = makeActivationService();
+export default _default;

--- a/backend/src/services/redeemOps/campaignProjection.js
+++ b/backend/src/services/redeemOps/campaignProjection.js
@@ -1,0 +1,78 @@
+import { Op } from 'sequelize';
+import { Campaign, Activation, sequelize } from '../../models/index.js';
+import { AppError } from '../../middleware/errorHandler.js';
+import { computeCampaignMetrics } from '../campaignService.js';
+import { normalizeCustomerHostChoice, customerHostOrigin } from '../../utils/customerHost.js';
+
+/**
+ * The ONLY Redeem Ops file that reads MKTR campaign internals
+ * (docs/redeem-ops/MKTR_INTEGRATION.md §1). Read-only, attribute-allowlisted —
+ * design_config is NEVER returned wholesale (builder internals stay on mktr.sg);
+ * only the customerHost choice is extracted to compute the public URL.
+ */
+const PROJECTION_ATTRS = ['id', 'name', 'status', 'type', 'is_active', 'design_config', 'createdAt'];
+
+function toProjection(campaign, liveActivationByCampaign = new Map()) {
+  const hostChoice = normalizeCustomerHostChoice(campaign.design_config?.customerHost);
+  const origin = customerHostOrigin(hostChoice);
+  return {
+    id: campaign.id,
+    name: campaign.name,
+    status: campaign.status,
+    type: campaign.type,
+    isActive: campaign.is_active,
+    customerHost: hostChoice,
+    publicUrl: `${origin}/LeadCapture?campaign_id=${campaign.id}`,
+    mktrAdminUrl: `https://mktr.sg/admin/campaigns/${campaign.id}/workspace`,
+    createdAt: campaign.createdAt,
+    linkedActivationId: liveActivationByCampaign.get(campaign.id) || null,
+  };
+}
+
+export function makeCampaignProjection(overrides = {}) {
+  const d = { Campaign, Activation, sequelize, ...overrides };
+
+  /** Search campaigns for the Activation link picker. */
+  async function searchCampaigns(query = {}) {
+    const where = {};
+    if (query.search) where.name = { [Op.iLike]: `%${String(query.search).trim()}%` };
+    if (query.status) where.status = String(query.status);
+    else where.status = { [Op.ne]: 'archived' };
+
+    const campaigns = await d.Campaign.findAll({
+      where,
+      attributes: PROJECTION_ATTRS,
+      order: [['createdAt', 'DESC']],
+      limit: Math.min(50, Math.max(1, parseInt(query.limit, 10) || 25)),
+    });
+
+    const live = await d.Activation.findAll({
+      where: {
+        campaignId: { [Op.in]: campaigns.map((c) => c.id) },
+        status: { [Op.in]: ['preparing', 'active', 'paused'] },
+      },
+      attributes: ['id', 'campaignId'],
+    });
+    const liveMap = new Map(live.map((a) => [a.campaignId, a.id]));
+    return campaigns.map((c) => toProjection(c, liveMap));
+  }
+
+  /** Read-only detail card for a linked campaign. */
+  async function getCampaignReference(campaignId) {
+    const campaign = await d.Campaign.findByPk(campaignId, { attributes: PROJECTION_ATTRS });
+    if (!campaign) throw new AppError('Campaign not found', 404);
+    return toProjection(campaign);
+  }
+
+  /** Acquisition metrics — ALWAYS MKTR's own numbers (computeCampaignMetrics), never re-counted. */
+  async function getCampaignMetrics(campaignId) {
+    const campaign = await d.Campaign.findByPk(campaignId, { attributes: ['id'] });
+    if (!campaign) throw new AppError('Campaign not found', 404);
+    return computeCampaignMetrics(campaignId);
+  }
+
+  return { searchCampaigns, getCampaignReference, getCampaignMetrics, toProjection };
+}
+
+const _default = makeCampaignProjection();
+export default _default;

--- a/backend/src/services/redeemOps/inventoryService.js
+++ b/backend/src/services/redeemOps/inventoryService.js
@@ -1,0 +1,186 @@
+import { RewardOffer, RewardInventoryEvent, sequelize } from '../../models/index.js';
+import { AppError } from '../../middleware/errorHandler.js';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Reward inventory (docs/redeem-ops/ERD.md §3.11/§3.14/§4.3, brief §24).
+ *
+ * Every quantity movement is TWO writes in ONE transaction:
+ *   (a) a guarded conditional UPDATE on the reward_offers counters — the
+ *       oversubscription gate (0 rows = typed 409; house pattern:
+ *       deductExternalLeadBalance), and
+ *   (b) an append-only reward_inventory_events ledger row — the audit truth.
+ *
+ * Invariants enforced by the guards: committed ≥ allocated ≥ issued ≥ redeemed,
+ * and no counter ever goes negative. reconcile() asserts ledger ⇄ counters.
+ */
+export function makeInventoryService(overrides = {}) {
+  const d = { RewardOffer, RewardInventoryEvent, sequelize, logger, ...overrides };
+
+  async function writeLedger(t, evt) {
+    return d.RewardInventoryEvent.create(
+      {
+        rewardOfferId: evt.rewardOfferId,
+        activationId: evt.activationId || null,
+        entitlementId: evt.entitlementId || null,
+        redemptionId: evt.redemptionId || null,
+        type: evt.type,
+        quantity: evt.quantity,
+        actorType: evt.actorType || 'staff',
+        actorUserId: evt.actorUser?.id || evt.actorUserId || null,
+        reason: evt.reason || null,
+      },
+      { transaction: t }
+    );
+  }
+
+  /**
+   * Run `guardSql` (a conditional UPDATE ... RETURNING) + ledger row atomically.
+   * Uses the caller's transaction when given, else owns one.
+   */
+  async function guardedMove({ offerId, quantity, guardSql, ledger, transaction = null, failMessage }) {
+    if (!Number.isInteger(quantity) || quantity <= 0) {
+      throw new AppError('quantity must be a positive integer', 400);
+    }
+    const run = async (t) => {
+      const [rows] = await d.sequelize.query(guardSql, {
+        replacements: { offerId, q: quantity },
+        transaction: t,
+      });
+      if (!Array.isArray(rows) || rows.length === 0) {
+        throw new AppError(failMessage, 409);
+      }
+      await writeLedger(t, { ...ledger, rewardOfferId: offerId, quantity });
+      return rows[0];
+    };
+    if (transaction) return run(transaction);
+    return d.sequelize.transaction(run);
+  }
+
+  /** Increase total committed supply (partner promised more). */
+  function increaseCommitted({ offerId, quantity, actorUser, reason, transaction }) {
+    return guardedMove({
+      offerId, quantity, transaction,
+      guardSql: `UPDATE reward_offers
+                    SET "committedQuantity" = "committedQuantity" + :q, "updatedAt" = NOW()
+                  WHERE id = :offerId
+                  RETURNING id, "committedQuantity"`,
+      ledger: { type: 'increased', actorUser, reason },
+      failMessage: 'Reward offer not found',
+    });
+  }
+
+  /** Decrease committed supply — never below what is already allocated. */
+  function decreaseCommitted({ offerId, quantity, actorUser, reason, transaction }) {
+    return guardedMove({
+      offerId, quantity, transaction,
+      guardSql: `UPDATE reward_offers
+                    SET "committedQuantity" = "committedQuantity" - :q, "updatedAt" = NOW()
+                  WHERE id = :offerId
+                    AND "committedQuantity" - :q >= "allocatedQuantity"
+                  RETURNING id, "committedQuantity"`,
+      ledger: { type: 'decreased', actorUser, reason },
+      failMessage: 'Cannot reduce committed supply below what is already allocated',
+    });
+  }
+
+  /** Allocate supply to an Activation — the oversubscription gate. */
+  function allocate({ offerId, activationId, quantity, actorUser, reason, transaction }) {
+    return guardedMove({
+      offerId, quantity, transaction,
+      guardSql: `UPDATE reward_offers
+                    SET "allocatedQuantity" = "allocatedQuantity" + :q, "updatedAt" = NOW()
+                  WHERE id = :offerId
+                    AND "committedQuantity" - "allocatedQuantity" >= :q
+                  RETURNING id, "allocatedQuantity"`,
+      ledger: { type: 'allocated', activationId, actorUser, reason },
+      failMessage: 'Not enough committed supply remaining to allocate',
+    });
+  }
+
+  /** Return allocation to the pool — never below what is already issued. */
+  function deallocate({ offerId, activationId, quantity, actorUser, reason, transaction }) {
+    return guardedMove({
+      offerId, quantity, transaction,
+      guardSql: `UPDATE reward_offers
+                    SET "allocatedQuantity" = "allocatedQuantity" - :q, "updatedAt" = NOW()
+                  WHERE id = :offerId
+                    AND "allocatedQuantity" - :q >= "issuedQuantity"
+                  RETURNING id, "allocatedQuantity"`,
+      ledger: { type: 'deallocated', activationId, actorUser, reason },
+      failMessage: 'Cannot deallocate below what has already been issued',
+    });
+  }
+
+  /** Phase 6: entitlement issued (reservation) consumes allocated supply. */
+  function recordIssued({ offerId, activationId, entitlementId, actorType = 'system', transaction }) {
+    return guardedMove({
+      offerId, quantity: 1, transaction,
+      guardSql: `UPDATE reward_offers
+                    SET "issuedQuantity" = "issuedQuantity" + 1, "updatedAt" = NOW()
+                  WHERE id = :offerId
+                    AND "allocatedQuantity" - "issuedQuantity" >= 1
+                  RETURNING id, "issuedQuantity"`,
+      ledger: { type: 'issued', activationId, entitlementId, actorType },
+      failMessage: 'Activation allocation exhausted',
+    });
+  }
+
+  /** Phase 6: expired/cancelled reservation returns a unit to the pool. */
+  function reverseIssued({ offerId, activationId, entitlementId, type = 'expired', actorType = 'system', reason, transaction }) {
+    return guardedMove({
+      offerId, quantity: 1, transaction,
+      guardSql: `UPDATE reward_offers
+                    SET "issuedQuantity" = "issuedQuantity" - 1, "updatedAt" = NOW()
+                  WHERE id = :offerId
+                    AND "issuedQuantity" - 1 >= "redeemedQuantity"
+                  RETURNING id, "issuedQuantity"`,
+      ledger: { type, activationId, entitlementId, actorType, reason },
+      failMessage: 'Cannot reverse an issuance that was already redeemed',
+    });
+  }
+
+  /** Phase 6: completed redemption. */
+  function recordRedeemed({ offerId, activationId, entitlementId, redemptionId, actorType = 'staff', actorUser, transaction }) {
+    return guardedMove({
+      offerId, quantity: 1, transaction,
+      guardSql: `UPDATE reward_offers
+                    SET "redeemedQuantity" = "redeemedQuantity" + 1, "updatedAt" = NOW()
+                  WHERE id = :offerId
+                    AND "issuedQuantity" - "redeemedQuantity" >= 1
+                  RETURNING id, "redeemedQuantity"`,
+      ledger: { type: 'redeemed', activationId, entitlementId, redemptionId, actorType, actorUser },
+      failMessage: 'No issued units available to redeem',
+    });
+  }
+
+  /** Ledger ⇄ counter reconciliation (test-time assertion; future cron). */
+  async function reconcile(offerId) {
+    const offer = await d.RewardOffer.findByPk(offerId);
+    if (!offer) throw new AppError('Reward offer not found', 404);
+    const events = await d.RewardInventoryEvent.findAll({ where: { rewardOfferId: offerId } });
+    const sum = (types) => events.filter((e) => types.includes(e.type)).reduce((n, e) => n + e.quantity, 0);
+    const derived = {
+      committedQuantity: sum(['committed', 'increased']) - sum(['decreased']),
+      allocatedQuantity: sum(['allocated']) - sum(['deallocated']),
+      issuedQuantity: sum(['issued']) - sum(['expired', 'cancelled', 'issue_reversed']),
+      redeemedQuantity: sum(['redeemed']),
+    };
+    const actual = {
+      committedQuantity: offer.committedQuantity,
+      allocatedQuantity: offer.allocatedQuantity,
+      issuedQuantity: offer.issuedQuantity,
+      redeemedQuantity: offer.redeemedQuantity,
+    };
+    const consistent = Object.keys(derived).every((k) => derived[k] === actual[k]);
+    return { consistent, derived, actual };
+  }
+
+  return {
+    increaseCommitted, decreaseCommitted, allocate, deallocate,
+    recordIssued, reverseIssued, recordRedeemed, reconcile, writeLedger,
+  };
+}
+
+const _default = makeInventoryService();
+export default _default;

--- a/backend/src/services/redeemOps/onboardingService.js
+++ b/backend/src/services/redeemOps/onboardingService.js
@@ -1,0 +1,66 @@
+import { PartnerOnboardingItem, PartnerOrganisation, sequelize } from '../../models/index.js';
+import { AppError } from '../../middleware/errorHandler.js';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Partner onboarding checklist (brief §22). Seeded when a partner hits
+ * PARTNERED (partnerService.changeStage → onPartnered hook); idempotent
+ * (unique (partner, itemKey)).
+ */
+export const ONBOARDING_TEMPLATE = [
+  { itemKey: 'partnership_confirmed', label: 'Partnership confirmed' },
+  { itemKey: 'primary_contact_verified', label: 'Primary contact verified' },
+  { itemKey: 'org_details_verified', label: 'Organisation details verified' },
+  { itemKey: 'locations_confirmed', label: 'Participating locations confirmed' },
+  { itemKey: 'reward_offer_entered', label: 'Reward offer entered' },
+  { itemKey: 'reward_terms_confirmed', label: 'Reward terms confirmed' },
+  { itemKey: 'quantity_confirmed', label: 'Quantity / capacity confirmed' },
+  { itemKey: 'redemption_method_confirmed', label: 'Redemption method confirmed' },
+  { itemKey: 'campaign_requirements_collected', label: 'Campaign requirements collected' },
+  { itemKey: 'documentation_recorded', label: 'Documentation status recorded' },
+  { itemKey: 'ready_for_activation', label: 'Ready for Activation' },
+];
+
+const ITEM_STATUSES = ['pending', 'in_progress', 'done', 'na'];
+
+export function makeOnboardingService(overrides = {}) {
+  const d = { PartnerOnboardingItem, PartnerOrganisation, sequelize, logger, ...overrides };
+
+  /** Idempotent template seed — safe to call on every PARTNERED transition. */
+  async function seedChecklist(partnerOrganisationId, transaction = null) {
+    for (const [i, item] of ONBOARDING_TEMPLATE.entries()) {
+      await d.PartnerOnboardingItem.findOrCreate({
+        where: { partnerOrganisationId, itemKey: item.itemKey },
+        defaults: { partnerOrganisationId, itemKey: item.itemKey, label: item.label, sortOrder: i },
+        transaction,
+      });
+    }
+  }
+
+  async function getChecklist(partnerOrganisationId) {
+    return d.PartnerOnboardingItem.findAll({
+      where: { partnerOrganisationId },
+      order: [['sortOrder', 'ASC']],
+    });
+  }
+
+  async function updateItem(itemId, body, user) {
+    const item = await d.PartnerOnboardingItem.findByPk(itemId);
+    if (!item) throw new AppError('Checklist item not found', 404);
+    const updates = {};
+    if (body.status !== undefined) {
+      if (!ITEM_STATUSES.includes(body.status)) throw new AppError('Unknown status', 400);
+      updates.status = body.status;
+      updates.completedAt = body.status === 'done' ? new Date() : null;
+    }
+    if (body.assigneeUserId !== undefined) updates.assigneeUserId = body.assigneeUserId;
+    if (body.notes !== undefined) updates.notes = body.notes;
+    await item.update(updates);
+    return item;
+  }
+
+  return { seedChecklist, getChecklist, updateItem };
+}
+
+const _default = makeOnboardingService();
+export default _default;

--- a/backend/src/services/redeemOps/partnerService.js
+++ b/backend/src/services/redeemOps/partnerService.js
@@ -13,6 +13,7 @@ import {
   PIPELINE_STAGES, STAGE_TRANSITIONS, PARTNER_AVAILABILITY,
   ACTIVITY_TYPES, MEANINGFUL_ACTIVITY_TYPES,
 } from './constants.js';
+import { makeOnboardingService } from './onboardingService.js';
 
 /**
  * Partner CRM core (docs/redeem-ops/ERD.md §3.1–3.6, brief §13–§18).
@@ -25,9 +26,8 @@ export function makePartnerService(overrides = {}) {
     PartnerStageEvent, OutreachActivity, User, sequelize, logger,
     audit: makeRedeemOpsAuditService(),
     dedupe: makeDedupeService(),
-    // PARTNERED hook — Phase 4 injects the onboarding-checklist seed here
-    // (changeStage guards on typeof, so null = no-op until then).
-    onPartnered: null,
+    // PARTNERED → seed the onboarding checklist (brief §22); injectable for tests.
+    onPartnered: (partner, _user, t) => makeOnboardingService().seedChecklist(partner.id, t),
     ...overrides,
   };
 

--- a/backend/src/services/redeemOps/rewardService.js
+++ b/backend/src/services/redeemOps/rewardService.js
@@ -1,0 +1,235 @@
+import { Op } from 'sequelize';
+import {
+  RewardOffer, RewardTermsVersion, RewardOfferLocation, RewardInventoryEvent,
+  PartnerOrganisation, PartnerLocation, User, sequelize,
+} from '../../models/index.js';
+import { AppError } from '../../middleware/errorHandler.js';
+import { logger } from '../../utils/logger.js';
+import { makeRedeemOpsAuditService } from './auditService.js';
+import { makeInventoryService } from './inventoryService.js';
+import { REWARD_TYPES } from './constants.js';
+
+const OFFER_STATUSES = ['draft', 'active', 'paused', 'ended'];
+const FULFILMENT_METHODS = ['unique_code', 'qr', 'partner_verification', 'manual_booking', 'external_link', 'physical_voucher'];
+
+/** Reward offers + versioned terms (docs/redeem-ops/ERD.md §3.11–3.13, brief §23). */
+export function makeRewardService(overrides = {}) {
+  const d = {
+    RewardOffer, RewardTermsVersion, RewardOfferLocation, RewardInventoryEvent,
+    PartnerOrganisation, PartnerLocation, User, sequelize, logger,
+    audit: makeRedeemOpsAuditService(),
+    inventory: makeInventoryService(),
+    ...overrides,
+  };
+
+  const EDITABLE = [
+    'title', 'publicTitle', 'internalRef', 'description', 'category', 'rewardType',
+    'retailValue', 'fulfilmentCost', 'fundingSource', 'validityStart', 'validityEnd',
+    'claimExpiryDays', 'redemptionExpiryDays', 'fulfilmentMethod', 'externalBookingUrl',
+  ];
+
+  function validateEnumFields(body) {
+    if (body.rewardType && !REWARD_TYPES.includes(body.rewardType)) throw new AppError('Unknown rewardType', 400);
+    if (body.fulfilmentMethod && !FULFILMENT_METHODS.includes(body.fulfilmentMethod)) throw new AppError('Unknown fulfilmentMethod', 400);
+  }
+
+  async function listOffers(query = {}) {
+    const where = {};
+    if (query.partnerOrganisationId) where.partnerOrganisationId = String(query.partnerOrganisationId);
+    if (query.status && OFFER_STATUSES.includes(query.status)) where.status = query.status;
+    const offers = await d.RewardOffer.findAll({
+      where,
+      include: [{ model: d.PartnerOrganisation, as: 'partner', attributes: ['id', 'tradingName', 'legalName', 'brandName'] }],
+      order: [['createdAt', 'DESC']],
+      limit: 200,
+    });
+    return offers;
+  }
+
+  async function getOffer(id) {
+    const offer = await d.RewardOffer.findByPk(id, {
+      include: [
+        { model: d.PartnerOrganisation, as: 'partner', attributes: ['id', 'tradingName', 'legalName', 'brandName'] },
+        { model: d.RewardOfferLocation, as: 'offerLocations', include: [{ model: d.PartnerLocation, as: 'location' }] },
+      ],
+    });
+    if (!offer) throw new AppError('Reward offer not found', 404);
+    const terms = await d.RewardTermsVersion.findAll({
+      where: { rewardOfferId: id },
+      order: [['version', 'DESC']],
+      limit: 5,
+    });
+    return { offer, terms };
+  }
+
+  async function createOffer(body, user, requestId = null) {
+    if (!body.title || !String(body.title).trim()) throw new AppError('Title is required', 400);
+    if (!body.partnerOrganisationId) throw new AppError('partnerOrganisationId is required', 400);
+    validateEnumFields(body);
+    const partner = await d.PartnerOrganisation.findByPk(body.partnerOrganisationId);
+    if (!partner || partner.mergedIntoId) throw new AppError('Partner not found', 404);
+
+    const committed = Number.isInteger(body.committedQuantity) && body.committedQuantity > 0
+      ? body.committedQuantity : 0;
+
+    return d.sequelize.transaction(async (t) => {
+      const offer = await d.RewardOffer.create(
+        {
+          partnerOrganisationId: body.partnerOrganisationId,
+          title: String(body.title).trim(),
+          publicTitle: body.publicTitle || null,
+          internalRef: body.internalRef || null,
+          description: body.description || null,
+          category: body.category || partner.category || null,
+          rewardType: body.rewardType || 'free_service',
+          retailValue: body.retailValue ?? null,
+          fulfilmentCost: body.fulfilmentCost ?? null,
+          fundingSource: body.fundingSource || 'partner',
+          committedQuantity: committed,
+          validityStart: body.validityStart || null,
+          validityEnd: body.validityEnd || null,
+          claimExpiryDays: body.claimExpiryDays ?? null,
+          redemptionExpiryDays: body.redemptionExpiryDays ?? null,
+          fulfilmentMethod: body.fulfilmentMethod || 'partner_verification',
+          externalBookingUrl: body.externalBookingUrl || null,
+          createdBy: user.id,
+        },
+        { transaction: t }
+      );
+      if (committed > 0) {
+        await d.inventory.writeLedger(t, {
+          rewardOfferId: offer.id, type: 'committed', quantity: committed, actorUser: user,
+          reason: 'initial commitment',
+        });
+      }
+      if (body.terms) {
+        await d.RewardTermsVersion.create(
+          { rewardOfferId: offer.id, version: 1, structured: body.terms.structured || {}, freeText: body.terms.freeText || null, createdBy: user.id },
+          { transaction: t }
+        );
+        await offer.update({ currentTermsVersion: 1 }, { transaction: t });
+      }
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'reward.created', entityType: 'reward_offer', entityId: offer.id,
+        after: { title: offer.title, partnerOrganisationId: offer.partnerOrganisationId, committedQuantity: committed },
+        requestId, transaction: t,
+      });
+      return offer;
+    });
+  }
+
+  async function updateOffer(id, body, user, requestId = null) {
+    const offer = await d.RewardOffer.findByPk(id);
+    if (!offer) throw new AppError('Reward offer not found', 404);
+    validateEnumFields(body);
+    const updates = {};
+    for (const f of EDITABLE) if (body[f] !== undefined) updates[f] = body[f];
+    const before = {};
+    for (const k of Object.keys(updates)) before[k] = offer.get(k);
+
+    await d.sequelize.transaction(async (t) => {
+      await offer.update(updates, { transaction: t });
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'reward.edited', entityType: 'reward_offer', entityId: id,
+        before, after: updates, requestId, transaction: t,
+      });
+    });
+    return offer;
+  }
+
+  async function setOfferStatus(id, status, user, requestId = null) {
+    if (!OFFER_STATUSES.includes(status)) throw new AppError('Unknown status', 400);
+    const offer = await d.RewardOffer.findByPk(id);
+    if (!offer) throw new AppError('Reward offer not found', 404);
+    const before = offer.status;
+    await d.sequelize.transaction(async (t) => {
+      await offer.update({ status }, { transaction: t });
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'reward.status_changed', entityType: 'reward_offer', entityId: id,
+        before: { status: before }, after: { status }, requestId, transaction: t,
+      });
+    });
+    return offer;
+  }
+
+  /** Append a new terms version and point the offer at it. */
+  async function addTermsVersion(id, body, user, requestId = null) {
+    const offer = await d.RewardOffer.findByPk(id);
+    if (!offer) throw new AppError('Reward offer not found', 404);
+    return d.sequelize.transaction(async (t) => {
+      const version = offer.currentTermsVersion + 1;
+      const terms = await d.RewardTermsVersion.create(
+        {
+          rewardOfferId: id, version,
+          structured: body.structured || {}, freeText: body.freeText || null, createdBy: user.id,
+        },
+        { transaction: t }
+      );
+      await offer.update({ currentTermsVersion: version }, { transaction: t });
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'terms.versioned', entityType: 'reward_offer', entityId: id,
+        after: { version }, requestId, transaction: t,
+      });
+      return terms;
+    });
+  }
+
+  /** Replace the participating-locations set (must belong to the offer's partner). */
+  async function setLocations(id, partnerLocationIds, _user) {
+    const offer = await d.RewardOffer.findByPk(id);
+    if (!offer) throw new AppError('Reward offer not found', 404);
+    const locations = await d.PartnerLocation.findAll({
+      where: { id: { [Op.in]: partnerLocationIds || [] }, partnerOrganisationId: offer.partnerOrganisationId },
+    });
+    if ((partnerLocationIds || []).length !== locations.length) {
+      throw new AppError('All locations must belong to the reward’s partner', 400);
+    }
+    return d.sequelize.transaction(async (t) => {
+      await d.RewardOfferLocation.destroy({ where: { rewardOfferId: id }, transaction: t });
+      for (const loc of locations) {
+        await d.RewardOfferLocation.create({ rewardOfferId: id, partnerLocationId: loc.id }, { transaction: t });
+      }
+      return locations;
+    });
+  }
+
+  /** Manual inventory movements from the UI (committed_increase|committed_decrease|manual_adjustment). */
+  async function adjustInventory(id, { type, quantity, reason }, user, requestId = null) {
+    if (!reason || !String(reason).trim()) throw new AppError('A reason is required for inventory changes', 400);
+    const offer = await d.RewardOffer.findByPk(id);
+    if (!offer) throw new AppError('Reward offer not found', 404);
+
+    let result;
+    if (type === 'committed_increase') {
+      result = await d.inventory.increaseCommitted({ offerId: id, quantity, actorUser: user, reason });
+    } else if (type === 'committed_decrease') {
+      result = await d.inventory.decreaseCommitted({ offerId: id, quantity, actorUser: user, reason });
+    } else {
+      throw new AppError('Unknown inventory adjustment type', 400);
+    }
+    await d.audit.recordAuditEvent({
+      actorUser: user, action: 'inventory.adjusted', entityType: 'reward_offer', entityId: id,
+      after: { type, quantity }, reason, requestId,
+    });
+    return result;
+  }
+
+  async function getLedger(id, query = {}) {
+    const limit = Math.min(200, Math.max(1, parseInt(query.limit, 10) || 50));
+    const events = await d.RewardInventoryEvent.findAll({
+      where: { rewardOfferId: id },
+      include: [{ model: d.User, as: 'actor', attributes: ['id', 'fullName'] }],
+      order: [['createdAt', 'DESC']],
+      limit,
+    });
+    return events;
+  }
+
+  return {
+    listOffers, getOffer, createOffer, updateOffer, setOfferStatus,
+    addTermsVersion, setLocations, adjustInventory, getLedger,
+  };
+}
+
+const _default = makeRewardService();
+export default _default;

--- a/backend/test/redeemOpsRewards.test.js
+++ b/backend/test/redeemOpsRewards.test.js
@@ -1,0 +1,237 @@
+/**
+ * Phases 4+5 — rewards/inventory/onboarding/activations (brief §37 Reward inventory).
+ * The heart of it: CONCURRENT allocations can never oversubscribe committed supply,
+ * and every counter movement has a matching append-only ledger row.
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+
+import request from 'supertest';
+import { getApp, closeDb, createTestUser, createTestCampaign } from './helpers.js';
+import {
+  PartnerOrganisation, RewardOffer, RewardInventoryEvent, PartnerOnboardingItem,
+  Activation, Campaign, sequelize,
+} from '../src/models/index.js';
+import { makeInventoryService } from '../src/services/redeemOps/inventoryService.js';
+
+let app;
+let admin, campaignOps, exec;
+
+beforeAll(async () => {
+  app = await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  campaignOps = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'campaign_ops' });
+  exec = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+const auth = (t) => ({ Authorization: `Bearer ${t}` });
+
+async function makePartner(name) {
+  const res = await request(app)
+    .post('/api/redeem-ops/partners')
+    .set(auth(admin.token))
+    .send({ tradingName: name });
+  return res.body.data.partner;
+}
+
+async function makeOffer(partnerId, committed = 100, title = 'Free Express Manicure') {
+  const res = await request(app)
+    .post('/api/redeem-ops/rewards')
+    .set(auth(admin.token))
+    .send({ partnerOrganisationId: partnerId, title, committedQuantity: committed });
+  return res.body.data.offer;
+}
+
+describe('reward offers + ledger', () => {
+  let partner;
+  beforeAll(async () => { partner = await makePartner('Nail Bliss Test Studio'); });
+
+  test('creation writes the opening committed ledger entry; exec cannot create', async () => {
+    const denied = await request(app)
+      .post('/api/redeem-ops/rewards')
+      .set(auth(exec.token))
+      .send({ partnerOrganisationId: partner.id, title: 'Nope', committedQuantity: 10 });
+    expect(denied.status).toBe(403);
+
+    const offer = await makeOffer(partner.id, 100);
+    expect(offer.committedQuantity).toBe(100);
+    const ledger = await RewardInventoryEvent.findAll({ where: { rewardOfferId: offer.id } });
+    expect(ledger).toHaveLength(1);
+    expect(ledger[0].type).toBe('committed');
+    expect(ledger[0].quantity).toBe(100);
+  });
+
+  test('committed cannot drop below allocated; reasoned adjustments are ledgered', async () => {
+    const offer = await makeOffer(partner.id, 50, 'Adjustable Reward');
+    const inventory = makeInventoryService();
+    await inventory.allocate({ offerId: offer.id, quantity: 40, actorUser: admin.user });
+
+    const tooFar = await request(app)
+      .post(`/api/redeem-ops/rewards/${offer.id}/inventory`)
+      .set(auth(admin.token))
+      .send({ type: 'committed_decrease', quantity: 20, reason: 'partner cut supply' });
+    expect(tooFar.status).toBe(409);
+
+    const ok = await request(app)
+      .post(`/api/redeem-ops/rewards/${offer.id}/inventory`)
+      .set(auth(admin.token))
+      .send({ type: 'committed_decrease', quantity: 10, reason: 'partner cut supply' });
+    expect(ok.status).toBe(200);
+
+    const noReason = await request(app)
+      .post(`/api/redeem-ops/rewards/${offer.id}/inventory`)
+      .set(auth(admin.token))
+      .send({ type: 'committed_increase', quantity: 5, reason: '' });
+    expect(noReason.status).toBe(400);
+  });
+
+  test('CONCURRENT allocations cannot oversubscribe committed supply', async () => {
+    const offer = await makeOffer(partner.id, 10, 'Contended Reward');
+    const inventory = makeInventoryService();
+
+    const attempts = await Promise.allSettled(
+      Array.from({ length: 5 }, () =>
+        inventory.allocate({ offerId: offer.id, quantity: 4, actorUser: admin.user })
+      )
+    );
+    const wins = attempts.filter((r) => r.status === 'fulfilled').length;
+    expect(wins).toBe(2); // 2 × 4 = 8 ≤ 10; a third would need 12
+
+    const row = await RewardOffer.findByPk(offer.id);
+    expect(row.allocatedQuantity).toBe(8);
+    expect(row.allocatedQuantity).toBeLessThanOrEqual(row.committedQuantity);
+
+    const { consistent, derived, actual } = await inventory.reconcile(offer.id);
+    expect({ consistent, derived, actual }).toEqual(
+      expect.objectContaining({ consistent: true })
+    );
+  });
+});
+
+describe('onboarding checklist', () => {
+  test('seeded on PARTNERED transition (via forced stage change)', async () => {
+    const partner = await makePartner('Onboard Me Fitness');
+    await request(app).post(`/api/redeem-ops/partners/${partner.id}/claim`).set(auth(admin.token));
+    const res = await request(app)
+      .patch(`/api/redeem-ops/partners/${partner.id}/stage`)
+      .set(auth(admin.token))
+      .send({ toStage: 'PARTNERED', reason: 'signed on the spot' });
+    expect(res.status).toBe(200);
+
+    const items = await PartnerOnboardingItem.findAll({ where: { partnerOrganisationId: partner.id } });
+    expect(items.length).toBe(11);
+
+    const done = await request(app)
+      .patch(`/api/redeem-ops/onboarding/${items[0].id}`)
+      .set(auth(admin.token))
+      .send({ status: 'done' });
+    expect(done.status).toBe(200);
+    expect(done.body.data.item.completedAt).toBeTruthy();
+  });
+});
+
+describe('activations + campaign linkage', () => {
+  let partner, offer, campaignA, campaignB;
+
+  beforeAll(async () => {
+    partner = await makePartner('Activation Partner Spa');
+    offer = await makeOffer(partner.id, 100, 'Activatable Reward');
+    campaignA = await createTestCampaign(admin.user.id, { name: 'Redeem Test Campaign A' });
+    campaignB = await createTestCampaign(admin.user.id, { name: 'Redeem Test Campaign B' });
+  });
+
+  test('campaign_ops creates an activation; allocation draws from the offer', async () => {
+    const res = await request(app)
+      .post('/api/redeem-ops/activations')
+      .set(auth(campaignOps.token))
+      .send({ rewardOfferId: offer.id, allocatedQuantity: 60 });
+    expect(res.status).toBe(201);
+    const row = await RewardOffer.findByPk(offer.id);
+    expect(row.allocatedQuantity).toBe(60);
+  });
+
+  test('cannot allocate beyond the offer remaining', async () => {
+    const res = await request(app)
+      .post('/api/redeem-ops/activations')
+      .set(auth(campaignOps.token))
+      .send({ rewardOfferId: offer.id, allocatedQuantity: 50 }); // only 40 left
+    expect(res.status).toBe(409);
+  });
+
+  test('link campaign: archived rejected; second LIVE activation on same campaign 409s; projection leaks nothing', async () => {
+    const list = await request(app)
+      .get('/api/redeem-ops/activations')
+      .set(auth(campaignOps.token));
+    const activation = list.body.data.activations.find((a) => a.rewardOffer?.id === offer.id);
+
+    await Campaign.update({ status: 'archived' }, { where: { id: campaignB.id } });
+    const archived = await request(app)
+      .patch(`/api/redeem-ops/activations/${activation.id}/campaign`)
+      .set(auth(campaignOps.token))
+      .send({ campaignId: campaignB.id });
+    expect(archived.status).toBe(400);
+
+    const linked = await request(app)
+      .patch(`/api/redeem-ops/activations/${activation.id}/campaign`)
+      .set(auth(campaignOps.token))
+      .send({ campaignId: campaignA.id });
+    expect(linked.status).toBe(200);
+    expect(linked.body.data.activation.campaignNameSnapshot).toBe('Redeem Test Campaign A');
+
+    // draft → preparing = LIVE; a second activation linking the same campaign must 409
+    await request(app)
+      .patch(`/api/redeem-ops/activations/${activation.id}/status`)
+      .set(auth(campaignOps.token))
+      .send({ status: 'preparing' });
+
+    const second = await request(app)
+      .post('/api/redeem-ops/activations')
+      .set(auth(campaignOps.token))
+      .send({ rewardOfferId: offer.id, allocatedQuantity: 0 });
+    await request(app)
+      .patch(`/api/redeem-ops/activations/${second.body.data.activation.id}/status`)
+      .set(auth(campaignOps.token))
+      .send({ status: 'preparing' });
+    const conflict = await request(app)
+      .patch(`/api/redeem-ops/activations/${second.body.data.activation.id}/campaign`)
+      .set(auth(campaignOps.token))
+      .send({ campaignId: campaignA.id });
+    expect(conflict.status).toBe(409);
+
+    // Projection: attribute-allowlisted, never design_config
+    const search = await request(app)
+      .get('/api/redeem-ops/campaigns')
+      .query({ search: 'Redeem Test Campaign' })
+      .set(auth(campaignOps.token));
+    expect(search.status).toBe(200);
+    for (const c of search.body.data.campaigns) {
+      expect(c.design_config).toBeUndefined();
+      expect(c.publicUrl).toContain('/LeadCapture?campaign_id=');
+      expect(c.mktrAdminUrl).toContain('/admin/campaigns/');
+    }
+
+    // Detail endpoint returns activation + read-only campaign card + MKTR metrics shape
+    const detail = await request(app)
+      .get(`/api/redeem-ops/activations/${activation.id}`)
+      .set(auth(campaignOps.token));
+    expect(detail.body.data.campaign.name).toBe('Redeem Test Campaign A');
+
+    const metrics = await request(app)
+      .get(`/api/redeem-ops/activations/${activation.id}/campaign-metrics`)
+      .set(auth(campaignOps.token));
+    expect(metrics.status).toBe(200);
+    expect(metrics.body.data).toHaveProperty('acquisition');
+    expect(metrics.body.data).toHaveProperty('reward');
+  });
+
+  test('outreach exec cannot manage activations', async () => {
+    const res = await request(app)
+      .post('/api/redeem-ops/activations')
+      .set(auth(exec.token))
+      .send({ rewardOfferId: offer.id });
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -138,4 +138,84 @@ export const redeemOpsApi = {
     const res = await apiClient.post(`/redeem-ops/pools/${poolId}/claim-next`, {});
     return res.data;
   },
+
+  // ── Rewards + onboarding (Phase 4) ─────────────────────────────────────
+  async listRewards(params = {}) {
+    const res = await apiClient.get('/redeem-ops/rewards', params);
+    return res.data?.offers || [];
+  },
+  async getReward(id) {
+    const res = await apiClient.get(`/redeem-ops/rewards/${id}`);
+    return res.data;
+  },
+  async createReward(body) {
+    const res = await apiClient.post('/redeem-ops/rewards', body);
+    return res.data?.offer;
+  },
+  async updateReward(id, body) {
+    const res = await apiClient.put(`/redeem-ops/rewards/${id}`, body);
+    return res.data?.offer;
+  },
+  async setRewardStatus(id, status) {
+    const res = await apiClient.patch(`/redeem-ops/rewards/${id}/status`, { status });
+    return res.data?.offer;
+  },
+  async addRewardTerms(id, body) {
+    const res = await apiClient.post(`/redeem-ops/rewards/${id}/terms`, body);
+    return res.data?.terms;
+  },
+  async setRewardLocations(id, partnerLocationIds) {
+    const res = await apiClient.put(`/redeem-ops/rewards/${id}/locations`, { partnerLocationIds });
+    return res.data;
+  },
+  async adjustRewardInventory(id, body) {
+    const res = await apiClient.post(`/redeem-ops/rewards/${id}/inventory`, body);
+    return res.data;
+  },
+  async getRewardLedger(id, params = {}) {
+    const res = await apiClient.get(`/redeem-ops/rewards/${id}/ledger`, params);
+    return res.data?.events || [];
+  },
+  async getOnboarding(partnerId) {
+    const res = await apiClient.get(`/redeem-ops/partners/${partnerId}/onboarding`);
+    return res.data?.items || [];
+  },
+  async updateOnboardingItem(itemId, body) {
+    const res = await apiClient.patch(`/redeem-ops/onboarding/${itemId}`, body);
+    return res.data?.item;
+  },
+
+  // ── Activations + campaign reference (Phase 5) ─────────────────────────
+  async searchCampaigns(params = {}) {
+    const res = await apiClient.get('/redeem-ops/campaigns', params);
+    return res.data?.campaigns || [];
+  },
+  async listActivations(params = {}) {
+    const res = await apiClient.get('/redeem-ops/activations', params);
+    return res.data?.activations || [];
+  },
+  async getActivation(id) {
+    const res = await apiClient.get(`/redeem-ops/activations/${id}`);
+    return res.data;
+  },
+  async createActivation(body) {
+    const res = await apiClient.post('/redeem-ops/activations', body);
+    return res.data?.activation;
+  },
+  async linkActivationCampaign(id, campaignId) {
+    const res = await apiClient.patch(`/redeem-ops/activations/${id}/campaign`, { campaignId });
+    return res.data?.activation;
+  },
+  async changeActivationAllocation(id, delta, reason) {
+    const res = await apiClient.patch(`/redeem-ops/activations/${id}/allocation`, { delta, reason });
+    return res.data?.activation;
+  },
+  async setActivationStatus(id, status) {
+    const res = await apiClient.patch(`/redeem-ops/activations/${id}/status`, { status });
+    return res.data?.activation;
+  },
+  async getActivationMetrics(id) {
+    const res = await apiClient.get(`/redeem-ops/activations/${id}/campaign-metrics`);
+    return res.data;
+  },
 };

--- a/src/components/layout/DashboardLayout.jsx
+++ b/src/components/layout/DashboardLayout.jsx
@@ -109,6 +109,8 @@ const getNavigationItems = (user) => {
  { title: 'Pipeline', url: '/redeem-ops/pipeline', icon: Settings, capability: 'pipeline.view_team' },
  { title: 'Tasks', url: '/redeem-ops/tasks', icon: FileText, capability: 'tasks.manage' },
  { title: 'Pools', url: '/redeem-ops/pools', icon: Package, capability: 'pools.claim_next' },
+ { title: 'Rewards', url: '/redeem-ops/rewards', icon: Package, capability: 'rewards.view' },
+ { title: 'Activations', url: '/redeem-ops/activations', icon: Link2, capability: 'activations.view' },
  { title: 'Team', url: '/redeem-ops/team', icon: Users, capability: 'analytics.view_team' },
  ].filter((item) => !item.capability || hasRedeemOpsCapability(user, item.capability)),
  },

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -84,6 +84,10 @@ const RedeemOpsMyQueue = lazy(() => import('./redeemops/MyQueue'));
 const RedeemOpsTasks = lazy(() => import('./redeemops/TasksPage'));
 const RedeemOpsPools = lazy(() => import('./redeemops/PoolsPage'));
 const RedeemOpsTeamPipeline = lazy(() => import('./redeemops/TeamPipeline'));
+const RedeemOpsRewards = lazy(() => import('./redeemops/RewardsPage'));
+const RedeemOpsRewardDetail = lazy(() => import('./redeemops/RewardDetail'));
+const RedeemOpsActivations = lazy(() => import('./redeemops/ActivationsPage'));
+const RedeemOpsActivationDetail = lazy(() => import('./redeemops/ActivationDetail'));
 
 function PagesContent() {
  const navigate = useNavigate();
@@ -525,6 +529,50 @@ function PagesContent() {
  <RedeemOpsRoute capability="pipeline.view_team">
  <DashboardLayout>
  <RedeemOpsTeamPipeline />
+ </DashboardLayout>
+ </RedeemOpsRoute>
+ }
+ />
+ )}
+ {REDEEM_OPS_ENABLED && (
+ <Route
+ path="/redeem-ops/rewards" element={
+ <RedeemOpsRoute capability="rewards.view">
+ <DashboardLayout>
+ <RedeemOpsRewards />
+ </DashboardLayout>
+ </RedeemOpsRoute>
+ }
+ />
+ )}
+ {REDEEM_OPS_ENABLED && (
+ <Route
+ path="/redeem-ops/rewards/:id" element={
+ <RedeemOpsRoute capability="rewards.view">
+ <DashboardLayout>
+ <RedeemOpsRewardDetail />
+ </DashboardLayout>
+ </RedeemOpsRoute>
+ }
+ />
+ )}
+ {REDEEM_OPS_ENABLED && (
+ <Route
+ path="/redeem-ops/activations" element={
+ <RedeemOpsRoute capability="activations.view">
+ <DashboardLayout>
+ <RedeemOpsActivations />
+ </DashboardLayout>
+ </RedeemOpsRoute>
+ }
+ />
+ )}
+ {REDEEM_OPS_ENABLED && (
+ <Route
+ path="/redeem-ops/activations/:id" element={
+ <RedeemOpsRoute capability="activations.view">
+ <DashboardLayout>
+ <RedeemOpsActivationDetail />
  </DashboardLayout>
  </RedeemOpsRoute>
  }

--- a/src/pages/redeemops/ActivationDetail.jsx
+++ b/src/pages/redeemops/ActivationDetail.jsx
@@ -1,0 +1,211 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { redeemOpsApi } from '@/api/redeemOps';
+import { useAuthStore } from '@/stores/authStore';
+import { hasCapability } from '@/lib/redeemOpsPermissions';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import ExternalLink from 'lucide-react/icons/external-link';
+
+const NEXT_STATUS = {
+  draft: ['preparing', 'cancelled'],
+  preparing: ['active', 'cancelled'],
+  active: ['paused', 'completed', 'cancelled'],
+  paused: ['active', 'completed', 'cancelled'],
+  completed: [],
+  cancelled: [],
+};
+
+export default function ActivationDetail() {
+  const { id } = useParams();
+  const user = useAuthStore((s) => s.user);
+  const canManage = hasCapability(user, 'activations.manage');
+  const canLink = hasCapability(user, 'activations.link_campaign');
+  const canAllocate = hasCapability(user, 'activations.allocate_inventory');
+  const queryClient = useQueryClient();
+
+  const detailQuery = useQuery({ queryKey: ['redeem-ops', 'activation', id], queryFn: () => redeemOpsApi.getActivation(id) });
+  const metricsQuery = useQuery({
+    queryKey: ['redeem-ops', 'activation', id, 'metrics'],
+    queryFn: () => redeemOpsApi.getActivationMetrics(id),
+    enabled: !!detailQuery.data?.activation?.campaignId,
+    retry: false,
+  });
+
+  const [campaignSearch, setCampaignSearch] = useState('');
+  const campaignsQuery = useQuery({
+    queryKey: ['redeem-ops', 'campaign-search', campaignSearch],
+    queryFn: () => redeemOpsApi.searchCampaigns(campaignSearch ? { search: campaignSearch } : {}),
+    enabled: canLink,
+  });
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'activation', id] });
+    queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'activations'] });
+  };
+
+  const linkMutation = useMutation({
+    mutationFn: (campaignId) => redeemOpsApi.linkActivationCampaign(id, campaignId),
+    onSuccess: () => { toast.success('Campaign linked'); invalidate(); },
+    onError: (err) => toast.error('Link failed', { description: err.message }),
+  });
+  const statusMutation = useMutation({
+    mutationFn: (status) => redeemOpsApi.setActivationStatus(id, status),
+    onSuccess: () => { toast.success('Status updated'); invalidate(); },
+    onError: (err) => toast.error('Status change rejected', { description: err.message }),
+  });
+
+  const [alloc, setAlloc] = useState({ delta: '', reason: '' });
+  const allocMutation = useMutation({
+    mutationFn: () => redeemOpsApi.changeActivationAllocation(id, parseInt(alloc.delta, 10), alloc.reason),
+    onSuccess: () => {
+      toast.success('Allocation updated — ledgered');
+      setAlloc({ delta: '', reason: '' });
+      invalidate();
+    },
+    onError: (err) => toast.error('Allocation change rejected', { description: err.message }),
+  });
+
+  const data = detailQuery.data;
+  if (detailQuery.isLoading) return <div className="p-6 text-muted-foreground">Loading…</div>;
+  if (!data?.activation) return <div className="p-6 text-muted-foreground">Activation not found.</div>;
+  const a = data.activation;
+  const campaign = data.campaign;
+  const acquisition = metricsQuery.data?.acquisition;
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto space-y-4">
+      <Card>
+        <CardContent className="pt-5">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <h1 className="text-xl font-semibold tracking-tight">
+                {a.rewardOffer?.title} <span className="text-muted-foreground font-normal">×</span> {a.campaignNameSnapshot || 'No campaign yet'}
+              </h1>
+              <p className="text-sm text-muted-foreground mt-0.5">
+                {a.partner?.tradingName || a.partner?.legalName}
+                {' · unlock: '}{a.unlockPolicy === 'agent_unlock' ? 'at consultant meeting' : 'instant on signup'}
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Badge variant={a.status === 'active' ? 'default' : 'secondary'}>{a.status}</Badge>
+              {canManage && (NEXT_STATUS[a.status] || []).length > 0 && (
+                <Select onValueChange={(s) => statusMutation.mutate(s)}>
+                  <SelectTrigger className="w-36 h-9"><SelectValue placeholder="Move to…" /></SelectTrigger>
+                  <SelectContent>
+                    {NEXT_STATUS[a.status].map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}
+                  </SelectContent>
+                </Select>
+              )}
+            </div>
+          </div>
+          <div className="grid grid-cols-3 gap-3 mt-5 text-center">
+            <div><p className="text-2xl font-semibold tabular-nums">{a.allocatedQuantity}</p><p className="text-xs text-muted-foreground">Allocated</p></div>
+            <div><p className="text-2xl font-semibold tabular-nums">{a.issuedCount}</p><p className="text-xs text-muted-foreground">Issued</p></div>
+            <div><p className="text-2xl font-semibold tabular-nums">{a.redeemedCount}</p><p className="text-xs text-muted-foreground">Redeemed</p></div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">MKTR campaign</CardTitle>
+            <CardDescription>Read-only reference — manage the campaign itself on mktr.sg.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {campaign ? (
+              <div className="space-y-2 text-sm">
+                <p className="font-medium">{campaign.name}</p>
+                <p className="text-muted-foreground">
+                  Status: {campaign.status} · Host: {campaign.customerHost}
+                </p>
+                <p className="text-muted-foreground break-all">{campaign.publicUrl}</p>
+                {acquisition && (
+                  <p className="text-muted-foreground">
+                    Leads: {acquisition.totalLeads ?? acquisition.leads ?? '—'}
+                  </p>
+                )}
+                <div className="flex gap-2 pt-1">
+                  <Button asChild size="sm" variant="outline">
+                    <a href={campaign.mktrAdminUrl} target="_blank" rel="noopener noreferrer">
+                      <ExternalLink className="w-3.5 h-3.5 mr-1.5" aria-hidden="true" /> Open in MKTR
+                    </a>
+                  </Button>
+                  {canLink && (
+                    <Button size="sm" variant="ghost" onClick={() => linkMutation.mutate(null)}>Unlink</Button>
+                  )}
+                </div>
+              </div>
+            ) : canLink ? (
+              <div className="space-y-2">
+                <Input
+                  placeholder="Search campaigns…"
+                  value={campaignSearch}
+                  onChange={(e) => setCampaignSearch(e.target.value)}
+                />
+                <div className="max-h-56 overflow-y-auto space-y-1">
+                  {(campaignsQuery.data || []).map((c) => (
+                    <button
+                      key={c.id}
+                      type="button"
+                      className="w-full text-left rounded-md border border-border p-2 hover:bg-accent transition-colors disabled:opacity-50"
+                      disabled={!!c.linkedActivationId || linkMutation.isPending}
+                      onClick={() => linkMutation.mutate(c.id)}
+                    >
+                      <p className="text-sm font-medium">{c.name}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {c.status} · {c.customerHost}
+                        {c.linkedActivationId ? ' · already linked to another activation' : ''}
+                      </p>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">No campaign linked.</p>
+            )}
+          </CardContent>
+        </Card>
+
+        {canAllocate && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Allocation</CardTitle>
+              <CardDescription>
+                Draws from the reward's unallocated pool; can never exceed committed supply or drop below issued.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label>Change (±)</Label>
+                  <Input type="number" value={alloc.delta} onChange={(e) => setAlloc((v) => ({ ...v, delta: e.target.value }))} placeholder="+50 or -20" />
+                </div>
+                <div className="space-y-1.5">
+                  <Label>Reason</Label>
+                  <Input value={alloc.reason} onChange={(e) => setAlloc((v) => ({ ...v, reason: e.target.value }))} placeholder="Extended campaign run" />
+                </div>
+              </div>
+              <Button
+                size="sm"
+                disabled={!alloc.delta || parseInt(alloc.delta, 10) === 0 || allocMutation.isPending}
+                onClick={() => allocMutation.mutate()}
+              >
+                Apply change
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/redeemops/ActivationsPage.jsx
+++ b/src/pages/redeemops/ActivationsPage.jsx
@@ -1,0 +1,153 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { redeemOpsApi } from '@/api/redeemOps';
+import { useAuthStore } from '@/stores/authStore';
+import { hasCapability } from '@/lib/redeemOpsPermissions';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table';
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import Plus from 'lucide-react/icons/plus';
+
+const STATUS_BADGE = { active: 'default', draft: 'secondary', preparing: 'secondary', paused: 'outline', completed: 'outline', cancelled: 'destructive' };
+
+export default function ActivationsPage() {
+  const user = useAuthStore((s) => s.user);
+  const canManage = hasCapability(user, 'activations.manage');
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const listQuery = useQuery({ queryKey: ['redeem-ops', 'activations'], queryFn: () => redeemOpsApi.listActivations() });
+  const rewardsQuery = useQuery({
+    queryKey: ['redeem-ops', 'rewards'],
+    queryFn: () => redeemOpsApi.listRewards(),
+    enabled: canManage,
+  });
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [form, setForm] = useState({ rewardOfferId: '', allocatedQuantity: '' });
+
+  const createMutation = useMutation({
+    mutationFn: () => redeemOpsApi.createActivation({
+      rewardOfferId: form.rewardOfferId,
+      allocatedQuantity: form.allocatedQuantity ? parseInt(form.allocatedQuantity, 10) : 0,
+    }),
+    onSuccess: (activation) => {
+      toast.success('Activation created');
+      setCreateOpen(false); setForm({ rewardOfferId: '', allocatedQuantity: '' });
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'activations'] });
+      if (activation?.id) navigate(`/redeem-ops/activations/${activation.id}`);
+    },
+    onError: (err) => toast.error('Could not create activation', { description: err.message }),
+  });
+
+  const activations = listQuery.data || [];
+  const rewards = (rewardsQuery.data || []).filter((r) => r.status !== 'ended');
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto space-y-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Activations</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            A reward allocated to one MKTR campaign — the campaign itself stays managed on mktr.sg.
+          </p>
+        </div>
+        {canManage && (
+          <Button size="sm" onClick={() => setCreateOpen(true)}>
+            <Plus className="w-4 h-4 mr-2" aria-hidden="true" /> New activation
+          </Button>
+        )}
+      </div>
+
+      <Card>
+        <CardContent className="pt-4">
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Reward</TableHead>
+                  <TableHead>Partner</TableHead>
+                  <TableHead>Campaign</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Allocated</TableHead>
+                  <TableHead className="text-right">Issued</TableHead>
+                  <TableHead className="text-right">Redeemed</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {activations.map((a) => (
+                  <TableRow key={a.id} className="cursor-pointer" onClick={() => navigate(`/redeem-ops/activations/${a.id}`)}>
+                    <TableCell className="font-medium">{a.rewardOffer?.title || '—'}</TableCell>
+                    <TableCell className="text-muted-foreground">{a.partner?.tradingName || a.partner?.legalName || '—'}</TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {a.campaignNameSnapshot || (a.campaignId ? a.campaignId.slice(0, 8) : 'Not linked')}
+                    </TableCell>
+                    <TableCell><Badge variant={STATUS_BADGE[a.status] || 'secondary'}>{a.status}</Badge></TableCell>
+                    <TableCell className="text-right">{a.allocatedQuantity}</TableCell>
+                    <TableCell className="text-right">{a.issuedCount}</TableCell>
+                    <TableCell className="text-right">{a.redeemedCount}</TableCell>
+                  </TableRow>
+                ))}
+                {!listQuery.isLoading && activations.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={7} className="text-center text-muted-foreground py-10">
+                      No activations yet{canManage ? ' — create one from an active reward.' : '.'}
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New activation</DialogTitle>
+            <DialogDescription>
+              Allocation draws from the reward's unallocated supply (oversubscription is impossible).
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 py-2">
+            <div className="space-y-1.5">
+              <Label>Reward offer *</Label>
+              <Select value={form.rewardOfferId} onValueChange={(v) => setForm((f) => ({ ...f, rewardOfferId: v }))}>
+                <SelectTrigger><SelectValue placeholder="Select a reward" /></SelectTrigger>
+                <SelectContent>
+                  {rewards.map((r) => (
+                    <SelectItem key={r.id} value={r.id}>
+                      {r.title} ({r.committedQuantity - r.allocatedQuantity} unallocated)
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label>Allocate quantity</Label>
+              <Input type="number" min="0" value={form.allocatedQuantity} onChange={(e) => setForm((f) => ({ ...f, allocatedQuantity: e.target.value }))} placeholder="100" />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button disabled={!form.rewardOfferId || createMutation.isPending} onClick={() => createMutation.mutate()}>
+              {createMutation.isPending ? 'Creating…' : 'Create'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/redeemops/PartnerDetail.jsx
+++ b/src/pages/redeemops/PartnerDetail.jsx
@@ -63,6 +63,55 @@ function TimelineEntry({ entry }) {
   );
 }
 
+const ONBOARDING_STATUS_BADGE = { done: 'default', in_progress: 'secondary', pending: 'outline', na: 'outline' };
+
+function OnboardingChecklist({ partnerId }) {
+  const queryClient = useQueryClient();
+  const itemsQuery = useQuery({
+    queryKey: ['redeem-ops', 'partner', partnerId, 'onboarding'],
+    queryFn: () => redeemOpsApi.getOnboarding(partnerId),
+  });
+  const updateMutation = useMutation({
+    mutationFn: ({ itemId, status }) => redeemOpsApi.updateOnboardingItem(itemId, { status }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partner', partnerId, 'onboarding'] }),
+    onError: (err) => toast.error('Could not update item', { description: err.message }),
+  });
+
+  const items = itemsQuery.data || [];
+  const doneCount = items.filter((i) => i.status === 'done' || i.status === 'na').length;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Onboarding checklist</CardTitle>
+        <p className="text-sm text-muted-foreground">{doneCount} of {items.length} complete</p>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {items.map((item) => (
+          <div key={item.id} className="flex items-center justify-between gap-2 border-b border-border pb-2 last:border-0">
+            <span className="text-sm">{item.label}</span>
+            <Select
+              value={item.status}
+              onValueChange={(status) => updateMutation.mutate({ itemId: item.id, status })}
+            >
+              <SelectTrigger className="w-36 h-8">
+                <Badge variant={ONBOARDING_STATUS_BADGE[item.status] || 'outline'}>
+                  {item.status.replaceAll('_', ' ')}
+                </Badge>
+              </SelectTrigger>
+              <SelectContent>
+                {['pending', 'in_progress', 'done', 'na'].map((s) => (
+                  <SelectItem key={s} value={s}>{s.replaceAll('_', ' ')}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
 const EMPTY_ACTIVITY = { type: 'call_attempt', summary: '', details: '', outcome: '', contactId: '' };
 const EMPTY_CONTACT = { name: '', roleTitle: '', mobile: '', email: '', preferredChannel: '' };
 const EMPTY_LOCATION = { name: '', addressLine: '', postalCode: '', phone: '' };
@@ -159,6 +208,7 @@ export default function PartnerDetail() {
   const isOwner = partner.ownerUserId === user?.id;
   const isUnowned = !partner.ownerUserId;
   const canReassign = hasCapability(user, 'partners.reassign');
+  const canOnboard = hasCapability(user, 'onboarding.manage');
   const allowedNext = constants.data?.stageTransitions?.[partner.pipelineStage] || [];
   const activityTypes = constants.data?.activityTypes || [];
 
@@ -230,6 +280,9 @@ export default function PartnerDetail() {
           <TabsTrigger value="timeline">Timeline</TabsTrigger>
           <TabsTrigger value="contacts">Contacts ({partner.contacts?.length || 0})</TabsTrigger>
           <TabsTrigger value="locations">Locations ({partner.locations?.length || 0})</TabsTrigger>
+          {partner.pipelineStage === 'PARTNERED' && canOnboard && (
+            <TabsTrigger value="onboarding">Onboarding</TabsTrigger>
+          )}
         </TabsList>
 
         <TabsContent value="timeline">
@@ -315,6 +368,12 @@ export default function PartnerDetail() {
             </CardContent>
           </Card>
         </TabsContent>
+
+        {partner.pipelineStage === 'PARTNERED' && canOnboard && (
+          <TabsContent value="onboarding">
+            <OnboardingChecklist partnerId={id} />
+          </TabsContent>
+        )}
       </Tabs>
 
       <Dialog open={activityOpen} onOpenChange={setActivityOpen}>

--- a/src/pages/redeemops/RewardDetail.jsx
+++ b/src/pages/redeemops/RewardDetail.jsx
@@ -1,0 +1,214 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { redeemOpsApi } from '@/api/redeemOps';
+import { useAuthStore } from '@/stores/authStore';
+import { hasCapability } from '@/lib/redeemOpsPermissions';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import { Textarea } from '@/components/ui/textarea';
+
+function Counter({ label, value }) {
+  return (
+    <div className="text-center">
+      <p className="text-2xl font-semibold tabular-nums">{value}</p>
+      <p className="text-xs text-muted-foreground">{label}</p>
+    </div>
+  );
+}
+
+export default function RewardDetail() {
+  const { id } = useParams();
+  const user = useAuthStore((s) => s.user);
+  const canManage = hasCapability(user, 'rewards.manage');
+  const canAdjust = hasCapability(user, 'inventory.adjust');
+  const queryClient = useQueryClient();
+
+  const offerQuery = useQuery({ queryKey: ['redeem-ops', 'reward', id], queryFn: () => redeemOpsApi.getReward(id) });
+  const ledgerQuery = useQuery({ queryKey: ['redeem-ops', 'reward', id, 'ledger'], queryFn: () => redeemOpsApi.getRewardLedger(id) });
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'reward', id] });
+    queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'rewards'] });
+  };
+
+  const [adjust, setAdjust] = useState({ type: 'committed_increase', quantity: '', reason: '' });
+  const adjustMutation = useMutation({
+    mutationFn: () => redeemOpsApi.adjustRewardInventory(id, {
+      type: adjust.type, quantity: parseInt(adjust.quantity, 10), reason: adjust.reason,
+    }),
+    onSuccess: () => {
+      toast.success('Inventory updated — ledger entry written');
+      setAdjust({ type: 'committed_increase', quantity: '', reason: '' });
+      invalidate();
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'reward', id, 'ledger'] });
+    },
+    onError: (err) => toast.error('Inventory change rejected', { description: err.message }),
+  });
+
+  const statusMutation = useMutation({
+    mutationFn: (status) => redeemOpsApi.setRewardStatus(id, status),
+    onSuccess: () => { toast.success('Status updated'); invalidate(); },
+    onError: (err) => toast.error('Status change failed', { description: err.message }),
+  });
+
+  const [terms, setTerms] = useState('');
+  const termsMutation = useMutation({
+    mutationFn: () => redeemOpsApi.addRewardTerms(id, { freeText: terms }),
+    onSuccess: () => { toast.success('New terms version saved'); setTerms(''); invalidate(); },
+    onError: (err) => toast.error('Could not save terms', { description: err.message }),
+  });
+
+  const data = offerQuery.data;
+  if (offerQuery.isLoading) return <div className="p-6 text-muted-foreground">Loading…</div>;
+  if (!data?.offer) return <div className="p-6 text-muted-foreground">Reward not found.</div>;
+  const offer = data.offer;
+  const remaining = offer.committedQuantity - offer.allocatedQuantity;
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto space-y-4">
+      <Card>
+        <CardContent className="pt-5">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <h1 className="text-xl font-semibold tracking-tight">{offer.title}</h1>
+              <p className="text-sm text-muted-foreground mt-0.5">
+                {offer.partner?.tradingName || offer.partner?.legalName}
+                {' · '}{offer.rewardType.replaceAll('_', ' ')}
+                {offer.retailValue ? ` · worth S$${offer.retailValue}` : ''}
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Badge variant={offer.status === 'active' ? 'default' : 'secondary'}>{offer.status}</Badge>
+              {canManage && (
+                <Select value={offer.status} onValueChange={(s) => statusMutation.mutate(s)}>
+                  <SelectTrigger className="w-32 h-9"><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    {['draft', 'active', 'paused', 'ended'].map((s) => (
+                      <SelectItem key={s} value={s}>{s}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </div>
+          </div>
+          <div className="grid grid-cols-5 gap-3 mt-5">
+            <Counter label="Committed" value={offer.committedQuantity} />
+            <Counter label="Allocated" value={offer.allocatedQuantity} />
+            <Counter label="Unallocated" value={remaining} />
+            <Counter label="Issued" value={offer.issuedQuantity} />
+            <Counter label="Redeemed" value={offer.redeemedQuantity} />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Tabs defaultValue="ledger">
+        <TabsList>
+          <TabsTrigger value="ledger">Inventory ledger</TabsTrigger>
+          <TabsTrigger value="terms">Terms</TabsTrigger>
+          {canAdjust && <TabsTrigger value="adjust">Adjust supply</TabsTrigger>}
+        </TabsList>
+
+        <TabsContent value="ledger">
+          <Card>
+            <CardContent className="pt-5 space-y-2">
+              {(ledgerQuery.data || []).map((e) => (
+                <div key={e.id} className="flex items-center justify-between border-b border-border pb-2 last:border-0 text-sm">
+                  <span>
+                    <Badge variant="outline" className="mr-2">{e.type.replaceAll('_', ' ')}</Badge>
+                    {e.quantity} unit{e.quantity === 1 ? '' : 's'}
+                    {e.reason ? <span className="text-muted-foreground"> — {e.reason}</span> : ''}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {e.actor?.fullName || e.actorType} · {new Date(e.createdAt).toLocaleString()}
+                  </span>
+                </div>
+              ))}
+              {(ledgerQuery.data || []).length === 0 && (
+                <p className="text-sm text-muted-foreground">No movements yet.</p>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="terms">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Terms (version {offer.currentTermsVersion})</CardTitle>
+              <CardDescription>Terms are versioned — every change is a new version, never an overwrite.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {(data.terms || []).map((t) => (
+                <div key={t.id} className="border-b border-border pb-3 last:border-0">
+                  <p className="text-xs font-semibold text-muted-foreground">v{t.version} · {new Date(t.createdAt).toLocaleDateString()}</p>
+                  <p className="text-sm whitespace-pre-wrap">{t.freeText || JSON.stringify(t.structured)}</p>
+                </div>
+              ))}
+              {canManage && (
+                <div className="space-y-2 pt-2">
+                  <Textarea
+                    rows={3}
+                    value={terms}
+                    onChange={(e) => setTerms(e.target.value)}
+                    placeholder="First-time customers only. Weekdays before 5pm. Appointment required."
+                  />
+                  <Button size="sm" disabled={!terms.trim() || termsMutation.isPending} onClick={() => termsMutation.mutate()}>
+                    Save as v{offer.currentTermsVersion + 1}
+                  </Button>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {canAdjust && (
+          <TabsContent value="adjust">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Adjust committed supply</CardTitle>
+                <CardDescription>
+                  Guarded: committed can never drop below what's already allocated. A reason is mandatory and ledgered.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="grid grid-cols-3 gap-3">
+                <div className="space-y-1.5">
+                  <Label>Direction</Label>
+                  <Select value={adjust.type} onValueChange={(v) => setAdjust((a) => ({ ...a, type: v }))}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="committed_increase">Increase</SelectItem>
+                      <SelectItem value="committed_decrease">Decrease</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-1.5">
+                  <Label>Quantity</Label>
+                  <Input type="number" min="1" value={adjust.quantity} onChange={(e) => setAdjust((a) => ({ ...a, quantity: e.target.value }))} />
+                </div>
+                <div className="space-y-1.5 col-span-3">
+                  <Label>Reason *</Label>
+                  <Input value={adjust.reason} onChange={(e) => setAdjust((a) => ({ ...a, reason: e.target.value }))} placeholder="Partner topped up 50 more for December" />
+                </div>
+                <Button
+                  size="sm" className="justify-self-start"
+                  disabled={!adjust.quantity || !adjust.reason.trim() || adjustMutation.isPending}
+                  onClick={() => adjustMutation.mutate()}
+                >
+                  Apply
+                </Button>
+              </CardContent>
+            </Card>
+          </TabsContent>
+        )}
+      </Tabs>
+    </div>
+  );
+}

--- a/src/pages/redeemops/RewardsPage.jsx
+++ b/src/pages/redeemops/RewardsPage.jsx
@@ -1,0 +1,179 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { redeemOpsApi } from '@/api/redeemOps';
+import { useAuthStore } from '@/stores/authStore';
+import { hasCapability } from '@/lib/redeemOpsPermissions';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table';
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import Plus from 'lucide-react/icons/plus';
+
+const STATUS_BADGE = { active: 'default', draft: 'secondary', paused: 'outline', ended: 'outline' };
+const EMPTY = { partnerOrganisationId: '', title: '', rewardType: 'free_service', retailValue: '', committedQuantity: '' };
+
+export default function RewardsPage() {
+  const user = useAuthStore((s) => s.user);
+  const canManage = hasCapability(user, 'rewards.manage');
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const offersQuery = useQuery({ queryKey: ['redeem-ops', 'rewards'], queryFn: () => redeemOpsApi.listRewards() });
+  const partnersQuery = useQuery({
+    queryKey: ['redeem-ops', 'partners', { stage: 'PARTNERED' }],
+    queryFn: () => redeemOpsApi.listPartners({ stage: 'PARTNERED', limit: 100 }),
+    enabled: canManage,
+  });
+  const constants = useQuery({
+    queryKey: ['redeem-ops', 'constants'],
+    queryFn: redeemOpsApi.getConstants,
+    staleTime: Infinity,
+  });
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [form, setForm] = useState(EMPTY);
+
+  const createMutation = useMutation({
+    mutationFn: () => redeemOpsApi.createReward({
+      ...form,
+      retailValue: form.retailValue ? Number(form.retailValue) : null,
+      committedQuantity: form.committedQuantity ? parseInt(form.committedQuantity, 10) : 0,
+    }),
+    onSuccess: (offer) => {
+      toast.success('Reward offer created');
+      setCreateOpen(false); setForm(EMPTY);
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'rewards'] });
+      if (offer?.id) navigate(`/redeem-ops/rewards/${offer.id}`);
+    },
+    onError: (err) => toast.error('Could not create reward', { description: err.message }),
+  });
+
+  const offers = offersQuery.data || [];
+  const partners = partnersQuery.data?.partners || [];
+  const rewardTypes = constants.data?.rewardTypes || [];
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto space-y-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Rewards</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Partner-funded reward supply — every quantity movement is ledgered.
+          </p>
+        </div>
+        {canManage && (
+          <Button size="sm" onClick={() => setCreateOpen(true)}>
+            <Plus className="w-4 h-4 mr-2" aria-hidden="true" /> New reward
+          </Button>
+        )}
+      </div>
+
+      <Card>
+        <CardContent className="pt-4">
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Reward</TableHead>
+                  <TableHead>Partner</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Committed</TableHead>
+                  <TableHead className="text-right">Allocated</TableHead>
+                  <TableHead className="text-right">Issued</TableHead>
+                  <TableHead className="text-right">Redeemed</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {offers.map((o) => (
+                  <TableRow key={o.id} className="cursor-pointer" onClick={() => navigate(`/redeem-ops/rewards/${o.id}`)}>
+                    <TableCell className="font-medium">{o.title}</TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {o.partner?.tradingName || o.partner?.legalName || '—'}
+                    </TableCell>
+                    <TableCell><Badge variant={STATUS_BADGE[o.status] || 'secondary'}>{o.status}</Badge></TableCell>
+                    <TableCell className="text-right">{o.committedQuantity}</TableCell>
+                    <TableCell className="text-right">{o.allocatedQuantity}</TableCell>
+                    <TableCell className="text-right">{o.issuedQuantity}</TableCell>
+                    <TableCell className="text-right">{o.redeemedQuantity}</TableCell>
+                  </TableRow>
+                ))}
+                {!offersQuery.isLoading && offers.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={7} className="text-center text-muted-foreground py-10">
+                      No rewards yet{canManage ? ' — create the first one from a PARTNERED business.' : '.'}
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New reward offer</DialogTitle>
+            <DialogDescription>The committed quantity becomes the opening ledger entry.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 py-2">
+            <div className="space-y-1.5">
+              <Label>Partner *</Label>
+              <Select value={form.partnerOrganisationId} onValueChange={(v) => setForm((f) => ({ ...f, partnerOrganisationId: v }))}>
+                <SelectTrigger><SelectValue placeholder="Select a PARTNERED business" /></SelectTrigger>
+                <SelectContent>
+                  {partners.map((p) => (
+                    <SelectItem key={p.id} value={p.id}>{p.tradingName || p.brandName || p.legalName}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label>Title *</Label>
+              <Input value={form.title} onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))} placeholder="Complimentary Express Manicure" />
+            </div>
+            <div className="grid grid-cols-3 gap-3">
+              <div className="space-y-1.5 col-span-1">
+                <Label>Type</Label>
+                <Select value={form.rewardType} onValueChange={(v) => setForm((f) => ({ ...f, rewardType: v }))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    {rewardTypes.map((t) => <SelectItem key={t} value={t}>{t.replaceAll('_', ' ')}</SelectItem>)}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <Label>Retail value (S$)</Label>
+                <Input type="number" value={form.retailValue} onChange={(e) => setForm((f) => ({ ...f, retailValue: e.target.value }))} placeholder="35" />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Committed qty</Label>
+                <Input type="number" value={form.committedQuantity} onChange={(e) => setForm((f) => ({ ...f, committedQuantity: e.target.value }))} placeholder="100" />
+              </div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              disabled={!form.partnerOrganisationId || !form.title.trim() || createMutation.isPending}
+              onClick={() => createMutation.mutate()}
+            >
+              {createMutation.isPending ? 'Creating…' : 'Create reward'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}


### PR DESCRIPTION
## What this is

Phases 4+5 of Redeem Ops (`docs/redeem-ops/IMPLEMENTATION_PLAN.md`), building on the merged V1 (#95). Same dark posture: everything behind `REDEEM_OPS_ENABLED`.

## Phase 4 — Onboarding + rewards + inventory ledger
- **Migration 048**: `reward_offers` (guarded counters), `reward_terms_versions` (append-only), `reward_offer_locations`, `reward_inventory_events` (the ledger), `partner_onboarding_items`.
- **Inventory invariants** (brief §24): every movement is a guarded conditional `UPDATE … RETURNING` **plus** an append-only ledger row in one transaction. `committed ≥ allocated ≥ issued ≥ redeemed` enforced by the guards; a failed guard is a typed 409, never a silent overwrite. `reconcile()` asserts ledger ⇄ counters (test-verified).
- **Onboarding** (brief §22): 11-item checklist seeded on PARTNERED via the `onPartnered` hook.

## Phase 5 — Activations (brief §25, §28)
- **Migration 049**: `activations` with a **partial unique index = one live activation per campaign** (schema-enforced, surfaced as 409), `campaignNameSnapshot` for display resilience, and `unlockPolicy` (`agent_unlock` default) ready for Phase 6's review-gated vouchers.
- **Campaign integration** exactly per `MKTR_INTEGRATION.md`: `campaignProjection.js` is the only file reading campaign internals — attribute-allowlisted (a test asserts `design_config` never leaks), public URL from the campaign's customerHost, metrics via `computeCampaignMetrics` (MKTR's numbers, never re-counted), and an **Open in MKTR** deep link for any actual campaign management.
- Activation status machine requires a linked campaign before going live; archived campaigns can't be linked.

## Verification
- ✅ New DB suite: **concurrent allocations cannot oversubscribe** (Promise.allSettled race → exactly the affordable wins), committed-below-allocated 409, ledger reconciliation, onboarding seed, second-live-activation 409, projection leak check, capability denials
- ✅ Vite build + eslint clean; migration `down()` static checks pass
- Known-red baseline: `test/unit/shortlinkService.test.js` (identical on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)