### PR TITLE
feat(redeem-ops): CRM P1 batch — tasks overhaul, contact edit, notes, merge UI, reservation search, CSV import

### DIFF
--- a/backend/src/services/redeemOps/entitlementService.js
+++ b/backend/src/services/redeemOps/entitlementService.js
@@ -352,10 +352,27 @@ export function makeEntitlementService(overrides = {}) {
     if (query.status) where.status = String(query.status);
     const page = Math.max(1, parseInt(query.page, 10) || 1);
     const limit = Math.min(100, Math.max(1, parseInt(query.limit, 10) || 25));
+    // Console search: holder name or phone (the verify console legitimately
+    // handles identity, so the search itself may use the raw phone).
+    const prospectWhere = {};
+    if (query.search) {
+      const term = String(query.search).trim();
+      const like = `%${term}%`;
+      prospectWhere[Op.or] = [
+        { firstName: { [Op.iLike]: like } },
+        { lastName: { [Op.iLike]: like } },
+        { phone: { [Op.like]: like.replace(/\s+/g, '') } },
+      ];
+    }
     const { rows, count } = await d.RewardEntitlement.findAndCountAll({
       where,
       include: [
-        { model: d.Prospect, as: 'prospect', attributes: ['id', 'firstName', 'lastName', 'phone'] },
+        {
+          model: d.Prospect,
+          as: 'prospect',
+          attributes: ['id', 'firstName', 'lastName', 'phone'],
+          ...(query.search ? { where: prospectWhere, required: true } : {}),
+        },
         { model: d.RewardOffer, as: 'rewardOffer', attributes: ['id', 'title'] },
         { model: d.Activation, as: 'activation', attributes: ['id', 'campaignNameSnapshot'] },
       ],

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -60,6 +60,10 @@ export const redeemOpsApi = {
     const res = await apiClient.put(`/redeem-ops/partners/${id}`, body);
     return res.data?.partner;
   },
+  async mergePartners(survivorId, duplicateId, reason) {
+    const res = await apiClient.post(`/redeem-ops/partners/${survivorId}/merge`, { duplicateId, reason });
+    return res.data?.partner;
+  },
   async deletePartner(id) {
     const res = await apiClient.delete(`/redeem-ops/partners/${id}`);
     return res;

--- a/src/pages/redeemops/PartnerDetail.jsx
+++ b/src/pages/redeemops/PartnerDetail.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -27,10 +27,20 @@ import ArrowRight from 'lucide-react/icons/arrow-right';
 import Star from 'lucide-react/icons/star';
 import MapPin from 'lucide-react/icons/map-pin';
 import ListChecks from 'lucide-react/icons/list-checks';
+import X from 'lucide-react/icons/x';
 import Plus from 'lucide-react/icons/plus';
 import Pencil from 'lucide-react/icons/pencil';
 import ArrowLeft from 'lucide-react/icons/arrow-left';
 import { RoStageTag, RoAvatar, RoTag, prettyEnum } from '@/components/redeemops/ui';
+
+function useDebounced(value, ms = 300) {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), ms);
+    return () => clearTimeout(t);
+  }, [value, ms]);
+  return debounced;
+}
 
 /* Activity type → pastel icon circle (timeline card in the design system). */
 function timelineIcon(entry) {
@@ -333,6 +343,7 @@ export default function PartnerDetail() {
       website: editForm.website,
       uen: editForm.uen,
       primaryEmail: editForm.primaryEmail,
+      notes: editForm.notes,
     }),
     onSuccess: () => {
       toast.success('Details updated');
@@ -349,6 +360,7 @@ export default function PartnerDetail() {
     website: p.website || p.websiteDomain || '',
     uen: p.uen || '',
     primaryEmail: p.primaryEmail || '',
+    notes: p.notes || '',
   });
   const setEdit = (k) => (e) => setEditForm((f) => ({ ...f, [k]: e.target.value }));
 
@@ -367,6 +379,44 @@ export default function PartnerDetail() {
     mutationFn: () => redeemOpsApi.addContact(id, contactForm),
     onSuccess: () => { toast.success('Contact added'); setContactForm(EMPTY_CONTACT); invalidate(); },
     onError: (err) => toast.error('Could not add contact', { description: err.message }),
+  });
+
+  const [contactEdit, setContactEdit] = useState(null); // { id, name, roleTitle, mobile, email }
+  const contactUpdateMutation = useMutation({
+    mutationFn: () => redeemOpsApi.updateContact(contactEdit.id, {
+      name: contactEdit.name.trim(),
+      roleTitle: contactEdit.roleTitle || null,
+      mobile: contactEdit.mobile || null,
+      email: contactEdit.email || null,
+    }),
+    onSuccess: () => { toast.success('Contact updated'); setContactEdit(null); invalidate(); },
+    onError: (err) => toast.error('Could not update contact', { description: err.message }),
+  });
+  const contactArchiveMutation = useMutation({
+    mutationFn: (contactId) => redeemOpsApi.archiveContact(contactId),
+    onSuccess: () => { toast.success('Contact removed'); invalidate(); },
+    onError: (err) => toast.error('Could not remove contact', { description: err.message }),
+  });
+
+  // ── Merge a duplicate record into this one ──
+  const [mergeOpen, setMergeOpen] = useState(false);
+  const [mergeSearch, setMergeSearch] = useState('');
+  const [mergeTarget, setMergeTarget] = useState(null);
+  const debouncedMergeSearch = useDebounced(mergeSearch);
+  const mergeCandidates = useQuery({
+    queryKey: ['redeem-ops', 'merge-search', id, debouncedMergeSearch],
+    queryFn: () => redeemOpsApi.listPartners({ limit: 6, ...(debouncedMergeSearch ? { search: debouncedMergeSearch } : {}) }),
+    enabled: mergeOpen,
+  });
+  const mergeMutation = useMutation({
+    mutationFn: () => redeemOpsApi.mergePartners(id, mergeTarget.id),
+    onSuccess: () => {
+      toast.success('Merged — the duplicate’s history now lives here');
+      setMergeOpen(false); setMergeTarget(null); setMergeSearch('');
+      invalidate();
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partner', id, 'timeline'] });
+    },
+    onError: (err) => toast.error('Merge failed', { description: err.message }),
   });
 
   const [locationForm, setLocationForm] = useState(EMPTY_LOCATION);
@@ -501,7 +551,7 @@ export default function PartnerDetail() {
               {(partner.contacts || []).map((c) => (
                 <div key={c.id} className="flex items-center gap-3 border-b border-border pb-3 last:border-0 last:pb-0">
                   <RoAvatar name={c.name} size={32} />
-                  <div className="min-w-0">
+                  <div className="min-w-0 flex-1">
                     <p className="text-sm font-semibold m-0 flex items-center gap-1.5">
                       {c.name}
                       {c.isPrimary && <Star className="w-3.5 h-3.5" style={{ color: 'var(--ro-tag-yellow-fg)' }} aria-label="Primary contact" />}
@@ -510,6 +560,29 @@ export default function PartnerDetail() {
                       {[c.roleTitle, c.mobile, c.email].filter(Boolean).join(' · ') || '—'}
                     </p>
                   </div>
+                  {(isOwner || canReassign) && (
+                    <span className="flex gap-1 shrink-0">
+                      <Button
+                        size="sm" variant="ghost" aria-label={`Edit ${c.name}`}
+                        onClick={() => setContactEdit({
+                          id: c.id, name: c.name, roleTitle: c.roleTitle || '', mobile: c.mobile || '', email: c.email || '',
+                        })}
+                      >
+                        <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
+                      </Button>
+                      <Button
+                        size="sm" variant="ghost" aria-label={`Remove ${c.name}`}
+                        disabled={contactArchiveMutation.isPending}
+                        onClick={() => {
+                          if (window.confirm(`Remove ${c.name} from this business? Past activities keep their record.`)) {
+                            contactArchiveMutation.mutate(c.id);
+                          }
+                        }}
+                      >
+                        <X className="w-3.5 h-3.5" aria-hidden="true" />
+                      </Button>
+                    </span>
+                  )}
                 </div>
               ))}
               {(isOwner || canReassign) && (
@@ -600,6 +673,17 @@ export default function PartnerDetail() {
             </div>
           )}
 
+          {hasCapability(user, 'partners.merge') && (
+            <div className="pt-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => { setMergeOpen(true); setMergeTarget(null); setMergeSearch(''); }}
+              >
+                Merge duplicate into this…
+              </Button>
+            </div>
+          )}
           {hasCapability(user, 'partners.delete') && partner.pipelineStage !== 'PARTNERED' && (
             <div className="pt-1">
               <Button
@@ -667,6 +751,103 @@ export default function PartnerDetail() {
         </DialogContent>
       </Dialog>
 
+      <Dialog open={!!contactEdit} onOpenChange={(open) => { if (!open) setContactEdit(null); }}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Edit contact</DialogTitle>
+          </DialogHeader>
+          {contactEdit && (
+            <div className="space-y-3 py-1">
+              <div className="space-y-1.5">
+                <Label>Name *</Label>
+                <Input value={contactEdit.name} onChange={(e) => setContactEdit((c) => ({ ...c, name: e.target.value }))} />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Role</Label>
+                <Input value={contactEdit.roleTitle} onChange={(e) => setContactEdit((c) => ({ ...c, roleTitle: e.target.value }))} placeholder="Owner" />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label>Mobile</Label>
+                  <Input value={contactEdit.mobile} onChange={(e) => setContactEdit((c) => ({ ...c, mobile: e.target.value }))} />
+                </div>
+                <div className="space-y-1.5">
+                  <Label>Email</Label>
+                  <Input value={contactEdit.email} onChange={(e) => setContactEdit((c) => ({ ...c, email: e.target.value }))} />
+                </div>
+              </div>
+            </div>
+          )}
+          <DialogFooter>
+            <Button
+              disabled={!contactEdit?.name?.trim() || contactUpdateMutation.isPending}
+              onClick={() => contactUpdateMutation.mutate()}
+            >
+              {contactUpdateMutation.isPending ? 'Saving…' : 'Save'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={mergeOpen} onOpenChange={(open) => { if (!open) { setMergeOpen(false); setMergeTarget(null); } }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Merge a duplicate into “{name}”</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2 py-1">
+            <p className="text-[13px] m-0" style={{ color: 'var(--ro-text-2)' }}>
+              The duplicate's contacts, activities and history move onto this record, and the duplicate is archived. This keeps every touchpoint — use Delete only for records created by mistake.
+            </p>
+            <input
+              className="ro-search w-full"
+              placeholder="Search the duplicate by name, phone or UEN"
+              value={mergeSearch}
+              onChange={(e) => { setMergeSearch(e.target.value); setMergeTarget(null); }}
+            />
+            <div className="max-h-48 overflow-y-auto rounded-xl border border-border">
+              {(mergeCandidates.data?.partners || []).filter((p2) => p2.id !== id).map((p2) => {
+                const n2 = p2.tradingName || p2.brandName || p2.legalName;
+                const selected = mergeTarget?.id === p2.id;
+                return (
+                  <button
+                    key={p2.id}
+                    type="button"
+                    onClick={() => setMergeTarget(p2)}
+                    className="w-full flex items-center gap-2.5 px-3 py-2 border-t border-border first:border-t-0 cursor-pointer text-left"
+                    style={{ background: selected ? 'var(--ro-tag-blue-bg)' : '#fff' }}
+                  >
+                    <RoAvatar name={n2} size={26} />
+                    <span className="min-w-0">
+                      <span className="block text-sm font-semibold truncate">{n2}</span>
+                      <span className="block text-xs truncate" style={{ color: 'var(--ro-text-2)' }}>
+                        {[p2.category, p2.primaryPhone].filter(Boolean).join(' · ') || '—'}
+                      </span>
+                    </span>
+                    <RoStageTag stage={p2.pipelineStage} size="sm" className="ml-auto shrink-0" />
+                  </button>
+                );
+              })}
+              {mergeOpen && !mergeCandidates.isLoading && (mergeCandidates.data?.partners || []).filter((p2) => p2.id !== id).length === 0 && (
+                <p className="text-sm text-center py-4 m-0" style={{ color: 'var(--ro-text-2)' }}>No businesses match.</p>
+              )}
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              disabled={!mergeTarget || mergeMutation.isPending}
+              onClick={() => {
+                const n2 = mergeTarget.tradingName || mergeTarget.brandName || mergeTarget.legalName;
+                if (window.confirm(`Merge "${n2}" into "${name}"? "${n2}" will be archived.`)) {
+                  mergeMutation.mutate();
+                }
+              }}
+            >
+              {mergeMutation.isPending ? 'Merging…' : 'Merge'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       <Dialog open={!!editForm} onOpenChange={(open) => { if (!open) setEditForm(null); }}>
         <DialogContent className="max-w-lg">
           <DialogHeader>
@@ -701,6 +882,10 @@ export default function PartnerDetail() {
               <div className="space-y-1.5">
                 <Label>Email</Label>
                 <Input value={editForm.primaryEmail} onChange={setEdit('primaryEmail')} placeholder="hello@nailbliss.sg" />
+              </div>
+              <div className="col-span-2 space-y-1.5">
+                <Label>Notes</Label>
+                <Textarea rows={3} value={editForm.notes} onChange={setEdit('notes')} placeholder="Anything the team should know about this business" />
               </div>
             </div>
           )}

--- a/src/pages/redeemops/PartnersList.jsx
+++ b/src/pages/redeemops/PartnersList.jsx
@@ -3,6 +3,8 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { redeemOpsApi } from '@/api/redeemOps';
+import { useAuthStore } from '@/stores/authStore';
+import { hasCapability } from '@/lib/redeemOpsPermissions';
 import {
   Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
 } from '@/components/ui/dialog';
@@ -13,6 +15,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import Plus from 'lucide-react/icons/plus';
+import Upload from 'lucide-react/icons/upload';
 import AlertTriangle from 'lucide-react/icons/alert-triangle';
 import { RoStageTag, RoAvatar, RoOwner, RoPageHeader, prettyEnum } from '@/components/redeemops/ui';
 
@@ -24,6 +27,35 @@ function useDebounced(value, ms = 300) {
   }, [value, ms]);
   return debounced;
 }
+
+/* Minimal CSV parsing for the strict import template (handles quoted fields). */
+function parseCsv(text) {
+  const rows = [];
+  let row = [];
+  let cell = '';
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (inQuotes) {
+      if (ch === '"' && text[i + 1] === '"') { cell += '"'; i += 1; }
+      else if (ch === '"') inQuotes = false;
+      else cell += ch;
+    } else if (ch === '"') inQuotes = true;
+    else if (ch === ',') { row.push(cell); cell = ''; }
+    else if (ch === '\n' || ch === '\r') {
+      if (ch === '\r' && text[i + 1] === '\n') i += 1;
+      row.push(cell); cell = '';
+      if (row.some((c) => c.trim() !== '')) rows.push(row);
+      row = [];
+    } else cell += ch;
+  }
+  row.push(cell);
+  if (row.some((c) => c.trim() !== '')) rows.push(row);
+  return rows;
+}
+
+const IMPORT_TEMPLATE = 'name,category,phone,instagram,website,uen,email\n"Nail Bliss","Nail Salon","+6591234567","@nailbliss.sg","nailbliss.sg","202512345K","hello@nailbliss.sg"\n';
+const IMPORT_COLUMNS = ['name', 'category', 'phone', 'instagram', 'website', 'uen', 'email'];
 
 const EMPTY_FORM = {
   tradingName: '', legalName: '', category: '', primaryPhone: '', primaryEmail: '',
@@ -104,6 +136,54 @@ export default function PartnersList() {
     });
   };
 
+  // ── CSV import: strict template, row-by-row through the same dedupe-gated
+  // create endpoint (exact duplicates are skipped and counted, every created
+  // row is audited like a manual add). Client-side on purpose — no new
+  // backend surface, works for the list sizes a 3-person team imports.
+  const user = useAuthStore((st) => st.user);
+  const canImport = hasCapability(user, 'partners.import');
+  const [importOpen, setImportOpen] = useState(false);
+  const [importState, setImportState] = useState(null); // null | {running, done, total, created, skipped, failed, errors[]}
+
+  const runImport = async (file) => {
+    const text = await file.text();
+    const rows = parseCsv(text);
+    if (rows.length < 2) { toast.error('CSV has no data rows'); return; }
+    const header = rows[0].map((h) => h.trim().toLowerCase());
+    const idx = Object.fromEntries(IMPORT_COLUMNS.map((c) => [c, header.indexOf(c)]));
+    if (idx.name === -1) { toast.error('CSV must have a "name" column — download the template'); return; }
+    const dataRows = rows.slice(1).slice(0, 500);
+    const state = { running: true, done: 0, total: dataRows.length, created: 0, skipped: 0, failed: 0, errors: [] };
+    setImportState({ ...state });
+    for (const row of dataRows) {
+      const cell = (k) => (idx[k] >= 0 ? String(row[idx[k]] || '').trim() : '');
+      const body = {
+        tradingName: cell('name'),
+        category: cell('category'),
+        primaryPhone: cell('phone'),
+        instagramHandle: cell('instagram'),
+        website: cell('website'),
+        uen: cell('uen'),
+        primaryEmail: cell('email'),
+      };
+      if (!body.tradingName) { state.failed += 1; state.errors.push('Row with empty name skipped'); }
+      else {
+        try {
+          await redeemOpsApi.createPartner(body);
+          state.created += 1;
+        } catch (err) {
+          if (err.status === 409) state.skipped += 1;
+          else { state.failed += 1; if (state.errors.length < 5) state.errors.push(`${body.tradingName}: ${err.message}`); }
+        }
+      }
+      state.done += 1;
+      setImportState({ ...state });
+    }
+    state.running = false;
+    setImportState({ ...state });
+    queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partners'] });
+  };
+
   const partners = listQuery.data?.partners || [];
   const pagination = listQuery.data?.pagination;
   const stages = constants.data?.pipelineStages || [];
@@ -119,9 +199,16 @@ export default function PartnersList() {
         title="Partners"
         sub={pagination ? `${pagination.total} business${pagination.total === 1 ? '' : 'es'} on the books — search before you add, claim before you contact.` : 'The shared business database — search before you add, claim before you contact.'}
         actions={(
-          <Button onClick={() => { setCreateOpen(true); setDuplicates(null); }}>
-            <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" /> Add business
-          </Button>
+          <>
+            {canImport && (
+              <Button variant="outline" onClick={() => { setImportOpen(true); setImportState(null); }}>
+                <Upload className="w-4 h-4 mr-1.5" aria-hidden="true" /> Import CSV
+              </Button>
+            )}
+            <Button onClick={() => { setCreateOpen(true); setDuplicates(null); }}>
+              <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" /> Add business
+            </Button>
+          </>
         )}
       />
 
@@ -218,6 +305,49 @@ export default function PartnersList() {
           </div>
         )}
       </div>
+
+      <Dialog open={importOpen} onOpenChange={(open) => { if (!open && !importState?.running) { setImportOpen(false); setImportState(null); } }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Import businesses from CSV</DialogTitle>
+            <DialogDescription>
+              Columns: name (required), category, phone (+65…), instagram, website, uen, email.
+              Exact duplicates are skipped automatically; every created row is audited.{' '}
+              <a
+                className="ro-link"
+                href={`data:text/csv;charset=utf-8,${encodeURIComponent(IMPORT_TEMPLATE)}`}
+                download="redeem-ops-import-template.csv"
+              >
+                Download template
+              </a>
+            </DialogDescription>
+          </DialogHeader>
+          {!importState && (
+            <div className="py-2">
+              <Input
+                type="file"
+                accept=".csv,text/csv"
+                onChange={(e) => { const f = e.target.files?.[0]; if (f) runImport(f); }}
+              />
+              <p className="text-xs mt-2 m-0" style={{ color: 'var(--ro-text-3)' }}>Up to 500 rows per file.</p>
+            </div>
+          )}
+          {importState && (
+            <div className="py-2 space-y-2">
+              <div className="ro-progress"><i style={{ width: `${importState.total ? Math.round((importState.done / importState.total) * 100) : 0}%` }} /></div>
+              <p className="text-sm m-0">
+                {importState.running ? `Importing ${importState.done} of ${importState.total}…` : 'Done.'}{' '}
+                <b>{importState.created}</b> created · <b>{importState.skipped}</b> duplicates skipped · <b>{importState.failed}</b> failed
+              </p>
+              {importState.errors.length > 0 && (
+                <ul className="text-xs m-0 pl-4" style={{ color: 'var(--ro-tag-red-fg)' }}>
+                  {importState.errors.map((er) => <li key={er}>{er}</li>)}
+                </ul>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={createOpen} onOpenChange={(open) => { setCreateOpen(open); if (!open) { setDuplicates(null); setOverrideReason(''); } }}>
         <DialogContent className="max-w-lg">

--- a/src/pages/redeemops/RedemptionsPage.jsx
+++ b/src/pages/redeemops/RedemptionsPage.jsx
@@ -23,9 +23,10 @@ export default function RedemptionsPage() {
     queryKey: ['redeem-ops', 'redemptions'],
     queryFn: () => redeemOpsApi.listRedemptions(),
   });
+  const [resSearch, setResSearch] = useState('');
   const entitlementsQuery = useQuery({
-    queryKey: ['redeem-ops', 'entitlements'],
-    queryFn: () => redeemOpsApi.listEntitlements({ limit: 15 }),
+    queryKey: ['redeem-ops', 'entitlements', resSearch],
+    queryFn: () => redeemOpsApi.listEntitlements({ limit: 15, ...(resSearch.trim() ? { search: resSearch.trim() } : {}) }),
   });
 
   const unlockMutation = useMutation({
@@ -130,6 +131,12 @@ export default function RedemptionsPage() {
           </CardDescription>
         </CardHeader>
         <CardContent>
+          <input
+            className="ro-search w-full max-w-xs mb-3"
+            placeholder="Search holder name or phone"
+            value={resSearch}
+            onChange={(e) => setResSearch(e.target.value)}
+          />
           <div className="space-y-0">
             {(entitlementsQuery.data?.entitlements || []).map((e) => (
               <div key={e.id} className="flex items-center gap-3 py-2.5 border-t border-border first:border-t-0">

--- a/src/pages/redeemops/TasksPage.jsx
+++ b/src/pages/redeemops/TasksPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -9,16 +9,103 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '@/components/ui/table';
+import {
+  Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
-import { RoPageHeader, RoTag } from '@/components/redeemops/ui';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import Plus from 'lucide-react/icons/plus';
+import Pencil from 'lucide-react/icons/pencil';
+import { RoPageHeader, RoTag, RoAvatar, prettyEnum } from '@/components/redeemops/ui';
 
 const VIEWS = [
   { key: 'today', label: 'Due today', params: { due: 'today' } },
   { key: 'overdue', label: 'Overdue', params: { due: 'overdue' } },
   { key: 'upcoming', label: 'Upcoming', params: { due: 'upcoming' } },
   { key: 'mine', label: 'All mine', params: {} },
-  { key: 'team', label: 'Team', params: { scope: 'team' }, managerOnly: true },
+  { key: 'completed', label: 'Completed', params: { status: 'completed' } },
+  { key: 'team', label: 'Team', params: { scope: 'team', status: 'all' }, managerOnly: true },
 ];
+
+function useDebounced(value, ms = 300) {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), ms);
+    return () => clearTimeout(t);
+  }, [value, ms]);
+  return debounced;
+}
+
+function dueLabel(t) {
+  if (t.status === 'completed') {
+    return { text: t.completedAt ? `Done ${new Date(t.completedAt).toLocaleDateString()}` : 'Done', color: 'var(--ro-tag-green-fg)' };
+  }
+  if (t.status === 'cancelled') return { text: 'Cancelled', color: 'var(--ro-text-3)' };
+  const due = new Date(t.dueAt);
+  const today = new Date(); today.setHours(0, 0, 0, 0);
+  const tomorrow = new Date(today); tomorrow.setDate(tomorrow.getDate() + 1);
+  if (due < today) {
+    const days = Math.max(1, Math.round((today - due) / 86400000));
+    return { text: `${days}d overdue`, color: 'var(--ro-tag-red-fg)' };
+  }
+  if (due < tomorrow) {
+    return { text: t.hasTime ? due.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : 'Today', color: 'var(--ro-tag-yellow-fg)' };
+  }
+  return { text: due.toLocaleDateString(), color: 'var(--ro-text-2)' };
+}
+
+/* Shared partner search-picker used by the New task dialog. */
+function PartnerPicker({ value, onPick }) {
+  const [search, setSearch] = useState('');
+  const debounced = useDebounced(search);
+  const results = useQuery({
+    queryKey: ['redeem-ops', 'task-partner-search', debounced],
+    queryFn: () => redeemOpsApi.listPartners({ limit: 6, ...(debounced ? { search: debounced } : {}) }),
+  });
+  const partners = results.data?.partners || [];
+  return (
+    <div className="space-y-2">
+      <input
+        className="ro-search w-full"
+        placeholder="Search business by name, phone or UEN"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
+      <div className="max-h-48 overflow-y-auto rounded-xl border border-border">
+        {partners.map((p) => {
+          const name = p.tradingName || p.brandName || p.legalName;
+          const selected = value?.id === p.id;
+          return (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => onPick(p)}
+              className="w-full flex items-center gap-2.5 px-3 py-2 border-t border-border first:border-t-0 cursor-pointer text-left"
+              style={{ background: selected ? 'var(--ro-tag-blue-bg)' : '#fff' }}
+            >
+              <RoAvatar name={name} size={26} />
+              <span className="min-w-0">
+                <span className="block text-sm font-semibold truncate">{name}</span>
+                <span className="block text-xs truncate" style={{ color: 'var(--ro-text-2)' }}>
+                  {[p.category, p.owner?.fullName && `owned by ${p.owner.fullName}`].filter(Boolean).join(' · ') || '—'}
+                </span>
+              </span>
+            </button>
+          );
+        })}
+        {!results.isLoading && partners.length === 0 && (
+          <p className="text-sm text-center py-4 m-0" style={{ color: 'var(--ro-text-2)' }}>No businesses match.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const EMPTY_TASK = { title: '', dueDate: '', priority: 'medium', assigneeUserId: '' };
 
 export default function TasksPage() {
   const user = useAuthStore((s) => s.user);
@@ -32,24 +119,70 @@ export default function TasksPage() {
     queryFn: () => redeemOpsApi.listTasks({ ...activeView.params, limit: 50 }),
     placeholderData: keepPreviousData,
   });
+  const teamQuery = useQuery({
+    queryKey: ['redeem-ops', 'team'],
+    queryFn: redeemOpsApi.getTeam,
+    enabled: isManager,
+  });
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'tasks'] });
+    queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'queue'] });
+  };
 
   const updateMutation = useMutation({
     mutationFn: ({ taskId, body }) => redeemOpsApi.updateTask(taskId, body),
-    onSuccess: () => {
-      toast.success('Task updated');
-      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'tasks'] });
-      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'queue'] });
-    },
+    onSuccess: () => { toast.success('Task updated'); invalidate(); },
     onError: (err) => toast.error('Update failed', { description: err.message }),
   });
 
+  // ── New task ────────────────────────────────────────────────────────────
+  const [createOpen, setCreateOpen] = useState(false);
+  const [partner, setPartner] = useState(null);
+  const [form, setForm] = useState(EMPTY_TASK);
+  const createMutation = useMutation({
+    mutationFn: () => redeemOpsApi.createTask({
+      partnerOrganisationId: partner.id,
+      title: form.title.trim(),
+      dueAt: new Date(`${form.dueDate}T09:00:00`).toISOString(),
+      priority: form.priority,
+      ...(form.assigneeUserId ? { assigneeUserId: form.assigneeUserId } : {}),
+    }),
+    onSuccess: () => {
+      toast.success('Task created');
+      setCreateOpen(false); setPartner(null); setForm(EMPTY_TASK);
+      invalidate();
+    },
+    onError: (err) => toast.error('Could not create task', { description: err.message }),
+  });
+
+  // ── Edit task ───────────────────────────────────────────────────────────
+  const [editTask, setEditTask] = useState(null); // { id, title, dueDate, priority, assigneeUserId }
+  const editMutation = useMutation({
+    mutationFn: () => redeemOpsApi.updateTask(editTask.id, {
+      title: editTask.title.trim(),
+      dueAt: new Date(`${editTask.dueDate}T09:00:00`).toISOString(),
+      priority: editTask.priority,
+      ...(isManager && editTask.assigneeUserId ? { assigneeUserId: editTask.assigneeUserId } : {}),
+    }),
+    onSuccess: () => { toast.success('Task updated'); setEditTask(null); invalidate(); },
+    onError: (err) => toast.error('Could not update task', { description: err.message }),
+  });
+
   const tasks = tasksQuery.data?.tasks || [];
+  const team = (teamQuery.data || []).filter((m) => m.isActive);
+  const showStatus = view === 'mine' || view === 'team' || view === 'completed';
 
   return (
     <div className="p-6 md:p-8 max-w-5xl mx-auto space-y-5">
       <RoPageHeader
         title="Tasks"
-        sub="Follow-ups are tasks, not notes — create them from a partner's page."
+        sub="Your follow-ups across every business — completed ones live in their own tab."
+        actions={(
+          <Button onClick={() => { setCreateOpen(true); setPartner(null); setForm(EMPTY_TASK); }}>
+            <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" /> New task
+          </Button>
+        )}
       />
 
       <Tabs value={view} onValueChange={setView}>
@@ -70,54 +203,85 @@ export default function TasksPage() {
                   <TableHead>Business</TableHead>
                   <TableHead>Due</TableHead>
                   <TableHead>Priority</TableHead>
+                  {showStatus && <TableHead>Status</TableHead>}
                   {view === 'team' && <TableHead>Assignee</TableHead>}
                   <TableHead className="text-right">Actions</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {tasks.map((t) => (
-                  <TableRow key={t.id}>
-                    <TableCell className="font-medium">{t.title}</TableCell>
-                    <TableCell>
-                      <Link to={`/redeem-ops/partners/${t.partner?.id}`} className="ro-link text-sm">
-                        {t.partner?.tradingName || t.partner?.brandName || t.partner?.legalName || '—'}
-                      </Link>
-                    </TableCell>
-                    <TableCell className="text-muted-foreground text-sm">
-                      {new Date(t.dueAt).toLocaleDateString()}
-                      {t.hasTime ? ` ${new Date(t.dueAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}` : ''}
-                    </TableCell>
-                    <TableCell>
-                      <RoTag tone={t.priority} size="sm">{t.priority}</RoTag>
-                    </TableCell>
-                    {view === 'team' && (
-                      <TableCell className="text-muted-foreground text-sm">{t.assignee?.fullName || '—'}</TableCell>
-                    )}
-                    <TableCell className="text-right space-x-1">
-                      {t.status !== 'completed' && (
-                        <Button
-                          size="sm" variant="outline"
-                          disabled={updateMutation.isPending}
-                          onClick={() => updateMutation.mutate({ taskId: t.id, body: { status: 'completed' } })}
-                        >
-                          Complete
-                        </Button>
+                {tasks.map((t) => {
+                  const due = dueLabel(t);
+                  const open = t.status === 'open' || t.status === 'in_progress';
+                  return (
+                    <TableRow key={t.id}>
+                      <TableCell className="font-medium">{t.title}</TableCell>
+                      <TableCell>
+                        <Link to={`/redeem-ops/partners/${t.partner?.id}`} className="ro-link text-sm">
+                          {t.partner?.tradingName || t.partner?.brandName || t.partner?.legalName || '—'}
+                        </Link>
+                      </TableCell>
+                      <TableCell>
+                        <span className="text-[12.5px] font-semibold" style={{ color: due.color }}>{due.text}</span>
+                      </TableCell>
+                      <TableCell>
+                        <RoTag tone={t.priority} size="sm">{t.priority}</RoTag>
+                      </TableCell>
+                      {showStatus && (
+                        <TableCell>
+                          <RoTag tone={t.status} size="sm">{prettyEnum(t.status)}</RoTag>
+                        </TableCell>
                       )}
-                      {t.status === 'open' && (
-                        <Button
-                          size="sm" variant="ghost"
-                          disabled={updateMutation.isPending}
-                          onClick={() => updateMutation.mutate({ taskId: t.id, body: { status: 'cancelled' } })}
-                        >
-                          Cancel
-                        </Button>
+                      {view === 'team' && (
+                        <TableCell className="text-muted-foreground text-sm">{t.assignee?.fullName || '—'}</TableCell>
                       )}
-                    </TableCell>
-                  </TableRow>
-                ))}
+                      <TableCell className="text-right space-x-1 whitespace-nowrap">
+                        {open && (
+                          <>
+                            <Button
+                              size="sm" variant="outline"
+                              disabled={updateMutation.isPending}
+                              onClick={() => updateMutation.mutate({ taskId: t.id, body: { status: 'completed' } })}
+                            >
+                              Complete
+                            </Button>
+                            <Button
+                              size="sm" variant="ghost"
+                              aria-label="Edit task"
+                              onClick={() => setEditTask({
+                                id: t.id,
+                                title: t.title,
+                                dueDate: new Date(t.dueAt).toISOString().slice(0, 10),
+                                priority: t.priority,
+                                assigneeUserId: t.assigneeUserId || '',
+                              })}
+                            >
+                              <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
+                            </Button>
+                            <Button
+                              size="sm" variant="ghost"
+                              disabled={updateMutation.isPending}
+                              onClick={() => updateMutation.mutate({ taskId: t.id, body: { status: 'cancelled' } })}
+                            >
+                              Cancel
+                            </Button>
+                          </>
+                        )}
+                        {t.status === 'completed' && (
+                          <Button
+                            size="sm" variant="ghost"
+                            disabled={updateMutation.isPending}
+                            onClick={() => updateMutation.mutate({ taskId: t.id, body: { status: 'open' } })}
+                          >
+                            Reopen
+                          </Button>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
                 {!tasksQuery.isLoading && tasks.length === 0 && (
                   <TableRow>
-                    <TableCell colSpan={view === 'team' ? 6 : 5} className="text-center text-muted-foreground py-10">
+                    <TableCell colSpan={7} className="text-center text-muted-foreground py-10">
                       Nothing here.
                     </TableCell>
                   </TableRow>
@@ -127,6 +291,119 @@ export default function TasksPage() {
           </div>
         </div>
       </div>
+
+      <Dialog open={createOpen} onOpenChange={(open) => { if (!open) setCreateOpen(false); }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>New task</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3 py-1">
+            {partner ? (
+              <div className="flex items-center gap-2.5 rounded-xl border border-border px-3 py-2">
+                <RoAvatar name={partner.tradingName || partner.brandName || partner.legalName} size={26} />
+                <span className="text-sm font-semibold flex-1 truncate">
+                  {partner.tradingName || partner.brandName || partner.legalName}
+                </span>
+                <Button size="sm" variant="ghost" onClick={() => setPartner(null)}>Change</Button>
+              </div>
+            ) : (
+              <PartnerPicker value={partner} onPick={setPartner} />
+            )}
+            <div className="space-y-1.5">
+              <Label>What needs doing? *</Label>
+              <Input value={form.title} onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))} placeholder="Follow up on proposal" />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label>Due date *</Label>
+                <Input type="date" value={form.dueDate} onChange={(e) => setForm((f) => ({ ...f, dueDate: e.target.value }))} />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Priority</Label>
+                <Select value={form.priority} onValueChange={(priority) => setForm((f) => ({ ...f, priority }))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="low">Low</SelectItem>
+                    <SelectItem value="medium">Medium</SelectItem>
+                    <SelectItem value="high">High</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            {isManager && team.length > 0 && (
+              <div className="space-y-1.5">
+                <Label>Assign to</Label>
+                <Select value={form.assigneeUserId} onValueChange={(assigneeUserId) => setForm((f) => ({ ...f, assigneeUserId }))}>
+                  <SelectTrigger><SelectValue placeholder="Myself" /></SelectTrigger>
+                  <SelectContent>
+                    {team.map((m) => <SelectItem key={m.id} value={m.id}>{m.fullName || m.email}</SelectItem>)}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              disabled={!partner || !form.title.trim() || !form.dueDate || createMutation.isPending}
+              onClick={() => createMutation.mutate()}
+            >
+              {createMutation.isPending ? 'Saving…' : 'Create task'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={!!editTask} onOpenChange={(open) => { if (!open) setEditTask(null); }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Edit task</DialogTitle>
+          </DialogHeader>
+          {editTask && (
+            <div className="space-y-3 py-1">
+              <div className="space-y-1.5">
+                <Label>Title *</Label>
+                <Input value={editTask.title} onChange={(e) => setEditTask((t) => ({ ...t, title: e.target.value }))} />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label>Due date *</Label>
+                  <Input type="date" value={editTask.dueDate} onChange={(e) => setEditTask((t) => ({ ...t, dueDate: e.target.value }))} />
+                </div>
+                <div className="space-y-1.5">
+                  <Label>Priority</Label>
+                  <Select value={editTask.priority} onValueChange={(priority) => setEditTask((t) => ({ ...t, priority }))}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="low">Low</SelectItem>
+                      <SelectItem value="medium">Medium</SelectItem>
+                      <SelectItem value="high">High</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              {isManager && team.length > 0 && (
+                <div className="space-y-1.5">
+                  <Label>Assignee</Label>
+                  <Select value={editTask.assigneeUserId} onValueChange={(assigneeUserId) => setEditTask((t) => ({ ...t, assigneeUserId }))}>
+                    <SelectTrigger><SelectValue placeholder="Unchanged" /></SelectTrigger>
+                    <SelectContent>
+                      {team.map((m) => <SelectItem key={m.id} value={m.id}>{m.fullName || m.email}</SelectItem>)}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+            </div>
+          )}
+          <DialogFooter>
+            <Button
+              disabled={!editTask?.title?.trim() || !editTask?.dueDate || editMutation.isPending}
+              onClick={() => editMutation.mutate()}
+            >
+              {editMutation.isPending ? 'Saving…' : 'Save changes'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
Full sweep of the "backend supports it, UI never exposed it" class (user-reported completed-tasks disappearance + the CRM audit's P1 list):

- **Tasks**: Completed tab + Reopen, status column, colored due labels, create-from-page with partner picker (+ manager assignment), edit dialog (retitle/reschedule/reprioritize/reassign)
- **Partner page**: contact edit + archive, notes in the edit dialog, **merge-duplicates UI** over the existing endpoint
- **Redemptions**: holder search on the reservations panel (backend \`listEntitlements\` gains \`search\`)
- **Partners**: **CSV import** (strict downloadable template, dedupe-gated row-by-row via the existing create endpoint, duplicates skipped/counted, audited)

Verified: both builds, 1113 vitest pass, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqCcNpihKgDTQ9YG811btF