### PR TITLE
feat(redeem-ops): Discover redesign — triage-first results, first-run state, skeleton loading

### DIFF
--- a/backend/src/controllers/redeemOps/discoveryController.js
+++ b/backend/src/controllers/redeemOps/discoveryController.js
@@ -20,10 +20,13 @@ export const startDiscovery = asyncHandler(async (req, res) => {
   res.status(202).json({ success: true, data: { run } });
 });
 
-/** GET /discovery/runs — recent searches. */
+/** GET /discovery/runs — recent searches + the caller's remaining daily budget. */
 export const listRuns = asyncHandler(async (req, res) => {
-  const runs = await discoveryService.listRuns({ limit: Math.min(Number(req.query.limit) || 20, 50) });
-  res.json({ success: true, data: { runs } });
+  const [runs, quota] = await Promise.all([
+    discoveryService.listRuns({ limit: Math.min(Number(req.query.limit) || 20, 50) }),
+    discoveryService.getQuota(req.user),
+  ]);
+  res.json({ success: true, data: { runs, quota } });
 });
 
 /** GET /discovery/runs/:id — status + candidates (frontend polls this). */

--- a/backend/src/services/redeemOps/discoveryService.js
+++ b/backend/src/services/redeemOps/discoveryService.js
@@ -66,6 +66,16 @@ export function makeDiscoveryService(overrides = {}) {
     }
   }
 
+  /** Per-user search budget for the day (drives the UI's usage chip). */
+  async function getQuota(user) {
+    const c = cfg();
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const used = await d.DiscoveryRun.count({
+      where: { provider: 'apify_google_maps', createdBy: user.id, createdAt: { [Op.gte]: since } },
+    });
+    return { used, limit: c.maxRunsPerUserDay, remaining: Math.max(0, c.maxRunsPerUserDay - used) };
+  }
+
   function webhookUrl() {
     const c = cfg();
     if (!c.webhookSecret) return undefined;
@@ -352,8 +362,8 @@ export function makeDiscoveryService(overrides = {}) {
 
   return {
     startDiscovery, processRun, processByProviderRunId, enrichCandidates, addToPartners,
-    dismissCandidate, listRuns, getRunWithCandidates, reconcileStuckRuns, verifyWebhookSecret,
-    classifyAgainstPartners, materializeCandidates, applyEnrichment,
+    dismissCandidate, listRuns, getRunWithCandidates, getQuota, reconcileStuckRuns,
+    verifyWebhookSecret, classifyAgainstPartners, materializeCandidates, applyEnrichment,
   };
 }
 

--- a/backend/test/redeemOpsDiscovery.test.js
+++ b/backend/test/redeemOpsDiscovery.test.js
@@ -33,9 +33,17 @@ beforeAll(async () => {
 });
 
 afterAll(async () => { await closeDb(); });
+// Never let a per-test env override leak into the next test (providerRunId is
+// UNIQUE, so a fresh CI DB enforces it — a leaked limit cascades otherwise).
+afterEach(() => { delete process.env.DISCOVERY_MAX_RUNS_PER_USER_DAY; });
+
+let runIdSeq = 0;
+// mockImplementation (not mockResolvedValue) so each call yields a UNIQUE runId —
+// the providerRunId unique index would otherwise 409 the 2nd call on a fresh DB.
+const uniqueRunId = () => ({ runId: `run_${Date.now()}_${++runIdSeq}`, datasetId: 'ds1', status: 'RUNNING' });
 
 async function startedRun(svc, apify) {
-  apify.startRun.mockResolvedValue({ runId: `run_${Date.now()}_${Math.random()}`, datasetId: 'ds1', status: 'RUNNING' });
+  apify.startRun.mockImplementation(async () => uniqueRunId());
   return svc.startDiscovery({ category: 'Nail Salon', area: 'Tampines', limit: 60 }, admin.user);
 }
 
@@ -55,12 +63,12 @@ describe('start + quota', () => {
     const apify = makeApifyStub();
     const svc = makeDiscoveryService({ apify });
     const solo = await createTestUser({ role: 'admin' });
-    apify.startRun.mockResolvedValue({ runId: `r_${Math.random()}`, datasetId: 'ds', status: 'RUNNING' });
+    apify.startRun.mockImplementation(async () => uniqueRunId());
     await svc.startDiscovery({ category: 'Nail Salon', area: 'A', limit: 30 }, solo.user);
     await svc.startDiscovery({ category: 'Nail Salon', area: 'B', limit: 30 }, solo.user);
     await expect(svc.startDiscovery({ category: 'Nail Salon', area: 'C', limit: 30 }, solo.user))
       .rejects.toMatchObject({ statusCode: 429 });
-    delete process.env.DISCOVERY_MAX_RUNS_PER_USER_DAY;
+    // env cleanup handled by afterEach (leak-proof even if an assertion throws)
   });
 });
 

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -68,7 +68,7 @@ export const redeemOpsApi = {
   },
   async listDiscoveryRuns(params = {}) {
     const res = await apiClient.get('/redeem-ops/discovery/runs', params);
-    return res.data?.runs || [];
+    return { runs: res.data?.runs || [], quota: res.data?.quota || null };
   },
   async getDiscoveryRun(id) {
     const res = await apiClient.get(`/redeem-ops/discovery/runs/${id}`);

--- a/src/pages/redeemops/DiscoverPage.jsx
+++ b/src/pages/redeemops/DiscoverPage.jsx
@@ -13,40 +13,128 @@ import Search from 'lucide-react/icons/search';
 import Sparkles from 'lucide-react/icons/sparkles';
 import Plus from 'lucide-react/icons/plus';
 import X from 'lucide-react/icons/x';
-import { RoPageHeader, RoTag } from '@/components/redeemops/ui';
+import Check from 'lucide-react/icons/check';
+import ChevronRight from 'lucide-react/icons/chevron-right';
+import Instagram from 'lucide-react/icons/instagram';
+import Star from 'lucide-react/icons/star';
+import { RoPageHeader, RoTag, RoAvatar } from '@/components/redeemops/ui';
 import CategorySelect from '@/components/redeemops/CategorySelect';
 
 const TERMINAL = ['completed', 'failed', 'aborted', 'timed_out'];
+const RUNS_KEY = ['redeem-ops', 'discovery', 'runs'];
+
 const DEDUPE = {
   new: { tone: 'open', label: 'New' },
   possible_duplicate: { tone: 'paused', label: 'Possible dup' },
   existing_partner: { tone: 'archived', label: 'Already a partner' },
 };
+const SORTS = [
+  { v: 'followers', label: 'Followers' },
+  { v: 'rating', label: 'Rating' },
+  { v: 'reviews', label: 'Reviews' },
+  { v: 'name', label: 'Name' },
+];
+const POPULAR_AREAS = ['Tampines', 'Orchard', 'Jurong East', 'Katong', 'Bedok', 'Serangoon'];
+// Curated flavour for the common verticals; anything else falls back gracefully.
+const CURATED = {
+  'nail salon': { emoji: '💅', note: 'High density, strong IG reach' },
+  'facial & beauty': { emoji: '✨', note: 'Premium, high repeat value' },
+  'hair salon': { emoji: '💇', note: 'Owner-run, fast to reach' },
+  'lashes & brows': { emoji: '👁️', note: 'IG-native, easy yes' },
+  'massage & spa': { emoji: '🧖', note: 'Free-trial friendly' },
+  barbershop: { emoji: '💈', note: 'Owner-operated, quick yes' },
+  café: { emoji: '☕', note: 'High foot traffic' },
+  cafe: { emoji: '☕', note: 'High foot traffic' },
+  'dessert & bakery': { emoji: '🧁', note: 'Great consumer appeal' },
+  'gym & fitness': { emoji: '🏋️', note: 'Trial-offer playbook' },
+  'pet grooming': { emoji: '🐾', note: 'Loyal repeat customers' },
+};
+const num = (v) => (v == null ? -1 : v);
+const fmtFollowers = (n) => (n == null ? null : n >= 1000 ? `${(n / 1000).toFixed(1)}k` : `${n}`);
+const timeAgo = (iso) => {
+  if (!iso) return '';
+  const s = (Date.now() - new Date(iso).getTime()) / 1000;
+  if (s < 3600) return `${Math.max(1, Math.round(s / 60))}m ago`;
+  if (s < 86400) return `${Math.round(s / 3600)}h ago`;
+  return `${Math.round(s / 86400)}d ago`;
+};
 
 export default function DiscoverPage() {
   const queryClient = useQueryClient();
-  const [form, setForm] = useState({ category: '', area: '', limit: '60' });
+  const [form, setForm] = useState({ category: '', area: '', limit: '30' });
   const [runId, setRunId] = useState(null);
   const [selected, setSelected] = useState(() => new Set());
+  const [filter, setFilter] = useState('all');
+  const [sort, setSort] = useState('followers');
+
+  const listQuery = useQuery({ queryKey: RUNS_KEY, queryFn: () => redeemOpsApi.listDiscoveryRuns() });
+  const recentRuns = listQuery.data?.runs || [];
+  const quota = listQuery.data?.quota;
+  const categoriesQuery = useQuery({
+    queryKey: ['redeem-ops', 'categories'],
+    queryFn: () => redeemOpsApi.listCategories(),
+    staleTime: 60_000,
+  });
 
   const runQuery = useQuery({
     queryKey: ['redeem-ops', 'discovery', 'run', runId],
     queryFn: () => redeemOpsApi.getDiscoveryRun(runId),
     enabled: !!runId,
-    refetchInterval: (query) => (TERMINAL.includes(query.state.data?.run?.status) ? false : 2500),
+    refetchInterval: (q) => (TERMINAL.includes(q.state.data?.run?.status) ? false : 2500),
   });
   const run = runQuery.data?.run;
   const candidates = useMemo(() => runQuery.data?.candidates || [], [runQuery.data]);
   const isSearching = run && !TERMINAL.includes(run.status);
+  const failed = run && ['failed', 'aborted', 'timed_out'].includes(run.status);
 
+  const counts = useMemo(() => {
+    const c = { total: candidates.length, new: 0, partners: 0, possible: 0, ig: 0 };
+    for (const x of candidates) {
+      if (x.dedupeStatus === 'existing_partner') c.partners += 1;
+      else if (x.dedupeStatus === 'possible_duplicate') c.possible += 1;
+      else c.new += 1;
+      if (x.instagramHandle) c.ig += 1;
+    }
+    return c;
+  }, [candidates]);
+  const addedCount = useMemo(() => candidates.filter((c) => c.status === 'added').length, [candidates]);
+
+  const visible = useMemo(() => {
+    let list = candidates;
+    if (filter === 'new') list = list.filter((c) => c.dedupeStatus === 'new');
+    else if (filter === 'partners') list = list.filter((c) => c.dedupeStatus === 'existing_partner');
+    else if (filter === 'possible') list = list.filter((c) => c.dedupeStatus === 'possible_duplicate');
+    else if (filter === 'ig') list = list.filter((c) => c.instagramHandle);
+    const sorted = [...list];
+    if (sort === 'name') sorted.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+    else sorted.sort((a, b) => num(b[sort === 'followers' ? 'followersCount' : sort === 'rating' ? 'rating' : 'reviewsCount'])
+      - num(a[sort === 'followers' ? 'followersCount' : sort === 'rating' ? 'rating' : 'reviewsCount']));
+    return sorted;
+  }, [candidates, filter, sort]);
+
+  const selectableIds = useMemo(
+    () => visible.filter((c) => c.status === 'pending' && c.dedupeStatus !== 'existing_partner').map((c) => c.id),
+    [visible],
+  );
+  const allSelected = selectableIds.length > 0 && selectableIds.every((id) => selected.has(id));
+
+  const suggestions = useMemo(() => {
+    const cats = (categoriesQuery.data || []).map((c) => c.name);
+    return cats.slice(0, 6).map((cat, i) => {
+      const meta = CURATED[cat.toLowerCase()] || { emoji: '📍', note: 'Prospect this vertical' };
+      return { category: cat, area: POPULAR_AREAS[i % POPULAR_AREAS.length], ...meta };
+    });
+  }, [categoriesQuery.data]);
+
+  // ── Mutations ──────────────────────────────────────────────────────────
   const startMutation = useMutation({
-    mutationFn: () => redeemOpsApi.startDiscovery({
-      category: form.category, area: form.area.trim(), limit: Number(form.limit),
-    }),
-    onSuccess: (r) => { setRunId(r.id); setSelected(new Set()); },
+    mutationFn: (body) => redeemOpsApi.startDiscovery(body),
+    onSuccess: (r) => {
+      setRunId(r.id); setSelected(new Set()); setFilter('all'); setSort('followers');
+      queryClient.invalidateQueries({ queryKey: RUNS_KEY });
+    },
     onError: (err) => toast.error('Could not start search', { description: err.message }),
   });
-
   const addMutation = useMutation({
     mutationFn: (ids) => redeemOpsApi.addDiscoveryCandidates(runId, ids),
     onSuccess: (res) => {
@@ -59,86 +147,169 @@ export default function DiscoverPage() {
     },
     onError: (err) => toast.error('Could not add', { description: err.message }),
   });
-
   const enrichMutation = useMutation({
     mutationFn: (ids) => redeemOpsApi.enrichDiscoveryCandidates(ids),
     onSuccess: () => {
-      toast.success('Enriching from Instagram — refresh in a moment for followers & bio');
-      setSelected(new Set());
+      toast.success('Enriching from Instagram — followers & bio fill in shortly');
       setTimeout(() => runQuery.refetch(), 4000);
     },
     onError: (err) => toast.error('Could not enrich', { description: err.message }),
   });
-
   const dismissMutation = useMutation({
     mutationFn: (id) => redeemOpsApi.dismissDiscoveryCandidate(id),
     onSuccess: () => runQuery.refetch(),
   });
 
-  const selectable = useMemo(
-    () => candidates.filter((c) => c.status === 'pending' && c.dedupeStatus !== 'existing_partner'),
-    [candidates],
-  );
+  const runSearch = (category, area, limit = 30) => {
+    if (!category || !String(area).trim()) return;
+    setForm({ category, area, limit: String(limit) });
+    startMutation.mutate({ category, area: String(area).trim(), limit: Number(limit) });
+  };
   const toggle = (id) => setSelected((prev) => {
-    const next = new Set(prev);
-    next.has(id) ? next.delete(id) : next.add(id);
-    return next;
+    const next = new Set(prev); next.has(id) ? next.delete(id) : next.add(id); return next;
   });
-  const allSelected = selectable.length > 0 && selectable.every((c) => selected.has(c.id));
-  const toggleAll = () => setSelected(allSelected ? new Set() : new Set(selectable.map((c) => c.id)));
-
+  const toggleAll = () => setSelected(allSelected ? new Set() : new Set(selectableIds));
+  const enrichAll = () => {
+    const ids = candidates.filter((c) => c.instagramHandle && c.enrichmentStatus !== 'enriched' && c.status !== 'dismissed').map((c) => c.id);
+    if (ids.length === 0) { toast.info('Nothing to enrich — no un-enriched Instagram handles'); return; }
+    enrichMutation.mutate(ids);
+  };
   const canSearch = form.category && form.area.trim() && !startMutation.isPending;
 
   return (
-    <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-6">
+    <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-6 pb-24">
       <RoPageHeader
         title="Discover"
-        sub="Find businesses to prospect by category and area, skip the ones you already have, and add the rest to your pipeline in one click."
+        sub="Find businesses to prospect by category and area — deduped against your partners, one click to your pipeline."
+        actions={quota && (
+          <span className="hidden sm:inline-flex items-center gap-2 text-[12.5px] font-semibold rounded-full px-3 py-1.5"
+            style={{ color: 'var(--ro-text-2)', background: 'var(--ro-subtle)', border: '1px solid var(--ro-border)' }}>
+            <i className="w-[7px] h-[7px] rounded-full" style={{ background: quota.remaining > 0 ? 'var(--ro-tag-green-fg)' : 'var(--ro-tag-red-fg)' }} />
+            <b style={{ color: 'var(--ro-bunker)' }}>{quota.used}</b> of {quota.limit} searches today
+          </span>
+        )}
       />
 
-      <div className="rounded-2xl border border-border bg-white p-4 md:p-5">
-        <div className="grid gap-3 md:grid-cols-[1fr_1fr_auto_auto] md:items-end">
-          <div className="space-y-1.5">
-            <Label>Category</Label>
-            <CategorySelect value={form.category} onChange={(v) => setForm((f) => ({ ...f, category: v }))} />
+      {/* ── First-run: search + suggested + recent ───────────────────────── */}
+      {!runId && (
+        <>
+          <div className="rounded-2xl border border-border bg-white p-4 md:p-5">
+            <div className="grid gap-3 md:grid-cols-[1fr_1fr_120px_auto] md:items-end">
+              <div className="space-y-1.5">
+                <Label>Category</Label>
+                <CategorySelect value={form.category} onChange={(v) => setForm((f) => ({ ...f, category: v }))} />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="disc-area">Area</Label>
+                <Input id="disc-area" value={form.area} placeholder="Neighbourhood or district…"
+                  onChange={(e) => setForm((f) => ({ ...f, area: e.target.value }))}
+                  onKeyDown={(e) => { if (e.key === 'Enter' && canSearch) runSearch(form.category, form.area, form.limit); }} />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Results</Label>
+                <Select value={form.limit} onValueChange={(v) => setForm((f) => ({ ...f, limit: v }))}>
+                  <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+                  <SelectContent>{['30', '60', '120'].map((n) => <SelectItem key={n} value={n}>{n}</SelectItem>)}</SelectContent>
+                </Select>
+              </div>
+              <Button disabled={!canSearch} onClick={() => runSearch(form.category, form.area, form.limit)}>
+                <Search className="w-4 h-4 mr-1.5" aria-hidden="true" />{startMutation.isPending ? 'Starting…' : 'Search'}
+              </Button>
+            </div>
+            <div className="flex flex-wrap items-center gap-2 mt-3">
+              <span className="text-xs font-semibold" style={{ color: 'var(--ro-text-3)' }}>Popular areas</span>
+              {POPULAR_AREAS.map((a) => (
+                <button key={a} type="button" onClick={() => setForm((f) => ({ ...f, area: a }))}
+                  className="h-7 px-3 rounded-full text-[12.5px] font-semibold"
+                  style={{ background: 'var(--ro-subtle)', border: '1px solid var(--ro-border)', color: 'var(--ro-text-2)' }}>{a}</button>
+              ))}
+            </div>
           </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="disc-area">Area</Label>
-            <Input
-              id="disc-area" value={form.area} placeholder="Tampines"
-              onChange={(e) => setForm((f) => ({ ...f, area: e.target.value }))}
-              onKeyDown={(e) => { if (e.key === 'Enter' && canSearch) startMutation.mutate(); }}
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label>Results</Label>
-            <Select value={form.limit} onValueChange={(v) => setForm((f) => ({ ...f, limit: v }))}>
-              <SelectTrigger className="w-28"><SelectValue /></SelectTrigger>
-              <SelectContent>
-                {['30', '60', '120'].map((n) => <SelectItem key={n} value={n}>{n}</SelectItem>)}
-              </SelectContent>
-            </Select>
-          </div>
-          <Button disabled={!canSearch} onClick={() => startMutation.mutate()}>
-            <Search className="w-4 h-4 mr-1.5" aria-hidden="true" />
-            {startMutation.isPending ? 'Starting…' : 'Search'}
-          </Button>
-        </div>
-        <p className="text-xs mt-2 m-0" style={{ color: 'var(--ro-text-3)' }}>
-          Pulls businesses from Google Maps (~a minute). Instagram handles fill in via Enrich.
-        </p>
-      </div>
 
-      {isSearching && (
-        <div className="rounded-2xl border border-border bg-white p-8 text-center">
-          <div className="ro-progress mb-3 max-w-xs mx-auto"><i style={{ width: '60%' }} /></div>
-          <p className="text-sm m-0" style={{ color: 'var(--ro-text-2)' }}>
-            Searching Google Maps for “{run.category} {run.area}”… this takes about a minute.
-          </p>
+          {suggestions.length > 0 && (
+            <div>
+              <h2 className="text-[13px] font-bold mb-3" style={{ color: 'var(--ro-text-2)' }}>Suggested searches</h2>
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {suggestions.map((s) => (
+                  <button key={`${s.category}-${s.area}`} type="button" onClick={() => runSearch(s.category, s.area, 60)}
+                    className="flex items-center gap-3 rounded-2xl border border-border bg-white p-4 text-left hover:bg-[var(--ro-subtle)]">
+                    <span className="w-10 h-10 rounded-xl grid place-items-center text-lg shrink-0" style={{ background: 'var(--ro-subtle)' }}>{s.emoji}</span>
+                    <span className="min-w-0">
+                      <b className="text-[14px] block truncate">{s.category} · {s.area}</b>
+                      <span className="text-[12.5px]" style={{ color: 'var(--ro-text-3)' }}>{s.note}</span>
+                    </span>
+                    <ChevronRight className="w-4 h-4 ml-auto shrink-0" style={{ color: 'var(--ro-text-3)' }} aria-hidden="true" />
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {recentRuns.length > 0 && (
+            <div>
+              <h2 className="text-[13px] font-bold mb-3" style={{ color: 'var(--ro-text-2)' }}>Recent searches</h2>
+              <div className="rounded-2xl border border-border bg-white overflow-hidden">
+                {recentRuns.map((r) => (
+                  <button key={r.id} type="button" onClick={() => { setRunId(r.id); setSelected(new Set()); setFilter('all'); }}
+                    className="w-full flex items-center gap-3.5 px-4 py-3 border-t border-border first:border-t-0 text-left hover:bg-[var(--ro-subtle)]">
+                    <span className="w-[34px] h-[34px] rounded-[10px] grid place-items-center shrink-0" style={{ background: 'var(--ro-azure-tint)', color: 'var(--ro-azure)' }}>
+                      <Search className="w-4 h-4" aria-hidden="true" />
+                    </span>
+                    <span className="min-w-0">
+                      <b className="text-[14px] block truncate">{r.category} · {r.area}</b>
+                      <span className="text-[12.5px]" style={{ color: 'var(--ro-text-3)' }}>
+                        {timeAgo(r.createdAt)} · {r.resultCount || 0} result{r.resultCount === 1 ? '' : 's'}
+                        {!TERMINAL.includes(r.status) && ' · running…'}
+                      </span>
+                    </span>
+                    <span className="ml-auto text-[12.5px] font-semibold shrink-0" style={{ color: 'var(--ro-text-2)' }}>Open results ›</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      {/* ── Active run: query bar ─────────────────────────────────────────── */}
+      {runId && (
+        <div className="flex items-center gap-2 flex-wrap rounded-2xl border border-border bg-white px-4 py-3">
+          {[['Category', run?.category], ['Area', run?.area], ['Results', run?.requestedLimit]].map(([k, v]) => (
+            <span key={k} className="inline-flex items-center gap-2 h-9 px-3.5 rounded-full text-[13.5px] font-semibold" style={{ border: '1px solid var(--ro-border-strong)' }}>
+              <span style={{ color: 'var(--ro-text-3)', fontWeight: 500 }}>{k}</span> {v ?? '—'}
+            </span>
+          ))}
+          <button type="button" onClick={() => setRunId(null)}
+            className="ml-auto h-9 px-4 rounded-full text-[13px] font-semibold" style={{ border: '1px solid var(--ro-border-strong)', background: '#fff' }}>New search</button>
         </div>
       )}
 
-      {run && ['failed', 'aborted', 'timed_out'].includes(run.status) && (
+      {/* Searching — skeleton */}
+      {isSearching && (
+        <div>
+          <div className="flex items-center gap-3 mb-3">
+            <span className="w-[18px] h-[18px] rounded-full animate-spin" style={{ border: '2.4px solid var(--ro-azure-tint)', borderTopColor: 'var(--ro-azure)' }} />
+            <b className="text-[15px]">Searching Google Maps…</b>
+            <span className="hidden sm:inline text-[13px]" style={{ color: 'var(--ro-text-2)' }}>usually 30–60 seconds · you can keep working other tabs</span>
+          </div>
+          <div className="rounded-2xl border border-border bg-white overflow-hidden">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-3 px-4 border-t border-border first:border-t-0" style={{ height: 64 }}>
+                <span className="ro-sk" style={{ width: 19, height: 19, borderRadius: 6 }} />
+                <span className="ro-sk" style={{ width: 38, height: 38, borderRadius: 11 }} />
+                <span className="flex flex-col gap-2 flex-1">
+                  <span className="ro-sk" style={{ width: `${40 + (i % 3) * 12}%`, height: 12 }} />
+                  <span className="ro-sk" style={{ width: '90px', height: 10 }} />
+                </span>
+                <span className="ro-sk" style={{ width: 120, height: 12 }} />
+                <span className="ro-sk" style={{ width: 60, height: 22, borderRadius: 8 }} />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {failed && (
         <div className="rounded-2xl border border-border bg-white p-6 text-center">
           <p className="text-sm m-0" style={{ color: 'var(--ro-tag-red-fg)' }}>
             Search {run.status.replace('_', ' ')} — {run.error || 'no results'}. Try again or narrow the area.
@@ -146,78 +317,130 @@ export default function DiscoverPage() {
         </div>
       )}
 
+      {/* Completed — results */}
       {run?.status === 'completed' && (
-        <div className="rounded-2xl border border-border bg-white overflow-hidden">
-          <div className="flex items-center gap-3 flex-wrap px-4 py-3 border-b border-border">
-            <label className="flex items-center gap-2 text-sm font-medium cursor-pointer">
-              <input type="checkbox" checked={allSelected} onChange={toggleAll} disabled={selectable.length === 0} />
-              {selected.size > 0 ? `${selected.size} selected` : `${candidates.length} found`}
-            </label>
-            <span className="ml-auto flex items-center gap-2">
-              <Button size="sm" variant="outline" disabled={selected.size === 0 || enrichMutation.isPending}
-                onClick={() => enrichMutation.mutate([...selected])}>
-                <Sparkles className="w-4 h-4 mr-1.5" aria-hidden="true" /> Enrich
-              </Button>
-              <Button size="sm" disabled={selected.size === 0 || addMutation.isPending}
-                onClick={() => addMutation.mutate([...selected])}>
-                <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" />
-                {addMutation.isPending ? 'Adding…' : `Add ${selected.size || ''}`.trim()}
-              </Button>
-            </span>
+        <div>
+          <div className="flex items-center gap-2 flex-wrap mb-3.5">
+            {selectableIds.length > 0 && (
+              <button type="button" aria-label={allSelected ? 'Clear selection' : 'Select all'} onClick={toggleAll}
+                className="w-[19px] h-[19px] rounded-md grid place-items-center shrink-0"
+                style={{ border: allSelected ? '1.8px solid var(--ro-azure)' : '1.8px solid var(--ro-border-strong)', background: allSelected ? 'var(--ro-azure)' : '#fff' }}>
+                {allSelected && <Check className="w-3 h-3" style={{ color: '#fff' }} strokeWidth={3} aria-hidden="true" />}
+              </button>
+            )}
+            <span className="text-[15px] font-bold mr-1">{selected.size > 0 ? `${selected.size} selected` : `${counts.total} found`}</span>
+            <Seg on={filter === 'all'} onClick={() => setFilter('all')}>All <b className="tabular-nums">{counts.total}</b></Seg>
+            <Seg on={filter === 'new'} onClick={() => setFilter('new')} dot="var(--ro-tag-blue-fg)">New <b className="tabular-nums">{counts.new}</b></Seg>
+            <Seg on={filter === 'partners'} onClick={() => setFilter('partners')} dot="var(--ro-tag-gray-fg)">Partners <b className="tabular-nums">{counts.partners}</b></Seg>
+            {counts.possible > 0 && <Seg on={filter === 'possible'} onClick={() => setFilter('possible')} dot="var(--ro-tag-yellow-fg)">Possible dup <b className="tabular-nums">{counts.possible}</b></Seg>}
+            <Seg on={filter === 'ig'} onClick={() => setFilter('ig')}>Has Instagram <b className="tabular-nums">{counts.ig}</b></Seg>
+            <span className="flex-1" />
+            <button type="button" onClick={enrichAll} disabled={enrichMutation.isPending}
+              className="inline-flex items-center gap-2 h-8 px-3.5 rounded-full text-[13px] font-semibold"
+              style={{ border: '1px solid var(--ro-azure)', background: 'var(--ro-azure-tint)', color: 'var(--ro-azure-dark)' }}>
+              <Sparkles className="w-[15px] h-[15px]" aria-hidden="true" />Enrich all with Instagram
+            </button>
+            <Select value={sort} onValueChange={setSort}>
+              <SelectTrigger className="w-auto h-8 gap-1.5"><span style={{ color: 'var(--ro-text-3)' }}>Sort</span><SelectValue /></SelectTrigger>
+              <SelectContent>{SORTS.map((s) => <SelectItem key={s.v} value={s.v}>{s.label}</SelectItem>)}</SelectContent>
+            </Select>
           </div>
 
-          {candidates.length === 0 && (
-            <p className="text-sm text-center py-10 m-0" style={{ color: 'var(--ro-text-2)' }}>
-              No businesses found — try a broader area.
-            </p>
-          )}
-
-          <ul className="m-0 p-0 list-none">
-            {candidates.map((c) => {
+          <div className="rounded-2xl border border-border bg-white overflow-hidden">
+            {visible.length === 0 && (
+              <p className="text-sm text-center py-10 m-0" style={{ color: 'var(--ro-text-2)' }}>
+                {counts.total === 0 ? 'No businesses found — try a broader area.' : 'Nothing in this filter.'}
+              </p>
+            )}
+            {visible.map((c) => {
               const badge = DEDUPE[c.dedupeStatus] || DEDUPE.new;
-              const isSelectable = c.status === 'pending' && c.dedupeStatus !== 'existing_partner';
-              const meta = [c.area, c.primaryPhone, c.rating && `★ ${c.rating}${c.reviewsCount ? ` (${c.reviewsCount})` : ''}`].filter(Boolean).join(' · ');
+              const selectable = c.status === 'pending' && c.dedupeStatus !== 'existing_partner';
+              const isSel = selected.has(c.id);
+              const isPartner = c.dedupeStatus === 'existing_partner';
               return (
-                <li key={c.id} className="flex items-center gap-3 px-4 py-3 border-t border-border first:border-t-0">
-                  <input
-                    type="checkbox" className="shrink-0"
-                    checked={selected.has(c.id)} disabled={!isSelectable}
-                    onChange={() => toggle(c.id)}
-                  />
-                  <span className="min-w-0 flex-1">
-                    <span className="font-semibold text-[14px] flex items-center gap-2 leading-tight">
-                      <span className="truncate">{c.name}</span>
-                      {c.status === 'added' && <RoTag tone="completed" size="sm">Added</RoTag>}
-                    </span>
-                    <span className="block text-xs truncate" style={{ color: 'var(--ro-text-2)' }}>{meta || '—'}</span>
-                    {c.instagramHandle && (
-                      <span className="block text-[11px] truncate mt-0.5" style={{ color: 'var(--ro-text-3)' }}>
-                        @{c.instagramHandle}{c.followersCount != null ? ` · ${c.followersCount.toLocaleString()} followers` : ''}
+                <div key={c.id}
+                  className={`grid items-center gap-2 md:gap-3 px-3 md:px-4 border-t border-border first:border-t-0 relative ${isSel ? 'bg-[var(--ro-azure-tint)]' : ''} ${isPartner ? 'opacity-55' : ''}`}
+                  style={{ gridTemplateColumns: '26px minmax(0,2.3fr) 0.9fr 1.5fr auto', minHeight: 64 }}>
+                  {isSel && <span className="absolute left-0 top-0 bottom-0 w-[3px]" style={{ background: 'var(--ro-azure)' }} />}
+                  <button type="button" aria-label={selectable ? `Select ${c.name}` : undefined} disabled={!selectable}
+                    onClick={() => selectable && toggle(c.id)}
+                    className="w-[19px] h-[19px] rounded-md grid place-items-center shrink-0"
+                    style={{ border: isSel ? '1.8px solid var(--ro-azure)' : '1.8px solid var(--ro-border-strong)', background: isSel ? 'var(--ro-azure)' : '#fff', opacity: selectable ? 1 : 0.4 }}>
+                    {isSel && <Check className="w-3 h-3" style={{ color: '#fff' }} strokeWidth={3} aria-hidden="true" />}
+                  </button>
+                  <span className="flex items-center gap-3 min-w-0">
+                    <RoAvatar name={c.name} size={38} />
+                    <span className="min-w-0">
+                      <b className="text-[14px] font-semibold block leading-tight flex items-center gap-2">
+                        <span className="truncate">{c.name}</span>
+                        {c.status === 'added' && <RoTag tone="completed" size="sm">Added</RoTag>}
+                      </b>
+                      <span className="text-[12.5px] block truncate" style={{ color: 'var(--ro-text-2)' }}>
+                        {[c.category, c.area].filter(Boolean).join(' · ') || c.primaryPhone || '—'}
                       </span>
+                    </span>
+                  </span>
+                  <span className="text-[13px] font-semibold tabular-nums hidden sm:flex items-center gap-1.5">
+                    {c.rating != null ? (<><Star className="w-3.5 h-3.5" style={{ fill: '#F5A623', stroke: 'none' }} aria-hidden="true" />{c.rating}<span style={{ color: 'var(--ro-text-3)', fontWeight: 500 }}>{c.reviewsCount ? `(${c.reviewsCount})` : ''}</span></>) : <span style={{ color: 'var(--ro-text-3)' }}>—</span>}
+                  </span>
+                  <span className="hidden md:flex items-center gap-2 text-[13px] min-w-0">
+                    {c.instagramHandle ? (
+                      <>
+                        <span className="ro-ig-badge w-[26px] h-[26px] rounded-lg grid place-items-center shrink-0"><Instagram className="w-[15px] h-[15px]" style={{ color: '#fff' }} aria-hidden="true" /></span>
+                        <span className="truncate" style={{ color: 'var(--ro-text-2)' }}>@{c.instagramHandle}{c.followersCount != null ? ' ·' : ''}</span>
+                        {c.followersCount != null
+                          ? <b className="tabular-nums" style={{ color: c.followersCount >= 10000 ? 'var(--ro-tag-purple-fg)' : 'var(--ro-bunker)' }}>{fmtFollowers(c.followersCount)}</b>
+                          : selectable && <button type="button" onClick={() => enrichMutation.mutate([c.id])} className="ro-link text-[12px] font-semibold">followers?</button>}
+                      </>
+                    ) : <span className="text-[12.5px]" style={{ color: 'var(--ro-text-3)' }}>No Instagram</span>}
+                  </span>
+                  <span className="justify-self-end flex items-center gap-2">
+                    {isPartner && c.matchedPartnerId
+                      ? <Link to={`/redeem-ops/partners/${c.matchedPartnerId}`}><RoTag tone={badge.tone} size="sm">{badge.label} ›</RoTag></Link>
+                      : <RoTag tone={badge.tone} size="sm">{badge.label}</RoTag>}
+                    {selectable && (
+                      <button type="button" aria-label={`Dismiss ${c.name}`} onClick={() => dismissMutation.mutate(c.id)}
+                        className="shrink-0" style={{ color: 'var(--ro-text-3)' }}><X className="w-4 h-4" aria-hidden="true" /></button>
                     )}
                   </span>
-                  {c.dedupeStatus === 'existing_partner' && c.matchedPartnerId ? (
-                    <Link to={`/redeem-ops/partners/${c.matchedPartnerId}`} className="shrink-0">
-                      <RoTag tone={badge.tone} size="sm">{badge.label}</RoTag>
-                    </Link>
-                  ) : (
-                    <RoTag tone={badge.tone} size="sm" className="shrink-0">{badge.label}</RoTag>
-                  )}
-                  {isSelectable && (
-                    <button
-                      type="button" aria-label={`Dismiss ${c.name}`}
-                      className="shrink-0 text-[var(--ro-text-3)] hover:text-[var(--ro-bunker)]"
-                      onClick={() => dismissMutation.mutate(c.id)}
-                    >
-                      <X className="w-4 h-4" aria-hidden="true" />
-                    </button>
-                  )}
-                </li>
+                </div>
               );
             })}
-          </ul>
+          </div>
+        </div>
+      )}
+
+      {/* Sticky bulk-add dock */}
+      {selected.size > 0 && (
+        <div className="ro-dock flex items-center gap-3 px-4 md:px-8 py-3">
+          <span className="w-[22px] h-[22px] rounded-md grid place-items-center shrink-0" style={{ background: 'var(--ro-azure)' }}>
+            <Check className="w-3.5 h-3.5" style={{ color: '#fff' }} strokeWidth={3} aria-hidden="true" />
+          </span>
+          <b className="text-[14px]">{selected.size} selected</b>
+          <button type="button" className="text-[13px] font-semibold underline" style={{ color: 'var(--ro-text-2)' }} onClick={() => setSelected(new Set())}>Clear</button>
+          {addedCount > 0 && <span className="hidden sm:inline text-[12.5px]" style={{ color: 'var(--ro-text-3)' }}>· {addedCount} added this search</span>}
+          <span className="flex-1" />
+          <Button variant="outline" size="sm" disabled={enrichMutation.isPending} onClick={() => enrichMutation.mutate([...selected])}>
+            <Sparkles className="w-4 h-4 mr-1.5" aria-hidden="true" />Enrich
+          </Button>
+          <Button size="sm" disabled={addMutation.isPending} onClick={() => addMutation.mutate([...selected])}>
+            <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" />{addMutation.isPending ? 'Adding…' : `Add ${selected.size} to pipeline`}
+          </Button>
         </div>
       )}
     </div>
+  );
+}
+
+function Seg({ on, onClick, dot, children }) {
+  return (
+    <button type="button" onClick={onClick}
+      className="inline-flex items-center gap-1.5 h-8 px-3 rounded-full text-[13px] font-semibold"
+      style={on
+        ? { background: 'var(--ro-bunker)', color: '#fff', border: '1px solid var(--ro-bunker)' }
+        : { background: '#fff', color: 'var(--ro-text-2)', border: '1px solid var(--ro-border-strong)' }}>
+      {dot && <span className="w-2 h-2 rounded-full" style={{ background: dot }} />}
+      {children}
+    </button>
   );
 }

--- a/src/styles/redeem-ops-theme.css
+++ b/src/styles/redeem-ops-theme.css
@@ -292,6 +292,41 @@
   transition: width 300ms ease;
 }
 
+/* ── Skeleton shimmer (Discover searching state) ─────────────────────── */
+.ro-sk {
+  background: linear-gradient(90deg, #eef1f3 25%, #f6f8f9 37%, #eef1f3 63%);
+  background-size: 400% 100%;
+  animation: ro-sk-shimmer 1.4s ease infinite;
+  border-radius: 7px;
+}
+@keyframes ro-sk-shimmer {
+  0% { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}
+
+/* Instagram gradient chip (Discover reach signal) */
+.ro-ig-badge {
+  background: linear-gradient(135deg, #f58529, #dd2a7b 55%, #8134af);
+}
+
+/* Sticky bulk-action dock (Discover) — clears the rail on desktop, the tab bar on mobile */
+.ro-dock {
+  position: fixed;
+  left: 78px;
+  right: 0;
+  bottom: 0;
+  z-index: 35;
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(10px);
+  border-top: 1px solid var(--ro-border);
+}
+@media (max-width: 767px) {
+  .ro-dock {
+    left: 0;
+    bottom: calc(62px + env(safe-area-inset-bottom));
+  }
+}
+
 /* ── Docket group labels ─────────────────────────────────────────────── */
 .ro-group-label {
   font-size: 12.5px;


### PR DESCRIPTION
## What

Rebuilds the Discover page from a *form-that-returns-a-list* into a **triage tool**, matching the three mockups designed in the Redeem Ops Design System. The job is **scan → judge → grab the winners**, and every change serves that.

## The three states

- **First run** (was a blank page): search bar with **popular-area chips**, **suggested searches** drawn from the live category taxonomy (so they're always addable), and **recent searches** you can reopen without spending another paid run.
- **Searching** (was a lone progress bar): **skeleton rows** shimmer into place, with a "keep working other tabs" note.
- **Results** (was a flat list): a **summary bar** (`34 found · New 24 · Partners 6 · Possible 4 · Has Instagram 19`) where each segment **filters**; **sort by follower reach** / rating / reviews / name; **"Enrich all with Instagram"** (reach is the IG-first prioritization signal); **rich rows** with rating+reviews, IG handle+followers, dedupe badge; **already-a-partner rows dimmed**; and a **sticky bulk-add dock** (`N selected · Enrich · Add N to pipeline`) that clears the rail on desktop and the tab bar on mobile.
- A per-user **"X of 5 searches today"** quota chip for cost awareness.

## Changes

- **Backend:** `getQuota(user)` on `discoveryService` + quota in the `GET /discovery/runs` response. (All other data — counts, followers, dedupe — is computed client-side from the existing candidate fields.)
- **Frontend:** full `DiscoverPage.jsx` rewrite (three states, filters/sort, sticky dock); skeleton-shimmer + dock + IG-badge styles in `redeem-ops-theme.css`.

## Also fixes a latent test bug

The quota work surfaced a flaky discovery test: the Apify mock used `mockResolvedValue` with `Math.random()` — **one id reused across calls** — which 409'd on the `providerRunId` unique index **on a fresh CI DB** (indexes exist there via the migration) and leaked `DISCOVERY_MAX_RUNS_PER_USER_DAY` into the next test. Now unique-id-per-call + a leak-proof `afterEach`. **8/8 stable across fresh DBs.**

## Testing

Full redeem-ops suite green except the pre-existing `redeemOpsRewards` PARTNERED failure (already red on `main`). Frontend builds clean (flag on), lint clean.

## Rollout

Same dark flags as the Discover feature (`DISCOVERY_ENABLED` + `VITE_DISCOVERY_ENABLED`) — this only changes the page you already turned on. Ships when the static sites redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)