### PR TITLE
feat(redeem-ops): Phase 6 — entitlements, review-gated vouchers, redemptions + capture hook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,10 @@ META_TEST_EVENT_CODE=          # Test Event code from Pixel → Test Events tab 
 # Redeem Ops module (docs/redeem-ops/) — the /api/redeem-ops/* routes stay
 # UNMOUNTED until this is "true" (route auto-loader flag gating)
 REDEEM_OPS_ENABLED=false
+# Phase 6 fulfilment: registers the lead-capture entitlement hook, mounts the
+# public /api/reward-claim + consultant unlock surfaces, schedules the
+# expiry/reconciliation sweep. Requires REDEEM_OPS_ENABLED too.
+REDEEM_OPS_ENTITLEMENTS_ENABLED=false
 
 # Webhook system
 WEBHOOK_ENABLED=false          # Master switch — MUST be "true" for leads to reach Lyfe

--- a/backend/src/controllers/redeemOps/fulfilmentController.js
+++ b/backend/src/controllers/redeemOps/fulfilmentController.js
@@ -1,0 +1,90 @@
+import Joi from 'joi';
+import { asyncHandler, AppError } from '../../middleware/errorHandler.js';
+import entitlementService from '../../services/redeemOps/entitlementService.js';
+import redemptionService from '../../services/redeemOps/redemptionService.js';
+
+function validateBody(schema, body) {
+  const { error, value } = schema.validate(body, { abortEarly: false });
+  if (error) throw new AppError(error.details.map((x) => x.message).join(', '), 400);
+  return value;
+}
+
+export const listEntitlements = asyncHandler(async (req, res) => {
+  const data = await entitlementService.listEntitlements(req.query);
+  res.json({ success: true, data });
+});
+
+export const issueManual = asyncHandler(async (req, res) => {
+  const body = validateBody(
+    Joi.object({
+      activationId: Joi.string().uuid().required(),
+      prospectId: Joi.string().uuid().required(),
+    }),
+    req.body
+  );
+  const result = await entitlementService.issueManual(body, req.user, req.id);
+  res.status(201).json({
+    success: true,
+    data: {
+      entitlement: result.entitlement,
+      // Raw tokens are returned ONCE at manual issue for staff hand-delivery
+      presentationToken: result.presentationToken || null,
+      voucherToken: result.voucherToken || null,
+    },
+  });
+});
+
+export const cancelEntitlement = asyncHandler(async (req, res) => {
+  const body = validateBody(Joi.object({ reason: Joi.string().max(255).required() }), req.body);
+  const entitlement = await entitlementService.cancelEntitlement(req.params.id, req.user, body.reason, req.id);
+  res.json({ success: true, data: { entitlement } });
+});
+
+export const verifyVoucher = asyncHandler(async (req, res) => {
+  const body = validateBody(Joi.object({ token: Joi.string().min(6).max(128).required() }), req.body);
+  const result = await redemptionService.verify(body.token, req.user, { actorType: 'staff' });
+  res.json({
+    success: true,
+    data: {
+      valid: result.valid,
+      state: result.state,
+      reward: result.reward,
+      holder: result.holder, // unmasked under redemptions.verify (fulfilment identity check)
+      entitlementId: result.entitlement.id,
+    },
+  });
+});
+
+export const completeRedemption = asyncHandler(async (req, res) => {
+  const body = validateBody(
+    Joi.object({
+      token: Joi.string().min(6).max(128).required(),
+      locationId: Joi.string().uuid().allow(null),
+      method: Joi.string().valid('code', 'qr', 'partner_verification', 'manual_override'),
+      notes: Joi.string().max(1000).allow('', null),
+    }),
+    req.body
+  );
+  const result = await redemptionService.complete(
+    body.token,
+    { locationId: body.locationId || null, method: body.method || 'code', notes: body.notes || null },
+    req.user,
+    { actorType: 'staff' }
+  );
+  res.json({
+    success: true,
+    message: result.already ? 'Already redeemed' : 'Redeemed',
+    data: { redemption: result.redemption, already: result.already },
+  });
+});
+
+export const reverseRedemption = asyncHandler(async (req, res) => {
+  const body = validateBody(Joi.object({ reason: Joi.string().max(255).required() }), req.body);
+  const redemption = await redemptionService.reverse(req.params.id, req.user, body.reason, req.id);
+  res.json({ success: true, data: { redemption } });
+});
+
+export const listRedemptions = asyncHandler(async (req, res) => {
+  const data = await redemptionService.listRedemptions(req.query);
+  res.json({ success: true, data });
+});

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -165,6 +165,55 @@ export async function bootstrapDatabase() {
       setTimeout(runRedeemOpsSweepSafe, 120_000);
       setInterval(runRedeemOpsSweepSafe, 30 * 60 * 1000); // every 30 min
       logger.info('[RedeemOps] stale sweep scheduled (30m interval)');
+
+      // Phase 6 fulfilment (docs/redeem-ops/MKTR_INTEGRATION.md §2). This is the
+      // COMPOSITION ROOT for the dependency-inverted capture hook: prospectService
+      // never imports Redeem Ops — we register the callback here, so removing this
+      // block returns lead capture to byte-identical pre-Redeem-Ops behaviour.
+      // Additionally gated by REDEEM_OPS_ENTITLEMENTS_ENABLED so partners/rewards
+      // can go live before reward issuance does.
+      if (String(process.env.REDEEM_OPS_ENTITLEMENTS_ENABLED || 'false').toLowerCase() === 'true') {
+        await safeRun('Redeem Ops entitlement hook', async () => {
+          const { registerLeadCapturedHook } = await import('../services/prospectService.js');
+          const { makeEntitlementService } = await import('../services/redeemOps/entitlementService.js');
+          const { makeFulfilmentNotify } = await import('../services/redeemOps/fulfilmentNotify.js');
+          const notify = makeFulfilmentNotify();
+          const entitlements = makeEntitlementService({
+            notifyUnlock: ({ entitlement, prospect, voucherToken }) =>
+              notify.sendVoucherEmail({ entitlement, prospect, voucherToken }),
+          });
+          registerLeadCapturedHook(async (prospect) => {
+            const r = await entitlements.issueForProspect(prospect, { via: 'hook' });
+            if (r?.entitlement && r.reason === null && r.presentationToken && !r.voucherToken) {
+              // agent_unlock policy: deliver the reservation pass (fire-and-forget)
+              notify.sendReservationEmail({
+                entitlement: r.entitlement, prospect, presentationToken: r.presentationToken,
+              }).catch((err) => logger.error('[RedeemOps] reservation email failed', { error: err?.message }));
+            } else if (r?.voucherToken) {
+              notify.sendVoucherEmail({
+                entitlement: r.entitlement, prospect, voucherToken: r.voucherToken,
+              }).catch((err) => logger.error('[RedeemOps] voucher email failed', { error: err?.message }));
+            }
+          });
+          logger.info('[RedeemOps] entitlement capture hook registered');
+        });
+
+        // Reservation expiry + missed-lead reconciliation (at-least-once backstop
+        // for the hook; idempotent via the unique (activationId, prospectId) anchor).
+        const runFulfilmentSweepSafe = async () => {
+          try {
+            const { makeEntitlementService } = await import('../services/redeemOps/entitlementService.js');
+            const svc = makeEntitlementService();
+            await svc.expireReservations();
+            await svc.reconcileMissedLeads();
+          } catch (err) {
+            logger.warn('[RedeemOps] fulfilment sweep failed (non-fatal)', { error: err?.message });
+          }
+        };
+        setTimeout(runFulfilmentSweepSafe, 180_000);
+        setInterval(runFulfilmentSweepSafe, 15 * 60 * 1000); // every 15 min
+        logger.info('[RedeemOps] fulfilment sweep scheduled (15m interval)');
+      }
     }
 
     // DNC re-scrub / retry backfill — recovers dnc_pending leads whose check errored or

--- a/backend/src/database/migrations/050-redeem-ops-fulfilment.js
+++ b/backend/src/database/migrations/050-redeem-ops-fulfilment.js
@@ -1,0 +1,82 @@
+/**
+ * Redeem Ops Phase 6 — entitlements, redemptions, fulfilment history
+ * (docs/redeem-ops/ERD.md §3.16–3.18). Two-token design: reservation pass at
+ * capture, voucher minted only at the consultant unlock.
+ */
+export async function up(queryInterface, Sequelize) {
+  const tables = await queryInterface.showAllTables();
+  const UUID = Sequelize.UUID;
+  const ts = () => ({
+    createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+  });
+
+  if (!tables.includes('reward_entitlements')) {
+    await queryInterface.createTable('reward_entitlements', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      rewardOfferId: { type: UUID, allowNull: false, references: { model: 'reward_offers', key: 'id' }, onDelete: 'RESTRICT' },
+      activationId: { type: UUID, allowNull: false, references: { model: 'activations', key: 'id' }, onDelete: 'RESTRICT' },
+      prospectId: { type: UUID, references: { model: 'prospects', key: 'id' }, onDelete: 'SET NULL' },
+      status: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'eligible' },
+      reservedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      unlockedAt: { type: Sequelize.DATE },
+      unlockedByUserId: { type: UUID, references: { model: 'users', key: 'id' }, onDelete: 'SET NULL' },
+      unlockedVia: { type: Sequelize.STRING(16) },
+      expiresAt: { type: Sequelize.DATE },
+      presentationTokenHash: { type: Sequelize.STRING(64), allowNull: false },
+      tokenHash: { type: Sequelize.STRING(64) },
+      tokenHint: { type: Sequelize.STRING(8) },
+      issuedVia: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'hook' },
+      createdBy: { type: UUID },
+      ...ts(),
+    });
+  }
+
+  if (!tables.includes('redemptions')) {
+    await queryInterface.createTable('redemptions', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      entitlementId: { type: UUID, allowNull: false, references: { model: 'reward_entitlements', key: 'id' }, onDelete: 'RESTRICT' },
+      rewardOfferId: { type: UUID, allowNull: false, references: { model: 'reward_offers', key: 'id' }, onDelete: 'RESTRICT' },
+      activationId: { type: UUID, allowNull: false, references: { model: 'activations', key: 'id' }, onDelete: 'RESTRICT' },
+      partnerOrganisationId: { type: UUID, allowNull: false, references: { model: 'partner_organisations', key: 'id' }, onDelete: 'RESTRICT' },
+      locationId: { type: UUID, references: { model: 'partner_locations', key: 'id' }, onDelete: 'SET NULL' },
+      redeemedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      method: { type: Sequelize.STRING(24), allowNull: false, defaultValue: 'code' },
+      status: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'completed' },
+      actorType: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'staff' },
+      actorUserId: { type: UUID, references: { model: 'users', key: 'id' }, onDelete: 'SET NULL' },
+      notes: { type: Sequelize.TEXT },
+      ...ts(),
+    });
+  }
+
+  if (!tables.includes('redemption_events')) {
+    await queryInterface.createTable('redemption_events', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      entitlementId: { type: UUID, allowNull: false, references: { model: 'reward_entitlements', key: 'id' }, onDelete: 'CASCADE' },
+      redemptionId: { type: UUID, references: { model: 'redemptions', key: 'id' }, onDelete: 'CASCADE' },
+      type: { type: Sequelize.STRING(24), allowNull: false },
+      metadata: { type: Sequelize.JSONB },
+      actorType: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'system' },
+      actorUserId: { type: UUID },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    });
+  }
+
+  const idx = (sql) => queryInterface.sequelize.query(sql);
+  await idx('CREATE UNIQUE INDEX IF NOT EXISTS uq_re_activation_prospect ON reward_entitlements ("activationId", "prospectId") WHERE "prospectId" IS NOT NULL');
+  await idx('CREATE UNIQUE INDEX IF NOT EXISTS uq_re_presentation_token ON reward_entitlements ("presentationTokenHash")');
+  await idx('CREATE UNIQUE INDEX IF NOT EXISTS uq_re_voucher_token ON reward_entitlements ("tokenHash") WHERE "tokenHash" IS NOT NULL');
+  await idx('CREATE INDEX IF NOT EXISTS idx_re_activation_status ON reward_entitlements ("activationId", "status")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_re_prospect ON reward_entitlements ("prospectId")');
+  await idx(`CREATE INDEX IF NOT EXISTS idx_re_expiry_eligible ON reward_entitlements ("expiresAt") WHERE "status" = 'eligible'`);
+  await idx('CREATE UNIQUE INDEX IF NOT EXISTS "redemptions_entitlementId_key" ON redemptions ("entitlementId")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_red_partner_redeemed ON redemptions ("partnerOrganisationId", "redeemedAt")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_rde_entitlement_created ON redemption_events ("entitlementId", "createdAt")');
+}
+
+export async function down(queryInterface) {
+  for (const table of ['redemption_events', 'redemptions', 'reward_entitlements']) {
+    await queryInterface.sequelize.query(`DROP TABLE IF EXISTS ${table} CASCADE`);
+  }
+}

--- a/backend/src/models/Redemption.js
+++ b/backend/src/models/Redemption.js
@@ -1,0 +1,35 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * A completed redemption (docs/redeem-ops/ERD.md §3.17). UNIQUE entitlementId =
+ * double redemption impossible at the schema level. Reversal is TERMINAL for
+ * the entitlement — re-fulfilment means cancelling and manually issuing a new
+ * entitlement (documented escape hatch: partial unique over active states).
+ */
+const Redemption = sequelize.define('Redemption', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  entitlementId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    unique: true,
+    references: { model: 'reward_entitlements', key: 'id' }
+  },
+  rewardOfferId: { type: DataTypes.UUID, allowNull: false, references: { model: 'reward_offers', key: 'id' } },
+  activationId: { type: DataTypes.UUID, allowNull: false, references: { model: 'activations', key: 'id' } },
+  partnerOrganisationId: { type: DataTypes.UUID, allowNull: false, references: { model: 'partner_organisations', key: 'id' } },
+  locationId: { type: DataTypes.UUID, allowNull: true, references: { model: 'partner_locations', key: 'id' } },
+  redeemedAt: { type: DataTypes.DATE, allowNull: false, defaultValue: DataTypes.NOW },
+  method: { type: DataTypes.STRING(24), allowNull: false, defaultValue: 'code', comment: 'code|qr|partner_verification|manual_override' },
+  status: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'completed', comment: 'completed|reversed|flagged' },
+  actorType: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'staff' },
+  actorUserId: { type: DataTypes.UUID, allowNull: true, references: { model: 'users', key: 'id' } },
+  notes: { type: DataTypes.TEXT, allowNull: true }
+}, {
+  tableName: 'redemptions',
+  indexes: [
+    { fields: ['partnerOrganisationId', 'redeemedAt'], name: 'idx_red_partner_redeemed' }
+  ]
+});
+
+export default Redemption;

--- a/backend/src/models/RedemptionEvent.js
+++ b/backend/src/models/RedemptionEvent.js
@@ -1,0 +1,26 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/** Append-only fulfilment history (docs/redeem-ops/ERD.md §3.18). */
+const RedemptionEvent = sequelize.define('RedemptionEvent', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  entitlementId: { type: DataTypes.UUID, allowNull: false, references: { model: 'reward_entitlements', key: 'id' } },
+  redemptionId: { type: DataTypes.UUID, allowNull: true, references: { model: 'redemptions', key: 'id' } },
+  type: {
+    type: DataTypes.STRING(24),
+    allowNull: false,
+    comment: 'reserved|unlocked|claim_viewed|verify_attempt|verified|redeemed|rejected|expired|manual_override|reversed'
+  },
+  metadata: { type: DataTypes.JSONB, allowNull: true },
+  actorType: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'system', comment: 'staff|agent|partner_user|consumer|system' },
+  actorUserId: { type: DataTypes.UUID, allowNull: true }
+}, {
+  tableName: 'redemption_events',
+  timestamps: true,
+  updatedAt: false,
+  indexes: [
+    { fields: ['entitlementId', 'createdAt'], name: 'idx_rde_entitlement_created' }
+  ]
+});
+
+export default RedemptionEvent;

--- a/backend/src/models/RewardEntitlement.js
+++ b/backend/src/models/RewardEntitlement.js
@@ -1,0 +1,60 @@
+import { DataTypes, Op } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * A specific consumer/lead's right to a reward (docs/redeem-ops/ERD.md §3.16).
+ *
+ * Lifecycle: eligible (reserved/locked — inventory held, NO voucher exists) →
+ * issued (unlocked at the consultant meeting — voucher token minted) →
+ * redeemed | expired | cancelled.
+ *
+ * Two tokens, one consumer link: presentationTokenHash is the reservation-pass
+ * QR shown to the CONSULTANT (salon verify rejects it); tokenHash is the
+ * redemption voucher, minted only at unlock. Raw tokens are random 32-byte
+ * base64url, SHA-256 at rest, returned once.
+ */
+const RewardEntitlement = sequelize.define('RewardEntitlement', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  rewardOfferId: { type: DataTypes.UUID, allowNull: false, references: { model: 'reward_offers', key: 'id' } },
+  activationId: { type: DataTypes.UUID, allowNull: false, references: { model: 'activations', key: 'id' } },
+  prospectId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    references: { model: 'prospects', key: 'id' },
+    comment: 'Canonical MKTR lead reference — SET NULL on lead delete; entitlement survives PII removal'
+  },
+  status: {
+    type: DataTypes.STRING(16),
+    allowNull: false,
+    defaultValue: 'eligible',
+    comment: 'eligible(reserved/locked)|issued(unlocked)|redeemed|expired|cancelled|blocked'
+  },
+  reservedAt: { type: DataTypes.DATE, allowNull: false, defaultValue: DataTypes.NOW },
+  unlockedAt: { type: DataTypes.DATE, allowNull: true },
+  unlockedByUserId: { type: DataTypes.UUID, allowNull: true, references: { model: 'users', key: 'id' } },
+  unlockedVia: { type: DataTypes.STRING(16), allowNull: true, comment: 'agent_scan|agent_button|auto_on_capture|manual' },
+  expiresAt: {
+    type: DataTypes.DATE,
+    allowNull: true,
+    comment: 'State-dependent: reservation window while eligible; re-stamped to the redemption window at unlock'
+  },
+  presentationTokenHash: { type: DataTypes.STRING(64), allowNull: false, comment: 'SHA-256 of the reservation-pass token (meeting QR)' },
+  tokenHash: { type: DataTypes.STRING(64), allowNull: true, comment: 'SHA-256 of the redemption voucher token — minted at unlock' },
+  tokenHint: { type: DataTypes.STRING(8), allowNull: true, comment: 'Last 4 of the voucher code, for support' },
+  issuedVia: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'hook', comment: 'hook|sweep|manual' },
+  createdBy: { type: DataTypes.UUID, allowNull: true }
+}, {
+  tableName: 'reward_entitlements',
+  indexes: [
+    // Idempotency anchor for hook+sweep issuance — partial because deleted
+    // prospects SET-NULL and Postgres treats NULLs as distinct (ERD.md §3.16)
+    { unique: true, fields: ['activationId', 'prospectId'], name: 'uq_re_activation_prospect', where: { prospectId: { [Op.ne]: null } } },
+    { unique: true, fields: ['presentationTokenHash'], name: 'uq_re_presentation_token' },
+    { unique: true, fields: ['tokenHash'], name: 'uq_re_voucher_token', where: { tokenHash: { [Op.ne]: null } } },
+    { fields: ['activationId', 'status'], name: 'idx_re_activation_status' },
+    { fields: ['prospectId'], name: 'idx_re_prospect' },
+    { fields: ['expiresAt'], name: 'idx_re_expiry_eligible', where: { status: 'eligible' } }
+  ]
+});
+
+export default RewardEntitlement;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -217,6 +217,23 @@ function defineAssociations() {
   Activation.belongsTo(RewardOffer, { foreignKey: 'rewardOfferId', as: 'rewardOffer', onDelete: 'RESTRICT' });
   Activation.belongsTo(Campaign, { foreignKey: 'campaignId', as: 'campaign', onDelete: 'SET NULL' });
 
+  // Fulfilment (Phase 6) — entitlement references the canonical MKTR lead by FK
+  // (SET NULL on lead delete; no PII copies). History tables are append-only.
+  const { RewardEntitlement, Redemption, RedemptionEvent } = models;
+  RewardEntitlement.belongsTo(RewardOffer, { foreignKey: 'rewardOfferId', as: 'rewardOffer', onDelete: 'RESTRICT' });
+  RewardEntitlement.belongsTo(Activation, { foreignKey: 'activationId', as: 'activation', onDelete: 'RESTRICT' });
+  RewardEntitlement.belongsTo(Prospect, { foreignKey: 'prospectId', as: 'prospect', onDelete: 'SET NULL' });
+  RewardEntitlement.belongsTo(User, { foreignKey: 'unlockedByUserId', as: 'unlockedBy', onDelete: 'SET NULL' });
+  Activation.hasMany(RewardEntitlement, { foreignKey: 'activationId', as: 'entitlements', onDelete: 'RESTRICT' });
+  Redemption.belongsTo(RewardEntitlement, { foreignKey: 'entitlementId', as: 'entitlement', onDelete: 'RESTRICT' });
+  Redemption.belongsTo(RewardOffer, { foreignKey: 'rewardOfferId', as: 'rewardOffer', onDelete: 'RESTRICT' });
+  Redemption.belongsTo(Activation, { foreignKey: 'activationId', as: 'activation', onDelete: 'RESTRICT' });
+  Redemption.belongsTo(PartnerOrganisation, { foreignKey: 'partnerOrganisationId', as: 'partner', onDelete: 'RESTRICT' });
+  Redemption.belongsTo(PartnerLocation, { foreignKey: 'locationId', as: 'location', onDelete: 'SET NULL' });
+  Redemption.belongsTo(User, { foreignKey: 'actorUserId', as: 'actor', onDelete: 'SET NULL' });
+  RedemptionEvent.belongsTo(RewardEntitlement, { foreignKey: 'entitlementId', as: 'entitlement', onDelete: 'CASCADE' });
+  RedemptionEvent.belongsTo(Redemption, { foreignKey: 'redemptionId', as: 'redemption', onDelete: 'CASCADE' });
+
   // Outreach work (Phase 3)
   const { OutreachTask, ProspectingPool, ProspectingPoolMember } = models;
   PartnerOrganisation.hasMany(OutreachTask, { foreignKey: 'partnerOrganisationId', as: 'tasks', onDelete: 'CASCADE' });
@@ -264,7 +281,8 @@ export const {
   PartnerContact, PartnerAssignmentEvent, PartnerStageEvent, OutreachActivity,
   OutreachTask, ProspectingPool, ProspectingPoolMember, RewardOffer,
   RewardTermsVersion, RewardOfferLocation, RewardInventoryEvent,
-  PartnerOnboardingItem, Activation
+  PartnerOnboardingItem, Activation, RewardEntitlement, Redemption,
+  RedemptionEvent
 } = models;
 
 export { sequelize };

--- a/backend/src/routes/externalEntitlements.js
+++ b/backend/src/routes/externalEntitlements.js
@@ -1,0 +1,57 @@
+import express from 'express';
+import { asyncHandler } from '../middleware/errorHandler.js';
+import { requireExternalHmac } from '../controllers/externalBillingController.js';
+import { User } from '../models/index.js';
+import { makeEntitlementService } from '../services/redeemOps/entitlementService.js';
+
+/**
+ * mktr-leads consultant → voucher unlock (docs/redeem-ops/MKTR_INTEGRATION.md §2).
+ * Same posture as the other /api/external/* surfaces: HMAC over the raw body with
+ * EXTERNAL_APP_SECRET + signed timestamp (requireExternalHmac), rawBody capture
+ * and rate-limiter exemption already wired for the prefix.
+ *
+ * Body: { timestamp, agentMktrUserId, presentationToken?, prospectId?, via? }
+ * The resolved mirror user must be the lead's assigned consultant.
+ */
+export const meta = {
+  path: '/api/external/entitlements',
+  flag: 'REDEEM_OPS_ENTITLEMENTS_ENABLED',
+  flagDefault: 'false',
+};
+
+const router = express.Router();
+
+router.post('/unlock', requireExternalHmac, asyncHandler(async (req, res) => {
+  const { agentMktrUserId, presentationToken, prospectId, via } = req.body || {};
+  if (!agentMktrUserId || (!presentationToken && !prospectId)) {
+    return res.status(400).json({ success: false, error: 'agentMktrUserId and presentationToken or prospectId are required' });
+  }
+
+  const agent = await User.findOne({
+    where: { mktrLeadsId: String(agentMktrUserId), isActive: true },
+  });
+  if (!agent) {
+    return res.status(404).json({ success: false, error: 'Unknown agent' });
+  }
+
+  try {
+    const result = await makeEntitlementService().unlockEntitlement(
+      presentationToken ? { presentationToken } : { prospectId },
+      agent,
+      via === 'button' ? 'agent_button' : 'agent_scan'
+    );
+    return res.json({
+      success: true,
+      already: result.already,
+      entitlementId: result.entitlement.id,
+      status: result.entitlement.status,
+      tokenHint: result.entitlement.tokenHint,
+    });
+  } catch (err) {
+    const code = err.statusCode || 500;
+    if (code >= 500) throw err;
+    return res.status(code).json({ success: false, error: err.message });
+  }
+}));
+
+export default router;

--- a/backend/src/routes/lyfeEntitlementUnlock.js
+++ b/backend/src/routes/lyfeEntitlementUnlock.js
@@ -1,0 +1,97 @@
+import express from 'express';
+import crypto from 'crypto';
+import { asyncHandler } from '../middleware/errorHandler.js';
+import { User } from '../models/index.js';
+import { makeEntitlementService } from '../services/redeemOps/entitlementService.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Lyfe consultant → voucher unlock at the physical meeting
+ * (docs/redeem-ops/MKTR_INTEGRATION.md §2 "agent-mediated unlock").
+ *
+ * Auth mirrors /api/integrations/lyfe/lead-outcome: HMAC-SHA256 over
+ * `${timestamp}.${rawBody}` with LYFE_LEAD_OUTCOME_SECRET (same shared secret —
+ * one Lyfe→MKTR channel, one key). rawBody capture for this prefix is already
+ * wired in server_internal.js; the prefix is rate-limiter-exempt.
+ *
+ * Body: { agentLyfeId, presentationToken? , prospectId?, via? }
+ *  - scan path: presentationToken (proves the client was present)
+ *  - button path: prospectId (consultant unlocks from the lead record)
+ * The resolved agent must be the lead's assigned consultant.
+ */
+export const meta = {
+  path: '/api/integrations/lyfe',
+  flag: 'REDEEM_OPS_ENTITLEMENTS_ENABLED',
+  flagDefault: 'false',
+};
+
+const MAX_SKEW_MS = 7 * 24 * 60 * 60 * 1000; // matches lead-outcome tolerance
+
+function timingSafeHexEq(aHex, bHex) {
+  try {
+    const a = Buffer.from(aHex, 'hex');
+    const b = Buffer.from(bHex, 'hex');
+    return a.length === b.length && crypto.timingSafeEqual(a, b);
+  } catch {
+    return false;
+  }
+}
+
+function verifyLyfeHmac(req) {
+  const secret = process.env.LYFE_LEAD_OUTCOME_SECRET;
+  if (!secret) {
+    logger.error('[lyfe-entitlement-unlock] LYFE_LEAD_OUTCOME_SECRET not configured');
+    return false;
+  }
+  const timestamp = req.get('x-webhook-timestamp');
+  const signature = req.get('x-webhook-signature');
+  if (!timestamp || !signature || !signature.startsWith('sha256=') || !req.rawBody) return false;
+  const tsMs = Date.parse(timestamp);
+  if (Number.isNaN(tsMs) || Math.abs(Date.now() - tsMs) > MAX_SKEW_MS) return false;
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(`${timestamp}.${req.rawBody}`)
+    .digest('hex');
+  return timingSafeHexEq(signature.slice(7), expected);
+}
+
+const router = express.Router();
+
+router.post('/entitlement-unlock', asyncHandler(async (req, res) => {
+  if (!verifyLyfeHmac(req)) {
+    return res.status(401).json({ success: false, message: 'Invalid signature' });
+  }
+  const { agentLyfeId, presentationToken, prospectId, via } = req.body || {};
+  if (!agentLyfeId || (!presentationToken && !prospectId)) {
+    return res.status(400).json({ success: false, message: 'agentLyfeId and presentationToken or prospectId are required' });
+  }
+
+  const agent = await User.findOne({ where: { lyfeId: String(agentLyfeId), isActive: true } });
+  if (!agent) {
+    return res.status(404).json({ success: false, message: 'Unknown agent' });
+  }
+
+  try {
+    const result = await makeEntitlementService().unlockEntitlement(
+      presentationToken ? { presentationToken } : { prospectId },
+      agent,
+      via === 'button' ? 'agent_button' : 'agent_scan'
+    );
+    return res.json({
+      success: true,
+      message: result.already ? 'Already unlocked' : 'Voucher unlocked — the customer has been notified',
+      data: {
+        already: result.already,
+        entitlementId: result.entitlement.id,
+        status: result.entitlement.status,
+        tokenHint: result.entitlement.tokenHint,
+      },
+    });
+  } catch (err) {
+    const code = err.statusCode || 500;
+    if (code >= 500) throw err;
+    return res.status(code).json({ success: false, message: err.message });
+  }
+}));
+
+export default router;

--- a/backend/src/routes/redeemOpsFulfilment.js
+++ b/backend/src/routes/redeemOpsFulfilment.js
@@ -1,0 +1,30 @@
+import express from 'express';
+import { requireRedeemOps } from '../middleware/redeemOpsAuth.js';
+import * as ctrl from '../controllers/redeemOps/fulfilmentController.js';
+
+/**
+ * Redeem Ops Phase 6 — entitlements + redemption console (docs/redeem-ops/
+ * ROUTE_MAP.md §1). Consumer claim lives in the SEPARATE public namespace
+ * /api/reward-claim (never under this host-blocked internal prefix), and the
+ * consultant unlock rides the existing HMAC surfaces (see MKTR_INTEGRATION.md §2).
+ */
+export const meta = {
+  path: '/api/redeem-ops',
+  flag: 'REDEEM_OPS_ENABLED',
+  flagDefault: 'false',
+};
+
+const router = express.Router();
+
+// Entitlements
+router.get('/entitlements', requireRedeemOps('entitlements.view'), ctrl.listEntitlements);
+router.post('/entitlements', requireRedeemOps('entitlements.issue_manual'), ctrl.issueManual);
+router.patch('/entitlements/:id/cancel', requireRedeemOps('entitlements.issue_manual'), ctrl.cancelEntitlement);
+
+// Redemption console (voucher verify → complete; unmasked holder identity here only)
+router.post('/redemptions/verify', requireRedeemOps('redemptions.verify'), ctrl.verifyVoucher);
+router.post('/redemptions/complete', requireRedeemOps('redemptions.verify'), ctrl.completeRedemption);
+router.post('/redemptions/:id/reverse', requireRedeemOps('redemptions.override'), ctrl.reverseRedemption);
+router.get('/redemptions', requireRedeemOps('entitlements.view'), ctrl.listRedemptions);
+
+export default router;

--- a/backend/src/routes/rewardClaim.js
+++ b/backend/src/routes/rewardClaim.js
@@ -1,0 +1,120 @@
+import express from 'express';
+import rateLimit from 'express-rate-limit';
+import { Op } from 'sequelize';
+import QRCode from 'qrcode';
+import { asyncHandler } from '../middleware/errorHandler.js';
+import {
+  RewardEntitlement, RewardOffer, PartnerOrganisation, PartnerLocation,
+  RewardOfferLocation, RedemptionEvent,
+} from '../models/index.js';
+import { hashToken } from '../services/redeemOps/tokens.js';
+
+/**
+ * PUBLIC consumer reward view — backs redeem.sg/r/:token
+ * (docs/redeem-ops/ROUTE_MAP.md: deliberately OUTSIDE /api/redeem-ops, which is
+ * host-blocked from the consumer site).
+ *
+ * One stable link, two states: while locked it renders the reservation pass
+ * (QR the consultant scans); once unlocked the SAME link renders the voucher
+ * (QR the merchant scans). Token-authenticated: the URL token IS the credential;
+ * responses carry only reward/partner info + the holder's first name — never
+ * full lead PII (docs/redeem-ops/USER_SURFACES… §4).
+ */
+export const meta = {
+  path: '/api/reward-claim',
+  flag: 'REDEEM_OPS_ENTITLEMENTS_ENABLED',
+  flagDefault: 'false',
+};
+
+const claimLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 60, // generous for a human, hostile to token scanning
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { success: false, message: 'Too many requests — try again later.' },
+});
+
+const router = express.Router();
+
+router.get('/:token', claimLimiter, asyncHandler(async (req, res) => {
+  const raw = String(req.params.token || '').trim();
+  if (raw.length < 16 || raw.length > 128) {
+    return res.status(404).json({ success: false, message: 'Not found' });
+  }
+  const hash = hashToken(raw);
+
+  // The link carries the PRESENTATION token for its whole life; after unlock the
+  // same page shows the voucher. A voucher token pasted here also resolves.
+  const entitlement = await RewardEntitlement.findOne({
+    where: { [Op.or]: [{ presentationTokenHash: hash }, { tokenHash: hash }] },
+    include: [
+      {
+        model: RewardOffer,
+        as: 'rewardOffer',
+        attributes: ['id', 'title', 'publicTitle', 'description', 'fulfilmentMethod', 'externalBookingUrl', 'currentTermsVersion'],
+        include: [{ model: PartnerOrganisation, as: 'partner', attributes: ['tradingName', 'brandName', 'legalName'] }],
+      },
+      { association: 'prospect', attributes: ['firstName'] },
+    ],
+  });
+  if (!entitlement) {
+    return res.status(404).json({ success: false, message: 'Not found' });
+  }
+
+  RedemptionEvent.create({
+    entitlementId: entitlement.id,
+    type: 'claim_viewed',
+    actorType: 'consumer',
+  }).catch(() => {});
+
+  const offer = entitlement.rewardOffer;
+  const partner = offer?.partner;
+  const locations = await RewardOfferLocation.findAll({
+    where: { rewardOfferId: entitlement.rewardOfferId },
+    include: [{ model: PartnerLocation, as: 'location', attributes: ['name', 'addressLine', 'postalCode'] }],
+  });
+
+  const expired = entitlement.expiresAt && new Date(entitlement.expiresAt) < new Date();
+  const base = {
+    firstName: entitlement.prospect?.firstName || null,
+    reward: {
+      title: offer?.publicTitle || offer?.title,
+      description: offer?.description || null,
+      partnerName: partner?.tradingName || partner?.brandName || partner?.legalName || null,
+      locations: locations.map((l) => ({
+        name: l.location?.name, addressLine: l.location?.addressLine, postalCode: l.location?.postalCode,
+      })),
+    },
+    expiresAt: entitlement.expiresAt,
+  };
+
+  // Locked reservation → the meeting pass (only when the link used the presentation token)
+  if (entitlement.status === 'eligible' && entitlement.presentationTokenHash === hash && !expired) {
+    const qrDataUrl = await QRCode.toDataURL(raw, { width: 280, margin: 1 });
+    return res.json({
+      success: true,
+      data: { ...base, state: 'reserved', pass: { qrDataUrl } },
+    });
+  }
+
+  // Unlocked voucher — the SAME stable link now renders a scannable QR. The QR
+  // encodes the bearer's own raw token (voucher or post-unlock presentation);
+  // redemptionService accepts either once status='issued' — the STATE MACHINE is
+  // the gate, so extra copies of either code change nothing.
+  if (entitlement.status === 'issued' && !expired) {
+    const qrDataUrl = await QRCode.toDataURL(raw, { width: 280, margin: 1 });
+    return res.json({
+      success: true,
+      data: {
+        ...base,
+        state: 'unlocked',
+        voucher: { tokenHint: entitlement.tokenHint, qrDataUrl },
+      },
+    });
+  }
+
+  const state = expired && ['eligible', 'issued'].includes(entitlement.status) ? 'expired' : entitlement.status;
+  return res.json({ success: true, data: { ...base, state } });
+}));
+
+export default router;

--- a/backend/src/services/mailer.js
+++ b/backend/src/services/mailer.js
@@ -58,7 +58,7 @@ export function getTransporter() {
 }
 
 
-export async function sendEmail({ to, subject, html, text, context, from }) {
+export async function sendEmail({ to, subject, html, text, context, from, attachments }) {
   // Resolve from-address by context (lead-capture flows pass context='redeem',
   // admin flows omit it). An explicit `from` arg overrides both.
   const resolvedFrom = from || resolveEmailFrom(context);
@@ -71,7 +71,11 @@ export async function sendEmail({ to, subject, html, text, context, from }) {
   }
 
   try {
-    await transporter.sendMail({ from: resolvedFrom, to, subject, html, text });
+    // `attachments` (optional, nodemailer passthrough) carries CID-inline images —
+    // the Redeem Ops voucher QR ships as an attachment, not a remote URL, so it
+    // renders with remote images blocked and the token stays out of image-proxy
+    // logs (docs/redeem-ops/MKTR_INTEGRATION.md §2).
+    await transporter.sendMail({ from: resolvedFrom, to, subject, html, text, ...(attachments ? { attachments } : {}) });
     return { success: true };
   } catch (err) {
     // Surface SES/SMTP rejection details — Nodemailer attaches `code`,

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -33,7 +33,18 @@ import {
   sendTikTokCompleteRegistrationEvent,
 } from './tiktokEventsService.js';
 import { getOrCreateProspectShareLink } from './shortlinkService.js';
+import { isPhoneRecentlyVerified } from './verifiedPhoneStore.js';
 import { customerHostOrigin, normalizeCustomerHostChoice } from '../utils/customerHost.js';
+
+// Redeem Ops capture hook (docs/redeem-ops/MKTR_INTEGRATION.md §2): a
+// dependency-INVERTED callback — this module never imports Redeem Ops code.
+// bootstrap (the composition root) registers the real implementation when the
+// module is enabled; the default is a no-op. Removing the registration makes
+// lead capture byte-identical to the pre-Redeem-Ops behaviour.
+let _leadCapturedHook = null;
+export function registerLeadCapturedHook(fn) {
+  _leadCapturedHook = typeof fn === 'function' ? fn : null;
+}
 import { logger } from '../utils/logger.js';
 import { signupActivityDescription, signupSourceLabel } from '../utils/sourceLabel.js';
 import {
@@ -120,6 +131,8 @@ const defaultDeps = {
   sendTikTokLeadEvent,
   sendTikTokCompleteRegistrationEvent,
   getOrCreateProspectShareLink,
+  isPhoneRecentlyVerified,
+  onLeadCaptured: (prospect) => (_leadCapturedHook ? _leadCapturedHook(prospect) : null),
   AppError,
   logger,
 };
@@ -206,6 +219,17 @@ export function makeProspectService(overrides = {}) {
     };
     if (Object.keys(capiSourceMetadata).length > 0) {
       incoming.sourceMetadata = { ...(incoming.sourceMetadata || {}), ...capiSourceMetadata };
+    }
+
+    // Server-side phone-verification stamp (docs/redeem-ops/MKTR_INTEGRATION.md §2.0):
+    // written iff the OTP marker is live at create time. Durable evidence that
+    // Redeem Ops reward issuance REQUIRES — a raw unverified POST still captures
+    // as a lead but can never mint reward value (anti-farming precondition).
+    if (incoming.phone && d.isPhoneRecentlyVerified?.(incoming.phone)) {
+      incoming.sourceMetadata = {
+        ...(incoming.sourceMetadata || {}),
+        phoneVerifiedAt: new Date().toISOString(),
+      };
     }
 
     // Third-party-disclosure consent evidence. Written ONLY when the person ticked
@@ -929,6 +953,23 @@ export function makeProspectService(overrides = {}) {
       d.sendTikTokCompleteRegistrationEvent(prospect, { eventId: registrationEventId, ...tiktokCtxBase }).catch((err) => {
         d.logger.error('[TikTok] sendTikTokCompleteRegistrationEvent error', { error: err?.message || String(err) });
       });
+    }
+
+    // Redeem Ops reward-entitlement hook — post-commit, fire-and-forget (a
+    // Redeem Ops failure must never fail or slow lead capture). No-op unless
+    // bootstrap registered the callback (module flag on). Idempotent downstream
+    // via the unique (activationId, prospectId) anchor.
+    if (!quarantined) {
+      try {
+        const hookResult = d.onLeadCaptured?.(prospect);
+        if (hookResult && typeof hookResult.catch === 'function') {
+          hookResult.catch((err) =>
+            d.logger.error('[RedeemOps] onLeadCaptured error', { error: err?.message || String(err) })
+          );
+        }
+      } catch (err) {
+        d.logger.error('[RedeemOps] onLeadCaptured error', { error: err?.message || String(err) });
+      }
     }
 
     // Pre-load agent + prospect-with-campaign for the caller's fire-and-forget

--- a/backend/src/services/redeemOps/entitlementService.js
+++ b/backend/src/services/redeemOps/entitlementService.js
@@ -1,0 +1,381 @@
+import { Op } from 'sequelize';
+import {
+  RewardEntitlement, RedemptionEvent, Activation, RewardOffer, PartnerOrganisation,
+  Prospect, User, sequelize,
+} from '../../models/index.js';
+import { AppError } from '../../middleware/errorHandler.js';
+import { logger } from '../../utils/logger.js';
+import { makeInventoryService } from './inventoryService.js';
+import { makeRedeemOpsAuditService } from './auditService.js';
+import { mintToken, hashToken, tokenHintOf } from './tokens.js';
+
+const DEFAULT_RESERVATION_DAYS = 30;
+const DEFAULT_REDEMPTION_DAYS = 90;
+
+/**
+ * Reward entitlements (docs/redeem-ops/MKTR_INTEGRATION.md §2, ERD.md §3.16).
+ *
+ * Issuance is at-least-once (capture hook + reconciliation sweep) made
+ * exactly-once by the partial unique (activationId, prospectId) anchor.
+ * Preconditions (anti-farming): server-stamped phone verification on the
+ * prospect, not quarantined, activation ACTIVE with allocation remaining.
+ *
+ * unlockPolicy='agent_unlock' (default): capture creates a locked RESERVATION
+ * (presentation-pass token only); the lead's assigned consultant unlocks at the
+ * physical meeting (scan or button) which mints the voucher token.
+ */
+export function makeEntitlementService(overrides = {}) {
+  const d = {
+    RewardEntitlement, RedemptionEvent, Activation, RewardOffer, PartnerOrganisation,
+    Prospect, User, sequelize, logger,
+    inventory: makeInventoryService(),
+    audit: makeRedeemOpsAuditService(),
+    notifyUnlock: null, // injected by fulfilment wiring (email/SMS) — null-safe
+    ...overrides,
+  };
+
+  async function writeEvent(t, evt) {
+    return d.RedemptionEvent.create(
+      {
+        entitlementId: evt.entitlementId,
+        redemptionId: evt.redemptionId || null,
+        type: evt.type,
+        metadata: evt.metadata || null,
+        actorType: evt.actorType || 'system',
+        actorUserId: evt.actorUserId || null,
+      },
+      { transaction: t }
+    );
+  }
+
+  function verificationStampOf(prospect) {
+    return prospect?.sourceMetadata?.phoneVerifiedAt || null;
+  }
+
+  /**
+   * Issue (reserve) for a captured lead. Returns the entitlement or null with a
+   * reason — NEVER throws into the capture path (the hook wraps it anyway).
+   */
+  async function issueForProspect(prospect, { via = 'hook' } = {}) {
+    try {
+      if (!prospect?.campaignId) return { entitlement: null, reason: 'no_campaign' };
+      if (prospect.quarantinedAt) return { entitlement: null, reason: 'quarantined' };
+      if (!verificationStampOf(prospect)) return { entitlement: null, reason: 'phone_not_verified' };
+
+      const activation = await d.Activation.findOne({
+        where: { campaignId: prospect.campaignId, status: 'active' },
+        include: [{ model: d.RewardOffer, as: 'rewardOffer' }],
+      });
+      if (!activation) return { entitlement: null, reason: 'no_active_activation' };
+
+      const existing = await d.RewardEntitlement.findOne({
+        where: { activationId: activation.id, prospectId: prospect.id },
+      });
+      if (existing) return { entitlement: existing, reason: 'duplicate' };
+
+      const offer = activation.rewardOffer;
+      const onCapture = activation.unlockPolicy === 'on_capture';
+      const reservationDays = offer.claimExpiryDays || DEFAULT_RESERVATION_DAYS;
+      const redemptionDays = offer.redemptionExpiryDays || DEFAULT_REDEMPTION_DAYS;
+
+      const presentation = mintToken();
+      const voucher = onCapture ? mintToken() : null;
+
+      const entitlement = await d.sequelize.transaction(async (t) => {
+        // Activation-level guard: issuedCount < allocatedQuantity (single statement)
+        const [rows] = await d.sequelize.query(
+          `UPDATE activations
+              SET "issuedCount" = "issuedCount" + 1, "updatedAt" = NOW()
+            WHERE id = :id AND "issuedCount" < "allocatedQuantity" AND status = 'active'
+            RETURNING id`,
+          { replacements: { id: activation.id }, transaction: t }
+        );
+        if (!Array.isArray(rows) || rows.length === 0) {
+          throw Object.assign(new Error('allocation_exhausted'), { _soft: true });
+        }
+        // Offer-level counter + ledger
+        await d.inventory.recordIssued({
+          offerId: offer.id, activationId: activation.id, transaction: t,
+        });
+
+        const created = await d.RewardEntitlement.create(
+          {
+            rewardOfferId: offer.id,
+            activationId: activation.id,
+            prospectId: prospect.id,
+            status: onCapture ? 'issued' : 'eligible',
+            unlockedAt: onCapture ? new Date() : null,
+            unlockedVia: onCapture ? 'auto_on_capture' : null,
+            expiresAt: new Date(Date.now() + (onCapture ? redemptionDays : reservationDays) * 24 * 3600 * 1000),
+            presentationTokenHash: presentation.hash,
+            tokenHash: voucher ? voucher.hash : null,
+            tokenHint: voucher ? tokenHintOf(voucher.raw) : null,
+            issuedVia: via,
+          },
+          { transaction: t }
+        );
+        await writeEvent(t, { entitlementId: created.id, type: 'reserved', metadata: { via, unlockPolicy: activation.unlockPolicy } });
+        if (onCapture) {
+          await writeEvent(t, { entitlementId: created.id, type: 'unlocked', metadata: { via: 'auto_on_capture' } });
+        }
+        return created;
+      });
+
+      // Raw tokens returned ONCE for delivery (email/link); only hashes persist.
+      return {
+        entitlement,
+        reason: null,
+        presentationToken: presentation.raw,
+        voucherToken: voucher ? voucher.raw : null,
+      };
+    } catch (err) {
+      if (err?._soft) return { entitlement: null, reason: err.message };
+      if (err?.name === 'SequelizeUniqueConstraintError') {
+        const existing = await d.RewardEntitlement.findOne({
+          where: { prospectId: prospect.id },
+          order: [['createdAt', 'DESC']],
+        });
+        return { entitlement: existing, reason: 'duplicate' };
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Consultant unlock at the physical meeting (MKTR_INTEGRATION.md §2).
+   * `by` = { presentationToken } (scan — proves presence) or { prospectId } (button).
+   * The acting agent must be the lead's assigned consultant (admin override allowed).
+   * Idempotent: an already-unlocked entitlement returns { already: true }.
+   */
+  async function unlockEntitlement(by, agentUser, via = 'agent_scan') {
+    let entitlement;
+    if (by.presentationToken) {
+      entitlement = await d.RewardEntitlement.findOne({
+        where: { presentationTokenHash: hashToken(by.presentationToken) },
+      });
+    } else if (by.prospectId) {
+      entitlement = await d.RewardEntitlement.findOne({
+        where: { prospectId: by.prospectId, status: { [Op.in]: ['eligible', 'issued'] } },
+        order: [['createdAt', 'DESC']],
+      });
+    }
+    if (!entitlement) throw new AppError('Entitlement not found', 404);
+
+    if (['issued', 'redeemed'].includes(entitlement.status)) {
+      return { entitlement, already: true, voucherToken: null };
+    }
+    if (entitlement.status !== 'eligible') {
+      throw new AppError(`Entitlement is ${entitlement.status}`, 409);
+    }
+
+    // Assigned-consultant binding (admin override audited via unlockedVia='manual')
+    const prospect = entitlement.prospectId ? await d.Prospect.findByPk(entitlement.prospectId) : null;
+    const isAdmin = agentUser.role === 'admin';
+    if (!isAdmin) {
+      if (!prospect || prospect.assignedAgentId !== agentUser.id) {
+        throw new AppError('Only the assigned consultant can unlock this reward', 403);
+      }
+    }
+
+    const offer = await d.RewardOffer.findByPk(entitlement.rewardOfferId);
+    const redemptionDays = offer?.redemptionExpiryDays || DEFAULT_REDEMPTION_DAYS;
+    const voucher = mintToken();
+
+    const result = await d.sequelize.transaction(async (t) => {
+      const [count] = await d.RewardEntitlement.update(
+        {
+          status: 'issued',
+          unlockedAt: new Date(),
+          unlockedByUserId: agentUser.id,
+          unlockedVia: isAdmin && !prospect ? 'manual' : via,
+          tokenHash: voucher.hash,
+          tokenHint: tokenHintOf(voucher.raw),
+          expiresAt: new Date(Date.now() + redemptionDays * 24 * 3600 * 1000),
+        },
+        {
+          where: {
+            id: entitlement.id,
+            status: 'eligible', // conditional transition — replay-safe
+            [Op.or]: [{ expiresAt: null }, { expiresAt: { [Op.gt]: new Date() } }],
+          },
+          transaction: t,
+        }
+      );
+      if (count === 0) {
+        throw new AppError('Reservation expired or already unlocked', 409);
+      }
+      await writeEvent(t, {
+        entitlementId: entitlement.id, type: 'unlocked',
+        actorType: 'agent', actorUserId: agentUser.id, metadata: { via },
+      });
+      return true;
+    });
+
+    await entitlement.reload();
+    if (result && typeof d.notifyUnlock === 'function') {
+      // Fire-and-forget consumer notification (voucher email w/ QR + link)
+      Promise.resolve(d.notifyUnlock({ entitlement, prospect, voucherToken: voucher.raw }))
+        .catch((err) => d.logger.error('redeem_ops.unlock.notify_failed', { error: err?.message }));
+    }
+    return { entitlement, already: false, voucherToken: voucher.raw };
+  }
+
+  /** Manual issue by redemption_ops (requires an existing lead). */
+  async function issueManual({ activationId, prospectId }, user, requestId = null) {
+    const activation = await d.Activation.findByPk(activationId, {
+      include: [{ model: d.RewardOffer, as: 'rewardOffer' }],
+    });
+    if (!activation) throw new AppError('Activation not found', 404);
+    const prospect = await d.Prospect.findByPk(prospectId);
+    if (!prospect) throw new AppError('Lead not found', 404);
+
+    const result = await issueForProspect(
+      { ...prospect.toJSON(), sourceMetadata: { ...(prospect.sourceMetadata || {}), phoneVerifiedAt: prospect.sourceMetadata?.phoneVerifiedAt || new Date().toISOString() } },
+      { via: 'manual' }
+    );
+    if (!result.entitlement) throw new AppError(`Cannot issue: ${result.reason}`, 409);
+    await d.audit.recordAuditEvent({
+      actorUser: user, action: 'entitlement.issued_manual', entityType: 'reward_entitlement',
+      entityId: result.entitlement.id, after: { activationId, prospectId }, requestId,
+    });
+    return result;
+  }
+
+  async function cancelEntitlement(id, user, reason, requestId = null) {
+    if (!reason || !String(reason).trim()) throw new AppError('A reason is required', 400);
+    const entitlement = await d.RewardEntitlement.findByPk(id);
+    if (!entitlement) throw new AppError('Entitlement not found', 404);
+    if (!['eligible', 'issued'].includes(entitlement.status)) {
+      throw new AppError(`Entitlement is ${entitlement.status}`, 409);
+    }
+    await d.sequelize.transaction(async (t) => {
+      const [count] = await d.RewardEntitlement.update(
+        { status: 'cancelled' },
+        { where: { id, status: { [Op.in]: ['eligible', 'issued'] } }, transaction: t }
+      );
+      if (count === 0) throw new AppError('Entitlement changed state — retry', 409);
+      await d.inventory.reverseIssued({
+        offerId: entitlement.rewardOfferId, activationId: entitlement.activationId,
+        entitlementId: id, type: 'cancelled', actorType: 'staff', reason, transaction: t,
+      });
+      await d.sequelize.query(
+        `UPDATE activations SET "issuedCount" = "issuedCount" - 1, "updatedAt" = NOW()
+          WHERE id = :id AND "issuedCount" > 0`,
+        { replacements: { id: entitlement.activationId }, transaction: t }
+      );
+      await writeEvent(t, {
+        entitlementId: id, type: 'manual_override', actorType: 'staff', actorUserId: user.id,
+        metadata: { action: 'cancelled', reason },
+      });
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'entitlement.cancelled', entityType: 'reward_entitlement',
+        entityId: id, reason, requestId, transaction: t,
+      });
+    });
+    await entitlement.reload();
+    return entitlement;
+  }
+
+  /** Reservation-expiry sweep — expired reservations return inventory to the pool. */
+  async function expireReservations() {
+    const stale = await d.RewardEntitlement.findAll({
+      where: { status: 'eligible', expiresAt: { [Op.lt]: new Date() } },
+      limit: 200,
+    });
+    let expired = 0;
+    for (const ent of stale) {
+      try {
+        await d.sequelize.transaction(async (t) => {
+          const [count] = await d.RewardEntitlement.update(
+            { status: 'expired' },
+            { where: { id: ent.id, status: 'eligible' }, transaction: t }
+          );
+          if (count === 0) return;
+          await d.inventory.reverseIssued({
+            offerId: ent.rewardOfferId, activationId: ent.activationId,
+            entitlementId: ent.id, type: 'expired', transaction: t,
+          });
+          await d.sequelize.query(
+            `UPDATE activations SET "issuedCount" = "issuedCount" - 1, "updatedAt" = NOW()
+              WHERE id = :id AND "issuedCount" > 0`,
+            { replacements: { id: ent.activationId }, transaction: t }
+          );
+          await writeEvent(t, { entitlementId: ent.id, type: 'expired' });
+          expired += 1;
+        });
+      } catch (err) {
+        d.logger.warn('redeem_ops.entitlement.expire_failed', { id: ent.id, error: err?.message });
+      }
+    }
+    if (expired > 0) d.logger.info('redeem_ops.entitlements.expired', { expired });
+    return expired;
+  }
+
+  /**
+   * Reconciliation sweep (at-least-once backstop for the capture hook): recent
+   * verified, unquarantined leads on ACTIVE activation campaigns lacking an
+   * entitlement get one. The unique anchor dedupes against hook races.
+   */
+  async function reconcileMissedLeads({ sinceHours = 48 } = {}) {
+    const activations = await d.Activation.findAll({
+      where: { status: 'active', campaignId: { [Op.ne]: null } },
+      attributes: ['id', 'campaignId'],
+    });
+    let issued = 0;
+    for (const activation of activations) {
+      const prospects = await d.Prospect.findAll({
+        where: {
+          campaignId: activation.campaignId,
+          quarantinedAt: null,
+          createdAt: { [Op.gt]: new Date(Date.now() - sinceHours * 3600 * 1000) },
+          id: {
+            [Op.notIn]: d.sequelize.literal(
+              `(SELECT "prospectId" FROM reward_entitlements WHERE "activationId" = '${activation.id}' AND "prospectId" IS NOT NULL)`
+            ),
+          },
+        },
+        limit: 100,
+      });
+      for (const prospect of prospects) {
+        const r = await issueForProspect(prospect, { via: 'sweep' }).catch(() => null);
+        if (r?.entitlement && r.reason === null) issued += 1;
+      }
+    }
+    if (issued > 0) d.logger.info('redeem_ops.entitlements.reconciled', { issued });
+    return issued;
+  }
+
+  /** Ops listing (staff view — lead PII via JOIN at read time, never copied). */
+  async function listEntitlements(query = {}) {
+    const where = {};
+    if (query.activationId) where.activationId = String(query.activationId);
+    if (query.status) where.status = String(query.status);
+    const page = Math.max(1, parseInt(query.page, 10) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(query.limit, 10) || 25));
+    const { rows, count } = await d.RewardEntitlement.findAndCountAll({
+      where,
+      include: [
+        { model: d.Prospect, as: 'prospect', attributes: ['id', 'firstName', 'lastName', 'phone'] },
+        { model: d.RewardOffer, as: 'rewardOffer', attributes: ['id', 'title'] },
+        { model: d.Activation, as: 'activation', attributes: ['id', 'campaignNameSnapshot'] },
+      ],
+      order: [['createdAt', 'DESC']],
+      limit, offset: (page - 1) * limit,
+    });
+    // Mask phones by default (redemptions.verify unmasks at the console)
+    const masked = rows.map((r) => {
+      const j = r.toJSON();
+      if (j.prospect?.phone) j.prospect.phone = `••••${String(j.prospect.phone).slice(-4)}`;
+      return j;
+    });
+    return { entitlements: masked, pagination: { page, limit, total: count, totalPages: Math.ceil(count / limit) } };
+  }
+
+  return {
+    issueForProspect, unlockEntitlement, issueManual, cancelEntitlement,
+    expireReservations, reconcileMissedLeads, listEntitlements, verificationStampOf,
+  };
+}
+
+const _default = makeEntitlementService();
+export default _default;

--- a/backend/src/services/redeemOps/fulfilmentNotify.js
+++ b/backend/src/services/redeemOps/fulfilmentNotify.js
@@ -1,0 +1,106 @@
+import QRCode from 'qrcode';
+import { RewardOffer, PartnerOrganisation, Campaign, Activation } from '../../models/index.js';
+import { sendEmail } from '../mailer.js';
+import { logger } from '../../utils/logger.js';
+import { customerHostOrigin, normalizeCustomerHostChoice } from '../../utils/customerHost.js';
+
+/**
+ * Consumer voucher delivery on unlock (docs/redeem-ops/MKTR_INTEGRATION.md §2).
+ * The email carries the reward in three redundant forms: the voucher QR as a
+ * CID-INLINE attachment (renders with remote images blocked; token stays out of
+ * image-proxy logs), the short code as text, and the live /r/… link (which now
+ * renders the voucher). Fire-and-forget — callers never await delivery.
+ */
+export function makeFulfilmentNotify(overrides = {}) {
+  const d = { RewardOffer, PartnerOrganisation, Campaign, Activation, sendEmail, logger, QRCode, ...overrides };
+
+  async function claimOrigin(activation) {
+    // Brand the link by the linked campaign's customer host (redeem default)
+    let hostChoice = 'redeem';
+    if (activation?.campaignId) {
+      const campaign = await d.Campaign.findByPk(activation.campaignId, { attributes: ['design_config'] });
+      hostChoice = normalizeCustomerHostChoice(campaign?.design_config?.customerHost);
+    }
+    return { origin: customerHostOrigin(hostChoice), hostChoice };
+  }
+
+  /** Reservation-pass email at capture (agent_unlock policy). */
+  async function sendReservationEmail({ entitlement, prospect, presentationToken }) {
+    if (!prospect?.email || /@calls\.mktr\.sg$/i.test(prospect.email)) return;
+    const offer = await d.RewardOffer.findByPk(entitlement.rewardOfferId, {
+      include: [{ model: d.PartnerOrganisation, as: 'partner', attributes: ['tradingName', 'legalName', 'brandName'] }],
+    });
+    const activation = await d.Activation.findByPk(entitlement.activationId);
+    const { origin, hostChoice } = await claimOrigin(activation);
+    const link = `${origin}/r/${presentationToken}`;
+    const rewardName = offer?.publicTitle || offer?.title || 'your reward';
+    const partnerName = offer?.partner?.tradingName || offer?.partner?.brandName || offer?.partner?.legalName || 'our partner';
+
+    const qrPng = await d.QRCode.toBuffer(link, { width: 320, margin: 1 });
+    const html = `
+      <div style="font-family:Arial,sans-serif;max-width:520px;margin:0 auto;padding:24px">
+        <h2 style="margin:0 0 8px">Your ${escapeHtml(rewardName)} is reserved 🎁</h2>
+        <p>Hi ${escapeHtml(prospect.firstName || 'there')},</p>
+        <p><strong>${escapeHtml(rewardName)}</strong> from <strong>${escapeHtml(partnerName)}</strong> is reserved for you.
+        It unlocks after your complimentary financial review — show this pass to your consultant at the meeting.</p>
+        <p style="text-align:center;margin:20px 0"><img src="cid:reservation-qr" width="220" height="220" alt="Reservation pass QR"/></p>
+        <p style="text-align:center"><a href="${link}" style="color:#2563eb">View your reservation</a></p>
+        <p style="color:#6b7280;font-size:12px">This pass is not a voucher yet — it can only be scanned by your consultant.
+        Expires ${entitlement.expiresAt ? new Date(entitlement.expiresAt).toLocaleDateString('en-SG') : 'soon'}.</p>
+      </div>`;
+    await d.sendEmail({
+      to: prospect.email,
+      subject: `Reserved for you: ${rewardName}`,
+      html,
+      text: `Your ${rewardName} from ${partnerName} is reserved. Show this link's QR to your consultant at your review to unlock it: ${link}`,
+      context: hostChoice === 'mktr' ? 'mktr' : 'redeem',
+      attachments: [{ filename: 'reservation.png', content: qrPng, cid: 'reservation-qr' }],
+    });
+  }
+
+  /** Voucher email at unlock. */
+  async function sendVoucherEmail({ entitlement, prospect, voucherToken }) {
+    if (!prospect?.email || /@calls\.mktr\.sg$/i.test(prospect.email)) return;
+    const offer = await d.RewardOffer.findByPk(entitlement.rewardOfferId, {
+      include: [{ model: d.PartnerOrganisation, as: 'partner', attributes: ['tradingName', 'legalName', 'brandName'] }],
+    });
+    const activation = await d.Activation.findByPk(entitlement.activationId);
+    const { origin, hostChoice } = await claimOrigin(activation);
+    const rewardName = offer?.publicTitle || offer?.title || 'your reward';
+    const partnerName = offer?.partner?.tradingName || offer?.partner?.brandName || offer?.partner?.legalName || 'our partner';
+    const shortCode = entitlement.tokenHint || voucherToken.slice(-4).toUpperCase();
+
+    const qrPng = await d.QRCode.toBuffer(voucherToken, { width: 320, margin: 1 });
+    const html = `
+      <div style="font-family:Arial,sans-serif;max-width:520px;margin:0 auto;padding:24px">
+        <h2 style="margin:0 0 8px">Your ${escapeHtml(rewardName)} is unlocked 🎉</h2>
+        <p>Hi ${escapeHtml(prospect.firstName || 'there')},</p>
+        <p>Show this voucher at <strong>${escapeHtml(partnerName)}</strong> to redeem
+        your <strong>${escapeHtml(rewardName)}</strong>.</p>
+        <p style="text-align:center;margin:20px 0"><img src="cid:voucher-qr" width="220" height="220" alt="Voucher QR"/></p>
+        <p style="text-align:center;font-size:18px">or quote code <strong>${escapeHtml(shortCode)}</strong></p>
+        <p style="text-align:center"><a href="${origin}/r/${voucherToken}" style="color:#2563eb">View your voucher</a></p>
+        <p style="color:#6b7280;font-size:12px">One-time use.
+        ${entitlement.expiresAt ? `Valid until ${new Date(entitlement.expiresAt).toLocaleDateString('en-SG')}.` : ''}</p>
+      </div>`;
+    await d.sendEmail({
+      to: prospect.email,
+      subject: `Your voucher: ${rewardName}`,
+      html,
+      text: `Your ${rewardName} from ${partnerName} is unlocked! Voucher code: ${shortCode}. View it: ${origin}/r/${voucherToken}`,
+      context: hostChoice === 'mktr' ? 'mktr' : 'redeem',
+      attachments: [{ filename: 'voucher.png', content: qrPng, cid: 'voucher-qr' }],
+    });
+  }
+
+  return { sendReservationEmail, sendVoucherEmail };
+}
+
+function escapeHtml(s) {
+  return String(s ?? '').replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+  ));
+}
+
+const _default = makeFulfilmentNotify();
+export default _default;

--- a/backend/src/services/redeemOps/redemptionService.js
+++ b/backend/src/services/redeemOps/redemptionService.js
@@ -1,0 +1,231 @@
+import { Op } from 'sequelize';
+import {
+  RewardEntitlement, Redemption, RedemptionEvent, RewardOffer, Activation,
+  PartnerOrganisation, PartnerLocation, Prospect, User, sequelize,
+} from '../../models/index.js';
+import { AppError } from '../../middleware/errorHandler.js';
+import { logger } from '../../utils/logger.js';
+import { makeInventoryService } from './inventoryService.js';
+import { makeRedeemOpsAuditService } from './auditService.js';
+import { hashToken } from './tokens.js';
+
+/**
+ * Redemption (docs/redeem-ops/ERD.md §3.17–3.18, brief §27). Server-validated,
+ * transaction-safe, idempotent:
+ *  - a QR/code is only a POINTER — the server decides validity;
+ *  - reservation-pass tokens are REJECTED here (meeting QR ≠ voucher);
+ *  - issued→redeemed is a conditional UPDATE + UNIQUE redemptions.entitlementId,
+ *    so double redemption is impossible even under concurrent verifies;
+ *  - replays get a typed "already redeemed" (200-shaped, idempotent).
+ */
+export function makeRedemptionService(overrides = {}) {
+  const d = {
+    RewardEntitlement, Redemption, RedemptionEvent, RewardOffer, Activation,
+    PartnerOrganisation, PartnerLocation, Prospect, User, sequelize, logger,
+    inventory: makeInventoryService(),
+    audit: makeRedeemOpsAuditService(),
+    ...overrides,
+  };
+
+  async function writeEvent(t, evt) {
+    return d.RedemptionEvent.create(
+      {
+        entitlementId: evt.entitlementId,
+        redemptionId: evt.redemptionId || null,
+        type: evt.type,
+        metadata: evt.metadata || null,
+        actorType: evt.actorType || 'staff',
+        actorUserId: evt.actorUserId || null,
+      },
+      { transaction: t }
+    );
+  }
+
+  /**
+   * Resolve a counter-presented token. Accepts the voucher token always, and the
+   * presentation token ONLY once the entitlement is unlocked (status='issued'+):
+   * post-unlock the consumer's stable /r link renders a scannable QR of their own
+   * presentation token, and the STATE MACHINE — not the token string — is the
+   * redemption gate. Pre-unlock, a presentation token at the counter is the
+   * classic mistake and gets a typed rejection.
+   */
+  async function findByVoucherToken(token) {
+    if (!token || typeof token !== 'string') return null;
+    const hash = hashToken(token.trim());
+    const entitlement = await d.RewardEntitlement.findOne({
+      where: { [Op.or]: [{ tokenHash: hash }, { presentationTokenHash: hash }] },
+      include: [
+        { model: d.RewardOffer, as: 'rewardOffer', attributes: ['id', 'title', 'publicTitle', 'partnerOrganisationId'] },
+        { model: d.Activation, as: 'activation', attributes: ['id', 'campaignNameSnapshot', 'partnerOrganisationId'] },
+        { model: d.Prospect, as: 'prospect', attributes: ['id', 'firstName', 'lastName', 'phone'] },
+      ],
+    });
+    if (!entitlement) return null;
+    entitlement._matchedViaPresentation = entitlement.presentationTokenHash === hash && entitlement.tokenHash !== hash;
+    return entitlement;
+  }
+
+  /** Verify a voucher (idempotent read + audited attempt). */
+  async function verify(token, actor, { actorType = 'staff' } = {}) {
+    const entitlement = await findByVoucherToken(token);
+    if (!entitlement) {
+      throw new AppError('Voucher not found', 404);
+    }
+    if (entitlement._matchedViaPresentation && entitlement.status === 'eligible') {
+      await writeEvent(null, {
+        entitlementId: entitlement.id, type: 'rejected', actorType,
+        actorUserId: actor?.id || null, metadata: { reason: 'reservation_pass_at_counter' },
+      });
+      throw new AppError('This is a reservation pass, not a voucher — the reward unlocks at the financial review.', 422);
+    }
+
+    await writeEvent(null, {
+      entitlementId: entitlement.id, type: 'verify_attempt', actorType,
+      actorUserId: actor?.id || null,
+    });
+
+    const expired = entitlement.expiresAt && new Date(entitlement.expiresAt) < new Date();
+    return {
+      entitlement,
+      valid: entitlement.status === 'issued' && !expired,
+      state: entitlement.status === 'issued' && expired ? 'expired' : entitlement.status,
+      reward: {
+        title: entitlement.rewardOffer?.publicTitle || entitlement.rewardOffer?.title,
+        tokenHint: entitlement.tokenHint,
+        expiresAt: entitlement.expiresAt,
+      },
+      // Fulfilment-context identity (redemptions.verify capability unmasks)
+      holder: entitlement.prospect
+        ? { firstName: entitlement.prospect.firstName, lastName: entitlement.prospect.lastName, phone: entitlement.prospect.phone }
+        : null,
+    };
+  }
+
+  /** Complete a redemption — exactly once. */
+  async function complete(token, { locationId = null, method = 'code', notes = null } = {}, actor, { actorType = 'staff' } = {}) {
+    const entitlement = await findByVoucherToken(token);
+    if (!entitlement) throw new AppError('Voucher not found', 404);
+    if (entitlement._matchedViaPresentation && entitlement.status === 'eligible') {
+      throw new AppError('This is a reservation pass, not a voucher — the reward unlocks at the financial review.', 422);
+    }
+
+    if (entitlement.status === 'redeemed') {
+      const existing = await d.Redemption.findOne({ where: { entitlementId: entitlement.id } });
+      return { redemption: existing, entitlement, already: true };
+    }
+    if (entitlement.status !== 'issued') {
+      throw new AppError(`Voucher is ${entitlement.status}`, 409);
+    }
+    if (entitlement.expiresAt && new Date(entitlement.expiresAt) < new Date()) {
+      throw new AppError('Voucher has expired', 409);
+    }
+    if (locationId) {
+      const location = await d.PartnerLocation.findByPk(locationId);
+      if (!location || location.partnerOrganisationId !== entitlement.activation.partnerOrganisationId) {
+        throw new AppError('Location does not belong to this reward’s partner', 400);
+      }
+    }
+
+    try {
+      const redemption = await d.sequelize.transaction(async (t) => {
+        // Conditional state transition — the concurrency gate
+        const [count] = await d.RewardEntitlement.update(
+          { status: 'redeemed' },
+          { where: { id: entitlement.id, status: 'issued' }, transaction: t }
+        );
+        if (count === 0) {
+          throw Object.assign(new Error('already'), { _already: true });
+        }
+        const created = await d.Redemption.create(
+          {
+            entitlementId: entitlement.id,
+            rewardOfferId: entitlement.rewardOfferId,
+            activationId: entitlement.activationId,
+            partnerOrganisationId: entitlement.activation.partnerOrganisationId,
+            locationId,
+            method,
+            actorType,
+            actorUserId: actor?.id || null,
+            notes,
+          },
+          { transaction: t }
+        );
+        await d.inventory.recordRedeemed({
+          offerId: entitlement.rewardOfferId, activationId: entitlement.activationId,
+          entitlementId: entitlement.id, redemptionId: created.id,
+          actorType, actorUser: actor, transaction: t,
+        });
+        await d.sequelize.query(
+          `UPDATE activations SET "redeemedCount" = "redeemedCount" + 1, "updatedAt" = NOW()
+            WHERE id = :id`,
+          { replacements: { id: entitlement.activationId }, transaction: t }
+        );
+        await writeEvent(t, {
+          entitlementId: entitlement.id, redemptionId: created.id, type: 'redeemed',
+          actorType, actorUserId: actor?.id || null, metadata: { method, locationId },
+        });
+        return created;
+      });
+      return { redemption, entitlement, already: false };
+    } catch (err) {
+      if (err?._already) {
+        const existing = await d.Redemption.findOne({ where: { entitlementId: entitlement.id } });
+        return { redemption: existing, entitlement, already: true };
+      }
+      if (err?.name === 'SequelizeUniqueConstraintError') {
+        const existing = await d.Redemption.findOne({ where: { entitlementId: entitlement.id } });
+        return { redemption: existing, entitlement, already: true };
+      }
+      throw err;
+    }
+  }
+
+  /** Authorized manual exception — reverse a completed redemption (TERMINAL for the entitlement). */
+  async function reverse(redemptionId, user, reason, requestId = null) {
+    if (!reason || !String(reason).trim()) throw new AppError('A reason is required', 400);
+    const redemption = await d.Redemption.findByPk(redemptionId);
+    if (!redemption) throw new AppError('Redemption not found', 404);
+    if (redemption.status === 'reversed') return redemption;
+
+    await d.sequelize.transaction(async (t) => {
+      await redemption.update({ status: 'reversed', notes: [redemption.notes, `REVERSED: ${reason}`].filter(Boolean).join('\n') }, { transaction: t });
+      // Terminal for the entitlement (ERD.md §3.17): cancel it; re-fulfilment = manual re-issue.
+      await d.RewardEntitlement.update(
+        { status: 'cancelled' },
+        { where: { id: redemption.entitlementId }, transaction: t }
+      );
+      await writeEvent(t, {
+        entitlementId: redemption.entitlementId, redemptionId, type: 'reversed',
+        actorType: 'staff', actorUserId: user.id, metadata: { reason },
+      });
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'redemption.overridden', entityType: 'redemption',
+        entityId: redemptionId, reason, requestId, transaction: t,
+      });
+    });
+    return redemption;
+  }
+
+  async function listRedemptions(query = {}) {
+    const where = {};
+    if (query.partnerOrganisationId) where.partnerOrganisationId = String(query.partnerOrganisationId);
+    const page = Math.max(1, parseInt(query.page, 10) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(query.limit, 10) || 25));
+    const { rows, count } = await d.Redemption.findAndCountAll({
+      where,
+      include: [
+        { model: d.RewardOffer, as: 'rewardOffer', attributes: ['id', 'title'] },
+        { model: d.PartnerOrganisation, as: 'partner', attributes: ['id', 'tradingName', 'legalName'] },
+        { model: d.User, as: 'actor', attributes: ['id', 'fullName'] },
+      ],
+      order: [['redeemedAt', 'DESC']],
+      limit, offset: (page - 1) * limit,
+    });
+    return { redemptions: rows, pagination: { page, limit, total: count, totalPages: Math.ceil(count / limit) } };
+  }
+
+  return { verify, complete, reverse, listRedemptions, findByVoucherToken };
+}
+
+const _default = makeRedemptionService();
+export default _default;

--- a/backend/src/services/redeemOps/tokens.js
+++ b/backend/src/services/redeemOps/tokens.js
@@ -1,0 +1,19 @@
+import crypto from 'crypto';
+
+/**
+ * Fulfilment tokens (docs/redeem-ops/ERD.md §3.16): random 32-byte base64url,
+ * SHA-256 at rest, shown once — never sequential or database ids.
+ */
+export function mintToken() {
+  const raw = crypto.randomBytes(32).toString('base64url');
+  return { raw, hash: hashToken(raw) };
+}
+
+export function hashToken(raw) {
+  return crypto.createHash('sha256').update(String(raw)).digest('hex');
+}
+
+/** Short human-typable voucher hint (last 4 of the raw token, uppercased). */
+export function tokenHintOf(raw) {
+  return String(raw).slice(-4).toUpperCase();
+}

--- a/backend/test/redeemOpsFulfilment.test.js
+++ b/backend/test/redeemOpsFulfilment.test.js
@@ -1,0 +1,247 @@
+/**
+ * Phase 6 — entitlements + redemptions (brief §37 Entitlements and redemption).
+ * The battery: anti-farming precondition, reservation→unlock→redeem lifecycle,
+ * wrong-consultant 403, reservation-pass-at-counter rejection, DOUBLE REDEMPTION
+ * impossible + idempotent replay, expiry returns inventory, hook is inert for
+ * capture (registration is composition-root-only).
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+process.env.REDEEM_OPS_ENTITLEMENTS_ENABLED = 'true'; // mounts /api/reward-claim + unlock surfaces
+
+import request from 'supertest';
+import { getApp, closeDb, createTestUser, createTestCampaign } from './helpers.js';
+import {
+  Prospect, RewardOffer, Activation, RewardEntitlement, Redemption,
+  PartnerOrganisation,
+} from '../src/models/index.js';
+import { makeEntitlementService } from '../src/services/redeemOps/entitlementService.js';
+import { makeRedemptionService } from '../src/services/redeemOps/redemptionService.js';
+import { registerLeadCapturedHook } from '../src/services/prospectService.js';
+
+let app;
+let admin, agentA, agentB, redemptionOps;
+let partner, offer, activation, campaign;
+
+const entitlements = makeEntitlementService();
+const redemptions = makeRedemptionService();
+
+async function makeVerifiedProspect(overrides = {}) {
+  return Prospect.create({
+    firstName: 'Voucher',
+    lastName: 'Holder',
+    phone: `+65${Math.floor(80000000 + Math.random() * 9999999)}`,
+    email: `holder-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@test.com`,
+    leadSource: 'website',
+    campaignId: campaign.id,
+    assignedAgentId: agentA.user.id,
+    sourceMetadata: { phoneVerifiedAt: new Date().toISOString() },
+    ...overrides,
+  });
+}
+
+beforeAll(async () => {
+  app = await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  agentA = await createTestUser({ role: 'agent' });
+  agentB = await createTestUser({ role: 'agent' });
+  redemptionOps = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'redemption_ops' });
+
+  partner = await PartnerOrganisation.create({
+    tradingName: 'Fulfilment Test Salon', normalizedName: 'fulfilment test salon', createdBy: admin.user.id,
+  });
+  campaign = await createTestCampaign(admin.user.id, { name: 'Fulfilment Campaign' });
+
+  offer = await RewardOffer.create({
+    partnerOrganisationId: partner.id, title: 'Free Express Manicure',
+    committedQuantity: 10, allocatedQuantity: 5, status: 'active',
+    claimExpiryDays: 30, redemptionExpiryDays: 90, createdBy: admin.user.id,
+  });
+  activation = await Activation.create({
+    partnerOrganisationId: partner.id, rewardOfferId: offer.id, campaignId: campaign.id,
+    campaignNameSnapshot: campaign.name, allocatedQuantity: 5, status: 'active',
+    unlockPolicy: 'agent_unlock', createdBy: admin.user.id,
+  });
+});
+
+afterAll(async () => {
+  registerLeadCapturedHook(null);
+  await closeDb();
+});
+
+const auth = (t) => ({ Authorization: `Bearer ${t}` });
+
+describe('issuance preconditions (anti-farming)', () => {
+  test('an UNVERIFIED lead never earns an entitlement', async () => {
+    const prospect = await makeVerifiedProspect({ sourceMetadata: {} });
+    const r = await entitlements.issueForProspect(prospect);
+    expect(r.entitlement).toBeNull();
+    expect(r.reason).toBe('phone_not_verified');
+  });
+
+  test('quarantined leads never earn one', async () => {
+    const prospect = await makeVerifiedProspect({ quarantinedAt: new Date(), quarantineReason: 'no_funded_agent' });
+    const r = await entitlements.issueForProspect(prospect);
+    expect(r.reason).toBe('quarantined');
+  });
+
+  test('verified lead on the active activation → locked reservation; duplicate issuance collapses to one', async () => {
+    const prospect = await makeVerifiedProspect();
+    const [a, b] = await Promise.all([
+      entitlements.issueForProspect(prospect, { via: 'hook' }),
+      entitlements.issueForProspect(prospect, { via: 'sweep' }),
+    ]);
+    const issued = [a, b].filter((r) => r.entitlement && r.reason === null);
+    const dupes = [a, b].filter((r) => r.reason === 'duplicate' || r.reason === 'allocation_exhausted');
+    expect(issued.length + dupes.length).toBe(2);
+    expect(issued.length).toBeGreaterThanOrEqual(1);
+
+    const rows = await RewardEntitlement.findAll({ where: { prospectId: prospect.id } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe('eligible'); // agent_unlock → locked, no voucher yet
+    expect(rows[0].tokenHash).toBeNull();
+  });
+});
+
+describe('unlock at the meeting', () => {
+  let prospect, issueResult;
+
+  beforeAll(async () => {
+    prospect = await makeVerifiedProspect();
+    issueResult = await entitlements.issueForProspect(prospect);
+    expect(issueResult.reason).toBeNull();
+  });
+
+  test('reservation pass at the counter (pre-unlock) → typed rejection', async () => {
+    const res = await request(app)
+      .post('/api/redeem-ops/redemptions/verify')
+      .set(auth(redemptionOps.token))
+      .send({ token: issueResult.presentationToken });
+    expect(res.status).toBe(422);
+    expect(res.body.message).toContain('reservation pass');
+  });
+
+  test('the WRONG consultant cannot unlock', async () => {
+    await expect(
+      entitlements.unlockEntitlement({ presentationToken: issueResult.presentationToken }, agentB.user)
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  test('assigned consultant unlocks (scan); replay is idempotent', async () => {
+    const first = await entitlements.unlockEntitlement(
+      { presentationToken: issueResult.presentationToken }, agentA.user, 'agent_scan'
+    );
+    expect(first.already).toBe(false);
+    expect(first.voucherToken).toBeTruthy();
+    expect(first.entitlement.status).toBe('issued');
+    expect(first.entitlement.unlockedByUserId).toBe(agentA.user.id);
+
+    const replay = await entitlements.unlockEntitlement(
+      { presentationToken: issueResult.presentationToken }, agentA.user, 'agent_scan'
+    );
+    expect(replay.already).toBe(true);
+
+    // stash for redemption tests
+    prospect._voucherToken = first.voucherToken;
+    globalThis.__voucher = first.voucherToken;
+    globalThis.__presentation = issueResult.presentationToken;
+  });
+
+  test('verify now unmasks holder + shows VALID; post-unlock the presentation token also verifies', async () => {
+    const res = await request(app)
+      .post('/api/redeem-ops/redemptions/verify')
+      .set(auth(redemptionOps.token))
+      .send({ token: globalThis.__voucher });
+    expect(res.status).toBe(200);
+    expect(res.body.data.valid).toBe(true);
+    expect(res.body.data.holder.firstName).toBe('Voucher');
+
+    const viaPass = await request(app)
+      .post('/api/redeem-ops/redemptions/verify')
+      .set(auth(redemptionOps.token))
+      .send({ token: globalThis.__presentation });
+    expect(viaPass.status).toBe(200);
+    expect(viaPass.body.data.valid).toBe(true);
+  });
+});
+
+describe('redemption — exactly once', () => {
+  test('CONCURRENT completes → one redemption row; replays return already:true', async () => {
+    const results = await Promise.all([
+      redemptions.complete(globalThis.__voucher, {}, redemptionOps.user),
+      redemptions.complete(globalThis.__voucher, {}, redemptionOps.user),
+      redemptions.complete(globalThis.__presentation, {}, redemptionOps.user),
+    ]);
+    const fresh = results.filter((r) => !r.already);
+    expect(fresh).toHaveLength(1);
+
+    const rows = await Redemption.findAll({ where: { entitlementId: results[0].redemption.entitlementId } });
+    expect(rows).toHaveLength(1);
+
+    const viaHttp = await request(app)
+      .post('/api/redeem-ops/redemptions/complete')
+      .set(auth(redemptionOps.token))
+      .send({ token: globalThis.__voucher });
+    expect(viaHttp.status).toBe(200);
+    expect(viaHttp.body.data.already).toBe(true);
+
+    await offer.reload();
+    expect(offer.redeemedQuantity).toBe(1);
+  });
+
+  test('garbage tokens are rejected server-side', async () => {
+    const res = await request(app)
+      .post('/api/redeem-ops/redemptions/verify')
+      .set(auth(redemptionOps.token))
+      .send({ token: 'not-a-real-token-000000' });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('expiry returns inventory', () => {
+  test('expired reservation → status expired, issued counters roll back', async () => {
+    const prospect = await makeVerifiedProspect();
+    const r = await entitlements.issueForProspect(prospect);
+    expect(r.reason).toBeNull();
+    await RewardEntitlement.update(
+      { expiresAt: new Date(Date.now() - 1000) },
+      { where: { id: r.entitlement.id } }
+    );
+    const before = (await Activation.findByPk(activation.id)).issuedCount;
+    const expired = await entitlements.expireReservations();
+    expect(expired).toBeGreaterThanOrEqual(1);
+
+    const row = await RewardEntitlement.findByPk(r.entitlement.id);
+    expect(row.status).toBe('expired');
+    const after = (await Activation.findByPk(activation.id)).issuedCount;
+    expect(after).toBe(before - 1);
+  });
+});
+
+describe('public consumer claim endpoint', () => {
+  test('renders reservation state, then voucher state on the SAME link', async () => {
+    const prospect = await makeVerifiedProspect();
+    const r = await entitlements.issueForProspect(prospect);
+    expect(r.reason).toBeNull();
+
+    const locked = await request(app).get(`/api/reward-claim/${r.presentationToken}`);
+    expect(locked.status).toBe(200);
+    expect(locked.body.data.state).toBe('reserved');
+    expect(locked.body.data.pass.qrDataUrl).toContain('data:image/png');
+
+    await entitlements.unlockEntitlement({ presentationToken: r.presentationToken }, agentA.user);
+    const unlocked = await request(app).get(`/api/reward-claim/${r.presentationToken}`);
+    expect(unlocked.body.data.state).toBe('unlocked');
+    expect(unlocked.body.data.voucher.qrDataUrl).toContain('data:image/png');
+  });
+});
+
+describe('capture-hook seam', () => {
+  test('prospectService exposes the registry; unregistered = no-op (capture unaffected)', async () => {
+    const mod = await import('../src/services/prospectService.js');
+    expect(typeof mod.registerLeadCapturedHook).toBe('function');
+    expect(typeof mod.makeProspectService).toBe('function');
+    // Registering and clearing must never throw — the default dep is null-safe.
+    mod.registerLeadCapturedHook(() => {});
+    mod.registerLeadCapturedHook(null);
+  });
+});

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -218,4 +218,22 @@ export const redeemOpsApi = {
     const res = await apiClient.get(`/redeem-ops/activations/${id}/campaign-metrics`);
     return res.data;
   },
+
+  // ── Fulfilment (Phase 6) ───────────────────────────────────────────────
+  async listEntitlements(params = {}) {
+    const res = await apiClient.get('/redeem-ops/entitlements', params);
+    return res.data;
+  },
+  async verifyVoucher(token) {
+    const res = await apiClient.post('/redeem-ops/redemptions/verify', { token });
+    return res.data;
+  },
+  async completeRedemption(token, extra = {}) {
+    const res = await apiClient.post('/redeem-ops/redemptions/complete', { token, ...extra });
+    return res.data;
+  },
+  async listRedemptions(params = {}) {
+    const res = await apiClient.get('/redeem-ops/redemptions', params);
+    return res.data;
+  },
 };

--- a/src/components/layout/DashboardLayout.jsx
+++ b/src/components/layout/DashboardLayout.jsx
@@ -111,6 +111,7 @@ const getNavigationItems = (user) => {
  { title: 'Pools', url: '/redeem-ops/pools', icon: Package, capability: 'pools.claim_next' },
  { title: 'Rewards', url: '/redeem-ops/rewards', icon: Package, capability: 'rewards.view' },
  { title: 'Activations', url: '/redeem-ops/activations', icon: Link2, capability: 'activations.view' },
+ { title: 'Redemptions', url: '/redeem-ops/redemptions', icon: QrCode, capability: 'redemptions.verify' },
  { title: 'Team', url: '/redeem-ops/team', icon: Users, capability: 'analytics.view_team' },
  ].filter((item) => !item.capability || hasRedeemOpsCapability(user, item.capability)),
  },

--- a/src/pages/RewardClaim.jsx
+++ b/src/pages/RewardClaim.jsx
@@ -1,0 +1,113 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { apiClient } from '@/api/client';
+
+/**
+ * Consumer reward page — redeem.sg/r/:token (docs/redeem-ops/ROUTE_MAP.md).
+ * One stable link, state-dependent render: reservation pass while locked,
+ * scannable voucher once the consultant unlocks it. Public + token-authenticated;
+ * deliberately dependency-light (no dashboard chrome).
+ */
+export default function RewardClaim() {
+  const { token } = useParams();
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiClient.get(`/reward-claim/${encodeURIComponent(token)}`)
+      .then((res) => { if (!cancelled) setData(res.data); })
+      .catch((err) => { if (!cancelled) setError(err.status === 404 ? 'This link is not valid.' : 'Something went wrong — try again shortly.'); });
+    return () => { cancelled = true; };
+  }, [token]);
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background p-6">
+        <p className="text-muted-foreground">{error}</p>
+      </div>
+    );
+  }
+  if (!data) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-ring" />
+      </div>
+    );
+  }
+
+  const { state, reward, firstName, expiresAt, pass, voucher } = data;
+  const expiry = expiresAt ? new Date(expiresAt).toLocaleDateString('en-SG', { day: 'numeric', month: 'short', year: 'numeric' }) : null;
+
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-6">
+      <div className="w-full max-w-md rounded-2xl border border-border bg-card p-8 text-center space-y-4 shadow-sm">
+        <p className="text-sm text-muted-foreground">
+          {firstName ? `Hi ${firstName},` : 'Hello,'}
+        </p>
+        <h1 className="text-xl font-semibold tracking-tight">{reward?.title}</h1>
+        {reward?.partnerName && (
+          <p className="text-sm text-muted-foreground">at {reward.partnerName}</p>
+        )}
+
+        {state === 'reserved' && (
+          <>
+            <div className="rounded-xl bg-amber-50 dark:bg-amber-950/30 border border-amber-200 p-3 text-sm">
+              <p className="font-medium">Reserved for you 🎁</p>
+              <p className="text-muted-foreground mt-1">
+                Show this pass to your consultant at your complimentary financial review to unlock it.
+              </p>
+            </div>
+            {pass?.qrDataUrl && (
+              <img src={pass.qrDataUrl} alt="Reservation pass QR" className="mx-auto w-56 h-56" />
+            )}
+            <p className="text-xs text-muted-foreground">
+              This pass is not a voucher yet — only your consultant can activate it.
+              {expiry ? ` Reservation expires ${expiry}.` : ''}
+            </p>
+          </>
+        )}
+
+        {state === 'unlocked' && (
+          <>
+            <div className="rounded-xl bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-200 p-3 text-sm">
+              <p className="font-medium">Unlocked — ready to redeem 🎉</p>
+              <p className="text-muted-foreground mt-1">Show this at the counter.</p>
+            </div>
+            {voucher?.qrDataUrl && (
+              <img src={voucher.qrDataUrl} alt="Voucher QR" className="mx-auto w-56 h-56" />
+            )}
+            {voucher?.tokenHint && (
+              <p className="text-sm">or quote code <span className="font-semibold tracking-wider">{voucher.tokenHint}</span></p>
+            )}
+            {reward?.locations?.length > 0 && (
+              <div className="text-xs text-muted-foreground space-y-0.5">
+                <p className="font-medium text-foreground">Participating outlets</p>
+                {reward.locations.map((l, i) => (
+                  <p key={i}>{[l.name, l.addressLine, l.postalCode && `S${l.postalCode}`].filter(Boolean).join(' · ')}</p>
+                ))}
+              </div>
+            )}
+            <p className="text-xs text-muted-foreground">One-time use.{expiry ? ` Valid until ${expiry}.` : ''}</p>
+          </>
+        )}
+
+        {state === 'redeemed' && (
+          <div className="rounded-xl bg-muted p-4 text-sm">
+            <p className="font-medium">Already redeemed ✔</p>
+            <p className="text-muted-foreground mt-1">This reward has been used. Enjoy!</p>
+          </div>
+        )}
+
+        {['expired', 'cancelled', 'blocked'].includes(state) && (
+          <div className="rounded-xl bg-muted p-4 text-sm">
+            <p className="font-medium">No longer available</p>
+            <p className="text-muted-foreground mt-1">
+              This reward has {state === 'expired' ? 'expired' : 'been cancelled'}.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -13,6 +13,7 @@ import {
 
 const LeadCapture = lazy(() => import('./LeadCapture'));
 const LeadCaptureDemo = lazy(() => import('./LeadCaptureDemo'));
+const RewardClaim = lazy(() => import('./RewardClaim'));
 const PublicPreview = lazy(() => import('./public/Preview'));
 const TrackRedirect = lazy(() => import('./TrackRedirect'));
 const ShareRedirect = lazy(() => import('./ShareRedirect'));
@@ -88,6 +89,7 @@ const RedeemOpsRewards = lazy(() => import('./redeemops/RewardsPage'));
 const RedeemOpsRewardDetail = lazy(() => import('./redeemops/RewardDetail'));
 const RedeemOpsActivations = lazy(() => import('./redeemops/ActivationsPage'));
 const RedeemOpsActivationDetail = lazy(() => import('./redeemops/ActivationDetail'));
+const RedeemOpsRedemptions = lazy(() => import('./redeemops/RedemptionsPage'));
 
 function PagesContent() {
  const navigate = useNavigate();
@@ -120,6 +122,8 @@ function PagesContent() {
  <Route path="/p/:slug" element={<PublicPreview />} />
  <Route path="/t/:slug" element={<TrackRedirect />} />
  <Route path="/share/:slug" element={<ShareRedirect />} />
+ {/* Consumer reward journey — reservation pass / voucher (docs/redeem-ops/ROUTE_MAP.md) */}
+ <Route path="/r/:token" element={<RewardClaim />} />
 
  {/* Design exploration prototypes — mktr build only */}
  <Route path="/preview" element={IS_REDEEM_BUILD ? <MktrOnlyRedirect /> : <PreviewHub />} />
@@ -573,6 +577,17 @@ function PagesContent() {
  <RedeemOpsRoute capability="activations.view">
  <DashboardLayout>
  <RedeemOpsActivationDetail />
+ </DashboardLayout>
+ </RedeemOpsRoute>
+ }
+ />
+ )}
+ {REDEEM_OPS_ENABLED && (
+ <Route
+ path="/redeem-ops/redemptions" element={
+ <RedeemOpsRoute capability="redemptions.verify">
+ <DashboardLayout>
+ <RedeemOpsRedemptions />
  </DashboardLayout>
  </RedeemOpsRoute>
  }

--- a/src/pages/redeemops/RedemptionsPage.jsx
+++ b/src/pages/redeemops/RedemptionsPage.jsx
@@ -1,0 +1,149 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { redeemOpsApi } from '@/api/redeemOps';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import ScanLine from 'lucide-react/icons/scan-line';
+
+export default function RedemptionsPage() {
+  const queryClient = useQueryClient();
+  const [token, setToken] = useState('');
+  const [verified, setVerified] = useState(null);
+
+  const historyQuery = useQuery({
+    queryKey: ['redeem-ops', 'redemptions'],
+    queryFn: () => redeemOpsApi.listRedemptions(),
+  });
+
+  const verifyMutation = useMutation({
+    mutationFn: () => redeemOpsApi.verifyVoucher(token.trim()),
+    onSuccess: (data) => setVerified(data),
+    onError: (err) => {
+      setVerified(null);
+      toast.error('Verification failed', { description: err.message });
+    },
+  });
+
+  const completeMutation = useMutation({
+    mutationFn: () => redeemOpsApi.completeRedemption(token.trim()),
+    onSuccess: (data) => {
+      toast.success(data?.already ? 'Already redeemed' : 'Redeemed ✔');
+      setVerified(null); setToken('');
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'redemptions'] });
+    },
+    onError: (err) => toast.error('Redemption failed', { description: err.message }),
+  });
+
+  const redemptions = historyQuery.data?.redemptions || [];
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto space-y-4">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Redemptions</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Verify a voucher, confirm identity, redeem — double redemption is impossible.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <ScanLine className="w-4 h-4" aria-hidden="true" /> Verify a voucher
+          </CardTitle>
+          <CardDescription>Paste the scanned QR value or the full voucher code.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex gap-2">
+            <Input
+              value={token}
+              onChange={(e) => { setToken(e.target.value); setVerified(null); }}
+              placeholder="Voucher code…"
+              className="font-mono"
+            />
+            <Button disabled={!token.trim() || verifyMutation.isPending} onClick={() => verifyMutation.mutate()}>
+              {verifyMutation.isPending ? 'Checking…' : 'Verify'}
+            </Button>
+          </div>
+
+          {verified && (
+            <div className={`rounded-lg border p-4 space-y-2 ${verified.valid ? 'border-emerald-300 bg-emerald-50 dark:bg-emerald-950/30' : 'border-destructive/40 bg-destructive/5'}`}>
+              <div className="flex items-center justify-between">
+                <p className="font-medium">{verified.reward?.title}</p>
+                <Badge variant={verified.valid ? 'default' : 'destructive'}>
+                  {verified.valid ? 'VALID' : verified.state.toUpperCase()}
+                </Badge>
+              </div>
+              {verified.holder && (
+                <p className="text-sm text-muted-foreground">
+                  Holder: {[verified.holder.firstName, verified.holder.lastName].filter(Boolean).join(' ')}
+                  {verified.holder.phone ? ` · ${verified.holder.phone}` : ''}
+                </p>
+              )}
+              {verified.reward?.expiresAt && (
+                <p className="text-xs text-muted-foreground">
+                  Expires {new Date(verified.reward.expiresAt).toLocaleDateString()}
+                </p>
+              )}
+              {verified.valid && (
+                <Button
+                  size="sm"
+                  disabled={completeMutation.isPending}
+                  onClick={() => completeMutation.mutate()}
+                >
+                  {completeMutation.isPending ? 'Redeeming…' : 'Confirm redemption'}
+                </Button>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Recent redemptions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Reward</TableHead>
+                  <TableHead>Partner</TableHead>
+                  <TableHead>When</TableHead>
+                  <TableHead>By</TableHead>
+                  <TableHead>Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {redemptions.map((r) => (
+                  <TableRow key={r.id}>
+                    <TableCell className="font-medium">{r.rewardOffer?.title || '—'}</TableCell>
+                    <TableCell className="text-muted-foreground">{r.partner?.tradingName || r.partner?.legalName || '—'}</TableCell>
+                    <TableCell className="text-muted-foreground">{new Date(r.redeemedAt).toLocaleString()}</TableCell>
+                    <TableCell className="text-muted-foreground">{r.actor?.fullName || r.actorType}</TableCell>
+                    <TableCell>
+                      <Badge variant={r.status === 'completed' ? 'default' : 'destructive'}>{r.status}</Badge>
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {!historyQuery.isLoading && redemptions.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={5} className="text-center text-muted-foreground py-10">
+                      No redemptions yet.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## What this is

Phase 6 of Redeem Ops — the fulfilment engine. **The whole reward journey now works end-to-end**: verified lead → locked reservation at capture → consultant unlocks at the meeting (scan/button) → voucher email (CID-inline QR + code + live link) → one-time redemption at the partner. Dark behind `REDEEM_OPS_ENTITLEMENTS_ENABLED` (on top of `REDEEM_OPS_ENABLED`); with flags off, lead capture is **byte-identical** (the hook is a no-op unless bootstrap registers it).

## Design highlights (per `MKTR_INTEGRATION.md` §2 + `ERD.md` §3.16–3.18)
- **Anti-farming**: `POST /api/prospects` stamps `sourceMetadata.phoneVerifiedAt` server-side from the OTP marker; issuance requires the stamp + not-quarantined + ACTIVE activation with allocation. A raw unverified POST creates a lead but can never mint reward value (tested).
- **Two tokens, one link**: reservation pass at capture (consultant-scannable only), voucher minted at unlock. Post-unlock the consumer's stable `/r` link renders a scannable code — the state machine, not the token string, is the gate.
- **Exactly-once everywhere**: partial-unique `(activationId, prospectId)` collapses hook+sweep races; UNIQUE `redemptions.entitlementId` + conditional `issued→redeemed` makes double redemption schema-impossible; replays return typed `already` responses.
- **The ONE MKTR-side edit** is dependency-inverted: `prospectService` exports `registerLeadCapturedHook`; only `bootstrap` (composition root) registers the Redeem Ops callback. No MKTR file imports Redeem Ops code.
- **Consultant unlock** rides the existing HMAC surfaces (`/api/integrations/lyfe/*` lead-outcome pattern; `/api/external/*` requireExternalHmac) with assigned-consultant binding. The in-app scan screens for Lyfe / mktr-leads are follow-on work in those repos.
- **Inventory stays truthful**: unlock/redeem/expire move guarded activation+offer counters with append-only ledger rows in the same transaction; expired reservations return supply to the pool.

## Verification
- ✅ New DB suite covers the §37 battery (see commit message for the full list) — runs in CI against postgres:15
- ✅ Vite build + eslint clean (0 errors); migration `down()` static checks pass; module-chain import smoke green
- Known-red baseline: `test/unit/shortlinkService.test.js` (identical on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)