### PR TITLE
fix(redeem-ops): mobile stat pairs that wrap — no colliding labels, real empty states

### DIFF
--- a/src/components/redeemops/ui.jsx
+++ b/src/components/redeemops/ui.jsx
@@ -211,12 +211,27 @@ export function RoMobileCard({ onClick, children, className }) {
   );
 }
 
-/** Tiny label→value pair for compact stat grids on mobile cards. */
+/**
+ * Inline value+label stat pair (design: screens/mobile-analytics.html).
+ * Pairs live in a `flex flex-wrap gap-x-4 gap-y-1` row so they FLOW at any
+ * width — never fixed stat columns on mobile (uppercase labels in a 4-col
+ * grid collide at 337px).
+ */
 export function RoStat({ label, children }) {
   return (
-    <span className="min-w-0">
-      <span className="block text-[10px] font-bold uppercase tracking-wide" style={{ color: 'var(--ro-text-3)' }}>{label}</span>
-      <span className="block text-[13px] font-bold tabular-nums truncate">{children}</span>
+    <span className="inline-flex items-baseline gap-[5px]">
+      <span className="text-[13.5px] font-bold tabular-nums">{children}</span>
+      <span className="text-[11.5px] font-medium" style={{ color: 'var(--ro-text-3)' }}>{label}</span>
     </span>
+  );
+}
+
+/** Empty state for a mobile list — a section should say it's empty, not render hollow. */
+export function RoMobileEmpty({ title = 'Nothing to show yet', hint }) {
+  return (
+    <div className="px-6 py-7 text-center border-t border-border">
+      <p className="text-[13px] font-semibold m-0">{title}</p>
+      {hint && <p className="text-xs m-0 mt-0.5" style={{ color: 'var(--ro-text-2)' }}>{hint}</p>}
+    </div>
   );
 }

--- a/src/pages/redeemops/ActivationDetail.jsx
+++ b/src/pages/redeemops/ActivationDetail.jsx
@@ -84,7 +84,7 @@ export default function ActivationDetail() {
   const acquisition = metricsQuery.data?.acquisition;
 
   return (
-    <div className="p-6 md:p-8 max-w-5xl mx-auto space-y-5">
+    <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-5">
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
           <h1 className="ro-title text-[26px]">

--- a/src/pages/redeemops/ActivationsPage.jsx
+++ b/src/pages/redeemops/ActivationsPage.jsx
@@ -57,7 +57,7 @@ export default function ActivationsPage() {
   const rewards = (rewardsQuery.data || []).filter((r) => r.status !== 'ended');
 
   return (
-    <div className="p-6 md:p-8 max-w-6xl mx-auto space-y-5">
+    <div className="p-4 md:p-8 max-w-6xl mx-auto space-y-4 md:space-y-5">
       <RoPageHeader
         title="Activations"
         sub="A reward allocated to one MKTR campaign — the campaign itself stays managed on mktr.sg."
@@ -84,10 +84,10 @@ export default function ActivationsPage() {
                   </span>
                   <RoTag tone={ACTIVATION_TONE[a.status] || a.status} size="sm">{prettyEnum(a.status)}</RoTag>
                 </span>
-                <span className="grid grid-cols-3 gap-2 mt-2.5">
-                  <RoStat label="Allocated">{a.allocatedQuantity}</RoStat>
-                  <RoStat label="Issued">{a.issuedCount}</RoStat>
-                  <RoStat label="Redeemed">{a.redeemedCount}</RoStat>
+                <span className="flex flex-wrap gap-x-4 gap-y-1 mt-2">
+                  <RoStat label="allocated">{a.allocatedQuantity}</RoStat>
+                  <RoStat label="issued">{a.issuedCount}</RoStat>
+                  <RoStat label="redeemed">{a.redeemedCount}</RoStat>
                 </span>
               </RoMobileCard>
             ))}

--- a/src/pages/redeemops/AnalyticsPage.jsx
+++ b/src/pages/redeemops/AnalyticsPage.jsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '@/components/ui/table';
-import { RoMobileCard, RoStat, RoPageHeader, RoTag, prettyEnum } from '@/components/redeemops/ui';
+import { RoMobileCard, RoMobileEmpty, RoStat, RoPageHeader, RoTag, prettyEnum } from '@/components/redeemops/ui';
 
 function Section({ title, description, mobile, children }) {
   return (
@@ -48,7 +48,7 @@ export default function AnalyticsPage() {
   });
 
   return (
-    <div className="p-6 md:p-8 max-w-6xl mx-auto space-y-5">
+    <div className="p-4 md:p-8 max-w-6xl mx-auto space-y-4 md:space-y-5">
       <RoPageHeader
         title="Analytics"
         sub="Acquisition numbers come from MKTR's own metrics — nothing is re-counted here."
@@ -56,25 +56,29 @@ export default function AnalyticsPage() {
 
       <Section
         title={teamWide ? 'Outreach — by team member' : 'Outreach — your performance'}
-        mobile={(outreach.data?.members || []).map((m) => (
+        mobile={outreach.isLoading ? null : (outreach.data?.members || []).length === 0 ? (
+          <RoMobileEmpty hint="Numbers appear once outreach is logged." />
+        ) : (outreach.data?.members || []).map((m) => (
           <RoMobileCard key={m.userId} className="px-6">
             <span className="flex items-center gap-2">
               <span className="font-semibold text-[14px] flex-1 min-w-0 truncate">{m.name}</span>
               <RoTag tone="primary" size="sm">{m.partneredRate}% conv.</RoTag>
             </span>
-            <span className="grid grid-cols-4 gap-2 mt-2.5">
-              <RoStat label="Owned">{m.owned}</RoStat>
-              <RoStat label="Contacted">{m.contacted}</RoStat>
-              <RoStat label="Touches">{m.outboundTouches}</RoStat>
-              <RoStat label="Replies">{m.replies}</RoStat>
-              <RoStat label="Meetings">{m.meetingsBooked}</RoStat>
-              <RoStat label="Proposals">{m.proposalsSent}</RoStat>
-              <RoStat label="Partnered">{m.partnered}</RoStat>
-              <RoStat label="Stale">{m.stale}</RoStat>
+            <span className="flex flex-wrap gap-x-4 gap-y-1 mt-2">
+              <RoStat label="owned">{m.owned}</RoStat>
+              <RoStat label="contacted">{m.contacted}</RoStat>
+              <RoStat label="touches">{m.outboundTouches}</RoStat>
+              <RoStat label="replies">{m.replies}</RoStat>
+              <RoStat label="meetings">{m.meetingsBooked}</RoStat>
+              <RoStat label="proposals">{m.proposalsSent}</RoStat>
+              <RoStat label="partnered">{m.partnered}</RoStat>
+              <RoStat label="stale">{m.stale}</RoStat>
             </span>
-            <span className="block text-[11px] mt-2" style={{ color: 'var(--ro-text-3)' }}>
-              Avg {m.avgHoursToFirstOutreach ?? '—'}h to first touch
-            </span>
+            {m.avgHoursToFirstOutreach != null && (
+              <span className="block text-[11px] mt-2" style={{ color: 'var(--ro-text-3)' }}>
+                Avg {m.avgHoursToFirstOutreach}h to first touch
+              </span>
+            )}
           </RoMobileCard>
         ))}
       >
@@ -119,17 +123,19 @@ export default function AnalyticsPage() {
           <Section
             title="Category conversion"
             description="Where outreach converts — and where it doesn't."
-            mobile={(categories.data?.categories || []).map((c) => (
+            mobile={categories.isLoading ? null : (categories.data?.categories || []).length === 0 ? (
+              <RoMobileEmpty hint="Categories appear once businesses are added." />
+            ) : (categories.data?.categories || []).map((c) => (
               <RoMobileCard key={c.category} className="px-6">
                 <span className="flex items-center gap-2">
                   <span className="font-semibold text-[14px] flex-1 min-w-0 truncate">{c.category}</span>
                   <RoTag tone="primary" size="sm">{c.partnered} partnered</RoTag>
                 </span>
-                <span className="grid grid-cols-4 gap-2 mt-2.5">
-                  <RoStat label="Total">{c.total}</RoStat>
-                  <RoStat label="Contacted">{c.contacted}</RoStat>
-                  <RoStat label="Replied">{c.replied}</RoStat>
-                  <RoStat label="Meetings">{c.meetings}</RoStat>
+                <span className="flex flex-wrap gap-x-4 gap-y-1 mt-2">
+                  <RoStat label="total">{c.total}</RoStat>
+                  <RoStat label="contacted">{c.contacted}</RoStat>
+                  <RoStat label="replied">{c.replied}</RoStat>
+                  <RoStat label="meetings">{c.meetings}</RoStat>
                 </span>
               </RoMobileCard>
             ))}
@@ -163,7 +169,9 @@ export default function AnalyticsPage() {
           <Section
             title="Reward supply"
             description="Committed → allocated → issued → redeemed (ledger-audited counters)."
-            mobile={(rewards.data?.rewards || []).map((r) => (
+            mobile={rewards.isLoading ? null : (rewards.data?.rewards || []).length === 0 ? (
+              <RoMobileEmpty hint="Numbers appear once a reward is created." />
+            ) : (rewards.data?.rewards || []).map((r) => (
               <RoMobileCard key={r.id} className="px-6">
                 <span className="flex items-center gap-2">
                   <span className="min-w-0 flex-1">
@@ -172,11 +180,11 @@ export default function AnalyticsPage() {
                   </span>
                   <RoTag tone="primary" size="sm">{r.redemptionRate}% redeemed</RoTag>
                 </span>
-                <span className="grid grid-cols-4 gap-2 mt-2.5">
-                  <RoStat label="Committed">{r.committed}</RoStat>
-                  <RoStat label="Allocated">{r.allocated}</RoStat>
-                  <RoStat label="Issued">{r.issued}</RoStat>
-                  <RoStat label="Redeemed">{r.redeemed}</RoStat>
+                <span className="flex flex-wrap gap-x-4 gap-y-1 mt-2">
+                  <RoStat label="committed">{r.committed}</RoStat>
+                  <RoStat label="allocated">{r.allocated}</RoStat>
+                  <RoStat label="issued">{r.issued}</RoStat>
+                  <RoStat label="redeemed">{r.redeemed}</RoStat>
                 </span>
               </RoMobileCard>
             ))}
@@ -212,7 +220,9 @@ export default function AnalyticsPage() {
           <Section
             title="Activation funnels"
             description="MKTR acquisition + Redeem fulfilment, per activation."
-            mobile={(funnels.data?.funnels || []).map((f) => (
+            mobile={funnels.isLoading ? null : (funnels.data?.funnels || []).length === 0 ? (
+              <RoMobileEmpty hint="Funnels appear once an activation is created." />
+            ) : (funnels.data?.funnels || []).map((f) => (
               <RoMobileCard key={f.id} className="px-6">
                 <span className="flex items-start gap-2">
                   <span className="min-w-0 flex-1">
@@ -223,10 +233,10 @@ export default function AnalyticsPage() {
                   </span>
                   <RoTag tone={f.status} size="sm">{prettyEnum(f.status)}</RoTag>
                 </span>
-                <span className="grid grid-cols-3 gap-2 mt-2.5">
-                  <RoStat label="Leads (MKTR)">{f.acquisition?.totalLeads ?? f.acquisition?.leads ?? '—'}</RoStat>
-                  <RoStat label="Issued">{f.reward.issued}</RoStat>
-                  <RoStat label="Redeemed">{f.reward.redeemed}</RoStat>
+                <span className="flex flex-wrap gap-x-4 gap-y-1 mt-2">
+                  <RoStat label="leads (MKTR)">{f.acquisition?.totalLeads ?? f.acquisition?.leads ?? '—'}</RoStat>
+                  <RoStat label="issued">{f.reward.issued}</RoStat>
+                  <RoStat label="redeemed">{f.reward.redeemed}</RoStat>
                 </span>
                 <span className="block text-[11px] mt-2" style={{ color: 'var(--ro-text-3)' }}>
                   Renewal: {f.renewalOutcome || 'pending'}

--- a/src/pages/redeemops/MyQueue.jsx
+++ b/src/pages/redeemops/MyQueue.jsx
@@ -97,7 +97,7 @@ export default function MyQueue() {
   );
 
   return (
-    <div className="p-6 md:p-8 max-w-6xl mx-auto space-y-6">
+    <div className="p-4 md:p-8 max-w-6xl mx-auto space-y-6">
       <div className="flex flex-wrap items-end justify-between gap-4">
         <div>
           <h1 className="ro-title">{greeting()}, {firstName}</h1>

--- a/src/pages/redeemops/PartnersList.jsx
+++ b/src/pages/redeemops/PartnersList.jsx
@@ -203,7 +203,7 @@ export default function PartnersList() {
     .filter(Boolean).slice(0, 2).join(' · ');
 
   return (
-    <div className="p-6 md:p-8 max-w-6xl mx-auto space-y-5">
+    <div className="p-4 md:p-8 max-w-6xl mx-auto space-y-5">
       <RoPageHeader
         title="Partners"
         sub={pagination ? `${pagination.total} business${pagination.total === 1 ? '' : 'es'} on the books — search before you add, claim before you contact.` : 'The shared business database — search before you add, claim before you contact.'}

--- a/src/pages/redeemops/PoolsPage.jsx
+++ b/src/pages/redeemops/PoolsPage.jsx
@@ -155,7 +155,7 @@ export default function PoolsPage() {
   const pools = poolsQuery.data || [];
 
   return (
-    <div className="p-6 md:p-8 max-w-5xl mx-auto space-y-5">
+    <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-5">
       <RoPageHeader
         title="Prospecting pools"
         sub="Curated prospect lists — hit “Claim next” to pull your next business, no cherry-picking, no collisions."

--- a/src/pages/redeemops/ProfilePage.jsx
+++ b/src/pages/redeemops/ProfilePage.jsx
@@ -46,7 +46,7 @@ export default function ProfilePage() {
   const pwMismatch = pw.next.length > 0 && pw.confirm.length > 0 && pw.next !== pw.confirm;
 
   return (
-    <div className="p-6 md:p-8 max-w-2xl mx-auto space-y-6">
+    <div className="p-4 md:p-8 max-w-2xl mx-auto space-y-6">
       <RoPageHeader title="Your profile" sub="How your name appears to the team, and your sign-in password." />
 
       <div className="rounded-2xl border border-border bg-white p-6">

--- a/src/pages/redeemops/RedeemOpsHome.jsx
+++ b/src/pages/redeemops/RedeemOpsHome.jsx
@@ -33,7 +33,7 @@ export default function RedeemOpsHome() {
   const canSeeRewards = hasCapability(user, 'rewards.view');
 
   return (
-    <div className="p-6 md:p-8 max-w-5xl mx-auto space-y-6">
+    <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-6">
       <RoPageHeader
         title="Redeem Ops"
         sub="Partner prospecting, rewards, and redemption operations."

--- a/src/pages/redeemops/RedeemOpsTeam.jsx
+++ b/src/pages/redeemops/RedeemOpsTeam.jsx
@@ -81,7 +81,7 @@ export default function RedeemOpsTeam() {
   const team = teamQuery.data || [];
 
   return (
-    <div className="p-6 md:p-8 max-w-5xl mx-auto space-y-6">
+    <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-6">
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
           <h1 className="ro-title">Team &amp; access</h1>

--- a/src/pages/redeemops/RedemptionsPage.jsx
+++ b/src/pages/redeemops/RedemptionsPage.jsx
@@ -60,7 +60,7 @@ export default function RedemptionsPage() {
   const redemptions = historyQuery.data?.redemptions || [];
 
   return (
-    <div className="p-6 md:p-8 max-w-5xl mx-auto space-y-5">
+    <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-5">
       <RoPageHeader
         title="Redemptions"
         sub="Verify a voucher, confirm identity, redeem — double redemption is impossible."

--- a/src/pages/redeemops/RewardDetail.jsx
+++ b/src/pages/redeemops/RewardDetail.jsx
@@ -65,7 +65,7 @@ export default function RewardDetail() {
   const remaining = offer.committedQuantity - offer.allocatedQuantity;
 
   return (
-    <div className="p-6 md:p-8 max-w-5xl mx-auto space-y-5">
+    <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-5">
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
           <h1 className="ro-title text-[26px]">{offer.title}</h1>

--- a/src/pages/redeemops/RewardsPage.jsx
+++ b/src/pages/redeemops/RewardsPage.jsx
@@ -64,7 +64,7 @@ export default function RewardsPage() {
   const rewardTypes = constants.data?.rewardTypes || [];
 
   return (
-    <div className="p-6 md:p-8 max-w-6xl mx-auto space-y-5">
+    <div className="p-4 md:p-8 max-w-6xl mx-auto space-y-4 md:space-y-5">
       <RoPageHeader
         title="Rewards"
         sub="Partner-funded reward supply — every quantity movement is ledgered."
@@ -89,11 +89,11 @@ export default function RewardsPage() {
                   </span>
                   <RoTag tone={o.status} size="sm">{prettyEnum(o.status)}</RoTag>
                 </span>
-                <span className="grid grid-cols-4 gap-2 mt-2.5">
-                  <RoStat label="Committed">{o.committedQuantity}</RoStat>
-                  <RoStat label="Allocated">{o.allocatedQuantity}</RoStat>
-                  <RoStat label="Issued">{o.issuedQuantity}</RoStat>
-                  <RoStat label="Redeemed">{o.redeemedQuantity}</RoStat>
+                <span className="flex flex-wrap gap-x-4 gap-y-1 mt-2">
+                  <RoStat label="committed">{o.committedQuantity}</RoStat>
+                  <RoStat label="allocated">{o.allocatedQuantity}</RoStat>
+                  <RoStat label="issued">{o.issuedQuantity}</RoStat>
+                  <RoStat label="redeemed">{o.redeemedQuantity}</RoStat>
                 </span>
               </RoMobileCard>
             ))}

--- a/src/pages/redeemops/TasksPage.jsx
+++ b/src/pages/redeemops/TasksPage.jsx
@@ -174,7 +174,7 @@ export default function TasksPage() {
   const showStatus = view === 'mine' || view === 'team' || view === 'completed';
 
   return (
-    <div className="p-6 md:p-8 max-w-5xl mx-auto space-y-5">
+    <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-5">
       <RoPageHeader
         title="Tasks"
         sub="Your follow-ups across every business — completed ones live in their own tab."


### PR DESCRIPTION
## What

Fixes the mobile UI defects visible on Analytics at 337px: overlapping stat labels ("CONTACTEDREPLIED"), the broken "Avg —h to first touch" string, and hollow cards for empty sections.

## How

Designed first — new card **"Mobile — Analytics & stat pairs"** in the Redeem Ops Design System (Mobile group), including a "Don't" panel showing the shipped mistake.

- **`RoStat` redesigned**: inline **value+label** pair (bold tabular number, lowercase muted label) inside a `flex flex-wrap gap-x-4` row. Pairs wrap to the next line at any viewport width — collision is structurally impossible, unlike fixed `grid-cols-4` with tracked uppercase labels. Applied to all four Analytics sections + Rewards + Activations cards.
- **Missing data drops the line**: the avg-hours foot renders only when `avgHoursToFirstOutreach != null` — never "Avg —h".
- **Empty states**: new `RoMobileEmpty` ("Nothing to show yet" + a hint of what makes numbers appear) renders for empty Analytics sections instead of hollow cards; hidden while loading.
- Consistency: every ops page uses `p-4` mobile padding (`p-8` from md).

## Verify

- eslint 0 errors, vitest 1113 ✅, both production builds ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqCcNpihKgDTQ9YG811btF