### PR TITLE
fix(redeem): honest copy — as-and-when drops, lucky draws & partner offers, no SMS-delivery claim

### DIFF
--- a/src/pages/RedeemHome.jsx
+++ b/src/pages/RedeemHome.jsx
@@ -17,7 +17,7 @@ import './redeemHome.css';
 
 const PAGE_TITLE = 'Redeem — Free stuff from real Singapore brands';
 const PAGE_DESCRIPTION =
-  'Real vouchers from real Singapore brands, dropped every week. Claim in 30 seconds — no app, no points, no credit card. A service of MKTR PTE. LTD.';
+  'Vouchers, lucky draws and partner offers from real Singapore brands. Claim in 30 seconds — no app, no points, no credit card. A service of MKTR PTE. LTD.';
 
 /** "Ends Sunday"-style chip from the API's YYYY-MM-DD (SGT end-of-day). */
 function endsLabel(endsAt) {
@@ -190,16 +190,16 @@ export default function RedeemHome() {
                 <span className="rh-sticker__dot" />
                 {liveDrop ? 'Drop live now' : 'Next drop loading'}
               </span>
-              <span className="rh-sticker rh-sticker--plain">New drop every week</span>
+              <span className="rh-sticker rh-sticker--plain">Drops · lucky draws · partner offers</span>
             </div>
             <h1 className="rh-h1">
-              Free<br />
-              <span className="rh-h1__hollow">stuff</span><br />
-              <span className="rh-h1__tilt">weekly.</span>
+              Real<br />
+              <span className="rh-h1__hollow">free</span><br />
+              <span className="rh-h1__tilt">stuff.</span>
             </h1>
             <p className="rh-hero__sub">
-              Real vouchers from real Singapore brands, dropped every week.{' '}
-              <span className="rh-hl">30 seconds</span> to claim, straight to your SMS.
+              Vouchers, lucky draws and partner offers from real Singapore brands.{' '}
+              <span className="rh-hl">30 seconds</span> to claim.
               No app. No points. No credit card. Ever.
             </p>
             <div className="rh-hero__ctas">
@@ -260,10 +260,10 @@ export default function RedeemHome() {
                 </div>
               </div>
             )}
-            <div className="rh-star">New<br />drop<br />weekly</div>
+            <div className="rh-star">Lucky<br />draws<br />too</div>
             <div className="rh-toast rh-toast--t1">
               <span className="rh-toast__ico">🎟</span>
-              <div>Straight to your SMS<small>Show it at the counter</small></div>
+              <div>Draws &amp; partner offers<small>From brands across SG</small></div>
             </div>
             <div className="rh-toast rh-toast--t2">
               <span className="rh-toast__ico">✓</span>
@@ -303,7 +303,7 @@ export default function RedeemHome() {
             <div className="rh-step">
               <span className="rh-step__n">03</span>
               <h3>Use it</h3>
-              <p>Your voucher hits your SMS instantly. Show it at the counter. <span className="rh-hl">Done.</span></p>
+              <p>Voucher, draw entry or partner deal — show it at the counter or use it online. <span className="rh-hl">Done.</span></p>
             </div>
           </div>
           <div className="rh-rule">🔒 Not on redeem.sg? Not us. Close the tab.</div>
@@ -317,7 +317,7 @@ export default function RedeemHome() {
             <div>
               <span className="rh-kicker">This week</span>
               <h2 className="rh-h2" style={{ marginBottom: 0 }}>
-                {liveDrop ? <>Live <span className="rh-h2__hl">this week.</span></> : <>Next <span className="rh-h2__hl">drop.</span></>}
+                {liveDrop ? <>Live <span className="rh-h2__hl">right now.</span></> : <>Next <span className="rh-h2__hl">drop.</span></>}
               </h2>
             </div>
           </div>
@@ -329,7 +329,7 @@ export default function RedeemHome() {
             <div className="rh-drops__empty">
               <h3>The next drop is loading.</h3>
               <p>
-                New rewards land regularly — in taxis, at roadshows, and right here.
+                Drops, lucky draws and partner offers land as and when — in taxis, at roadshows, and right here.
                 Spotted one of our QR codes out in the wild? That’s your way in.
               </p>
             </div>
@@ -471,7 +471,7 @@ export default function RedeemHome() {
           <div className="rh-footer__grid">
             <div>
               <div className="rh-footer__logo">✷ REDEEM</div>
-              <p className="rh-footer__tag">Free stuff from real Singapore brands. New drop every week.</p>
+              <p className="rh-footer__tag">Free stuff from real Singapore brands — drops, lucky draws and partner offers.</p>
             </div>
             <div className="rh-footer__col">
               <h4>Explore</h4>

--- a/src/pages/redeemHomeContent.js
+++ b/src/pages/redeemHomeContent.js
@@ -40,7 +40,8 @@ export const MARQUEE_ITEMS = [
   { text: 'S$20 vouchers' },
   { text: 'SMS-verified claims', accent: true },
   { text: 'No app. No points.' },
-  { text: 'New drop every week', accent: true },
+  { text: 'Lucky draws', accent: true },
+  { text: 'Partner offers' },
   { text: 'redeem.sg only' },
 ];
 
@@ -62,11 +63,11 @@ export const PARTNERS = [
 export const FAQ = [
   {
     q: 'Why do you need my number?',
-    a: 'The one-time code proves you’re a real person — one reward per human, not per bot — and it’s where the voucher lands. Some drops are sponsored by partners who’d like to say hello: we name them on the form, before you submit.',
+    a: 'The one-time code proves you’re a real person — one reward per human, not per bot. Some drops are sponsored by partners who’d like to say hello: we name them on the form, before you submit.',
   },
   {
     q: 'Do I need an app?',
-    a: 'No. Everything runs in your browser on redeem.sg. Scan the QR or tap the link, fill in the short form, and your voucher arrives by SMS. Nothing to download, nothing to sign in to.',
+    a: 'No. Everything runs in your browser on redeem.sg. Scan the QR or tap the link, fill in the short form — done. Nothing to download, nothing to sign in to.',
   },
   {
     q: 'Will I get spam calls?',
@@ -77,7 +78,7 @@ export const FAQ = [
     a: 'One rule: real Redeem links live on redeem.sg — nothing else, no lookalike domains. We verify you with an SMS code before any reward, and we will never ask for your NRIC, bank details, or any payment.',
   },
   {
-    q: 'My voucher didn’t arrive.',
-    a: 'Check the mobile number you entered and give the SMS a minute. Still nothing? Email hello@redeem.sg with the drop name and your number — a human will sort it out.',
+    q: 'My reward didn’t arrive.',
+    a: 'Email hello@redeem.sg with the drop name and the mobile number you used — a human will sort it out.',
   },
 ];

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,7 +15,7 @@ const brandConfigPath = path.resolve(__dirname, `./src/lib/brandConfigs/${BRAND}
 const BRAND_HTML_DEFAULTS = BRAND === 'redeem'
   ? {
       VITE_PAGE_TITLE: 'Redeem — Free stuff from real Singapore brands',
-      VITE_META_DESCRIPTION: 'Real vouchers from real Singapore brands, dropped every week. Claim in 30 seconds — no app, no points, no credit card. A service of MKTR PTE. LTD.',
+      VITE_META_DESCRIPTION: 'Vouchers, lucky draws and partner offers from real Singapore brands. Claim in 30 seconds — no app, no points, no credit card. A service of MKTR PTE. LTD.',
       VITE_FAVICON_SRC: '/redeem-favicon.svg',
       VITE_CANONICAL_BASE: 'https://redeem.sg/',
     }


### PR DESCRIPTION
Copy corrections from Shawn: we don't drop weekly (as-and-when, plus lucky draws and partner offers), and rewards don't land in the SMS inbox — so the page stops claiming either. Headline becomes **REAL / FREE / STUFF.**; 'lucky draws' and 'partner offers' now appear in the hero, stickers, marquee, empty-state, footer and meta description. SMS *verification* copy (one-time code, no bots) is untouched — that part is true. Verified on the built bundle: zero weekly/SMS-delivery strings in the rendered page, draws/offers present, SMS-verified retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FS33kQWQVbULWpXs54z6Kn