### PR TITLE
feat(redeem-ops): Fresha-language UI for the ops surface

### DIFF
--- a/src/components/redeemops/RedeemOpsLayout.jsx
+++ b/src/components/redeemops/RedeemOpsLayout.jsx
@@ -1,0 +1,123 @@
+import { useEffect } from 'react';
+import { NavLink, Link, useNavigate } from 'react-router-dom';
+import { useAuthStore } from '@/stores/authStore';
+import { hasCapability } from '@/lib/redeemOpsPermissions';
+import { RoAvatar } from '@/components/redeemops/ui';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import House from 'lucide-react/icons/house';
+import Users from 'lucide-react/icons/users';
+import Kanban from 'lucide-react/icons/kanban';
+import ListChecks from 'lucide-react/icons/list-checks';
+import Layers from 'lucide-react/icons/layers';
+import Gift from 'lucide-react/icons/gift';
+import Link2 from 'lucide-react/icons/link-2';
+import QrCode from 'lucide-react/icons/qr-code';
+import ChartColumn from 'lucide-react/icons/chart-column';
+import UserCog from 'lucide-react/icons/user-cog';
+import Shield from 'lucide-react/icons/shield';
+import LogOut from 'lucide-react/icons/log-out';
+import '@/styles/redeem-ops-theme.css';
+
+/**
+ * Fresha-language shell for /redeem-ops/* (design source of truth:
+ * claude.ai/design "Redeem Ops Design System"): slim dark icon rail on white
+ * canvas. Nav items mirror the capability their page requires, same as the
+ * route guards — nobody sees a link the API would 403.
+ */
+const NAV = [
+  { title: 'Queue', url: '/redeem-ops/queue', icon: House },
+  { title: 'Partners', url: '/redeem-ops/partners', icon: Users, capability: 'partners.view' },
+  { title: 'Pipeline', url: '/redeem-ops/pipeline', icon: Kanban, capability: 'pipeline.view_team' },
+  { title: 'Tasks', url: '/redeem-ops/tasks', icon: ListChecks, capability: 'tasks.manage' },
+  { title: 'Pools', url: '/redeem-ops/pools', icon: Layers, capability: 'pools.claim_next' },
+  { title: 'Rewards', url: '/redeem-ops/rewards', icon: Gift, capability: 'rewards.view' },
+  { title: 'Activations', url: '/redeem-ops/activations', icon: Link2, capability: 'activations.view' },
+  { title: 'Redemptions', url: '/redeem-ops/redemptions', icon: QrCode, capability: 'redemptions.verify' },
+  { title: 'Analytics', url: '/redeem-ops/analytics', icon: ChartColumn, capability: 'analytics.view_own' },
+  { title: 'Team', url: '/redeem-ops/team', icon: UserCog, capability: 'analytics.view_team' },
+];
+
+const FIGTREE_LINK_ID = 'ro-figtree-font';
+
+export default function RedeemOpsLayout({ children }) {
+  const user = useAuthStore((s) => s.user);
+  const logout = useAuthStore((s) => s.logout);
+  const navigate = useNavigate();
+
+  // Figtree loads only when a Redeem Ops screen mounts — the mktr admin and
+  // both public brands never pay for it. The link persists once added (fonts
+  // cache; removing it on unmount would just cause refetch churn).
+  useEffect(() => {
+    if (document.getElementById(FIGTREE_LINK_ID)) return;
+    const link = document.createElement('link');
+    link.id = FIGTREE_LINK_ID;
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Figtree:wght@400;500;600;700;800&display=swap';
+    document.head.appendChild(link);
+  }, []);
+
+  const items = NAV.filter((item) => !item.capability || hasCapability(user, item.capability));
+  const displayName = user?.fullName || [user?.firstName, user?.lastName].filter(Boolean).join(' ') || user?.email || 'Me';
+
+  const handleLogout = () => {
+    logout();
+    navigate('/CustomerLogin');
+  };
+
+  return (
+    <div className="ro-app">
+      <aside className="ro-rail" aria-label="Redeem Ops navigation">
+        <Link to="/redeem-ops" className="ro-rail-logo" aria-label="Redeem Ops home">
+          R
+        </Link>
+        <nav className="ro-rail-nav">
+          {items.map((item) => (
+            <NavLink
+              key={item.url}
+              to={item.url}
+              className={({ isActive }) => `ro-rail-item${isActive ? ' active' : ''}`}
+            >
+              <item.icon aria-hidden="true" />
+              <span>{item.title}</span>
+            </NavLink>
+          ))}
+        </nav>
+        <div className="ro-rail-me">
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              className="rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-label="Account menu"
+            >
+              <RoAvatar name={displayName} size={34} title={displayName} />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent side="right" align="end" className="w-56">
+              <DropdownMenuLabel className="font-normal">
+                <p className="text-sm font-semibold m-0">{displayName}</p>
+                <p className="text-xs text-muted-foreground m-0 truncate">{user?.email}</p>
+              </DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              {user?.role === 'admin' && (
+                <DropdownMenuItem onClick={() => navigate('/AdminDashboard')}>
+                  <Shield className="w-4 h-4 mr-2" aria-hidden="true" />
+                  MKTR admin console
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuItem onClick={handleLogout}>
+                <LogOut className="w-4 h-4 mr-2" aria-hidden="true" />
+                Log out
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </aside>
+      <main className="ro-main">{children}</main>
+    </div>
+  );
+}

--- a/src/components/redeemops/ui.jsx
+++ b/src/components/redeemops/ui.jsx
@@ -1,0 +1,169 @@
+/**
+ * Redeem Ops Fresha-language primitives (design source of truth:
+ * claude.ai/design "Redeem Ops Design System"). Pure presentational helpers —
+ * behaviour stays in shadcn/Radix components, which pick up the theme via the
+ * variables in src/styles/redeem-ops-theme.css.
+ */
+import { cn } from '@/lib/utils';
+
+/** Sentence-case a SCREAMING_SNAKE enum: MEETING_BOOKED → "Meeting booked". */
+export function prettyEnum(value) {
+  if (!value) return '';
+  const s = String(value).replaceAll('_', ' ').toLowerCase();
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+/* 14 pipeline stages → six pastel families (stage-tags card). */
+const STAGE_TAG = {
+  UNCLAIMED: 'ro-tag--outline',
+  CLAIMED: 'ro-tag--gray',
+  RESEARCHING: 'ro-tag--gray',
+  CONTACTED: 'ro-tag--yellow',
+  REPLIED: 'ro-tag--blue',
+  MEETING_BOOKED: 'ro-tag--blue',
+  MEETING_COMPLETED: 'ro-tag--blue',
+  PROPOSAL_SENT: 'ro-tag--purple',
+  NEGOTIATING: 'ro-tag--purple',
+  PARTNERED: 'ro-tag--green',
+  FOLLOW_UP_LATER: 'ro-tag--yellow ro-tag--faded',
+  NO_RESPONSE: 'ro-tag--yellow ro-tag--faded',
+  NOT_INTERESTED: 'ro-tag--gray ro-tag--faded',
+  DISQUALIFIED: 'ro-tag--red',
+};
+
+export function RoStageTag({ stage, size, className }) {
+  return (
+    <span className={cn('ro-tag', STAGE_TAG[stage] || 'ro-tag--gray', size === 'sm' && 'ro-tag--sm', className)}>
+      {prettyEnum(stage)}
+    </span>
+  );
+}
+
+/* Generic status/priority tag; tone keys cover every enum the pages render. */
+const TONE_TAG = {
+  // reward / activation status
+  active: 'ro-tag--green',
+  draft: 'ro-tag--gray',
+  paused: 'ro-tag--yellow',
+  ended: 'ro-tag--gray ro-tag--faded',
+  archived: 'ro-tag--gray ro-tag--faded',
+  // tasks
+  open: 'ro-tag--blue',
+  completed: 'ro-tag--green',
+  cancelled: 'ro-tag--gray ro-tag--faded',
+  // priority
+  high: 'ro-tag--red',
+  medium: 'ro-tag--yellow',
+  low: 'ro-tag--gray',
+  // onboarding
+  done: 'ro-tag--green',
+  in_progress: 'ro-tag--blue',
+  pending: 'ro-tag--outline',
+  na: 'ro-tag--gray ro-tag--faded',
+  // entitlements / redemptions
+  reserved: 'ro-tag--yellow',
+  issued: 'ro-tag--blue',
+  redeemed: 'ro-tag--green',
+  expired: 'ro-tag--gray ro-tag--faded',
+  void: 'ro-tag--red ro-tag--faded',
+  // misc
+  primary: 'ro-tag--blue',
+  inactive: 'ro-tag--gray ro-tag--faded',
+};
+
+export function RoTag({ tone, size, className, children }) {
+  return (
+    <span className={cn('ro-tag', TONE_TAG[tone] || 'ro-tag--gray', size === 'sm' && 'ro-tag--sm', className)}>
+      {children}
+    </span>
+  );
+}
+
+/* Deterministic pastel avatar — same person, same colour, every screen. */
+const AVATAR_PALETTES = [
+  { bg: '#E5F1FF', fg: '#0364D3' },
+  { bg: '#F0EAFE', fg: '#6A3FD1' },
+  { bg: '#E3F5E9', fg: '#177239' },
+  { bg: '#FFF2D6', fg: '#8F6400' },
+  { bg: '#FDEAE8', fg: '#BD3A2E' },
+  { bg: '#F0F2F4', fg: '#4C555E' },
+];
+
+export function roInitials(name) {
+  const words = String(name || '').trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return '—';
+  const first = words[0][0] || '';
+  const second = words.length > 1 ? words[words.length - 1][0] || '' : words[0][1] || '';
+  return (first + second).toUpperCase();
+}
+
+export function RoAvatar({ name, size = 36, className, title }) {
+  let hash = 0;
+  const s = String(name || '');
+  for (let i = 0; i < s.length; i += 1) hash = (hash * 31 + s.charCodeAt(i)) >>> 0;
+  const palette = AVATAR_PALETTES[hash % AVATAR_PALETTES.length];
+  return (
+    <span
+      className={cn('ro-avatar', className)}
+      title={title ?? (name || undefined)}
+      style={{
+        width: size,
+        height: size,
+        background: palette.bg,
+        color: palette.fg,
+        fontSize: Math.max(9, Math.round(size * 0.36)),
+      }}
+    >
+      {roInitials(name)}
+    </span>
+  );
+}
+
+/* Owner chip: avatar + first name, or a quiet dash when unowned. */
+export function RoOwner({ name, size = 24 }) {
+  if (!name) return <span className="text-sm" style={{ color: 'var(--ro-text-3)' }}>—</span>;
+  return (
+    <span className="inline-flex items-center gap-2 text-sm">
+      <RoAvatar name={name} size={size} />
+      {name.split(/\s+/)[0]}
+    </span>
+  );
+}
+
+export function RoPageHeader({ title, sub, actions, className }) {
+  return (
+    <div className={cn('flex flex-wrap items-start justify-between gap-4', className)}>
+      <div className="min-w-0">
+        <h1 className="ro-title">{title}</h1>
+        {sub && <p className="ro-sub">{sub}</p>}
+      </div>
+      {actions && <div className="flex items-center gap-2 shrink-0">{actions}</div>}
+    </div>
+  );
+}
+
+export function RoStatTile({ value, label, hot }) {
+  return (
+    <div className={cn('ro-tile', hot && value > 0 && 'ro-tile--hot')}>
+      <b>{value}</b>
+      <span>{label}</span>
+    </div>
+  );
+}
+
+export function RoEmpty({ title, body, children, className }) {
+  return (
+    <div className={cn('rounded-2xl border border-border px-8 py-10 text-center', className)}>
+      <div
+        className="ro-icon-circle mx-auto mb-3"
+        style={{ width: 48, height: 48, background: 'var(--ro-tag-green-bg)', color: 'var(--ro-tag-green-fg)', fontSize: 20 }}
+        aria-hidden="true"
+      >
+        ✓
+      </div>
+      <p className="font-bold text-base m-0">{title}</p>
+      {body && <p className="text-sm mt-1 mb-4" style={{ color: 'var(--ro-text-2)' }}>{body}</p>}
+      {children}
+    </div>
+  );
+}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -2,6 +2,7 @@ import { lazy, Suspense, useEffect } from 'react';
 import ProtectedRoute from '@/components/auth/ProtectedRoute';
 import RedeemOpsRoute from '@/components/auth/RedeemOpsRoute';
 import DashboardLayout from '@/components/layout/DashboardLayout';
+import RedeemOpsLayout from '@/components/redeemops/RedeemOpsLayout';
 import { BrowserRouter as Router, Route, Routes, useNavigate } from 'react-router-dom';
 import ErrorBoundary from './ErrorBoundary';
 import { brand } from '@/lib/brand';
@@ -455,9 +456,9 @@ function PagesContent() {
  <Route
  path="/redeem-ops" element={
  <RedeemOpsRoute>
- <DashboardLayout>
+ <RedeemOpsLayout>
  <RedeemOpsHome />
- </DashboardLayout>
+ </RedeemOpsLayout>
  </RedeemOpsRoute>
  }
  />
@@ -466,9 +467,9 @@ function PagesContent() {
  <Route
  path="/redeem-ops/team" element={
  <RedeemOpsRoute capability="analytics.view_team">
- <DashboardLayout>
+ <RedeemOpsLayout>
  <RedeemOpsTeam />
- </DashboardLayout>
+ </RedeemOpsLayout>
  </RedeemOpsRoute>
  }
  />
@@ -477,9 +478,9 @@ function PagesContent() {
  <Route
  path="/redeem-ops/partners" element={
  <RedeemOpsRoute capability="partners.view">
- <DashboardLayout>
+ <RedeemOpsLayout>
  <RedeemOpsPartnersList />
- </DashboardLayout>
+ </RedeemOpsLayout>
  </RedeemOpsRoute>
  }
  />
@@ -488,9 +489,9 @@ function PagesContent() {
  <Route
  path="/redeem-ops/partners/:id" element={
  <RedeemOpsRoute capability="partners.view">
- <DashboardLayout>
+ <RedeemOpsLayout>
  <RedeemOpsPartnerDetail />
- </DashboardLayout>
+ </RedeemOpsLayout>
  </RedeemOpsRoute>
  }
  />
@@ -499,9 +500,9 @@ function PagesContent() {
  <Route
  path="/redeem-ops/queue" element={
  <RedeemOpsRoute>
- <DashboardLayout>
+ <RedeemOpsLayout>
  <RedeemOpsMyQueue />
- </DashboardLayout>
+ </RedeemOpsLayout>
  </RedeemOpsRoute>
  }
  />
@@ -510,9 +511,9 @@ function PagesContent() {
  <Route
  path="/redeem-ops/tasks" element={
  <RedeemOpsRoute capability="tasks.manage">
- <DashboardLayout>
+ <RedeemOpsLayout>
  <RedeemOpsTasks />
- </DashboardLayout>
+ </RedeemOpsLayout>
  </RedeemOpsRoute>
  }
  />
@@ -521,9 +522,9 @@ function PagesContent() {
  <Route
  path="/redeem-ops/pools" element={
  <RedeemOpsRoute capability="pools.claim_next">
- <DashboardLayout>
+ <RedeemOpsLayout>
  <RedeemOpsPools />
- </DashboardLayout>
+ </RedeemOpsLayout>
  </RedeemOpsRoute>
  }
  />
@@ -532,9 +533,9 @@ function PagesContent() {
  <Route
  path="/redeem-ops/pipeline" element={
  <RedeemOpsRoute capability="pipeline.view_team">
- <DashboardLayout>
+ <RedeemOpsLayout>
  <RedeemOpsTeamPipeline />
- </DashboardLayout>
+ </RedeemOpsLayout>
  </RedeemOpsRoute>
  }
  />
@@ -543,9 +544,9 @@ function PagesContent() {
  <Route
  path="/redeem-ops/rewards" element={
  <RedeemOpsRoute capability="rewards.view">
- <DashboardLayout>
+ <RedeemOpsLayout>
  <RedeemOpsRewards />
- </DashboardLayout>
+ </RedeemOpsLayout>
  </RedeemOpsRoute>
  }
  />
@@ -554,9 +555,9 @@ function PagesContent() {
  <Route
  path="/redeem-ops/rewards/:id" element={
  <RedeemOpsRoute capability="rewards.view">
- <DashboardLayout>
+ <RedeemOpsLayout>
  <RedeemOpsRewardDetail />
- </DashboardLayout>
+ </RedeemOpsLayout>
  </RedeemOpsRoute>
  }
  />
@@ -565,9 +566,9 @@ function PagesContent() {
  <Route
  path="/redeem-ops/activations" element={
  <RedeemOpsRoute capability="activations.view">
- <DashboardLayout>
+ <RedeemOpsLayout>
  <RedeemOpsActivations />
- </DashboardLayout>
+ </RedeemOpsLayout>
  </RedeemOpsRoute>
  }
  />
@@ -576,9 +577,9 @@ function PagesContent() {
  <Route
  path="/redeem-ops/activations/:id" element={
  <RedeemOpsRoute capability="activations.view">
- <DashboardLayout>
+ <RedeemOpsLayout>
  <RedeemOpsActivationDetail />
- </DashboardLayout>
+ </RedeemOpsLayout>
  </RedeemOpsRoute>
  }
  />
@@ -587,9 +588,9 @@ function PagesContent() {
  <Route
  path="/redeem-ops/redemptions" element={
  <RedeemOpsRoute capability="redemptions.verify">
- <DashboardLayout>
+ <RedeemOpsLayout>
  <RedeemOpsRedemptions />
- </DashboardLayout>
+ </RedeemOpsLayout>
  </RedeemOpsRoute>
  }
  />
@@ -598,9 +599,9 @@ function PagesContent() {
  <Route
  path="/redeem-ops/analytics" element={
  <RedeemOpsRoute capability="analytics.view_own">
- <DashboardLayout>
+ <RedeemOpsLayout>
  <RedeemOpsAnalytics />
- </DashboardLayout>
+ </RedeemOpsLayout>
  </RedeemOpsRoute>
  }
  />

--- a/src/pages/redeemops/ActivationDetail.jsx
+++ b/src/pages/redeemops/ActivationDetail.jsx
@@ -12,8 +12,10 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Badge } from '@/components/ui/badge';
 import ExternalLink from 'lucide-react/icons/external-link';
+import { RoTag, RoStatTile, prettyEnum } from '@/components/redeemops/ui';
+
+const ACTIVATION_TONE = { preparing: 'pending', completed: 'done' };
 
 const NEXT_STATUS = {
   draft: ['preparing', 'cancelled'],
@@ -82,38 +84,35 @@ export default function ActivationDetail() {
   const acquisition = metricsQuery.data?.acquisition;
 
   return (
-    <div className="p-6 max-w-5xl mx-auto space-y-4">
-      <Card>
-        <CardContent className="pt-5">
-          <div className="flex flex-wrap items-start justify-between gap-4">
-            <div>
-              <h1 className="text-xl font-semibold tracking-tight">
-                {a.rewardOffer?.title} <span className="text-muted-foreground font-normal">×</span> {a.campaignNameSnapshot || 'No campaign yet'}
-              </h1>
-              <p className="text-sm text-muted-foreground mt-0.5">
-                {a.partner?.tradingName || a.partner?.legalName}
-                {' · unlock: '}{a.unlockPolicy === 'agent_unlock' ? 'at consultant meeting' : 'instant on signup'}
-              </p>
-            </div>
-            <div className="flex items-center gap-2">
-              <Badge variant={a.status === 'active' ? 'default' : 'secondary'}>{a.status}</Badge>
-              {canManage && (NEXT_STATUS[a.status] || []).length > 0 && (
-                <Select onValueChange={(s) => statusMutation.mutate(s)}>
-                  <SelectTrigger className="w-36 h-9"><SelectValue placeholder="Move to…" /></SelectTrigger>
-                  <SelectContent>
-                    {NEXT_STATUS[a.status].map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}
-                  </SelectContent>
-                </Select>
-              )}
-            </div>
-          </div>
-          <div className="grid grid-cols-3 gap-3 mt-5 text-center">
-            <div><p className="text-2xl font-semibold tabular-nums">{a.allocatedQuantity}</p><p className="text-xs text-muted-foreground">Allocated</p></div>
-            <div><p className="text-2xl font-semibold tabular-nums">{a.issuedCount}</p><p className="text-xs text-muted-foreground">Issued</p></div>
-            <div><p className="text-2xl font-semibold tabular-nums">{a.redeemedCount}</p><p className="text-xs text-muted-foreground">Redeemed</p></div>
-          </div>
-        </CardContent>
-      </Card>
+    <div className="p-6 md:p-8 max-w-5xl mx-auto space-y-5">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="ro-title text-[26px]">
+            {a.rewardOffer?.title} <span className="font-normal" style={{ color: 'var(--ro-text-3)' }}>×</span> {a.campaignNameSnapshot || 'No campaign yet'}
+          </h1>
+          <p className="ro-sub">
+            {a.partner?.tradingName || a.partner?.legalName}
+            {' · unlock: '}{a.unlockPolicy === 'agent_unlock' ? 'at consultant meeting' : 'instant on signup'}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <RoTag tone={ACTIVATION_TONE[a.status] || a.status}>{prettyEnum(a.status)}</RoTag>
+          {canManage && (NEXT_STATUS[a.status] || []).length > 0 && (
+            <Select onValueChange={(s) => statusMutation.mutate(s)}>
+              <SelectTrigger className="w-36 h-10"><SelectValue placeholder="Move to…" /></SelectTrigger>
+              <SelectContent>
+                {NEXT_STATUS[a.status].map((s) => <SelectItem key={s} value={s}>{prettyEnum(s)}</SelectItem>)}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+      </div>
+
+      <div className="ro-tiles">
+        <RoStatTile label="Allocated" value={a.allocatedQuantity} />
+        <RoStatTile label="Issued" value={a.issuedCount} />
+        <RoStatTile label="Redeemed" value={a.redeemedCount} />
+      </div>
 
       <div className="grid gap-4 lg:grid-cols-2">
         <Card>

--- a/src/pages/redeemops/ActivationsPage.jsx
+++ b/src/pages/redeemops/ActivationsPage.jsx
@@ -18,10 +18,10 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Badge } from '@/components/ui/badge';
 import Plus from 'lucide-react/icons/plus';
+import { RoPageHeader, RoTag, prettyEnum } from '@/components/redeemops/ui';
 
-const STATUS_BADGE = { active: 'default', draft: 'secondary', preparing: 'secondary', paused: 'outline', completed: 'outline', cancelled: 'destructive' };
+const ACTIVATION_TONE = { preparing: 'pending', completed: 'done' };
 
 export default function ActivationsPage() {
   const user = useAuthStore((s) => s.user);
@@ -57,20 +57,16 @@ export default function ActivationsPage() {
   const rewards = (rewardsQuery.data || []).filter((r) => r.status !== 'ended');
 
   return (
-    <div className="p-6 max-w-6xl mx-auto space-y-4">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Activations</h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            A reward allocated to one MKTR campaign — the campaign itself stays managed on mktr.sg.
-          </p>
-        </div>
-        {canManage && (
-          <Button size="sm" onClick={() => setCreateOpen(true)}>
-            <Plus className="w-4 h-4 mr-2" aria-hidden="true" /> New activation
+    <div className="p-6 md:p-8 max-w-6xl mx-auto space-y-5">
+      <RoPageHeader
+        title="Activations"
+        sub="A reward allocated to one MKTR campaign — the campaign itself stays managed on mktr.sg."
+        actions={canManage && (
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" /> New activation
           </Button>
         )}
-      </div>
+      />
 
       <Card>
         <CardContent className="pt-4">
@@ -95,7 +91,7 @@ export default function ActivationsPage() {
                     <TableCell className="text-muted-foreground">
                       {a.campaignNameSnapshot || (a.campaignId ? a.campaignId.slice(0, 8) : 'Not linked')}
                     </TableCell>
-                    <TableCell><Badge variant={STATUS_BADGE[a.status] || 'secondary'}>{a.status}</Badge></TableCell>
+                    <TableCell><RoTag tone={ACTIVATION_TONE[a.status] || a.status} size="sm">{prettyEnum(a.status)}</RoTag></TableCell>
                     <TableCell className="text-right">{a.allocatedQuantity}</TableCell>
                     <TableCell className="text-right">{a.issuedCount}</TableCell>
                     <TableCell className="text-right">{a.redeemedCount}</TableCell>

--- a/src/pages/redeemops/AnalyticsPage.jsx
+++ b/src/pages/redeemops/AnalyticsPage.jsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '@/components/ui/table';
-import { Badge } from '@/components/ui/badge';
+import { RoPageHeader, RoTag, prettyEnum } from '@/components/redeemops/ui';
 
 function Section({ title, description, children }) {
   return (
@@ -47,13 +47,11 @@ export default function AnalyticsPage() {
   });
 
   return (
-    <div className="p-6 max-w-6xl mx-auto space-y-4">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">Analytics</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          Acquisition numbers come from MKTR's own metrics — nothing is re-counted here.
-        </p>
-      </div>
+    <div className="p-6 md:p-8 max-w-6xl mx-auto space-y-5">
+      <RoPageHeader
+        title="Analytics"
+        sub="Acquisition numbers come from MKTR's own metrics — nothing is re-counted here."
+      />
 
       <Section title={teamWide ? 'Outreach — by team member' : 'Outreach — your performance'}>
         <Table>
@@ -170,7 +168,7 @@ export default function AnalyticsPage() {
                       {f.rewardTitle} <span className="text-muted-foreground">· {f.partnerName}</span>
                     </TableCell>
                     <TableCell className="text-muted-foreground">{f.campaignName || 'Not linked'}</TableCell>
-                    <TableCell><Badge variant={f.status === 'active' ? 'default' : 'secondary'}>{f.status}</Badge></TableCell>
+                    <TableCell><RoTag tone={f.status} size="sm">{prettyEnum(f.status)}</RoTag></TableCell>
                     <TableCell className="text-right">
                       {f.acquisition?.totalLeads ?? f.acquisition?.leads ?? '—'}
                     </TableCell>

--- a/src/pages/redeemops/MyQueue.jsx
+++ b/src/pages/redeemops/MyQueue.jsx
@@ -2,65 +2,45 @@ import { Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { redeemOpsApi } from '@/api/redeemOps';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useAuthStore } from '@/stores/authStore';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
+import { RoStatTile, RoEmpty, prettyEnum } from '@/components/redeemops/ui';
 
 function partnerName(p) {
   return p?.tradingName || p?.brandName || p?.legalName || 'Business';
 }
 
-function TaskRow({ task, onComplete, completing }) {
+function greeting() {
+  const h = new Date().getHours();
+  if (h < 12) return 'Good morning';
+  if (h < 18) return 'Good afternoon';
+  return 'Good evening';
+}
+
+function GroupLabel({ color, children }) {
+  return <div className="ro-group-label" style={{ color }}>{children}</div>;
+}
+
+function DocketRow({ title, sub, when, whenColor, action }) {
   return (
-    <div className="flex items-center justify-between gap-2 py-2 border-b border-border last:border-0">
-      <div className="min-w-0">
-        <p className="text-sm font-medium truncate">{task.title}</p>
-        <p className="text-xs text-muted-foreground truncate">
-          <Link to={`/redeem-ops/partners/${task.partner?.id}`} className="underline">
-            {partnerName(task.partner)}
-          </Link>
-          {' · due '}
-          {new Date(task.dueAt).toLocaleDateString()}
-          {task.contact?.name ? ` · ${task.contact.name}` : ''}
-        </p>
+    <div className="flex items-center gap-3.5 px-5 py-3 border-t border-border hover:bg-[var(--ro-subtle)] transition-colors">
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold m-0 truncate">{title}</p>
+        <p className="text-xs m-0 mt-0.5 truncate" style={{ color: 'var(--ro-text-2)' }}>{sub}</p>
       </div>
-      <Button size="sm" variant="outline" disabled={completing} onClick={() => onComplete(task.id)}>
-        Done
-      </Button>
+      {when && (
+        <span className="text-xs font-semibold whitespace-nowrap" style={{ color: whenColor || 'var(--ro-text-3)' }}>
+          {when}
+        </span>
+      )}
+      {action}
     </div>
-  );
-}
-
-function PartnerRow({ partner, note }) {
-  return (
-    <div className="py-2 border-b border-border last:border-0">
-      <p className="text-sm font-medium">
-        <Link to={`/redeem-ops/partners/${partner.id}`} className="underline">
-          {partnerName(partner)}
-        </Link>
-      </p>
-      <p className="text-xs text-muted-foreground">{note}</p>
-    </div>
-  );
-}
-
-function Bucket({ title, description, count, children, tone }) {
-  return (
-    <Card className={tone === 'warn' ? 'border-amber-300' : undefined}>
-      <CardHeader className="pb-2">
-        <CardTitle className="text-base flex items-center gap-2">
-          {title}
-          {count > 0 && <Badge variant={tone === 'warn' ? 'destructive' : 'secondary'}>{count}</Badge>}
-        </CardTitle>
-        <CardDescription>{description}</CardDescription>
-      </CardHeader>
-      <CardContent>{children}</CardContent>
-    </Card>
   );
 }
 
 export default function MyQueue() {
   const queryClient = useQueryClient();
+  const user = useAuthStore((s) => s.user);
   const queueQuery = useQuery({ queryKey: ['redeem-ops', 'queue'], queryFn: redeemOpsApi.getMyQueue });
 
   const completeMutation = useMutation({
@@ -74,93 +54,207 @@ export default function MyQueue() {
   });
 
   const q = queueQuery.data;
-  if (queueQuery.isLoading) return <div className="p-6 text-muted-foreground">Loading your queue…</div>;
-  if (!q) return <div className="p-6 text-muted-foreground">Queue unavailable.</div>;
+  if (queueQuery.isLoading) {
+    return <div className="p-8" style={{ color: 'var(--ro-text-2)' }}>Loading your queue…</div>;
+  }
+  if (!q) {
+    return <div className="p-8" style={{ color: 'var(--ro-text-2)' }}>Queue unavailable.</div>;
+  }
 
-  const empty =
-    q.overdueTasks.items.length + q.dueTodayTasks.items.length + q.awaitingFirstOutreach.items.length +
-    q.stalePartners.items.length + q.recentReplies.items.length + q.upcomingTasks.items.length === 0;
+  const firstName = (user?.firstName || user?.fullName || '').split(/\s+/)[0] || 'there';
+  const overdue = q.overdueTasks.items;
+  const dueToday = q.dueTodayTasks.items;
+  const awaiting = q.awaitingFirstOutreach.items;
+  const replies = q.recentReplies.items;
+  const upcoming = q.upcomingTasks.items;
+  const stale = q.stalePartners.items;
+
+  const todoToday = (q.overdueTasks.total || 0) + (q.dueTodayTasks.total || 0) + (q.awaitingFirstOutreach.total || 0);
+  const empty = overdue.length + dueToday.length + awaiting.length + stale.length + replies.length + upcoming.length === 0;
+
+  const doneButton = (task) => (
+    <Button
+      size="sm"
+      variant="outline"
+      className="ml-1 shrink-0"
+      disabled={completeMutation.isPending}
+      onClick={() => completeMutation.mutate(task.id)}
+    >
+      Done
+    </Button>
+  );
+  const openButton = (partnerId) => (
+    <Button size="sm" variant="outline" className="ml-1 shrink-0" asChild>
+      <Link to={`/redeem-ops/partners/${partnerId}`}>Open</Link>
+    </Button>
+  );
+
+  const taskSub = (t) => (
+    <>
+      <Link to={`/redeem-ops/partners/${t.partner?.id}`} className="ro-link">{partnerName(t.partner)}</Link>
+      {t.contact?.name ? ` · ${t.contact.name}` : ''}
+    </>
+  );
 
   return (
-    <div className="p-6 max-w-5xl mx-auto space-y-4">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">My queue</h1>
-        <p className="text-sm text-muted-foreground mt-1">Start here — this is your day, in order of urgency.</p>
+    <div className="p-6 md:p-8 max-w-6xl mx-auto space-y-6">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="ro-title">{greeting()}, {firstName}</h1>
+          <p className="ro-sub">
+            {new Date().toLocaleDateString(undefined, { weekday: 'long', day: 'numeric', month: 'long' })}
+            {' · '}
+            {todoToday === 0 ? 'nothing due — nice' : `${todoToday} thing${todoToday === 1 ? '' : 's'} to clear today`}
+          </p>
+        </div>
+        <Button asChild>
+          <Link to="/redeem-ops/pools">Claim next prospect</Link>
+        </Button>
       </div>
 
-      {empty && (
-        <Card>
-          <CardContent className="py-10 text-center text-muted-foreground">
-            Queue clear 🎉 — grab a new prospect from a <Link to="/redeem-ops/pools" className="underline">pool</Link> or
-            search <Link to="/redeem-ops/partners" className="underline">Partners</Link>.
-          </CardContent>
-        </Card>
-      )}
+      <div className="ro-tiles">
+        <RoStatTile value={todoToday} label="To do today" />
+        <RoStatTile value={q.overdueTasks.total || 0} label="Overdue" hot />
+        <RoStatTile value={q.awaitingFirstOutreach.total || 0} label="Awaiting first touch" />
+        <RoStatTile value={replies.length} label="Replies to answer" />
+        <RoStatTile value={q.stalePartners.total || 0} label="Gone quiet" />
+      </div>
 
-      <div className="grid gap-4 lg:grid-cols-2">
-        {q.overdueTasks.items.length > 0 && (
-          <Bucket title="Overdue" description="Follow-ups past their due date" count={q.overdueTasks.total} tone="warn">
-            {q.overdueTasks.items.map((t) => (
-              <TaskRow key={t.id} task={t} onComplete={completeMutation.mutate} completing={completeMutation.isPending} />
-            ))}
-          </Bucket>
-        )}
-        {q.dueTodayTasks.items.length > 0 && (
-          <Bucket title="Due today" description="Scheduled for today" count={q.dueTodayTasks.total}>
-            {q.dueTodayTasks.items.map((t) => (
-              <TaskRow key={t.id} task={t} onComplete={completeMutation.mutate} completing={completeMutation.isPending} />
-            ))}
-          </Bucket>
-        )}
-        {q.awaitingFirstOutreach.items.length > 0 && (
-          <Bucket
-            title="Awaiting first outreach"
-            description="Claimed but not yet contacted — reach out within 48h"
-            count={q.awaitingFirstOutreach.total}
-            tone="warn"
-          >
-            {q.awaitingFirstOutreach.items.map((p) => (
-              <PartnerRow
-                key={p.id}
-                partner={p}
-                note={`Claimed ${p.claimedAt ? new Date(p.claimedAt).toLocaleDateString() : 'recently'}${p.atRiskFlag ? ' · AT RISK' : ''}`}
-              />
-            ))}
-          </Bucket>
-        )}
-        {q.recentReplies.items.length > 0 && (
-          <Bucket title="Recent replies" description="They responded — keep the momentum" count={q.recentReplies.items.length}>
-            {q.recentReplies.items.map((r) => (
-              <div key={r.id} className="py-2 border-b border-border last:border-0">
-                <p className="text-sm font-medium">
-                  <Link to={`/redeem-ops/partners/${r.partnerId}`} className="underline">{r.partnerName}</Link>
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  {r.type.replaceAll('_', ' ')} · {r.summary} · {new Date(r.occurredAt).toLocaleDateString()}
-                </p>
+      {empty ? (
+        <RoEmpty
+          title="You're all caught up"
+          body="Nothing due right now. Pull your next prospect from a pool and keep the pipeline moving."
+        >
+          <Button asChild>
+            <Link to="/redeem-ops/pools">Claim next prospect</Link>
+          </Button>
+        </RoEmpty>
+      ) : (
+        <div className="grid gap-5 lg:grid-cols-[1fr_316px] items-start">
+          <div className="rounded-2xl border border-border overflow-hidden bg-white">
+            <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+              <p className="text-base font-bold m-0">Today's docket</p>
+              <span className="text-xs" style={{ color: 'var(--ro-text-3)' }}>Ordered by urgency</span>
+            </div>
+
+            {overdue.length > 0 && (
+              <>
+                <GroupLabel color="var(--ro-tag-red-fg)">Overdue</GroupLabel>
+                {overdue.map((t) => (
+                  <DocketRow
+                    key={t.id}
+                    title={t.title}
+                    sub={taskSub(t)}
+                    when={`Due ${new Date(t.dueAt).toLocaleDateString()}`}
+                    whenColor="var(--ro-tag-red-fg)"
+                    action={doneButton(t)}
+                  />
+                ))}
+              </>
+            )}
+
+            {dueToday.length > 0 && (
+              <>
+                <GroupLabel color="var(--ro-bunker)">Due today</GroupLabel>
+                {dueToday.map((t) => (
+                  <DocketRow
+                    key={t.id}
+                    title={t.title}
+                    sub={taskSub(t)}
+                    when={t.hasTime ? new Date(t.dueAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : 'Today'}
+                    action={doneButton(t)}
+                  />
+                ))}
+              </>
+            )}
+
+            {awaiting.length > 0 && (
+              <>
+                <GroupLabel color="var(--ro-tag-yellow-fg)">Awaiting first touch</GroupLabel>
+                {awaiting.map((p) => (
+                  <DocketRow
+                    key={p.id}
+                    title={`Make first contact — ${partnerName(p)}`}
+                    sub={`Claimed ${p.claimedAt ? new Date(p.claimedAt).toLocaleDateString() : 'recently'} · 48h window`}
+                    when={p.atRiskFlag ? 'At risk' : 'Today'}
+                    whenColor="var(--ro-tag-yellow-fg)"
+                    action={openButton(p.id)}
+                  />
+                ))}
+              </>
+            )}
+
+            {replies.length > 0 && (
+              <>
+                <GroupLabel color="var(--ro-tag-blue-fg)">Replied — keep the momentum</GroupLabel>
+                {replies.map((r) => (
+                  <DocketRow
+                    key={r.id}
+                    title={r.summary || prettyEnum(r.type)}
+                    sub={`${r.partnerName} · ${prettyEnum(r.type)} · ${new Date(r.occurredAt).toLocaleDateString()}`}
+                    when="Reply now"
+                    whenColor="var(--ro-tag-blue-fg)"
+                    action={openButton(r.partnerId)}
+                  />
+                ))}
+              </>
+            )}
+
+            {upcoming.length > 0 && (
+              <>
+                <GroupLabel color="var(--ro-text-3)">Coming up (3 days)</GroupLabel>
+                {upcoming.map((t) => (
+                  <DocketRow
+                    key={t.id}
+                    title={t.title}
+                    sub={taskSub(t)}
+                    when={new Date(t.dueAt).toLocaleDateString(undefined, { weekday: 'short' })}
+                    action={doneButton(t)}
+                  />
+                ))}
+              </>
+            )}
+          </div>
+
+          <div className="space-y-4">
+            <div className="rounded-2xl border border-border bg-white p-5">
+              <p className="text-[15px] font-bold m-0">Need more prospects?</p>
+              <p className="text-[13px] mt-1 mb-3.5 leading-relaxed" style={{ color: 'var(--ro-text-2)' }}>
+                Pull the next business from a pool — claiming is collision-safe, so the team can draw at once.
+              </p>
+              <Button asChild className="w-full">
+                <Link to="/redeem-ops/pools">Claim next</Link>
+              </Button>
+            </div>
+
+            {stale.length > 0 && (
+              <div className="rounded-2xl border border-border bg-white overflow-hidden">
+                <div className="px-5 pt-4 pb-2">
+                  <p className="text-[15px] font-bold m-0">Gone quiet</p>
+                  <p className="text-[13px] mt-1 m-0" style={{ color: 'var(--ro-text-2)' }}>
+                    No activity in 14+ days. Revive or release.
+                  </p>
+                </div>
+                {stale.map((p) => (
+                  <div key={p.id} className="flex items-center justify-between gap-2 px-5 py-2.5 border-t border-border">
+                    <Link to={`/redeem-ops/partners/${p.id}`} className="text-sm font-semibold truncate text-foreground no-underline hover:underline">
+                      {partnerName(p)}
+                    </Link>
+                    <span className="text-xs font-semibold shrink-0" style={{ color: 'var(--ro-tag-red-fg)' }}>
+                      {p.lastActivityAt
+                        ? `${Math.max(1, Math.round((Date.now() - new Date(p.lastActivityAt)) / 86400000))}d`
+                        : 'never'}
+                    </span>
+                  </div>
+                ))}
+                <Link to="/redeem-ops/partners" className="ro-link block px-5 py-3 border-t border-border text-[13px]">
+                  See all partners
+                </Link>
               </div>
-            ))}
-          </Bucket>
-        )}
-        {q.upcomingTasks.items.length > 0 && (
-          <Bucket title="Coming up (3 days)" description="What's next after today">
-            {q.upcomingTasks.items.map((t) => (
-              <TaskRow key={t.id} task={t} onComplete={completeMutation.mutate} completing={completeMutation.isPending} />
-            ))}
-          </Bucket>
-        )}
-        {q.stalePartners.items.length > 0 && (
-          <Bucket title="Gone quiet" description="No activity in 14+ days — revive or release" count={q.stalePartners.total} tone="warn">
-            {q.stalePartners.items.map((p) => (
-              <PartnerRow
-                key={p.id}
-                partner={p}
-                note={`Last activity ${p.lastActivityAt ? new Date(p.lastActivityAt).toLocaleDateString() : 'never'} · ${p.pipelineStage.replaceAll('_', ' ')}`}
-              />
-            ))}
-          </Bucket>
-        )}
-      </div>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/redeemops/PartnerDetail.jsx
+++ b/src/pages/redeemops/PartnerDetail.jsx
@@ -1,11 +1,10 @@
 import { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { redeemOpsApi } from '@/api/redeemOps';
 import { useAuthStore } from '@/stores/authStore';
 import { hasCapability } from '@/lib/redeemOpsPermissions';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
@@ -16,54 +15,81 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Badge } from '@/components/ui/badge';
 import { Textarea } from '@/components/ui/textarea';
 import Phone from 'lucide-react/icons/phone';
 import Globe from 'lucide-react/icons/globe';
 import Instagram from 'lucide-react/icons/instagram';
+import MessageCircle from 'lucide-react/icons/message-circle';
+import Mail from 'lucide-react/icons/mail';
+import Calendar from 'lucide-react/icons/calendar';
+import FileText from 'lucide-react/icons/file-text';
+import ArrowRight from 'lucide-react/icons/arrow-right';
+import Star from 'lucide-react/icons/star';
+import MapPin from 'lucide-react/icons/map-pin';
+import Plus from 'lucide-react/icons/plus';
+import ArrowLeft from 'lucide-react/icons/arrow-left';
+import { RoStageTag, RoAvatar, RoTag, prettyEnum } from '@/components/redeemops/ui';
+
+/* Activity type → pastel icon circle (timeline card in the design system). */
+function timelineIcon(entry) {
+  if (entry.kind === 'stage') {
+    return { Icon: ArrowRight, bg: 'var(--ro-tag-purple-bg)', fg: 'var(--ro-tag-purple-fg)' };
+  }
+  if (entry.kind !== 'activity') {
+    return { Icon: Plus, bg: 'var(--ro-tag-gray-bg)', fg: 'var(--ro-tag-gray-fg)' };
+  }
+  const t = String(entry.data.type || '');
+  if (t.includes('call')) return { Icon: Phone, bg: 'var(--ro-tag-blue-bg)', fg: 'var(--ro-tag-blue-fg)' };
+  if (t.includes('whatsapp') || t.includes('sms') || t.includes('dm')) {
+    return { Icon: MessageCircle, bg: 'var(--ro-tag-green-bg)', fg: 'var(--ro-tag-green-fg)' };
+  }
+  if (t.includes('email')) return { Icon: Mail, bg: 'var(--ro-tag-yellow-bg)', fg: 'var(--ro-tag-yellow-fg)' };
+  if (t.includes('meeting') || t.includes('visit')) {
+    return { Icon: Calendar, bg: 'var(--ro-tag-blue-bg)', fg: 'var(--ro-tag-blue-fg)' };
+  }
+  return { Icon: FileText, bg: 'var(--ro-tag-gray-bg)', fg: 'var(--ro-tag-gray-fg)' };
+}
 
 function TimelineEntry({ entry }) {
   const at = new Date(entry.at).toLocaleString();
+  const { Icon, bg, fg } = timelineIcon(entry);
+
+  let title;
+  let body = null;
+  let meta;
   if (entry.kind === 'activity') {
     const a = entry.data;
-    return (
-      <div className="border-l-2 border-border pl-3 pb-4">
-        <p className="text-sm font-medium">
-          {a.type.replaceAll('_', ' ')}
-          {a.contact?.name ? ` · with ${a.contact.name}` : ''}
-        </p>
-        <p className="text-sm text-muted-foreground">{a.summary}</p>
-        {a.outcome && <p className="text-xs text-muted-foreground">Outcome: {a.outcome}</p>}
-        <p className="text-xs text-muted-foreground mt-0.5">{a.actor?.fullName || 'System'} · {at}</p>
-      </div>
+    title = `${prettyEnum(a.type)}${a.contact?.name ? ` · with ${a.contact.name}` : ''}`;
+    body = (
+      <>
+        {a.summary && <p className="text-[13.5px] leading-relaxed m-0 mt-0.5" style={{ color: 'var(--ro-text-2)' }}>{a.summary}</p>}
+        {a.outcome && <p className="text-xs m-0 mt-0.5" style={{ color: 'var(--ro-text-3)' }}>Outcome: {a.outcome}</p>}
+      </>
     );
-  }
-  if (entry.kind === 'stage') {
+    meta = `${a.actor?.fullName || 'System'} · ${at}`;
+  } else if (entry.kind === 'stage') {
     const e = entry.data;
-    return (
-      <div className="border-l-2 border-primary/40 pl-3 pb-4">
-        <p className="text-sm">
-          Stage: <span className="font-medium">{(e.fromStage || '—').replaceAll('_', ' ')}</span>
-          {' → '}
-          <span className="font-medium">{e.toStage.replaceAll('_', ' ')}</span>
-        </p>
-        <p className="text-xs text-muted-foreground mt-0.5">{e.actor?.fullName || 'System'} · {at}{e.reason ? ` · ${e.reason}` : ''}</p>
-      </div>
-    );
+    title = `Stage moved: ${prettyEnum(e.fromStage || '—')} → ${prettyEnum(e.toStage)}`;
+    meta = `${e.actor?.fullName || 'System'} · ${at}${e.reason ? ` · ${e.reason}` : ''}`;
+  } else {
+    const e = entry.data;
+    title = `Ownership: ${prettyEnum(e.kind)}${e.toUser ? ` → ${e.toUser.fullName}` : ''}`;
+    meta = `${e.actor?.fullName || 'System'} · ${at}${e.reason ? ` · ${e.reason}` : ''}`;
   }
-  const e = entry.data;
+
   return (
-    <div className="border-l-2 border-border pl-3 pb-4">
-      <p className="text-sm">
-        Ownership: <span className="font-medium">{e.kind}</span>
-        {e.toUser ? ` → ${e.toUser.fullName}` : ''}
-      </p>
-      <p className="text-xs text-muted-foreground mt-0.5">{e.actor?.fullName || 'System'} · {at}{e.reason ? ` · ${e.reason}` : ''}</p>
+    <div className="grid grid-cols-[40px_1fr] gap-3.5 py-3.5 border-t border-border first:border-t-0 first:pt-0">
+      <span className="ro-icon-circle" style={{ background: bg, color: fg }} aria-hidden="true">
+        <Icon className="w-4 h-4" />
+      </span>
+      <div className="min-w-0">
+        <p className="text-sm font-bold m-0">{title}</p>
+        {body}
+        <p className="text-xs m-0 mt-1" style={{ color: 'var(--ro-text-3)' }}>{meta}</p>
+      </div>
     </div>
   );
 }
-
-const ONBOARDING_STATUS_BADGE = { done: 'default', in_progress: 'secondary', pending: 'outline', na: 'outline' };
 
 function OnboardingChecklist({ partnerId }) {
   const queryClient = useQueryClient();
@@ -79,36 +105,40 @@ function OnboardingChecklist({ partnerId }) {
 
   const items = itemsQuery.data || [];
   const doneCount = items.filter((i) => i.status === 'done' || i.status === 'na').length;
+  const pct = items.length ? Math.round((doneCount / items.length) * 100) : 0;
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-base">Onboarding checklist</CardTitle>
-        <p className="text-sm text-muted-foreground">{doneCount} of {items.length} complete</p>
-      </CardHeader>
-      <CardContent className="space-y-2">
+    <div className="rounded-2xl border border-border bg-white p-5">
+      <div className="flex items-baseline justify-between">
+        <p className="text-[15px] font-bold m-0">Onboarding · {doneCount} of {items.length}</p>
+        <span className="text-xs tabular-nums" style={{ color: 'var(--ro-text-3)' }}>{pct}%</span>
+      </div>
+      <div className="ro-progress my-3"><i style={{ width: `${pct}%` }} /></div>
+      <div>
         {items.map((item) => (
-          <div key={item.id} className="flex items-center justify-between gap-2 border-b border-border pb-2 last:border-0">
-            <span className="text-sm">{item.label}</span>
+          <div key={item.id} className="flex items-center justify-between gap-2 py-2 border-t border-border first:border-t-0">
+            <span className={`text-sm ${item.status === 'done' || item.status === 'na' ? 'line-through' : ''}`}
+              style={item.status === 'done' || item.status === 'na' ? { color: 'var(--ro-text-3)' } : undefined}
+            >
+              {item.label}
+            </span>
             <Select
               value={item.status}
               onValueChange={(status) => updateMutation.mutate({ itemId: item.id, status })}
             >
-              <SelectTrigger className="w-36 h-8">
-                <Badge variant={ONBOARDING_STATUS_BADGE[item.status] || 'outline'}>
-                  {item.status.replaceAll('_', ' ')}
-                </Badge>
+              <SelectTrigger className="w-36 h-8 border-none shadow-none justify-end gap-1 px-1">
+                <RoTag tone={item.status} size="sm">{prettyEnum(item.status)}</RoTag>
               </SelectTrigger>
               <SelectContent>
                 {['pending', 'in_progress', 'done', 'na'].map((s) => (
-                  <SelectItem key={s} value={s}>{s.replaceAll('_', ' ')}</SelectItem>
+                  <SelectItem key={s} value={s}>{prettyEnum(s)}</SelectItem>
                 ))}
               </SelectContent>
             </Select>
           </div>
         ))}
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }
 
@@ -198,10 +228,10 @@ export default function PartnerDetail() {
 
   const partner = partnerQuery.data;
   if (partnerQuery.isLoading) {
-    return <div className="p-6 text-muted-foreground">Loading…</div>;
+    return <div className="p-8" style={{ color: 'var(--ro-text-2)' }}>Loading…</div>;
   }
   if (!partner) {
-    return <div className="p-6 text-muted-foreground">Business not found.</div>;
+    return <div className="p-8" style={{ color: 'var(--ro-text-2)' }}>Business not found.</div>;
   }
 
   const name = partner.tradingName || partner.brandName || partner.legalName;
@@ -213,168 +243,197 @@ export default function PartnerDetail() {
   const activityTypes = constants.data?.activityTypes || [];
 
   return (
-    <div className="p-6 max-w-5xl mx-auto space-y-4">
-      <Card>
-        <CardContent className="pt-5">
-          <div className="flex flex-wrap items-start justify-between gap-4">
-            <div className="space-y-1 min-w-0">
-              <h1 className="text-xl font-semibold tracking-tight">{name}</h1>
-              <p className="text-sm text-muted-foreground">
-                {partner.category || 'Uncategorised'}
-                {partner.legalName && partner.legalName !== name ? ` · ${partner.legalName}` : ''}
-                {partner.uen ? ` · UEN ${partner.uen}` : ''}
-              </p>
-              <div className="flex flex-wrap gap-3 text-sm text-muted-foreground pt-1">
-                {partner.primaryPhone && <span className="flex items-center gap-1"><Phone className="w-3.5 h-3.5" aria-hidden="true" />{partner.primaryPhone}</span>}
-                {partner.websiteDomain && <span className="flex items-center gap-1"><Globe className="w-3.5 h-3.5" aria-hidden="true" />{partner.websiteDomain}</span>}
-                {partner.instagramHandle && <span className="flex items-center gap-1"><Instagram className="w-3.5 h-3.5" aria-hidden="true" />@{partner.instagramHandle}</span>}
-              </div>
-            </div>
+    <div className="p-6 md:p-8 max-w-6xl mx-auto space-y-5">
+      <Link to="/redeem-ops/partners" className="ro-link inline-flex items-center gap-1 text-[13.5px]">
+        <ArrowLeft className="w-3.5 h-3.5" aria-hidden="true" /> Partners
+      </Link>
 
-            <div className="flex flex-col items-end gap-2">
-              <div className="flex items-center gap-2">
-                <Badge variant="secondary">{partner.pipelineStage.replaceAll('_', ' ')}</Badge>
-                {partner.owner
-                  ? <Badge variant="outline">Owner: {partner.owner.fullName}</Badge>
-                  : <Badge variant="outline">Unowned</Badge>}
-              </div>
-              <div className="flex items-center gap-2">
-                {isUnowned && hasCapability(user, 'partners.claim') && (
-                  <Button size="sm" onClick={() => claimMutation.mutate()} disabled={claimMutation.isPending}>
-                    {claimMutation.isPending ? 'Claiming…' : 'Claim business'}
-                  </Button>
-                )}
-                {isOwner && (
-                  <Button size="sm" variant="outline" onClick={() => releaseMutation.mutate()}>
-                    Release
-                  </Button>
-                )}
-                {canReassign && (
-                  <Select onValueChange={(toUserId) => assignMutation.mutate({ toUserId })}>
-                    <SelectTrigger className="w-44 h-9"><SelectValue placeholder="Assign to…" /></SelectTrigger>
-                    <SelectContent>
-                      {(teamQuery.data || []).filter((m) => m.isActive).map((m) => (
-                        <SelectItem key={m.id} value={m.id}>{m.fullName || m.email}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                )}
-                {(isOwner || canReassign) && allowedNext.length > 0 && (
-                  <Select onValueChange={(toStage) => stageMutation.mutate({ toStage })}>
-                    <SelectTrigger className="w-48 h-9"><SelectValue placeholder="Move stage…" /></SelectTrigger>
-                    <SelectContent>
-                      {allowedNext.map((s) => (
-                        <SelectItem key={s} value={s}>{s.replaceAll('_', ' ')}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                )}
-              </div>
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="flex items-center gap-4 min-w-0">
+          <RoAvatar name={name} size={56} />
+          <div className="min-w-0">
+            <h1 className="ro-title text-[26px]">{name}</h1>
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1.5 text-[13.5px]" style={{ color: 'var(--ro-text-2)' }}>
+              <span>{partner.category || 'Uncategorised'}</span>
+              {partner.uen && <span>UEN {partner.uen}</span>}
+              {partner.primaryPhone && (
+                <span className="inline-flex items-center gap-1"><Phone className="w-3.5 h-3.5" aria-hidden="true" />{partner.primaryPhone}</span>
+              )}
+              {partner.websiteDomain && (
+                <span className="inline-flex items-center gap-1"><Globe className="w-3.5 h-3.5" aria-hidden="true" />{partner.websiteDomain}</span>
+              )}
+              {partner.instagramHandle && (
+                <span className="inline-flex items-center gap-1"><Instagram className="w-3.5 h-3.5" aria-hidden="true" />@{partner.instagramHandle}</span>
+              )}
+              <RoStageTag stage={partner.pipelineStage} />
             </div>
           </div>
-        </CardContent>
-      </Card>
+        </div>
 
-      <Tabs defaultValue="timeline">
-        <TabsList>
-          <TabsTrigger value="timeline">Timeline</TabsTrigger>
-          <TabsTrigger value="contacts">Contacts ({partner.contacts?.length || 0})</TabsTrigger>
-          <TabsTrigger value="locations">Locations ({partner.locations?.length || 0})</TabsTrigger>
-          {partner.pipelineStage === 'PARTNERED' && canOnboard && (
-            <TabsTrigger value="onboarding">Onboarding</TabsTrigger>
+        <div className="flex flex-wrap items-center gap-2">
+          {canReassign && (
+            <Select onValueChange={(toUserId) => assignMutation.mutate({ toUserId })}>
+              <SelectTrigger className="w-40 h-10"><SelectValue placeholder="Assign to…" /></SelectTrigger>
+              <SelectContent>
+                {(teamQuery.data || []).filter((m) => m.isActive).map((m) => (
+                  <SelectItem key={m.id} value={m.id}>{m.fullName || m.email}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           )}
-        </TabsList>
+          {(isOwner || canReassign) && allowedNext.length > 0 && (
+            <Select onValueChange={(toStage) => stageMutation.mutate({ toStage })}>
+              <SelectTrigger className="w-44 h-10"><SelectValue placeholder="Move stage…" /></SelectTrigger>
+              <SelectContent>
+                {allowedNext.map((s) => (
+                  <SelectItem key={s} value={s}>{prettyEnum(s)}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          {isOwner && (
+            <Button variant="outline" onClick={() => releaseMutation.mutate()}>Release</Button>
+          )}
+          {(isOwner || canReassign) && (
+            <Button variant="outline" onClick={() => setActivityOpen(true)}>Log activity</Button>
+          )}
+          {isUnowned && hasCapability(user, 'partners.claim') && (
+            <Button onClick={() => claimMutation.mutate()} disabled={claimMutation.isPending}>
+              {claimMutation.isPending ? 'Claiming…' : 'Claim business'}
+            </Button>
+          )}
+        </div>
+      </div>
 
-        <TabsContent value="timeline">
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between">
-              <CardTitle className="text-base">Activity timeline</CardTitle>
-              {(isOwner || canReassign) && (
-                <Button size="sm" onClick={() => setActivityOpen(true)}>Log activity</Button>
-              )}
-            </CardHeader>
-            <CardContent>
+      <div className="grid gap-5 lg:grid-cols-[1fr_320px] items-start">
+        <Tabs defaultValue="timeline">
+          <TabsList>
+            <TabsTrigger value="timeline">Timeline</TabsTrigger>
+            <TabsTrigger value="contacts">Contacts ({partner.contacts?.length || 0})</TabsTrigger>
+            <TabsTrigger value="locations">Locations ({partner.locations?.length || 0})</TabsTrigger>
+            {partner.pipelineStage === 'PARTNERED' && canOnboard && (
+              <TabsTrigger value="onboarding">Onboarding</TabsTrigger>
+            )}
+          </TabsList>
+
+          <TabsContent value="timeline">
+            <div className="rounded-2xl border border-border bg-white p-5">
               {(timelineQuery.data || []).length === 0 && (
-                <p className="text-sm text-muted-foreground">No activity yet — claim it and make the first touch.</p>
+                <p className="text-sm m-0" style={{ color: 'var(--ro-text-2)' }}>
+                  No activity yet — claim it and make the first touch.
+                </p>
               )}
               {(timelineQuery.data || []).map((entry, i) => (
                 <TimelineEntry key={`${entry.kind}-${entry.data.id || i}`} entry={entry} />
               ))}
-            </CardContent>
-          </Card>
-        </TabsContent>
+            </div>
+          </TabsContent>
 
-        <TabsContent value="contacts">
-          <Card>
-            <CardContent className="pt-5 space-y-4">
+          <TabsContent value="contacts">
+            <div className="rounded-2xl border border-border bg-white p-5 space-y-4">
               {(partner.contacts || []).map((c) => (
-                <div key={c.id} className="flex items-start justify-between border-b border-border pb-3 last:border-0">
-                  <div>
-                    <p className="text-sm font-medium">
-                      {c.name} {c.isPrimary && <Badge variant="secondary" className="ml-1">Primary</Badge>}
+                <div key={c.id} className="flex items-center gap-3 border-b border-border pb-3 last:border-0 last:pb-0">
+                  <RoAvatar name={c.name} size={32} />
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold m-0 flex items-center gap-1.5">
+                      {c.name}
+                      {c.isPrimary && <Star className="w-3.5 h-3.5" style={{ color: 'var(--ro-tag-yellow-fg)' }} aria-label="Primary contact" />}
                     </p>
-                    <p className="text-xs text-muted-foreground">
+                    <p className="text-xs m-0" style={{ color: 'var(--ro-text-2)' }}>
                       {[c.roleTitle, c.mobile, c.email].filter(Boolean).join(' · ') || '—'}
                     </p>
                   </div>
                 </div>
               ))}
               {(isOwner || canReassign) && (
-                <div className="grid grid-cols-2 gap-2 pt-2">
+                <div className="grid grid-cols-2 gap-2 pt-1">
                   <Input placeholder="Name *" value={contactForm.name} onChange={(e) => setContactForm((f) => ({ ...f, name: e.target.value }))} />
                   <Input placeholder="Role (e.g. Owner)" value={contactForm.roleTitle} onChange={(e) => setContactForm((f) => ({ ...f, roleTitle: e.target.value }))} />
                   <Input placeholder="Mobile" value={contactForm.mobile} onChange={(e) => setContactForm((f) => ({ ...f, mobile: e.target.value }))} />
                   <Input placeholder="Email" value={contactForm.email} onChange={(e) => setContactForm((f) => ({ ...f, email: e.target.value }))} />
                   <Button
-                    size="sm"
+                    variant="outline"
                     className="col-span-2 justify-self-start"
                     disabled={!contactForm.name.trim() || contactMutation.isPending}
                     onClick={() => contactMutation.mutate()}
                   >
-                    Add contact
+                    <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" /> Add contact
                   </Button>
                 </div>
               )}
-            </CardContent>
-          </Card>
-        </TabsContent>
+            </div>
+          </TabsContent>
 
-        <TabsContent value="locations">
-          <Card>
-            <CardContent className="pt-5 space-y-4">
+          <TabsContent value="locations">
+            <div className="rounded-2xl border border-border bg-white p-5 space-y-4">
               {(partner.locations || []).map((l) => (
-                <div key={l.id} className="border-b border-border pb-3 last:border-0">
-                  <p className="text-sm font-medium">{l.name || 'Outlet'}</p>
-                  <p className="text-xs text-muted-foreground">
-                    {[l.addressLine, l.postalCode && `S${l.postalCode}`, l.phone].filter(Boolean).join(' · ') || '—'}
-                  </p>
+                <div key={l.id} className="flex items-center gap-3 border-b border-border pb-3 last:border-0 last:pb-0">
+                  <span className="ro-icon-circle" style={{ width: 32, height: 32, background: 'var(--ro-tag-gray-bg)', color: 'var(--ro-tag-gray-fg)' }} aria-hidden="true">
+                    <MapPin className="w-3.5 h-3.5" />
+                  </span>
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold m-0">{l.name || 'Outlet'}</p>
+                    <p className="text-xs m-0" style={{ color: 'var(--ro-text-2)' }}>
+                      {[l.addressLine, l.postalCode && `S${l.postalCode}`, l.phone].filter(Boolean).join(' · ') || '—'}
+                    </p>
+                  </div>
                 </div>
               ))}
               {(isOwner || canReassign) && (
-                <div className="grid grid-cols-2 gap-2 pt-2">
+                <div className="grid grid-cols-2 gap-2 pt-1">
                   <Input placeholder="Outlet name" value={locationForm.name} onChange={(e) => setLocationForm((f) => ({ ...f, name: e.target.value }))} />
                   <Input placeholder="Postal code" value={locationForm.postalCode} onChange={(e) => setLocationForm((f) => ({ ...f, postalCode: e.target.value }))} />
                   <Input placeholder="Address" className="col-span-2" value={locationForm.addressLine} onChange={(e) => setLocationForm((f) => ({ ...f, addressLine: e.target.value }))} />
                   <Button
-                    size="sm"
+                    variant="outline"
                     className="col-span-2 justify-self-start"
                     disabled={locationMutation.isPending}
                     onClick={() => locationMutation.mutate()}
                   >
-                    Add location
+                    <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" /> Add location
                   </Button>
                 </div>
               )}
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        {partner.pipelineStage === 'PARTNERED' && canOnboard && (
-          <TabsContent value="onboarding">
-            <OnboardingChecklist partnerId={id} />
+            </div>
           </TabsContent>
-        )}
-      </Tabs>
+
+          {partner.pipelineStage === 'PARTNERED' && canOnboard && (
+            <TabsContent value="onboarding">
+              <OnboardingChecklist partnerId={id} />
+            </TabsContent>
+          )}
+        </Tabs>
+
+        <div className="space-y-4">
+          <div className="rounded-2xl border border-border bg-white p-5">
+            <p className="text-[15px] font-bold m-0 mb-3">Owner</p>
+            {partner.owner ? (
+              <div className="flex items-center gap-3">
+                <RoAvatar name={partner.owner.fullName} size={32} />
+                <div>
+                  <p className="text-sm font-semibold m-0">{partner.owner.fullName}</p>
+                  {partner.claimedAt && (
+                    <p className="text-xs m-0" style={{ color: 'var(--ro-text-2)' }}>
+                      Claimed {new Date(partner.claimedAt).toLocaleDateString()}
+                    </p>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <p className="text-sm m-0" style={{ color: 'var(--ro-text-2)' }}>
+                Unowned — claim it to start outreach.
+              </p>
+            )}
+          </div>
+
+          {partner.notes && (
+            <div className="rounded-2xl border border-border bg-white p-5">
+              <p className="text-[15px] font-bold m-0 mb-2">Notes</p>
+              <p className="text-[13.5px] leading-relaxed m-0 whitespace-pre-wrap" style={{ color: 'var(--ro-text-2)' }}>{partner.notes}</p>
+            </div>
+          )}
+        </div>
+      </div>
 
       <Dialog open={activityOpen} onOpenChange={setActivityOpen}>
         <DialogContent>
@@ -388,7 +447,7 @@ export default function PartnerDetail() {
                 <SelectTrigger><SelectValue /></SelectTrigger>
                 <SelectContent>
                   {activityTypes.map((t) => (
-                    <SelectItem key={t} value={t}>{t.replaceAll('_', ' ')}</SelectItem>
+                    <SelectItem key={t} value={t}>{prettyEnum(t)}</SelectItem>
                   ))}
                 </SelectContent>
               </Select>

--- a/src/pages/redeemops/PartnersList.jsx
+++ b/src/pages/redeemops/PartnersList.jsx
@@ -3,10 +3,6 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { redeemOpsApi } from '@/api/redeemOps';
-import { Card, CardContent } from '@/components/ui/card';
-import {
-  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
-} from '@/components/ui/table';
 import {
   Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
 } from '@/components/ui/dialog';
@@ -16,15 +12,9 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Badge } from '@/components/ui/badge';
 import Plus from 'lucide-react/icons/plus';
 import AlertTriangle from 'lucide-react/icons/alert-triangle';
-
-const STAGE_BADGE = {
-  PARTNERED: 'default',
-  DISQUALIFIED: 'destructive',
-  NOT_INTERESTED: 'destructive',
-};
+import { RoStageTag, RoAvatar, RoOwner, RoPageHeader, prettyEnum } from '@/components/redeemops/ui';
 
 function useDebounced(value, ms = 300) {
   const [debounced, setDebounced] = useState(value);
@@ -119,105 +109,115 @@ export default function PartnersList() {
   const stages = constants.data?.pipelineStages || [];
   const needsOverride = (duplicates?.exact?.length || 0) > 0;
 
-  return (
-    <div className="p-6 max-w-6xl mx-auto space-y-4">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Partners</h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            The shared business database — search before you add, claim before you contact.
-          </p>
-        </div>
-        <Button size="sm" onClick={() => { setCreateOpen(true); setDuplicates(null); }}>
-          <Plus className="w-4 h-4 mr-2" aria-hidden="true" /> Add business
-        </Button>
-      </div>
+  const partnerName = (p) => p.tradingName || p.brandName || p.legalName;
+  const partnerMeta = (p) => [p.category, p.instagramHandle && `@${p.instagramHandle}`, p.primaryPhone]
+    .filter(Boolean).slice(0, 2).join(' · ');
 
-      <div className="flex flex-wrap gap-2">
-        <Input
-          placeholder="Search name, phone, UEN, @handle, domain…"
+  return (
+    <div className="p-6 md:p-8 max-w-6xl mx-auto space-y-5">
+      <RoPageHeader
+        title="Partners"
+        sub={pagination ? `${pagination.total} business${pagination.total === 1 ? '' : 'es'} on the books — search before you add, claim before you contact.` : 'The shared business database — search before you add, claim before you contact.'}
+        actions={(
+          <Button onClick={() => { setCreateOpen(true); setDuplicates(null); }}>
+            <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" /> Add business
+          </Button>
+        )}
+      />
+
+      <div className="flex flex-wrap gap-2 items-center">
+        <input
+          className="ro-search w-full max-w-xs"
+          placeholder="Search name, phone, UEN or @handle"
           value={search}
           onChange={(e) => { setSearch(e.target.value); setPage(1); }}
-          className="max-w-sm"
         />
-        <Select value={stage} onValueChange={(v) => { setStage(v); setPage(1); }}>
-          <SelectTrigger className="w-48"><SelectValue placeholder="Stage" /></SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All stages</SelectItem>
-            {stages.map((s) => <SelectItem key={s} value={s}>{s.replaceAll('_', ' ')}</SelectItem>)}
-          </SelectContent>
-        </Select>
         <Select value={owner} onValueChange={(v) => { setOwner(v); setPage(1); }}>
-          <SelectTrigger className="w-40"><SelectValue placeholder="Owner" /></SelectTrigger>
+          <SelectTrigger className="w-40 h-10"><SelectValue placeholder="Owner" /></SelectTrigger>
           <SelectContent>
             <SelectItem value="all">Any owner</SelectItem>
             <SelectItem value="me">My partners</SelectItem>
             <SelectItem value="none">Unowned</SelectItem>
           </SelectContent>
         </Select>
+        <Select value={stage} onValueChange={(v) => { setStage(v); setPage(1); }}>
+          <SelectTrigger className="w-48 h-10"><SelectValue placeholder="Stage" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All stages</SelectItem>
+            {stages.map((s) => <SelectItem key={s} value={s}>{prettyEnum(s)}</SelectItem>)}
+          </SelectContent>
+        </Select>
       </div>
 
-      <Card>
-        <CardContent className="pt-4">
-          <div className="overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Business</TableHead>
-                  <TableHead>Category</TableHead>
-                  <TableHead>Stage</TableHead>
-                  <TableHead>Owner</TableHead>
-                  <TableHead>Last activity</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {partners.map((p) => (
-                  <TableRow
-                    key={p.id}
-                    className="cursor-pointer"
-                    onClick={() => navigate(`/redeem-ops/partners/${p.id}`)}
-                  >
-                    <TableCell className="font-medium">
-                      <span className="flex items-center gap-2">
-                        {p.tradingName || p.brandName || p.legalName}
-                        {(p.atRiskFlag || p.staleFlag) && (
-                          <AlertTriangle className="w-3.5 h-3.5 text-amber-500" aria-label={p.atRiskFlag ? 'At risk — no first outreach' : 'Stale'} />
-                        )}
+      <div className="rounded-2xl border border-border bg-white overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm border-collapse">
+            <thead>
+              <tr className="text-left" style={{ color: 'var(--ro-text-2)' }}>
+                <th className="font-semibold text-[12.5px] px-5 py-3">Business</th>
+                <th className="font-semibold text-[12.5px] px-3 py-3">Category</th>
+                <th className="font-semibold text-[12.5px] px-3 py-3">Stage</th>
+                <th className="font-semibold text-[12.5px] px-3 py-3">Owner</th>
+                <th className="font-semibold text-[12.5px] px-5 py-3 text-right">Last activity</th>
+              </tr>
+            </thead>
+            <tbody>
+              {partners.map((p) => (
+                <tr
+                  key={p.id}
+                  className="cursor-pointer border-t border-border hover:bg-[var(--ro-subtle)] transition-colors"
+                  onClick={() => navigate(`/redeem-ops/partners/${p.id}`)}
+                >
+                  <td className="px-5 py-2.5">
+                    <span className="flex items-center gap-3 min-w-0">
+                      <RoAvatar name={partnerName(p)} size={36} />
+                      <span className="min-w-0">
+                        <span className="font-semibold flex items-center gap-1.5 leading-tight">
+                          <span className="truncate">{partnerName(p)}</span>
+                          {(p.atRiskFlag || p.staleFlag) && (
+                            <AlertTriangle
+                              className="w-3.5 h-3.5 shrink-0"
+                              style={{ color: 'var(--ro-tag-yellow-fg)' }}
+                              aria-label={p.atRiskFlag ? 'At risk — no first outreach' : 'Stale'}
+                            />
+                          )}
+                        </span>
+                        <span className="block text-xs truncate" style={{ color: 'var(--ro-text-2)' }}>
+                          {partnerMeta(p) || '—'}
+                        </span>
                       </span>
-                    </TableCell>
-                    <TableCell className="text-muted-foreground">{p.category || '—'}</TableCell>
-                    <TableCell>
-                      <Badge variant={STAGE_BADGE[p.pipelineStage] || 'secondary'}>
-                        {p.pipelineStage.replaceAll('_', ' ')}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-muted-foreground">{p.owner?.fullName || '—'}</TableCell>
-                    <TableCell className="text-muted-foreground">
-                      {p.lastActivityAt ? new Date(p.lastActivityAt).toLocaleDateString() : 'Never'}
-                    </TableCell>
-                  </TableRow>
-                ))}
-                {!listQuery.isLoading && partners.length === 0 && (
-                  <TableRow>
-                    <TableCell colSpan={5} className="text-center text-muted-foreground py-10">
-                      No businesses match. Add the first one.
-                    </TableCell>
-                  </TableRow>
-                )}
-              </TableBody>
-            </Table>
-          </div>
-          {pagination && pagination.totalPages > 1 && (
-            <div className="flex items-center justify-end gap-2 pt-3">
-              <span className="text-xs text-muted-foreground">
-                Page {pagination.page} of {pagination.totalPages} · {pagination.total} businesses
-              </span>
+                    </span>
+                  </td>
+                  <td className="px-3 py-2.5" style={{ color: 'var(--ro-text-2)' }}>{p.category || '—'}</td>
+                  <td className="px-3 py-2.5"><RoStageTag stage={p.pipelineStage} /></td>
+                  <td className="px-3 py-2.5"><RoOwner name={p.owner?.fullName} /></td>
+                  <td className="px-5 py-2.5 text-right text-[12.5px] tabular-nums" style={{ color: 'var(--ro-text-3)' }}>
+                    {p.lastActivityAt ? new Date(p.lastActivityAt).toLocaleDateString() : 'Never'}
+                  </td>
+                </tr>
+              ))}
+              {!listQuery.isLoading && partners.length === 0 && (
+                <tr className="border-t border-border">
+                  <td colSpan={5} className="text-center py-12" style={{ color: 'var(--ro-text-2)' }}>
+                    No businesses match. Add the first one.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+        {pagination && pagination.totalPages > 1 && (
+          <div className="flex items-center justify-between px-5 py-3 border-t border-border">
+            <span className="text-[13px]" style={{ color: 'var(--ro-text-2)' }}>
+              Page {pagination.page} of {pagination.totalPages} · {pagination.total} businesses
+            </span>
+            <span className="flex gap-2">
               <Button variant="outline" size="sm" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>Prev</Button>
               <Button variant="outline" size="sm" disabled={page >= pagination.totalPages} onClick={() => setPage((p) => p + 1)}>Next</Button>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+            </span>
+          </div>
+        )}
+      </div>
 
       <Dialog open={createOpen} onOpenChange={(open) => { setCreateOpen(open); if (!open) { setDuplicates(null); setOverrideReason(''); } }}>
         <DialogContent className="max-w-lg">
@@ -260,9 +260,9 @@ export default function PartnersList() {
           </div>
 
           {duplicates && (duplicates.exact.length > 0 || duplicates.potential.length > 0) && (
-            <div className="rounded-lg border border-amber-300 bg-amber-50 dark:bg-amber-950/30 p-3 space-y-2 text-sm">
-              <p className="font-medium flex items-center gap-2">
-                <AlertTriangle className="w-4 h-4 text-amber-500" aria-hidden="true" />
+            <div className="rounded-xl p-3.5 space-y-2 text-sm" style={{ background: 'var(--ro-tag-yellow-bg)' }}>
+              <p className="font-semibold flex items-center gap-2 m-0" style={{ color: 'var(--ro-bunker)' }}>
+                <AlertTriangle className="w-4 h-4" style={{ color: 'var(--ro-tag-yellow-fg)' }} aria-hidden="true" />
                 {duplicates.exact.length > 0 ? 'This business may already exist' : 'Similar businesses found'}
               </p>
               {[...duplicates.exact, ...duplicates.potential].slice(0, 4).map((m) => (
@@ -270,13 +270,13 @@ export default function PartnersList() {
                   <span>
                     <Link
                       to={`/redeem-ops/partners/${m.partner.id}`}
-                      className="underline font-medium"
+                      className="ro-link"
                       onClick={() => setCreateOpen(false)}
                     >
                       {m.partner.tradingName || m.partner.legalName}
                     </Link>{' '}
-                    <span className="text-muted-foreground">
-                      — {m.reason} · {m.partner.pipelineStage.replaceAll('_', ' ')}
+                    <span style={{ color: 'var(--ro-text-2)' }}>
+                      — {m.reason} · {prettyEnum(m.partner.pipelineStage)}
                       {m.partner.owner ? ` · owned by ${m.partner.owner.fullName}` : ' · unowned'}
                     </span>
                   </span>

--- a/src/pages/redeemops/PoolsPage.jsx
+++ b/src/pages/redeemops/PoolsPage.jsx
@@ -12,8 +12,8 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Badge } from '@/components/ui/badge';
 import Plus from 'lucide-react/icons/plus';
+import { RoPageHeader, RoTag } from '@/components/redeemops/ui';
 
 export default function PoolsPage() {
   const user = useAuthStore((s) => s.user);
@@ -55,20 +55,16 @@ export default function PoolsPage() {
   const pools = poolsQuery.data || [];
 
   return (
-    <div className="p-6 max-w-5xl mx-auto space-y-4">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Prospecting pools</h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            Curated prospect lists — hit “Claim next” to pull your next business, no cherry-picking, no collisions.
-          </p>
-        </div>
-        {canManage && (
-          <Button size="sm" onClick={() => setCreateOpen(true)}>
-            <Plus className="w-4 h-4 mr-2" aria-hidden="true" /> New pool
+    <div className="p-6 md:p-8 max-w-5xl mx-auto space-y-5">
+      <RoPageHeader
+        title="Prospecting pools"
+        sub="Curated prospect lists — hit “Claim next” to pull your next business, no cherry-picking, no collisions."
+        actions={canManage && (
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" /> New pool
           </Button>
         )}
-      </div>
+      />
 
       <div className="grid gap-4 sm:grid-cols-2">
         {pools.map((pool) => {
@@ -84,8 +80,8 @@ export default function PoolsPage() {
               </CardHeader>
               <CardContent className="flex items-center justify-between">
                 <div className="flex gap-2">
-                  <Badge variant="secondary">{available} available</Badge>
-                  <Badge variant="outline">{claimed} claimed</Badge>
+                  <RoTag tone={available > 0 ? 'active' : 'ended'}>{available} available</RoTag>
+                  <RoTag tone="inactive">{claimed} claimed</RoTag>
                 </div>
                 <Button
                   size="sm"

--- a/src/pages/redeemops/RedeemOpsHome.jsx
+++ b/src/pages/redeemops/RedeemOpsHome.jsx
@@ -1,74 +1,92 @@
 import { Link } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
 import { hasCapability } from '@/lib/redeemOpsPermissions';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { RoPageHeader } from '@/components/redeemops/ui';
+import House from 'lucide-react/icons/house';
 import Users from 'lucide-react/icons/users';
-import Building2 from 'lucide-react/icons/building-2';
+import Gift from 'lucide-react/icons/gift';
+import UserCog from 'lucide-react/icons/user-cog';
 
 /**
- * Redeem Ops overview (Phase 1 shell). Deliberately honest about what exists:
- * modules that haven't shipped are named with their phase, not faked as
- * functional placeholders (docs/redeem-ops/ROUTE_MAP.md §2).
+ * Redeem Ops overview. Deliberately honest about what exists: modules that
+ * haven't shipped are named with their phase, not faked as functional
+ * placeholders (docs/redeem-ops/ROUTE_MAP.md §2).
  */
+function HomeCard({ icon: Icon, iconBg, iconFg, title, body, children }) {
+  return (
+    <div className="rounded-2xl border border-border bg-white p-5">
+      <span className="ro-icon-circle mb-3" style={{ background: iconBg, color: iconFg }} aria-hidden="true">
+        <Icon className="w-4 h-4" />
+      </span>
+      <p className="text-[15px] font-bold m-0">{title}</p>
+      <p className="text-[13px] mt-1 mb-4 leading-relaxed" style={{ color: 'var(--ro-text-2)' }}>{body}</p>
+      <div className="flex flex-wrap gap-2">{children}</div>
+    </div>
+  );
+}
+
 export default function RedeemOpsHome() {
   const user = useAuthStore((s) => s.user);
   const canManageTeam = hasCapability(user, 'team.manage_access');
   const canSeeTeam = hasCapability(user, 'analytics.view_team');
+  const canSeeRewards = hasCapability(user, 'rewards.view');
 
   return (
-    <div className="p-6 max-w-5xl mx-auto space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">Redeem Ops</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          Partner prospecting, rewards, and redemption operations.
-        </p>
-      </div>
+    <div className="p-6 md:p-8 max-w-5xl mx-auto space-y-6">
+      <RoPageHeader
+        title="Redeem Ops"
+        sub="Partner prospecting, rewards, and redemption operations."
+      />
 
       <div className="grid gap-4 sm:grid-cols-2">
-        {canSeeTeam && (
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2 text-base">
-                <Users className="w-4 h-4" aria-hidden="true" />
-                Team &amp; access
-              </CardTitle>
-              <CardDescription>
-                {canManageTeam
-                  ? 'Invite outreach staff and manage Redeem Ops sub-roles.'
-                  : 'See who is on the Redeem Ops team.'}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <Button asChild size="sm">
-                <Link to="/redeem-ops/team">Open Team</Link>
-              </Button>
-            </CardContent>
-          </Card>
+        <HomeCard
+          icon={House}
+          iconBg="var(--ro-tag-blue-bg)"
+          iconFg="var(--ro-tag-blue-fg)"
+          title="Your day"
+          body="Start in the queue — overdue follow-ups, first touches and fresh replies, in order of urgency."
+        >
+          <Button asChild size="sm"><Link to="/redeem-ops/queue">My queue</Link></Button>
+        </HomeCard>
+
+        <HomeCard
+          icon={Users}
+          iconBg="var(--ro-tag-purple-bg)"
+          iconFg="var(--ro-tag-purple-fg)"
+          title="Partner CRM"
+          body="Search the shared business database, claim prospects, log outreach, move the pipeline."
+        >
+          <Button asChild size="sm" variant="outline"><Link to="/redeem-ops/partners">Partners</Link></Button>
+          <Button asChild size="sm" variant="outline"><Link to="/redeem-ops/pools">Pools</Link></Button>
+        </HomeCard>
+
+        {canSeeRewards && (
+          <HomeCard
+            icon={Gift}
+            iconBg="var(--ro-tag-green-bg)"
+            iconFg="var(--ro-tag-green-fg)"
+            title="Rewards & fulfilment"
+            body="Partner-funded reward supply, campaign activations and counter redemptions — all ledgered."
+          >
+            <Button asChild size="sm" variant="outline"><Link to="/redeem-ops/rewards">Rewards</Link></Button>
+            <Button asChild size="sm" variant="outline"><Link to="/redeem-ops/activations">Activations</Link></Button>
+          </HomeCard>
         )}
 
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-base">
-              <Building2 className="w-4 h-4" aria-hidden="true" />
-              Partner CRM
-            </CardTitle>
-            <CardDescription>
-              Search the shared business database, claim prospects, log outreach, move the pipeline.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="flex gap-2">
-            <Button asChild size="sm">
-              <Link to="/redeem-ops/queue">My queue</Link>
-            </Button>
-            <Button asChild size="sm" variant="outline">
-              <Link to="/redeem-ops/partners">Partners</Link>
-            </Button>
-            <Button asChild size="sm" variant="outline">
-              <Link to="/redeem-ops/pools">Pools</Link>
-            </Button>
-          </CardContent>
-        </Card>
+        {canSeeTeam && (
+          <HomeCard
+            icon={UserCog}
+            iconBg="var(--ro-tag-yellow-bg)"
+            iconFg="var(--ro-tag-yellow-fg)"
+            title="Team & access"
+            body={canManageTeam
+              ? 'Invite outreach staff and manage Redeem Ops sub-roles.'
+              : 'See who is on the Redeem Ops team.'}
+          >
+            <Button asChild size="sm" variant="outline"><Link to="/redeem-ops/team">Open Team</Link></Button>
+          </HomeCard>
+        )}
       </div>
     </div>
   );

--- a/src/pages/redeemops/RedeemOpsTeam.jsx
+++ b/src/pages/redeemops/RedeemOpsTeam.jsx
@@ -17,8 +17,8 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Badge } from '@/components/ui/badge';
 import UserPlus from 'lucide-react/icons/user-plus';
+import { RoTag, RoAvatar } from '@/components/redeemops/ui';
 
 const TEAM_KEY = ['redeem-ops', 'team'];
 
@@ -63,19 +63,19 @@ export default function RedeemOpsTeam() {
   const team = teamQuery.data || [];
 
   return (
-    <div className="p-6 max-w-5xl mx-auto space-y-6">
-      <div className="flex items-start justify-between gap-4">
+    <div className="p-6 md:p-8 max-w-5xl mx-auto space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Team &amp; access</h1>
-          <p className="text-sm text-muted-foreground mt-1">
+          <h1 className="ro-title">Team &amp; access</h1>
+          <p className="ro-sub">
             Redeem Ops staff and their sub-roles. Admins are implicit super admins.
           </p>
         </div>
         {canManage && (
           <Dialog open={inviteOpen} onOpenChange={setInviteOpen}>
             <DialogTrigger asChild>
-              <Button size="sm">
-                <UserPlus className="w-4 h-4 mr-2" aria-hidden="true" />
+              <Button>
+                <UserPlus className="w-4 h-4 mr-1.5" aria-hidden="true" />
                 Invite staff
               </Button>
             </DialogTrigger>
@@ -161,7 +161,10 @@ export default function RedeemOpsTeam() {
                 {team.map((member) => (
                   <TableRow key={member.id}>
                     <TableCell className="font-medium">
-                      {member.fullName || [member.firstName, member.lastName].filter(Boolean).join(' ') || '—'}
+                      <span className="flex items-center gap-2.5">
+                        <RoAvatar name={member.fullName || member.email} size={30} />
+                        {member.fullName || [member.firstName, member.lastName].filter(Boolean).join(' ') || '—'}
+                      </span>
                     </TableCell>
                     <TableCell className="text-muted-foreground">{member.email}</TableCell>
                     <TableCell>
@@ -182,15 +185,15 @@ export default function RedeemOpsTeam() {
                           </SelectContent>
                         </Select>
                       ) : (
-                        <Badge variant="secondary">
+                        <RoTag tone="primary" size="sm">
                           {subRoleLabels[member.redeemOpsRole] || member.redeemOpsRole || '—'}
-                        </Badge>
+                        </RoTag>
                       )}
                     </TableCell>
                     <TableCell>
-                      <Badge variant={member.isActive ? 'default' : 'outline'}>
+                      <RoTag tone={member.isActive ? 'active' : 'inactive'} size="sm">
                         {member.isActive ? 'Active' : 'Inactive'}
-                      </Badge>
+                      </RoTag>
                     </TableCell>
                   </TableRow>
                 ))}

--- a/src/pages/redeemops/RedemptionsPage.jsx
+++ b/src/pages/redeemops/RedemptionsPage.jsx
@@ -8,8 +8,8 @@ import {
 } from '@/components/ui/table';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
 import ScanLine from 'lucide-react/icons/scan-line';
+import { RoPageHeader, RoTag, prettyEnum } from '@/components/redeemops/ui';
 
 export default function RedemptionsPage() {
   const queryClient = useQueryClient();
@@ -43,13 +43,11 @@ export default function RedemptionsPage() {
   const redemptions = historyQuery.data?.redemptions || [];
 
   return (
-    <div className="p-6 max-w-5xl mx-auto space-y-4">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">Redemptions</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          Verify a voucher, confirm identity, redeem — double redemption is impossible.
-        </p>
-      </div>
+    <div className="p-6 md:p-8 max-w-5xl mx-auto space-y-5">
+      <RoPageHeader
+        title="Redemptions"
+        sub="Verify a voucher, confirm identity, redeem — double redemption is impossible."
+      />
 
       <Card>
         <CardHeader>
@@ -72,12 +70,15 @@ export default function RedemptionsPage() {
           </div>
 
           {verified && (
-            <div className={`rounded-lg border p-4 space-y-2 ${verified.valid ? 'border-emerald-300 bg-emerald-50 dark:bg-emerald-950/30' : 'border-destructive/40 bg-destructive/5'}`}>
+            <div
+              className="rounded-xl p-4 space-y-2"
+              style={{ background: verified.valid ? 'var(--ro-tag-green-bg)' : 'var(--ro-tag-red-bg)' }}
+            >
               <div className="flex items-center justify-between">
-                <p className="font-medium">{verified.reward?.title}</p>
-                <Badge variant={verified.valid ? 'default' : 'destructive'}>
-                  {verified.valid ? 'VALID' : verified.state.toUpperCase()}
-                </Badge>
+                <p className="font-semibold m-0">{verified.reward?.title}</p>
+                <RoTag tone={verified.valid ? 'redeemed' : 'void'}>
+                  {verified.valid ? 'Valid' : prettyEnum(verified.state)}
+                </RoTag>
               </div>
               {verified.holder && (
                 <p className="text-sm text-muted-foreground">
@@ -128,7 +129,7 @@ export default function RedemptionsPage() {
                     <TableCell className="text-muted-foreground">{new Date(r.redeemedAt).toLocaleString()}</TableCell>
                     <TableCell className="text-muted-foreground">{r.actor?.fullName || r.actorType}</TableCell>
                     <TableCell>
-                      <Badge variant={r.status === 'completed' ? 'default' : 'destructive'}>{r.status}</Badge>
+                      <RoTag tone={r.status === 'completed' ? 'completed' : 'void'} size="sm">{prettyEnum(r.status)}</RoTag>
                     </TableCell>
                   </TableRow>
                 ))}

--- a/src/pages/redeemops/RewardDetail.jsx
+++ b/src/pages/redeemops/RewardDetail.jsx
@@ -13,17 +13,8 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Badge } from '@/components/ui/badge';
 import { Textarea } from '@/components/ui/textarea';
-
-function Counter({ label, value }) {
-  return (
-    <div className="text-center">
-      <p className="text-2xl font-semibold tabular-nums">{value}</p>
-      <p className="text-xs text-muted-foreground">{label}</p>
-    </div>
-  );
-}
+import { RoTag, RoStatTile, prettyEnum } from '@/components/redeemops/ui';
 
 export default function RewardDetail() {
   const { id } = useParams();
@@ -74,41 +65,38 @@ export default function RewardDetail() {
   const remaining = offer.committedQuantity - offer.allocatedQuantity;
 
   return (
-    <div className="p-6 max-w-5xl mx-auto space-y-4">
-      <Card>
-        <CardContent className="pt-5">
-          <div className="flex flex-wrap items-start justify-between gap-4">
-            <div>
-              <h1 className="text-xl font-semibold tracking-tight">{offer.title}</h1>
-              <p className="text-sm text-muted-foreground mt-0.5">
-                {offer.partner?.tradingName || offer.partner?.legalName}
-                {' · '}{offer.rewardType.replaceAll('_', ' ')}
-                {offer.retailValue ? ` · worth S$${offer.retailValue}` : ''}
-              </p>
-            </div>
-            <div className="flex items-center gap-2">
-              <Badge variant={offer.status === 'active' ? 'default' : 'secondary'}>{offer.status}</Badge>
-              {canManage && (
-                <Select value={offer.status} onValueChange={(s) => statusMutation.mutate(s)}>
-                  <SelectTrigger className="w-32 h-9"><SelectValue /></SelectTrigger>
-                  <SelectContent>
-                    {['draft', 'active', 'paused', 'ended'].map((s) => (
-                      <SelectItem key={s} value={s}>{s}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              )}
-            </div>
-          </div>
-          <div className="grid grid-cols-5 gap-3 mt-5">
-            <Counter label="Committed" value={offer.committedQuantity} />
-            <Counter label="Allocated" value={offer.allocatedQuantity} />
-            <Counter label="Unallocated" value={remaining} />
-            <Counter label="Issued" value={offer.issuedQuantity} />
-            <Counter label="Redeemed" value={offer.redeemedQuantity} />
-          </div>
-        </CardContent>
-      </Card>
+    <div className="p-6 md:p-8 max-w-5xl mx-auto space-y-5">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="ro-title text-[26px]">{offer.title}</h1>
+          <p className="ro-sub">
+            {offer.partner?.tradingName || offer.partner?.legalName}
+            {' · '}{prettyEnum(offer.rewardType)}
+            {offer.retailValue ? ` · worth S$${offer.retailValue}` : ''}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <RoTag tone={offer.status}>{prettyEnum(offer.status)}</RoTag>
+          {canManage && (
+            <Select value={offer.status} onValueChange={(s) => statusMutation.mutate(s)}>
+              <SelectTrigger className="w-32 h-10"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                {['draft', 'active', 'paused', 'ended'].map((s) => (
+                  <SelectItem key={s} value={s}>{prettyEnum(s)}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+      </div>
+
+      <div className="ro-tiles">
+        <RoStatTile label="Committed" value={offer.committedQuantity} />
+        <RoStatTile label="Allocated" value={offer.allocatedQuantity} />
+        <RoStatTile label="Unallocated" value={remaining} />
+        <RoStatTile label="Issued" value={offer.issuedQuantity} />
+        <RoStatTile label="Redeemed" value={offer.redeemedQuantity} />
+      </div>
 
       <Tabs defaultValue="ledger">
         <TabsList>
@@ -122,10 +110,10 @@ export default function RewardDetail() {
             <CardContent className="pt-5 space-y-2">
               {(ledgerQuery.data || []).map((e) => (
                 <div key={e.id} className="flex items-center justify-between border-b border-border pb-2 last:border-0 text-sm">
-                  <span>
-                    <Badge variant="outline" className="mr-2">{e.type.replaceAll('_', ' ')}</Badge>
-                    {e.quantity} unit{e.quantity === 1 ? '' : 's'}
-                    {e.reason ? <span className="text-muted-foreground"> — {e.reason}</span> : ''}
+                  <span className="flex items-center gap-2">
+                    <RoTag tone="inactive" size="sm">{prettyEnum(e.type)}</RoTag>
+                    <span className="tabular-nums">{e.quantity} unit{e.quantity === 1 ? '' : 's'}</span>
+                    {e.reason ? <span className="text-muted-foreground">— {e.reason}</span> : ''}
                   </span>
                   <span className="text-xs text-muted-foreground">
                     {e.actor?.fullName || e.actorType} · {new Date(e.createdAt).toLocaleString()}

--- a/src/pages/redeemops/RewardsPage.jsx
+++ b/src/pages/redeemops/RewardsPage.jsx
@@ -18,10 +18,9 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Badge } from '@/components/ui/badge';
 import Plus from 'lucide-react/icons/plus';
+import { RoPageHeader, RoTag, prettyEnum } from '@/components/redeemops/ui';
 
-const STATUS_BADGE = { active: 'default', draft: 'secondary', paused: 'outline', ended: 'outline' };
 const EMPTY = { partnerOrganisationId: '', title: '', rewardType: 'free_service', retailValue: '', committedQuantity: '' };
 
 export default function RewardsPage() {
@@ -65,20 +64,16 @@ export default function RewardsPage() {
   const rewardTypes = constants.data?.rewardTypes || [];
 
   return (
-    <div className="p-6 max-w-6xl mx-auto space-y-4">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Rewards</h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            Partner-funded reward supply — every quantity movement is ledgered.
-          </p>
-        </div>
-        {canManage && (
-          <Button size="sm" onClick={() => setCreateOpen(true)}>
-            <Plus className="w-4 h-4 mr-2" aria-hidden="true" /> New reward
+    <div className="p-6 md:p-8 max-w-6xl mx-auto space-y-5">
+      <RoPageHeader
+        title="Rewards"
+        sub="Partner-funded reward supply — every quantity movement is ledgered."
+        actions={canManage && (
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" /> New reward
           </Button>
         )}
-      </div>
+      />
 
       <Card>
         <CardContent className="pt-4">
@@ -102,7 +97,7 @@ export default function RewardsPage() {
                     <TableCell className="text-muted-foreground">
                       {o.partner?.tradingName || o.partner?.legalName || '—'}
                     </TableCell>
-                    <TableCell><Badge variant={STATUS_BADGE[o.status] || 'secondary'}>{o.status}</Badge></TableCell>
+                    <TableCell><RoTag tone={o.status} size="sm">{prettyEnum(o.status)}</RoTag></TableCell>
                     <TableCell className="text-right">{o.committedQuantity}</TableCell>
                     <TableCell className="text-right">{o.allocatedQuantity}</TableCell>
                     <TableCell className="text-right">{o.issuedQuantity}</TableCell>

--- a/src/pages/redeemops/TasksPage.jsx
+++ b/src/pages/redeemops/TasksPage.jsx
@@ -5,13 +5,12 @@ import { toast } from 'sonner';
 import { redeemOpsApi } from '@/api/redeemOps';
 import { useAuthStore } from '@/stores/authStore';
 import { hasCapability } from '@/lib/redeemOpsPermissions';
-import { Card, CardContent } from '@/components/ui/card';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '@/components/ui/table';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
+import { RoPageHeader, RoTag } from '@/components/redeemops/ui';
 
 const VIEWS = [
   { key: 'today', label: 'Due today', params: { due: 'today' } },
@@ -20,8 +19,6 @@ const VIEWS = [
   { key: 'mine', label: 'All mine', params: {} },
   { key: 'team', label: 'Team', params: { scope: 'team' }, managerOnly: true },
 ];
-
-const PRIORITY_BADGE = { high: 'destructive', medium: 'secondary', low: 'outline' };
 
 export default function TasksPage() {
   const user = useAuthStore((s) => s.user);
@@ -49,13 +46,11 @@ export default function TasksPage() {
   const tasks = tasksQuery.data?.tasks || [];
 
   return (
-    <div className="p-6 max-w-5xl mx-auto space-y-4">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">Tasks</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          Follow-ups are tasks, not notes — create them from a partner's page.
-        </p>
-      </div>
+    <div className="p-6 md:p-8 max-w-5xl mx-auto space-y-5">
+      <RoPageHeader
+        title="Tasks"
+        sub="Follow-ups are tasks, not notes — create them from a partner's page."
+      />
 
       <Tabs value={view} onValueChange={setView}>
         <TabsList>
@@ -65,8 +60,8 @@ export default function TasksPage() {
         </TabsList>
       </Tabs>
 
-      <Card>
-        <CardContent className="pt-4">
+      <div className="rounded-2xl border border-border bg-white overflow-hidden">
+        <div className="px-2 py-1">
           <div className="overflow-x-auto">
             <Table>
               <TableHeader>
@@ -84,7 +79,7 @@ export default function TasksPage() {
                   <TableRow key={t.id}>
                     <TableCell className="font-medium">{t.title}</TableCell>
                     <TableCell>
-                      <Link to={`/redeem-ops/partners/${t.partner?.id}`} className="underline text-sm">
+                      <Link to={`/redeem-ops/partners/${t.partner?.id}`} className="ro-link text-sm">
                         {t.partner?.tradingName || t.partner?.brandName || t.partner?.legalName || '—'}
                       </Link>
                     </TableCell>
@@ -93,7 +88,7 @@ export default function TasksPage() {
                       {t.hasTime ? ` ${new Date(t.dueAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}` : ''}
                     </TableCell>
                     <TableCell>
-                      <Badge variant={PRIORITY_BADGE[t.priority] || 'secondary'}>{t.priority}</Badge>
+                      <RoTag tone={t.priority} size="sm">{t.priority}</RoTag>
                     </TableCell>
                     {view === 'team' && (
                       <TableCell className="text-muted-foreground text-sm">{t.assignee?.fullName || '—'}</TableCell>
@@ -130,8 +125,8 @@ export default function TasksPage() {
               </TableBody>
             </Table>
           </div>
-        </CardContent>
-      </Card>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/pages/redeemops/TeamPipeline.jsx
+++ b/src/pages/redeemops/TeamPipeline.jsx
@@ -1,9 +1,8 @@
 import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { redeemOpsApi } from '@/api/redeemOps';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
 import AlertTriangle from 'lucide-react/icons/alert-triangle';
+import { RoPageHeader, RoAvatar, prettyEnum } from '@/components/redeemops/ui';
 
 /**
  * Manager board: pipeline stages as columns, partner cards inside. Stage moves
@@ -31,50 +30,57 @@ export default function TeamPipeline() {
   }
 
   return (
-    <div className="p-6 space-y-4">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">Team pipeline</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          Everyone's opportunities by stage. Click a business to act on it.
-        </p>
-      </div>
+    <div className="p-6 md:p-8 space-y-5">
+      <RoPageHeader
+        title="Team pipeline"
+        sub="Everyone's opportunities by stage. Click a business to act on it."
+      />
 
       <div className="flex gap-3 overflow-x-auto pb-4">
         {stages.map((stage) => {
           const items = byStage[stage] || [];
           if (items.length === 0 && ['NO_RESPONSE', 'NOT_INTERESTED', 'DISQUALIFIED'].includes(stage)) return null;
           return (
-            <Card key={stage} className="min-w-64 w-64 shrink-0">
-              <CardHeader className="pb-2">
-                <CardTitle className="text-sm flex items-center justify-between">
-                  {stage.replaceAll('_', ' ')}
-                  <Badge variant="secondary">{items.length}</Badge>
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-2">
+            <div key={stage} className="min-w-64 w-64 shrink-0">
+              <div className="flex items-center justify-between px-1 pb-2">
+                <p className="text-[12.5px] font-bold m-0" style={{ color: 'var(--ro-text-2)' }}>
+                  {prettyEnum(stage)}
+                </p>
+                <span className="text-[11.5px] font-bold tabular-nums rounded-full px-2 py-0.5"
+                  style={{ background: 'var(--ro-tag-gray-bg)', color: 'var(--ro-tag-gray-fg)' }}
+                >
+                  {items.length}
+                </span>
+              </div>
+              <div className="space-y-2">
                 {items.slice(0, 30).map((p) => (
                   <Link
                     key={p.id}
                     to={`/redeem-ops/partners/${p.id}`}
-                    className="block rounded-md border border-border p-2 hover:bg-accent transition-colors"
+                    className="block rounded-xl border border-border bg-white p-3 hover:bg-[var(--ro-subtle)] transition-colors no-underline"
                   >
-                    <p className="text-sm font-medium flex items-center gap-1.5">
-                      {p.tradingName || p.brandName || p.legalName}
+                    <p className="text-sm font-semibold flex items-center gap-1.5 m-0 text-foreground">
+                      <span className="truncate">{p.tradingName || p.brandName || p.legalName}</span>
                       {(p.atRiskFlag || p.staleFlag) && (
-                        <AlertTriangle className="w-3 h-3 text-amber-500" aria-hidden="true" />
+                        <AlertTriangle className="w-3 h-3 shrink-0" style={{ color: 'var(--ro-tag-yellow-fg)' }} aria-hidden="true" />
                       )}
                     </p>
-                    <p className="text-xs text-muted-foreground">
-                      {p.owner?.fullName || 'Unowned'}
-                      {p.category ? ` · ${p.category}` : ''}
+                    <p className="text-xs m-0 mt-1.5 flex items-center gap-1.5" style={{ color: 'var(--ro-text-2)' }}>
+                      {p.owner?.fullName ? (
+                        <>
+                          <RoAvatar name={p.owner.fullName} size={18} />
+                          {p.owner.fullName.split(/\s+/)[0]}
+                        </>
+                      ) : 'Unowned'}
+                      {p.category ? <span className="truncate">· {p.category}</span> : null}
                     </p>
                   </Link>
                 ))}
                 {items.length === 0 && (
-                  <p className="text-xs text-muted-foreground py-2">Empty</p>
+                  <p className="text-xs px-1 py-2 m-0" style={{ color: 'var(--ro-text-3)' }}>Empty</p>
                 )}
-              </CardContent>
-            </Card>
+              </div>
+            </div>
           );
         })}
       </div>

--- a/src/styles/redeem-ops-theme.css
+++ b/src/styles/redeem-ops-theme.css
@@ -1,0 +1,294 @@
+/*
+ * Redeem Ops — Fresha-language theme (design source of truth:
+ * claude.ai/design "Redeem Ops Design System", tokens.css).
+ *
+ * Scoping: RedeemOpsLayout renders a `.ro-app` wrapper that owns the full
+ * viewport. Radix portals (Dialog/Select/Dropdown/Sonner) mount on <body>,
+ * OUTSIDE that wrapper, so the shadcn variables are re-declared on
+ * `:root:has(.ro-app)` — the whole document speaks Fresha while a Redeem Ops
+ * screen is mounted, and reverts to Tropic the moment it unmounts. Nothing
+ * here leaks into the mktr admin, which never mounts `.ro-app`.
+ */
+
+:root:has(.ro-app) {
+  /* shadcn semantic variables — Bunker #0D1619 / white / Azure #037AFF */
+  --background: 0 0% 100%;
+  --foreground: 195 32% 7%;
+  --card: 0 0% 100%;
+  --card-foreground: 195 32% 7%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 195 32% 7%;
+  --primary: 195 32% 7%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 200 20% 97%;
+  --secondary-foreground: 210 10% 40%;
+  --muted: 210 15% 95%;
+  --muted-foreground: 210 10% 40%;
+  --accent: 200 20% 97%;
+  --accent-foreground: 195 32% 7%;
+  --destructive: 5 61% 46%;
+  --destructive-foreground: 0 0% 100%;
+  --info: 212 100% 51%;
+  --info-foreground: 0 0% 100%;
+  --success: 142 66% 27%;
+  --success-foreground: 0 0% 100%;
+  --warning: 42 100% 28%;
+  --warning-foreground: 0 0% 100%;
+  --border: 210 12% 91%;
+  --input: 210 11% 85%;
+  --ring: 212 100% 51%;
+  --radius: 1rem;
+
+  /* Fresha raw tokens (tag pastels etc.) for the ro-* classes below */
+  --ro-bunker: #0d1619;
+  --ro-text-2: #5c6670;
+  --ro-text-3: #98a1aa;
+  --ro-border: #e4e7ea;
+  --ro-border-strong: #d5d9dd;
+  --ro-subtle: #f6f8f9;
+  --ro-azure: #037aff;
+  --ro-tag-blue-bg: #e5f1ff;
+  --ro-tag-blue-fg: #0364d3;
+  --ro-tag-green-bg: #e3f5e9;
+  --ro-tag-green-fg: #177239;
+  --ro-tag-yellow-bg: #fff2d6;
+  --ro-tag-yellow-fg: #8f6400;
+  --ro-tag-red-bg: #fdeae8;
+  --ro-tag-red-fg: #bd3a2e;
+  --ro-tag-purple-bg: #f0eafe;
+  --ro-tag-purple-fg: #6a3fd1;
+  --ro-tag-gray-bg: #f0f2f4;
+  --ro-tag-gray-fg: #4c555e;
+}
+
+/* Everything on screen is Redeem Ops while .ro-app is mounted — portals too. */
+:root:has(.ro-app) body {
+  font-family: 'Figtree', -apple-system, 'Segoe UI', system-ui, sans-serif;
+}
+
+/* Fresha rounds every action into a pill; checkboxes become circles. */
+:root:has(.ro-app) button {
+  border-radius: 9999px;
+}
+:root:has(.ro-app) [role='tablist'] {
+  border-radius: 9999px;
+}
+
+.ro-app {
+  min-height: 100vh;
+  display: flex;
+  background: #fff;
+  color: var(--ro-bunker);
+  font-family: 'Figtree', -apple-system, 'Segoe UI', system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ── Dark icon rail ──────────────────────────────────────────────────── */
+.ro-rail {
+  width: 78px;
+  flex: none;
+  background: var(--ro-bunker);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 16px 0;
+  gap: 4px;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  z-index: 30;
+}
+.ro-rail-logo {
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  background: #fff;
+  color: var(--ro-bunker);
+  display: grid;
+  place-items: center;
+  font-weight: 800;
+  font-size: 16px;
+  margin-bottom: 14px;
+}
+.ro-rail-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+  align-items: center;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+.ro-rail-item {
+  width: 62px;
+  padding: 9px 0 7px;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  color: rgba(255, 255, 255, 0.62);
+  text-decoration: none;
+  transition: color 120ms ease, background-color 120ms ease;
+}
+.ro-rail-item svg {
+  width: 19px;
+  height: 19px;
+}
+.ro-rail-item span {
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+.ro-rail-item:hover {
+  color: rgba(255, 255, 255, 0.92);
+}
+.ro-rail-item.active {
+  background: rgba(255, 255, 255, 0.14);
+  color: #fff;
+}
+.ro-rail-me {
+  margin-top: auto;
+}
+
+/* ── Content column ──────────────────────────────────────────────────── */
+.ro-main {
+  flex: 1;
+  min-width: 0;
+  height: 100vh;
+  overflow-y: auto;
+}
+
+/* ── Page header ─────────────────────────────────────────────────────── */
+.ro-title {
+  font-size: 28px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  margin: 0;
+}
+.ro-sub {
+  font-size: 14px;
+  color: var(--ro-text-2);
+  margin: 4px 0 0;
+}
+
+/* ── Status tags — six pastel families ───────────────────────────────── */
+.ro-tag {
+  display: inline-flex;
+  align-items: center;
+  height: 26px;
+  padding: 0 11px;
+  border-radius: 8px;
+  font-size: 12.5px;
+  font-weight: 600;
+  white-space: nowrap;
+  border: 1px solid transparent;
+}
+.ro-tag--blue { color: var(--ro-tag-blue-fg); background: var(--ro-tag-blue-bg); }
+.ro-tag--green { color: var(--ro-tag-green-fg); background: var(--ro-tag-green-bg); }
+.ro-tag--yellow { color: var(--ro-tag-yellow-fg); background: var(--ro-tag-yellow-bg); }
+.ro-tag--red { color: var(--ro-tag-red-fg); background: var(--ro-tag-red-bg); }
+.ro-tag--purple { color: var(--ro-tag-purple-fg); background: var(--ro-tag-purple-bg); }
+.ro-tag--gray { color: var(--ro-tag-gray-fg); background: var(--ro-tag-gray-bg); }
+.ro-tag--outline { color: var(--ro-text-2); background: #fff; border-color: var(--ro-border); }
+.ro-tag--faded { opacity: 0.62; }
+.ro-tag--sm { height: 22px; padding: 0 9px; font-size: 11.5px; }
+
+/* ── Avatars — deterministic pastel initials ─────────────────────────── */
+.ro-avatar {
+  border-radius: 9999px;
+  display: inline-grid;
+  place-items: center;
+  font-weight: 700;
+  flex: none;
+  user-select: none;
+}
+
+/* ── Stat tiles ──────────────────────────────────────────────────────── */
+.ro-tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 12px;
+}
+.ro-tile {
+  background: #fff;
+  border: 1px solid var(--ro-border);
+  border-radius: 16px;
+  padding: 16px 18px;
+}
+.ro-tile b {
+  font-size: 26px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  display: block;
+  line-height: 1.15;
+  font-variant-numeric: tabular-nums;
+}
+.ro-tile span {
+  font-size: 12.5px;
+  color: var(--ro-text-2);
+  font-weight: 500;
+}
+.ro-tile--hot b { color: var(--ro-tag-red-fg); }
+
+/* ── Search input (pill with magnifier) ──────────────────────────────── */
+.ro-search {
+  height: 40px;
+  border: 1px solid var(--ro-border-strong);
+  border-radius: 9999px;
+  background: #fff;
+  padding: 0 16px 0 38px;
+  font-family: inherit;
+  font-size: 13.5px;
+  color: var(--ro-bunker);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='15' height='15' viewBox='0 0 24 24' fill='none' stroke='%235C6670' stroke-width='2.2'%3E%3Ccircle cx='11' cy='11' r='7'/%3E%3Cpath d='M21 21l-4.3-4.3'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: 14px center;
+}
+.ro-search::placeholder { color: var(--ro-text-3); }
+.ro-search:focus {
+  outline: 2px solid var(--ro-azure);
+  outline-offset: 1px;
+  border-color: transparent;
+}
+
+/* ── Timeline icon circles (replaces border-left stripes) ────────────── */
+.ro-icon-circle {
+  width: 36px;
+  height: 36px;
+  border-radius: 9999px;
+  display: grid;
+  place-items: center;
+  flex: none;
+}
+
+/* ── Progress bar (onboarding) ───────────────────────────────────────── */
+.ro-progress {
+  height: 6px;
+  border-radius: 9999px;
+  background: var(--ro-tag-gray-bg);
+  overflow: hidden;
+}
+.ro-progress i {
+  display: block;
+  height: 100%;
+  background: var(--ro-azure);
+  border-radius: 9999px;
+  transition: width 300ms ease;
+}
+
+/* ── Docket group labels ─────────────────────────────────────────────── */
+.ro-group-label {
+  font-size: 12.5px;
+  font-weight: 700;
+  padding: 12px 20px 6px;
+}
+
+/* Azure text links (Fresha: azure points, black pills act) */
+.ro-link {
+  color: var(--ro-azure);
+  font-weight: 600;
+  text-decoration: none;
+}
+.ro-link:hover { text-decoration: underline; }


### PR DESCRIPTION
## What

Full visual redesign of the Redeem Ops staff surface (`/redeem-ops/*`) in the **Fresha design language**, per the approved [Redeem Ops Design System](https://claude.ai/design/p/d98047ba-5c99-4732-8902-c376152d19de) on claude.ai/design:

- **Bunker `#0D1619` + white + Azure `#037AFF`** — black pill primary actions, azure for links/selection, white canvas with 1px-bordered 16px-radius cards
- **Slim dark icon rail** (capability-filtered, mirrors the route guards) replaces the mktr admin sidebar via a new `RedeemOpsLayout`
- **Six pastel tag families** carry all 14 pipeline stages + every status/priority enum (`RoStageTag` / `RoTag`)
- **Deterministic pastel avatars** (`RoAvatar`) lead every people/business row
- **Figtree** (closest Google-font stand-in for Fresha's Roobert), injected only when a Redeem Ops screen mounts
- MyQueue → Fresha home (greeting, day stat tiles, urgency-ordered docket, pool/gone-quiet rail); PartnersList → avatar-led ledger with pill search; PartnerDetail → profile header + pastel icon-circle timeline + onboarding progress bar; all other pages restyled via shared primitives

## How it's scoped (no leakage)

`src/styles/redeem-ops-theme.css` re-declares the shadcn CSS variables on `:root:has(.ro-app)` — the whole document (including Radix **portals**: dialogs, selects, dropdowns, toasts) speaks Fresha while a Redeem Ops screen is mounted, and reverts to Tropic the moment it unmounts. The mktr admin never mounts `.ro-app`, so nothing changes there. Behaviour (queries, mutations, capability gates, guards) is untouched; still dark behind `VITE_REDEEM_OPS_ENABLED`.

## Verification

- `npx vite build` ✓ (mktr brand) and `VITE_BRAND=redeem npx vite build` ✓
- `npx vitest run` ✓ — 92 files, 1113 tests passed
- `npx eslint` on all touched files ✓ (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqCcNpihKgDTQ9YG811btF