### PR TITLE
fix(leadcapture): blank brand wordmark shows customer host, not a fabricated domain

### DIFF
--- a/src/components/campaigns/__tests__/leadCaptureContent.test.js
+++ b/src/components/campaigns/__tests__/leadCaptureContent.test.js
@@ -2,21 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { brand } from '@/lib/brand';
 import {
   deriveLeadCaptureContent,
-  brandFromCampaignName,
   paragraphsFromText,
 } from '@/components/campaigns/leadCaptureContent';
-
-describe('brandFromCampaignName', () => {
-  it('takes the first significant word and appends .sg', () => {
-    expect(brandFromCampaignName('Goodies — Free Luggage')).toBe('goodies.sg');
-    expect(brandFromCampaignName('Acme Roadshow 2026')).toBe('acme.sg');
-  });
-
-  it('returns null for empty input', () => {
-    expect(brandFromCampaignName('')).toBeNull();
-    expect(brandFromCampaignName(null)).toBeNull();
-  });
-});
 
 describe('paragraphsFromText', () => {
   it('splits on blank lines and trims', () => {
@@ -38,9 +25,21 @@ describe('deriveLeadCaptureContent', () => {
     expect(wordmark).toBe('custom.sg');
   });
 
-  it('falls back to the campaign name when no wordmark is set', () => {
-    const { wordmark } = deriveLeadCaptureContent({ name: 'Acme Campaign', design_config: {} });
-    expect(wordmark).toBe('acme.sg');
+  it('falls back to the customer host when no wordmark is set', () => {
+    // Empty design_config → default customer host (redeem.sg), never a domain
+    // fabricated from the campaign name.
+    const redeemDefault = deriveLeadCaptureContent({
+      name: 'Tokyo Getaway Lucky Draw',
+      design_config: {},
+    });
+    expect(redeemDefault.wordmark).toBe('redeem.sg');
+
+    // An mktr-hosted campaign shows mktr.sg.
+    const mktrHosted = deriveLeadCaptureContent({
+      name: 'Tokyo Getaway Lucky Draw',
+      design_config: { customerHost: 'mktr' },
+    });
+    expect(mktrHosted.wordmark).toBe('mktr.sg');
   });
 
   it('derives the story from storyText ONLY (no formSubheadline fallback)', () => {

--- a/src/components/campaigns/editor/ContentPanel.jsx
+++ b/src/components/campaigns/editor/ContentPanel.jsx
@@ -201,7 +201,7 @@ export default function ContentPanel({ currentDesign, onDesignChange, campaignNa
  placeholder="e.g., goodies.sg" maxLength={40}
  />
  <p className="text-xs text-muted-foreground">
- Large display name at the top of the page. Leave blank to derive it from the campaign name.
+ Large display name at the top of the page. Leave blank to show the campaign's customer domain (redeem.sg or mktr.sg).
  </p>
  </div>
 

--- a/src/components/campaigns/leadCaptureContent.js
+++ b/src/components/campaigns/leadCaptureContent.js
@@ -1,4 +1,4 @@
-import { brand } from '@/lib/brand';
+import { brand, resolveCustomerHost } from '@/lib/brand';
 
 /**
  * Shared content-derivation for the public lead-capture page.
@@ -14,14 +14,6 @@ import { brand } from '@/lib/brand';
  * shared derivation.
  */
 
-// First significant word of the campaign name → "{word}.sg" wordmark fallback.
-export function brandFromCampaignName(name) {
-  if (!name) return null;
-  const first = name.trim().split(/[\s—–-]+/)[0]?.toLowerCase();
-  if (!first) return null;
-  return `${first}.sg`;
-}
-
 // Split free text into paragraphs on blank lines.
 export function paragraphsFromText(text) {
   if (!text) return [];
@@ -35,7 +27,7 @@ export function paragraphsFromText(text) {
  * Derive the lead-capture content slots from a campaign.
  *
  * @returns {{
- *   wordmark: string | null,
+ *   wordmark: string,
  *   story: { paragraphs: string[], emphasis?: string } | null,
  *   primaryCtaData: { label: string, color?: string, enabled: boolean } | null,
  *   regulatoryFooter: string,
@@ -45,7 +37,10 @@ export function paragraphsFromText(text) {
 export function deriveLeadCaptureContent(campaign) {
   const design = campaign?.design_config || {};
 
-  const wordmark = design.brandWordmark || brandFromCampaignName(campaign?.name);
+  // No explicit wordmark → show the campaign's actual customer host (redeem.sg or
+  // mktr.sg), never a domain fabricated from the campaign name (which produced
+  // misleading wordmarks like "tokyo.sg" from "Tokyo Getaway Lucky Draw").
+  const wordmark = design.brandWordmark || resolveCustomerHost(design.customerHost);
 
   // Story card sources from `storyText` ONLY. The old `storyText || formSubheadline`
   // fallback made the sub-headline render twice (once under the form headline and


### PR DESCRIPTION
## Problem
A campaign with a blank **Brand Wordmark** rendered a wordmark derived from the first word of its name + `.sg`. "Tokyo Getaway Lucky Draw" → **`tokyo.sg`** — a string that reads like a real, unrelated domain, shown large at the top of the customer's lead-capture page. Nobody set that value; it was auto-generated.

## Fix
A blank wordmark now falls back to the campaign's **actual customer host** — `redeem.sg` (or `mktr.sg` for an mktr-hosted campaign) — via `resolveCustomerHost(design.customerHost)`. It can no longer fabricate a domain from the campaign name.

- Removed the `brandFromCampaignName` helper (its only job was producing the misleading value).
- Corrected the designer's **Brand Wordmark** help text to match the new behavior.
- Updated unit tests — **9/9 passing**.

Affects the live lead-capture page, the `/p/:slug` preview, and the designer's inline preview (all share `deriveLeadCaptureContent`).

## Verification
`npx vitest run src/components/campaigns/__tests__/leadCaptureContent.test.js` → **9 passed**. For the Tokyo Getaway Lucky Draw campaign (blank wordmark, `customerHost: redeem`) the wordmark now resolves to `redeem.sg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)