### PR TITLE
feat(redeem-ops): controlled territories + All-Singapore (Phase 2b)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -287,6 +287,7 @@ HITPAY_REDIRECT_URL=                         # app deep link back after pay (opt
 # ── Redeem Ops — Discover tool (Apify prospecting; migration 053) ──────────────
 DISCOVERY_ENABLED=false                       # master switch (also gates the reconcile sweep)
 DISCOVERY_SEARCH_TERMS_ENABLED=false          # expand category aliases in Maps searches; off preserves legacy one-name input
+DISCOVERY_TERRITORIES_ENABLED=false           # admin-curated SG area picker; off preserves the free-text Area UI
 APIFY_TOKEN=                                  # SECRET — Apify API token
 APIFY_MAPS_ACTOR_ID=compass~crawler-google-places   # Google Maps scraper actor
 APIFY_INSTAGRAM_ACTOR_ID=apify~instagram-profile-scraper    # IG enrichment actor (PROFILE scraper — takes `usernames`; plain instagram-scraper does NOT)

--- a/backend/src/controllers/redeemOps/adminController.js
+++ b/backend/src/controllers/redeemOps/adminController.js
@@ -12,6 +12,8 @@ import { REDEEM_OPS_SUB_ROLES } from '../../services/redeemOps/permissions.js';
 import { SUB_ROLE_LABELS, publicConstants } from '../../services/redeemOps/constants.js';
 import { recordAuditEvent } from '../../services/redeemOps/auditService.js';
 import categoryService from '../../services/redeemOps/categoryService.js';
+import territoryService from '../../services/redeemOps/territoryService.js';
+import { cfg as discoveryConfig } from '../../services/redeemOps/discoveryService.js';
 
 const TEAM_ATTRIBUTES = [
   'id', 'email', 'firstName', 'lastName', 'fullName',
@@ -275,5 +277,49 @@ export const mergeCategory = asyncHandler(async (req, res) => {
 /** DELETE /api/redeem-ops/categories/:id — unreferenced rows only. */
 export const deleteCategory = asyncHandler(async (req, res) => {
   const result = await categoryService.deleteCategory(req.params.id, req.user, req.id);
+  res.json({ success: true, data: result });
+});
+
+// ---- Discover territories (migration 063; search filters only) ----
+
+const territoryCreateSchema = Joi.object({
+  name: Joi.string().min(1).max(64).required(),
+});
+
+const territoryUpdateSchema = Joi.object({
+  name: Joi.string().min(1).max(64),
+  isActive: Joi.boolean(),
+}).min(1);
+
+/** GET /api/redeem-ops/territories — active picker list; all rows for Settings. */
+export const listTerritories = asyncHandler(async (req, res) => {
+  const territories = await territoryService.listTerritories({
+    includeInactive: req.query.includeInactive === 'true',
+  });
+  res.json({
+    success: true,
+    data: { enabled: discoveryConfig().territoriesEnabled, territories },
+  });
+});
+
+/** POST /api/redeem-ops/territories */
+export const createTerritory = asyncHandler(async (req, res) => {
+  const { error, value } = territoryCreateSchema.validate(req.body, { abortEarly: false });
+  if (error) throw new AppError(error.details.map((d) => d.message).join(', '), 400);
+  const territory = await territoryService.createTerritory(value, req.user, req.id);
+  res.status(201).json({ success: true, data: { territory } });
+});
+
+/** PATCH /api/redeem-ops/territories/:id — rename and/or retire; no cascades. */
+export const updateTerritory = asyncHandler(async (req, res) => {
+  const { error, value } = territoryUpdateSchema.validate(req.body, { abortEarly: false });
+  if (error) throw new AppError(error.details.map((d) => d.message).join(', '), 400);
+  const territory = await territoryService.updateTerritory(req.params.id, value, req.user, req.id);
+  res.json({ success: true, data: { territory } });
+});
+
+/** DELETE /api/redeem-ops/territories/:id — names are not referenced by other tables. */
+export const deleteTerritory = asyncHandler(async (req, res) => {
+  const result = await territoryService.deleteTerritory(req.params.id, req.user, req.id);
   res.json({ success: true, data: result });
 });

--- a/backend/src/database/migrations/063-discovery-territories.js
+++ b/backend/src/database/migrations/063-discovery-territories.js
@@ -1,0 +1,68 @@
+/**
+ * 063 — Admin-curated Singapore territories for Discover search filters.
+ *
+ * Territory names remain soft controls: DiscoveryRun.area is still a plain
+ * string and no partner/pool ownership or assignment is introduced. Guarded
+ * and idempotent like 052–062; safe when NODE_ENV=test sync() created the table
+ * before migrations run.
+ */
+export async function up(queryInterface, Sequelize) {
+  const q = async (sql) => queryInterface.sequelize.query(sql);
+  const tables = await queryInterface.showAllTables();
+
+  if (!tables.includes('discovery_territories')) {
+    await queryInterface.createTable('discovery_territories', {
+      id: { type: Sequelize.UUID, primaryKey: true, allowNull: false, defaultValue: Sequelize.literal('gen_random_uuid()') },
+      name: { type: Sequelize.STRING(64), allowNull: false },
+      isActive: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: true },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    });
+  }
+
+  await q(`CREATE UNIQUE INDEX IF NOT EXISTS uq_discovery_territories_name_ci
+             ON discovery_territories (LOWER(name))`);
+
+  // Supply UUID/timestamps explicitly: sync()-created test tables enforce the
+  // same NOT NULL columns but do not carry migration-side DB defaults.
+  await q(`INSERT INTO discovery_territories (id, name, "isActive", "createdAt", "updatedAt")
+           SELECT gen_random_uuid(), seed.name, TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+             FROM (VALUES
+                    ('Ang Mo Kio'),
+                    ('Bedok'),
+                    ('Bishan'),
+                    ('Bukit Batok'),
+                    ('Bukit Merah'),
+                    ('Bukit Panjang'),
+                    ('Bukit Timah'),
+                    ('Chinatown'),
+                    ('Choa Chu Kang'),
+                    ('Clementi'),
+                    ('Geylang'),
+                    ('Hougang'),
+                    ('Jurong East'),
+                    ('Jurong West'),
+                    ('Kallang'),
+                    ('Katong'),
+                    ('Marine Parade'),
+                    ('Novena'),
+                    ('Orchard'),
+                    ('Pasir Ris'),
+                    ('Punggol'),
+                    ('Queenstown'),
+                    ('Raffles Place'),
+                    ('Sembawang'),
+                    ('Sengkang'),
+                    ('Serangoon'),
+                    ('Tampines'),
+                    ('Tiong Bahru'),
+                    ('Toa Payoh'),
+                    ('Woodlands'),
+                    ('Yishun')
+                  ) AS seed(name)
+           ON CONFLICT DO NOTHING`);
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query('DROP TABLE IF EXISTS discovery_territories');
+}

--- a/backend/src/models/DiscoveryTerritory.js
+++ b/backend/src/models/DiscoveryTerritory.js
@@ -1,0 +1,19 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Admin-curated Singapore areas offered as Discover search filters. These rows
+ * are not assignments and DiscoveryRun.area deliberately remains a plain string.
+ */
+const DiscoveryTerritory = sequelize.define('DiscoveryTerritory', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  name: { type: DataTypes.STRING(64), allowNull: false },
+  isActive: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+}, {
+  tableName: 'discovery_territories',
+  indexes: [
+    { name: 'uq_discovery_territories_name_ci', unique: true, fields: [sequelize.fn('lower', sequelize.col('name'))] },
+  ],
+});
+
+export default DiscoveryTerritory;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -331,7 +331,7 @@ export const {
   RewardTermsVersion, DrawTermsVersion, Draw, DrawEntry, DrawAttempt,
   DrawBoostReview, RewardOfferLocation, RewardInventoryEvent,
   PartnerOnboardingItem, Activation, RewardEntitlement, Redemption,
-  RedemptionEvent, RedeemOpsCategory, DiscoveryRun, DiscoveryCandidate,
+  RedemptionEvent, RedeemOpsCategory, DiscoveryTerritory, DiscoveryRun, DiscoveryCandidate,
   DiscoveryPlaceMemory, OutreachCadence, OutreachCadenceStep,
   OutreachCadenceTransition, OutreachCadenceEnrollment, OutreachSuppression,
   AiSettings

--- a/backend/src/routes/redeemOpsAdmin.js
+++ b/backend/src/routes/redeemOpsAdmin.js
@@ -38,4 +38,10 @@ router.patch('/categories/:id', requireRedeemOps('settings.manage'), ctrl.update
 router.post('/categories/:id/merge', requireRedeemOps('settings.manage'), ctrl.mergeCategory);
 router.delete('/categories/:id', requireRedeemOps('settings.manage'), ctrl.deleteCategory);
 
+// Discover territories — search filters only; writes admin-only.
+router.get('/territories', requireRedeemOps(), ctrl.listTerritories);
+router.post('/territories', requireRedeemOps('settings.manage'), ctrl.createTerritory);
+router.patch('/territories/:id', requireRedeemOps('settings.manage'), ctrl.updateTerritory);
+router.delete('/territories/:id', requireRedeemOps('settings.manage'), ctrl.deleteTerritory);
+
 export default router;

--- a/backend/src/services/redeemOps/discoveryService.js
+++ b/backend/src/services/redeemOps/discoveryService.js
@@ -15,10 +15,11 @@ import { sgtDayWindow } from './taskService.js';
 
 const TERMINAL = ['completed', 'failed', 'aborted', 'timed_out'];
 
-function cfg() {
+export function cfg() {
   return {
     enabled: process.env.DISCOVERY_ENABLED === 'true',
     searchTermsEnabled: process.env.DISCOVERY_SEARCH_TERMS_ENABLED === 'true',
+    territoriesEnabled: process.env.DISCOVERY_TERRITORIES_ENABLED === 'true',
     mapsActor: process.env.APIFY_MAPS_ACTOR_ID || 'compass~crawler-google-places',
     // MUST be the PROFILE scraper — apify~instagram-scraper (its sibling) has no
     // `usernames` input (wants directUrls), so every enrichment run came back
@@ -146,7 +147,9 @@ export function makeDiscoveryService(overrides = {}) {
       // it and crawls that polygon), NOT concatenated into the search string —
       // "Beauty Tampines" as free text let the crawler pad the result budget
       // with global brand matches (Sephora New York/Oshawa/Edmonton, 2026-07-12).
-      const locationQuery = /\bsingapore\b/i.test(run.area) ? run.area : `${run.area}, Singapore`;
+      const isAllSg = /^all\s+singapore$/i.test(String(run.area).trim());
+      const locationQuery = isAllSg ? 'Singapore'
+        : (/\bsingapore\b/i.test(run.area) ? run.area : `${run.area}, Singapore`);
       const input = {
         searchStringsArray: searchTermsUsed,
         locationQuery,

--- a/backend/src/services/redeemOps/territoryService.js
+++ b/backend/src/services/redeemOps/territoryService.js
@@ -1,0 +1,115 @@
+import { DiscoveryTerritory, sequelize } from '../../models/index.js';
+import { AppError } from '../../middleware/errorHandler.js';
+import { makeRedeemOpsAuditService } from './auditService.js';
+
+const ALL_SINGAPORE = /^all\s+singapore$/i;
+
+/** Admin-curated Discover search filters. Territory names are never validated
+ * on discovery runs and are not ownership or assignment records. */
+export function makeTerritoryService(overrides = {}) {
+  const d = {
+    DiscoveryTerritory, sequelize, audit: makeRedeemOpsAuditService(), ...overrides,
+  };
+
+  function cleanName(raw) {
+    const name = String(raw ?? '').trim();
+    if (!name) throw new AppError('Territory name is required', 400);
+    if (name.length > 64) throw new AppError('Territory name must be 64 characters or fewer', 400);
+    if (ALL_SINGAPORE.test(name)) {
+      throw new AppError("'All Singapore' is reserved for the whole-country search option", 400);
+    }
+    return name;
+  }
+
+  function whereNameCi(name) {
+    return d.sequelize.where(d.sequelize.fn('LOWER', d.sequelize.col('name')), name.toLowerCase());
+  }
+
+  async function listTerritories({ includeInactive = false } = {}) {
+    return d.DiscoveryTerritory.findAll({
+      where: includeInactive ? {} : { isActive: true },
+      order: [[d.sequelize.fn('LOWER', d.sequelize.col('name')), 'ASC']],
+    });
+  }
+
+  async function createTerritory(body, user, requestId = null) {
+    const name = cleanName(body?.name);
+    const existing = await d.DiscoveryTerritory.findOne({ where: whereNameCi(name) });
+    if (existing) throw new AppError(`Territory '${existing.name}' already exists`, 409);
+
+    try {
+      const territory = await d.DiscoveryTerritory.create({ name });
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'settings.territory_created',
+        entityType: 'discovery_territory', entityId: territory.id,
+        after: { name, isActive: territory.isActive }, requestId,
+      });
+      return territory;
+    } catch (err) {
+      if (err?.name === 'SequelizeUniqueConstraintError') {
+        throw new AppError(`Territory '${name}' already exists`, 409);
+      }
+      throw err;
+    }
+  }
+
+  async function updateTerritory(id, body, user, requestId = null) {
+    const territory = await d.DiscoveryTerritory.findByPk(id);
+    if (!territory) throw new AppError('Territory not found', 404);
+
+    const updates = {};
+    if (body?.name !== undefined) {
+      const name = cleanName(body.name);
+      if (name !== territory.name) {
+        const clash = await d.DiscoveryTerritory.findOne({ where: whereNameCi(name) });
+        if (clash && clash.id !== territory.id) {
+          throw new AppError(`Territory '${clash.name}' already exists`, 409);
+        }
+        updates.name = name;
+      }
+    }
+    if (body?.isActive !== undefined) updates.isActive = !!body.isActive;
+    if (Object.keys(updates).length === 0) return territory;
+
+    const before = { name: territory.name, isActive: territory.isActive };
+    try {
+      await d.sequelize.transaction(async (transaction) => {
+        await territory.update(updates, { transaction });
+        await d.audit.recordAuditEvent({
+          actorUser: user, action: 'settings.territory_updated',
+          entityType: 'discovery_territory', entityId: territory.id,
+          before,
+          after: { name: territory.name, isActive: territory.isActive },
+          requestId, transaction,
+        });
+      });
+    } catch (err) {
+      if (err?.name === 'SequelizeUniqueConstraintError') {
+        throw new AppError(`Territory '${updates.name}' already exists`, 409);
+      }
+      throw err;
+    }
+    return territory;
+  }
+
+  async function deleteTerritory(id, user, requestId = null) {
+    const territory = await d.DiscoveryTerritory.findByPk(id);
+    if (!territory) throw new AppError('Territory not found', 404);
+
+    await d.sequelize.transaction(async (transaction) => {
+      await territory.destroy({ transaction });
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'settings.territory_deleted',
+        entityType: 'discovery_territory', entityId: territory.id,
+        before: { name: territory.name, isActive: territory.isActive },
+        requestId, transaction,
+      });
+    });
+    return { deleted: true };
+  }
+
+  return { listTerritories, createTerritory, updateTerritory, deleteTerritory };
+}
+
+const _default = makeTerritoryService();
+export default _default;

--- a/backend/test/redeemOpsDiscovery.test.js
+++ b/backend/test/redeemOpsDiscovery.test.js
@@ -351,6 +351,38 @@ describe('geo-anchored search input', () => {
     expect(apify.startRun.mock.calls[0][1].locationQuery).toBe('Bedok, Singapore');
   });
 
+  test("'All Singapore' searches the country while preserving the run snapshot", async () => {
+    const apify = makeApifyStub();
+    const svc = makeDiscoveryService({ apify });
+    const solo = await createTestUser({ role: 'admin' });
+    apify.startRun.mockImplementation(async () => uniqueRunId());
+    const run = await svc.startDiscovery({
+      category: 'Nail Salon', area: 'All Singapore', limit: 5,
+    }, solo.user);
+    expect(apify.startRun.mock.calls[0][1].locationQuery).toBe('Singapore');
+    expect(run.area).toBe('All Singapore');
+  });
+
+  test('a normal territory keeps the existing Singapore suffix behavior', async () => {
+    const apify = makeApifyStub();
+    const svc = makeDiscoveryService({ apify });
+    const solo = await createTestUser({ role: 'admin' });
+    apify.startRun.mockImplementation(async () => uniqueRunId());
+    await svc.startDiscovery({ category: 'Nail Salon', area: 'Woodlands', limit: 5 }, solo.user);
+    expect(apify.startRun.mock.calls[0][1].locationQuery).toBe('Woodlands, Singapore');
+  });
+
+  test('a legacy free-text area keeps the existing Singapore suffix behavior', async () => {
+    const apify = makeApifyStub();
+    const svc = makeDiscoveryService({ apify });
+    const solo = await createTestUser({ role: 'admin' });
+    apify.startRun.mockImplementation(async () => uniqueRunId());
+    await svc.startDiscovery({
+      category: 'Nail Salon', area: 'Upper Thomson Road', limit: 5,
+    }, solo.user);
+    expect(apify.startRun.mock.calls[0][1].locationQuery).toBe('Upper Thomson Road, Singapore');
+  });
+
   test('foreign-labelled items never materialize; unknown country is kept', async () => {
     const svc = makeDiscoveryService({ apify: makeApifyStub() });
     const run = await DiscoveryRun.create({ createdBy: admin.user.id, provider: 'apify_google_maps', status: 'running', requestedLimit: 10 });

--- a/backend/test/redeemOpsTerritories.test.js
+++ b/backend/test/redeemOpsTerritories.test.js
@@ -1,0 +1,125 @@
+/**
+ * Redeem Ops admin-curated Discover territories (migration 063).
+ * Covers runtime flag exposure, capability gating, CRUD, active-list filtering,
+ * case-insensitive uniqueness, reserved All Singapore sentinel, and write audits.
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+delete process.env.DISCOVERY_TERRITORIES_ENABLED;
+
+import request from 'supertest';
+import { getApp, closeDb, createTestUser } from './helpers.js';
+import { DiscoveryTerritory, RedeemOpsAuditEvent } from '../src/models/index.js';
+
+let app;
+let admin;
+let bdm;
+let exec;
+
+beforeAll(async () => {
+  app = await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  bdm = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'bdm' });
+  exec = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
+});
+
+afterEach(() => {
+  delete process.env.DISCOVERY_TERRITORIES_ENABLED;
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+const auth = (token) => ({ Authorization: `Bearer ${token}` });
+let nameSeq = 0;
+const uniq = (base) => `${base} ${Date.now()}-${++nameSeq}`;
+const createTerritory = (token, name) => request(app)
+  .post('/api/redeem-ops/territories')
+  .set(auth(token))
+  .send({ name });
+
+describe('read access and runtime flag', () => {
+  test('any Redeem Ops principal can list active territories; flag defaults off', async () => {
+    const res = await request(app).get('/api/redeem-ops/territories').set(auth(exec.token));
+    expect(res.status).toBe(200);
+    expect(res.body.data.enabled).toBe(false);
+    expect(Array.isArray(res.body.data.territories)).toBe(true);
+    expect(res.body.data.territories.some((territory) => territory.name === 'All Singapore')).toBe(false);
+  });
+
+  test('enabled is read at request time', async () => {
+    process.env.DISCOVERY_TERRITORIES_ENABLED = 'true';
+    const res = await request(app).get('/api/redeem-ops/territories').set(auth(exec.token));
+    expect(res.status).toBe(200);
+    expect(res.body.data.enabled).toBe(true);
+  });
+});
+
+describe('CRUD and capability gate', () => {
+  test('bdm cannot write; admin can create, list, rename/retire, restore, and delete', async () => {
+    const initialName = uniq('Upper Thomson');
+    expect((await createTerritory(bdm.token, initialName)).status).toBe(403);
+
+    const created = await createTerritory(admin.token, initialName);
+    expect(created.status).toBe(201);
+    const id = created.body.data.territory.id;
+    expect(created.body.data.territory.name).toBe(initialName);
+
+    const activeList = await request(app).get('/api/redeem-ops/territories').set(auth(exec.token));
+    expect(activeList.body.data.territories.some((territory) => territory.id === id)).toBe(true);
+
+    const renamed = uniq('Thomson');
+    const update = await request(app)
+      .patch(`/api/redeem-ops/territories/${id}`)
+      .set(auth(admin.token))
+      .send({ name: renamed, isActive: false });
+    expect(update.status).toBe(200);
+    expect(update.body.data.territory).toMatchObject({ id, name: renamed, isActive: false });
+
+    const afterRetire = await request(app).get('/api/redeem-ops/territories').set(auth(exec.token));
+    expect(afterRetire.body.data.territories.some((territory) => territory.id === id)).toBe(false);
+    const allRows = await request(app)
+      .get('/api/redeem-ops/territories?includeInactive=true')
+      .set(auth(exec.token));
+    expect(allRows.body.data.territories).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id, name: renamed, isActive: false }),
+    ]));
+
+    const restore = await request(app)
+      .patch(`/api/redeem-ops/territories/${id}`)
+      .set(auth(admin.token))
+      .send({ isActive: true });
+    expect(restore.status).toBe(200);
+    expect(restore.body.data.territory.isActive).toBe(true);
+
+    const deleted = await request(app)
+      .delete(`/api/redeem-ops/territories/${id}`)
+      .set(auth(admin.token));
+    expect(deleted.status).toBe(200);
+    expect(deleted.body.data.deleted).toBe(true);
+    expect(await DiscoveryTerritory.findByPk(id)).toBeNull();
+
+    const audits = await RedeemOpsAuditEvent.findAll({
+      where: { entityType: 'discovery_territory', entityId: id },
+    });
+    expect(audits.map((audit) => audit.action)).toEqual(expect.arrayContaining([
+      'settings.territory_created',
+      'settings.territory_updated',
+      'settings.territory_deleted',
+    ]));
+  });
+});
+
+describe('name controls', () => {
+  test('case-insensitive duplicate returns 409', async () => {
+    const name = uniq('Harbourfront');
+    expect((await createTerritory(admin.token, name)).status).toBe(201);
+    expect((await createTerritory(admin.token, name.toUpperCase())).status).toBe(409);
+  });
+
+  test("'All Singapore' is reserved case-insensitively", async () => {
+    expect((await createTerritory(admin.token, 'All Singapore')).status).toBe(400);
+    expect((await createTerritory(admin.token, '  ALL SINGAPORE  ')).status).toBe(400);
+    expect((await createTerritory(admin.token, 'All   Singapore')).status).toBe(400);
+  });
+});

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -61,6 +61,27 @@ export const redeemOpsApi = {
     return res.data;
   },
 
+  // ── Discover territories (admin-curated search filters) ───────────────
+  async listTerritories(params = {}) {
+    const res = await apiClient.get('/redeem-ops/territories', params);
+    return {
+      enabled: res.data?.enabled === true,
+      territories: res.data?.territories || [],
+    };
+  },
+  async createTerritory(body) {
+    const res = await apiClient.post('/redeem-ops/territories', body);
+    return res.data?.territory;
+  },
+  async updateTerritory(id, body) {
+    const res = await apiClient.patch(`/redeem-ops/territories/${id}`, body);
+    return res.data?.territory;
+  },
+  async deleteTerritory(id) {
+    const res = await apiClient.delete(`/redeem-ops/territories/${id}`);
+    return res.data;
+  },
+
   // ── Discover tool (Apify prospecting) ──────────────────────────────────
   async startDiscovery(body) {
     const res = await apiClient.post('/redeem-ops/discovery/runs', body);

--- a/src/pages/redeemops/DiscoverPage.jsx
+++ b/src/pages/redeemops/DiscoverPage.jsx
@@ -22,6 +22,7 @@ import CategorySelect from '@/components/redeemops/CategorySelect';
 
 const TERMINAL = ['completed', 'failed', 'aborted', 'timed_out'];
 const RUNS_KEY = ['redeem-ops', 'discovery', 'runs'];
+const ALL_SINGAPORE = 'All Singapore';
 
 const DEDUPE = {
   new: { tone: 'open', label: 'New' },
@@ -82,6 +83,18 @@ export default function DiscoverPage() {
     queryFn: () => redeemOpsApi.listCategories(),
     staleTime: 60_000,
   });
+  const territoriesQuery = useQuery({
+    queryKey: ['redeem-ops', 'territories'],
+    queryFn: () => redeemOpsApi.listTerritories(),
+    staleTime: 60_000,
+  });
+  const territoriesEnabled = territoriesQuery.isSuccess && territoriesQuery.data.enabled;
+  const territoryNames = (territoriesQuery.data?.territories || []).map((territory) => territory.name);
+  const customArea = form.area
+    && form.area !== ALL_SINGAPORE
+    && !territoryNames.includes(form.area)
+    ? form.area
+    : null;
 
   const runQuery = useQuery({
     queryKey: ['redeem-ops', 'discovery', 'run', runId],
@@ -247,9 +260,24 @@ export default function DiscoverPage() {
               </div>
               <div className="space-y-1.5">
                 <Label htmlFor="disc-area">Area</Label>
-                <Input id="disc-area" value={form.area} placeholder="Neighbourhood or district…"
-                  onChange={(e) => setForm((f) => ({ ...f, area: e.target.value }))}
-                  onKeyDown={(e) => { if (e.key === 'Enter' && canSearch) runSearch(form.category, form.area, form.limit); }} />
+                {territoriesEnabled ? (
+                  <Select value={form.area} onValueChange={(area) => setForm((f) => ({ ...f, area }))}>
+                    <SelectTrigger id="disc-area" className="w-full">
+                      <SelectValue placeholder="Select a territory…" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={ALL_SINGAPORE}>{ALL_SINGAPORE}</SelectItem>
+                      {territoryNames.map((name) => (
+                        <SelectItem key={name} value={name}>{name}</SelectItem>
+                      ))}
+                      {customArea && <SelectItem value={customArea}>{customArea}</SelectItem>}
+                    </SelectContent>
+                  </Select>
+                ) : (
+                  <Input id="disc-area" value={form.area} placeholder="Neighbourhood or district…"
+                    onChange={(e) => setForm((f) => ({ ...f, area: e.target.value }))}
+                    onKeyDown={(e) => { if (e.key === 'Enter' && canSearch) runSearch(form.category, form.area, form.limit); }} />
+                )}
               </div>
               <div className="space-y-1.5">
                 <Label>Results</Label>
@@ -263,12 +291,16 @@ export default function DiscoverPage() {
               </Button>
             </div>
             <div className="flex flex-wrap items-center gap-2 mt-3">
-              <span className="text-xs font-semibold" style={{ color: 'var(--ro-text-3)' }}>Popular areas</span>
-              {POPULAR_AREAS.map((a) => (
-                <button key={a} type="button" onClick={() => setForm((f) => ({ ...f, area: a }))}
-                  className="h-7 px-3 rounded-full text-[12.5px] font-semibold"
-                  style={{ background: 'var(--ro-subtle)', border: '1px solid var(--ro-border)', color: 'var(--ro-text-2)' }}>{a}</button>
-              ))}
+              {!territoriesEnabled && (
+                <>
+                  <span className="text-xs font-semibold" style={{ color: 'var(--ro-text-3)' }}>Popular areas</span>
+                  {POPULAR_AREAS.map((a) => (
+                    <button key={a} type="button" onClick={() => setForm((f) => ({ ...f, area: a }))}
+                      className="h-7 px-3 rounded-full text-[12.5px] font-semibold"
+                      style={{ background: 'var(--ro-subtle)', border: '1px solid var(--ro-border)', color: 'var(--ro-text-2)' }}>{a}</button>
+                  ))}
+                </>
+              )}
               {quota?.costPerResultUsd > 0 && (
                 <span className="ml-auto text-[12px]" style={{ color: 'var(--ro-text-3)' }}>
                   ≈ ${(Number(form.limit) * quota.costPerResultUsd).toFixed(2)} per search

--- a/src/pages/redeemops/SettingsPage.jsx
+++ b/src/pages/redeemops/SettingsPage.jsx
@@ -21,6 +21,7 @@ import Trash2 from 'lucide-react/icons/trash-2';
 import { RoPageHeader, RoTag } from '@/components/redeemops/ui';
 
 const CATEGORIES_KEY = ['redeem-ops', 'categories'];
+const TERRITORIES_KEY = ['redeem-ops', 'territories'];
 const parseSearchTerms = (value) => value.split(',').map((term) => term.trim()).filter(Boolean);
 
 /**
@@ -38,6 +39,11 @@ export default function SettingsPage() {
     queryFn: () => redeemOpsApi.listCategories({ includeInactive: 'true' }),
   });
   const categories = listQuery.data || [];
+  const territoriesQuery = useQuery({
+    queryKey: [...TERRITORIES_KEY, 'all'],
+    queryFn: () => redeemOpsApi.listTerritories({ includeInactive: 'true' }),
+  });
+  const territories = territoriesQuery.data?.territories || [];
 
   const invalidate = () => {
     // Both the settings list (…, 'all') and the picker list share the prefix.
@@ -131,11 +137,61 @@ export default function SettingsPage() {
 
   const mergeTargets = categories.filter((c) => c.isActive && c.id !== mergeSource?.id);
 
+  // ── Discover territories ──────────────────────────────────────────────
+  const invalidateTerritories = () => {
+    queryClient.invalidateQueries({ queryKey: TERRITORIES_KEY });
+  };
+  const [newTerritoryName, setNewTerritoryName] = useState('');
+  const createTerritoryMutation = useMutation({
+    mutationFn: () => redeemOpsApi.createTerritory({ name: newTerritoryName.trim() }),
+    onSuccess: (territory) => {
+      toast.success(`Added '${territory?.name || newTerritoryName.trim()}'`);
+      setNewTerritoryName('');
+      invalidateTerritories();
+    },
+    onError: onError('Could not add territory'),
+  });
+
+  const [territoryRenameTarget, setTerritoryRenameTarget] = useState(null);
+  const [territoryRenameTo, setTerritoryRenameTo] = useState('');
+  const renameTerritoryMutation = useMutation({
+    mutationFn: () => redeemOpsApi.updateTerritory(
+      territoryRenameTarget.id,
+      { name: territoryRenameTo.trim() },
+    ),
+    onSuccess: () => {
+      toast.success('Territory renamed');
+      setTerritoryRenameTarget(null);
+      invalidateTerritories();
+    },
+    onError: onError('Could not rename territory'),
+  });
+
+  const territoryActiveMutation = useMutation({
+    mutationFn: ({ id, isActive }) => redeemOpsApi.updateTerritory(id, { isActive }),
+    onSuccess: (_territory, vars) => {
+      toast.success(vars.isActive
+        ? 'Territory restored to the Discover picker'
+        : 'Territory retired from the Discover picker');
+      invalidateTerritories();
+    },
+    onError: onError('Could not update territory'),
+  });
+
+  const deleteTerritoryMutation = useMutation({
+    mutationFn: (id) => redeemOpsApi.deleteTerritory(id),
+    onSuccess: () => {
+      toast.success('Territory deleted');
+      invalidateTerritories();
+    },
+    onError: onError('Could not delete territory'),
+  });
+
   return (
     <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-6">
       <RoPageHeader
         title="Settings"
-        sub="Categories and cadences are managed here and picked everywhere else — partner forms, pools, imports, and the Start cadence menu."
+        sub="Categories, Discover territories, and cadences are managed here and picked everywhere else."
       />
 
       <Card>
@@ -218,6 +274,100 @@ export default function SettingsPage() {
                     variant="ghost" size="sm" aria-label={`Delete ${cat.name}`}
                     disabled={deleteMutation.isPending}
                     onClick={() => deleteMutation.mutate(cat.id)}
+                  >
+                    <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
+                  </Button>
+                </span>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            Territories
+            {territoriesQuery.isSuccess && (
+              <RoTag tone={territoriesQuery.data.enabled ? 'active' : 'inactive'} size="sm">
+                picker {territoriesQuery.data.enabled ? 'on' : 'off'}
+              </RoTag>
+            )}
+          </CardTitle>
+          <CardDescription>
+            Search filters offered in Discover. They never assign or own partners. “All Singapore”
+            is built in separately; retire a territory to hide it from new searches.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form
+            className="flex gap-2 mb-4"
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (newTerritoryName.trim()) createTerritoryMutation.mutate();
+            }}
+          >
+            <Input
+              value={newTerritoryName}
+              onChange={(e) => setNewTerritoryName(e.target.value)}
+              placeholder="New territory, e.g. Upper Thomson"
+            />
+            <Button
+              type="submit"
+              disabled={!newTerritoryName.trim() || createTerritoryMutation.isPending}
+            >
+              <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" /> Add
+            </Button>
+          </form>
+
+          {territoriesQuery.isLoading && (
+            <p className="text-sm m-0" style={{ color: 'var(--ro-text-2)' }}>Loading…</p>
+          )}
+          {territoriesQuery.isError && (
+            <p className="text-sm m-0" style={{ color: 'var(--ro-text-2)' }}>
+              Could not load territories.
+            </p>
+          )}
+          {territoriesQuery.isSuccess && territories.length === 0 && (
+            <p className="text-sm m-0" style={{ color: 'var(--ro-text-2)' }}>
+              No territories yet — add the areas your team searches.
+            </p>
+          )}
+
+          <ul className="m-0 p-0 list-none divide-y divide-border">
+            {territories.map((territory) => (
+              <li key={territory.id} className="flex items-center gap-2 py-2.5">
+                <span className="text-sm font-medium min-w-0 truncate">{territory.name}</span>
+                {!territory.isActive && <RoTag tone="inactive">retired</RoTag>}
+                <span className="flex items-center gap-1 ml-auto shrink-0">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    aria-label={`Rename ${territory.name}`}
+                    onClick={() => {
+                      setTerritoryRenameTarget(territory);
+                      setTerritoryRenameTo(territory.name);
+                    }}
+                  >
+                    <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={territoryActiveMutation.isPending}
+                    onClick={() => territoryActiveMutation.mutate({
+                      id: territory.id,
+                      isActive: !territory.isActive,
+                    })}
+                  >
+                    {territory.isActive ? 'Retire' : 'Restore'}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    aria-label={`Delete ${territory.name}`}
+                    disabled={deleteTerritoryMutation.isPending}
+                    onClick={() => deleteTerritoryMutation.mutate(territory.id)}
                   >
                     <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
                   </Button>
@@ -312,6 +462,40 @@ export default function SettingsPage() {
               onClick={() => mergeMutation.mutate()}
             >
               {mergeMutation.isPending ? 'Merging…' : 'Merge'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={!!territoryRenameTarget}
+        onOpenChange={(open) => { if (!open) setTerritoryRenameTarget(null); }}
+      >
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Rename territory</DialogTitle>
+            <DialogDescription>
+              This changes the picker label only. Previous Discover runs keep their saved area.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-1.5 py-2">
+            <Label htmlFor="territory-rename-to">New name</Label>
+            <Input
+              id="territory-rename-to"
+              value={territoryRenameTo}
+              onChange={(e) => setTerritoryRenameTo(e.target.value)}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              disabled={
+                !territoryRenameTo.trim()
+                || territoryRenameTo.trim() === territoryRenameTarget?.name
+                || renameTerritoryMutation.isPending
+              }
+              onClick={() => renameTerritoryMutation.mutate()}
+            >
+              {renameTerritoryMutation.isPending ? 'Renaming…' : 'Rename'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/pages/redeemops/__tests__/DiscoverPage.test.jsx
+++ b/src/pages/redeemops/__tests__/DiscoverPage.test.jsx
@@ -14,6 +14,7 @@ import { MemoryRouter } from 'react-router-dom';
 const api = vi.hoisted(() => ({
   listDiscoveryRuns: vi.fn(),
   listCategories: vi.fn(),
+  listTerritories: vi.fn(),
   getDiscoveryRun: vi.fn(),
   startDiscovery: vi.fn(),
   enrichDiscoveryCandidates: vi.fn(),
@@ -70,6 +71,7 @@ async function openResults() {
 beforeEach(() => {
   vi.clearAllMocks();
   api.listCategories.mockResolvedValue([{ name: 'Nail Salon' }]);
+  api.listTerritories.mockResolvedValue({ enabled: false, territories: [] });
   api.listDiscoveryRuns.mockResolvedValue({ runs: [], quota });
 });
 
@@ -80,6 +82,30 @@ describe('DiscoverPage', () => {
     await userEvent.click(card);
     expect(api.startDiscovery).not.toHaveBeenCalled();
     expect(screen.getByPlaceholderText('Neighbourhood or district…')).toHaveValue('Tampines');
+  });
+
+  it('uses the territory picker with All Singapore only when the runtime flag is enabled', async () => {
+    api.listTerritories.mockResolvedValue({
+      enabled: true,
+      territories: [{ name: 'Bedok' }, { name: 'Tampines' }],
+    });
+    renderPage();
+    const areaPicker = await screen.findByRole('combobox', { name: 'Area' });
+    expect(screen.queryByPlaceholderText('Neighbourhood or district…')).not.toBeInTheDocument();
+    expect(screen.queryByText('Popular areas')).not.toBeInTheDocument();
+    areaPicker.hasPointerCapture = vi.fn(() => false);
+    areaPicker.releasePointerCapture = vi.fn();
+    HTMLElement.prototype.scrollIntoView = vi.fn();
+    await userEvent.click(areaPicker);
+    expect(await screen.findByRole('option', { name: 'All Singapore' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Bedok' })).toBeInTheDocument();
+  });
+
+  it('keeps the existing free-text Area controls when the territories request fails', async () => {
+    api.listTerritories.mockRejectedValue(new Error('territories unavailable'));
+    renderPage();
+    expect(await screen.findByPlaceholderText('Neighbourhood or district…')).toBeInTheDocument();
+    expect(screen.getByText('Popular areas')).toBeInTheDocument();
   });
 
   it('shows Enriching… while enrichment is pending instead of another paid action', async () => {


### PR DESCRIPTION
## Phase 2b — controlled Territories + All-Singapore (replaces free-text Area)

Discover's Area was free-text (typo-prone, geocode-roulette). This adds an admin-curated Singapore **territory** picker plus a first-class **All Singapore** option. Territories are a **search filter only** — no ownership/assignment.

### Changes
- **Migration 063**: `discovery_territories` (id/name/isActive) + LOWER(name) unique index; seeds **31** SG towns/areas. "All Singapore" is a **sentinel, not a row**. Guarded/idempotent (`ON CONFLICT DO NOTHING`).
- **`territoryService`** (mirrors categories, simpler — **no cascade, no merge**): list/create/update/delete + audit; rejects "All Singapore" as a name; hard delete is safe (`discovery_runs.area` is a string snapshot, not an FK).
- **`startDiscovery`**: maps the `All Singapore` sentinel → `locationQuery:"Singapore"` while keeping `run.area` verbatim; every other Apify input unchanged.
- **Routes** (`redeemOpsAdmin`): `GET /territories` open (feeds picker + Settings, returns `{enabled, territories}`), writes under `settings.manage`.
- **UI**: DiscoverPage swaps the Area input for a territory `Select` **only when enabled**; SettingsPage gets a Territories card.

### Safety / rollout
Gated by **`DISCOVERY_TERRITORIES_ENABLED` (default `false`)**. Off (or if the territory fetch fails) ⇒ the existing free-text Area + Popular Areas chips render unchanged, and the Apify input for non-sentinel areas is unchanged. **Soft control**: the backend still accepts any `area` string, so old links/API keep working. Ships dark.

### Verification (local)
- **DB Jest: 49/49** (`redeemOpsTerritories` + `redeemOpsDiscovery`) on Postgres 5433.
- DiscoverPage Vitest **7/7**; frontend build ✓; ESLint on changed files ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)