### PR TITLE
feat(redeem-ops): category provider search terms + flagged Maps expansion (Phase 2a)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -286,6 +286,7 @@ HITPAY_REDIRECT_URL=                         # app deep link back after pay (opt
 
 # ── Redeem Ops — Discover tool (Apify prospecting; migration 053) ──────────────
 DISCOVERY_ENABLED=false                       # master switch (also gates the reconcile sweep)
+DISCOVERY_SEARCH_TERMS_ENABLED=false          # expand category aliases in Maps searches; off preserves legacy one-name input
 APIFY_TOKEN=                                  # SECRET — Apify API token
 APIFY_MAPS_ACTOR_ID=compass~crawler-google-places   # Google Maps scraper actor
 APIFY_INSTAGRAM_ACTOR_ID=apify~instagram-profile-scraper    # IG enrichment actor (PROFILE scraper — takes `usernames`; plain instagram-scraper does NOT)

--- a/backend/src/controllers/redeemOps/adminController.js
+++ b/backend/src/controllers/redeemOps/adminController.js
@@ -227,11 +227,13 @@ export const getConstants = asyncHandler(async (req, res) => {
 
 const categoryCreateSchema = Joi.object({
   name: Joi.string().min(1).max(64).required(),
+  searchTerms: Joi.array().items(Joi.string().min(1).max(64)).max(20),
 });
 
 const categoryUpdateSchema = Joi.object({
   name: Joi.string().min(1).max(64),
   isActive: Joi.boolean(),
+  searchTerms: Joi.array().items(Joi.string().min(1).max(64)).max(20),
 }).min(1);
 
 const categoryMergeSchema = Joi.object({

--- a/backend/src/database/migrations/062-redeem-ops-category-search-terms.js
+++ b/backend/src/database/migrations/062-redeem-ops-category-search-terms.js
@@ -1,0 +1,20 @@
+/**
+ * 062 — Provider-specific search terms for the Redeem Ops category taxonomy.
+ *
+ * The category name remains the stable CRM classification while Discover can
+ * use a category's aliases as Google Maps search strings. Guarded/idempotent
+ * like 052–056 and safe under NODE_ENV=test's sync-first empty tables.
+ */
+export async function up(queryInterface) {
+  const q = async (sql) => queryInterface.sequelize.query(sql);
+  await q('ALTER TABLE redeem_ops_categories ADD COLUMN IF NOT EXISTS "providerSearchTerms" text[]');
+  await q(`UPDATE redeem_ops_categories
+              SET "providerSearchTerms" = ARRAY[name]
+            WHERE "providerSearchTerms" IS NULL`);
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query(
+    'ALTER TABLE redeem_ops_categories DROP COLUMN IF EXISTS "providerSearchTerms"'
+  );
+}

--- a/backend/src/models/RedeemOpsCategory.js
+++ b/backend/src/models/RedeemOpsCategory.js
@@ -10,6 +10,7 @@ import { sequelize } from '../database/connection.js';
 const RedeemOpsCategory = sequelize.define('RedeemOpsCategory', {
   id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
   name: { type: DataTypes.STRING(64), allowNull: false },
+  providerSearchTerms: { type: DataTypes.ARRAY(DataTypes.TEXT), allowNull: true },
   isActive: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
 }, {
   tableName: 'redeem_ops_categories',

--- a/backend/src/services/redeemOps/categoryService.js
+++ b/backend/src/services/redeemOps/categoryService.js
@@ -36,8 +36,34 @@ export function makeCategoryService(overrides = {}) {
     return name;
   }
 
+  function cleanSearchTerms(raw, fallbackName) {
+    if (raw === undefined) return undefined;
+    const values = Array.isArray(raw) ? raw : [raw];
+    const seen = new Set();
+    const cleaned = [];
+    for (const value of values) {
+      const term = String(value ?? '').trim().slice(0, 64);
+      const key = term.toLowerCase();
+      if (!term || seen.has(key)) continue;
+      seen.add(key);
+      cleaned.push(term);
+      if (cleaned.length === 20) break;
+    }
+    return cleaned.length > 0 ? cleaned : [fallbackName];
+  }
+
   function whereNameCi(name) {
     return d.sequelize.where(d.sequelize.fn('LOWER', d.sequelize.col('name')), name.toLowerCase());
+  }
+
+  async function findActiveCategory(name) {
+    const match = await d.RedeemOpsCategory.findOne({
+      where: { [Op.and]: [whereNameCi(name), { isActive: true }] },
+    });
+    if (!match) {
+      throw new AppError(`Unknown category '${name}' — ask an admin to add it in Settings`, 422);
+    }
+    return match;
   }
 
   async function listCategories({ includeInactive = false } = {}) {
@@ -49,14 +75,15 @@ export function makeCategoryService(overrides = {}) {
 
   async function createCategory(body, user, requestId = null) {
     const name = cleanName(body?.name);
+    const providerSearchTerms = cleanSearchTerms(body?.searchTerms, name) ?? [name];
     const existing = await d.RedeemOpsCategory.findOne({ where: whereNameCi(name) });
     if (existing) throw new AppError(`Category '${existing.name}' already exists`, 409);
     try {
-      const category = await d.RedeemOpsCategory.create({ name });
+      const category = await d.RedeemOpsCategory.create({ name, providerSearchTerms });
       await d.audit.recordAuditEvent({
         actorUser: user, action: 'settings.category_created',
         entityType: 'redeem_ops_category', entityId: category.id,
-        after: { name }, requestId,
+        after: { name, searchTerms: providerSearchTerms }, requestId,
       });
       return category;
     } catch (err) {
@@ -94,9 +121,17 @@ export function makeCategoryService(overrides = {}) {
       }
     }
     if (body?.isActive !== undefined) updates.isActive = !!body.isActive;
+    if (body?.searchTerms !== undefined) {
+      const effectiveName = updates.name || category.name;
+      updates.providerSearchTerms = cleanSearchTerms(body.searchTerms, effectiveName);
+    }
     if (Object.keys(updates).length === 0) return category;
 
-    const before = { name: category.name, isActive: category.isActive };
+    const before = {
+      name: category.name,
+      isActive: category.isActive,
+      searchTerms: category.providerSearchTerms,
+    };
     await d.sequelize.transaction(async (t) => {
       await category.update(updates, { transaction: t });
       if (cascade) {
@@ -110,7 +145,13 @@ export function makeCategoryService(overrides = {}) {
       await d.audit.recordAuditEvent({
         actorUser: user, action: 'settings.category_updated',
         entityType: 'redeem_ops_category', entityId: category.id,
-        before, after: { ...before, ...updates }, requestId, transaction: t,
+        before,
+        after: {
+          name: updates.name ?? before.name,
+          isActive: updates.isActive ?? before.isActive,
+          searchTerms: updates.providerSearchTerms ?? before.searchTerms,
+        },
+        requestId, transaction: t,
       });
     });
     return category;
@@ -142,12 +183,24 @@ export function makeCategoryService(overrides = {}) {
         );
         rowsMoved += meta?.rowCount ?? 0;
       }
+      const targetTerms = target.providerSearchTerms?.length
+        ? target.providerSearchTerms
+        : [target.name];
+      const mergedSearchTerms = cleanSearchTerms([
+        ...targetTerms,
+        ...(source.providerSearchTerms || []),
+        source.name,
+      ], target.name);
+      await target.update({ providerSearchTerms: mergedSearchTerms }, { transaction: t });
       await source.destroy({ transaction: t });
       await d.audit.recordAuditEvent({
         actorUser: user, action: 'settings.category_merged',
         entityType: 'redeem_ops_category', entityId: source.id,
         before: { name: source.name },
-        after: { mergedInto: target.name, targetId: target.id, rowsMoved },
+        after: {
+          mergedInto: target.name, targetId: target.id, rowsMoved,
+          searchTerms: mergedSearchTerms,
+        },
         requestId, transaction: t,
       });
     });
@@ -199,18 +252,24 @@ export function makeCategoryService(overrides = {}) {
     if (currentValue && name.toLowerCase() === String(currentValue).trim().toLowerCase()) {
       return currentValue;
     }
-    const match = await d.RedeemOpsCategory.findOne({
-      where: { [Op.and]: [whereNameCi(name), { isActive: true }] },
-    });
-    if (!match) {
-      throw new AppError(`Unknown category '${name}' — ask an admin to add it in Settings`, 422);
-    }
+    const match = await findActiveCategory(name);
     return match.name;
+  }
+
+  async function resolveCategoryForSearch(input) {
+    const name = String(input ?? '').trim();
+    const match = await findActiveCategory(name);
+    return {
+      name: match.name,
+      searchTerms: match.providerSearchTerms?.length
+        ? match.providerSearchTerms
+        : [match.name],
+    };
   }
 
   return {
     listCategories, createCategory, updateCategory, mergeCategory, deleteCategory,
-    resolveCategoryName,
+    resolveCategoryName, resolveCategoryForSearch,
   };
 }
 

--- a/backend/src/services/redeemOps/discoveryService.js
+++ b/backend/src/services/redeemOps/discoveryService.js
@@ -18,6 +18,7 @@ const TERMINAL = ['completed', 'failed', 'aborted', 'timed_out'];
 function cfg() {
   return {
     enabled: process.env.DISCOVERY_ENABLED === 'true',
+    searchTermsEnabled: process.env.DISCOVERY_SEARCH_TERMS_ENABLED === 'true',
     mapsActor: process.env.APIFY_MAPS_ACTOR_ID || 'compass~crawler-google-places',
     // MUST be the PROFILE scraper — apify~instagram-scraper (its sibling) has no
     // `usernames` input (wants directUrls), so every enrichment run came back
@@ -120,10 +121,18 @@ export function makeDiscoveryService(overrides = {}) {
     // spend — otherwise every add-to-pipeline would fail after the money was paid.
     // Stores the taxonomy's canonical casing so add-time createPartner re-validation
     // can only fail on the (rare) delete-category-mid-run race.
-    const canonicalCategory = await d.categories.resolveCategoryName(String(category).trim());
+    const { name: canonicalCategory, searchTerms } = await d.categories.resolveCategoryForSearch(
+      String(category).trim()
+    );
     await assertQuota(user);
     const c = cfg();
     const requestedLimit = Math.min(Math.max(Number(limit) || 60, 1), c.maxResultsPerRun);
+    const searchTermsUsed = c.searchTermsEnabled ? searchTerms : [canonicalCategory];
+    // The Maps actor applies this cap to EACH search string, so divide the
+    // requested total across aliases to avoid multiplying crawl cost by N.
+    const perSearchLimit = c.searchTermsEnabled
+      ? Math.max(1, Math.floor(requestedLimit / searchTermsUsed.length))
+      : requestedLimit;
 
     const run = await d.DiscoveryRun.create({
       createdBy: user.id, provider: 'apify_google_maps',
@@ -139,9 +148,9 @@ export function makeDiscoveryService(overrides = {}) {
       // with global brand matches (Sephora New York/Oshawa/Edmonton, 2026-07-12).
       const locationQuery = /\bsingapore\b/i.test(run.area) ? run.area : `${run.area}, Singapore`;
       const input = {
-        searchStringsArray: [canonicalCategory],
+        searchStringsArray: searchTermsUsed,
         locationQuery,
-        maxCrawledPlacesPerSearch: requestedLimit,
+        maxCrawledPlacesPerSearch: perSearchLimit,
         language: 'en',
         scrapeContacts: true, // enables the instagrams/social arrays
       };
@@ -154,7 +163,12 @@ export function makeDiscoveryService(overrides = {}) {
 
     await d.audit.recordAuditEvent({
       actorUser: user, action: 'discovery.run_started', entityType: 'discovery_run',
-      entityId: run.id, after: { category: run.category, area: run.area, requestedLimit }, requestId,
+      entityId: run.id,
+      after: {
+        category: run.category, area: run.area, requestedLimit,
+        searchTerms: searchTermsUsed,
+      },
+      requestId,
     });
     return run;
   }

--- a/backend/test/redeemOpsCategories.test.js
+++ b/backend/test/redeemOpsCategories.test.js
@@ -11,6 +11,7 @@ process.env.REDEEM_OPS_ENABLED = 'true'; // must be set before getApp() mounts r
 import request from 'supertest';
 import { getApp, closeDb, createTestUser } from './helpers.js';
 import { RedeemOpsCategory, PartnerOrganisation } from '../src/models/index.js';
+import { makeCategoryService } from '../src/services/redeemOps/categoryService.js';
 
 let app;
 let admin, bdm, exec;
@@ -30,8 +31,11 @@ const auth = (t) => ({ Authorization: `Bearer ${t}` });
 let nameSeq = 0;
 const uniq = (base) => `${base} ${Date.now()}-${++nameSeq}`;
 
-const createCategory = (token, name) =>
-  request(app).post('/api/redeem-ops/categories').set(auth(token)).send({ name });
+const createCategory = (token, name, searchTerms = undefined) =>
+  request(app).post('/api/redeem-ops/categories').set(auth(token)).send({
+    name,
+    ...(searchTerms === undefined ? {} : { searchTerms }),
+  });
 const createPartner = (token, body) =>
   request(app).post('/api/redeem-ops/partners').set(auth(token)).send(body);
 const updatePartner = (token, id, body) =>
@@ -53,6 +57,18 @@ describe('create + capability gate', () => {
     const ok = await createCategory(admin.token, name);
     expect(ok.status).toBe(201);
     expect(ok.body.data.category.name).toBe(name);
+    expect(ok.body.data.category.providerSearchTerms).toEqual([name]);
+  });
+
+  test('provider search terms are trimmed and deduped case-insensitively', async () => {
+    const name = uniq('Local Coffeeshop');
+    const ok = await createCategory(admin.token, name, [
+      ' kopitiam ', 'KOPITIAM', 'zi char', 'coffeeshop',
+    ]);
+    expect(ok.status).toBe(201);
+    expect(ok.body.data.category.providerSearchTerms).toEqual([
+      'kopitiam', 'zi char', 'coffeeshop',
+    ]);
   });
 
   test('case-insensitive duplicate → 409', async () => {
@@ -128,6 +144,40 @@ describe('rename cascade', () => {
       .send({ name: b });
     expect(res.status).toBe(409);
   });
+
+  test('search-term edits persist and a later rename leaves them intact', async () => {
+    const from = uniq('Local Cafe');
+    const created = await createCategory(admin.token, from);
+    const categoryId = created.body.data.category.id;
+    const partnerRes = await createPartner(exec.token, {
+      tradingName: uniq('Kopi House'), category: from,
+    });
+
+    const termsUpdate = await request(app)
+      .patch(`/api/redeem-ops/categories/${categoryId}`)
+      .set(auth(admin.token))
+      .send({ searchTerms: [' kopitiam ', 'KOPITIAM', 'zi char'] });
+    expect(termsUpdate.status).toBe(200);
+    expect(termsUpdate.body.data.category.providerSearchTerms).toEqual(['kopitiam', 'zi char']);
+
+    const to = uniq('Neighbourhood Coffeeshop');
+    const rename = await request(app)
+      .patch(`/api/redeem-ops/categories/${categoryId}`)
+      .set(auth(admin.token))
+      .send({ name: to });
+    expect(rename.status).toBe(200);
+    expect(rename.body.data.category.providerSearchTerms).toEqual(['kopitiam', 'zi char']);
+
+    const partner = await PartnerOrganisation.findByPk(partnerRes.body.data.partner.id);
+    expect(partner.category).toBe(to);
+
+    const reset = await request(app)
+      .patch(`/api/redeem-ops/categories/${categoryId}`)
+      .set(auth(admin.token))
+      .send({ searchTerms: [] });
+    expect(reset.status).toBe(200);
+    expect(reset.body.data.category.providerSearchTerms).toEqual([to]);
+  });
 });
 
 describe('currentValue pass-through', () => {
@@ -165,8 +215,8 @@ describe('merge', () => {
   test('merge moves consuming rows to the target and deletes the source', async () => {
     const source = uniq('Nails');
     const target = uniq('Nail Bar');
-    const createdSource = await createCategory(admin.token, source);
-    const createdTarget = await createCategory(admin.token, target);
+    const createdSource = await createCategory(admin.token, source, ['common alias', 'manicure']);
+    const createdTarget = await createCategory(admin.token, target, ['Common Alias', 'nail studio']);
 
     const partnerRes = await createPartner(exec.token, { tradingName: uniq('Tips Co'), category: source });
     const partnerId = partnerRes.body.data.partner.id;
@@ -181,6 +231,10 @@ describe('merge', () => {
     const partner = await PartnerOrganisation.findByPk(partnerId);
     expect(partner.category).toBe(target);
     expect(await RedeemOpsCategory.findByPk(createdSource.body.data.category.id)).toBeNull();
+    const mergedTarget = await RedeemOpsCategory.findByPk(createdTarget.body.data.category.id);
+    expect(mergedTarget.providerSearchTerms).toEqual([
+      'Common Alias', 'nail studio', 'manicure', source,
+    ]);
   });
 
   test('merging a category into itself → 400', async () => {
@@ -191,6 +245,33 @@ describe('merge', () => {
       .set(auth(admin.token))
       .send({ targetId: id });
     expect(res.status).toBe(400);
+  });
+});
+
+describe('resolveCategoryForSearch', () => {
+  const categoryService = makeCategoryService();
+
+  test('known category returns canonical name and provider terms', async () => {
+    const name = uniq('Searchable Cafe');
+    await createCategory(admin.token, name, ['kopitiam', 'zi char']);
+    await expect(categoryService.resolveCategoryForSearch(name.toLowerCase())).resolves.toEqual({
+      name,
+      searchTerms: ['kopitiam', 'zi char'],
+    });
+  });
+
+  test('unknown category returns the same 422 used by category writes', async () => {
+    await expect(categoryService.resolveCategoryForSearch(uniq('Unknown Search Category')))
+      .rejects.toMatchObject({ statusCode: 422 });
+  });
+
+  test('legacy null terms fall back to the canonical name', async () => {
+    const name = uniq('Legacy Search Category');
+    await RedeemOpsCategory.create({ name, providerSearchTerms: null });
+    await expect(categoryService.resolveCategoryForSearch(name)).resolves.toEqual({
+      name,
+      searchTerms: [name],
+    });
   });
 });
 

--- a/backend/test/redeemOpsDiscovery.test.js
+++ b/backend/test/redeemOpsDiscovery.test.js
@@ -19,7 +19,10 @@ import { makeDiscoveryService } from '../src/services/redeemOps/discoveryService
 import { makePartnerService } from '../src/services/redeemOps/partnerService.js';
 import { makeDedupeService } from '../src/services/redeemOps/dedupeService.js';
 import { sgtDayWindow } from '../src/services/redeemOps/taskService.js';
-import { DiscoveryRun, DiscoveryCandidate, DiscoveryPlaceMemory, PartnerOrganisation, sequelize } from '../src/models/index.js';
+import {
+  DiscoveryRun, DiscoveryCandidate, DiscoveryPlaceMemory, PartnerOrganisation,
+  RedeemOpsAuditEvent, sequelize,
+} from '../src/models/index.js';
 
 let app;
 let admin;
@@ -294,15 +297,49 @@ describe('category validation', () => {
 });
 
 describe('geo-anchored search input', () => {
-  test('area is sent as locationQuery (Singapore-anchored), never in the search string', async () => {
+  test('flag OFF keeps the legacy Apify input and full requested limit', async () => {
+    delete process.env.DISCOVERY_SEARCH_TERMS_ENABLED;
+    const category = `Legacy Input Category ${Date.now()}`;
+    await seedRedeemOpsCategory(category, { providerSearchTerms: ['provider alias'] });
     const apify = makeApifyStub();
     const svc = makeDiscoveryService({ apify });
     const solo = await createTestUser({ role: 'admin' });
     apify.startRun.mockImplementation(async () => uniqueRunId());
-    await svc.startDiscovery({ category: 'Nail Salon', area: 'Tampines', limit: 5 }, solo.user);
+    await svc.startDiscovery({ category, area: 'Tampines', limit: 5 }, solo.user);
     const input = apify.startRun.mock.calls[0][1];
-    expect(input.searchStringsArray).toEqual(['Nail Salon']);
-    expect(input.locationQuery).toBe('Tampines, Singapore');
+    expect(input).toEqual({
+      searchStringsArray: [category],
+      locationQuery: 'Tampines, Singapore',
+      maxCrawledPlacesPerSearch: 5,
+      language: 'en',
+      scrapeContacts: true,
+    });
+  });
+
+  test('flag ON sends provider terms, divides the limit, and snapshots the category name', async () => {
+    process.env.DISCOVERY_SEARCH_TERMS_ENABLED = 'true';
+    const category = `Local Coffeeshop ${Date.now()}`;
+    const providerSearchTerms = ['kopitiam', 'zi char', 'coffeeshop'];
+    await seedRedeemOpsCategory(category, { providerSearchTerms });
+    const apify = makeApifyStub();
+    const svc = makeDiscoveryService({ apify });
+    const solo = await createTestUser({ role: 'admin' });
+    apify.startRun.mockImplementation(async () => uniqueRunId());
+
+    const run = await svc.startDiscovery({ category, area: 'Tampines', limit: 10 }, solo.user);
+
+    expect(apify.startRun.mock.calls[0][1]).toEqual({
+      searchStringsArray: providerSearchTerms,
+      locationQuery: 'Tampines, Singapore',
+      maxCrawledPlacesPerSearch: 3,
+      language: 'en',
+      scrapeContacts: true,
+    });
+    expect(run.category).toBe(category);
+    const audit = await RedeemOpsAuditEvent.findOne({
+      where: { action: 'discovery.run_started', entityId: run.id },
+    });
+    expect(audit.after.searchTerms).toEqual(providerSearchTerms);
   });
 
   test('an area already naming Singapore is not double-suffixed', async () => {

--- a/src/pages/redeemops/SettingsPage.jsx
+++ b/src/pages/redeemops/SettingsPage.jsx
@@ -15,11 +15,13 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import Plus from 'lucide-react/icons/plus';
 import Pencil from 'lucide-react/icons/pencil';
+import Search from 'lucide-react/icons/search';
 import Merge from 'lucide-react/icons/merge';
 import Trash2 from 'lucide-react/icons/trash-2';
 import { RoPageHeader, RoTag } from '@/components/redeemops/ui';
 
 const CATEGORIES_KEY = ['redeem-ops', 'categories'];
+const parseSearchTerms = (value) => value.split(',').map((term) => term.trim()).filter(Boolean);
 
 /**
  * /redeem-ops/settings — admin knobs (settings.manage). First resident: the
@@ -45,11 +47,17 @@ export default function SettingsPage() {
 
   // ── Add ────────────────────────────────────────────────────────────────
   const [newName, setNewName] = useState('');
+  const [newSearchTerms, setNewSearchTerms] = useState('');
   const createMutation = useMutation({
-    mutationFn: () => redeemOpsApi.createCategory({ name: newName.trim() }),
+    mutationFn: () => {
+      const body = { name: newName.trim() };
+      if (newSearchTerms.trim()) body.searchTerms = parseSearchTerms(newSearchTerms);
+      return redeemOpsApi.createCategory(body);
+    },
     onSuccess: (cat) => {
       toast.success(`Added '${cat?.name || newName.trim()}'`);
       setNewName('');
+      setNewSearchTerms('');
       invalidate();
     },
     onError: onError('Could not add category'),
@@ -67,6 +75,21 @@ export default function SettingsPage() {
       queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partners'] });
     },
     onError: onError('Could not rename'),
+  });
+
+  // ── Provider search terms ──────────────────────────────────────────────
+  const [searchTermsTarget, setSearchTermsTarget] = useState(null);
+  const [searchTermsText, setSearchTermsText] = useState('');
+  const searchTermsMutation = useMutation({
+    mutationFn: () => redeemOpsApi.updateCategory(searchTermsTarget.id, {
+      searchTerms: parseSearchTerms(searchTermsText),
+    }),
+    onSuccess: () => {
+      toast.success('Search terms updated');
+      setSearchTermsTarget(null);
+      invalidate();
+    },
+    onError: onError('Could not update search terms'),
   });
 
   // ── Retire / restore ───────────────────────────────────────────────────
@@ -126,16 +149,26 @@ export default function SettingsPage() {
         </CardHeader>
         <CardContent>
           <form
-            className="flex gap-2 mb-4"
+            className="grid gap-2 mb-4 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] sm:items-start"
             onSubmit={(e) => { e.preventDefault(); if (newName.trim()) createMutation.mutate(); }}
           >
             <Input
               value={newName}
               onChange={(e) => setNewName(e.target.value)}
               placeholder="New category, e.g. Pet Grooming"
-              className="max-w-xs"
             />
-            <Button type="submit" disabled={!newName.trim() || createMutation.isPending}>
+            <div className="space-y-1">
+              <Input
+                value={newSearchTerms}
+                onChange={(e) => setNewSearchTerms(e.target.value)}
+                placeholder="Search terms (optional), comma-separated"
+                aria-label="Search terms"
+              />
+              <p className="text-xs m-0" style={{ color: 'var(--ro-text-2)' }}>
+                Terms Discover sends to Google Maps — e.g. kopitiam, zi char. Defaults to the category name.
+              </p>
+            </div>
+            <Button type="submit" className="sm:mt-0" disabled={!newName.trim() || createMutation.isPending}>
               <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" /> Add
             </Button>
           </form>
@@ -158,6 +191,15 @@ export default function SettingsPage() {
                     onClick={() => { setRenameTarget(cat); setRenameTo(cat.name); }}
                   >
                     <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
+                  </Button>
+                  <Button
+                    variant="ghost" size="sm" aria-label={`Edit search terms for ${cat.name}`}
+                    onClick={() => {
+                      setSearchTermsTarget(cat);
+                      setSearchTermsText((cat.providerSearchTerms || []).join(', '));
+                    }}
+                  >
+                    <Search className="w-3.5 h-3.5" aria-hidden="true" />
                   </Button>
                   <Button
                     variant="ghost" size="sm" aria-label={`Merge ${cat.name} into another category`}
@@ -207,6 +249,38 @@ export default function SettingsPage() {
               onClick={() => renameMutation.mutate()}
             >
               {renameMutation.isPending ? 'Renaming…' : 'Rename'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={!!searchTermsTarget}
+        onOpenChange={(open) => { if (!open) setSearchTermsTarget(null); }}
+      >
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Edit search terms</DialogTitle>
+            <DialogDescription>
+              Terms Discover sends to Google Maps — e.g. kopitiam, zi char. Defaults to the
+              category name.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-1.5 py-2">
+            <Label htmlFor="category-search-terms">Search terms</Label>
+            <Input
+              id="category-search-terms"
+              value={searchTermsText}
+              onChange={(e) => setSearchTermsText(e.target.value)}
+              placeholder={searchTermsTarget?.name}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              disabled={searchTermsMutation.isPending}
+              onClick={() => searchTermsMutation.mutate()}
+            >
+              {searchTermsMutation.isPending ? 'Saving…' : 'Save'}
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## Phase 2a — decouple provider search terms from the CRM category name

Today the category name is sent verbatim to Google Maps as the search string. This lets each category carry provider **search terms** (e.g. category "Local Coffeeshop" → `["kopitiam","zi char","coffeeshop"]`) that Discover sends instead — while the category **name** stays the stable CRM classification.

### Changes
- **Migration 062**: `redeem_ops_categories.providerSearchTerms text[]` (nullable), backfilled to `ARRAY[name]`. Guarded/idempotent; safe under `NODE_ENV=test` sync-first.
- **`categoryService`**: `cleanSearchTerms` (trim/dedupe-ci/cap 20×64/fallback to name); create + update store terms; **`mergeCategory` unions target+source terms+source name before `destroy()`** (no alias loss); new `resolveCategoryForSearch()` returns `{name, searchTerms}` and reuses the same active-category lookup so `resolveCategoryName`'s 422 is unchanged.
- **`discoveryService.startDiscovery`**: gated by `DISCOVERY_SEARCH_TERMS_ENABLED` (**default `false`**). Off ⇒ `searchStringsArray:[name]`, `maxCrawledPlacesPerSearch:requestedLimit` — **byte-identical to today**. On ⇒ terms expand and the limit is divided across them (`floor(limit/N)`), because the `compass~crawler` actor applies the cap **per search string** (verified against its input schema) — avoids ~N× crawl cost.
- Admin UI (`SettingsPage`) to add/edit comma-separated search terms; Joi accepts an optional `searchTerms[]`.

### Safety / rollout
Ships **dark**: with the flag off (default) the Apify input is unchanged. The only always-on behaviour is the additive migration and the admin merge-union. Rollback = revert; the column is nullable and harmless.

### Verification (local)
- **Both DB-backed Jest suites pass: 59/59** (`redeemOpsCategories`, `redeemOpsDiscovery`) against Postgres 15/17.
- Frontend production build ✓ (exit 0); ESLint on changed files ✓ (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)