### PR TITLE
feat(redeem-ops): full-page cadence editor — the dialog was too cramped

### DIFF
--- a/src/components/redeemops/CadenceStudio.jsx
+++ b/src/components/redeemops/CadenceStudio.jsx
@@ -1,168 +1,21 @@
-import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import Plus from 'lucide-react/icons/plus';
-import Trash2 from 'lucide-react/icons/trash-2';
-import ArrowUp from 'lucide-react/icons/arrow-up';
-import ArrowDown from 'lucide-react/icons/arrow-down';
 import Pencil from 'lucide-react/icons/pencil';
 import { redeemOpsApi } from '@/api/redeemOps';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import {
-  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
-} from '@/components/ui/dialog';
-import {
-  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
-} from '@/components/ui/select';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
 import { CADENCES_ENABLED } from '@/components/redeemops/cadence';
-
-const CHANNELS = [
-  { value: 'call', label: 'Call' },
-  { value: 'whatsapp', label: 'WhatsApp' },
-  { value: 'email', label: 'Email' },
-  { value: 'instagram_dm', label: 'Instagram DM' },
-  { value: 'visit', label: 'Walk-in visit' },
-  { value: 'custom', label: 'Custom step' },
-];
-const WINDOWS = [
-  { value: 'any', label: 'Any time' },
-  { value: 'morning', label: 'Morning (9:30)' },
-  { value: 'afternoon', label: 'Afternoon (15:00)' },
-  { value: 'off_peak', label: 'Off-peak (15:00–17:00)' },
-];
-/** Non-terminal outcomes that may advance to the next step, per channel. */
-const CONTINUE_OPTIONS = {
-  call: [{ value: '*', label: 'Any outcome' }, { value: 'no_answer', label: 'No answer only' }, { value: 'connected', label: 'Connected only' }],
-  whatsapp: [{ value: '*', label: 'Any outcome' }, { value: 'sent', label: 'Sent' }],
-  email: [{ value: '*', label: 'Any outcome' }, { value: 'sent', label: 'Sent' }],
-  instagram_dm: [{ value: '*', label: 'Any outcome' }, { value: 'sent', label: 'Sent' }],
-  visit: [{ value: '*', label: 'Any outcome' }, { value: 'met', label: 'Met only' }, { value: 'closed', label: 'Outlet closed only' }],
-  custom: [{ value: '*', label: 'Any outcome' }, { value: 'done', label: 'Done' }],
-};
-const CHANNEL_LABEL = Object.fromEntries(CHANNELS.map((c) => [c.value, c.label]));
-
-const emptyStep = (channel = 'call') => ({
-  channel, title: '', script: '', priority: 'medium',
-  delayDays: 0, timeWindow: 'any', continueOn: channel === 'call' ? 'no_answer' : '*',
-});
+import { CHANNEL_LABEL } from '@/components/redeemops/cadenceBuilder';
 
 /**
- * Reverse-map a stored cadence (steps + transition edges) into the builder's
- * linear dialect: each step's delay/window ride its INCOMING edge, its
- * continue-on is the OUTGOING edge to the next step. Both seeded cadences and
- * everything the builder saves are linear, so the round-trip is lossless.
+ * Settings → Cadences: the list. Creating and editing happen on the dedicated
+ * full-page editor (/redeem-ops/cadences/new, /redeem-ops/cadences/:id/edit) —
+ * a dialog was too cramped for a step editor.
  */
-export function toBuilderSteps(cadence) {
-  const steps = [...(cadence.steps || [])].sort((a, b) => a.stepOrder - b.stepOrder);
-  const byFrom = {};
-  let entry = null;
-  for (const t of cadence.transitions || []) {
-    if (t.fromStepId) byFrom[t.fromStepId] = t;
-    else entry = t;
-  }
-  return steps.map((s, i) => {
-    const incoming = i === 0 ? entry : byFrom[steps[i - 1].id];
-    const outgoing = byFrom[s.id];
-    return {
-      channel: s.channel,
-      title: s.title,
-      script: s.scriptTemplate || '',
-      priority: s.priority || 'medium',
-      delayDays: incoming?.delayDays ?? 0,
-      timeWindow: incoming?.timeWindow || 'any',
-      continueOn: outgoing?.disposition || '*',
-    };
-  });
-}
-
-function StepEditor({ step, index, total, onChange, onRemove, onMove }) {
-  const set = (patch) => onChange({ ...step, ...patch });
-  const isLast = index === total - 1;
-  return (
-    <div className="rounded-xl border border-border p-3.5 space-y-2.5">
-      <div className="flex items-center gap-2">
-        <span className="text-xs font-bold w-5 shrink-0" style={{ color: 'var(--ro-text-3)' }}>{index + 1}.</span>
-        <Select value={step.channel} onValueChange={(channel) => set({ channel, continueOn: channel === 'call' ? 'no_answer' : '*' })}>
-          <SelectTrigger className="w-[150px] shrink-0"><SelectValue /></SelectTrigger>
-          <SelectContent>
-            {CHANNELS.map((c) => <SelectItem key={c.value} value={c.value}>{c.label}</SelectItem>)}
-          </SelectContent>
-        </Select>
-        <Input
-          value={step.title}
-          placeholder="Step title (becomes the task title)"
-          onChange={(e) => set({ title: e.target.value })}
-        />
-        <span className="inline-flex gap-0.5 shrink-0">
-          <Button size="sm" variant="ghost" aria-label="Move up" disabled={index === 0} onClick={() => onMove(-1)}>
-            <ArrowUp className="w-3.5 h-3.5" aria-hidden="true" />
-          </Button>
-          <Button size="sm" variant="ghost" aria-label="Move down" disabled={isLast} onClick={() => onMove(1)}>
-            <ArrowDown className="w-3.5 h-3.5" aria-hidden="true" />
-          </Button>
-          <Button size="sm" variant="ghost" aria-label="Remove step" disabled={total === 1} onClick={onRemove}>
-            <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
-          </Button>
-        </span>
-      </div>
-      <div className="flex flex-wrap items-center gap-2 text-sm">
-        <Label className="text-xs" style={{ color: 'var(--ro-text-2)' }}>
-          {index === 0 ? 'Start' : 'Wait'}
-        </Label>
-        <Input
-          type="number" min={0} max={60} className="w-16"
-          value={step.delayDays}
-          onChange={(e) => set({ delayDays: e.target.value })}
-        />
-        <span className="text-xs" style={{ color: 'var(--ro-text-2)' }}>
-          {index === 0 ? 'day(s) after enrolling' : 'day(s) after the previous step'}
-        </span>
-        <Select value={step.timeWindow} onValueChange={(timeWindow) => set({ timeWindow })}>
-          <SelectTrigger className="w-[160px]"><SelectValue /></SelectTrigger>
-          <SelectContent>
-            {WINDOWS.map((w) => <SelectItem key={w.value} value={w.value}>{w.label}</SelectItem>)}
-          </SelectContent>
-        </Select>
-        {!isLast && (
-          <>
-            <Label className="text-xs ml-1" style={{ color: 'var(--ro-text-2)' }}>Continue when</Label>
-            <Select value={step.continueOn} onValueChange={(continueOn) => set({ continueOn })}>
-              <SelectTrigger className="w-[160px]"><SelectValue /></SelectTrigger>
-              <SelectContent>
-                {(CONTINUE_OPTIONS[step.channel] || CONTINUE_OPTIONS.custom).map((o) => (
-                  <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </>
-        )}
-      </div>
-      <Textarea
-        rows={2}
-        value={step.script}
-        placeholder="Script / notes shown on the task ({{partner_name}}, {{contact_name}} merge in)"
-        onChange={(e) => set({ script: e.target.value })}
-      />
-      {isLast && (
-        <p className="text-[11.5px] m-0" style={{ color: 'var(--ro-text-3)' }}>
-          Last step — any outcome finishes the cadence. Replies and “not interested” always end it early.
-        </p>
-      )}
-    </div>
-  );
-}
-
 export default function CadenceStudio() {
   const queryClient = useQueryClient();
-  const [editorOpen, setEditorOpen] = useState(false);
-  const [editing, setEditing] = useState(null); // cadence being edited (null = new)
-  const [name, setName] = useState('');
-  const [description, setDescription] = useState('');
-  const [steps, setSteps] = useState([emptyStep()]);
 
   const listQuery = useQuery({
     queryKey: ['redeem-ops', 'cadences'],
@@ -170,51 +23,16 @@ export default function CadenceStudio() {
     enabled: CADENCES_ENABLED,
   });
 
-  const invalidate = () => queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'cadences'] });
-
-  const saveMutation = useMutation({
-    mutationFn: (payload) => (editing
-      ? redeemOpsApi.createCadenceVersion(editing.id, payload)
-      : redeemOpsApi.createCadence(payload)),
-    onSuccess: (cadence) => {
-      setEditorOpen(false);
-      toast.success(editing
-        ? `Saved as v${cadence?.version} — businesses already enrolled finish on their current version`
-        : 'Cadence created — it’s available in every Start cadence picker now');
-      invalidate();
-    },
-    onError: (err) => toast.error('Could not save the cadence', { description: err.message }),
-  });
   const retireMutation = useMutation({
     mutationFn: (id) => redeemOpsApi.retireCadence(id),
-    onSuccess: () => { toast.success('Cadence retired — no new enrollments; running ones finish normally'); invalidate(); },
+    onSuccess: () => {
+      toast.success('Cadence retired — no new enrollments; running ones finish normally');
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'cadences'] });
+    },
     onError: (err) => toast.error('Could not retire', { description: err.message }),
   });
 
   if (!CADENCES_ENABLED) return null;
-
-  const openNew = () => {
-    setEditing(null); setName(''); setDescription(''); setSteps([emptyStep()]);
-    setEditorOpen(true);
-  };
-  const openEdit = (cadence) => {
-    setEditing(cadence); setName(cadence.name); setDescription(cadence.description || '');
-    setSteps(toBuilderSteps(cadence));
-    setEditorOpen(true);
-  };
-  const save = () => {
-    if (!name.trim()) return toast.error('Give the cadence a name');
-    if (steps.some((s) => !s.title.trim())) return toast.error('Every step needs a title');
-    return saveMutation.mutate({
-      name: name.trim(),
-      description: description.trim() || null,
-      steps: steps.map((s) => ({
-        channel: s.channel, title: s.title.trim(), script: s.script || null,
-        priority: s.priority, delayDays: Number(s.delayDays) || 0,
-        timeWindow: s.timeWindow, continueOn: s.continueOn,
-      })),
-    });
-  };
 
   const cadences = listQuery.data || [];
 
@@ -228,8 +46,10 @@ export default function CadenceStudio() {
             version — businesses mid-cadence finish on the version they started.
           </CardDescription>
         </div>
-        <Button size="sm" onClick={openNew}>
-          <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" /> New cadence
+        <Button size="sm" asChild>
+          <Link to="/redeem-ops/cadences/new">
+            <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" /> New cadence
+          </Link>
         </Button>
       </CardHeader>
       <CardContent className="space-y-2">
@@ -243,8 +63,10 @@ export default function CadenceStudio() {
                 {(c.steps || []).length} steps — {(c.steps || []).map((s) => CHANNEL_LABEL[s.channel] || s.channel).join(' → ')}
               </p>
             </div>
-            <Button size="sm" variant="ghost" aria-label={`Edit ${c.name}`} onClick={() => openEdit(c)}>
-              <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
+            <Button size="sm" variant="ghost" aria-label={`Edit ${c.name}`} asChild>
+              <Link to={`/redeem-ops/cadences/${c.id}/edit`}>
+                <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
+              </Link>
             </Button>
             <Button
               size="sm" variant="ghost"
@@ -261,54 +83,6 @@ export default function CadenceStudio() {
           </p>
         )}
       </CardContent>
-
-      <Dialog open={editorOpen} onOpenChange={setEditorOpen}>
-        <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>{editing ? `Edit ${editing.name}` : 'New cadence'}</DialogTitle>
-            <DialogDescription>
-              {editing
-                ? `Saving creates v${editing.version + 1}. Businesses already enrolled keep following v${editing.version}.`
-                : 'Each step becomes a task in the owner’s queue at the right time.'}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-3">
-            <div className="grid gap-2">
-              <Label htmlFor="cadence-name">Name</Label>
-              <Input id="cadence-name" value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Beauty salons — call-first" />
-            </div>
-            <div className="grid gap-2">
-              <Label htmlFor="cadence-desc">Description (optional)</Label>
-              <Input id="cadence-desc" value={description} onChange={(e) => setDescription(e.target.value)} placeholder="When should reps pick this one?" />
-            </div>
-            <div className="space-y-2.5">
-              {steps.map((s, i) => (
-                <StepEditor
-                  key={i}
-                  step={s} index={i} total={steps.length}
-                  onChange={(next) => setSteps(steps.map((x, j) => (j === i ? next : x)))}
-                  onRemove={() => setSteps(steps.filter((_, j) => j !== i))}
-                  onMove={(dir) => {
-                    const j = i + dir;
-                    const next = [...steps];
-                    [next[i], next[j]] = [next[j], next[i]];
-                    setSteps(next);
-                  }}
-                />
-              ))}
-            </div>
-            <Button variant="outline" size="sm" disabled={steps.length >= 20} onClick={() => setSteps([...steps, emptyStep('whatsapp')])}>
-              <Plus className="w-3.5 h-3.5 mr-1.5" aria-hidden="true" /> Add step
-            </Button>
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setEditorOpen(false)}>Cancel</Button>
-            <Button disabled={saveMutation.isPending} onClick={save}>
-              {saveMutation.isPending ? 'Saving…' : editing ? `Save as v${editing.version + 1}` : 'Create cadence'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </Card>
   );
 }

--- a/src/components/redeemops/__tests__/cadence.test.jsx
+++ b/src/components/redeemops/__tests__/cadence.test.jsx
@@ -9,7 +9,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
 
 vi.hoisted(() => {
   vi.stubEnv('VITE_REDEEM_OPS_CADENCES_ENABLED', 'true');
@@ -23,6 +23,9 @@ const api = vi.hoisted(() => ({
   pauseCadence: vi.fn(),
   resumeCadence: vi.fn(),
   stopCadence: vi.fn(),
+  createCadence: vi.fn(),
+  createCadenceVersion: vi.fn(),
+  retireCadence: vi.fn(),
 }));
 vi.mock('@/api/redeemOps', () => ({ redeemOpsApi: api }));
 
@@ -35,7 +38,8 @@ const toastMock = vi.hoisted(() => {
 vi.mock('sonner', () => ({ toast: toastMock }));
 
 import { CadenceOutcomeButton, CadenceChip, CadencePanel } from '../cadence';
-import { toBuilderSteps } from '../CadenceStudio';
+import { toBuilderSteps } from '../cadenceBuilder';
+import CadenceEditorPage from '@/pages/redeemops/CadenceEditorPage';
 
 function wrap(ui) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -116,6 +120,50 @@ describe('toBuilderSteps (edit prefill)', () => {
       { channel: 'call', title: 'Intro call', script: 'hi', priority: 'high', delayDays: 0, timeWindow: 'any', continueOn: 'no_answer' },
       { channel: 'whatsapp', title: 'WA intro', script: '', priority: 'medium', delayDays: 2, timeWindow: 'off_peak', continueOn: '*' },
     ]);
+  });
+});
+
+describe('CadenceEditorPage (full-page builder)', () => {
+  function renderNew() {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return render(
+      <QueryClientProvider client={qc}>
+        <MemoryRouter initialEntries={['/redeem-ops/cadences/new']}>
+          <Routes>
+            <Route path="/redeem-ops/cadences/new" element={<CadenceEditorPage />} />
+            <Route path="/redeem-ops/settings" element={<p>settings page</p>} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  }
+
+  it('creates a cadence from the mapped builder state', async () => {
+    api.createCadence.mockResolvedValue({ id: 'c-new', version: 1 });
+    const user = userEvent.setup();
+    renderNew();
+
+    await user.type(screen.getByPlaceholderText(/beauty salons/i), 'Fitness studios chase');
+    await user.type(screen.getByPlaceholderText(/what the rep sees/i), 'Intro call');
+    await user.click(screen.getByRole('button', { name: /add step/i }));
+    const titles = screen.getAllByPlaceholderText(/what the rep sees/i);
+    await user.type(titles[1], 'WhatsApp follow-up');
+
+    await user.click(screen.getByRole('button', { name: /create cadence/i }));
+    await waitFor(() => expect(api.createCadence).toHaveBeenCalledTimes(1));
+    const payload = api.createCadence.mock.calls[0][0];
+    expect(payload.name).toBe('Fitness studios chase');
+    expect(payload.steps).toHaveLength(2);
+    expect(payload.steps[0]).toMatchObject({ channel: 'call', title: 'Intro call', continueOn: 'no_answer' });
+    expect(payload.steps[1]).toMatchObject({ channel: 'whatsapp', title: 'WhatsApp follow-up' });
+  });
+
+  it('refuses to save without a name', async () => {
+    const user = userEvent.setup();
+    renderNew();
+    await user.click(screen.getByRole('button', { name: /create cadence/i }));
+    expect(api.createCadence).not.toHaveBeenCalled();
+    expect(toastMock.error).toHaveBeenCalled();
   });
 });
 

--- a/src/components/redeemops/cadenceBuilder.js
+++ b/src/components/redeemops/cadenceBuilder.js
@@ -1,0 +1,95 @@
+/**
+ * Shared builder vocabulary + mapping helpers for the cadence editor
+ * (docs/plans/redeem-ops-cadences.md §8.5). Pure module — no JSX — imported by
+ * the editor page, the Settings list, and tests.
+ */
+
+export const CHANNELS = [
+  { value: 'call', label: 'Call' },
+  { value: 'whatsapp', label: 'WhatsApp' },
+  { value: 'email', label: 'Email' },
+  { value: 'instagram_dm', label: 'Instagram DM' },
+  { value: 'visit', label: 'Walk-in visit' },
+  { value: 'custom', label: 'Custom step' },
+];
+
+export const WINDOWS = [
+  { value: 'any', label: 'Any time' },
+  { value: 'morning', label: 'Morning (9:30)' },
+  { value: 'afternoon', label: 'Afternoon (15:00)' },
+  { value: 'off_peak', label: 'Off-peak (15:00–17:00)' },
+];
+
+export const PRIORITIES = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+];
+
+/** Non-terminal outcomes that may advance to the next step, per channel. */
+export const CONTINUE_OPTIONS = {
+  call: [{ value: '*', label: 'Any outcome' }, { value: 'no_answer', label: 'No answer only' }, { value: 'connected', label: 'Connected only' }],
+  whatsapp: [{ value: '*', label: 'Any outcome' }, { value: 'sent', label: 'Sent' }],
+  email: [{ value: '*', label: 'Any outcome' }, { value: 'sent', label: 'Sent' }],
+  instagram_dm: [{ value: '*', label: 'Any outcome' }, { value: 'sent', label: 'Sent' }],
+  visit: [{ value: '*', label: 'Any outcome' }, { value: 'met', label: 'Met only' }, { value: 'closed', label: 'Outlet closed only' }],
+  custom: [{ value: '*', label: 'Any outcome' }, { value: 'done', label: 'Done' }],
+};
+
+export const CHANNEL_LABEL = Object.fromEntries(CHANNELS.map((c) => [c.value, c.label]));
+
+export const emptyStep = (channel = 'call') => ({
+  channel, title: '', script: '', priority: 'medium',
+  delayDays: 0, timeWindow: 'any', continueOn: channel === 'call' ? 'no_answer' : '*',
+});
+
+/**
+ * Reverse-map a stored cadence (steps + transition edges) into the builder's
+ * linear dialect: each step's delay/window ride its INCOMING edge, its
+ * continue-on is the OUTGOING edge to the next step. Both seeded cadences and
+ * everything the builder saves are linear, so the round-trip is lossless.
+ */
+export function toBuilderSteps(cadence) {
+  const steps = [...(cadence.steps || [])].sort((a, b) => a.stepOrder - b.stepOrder);
+  const byFrom = {};
+  let entry = null;
+  for (const t of cadence.transitions || []) {
+    if (t.fromStepId) byFrom[t.fromStepId] = t;
+    else entry = t;
+  }
+  return steps.map((s, i) => {
+    const incoming = i === 0 ? entry : byFrom[steps[i - 1].id];
+    const outgoing = byFrom[s.id];
+    return {
+      channel: s.channel,
+      title: s.title,
+      script: s.scriptTemplate || '',
+      priority: s.priority || 'medium',
+      delayDays: incoming?.delayDays ?? 0,
+      timeWindow: incoming?.timeWindow || 'any',
+      continueOn: outgoing?.disposition || '*',
+    };
+  });
+}
+
+/** "≈ Day N" markers: cumulative delay down the continue path. */
+export function cumulativeDays(steps) {
+  let day = 0;
+  return steps.map((s) => {
+    day += Number(s.delayDays) || 0;
+    return day;
+  });
+}
+
+/** Builder state → API payload. */
+export function toPayload({ name, description, steps }) {
+  return {
+    name: name.trim(),
+    description: (description || '').trim() || null,
+    steps: steps.map((s) => ({
+      channel: s.channel, title: s.title.trim(), script: s.script || null,
+      priority: s.priority, delayDays: Number(s.delayDays) || 0,
+      timeWindow: s.timeWindow, continueOn: s.continueOn,
+    })),
+  };
+}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -80,6 +80,7 @@ const AgentProfile = lazy(() => import('./AgentProfile'));
 // Dark until VITE_REDEEM_OPS_ENABLED=true is baked into the build.
 const REDEEM_OPS_ENABLED = import.meta.env.VITE_REDEEM_OPS_ENABLED === 'true';
 const DISCOVERY_ENABLED = import.meta.env.VITE_DISCOVERY_ENABLED === 'true';
+const CADENCES_ENABLED = import.meta.env.VITE_REDEEM_OPS_CADENCES_ENABLED === 'true';
 const RedeemOpsHome = lazy(() => import('./redeemops/RedeemOpsHome'));
 const RedeemOpsTeam = lazy(() => import('./redeemops/RedeemOpsTeam'));
 const RedeemOpsPartnersList = lazy(() => import('./redeemops/PartnersList'));
@@ -97,6 +98,7 @@ const RedeemOpsRedemptions = lazy(() => import('./redeemops/RedemptionsPage'));
 const RedeemOpsAnalytics = lazy(() => import('./redeemops/AnalyticsPage'));
 const RedeemOpsProfile = lazy(() => import('./redeemops/ProfilePage'));
 const RedeemOpsSettings = lazy(() => import('./redeemops/SettingsPage'));
+const RedeemOpsCadenceEditor = lazy(() => import('./redeemops/CadenceEditorPage'));
 
 // ops.redeem.sg — dedicated staff surface (docs/redeem-ops/
 // USER_SURFACES_AND_DEPLOYMENT_BOUNDARIES.md). Mirrors the VITE_BRAND pattern:
@@ -131,6 +133,11 @@ function redeemOpsRouteElements() {
     { path: '/redeem-ops/analytics', capability: 'analytics.view_own', Page: RedeemOpsAnalytics },
     { path: '/redeem-ops/profile', capability: null, Page: RedeemOpsProfile },
     { path: '/redeem-ops/settings', capability: 'settings.manage', Page: RedeemOpsSettings },
+    // Full-page cadence editor (a dialog was too cramped for a step editor).
+    ...(CADENCES_ENABLED ? [
+      { path: '/redeem-ops/cadences/new', capability: 'settings.manage', Page: RedeemOpsCadenceEditor },
+      { path: '/redeem-ops/cadences/:cadenceId/edit', capability: 'settings.manage', Page: RedeemOpsCadenceEditor },
+    ] : []),
   ];
   return routes.map(({ path, capability, Page }) => (
     <Route

--- a/src/pages/redeemops/CadenceEditorPage.jsx
+++ b/src/pages/redeemops/CadenceEditorPage.jsx
@@ -1,0 +1,292 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import Plus from 'lucide-react/icons/plus';
+import Trash2 from 'lucide-react/icons/trash-2';
+import ArrowUp from 'lucide-react/icons/arrow-up';
+import ArrowDown from 'lucide-react/icons/arrow-down';
+import Zap from 'lucide-react/icons/zap';
+import { redeemOpsApi } from '@/api/redeemOps';
+import { Button } from '@/components/ui/button';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { RoPageHeader } from '@/components/redeemops/ui';
+import {
+  CHANNELS, WINDOWS, PRIORITIES, CONTINUE_OPTIONS, CHANNEL_LABEL,
+  emptyStep, toBuilderSteps, cumulativeDays, toPayload,
+} from '@/components/redeemops/cadenceBuilder';
+
+function Field({ label, children, className = '' }) {
+  return (
+    <div className={`grid gap-1.5 ${className}`}>
+      <Label className="text-xs font-semibold" style={{ color: 'var(--ro-text-2)' }}>{label}</Label>
+      {children}
+    </div>
+  );
+}
+
+function StepCard({ step, index, total, dayMark, onChange, onRemove, onMove }) {
+  const set = (patch) => onChange({ ...step, ...patch });
+  const isLast = index === total - 1;
+  return (
+    <div className="relative pl-12">
+      {/* timeline gutter: numbered bubble + connector */}
+      <div className="absolute left-0 top-0 bottom-0 flex flex-col items-center w-8">
+        <span
+          className="w-8 h-8 rounded-full flex items-center justify-center text-[13px] font-bold shrink-0 bg-white border border-border"
+          style={{ color: 'var(--ro-bunker, #0D1619)' }}
+        >
+          {index + 1}
+        </span>
+        {!isLast && <span className="w-px flex-1 mt-1" style={{ background: 'var(--ro-subtle)' }} />}
+      </div>
+
+      <div className="rounded-2xl border border-border bg-white p-4 md:p-5 space-y-3.5">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-[11.5px] font-bold uppercase tracking-wide" style={{ color: 'var(--ro-text-3)' }}>
+            Step {index + 1} · ≈ Day {dayMark}
+          </span>
+          <span className="inline-flex gap-0.5">
+            <Button size="sm" variant="ghost" aria-label="Move step up" disabled={index === 0} onClick={() => onMove(-1)}>
+              <ArrowUp className="w-3.5 h-3.5" aria-hidden="true" />
+            </Button>
+            <Button size="sm" variant="ghost" aria-label="Move step down" disabled={isLast} onClick={() => onMove(1)}>
+              <ArrowDown className="w-3.5 h-3.5" aria-hidden="true" />
+            </Button>
+            <Button size="sm" variant="ghost" aria-label="Remove step" disabled={total === 1} onClick={onRemove}>
+              <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
+            </Button>
+          </span>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-[170px_1fr_130px]">
+          <Field label="Channel">
+            <Select value={step.channel} onValueChange={(channel) => set({ channel, continueOn: channel === 'call' ? 'no_answer' : '*' })}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                {CHANNELS.map((c) => <SelectItem key={c.value} value={c.value}>{c.label}</SelectItem>)}
+              </SelectContent>
+            </Select>
+          </Field>
+          <Field label="Task title">
+            <Input
+              value={step.title}
+              placeholder="What the rep sees in their queue"
+              onChange={(e) => set({ title: e.target.value })}
+            />
+          </Field>
+          <Field label="Priority">
+            <Select value={step.priority} onValueChange={(priority) => set({ priority })}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                {PRIORITIES.map((p) => <SelectItem key={p.value} value={p.value}>{p.label}</SelectItem>)}
+              </SelectContent>
+            </Select>
+          </Field>
+        </div>
+
+        <div className={`grid gap-3 ${isLast ? 'sm:grid-cols-2' : 'sm:grid-cols-3'}`}>
+          <Field label={index === 0 ? 'Start (days after enrolling)' : 'Wait (days after previous step)'}>
+            <Input
+              type="number" min={0} max={60}
+              value={step.delayDays}
+              onChange={(e) => set({ delayDays: e.target.value })}
+            />
+          </Field>
+          <Field label="Time window (SGT)">
+            <Select value={step.timeWindow} onValueChange={(timeWindow) => set({ timeWindow })}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                {WINDOWS.map((w) => <SelectItem key={w.value} value={w.value}>{w.label}</SelectItem>)}
+              </SelectContent>
+            </Select>
+          </Field>
+          {!isLast && (
+            <Field label="Continue to next step when">
+              <Select value={step.continueOn} onValueChange={(continueOn) => set({ continueOn })}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {(CONTINUE_OPTIONS[step.channel] || CONTINUE_OPTIONS.custom).map((o) => (
+                    <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Field>
+          )}
+        </div>
+
+        <Field label="Script / notes (shown on the task)">
+          <Textarea
+            rows={4}
+            value={step.script}
+            placeholder={'Hi {{contact_name}}, calling about {{partner_name}} — …'}
+            onChange={(e) => set({ script: e.target.value })}
+          />
+        </Field>
+
+        {isLast && (
+          <p className="text-[12px] m-0" style={{ color: 'var(--ro-text-3)' }}>
+            Last step — any outcome finishes the cadence.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function CadenceEditorPage() {
+  const { cadenceId } = useParams();
+  const isNew = !cadenceId;
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [steps, setSteps] = useState([emptyStep()]);
+  const [loadedFrom, setLoadedFrom] = useState(null);
+
+  const listQuery = useQuery({
+    queryKey: ['redeem-ops', 'cadences', 'all'],
+    queryFn: () => redeemOpsApi.listCadences({ all: 'true' }),
+    enabled: !isNew,
+  });
+  const base = isNew ? null : (listQuery.data || []).find((c) => c.id === cadenceId);
+
+  useEffect(() => {
+    if (base && loadedFrom !== base.id) {
+      setName(base.name);
+      setDescription(base.description || '');
+      setSteps(toBuilderSteps(base));
+      setLoadedFrom(base.id);
+    }
+  }, [base, loadedFrom]);
+
+  useEffect(() => {
+    if (!isNew && listQuery.isSuccess && !base) {
+      toast.error('Cadence not found');
+      navigate('/redeem-ops/settings', { replace: true });
+    }
+  }, [isNew, listQuery.isSuccess, base, navigate]);
+
+  const saveMutation = useMutation({
+    mutationFn: (payload) => (isNew
+      ? redeemOpsApi.createCadence(payload)
+      : redeemOpsApi.createCadenceVersion(cadenceId, payload)),
+    onSuccess: (cadence) => {
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'cadences'] });
+      toast.success(isNew
+        ? 'Cadence created — it’s in every Start cadence picker now'
+        : `Saved as v${cadence?.version} — businesses already enrolled finish on their current version`);
+      navigate('/redeem-ops/settings');
+    },
+    onError: (err) => toast.error('Could not save the cadence', { description: err.message }),
+  });
+
+  const save = () => {
+    if (!name.trim()) return toast.error('Give the cadence a name');
+    if (steps.some((s) => !s.title.trim())) return toast.error('Every step needs a title');
+    return saveMutation.mutate(toPayload({ name, description, steps }));
+  };
+
+  const dayMarks = useMemo(() => cumulativeDays(steps), [steps]);
+  const spanDays = dayMarks[dayMarks.length - 1] || 0;
+
+  if (!isNew && listQuery.isLoading) {
+    return <div className="p-8" style={{ color: 'var(--ro-text-2)' }}>Loading cadence…</div>;
+  }
+
+  return (
+    <div className="p-4 md:p-8 max-w-6xl mx-auto space-y-5">
+      <RoPageHeader
+        title={isNew ? 'New cadence' : `Edit — ${base?.name || ''}`}
+        sub={isNew
+          ? 'Each step becomes a task in the owner’s queue at the right time. Replies and “not interested” always end the cadence early.'
+          : `Saving creates v${(base?.version || 1) + 1}. Businesses already enrolled keep following v${base?.version}.`}
+        actions={(
+          <span className="inline-flex gap-2">
+            <Button variant="outline" asChild>
+              <Link to="/redeem-ops/settings">Cancel</Link>
+            </Button>
+            <Button disabled={saveMutation.isPending} onClick={save}>
+              {saveMutation.isPending ? 'Saving…' : isNew ? 'Create cadence' : `Save as v${(base?.version || 1) + 1}`}
+            </Button>
+          </span>
+        )}
+      />
+
+      <div className="grid gap-5 lg:grid-cols-[1fr_300px] items-start">
+        <div className="space-y-4">
+          <div className="rounded-2xl border border-border bg-white p-4 md:p-5 grid gap-3.5">
+            <Field label="Name">
+              <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Beauty salons — call-first" />
+            </Field>
+            <Field label="Description (optional — when should reps pick this one?)">
+              <Input value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Cold chase for beauty & wellness outlets" />
+            </Field>
+          </div>
+
+          <div className="space-y-4">
+            {steps.map((s, i) => (
+              <StepCard
+                key={i}
+                step={s} index={i} total={steps.length} dayMark={dayMarks[i]}
+                onChange={(next) => setSteps(steps.map((x, j) => (j === i ? next : x)))}
+                onRemove={() => setSteps(steps.filter((_, j) => j !== i))}
+                onMove={(dir) => {
+                  const j = i + dir;
+                  const next = [...steps];
+                  [next[i], next[j]] = [next[j], next[i]];
+                  setSteps(next);
+                }}
+              />
+            ))}
+          </div>
+
+          <div className="pl-12">
+            <Button variant="outline" disabled={steps.length >= 20} onClick={() => setSteps([...steps, emptyStep('whatsapp')])}>
+              <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" /> Add step
+            </Button>
+          </div>
+        </div>
+
+        <div className="space-y-4 lg:sticky lg:top-6">
+          <div className="rounded-2xl border border-border bg-white p-5">
+            <p className="text-[15px] font-bold m-0 mb-2">
+              <Zap className="w-4 h-4 inline mr-1 -mt-0.5" aria-hidden="true" /> Summary
+            </p>
+            <p className="text-[13px] m-0 leading-relaxed" style={{ color: 'var(--ro-text-2)' }}>
+              {steps.length} step{steps.length === 1 ? '' : 's'} over ≈ {spanDays} day{spanDays === 1 ? '' : 's'}
+            </p>
+            <p className="text-[13px] mt-1.5 mb-0 leading-relaxed" style={{ color: 'var(--ro-text-2)' }}>
+              {steps.map((s) => CHANNEL_LABEL[s.channel] || s.channel).join(' → ')}
+            </p>
+          </div>
+
+          <div className="rounded-2xl border border-border bg-white p-5">
+            <p className="text-[15px] font-bold m-0 mb-2">Merge fields</p>
+            <p className="text-[12.5px] m-0 leading-relaxed" style={{ color: 'var(--ro-text-2)' }}>
+              Scripts can use <code>{'{{partner_name}}'}</code>, <code>{'{{contact_name}}'}</code>,{' '}
+              <code>{'{{category}}'}</code> and <code>{'{{recipient}}'}</code> — filled in when each
+              task is created. An unknown field blocks the step, so stick to these.
+            </p>
+          </div>
+
+          <div className="rounded-2xl border border-border bg-white p-5">
+            <p className="text-[15px] font-bold m-0 mb-2">How steps advance</p>
+            <p className="text-[12.5px] m-0 leading-relaxed" style={{ color: 'var(--ro-text-2)' }}>
+              A step only reaches the next one on its “continue when” outcome. Replies and
+              “not interested” end the cadence immediately; moving the business to Meeting or
+              beyond, snoozing, or releasing it stops the schedule automatically. Steps that can’t
+              reach anyone (no phone or handle on record) are skipped.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

The cadence editor/creator moves from a dialog to a **dedicated full page** (user feedback: the dialog was cramped). Frontend-only — no backend changes.

- **Routes**: `/redeem-ops/cadences/new` and `/redeem-ops/cadences/:id/edit` — `settings.manage`-gated, registered behind the cadence flag (same pattern as Discover's route), shared verbatim between mktr.sg and ops.redeem.sg builds.
- **The page**: timeline gutter (numbered bubbles + connectors) with a computed **≈ Day N** marker per step; roomier step cards — channel / title / **priority** (which the dialog never exposed) on one row, start-vs-wait timing + SGT window + continue-when on the next, 4-row script field; sticky rail with a live summary (step count, span in days, channel flow), a merge-fields cheatsheet, and a plain-language "how steps advance" explainer; header carries the versioning copy (**Save as vN+1** — in-flight enrollments finish on their version).
- **Settings card** slims to the cadence list; New/Edit navigate to the page. Shared vocabulary + `toBuilderSteps`/`cumulativeDays`/`toPayload` extracted to `cadenceBuilder.js` (pure module).

## Tests

3 new vitest cases (create flow maps builder state → API payload incl. defaulted continue-when; name-required guard; round-trip mapping already covered) — **vitest 1127/1127**, vite build clean.

## Live behavior after deploy

Rides the existing flags (already on) — Settings → Cadences → New/Edit will open the full page after the static sites redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)