### PR TITLE
feat(redeem-ops): team member management — edit details + deactivate/reactivate

### DIFF
--- a/backend/src/controllers/redeemOps/adminController.js
+++ b/backend/src/controllers/redeemOps/adminController.js
@@ -125,6 +125,67 @@ export const setTeamRole = asyncHandler(async (req, res) => {
   res.json({ success: true, data: { user: target.toJSON() } });
 });
 
+const updateMemberSchema = Joi.object({
+  fullName: Joi.string().min(1).max(100),
+  phone: Joi.string().min(8).max(20).allow('', null),
+  isActive: Joi.boolean(),
+}).min(1);
+
+/**
+ * PATCH /api/redeem-ops/team/:userId — admin edit of a member's details and
+ * active state. Deactivation is a hard lock-out (authenticateToken rejects
+ * inactive users on every request). You cannot deactivate yourself.
+ */
+export const updateTeamMember = asyncHandler(async (req, res) => {
+  const { error, value } = updateMemberSchema.validate(req.body, { abortEarly: false });
+  if (error) {
+    throw new AppError(error.details.map((d) => d.message).join(', '), 400);
+  }
+  const target = await User.findByPk(req.params.userId);
+  if (!target) throw new AppError('User not found', 404);
+  if (!['redeem_ops', 'admin'].includes(target.role)) {
+    throw new AppError('Not a Redeem Ops team member', 400);
+  }
+  if (value.isActive === false && target.id === req.user.id) {
+    throw new AppError('You cannot deactivate your own account', 400);
+  }
+
+  const updates = {};
+  if (value.fullName !== undefined) {
+    const parts = String(value.fullName).trim().split(/\s+/);
+    updates.firstName = parts[0] || target.firstName;
+    updates.lastName = parts.slice(1).join(' ') || '';
+  }
+  if (value.phone !== undefined) updates.phone = value.phone || null;
+  if (value.isActive !== undefined) updates.isActive = value.isActive;
+
+  const before = {
+    firstName: target.firstName,
+    lastName: target.lastName,
+    phone: target.phone,
+    isActive: target.isActive,
+  };
+  await sequelize.transaction(async (t) => {
+    await target.update(updates, { transaction: t });
+    await recordAuditEvent({
+      actorUser: req.user,
+      action: value.isActive === false
+        ? 'access.deactivated'
+        : value.isActive === true && before.isActive === false
+          ? 'access.reactivated'
+          : 'access.member_updated',
+      entityType: 'user',
+      entityId: target.id,
+      before,
+      after: updates,
+      requestId: req.id || null,
+      transaction: t,
+    });
+  });
+
+  res.json({ success: true, data: { user: target.toJSON() } });
+});
+
 /** GET /api/redeem-ops/audit — filterable, paginated audit trail (newest first). */
 export const listAudit = asyncHandler(async (req, res) => {
   const page = Math.max(1, parseInt(req.query.page, 10) || 1);

--- a/backend/src/routes/redeemOpsAdmin.js
+++ b/backend/src/routes/redeemOpsAdmin.js
@@ -22,6 +22,7 @@ const router = express.Router();
 router.get('/team', requireRedeemOps('analytics.view_team'), ctrl.listTeam);
 router.post('/team/invite', requireRedeemOps('team.manage_access'), ctrl.inviteTeamMember);
 router.patch('/team/:userId/role', requireRedeemOps('team.manage_access'), ctrl.setTeamRole);
+router.patch('/team/:userId', requireRedeemOps('team.manage_access'), ctrl.updateTeamMember);
 
 // Audit trail
 router.get('/audit', requireRedeemOps('audit.view'), ctrl.listAudit);

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -20,6 +20,10 @@ export const redeemOpsApi = {
     return res.data;
   },
 
+  async updateTeamMember(userId, body) {
+    const res = await apiClient.patch(`/redeem-ops/team/${userId}`, body);
+    return res.data?.user;
+  },
   async setTeamRole(userId, redeemOpsRole) {
     const res = await apiClient.patch(`/redeem-ops/team/${userId}/role`, { redeemOpsRole });
     return res.data;

--- a/src/pages/redeemops/RedeemOpsTeam.jsx
+++ b/src/pages/redeemops/RedeemOpsTeam.jsx
@@ -18,6 +18,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import UserPlus from 'lucide-react/icons/user-plus';
+import Pencil from 'lucide-react/icons/pencil';
 import { RoTag, RoAvatar } from '@/components/redeemops/ui';
 
 const TEAM_KEY = ['redeem-ops', 'team'];
@@ -58,6 +59,23 @@ export default function RedeemOpsTeam() {
       queryClient.invalidateQueries({ queryKey: TEAM_KEY });
     },
     onError: (err) => toast.error('Role change failed', { description: err.message }),
+  });
+
+  const [editTarget, setEditTarget] = useState(null); // { id, fullName, phone }
+  const memberMutation = useMutation({
+    mutationFn: ({ userId, body }) => redeemOpsApi.updateTeamMember(userId, body),
+    onSuccess: (_data, vars) => {
+      toast.success(
+        vars.body.isActive === false
+          ? 'Account deactivated — they can no longer sign in'
+          : vars.body.isActive === true
+            ? 'Account reactivated'
+            : 'Member updated'
+      );
+      setEditTarget(null);
+      queryClient.invalidateQueries({ queryKey: TEAM_KEY });
+    },
+    onError: (err) => toast.error('Update failed', { description: err.message }),
   });
 
   const team = teamQuery.data || [];
@@ -155,6 +173,7 @@ export default function RedeemOpsTeam() {
                   <TableHead>Email</TableHead>
                   <TableHead>Sub-role</TableHead>
                   <TableHead>Status</TableHead>
+                  {canManage && <TableHead className="text-right">Actions</TableHead>}
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -192,14 +211,47 @@ export default function RedeemOpsTeam() {
                     </TableCell>
                     <TableCell>
                       <RoTag tone={member.isActive ? 'active' : 'inactive'} size="sm">
-                        {member.isActive ? 'Active' : 'Inactive'}
+                        {member.isActive ? 'Active' : 'Deactivated'}
                       </RoTag>
                     </TableCell>
+                    {canManage && (
+                      <TableCell className="text-right whitespace-nowrap">
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          aria-label="Edit member"
+                          onClick={() => setEditTarget({
+                            id: member.id,
+                            fullName: member.fullName || [member.firstName, member.lastName].filter(Boolean).join(' '),
+                            phone: member.phone || '',
+                          })}
+                        >
+                          <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
+                        </Button>
+                        {member.id !== currentUser?.id && (
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            className={member.isActive ? 'text-destructive hover:text-destructive' : undefined}
+                            disabled={memberMutation.isPending}
+                            onClick={() => {
+                              const name = member.fullName || member.email;
+                              const ok = member.isActive
+                                ? window.confirm(`Deactivate ${name}? They will be signed out and unable to log in until reactivated.`)
+                                : true;
+                              if (ok) memberMutation.mutate({ userId: member.id, body: { isActive: !member.isActive } });
+                            }}
+                          >
+                            {member.isActive ? 'Deactivate' : 'Reactivate'}
+                          </Button>
+                        )}
+                      </TableCell>
+                    )}
                   </TableRow>
                 ))}
                 {!teamQuery.isLoading && team.length === 0 && (
                   <TableRow>
-                    <TableCell colSpan={4} className="text-center text-muted-foreground py-8">
+                    <TableCell colSpan={canManage ? 5 : 4} className="text-center text-muted-foreground py-8">
                       No Redeem Ops staff yet{canManage ? ' — send the first invite.' : '.'}
                     </TableCell>
                   </TableRow>
@@ -209,6 +261,48 @@ export default function RedeemOpsTeam() {
           </div>
         </CardContent>
       </Card>
+
+      <Dialog open={!!editTarget} onOpenChange={(open) => { if (!open) setEditTarget(null); }}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Edit member</DialogTitle>
+            <DialogDescription>
+              Name and phone. Members can also edit these themselves via Edit profile.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 py-2">
+            <div className="space-y-1.5">
+              <Label>Full name</Label>
+              <Input
+                value={editTarget?.fullName || ''}
+                onChange={(e) => setEditTarget((t) => ({ ...t, fullName: e.target.value }))}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Phone</Label>
+              <Input
+                value={editTarget?.phone || ''}
+                onChange={(e) => setEditTarget((t) => ({ ...t, phone: e.target.value }))}
+                placeholder="+65 9123 4567"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              disabled={!editTarget?.fullName?.trim() || memberMutation.isPending}
+              onClick={() => memberMutation.mutate({
+                userId: editTarget.id,
+                body: {
+                  fullName: editTarget.fullName.trim(),
+                  phone: editTarget.phone?.trim() || null,
+                },
+              })}
+            >
+              {memberMutation.isPending ? 'Saving…' : 'Save'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
Admins could only invite and change sub-roles. Now:
- **Edit member** (name, phone) via a dialog on the Team page
- **Deactivate / Reactivate** with confirm — deactivation is a hard lock-out (authenticateToken rejects inactive users); self-deactivation rejected server-side
- New \`PATCH /api/redeem-ops/team/:userId\` (\`team.manage_access\`), update + audit atomic

Verified: mktr + ops builds, 1113 vitest pass, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqCcNpihKgDTQ9YG811btF