### PR TITLE
fix(redeem-ops): Settings page uses the standard page frame

### DIFF
--- a/src/pages/redeemops/SettingsPage.jsx
+++ b/src/pages/redeemops/SettingsPage.jsx
@@ -108,7 +108,7 @@ export default function SettingsPage() {
   const mergeTargets = categories.filter((c) => c.isActive && c.id !== mergeSource?.id);
 
   return (
-    <div className="space-y-6">
+    <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-6">
       <RoPageHeader
         title="Settings"
         sub="Categories are managed here and picked everywhere else — partner forms, pools, imports, and the partners filter."
@@ -116,7 +116,7 @@ export default function SettingsPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>Categories</CardTitle>
+          <CardTitle className="text-base">Categories</CardTitle>
           <CardDescription>
             Rename updates every business, pool, and reward carrying the old name. Retire to stop
             new use without touching history; merge to consolidate duplicates like “Nails” into


### PR DESCRIPTION
## Problem

The Settings page (shipped in #122) looked barren and off-brand — a single card sprawling the full ~1900px viewport with a lone input in it. Root cause: it was the **only** redeem-ops screen missing the shared content frame every sibling page uses.

## Fix

Match the closest sibling (the Team admin page):
- Outer wrapper `space-y-6` → **`p-4 md:p-8 max-w-5xl mx-auto space-y-6`** (padded, max-width, centered) — the card no longer stretches edge-to-edge.
- Card title → **`text-base`** to match the other admin cards.

No logic changes. Pure layout alignment with the existing Fresha design system.

## Notes
- The grey "Add" button in the reported screenshot was just its disabled state (empty input) — it darkens on input; not a bug.
- The "No categories yet" empty state is correct: migration 052's seed found no existing category values to import (partners/pools had blank categories), so the list starts empty until an admin adds verticals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)