### PR TITLE
feat(redeem-ops): Instagram-hashtag discovery pilot — backend

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -286,12 +286,14 @@ HITPAY_REDIRECT_URL=                         # app deep link back after pay (opt
 
 # ── Redeem Ops — Discover tool (Apify prospecting; migration 053) ──────────────
 DISCOVERY_ENABLED=false                       # master switch (also gates the reconcile sweep)
+DISCOVERY_IG_ENABLED=false                    # Instagram hashtag-discovery pilot (provider kill switch; Maps stays primary)
 DISCOVERY_SEARCH_TERMS_ENABLED=false          # expand category aliases in Maps searches; off preserves legacy one-name input
 DISCOVERY_TERRITORIES_ENABLED=false           # admin-curated SG area picker; off preserves the free-text Area UI
 DISCOVERY_RESULT_QUOTA_ENABLED=false          # atomic result/profile counters; off preserves run-count quotas
 APIFY_TOKEN=                                  # SECRET — Apify API token
 APIFY_MAPS_ACTOR_ID=compass~crawler-google-places   # Google Maps scraper actor
 APIFY_INSTAGRAM_ACTOR_ID=apify~instagram-profile-scraper    # IG enrichment actor (PROFILE scraper — takes `usernames`; plain instagram-scraper does NOT)
+APIFY_INSTAGRAM_HASHTAG_ACTOR_ID=apify~instagram-hashtag-scraper    # IG hashtag DISCOVERY actor (`hashtags` + `resultsLimit` input; not the enrichment actor above)
 DISCOVERY_WEBHOOK_SECRET=                     # URL-path secret for the Apify terminal-event callback
 DISCOVERY_WEBHOOK_BASE_URL=https://api.mktr.sg      # public base for the callback URL
 DISCOVERY_MAX_RESULTS_PER_RUN=500            # per-search depth cap; 500 ≈ one whole-SG sweep of a dense category (~$3.50)

--- a/backend/src/controllers/redeemOps/adminController.js
+++ b/backend/src/controllers/redeemOps/adminController.js
@@ -230,12 +230,14 @@ export const getConstants = asyncHandler(async (req, res) => {
 const categoryCreateSchema = Joi.object({
   name: Joi.string().min(1).max(64).required(),
   searchTerms: Joi.array().items(Joi.string().min(1).max(64)).max(20),
+  igHashtags: Joi.array().items(Joi.string().min(1).max(64)).max(20),
 });
 
 const categoryUpdateSchema = Joi.object({
   name: Joi.string().min(1).max(64),
   isActive: Joi.boolean(),
   searchTerms: Joi.array().items(Joi.string().min(1).max(64)).max(20),
+  igHashtags: Joi.array().items(Joi.string().min(1).max(64)).max(20),
 }).min(1);
 
 const categoryMergeSchema = Joi.object({

--- a/backend/src/controllers/redeemOps/discoveryController.js
+++ b/backend/src/controllers/redeemOps/discoveryController.js
@@ -7,6 +7,8 @@ const startSchema = Joi.object({
   category: Joi.string().min(1).max(64).required(),
   area: Joi.string().min(1).max(120).required(),
   limit: Joi.number().integer().min(1).max(500), // sanity bound; service clamps to DISCOVERY_MAX_RESULTS_PER_RUN
+  // Mechanism pick; omitted = Maps. The IG pilot additionally needs DISCOVERY_IG_ENABLED.
+  provider: Joi.string().valid('google_maps', 'instagram_hashtag'),
 });
 const idsSchema = Joi.object({
   // .max(500): each id can become a PAID scrape — sanity-bound to one full run's

--- a/backend/src/database/migrations/065-redeem-ops-category-ig-hashtags.js
+++ b/backend/src/database/migrations/065-redeem-ops-category-ig-hashtags.js
@@ -1,0 +1,21 @@
+/**
+ * 065 — Instagram hashtags for the Redeem Ops category taxonomy (IG-discovery pilot).
+ *
+ * The IG analog of 062's providerSearchTerms: admin-curated hashtags the
+ * Instagram hashtag provider fires for a category. Nullable with NO backfill —
+ * unlike search terms there is no safe name fallback (a category name is not a
+ * hashtag), so null means "no IG tags curated yet" and
+ * resolveCategoryForInstagram refuses the search (422). Guarded/idempotent like
+ * 052–064 and safe under NODE_ENV=test's sync-first empty tables.
+ */
+export async function up(queryInterface) {
+  await queryInterface.sequelize.query(
+    'ALTER TABLE redeem_ops_categories ADD COLUMN IF NOT EXISTS "igHashtags" text[]'
+  );
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query(
+    'ALTER TABLE redeem_ops_categories DROP COLUMN IF EXISTS "igHashtags"'
+  );
+}

--- a/backend/src/models/DiscoveryCandidate.js
+++ b/backend/src/models/DiscoveryCandidate.js
@@ -1,4 +1,4 @@
-import { DataTypes } from 'sequelize';
+import { DataTypes, Op } from 'sequelize';
 import { sequelize } from '../database/connection.js';
 
 /**
@@ -39,6 +39,17 @@ const DiscoveryCandidate = sequelize.define('DiscoveryCandidate', {
   rawPayload: { type: DataTypes.JSONB, allowNull: true },
 }, {
   tableName: 'discovery_candidates',
+  indexes: [
+    // Partial (some sources carry no place id) — defined here AND in migration
+    // 053 so sync()-built schemas enforce it too (DrawEntry/059 pattern). The
+    // idempotent bulkCreate({ ignoreDuplicates }) in materialization depends on it.
+    {
+      unique: true,
+      fields: ['discoveryRunId', 'externalPlaceId'],
+      name: 'uq_discovery_candidates_run_place',
+      where: { externalPlaceId: { [Op.ne]: null } },
+    },
+  ],
 });
 
 export default DiscoveryCandidate;

--- a/backend/src/models/RedeemOpsCategory.js
+++ b/backend/src/models/RedeemOpsCategory.js
@@ -11,6 +11,9 @@ const RedeemOpsCategory = sequelize.define('RedeemOpsCategory', {
   id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
   name: { type: DataTypes.STRING(64), allowNull: false },
   providerSearchTerms: { type: DataTypes.ARRAY(DataTypes.TEXT), allowNull: true },
+  // Instagram hashtag-discovery tags (migration 065). NULL = not curated yet —
+  // there is deliberately no name fallback (a category name is not a hashtag).
+  igHashtags: { type: DataTypes.ARRAY(DataTypes.TEXT), allowNull: true },
   isActive: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
 }, {
   tableName: 'redeem_ops_categories',

--- a/backend/src/services/redeemOps/categoryService.js
+++ b/backend/src/services/redeemOps/categoryService.js
@@ -52,6 +52,24 @@ export function makeCategoryService(overrides = {}) {
     return cleaned.length > 0 ? cleaned : [fallbackName];
   }
 
+  /** IG analog of cleanSearchTerms with NO name fallback: a category name is not
+   *  a hashtag, so an emptied list stores NULL ("no IG tags curated yet") and
+   *  resolveCategoryForInstagram refuses the search until an admin curates tags. */
+  function cleanHashtags(raw) {
+    if (raw === undefined) return undefined;
+    const values = Array.isArray(raw) ? raw : [raw];
+    const seen = new Set();
+    const cleaned = [];
+    for (const value of values) {
+      const tag = String(value ?? '').trim().replace(/^#+/, '').trim().toLowerCase().slice(0, 64);
+      if (!tag || seen.has(tag)) continue;
+      seen.add(tag);
+      cleaned.push(tag);
+      if (cleaned.length === 20) break;
+    }
+    return cleaned.length > 0 ? cleaned : null;
+  }
+
   function whereNameCi(name) {
     return d.sequelize.where(d.sequelize.fn('LOWER', d.sequelize.col('name')), name.toLowerCase());
   }
@@ -76,14 +94,16 @@ export function makeCategoryService(overrides = {}) {
   async function createCategory(body, user, requestId = null) {
     const name = cleanName(body?.name);
     const providerSearchTerms = cleanSearchTerms(body?.searchTerms, name) ?? [name];
+    const igHashtags = cleanHashtags(body?.igHashtags) ?? null;
     const existing = await d.RedeemOpsCategory.findOne({ where: whereNameCi(name) });
     if (existing) throw new AppError(`Category '${existing.name}' already exists`, 409);
     try {
-      const category = await d.RedeemOpsCategory.create({ name, providerSearchTerms });
+      const category = await d.RedeemOpsCategory.create({ name, providerSearchTerms, igHashtags });
       await d.audit.recordAuditEvent({
         actorUser: user, action: 'settings.category_created',
         entityType: 'redeem_ops_category', entityId: category.id,
-        after: { name, searchTerms: providerSearchTerms }, requestId,
+        after: { name, searchTerms: providerSearchTerms, ...(igHashtags ? { igHashtags } : {}) },
+        requestId,
       });
       return category;
     } catch (err) {
@@ -125,12 +145,15 @@ export function makeCategoryService(overrides = {}) {
       const effectiveName = updates.name || category.name;
       updates.providerSearchTerms = cleanSearchTerms(body.searchTerms, effectiveName);
     }
+    if (body?.igHashtags !== undefined) updates.igHashtags = cleanHashtags(body.igHashtags);
     if (Object.keys(updates).length === 0) return category;
 
+    const touchesHashtags = 'igHashtags' in updates;
     const before = {
       name: category.name,
       isActive: category.isActive,
       searchTerms: category.providerSearchTerms,
+      ...(touchesHashtags ? { igHashtags: category.igHashtags } : {}),
     };
     await d.sequelize.transaction(async (t) => {
       await category.update(updates, { transaction: t });
@@ -150,6 +173,7 @@ export function makeCategoryService(overrides = {}) {
           name: updates.name ?? before.name,
           isActive: updates.isActive ?? before.isActive,
           searchTerms: updates.providerSearchTerms ?? before.searchTerms,
+          ...(touchesHashtags ? { igHashtags: updates.igHashtags } : {}),
         },
         requestId, transaction: t,
       });
@@ -267,9 +291,21 @@ export function makeCategoryService(overrides = {}) {
     };
   }
 
+  /** Instagram-discovery resolver (migration 065). Unlike resolveCategoryForSearch
+   *  there is NO name fallback — a category without curated hashtags is not
+   *  IG-searchable, and the 422 names the fix. */
+  async function resolveCategoryForInstagram(input) {
+    const name = String(input ?? '').trim();
+    const match = await findActiveCategory(name);
+    if (!match.igHashtags?.length) {
+      throw new AppError(`Category '${match.name}' has no Instagram hashtags — add them in Settings`, 422);
+    }
+    return { name: match.name, hashtags: match.igHashtags };
+  }
+
   return {
     listCategories, createCategory, updateCategory, mergeCategory, deleteCategory,
-    resolveCategoryName, resolveCategoryForSearch,
+    resolveCategoryName, resolveCategoryForSearch, resolveCategoryForInstagram,
   };
 }
 

--- a/backend/src/services/redeemOps/discovery/normalizers.js
+++ b/backend/src/services/redeemOps/discovery/normalizers.js
@@ -62,6 +62,37 @@ function pruneMapsRaw(raw) {
   return rest;
 }
 
+/**
+ * Apify Instagram hashtag post → the authoring account's identity plus the text
+ * the territory soft-filter reads. Requires BOTH the username and the numeric
+ * owner id: the id is the pilot's namespaced candidate key ('ig:<ownerId>'), so
+ * a post without it cannot be idempotently materialized and is dropped.
+ */
+export function normalizeInstagramHashtagPost(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const ownerUsername = normalizeHandle(raw.ownerUsername || null);
+  const ownerId = raw.ownerId == null ? null : String(raw.ownerId).trim();
+  if (!ownerUsername || !ownerId) return null;
+  return {
+    ownerUsername: trunc(ownerUsername, 64),
+    ownerId,
+    ownerFullName: raw.ownerFullName ? String(raw.ownerFullName).trim() || null : null,
+    caption: typeof raw.caption === 'string' ? raw.caption : null,
+    url: trunc(raw.url || null, 500),
+    locationName: raw.locationName ? String(raw.locationName) : null,
+  };
+}
+
+/** Hashtag-post payload pruning (pruneMapsRaw analog) — IG posts carry far more
+ *  per-item weight: image variants, carousel children, comment threads, music. */
+export function pruneInstagramHashtagRaw(raw) {
+  const rest = { ...(raw || {}) };
+  for (const k of ['images', 'childPosts', 'latestComments', 'musicInfo']) {
+    delete rest[k];
+  }
+  return rest;
+}
+
 const EMAIL_RE = /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/i;
 
 /** Pull an email out of an IG bio (best-effort, low confidence — not a structured field). */

--- a/backend/src/services/redeemOps/discoveryService.js
+++ b/backend/src/services/redeemOps/discoveryService.js
@@ -9,7 +9,10 @@ import { makeCategoryService } from './categoryService.js';
 import { makeDiscoveryUsageService } from './discoveryUsageService.js';
 import { makeDedupeService } from './dedupeService.js';
 import { makeApifyClient } from './discovery/apifyClient.js';
-import { normalizeMapsItem, normalizeInstagramItem, isSingaporeMapsItem } from './discovery/normalizers.js';
+import {
+  normalizeMapsItem, normalizeInstagramItem, isSingaporeMapsItem,
+  normalizeInstagramHashtagPost, pruneInstagramHashtagRaw,
+} from './discovery/normalizers.js';
 import { normalizeBusinessName, normalizeDomain, normalizeHandle } from './normalizers.js';
 import { normalizePhone } from '../prospectHelpers.js';
 import { sgDateKey, sgtDayWindow } from './taskService.js';
@@ -19,6 +22,9 @@ const TERMINAL = ['completed', 'failed', 'aborted', 'timed_out'];
 export function cfg() {
   return {
     enabled: process.env.DISCOVERY_ENABLED === 'true',
+    // Pilot kill switch for the Instagram hashtag provider (spike doc: unofficial,
+    // revocable dependency) — Maps stays the primary/fallback source when off.
+    igEnabled: process.env.DISCOVERY_IG_ENABLED === 'true',
     searchTermsEnabled: process.env.DISCOVERY_SEARCH_TERMS_ENABLED === 'true',
     territoriesEnabled: process.env.DISCOVERY_TERRITORIES_ENABLED === 'true',
     resultQuotaEnabled: process.env.DISCOVERY_RESULT_QUOTA_ENABLED === 'true',
@@ -27,6 +33,9 @@ export function cfg() {
     // `usernames` input (wants directUrls), so every enrichment run came back
     // empty and all targets were marked failed (live incident, 2026-07-12).
     igActor: process.env.APIFY_INSTAGRAM_ACTOR_ID || 'apify~instagram-profile-scraper',
+    // Hashtag DISCOVERY actor (posts by hashtag) — a third actor, distinct from
+    // both the Maps crawler and the profile-enrichment scraper above.
+    igHashtagActor: process.env.APIFY_INSTAGRAM_HASHTAG_ACTOR_ID || 'apify~instagram-hashtag-scraper',
     webhookSecret: process.env.DISCOVERY_WEBHOOK_SECRET || '',
     webhookBase: process.env.DISCOVERY_WEBHOOK_BASE_URL || 'https://api.mktr.sg',
     // 500 ≈ one whole-Singapore sweep of a dense category (nail/hair/café) in a
@@ -53,6 +62,12 @@ export function cfg() {
 const COUNTS_TOWARD_QUOTA = {
   [Op.not]: { [Op.and]: [{ status: 'failed' }, { providerRunId: null }] },
 };
+
+/** Both DISCOVERY providers spend from the SAME daily search budget (run counts
+ *  here; the Phase-3 result counters are provider-agnostic by construction).
+ *  apify_instagram (profile ENRICHMENT) stays outside — it is metered in
+ *  profiles, not searches. */
+const DISCOVERY_PROVIDERS = ['apify_google_maps', 'apify_instagram_hashtag'];
 
 export function makeDiscoveryService(overrides = {}) {
   const d = {
@@ -84,7 +99,7 @@ export function makeDiscoveryService(overrides = {}) {
   async function assertQuota(user) {
     const c = cfg();
     const { start: since } = sgtDayWindow();
-    const base = { provider: 'apify_google_maps', createdAt: { [Op.gte]: since }, ...COUNTS_TOWARD_QUOTA };
+    const base = { provider: { [Op.in]: DISCOVERY_PROVIDERS }, createdAt: { [Op.gte]: since }, ...COUNTS_TOWARD_QUOTA };
     const [mine, all] = await Promise.all([
       d.DiscoveryRun.count({ where: { ...base, createdBy: user.id } }),
       d.DiscoveryRun.count({ where: base }),
@@ -117,7 +132,7 @@ export function makeDiscoveryService(overrides = {}) {
     const { start: since } = sgtDayWindow();
     const used = await d.DiscoveryRun.count({
       where: {
-        provider: 'apify_google_maps', createdBy: user.id,
+        provider: { [Op.in]: DISCOVERY_PROVIDERS }, createdBy: user.id,
         createdAt: { [Op.gte]: since }, ...COUNTS_TOWARD_QUOTA,
       },
     });
@@ -172,33 +187,50 @@ export function makeDiscoveryService(overrides = {}) {
   }
 
   // ── Start a discovery search ───────────────────────────────────────────
-  async function startDiscovery({ category, area, limit }, user, requestId = null) {
+  /** `provider` selects the mechanism ('google_maps' default | 'instagram_hashtag'
+   *  pilot); Category + Territory stay the operator picks either way. */
+  async function startDiscovery({ category, area, limit, provider = 'google_maps' }, user, requestId = null) {
     assertEnabled();
+    const isInstagram = provider === 'instagram_hashtag';
+    if (!isInstagram && provider !== 'google_maps') {
+      throw new AppError(`Unknown provider '${provider}'`, 400);
+    }
+    if (isInstagram && !cfg().igEnabled) {
+      throw new AppError('Instagram discovery is not enabled', 503);
+    }
     if (!category || !String(category).trim()) throw new AppError('Category is required', 400);
     if (!area || !String(area).trim()) throw new AppError('Area is required', 400);
     // Fail fast on an unknown/inactive category (422) BEFORE any run row or Apify
     // spend — otherwise every add-to-pipeline would fail after the money was paid.
     // Stores the taxonomy's canonical casing so add-time createPartner re-validation
-    // can only fail on the (rare) delete-category-mid-run race.
-    const { name: canonicalCategory, searchTerms } = await d.categories.resolveCategoryForSearch(
-      String(category).trim()
-    );
+    // can only fail on the (rare) delete-category-mid-run race. The IG resolver
+    // additionally 422s when the category has no curated hashtags.
+    const resolved = isInstagram
+      ? await d.categories.resolveCategoryForInstagram(String(category).trim())
+      : await d.categories.resolveCategoryForSearch(String(category).trim());
+    const canonicalCategory = resolved.name;
     const c = cfg();
     if (!c.resultQuotaEnabled) await assertQuota(user);
     const requestedLimit = Math.min(Math.max(Number(limit) || 60, 1), c.maxResultsPerRun);
-    const searchTermsUsed = c.searchTermsEnabled ? searchTerms : [canonicalCategory];
+    const searchTermsUsed = isInstagram ? null
+      : (c.searchTermsEnabled ? resolved.searchTerms : [canonicalCategory]);
     // The Maps actor applies this cap to EACH search string, so divide the
     // requested total across aliases to avoid multiplying crawl cost by N.
-    const perSearchLimit = c.searchTermsEnabled
+    const perSearchLimit = isInstagram ? null : (c.searchTermsEnabled
       ? Math.max(1, Math.floor(requestedLimit / searchTermsUsed.length))
-      : requestedLimit;
+      : requestedLimit);
 
     const runValues = {
-      createdBy: user.id, provider: 'apify_google_maps',
+      createdBy: user.id, provider: isInstagram ? 'apify_instagram_hashtag' : 'apify_google_maps',
       category: canonicalCategory, area: String(area).trim(),
       requestedLimit, status: 'pending',
       estimatedCostUsd: Number((requestedLimit * c.costPerResultUsd).toFixed(4)),
     };
+    // IG runs snapshot the fired hashtags + territory so materialization's soft
+    // filter and the UI never re-resolve the category (it may be edited mid-run).
+    const igPayload = isInstagram
+      ? { hashtags: resolved.hashtags, territory: runValues.area }
+      : null;
     let run;
     if (c.resultQuotaEnabled) {
       const sgDate = sgDateKey();
@@ -210,31 +242,42 @@ export function makeDiscoveryService(overrides = {}) {
           transaction,
         });
         return d.DiscoveryRun.create(
-          { ...runValues, rawPayload: { dailyUsageReservation: reservation } },
+          { ...runValues, rawPayload: { ...(igPayload || {}), dailyUsageReservation: reservation } },
           { transaction },
         );
       });
     } else {
-      run = await d.DiscoveryRun.create(runValues);
+      run = await d.DiscoveryRun.create(igPayload ? { ...runValues, rawPayload: igPayload } : runValues);
     }
 
     let providerStarted = false;
     try {
-      // Geo-anchored search: the area goes in locationQuery (the actor geocodes
-      // it and crawls that polygon), NOT concatenated into the search string —
-      // "Beauty Tampines" as free text let the crawler pad the result budget
-      // with global brand matches (Sephora New York/Oshawa/Edmonton, 2026-07-12).
-      const isAllSg = /^all\s+singapore$/i.test(String(run.area).trim());
-      const locationQuery = isAllSg ? 'Singapore'
-        : (/\bsingapore\b/i.test(run.area) ? run.area : `${run.area}, Singapore`);
-      const input = {
-        searchStringsArray: searchTermsUsed,
-        locationQuery,
-        maxCrawledPlacesPerSearch: perSearchLimit,
-        language: 'en',
-        scrapeContacts: true, // enables the instagrams/social arrays
-      };
-      const started = await d.apify.startRun(c.mapsActor, input, { webhookUrl: webhookUrl() });
+      let actorId;
+      let input;
+      if (isInstagram) {
+        // The hashtag scraper's whole contract is hashtags + a post budget; every
+        // richer filter is applied by US post-scrape (spike doc: "rich parameters"
+        // = a good filter UI over a simple scrape, not actor config).
+        actorId = c.igHashtagActor;
+        input = { hashtags: resolved.hashtags, resultsLimit: requestedLimit };
+      } else {
+        // Geo-anchored search: the area goes in locationQuery (the actor geocodes
+        // it and crawls that polygon), NOT concatenated into the search string —
+        // "Beauty Tampines" as free text let the crawler pad the result budget
+        // with global brand matches (Sephora New York/Oshawa/Edmonton, 2026-07-12).
+        const isAllSg = /^all\s+singapore$/i.test(String(run.area).trim());
+        const locationQuery = isAllSg ? 'Singapore'
+          : (/\bsingapore\b/i.test(run.area) ? run.area : `${run.area}, Singapore`);
+        actorId = c.mapsActor;
+        input = {
+          searchStringsArray: searchTermsUsed,
+          locationQuery,
+          maxCrawledPlacesPerSearch: perSearchLimit,
+          language: 'en',
+          scrapeContacts: true, // enables the instagrams/social arrays
+        };
+      }
+      const started = await d.apify.startRun(actorId, input, { webhookUrl: webhookUrl() });
       providerStarted = true;
       await run.update({ providerRunId: started.runId, providerDatasetId: started.datasetId || null, status: 'running', startedAt: new Date() });
     } catch (err) {
@@ -262,7 +305,9 @@ export function makeDiscoveryService(overrides = {}) {
       entityId: run.id,
       after: {
         category: run.category, area: run.area, requestedLimit,
-        searchTerms: searchTermsUsed,
+        ...(isInstagram
+          ? { provider: 'apify_instagram_hashtag', hashtags: resolved.hashtags }
+          : { searchTerms: searchTermsUsed }),
       },
       requestId,
     });
@@ -302,6 +347,8 @@ export function makeDiscoveryService(overrides = {}) {
     const items = await d.apify.getDatasetItems(info.datasetId, { limit: run.requestedLimit });
     if (run.provider === 'apify_instagram') {
       await applyEnrichment(run, items);
+    } else if (run.provider === 'apify_instagram_hashtag') {
+      await materializeInstagramHashtagCandidates(run, items);
     } else {
       await materializeCandidates(run, items);
     }
@@ -314,6 +361,58 @@ export function makeDiscoveryService(overrides = {}) {
   async function materializeCandidates(run, items) {
     // Singapore-only: foreign-labelled items never become candidates (geo guard).
     const rows = items.filter(isSingaporeMapsItem).map(normalizeMapsItem).filter((r) => r && r.name);
+    await insertAndClassifyCandidates(run, rows);
+  }
+
+  /**
+   * Instagram hashtag posts → DISTINCT authoring accounts (a business posts many
+   * times; each account becomes ONE candidate). Pilot identity shortcut: the
+   * account is keyed into the existing externalPlaceId column as
+   * 'ig:<numericUserId>', so the (run, place) unique index, place memory and
+   * partner dedupe reuse the Maps machinery unchanged — the (source, kind,
+   * externalId) generalisation is deferred to productionisation (spike doc §
+   * Engineering shape). Territory is a SOFT filter (IG has no coordinates): a
+   * specific territory keeps only accounts whose profile-name/caption/location-tag
+   * text mentions it; All-Singapore keeps everything — the SG signal comes from
+   * the SG-flavoured hashtags themselves.
+   */
+  async function materializeInstagramHashtagCandidates(run, items) {
+    const accounts = new Map(); // handle → { row, matchText }
+    for (const raw of items) {
+      const post = normalizeInstagramHashtagPost(raw);
+      if (!post) continue; // no username or no owner id → not materializable
+      let acc = accounts.get(post.ownerUsername);
+      if (!acc) {
+        acc = {
+          row: {
+            externalPlaceId: `ig:${post.ownerId}`.slice(0, 128),
+            name: (post.ownerFullName || post.ownerUsername).slice(0, 200),
+            instagramHandle: post.ownerUsername,
+            sourceUrl: `https://instagram.com/${post.ownerUsername}`,
+            enrichmentStatus: 'none',
+            // Contact = handle + bio only on this path; enrichment fills the rest.
+            rawPayload: pruneInstagramHashtagRaw(raw),
+          },
+          matchText: '',
+        };
+        accounts.set(post.ownerUsername, acc);
+      }
+      // Aggregate across ALL of the account's posts — any one mentioning the
+      // territory keeps the account.
+      acc.matchText += ` ${post.ownerFullName || ''} ${post.caption || ''} ${post.locationName || ''}`.toLowerCase();
+    }
+    const territory = String(run.area || '').trim();
+    const applyTerritory = territory && !/^all\s+singapore$/i.test(territory);
+    const needle = territory.toLowerCase();
+    const rows = [...accounts.values()]
+      .filter((a) => !applyTerritory || a.matchText.includes(needle))
+      .map((a) => a.row);
+    await insertAndClassifyCandidates(run, rows);
+  }
+
+  /** Shared materialization tail — both providers land here so dedupe stays in
+   *  exactly one place. */
+  async function insertAndClassifyCandidates(run, rows) {
     if (rows.length === 0) return;
     // Idempotent insert — the (discoveryRunId, externalPlaceId) unique index makes
     // a duplicate webhook / reconcile a no-op.
@@ -786,8 +885,9 @@ export function makeDiscoveryService(overrides = {}) {
 
   // ── Reads for the UI ───────────────────────────────────────────────────
   async function listRuns({ limit = 20 } = {}) {
+    // Both discovery providers list; apify_instagram ENRICHMENT runs stay hidden.
     return d.DiscoveryRun.findAll({
-      where: { provider: 'apify_google_maps' },
+      where: { provider: { [Op.in]: DISCOVERY_PROVIDERS } },
       order: [['createdAt', 'DESC']], limit,
     });
   }
@@ -938,7 +1038,8 @@ export function makeDiscoveryService(overrides = {}) {
     startDiscovery, processRun, processByProviderRunId, enrichCandidates, addToPartners,
     dismissCandidate, restoreCandidate, listRuns, getRunWithCandidates, getQuota,
     reconcileStuckRuns, purgeExpiredCandidates,
-    verifyWebhookSecret, classifyAgainstPartners, materializeCandidates, applyEnrichment,
+    verifyWebhookSecret, classifyAgainstPartners, materializeCandidates,
+    materializeInstagramHashtagCandidates, applyEnrichment,
     applyPlaceMemory, buildMemoryEnrichment,
   };
 }

--- a/backend/test/redeemOpsDiscoveryInstagram.test.js
+++ b/backend/test/redeemOpsDiscoveryInstagram.test.js
@@ -1,0 +1,430 @@
+/**
+ * Redeem Ops Discover — Instagram hashtag-discovery pilot (DB-backed, Apify
+ * mocked; DISCOVERY_IG_ENABLED). Covers: category hashtag curation (create/
+ * update cleaning, resolveCategoryForInstagram 422), flag gating (503) +
+ * provider validation, IG run start (actor/input/snapshot/canonical casing),
+ * post→distinct-account materialization on the namespaced 'ig:<ownerId>'
+ * externalPlaceId (idempotent re-materialization, pruned rawPayload, place
+ * memory birth), the territory soft filter (specific town vs All Singapore),
+ * partner dedupe by handle, profile enrichment on an IG candidate, the shared
+ * cross-provider search quota, and the provider-default Maps path staying
+ * byte-identical (input + run shape).
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+process.env.DISCOVERY_ENABLED = 'true';
+process.env.DISCOVERY_IG_ENABLED = 'true';
+process.env.DISCOVERY_WEBHOOK_SECRET = 'test-secret';
+
+import { jest } from '@jest/globals';
+import { getApp, closeDb, createTestUser, seedRedeemOpsCategory } from './helpers.js';
+import { makeDiscoveryService } from '../src/services/redeemOps/discoveryService.js';
+import { makeCategoryService } from '../src/services/redeemOps/categoryService.js';
+import { makePartnerService } from '../src/services/redeemOps/partnerService.js';
+import {
+  DiscoveryRun, DiscoveryCandidate, DiscoveryPlaceMemory, RedeemOpsAuditEvent,
+} from '../src/models/index.js';
+
+let admin;
+const partners = makePartnerService();
+const categories = makeCategoryService();
+
+function makeApifyStub() {
+  return { startRun: jest.fn(), getRun: jest.fn(), getDatasetItems: jest.fn() };
+}
+
+beforeAll(async () => {
+  await getApp(); // boots + syncs the test DB (no HTTP calls in this suite)
+  admin = await createTestUser({ role: 'admin' });
+});
+
+afterAll(async () => { await closeDb(); });
+
+// Same leak-proofing as the sibling suite: snapshot DISCOVERY_* after this
+// file's own env sets, restore after every test.
+const DISCOVERY_ENV_SNAPSHOT = Object.fromEntries(
+  Object.entries(process.env).filter(([k]) => k.startsWith('DISCOVERY_')),
+);
+afterEach(() => {
+  for (const k of Object.keys(process.env)) {
+    if (k.startsWith('DISCOVERY_')) delete process.env[k];
+  }
+  Object.assign(process.env, DISCOVERY_ENV_SNAPSHOT);
+});
+
+let runIdSeq = 0;
+const uniqueRunId = () => ({ runId: `igrun_${Date.now()}_${++runIdSeq}`, datasetId: 'ds1', status: 'RUNNING' });
+
+// IG owner ids feed the GLOBAL place-memory table ('ig:<ownerId>' keys, shared
+// DB) — every test mints fresh ids/handles or memory assertions become
+// order-dependent (same discipline as uniquePlaceId in the sibling suite).
+let igSeq = 0;
+const uniqueOwner = (prefix = 'igbiz') => {
+  igSeq += 1;
+  return { ownerId: `${Date.now()}${igSeq}`, ownerUsername: `${prefix}${igSeq}.sg` };
+};
+
+/** Apify instagram-hashtag-scraper post item (heavy fields included so pruning is observable). */
+const post = (over = {}) => ({
+  ownerUsername: 'someone.sg',
+  ownerId: '0',
+  ownerFullName: 'Someone SG',
+  caption: 'Fresh BIAB set — DM to book #sgnails',
+  url: 'https://www.instagram.com/p/AAA/',
+  locationName: null,
+  hashtags: ['sgnails'],
+  images: ['https://cdn.example/one.jpg'],
+  childPosts: [{ id: 'child1' }],
+  latestComments: [{ text: 'so pretty!' }],
+  musicInfo: { song_name: 'x' },
+  ...over,
+});
+
+async function seedIgCategory(igHashtags = ['sgnails', 'nailsg']) {
+  const name = `IG Nails ${Date.now()}_${++igSeq}`;
+  await seedRedeemOpsCategory(name, { igHashtags });
+  return name;
+}
+
+describe('category hashtag curation', () => {
+  test('createCategory cleans hashtags: # stripped, lowercased, deduped, blanks dropped', async () => {
+    const category = await categories.createCategory(
+      { name: `Tag Clean ${Date.now()}_${++igSeq}`, igHashtags: ['#SGNails', 'sgnails', '   ', '#nailsg', '#', '# BiabSG '] },
+      admin.user,
+    );
+    expect(category.igHashtags).toEqual(['sgnails', 'nailsg', 'biabsg']);
+  });
+
+  test('resolveCategoryForInstagram → 422 when the category has no hashtags; search resolver unaffected', async () => {
+    const name = `No Tags ${Date.now()}_${++igSeq}`;
+    await seedRedeemOpsCategory(name);
+    await expect(categories.resolveCategoryForInstagram(name)).rejects.toMatchObject({
+      statusCode: 422,
+      message: expect.stringContaining('has no Instagram hashtags'),
+    });
+    // The Maps resolver keeps its name fallback — untouched by the pilot.
+    await expect(categories.resolveCategoryForSearch(name)).resolves.toEqual({
+      name, searchTerms: [name],
+    });
+  });
+
+  test('emptying igHashtags on update stores NULL and turns the IG resolver off again', async () => {
+    const category = await categories.createCategory(
+      { name: `Tag Empty ${Date.now()}_${++igSeq}`, igHashtags: ['#keepme'] },
+      admin.user,
+    );
+    await categories.updateCategory(category.id, { igHashtags: [] }, admin.user);
+    await category.reload();
+    expect(category.igHashtags).toBeNull();
+    await expect(categories.resolveCategoryForInstagram(category.name))
+      .rejects.toMatchObject({ statusCode: 422 });
+  });
+});
+
+describe('flag + provider gating', () => {
+  test('unknown provider → 400 before any run row or Apify call', async () => {
+    const apify = makeApifyStub();
+    const svc = makeDiscoveryService({ apify });
+    const before = await DiscoveryRun.count();
+    await expect(svc.startDiscovery(
+      { category: 'whatever', area: 'Tampines', limit: 10, provider: 'tiktok' }, admin.user,
+    )).rejects.toMatchObject({ statusCode: 400 });
+    expect(await DiscoveryRun.count()).toBe(before);
+    expect(apify.startRun).not.toHaveBeenCalled();
+  });
+
+  test('DISCOVERY_IG_ENABLED off → 503 (kill switch), Maps default unaffected', async () => {
+    delete process.env.DISCOVERY_IG_ENABLED;
+    const category = await seedIgCategory();
+    const apify = makeApifyStub();
+    const svc = makeDiscoveryService({ apify });
+    const solo = await createTestUser({ role: 'admin' });
+    const before = await DiscoveryRun.count();
+    await expect(svc.startDiscovery(
+      { category, area: 'All Singapore', limit: 10, provider: 'instagram_hashtag' }, solo.user,
+    )).rejects.toMatchObject({ statusCode: 503 });
+    expect(await DiscoveryRun.count()).toBe(before);
+    expect(apify.startRun).not.toHaveBeenCalled();
+    // The Maps path still starts with the pilot flag off.
+    apify.startRun.mockImplementation(async () => uniqueRunId());
+    const run = await svc.startDiscovery({ category, area: 'Tampines', limit: 5 }, solo.user);
+    expect(run.provider).toBe('apify_google_maps');
+  });
+
+  test('IG search on a category without hashtags → 422 before any run row or spend', async () => {
+    const name = `IG No Tags ${Date.now()}_${++igSeq}`;
+    await seedRedeemOpsCategory(name);
+    const apify = makeApifyStub();
+    const svc = makeDiscoveryService({ apify });
+    const before = await DiscoveryRun.count();
+    await expect(svc.startDiscovery(
+      { category: name, area: 'All Singapore', limit: 10, provider: 'instagram_hashtag' }, admin.user,
+    )).rejects.toMatchObject({ statusCode: 422 });
+    expect(await DiscoveryRun.count()).toBe(before);
+    expect(apify.startRun).not.toHaveBeenCalled();
+  });
+});
+
+describe('IG run start', () => {
+  test('starts the hashtag actor with { hashtags, resultsLimit } and snapshots the run', async () => {
+    const category = await seedIgCategory(['sgnails', 'homebasednailssg']);
+    const apify = makeApifyStub();
+    const svc = makeDiscoveryService({ apify });
+    const solo = await createTestUser({ role: 'admin' });
+    apify.startRun.mockImplementation(async () => uniqueRunId());
+
+    const run = await svc.startDiscovery(
+      { category: category.toLowerCase(), area: 'All Singapore', limit: 40, provider: 'instagram_hashtag' },
+      solo.user,
+    );
+
+    expect(apify.startRun).toHaveBeenCalledTimes(1);
+    const [actorId, input, opts] = apify.startRun.mock.calls[0];
+    expect(actorId).toBe('apify~instagram-hashtag-scraper');
+    expect(input).toEqual({ hashtags: ['sgnails', 'homebasednailssg'], resultsLimit: 40 });
+    expect(opts.webhookUrl).toContain('test-secret');
+
+    expect(run.provider).toBe('apify_instagram_hashtag');
+    expect(run.category).toBe(category); // canonical taxonomy casing
+    expect(run.area).toBe('All Singapore');
+    expect(run.status).toBe('running');
+    expect(run.rawPayload).toEqual({ hashtags: ['sgnails', 'homebasednailssg'], territory: 'All Singapore' });
+
+    const audit = await RedeemOpsAuditEvent.findOne({
+      where: { action: 'discovery.run_started', entityId: run.id },
+    });
+    expect(audit.after.provider).toBe('apify_instagram_hashtag');
+    expect(audit.after.hashtags).toEqual(['sgnails', 'homebasednailssg']);
+  });
+});
+
+describe('materialization — posts collapse to distinct accounts', () => {
+  test('6 posts from 2 owners → 2 candidates with ig:-namespaced ids (idempotent, pruned payloads)', async () => {
+    const category = await seedIgCategory();
+    const apify = makeApifyStub();
+    const svc = makeDiscoveryService({ apify });
+    const solo = await createTestUser({ role: 'admin' });
+    apify.startRun.mockImplementation(async () => uniqueRunId());
+
+    const a = uniqueOwner('juicyclawz');
+    const b = uniqueOwner('aprilcollective');
+    const sixPosts = [
+      post({ ...a, ownerFullName: 'Juicy Clawz SG', url: 'https://www.instagram.com/p/A1/' }),
+      post({ ...a, ownerFullName: 'Juicy Clawz SG', caption: 'Cat-eye chrome set #nailsg', url: 'https://www.instagram.com/p/A2/' }),
+      post({ ...a, ownerFullName: 'Juicy Clawz SG', url: 'https://www.instagram.com/p/A3/' }),
+      post({ ...a, ownerFullName: 'Juicy Clawz SG', url: 'https://www.instagram.com/p/A4/' }),
+      post({ ...b, ownerFullName: 'April Collective', url: 'https://www.instagram.com/p/B1/' }),
+      post({ ...b, ownerFullName: 'April Collective', url: 'https://www.instagram.com/p/B2/' }),
+      // Not materializable — no owner id / no username / junk.
+      post({ ownerUsername: 'noid.sg', ownerId: null }),
+      { caption: 'no owner at all' },
+    ];
+
+    const run = await svc.startDiscovery(
+      { category, area: 'All Singapore', limit: 60, provider: 'instagram_hashtag' }, solo.user,
+    );
+    apify.getRun.mockResolvedValue({
+      runId: run.providerRunId, status: 'SUCCEEDED', datasetId: 'ds1',
+      usageTotalUsd: 0.02, terminalStatus: 'completed',
+    });
+    apify.getDatasetItems.mockResolvedValue(sixPosts);
+
+    await svc.processRun(run.id);
+    await svc.processRun(run.id); // terminal early-return (idempotent)
+    await run.reload();
+    expect(run.status).toBe('completed');
+    expect(run.resultCount).toBe(8); // budget counts POSTS scanned, not accounts
+
+    // Re-materializing the same dataset directly must be an index-level no-op.
+    await svc.materializeInstagramHashtagCandidates(run, sixPosts);
+
+    const cands = await DiscoveryCandidate.findAll({
+      where: { discoveryRunId: run.id }, order: [['name', 'ASC']],
+    });
+    expect(cands).toHaveLength(2);
+
+    const april = cands.find((x) => x.instagramHandle === b.ownerUsername);
+    const juicy = cands.find((x) => x.instagramHandle === a.ownerUsername);
+    expect(juicy.externalPlaceId).toBe(`ig:${a.ownerId}`);
+    expect(april.externalPlaceId).toBe(`ig:${b.ownerId}`);
+    expect(juicy.name).toBe('Juicy Clawz SG');
+    expect(juicy.sourceUrl).toBe(`https://instagram.com/${a.ownerUsername}`);
+    expect(juicy.enrichmentStatus).toBe('none');
+    expect(juicy.primaryPhone).toBeNull();
+    expect(juicy.address).toBeNull();
+    expect(juicy.rating).toBeNull();
+    // Heavy arrays pruned; the useful post context kept.
+    expect(juicy.rawPayload.images).toBeUndefined();
+    expect(juicy.rawPayload.childPosts).toBeUndefined();
+    expect(juicy.rawPayload.latestComments).toBeUndefined();
+    expect(juicy.rawPayload.musicInfo).toBeUndefined();
+    expect(juicy.rawPayload.caption).toContain('BIAB');
+
+    // Place memory born on the namespaced key; the same-run re-materialization
+    // above must not have inflated the sighting count.
+    const mem = await DiscoveryPlaceMemory.findByPk(`ig:${a.ownerId}`);
+    expect(mem).not.toBeNull();
+    expect(mem.timesSeen).toBe(1);
+  });
+});
+
+describe('territory soft filter', () => {
+  const mkIgRun = (area) => DiscoveryRun.create({
+    createdBy: admin.user.id, provider: 'apify_instagram_hashtag', status: 'running',
+    area, requestedLimit: 30,
+  });
+
+  test('a specific territory keeps only accounts mentioning it (name/caption/location)', async () => {
+    const svc = makeDiscoveryService({ apify: makeApifyStub() });
+    const viaCaption = uniqueOwner('capmention');
+    const viaLocation = uniqueOwner('locmention');
+    const viaFullName = uniqueOwner('namemention');
+    const noMention = uniqueOwner('nomention');
+    const items = [
+      post({ ...viaCaption, caption: 'Home studio in woodlands! DM to book' }),
+      post({ ...viaLocation, caption: 'New set!', locationName: 'Woodlands Mart' }),
+      post({ ...viaFullName, ownerFullName: 'Nails by Kim (Woodlands)', caption: 'Chrome francais' }),
+      post({ ...noMention, caption: 'Tampines girlies come thru', locationName: 'Tampines Hub' }),
+    ];
+
+    const run = await mkIgRun('Woodlands');
+    await svc.materializeInstagramHashtagCandidates(run, items);
+    const kept = (await DiscoveryCandidate.findAll({ where: { discoveryRunId: run.id } }))
+      .map((x) => x.instagramHandle).sort();
+    expect(kept).toEqual([
+      viaCaption.ownerUsername, viaLocation.ownerUsername, viaFullName.ownerUsername,
+    ].sort());
+  });
+
+  test('any one of an account\'s posts mentioning the territory keeps the account', async () => {
+    const svc = makeDiscoveryService({ apify: makeApifyStub() });
+    const owner = uniqueOwner('multipost');
+    const run = await mkIgRun('Yishun');
+    await svc.materializeInstagramHashtagCandidates(run, [
+      post({ ...owner, caption: 'nothing geographic here' }),
+      post({ ...owner, caption: 'Based in YISHUN, islandwide mobile' }),
+    ]);
+    expect(await DiscoveryCandidate.count({ where: { discoveryRunId: run.id } })).toBe(1);
+  });
+
+  test('All Singapore (and a blank legacy area) keep every account', async () => {
+    const svc = makeDiscoveryService({ apify: makeApifyStub() });
+    const one = uniqueOwner('allsg');
+    const two = uniqueOwner('allsg');
+    const items = [
+      post({ ...one, caption: 'no town named' }),
+      post({ ...two, caption: 'also no town', locationName: null }),
+    ];
+    const runAll = await mkIgRun('All Singapore');
+    await svc.materializeInstagramHashtagCandidates(runAll, items);
+    expect(await DiscoveryCandidate.count({ where: { discoveryRunId: runAll.id } })).toBe(2);
+
+    const runBlank = await mkIgRun(null);
+    await svc.materializeInstagramHashtagCandidates(runBlank, items);
+    expect(await DiscoveryCandidate.count({ where: { discoveryRunId: runBlank.id } })).toBe(2);
+  });
+});
+
+describe('partner dedupe by handle', () => {
+  test('an account whose handle matches an existing partner classifies existing_partner', async () => {
+    const svc = makeDiscoveryService({ apify: makeApifyStub() });
+    const owner = uniqueOwner('dupehandle');
+    const { partner } = await partners.createPartner(
+      { tradingName: `Handle Dup Nails ${igSeq}`, instagramHandle: owner.ownerUsername },
+      admin.user,
+    );
+    const run = await DiscoveryRun.create({
+      createdBy: admin.user.id, provider: 'apify_instagram_hashtag', status: 'running',
+      area: 'All Singapore', requestedLimit: 10,
+    });
+    await svc.materializeInstagramHashtagCandidates(run, [post(owner)]);
+    const cand = await DiscoveryCandidate.findOne({ where: { discoveryRunId: run.id } });
+    expect(cand.dedupeStatus).toBe('existing_partner');
+    expect(cand.matchedPartnerId).toBe(partner.id);
+  });
+});
+
+describe('profile enrichment on an IG candidate', () => {
+  test('enrichCandidates claims the handle, and applyEnrichment fills metrics + handle-keyed memory', async () => {
+    const apify = makeApifyStub();
+    const svc = makeDiscoveryService({ apify });
+    const owner = uniqueOwner('enrichig');
+    const run = await DiscoveryRun.create({
+      createdBy: admin.user.id, provider: 'apify_instagram_hashtag', status: 'completed',
+      area: 'All Singapore', requestedLimit: 10,
+    });
+    await svc.materializeInstagramHashtagCandidates(run, [post(owner)]);
+    const cand = await DiscoveryCandidate.findOne({ where: { discoveryRunId: run.id } });
+
+    apify.startRun.mockImplementation(async () => uniqueRunId());
+    const enrichRun = await svc.enrichCandidates([cand.id], admin.user);
+    expect(apify.startRun.mock.calls[0][0]).toBe('apify~instagram-profile-scraper');
+    expect(apify.startRun.mock.calls[0][1]).toEqual({ usernames: [owner.ownerUsername] });
+
+    await svc.applyEnrichment(enrichRun, [{
+      username: owner.ownerUsername, followersCount: 4321,
+      biography: 'Home-based nail studio — hello@enrich.sg', verified: false,
+    }]);
+    await cand.reload();
+    expect(cand.enrichmentStatus).toBe('enriched');
+    expect(cand.followersCount).toBe(4321);
+    expect(cand.isVerified).toBe(false);
+    expect(cand.email).toBe('hello@enrich.sg');
+
+    const mem = await DiscoveryPlaceMemory.findByPk(`ig:${owner.ownerId}`);
+    expect(mem.lastEnrichment).toMatchObject({
+      handle: owner.ownerUsername, followersCount: 4321,
+    });
+  });
+});
+
+describe('shared search quota across providers', () => {
+  test('IG runs spend from the same per-user daily search budget as Maps', async () => {
+    process.env.DISCOVERY_MAX_RUNS_PER_USER_DAY = '2';
+    const category = await seedIgCategory();
+    const apify = makeApifyStub();
+    const svc = makeDiscoveryService({ apify });
+    const solo = await createTestUser({ role: 'admin' });
+    apify.startRun.mockImplementation(async () => uniqueRunId());
+
+    await svc.startDiscovery({ category, area: 'Tampines', limit: 5 }, solo.user);
+    await svc.startDiscovery({ category, area: 'All Singapore', limit: 5, provider: 'instagram_hashtag' }, solo.user);
+    await expect(svc.startDiscovery({ category, area: 'Bedok', limit: 5 }, solo.user))
+      .rejects.toMatchObject({ statusCode: 429 });
+
+    delete process.env.DISCOVERY_MAX_RUNS_PER_USER_DAY;
+    const quota = await svc.getQuota(solo.user);
+    expect(quota.used).toBe(2); // both providers counted
+  });
+});
+
+describe('provider-default Maps path stays byte-identical', () => {
+  test('omitted provider = legacy Maps input/actor/run shape even when the category has hashtags', async () => {
+    const category = await seedIgCategory(['sgnails']); // IG-ready category must not leak into Maps
+    const apify = makeApifyStub();
+    const svc = makeDiscoveryService({ apify });
+    const solo = await createTestUser({ role: 'admin' });
+    apify.startRun.mockImplementation(async () => uniqueRunId());
+
+    const run = await svc.startDiscovery({ category, area: 'Tampines', limit: 5 }, solo.user);
+
+    const [actorId, input, opts] = apify.startRun.mock.calls[0];
+    expect(actorId).toBe('compass~crawler-google-places');
+    expect(input).toEqual({
+      searchStringsArray: [category],
+      locationQuery: 'Tampines, Singapore',
+      maxCrawledPlacesPerSearch: 5,
+      language: 'en',
+      scrapeContacts: true,
+    });
+    expect(opts.webhookUrl).toContain('test-secret');
+    expect(run.provider).toBe('apify_google_maps');
+    expect(run.rawPayload).toBeNull(); // no IG snapshot on the Maps path
+
+    const audit = await RedeemOpsAuditEvent.findOne({
+      where: { action: 'discovery.run_started', entityId: run.id },
+    });
+    expect(audit.after.searchTerms).toEqual([category]);
+    expect(audit.after.hashtags).toBeUndefined();
+    expect(audit.after.provider).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## IG-hashtag discovery pilot — backend (measured GO from the Phase 5 spike)

Adds a **second discovery provider** — `apify/instagram-hashtag-scraper` — to reach the SG home-based / IG-only businesses Google Maps structurally misses (memo: `docs/plans/redeem-ops-ig-discovery-spike.md`; place/user search was ~94% Google-sourced = 0 novelty; hashtag path = 86% SG, 100% novel).

### Changes
- **Migration 065** `redeem_ops_categories.igHashtags text[]` (nullable, no backfill — a category name isn't a hashtag; `resolveCategoryForInstagram` 422s when empty). IG analog of Phase 2a's `providerSearchTerms`.
- **`startDiscovery`** takes an optional `provider` (`'google_maps'` default | `'instagram_hashtag'` behind `DISCOVERY_IG_ENABLED`, 503 when off — before any run row/Apify call). IG fires `{ hashtags, resultsLimit }`.
- **Materialization** collapses posts → **distinct owner accounts** stored as `externalPlaceId='ig:<numericId>'` (namespaced in the existing column — **no identity-schema refactor**), territory = soft `fullName+caption+location` filter (All-Singapore keeps all), then **reuses the Maps tail verbatim** (partial-unique index → place memory → classifier).
- Run-count quota counts **both** discovery providers; Phase-3 result counters are provider-agnostic already. Enrichment/add/webhook/reconcile/purge reused unchanged.
- `DiscoveryCandidate` model mirrors migration 053's **partial** unique so `sync({force:true})` test DBs still dedup.

### Safety
Ships **dark** — `DISCOVERY_IG_ENABLED=false`. `provider` defaults to `google_maps`; the Maps path (input/actor/run shape, null `rawPayload`) is byte-identical, asserted by a dedicated test.

### Verification (local, pg 5433)
- DB Jest **85/85** — 15 new (`redeemOpsDiscoveryInstagram`) + 70 regression (`redeemOpsDiscovery` + `redeemOpsCategories` + `redeemOpsDiscoveryUsage`), zero regressions.
- Build ✓; ESLint 0 errors.

Frontend (Provider toggle + IG result rendering + filter panel) is the follow-up. 🤖 Generated with [Claude Code](https://claude.com/claude-code)