### PR TITLE
feat(redeem-ops): full field-history in the partner timeline

### DIFF
--- a/backend/src/services/redeemOps/partnerService.js
+++ b/backend/src/services/redeemOps/partnerService.js
@@ -1,7 +1,8 @@
 import { Op } from 'sequelize';
 import {
   PartnerOrganisation, PartnerLocation, PartnerContact, PartnerAssignmentEvent,
-  PartnerStageEvent, OutreachActivity, RewardOffer, Activation, User, sequelize,
+  PartnerStageEvent, OutreachActivity, RewardOffer, Activation, RedeemOpsAuditEvent,
+  User, sequelize,
 } from '../../models/index.js';
 import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';
@@ -23,7 +24,8 @@ import { makeOnboardingService } from './onboardingService.js';
 export function makePartnerService(overrides = {}) {
   const d = {
     PartnerOrganisation, PartnerLocation, PartnerContact, PartnerAssignmentEvent,
-    PartnerStageEvent, OutreachActivity, RewardOffer, Activation, User, sequelize, logger,
+    PartnerStageEvent, OutreachActivity, RewardOffer, Activation, RedeemOpsAuditEvent,
+    User, sequelize, logger,
     audit: makeRedeemOpsAuditService(),
     dedupe: makeDedupeService(),
     // PARTNERED → seed the onboarding checklist (brief §22); injectable for tests.
@@ -247,7 +249,7 @@ export function makePartnerService(overrides = {}) {
   async function getTimeline(id, query = {}) {
     await getLivePartner(id, { attributes: ['id', 'mergedIntoId'] });
     const limit = Math.min(100, Math.max(1, parseInt(query.limit, 10) || 50));
-    const [activities, stageEvents, assignmentEvents] = await Promise.all([
+    const [activities, stageEvents, assignmentEvents, auditEvents] = await Promise.all([
       d.OutreachActivity.findAll({
         where: { partnerOrganisationId: id, voidedAt: null },
         include: [
@@ -273,12 +275,25 @@ export function makePartnerService(overrides = {}) {
         order: [['createdAt', 'DESC']],
         limit,
       }),
+      // Field-history entries (Salesforce-style): creation + detail edits with
+      // before/after diffs come straight off the immutable audit trail.
+      d.RedeemOpsAuditEvent.findAll({
+        where: {
+          entityType: 'partner_organisation',
+          entityId: String(id),
+          action: { [Op.in]: ['partner.created', 'partner.edited'] },
+        },
+        include: [{ model: d.User, as: 'actor', attributes: ['id', 'fullName'] }],
+        order: [['createdAt', 'DESC']],
+        limit,
+      }),
     ]);
 
     const entries = [
       ...activities.map((a) => ({ kind: 'activity', at: a.occurredAt, data: a })),
       ...stageEvents.map((e) => ({ kind: 'stage', at: e.createdAt, data: e })),
       ...assignmentEvents.map((e) => ({ kind: 'assignment', at: e.createdAt, data: e })),
+      ...auditEvents.map((e) => ({ kind: 'audit', at: e.createdAt, data: e })),
     ].sort((x, y) => new Date(y.at) - new Date(x.at)).slice(0, limit);
 
     return { entries };

--- a/src/pages/redeemops/PartnerDetail.jsx
+++ b/src/pages/redeemops/PartnerDetail.jsx
@@ -36,6 +36,11 @@ function timelineIcon(entry) {
   if (entry.kind === 'stage') {
     return { Icon: ArrowRight, bg: 'var(--ro-tag-purple-bg)', fg: 'var(--ro-tag-purple-fg)' };
   }
+  if (entry.kind === 'audit') {
+    return entry.data.action === 'partner.created'
+      ? { Icon: Plus, bg: 'var(--ro-tag-green-bg)', fg: 'var(--ro-tag-green-fg)' }
+      : { Icon: Pencil, bg: 'var(--ro-tag-yellow-bg)', fg: 'var(--ro-tag-yellow-fg)' };
+  }
   if (entry.kind !== 'activity') {
     return { Icon: Plus, bg: 'var(--ro-tag-gray-bg)', fg: 'var(--ro-tag-gray-fg)' };
   }
@@ -49,6 +54,37 @@ function timelineIcon(entry) {
     return { Icon: Calendar, bg: 'var(--ro-tag-blue-bg)', fg: 'var(--ro-tag-blue-fg)' };
   }
   return { Icon: FileText, bg: 'var(--ro-tag-gray-bg)', fg: 'var(--ro-tag-gray-fg)' };
+}
+
+/* Human labels for field-history diffs; derived/internal keys are hidden. */
+const FIELD_LABELS = {
+  tradingName: 'Business name',
+  legalName: 'Legal name',
+  brandName: 'Brand name',
+  category: 'Category',
+  subcategory: 'Subcategory',
+  primaryPhone: 'Phone',
+  primaryEmail: 'Email',
+  instagramHandle: 'Instagram',
+  tiktokHandle: 'TikTok',
+  website: 'Website',
+  uen: 'UEN',
+  facebookUrl: 'Facebook',
+  linkedinUrl: 'LinkedIn',
+  source: 'Source',
+  notes: 'Notes',
+};
+
+function fieldDiffs(before = {}, after = {}) {
+  const diffs = [];
+  for (const [key, label] of Object.entries(FIELD_LABELS)) {
+    if (!(key in (after || {}))) continue;
+    const prev = before?.[key] ?? null;
+    const next = after?.[key] ?? null;
+    if (String(prev ?? '') === String(next ?? '')) continue;
+    diffs.push({ key, label, prev, next });
+  }
+  return diffs;
 }
 
 function TimelineEntry({ entry }) {
@@ -72,9 +108,42 @@ function TimelineEntry({ entry }) {
     const e = entry.data;
     title = `Stage moved: ${prettyEnum(e.fromStage || '—')} → ${prettyEnum(e.toStage)}`;
     meta = `${e.actor?.fullName || 'System'} · ${at}${e.reason ? ` · ${e.reason}` : ''}`;
+  } else if (entry.kind === 'audit') {
+    const e = entry.data;
+    if (e.action === 'partner.created') {
+      title = 'Business added';
+      body = e.after?.name ? (
+        <p className="text-[13.5px] m-0 mt-0.5" style={{ color: 'var(--ro-text-2)' }}>
+          {e.after.name}{e.after.category ? ` · ${e.after.category}` : ''}
+        </p>
+      ) : null;
+    } else {
+      const diffs = fieldDiffs(e.before, e.after);
+      title = 'Details edited';
+      body = diffs.length > 0 ? (
+        <div className="mt-1 space-y-0.5">
+          {diffs.map((dff) => (
+            <p key={dff.key} className="text-[13px] m-0 leading-relaxed" style={{ color: 'var(--ro-text-2)' }}>
+              <span className="font-semibold">{dff.label}:</span>{' '}
+              <span className="line-through" style={{ color: 'var(--ro-text-3)' }}>{String(dff.prev ?? '') || '—'}</span>
+              {' → '}
+              <span>{String(dff.next ?? '') || '—'}</span>
+            </p>
+          ))}
+        </div>
+      ) : (
+        <p className="text-[13px] m-0 mt-0.5" style={{ color: 'var(--ro-text-3)' }}>Internal fields updated</p>
+      );
+    }
+    meta = `${e.actor?.fullName || 'System'} · ${at}`;
   } else {
     const e = entry.data;
-    title = `Ownership: ${prettyEnum(e.kind)}${e.toUser ? ` → ${e.toUser.fullName}` : ''}`;
+    const K = String(e.kind || '');
+    if (K === 'claim') title = `Claimed by ${e.toUser?.fullName || e.actor?.fullName || 'someone'}`;
+    else if (K === 'release') title = `Released back to the pool${e.fromUser?.fullName ? ` by ${e.fromUser.fullName}` : ''}`;
+    else if (K === 'assign') title = `Assigned to ${e.toUser?.fullName || '—'}${e.fromUser?.fullName ? ` (from ${e.fromUser.fullName})` : ''}`;
+    else if (K === 'merge') title = 'Duplicate record merged in';
+    else title = `Ownership: ${prettyEnum(K)}${e.toUser ? ` → ${e.toUser.fullName}` : ''}`;
     meta = `${e.actor?.fullName || 'System'} · ${at}${e.reason ? ` · ${e.reason}` : ''}`;
   }
 


### PR DESCRIPTION
The partner timeline now surfaces the audit trail (which has recorded everything since Phase 2) as first-class entries:
- **Business added** — creator, time, initial name/category
- **Details edited** — per-field before → after diffs with human labels (derived keys hidden)
- Ownership events reworded: *Claimed by X / Released / Assigned to X (from Y) / Duplicate merged*

Backend: \`getTimeline\` additionally fetches \`partner.created\`/\`partner.edited\` audit rows (actor included) and merges them — no new writes, the trail was already immutable.

Verified: both builds, 1113 vitest pass, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqCcNpihKgDTQ9YG811btF