### PR TITLE
feat(redeem-ops): mobile card layouts for all list pages — no sideways scrolling

### DIFF
--- a/src/components/redeemops/ui.jsx
+++ b/src/components/redeemops/ui.jsx
@@ -192,3 +192,31 @@ export function RoEmpty({ title, body, children, className }) {
     </div>
   );
 }
+
+/** Tap-card for mobile lists (tables collapse to these under md). */
+export function RoMobileCard({ onClick, children, className }) {
+  const Tag = onClick ? 'button' : 'div';
+  return (
+    <Tag
+      type={onClick ? 'button' : undefined}
+      onClick={onClick}
+      className={cn(
+        'w-full text-left bg-white px-4 py-3 border-t border-border first:border-t-0 block',
+        onClick && 'cursor-pointer hover:bg-[var(--ro-subtle)] transition-colors',
+        className
+      )}
+    >
+      {children}
+    </Tag>
+  );
+}
+
+/** Tiny label→value pair for compact stat grids on mobile cards. */
+export function RoStat({ label, children }) {
+  return (
+    <span className="min-w-0">
+      <span className="block text-[10px] font-bold uppercase tracking-wide" style={{ color: 'var(--ro-text-3)' }}>{label}</span>
+      <span className="block text-[13px] font-bold tabular-nums truncate">{children}</span>
+    </span>
+  );
+}

--- a/src/pages/redeemops/ActivationsPage.jsx
+++ b/src/pages/redeemops/ActivationsPage.jsx
@@ -19,7 +19,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import Plus from 'lucide-react/icons/plus';
-import { RoPageHeader, RoTag, prettyEnum } from '@/components/redeemops/ui';
+import { RoMobileCard, RoStat, RoPageHeader, RoTag, prettyEnum } from '@/components/redeemops/ui';
 
 const ACTIVATION_TONE = { preparing: 'pending', completed: 'done' };
 
@@ -70,7 +70,34 @@ export default function ActivationsPage() {
 
       <Card>
         <CardContent className="pt-4">
-          <div className="overflow-x-auto">
+          <div className="md:hidden -mx-6 -mt-2">
+            {activations.map((a) => (
+              <RoMobileCard key={a.id} className="px-6" onClick={() => navigate(`/redeem-ops/activations/${a.id}`)}>
+                <span className="flex items-start gap-2">
+                  <span className="min-w-0 flex-1">
+                    <span className="block font-semibold text-[14px] leading-tight">{a.rewardOffer?.title || '—'}</span>
+                    <span className="block text-xs truncate mt-0.5" style={{ color: 'var(--ro-text-2)' }}>
+                      {a.partner?.tradingName || a.partner?.legalName || '—'}
+                      {' · '}
+                      {a.campaignNameSnapshot || (a.campaignId ? a.campaignId.slice(0, 8) : 'Not linked')}
+                    </span>
+                  </span>
+                  <RoTag tone={ACTIVATION_TONE[a.status] || a.status} size="sm">{prettyEnum(a.status)}</RoTag>
+                </span>
+                <span className="grid grid-cols-3 gap-2 mt-2.5">
+                  <RoStat label="Allocated">{a.allocatedQuantity}</RoStat>
+                  <RoStat label="Issued">{a.issuedCount}</RoStat>
+                  <RoStat label="Redeemed">{a.redeemedCount}</RoStat>
+                </span>
+              </RoMobileCard>
+            ))}
+            {!listQuery.isLoading && activations.length === 0 && (
+              <p className="text-sm text-center py-8 m-0" style={{ color: 'var(--ro-text-2)' }}>
+                No activations yet{canManage ? ' — create one from an active reward.' : '.'}
+              </p>
+            )}
+          </div>
+          <div className="hidden md:block overflow-x-auto">
             <Table>
               <TableHeader>
                 <TableRow>

--- a/src/pages/redeemops/AnalyticsPage.jsx
+++ b/src/pages/redeemops/AnalyticsPage.jsx
@@ -6,9 +6,9 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '@/components/ui/table';
-import { RoPageHeader, RoTag, prettyEnum } from '@/components/redeemops/ui';
+import { RoMobileCard, RoStat, RoPageHeader, RoTag, prettyEnum } from '@/components/redeemops/ui';
 
-function Section({ title, description, children }) {
+function Section({ title, description, mobile, children }) {
   return (
     <Card>
       <CardHeader>
@@ -16,7 +16,8 @@ function Section({ title, description, children }) {
         {description && <CardDescription>{description}</CardDescription>}
       </CardHeader>
       <CardContent>
-        <div className="overflow-x-auto">{children}</div>
+        {mobile && <div className="md:hidden -mx-6 -mt-2">{mobile}</div>}
+        <div className={mobile ? 'hidden md:block overflow-x-auto' : 'overflow-x-auto'}>{children}</div>
       </CardContent>
     </Card>
   );
@@ -53,7 +54,30 @@ export default function AnalyticsPage() {
         sub="Acquisition numbers come from MKTR's own metrics — nothing is re-counted here."
       />
 
-      <Section title={teamWide ? 'Outreach — by team member' : 'Outreach — your performance'}>
+      <Section
+        title={teamWide ? 'Outreach — by team member' : 'Outreach — your performance'}
+        mobile={(outreach.data?.members || []).map((m) => (
+          <RoMobileCard key={m.userId} className="px-6">
+            <span className="flex items-center gap-2">
+              <span className="font-semibold text-[14px] flex-1 min-w-0 truncate">{m.name}</span>
+              <RoTag tone="primary" size="sm">{m.partneredRate}% conv.</RoTag>
+            </span>
+            <span className="grid grid-cols-4 gap-2 mt-2.5">
+              <RoStat label="Owned">{m.owned}</RoStat>
+              <RoStat label="Contacted">{m.contacted}</RoStat>
+              <RoStat label="Touches">{m.outboundTouches}</RoStat>
+              <RoStat label="Replies">{m.replies}</RoStat>
+              <RoStat label="Meetings">{m.meetingsBooked}</RoStat>
+              <RoStat label="Proposals">{m.proposalsSent}</RoStat>
+              <RoStat label="Partnered">{m.partnered}</RoStat>
+              <RoStat label="Stale">{m.stale}</RoStat>
+            </span>
+            <span className="block text-[11px] mt-2" style={{ color: 'var(--ro-text-3)' }}>
+              Avg {m.avgHoursToFirstOutreach ?? '—'}h to first touch
+            </span>
+          </RoMobileCard>
+        ))}
+      >
         <Table>
           <TableHeader>
             <TableRow>
@@ -92,7 +116,24 @@ export default function AnalyticsPage() {
 
       {teamWide && (
         <>
-          <Section title="Category conversion" description="Where outreach converts — and where it doesn't.">
+          <Section
+            title="Category conversion"
+            description="Where outreach converts — and where it doesn't."
+            mobile={(categories.data?.categories || []).map((c) => (
+              <RoMobileCard key={c.category} className="px-6">
+                <span className="flex items-center gap-2">
+                  <span className="font-semibold text-[14px] flex-1 min-w-0 truncate">{c.category}</span>
+                  <RoTag tone="primary" size="sm">{c.partnered} partnered</RoTag>
+                </span>
+                <span className="grid grid-cols-4 gap-2 mt-2.5">
+                  <RoStat label="Total">{c.total}</RoStat>
+                  <RoStat label="Contacted">{c.contacted}</RoStat>
+                  <RoStat label="Replied">{c.replied}</RoStat>
+                  <RoStat label="Meetings">{c.meetings}</RoStat>
+                </span>
+              </RoMobileCard>
+            ))}
+          >
             <Table>
               <TableHeader>
                 <TableRow>
@@ -119,7 +160,27 @@ export default function AnalyticsPage() {
             </Table>
           </Section>
 
-          <Section title="Reward supply" description="Committed → allocated → issued → redeemed (ledger-audited counters).">
+          <Section
+            title="Reward supply"
+            description="Committed → allocated → issued → redeemed (ledger-audited counters)."
+            mobile={(rewards.data?.rewards || []).map((r) => (
+              <RoMobileCard key={r.id} className="px-6">
+                <span className="flex items-center gap-2">
+                  <span className="min-w-0 flex-1">
+                    <span className="block font-semibold text-[14px] leading-tight truncate">{r.title}</span>
+                    <span className="block text-xs truncate" style={{ color: 'var(--ro-text-2)' }}>{r.partnerName || '—'}</span>
+                  </span>
+                  <RoTag tone="primary" size="sm">{r.redemptionRate}% redeemed</RoTag>
+                </span>
+                <span className="grid grid-cols-4 gap-2 mt-2.5">
+                  <RoStat label="Committed">{r.committed}</RoStat>
+                  <RoStat label="Allocated">{r.allocated}</RoStat>
+                  <RoStat label="Issued">{r.issued}</RoStat>
+                  <RoStat label="Redeemed">{r.redeemed}</RoStat>
+                </span>
+              </RoMobileCard>
+            ))}
+          >
             <Table>
               <TableHeader>
                 <TableRow>
@@ -148,7 +209,31 @@ export default function AnalyticsPage() {
             </Table>
           </Section>
 
-          <Section title="Activation funnels" description="MKTR acquisition + Redeem fulfilment, per activation.">
+          <Section
+            title="Activation funnels"
+            description="MKTR acquisition + Redeem fulfilment, per activation."
+            mobile={(funnels.data?.funnels || []).map((f) => (
+              <RoMobileCard key={f.id} className="px-6">
+                <span className="flex items-start gap-2">
+                  <span className="min-w-0 flex-1">
+                    <span className="block font-semibold text-[14px] leading-tight">{f.rewardTitle}</span>
+                    <span className="block text-xs truncate mt-0.5" style={{ color: 'var(--ro-text-2)' }}>
+                      {f.partnerName}{f.campaignName ? ` · ${f.campaignName}` : ' · Not linked'}
+                    </span>
+                  </span>
+                  <RoTag tone={f.status} size="sm">{prettyEnum(f.status)}</RoTag>
+                </span>
+                <span className="grid grid-cols-3 gap-2 mt-2.5">
+                  <RoStat label="Leads (MKTR)">{f.acquisition?.totalLeads ?? f.acquisition?.leads ?? '—'}</RoStat>
+                  <RoStat label="Issued">{f.reward.issued}</RoStat>
+                  <RoStat label="Redeemed">{f.reward.redeemed}</RoStat>
+                </span>
+                <span className="block text-[11px] mt-2" style={{ color: 'var(--ro-text-3)' }}>
+                  Renewal: {f.renewalOutcome || 'pending'}
+                </span>
+              </RoMobileCard>
+            ))}
+          >
             <Table>
               <TableHeader>
                 <TableRow>

--- a/src/pages/redeemops/PartnersList.jsx
+++ b/src/pages/redeemops/PartnersList.jsx
@@ -17,7 +17,7 @@ import { Label } from '@/components/ui/label';
 import Plus from 'lucide-react/icons/plus';
 import Upload from 'lucide-react/icons/upload';
 import AlertTriangle from 'lucide-react/icons/alert-triangle';
-import { RoStageTag, RoAvatar, RoOwner, RoPageHeader, prettyEnum } from '@/components/redeemops/ui';
+import { RoMobileCard, RoStageTag, RoAvatar, RoOwner, RoPageHeader, prettyEnum } from '@/components/redeemops/ui';
 
 function useDebounced(value, ms = 300) {
   const [debounced, setDebounced] = useState(value);
@@ -246,7 +246,36 @@ export default function PartnersList() {
       </div>
 
       <div className="rounded-2xl border border-border bg-white overflow-hidden">
-        <div className="overflow-x-auto">
+        <div className="md:hidden">
+          {partners.map((p) => (
+            <RoMobileCard key={p.id} onClick={() => navigate(`/redeem-ops/partners/${p.id}`)}>
+              <span className="flex items-center gap-3 min-w-0">
+                <RoAvatar name={partnerName(p)} size={38} />
+                <span className="min-w-0 flex-1">
+                  <span className="font-semibold text-[14px] flex items-center gap-1.5 leading-tight">
+                    <span className="truncate">{partnerName(p)}</span>
+                    {(p.atRiskFlag || p.staleFlag) && (
+                      <AlertTriangle className="w-3.5 h-3.5 shrink-0" style={{ color: 'var(--ro-tag-yellow-fg)' }} aria-hidden="true" />
+                    )}
+                  </span>
+                  <span className="block text-xs truncate" style={{ color: 'var(--ro-text-2)' }}>
+                    {partnerMeta(p) || '—'}
+                  </span>
+                  <span className="block text-[11px] truncate mt-0.5" style={{ color: 'var(--ro-text-3)' }}>
+                    {p.owner?.fullName || 'Unowned'} · {p.lastActivityAt ? new Date(p.lastActivityAt).toLocaleDateString('en-SG', { day: 'numeric', month: 'short' }) : 'no activity'}
+                  </span>
+                </span>
+                <RoStageTag stage={p.pipelineStage} size="sm" className="shrink-0" />
+              </span>
+            </RoMobileCard>
+          ))}
+          {!listQuery.isLoading && partners.length === 0 && (
+            <p className="text-sm text-center py-10 m-0" style={{ color: 'var(--ro-text-2)' }}>
+              No businesses match. Add the first one.
+            </p>
+          )}
+        </div>
+        <div className="hidden md:block overflow-x-auto">
           <table className="w-full text-sm border-collapse">
             <thead>
               <tr className="text-left" style={{ color: 'var(--ro-text-2)' }}>

--- a/src/pages/redeemops/RedeemOpsTeam.jsx
+++ b/src/pages/redeemops/RedeemOpsTeam.jsx
@@ -19,7 +19,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import UserPlus from 'lucide-react/icons/user-plus';
 import Pencil from 'lucide-react/icons/pencil';
-import { RoTag, RoAvatar } from '@/components/redeemops/ui';
+import { RoMobileCard, RoTag, RoAvatar } from '@/components/redeemops/ui';
 
 const TEAM_KEY = ['redeem-ops', 'team'];
 
@@ -165,7 +165,75 @@ export default function RedeemOpsTeam() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="overflow-x-auto">
+          <div className="md:hidden -mx-6">
+            {team.map((member) => (
+              <RoMobileCard key={member.id} className="px-6">
+                <span className="flex items-center gap-2.5 min-w-0">
+                  <RoAvatar name={member.fullName || member.email} size={34} />
+                  <span className="min-w-0 flex-1">
+                    <span className="block font-semibold text-[14px] truncate">
+                      {member.fullName || [member.firstName, member.lastName].filter(Boolean).join(' ') || '—'}
+                    </span>
+                    <span className="block text-xs truncate" style={{ color: 'var(--ro-text-2)' }}>{member.email}</span>
+                  </span>
+                  <RoTag tone={member.isActive ? 'active' : 'inactive'} size="sm">
+                    {member.isActive ? 'Active' : 'Deactivated'}
+                  </RoTag>
+                </span>
+                {canManage && member.id !== currentUser?.id ? (
+                  <span className="flex items-center gap-2 mt-2.5">
+                    <Select
+                      value={member.redeemOpsRole || ''}
+                      onValueChange={(redeemOpsRole) => roleMutation.mutate({ userId: member.id, redeemOpsRole })}
+                    >
+                      <SelectTrigger className="flex-1 h-9"><SelectValue placeholder="No sub-role" /></SelectTrigger>
+                      <SelectContent>
+                        {subRoles.map((r) => (
+                          <SelectItem key={r} value={r}>{subRoleLabels[r] || r}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      size="sm" variant="ghost" aria-label="Edit member"
+                      onClick={() => setEditTarget({
+                        id: member.id,
+                        fullName: member.fullName || [member.firstName, member.lastName].filter(Boolean).join(' '),
+                        phone: member.phone || '',
+                      })}
+                    >
+                      <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
+                    </Button>
+                    <Button
+                      size="sm" variant="ghost"
+                      className={member.isActive ? 'text-destructive hover:text-destructive' : undefined}
+                      disabled={memberMutation.isPending}
+                      onClick={() => {
+                        const name = member.fullName || member.email;
+                        const ok = member.isActive
+                          ? window.confirm(`Deactivate ${name}? They will be signed out and unable to log in until reactivated.`)
+                          : true;
+                        if (ok) memberMutation.mutate({ userId: member.id, body: { isActive: !member.isActive } });
+                      }}
+                    >
+                      {member.isActive ? 'Deactivate' : 'Reactivate'}
+                    </Button>
+                  </span>
+                ) : (
+                  <span className="block mt-2">
+                    <RoTag tone="primary" size="sm">
+                      {subRoleLabels[member.redeemOpsRole] || member.redeemOpsRole || '—'}
+                    </RoTag>
+                  </span>
+                )}
+              </RoMobileCard>
+            ))}
+            {!teamQuery.isLoading && team.length === 0 && (
+              <p className="text-sm text-center py-8 m-0" style={{ color: 'var(--ro-text-2)' }}>
+                No Redeem Ops staff yet{canManage ? ' — send the first invite.' : '.'}
+              </p>
+            )}
+          </div>
+          <div className="hidden md:block overflow-x-auto">
             <Table>
               <TableHeader>
                 <TableRow>

--- a/src/pages/redeemops/RedemptionsPage.jsx
+++ b/src/pages/redeemops/RedemptionsPage.jsx
@@ -10,7 +10,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import ScanLine from 'lucide-react/icons/scan-line';
-import { RoPageHeader, RoTag, prettyEnum } from '@/components/redeemops/ui';
+import { RoMobileCard, RoPageHeader, RoTag, prettyEnum } from '@/components/redeemops/ui';
 
 export default function RedemptionsPage() {
   const queryClient = useQueryClient();
@@ -180,7 +180,32 @@ export default function RedemptionsPage() {
           <CardTitle className="text-base">Recent redemptions</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="overflow-x-auto">
+          <div className="md:hidden -mx-6">
+            {redemptions.map((r) => (
+              <RoMobileCard key={r.id} className="px-6">
+                <span className="flex items-start gap-2">
+                  <span className="min-w-0 flex-1">
+                    <span className="block font-semibold text-[14px] leading-tight">{r.rewardOffer?.title || '—'}</span>
+                    <span className="block text-xs truncate mt-0.5" style={{ color: 'var(--ro-text-2)' }}>
+                      {r.partner?.tradingName || r.partner?.legalName || '—'}
+                    </span>
+                    <span className="block text-[11px] truncate mt-0.5" style={{ color: 'var(--ro-text-3)' }}>
+                      {new Date(r.redeemedAt).toLocaleDateString('en-SG', { day: 'numeric', month: 'short' })}
+                      {', '}
+                      {new Date(r.redeemedAt).toLocaleTimeString('en-SG', { hour: 'numeric', minute: '2-digit' })}
+                      {' · '}
+                      {r.actor?.fullName || r.actorType}
+                    </span>
+                  </span>
+                  <RoTag tone={r.status === 'completed' ? 'completed' : 'void'} size="sm">{prettyEnum(r.status)}</RoTag>
+                </span>
+              </RoMobileCard>
+            ))}
+            {!historyQuery.isLoading && redemptions.length === 0 && (
+              <p className="text-sm text-center py-8 m-0" style={{ color: 'var(--ro-text-2)' }}>No redemptions yet.</p>
+            )}
+          </div>
+          <div className="hidden md:block overflow-x-auto">
             <Table>
               <TableHeader>
                 <TableRow>

--- a/src/pages/redeemops/RewardDetail.jsx
+++ b/src/pages/redeemops/RewardDetail.jsx
@@ -99,11 +99,13 @@ export default function RewardDetail() {
       </div>
 
       <Tabs defaultValue="ledger">
-        <TabsList>
+        <div className="max-w-full overflow-x-auto">
+        <TabsList className="w-max">
           <TabsTrigger value="ledger">Inventory ledger</TabsTrigger>
           <TabsTrigger value="terms">Terms</TabsTrigger>
           {canAdjust && <TabsTrigger value="adjust">Adjust supply</TabsTrigger>}
         </TabsList>
+        </div>
 
         <TabsContent value="ledger">
           <Card>

--- a/src/pages/redeemops/RewardsPage.jsx
+++ b/src/pages/redeemops/RewardsPage.jsx
@@ -19,7 +19,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import Plus from 'lucide-react/icons/plus';
-import { RoPageHeader, RoTag, prettyEnum } from '@/components/redeemops/ui';
+import { RoMobileCard, RoStat, RoPageHeader, RoTag, prettyEnum } from '@/components/redeemops/ui';
 
 const EMPTY = { partnerOrganisationId: '', title: '', rewardType: 'free_service', retailValue: '', committedQuantity: '' };
 
@@ -77,7 +77,33 @@ export default function RewardsPage() {
 
       <Card>
         <CardContent className="pt-4">
-          <div className="overflow-x-auto">
+          <div className="md:hidden -mx-6 -mt-2">
+            {offers.map((o) => (
+              <RoMobileCard key={o.id} className="px-6" onClick={() => navigate(`/redeem-ops/rewards/${o.id}`)}>
+                <span className="flex items-start gap-2">
+                  <span className="min-w-0 flex-1">
+                    <span className="block font-semibold text-[14px] leading-tight">{o.title}</span>
+                    <span className="block text-xs truncate mt-0.5" style={{ color: 'var(--ro-text-2)' }}>
+                      {o.partner?.tradingName || o.partner?.legalName || '—'}
+                    </span>
+                  </span>
+                  <RoTag tone={o.status} size="sm">{prettyEnum(o.status)}</RoTag>
+                </span>
+                <span className="grid grid-cols-4 gap-2 mt-2.5">
+                  <RoStat label="Committed">{o.committedQuantity}</RoStat>
+                  <RoStat label="Allocated">{o.allocatedQuantity}</RoStat>
+                  <RoStat label="Issued">{o.issuedQuantity}</RoStat>
+                  <RoStat label="Redeemed">{o.redeemedQuantity}</RoStat>
+                </span>
+              </RoMobileCard>
+            ))}
+            {!offersQuery.isLoading && offers.length === 0 && (
+              <p className="text-sm text-center py-8 m-0" style={{ color: 'var(--ro-text-2)' }}>
+                No rewards yet{canManage ? ' — create the first one from a PARTNERED business.' : '.'}
+              </p>
+            )}
+          </div>
+          <div className="hidden md:block overflow-x-auto">
             <Table>
               <TableHeader>
                 <TableRow>

--- a/src/pages/redeemops/TasksPage.jsx
+++ b/src/pages/redeemops/TasksPage.jsx
@@ -20,7 +20,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import Plus from 'lucide-react/icons/plus';
 import Pencil from 'lucide-react/icons/pencil';
-import { RoPageHeader, RoTag, RoAvatar, prettyEnum } from '@/components/redeemops/ui';
+import { RoMobileCard, RoPageHeader, RoTag, RoAvatar, prettyEnum } from '@/components/redeemops/ui';
 
 const VIEWS = [
   { key: 'today', label: 'Due today', params: { due: 'today' } },
@@ -186,15 +186,79 @@ export default function TasksPage() {
       />
 
       <Tabs value={view} onValueChange={setView}>
-        <TabsList>
+        <div className="max-w-full overflow-x-auto">
+        <TabsList className="w-max">
           {VIEWS.filter((v) => !v.managerOnly || isManager).map((v) => (
             <TabsTrigger key={v.key} value={v.key}>{v.label}</TabsTrigger>
           ))}
         </TabsList>
+        </div>
       </Tabs>
 
       <div className="rounded-2xl border border-border bg-white overflow-hidden">
-        <div className="px-2 py-1">
+        <div className="md:hidden">
+          {tasks.map((t) => {
+            const due = dueLabel(t);
+            const open = t.status === 'open' || t.status === 'in_progress';
+            return (
+              <RoMobileCard key={t.id}>
+                <p className="text-[14px] font-semibold m-0 leading-tight">{t.title}</p>
+                <p className="text-xs m-0 mt-0.5 truncate">
+                  <Link to={`/redeem-ops/partners/${t.partner?.id}`} className="ro-link">
+                    {t.partner?.tradingName || t.partner?.brandName || t.partner?.legalName || '—'}
+                  </Link>
+                  {view === 'team' && t.assignee?.fullName ? (
+                    <span style={{ color: 'var(--ro-text-3)' }}> · {t.assignee.fullName}</span>
+                  ) : null}
+                </p>
+                <span className="flex items-center gap-2 mt-2 flex-wrap">
+                  <span className="text-[12.5px] font-semibold" style={{ color: due.color }}>{due.text}</span>
+                  <RoTag tone={t.priority} size="sm">{t.priority}</RoTag>
+                  {showStatus && <RoTag tone={t.status} size="sm">{prettyEnum(t.status)}</RoTag>}
+                  <span className="ml-auto inline-flex gap-1">
+                    {open && (
+                      <>
+                        <Button
+                          size="sm" variant="outline"
+                          disabled={updateMutation.isPending}
+                          onClick={() => updateMutation.mutate({ taskId: t.id, body: { status: 'completed' } })}
+                        >
+                          Complete
+                        </Button>
+                        <Button
+                          size="sm" variant="ghost"
+                          aria-label="Edit task"
+                          onClick={() => setEditTask({
+                            id: t.id,
+                            title: t.title,
+                            dueDate: new Date(t.dueAt).toISOString().slice(0, 10),
+                            priority: t.priority,
+                            assigneeUserId: t.assigneeUserId || '',
+                          })}
+                        >
+                          <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
+                        </Button>
+                      </>
+                    )}
+                    {t.status === 'completed' && (
+                      <Button
+                        size="sm" variant="ghost"
+                        disabled={updateMutation.isPending}
+                        onClick={() => updateMutation.mutate({ taskId: t.id, body: { status: 'open' } })}
+                      >
+                        Reopen
+                      </Button>
+                    )}
+                  </span>
+                </span>
+              </RoMobileCard>
+            );
+          })}
+          {!tasksQuery.isLoading && tasks.length === 0 && (
+            <p className="text-sm text-center py-10 m-0" style={{ color: 'var(--ro-text-2)' }}>Nothing here.</p>
+          )}
+        </div>
+        <div className="hidden md:block px-2 py-1">
           <div className="overflow-x-auto">
             <Table>
               <TableHeader>

--- a/src/styles/redeem-ops-theme.css
+++ b/src/styles/redeem-ops-theme.css
@@ -313,6 +313,7 @@
   .ro-main {
     height: 100dvh;
     padding-bottom: calc(70px + env(safe-area-inset-bottom));
+    overflow-x: hidden; /* wide widgets scroll in their own strips, never the page */
   }
 }
 


### PR DESCRIPTION
## What

Follow-up to #119: every remaining ops tab now reads top-to-bottom on a phone with **no horizontal scrolling anywhere** — tables collapse into stacked tap-cards under 768px, desktop keeps the tables unchanged.

## Pages

| Page | Mobile treatment |
|---|---|
| Partners | Avatar rows: name + flags, category/phone meta, owner · last activity, stage tag |
| Tasks | Card per task: title, partner link, due + priority/status tags, Complete/Edit/Reopen inline; view tabs scroll in their own strip |
| Team | Member cards: avatar, email, role select (managers), status, edit/deactivate |
| Rewards | Cards with status tag + Committed/Allocated/Issued/Redeemed stat grid |
| Activations | Cards with campaign line + Allocated/Issued/Redeemed stats |
| Redemptions | Recent redemptions as cards (reward, partner, when · by, status) |
| Analytics | All four sections get stat cards (outreach w/ conv %, categories, reward supply, funnels) — the 11-column table is desktop-only |
| Reward detail | Tabs scroll in their own strip (same fix as partner detail) |

## How

- New shared primitives in `redeemops/ui.jsx`: `RoMobileCard` (tap row) + `RoStat` (label→value pair).
- Each table wrapper becomes `hidden md:block`; a `md:hidden` card list renders the same data and actions.
- Global guard: `.ro-main { overflow-x: hidden }` under 768px — wide widgets scroll inside their own strips, the page itself can never pan sideways.

## Verify

- eslint ✅ (0 errors), vitest 1113 ✅, `npm run build` + `VITE_SURFACE=ops npm run build` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqCcNpihKgDTQ9YG811btF