### PR TITLE
feat(redeem-ops): cadence P0 — tx primitives + hook registry (no behavior change)

### DIFF
--- a/backend/src/services/redeemOps/cadenceHooks.js
+++ b/backend/src/services/redeemOps/cadenceHooks.js
@@ -1,0 +1,47 @@
+/**
+ * Cadence hook registry (docs/plans/redeem-ops-cadences.md §3 — P0).
+ *
+ * The CRM choke points (activity logging, stage machine, snooze, claim/release/
+ * reassign, merge) fire named hooks INSIDE their owning transaction; the cadence
+ * engine (P1) registers implementations from the bootstrap composition root
+ * (house precedent: prospectService.registerLeadCapturedHook). Nothing
+ * registered → every fire is a no-op, so this ships dark with zero behavior
+ * change. This module imports nothing from the services, so registering
+ * service-touching hooks in bootstrap can never create an import cycle.
+ *
+ * A hook that throws aborts the caller's transaction ON PURPOSE — cadence state
+ * must never diverge from the CRM state it reacts to. The one exception is the
+ * stale-sweep wake, which fires outside any transaction (payload has no
+ * `transaction`) and catches per-partner failures itself.
+ */
+const HOOK_NAMES = [
+  'onInboundActivity', // logActivityTx: direction=inbound + meaningful (unless suppressed)
+  'onStageChange', // changeStageTx + undoStageChange
+  'onSnooze', // snoozePartnerTx
+  'onUnsnooze', // unsnoozePartnerTx (source:'manual') + stale-sweep wake (source:'sweep')
+  'onRelease', // claimService.releasePartner
+  'onReassign', // claimService.assignPartner
+  'onMergeDuplicate', // mergePartners — fired BEFORE child repointing (§5.4 ordering)
+];
+
+let registered = {};
+
+export function registerCadenceHooks(hooks = {}) {
+  const unknown = Object.keys(hooks).filter((k) => !HOOK_NAMES.includes(k));
+  if (unknown.length > 0) {
+    throw new Error(`Unknown cadence hook(s): ${unknown.join(', ')}`);
+  }
+  registered = { ...registered, ...hooks };
+}
+
+/** Tests only — the registry is process-global. */
+export function clearCadenceHooks() {
+  registered = {};
+}
+
+export async function fireCadenceHook(name, payload) {
+  if (!HOOK_NAMES.includes(name)) throw new Error(`Unknown cadence hook: ${name}`);
+  const fn = registered[name];
+  if (typeof fn !== 'function') return;
+  await fn(payload);
+}

--- a/backend/src/services/redeemOps/claimService.js
+++ b/backend/src/services/redeemOps/claimService.js
@@ -2,6 +2,7 @@ import { PartnerOrganisation, PartnerAssignmentEvent, PartnerStageEvent, User, s
 import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';
 import { makeRedeemOpsAuditService } from './auditService.js';
+import { fireCadenceHook } from './cadenceHooks.js';
 
 /**
  * Business claiming / ownership (docs/redeem-ops/ERD.md §4.1, brief §15).
@@ -14,7 +15,7 @@ import { makeRedeemOpsAuditService } from './auditService.js';
 export function makeClaimService(overrides = {}) {
   const d = {
     PartnerOrganisation, PartnerAssignmentEvent, PartnerStageEvent, User, sequelize, logger,
-    audit: makeRedeemOpsAuditService(), ...overrides,
+    audit: makeRedeemOpsAuditService(), fireCadenceHook, ...overrides,
   };
 
   async function conflictPayload(partnerId) {
@@ -114,6 +115,7 @@ export function makeClaimService(overrides = {}) {
         actorUser: user, action: 'partner.released', entityType: 'partner_organisation',
         entityId: partnerId, reason, requestId, transaction: t,
       });
+      await d.fireCadenceHook('onRelease', { partnerId, user, transaction: t });
       return rows[0];
     });
   }
@@ -152,6 +154,7 @@ export function makeClaimService(overrides = {}) {
         entityId: partnerId, before: { ownerUserId: fromUserId }, after: { ownerUserId: toUserId },
         reason, requestId, transaction: t,
       });
+      await d.fireCadenceHook('onReassign', { partner, fromUserId, toUserId, actor, transaction: t });
       return partner;
     });
   }

--- a/backend/src/services/redeemOps/partnerService.js
+++ b/backend/src/services/redeemOps/partnerService.js
@@ -17,11 +17,18 @@ import {
 } from './constants.js';
 import { makeOnboardingService } from './onboardingService.js';
 import { makeCategoryService } from './categoryService.js';
+import { fireCadenceHook } from './cadenceHooks.js';
 
 /**
  * Partner CRM core (docs/redeem-ops/ERD.md §3.1–3.6, brief §13–§18).
  * Row-level "own" scoping lives HERE (not in middleware): outreach_execs act only
  * on partners they own; managers (bdm/ops_admin/super_admin/admin) act on any.
+ *
+ * P0 tx primitives (docs/plans/redeem-ops-cadences.md §3): the stage machine,
+ * snooze, and activity logging expose `*Tx` variants that run inside a
+ * CALLER-owned transaction with the partner row locked (`FOR UPDATE`) before
+ * any decision is made, and fire the cadence hook registry inside that same
+ * transaction. The public wrappers keep their exact signatures and behavior.
  */
 export function makePartnerService(overrides = {}) {
   const d = {
@@ -32,6 +39,7 @@ export function makePartnerService(overrides = {}) {
     audit: makeRedeemOpsAuditService(),
     dedupe: makeDedupeService(),
     categories: makeCategoryService(),
+    fireCadenceHook,
     // PARTNERED → seed the onboarding checklist (brief §22); injectable for tests.
     onPartnered: (partner, _user, t) => makeOnboardingService().seedChecklist(partner.id, t),
     ...overrides,
@@ -219,10 +227,11 @@ export function makePartnerService(overrides = {}) {
    * contact, plus a phone or email somewhere on the record. Everything else
    * (terms, outlets, launch) belongs to the onboarding checklist.
    */
-  async function assertPartneredEntryRequirements(id, partner) {
+  async function assertPartneredEntryRequirements(id, partner, transaction = null) {
     const contacts = await d.PartnerContact.findAll({
       where: { partnerOrganisationId: id, archivedAt: null },
       attributes: ['id', 'mobile', 'email'],
+      transaction,
     });
     if (contacts.length === 0) {
       throw new AppError(
@@ -240,12 +249,12 @@ export function makePartnerService(overrides = {}) {
     }
   }
 
-  async function changeStage(id, toStage, user, reason = null, requestId = null, lostReason = null) {
+  async function changeStageTx(id, toStage, user, t, { reason = null, requestId = null, lostReason = null } = {}) {
     if (!PIPELINE_STAGES.includes(toStage)) throw new AppError('Unknown stage', 400);
     if (toStage === 'LOST' && !LOST_REASONS.includes(lostReason)) {
       throw new AppError('A reason is required when marking a business as Lost', 400);
     }
-    const partner = await getLivePartner(id);
+    const partner = await getLivePartner(id, { transaction: t, lock: t.LOCK.UPDATE });
     if (!canActOnRow(user, partner)) {
       throw new AppError('You can only move businesses you own', 403);
     }
@@ -264,7 +273,7 @@ export function makePartnerService(overrides = {}) {
     // Entry requirement for PARTNERED (Salesforce-style stage validation, applies
     // to EVERYONE incl. admins) — also enforced when an undo restores PARTNERED.
     if (toStage === 'PARTNERED') {
-      await assertPartneredEntryRequirements(id, partner);
+      await assertPartneredEntryRequirements(id, partner, t);
     }
 
     // LOST leaves the working pool (reuses the 'disqualified' availability so
@@ -273,28 +282,32 @@ export function makePartnerService(overrides = {}) {
       toStage === 'LOST' ? 'disqualified'
       : partner.ownerUserId ? 'owned' : 'available';
 
-    await d.sequelize.transaction(async (t) => {
-      await partner.update({
-        pipelineStage: toStage, availability, staleFlag: false, snoozedUntil: null,
-        // lostReason persists after LOST → re-engage so an undo/relapse keeps
-        // context; the UI only shows it while the stage is LOST.
-        ...(toStage === 'LOST' ? { lostReason } : {}),
-      }, { transaction: t });
-      await d.PartnerStageEvent.create(
-        { partnerOrganisationId: id, fromStage, toStage, actorUserId: user.id, reason },
-        { transaction: t }
-      );
-      await d.audit.recordAuditEvent({
-        actorUser: user, action: 'stage.changed', entityType: 'partner_organisation',
-        entityId: id, before: { stage: fromStage }, after: { stage: toStage },
-        reason, requestId, transaction: t,
-      });
-      // PARTNERED → onboarding checklist seeding hooks in here (Phase 4).
-      if (toStage === 'PARTNERED' && typeof d.onPartnered === 'function') {
-        await d.onPartnered(partner, user, t);
-      }
+    await partner.update({
+      pipelineStage: toStage, availability, staleFlag: false, snoozedUntil: null,
+      // lostReason persists after LOST → re-engage so an undo/relapse keeps
+      // context; the UI only shows it while the stage is LOST.
+      ...(toStage === 'LOST' ? { lostReason } : {}),
+    }, { transaction: t });
+    await d.PartnerStageEvent.create(
+      { partnerOrganisationId: id, fromStage, toStage, actorUserId: user.id, reason },
+      { transaction: t }
+    );
+    await d.audit.recordAuditEvent({
+      actorUser: user, action: 'stage.changed', entityType: 'partner_organisation',
+      entityId: id, before: { stage: fromStage }, after: { stage: toStage },
+      reason, requestId, transaction: t,
     });
+    // PARTNERED → onboarding checklist seeding hooks in here (Phase 4).
+    if (toStage === 'PARTNERED' && typeof d.onPartnered === 'function') {
+      await d.onPartnered(partner, user, t);
+    }
+    await d.fireCadenceHook('onStageChange', { partner, fromStage, toStage, user, transaction: t });
     return partner;
+  }
+
+  async function changeStage(id, toStage, user, reason = null, requestId = null, lostReason = null) {
+    return d.sequelize.transaction(async (t) =>
+      changeStageTx(id, toStage, user, t, { reason, requestId, lostReason }));
   }
 
   // ── Timeline & activities ────────────────────────────────────────────────
@@ -307,39 +320,40 @@ export function makePartnerService(overrides = {}) {
    * with a stage event + audit row like any other move.
    */
   async function undoStageChange(id, user, requestId = null) {
-    const partner = await getLivePartner(id);
-    if (!canActOnRow(user, partner)) {
-      throw new AppError('You can only move businesses you own', 403);
-    }
-    const last = await d.PartnerStageEvent.findOne({
-      where: { partnerOrganisationId: id },
-      order: [['createdAt', 'DESC']],
-    });
-    if (!last || !last.fromStage || last.toStage !== partner.pipelineStage) {
-      throw new AppError('Nothing to undo', 400);
-    }
-    // Undo is terminal — no undo-of-undo ping-pong.
-    if (last.reason === 'undo') {
-      throw new AppError('That move was already an undo', 400);
-    }
-    if (last.actorUserId !== user.id) {
-      throw new AppError('Only the person who made the move can undo it', 403);
-    }
-    if (Date.now() - new Date(last.createdAt).getTime() > 5 * 60 * 1000) {
-      throw new AppError('The undo window (5 minutes) has passed', 400);
-    }
+    return d.sequelize.transaction(async (t) => {
+      const partner = await getLivePartner(id, { transaction: t, lock: t.LOCK.UPDATE });
+      if (!canActOnRow(user, partner)) {
+        throw new AppError('You can only move businesses you own', 403);
+      }
+      const last = await d.PartnerStageEvent.findOne({
+        where: { partnerOrganisationId: id },
+        order: [['createdAt', 'DESC']],
+        transaction: t,
+      });
+      if (!last || !last.fromStage || last.toStage !== partner.pipelineStage) {
+        throw new AppError('Nothing to undo', 400);
+      }
+      // Undo is terminal — no undo-of-undo ping-pong.
+      if (last.reason === 'undo') {
+        throw new AppError('That move was already an undo', 400);
+      }
+      if (last.actorUserId !== user.id) {
+        throw new AppError('Only the person who made the move can undo it', 403);
+      }
+      if (Date.now() - new Date(last.createdAt).getTime() > 5 * 60 * 1000) {
+        throw new AppError('The undo window (5 minutes) has passed', 400);
+      }
 
-    const fromStage = partner.pipelineStage;
-    const toStage = last.fromStage;
-    // Restoring PARTNERED must meet the same entry bar as reaching it.
-    if (toStage === 'PARTNERED') {
-      await assertPartneredEntryRequirements(id, partner);
-    }
-    const availability =
-      toStage === 'LOST' ? 'disqualified'
-      : partner.ownerUserId ? 'owned' : 'available';
+      const fromStage = partner.pipelineStage;
+      const toStage = last.fromStage;
+      // Restoring PARTNERED must meet the same entry bar as reaching it.
+      if (toStage === 'PARTNERED') {
+        await assertPartneredEntryRequirements(id, partner, t);
+      }
+      const availability =
+        toStage === 'LOST' ? 'disqualified'
+        : partner.ownerUserId ? 'owned' : 'available';
 
-    await d.sequelize.transaction(async (t) => {
       // Conditional transition — a concurrent move loses cleanly instead of
       // silently overwriting it.
       const [moved] = await d.PartnerOrganisation.update(
@@ -358,8 +372,9 @@ export function makePartnerService(overrides = {}) {
         entityId: id, before: { stage: fromStage }, after: { stage: toStage },
         reason: 'undo', requestId, transaction: t,
       });
+      await d.fireCadenceHook('onStageChange', { partner, fromStage, toStage, user, transaction: t });
+      return partner;
     });
-    return partner;
   }
 
   /**
@@ -367,8 +382,8 @@ export function makePartnerService(overrides = {}) {
    * pipeline position; availability='follow_up_later' hides it from the queue
    * until the stale sweep wakes it at snoozedUntil.
    */
-  async function snoozePartner(id, user, until, requestId = null) {
-    const partner = await getLivePartner(id);
+  async function snoozePartnerTx(id, user, until, t, { requestId = null } = {}) {
+    const partner = await getLivePartner(id, { transaction: t, lock: t.LOCK.UPDATE });
     if (!canActOnRow(user, partner)) {
       throw new AppError('You can only snooze businesses you own', 403);
     }
@@ -382,36 +397,42 @@ export function makePartnerService(overrides = {}) {
     if (wake.getTime() > Date.now() + 366 * 24 * 60 * 60 * 1000) {
       throw new AppError('Snooze at most one year ahead', 400);
     }
-    await d.sequelize.transaction(async (t) => {
-      await partner.update(
-        { availability: 'follow_up_later', snoozedUntil: wake, staleFlag: false },
-        { transaction: t }
-      );
-      await d.audit.recordAuditEvent({
-        actorUser: user, action: 'partner.snoozed', entityType: 'partner_organisation',
-        entityId: id, after: { snoozedUntil: wake.toISOString() }, requestId, transaction: t,
-      });
+    await partner.update(
+      { availability: 'follow_up_later', snoozedUntil: wake, staleFlag: false },
+      { transaction: t }
+    );
+    await d.audit.recordAuditEvent({
+      actorUser: user, action: 'partner.snoozed', entityType: 'partner_organisation',
+      entityId: id, after: { snoozedUntil: wake.toISOString() }, requestId, transaction: t,
     });
+    await d.fireCadenceHook('onSnooze', { partner, until: wake, user, transaction: t });
     return partner;
   }
 
-  async function unsnoozePartner(id, user, requestId = null) {
-    const partner = await getLivePartner(id);
+  async function snoozePartner(id, user, until, requestId = null) {
+    return d.sequelize.transaction(async (t) => snoozePartnerTx(id, user, until, t, { requestId }));
+  }
+
+  async function unsnoozePartnerTx(id, user, t, { requestId = null } = {}) {
+    const partner = await getLivePartner(id, { transaction: t, lock: t.LOCK.UPDATE });
     if (!canActOnRow(user, partner)) {
       throw new AppError('You can only snooze businesses you own', 403);
     }
     if (partner.availability !== 'follow_up_later' && !partner.snoozedUntil) return partner;
-    await d.sequelize.transaction(async (t) => {
-      await partner.update(
-        { availability: partner.ownerUserId ? 'owned' : 'available', snoozedUntil: null },
-        { transaction: t }
-      );
-      await d.audit.recordAuditEvent({
-        actorUser: user, action: 'partner.unsnoozed', entityType: 'partner_organisation',
-        entityId: id, requestId, transaction: t,
-      });
+    await partner.update(
+      { availability: partner.ownerUserId ? 'owned' : 'available', snoozedUntil: null },
+      { transaction: t }
+    );
+    await d.audit.recordAuditEvent({
+      actorUser: user, action: 'partner.unsnoozed', entityType: 'partner_organisation',
+      entityId: id, requestId, transaction: t,
     });
+    await d.fireCadenceHook('onUnsnooze', { partner, user, source: 'manual', transaction: t });
     return partner;
+  }
+
+  async function unsnoozePartner(id, user, requestId = null) {
+    return d.sequelize.transaction(async (t) => unsnoozePartnerTx(id, user, t, { requestId }));
   }
 
   async function getTimeline(id, query = {}) {
@@ -493,10 +514,10 @@ export function makePartnerService(overrides = {}) {
     return { entries };
   }
 
-  async function logActivity(id, body, user, requestId = null) {
+  async function logActivityTx(id, body, user, t, { requestId = null, suppressCadenceHooks = false } = {}) {
     if (!ACTIVITY_TYPES.includes(body.type)) throw new AppError('Unknown activity type', 400);
     if (!body.summary || !String(body.summary).trim()) throw new AppError('Summary is required', 400);
-    const partner = await getLivePartner(id);
+    const partner = await getLivePartner(id, { transaction: t, lock: t.LOCK.UPDATE });
     if (!canActOnRow(user, partner) && !hasCapability(user, 'partners.reassign')) {
       // redemption_ops may log notes on any partner (fulfilment context)
       if (!(user.redeemOpsRole === 'redemption_ops' && hasCapability(user, 'activities.log'))) {
@@ -505,34 +526,42 @@ export function makePartnerService(overrides = {}) {
     }
 
     const meaningful = MEANINGFUL_ACTIVITY_TYPES.includes(body.type);
-    return d.sequelize.transaction(async (t) => {
-      const activity = await d.OutreachActivity.create(
+    const activity = await d.OutreachActivity.create(
+      {
+        partnerOrganisationId: id,
+        contactId: body.contactId || null,
+        type: body.type,
+        direction: ['outbound', 'inbound', 'internal'].includes(body.direction) ? body.direction : 'outbound',
+        summary: String(body.summary).trim(),
+        details: body.details || null,
+        outcome: body.outcome || null,
+        occurredAt: body.occurredAt ? new Date(body.occurredAt) : new Date(),
+        actorUserId: user.id,
+      },
+      { transaction: t }
+    );
+    if (meaningful) {
+      await partner.update(
         {
-          partnerOrganisationId: id,
-          contactId: body.contactId || null,
-          type: body.type,
-          direction: ['outbound', 'inbound', 'internal'].includes(body.direction) ? body.direction : 'outbound',
-          summary: String(body.summary).trim(),
-          details: body.details || null,
-          outcome: body.outcome || null,
-          occurredAt: body.occurredAt ? new Date(body.occurredAt) : new Date(),
-          actorUserId: user.id,
+          lastActivityAt: activity.occurredAt,
+          firstOutreachAt: partner.firstOutreachAt || activity.occurredAt,
+          atRiskFlag: false,
+          staleFlag: false,
         },
         { transaction: t }
       );
-      if (meaningful) {
-        await partner.update(
-          {
-            lastActivityAt: activity.occurredAt,
-            firstOutreachAt: partner.firstOutreachAt || activity.occurredAt,
-            atRiskFlag: false,
-            staleFlag: false,
-          },
-          { transaction: t }
-        );
-      }
-      return activity;
-    });
+    }
+    // A real inbound reply is a cadence exit signal. The suppress flag exists
+    // for the cadence engine itself (P1): the activity IT logs on completion
+    // must not re-enter the engine.
+    if (meaningful && activity.direction === 'inbound' && !suppressCadenceHooks) {
+      await d.fireCadenceHook('onInboundActivity', { partner, activity, user, transaction: t });
+    }
+    return activity;
+  }
+
+  async function logActivity(id, body, user, requestId = null) {
+    return d.sequelize.transaction(async (t) => logActivityTx(id, body, user, t, { requestId }));
   }
 
   async function editActivity(activityId, body, user, requestId = null) {
@@ -701,6 +730,12 @@ export function makePartnerService(overrides = {}) {
         throw new AppError('The duplicate has rewards or activations attached — move or end those first, then merge', 409);
       }
 
+      // Cadence hook BEFORE repointing (docs/plans/redeem-ops-cadences.md §5.4):
+      // the engine must exit the duplicate's enrollment while its tasks still
+      // point at the duplicate, or survivor tasks end up tied to a foreign
+      // enrollment.
+      await d.fireCadenceHook('onMergeDuplicate', { survivor, duplicate, user, transaction: t });
+
       for (const [Model, fk] of REPOINT_TARGETS()) {
         await Model.update({ [fk]: survivorId }, { where: { [fk]: duplicateId }, transaction: t });
       }
@@ -810,6 +845,8 @@ export function makePartnerService(overrides = {}) {
     importPartners, getTimeline, logActivity, editActivity, voidActivity,
     addContact, updateContact, archiveContact, addLocation, updateLocation,
     mergePartners, deletePartner, canActOnRow,
+    // P0 caller-transaction primitives (cadence engine + composed flows)
+    changeStageTx, snoozePartnerTx, unsnoozePartnerTx, logActivityTx,
   };
 }
 

--- a/backend/src/services/redeemOps/staleSweep.js
+++ b/backend/src/services/redeemOps/staleSweep.js
@@ -1,5 +1,6 @@
 import { sequelize } from '../../models/index.js';
 import { logger } from '../../utils/logger.js';
+import { fireCadenceHook } from './cadenceHooks.js';
 
 /**
  * Claim-inactivity sweep (brief §16, docs/redeem-ops/ERD.md §6). Flags only —
@@ -47,17 +48,29 @@ export async function runRedeemOpsStaleSweep() {
         )`
   );
 
-  // Wake expired snoozes: back to the working pool/queue.
-  const [, woken] = await sequelize.query(
+  // Wake expired snoozes: back to the working pool/queue. RETURNING feeds the
+  // cadence wake hook (docs/plans/redeem-ops-cadences.md §5.4) — without it a
+  // cadence paused by snooze would never resume, because this raw UPDATE
+  // bypasses unsnoozePartner entirely. Fired outside any transaction; each
+  // failure is contained per partner (the P1 reconciler is the backstop).
+  const [wokenRows] = await sequelize.query(
     `UPDATE partner_organisations
         SET availability = CASE WHEN "ownerUserId" IS NULL THEN 'available' ELSE 'owned' END,
             "snoozedUntil" = NULL, "updatedAt" = NOW()
       WHERE availability = 'follow_up_later'
         AND "snoozedUntil" IS NOT NULL AND "snoozedUntil" < NOW()
-        AND "archivedAt" IS NULL AND "mergedIntoId" IS NULL`
+        AND "archivedAt" IS NULL AND "mergedIntoId" IS NULL
+      RETURNING id`
   );
-  const wokenCount = woken?.rowCount ?? 0;
+  const wokenCount = Array.isArray(wokenRows) ? wokenRows.length : 0;
   if (wokenCount > 0) logger.info('redeem_ops.stale_sweep.woken', { woken: wokenCount });
+  for (const row of wokenRows || []) {
+    try {
+      await fireCadenceHook('onUnsnooze', { partnerId: row.id, source: 'sweep' });
+    } catch (err) {
+      logger.warn('redeem_ops.stale_sweep.wake_hook_failed', { partnerId: row.id, error: err?.message });
+    }
+  }
 
   const atRiskCount = atRisk?.rowCount ?? 0;
   const staleCount = stale?.rowCount ?? 0;

--- a/backend/src/services/redeemOps/taskService.js
+++ b/backend/src/services/redeemOps/taskService.js
@@ -21,6 +21,13 @@ export function sgtDayWindow(now = new Date()) {
  * managers (admin/super_admin/ops_admin/bdm) act on any task; everyone else only
  * on tasks they are assigned to or created. Task changes recompute the partner's
  * denormalized nextTaskAt.
+ *
+ * P0 tx primitives (docs/plans/redeem-ops-cadences.md §3): the write paths are
+ * `*Tx` functions that run inside a CALLER-owned transaction with the partner
+ * row locked before any task write — lock order is partner → task everywhere,
+ * matching the cadence engine's enrollment → partner → task. The public
+ * `createTask`/`updateTask` keep their exact signatures and behavior as thin
+ * one-transaction wrappers.
  */
 export function makeTaskService(overrides = {}) {
   const d = { OutreachTask, PartnerOrganisation, PartnerContact, User, sequelize, logger, ...overrides };
@@ -39,44 +46,48 @@ export function makeTaskService(overrides = {}) {
     );
   }
 
-  async function createTask(body, user) {
+  async function createTaskTx(body, user, t) {
     if (!body.title || !String(body.title).trim()) throw new AppError('Title is required', 400);
     if (!body.partnerOrganisationId) throw new AppError('partnerOrganisationId is required', 400);
     if (!body.dueAt || Number.isNaN(new Date(body.dueAt).getTime())) throw new AppError('A valid dueAt is required', 400);
     if (body.priority && !TASK_PRIORITIES.includes(body.priority)) throw new AppError('Unknown priority', 400);
     if (body.type && !TASK_TYPES.includes(body.type)) throw new AppError('Unknown task type', 400);
 
-    const partner = await d.PartnerOrganisation.findByPk(body.partnerOrganisationId);
+    const partner = await d.PartnerOrganisation.findByPk(body.partnerOrganisationId, {
+      transaction: t, lock: t.LOCK.UPDATE,
+    });
     if (!partner || partner.mergedIntoId) throw new AppError('Partner not found', 404);
 
     const assigneeUserId = body.assigneeUserId || user.id;
     if (assigneeUserId !== user.id && !isManager(user)) {
       throw new AppError('Only managers can assign tasks to others', 403);
     }
-    const assignee = await d.User.findByPk(assigneeUserId);
+    const assignee = await d.User.findByPk(assigneeUserId, { transaction: t });
     if (!assignee || !assignee.isActive || !(assignee.role === 'redeem_ops' || assignee.role === 'admin' || assignee.redeemOpsRole)) {
       throw new AppError('Assignee must be an active Redeem Ops staff member', 400);
     }
 
-    return d.sequelize.transaction(async (t) => {
-      const task = await d.OutreachTask.create(
-        {
-          title: String(body.title).trim(),
-          partnerOrganisationId: body.partnerOrganisationId,
-          contactId: body.contactId || null,
-          assigneeUserId,
-          createdBy: user.id,
-          dueAt: new Date(body.dueAt),
-          hasTime: !!body.hasTime,
-          priority: body.priority || 'medium',
-          type: body.type || 'follow_up',
-          description: body.description || null,
-        },
-        { transaction: t }
-      );
-      await recomputeNextTaskAt(body.partnerOrganisationId, t);
-      return task;
-    });
+    const task = await d.OutreachTask.create(
+      {
+        title: String(body.title).trim(),
+        partnerOrganisationId: body.partnerOrganisationId,
+        contactId: body.contactId || null,
+        assigneeUserId,
+        createdBy: user.id,
+        dueAt: new Date(body.dueAt),
+        hasTime: !!body.hasTime,
+        priority: body.priority || 'medium',
+        type: body.type || 'follow_up',
+        description: body.description || null,
+      },
+      { transaction: t }
+    );
+    await recomputeNextTaskAt(body.partnerOrganisationId, t);
+    return task;
+  }
+
+  async function createTask(body, user) {
+    return d.sequelize.transaction(async (t) => createTaskTx(body, user, t));
   }
 
   async function listTasks(query, user) {
@@ -113,8 +124,18 @@ export function makeTaskService(overrides = {}) {
     return { tasks: rows, pagination: { page, limit, total: count, totalPages: Math.ceil(count / limit) } };
   }
 
-  async function updateTask(taskId, body, user) {
-    const task = await d.OutreachTask.findByPk(taskId);
+  async function updateTaskTx(taskId, body, user, t) {
+    // Non-locking probe first: the partner must be locked BEFORE the task row
+    // (lock order partner → task; partnerOrganisationId is immutable on tasks,
+    // so the probe cannot go stale between the two reads).
+    const probe = await d.OutreachTask.findByPk(taskId, {
+      attributes: ['id', 'partnerOrganisationId'], transaction: t,
+    });
+    if (!probe) throw new AppError('Task not found', 404);
+    await d.PartnerOrganisation.findByPk(probe.partnerOrganisationId, {
+      transaction: t, lock: t.LOCK.UPDATE,
+    });
+    const task = await d.OutreachTask.findByPk(taskId, { transaction: t, lock: t.LOCK.UPDATE });
     if (!task) throw new AppError('Task not found', 404);
     if (!isManager(user) && task.assigneeUserId !== user.id && task.createdBy !== user.id) {
       throw new AppError('You can only update your own tasks', 403);
@@ -142,14 +163,19 @@ export function makeTaskService(overrides = {}) {
     }
     if (updates.priority && !TASK_PRIORITIES.includes(updates.priority)) throw new AppError('Unknown priority', 400);
 
-    return d.sequelize.transaction(async (t) => {
-      await task.update(updates, { transaction: t });
-      await recomputeNextTaskAt(task.partnerOrganisationId, t);
-      return task;
-    });
+    await task.update(updates, { transaction: t });
+    await recomputeNextTaskAt(task.partnerOrganisationId, t);
+    return task;
   }
 
-  return { createTask, listTasks, updateTask, recomputeNextTaskAt, isManager };
+  async function updateTask(taskId, body, user) {
+    return d.sequelize.transaction(async (t) => updateTaskTx(taskId, body, user, t));
+  }
+
+  return {
+    createTask, createTaskTx, listTasks, updateTask, updateTaskTx,
+    recomputeNextTaskAt, isManager,
+  };
 }
 
 const _default = makeTaskService();

--- a/backend/test/redeemOpsCadenceHooks.test.js
+++ b/backend/test/redeemOpsCadenceHooks.test.js
@@ -1,0 +1,251 @@
+/**
+ * P0 cadence tx-primitives + hook registry (docs/plans/redeem-ops-cadences.md §3).
+ * Proves: hooks fire inside the owning transaction at every CRM choke point,
+ * a throwing hook rolls the whole operation back, nothing registered = no-op
+ * (dark-ship), and the *Tx primitives compose into one caller transaction.
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+
+import { jest } from '@jest/globals';
+import { getApp, closeDb, createTestUser } from './helpers.js';
+import {
+  PartnerOrganisation, PartnerStageEvent, OutreachActivity, OutreachTask, sequelize,
+} from '../src/models/index.js';
+import { makePartnerService } from '../src/services/redeemOps/partnerService.js';
+import { makeClaimService } from '../src/services/redeemOps/claimService.js';
+import { makeTaskService } from '../src/services/redeemOps/taskService.js';
+import {
+  registerCadenceHooks, clearCadenceHooks, fireCadenceHook,
+} from '../src/services/redeemOps/cadenceHooks.js';
+import { runRedeemOpsStaleSweep } from '../src/services/redeemOps/staleSweep.js';
+
+let admin, exec;
+const partnerSvc = makePartnerService();
+const claimSvc = makeClaimService();
+const taskSvc = makeTaskService();
+
+beforeAll(async () => {
+  await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  exec = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
+});
+
+afterEach(() => clearCadenceHooks());
+afterAll(async () => {
+  await closeDb();
+});
+
+async function makePartner(name, patch = {}) {
+  const { partner } = await partnerSvc.createPartner({ tradingName: name }, admin.user);
+  if (Object.keys(patch).length) await partner.update(patch);
+  return partner;
+}
+
+const future = (days = 1) => new Date(Date.now() + days * 24 * 3600 * 1000);
+
+describe('registry', () => {
+  test('unknown hook names are rejected at register and fire time', async () => {
+    expect(() => registerCadenceHooks({ onSomethingElse: () => {} })).toThrow(/Unknown cadence hook/);
+    await expect(fireCadenceHook('onSomethingElse', {})).rejects.toThrow(/Unknown cadence hook/);
+  });
+
+  test('nothing registered → fire is a no-op (dark-ship default)', async () => {
+    await expect(fireCadenceHook('onStageChange', {})).resolves.toBeUndefined();
+  });
+});
+
+describe('onStageChange', () => {
+  test('fires inside the transaction with from/to stages', async () => {
+    const partner = await makePartner('Hook Stage Cafe', { pipelineStage: 'NEW' });
+    const spy = jest.fn();
+    registerCadenceHooks({ onStageChange: spy });
+
+    await partnerSvc.changeStage(partner.id, 'CONTACTED', admin.user);
+    expect(spy).toHaveBeenCalledTimes(1);
+    const payload = spy.mock.calls[0][0];
+    expect(payload.fromStage).toBe('NEW');
+    expect(payload.toStage).toBe('CONTACTED');
+    expect(payload.partner.id).toBe(partner.id);
+    expect(payload.transaction).toBeTruthy();
+  });
+
+  test('same-stage move does not fire', async () => {
+    const partner = await makePartner('Hook Stage Same', { pipelineStage: 'NEW' });
+    const spy = jest.fn();
+    registerCadenceHooks({ onStageChange: spy });
+    await partnerSvc.changeStage(partner.id, 'NEW', admin.user);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  test('a throwing hook rolls back the stage change atomically', async () => {
+    const partner = await makePartner('Hook Rollback Cafe', { pipelineStage: 'NEW' });
+    registerCadenceHooks({ onStageChange: () => { throw new Error('cadence says no'); } });
+
+    await expect(partnerSvc.changeStage(partner.id, 'CONTACTED', admin.user))
+      .rejects.toThrow('cadence says no');
+
+    const reloaded = await PartnerOrganisation.findByPk(partner.id);
+    expect(reloaded.pipelineStage).toBe('NEW');
+    const events = await PartnerStageEvent.count({ where: { partnerOrganisationId: partner.id } });
+    expect(events).toBe(0);
+  });
+});
+
+describe('onInboundActivity', () => {
+  test('meaningful inbound fires; outbound and internal notes do not', async () => {
+    const partner = await makePartner('Hook Inbound Cafe');
+    const spy = jest.fn();
+    registerCadenceHooks({ onInboundActivity: spy });
+
+    await partnerSvc.logActivity(partner.id, {
+      type: 'whatsapp_reply', direction: 'inbound', summary: 'They replied!',
+    }, admin.user);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].activity.type).toBe('whatsapp_reply');
+    expect(spy.mock.calls[0][0].transaction).toBeTruthy();
+
+    await partnerSvc.logActivity(partner.id, {
+      type: 'call_attempt', summary: 'rang, no answer',
+    }, admin.user);
+    await partnerSvc.logActivity(partner.id, {
+      type: 'internal_note', direction: 'inbound', summary: 'note to self',
+    }, admin.user);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test('suppressCadenceHooks keeps the engine-logged activity out of the loop', async () => {
+    const partner = await makePartner('Hook Suppress Cafe');
+    const spy = jest.fn();
+    registerCadenceHooks({ onInboundActivity: spy });
+
+    await sequelize.transaction(async (t) => {
+      await partnerSvc.logActivityTx(partner.id, {
+        type: 'email_reply', direction: 'inbound', summary: 'reply recorded by engine',
+      }, admin.user, t, { suppressCadenceHooks: true });
+    });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('onSnooze / onUnsnooze', () => {
+  test('manual snooze and wake fire with source', async () => {
+    const partner = await makePartner('Hook Snooze Cafe', { pipelineStage: 'CONTACTED' });
+    const snoozeSpy = jest.fn();
+    const wakeSpy = jest.fn();
+    registerCadenceHooks({ onSnooze: snoozeSpy, onUnsnooze: wakeSpy });
+
+    await partnerSvc.snoozePartner(partner.id, admin.user, future(10).toISOString());
+    expect(snoozeSpy).toHaveBeenCalledTimes(1);
+    expect(snoozeSpy.mock.calls[0][0].transaction).toBeTruthy();
+
+    await partnerSvc.unsnoozePartner(partner.id, admin.user);
+    expect(wakeSpy).toHaveBeenCalledTimes(1);
+    expect(wakeSpy.mock.calls[0][0].source).toBe('manual');
+  });
+
+  test('stale-sweep wake fires onUnsnooze per woken partner and survives hook failures', async () => {
+    const partner = await makePartner('Hook Sweep Wake Cafe', {
+      pipelineStage: 'CONTACTED',
+      availability: 'follow_up_later',
+      snoozedUntil: new Date(Date.now() - 3600 * 1000),
+    });
+    const calls = [];
+    registerCadenceHooks({
+      onUnsnooze: (p) => {
+        calls.push(p);
+        throw new Error('resume failed'); // must not crash the sweep
+      },
+    });
+
+    await expect(runRedeemOpsStaleSweep()).resolves.toBeTruthy();
+    const mine = calls.find((c) => c.partnerId === partner.id);
+    expect(mine).toBeTruthy();
+    expect(mine.source).toBe('sweep');
+
+    const reloaded = await PartnerOrganisation.findByPk(partner.id);
+    expect(reloaded.availability).toBe('available');
+    expect(reloaded.snoozedUntil).toBeNull();
+  });
+});
+
+describe('onRelease / onReassign', () => {
+  test('release fires after a claim', async () => {
+    const partner = await makePartner('Hook Release Cafe');
+    const spy = jest.fn();
+    registerCadenceHooks({ onRelease: spy });
+
+    await claimSvc.claimPartner(partner.id, exec.user);
+    await claimSvc.releasePartner(partner.id, exec.user);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].partnerId).toBe(partner.id);
+    expect(spy.mock.calls[0][0].transaction).toBeTruthy();
+  });
+
+  test('reassign fires with from/to users', async () => {
+    const partner = await makePartner('Hook Reassign Cafe');
+    const spy = jest.fn();
+    registerCadenceHooks({ onReassign: spy });
+
+    await claimSvc.assignPartner(partner.id, exec.user.id, admin.user);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].toUserId).toBe(exec.user.id);
+    expect(spy.mock.calls[0][0].transaction).toBeTruthy();
+  });
+});
+
+describe('onMergeDuplicate', () => {
+  test('fires BEFORE child repointing — duplicate still owns its tasks at hook time', async () => {
+    const survivor = await makePartner('Merge Survivor Cafe');
+    const duplicate = await makePartner('Merge Duplicate Cafe');
+    const task = await taskSvc.createTask({
+      title: 'Call the dup', partnerOrganisationId: duplicate.id, dueAt: future(2).toISOString(),
+    }, admin.user);
+
+    let tasksOnDuplicateAtHookTime = null;
+    registerCadenceHooks({
+      onMergeDuplicate: async ({ duplicate: dup, transaction }) => {
+        tasksOnDuplicateAtHookTime = await OutreachTask.count({
+          where: { partnerOrganisationId: dup.id }, transaction,
+        });
+      },
+    });
+
+    await partnerSvc.mergePartners(survivor.id, duplicate.id, admin.user);
+    expect(tasksOnDuplicateAtHookTime).toBe(1);
+
+    const moved = await OutreachTask.findByPk(task.id);
+    expect(moved.partnerOrganisationId).toBe(survivor.id);
+  });
+});
+
+describe('tx primitives compose (the point of P0)', () => {
+  test('logActivityTx + changeStageTx commit atomically in one caller transaction', async () => {
+    const partner = await makePartner('Composed Flow Cafe', { pipelineStage: 'NEW' });
+
+    await sequelize.transaction(async (t) => {
+      await partnerSvc.logActivityTx(partner.id, {
+        type: 'call_connected', summary: 'spoke to owner',
+      }, admin.user, t, { suppressCadenceHooks: true });
+      await partnerSvc.changeStageTx(partner.id, 'CONTACTED', admin.user, t);
+    });
+
+    const reloaded = await PartnerOrganisation.findByPk(partner.id);
+    expect(reloaded.pipelineStage).toBe('CONTACTED');
+    expect(reloaded.firstOutreachAt).toBeTruthy();
+    const acts = await OutreachActivity.count({ where: { partnerOrganisationId: partner.id } });
+    expect(acts).toBe(1);
+  });
+
+  test('behavior lock: completing the only open task still clears nextTaskAt', async () => {
+    const partner = await makePartner('Task Behavior Cafe');
+    const task = await taskSvc.createTask({
+      title: 'One task', partnerOrganisationId: partner.id, dueAt: future(3).toISOString(),
+    }, admin.user);
+    let row = await PartnerOrganisation.findByPk(partner.id);
+    expect(row.nextTaskAt).toBeTruthy();
+
+    await taskSvc.updateTask(task.id, { status: 'completed' }, admin.user);
+    row = await PartnerOrganisation.findByPk(partner.id);
+    expect(row.nextTaskAt).toBeNull();
+  });
+});

--- a/docs/plans/redeem-ops-cadences.md
+++ b/docs/plans/redeem-ops-cadences.md
@@ -1,0 +1,295 @@
+# Redeem Ops — Outreach Cadences (sequencing engine)
+
+**Status:** v2 DRAFT — revised after Codex review (gpt-5.6-sol xhigh, 2026-07-12, verdict RETHINK
+on v1; all 4 blockers verified against code and addressed below). Not yet built.
+**Depends on:** Redeem Ops Phases 1–7 (live), Discover (live). Migrations through 056 applied.
+
+## 1. Problem
+
+Discover fills the top of the funnel at machine scale, but every follow-up `outreach_tasks` row
+is created by hand — nothing outside `taskService` writes one. Today's only automation is the
+stale sweep (flags at >48h no first outreach / >14d inactivity): it detects neglect instead of
+preventing it. A **cadence** (Outreach.io "sequence") fixes this: an ordered step template a
+partner is *enrolled* into; the engine materializes the next task at the right time; completing
+a task with a **disposition** advances/branches; replies and stage changes exit automatically.
+
+Deviations from Outreach: channels are call/WhatsApp/IG/visit-first (SG F&B merchants); email is
+a support touch; **all steps are manual tasks in v1** (no auto-send).
+
+## 2. Goals / non-goals
+
+**Goals (P1):** versioned cadence definitions (seeded, no builder UI), enrollment lifecycle with
+per-owner capacity cap, linearizable advance-on-disposition, automatic exits/pauses wired into
+existing choke points, tasks in the existing queue/tasks surfaces via one shared component.
+
+**Non-goals (P1):** auto-send anything, mailbox sync/reply detection, builder UI, A/B tests,
+open/click tracking, per-step analytics, automatic pipeline-stage movement.
+
+## 3. Phase 0 — transaction-primitive refactor (prerequisite PR, pure refactor)
+
+Codex-verified: the promised atomic completion **cannot be composed from today's services** —
+`taskService.updateTask` reads via `findByPk` outside any transaction then opens its own
+(`taskService.js:117,146`); `partnerService.logActivity` likewise (`partnerService.js:496,508`);
+`recomputeNextTaskAt` reads the MIN with no partner lock (`taskService.js:31`). Before any cadence
+code:
+
+- Extract caller-transaction primitives, keeping public signatures behavior-identical:
+  `completeTaskTx(task, disposition-free updates, user, t)`, `logActivityTx(partner, body, user, t, opts)`,
+  `recomputeNextTaskAtTx(partnerId, t)` (recompute once, after all task writes, partner row locked),
+  `changeStageTx(partner, toStage, user, t, …)`, `resumeSnoozeTx/pauseTx` equivalents.
+- All reads that feed decisions move inside the transaction with `FOR UPDATE` on the row.
+- `logActivityTx` gains `opts.suppressCadenceHooks` (recursion guard: the activity a cadence
+  completion writes must not re-enter the cadence engine).
+- Cadence hooks are **dependency-inverted**: services expose `registerCadenceHooks({onInboundActivity,
+  onStageChange, onSnooze, onUnsnooze, onRelease, onReassign, onMergeDuplicate, onArchive})`, wired in
+  `bootstrap.js` (house precedent: the Phase-6 fulfilment capture hook composition root). No
+  circular imports; hooks run **inside the owning transaction**.
+- Ship as its own PR with tests proving no behavior change.
+
+## 4. Data model (migration 057 — schema ONLY, per-column guards + `IF NOT EXISTS` indexes; NO seed)
+
+### 4.1 `outreach_cadences` — a row is one immutable VERSION
+```
+id UUID PK; key STRING(64) NOT NULL;        -- immutable machine key, e.g. 'fnb_call_first'
+version INTEGER NOT NULL;                    -- UNIQUE (key, version)
+name STRING(120) NOT NULL;                   -- display only, never an identifier
+description TEXT; targetCategory STRING(64) NULL;
+isActive BOOLEAN NOT NULL default true;      -- retired versions: false (never delete)
+createdBy UUID NOT NULL FK users RESTRICT; timestamps.
+```
+Editing a definition = insert version n+1, retire n. Live enrollments keep their frozen version.
+`targetCategory` must be added to `categoryService` rename/merge cascades (it's a 4th consumer).
+
+### 4.2 `outreach_cadence_steps`
+```
+id UUID PK; cadenceId UUID NOT NULL FK RESTRICT;
+stepOrder INTEGER NOT NULL CHECK >= 1;       -- display ordering; UNIQUE (cadenceId, stepOrder)
+channel STRING(24) NOT NULL;                 -- call | whatsapp | email | instagram_dm | visit | custom
+mode STRING(12) NOT NULL default 'manual';   -- 'auto' reserved (P3, email only)
+title STRING(160) NOT NULL; scriptTemplate TEXT;
+priority STRING(12) NOT NULL default 'medium';
+```
+
+### 4.3 `outreach_cadence_transitions` — explicit edges (replaces v1's conditional-skip)
+```
+id UUID PK; cadenceId UUID NOT NULL FK RESTRICT;
+fromStepId UUID NULL FK steps RESTRICT;      -- NULL = entry edge (enrollment start)
+disposition STRING(24) NOT NULL;             -- or '*' default edge
+toStepId UUID NULL FK steps RESTRICT;        -- NULL = finish (state completed)
+terminalAction STRING(24) NULL;              -- exit_not_interested | finish | NULL
+delayDays INTEGER NOT NULL default 0 CHECK >= 0;  -- AFTER the from-step's completion
+timeWindow STRING(16) NOT NULL default 'any';     -- any | morning | afternoon | off_peak
+UNIQUE (fromStepId, disposition)
+```
+Resolution: exact `(fromStepId, disposition)` edge, else `(fromStepId,'*')`, else finish. Branch
+context is carried by the edge itself — no lost-disposition problem, branch-specific delays are
+free, and the D0/D2 arithmetic ambiguity from v1 is gone (delays live on edges, always relative
+to the previous completion; the seeded gaps below are edge delays, not absolute day numbers).
+
+### 4.4 `outreach_cadence_enrollments`
+```
+id UUID PK; cadenceId UUID NOT NULL FK RESTRICT;   -- frozen version row
+partnerOrganisationId UUID NOT NULL FK CASCADE;
+state STRING(16) NOT NULL default 'active';        -- active | paused | completed | exited
+currentStepId UUID NULL FK steps RESTRICT;
+lastDisposition STRING(24) NULL;
+exitReason STRING(32) NULL;   -- replied | stage_advanced | lost | not_interested | released |
+                              -- archived | merged | manual_stop | finished
+enrolledBy UUID NOT NULL FK users RESTRICT; pausedAt/endedAt DATE NULL; timestamps.
+PARTIAL UNIQUE INDEX (partnerOrganisationId) WHERE state IN ('active','paused')
+INDEX (state, updatedAt)
+```
+
+### 4.5 `outreach_tasks` additions (+ integrity)
+```
+cadenceEnrollmentId UUID NULL FK RESTRICT; cadenceStepId UUID NULL FK RESTRICT;
+snapshotRecipient STRING(160) NULL;          -- resolved phone/email/handle/address at materialization
+-- scriptTemplate renders INTO description at materialization (frozen snapshot)
+CHECK ((cadenceEnrollmentId IS NULL) = (cadenceStepId IS NULL))
+PARTIAL UNIQUE INDEX (cadenceEnrollmentId) WHERE status IN ('open','in_progress')
+```
+Service-enforced (tested, not DB-checked): step belongs to enrollment's cadence; task partner ==
+enrollment partner. FKs are RESTRICT so history survives definition retirement.
+
+### 4.6 `outreach_suppressions` (compliance, minimal P1)
+```
+id UUID PK; channel STRING(24) NOT NULL;     -- call | whatsapp | email | any
+value STRING(160) NOT NULL;                  -- normalized phone/email
+reason STRING(32) NOT NULL;                  -- opt_out | dnc_listed | bounced | complaint
+source STRING(32); expiresAt DATE NULL; timestamps. UNIQUE (channel, value)
+```
+Materialization gate: recipient in suppressions → step outcome `blocked` (skip + audit + owner
+notified). Applies to manual steps too. PDPC's B2B exclusion is purpose-based, not line-type-based;
+when `DNC_API_ENABLED` flips, call/whatsapp materialization runs `dncGate` and records
+result + checkedAt on the task snapshot. Until then: suppressions + honest badge.
+
+### 4.7 Constants (constants.js, exposed via `publicConstants`)
+`CADENCE_CHANNELS`, `CADENCE_ENROLLMENT_STATES`, `CADENCE_EXIT_REASONS`, `CADENCE_TIME_WINDOWS`,
+and an exhaustive **per-channel disposition matrix** (no global list — call+`sent` is nonsense):
+```
+CHANNEL_DISPOSITIONS = {
+  call:         ['connected','no_answer','not_interested','replied'],
+  whatsapp:     ['sent','replied','not_interested'],
+  email:        ['sent','replied','not_interested'],
+  instagram_dm: ['sent','replied','not_interested'],
+  visit:        ['met','closed','not_interested'],
+  custom:       ['done','not_interested'],
+}
+ACTIVITY_TYPES += 'visit' (also MEANINGFUL_ACTIVITY_TYPES)  -- Codex Q3: agreed
+```
+
+## 5. Engine semantics (`makeCadenceService(overrides={})` — house factory style)
+
+### 5.1 Enroll — with capacity cap (P1, Codex Q7: agreed)
+Preconditions inside one transaction: partner live + **owned** (or actor manager), no live
+enrollment (partial-unique backstops the check), owner's active-enrollment count < cap
+(default 60; manager override flag audited) counted under lock. Resolve the entry edge,
+**materialize the first task synchronously**, audit. Enrollment requires an owner because tasks
+require an assignee — see §7 for the Discover/pool implication.
+
+### 5.2 Completion — the linearizable core
+Dedicated endpoint `POST /api/redeem-ops/cadence-tasks/:taskId/complete { disposition, alsoMarkLost? }`.
+One transaction, one lock order everywhere (**enrollment → partner → task**):
+1. `SELECT enrollment FOR UPDATE`; require `state='active'` and `currentStepId == task.cadenceStepId`.
+2. `SELECT partner FOR UPDATE` (live check). 3. Complete task with a status predicate
+   (`UPDATE … WHERE status IN ('open','in_progress')`); 0 rows → replay: return the recorded
+   result (idempotent) or 409.
+4. Validate disposition against `CHANNEL_DISPOSITIONS[step.channel]`.
+5. `logActivityTx(…, {suppressCadenceHooks:true})` with an **honest** mapping: call+connected →
+   `call_connected`; call+no_answer → `call_attempt`; sent → channel's `*_sent`/`instagram_dm`;
+   visit+met → `visit`; replied → channel's `*_reply` (direction inbound); **not_interested →
+   the channel-truthful outbound type** (e.g. `call_connected`, summary "Not interested") — never
+   a fake `follow_up` (v1 would have stamped `firstOutreachAt` dishonestly).
+6. Terminal handling: `not_interested` → exit(not_interested); if `alsoMarkLost` (UI confirm
+   dialog) → `changeStageTx(LOST, lostReason='not_interested')` in the SAME transaction — no
+   contradictory half-state. `replied` → exit(replied) + UI one-click stage suggestion
+   (no auto stage move — Codex Q5: agreed, activity logging never moves stages in this codebase).
+7. Otherwise resolve edge → materialize next task; `recomputeNextTaskAtTx` once at the end.
+
+### 5.3 Materialization (used by enroll/advance/resume/reconcile)
+- **Channel prerequisites**: resolve recipient (call/whatsapp → contact mobile else org
+  `primaryPhone`; email → contact email else `primaryEmail`; instagram_dm → handle; visit →
+  active location). Missing or suppressed → outcome `blocked`: skip via the step's `'*'` edge,
+  audit, notify owner. Snapshot resolved recipient + rendered script onto the task (allowlisted
+  plain-text merge engine; unresolved placeholder ⇒ blocked, never a template leaked to a card).
+- **Scheduling**: `dueAt = previous completion + delayDays`, clamped into the SGT `timeWindow`
+  (new `sgtWindowClamp` helper — `sgtDayWindow` only yields day bounds). If the window already
+  passed today, **roll forward to the next allowed day** (never due-in-the-past). No weekend
+  skip for F&B cadences (merchants trade weekends); `off_peak` = 15:00–17:00 SGT.
+- Assignee = partner owner at materialization time.
+
+### 5.4 Exits & pauses — hooks INSIDE owning transactions (composition-root registered)
+| Trigger (Tx hook) | Effect on live enrollment |
+|---|---|
+| inbound meaningful activity (not suppressed) | exit(replied); cancel open cadence task |
+| `changeStageTx` → MEETING/PROPOSAL/PARTNERED | exit(stage_advanced) |
+| `changeStageTx` → LOST | exit(lost) |
+| partner snooze | pause (+ cancel open cadence task). **Snooze ⇒ cadence pause, but cadence "Pause" ≠ snooze** — pausing a cadence must not flip global partner availability (Codex #10: agreed; UI copy states the difference) |
+| unsnooze (manual) | resume via `resumeTx`: re-materialize current step, anchor = resume time |
+| **sweep snooze-wake** | the sweep's raw-SQL wake (`staleSweep.js:51`) bypasses services — it must `RETURNING id` and invoke `resumeTx` per woken partner (or mark enrollments `wake_pending` for the reconciler). Verified gap; without this, paused cadences never resume |
+| release | exit(released) |
+| reassign | keep enrollment; reassign the open cadence task in the same tx |
+| merge | **exit/cancel the duplicate's enrollment BEFORE task repointing** (else survivor gets tasks pointing at a foreign enrollment and a partial-unique collision); survivor's enrollment wins |
+| archive / hard delete | exit(archived) / cascade per existing delete semantics |
+All exits cancel the open cadence task and write an audit event in the same transaction.
+
+### 5.5 Generic task APIs must not bypass the engine (verified blocker)
+`taskService.updateTask` currently lets assignee OR **creator** flip status/reassign/edit
+(`taskService.js:117-131`), and TasksPage exposes Complete/Cancel/Reopen/Edit. Rules:
+- On cadence tasks, generic PATCH may edit only `description`/`priority`. Status changes,
+  `dueAt`, `assigneeUserId`, and provenance fields → 409 pointing at the disposition endpoint
+  (manager reassign goes through the reassign hook). Reopen is never valid on a cadence task.
+- Cancel = "stop cadence" only (explicit endpoint, records manual_stop).
+- Both MyQueue and TasksPage render the shared cadence card (§8) — not just MyQueue.
+
+### 5.6 Reconciliation tick (small, safe)
+In-process on the bootstrap interval, but: `pg_try_advisory_lock` + re-entrancy guard (the
+existing bare `setInterval` sweeps can overlap — verified), `FOR UPDATE SKIP LOCKED` row claims.
+Scope: (a) active enrollments with no open cadence task NOT caused by a deliberate stop
+(cancellation writes reason+generation, reconciler skips those); (b) `wake_pending` resumes;
+(c) P3 auto-sends. Log counters: orphans repaired, duplicates prevented, failed advances, due
+backlog. Nothing else — normal advance stays synchronous.
+
+## 6. Email steps
+
+**P1 (manual):** email step = task whose card shows the rendered snapshot ([Copy] + `mailto:`).
+Rep sends from their own Zoho mailbox, taps `sent`. Reply arrives in their real inbox; logging
+the inbound activity exits the cadence.
+**P3 (auto, `REDEEM_OPS_CADENCE_AUTOSEND`):** verified: the current mailer cannot carry this —
+single cached transporter, no reply-to/threading/unsubscribe headers, no idempotency
+(`mailer.js:17-38`). Requires a separate outreach transport + **`outreach_send_attempts` outbox**
+(claim → send with idempotency key → persist provider Message-ID → advance; send never inside
+the DB transaction). Transport options: per-rep Zoho SMTP/OAuth (sends as the rep) or SES from an
+isolated warmed subdomain (`partners.redeem.sg`) — never root `redeem.sg` (consumer transactional
+mail). Bounce/complaint webhooks → `outreach_suppressions` BEFORE auto mode ships.
+`List-Unsubscribe` + honored opt-out (Spam Control Act / IMDA).
+
+## 7. Enrollment surfaces & ownership (Codex #12 verified: Discover returns counts, partners start unowned)
+
+- P1: enroll button on Partner Detail (owned partners), bulk from **my owned** partners list.
+- P2: pool/Discover moments need an **atomic claim-and-enroll** op (claim via `claimPartnerTx`
+  + enroll in one transaction, capacity preflight) and `addToPartners` must return created
+  partner IDs (today: counts only, `discoveryService.js:541-547`). Prompt fires post-claim.
+
+## 8. UI spec (Fresha idiom)
+
+1. **One shared `CadenceTaskCard`** used by MyQueue AND TasksPage: cadence chip
+   (`F&B call-first v1 · 3/7`), **expandable** script (queue rows are compact `DocketRow`s —
+   always-inline doesn't fit; verified), channel-valid disposition buttons only, per-task pending
+   state, confirm + undo-window for terminal dispositions (`not_interested` opens the
+   "also mark Lost?" confirm that drives §5.2's atomic path).
+2. **Partner Detail**: compact cadence summary directly under the header on mobile (the 320px
+   right rail lands below all tab content on mobile — verified), full card in the desktop rail:
+   step list with done/skipped/current/blocked states + SGT dates, exit reason, Pause/Stop,
+   atomic Switch (exit old + enroll new version in one call).
+3. **Queue accounting** (Codex Q6 verified — real double-count today: `todoToday` sums
+   due-tasks + awaiting-first-outreach, `MyQueue.jsx:73`): awaiting-first-outreach excludes
+   partners with an open cadence first-touch task that is not overdue.
+4. **Coverage stat** (team pipeline): % of owned partners with an open *outreach-type* task
+   (call/whatsapp/email/instagram_dm/visit/follow_up) — NOT bare `nextTaskAt`, which counts
+   admin/meeting tasks.
+5. Settings → Cadences: read-only version list per key. Builder UI deferred; `settings.manage`.
+
+## 9. Permissions & flags
+
+- Enroll/pause/stop/complete: partner owner; managers (existing `isManager` set) any.
+- Definitions (create/retire versions — even before builder UI, via seeds): `settings.manage`.
+- Flags: backend `REDEEM_OPS_CADENCES_ENABLED` (routes + tick + hooks no-op when off), frontend
+  `VITE_REDEEM_OPS_CADENCES_ENABLED` (SPA has only the master flag today — verified).
+
+## 10. Seeds — bootstrap, not migration (Codex Q4 verified: migrations run before `initSystemAgent`, `createdBy` FK would dangle on fresh DBs)
+
+Idempotent `ensureCadences()` in bootstrap after `initSystemAgent`, advisory-lock guarded,
+keyed by immutable `(key, version)`:
+- **`fnb_call_first` v1** (edge delays, not absolute days): call#1 —(no_answer, +0d, off_peak)→
+  WhatsApp intro —(*, +2d)→ call#2 —(no_answer, +2d)→ IG DM —(*, +3d)→ call#3 —(no_answer, +3d)→
+  visit —(*, +4d)→ break-up WhatsApp —(sent)→ finish. `connected`/`replied` edges terminate or
+  fast-forward per matrix.
+- **`revival_60d` v1**: WhatsApp check-in —(*, +5d)→ call —(no_answer, +7d)→ email → finish.
+
+## 11. Phasing
+
+- **P0:** transaction-primitive refactor + hook registry (pure refactor PR, no behavior change).
+- **P1:** migration 057 + models/constants; cadenceService (enroll/complete/exit/pause/resume/
+  reconcile + capacity cap); hook wiring incl. sweep-wake fix; disposition endpoint + generic-PATCH
+  guard; `CadenceTaskCard` in MyQueue + TasksPage; Partner Detail card; queue dedup; suppressions
+  gate; bootstrap seeds; dark flags.
+- **P2:** claim-and-enroll (pool/Discover, `addToPartners` returns IDs); coverage stat; Settings
+  read-only view; DNC gate wiring when enabled.
+- **P3:** auto-email (outreach transport + outbox + bounce suppression), Zoho reply auto-exit
+  (IMAP/API poll), builder UI, per-step funnel analytics.
+
+## 12. Testing
+
+House pattern (jest from `backend/`, throwaway pg on 5433). Beyond the usual unit/route coverage:
+**concurrency tests** — double-complete race (two tx, one wins, replay semantics), completion vs
+inbound-exit race, merge-vs-advance, tick overlap (advisory lock), crash between task-create and
+enrollment-update (reconciler repairs); migration guarded re-run; P0 refactor equivalence suite.
+
+## 13. Resolved questions (v1 §12 → Codex answers, verified where they touch code)
+
+1. Branching: explicit transition edges, not conditional-skip. 2. Reassign keeps / release exits;
+merge exits duplicate BEFORE repointing. 3. `visit` becomes a real activity type. 4. Seeds in
+bootstrap. 5. No automatic stage movement; one-click suggestion after `replied`. 6. Queue
+excludes scheduled cadence first-touches; coverage counts outreach-type tasks only. 7. Capacity
+cap ships in P1.


### PR DESCRIPTION
## What

Prerequisite refactor for the Outreach-style cadence engine (design doc: `docs/plans/redeem-ops-cadences.md`, included in this PR — v2 after a Codex gpt-5.6-sol xhigh review returned 24 findings / 4 blockers, every code-level claim verified against the repo before folding in).

The blockers all reduced to one fact: **the promised atomic cadence completion could not be composed from today's services** — `taskService.updateTask` and `partnerService.logActivity` read outside a transaction then open their own, `recomputeNextTaskAt` reads without a partner lock, and the stale-sweep snooze wake is raw SQL invisible to services. This PR fixes the substrate without changing behavior:

- **Tx primitives**: `changeStageTx` / `logActivityTx` / `snoozePartnerTx` / `unsnoozePartnerTx` / `createTaskTx` / `updateTaskTx` run inside a caller-owned transaction, decision reads inside with `FOR UPDATE` on the partner; lock order **partner → task** everywhere. Public wrappers keep exact signatures.
- **Hook registry** (`cadenceHooks.js`): dependency-inverted, fired inside the owning transaction at every choke point — inbound activity, stage change (incl. undo), snooze/unsnooze, release/reassign, and merge **before** child repointing. Nothing registered → every fire is a no-op, so this ships dark. A throwing hook aborts the transaction by design (cadence state must never diverge from CRM state).
- **Recursion guard**: `logActivityTx(..., { suppressCadenceHooks })` for the engine's own completion activities (P1).
- **Sweep wake**: `RETURNING id` + per-partner `onUnsnooze(source:'sweep')` with contained failures — previously a snooze-paused cadence could never resume.

## Tests

- 12 new tests in `redeemOpsCadenceHooks.test.js`: rollback-on-hook-throw atomicity, merge-hook ordering proof (duplicate still owns its tasks at hook time), tx-primitive composability in one transaction, dark-ship no-op, sweep wake + hook-failure containment, behavior locks.
- Full redeem-ops + discovery set locally (throwaway pg 5433): **154/155 pass across 12 suites** — the single `redeemOpsRewards` failure is pre-existing and verified byte-identical on unmodified baseline via stash.
- CI note: backend CI fails fast at the unit step (shortlinkService, known baseline), so DB-backed suites run locally only.

## Next

P1 (engine: migration 057, enroll/complete/exit, disposition endpoint, queue UI) builds on these primitives per the design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)