### PR TITLE
feat(redeem-ops): cadence engine P1 — enroll, disposition completion, exits, seeds, UI (dark)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -294,3 +294,7 @@ DISCOVERY_ENRICH_MAX_PER_USER_DAY=200        # per-user profile cap (same guardr
 DISCOVERY_COST_PER_RESULT_USD=0.007          # rough pre-run estimate; actual read from the run
 DISCOVERY_RECONCILE_STUCK_MINUTES=10         # age before a non-terminal run is re-fetched from Apify
 DISCOVERY_CANDIDATE_TTL_DAYS=90              # retention: purge scraped candidates after N days (0 = keep forever)
+
+# ── Redeem Ops — Outreach cadences (sequencing engine; migration 057) ──────────
+REDEEM_OPS_CADENCES_ENABLED=false             # routes + hook wiring + seeds + reconcile tick (needs REDEEM_OPS_ENABLED too)
+REDEEM_OPS_CADENCE_CAP=60                     # max live enrollments per owner (managers may override per-enroll)

--- a/backend/src/controllers/redeemOps/cadenceController.js
+++ b/backend/src/controllers/redeemOps/cadenceController.js
@@ -1,0 +1,59 @@
+import Joi from 'joi';
+import { asyncHandler, AppError } from '../../middleware/errorHandler.js';
+import cadenceService from '../../services/redeemOps/cadenceService.js';
+import { LOST_REASONS } from '../../services/redeemOps/constants.js';
+
+function validateBody(schema, body) {
+  const { error, value } = schema.validate(body, { abortEarly: false });
+  if (error) throw new AppError(error.details.map((x) => x.message).join(', '), 400);
+  return value;
+}
+
+export const listCadences = asyncHandler(async (req, res) => {
+  const cadences = await cadenceService.listCadences();
+  res.json({ success: true, data: { cadences } });
+});
+
+export const getPartnerCadence = asyncHandler(async (req, res) => {
+  const data = await cadenceService.getPartnerCadence(req.params.partnerId);
+  res.json({ success: true, data });
+});
+
+const enrollSchema = Joi.object({
+  cadenceId: Joi.string().uuid(),
+  cadenceKey: Joi.string().max(64),
+  overrideCapacity: Joi.boolean(),
+}).or('cadenceId', 'cadenceKey');
+
+export const enroll = asyncHandler(async (req, res) => {
+  const body = validateBody(enrollSchema, req.body || {});
+  const result = await cadenceService.enrollPartner(req.params.partnerId, body, req.user, req.id);
+  res.status(201).json({ success: true, data: result });
+});
+
+const completeSchema = Joi.object({
+  disposition: Joi.string().max(24).required(),
+  alsoMarkLost: Joi.boolean(),
+  lostReason: Joi.string().valid(...LOST_REASONS),
+});
+
+export const completeCadenceTask = asyncHandler(async (req, res) => {
+  const body = validateBody(completeSchema, req.body || {});
+  const result = await cadenceService.completeCadenceTask(req.params.taskId, body, req.user, req.id);
+  res.json({ success: true, data: result });
+});
+
+export const pause = asyncHandler(async (req, res) => {
+  const enrollment = await cadenceService.pauseEnrollment(req.params.partnerId, req.user, req.id);
+  res.json({ success: true, data: { enrollment } });
+});
+
+export const resume = asyncHandler(async (req, res) => {
+  const enrollment = await cadenceService.resumeEnrollment(req.params.partnerId, req.user, req.id);
+  res.json({ success: true, data: { enrollment } });
+});
+
+export const stop = asyncHandler(async (req, res) => {
+  const enrollment = await cadenceService.stopEnrollment(req.params.partnerId, req.user, req.id);
+  res.json({ success: true, data: { enrollment } });
+});

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -201,6 +201,31 @@ export async function bootstrapDatabase() {
       setInterval(runRedeemOpsSweepSafe, 30 * 60 * 1000); // every 30 min
       logger.info('[RedeemOps] stale sweep scheduled (30m interval)');
 
+      // Cadence engine (docs/plans/redeem-ops-cadences.md §5.4) — COMPOSITION
+      // ROOT for the P0 hook registry: the CRM services never import the
+      // engine; we register its handlers here. Removing this block (or leaving
+      // the flag off) returns every choke point to no-op hook fires.
+      if (String(process.env.REDEEM_OPS_CADENCES_ENABLED || 'false').toLowerCase() === 'true') {
+        await safeRun('Redeem Ops cadence engine', async () => {
+          const { registerCadenceHooks } = await import('../services/redeemOps/cadenceHooks.js');
+          const { makeCadenceService } = await import('../services/redeemOps/cadenceService.js');
+          const { ensureCadences } = await import('../services/redeemOps/cadenceSeeds.js');
+          const cadences = makeCadenceService();
+          registerCadenceHooks(cadences.hookHandlers());
+          await ensureCadences();
+          const runCadenceReconcileSafe = async () => {
+            try {
+              await cadences.reconcile();
+            } catch (err) {
+              logger.warn('[RedeemOps] cadence reconcile failed (non-fatal)', { error: err?.message });
+            }
+          };
+          setTimeout(runCadenceReconcileSafe, 240_000);
+          setInterval(runCadenceReconcileSafe, 30 * 60 * 1000); // every 30 min
+          logger.info('[RedeemOps] cadence hooks registered + reconcile scheduled (30m interval)');
+        });
+      }
+
       // Phase 6 fulfilment (docs/redeem-ops/MKTR_INTEGRATION.md §2). This is the
       // COMPOSITION ROOT for the dependency-inverted capture hook: prospectService
       // never imports Redeem Ops — we register the callback here, so removing this

--- a/backend/src/database/migrations/057-redeem-ops-cadences.js
+++ b/backend/src/database/migrations/057-redeem-ops-cadences.js
@@ -1,0 +1,145 @@
+/**
+ * Redeem Ops cadences P1 — schema ONLY (docs/plans/redeem-ops-cadences.md §4).
+ * Definitions are seeded by bootstrap.ensureCadences AFTER initSystemAgent
+ * (migrations run before the system agent exists, so a migration seed could
+ * never satisfy createdBy NOT NULL on a fresh database).
+ *
+ * Guarded for partial re-runs and NODE_ENV=test sync-first, like 045-053.
+ */
+export async function up(queryInterface, Sequelize) {
+  const tables = await queryInterface.showAllTables();
+  const UUID = Sequelize.UUID;
+  const ts = () => ({
+    createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+  });
+
+  if (!tables.includes('outreach_cadences')) {
+    await queryInterface.createTable('outreach_cadences', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      key: { type: Sequelize.STRING(64), allowNull: false },
+      version: { type: Sequelize.INTEGER, allowNull: false },
+      name: { type: Sequelize.STRING(120), allowNull: false },
+      description: { type: Sequelize.TEXT },
+      targetCategory: { type: Sequelize.STRING(64) },
+      isActive: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: true },
+      createdBy: { type: UUID, allowNull: false, references: { model: 'users', key: 'id' }, onDelete: 'RESTRICT' },
+      ...ts(),
+    });
+  }
+
+  if (!tables.includes('outreach_cadence_steps')) {
+    await queryInterface.createTable('outreach_cadence_steps', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      cadenceId: { type: UUID, allowNull: false, references: { model: 'outreach_cadences', key: 'id' }, onDelete: 'RESTRICT' },
+      stepOrder: { type: Sequelize.INTEGER, allowNull: false },
+      channel: { type: Sequelize.STRING(24), allowNull: false },
+      mode: { type: Sequelize.STRING(12), allowNull: false, defaultValue: 'manual' },
+      title: { type: Sequelize.STRING(160), allowNull: false },
+      scriptTemplate: { type: Sequelize.TEXT },
+      priority: { type: Sequelize.STRING(12), allowNull: false, defaultValue: 'medium' },
+      ...ts(),
+    });
+  }
+
+  if (!tables.includes('outreach_cadence_transitions')) {
+    await queryInterface.createTable('outreach_cadence_transitions', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      cadenceId: { type: UUID, allowNull: false, references: { model: 'outreach_cadences', key: 'id' }, onDelete: 'RESTRICT' },
+      // NULL = entry edge (enrollment start)
+      fromStepId: { type: UUID, references: { model: 'outreach_cadence_steps', key: 'id' }, onDelete: 'RESTRICT' },
+      disposition: { type: Sequelize.STRING(24), allowNull: false },
+      // NULL toStepId + NULL terminalAction = finish
+      toStepId: { type: UUID, references: { model: 'outreach_cadence_steps', key: 'id' }, onDelete: 'RESTRICT' },
+      terminalAction: { type: Sequelize.STRING(24) },
+      delayDays: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 0 },
+      timeWindow: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'any' },
+      ...ts(),
+    });
+  }
+
+  if (!tables.includes('outreach_cadence_enrollments')) {
+    await queryInterface.createTable('outreach_cadence_enrollments', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      cadenceId: { type: UUID, allowNull: false, references: { model: 'outreach_cadences', key: 'id' }, onDelete: 'RESTRICT' },
+      partnerOrganisationId: { type: UUID, allowNull: false, references: { model: 'partner_organisations', key: 'id' }, onDelete: 'CASCADE' },
+      state: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'active' },
+      currentStepId: { type: UUID, references: { model: 'outreach_cadence_steps', key: 'id' }, onDelete: 'RESTRICT' },
+      lastDisposition: { type: Sequelize.STRING(24) },
+      exitReason: { type: Sequelize.STRING(32) },
+      enrolledBy: { type: UUID, allowNull: false, references: { model: 'users', key: 'id' }, onDelete: 'RESTRICT' },
+      pausedAt: { type: Sequelize.DATE },
+      endedAt: { type: Sequelize.DATE },
+      ...ts(),
+    });
+  }
+
+  if (!tables.includes('outreach_suppressions')) {
+    await queryInterface.createTable('outreach_suppressions', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      channel: { type: Sequelize.STRING(24), allowNull: false },
+      value: { type: Sequelize.STRING(160), allowNull: false },
+      reason: { type: Sequelize.STRING(32), allowNull: false },
+      source: { type: Sequelize.STRING(32) },
+      expiresAt: { type: Sequelize.DATE },
+      ...ts(),
+    });
+  }
+
+  // outreach_tasks provenance columns — per-column guards (047 pattern).
+  const taskCols = await queryInterface.describeTable('outreach_tasks');
+  if (!taskCols.cadenceEnrollmentId) {
+    // NO ACTION (not RESTRICT): checked at statement end, so a partner-delete
+    // cascade that removes both enrollments and tasks still succeeds, while a
+    // direct enrollment delete with live tasks is refused.
+    await queryInterface.addColumn('outreach_tasks', 'cadenceEnrollmentId', {
+      type: UUID, references: { model: 'outreach_cadence_enrollments', key: 'id' },
+    });
+  }
+  if (!taskCols.cadenceStepId) {
+    await queryInterface.addColumn('outreach_tasks', 'cadenceStepId', {
+      type: UUID, references: { model: 'outreach_cadence_steps', key: 'id' },
+    });
+  }
+  if (!taskCols.snapshotRecipient) {
+    await queryInterface.addColumn('outreach_tasks', 'snapshotRecipient', { type: Sequelize.STRING(160) });
+  }
+
+  // Indexes — always-run IF NOT EXISTS (runner is non-transactional; 045/047 pattern).
+  const idx = (sql) => queryInterface.sequelize.query(sql);
+  await idx('CREATE UNIQUE INDEX IF NOT EXISTS uq_oc_key_version ON outreach_cadences ("key", "version")');
+  await idx('CREATE UNIQUE INDEX IF NOT EXISTS uq_ocs_cadence_order ON outreach_cadence_steps ("cadenceId", "stepOrder")');
+  await idx(`CREATE UNIQUE INDEX IF NOT EXISTS uq_oct_from_dispo ON outreach_cadence_transitions ("fromStepId", "disposition") WHERE "fromStepId" IS NOT NULL`);
+  await idx(`CREATE UNIQUE INDEX IF NOT EXISTS uq_oct_entry ON outreach_cadence_transitions ("cadenceId", "disposition") WHERE "fromStepId" IS NULL`);
+  await idx(`CREATE UNIQUE INDEX IF NOT EXISTS uq_oce_live_partner ON outreach_cadence_enrollments ("partnerOrganisationId") WHERE "state" IN ('active', 'paused')`);
+  await idx('CREATE INDEX IF NOT EXISTS idx_oce_state_updated ON outreach_cadence_enrollments ("state", "updatedAt")');
+  await idx(`CREATE UNIQUE INDEX IF NOT EXISTS uq_ot_open_per_enrollment ON outreach_tasks ("cadenceEnrollmentId") WHERE "cadenceEnrollmentId" IS NOT NULL AND "status" IN ('open', 'in_progress')`);
+  await idx(`CREATE INDEX IF NOT EXISTS idx_ot_cadence_enrollment ON outreach_tasks ("cadenceEnrollmentId") WHERE "cadenceEnrollmentId" IS NOT NULL`);
+  await idx('CREATE UNIQUE INDEX IF NOT EXISTS uq_osup_channel_value ON outreach_suppressions ("channel", "value")');
+
+  // Structural CHECKs (prod backstops; NODE_ENV=test sync-first skips these —
+  // the service enforces the same invariants and tests cover them).
+  const check = (name, table, expr) => queryInterface.sequelize.query(`
+    DO $$ BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = '${name}') THEN
+        ALTER TABLE ${table} ADD CONSTRAINT ${name} CHECK (${expr});
+      END IF;
+    END $$;`);
+  await check('ck_ocs_step_order_min', 'outreach_cadence_steps', '"stepOrder" >= 1');
+  await check('ck_oct_delay_min', 'outreach_cadence_transitions', '"delayDays" >= 0');
+  await check('ck_ot_cadence_pair', 'outreach_tasks', '("cadenceEnrollmentId" IS NULL) = ("cadenceStepId" IS NULL)');
+}
+
+export async function down(queryInterface) {
+  const q = (sql) => queryInterface.sequelize.query(sql);
+  await q('ALTER TABLE outreach_tasks DROP CONSTRAINT IF EXISTS ck_ot_cadence_pair');
+  await q('ALTER TABLE outreach_tasks DROP COLUMN IF EXISTS "cadenceEnrollmentId"');
+  await q('ALTER TABLE outreach_tasks DROP COLUMN IF EXISTS "cadenceStepId"');
+  await q('ALTER TABLE outreach_tasks DROP COLUMN IF EXISTS "snapshotRecipient"');
+  for (const table of [
+    'outreach_suppressions', 'outreach_cadence_enrollments',
+    'outreach_cadence_transitions', 'outreach_cadence_steps', 'outreach_cadences',
+  ]) {
+    await q(`DROP TABLE IF EXISTS ${table} CASCADE`);
+  }
+}

--- a/backend/src/models/OutreachCadence.js
+++ b/backend/src/models/OutreachCadence.js
@@ -1,0 +1,26 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Cadence definition — one row per immutable VERSION (docs/plans/
+ * redeem-ops-cadences.md §4.1). Editing = insert version n+1, retire n;
+ * live enrollments keep their frozen version. `key` is the stable machine
+ * identity ('fnb_call_first'); `name` is display-only.
+ */
+const OutreachCadence = sequelize.define('OutreachCadence', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  key: { type: DataTypes.STRING(64), allowNull: false },
+  version: { type: DataTypes.INTEGER, allowNull: false },
+  name: { type: DataTypes.STRING(120), allowNull: false },
+  description: { type: DataTypes.TEXT, allowNull: true },
+  targetCategory: { type: DataTypes.STRING(64), allowNull: true },
+  isActive: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+  createdBy: { type: DataTypes.UUID, allowNull: false, references: { model: 'users', key: 'id' } },
+}, {
+  tableName: 'outreach_cadences',
+  indexes: [
+    { fields: ['key', 'version'], unique: true, name: 'uq_oc_key_version' },
+  ],
+});
+
+export default OutreachCadence;

--- a/backend/src/models/OutreachCadenceEnrollment.js
+++ b/backend/src/models/OutreachCadenceEnrollment.js
@@ -1,0 +1,28 @@
+import { DataTypes, Op } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * A partner working through a cadence version (docs/plans/
+ * redeem-ops-cadences.md §4.4). At most ONE live (active|paused) enrollment
+ * per partner — enforced by the partial unique index.
+ */
+const OutreachCadenceEnrollment = sequelize.define('OutreachCadenceEnrollment', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  cadenceId: { type: DataTypes.UUID, allowNull: false, references: { model: 'outreach_cadences', key: 'id' } },
+  partnerOrganisationId: { type: DataTypes.UUID, allowNull: false, references: { model: 'partner_organisations', key: 'id' } },
+  state: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'active', comment: 'active|paused|completed|exited' },
+  currentStepId: { type: DataTypes.UUID, allowNull: true, references: { model: 'outreach_cadence_steps', key: 'id' } },
+  lastDisposition: { type: DataTypes.STRING(24), allowNull: true },
+  exitReason: { type: DataTypes.STRING(32), allowNull: true },
+  enrolledBy: { type: DataTypes.UUID, allowNull: false, references: { model: 'users', key: 'id' } },
+  pausedAt: { type: DataTypes.DATE, allowNull: true },
+  endedAt: { type: DataTypes.DATE, allowNull: true },
+}, {
+  tableName: 'outreach_cadence_enrollments',
+  indexes: [
+    { fields: ['partnerOrganisationId'], unique: true, name: 'uq_oce_live_partner', where: { state: { [Op.in]: ['active', 'paused'] } } },
+    { fields: ['state', 'updatedAt'], name: 'idx_oce_state_updated' },
+  ],
+});
+
+export default OutreachCadenceEnrollment;

--- a/backend/src/models/OutreachCadenceStep.js
+++ b/backend/src/models/OutreachCadenceStep.js
@@ -1,0 +1,21 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/** One touch in a cadence (docs/plans/redeem-ops-cadences.md §4.2). */
+const OutreachCadenceStep = sequelize.define('OutreachCadenceStep', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  cadenceId: { type: DataTypes.UUID, allowNull: false, references: { model: 'outreach_cadences', key: 'id' } },
+  stepOrder: { type: DataTypes.INTEGER, allowNull: false, comment: 'display ordering, 1..n' },
+  channel: { type: DataTypes.STRING(24), allowNull: false, comment: 'call|whatsapp|email|instagram_dm|visit|custom' },
+  mode: { type: DataTypes.STRING(12), allowNull: false, defaultValue: 'manual', comment: "'auto' reserved for P3 email" },
+  title: { type: DataTypes.STRING(160), allowNull: false },
+  scriptTemplate: { type: DataTypes.TEXT, allowNull: true },
+  priority: { type: DataTypes.STRING(12), allowNull: false, defaultValue: 'medium' },
+}, {
+  tableName: 'outreach_cadence_steps',
+  indexes: [
+    { fields: ['cadenceId', 'stepOrder'], unique: true, name: 'uq_ocs_cadence_order' },
+  ],
+});
+
+export default OutreachCadenceStep;

--- a/backend/src/models/OutreachCadenceTransition.js
+++ b/backend/src/models/OutreachCadenceTransition.js
@@ -1,0 +1,27 @@
+import { DataTypes, Op } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Explicit branch edge: (fromStepId, disposition) → toStepId with the delay ON
+ * the edge (docs/plans/redeem-ops-cadences.md §4.3). fromStepId NULL = entry
+ * edge; toStepId NULL = finish. Resolution: exact disposition, else '*', else
+ * finish — branch context travels with the edge, so it is never lost.
+ */
+const OutreachCadenceTransition = sequelize.define('OutreachCadenceTransition', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  cadenceId: { type: DataTypes.UUID, allowNull: false, references: { model: 'outreach_cadences', key: 'id' } },
+  fromStepId: { type: DataTypes.UUID, allowNull: true, references: { model: 'outreach_cadence_steps', key: 'id' } },
+  disposition: { type: DataTypes.STRING(24), allowNull: false, comment: "channel disposition or '*'" },
+  toStepId: { type: DataTypes.UUID, allowNull: true, references: { model: 'outreach_cadence_steps', key: 'id' } },
+  terminalAction: { type: DataTypes.STRING(24), allowNull: true },
+  delayDays: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0, comment: 'days AFTER the from-step completion' },
+  timeWindow: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'any', comment: 'any|morning|afternoon|off_peak (SGT)' },
+}, {
+  tableName: 'outreach_cadence_transitions',
+  indexes: [
+    { fields: ['fromStepId', 'disposition'], unique: true, name: 'uq_oct_from_dispo', where: { fromStepId: { [Op.ne]: null } } },
+    { fields: ['cadenceId', 'disposition'], unique: true, name: 'uq_oct_entry', where: { fromStepId: null } },
+  ],
+});
+
+export default OutreachCadenceTransition;

--- a/backend/src/models/OutreachSuppression.js
+++ b/backend/src/models/OutreachSuppression.js
@@ -1,0 +1,23 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Do-not-contact list for cadence materialization (docs/plans/
+ * redeem-ops-cadences.md §4.6) — applies to MANUAL steps too. A suppressed
+ * recipient blocks the step (skipped via its '*' edge, audited).
+ */
+const OutreachSuppression = sequelize.define('OutreachSuppression', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  channel: { type: DataTypes.STRING(24), allowNull: false, comment: 'call|whatsapp|email|any' },
+  value: { type: DataTypes.STRING(160), allowNull: false, comment: 'normalized phone/email' },
+  reason: { type: DataTypes.STRING(32), allowNull: false, comment: 'opt_out|dnc_listed|bounced|complaint' },
+  source: { type: DataTypes.STRING(32), allowNull: true },
+  expiresAt: { type: DataTypes.DATE, allowNull: true },
+}, {
+  tableName: 'outreach_suppressions',
+  indexes: [
+    { fields: ['channel', 'value'], unique: true, name: 'uq_osup_channel_value' },
+  ],
+});
+
+export default OutreachSuppression;

--- a/backend/src/models/OutreachTask.js
+++ b/backend/src/models/OutreachTask.js
@@ -20,13 +20,20 @@ const OutreachTask = sequelize.define('OutreachTask', {
   status: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'open', comment: 'open|in_progress|completed|cancelled' },
   description: { type: DataTypes.TEXT, allowNull: true },
   completedAt: { type: DataTypes.DATE, allowNull: true },
-  completedBy: { type: DataTypes.UUID, allowNull: true }
+  completedBy: { type: DataTypes.UUID, allowNull: true },
+  // Cadence provenance (docs/plans/redeem-ops-cadences.md §4.5) — both set or
+  // both null; a cadence task is a normal task plus where it came from.
+  cadenceEnrollmentId: { type: DataTypes.UUID, allowNull: true, references: { model: 'outreach_cadence_enrollments', key: 'id' } },
+  cadenceStepId: { type: DataTypes.UUID, allowNull: true, references: { model: 'outreach_cadence_steps', key: 'id' } },
+  snapshotRecipient: { type: DataTypes.STRING(160), allowNull: true, comment: 'resolved phone/email/handle/address at materialization' }
 }, {
   tableName: 'outreach_tasks',
   indexes: [
     { fields: ['assigneeUserId', 'status', 'dueAt'], name: 'idx_ot_assignee_status_due' },
     { fields: ['partnerOrganisationId', 'status'], name: 'idx_ot_partner_status' },
-    { fields: ['dueAt'], name: 'idx_ot_due_open', where: { status: { [Op.in]: ['open', 'in_progress'] } } }
+    { fields: ['dueAt'], name: 'idx_ot_due_open', where: { status: { [Op.in]: ['open', 'in_progress'] } } },
+    // one OPEN task per enrollment — the engine's concurrency backstop
+    { fields: ['cadenceEnrollmentId'], unique: true, name: 'uq_ot_open_per_enrollment', where: { cadenceEnrollmentId: { [Op.ne]: null }, status: { [Op.in]: ['open', 'in_progress'] } } }
   ]
 });
 

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -253,6 +253,26 @@ function defineAssociations() {
   DiscoveryCandidate.belongsTo(PartnerOrganisation, { foreignKey: 'matchedPartnerId', as: 'matchedPartner', onDelete: 'SET NULL' });
   DiscoveryCandidate.belongsTo(PartnerOrganisation, { foreignKey: 'addedPartnerId', as: 'addedPartner', onDelete: 'SET NULL' });
   DiscoveryPlaceMemory.belongsTo(PartnerOrganisation, { foreignKey: 'addedPartnerId', as: 'addedPartner', onDelete: 'SET NULL' });
+
+  // Cadences (migration 057, docs/plans/redeem-ops-cadences.md §4). Definition
+  // rows are never deleted (retired instead), so history references RESTRICT.
+  const {
+    OutreachCadence, OutreachCadenceStep, OutreachCadenceTransition, OutreachCadenceEnrollment,
+  } = models;
+  OutreachCadence.belongsTo(User, { foreignKey: 'createdBy', as: 'creator', onDelete: 'RESTRICT' });
+  OutreachCadence.hasMany(OutreachCadenceStep, { foreignKey: 'cadenceId', as: 'steps', onDelete: 'RESTRICT' });
+  OutreachCadenceStep.belongsTo(OutreachCadence, { foreignKey: 'cadenceId', as: 'cadence' });
+  OutreachCadence.hasMany(OutreachCadenceTransition, { foreignKey: 'cadenceId', as: 'transitions', onDelete: 'RESTRICT' });
+  OutreachCadenceTransition.belongsTo(OutreachCadence, { foreignKey: 'cadenceId', as: 'cadence' });
+  OutreachCadenceTransition.belongsTo(OutreachCadenceStep, { foreignKey: 'fromStepId', as: 'fromStep', onDelete: 'RESTRICT' });
+  OutreachCadenceTransition.belongsTo(OutreachCadenceStep, { foreignKey: 'toStepId', as: 'toStep', onDelete: 'RESTRICT' });
+  OutreachCadenceEnrollment.belongsTo(OutreachCadence, { foreignKey: 'cadenceId', as: 'cadence', onDelete: 'RESTRICT' });
+  OutreachCadenceEnrollment.belongsTo(PartnerOrganisation, { foreignKey: 'partnerOrganisationId', as: 'partner', onDelete: 'CASCADE' });
+  PartnerOrganisation.hasMany(OutreachCadenceEnrollment, { foreignKey: 'partnerOrganisationId', as: 'cadenceEnrollments', onDelete: 'CASCADE' });
+  OutreachCadenceEnrollment.belongsTo(OutreachCadenceStep, { foreignKey: 'currentStepId', as: 'currentStep', onDelete: 'RESTRICT' });
+  OutreachCadenceEnrollment.belongsTo(User, { foreignKey: 'enrolledBy', as: 'enrolledByUser', onDelete: 'RESTRICT' });
+  OutreachTask.belongsTo(OutreachCadenceEnrollment, { foreignKey: 'cadenceEnrollmentId', as: 'cadenceEnrollment' });
+  OutreachTask.belongsTo(OutreachCadenceStep, { foreignKey: 'cadenceStepId', as: 'cadenceStep' });
 }
 
 defineAssociations();
@@ -292,7 +312,8 @@ export const {
   RewardTermsVersion, RewardOfferLocation, RewardInventoryEvent,
   PartnerOnboardingItem, Activation, RewardEntitlement, Redemption,
   RedemptionEvent, RedeemOpsCategory, DiscoveryRun, DiscoveryCandidate,
-  DiscoveryPlaceMemory
+  DiscoveryPlaceMemory, OutreachCadence, OutreachCadenceStep,
+  OutreachCadenceTransition, OutreachCadenceEnrollment, OutreachSuppression
 } = models;
 
 export { sequelize };

--- a/backend/src/routes/redeemOpsCadences.js
+++ b/backend/src/routes/redeemOpsCadences.js
@@ -1,0 +1,38 @@
+import express from 'express';
+import { requireRedeemOps } from '../middleware/redeemOpsAuth.js';
+import * as ctrl from '../controllers/redeemOps/cadenceController.js';
+
+/**
+ * Cadence engine routes (docs/plans/redeem-ops-cadences.md §9). Dark behind
+ * its OWN flag on top of the Redeem Ops module flag — both must be true.
+ */
+export const meta = {
+  path: '/api/redeem-ops',
+  flag: 'REDEEM_OPS_CADENCES_ENABLED',
+  flagDefault: 'false',
+};
+
+const router = express.Router();
+
+// The cadence surface is meaningless without the ops module itself.
+router.use((req, res, next) => {
+  if (String(process.env.REDEEM_OPS_ENABLED || 'false').toLowerCase() !== 'true') {
+    return res.status(404).json({ success: false, message: 'Not found' });
+  }
+  return next();
+});
+
+// Definitions — every ops principal reads them (queue chips resolve names).
+router.get('/cadences', requireRedeemOps(), ctrl.listCadences);
+
+// Partner-scoped enrollment lifecycle (owner/manager checks in the service).
+router.get('/partners/:partnerId/cadence', requireRedeemOps(), ctrl.getPartnerCadence);
+router.post('/partners/:partnerId/cadence/enroll', requireRedeemOps('tasks.manage'), ctrl.enroll);
+router.post('/partners/:partnerId/cadence/pause', requireRedeemOps('tasks.manage'), ctrl.pause);
+router.post('/partners/:partnerId/cadence/resume', requireRedeemOps('tasks.manage'), ctrl.resume);
+router.post('/partners/:partnerId/cadence/stop', requireRedeemOps('tasks.manage'), ctrl.stop);
+
+// The disposition endpoint — the ONLY way to complete a cadence task (§5.2).
+router.post('/cadence-tasks/:taskId/complete', requireRedeemOps('tasks.manage'), ctrl.completeCadenceTask);
+
+export default router;

--- a/backend/src/services/redeemOps/cadenceSeeds.js
+++ b/backend/src/services/redeemOps/cadenceSeeds.js
@@ -1,0 +1,109 @@
+import {
+  OutreachCadence, OutreachCadenceStep, OutreachCadenceTransition, User, sequelize,
+} from '../../models/index.js';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Canonical cadence definitions (docs/plans/redeem-ops-cadences.md §10).
+ * Seeded from bootstrap AFTER initSystemAgent — a migration seed could never
+ * satisfy createdBy on a fresh DB. Idempotent by immutable (key, version);
+ * editing a definition means adding a NEW version here, never mutating one.
+ * There is deliberately no builder UI in P1 — these are the cadences.
+ *
+ * Transitions: `from`/`to` reference stepOrder (resolved to ids at insert);
+ * from=null is the entry edge; missing edges finish the enrollment. delayDays
+ * count from the PREVIOUS step's completion (edge semantics, not absolute days).
+ */
+const SEEDS = [
+  {
+    key: 'fnb_call_first',
+    version: 1,
+    name: 'F&B acquisition — call-first',
+    description: 'Default acquisition chase for F&B and retail merchants: calls carry the sequence, WhatsApp/IG fill the gaps, a walk-in closes it out.',
+    steps: [
+      { o: 1, channel: 'call', title: 'Intro call', priority: 'high', script: 'Hi {{contact_name}}, calling from Redeem about {{partner_name}} — we send nearby customers to partner outlets through voucher campaigns. 30 seconds to explain?' },
+      { o: 2, channel: 'whatsapp', title: 'WhatsApp intro (after no answer)', priority: 'medium', script: 'Hi {{contact_name}}! Tried calling about {{partner_name}} — we run Redeem (redeem.sg), sending verified customers to partner outlets. Free to list, you only honour redemptions. Keen to hear more?' },
+      { o: 3, channel: 'call', title: 'Call #2 (off-peak)', priority: 'medium', script: 'Second attempt — reference the WhatsApp intro if it was sent.' },
+      { o: 4, channel: 'instagram_dm', title: 'Instagram DM', priority: 'low', script: 'Hi! Love what {{partner_name}} is doing. We feature partner outlets on redeem.sg voucher drops — no upfront cost. Who handles partnerships?' },
+      { o: 5, channel: 'call', title: 'Call #3 (final phone attempt)', priority: 'medium', script: 'Final call attempt — if no answer, the walk-in is next.' },
+      { o: 6, channel: 'visit', title: 'Walk-in visit', priority: 'high', script: 'Drop by, ask for the owner/manager. Bring the partner one-pager.' },
+      { o: 7, channel: 'whatsapp', title: 'Break-up message', priority: 'low', script: 'Hi {{contact_name}}, last note from me — if partnering with Redeem ever makes sense for {{partner_name}}, my line is open. All the best!' },
+    ],
+    transitions: [
+      { from: null, disposition: '*', to: 1, delayDays: 0, timeWindow: 'any' },
+      { from: 1, disposition: 'no_answer', to: 2, delayDays: 0, timeWindow: 'any' },
+      // single-outcome steps use '*' so a BLOCKED step (no IG handle, no phone
+      // on record) skips forward instead of finishing the whole cadence
+      { from: 2, disposition: '*', to: 3, delayDays: 2, timeWindow: 'off_peak' },
+      { from: 3, disposition: 'no_answer', to: 4, delayDays: 2, timeWindow: 'any' },
+      { from: 4, disposition: '*', to: 5, delayDays: 3, timeWindow: 'off_peak' },
+      { from: 5, disposition: 'no_answer', to: 6, delayDays: 3, timeWindow: 'any' },
+      { from: 6, disposition: 'closed', to: 7, delayDays: 4, timeWindow: 'any' },
+      // everything else (connected without a follow-on, sent break-up, met…) → finish
+    ],
+  },
+  {
+    key: 'revival_60d',
+    version: 1,
+    name: 'Revival — 60 days later',
+    description: 'Light-touch re-engagement for businesses that went quiet or were lost to no-response.',
+    steps: [
+      { o: 1, channel: 'whatsapp', title: 'Check-in message', priority: 'medium', script: 'Hi {{contact_name}}, checking back in — Redeem has grown since we last spoke. Worth a fresh look for {{partner_name}}?' },
+      { o: 2, channel: 'call', title: 'Revival call', priority: 'medium', script: 'Follow the check-in message; lead with what changed (new campaigns, redemption volume).' },
+      { o: 3, channel: 'email', title: 'Recap email', priority: 'low', script: 'Hi {{contact_name}},\n\nSharing a quick recap of the Redeem partner programme for {{partner_name}} — happy to answer anything.\n\nBest,' },
+    ],
+    transitions: [
+      { from: null, disposition: '*', to: 1, delayDays: 0, timeWindow: 'any' },
+      { from: 1, disposition: '*', to: 2, delayDays: 5, timeWindow: 'off_peak' },
+      { from: 2, disposition: 'no_answer', to: 3, delayDays: 7, timeWindow: 'any' },
+    ],
+  },
+];
+
+/** Idempotent bootstrap seeding, advisory-lock guarded (single-flight). */
+export async function ensureCadences() {
+  const creator = await User.findOne({
+    where: { email: process.env.SYSTEM_AGENT_EMAIL || 'system@mktr.local' },
+  });
+  if (!creator) {
+    logger.warn('[RedeemOps] cadence seeds skipped — system agent not found');
+    return { seeded: 0 };
+  }
+
+  let seeded = 0;
+  await sequelize.transaction(async (t) => {
+    await sequelize.query('SELECT pg_advisory_xact_lock(9157002)', { transaction: t });
+    for (const seed of SEEDS) {
+      const existing = await OutreachCadence.findOne({
+        where: { key: seed.key, version: seed.version }, transaction: t,
+      });
+      if (existing) continue;
+
+      const cadence = await OutreachCadence.create({
+        key: seed.key, version: seed.version, name: seed.name,
+        description: seed.description, createdBy: creator.id,
+      }, { transaction: t });
+
+      const idByOrder = {};
+      for (const s of seed.steps) {
+        const step = await OutreachCadenceStep.create({
+          cadenceId: cadence.id, stepOrder: s.o, channel: s.channel,
+          title: s.title, scriptTemplate: s.script || null, priority: s.priority || 'medium',
+        }, { transaction: t });
+        idByOrder[s.o] = step.id;
+      }
+      for (const tr of seed.transitions) {
+        await OutreachCadenceTransition.create({
+          cadenceId: cadence.id,
+          fromStepId: tr.from === null ? null : idByOrder[tr.from],
+          disposition: tr.disposition,
+          toStepId: tr.to === null ? null : idByOrder[tr.to],
+          delayDays: tr.delayDays, timeWindow: tr.timeWindow,
+        }, { transaction: t });
+      }
+      seeded += 1;
+      logger.info('redeem_ops.cadence.seeded', { key: seed.key, version: seed.version });
+    }
+  });
+  return { seeded };
+}

--- a/backend/src/services/redeemOps/cadenceService.js
+++ b/backend/src/services/redeemOps/cadenceService.js
@@ -1,0 +1,711 @@
+import { Op, QueryTypes } from 'sequelize';
+import {
+  OutreachCadence, OutreachCadenceStep, OutreachCadenceTransition, OutreachCadenceEnrollment,
+  OutreachSuppression, OutreachTask, PartnerOrganisation, PartnerContact, PartnerLocation,
+  User, sequelize,
+} from '../../models/index.js';
+import { AppError } from '../../middleware/errorHandler.js';
+import { logger } from '../../utils/logger.js';
+import { makeRedeemOpsAuditService } from './auditService.js';
+import { makeTaskService } from './taskService.js';
+import { makePartnerService } from './partnerService.js';
+import { normalizePhone } from '../prospectHelpers.js';
+import {
+  CHANNEL_DISPOSITIONS, CADENCE_TERMINAL_DISPOSITIONS, CADENCE_WILDCARD_DISPOSITION,
+  LOST_REASONS,
+} from './constants.js';
+
+/**
+ * Cadence engine (docs/plans/redeem-ops-cadences.md §5) — the generator the
+ * outreach layer was missing: reps decide what to say, the engine decides when
+ * and what's next. Advance is SYNCHRONOUS inside completeCadenceTask's
+ * transaction (lock order enrollment → partner → task); the reconcile tick only
+ * repairs faults. Exits ride the P0 hook registry, registered from bootstrap.
+ */
+
+const WINDOW_START_SGT = { any: 10, morning: 9.5, afternoon: 15, off_peak: 15 };
+const SGT_OFFSET_MS = 8 * 60 * 60 * 1000;
+const RECONCILE_LOCK_KEY = 9157001;
+
+/**
+ * Schedule a step: `anchor + delayDays` on the SGT calendar, clamped into the
+ * window's start hour. Never due-in-the-past: a delay-0 step whose window
+ * already passed is due NOW (same-day branches like "WhatsApp after a 6pm
+ * no-answer call" must not slip to tomorrow); a delayed step rolls forward a
+ * day. No weekend skip — F&B merchants trade weekends.
+ */
+export function sgtWindowClamp(anchor, delayDays, timeWindow, now = new Date()) {
+  const startHour = WINDOW_START_SGT[timeWindow] ?? WINDOW_START_SGT.any;
+  const hours = Math.floor(startHour);
+  const minutes = Math.round((startHour - hours) * 60);
+
+  const atWindow = (base, plusDays) => {
+    const sgt = new Date(base.getTime() + SGT_OFFSET_MS);
+    return new Date(
+      Date.UTC(sgt.getUTCFullYear(), sgt.getUTCMonth(), sgt.getUTCDate() + plusDays, hours, minutes) - SGT_OFFSET_MS
+    );
+  };
+
+  let due = atWindow(anchor, delayDays);
+  if (due.getTime() > now.getTime()) return due;
+  if (delayDays === 0) return new Date(now);
+  // A rolled-forward day can still be in the past if the anchor is old
+  // (reconciler repairs, resumes) — walk forward until it isn't.
+  due = atWindow(anchor, delayDays + 1);
+  let guard = 0;
+  while (due.getTime() <= now.getTime() && guard < 366) {
+    due = atWindow(due, 1);
+    guard += 1;
+  }
+  return due;
+}
+
+const DISPOSITION_LABELS = {
+  connected: 'connected', no_answer: 'no answer', sent: 'sent', replied: 'replied',
+  not_interested: 'not interested', met: 'met in person', closed: 'outlet closed', done: 'done',
+};
+
+/** Honest activity for each (channel, disposition) — §5.2.5. */
+export function activityForDisposition(channel, disposition) {
+  if (disposition === 'replied') {
+    const type = { whatsapp: 'whatsapp_reply', email: 'email_reply', call: 'call_connected', instagram_dm: 'instagram_dm' }[channel] || 'follow_up';
+    return { type, direction: 'inbound' };
+  }
+  if (disposition === 'not_interested') {
+    const map = {
+      call: { type: 'call_connected', direction: 'outbound' },
+      whatsapp: { type: 'whatsapp_reply', direction: 'inbound' },
+      email: { type: 'email_reply', direction: 'inbound' },
+      instagram_dm: { type: 'instagram_dm', direction: 'inbound' },
+      visit: { type: 'visit', direction: 'outbound' },
+    };
+    return map[channel] || { type: 'follow_up', direction: 'outbound' };
+  }
+  switch (channel) {
+    case 'call': return { type: disposition === 'connected' ? 'call_connected' : 'call_attempt', direction: 'outbound' };
+    case 'whatsapp': return { type: 'whatsapp_sent', direction: 'outbound' };
+    case 'email': return { type: 'email_sent', direction: 'outbound' };
+    case 'instagram_dm': return { type: 'instagram_dm', direction: 'outbound' };
+    case 'visit': return { type: 'visit', direction: 'outbound' };
+    default: return { type: 'follow_up', direction: 'outbound' };
+  }
+}
+
+const CHANNEL_TASK_TYPE = {
+  call: 'call', whatsapp: 'follow_up', email: 'follow_up',
+  instagram_dm: 'follow_up', visit: 'other', custom: 'other',
+};
+
+export function makeCadenceService(overrides = {}) {
+  const d = {
+    OutreachCadence, OutreachCadenceStep, OutreachCadenceTransition, OutreachCadenceEnrollment,
+    OutreachSuppression, OutreachTask, PartnerOrganisation, PartnerContact, PartnerLocation,
+    User, sequelize, logger,
+    audit: makeRedeemOpsAuditService(),
+    tasks: makeTaskService(),
+    partners: makePartnerService(),
+    enrollmentCap: parseInt(process.env.REDEEM_OPS_CADENCE_CAP, 10) || 60,
+    now: () => new Date(),
+    ...overrides,
+  };
+
+  const isManager = (user) =>
+    user.role === 'admin' || ['super_admin', 'ops_admin', 'bdm'].includes(user.redeemOpsRole);
+
+  const canActOnPartner = (user, partner) => isManager(user) || partner.ownerUserId === user.id;
+
+  // ── Definition lookup ──────────────────────────────────────────────────────
+
+  async function listCadences() {
+    return d.OutreachCadence.findAll({
+      where: { isActive: true },
+      include: [
+        { model: d.OutreachCadenceStep, as: 'steps' },
+        { model: d.OutreachCadenceTransition, as: 'transitions' },
+      ],
+      order: [['key', 'ASC'], ['version', 'DESC'], [{ model: d.OutreachCadenceStep, as: 'steps' }, 'stepOrder', 'ASC']],
+    });
+  }
+
+  async function resolveCadenceTx({ cadenceId, cadenceKey }, t) {
+    if (cadenceId) {
+      const cadence = await d.OutreachCadence.findByPk(cadenceId, { transaction: t });
+      if (!cadence || !cadence.isActive) throw new AppError('Cadence not found or retired', 404);
+      return cadence;
+    }
+    if (cadenceKey) {
+      const cadence = await d.OutreachCadence.findOne({
+        where: { key: cadenceKey, isActive: true },
+        order: [['version', 'DESC']],
+        transaction: t,
+      });
+      if (!cadence) throw new AppError('Cadence not found or retired', 404);
+      return cadence;
+    }
+    throw new AppError('cadenceId or cadenceKey is required', 400);
+  }
+
+  async function resolveTransitionTx(cadenceId, fromStepId, disposition, t) {
+    const base = { cadenceId, fromStepId: fromStepId ?? null };
+    const exact = await d.OutreachCadenceTransition.findOne({ where: { ...base, disposition }, transaction: t });
+    if (exact) return exact;
+    if (disposition === CADENCE_WILDCARD_DISPOSITION) return null;
+    return d.OutreachCadenceTransition.findOne({
+      where: { ...base, disposition: CADENCE_WILDCARD_DISPOSITION }, transaction: t,
+    });
+  }
+
+  // ── Materialization (§5.3) ────────────────────────────────────────────────
+
+  async function resolveRecipientTx(partner, channel, t) {
+    if (channel === 'custom') return { recipient: null, ok: true };
+    const contacts = await d.PartnerContact.findAll({
+      where: { partnerOrganisationId: partner.id, archivedAt: null },
+      order: [['isPrimary', 'DESC'], ['createdAt', 'ASC']],
+      transaction: t,
+    });
+    const primary = contacts[0] || null;
+    if (channel === 'call' || channel === 'whatsapp') {
+      const phone = primary?.whatsapp || primary?.mobile
+        || contacts.find((c) => c.mobile || c.whatsapp)?.mobile
+        || partner.primaryPhone;
+      return phone ? { recipient: String(phone), ok: true, contactId: primary?.id || null } : { ok: false, reason: 'no_phone' };
+    }
+    if (channel === 'email') {
+      const email = primary?.email || contacts.find((c) => c.email)?.email || partner.primaryEmail;
+      return email ? { recipient: String(email).toLowerCase(), ok: true, contactId: primary?.id || null } : { ok: false, reason: 'no_email' };
+    }
+    if (channel === 'instagram_dm') {
+      return partner.instagramHandle
+        ? { recipient: `@${String(partner.instagramHandle).replace(/^@/, '')}`, ok: true }
+        : { ok: false, reason: 'no_instagram_handle' };
+    }
+    if (channel === 'visit') {
+      const location = await d.PartnerLocation.findOne({
+        where: { partnerOrganisationId: partner.id, isActive: true },
+        order: [['createdAt', 'ASC']],
+        transaction: t,
+      });
+      return location
+        ? { recipient: [location.name, location.addressLine].filter(Boolean).join(', ').slice(0, 160) || 'registered outlet', ok: true }
+        : { ok: false, reason: 'no_active_location' };
+    }
+    return { ok: false, reason: 'unknown_channel' };
+  }
+
+  async function isSuppressedTx(channel, recipient, t) {
+    if (!recipient || !['call', 'whatsapp', 'email'].includes(channel)) return false;
+    const value = channel === 'email' ? recipient.toLowerCase() : (normalizePhone(recipient) || recipient);
+    const hit = await d.OutreachSuppression.findOne({
+      where: {
+        channel: { [Op.in]: [channel, 'any'] },
+        value,
+        [Op.or]: [{ expiresAt: null }, { expiresAt: { [Op.gt]: d.now() } }],
+      },
+      transaction: t,
+    });
+    return !!hit;
+  }
+
+  /** Allowlisted plain-text merge — an unresolved token blocks the step. */
+  function renderTemplate(template, ctx) {
+    if (!template) return { text: null, ok: true };
+    const text = template.replace(/{{\s*([a-z_]+)\s*}}/gi, (m, key) => {
+      const k = key.toLowerCase();
+      return Object.prototype.hasOwnProperty.call(ctx, k) ? String(ctx[k] ?? '') : m;
+    });
+    return /{{[^}]+}}/.test(text) ? { ok: false } : { text, ok: true };
+  }
+
+  async function tryMaterializeTx(enrollment, partner, step, timing, actorUser, t) {
+    if (!partner.ownerUserId) return { blocked: true, reason: 'partner_unowned' };
+    const resolved = await resolveRecipientTx(partner, step.channel, t);
+    if (!resolved.ok) return { blocked: true, reason: resolved.reason };
+    if (await isSuppressedTx(step.channel, resolved.recipient, t)) {
+      return { blocked: true, reason: 'suppressed' };
+    }
+
+    const primaryContact = resolved.contactId
+      ? await d.PartnerContact.findByPk(resolved.contactId, { attributes: ['id', 'name'], transaction: t })
+      : null;
+    const rendered = renderTemplate(step.scriptTemplate, {
+      partner_name: partner.tradingName || partner.brandName || partner.legalName || 'there',
+      contact_name: primaryContact?.name || 'there',
+      category: partner.category || '',
+      recipient: resolved.recipient || '',
+    });
+    if (!rendered.ok) return { blocked: true, reason: 'unresolved_template' };
+
+    const dueAt = sgtWindowClamp(d.now(), timing.delayDays, timing.timeWindow, d.now());
+    // System contexts (sweep resume, reconciler) have no acting user — the
+    // partner owner stands in: they're the assignee anyway, so the row rules
+    // in createTaskTx pass without a manager check.
+    const actor = actorUser || { id: partner.ownerUserId };
+    const task = await d.tasks.createTaskTx({
+      title: step.title,
+      partnerOrganisationId: partner.id,
+      contactId: resolved.contactId || null,
+      assigneeUserId: partner.ownerUserId,
+      dueAt,
+      priority: step.priority || 'medium',
+      type: CHANNEL_TASK_TYPE[step.channel] || 'other',
+      description: rendered.text || null,
+    }, actor, t);
+    // Provenance rides a second write so taskService stays cadence-agnostic;
+    // the partial unique index (one open task per enrollment) bites HERE.
+    await task.update({
+      cadenceEnrollmentId: enrollment.id,
+      cadenceStepId: step.id,
+      snapshotRecipient: resolved.recipient || null,
+    }, { transaction: t });
+    return { task };
+  }
+
+  /**
+   * Land the enrollment on `step` (materialize its task), chaining through
+   * blocked steps via their '*' edges; finishes the enrollment if the chain
+   * runs out (§5.3).
+   */
+  async function placeAtStepTx(enrollment, partner, step, timing, actorUser, t) {
+    let cur = step;
+    let curTiming = timing;
+    let guard = 0;
+    while (cur) {
+      const mat = await tryMaterializeTx(enrollment, partner, cur, curTiming, actorUser, t);
+      if (!mat.blocked) {
+        await enrollment.update({ currentStepId: cur.id }, { transaction: t });
+        return { task: mat.task, step: cur };
+      }
+      await d.audit.recordAuditEvent({
+        actorUser, actorType: actorUser ? 'staff' : 'system', action: 'cadence.step_blocked',
+        entityType: 'outreach_cadence_enrollment', entityId: enrollment.id,
+        after: { stepId: cur.id, stepTitle: cur.title, reason: mat.reason }, transaction: t,
+      });
+      if (mat.reason === 'partner_unowned') {
+        await endEnrollmentTx(enrollment, { state: 'exited', exitReason: 'released' }, actorUser, t);
+        return { finished: true, reason: mat.reason };
+      }
+      const edge = await resolveTransitionTx(enrollment.cadenceId, cur.id, CADENCE_WILDCARD_DISPOSITION, t);
+      if (!edge || !edge.toStepId) {
+        await endEnrollmentTx(enrollment, { state: 'completed', exitReason: 'finished' }, actorUser, t);
+        return { finished: true, reason: mat.reason };
+      }
+      cur = await d.OutreachCadenceStep.findByPk(edge.toStepId, { transaction: t });
+      curTiming = { delayDays: edge.delayDays, timeWindow: edge.timeWindow };
+      guard += 1;
+      if (guard > 30) throw new AppError('Cadence step chain exceeded limit', 500);
+    }
+    return { finished: true };
+  }
+
+  // ── Enrollment lifecycle ──────────────────────────────────────────────────
+
+  async function endEnrollmentTx(enrollment, { state, exitReason }, actorUser, t) {
+    await d.OutreachTask.update(
+      { status: 'cancelled' },
+      {
+        where: { cadenceEnrollmentId: enrollment.id, status: { [Op.in]: ['open', 'in_progress'] } },
+        transaction: t,
+      }
+    );
+    await enrollment.update({ state, exitReason, endedAt: d.now() }, { transaction: t });
+    await d.tasks.recomputeNextTaskAt(enrollment.partnerOrganisationId, t);
+    await d.audit.recordAuditEvent({
+      actorUser, actorType: actorUser ? 'staff' : 'system', action: 'cadence.ended',
+      entityType: 'outreach_cadence_enrollment', entityId: enrollment.id,
+      after: { state, exitReason }, transaction: t,
+    });
+    return enrollment;
+  }
+
+  async function liveEnrollmentForPartnerTx(partnerId, t, { states = ['active', 'paused'] } = {}) {
+    return d.OutreachCadenceEnrollment.findOne({
+      where: { partnerOrganisationId: partnerId, state: { [Op.in]: states } },
+      transaction: t,
+      lock: t.LOCK.UPDATE,
+    });
+  }
+
+  async function enrollPartner(partnerId, { cadenceId, cadenceKey, overrideCapacity = false }, user, requestId = null) {
+    return d.sequelize.transaction(async (t) => {
+      const partner = await d.PartnerOrganisation.findByPk(partnerId, { transaction: t, lock: t.LOCK.UPDATE });
+      if (!partner || partner.mergedIntoId || partner.archivedAt) throw new AppError('Partner not found', 404);
+      if (!partner.ownerUserId) throw new AppError('Claim the business first — cadence tasks need an owner to be assigned to', 409);
+      if (!canActOnPartner(user, partner)) throw new AppError('You can only enroll businesses you own', 403);
+      if (['PARTNERED', 'LOST'].includes(partner.pipelineStage)) {
+        throw new AppError(`A ${partner.pipelineStage === 'LOST' ? 'Lost' : 'Partnered'} business cannot be enrolled — revive it first`, 409);
+      }
+
+      const cadence = await resolveCadenceTx({ cadenceId, cadenceKey }, t);
+
+      const existing = await liveEnrollmentForPartnerTx(partnerId, t);
+      if (existing) throw new AppError('This business is already in a cadence', 409);
+
+      // Per-owner capacity — serialized via an advisory xact lock so two
+      // concurrent enrollments cannot both squeeze under the cap (§5.1).
+      await d.sequelize.query('SELECT pg_advisory_xact_lock(hashtext(:k))', {
+        replacements: { k: `cadence-cap:${partner.ownerUserId}` }, transaction: t,
+      });
+      const liveCount = await d.OutreachCadenceEnrollment.count({
+        where: { state: { [Op.in]: ['active', 'paused'] } },
+        include: [{
+          model: d.PartnerOrganisation, as: 'partner', attributes: [],
+          where: { ownerUserId: partner.ownerUserId },
+        }],
+        transaction: t,
+      });
+      if (liveCount >= d.enrollmentCap && !(overrideCapacity && isManager(user))) {
+        throw new AppError(
+          `Cap reached: ${liveCount} businesses already in cadences for this owner (max ${d.enrollmentCap}). Finish or stop some first.`,
+          409
+        );
+      }
+
+      const enrollment = await d.OutreachCadenceEnrollment.create({
+        cadenceId: cadence.id, partnerOrganisationId: partnerId, enrolledBy: user.id,
+      }, { transaction: t });
+
+      const entry = await resolveTransitionTx(cadence.id, null, CADENCE_WILDCARD_DISPOSITION, t);
+      if (!entry || !entry.toStepId) throw new AppError('Cadence has no entry step — definition is broken', 500);
+      const firstStep = await d.OutreachCadenceStep.findByPk(entry.toStepId, { transaction: t });
+      const placed = await placeAtStepTx(
+        enrollment, partner, firstStep,
+        { delayDays: entry.delayDays, timeWindow: entry.timeWindow }, user, t
+      );
+
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'cadence.enrolled', entityType: 'outreach_cadence_enrollment',
+        entityId: enrollment.id,
+        after: { cadenceKey: cadence.key, version: cadence.version, partnerId, capacityOverride: !!overrideCapacity },
+        requestId, transaction: t,
+      });
+      return { enrollment, cadence, firstTask: placed.task || null, finishedImmediately: !!placed.finished };
+    });
+  }
+
+  // ── Completion — the linearizable core (§5.2) ─────────────────────────────
+
+  async function completeCadenceTask(taskId, { disposition, alsoMarkLost = false, lostReason = null }, user, requestId = null) {
+    return d.sequelize.transaction(async (t) => {
+      // Non-locking probe for ids only. GLOBAL lock order is partner →
+      // enrollment → task: the P0 hooks fire inside transactions that already
+      // hold the partner lock, so every other path must take it first too.
+      const probe = await d.OutreachTask.findByPk(taskId, {
+        attributes: ['id', 'cadenceEnrollmentId', 'partnerOrganisationId'], transaction: t,
+      });
+      if (!probe) throw new AppError('Task not found', 404);
+      if (!probe.cadenceEnrollmentId) {
+        throw new AppError('Not a cadence task — complete it through the normal task update', 400);
+      }
+
+      const partner = await d.PartnerOrganisation.findByPk(probe.partnerOrganisationId, {
+        transaction: t, lock: t.LOCK.UPDATE,
+      });
+      if (!partner || partner.mergedIntoId) throw new AppError('Partner not found', 404);
+
+      const enrollment = await d.OutreachCadenceEnrollment.findByPk(probe.cadenceEnrollmentId, {
+        transaction: t, lock: t.LOCK.UPDATE,
+      });
+      if (!enrollment) throw new AppError('Enrollment not found', 404);
+      if (enrollment.state !== 'active') {
+        throw new AppError(`This cadence is ${enrollment.state} — the task is no longer actionable`, 409);
+      }
+
+      const task = await d.OutreachTask.findByPk(taskId, { transaction: t, lock: t.LOCK.UPDATE });
+      if (!['open', 'in_progress'].includes(task.status)) {
+        throw new AppError('This task was already completed or cancelled', 409);
+      }
+      if (enrollment.currentStepId !== task.cadenceStepId) {
+        throw new AppError('This task is no longer the cadence’s current step — refresh', 409);
+      }
+      if (!isManager(user) && task.assigneeUserId !== user.id) {
+        throw new AppError('You can only complete your own tasks', 403);
+      }
+
+      const step = await d.OutreachCadenceStep.findByPk(task.cadenceStepId, { transaction: t });
+      const valid = CHANNEL_DISPOSITIONS[step.channel] || [];
+      if (!valid.includes(disposition)) {
+        throw new AppError(`'${disposition}' is not a valid outcome for a ${step.channel} step`, 400);
+      }
+      if (alsoMarkLost && !LOST_REASONS.includes(lostReason || 'not_interested')) {
+        throw new AppError('Unknown lost reason', 400);
+      }
+
+      // 1. Complete the task (direct — the generic PATCH path refuses cadence tasks).
+      await task.update({ status: 'completed', completedAt: d.now(), completedBy: user.id }, { transaction: t });
+
+      // 2. Log the honest activity. Suppressed hooks: the engine handles its own
+      //    exits below — this activity must not re-enter it.
+      const mapped = activityForDisposition(step.channel, disposition);
+      await d.partners.logActivityTx(partner.id, {
+        type: mapped.type,
+        direction: mapped.direction,
+        summary: `${step.title} — ${DISPOSITION_LABELS[disposition] || disposition}`,
+        contactId: task.contactId || null,
+      }, user, t, { suppressCadenceHooks: true, requestId });
+
+      await enrollment.update({ lastDisposition: disposition }, { transaction: t });
+
+      // 3. Terminal dispositions end the enrollment; the stage move (if asked
+      //    for) happens in the SAME transaction so no contradictory half-state
+      //    can survive a crash (§5.2.6).
+      let nextTask = null;
+      if (CADENCE_TERMINAL_DISPOSITIONS.includes(disposition)) {
+        const exitReason = disposition === 'replied' ? 'replied' : 'not_interested';
+        await endEnrollmentTx(enrollment, { state: 'exited', exitReason }, user, t);
+        if (disposition === 'not_interested' && alsoMarkLost) {
+          await d.partners.changeStageTx(partner.id, 'LOST', user, t, {
+            lostReason: lostReason || 'not_interested', requestId,
+          });
+        }
+      } else {
+        const edge = await resolveTransitionTx(enrollment.cadenceId, step.id, disposition, t);
+        if (!edge || !edge.toStepId) {
+          await endEnrollmentTx(enrollment, { state: 'completed', exitReason: 'finished' }, user, t);
+        } else {
+          const nextStep = await d.OutreachCadenceStep.findByPk(edge.toStepId, { transaction: t });
+          const placed = await placeAtStepTx(
+            enrollment, partner, nextStep,
+            { delayDays: edge.delayDays, timeWindow: edge.timeWindow }, user, t
+          );
+          nextTask = placed.task || null;
+        }
+      }
+
+      await d.tasks.recomputeNextTaskAt(partner.id, t);
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'cadence.task_completed', entityType: 'outreach_task',
+        entityId: taskId, after: { disposition, enrollmentState: enrollment.state }, requestId, transaction: t,
+      });
+
+      return { task, enrollment, nextTask };
+    });
+  }
+
+  // ── Manual pause / resume / stop (partner-scoped; pause ≠ snooze §5.4) ───
+
+  async function withOwnedLiveEnrollment(partnerId, user, states, fn) {
+    return d.sequelize.transaction(async (t) => {
+      // partner → enrollment (global lock order)
+      const partner = await d.PartnerOrganisation.findByPk(partnerId, { transaction: t, lock: t.LOCK.UPDATE });
+      if (!partner || partner.mergedIntoId) throw new AppError('Partner not found', 404);
+      if (!canActOnPartner(user, partner)) throw new AppError('You can only manage cadences on businesses you own', 403);
+      const enrollment = await liveEnrollmentForPartnerTx(partnerId, t, { states });
+      if (!enrollment) throw new AppError('No live cadence on this business', 404);
+      return fn(enrollment, partner, t);
+    });
+  }
+
+  async function pauseEnrollment(partnerId, user, requestId = null) {
+    return withOwnedLiveEnrollment(partnerId, user, ['active'], async (enrollment, partner, t) => {
+      await d.OutreachTask.update(
+        { status: 'cancelled' },
+        { where: { cadenceEnrollmentId: enrollment.id, status: { [Op.in]: ['open', 'in_progress'] } }, transaction: t }
+      );
+      await enrollment.update({ state: 'paused', pausedAt: d.now() }, { transaction: t });
+      await d.tasks.recomputeNextTaskAt(partnerId, t);
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'cadence.paused', entityType: 'outreach_cadence_enrollment',
+        entityId: enrollment.id, requestId, transaction: t,
+      });
+      return enrollment;
+    });
+  }
+
+  async function resumeEnrollmentTx(enrollment, partner, actorUser, t) {
+    await enrollment.update({ state: 'active', pausedAt: null }, { transaction: t });
+    const step = await d.OutreachCadenceStep.findByPk(enrollment.currentStepId, { transaction: t });
+    if (!step) {
+      return endEnrollmentTx(enrollment, { state: 'completed', exitReason: 'finished' }, actorUser, t);
+    }
+    await placeAtStepTx(enrollment, partner, step, { delayDays: 0, timeWindow: 'any' }, actorUser, t);
+    await d.audit.recordAuditEvent({
+      actorUser, actorType: actorUser ? 'staff' : 'system', action: 'cadence.resumed',
+      entityType: 'outreach_cadence_enrollment', entityId: enrollment.id, transaction: t,
+    });
+    return enrollment;
+  }
+
+  async function resumeEnrollment(partnerId, user, requestId = null) {
+    return withOwnedLiveEnrollment(partnerId, user, ['paused'], (enrollment, partner, t) =>
+      resumeEnrollmentTx(enrollment, partner, user, t));
+  }
+
+  async function stopEnrollment(partnerId, user, requestId = null) {
+    return withOwnedLiveEnrollment(partnerId, user, ['active', 'paused'], (enrollment, partner, t) =>
+      endEnrollmentTx(enrollment, { state: 'exited', exitReason: 'manual_stop' }, user, t));
+  }
+
+  // ── Read model for the UI card ────────────────────────────────────────────
+
+  async function getPartnerCadence(partnerId) {
+    const live = await d.OutreachCadenceEnrollment.findOne({
+      where: { partnerOrganisationId: partnerId, state: { [Op.in]: ['active', 'paused'] } },
+      include: [
+        { model: d.OutreachCadence, as: 'cadence', include: [{ model: d.OutreachCadenceStep, as: 'steps' }] },
+        { model: d.OutreachCadenceStep, as: 'currentStep' },
+      ],
+    });
+    const enrollment = live || await d.OutreachCadenceEnrollment.findOne({
+      where: { partnerOrganisationId: partnerId },
+      include: [
+        { model: d.OutreachCadence, as: 'cadence', include: [{ model: d.OutreachCadenceStep, as: 'steps' }] },
+        { model: d.OutreachCadenceStep, as: 'currentStep' },
+      ],
+      order: [['createdAt', 'DESC']],
+    });
+    if (!enrollment) return { enrollment: null, openTask: null };
+    const openTask = await d.OutreachTask.findOne({
+      where: { cadenceEnrollmentId: enrollment.id, status: { [Op.in]: ['open', 'in_progress'] } },
+    });
+    const json = enrollment.toJSON();
+    if (json.cadence?.steps) json.cadence.steps.sort((a, b) => a.stepOrder - b.stepOrder);
+    return { enrollment: json, openTask };
+  }
+
+  // ── Hook handlers (registered from bootstrap — §5.4) ─────────────────────
+
+  async function exitLiveForPartnerTx(partnerId, exitReason, actorUser, t) {
+    const enrollment = await liveEnrollmentForPartnerTx(partnerId, t);
+    if (!enrollment) return null;
+    return endEnrollmentTx(enrollment, { state: 'exited', exitReason }, actorUser, t);
+  }
+
+  function hookHandlers() {
+    return {
+      onInboundActivity: ({ partner, user, transaction }) =>
+        exitLiveForPartnerTx(partner.id, 'replied', user, transaction),
+      onStageChange: async ({ partner, toStage, user, transaction }) => {
+        if (['MEETING', 'PROPOSAL', 'PARTNERED'].includes(toStage)) {
+          await exitLiveForPartnerTx(partner.id, 'stage_advanced', user, transaction);
+        } else if (toStage === 'LOST') {
+          await exitLiveForPartnerTx(partner.id, 'lost', user, transaction);
+        }
+      },
+      onSnooze: async ({ partner, user, transaction: t }) => {
+        const enrollment = await liveEnrollmentForPartnerTx(partner.id, t, { states: ['active'] });
+        if (!enrollment) return;
+        await d.OutreachTask.update(
+          { status: 'cancelled' },
+          { where: { cadenceEnrollmentId: enrollment.id, status: { [Op.in]: ['open', 'in_progress'] } }, transaction: t }
+        );
+        await enrollment.update({ state: 'paused', pausedAt: d.now() }, { transaction: t });
+        await d.tasks.recomputeNextTaskAt(partner.id, t);
+      },
+      onUnsnooze: async ({ partner, partnerId, user, transaction }) => {
+        const pid = partner?.id || partnerId;
+        const run = async (t) => {
+          const enrollment = await liveEnrollmentForPartnerTx(pid, t, { states: ['paused'] });
+          if (!enrollment) return;
+          const p = await d.PartnerOrganisation.findByPk(pid, { transaction: t, lock: t.LOCK.UPDATE });
+          if (!p || p.mergedIntoId || p.archivedAt) return;
+          await resumeEnrollmentTx(enrollment, p, user || null, t);
+        };
+        // Sweep wake arrives without a transaction — open our own.
+        if (transaction) return run(transaction);
+        return d.sequelize.transaction(run);
+      },
+      onRelease: ({ partnerId, user, transaction }) =>
+        exitLiveForPartnerTx(partnerId, 'released', user, transaction),
+      onReassign: async ({ partner, toUserId, transaction: t }) => {
+        const enrollment = await liveEnrollmentForPartnerTx(partner.id, t);
+        if (!enrollment) return;
+        await d.OutreachTask.update(
+          { assigneeUserId: toUserId },
+          { where: { cadenceEnrollmentId: enrollment.id, status: { [Op.in]: ['open', 'in_progress'] } }, transaction: t }
+        );
+      },
+      // BEFORE task repointing (P0 ordering) — the duplicate's cadence dies with it.
+      onMergeDuplicate: ({ duplicate, user, transaction }) =>
+        exitLiveForPartnerTx(duplicate.id, 'merged', user, transaction),
+    };
+  }
+
+  // ── Reconcile tick (§5.6) — fault repair only ─────────────────────────────
+
+  async function reconcile() {
+    return d.sequelize.transaction(async (t) => {
+      const [[{ locked }]] = await d.sequelize.query(
+        `SELECT pg_try_advisory_xact_lock(${RECONCILE_LOCK_KEY}) AS locked`, { transaction: t }
+      );
+      if (!locked) return { skipped: true };
+
+      let repaired = 0;
+      let resumed = 0;
+
+      // Candidate scans take NO row locks — per-candidate repair re-locks in
+      // the global partner → enrollment order and re-validates under lock.
+
+      // (a) paused enrollments whose partner is awake — the sweep-wake hook
+      //     failed or crashed mid-way; finish the resume it owed.
+      const strandedPaused = await d.sequelize.query(
+        `SELECT e.id, e."partnerOrganisationId" AS pid FROM outreach_cadence_enrollments e
+           JOIN partner_organisations p ON p.id = e."partnerOrganisationId"
+          WHERE e.state = 'paused' AND e."pausedAt" < NOW() - INTERVAL '10 minutes'
+            AND p.availability NOT IN ('follow_up_later')
+            AND p."archivedAt" IS NULL AND p."mergedIntoId" IS NULL
+            AND p."ownerUserId" IS NOT NULL
+          LIMIT 50`,
+        { transaction: t, type: QueryTypes.SELECT }
+      );
+      for (const row of strandedPaused) {
+        const partner = await d.PartnerOrganisation.findByPk(row.pid, { transaction: t, lock: t.LOCK.UPDATE });
+        const enrollment = await d.OutreachCadenceEnrollment.findByPk(row.id, { transaction: t, lock: t.LOCK.UPDATE });
+        if (!partner || !enrollment || enrollment.state !== 'paused' || partner.availability === 'follow_up_later') continue;
+        await resumeEnrollmentTx(enrollment, partner, null, t);
+        resumed += 1;
+      }
+
+      // (b) active enrollments with no open task and no recent write — a fault
+      //     (deliberate stops are 'exited', engine advances are atomic).
+      const orphans = await d.sequelize.query(
+        `SELECT e.id, e."partnerOrganisationId" AS pid FROM outreach_cadence_enrollments e
+           JOIN partner_organisations p ON p.id = e."partnerOrganisationId"
+          WHERE e.state = 'active' AND e."updatedAt" < NOW() - INTERVAL '15 minutes'
+            AND p."archivedAt" IS NULL AND p."mergedIntoId" IS NULL
+            AND NOT EXISTS (
+              SELECT 1 FROM outreach_tasks ot
+               WHERE ot."cadenceEnrollmentId" = e.id AND ot.status IN ('open', 'in_progress'))
+          LIMIT 50`,
+        { transaction: t, type: QueryTypes.SELECT }
+      );
+      for (const row of orphans) {
+        const partner = await d.PartnerOrganisation.findByPk(row.pid, { transaction: t, lock: t.LOCK.UPDATE });
+        const enrollment = await d.OutreachCadenceEnrollment.findByPk(row.id, { transaction: t, lock: t.LOCK.UPDATE });
+        if (!partner || !enrollment || enrollment.state !== 'active') continue;
+        const hasOpen = await d.OutreachTask.count({
+          where: { cadenceEnrollmentId: enrollment.id, status: { [Op.in]: ['open', 'in_progress'] } },
+          transaction: t,
+        });
+        if (hasOpen > 0) continue;
+        if (!partner.ownerUserId) {
+          await endEnrollmentTx(enrollment, { state: 'exited', exitReason: 'released' }, null, t);
+        } else {
+          const step = await d.OutreachCadenceStep.findByPk(enrollment.currentStepId, { transaction: t });
+          if (!step) {
+            await endEnrollmentTx(enrollment, { state: 'completed', exitReason: 'finished' }, null, t);
+          } else {
+            await placeAtStepTx(enrollment, partner, step, { delayDays: 0, timeWindow: 'any' }, null, t);
+          }
+        }
+        repaired += 1;
+      }
+
+      if (repaired > 0 || resumed > 0) {
+        d.logger.info('redeem_ops.cadence.reconcile.done', { repaired, resumed });
+      }
+      return { repaired, resumed };
+    });
+  }
+
+  return {
+    listCadences, enrollPartner, completeCadenceTask,
+    pauseEnrollment, resumeEnrollment, stopEnrollment,
+    getPartnerCadence, hookHandlers, reconcile,
+    // exported for tests
+    sgtWindowClamp, activityForDisposition,
+  };
+}
+
+const _default = makeCadenceService();
+export default _default;

--- a/backend/src/services/redeemOps/constants.js
+++ b/backend/src/services/redeemOps/constants.js
@@ -50,7 +50,7 @@ export const STAGE_TRANSITIONS = {
 export const MEANINGFUL_ACTIVITY_TYPES = [
   'call_attempt', 'call_connected', 'whatsapp_sent', 'whatsapp_reply', 'email_sent',
   'email_reply', 'instagram_dm', 'facebook_message', 'meeting_booked',
-  'meeting_completed', 'proposal_sent', 'follow_up',
+  'meeting_completed', 'proposal_sent', 'follow_up', 'visit',
 ];
 
 export const ACTIVITY_TYPES = [
@@ -66,6 +66,7 @@ export const ACTIVITY_TYPES = [
   'meeting_completed',
   'proposal_sent',
   'follow_up',
+  'visit',
   'internal_note',
   'other',
 ];
@@ -83,6 +84,36 @@ export const REWARD_TYPES = [
 
 export const TASK_STATUSES = ['open', 'in_progress', 'completed', 'cancelled'];
 export const TASK_PRIORITIES = ['low', 'medium', 'high'];
+
+// ── Cadences (docs/plans/redeem-ops-cadences.md §4.7) ───────────────────────
+
+export const CADENCE_CHANNELS = ['call', 'whatsapp', 'email', 'instagram_dm', 'visit', 'custom'];
+export const CADENCE_STEP_MODES = ['manual', 'auto']; // 'auto' reserved for P3 email
+export const CADENCE_TIME_WINDOWS = ['any', 'morning', 'afternoon', 'off_peak'];
+export const CADENCE_ENROLLMENT_STATES = ['active', 'paused', 'completed', 'exited'];
+export const CADENCE_EXIT_REASONS = [
+  'replied', 'stage_advanced', 'lost', 'not_interested', 'released',
+  'archived', 'merged', 'manual_stop', 'finished',
+];
+/** Transitions may match a step's disposition exactly or fall back to this. */
+export const CADENCE_WILDCARD_DISPOSITION = '*';
+
+/**
+ * Per-channel disposition matrix — there is deliberately NO global disposition
+ * list (call+'sent' is nonsense). The completion endpoint validates against
+ * the step's channel; the UI renders exactly these buttons.
+ */
+export const CHANNEL_DISPOSITIONS = {
+  call: ['connected', 'no_answer', 'not_interested', 'replied'],
+  whatsapp: ['sent', 'replied', 'not_interested'],
+  email: ['sent', 'replied', 'not_interested'],
+  instagram_dm: ['sent', 'replied', 'not_interested'],
+  visit: ['met', 'closed', 'not_interested'],
+  custom: ['done', 'not_interested'],
+};
+
+/** Dispositions that end the enrollment regardless of transition edges. */
+export const CADENCE_TERMINAL_DISPOSITIONS = ['replied', 'not_interested'];
 
 export const SUB_ROLE_LABELS = {
   super_admin: 'Super Admin',
@@ -109,5 +140,10 @@ export function publicConstants() {
     subRoleLabels: SUB_ROLE_LABELS,
     capabilities: CAPABILITIES,
     roleCapabilities: ROLE_CAPABILITIES,
+    cadenceChannels: CADENCE_CHANNELS,
+    cadenceTimeWindows: CADENCE_TIME_WINDOWS,
+    cadenceEnrollmentStates: CADENCE_ENROLLMENT_STATES,
+    cadenceExitReasons: CADENCE_EXIT_REASONS,
+    channelDispositions: CHANNEL_DISPOSITIONS,
   };
 }

--- a/backend/src/services/redeemOps/queueService.js
+++ b/backend/src/services/redeemOps/queueService.js
@@ -1,6 +1,7 @@
 import { Op, QueryTypes } from 'sequelize';
 import {
   OutreachTask, OutreachActivity, PartnerOrganisation, PartnerContact, User, sequelize,
+  OutreachCadenceStep, OutreachCadence,
 } from '../../models/index.js';
 import { sgtDayWindow } from './taskService.js';
 
@@ -12,16 +13,37 @@ const BUCKET_LIMIT = 10;
  * read; each bucket capped at 10 with a total count so the page renders fast.
  */
 export function makeQueueService(overrides = {}) {
-  const d = { OutreachTask, OutreachActivity, PartnerOrganisation, PartnerContact, User, sequelize, ...overrides };
+  const d = {
+    OutreachTask, OutreachActivity, PartnerOrganisation, PartnerContact, User, sequelize,
+    OutreachCadenceStep, OutreachCadence, ...overrides,
+  };
 
   async function getMyQueue(user) {
     const { start, end } = sgtDayWindow();
     const taskInclude = [
       { model: d.PartnerOrganisation, as: 'partner', attributes: PARTNER_LITE },
       { model: d.PartnerContact, as: 'contact', attributes: ['id', 'name'] },
+      {
+        model: d.OutreachCadenceStep, as: 'cadenceStep', required: false,
+        attributes: ['id', 'stepOrder', 'channel', 'title'],
+        include: [{ model: d.OutreachCadence, as: 'cadence', attributes: ['id', 'key', 'name', 'version'] }],
+      },
     ];
     const openTasks = { assigneeUserId: user.id, status: { [Op.in]: ['open', 'in_progress'] } };
     const myLivePartners = { ownerUserId: user.id, mergedIntoId: null, archivedAt: null };
+    // A partner whose cadence already scheduled the first touch is being worked —
+    // counting it under "awaiting first outreach" would double-count the same
+    // to-do (docs/plans/redeem-ops-cadences.md §8.3). Overdue cadence tasks stay
+    // counted: those DO need attention.
+    const noScheduledCadenceTouch = {
+      id: {
+        [Op.notIn]: d.sequelize.literal(`(
+          SELECT ot."partnerOrganisationId" FROM outreach_tasks ot
+           WHERE ot."cadenceEnrollmentId" IS NOT NULL
+             AND ot.status IN ('open', 'in_progress')
+             AND ot."dueAt" >= '${start.toISOString()}')`),
+      },
+    };
 
     const [
       overdueTasks, overdueCount,
@@ -40,11 +62,11 @@ export function makeQueueService(overrides = {}) {
         include: taskInclude, order: [['dueAt', 'ASC']], limit: BUCKET_LIMIT,
       }),
       d.PartnerOrganisation.findAll({
-        where: { ...myLivePartners, firstOutreachAt: null, availability: 'owned' },
+        where: { ...myLivePartners, firstOutreachAt: null, availability: 'owned', ...noScheduledCadenceTouch },
         attributes: [...PARTNER_LITE, 'atRiskFlag'],
         order: [['claimedAt', 'ASC']], limit: BUCKET_LIMIT,
       }),
-      d.PartnerOrganisation.count({ where: { ...myLivePartners, firstOutreachAt: null, availability: 'owned' } }),
+      d.PartnerOrganisation.count({ where: { ...myLivePartners, firstOutreachAt: null, availability: 'owned', ...noScheduledCadenceTouch } }),
       d.PartnerOrganisation.findAll({
         where: { ...myLivePartners, staleFlag: true },
         attributes: [...PARTNER_LITE, 'staleFlag'],

--- a/backend/src/services/redeemOps/taskService.js
+++ b/backend/src/services/redeemOps/taskService.js
@@ -1,6 +1,7 @@
 import { Op } from 'sequelize';
 import {
   OutreachTask, PartnerOrganisation, PartnerContact, User, sequelize,
+  OutreachCadenceStep, OutreachCadence,
 } from '../../models/index.js';
 import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';
@@ -30,7 +31,10 @@ export function sgtDayWindow(now = new Date()) {
  * one-transaction wrappers.
  */
 export function makeTaskService(overrides = {}) {
-  const d = { OutreachTask, PartnerOrganisation, PartnerContact, User, sequelize, logger, ...overrides };
+  const d = {
+    OutreachTask, PartnerOrganisation, PartnerContact, User, sequelize, logger,
+    OutreachCadenceStep, OutreachCadence, ...overrides,
+  };
 
   const isManager = (user) =>
     user.role === 'admin' || ['super_admin', 'ops_admin', 'bdm'].includes(user.redeemOpsRole);
@@ -116,6 +120,11 @@ export function makeTaskService(overrides = {}) {
         { model: d.PartnerOrganisation, as: 'partner', attributes: ['id', 'tradingName', 'legalName', 'brandName'] },
         { model: d.User, as: 'assignee', attributes: ['id', 'fullName'] },
         { model: d.PartnerContact, as: 'contact', attributes: ['id', 'name'] },
+        {
+          model: d.OutreachCadenceStep, as: 'cadenceStep', required: false,
+          attributes: ['id', 'stepOrder', 'channel', 'title'],
+          include: [{ model: d.OutreachCadence, as: 'cadence', attributes: ['id', 'key', 'name', 'version'] }],
+        },
       ],
       order: [['dueAt', 'ASC']],
       limit,
@@ -139,6 +148,20 @@ export function makeTaskService(overrides = {}) {
     if (!task) throw new AppError('Task not found', 404);
     if (!isManager(user) && task.assigneeUserId !== user.id && task.createdBy !== user.id) {
       throw new AppError('You can only update your own tasks', 403);
+    }
+
+    // Cadence tasks bypass-guard (docs/plans/redeem-ops-cadences.md §5.5):
+    // status/schedule/assignee changes must go through the cadence engine —
+    // the generic PATCH may only touch cosmetic fields.
+    if (task.cadenceEnrollmentId) {
+      const CADENCE_EDITABLE = ['description', 'priority'];
+      const blocked = Object.keys(body).filter((k) => body[k] !== undefined && !CADENCE_EDITABLE.includes(k));
+      if (blocked.length > 0) {
+        throw new AppError(
+          'This task is driven by a cadence — record an outcome to complete it, or stop the cadence on the business. Only description and priority can be edited here.',
+          409
+        );
+      }
     }
 
     const updates = {};

--- a/backend/test/redeemOpsCadences.test.js
+++ b/backend/test/redeemOpsCadences.test.js
@@ -1,0 +1,361 @@
+/**
+ * P1 cadence engine (docs/plans/redeem-ops-cadences.md §5): enroll → disposition
+ * completion → edge advance → exits (terminal, hooks, sweep) → reconcile,
+ * plus the generic-PATCH guard, scheduling clamp, suppressions, and queue dedup.
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+process.env.REDEEM_OPS_CADENCES_ENABLED = 'true';
+
+import request from 'supertest';
+import { getApp, closeDb, createTestUser } from './helpers.js';
+import {
+  PartnerOrganisation, OutreachTask, OutreachActivity,
+  OutreachCadence, OutreachCadenceEnrollment, OutreachSuppression, User, sequelize,
+} from '../src/models/index.js';
+import { makeCadenceService, sgtWindowClamp } from '../src/services/redeemOps/cadenceService.js';
+import { ensureCadences } from '../src/services/redeemOps/cadenceSeeds.js';
+import { registerCadenceHooks, clearCadenceHooks } from '../src/services/redeemOps/cadenceHooks.js';
+import { makePartnerService } from '../src/services/redeemOps/partnerService.js';
+import { makeClaimService } from '../src/services/redeemOps/claimService.js';
+import { makeTaskService } from '../src/services/redeemOps/taskService.js';
+import { runRedeemOpsStaleSweep } from '../src/services/redeemOps/staleSweep.js';
+
+let app;
+let admin, execA, execB;
+const svc = makeCadenceService();
+const partnerSvc = makePartnerService();
+const claimSvc = makeClaimService();
+const taskSvc = makeTaskService();
+
+let phoneSeq = 81000000;
+const nextPhone = () => `+65${phoneSeq++}`;
+
+beforeAll(async () => {
+  app = await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  execA = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
+  execB = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
+  // the app boot may have created the system agent already — don't collide
+  await User.findOrCreate({
+    where: { email: 'system@mktr.local' },
+    defaults: {
+      firstName: 'System', lastName: 'Agent', role: 'admin',
+      isActive: true, emailVerified: true, password: 'TestPassword123!',
+    },
+  });
+  await ensureCadences();
+  registerCadenceHooks(svc.hookHandlers());
+});
+
+afterAll(async () => {
+  clearCadenceHooks();
+  await closeDb();
+});
+
+const auth = (t) => ({ Authorization: `Bearer ${t}` });
+
+async function ownedPartner(name, owner = execA, patch = {}) {
+  const { partner } = await partnerSvc.createPartner(
+    { tradingName: name, primaryPhone: nextPhone() }, admin.user
+  );
+  await claimSvc.claimPartner(partner.id, owner.user);
+  if (Object.keys(patch).length) await partner.update(patch);
+  return PartnerOrganisation.findByPk(partner.id);
+}
+
+async function openCadenceTask(enrollmentId) {
+  return OutreachTask.findOne({
+    where: { cadenceEnrollmentId: enrollmentId, status: ['open', 'in_progress'] },
+  });
+}
+
+describe('seeds', () => {
+  test('two cadences seeded, idempotently', async () => {
+    const again = await ensureCadences();
+    expect(again.seeded).toBe(0);
+    const fnb = await OutreachCadence.findOne({ where: { key: 'fnb_call_first', version: 1 } });
+    expect(fnb).toBeTruthy();
+    const cadences = await svc.listCadences();
+    const keys = cadences.map((c) => c.key).sort();
+    expect(keys).toEqual(['fnb_call_first', 'revival_60d']);
+    expect(cadences.find((c) => c.key === 'fnb_call_first').steps).toHaveLength(7);
+  });
+});
+
+describe('sgtWindowClamp', () => {
+  const at = (iso) => new Date(iso);
+  test('delay-0 with the window already past is due NOW, not tomorrow', () => {
+    const now = at('2026-07-12T12:00:00Z'); // 20:00 SGT — past every window
+    expect(sgtWindowClamp(now, 0, 'any', now).getTime()).toBe(now.getTime());
+  });
+  test('delay-0 before the window lands on today’s window start', () => {
+    const now = at('2026-07-11T21:00:00Z'); // 05:00 SGT 12 Jul
+    expect(sgtWindowClamp(now, 0, 'off_peak', now).toISOString()).toBe('2026-07-12T07:00:00.000Z'); // 15:00 SGT
+  });
+  test('delayed steps land on the window start N days out', () => {
+    const now = at('2026-07-12T04:00:00Z'); // 12:00 SGT
+    expect(sgtWindowClamp(now, 2, 'off_peak', now).toISOString()).toBe('2026-07-14T07:00:00.000Z');
+  });
+  test('stale anchors roll forward until the due date is in the future', () => {
+    const now = at('2026-07-12T04:00:00Z');
+    const oldAnchor = at('2026-07-01T04:00:00Z');
+    expect(sgtWindowClamp(oldAnchor, 1, 'morning', now).getTime()).toBeGreaterThan(now.getTime());
+  });
+});
+
+describe('enroll', () => {
+  test('enrolls an owned partner: first task materialized with provenance + recipient snapshot', async () => {
+    const p = await ownedPartner('Cadence Enroll Cafe');
+    const { enrollment, firstTask } = await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+    expect(enrollment.state).toBe('active');
+    expect(firstTask.title).toBe('Intro call');
+    expect(firstTask.assigneeUserId).toBe(execA.user.id);
+    expect(firstTask.cadenceEnrollmentId).toBe(enrollment.id);
+    expect(firstTask.snapshotRecipient).toBe(p.primaryPhone);
+  });
+
+  test('unowned partners and double-enrollment are refused', async () => {
+    const { partner } = await partnerSvc.createPartner({ tradingName: 'Unowned Cafe', primaryPhone: nextPhone() }, admin.user);
+    await expect(svc.enrollPartner(partner.id, { cadenceKey: 'fnb_call_first' }, admin.user))
+      .rejects.toMatchObject({ statusCode: 409 });
+
+    const p = await ownedPartner('Double Enroll Cafe');
+    await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+    await expect(svc.enrollPartner(p.id, { cadenceKey: 'revival_60d' }, execA.user))
+      .rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  test('per-owner capacity cap: refused at cap, manager may override', async () => {
+    const capped = makeCadenceService({ enrollmentCap: 1 });
+    const owner = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
+    const p1 = await ownedPartner('Cap Cafe 1', owner);
+    const p2 = await ownedPartner('Cap Cafe 2', owner);
+    await capped.enrollPartner(p1.id, { cadenceKey: 'fnb_call_first' }, owner.user);
+    await expect(capped.enrollPartner(p2.id, { cadenceKey: 'fnb_call_first' }, owner.user))
+      .rejects.toMatchObject({ statusCode: 409 });
+    const ok = await capped.enrollPartner(p2.id, { cadenceKey: 'fnb_call_first', overrideCapacity: true }, admin.user);
+    expect(ok.enrollment.state).toBe('active');
+  });
+
+  test('route: enroll via POST returns 201', async () => {
+    const p = await ownedPartner('Route Enroll Cafe');
+    const res = await request(app)
+      .post(`/api/redeem-ops/partners/${p.id}/cadence/enroll`)
+      .set(auth(execA.token))
+      .send({ cadenceKey: 'fnb_call_first' });
+    expect(res.status).toBe(201);
+    expect(res.body.data.firstTask.title).toBe('Intro call');
+  });
+});
+
+describe('completion & advance', () => {
+  test('no_answer branches to the same-day WhatsApp; honest activity + firstOutreachAt', async () => {
+    const p = await ownedPartner('Advance Cafe');
+    const { enrollment, firstTask } = await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+
+    const result = await svc.completeCadenceTask(firstTask.id, { disposition: 'no_answer' }, execA.user);
+    expect(result.nextTask.title).toContain('WhatsApp intro');
+
+    const acts = await OutreachActivity.findAll({ where: { partnerOrganisationId: p.id } });
+    expect(acts.some((a) => a.type === 'call_attempt' && a.direction === 'outbound')).toBe(true);
+    const reloaded = await PartnerOrganisation.findByPk(p.id);
+    expect(reloaded.firstOutreachAt).toBeTruthy();
+
+    // WhatsApp 'sent' → call #2, two days out in the off-peak window (15:00 SGT)
+    const r2 = await svc.completeCadenceTask(result.nextTask.id, { disposition: 'sent' }, execA.user);
+    expect(r2.nextTask.title).toContain('Call #2');
+    expect(new Date(r2.nextTask.dueAt).getTime()).toBeGreaterThan(Date.now() + 24 * 3600 * 1000);
+    expect(new Date(r2.nextTask.dueAt).getUTCHours()).toBe(7); // 15:00 SGT
+
+    const e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
+    expect(e.state).toBe('active');
+    expect(e.lastDisposition).toBe('sent');
+  });
+
+  test('double-completion and channel-invalid dispositions are refused', async () => {
+    const p = await ownedPartner('Refusal Cafe');
+    const { firstTask } = await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+    await expect(svc.completeCadenceTask(firstTask.id, { disposition: 'sent' }, execA.user))
+      .rejects.toMatchObject({ statusCode: 400 }); // call step has no 'sent'
+    await svc.completeCadenceTask(firstTask.id, { disposition: 'no_answer' }, execA.user);
+    await expect(svc.completeCadenceTask(firstTask.id, { disposition: 'no_answer' }, execA.user))
+      .rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  test("'replied' exits the enrollment and leaves no open cadence task", async () => {
+    const p = await ownedPartner('Replied Cafe');
+    const { enrollment, firstTask } = await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+    await svc.completeCadenceTask(firstTask.id, { disposition: 'replied' }, execA.user);
+    const e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
+    expect(e.state).toBe('exited');
+    expect(e.exitReason).toBe('replied');
+    expect(await openCadenceTask(enrollment.id)).toBeNull();
+  });
+
+  test('not_interested + alsoMarkLost exits AND moves the stage in one transaction', async () => {
+    const p = await ownedPartner('NotInterested Cafe');
+    const { enrollment, firstTask } = await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+    const res = await request(app)
+      .post(`/api/redeem-ops/cadence-tasks/${firstTask.id}/complete`)
+      .set(auth(execA.token))
+      .send({ disposition: 'not_interested', alsoMarkLost: true, lostReason: 'not_interested' });
+    expect(res.status).toBe(200);
+    const e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
+    expect(e.exitReason).toBe('not_interested');
+    const reloaded = await PartnerOrganisation.findByPk(p.id);
+    expect(reloaded.pipelineStage).toBe('LOST');
+    expect(reloaded.lostReason).toBe('not_interested');
+  });
+
+  test('generic PATCH refuses cadence-task status changes but allows description edits', async () => {
+    const p = await ownedPartner('Guard Cafe');
+    const { firstTask } = await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+    await expect(taskSvc.updateTask(firstTask.id, { status: 'completed' }, execA.user))
+      .rejects.toMatchObject({ statusCode: 409 });
+    const edited = await taskSvc.updateTask(firstTask.id, { description: 'prep note' }, execA.user);
+    expect(edited.description).toBe('prep note');
+  });
+});
+
+describe('hook-driven exits and pauses', () => {
+  test('a real inbound reply exits the cadence and cancels its task', async () => {
+    const p = await ownedPartner('Inbound Exit Cafe');
+    const { enrollment } = await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+    await partnerSvc.logActivity(p.id, { type: 'whatsapp_reply', direction: 'inbound', summary: 'they wrote back' }, execA.user);
+    const e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
+    expect(e.state).toBe('exited');
+    expect(e.exitReason).toBe('replied');
+    expect(await openCadenceTask(enrollment.id)).toBeNull();
+  });
+
+  test('stage moves: CONTACTED keeps the cadence, MEETING exits it', async () => {
+    const p = await ownedPartner('Stage Exit Cafe');
+    const { enrollment } = await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+    await partnerSvc.changeStage(p.id, 'CONTACTED', execA.user);
+    expect((await OutreachCadenceEnrollment.findByPk(enrollment.id)).state).toBe('active');
+    await partnerSvc.changeStage(p.id, 'MEETING', execA.user);
+    const e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
+    expect(e.state).toBe('exited');
+    expect(e.exitReason).toBe('stage_advanced');
+  });
+
+  test('snooze pauses + cancels; manual unsnooze resumes with a fresh task', async () => {
+    const p = await ownedPartner('Snooze Cafe');
+    const { enrollment } = await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+    await partnerSvc.snoozePartner(p.id, execA.user, new Date(Date.now() + 7 * 24 * 3600 * 1000).toISOString());
+    let e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
+    expect(e.state).toBe('paused');
+    expect(await openCadenceTask(enrollment.id)).toBeNull();
+
+    await partnerSvc.unsnoozePartner(p.id, execA.user);
+    e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
+    expect(e.state).toBe('active');
+    expect(await openCadenceTask(enrollment.id)).toBeTruthy();
+  });
+
+  test('sweep wake resumes a snooze-paused cadence', async () => {
+    const p = await ownedPartner('Sweep Wake Cafe');
+    const { enrollment } = await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+    await partnerSvc.snoozePartner(p.id, execA.user, new Date(Date.now() + 24 * 3600 * 1000).toISOString());
+    await sequelize.query(
+      `UPDATE partner_organisations SET "snoozedUntil" = NOW() - INTERVAL '1 hour' WHERE id = :id`,
+      { replacements: { id: p.id } }
+    );
+    await runRedeemOpsStaleSweep();
+    const e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
+    expect(e.state).toBe('active');
+    expect(await openCadenceTask(enrollment.id)).toBeTruthy();
+  });
+
+  test('release exits; reassign keeps the enrollment and moves the task', async () => {
+    const p1 = await ownedPartner('Release Cafe');
+    const { enrollment: e1 } = await svc.enrollPartner(p1.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+    await claimSvc.releasePartner(p1.id, execA.user);
+    expect((await OutreachCadenceEnrollment.findByPk(e1.id)).exitReason).toBe('released');
+
+    const p2 = await ownedPartner('Reassign Cafe');
+    const { enrollment: e2 } = await svc.enrollPartner(p2.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+    await claimSvc.assignPartner(p2.id, execB.user.id, admin.user);
+    expect((await OutreachCadenceEnrollment.findByPk(e2.id)).state).toBe('active');
+    expect((await openCadenceTask(e2.id)).assigneeUserId).toBe(execB.user.id);
+  });
+
+  test('merge exits the duplicate’s enrollment (before task repointing)', async () => {
+    const survivor = await ownedPartner('Merge Survivor Cadence');
+    const dup = await ownedPartner('Merge Dup Cadence');
+    const { enrollment } = await svc.enrollPartner(dup.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+    await partnerSvc.mergePartners(survivor.id, dup.id, admin.user);
+    const e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
+    expect(e.state).toBe('exited');
+    expect(e.exitReason).toBe('merged');
+    expect(await openCadenceTask(enrollment.id)).toBeNull();
+  });
+
+  test('manual pause/stop endpoints', async () => {
+    const p = await ownedPartner('PauseStop Cafe');
+    await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+    const paused = await request(app).post(`/api/redeem-ops/partners/${p.id}/cadence/pause`).set(auth(execA.token));
+    expect(paused.status).toBe(200);
+    // pausing a cadence does NOT snooze the partner (pause ≠ snooze)
+    expect((await PartnerOrganisation.findByPk(p.id)).availability).toBe('owned');
+    const resumed = await request(app).post(`/api/redeem-ops/partners/${p.id}/cadence/resume`).set(auth(execA.token));
+    expect(resumed.status).toBe(200);
+    const stopped = await request(app).post(`/api/redeem-ops/partners/${p.id}/cadence/stop`).set(auth(execA.token));
+    expect(stopped.status).toBe(200);
+    expect(stopped.body.data.enrollment.exitReason).toBe('manual_stop');
+  });
+});
+
+describe('suppressions', () => {
+  test("an 'any'-channel suppression blocks every step → enrollment finishes immediately", async () => {
+    const p = await ownedPartner('Suppressed Cafe');
+    await OutreachSuppression.create({ channel: 'any', value: p.primaryPhone, reason: 'opt_out' });
+    // IG / visit steps blocked too (no handle, no location), so the chain finishes
+    const { enrollment, finishedImmediately } = await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+    expect(finishedImmediately).toBe(true);
+    const e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
+    expect(e.state).toBe('completed');
+    expect(await openCadenceTask(enrollment.id)).toBeNull();
+  });
+});
+
+describe('queue accounting', () => {
+  test('a scheduled cadence first touch removes the partner from awaiting-first-outreach', async () => {
+    const owner = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
+    const enrolled = await ownedPartner('Queue Dedup Enrolled', owner);
+    const bare = await ownedPartner('Queue Dedup Bare', owner);
+    await svc.enrollPartner(enrolled.id, { cadenceKey: 'fnb_call_first' }, owner.user);
+
+    const res = await request(app).get('/api/redeem-ops/queue').set(auth(owner.token));
+    expect(res.status).toBe(200);
+    const awaitingIds = res.body.data.awaitingFirstOutreach.items.map((x) => x.id);
+    expect(awaitingIds).toContain(bare.id);
+    expect(awaitingIds).not.toContain(enrolled.id);
+    // and the queue exposes the cadence chip data on the task
+    const allTasks = [
+      ...res.body.data.overdueTasks.items,
+      ...res.body.data.dueTodayTasks.items,
+      ...res.body.data.upcomingTasks.items,
+    ];
+    const chip = allTasks.find((tk) => tk.partner?.id === enrolled.id);
+    expect(chip?.cadenceStep?.cadence?.key).toBe('fnb_call_first');
+  });
+});
+
+describe('reconcile', () => {
+  test('re-materializes the task for an orphaned active enrollment', async () => {
+    const p = await ownedPartner('Reconcile Cafe');
+    const { enrollment } = await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+    await sequelize.query(
+      `UPDATE outreach_tasks SET status = 'cancelled' WHERE "cadenceEnrollmentId" = :eid`,
+      { replacements: { eid: enrollment.id } }
+    );
+    await sequelize.query(
+      `UPDATE outreach_cadence_enrollments SET "updatedAt" = NOW() - INTERVAL '20 minutes' WHERE id = :eid`,
+      { replacements: { eid: enrollment.id } }
+    );
+    const result = await svc.reconcile();
+    expect(result.repaired).toBeGreaterThanOrEqual(1);
+    expect(await openCadenceTask(enrollment.id)).toBeTruthy();
+  });
+});

--- a/docs/plans/redeem-ops-cadences.md
+++ b/docs/plans/redeem-ops-cadences.md
@@ -1,8 +1,12 @@
 # Redeem Ops — Outreach Cadences (sequencing engine)
 
-**Status:** v2 DRAFT — revised after Codex review (gpt-5.6-sol xhigh, 2026-07-12, verdict RETHINK
-on v1; all 4 blockers verified against code and addressed below). Not yet built.
-**Depends on:** Redeem Ops Phases 1–7 (live), Discover (live). Migrations through 056 applied.
+**Status:** v2 — revised after Codex review (gpt-5.6-sol xhigh, 2026-07-12, verdict RETHINK on v1;
+all 4 blockers verified against code and addressed below). **P0 merged** (PR #135 — tx primitives +
+hook registry). **P1 built** (migration 057, engine, disposition endpoint, seeds, queue/tasks/
+partner UI — dark behind `REDEEM_OPS_CADENCES_ENABLED` + `VITE_REDEEM_OPS_CADENCES_ENABLED`).
+Implementation note: the effective GLOBAL lock order is **partner → enrollment → task** (not
+§5.2's enrollment-first) because hooks fire inside transactions that already hold the partner lock.
+**Depends on:** Redeem Ops Phases 1–7 (live), Discover (live).
 
 ## 1. Problem
 

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -344,4 +344,34 @@ export const redeemOpsApi = {
     const res = await apiClient.patch(`/redeem-ops/activations/${id}/renewal`, { renewalOutcome });
     return res.data?.activation;
   },
+
+  // ── Cadences (docs/plans/redeem-ops-cadences.md; flag REDEEM_OPS_CADENCES_ENABLED) ──
+  async listCadences() {
+    const res = await apiClient.get('/redeem-ops/cadences');
+    return res.data?.cadences || [];
+  },
+  async getPartnerCadence(partnerId) {
+    const res = await apiClient.get(`/redeem-ops/partners/${partnerId}/cadence`);
+    return res.data;
+  },
+  async enrollCadence(partnerId, body) {
+    const res = await apiClient.post(`/redeem-ops/partners/${partnerId}/cadence/enroll`, body);
+    return res.data;
+  },
+  async completeCadenceTask(taskId, body) {
+    const res = await apiClient.post(`/redeem-ops/cadence-tasks/${taskId}/complete`, body);
+    return res.data;
+  },
+  async pauseCadence(partnerId) {
+    const res = await apiClient.post(`/redeem-ops/partners/${partnerId}/cadence/pause`);
+    return res.data?.enrollment;
+  },
+  async resumeCadence(partnerId) {
+    const res = await apiClient.post(`/redeem-ops/partners/${partnerId}/cadence/resume`);
+    return res.data?.enrollment;
+  },
+  async stopCadence(partnerId) {
+    const res = await apiClient.post(`/redeem-ops/partners/${partnerId}/cadence/stop`);
+    return res.data?.enrollment;
+  },
 };

--- a/src/components/redeemops/__tests__/cadence.test.jsx
+++ b/src/components/redeemops/__tests__/cadence.test.jsx
@@ -1,0 +1,125 @@
+/**
+ * Cadence UI — the behaviors that guard the engine's contract:
+ * 1. the Outcome menu offers ONLY the channel-valid dispositions;
+ * 2. a disposition fires the dedicated completion endpoint (never generic PATCH);
+ * 3. not_interested confirms first and can mark the business Lost in the same call.
+ * redeemOpsApi is fully mocked — no network.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.hoisted(() => {
+  vi.stubEnv('VITE_REDEEM_OPS_CADENCES_ENABLED', 'true');
+});
+
+const api = vi.hoisted(() => ({
+  completeCadenceTask: vi.fn(),
+  getPartnerCadence: vi.fn(),
+  listCadences: vi.fn(),
+  enrollCadence: vi.fn(),
+  pauseCadence: vi.fn(),
+  resumeCadence: vi.fn(),
+  stopCadence: vi.fn(),
+}));
+vi.mock('@/api/redeemOps', () => ({ redeemOpsApi: api }));
+
+const toastMock = vi.hoisted(() => {
+  const t = vi.fn();
+  t.success = vi.fn();
+  t.error = vi.fn();
+  return t;
+});
+vi.mock('sonner', () => ({ toast: toastMock }));
+
+import { CadenceOutcomeButton, CadenceChip, CadencePanel } from '../cadence';
+
+function wrap(ui) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+const callTask = {
+  id: 'task-1',
+  title: 'Intro call',
+  partnerOrganisationId: 'p-1',
+  description: 'Hi there, calling from Redeem…',
+  snapshotRecipient: '+6581234567',
+  cadenceStep: { id: 's-1', stepOrder: 1, channel: 'call', title: 'Intro call', cadence: { key: 'fnb_call_first', name: 'F&B call-first', version: 1 } },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.completeCadenceTask.mockResolvedValue({ nextTask: null });
+});
+
+describe('CadenceChip', () => {
+  it('shows the cadence name and step order', () => {
+    wrap(<CadenceChip task={callTask} />);
+    expect(screen.getByText(/F&B call-first · 1/)).toBeInTheDocument();
+  });
+});
+
+describe('CadenceOutcomeButton', () => {
+  it('offers only the call-channel dispositions', async () => {
+    const user = userEvent.setup();
+    wrap(<CadenceOutcomeButton task={callTask} />);
+    await user.click(screen.getByRole('button', { name: /outcome/i }));
+    expect(await screen.findByText('Connected')).toBeInTheDocument();
+    expect(screen.getByText('No answer')).toBeInTheDocument();
+    expect(screen.getByText('They replied')).toBeInTheDocument();
+    expect(screen.queryByText('Sent')).not.toBeInTheDocument(); // whatsapp/email only
+  });
+
+  it('a plain disposition hits the dedicated completion endpoint', async () => {
+    const user = userEvent.setup();
+    wrap(<CadenceOutcomeButton task={callTask} />);
+    await user.click(screen.getByRole('button', { name: /outcome/i }));
+    await user.click(await screen.findByText('No answer'));
+    await waitFor(() => expect(api.completeCadenceTask).toHaveBeenCalledWith('task-1', { disposition: 'no_answer' }));
+  });
+
+  it('not_interested confirms and can mark Lost in the same call', async () => {
+    const user = userEvent.setup();
+    wrap(<CadenceOutcomeButton task={callTask} />);
+    await user.click(screen.getByRole('button', { name: /outcome/i }));
+    await user.click(await screen.findByText('Not interested'));
+    // confirm dialog, "also mark Lost" pre-checked
+    await user.click(await screen.findByRole('button', { name: /confirm/i }));
+    await waitFor(() => expect(api.completeCadenceTask).toHaveBeenCalledWith('task-1', {
+      disposition: 'not_interested', alsoMarkLost: true, lostReason: 'not_interested',
+    }));
+  });
+});
+
+describe('CadencePanel', () => {
+  it('renders the live enrollment with progress and controls', async () => {
+    api.getPartnerCadence.mockResolvedValue({
+      enrollment: {
+        id: 'e-1', state: 'active',
+        cadence: { id: 'c-1', name: 'F&B call-first', version: 1, steps: [
+          { id: 's-1', stepOrder: 1, title: 'Intro call' },
+          { id: 's-2', stepOrder: 2, title: 'WhatsApp intro' },
+        ] },
+        currentStep: { id: 's-2', stepOrder: 2 },
+      },
+      openTask: { id: 'task-2', title: 'WhatsApp intro', dueAt: new Date().toISOString() },
+    });
+    wrap(<CadencePanel partner={{ id: 'p-1', ownerUserId: 'u-1', pipelineStage: 'NEW' }} />);
+    expect(await screen.findByText(/F&B call-first/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /pause/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /stop/i })).toBeInTheDocument();
+  });
+
+  it('offers enrollment when there is no live cadence', async () => {
+    api.getPartnerCadence.mockResolvedValue({ enrollment: null, openTask: null });
+    wrap(<CadencePanel partner={{ id: 'p-1', ownerUserId: 'u-1', pipelineStage: 'NEW' }} />);
+    expect(await screen.findByRole('button', { name: /start cadence/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/redeemops/cadence.jsx
+++ b/src/components/redeemops/cadence.jsx
@@ -1,0 +1,370 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import Zap from 'lucide-react/icons/zap';
+import Eye from 'lucide-react/icons/eye';
+import { redeemOpsApi } from '@/api/redeemOps';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel,
+  DropdownMenuSeparator, DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Checkbox } from '@/components/ui/checkbox';
+import { RoTag } from '@/components/redeemops/ui';
+
+export const CADENCES_ENABLED = import.meta.env.VITE_REDEEM_OPS_CADENCES_ENABLED === 'true';
+
+/** Mirror of backend CHANNEL_DISPOSITIONS (constants.js) — the buttons a rep sees. */
+const CHANNEL_DISPOSITIONS = {
+  call: ['connected', 'no_answer', 'not_interested', 'replied'],
+  whatsapp: ['sent', 'replied', 'not_interested'],
+  email: ['sent', 'replied', 'not_interested'],
+  instagram_dm: ['sent', 'replied', 'not_interested'],
+  visit: ['met', 'closed', 'not_interested'],
+  custom: ['done', 'not_interested'],
+};
+
+const DISPOSITION_LABELS = {
+  connected: 'Connected', no_answer: 'No answer', sent: 'Sent', replied: 'They replied',
+  not_interested: 'Not interested', met: 'Met in person', closed: 'Outlet closed', done: 'Done',
+};
+
+const CHANNEL_LABELS = {
+  call: 'Call', whatsapp: 'WhatsApp', email: 'Email',
+  instagram_dm: 'Instagram DM', visit: 'Visit', custom: 'Step',
+};
+
+function invalidateCadenceData(queryClient, partnerId) {
+  queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'queue'] });
+  queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'tasks'] });
+  if (partnerId) {
+    queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partner', partnerId] });
+    queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partner-cadence', partnerId] });
+  }
+}
+
+/** Small pill marking a task as cadence-driven: "⚡ F&B call-first · 3". */
+export function CadenceChip({ task }) {
+  const step = task?.cadenceStep;
+  if (!step) return null;
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold align-middle"
+      style={{ background: 'var(--ro-subtle)', color: 'var(--ro-text-2)' }}
+      title={`${step.cadence?.name || 'Cadence'} — step ${step.stepOrder}`}
+    >
+      <Zap className="w-3 h-3" aria-hidden="true" />
+      {step.cadence?.name || 'Cadence'} · {step.stepOrder}
+    </span>
+  );
+}
+
+/**
+ * The one-tap completion for cadence tasks (docs/plans/redeem-ops-cadences.md §8.1):
+ * an "Outcome" menu with only the channel-valid dispositions. One choice
+ * completes the task, logs the honest activity, and schedules the next step.
+ * `not_interested` confirms first and offers marking the business Lost in the
+ * same transaction.
+ */
+export function CadenceOutcomeButton({ task, size = 'sm' }) {
+  const queryClient = useQueryClient();
+  const [confirmNI, setConfirmNI] = useState(false);
+  const [alsoMarkLost, setAlsoMarkLost] = useState(true);
+  const [scriptOpen, setScriptOpen] = useState(false);
+
+  const channel = task?.cadenceStep?.channel || 'custom';
+  const dispositions = CHANNEL_DISPOSITIONS[channel] || CHANNEL_DISPOSITIONS.custom;
+
+  const completeMutation = useMutation({
+    mutationFn: (body) => redeemOpsApi.completeCadenceTask(task.id, body),
+    onSuccess: (data) => {
+      setConfirmNI(false);
+      const next = data?.nextTask;
+      if (next) {
+        toast.success('Logged — next step scheduled', {
+          description: `${next.title} · ${new Date(next.dueAt).toLocaleDateString(undefined, { weekday: 'short', day: 'numeric', month: 'short' })}`,
+        });
+      } else {
+        toast.success('Logged — cadence finished for this business');
+      }
+      invalidateCadenceData(queryClient, task.partnerOrganisationId || task.partner?.id);
+    },
+    onError: (err) => toast.error('Could not record the outcome', { description: err.message }),
+  });
+
+  const pick = (disposition) => {
+    if (disposition === 'not_interested') {
+      setAlsoMarkLost(true);
+      setConfirmNI(true);
+      return;
+    }
+    completeMutation.mutate({ disposition });
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button size={size} variant="outline" className="ml-1 shrink-0" disabled={completeMutation.isPending}>
+            {completeMutation.isPending ? 'Saving…' : 'Outcome'}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuLabel>{CHANNEL_LABELS[channel]} — what happened?</DropdownMenuLabel>
+          {dispositions.map((dsp) => (
+            <DropdownMenuItem key={dsp} onSelect={() => pick(dsp)}>
+              {DISPOSITION_LABELS[dsp] || dsp}
+            </DropdownMenuItem>
+          ))}
+          {(task.description || task.snapshotRecipient) && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onSelect={() => setScriptOpen(true)}>
+                <Eye className="w-3.5 h-3.5 mr-1.5" aria-hidden="true" /> View script
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={confirmNI} onOpenChange={setConfirmNI}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Not interested</DialogTitle>
+            <DialogDescription>
+              This ends the cadence for the business. You can revive it later from the pipeline.
+            </DialogDescription>
+          </DialogHeader>
+          <label className="flex items-center gap-2 text-sm font-medium cursor-pointer">
+            <Checkbox checked={alsoMarkLost} onCheckedChange={(v) => setAlsoMarkLost(!!v)} />
+            Also move the business to Lost
+          </label>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmNI(false)}>Back</Button>
+            <Button
+              disabled={completeMutation.isPending}
+              onClick={() => completeMutation.mutate({
+                disposition: 'not_interested',
+                alsoMarkLost,
+                ...(alsoMarkLost ? { lostReason: 'not_interested' } : {}),
+              })}
+            >
+              {completeMutation.isPending ? 'Saving…' : 'Confirm'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={scriptOpen} onOpenChange={setScriptOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>{task.title}</DialogTitle>
+            {task.snapshotRecipient && (
+              <DialogDescription>To: {task.snapshotRecipient}</DialogDescription>
+            )}
+          </DialogHeader>
+          <p className="text-sm whitespace-pre-wrap m-0" style={{ color: 'var(--ro-text-2)' }}>
+            {task.description || 'No script for this step.'}
+          </p>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+/**
+ * Partner Detail cadence card (§8.2): live enrollment with step progress and
+ * Pause/Resume/Stop, or an Enroll picker. `variant="summary"` renders the
+ * compact mobile strip. Renders nothing while the feature flag is off.
+ */
+export function CadencePanel({ partner, canManage = true, variant = 'card' }) {
+  const queryClient = useQueryClient();
+  const [enrollOpen, setEnrollOpen] = useState(false);
+  const partnerId = partner?.id;
+
+  const cadenceQuery = useQuery({
+    queryKey: ['redeem-ops', 'partner-cadence', partnerId],
+    queryFn: () => redeemOpsApi.getPartnerCadence(partnerId),
+    enabled: CADENCES_ENABLED && !!partnerId,
+  });
+  const defsQuery = useQuery({
+    queryKey: ['redeem-ops', 'cadences'],
+    queryFn: redeemOpsApi.listCadences,
+    enabled: CADENCES_ENABLED && enrollOpen,
+  });
+
+  const enrollMutation = useMutation({
+    mutationFn: (body) => redeemOpsApi.enrollCadence(partnerId, body),
+    onSuccess: (data) => {
+      setEnrollOpen(false);
+      toast.success(data?.finishedImmediately
+        ? 'Enrolled — but every step was blocked (check phone/handle on record)'
+        : 'Cadence started — first task is in the queue');
+      invalidateCadenceData(queryClient, partnerId);
+    },
+    onError: (err) => toast.error('Could not enroll', { description: err.message }),
+  });
+  const pauseMutation = useMutation({
+    mutationFn: () => redeemOpsApi.pauseCadence(partnerId),
+    onSuccess: () => { toast.success('Cadence paused'); invalidateCadenceData(queryClient, partnerId); },
+    onError: (err) => toast.error('Could not pause', { description: err.message }),
+  });
+  const resumeMutation = useMutation({
+    mutationFn: () => redeemOpsApi.resumeCadence(partnerId),
+    onSuccess: () => { toast.success('Cadence resumed'); invalidateCadenceData(queryClient, partnerId); },
+    onError: (err) => toast.error('Could not resume', { description: err.message }),
+  });
+  const stopMutation = useMutation({
+    mutationFn: () => redeemOpsApi.stopCadence(partnerId),
+    onSuccess: () => { toast.success('Cadence stopped'); invalidateCadenceData(queryClient, partnerId); },
+    onError: (err) => toast.error('Could not stop', { description: err.message }),
+  });
+
+  if (!CADENCES_ENABLED || !partnerId) return null;
+
+  const enrollment = cadenceQuery.data?.enrollment;
+  const openTask = cadenceQuery.data?.openTask;
+  const live = enrollment && ['active', 'paused'].includes(enrollment.state);
+  const steps = enrollment?.cadence?.steps || [];
+  const currentOrder = enrollment?.currentStep?.stepOrder || 0;
+  const terminalStage = ['PARTNERED', 'LOST'].includes(partner?.pipelineStage);
+
+  const enrollButton = canManage && !terminalStage && (
+    <Button
+      size="sm"
+      className={variant === 'summary' ? 'shrink-0' : 'w-full'}
+      disabled={!partner?.ownerUserId}
+      title={partner?.ownerUserId ? undefined : 'Claim the business first'}
+      onClick={() => setEnrollOpen(true)}
+    >
+      Start cadence
+    </Button>
+  );
+
+  const body = live ? (
+    <>
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-sm font-semibold m-0 truncate">
+          {enrollment.cadence?.name}
+          <span className="font-normal" style={{ color: 'var(--ro-text-3)' }}> · v{enrollment.cadence?.version}</span>
+        </p>
+        <RoTag tone={enrollment.state === 'active' ? 'open' : 'follow_up_later'} size="sm">
+          {enrollment.state}
+        </RoTag>
+      </div>
+      {steps.length > 0 && (
+        <div className="flex items-center gap-1.5 mt-2.5" aria-label={`Step ${currentOrder} of ${steps.length}`}>
+          {steps.map((s) => (
+            <span
+              key={s.id}
+              className="h-1.5 rounded-full flex-1"
+              title={`${s.stepOrder}. ${s.title}`}
+              style={{
+                background: s.stepOrder < currentOrder
+                  ? 'var(--ro-azure, #037AFF)'
+                  : s.stepOrder === currentOrder ? 'var(--ro-bunker, #0D1619)' : 'var(--ro-subtle)',
+              }}
+            />
+          ))}
+        </div>
+      )}
+      <p className="text-[13px] mt-2 mb-0" style={{ color: 'var(--ro-text-2)' }}>
+        {enrollment.state === 'paused'
+          ? 'Paused — no tasks will be scheduled until resumed.'
+          : openTask
+            ? <>Next: <span className="font-semibold">{openTask.title}</span> · {new Date(openTask.dueAt).toLocaleDateString(undefined, { weekday: 'short', day: 'numeric', month: 'short' })}</>
+            : 'Scheduling next step…'}
+      </p>
+      {canManage && (
+        <div className="flex gap-1.5 mt-3">
+          {enrollment.state === 'active' ? (
+            <Button size="sm" variant="outline" disabled={pauseMutation.isPending} onClick={() => pauseMutation.mutate()}>Pause</Button>
+          ) : (
+            <Button size="sm" variant="outline" disabled={resumeMutation.isPending} onClick={() => resumeMutation.mutate()}>Resume</Button>
+          )}
+          <Button size="sm" variant="ghost" disabled={stopMutation.isPending} onClick={() => stopMutation.mutate()}>Stop</Button>
+        </div>
+      )}
+    </>
+  ) : (
+    <>
+      <p className="text-[13px] m-0 leading-relaxed" style={{ color: 'var(--ro-text-2)' }}>
+        {enrollment
+          ? `Last cadence ${enrollment.state === 'completed' ? 'finished' : `ended (${(enrollment.exitReason || '').replace(/_/g, ' ')})`}.`
+          : 'No cadence yet — enroll to auto-schedule every follow-up touch.'}
+      </p>
+      <div className="mt-3">{enrollButton}</div>
+    </>
+  );
+
+  return (
+    <>
+      {variant === 'summary' ? (
+        <div className="rounded-2xl border border-border bg-white px-4 py-3 lg:hidden">
+          {live ? (
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-[13px] font-semibold m-0 truncate">
+                <Zap className="w-3.5 h-3.5 inline mr-1 -mt-0.5" aria-hidden="true" />
+                {enrollment.cadence?.name} · step {currentOrder}/{steps.length}
+                {enrollment.state === 'paused' && <span style={{ color: 'var(--ro-text-3)' }}> · paused</span>}
+              </p>
+              {openTask && (
+                <span className="text-xs font-semibold shrink-0" style={{ color: 'var(--ro-text-2)' }}>
+                  {new Date(openTask.dueAt).toLocaleDateString(undefined, { day: 'numeric', month: 'short' })}
+                </span>
+              )}
+            </div>
+          ) : (
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-[13px] m-0" style={{ color: 'var(--ro-text-2)' }}>No active cadence</p>
+              {enrollButton}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="rounded-2xl border border-border bg-white p-5">
+          <p className="text-[15px] font-bold m-0 mb-3">
+            <Zap className="w-4 h-4 inline mr-1 -mt-0.5" aria-hidden="true" /> Cadence
+          </p>
+          {cadenceQuery.isLoading ? (
+            <p className="text-[13px] m-0" style={{ color: 'var(--ro-text-2)' }}>Loading…</p>
+          ) : body}
+        </div>
+      )}
+
+      <Dialog open={enrollOpen} onOpenChange={setEnrollOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Start a cadence</DialogTitle>
+            <DialogDescription>
+              Every step becomes a task in the owner's queue at the right time — replies and stage moves stop it automatically.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            {(defsQuery.data || []).map((c) => (
+              <button
+                key={c.id}
+                type="button"
+                className="w-full text-left rounded-xl border border-border px-4 py-3 hover:bg-[var(--ro-subtle)] transition-colors disabled:opacity-60"
+                disabled={enrollMutation.isPending}
+                onClick={() => enrollMutation.mutate({ cadenceId: c.id })}
+              >
+                <p className="text-sm font-semibold m-0">{c.name}</p>
+                <p className="text-xs m-0 mt-0.5" style={{ color: 'var(--ro-text-2)' }}>
+                  {c.steps?.length || 0} steps — {(c.steps || []).map((s) => CHANNEL_LABELS[s.channel] || s.channel).join(' → ')}
+                </p>
+              </button>
+            ))}
+            {defsQuery.isLoading && <p className="text-sm m-0" style={{ color: 'var(--ro-text-2)' }}>Loading cadences…</p>}
+            {!defsQuery.isLoading && (defsQuery.data || []).length === 0 && (
+              <p className="text-sm m-0" style={{ color: 'var(--ro-text-2)' }}>No cadences defined yet.</p>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/pages/redeemops/MyQueue.jsx
+++ b/src/pages/redeemops/MyQueue.jsx
@@ -5,6 +5,7 @@ import { redeemOpsApi } from '@/api/redeemOps';
 import { useAuthStore } from '@/stores/authStore';
 import { Button } from '@/components/ui/button';
 import { RoStatTile, RoEmpty, prettyEnum } from '@/components/redeemops/ui';
+import { CadenceChip, CadenceOutcomeButton } from '@/components/redeemops/cadence';
 
 function partnerName(p) {
   return p?.tradingName || p?.brandName || p?.legalName || 'Business';
@@ -72,7 +73,11 @@ export default function MyQueue() {
   const todoToday = (q.overdueTasks.total || 0) + (q.dueTodayTasks.total || 0) + (q.awaitingFirstOutreach.total || 0);
   const empty = overdue.length + dueToday.length + awaiting.length + stale.length + replies.length + upcoming.length === 0;
 
-  const doneButton = (task) => (
+  // Cadence tasks complete through a disposition, never a bare "Done" —
+  // the outcome drives what the engine schedules next.
+  const doneButton = (task) => (task.cadenceStep ? (
+    <CadenceOutcomeButton task={task} />
+  ) : (
     <Button
       size="sm"
       variant="outline"
@@ -82,7 +87,7 @@ export default function MyQueue() {
     >
       Done
     </Button>
-  );
+  ));
   const openButton = (partnerId) => (
     <Button size="sm" variant="outline" className="ml-1 shrink-0" asChild>
       <Link to={`/redeem-ops/partners/${partnerId}`}>Open</Link>
@@ -93,6 +98,7 @@ export default function MyQueue() {
     <>
       <Link to={`/redeem-ops/partners/${t.partner?.id}`} className="ro-link">{partnerName(t.partner)}</Link>
       {t.contact?.name ? ` · ${t.contact.name}` : ''}
+      {t.cadenceStep ? <> <CadenceChip task={t} /></> : null}
     </>
   );
 

--- a/src/pages/redeemops/PartnerDetail.jsx
+++ b/src/pages/redeemops/PartnerDetail.jsx
@@ -35,6 +35,7 @@ import Plus from 'lucide-react/icons/plus';
 import Pencil from 'lucide-react/icons/pencil';
 import ArrowLeft from 'lucide-react/icons/arrow-left';
 import { RoStageTag, RoAvatar, RoTag, prettyEnum } from '@/components/redeemops/ui';
+import { CadencePanel } from '@/components/redeemops/cadence';
 import CategorySelect from '@/components/redeemops/CategorySelect';
 
 function useDebounced(value, ms = 300) {
@@ -623,6 +624,11 @@ export default function PartnerDetail() {
         </div>
       </div>
 
+      {/* Mobile: the cadence state sits right under the header — the 320px rail
+          lands below all tab content on small screens (cadence.jsx renders
+          nothing while the feature flag is off). */}
+      <CadencePanel partner={partner} canManage={hasCapability(user, 'tasks.manage')} variant="summary" />
+
       <div className="grid gap-5 lg:grid-cols-[1fr_320px] items-start">
         <Tabs defaultValue="timeline">
           <div className="max-w-full overflow-x-auto">
@@ -748,6 +754,9 @@ export default function PartnerDetail() {
         </Tabs>
 
         <div className="space-y-4">
+          <div className="hidden lg:block">
+            <CadencePanel partner={partner} canManage={hasCapability(user, 'tasks.manage')} />
+          </div>
           <div className="rounded-2xl border border-border bg-white p-5">
             <p className="text-[15px] font-bold m-0 mb-3">Owner</p>
             {partner.owner ? (

--- a/src/pages/redeemops/TasksPage.jsx
+++ b/src/pages/redeemops/TasksPage.jsx
@@ -21,6 +21,7 @@ import { Label } from '@/components/ui/label';
 import Plus from 'lucide-react/icons/plus';
 import Pencil from 'lucide-react/icons/pencil';
 import { RoMobileCard, RoPageHeader, RoTag, RoAvatar, prettyEnum } from '@/components/redeemops/ui';
+import { CadenceChip, CadenceOutcomeButton } from '@/components/redeemops/cadence';
 
 const VIEWS = [
   { key: 'today', label: 'Due today', params: { due: 'today' } },
@@ -215,8 +216,11 @@ export default function TasksPage() {
                   <span className="text-[12.5px] font-semibold" style={{ color: due.color }}>{due.text}</span>
                   <RoTag tone={t.priority} size="sm">{t.priority}</RoTag>
                   {showStatus && <RoTag tone={t.status} size="sm">{prettyEnum(t.status)}</RoTag>}
+                  {t.cadenceStep && <CadenceChip task={t} />}
                   <span className="ml-auto inline-flex gap-1">
-                    {open && (
+                    {open && (t.cadenceStep ? (
+                      <CadenceOutcomeButton task={t} />
+                    ) : (
                       <>
                         <Button
                           size="sm" variant="outline"
@@ -239,8 +243,8 @@ export default function TasksPage() {
                           <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
                         </Button>
                       </>
-                    )}
-                    {t.status === 'completed' && (
+                    ))}
+                    {t.status === 'completed' && !t.cadenceStep && (
                       <Button
                         size="sm" variant="ghost"
                         disabled={updateMutation.isPending}
@@ -299,7 +303,9 @@ export default function TasksPage() {
                         <TableCell className="text-muted-foreground text-sm">{t.assignee?.fullName || '—'}</TableCell>
                       )}
                       <TableCell className="text-right space-x-1 whitespace-nowrap">
-                        {open && (
+                        {open && (t.cadenceStep ? (
+                          <CadenceOutcomeButton task={t} />
+                        ) : (
                           <>
                             <Button
                               size="sm" variant="outline"
@@ -329,8 +335,8 @@ export default function TasksPage() {
                               Cancel
                             </Button>
                           </>
-                        )}
-                        {t.status === 'completed' && (
+                        ))}
+                        {t.status === 'completed' && !t.cadenceStep && (
                           <Button
                             size="sm" variant="ghost"
                             disabled={updateMutation.isPending}


### PR DESCRIPTION
## What

**P1 of the cadence engine** (design: `docs/plans/redeem-ops-cadences.md` v2, Codex-reviewed; P0 tx-primitives landed in #135). Outreach-style sequencing on the partner CRM: enroll a business into a cadence and the engine schedules every touch as a task in the existing queue; completing with a **disposition** advances/branches; replies, stage moves, snoozes, releases, and merges end or pause it automatically.

Ships **fully dark**: `REDEEM_OPS_CADENCES_ENABLED` (routes, bootstrap hook wiring, seeds, reconcile tick) + `VITE_REDEEM_OPS_CADENCES_ENABLED` (SPA). Flags off = today's behavior byte-for-byte (P0 hooks stay no-ops).

## Backend
- **Migration 057** (schema only, guarded): versioned `outreach_cadences` (immutable key+version), steps, **transition edges** `(fromStep, disposition) → toStep` with delay/window on the edge, enrollments (partial-unique: one live per partner), suppressions; `outreach_tasks` gains provenance + a one-open-task-per-enrollment partial unique.
- **cadenceService**: synchronous advance in one transaction — global lock order **partner → enrollment → task** (deviation from doc §5.2 noted in the doc: hooks fire under an already-held partner lock); channel-valid dispositions; honest activity mapping with hook suppression (no recursion); `not_interested` + `alsoMarkLost` moves the stage to LOST **in the same transaction**; blocked-step chaining ('*' edges) for missing recipients / suppressions / unresolved templates; SGT window clamp (delay-0 past-window = due NOW); per-owner capacity cap under an advisory xact lock; reconcile tick (advisory-lock guarded, repairs orphans + stranded resumes only).
- **Hook handlers** registered from bootstrap: inbound reply → exit(replied); MEETING+/LOST → exit; snooze ↔ pause/resume (incl. the sweep wake); release → exit; reassign moves the open task; merge exits the duplicate before repointing.
- **Generic PATCH guard**: status/schedule/assignee changes on cadence tasks → 409 pointing at the disposition endpoint (verified Codex blocker #3).
- **Queue fixes**: awaiting-first-outreach no longer double-counts a partner whose cadence already scheduled the first touch; queue/tasks return `cadenceStep` chip data.
- **Seeds in bootstrap** after `initSystemAgent` (`fnb_call_first` v1 — call-first F&B chase w/ same-day WhatsApp branch, off-peak call windows, walk-in, break-up; `revival_60d` v1) — migration seeding can't satisfy `createdBy` on a fresh DB (verified Codex finding #18).

## Frontend
- `CadenceOutcomeButton` + `CadenceChip` shared by **My Queue and Tasks** (one tap = complete + log + schedule next; `not_interested` confirms with "also mark Lost"; view-script dialog shows the rendered template + recipient).
- `CadencePanel` on Partner Detail: compact mobile summary under the header + desktop rail card (progress bar, next step, Pause/Resume/Stop, enroll picker).

## Tests
- **24 new backend engine tests**: enroll (incl. capacity + routes), branching + SGT scheduling, terminal dispositions, PATCH guard, all hook exits, sweep-wake resume, suppression blocking, queue dedup, reconcile repair, clamp unit tests. The suite caught 3 real bugs during development (clamp off-by-one rolling due-now to tomorrow; null-user crash in sweep-resume and reconciler materialization) — fixed.
- Full redeem-ops + discovery set: **178/179** (the 1 = pre-existing `redeemOpsRewards` baseline, stash-verified unchanged).
- Frontend: 6 new component tests; **full vitest 1124/1124**; vite build clean.
- CI note: DB-backed suites run locally only (CI fails fast at the known shortlinkService baseline).

## Go-live (later, user-side)
Render env: `REDEEM_OPS_CADENCES_ENABLED=true` on `mktr-backend-jo6r`; `VITE_REDEEM_OPS_CADENCES_ENABLED=true` on the two ops-serving static sites. Migration 057 applies on deploy (additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)