### PR TITLE
feat(lucky-draw): Phase 1 — server-enforced draw entries, terms versioning, via derivation, draw email

### DIFF
--- a/backend/src/database/migrations/058-lucky-draw-terms.js
+++ b/backend/src/database/migrations/058-lucky-draw-terms.js
@@ -1,0 +1,29 @@
+/**
+ * Lucky draw Phase 1 — versioned draw T&Cs (docs/plans/lucky-draw-10x.md §4.6).
+ * Append-only, mirroring reward_terms_versions (048). Guarded createTable +
+ * always-run IF NOT EXISTS indexes (045/046/047 pattern).
+ */
+export async function up(queryInterface, Sequelize) {
+  const tables = await queryInterface.showAllTables();
+  const UUID = Sequelize.UUID;
+
+  if (!tables.includes('draw_terms_versions')) {
+    await queryInterface.createTable('draw_terms_versions', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      campaignId: { type: UUID, allowNull: false, references: { model: 'campaigns', key: 'id' }, onDelete: 'CASCADE' },
+      version: { type: Sequelize.INTEGER, allowNull: false },
+      content: { type: Sequelize.TEXT, allowNull: false },
+      contentSha256: { type: Sequelize.STRING(64), allowNull: false },
+      createdBy: { type: UUID, allowNull: false, references: { model: 'users', key: 'id' }, onDelete: 'RESTRICT' },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    });
+  }
+
+  const idx = (sql) => queryInterface.sequelize.query(sql);
+  await idx('CREATE UNIQUE INDEX IF NOT EXISTS uq_dtv_campaign_version ON draw_terms_versions ("campaignId", version)');
+  await idx('CREATE INDEX IF NOT EXISTS idx_dtv_campaign_hash ON draw_terms_versions ("campaignId", "contentSha256")');
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query('DROP TABLE IF EXISTS draw_terms_versions CASCADE');
+}

--- a/backend/src/models/DrawTermsVersion.js
+++ b/backend/src/models/DrawTermsVersion.js
@@ -1,0 +1,36 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Versioned lucky-draw T&Cs (docs/plans/lucky-draw-10x.md §4.6) — append-only,
+ * mirroring RewardTermsVersion. A bare hash of the mutable
+ * design_config.termsContent can only detect change; the version row stores
+ * the canonical content so the historical terms are recoverable and each
+ * entrant's consentMetadata.drawTerms can pin exactly what they accepted.
+ */
+const DrawTermsVersion = sequelize.define('DrawTermsVersion', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  campaignId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'campaigns', key: 'id' }
+  },
+  version: { type: DataTypes.INTEGER, allowNull: false },
+  content: {
+    type: DataTypes.TEXT,
+    allowNull: false,
+    comment: 'Raw stored designer HTML (design_config.termsContent) at version time — the canonical bytes contentSha256 covers'
+  },
+  contentSha256: { type: DataTypes.STRING(64), allowNull: false },
+  createdBy: { type: DataTypes.UUID, allowNull: false, references: { model: 'users', key: 'id' } }
+}, {
+  tableName: 'draw_terms_versions',
+  timestamps: true,
+  updatedAt: false,
+  indexes: [
+    { unique: true, fields: ['campaignId', 'version'], name: 'uq_dtv_campaign_version' },
+    { fields: ['campaignId', 'contentSha256'], name: 'idx_dtv_campaign_hash' }
+  ]
+});
+
+export default DrawTermsVersion;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -196,8 +196,11 @@ function defineAssociations() {
   // Rewards, onboarding, activations (Phases 4–5)
   const {
     RewardOffer, RewardTermsVersion, RewardOfferLocation, RewardInventoryEvent,
-    PartnerOnboardingItem, Activation,
+    PartnerOnboardingItem, Activation, DrawTermsVersion,
   } = models;
+  // Lucky-draw T&C versions (docs/plans/lucky-draw-10x.md §4.6)
+  Campaign.hasMany(DrawTermsVersion, { foreignKey: 'campaignId', as: 'drawTermsVersions', onDelete: 'CASCADE' });
+  DrawTermsVersion.belongsTo(Campaign, { foreignKey: 'campaignId', as: 'campaign' });
   PartnerOrganisation.hasMany(RewardOffer, { foreignKey: 'partnerOrganisationId', as: 'rewardOffers', onDelete: 'RESTRICT' });
   RewardOffer.belongsTo(PartnerOrganisation, { foreignKey: 'partnerOrganisationId', as: 'partner', onDelete: 'RESTRICT' });
   RewardOffer.hasMany(RewardTermsVersion, { foreignKey: 'rewardOfferId', as: 'termsVersions', onDelete: 'CASCADE' });
@@ -309,7 +312,7 @@ export const {
   WaitlistSignup, RedeemOpsAuditEvent, PartnerOrganisation, PartnerLocation,
   PartnerContact, PartnerAssignmentEvent, PartnerStageEvent, OutreachActivity,
   OutreachTask, ProspectingPool, ProspectingPoolMember, RewardOffer,
-  RewardTermsVersion, RewardOfferLocation, RewardInventoryEvent,
+  RewardTermsVersion, DrawTermsVersion, RewardOfferLocation, RewardInventoryEvent,
   PartnerOnboardingItem, Activation, RewardEntitlement, Redemption,
   RedemptionEvent, RedeemOpsCategory, DiscoveryRun, DiscoveryCandidate,
   DiscoveryPlaceMemory, OutreachCadence, OutreachCadenceStep,

--- a/backend/src/routes/externalEntitlements.js
+++ b/backend/src/routes/externalEntitlements.js
@@ -10,7 +10,9 @@ import { makeEntitlementService } from '../services/redeemOps/entitlementService
  * EXTERNAL_APP_SECRET + signed timestamp (requireExternalHmac), rawBody capture
  * and rate-limiter exemption already wired for the prefix.
  *
- * Body: { timestamp, agentMktrUserId, presentationToken?, prospectId?, via? }
+ * Body: { timestamp, agentMktrUserId, presentationToken?, prospectId? }
+ * unlockedVia is server-derived: presentationToken ⇒ agent_scan,
+ * prospectId ⇒ agent_button (a client-sent `via` is ignored).
  * The resolved mirror user must be the lead's assigned consultant.
  */
 export const meta = {
@@ -22,7 +24,7 @@ export const meta = {
 const router = express.Router();
 
 router.post('/unlock', requireExternalHmac, asyncHandler(async (req, res) => {
-  const { agentMktrUserId, presentationToken, prospectId, via } = req.body || {};
+  const { agentMktrUserId, presentationToken, prospectId } = req.body || {};
   if (!agentMktrUserId || (!presentationToken && !prospectId)) {
     return res.status(400).json({ success: false, error: 'agentMktrUserId and presentationToken or prospectId are required' });
   }
@@ -35,10 +37,14 @@ router.post('/unlock', requireExternalHmac, asyncHandler(async (req, res) => {
   }
 
   try {
+    // `via` is SERVER-derived from the identifier, never trusted from the body:
+    // only a presentation token (the customer's QR pass, presented live) counts
+    // as scan evidence; a bare prospectId is always the button path. Draw
+    // weighting treats the two differently (docs/plans/lucky-draw-10x.md §4.4).
     const result = await makeEntitlementService().unlockEntitlement(
       presentationToken ? { presentationToken } : { prospectId },
       agent,
-      via === 'button' ? 'agent_button' : 'agent_scan'
+      presentationToken ? 'agent_scan' : 'agent_button'
     );
     return res.json({
       success: true,

--- a/backend/src/routes/lyfeEntitlementUnlock.js
+++ b/backend/src/routes/lyfeEntitlementUnlock.js
@@ -14,9 +14,11 @@ import { logger } from '../utils/logger.js';
  * one Lyfe→MKTR channel, one key). rawBody capture for this prefix is already
  * wired in server_internal.js; the prefix is rate-limiter-exempt.
  *
- * Body: { agentLyfeId, presentationToken? , prospectId?, via? }
+ * Body: { agentLyfeId, presentationToken? , prospectId? }
  *  - scan path: presentationToken (proves the client was present)
  *  - button path: prospectId (consultant unlocks from the lead record)
+ * unlockedVia is server-derived from which identifier was sent (a client
+ * `via` field is ignored) — only a live token counts as scan evidence.
  * The resolved agent must be the lead's assigned consultant.
  */
 export const meta = {
@@ -61,7 +63,7 @@ router.post('/entitlement-unlock', asyncHandler(async (req, res) => {
   if (!verifyLyfeHmac(req)) {
     return res.status(401).json({ success: false, message: 'Invalid signature' });
   }
-  const { agentLyfeId, presentationToken, prospectId, via } = req.body || {};
+  const { agentLyfeId, presentationToken, prospectId } = req.body || {};
   if (!agentLyfeId || (!presentationToken && !prospectId)) {
     return res.status(400).json({ success: false, message: 'agentLyfeId and presentationToken or prospectId are required' });
   }
@@ -72,10 +74,14 @@ router.post('/entitlement-unlock', asyncHandler(async (req, res) => {
   }
 
   try {
+    // `via` is SERVER-derived from the identifier, never trusted from the body:
+    // only a presentation token (the customer's QR pass, presented live) counts
+    // as scan evidence; a bare prospectId is always the button path
+    // (docs/plans/lucky-draw-10x.md §4.4).
     const result = await makeEntitlementService().unlockEntitlement(
       presentationToken ? { presentationToken } : { prospectId },
       agent,
-      via === 'button' ? 'agent_button' : 'agent_scan'
+      presentationToken ? 'agent_scan' : 'agent_button'
     );
     return res.json({
       success: true,

--- a/backend/src/services/campaignService.js
+++ b/backend/src/services/campaignService.js
@@ -1,16 +1,20 @@
+import crypto from 'crypto';
 import { Op } from 'sequelize';
-import { Campaign, QrTag, Prospect, Commission, Device, CampaignMediaItem, CampaignAgentAssignment, sequelize } from '../models/index.js';
+import { Campaign, QrTag, Prospect, Commission, Device, CampaignMediaItem, CampaignAgentAssignment, DrawTermsVersion, sequelize } from '../models/index.js';
 import { getTenantId } from '../middleware/tenant.js';
 import { storageService } from './storage.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { normalizeCustomerHostChoice } from '../utils/customerHost.js';
 import { applyFeaturedDropPolicy } from '../utils/featuredDrop.js';
+import { applyLuckyDrawPolicy } from '../utils/luckyDraw.js';
 
 /**
  * Clamp the security-sensitive keys of a design_config before persisting.
  * customerHost: enum clamp (never trust a raw host from client JSON).
  * featuredDrop: publication to the public redeem.sg homepage — admin-only to
  * change; non-admins keep whatever is already stored (see utils/featuredDrop.js).
+ * luckyDraw: draw-campaign enforcement settings — admin-only, same policy
+ * (see utils/luckyDraw.js and docs/plans/lucky-draw-10x.md §4.1).
  */
 function clampDesignConfig(incoming, storedConfig, role) {
   if (!incoming || typeof incoming !== 'object') return incoming;
@@ -22,7 +26,61 @@ function clampDesignConfig(incoming, storedConfig, role) {
   });
   if (featuredDrop === undefined) delete clamped.featuredDrop;
   else clamped.featuredDrop = featuredDrop;
+  const luckyDraw = applyLuckyDrawPolicy({
+    incoming: incoming.luckyDraw,
+    stored: storedConfig?.luckyDraw,
+    role,
+  });
+  if (luckyDraw === undefined) delete clamped.luckyDraw;
+  else clamped.luckyDraw = luckyDraw;
   return clamped;
+}
+
+/**
+ * Draw-terms versioning (docs/plans/lucky-draw-10x.md §4.6). For an enabled
+ * lucky draw, pin the CURRENT designer T&C content as an append-only
+ * draw_terms_versions row and stamp its id + hash into luckyDraw, so each
+ * entrant's acceptance (consentMetadata.drawTerms) references immutable
+ * content — editing termsContent later mints a NEW version instead of
+ * rewriting what earlier entrants agreed to.
+ *
+ * Canonical bytes = the TRIMMED raw designer HTML (design_config.termsContent).
+ * Idempotent: unchanged content re-resolves to the existing version row.
+ * Exported for tests; `d` is a DI seam (defaults to the real model).
+ */
+export async function ensureDrawTermsVersion(designConfig, campaignId, userId, d = { DrawTermsVersion }) {
+  const ld = designConfig?.luckyDraw;
+  if (!ld || ld.enabled !== true) return designConfig;
+  const content = typeof designConfig.termsContent === 'string' ? designConfig.termsContent.trim() : '';
+  if (!content) {
+    throw new AppError(
+      'Lucky-draw campaigns need Terms & Conditions content (designer → Terms & Conditions) before they can be enabled.',
+      422
+    );
+  }
+  const contentSha256 = crypto.createHash('sha256').update(content).digest('hex');
+  let row = await d.DrawTermsVersion.findOne({
+    where: { campaignId, contentSha256 },
+    order: [['version', 'DESC']],
+  });
+  if (!row) {
+    const latest = await d.DrawTermsVersion.max('version', { where: { campaignId } });
+    try {
+      row = await d.DrawTermsVersion.create({
+        campaignId,
+        version: (Number.isInteger(latest) ? latest : 0) + 1,
+        content,
+        contentSha256,
+        createdBy: userId,
+      });
+    } catch (err) {
+      // Concurrent save minted the same version number — the content row we
+      // need either exists now (same hash) or the retry below surfaces the error.
+      row = await d.DrawTermsVersion.findOne({ where: { campaignId, contentSha256 } });
+      if (!row) throw err;
+    }
+  }
+  return { ...designConfig, luckyDraw: { ...ld, termsVersionId: row.id, termsHash: contentSha256 } };
 }
 
 /**
@@ -219,7 +277,25 @@ export async function createCampaign(body, user) {
     campaignData.design_config = clampDesignConfig(body.design_config, undefined, user?.role);
   }
 
+  // Draw terms need the campaign id for the version row, but the content
+  // requirement must fail BEFORE the row exists — no half-created draw campaign.
+  if (campaignData.design_config?.luckyDraw?.enabled === true) {
+    const terms = typeof campaignData.design_config.termsContent === 'string'
+      ? campaignData.design_config.termsContent.trim() : '';
+    if (!terms) {
+      throw new AppError(
+        'Lucky-draw campaigns need Terms & Conditions content (designer → Terms & Conditions) before they can be enabled.',
+        422
+      );
+    }
+  }
+
   const campaign = await Campaign.create(campaignData);
+
+  if (campaignData.design_config?.luckyDraw?.enabled === true) {
+    const withTerms = await ensureDrawTermsVersion(campaignData.design_config, campaign.id, user.id);
+    await campaign.update({ design_config: withTerms });
+  }
 
   // Write agent assignments to join table
   if (assigned_agents && Array.isArray(assigned_agents) && assigned_agents.length > 0) {
@@ -270,9 +346,13 @@ export async function updateCampaign(id, body, req) {
   }
   if (design_config !== undefined) {
     // Clamp the per-campaign customer host to the enum (never trust a raw host
-    // from client JSON) and gate featuredDrop changes to admins; preserve all
-    // other design keys untouched.
+    // from client JSON) and gate featuredDrop/luckyDraw changes to admins;
+    // preserve all other design keys untouched.
     updateData.design_config = clampDesignConfig(design_config, campaign.design_config, req.user?.role);
+    // Enabled draws pin their T&C content as an immutable version (also catches
+    // termsContent edits on saves that didn't touch luckyDraw itself — the
+    // clamp preserved the stored luckyDraw, and unchanged content is a no-op).
+    updateData.design_config = await ensureDrawTermsVersion(updateData.design_config, campaign.id, req.user?.id);
   }
   if (commission_amount_driver !== undefined) updateData.commission_amount_driver = commission_amount_driver;
   if (commission_amount_fleet !== undefined) updateData.commission_amount_fleet = commission_amount_fleet;
@@ -411,16 +491,20 @@ export async function duplicateCampaign(id, body, req) {
 
   const { metrics: _discardedMetrics, ...rest } = original.toJSON();
   // Never clone homepage publication: a duplicate of a featured campaign must
-  // not silently appear on redeem.sg when it is later activated.
-  const dupDesign =
-    rest.design_config && typeof rest.design_config === 'object'
-      ? {
-          ...rest.design_config,
-          ...(rest.design_config.featuredDrop && typeof rest.design_config.featuredDrop === 'object'
-            ? { featuredDrop: { ...rest.design_config.featuredDrop, enabled: false } }
-            : {}),
-        }
-      : rest.design_config;
+  // not silently appear on redeem.sg when it is later activated. Never clone
+  // luckyDraw either — its dates, activation, and terms version are all
+  // campaign-specific (docs/plans/lucky-draw-10x.md §4.1); a duplicate must be
+  // deliberately re-enabled as its own draw.
+  const dupDesign = (() => {
+    if (!rest.design_config || typeof rest.design_config !== 'object') return rest.design_config;
+    const { luckyDraw: _neverCloneDraw, ...base } = rest.design_config;
+    return {
+      ...base,
+      ...(rest.design_config.featuredDrop && typeof rest.design_config.featuredDrop === 'object'
+        ? { featuredDrop: { ...rest.design_config.featuredDrop, enabled: false } }
+        : {}),
+    };
+  })();
   const copy = await Campaign.create({
     ...rest,
     design_config: dupDesign,

--- a/backend/src/services/email-templates/confirmation-email-draw.html
+++ b/backend/src/services/email-templates/confirmation-email-draw.html
@@ -1,0 +1,300 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="x-apple-disable-message-reformatting">
+<meta name="format-detection" content="telephone=no, date=no, address=no, email=no">
+<meta name="color-scheme" content="light only">
+<meta name="supported-color-schemes" content="light only">
+<title>Your request is confirmed</title>
+<!-- Display serif: progressive enhancement. Apple Mail / iOS Mail render Fraunces; other clients fall back to Georgia. -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&display=swap" rel="stylesheet">
+<!--[if mso]>
+<noscript><xml><o:OfficeDocumentSettings><o:PixelsPerInch>96</o:PixelsPerInch></o:OfficeDocumentSettings></xml></noscript>
+<![endif]-->
+<style type="text/css">
+  /* ---------- Client resets ---------- */
+  html, body { margin: 0 !important; padding: 0 !important; height: 100% !important; width: 100% !important; }
+  * { -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; }
+  table, td { mso-table-lspace: 0pt !important; mso-table-rspace: 0pt !important; border-collapse: collapse !important; }
+  img { -ms-interpolation-mode: bicubic; border: 0; height: auto; line-height: 100%; outline: none; text-decoration: none; display: block; }
+  a { text-decoration: none; }
+  body { background-color: #FBF7F0; }
+  .body-link a { color: #A85822; text-decoration: underline; }
+
+  /* ---------- Force light, sensible behaviour under dark mode ---------- */
+  :root { color-scheme: light only; supported-color-schemes: light only; }
+  u + .body { background-color: #FBF7F0; }
+
+  /* ---------- Button hover (supporting clients) ---------- */
+  .btn-a:hover { background-color: #8F4A1C !important; }
+  .soc-a:hover { background-color: #FBF3E6 !important; border-color: #D8C29A !important; }
+  .copy-btn:hover { background-color: #2A1607 !important; }
+  .ghost:hover { color: #8F4A1C !important; }
+
+  /* ---------- Responsive ---------- */
+  @media only screen and (max-width: 600px) {
+    .container { width: 100% !important; }
+    .px { padding-left: 24px !important; padding-right: 24px !important; }
+    .pt { padding-top: 32px !important; }
+    .pb { padding-bottom: 32px !important; }
+    .h1 { font-size: 30px !important; line-height: 36px !important; }
+    .card-px { padding-left: 22px !important; padding-right: 22px !important; }
+    .card-py { padding-top: 26px !important; padding-bottom: 26px !important; }
+    .btn-a { display: block !important; width: 100% !important; box-sizing: border-box !important; }
+    .soc-a { padding-left: 2px !important; padding-right: 2px !important; }
+    .full { width: 100% !important; }
+  }
+
+  /* ---------- Motion: progressive enhancement only ----------
+     Every animated element's RESTING state (its inline style) is the
+     final, fully-visible state. Keyframes only run in clients that both
+     support CSS animation and honour prefers-reduced-motion, so any
+     client that strips this block simply shows the finished layout. */
+  @media (prefers-reduced-motion: no-preference) {
+    @keyframes riseIn { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: translateY(0); } }
+    @keyframes sealIn { from { opacity: 0; transform: scale(0.86); } to { opacity: 1; transform: scale(1); } }
+    .anim-seal { animation: sealIn 0.6s cubic-bezier(0.2, 0.7, 0.2, 1) both; }
+    .anim-1 { animation: riseIn 0.7s cubic-bezier(0.2, 0.7, 0.2, 1) 0.05s both; }
+    .anim-2 { animation: riseIn 0.7s cubic-bezier(0.2, 0.7, 0.2, 1) 0.16s both; }
+    .anim-3 { animation: riseIn 0.7s cubic-bezier(0.2, 0.7, 0.2, 1) 0.28s both; }
+  }
+</style>
+</head>
+<body class="body" style="margin:0; padding:0; width:100%; background-color:#FBF7F0; -webkit-font-smoothing:antialiased;">
+
+  <!-- Preheader: shown in inbox preview, hidden in the body -->
+  <div style="display:none; max-height:0; overflow:hidden; mso-hide:all; font-size:1px; line-height:1px; color:#FBF7F0; opacity:0;">
+    You&rsquo;re in the draw. Complete your session to multiply your chances &times;{{multiplier}}.
+    &#847; &zwnj; &nbsp; &#847; &zwnj; &nbsp; &#847; &zwnj; &nbsp; &#847; &zwnj; &nbsp; &#847; &zwnj; &nbsp; &#847; &zwnj; &nbsp;
+  </div>
+
+  <!-- Full-bleed background -->
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#FBF7F0;">
+    <tr>
+      <td align="center" style="padding:32px 12px;">
+
+        <!--[if mso]><table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0"><tr><td><![endif]-->
+        <table role="presentation" class="container" width="600" cellpadding="0" cellspacing="0" border="0" style="width:600px; max-width:600px; margin:0 auto;">
+
+          <!-- ============ HEADER / LETTERHEAD ============ -->
+          <tr>
+            <td align="center" bgcolor="#3D1F0B" style="background-color:#3D1F0B; border-radius:18px 18px 0 0; padding:42px 40px 34px 40px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                  <td align="center" style="color:#FFFCF7;">
+                    {{heroLogo}}
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style="padding-top:18px;">
+                    <table role="presentation" cellpadding="0" cellspacing="0" border="0"><tr>
+                      <td style="font-size:0; line-height:0; height:2px; width:54px; background-color:#D17029; border-radius:2px;">&nbsp;</td>
+                    </tr></table>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- ============ HERO ============ -->
+          <tr>
+            <td bgcolor="#FFFFFF" class="px pt" style="background-color:#FFFFFF; padding:44px 56px 8px 56px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+
+                <!-- Confirmation seal (pure CSS, no image required) -->
+                <tr>
+                  <td align="center" style="padding-bottom:26px;">
+                    <table role="presentation" class="anim-seal" cellpadding="0" cellspacing="0" border="0">
+                      <tr>
+                        <td align="center" valign="middle" width="74" height="74" bgcolor="#FBF3E6" style="width:74px; height:74px; background-color:#FBF3E6; border-radius:50%; text-align:center; vertical-align:middle; font-family:Georgia,'Times New Roman',serif; font-size:34px; line-height:74px; color:#A85822;">
+                          &#10003;
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+
+                <!-- Kicker -->
+                <tr>
+                  <td align="center" class="anim-1" style="padding-bottom:12px;">
+                    <span style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:12px; font-weight:600; letter-spacing:0.22em; text-transform:uppercase; color:#A85822;">Entry confirmed</span>
+                  </td>
+                </tr>
+
+                <!-- Focal headline -->
+                <tr>
+                  <td align="center" class="anim-1 h1" style="font-family:'Fraunces',Georgia,'Times New Roman',serif; font-size:38px; line-height:44px; font-weight:600; color:#3D1F0B; padding-bottom:18px;">
+                    You&rsquo;re in the draw.
+                  </td>
+                </tr>
+
+                <!-- Greeting, campaign name (own row), body -->
+                <tr>
+                  <td align="center" class="anim-2" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:16px; line-height:26px; color:#5A301A; padding-bottom:8px;">
+                    Hello {{firstName}}, your entry is in for
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" class="anim-2" style="font-family:'Fraunces',Georgia,'Times New Roman',serif; font-size:21px; line-height:28px; font-weight:600; color:#3D1F0B; padding:0 4px 4px 4px;">
+                    {{campaignName}}.
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" class="anim-2" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:16px; line-height:26px; color:#5A301A; padding:14px 8px 0 8px;">
+                    You&rsquo;re in the running for <strong>{{prize}}</strong>. Want {{multiplier}}&times; the chances? Complete your complimentary financial review session &mdash; when your consultant records it, your entry is multiplied. We contact the winner directly after the draw, and we never ask for payment to release a prize.
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Divider -->
+          <tr>
+            <td bgcolor="#FFFFFF" class="px" style="background-color:#FFFFFF; padding:34px 56px 0 56px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"><tr>
+                <td style="font-size:0; line-height:0; height:1px; background-color:#EFE3CC;">&nbsp;</td>
+              </tr></table>
+            </td>
+          </tr>
+
+          <!-- ============ REFERRAL REWARD CARD ============ -->
+          <tr>
+            <td bgcolor="#FFFFFF" class="px" style="background-color:#FFFFFF; padding:34px 56px 8px 56px;">
+              <table role="presentation" class="anim-3" width="100%" cellpadding="0" cellspacing="0" border="0" style="border:1px solid #EAD9B6; border-radius:16px; background-color:#FFFAF0;">
+                <tr>
+                  <td class="card-px card-py" style="padding:30px 32px 32px 32px;">
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                      <tr>
+                        <td align="center" style="padding-bottom:10px;">
+                          <span style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:12px; font-weight:600; letter-spacing:0.2em; text-transform:uppercase; color:#A85822;">Share &amp; get credited</span>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td align="center" style="font-family:'Fraunces',Georgia,'Times New Roman',serif; font-size:24px; line-height:30px; font-weight:600; color:#3D1F0B; padding-bottom:12px;">
+                          Refer a friend, share the joy.
+                        </td>
+                      </tr>
+                      <tr>
+                        <td align="center" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:15px; line-height:24px; color:#5A301A; padding-bottom:22px;">
+                          Share your personal link with friends. When someone signs up through it, you are credited as their referrer.
+                        </td>
+                      </tr>
+
+                      <!-- Visible, selectable referral link as plain text (NOT a link, so tapping it
+                           does not navigate away). Email clients strip JS, so a true clipboard copy
+                           cannot run in the message: long-press on mobile or select on desktop to copy.
+                           The share buttons below are the one-tap actions. Works with images off. -->
+                      <tr>
+                        <td style="padding-bottom:18px;">
+                          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#FBF3E6; border:1px solid #E8D7B8; border-radius:10px;">
+                            <tr>
+                              <td valign="middle" align="center" style="padding:13px 18px;">
+                                <span class="copy-url" style="font-family:'SFMono-Regular',Consolas,'Liberation Mono',Menlo,Courier,monospace; font-size:14px; line-height:20px; color:#3D1F0B; word-break:break-all;">{{shareUrl}}</span>
+                              </td>
+                            </tr>
+                          </table>
+                        </td>
+                      </tr>
+
+                      <!-- Social share buttons: real platform logos (hosted PNG) + label. With images off, the bordered pill and label remain. -->
+                      <tr>
+                        <td>
+                          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                            <tr>
+                              <td width="33.33%" valign="top" style="padding:0 5px 0 0;">
+                                <a href="https://wa.me/?text=I%20just%20signed%20up%20with%20{{brandName}}.%20Take%20a%20look%3A%20{{shareUrl}}" class="soc-a" style="display:block; text-align:center; background-color:#FFFAF0; border:1px solid #E8D7B8; border-radius:12px; padding:15px 4px 13px 4px; text-decoration:none;">
+                                  <img src="https://redeem.sg/email/social/whatsapp.png" width="30" height="30" alt="" style="display:block; margin:0 auto 7px auto; border:0; outline:none;">
+                                  <span style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:12px; font-weight:600; letter-spacing:0.01em; color:#5A301A;">WhatsApp</span>
+                                </a>
+                              </td>
+                              <td width="33.33%" valign="top" style="padding:0 5px;">
+                                <a href="https://www.facebook.com/sharer/sharer.php?u={{shareUrl}}" class="soc-a" style="display:block; text-align:center; background-color:#FFFAF0; border:1px solid #E8D7B8; border-radius:12px; padding:15px 4px 13px 4px; text-decoration:none;">
+                                  <img src="https://redeem.sg/email/social/facebook.png" width="30" height="30" alt="" style="display:block; margin:0 auto 7px auto; border:0; outline:none;">
+                                  <span style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:12px; font-weight:600; letter-spacing:0.01em; color:#5A301A;">Facebook</span>
+                                </a>
+                              </td>
+                              <td width="33.33%" valign="top" style="padding:0 0 0 5px;">
+                                <a href="https://twitter.com/intent/tweet?text=I%20just%20signed%20up%20with%20{{brandName}}.%20Take%20a%20look%3A&amp;url={{shareUrl}}" class="soc-a" style="display:block; text-align:center; background-color:#FFFAF0; border:1px solid #E8D7B8; border-radius:12px; padding:15px 4px 13px 4px; text-decoration:none;">
+                                  <img src="https://redeem.sg/email/social/x.png" width="30" height="30" alt="" style="display:block; margin:0 auto 7px auto; border:0; outline:none;">
+                                  <span style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:12px; font-weight:600; letter-spacing:0.01em; color:#5A301A;">X</span>
+                                </a>
+                              </td>
+                            </tr>
+                          </table>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td align="center" style="padding-top:16px; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:13px; line-height:18px; color:#9A7E5E;">
+                          Tap a button to share, or copy the link above.
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- ============ REASSURANCE + SIGN-OFF ============ -->
+          <tr>
+            <td bgcolor="#FFFFFF" class="px pb" style="background-color:#FFFFFF; padding:30px 56px 44px 56px; border-radius:0 0 0 0;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                  <td align="center" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:13px; line-height:20px; color:#9A7E5E; padding-bottom:26px;">
+                    Did not request this? No action is needed. You can safely ignore this email.
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style="font-family:'Fraunces',Georgia,'Times New Roman',serif; font-size:16px; line-height:22px; color:#5A301A; font-style:italic;">
+                    Warm regards,
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style="font-family:'Fraunces',Georgia,'Times New Roman',serif; font-size:17px; line-height:24px; color:#3D1F0B; padding-top:4px;">
+                    The {{brandName}} team
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- ============ FOOTER ============ -->
+          <tr>
+            <td bgcolor="#F4EAD8" class="px" style="background-color:#F4EAD8; border-radius:0 0 18px 18px; padding:28px 48px 32px 48px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                  <td align="center" style="font-family:'Fraunces',Georgia,'Times New Roman',serif; font-size:16px; line-height:20px; font-weight:600; color:#7A5230; letter-spacing:0.02em; padding-bottom:12px;">
+                    {{brandWordmark}}
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:12px; line-height:18px; color:#8A6B49; padding-bottom:6px;">
+                    You are receiving this because you submitted a request to {{brandName}}.
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:12px; line-height:18px; color:#8A6B49;">
+                    {{footerEntity}}
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:12px; line-height:18px; color:#A98A66; padding-top:6px;">
+                    &copy; {{year}} {{brandName}}. All rights reserved.
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+        </table>
+        <!--[if mso]></td></tr></table><![endif]-->
+
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/backend/src/services/email-templates/confirmation-email-draw.txt
+++ b/backend/src/services/email-templates/confirmation-email-draw.txt
@@ -1,0 +1,31 @@
+You're in the draw.
+
+Hello {{firstName}},
+
+Your entry for {{campaignName}} is in — you're in the running for {{prize}}.
+
+Want {{multiplier}}x the chances? Complete your complimentary financial review session — when your consultant records it, your entry is multiplied.
+
+We contact the winner directly after the draw, and we never ask for payment to release a prize.
+
+------------------------------------------------------------
+
+SHARE AND GET CREDITED
+
+Share your personal link with friends. When someone signs up through it, you are credited as their referrer.
+
+Your referral link:
+{{shareUrl}}
+
+------------------------------------------------------------
+
+Did not request this? No action is needed. You can safely ignore this email.
+
+The {{brandName}} team
+
+------------------------------------------------------------
+
+{{brandWordmark}}
+You are receiving this because you submitted a request to {{brandName}}.
+{{footerEntity}}
+(c) {{year}} {{brandName}}. All rights reserved.

--- a/backend/src/services/featuredDropsService.js
+++ b/backend/src/services/featuredDropsService.js
@@ -13,6 +13,7 @@ import { Op } from 'sequelize';
 import { Campaign, Prospect } from '../models/index.js';
 import { normalizeFeaturedDrop } from '../utils/featuredDrop.js';
 import { customerHostOrigin } from '../utils/customerHost.js';
+import { sgtDayEndExclusiveMs } from '../utils/sgtTime.js';
 import { logger } from '../utils/logger.js';
 
 const TTL_MS = 60_000;
@@ -22,11 +23,9 @@ const MAX_DROPS = 6;
 let cache = { data: null, ts: 0 };
 let inflight = null;
 
-/** endsAt is inclusive through 23:59:59 Asia/Singapore (not midnight UTC). */
-function sgtEndOfDayMs(ymd) {
-  const t = Date.parse(`${ymd}T23:59:59+08:00`);
-  return Number.isNaN(t) ? null : t;
-}
+// endsAt is inclusive through the whole SGT day: an instant is within the day
+// iff now < sgtDayEndExclusiveMs(endsAt) (shared util — the old private helper
+// stopped at 23:59:59.000 and dropped the day's final 999ms).
 
 async function fetchDrops(now) {
   const campaigns = await Campaign.findAll({
@@ -42,8 +41,8 @@ async function fetchDrops(now) {
     // campaignService (seeds, manual SQL, old code paths).
     const fd = normalizeFeaturedDrop(c.design_config?.featuredDrop);
     if (!fd || fd.enabled !== true) continue;
-    const endMs = fd.endsAt ? sgtEndOfDayMs(fd.endsAt) : null;
-    if (endMs !== null && now > endMs + GONE_RETENTION_MS) continue;
+    const endMs = fd.endsAt ? sgtDayEndExclusiveMs(fd.endsAt) : null;
+    if (endMs !== null && now >= endMs + GONE_RETENTION_MS) continue;
     flagged.push({ c, fd, endMs });
   }
   if (flagged.length === 0) return [];
@@ -62,7 +61,7 @@ async function fetchDrops(now) {
   const drops = flagged.map(({ c, fd, endMs }) => {
     const claimed = counts.get(String(c.id)) || 0;
     const capReached = typeof fd.cap === 'number' && claimed >= fd.cap;
-    const ended = endMs !== null && now > endMs;
+    const ended = endMs !== null && now >= endMs;
     const drop = {
       id: c.id,
       title: fd.title || c.name,
@@ -82,8 +81,8 @@ async function fetchDrops(now) {
   // Deterministic: live first, then soonest-ending (nulls last), then id.
   drops.sort((a, b) => {
     if (a.status !== b.status) return a.status === 'live' ? -1 : 1;
-    const ae = a.endsAt ? sgtEndOfDayMs(a.endsAt) : Infinity;
-    const be = b.endsAt ? sgtEndOfDayMs(b.endsAt) : Infinity;
+    const ae = a.endsAt ? sgtDayEndExclusiveMs(a.endsAt) : Infinity;
+    const be = b.endsAt ? sgtDayEndExclusiveMs(b.endsAt) : Infinity;
     if (ae !== be) return ae - be;
     return String(a.id).localeCompare(String(b.id));
   });

--- a/backend/src/services/mailer.js
+++ b/backend/src/services/mailer.js
@@ -13,6 +13,11 @@ import { getOrCreateProspectShareLink } from './shortlinkService.js';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CONFIRMATION_EMAIL_HTML = readFileSync(join(__dirname, 'email-templates/confirmation-email.html'), 'utf8');
 const CONFIRMATION_EMAIL_TXT = readFileSync(join(__dirname, 'email-templates/confirmation-email.txt'), 'utf8');
+// Lucky-draw variant (docs/plans/lucky-draw-10x.md §4.5): draw campaigns must
+// not promise the generic "gift + call within 24 hours" — they confirm the
+// entry and pitch the ×N session multiplier instead.
+const CONFIRMATION_EMAIL_DRAW_HTML = readFileSync(join(__dirname, 'email-templates/confirmation-email-draw.html'), 'utf8');
+const CONFIRMATION_EMAIL_DRAW_TXT = readFileSync(join(__dirname, 'email-templates/confirmation-email-draw.txt'), 'utf8');
 
 // D12: per-origin from-address. Lead-capture confirmations sent from the
 // redeem.sg flow use noreply@redeem.sg; admin / agent emails keep the
@@ -271,7 +276,13 @@ export async function sendLeadConfirmationEmail(prospect, { shareUrl: shareUrlOv
   }
 
   const firstName = prospect.firstName || 'there';
-  const subject = `We've received your interest in ${campaignName}`;
+  // Draw campaigns confirm a draw ENTRY (no gift/24h-call promise) — template
+  // pair + subject swap on design_config.luckyDraw (docs/plans/lucky-draw-10x.md §4.5).
+  const luckyDraw = prospect.campaign?.design_config?.luckyDraw;
+  const isDraw = luckyDraw?.enabled === true;
+  const subject = isDraw
+    ? `You're in the draw — ${campaignName}`
+    : `We've received your interest in ${campaignName}`;
 
   // Brand the confirmation email by the campaign's customer host: redeem.sg (default) shows
   // the Redeem brand; an mktr.sg campaign shows MKTR. Backend code is not bundled into the
@@ -322,12 +333,17 @@ export async function sendLeadConfirmationEmail(prospect, { shareUrl: shareUrlOv
     footerEntity,
     year: new Date().getFullYear(),
     heroLogo,
+    ...(isDraw
+      ? { prize: luckyDraw.prize || campaignName, multiplier: luckyDraw.multiplier || 10 }
+      : {}),
   };
-  const escapeFields = new Set(['firstName', 'campaignName', 'shareUrl']);
-  const html = CONFIRMATION_EMAIL_HTML.replace(/\{\{(\w+)\}\}/g, (_, k) =>
+  const escapeFields = new Set(['firstName', 'campaignName', 'shareUrl', 'prize']);
+  const htmlTemplate = isDraw ? CONFIRMATION_EMAIL_DRAW_HTML : CONFIRMATION_EMAIL_HTML;
+  const textTemplate = isDraw ? CONFIRMATION_EMAIL_DRAW_TXT : CONFIRMATION_EMAIL_TXT;
+  const html = htmlTemplate.replace(/\{\{(\w+)\}\}/g, (_, k) =>
     k in fields ? (escapeFields.has(k) ? escapeHtml(fields[k]) : String(fields[k])) : `{{${k}}}`
   );
-  const text = CONFIRMATION_EMAIL_TXT.replace(/\{\{(\w+)\}\}/g, (_, k) =>
+  const text = textTemplate.replace(/\{\{(\w+)\}\}/g, (_, k) =>
     k in fields ? String(fields[k]) : `{{${k}}}`
   );
 

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID, createHash } from 'crypto';
 import { Op, Transaction } from 'sequelize';
 import {
   Prospect,
@@ -35,6 +35,7 @@ import {
 import { getOrCreateProspectShareLink } from './shortlinkService.js';
 import { isPhoneRecentlyVerified } from './verifiedPhoneStore.js';
 import { customerHostOrigin, normalizeCustomerHostChoice } from '../utils/customerHost.js';
+import { sgtDayEndExclusiveMs } from '../utils/sgtTime.js';
 
 // Redeem Ops capture hook (docs/redeem-ops/MKTR_INTEGRATION.md §2): a
 // dependency-INVERTED callback — this module never imports Redeem Ops code.
@@ -221,16 +222,9 @@ export function makeProspectService(overrides = {}) {
       incoming.sourceMetadata = { ...(incoming.sourceMetadata || {}), ...capiSourceMetadata };
     }
 
-    // Server-side phone-verification stamp (docs/redeem-ops/MKTR_INTEGRATION.md §2.0):
-    // written iff the OTP marker is live at create time. Durable evidence that
-    // Redeem Ops reward issuance REQUIRES — a raw unverified POST still captures
-    // as a lead but can never mint reward value (anti-farming precondition).
-    if (incoming.phone && d.isPhoneRecentlyVerified?.(incoming.phone)) {
-      incoming.sourceMetadata = {
-        ...(incoming.sourceMetadata || {}),
-        phoneVerifiedAt: new Date().toISOString(),
-      };
-    }
+    // (Phone-verification stamping happens AFTER normalization below — the OTP
+    // marker is keyed by the full E.164 phone, so the check must run on the
+    // normalized value; see docs/plans/lucky-draw-10x.md §4.4.)
 
     // Third-party-disclosure consent evidence. Written ONLY when the person ticked
     // the box (=> consentMetadata.external), which — together with the campaign's
@@ -360,6 +354,30 @@ export function makeProspectService(overrides = {}) {
       throw new d.AppError('This campaign is no longer active.', 410);
     }
 
+    // Lucky-draw entry gate (docs/plans/lucky-draw-10x.md §4.4) — draw campaigns
+    // ONLY; the general funnel's capture-everything posture is untouched. Runs
+    // before any routing side effect (the round-robin cursor below advances on
+    // resolution), and normalizes the phone itself because the shared
+    // normalization happens later in this function. The browser flow always
+    // satisfies all four checks; only direct-API callers are affected.
+    const luckyDraw = sourceCampaign?.design_config?.luckyDraw;
+    if (luckyDraw?.enabled === true) {
+      const drawPhone = incoming.phone ? normalizePhone(incoming.phone) : null;
+      if (!drawPhone) {
+        throw new d.AppError('A mobile number is required to enter this draw.', 422);
+      }
+      if (consentTerms !== true) {
+        throw new d.AppError('You must accept the terms and conditions to enter this draw.', 422);
+      }
+      if (!d.isPhoneRecentlyVerified?.(drawPhone)) {
+        throw new d.AppError('Please verify your mobile number before entering this draw.', 403);
+      }
+      const closesAtEnd = luckyDraw.closesAt ? sgtDayEndExclusiveMs(luckyDraw.closesAt) : null;
+      if (closesAtEnd !== null && Date.now() >= closesAtEnd) {
+        throw new d.AppError('Entries for this draw have closed.', 410);
+      }
+    }
+
     // External (MKTR Leads) eligibility. INERT until per-source consent capture writes
     // consentMetadata.external — hasValidExternalConsent returns false for all current
     // data, so allowExternal is false and routing takes the internal-only path below,
@@ -412,6 +430,36 @@ export function makeProspectService(overrides = {}) {
     // Normalize phone to E.164 format
     if (incoming.phone) {
       incoming.phone = normalizePhone(incoming.phone);
+    }
+
+    // Server-side phone-verification stamp (docs/redeem-ops/MKTR_INTEGRATION.md
+    // §2.0): written iff the OTP marker is live at create time. Durable evidence
+    // that Redeem Ops reward issuance REQUIRES — a raw unverified POST still
+    // captures as a lead but can never mint reward value (anti-farming
+    // precondition). Checked on the NORMALIZED phone (the marker is keyed by
+    // full E.164). phoneVerifiedFor binds the stamp to the number it was earned
+    // for: a later staff phone edit breaks the match instead of silently
+    // inheriting verified status (docs/plans/lucky-draw-10x.md §4.4).
+    if (incoming.phone && d.isPhoneRecentlyVerified?.(incoming.phone)) {
+      incoming.sourceMetadata = {
+        ...(incoming.sourceMetadata || {}),
+        phoneVerifiedAt: new Date().toISOString(),
+        phoneVerifiedFor: createHash('sha256').update(incoming.phone).digest('hex'),
+      };
+    }
+
+    // Draw-terms acceptance evidence (docs/plans/lucky-draw-10x.md §4.6):
+    // server-built pin of the exact terms version live at entry time. The draw
+    // gate above already guaranteed consent_terms === true for draw campaigns.
+    if (luckyDraw?.enabled === true && luckyDraw.termsVersionId) {
+      incoming.consentMetadata = {
+        ...(incoming.consentMetadata || {}),
+        drawTerms: {
+          termsVersionId: luckyDraw.termsVersionId,
+          termsHash: luckyDraw.termsHash || null,
+          acceptedAt: new Date().toISOString(),
+        },
+      };
     }
 
     // DNC (Do Not Call) scrubbing mode for this lead. 'off' unless scrubbing is configured

--- a/backend/src/utils/luckyDraw.js
+++ b/backend/src/utils/luckyDraw.js
@@ -1,0 +1,90 @@
+/**
+ * design_config.luckyDraw — lucky-draw campaign settings
+ * (docs/plans/lucky-draw-10x.md §4.1).
+ *
+ * These values gate PUBLIC signup behaviour (prospectService draw gate) and
+ * feed the draw pool, so they are normalized on every save exactly like
+ * featuredDrop: unknown keys stripped, every field coerced or dropped, and
+ * changes are admin-only (campaign PUT is open to agents).
+ *
+ * termsVersionId/termsHash are SERVER-managed (campaignService appends a
+ * draw_terms_versions row and stamps them after the clamp) but are normalized
+ * here so stored values survive round-trips and hand-written rows can't
+ * smuggle arbitrary content.
+ */
+
+const MAX_PRIZE = 80;
+const MIN_MULTIPLIER = 2;
+const MAX_MULTIPLIER = 100;
+const DEFAULT_MULTIPLIER = 10;
+const YMD_RE = /^\d{4}-\d{2}-\d{2}$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SHA256_RE = /^[0-9a-f]{64}$/i;
+
+function isPlainObject(v) {
+  return Object.prototype.toString.call(v) === '[object Object]';
+}
+
+function cleanString(v, max) {
+  if (typeof v !== 'string') return undefined;
+  const t = v.trim();
+  if (!t) return undefined;
+  return t.slice(0, max);
+}
+
+function cleanYmd(v) {
+  if (typeof v !== 'string') return undefined;
+  const s = v.trim();
+  if (!YMD_RE.test(s) || Number.isNaN(Date.parse(`${s}T00:00:00Z`))) return undefined;
+  return s;
+}
+
+/**
+ * Normalize a raw luckyDraw value into the canonical shape, or undefined when
+ * the input isn't a plain object (caller should drop the key entirely).
+ */
+export function normalizeLuckyDraw(raw) {
+  if (!isPlainObject(raw)) return undefined;
+  const out = { enabled: raw.enabled === true };
+
+  const prize = cleanString(raw.prize, MAX_PRIZE);
+  if (prize) out.prize = prize;
+
+  for (const key of ['closesAt', 'boostClosesAt', 'drawOn']) {
+    const ymd = cleanYmd(raw[key]);
+    if (ymd) out[key] = ymd;
+  }
+
+  const multiplier = Number(raw.multiplier);
+  out.multiplier =
+    Number.isInteger(multiplier) && multiplier >= MIN_MULTIPLIER && multiplier <= MAX_MULTIPLIER
+      ? multiplier
+      : DEFAULT_MULTIPLIER;
+
+  for (const key of ['activationId', 'termsVersionId']) {
+    if (typeof raw[key] === 'string' && UUID_RE.test(raw[key].trim())) {
+      out[key] = raw[key].trim().toLowerCase();
+    }
+  }
+
+  if (typeof raw.termsHash === 'string' && SHA256_RE.test(raw.termsHash.trim())) {
+    out.termsHash = raw.termsHash.trim().toLowerCase();
+  }
+
+  return out;
+}
+
+/**
+ * Same policy as featuredDrop (utils/featuredDrop.js): only admins may change
+ * luckyDraw — it flips public signup enforcement and draw semantics.
+ *
+ * - admin: incoming value wins (normalized); omitting the key preserves stored.
+ * - everyone else: stored value is preserved (normalized), incoming ignored.
+ * Returns undefined when the result should not be present at all.
+ */
+export function applyLuckyDrawPolicy({ incoming, stored, role }) {
+  if (role === 'admin') {
+    return incoming === undefined ? normalizeLuckyDraw(stored) : normalizeLuckyDraw(incoming);
+  }
+  return normalizeLuckyDraw(stored);
+}

--- a/backend/src/utils/sgtTime.js
+++ b/backend/src/utils/sgtTime.js
@@ -1,0 +1,22 @@
+/**
+ * Singapore-time day boundaries. SGT (+08:00) observes no DST, so a calendar
+ * day is exactly 24h and boundaries are computable with a fixed offset.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const YMD_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * EXCLUSIVE end-of-day instant for a YYYY-MM-DD in SGT: the first millisecond
+ * of the NEXT day. An instant t falls on or before the day iff
+ * `t < sgtDayEndExclusiveMs(ymd)` — no 23:59:59.999 gap (the old private
+ * featured-drops helper stopped at 23:59:59.000 and dropped the final 999ms).
+ * Returns null for anything that isn't a valid YYYY-MM-DD string.
+ */
+export function sgtDayEndExclusiveMs(ymd) {
+  if (typeof ymd !== 'string') return null;
+  const s = ymd.trim();
+  if (!YMD_RE.test(s)) return null;
+  const start = Date.parse(`${s}T00:00:00+08:00`);
+  return Number.isNaN(start) ? null : start + DAY_MS;
+}

--- a/backend/test/drawTermsVersioning.test.js
+++ b/backend/test/drawTermsVersioning.test.js
@@ -1,0 +1,91 @@
+/**
+ * Draw-terms versioning (campaignService.ensureDrawTermsVersion, DI seam) —
+ * docs/plans/lucky-draw-10x.md §4.6. Pins: enabling a draw without T&C content
+ * 422s; new content mints version N+1; unchanged content is idempotent (reuses
+ * the row); the result stamps termsVersionId + termsHash into luckyDraw.
+ */
+import crypto from 'crypto';
+import { jest } from '@jest/globals';
+import { ensureDrawTermsVersion } from '../src/services/campaignService.js';
+
+const CAMPAIGN_ID = 'camp-1';
+const USER_ID = 'admin-1';
+
+function fakeModel({ existing = null, latestVersion = null } = {}) {
+  const created = [];
+  return {
+    created,
+    findOne: jest.fn().mockResolvedValue(existing),
+    max: jest.fn().mockResolvedValue(latestVersion),
+    create: jest.fn().mockImplementation((fields) => {
+      const row = { id: `dtv-${created.length + 1}`, ...fields };
+      created.push(row);
+      return Promise.resolve(row);
+    }),
+  };
+}
+
+describe('ensureDrawTermsVersion', () => {
+  it('passes through untouched when luckyDraw is absent or disabled', async () => {
+    const DrawTermsVersion = fakeModel();
+    const plain = { termsContent: 'x' };
+    expect(await ensureDrawTermsVersion(plain, CAMPAIGN_ID, USER_ID, { DrawTermsVersion })).toBe(plain);
+    const off = { luckyDraw: { enabled: false } };
+    expect(await ensureDrawTermsVersion(off, CAMPAIGN_ID, USER_ID, { DrawTermsVersion })).toBe(off);
+    expect(DrawTermsVersion.findOne).not.toHaveBeenCalled();
+  });
+
+  it('422s when an enabled draw has no T&C content', async () => {
+    const DrawTermsVersion = fakeModel();
+    await expect(
+      ensureDrawTermsVersion({ luckyDraw: { enabled: true }, termsContent: '   ' }, CAMPAIGN_ID, USER_ID, { DrawTermsVersion })
+    ).rejects.toMatchObject({ statusCode: 422 });
+    expect(DrawTermsVersion.create).not.toHaveBeenCalled();
+  });
+
+  it('mints version N+1 for new content and stamps id + hash into luckyDraw', async () => {
+    const DrawTermsVersion = fakeModel({ latestVersion: 3 });
+    const designConfig = { luckyDraw: { enabled: true, prize: 'Luggage' }, termsContent: '  <p>Draw rules v4</p> ' };
+    const out = await ensureDrawTermsVersion(designConfig, CAMPAIGN_ID, USER_ID, { DrawTermsVersion });
+
+    const expectedHash = crypto.createHash('sha256').update('<p>Draw rules v4</p>').digest('hex');
+    expect(DrawTermsVersion.create).toHaveBeenCalledWith(expect.objectContaining({
+      campaignId: CAMPAIGN_ID,
+      version: 4,
+      content: '<p>Draw rules v4</p>',
+      contentSha256: expectedHash,
+      createdBy: USER_ID,
+    }));
+    expect(out.luckyDraw).toMatchObject({ enabled: true, prize: 'Luggage', termsVersionId: 'dtv-1', termsHash: expectedHash });
+    // Input is not mutated — a fresh object is returned.
+    expect(designConfig.luckyDraw.termsVersionId).toBeUndefined();
+  });
+
+  it('is idempotent: unchanged content reuses the existing version row', async () => {
+    const hash = crypto.createHash('sha256').update('<p>Rules</p>').digest('hex');
+    const DrawTermsVersion = fakeModel({ existing: { id: 'dtv-existing', version: 2, contentSha256: hash } });
+    const out = await ensureDrawTermsVersion(
+      { luckyDraw: { enabled: true }, termsContent: '<p>Rules</p>' },
+      CAMPAIGN_ID, USER_ID, { DrawTermsVersion }
+    );
+    expect(DrawTermsVersion.create).not.toHaveBeenCalled();
+    expect(out.luckyDraw.termsVersionId).toBe('dtv-existing');
+    expect(out.luckyDraw.termsHash).toBe(hash);
+  });
+
+  it('recovers when a concurrent save minted the version first', async () => {
+    const hash = crypto.createHash('sha256').update('<p>Rules</p>').digest('hex');
+    const winner = { id: 'dtv-winner', version: 1, contentSha256: hash };
+    const DrawTermsVersion = fakeModel();
+    DrawTermsVersion.findOne
+      .mockResolvedValueOnce(null)       // pre-create lookup: not there yet
+      .mockResolvedValueOnce(winner);    // post-conflict retry finds the winner
+    DrawTermsVersion.create.mockRejectedValueOnce(new Error('unique violation'));
+
+    const out = await ensureDrawTermsVersion(
+      { luckyDraw: { enabled: true }, termsContent: '<p>Rules</p>' },
+      CAMPAIGN_ID, USER_ID, { DrawTermsVersion }
+    );
+    expect(out.luckyDraw.termsVersionId).toBe('dtv-winner');
+  });
+});

--- a/backend/test/entitlementUnlockVia.test.js
+++ b/backend/test/entitlementUnlockVia.test.js
@@ -1,0 +1,123 @@
+/**
+ * Server-derived unlockedVia on both consultant unlock routes
+ * (docs/plans/lucky-draw-10x.md §4.4): only a presentation token counts as
+ * scan evidence; a bare prospectId is ALWAYS the button path, regardless of
+ * any client-sent `via`. Before this fix, {prospectId, via:'scan'} forged
+ * scan evidence.
+ *
+ * entitlementService + models are mocked (unstable_mockModule, repo pattern);
+ * the routers are exercised through supertest. The Lyfe route's inline HMAC is
+ * satisfied with a genuinely signed request; the external route's shared
+ * requireExternalHmac middleware is stubbed to pass (its own behaviour is
+ * covered by the externalHeldLeadsController tests).
+ */
+import { jest } from '@jest/globals';
+import crypto from 'crypto';
+import express from 'express';
+import request from 'supertest';
+
+const LYFE_SECRET = 'test-lyfe-outcome-secret';
+
+const unlockMock = jest.fn();
+
+jest.unstable_mockModule('../src/services/redeemOps/entitlementService.js', () => ({
+  makeEntitlementService: () => ({ unlockEntitlement: unlockMock }),
+}));
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  User: { findOne: jest.fn().mockResolvedValue({ id: 'agent-1', role: 'agent' }) },
+}));
+jest.unstable_mockModule('../src/controllers/externalBillingController.js', () => ({
+  requireExternalHmac: (_req, _res, next) => next(),
+}));
+
+let externalRouter, lyfeRouter;
+
+beforeAll(async () => {
+  ({ default: externalRouter } = await import('../src/routes/externalEntitlements.js'));
+  ({ default: lyfeRouter } = await import('../src/routes/lyfeEntitlementUnlock.js'));
+});
+
+beforeEach(() => {
+  process.env.LYFE_LEAD_OUTCOME_SECRET = LYFE_SECRET;
+  unlockMock.mockReset().mockResolvedValue({
+    already: false,
+    entitlement: { id: 'ent-1', status: 'issued', tokenHint: 'ABCD' },
+  });
+});
+
+function externalApp() {
+  return express().use(express.json()).use(externalRouter);
+}
+
+function lyfeApp() {
+  // Mirror server_internal.js: the prefix captures rawBody for the HMAC check.
+  return express()
+    .use(express.json({ verify: (req, _res, buf) => { req.rawBody = buf.toString('utf8'); } }))
+    .use(lyfeRouter);
+}
+
+function lyfeSign(bodyString, timestamp) {
+  const hex = crypto.createHmac('sha256', LYFE_SECRET).update(`${timestamp}.${bodyString}`).digest('hex');
+  return `sha256=${hex}`;
+}
+
+describe('external (mktr-leads) unlock — server-derived via', () => {
+  it('prospectId with a forged via:"scan" is recorded as agent_button', async () => {
+    const res = await request(externalApp())
+      .post('/unlock')
+      .send({ agentMktrUserId: 'm-1', prospectId: 'pros-1', via: 'scan' });
+    expect(res.status).toBe(200);
+    expect(unlockMock).toHaveBeenCalledWith({ prospectId: 'pros-1' }, expect.anything(), 'agent_button');
+  });
+
+  it('presentationToken is recorded as agent_scan (client via ignored)', async () => {
+    const res = await request(externalApp())
+      .post('/unlock')
+      .send({ agentMktrUserId: 'm-1', presentationToken: 'tok-1', via: 'button' });
+    expect(res.status).toBe(200);
+    expect(unlockMock).toHaveBeenCalledWith({ presentationToken: 'tok-1' }, expect.anything(), 'agent_scan');
+  });
+
+  it('still 400s without an identifier', async () => {
+    const res = await request(externalApp()).post('/unlock').send({ agentMktrUserId: 'm-1' });
+    expect(res.status).toBe(400);
+    expect(unlockMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('lyfe unlock — server-derived via (through real HMAC)', () => {
+  async function signedPost(body) {
+    const bodyString = JSON.stringify(body);
+    const timestamp = new Date().toISOString();
+    return request(lyfeApp())
+      .post('/entitlement-unlock')
+      .set('content-type', 'application/json')
+      .set('x-webhook-timestamp', timestamp)
+      .set('x-webhook-signature', lyfeSign(bodyString, timestamp))
+      .send(bodyString);
+  }
+
+  it('prospectId with a forged via:"scan" is recorded as agent_button', async () => {
+    const res = await signedPost({ agentLyfeId: 'l-1', prospectId: 'pros-9', via: 'scan' });
+    expect(res.status).toBe(200);
+    expect(unlockMock).toHaveBeenCalledWith({ prospectId: 'pros-9' }, expect.anything(), 'agent_button');
+  });
+
+  it('presentationToken is recorded as agent_scan', async () => {
+    const res = await signedPost({ agentLyfeId: 'l-1', presentationToken: 'tok-9' });
+    expect(res.status).toBe(200);
+    expect(unlockMock).toHaveBeenCalledWith({ presentationToken: 'tok-9' }, expect.anything(), 'agent_scan');
+  });
+
+  it('rejects a bad signature with 401', async () => {
+    const bodyString = JSON.stringify({ agentLyfeId: 'l-1', prospectId: 'pros-9' });
+    const res = await request(lyfeApp())
+      .post('/entitlement-unlock')
+      .set('content-type', 'application/json')
+      .set('x-webhook-timestamp', new Date().toISOString())
+      .set('x-webhook-signature', 'sha256=deadbeef')
+      .send(bodyString);
+    expect(res.status).toBe(401);
+    expect(unlockMock).not.toHaveBeenCalled();
+  });
+});

--- a/backend/test/luckyDraw.util.test.js
+++ b/backend/test/luckyDraw.util.test.js
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for design_config.luckyDraw normalization + admin-only policy
+ * (utils/luckyDraw.js) and the shared SGT day-boundary helper (utils/sgtTime.js).
+ * Mirrors featuredDrop.util.test.js — these values gate PUBLIC signup
+ * enforcement, so the clamp is the security boundary.
+ */
+import { normalizeLuckyDraw, applyLuckyDrawPolicy } from '../src/utils/luckyDraw.js';
+import { sgtDayEndExclusiveMs } from '../src/utils/sgtTime.js';
+
+const UUID = '123e4567-e89b-42d3-a456-426614174000';
+const HASH = 'a'.repeat(64);
+
+describe('normalizeLuckyDraw', () => {
+  it('returns undefined for non-objects (caller drops the key)', () => {
+    for (const v of [undefined, null, 'x', 42, [], true]) {
+      expect(normalizeLuckyDraw(v)).toBeUndefined();
+    }
+  });
+
+  it('coerces enabled to a strict boolean', () => {
+    expect(normalizeLuckyDraw({ enabled: true }).enabled).toBe(true);
+    expect(normalizeLuckyDraw({ enabled: 'yes' }).enabled).toBe(false);
+    expect(normalizeLuckyDraw({}).enabled).toBe(false);
+  });
+
+  it('keeps valid YMD dates and drops invalid ones', () => {
+    const out = normalizeLuckyDraw({
+      enabled: true,
+      closesAt: '2026-08-31',
+      boostClosesAt: '31/08/2026',
+      drawOn: '2026-13-99',
+    });
+    expect(out.closesAt).toBe('2026-08-31');
+    expect(out.boostClosesAt).toBeUndefined();
+    expect(out.drawOn).toBeUndefined();
+  });
+
+  it('defaults multiplier to 10 and clamps out-of-range values back to 10', () => {
+    expect(normalizeLuckyDraw({}).multiplier).toBe(10);
+    expect(normalizeLuckyDraw({ multiplier: 50 }).multiplier).toBe(50);
+    expect(normalizeLuckyDraw({ multiplier: 1 }).multiplier).toBe(10);
+    expect(normalizeLuckyDraw({ multiplier: 101 }).multiplier).toBe(10);
+    expect(normalizeLuckyDraw({ multiplier: 'ten' }).multiplier).toBe(10);
+  });
+
+  it('keeps well-formed uuids/hashes and drops junk', () => {
+    const out = normalizeLuckyDraw({
+      enabled: true,
+      activationId: UUID.toUpperCase(),
+      termsVersionId: 'not-a-uuid',
+      termsHash: HASH.toUpperCase(),
+    });
+    expect(out.activationId).toBe(UUID);
+    expect(out.termsVersionId).toBeUndefined();
+    expect(out.termsHash).toBe(HASH);
+  });
+
+  it('trims + caps the prize and strips unknown keys', () => {
+    const out = normalizeLuckyDraw({ enabled: true, prize: '  Cabin luggage  ', evil: 'x' });
+    expect(out.prize).toBe('Cabin luggage');
+    expect(out.evil).toBeUndefined();
+  });
+});
+
+describe('applyLuckyDrawPolicy', () => {
+  const stored = { enabled: true, prize: 'Luggage', multiplier: 10 };
+
+  it('admin: incoming wins; omitting the key preserves stored', () => {
+    const incoming = { enabled: false };
+    expect(applyLuckyDrawPolicy({ incoming, stored, role: 'admin' }).enabled).toBe(false);
+    expect(applyLuckyDrawPolicy({ incoming: undefined, stored, role: 'admin' }).prize).toBe('Luggage');
+  });
+
+  it('non-admin: stored preserved, incoming ignored', () => {
+    const incoming = { enabled: false, prize: 'Hijacked' };
+    const out = applyLuckyDrawPolicy({ incoming, stored, role: 'agent' });
+    expect(out.enabled).toBe(true);
+    expect(out.prize).toBe('Luggage');
+  });
+
+  it('returns undefined when neither side has a usable value', () => {
+    expect(applyLuckyDrawPolicy({ incoming: undefined, stored: undefined, role: 'admin' })).toBeUndefined();
+    expect(applyLuckyDrawPolicy({ incoming: { enabled: true }, stored: undefined, role: 'agent' })).toBeUndefined();
+  });
+});
+
+describe('sgtDayEndExclusiveMs', () => {
+  it('returns the first ms of the NEXT SGT day (exclusive boundary)', () => {
+    const end = sgtDayEndExclusiveMs('2026-07-12');
+    expect(end).toBe(Date.parse('2026-07-13T00:00:00+08:00'));
+    // 23:59:59.999 SGT is still within the day; midnight is not.
+    expect(Date.parse('2026-07-12T23:59:59.999+08:00')).toBeLessThan(end);
+    expect(Date.parse('2026-07-13T00:00:00.000+08:00')).toBe(end);
+  });
+
+  it('returns null for invalid input', () => {
+    for (const v of [null, undefined, 42, '2026-13-99', '12/07/2026', '2026-07-12T00:00:00Z']) {
+      expect(sgtDayEndExclusiveMs(v)).toBeNull();
+    }
+  });
+});

--- a/backend/test/prospectServiceDrawGate.test.js
+++ b/backend/test/prospectServiceDrawGate.test.js
@@ -1,0 +1,192 @@
+/**
+ * Lucky-draw entry gate + verification-stamp binding
+ * (docs/plans/lucky-draw-10x.md §4.4), via the makeProspectService DI seam —
+ * no live Postgres. Pins:
+ *  - draw campaigns REQUIRE phone (422), accepted terms (422), a live OTP
+ *    marker on the NORMALIZED phone (403), and an open entry window (410);
+ *  - the stamp is written post-normalization with phoneVerifiedFor binding;
+ *  - draw-terms acceptance is pinned into consentMetadata.drawTerms;
+ *  - non-draw campaigns keep the capture-everything posture byte-identical.
+ */
+import { createHash } from 'crypto';
+import { jest } from '@jest/globals';
+import { makeProspectService } from '../src/services/prospectService.js';
+
+const silentLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+
+const FULL_PHONE = '+6591234567';
+const TERMS_VERSION_ID = '123e4567-e89b-42d3-a456-426614174000';
+const TERMS_HASH = 'b'.repeat(64);
+
+function drawCampaign(overrides = {}) {
+  return {
+    id: 'camp-draw-1',
+    name: 'Cabin Luggage Draw',
+    status: 'active',
+    design_config: {
+      luckyDraw: {
+        enabled: true,
+        closesAt: '2099-12-31',
+        prize: 'Cabin luggage',
+        multiplier: 10,
+        termsVersionId: TERMS_VERSION_ID,
+        termsHash: TERMS_HASH,
+        ...overrides,
+      },
+    },
+  };
+}
+
+function buildDeps({ campaign = null, phoneVerified = () => false, overrides = {} } = {}) {
+  const Prospect = {
+    findOne: jest.fn().mockResolvedValue(null),
+    findByPk: jest.fn().mockImplementation((id) =>
+      Promise.resolve({ id, campaign: null, assignedAgent: null })
+    ),
+    create: jest.fn().mockImplementation((fields) =>
+      Promise.resolve({ id: 'pros-1', ...fields, update: jest.fn() })
+    ),
+  };
+  const models = {
+    Prospect,
+    ProspectActivity: { create: jest.fn().mockResolvedValue({}) },
+    Attribution: { findOne: jest.fn().mockResolvedValue(null) },
+    Campaign: { findByPk: jest.fn().mockResolvedValue(campaign) },
+    QrTag: { findByPk: jest.fn().mockResolvedValue(null) },
+    User: { findByPk: jest.fn().mockResolvedValue(null) },
+    AgentGroup: { findByPk: jest.fn().mockResolvedValue(null) },
+    AgentGroupMember: { findAll: jest.fn().mockResolvedValue([]) },
+    Commission: {},
+  };
+  return {
+    models,
+    sequelize: {
+      transaction: jest.fn().mockImplementation(async (cb) => cb({})),
+      literal: jest.fn().mockImplementation((s) => ({ literal: s })),
+    },
+    resolveAssignedAgentId: jest.fn().mockResolvedValue(null),
+    getSystemAgentId: jest.fn().mockResolvedValue(null),
+    deductLeadCredit: jest.fn().mockResolvedValue(),
+    buildProspectWhere: jest.fn(),
+    // The happy path runs to completion, so every dep that would touch a live
+    // Postgres is stubbed (unlike prospectServiceCapi.test.js, which predates
+    // this and needs the throwaway-pg setup to go green).
+    resolveLeadRouting: jest.fn().mockResolvedValue({ agentId: null, via: 'none' }),
+    resolveLeadAssignment: jest.fn().mockResolvedValue({ agentId: null, via: 'none' }),
+    chargeLeadCredit: jest.fn().mockResolvedValue({ charged: false }),
+    deductExternalLeadBalance: jest.fn().mockResolvedValue({ charged: false }),
+    hasDeliverableSubscriber: jest.fn().mockResolvedValue(false),
+    persistEventDeliveries: jest.fn().mockResolvedValue([]),
+    flushDeliveries: jest.fn().mockResolvedValue(),
+    getOrCreateProspectShareLink: jest.fn().mockResolvedValue({ url: '/share/test' }),
+    dispatchEvent: jest.fn().mockResolvedValue(),
+    sendLeadEvent: jest.fn().mockResolvedValue({ sent: false, reason: 'guarded' }),
+    sendCompleteRegistrationEvent: jest.fn().mockResolvedValue({ sent: false, reason: 'guarded' }),
+    sendTikTokLeadEvent: jest.fn().mockResolvedValue({ sent: false, reason: 'guarded' }),
+    sendTikTokCompleteRegistrationEvent: jest.fn().mockResolvedValue({ sent: false, reason: 'guarded' }),
+    isPhoneRecentlyVerified: jest.fn().mockImplementation(phoneVerified),
+    AppError: class AppError extends Error {
+      constructor(m, s) { super(m); this.statusCode = s; }
+    },
+    logger: silentLogger,
+    ...overrides,
+  };
+}
+
+const admin = { id: 'admin-1', role: 'admin' };
+const baseBody = {
+  firstName: 'Jane',
+  lastName: 'Doe',
+  email: 'jane@example.com',
+  leadSource: 'qr_code',
+  campaignId: 'camp-draw-1',
+  consent_terms: true,
+};
+
+describe('lucky-draw entry gate (createProspect)', () => {
+  it('rejects a phone-less entry with 422', async () => {
+    const deps = buildDeps({ campaign: drawCampaign() });
+    const svc = makeProspectService(deps);
+    await expect(svc.createProspect({ ...baseBody }, admin, {})).rejects.toMatchObject({ statusCode: 422 });
+    expect(deps.models.Prospect.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing consent_terms with 422', async () => {
+    const deps = buildDeps({ campaign: drawCampaign(), phoneVerified: () => true });
+    const svc = makeProspectService(deps);
+    const { consent_terms: _omit, ...noTerms } = baseBody;
+    await expect(
+      svc.createProspect({ ...noTerms, phone: FULL_PHONE }, admin, {})
+    ).rejects.toMatchObject({ statusCode: 422 });
+  });
+
+  it('rejects an unverified phone with 403', async () => {
+    const deps = buildDeps({ campaign: drawCampaign(), phoneVerified: () => false });
+    const svc = makeProspectService(deps);
+    await expect(
+      svc.createProspect({ ...baseBody, phone: FULL_PHONE }, admin, {})
+    ).rejects.toMatchObject({ statusCode: 403 });
+    expect(deps.models.Prospect.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects entries after closesAt (SGT end-of-day, exclusive) with 410', async () => {
+    const deps = buildDeps({
+      campaign: drawCampaign({ closesAt: '2020-01-01' }),
+      phoneVerified: (p) => p === FULL_PHONE,
+    });
+    const svc = makeProspectService(deps);
+    await expect(
+      svc.createProspect({ ...baseBody, phone: FULL_PHONE }, admin, {})
+    ).rejects.toMatchObject({ statusCode: 410 });
+  });
+
+  it('normalizes a raw 8-digit phone BEFORE the marker check, then stamps the binding + draw terms', async () => {
+    // Marker keyed by full E.164 (how /verify/check writes it) — a raw-digits
+    // body must still match after normalization (Codex-review fix, §4.4).
+    const deps = buildDeps({
+      campaign: drawCampaign(),
+      phoneVerified: (p) => p === FULL_PHONE,
+    });
+    const svc = makeProspectService(deps);
+    await svc.createProspect({ ...baseBody, phone: '91234567' }, admin, {});
+
+    expect(deps.models.Prospect.create).toHaveBeenCalledTimes(1);
+    const created = deps.models.Prospect.create.mock.calls[0][0];
+    expect(created.phone).toBe(FULL_PHONE);
+    expect(created.sourceMetadata.phoneVerifiedAt).toEqual(expect.any(String));
+    expect(created.sourceMetadata.phoneVerifiedFor).toBe(
+      createHash('sha256').update(FULL_PHONE).digest('hex')
+    );
+    expect(created.consentMetadata.drawTerms).toMatchObject({
+      termsVersionId: TERMS_VERSION_ID,
+      termsHash: TERMS_HASH,
+      acceptedAt: expect.any(String),
+    });
+  });
+
+  it('leaves non-draw campaigns byte-identical: phone-less, consent-less POST still captures', async () => {
+    const deps = buildDeps({
+      campaign: { id: 'camp-plain', name: 'Plain', status: 'active', design_config: {} },
+    });
+    const svc = makeProspectService(deps);
+    const { consent_terms: _omit, ...noTerms } = baseBody;
+    await svc.createProspect({ ...noTerms, campaignId: 'camp-plain' }, admin, {});
+    expect(deps.models.Prospect.create).toHaveBeenCalledTimes(1);
+    const created = deps.models.Prospect.create.mock.calls[0][0];
+    expect(created.sourceMetadata?.phoneVerifiedAt).toBeUndefined();
+    expect(created.consentMetadata?.drawTerms).toBeUndefined();
+  });
+
+  it('stamps phoneVerifiedFor on NON-draw campaigns too when the marker is live', async () => {
+    const deps = buildDeps({
+      campaign: { id: 'camp-plain', name: 'Plain', status: 'active', design_config: {} },
+      phoneVerified: (p) => p === FULL_PHONE,
+    });
+    const svc = makeProspectService(deps);
+    await svc.createProspect({ ...baseBody, campaignId: 'camp-plain', phone: FULL_PHONE }, admin, {});
+    const created = deps.models.Prospect.create.mock.calls[0][0];
+    expect(created.sourceMetadata.phoneVerifiedFor).toBe(
+      createHash('sha256').update(FULL_PHONE).digest('hex')
+    );
+  });
+});

--- a/backend/test/unit/campaignDeviceSync.test.js
+++ b/backend/test/unit/campaignDeviceSync.test.js
@@ -79,6 +79,12 @@ jest.unstable_mockModule('../../src/models/index.js', () => ({
   Commission,
   CampaignMediaItem,
   CampaignAgentAssignment,
+  // Draw-terms versioning dep (lucky draw) — inert stub, not exercised here.
+  DrawTermsVersion: {
+    findOne: async () => null,
+    max: async () => null,
+    create: async (fields) => ({ id: 'dtv-mock', ...fields }),
+  },
   sequelize,
 }));
 

--- a/backend/test/unit/campaignService.test.js
+++ b/backend/test/unit/campaignService.test.js
@@ -80,6 +80,13 @@ const pushSendEvent = jest.fn();
 jest.unstable_mockModule('../../src/models/index.js', () => ({
   Campaign, QrTag, Prospect, Commission, Device,
   CampaignMediaItem, CampaignAgentAssignment, sequelize,
+  // Draw-terms versioning dep (lucky draw) — inert stub; drawTermsVersioning.test.js
+  // covers the real logic through the DI seam.
+  DrawTermsVersion: {
+    findOne: async () => null,
+    max: async () => null,
+    create: async (fields) => ({ id: 'dtv-mock', ...fields }),
+  },
   Op,
 }));
 

--- a/docs/plans/lucky-draw-10x.md
+++ b/docs/plans/lucky-draw-10x.md
@@ -1,0 +1,335 @@
+# Lucky Draw + 10× Session Multiplier — Design & Implementation Plan
+
+> Status: DRAFT v2 (2026-07-12). Codex-reviewed (gpt-5.6-sol xhigh) and corrected
+> against the repo; review disposition in §9. Not yet implemented.
+> Companion reading: `docs/redeem-ops/MKTR_INTEGRATION.md` §2 (entitlements),
+> `docs/plans/redeem-home-featured-drops.md` (homepage drops).
+
+## 1. Goal & mechanic
+
+Run consumer lucky-draw campaigns on redeem.sg with a defensible, auditable draw:
+
+- **1× chance** — verified signup on the campaign's LeadCapture form (SMS OTP).
+- **10× chances** — the prospect completes a ~20-min financial-advisory session,
+  recorded by their **assigned consultant**:
+  - **Physical meeting**: consultant scans the QR pass from the customer's email.
+  - **Virtual meeting (Zoom)**: primary path is still a scan — the customer shows
+    the QR on screen / webcam and the consultant scans it off the screen (a real
+    token-backed scan). Fallback: a "virtual meeting" toggle → button unlock,
+    which is review-gated for draw weighting (§6).
+- Winner drawn after close (weighted random, witnessed, reproducible), contacted
+  directly, 14 days to claim, redrawn if unclaimed, published on redeem.sg/winners.
+
+Consultant channel: **mktr-leads** (mirrored `User` agents via `mktrLeadsId`)
+first; Lyfe app (internal agents) later. The paid `ExternalAgent` buyer rail is
+**out of scope** — the unlock routes resolve `User` rows and authorize
+`prospect.assignedAgentId` only, and draw-campaign leads are never sold leads.
+
+## 2. What already exists (verified 2026-07-12)
+
+| Rail | Where | Notes |
+|---|---|---|
+| Reservation + QR pass email at signup | `backend/src/services/redeemOps/fulfilmentNotify.js` `sendReservationEmail` | Inline QR (CID), `/r/{token}` link, "show this pass to your consultant". Fires from the capture hook when the campaign has a live Activation. |
+| Presentation-pass token | `backend/src/services/redeemOps/tokens.js` | 32-byte base64url, SHA-256 at rest, shown once. |
+| Issuance preconditions (anti-farming) | `entitlementService.js` `issueForProspect` | Requires `sourceMetadata.phoneVerifiedAt`, not quarantined, live activation with allocation. **Caveat:** `issueManual` (`entitlementService.js:233`) fabricates `phoneVerifiedAt` when absent — manual issues are NOT OTP evidence and must be excluded/reviewed for ×10 (`issuedVia='manual'` is recorded). |
+| Unlock API — mktr-leads | `backend/src/routes/externalEntitlements.js` `POST /api/external/entitlements/unlock` | HMAC over raw body with `EXTERNAL_APP_SECRET` **+ signed `timestamp` field required in the body** (`externalBillingController.js:62`). Body: `{timestamp, agentMktrUserId, presentationToken?\|prospectId?, via?}`. |
+| Unlock API — Lyfe | `backend/src/routes/lyfeEntitlementUnlock.js` `POST /api/integrations/lyfe/entitlement-unlock` | HMAC via `x-webhook-timestamp`/`x-webhook-signature` **headers** (`LYFE_LEAD_OUTCOME_SECRET`) — different envelope from the external route. |
+| Scan vs button recording | `RewardEntitlement.unlockedVia` + `RedemptionEvent` metadata | **Today the label is caller-chosen** — both routes map `via !== 'button'` → `agent_scan` regardless of whether a token or a prospectId was supplied. §4.4 fixes this server-side (Phase 1) before scan evidence is trusted. |
+| Assigned-consultant guard | `entitlementService.js` `unlockEntitlement` (~172-178) | 403 unless `prospect.assignedAgentId === agentUser.id`; admin override recorded `unlockedVia='manual'`. |
+| Replay-safe unlock | `entitlementService.js` (conditional `status:'eligible'` UPDATE) | `eligible → issued`; stamps `unlockedAt/unlockedByUserId/unlockedVia`; expiry-checked. Writes an append-only `redemption_events` row `type='unlocked'` with `metadata.via` — **this event row is the durable ×10 evidence** (an `issued` entitlement can later be `cancelled`: `cancelEntitlement` accepts `eligible|issued`). |
+| Status lifecycle | `RewardEntitlement.status` | `eligible → issued → redeemed`; `expired\|cancelled\|blocked`. Unique `(activationId, prospectId)` index has **no status filter** (migration 050) — an expired/cancelled row permanently blocks reissue for that activation+prospect. |
+| One live activation per campaign | migration 049 `uq_act_live_campaign` | Partial unique on `campaignId` across `preparing\|active\|paused` — at most one live activation, schema-guaranteed. |
+| Capture hook composition root | `backend/src/database/bootstrap.js` (~203-215) | Registered only when `REDEEM_OPS_ENABLED` + `REDEEM_OPS_ENTITLEMENTS_ENABLED` true. Hook is **skipped for quarantined prospects** (`prospectService.js:962`); late release reconciliation only covers ~48h (`entitlementService.js:319`). |
+| One phone = one entry per campaign | `prospectService.js` (~429-461) + partial unique index `prospects_campaign_id_phone` (migration 010) | App precheck returns 409; a concurrent duplicate that reaches the index surfaces as a generic 400 (`errorHandler.js:47`). **Verify the index exists in prod** (migration swallows errors; the model comment's `ensurePostgresIndexes` does not exist). |
+| Campaign off gate | `prospectService.js` (~347-361) | Non-`active` status → 410. Real Pause exists in the flag-gated workspace (`CampaignLaunchTab.jsx`, `campaignService.js` `setCampaignActive` → `paused`); classic UI Edit→Active-off maps to `draft` (also blocks). |
+| Homepage drop card | `featuredDropsService.js` | `design_config.featuredDrop` (cap + SGT endsAt, display-only). `sgtEndOfDayMs` is module-private — extract to a shared util before reuse. |
+| Winners' wall | `src/pages/RedeemWinners.jsx` + `redeemWinnersContent.js` | Static, hand-edited, PDPA-masked format. Stays the publishing surface for v1. |
+
+## 3. Blockers this plan must close (from the 2026-07-12 platform review)
+
+1. **No server-enforced verified-entry invariant** — `phone` optional in the
+   public schema; OTP marker never required; `consent_terms` optional
+   server-side (`validation.js:215`). → Phase 1.
+2. **No immutable pool / draw ledger** — prospects hard-deletable and editable
+   (phone can change while `phoneVerifiedAt` survives, unbound to a value);
+   AdminProspects export is selection-or-current-page only. → Phases 1–2.
+3. **No authoritative close** — `end_date` unenforced. → Phase 1 (`closesAt`
+   gate) + Phase 2 (freeze enforces the stored cutoff independently).
+4. **No 10× evidence** — closed by unlock events + server-derived `via`. → Phases 1–3.
+5. **Confirmation email copy wrong for draws** (generic "gift + 24h call"
+   template; mailer uses static HTML+text template files, so this is a new
+   template pair, not a copy branch). → Phase 1.
+6. **T&Cs mutable after the fact** — adopt the repo's existing append-only
+   versioned-terms pattern (`RewardTermsVersion`), not a bare hash. → Phase 1.
+
+## 4. Design
+
+### 4.1 Campaign shape
+
+A lucky draw is a **Regular (`lead_generation`) campaign** with:
+
+- `design_config.luckyDraw = { enabled: true, closesAt: 'YYYY-MM-DD', boostClosesAt: 'YYYY-MM-DD', drawOn?: 'YYYY-MM-DD', prize: '…', multiplier: 10, activationId: '<uuid>', termsVersionId: '<uuid>' }`
+  — admin-gated on write like `featuredDrop` (`applyFeaturedDropPolicy` pattern),
+  clamped server-side in `campaignService`. `duplicateCampaign` must strip
+  `luckyDraw` (it currently copies design config wholesale and disables only
+  `featuredDrop` — `campaignService.js:412`).
+- A live Redeem Ops **Activation** (`luckyDraw.activationId`, validated to belong
+  to this campaign). Recommended: pair the draw with the guaranteed session
+  voucher — one Activation powers the voucher AND the ×10 evidence.
+- All dates stored/compared as **UTC instants derived from SGT day boundaries**
+  (next-day-exclusive, i.e. `< (date+1)T00:00+08:00` — avoids the 999ms gap in
+  the featured-drops helper).
+- Optional `design_config.featuredDrop` for the homepage card.
+
+### 4.2 Entry tiers (the draw predicate)
+
+Executable form (columns are camelCase and must be quoted):
+
+```sql
+-- 1× pool: verified entrants in the entry window
+SELECT p.id, p.phone, p."firstName", p."lastName"
+FROM prospects p
+WHERE p."campaignId" = :campaignId
+  AND p.phone IS NOT NULL
+  AND p."sourceMetadata"->>'phoneVerifiedAt' IS NOT NULL
+  AND p."sourceMetadata"->>'phoneVerifiedFor' = encode(digest(p.phone, 'sha256'), 'hex')  -- Phase 1 binding, §4.4
+  AND p."createdAt" <= :closesAtInstant;
+
+-- ×10 evidence: append-only unlock EVENTS (not current status — an issued
+-- entitlement can later be cancelled), scoped to the designated activation,
+-- inside the boost window, with server-derived via:
+SELECT re."prospectId", ev."createdAt" AS "unlockedAt", ev.metadata->>'via' AS via
+FROM redemption_events ev
+JOIN reward_entitlements re ON re.id = ev."entitlementId"
+WHERE ev.type = 'unlocked'
+  AND re."activationId" = :designatedActivationId
+  AND re."issuedVia" <> 'manual'                      -- manual issues excluded (§8.1)
+  AND ev."createdAt" <= :boostClosesAtInstant;
+-- chances = 10 where via='agent_scan', or via='agent_button' with an APPROVED
+-- boost review row (§4.3); else 1.
+```
+
+- **No activation-status filter at draw time** — completing/cancelling an
+  activation does not cancel existing entitlements and unlock doesn't check it;
+  the designated `activationId` + event cutoff is the boundary.
+- Quarantined prospects (DNC-held / external-hold) **stay in the 1× pool** —
+  quarantine restricts marketing delivery, not entry validity. Note they cannot
+  earn ×10 while quarantined (the capture hook skips them, so no reservation
+  exists; late release reconciles only ~48h back). Draw campaigns should
+  therefore either leave `dncCheckAtSubmit` off (consent-first form instead) or
+  accept 1×-only for held entrants — decide per campaign, state it in T&Cs.
+- Entries accrue until `closesAt`; unlock events count until `boostClosesAt` —
+  a **fixed scheduled instant**, independent of when the operator runs the
+  runner (an ops delay must not silently admit more boosts).
+
+### 4.3 Draw model (new — Phase 2)
+
+Migrations from **057** (numbering verified; duplicate numbers fail
+`migrations.test.js`). Models need named exports + explicit associations in
+`models/index.js` (repo pattern).
+
+```
+draws:        id, campaignId, activationId, termsVersionId,
+              closesAt, boostClosesAt, frozenAt, poolHash,
+              status ENUM(open|frozen|sealed|drawn|published|claimed|void),
+              witnessedByUserId, notes, timestamps
+draw_attempts: id, drawId, attemptNo, seed, pickedEntryId,
+              reason ENUM(initial|unclaimed|unreachable|ineligible|declined),
+              drawnAt, contactedAt, claimDeadline, claimedAt, outcome, timestamps
+              -- every redraw is a child attempt; exclusions = all prior attempts' picks
+draw_entries: id, drawId, prospectId (FK SET NULL), phoneHash, phoneLast4,
+              displayName, chances INT, verifiedAtFreeze, boostVia, boostEventId,
+              UNIQUE(drawId, prospectId)
+draw_boost_reviews: id, drawId, entitlementId, unlockEventId,
+              decision ENUM(approved|rejected), reviewedByUserId, reason, timestamps
+```
+
+- **Two-cutoff freeze**: `freeze` (at/after `closesAt`) snapshots the 1× pool
+  into `draw_entries`; `seal` (at/after `boostClosesAt`, once button reviews are
+  decided) writes `chances` and `poolHash`. Post-freeze staff edits/deletes
+  can't alter the pool; the gap between close and freeze is minimized by running
+  freeze promptly — freeze re-applies the `createdAt <= closesAt` cutoff itself,
+  so late rows never enter regardless of when it runs.
+- **PII posture**: entries store `phoneHash` + `phoneLast4` + `displayName`
+  (enough to publish "9••• •312 · Sarah T." and to audit), never the full
+  phone/email — winner contact uses the live prospect row. Erasure/deletion of a
+  prospect between freeze and award ⇒ entry is disqualified at pick time
+  (recorded as `ineligible`, next attempt drawn). Runner audit JSON prints
+  hashes and masked values only.
+- **poolHash** = SHA-256 over the canonical ordered list of
+  `(entryId, prospectId, phoneHash, chances, boostVia)` tuples — commits to the
+  weights, not just membership.
+- **Seed = commit/reveal**: `poolHash` committed at seal; the seed is generated
+  at pick time in front of the witness (`crypto.randomBytes`), recorded on the
+  attempt with the derived winner. Reproducibility = seed + sealed snapshot
+  re-runs to the same pick; the seed not existing before the witnessed moment is
+  what makes the pick unpredictable. PRNG + ordering specified in code:
+  entries ordered by `id`, expanded by `chances`, index = seeded
+  ChaCha20/xoshiro (any seedable PRNG, pinned + unit-tested) mod total.
+- **Claim lifecycle** on the attempt: `drawnAt → contactedAt → claimedAt` or
+  `claimDeadline` (14d) lapse → next attempt with `reason='unclaimed'`,
+  excluding **all** prior picked entries.
+- Runner: `backend/scripts/run-lucky-draw.js` (`freeze` / `seal` / `draw` /
+  `redraw` / `verify` subcommands; idempotent transitions; refuses to re-seed a
+  drawn attempt). Admin UI panel is a later slice.
+- `draws.status='published'` means the winners-file SPA change is **deployed and
+  verified live** (deploy-verification steps in CLAUDE.md), not merely edited.
+
+### 4.4 Server-enforced verified entries (Phase 1)
+
+Scoped to draw campaigns (`sourceCampaign.design_config.luckyDraw?.enabled`),
+so the general funnel's "never lose a lead" posture is untouched:
+
+- **Gate placement**: after campaign load AND after phone normalization
+  (`prospectService.js:412-415`), before routing/round-robin — the OTP marker is
+  keyed by full `+65…` E.164, and the raw-digits form a direct caller may send
+  must be normalized before the lookup or legit verified callers 403.
+- Require: `phone` present; `isPhoneRecentlyVerified(normalizedPhone)` live
+  (else 403 "verify your number first" — browser flow always passes; retry after
+  re-verify succeeds); `consent_terms === true` (else 422); `now <= closesAt`
+  (else 410).
+- **Bind the stamp to the number**: write
+  `sourceMetadata.phoneVerifiedFor = sha256(normalizedPhone)` alongside
+  `phoneVerifiedAt`. The draw predicate requires the hash to match the current
+  phone — a staff phone edit after verification breaks the match instead of
+  silently inheriting verified status. (Alternative considered — blocking phone
+  edits on draw entrants — rejected: support needs edits; the binding makes
+  edits safe instead of forbidden.)
+- **Server-derived `via`** (both unlock routes): `presentationToken` ⇒
+  `agent_scan`, `prospectId` ⇒ `agent_button`; the client's `via` field becomes
+  advisory-only/ignored. Without this, `{prospectId, via:'scan'}` forges scan
+  evidence today.
+
+### 4.5 Emails (Phase 1)
+
+- New draw confirmation template pair (`confirmation-email-draw.html/.txt` — the
+  mailer loads static template files): "You're in the draw for {prize}. Complete
+  your complimentary session to multiply your chances ×10." Keep the referral
+  block. Selected in `sendLeadConfirmationEmail` by `luckyDraw.enabled`.
+- Reservation-pass email (already built) optionally gains a line: "scanning this
+  at your session = ×10 draw chances" (`fulfilmentNotify.js`).
+
+### 4.6 Draw terms (Phase 1)
+
+- Follow the repo's `RewardTermsVersion` append-only pattern: a
+  `draw_terms_versions` row (content, sha256, version, createdBy) — or reuse the
+  table with a scope column. `luckyDraw.termsVersionId` pins the active version;
+  the draw row copies it at freeze; each draw-campaign prospect stores the
+  accepted version id + hash in `consentMetadata` at create. A bare hash of
+  mutable `design_config.termsContent` is insufficient (empty content renders a
+  JSX default; the dialog sanitizes via DOMPurify, so raw-HTML hashes don't even
+  match what was shown — the versioned row stores the canonical content).
+- Terms must state: entry window + close, draw method (sealed weighted pool,
+  witnessed seeded pick), ×10 condition ("your consultant records your completed
+  session — QR scan at the meeting, or verified confirmation for virtual
+  sessions"), 14-day claim + redraw policy, masked publication on /winners, and
+  the winner-contact channel. **DNC/PDPA position on winner contact needs
+  sign-off** — "transactional" treatment of the prize call is our reading, not a
+  code-verifiable fact.
+
+### 4.7 mktr-leads app (separate repo — Phase 4)
+
+Backend contract (after the Phase 1 `via` fix):
+
+- **Scan screen**: camera → parse `/r/{token}` →
+  `POST /api/external/entitlements/unlock` with
+  `{timestamp: ISO-now, agentMktrUserId, presentationToken}` (HMAC over raw
+  body; `timestamp` in the body is required by `requireExternalHmac`).
+- **Lead detail**: "Session complete" button behind a *"this was a virtual
+  meeting"* toggle → same endpoint with `{timestamp, agentMktrUserId,
+  prospectId}` → recorded `agent_button`; copy states virtual confirmations are
+  reviewed before draw weighting.
+- Identity rail: mirrored `User` agents (`users.mktrLeadsId`) — verified as how
+  the route resolves agents and how draw-campaign leads are assigned. Deploy via
+  Shawn (no write creds in that repo's env); OTA-friendly.
+- Lyfe mirror later: same UI, but the **header-based** HMAC envelope.
+
+## 5. Phases
+
+| Phase | Scope | Size |
+|---|---|---|
+| **0 — Ops setup + launch blockers (no code)** | Verify `prospects_campaign_id_phone` exists in prod (`SELECT indexname FROM pg_indexes WHERE tablename='prospects'`); flip `REDEEM_OPS_ENABLED` + `REDEEM_OPS_ENTITLEMENTS_ENABLED` (+ `VITE_REDEEM_OPS_ENABLED` if ops UI needed); create partner → offer → Activation; **size `offer.claimExpiryDays` to cover earliest-signup → `boostClosesAt`** (reservation expiry = `claimExpiryDays \|\| 30`; an expired reservation cannot be unlocked AND cannot be reissued — the unique index has no status filter); **size activation allocation ≥ expected signups** (exhaustion leaves later entrants with no pass; the reconcile sweep only backfills ~48h). | — |
+| **1 — Draw-campaign hardening** | `luckyDraw` config block + admin clamp + duplicate-strip; create-gate (phone + normalized OTP marker + `consent_terms` + `closesAt`) placed post-normalization; `phoneVerifiedFor` hash binding; **server-derived `via` on both unlock routes**; draw confirmation template pair; `draw_terms_versions` + acceptance stamping; extract shared SGT-boundary util. Tests pin: direct-API POST without OTP → 403, after `closesAt` → 410, `via` forgery impossible, non-draw campaigns byte-identical. | **M–L** |
+| **2 — Draw model + runner** | Migrations 057+ (`draws`, `draw_attempts`, `draw_entries`, `draw_boost_reviews` — winner FK added after entries table to avoid the circular reference, or validated in-service); freeze/seal/draw/redraw service with idempotent transitions; canonical poolHash; commit/reveal seed; pinned seeded PRNG + unit tests; PII-masked snapshot + audit JSON; `run-lucky-draw.js` CLI with safeguards; concurrency tests. | **L** |
+| **3 — Boost review UI** | Ops list of `agent_button` unlock events pending review → approve/reject writes `draw_boost_reviews` (schema exists from Phase 2, so no circularity); needs a reviewer capability added to **both** permission copies (`permissions.js` + SPA copy — drift test enforces equality). | **M** |
+| **4 — mktr-leads screens** | Scan screen + virtual-toggle button unlock per §4.7 (separate repo). | S |
+| **5 — Later** | Lyfe app mirror; admin draw panel; durable per-submission verification records; winners API instead of static file. | — |
+
+Phases 0–3 support a full draw with the ops admin-unlock panel as the interim
+consultant tool **only if** each manual unlock is individually approved in the
+boost review (manual issues/unlocks are excluded from ×10 by default, §8.1).
+
+## 6. Fraud & fairness analysis
+
+| Vector | Control |
+|---|---|
+| Direct-API fake entries (no OTP) | Phase 1 gate: 403 without live normalized OTP marker; phone + terms required. |
+| Entry farming with many SIMs | One entry per phone per campaign (409 + unique index); OTP per phone; SIM cost; T&Cs say "one entry per verified mobile number" (no person-level identity claimed). |
+| Forged scan evidence (`{prospectId, via:'scan'}`) | **Closed in Phase 1**: `via` derived server-side from the identifier. |
+| Consultant self-unlocks ×10 without meeting (button) | `agent_button` requires boost-review approval for draw weight; assigned-consultant guard bounds blast radius to own leads; leads cost package credits; unlock counts visible in ops analytics. |
+| Manual issuance/unlock laundering (`issueManual` fabricates the OTP stamp; admin unlock bypasses the consultant guard) | `issuedVia='manual'` excluded from ×10 by default; inclusion only via an individually approved boost review. |
+| Consultant asks customer to forward QR (no meeting) | Residual — scan proves pass presentation, not session duration. T&Cs wording ("records your completed session") + winner spot-check before award. |
+| Staff phone edit inherits verified status | `phoneVerifiedFor` hash binding (Phase 1) breaks the match on edit. |
+| Staff edits/deletes after close | Freeze re-applies the `createdAt <= closesAt` cutoff; post-freeze snapshot immutable; deletion between close and freeze is bounded by running freeze promptly, and any post-freeze erasure ⇒ recorded disqualification, not silent pool change. |
+| Ops delay extends the boost window | `boostClosesAt` is a fixed stored instant; seal filters events by it, not by run time. |
+| Winner predictable before the witnessed pick | Commit/reveal: poolHash sealed first; seed generated at the witnessed pick, recorded after. |
+| Winner disputes the pick | Sealed snapshot + seed + pinned PRNG reproduce the pick; witness + attempts ledger recorded. |
+| Junk inflates homepage "claimed" meter | Pre-existing (display-only); Phase 1's 403 stops junk at source for draw campaigns. |
+| OTP throughput on shared IPs (CGNAT / venue Wi-Fi) | Pre-existing: `/verify/send`+`/check` share 10 req/15 min/IP (~5 signups). Monitor during ad bursts; split/raise the limiter pre-launch if roadshow or burst traffic is expected. |
+
+## 7. Env & flags
+
+| Var | Value for launch |
+|---|---|
+| `REDEEM_OPS_ENABLED` | `true` (already live for ops) |
+| `REDEEM_OPS_ENTITLEMENTS_ENABLED` | `true` (**currently false — arms reservations, pass emails, unlock routes, capture hook**) |
+| `EXTERNAL_APP_SECRET` | already set (mktr-leads HMAC) |
+| `LYFE_LEAD_OUTCOME_SECRET` | already set (Lyfe HMAC channel) |
+| `DNC_VERIFIED_MARKER_TTL_MS` | optional: raise from 10 min if Phase 1 telemetry shows 403-retries on slow form fills |
+
+Unverifiable from the repo (must check in prod): the prospects unique index,
+current Render flag values, single-instance deployment assumption behind the
+in-memory OTP marker.
+
+## 8. Decisions (was: open questions — resolved with review input)
+
+1. **Manual unlocks/issues**: excluded from ×10 by default; included only via an
+   individually approved `draw_boost_reviews` row. (`issueManual` fabricates the
+   OTP stamp; admin unlock bypasses the consultant guard — both are support
+   tools, not evidence.)
+2. **Activation scoping**: designated `luckyDraw.activationId`, validated
+   against the campaign at enable AND at freeze. No activation-status filter at
+   draw time. (Schema already guarantees ≤1 live activation per campaign.)
+3. **Unlock deadline**: fixed `boostClosesAt` instant (may be after entry
+   close — sessions run 1–3 weeks post-signup and driving completions is the
+   point of ×10). Reservation expiry (`claimExpiryDays`) must cover it (Phase 0
+   blocker).
+4. **Redraw**: same sealed snapshot, excluding **all** prior picked entries;
+   each pick is a `draw_attempts` child row with its own seed, witness, reason
+   (`unclaimed|unreachable|ineligible|declined`), and claim timestamps.
+5. **Prize fulfilment**: a lucky-draw claim/handover record on the attempt row
+   (contacted/claimed/outcome) — NOT the partner `Redemption` model, which has
+   different lifecycle semantics.
+6. **Winners file**: static publishing stays for v1; `published` status requires
+   the deploy verified live (hash-flip check per CLAUDE.md), not just the edit.
+
+## 9. Review log
+
+- **2026-07-12 — Codex (gpt-5.6-sol, xhigh) plan review.** Verified-and-adopted:
+  camelCase quoting in predicate SQL; unlock **events** (not revocable status) as
+  ×10 evidence; explicit `createdAt` cutoff in the pool; `issueManual` fabricated
+  stamp ⇒ manual exclusion; caller-chosen `via` ⇒ server-side derivation moved to
+  Phase 1; external-route `timestamp`-in-body contract; `consent_terms` optional
+  server-side ⇒ required by the Phase 1 gate; `phoneVerifiedAt` unbound to a
+  phone value ⇒ `phoneVerifiedFor` hash binding; versioned terms over bare hash
+  (`RewardTermsVersion` pattern); `duplicateCampaign` cloning `luckyDraw`;
+  circular winner-FK; poolHash must commit to weights; seed commit/reveal;
+  two-cutoff freeze/seal; redraw = child attempts excluding all prior picks;
+  reservation-expiry-blocks-reissue (unique index has no status filter) and
+  allocation-exhaustion (~48h reconcile) promoted to Phase 0 launch blockers;
+  quarantine ⇒ no ×10 path documented; phase sizes revised (1: M–L, 2: L, 3: M);
+  permissions drift test scope for the reviewer capability; PII-masked
+  `draw_entries` + erasure handling; mktr-leads identity rail pinned to mirrored
+  `User`/`mktrLeadsId` (paid `ExternalAgent` rail out of scope).
+- Declined/kept-as-is: none material; DNC "transactional winner contact" kept as
+  an explicit legal-sign-off item rather than a code decision (§4.6).

--- a/docs/plans/lucky-draw-10x.md
+++ b/docs/plans/lucky-draw-10x.md
@@ -1,7 +1,8 @@
 # Lucky Draw + 10× Session Multiplier — Design & Implementation Plan
 
-> Status: DRAFT v2 (2026-07-12). Codex-reviewed (gpt-5.6-sol xhigh) and corrected
-> against the repo; review disposition in §9. Not yet implemented.
+> Status: v2 (2026-07-12), Codex-reviewed (gpt-5.6-sol xhigh); disposition in §9.
+> **Phase 1 IMPLEMENTED** on `feat/lucky-draw-phase1` (commit ba9fc97) — see §5.
+> Migration numbering shifted 057→058 after #136 took 057.
 > Companion reading: `docs/redeem-ops/MKTR_INTEGRATION.md` §2 (entitlements),
 > `docs/plans/redeem-home-featured-drops.md` (homepage drops).
 
@@ -124,8 +125,7 @@ WHERE ev.type = 'unlocked'
 
 ### 4.3 Draw model (new — Phase 2)
 
-Migrations from **057** (numbering verified; duplicate numbers fail
-`migrations.test.js`). Models need named exports + explicit associations in
+Migrations from **059** (058 = draw_terms_versions, shipped in Phase 1; duplicate numbers fail `migrations.test.js`). Models need named exports + explicit associations in
 `models/index.js` (repo pattern).
 
 ```
@@ -249,8 +249,8 @@ Backend contract (after the Phase 1 `via` fix):
 | Phase | Scope | Size |
 |---|---|---|
 | **0 — Ops setup + launch blockers (no code)** | Verify `prospects_campaign_id_phone` exists in prod (`SELECT indexname FROM pg_indexes WHERE tablename='prospects'`); flip `REDEEM_OPS_ENABLED` + `REDEEM_OPS_ENTITLEMENTS_ENABLED` (+ `VITE_REDEEM_OPS_ENABLED` if ops UI needed); create partner → offer → Activation; **size `offer.claimExpiryDays` to cover earliest-signup → `boostClosesAt`** (reservation expiry = `claimExpiryDays \|\| 30`; an expired reservation cannot be unlocked AND cannot be reissued — the unique index has no status filter); **size activation allocation ≥ expected signups** (exhaustion leaves later entrants with no pass; the reconcile sweep only backfills ~48h). | — |
-| **1 — Draw-campaign hardening** | `luckyDraw` config block + admin clamp + duplicate-strip; create-gate (phone + normalized OTP marker + `consent_terms` + `closesAt`) placed post-normalization; `phoneVerifiedFor` hash binding; **server-derived `via` on both unlock routes**; draw confirmation template pair; `draw_terms_versions` + acceptance stamping; extract shared SGT-boundary util. Tests pin: direct-API POST without OTP → 403, after `closesAt` → 410, `via` forgery impossible, non-draw campaigns byte-identical. | **M–L** |
-| **2 — Draw model + runner** | Migrations 057+ (`draws`, `draw_attempts`, `draw_entries`, `draw_boost_reviews` — winner FK added after entries table to avoid the circular reference, or validated in-service); freeze/seal/draw/redraw service with idempotent transitions; canonical poolHash; commit/reveal seed; pinned seeded PRNG + unit tests; PII-masked snapshot + audit JSON; `run-lucky-draw.js` CLI with safeguards; concurrency tests. | **L** |
+| **1 — Draw-campaign hardening** ✅ shipped (ba9fc97, tests green) | `luckyDraw` config block + admin clamp + duplicate-strip; create-gate (phone + normalized OTP marker + `consent_terms` + `closesAt`) placed post-normalization; `phoneVerifiedFor` hash binding; **server-derived `via` on both unlock routes**; draw confirmation template pair; `draw_terms_versions` + acceptance stamping; extract shared SGT-boundary util. Tests pin: direct-API POST without OTP → 403, after `closesAt` → 410, `via` forgery impossible, non-draw campaigns byte-identical. | **M–L** |
+| **2 — Draw model + runner** | Migrations 059+ (`draws`, `draw_attempts`, `draw_entries`, `draw_boost_reviews` — winner FK added after entries table to avoid the circular reference, or validated in-service); freeze/seal/draw/redraw service with idempotent transitions; canonical poolHash; commit/reveal seed; pinned seeded PRNG + unit tests; PII-masked snapshot + audit JSON; `run-lucky-draw.js` CLI with safeguards; concurrency tests. | **L** |
 | **3 — Boost review UI** | Ops list of `agent_button` unlock events pending review → approve/reject writes `draw_boost_reviews` (schema exists from Phase 2, so no circularity); needs a reviewer capability added to **both** permission copies (`permissions.js` + SPA copy — drift test enforces equality). | **M** |
 | **4 — mktr-leads screens** | Scan screen + virtual-toggle button unlock per §4.7 (separate repo). | S |
 | **5 — Later** | Lyfe app mirror; admin draw panel; durable per-submission verification records; winners API instead of static file. | — |
@@ -287,7 +287,9 @@ boost review (manual issues/unlocks are excluded from ×10 by default, §8.1).
 | `LYFE_LEAD_OUTCOME_SECRET` | already set (Lyfe HMAC channel) |
 | `DNC_VERIFIED_MARKER_TTL_MS` | optional: raise from 10 min if Phase 1 telemetry shows 403-retries on slow form fills |
 
-Unverifiable from the repo (must check in prod): the prospects unique index,
+Unverifiable from the repo (must check in prod): the prospects unique index
+(**observed genuinely missing in a fresh sync()-built test DB on 2026-07-12 —
+the swallow is not theoretical; run the §5 Phase 0 query against prod**),
 current Render flag values, single-instance deployment assumption behind the
 in-memory OTP marker.
 


### PR DESCRIPTION
Implements **Phase 1** of `docs/plans/lucky-draw-10x.md` (plan committed here too — Codex-reviewed design for lucky-draw campaigns with the ×10 session multiplier).

## What this does

- **`design_config.luckyDraw` block** — `utils/luckyDraw.js` normalize + admin-only policy (same pattern as `featuredDrop`), clamped in `campaignService` create/update; `duplicateCampaign` never clones it.
- **Draw entry gate** (`prospectService.createProspect`, draw campaigns only): phone required (422), `consent_terms === true` required (422), live OTP marker checked on the **normalized** E.164 phone (403), entries close at `closesAt` SGT end-of-day exclusive (410). Placed before round-robin side effects. Non-draw campaigns byte-identical (pinned by test).
- **`phoneVerifiedFor` binding** — verification stamp moved post-normalization and now includes `sha256(phone)`; a later staff phone edit breaks the match instead of inheriting verified status.
- **Server-derived `unlockedVia`** on both consultant unlock routes (`/api/external/entitlements/unlock`, `/api/integrations/lyfe/entitlement-unlock`): `presentationToken` ⇒ `agent_scan`, `prospectId` ⇒ `agent_button`. Closes the forgery where `{prospectId, via:'scan'}` minted scan evidence.
- **Draw terms versioning** — migration **058** `draw_terms_versions` (append-only, mirrors `RewardTermsVersion`); enabling a draw without T&C content 422s; entrants get `consentMetadata.drawTerms` pinning the exact version + hash they accepted.
- **Draw confirmation email** — new template pair (entry confirmation + ×N session pitch) replacing the generic "gift + 24h call" copy for draw campaigns.
- **`utils/sgtTime.js`** shared SGT day boundary (next-day-exclusive); featured drops migrated off their private 23:59:59 helper (fixes the dropped final 999ms).

## Tests

- 4 new suites: `luckyDraw.util`, `prospectServiceDrawGate` (DI, no DB), `entitlementUnlockVia` (both routes, incl. real Lyfe HMAC), `drawTermsVersioning` (DI seam).
- 2 existing unit-suite mocks updated for the new `DrawTermsVersion` export.
- **165/165 green** on all touched suites; full suite vs `origin/main` against a throwaway Postgres = identical set of pre-existing failures (no regressions).
- Migration 058 verified applying cleanly to a fresh DB.

## Ops note (pre-launch, not blocking this PR)

While testing: `prospects_campaign_id_phone` (the one-entry-per-phone unique index from migration 010) was **missing in a fresh DB** — its creation error is swallowed. Before any draw launch, verify it exists in prod:
`SELECT indexname FROM pg_indexes WHERE tablename='prospects' AND indexname='prospects_campaign_id_phone';`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FS33kQWQVbULWpXs54z6Kn