### PR TITLE
fix(redeem-ops): invited staff land on ops.redeem.sg login after setting password

### DIFF
--- a/src/pages/AcceptInvite.jsx
+++ b/src/pages/AcceptInvite.jsx
@@ -22,6 +22,12 @@ import {
 } from"@/components/ui/input-otp";
 import { REGEXP_ONLY_DIGITS } from"input-otp";
 
+// Redeem Ops staff sign in on the dedicated ops.redeem.sg surface. VITE_OPS_ORIGIN
+// overrides the host for staging/dev; IS_OPS_SURFACE means THIS build already is
+// ops.redeem.sg, so a same-origin route suffices instead of a cross-origin hop.
+const IS_OPS_SURFACE = import.meta.env.VITE_SURFACE === 'ops';
+const OPS_LOGIN_URL = `${import.meta.env.VITE_OPS_ORIGIN || 'https://ops.redeem.sg'}/CustomerLogin`;
+
 export default function AcceptInvite() {
  const [searchParams] = useSearchParams();
  const navigate = useNavigate();
@@ -222,7 +228,14 @@ export default function AcceptInvite() {
  });
  if (resp.success) {
  const role = resp?.data?.user?.role;
- if (role === 'admin') navigate('/AdminDashboard');
+ if (role === 'redeem_ops') {
+ // Redeem Ops staff belong on the dedicated ops.redeem.sg console. The invite
+ // is accepted on whichever origin FRONTEND_BASE_URL points at (e.g. mktr.sg),
+ // so cross over to the ops login page — the password just set signs them into
+ // /redeem-ops there. Same-origin navigate when this already IS the ops build.
+ if (IS_OPS_SURFACE) navigate('/CustomerLogin');
+ else window.location.replace(OPS_LOGIN_URL);
+ } else if (role === 'admin') navigate('/AdminDashboard');
  else if (role === 'agent') navigate('/AgentDashboard');
  else navigate('/');
  }


### PR DESCRIPTION
## What

After a Redeem Ops invitee accepts their invite and creates a password, `AcceptInvite.jsx` fell through the role switch to `navigate('/')` — landing them on the **mktr.sg homepage** (the origin `FRONTEND_BASE_URL` points at), not the Redeem Ops console.

This routes `redeem_ops` users to the **ops.redeem.sg login page** instead:
- Same-origin `/CustomerLogin` when this already is the ops build (`VITE_SURFACE=ops`)
- Cross-origin hop to `https://ops.redeem.sg/CustomerLogin` otherwise (`VITE_OPS_ORIGIN` overrides for staging/dev)

## Why the login page (not the dashboard directly)

The invite-accept session cookie is **domain-scoped** (`.mktr.sg` vs `.redeem.sg`). Crossing to `ops.redeem.sg` presents a genuine login page where the password just set signs them in; `CustomerLogin` then forwards `redeem_ops` → `/redeem-ops`. Net flow: **set password → ops.redeem.sg login → dashboard.**

## Scope / risk

- Frontend-only, one file (`src/pages/AcceptInvite.jsx`), +14/−1.
- Only the `redeem_ops` branch is new; `admin`/`agent`/others are unchanged.
- No env change needed for prod (`VITE_OPS_ORIGIN` defaults to `https://ops.redeem.sg`, consistent with the backend's existing hardcoded ops allowlist).
- Ships on the next `mktr-platform` + `redeem-ops-frontend` static-site deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)