### PR TITLE
fix(redeem-ops): keep Discover dark behind VITE_DISCOVERY_ENABLED

### DIFF
--- a/src/components/redeemops/RedeemOpsLayout.jsx
+++ b/src/components/redeemops/RedeemOpsLayout.jsx
@@ -38,7 +38,11 @@ import '@/styles/redeem-ops-theme.css';
 const NAV = [
   { title: 'Queue', url: '/redeem-ops/queue', icon: House },
   { title: 'Partners', url: '/redeem-ops/partners', icon: Users, capability: 'partners.view' },
-  { title: 'Discover', url: '/redeem-ops/discover', icon: Compass },
+  // Discover has no capability gate (all principals), so its own build flag is what
+  // keeps it hidden until go-live (backend DISCOVERY_ENABLED + Apify token).
+  ...(import.meta.env.VITE_DISCOVERY_ENABLED === 'true'
+    ? [{ title: 'Discover', url: '/redeem-ops/discover', icon: Compass }]
+    : []),
   { title: 'Pipeline', url: '/redeem-ops/pipeline', icon: Kanban, capability: 'pipeline.view_team' },
   { title: 'Tasks', url: '/redeem-ops/tasks', icon: ListChecks, capability: 'tasks.manage' },
   { title: 'Pools', url: '/redeem-ops/pools', icon: Layers, capability: 'pools.claim_next' },

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -78,6 +78,7 @@ const AgentProfile = lazy(() => import('./AgentProfile'));
 // Redeem Ops — flag-gated internal staff surface (docs/redeem-ops/ROUTE_MAP.md §2).
 // Dark until VITE_REDEEM_OPS_ENABLED=true is baked into the build.
 const REDEEM_OPS_ENABLED = import.meta.env.VITE_REDEEM_OPS_ENABLED === 'true';
+const DISCOVERY_ENABLED = import.meta.env.VITE_DISCOVERY_ENABLED === 'true';
 const RedeemOpsHome = lazy(() => import('./redeemops/RedeemOpsHome'));
 const RedeemOpsTeam = lazy(() => import('./redeemops/RedeemOpsTeam'));
 const RedeemOpsPartnersList = lazy(() => import('./redeemops/PartnersList'));
@@ -114,7 +115,9 @@ function redeemOpsRouteElements() {
     { path: '/redeem-ops/team', capability: 'analytics.view_team', Page: RedeemOpsTeam },
     { path: '/redeem-ops/partners', capability: 'partners.view', Page: RedeemOpsPartnersList },
     { path: '/redeem-ops/partners/:id', capability: 'partners.view', Page: RedeemOpsPartnerDetail },
-    { path: '/redeem-ops/discover', capability: null, Page: RedeemOpsDiscover },
+    // Discover is dark until its own build flag AND the backend token are set —
+    // it has no capability gate (all principals), so this flag is what hides it.
+    ...(DISCOVERY_ENABLED ? [{ path: '/redeem-ops/discover', capability: null, Page: RedeemOpsDiscover }] : []),
     { path: '/redeem-ops/queue', capability: null, Page: RedeemOpsMyQueue },
     { path: '/redeem-ops/tasks', capability: 'tasks.manage', Page: RedeemOpsTasks },
     { path: '/redeem-ops/pools', capability: 'pools.claim_next', Page: RedeemOpsPools },


### PR DESCRIPTION
## Why

Discover (#124) has **no capability gate** — it's open to all ops principals by design. So unlike Settings (gated by `settings.manage`), nothing hid its nav item: it would appear for the whole ops team the moment the static sites redeployed, while any search returns a clean but useless "Discover is not enabled" 503 until the backend Apify token is configured. That contradicts merging it **dark**.

## Fix

Gate the Discover **route** (`src/pages/index.jsx`) and **nav item** (`RedeemOpsLayout.jsx`) behind a `VITE_DISCOVERY_ENABLED` build flag, matching the house `VITE_*` pattern. When off (default), the feature is fully unreachable — no nav, no route. The lazy chunk still builds but nothing references or fetches it.

## Go-live (both together)

- Static sites: `VITE_DISCOVERY_ENABLED=true`
- Backend: `DISCOVERY_ENABLED=true` + `APIFY_TOKEN` + `DISCOVERY_WEBHOOK_SECRET`

🤖 Generated with [Claude Code](https://claude.com/claude-code)