### PR TITLE
feat(redeem): winners' wall at /winners — lucky-draw results page

### DIFF
--- a/src/pages/RedeemHome.jsx
+++ b/src/pages/RedeemHome.jsx
@@ -170,6 +170,7 @@ export default function RedeemHome() {
             <a href="#how">How it works</a>
             <a href="#drops">This week</a>
             <a href="#legit">Legit?</a>
+            <a href="/winners">Winners</a>
             <a href="#faq">FAQ</a>
           </div>
           <div className="rh-nav__right">
@@ -477,6 +478,7 @@ export default function RedeemHome() {
               <h4>Explore</h4>
               <a href="#how">How it works</a>
               <a href="#drops">This week’s drop</a>
+              <a href="/winners">Winners’ wall</a>
               <a href="#faq">FAQ</a>
             </div>
             <div className="rh-footer__col">

--- a/src/pages/RedeemWinners.jsx
+++ b/src/pages/RedeemWinners.jsx
@@ -1,0 +1,181 @@
+import { useEffect } from 'react';
+import { brand } from '@/lib/brand';
+import { WINNERS } from './redeemWinnersContent';
+import './redeemHome.css';
+import './redeemWinners.css';
+
+/**
+ * redeem.sg/winners — lucky-draw results wall (redeem build only).
+ * Winners are posted by editing redeemWinnersContent.js (photos in
+ * public/winners/). Empty list → honest "first draw is loading" state.
+ * Identities arrive pre-masked in the config (PDPA — see that file's header).
+ */
+
+const PANELS = ['rhw-card__ph--lime', 'rhw-card__ph--pink', 'rhw-card__ph--violet'];
+
+function Photo({ w, tall }) {
+  if (w.photo) {
+    return <img src={w.photo} alt={`${w.name} — ${w.prize}`} loading={tall ? undefined : 'lazy'} />;
+  }
+  const pending = w.status === 'pending';
+  return (
+    <>
+      <span className="rhw-avatar">{pending ? '?' : (w.name || '?').charAt(0)}</span>
+      <span className="rhw-flag">{pending ? 'Winner contacted' : 'No photo — winner’s choice'}</span>
+    </>
+  );
+}
+
+export default function RedeemWinners() {
+  useEffect(() => {
+    document.title = 'Redeem — Winners’ wall';
+    const meta = document.querySelector('meta[name="description"]');
+    if (meta) {
+      meta.setAttribute(
+        'content',
+        'Every Redeem lucky draw ends here — the prize, the draw date, and the winner. A service of MKTR PTE. LTD.'
+      );
+    }
+  }, []);
+
+  const [latest, ...past] = WINNERS;
+
+  return (
+    <div className="rh-page">
+      <nav className="rh-nav" aria-label="Main">
+        <div className="rh-wrap rh-nav__inner">
+          <a className="rh-logo" href="/"><span className="rh-logo__spark">✷</span>REDEEM</a>
+          <div className="rh-nav__links">
+            <a href="/#how">How it works</a>
+            <a href="/#drops">Drops</a>
+            <a href="/winners" style={{ opacity: 1, borderBottom: '3px solid var(--rh-lime-deep)', paddingBottom: 4 }}>Winners</a>
+            <a href="/#faq">FAQ</a>
+          </div>
+          <div className="rh-nav__right">
+            <a className="rh-btn rh-btn--lime rh-btn--sm" href="/#drops">What’s dropping</a>
+          </div>
+        </div>
+      </nav>
+
+      <header className="rhw-head">
+        <div className="rh-wrap">
+          <span className="rh-kicker">Lucky draws · results</span>
+          <h1 className="rh-h1" style={{ fontSize: 84 }}>
+            Winners’<br />
+            <span className="rh-h1__hollow">wall</span> <span className="rh-h1__tilt">of fame.</span>
+          </h1>
+          <p className="rh-hero__sub">
+            Every lucky draw we run ends here — the prize, the draw date, and the person who took
+            it home. If your number was drawn, this is where you’ll see it.
+          </p>
+          <div className="rh-rule">🔒 We contact winners directly — and never ask for payment to release a prize.</div>
+        </div>
+      </header>
+
+      {latest ? (
+        <div className="rh-wrap">
+          <section className="rhw-feature">
+            <div>
+              <span className="rh-kicker">Latest draw · {latest.draw}</span>
+              <h2>{latest.prize}</h2>
+              {latest.prizeMeta && <p className="rhw-feature__meta">{latest.prizeMeta}</p>}
+              <div className="rhw-wtag">
+                🎉{' '}
+                <div>
+                  {latest.status === 'pending' ? 'Drawn — awaiting claim' : latest.name}
+                  <small>
+                    entry {latest.entry}
+                    {latest.area ? ` · ${latest.area}` : ''}
+                  </small>
+                </div>
+              </div>
+              <div className="rhw-chips">
+                {latest.drawnOn && <span className="rhw-chip">Drawn {latest.drawnOn}</span>}
+                <span className="rhw-chip">Witnessed draw</span>
+                {latest.status === 'pending'
+                  ? <span className="rhw-chip">14 days to claim</span>
+                  : <span className="rhw-chip rhw-chip--lime">Claimed ✓</span>}
+              </div>
+            </div>
+            <div className="rhw-pol">
+              <div className="rhw-tape" />
+              <div className="rhw-stamp">Winner</div>
+              <div className="rhw-pol__ph"><Photo w={latest} tall /></div>
+              <div className="rhw-pol__cap">
+                {latest.photo ? (latest.photoCaption || `${latest.name} takes it home`) : latest.name || 'Awaiting claim'}
+                {latest.photo && <small>Photo shared with permission</small>}
+              </div>
+            </div>
+          </section>
+        </div>
+      ) : (
+        <div className="rh-wrap">
+          <div className="rhw-empty">
+            <h3>The first draw is loading.</h3>
+            <p>
+              No draws have concluded yet. When one does, the result lands here — the prize, the
+              draw date, and the winner. Claiming an eligible drop is your entry.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {past.length > 0 && (
+        <section className="rh-section" style={{ paddingTop: 72 }}>
+          <div className="rh-wrap">
+            <span className="rh-kicker">Past draws</span>
+            <h3 className="rh-h2" style={{ fontSize: 34 }}>Every draw. Every winner.</h3>
+            <div className="rhw-grid">
+              {past.map((w, i) => (
+                <article className="rhw-card" key={`${w.draw}-${w.entry}`}>
+                  <div className="rhw-card__top"><span>{w.draw}</span><span className="rhw-bar" /></div>
+                  <div className={`rhw-card__ph ${w.status === 'pending' ? 'rhw-card__ph--stone' : PANELS[i % PANELS.length]}`}>
+                    <Photo w={w} />
+                  </div>
+                  <div className="rhw-card__bd">
+                    <div className="rhw-who">
+                      {w.status === 'pending' ? 'Drawn — awaiting claim' : w.name}
+                      <small>
+                        entry {w.entry}
+                        {w.status === 'pending' ? ' · 14 days to claim' : w.area ? ` · ${w.area}` : ''}
+                      </small>
+                    </div>
+                    <div className="rhw-prz">
+                      <span>{w.prize}</span>
+                      {w.status === 'pending'
+                        ? <span className="rhw-pend">Pending…</span>
+                        : <span className="rhw-ok">Claimed ✓</span>}
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      <section className="rhw-how">
+        <div className="rh-wrap">
+          <span className="rh-kicker">How draws work</span>
+          <h3>Fair, drawn, posted.</h3>
+          <div className="rhw-steps">
+            <div className="rhw-st"><b>01 — ENTER</b><p>Claiming an eligible drop is your entry. One entry per verified person.</p></div>
+            <div className="rhw-st"><b>02 — DRAWN</b><p>Winner picked at random after the end date, witnessed by MKTR staff.</p></div>
+            <div className="rhw-st"><b>03 — CONTACTED</b><p>We call or SMS the winner directly. 14 days to claim, or we redraw.</p></div>
+            <div className="rhw-st"><b>04 — POSTED</b><p>The result lands on this wall — masked entry number, and a photo if the winner’s happy to share.</p></div>
+          </div>
+          <div className="rhw-scam">🔒 Anyone asking you for a “release fee” is a scammer. Report them to us.</div>
+        </div>
+      </section>
+
+      <footer className="rh-footer" style={{ marginTop: 0 }}>
+        <div className="rh-wrap">
+          <div className="rh-footer__legal" style={{ marginTop: 0, paddingTop: 0, borderTop: 'none' }}>
+            <span>{brand.consumerLine} · UEN {brand.uen} · Singapore</span>
+            <span>© {new Date().getFullYear()} {brand.legalName}</span>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -27,6 +27,7 @@ const SpecimenPreview = lazy(() => import('./preview/SpecimenPreview'));
 
 const Homepage = lazy(() => import('./Homepage'));
 const RedeemHome = lazy(() => import('./RedeemHome'));
+const RedeemWinners = lazy(() => import('./RedeemWinners'));
 const Features = lazy(() => import('./Features'));
 const Pricing = lazy(() => import('./Pricing'));
 const About = lazy(() => import('./About'));
@@ -192,6 +193,7 @@ function PagesContent() {
  {/* Public routes - no protection needed. Lead capture flow stays on both brands. */}
  <Route path="/" element={brand.showHomepage ? <Homepage /> : (IS_REDEEM_BUILD ? <RedeemHome /> : <LeadCapture />)} />
  <Route path="/LeadCapture" element={<LeadCapture />} />
+ <Route path="/winners" element={IS_REDEEM_BUILD ? <RedeemWinners /> : <NotFoundForBrand />} />
  <Route path="/LeadCapture/demo" element={<LeadCaptureDemo />} />
  <Route path="/p/:slug" element={<PublicPreview />} />
  <Route path="/t/:slug" element={<TrackRedirect />} />

--- a/src/pages/redeemWinners.css
+++ b/src/pages/redeemWinners.css
@@ -1,0 +1,78 @@
+/* Winners' wall (/winners) — rhw-* additions on top of the rh-* base
+   (redeemHome.css is imported by the page for tokens, nav, buttons, footer). */
+
+.rhw-head { padding: 64px 0 20px; }
+
+/* Featured latest draw */
+.rhw-feature {
+  margin: 44px 0 0; background: var(--rh-ink); border: var(--rh-bd); border-radius: 20px;
+  box-shadow: 10px 10px 0 rgba(19, 19, 19, 0.25); padding: 40px 44px; color: var(--rh-paper);
+  display: grid; grid-template-columns: 1fr 340px; gap: 44px; align-items: center;
+}
+.rhw-feature .rh-kicker { color: var(--rh-lime); }
+.rhw-feature h2 { font-family: var(--rh-display); font-size: 44px; text-transform: uppercase; line-height: 1; margin: 12px 0 8px; font-weight: 400; }
+.rhw-feature__meta { font-size: 15px; font-weight: 600; color: rgba(244, 242, 234, 0.75); }
+.rhw-wtag {
+  display: inline-flex; align-items: center; gap: 10px; margin-top: 22px; background: var(--rh-white);
+  color: var(--rh-ink); border: var(--rh-bd); border-radius: 12px; box-shadow: 5px 5px 0 var(--rh-lime);
+  padding: 12px 18px; font-weight: 700; font-size: 16px;
+}
+.rhw-wtag small { display: block; font-size: 11px; font-weight: 700; letter-spacing: 0.1em; color: var(--rh-muted); text-transform: uppercase; }
+.rhw-chips { display: flex; gap: 12px; margin-top: 18px; flex-wrap: wrap; }
+.rhw-chip { border: 2.5px solid var(--rh-paper); border-radius: 9px; padding: 6px 11px; font-size: 11px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: var(--rh-paper); }
+.rhw-chip--lime { background: var(--rh-lime); color: var(--rh-ink); border-color: var(--rh-ink); }
+
+/* Polaroid */
+.rhw-pol { background: var(--rh-white); border: var(--rh-bd); padding: 12px 12px 0; box-shadow: 8px 8px 0 var(--rh-lime); transform: rotate(2.5deg); position: relative; }
+.rhw-pol__ph { height: 250px; display: flex; align-items: center; justify-content: center; border: var(--rh-bd); overflow: hidden; background: var(--rh-stone); }
+.rhw-pol__ph img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.rhw-pol__cap { text-align: center; padding: 12px 6px; color: var(--rh-ink); font-weight: 700; font-size: 14px; letter-spacing: 0.04em; }
+.rhw-pol__cap small { display: block; font-weight: 600; font-size: 11px; color: var(--rh-muted); letter-spacing: 0.08em; text-transform: uppercase; margin-top: 2px; }
+.rhw-tape { position: absolute; top: -14px; left: 50%; transform: translateX(-50%) rotate(-3deg); width: 110px; height: 28px; background: rgba(205, 246, 59, 0.85); border: 2px solid rgba(19, 19, 19, 0.25); }
+.rhw-stamp {
+  position: absolute; right: -16px; top: -16px; width: 88px; height: 88px; border-radius: 50%;
+  background: var(--rh-lime); border: 3px solid var(--rh-ink); display: flex; align-items: center;
+  justify-content: center; font-size: 11px; font-weight: 800; letter-spacing: 0.1em;
+  text-transform: uppercase; transform: rotate(10deg); box-shadow: 4px 4px 0 var(--rh-ink); color: var(--rh-ink);
+}
+
+/* Past draws grid */
+.rhw-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 26px; }
+.rhw-card { background: var(--rh-white); border: var(--rh-bd); border-radius: 16px; box-shadow: 6px 6px 0 var(--rh-ink); overflow: hidden; }
+.rhw-card__top { display: flex; justify-content: space-between; align-items: center; padding: 12px 16px; border-bottom: var(--rh-bd); font-family: var(--rh-display); font-size: 13px; text-transform: uppercase; }
+.rhw-bar { width: 64px; height: 18px; background: repeating-linear-gradient(90deg, var(--rh-ink) 0 2px, transparent 2px 5px); }
+.rhw-card__ph { height: 190px; display: flex; align-items: center; justify-content: center; border-bottom: var(--rh-bd); position: relative; overflow: hidden; }
+.rhw-card__ph img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.rhw-card__ph--lime { background: var(--rh-lime); } .rhw-card__ph--pink { background: var(--rh-pink); }
+.rhw-card__ph--violet { background: var(--rh-violet); } .rhw-card__ph--stone { background: var(--rh-stone); }
+.rhw-avatar { width: 110px; height: 110px; border-radius: 50%; border: var(--rh-bd); background: var(--rh-white); display: flex; align-items: center; justify-content: center; font-family: var(--rh-display); font-size: 44px; }
+.rhw-flag { position: absolute; top: 10px; left: 12px; border: var(--rh-bd); border-radius: 8px; background: var(--rh-white); font-size: 10px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; padding: 4px 8px; }
+.rhw-card__bd { padding: 16px 18px 18px; }
+.rhw-who { font-weight: 700; font-size: 17px; }
+.rhw-who small { display: block; font-size: 11.5px; font-weight: 600; color: var(--rh-muted); letter-spacing: 0.06em; text-transform: uppercase; margin-top: 2px; }
+.rhw-prz { margin-top: 12px; display: flex; justify-content: space-between; align-items: center; gap: 10px; font-size: 12px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; }
+.rhw-ok { color: #3e7a1f; } .rhw-pend { color: var(--rh-muted); }
+
+/* How draws work */
+.rhw-how { background: var(--rh-ink); color: var(--rh-paper); border-top: var(--rh-bd); padding: 56px 0 64px; }
+.rhw-how .rh-kicker { color: var(--rh-lime); }
+.rhw-how h3 { font-family: var(--rh-display); font-size: 34px; text-transform: uppercase; margin: 10px 0 30px; font-weight: 400; color: var(--rh-paper); }
+.rhw-steps { display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; }
+.rhw-st { border: 2.5px dashed rgba(244, 242, 234, 0.35); border-radius: 14px; padding: 18px; }
+.rhw-st b { font-family: var(--rh-display); color: var(--rh-lime); font-size: 13px; display: block; margin-bottom: 8px; }
+.rhw-st p { font-size: 13.5px; font-weight: 500; color: rgba(244, 242, 234, 0.8); margin: 0; }
+.rhw-scam { margin-top: 26px; display: inline-flex; align-items: center; gap: 10px; background: var(--rh-lime); color: var(--rh-ink); border: var(--rh-bd); border-radius: 12px; box-shadow: 5px 5px 0 rgba(244, 242, 234, 0.3); padding: 12px 18px; font-size: 13px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; }
+
+/* Empty state */
+.rhw-empty { margin-top: 44px; border: var(--rh-bd); border-radius: 16px; background: var(--rh-white); box-shadow: 6px 6px 0 var(--rh-ink); padding: 40px 32px; max-width: 640px; }
+.rhw-empty h3 { font-family: var(--rh-display); font-size: 24px; text-transform: uppercase; margin: 0 0 10px; font-weight: 400; }
+.rhw-empty p { font-size: 15px; font-weight: 500; line-height: 1.6; margin: 0; }
+
+@media (max-width: 1020px) {
+  .rhw-feature { grid-template-columns: 1fr; padding: 32px 26px; }
+  .rhw-steps { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 640px) {
+  .rhw-feature h2 { font-size: 32px; }
+  .rhw-steps { grid-template-columns: 1fr; }
+}

--- a/src/pages/redeemWinnersContent.js
+++ b/src/pages/redeemWinnersContent.js
@@ -1,0 +1,24 @@
+// Lucky-draw results shown on redeem.sg/winners — edit this file to post a
+// winner; the page's empty state shows until this list has entries.
+//
+// PDPA rules baked into the format: mask the name to first name + initial,
+// mask the entry number (keep last 3-4 digits), photo ONLY with the winner's
+// written permission (photoCaption should say so). Photos live in
+// public/winners/ (JPG/PNG, roughly square, ≥600px).
+//
+// Newest draw first — the top entry renders as the featured card. Example:
+//
+//   {
+//     draw: 'Drop 08',                    // which drop/campaign the draw belonged to
+//     prize: 'Cabin luggage',
+//     prizeMeta: 'Hardshell spinner · 1 of 300 entries drawn',
+//     name: 'Sarah T.',                   // masked
+//     entry: '9••• •312',                 // masked mobile/entry number
+//     area: 'Bedok',                      // optional
+//     drawnOn: '20 Jul 2026',
+//     status: 'claimed',                  // 'claimed' | 'pending' (contacted, not yet collected)
+//     photo: '/winners/drop08-sarah.jpg', // optional — omit for initials avatar
+//     photoCaption: 'Sarah collects her luggage',
+//   },
+
+export const WINNERS = [];

--- a/vite.config.js
+++ b/vite.config.js
@@ -54,7 +54,8 @@ function brandSeoFiles() {
   // /features, /pricing, /about are hidden (show* flags false) pending a rewrite,
   // so they're intentionally excluded from the sitemap to avoid advertising 404s.
   const mktrOnlyRoutes = []
-  const routes = BRAND === 'redeem' ? sharedRoutes : [...sharedRoutes, ...mktrOnlyRoutes]
+  const redeemOnlyRoutes = ['/winners']
+  const routes = BRAND === 'redeem' ? [...sharedRoutes, ...redeemOnlyRoutes] : [...sharedRoutes, ...mktrOnlyRoutes]
 
   const robots = [
     'User-agent: *',


### PR DESCRIPTION
Implements the winners'-wall mock from the design project: dedicated `/winners` route (redeem build only, linked from homepage nav + footer, on the sitemap), featured latest draw with polaroid photo, past-draw grid with photo / no-photo / pending states, PDPA-masked identities, and the fair-draw + anti-scam trust strip.

**To post a winner:** edit `src/pages/redeemWinnersContent.js` (documented example in the file header), drop the photo into `public/winners/` — photo only with the winner's permission. Empty list = honest "first draw is loading" state (ships that way).

Verified with Playwright: filled + empty states, photo loading, nav from homepage; mktr build unaffected (route 404s there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FS33kQWQVbULWpXs54z6Kn