### PR TITLE
fix(redeem-ops): gate paid discovery + SGT-calendar-day quotas (Phase 1)

### DIFF
--- a/backend/src/routes/redeemOpsDiscovery.js
+++ b/backend/src/routes/redeemOpsDiscovery.js
@@ -4,10 +4,10 @@ import * as ctrl from '../controllers/redeemOps/discoveryController.js';
 
 /**
  * Redeem Ops — Discover tool (spec: ~/.claude/plans/redeem-ops-discover-tool.md).
- * Flag + host-guard posture as siblings. Search/read/enrich/dismiss are open to any
- * ops principal (paid-job cost is bounded by quotas in discoveryService, not a
- * capability); adding to the pipeline needs partners.create; the Apify webhook is
- * authenticated by a URL secret only (server-to-server, no JWT).
+ * Flag + host-guard posture as siblings. Paid search/enrichment require their
+ * discovery capabilities; read/dismiss remain open to any ops principal. Adding
+ * to the pipeline needs partners.create; the Apify webhook is authenticated by a
+ * URL secret only (server-to-server, no JWT).
  */
 export const meta = {
   path: '/api/redeem-ops',
@@ -20,13 +20,13 @@ const router = express.Router();
 // Apify terminal-event callback — secret in the URL, no JWT (must precede param routes).
 router.post('/discovery/webhook/:secret', ctrl.webhook);
 
-// Search + read (any authenticated ops principal)
-router.post('/discovery/runs', requireRedeemOps(), ctrl.startDiscovery);
+// Paid search + read
+router.post('/discovery/runs', requireRedeemOps('discovery.search'), ctrl.startDiscovery);
 router.get('/discovery/runs', requireRedeemOps(), ctrl.listRuns);
 router.get('/discovery/runs/:id', requireRedeemOps(), ctrl.getRun);
 
-// Enrich + dismiss
-router.post('/discovery/candidates/enrich', requireRedeemOps(), ctrl.enrichCandidates);
+// Paid enrichment + dismiss
+router.post('/discovery/candidates/enrich', requireRedeemOps('discovery.enrich'), ctrl.enrichCandidates);
 router.patch('/discovery/candidates/:id', requireRedeemOps(), ctrl.dismissCandidate);
 
 // Convert candidates → partners (only create-capable roles push to the pipeline)

--- a/backend/src/services/redeemOps/discoveryService.js
+++ b/backend/src/services/redeemOps/discoveryService.js
@@ -11,6 +11,7 @@ import { makeApifyClient } from './discovery/apifyClient.js';
 import { normalizeMapsItem, normalizeInstagramItem, isSingaporeMapsItem } from './discovery/normalizers.js';
 import { normalizeBusinessName, normalizeDomain, normalizeHandle } from './normalizers.js';
 import { normalizePhone } from '../prospectHelpers.js';
+import { sgtDayWindow } from './taskService.js';
 
 const TERMINAL = ['completed', 'failed', 'aborted', 'timed_out'];
 
@@ -73,7 +74,7 @@ export function makeDiscoveryService(overrides = {}) {
   // accepted residual: single backend instance, tiny ops team, small overshoot.
   async function assertQuota(user) {
     const c = cfg();
-    const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const { start: since } = sgtDayWindow();
     const base = { provider: 'apify_google_maps', createdAt: { [Op.gte]: since }, ...COUNTS_TOWARD_QUOTA };
     const [mine, all] = await Promise.all([
       d.DiscoveryRun.count({ where: { ...base, createdBy: user.id } }),
@@ -90,7 +91,7 @@ export function makeDiscoveryService(overrides = {}) {
   /** Per-user search budget for the day (drives the UI's usage chip). */
   async function getQuota(user) {
     const c = cfg();
-    const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const { start: since } = sgtDayWindow();
     const used = await d.DiscoveryRun.count({
       where: {
         provider: 'apify_google_maps', createdBy: user.id,
@@ -440,7 +441,7 @@ export function makeDiscoveryService(overrides = {}) {
 
     // Quotas count PROFILES (requestedLimit = handle count per run), excluding
     // runs that never reached Apify. SUM(int) can surface as a bigint string.
-    const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const { start: since } = sgtDayWindow();
     const igBase = { provider: 'apify_instagram', createdAt: { [Op.gte]: since }, ...COUNTS_TOWARD_QUOTA };
     const [globalUsedRaw, userUsedRaw] = await Promise.all([
       d.DiscoveryRun.sum('requestedLimit', { where: igBase }),

--- a/backend/src/services/redeemOps/permissions.js
+++ b/backend/src/services/redeemOps/permissions.js
@@ -61,6 +61,8 @@ export const CAPABILITIES = [
   'audit.view',
   'team.manage_access',
   'settings.manage',
+  'discovery.search',
+  'discovery.enrich',
 ];
 
 const ALL = [...CAPABILITIES];
@@ -93,6 +95,8 @@ export const ROLE_CAPABILITIES = {
     'analytics.view_own',
     'analytics.view_team',
     'exports.run',
+    'discovery.search',
+    'discovery.enrich',
   ],
   outreach_exec: [
     'partners.view',
@@ -110,6 +114,8 @@ export const ROLE_CAPABILITIES = {
     'onboarding.manage',
     'rewards.view',
     'analytics.view_own',
+    'discovery.search',
+    'discovery.enrich',
   ],
   campaign_ops: [
     'partners.view',

--- a/backend/test/redeemOpsDiscovery.test.js
+++ b/backend/test/redeemOpsDiscovery.test.js
@@ -18,6 +18,7 @@ import { getApp, closeDb, createTestUser, seedRedeemOpsCategory } from './helper
 import { makeDiscoveryService } from '../src/services/redeemOps/discoveryService.js';
 import { makePartnerService } from '../src/services/redeemOps/partnerService.js';
 import { makeDedupeService } from '../src/services/redeemOps/dedupeService.js';
+import { sgtDayWindow } from '../src/services/redeemOps/taskService.js';
 import { DiscoveryRun, DiscoveryCandidate, DiscoveryPlaceMemory, PartnerOrganisation, sequelize } from '../src/models/index.js';
 
 let app;
@@ -65,7 +66,7 @@ let placeSeq = 0;
 const uniquePlaceId = () => `place_${Date.now()}_${++placeSeq}`;
 
 // Default user = the shared admin; new tests that call startDiscovery pass a
-// FRESH user instead — the shared admin's 24h search quota fills up across the
+// FRESH user instead — the shared admin's current-SGT-day quota fills up across the
 // suite (direct DiscoveryRun.create rows count too).
 async function startedRun(svc, apify, user = null) {
   apify.startRun.mockImplementation(async () => uniqueRunId());
@@ -398,8 +399,8 @@ describe('enrichment eligibility + profile quotas', () => {
       createdBy: solo.user.id, provider: 'apify_instagram', status: 'failed',
       providerRunId: null, requestedLimit: 500,
     });
-    // Baseline: profiles counted by the quota rule in the last 24h (shared DB).
-    const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    // Baseline: profiles counted by the quota rule in the current SGT day (shared DB).
+    const { start: since } = sgtDayWindow();
     const igRuns = await DiscoveryRun.findAll({ where: { provider: 'apify_instagram' } });
     const used = igRuns
       .filter((r) => r.createdAt >= since && !(r.status === 'failed' && !r.providerRunId))

--- a/backend/test/redeemOpsDiscoveryPermissions.test.js
+++ b/backend/test/redeemOpsDiscoveryPermissions.test.js
@@ -1,0 +1,75 @@
+import { jest } from '@jest/globals';
+import express from 'express';
+import request from 'supertest';
+
+jest.unstable_mockModule('../src/middleware/auth.js', () => ({
+  authenticateToken: (_req, _res, next) => next(),
+}));
+
+const allow = (_req, res) => res.sendStatus(204);
+jest.unstable_mockModule('../src/controllers/redeemOps/discoveryController.js', () => ({
+  startDiscovery: allow,
+  listRuns: allow,
+  getRun: allow,
+  enrichCandidates: allow,
+  addToPartners: allow,
+  dismissCandidate: allow,
+  webhook: allow,
+}));
+
+const { default: router } = await import('../src/routes/redeemOpsDiscovery.js');
+
+const USERS = {
+  admin: { role: 'admin' },
+  super_admin: { role: 'redeem_ops', redeemOpsRole: 'super_admin' },
+  ops_admin: { role: 'redeem_ops', redeemOpsRole: 'ops_admin' },
+  bdm: { role: 'redeem_ops', redeemOpsRole: 'bdm' },
+  outreach_exec: { role: 'redeem_ops', redeemOpsRole: 'outreach_exec' },
+  campaign_ops: { role: 'redeem_ops', redeemOpsRole: 'campaign_ops' },
+  redemption_ops: { role: 'redeem_ops', redeemOpsRole: 'redemption_ops' },
+  analyst: { role: 'redeem_ops', redeemOpsRole: 'analyst' },
+};
+
+const app = express();
+app.use(express.json());
+app.use((req, _res, next) => {
+  req.user = USERS[req.get('x-test-user')];
+  next();
+});
+app.use('/api/redeem-ops', router);
+
+const paidRoutes = [
+  ['search', '/api/redeem-ops/discovery/runs'],
+  ['enrich', '/api/redeem-ops/discovery/candidates/enrich'],
+];
+
+describe('Redeem Ops discovery route capabilities', () => {
+  test.each(['campaign_ops', 'redemption_ops', 'analyst'])(
+    '%s is forbidden from paid discovery mutations',
+    async (role) => {
+      for (const [, url] of paidRoutes) {
+        await request(app).post(url).set('x-test-user', role).send({}).expect(403);
+      }
+    }
+  );
+
+  test.each(['admin', 'super_admin', 'ops_admin', 'bdm', 'outreach_exec'])(
+    '%s is allowed through both paid discovery gates',
+    async (role) => {
+      for (const [, url] of paidRoutes) {
+        await request(app).post(url).set('x-test-user', role).send({}).expect(204);
+      }
+    }
+  );
+
+  test.each(Object.keys(USERS))('%s retains read and dismiss access', async (role) => {
+    const headers = { 'x-test-user': role };
+    await request(app).get('/api/redeem-ops/discovery/runs').set(headers).expect(204);
+    await request(app).get('/api/redeem-ops/discovery/runs/run-id').set(headers).expect(204);
+    await request(app)
+      .patch('/api/redeem-ops/discovery/candidates/candidate-id')
+      .set(headers)
+      .send({})
+      .expect(204);
+  });
+});

--- a/backend/test/redeemOpsPermissions.test.js
+++ b/backend/test/redeemOpsPermissions.test.js
@@ -58,6 +58,18 @@ describe('redeemOps permissions map', () => {
     }
   });
 
+  test('paid discovery is limited to admins, BDMs, and outreach executives', () => {
+    for (const role of ['super_admin', 'ops_admin', 'bdm', 'outreach_exec']) {
+      expect(ROLE_CAPABILITIES[role]).toEqual(
+        expect.arrayContaining(['discovery.search', 'discovery.enrich'])
+      );
+    }
+    for (const role of ['campaign_ops', 'redemption_ops', 'analyst']) {
+      expect(ROLE_CAPABILITIES[role]).not.toContain('discovery.search');
+      expect(ROLE_CAPABILITIES[role]).not.toContain('discovery.enrich');
+    }
+  });
+
   test('hasCapability: admin is implicit super_admin; sub-roles resolve; null-sub-role users hold nothing', () => {
     expect(hasCapability({ role: 'admin' }, 'team.manage_access')).toBe(true);
     expect(hasCapability({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' }, 'partners.claim')).toBe(true);

--- a/backend/test/sgtDayWindow.test.js
+++ b/backend/test/sgtDayWindow.test.js
@@ -1,0 +1,13 @@
+import { sgtDayWindow } from '../src/services/redeemOps/taskService.js';
+
+describe('sgtDayWindow', () => {
+  test('flips the current Singapore calendar day at 16:00 UTC', () => {
+    const beforeBoundary = sgtDayWindow(new Date('2026-07-14T15:59:00.000Z'));
+    const afterBoundary = sgtDayWindow(new Date('2026-07-14T16:01:00.000Z'));
+
+    expect(beforeBoundary.start.toISOString()).toBe('2026-07-13T16:00:00.000Z');
+    expect(beforeBoundary.end.toISOString()).toBe('2026-07-14T16:00:00.000Z');
+    expect(afterBoundary.start.toISOString()).toBe('2026-07-14T16:00:00.000Z');
+    expect(afterBoundary.end.toISOString()).toBe('2026-07-15T16:00:00.000Z');
+  });
+});

--- a/src/components/redeemops/RedeemOpsLayout.jsx
+++ b/src/components/redeemops/RedeemOpsLayout.jsx
@@ -38,10 +38,10 @@ import '@/styles/redeem-ops-theme.css';
 const NAV = [
   { title: 'Queue', url: '/redeem-ops/queue', icon: House },
   { title: 'Partners', url: '/redeem-ops/partners', icon: Users, capability: 'partners.view' },
-  // Discover has no capability gate (all principals), so its own build flag is what
-  // keeps it hidden until go-live (backend DISCOVERY_ENABLED + Apify token).
+  // Discover also has its own build flag for go-live (backend DISCOVERY_ENABLED +
+  // Apify token); the capability gate hides paid search from non-spending roles.
   ...(import.meta.env.VITE_DISCOVERY_ENABLED === 'true'
-    ? [{ title: 'Discover', url: '/redeem-ops/discover', icon: Compass }]
+    ? [{ title: 'Discover', url: '/redeem-ops/discover', icon: Compass, capability: 'discovery.search' }]
     : []),
   { title: 'Pipeline', url: '/redeem-ops/pipeline', icon: Kanban, capability: 'pipeline.view_team' },
   { title: 'Tasks', url: '/redeem-ops/tasks', icon: ListChecks, capability: 'tasks.manage' },

--- a/src/lib/redeemOpsPermissions.js
+++ b/src/lib/redeemOpsPermissions.js
@@ -57,6 +57,8 @@ export const CAPABILITIES = [
   'audit.view',
   'team.manage_access',
   'settings.manage',
+  'discovery.search',
+  'discovery.enrich',
 ];
 
 const ALL = [...CAPABILITIES];
@@ -89,6 +91,8 @@ export const ROLE_CAPABILITIES = {
     'analytics.view_own',
     'analytics.view_team',
     'exports.run',
+    'discovery.search',
+    'discovery.enrich',
   ],
   outreach_exec: [
     'partners.view',
@@ -106,6 +110,8 @@ export const ROLE_CAPABILITIES = {
     'onboarding.manage',
     'rewards.view',
     'analytics.view_own',
+    'discovery.search',
+    'discovery.enrich',
   ],
   campaign_ops: [
     'partners.view',


### PR DESCRIPTION
## Phase 1 — Discovery hardening: access gate + Asia/Singapore day boundary

Two independent, low-risk hardening fixes for the Redeem Ops **Discover** tool.

### 1. Gate paid discovery behind capabilities
Previously search/read/enrich/dismiss were open to **any** Redeem Ops principal (`requireRedeemOps()` with no capability), so read-mostly roles could fire paid Apify runs and Instagram enrichment. Now the two **paid** mutations are capability-gated; reads + dismiss stay open.

| Role | Search (POST) | Enrich (POST) | Read | Dismiss |
|---|:--:|:--:|:--:|:--:|
| admin / super_admin / ops_admin | ✅ | ✅ | ✅ | ✅ |
| bdm / outreach_exec | ✅ | ✅ | ✅ | ✅ |
| campaign_ops / redemption_ops / analyst | **403** | **403** | ✅ | ✅ |

- New capabilities `discovery.search` / `discovery.enrich` (backend `permissions.js` + frontend mirror; drift test green).
- `admin` implicit super_admin; `ops_admin` inherits via `ALL`.
- Add-to-pipeline still `partners.create`; webhook still URL-secret. Discover nav hidden from non-spenders.

### 2. Scope quotas to an Asia/Singapore calendar day
Quota windows used a rolling 24h (`Date.now() - 24h`) instead of a Singapore calendar day. All three quota sites now use the shared `sgtDayWindow()` helper (already used by `taskService`/`queueService`); reconcile + retention `Date.now()` sites are unrelated and untouched. Quotas now reset at 00:00 SGT.

### Testing
- Backend: `sgtDayWindow`, `redeemOpsPermissions`, `redeemOpsDiscoveryPermissions`, and the DB-backed discovery suite pass (26 tests in the fast suites, verified locally).
- Frontend permissions drift test passes (mirror matches backend).

### Rollback
Access gate: revert the route capability args. Day boundary: no schema, pure computation. No new feature flag; sits under the existing `REDEEM_OPS_ENABLED` / `DISCOVERY_ENABLED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)