### PR TITLE
fix(redeem): gap between winners content and the how-draws section

### DIFF
--- a/src/pages/RedeemWinners.jsx
+++ b/src/pages/RedeemWinners.jsx
@@ -121,7 +121,7 @@ export default function RedeemWinners() {
       )}
 
       {past.length > 0 && (
-        <section className="rh-section" style={{ paddingTop: 72 }}>
+        <section className="rh-section" style={{ paddingTop: 0 }}>
           <div className="rh-wrap">
             <span className="rh-kicker">Past draws</span>
             <h3 className="rh-h2" style={{ fontSize: 34 }}>Every draw. Every winner.</h3>

--- a/src/pages/redeemWinners.css
+++ b/src/pages/redeemWinners.css
@@ -5,7 +5,7 @@
 
 /* Featured latest draw */
 .rhw-feature {
-  margin: 44px 0 0; background: var(--rh-ink); border: var(--rh-bd); border-radius: 20px;
+  margin: 44px 0 90px; background: var(--rh-ink); border: var(--rh-bd); border-radius: 20px;
   box-shadow: 10px 10px 0 rgba(19, 19, 19, 0.25); padding: 40px 44px; color: var(--rh-paper);
   display: grid; grid-template-columns: 1fr 340px; gap: 44px; align-items: center;
 }
@@ -64,7 +64,7 @@
 .rhw-scam { margin-top: 26px; display: inline-flex; align-items: center; gap: 10px; background: var(--rh-lime); color: var(--rh-ink); border: var(--rh-bd); border-radius: 12px; box-shadow: 5px 5px 0 rgba(244, 242, 234, 0.3); padding: 12px 18px; font-size: 13px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; }
 
 /* Empty state */
-.rhw-empty { margin-top: 44px; border: var(--rh-bd); border-radius: 16px; background: var(--rh-white); box-shadow: 6px 6px 0 var(--rh-ink); padding: 40px 32px; max-width: 640px; }
+.rhw-empty { margin: 44px 0 90px; border: var(--rh-bd); border-radius: 16px; background: var(--rh-white); box-shadow: 6px 6px 0 var(--rh-ink); padding: 40px 32px; max-width: 640px; }
 .rhw-empty h3 { font-family: var(--rh-display); font-size: 24px; text-transform: uppercase; margin: 0 0 10px; font-weight: 400; }
 .rhw-empty p { font-size: 15px; font-weight: 500; line-height: 1.6; margin: 0; }
 


### PR DESCRIPTION
The empty-state card sat flush against the black band (same would happen to the featured card with no past draws). Both get 90px bottom margin, past-draws section top padding compensates. Measured 90px via Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FS33kQWQVbULWpXs54z6Kn