### PR TITLE
feat(redeem-ops): account menu shows role title + Edit profile page

### DIFF
--- a/src/components/redeemops/RedeemOpsLayout.jsx
+++ b/src/components/redeemops/RedeemOpsLayout.jsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { NavLink, Link, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
 import { hasCapability } from '@/lib/redeemOpsPermissions';
-import { RoAvatar } from '@/components/redeemops/ui';
+import { RoAvatar, roRoleLabel } from '@/components/redeemops/ui';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -22,6 +22,7 @@ import QrCode from 'lucide-react/icons/qr-code';
 import ChartColumn from 'lucide-react/icons/chart-column';
 import UserCog from 'lucide-react/icons/user-cog';
 import Shield from 'lucide-react/icons/shield';
+import Settings from 'lucide-react/icons/settings';
 import LogOut from 'lucide-react/icons/log-out';
 import '@/styles/redeem-ops-theme.css';
 
@@ -97,12 +98,17 @@ export default function RedeemOpsLayout({ children }) {
             >
               <RoAvatar name={displayName} size={34} title={displayName} />
             </DropdownMenuTrigger>
-            <DropdownMenuContent side="right" align="end" className="w-56">
+            <DropdownMenuContent side="right" align="end" className="w-60">
               <DropdownMenuLabel className="font-normal">
                 <p className="text-sm font-semibold m-0">{displayName}</p>
+                <p className="text-xs m-0" style={{ color: 'var(--ro-azure)' }}>{roRoleLabel(user)}</p>
                 <p className="text-xs text-muted-foreground m-0 truncate">{user?.email}</p>
               </DropdownMenuLabel>
               <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => navigate('/redeem-ops/profile')}>
+                <Settings className="w-4 h-4 mr-2" aria-hidden="true" />
+                Edit profile
+              </DropdownMenuItem>
               {user?.role === 'admin' && (
                 <DropdownMenuItem onClick={() => navigate('/AdminDashboard')}>
                   <Shield className="w-4 h-4 mr-2" aria-hidden="true" />

--- a/src/components/redeemops/ui.jsx
+++ b/src/components/redeemops/ui.jsx
@@ -6,6 +6,25 @@
  */
 import { cn } from '@/lib/utils';
 
+/* Display labels for Redeem Ops sub-roles — mirrors backend
+   services/redeemOps/constants.js SUB_ROLE_LABELS (display-only). */
+const RO_ROLE_LABELS = {
+  super_admin: 'Super Admin',
+  ops_admin: 'Ops Admin',
+  bdm: 'Business Development Manager',
+  outreach_exec: 'Outreach Executive',
+  campaign_ops: 'Campaign Ops',
+  redemption_ops: 'Redemption Ops',
+  analyst: 'Analyst',
+};
+
+/** Human title for the signed-in principal shown in the account menu. */
+export function roRoleLabel(user) {
+  if (!user) return '';
+  if (user.role === 'admin') return 'Administrator';
+  return RO_ROLE_LABELS[user.redeemOpsRole] || 'Redeem Ops';
+}
+
 /** Sentence-case a SCREAMING_SNAKE enum: MEETING_BOOKED → "Meeting booked". */
 export function prettyEnum(value) {
   if (!value) return '';

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -92,6 +92,7 @@ const RedeemOpsActivations = lazy(() => import('./redeemops/ActivationsPage'));
 const RedeemOpsActivationDetail = lazy(() => import('./redeemops/ActivationDetail'));
 const RedeemOpsRedemptions = lazy(() => import('./redeemops/RedemptionsPage'));
 const RedeemOpsAnalytics = lazy(() => import('./redeemops/AnalyticsPage'));
+const RedeemOpsProfile = lazy(() => import('./redeemops/ProfilePage'));
 
 // ops.redeem.sg — dedicated staff surface (docs/redeem-ops/
 // USER_SURFACES_AND_DEPLOYMENT_BOUNDARIES.md). Mirrors the VITE_BRAND pattern:
@@ -121,6 +122,7 @@ function redeemOpsRouteElements() {
     { path: '/redeem-ops/activations/:id', capability: 'activations.view', Page: RedeemOpsActivationDetail },
     { path: '/redeem-ops/redemptions', capability: 'redemptions.verify', Page: RedeemOpsRedemptions },
     { path: '/redeem-ops/analytics', capability: 'analytics.view_own', Page: RedeemOpsAnalytics },
+    { path: '/redeem-ops/profile', capability: null, Page: RedeemOpsProfile },
   ];
   return routes.map(({ path, capability, Page }) => (
     <Route

--- a/src/pages/redeemops/ProfilePage.jsx
+++ b/src/pages/redeemops/ProfilePage.jsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { auth as authApi } from '@/api/client';
+import { useAuthStore } from '@/stores/authStore';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { RoPageHeader, RoAvatar, RoTag, roRoleLabel } from '@/components/redeemops/ui';
+
+export default function ProfilePage() {
+  const user = useAuthStore((s) => s.user);
+  const refreshUser = useAuthStore((s) => s.refreshUser);
+
+  const [form, setForm] = useState({
+    firstName: user?.firstName || '',
+    lastName: user?.lastName || '',
+    phone: user?.phone || '',
+  });
+  const [pw, setPw] = useState({ current: '', next: '', confirm: '' });
+
+  const displayName = [form.firstName, form.lastName].filter(Boolean).join(' ') || user?.email || 'Me';
+
+  const profileMutation = useMutation({
+    mutationFn: () => authApi.updateProfile({
+      firstName: form.firstName.trim(),
+      lastName: form.lastName.trim(),
+      ...(form.phone.trim() ? { phone: form.phone.trim() } : {}),
+    }),
+    onSuccess: async () => {
+      toast.success('Profile updated');
+      await refreshUser();
+    },
+    onError: (err) => toast.error('Could not update profile', { description: err.message }),
+  });
+
+  const passwordMutation = useMutation({
+    mutationFn: () => authApi.changePassword(pw.current, pw.next),
+    onSuccess: () => {
+      toast.success('Password changed');
+      setPw({ current: '', next: '', confirm: '' });
+    },
+    onError: (err) => toast.error('Could not change password', { description: err.message }),
+  });
+
+  const pwMismatch = pw.next.length > 0 && pw.confirm.length > 0 && pw.next !== pw.confirm;
+
+  return (
+    <div className="p-6 md:p-8 max-w-2xl mx-auto space-y-6">
+      <RoPageHeader title="Your profile" sub="How your name appears to the team, and your sign-in password." />
+
+      <div className="rounded-2xl border border-border bg-white p-6">
+        <div className="flex items-center gap-4 mb-6">
+          <RoAvatar name={displayName} size={56} />
+          <div className="min-w-0">
+            <p className="text-lg font-bold m-0 truncate">{displayName}</p>
+            <p className="text-[13px] m-0 truncate" style={{ color: 'var(--ro-text-2)' }}>{user?.email}</p>
+          </div>
+          <RoTag tone="primary" className="ml-auto shrink-0">{roRoleLabel(user)}</RoTag>
+        </div>
+
+        <div className="grid sm:grid-cols-2 gap-4">
+          <div className="space-y-1.5">
+            <Label>First name</Label>
+            <Input value={form.firstName} onChange={(e) => setForm((f) => ({ ...f, firstName: e.target.value }))} />
+          </div>
+          <div className="space-y-1.5">
+            <Label>Last name</Label>
+            <Input value={form.lastName} onChange={(e) => setForm((f) => ({ ...f, lastName: e.target.value }))} />
+          </div>
+          <div className="space-y-1.5 sm:col-span-2">
+            <Label>Phone</Label>
+            <Input value={form.phone} onChange={(e) => setForm((f) => ({ ...f, phone: e.target.value }))} placeholder="+65 9123 4567" />
+          </div>
+        </div>
+        <div className="mt-5">
+          <Button
+            disabled={!form.firstName.trim() || profileMutation.isPending}
+            onClick={() => profileMutation.mutate()}
+          >
+            {profileMutation.isPending ? 'Saving…' : 'Save changes'}
+          </Button>
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-border bg-white p-6">
+        <p className="text-[15px] font-bold m-0 mb-1">Change password</p>
+        <p className="text-[13px] m-0 mb-5" style={{ color: 'var(--ro-text-2)' }}>
+          You'll stay signed in on this device.
+        </p>
+        <div className="grid sm:grid-cols-3 gap-4">
+          <div className="space-y-1.5">
+            <Label>Current password</Label>
+            <Input type="password" autoComplete="current-password" value={pw.current} onChange={(e) => setPw((p) => ({ ...p, current: e.target.value }))} />
+          </div>
+          <div className="space-y-1.5">
+            <Label>New password</Label>
+            <Input type="password" autoComplete="new-password" value={pw.next} onChange={(e) => setPw((p) => ({ ...p, next: e.target.value }))} />
+          </div>
+          <div className="space-y-1.5">
+            <Label>Confirm new password</Label>
+            <Input type="password" autoComplete="new-password" value={pw.confirm} onChange={(e) => setPw((p) => ({ ...p, confirm: e.target.value }))} />
+          </div>
+        </div>
+        {pwMismatch && (
+          <p className="text-xs mt-2 m-0" style={{ color: 'var(--ro-tag-red-fg)' }}>Passwords don't match.</p>
+        )}
+        <div className="mt-5">
+          <Button
+            variant="outline"
+            disabled={!pw.current || pw.next.length < 8 || pw.next !== pw.confirm || passwordMutation.isPending}
+            onClick={() => passwordMutation.mutate()}
+          >
+            {passwordMutation.isPending ? 'Updating…' : 'Update password'}
+          </Button>
+          {pw.next.length > 0 && pw.next.length < 8 && (
+            <span className="text-xs ml-3" style={{ color: 'var(--ro-text-3)' }}>At least 8 characters.</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Account dropdown now shows the person's title (sub-role label; \"Administrator\" for admins) under their name
- New **Edit profile** page at /redeem-ops/profile: name + phone (existing PUT /auth/profile) and password change (existing PUT /auth/change-password) — both under /api/auth which is already allowlisted on ops.redeem.sg, so no backend change and the host guard is untouched

Verified: mktr + ops builds compile, 1113 vitest pass, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqCcNpihKgDTQ9YG811btF