### PR TITLE
feat(redeem-ops): admin-managed category taxonomy

### DIFF
--- a/backend/src/controllers/redeemOps/adminController.js
+++ b/backend/src/controllers/redeemOps/adminController.js
@@ -11,6 +11,7 @@ import {
 import { REDEEM_OPS_SUB_ROLES } from '../../services/redeemOps/permissions.js';
 import { SUB_ROLE_LABELS, publicConstants } from '../../services/redeemOps/constants.js';
 import { recordAuditEvent } from '../../services/redeemOps/auditService.js';
+import categoryService from '../../services/redeemOps/categoryService.js';
 
 const TEAM_ATTRIBUTES = [
   'id', 'email', 'firstName', 'lastName', 'fullName',
@@ -220,4 +221,57 @@ export const listAudit = asyncHandler(async (req, res) => {
 /** GET /api/redeem-ops/meta/constants — stages/types/roles/capabilities for the SPA. */
 export const getConstants = asyncHandler(async (req, res) => {
   res.json({ success: true, data: publicConstants() });
+});
+
+// ---- Category taxonomy (migration 052; categoryService owns all writes) ----
+
+const categoryCreateSchema = Joi.object({
+  name: Joi.string().min(1).max(64).required(),
+});
+
+const categoryUpdateSchema = Joi.object({
+  name: Joi.string().min(1).max(64),
+  isActive: Joi.boolean(),
+}).min(1);
+
+const categoryMergeSchema = Joi.object({
+  targetId: Joi.string().uuid().required(),
+});
+
+/** GET /api/redeem-ops/categories — active list for pickers; ?includeInactive=true for Settings. */
+export const listCategories = asyncHandler(async (req, res) => {
+  const categories = await categoryService.listCategories({
+    includeInactive: req.query.includeInactive === 'true',
+  });
+  res.json({ success: true, data: { categories } });
+});
+
+/** POST /api/redeem-ops/categories */
+export const createCategory = asyncHandler(async (req, res) => {
+  const { error, value } = categoryCreateSchema.validate(req.body, { abortEarly: false });
+  if (error) throw new AppError(error.details.map((d) => d.message).join(', '), 400);
+  const category = await categoryService.createCategory(value, req.user, req.id);
+  res.status(201).json({ success: true, data: { category } });
+});
+
+/** PATCH /api/redeem-ops/categories/:id — rename (cascades) and/or retire. */
+export const updateCategory = asyncHandler(async (req, res) => {
+  const { error, value } = categoryUpdateSchema.validate(req.body, { abortEarly: false });
+  if (error) throw new AppError(error.details.map((d) => d.message).join(', '), 400);
+  const category = await categoryService.updateCategory(req.params.id, value, req.user, req.id);
+  res.json({ success: true, data: { category } });
+});
+
+/** POST /api/redeem-ops/categories/:id/merge — consolidate :id into targetId. */
+export const mergeCategory = asyncHandler(async (req, res) => {
+  const { error, value } = categoryMergeSchema.validate(req.body, { abortEarly: false });
+  if (error) throw new AppError(error.details.map((d) => d.message).join(', '), 400);
+  const result = await categoryService.mergeCategory(req.params.id, value, req.user, req.id);
+  res.json({ success: true, data: result });
+});
+
+/** DELETE /api/redeem-ops/categories/:id — unreferenced rows only. */
+export const deleteCategory = asyncHandler(async (req, res) => {
+  const result = await categoryService.deleteCategory(req.params.id, req.user, req.id);
+  res.json({ success: true, data: result });
 });

--- a/backend/src/database/migrations/052-redeem-ops-categories.js
+++ b/backend/src/database/migrations/052-redeem-ops-categories.js
@@ -1,0 +1,59 @@
+/**
+ * 052 — Admin-managed category taxonomy (redeem_ops_categories).
+ *
+ * Partner/pool/reward `category` stays a STRING column (house style, constants.js),
+ * but writes are now validated against this admin-curated list. Seeded from every
+ * distinct value already live in the three tables so day-one behaviour is unchanged;
+ * admins then rename/merge/retire from the Settings UI.
+ *
+ * Guarded + idempotent like 045–051; safe under NODE_ENV=test where sync() has
+ * already created the table (createTable skipped, index IF NOT EXISTS, seed no-ops).
+ */
+export async function up(queryInterface, Sequelize) {
+  const q = async (sql) => queryInterface.sequelize.query(sql);
+  const tables = await queryInterface.showAllTables();
+
+  if (!tables.includes('redeem_ops_categories')) {
+    await queryInterface.createTable('redeem_ops_categories', {
+      // DB-side default (unlike the app-side UUIDV4 house norm) so the seed INSERT
+      // below can omit id. Precedent: migration 021. PG15 everywhere → built-in.
+      id: { type: Sequelize.UUID, primaryKey: true, allowNull: false, defaultValue: Sequelize.literal('gen_random_uuid()') },
+      name: { type: Sequelize.STRING(64), allowNull: false },
+      isActive: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: true },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    });
+  }
+
+  // Case-insensitive uniqueness. Functional index, NOT a constraint — so any
+  // ON CONFLICT against it must use the bare form (no ON CONSTRAINT).
+  await q(`CREATE UNIQUE INDEX IF NOT EXISTS uq_redeem_ops_categories_name_ci
+             ON redeem_ops_categories (LOWER(name))`);
+
+  // One-time normalization: padded/blank legacy values would otherwise dodge the
+  // rename/merge cascades (which match on the stored string) forever.
+  for (const table of ['partner_organisations', 'prospecting_pools', 'reward_offers']) {
+    await q(`UPDATE ${table}
+                SET category = NULLIF(TRIM(category), '')
+              WHERE category IS NOT NULL
+                AND category IS DISTINCT FROM NULLIF(TRIM(category), '')`);
+  }
+
+  // Seed: one row per distinct value across the three tables; the most frequent
+  // casing wins deterministically (mode() breaks ties by its ORDER BY).
+  await q(`INSERT INTO redeem_ops_categories (name)
+           SELECT mode() WITHIN GROUP (ORDER BY category)
+             FROM (
+                   SELECT category FROM partner_organisations WHERE category IS NOT NULL
+                   UNION ALL
+                   SELECT category FROM prospecting_pools WHERE category IS NOT NULL
+                   UNION ALL
+                   SELECT category FROM reward_offers WHERE category IS NOT NULL
+                  ) s
+            GROUP BY LOWER(category)
+               ON CONFLICT DO NOTHING`);
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query('DROP TABLE IF EXISTS redeem_ops_categories');
+}

--- a/backend/src/models/RedeemOpsCategory.js
+++ b/backend/src/models/RedeemOpsCategory.js
@@ -1,0 +1,23 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Admin-curated business-vertical taxonomy for Redeem Ops (migration 052).
+ * Partner/pool/reward `category` columns stay plain strings; categoryService
+ * validates writes against the active rows here. Retire via isActive=false —
+ * hard delete is only allowed while nothing references the name.
+ */
+const RedeemOpsCategory = sequelize.define('RedeemOpsCategory', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  name: { type: DataTypes.STRING(64), allowNull: false },
+  isActive: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+}, {
+  tableName: 'redeem_ops_categories',
+  indexes: [
+    // Same name as migration 052's index so NODE_ENV=test sync() and the
+    // migration's IF NOT EXISTS never create duplicates.
+    { name: 'uq_redeem_ops_categories_name_ci', unique: true, fields: [sequelize.fn('lower', sequelize.col('name'))] },
+  ],
+});
+
+export default RedeemOpsCategory;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -282,7 +282,7 @@ export const {
   OutreachTask, ProspectingPool, ProspectingPoolMember, RewardOffer,
   RewardTermsVersion, RewardOfferLocation, RewardInventoryEvent,
   PartnerOnboardingItem, Activation, RewardEntitlement, Redemption,
-  RedemptionEvent
+  RedemptionEvent, RedeemOpsCategory
 } = models;
 
 export { sequelize };

--- a/backend/src/routes/redeemOpsAdmin.js
+++ b/backend/src/routes/redeemOpsAdmin.js
@@ -30,4 +30,12 @@ router.get('/audit', requireRedeemOps('audit.view'), ctrl.listAudit);
 // Domain constants (any authenticated Redeem Ops principal)
 router.get('/meta/constants', requireRedeemOps(), ctrl.getConstants);
 
+// Category taxonomy — read for every principal (feeds pickers; all sub-roles
+// already see category on partner rows via partners.view), writes admin-only.
+router.get('/categories', requireRedeemOps(), ctrl.listCategories);
+router.post('/categories', requireRedeemOps('settings.manage'), ctrl.createCategory);
+router.patch('/categories/:id', requireRedeemOps('settings.manage'), ctrl.updateCategory);
+router.post('/categories/:id/merge', requireRedeemOps('settings.manage'), ctrl.mergeCategory);
+router.delete('/categories/:id', requireRedeemOps('settings.manage'), ctrl.deleteCategory);
+
 export default router;

--- a/backend/src/services/redeemOps/categoryService.js
+++ b/backend/src/services/redeemOps/categoryService.js
@@ -1,0 +1,218 @@
+import { Op } from 'sequelize';
+import { RedeemOpsCategory, sequelize } from '../../models/index.js';
+import { AppError } from '../../middleware/errorHandler.js';
+import { makeRedeemOpsAuditService } from './auditService.js';
+
+/**
+ * Admin-managed category taxonomy (migration 052). The three consuming columns
+ * stay plain strings; this service is the only writer of the taxonomy and the
+ * shared validator for every category write path (partner/pool/reward create+update).
+ *
+ * Consolidating seeded variants ("Nails" → "Nail Salon") is the primary admin job,
+ * so merge is first-class: rename refuses to collide (409) and points here instead.
+ *
+ * Concurrency stance: validate-then-commit, no locks. A save that validated against
+ * a name mid-rename can land the old string — harmless (strings, not FKs) and
+ * self-healing: rename/merge cascades are idempotent re-runnable UPDATEs.
+ */
+const CATEGORY_TABLES = ['partner_organisations', 'prospecting_pools', 'reward_offers'];
+
+// analyticsService folds NULL categories into the literal 'Uncategorised'; a real
+// category with that name would silently merge with the null bucket.
+const RESERVED_NAMES = ['uncategorised', 'uncategorized'];
+
+export function makeCategoryService(overrides = {}) {
+  const d = {
+    RedeemOpsCategory, sequelize, audit: makeRedeemOpsAuditService(), ...overrides,
+  };
+
+  function cleanName(raw) {
+    const name = String(raw ?? '').trim();
+    if (!name) throw new AppError('Category name is required', 400);
+    if (name.length > 64) throw new AppError('Category name must be 64 characters or fewer', 400);
+    if (RESERVED_NAMES.includes(name.toLowerCase())) {
+      throw new AppError(`'${name}' is reserved for records with no category`, 400);
+    }
+    return name;
+  }
+
+  function whereNameCi(name) {
+    return d.sequelize.where(d.sequelize.fn('LOWER', d.sequelize.col('name')), name.toLowerCase());
+  }
+
+  async function listCategories({ includeInactive = false } = {}) {
+    return d.RedeemOpsCategory.findAll({
+      where: includeInactive ? {} : { isActive: true },
+      order: [[d.sequelize.fn('LOWER', d.sequelize.col('name')), 'ASC']],
+    });
+  }
+
+  async function createCategory(body, user, requestId = null) {
+    const name = cleanName(body?.name);
+    const existing = await d.RedeemOpsCategory.findOne({ where: whereNameCi(name) });
+    if (existing) throw new AppError(`Category '${existing.name}' already exists`, 409);
+    try {
+      const category = await d.RedeemOpsCategory.create({ name });
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'settings.category_created',
+        entityType: 'redeem_ops_category', entityId: category.id,
+        after: { name }, requestId,
+      });
+      return category;
+    } catch (err) {
+      // The DB functional index backstops a create/create race; NODE_ENV=test DBs
+      // are sync()-built and may lack it, which is why the findOne above is the
+      // authoritative check rather than a fast path.
+      if (err?.name === 'SequelizeUniqueConstraintError') {
+        throw new AppError(`Category '${name}' already exists`, 409);
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Rename and/or (de)activate. Rename cascades the string onto every consuming
+   * row so analytics grouping and the ?category= filter stay coherent. Renaming
+   * onto a DIFFERENT existing name is refused — that operation is mergeCategory.
+   * Case-only renames of the same category are allowed (canonical casing fix).
+   */
+  async function updateCategory(id, body, user, requestId = null) {
+    const category = await d.RedeemOpsCategory.findByPk(id);
+    if (!category) throw new AppError('Category not found', 404);
+
+    const updates = {};
+    let cascade = null;
+    if (body?.name !== undefined) {
+      const newName = cleanName(body.name);
+      if (newName !== category.name) {
+        const clash = await d.RedeemOpsCategory.findOne({ where: whereNameCi(newName) });
+        if (clash && clash.id !== category.id) {
+          throw new AppError(`'${clash.name}' already exists — merge into it instead`, 409);
+        }
+        cascade = { from: category.name, to: newName };
+        updates.name = newName;
+      }
+    }
+    if (body?.isActive !== undefined) updates.isActive = !!body.isActive;
+    if (Object.keys(updates).length === 0) return category;
+
+    const before = { name: category.name, isActive: category.isActive };
+    await d.sequelize.transaction(async (t) => {
+      await category.update(updates, { transaction: t });
+      if (cascade) {
+        for (const table of CATEGORY_TABLES) {
+          await d.sequelize.query(
+            `UPDATE ${table} SET category = :to WHERE LOWER(category) = LOWER(:from)`,
+            { replacements: cascade, transaction: t }
+          );
+        }
+      }
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'settings.category_updated',
+        entityType: 'redeem_ops_category', entityId: category.id,
+        before, after: { ...before, ...updates }, requestId, transaction: t,
+      });
+    });
+    return category;
+  }
+
+  /**
+   * Consolidate: move every row carrying the source name onto the target's
+   * canonical name, then delete the source. The only way to defragment seeded
+   * variants — delete refuses while referenced and rename refuses to collide.
+   */
+  async function mergeCategory(id, body, user, requestId = null) {
+    const targetId = body?.targetId;
+    if (!targetId) throw new AppError('targetId is required', 400);
+    if (String(targetId) === String(id)) throw new AppError('Cannot merge a category into itself', 400);
+
+    const [source, target] = await Promise.all([
+      d.RedeemOpsCategory.findByPk(id),
+      d.RedeemOpsCategory.findByPk(targetId),
+    ]);
+    if (!source || !target) throw new AppError('Category not found', 404);
+    if (!target.isActive) throw new AppError('Cannot merge into a retired category', 400);
+
+    let rowsMoved = 0;
+    await d.sequelize.transaction(async (t) => {
+      for (const table of CATEGORY_TABLES) {
+        const [, meta] = await d.sequelize.query(
+          `UPDATE ${table} SET category = :to WHERE LOWER(category) = LOWER(:from)`,
+          { replacements: { from: source.name, to: target.name }, transaction: t }
+        );
+        rowsMoved += meta?.rowCount ?? 0;
+      }
+      await source.destroy({ transaction: t });
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'settings.category_merged',
+        entityType: 'redeem_ops_category', entityId: source.id,
+        before: { name: source.name },
+        after: { mergedInto: target.name, targetId: target.id, rowsMoved },
+        requestId, transaction: t,
+      });
+    });
+    return { rowsMoved, target };
+  }
+
+  /** Hard delete — only for unreferenced rows (just-created typos). */
+  async function deleteCategory(id, user, requestId = null) {
+    const category = await d.RedeemOpsCategory.findByPk(id);
+    if (!category) throw new AppError('Category not found', 404);
+
+    await d.sequelize.transaction(async (t) => {
+      let refs = 0;
+      for (const table of CATEGORY_TABLES) {
+        const [[row]] = await d.sequelize.query(
+          `SELECT COUNT(*)::int AS count FROM ${table} WHERE LOWER(category) = LOWER(:name)`,
+          { replacements: { name: category.name }, transaction: t }
+        );
+        refs += row?.count ?? 0;
+      }
+      if (refs > 0) {
+        throw new AppError(`'${category.name}' is used by ${refs} record(s) — merge or retire it instead`, 409);
+      }
+      await category.destroy({ transaction: t });
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'settings.category_deleted',
+        entityType: 'redeem_ops_category', entityId: category.id,
+        before: { name: category.name }, requestId, transaction: t,
+      });
+    });
+    return { deleted: true };
+  }
+
+  /**
+   * Shared write-time validator for partner/pool/reward category writes.
+   *
+   * - undefined → undefined (field absent; update loops skip it, creates coalesce to null)
+   * - blank → null (explicit clear; renders as "Uncategorised")
+   * - equals the row's CURRENT stored value (case-insensitive) → passed through
+   *   unchanged, even if retired/legacy — an admin rename must never 422 an
+   *   unrelated edit (PartnerDetail sends category on every save)
+   * - matches an ACTIVE category case-insensitively → canonical stored casing
+   * - otherwise → 422 telling the user who can fix it
+   */
+  async function resolveCategoryName(input, { currentValue = undefined } = {}) {
+    if (input === undefined) return undefined;
+    const name = String(input ?? '').trim();
+    if (!name) return null;
+    if (currentValue && name.toLowerCase() === String(currentValue).trim().toLowerCase()) {
+      return currentValue;
+    }
+    const match = await d.RedeemOpsCategory.findOne({
+      where: { [Op.and]: [whereNameCi(name), { isActive: true }] },
+    });
+    if (!match) {
+      throw new AppError(`Unknown category '${name}' — ask an admin to add it in Settings`, 422);
+    }
+    return match.name;
+  }
+
+  return {
+    listCategories, createCategory, updateCategory, mergeCategory, deleteCategory,
+    resolveCategoryName,
+  };
+}
+
+const _default = makeCategoryService();
+export default _default;

--- a/backend/src/services/redeemOps/partnerService.js
+++ b/backend/src/services/redeemOps/partnerService.js
@@ -16,6 +16,7 @@ import {
   ACTIVITY_TYPES, MEANINGFUL_ACTIVITY_TYPES, LOST_REASONS,
 } from './constants.js';
 import { makeOnboardingService } from './onboardingService.js';
+import { makeCategoryService } from './categoryService.js';
 
 /**
  * Partner CRM core (docs/redeem-ops/ERD.md §3.1–3.6, brief §13–§18).
@@ -30,6 +31,7 @@ export function makePartnerService(overrides = {}) {
     RedeemOpsAuditEvent, User, sequelize, logger,
     audit: makeRedeemOpsAuditService(),
     dedupe: makeDedupeService(),
+    categories: makeCategoryService(),
     // PARTNERED → seed the onboarding checklist (brief §22); injectable for tests.
     onPartnered: (partner, _user, t) => makeOnboardingService().seedChecklist(partner.id, t),
     ...overrides,
@@ -126,6 +128,7 @@ export function makePartnerService(overrides = {}) {
     }
     const keys = deriveMatchingKeys(body);
     if (!keys.normalizedName) throw new AppError('Business name is required', 400);
+    const category = (await d.categories.resolveCategoryName(body.category)) ?? null;
 
     const { exact, potential } = await d.dedupe.findDuplicates(body);
     const overrideReason = body.overrideReason && String(body.overrideReason).trim();
@@ -150,7 +153,7 @@ export function makePartnerService(overrides = {}) {
           primaryEmail: body.primaryEmail ? String(body.primaryEmail).toLowerCase() : null,
           facebookUrl: body.facebookUrl || null,
           linkedinUrl: body.linkedinUrl || null,
-          category: body.category || null,
+          category,
           subcategory: body.subcategory || null,
           source: body.source || 'manual',
           tags: Array.isArray(body.tags) ? body.tags : [],
@@ -162,7 +165,7 @@ export function makePartnerService(overrides = {}) {
       await d.audit.recordAuditEvent({
         actorUser: user, action: 'partner.created', entityType: 'partner_organisation',
         entityId: created.id,
-        after: { name: displayNameOf(body), category: body.category || null },
+        after: { name: displayNameOf(body), category },
         reason: overrideReason || null, requestId, transaction: t,
       });
       return created;
@@ -184,6 +187,13 @@ export function makePartnerService(overrides = {}) {
     }
     const updates = {};
     for (const f of EDITABLE_FIELDS) if (body[f] !== undefined) updates[f] = body[f];
+    if (updates.category !== undefined) {
+      // currentValue pass-through: an admin rename/retire must never 422 an
+      // unrelated edit (the SPA sends category on every save).
+      updates.category = await d.categories.resolveCategoryName(updates.category, {
+        currentValue: partner.category,
+      });
+    }
     // Re-derive matching keys from the merged view so they never drift
     const merged = { ...partner.toJSON(), ...updates };
     Object.assign(updates, deriveMatchingKeys(merged));

--- a/backend/src/services/redeemOps/permissions.js
+++ b/backend/src/services/redeemOps/permissions.js
@@ -60,6 +60,7 @@ export const CAPABILITIES = [
   'exports.run',
   'audit.view',
   'team.manage_access',
+  'settings.manage',
 ];
 
 const ALL = [...CAPABILITIES];

--- a/backend/src/services/redeemOps/poolService.js
+++ b/backend/src/services/redeemOps/poolService.js
@@ -5,6 +5,7 @@ import {
 import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';
 import { makeClaimService } from './claimService.js';
+import { makeCategoryService } from './categoryService.js';
 
 /**
  * Prospecting pools + Claim Next (docs/redeem-ops/ERD.md §3.8–3.9, brief §21).
@@ -17,7 +18,7 @@ import { makeClaimService } from './claimService.js';
 export function makePoolService(overrides = {}) {
   const d = {
     ProspectingPool, ProspectingPoolMember, PartnerOrganisation, sequelize, logger,
-    claims: makeClaimService(), ...overrides,
+    claims: makeClaimService(), categories: makeCategoryService(), ...overrides,
   };
 
   async function createPool(body, user) {
@@ -25,7 +26,7 @@ export function makePoolService(overrides = {}) {
     return d.ProspectingPool.create({
       name: String(body.name).trim(),
       description: body.description || null,
-      category: body.category || null,
+      category: (await d.categories.resolveCategoryName(body.category)) ?? null,
       area: body.area || null,
       createdBy: user.id,
     });
@@ -52,6 +53,11 @@ export function makePoolService(overrides = {}) {
     const updates = {};
     for (const f of ['name', 'description', 'category', 'area', 'isActive']) {
       if (body[f] !== undefined) updates[f] = body[f];
+    }
+    if (updates.category !== undefined) {
+      updates.category = await d.categories.resolveCategoryName(updates.category, {
+        currentValue: pool.category,
+      });
     }
     await pool.update(updates);
     return pool;

--- a/backend/src/services/redeemOps/rewardService.js
+++ b/backend/src/services/redeemOps/rewardService.js
@@ -7,6 +7,7 @@ import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';
 import { makeRedeemOpsAuditService } from './auditService.js';
 import { makeInventoryService } from './inventoryService.js';
+import { makeCategoryService } from './categoryService.js';
 import { REWARD_TYPES } from './constants.js';
 
 const OFFER_STATUSES = ['draft', 'active', 'paused', 'ended'];
@@ -19,6 +20,7 @@ export function makeRewardService(overrides = {}) {
     PartnerOrganisation, PartnerLocation, User, sequelize, logger,
     audit: makeRedeemOpsAuditService(),
     inventory: makeInventoryService(),
+    categories: makeCategoryService(),
     ...overrides,
   };
 
@@ -72,6 +74,11 @@ export function makeRewardService(overrides = {}) {
     const committed = Number.isInteger(body.committedQuantity) && body.committedQuantity > 0
       ? body.committedQuantity : 0;
 
+    // Explicit category is validated; the partner.category fallback is copied
+    // as-is even if retired — a known name that must never block offer creation.
+    const category = (await d.categories.resolveCategoryName(body.category))
+      ?? partner.category ?? null;
+
     return d.sequelize.transaction(async (t) => {
       const offer = await d.RewardOffer.create(
         {
@@ -80,7 +87,7 @@ export function makeRewardService(overrides = {}) {
           publicTitle: body.publicTitle || null,
           internalRef: body.internalRef || null,
           description: body.description || null,
-          category: body.category || partner.category || null,
+          category,
           rewardType: body.rewardType || 'free_service',
           retailValue: body.retailValue ?? null,
           fulfilmentCost: body.fulfilmentCost ?? null,
@@ -124,6 +131,11 @@ export function makeRewardService(overrides = {}) {
     validateEnumFields(body);
     const updates = {};
     for (const f of EDITABLE) if (body[f] !== undefined) updates[f] = body[f];
+    if (updates.category !== undefined) {
+      updates.category = await d.categories.resolveCategoryName(updates.category, {
+        currentValue: offer.category,
+      });
+    }
     const before = {};
     for (const k of Object.keys(updates)) before[k] = offer.get(k);
 

--- a/backend/test/helpers.js
+++ b/backend/test/helpers.js
@@ -2,7 +2,7 @@ import express from 'express';
 import jwt from 'jsonwebtoken';
 import { init } from '../src/server_internal.js';
 import { sequelize } from '../src/database/connection.js';
-import { User, Campaign, Commission, Prospect, FleetOwner, Car, QrTag, AgentGroup, AgentGroupMember, Attribution, QrScan, LeadPackage, LeadPackageAssignment } from '../src/models/index.js';
+import { User, Campaign, Commission, Prospect, FleetOwner, Car, QrTag, AgentGroup, AgentGroupMember, Attribution, QrScan, LeadPackage, LeadPackageAssignment, RedeemOpsCategory } from '../src/models/index.js';
 
 const JWT_SECRET = process.env.JWT_SECRET;
 let _app = null;
@@ -248,4 +248,17 @@ export async function createTestLeadPackageAssignment(agentId, packageId, overri
     purchaseDate: overrides.purchaseDate || new Date(),
     ...overrides
   });
+}
+
+/**
+ * Seed a Redeem Ops category (migration 052 taxonomy). Category writes are now
+ * validated against this table, so any test that creates a partner/pool/reward
+ * with a category must seed it first. Idempotent (case-insensitive).
+ */
+export async function seedRedeemOpsCategory(name, overrides = {}) {
+  const [category] = await RedeemOpsCategory.findOrCreate({
+    where: { name },
+    defaults: { name, isActive: true, ...overrides },
+  });
+  return category;
 }

--- a/backend/test/redeemOpsCategories.test.js
+++ b/backend/test/redeemOpsCategories.test.js
@@ -1,0 +1,211 @@
+/**
+ * Redeem Ops admin-managed category taxonomy (migration 052).
+ * Covers: capability gating (settings.manage), create validation (ci-dup,
+ * reserved name), write-path enforcement (unknown → 422, canonicalized casing),
+ * rename cascade onto consuming rows, rename-collision → 409, currentValue
+ * pass-through (a retired category must not brick unrelated partner edits),
+ * merge (cascade + source deletion), and the delete reference guard.
+ */
+process.env.REDEEM_OPS_ENABLED = 'true'; // must be set before getApp() mounts routes
+
+import request from 'supertest';
+import { getApp, closeDb, createTestUser } from './helpers.js';
+import { RedeemOpsCategory, PartnerOrganisation } from '../src/models/index.js';
+
+let app;
+let admin, bdm, exec;
+
+beforeAll(async () => {
+  app = await getApp();
+  admin = await createTestUser({ role: 'admin' }); // implicit super_admin
+  bdm = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'bdm' });
+  exec = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+const auth = (t) => ({ Authorization: `Bearer ${t}` });
+let nameSeq = 0;
+const uniq = (base) => `${base} ${Date.now()}-${++nameSeq}`;
+
+const createCategory = (token, name) =>
+  request(app).post('/api/redeem-ops/categories').set(auth(token)).send({ name });
+const createPartner = (token, body) =>
+  request(app).post('/api/redeem-ops/partners').set(auth(token)).send(body);
+const updatePartner = (token, id, body) =>
+  request(app).put(`/api/redeem-ops/partners/${id}`).set(auth(token)).send(body);
+
+describe('read access', () => {
+  test('any Redeem Ops principal can list categories (feeds pickers)', async () => {
+    const res = await request(app).get('/api/redeem-ops/categories').set(auth(exec.token));
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data.categories)).toBe(true);
+  });
+});
+
+describe('create + capability gate', () => {
+  test('bdm lacks settings.manage → 403; admin creates → 201', async () => {
+    const name = uniq('Pet Grooming');
+    expect((await createCategory(bdm.token, name)).status).toBe(403);
+
+    const ok = await createCategory(admin.token, name);
+    expect(ok.status).toBe(201);
+    expect(ok.body.data.category.name).toBe(name);
+  });
+
+  test('case-insensitive duplicate → 409', async () => {
+    const name = uniq('Yoga Studio');
+    expect((await createCategory(admin.token, name)).status).toBe(201);
+    const dup = await createCategory(admin.token, name.toUpperCase());
+    expect(dup.status).toBe(409);
+  });
+
+  test("reserved 'Uncategorised' → 400 (collides with the analytics null bucket)", async () => {
+    expect((await createCategory(admin.token, 'Uncategorised')).status).toBe(400);
+    expect((await createCategory(admin.token, 'uncategorized')).status).toBe(400);
+  });
+});
+
+describe('write-path enforcement', () => {
+  test('partner create with an unknown category → 422', async () => {
+    const res = await createPartner(exec.token, {
+      tradingName: uniq('Ghost Spa'),
+      category: 'Definitely Not A Real Category',
+    });
+    expect(res.status).toBe(422);
+  });
+
+  test('known category is accepted and canonicalized to stored casing', async () => {
+    const canonical = uniq('Barbershop');
+    expect((await createCategory(admin.token, canonical)).status).toBe(201);
+
+    const res = await createPartner(exec.token, {
+      tradingName: uniq('Fades Co'),
+      category: canonical.toLowerCase(), // different casing on the way in
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.data.partner.category).toBe(canonical); // stored casing wins
+  });
+
+  test('blank category is allowed (stays null)', async () => {
+    const res = await createPartner(exec.token, { tradingName: uniq('No Cat Co'), category: '' });
+    expect(res.status).toBe(201);
+    expect(res.body.data.partner.category).toBeNull();
+  });
+});
+
+describe('rename cascade', () => {
+  test('renaming a category rewrites every consuming partner row', async () => {
+    const from = uniq('Naadi');
+    const created = await createCategory(admin.token, from);
+    const categoryId = created.body.data.category.id;
+
+    const partnerRes = await createPartner(exec.token, { tradingName: uniq('Naadi Bliss'), category: from });
+    const partnerId = partnerRes.body.data.partner.id;
+
+    const to = uniq('Nail Salon');
+    const rename = await request(app)
+      .patch(`/api/redeem-ops/categories/${categoryId}`)
+      .set(auth(admin.token))
+      .send({ name: to });
+    expect(rename.status).toBe(200);
+
+    const partner = await PartnerOrganisation.findByPk(partnerId);
+    expect(partner.category).toBe(to);
+  });
+
+  test('renaming onto an existing name → 409 (must merge instead)', async () => {
+    const a = uniq('Massage');
+    const b = uniq('Spa');
+    const createdA = await createCategory(admin.token, a);
+    await createCategory(admin.token, b);
+
+    const res = await request(app)
+      .patch(`/api/redeem-ops/categories/${createdA.body.data.category.id}`)
+      .set(auth(admin.token))
+      .send({ name: b });
+    expect(res.status).toBe(409);
+  });
+});
+
+describe('currentValue pass-through', () => {
+  test('a retired category does not block an unrelated edit on a partner that still has it', async () => {
+    const name = uniq('Florist');
+    const created = await createCategory(admin.token, name);
+    const categoryId = created.body.data.category.id;
+
+    const partnerRes = await createPartner(exec.token, { tradingName: uniq('Petal Co'), category: name });
+    const partnerId = partnerRes.body.data.partner.id;
+
+    // Retire the category — it leaves the active list / pickers.
+    const retire = await request(app)
+      .patch(`/api/redeem-ops/categories/${categoryId}`)
+      .set(auth(admin.token))
+      .send({ isActive: false });
+    expect(retire.status).toBe(200);
+
+    // Editing an unrelated field must still succeed: the SPA sends category on
+    // every save, and its unchanged (now-retired) value passes through. (admin
+    // edits any row — this isolates category validation from ownership scoping.)
+    const edit = await updatePartner(admin.token, partnerId, {
+      tradingName: 'Petal Co Renamed',
+      category: name,
+      notes: 'touched an unrelated field',
+    });
+    expect(edit.status).toBe(200);
+
+    const partner = await PartnerOrganisation.findByPk(partnerId);
+    expect(partner.category).toBe(name); // retained, not nulled or rejected
+  });
+});
+
+describe('merge', () => {
+  test('merge moves consuming rows to the target and deletes the source', async () => {
+    const source = uniq('Nails');
+    const target = uniq('Nail Bar');
+    const createdSource = await createCategory(admin.token, source);
+    const createdTarget = await createCategory(admin.token, target);
+
+    const partnerRes = await createPartner(exec.token, { tradingName: uniq('Tips Co'), category: source });
+    const partnerId = partnerRes.body.data.partner.id;
+
+    const res = await request(app)
+      .post(`/api/redeem-ops/categories/${createdSource.body.data.category.id}/merge`)
+      .set(auth(admin.token))
+      .send({ targetId: createdTarget.body.data.category.id });
+    expect(res.status).toBe(200);
+    expect(res.body.data.rowsMoved).toBeGreaterThanOrEqual(1);
+
+    const partner = await PartnerOrganisation.findByPk(partnerId);
+    expect(partner.category).toBe(target);
+    expect(await RedeemOpsCategory.findByPk(createdSource.body.data.category.id)).toBeNull();
+  });
+
+  test('merging a category into itself → 400', async () => {
+    const created = await createCategory(admin.token, uniq('Cafe'));
+    const id = created.body.data.category.id;
+    const res = await request(app)
+      .post(`/api/redeem-ops/categories/${id}/merge`)
+      .set(auth(admin.token))
+      .send({ targetId: id });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('delete reference guard', () => {
+  test('unreferenced category deletes; referenced one → 409', async () => {
+    const unused = await createCategory(admin.token, uniq('Unused'));
+    expect((await request(app)
+      .delete(`/api/redeem-ops/categories/${unused.body.data.category.id}`)
+      .set(auth(admin.token))).status).toBe(200);
+
+    const used = await createCategory(admin.token, uniq('Used'));
+    await createPartner(exec.token, { tradingName: uniq('User Co'), category: used.body.data.category.name });
+    const res = await request(app)
+      .delete(`/api/redeem-ops/categories/${used.body.data.category.id}`)
+      .set(auth(admin.token));
+    expect(res.status).toBe(409);
+  });
+});

--- a/backend/test/redeemOpsPartners.test.js
+++ b/backend/test/redeemOpsPartners.test.js
@@ -7,7 +7,7 @@
 process.env.REDEEM_OPS_ENABLED = 'true';
 
 import request from 'supertest';
-import { getApp, closeDb, createTestUser } from './helpers.js';
+import { getApp, closeDb, createTestUser, seedRedeemOpsCategory } from './helpers.js';
 import {
   PartnerOrganisation, PartnerContact, OutreachActivity,
 } from '../src/models/index.js';
@@ -22,6 +22,9 @@ beforeAll(async () => {
   execA = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
   execB = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
   bdm = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'bdm' });
+  // Category writes validate against the taxonomy (migration 052); seed the one
+  // this suite uses so partner creation isn't rejected as an unknown category.
+  await seedRedeemOpsCategory('Nail Salon');
 });
 
 afterAll(async () => {

--- a/docs/redeem-ops/ERD.md
+++ b/docs/redeem-ops/ERD.md
@@ -291,7 +291,24 @@ id; actorUserId NULL FK SET NULL; actorType STRING(16) default 'staff'; action S
 after JSONB NULL; reason STRING(255) NULL; requestId STRING(64) NULL (from `requestId` middleware).
 Indexes: `(entityType, entityId, createdAt)`, `(actorUserId, createdAt)`, `(action, createdAt)`.
 
-### 3.20 Future (designed, not in V1 migrations)
+### 3.20 `redeem_ops_categories` (`RedeemOpsCategory`) — admin-managed taxonomy (migration 052)
+
+id UUID PK (DB-default `gen_random_uuid()` — the seed INSERT omits id; PG15 built-in);
+name STRING(64) NOT NULL; isActive BOOLEAN NOT NULL default true; timestamps.
+Unique functional index `uq_redeem_ops_categories_name_ci` on `LOWER(name)` (case-insensitive).
+
+The single business-vertical taxonomy shared by `partner_organisations.category`,
+`prospecting_pools.category`, and `reward_offers.category` — those stay plain STRING columns
+(house style: STRING + app-level lists, not FKs/enums), but `categoryService.resolveCategoryName`
+validates every write against the **active** rows here (unknown → 422; a row's unchanged current
+value always passes so an admin rename/retire never breaks an unrelated edit; blank → NULL, shown
+as "Uncategorised"). Curated only by `settings.manage` (super_admin/ops_admin): rename cascades the
+string onto all three tables; merge cascades then deletes the source (the sole way to consolidate
+seeded variants — rename-into-existing is refused 409); delete is allowed only while unreferenced.
+Migration 052 TRIM-normalizes the three columns then seeds one row per distinct value (`mode()`
+picks the most-frequent casing). `'Uncategorised'` is a reserved name.
+
+### 3.21 Future (designed, not in V1 migrations)
 
 `partner_import_batches` + `partner_import_rows` (CSV import, brief §32);
 `partner_users` (portal principals — see `RECOMMENDED_ARCHITECTURE.md` §7).

--- a/docs/redeem-ops/PERMISSION_MATRIX.md
+++ b/docs/redeem-ops/PERMISSION_MATRIX.md
@@ -60,6 +60,7 @@ Legend: ✓ full · O = own/owned-records only · — = no.
 | `exports.run` | ✓ | ✓ | ✓ | — | — | — | ✓ |
 | `audit.view` | ✓ | ✓ | — | — | — | — | — |
 | `team.manage_access` (grant sub-roles, invite staff) | ✓ | — | — | — | — | — | — |
+| `settings.manage` (category taxonomy: create/rename/merge/retire) | ✓ | ✓ | — | — | — | — | — |
 
 "O (own)" is a **row-level** check: `partner_organisations.ownerUserId === req.user.id`
 (or task `assigneeUserId`). Implemented in services, not just middleware.

--- a/docs/redeem-ops/ROUTE_MAP.md
+++ b/docs/redeem-ops/ROUTE_MAP.md
@@ -99,6 +99,9 @@ contradict the guard). Also future: `/api/partner-portal/*` namespace (separate 
 | POST `/team/invite` · PATCH `/team/:userId/role` | team.manage_access |
 | GET `/audit` (filter by entity/actor/action/date) | audit.view |
 | GET `/meta/constants` (stages, activity types, reward types — the constants module, so SPA and API can't drift) | any authenticated redeem-ops user |
+| GET `/categories` (`?includeInactive=true` for Settings) — admin-managed taxonomy; feeds partner/pool/reward pickers | any authenticated redeem-ops user |
+| POST `/categories` · PATCH `/categories/:id` (rename cascades onto rows; retire via `isActive`) | settings.manage |
+| POST `/categories/:id/merge` (consolidate a variant into another; cascade + delete source) · DELETE `/categories/:id` (unreferenced only) | settings.manage |
 
 ## 2. SPA pages (`src/pages/redeemops/`, routes in `src/pages/index.jsx`)
 
@@ -122,7 +125,7 @@ build as the whole app; never in the consumer `redeem` build. All wrapped in
 | `/redeem-ops/analytics` | Analytics (outreach/category/reward/activation) | 7 | Insights |
 | `/redeem-ops/team` | Team & access | 1 | Admin |
 | `/redeem-ops/audit` | Audit log | 1 (write) / 2 (UI) | Admin |
-| `/redeem-ops/settings` | Settings (stale thresholds display; config later) | later | Admin |
+| `/redeem-ops/settings` | Settings (category taxonomy: add/rename/merge/retire; more config later) | 8 | Admin |
 
 Not-yet-built modules stay **out of the nav** (brief §30) rather than shipping as placeholders.
 

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -39,6 +39,28 @@ export const redeemOpsApi = {
     return res.data;
   },
 
+  // ── Category taxonomy (admin-managed; feeds pickers everywhere) ────────
+  async listCategories(params = {}) {
+    const res = await apiClient.get('/redeem-ops/categories', params);
+    return res.data?.categories || [];
+  },
+  async createCategory(body) {
+    const res = await apiClient.post('/redeem-ops/categories', body);
+    return res.data?.category;
+  },
+  async updateCategory(id, body) {
+    const res = await apiClient.patch(`/redeem-ops/categories/${id}`, body);
+    return res.data?.category;
+  },
+  async mergeCategory(id, targetId) {
+    const res = await apiClient.post(`/redeem-ops/categories/${id}/merge`, { targetId });
+    return res.data;
+  },
+  async deleteCategory(id) {
+    const res = await apiClient.delete(`/redeem-ops/categories/${id}`);
+    return res.data;
+  },
+
   // ── Partner CRM (Phase 2) ──────────────────────────────────────────────
   async listPartners(params = {}) {
     const res = await apiClient.get('/redeem-ops/partners', params);

--- a/src/components/redeemops/CategorySelect.jsx
+++ b/src/components/redeemops/CategorySelect.jsx
@@ -1,0 +1,48 @@
+import { useQuery } from '@tanstack/react-query';
+import { redeemOpsApi } from '@/api/redeemOps';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+
+const NONE = '__none__';
+
+/**
+ * Admin-managed category picker (GET /redeem-ops/categories — settings.manage
+ * holders curate the list under /redeem-ops/settings).
+ *
+ * `value` is the raw category string ('' = none); `onChange` receives the new
+ * string. A current value missing from the active list (retired, or legacy
+ * casing) stays selectable as an extra option so edit forms round-trip without
+ * tripping the backend validator's unknown-category 422.
+ */
+export default function CategorySelect({ value, onChange, placeholder = 'Select category', id }) {
+  const { data: categories = [], isLoading } = useQuery({
+    queryKey: ['redeem-ops', 'categories'],
+    queryFn: () => redeemOpsApi.listCategories(),
+    staleTime: 60_000,
+  });
+
+  const names = categories.map((c) => c.name);
+  const current = (value || '').trim();
+  const hasExact = names.includes(current);
+  const hasCaseInsensitive = names.some((n) => n.toLowerCase() === current.toLowerCase());
+
+  return (
+    <Select value={current || NONE} onValueChange={(v) => onChange(v === NONE ? '' : v)}>
+      <SelectTrigger id={id}>
+        <SelectValue placeholder={isLoading ? 'Loading…' : placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={NONE}>No category</SelectItem>
+        {current && !hasExact && (
+          <SelectItem value={current}>
+            {current}{hasCaseInsensitive ? '' : ' (retired)'}
+          </SelectItem>
+        )}
+        {names.map((n) => (
+          <SelectItem key={n} value={n}>{n}</SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/components/redeemops/RedeemOpsLayout.jsx
+++ b/src/components/redeemops/RedeemOpsLayout.jsx
@@ -45,6 +45,7 @@ const NAV = [
   { title: 'Redemptions', url: '/redeem-ops/redemptions', icon: QrCode, capability: 'redemptions.verify' },
   { title: 'Analytics', url: '/redeem-ops/analytics', icon: ChartColumn, capability: 'analytics.view_own' },
   { title: 'Team', url: '/redeem-ops/team', icon: UserCog, capability: 'analytics.view_team' },
+  { title: 'Settings', url: '/redeem-ops/settings', icon: Settings, capability: 'settings.manage' },
 ];
 
 const FIGTREE_LINK_ID = 'ro-figtree-font';

--- a/src/lib/redeemOpsPermissions.js
+++ b/src/lib/redeemOpsPermissions.js
@@ -56,6 +56,7 @@ export const CAPABILITIES = [
   'exports.run',
   'audit.view',
   'team.manage_access',
+  'settings.manage',
 ];
 
 const ALL = [...CAPABILITIES];

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -93,6 +93,7 @@ const RedeemOpsActivationDetail = lazy(() => import('./redeemops/ActivationDetai
 const RedeemOpsRedemptions = lazy(() => import('./redeemops/RedemptionsPage'));
 const RedeemOpsAnalytics = lazy(() => import('./redeemops/AnalyticsPage'));
 const RedeemOpsProfile = lazy(() => import('./redeemops/ProfilePage'));
+const RedeemOpsSettings = lazy(() => import('./redeemops/SettingsPage'));
 
 // ops.redeem.sg — dedicated staff surface (docs/redeem-ops/
 // USER_SURFACES_AND_DEPLOYMENT_BOUNDARIES.md). Mirrors the VITE_BRAND pattern:
@@ -102,7 +103,7 @@ const RedeemOpsProfile = lazy(() => import('./redeemops/ProfilePage'));
 const IS_OPS_SURFACE = import.meta.env.VITE_SURFACE === 'ops';
 
 /**
- * The 14 redeem-ops routes, shared verbatim between the mktr.sg dogfood
+ * The redeem-ops routes, shared verbatim between the mktr.sg dogfood
  * surface and the ops.redeem.sg build so the two can never drift.
  */
 function redeemOpsRouteElements() {
@@ -123,6 +124,7 @@ function redeemOpsRouteElements() {
     { path: '/redeem-ops/redemptions', capability: 'redemptions.verify', Page: RedeemOpsRedemptions },
     { path: '/redeem-ops/analytics', capability: 'analytics.view_own', Page: RedeemOpsAnalytics },
     { path: '/redeem-ops/profile', capability: null, Page: RedeemOpsProfile },
+    { path: '/redeem-ops/settings', capability: 'settings.manage', Page: RedeemOpsSettings },
   ];
   return routes.map(({ path, capability, Page }) => (
     <Route

--- a/src/pages/redeemops/PartnerDetail.jsx
+++ b/src/pages/redeemops/PartnerDetail.jsx
@@ -35,6 +35,7 @@ import Plus from 'lucide-react/icons/plus';
 import Pencil from 'lucide-react/icons/pencil';
 import ArrowLeft from 'lucide-react/icons/arrow-left';
 import { RoStageTag, RoAvatar, RoTag, prettyEnum } from '@/components/redeemops/ui';
+import CategorySelect from '@/components/redeemops/CategorySelect';
 
 function useDebounced(value, ms = 300) {
   const [debounced, setDebounced] = useState(value);
@@ -963,7 +964,10 @@ export default function PartnerDetail() {
               </div>
               <div className="space-y-1.5">
                 <Label>Category</Label>
-                <Input value={editForm.category} onChange={setEdit('category')} placeholder="Nail Salon" />
+                <CategorySelect
+                  value={editForm.category}
+                  onChange={(v) => setEditForm((f) => ({ ...f, category: v }))}
+                />
               </div>
               <div className="space-y-1.5">
                 <Label>Phone (+65…)</Label>

--- a/src/pages/redeemops/PartnersList.jsx
+++ b/src/pages/redeemops/PartnersList.jsx
@@ -18,6 +18,7 @@ import Plus from 'lucide-react/icons/plus';
 import Upload from 'lucide-react/icons/upload';
 import AlertTriangle from 'lucide-react/icons/alert-triangle';
 import { RoMobileCard, RoStageTag, RoAvatar, RoOwner, RoPageHeader, prettyEnum } from '@/components/redeemops/ui';
+import CategorySelect from '@/components/redeemops/CategorySelect';
 
 function useDebounced(value, ms = 300) {
   const [debounced, setDebounced] = useState(value);
@@ -69,6 +70,7 @@ export default function PartnersList() {
   const [search, setSearch] = useState('');
   const [stage, setStage] = useState('all');
   const [owner, setOwner] = useState('all');
+  const [category, setCategory] = useState('all');
   const [page, setPage] = useState(1);
   const debouncedSearch = useDebounced(search);
 
@@ -77,12 +79,19 @@ export default function PartnersList() {
     queryFn: redeemOpsApi.getConstants,
     staleTime: Infinity,
   });
+  const categoriesQuery = useQuery({
+    queryKey: ['redeem-ops', 'categories'],
+    queryFn: () => redeemOpsApi.listCategories(),
+    staleTime: 60_000,
+  });
+  const categoryNames = (categoriesQuery.data || []).map((c) => c.name);
 
   const params = {
     page, limit: 25,
     ...(debouncedSearch ? { search: debouncedSearch } : {}),
     ...(stage !== 'all' ? { stage } : {}),
     ...(owner !== 'all' ? { owner } : {}),
+    ...(category !== 'all' ? { category } : {}),
   };
   const listQuery = useQuery({
     queryKey: ['redeem-ops', 'partners', params],
@@ -243,6 +252,13 @@ export default function PartnersList() {
             {stages.map((s) => <SelectItem key={s} value={s}>{prettyEnum(s)}</SelectItem>)}
           </SelectContent>
         </Select>
+        <Select value={category} onValueChange={(v) => { setCategory(v); setPage(1); }}>
+          <SelectTrigger className="w-44 h-10"><SelectValue placeholder="Category" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All categories</SelectItem>
+            {categoryNames.map((n) => <SelectItem key={n} value={n}>{n}</SelectItem>)}
+          </SelectContent>
+        </Select>
       </div>
 
       <div className="rounded-2xl border border-border bg-white overflow-hidden">
@@ -350,6 +366,7 @@ export default function PartnersList() {
             <DialogTitle>Import businesses from CSV</DialogTitle>
             <DialogDescription>
               Columns: name (required), category, phone (+65…), instagram, website, uen, email.
+              Category must match one of the admin-managed categories (Settings page).
               Exact duplicates are skipped automatically; every created row is audited.{' '}
               <a
                 className="ro-link"
@@ -403,7 +420,10 @@ export default function PartnersList() {
             </div>
             <div className="space-y-1.5">
               <Label>Category</Label>
-              <Input value={form.category} onChange={set('category')} placeholder="Nail Salon" />
+              <CategorySelect
+                value={form.category}
+                onChange={(v) => setForm((f) => ({ ...f, category: v }))}
+              />
             </div>
             <div className="space-y-1.5">
               <Label>Phone (+65…)</Label>

--- a/src/pages/redeemops/PoolsPage.jsx
+++ b/src/pages/redeemops/PoolsPage.jsx
@@ -14,6 +14,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import Plus from 'lucide-react/icons/plus';
 import { RoPageHeader, RoTag, RoAvatar, RoStageTag } from '@/components/redeemops/ui';
+import CategorySelect from '@/components/redeemops/CategorySelect';
 
 function useDebounced(value, ms = 300) {
   const [debounced, setDebounced] = useState(value);
@@ -225,7 +226,10 @@ export default function PoolsPage() {
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-1.5">
                 <Label>Category</Label>
-                <Input value={form.category} onChange={(e) => setForm((f) => ({ ...f, category: e.target.value }))} placeholder="Pet Grooming" />
+                <CategorySelect
+                  value={form.category}
+                  onChange={(v) => setForm((f) => ({ ...f, category: v }))}
+                />
               </div>
               <div className="space-y-1.5">
                 <Label>Area</Label>

--- a/src/pages/redeemops/SettingsPage.jsx
+++ b/src/pages/redeemops/SettingsPage.jsx
@@ -1,0 +1,244 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { redeemOpsApi } from '@/api/redeemOps';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import Plus from 'lucide-react/icons/plus';
+import Pencil from 'lucide-react/icons/pencil';
+import Merge from 'lucide-react/icons/merge';
+import Trash2 from 'lucide-react/icons/trash-2';
+import { RoPageHeader, RoTag } from '@/components/redeemops/ui';
+
+const CATEGORIES_KEY = ['redeem-ops', 'categories'];
+
+/**
+ * /redeem-ops/settings — admin knobs (settings.manage). First resident: the
+ * category taxonomy that partner/pool/reward pickers and the CSV import
+ * validate against. Rename cascades onto existing rows; merge consolidates
+ * seeded variants; delete only works while nothing references the name
+ * (the API refuses otherwise and the toast relays why).
+ */
+export default function SettingsPage() {
+  const queryClient = useQueryClient();
+
+  const listQuery = useQuery({
+    queryKey: [...CATEGORIES_KEY, 'all'],
+    queryFn: () => redeemOpsApi.listCategories({ includeInactive: 'true' }),
+  });
+  const categories = listQuery.data || [];
+
+  const invalidate = () => {
+    // Both the settings list (…, 'all') and the picker list share the prefix.
+    queryClient.invalidateQueries({ queryKey: CATEGORIES_KEY });
+  };
+  const onError = (title) => (err) => toast.error(title, { description: err.message });
+
+  // ── Add ────────────────────────────────────────────────────────────────
+  const [newName, setNewName] = useState('');
+  const createMutation = useMutation({
+    mutationFn: () => redeemOpsApi.createCategory({ name: newName.trim() }),
+    onSuccess: (cat) => {
+      toast.success(`Added '${cat?.name || newName.trim()}'`);
+      setNewName('');
+      invalidate();
+    },
+    onError: onError('Could not add category'),
+  });
+
+  // ── Rename ─────────────────────────────────────────────────────────────
+  const [renameTarget, setRenameTarget] = useState(null); // { id, name } | null
+  const [renameTo, setRenameTo] = useState('');
+  const renameMutation = useMutation({
+    mutationFn: () => redeemOpsApi.updateCategory(renameTarget.id, { name: renameTo.trim() }),
+    onSuccess: () => {
+      toast.success('Renamed — existing records updated to match');
+      setRenameTarget(null);
+      invalidate();
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partners'] });
+    },
+    onError: onError('Could not rename'),
+  });
+
+  // ── Retire / restore ───────────────────────────────────────────────────
+  const activeMutation = useMutation({
+    mutationFn: ({ id, isActive }) => redeemOpsApi.updateCategory(id, { isActive }),
+    onSuccess: (_cat, vars) => {
+      toast.success(vars.isActive
+        ? 'Restored — available in pickers again'
+        : 'Retired — existing records keep it; pickers stop offering it');
+      invalidate();
+    },
+    onError: onError('Could not update'),
+  });
+
+  // ── Merge ──────────────────────────────────────────────────────────────
+  const [mergeSource, setMergeSource] = useState(null); // { id, name } | null
+  const [mergeTargetId, setMergeTargetId] = useState('');
+  const mergeMutation = useMutation({
+    mutationFn: () => redeemOpsApi.mergeCategory(mergeSource.id, mergeTargetId),
+    onSuccess: (data) => {
+      toast.success(`Merged — ${data?.rowsMoved ?? 0} record(s) moved to '${data?.target?.name}'`);
+      setMergeSource(null);
+      setMergeTargetId('');
+      invalidate();
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partners'] });
+    },
+    onError: onError('Could not merge'),
+  });
+
+  // ── Delete (unreferenced only — the API is the guard) ──────────────────
+  const deleteMutation = useMutation({
+    mutationFn: (id) => redeemOpsApi.deleteCategory(id),
+    onSuccess: () => {
+      toast.success('Category deleted');
+      invalidate();
+    },
+    onError: onError('Could not delete'),
+  });
+
+  const mergeTargets = categories.filter((c) => c.isActive && c.id !== mergeSource?.id);
+
+  return (
+    <div className="space-y-6">
+      <RoPageHeader
+        title="Settings"
+        sub="Categories are managed here and picked everywhere else — partner forms, pools, imports, and the partners filter."
+      />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Categories</CardTitle>
+          <CardDescription>
+            Rename updates every business, pool, and reward carrying the old name. Retire to stop
+            new use without touching history; merge to consolidate duplicates like “Nails” into
+            “Nail Salon”.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form
+            className="flex gap-2 mb-4"
+            onSubmit={(e) => { e.preventDefault(); if (newName.trim()) createMutation.mutate(); }}
+          >
+            <Input
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="New category, e.g. Pet Grooming"
+              className="max-w-xs"
+            />
+            <Button type="submit" disabled={!newName.trim() || createMutation.isPending}>
+              <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" /> Add
+            </Button>
+          </form>
+
+          {listQuery.isLoading && <p className="text-sm m-0" style={{ color: 'var(--ro-text-2)' }}>Loading…</p>}
+          {!listQuery.isLoading && categories.length === 0 && (
+            <p className="text-sm m-0" style={{ color: 'var(--ro-text-2)' }}>
+              No categories yet — add the verticals your team prospects in.
+            </p>
+          )}
+
+          <ul className="m-0 p-0 list-none divide-y divide-border">
+            {categories.map((cat) => (
+              <li key={cat.id} className="flex items-center gap-2 py-2.5">
+                <span className="text-sm font-medium min-w-0 truncate">{cat.name}</span>
+                {!cat.isActive && <RoTag tone="gray">retired</RoTag>}
+                <span className="flex items-center gap-1 ml-auto shrink-0">
+                  <Button
+                    variant="ghost" size="sm" aria-label={`Rename ${cat.name}`}
+                    onClick={() => { setRenameTarget(cat); setRenameTo(cat.name); }}
+                  >
+                    <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
+                  </Button>
+                  <Button
+                    variant="ghost" size="sm" aria-label={`Merge ${cat.name} into another category`}
+                    onClick={() => { setMergeSource(cat); setMergeTargetId(''); }}
+                  >
+                    <Merge className="w-3.5 h-3.5" aria-hidden="true" />
+                  </Button>
+                  <Button
+                    variant="ghost" size="sm"
+                    disabled={activeMutation.isPending}
+                    onClick={() => activeMutation.mutate({ id: cat.id, isActive: !cat.isActive })}
+                  >
+                    {cat.isActive ? 'Retire' : 'Restore'}
+                  </Button>
+                  <Button
+                    variant="ghost" size="sm" aria-label={`Delete ${cat.name}`}
+                    disabled={deleteMutation.isPending}
+                    onClick={() => deleteMutation.mutate(cat.id)}
+                  >
+                    <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
+                  </Button>
+                </span>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+
+      <Dialog open={!!renameTarget} onOpenChange={(open) => { if (!open) setRenameTarget(null); }}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Rename category</DialogTitle>
+            <DialogDescription>
+              Every business, pool, and reward currently set to “{renameTarget?.name}” is updated
+              to the new name. To fold it into an existing category, use Merge instead.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-1.5 py-2">
+            <Label htmlFor="rename-to">New name</Label>
+            <Input id="rename-to" value={renameTo} onChange={(e) => setRenameTo(e.target.value)} />
+          </div>
+          <DialogFooter>
+            <Button
+              disabled={!renameTo.trim() || renameTo.trim() === renameTarget?.name || renameMutation.isPending}
+              onClick={() => renameMutation.mutate()}
+            >
+              {renameMutation.isPending ? 'Renaming…' : 'Rename'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={!!mergeSource} onOpenChange={(open) => { if (!open) setMergeSource(null); }}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Merge “{mergeSource?.name}”</DialogTitle>
+            <DialogDescription>
+              Moves every record to the target category and deletes “{mergeSource?.name}”.
+              This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-1.5 py-2">
+            <Label>Merge into</Label>
+            <Select value={mergeTargetId} onValueChange={setMergeTargetId}>
+              <SelectTrigger><SelectValue placeholder="Select target category" /></SelectTrigger>
+              <SelectContent>
+                {mergeTargets.map((c) => (
+                  <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <DialogFooter>
+            <Button
+              disabled={!mergeTargetId || mergeMutation.isPending}
+              onClick={() => mergeMutation.mutate()}
+            >
+              {mergeMutation.isPending ? 'Merging…' : 'Merge'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Category was **free text** on partners, pools, and rewards — so `Nail Salon` / `nail salon` / `Nails` fragmented the Analytics "category performance" report and made the existing `?category=` filter useless. This makes categories an **admin-curated taxonomy**: admins manage one shared list, everyone else picks from it.

## How

- **Migration 052** — `redeem_ops_categories` (case-insensitive `LOWER(name)` unique index). TRIM-normalizes the three `category` columns, then seeds one row per distinct existing value, `mode()` picking the most-frequent casing. Additive + seeded → **day-one behaviour is unchanged**; the string columns stay (house style).
- **`categoryService`** — sole taxonomy writer *and* the shared write-time validator:
  - unknown category → **422**, blank → `null` ("Uncategorised"), and a row's **unchanged current value always passes** so an admin rename/retire never 422s an unrelated partner edit (the SPA sends `category` on every save).
  - **rename** cascades onto all three tables; **merge** cascades then deletes the source (the only way to consolidate seeded variants — rename-into-existing is refused **409**); **delete** only when unreferenced. `'Uncategorised'` is reserved.
- **Enforcement on every write path**: partner create/update, pool create/update, reward create **and update** (`updateOffer` was a bypass). Reward's `partner.category` inheritance is copied as-is.
- **New `settings.manage` capability** (super_admin + ops_admin), mirrored in the frontend permissions file (drift test) + `PERMISSION_MATRIX.md`.
- **Routes** under the flag-gated `/api/redeem-ops` namespace: `GET /categories` (any principal, feeds pickers) + `POST`/`PATCH`/`:id/merge`/`DELETE` (settings.manage).
- **Frontend**: `CategorySelect` (active list; a retired current value stays selectable as "(retired)"), swapped into the partner + pool forms; a **category filter** on PartnersList (wires the pre-existing backend param); new **`/redeem-ops/settings`** page (add/rename/merge/retire/delete).

## Testing

- 13 new category tests: capability gating, case-insensitive dup 409, reserved-name 400, write-path 422, canonical-casing coercion, rename cascade, collision 409, **currentValue pass-through** (retired category doesn't brick edits), merge (cascade + source deletion), delete reference guard. **All green.**
- Added test-helper category seeding so the existing partners suite fixture (`category: 'Nail Salon'`) stays green under strict validation.
- Migration seed verified against a **live PG15**: case-insensitive dedup, most-frequent-casing win, `' F&B '` TRIM, and idempotency.
- Frontend `vite build` + permissions drift test pass.
- The one failing suite locally (`redeemOpsRewards` PARTNERED-transition) is **pre-existing on `origin/main`** — confirmed by running it against a clean baseline worktree; unrelated to this change.

## Rollout

Dark-safe: everything is under the already-flagged `REDEEM_OPS_ENABLED` namespace, migration is additive and seeded from live data. No env vars, no Render changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)