### PR TITLE
feat(redeem-ops): mobile shell + partner profile redesign

### DIFF
--- a/src/components/redeemops/RedeemOpsLayout.jsx
+++ b/src/components/redeemops/RedeemOpsLayout.jsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { NavLink, Link, useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { NavLink, Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
 import { hasCapability } from '@/lib/redeemOpsPermissions';
 import { RoAvatar, roRoleLabel } from '@/components/redeemops/ui';
@@ -24,6 +24,8 @@ import UserCog from 'lucide-react/icons/user-cog';
 import Shield from 'lucide-react/icons/shield';
 import Settings from 'lucide-react/icons/settings';
 import LogOut from 'lucide-react/icons/log-out';
+import Ellipsis from 'lucide-react/icons/ellipsis';
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
 import '@/styles/redeem-ops-theme.css';
 
 /**
@@ -51,6 +53,8 @@ export default function RedeemOpsLayout({ children }) {
   const user = useAuthStore((s) => s.user);
   const logout = useAuthStore((s) => s.logout);
   const navigate = useNavigate();
+  const location = useLocation();
+  const [moreOpen, setMoreOpen] = useState(false);
 
   // Figtree loads only when a Redeem Ops screen mounts — the mktr admin and
   // both public brands never pay for it. The link persists once added (fonts
@@ -65,6 +69,11 @@ export default function RedeemOpsLayout({ children }) {
   }, []);
 
   const items = NAV.filter((item) => !item.capability || hasCapability(user, item.capability));
+  // Mobile bottom bar (design: screens/mobile-shell.html): first four sections
+  // get a slot, the rest live behind "More" with the account block.
+  const barItems = items.slice(0, 4);
+  const moreItems = items.slice(4);
+  const moreActive = moreItems.some((i) => location.pathname.startsWith(i.url));
   const displayName = user?.fullName || [user?.firstName, user?.lastName].filter(Boolean).join(' ') || user?.email || 'Me';
 
   const handleLogout = () => {
@@ -124,6 +133,67 @@ export default function RedeemOpsLayout({ children }) {
         </div>
       </aside>
       <main className="ro-main">{children}</main>
+
+      <nav className="ro-tabbar" aria-label="Redeem Ops navigation">
+        {barItems.map((item) => (
+          <NavLink
+            key={item.url}
+            to={item.url}
+            className={({ isActive }) => `ro-tabbar-item${isActive ? ' active' : ''}`}
+          >
+            <item.icon aria-hidden="true" />
+            {item.title}
+          </NavLink>
+        ))}
+        <button
+          type="button"
+          className={`ro-tabbar-item${moreActive || moreOpen ? ' active' : ''}`}
+          onClick={() => setMoreOpen(true)}
+        >
+          <Ellipsis aria-hidden="true" />
+          More
+        </button>
+      </nav>
+
+      <Sheet open={moreOpen} onOpenChange={setMoreOpen}>
+        <SheetContent side="bottom" className="rounded-t-[20px] px-4 pb-6 max-h-[80dvh] overflow-y-auto">
+          <SheetTitle className="sr-only">More</SheetTitle>
+          <div className="w-9 h-1 rounded-full mx-auto mb-2" style={{ background: 'var(--ro-border-strong)' }} />
+          {moreItems.map((item) => (
+            <button
+              key={item.url}
+              type="button"
+              className="ro-sheet-row"
+              onClick={() => { setMoreOpen(false); navigate(item.url); }}
+            >
+              <span className="ro-sheet-icon"><item.icon aria-hidden="true" /></span>
+              {item.title}
+            </button>
+          ))}
+          <div className="h-px my-2" style={{ background: 'var(--ro-divider, #EEF1F3)' }} />
+          <div className="flex items-center gap-3 px-1 py-2">
+            <RoAvatar name={displayName} size={40} />
+            <span className="min-w-0">
+              <span className="block text-[14px] font-bold truncate">{displayName}</span>
+              <span className="block text-[12px] font-semibold" style={{ color: 'var(--ro-azure)' }}>{roRoleLabel(user)}</span>
+            </span>
+          </div>
+          <button type="button" className="ro-sheet-row" onClick={() => { setMoreOpen(false); navigate('/redeem-ops/profile'); }}>
+            <span className="ro-sheet-icon"><Settings aria-hidden="true" /></span>
+            Edit profile
+          </button>
+          {user?.role === 'admin' && (
+            <button type="button" className="ro-sheet-row" onClick={() => { setMoreOpen(false); navigate('/AdminDashboard'); }}>
+              <span className="ro-sheet-icon"><Shield aria-hidden="true" /></span>
+              MKTR admin console
+            </button>
+          )}
+          <button type="button" className="ro-sheet-row" style={{ color: 'var(--ro-tag-red-fg)' }} onClick={handleLogout}>
+            <span className="ro-sheet-icon"><LogOut aria-hidden="true" /></span>
+            Log out
+          </button>
+        </SheetContent>
+      </Sheet>
     </div>
   );
 }

--- a/src/pages/redeemops/PartnerDetail.jsx
+++ b/src/pages/redeemops/PartnerDetail.jsx
@@ -7,6 +7,9 @@ import { useAuthStore } from '@/stores/authStore';
 import { hasCapability } from '@/lib/redeemOpsPermissions';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
+  DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
   Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
 } from '@/components/ui/dialog';
 import {
@@ -104,7 +107,11 @@ function fieldDiffs(before = {}, after = {}) {
 }
 
 function TimelineEntry({ entry }) {
-  const at = new Date(entry.at).toLocaleString();
+  const d = new Date(entry.at);
+  const at = `${d.toLocaleDateString('en-SG', {
+    day: 'numeric', month: 'short',
+    ...(d.getFullYear() !== new Date().getFullYear() ? { year: 'numeric' } : {}),
+  })}, ${d.toLocaleTimeString('en-SG', { hour: 'numeric', minute: '2-digit' })}`;
   const { Icon, bg, fg } = timelineIcon(entry);
 
   let title;
@@ -307,6 +314,8 @@ export default function PartnerDetail() {
   const [lostOpen, setLostOpen] = useState(false);
   const [lostReason, setLostReason] = useState(null);
   const [snoozeOpen, setSnoozeOpen] = useState(false);
+  const [assignOpen, setAssignOpen] = useState(false);
+  const [moveOpen, setMoveOpen] = useState(false);
   const [snoozeDays, setSnoozeDays] = useState(30);
   const snoozeMutation = useMutation({
     mutationFn: () => redeemOpsApi.snoozePartner(id, new Date(Date.now() + snoozeDays * 24 * 3600 * 1000).toISOString()),
@@ -468,17 +477,18 @@ export default function PartnerDetail() {
   const activityTypes = constants.data?.activityTypes || [];
 
   return (
-    <div className="p-6 md:p-8 max-w-6xl mx-auto space-y-5">
+    <div className="p-4 md:p-8 max-w-6xl mx-auto space-y-4 md:space-y-5 overflow-x-hidden">
       <Link to="/redeem-ops/partners" className="ro-link inline-flex items-center gap-1 text-[13.5px]">
         <ArrowLeft className="w-3.5 h-3.5" aria-hidden="true" /> Partners
       </Link>
 
       <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="flex items-center gap-4 min-w-0">
-          <RoAvatar name={name} size={56} />
+        <div className="flex items-center gap-3 md:gap-4 min-w-0">
+          <span className="md:hidden shrink-0"><RoAvatar name={name} size={44} /></span>
+          <span className="hidden md:block shrink-0"><RoAvatar name={name} size={56} /></span>
           <div className="min-w-0">
-            <h1 className="ro-title text-[26px] inline-flex items-center gap-2">
-              {name}
+            <h1 className="ro-title text-[21px] md:text-[26px] inline-flex items-center gap-2 min-w-0">
+              <span className="break-words min-w-0">{name}</span>
               {hasCapability(user, 'partners.edit') && (isOwner || canReassign) && (
                 <button
                   type="button"
@@ -519,7 +529,49 @@ export default function PartnerDetail() {
           </div>
         </div>
 
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex md:hidden items-center gap-2 w-full">
+          {isUnowned && hasCapability(user, 'partners.claim') ? (
+            <Button className="flex-1 h-[42px]" onClick={() => claimMutation.mutate()} disabled={claimMutation.isPending}>
+              {claimMutation.isPending ? 'Claiming…' : 'Claim business'}
+            </Button>
+          ) : (isOwner || canReassign) && (
+            <Button className="flex-1 h-[42px]" onClick={() => setActivityOpen(true)}>Log activity</Button>
+          )}
+          {hasCapability(user, 'tasks.manage') && (
+            <Button variant="outline" className="flex-1 h-[42px]" onClick={() => setTaskOpen(true)}>Add task</Button>
+          )}
+          {(isOwner || canReassign) && (
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                className="w-[42px] h-[42px] shrink-0 rounded-full border grid place-items-center outline-none"
+                style={{ borderColor: 'var(--ro-border-strong)', background: '#fff' }}
+                aria-label="More actions"
+              >
+                <span className="font-bold tracking-wider text-[15px]" style={{ color: 'var(--ro-bunker)' }}>⋯</span>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-52">
+                {canReassign && (
+                  <DropdownMenuItem onClick={() => setAssignOpen(true)}>Assign to…</DropdownMenuItem>
+                )}
+                {allowedNext.length > 0 && (
+                  <DropdownMenuItem onClick={() => setMoveOpen(true)}>Move stage…</DropdownMenuItem>
+                )}
+                {!['PARTNERED', 'LOST'].includes(partner.pipelineStage) && (
+                  partner.availability === 'follow_up_later' ? (
+                    <DropdownMenuItem onClick={() => unsnoozeMutation.mutate()}>Wake up</DropdownMenuItem>
+                  ) : (
+                    <DropdownMenuItem onClick={() => { setSnoozeDays(30); setSnoozeOpen(true); }}>Snooze</DropdownMenuItem>
+                  )
+                )}
+                {isOwner && (
+                  <DropdownMenuItem onClick={() => releaseMutation.mutate()}>Release claim</DropdownMenuItem>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
+
+        <div className="hidden md:flex flex-wrap items-center gap-2">
           {canReassign && (
             <Select onValueChange={(toUserId) => assignMutation.mutate({ toUserId })}>
               <SelectTrigger className="w-40 h-10"><SelectValue placeholder="Assign to…" /></SelectTrigger>
@@ -572,7 +624,8 @@ export default function PartnerDetail() {
 
       <div className="grid gap-5 lg:grid-cols-[1fr_320px] items-start">
         <Tabs defaultValue="timeline">
-          <TabsList>
+          <div className="max-w-full overflow-x-auto">
+          <TabsList className="w-max">
             <TabsTrigger value="timeline">Timeline</TabsTrigger>
             <TabsTrigger value="contacts">Contacts ({partner.contacts?.length || 0})</TabsTrigger>
             <TabsTrigger value="locations">Locations ({partner.locations?.length || 0})</TabsTrigger>
@@ -580,6 +633,7 @@ export default function PartnerDetail() {
               <TabsTrigger value="onboarding">Onboarding</TabsTrigger>
             )}
           </TabsList>
+          </div>
 
           <TabsContent value="timeline">
             <div className="rounded-2xl border border-border bg-white p-5">
@@ -993,6 +1047,57 @@ export default function PartnerDetail() {
               {activityMutation.isPending ? 'Saving…' : 'Log it'}
             </Button>
           </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={assignOpen} onOpenChange={setAssignOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Assign {name}</DialogTitle>
+            <DialogDescription>Hands ownership to a team member.</DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-1.5 max-h-[50dvh] overflow-y-auto">
+            {(teamQuery.data || []).filter((m) => m.isActive).map((m) => (
+              <button
+                key={m.id}
+                type="button"
+                className="h-[44px] px-4 rounded-xl text-[13.5px] font-semibold border text-left cursor-pointer flex items-center gap-2.5"
+                style={{ background: '#fff', borderColor: 'var(--ro-border-strong)', color: 'var(--ro-bunker)' }}
+                onClick={() => { setAssignOpen(false); assignMutation.mutate({ toUserId: m.id }); }}
+              >
+                <RoAvatar name={m.fullName || m.email} size={26} />
+                <span className="truncate">{m.fullName || m.email}</span>
+              </button>
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={moveOpen} onOpenChange={setMoveOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Move {name}</DialogTitle>
+            <DialogDescription>Currently {prettyEnum(partner.pipelineStage)}. Pick the next stage.</DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-1.5">
+            {allowedNext.map((st) => (
+              <button
+                key={st}
+                type="button"
+                className="h-[44px] px-4 rounded-xl text-[13.5px] font-semibold border text-left cursor-pointer"
+                style={st === 'LOST'
+                  ? { background: '#fff', borderColor: 'var(--ro-tag-red-fg)', color: 'var(--ro-tag-red-fg)' }
+                  : { background: '#fff', borderColor: 'var(--ro-border-strong)', color: 'var(--ro-bunker)' }}
+                onClick={() => {
+                  setMoveOpen(false);
+                  if (st === 'LOST') { setLostReason(null); setLostOpen(true); return; }
+                  stageMutation.mutate({ toStage: st });
+                }}
+              >
+                {prettyEnum(st)}
+              </button>
+            ))}
+          </div>
         </DialogContent>
       </Dialog>
 

--- a/src/pages/redeemops/TeamPipeline.jsx
+++ b/src/pages/redeemops/TeamPipeline.jsx
@@ -159,7 +159,7 @@ function LostDropBar({ activeCard, legalTargets }) {
   return (
     <div
       ref={setNodeRef}
-      className="fixed bottom-4 left-4 right-4 z-50 shadow-lg md:static md:z-auto md:shadow-none md:mt-2.5 rounded-2xl grid place-items-center h-[52px] text-[12.5px] font-bold transition-colors"
+      className="fixed bottom-[78px] left-4 right-4 z-50 shadow-lg md:static md:z-auto md:shadow-none md:mt-2.5 rounded-2xl grid place-items-center h-[52px] text-[12.5px] font-bold transition-colors"
       style={{
         background: isOver && isLegal ? '#FEF2F2' : 'var(--ro-subtle)',
         color: isLegal ? 'var(--ro-tag-red-fg)' : 'var(--ro-text-3)',

--- a/src/styles/redeem-ops-theme.css
+++ b/src/styles/redeem-ops-theme.css
@@ -306,3 +306,69 @@
   text-decoration: none;
 }
 .ro-link:hover { text-decoration: underline; }
+
+/* ── Mobile shell (<768px): the dark rail yields to a bottom tab bar ──── */
+@media (max-width: 767px) {
+  .ro-rail { display: none; }
+  .ro-main {
+    height: 100dvh;
+    padding-bottom: calc(70px + env(safe-area-inset-bottom));
+  }
+}
+
+.ro-tabbar {
+  position: fixed;
+  left: 0; right: 0; bottom: 0;
+  z-index: 40;
+  height: calc(62px + env(safe-area-inset-bottom));
+  padding-bottom: env(safe-area-inset-bottom);
+  background: #fff;
+  border-top: 1px solid var(--ro-border);
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+}
+@media (min-width: 768px) { .ro-tabbar { display: none; } }
+
+.ro-tabbar-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  color: var(--ro-text-3);
+  font-size: 10.5px;
+  font-weight: 600;
+  text-decoration: none;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font-family: inherit;
+}
+.ro-tabbar-item svg { width: 22px; height: 22px; }
+.ro-tabbar-item.active { color: var(--ro-bunker); }
+
+/* More sheet rows (mobile nav overflow + account block) */
+.ro-sheet-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  padding: 12px 4px;
+  font-size: 15px;
+  font-weight: 600;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font-family: inherit;
+  color: var(--ro-bunker);
+  text-align: left;
+}
+.ro-sheet-icon {
+  width: 38px; height: 38px;
+  border-radius: 50%;
+  background: var(--ro-subtle);
+  display: grid;
+  place-items: center;
+  flex: none;
+}
+.ro-sheet-icon svg { width: 18px; height: 18px; }


### PR DESCRIPTION
## What

Mobile-first pass on the ops app, designed in the claude.ai/design **Redeem Ops Design System** project (new **Mobile** group: "Mobile — App shell" + "Mobile — Partner profile") and built to match. Fixes the screenshot issues: rail eating a third of the screen, six stacked action pills, and horizontal clipping of tabs/timestamps.

## How

**App shell (<768px)**
- Dark rail hidden; **five-slot bottom tab bar** (first four capability-visible sections + **More**).
- More = bottom sheet with the remaining sections plus the account block (avatar, role title, Edit profile, MKTR admin for admins, Log out).
- `.ro-main` uses `100dvh` + safe-area bottom padding; the pipeline board's fixed Lost drop bar lifts above the bar (`bottom-[78px]`).

**Partner profile (mobile)**
- Compact header: 44px avatar inline with a 21px name; meta wraps below.
- One 42px action row: **Log activity** (or **Claim business** when unowned) + **Add task** + **⋯** menu → Assign to…, Move stage…, Snooze/Wake up, Release claim. Assign/Move open small pickers; Move → Lost still routes through the lost-reason dialog.
- Tabs scroll inside their own strip (`overflow-x-auto` wrapper + `w-max` list); page root gets `overflow-x-hidden` — no more sideways panning.
- Timeline timestamps shortened to "10 Jul, 6:04 pm" (year appended only when not the current year).

Desktop unchanged — every mobile treatment is gated under 768px.

## Verify

- eslint ✅, vitest 1113 ✅, `npm run build` + `VITE_SURFACE=ops npm run build` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqCcNpihKgDTQ9YG811btF