### PR TITLE
feat(redeem-ops): Discover — ad-hoc terms/hashtags + Maps quality inputs

### DIFF
--- a/backend/src/controllers/redeemOps/discoveryController.js
+++ b/backend/src/controllers/redeemOps/discoveryController.js
@@ -9,6 +9,12 @@ const startSchema = Joi.object({
   limit: Joi.number().integer().min(1).max(500), // sanity bound; service clamps to DISCOVERY_MAX_RESULTS_PER_RUN
   // Mechanism pick; omitted = Maps. The IG pilot additionally needs DISCOVERY_IG_ENABLED.
   provider: Joi.string().valid('google_maps', 'instagram_hashtag'),
+  // Ad-hoc, type-and-go overrides of the category's saved terms/hashtags.
+  searchTerms: Joi.array().items(Joi.string().min(1).max(64)).max(20), // Maps override
+  hashtags: Joi.array().items(Joi.string().min(1).max(64)).max(20), // Instagram override
+  // Maps quality inputs (actor-native — filter before paying). Empty/absent = no filter.
+  minStars: Joi.string().valid('', 'three', 'threeAndHalf', 'four', 'fourAndHalf'),
+  skipClosed: Joi.boolean(),
 });
 const idsSchema = Joi.object({
   // .max(500): each id can become a PAID scrape — sanity-bound to one full run's

--- a/backend/src/services/redeemOps/discoveryService.js
+++ b/backend/src/services/redeemOps/discoveryService.js
@@ -189,7 +189,10 @@ export function makeDiscoveryService(overrides = {}) {
   // ── Start a discovery search ───────────────────────────────────────────
   /** `provider` selects the mechanism ('google_maps' default | 'instagram_hashtag'
    *  pilot); Category + Territory stay the operator picks either way. */
-  async function startDiscovery({ category, area, limit, provider = 'google_maps' }, user, requestId = null) {
+  async function startDiscovery({
+    category, area, limit, provider = 'google_maps',
+    searchTerms: adHocTerms, hashtags: adHocTags, minStars, skipClosed,
+  }, user, requestId = null) {
     assertEnabled();
     const isInstagram = provider === 'instagram_hashtag';
     if (!isInstagram && provider !== 'google_maps') {
@@ -200,25 +203,37 @@ export function makeDiscoveryService(overrides = {}) {
     }
     if (!category || !String(category).trim()) throw new AppError('Category is required', 400);
     if (!area || !String(area).trim()) throw new AppError('Area is required', 400);
+    // Ad-hoc, type-and-go overrides: when the operator supplies their own terms/
+    // hashtags the category becomes just the CRM bucket — its saved terms aren't
+    // needed, so an IG search with ad-hoc tags skips the no-hashtags 422.
+    const cleanList = (a) => (Array.isArray(a)
+      ? [...new Set(a.map((x) => String(x).trim().replace(/^#+/, '')).filter(Boolean))].slice(0, 20)
+      : []);
+    const overrideTerms = cleanList(adHocTerms);
+    const overrideTags = cleanList(adHocTags);
     // Fail fast on an unknown/inactive category (422) BEFORE any run row or Apify
     // spend — otherwise every add-to-pipeline would fail after the money was paid.
     // Stores the taxonomy's canonical casing so add-time createPartner re-validation
     // can only fail on the (rare) delete-category-mid-run race. The IG resolver
-    // additionally 422s when the category has no curated hashtags.
-    const resolved = isInstagram
+    // additionally 422s when the category has no curated hashtags — unless ad-hoc
+    // hashtags were supplied, where name-only resolution suffices.
+    const resolved = (isInstagram && overrideTags.length === 0)
       ? await d.categories.resolveCategoryForInstagram(String(category).trim())
       : await d.categories.resolveCategoryForSearch(String(category).trim());
     const canonicalCategory = resolved.name;
     const c = cfg();
     if (!c.resultQuotaEnabled) await assertQuota(user);
     const requestedLimit = Math.min(Math.max(Number(limit) || 60, 1), c.maxResultsPerRun);
+    const igHashtagsUsed = isInstagram
+      ? (overrideTags.length ? overrideTags : resolved.hashtags)
+      : null;
     const searchTermsUsed = isInstagram ? null
-      : (c.searchTermsEnabled ? resolved.searchTerms : [canonicalCategory]);
-    // The Maps actor applies this cap to EACH search string, so divide the
-    // requested total across aliases to avoid multiplying crawl cost by N.
-    const perSearchLimit = isInstagram ? null : (c.searchTermsEnabled
-      ? Math.max(1, Math.floor(requestedLimit / searchTermsUsed.length))
-      : requestedLimit);
+      : (overrideTerms.length ? overrideTerms
+        : (c.searchTermsEnabled ? resolved.searchTerms : [canonicalCategory]));
+    // The Maps actor applies this cap to EACH search string, so divide the requested
+    // total across terms to avoid multiplying crawl cost by N (a single term = full limit).
+    const perSearchLimit = isInstagram ? null
+      : Math.max(1, Math.floor(requestedLimit / searchTermsUsed.length));
 
     const runValues = {
       createdBy: user.id, provider: isInstagram ? 'apify_instagram_hashtag' : 'apify_google_maps',
@@ -229,7 +244,7 @@ export function makeDiscoveryService(overrides = {}) {
     // IG runs snapshot the fired hashtags + territory so materialization's soft
     // filter and the UI never re-resolve the category (it may be edited mid-run).
     const igPayload = isInstagram
-      ? { hashtags: resolved.hashtags, territory: runValues.area }
+      ? { hashtags: igHashtagsUsed, territory: runValues.area }
       : null;
     let run;
     if (c.resultQuotaEnabled) {
@@ -259,7 +274,7 @@ export function makeDiscoveryService(overrides = {}) {
         // richer filter is applied by US post-scrape (spike doc: "rich parameters"
         // = a good filter UI over a simple scrape, not actor config).
         actorId = c.igHashtagActor;
-        input = { hashtags: resolved.hashtags, resultsLimit: requestedLimit };
+        input = { hashtags: igHashtagsUsed, resultsLimit: requestedLimit };
       } else {
         // Geo-anchored search: the area goes in locationQuery (the actor geocodes
         // it and crawls that polygon), NOT concatenated into the search string —
@@ -275,6 +290,10 @@ export function makeDiscoveryService(overrides = {}) {
           maxCrawledPlacesPerSearch: perSearchLimit,
           language: 'en',
           scrapeContacts: true, // enables the instagrams/social arrays
+          // Actor-native quality filters — added only when set, so the default
+          // (no-filter) input stays byte-identical to before.
+          ...(minStars ? { placeMinimumStars: minStars } : {}),
+          ...(skipClosed ? { skipClosedPlaces: true } : {}),
         };
       }
       const started = await d.apify.startRun(actorId, input, { webhookUrl: webhookUrl() });

--- a/src/pages/redeemops/DiscoverPage.jsx
+++ b/src/pages/redeemops/DiscoverPage.jsx
@@ -69,7 +69,10 @@ const timeAgo = (iso) => {
 
 export default function DiscoverPage() {
   const queryClient = useQueryClient();
-  const [form, setForm] = useState({ category: '', area: '', limit: '30', provider: 'google_maps' });
+  const [form, setForm] = useState({
+    category: '', area: '', limit: '30', provider: 'google_maps',
+    adhoc: '', minStars: 'any', skipClosed: false,
+  });
   const [runId, setRunId] = useState(null);
   const [selected, setSelected] = useState(() => new Set());
   const [filter, setFilter] = useState('all');
@@ -230,10 +233,22 @@ export default function DiscoverPage() {
     },
   });
 
-  const runSearch = (category, area, limit = 30, provider = form.provider) => {
-    if (!category || !String(area).trim()) return;
-    setForm((f) => ({ ...f, category, area, limit: String(limit) }));
-    startMutation.mutate({ category, area: String(area).trim(), limit: Number(limit), provider });
+  const parseCsv = (v) => (v || '').split(',').map((s) => s.trim().replace(/^#+/, '')).filter(Boolean);
+  const runSearch = () => {
+    if (!form.category || !form.area.trim() || startMutation.isPending) return;
+    const body = {
+      category: form.category, area: form.area.trim(),
+      limit: Number(form.limit), provider: form.provider,
+    };
+    const adhoc = parseCsv(form.adhoc); // ad-hoc override of the category's saved terms/hashtags
+    if (isIg) {
+      if (adhoc.length) body.hashtags = adhoc;
+    } else {
+      if (adhoc.length) body.searchTerms = adhoc;
+      if (form.minStars && form.minStars !== 'any') body.minStars = form.minStars;
+      if (form.skipClosed) body.skipClosed = true;
+    }
+    startMutation.mutate(body);
   };
   const toggle = (id) => setSelected((prev) => {
     const next = new Set(prev); next.has(id) ? next.delete(id) : next.add(id); return next;
@@ -302,7 +317,7 @@ export default function DiscoverPage() {
                 ) : (
                   <Input id="disc-area" value={form.area} placeholder="Neighbourhood or district…"
                     onChange={(e) => setForm((f) => ({ ...f, area: e.target.value }))}
-                    onKeyDown={(e) => { if (e.key === 'Enter' && canSearch) runSearch(form.category, form.area, form.limit); }} />
+                    onKeyDown={(e) => { if (e.key === 'Enter' && canSearch) runSearch(); }} />
                 )}
               </div>
               <div className="space-y-1.5">
@@ -312,9 +327,41 @@ export default function DiscoverPage() {
                   <SelectContent>{['30', '60', '120', '300', '500'].map((n) => <SelectItem key={n} value={n}>{n}</SelectItem>)}</SelectContent>
                 </Select>
               </div>
-              <Button disabled={!canSearch} onClick={() => runSearch(form.category, form.area, form.limit)}>
+              <Button disabled={!canSearch} onClick={() => runSearch()}>
                 <Search className="w-4 h-4 mr-1.5" aria-hidden="true" />{startMutation.isPending ? 'Starting…' : 'Search'}
               </Button>
+            </div>
+            <div className="grid gap-2 mt-3 sm:grid-cols-[1fr_auto_auto] sm:items-end">
+              <div className="space-y-1">
+                <Label htmlFor="disc-adhoc">
+                  {isIg ? 'Hashtags' : 'Search terms'} <span style={{ color: 'var(--ro-text-3)', fontWeight: 400 }}>(optional — overrides the category)</span>
+                </Label>
+                <Input id="disc-adhoc" value={form.adhoc}
+                  placeholder={isIg ? 'sgnails, biabsg, homebasednailssg' : 'kopitiam, zi char'}
+                  onChange={(e) => setForm((f) => ({ ...f, adhoc: e.target.value }))}
+                  onKeyDown={(e) => { if (e.key === 'Enter' && canSearch) runSearch(); }} />
+              </div>
+              {!isIg && (
+                <div className="space-y-1">
+                  <Label>Min rating</Label>
+                  <Select value={form.minStars} onValueChange={(v) => setForm((f) => ({ ...f, minStars: v }))}>
+                    <SelectTrigger className="w-full min-w-[104px]"><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="any">Any</SelectItem>
+                      <SelectItem value="three">3.0★+</SelectItem>
+                      <SelectItem value="threeAndHalf">3.5★+</SelectItem>
+                      <SelectItem value="four">4.0★+</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+              {!isIg && (
+                <label className="flex items-center gap-2 h-9 px-1 text-[13px] font-semibold cursor-pointer whitespace-nowrap" style={{ color: 'var(--ro-text-2)' }}>
+                  <input type="checkbox" className="w-4 h-4 accent-[var(--ro-bunker)]"
+                    checked={form.skipClosed} onChange={(e) => setForm((f) => ({ ...f, skipClosed: e.target.checked }))} />
+                  Skip closed
+                </label>
+              )}
             </div>
             <div className="flex flex-wrap items-center gap-2 mt-3">
               {!territoriesEnabled && !isIg && (


### PR DESCRIPTION
Adds the operator-controllable search fields:

- **Ad-hoc terms/hashtags** — type your own in the search bar to override the category defaults (no Settings trip). IG ad-hoc hashtags skip the no-hashtags 422; the category stays the CRM bucket for filing. Answers *"why must I add hashtags in Settings"*.
- **Maps quality inputs** (actor-native — filter *before* paying): **Min rating** (`placeMinimumStars`) + **Skip permanently closed** (`skipClosedPlaces`).

All **opt-in**: with no overrides the Apify input is byte-identical (the Phase-6 byte-identical test + 59 discovery/IG tests pass). IG business-only + follower-range filters deferred (business-only needs storing `isBusinessAccount`).

Verified: backend 59/59, frontend build ✓, DiscoverPage vitest 8/8, ESLint ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)