### PR TITLE
fix(redeem): per-section anchor offsets — content lands near the nav

### DIFF
--- a/src/pages/redeemHome.css
+++ b/src/pages/redeemHome.css
@@ -35,8 +35,12 @@
 @media (prefers-reduced-motion: no-preference) {
   html:has(.rh-page) { scroll-behavior: smooth; }
 }
-/* Anchored sections stop clear of the 76px sticky nav. */
+/* Anchored sections stop clear of the 76px sticky nav. Sections with deep
+   internal top padding get a tighter offset so their whitespace tucks under
+   the nav and the first real content lands near the top of the viewport
+   (the black #legit section sits flush against the nav). */
 .rh-page [id] { scroll-margin-top: 92px; }
+.rh-page #how, .rh-page #legit, .rh-page #clients, .rh-page #partners { scroll-margin-top: 24px; }
 .rh-page a { color: inherit; text-decoration: none; }
 
 .rh-wrap { max-width: 1200px; margin: 0 auto; padding: 0 40px; }


### PR DESCRIPTION
Follow-up to #130. Anchors were top-aligning correctly, but sections with 76–92px internal top padding made the first visible content land 150–291px down (previous section still peeking above) — perceived as misalignment. Deep-padded sections now use a 24px scroll offset so their padding tucks under the sticky nav; content consistently lands ~140–157px from the top and the black legit section sits flush under the nav. Measured before/after with Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FS33kQWQVbULWpXs54z6Kn