### PR TITLE
feat(redeem-ops): Discover tool — Apify prospecting → deduped one-click add to pipeline

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -278,3 +278,17 @@ HITPAY_PAYMENT_METHODS=paynow_online,card
 HITPAY_WEBHOOK_URL=                          # full URL to /api/external/billing/hitpay-webhook (optional if dashboard-configured)
 HITPAY_REDIRECT_URL=                         # app deep link back after pay (optional; webhook is source of truth)
 # NOTE: EXTERNAL_APP_SECRET (set above) also authenticates the agent-facing billing routes.
+
+# ── Redeem Ops — Discover tool (Apify prospecting; migration 053) ──────────────
+DISCOVERY_ENABLED=false                       # master switch (also gates the reconcile sweep)
+APIFY_TOKEN=                                  # SECRET — Apify API token
+APIFY_MAPS_ACTOR_ID=compass~crawler-google-places   # Google Maps scraper actor
+APIFY_INSTAGRAM_ACTOR_ID=apify~instagram-scraper    # IG enrichment actor
+DISCOVERY_WEBHOOK_SECRET=                     # URL-path secret for the Apify terminal-event callback
+DISCOVERY_WEBHOOK_BASE_URL=https://api.mktr.sg      # public base for the callback URL
+DISCOVERY_MAX_RESULTS_PER_RUN=120
+DISCOVERY_MAX_RUNS_PER_DAY=25                 # global daily cap
+DISCOVERY_MAX_RUNS_PER_USER_DAY=5             # per-user cap (cost guardrail — access is all-principals)
+DISCOVERY_ENRICH_MAX_PER_DAY=50              # separate cap for IG enrichment runs
+DISCOVERY_COST_PER_RESULT_USD=0.007          # rough pre-run estimate; actual read from the run
+DISCOVERY_RECONCILE_STUCK_MINUTES=10         # age before a non-terminal run is re-fetched from Apify

--- a/backend/src/controllers/redeemOps/discoveryController.js
+++ b/backend/src/controllers/redeemOps/discoveryController.js
@@ -1,0 +1,72 @@
+import Joi from 'joi';
+import { asyncHandler, AppError } from '../../middleware/errorHandler.js';
+import discoveryService from '../../services/redeemOps/discoveryService.js';
+import { logger } from '../../utils/logger.js';
+
+const startSchema = Joi.object({
+  category: Joi.string().min(1).max(64).required(),
+  area: Joi.string().min(1).max(120).required(),
+  limit: Joi.number().integer().min(1).max(500),
+});
+const idsSchema = Joi.object({
+  candidateIds: Joi.array().items(Joi.string().uuid()).min(1).required(),
+});
+
+/** POST /discovery/runs — start an Apify search. */
+export const startDiscovery = asyncHandler(async (req, res) => {
+  const { error, value } = startSchema.validate(req.body, { abortEarly: false });
+  if (error) throw new AppError(error.details.map((x) => x.message).join(', '), 400);
+  const run = await discoveryService.startDiscovery(value, req.user, req.id);
+  res.status(202).json({ success: true, data: { run } });
+});
+
+/** GET /discovery/runs — recent searches. */
+export const listRuns = asyncHandler(async (req, res) => {
+  const runs = await discoveryService.listRuns({ limit: Math.min(Number(req.query.limit) || 20, 50) });
+  res.json({ success: true, data: { runs } });
+});
+
+/** GET /discovery/runs/:id — status + candidates (frontend polls this). */
+export const getRun = asyncHandler(async (req, res) => {
+  const { run, candidates } = await discoveryService.getRunWithCandidates(req.params.id);
+  res.json({ success: true, data: { run, candidates } });
+});
+
+/** POST /discovery/candidates/enrich — on-demand Instagram enrichment. */
+export const enrichCandidates = asyncHandler(async (req, res) => {
+  const { error, value } = idsSchema.validate(req.body, { abortEarly: false });
+  if (error) throw new AppError(error.details.map((x) => x.message).join(', '), 400);
+  const run = await discoveryService.enrichCandidates(value.candidateIds, req.user, req.id);
+  res.status(202).json({ success: true, data: { run } });
+});
+
+/** POST /discovery/runs/:id/add — bulk-add selected candidates as partners. */
+export const addToPartners = asyncHandler(async (req, res) => {
+  const { error, value } = idsSchema.validate(req.body, { abortEarly: false });
+  if (error) throw new AppError(error.details.map((x) => x.message).join(', '), 400);
+  const results = await discoveryService.addToPartners(value.candidateIds, req.user, req.id);
+  res.json({ success: true, data: results });
+});
+
+/** PATCH /discovery/candidates/:id — dismiss. */
+export const dismissCandidate = asyncHandler(async (req, res) => {
+  await discoveryService.dismissCandidate(req.params.id, req.user);
+  res.json({ success: true });
+});
+
+/**
+ * POST /discovery/webhook/:secret — Apify terminal-event callback.
+ * Auth = URL secret only (Apify doesn't sign). We ack fast, then re-fetch the run
+ * from Apify and process idempotently in the background; reconciliation covers any miss.
+ */
+export const webhook = asyncHandler(async (req, res) => {
+  if (!discoveryService.verifyWebhookSecret(req.params.secret)) {
+    throw new AppError('Invalid webhook secret', 401);
+  }
+  const providerRunId = req.body?.eventData?.actorRunId || req.body?.resource?.id || null;
+  res.json({ success: true }); // ack immediately so Apify doesn't retry-storm
+  if (providerRunId) {
+    discoveryService.processByProviderRunId(providerRunId)
+      .catch((err) => logger.error('discovery.webhook.process_failed', { providerRunId, error: err.message }));
+  }
+});

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -124,6 +124,23 @@ export async function bootstrapDatabase() {
       }
     }, 2 * 60 * 1000); // every 2 min
 
+    // Discover tool: reconcile Apify runs whose completion webhook never landed
+    // (missed delivery, FAILED/TIMED_OUT with no hook, or an instance restart
+    // mid-run). In-process every 5 min; each stuck run is re-fetched from Apify
+    // and driven terminal idempotently. Gated by DISCOVERY_ENABLED.
+    if (String(process.env.DISCOVERY_ENABLED || 'false').toLowerCase() === 'true') {
+      setInterval(async () => {
+        try {
+          const { default: discoveryService } = await import('../services/redeemOps/discoveryService.js');
+          const { checked } = await discoveryService.reconcileStuckRuns();
+          if (checked > 0) logger.info(`[Discovery] reconciled ${checked} stuck run(s)`);
+        } catch (err) {
+          logger.warn('[Discovery] periodic reconcile failed', { error: err?.message });
+        }
+      }, 5 * 60 * 1000); // every 5 min
+      logger.info('[Discovery] periodic run reconciliation scheduled (5 min interval)');
+    }
+
     // Redeemed-audience exclusion sync (Meta customer list). Pushes hashed
     // redeemers into the exclusion audience so people who already redeemed stop
     // seeing ads. Runs IN-PROCESS (the backend is single-instance — no

--- a/backend/src/database/migrations/053-redeem-ops-discovery.js
+++ b/backend/src/database/migrations/053-redeem-ops-discovery.js
@@ -1,0 +1,90 @@
+/**
+ * Redeem Ops — Discover tool: async business-prospecting via Apify
+ * (spec: ~/.claude/plans/redeem-ops-discover-tool.md).
+ *
+ * discovery_runs = one Apify search job (start → terminal webhook → materialize).
+ * discovery_candidates = businesses found by a run, deduped against partners and
+ * one-click-addable to the pipeline. Guarded + always-run IF NOT EXISTS indexes
+ * (045–052 pattern); safe under NODE_ENV=test sync-first.
+ */
+export async function up(queryInterface, Sequelize) {
+  const q = async (sql) => queryInterface.sequelize.query(sql);
+  const tables = await queryInterface.showAllTables();
+  const UUID = Sequelize.UUID;
+  const ts = () => ({
+    createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+  });
+
+  if (!tables.includes('discovery_runs')) {
+    await queryInterface.createTable('discovery_runs', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      createdBy: { type: UUID, allowNull: false, references: { model: 'users', key: 'id' }, onDelete: 'CASCADE' },
+      provider: { type: Sequelize.STRING(32), allowNull: false, defaultValue: 'apify_google_maps' },
+      category: { type: Sequelize.STRING(64) },
+      area: { type: Sequelize.STRING(120) },
+      requestedLimit: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 60 },
+      // pending → running → processing → completed | failed | aborted | timed_out
+      status: { type: Sequelize.STRING(20), allowNull: false, defaultValue: 'pending' },
+      providerRunId: { type: Sequelize.STRING(64) },
+      providerDatasetId: { type: Sequelize.STRING(64) },
+      resultCount: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 0 },
+      estimatedCostUsd: { type: Sequelize.DECIMAL(10, 4) },
+      actualCostUsd: { type: Sequelize.DECIMAL(10, 4) },
+      error: { type: Sequelize.TEXT },
+      rawPayload: { type: Sequelize.JSONB },
+      startedAt: { type: Sequelize.DATE },
+      completedAt: { type: Sequelize.DATE },
+      ...ts(),
+    });
+  }
+
+  if (!tables.includes('discovery_candidates')) {
+    await queryInterface.createTable('discovery_candidates', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      discoveryRunId: { type: UUID, allowNull: false, references: { model: 'discovery_runs', key: 'id' }, onDelete: 'CASCADE' },
+      externalPlaceId: { type: Sequelize.STRING(128) },
+      name: { type: Sequelize.STRING(200) },
+      primaryPhone: { type: Sequelize.STRING(32) },
+      website: { type: Sequelize.STRING(255) },
+      websiteDomain: { type: Sequelize.STRING(160) },
+      instagramHandle: { type: Sequelize.STRING(64) },
+      address: { type: Sequelize.STRING(255) },
+      area: { type: Sequelize.STRING(64) },
+      rating: { type: Sequelize.DECIMAL(2, 1) },
+      reviewsCount: { type: Sequelize.INTEGER },
+      sourceUrl: { type: Sequelize.STRING(500) },
+      // new | possible_duplicate | existing_partner
+      dedupeStatus: { type: Sequelize.STRING(20), allowNull: false, defaultValue: 'new' },
+      matchedPartnerId: { type: UUID, references: { model: 'partner_organisations', key: 'id' }, onDelete: 'SET NULL' },
+      // pending | added | dismissed
+      status: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'pending' },
+      addedPartnerId: { type: UUID, references: { model: 'partner_organisations', key: 'id' }, onDelete: 'SET NULL' },
+      // none | pending | enriched | failed
+      enrichmentStatus: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'none' },
+      followersCount: { type: Sequelize.INTEGER },
+      email: { type: Sequelize.STRING(160) },
+      bio: { type: Sequelize.TEXT },
+      enrichedAt: { type: Sequelize.DATE },
+      enrichmentSource: { type: Sequelize.STRING(32) },
+      rawPayload: { type: Sequelize.JSONB },
+      ...ts(),
+    });
+  }
+
+  // Idempotency: one Apify run row per provider run id; one candidate row per
+  // (run, place) so re-materializing a dataset (duplicate webhook) is a no-op.
+  await q('CREATE UNIQUE INDEX IF NOT EXISTS uq_discovery_runs_provider_run_id ON discovery_runs ("providerRunId") WHERE "providerRunId" IS NOT NULL');
+  await q('CREATE UNIQUE INDEX IF NOT EXISTS uq_discovery_candidates_run_place ON discovery_candidates ("discoveryRunId", "externalPlaceId") WHERE "externalPlaceId" IS NOT NULL');
+  // Reconciliation sweep scans non-terminal runs by age.
+  await q('CREATE INDEX IF NOT EXISTS idx_discovery_runs_status ON discovery_runs (status, "startedAt")');
+  // Per-user daily quota counts a user's recent runs.
+  await q('CREATE INDEX IF NOT EXISTS idx_discovery_runs_creator ON discovery_runs ("createdBy", "createdAt")');
+  await q('CREATE INDEX IF NOT EXISTS idx_discovery_candidates_run ON discovery_candidates ("discoveryRunId", status)');
+}
+
+export async function down(queryInterface) {
+  const q = async (sql) => queryInterface.sequelize.query(sql);
+  await q('DROP TABLE IF EXISTS discovery_candidates');
+  await q('DROP TABLE IF EXISTS discovery_runs');
+}

--- a/backend/src/models/DiscoveryCandidate.js
+++ b/backend/src/models/DiscoveryCandidate.js
@@ -1,0 +1,38 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * A business found by a DiscoveryRun (migration 053). Deduped against existing
+ * partners (dedupeStatus) and one-click-addable to the pipeline (status/addedPartnerId).
+ * Instagram enrichment fields fill in on-demand (§2.6 of the spec).
+ */
+const DiscoveryCandidate = sequelize.define('DiscoveryCandidate', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  discoveryRunId: { type: DataTypes.UUID, allowNull: false, references: { model: 'discovery_runs', key: 'id' } },
+  externalPlaceId: { type: DataTypes.STRING(128), allowNull: true },
+  name: { type: DataTypes.STRING(200), allowNull: true },
+  primaryPhone: { type: DataTypes.STRING(32), allowNull: true },
+  website: { type: DataTypes.STRING(255), allowNull: true },
+  websiteDomain: { type: DataTypes.STRING(160), allowNull: true },
+  instagramHandle: { type: DataTypes.STRING(64), allowNull: true },
+  address: { type: DataTypes.STRING(255), allowNull: true },
+  area: { type: DataTypes.STRING(64), allowNull: true },
+  rating: { type: DataTypes.DECIMAL(2, 1), allowNull: true },
+  reviewsCount: { type: DataTypes.INTEGER, allowNull: true },
+  sourceUrl: { type: DataTypes.STRING(500), allowNull: true },
+  dedupeStatus: { type: DataTypes.STRING(20), allowNull: false, defaultValue: 'new' },
+  matchedPartnerId: { type: DataTypes.UUID, allowNull: true, references: { model: 'partner_organisations', key: 'id' } },
+  status: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'pending' },
+  addedPartnerId: { type: DataTypes.UUID, allowNull: true, references: { model: 'partner_organisations', key: 'id' } },
+  enrichmentStatus: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'none' },
+  followersCount: { type: DataTypes.INTEGER, allowNull: true },
+  email: { type: DataTypes.STRING(160), allowNull: true },
+  bio: { type: DataTypes.TEXT, allowNull: true },
+  enrichedAt: { type: DataTypes.DATE, allowNull: true },
+  enrichmentSource: { type: DataTypes.STRING(32), allowNull: true },
+  rawPayload: { type: DataTypes.JSONB, allowNull: true },
+}, {
+  tableName: 'discovery_candidates',
+});
+
+export default DiscoveryCandidate;

--- a/backend/src/models/DiscoveryRun.js
+++ b/backend/src/models/DiscoveryRun.js
@@ -1,0 +1,30 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * One Apify prospecting search (migration 053). Lifecycle:
+ * pending → running → processing → completed | failed | aborted | timed_out.
+ * Owns discovery_candidates. See ~/.claude/plans/redeem-ops-discover-tool.md.
+ */
+const DiscoveryRun = sequelize.define('DiscoveryRun', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  createdBy: { type: DataTypes.UUID, allowNull: false, references: { model: 'users', key: 'id' } },
+  provider: { type: DataTypes.STRING(32), allowNull: false, defaultValue: 'apify_google_maps' },
+  category: { type: DataTypes.STRING(64), allowNull: true },
+  area: { type: DataTypes.STRING(120), allowNull: true },
+  requestedLimit: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 60 },
+  status: { type: DataTypes.STRING(20), allowNull: false, defaultValue: 'pending' },
+  providerRunId: { type: DataTypes.STRING(64), allowNull: true },
+  providerDatasetId: { type: DataTypes.STRING(64), allowNull: true },
+  resultCount: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  estimatedCostUsd: { type: DataTypes.DECIMAL(10, 4), allowNull: true },
+  actualCostUsd: { type: DataTypes.DECIMAL(10, 4), allowNull: true },
+  error: { type: DataTypes.TEXT, allowNull: true },
+  rawPayload: { type: DataTypes.JSONB, allowNull: true },
+  startedAt: { type: DataTypes.DATE, allowNull: true },
+  completedAt: { type: DataTypes.DATE, allowNull: true },
+}, {
+  tableName: 'discovery_runs',
+});
+
+export default DiscoveryRun;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -244,6 +244,14 @@ function defineAssociations() {
   ProspectingPool.hasMany(ProspectingPoolMember, { foreignKey: 'poolId', as: 'members', onDelete: 'CASCADE' });
   ProspectingPoolMember.belongsTo(ProspectingPool, { foreignKey: 'poolId', as: 'pool' });
   ProspectingPoolMember.belongsTo(PartnerOrganisation, { foreignKey: 'partnerOrganisationId', as: 'partner', onDelete: 'CASCADE' });
+
+  // Discover tool (migration 053)
+  const { DiscoveryRun, DiscoveryCandidate } = models;
+  DiscoveryRun.belongsTo(User, { foreignKey: 'createdBy', as: 'creator', onDelete: 'CASCADE' });
+  DiscoveryRun.hasMany(DiscoveryCandidate, { foreignKey: 'discoveryRunId', as: 'candidates', onDelete: 'CASCADE' });
+  DiscoveryCandidate.belongsTo(DiscoveryRun, { foreignKey: 'discoveryRunId', as: 'run' });
+  DiscoveryCandidate.belongsTo(PartnerOrganisation, { foreignKey: 'matchedPartnerId', as: 'matchedPartner', onDelete: 'SET NULL' });
+  DiscoveryCandidate.belongsTo(PartnerOrganisation, { foreignKey: 'addedPartnerId', as: 'addedPartner', onDelete: 'SET NULL' });
 }
 
 defineAssociations();
@@ -282,7 +290,7 @@ export const {
   OutreachTask, ProspectingPool, ProspectingPoolMember, RewardOffer,
   RewardTermsVersion, RewardOfferLocation, RewardInventoryEvent,
   PartnerOnboardingItem, Activation, RewardEntitlement, Redemption,
-  RedemptionEvent, RedeemOpsCategory
+  RedemptionEvent, RedeemOpsCategory, DiscoveryRun, DiscoveryCandidate
 } = models;
 
 export { sequelize };

--- a/backend/src/routes/redeemOpsDiscovery.js
+++ b/backend/src/routes/redeemOpsDiscovery.js
@@ -1,0 +1,35 @@
+import express from 'express';
+import { requireRedeemOps } from '../middleware/redeemOpsAuth.js';
+import * as ctrl from '../controllers/redeemOps/discoveryController.js';
+
+/**
+ * Redeem Ops — Discover tool (spec: ~/.claude/plans/redeem-ops-discover-tool.md).
+ * Flag + host-guard posture as siblings. Search/read/enrich/dismiss are open to any
+ * ops principal (paid-job cost is bounded by quotas in discoveryService, not a
+ * capability); adding to the pipeline needs partners.create; the Apify webhook is
+ * authenticated by a URL secret only (server-to-server, no JWT).
+ */
+export const meta = {
+  path: '/api/redeem-ops',
+  flag: 'REDEEM_OPS_ENABLED',
+  flagDefault: 'false',
+};
+
+const router = express.Router();
+
+// Apify terminal-event callback — secret in the URL, no JWT (must precede param routes).
+router.post('/discovery/webhook/:secret', ctrl.webhook);
+
+// Search + read (any authenticated ops principal)
+router.post('/discovery/runs', requireRedeemOps(), ctrl.startDiscovery);
+router.get('/discovery/runs', requireRedeemOps(), ctrl.listRuns);
+router.get('/discovery/runs/:id', requireRedeemOps(), ctrl.getRun);
+
+// Enrich + dismiss
+router.post('/discovery/candidates/enrich', requireRedeemOps(), ctrl.enrichCandidates);
+router.patch('/discovery/candidates/:id', requireRedeemOps(), ctrl.dismissCandidate);
+
+// Convert candidates → partners (only create-capable roles push to the pipeline)
+router.post('/discovery/runs/:id/add', requireRedeemOps('partners.create'), ctrl.addToPartners);
+
+export default router;

--- a/backend/src/services/redeemOps/discovery/apifyClient.js
+++ b/backend/src/services/redeemOps/discovery/apifyClient.js
@@ -1,0 +1,98 @@
+import { logger } from '../../../utils/logger.js';
+
+/**
+ * Thin Apify API v2 wrapper for the Discover tool. Start an actor run, re-fetch
+ * its authoritative state, pull dataset items. `fetchImpl` is injectable so tests
+ * never hit the network.
+ *
+ * Webhook auth note: Apify does NOT HMAC-sign webhook payloads. We register the
+ * webhook with a secret in the URL path and, on receipt, IGNORE the payload's
+ * claims and re-fetch the run via getRun() using our own token — so a spoofed
+ * webhook can't drive state. (See spec §2.2.)
+ */
+const APIFY_BASE = 'https://api.apify.com/v2';
+
+// Apify run.status → our discovery_runs.status terminal mapping.
+export const TERMINAL_STATUS = {
+  SUCCEEDED: 'completed',
+  FAILED: 'failed',
+  ABORTED: 'aborted',
+  'TIMED-OUT': 'timed_out',
+};
+export const WEBHOOK_EVENT_TYPES = [
+  'ACTOR.RUN.SUCCEEDED', 'ACTOR.RUN.FAILED', 'ACTOR.RUN.ABORTED', 'ACTOR.RUN.TIMED_OUT',
+];
+
+export function makeApifyClient(overrides = {}) {
+  const d = {
+    token: process.env.APIFY_TOKEN,
+    baseUrl: APIFY_BASE,
+    fetchImpl: (...args) => globalThis.fetch(...args),
+    logger,
+    ...overrides,
+  };
+
+  function assertConfigured() {
+    if (!d.token) throw new Error('APIFY_TOKEN is not set');
+  }
+
+  async function call(method, path, { body, query } = {}) {
+    assertConfigured();
+    const url = new URL(`${d.baseUrl}${path}`);
+    url.searchParams.set('token', d.token);
+    for (const [k, v] of Object.entries(query || {})) {
+      if (v !== undefined && v !== null) url.searchParams.set(k, String(v));
+    }
+    const res = await d.fetchImpl(url.toString(), {
+      method,
+      headers: body ? { 'Content-Type': 'application/json' } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`Apify ${method} ${path} → ${res.status}: ${text.slice(0, 300)}`);
+    }
+    return res.json();
+  }
+
+  /**
+   * Start an actor run with an ad-hoc terminal webhook.
+   * @returns {{ runId, datasetId, status }}
+   */
+  async function startRun(actorId, input, { webhookUrl } = {}) {
+    const query = {};
+    if (webhookUrl) {
+      // Ad-hoc webhooks: base64 of a JSON array, passed on the run-start request.
+      const webhooks = [{ eventTypes: WEBHOOK_EVENT_TYPES, requestUrl: webhookUrl }];
+      query.webhooks = Buffer.from(JSON.stringify(webhooks)).toString('base64');
+    }
+    const json = await call('POST', `/acts/${encodeURIComponent(actorId)}/runs`, { body: input, query });
+    const data = json?.data || {};
+    return { runId: data.id, datasetId: data.defaultDatasetId, status: data.status };
+  }
+
+  /** Authoritative run state (status + dataset + real cost). */
+  async function getRun(runId) {
+    const json = await call('GET', `/actor-runs/${encodeURIComponent(runId)}`);
+    const data = json?.data || {};
+    return {
+      runId: data.id,
+      status: data.status,
+      datasetId: data.defaultDatasetId,
+      usageTotalUsd: data.usageTotalUsd ?? null,
+      terminalStatus: TERMINAL_STATUS[data.status] || null,
+    };
+  }
+
+  /** Pull cleaned dataset items (the businesses / profiles). */
+  async function getDatasetItems(datasetId, { limit } = {}) {
+    const items = await call('GET', `/datasets/${encodeURIComponent(datasetId)}/items`, {
+      query: { clean: 'true', format: 'json', ...(limit ? { limit } : {}) },
+    });
+    return Array.isArray(items) ? items : [];
+  }
+
+  return { startRun, getRun, getDatasetItems };
+}
+
+export default makeApifyClient;

--- a/backend/src/services/redeemOps/discovery/normalizers.js
+++ b/backend/src/services/redeemOps/discovery/normalizers.js
@@ -1,0 +1,76 @@
+import { normalizeDomain, normalizeHandle } from '../normalizers.js';
+import { normalizePhone } from '../../prospectHelpers.js';
+
+/**
+ * Map raw Apify actor items → our candidate/enrichment shapes. Kept dependency-light
+ * and pure so tests can feed fixture items without any network. Column-length-safe
+ * (truncates to the discovery_candidates limits).
+ */
+const trunc = (v, n) => (v == null ? null : String(v).slice(0, n));
+
+/** First Instagram URL/handle out of the actor's various social shapes → handle. */
+function extractInstagram(raw) {
+  const candidates = [];
+  if (Array.isArray(raw.instagrams)) candidates.push(...raw.instagrams);
+  if (raw.socialMedia?.instagram) candidates.push(raw.socialMedia.instagram);
+  if (raw.instagram) candidates.push(raw.instagram);
+  for (const c of candidates) {
+    const handle = normalizeHandle(c);
+    if (handle) return handle;
+  }
+  return null;
+}
+
+/** Apify Google Maps place → discovery_candidates fields. */
+export function normalizeMapsItem(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const website = raw.website || null;
+  return {
+    externalPlaceId: trunc(raw.placeId || raw.fid || null, 128),
+    name: trunc(raw.title || raw.name || null, 200),
+    primaryPhone: trunc(normalizePhone(raw.phoneUnformatted || raw.phone || null) || null, 32),
+    website: trunc(website, 255),
+    websiteDomain: trunc(normalizeDomain(website), 160),
+    instagramHandle: trunc(extractInstagram(raw), 64),
+    address: trunc(raw.address || raw.street || null, 255),
+    area: trunc(raw.city || raw.neighborhood || raw.state || null, 64),
+    rating: typeof raw.totalScore === 'number' ? raw.totalScore : null,
+    reviewsCount: Number.isInteger(raw.reviewsCount) ? raw.reviewsCount : null,
+    sourceUrl: trunc(raw.url || raw.searchPageUrl || null, 500),
+    // Trim heavy arrays (reviews/images) out of the stored payload — keep it light.
+    rawPayload: pruneMapsRaw(raw),
+  };
+}
+
+function pruneMapsRaw(raw) {
+  const rest = { ...(raw || {}) };
+  // Drop the heavy arrays — keep the stored payload light.
+  for (const k of ['reviews', 'images', 'imageUrls', 'reviewsDistribution', 'popularTimesHistogram']) {
+    delete rest[k];
+  }
+  return rest;
+}
+
+const EMAIL_RE = /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/i;
+
+/** Pull an email out of an IG bio (best-effort, low confidence — not a structured field). */
+export function parseEmailFromBio(bio) {
+  if (!bio || typeof bio !== 'string') return null;
+  const m = bio.match(EMAIL_RE);
+  return m ? m[0].toLowerCase() : null;
+}
+
+/** Apify Instagram profile → enrichment fields (fill-blanks/upgrade only, never blind overwrite). */
+export function normalizeInstagramItem(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const handle = normalizeHandle(raw.username || raw.url || null);
+  const bio = raw.biography || raw.bio || null;
+  return {
+    instagramHandle: trunc(handle, 64),
+    followersCount: Number.isInteger(raw.followersCount) ? raw.followersCount
+      : (Number.isInteger(raw.followers) ? raw.followers : null),
+    bio: bio || null,
+    email: trunc(raw.publicEmail || parseEmailFromBio(bio), 160),
+    isVerified: !!raw.verified,
+  };
+}

--- a/backend/src/services/redeemOps/discoveryService.js
+++ b/backend/src/services/redeemOps/discoveryService.js
@@ -1,0 +1,361 @@
+import { Op } from 'sequelize';
+import crypto from 'crypto';
+import { DiscoveryRun, DiscoveryCandidate, PartnerOrganisation, sequelize } from '../../models/index.js';
+import { AppError } from '../../middleware/errorHandler.js';
+import { logger } from '../../utils/logger.js';
+import { makeRedeemOpsAuditService } from './auditService.js';
+import { makePartnerService } from './partnerService.js';
+import { makeApifyClient } from './discovery/apifyClient.js';
+import { normalizeMapsItem, normalizeInstagramItem } from './discovery/normalizers.js';
+import { normalizeBusinessName, normalizeDomain, normalizeHandle } from './normalizers.js';
+import { normalizePhone } from '../prospectHelpers.js';
+
+const TERMINAL = ['completed', 'failed', 'aborted', 'timed_out'];
+
+function cfg() {
+  return {
+    enabled: process.env.DISCOVERY_ENABLED === 'true',
+    mapsActor: process.env.APIFY_MAPS_ACTOR_ID || 'compass~crawler-google-places',
+    igActor: process.env.APIFY_INSTAGRAM_ACTOR_ID || 'apify~instagram-scraper',
+    webhookSecret: process.env.DISCOVERY_WEBHOOK_SECRET || '',
+    webhookBase: process.env.DISCOVERY_WEBHOOK_BASE_URL || 'https://api.mktr.sg',
+    maxResultsPerRun: Number(process.env.DISCOVERY_MAX_RESULTS_PER_RUN || 120),
+    maxRunsPerDay: Number(process.env.DISCOVERY_MAX_RUNS_PER_DAY || 25),
+    maxRunsPerUserDay: Number(process.env.DISCOVERY_MAX_RUNS_PER_USER_DAY || 5),
+    enrichMaxPerDay: Number(process.env.DISCOVERY_ENRICH_MAX_PER_DAY || 50),
+    costPerResultUsd: Number(process.env.DISCOVERY_COST_PER_RESULT_USD || 0.007),
+    reconcileStuckMinutes: Number(process.env.DISCOVERY_RECONCILE_STUCK_MINUTES || 10),
+  };
+}
+
+export function makeDiscoveryService(overrides = {}) {
+  const d = {
+    DiscoveryRun, DiscoveryCandidate, PartnerOrganisation, sequelize, logger,
+    apify: makeApifyClient(),
+    partners: makePartnerService(),
+    audit: makeRedeemOpsAuditService(),
+    ...overrides,
+  };
+
+  function assertEnabled() {
+    if (!cfg().enabled) throw new AppError('Discover is not enabled', 503);
+  }
+
+  /** Constant-time webhook-secret check (Apify does not sign — see apifyClient). */
+  function verifyWebhookSecret(candidate) {
+    const secret = cfg().webhookSecret;
+    if (!secret) return false;
+    const a = Buffer.from(String(candidate || ''));
+    const b = Buffer.from(secret);
+    return a.length === b.length && crypto.timingSafeEqual(a, b);
+  }
+
+  async function assertQuota(user) {
+    const c = cfg();
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const base = { provider: 'apify_google_maps', createdAt: { [Op.gte]: since } };
+    const [mine, all] = await Promise.all([
+      d.DiscoveryRun.count({ where: { ...base, createdBy: user.id } }),
+      d.DiscoveryRun.count({ where: base }),
+    ]);
+    if (mine >= c.maxRunsPerUserDay) {
+      throw new AppError(`Daily search limit reached (${c.maxRunsPerUserDay}/day per user)`, 429);
+    }
+    if (all >= c.maxRunsPerDay) {
+      throw new AppError('Team daily search limit reached — try again tomorrow', 429);
+    }
+  }
+
+  function webhookUrl() {
+    const c = cfg();
+    if (!c.webhookSecret) return undefined;
+    return `${c.webhookBase.replace(/\/$/, '')}/api/redeem-ops/discovery/webhook/${encodeURIComponent(c.webhookSecret)}`;
+  }
+
+  // ── Start a discovery search ───────────────────────────────────────────
+  async function startDiscovery({ category, area, limit }, user, requestId = null) {
+    assertEnabled();
+    if (!category || !String(category).trim()) throw new AppError('Category is required', 400);
+    if (!area || !String(area).trim()) throw new AppError('Area is required', 400);
+    await assertQuota(user);
+    const c = cfg();
+    const requestedLimit = Math.min(Math.max(Number(limit) || 60, 1), c.maxResultsPerRun);
+
+    const run = await d.DiscoveryRun.create({
+      createdBy: user.id, provider: 'apify_google_maps',
+      category: String(category).trim(), area: String(area).trim(),
+      requestedLimit, status: 'pending',
+      estimatedCostUsd: Number((requestedLimit * c.costPerResultUsd).toFixed(4)),
+    });
+
+    try {
+      const input = {
+        searchStringsArray: [`${category} ${area}`],
+        maxCrawledPlacesPerSearch: requestedLimit,
+        language: 'en',
+        scrapeContacts: true, // enables the instagrams/social arrays
+      };
+      const started = await d.apify.startRun(c.mapsActor, input, { webhookUrl: webhookUrl() });
+      await run.update({ providerRunId: started.runId, providerDatasetId: started.datasetId || null, status: 'running', startedAt: new Date() });
+    } catch (err) {
+      await run.update({ status: 'failed', error: String(err.message).slice(0, 500) });
+      throw new AppError(`Could not start search: ${err.message}`, 502);
+    }
+
+    await d.audit.recordAuditEvent({
+      actorUser: user, action: 'discovery.run_started', entityType: 'discovery_run',
+      entityId: run.id, after: { category: run.category, area: run.area, requestedLimit }, requestId,
+    });
+    return run;
+  }
+
+  // ── Terminal-state processing (webhook or reconcile) ───────────────────
+  /** Idempotent: safe to call repeatedly. Materialization dedupes on (run, place). */
+  async function processRun(runId) {
+    const run = await d.DiscoveryRun.findByPk(runId);
+    if (!run || TERMINAL.includes(run.status) || !run.providerRunId) return;
+
+    const info = await d.apify.getRun(run.providerRunId);
+    if (!info.terminalStatus) return; // not done yet — a later webhook/sweep handles it
+
+    if (info.terminalStatus !== 'completed') {
+      await run.update({
+        status: info.terminalStatus, completedAt: new Date(),
+        actualCostUsd: info.usageTotalUsd, error: `Apify run ${info.status}`,
+      });
+      return;
+    }
+
+    const items = await d.apify.getDatasetItems(info.datasetId, { limit: run.requestedLimit });
+    if (run.provider === 'apify_instagram') {
+      await applyEnrichment(run, items);
+    } else {
+      await materializeCandidates(run, items);
+    }
+    await run.update({
+      status: 'completed', completedAt: new Date(), providerDatasetId: info.datasetId,
+      actualCostUsd: info.usageTotalUsd, resultCount: items.length,
+    });
+  }
+
+  async function materializeCandidates(run, items) {
+    const rows = items.map(normalizeMapsItem).filter((r) => r && r.name);
+    if (rows.length === 0) return;
+    // Idempotent insert — the (discoveryRunId, externalPlaceId) unique index makes
+    // a duplicate webhook / reconcile a no-op.
+    await d.DiscoveryCandidate.bulkCreate(
+      rows.map((r) => ({ ...r, discoveryRunId: run.id })),
+      { ignoreDuplicates: true }
+    );
+    const candidates = await d.DiscoveryCandidate.findAll({ where: { discoveryRunId: run.id } });
+    await classifyAgainstPartners(candidates);
+  }
+
+  /**
+   * Batched dedupe: one set-based query against live partners (NOT 120×findDuplicates).
+   * Marks exact hits existing_partner + matchedPartnerId; everything else stays 'new'.
+   * (createPartner runs the full fuzzy dedupe again at add-time, so a missed fuzzy
+   * match here is still caught before a partner is created.)
+   */
+  async function classifyAgainstPartners(candidates) {
+    const keyed = candidates.map((cand) => ({
+      cand,
+      phone: normalizePhone(cand.primaryPhone) || null,
+      domain: cand.websiteDomain || normalizeDomain(cand.website),
+      handle: normalizeHandle(cand.instagramHandle),
+      name: normalizeBusinessName(cand.name),
+    }));
+    const phones = [...new Set(keyed.map((k) => k.phone).filter(Boolean))];
+    const domains = [...new Set(keyed.map((k) => k.domain).filter(Boolean))];
+    const handles = [...new Set(keyed.map((k) => k.handle).filter(Boolean))];
+    const names = [...new Set(keyed.map((k) => k.name).filter(Boolean))];
+    if (!phones.length && !domains.length && !handles.length && !names.length) return;
+
+    const or = [];
+    if (phones.length) or.push({ primaryPhone: { [Op.in]: phones } });
+    if (domains.length) or.push({ websiteDomain: { [Op.in]: domains } });
+    if (handles.length) or.push({ instagramHandle: { [Op.in]: handles } });
+    if (names.length) or.push({ normalizedName: { [Op.in]: names } });
+
+    const partners = await d.PartnerOrganisation.findAll({
+      where: { mergedIntoId: null, archivedAt: null, [Op.or]: or },
+      attributes: ['id', 'primaryPhone', 'websiteDomain', 'instagramHandle', 'normalizedName'],
+    });
+    if (partners.length === 0) return;
+
+    const byPhone = new Map(), byDomain = new Map(), byHandle = new Map(), byName = new Map();
+    for (const p of partners) {
+      if (p.primaryPhone) byPhone.set(p.primaryPhone, p.id);
+      if (p.websiteDomain) byDomain.set(p.websiteDomain, p.id);
+      if (p.instagramHandle) byHandle.set(p.instagramHandle, p.id);
+      if (p.normalizedName) byName.set(p.normalizedName, p.id);
+    }
+    for (const k of keyed) {
+      const match = (k.phone && byPhone.get(k.phone)) || (k.domain && byDomain.get(k.domain))
+        || (k.handle && byHandle.get(k.handle)) || (k.name && byName.get(k.name));
+      if (match) {
+        await k.cand.update({ dedupeStatus: 'existing_partner', matchedPartnerId: match });
+      }
+    }
+  }
+
+  // ── On-demand Instagram enrichment (separate async run) ────────────────
+  async function enrichCandidates(candidateIds, user, requestId = null) {
+    assertEnabled();
+    if (!Array.isArray(candidateIds) || candidateIds.length === 0) {
+      throw new AppError('candidateIds is required', 400);
+    }
+    const c = cfg();
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const enrichedToday = await d.DiscoveryRun.count({ where: { provider: 'apify_instagram', createdAt: { [Op.gte]: since } } });
+    if (enrichedToday >= c.enrichMaxPerDay) throw new AppError('Daily enrichment limit reached', 429);
+
+    const candidates = await d.DiscoveryCandidate.findAll({
+      where: { id: { [Op.in]: candidateIds }, instagramHandle: { [Op.ne]: null } },
+    });
+    const handles = [...new Set(candidates.map((x) => x.instagramHandle).filter(Boolean))];
+    if (handles.length === 0) throw new AppError('None of the selected candidates have an Instagram handle', 400);
+
+    const run = await d.DiscoveryRun.create({
+      createdBy: user.id, provider: 'apify_instagram', status: 'pending',
+      requestedLimit: handles.length, rawPayload: { targetCandidateIds: candidates.map((x) => x.id) },
+    });
+    await d.DiscoveryCandidate.update({ enrichmentStatus: 'pending' }, { where: { id: { [Op.in]: candidates.map((x) => x.id) } } });
+
+    try {
+      const input = { usernames: handles, resultsType: 'details', resultsLimit: 1 };
+      const started = await d.apify.startRun(c.igActor, input, { webhookUrl: webhookUrl() });
+      await run.update({ providerRunId: started.runId, status: 'running', startedAt: new Date() });
+    } catch (err) {
+      await run.update({ status: 'failed', error: String(err.message).slice(0, 500) });
+      await d.DiscoveryCandidate.update({ enrichmentStatus: 'failed' }, { where: { id: { [Op.in]: candidates.map((x) => x.id) } } });
+      throw new AppError(`Could not start enrichment: ${err.message}`, 502);
+    }
+    await d.audit.recordAuditEvent({
+      actorUser: user, action: 'discovery.enrich_started', entityType: 'discovery_run',
+      entityId: run.id, after: { count: handles.length }, requestId,
+    });
+    return run;
+  }
+
+  /** Map IG profiles back to the run's target candidates by handle; fill-blanks only. */
+  async function applyEnrichment(run, items) {
+    const targetIds = run.rawPayload?.targetCandidateIds || [];
+    if (targetIds.length === 0) return;
+    const profiles = items.map(normalizeInstagramItem).filter((p) => p && p.instagramHandle);
+    const byHandle = new Map(profiles.map((p) => [p.instagramHandle.toLowerCase(), p]));
+    const candidates = await d.DiscoveryCandidate.findAll({ where: { id: { [Op.in]: targetIds } } });
+    for (const cand of candidates) {
+      const p = cand.instagramHandle && byHandle.get(cand.instagramHandle.toLowerCase());
+      if (!p) { await cand.update({ enrichmentStatus: 'failed' }); continue; }
+      const patch = { enrichmentStatus: 'enriched', enrichedAt: new Date(), enrichmentSource: 'apify_instagram' };
+      // Fill-blanks / upgrade only — never blindly overwrite a confident value.
+      if (p.followersCount != null) patch.followersCount = p.followersCount;
+      if (p.bio && !cand.bio) patch.bio = p.bio;
+      if (p.email && !cand.email) patch.email = p.email;
+      await cand.update(patch);
+    }
+  }
+
+  // ── Convert candidates → partners (bulk) ───────────────────────────────
+  async function addToPartners(candidateIds, user, requestId = null) {
+    assertEnabled();
+    if (!Array.isArray(candidateIds) || candidateIds.length === 0) {
+      throw new AppError('candidateIds is required', 400);
+    }
+    const candidates = await d.DiscoveryCandidate.findAll({
+      where: { id: { [Op.in]: candidateIds }, status: 'pending' },
+      include: [{ model: d.DiscoveryRun, as: 'run', attributes: ['category'] }],
+    });
+    const results = { added: 0, skipped: 0, failed: 0, errors: [] };
+    for (const cand of candidates) {
+      if (cand.dedupeStatus === 'existing_partner') { results.skipped += 1; continue; }
+      try {
+        const { partner } = await d.partners.createPartner({
+          tradingName: cand.name,
+          primaryPhone: normalizePhone(cand.primaryPhone) || null,
+          website: cand.website || null,
+          instagramHandle: cand.instagramHandle || null,
+          primaryEmail: cand.email || null,
+          category: cand.run?.category || null,
+          source: 'discovery',
+        }, user, requestId);
+        await cand.update({ status: 'added', addedPartnerId: partner.id });
+        results.added += 1;
+      } catch (err) {
+        if (err.statusCode === 409 || err.status === 409) {
+          // Exact duplicate surfaced at add-time — mark it as such, don't create.
+          await cand.update({ dedupeStatus: 'existing_partner' });
+          results.skipped += 1;
+        } else {
+          results.failed += 1;
+          if (results.errors.length < 5) results.errors.push(`${cand.name || 'Row'}: ${err.message}`);
+        }
+      }
+    }
+    return results;
+  }
+
+  /** Resolve an Apify webhook (providerRunId → our run) then process idempotently. */
+  async function processByProviderRunId(providerRunId) {
+    if (!providerRunId) return;
+    const run = await d.DiscoveryRun.findOne({ where: { providerRunId } });
+    if (run) await processRun(run.id);
+  }
+
+  async function dismissCandidate(candidateId, _user) {
+    const cand = await d.DiscoveryCandidate.findByPk(candidateId);
+    if (!cand) throw new AppError('Candidate not found', 404);
+    if (cand.status === 'pending') await cand.update({ status: 'dismissed' });
+    return cand;
+  }
+
+  // ── Reads for the UI ───────────────────────────────────────────────────
+  async function listRuns({ limit = 20 } = {}) {
+    return d.DiscoveryRun.findAll({
+      where: { provider: 'apify_google_maps' },
+      order: [['createdAt', 'DESC']], limit,
+    });
+  }
+
+  async function getRunWithCandidates(runId) {
+    const run = await d.DiscoveryRun.findByPk(runId);
+    if (!run) throw new AppError('Run not found', 404);
+    const candidates = await d.DiscoveryCandidate.findAll({
+      where: { discoveryRunId: runId, status: { [Op.ne]: 'dismissed' } },
+      order: [
+        d.sequelize.literal('"followersCount" DESC NULLS LAST'),
+        d.sequelize.literal('"reviewsCount" DESC NULLS LAST'),
+      ],
+    });
+    return { run, candidates };
+  }
+
+  // ── Reconciliation: re-drive runs whose webhook never landed ───────────
+  async function reconcileStuckRuns() {
+    if (!cfg().enabled) return { checked: 0 };
+    const cutoff = new Date(Date.now() - cfg().reconcileStuckMinutes * 60 * 1000);
+    const stuck = await d.DiscoveryRun.findAll({
+      where: {
+        status: { [Op.in]: ['pending', 'running'] },
+        providerRunId: { [Op.ne]: null },
+        startedAt: { [Op.lt]: cutoff },
+      },
+      limit: 25,
+    });
+    for (const run of stuck) {
+      try { await processRun(run.id); }
+      catch (err) { d.logger.error('discovery.reconcile.failed', { runId: run.id, error: err.message }); }
+    }
+    return { checked: stuck.length };
+  }
+
+  return {
+    startDiscovery, processRun, processByProviderRunId, enrichCandidates, addToPartners,
+    dismissCandidate, listRuns, getRunWithCandidates, reconcileStuckRuns, verifyWebhookSecret,
+    classifyAgainstPartners, materializeCandidates, applyEnrichment,
+  };
+}
+
+const _default = makeDiscoveryService();
+export default _default;

--- a/backend/test/redeemOpsDiscovery.test.js
+++ b/backend/test/redeemOpsDiscovery.test.js
@@ -1,0 +1,164 @@
+/**
+ * Redeem Ops Discover tool — DB-backed service tests with the Apify client mocked
+ * (no network). Covers: run start + quota, terminal-state processing (completed +
+ * failed), idempotent materialization, batched dedupe classification, convert →
+ * partners (skips existing), Instagram enrichment (fill-blanks), webhook secret.
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+process.env.DISCOVERY_ENABLED = 'true';
+process.env.DISCOVERY_WEBHOOK_SECRET = 'test-secret';
+
+import { jest } from '@jest/globals';
+import { getApp, closeDb, createTestUser, seedRedeemOpsCategory } from './helpers.js';
+import { makeDiscoveryService } from '../src/services/redeemOps/discoveryService.js';
+import { makePartnerService } from '../src/services/redeemOps/partnerService.js';
+import { DiscoveryRun, DiscoveryCandidate, PartnerOrganisation } from '../src/models/index.js';
+
+let admin;
+const partners = makePartnerService();
+
+function makeApifyStub() {
+  return { startRun: jest.fn(), getRun: jest.fn(), getDatasetItems: jest.fn() };
+}
+
+const mapsItems = [
+  { placeId: 'p1', title: 'Nail Bliss Studio', phoneUnformatted: '+6591230001', website: 'https://nailbliss.sg', instagrams: ['https://instagram.com/nailbliss'], city: 'Tampines', totalScore: 4.8, reviewsCount: 120, url: 'https://maps.google.com/?cid=1' },
+  { placeId: 'p2', title: 'Glossy Nails', phoneUnformatted: '+6591230002', city: 'Tampines', totalScore: 4.2, reviewsCount: 30, url: 'https://maps.google.com/?cid=2' },
+];
+
+beforeAll(async () => {
+  await getApp(); // boots + syncs the test DB
+  admin = await createTestUser({ role: 'admin' });
+  await seedRedeemOpsCategory('Nail Salon');
+});
+
+afterAll(async () => { await closeDb(); });
+
+async function startedRun(svc, apify) {
+  apify.startRun.mockResolvedValue({ runId: `run_${Date.now()}_${Math.random()}`, datasetId: 'ds1', status: 'RUNNING' });
+  return svc.startDiscovery({ category: 'Nail Salon', area: 'Tampines', limit: 60 }, admin.user);
+}
+
+describe('start + quota', () => {
+  test('startDiscovery creates a running run and calls Apify', async () => {
+    const apify = makeApifyStub();
+    const svc = makeDiscoveryService({ apify });
+    const run = await startedRun(svc, apify);
+    expect(apify.startRun).toHaveBeenCalledTimes(1);
+    expect(run.status).toBe('running');
+    expect(run.providerRunId).toBeTruthy();
+    expect(Number(run.estimatedCostUsd)).toBeGreaterThan(0);
+  });
+
+  test('per-user daily quota → 429', async () => {
+    process.env.DISCOVERY_MAX_RUNS_PER_USER_DAY = '2';
+    const apify = makeApifyStub();
+    const svc = makeDiscoveryService({ apify });
+    const solo = await createTestUser({ role: 'admin' });
+    apify.startRun.mockResolvedValue({ runId: `r_${Math.random()}`, datasetId: 'ds', status: 'RUNNING' });
+    await svc.startDiscovery({ category: 'Nail Salon', area: 'A', limit: 30 }, solo.user);
+    await svc.startDiscovery({ category: 'Nail Salon', area: 'B', limit: 30 }, solo.user);
+    await expect(svc.startDiscovery({ category: 'Nail Salon', area: 'C', limit: 30 }, solo.user))
+      .rejects.toMatchObject({ statusCode: 429 });
+    delete process.env.DISCOVERY_MAX_RUNS_PER_USER_DAY;
+  });
+});
+
+describe('terminal-state processing', () => {
+  test('completed run materializes + classifies candidates (idempotent)', async () => {
+    const apify = makeApifyStub();
+    const svc = makeDiscoveryService({ apify });
+    const run = await startedRun(svc, apify);
+
+    apify.getRun.mockResolvedValue({ runId: run.providerRunId, status: 'SUCCEEDED', datasetId: 'ds1', usageTotalUsd: 0.4, terminalStatus: 'completed' });
+    apify.getDatasetItems.mockResolvedValue(mapsItems);
+
+    await svc.processRun(run.id);
+    await svc.processRun(run.id); // second call must be a no-op (idempotent)
+
+    await run.reload();
+    expect(run.status).toBe('completed');
+    expect(Number(run.actualCostUsd)).toBe(0.4);
+    const cands = await DiscoveryCandidate.findAll({ where: { discoveryRunId: run.id } });
+    expect(cands).toHaveLength(2); // not 4 — dedup on (run, placeId)
+    const bliss = cands.find((c) => c.name === 'Nail Bliss Studio');
+    expect(bliss.instagramHandle).toBe('nailbliss');
+    expect(bliss.primaryPhone).toBe('+6591230001');
+  });
+
+  test('failed Apify run marks the run failed', async () => {
+    const apify = makeApifyStub();
+    const svc = makeDiscoveryService({ apify });
+    const run = await startedRun(svc, apify);
+    apify.getRun.mockResolvedValue({ runId: run.providerRunId, status: 'FAILED', datasetId: null, usageTotalUsd: 0, terminalStatus: 'failed' });
+    await svc.processRun(run.id);
+    await run.reload();
+    expect(run.status).toBe('failed');
+    expect(apify.getDatasetItems).not.toHaveBeenCalled();
+  });
+});
+
+describe('dedupe classification', () => {
+  test('a candidate matching a live partner by phone → existing_partner', async () => {
+    const svc = makeDiscoveryService({ apify: makeApifyStub() });
+    const { partner } = await partners.createPartner(
+      { tradingName: 'Already Ours Nails', primaryPhone: '+6598887777', category: 'Nail Salon' },
+      admin.user,
+    );
+    const run = await DiscoveryRun.create({ createdBy: admin.user.id, provider: 'apify_google_maps', status: 'completed', requestedLimit: 10 });
+    const hit = await DiscoveryCandidate.create({ discoveryRunId: run.id, name: 'Dup By Phone', primaryPhone: '+6598887777' });
+    const miss = await DiscoveryCandidate.create({ discoveryRunId: run.id, name: 'Totally New Salon', primaryPhone: '+6590001234' });
+
+    await svc.classifyAgainstPartners([hit, miss]);
+    await hit.reload(); await miss.reload();
+    expect(hit.dedupeStatus).toBe('existing_partner');
+    expect(hit.matchedPartnerId).toBe(partner.id);
+    expect(miss.dedupeStatus).toBe('new');
+  });
+});
+
+describe('convert → partners', () => {
+  test('adds new candidates, skips existing_partner', async () => {
+    const svc = makeDiscoveryService({ apify: makeApifyStub() });
+    const run = await DiscoveryRun.create({ createdBy: admin.user.id, provider: 'apify_google_maps', status: 'completed', category: 'Nail Salon', requestedLimit: 10 });
+    const fresh = await DiscoveryCandidate.create({ discoveryRunId: run.id, name: 'Fresh Prospect Nails', primaryPhone: '+6591112222', instagramHandle: 'freshnails', dedupeStatus: 'new', status: 'pending' });
+    const existing = await DiscoveryCandidate.create({ discoveryRunId: run.id, name: 'Existing One', dedupeStatus: 'existing_partner', status: 'pending' });
+
+    const res = await svc.addToPartners([fresh.id, existing.id], admin.user);
+    expect(res.added).toBe(1);
+    expect(res.skipped).toBe(1);
+    await fresh.reload();
+    expect(fresh.status).toBe('added');
+    expect(fresh.addedPartnerId).toBeTruthy();
+    const created = await PartnerOrganisation.findByPk(fresh.addedPartnerId);
+    expect(created.source).toBe('discovery');
+    expect(created.category).toBe('Nail Salon');
+  });
+});
+
+describe('instagram enrichment', () => {
+  test('applyEnrichment fills followers/bio/email on the target candidates (fill-blanks)', async () => {
+    const svc = makeDiscoveryService({ apify: makeApifyStub() });
+    const run = await DiscoveryRun.create({ createdBy: admin.user.id, provider: 'apify_google_maps', status: 'completed', requestedLimit: 10 });
+    const cand = await DiscoveryCandidate.create({ discoveryRunId: run.id, name: 'Enrich Me Nails', instagramHandle: 'enrichme', enrichmentStatus: 'pending' });
+    const enrichRun = await DiscoveryRun.create({ createdBy: admin.user.id, provider: 'apify_instagram', status: 'running', requestedLimit: 1, rawPayload: { targetCandidateIds: [cand.id] } });
+
+    await svc.applyEnrichment(enrichRun, [
+      { username: 'enrichme', followersCount: 5400, biography: 'Best nails in town — hello@enrichme.sg', verified: true },
+    ]);
+    await cand.reload();
+    expect(cand.enrichmentStatus).toBe('enriched');
+    expect(cand.followersCount).toBe(5400);
+    expect(cand.email).toBe('hello@enrichme.sg');
+    expect(cand.bio).toContain('Best nails');
+  });
+});
+
+describe('webhook secret', () => {
+  test('verifyWebhookSecret is constant-time exact match', () => {
+    const svc = makeDiscoveryService({ apify: makeApifyStub() });
+    expect(svc.verifyWebhookSecret('test-secret')).toBe(true);
+    expect(svc.verifyWebhookSecret('wrong')).toBe(false);
+    expect(svc.verifyWebhookSecret('')).toBe(false);
+  });
+});

--- a/docs/redeem-ops/ERD.md
+++ b/docs/redeem-ops/ERD.md
@@ -308,7 +308,25 @@ seeded variants — rename-into-existing is refused 409); delete is allowed only
 Migration 052 TRIM-normalizes the three columns then seeds one row per distinct value (`mode()`
 picks the most-frequent casing). `'Uncategorised'` is a reserved name.
 
-### 3.21 Future (designed, not in V1 migrations)
+### 3.21 `discovery_runs` + `discovery_candidates` (`DiscoveryRun` / `DiscoveryCandidate`) — Discover tool (migration 053)
+
+`discovery_runs` = one Apify prospecting job: createdBy FK; provider (`apify_google_maps` | `apify_instagram`);
+category; area; requestedLimit; status (pending→running→completed | failed | aborted | timed_out);
+**providerRunId (unique)**; providerDatasetId; resultCount; estimated/actualCostUsd; rawPayload JSONB;
+started/completedAt. `discovery_candidates` = a business found by a run: run FK CASCADE; externalPlaceId;
+name/phone/website/domain/instagram/address/area/rating/reviews/sourceUrl; **dedupeStatus** (new |
+possible_duplicate | existing_partner) + matchedPartnerId; **status** (pending | added | dismissed) +
+addedPartnerId; enrichment fields (enrichmentStatus, followersCount, email, bio, enrichedAt, source);
+**unique (discoveryRunId, externalPlaceId)** for idempotent materialization.
+
+Flow: Apify runs async → terminal webhook (URL-secret auth; state re-fetched from Apify, never trusted
+from the payload) → candidates materialized + **batched** dedupe-classified against live partners →
+bulk-add routes through `createPartner` (`source='discovery'`, category from the run). A periodic
+in-process reconcile sweep drives stuck runs terminal (missed webhook / restart). All-principal access
+(`requireRedeemOps()`); paid-job cost bounded by per-user + global daily quotas, not a capability.
+Provenance = the `addedPartnerId` link (no `sourceMetadata` column on partner_organisations).
+
+### 3.22 Future (designed, not in V1 migrations)
 
 `partner_import_batches` + `partner_import_rows` (CSV import, brief §32);
 `partner_users` (portal principals — see `RECOMMENDED_ARCHITECTURE.md` §7).

--- a/docs/redeem-ops/ROUTE_MAP.md
+++ b/docs/redeem-ops/ROUTE_MAP.md
@@ -29,6 +29,17 @@
 | GET/POST `/partners/:id/locations`, PATCH `/locations/:id` | locations.manage | |
 | GET/PATCH `/partners/:id/onboarding` | onboarding.manage | Checklist read/update (Phase 4). |
 
+### Discover — `routes/redeemOpsDiscovery.js` (Phase 8, Apify prospecting)
+
+| Method & path | Guard | Purpose |
+|---|---|---|
+| POST `/discovery/runs` | requireRedeemOps() | Start an Apify Google-Maps search `{category, area, limit}`; async, returns `202 {run}`. Per-user + global daily quotas. |
+| GET `/discovery/runs` · GET `/discovery/runs/:id` | requireRedeemOps() | Recent runs; run status + candidates (frontend polls the latter). |
+| POST `/discovery/candidates/enrich` | requireRedeemOps() | On-demand Instagram enrichment (Apify IG scraper) of selected candidate ids; async, separately capped. |
+| POST `/discovery/runs/:id/add` | partners.create | Bulk-convert selected candidates → `NEW` partners (via createPartner; `source='discovery'`; skips `existing_partner`). |
+| PATCH `/discovery/candidates/:id` | requireRedeemOps() | Dismiss a candidate. |
+| POST `/discovery/webhook/:secret` | URL secret (Apify doesn't sign) | Terminal-event callback; ack-fast then re-fetch the run from Apify and process idempotently. |
+
 ### Work queue, tasks, pools — `routes/redeemOpsWork.js` (Phase 3)
 
 | Method & path | Capability | Purpose |
@@ -115,6 +126,7 @@ build as the whole app; never in the consumer `redeem` build. All wrapped in
 | `/redeem-ops` | OpsOverview (my queue summary + team snapshot for managers) | 3 | Overview |
 | `/redeem-ops/partners` | PartnersList (table, filters, saved views; duplicate-aware create dialog) | 2 | Partners |
 | `/redeem-ops/partners/:id` | PartnerDetail (header w/ owner+stage+claim button; tabs: Timeline, Contacts, Locations, Tasks, Onboarding, Rewards) | 2 | Partners |
+| `/redeem-ops/discover` | Discover (category+area Apify search → deduped candidates → bulk-add to pipeline; IG enrich) | 8 | Partners |
 | `/redeem-ops/pipeline` | TeamPipeline (table + Kanban; dnd via existing `@dnd-kit`, server-validated) | 3 | Outreach |
 | `/redeem-ops/queue` | MyQueue (start-of-day worklist) | 3 | Outreach |
 | `/redeem-ops/tasks` | Tasks (My/Due Today/Overdue/Upcoming/Team) | 3 | Outreach |

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -61,6 +61,32 @@ export const redeemOpsApi = {
     return res.data;
   },
 
+  // ── Discover tool (Apify prospecting) ──────────────────────────────────
+  async startDiscovery(body) {
+    const res = await apiClient.post('/redeem-ops/discovery/runs', body);
+    return res.data?.run;
+  },
+  async listDiscoveryRuns(params = {}) {
+    const res = await apiClient.get('/redeem-ops/discovery/runs', params);
+    return res.data?.runs || [];
+  },
+  async getDiscoveryRun(id) {
+    const res = await apiClient.get(`/redeem-ops/discovery/runs/${id}`);
+    return res.data; // { run, candidates }
+  },
+  async enrichDiscoveryCandidates(candidateIds) {
+    const res = await apiClient.post('/redeem-ops/discovery/candidates/enrich', { candidateIds });
+    return res.data?.run;
+  },
+  async addDiscoveryCandidates(runId, candidateIds) {
+    const res = await apiClient.post(`/redeem-ops/discovery/runs/${runId}/add`, { candidateIds });
+    return res.data; // { added, skipped, failed, errors }
+  },
+  async dismissDiscoveryCandidate(id) {
+    const res = await apiClient.patch(`/redeem-ops/discovery/candidates/${id}`, {});
+    return res.data;
+  },
+
   // ── Partner CRM (Phase 2) ──────────────────────────────────────────────
   async listPartners(params = {}) {
     const res = await apiClient.get('/redeem-ops/partners', params);

--- a/src/components/redeemops/RedeemOpsLayout.jsx
+++ b/src/components/redeemops/RedeemOpsLayout.jsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import House from 'lucide-react/icons/house';
 import Users from 'lucide-react/icons/users';
+import Compass from 'lucide-react/icons/compass';
 import Kanban from 'lucide-react/icons/kanban';
 import ListChecks from 'lucide-react/icons/list-checks';
 import Layers from 'lucide-react/icons/layers';
@@ -37,6 +38,7 @@ import '@/styles/redeem-ops-theme.css';
 const NAV = [
   { title: 'Queue', url: '/redeem-ops/queue', icon: House },
   { title: 'Partners', url: '/redeem-ops/partners', icon: Users, capability: 'partners.view' },
+  { title: 'Discover', url: '/redeem-ops/discover', icon: Compass },
   { title: 'Pipeline', url: '/redeem-ops/pipeline', icon: Kanban, capability: 'pipeline.view_team' },
   { title: 'Tasks', url: '/redeem-ops/tasks', icon: ListChecks, capability: 'tasks.manage' },
   { title: 'Pools', url: '/redeem-ops/pools', icon: Layers, capability: 'pools.claim_next' },

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -81,6 +81,7 @@ const REDEEM_OPS_ENABLED = import.meta.env.VITE_REDEEM_OPS_ENABLED === 'true';
 const RedeemOpsHome = lazy(() => import('./redeemops/RedeemOpsHome'));
 const RedeemOpsTeam = lazy(() => import('./redeemops/RedeemOpsTeam'));
 const RedeemOpsPartnersList = lazy(() => import('./redeemops/PartnersList'));
+const RedeemOpsDiscover = lazy(() => import('./redeemops/DiscoverPage'));
 const RedeemOpsPartnerDetail = lazy(() => import('./redeemops/PartnerDetail'));
 const RedeemOpsMyQueue = lazy(() => import('./redeemops/MyQueue'));
 const RedeemOpsTasks = lazy(() => import('./redeemops/TasksPage'));
@@ -113,6 +114,7 @@ function redeemOpsRouteElements() {
     { path: '/redeem-ops/team', capability: 'analytics.view_team', Page: RedeemOpsTeam },
     { path: '/redeem-ops/partners', capability: 'partners.view', Page: RedeemOpsPartnersList },
     { path: '/redeem-ops/partners/:id', capability: 'partners.view', Page: RedeemOpsPartnerDetail },
+    { path: '/redeem-ops/discover', capability: null, Page: RedeemOpsDiscover },
     { path: '/redeem-ops/queue', capability: null, Page: RedeemOpsMyQueue },
     { path: '/redeem-ops/tasks', capability: 'tasks.manage', Page: RedeemOpsTasks },
     { path: '/redeem-ops/pools', capability: 'pools.claim_next', Page: RedeemOpsPools },

--- a/src/pages/redeemops/DiscoverPage.jsx
+++ b/src/pages/redeemops/DiscoverPage.jsx
@@ -1,0 +1,223 @@
+import { useState, useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { redeemOpsApi } from '@/api/redeemOps';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import Search from 'lucide-react/icons/search';
+import Sparkles from 'lucide-react/icons/sparkles';
+import Plus from 'lucide-react/icons/plus';
+import X from 'lucide-react/icons/x';
+import { RoPageHeader, RoTag } from '@/components/redeemops/ui';
+import CategorySelect from '@/components/redeemops/CategorySelect';
+
+const TERMINAL = ['completed', 'failed', 'aborted', 'timed_out'];
+const DEDUPE = {
+  new: { tone: 'open', label: 'New' },
+  possible_duplicate: { tone: 'paused', label: 'Possible dup' },
+  existing_partner: { tone: 'archived', label: 'Already a partner' },
+};
+
+export default function DiscoverPage() {
+  const queryClient = useQueryClient();
+  const [form, setForm] = useState({ category: '', area: '', limit: '60' });
+  const [runId, setRunId] = useState(null);
+  const [selected, setSelected] = useState(() => new Set());
+
+  const runQuery = useQuery({
+    queryKey: ['redeem-ops', 'discovery', 'run', runId],
+    queryFn: () => redeemOpsApi.getDiscoveryRun(runId),
+    enabled: !!runId,
+    refetchInterval: (query) => (TERMINAL.includes(query.state.data?.run?.status) ? false : 2500),
+  });
+  const run = runQuery.data?.run;
+  const candidates = useMemo(() => runQuery.data?.candidates || [], [runQuery.data]);
+  const isSearching = run && !TERMINAL.includes(run.status);
+
+  const startMutation = useMutation({
+    mutationFn: () => redeemOpsApi.startDiscovery({
+      category: form.category, area: form.area.trim(), limit: Number(form.limit),
+    }),
+    onSuccess: (r) => { setRunId(r.id); setSelected(new Set()); },
+    onError: (err) => toast.error('Could not start search', { description: err.message }),
+  });
+
+  const addMutation = useMutation({
+    mutationFn: (ids) => redeemOpsApi.addDiscoveryCandidates(runId, ids),
+    onSuccess: (res) => {
+      toast.success(`Added ${res.added} to pipeline`, {
+        description: [res.skipped && `${res.skipped} already partners`, res.failed && `${res.failed} failed`].filter(Boolean).join(' · ') || undefined,
+      });
+      setSelected(new Set());
+      runQuery.refetch();
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partners'] });
+    },
+    onError: (err) => toast.error('Could not add', { description: err.message }),
+  });
+
+  const enrichMutation = useMutation({
+    mutationFn: (ids) => redeemOpsApi.enrichDiscoveryCandidates(ids),
+    onSuccess: () => {
+      toast.success('Enriching from Instagram — refresh in a moment for followers & bio');
+      setSelected(new Set());
+      setTimeout(() => runQuery.refetch(), 4000);
+    },
+    onError: (err) => toast.error('Could not enrich', { description: err.message }),
+  });
+
+  const dismissMutation = useMutation({
+    mutationFn: (id) => redeemOpsApi.dismissDiscoveryCandidate(id),
+    onSuccess: () => runQuery.refetch(),
+  });
+
+  const selectable = useMemo(
+    () => candidates.filter((c) => c.status === 'pending' && c.dedupeStatus !== 'existing_partner'),
+    [candidates],
+  );
+  const toggle = (id) => setSelected((prev) => {
+    const next = new Set(prev);
+    next.has(id) ? next.delete(id) : next.add(id);
+    return next;
+  });
+  const allSelected = selectable.length > 0 && selectable.every((c) => selected.has(c.id));
+  const toggleAll = () => setSelected(allSelected ? new Set() : new Set(selectable.map((c) => c.id)));
+
+  const canSearch = form.category && form.area.trim() && !startMutation.isPending;
+
+  return (
+    <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-6">
+      <RoPageHeader
+        title="Discover"
+        sub="Find businesses to prospect by category and area, skip the ones you already have, and add the rest to your pipeline in one click."
+      />
+
+      <div className="rounded-2xl border border-border bg-white p-4 md:p-5">
+        <div className="grid gap-3 md:grid-cols-[1fr_1fr_auto_auto] md:items-end">
+          <div className="space-y-1.5">
+            <Label>Category</Label>
+            <CategorySelect value={form.category} onChange={(v) => setForm((f) => ({ ...f, category: v }))} />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="disc-area">Area</Label>
+            <Input
+              id="disc-area" value={form.area} placeholder="Tampines"
+              onChange={(e) => setForm((f) => ({ ...f, area: e.target.value }))}
+              onKeyDown={(e) => { if (e.key === 'Enter' && canSearch) startMutation.mutate(); }}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label>Results</Label>
+            <Select value={form.limit} onValueChange={(v) => setForm((f) => ({ ...f, limit: v }))}>
+              <SelectTrigger className="w-28"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                {['30', '60', '120'].map((n) => <SelectItem key={n} value={n}>{n}</SelectItem>)}
+              </SelectContent>
+            </Select>
+          </div>
+          <Button disabled={!canSearch} onClick={() => startMutation.mutate()}>
+            <Search className="w-4 h-4 mr-1.5" aria-hidden="true" />
+            {startMutation.isPending ? 'Starting…' : 'Search'}
+          </Button>
+        </div>
+        <p className="text-xs mt-2 m-0" style={{ color: 'var(--ro-text-3)' }}>
+          Pulls businesses from Google Maps (~a minute). Instagram handles fill in via Enrich.
+        </p>
+      </div>
+
+      {isSearching && (
+        <div className="rounded-2xl border border-border bg-white p-8 text-center">
+          <div className="ro-progress mb-3 max-w-xs mx-auto"><i style={{ width: '60%' }} /></div>
+          <p className="text-sm m-0" style={{ color: 'var(--ro-text-2)' }}>
+            Searching Google Maps for “{run.category} {run.area}”… this takes about a minute.
+          </p>
+        </div>
+      )}
+
+      {run && ['failed', 'aborted', 'timed_out'].includes(run.status) && (
+        <div className="rounded-2xl border border-border bg-white p-6 text-center">
+          <p className="text-sm m-0" style={{ color: 'var(--ro-tag-red-fg)' }}>
+            Search {run.status.replace('_', ' ')} — {run.error || 'no results'}. Try again or narrow the area.
+          </p>
+        </div>
+      )}
+
+      {run?.status === 'completed' && (
+        <div className="rounded-2xl border border-border bg-white overflow-hidden">
+          <div className="flex items-center gap-3 flex-wrap px-4 py-3 border-b border-border">
+            <label className="flex items-center gap-2 text-sm font-medium cursor-pointer">
+              <input type="checkbox" checked={allSelected} onChange={toggleAll} disabled={selectable.length === 0} />
+              {selected.size > 0 ? `${selected.size} selected` : `${candidates.length} found`}
+            </label>
+            <span className="ml-auto flex items-center gap-2">
+              <Button size="sm" variant="outline" disabled={selected.size === 0 || enrichMutation.isPending}
+                onClick={() => enrichMutation.mutate([...selected])}>
+                <Sparkles className="w-4 h-4 mr-1.5" aria-hidden="true" /> Enrich
+              </Button>
+              <Button size="sm" disabled={selected.size === 0 || addMutation.isPending}
+                onClick={() => addMutation.mutate([...selected])}>
+                <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" />
+                {addMutation.isPending ? 'Adding…' : `Add ${selected.size || ''}`.trim()}
+              </Button>
+            </span>
+          </div>
+
+          {candidates.length === 0 && (
+            <p className="text-sm text-center py-10 m-0" style={{ color: 'var(--ro-text-2)' }}>
+              No businesses found — try a broader area.
+            </p>
+          )}
+
+          <ul className="m-0 p-0 list-none">
+            {candidates.map((c) => {
+              const badge = DEDUPE[c.dedupeStatus] || DEDUPE.new;
+              const isSelectable = c.status === 'pending' && c.dedupeStatus !== 'existing_partner';
+              const meta = [c.area, c.primaryPhone, c.rating && `★ ${c.rating}${c.reviewsCount ? ` (${c.reviewsCount})` : ''}`].filter(Boolean).join(' · ');
+              return (
+                <li key={c.id} className="flex items-center gap-3 px-4 py-3 border-t border-border first:border-t-0">
+                  <input
+                    type="checkbox" className="shrink-0"
+                    checked={selected.has(c.id)} disabled={!isSelectable}
+                    onChange={() => toggle(c.id)}
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="font-semibold text-[14px] flex items-center gap-2 leading-tight">
+                      <span className="truncate">{c.name}</span>
+                      {c.status === 'added' && <RoTag tone="completed" size="sm">Added</RoTag>}
+                    </span>
+                    <span className="block text-xs truncate" style={{ color: 'var(--ro-text-2)' }}>{meta || '—'}</span>
+                    {c.instagramHandle && (
+                      <span className="block text-[11px] truncate mt-0.5" style={{ color: 'var(--ro-text-3)' }}>
+                        @{c.instagramHandle}{c.followersCount != null ? ` · ${c.followersCount.toLocaleString()} followers` : ''}
+                      </span>
+                    )}
+                  </span>
+                  {c.dedupeStatus === 'existing_partner' && c.matchedPartnerId ? (
+                    <Link to={`/redeem-ops/partners/${c.matchedPartnerId}`} className="shrink-0">
+                      <RoTag tone={badge.tone} size="sm">{badge.label}</RoTag>
+                    </Link>
+                  ) : (
+                    <RoTag tone={badge.tone} size="sm" className="shrink-0">{badge.label}</RoTag>
+                  )}
+                  {isSelectable && (
+                    <button
+                      type="button" aria-label={`Dismiss ${c.name}`}
+                      className="shrink-0 text-[var(--ro-text-3)] hover:text-[var(--ro-bunker)]"
+                      onClick={() => dismissMutation.mutate(c.id)}
+                    >
+                      <X className="w-4 h-4" aria-hidden="true" />
+                    </button>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Starting outreach from **zero partners**, the only way to fill the pipeline was manual entry. **Discover** makes "find businesses to contact" a repeatable, deduped, one-click-to-pipeline motion: pick **category + area** → Apify Google Maps finds candidates → dedupe against existing partners → **bulk-add as `NEW`**, pre-tagged with the category. Plus **on-demand Instagram enrichment** (followers/bio/email) since outreach is IG-first.

Composes with the shipped pieces: category taxonomy (search category comes from it), dedupe engine, and the pipeline.

## How (backend — migration 053: `discovery_runs` + `discovery_candidates`)

- **Async job that never blocks the single Render instance**: start Apify actor → terminal webhook → **re-fetch run state from Apify** (authoritative) → materialize. Apify does **not** HMAC-sign, so the webhook is authed by a **URL-path secret** (constant-time) and the payload is never trusted — we re-fetch with our own token, so a spoofed webhook is harmless. Handles all terminal states (`SUCCEEDED/FAILED/ABORTED/TIMED-OUT`) + a **periodic in-process reconcile sweep** for missed webhooks / restarts.
- **Batched dedupe** — one set-based query against live partners (not 120×`findDuplicates`) marks `existing_partner`; `createPartner` runs the full fuzzy dedupe again at add-time as the real gate.
- **IG enrichment** — separate capped async run; **fill-blanks merge only**, email parsed low-confidence from bio.
- **Access = all principals** (`requireRedeemOps()`, no capability); paid-job cost bounded by **per-user + global daily quotas**. Adding routes through `createPartner` (`source='discovery'`; provenance via the candidate→partner link — no `sourceMetadata` column needed). Idempotent materialization via `unique(discoveryRunId, externalPlaceId)`.

## How (frontend)

`/redeem-ops/discover` in the Fresha frame: search bar (CategorySelect + area + limit), live server-status progress poll, results with **dedupe badges** + IG handle/followers, **Enrich** + **bulk Add**, dismiss, and a Discover nav item.

## Review

Built from a spec run through **Codex xhigh** review — every code-fact verified against the repo before folding. The review caught: the Apify webhook-auth assumption (not HMAC), the `findDuplicates` signature (`primaryPhone` not `phone`), the missing `sourceMetadata` column, the N-query dedupe, and incomplete terminal-state handling. All folded into v2 of the spec and this implementation.

## Testing

- 8 service tests (Apify mocked): start + quota (429), completed & failed processing, **idempotent** materialization, batched dedupe classify, convert (adds new, skips existing), IG enrichment fill-blanks, webhook secret.
- Migration 053 verified against a **live PG15** — index SQL valid + idempotent, partial unique constraints present.
- Full redeem-ops suite green **except** the pre-existing `redeemOpsRewards` PARTNERED-transition failure (already red on `main` — confirmed unrelated).

## Rollout

Dark behind **`DISCOVERY_ENABLED`** (also gates the reconcile sweep) + the existing `REDEEM_OPS_ENABLED`. Needs `APIFY_TOKEN` + `DISCOVERY_WEBHOOK_SECRET` set on the backend before enabling; all vars documented in `.env.example`. No effect until switched on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)