### PR TITLE
feat(redeem-ops): atomic SGT-day results/profile spend counter (Phase 3)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -288,6 +288,7 @@ HITPAY_REDIRECT_URL=                         # app deep link back after pay (opt
 DISCOVERY_ENABLED=false                       # master switch (also gates the reconcile sweep)
 DISCOVERY_SEARCH_TERMS_ENABLED=false          # expand category aliases in Maps searches; off preserves legacy one-name input
 DISCOVERY_TERRITORIES_ENABLED=false           # admin-curated SG area picker; off preserves the free-text Area UI
+DISCOVERY_RESULT_QUOTA_ENABLED=false          # atomic result/profile counters; off preserves run-count quotas
 APIFY_TOKEN=                                  # SECRET — Apify API token
 APIFY_MAPS_ACTOR_ID=compass~crawler-google-places   # Google Maps scraper actor
 APIFY_INSTAGRAM_ACTOR_ID=apify~instagram-profile-scraper    # IG enrichment actor (PROFILE scraper — takes `usernames`; plain instagram-scraper does NOT)
@@ -298,6 +299,10 @@ DISCOVERY_MAX_RUNS_PER_DAY=25                 # global daily cap
 DISCOVERY_MAX_RUNS_PER_USER_DAY=5             # per-user cap (cost guardrail — access is all-principals)
 DISCOVERY_ENRICH_MAX_PER_DAY=500             # team cap for IG enrichment, in PROFILES/day (each handle scraped = 1)
 DISCOVERY_ENRICH_MAX_PER_USER_DAY=200        # per-user profile cap (same guardrail philosophy as searches)
+DISCOVERY_RESULTS_PER_USER_DAY=1500          # atomic per-user SGT-day result reservation cap
+DISCOVERY_RESULTS_PER_TEAM_DAY=6000          # advisory team SGT-day result cap
+DISCOVERY_PROFILES_PER_USER_DAY=200          # atomic per-user SGT-day IG profile cap
+DISCOVERY_PROFILES_PER_TEAM_DAY=500          # advisory team SGT-day IG profile cap
 DISCOVERY_COST_PER_RESULT_USD=0.007          # rough pre-run estimate; actual read from the run
 DISCOVERY_RECONCILE_STUCK_MINUTES=10         # age before a non-terminal run is re-fetched from Apify
 DISCOVERY_CANDIDATE_TTL_DAYS=90              # retention: purge scraped candidates after N days (0 = keep forever)

--- a/backend/src/database/migrations/064-discovery-daily-usage.js
+++ b/backend/src/database/migrations/064-discovery-daily-usage.js
@@ -1,0 +1,23 @@
+/**
+ * 064 — Atomic per-user Singapore-day Discover usage counters.
+ *
+ * The feature remains dark behind DISCOVERY_RESULT_QUOTA_ENABLED. Guarded and
+ * idempotent; NODE_ENV=test sync() creates this table before migrations run.
+ */
+export async function up(queryInterface, Sequelize) {
+  const tables = await queryInterface.showAllTables();
+  if (tables.includes('discovery_daily_usage')) return;
+
+  await queryInterface.createTable('discovery_daily_usage', {
+    userId: { type: Sequelize.UUID, allowNull: false, primaryKey: true },
+    sgDate: { type: Sequelize.DATEONLY, allowNull: false, primaryKey: true },
+    resultsUsed: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 0 },
+    profilesUsed: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 0 },
+    createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+  });
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query('DROP TABLE IF EXISTS discovery_daily_usage');
+}

--- a/backend/src/models/DiscoveryDailyUsage.js
+++ b/backend/src/models/DiscoveryDailyUsage.js
@@ -1,0 +1,14 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/** Atomic per-user counters keyed to a Singapore calendar day (migration 064). */
+const DiscoveryDailyUsage = sequelize.define('DiscoveryDailyUsage', {
+  userId: { type: DataTypes.UUID, allowNull: false, primaryKey: true },
+  sgDate: { type: DataTypes.DATEONLY, allowNull: false, primaryKey: true },
+  resultsUsed: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  profilesUsed: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+}, {
+  tableName: 'discovery_daily_usage',
+});
+
+export default DiscoveryDailyUsage;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -331,7 +331,8 @@ export const {
   RewardTermsVersion, DrawTermsVersion, Draw, DrawEntry, DrawAttempt,
   DrawBoostReview, RewardOfferLocation, RewardInventoryEvent,
   PartnerOnboardingItem, Activation, RewardEntitlement, Redemption,
-  RedemptionEvent, RedeemOpsCategory, DiscoveryTerritory, DiscoveryRun, DiscoveryCandidate,
+  RedemptionEvent, RedeemOpsCategory, DiscoveryTerritory, DiscoveryDailyUsage,
+  DiscoveryRun, DiscoveryCandidate,
   DiscoveryPlaceMemory, OutreachCadence, OutreachCadenceStep,
   OutreachCadenceTransition, OutreachCadenceEnrollment, OutreachSuppression,
   AiSettings

--- a/backend/src/services/redeemOps/discoveryService.js
+++ b/backend/src/services/redeemOps/discoveryService.js
@@ -6,12 +6,13 @@ import { logger } from '../../utils/logger.js';
 import { makeRedeemOpsAuditService } from './auditService.js';
 import { makePartnerService } from './partnerService.js';
 import { makeCategoryService } from './categoryService.js';
+import { makeDiscoveryUsageService } from './discoveryUsageService.js';
 import { makeDedupeService } from './dedupeService.js';
 import { makeApifyClient } from './discovery/apifyClient.js';
 import { normalizeMapsItem, normalizeInstagramItem, isSingaporeMapsItem } from './discovery/normalizers.js';
 import { normalizeBusinessName, normalizeDomain, normalizeHandle } from './normalizers.js';
 import { normalizePhone } from '../prospectHelpers.js';
-import { sgtDayWindow } from './taskService.js';
+import { sgDateKey, sgtDayWindow } from './taskService.js';
 
 const TERMINAL = ['completed', 'failed', 'aborted', 'timed_out'];
 
@@ -20,6 +21,7 @@ export function cfg() {
     enabled: process.env.DISCOVERY_ENABLED === 'true',
     searchTermsEnabled: process.env.DISCOVERY_SEARCH_TERMS_ENABLED === 'true',
     territoriesEnabled: process.env.DISCOVERY_TERRITORIES_ENABLED === 'true',
+    resultQuotaEnabled: process.env.DISCOVERY_RESULT_QUOTA_ENABLED === 'true',
     mapsActor: process.env.APIFY_MAPS_ACTOR_ID || 'compass~crawler-google-places',
     // MUST be the PROFILE scraper — apify~instagram-scraper (its sibling) has no
     // `usernames` input (wants directUrls), so every enrichment run came back
@@ -36,6 +38,10 @@ export function cfg() {
     // not runs — a run-count cap left per-call size unbounded.
     enrichMaxPerDay: Number(process.env.DISCOVERY_ENRICH_MAX_PER_DAY || 500),
     enrichMaxPerUserDay: Number(process.env.DISCOVERY_ENRICH_MAX_PER_USER_DAY || 200),
+    resultsPerUserDay: Number(process.env.DISCOVERY_RESULTS_PER_USER_DAY || 1500),
+    resultsPerTeamDay: Number(process.env.DISCOVERY_RESULTS_PER_TEAM_DAY || 6000),
+    profilesPerUserDay: Number(process.env.DISCOVERY_PROFILES_PER_USER_DAY || 200),
+    profilesPerTeamDay: Number(process.env.DISCOVERY_PROFILES_PER_TEAM_DAY || 500),
     costPerResultUsd: Number(process.env.DISCOVERY_COST_PER_RESULT_USD || 0.007),
     reconcileStuckMinutes: Number(process.env.DISCOVERY_RECONCILE_STUCK_MINUTES || 10),
     candidateTtlDays: Number(process.env.DISCOVERY_CANDIDATE_TTL_DAYS ?? 90),
@@ -54,6 +60,7 @@ export function makeDiscoveryService(overrides = {}) {
     apify: makeApifyClient(),
     partners: makePartnerService(),
     categories: makeCategoryService(),
+    usage: makeDiscoveryUsageService(),
     dedupe: makeDedupeService(),
     audit: makeRedeemOpsAuditService(),
     ...overrides,
@@ -93,6 +100,20 @@ export function makeDiscoveryService(overrides = {}) {
   /** Per-user search budget for the day (drives the UI's usage chip). */
   async function getQuota(user) {
     const c = cfg();
+    if (c.resultQuotaEnabled) {
+      const usage = await d.usage.getUsage(user.id, sgDateKey());
+      return {
+        mode: 'results',
+        resultsUsed: usage.resultsUsed,
+        resultsLimit: c.resultsPerUserDay,
+        resultsRemaining: Math.max(0, c.resultsPerUserDay - usage.resultsUsed),
+        profilesUsed: usage.profilesUsed,
+        profilesLimit: c.profilesPerUserDay,
+        profilesRemaining: Math.max(0, c.profilesPerUserDay - usage.profilesUsed),
+        estimatedSpendUsd: Number((usage.resultsUsed * c.costPerResultUsd).toFixed(4)),
+        costPerResultUsd: c.costPerResultUsd,
+      };
+    }
     const { start: since } = sgtDayWindow();
     const used = await d.DiscoveryRun.count({
       where: {
@@ -105,6 +126,43 @@ export function makeDiscoveryService(overrides = {}) {
       remaining: Math.max(0, c.maxRunsPerUserDay - used),
       costPerResultUsd: c.costPerResultUsd, // lets the UI show "≈ $x.xx" pre-search
     };
+  }
+
+  function dailyReservation(run) {
+    return run.rawPayload?.dailyUsageReservation || null;
+  }
+
+  async function refundReservation(run, amount, transaction = null) {
+    const reservation = dailyReservation(run);
+    const refundAmount = Math.max(0, Math.trunc(Number(amount) || 0));
+    if (!reservation || refundAmount === 0) return;
+    const args = {
+      userId: run.createdBy,
+      sgDate: reservation.sgDate,
+      amount: refundAmount,
+      transaction,
+    };
+    if (reservation.kind === 'results') await d.usage.refundResults(args);
+    if (reservation.kind === 'profiles') await d.usage.refundProfiles(args);
+  }
+
+  /** Terminal update + result true-up under one run-row lock, so duplicate
+   * webhook/reconcile workers can never refund the same reservation twice. */
+  async function completeRun(run, values) {
+    const reservation = dailyReservation(run);
+    if (reservation?.kind !== 'results') {
+      await run.update(values);
+      return;
+    }
+    await d.sequelize.transaction(async (transaction) => {
+      const locked = await d.DiscoveryRun.findByPk(run.id, {
+        transaction, lock: transaction.LOCK.UPDATE,
+      });
+      if (!locked || TERMINAL.includes(locked.status)) return;
+      const unused = Math.max(0, Number(reservation.amount) - Number(values.resultCount || 0));
+      await refundReservation(locked, unused, transaction);
+      await locked.update(values, { transaction });
+    });
   }
 
   function webhookUrl() {
@@ -125,8 +183,8 @@ export function makeDiscoveryService(overrides = {}) {
     const { name: canonicalCategory, searchTerms } = await d.categories.resolveCategoryForSearch(
       String(category).trim()
     );
-    await assertQuota(user);
     const c = cfg();
+    if (!c.resultQuotaEnabled) await assertQuota(user);
     const requestedLimit = Math.min(Math.max(Number(limit) || 60, 1), c.maxResultsPerRun);
     const searchTermsUsed = c.searchTermsEnabled ? searchTerms : [canonicalCategory];
     // The Maps actor applies this cap to EACH search string, so divide the
@@ -135,13 +193,32 @@ export function makeDiscoveryService(overrides = {}) {
       ? Math.max(1, Math.floor(requestedLimit / searchTermsUsed.length))
       : requestedLimit;
 
-    const run = await d.DiscoveryRun.create({
+    const runValues = {
       createdBy: user.id, provider: 'apify_google_maps',
       category: canonicalCategory, area: String(area).trim(),
       requestedLimit, status: 'pending',
       estimatedCostUsd: Number((requestedLimit * c.costPerResultUsd).toFixed(4)),
-    });
+    };
+    let run;
+    if (c.resultQuotaEnabled) {
+      const sgDate = sgDateKey();
+      const reservation = { kind: 'results', sgDate, amount: requestedLimit };
+      run = await d.sequelize.transaction(async (transaction) => {
+        await d.usage.reserveResults({
+          userId: user.id, sgDate, amount: requestedLimit,
+          userCap: c.resultsPerUserDay, teamCap: c.resultsPerTeamDay,
+          transaction,
+        });
+        return d.DiscoveryRun.create(
+          { ...runValues, rawPayload: { dailyUsageReservation: reservation } },
+          { transaction },
+        );
+      });
+    } else {
+      run = await d.DiscoveryRun.create(runValues);
+    }
 
+    let providerStarted = false;
     try {
       // Geo-anchored search: the area goes in locationQuery (the actor geocodes
       // it and crawls that polygon), NOT concatenated into the search string —
@@ -158,9 +235,25 @@ export function makeDiscoveryService(overrides = {}) {
         scrapeContacts: true, // enables the instagrams/social arrays
       };
       const started = await d.apify.startRun(c.mapsActor, input, { webhookUrl: webhookUrl() });
+      providerStarted = true;
       await run.update({ providerRunId: started.runId, providerDatasetId: started.datasetId || null, status: 'running', startedAt: new Date() });
     } catch (err) {
-      await run.update({ status: 'failed', error: String(err.message).slice(0, 500) });
+      if (dailyReservation(run) && !providerStarted) {
+        await d.sequelize.transaction(async (transaction) => {
+          const locked = await d.DiscoveryRun.findByPk(run.id, {
+            transaction, lock: transaction.LOCK.UPDATE,
+          });
+          if (!locked) return;
+          const reservation = dailyReservation(locked);
+          await refundReservation(locked, reservation?.amount, transaction);
+          await locked.update(
+            { status: 'failed', error: String(err.message).slice(0, 500) },
+            { transaction },
+          );
+        });
+      } else {
+        await run.update({ status: 'failed', error: String(err.message).slice(0, 500) });
+      }
       throw new AppError(`Could not start search: ${err.message}`, 502);
     }
 
@@ -212,7 +305,7 @@ export function makeDiscoveryService(overrides = {}) {
     } else {
       await materializeCandidates(run, items);
     }
-    await run.update({
+    await completeRun(run, {
       status: 'completed', completedAt: new Date(), providerDatasetId: info.datasetId,
       actualCostUsd: info.usageTotalUsd, resultCount: items.length,
     });
@@ -456,60 +549,116 @@ export function makeDiscoveryService(overrides = {}) {
       throw new AppError('Nothing to enrich — no un-enriched Instagram handles in the selection', 400);
     }
 
-    // Quotas count PROFILES (requestedLimit = handle count per run), excluding
-    // runs that never reached Apify. SUM(int) can surface as a bigint string.
-    const { start: since } = sgtDayWindow();
-    const igBase = { provider: 'apify_instagram', createdAt: { [Op.gte]: since }, ...COUNTS_TOWARD_QUOTA };
-    const [globalUsedRaw, userUsedRaw] = await Promise.all([
-      d.DiscoveryRun.sum('requestedLimit', { where: igBase }),
-      d.DiscoveryRun.sum('requestedLimit', { where: { ...igBase, createdBy: user.id } }),
-    ]);
-    const globalUsed = Number(globalUsedRaw) || 0;
-    const userUsed = Number(userUsedRaw) || 0;
-    if (userUsed + handles.length > c.enrichMaxPerUserDay) {
-      const left = Math.max(0, c.enrichMaxPerUserDay - userUsed);
-      throw new AppError(`Daily enrichment limit reached — ${left} profile${left === 1 ? '' : 's'} left today for you`, 429);
-    }
-    if (globalUsed + handles.length > c.enrichMaxPerDay) {
-      const left = Math.max(0, c.enrichMaxPerDay - globalUsed);
-      throw new AppError(`Team enrichment limit reached — ${left} profile${left === 1 ? '' : 's'} left today`, 429);
+    if (!c.resultQuotaEnabled) {
+      // Quotas count PROFILES (requestedLimit = handle count per run), excluding
+      // runs that never reached Apify. SUM(int) can surface as a bigint string.
+      const { start: since } = sgtDayWindow();
+      const igBase = { provider: 'apify_instagram', createdAt: { [Op.gte]: since }, ...COUNTS_TOWARD_QUOTA };
+      const [globalUsedRaw, userUsedRaw] = await Promise.all([
+        d.DiscoveryRun.sum('requestedLimit', { where: igBase }),
+        d.DiscoveryRun.sum('requestedLimit', { where: { ...igBase, createdBy: user.id } }),
+      ]);
+      const globalUsed = Number(globalUsedRaw) || 0;
+      const userUsed = Number(userUsedRaw) || 0;
+      if (userUsed + handles.length > c.enrichMaxPerUserDay) {
+        const left = Math.max(0, c.enrichMaxPerUserDay - userUsed);
+        throw new AppError(`Daily enrichment limit reached — ${left} profile${left === 1 ? '' : 's'} left today for you`, 429);
+      }
+      if (globalUsed + handles.length > c.enrichMaxPerDay) {
+        const left = Math.max(0, c.enrichMaxPerDay - globalUsed);
+        throw new AppError(`Team enrichment limit reached — ${left} profile${left === 1 ? '' : 's'} left today`, 429);
+      }
     }
 
-    // Run row FIRST, then the atomic claim: a crash between claim and Apify
-    // start leaves a pending run with NULL providerRunId — exactly the shape the
-    // stranded-run sweep repairs (targets reset to 'failed').
-    const run = await d.DiscoveryRun.create({
-      createdBy: user.id, provider: 'apify_instagram', status: 'pending', requestedLimit: 0,
-    });
     // Atomic claim — the ONLY transition into enrichment-'pending'. A concurrent
     // duplicate submit claims zero rows and 400s: no double-paid run (Codex F12).
-    const [claimed] = await d.sequelize.query(
-      `UPDATE discovery_candidates
-          SET "enrichmentStatus" = 'pending', "updatedAt" = NOW()
-        WHERE id IN (:ids) AND status = 'pending'
-          AND "instagramHandle" IS NOT NULL
-          AND "enrichmentStatus" IN ('none', 'failed')
-        RETURNING id, "instagramHandle"`,
-      { replacements: { ids: candidateIds } },
-    );
-    if (claimed.length === 0) {
-      await run.update({ status: 'failed', error: 'nothing eligible to enrich (raced or already handled)' });
-      throw new AppError('Nothing to enrich — no un-enriched Instagram handles in the selection', 400);
-    }
-    const claimedIds = claimed.map((x) => x.id);
-    const claimedHandles = [...new Set(claimed.map((x) => x.instagramHandle))];
-    await run.update({ requestedLimit: claimedHandles.length, rawPayload: { targetCandidateIds: claimedIds } });
+    const claimEligible = async (transaction = null) => {
+      const [rows] = await d.sequelize.query(
+        `UPDATE discovery_candidates
+            SET "enrichmentStatus" = 'pending', "updatedAt" = NOW()
+          WHERE id IN (:ids) AND status = 'pending'
+            AND "instagramHandle" IS NOT NULL
+            AND "enrichmentStatus" IN ('none', 'failed')
+          RETURNING id, "instagramHandle"`,
+        { replacements: { ids: candidateIds }, transaction },
+      );
+      return rows;
+    };
 
+    let run;
+    let claimedIds;
+    let claimedHandles;
+    if (c.resultQuotaEnabled) {
+      await d.sequelize.transaction(async (transaction) => {
+        run = await d.DiscoveryRun.create({
+          createdBy: user.id, provider: 'apify_instagram', status: 'pending', requestedLimit: 0,
+        }, { transaction });
+        const claimed = await claimEligible(transaction);
+        if (claimed.length === 0) {
+          throw new AppError('Nothing to enrich — no un-enriched Instagram handles in the selection', 400);
+        }
+        claimedIds = claimed.map((x) => x.id);
+        claimedHandles = [...new Set(claimed.map((x) => x.instagramHandle))];
+        const sgDate = sgDateKey();
+        const reservation = { kind: 'profiles', sgDate, amount: claimedHandles.length };
+        await d.usage.reserveProfiles({
+          userId: user.id, sgDate, amount: claimedHandles.length,
+          userCap: c.profilesPerUserDay, teamCap: c.profilesPerTeamDay,
+          transaction,
+        });
+        await run.update({
+          requestedLimit: claimedHandles.length,
+          rawPayload: { targetCandidateIds: claimedIds, dailyUsageReservation: reservation },
+        }, { transaction });
+      });
+    } else {
+      // Run row FIRST, then the atomic claim: a crash between claim and Apify
+      // start leaves a pending run with NULL providerRunId — exactly the shape the
+      // stranded-run sweep repairs (targets reset to 'failed').
+      run = await d.DiscoveryRun.create({
+        createdBy: user.id, provider: 'apify_instagram', status: 'pending', requestedLimit: 0,
+      });
+      const claimed = await claimEligible();
+      if (claimed.length === 0) {
+        await run.update({ status: 'failed', error: 'nothing eligible to enrich (raced or already handled)' });
+        throw new AppError('Nothing to enrich — no un-enriched Instagram handles in the selection', 400);
+      }
+      claimedIds = claimed.map((x) => x.id);
+      claimedHandles = [...new Set(claimed.map((x) => x.instagramHandle))];
+      await run.update({ requestedLimit: claimedHandles.length, rawPayload: { targetCandidateIds: claimedIds } });
+    }
+
+    let providerStarted = false;
     try {
       // instagram-profile-scraper contract: `usernames` only (one dataset item per
       // profile — username/followersCount/biography/verified, matching the
       // normalizer). resultsType/resultsLimit belong to the OTHER actor.
       const input = { usernames: claimedHandles };
       const started = await d.apify.startRun(c.igActor, input, { webhookUrl: webhookUrl() });
+      providerStarted = true;
       await run.update({ providerRunId: started.runId, status: 'running', startedAt: new Date() });
     } catch (err) {
-      await run.update({ status: 'failed', error: String(err.message).slice(0, 500) });
-      await d.DiscoveryCandidate.update({ enrichmentStatus: 'failed' }, { where: { id: { [Op.in]: claimedIds } } });
+      if (dailyReservation(run) && !providerStarted) {
+        await d.sequelize.transaction(async (transaction) => {
+          const locked = await d.DiscoveryRun.findByPk(run.id, {
+            transaction, lock: transaction.LOCK.UPDATE,
+          });
+          if (!locked) return;
+          await d.DiscoveryCandidate.update(
+            { enrichmentStatus: 'failed' },
+            { where: { id: { [Op.in]: claimedIds } }, transaction },
+          );
+          const reservation = dailyReservation(locked);
+          await refundReservation(locked, reservation?.amount, transaction);
+          await locked.update(
+            { status: 'failed', error: String(err.message).slice(0, 500) },
+            { transaction },
+          );
+        });
+      } else {
+        await run.update({ status: 'failed', error: String(err.message).slice(0, 500) });
+        await d.DiscoveryCandidate.update({ enrichmentStatus: 'failed' }, { where: { id: { [Op.in]: claimedIds } } });
+      }
       throw new AppError(`Could not start enrichment: ${err.message}`, 502);
     }
     await d.audit.recordAuditEvent({
@@ -687,19 +836,46 @@ export function makeDiscoveryService(overrides = {}) {
     });
     for (const run of stranded) {
       try {
-        if (run.provider === 'apify_instagram') {
-          const targetIds = run.rawPayload?.targetCandidateIds || [];
-          if (targetIds.length > 0) {
-            await d.DiscoveryCandidate.update(
-              { enrichmentStatus: 'failed' },
-              { where: { id: { [Op.in]: targetIds }, enrichmentStatus: 'pending' } },
-            );
+        if (dailyReservation(run)) {
+          await d.sequelize.transaction(async (transaction) => {
+            const locked = await d.DiscoveryRun.findByPk(run.id, {
+              transaction, lock: transaction.LOCK.UPDATE,
+            });
+            if (!locked || locked.status !== 'pending' || locked.providerRunId) return;
+            if (locked.provider === 'apify_instagram') {
+              const targetIds = locked.rawPayload?.targetCandidateIds || [];
+              if (targetIds.length > 0) {
+                await d.DiscoveryCandidate.update(
+                  { enrichmentStatus: 'failed' },
+                  {
+                    where: { id: { [Op.in]: targetIds }, enrichmentStatus: 'pending' },
+                    transaction,
+                  },
+                );
+              }
+            }
+            const reservation = dailyReservation(locked);
+            await refundReservation(locked, reservation.amount, transaction);
+            await locked.update({
+              status: 'failed', completedAt: new Date(),
+              error: 'never started — no provider run id recorded',
+            }, { transaction });
+          });
+        } else {
+          if (run.provider === 'apify_instagram') {
+            const targetIds = run.rawPayload?.targetCandidateIds || [];
+            if (targetIds.length > 0) {
+              await d.DiscoveryCandidate.update(
+                { enrichmentStatus: 'failed' },
+                { where: { id: { [Op.in]: targetIds }, enrichmentStatus: 'pending' } },
+              );
+            }
           }
+          await run.update({
+            status: 'failed', completedAt: new Date(),
+            error: 'never started — no provider run id recorded',
+          });
         }
-        await run.update({
-          status: 'failed', completedAt: new Date(),
-          error: 'never started — no provider run id recorded',
-        });
       } catch (err) {
         d.logger.error('discovery.reconcile.stranded_failed', { runId: run.id, error: err.message });
       }

--- a/backend/src/services/redeemOps/discoveryUsageService.js
+++ b/backend/src/services/redeemOps/discoveryUsageService.js
@@ -1,0 +1,99 @@
+import { DiscoveryDailyUsage, sequelize } from '../../models/index.js';
+import { AppError } from '../../middleware/errorHandler.js';
+
+const KINDS = {
+  results: { column: 'resultsUsed', label: 'search results' },
+  profiles: { column: 'profilesUsed', label: 'enrichment profiles' },
+};
+
+/**
+ * Atomic usage reservations. Per-user enforcement is one INSERT..ON CONFLICT
+ * statement; the team SUM remains advisory under the existing single-instance
+ * TOCTOU posture.
+ */
+export function makeDiscoveryUsageService(overrides = {}) {
+  const d = { DiscoveryDailyUsage, sequelize, ...overrides };
+
+  async function teamUsed(kind, sgDate, transaction = null) {
+    const { column } = KINDS[kind];
+    const [[row]] = await d.sequelize.query(
+      `SELECT COALESCE(SUM("${column}"), 0)::int AS used
+         FROM discovery_daily_usage
+        WHERE "sgDate" = :sgDate`,
+      { replacements: { sgDate }, transaction },
+    );
+    return Number(row?.used) || 0;
+  }
+
+  async function reserve(kind, {
+    userId, sgDate, amount, userCap, teamCap, transaction = null,
+  }) {
+    const spec = KINDS[kind];
+    const n = Math.max(0, Math.trunc(Number(amount) || 0));
+    if (n === 0) return 0;
+    if (n > userCap) throw new AppError(`Daily ${spec.label} limit reached`, 429);
+
+    const usedByTeam = await teamUsed(kind, sgDate, transaction);
+    if (usedByTeam + n > teamCap) {
+      throw new AppError(`Team daily ${spec.label} limit reached — try again tomorrow`, 429);
+    }
+
+    const isResults = kind === 'results';
+    const [rows] = await d.sequelize.query(
+      `INSERT INTO discovery_daily_usage
+              ("userId", "sgDate", "resultsUsed", "profilesUsed", "createdAt", "updatedAt")
+       VALUES (:userId, :sgDate, :results, :profiles, NOW(), NOW())
+       ON CONFLICT ("userId", "sgDate") DO UPDATE
+               SET "${spec.column}" = discovery_daily_usage."${spec.column}" + :amount,
+                   "updatedAt" = NOW()
+             WHERE discovery_daily_usage."${spec.column}" + :amount <= :userCap
+       RETURNING "${spec.column}" AS used`,
+      {
+        replacements: {
+          userId, sgDate, amount: n, userCap,
+          results: isResults ? n : 0,
+          profiles: isResults ? 0 : n,
+        },
+        transaction,
+      },
+    );
+    if (!Array.isArray(rows) || rows.length === 0) {
+      throw new AppError(`Daily ${spec.label} limit reached`, 429);
+    }
+    return Number(rows[0].used) || 0;
+  }
+
+  async function refund(kind, { userId, sgDate, amount, transaction = null }) {
+    const { column } = KINDS[kind];
+    const n = Math.max(0, Math.trunc(Number(amount) || 0));
+    if (n === 0) return null;
+    const [rows] = await d.sequelize.query(
+      `UPDATE discovery_daily_usage
+          SET "${column}" = GREATEST(0, "${column}" - :amount),
+              "updatedAt" = NOW()
+        WHERE "userId" = :userId AND "sgDate" = :sgDate
+        RETURNING "${column}" AS used`,
+      { replacements: { userId, sgDate, amount: n }, transaction },
+    );
+    return rows?.[0] ? Number(rows[0].used) || 0 : null;
+  }
+
+  async function getUsage(userId, sgDate) {
+    const row = await d.DiscoveryDailyUsage.findOne({ where: { userId, sgDate } });
+    return {
+      resultsUsed: Number(row?.resultsUsed) || 0,
+      profilesUsed: Number(row?.profilesUsed) || 0,
+    };
+  }
+
+  return {
+    reserveResults: (args) => reserve('results', args),
+    reserveProfiles: (args) => reserve('profiles', args),
+    refundResults: (args) => refund('results', args),
+    refundProfiles: (args) => refund('profiles', args),
+    getUsage,
+  };
+}
+
+const _default = makeDiscoveryUsageService();
+export default _default;

--- a/backend/src/services/redeemOps/taskService.js
+++ b/backend/src/services/redeemOps/taskService.js
@@ -8,10 +8,15 @@ import { logger } from '../../utils/logger.js';
 import { TASK_STATUSES, TASK_PRIORITIES } from './constants.js';
 
 const TASK_TYPES = ['follow_up', 'call', 'meeting', 'proposal', 'admin', 'other'];
+const SGT_OFFSET_MS = 8 * 60 * 60 * 1000;
+
+/** Singapore calendar date for counters/snapshots, independent of server TZ. */
+export function sgDateKey(now = new Date()) {
+  return new Date(now.getTime() + SGT_OFFSET_MS).toISOString().slice(0, 10);
+}
 
 /** "Today" in Singapore time regardless of server TZ. */
 export function sgtDayWindow(now = new Date()) {
-  const SGT_OFFSET_MS = 8 * 60 * 60 * 1000;
   const sgt = new Date(now.getTime() + SGT_OFFSET_MS);
   const startUtcMs = Date.UTC(sgt.getUTCFullYear(), sgt.getUTCMonth(), sgt.getUTCDate()) - SGT_OFFSET_MS;
   return { start: new Date(startUtcMs), end: new Date(startUtcMs + 24 * 60 * 60 * 1000) };

--- a/backend/test/redeemOpsDiscoveryUsage.test.js
+++ b/backend/test/redeemOpsDiscoveryUsage.test.js
@@ -1,0 +1,209 @@
+/**
+ * Phase 3 atomic Singapore-day Discover usage counters.
+ * DB-backed: per-user atomic caps, concurrent reservations, search settlement,
+ * pre-provider and stranded refunds, profile refunds, and flag-off compatibility.
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+process.env.DISCOVERY_ENABLED = 'true';
+
+import { jest } from '@jest/globals';
+import { getApp, closeDb, createTestUser, seedRedeemOpsCategory } from './helpers.js';
+import {
+  DiscoveryCandidate, DiscoveryRun, sequelize,
+} from '../src/models/index.js';
+import { makeDiscoveryService } from '../src/services/redeemOps/discoveryService.js';
+import { makeDiscoveryUsageService } from '../src/services/redeemOps/discoveryUsageService.js';
+import { sgDateKey } from '../src/services/redeemOps/taskService.js';
+
+let runSeq = 0;
+
+const DISCOVERY_ENV_SNAPSHOT = Object.fromEntries(
+  Object.entries(process.env).filter(([key]) => key.startsWith('DISCOVERY_')),
+);
+
+function apifyStub() {
+  return {
+    startRun: jest.fn(async () => ({
+      runId: `usage_run_${Date.now()}_${++runSeq}`,
+      datasetId: `usage_ds_${runSeq}`,
+      status: 'RUNNING',
+    })),
+    getRun: jest.fn(),
+    getDatasetItems: jest.fn(),
+  };
+}
+
+beforeAll(async () => {
+  await getApp();
+  await seedRedeemOpsCategory('Nail Salon');
+});
+
+afterEach(() => {
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith('DISCOVERY_')) delete process.env[key];
+  }
+  Object.assign(process.env, DISCOVERY_ENV_SNAPSHOT);
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+describe('atomic reservations', () => {
+  test('sgDateKey flips at the same Singapore midnight boundary as the quota window', () => {
+    expect(sgDateKey(new Date('2026-07-13T15:59:59.999Z'))).toBe('2026-07-13');
+    expect(sgDateKey(new Date('2026-07-13T16:00:00.000Z'))).toBe('2026-07-14');
+  });
+
+  test('a reservation that crosses the per-user cap returns 429', async () => {
+    const { user } = await createTestUser({ role: 'admin' });
+    const usage = makeDiscoveryUsageService();
+    const base = {
+      userId: user.id, sgDate: sgDateKey(), userCap: 5, teamCap: 10000,
+    };
+    await expect(usage.reserveResults({ ...base, amount: 4 })).resolves.toBe(4);
+    await expect(usage.reserveResults({ ...base, amount: 2 }))
+      .rejects.toMatchObject({ statusCode: 429 });
+    await expect(usage.getUsage(user.id, base.sgDate)).resolves.toMatchObject({ resultsUsed: 4 });
+  });
+
+  test("two concurrent reserves cannot take one user's counter over the cap", async () => {
+    const { user } = await createTestUser({ role: 'admin' });
+    const usage = makeDiscoveryUsageService();
+    const args = {
+      userId: user.id, sgDate: sgDateKey(), amount: 7, userCap: 10, teamCap: 10000,
+    };
+    const settled = await Promise.allSettled([
+      usage.reserveResults(args),
+      usage.reserveResults(args),
+    ]);
+    expect(settled.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+    expect(settled.filter((result) => result.status === 'rejected')).toHaveLength(1);
+    const current = await usage.getUsage(user.id, args.sgDate);
+    expect(current.resultsUsed).toBe(7);
+    expect(current.resultsUsed).toBeLessThanOrEqual(args.userCap);
+  });
+});
+
+describe('search reservation lifecycle', () => {
+  test('completed search refunds requestedLimit minus actual resultCount', async () => {
+    process.env.DISCOVERY_RESULT_QUOTA_ENABLED = 'true';
+    process.env.DISCOVERY_RESULTS_PER_USER_DAY = '100';
+    process.env.DISCOVERY_RESULTS_PER_TEAM_DAY = '10000';
+    const { user } = await createTestUser({ role: 'admin' });
+    const apify = apifyStub();
+    const discovery = makeDiscoveryService({ apify });
+    const run = await discovery.startDiscovery(
+      { category: 'Nail Salon', area: 'Bedok', limit: 10 }, user,
+    );
+    const usage = makeDiscoveryUsageService();
+    expect((await usage.getUsage(user.id, sgDateKey())).resultsUsed).toBe(10);
+
+    apify.getRun.mockResolvedValue({
+      runId: run.providerRunId, status: 'SUCCEEDED', datasetId: 'usage_settle_ds',
+      usageTotalUsd: 0.021, terminalStatus: 'completed',
+    });
+    apify.getDatasetItems.mockResolvedValue([
+      { placeId: `usage_place_${runSeq}_1`, title: 'Usage Nails One', countryCode: 'SG' },
+      { placeId: `usage_place_${runSeq}_2`, title: 'Usage Nails Two', countryCode: 'SG' },
+      { placeId: `usage_place_${runSeq}_3`, title: 'Usage Nails Three', countryCode: 'SG' },
+    ]);
+    await discovery.processRun(run.id);
+
+    expect((await usage.getUsage(user.id, sgDateKey())).resultsUsed).toBe(3);
+    const quota = await discovery.getQuota(user);
+    expect(quota).toMatchObject({
+      mode: 'results', resultsUsed: 3, resultsRemaining: 97,
+      profilesRemaining: 200,
+    });
+    expect(quota.estimatedSpendUsd).toBe(0.021);
+  });
+
+  test('pre-Apify start failure refunds the full search reservation', async () => {
+    process.env.DISCOVERY_RESULT_QUOTA_ENABLED = 'true';
+    process.env.DISCOVERY_RESULTS_PER_USER_DAY = '100';
+    process.env.DISCOVERY_RESULTS_PER_TEAM_DAY = '10000';
+    const { user } = await createTestUser({ role: 'admin' });
+    const apify = apifyStub();
+    apify.startRun.mockRejectedValue(new Error('provider unavailable'));
+    const discovery = makeDiscoveryService({ apify });
+
+    await expect(discovery.startDiscovery(
+      { category: 'Nail Salon', area: 'Bedok', limit: 25 }, user,
+    )).rejects.toMatchObject({ statusCode: 502 });
+    expect((await makeDiscoveryUsageService().getUsage(user.id, sgDateKey())).resultsUsed).toBe(0);
+  });
+
+  test('stranded-run sweep refunds the stored reservation exactly once', async () => {
+    process.env.DISCOVERY_RESULT_QUOTA_ENABLED = 'true';
+    process.env.DISCOVERY_RECONCILE_STUCK_MINUTES = '1';
+    const { user } = await createTestUser({ role: 'admin' });
+    const usage = makeDiscoveryUsageService();
+    const sgDate = sgDateKey();
+    await usage.reserveResults({
+      userId: user.id, sgDate, amount: 20, userCap: 100, teamCap: 10000,
+    });
+    const run = await DiscoveryRun.create({
+      createdBy: user.id, provider: 'apify_google_maps', status: 'pending', requestedLimit: 20,
+      rawPayload: { dailyUsageReservation: { kind: 'results', sgDate, amount: 20 } },
+    });
+    await sequelize.query(
+      `UPDATE discovery_runs SET "createdAt" = NOW() - INTERVAL '10 minutes' WHERE id = :id`,
+      { replacements: { id: run.id } },
+    );
+
+    const discovery = makeDiscoveryService({ apify: apifyStub() });
+    await discovery.reconcileStuckRuns();
+    await discovery.reconcileStuckRuns();
+    expect((await usage.getUsage(user.id, sgDate)).resultsUsed).toBe(0);
+    await run.reload();
+    expect(run.status).toBe('failed');
+  });
+
+  test('flag OFF preserves the existing run-count quota and writes no usage row', async () => {
+    delete process.env.DISCOVERY_RESULT_QUOTA_ENABLED;
+    process.env.DISCOVERY_MAX_RUNS_PER_USER_DAY = '1';
+    process.env.DISCOVERY_MAX_RUNS_PER_DAY = '1000';
+    const { user } = await createTestUser({ role: 'admin' });
+    const discovery = makeDiscoveryService({ apify: apifyStub() });
+
+    await discovery.startDiscovery({ category: 'Nail Salon', area: 'Bedok', limit: 5 }, user);
+    await expect(discovery.startDiscovery(
+      { category: 'Nail Salon', area: 'Tampines', limit: 5 }, user,
+    )).rejects.toMatchObject({ statusCode: 429 });
+    expect(await makeDiscoveryUsageService().getUsage(user.id, sgDateKey())).toEqual({
+      resultsUsed: 0, profilesUsed: 0,
+    });
+    await expect(discovery.getQuota(user)).resolves.toMatchObject({
+      used: 1, limit: 1, remaining: 0,
+    });
+  });
+});
+
+describe('profile reservation lifecycle', () => {
+  test('Apify start failure refunds profiles after the atomic candidate claim', async () => {
+    process.env.DISCOVERY_RESULT_QUOTA_ENABLED = 'true';
+    process.env.DISCOVERY_PROFILES_PER_USER_DAY = '10';
+    process.env.DISCOVERY_PROFILES_PER_TEAM_DAY = '10000';
+    const { user } = await createTestUser({ role: 'admin' });
+    const mapsRun = await DiscoveryRun.create({
+      createdBy: user.id, provider: 'apify_google_maps', status: 'completed', requestedLimit: 2,
+    });
+    const candidates = await Promise.all(['usageigone', 'usageigtwo'].map((instagramHandle) => (
+      DiscoveryCandidate.create({
+        discoveryRunId: mapsRun.id, name: instagramHandle,
+        instagramHandle, status: 'pending', enrichmentStatus: 'none',
+      })
+    )));
+    const apify = apifyStub();
+    apify.startRun.mockRejectedValue(new Error('profile actor unavailable'));
+    const discovery = makeDiscoveryService({ apify });
+
+    await expect(discovery.enrichCandidates(candidates.map((candidate) => candidate.id), user))
+      .rejects.toMatchObject({ statusCode: 502 });
+    const current = await makeDiscoveryUsageService().getUsage(user.id, sgDateKey());
+    expect(current.profilesUsed).toBe(0);
+    await Promise.all(candidates.map((candidate) => candidate.reload()));
+    expect(candidates.every((candidate) => candidate.enrichmentStatus === 'failed')).toBe(true);
+  });
+});

--- a/src/pages/redeemops/DiscoverPage.jsx
+++ b/src/pages/redeemops/DiscoverPage.jsx
@@ -78,6 +78,7 @@ export default function DiscoverPage() {
   });
   const recentRuns = listQuery.data?.runs || [];
   const quota = listQuery.data?.quota;
+  const resultsQuota = quota?.resultsRemaining != null;
   const categoriesQuery = useQuery({
     queryKey: ['redeem-ops', 'categories'],
     queryFn: () => redeemOpsApi.listCategories(),
@@ -243,8 +244,12 @@ export default function DiscoverPage() {
         actions={quota && (
           <span className="hidden sm:inline-flex items-center gap-2 text-[12.5px] font-semibold rounded-full px-3 py-1.5"
             style={{ color: 'var(--ro-text-2)', background: 'var(--ro-subtle)', border: '1px solid var(--ro-border)' }}>
-            <i className="w-[7px] h-[7px] rounded-full" style={{ background: quota.remaining > 0 ? 'var(--ro-tag-green-fg)' : 'var(--ro-tag-red-fg)' }} />
-            <b style={{ color: 'var(--ro-bunker)' }}>{quota.used}</b> of {quota.limit} searches today
+            <i className="w-[7px] h-[7px] rounded-full" style={{ background: (resultsQuota ? quota.resultsRemaining : quota.remaining) > 0 ? 'var(--ro-tag-green-fg)' : 'var(--ro-tag-red-fg)' }} />
+            {resultsQuota ? (
+              <><b style={{ color: 'var(--ro-bunker)' }}>{quota.resultsRemaining}</b> results left today</>
+            ) : (
+              <><b style={{ color: 'var(--ro-bunker)' }}>{quota.used}</b> of {quota.limit} searches today</>
+            )}
           </span>
         )}
       />

--- a/src/pages/redeemops/__tests__/DiscoverPage.test.jsx
+++ b/src/pages/redeemops/__tests__/DiscoverPage.test.jsx
@@ -108,6 +108,20 @@ describe('DiscoverPage', () => {
     expect(screen.getByText('Popular areas')).toBeInTheDocument();
   });
 
+  it('shows remaining results when the atomic quota response is present', async () => {
+    api.listDiscoveryRuns.mockResolvedValue({
+      runs: [],
+      quota: {
+        mode: 'results', resultsUsed: 125, resultsRemaining: 1375,
+        profilesRemaining: 200, costPerResultUsd: 0.007,
+      },
+    });
+    renderPage();
+    expect(await screen.findByText(/1375/)).toBeInTheDocument();
+    expect(screen.getByText(/results left today/)).toBeInTheDocument();
+    expect(screen.queryByText(/searches today/)).not.toBeInTheDocument();
+  });
+
   it('shows Enriching… while enrichment is pending instead of another paid action', async () => {
     api.listDiscoveryRuns.mockResolvedValue({ runs: [completedRun], quota });
     api.getDiscoveryRun.mockResolvedValue({


### PR DESCRIPTION
## Phase 3 — replace run-count quota with a per-Singapore-day results/profile budget

The old discovery quota counted **runs** (5/user/day), so a 30- and a 500-result run cost the same. This adds an atomic per-user, per-Asia/Singapore-day counter of **results + profiles**.

- **Migration 064** `discovery_daily_usage(userId, sgDate, resultsUsed, profilesUsed)`.
- Atomic reserve (`INSERT … ON CONFLICT … DO UPDATE … WHERE used+n <= cap`), **settle-refund** to actual on completion, **full refund** on stranded / failed-pre-Apify runs; advisory team caps.
- `getQuota` + DiscoverPage switch to **results-remaining** when enabled.
- Reuses the Asia/Singapore day boundary (`sgtDayWindow`/`sgDateKey` in `taskService`).

### Safety
Gated by **`DISCOVERY_RESULT_QUOTA_ENABLED` (default false)** → today's run-count quota, byte-identical Apify input + runs chip. Ships dark.

### Verification (local, pg 5433)
- DB Jest **70/70** (`redeemOpsDiscoveryUsage` + `redeemOpsDiscovery` regression + `redeemOpsCategories`).
- DiscoverPage Vitest 8/8; build ✓; ESLint ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)