### PR TITLE
feat(redeem-ops): Assignment Queues cleanup — labels + computed status (Phase 4)

### DIFF
--- a/backend/src/services/redeemOps/poolService.js
+++ b/backend/src/services/redeemOps/poolService.js
@@ -5,7 +5,6 @@ import {
 import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';
 import { makeClaimService } from './claimService.js';
-import { makeCategoryService } from './categoryService.js';
 
 /**
  * Prospecting pools + Claim Next (docs/redeem-ops/ERD.md §3.8–3.9, brief §21).
@@ -18,7 +17,7 @@ import { makeCategoryService } from './categoryService.js';
 export function makePoolService(overrides = {}) {
   const d = {
     ProspectingPool, ProspectingPoolMember, PartnerOrganisation, sequelize, logger,
-    claims: makeClaimService(), categories: makeCategoryService(), ...overrides,
+    claims: makeClaimService(), ...overrides,
   };
 
   async function createPool(body, user) {
@@ -26,14 +25,14 @@ export function makePoolService(overrides = {}) {
     return d.ProspectingPool.create({
       name: String(body.name).trim(),
       description: body.description || null,
-      category: (await d.categories.resolveCategoryName(body.category)) ?? null,
+      category: String(body.category ?? '').trim() || null,
       area: body.area || null,
       createdBy: user.id,
     });
   }
 
   async function listPools() {
-    const pools = await d.ProspectingPool.findAll({ where: { isActive: true }, order: [['createdAt', 'DESC']] });
+    const pools = await d.ProspectingPool.findAll({ order: [['createdAt', 'DESC']] });
     const counts = await d.ProspectingPoolMember.findAll({
       attributes: ['poolId', 'status', [d.sequelize.fn('COUNT', '*'), 'count']],
       group: ['poolId', 'status'],
@@ -44,7 +43,11 @@ export function makePoolService(overrides = {}) {
       byPool[c.poolId] = byPool[c.poolId] || {};
       byPool[c.poolId][c.status] = Number(c.count);
     }
-    return pools.map((p) => ({ ...p.toJSON(), memberCounts: byPool[p.id] || {} }));
+    return pools.map((p) => {
+      const memberCounts = byPool[p.id] || {};
+      const status = !p.isActive ? 'archived' : (memberCounts.available || 0) > 0 ? 'active' : 'exhausted';
+      return { ...p.toJSON(), memberCounts, status };
+    });
   }
 
   async function updatePool(poolId, body, user) {
@@ -54,11 +57,7 @@ export function makePoolService(overrides = {}) {
     for (const f of ['name', 'description', 'category', 'area', 'isActive']) {
       if (body[f] !== undefined) updates[f] = body[f];
     }
-    if (updates.category !== undefined) {
-      updates.category = await d.categories.resolveCategoryName(updates.category, {
-        currentValue: pool.category,
-      });
-    }
+    if (updates.category !== undefined) updates.category = String(updates.category ?? '').trim() || null;
     await pool.update(updates);
     return pool;
   }

--- a/backend/test/redeemOpsAssignmentQueues.test.js
+++ b/backend/test/redeemOpsAssignmentQueues.test.js
@@ -1,0 +1,146 @@
+/**
+ * Phase 4 Assignment Queues (the persisted API/model names remain pools).
+ * DB-backed coverage for free-text labels, computed status, and unchanged
+ * claim-next concurrency / mid-flight conditional-claim retry behavior.
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+
+import request from 'supertest';
+import { getApp, closeDb, createTestUser } from './helpers.js';
+import {
+  PartnerOrganisation, ProspectingPoolMember,
+} from '../src/models/index.js';
+import { makePoolService } from '../src/services/redeemOps/poolService.js';
+import { makeClaimService } from '../src/services/redeemOps/claimService.js';
+
+let app;
+let admin;
+let bdm;
+let execA;
+let execB;
+let seq = 0;
+
+const auth = (token) => ({ Authorization: `Bearer ${token}` });
+const uniq = (base) => `${base} ${Date.now()}-${++seq}`;
+
+beforeAll(async () => {
+  app = await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  bdm = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'bdm' });
+  execA = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
+  execB = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+async function createPartner(label) {
+  const res = await request(app)
+    .post('/api/redeem-ops/partners')
+    .set(auth(admin.token))
+    .send({ tradingName: uniq(label) });
+  expect(res.status).toBe(201);
+  return res.body.data.partner;
+}
+
+async function createQueue(body = {}) {
+  const res = await request(app)
+    .post('/api/redeem-ops/pools')
+    .set(auth(bdm.token))
+    .send({ name: uniq('Assignment Queue'), ...body });
+  expect(res.status).toBe(201);
+  return res.body.data.pool;
+}
+
+async function stockQueue(poolId, count) {
+  const partners = [];
+  for (let i = 0; i < count; i += 1) partners.push(await createPartner(`Queue Prospect ${i}`));
+  const res = await request(app)
+    .post(`/api/redeem-ops/pools/${poolId}/members`)
+    .set(auth(bdm.token))
+    .send({ partnerIds: partners.map((partner) => partner.id) });
+  expect(res.status).toBe(200);
+  expect(res.body.data.added).toBe(count);
+  return partners;
+}
+
+describe('labels and computed status', () => {
+  test('a free-text category outside the taxonomy is trimmed and accepted', async () => {
+    const category = uniq('Experimental Wellness Cohort');
+    const queue = await createQueue({ category: `  ${category}  `, area: 'East-ish' });
+    expect(queue.category).toBe(category);
+    expect(queue.area).toBe('East-ish');
+  });
+
+  test('listPools computes exhausted, active, and archived without storing status', async () => {
+    const service = makePoolService();
+    const exhausted = await service.createPool({ name: uniq('Empty Queue') }, bdm.user);
+    const active = await service.createPool({ name: uniq('Stocked Queue') }, bdm.user);
+    await stockQueue(active.id, 1);
+    const archived = await service.createPool({ name: uniq('Archived Queue') }, bdm.user);
+    await service.updatePool(archived.id, { isActive: false }, bdm.user);
+
+    const listed = await service.listPools();
+    const byId = new Map(listed.map((pool) => [pool.id, pool]));
+    expect(byId.get(exhausted.id).status).toBe('exhausted');
+    expect(byId.get(active.id).status).toBe('active');
+    expect(byId.get(archived.id).status).toBe('archived');
+    expect(byId.get(archived.id).isActive).toBe(false);
+  });
+});
+
+describe('claim-next invariants', () => {
+  test('concurrent claimers receive different partners', async () => {
+    const queue = await createQueue();
+    await stockQueue(queue.id, 2);
+    const service = makePoolService();
+    const [first, second] = await Promise.all([
+      service.claimNext(queue.id, execA.user),
+      service.claimNext(queue.id, execB.user),
+    ]);
+    expect(first).toBeTruthy();
+    expect(second).toBeTruthy();
+    expect(first).not.toBe(second);
+
+    const rows = await PartnerOrganisation.findAll({ where: { id: [first, second] } });
+    expect(rows.map((row) => row.ownerUserId).sort()).toEqual([
+      execA.user.id, execB.user.id,
+    ].sort());
+  });
+
+  test('a partner claimed after member selection is removed and the retry returns the next', async () => {
+    const queue = await createQueue();
+    const partners = await stockQueue(queue.id, 2);
+    const realClaims = makeClaimService();
+    let interceptedPartnerId = null;
+    let intercept = true;
+    const service = makePoolService({
+      claims: {
+        claimPartnerTx: async (partnerId, user, transaction, via) => {
+          if (intercept) {
+            intercept = false;
+            interceptedPartnerId = partnerId;
+            await realClaims.claimPartner(partnerId, execB.user);
+          }
+          return realClaims.claimPartnerTx(partnerId, user, transaction, via);
+        },
+      },
+    });
+
+    const claimedPartnerId = await service.claimNext(queue.id, execA.user);
+    expect(interceptedPartnerId).toBeTruthy();
+    expect(claimedPartnerId).toBeTruthy();
+    expect(claimedPartnerId).not.toBe(interceptedPartnerId);
+    expect(partners.map((partner) => partner.id)).toEqual(expect.arrayContaining([
+      interceptedPartnerId, claimedPartnerId,
+    ]));
+
+    const racedMember = await ProspectingPoolMember.findOne({
+      where: { poolId: queue.id, partnerOrganisationId: interceptedPartnerId },
+    });
+    expect(racedMember.status).toBe('removed');
+    expect((await PartnerOrganisation.findByPk(interceptedPartnerId)).ownerUserId).toBe(execB.user.id);
+    expect((await PartnerOrganisation.findByPk(claimedPartnerId)).ownerUserId).toBe(execA.user.id);
+  });
+});

--- a/src/components/redeemops/RedeemOpsLayout.jsx
+++ b/src/components/redeemops/RedeemOpsLayout.jsx
@@ -45,7 +45,7 @@ const NAV = [
     : []),
   { title: 'Pipeline', url: '/redeem-ops/pipeline', icon: Kanban, capability: 'pipeline.view_team' },
   { title: 'Tasks', url: '/redeem-ops/tasks', icon: ListChecks, capability: 'tasks.manage' },
-  { title: 'Pools', url: '/redeem-ops/pools', icon: Layers, capability: 'pools.claim_next' },
+  { title: 'Assignment Queues', url: '/redeem-ops/pools', icon: Layers, capability: 'pools.claim_next' },
   { title: 'Rewards', url: '/redeem-ops/rewards', icon: Gift, capability: 'rewards.view' },
   { title: 'Activations', url: '/redeem-ops/activations', icon: Link2, capability: 'activations.view' },
   { title: 'Redemptions', url: '/redeem-ops/redemptions', icon: QrCode, capability: 'redemptions.verify' },

--- a/src/pages/redeemops/PoolsPage.jsx
+++ b/src/pages/redeemops/PoolsPage.jsx
@@ -14,7 +14,6 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import Plus from 'lucide-react/icons/plus';
 import { RoPageHeader, RoTag, RoAvatar, RoStageTag } from '@/components/redeemops/ui';
-import CategorySelect from '@/components/redeemops/CategorySelect';
 
 function useDebounced(value, ms = 300) {
   const [debounced, setDebounced] = useState(value);
@@ -130,12 +129,12 @@ export default function PoolsPage() {
   const createMutation = useMutation({
     mutationFn: () => redeemOpsApi.createPool(form),
     onSuccess: () => {
-      toast.success('Pool created');
+      toast.success('Queue created');
       setCreateOpen(false);
       setForm({ name: '', description: '', category: '', area: '' });
       queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'pools'] });
     },
-    onError: (err) => toast.error('Could not create pool', { description: err.message }),
+    onError: (err) => toast.error('Could not create queue', { description: err.message }),
   });
 
   const claimMutation = useMutation({
@@ -147,7 +146,7 @@ export default function PoolsPage() {
         toast.success('Prospect claimed — it’s yours');
         navigate(`/redeem-ops/partners/${data.partnerId}`);
       } else {
-        toast.info('Pool exhausted', { description: 'No eligible prospects left in this pool.' });
+        toast.info('Queue exhausted', { description: 'No eligible prospects left in this queue.' });
       }
     },
     onError: (err) => toast.error('Claim failed', { description: err.message }),
@@ -158,11 +157,11 @@ export default function PoolsPage() {
   return (
     <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-5">
       <RoPageHeader
-        title="Prospecting pools"
+        title="Assignment queues"
         sub="Curated prospect lists — hit “Claim next” to pull your next business, no cherry-picking, no collisions."
         actions={canManage && (
           <Button onClick={() => setCreateOpen(true)}>
-            <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" /> New pool
+            <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" /> New queue
           </Button>
         )}
       />
@@ -174,7 +173,12 @@ export default function PoolsPage() {
           return (
             <Card key={pool.id}>
               <CardHeader className="pb-2">
-                <CardTitle className="text-base">{pool.name}</CardTitle>
+                <CardTitle className="text-base flex items-center gap-2">
+                  <span className="min-w-0 truncate">{pool.name}</span>
+                  <RoTag tone={pool.status === 'exhausted' ? 'ended' : pool.status} size="sm">
+                    {pool.status}
+                  </RoTag>
+                </CardTitle>
                 <CardDescription>
                   {[pool.category, pool.area].filter(Boolean).join(' · ') || pool.description || '—'}
                 </CardDescription>
@@ -186,13 +190,16 @@ export default function PoolsPage() {
                 </div>
                 <div className="flex gap-2">
                   {canManage && (
-                    <Button size="sm" variant="outline" onClick={() => setAddTarget(pool)}>
+                    <Button
+                      size="sm" variant="outline" disabled={pool.status === 'archived'}
+                      onClick={() => setAddTarget(pool)}
+                    >
                       Add businesses
                     </Button>
                   )}
                   <Button
                     size="sm"
-                    disabled={claimMutation.isPending || available === 0}
+                    disabled={claimMutation.isPending || pool.status !== 'active'}
                     onClick={() => claimMutation.mutate(pool.id)}
                   >
                     {claimMutation.isPending ? 'Claiming…' : 'Claim next'}
@@ -205,7 +212,7 @@ export default function PoolsPage() {
         {!poolsQuery.isLoading && pools.length === 0 && (
           <Card className="sm:col-span-2">
             <CardContent className="py-10 text-center text-muted-foreground">
-              No pools yet{canManage ? ' — create one and add businesses from the Partners list.' : '.'}
+              No assignment queues yet{canManage ? ' — create one and add businesses from the Partners list.' : '.'}
             </CardContent>
           </Card>
         )}
@@ -216,7 +223,7 @@ export default function PoolsPage() {
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>New prospecting pool</DialogTitle>
+            <DialogTitle>New assignment queue</DialogTitle>
           </DialogHeader>
           <div className="space-y-3 py-2">
             <div className="space-y-1.5">
@@ -226,9 +233,10 @@ export default function PoolsPage() {
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-1.5">
                 <Label>Category</Label>
-                <CategorySelect
+                <Input
                   value={form.category}
-                  onChange={(v) => setForm((f) => ({ ...f, category: v }))}
+                  onChange={(e) => setForm((f) => ({ ...f, category: e.target.value }))}
+                  placeholder="Any label, e.g. Pet Grooming"
                 />
               </div>
               <div className="space-y-1.5">
@@ -239,7 +247,7 @@ export default function PoolsPage() {
           </div>
           <DialogFooter>
             <Button disabled={!form.name.trim() || createMutation.isPending} onClick={() => createMutation.mutate()}>
-              {createMutation.isPending ? 'Creating…' : 'Create pool'}
+              {createMutation.isPending ? 'Creating…' : 'Create queue'}
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## Phase 4 — Pools → Assignment Queues (UI-first cleanup)

- **Rename in UI copy only** — "Pools" → "Assignment Queues" in `PoolsPage` + nav. Table, routes, API paths, and query keys are unchanged (no migration, no churn).
- **Demote category to a label** — unbinds the enforced `CategorySelect` on pool.category (it never enforced membership anyway); it's now a trimmed free-text label. Column retained (no data loss).
- **Computed status** — `active` / `exhausted` / `archived` derived in `listPools` (not stored).
- **Claim-Next untouched** — `FOR UPDATE SKIP LOCKED` + atomic conditional claim + 5 retries are byte-identical (diff-audited + test-covered).

### Verification (local, pg 5433)
- DB Jest **4/4** (`redeemOpsAssignmentQueues` — incl. concurrent Claim-Next + computed status).
- Build ✓; ESLint 0 errors (1 pre-existing unused-arg warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)