### PR TITLE
fix(auth): correct stale Google client ID in committed .env.production

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,2 @@
 VITE_API_URL=https://api.mktr.sg/api
-VITE_GOOGLE_CLIENT_ID=942720017977-odeosq0qbmd9hgij0n1fmuc0vuduhj4c.apps.googleusercontent.com
+VITE_GOOGLE_CLIENT_ID=917664265015-01vqe99c54ur01tf178tfiee9i9nt0e2.apps.googleusercontent.com


### PR DESCRIPTION
ops.redeem.sg's Google sign-in failed with redirect_uri_mismatch because the committed \`.env.production\` fallback carries an old OAuth client ID (\`942720017977-…\`). mktr.sg overrides it via its Render dashboard env; the new ops static site doesn't, so it baked the stale ID. This aligns the committed fallback with the live client (\`917664265015-…\`), which already has \`https://ops.redeem.sg\` registered. Client IDs are public identifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqCcNpihKgDTQ9YG811btF