### PR TITLE
feat(redeem-ops): guarded hard-delete for mistakenly created partners

### DIFF
--- a/backend/src/controllers/redeemOps/partnersController.js
+++ b/backend/src/controllers/redeemOps/partnersController.js
@@ -108,6 +108,11 @@ export const mergePartners = asyncHandler(async (req, res) => {
   res.json({ success: true, message: 'Merged', data: { partner: survivor } });
 });
 
+export const deletePartner = asyncHandler(async (req, res) => {
+  await partnerService.deletePartner(req.params.id, req.user, req.id);
+  res.json({ success: true, message: 'Business deleted' });
+});
+
 export const getTimeline = asyncHandler(async (req, res) => {
   const data = await partnerService.getTimeline(req.params.id, req.query);
   res.json({ success: true, data });

--- a/backend/src/routes/redeemOpsPartners.js
+++ b/backend/src/routes/redeemOpsPartners.js
@@ -33,6 +33,9 @@ router.patch('/partners/:id/stage', requireRedeemOps('pipeline.move'), ctrl.chan
 
 // Merge (destructive-adjacent — ops_admin+)
 router.post('/partners/:id/merge', requireRedeemOps('partners.merge'), ctrl.mergePartners);
+// Mistake-eraser only: service refuses PARTNERED rows and anything with
+// rewards/activations (DB RESTRICT backs it). Real duplicates → merge.
+router.delete('/partners/:id', requireRedeemOps('partners.delete'), ctrl.deletePartner);
 
 // Timeline + activities
 router.get('/partners/:id/timeline', requireRedeemOps('partners.view'), ctrl.getTimeline);

--- a/backend/src/services/redeemOps/partnerService.js
+++ b/backend/src/services/redeemOps/partnerService.js
@@ -1,7 +1,7 @@
 import { Op } from 'sequelize';
 import {
   PartnerOrganisation, PartnerLocation, PartnerContact, PartnerAssignmentEvent,
-  PartnerStageEvent, OutreachActivity, User, sequelize,
+  PartnerStageEvent, OutreachActivity, RewardOffer, Activation, User, sequelize,
 } from '../../models/index.js';
 import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';
@@ -23,7 +23,7 @@ import { makeOnboardingService } from './onboardingService.js';
 export function makePartnerService(overrides = {}) {
   const d = {
     PartnerOrganisation, PartnerLocation, PartnerContact, PartnerAssignmentEvent,
-    PartnerStageEvent, OutreachActivity, User, sequelize, logger,
+    PartnerStageEvent, OutreachActivity, RewardOffer, Activation, User, sequelize, logger,
     audit: makeRedeemOpsAuditService(),
     dedupe: makeDedupeService(),
     // PARTNERED → seed the onboarding checklist (brief §22); injectable for tests.
@@ -505,11 +505,42 @@ export function makePartnerService(overrides = {}) {
     });
   }
 
+  /**
+   * Hard-delete a mistakenly created business (docs case: typo duplicate with
+   * no history). Guarded: PARTNERED rows and anything carrying reward offers
+   * or activations are refused (the DB backs this with ON DELETE RESTRICT) —
+   * merge or disqualify those instead. Children (contacts, locations, events,
+   * activities, tasks, pool memberships) cascade at the DB level. The audit
+   * row is written in the same transaction, before the destroy.
+   */
+  async function deletePartner(id, user, requestId = null) {
+    return d.sequelize.transaction(async (t) => {
+      const partner = await getLivePartner(id, { transaction: t, lock: t.LOCK.UPDATE });
+      if (partner.pipelineStage === 'PARTNERED') {
+        throw new AppError('Partnered businesses cannot be deleted — merge duplicates or disqualify instead', 409);
+      }
+      const [offers, activations] = await Promise.all([
+        d.RewardOffer.count({ where: { partnerOrganisationId: id }, transaction: t }),
+        d.Activation.count({ where: { partnerOrganisationId: id }, transaction: t }),
+      ]);
+      if (offers > 0 || activations > 0) {
+        throw new AppError('This business has rewards or activations attached — it cannot be deleted', 409);
+      }
+      const snapshot = partner.toJSON();
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'partner.deleted', entityType: 'partner_organisation',
+        entityId: id, before: snapshot, after: null, requestId, transaction: t,
+      });
+      await partner.destroy({ transaction: t });
+      return snapshot;
+    });
+  }
+
   return {
     listPartners, getPartner, createPartner, updatePartner, changeStage,
     getTimeline, logActivity, editActivity, voidActivity,
     addContact, updateContact, archiveContact, addLocation, updateLocation,
-    mergePartners, canActOnRow,
+    mergePartners, deletePartner, canActOnRow,
   };
 }
 

--- a/backend/src/services/redeemOps/permissions.js
+++ b/backend/src/services/redeemOps/permissions.js
@@ -31,6 +31,7 @@ export const CAPABILITIES = [
   'partners.reassign',
   'partners.restrict_disqualify',
   'partners.merge',
+  'partners.delete',
   'partners.import',
   'contacts.manage',
   'locations.manage',

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -60,6 +60,10 @@ export const redeemOpsApi = {
     const res = await apiClient.put(`/redeem-ops/partners/${id}`, body);
     return res.data?.partner;
   },
+  async deletePartner(id) {
+    const res = await apiClient.delete(`/redeem-ops/partners/${id}`);
+    return res;
+  },
   async claimPartner(id) {
     const res = await apiClient.post(`/redeem-ops/partners/${id}/claim`, {});
     return res.data;

--- a/src/lib/redeemOpsPermissions.js
+++ b/src/lib/redeemOpsPermissions.js
@@ -27,6 +27,7 @@ export const CAPABILITIES = [
   'partners.reassign',
   'partners.restrict_disqualify',
   'partners.merge',
+  'partners.delete',
   'partners.import',
   'contacts.manage',
   'locations.manage',

--- a/src/pages/redeemops/PartnerDetail.jsx
+++ b/src/pages/redeemops/PartnerDetail.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { redeemOpsApi } from '@/api/redeemOps';
@@ -148,6 +148,7 @@ const EMPTY_LOCATION = { name: '', addressLine: '', postalCode: '', phone: '' };
 
 export default function PartnerDetail() {
   const { id } = useParams();
+  const navigate = useNavigate();
   const user = useAuthStore((s) => s.user);
   const queryClient = useQueryClient();
 
@@ -229,6 +230,16 @@ export default function PartnerDetail() {
       queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'queue'] });
     },
     onError: (err) => toast.error('Could not create task', { description: err.message }),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => redeemOpsApi.deletePartner(id),
+    onSuccess: () => {
+      toast.success('Business deleted');
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partners'] });
+      navigate('/redeem-ops/partners');
+    },
+    onError: (err) => toast.error('Could not delete', { description: err.message }),
   });
 
   const [contactForm, setContactForm] = useState(EMPTY_CONTACT);
@@ -452,6 +463,24 @@ export default function PartnerDetail() {
             <div className="rounded-2xl border border-border bg-white p-5">
               <p className="text-[15px] font-bold m-0 mb-2">Notes</p>
               <p className="text-[13.5px] leading-relaxed m-0 whitespace-pre-wrap" style={{ color: 'var(--ro-text-2)' }}>{partner.notes}</p>
+            </div>
+          )}
+
+          {hasCapability(user, 'partners.delete') && partner.pipelineStage !== 'PARTNERED' && (
+            <div className="pt-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-destructive hover:text-destructive"
+                disabled={deleteMutation.isPending}
+                onClick={() => {
+                  if (window.confirm(`Permanently delete "${name}"? Only for businesses created by mistake — its contacts, tasks and activity go with it. Real duplicates should be merged instead.`)) {
+                    deleteMutation.mutate();
+                  }
+                }}
+              >
+                {deleteMutation.isPending ? 'Deleting…' : 'Delete business'}
+              </Button>
             </div>
           )}
         </div>


### PR DESCRIPTION
No way existed to remove a typo'd business. Adds a deliberately narrow hard-delete:
- New \`partners.delete\` capability (custodial tier via ALL; drift test updated on both mirrors)
- \`DELETE /api/redeem-ops/partners/:id\` — refuses PARTNERED rows and anything with rewards/activations (DB RESTRICT backs it); children cascade; audited with full before-snapshot in the same transaction
- Quiet confirm-guarded "Delete business" on the partner page (hidden on PARTNERED)

Verified: both builds, vitest 1113 pass (incl. permissions drift), eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqCcNpihKgDTQ9YG811btF