### PR TITLE
feat(redeem-ops): Phase 7 — analytics, renewal tracking + go-live runbook

### DIFF
--- a/backend/src/controllers/redeemOps/activationsController.js
+++ b/backend/src/controllers/redeemOps/activationsController.js
@@ -71,6 +71,15 @@ export const setStatus = asyncHandler(async (req, res) => {
   res.json({ success: true, data: { activation } });
 });
 
+export const setRenewal = asyncHandler(async (req, res) => {
+  const body = validateBody(
+    Joi.object({ renewalOutcome: Joi.string().valid('renewed', 'not_renewed', 'pending').required() }),
+    req.body
+  );
+  const activation = await activationService.setRenewal(req.params.id, body.renewalOutcome, req.user, req.id);
+  res.json({ success: true, data: { activation } });
+});
+
 export const getCampaignMetrics = asyncHandler(async (req, res) => {
   const activation = await activationService.getActivation(req.params.id);
   if (!activation.campaignId) throw new AppError('No campaign linked to this activation', 400);

--- a/backend/src/routes/redeemOpsActivations.js
+++ b/backend/src/routes/redeemOpsActivations.js
@@ -26,6 +26,7 @@ router.get('/activations/:id', requireRedeemOps('activations.view'), ctrl.getAct
 router.patch('/activations/:id/campaign', requireRedeemOps('activations.link_campaign'), ctrl.linkCampaign);
 router.patch('/activations/:id/allocation', requireRedeemOps('activations.allocate_inventory'), ctrl.changeAllocation);
 router.patch('/activations/:id/status', requireRedeemOps('activations.manage'), ctrl.setStatus);
+router.patch('/activations/:id/renewal', requireRedeemOps('activations.manage'), ctrl.setRenewal);
 router.get('/activations/:id/campaign-metrics', requireRedeemOps('campaigns.read_reference'), ctrl.getCampaignMetrics);
 
 export default router;

--- a/backend/src/routes/redeemOpsAnalytics.js
+++ b/backend/src/routes/redeemOpsAnalytics.js
@@ -1,0 +1,42 @@
+import express from 'express';
+import { asyncHandler } from '../middleware/errorHandler.js';
+import { requireRedeemOps } from '../middleware/redeemOpsAuth.js';
+import analyticsService from '../services/redeemOps/analyticsService.js';
+
+/**
+ * Redeem Ops Phase 7 — analytics (docs/redeem-ops/ROUTE_MAP.md, brief §29).
+ * Read-only aggregates; execs get their own row via scope=me, team-wide views
+ * are capability-gated.
+ */
+export const meta = {
+  path: '/api/redeem-ops',
+  flag: 'REDEEM_OPS_ENABLED',
+  flagDefault: 'false',
+};
+
+const router = express.Router();
+
+router.get('/analytics/outreach', requireRedeemOps('analytics.view_own'), asyncHandler(async (req, res) => {
+  const teamWide = req.user.role === 'admin'
+    || ['super_admin', 'ops_admin', 'bdm', 'campaign_ops', 'redemption_ops', 'analyst'].includes(req.user.redeemOpsRole);
+  const ownerUserId = req.query.scope === 'me' || !teamWide ? req.user.id : null;
+  const members = await analyticsService.outreachPerformance({ ownerUserId });
+  res.json({ success: true, data: { members } });
+}));
+
+router.get('/analytics/categories', requireRedeemOps('analytics.view_team'), asyncHandler(async (req, res) => {
+  const categories = await analyticsService.categoryPerformance();
+  res.json({ success: true, data: { categories } });
+}));
+
+router.get('/analytics/rewards', requireRedeemOps('analytics.view_team'), asyncHandler(async (req, res) => {
+  const rewards = await analyticsService.rewardPerformance();
+  res.json({ success: true, data: { rewards } });
+}));
+
+router.get('/analytics/activations', requireRedeemOps('analytics.view_team'), asyncHandler(async (req, res) => {
+  const funnels = await analyticsService.activationFunnels();
+  res.json({ success: true, data: { funnels } });
+}));
+
+export default router;

--- a/backend/src/services/redeemOps/activationService.js
+++ b/backend/src/services/redeemOps/activationService.js
@@ -198,7 +198,24 @@ export function makeActivationService(overrides = {}) {
     return activation;
   }
 
-  return { listActivations, getActivation, createActivation, linkCampaign, changeAllocation, setStatus };
+  /** Record the renewal outcome (brief §29 partner renewal) — audited. */
+  async function setRenewal(id, renewalOutcome, user, requestId = null) {
+    if (!['renewed', 'not_renewed', 'pending'].includes(renewalOutcome)) {
+      throw new AppError('renewalOutcome must be renewed | not_renewed | pending', 400);
+    }
+    const activation = await getActivation(id);
+    const before = { renewalOutcome: activation.renewalOutcome };
+    await d.sequelize.transaction(async (t) => {
+      await activation.update({ renewalOutcome }, { transaction: t });
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'activation.renewal_recorded', entityType: 'activation',
+        entityId: id, before, after: { renewalOutcome }, requestId, transaction: t,
+      });
+    });
+    return activation;
+  }
+
+  return { listActivations, getActivation, createActivation, linkCampaign, changeAllocation, setStatus, setRenewal };
 }
 
 const _default = makeActivationService();

--- a/backend/src/services/redeemOps/analyticsService.js
+++ b/backend/src/services/redeemOps/analyticsService.js
@@ -1,0 +1,134 @@
+import { QueryTypes } from 'sequelize';
+import { sequelize, RewardOffer, Activation } from '../../models/index.js';
+import { makeCampaignProjection } from './campaignProjection.js';
+
+/**
+ * Redeem Ops analytics (brief §29) — plain SQL aggregates over OUR tables.
+ * Acquisition numbers are never re-counted here: activation funnels read
+ * computeCampaignMetrics via campaignProjection (MKTR stays the source of truth),
+ * and nothing is invented where instrumentation doesn't exist.
+ */
+export function makeAnalyticsService(overrides = {}) {
+  const d = { sequelize, RewardOffer, Activation, campaigns: makeCampaignProjection(), ...overrides };
+
+  /** Per-team-member outreach performance. `ownerUserId` limits to one member (exec self-view). */
+  async function outreachPerformance({ ownerUserId = null } = {}) {
+    const rows = await d.sequelize.query(
+      `SELECT u.id AS "userId",
+              COALESCE(u."fullName", u.email) AS "name",
+              COUNT(p.id) FILTER (WHERE p."ownerUserId" = u.id)::int AS "owned",
+              COUNT(p.id) FILTER (WHERE p."ownerUserId" = u.id AND p."firstOutreachAt" IS NOT NULL)::int AS "contacted",
+              COUNT(p.id) FILTER (WHERE p."ownerUserId" = u.id AND p."staleFlag")::int AS "stale",
+              COUNT(p.id) FILTER (WHERE p."ownerUserId" = u.id AND p."pipelineStage" = 'PARTNERED')::int AS "partnered",
+              ROUND(AVG(EXTRACT(EPOCH FROM (p."firstOutreachAt" - p."claimedAt")) / 3600)
+                    FILTER (WHERE p."ownerUserId" = u.id AND p."firstOutreachAt" IS NOT NULL AND p."claimedAt" IS NOT NULL))::int
+                AS "avgHoursToFirstOutreach"
+         FROM users u
+         LEFT JOIN partner_organisations p
+           ON p."ownerUserId" = u.id AND p."mergedIntoId" IS NULL AND p."archivedAt" IS NULL
+        WHERE (u.role = 'redeem_ops' OR u."redeemOpsRole" IS NOT NULL)
+          AND (:ownerUserId::uuid IS NULL OR u.id = :ownerUserId::uuid)
+        GROUP BY u.id, u."fullName", u.email
+        ORDER BY "owned" DESC`,
+      { replacements: { ownerUserId }, type: QueryTypes.SELECT }
+    );
+
+    const activity = await d.sequelize.query(
+      `SELECT a."actorUserId" AS "userId",
+              COUNT(*) FILTER (WHERE a.direction = 'outbound' AND a."voidedAt" IS NULL)::int AS "outboundTouches",
+              COUNT(*) FILTER (WHERE a.direction = 'inbound' AND a."voidedAt" IS NULL)::int AS "replies",
+              COUNT(*) FILTER (WHERE a.type = 'meeting_booked' AND a."voidedAt" IS NULL)::int AS "meetingsBooked",
+              COUNT(*) FILTER (WHERE a.type = 'proposal_sent' AND a."voidedAt" IS NULL)::int AS "proposalsSent"
+         FROM outreach_activities a
+        WHERE a."actorUserId" IS NOT NULL
+        GROUP BY a."actorUserId"`,
+      { type: QueryTypes.SELECT }
+    );
+    const byUser = new Map(activity.map((r) => [r.userId, r]));
+    return rows.map((r) => ({
+      ...r,
+      outboundTouches: byUser.get(r.userId)?.outboundTouches || 0,
+      replies: byUser.get(r.userId)?.replies || 0,
+      meetingsBooked: byUser.get(r.userId)?.meetingsBooked || 0,
+      proposalsSent: byUser.get(r.userId)?.proposalsSent || 0,
+      partneredRate: r.owned > 0 ? Math.round((r.partnered / r.owned) * 100) : 0,
+    }));
+  }
+
+  /** Category conversion (brief §29 "Category performance"). */
+  async function categoryPerformance() {
+    return d.sequelize.query(
+      `SELECT COALESCE(p.category, 'Uncategorised') AS category,
+              COUNT(*)::int AS total,
+              COUNT(*) FILTER (WHERE p."firstOutreachAt" IS NOT NULL)::int AS contacted,
+              COUNT(*) FILTER (WHERE p."pipelineStage" IN ('REPLIED','MEETING_BOOKED','MEETING_COMPLETED','PROPOSAL_SENT','NEGOTIATING','PARTNERED'))::int AS replied,
+              COUNT(*) FILTER (WHERE p."pipelineStage" IN ('MEETING_BOOKED','MEETING_COMPLETED','PROPOSAL_SENT','NEGOTIATING','PARTNERED'))::int AS meetings,
+              COUNT(*) FILTER (WHERE p."pipelineStage" = 'PARTNERED')::int AS partnered
+         FROM partner_organisations p
+        WHERE p."mergedIntoId" IS NULL AND p."archivedAt" IS NULL
+        GROUP BY COALESCE(p.category, 'Uncategorised')
+        ORDER BY total DESC
+        LIMIT 50`,
+      { type: QueryTypes.SELECT }
+    );
+  }
+
+  /** Reward supply performance — counters are already ledger-audited truth. */
+  async function rewardPerformance() {
+    const offers = await d.RewardOffer.findAll({
+      include: [{ association: 'partner', attributes: ['tradingName', 'legalName'] }],
+      order: [['createdAt', 'DESC']],
+      limit: 100,
+    });
+    return offers.map((o) => ({
+      id: o.id,
+      title: o.title,
+      partnerName: o.partner?.tradingName || o.partner?.legalName || null,
+      status: o.status,
+      committed: o.committedQuantity,
+      allocated: o.allocatedQuantity,
+      issued: o.issuedQuantity,
+      redeemed: o.redeemedQuantity,
+      redemptionRate: o.issuedQuantity > 0 ? Math.round((o.redeemedQuantity / o.issuedQuantity) * 100) : 0,
+    }));
+  }
+
+  /** Activation funnel — MKTR acquisition (never re-counted) + our fulfilment counters. */
+  async function activationFunnels() {
+    const activations = await d.Activation.findAll({
+      include: [
+        { association: 'rewardOffer', attributes: ['title'] },
+        { association: 'partner', attributes: ['tradingName', 'legalName'] },
+      ],
+      order: [['createdAt', 'DESC']],
+      limit: 50,
+    });
+    const funnels = [];
+    for (const a of activations) {
+      let acquisition = null;
+      if (a.campaignId) {
+        acquisition = await d.campaigns.getCampaignMetrics(a.campaignId).catch(() => null);
+      }
+      funnels.push({
+        id: a.id,
+        rewardTitle: a.rewardOffer?.title,
+        partnerName: a.partner?.tradingName || a.partner?.legalName || null,
+        campaignName: a.campaignNameSnapshot,
+        status: a.status,
+        renewalOutcome: a.renewalOutcome,
+        acquisition, // MKTR's own numbers (computeCampaignMetrics) or null when unlinked
+        reward: {
+          allocated: a.allocatedQuantity,
+          issued: a.issuedCount,
+          redeemed: a.redeemedCount,
+        },
+      });
+    }
+    return funnels;
+  }
+
+  return { outreachPerformance, categoryPerformance, rewardPerformance, activationFunnels };
+}
+
+const _default = makeAnalyticsService();
+export default _default;

--- a/docs/redeem-ops/IMPLEMENTATION_PLAN.md
+++ b/docs/redeem-ops/IMPLEMENTATION_PLAN.md
@@ -165,3 +165,32 @@ contacts, activities, follow-ups, daily queue → Phases 2–3. 10. Pipeline mov
 audit. 14. No second campaign builder → enforced by `RECOMMENDED_ARCHITECTURE.md` §10 +
 projection-only campaign access. 15. No duplicate lead DB → entitlements reference `prospects.id`
 only.
+
+## BUILD STATUS — 2026-07-09: Phases 1–7 SHIPPED (dark)
+
+All phases are merged to `main` and deployed dark:
+PR #94 (Phase 1, Codex-reviewed), #95 (Phases 2+3 = V1), #96 (Phases 4+5),
+#97 (Phase 6), Phase 7 analytics in the follow-on PR. Every CI run was at the
+house baseline (only the pre-existing `test/unit/shortlinkService.test.js`
+failure, identical on main). Migrations 045–050 are applied to production by
+the auto-deploy (all additive; routes stay unmounted).
+
+**Go-live runbook (user-side actions — env + DNS are dashboard operations):**
+1. Render `mktr-backend-jo6r`: set `REDEEM_OPS_ENABLED=true` → mounts
+   `/api/redeem-ops/*`, schedules the stale sweep.
+2. Render `mktr-platform` static site: set `VITE_REDEEM_OPS_ENABLED=true` +
+   redeploy → `/redeem-ops/*` dogfood surface on mktr.sg (admins see the nav).
+3. Invite the outreach staff from `/redeem-ops/team` (sub-role at invite).
+4. When V1 is validated: create the `ops.redeem.sg` static site per
+   `RECOMMENDED_ARCHITECTURE.md` §5 (VITE_SURFACE build gate = follow-on task;
+   interim: same mktr build) + Cloudflare CNAME.
+5. Rewards go-live needs nothing extra (same flag). Voucher issuance
+   additionally needs `REDEEM_OPS_ENTITLEMENTS_ENABLED=true` (hook + sweeps +
+   `/api/reward-claim` + unlock surfaces).
+6. Consultant-app scan/unlock screens are follow-on work in the `lyfe-app` and
+   `mktr-leads` repos (endpoints live: `POST /api/integrations/lyfe/entitlement-unlock`,
+   `POST /api/external/entitlements/unlock`).
+
+**Deferred (documented, not blocking):** `VITE_SURFACE=ops` bundle isolation
+(host guard + capabilities already enforce the boundary server-side), CSV
+import (§32), global search (§33), partner portal (future).

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -236,4 +236,26 @@ export const redeemOpsApi = {
     const res = await apiClient.get('/redeem-ops/redemptions', params);
     return res.data;
   },
+
+  // ── Analytics (Phase 7) ────────────────────────────────────────────────
+  async getOutreachAnalytics(params = {}) {
+    const res = await apiClient.get('/redeem-ops/analytics/outreach', params);
+    return res.data;
+  },
+  async getCategoryAnalytics() {
+    const res = await apiClient.get('/redeem-ops/analytics/categories');
+    return res.data;
+  },
+  async getRewardAnalytics() {
+    const res = await apiClient.get('/redeem-ops/analytics/rewards');
+    return res.data;
+  },
+  async getActivationAnalytics() {
+    const res = await apiClient.get('/redeem-ops/analytics/activations');
+    return res.data;
+  },
+  async setActivationRenewal(id, renewalOutcome) {
+    const res = await apiClient.patch(`/redeem-ops/activations/${id}/renewal`, { renewalOutcome });
+    return res.data?.activation;
+  },
 };

--- a/src/components/layout/DashboardLayout.jsx
+++ b/src/components/layout/DashboardLayout.jsx
@@ -112,6 +112,7 @@ const getNavigationItems = (user) => {
  { title: 'Rewards', url: '/redeem-ops/rewards', icon: Package, capability: 'rewards.view' },
  { title: 'Activations', url: '/redeem-ops/activations', icon: Link2, capability: 'activations.view' },
  { title: 'Redemptions', url: '/redeem-ops/redemptions', icon: QrCode, capability: 'redemptions.verify' },
+ { title: 'Analytics', url: '/redeem-ops/analytics', icon: DollarSign, capability: 'analytics.view_own' },
  { title: 'Team', url: '/redeem-ops/team', icon: Users, capability: 'analytics.view_team' },
  ].filter((item) => !item.capability || hasRedeemOpsCapability(user, item.capability)),
  },

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -90,6 +90,7 @@ const RedeemOpsRewardDetail = lazy(() => import('./redeemops/RewardDetail'));
 const RedeemOpsActivations = lazy(() => import('./redeemops/ActivationsPage'));
 const RedeemOpsActivationDetail = lazy(() => import('./redeemops/ActivationDetail'));
 const RedeemOpsRedemptions = lazy(() => import('./redeemops/RedemptionsPage'));
+const RedeemOpsAnalytics = lazy(() => import('./redeemops/AnalyticsPage'));
 
 function PagesContent() {
  const navigate = useNavigate();
@@ -588,6 +589,17 @@ function PagesContent() {
  <RedeemOpsRoute capability="redemptions.verify">
  <DashboardLayout>
  <RedeemOpsRedemptions />
+ </DashboardLayout>
+ </RedeemOpsRoute>
+ }
+ />
+ )}
+ {REDEEM_OPS_ENABLED && (
+ <Route
+ path="/redeem-ops/analytics" element={
+ <RedeemOpsRoute capability="analytics.view_own">
+ <DashboardLayout>
+ <RedeemOpsAnalytics />
  </DashboardLayout>
  </RedeemOpsRoute>
  }

--- a/src/pages/redeemops/AnalyticsPage.jsx
+++ b/src/pages/redeemops/AnalyticsPage.jsx
@@ -1,0 +1,189 @@
+import { useQuery } from '@tanstack/react-query';
+import { redeemOpsApi } from '@/api/redeemOps';
+import { useAuthStore } from '@/stores/authStore';
+import { hasCapability } from '@/lib/redeemOpsPermissions';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+
+function Section({ title, description, children }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{title}</CardTitle>
+        {description && <CardDescription>{description}</CardDescription>}
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">{children}</div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function AnalyticsPage() {
+  const user = useAuthStore((s) => s.user);
+  const teamWide = hasCapability(user, 'analytics.view_team');
+
+  const outreach = useQuery({
+    queryKey: ['redeem-ops', 'analytics', 'outreach'],
+    queryFn: () => redeemOpsApi.getOutreachAnalytics(),
+  });
+  const categories = useQuery({
+    queryKey: ['redeem-ops', 'analytics', 'categories'],
+    queryFn: () => redeemOpsApi.getCategoryAnalytics(),
+    enabled: teamWide,
+  });
+  const rewards = useQuery({
+    queryKey: ['redeem-ops', 'analytics', 'rewards'],
+    queryFn: () => redeemOpsApi.getRewardAnalytics(),
+    enabled: teamWide,
+  });
+  const funnels = useQuery({
+    queryKey: ['redeem-ops', 'analytics', 'activations'],
+    queryFn: () => redeemOpsApi.getActivationAnalytics(),
+    enabled: teamWide,
+  });
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto space-y-4">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Analytics</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Acquisition numbers come from MKTR's own metrics — nothing is re-counted here.
+        </p>
+      </div>
+
+      <Section title={teamWide ? 'Outreach — by team member' : 'Outreach — your performance'}>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Member</TableHead>
+              <TableHead className="text-right">Owned</TableHead>
+              <TableHead className="text-right">Contacted</TableHead>
+              <TableHead className="text-right">Touches</TableHead>
+              <TableHead className="text-right">Replies</TableHead>
+              <TableHead className="text-right">Meetings</TableHead>
+              <TableHead className="text-right">Proposals</TableHead>
+              <TableHead className="text-right">Partnered</TableHead>
+              <TableHead className="text-right">Conv.</TableHead>
+              <TableHead className="text-right">Avg h → 1st touch</TableHead>
+              <TableHead className="text-right">Stale</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {(outreach.data?.members || []).map((m) => (
+              <TableRow key={m.userId}>
+                <TableCell className="font-medium">{m.name}</TableCell>
+                <TableCell className="text-right">{m.owned}</TableCell>
+                <TableCell className="text-right">{m.contacted}</TableCell>
+                <TableCell className="text-right">{m.outboundTouches}</TableCell>
+                <TableCell className="text-right">{m.replies}</TableCell>
+                <TableCell className="text-right">{m.meetingsBooked}</TableCell>
+                <TableCell className="text-right">{m.proposalsSent}</TableCell>
+                <TableCell className="text-right">{m.partnered}</TableCell>
+                <TableCell className="text-right">{m.partneredRate}%</TableCell>
+                <TableCell className="text-right">{m.avgHoursToFirstOutreach ?? '—'}</TableCell>
+                <TableCell className="text-right">{m.stale}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Section>
+
+      {teamWide && (
+        <>
+          <Section title="Category conversion" description="Where outreach converts — and where it doesn't.">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Category</TableHead>
+                  <TableHead className="text-right">Total</TableHead>
+                  <TableHead className="text-right">Contacted</TableHead>
+                  <TableHead className="text-right">Replied</TableHead>
+                  <TableHead className="text-right">Meetings</TableHead>
+                  <TableHead className="text-right">Partnered</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(categories.data?.categories || []).map((c) => (
+                  <TableRow key={c.category}>
+                    <TableCell className="font-medium">{c.category}</TableCell>
+                    <TableCell className="text-right">{c.total}</TableCell>
+                    <TableCell className="text-right">{c.contacted}</TableCell>
+                    <TableCell className="text-right">{c.replied}</TableCell>
+                    <TableCell className="text-right">{c.meetings}</TableCell>
+                    <TableCell className="text-right">{c.partnered}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Section>
+
+          <Section title="Reward supply" description="Committed → allocated → issued → redeemed (ledger-audited counters).">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Reward</TableHead>
+                  <TableHead>Partner</TableHead>
+                  <TableHead className="text-right">Committed</TableHead>
+                  <TableHead className="text-right">Allocated</TableHead>
+                  <TableHead className="text-right">Issued</TableHead>
+                  <TableHead className="text-right">Redeemed</TableHead>
+                  <TableHead className="text-right">Redemption rate</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(rewards.data?.rewards || []).map((r) => (
+                  <TableRow key={r.id}>
+                    <TableCell className="font-medium">{r.title}</TableCell>
+                    <TableCell className="text-muted-foreground">{r.partnerName || '—'}</TableCell>
+                    <TableCell className="text-right">{r.committed}</TableCell>
+                    <TableCell className="text-right">{r.allocated}</TableCell>
+                    <TableCell className="text-right">{r.issued}</TableCell>
+                    <TableCell className="text-right">{r.redeemed}</TableCell>
+                    <TableCell className="text-right">{r.redemptionRate}%</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Section>
+
+          <Section title="Activation funnels" description="MKTR acquisition + Redeem fulfilment, per activation.">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Activation</TableHead>
+                  <TableHead>Campaign</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Leads (MKTR)</TableHead>
+                  <TableHead className="text-right">Issued</TableHead>
+                  <TableHead className="text-right">Redeemed</TableHead>
+                  <TableHead>Renewal</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(funnels.data?.funnels || []).map((f) => (
+                  <TableRow key={f.id}>
+                    <TableCell className="font-medium">
+                      {f.rewardTitle} <span className="text-muted-foreground">· {f.partnerName}</span>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">{f.campaignName || 'Not linked'}</TableCell>
+                    <TableCell><Badge variant={f.status === 'active' ? 'default' : 'secondary'}>{f.status}</Badge></TableCell>
+                    <TableCell className="text-right">
+                      {f.acquisition?.totalLeads ?? f.acquisition?.leads ?? '—'}
+                    </TableCell>
+                    <TableCell className="text-right">{f.reward.issued}</TableCell>
+                    <TableCell className="text-right">{f.reward.redeemed}</TableCell>
+                    <TableCell className="text-muted-foreground">{f.renewalOutcome || 'pending'}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Section>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What this is

The final phase. Outreach/category/reward/activation analytics (brief §29) with the hard rule intact: **acquisition numbers always come from MKTR's `computeCampaignMetrics`** via the read-only projection — Redeem Ops never re-counts leads. Adds the activation renewal outcome (audited) and the go-live runbook to `IMPLEMENTATION_PLAN.md`.

- `/api/redeem-ops/analytics/outreach` — per-member: owned, contacted, touches, replies, meetings, proposals, partnered + conversion, avg hours→first touch, stale count (execs auto-scoped to themselves)
- `/api/redeem-ops/analytics/categories|rewards|activations` — team-gated
- `PATCH /activations/:id/renewal` — renewed | not_renewed | pending, audited
- Analytics SPA page + nav (capability-gated)

Same dark posture; Vite build + eslint + import smoke clean.

With this merged, **Phases 1–7 are complete**: partner CRM → outreach ops (V1) → rewards + inventory ledger → activations → review-gated vouchers + redemptions → analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)