### PR TITLE
fix(invites): invited accounts are pre-approved — the invite is the approval

### DIFF
--- a/backend/src/services/invitationService.js
+++ b/backend/src/services/invitationService.js
@@ -53,6 +53,10 @@ export async function sendRoleInvitation({ email, fullName, role, inviterEmail, 
     role,
     isActive: true,
     emailVerified: false,
+    // An admin-issued invite IS the approval — invited accounts must not queue
+    // behind the self-signup review gate (User.approvalStatus defaults to
+    // 'pending', which sent invited staff to /PendingApproval after accepting).
+    approvalStatus: 'approved',
     invitationToken,
     invitationExpires,
     ...extraFields

--- a/backend/test/unit/invitationService.test.js
+++ b/backend/test/unit/invitationService.test.js
@@ -67,6 +67,8 @@ describe('invitationService (unit)', () => {
         role: 'agent',
         isActive: true,
         emailVerified: false,
+        // Invited accounts are pre-approved — the invite is the approval.
+        approvalStatus: 'approved',
       })
     );
     expect(result.user).toBeDefined();


### PR DESCRIPTION
Admin-invited users (incl. Redeem Ops staff) accepted their invite and then hit /PendingApproval — a second approval by the same admin who invited them. Root cause: \`User.approvalStatus\` defaults to \`'pending'\` (built for self-signups) and \`invitationService\` never set it. Invited-user creation now sets \`approvalStatus: 'approved'\`; unit test asserts it. Self-signup review flow untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqCcNpihKgDTQ9YG811btF