### PR TITLE
fix(users): recompose stored fullName when first/last name change

### DIFF
--- a/backend/src/controllers/redeemOps/adminController.js
+++ b/backend/src/controllers/redeemOps/adminController.js
@@ -152,9 +152,12 @@ export const updateTeamMember = asyncHandler(async (req, res) => {
 
   const updates = {};
   if (value.fullName !== undefined) {
-    const parts = String(value.fullName).trim().split(/\s+/);
+    const trimmed = String(value.fullName).trim();
+    const parts = trimmed.split(/\s+/);
     updates.firstName = parts[0] || target.firstName;
     updates.lastName = parts.slice(1).join(' ') || '';
+    // fullName is a stored column that would otherwise shadow the new name
+    updates.fullName = trimmed;
   }
   if (value.phone !== undefined) updates.phone = value.phone || null;
   if (value.isActive !== undefined) updates.isActive = value.isActive;

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -185,6 +185,18 @@ const User = sequelize.define('User', {
         if (composed) user.fullName = composed;
       }
 
+      // If first/last CHANGED on an existing row and fullName wasn't explicitly
+      // set in the same update, recompose it — otherwise the stored fullName
+      // keeps shadowing the new name everywhere it's displayed.
+      if (
+        !user.isNewRecord &&
+        (user.changed('firstName') || user.changed('lastName')) &&
+        !user.changed('fullName')
+      ) {
+        const composed = [user.firstName, user.lastName].filter(Boolean).join(' ').trim();
+        if (composed) user.fullName = composed;
+      }
+
       // If fullName provided but first/last missing, split it
       const hasFull = !!user.fullName && String(user.fullName).trim().length > 0;
       if (hasFull && !hasFirst && !hasLast) {


### PR DESCRIPTION
Editing a member's name appeared to do nothing: \`fullName\` is a stored column that the model only composed when empty, so first/last updates left the stale \`fullName\` shadowing the new name in every display path (Team page, account menu, owner chips). The model hook now recomposes \`fullName\` when first/last change on an existing row (explicit \`fullName\` in the same update still wins), and the team member-edit endpoint sets it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqCcNpihKgDTQ9YG811btF