### PR TITLE
feat(redeem-ops): cadence builder — create your own sequences from Settings

### DIFF
--- a/backend/src/controllers/redeemOps/cadenceController.js
+++ b/backend/src/controllers/redeemOps/cadenceController.js
@@ -10,8 +10,40 @@ function validateBody(schema, body) {
 }
 
 export const listCadences = asyncHandler(async (req, res) => {
-  const cadences = await cadenceService.listCadences();
+  const cadences = await cadenceService.listCadences({ includeRetired: req.query.all === 'true' });
   res.json({ success: true, data: { cadences } });
+});
+
+const stepSchema = Joi.object({
+  channel: Joi.string().valid('call', 'whatsapp', 'email', 'instagram_dm', 'visit', 'custom').required(),
+  title: Joi.string().max(160).required(),
+  script: Joi.string().max(5000).allow('', null),
+  priority: Joi.string().valid('low', 'medium', 'high'),
+  delayDays: Joi.number().integer().min(0).max(60).required(),
+  timeWindow: Joi.string().valid('any', 'morning', 'afternoon', 'off_peak'),
+  continueOn: Joi.string().max(24).allow(null),
+});
+const cadenceDefSchema = Joi.object({
+  name: Joi.string().max(120).required(),
+  description: Joi.string().max(2000).allow('', null),
+  steps: Joi.array().items(stepSchema).min(1).max(20).required(),
+});
+
+export const createCadence = asyncHandler(async (req, res) => {
+  const body = validateBody(cadenceDefSchema, req.body || {});
+  const cadence = await cadenceService.createCadence(body, req.user, req.id);
+  res.status(201).json({ success: true, data: { cadence } });
+});
+
+export const createCadenceVersion = asyncHandler(async (req, res) => {
+  const body = validateBody(cadenceDefSchema, req.body || {});
+  const cadence = await cadenceService.createCadenceVersion(req.params.cadenceId, body, req.user, req.id);
+  res.status(201).json({ success: true, data: { cadence } });
+});
+
+export const retireCadence = asyncHandler(async (req, res) => {
+  const cadence = await cadenceService.retireCadence(req.params.cadenceId, req.user, req.id);
+  res.json({ success: true, data: { cadence } });
 });
 
 export const getPartnerCadence = asyncHandler(async (req, res) => {

--- a/backend/src/routes/redeemOpsCadences.js
+++ b/backend/src/routes/redeemOpsCadences.js
@@ -25,6 +25,12 @@ router.use((req, res, next) => {
 // Definitions — every ops principal reads them (queue chips resolve names).
 router.get('/cadences', requireRedeemOps(), ctrl.listCadences);
 
+// Authoring — curated like categories: settings.manage (super_admin/ops_admin).
+// Editing creates a NEW version; live enrollments keep the one they started on.
+router.post('/cadences', requireRedeemOps('settings.manage'), ctrl.createCadence);
+router.post('/cadences/:cadenceId/versions', requireRedeemOps('settings.manage'), ctrl.createCadenceVersion);
+router.post('/cadences/:cadenceId/retire', requireRedeemOps('settings.manage'), ctrl.retireCadence);
+
 // Partner-scoped enrollment lifecycle (owner/manager checks in the service).
 router.get('/partners/:partnerId/cadence', requireRedeemOps(), ctrl.getPartnerCadence);
 router.post('/partners/:partnerId/cadence/enroll', requireRedeemOps('tasks.manage'), ctrl.enroll);

--- a/backend/src/services/redeemOps/cadenceService.js
+++ b/backend/src/services/redeemOps/cadenceService.js
@@ -12,7 +12,7 @@ import { makePartnerService } from './partnerService.js';
 import { normalizePhone } from '../prospectHelpers.js';
 import {
   CHANNEL_DISPOSITIONS, CADENCE_TERMINAL_DISPOSITIONS, CADENCE_WILDCARD_DISPOSITION,
-  LOST_REASONS,
+  CADENCE_CHANNELS, CADENCE_TIME_WINDOWS, TASK_PRIORITIES, LOST_REASONS,
 } from './constants.js';
 
 /**
@@ -116,14 +116,147 @@ export function makeCadenceService(overrides = {}) {
 
   // ── Definition lookup ──────────────────────────────────────────────────────
 
-  async function listCadences() {
+  async function listCadences({ includeRetired = false } = {}) {
     return d.OutreachCadence.findAll({
-      where: { isActive: true },
+      where: includeRetired ? {} : { isActive: true },
       include: [
         { model: d.OutreachCadenceStep, as: 'steps' },
         { model: d.OutreachCadenceTransition, as: 'transitions' },
       ],
       order: [['key', 'ASC'], ['version', 'DESC'], [{ model: d.OutreachCadenceStep, as: 'steps' }, 'stepOrder', 'ASC']],
+    });
+  }
+
+  // ── Definition authoring (builder — docs/plans/redeem-ops-cadences.md §8.5) ──
+  //
+  // The builder speaks a LINEAR dialect: an ordered step list where each step
+  // carries its own delay/window and a single `continueOn` disposition that
+  // advances to the next step; everything else finishes (terminal dispositions
+  // are engine-level). That compiles losslessly onto the edge model — and both
+  // seeded cadences are expressible in it, so the editor can round-trip them.
+
+  function validateBuilderDefinition(def) {
+    const name = String(def.name || '').trim();
+    if (!name || name.length > 120) throw new AppError('A cadence name (max 120 chars) is required', 400);
+    const rawSteps = Array.isArray(def.steps) ? def.steps : [];
+    if (rawSteps.length < 1 || rawSteps.length > 20) {
+      throw new AppError('A cadence needs between 1 and 20 steps', 400);
+    }
+    const steps = rawSteps.map((s, i) => {
+      const channel = String(s.channel || '');
+      if (!CADENCE_CHANNELS.includes(channel)) throw new AppError(`Step ${i + 1}: unknown channel`, 400);
+      const title = String(s.title || '').trim();
+      if (!title || title.length > 160) throw new AppError(`Step ${i + 1}: a title (max 160 chars) is required`, 400);
+      const delayDays = Number.parseInt(s.delayDays, 10);
+      if (!Number.isInteger(delayDays) || delayDays < 0 || delayDays > 60) {
+        throw new AppError(`Step ${i + 1}: delay must be 0–60 days`, 400);
+      }
+      const timeWindow = s.timeWindow || 'any';
+      if (!CADENCE_TIME_WINDOWS.includes(timeWindow)) throw new AppError(`Step ${i + 1}: unknown time window`, 400);
+      const priority = s.priority || 'medium';
+      if (!TASK_PRIORITIES.includes(priority)) throw new AppError(`Step ${i + 1}: unknown priority`, 400);
+      const isLast = i === rawSteps.length - 1;
+      let continueOn = null;
+      if (!isLast) {
+        continueOn = s.continueOn || (channel === 'call' ? 'no_answer' : CADENCE_WILDCARD_DISPOSITION);
+        const allowed = [...(CHANNEL_DISPOSITIONS[channel] || []), CADENCE_WILDCARD_DISPOSITION]
+          .filter((x) => !CADENCE_TERMINAL_DISPOSITIONS.includes(x));
+        if (!allowed.includes(continueOn)) {
+          throw new AppError(`Step ${i + 1}: '${continueOn}' cannot advance a ${channel} step`, 400);
+        }
+      }
+      return {
+        channel, title, continueOn, delayDays, timeWindow, priority,
+        script: s.script ? String(s.script).slice(0, 5000) : null,
+      };
+    });
+    return { name, description: def.description ? String(def.description).slice(0, 2000) : null, steps };
+  }
+
+  async function insertDefinitionTx({ key, version, name, description, steps }, user, t) {
+    const cadence = await d.OutreachCadence.create({
+      key, version, name, description, createdBy: user.id,
+    }, { transaction: t });
+    const created = [];
+    for (let i = 0; i < steps.length; i += 1) {
+      created.push(await d.OutreachCadenceStep.create({
+        cadenceId: cadence.id, stepOrder: i + 1, channel: steps[i].channel,
+        title: steps[i].title, scriptTemplate: steps[i].script, priority: steps[i].priority,
+      }, { transaction: t }));
+    }
+    await d.OutreachCadenceTransition.create({
+      cadenceId: cadence.id, fromStepId: null, disposition: CADENCE_WILDCARD_DISPOSITION,
+      toStepId: created[0].id, delayDays: steps[0].delayDays, timeWindow: steps[0].timeWindow,
+    }, { transaction: t });
+    for (let i = 0; i < steps.length - 1; i += 1) {
+      await d.OutreachCadenceTransition.create({
+        cadenceId: cadence.id, fromStepId: created[i].id, disposition: steps[i].continueOn,
+        toStepId: created[i + 1].id, delayDays: steps[i + 1].delayDays, timeWindow: steps[i + 1].timeWindow,
+      }, { transaction: t });
+    }
+    return cadence;
+  }
+
+  function slugifyKey(name) {
+    return name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '').slice(0, 56) || 'cadence';
+  }
+
+  async function createCadence(def, user, requestId = null) {
+    const norm = validateBuilderDefinition(def);
+    return d.sequelize.transaction(async (t) => {
+      await d.sequelize.query('SELECT pg_advisory_xact_lock(9157002)', { transaction: t });
+      let key = slugifyKey(norm.name);
+      const clashes = await d.OutreachCadence.count({ where: { key }, transaction: t });
+      if (clashes > 0) key = `${key}_${Date.now().toString(36)}`.slice(0, 64);
+      const cadence = await insertDefinitionTx({ ...norm, key, version: 1 }, user, t);
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'cadence.created', entityType: 'outreach_cadence',
+        entityId: cadence.id, after: { key, name: norm.name, steps: norm.steps.length },
+        requestId, transaction: t,
+      });
+      return cadence;
+    });
+  }
+
+  /**
+   * Editing = a NEW version of the same key; every active row of the key is
+   * retired in the same transaction. Live enrollments keep the version they
+   * started on (they FK the old row); the picker only offers active versions.
+   */
+  async function createCadenceVersion(cadenceId, def, user, requestId = null) {
+    const norm = validateBuilderDefinition(def);
+    return d.sequelize.transaction(async (t) => {
+      await d.sequelize.query('SELECT pg_advisory_xact_lock(9157002)', { transaction: t });
+      const base = await d.OutreachCadence.findByPk(cadenceId, { transaction: t, lock: t.LOCK.UPDATE });
+      if (!base) throw new AppError('Cadence not found', 404);
+      const latest = await d.OutreachCadence.max('version', { where: { key: base.key }, transaction: t });
+      await d.OutreachCadence.update(
+        { isActive: false },
+        { where: { key: base.key, isActive: true }, transaction: t }
+      );
+      const cadence = await insertDefinitionTx({ ...norm, key: base.key, version: latest + 1 }, user, t);
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'cadence.version_created', entityType: 'outreach_cadence',
+        entityId: cadence.id,
+        before: { version: base.version }, after: { version: latest + 1, name: norm.name, steps: norm.steps.length },
+        requestId, transaction: t,
+      });
+      return cadence;
+    });
+  }
+
+  async function retireCadence(cadenceId, user, requestId = null) {
+    return d.sequelize.transaction(async (t) => {
+      const cadence = await d.OutreachCadence.findByPk(cadenceId, { transaction: t, lock: t.LOCK.UPDATE });
+      if (!cadence) throw new AppError('Cadence not found', 404);
+      if (!cadence.isActive) return cadence;
+      await cadence.update({ isActive: false }, { transaction: t });
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'cadence.retired', entityType: 'outreach_cadence',
+        entityId: cadence.id, after: { key: cadence.key, version: cadence.version },
+        requestId, transaction: t,
+      });
+      return cadence;
     });
   }
 
@@ -699,11 +832,12 @@ export function makeCadenceService(overrides = {}) {
   }
 
   return {
-    listCadences, enrollPartner, completeCadenceTask,
+    listCadences, createCadence, createCadenceVersion, retireCadence,
+    enrollPartner, completeCadenceTask,
     pauseEnrollment, resumeEnrollment, stopEnrollment,
     getPartnerCadence, hookHandlers, reconcile,
     // exported for tests
-    sgtWindowClamp, activityForDisposition,
+    sgtWindowClamp, activityForDisposition, validateBuilderDefinition,
   };
 }
 

--- a/backend/test/redeemOpsCadences.test.js
+++ b/backend/test/redeemOpsCadences.test.js
@@ -342,6 +342,96 @@ describe('queue accounting', () => {
   });
 });
 
+describe('authoring (builder)', () => {
+  const builderDef = {
+    name: 'Grooming chase',
+    description: 'Pet services variant',
+    steps: [
+      { channel: 'call', title: 'Groomer intro call', delayDays: 0, timeWindow: 'any', continueOn: 'no_answer', script: 'Hi {{contact_name}}!' },
+      { channel: 'whatsapp', title: 'Groomer WhatsApp', delayDays: 1, timeWindow: 'off_peak' },
+      { channel: 'visit', title: 'Drop by the salon', delayDays: 3, timeWindow: 'afternoon' },
+    ],
+  };
+
+  test('create via route → compiled edges run end-to-end', async () => {
+    const res = await request(app)
+      .post('/api/redeem-ops/cadences')
+      .set(auth(admin.token))
+      .send(builderDef);
+    expect(res.status).toBe(201);
+    const created = res.body.data.cadence;
+    expect(created.key).toBe('grooming_chase');
+    expect(created.version).toBe(1);
+
+    // it actually runs: enroll → no_answer branches to the WhatsApp step
+    const p = await ownedPartner('Builder Run Cafe');
+    await partnerSvc.addLocation(p.id, { name: 'Main salon', addressLine: '1 Grooming Way' }, admin.user);
+    const { firstTask } = await svc.enrollPartner(p.id, { cadenceKey: 'grooming_chase' }, execA.user);
+    expect(firstTask.title).toBe('Groomer intro call');
+    const r = await svc.completeCadenceTask(firstTask.id, { disposition: 'no_answer' }, execA.user);
+    expect(r.nextTask.title).toBe('Groomer WhatsApp');
+    // step 2's continueOn defaulted to '*', so 'sent' advances to the visit
+    const r2 = await svc.completeCadenceTask(r.nextTask.id, { disposition: 'sent' }, execA.user);
+    expect(r2.nextTask.title).toBe('Drop by the salon');
+  });
+
+  test('validation: terminal continueOn and channel mismatches are refused; execs are not allowed', async () => {
+    const bad = {
+      name: 'Bad def',
+      steps: [
+        { channel: 'call', title: 'x', delayDays: 0, continueOn: 'replied' },
+        { channel: 'email', title: 'y', delayDays: 1 },
+      ],
+    };
+    const res = await request(app).post('/api/redeem-ops/cadences').set(auth(admin.token)).send(bad);
+    expect(res.status).toBe(400);
+
+    const denied = await request(app).post('/api/redeem-ops/cadences').set(auth(execA.token)).send(builderDef);
+    expect(denied.status).toBe(403);
+  });
+
+  test('editing creates a new version, retires the old, and in-flight enrollments finish on their version', async () => {
+    const created = await svc.createCadence({
+      name: 'Version test', steps: [
+        { channel: 'call', title: 'v1 call', delayDays: 0, continueOn: 'no_answer' },
+        { channel: 'whatsapp', title: 'v1 whatsapp', delayDays: 1 },
+      ],
+    }, admin.user);
+
+    const p = await ownedPartner('Version Pin Cafe');
+    const { enrollment, firstTask } = await svc.enrollPartner(p.id, { cadenceId: created.id }, execA.user);
+
+    const v2 = await svc.createCadenceVersion(created.id, {
+      name: 'Version test (tighter)', steps: [
+        { channel: 'whatsapp', title: 'v2 whatsapp first', delayDays: 0 },
+      ],
+    }, admin.user);
+    expect(v2.version).toBe(2);
+    expect((await OutreachCadence.findByPk(created.id)).isActive).toBe(false);
+
+    // the picker offers only v2…
+    const active = await svc.listCadences();
+    const versions = active.filter((c) => c.key === created.key).map((c) => c.version);
+    expect(versions).toEqual([2]);
+
+    // …while the in-flight enrollment still advances on v1's edges
+    const r = await svc.completeCadenceTask(firstTask.id, { disposition: 'no_answer' }, execA.user);
+    expect(r.nextTask.title).toBe('v1 whatsapp');
+    expect((await OutreachCadenceEnrollment.findByPk(enrollment.id)).cadenceId).toBe(created.id);
+  });
+
+  test('retire hides from the default list but stays queryable with all=true', async () => {
+    const created = await svc.createCadence({
+      name: 'Retire me', steps: [{ channel: 'call', title: 'only step', delayDays: 0 }],
+    }, admin.user);
+    await svc.retireCadence(created.id, admin.user);
+    const active = await svc.listCadences();
+    expect(active.some((c) => c.id === created.id)).toBe(false);
+    const all = await svc.listCadences({ includeRetired: true });
+    expect(all.some((c) => c.id === created.id)).toBe(true);
+  });
+});
+
 describe('reconcile', () => {
   test('re-materializes the task for an orphaned active enrollment', async () => {
     const p = await ownedPartner('Reconcile Cafe');

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -346,9 +346,21 @@ export const redeemOpsApi = {
   },
 
   // ── Cadences (docs/plans/redeem-ops-cadences.md; flag REDEEM_OPS_CADENCES_ENABLED) ──
-  async listCadences() {
-    const res = await apiClient.get('/redeem-ops/cadences');
+  async listCadences(params = {}) {
+    const res = await apiClient.get('/redeem-ops/cadences', params);
     return res.data?.cadences || [];
+  },
+  async createCadence(body) {
+    const res = await apiClient.post('/redeem-ops/cadences', body);
+    return res.data?.cadence;
+  },
+  async createCadenceVersion(cadenceId, body) {
+    const res = await apiClient.post(`/redeem-ops/cadences/${cadenceId}/versions`, body);
+    return res.data?.cadence;
+  },
+  async retireCadence(cadenceId) {
+    const res = await apiClient.post(`/redeem-ops/cadences/${cadenceId}/retire`);
+    return res.data?.cadence;
   },
   async getPartnerCadence(partnerId) {
     const res = await apiClient.get(`/redeem-ops/partners/${partnerId}/cadence`);

--- a/src/components/redeemops/CadenceStudio.jsx
+++ b/src/components/redeemops/CadenceStudio.jsx
@@ -1,0 +1,314 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import Plus from 'lucide-react/icons/plus';
+import Trash2 from 'lucide-react/icons/trash-2';
+import ArrowUp from 'lucide-react/icons/arrow-up';
+import ArrowDown from 'lucide-react/icons/arrow-down';
+import Pencil from 'lucide-react/icons/pencil';
+import { redeemOpsApi } from '@/api/redeemOps';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { CADENCES_ENABLED } from '@/components/redeemops/cadence';
+
+const CHANNELS = [
+  { value: 'call', label: 'Call' },
+  { value: 'whatsapp', label: 'WhatsApp' },
+  { value: 'email', label: 'Email' },
+  { value: 'instagram_dm', label: 'Instagram DM' },
+  { value: 'visit', label: 'Walk-in visit' },
+  { value: 'custom', label: 'Custom step' },
+];
+const WINDOWS = [
+  { value: 'any', label: 'Any time' },
+  { value: 'morning', label: 'Morning (9:30)' },
+  { value: 'afternoon', label: 'Afternoon (15:00)' },
+  { value: 'off_peak', label: 'Off-peak (15:00–17:00)' },
+];
+/** Non-terminal outcomes that may advance to the next step, per channel. */
+const CONTINUE_OPTIONS = {
+  call: [{ value: '*', label: 'Any outcome' }, { value: 'no_answer', label: 'No answer only' }, { value: 'connected', label: 'Connected only' }],
+  whatsapp: [{ value: '*', label: 'Any outcome' }, { value: 'sent', label: 'Sent' }],
+  email: [{ value: '*', label: 'Any outcome' }, { value: 'sent', label: 'Sent' }],
+  instagram_dm: [{ value: '*', label: 'Any outcome' }, { value: 'sent', label: 'Sent' }],
+  visit: [{ value: '*', label: 'Any outcome' }, { value: 'met', label: 'Met only' }, { value: 'closed', label: 'Outlet closed only' }],
+  custom: [{ value: '*', label: 'Any outcome' }, { value: 'done', label: 'Done' }],
+};
+const CHANNEL_LABEL = Object.fromEntries(CHANNELS.map((c) => [c.value, c.label]));
+
+const emptyStep = (channel = 'call') => ({
+  channel, title: '', script: '', priority: 'medium',
+  delayDays: 0, timeWindow: 'any', continueOn: channel === 'call' ? 'no_answer' : '*',
+});
+
+/**
+ * Reverse-map a stored cadence (steps + transition edges) into the builder's
+ * linear dialect: each step's delay/window ride its INCOMING edge, its
+ * continue-on is the OUTGOING edge to the next step. Both seeded cadences and
+ * everything the builder saves are linear, so the round-trip is lossless.
+ */
+export function toBuilderSteps(cadence) {
+  const steps = [...(cadence.steps || [])].sort((a, b) => a.stepOrder - b.stepOrder);
+  const byFrom = {};
+  let entry = null;
+  for (const t of cadence.transitions || []) {
+    if (t.fromStepId) byFrom[t.fromStepId] = t;
+    else entry = t;
+  }
+  return steps.map((s, i) => {
+    const incoming = i === 0 ? entry : byFrom[steps[i - 1].id];
+    const outgoing = byFrom[s.id];
+    return {
+      channel: s.channel,
+      title: s.title,
+      script: s.scriptTemplate || '',
+      priority: s.priority || 'medium',
+      delayDays: incoming?.delayDays ?? 0,
+      timeWindow: incoming?.timeWindow || 'any',
+      continueOn: outgoing?.disposition || '*',
+    };
+  });
+}
+
+function StepEditor({ step, index, total, onChange, onRemove, onMove }) {
+  const set = (patch) => onChange({ ...step, ...patch });
+  const isLast = index === total - 1;
+  return (
+    <div className="rounded-xl border border-border p-3.5 space-y-2.5">
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-bold w-5 shrink-0" style={{ color: 'var(--ro-text-3)' }}>{index + 1}.</span>
+        <Select value={step.channel} onValueChange={(channel) => set({ channel, continueOn: channel === 'call' ? 'no_answer' : '*' })}>
+          <SelectTrigger className="w-[150px] shrink-0"><SelectValue /></SelectTrigger>
+          <SelectContent>
+            {CHANNELS.map((c) => <SelectItem key={c.value} value={c.value}>{c.label}</SelectItem>)}
+          </SelectContent>
+        </Select>
+        <Input
+          value={step.title}
+          placeholder="Step title (becomes the task title)"
+          onChange={(e) => set({ title: e.target.value })}
+        />
+        <span className="inline-flex gap-0.5 shrink-0">
+          <Button size="sm" variant="ghost" aria-label="Move up" disabled={index === 0} onClick={() => onMove(-1)}>
+            <ArrowUp className="w-3.5 h-3.5" aria-hidden="true" />
+          </Button>
+          <Button size="sm" variant="ghost" aria-label="Move down" disabled={isLast} onClick={() => onMove(1)}>
+            <ArrowDown className="w-3.5 h-3.5" aria-hidden="true" />
+          </Button>
+          <Button size="sm" variant="ghost" aria-label="Remove step" disabled={total === 1} onClick={onRemove}>
+            <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
+          </Button>
+        </span>
+      </div>
+      <div className="flex flex-wrap items-center gap-2 text-sm">
+        <Label className="text-xs" style={{ color: 'var(--ro-text-2)' }}>
+          {index === 0 ? 'Start' : 'Wait'}
+        </Label>
+        <Input
+          type="number" min={0} max={60} className="w-16"
+          value={step.delayDays}
+          onChange={(e) => set({ delayDays: e.target.value })}
+        />
+        <span className="text-xs" style={{ color: 'var(--ro-text-2)' }}>
+          {index === 0 ? 'day(s) after enrolling' : 'day(s) after the previous step'}
+        </span>
+        <Select value={step.timeWindow} onValueChange={(timeWindow) => set({ timeWindow })}>
+          <SelectTrigger className="w-[160px]"><SelectValue /></SelectTrigger>
+          <SelectContent>
+            {WINDOWS.map((w) => <SelectItem key={w.value} value={w.value}>{w.label}</SelectItem>)}
+          </SelectContent>
+        </Select>
+        {!isLast && (
+          <>
+            <Label className="text-xs ml-1" style={{ color: 'var(--ro-text-2)' }}>Continue when</Label>
+            <Select value={step.continueOn} onValueChange={(continueOn) => set({ continueOn })}>
+              <SelectTrigger className="w-[160px]"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                {(CONTINUE_OPTIONS[step.channel] || CONTINUE_OPTIONS.custom).map((o) => (
+                  <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </>
+        )}
+      </div>
+      <Textarea
+        rows={2}
+        value={step.script}
+        placeholder="Script / notes shown on the task ({{partner_name}}, {{contact_name}} merge in)"
+        onChange={(e) => set({ script: e.target.value })}
+      />
+      {isLast && (
+        <p className="text-[11.5px] m-0" style={{ color: 'var(--ro-text-3)' }}>
+          Last step — any outcome finishes the cadence. Replies and “not interested” always end it early.
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default function CadenceStudio() {
+  const queryClient = useQueryClient();
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editing, setEditing] = useState(null); // cadence being edited (null = new)
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [steps, setSteps] = useState([emptyStep()]);
+
+  const listQuery = useQuery({
+    queryKey: ['redeem-ops', 'cadences'],
+    queryFn: () => redeemOpsApi.listCadences(),
+    enabled: CADENCES_ENABLED,
+  });
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'cadences'] });
+
+  const saveMutation = useMutation({
+    mutationFn: (payload) => (editing
+      ? redeemOpsApi.createCadenceVersion(editing.id, payload)
+      : redeemOpsApi.createCadence(payload)),
+    onSuccess: (cadence) => {
+      setEditorOpen(false);
+      toast.success(editing
+        ? `Saved as v${cadence?.version} — businesses already enrolled finish on their current version`
+        : 'Cadence created — it’s available in every Start cadence picker now');
+      invalidate();
+    },
+    onError: (err) => toast.error('Could not save the cadence', { description: err.message }),
+  });
+  const retireMutation = useMutation({
+    mutationFn: (id) => redeemOpsApi.retireCadence(id),
+    onSuccess: () => { toast.success('Cadence retired — no new enrollments; running ones finish normally'); invalidate(); },
+    onError: (err) => toast.error('Could not retire', { description: err.message }),
+  });
+
+  if (!CADENCES_ENABLED) return null;
+
+  const openNew = () => {
+    setEditing(null); setName(''); setDescription(''); setSteps([emptyStep()]);
+    setEditorOpen(true);
+  };
+  const openEdit = (cadence) => {
+    setEditing(cadence); setName(cadence.name); setDescription(cadence.description || '');
+    setSteps(toBuilderSteps(cadence));
+    setEditorOpen(true);
+  };
+  const save = () => {
+    if (!name.trim()) return toast.error('Give the cadence a name');
+    if (steps.some((s) => !s.title.trim())) return toast.error('Every step needs a title');
+    return saveMutation.mutate({
+      name: name.trim(),
+      description: description.trim() || null,
+      steps: steps.map((s) => ({
+        channel: s.channel, title: s.title.trim(), script: s.script || null,
+        priority: s.priority, delayDays: Number(s.delayDays) || 0,
+        timeWindow: s.timeWindow, continueOn: s.continueOn,
+      })),
+    });
+  };
+
+  const cadences = listQuery.data || [];
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between space-y-0 gap-3">
+        <div>
+          <CardTitle className="text-base">Cadences</CardTitle>
+          <CardDescription>
+            The outreach sequences your team can enroll businesses into. Editing creates a new
+            version — businesses mid-cadence finish on the version they started.
+          </CardDescription>
+        </div>
+        <Button size="sm" onClick={openNew}>
+          <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" /> New cadence
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {cadences.map((c) => (
+          <div key={c.id} className="flex items-center gap-3 rounded-xl border border-border px-4 py-3">
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-semibold m-0">
+                {c.name} <span className="font-normal" style={{ color: 'var(--ro-text-3)' }}>v{c.version}</span>
+              </p>
+              <p className="text-xs m-0 mt-0.5 truncate" style={{ color: 'var(--ro-text-2)' }}>
+                {(c.steps || []).length} steps — {(c.steps || []).map((s) => CHANNEL_LABEL[s.channel] || s.channel).join(' → ')}
+              </p>
+            </div>
+            <Button size="sm" variant="ghost" aria-label={`Edit ${c.name}`} onClick={() => openEdit(c)}>
+              <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
+            </Button>
+            <Button
+              size="sm" variant="ghost"
+              disabled={retireMutation.isPending}
+              onClick={() => retireMutation.mutate(c.id)}
+            >
+              Retire
+            </Button>
+          </div>
+        ))}
+        {!listQuery.isLoading && cadences.length === 0 && (
+          <p className="text-sm text-center py-6 m-0" style={{ color: 'var(--ro-text-2)' }}>
+            No cadences yet — create the first sequence your team will run.
+          </p>
+        )}
+      </CardContent>
+
+      <Dialog open={editorOpen} onOpenChange={setEditorOpen}>
+        <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>{editing ? `Edit ${editing.name}` : 'New cadence'}</DialogTitle>
+            <DialogDescription>
+              {editing
+                ? `Saving creates v${editing.version + 1}. Businesses already enrolled keep following v${editing.version}.`
+                : 'Each step becomes a task in the owner’s queue at the right time.'}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="grid gap-2">
+              <Label htmlFor="cadence-name">Name</Label>
+              <Input id="cadence-name" value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Beauty salons — call-first" />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="cadence-desc">Description (optional)</Label>
+              <Input id="cadence-desc" value={description} onChange={(e) => setDescription(e.target.value)} placeholder="When should reps pick this one?" />
+            </div>
+            <div className="space-y-2.5">
+              {steps.map((s, i) => (
+                <StepEditor
+                  key={i}
+                  step={s} index={i} total={steps.length}
+                  onChange={(next) => setSteps(steps.map((x, j) => (j === i ? next : x)))}
+                  onRemove={() => setSteps(steps.filter((_, j) => j !== i))}
+                  onMove={(dir) => {
+                    const j = i + dir;
+                    const next = [...steps];
+                    [next[i], next[j]] = [next[j], next[i]];
+                    setSteps(next);
+                  }}
+                />
+              ))}
+            </div>
+            <Button variant="outline" size="sm" disabled={steps.length >= 20} onClick={() => setSteps([...steps, emptyStep('whatsapp')])}>
+              <Plus className="w-3.5 h-3.5 mr-1.5" aria-hidden="true" /> Add step
+            </Button>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditorOpen(false)}>Cancel</Button>
+            <Button disabled={saveMutation.isPending} onClick={save}>
+              {saveMutation.isPending ? 'Saving…' : editing ? `Save as v${editing.version + 1}` : 'Create cadence'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/src/components/redeemops/__tests__/cadence.test.jsx
+++ b/src/components/redeemops/__tests__/cadence.test.jsx
@@ -35,6 +35,7 @@ const toastMock = vi.hoisted(() => {
 vi.mock('sonner', () => ({ toast: toastMock }));
 
 import { CadenceOutcomeButton, CadenceChip, CadencePanel } from '../cadence';
+import { toBuilderSteps } from '../CadenceStudio';
 
 function wrap(ui) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -95,6 +96,26 @@ describe('CadenceOutcomeButton', () => {
     await waitFor(() => expect(api.completeCadenceTask).toHaveBeenCalledWith('task-1', {
       disposition: 'not_interested', alsoMarkLost: true, lostReason: 'not_interested',
     }));
+  });
+});
+
+describe('toBuilderSteps (edit prefill)', () => {
+  it('reverse-maps edges into the linear builder dialect', () => {
+    const cadence = {
+      steps: [
+        { id: 's1', stepOrder: 1, channel: 'call', title: 'Intro call', scriptTemplate: 'hi', priority: 'high' },
+        { id: 's2', stepOrder: 2, channel: 'whatsapp', title: 'WA intro', scriptTemplate: null, priority: 'medium' },
+      ],
+      transitions: [
+        { fromStepId: null, disposition: '*', toStepId: 's1', delayDays: 0, timeWindow: 'any' },
+        { fromStepId: 's1', disposition: 'no_answer', toStepId: 's2', delayDays: 2, timeWindow: 'off_peak' },
+      ],
+    };
+    const steps = toBuilderSteps(cadence);
+    expect(steps).toEqual([
+      { channel: 'call', title: 'Intro call', script: 'hi', priority: 'high', delayDays: 0, timeWindow: 'any', continueOn: 'no_answer' },
+      { channel: 'whatsapp', title: 'WA intro', script: '', priority: 'medium', delayDays: 2, timeWindow: 'off_peak', continueOn: '*' },
+    ]);
   });
 });
 

--- a/src/pages/redeemops/SettingsPage.jsx
+++ b/src/pages/redeemops/SettingsPage.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { redeemOpsApi } from '@/api/redeemOps';
+import CadenceStudio from '@/components/redeemops/CadenceStudio';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
@@ -111,7 +112,7 @@ export default function SettingsPage() {
     <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-6">
       <RoPageHeader
         title="Settings"
-        sub="Categories are managed here and picked everywhere else — partner forms, pools, imports, and the partners filter."
+        sub="Categories and cadences are managed here and picked everywhere else — partner forms, pools, imports, and the Start cadence menu."
       />
 
       <Card>
@@ -184,6 +185,8 @@ export default function SettingsPage() {
           </ul>
         </CardContent>
       </Card>
+
+      <CadenceStudio />
 
       <Dialog open={!!renameTarget} onOpenChange={(open) => { if (!open) setRenameTarget(null); }}>
         <DialogContent className="max-w-sm">


### PR DESCRIPTION
## What

You can now **create and edit cadences from the UI** (Settings → Cadences), instead of being limited to the two seeded ones. Follows the versioning contract from the design doc: definitions are immutable once enrolled — **editing creates vN+1 and retires vN in the same transaction; businesses mid-cadence finish on the version they started**.

## How it works

- The builder speaks a **linear dialect**: an ordered step list where each step carries its own delay + SGT time window and a single *continue when* outcome (e.g. call → "No answer only"); anything else finishes, and replies / not-interested always end it early (engine-level). That compiles losslessly onto the transition-edge model — both seeded cadences round-trip through the editor.
- **Create**: name → slugified immutable key (clash-suffixed), v1, active immediately in every Start-cadence picker.
- **Edit**: prefilled via edge→linear reverse-map, saves as vN+1, retires all active rows of the key atomically (advisory-locked).
- **Retire**: hides from pickers; running enrollments finish normally.
- Authoring is `settings.manage`-gated (super_admin / ops_admin) — same curation posture as categories; reading stays all-principals.

## Tests

- Backend: 4 new authoring tests — a builder-created cadence **runs end-to-end through the engine** (enroll → no-answer branch → advance), validation rejections (terminal continue-on, exec 403), **version-pinning of in-flight enrollments** (old edges still advance after the key is re-versioned), retire visibility. Suite now 28; full redeem-ops set **182/183** (the 1 = pre-existing rewards baseline).
- Frontend: `toBuilderSteps` round-trip test; **vitest 1125/1125**; vite build clean.

## Live behavior after deploy

No flags to flip — rides the existing `REDEEM_OPS_CADENCES_ENABLED` / `VITE_REDEEM_OPS_CADENCES_ENABLED` (already on). Settings page gains the Cadences card on next static-site deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)