### PR TITLE
feat(redeem-ops): cadences — {{rep_name}} merge field; AI drafts stop emitting [Your Name]

### DIFF
--- a/backend/src/services/redeemOps/cadenceAiService.js
+++ b/backend/src/services/redeemOps/cadenceAiService.js
@@ -37,7 +37,7 @@ const CONTINUE_ALLOWED = Object.fromEntries(CHANNELS.map((ch) => [
 ]));
 /** The ONLY merge fields renderTemplate resolves — any other {{token}} blocks
  *  the live task (unresolved_template). Keep in lock-step with cadenceService. */
-const MERGE_FIELDS = new Set(['partner_name', 'contact_name', 'category', 'recipient']);
+const MERGE_FIELDS = new Set(['partner_name', 'contact_name', 'category', 'recipient', 'rep_name']);
 
 // Enums are supported by both providers' structured outputs (guided review uses
 // them in prod). continueOn stays a free string — its valid values depend on
@@ -82,7 +82,7 @@ Rules for a valid cadence:
 - delayDays: step 1 = days after enrolling (usually 0); later steps = days to wait after the previous step (1-4 is typical, max 60).
 - timeWindow (SGT): any, morning (9:30), afternoon (15:00), off_peak (15:00-17:00). Calls land best morning or off_peak; messages any.
 - title: short and imperative — what the rep sees in their queue (e.g. "Intro call — gauge interest").
-- script: the note or ready-to-send message shown on the task. 1-3 sentences, natural Singapore English, friendly and non-pushy. You may ONLY use these merge fields: {{partner_name}}, {{contact_name}}, {{category}}, {{recipient}} — any other {{placeholder}} breaks the task. Plain text otherwise.
+- script: the note or ready-to-send message shown on the task. 1-3 sentences, natural Singapore English, friendly and non-pushy. You may ONLY use these merge fields: {{partner_name}}, {{contact_name}}, {{category}}, {{recipient}}, {{rep_name}} — any other {{placeholder}} breaks the task. {{rep_name}} is the sales rep's own name, auto-filled per task: use it whenever the rep introduces themselves (e.g. "Hi, this is {{rep_name}} from Redeem"). NEVER write bracketed fill-ins like [Your Name] or [Business] — use a merge field or plain text.
 - priority: low, medium or high.
 - name (max 120 chars) and a one-line description saying when reps should pick this cadence.
 
@@ -104,7 +104,11 @@ const clampInt = (v, lo, hi, fallback) => {
  *  the blocker regex is any remaining {{...}}. Single pass — a canonicalize-
  *  then-strip pipeline would strip its own output. */
 export function sanitizeScript(raw) {
-  const s = typeof raw === 'string' ? raw : '';
+  let s = typeof raw === 'string' ? raw : '';
+  // LLMs write "[Your Name]" fill-ins even when told not to — canonicalize the
+  // self-introduction variants to the real merge field BEFORE the brace pass so
+  // the emitted {{rep_name}} rides the allowlist below.
+  s = s.replace(/\[\s*(?:your|my|rep|agent|sender)(?:'s)?\s+name\s*\]/gi, '{{rep_name}}');
   return s.replace(/{{([^}]*)}}/g, (m, inner) => {
     const key = inner.trim().toLowerCase();
     // {{lead-name}}, {{first name}}, {{foo1}}… would block the task — keep the

--- a/backend/src/services/redeemOps/cadenceService.js
+++ b/backend/src/services/redeemOps/cadenceService.js
@@ -361,11 +361,17 @@ export function makeCadenceService(overrides = {}) {
     const primaryContact = resolved.contactId
       ? await d.PartnerContact.findByPk(resolved.contactId, { attributes: ['id', 'name'], transaction: t })
       : null;
+    // {{rep_name}} = whoever works the task, and the assignee is always the
+    // partner owner — fetched only when the template asks for it.
+    const owner = /{{\s*rep_name\s*}}/i.test(step.scriptTemplate || '')
+      ? await d.User.findByPk(partner.ownerUserId, { attributes: ['firstName', 'fullName'], transaction: t })
+      : null;
     const rendered = renderTemplate(step.scriptTemplate, {
       partner_name: partner.tradingName || partner.brandName || partner.legalName || 'there',
       contact_name: primaryContact?.name || 'there',
       category: partner.category || '',
       recipient: resolved.recipient || '',
+      rep_name: owner?.firstName || owner?.fullName || 'the Redeem team',
     });
     if (!rendered.ok) return { blocked: true, reason: 'unresolved_template' };
 

--- a/backend/test/redeemOpsCadenceAiSuggest.test.js
+++ b/backend/test/redeemOpsCadenceAiSuggest.test.js
@@ -38,6 +38,17 @@ describe('sanitizeScript — merge tokens mirror renderTemplate', () => {
   test('canonicalizes allowlisted fields (case/padding) and keeps them', () => {
     expect(sanitizeScript('Hi {{ Contact_Name }}, about {{PARTNER_NAME}} ({{category}})'))
       .toBe('Hi {{contact_name}}, about {{partner_name}} ({{category}})');
+    expect(sanitizeScript('This is {{ Rep_Name }} from Redeem'))
+      .toBe('This is {{rep_name}} from Redeem');
+  });
+
+  test('bracketed self-introduction fill-ins become {{rep_name}}', () => {
+    expect(sanitizeScript("Hi, this is [Your Name] from Redeem")).toBe('Hi, this is {{rep_name}} from Redeem');
+    expect(sanitizeScript('— [ my name ], Redeem')).toBe('— {{rep_name}}, Redeem');
+    expect(sanitizeScript("[Rep's Name] here, [Agent name] and [SENDER NAME] too"))
+      .toBe('{{rep_name}} here, {{rep_name}} and {{rep_name}} too');
+    // unrelated brackets are content, not fill-ins
+    expect(sanitizeScript('offer [20% off] ends [soon]')).toBe('offer [20% off] ends [soon]');
   });
 
   test('strips every blocker-shaped token the live regex would trip on', () => {

--- a/backend/test/redeemOpsCadences.test.js
+++ b/backend/test/redeemOpsCadences.test.js
@@ -347,7 +347,7 @@ describe('authoring (builder)', () => {
     name: 'Grooming chase',
     description: 'Pet services variant',
     steps: [
-      { channel: 'call', title: 'Groomer intro call', delayDays: 0, timeWindow: 'any', continueOn: 'no_answer', script: 'Hi {{contact_name}}!' },
+      { channel: 'call', title: 'Groomer intro call', delayDays: 0, timeWindow: 'any', continueOn: 'no_answer', script: 'Hi {{contact_name}}, {{rep_name}} from Redeem!' },
       { channel: 'whatsapp', title: 'Groomer WhatsApp', delayDays: 1, timeWindow: 'off_peak' },
       { channel: 'visit', title: 'Drop by the salon', delayDays: 3, timeWindow: 'afternoon' },
     ],
@@ -368,6 +368,9 @@ describe('authoring (builder)', () => {
     await partnerSvc.addLocation(p.id, { name: 'Main salon', addressLine: '1 Grooming Way' }, admin.user);
     const { firstTask } = await svc.enrollPartner(p.id, { cadenceKey: 'grooming_chase' }, execA.user);
     expect(firstTask.title).toBe('Groomer intro call');
+    // {{rep_name}} resolves to the assignee (partner owner); no contact on
+    // record so {{contact_name}} falls back to 'there'
+    expect(firstTask.description).toBe(`Hi there, ${execA.user.firstName} from Redeem!`);
     const r = await svc.completeCadenceTask(firstTask.id, { disposition: 'no_answer' }, execA.user);
     expect(r.nextTask.title).toBe('Groomer WhatsApp');
     // step 2's continueOn defaulted to '*', so 'sent' advances to the visit

--- a/src/pages/redeemops/CadenceEditorPage.jsx
+++ b/src/pages/redeemops/CadenceEditorPage.jsx
@@ -343,7 +343,8 @@ export default function CadenceEditorPage() {
             <p className="text-[15px] font-bold m-0 mb-2">Merge fields</p>
             <p className="text-[12.5px] m-0 leading-relaxed" style={{ color: 'var(--ro-text-2)' }}>
               Scripts can use <code>{'{{partner_name}}'}</code>, <code>{'{{contact_name}}'}</code>,{' '}
-              <code>{'{{category}}'}</code> and <code>{'{{recipient}}'}</code> — filled in when each
+              <code>{'{{category}}'}</code>, <code>{'{{recipient}}'}</code> and{' '}
+              <code>{'{{rep_name}}'}</code> (the assigned rep&apos;s own name) — filled in when each
               task is created. An unknown field blocks the step, so stick to these.
             </p>
           </div>


### PR DESCRIPTION
## Why

AI-drafted cadence scripts said literally **"Hi, this is [Your Name] from Redeem"** on call steps (screenshot from `/redeem-ops/cadences/new`). The drafter's merge-field allowlist (`partner_name`, `contact_name`, `category`, `recipient`) had no field for the rep's own name, so the LLM improvised a bracketed fill-in — and the render engine had nothing to fill it with anyway.

## What

- **`cadenceService.tryMaterializeTx`**: new `{{rep_name}}` merge field, resolved at task-materialization time from the task assignee (always the partner owner) — first name preferred, `fullName` fallback, `'the Redeem team'` last resort. Owner is only fetched when the template references the field.
- **`cadenceAiService`**: `rep_name` added to the drafter's allowlist; system prompt now tells the LLM to use `{{rep_name}}` for self-introductions and never write bracketed fill-ins like `[Your Name]`.
- **`sanitizeScript` safety net**: `[Your Name]` / `[my name]` / `[rep's name]` / `[agent name]` / `[sender name]` variants are canonicalized to `{{rep_name}}` before the brace pass, so even a non-compliant LLM draft renders correctly. Unrelated brackets are left alone.
- **Builder help copy** (`CadenceEditorPage`): Merge fields panel documents `{{rep_name}}`.

Existing cadences are unaffected (the field only resolves when a template uses it; unknown tokens still block the step as before).

## Tests

- `redeemOpsCadences.test.js`: builder end-to-end now asserts `{{rep_name}}` renders to the assignee's first name (and `{{contact_name}}` fallback) on the materialized task.
- `redeemOpsCadenceAiSuggest.test.js`: bracket-fill-in canonicalization + `{{rep_name}}` allowlist cases.
- All 59 backend cadence tests + 12 frontend cadence tests pass (throwaway pg on 5433).

🤖 Generated with [Claude Code](https://claude.com/claude-code)