### PR TITLE
feat(lucky-draw): Phase 2 — draw ledger, seeded witnessed picks, boost reviews, CLI runner

### DIFF
--- a/backend/scripts/run-lucky-draw.js
+++ b/backend/scripts/run-lucky-draw.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * Lucky-draw runner (docs/plans/lucky-draw-10x.md §4.3) — the ops tool for the
+ * whole draw lifecycle until the admin panel ships (Phase 5).
+ *
+ * Run from backend/ with the DB env set (same vars as the server):
+ *
+ *   node scripts/run-lucky-draw.js create  --campaign <id>            --as <email|userId>
+ *   node scripts/run-lucky-draw.js status  --draw <id>
+ *   node scripts/run-lucky-draw.js freeze  --draw <id>                --as …
+ *   node scripts/run-lucky-draw.js reviews --draw <id>
+ *   node scripts/run-lucky-draw.js review  --draw <id> --entitlement <id> --approve|--reject [--reason "…"] --as …
+ *   node scripts/run-lucky-draw.js seal    --draw <id>                --as …
+ *   node scripts/run-lucky-draw.js draw    --draw <id> [--witness <email|userId>] [--reason unclaimed|…] --as …
+ *   node scripts/run-lucky-draw.js outcome --attempt <id> --outcome claimed|unclaimed|unreachable|ineligible|declined --as …
+ *   node scripts/run-lucky-draw.js publish --draw <id>                --as …
+ *   node scripts/run-lucky-draw.js verify  --draw <id>
+ *   node scripts/run-lucky-draw.js void    --draw <id> --reason "…"   --as …
+ *
+ * Output is JSON with MASKED identity only (displayName + phoneLast4) — winner
+ * CONTACT details come from the admin prospects view, never from this tool's
+ * output (PII posture, plan §4.3).
+ */
+
+import { makeLuckyDrawService } from '../src/services/luckyDrawService.js';
+import { User, sequelize } from '../src/models/index.js';
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  const args = { command, flags: {} };
+  for (let i = 0; i < rest.length; i += 1) {
+    const a = rest[i];
+    if (a === '--approve') args.flags.decision = 'approved';
+    else if (a === '--reject') args.flags.decision = 'rejected';
+    else if (a.startsWith('--')) {
+      args.flags[a.slice(2)] = rest[i + 1];
+      i += 1;
+    }
+  }
+  return args;
+}
+
+async function resolveUser(ref) {
+  if (!ref) throw new Error('--as <email|userId> is required for this command');
+  const where = ref.includes('@') ? { email: ref } : { id: ref };
+  const user = await User.findOne({ where });
+  if (!user) throw new Error(`No user found for --as ${ref}`);
+  return user;
+}
+
+function out(obj) {
+  console.log(JSON.stringify(obj, null, 2));
+}
+
+async function main() {
+  const { command, flags } = parseArgs(process.argv.slice(2));
+  const svc = makeLuckyDrawService();
+
+  switch (command) {
+    case 'create': {
+      const user = await resolveUser(flags.as);
+      const draw = await svc.createDraw({ campaignId: flags.campaign }, user);
+      out({ created: { id: draw.id, status: draw.status, closesAt: draw.closesAt, boostClosesAt: draw.boostClosesAt, multiplier: draw.multiplier } });
+      break;
+    }
+    case 'status': {
+      out(await svc.getDrawState(flags.draw));
+      break;
+    }
+    case 'freeze': {
+      const user = await resolveUser(flags.as);
+      out(await svc.freezeDraw(flags.draw, user));
+      break;
+    }
+    case 'reviews': {
+      out({ pending: await svc.listPendingBoostReviews(flags.draw) });
+      break;
+    }
+    case 'review': {
+      const user = await resolveUser(flags.as);
+      const row = await svc.reviewBoost(
+        { drawId: flags.draw, entitlementId: flags.entitlement, decision: flags.decision, reason: flags.reason },
+        user
+      );
+      out({ reviewed: { entitlementId: row.entitlementId, decision: row.decision } });
+      break;
+    }
+    case 'seal': {
+      const user = await resolveUser(flags.as);
+      out(await svc.sealDraw(flags.draw, user));
+      break;
+    }
+    case 'draw': {
+      const user = await resolveUser(flags.as);
+      const witness = flags.witness ? await resolveUser(flags.witness) : user;
+      const result = await svc.runDrawAttempt(
+        flags.draw,
+        { witnessUserId: witness.id, reason: flags.reason || 'initial' },
+        user
+      );
+      out({
+        attemptNo: result.attempt.attemptNo,
+        seed: result.attempt.seed,
+        totalChances: result.attempt.totalChances,
+        claimDeadline: result.attempt.claimDeadline,
+        picked: result.picked, // masked: displayName + phoneLast4 (+ prospectId for the admin lookup)
+      });
+      break;
+    }
+    case 'outcome': {
+      const user = await resolveUser(flags.as);
+      const attempt = await svc.recordAttemptOutcome(flags.attempt, { outcome: flags.outcome }, user);
+      out({ attemptNo: attempt.attemptNo, outcome: attempt.outcome, claimedAt: attempt.claimedAt });
+      break;
+    }
+    case 'publish': {
+      const user = await resolveUser(flags.as);
+      const draw = await svc.markPublished(flags.draw, user);
+      out({ id: draw.id, status: draw.status });
+      break;
+    }
+    case 'verify': {
+      out(await svc.verifyDraw(flags.draw));
+      break;
+    }
+    case 'void': {
+      const user = await resolveUser(flags.as);
+      const draw = await svc.voidDraw(flags.draw, flags.reason, user);
+      out({ id: draw.id, status: draw.status });
+      break;
+    }
+    default:
+      console.error('Unknown command. See the header of this file for usage.');
+      process.exitCode = 1;
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error(JSON.stringify({ error: err.message, ...(err.data ? { data: err.data } : {}) }));
+    process.exitCode = 1;
+  })
+  .finally(() => sequelize.close().catch(() => {}));

--- a/backend/src/database/migrations/059-lucky-draw-model.js
+++ b/backend/src/database/migrations/059-lucky-draw-model.js
@@ -1,0 +1,104 @@
+/**
+ * Lucky draw Phase 2 — the draw ledger (docs/plans/lucky-draw-10x.md §4.3):
+ * draws (one per campaign draw), draw_entries (the frozen, PII-masked pool
+ * snapshot), draw_attempts (every witnessed pick incl. redraws), and
+ * draw_boost_reviews (approve/reject of agent_button ×N evidence).
+ * Guarded createTable + always-run IF NOT EXISTS indexes (048/058 pattern).
+ *
+ * No circular FK: the picked winner lives on draw_attempts.pickedEntryId
+ * (created after draw_entries), never on draws.
+ */
+export async function up(queryInterface, Sequelize) {
+  const tables = await queryInterface.showAllTables();
+  const UUID = Sequelize.UUID;
+  const ts = () => ({
+    createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+  });
+
+  if (!tables.includes('draws')) {
+    await queryInterface.createTable('draws', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      campaignId: { type: UUID, allowNull: false, references: { model: 'campaigns', key: 'id' }, onDelete: 'RESTRICT' },
+      activationId: { type: UUID, references: { model: 'activations', key: 'id' }, onDelete: 'RESTRICT' },
+      termsVersionId: { type: UUID, references: { model: 'draw_terms_versions', key: 'id' }, onDelete: 'RESTRICT' },
+      closesAt: { type: Sequelize.DATE, allowNull: false },
+      boostClosesAt: { type: Sequelize.DATE },
+      multiplier: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 10 },
+      status: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'open' },
+      poolHash: { type: Sequelize.STRING(64) },
+      witnessedByUserId: { type: UUID, references: { model: 'users', key: 'id' }, onDelete: 'SET NULL' },
+      notes: { type: Sequelize.TEXT },
+      createdBy: { type: UUID, allowNull: false, references: { model: 'users', key: 'id' }, onDelete: 'RESTRICT' },
+      ...ts(),
+    });
+  }
+
+  if (!tables.includes('draw_entries')) {
+    await queryInterface.createTable('draw_entries', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      drawId: { type: UUID, allowNull: false, references: { model: 'draws', key: 'id' }, onDelete: 'CASCADE' },
+      prospectId: { type: UUID, references: { model: 'prospects', key: 'id' }, onDelete: 'SET NULL' },
+      phoneHash: { type: Sequelize.STRING(64), allowNull: false },
+      phoneLast4: { type: Sequelize.STRING(4) },
+      displayName: { type: Sequelize.STRING(120) },
+      chances: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 1 },
+      verifiedAtFreeze: { type: Sequelize.DATE },
+      boostVia: { type: Sequelize.STRING(16) },
+      boostEventId: { type: UUID, references: { model: 'redemption_events', key: 'id' }, onDelete: 'SET NULL' },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    });
+  }
+
+  if (!tables.includes('draw_attempts')) {
+    await queryInterface.createTable('draw_attempts', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      drawId: { type: UUID, allowNull: false, references: { model: 'draws', key: 'id' }, onDelete: 'CASCADE' },
+      attemptNo: { type: Sequelize.INTEGER, allowNull: false },
+      seed: { type: Sequelize.STRING(64), allowNull: false },
+      totalChances: { type: Sequelize.INTEGER, allowNull: false },
+      eligibleHash: { type: Sequelize.STRING(64), allowNull: false },
+      pickedEntryId: { type: UUID, allowNull: false, references: { model: 'draw_entries', key: 'id' }, onDelete: 'RESTRICT' },
+      reason: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'initial' },
+      drawnAt: { type: Sequelize.DATE, allowNull: false },
+      witnessedByUserId: { type: UUID, references: { model: 'users', key: 'id' }, onDelete: 'SET NULL' },
+      contactedAt: { type: Sequelize.DATE },
+      claimDeadline: { type: Sequelize.DATE },
+      claimedAt: { type: Sequelize.DATE },
+      outcome: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'pending' },
+      ...ts(),
+    });
+  }
+
+  if (!tables.includes('draw_boost_reviews')) {
+    await queryInterface.createTable('draw_boost_reviews', {
+      id: { type: UUID, primaryKey: true, allowNull: false },
+      drawId: { type: UUID, allowNull: false, references: { model: 'draws', key: 'id' }, onDelete: 'CASCADE' },
+      entitlementId: { type: UUID, allowNull: false, references: { model: 'reward_entitlements', key: 'id' }, onDelete: 'RESTRICT' },
+      prospectId: { type: UUID },
+      decision: { type: Sequelize.STRING(16), allowNull: false },
+      reviewedByUserId: { type: UUID, allowNull: false, references: { model: 'users', key: 'id' }, onDelete: 'RESTRICT' },
+      reason: { type: Sequelize.TEXT },
+      ...ts(),
+    });
+  }
+
+  const idx = (sql) => queryInterface.sequelize.query(sql);
+  // At most ONE live draw per campaign — history (published/void) unlimited.
+  await idx(`CREATE UNIQUE INDEX IF NOT EXISTS uq_draws_live_campaign ON draws ("campaignId")
+             WHERE status IN ('open', 'frozen', 'sealed', 'drawn')`);
+  await idx('CREATE INDEX IF NOT EXISTS idx_draws_campaign ON draws ("campaignId")');
+  await idx(`CREATE UNIQUE INDEX IF NOT EXISTS uq_de_draw_prospect ON draw_entries ("drawId", "prospectId")
+             WHERE "prospectId" IS NOT NULL`);
+  await idx('CREATE INDEX IF NOT EXISTS idx_de_draw ON draw_entries ("drawId")');
+  await idx('CREATE UNIQUE INDEX IF NOT EXISTS uq_da_draw_attempt ON draw_attempts ("drawId", "attemptNo")');
+  await idx('CREATE UNIQUE INDEX IF NOT EXISTS uq_dbr_draw_entitlement ON draw_boost_reviews ("drawId", "entitlementId")');
+}
+
+export async function down(queryInterface) {
+  const q = (sql) => queryInterface.sequelize.query(sql);
+  await q('DROP TABLE IF EXISTS draw_boost_reviews CASCADE');
+  await q('DROP TABLE IF EXISTS draw_attempts CASCADE');
+  await q('DROP TABLE IF EXISTS draw_entries CASCADE');
+  await q('DROP TABLE IF EXISTS draws CASCADE');
+}

--- a/backend/src/models/Draw.js
+++ b/backend/src/models/Draw.js
@@ -1,0 +1,69 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * A lucky draw for one campaign (docs/plans/lucky-draw-10x.md §4.3).
+ *
+ * Lifecycle: open → frozen (1× pool snapshotted) → sealed (boosts + poolHash
+ * committed) → drawn (≥1 witnessed attempt) → published / claimed; void from
+ * any pre-published state. The winner is NEVER stored here — each pick is a
+ * draw_attempts row (redraws = further attempts), so there is no circular FK
+ * and the full history is append-shaped.
+ *
+ * closesAt / boostClosesAt are UTC INSTANTS (derived from SGT day boundaries
+ * at createDraw time) — freeze/seal re-apply them regardless of when an
+ * operator actually runs, so an ops delay can never widen a window.
+ */
+const Draw = sequelize.define('Draw', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  campaignId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'campaigns', key: 'id' }
+  },
+  activationId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    references: { model: 'activations', key: 'id' },
+    comment: 'Designated ×N activation — unlock events on OTHER activations never boost'
+  },
+  termsVersionId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    references: { model: 'draw_terms_versions', key: 'id' }
+  },
+  closesAt: { type: DataTypes.DATE, allowNull: false, comment: 'Entry cutoff instant (UTC)' },
+  boostClosesAt: { type: DataTypes.DATE, allowNull: true, comment: 'Unlock-event cutoff instant (UTC); null = no boost tier' },
+  multiplier: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 10 },
+  status: {
+    type: DataTypes.STRING(16),
+    allowNull: false,
+    defaultValue: 'open',
+    comment: 'open|frozen|sealed|drawn|published|claimed|void'
+  },
+  poolHash: {
+    type: DataTypes.STRING(64),
+    allowNull: true,
+    comment: 'sha256 over the canonical ordered entry tuples (id|prospectId|phoneHash|chances|boostVia) — committed at seal, BEFORE any seed exists'
+  },
+  witnessedByUserId: { type: DataTypes.UUID, allowNull: true, references: { model: 'users', key: 'id' } },
+  notes: { type: DataTypes.TEXT, allowNull: true },
+  createdBy: { type: DataTypes.UUID, allowNull: false, references: { model: 'users', key: 'id' } }
+}, {
+  tableName: 'draws',
+  timestamps: true,
+  indexes: [
+    { fields: ['campaignId'], name: 'idx_draws_campaign' },
+    // One LIVE draw per campaign (history unlimited). Defined here AND in
+    // migration 059 so sync()-built schemas (tests) enforce it too — the
+    // prospects_campaign_id_phone lesson.
+    {
+      unique: true,
+      fields: ['campaignId'],
+      name: 'uq_draws_live_campaign',
+      where: { status: ['open', 'frozen', 'sealed', 'drawn'] }
+    }
+  ]
+});
+
+export default Draw;

--- a/backend/src/models/DrawAttempt.js
+++ b/backend/src/models/DrawAttempt.js
@@ -1,0 +1,60 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * One witnessed pick (docs/plans/lucky-draw-10x.md §4.3) — the initial draw is
+ * attempt 1; every redraw (unclaimed/unreachable/ineligible/declined) is a
+ * further attempt excluding ALL previously picked entries.
+ *
+ * Commit/reveal: the pool (poolHash on the draw) is sealed FIRST; the seed is
+ * generated at the witnessed pick and recorded here after. Reproducibility:
+ * totalChances + eligibleHash pin the exact eligible set the seed was applied
+ * to, so `verify` re-derives the same pickedEntryId — and can DETECT (not
+ * silently absorb) any post-attempt erasure that changed the set.
+ */
+const DrawAttempt = sequelize.define('DrawAttempt', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  drawId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'draws', key: 'id' }
+  },
+  attemptNo: { type: DataTypes.INTEGER, allowNull: false },
+  seed: { type: DataTypes.STRING(64), allowNull: false, comment: '32 random bytes hex, minted at the witnessed pick' },
+  totalChances: { type: DataTypes.INTEGER, allowNull: false },
+  eligibleHash: {
+    type: DataTypes.STRING(64),
+    allowNull: false,
+    comment: 'sha256 over the ordered eligible (entryId|chances) pairs this seed was applied to'
+  },
+  pickedEntryId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'draw_entries', key: 'id' }
+  },
+  reason: {
+    type: DataTypes.STRING(16),
+    allowNull: false,
+    defaultValue: 'initial',
+    comment: 'Why this attempt ran: initial|unclaimed|unreachable|ineligible|declined (= prior attempt outcome)'
+  },
+  drawnAt: { type: DataTypes.DATE, allowNull: false },
+  witnessedByUserId: { type: DataTypes.UUID, allowNull: true, references: { model: 'users', key: 'id' } },
+  contactedAt: { type: DataTypes.DATE, allowNull: true },
+  claimDeadline: { type: DataTypes.DATE, allowNull: true, comment: 'drawnAt + 14 days (the public /winners promise)' },
+  claimedAt: { type: DataTypes.DATE, allowNull: true },
+  outcome: {
+    type: DataTypes.STRING(16),
+    allowNull: false,
+    defaultValue: 'pending',
+    comment: 'pending|claimed|unclaimed|unreachable|ineligible|declined'
+  }
+}, {
+  tableName: 'draw_attempts',
+  timestamps: true,
+  indexes: [
+    { unique: true, fields: ['drawId', 'attemptNo'], name: 'uq_da_draw_attempt' }
+  ]
+});
+
+export default DrawAttempt;

--- a/backend/src/models/DrawBoostReview.js
+++ b/backend/src/models/DrawBoostReview.js
@@ -1,0 +1,35 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Ops review of a virtual-meeting (agent_button) unlock for draw weighting
+ * (docs/plans/lucky-draw-10x.md §4.2/§8.1). agent_scan unlocks boost
+ * automatically; agent_button unlocks are assertion-only, so each one must be
+ * approved/rejected here before the draw can seal. The voucher itself is
+ * untouched either way — this decides only the ×N draw weight.
+ */
+const DrawBoostReview = sequelize.define('DrawBoostReview', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  drawId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'draws', key: 'id' }
+  },
+  entitlementId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'reward_entitlements', key: 'id' }
+  },
+  prospectId: { type: DataTypes.UUID, allowNull: true, comment: 'Denormalized join aid — no FK, evidence survives lead erasure' },
+  decision: { type: DataTypes.STRING(16), allowNull: false, comment: 'approved|rejected' },
+  reviewedByUserId: { type: DataTypes.UUID, allowNull: false, references: { model: 'users', key: 'id' } },
+  reason: { type: DataTypes.TEXT, allowNull: true }
+}, {
+  tableName: 'draw_boost_reviews',
+  timestamps: true,
+  indexes: [
+    { unique: true, fields: ['drawId', 'entitlementId'], name: 'uq_dbr_draw_entitlement' }
+  ]
+});
+
+export default DrawBoostReview;

--- a/backend/src/models/DrawEntry.js
+++ b/backend/src/models/DrawEntry.js
@@ -1,0 +1,57 @@
+import { DataTypes, Op } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * One frozen draw entry (docs/plans/lucky-draw-10x.md §4.3). Snapshotted at
+ * freeze from the verified prospect pool; immutable thereafter except for the
+ * seal step writing chances/boost evidence.
+ *
+ * PII posture: only masked/derived identity is copied (phoneHash + last4 +
+ * "First L." display name) — winner CONTACT uses the live prospect row. If the
+ * prospect is erased before the pick, prospectId goes NULL and the entry is
+ * skipped as ineligible (recorded on the next attempt), never silently
+ * re-weighted.
+ */
+const DrawEntry = sequelize.define('DrawEntry', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  drawId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'draws', key: 'id' }
+  },
+  prospectId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    references: { model: 'prospects', key: 'id' },
+    comment: 'SET NULL on prospect deletion/erasure — entry survives, becomes unpickable'
+  },
+  phoneHash: { type: DataTypes.STRING(64), allowNull: false, comment: 'sha256 of the E.164 phone at freeze' },
+  phoneLast4: { type: DataTypes.STRING(4), allowNull: true },
+  displayName: { type: DataTypes.STRING(120), allowNull: true, comment: 'Pre-masked "First L." — safe to publish' },
+  chances: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 1 },
+  verifiedAtFreeze: { type: DataTypes.DATE, allowNull: true, comment: 'Copy of sourceMetadata.phoneVerifiedAt evidence' },
+  boostVia: { type: DataTypes.STRING(16), allowNull: true, comment: 'agent_scan|agent_button — how the ×N was earned (button ⇒ an approved review exists)' },
+  boostEventId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    references: { model: 'redemption_events', key: 'id' },
+    comment: 'The append-only unlocked event backing the boost'
+  }
+}, {
+  tableName: 'draw_entries',
+  timestamps: true,
+  updatedAt: false,
+  indexes: [
+    { fields: ['drawId'], name: 'idx_de_draw' },
+    // Partial (erasure sets prospectId NULL) — defined here AND in migration
+    // 059 so sync()-built schemas enforce it too.
+    {
+      unique: true,
+      fields: ['drawId', 'prospectId'],
+      name: 'uq_de_draw_prospect',
+      where: { prospectId: { [Op.ne]: null } }
+    }
+  ]
+});
+
+export default DrawEntry;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -237,6 +237,22 @@ function defineAssociations() {
   RedemptionEvent.belongsTo(RewardEntitlement, { foreignKey: 'entitlementId', as: 'entitlement', onDelete: 'CASCADE' });
   RedemptionEvent.belongsTo(Redemption, { foreignKey: 'redemptionId', as: 'redemption', onDelete: 'CASCADE' });
 
+  // Lucky-draw ledger (docs/plans/lucky-draw-10x.md §4.3)
+  const { Draw, DrawEntry, DrawAttempt, DrawBoostReview } = models;
+  Campaign.hasMany(Draw, { foreignKey: 'campaignId', as: 'draws', onDelete: 'RESTRICT' });
+  Draw.belongsTo(Campaign, { foreignKey: 'campaignId', as: 'campaign' });
+  Draw.belongsTo(Activation, { foreignKey: 'activationId', as: 'activation', onDelete: 'RESTRICT' });
+  Draw.belongsTo(DrawTermsVersion, { foreignKey: 'termsVersionId', as: 'termsVersion', onDelete: 'RESTRICT' });
+  Draw.hasMany(DrawEntry, { foreignKey: 'drawId', as: 'entries', onDelete: 'CASCADE' });
+  DrawEntry.belongsTo(Draw, { foreignKey: 'drawId', as: 'draw' });
+  DrawEntry.belongsTo(Prospect, { foreignKey: 'prospectId', as: 'prospect', onDelete: 'SET NULL' });
+  Draw.hasMany(DrawAttempt, { foreignKey: 'drawId', as: 'attempts', onDelete: 'CASCADE' });
+  DrawAttempt.belongsTo(Draw, { foreignKey: 'drawId', as: 'draw' });
+  DrawAttempt.belongsTo(DrawEntry, { foreignKey: 'pickedEntryId', as: 'pickedEntry', onDelete: 'RESTRICT' });
+  Draw.hasMany(DrawBoostReview, { foreignKey: 'drawId', as: 'boostReviews', onDelete: 'CASCADE' });
+  DrawBoostReview.belongsTo(Draw, { foreignKey: 'drawId', as: 'draw' });
+  DrawBoostReview.belongsTo(RewardEntitlement, { foreignKey: 'entitlementId', as: 'entitlement', onDelete: 'RESTRICT' });
+
   // Outreach work (Phase 3)
   const { OutreachTask, ProspectingPool, ProspectingPoolMember } = models;
   PartnerOrganisation.hasMany(OutreachTask, { foreignKey: 'partnerOrganisationId', as: 'tasks', onDelete: 'CASCADE' });
@@ -312,7 +328,8 @@ export const {
   WaitlistSignup, RedeemOpsAuditEvent, PartnerOrganisation, PartnerLocation,
   PartnerContact, PartnerAssignmentEvent, PartnerStageEvent, OutreachActivity,
   OutreachTask, ProspectingPool, ProspectingPoolMember, RewardOffer,
-  RewardTermsVersion, DrawTermsVersion, RewardOfferLocation, RewardInventoryEvent,
+  RewardTermsVersion, DrawTermsVersion, Draw, DrawEntry, DrawAttempt,
+  DrawBoostReview, RewardOfferLocation, RewardInventoryEvent,
   PartnerOnboardingItem, Activation, RewardEntitlement, Redemption,
   RedemptionEvent, RedeemOpsCategory, DiscoveryRun, DiscoveryCandidate,
   DiscoveryPlaceMemory, OutreachCadence, OutreachCadenceStep,

--- a/backend/src/services/luckyDrawService.js
+++ b/backend/src/services/luckyDrawService.js
@@ -1,0 +1,613 @@
+import crypto from 'crypto';
+import { Op } from 'sequelize';
+import {
+  Draw, DrawEntry, DrawAttempt, DrawBoostReview,
+  Campaign, Prospect, Activation, RewardEntitlement, RedemptionEvent,
+  sequelize,
+} from '../models/index.js';
+import { AppError } from '../middleware/errorHandler.js';
+import { logger } from '../utils/logger.js';
+import { sgtDayEndExclusiveMs } from '../utils/sgtTime.js';
+
+/**
+ * Lucky-draw lifecycle (docs/plans/lucky-draw-10x.md §4.2–§4.3).
+ *
+ *   create → freeze (1× pool snapshot at closesAt) → [review agent_button
+ *   boosts] → seal (chances + poolHash committed) → draw (witnessed seeded
+ *   pick; redraws = further attempts) → published / claimed; void anywhere
+ *   before published.
+ *
+ * Fairness spine:
+ *  - Every transition is a CONDITIONAL UPDATE (`WHERE status = <from>`), so
+ *    concurrent/replayed operations lose cleanly instead of double-running.
+ *  - The pool is committed (poolHash) at seal, BEFORE any seed exists; the
+ *    seed is minted at the witnessed pick (commit/reveal — the winner is not
+ *    predictable before the witnessed moment).
+ *  - The pick is a pure function of (seed, ordered eligible entries) — see
+ *    pickWinner(). Each attempt stores seed + totalChances + eligibleHash, so
+ *    verifyDraw() re-derives every pick and DETECTS post-hoc changes.
+ *  - ×N evidence is the append-only redemption_events 'unlocked' row (a later
+ *    entitlement cancellation can't erase an earned boost), scoped to the
+ *    draw's designated activation, excluding manual issuance
+ *    (issuedVia='manual' fabricates the OTP stamp), inside boostClosesAt.
+ *    agent_scan boosts automatically; agent_button requires an approved
+ *    DrawBoostReview (§8.1).
+ */
+
+const CLAIM_WINDOW_DAYS = 14; // the public /winners promise
+const ATTEMPT_REASONS = new Set(['initial', 'unclaimed', 'unreachable', 'ineligible', 'declined']);
+const OUTCOMES = new Set(['claimed', 'unclaimed', 'unreachable', 'ineligible', 'declined']);
+
+function sha256Hex(s) {
+  return crypto.createHash('sha256').update(s).digest('hex');
+}
+
+/** "Sarah Tan" → "Sarah T." — pre-masked display identity, safe to publish. */
+function maskName(firstName, lastName) {
+  const first = (firstName || '').trim();
+  const lastInitial = (lastName || '').trim().charAt(0);
+  return [first, lastInitial ? `${lastInitial.toUpperCase()}.` : ''].filter(Boolean).join(' ') || 'Entrant';
+}
+
+function maskPhoneLast4(phone) {
+  const digits = String(phone || '').replace(/\D/g, '');
+  return digits.slice(-4) || null;
+}
+
+/**
+ * Canonical pool commitment: sha256 over the ordered entry tuples. Includes
+ * every outcome-affecting field (weights, identity hash, boost evidence), so
+ * the hash pins the WEIGHTED pool, not just membership.
+ */
+export function computePoolHash(entries) {
+  const lines = [...entries]
+    .sort((a, b) => String(a.id).localeCompare(String(b.id)))
+    .map((e) => `${e.id}|${e.prospectId || ''}|${e.phoneHash}|${e.chances}|${e.boostVia || ''}`);
+  return sha256Hex(lines.join('\n'));
+}
+
+/** Commitment to the exact eligible set an attempt's seed was applied to. */
+export function computeEligibleHash(eligibleEntries) {
+  const lines = eligibleEntries.map((e) => `${e.id}|${e.chances}`);
+  return sha256Hex(lines.join('\n'));
+}
+
+/**
+ * Deterministic weighted pick: entries ordered by id ASC, expanded by
+ * `chances`; winner index = sha256(seed) as a 256-bit integer mod
+ * totalChances. Modulo bias is ≤ totalChances/2^256 — immeasurably small for
+ * any real pool — accepted in exchange for a pick anyone can re-derive with
+ * one hash. Returns the winning entry.
+ */
+export function pickWinner(seedHex, eligibleEntries) {
+  const total = eligibleEntries.reduce((n, e) => n + e.chances, 0);
+  if (total <= 0) throw new AppError('No eligible entries to draw from', 409);
+  const value = BigInt(`0x${sha256Hex(seedHex)}`) % BigInt(total);
+  let cumulative = 0n;
+  for (const entry of eligibleEntries) {
+    cumulative += BigInt(entry.chances);
+    if (value < cumulative) return entry;
+  }
+  // Unreachable: value < total by construction.
+  throw new AppError('Pick walked past the pool — invariant broken', 500);
+}
+
+/** Entries ordered by id ASC — the ONE canonical order every hash/pick uses. */
+function orderedEntries(entries) {
+  return [...entries].sort((a, b) => String(a.id).localeCompare(String(b.id)));
+}
+
+export function makeLuckyDrawService(overrides = {}) {
+  const d = {
+    Draw, DrawEntry, DrawAttempt, DrawBoostReview,
+    Campaign, Prospect, Activation, RewardEntitlement, RedemptionEvent,
+    sequelize, logger,
+    now: () => new Date(),
+    mintSeed: () => crypto.randomBytes(32).toString('hex'),
+    ...overrides,
+  };
+
+  /** Conditional status transition — the concurrency guard for every step. */
+  async function transition(drawId, from, to, extra = {}, t = null) {
+    const [count] = await d.Draw.update(
+      { status: to, ...extra },
+      { where: { id: drawId, status: from }, ...(t ? { transaction: t } : {}) }
+    );
+    if (count === 0) {
+      throw new AppError(`Draw is not in '${from}' state (concurrent change?)`, 409);
+    }
+  }
+
+  async function getDrawOr404(drawId) {
+    const draw = await d.Draw.findByPk(drawId);
+    if (!draw) throw new AppError('Draw not found', 404);
+    return draw;
+  }
+
+  /**
+   * Create the draw row from the campaign's luckyDraw config. Dates become
+   * fixed UTC instants HERE (SGT end-of-day exclusive) — later steps compare
+   * against the stored instants, never against config or wall-clock choices.
+   */
+  async function createDraw({ campaignId }, user) {
+    const campaign = await d.Campaign.findByPk(campaignId);
+    if (!campaign) throw new AppError('Campaign not found', 404);
+    const ld = campaign.design_config?.luckyDraw;
+    if (ld?.enabled !== true) {
+      throw new AppError('Campaign has no enabled luckyDraw config (designer → luckyDraw)', 422);
+    }
+    const closesAtMs = ld.closesAt ? sgtDayEndExclusiveMs(ld.closesAt) : null;
+    if (closesAtMs === null) {
+      throw new AppError('luckyDraw.closesAt (YYYY-MM-DD) is required to create a draw', 422);
+    }
+    const boostClosesAtMs = ld.boostClosesAt ? sgtDayEndExclusiveMs(ld.boostClosesAt) : null;
+    if (boostClosesAtMs !== null && boostClosesAtMs < closesAtMs) {
+      throw new AppError('boostClosesAt must not be before closesAt', 422);
+    }
+
+    let activationId = null;
+    if (ld.activationId) {
+      const activation = await d.Activation.findByPk(ld.activationId);
+      if (!activation || String(activation.campaignId) !== String(campaignId)) {
+        throw new AppError('luckyDraw.activationId does not belong to this campaign', 422);
+      }
+      activationId = activation.id;
+    }
+
+    try {
+      const draw = await d.Draw.create({
+        campaignId,
+        activationId,
+        termsVersionId: ld.termsVersionId || null,
+        closesAt: new Date(closesAtMs),
+        boostClosesAt: boostClosesAtMs !== null ? new Date(boostClosesAtMs) : null,
+        multiplier: ld.multiplier || 10,
+        status: 'open',
+        createdBy: user.id,
+      });
+      return draw;
+    } catch (err) {
+      // uq_draws_live_campaign: one live draw per campaign.
+      if (err?.name === 'SequelizeUniqueConstraintError' || /uq_draws_live_campaign/.test(err?.message || '')) {
+        throw new AppError('This campaign already has a live draw', 409);
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Freeze the 1× pool. Runs any time AT/after closesAt; re-applies the
+   * stored cutoff itself (`createdAt <= closesAt`), so a late freeze admits
+   * nothing extra. Pool predicate (docs/plans/lucky-draw-10x.md §4.2): phone
+   * present, verification stamp present AND bound to the CURRENT phone
+   * (phoneVerifiedFor = sha256(phone) — a post-entry staff phone edit breaks
+   * the bind), created inside the window. Quarantined prospects stay in
+   * (quarantine restricts delivery, not entry validity).
+   */
+  async function freezeDraw(drawId, user) {
+    const draw = await getDrawOr404(drawId);
+    if (draw.status !== 'open') throw new AppError(`Draw is ${draw.status}, expected open`, 409);
+    const now = d.now();
+    if (now.getTime() < new Date(draw.closesAt).getTime()) {
+      throw new AppError(`Entries close at ${new Date(draw.closesAt).toISOString()} — freeze after that`, 409);
+    }
+
+    const prospects = await d.Prospect.findAll({
+      where: {
+        campaignId: draw.campaignId,
+        phone: { [Op.ne]: null },
+        createdAt: { [Op.lte]: draw.closesAt },
+      },
+      attributes: ['id', 'firstName', 'lastName', 'phone', 'sourceMetadata', 'createdAt'],
+    });
+
+    const eligible = prospects.filter((p) => {
+      const sm = p.sourceMetadata || {};
+      return (
+        typeof sm.phoneVerifiedAt === 'string' &&
+        typeof sm.phoneVerifiedFor === 'string' &&
+        sm.phoneVerifiedFor === sha256Hex(p.phone)
+      );
+    });
+
+    const rows = eligible.map((p) => ({
+      drawId: draw.id,
+      prospectId: p.id,
+      phoneHash: sha256Hex(p.phone),
+      phoneLast4: maskPhoneLast4(p.phone),
+      displayName: maskName(p.firstName, p.lastName),
+      chances: 1,
+      verifiedAtFreeze: new Date(p.sourceMetadata.phoneVerifiedAt),
+    }));
+
+    await d.sequelize.transaction(async (t) => {
+      await transition(draw.id, 'open', 'frozen', {}, t);
+      if (rows.length > 0) await d.DrawEntry.bulkCreate(rows, { transaction: t });
+    });
+
+    d.logger.info('lucky_draw.frozen', {
+      drawId: draw.id, campaignId: draw.campaignId,
+      candidates: prospects.length, entries: rows.length,
+    });
+    return { drawId: draw.id, candidates: prospects.length, entries: rows.length };
+  }
+
+  /**
+   * The boost evidence for a draw: append-only 'unlocked' events on the
+   * designated activation, non-manual issuance, inside boostClosesAt, for
+   * prospects that hold a frozen entry. Two-step query (no association
+   * dependency). Returns { byProspect, buttonEventsNeedingReview }.
+   */
+  async function collectBoostEvidence(draw, entries) {
+    if (!draw.activationId) return { byProspect: new Map(), undecidedButtons: [] };
+    const prospectIds = entries.map((e) => e.prospectId).filter(Boolean);
+    if (prospectIds.length === 0) return { byProspect: new Map(), undecidedButtons: [] };
+
+    const entitlements = await d.RewardEntitlement.findAll({
+      where: {
+        activationId: draw.activationId,
+        prospectId: { [Op.in]: prospectIds },
+        issuedVia: { [Op.ne]: 'manual' },
+      },
+      attributes: ['id', 'prospectId', 'issuedVia'],
+    });
+    if (entitlements.length === 0) return { byProspect: new Map(), undecidedButtons: [] };
+    const entitlementById = new Map(entitlements.map((e) => [String(e.id), e]));
+
+    const cutoff = draw.boostClosesAt || d.now();
+    const events = await d.RedemptionEvent.findAll({
+      where: {
+        entitlementId: { [Op.in]: entitlements.map((e) => e.id) },
+        type: 'unlocked',
+        createdAt: { [Op.lte]: cutoff },
+      },
+      attributes: ['id', 'entitlementId', 'metadata', 'createdAt'],
+      order: [['createdAt', 'ASC']],
+    });
+
+    const reviews = await d.DrawBoostReview.findAll({
+      where: { drawId: draw.id },
+      attributes: ['entitlementId', 'decision'],
+    });
+    const reviewByEntitlement = new Map(reviews.map((r) => [String(r.entitlementId), r.decision]));
+
+    const byProspect = new Map(); // prospectId -> { via, eventId }
+    const undecidedButtons = [];
+    for (const ev of events) {
+      const ent = entitlementById.get(String(ev.entitlementId));
+      if (!ent) continue;
+      const via = ev.metadata?.via === 'agent_button' ? 'agent_button' : 'agent_scan';
+      const key = String(ent.prospectId);
+      if (via === 'agent_scan') {
+        // Scan is the strongest evidence — always wins for the prospect.
+        byProspect.set(key, { via, eventId: ev.id });
+      } else {
+        const decision = reviewByEntitlement.get(String(ev.entitlementId));
+        if (decision === 'approved') {
+          if (!byProspect.has(key)) byProspect.set(key, { via, eventId: ev.id });
+        } else if (decision !== 'rejected') {
+          undecidedButtons.push({ entitlementId: ent.id, prospectId: ent.prospectId, eventId: ev.id });
+        }
+        // rejected → no boost, no block.
+      }
+    }
+    return { byProspect, undecidedButtons };
+  }
+
+  /** Virtual (agent_button) unlocks awaiting a boost decision for this draw. */
+  async function listPendingBoostReviews(drawId) {
+    const draw = await getDrawOr404(drawId);
+    const entries = await d.DrawEntry.findAll({ where: { drawId: draw.id } });
+    const { undecidedButtons } = await collectBoostEvidence(draw, entries);
+    return undecidedButtons;
+  }
+
+  /** Approve/reject one agent_button unlock for ×N weighting (voucher untouched). */
+  async function reviewBoost({ drawId, entitlementId, decision, reason }, user) {
+    if (!['approved', 'rejected'].includes(decision)) {
+      throw new AppError("decision must be 'approved' or 'rejected'", 422);
+    }
+    const draw = await getDrawOr404(drawId);
+    if (!['open', 'frozen'].includes(draw.status)) {
+      throw new AppError(`Draw is ${draw.status} — boost reviews close at seal`, 409);
+    }
+    const entitlement = await d.RewardEntitlement.findByPk(entitlementId);
+    if (!entitlement) throw new AppError('Entitlement not found', 404);
+    try {
+      return await d.DrawBoostReview.create({
+        drawId: draw.id,
+        entitlementId,
+        prospectId: entitlement.prospectId || null,
+        decision,
+        reviewedByUserId: user.id,
+        reason: reason || null,
+      });
+    } catch (err) {
+      if (err?.name === 'SequelizeUniqueConstraintError' || /uq_dbr_draw_entitlement/.test(err?.message || '')) {
+        throw new AppError('This unlock has already been reviewed for this draw', 409);
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Seal: write chances + boost evidence onto the frozen entries and commit
+   * poolHash. Refuses while any agent_button unlock is undecided (the review
+   * step cannot be silently skipped) and never runs before boostClosesAt.
+   */
+  async function sealDraw(drawId, user) {
+    const draw = await getDrawOr404(drawId);
+    if (draw.status !== 'frozen') throw new AppError(`Draw is ${draw.status}, expected frozen`, 409);
+    const now = d.now();
+    if (draw.boostClosesAt && now.getTime() < new Date(draw.boostClosesAt).getTime()) {
+      throw new AppError(`Boost window closes at ${new Date(draw.boostClosesAt).toISOString()} — seal after that`, 409);
+    }
+
+    const entries = await d.DrawEntry.findAll({ where: { drawId: draw.id } });
+    if (entries.length === 0) throw new AppError('Draw has no entries — nothing to seal', 409);
+
+    const { byProspect, undecidedButtons } = await collectBoostEvidence(draw, entries);
+    if (undecidedButtons.length > 0) {
+      const err = new AppError(
+        `${undecidedButtons.length} virtual (agent_button) unlock(s) await boost review — approve/reject them first`,
+        409
+      );
+      err.data = { undecided: undecidedButtons };
+      throw err;
+    }
+
+    const boosted = [];
+    for (const entry of entries) {
+      const boost = entry.prospectId ? byProspect.get(String(entry.prospectId)) : null;
+      if (boost) {
+        entry.chances = draw.multiplier;
+        entry.boostVia = boost.via;
+        entry.boostEventId = boost.eventId;
+        boosted.push(entry);
+      }
+    }
+    const poolHash = computePoolHash(entries);
+
+    await d.sequelize.transaction(async (t) => {
+      for (const entry of boosted) {
+        await d.DrawEntry.update(
+          { chances: entry.chances, boostVia: entry.boostVia, boostEventId: entry.boostEventId },
+          { where: { id: entry.id }, transaction: t }
+        );
+      }
+      await transition(draw.id, 'frozen', 'sealed', { poolHash }, t);
+    });
+
+    const totalChances = entries.reduce((n, e) => n + e.chances, 0);
+    d.logger.info('lucky_draw.sealed', {
+      drawId: draw.id, entries: entries.length, boosted: boosted.length, totalChances, poolHash,
+    });
+    return { drawId: draw.id, entries: entries.length, boosted: boosted.length, totalChances, poolHash };
+  }
+
+  /**
+   * The witnessed pick. Eligible = entries minus ALL previously picked minus
+   * erased entrants (prospectId NULL). The seed is minted NOW (commit/reveal:
+   * poolHash predates it), recorded with totalChances + eligibleHash so the
+   * pick is re-derivable forever. Redraws pass `reason` = the prior attempt's
+   * failure mode and require that attempt to be closed out first.
+   */
+  async function runDrawAttempt(drawId, { witnessUserId = null, reason = 'initial' } = {}, user) {
+    if (!ATTEMPT_REASONS.has(reason)) {
+      throw new AppError(`reason must be one of: ${[...ATTEMPT_REASONS].join(', ')}`, 422);
+    }
+    const draw = await getDrawOr404(drawId);
+    if (!['sealed', 'drawn'].includes(draw.status)) {
+      throw new AppError(`Draw is ${draw.status}, expected sealed (or drawn, for a redraw)`, 409);
+    }
+
+    const priorAttempts = await d.DrawAttempt.findAll({
+      where: { drawId: draw.id },
+      order: [['attemptNo', 'ASC']],
+    });
+    const pending = priorAttempts.find((a) => a.outcome === 'pending');
+    if (pending) {
+      throw new AppError(`Attempt ${pending.attemptNo} is still pending — record its outcome before redrawing`, 409);
+    }
+    if (priorAttempts.some((a) => a.outcome === 'claimed')) {
+      throw new AppError('This draw already has a claimed winner', 409);
+    }
+    if (priorAttempts.length > 0 && reason === 'initial') {
+      throw new AppError("A redraw needs its reason (the prior attempt's outcome), not 'initial'", 422);
+    }
+
+    const pickedBefore = new Set(priorAttempts.map((a) => String(a.pickedEntryId)));
+    const allEntries = await d.DrawEntry.findAll({ where: { drawId: draw.id } });
+    const eligible = orderedEntries(allEntries).filter(
+      (e) => e.prospectId != null && !pickedBefore.has(String(e.id))
+    );
+    if (eligible.length === 0) throw new AppError('No eligible entries left to draw from', 409);
+
+    const totalChances = eligible.reduce((n, e) => n + e.chances, 0);
+    const eligibleHash = computeEligibleHash(eligible);
+    const seed = d.mintSeed();
+    const picked = pickWinner(seed, eligible);
+    const drawnAt = d.now();
+
+    let attempt;
+    await d.sequelize.transaction(async (t) => {
+      attempt = await d.DrawAttempt.create(
+        {
+          drawId: draw.id,
+          attemptNo: priorAttempts.length + 1,
+          seed,
+          totalChances,
+          eligibleHash,
+          pickedEntryId: picked.id,
+          reason,
+          drawnAt,
+          witnessedByUserId: witnessUserId,
+          claimDeadline: new Date(drawnAt.getTime() + CLAIM_WINDOW_DAYS * 24 * 3600 * 1000),
+          outcome: 'pending',
+        },
+        { transaction: t }
+      );
+      if (draw.status === 'sealed') {
+        await transition(draw.id, 'sealed', 'drawn', { witnessedByUserId: witnessUserId }, t);
+      }
+    });
+
+    d.logger.info('lucky_draw.drawn', {
+      drawId: draw.id, attemptNo: attempt.attemptNo, totalChances,
+      pickedEntryId: picked.id, displayName: picked.displayName, phoneLast4: picked.phoneLast4,
+    });
+    return {
+      attempt,
+      picked: {
+        entryId: picked.id,
+        prospectId: picked.prospectId,
+        displayName: picked.displayName,
+        phoneLast4: picked.phoneLast4,
+        chances: picked.chances,
+        boostVia: picked.boostVia || null,
+      },
+    };
+  }
+
+  /** Close out an attempt: claimed | unclaimed | unreachable | ineligible | declined. */
+  async function recordAttemptOutcome(attemptId, { outcome, contactedAt = null, claimedAt = null } = {}, user) {
+    if (!OUTCOMES.has(outcome)) {
+      throw new AppError(`outcome must be one of: ${[...OUTCOMES].join(', ')}`, 422);
+    }
+    const attempt = await d.DrawAttempt.findByPk(attemptId);
+    if (!attempt) throw new AppError('Attempt not found', 404);
+
+    const [count] = await d.DrawAttempt.update(
+      {
+        outcome,
+        ...(contactedAt ? { contactedAt } : {}),
+        ...(outcome === 'claimed' ? { claimedAt: claimedAt || d.now() } : {}),
+      },
+      { where: { id: attemptId, outcome: 'pending' } }
+    );
+    if (count === 0) throw new AppError(`Attempt already has outcome '${attempt.outcome}'`, 409);
+
+    if (outcome === 'claimed') {
+      await d.Draw.update(
+        { status: 'claimed' },
+        { where: { id: attempt.drawId, status: { [Op.in]: ['drawn', 'published'] } } }
+      );
+    }
+    return d.DrawAttempt.findByPk(attemptId);
+  }
+
+  /**
+   * Mark published AFTER the winners-wall deploy is verified live
+   * (redeemWinnersContent.js edit + deploy + hash-flip check — CLAUDE.md).
+   */
+  async function markPublished(drawId, user) {
+    const draw = await getDrawOr404(drawId);
+    if (!['drawn', 'claimed'].includes(draw.status)) {
+      throw new AppError(`Draw is ${draw.status}, expected drawn or claimed`, 409);
+    }
+    await transition(draw.id, draw.status, draw.status === 'claimed' ? 'claimed' : 'published');
+    // A claimed draw stays 'claimed' (terminal-est state); publishing is
+    // recorded in notes for that case.
+    if (draw.status === 'claimed') {
+      await d.Draw.update(
+        { notes: `${draw.notes ? `${draw.notes}\n` : ''}Published ${d.now().toISOString()}` },
+        { where: { id: draw.id } }
+      );
+    }
+    return getDrawOr404(drawId);
+  }
+
+  /** Cancel a not-yet-published draw. Reason is mandatory and recorded. */
+  async function voidDraw(drawId, reason, user) {
+    if (!reason || !String(reason).trim()) throw new AppError('A reason is required to void a draw', 422);
+    const draw = await getDrawOr404(drawId);
+    if (['published', 'claimed'].includes(draw.status)) {
+      throw new AppError('A published/claimed draw cannot be voided', 409);
+    }
+    await d.Draw.update(
+      {
+        status: 'void',
+        notes: `${draw.notes ? `${draw.notes}\n` : ''}VOID (${d.now().toISOString()}, by ${user?.id || 'unknown'}): ${reason}`,
+      },
+      { where: { id: draw.id, status: draw.status } }
+    );
+    return getDrawOr404(drawId);
+  }
+
+  /**
+   * Independent re-derivation of everything the fairness story rests on:
+   * poolHash from the stored entries, and every attempt's pick from its seed
+   * over its committed eligible set. Any mismatch (tamper, post-hoc erasure)
+   * is reported, never absorbed.
+   */
+  async function verifyDraw(drawId) {
+    const draw = await getDrawOr404(drawId);
+    const entries = await d.DrawEntry.findAll({ where: { drawId: draw.id } });
+    const attempts = await d.DrawAttempt.findAll({ where: { drawId: draw.id }, order: [['attemptNo', 'ASC']] });
+
+    const report = { drawId: draw.id, status: draw.status, ok: true, checks: [] };
+
+    if (draw.poolHash) {
+      const recomputed = computePoolHash(entries);
+      const ok = recomputed === draw.poolHash;
+      report.checks.push({ check: 'poolHash', ok, expected: draw.poolHash, recomputed });
+      if (!ok) report.ok = false;
+    }
+
+    const pickedBefore = new Set();
+    for (const attempt of attempts) {
+      const eligible = orderedEntries(entries).filter(
+        (e) => e.prospectId != null && !pickedBefore.has(String(e.id))
+      );
+      const eligibleHash = computeEligibleHash(eligible);
+      if (eligibleHash !== attempt.eligibleHash) {
+        // The set changed since the pick (e.g. an erasure) — the committed
+        // hash still proves what the seed was applied to; flag, don't guess.
+        report.checks.push({
+          check: `attempt#${attempt.attemptNo}.eligibleSet`, ok: false,
+          note: 'eligible set differs from the committed one (post-attempt erasure?) — pick verified against stored commitment only',
+        });
+        report.ok = false;
+      } else {
+        const picked = pickWinner(attempt.seed, eligible);
+        const ok = String(picked.id) === String(attempt.pickedEntryId);
+        report.checks.push({ check: `attempt#${attempt.attemptNo}.pick`, ok });
+        if (!ok) report.ok = false;
+      }
+      pickedBefore.add(String(attempt.pickedEntryId));
+    }
+    return report;
+  }
+
+  /** Masked full state for the CLI / future admin panel. */
+  async function getDrawState(drawId) {
+    const draw = await getDrawOr404(drawId);
+    const entries = await d.DrawEntry.findAll({ where: { drawId: draw.id } });
+    const attempts = await d.DrawAttempt.findAll({ where: { drawId: draw.id }, order: [['attemptNo', 'ASC']] });
+    return {
+      draw: {
+        id: draw.id, campaignId: draw.campaignId, status: draw.status,
+        closesAt: draw.closesAt, boostClosesAt: draw.boostClosesAt,
+        multiplier: draw.multiplier, poolHash: draw.poolHash,
+        activationId: draw.activationId, termsVersionId: draw.termsVersionId,
+      },
+      entries: {
+        count: entries.length,
+        totalChances: entries.reduce((n, e) => n + e.chances, 0),
+        boosted: entries.filter((e) => e.boostVia).length,
+        erased: entries.filter((e) => e.prospectId == null).length,
+      },
+      attempts: attempts.map((a) => ({
+        attemptNo: a.attemptNo, reason: a.reason, outcome: a.outcome,
+        drawnAt: a.drawnAt, claimDeadline: a.claimDeadline, claimedAt: a.claimedAt,
+        pickedEntryId: a.pickedEntryId, seed: a.seed,
+      })),
+    };
+  }
+
+  return {
+    createDraw, freezeDraw, listPendingBoostReviews, reviewBoost, sealDraw,
+    runDrawAttempt, recordAttemptOutcome, markPublished, voidDraw,
+    verifyDraw, getDrawState,
+  };
+}

--- a/backend/test/luckyDrawService.test.js
+++ b/backend/test/luckyDrawService.test.js
@@ -1,0 +1,433 @@
+/**
+ * Lucky-draw lifecycle (luckyDrawService, DI seam — no DB):
+ * pool filters at freeze, boost math + review gating at seal, commit/reveal
+ * determinism of the pick, redraw exclusions, outcome transitions, and
+ * verifyDraw's tamper detection. docs/plans/lucky-draw-10x.md §4.2–§4.3.
+ */
+import crypto from 'crypto';
+import { jest } from '@jest/globals';
+import {
+  makeLuckyDrawService, pickWinner, computePoolHash, computeEligibleHash,
+} from '../src/services/luckyDrawService.js';
+import { sgtDayEndExclusiveMs } from '../src/utils/sgtTime.js';
+
+const sha = (s) => crypto.createHash('sha256').update(s).digest('hex');
+const silentLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+
+const CAMPAIGN_ID = 'camp-1';
+const DRAW_ID = 'draw-1';
+const ADMIN = { id: 'admin-1', role: 'admin' };
+
+// Fixed clock: after both cutoffs below.
+const NOW = new Date('2026-09-15T04:00:00Z');
+const CLOSES_AT = new Date(sgtDayEndExclusiveMs('2026-08-31'));
+const BOOST_CLOSES_AT = new Date(sgtDayEndExclusiveMs('2026-09-10'));
+
+function verifiedProspect(id, first, last, phone, createdAt = '2026-08-01T00:00:00Z') {
+  return {
+    id, firstName: first, lastName: last, phone,
+    createdAt: new Date(createdAt),
+    sourceMetadata: { phoneVerifiedAt: '2026-08-01T00:00:00Z', phoneVerifiedFor: sha(phone) },
+  };
+}
+
+function entryRow(id, prospectId, phone, chances = 1, boostVia = null) {
+  return { id, drawId: DRAW_ID, prospectId, phoneHash: sha(phone), phoneLast4: phone.slice(-4), displayName: 'X', chances, boostVia };
+}
+
+function buildDeps({ draw = null, prospects = [], entries = [], attempts = [], reviews = [], entitlements = [], events = [] } = {}) {
+  const state = {
+    draw: draw && { ...draw },
+    entries: entries.map((e) => ({ ...e })),
+    attempts: attempts.map((a) => ({ ...a })),
+    reviews: reviews.map((r) => ({ ...r })),
+  };
+
+  const Draw = {
+    findByPk: jest.fn().mockImplementation(async () => (state.draw ? { ...state.draw } : null)),
+    create: jest.fn().mockImplementation(async (fields) => {
+      state.draw = { id: DRAW_ID, ...fields };
+      return { ...state.draw };
+    }),
+    update: jest.fn().mockImplementation(async (values, { where }) => {
+      if (!state.draw || state.draw.id !== where.id) return [0];
+      if (where.status !== undefined) {
+        const allowed = Array.isArray(where.status?.__in) ? where.status.__in : null;
+        // Sequelize Op.in arrives as a symbol-keyed object — emulate both forms.
+        if (typeof where.status === 'string') {
+          if (state.draw.status !== where.status) return [0];
+        } else if (allowed) {
+          if (!allowed.includes(state.draw.status)) return [0];
+        } else {
+          const symbolVals = Object.getOwnPropertySymbols(where.status || {}).map((s) => where.status[s]);
+          if (symbolVals.length && !symbolVals[0].includes(state.draw.status)) return [0];
+        }
+      }
+      Object.assign(state.draw, values);
+      return [1];
+    }),
+  };
+
+  const DrawEntry = {
+    findAll: jest.fn().mockImplementation(async () => state.entries.map((e) => ({ ...e }))),
+    bulkCreate: jest.fn().mockImplementation(async (rows) => {
+      rows.forEach((r, i) => state.entries.push({ id: `entry-${state.entries.length + i + 1}`, ...r }));
+      return rows;
+    }),
+    update: jest.fn().mockImplementation(async (values, { where }) => {
+      const row = state.entries.find((e) => e.id === where.id);
+      if (!row) return [0];
+      Object.assign(row, values);
+      return [1];
+    }),
+  };
+
+  const DrawAttempt = {
+    findAll: jest.fn().mockImplementation(async () => state.attempts.map((a) => ({ ...a }))),
+    findByPk: jest.fn().mockImplementation(async (id) => {
+      const row = state.attempts.find((a) => a.id === id);
+      return row ? { ...row } : null;
+    }),
+    create: jest.fn().mockImplementation(async (fields) => {
+      const row = { id: `attempt-${state.attempts.length + 1}`, ...fields };
+      state.attempts.push(row);
+      return { ...row };
+    }),
+    update: jest.fn().mockImplementation(async (values, { where }) => {
+      const row = state.attempts.find((a) => a.id === where.id);
+      if (!row || (where.outcome !== undefined && row.outcome !== where.outcome)) return [0];
+      Object.assign(row, values);
+      return [1];
+    }),
+  };
+
+  const DrawBoostReview = {
+    findAll: jest.fn().mockImplementation(async () => state.reviews.map((r) => ({ ...r }))),
+    create: jest.fn().mockImplementation(async (fields) => {
+      if (state.reviews.some((r) => r.entitlementId === fields.entitlementId)) {
+        const err = new Error('dup'); err.name = 'SequelizeUniqueConstraintError'; throw err;
+      }
+      const row = { id: `review-${state.reviews.length + 1}`, ...fields };
+      state.reviews.push(row);
+      return { ...row };
+    }),
+  };
+
+  return {
+    state,
+    deps: {
+      Draw, DrawEntry, DrawAttempt, DrawBoostReview,
+      Campaign: { findByPk: jest.fn().mockResolvedValue(null) },
+      Prospect: { findAll: jest.fn().mockResolvedValue(prospects) },
+      Activation: { findByPk: jest.fn().mockResolvedValue(null) },
+      RewardEntitlement: { findAll: jest.fn().mockResolvedValue(entitlements), findByPk: jest.fn().mockResolvedValue({ id: 'ent-x', prospectId: 'pros-x' }) },
+      RedemptionEvent: { findAll: jest.fn().mockResolvedValue(events) },
+      sequelize: { transaction: jest.fn().mockImplementation(async (cb) => cb({})) },
+      logger: silentLogger,
+      now: () => NOW,
+      mintSeed: () => 'a'.repeat(64),
+    },
+  };
+}
+
+const openDraw = {
+  id: DRAW_ID, campaignId: CAMPAIGN_ID, status: 'open',
+  closesAt: CLOSES_AT, boostClosesAt: BOOST_CLOSES_AT,
+  multiplier: 10, activationId: 'act-1', poolHash: null, notes: null,
+};
+
+// ── Pure pick math ──────────────────────────────────────────────────────────
+
+describe('pickWinner / hashes (pure)', () => {
+  const entries = [
+    { id: 'e1', prospectId: 'p1', phoneHash: 'h1', chances: 1, boostVia: null },
+    { id: 'e2', prospectId: 'p2', phoneHash: 'h2', chances: 10, boostVia: 'agent_scan' },
+    { id: 'e3', prospectId: 'p3', phoneHash: 'h3', chances: 1, boostVia: null },
+  ];
+
+  it('is deterministic for a fixed seed and respects the eligible set', () => {
+    const first = pickWinner('seed-1', entries);
+    for (let i = 0; i < 5; i += 1) expect(pickWinner('seed-1', entries).id).toBe(first.id);
+    expect(entries.map((e) => e.id)).toContain(first.id);
+  });
+
+  it('weights by chances (boosted entry wins overwhelmingly over many seeds)', () => {
+    let boostedWins = 0;
+    for (let i = 0; i < 200; i += 1) {
+      if (pickWinner(`seed-${i}`, entries).id === 'e2') boostedWins += 1;
+    }
+    // e2 holds 10 of 12 chances (~83%); allow wide tolerance.
+    expect(boostedWins).toBeGreaterThan(120);
+  });
+
+  it('poolHash is order-independent of input array and pins the weights', () => {
+    const a = computePoolHash(entries);
+    const b = computePoolHash([...entries].reverse());
+    expect(a).toBe(b);
+    const tampered = computePoolHash(entries.map((e) => (e.id === 'e1' ? { ...e, chances: 5 } : e)));
+    expect(tampered).not.toBe(a);
+  });
+});
+
+// ── createDraw ──────────────────────────────────────────────────────────────
+
+describe('createDraw', () => {
+  it('422s without an enabled luckyDraw config', async () => {
+    const { deps } = buildDeps();
+    deps.Campaign.findByPk.mockResolvedValue({ id: CAMPAIGN_ID, design_config: {} });
+    const svc = makeLuckyDrawService(deps);
+    await expect(svc.createDraw({ campaignId: CAMPAIGN_ID }, ADMIN)).rejects.toMatchObject({ statusCode: 422 });
+  });
+
+  it('422s when the designated activation belongs to another campaign', async () => {
+    const { deps } = buildDeps();
+    deps.Campaign.findByPk.mockResolvedValue({
+      id: CAMPAIGN_ID,
+      design_config: { luckyDraw: { enabled: true, closesAt: '2026-08-31', activationId: 'act-9' } },
+    });
+    deps.Activation.findByPk.mockResolvedValue({ id: 'act-9', campaignId: 'OTHER' });
+    const svc = makeLuckyDrawService(deps);
+    await expect(svc.createDraw({ campaignId: CAMPAIGN_ID }, ADMIN)).rejects.toMatchObject({ statusCode: 422 });
+  });
+
+  it('derives fixed SGT-exclusive instants and persists config', async () => {
+    const { deps } = buildDeps();
+    deps.Campaign.findByPk.mockResolvedValue({
+      id: CAMPAIGN_ID,
+      design_config: { luckyDraw: { enabled: true, closesAt: '2026-08-31', boostClosesAt: '2026-09-10', multiplier: 10 } },
+    });
+    const svc = makeLuckyDrawService(deps);
+    const draw = await svc.createDraw({ campaignId: CAMPAIGN_ID }, ADMIN);
+    expect(new Date(draw.closesAt).getTime()).toBe(sgtDayEndExclusiveMs('2026-08-31'));
+    expect(new Date(draw.boostClosesAt).getTime()).toBe(sgtDayEndExclusiveMs('2026-09-10'));
+    expect(draw.status).toBe('open');
+    expect(draw.createdBy).toBe(ADMIN.id);
+  });
+});
+
+// ── freezeDraw ──────────────────────────────────────────────────────────────
+
+describe('freezeDraw', () => {
+  it('refuses to freeze before entries close', async () => {
+    const { deps } = buildDeps({ draw: { ...openDraw, closesAt: new Date('2027-01-01T00:00:00Z') } });
+    const svc = makeLuckyDrawService(deps);
+    await expect(svc.freezeDraw(DRAW_ID, ADMIN)).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it('snapshots ONLY bound-verified in-window prospects, masked', async () => {
+    const good = verifiedProspect('p1', 'Jane', 'Doe', '+6591234567');
+    const unstamped = { ...verifiedProspect('p2', 'No', 'Stamp', '+6591111111'), sourceMetadata: {} };
+    const unbound = { ...verifiedProspect('p3', 'Moved', 'Phone', '+6592222222'), sourceMetadata: { phoneVerifiedAt: 'x', phoneVerifiedFor: sha('+6599999999') } };
+    const { deps, state } = buildDeps({ draw: { ...openDraw }, prospects: [good, unstamped, unbound] });
+    const svc = makeLuckyDrawService(deps);
+
+    const result = await svc.freezeDraw(DRAW_ID, ADMIN);
+    expect(result).toMatchObject({ candidates: 3, entries: 1 });
+    expect(state.draw.status).toBe('frozen');
+    const entry = state.entries[0];
+    expect(entry).toMatchObject({
+      prospectId: 'p1',
+      phoneHash: sha('+6591234567'),
+      phoneLast4: '4567',
+      displayName: 'Jane D.',
+      chances: 1,
+    });
+    // The where clause re-applies the stored cutoff (createdAt <= closesAt).
+    const where = deps.Prospect.findAll.mock.calls[0][0].where;
+    expect(where.campaignId).toBe(CAMPAIGN_ID);
+  });
+
+  it('409s when the draw is not open (double freeze)', async () => {
+    const { deps } = buildDeps({ draw: { ...openDraw, status: 'frozen' } });
+    const svc = makeLuckyDrawService(deps);
+    await expect(svc.freezeDraw(DRAW_ID, ADMIN)).rejects.toMatchObject({ statusCode: 409 });
+  });
+});
+
+// ── boost review + seal ─────────────────────────────────────────────────────
+
+function boostScenario({ reviews = [] } = {}) {
+  const entries = [
+    entryRow('e1', 'p1', '+6591111111'), // scan boost
+    entryRow('e2', 'p2', '+6592222222'), // button boost (review-dependent)
+    entryRow('e3', 'p3', '+6593333333'), // no boost
+    entryRow('e4', 'p4', '+6594444444'), // manual issuance — must never boost
+  ];
+  const entitlements = [
+    { id: 'ent-1', prospectId: 'p1', issuedVia: 'hook' },
+    { id: 'ent-2', prospectId: 'p2', issuedVia: 'hook' },
+    // ent for p4 excluded by the issuedVia != manual query — emulate by not returning it.
+  ];
+  const events = [
+    { id: 'ev-1', entitlementId: 'ent-1', metadata: { via: 'agent_scan' }, createdAt: new Date('2026-09-01T00:00:00Z') },
+    { id: 'ev-2', entitlementId: 'ent-2', metadata: { via: 'agent_button' }, createdAt: new Date('2026-09-02T00:00:00Z') },
+  ];
+  return buildDeps({ draw: { ...openDraw, status: 'frozen' }, entries, entitlements, events, reviews });
+}
+
+describe('sealDraw', () => {
+  it('refuses to seal before boostClosesAt', async () => {
+    const { deps } = buildDeps({ draw: { ...openDraw, status: 'frozen', boostClosesAt: new Date('2027-01-01T00:00:00Z') }, entries: [entryRow('e1', 'p1', '+6591111111')] });
+    const svc = makeLuckyDrawService(deps);
+    await expect(svc.sealDraw(DRAW_ID, ADMIN)).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it('blocks sealing while a button unlock is undecided, listing it', async () => {
+    const { deps } = boostScenario();
+    const svc = makeLuckyDrawService(deps);
+    const err = await svc.sealDraw(DRAW_ID, ADMIN).catch((e) => e);
+    expect(err.statusCode).toBe(409);
+    expect(err.data.undecided).toEqual([
+      expect.objectContaining({ entitlementId: 'ent-2', prospectId: 'p2' }),
+    ]);
+  });
+
+  it('boosts scan automatically, approved button ×N, rejected button stays 1×, and commits poolHash', async () => {
+    const { deps, state } = boostScenario({
+      reviews: [{ id: 'r1', drawId: DRAW_ID, entitlementId: 'ent-2', decision: 'approved' }],
+    });
+    const svc = makeLuckyDrawService(deps);
+    const result = await svc.sealDraw(DRAW_ID, ADMIN);
+
+    const byId = Object.fromEntries(state.entries.map((e) => [e.id, e]));
+    expect(byId.e1).toMatchObject({ chances: 10, boostVia: 'agent_scan', boostEventId: 'ev-1' });
+    expect(byId.e2).toMatchObject({ chances: 10, boostVia: 'agent_button', boostEventId: 'ev-2' });
+    expect(byId.e3.chances).toBe(1);
+    expect(byId.e4.chances).toBe(1);
+    expect(result.totalChances).toBe(22);
+    expect(state.draw.status).toBe('sealed');
+    expect(state.draw.poolHash).toBe(computePoolHash(state.entries));
+    // Boost evidence query excluded manual issuance.
+    const entWhere = deps.RewardEntitlement.findAll.mock.calls[0][0].where;
+    expect(entWhere.activationId).toBe('act-1');
+
+    // Rejected instead of approved → 1×.
+    const rejected = boostScenario({
+      reviews: [{ id: 'r1', drawId: DRAW_ID, entitlementId: 'ent-2', decision: 'rejected' }],
+    });
+    const svc2 = makeLuckyDrawService(rejected.deps);
+    const result2 = await svc2.sealDraw(DRAW_ID, ADMIN);
+    expect(Object.fromEntries(rejected.state.entries.map((e) => [e.id, e.chances])).e2).toBe(1);
+    expect(result2.totalChances).toBe(13);
+  });
+});
+
+describe('reviewBoost', () => {
+  it('422s on a bad decision and 409s on double review', async () => {
+    const { deps } = boostScenario();
+    const svc = makeLuckyDrawService(deps);
+    await expect(svc.reviewBoost({ drawId: DRAW_ID, entitlementId: 'ent-2', decision: 'maybe' }, ADMIN))
+      .rejects.toMatchObject({ statusCode: 422 });
+    await svc.reviewBoost({ drawId: DRAW_ID, entitlementId: 'ent-2', decision: 'approved' }, ADMIN);
+    await expect(svc.reviewBoost({ drawId: DRAW_ID, entitlementId: 'ent-2', decision: 'rejected' }, ADMIN))
+      .rejects.toMatchObject({ statusCode: 409 });
+  });
+});
+
+// ── runDrawAttempt / outcomes ───────────────────────────────────────────────
+
+function sealedScenario({ entries, attempts = [] }) {
+  return buildDeps({
+    draw: { ...openDraw, status: attempts.length > 0 ? 'drawn' : 'sealed', poolHash: computePoolHash(entries) },
+    entries, attempts,
+  });
+}
+
+describe('runDrawAttempt', () => {
+  const entries = [
+    entryRow('e1', 'p1', '+6591111111', 1),
+    entryRow('e2', 'p2', '+6592222222', 10, 'agent_scan'),
+    entryRow('e3', 'p3', '+6593333333', 1),
+  ];
+
+  it('picks deterministically from the injected seed, commits the eligible set, sets the 14-day deadline', async () => {
+    const { deps, state } = sealedScenario({ entries });
+    const svc = makeLuckyDrawService(deps);
+    const { attempt, picked } = await svc.runDrawAttempt(DRAW_ID, { witnessUserId: 'w-1' }, ADMIN);
+
+    const orderedEligible = [...entries].sort((a, b) => a.id.localeCompare(b.id));
+    const expected = pickWinner('a'.repeat(64), orderedEligible);
+    expect(picked.entryId).toBe(expected.id);
+    expect(attempt.totalChances).toBe(12);
+    expect(attempt.eligibleHash).toBe(computeEligibleHash(orderedEligible));
+    expect(new Date(attempt.claimDeadline).getTime()).toBe(NOW.getTime() + 14 * 24 * 3600 * 1000);
+    expect(state.draw.status).toBe('drawn');
+  });
+
+  it('blocks a redraw while an attempt is pending, and requires a real reason after', async () => {
+    const prior = { id: 'attempt-0', drawId: DRAW_ID, attemptNo: 1, pickedEntryId: 'e2', outcome: 'pending' };
+    const { deps } = sealedScenario({ entries, attempts: [prior] });
+    const svc = makeLuckyDrawService(deps);
+    await expect(svc.runDrawAttempt(DRAW_ID, {}, ADMIN)).rejects.toMatchObject({ statusCode: 409 });
+
+    const lapsed = { ...prior, outcome: 'unclaimed' };
+    const { deps: deps2 } = sealedScenario({ entries, attempts: [lapsed] });
+    const svc2 = makeLuckyDrawService(deps2);
+    await expect(svc2.runDrawAttempt(DRAW_ID, { reason: 'initial' }, ADMIN)).rejects.toMatchObject({ statusCode: 422 });
+  });
+
+  it('redraw excludes every previously picked entry AND erased entrants', async () => {
+    const withErased = [
+      entryRow('e1', 'p1', '+6591111111', 1),
+      entryRow('e2', 'p2', '+6592222222', 10, 'agent_scan'),
+      { ...entryRow('e3', 'p3', '+6593333333', 1), prospectId: null }, // erased post-freeze
+    ];
+    const prior = { id: 'attempt-0', drawId: DRAW_ID, attemptNo: 1, pickedEntryId: 'e2', outcome: 'unclaimed' };
+    const { deps } = sealedScenario({ entries: withErased, attempts: [prior] });
+    const svc = makeLuckyDrawService(deps);
+    const { attempt, picked } = await svc.runDrawAttempt(DRAW_ID, { reason: 'unclaimed' }, ADMIN);
+    // Only e1 is left: e2 already picked, e3 erased.
+    expect(picked.entryId).toBe('e1');
+    expect(attempt.attemptNo).toBe(2);
+    expect(attempt.totalChances).toBe(1);
+  });
+});
+
+describe('recordAttemptOutcome', () => {
+  it('claims: stamps claimedAt and moves the draw to claimed; refuses a second outcome', async () => {
+    const entries = [entryRow('e1', 'p1', '+6591111111', 1)];
+    const attempt = { id: 'attempt-1', drawId: DRAW_ID, attemptNo: 1, pickedEntryId: 'e1', outcome: 'pending' };
+    const { deps, state } = sealedScenario({ entries, attempts: [attempt] });
+    state.draw.status = 'drawn';
+    const svc = makeLuckyDrawService(deps);
+
+    const updated = await svc.recordAttemptOutcome('attempt-1', { outcome: 'claimed' }, ADMIN);
+    expect(updated.outcome).toBe('claimed');
+    expect(updated.claimedAt).toBeTruthy();
+    expect(state.draw.status).toBe('claimed');
+
+    await expect(svc.recordAttemptOutcome('attempt-1', { outcome: 'declined' }, ADMIN))
+      .rejects.toMatchObject({ statusCode: 409 });
+  });
+});
+
+// ── verifyDraw ──────────────────────────────────────────────────────────────
+
+describe('verifyDraw', () => {
+  it('verifies a clean draw and detects a tampered pool', async () => {
+    const entries = [
+      entryRow('e1', 'p1', '+6591111111', 1),
+      entryRow('e2', 'p2', '+6592222222', 10, 'agent_scan'),
+    ];
+    const orderedEligible = [...entries].sort((a, b) => a.id.localeCompare(b.id));
+    const seed = 'a'.repeat(64);
+    const picked = pickWinner(seed, orderedEligible);
+    const attempt = {
+      id: 'attempt-1', drawId: DRAW_ID, attemptNo: 1, seed,
+      totalChances: 11, eligibleHash: computeEligibleHash(orderedEligible),
+      pickedEntryId: picked.id, outcome: 'pending',
+    };
+    const clean = sealedScenario({ entries, attempts: [attempt] });
+    const svc = makeLuckyDrawService(clean.deps);
+    const report = await svc.verifyDraw(DRAW_ID);
+    expect(report.ok).toBe(true);
+
+    // Tamper: bump a weight after seal → poolHash AND eligibleHash mismatch.
+    const tampered = sealedScenario({ entries, attempts: [attempt] });
+    tampered.state.entries[0].chances = 5;
+    const svc2 = makeLuckyDrawService(tampered.deps);
+    const report2 = await svc2.verifyDraw(DRAW_ID);
+    expect(report2.ok).toBe(false);
+    expect(report2.checks.some((c) => c.check === 'poolHash' && !c.ok)).toBe(true);
+  });
+});

--- a/docs/plans/lucky-draw-10x.md
+++ b/docs/plans/lucky-draw-10x.md
@@ -1,7 +1,11 @@
 # Lucky Draw + 10× Session Multiplier — Design & Implementation Plan
 
 > Status: v2 (2026-07-12), Codex-reviewed (gpt-5.6-sol xhigh); disposition in §9.
-> **Phase 1 IMPLEMENTED** on `feat/lucky-draw-phase1` (commit ba9fc97) — see §5.
+> **Phase 1 IMPLEMENTED** — PR #139 (`feat/lucky-draw-phase1`, ba9fc97).
+> **Phase 2 IMPLEMENTED** on `feat/lucky-draw-phase2` (stacked on #139) — draws /
+> draw_entries / draw_attempts / draw_boost_reviews (migration 059, partial
+> uniques ALSO on the models — sync()-built schemas enforce them),
+> luckyDrawService lifecycle + `backend/scripts/run-lucky-draw.js` runner.
 > Migration numbering shifted 057→058 after #136 took 057.
 > Companion reading: `docs/redeem-ops/MKTR_INTEGRATION.md` §2 (entitlements),
 > `docs/plans/redeem-home-featured-drops.md` (homepage drops).
@@ -250,7 +254,7 @@ Backend contract (after the Phase 1 `via` fix):
 |---|---|---|
 | **0 — Ops setup + launch blockers (no code)** | Verify `prospects_campaign_id_phone` exists in prod (`SELECT indexname FROM pg_indexes WHERE tablename='prospects'`); flip `REDEEM_OPS_ENABLED` + `REDEEM_OPS_ENTITLEMENTS_ENABLED` (+ `VITE_REDEEM_OPS_ENABLED` if ops UI needed); create partner → offer → Activation; **size `offer.claimExpiryDays` to cover earliest-signup → `boostClosesAt`** (reservation expiry = `claimExpiryDays \|\| 30`; an expired reservation cannot be unlocked AND cannot be reissued — the unique index has no status filter); **size activation allocation ≥ expected signups** (exhaustion leaves later entrants with no pass; the reconcile sweep only backfills ~48h). | — |
 | **1 — Draw-campaign hardening** ✅ shipped (ba9fc97, tests green) | `luckyDraw` config block + admin clamp + duplicate-strip; create-gate (phone + normalized OTP marker + `consent_terms` + `closesAt`) placed post-normalization; `phoneVerifiedFor` hash binding; **server-derived `via` on both unlock routes**; draw confirmation template pair; `draw_terms_versions` + acceptance stamping; extract shared SGT-boundary util. Tests pin: direct-API POST without OTP → 403, after `closesAt` → 410, `via` forgery impossible, non-draw campaigns byte-identical. | **M–L** |
-| **2 — Draw model + runner** | Migrations 059+ (`draws`, `draw_attempts`, `draw_entries`, `draw_boost_reviews` — winner FK added after entries table to avoid the circular reference, or validated in-service); freeze/seal/draw/redraw service with idempotent transitions; canonical poolHash; commit/reveal seed; pinned seeded PRNG + unit tests; PII-masked snapshot + audit JSON; `run-lucky-draw.js` CLI with safeguards; concurrency tests. | **L** |
+| **2 — Draw model + runner** ✅ shipped | Migrations 059+ (`draws`, `draw_attempts`, `draw_entries`, `draw_boost_reviews` — winner FK added after entries table to avoid the circular reference, or validated in-service); freeze/seal/draw/redraw service with idempotent transitions; canonical poolHash; commit/reveal seed; pinned seeded PRNG + unit tests; PII-masked snapshot + audit JSON; `run-lucky-draw.js` CLI with safeguards; concurrency tests. | **L** |
 | **3 — Boost review UI** | Ops list of `agent_button` unlock events pending review → approve/reject writes `draw_boost_reviews` (schema exists from Phase 2, so no circularity); needs a reviewer capability added to **both** permission copies (`permissions.js` + SPA copy — drift test enforces equality). | **M** |
 | **4 — mktr-leads screens** | Scan screen + virtual-toggle button unlock per §4.7 (separate repo). | S |
 | **5 — Later** | Lyfe app mirror; admin draw panel; durable per-submission verification records; winners API instead of static file. | — |


### PR DESCRIPTION
**Stacked on #139** (Phase 1) — merge that first; this PR then retargets to `main` cleanly.

Implements **Phase 2** of `docs/plans/lucky-draw-10x.md`: the auditable draw itself.

## The model (migration 059)

- **`draws`** — one lifecycle row per campaign draw (`open → frozen → sealed → drawn → published/claimed`, `void` before publish). At most one LIVE draw per campaign (partial unique). `closesAt`/`boostClosesAt` are fixed UTC instants derived from SGT day boundaries at create — an ops delay can never widen a window.
- **`draw_entries`** — the frozen pool, PII-masked (`phoneHash` + last-4 + "First L."); prospect FK `SET NULL` on erasure so erased entrants become unpickable, never silently re-weighted. Winner *contact* uses the live prospect row, never the snapshot.
- **`draw_attempts`** — every witnessed pick, redraws included. Each attempt commits `seed + totalChances + eligibleHash`, so any pick is re-derivable forever.
- **`draw_boost_reviews`** — approve/reject of virtual (`agent_button`) unlocks for ×N weighting; the voucher itself is untouched.

Partial uniques are defined **on the models as well as the migration**: the test harness builds schema via `sync({force:true})`, which clobbers migration-made indexes — the same mechanism that left `prospects_campaign_id_phone` missing in fresh DBs.

## Fairness spine (`luckyDrawService`)

- Every transition is a conditional `UPDATE … WHERE status = <from>` — concurrent/replayed ops lose cleanly.
- **Freeze** re-applies the stored `createdAt <= closesAt` cutoff itself and admits only bound-verified entrants (`phoneVerifiedFor = sha256(phone)`).
- **×10 evidence** = append-only `redemption_events` `'unlocked'` rows on the designated activation (a later entitlement cancellation can't erase an earned boost); `issuedVia='manual'` excluded; `agent_scan` boosts automatically; `agent_button` requires an approved review — **seal refuses while any are undecided**.
- **Commit/reveal**: `poolHash` (canonical ordered `id|prospectId|phoneHash|chances|boostVia` tuples — commits to the *weights*) is sealed before any seed exists; the seed is minted at the witnessed pick.
- **Pick** = `sha256(seed) mod totalChances` over id-ordered expanded entries (documented negligible modulo bias) — one hash anyone can re-run.
- **Redraws** exclude all prior picks + erased entrants, require the prior attempt closed out with a real reason, and carry their own seed/witness/14-day claim deadline.
- **`verifyDraw`** independently re-derives poolHash and every attempt's pick; tamper and post-attempt erasure are *reported, never absorbed*.

## Ops tool

`backend/scripts/run-lucky-draw.js` — `create / status / freeze / reviews / review / seal / draw / outcome / publish / verify / void`, masked-identity JSON output only.

## Tests

- 18-case DI suite (`test/luckyDrawService.test.js`): pool filters, boost math + review gating, pick determinism, redraw exclusions, outcome transitions, tamper detection.
- Full backend suite vs `origin/main` on a throwaway Postgres: identical pre-existing failure set, zero regressions.
- Migration runner verified end-to-end on a sync-built DB; model partial indexes verified under `sync({force:true})`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FS33kQWQVbULWpXs54z6Kn