### PR TITLE
fix(redeem-ops): fade form placeholders so empty fields don't read as pre-filled

### DIFF
--- a/src/styles/redeem-ops-theme.css
+++ b/src/styles/redeem-ops-theme.css
@@ -59,6 +59,20 @@
   --ro-tag-purple-fg: #6a3fd1;
   --ro-tag-gray-bg: #f0f2f4;
   --ro-tag-gray-fg: #4c555e;
+  /* Hint text — deliberately much fainter than entered values so empty
+     fields can never read as pre-filled. */
+  --ro-placeholder: #b7bec5;
+}
+
+/* Placeholders read as hints, not values — every input/textarea on the ops
+   surface, including forms inside portaled dialogs. */
+:root:has(.ro-app) ::placeholder {
+  color: var(--ro-placeholder);
+  opacity: 1; /* Firefox applies its own opacity otherwise */
+}
+/* Radix Select triggers showing their placeholder */
+:root:has(.ro-app) [data-placeholder] {
+  color: var(--ro-placeholder);
 }
 
 /* Everything on screen is Redeem Ops while .ro-app is mounted — portals too. */
@@ -246,7 +260,7 @@
   background-repeat: no-repeat;
   background-position: 14px center;
 }
-.ro-search::placeholder { color: var(--ro-text-3); }
+.ro-search::placeholder { color: var(--ro-placeholder); }
 .ro-search:focus {
   outline: 2px solid var(--ro-azure);
   outline-offset: 1px;


### PR DESCRIPTION
Placeholders were rendering in the theme's regular muted-text colour — dark enough to look like entered values (user-reported on the Add business dialog). One scoped rule now applies a deliberately faint \`--ro-placeholder\` to every placeholder on the ops surface (including forms in portaled dialogs) and to Select triggers showing their placeholder. Ops-scoped; mktr admin untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqCcNpihKgDTQ9YG811btF