### PR TITLE
feat(redeem-ops): add-task + stock-pools + manual unlock + Google-on-ops

### DIFF
--- a/backend/src/controllers/redeemOps/fulfilmentController.js
+++ b/backend/src/controllers/redeemOps/fulfilmentController.js
@@ -14,6 +14,35 @@ export const listEntitlements = asyncHandler(async (req, res) => {
   res.json({ success: true, data });
 });
 
+export const unlockEntitlement = asyncHandler(async (req, res) => {
+  const body = validateBody(
+    Joi.object({
+      prospectId: Joi.string().uuid(),
+      presentationToken: Joi.string().max(256),
+    }).or('prospectId', 'presentationToken'),
+    req.body
+  );
+  // Service enforces the consultant binding: non-admin callers must be the
+  // lead's assigned consultant; role=admin overrides (audited as via=manual).
+  const result = await entitlementService.unlockEntitlement(body, req.user, 'manual');
+  const e = result.entitlement;
+  res.json({
+    success: true,
+    data: {
+      already: result.already,
+      // The raw voucher token is NOT returned here — it travels to the
+      // consumer via the unlock email; staff see only the hint.
+      entitlement: {
+        id: e.id,
+        status: e.status,
+        tokenHint: e.tokenHint,
+        expiresAt: e.expiresAt,
+        unlockedVia: e.unlockedVia,
+      },
+    },
+  });
+});
+
 export const issueManual = asyncHandler(async (req, res) => {
   const body = validateBody(
     Joi.object({

--- a/backend/src/routes/redeemOpsFulfilment.js
+++ b/backend/src/routes/redeemOpsFulfilment.js
@@ -19,6 +19,9 @@ const router = express.Router();
 // Entitlements
 router.get('/entitlements', requireRedeemOps('entitlements.view'), ctrl.listEntitlements);
 router.post('/entitlements', requireRedeemOps('entitlements.issue_manual'), ctrl.issueManual);
+// Manual unlock (testing / counter fallback). The capability gates the route;
+// the service additionally enforces assigned-consultant binding for non-admins.
+router.post('/entitlements/unlock', requireRedeemOps('entitlements.issue_manual'), ctrl.unlockEntitlement);
 router.patch('/entitlements/:id/cancel', requireRedeemOps('entitlements.issue_manual'), ctrl.cancelEntitlement);
 
 // Redemption console (voucher verify → complete; unmasked holder identity here only)

--- a/backend/src/services/authService.js
+++ b/backend/src/services/authService.js
@@ -4,6 +4,7 @@ import { User } from '../models/index.js';
 import { generateToken } from '../middleware/auth.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
+import { isAllowedPublicHost } from '../utils/publicHost.js';
 
 // Simple in-memory login attempt tracker (resets on server restart)
 const loginAttempts = new Map();
@@ -223,15 +224,31 @@ export async function googleIdTokenLogin({ email, googleSub, name, picture }) {
  * @returns {{ user: object, token: string }}
  */
 export async function googleOAuthCallback(code, origin) {
-  // Determine redirect_uri that matches the initial Google auth request
+  // Determine redirect_uri that matches the initial Google auth request.
+  // The SPA always initiates with `window.location.origin + /auth/google/callback`
+  // (Login.jsx), and Google requires the token exchange to repeat the exact
+  // same redirect_uri — so when the request comes from one of our allowlisted
+  // public hosts (mktr.sg / ops.redeem.sg / …) the origin-derived URI is the
+  // only correct one. Env pin / FRONTEND_BASE_URL remain the fallback for
+  // everything else (unknown origins, server-side callers).
   const explicitRedirectUri = process.env.GOOGLE_REDIRECT_URI;
   const isLocalhost = origin && (origin.includes('localhost') || origin.includes('127.0.0.1'));
+
+  let originHost;
+  try {
+    originHost = origin ? new URL(origin).host : undefined;
+  } catch {
+    originHost = undefined;
+  }
+  const isAllowlistedOrigin = isAllowedPublicHost(originHost);
 
   const derivedFrontendBaseUrl = isLocalhost
     ? origin
     : process.env.FRONTEND_BASE_URL || origin || 'http://localhost:5173';
 
-  const finalRedirectUri = explicitRedirectUri || `${derivedFrontendBaseUrl}/auth/google/callback`;
+  const finalRedirectUri = isAllowlistedOrigin
+    ? `${origin}/auth/google/callback`
+    : explicitRedirectUri || `${derivedFrontendBaseUrl}/auth/google/callback`;
 
   logger.debug('OAuth token exchange redirect_uri', { redirectUri: finalRedirectUri });
 

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -224,6 +224,12 @@ export const redeemOpsApi = {
     const res = await apiClient.get('/redeem-ops/entitlements', params);
     return res.data;
   },
+  async unlockEntitlement(body) {
+    // { prospectId } or { presentationToken }. Manual unlock — admins only
+    // in practice (server enforces the assigned-consultant binding otherwise).
+    const res = await apiClient.post('/redeem-ops/entitlements/unlock', body);
+    return res.data;
+  },
   async verifyVoucher(token) {
     const res = await apiClient.post('/redeem-ops/redemptions/verify', { token });
     return res.data;

--- a/src/pages/redeemops/PartnerDetail.jsx
+++ b/src/pages/redeemops/PartnerDetail.jsx
@@ -212,6 +212,25 @@ export default function PartnerDetail() {
     onError: (err) => toast.error('Could not log activity', { description: err.message }),
   });
 
+  const [taskOpen, setTaskOpen] = useState(false);
+  const [task, setTask] = useState({ title: '', dueDate: '', priority: 'medium' });
+  const taskMutation = useMutation({
+    mutationFn: () => redeemOpsApi.createTask({
+      partnerOrganisationId: id,
+      title: task.title.trim(),
+      dueAt: new Date(`${task.dueDate}T09:00:00`).toISOString(),
+      priority: task.priority,
+    }),
+    onSuccess: () => {
+      toast.success('Task created');
+      setTaskOpen(false);
+      setTask({ title: '', dueDate: '', priority: 'medium' });
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'tasks'] });
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'queue'] });
+    },
+    onError: (err) => toast.error('Could not create task', { description: err.message }),
+  });
+
   const [contactForm, setContactForm] = useState(EMPTY_CONTACT);
   const contactMutation = useMutation({
     mutationFn: () => redeemOpsApi.addContact(id, contactForm),
@@ -293,6 +312,9 @@ export default function PartnerDetail() {
           )}
           {isOwner && (
             <Button variant="outline" onClick={() => releaseMutation.mutate()}>Release</Button>
+          )}
+          {hasCapability(user, 'tasks.manage') && (
+            <Button variant="outline" onClick={() => setTaskOpen(true)}>Add task</Button>
           )}
           {(isOwner || canReassign) && (
             <Button variant="outline" onClick={() => setActivityOpen(true)}>Log activity</Button>
@@ -434,6 +456,53 @@ export default function PartnerDetail() {
           )}
         </div>
       </div>
+
+      <Dialog open={taskOpen} onOpenChange={setTaskOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add task</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3 py-2">
+            <div className="space-y-1.5">
+              <Label>What needs doing? *</Label>
+              <Input
+                value={task.title}
+                onChange={(e) => setTask((t) => ({ ...t, title: e.target.value }))}
+                placeholder="Follow up on proposal"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label>Due date *</Label>
+                <Input
+                  type="date"
+                  value={task.dueDate}
+                  onChange={(e) => setTask((t) => ({ ...t, dueDate: e.target.value }))}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Priority</Label>
+                <Select value={task.priority} onValueChange={(priority) => setTask((t) => ({ ...t, priority }))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="low">Low</SelectItem>
+                    <SelectItem value="medium">Medium</SelectItem>
+                    <SelectItem value="high">High</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              onClick={() => taskMutation.mutate()}
+              disabled={!task.title.trim() || !task.dueDate || taskMutation.isPending}
+            >
+              {taskMutation.isPending ? 'Saving…' : 'Create task'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={activityOpen} onOpenChange={setActivityOpen}>
         <DialogContent>

--- a/src/pages/redeemops/PoolsPage.jsx
+++ b/src/pages/redeemops/PoolsPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -13,7 +13,106 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import Plus from 'lucide-react/icons/plus';
-import { RoPageHeader, RoTag } from '@/components/redeemops/ui';
+import { RoPageHeader, RoTag, RoAvatar, RoStageTag } from '@/components/redeemops/ui';
+
+function useDebounced(value, ms = 300) {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), ms);
+    return () => clearTimeout(t);
+  }, [value, ms]);
+  return debounced;
+}
+
+/** Search-and-tick dialog for stocking a pool with businesses. */
+function AddMembersDialog({ pool, onClose }) {
+  const queryClient = useQueryClient();
+  const [search, setSearch] = useState('');
+  const [selected, setSelected] = useState({});
+  const debounced = useDebounced(search);
+
+  const results = useQuery({
+    queryKey: ['redeem-ops', 'pool-add-search', debounced],
+    queryFn: () => redeemOpsApi.listPartners({ limit: 10, ...(debounced ? { search: debounced } : {}) }),
+    enabled: !!pool,
+  });
+
+  const addMutation = useMutation({
+    mutationFn: () => redeemOpsApi.addPoolMembers(pool.id, Object.keys(selected)),
+    onSuccess: (data) => {
+      const added = data?.added ?? Object.keys(selected).length;
+      toast.success(`Added ${added} business${added === 1 ? '' : 'es'} to ${pool.name}`);
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'pools'] });
+      onClose();
+    },
+    onError: (err) => toast.error('Could not add businesses', { description: err.message }),
+  });
+
+  const partners = results.data?.partners || [];
+  const count = Object.keys(selected).length;
+
+  return (
+    <Dialog open={!!pool} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Add businesses to “{pool?.name}”</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3 py-1">
+          <input
+            className="ro-search w-full"
+            placeholder="Search name, phone or UEN"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <div className="max-h-64 overflow-y-auto rounded-xl border border-border">
+            {partners.map((p) => {
+              const name = p.tradingName || p.brandName || p.legalName;
+              const checked = !!selected[p.id];
+              return (
+                <label
+                  key={p.id}
+                  className="flex items-center gap-3 px-3.5 py-2.5 border-t border-border first:border-t-0 cursor-pointer hover:bg-[var(--ro-subtle)]"
+                >
+                  <input
+                    type="checkbox"
+                    className="w-4 h-4 accent-[var(--ro-bunker)]"
+                    checked={checked}
+                    onChange={() => setSelected((s) => {
+                      const next = { ...s };
+                      if (next[p.id]) delete next[p.id]; else next[p.id] = true;
+                      return next;
+                    })}
+                  />
+                  <RoAvatar name={name} size={30} />
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-sm font-semibold truncate">{name}</span>
+                    <span className="block text-xs truncate" style={{ color: 'var(--ro-text-2)' }}>
+                      {[p.category, p.owner?.fullName && `owned by ${p.owner.fullName}`].filter(Boolean).join(' · ') || '—'}
+                    </span>
+                  </span>
+                  <RoStageTag stage={p.pipelineStage} size="sm" />
+                </label>
+              );
+            })}
+            {!results.isLoading && partners.length === 0 && (
+              <p className="text-sm text-center py-6 m-0" style={{ color: 'var(--ro-text-2)' }}>
+                No businesses match.
+              </p>
+            )}
+          </div>
+          <p className="text-xs m-0" style={{ color: 'var(--ro-text-3)' }}>
+            Unclaimed businesses become claimable via “Claim next”; owned ones are skipped by the queue until released.
+          </p>
+        </div>
+        <DialogFooter>
+          <Button disabled={count === 0 || addMutation.isPending} onClick={() => addMutation.mutate()}>
+            {addMutation.isPending ? 'Adding…' : `Add ${count || ''} selected`}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
 
 export default function PoolsPage() {
   const user = useAuthStore((s) => s.user);
@@ -25,6 +124,7 @@ export default function PoolsPage() {
 
   const [createOpen, setCreateOpen] = useState(false);
   const [form, setForm] = useState({ name: '', description: '', category: '', area: '' });
+  const [addTarget, setAddTarget] = useState(null);
 
   const createMutation = useMutation({
     mutationFn: () => redeemOpsApi.createPool(form),
@@ -78,18 +178,25 @@ export default function PoolsPage() {
                   {[pool.category, pool.area].filter(Boolean).join(' · ') || pool.description || '—'}
                 </CardDescription>
               </CardHeader>
-              <CardContent className="flex items-center justify-between">
+              <CardContent className="flex items-center justify-between gap-2 flex-wrap">
                 <div className="flex gap-2">
                   <RoTag tone={available > 0 ? 'active' : 'ended'}>{available} available</RoTag>
                   <RoTag tone="inactive">{claimed} claimed</RoTag>
                 </div>
-                <Button
-                  size="sm"
-                  disabled={claimMutation.isPending || available === 0}
-                  onClick={() => claimMutation.mutate(pool.id)}
-                >
-                  {claimMutation.isPending ? 'Claiming…' : 'Claim next'}
-                </Button>
+                <div className="flex gap-2">
+                  {canManage && (
+                    <Button size="sm" variant="outline" onClick={() => setAddTarget(pool)}>
+                      Add businesses
+                    </Button>
+                  )}
+                  <Button
+                    size="sm"
+                    disabled={claimMutation.isPending || available === 0}
+                    onClick={() => claimMutation.mutate(pool.id)}
+                  >
+                    {claimMutation.isPending ? 'Claiming…' : 'Claim next'}
+                  </Button>
+                </div>
               </CardContent>
             </Card>
           );
@@ -102,6 +209,8 @@ export default function PoolsPage() {
           </Card>
         )}
       </div>
+
+      {addTarget && <AddMembersDialog pool={addTarget} onClose={() => setAddTarget(null)} />}
 
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>
         <DialogContent>

--- a/src/pages/redeemops/RedemptionsPage.jsx
+++ b/src/pages/redeemops/RedemptionsPage.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { redeemOpsApi } from '@/api/redeemOps';
+import { useAuthStore } from '@/stores/authStore';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
@@ -13,12 +14,27 @@ import { RoPageHeader, RoTag, prettyEnum } from '@/components/redeemops/ui';
 
 export default function RedemptionsPage() {
   const queryClient = useQueryClient();
+  const user = useAuthStore((s) => s.user);
+  const isAdmin = user?.role === 'admin';
   const [token, setToken] = useState('');
   const [verified, setVerified] = useState(null);
 
   const historyQuery = useQuery({
     queryKey: ['redeem-ops', 'redemptions'],
     queryFn: () => redeemOpsApi.listRedemptions(),
+  });
+  const entitlementsQuery = useQuery({
+    queryKey: ['redeem-ops', 'entitlements'],
+    queryFn: () => redeemOpsApi.listEntitlements({ limit: 15 }),
+  });
+
+  const unlockMutation = useMutation({
+    mutationFn: (prospectId) => redeemOpsApi.unlockEntitlement({ prospectId }),
+    onSuccess: (data) => {
+      toast.success(data?.already ? 'Already unlocked' : 'Voucher unlocked — email with QR sent to the customer');
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'entitlements'] });
+    },
+    onError: (err) => toast.error('Unlock failed', { description: err.message }),
   });
 
   const verifyMutation = useMutation({
@@ -102,6 +118,53 @@ export default function RedemptionsPage() {
               )}
             </div>
           )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Reservations &amp; vouchers</CardTitle>
+          <CardDescription>
+            Every captured lead's reward, from locked reservation to redeemed voucher.
+            {isAdmin ? ' As admin you can unlock a reservation manually (audited) — normally the assigned consultant does this at the meeting.' : ''}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-0">
+            {(entitlementsQuery.data?.entitlements || []).map((e) => (
+              <div key={e.id} className="flex items-center gap-3 py-2.5 border-t border-border first:border-t-0">
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-semibold m-0 truncate">
+                    {[e.prospect?.firstName, e.prospect?.lastName].filter(Boolean).join(' ') || 'Customer'}
+                    <span className="font-normal" style={{ color: 'var(--ro-text-3)' }}>
+                      {e.prospect?.phone ? ` · ${e.prospect.phone}` : ''}
+                    </span>
+                  </p>
+                  <p className="text-xs m-0 truncate" style={{ color: 'var(--ro-text-2)' }}>
+                    {e.rewardOffer?.title || '—'}
+                    {e.activation?.campaignNameSnapshot ? ` · ${e.activation.campaignNameSnapshot}` : ''}
+                    {e.tokenHint ? ` · code …${e.tokenHint}` : ''}
+                  </p>
+                </div>
+                <RoTag tone={e.status} size="sm">{prettyEnum(e.status)}</RoTag>
+                {isAdmin && e.status === 'eligible' && e.prospect?.id && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={unlockMutation.isPending}
+                    onClick={() => unlockMutation.mutate(e.prospect.id)}
+                  >
+                    Unlock
+                  </Button>
+                )}
+              </div>
+            ))}
+            {!entitlementsQuery.isLoading && (entitlementsQuery.data?.entitlements || []).length === 0 && (
+              <p className="text-sm text-center py-6 m-0" style={{ color: 'var(--ro-text-2)' }}>
+                No reservations yet — they appear when customers sign up on an active activation's campaign.
+              </p>
+            )}
+          </div>
         </CardContent>
       </Card>
 


### PR DESCRIPTION
Closes the gaps found during the go-live walkthrough:

1. **Add task** — dialog on the partner page (`tasks.manage`); queue/tasks views now populatable from the UI
2. **Add businesses to a pool** — search-and-tick dialog on Pools (`pools.manage`); makes "Claim next" usable
3. **Manual voucher unlock** — "Reservations & vouchers" panel on Redemptions + admin-only Unlock button; new `POST /api/redeem-ops/entitlements/unlock` (`entitlements.issue_manual`) wrapping the existing `unlockEntitlement` service (consultant binding + audited admin override + voucher email already there; raw token never returned to staff)
4. **Google sign-in from ops.redeem.sg** — OAuth token exchange derives `redirect_uri` from the allowlisted request origin (matches what Login.jsx initiated) instead of the mktr.sg env pin; fallback unchanged for unknown origins

Verified: mktr + ops builds compile; 92 files / 1113 vitest pass; backend `authService.test.js` 50/50 pass with the OAuth change; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqCcNpihKgDTQ9YG811btF