### PR TITLE
feat(redeem-ops): five-stage pipeline — Lost with reasons, snooze with wake dates

### DIFF
--- a/backend/src/controllers/redeemOps/partnersController.js
+++ b/backend/src/controllers/redeemOps/partnersController.js
@@ -3,6 +3,7 @@ import { asyncHandler, AppError } from '../../middleware/errorHandler.js';
 import partnerService from '../../services/redeemOps/partnerService.js';
 import { makeClaimService } from '../../services/redeemOps/claimService.js';
 import { makeDedupeService } from '../../services/redeemOps/dedupeService.js';
+import { LOST_REASONS } from '../../services/redeemOps/constants.js';
 
 const claimService = makeClaimService();
 const dedupeService = makeDedupeService();
@@ -92,9 +93,24 @@ export const changeStage = asyncHandler(async (req, res) => {
   const schema = Joi.object({
     toStage: Joi.string().max(32).required(),
     reason: Joi.string().max(255).allow('', null),
+    lostReason: Joi.string().valid(...LOST_REASONS).allow(null),
   });
   const body = validateBody(schema, req.body);
-  const partner = await partnerService.changeStage(req.params.id, body.toStage, req.user, body.reason || null, req.id);
+  const partner = await partnerService.changeStage(
+    req.params.id, body.toStage, req.user, body.reason || null, req.id, body.lostReason || null
+  );
+  res.json({ success: true, data: { partner } });
+});
+
+export const snoozePartner = asyncHandler(async (req, res) => {
+  const schema = Joi.object({ until: Joi.date().iso().required() });
+  const body = validateBody(schema, req.body);
+  const partner = await partnerService.snoozePartner(req.params.id, req.user, body.until, req.id);
+  res.json({ success: true, data: { partner } });
+});
+
+export const unsnoozePartner = asyncHandler(async (req, res) => {
+  const partner = await partnerService.unsnoozePartner(req.params.id, req.user, req.id);
   res.json({ success: true, data: { partner } });
 });
 

--- a/backend/src/database/migrations/051-five-stage-pipeline.js
+++ b/backend/src/database/migrations/051-five-stage-pipeline.js
@@ -1,0 +1,71 @@
+/**
+ * 051 — Five-stage pipeline (docs: research-backed reduction from 14 stages).
+ *
+ * New model: NEW → CONTACTED → MEETING → PROPOSAL → PARTNERED, plus LOST as a
+ * terminal outcome with a reason, plus snooze-as-flag. Old stage names remain
+ * valid history in partner_stage_events (STRING columns, never rewritten).
+ *
+ * Idempotent + guarded like 045-050; down() restores a best-effort mapping
+ * (lossy by design — merged stages can't be split back).
+ */
+export async function up(queryInterface) {
+  const q = async (sql) => queryInterface.sequelize.query(sql);
+
+  await q('ALTER TABLE partner_organisations ADD COLUMN IF NOT EXISTS "lostReason" VARCHAR(32)');
+  await q('ALTER TABLE partner_organisations ADD COLUMN IF NOT EXISTS "snoozedUntil" TIMESTAMPTZ');
+
+  // Ownership decouples from stage: UNCLAIMED/CLAIMED/RESEARCHING were never
+  // commitment milestones. Researching work is a task; claiming is ownerUserId.
+  await q(`UPDATE partner_organisations SET "pipelineStage" = 'NEW'
+            WHERE "pipelineStage" IN ('UNCLAIMED', 'CLAIMED', 'RESEARCHING')`);
+
+  // Replied is an activity outcome; no-response is a risk signal, not a stage.
+  await q(`UPDATE partner_organisations SET "staleFlag" = TRUE
+            WHERE "pipelineStage" = 'NO_RESPONSE'`);
+  await q(`UPDATE partner_organisations SET "pipelineStage" = 'CONTACTED'
+            WHERE "pipelineStage" IN ('REPLIED', 'NO_RESPONSE')`);
+
+  await q(`UPDATE partner_organisations SET "pipelineStage" = 'MEETING'
+            WHERE "pipelineStage" IN ('MEETING_BOOKED', 'MEETING_COMPLETED')`);
+
+  await q(`UPDATE partner_organisations SET "pipelineStage" = 'PROPOSAL'
+            WHERE "pipelineStage" IN ('PROPOSAL_SENT', 'NEGOTIATING')`);
+
+  // Two dead stages become one outcome with a reason.
+  await q(`UPDATE partner_organisations SET "pipelineStage" = 'LOST', "lostReason" = 'not_interested'
+            WHERE "pipelineStage" = 'NOT_INTERESTED'`);
+  await q(`UPDATE partner_organisations SET "pipelineStage" = 'LOST', "lostReason" = 'disqualified'
+            WHERE "pipelineStage" = 'DISQUALIFIED'`);
+
+  // Snooze becomes a flag: keep availability='follow_up_later' (already set by
+  // the old stage move) and give it a 30-day wake so nothing sleeps forever.
+  await q(`UPDATE partner_organisations
+              SET "pipelineStage" = 'CONTACTED',
+                  "snoozedUntil" = NOW() + INTERVAL '30 days'
+            WHERE "pipelineStage" = 'FOLLOW_UP_LATER'`);
+
+  // New records start at NEW.
+  await q(`ALTER TABLE partner_organisations ALTER COLUMN "pipelineStage" SET DEFAULT 'NEW'`);
+}
+
+export async function down(queryInterface) {
+  const q = async (sql) => queryInterface.sequelize.query(sql);
+  // Best-effort reversal onto representative old names (merged detail is gone).
+  await q(`UPDATE partner_organisations SET "pipelineStage" = 'CLAIMED'
+            WHERE "pipelineStage" = 'NEW' AND "ownerUserId" IS NOT NULL`);
+  await q(`UPDATE partner_organisations SET "pipelineStage" = 'UNCLAIMED'
+            WHERE "pipelineStage" = 'NEW'`);
+  await q(`UPDATE partner_organisations SET "pipelineStage" = 'MEETING_BOOKED'
+            WHERE "pipelineStage" = 'MEETING'`);
+  await q(`UPDATE partner_organisations SET "pipelineStage" = 'PROPOSAL_SENT'
+            WHERE "pipelineStage" = 'PROPOSAL'`);
+  await q(`UPDATE partner_organisations SET "pipelineStage" = 'NOT_INTERESTED'
+            WHERE "pipelineStage" = 'LOST' AND "lostReason" = 'not_interested'`);
+  await q(`UPDATE partner_organisations SET "pipelineStage" = 'DISQUALIFIED'
+            WHERE "pipelineStage" = 'LOST'`);
+  await q(`UPDATE partner_organisations SET "pipelineStage" = 'FOLLOW_UP_LATER'
+            WHERE availability = 'follow_up_later' AND "pipelineStage" = 'CONTACTED'`);
+  await q(`ALTER TABLE partner_organisations ALTER COLUMN "pipelineStage" SET DEFAULT 'UNCLAIMED'`);
+  await q('ALTER TABLE partner_organisations DROP COLUMN IF EXISTS "lostReason"');
+  await q('ALTER TABLE partner_organisations DROP COLUMN IF EXISTS "snoozedUntil"');
+}

--- a/backend/src/models/PartnerOrganisation.js
+++ b/backend/src/models/PartnerOrganisation.js
@@ -45,7 +45,9 @@ const PartnerOrganisation = sequelize.define('PartnerOrganisation', {
   notes: { type: DataTypes.TEXT, allowNull: true },
 
   // Pipeline + ownership (constants: services/redeemOps/constants.js — STRING not ENUM, house style)
-  pipelineStage: { type: DataTypes.STRING(32), allowNull: false, defaultValue: 'UNCLAIMED' },
+  pipelineStage: { type: DataTypes.STRING(32), allowNull: false, defaultValue: 'NEW' },
+  lostReason: { type: DataTypes.STRING(32), allowNull: true },
+  snoozedUntil: { type: DataTypes.DATE, allowNull: true },
   availability: {
     type: DataTypes.STRING(24),
     allowNull: false,

--- a/backend/src/routes/redeemOpsPartners.js
+++ b/backend/src/routes/redeemOpsPartners.js
@@ -32,6 +32,8 @@ router.post('/partners/:id/assign', requireRedeemOps('partners.reassign'), ctrl.
 // Pipeline
 router.patch('/partners/:id/stage', requireRedeemOps('pipeline.move'), ctrl.changeStage);
 router.post('/partners/:id/stage/undo', requireRedeemOps('pipeline.move'), ctrl.undoStage);
+router.post('/partners/:id/snooze', requireRedeemOps('pipeline.move'), ctrl.snoozePartner);
+router.post('/partners/:id/unsnooze', requireRedeemOps('pipeline.move'), ctrl.unsnoozePartner);
 
 // Merge (destructive-adjacent — ops_admin+)
 router.post('/partners/:id/merge', requireRedeemOps('partners.merge'), ctrl.mergePartners);

--- a/backend/src/services/redeemOps/analyticsService.js
+++ b/backend/src/services/redeemOps/analyticsService.js
@@ -61,8 +61,12 @@ export function makeAnalyticsService(overrides = {}) {
       `SELECT COALESCE(p.category, 'Uncategorised') AS category,
               COUNT(*)::int AS total,
               COUNT(*) FILTER (WHERE p."firstOutreachAt" IS NOT NULL)::int AS contacted,
-              COUNT(*) FILTER (WHERE p."pipelineStage" IN ('REPLIED','MEETING_BOOKED','MEETING_COMPLETED','PROPOSAL_SENT','NEGOTIATING','PARTNERED'))::int AS replied,
-              COUNT(*) FILTER (WHERE p."pipelineStage" IN ('MEETING_BOOKED','MEETING_COMPLETED','PROPOSAL_SENT','NEGOTIATING','PARTNERED'))::int AS meetings,
+              COUNT(*) FILTER (WHERE EXISTS (
+                SELECT 1 FROM outreach_activities a
+                 WHERE a."partnerOrganisationId" = p.id
+                   AND a.direction = 'inbound' AND a."voidedAt" IS NULL
+              ) OR p."pipelineStage" IN ('MEETING','PROPOSAL','PARTNERED'))::int AS replied,
+              COUNT(*) FILTER (WHERE p."pipelineStage" IN ('MEETING','PROPOSAL','PARTNERED'))::int AS meetings,
               COUNT(*) FILTER (WHERE p."pipelineStage" = 'PARTNERED')::int AS partnered
          FROM partner_organisations p
         WHERE p."mergedIntoId" IS NULL AND p."archivedAt" IS NULL

--- a/backend/src/services/redeemOps/claimService.js
+++ b/backend/src/services/redeemOps/claimService.js
@@ -43,7 +43,6 @@ export function makeClaimService(overrides = {}) {
           SET "ownerUserId" = :userId,
               "claimedAt" = NOW(),
               availability = 'owned',
-              "pipelineStage" = CASE WHEN "pipelineStage" = 'UNCLAIMED' THEN 'CLAIMED' ELSE "pipelineStage" END,
               "updatedAt" = NOW()
         WHERE id = :partnerId
           AND "ownerUserId" IS NULL
@@ -59,10 +58,8 @@ export function makeClaimService(overrides = {}) {
       { partnerOrganisationId: partnerId, kind: 'claim', toUserId: user.id, actorUserId: user.id, reason: via === 'claim' ? null : via },
       { transaction: t }
     );
-    await d.PartnerStageEvent.create(
-      { partnerOrganisationId: partnerId, fromStage: 'UNCLAIMED', toStage: rows[0].pipelineStage, actorUserId: user.id, reason: via },
-      { transaction: t }
-    );
+    // Ownership is not pipeline progress (5-stage model): claiming records an
+    // assignment event + audit only; the stage stays where the deal is.
     await d.audit.recordAuditEvent({
       actorUser: user, action: 'partner.claimed', entityType: 'partner_organisation',
       entityId: partnerId, reason: via === 'claim' ? null : via, transaction: t,
@@ -139,7 +136,6 @@ export function makeClaimService(overrides = {}) {
           availability: 'owned',
           claimedAt: partner.claimedAt || new Date(),
           atRiskFlag: false,
-          pipelineStage: partner.pipelineStage === 'UNCLAIMED' ? 'CLAIMED' : partner.pipelineStage,
         },
         { transaction: t }
       );

--- a/backend/src/services/redeemOps/constants.js
+++ b/backend/src/services/redeemOps/constants.js
@@ -5,22 +5,29 @@
  */
 import { REDEEM_OPS_SUB_ROLES, CAPABILITIES, ROLE_CAPABILITIES } from './permissions.js';
 
+/**
+ * Five working stages + one terminal outcome (2026-07-10 redesign, migration
+ * 051). Industry-standard shape (Pipedrive 5 / HubSpot 5-7): each stage is a
+ * verifiable commitment milestone. Everything the old 14-stage model encoded
+ * elsewhere now lives where it belongs:
+ *   ownership   → ownerUserId (claiming never touches the stage)
+ *   researching → a task
+ *   replied     → the activity log (inbound activities)
+ *   no response → staleFlag / atRiskFlag
+ *   snooze      → availability='follow_up_later' + snoozedUntil (wake sweep)
+ *   two dead stages → LOST + lostReason
+ * Historical stage events keep the old names; the UI still renders them.
+ */
 export const PIPELINE_STAGES = [
-  'UNCLAIMED',
-  'CLAIMED',
-  'RESEARCHING',
+  'NEW',
   'CONTACTED',
-  'REPLIED',
-  'MEETING_BOOKED',
-  'MEETING_COMPLETED',
-  'PROPOSAL_SENT',
-  'NEGOTIATING',
+  'MEETING',
+  'PROPOSAL',
   'PARTNERED',
-  'FOLLOW_UP_LATER',
-  'NO_RESPONSE',
-  'NOT_INTERESTED',
-  'DISQUALIFIED',
+  'LOST',
 ];
+
+export const LOST_REASONS = ['not_interested', 'disqualified', 'no_response', 'other'];
 
 export const PARTNER_AVAILABILITY = ['available', 'owned', 'follow_up_later', 'restricted', 'disqualified'];
 
@@ -30,20 +37,13 @@ export const PARTNER_AVAILABILITY = ['available', 'owned', 'follow_up_later', 'r
  * ops_admin may force any transition (audited with a required reason).
  */
 export const STAGE_TRANSITIONS = {
-  UNCLAIMED: ['CLAIMED'],
-  CLAIMED: ['RESEARCHING', 'CONTACTED', 'FOLLOW_UP_LATER', 'NO_RESPONSE', 'NOT_INTERESTED', 'DISQUALIFIED'],
-  RESEARCHING: ['CONTACTED', 'FOLLOW_UP_LATER', 'NOT_INTERESTED', 'DISQUALIFIED'],
-  CONTACTED: ['REPLIED', 'NO_RESPONSE', 'FOLLOW_UP_LATER', 'NOT_INTERESTED', 'DISQUALIFIED'],
-  REPLIED: ['MEETING_BOOKED', 'PROPOSAL_SENT', 'FOLLOW_UP_LATER', 'NOT_INTERESTED', 'DISQUALIFIED'],
-  MEETING_BOOKED: ['MEETING_COMPLETED', 'NO_RESPONSE', 'FOLLOW_UP_LATER', 'NOT_INTERESTED'],
-  MEETING_COMPLETED: ['PROPOSAL_SENT', 'NEGOTIATING', 'PARTNERED', 'FOLLOW_UP_LATER', 'NOT_INTERESTED'],
-  PROPOSAL_SENT: ['NEGOTIATING', 'PARTNERED', 'NO_RESPONSE', 'FOLLOW_UP_LATER', 'NOT_INTERESTED'],
-  NEGOTIATING: ['PARTNERED', 'PROPOSAL_SENT', 'FOLLOW_UP_LATER', 'NOT_INTERESTED'],
-  PARTNERED: ['FOLLOW_UP_LATER'],
-  FOLLOW_UP_LATER: ['CONTACTED', 'REPLIED', 'MEETING_BOOKED', 'PROPOSAL_SENT', 'NEGOTIATING', 'NOT_INTERESTED', 'DISQUALIFIED'],
-  NO_RESPONSE: ['CONTACTED', 'FOLLOW_UP_LATER', 'NOT_INTERESTED', 'DISQUALIFIED'],
-  NOT_INTERESTED: ['FOLLOW_UP_LATER', 'CONTACTED'],
-  DISQUALIFIED: [],
+  NEW: ['CONTACTED', 'LOST'],
+  CONTACTED: ['MEETING', 'PROPOSAL', 'LOST'],
+  MEETING: ['PROPOSAL', 'PARTNERED', 'LOST'],
+  PROPOSAL: ['PARTNERED', 'MEETING', 'LOST'],
+  PARTNERED: [],
+  // Revival: a lost business can re-enter the conversation.
+  LOST: ['CONTACTED'],
 };
 
 /** Activity types that count as real outreach (bump lastActivityAt / clear flags). */
@@ -99,6 +99,7 @@ export function publicConstants() {
   return {
     pipelineStages: PIPELINE_STAGES,
     stageTransitions: STAGE_TRANSITIONS,
+    lostReasons: LOST_REASONS,
     partnerAvailability: PARTNER_AVAILABILITY,
     activityTypes: ACTIVITY_TYPES,
     rewardTypes: REWARD_TYPES,

--- a/backend/src/services/redeemOps/partnerService.js
+++ b/backend/src/services/redeemOps/partnerService.js
@@ -13,7 +13,7 @@ import { hasCapability } from './permissions.js';
 import { deriveMatchingKeys, postalDistrictOf } from './normalizers.js';
 import {
   PIPELINE_STAGES, STAGE_TRANSITIONS, PARTNER_AVAILABILITY,
-  ACTIVITY_TYPES, MEANINGFUL_ACTIVITY_TYPES,
+  ACTIVITY_TYPES, MEANINGFUL_ACTIVITY_TYPES, LOST_REASONS,
 } from './constants.js';
 import { makeOnboardingService } from './onboardingService.js';
 
@@ -230,8 +230,11 @@ export function makePartnerService(overrides = {}) {
     }
   }
 
-  async function changeStage(id, toStage, user, reason = null, requestId = null) {
+  async function changeStage(id, toStage, user, reason = null, requestId = null, lostReason = null) {
     if (!PIPELINE_STAGES.includes(toStage)) throw new AppError('Unknown stage', 400);
+    if (toStage === 'LOST' && !LOST_REASONS.includes(lostReason)) {
+      throw new AppError('A reason is required when marking a business as Lost', 400);
+    }
     const partner = await getLivePartner(id);
     if (!canActOnRow(user, partner)) {
       throw new AppError('You can only move businesses you own', 403);
@@ -254,13 +257,19 @@ export function makePartnerService(overrides = {}) {
       await assertPartneredEntryRequirements(id, partner);
     }
 
+    // LOST leaves the working pool (reuses the 'disqualified' availability so
+    // pools/queue exclusions keep working); any other move wakes a snooze.
     const availability =
-      toStage === 'FOLLOW_UP_LATER' ? 'follow_up_later'
-      : toStage === 'DISQUALIFIED' ? 'disqualified'
+      toStage === 'LOST' ? 'disqualified'
       : partner.ownerUserId ? 'owned' : 'available';
 
     await d.sequelize.transaction(async (t) => {
-      await partner.update({ pipelineStage: toStage, availability, staleFlag: false }, { transaction: t });
+      await partner.update({
+        pipelineStage: toStage, availability, staleFlag: false, snoozedUntil: null,
+        // lostReason persists after LOST → re-engage so an undo/relapse keeps
+        // context; the UI only shows it while the stage is LOST.
+        ...(toStage === 'LOST' ? { lostReason } : {}),
+      }, { transaction: t });
       await d.PartnerStageEvent.create(
         { partnerOrganisationId: id, fromStage, toStage, actorUserId: user.id, reason },
         { transaction: t }
@@ -317,15 +326,14 @@ export function makePartnerService(overrides = {}) {
       await assertPartneredEntryRequirements(id, partner);
     }
     const availability =
-      toStage === 'FOLLOW_UP_LATER' ? 'follow_up_later'
-      : toStage === 'DISQUALIFIED' ? 'disqualified'
+      toStage === 'LOST' ? 'disqualified'
       : partner.ownerUserId ? 'owned' : 'available';
 
     await d.sequelize.transaction(async (t) => {
       // Conditional transition — a concurrent move loses cleanly instead of
       // silently overwriting it.
       const [moved] = await d.PartnerOrganisation.update(
-        { pipelineStage: toStage, availability },
+        { pipelineStage: toStage, availability, snoozedUntil: null },
         { where: { id, pipelineStage: fromStage }, transaction: t }
       );
       if (moved === 0) {
@@ -339,6 +347,58 @@ export function makePartnerService(overrides = {}) {
         actorUser: user, action: 'stage.undone', entityType: 'partner_organisation',
         entityId: id, before: { stage: fromStage }, after: { stage: toStage },
         reason: 'undo', requestId, transaction: t,
+      });
+    });
+    return partner;
+  }
+
+  /**
+   * Snooze — "not now, wake me later". A flag, not a stage: the deal keeps its
+   * pipeline position; availability='follow_up_later' hides it from the queue
+   * until the stale sweep wakes it at snoozedUntil.
+   */
+  async function snoozePartner(id, user, until, requestId = null) {
+    const partner = await getLivePartner(id);
+    if (!canActOnRow(user, partner)) {
+      throw new AppError('You can only snooze businesses you own', 403);
+    }
+    if (partner.pipelineStage === 'PARTNERED' || partner.pipelineStage === 'LOST') {
+      throw new AppError('Partnered and Lost businesses cannot be snoozed', 400);
+    }
+    const wake = new Date(until);
+    if (!until || Number.isNaN(wake.getTime()) || wake.getTime() <= Date.now()) {
+      throw new AppError('Pick a wake date in the future', 400);
+    }
+    if (wake.getTime() > Date.now() + 366 * 24 * 60 * 60 * 1000) {
+      throw new AppError('Snooze at most one year ahead', 400);
+    }
+    await d.sequelize.transaction(async (t) => {
+      await partner.update(
+        { availability: 'follow_up_later', snoozedUntil: wake, staleFlag: false },
+        { transaction: t }
+      );
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'partner.snoozed', entityType: 'partner_organisation',
+        entityId: id, after: { snoozedUntil: wake.toISOString() }, requestId, transaction: t,
+      });
+    });
+    return partner;
+  }
+
+  async function unsnoozePartner(id, user, requestId = null) {
+    const partner = await getLivePartner(id);
+    if (!canActOnRow(user, partner)) {
+      throw new AppError('You can only snooze businesses you own', 403);
+    }
+    if (partner.availability !== 'follow_up_later' && !partner.snoozedUntil) return partner;
+    await d.sequelize.transaction(async (t) => {
+      await partner.update(
+        { availability: partner.ownerUserId ? 'owned' : 'available', snoozedUntil: null },
+        { transaction: t }
+      );
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'partner.unsnoozed', entityType: 'partner_organisation',
+        entityId: id, requestId, transaction: t,
       });
     });
     return partner;
@@ -379,7 +439,7 @@ export function makePartnerService(overrides = {}) {
         where: {
           entityType: 'partner_organisation',
           entityId: String(id),
-          action: { [Op.in]: ['partner.created', 'partner.edited'] },
+          action: { [Op.in]: ['partner.created', 'partner.edited', 'partner.snoozed', 'partner.unsnoozed'] },
         },
         include: [{ model: d.User, as: 'actor', attributes: ['id', 'fullName'] }],
         order: [['createdAt', 'DESC']],
@@ -736,6 +796,7 @@ export function makePartnerService(overrides = {}) {
 
   return {
     listPartners, getPartner, createPartner, updatePartner, changeStage, undoStageChange,
+    snoozePartner, unsnoozePartner,
     importPartners, getTimeline, logActivity, editActivity, voidActivity,
     addContact, updateContact, archiveContact, addLocation, updateLocation,
     mergePartners, deletePartner, canActOnRow,

--- a/backend/src/services/redeemOps/queueService.js
+++ b/backend/src/services/redeemOps/queueService.js
@@ -93,7 +93,7 @@ export function makeQueueService(overrides = {}) {
     );
     const partners = await d.PartnerOrganisation.findAll({
       where: { mergedIntoId: null, archivedAt: null },
-      attributes: [...PARTNER_LITE, 'ownerUserId', 'atRiskFlag', 'staleFlag', 'createdAt'],
+      attributes: [...PARTNER_LITE, 'ownerUserId', 'atRiskFlag', 'staleFlag', 'createdAt', 'availability', 'snoozedUntil', 'lostReason'],
       include: [{ model: d.User, as: 'owner', attributes: ['id', 'fullName'] }],
       order: [['lastActivityAt', 'DESC']],
       limit: 500,

--- a/backend/src/services/redeemOps/staleSweep.js
+++ b/backend/src/services/redeemOps/staleSweep.js
@@ -7,9 +7,9 @@ import { logger } from '../../utils/logger.js';
  * views). Runs in-process on the bootstrap interval (house pattern: releaseSweep).
  *
  *  - atRiskFlag: claimed >48h ago, still no first outreach.
- *  - staleFlag:  no meaningful activity for >14 days — EXCEPT a FOLLOW_UP_LATER
- *    partner with a future open task (that's a deliberate parked state), and
- *    terminal stages (PARTNERED/NOT_INTERESTED/DISQUALIFIED).
+ *  - staleFlag:  no meaningful activity for >14 days — EXCEPT a snoozed
+ *    partner whose wake date or open task is still in the future, and
+ *    terminal stages (PARTNERED/LOST). Expired snoozes are woken here too.
  *
  * Both flags are cleared automatically when real activity is logged
  * (partnerService.logActivity).
@@ -32,17 +32,32 @@ export async function runRedeemOpsStaleSweep() {
         AND COALESCE(p."lastActivityAt", p."claimedAt") < NOW() - INTERVAL '14 days'
         AND p."staleFlag" = FALSE
         AND p."archivedAt" IS NULL AND p."mergedIntoId" IS NULL
-        AND p."pipelineStage" NOT IN ('PARTNERED', 'NOT_INTERESTED', 'DISQUALIFIED')
+        AND p."pipelineStage" NOT IN ('PARTNERED', 'LOST')
         AND NOT (
-          p."pipelineStage" = 'FOLLOW_UP_LATER'
-          AND EXISTS (
-            SELECT 1 FROM outreach_tasks t
-             WHERE t."partnerOrganisationId" = p.id
-               AND t.status IN ('open', 'in_progress')
-               AND t."dueAt" > NOW()
+          p.availability = 'follow_up_later'
+          AND (
+            (p."snoozedUntil" IS NOT NULL AND p."snoozedUntil" > NOW())
+            OR EXISTS (
+              SELECT 1 FROM outreach_tasks t
+               WHERE t."partnerOrganisationId" = p.id
+                 AND t.status IN ('open', 'in_progress')
+                 AND t."dueAt" > NOW()
+            )
           )
         )`
   );
+
+  // Wake expired snoozes: back to the working pool/queue.
+  const [, woken] = await sequelize.query(
+    `UPDATE partner_organisations
+        SET availability = CASE WHEN "ownerUserId" IS NULL THEN 'available' ELSE 'owned' END,
+            "snoozedUntil" = NULL, "updatedAt" = NOW()
+      WHERE availability = 'follow_up_later'
+        AND "snoozedUntil" IS NOT NULL AND "snoozedUntil" < NOW()
+        AND "archivedAt" IS NULL AND "mergedIntoId" IS NULL`
+  );
+  const wokenCount = woken?.rowCount ?? 0;
+  if (wokenCount > 0) logger.info('redeem_ops.stale_sweep.woken', { woken: wokenCount });
 
   const atRiskCount = atRisk?.rowCount ?? 0;
   const staleCount = stale?.rowCount ?? 0;

--- a/backend/test/redeemOpsPartners.test.js
+++ b/backend/test/redeemOpsPartners.test.js
@@ -9,7 +9,7 @@ process.env.REDEEM_OPS_ENABLED = 'true';
 import request from 'supertest';
 import { getApp, closeDb, createTestUser } from './helpers.js';
 import {
-  PartnerOrganisation, PartnerContact, OutreachActivity, sequelize,
+  PartnerOrganisation, PartnerContact, OutreachActivity,
 } from '../src/models/index.js';
 import { makeClaimService } from '../src/services/redeemOps/claimService.js';
 
@@ -113,7 +113,7 @@ describe('claiming (concurrency-safe)', () => {
     }
     const row = await PartnerOrganisation.findByPk(partnerId);
     expect(row.availability).toBe('owned');
-    expect(row.pipelineStage).toBe('CLAIMED');
+    expect(row.pipelineStage).toBe('NEW'); // ownership is not pipeline progress
   });
 
   test('claiming an owned business over HTTP → 409', async () => {
@@ -171,7 +171,7 @@ describe('stage machine + activities + row-level ownership', () => {
     const bad = await request(app)
       .patch(`/api/redeem-ops/partners/${partnerId}/stage`)
       .set(auth(execA.token))
-      .send({ toStage: 'PARTNERED' }); // CLAIMED → PARTNERED is not allowed
+      .send({ toStage: 'PARTNERED' }); // NEW → PARTNERED is not allowed
     expect(bad.status).toBe(400);
 
     const forcedNoReason = await request(app)
@@ -180,6 +180,18 @@ describe('stage machine + activities + row-level ownership', () => {
       .send({ toStage: 'PARTNERED' });
     expect(forcedNoReason.status).toBe(400);
 
+    // Entry requirement: no contact on record yet → 422 even for a forcing admin.
+    const noContact = await request(app)
+      .patch(`/api/redeem-ops/partners/${partnerId}/stage`)
+      .set(auth(admin.token))
+      .send({ toStage: 'PARTNERED', reason: 'signed at event' });
+    expect(noContact.status).toBe(422);
+
+    await request(app)
+      .post(`/api/redeem-ops/partners/${partnerId}/contacts`)
+      .set(auth(execA.token))
+      .send({ name: 'Deal Maker', mobile: '+6591239999' });
+
     const forced = await request(app)
       .patch(`/api/redeem-ops/partners/${partnerId}/stage`)
       .set(auth(admin.token))
@@ -187,11 +199,63 @@ describe('stage machine + activities + row-level ownership', () => {
     expect(forced.status).toBe(200);
   });
 
+  test('LOST requires a reason from the fixed list', async () => {
+    const res = await createPartner(admin.token, { tradingName: 'Lost Cause Cafe' });
+    const lostId = res.body.data.partner.id;
+    await request(app).post(`/api/redeem-ops/partners/${lostId}/claim`).set(auth(execA.token));
+
+    const noReason = await request(app)
+      .patch(`/api/redeem-ops/partners/${lostId}/stage`)
+      .set(auth(execA.token))
+      .send({ toStage: 'LOST' });
+    expect(noReason.status).toBe(400);
+
+    const ok = await request(app)
+      .patch(`/api/redeem-ops/partners/${lostId}/stage`)
+      .set(auth(execA.token))
+      .send({ toStage: 'LOST', lostReason: 'not_interested' });
+    expect(ok.status).toBe(200);
+    const row = await PartnerOrganisation.findByPk(lostId);
+    expect(row.pipelineStage).toBe('LOST');
+    expect(row.lostReason).toBe('not_interested');
+    expect(row.availability).toBe('disqualified'); // out of the working pool
+  });
+
+  test('snooze parks with a wake date; unsnooze restores availability', async () => {
+    const res = await createPartner(admin.token, { tradingName: 'Sleepy Spa' });
+    const snoozeId = res.body.data.partner.id;
+    await request(app).post(`/api/redeem-ops/partners/${snoozeId}/claim`).set(auth(execA.token));
+
+    const past = await request(app)
+      .post(`/api/redeem-ops/partners/${snoozeId}/snooze`)
+      .set(auth(execA.token))
+      .send({ until: new Date(Date.now() - 3600 * 1000).toISOString() });
+    expect(past.status).toBe(400);
+
+    const wake = new Date(Date.now() + 14 * 24 * 3600 * 1000).toISOString();
+    const ok = await request(app)
+      .post(`/api/redeem-ops/partners/${snoozeId}/snooze`)
+      .set(auth(execA.token))
+      .send({ until: wake });
+    expect(ok.status).toBe(200);
+    let row = await PartnerOrganisation.findByPk(snoozeId);
+    expect(row.availability).toBe('follow_up_later');
+    expect(row.snoozedUntil).not.toBeNull();
+
+    const un = await request(app)
+      .post(`/api/redeem-ops/partners/${snoozeId}/unsnooze`)
+      .set(auth(execA.token));
+    expect(un.status).toBe(200);
+    row = await PartnerOrganisation.findByPk(snoozeId);
+    expect(row.availability).toBe('owned');
+    expect(row.snoozedUntil).toBeNull();
+  });
+
   test('non-owner exec cannot move stage or log activity on someone else’s partner', async () => {
     const move = await request(app)
       .patch(`/api/redeem-ops/partners/${partnerId}/stage`)
       .set(auth(execB.token))
-      .send({ toStage: 'FOLLOW_UP_LATER' });
+      .send({ toStage: 'CONTACTED' });
     expect(move.status).toBe(403);
 
     const log = await request(app)

--- a/backend/test/redeemOpsWork.test.js
+++ b/backend/test/redeemOpsWork.test.js
@@ -5,7 +5,7 @@ process.env.REDEEM_OPS_ENABLED = 'true';
 
 import request from 'supertest';
 import { getApp, closeDb, createTestUser } from './helpers.js';
-import { PartnerOrganisation, OutreachTask, ProspectingPoolMember, sequelize } from '../src/models/index.js';
+import { PartnerOrganisation, OutreachTask, ProspectingPoolMember } from '../src/models/index.js';
 import { makePoolService } from '../src/services/redeemOps/poolService.js';
 import { runRedeemOpsStaleSweep } from '../src/services/redeemOps/staleSweep.js';
 import { sgtDayWindow } from '../src/services/redeemOps/taskService.js';
@@ -174,7 +174,7 @@ describe('pools + claim-next concurrency', () => {
 });
 
 describe('stale sweep', () => {
-  test('flags at-risk + stale, but spares FOLLOW_UP_LATER with a future task', async () => {
+  test('flags at-risk + stale, but spares snoozed/parked partners', async () => {
     const old = new Date(Date.now() - 20 * 24 * 3600 * 1000);
 
     const atRisk = await makePartner('AtRisk Barber');
@@ -191,7 +191,7 @@ describe('stale sweep', () => {
 
     const parked = await makePartner('Parked Gym');
     await PartnerOrganisation.update(
-      { ownerUserId: execA.user.id, availability: 'follow_up_later', claimedAt: old, firstOutreachAt: old, lastActivityAt: old, pipelineStage: 'FOLLOW_UP_LATER' },
+      { ownerUserId: execA.user.id, availability: 'follow_up_later', claimedAt: old, firstOutreachAt: old, lastActivityAt: old, pipelineStage: 'CONTACTED' },
       { where: { id: parked.id } }
     );
     await OutreachTask.create({
@@ -200,11 +200,29 @@ describe('stale sweep', () => {
       dueAt: new Date(Date.now() + 30 * 24 * 3600 * 1000),
     });
 
+    const snoozed = await makePartner('Snoozed Florist');
+    await PartnerOrganisation.update(
+      { ownerUserId: execA.user.id, availability: 'follow_up_later', claimedAt: old, firstOutreachAt: old, lastActivityAt: old, pipelineStage: 'CONTACTED', snoozedUntil: new Date(Date.now() + 10 * 24 * 3600 * 1000) },
+      { where: { id: snoozed.id } }
+    );
+
+    const expired = await makePartner('Overslept Tailor');
+    await PartnerOrganisation.update(
+      { ownerUserId: execA.user.id, availability: 'follow_up_later', claimedAt: old, snoozedUntil: new Date(Date.now() - 24 * 3600 * 1000) },
+      { where: { id: expired.id } }
+    );
+
     await runRedeemOpsStaleSweep();
 
     expect((await PartnerOrganisation.findByPk(atRisk.id)).atRiskFlag).toBe(true);
     expect((await PartnerOrganisation.findByPk(stale.id)).staleFlag).toBe(true);
     expect((await PartnerOrganisation.findByPk(parked.id)).staleFlag).toBe(false);
+    expect((await PartnerOrganisation.findByPk(snoozed.id)).staleFlag).toBe(false);
+
+    // Expired snooze wakes back into the owner's working list.
+    const awake = await PartnerOrganisation.findByPk(expired.id);
+    expect(awake.availability).toBe('owned');
+    expect(awake.snoozedUntil).toBeNull();
   });
 });
 

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -84,8 +84,16 @@ export const redeemOpsApi = {
     const res = await apiClient.post(`/redeem-ops/partners/${id}/assign`, { toUserId, reason });
     return res.data;
   },
-  async changeStage(id, toStage, reason) {
-    const res = await apiClient.patch(`/redeem-ops/partners/${id}/stage`, { toStage, reason });
+  async changeStage(id, toStage, reason, lostReason) {
+    const res = await apiClient.patch(`/redeem-ops/partners/${id}/stage`, { toStage, reason, lostReason });
+    return res.data;
+  },
+  async snoozePartner(id, until) {
+    const res = await apiClient.post(`/redeem-ops/partners/${id}/snooze`, { until });
+    return res.data;
+  },
+  async unsnoozePartner(id) {
+    const res = await apiClient.post(`/redeem-ops/partners/${id}/unsnooze`);
     return res.data;
   },
   async undoStage(id) {

--- a/src/components/redeemops/ui.jsx
+++ b/src/components/redeemops/ui.jsx
@@ -34,6 +34,12 @@ export function prettyEnum(value) {
 
 /* 14 pipeline stages → six pastel families (stage-tags card). */
 const STAGE_TAG = {
+  // Five-stage pipeline (current)
+  NEW: 'ro-tag--outline',
+  MEETING: 'ro-tag--blue',
+  PROPOSAL: 'ro-tag--purple',
+  LOST: 'ro-tag--red',
+  // Legacy stage names — keep so historical timeline events still render
   UNCLAIMED: 'ro-tag--outline',
   CLAIMED: 'ro-tag--gray',
   RESEARCHING: 'ro-tag--gray',

--- a/src/pages/redeemops/PartnerDetail.jsx
+++ b/src/pages/redeemops/PartnerDetail.jsx
@@ -7,7 +7,7 @@ import { useAuthStore } from '@/stores/authStore';
 import { hasCapability } from '@/lib/redeemOpsPermissions';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
-  Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
 } from '@/components/ui/dialog';
 import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
@@ -141,7 +141,18 @@ function TimelineEntry({ entry }) {
     }
   } else if (entry.kind === 'audit') {
     const e = entry.data;
-    if (e.action === 'partner.created') {
+    if (e.action === 'partner.snoozed') {
+      title = 'Snoozed';
+      body = e.after?.snoozedUntil ? (
+        <p className="text-[13.5px] m-0 mt-0.5" style={{ color: 'var(--ro-text-2)' }}>
+          Until {new Date(e.after.snoozedUntil).toLocaleDateString('en-SG', { day: 'numeric', month: 'short', year: 'numeric' })}
+        </p>
+      ) : null;
+      meta = `${e.actor?.fullName || 'System'} · ${at}`;
+    } else if (e.action === 'partner.unsnoozed') {
+      title = 'Woken from snooze';
+      meta = `${e.actor?.fullName || 'System'} · ${at}`;
+    } else if (e.action === 'partner.created') {
       title = 'Business added';
       body = e.after?.name ? (
         <p className="text-[13.5px] m-0 mt-0.5" style={{ color: 'var(--ro-text-2)' }}>
@@ -289,10 +300,20 @@ export default function PartnerDetail() {
   const claimMutation = useSimpleMutation(() => redeemOpsApi.claimPartner(id), 'Business claimed — it’s yours');
   const releaseMutation = useSimpleMutation(() => redeemOpsApi.releasePartner(id), 'Released back to the pool');
   const stageMutation = useMutation({
-    mutationFn: ({ toStage, reason }) => redeemOpsApi.changeStage(id, toStage, reason),
-    onSuccess: () => { toast.success('Stage updated'); invalidate(); },
+    mutationFn: ({ toStage, reason, lostReason }) => redeemOpsApi.changeStage(id, toStage, reason, lostReason),
+    onSuccess: () => { toast.success('Stage updated'); setLostOpen(false); invalidate(); },
     onError: (err) => toast.error('Stage change rejected', { description: err.message }),
   });
+  const [lostOpen, setLostOpen] = useState(false);
+  const [lostReason, setLostReason] = useState(null);
+  const [snoozeOpen, setSnoozeOpen] = useState(false);
+  const [snoozeDays, setSnoozeDays] = useState(30);
+  const snoozeMutation = useMutation({
+    mutationFn: () => redeemOpsApi.snoozePartner(id, new Date(Date.now() + snoozeDays * 24 * 3600 * 1000).toISOString()),
+    onSuccess: () => { toast.success(`Snoozed for ${snoozeDays} days`); setSnoozeOpen(false); invalidate(); },
+    onError: (err) => toast.error('Could not snooze', { description: err.message }),
+  });
+  const unsnoozeMutation = useSimpleMutation(() => redeemOpsApi.unsnoozePartner(id), 'Back on the active list');
   const assignMutation = useMutation({
     mutationFn: ({ toUserId }) => redeemOpsApi.assignPartner(id, toUserId),
     onSuccess: () => { toast.success('Reassigned'); invalidate(); },
@@ -484,6 +505,16 @@ export default function PartnerDetail() {
                 <span className="inline-flex items-center gap-1"><Instagram className="w-3.5 h-3.5" aria-hidden="true" />@{partner.instagramHandle}</span>
               )}
               <RoStageTag stage={partner.pipelineStage} />
+              {partner.pipelineStage === 'LOST' && partner.lostReason && (
+                <span style={{ color: 'var(--ro-tag-red-fg)' }} className="font-semibold">
+                  {prettyEnum(partner.lostReason)}
+                </span>
+              )}
+              {partner.availability === 'follow_up_later' && partner.snoozedUntil && (
+                <span className="font-semibold">
+                  Snoozed until {new Date(partner.snoozedUntil).toLocaleDateString('en-SG', { day: 'numeric', month: 'short' })}
+                </span>
+              )}
             </div>
           </div>
         </div>
@@ -500,7 +531,13 @@ export default function PartnerDetail() {
             </Select>
           )}
           {(isOwner || canReassign) && allowedNext.length > 0 && (
-            <Select onValueChange={(toStage) => stageMutation.mutate({ toStage })}>
+            <Select
+              value=""
+              onValueChange={(toStage) => {
+                if (toStage === 'LOST') { setLostReason(null); setLostOpen(true); return; }
+                stageMutation.mutate({ toStage });
+              }}
+            >
               <SelectTrigger className="w-44 h-10"><SelectValue placeholder="Move stage…" /></SelectTrigger>
               <SelectContent>
                 {allowedNext.map((s) => (
@@ -508,6 +545,13 @@ export default function PartnerDetail() {
                 ))}
               </SelectContent>
             </Select>
+          )}
+          {(isOwner || canReassign) && !['PARTNERED', 'LOST'].includes(partner.pipelineStage) && (
+            partner.availability === 'follow_up_later' ? (
+              <Button variant="outline" onClick={() => unsnoozeMutation.mutate()}>Wake up</Button>
+            ) : (
+              <Button variant="outline" onClick={() => { setSnoozeDays(30); setSnoozeOpen(true); }}>Snooze</Button>
+            )
           )}
           {isOwner && (
             <Button variant="outline" onClick={() => releaseMutation.mutate()}>Release</Button>
@@ -947,6 +991,76 @@ export default function PartnerDetail() {
               disabled={!activity.summary.trim() || activityMutation.isPending}
             >
               {activityMutation.isPending ? 'Saving…' : 'Log it'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={lostOpen} onOpenChange={setLostOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Mark {name} as Lost</DialogTitle>
+            <DialogDescription>Why didn’t this one work out? Kept on record — you can re-engage later.</DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-1.5">
+            {(constants.data?.lostReasons || []).map((r) => (
+              <button
+                key={r}
+                type="button"
+                onClick={() => setLostReason(r)}
+                className="h-[42px] px-4 rounded-xl text-[13px] font-semibold border text-left cursor-pointer"
+                style={r === lostReason
+                  ? { background: 'var(--ro-bunker)', borderColor: 'var(--ro-bunker)', color: '#fff' }
+                  : { background: '#fff', borderColor: 'var(--ro-border-strong)', color: 'var(--ro-bunker)' }}
+              >
+                {prettyEnum(r)}
+              </button>
+            ))}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setLostOpen(false)}>Cancel</Button>
+            <Button
+              variant="destructive"
+              disabled={!lostReason || stageMutation.isPending}
+              onClick={() => stageMutation.mutate({ toStage: 'LOST', lostReason })}
+            >
+              {stageMutation.isPending ? 'Saving…' : 'Mark as Lost'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={snoozeOpen} onOpenChange={setSnoozeOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Snooze {name}</DialogTitle>
+            <DialogDescription>
+              Hides it from your queue until the wake date — it keeps its pipeline stage
+              and comes back automatically.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-1.5">
+            {[7, 14, 30, 90].map((days) => (
+              <button
+                key={days}
+                type="button"
+                onClick={() => setSnoozeDays(days)}
+                className="h-[42px] px-4 rounded-xl text-[13px] font-semibold border text-left cursor-pointer"
+                style={days === snoozeDays
+                  ? { background: 'var(--ro-bunker)', borderColor: 'var(--ro-bunker)', color: '#fff' }
+                  : { background: '#fff', borderColor: 'var(--ro-border-strong)', color: 'var(--ro-bunker)' }}
+              >
+                {days === 7 ? '1 week' : days === 14 ? '2 weeks' : days === 30 ? '1 month' : '3 months'}
+                <span className="font-normal" style={{ color: days === snoozeDays ? 'rgba(255,255,255,0.7)' : 'var(--ro-text-3)' }}>
+                  {' '}— wakes {new Date(Date.now() + days * 24 * 3600 * 1000).toLocaleDateString('en-SG', { day: 'numeric', month: 'short' })}
+                </span>
+              </button>
+            ))}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setSnoozeOpen(false)}>Cancel</Button>
+            <Button disabled={snoozeMutation.isPending} onClick={() => snoozeMutation.mutate()}>
+              {snoozeMutation.isPending ? 'Saving…' : 'Snooze'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/pages/redeemops/TeamPipeline.jsx
+++ b/src/pages/redeemops/TeamPipeline.jsx
@@ -13,38 +13,29 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import AlertTriangle from 'lucide-react/icons/alert-triangle';
-import Minus from 'lucide-react/icons/minus';
+import Moon from 'lucide-react/icons/moon';
 import { RoAvatar, prettyEnum } from '@/components/redeemops/ui';
 
 const PIPELINE_KEY = ['redeem-ops', 'team-pipeline'];
 
-/* Stage → lane dot colour (same six families as RoStageTag). */
+/* The five working columns. LOST is not a column — it's the drop bar below. */
+const STAGES = ['NEW', 'CONTACTED', 'MEETING', 'PROPOSAL', 'PARTNERED'];
+
 const STAGE_DOT = {
-  CLAIMED: 'var(--ro-tag-gray-fg)',
-  RESEARCHING: 'var(--ro-tag-gray-fg)',
+  NEW: 'var(--ro-tag-gray-fg)',
   CONTACTED: 'var(--ro-tag-yellow-fg)',
-  REPLIED: 'var(--ro-tag-blue-fg)',
-  MEETING_BOOKED: 'var(--ro-tag-blue-fg)',
-  MEETING_COMPLETED: 'var(--ro-tag-blue-fg)',
-  PROPOSAL_SENT: 'var(--ro-tag-purple-fg)',
-  NEGOTIATING: 'var(--ro-tag-purple-fg)',
+  MEETING: 'var(--ro-tag-blue-fg)',
+  PROPOSAL: 'var(--ro-tag-purple-fg)',
   PARTNERED: 'var(--ro-tag-green-fg)',
-  FOLLOW_UP_LATER: 'var(--ro-tag-yellow-fg)',
-  NO_RESPONSE: 'var(--ro-tag-yellow-fg)',
-  NOT_INTERESTED: 'var(--ro-tag-gray-fg)',
-  DISQUALIFIED: 'var(--ro-tag-red-fg)',
+  LOST: 'var(--ro-tag-red-fg)',
 };
 
-/* Phase scoping — each chip fits its stages on one screen. */
-const PHASES = {
-  active: {
-    label: 'Active',
-    stages: ['CLAIMED', 'RESEARCHING', 'CONTACTED', 'REPLIED', 'MEETING_BOOKED', 'MEETING_COMPLETED', 'PROPOSAL_SENT', 'NEGOTIATING', 'PARTNERED'],
-  },
-  prospecting: { label: 'Prospecting', stages: ['CLAIMED', 'RESEARCHING'] },
-  conversation: { label: 'Conversation', stages: ['CONTACTED', 'REPLIED', 'NO_RESPONSE', 'FOLLOW_UP_LATER'] },
-  momentum: { label: 'Momentum', stages: ['MEETING_BOOKED', 'MEETING_COMPLETED', 'PROPOSAL_SENT', 'NEGOTIATING'] },
-  closed: { label: 'Closed', stages: ['PARTNERED', 'NOT_INTERESTED', 'DISQUALIFIED'] },
+const STAGE_HINT = {
+  NEW: 'Not yet reached out',
+  CONTACTED: 'First touch made',
+  MEETING: 'Meeting booked or done',
+  PROPOSAL: 'Terms on the table',
+  PARTNERED: 'Signed on',
 };
 
 function partnerName(p) {
@@ -71,18 +62,24 @@ function canDragCard(user, p) {
 
 function CardInner({ p, dragging }) {
   const t = timeInStage(p);
+  const snoozed = p.availability === 'follow_up_later';
   return (
     <div
       className={`bg-white border border-border rounded-xl px-3 py-2.5 select-none ${dragging ? 'shadow-2xl rotate-2 cursor-grabbing' : ''}`}
     >
       <p className="text-[13.5px] font-semibold m-0 leading-tight flex items-center gap-1.5">
         <span className="truncate">{partnerName(p)}</span>
-        {(p.atRiskFlag || p.staleFlag) && (
+        {snoozed && (
+          <Moon className="w-3 h-3 shrink-0" style={{ color: 'var(--ro-text-3)' }} aria-label="Snoozed" />
+        )}
+        {(p.atRiskFlag || p.staleFlag) && !snoozed && (
           <AlertTriangle className="w-3 h-3 shrink-0" style={{ color: 'var(--ro-tag-yellow-fg)' }} aria-hidden="true" />
         )}
       </p>
-      {p.category && (
-        <p className="text-[11.5px] m-0 mt-0.5 truncate" style={{ color: 'var(--ro-text-2)' }}>{p.category}</p>
+      {(p.category || p.lostReason) && (
+        <p className="text-[11.5px] m-0 mt-0.5 truncate" style={{ color: 'var(--ro-text-2)' }}>
+          {p.pipelineStage === 'LOST' && p.lostReason ? `Lost — ${prettyEnum(p.lostReason)}` : p.category}
+        </p>
       )}
       <div className="flex items-center gap-1.5 mt-2">
         {p.owner?.fullName ? (
@@ -123,34 +120,7 @@ function BoardCard({ p, draggable, onOpen }) {
   );
 }
 
-/* Horizontal, readable stand-in for an empty stage: droppable, click to open. */
-function DockPill({ stage, activeCard, legalTargets, onExpand }) {
-  const { setNodeRef, isOver } = useDroppable({ id: stage });
-  const isLegal = !!activeCard && legalTargets.includes(stage);
-  const dimmed = !!activeCard && !isLegal;
-  return (
-    <button
-      ref={setNodeRef}
-      type="button"
-      onClick={onExpand}
-      className="inline-flex items-center gap-2 h-[30px] px-3.5 rounded-full text-[12px] font-semibold cursor-pointer border transition-opacity"
-      style={{
-        background: isOver && isLegal ? '#EFF6FF' : 'var(--ro-subtle)',
-        borderColor: 'var(--ro-border)',
-        color: isLegal ? 'var(--ro-bunker)' : 'var(--ro-text-2)',
-        opacity: dimmed ? 0.45 : 1,
-        outline: isLegal ? '2px dashed var(--ro-azure)' : 'none',
-        outlineOffset: '-2px',
-      }}
-      title={`${prettyEnum(stage)} — open as a lane, or drop a card here`}
-    >
-      <span className="w-[7px] h-[7px] rounded-full shrink-0" style={{ background: STAGE_DOT[stage] }} />
-      {prettyEnum(stage)}
-    </button>
-  );
-}
-
-function Lane({ stage, items, activeCard, legalTargets, onCollapse, children }) {
+function Lane({ stage, items, activeCard, legalTargets, children }) {
   const { setNodeRef, isOver } = useDroppable({ id: stage });
   const isSource = activeCard?.pipelineStage === stage;
   const isLegal = !!activeCard && legalTargets.includes(stage);
@@ -159,7 +129,7 @@ function Lane({ stage, items, activeCard, legalTargets, onCollapse, children }) 
   return (
     <div
       ref={setNodeRef}
-      className="w-[250px] flex-none rounded-2xl flex flex-col min-h-0 transition-opacity"
+      className="flex-1 min-w-[210px] rounded-2xl flex flex-col min-h-0 transition-opacity"
       style={{
         background: isOver && isLegal ? '#EFF6FF' : 'var(--ro-subtle)',
         opacity: dimmed ? 0.45 : 1,
@@ -167,28 +137,38 @@ function Lane({ stage, items, activeCard, legalTargets, onCollapse, children }) 
         outlineOffset: '-2px',
       }}
     >
-      <div className="flex items-center gap-2 px-3.5 pt-3 pb-2">
+      <div className="flex items-center gap-2 px-3.5 pt-3 pb-2" title={STAGE_HINT[stage]}>
         <span className="w-2 h-2 rounded-full shrink-0" style={{ background: STAGE_DOT[stage] }} />
         <span className="text-[12.5px] font-bold">{prettyEnum(stage)}</span>
         <span className="ml-auto text-[11px] font-bold bg-white border border-border rounded-full px-2 py-px" style={{ color: 'var(--ro-text-2)' }}>
           {items.length}
         </span>
-        {items.length === 0 && onCollapse && (
-          <button
-            type="button"
-            onClick={onCollapse}
-            className="w-5 h-5 rounded-full bg-white border border-border grid place-items-center cursor-pointer p-0"
-            style={{ color: 'var(--ro-text-2)' }}
-            aria-label={`Collapse ${prettyEnum(stage)}`}
-            title="Collapse"
-          >
-            <Minus className="w-3 h-3" />
-          </button>
-        )}
       </div>
-      <div className="px-2 pb-2.5 flex flex-col gap-2 overflow-y-auto min-h-[56px]">
+      <div className="px-2 pb-2.5 flex flex-col gap-2 overflow-y-auto min-h-[56px] flex-1">
         {children}
       </div>
+    </div>
+  );
+}
+
+/* Red strip that appears while dragging — the only way to mark a deal Lost. */
+function LostDropBar({ activeCard, legalTargets }) {
+  const { setNodeRef, isOver } = useDroppable({ id: 'LOST' });
+  const isLegal = !!activeCard && legalTargets.includes('LOST');
+  if (!activeCard) return null;
+  return (
+    <div
+      ref={setNodeRef}
+      className="mt-2.5 rounded-2xl grid place-items-center h-[52px] text-[12.5px] font-bold transition-colors"
+      style={{
+        background: isOver && isLegal ? '#FEF2F2' : 'var(--ro-subtle)',
+        color: isLegal ? 'var(--ro-tag-red-fg)' : 'var(--ro-text-3)',
+        outline: `2px dashed ${isLegal ? 'var(--ro-tag-red-fg)' : 'var(--ro-border-strong)'}`,
+        outlineOffset: '-2px',
+        opacity: isLegal ? 1 : 0.45,
+      }}
+    >
+      {isLegal ? 'Mark as Lost — drop here (asks for a reason)' : 'Partnered businesses can’t be marked Lost'}
     </div>
   );
 }
@@ -197,10 +177,11 @@ export default function TeamPipeline() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const user = useAuthStore((s) => s.user);
-  const [phase, setPhase] = useState('active');
-  const [expanded, setExpanded] = useState({});
   const [activeCard, setActiveCard] = useState(null);
-  const [confirmMove, setConfirmMove] = useState(null); // { card, toStage } — Partnered is a milestone, confirm it
+  const [confirmMove, setConfirmMove] = useState(null); // { card } — Partnered is a milestone, confirm it
+  const [lostMove, setLostMove] = useState(null); // { card } — Lost requires a reason
+  const [lostReason, setLostReason] = useState(null);
+  const [showLost, setShowLost] = useState(false);
 
   const constants = useQuery({
     queryKey: ['redeem-ops', 'constants'],
@@ -222,7 +203,7 @@ export default function TeamPipeline() {
   });
 
   const stageMutation = useMutation({
-    mutationFn: ({ partnerId, toStage }) => redeemOpsApi.changeStage(partnerId, toStage),
+    mutationFn: ({ partnerId, toStage, lostReason: lr }) => redeemOpsApi.changeStage(partnerId, toStage, undefined, lr),
     onError: (err) => {
       toast.error('Move rejected', { description: err.message });
       queryClient.invalidateQueries({ queryKey: PIPELINE_KEY });
@@ -241,6 +222,7 @@ export default function TeamPipeline() {
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
 
   const transitions = constants.data?.stageTransitions || {};
+  const lostReasons = constants.data?.lostReasons || [];
   const partners = boardQuery.data?.partners || [];
 
   const byStage = useMemo(() => {
@@ -251,16 +233,18 @@ export default function TeamPipeline() {
     return map;
   }, [partners]);
 
-  const stages = PHASES[phase].stages;
+  const lostItems = byStage.LOST || [];
   const legalTargets = activeCard ? (transitions[activeCard.pipelineStage] || []) : [];
 
-  const executeMove = (card, toStage) => {
+  const executeMove = (card, toStage, lr = null) => {
     // Optimistic: move the card locally, server confirms (and audits) the change.
     queryClient.setQueryData(PIPELINE_KEY, (prev) => prev && ({
       ...prev,
-      partners: prev.partners.map((p) => (p.id === card.id ? { ...p, pipelineStage: toStage, stageSince: new Date().toISOString() } : p)),
+      partners: prev.partners.map((p) => (p.id === card.id
+        ? { ...p, pipelineStage: toStage, lostReason: toStage === 'LOST' ? lr : p.lostReason, stageSince: new Date().toISOString() }
+        : p)),
     }));
-    stageMutation.mutate({ partnerId: card.id, toStage, name: partnerName(card) });
+    stageMutation.mutate({ partnerId: card.id, toStage, lostReason: lr, name: partnerName(card) });
   };
 
   const handleDragEnd = ({ over }) => {
@@ -276,7 +260,12 @@ export default function TeamPipeline() {
     if (toStage === 'PARTNERED') {
       // Milestone move: seeds onboarding, unlocks rewards, and the server
       // requires a contact + phone/email on file — confirm before committing.
-      setConfirmMove({ card, toStage });
+      setConfirmMove({ card });
+      return;
+    }
+    if (toStage === 'LOST') {
+      setLostReason(null);
+      setLostMove({ card });
       return;
     }
     executeMove(card, toStage);
@@ -284,28 +273,21 @@ export default function TeamPipeline() {
 
   return (
     <div className="flex flex-col h-full min-h-0 p-6 md:p-8 md:pb-4 gap-0">
-      <div>
-        <h1 className="ro-title">Team pipeline</h1>
-        <p className="ro-sub">Drag a business to move its stage — only legal next steps light up. Click to open.</p>
-      </div>
-
-      <div className="flex flex-wrap items-center gap-2 mt-4 mb-4">
-        {Object.entries(PHASES).map(([key, ph]) => (
-          <button
-            key={key}
-            type="button"
-            onClick={() => setPhase(key)}
-            className="h-[34px] px-4 rounded-full text-[12.5px] font-semibold border cursor-pointer"
-            style={key === phase
-              ? { background: 'var(--ro-bunker)', borderColor: 'var(--ro-bunker)', color: '#fff' }
-              : { background: '#fff', borderColor: 'var(--ro-border-strong)', color: 'var(--ro-bunker)' }}
-          >
-            {ph.label}
-          </button>
-        ))}
-        <span className="ml-auto text-[12px] hidden md:inline" style={{ color: 'var(--ro-text-3)' }}>
-          Empty stages are collapsed — click to expand
-        </span>
+      <div className="flex flex-wrap items-end gap-3">
+        <div>
+          <h1 className="ro-title">Team pipeline</h1>
+          <p className="ro-sub">Drag a business forward — or onto the red bar to mark it Lost. Click to open.</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowLost((v) => !v)}
+          className="ml-auto h-[34px] px-4 rounded-full text-[12.5px] font-semibold border cursor-pointer"
+          style={showLost
+            ? { background: 'var(--ro-bunker)', borderColor: 'var(--ro-bunker)', color: '#fff' }
+            : { background: '#fff', borderColor: 'var(--ro-border-strong)', color: 'var(--ro-bunker)' }}
+        >
+          Lost ({lostItems.length})
+        </button>
       </div>
 
       <DndContext
@@ -314,32 +296,11 @@ export default function TeamPipeline() {
         onDragEnd={handleDragEnd}
         onDragCancel={() => setActiveCard(null)}
       >
-        {stages.some((st) => (byStage[st] || []).length === 0 && !expanded[st]) && (
-          <div className="flex flex-wrap items-center gap-2 mb-3">
-            <span className="text-[11.5px] font-bold" style={{ color: 'var(--ro-text-3)' }}>Empty stages</span>
-            {stages.filter((st) => (byStage[st] || []).length === 0 && !expanded[st]).map((st) => (
-              <DockPill
-                key={st}
-                stage={st}
-                activeCard={activeCard}
-                legalTargets={legalTargets}
-                onExpand={() => setExpanded((e) => ({ ...e, [st]: true }))}
-              />
-            ))}
-          </div>
-        )}
-        <div className="flex gap-2.5 overflow-x-auto pb-4 items-stretch flex-1 min-h-0">
-          {stages.filter((st) => (byStage[st] || []).length > 0 || expanded[st]).map((stage) => {
+        <div className="flex gap-2.5 overflow-x-auto pb-1 items-stretch flex-1 min-h-0 mt-4">
+          {STAGES.map((stage) => {
             const items = byStage[stage] || [];
             return (
-              <Lane
-                key={stage}
-                stage={stage}
-                items={items}
-                activeCard={activeCard}
-                legalTargets={legalTargets}
-                onCollapse={items.length === 0 ? () => setExpanded((e) => ({ ...e, [stage]: false })) : null}
-              >
+              <Lane key={stage} stage={stage} items={items} activeCard={activeCard} legalTargets={legalTargets}>
                 {items.slice(0, 30).map((p) => (
                   <BoardCard
                     key={p.id}
@@ -354,12 +315,32 @@ export default function TeamPipeline() {
                   </p>
                 )}
                 {items.length === 0 && (
-                  <p className="text-[11.5px] m-0 px-1.5 py-2" style={{ color: 'var(--ro-text-3)' }}>Empty</p>
+                  <p className="text-[11.5px] m-0 px-1.5 py-2" style={{ color: 'var(--ro-text-3)' }}>
+                    {STAGE_HINT[stage]}
+                  </p>
                 )}
               </Lane>
             );
           })}
+          {showLost && (
+            <Lane stage="LOST" items={lostItems} activeCard={activeCard} legalTargets={legalTargets}>
+              {lostItems.slice(0, 30).map((p) => (
+                <BoardCard
+                  key={p.id}
+                  p={p}
+                  draggable={canDragCard(user, p)}
+                  onOpen={(pid) => navigate(`/redeem-ops/partners/${pid}`)}
+                />
+              ))}
+              {lostItems.length === 0 && (
+                <p className="text-[11.5px] m-0 px-1.5 py-2" style={{ color: 'var(--ro-text-3)' }}>
+                  Nothing marked Lost — drag back to Contacted to re-engage.
+                </p>
+              )}
+            </Lane>
+          )}
         </div>
+        <LostDropBar activeCard={activeCard} legalTargets={legalTargets} />
         <DragOverlay dropAnimation={null}>
           {activeCard ? <div className="w-[234px]"><CardInner p={activeCard} dragging /></div> : null}
         </DragOverlay>
@@ -381,10 +362,48 @@ export default function TeamPipeline() {
               onClick={() => {
                 const m = confirmMove;
                 setConfirmMove(null);
-                if (m) executeMove(m.card, m.toStage);
+                if (m) executeMove(m.card, 'PARTNERED');
               }}
             >
               Mark as Partnered
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={!!lostMove} onOpenChange={(open) => { if (!open) setLostMove(null); }}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Mark {lostMove ? partnerName(lostMove.card) : ''} as Lost</DialogTitle>
+            <DialogDescription>Why didn’t this one work out? Kept on record — you can re-engage later.</DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-1.5">
+            {lostReasons.map((r) => (
+              <button
+                key={r}
+                type="button"
+                onClick={() => setLostReason(r)}
+                className="h-[42px] px-4 rounded-xl text-[13px] font-semibold border text-left cursor-pointer"
+                style={r === lostReason
+                  ? { background: 'var(--ro-bunker)', borderColor: 'var(--ro-bunker)', color: '#fff' }
+                  : { background: '#fff', borderColor: 'var(--ro-border-strong)', color: 'var(--ro-bunker)' }}
+              >
+                {prettyEnum(r)}
+              </button>
+            ))}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setLostMove(null)}>Cancel</Button>
+            <Button
+              variant="destructive"
+              disabled={!lostReason}
+              onClick={() => {
+                const m = lostMove;
+                setLostMove(null);
+                if (m) executeMove(m.card, 'LOST', lostReason);
+              }}
+            >
+              Mark as Lost
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## What

Replaces the 14-stage partner pipeline with the industry-standard five-stage model, per the kanban research: **New → Contacted → Meeting → Proposal → Partnered**, plus **Lost** as a terminal outcome (never a column) and **snooze** as a flag with a wake date.

Where each removed stage went:
| Old | Now |
|---|---|
| UNCLAIMED / CLAIMED / RESEARCHING | `NEW` — ownership lives on `ownerUserId` only; claiming no longer moves the stage |
| REPLIED | activity log (inbound activities) |
| NO_RESPONSE | `staleFlag` risk signal |
| MEETING_BOOKED / MEETING_COMPLETED | `MEETING` |
| PROPOSAL_SENT / NEGOTIATING | `PROPOSAL` |
| NOT_INTERESTED / DISQUALIFIED | `LOST` + required reason (`not_interested`, `disqualified`, `no_response`, `other`) |
| FOLLOW_UP_LATER | snooze: `availability='follow_up_later'` + `snoozedUntil`, woken by the stale sweep |

## How

- **Migration 051** maps every live row onto the new model (legacy `FOLLOW_UP_LATER` rows get a 30-day wake so nothing sleeps forever) and adds `lostReason` / `snoozedUntil`. Historical `partner_stage_events` keep old names; `RoStageTag` retains all 14 legacy labels so timelines render unchanged.
- **Board**: five fixed lanes, no phase chips/dock. Dragging reveals a red **Mark as Lost** drop bar → reason dialog. A **Lost (n)** toggle shows the lost lane; `LOST → CONTACTED` drag re-engages. Partnered confirm + 5-min undo kept.
- **Snooze**: `POST /partners/:id/snooze|unsnooze` (pipeline.move gate, own-row rule, terminal stages refused). Sweep wakes expired snoozes back to `owned`/`available`; unexpired snoozes are exempt from the stale flag.
- **Analytics**: `replied` derived from inbound activities; meeting/proposal funnels use the merged sets.
- **Tests**: DB-backed suites updated (stage machine, LOST reason, snooze/wake). Also fixed a latent wrong expectation (forced PARTNERED without a contact must 422 since #112) — note these root-level suites currently never run on CI because the job fails fast at the unit step (shortlinkService baseline).

## Verify

- `npm run build` + `VITE_SURFACE=ops npm run build` ✅, vitest 1113 ✅, backend units: only shortlinkService (known baseline) ✅, eslint ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqCcNpihKgDTQ9YG811btF