### PR TITLE
feat(redeem-ops): tasks appear in the partner timeline

### DIFF
--- a/backend/src/services/redeemOps/partnerService.js
+++ b/backend/src/services/redeemOps/partnerService.js
@@ -1,8 +1,8 @@
 import { Op } from 'sequelize';
 import {
   PartnerOrganisation, PartnerLocation, PartnerContact, PartnerAssignmentEvent,
-  PartnerStageEvent, OutreachActivity, RewardOffer, Activation, RedeemOpsAuditEvent,
-  User, sequelize,
+  PartnerStageEvent, OutreachActivity, OutreachTask, RewardOffer, Activation,
+  RedeemOpsAuditEvent, User, sequelize,
 } from '../../models/index.js';
 import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';
@@ -24,8 +24,8 @@ import { makeOnboardingService } from './onboardingService.js';
 export function makePartnerService(overrides = {}) {
   const d = {
     PartnerOrganisation, PartnerLocation, PartnerContact, PartnerAssignmentEvent,
-    PartnerStageEvent, OutreachActivity, RewardOffer, Activation, RedeemOpsAuditEvent,
-    User, sequelize, logger,
+    PartnerStageEvent, OutreachActivity, OutreachTask, RewardOffer, Activation,
+    RedeemOpsAuditEvent, User, sequelize, logger,
     audit: makeRedeemOpsAuditService(),
     dedupe: makeDedupeService(),
     // PARTNERED → seed the onboarding checklist (brief §22); injectable for tests.
@@ -323,7 +323,7 @@ export function makePartnerService(overrides = {}) {
   async function getTimeline(id, query = {}) {
     await getLivePartner(id, { attributes: ['id', 'mergedIntoId'] });
     const limit = Math.min(100, Math.max(1, parseInt(query.limit, 10) || 50));
-    const [activities, stageEvents, assignmentEvents, auditEvents] = await Promise.all([
+    const [activities, stageEvents, assignmentEvents, auditEvents, tasks] = await Promise.all([
       d.OutreachActivity.findAll({
         where: { partnerOrganisationId: id, voidedAt: null },
         include: [
@@ -361,13 +361,37 @@ export function makePartnerService(overrides = {}) {
         order: [['createdAt', 'DESC']],
         limit,
       }),
+      // Tasks belong in the activity history like any CRM: creation, and the
+      // completion/cancellation as its own dated entry.
+      d.OutreachTask.findAll({
+        where: { partnerOrganisationId: id },
+        include: [
+          { model: d.User, as: 'creator', attributes: ['id', 'fullName'] },
+          { model: d.User, as: 'assignee', attributes: ['id', 'fullName'] },
+        ],
+        order: [['createdAt', 'DESC']],
+        limit,
+      }),
     ]);
+
+    const taskEntries = [];
+    for (const task of tasks) {
+      const j = task.toJSON();
+      taskEntries.push({ kind: 'task', at: j.createdAt, data: { event: 'created', task: j } });
+      if (j.status === 'completed' && j.completedAt) {
+        taskEntries.push({ kind: 'task', at: j.completedAt, data: { event: 'completed', task: j } });
+      }
+      if (j.status === 'cancelled') {
+        taskEntries.push({ kind: 'task', at: j.updatedAt, data: { event: 'cancelled', task: j } });
+      }
+    }
 
     const entries = [
       ...activities.map((a) => ({ kind: 'activity', at: a.occurredAt, data: a })),
       ...stageEvents.map((e) => ({ kind: 'stage', at: e.createdAt, data: e })),
       ...assignmentEvents.map((e) => ({ kind: 'assignment', at: e.createdAt, data: e })),
       ...auditEvents.map((e) => ({ kind: 'audit', at: e.createdAt, data: e })),
+      ...taskEntries,
     ].sort((x, y) => new Date(y.at) - new Date(x.at)).slice(0, limit);
 
     return { entries };

--- a/src/pages/redeemops/PartnerDetail.jsx
+++ b/src/pages/redeemops/PartnerDetail.jsx
@@ -26,6 +26,7 @@ import FileText from 'lucide-react/icons/file-text';
 import ArrowRight from 'lucide-react/icons/arrow-right';
 import Star from 'lucide-react/icons/star';
 import MapPin from 'lucide-react/icons/map-pin';
+import ListChecks from 'lucide-react/icons/list-checks';
 import Plus from 'lucide-react/icons/plus';
 import Pencil from 'lucide-react/icons/pencil';
 import ArrowLeft from 'lucide-react/icons/arrow-left';
@@ -40,6 +41,11 @@ function timelineIcon(entry) {
     return entry.data.action === 'partner.created'
       ? { Icon: Plus, bg: 'var(--ro-tag-green-bg)', fg: 'var(--ro-tag-green-fg)' }
       : { Icon: Pencil, bg: 'var(--ro-tag-yellow-bg)', fg: 'var(--ro-tag-yellow-fg)' };
+  }
+  if (entry.kind === 'task') {
+    return entry.data.event === 'completed'
+      ? { Icon: ListChecks, bg: 'var(--ro-tag-green-bg)', fg: 'var(--ro-tag-green-fg)' }
+      : { Icon: ListChecks, bg: 'var(--ro-tag-gray-bg)', fg: 'var(--ro-tag-gray-fg)' };
   }
   if (entry.kind !== 'activity') {
     return { Icon: Plus, bg: 'var(--ro-tag-gray-bg)', fg: 'var(--ro-tag-gray-fg)' };
@@ -108,6 +114,21 @@ function TimelineEntry({ entry }) {
     const e = entry.data;
     title = `Stage moved: ${prettyEnum(e.fromStage || '—')} → ${prettyEnum(e.toStage)}`;
     meta = `${e.actor?.fullName || 'System'} · ${at}${e.reason ? ` · ${e.reason}` : ''}`;
+  } else if (entry.kind === 'task') {
+    const { event, task } = entry.data;
+    const completerName = task.completedBy === task.assigneeUserId
+      ? task.assignee?.fullName
+      : task.completedBy === task.createdBy ? task.creator?.fullName : null;
+    if (event === 'completed') {
+      title = `Task completed — ${task.title}`;
+      meta = `${completerName || task.assignee?.fullName || 'Team member'} · ${at}`;
+    } else if (event === 'cancelled') {
+      title = `Task cancelled — ${task.title}`;
+      meta = `${task.assignee?.fullName || task.creator?.fullName || 'Team member'} · ${at}`;
+    } else {
+      title = `Task created — ${task.title}`;
+      meta = `${task.creator?.fullName || 'Team member'} · ${at} · due ${new Date(task.dueAt).toLocaleDateString()}${task.assignee && task.assignee.id !== task.createdBy ? ` · for ${task.assignee.fullName}` : ''}`;
+    }
   } else if (entry.kind === 'audit') {
     const e = entry.data;
     if (e.action === 'partner.created') {


### PR DESCRIPTION
Completing a task left no trace on the business's timeline. Task events are now first-class timeline entries — created (creator, due, assignee), completed (completer, green check), cancelled — merged from the existing OutreachTask data (creator/assignee/completedAt/completedBy were always recorded), so it's retroactive.

Verified: both builds, 1113 vitest pass, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqCcNpihKgDTQ9YG811btF