### PR TITLE
fix(redeem-ops): Discover — Category optional when ad-hoc terms/hashtags supplied

### DIFF
--- a/backend/src/controllers/redeemOps/discoveryController.js
+++ b/backend/src/controllers/redeemOps/discoveryController.js
@@ -4,7 +4,7 @@ import discoveryService, { cfg } from '../../services/redeemOps/discoveryService
 import { logger } from '../../utils/logger.js';
 
 const startSchema = Joi.object({
-  category: Joi.string().min(1).max(64).required(),
+  category: Joi.string().max(64).allow(''), // optional — ad-hoc terms/hashtags can stand in
   area: Joi.string().min(1).max(120).required(),
   limit: Joi.number().integer().min(1).max(500), // sanity bound; service clamps to DISCOVERY_MAX_RESULTS_PER_RUN
   // Mechanism pick; omitted = Maps. The IG pilot additionally needs DISCOVERY_IG_ENABLED.

--- a/backend/src/services/redeemOps/discoveryService.js
+++ b/backend/src/services/redeemOps/discoveryService.js
@@ -201,26 +201,33 @@ export function makeDiscoveryService(overrides = {}) {
     if (isInstagram && !cfg().igEnabled) {
       throw new AppError('Instagram discovery is not enabled', 503);
     }
-    if (!category || !String(category).trim()) throw new AppError('Category is required', 400);
     if (!area || !String(area).trim()) throw new AppError('Area is required', 400);
-    // Ad-hoc, type-and-go overrides: when the operator supplies their own terms/
-    // hashtags the category becomes just the CRM bucket — its saved terms aren't
-    // needed, so an IG search with ad-hoc tags skips the no-hashtags 422.
+    // Ad-hoc, type-and-go terms/hashtags. When supplied they ARE the search, so a
+    // category is OPTIONAL — it's then just the CRM bucket for filing (an ad-hoc-only
+    // run is Uncategorised until its results are added to the pipeline).
     const cleanList = (a) => (Array.isArray(a)
       ? [...new Set(a.map((x) => String(x).trim().replace(/^#+/, '')).filter(Boolean))].slice(0, 20)
       : []);
     const overrideTerms = cleanList(adHocTerms);
     const overrideTags = cleanList(adHocTags);
-    // Fail fast on an unknown/inactive category (422) BEFORE any run row or Apify
-    // spend — otherwise every add-to-pipeline would fail after the money was paid.
-    // Stores the taxonomy's canonical casing so add-time createPartner re-validation
-    // can only fail on the (rare) delete-category-mid-run race. The IG resolver
-    // additionally 422s when the category has no curated hashtags — unless ad-hoc
-    // hashtags were supplied, where name-only resolution suffices.
-    const resolved = (isInstagram && overrideTags.length === 0)
-      ? await d.categories.resolveCategoryForInstagram(String(category).trim())
-      : await d.categories.resolveCategoryForSearch(String(category).trim());
-    const canonicalCategory = resolved.name;
+    const hasCategory = !!(category && String(category).trim());
+    const override = isInstagram ? overrideTags : overrideTerms;
+    if (!hasCategory && override.length === 0) {
+      throw new AppError(isInstagram
+        ? 'Pick a category or enter hashtags to search'
+        : 'Pick a category or enter search terms', 400);
+    }
+    // Resolve the category only when one was picked. Fail fast on an unknown/inactive
+    // category (422) BEFORE any run row or Apify spend. The IG resolver additionally
+    // 422s when the category has no curated hashtags — unless ad-hoc hashtags were
+    // supplied, where name-only resolution suffices.
+    let resolved = null;
+    if (hasCategory) {
+      resolved = (isInstagram && overrideTags.length === 0)
+        ? await d.categories.resolveCategoryForInstagram(String(category).trim())
+        : await d.categories.resolveCategoryForSearch(String(category).trim());
+    }
+    const canonicalCategory = resolved ? resolved.name : null;
     const c = cfg();
     if (!c.resultQuotaEnabled) await assertQuota(user);
     const requestedLimit = Math.min(Math.max(Number(limit) || 60, 1), c.maxResultsPerRun);

--- a/src/pages/redeemops/DiscoverPage.jsx
+++ b/src/pages/redeemops/DiscoverPage.jsx
@@ -261,7 +261,7 @@ export default function DiscoverPage() {
     if (ids.length === 0) { toast.info('Nothing to enrich — no un-enriched Instagram handles'); return; }
     enrichMutation.mutate(ids);
   };
-  const canSearch = form.category && form.area.trim() && !startMutation.isPending;
+  const canSearch = form.area.trim() && (form.category || parseCsv(form.adhoc).length > 0) && !startMutation.isPending;
 
   return (
     <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-6 pb-24">
@@ -296,7 +296,7 @@ export default function DiscoverPage() {
             )}
             <div className="grid gap-3 md:grid-cols-[1fr_1fr_120px_auto] md:items-end">
               <div className="space-y-1.5">
-                <Label>Category</Label>
+                <Label>Category <span style={{ color: 'var(--ro-text-3)', fontWeight: 400 }}>(optional)</span></Label>
                 <CategorySelect value={form.category} onChange={(v) => setForm((f) => ({ ...f, category: v }))} />
               </div>
               <div className="space-y-1.5">
@@ -420,7 +420,7 @@ export default function DiscoverPage() {
                       <Search className="w-4 h-4" aria-hidden="true" />
                     </span>
                     <span className="min-w-0">
-                      <b className="text-[14px] block truncate">{r.category} · {r.area}</b>
+                      <b className="text-[14px] block truncate">{[r.category, r.area].filter(Boolean).join(' · ') || '—'}</b>
                       <span className="text-[12.5px]" style={{ color: 'var(--ro-text-3)' }}>
                         {timeAgo(r.createdAt)} · {r.resultCount || 0} result{r.resultCount === 1 ? '' : 's'}
                         {r.actualCostUsd != null && ` · $${Number(r.actualCostUsd).toFixed(2)}`}


### PR DESCRIPTION
Fixes the friction where a search with ad-hoc terms still demanded a category. Now: **Search needs an Area + (a Category **or** ad-hoc terms/hashtags)**. Type `taekwondo` with no category → runs and files results as Uncategorised (categorise them when adding). The category picker stays (curated fast-path + CRM bucket), now labelled *optional*. No-override path byte-identical (59 tests pass); build ✓, vitest 8/8, lint ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)