### PR TITLE
fix(redeem): smooth-scroll anchor navigation + sticky-nav clearance

### DIFF
--- a/src/pages/redeemHome.css
+++ b/src/pages/redeemHome.css
@@ -26,9 +26,17 @@
   line-height: 1.5;
   min-height: 100vh;
   -webkit-font-smoothing: antialiased;
-  scroll-behavior: smooth;
 }
 .rh-page * { box-sizing: border-box; }
+
+/* Smooth anchor scrolling must live on the document scroller (html), not the
+   .rh-page div (which never scrolls itself) — scoped to when the homepage is
+   mounted so the admin app is untouched. */
+@media (prefers-reduced-motion: no-preference) {
+  html:has(.rh-page) { scroll-behavior: smooth; }
+}
+/* Anchored sections stop clear of the 76px sticky nav. */
+.rh-page [id] { scroll-margin-top: 92px; }
 .rh-page a { color: inherit; text-decoration: none; }
 
 .rh-wrap { max-width: 1200px; margin: 0 auto; padding: 0 40px; }


### PR DESCRIPTION
Anchor clicks (#drops, #legit, #partners, footer links, the lime CTA chip) now glide to their section instead of jumping — `scroll-behavior: smooth` was on `.rh-page`, which doesn't scroll; it now targets `html` scoped via `:has(.rh-page)` (admin app untouched, `prefers-reduced-motion` respected). Sections also get `scroll-margin-top: 92px` so they stop below the sticky nav instead of underneath it.

Verified with Playwright: scrollY animates through intermediate positions after a nav click; #legit lands at y=92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FS33kQWQVbULWpXs54z6Kn