### PR TITLE
feat(redeem-ops): cadence drafts — private to creator + admins until published

### DIFF
--- a/backend/src/controllers/redeemOps/cadenceController.js
+++ b/backend/src/controllers/redeemOps/cadenceController.js
@@ -11,7 +11,11 @@ function validateBody(schema, body) {
 }
 
 export const listCadences = asyncHandler(async (req, res) => {
-  const cadences = await cadenceService.listCadences({ includeRetired: req.query.all === 'true' });
+  // forUser scopes drafts: creator + admins only; published rows go to everyone.
+  const cadences = await cadenceService.listCadences({
+    includeRetired: req.query.all === 'true',
+    forUser: req.user,
+  });
   // aiEnabled drives the editor's "Draft with AI" card — same helper the
   // suggest endpoint gates on, so the UI can never disagree with the API.
   res.json({ success: true, data: { cadences, aiEnabled: cadenceAiEnabled() } });
@@ -44,6 +48,9 @@ const cadenceDefSchema = Joi.object({
   name: Joi.string().max(120).required(),
   description: Joi.string().max(2000).allow('', null),
   steps: Joi.array().items(stepSchema).min(1).max(20).required(),
+  // false = save as a private draft (creator + admins). Omitted = publish,
+  // matching pre-draft behavior for existing callers.
+  publish: Joi.boolean(),
 });
 
 export const createCadence = asyncHandler(async (req, res) => {
@@ -60,6 +67,11 @@ export const createCadenceVersion = asyncHandler(async (req, res) => {
 
 export const retireCadence = asyncHandler(async (req, res) => {
   const cadence = await cadenceService.retireCadence(req.params.cadenceId, req.user, req.id);
+  res.json({ success: true, data: { cadence } });
+});
+
+export const publishCadence = asyncHandler(async (req, res) => {
+  const cadence = await cadenceService.publishCadence(req.params.cadenceId, req.user, req.id);
   res.json({ success: true, data: { cadence } });
 });
 

--- a/backend/src/database/migrations/066-cadence-draft-visibility.js
+++ b/backend/src/database/migrations/066-cadence-draft-visibility.js
@@ -1,0 +1,22 @@
+/**
+ * 066 — Draft visibility for cadences. `publishedAt` NULL = draft: listed and
+ * enrollable only by its creator and admins (settings.manage); publishing
+ * shares it team-wide. Every pre-existing row was team-wide by construction
+ * (authoring used to be settings.manage-only), so they backfill as published
+ * at their creation time. Guarded/idempotent like 052–065 and safe under
+ * NODE_ENV=test's sync-first empty tables.
+ */
+export async function up(queryInterface) {
+  await queryInterface.sequelize.query(
+    'ALTER TABLE outreach_cadences ADD COLUMN IF NOT EXISTS "publishedAt" timestamptz'
+  );
+  await queryInterface.sequelize.query(
+    'UPDATE outreach_cadences SET "publishedAt" = "createdAt" WHERE "publishedAt" IS NULL'
+  );
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query(
+    'ALTER TABLE outreach_cadences DROP COLUMN IF EXISTS "publishedAt"'
+  );
+}

--- a/backend/src/models/OutreachCadence.js
+++ b/backend/src/models/OutreachCadence.js
@@ -15,6 +15,9 @@ const OutreachCadence = sequelize.define('OutreachCadence', {
   description: { type: DataTypes.TEXT, allowNull: true },
   targetCategory: { type: DataTypes.STRING(64), allowNull: true },
   isActive: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+  // NULL = draft: listed/enrollable only by its creator and admins
+  // (settings.manage). Publishing shares it team-wide; there is no unpublish.
+  publishedAt: { type: DataTypes.DATE, allowNull: true },
   createdBy: { type: DataTypes.UUID, allowNull: false, references: { model: 'users', key: 'id' } },
 }, {
   tableName: 'outreach_cadences',

--- a/backend/src/routes/redeemOpsCadences.js
+++ b/backend/src/routes/redeemOpsCadences.js
@@ -37,13 +37,16 @@ const cadenceAiLimiter = rateLimit({
   message: { success: false, message: 'Too many AI requests. Try again in a minute.' },
 });
 
-// Authoring — curated like categories: settings.manage (super_admin/ops_admin).
+// Authoring — any rep who works tasks can build cadences (tasks.manage), saved
+// as a private draft (creator + admins) or published team-wide. Row rules live
+// in the service: only the creator or an admin edits/retires/publishes a row.
 // Editing creates a NEW version; live enrollments keep the one they started on.
-router.post('/cadences', requireRedeemOps('settings.manage'), ctrl.createCadence);
+router.post('/cadences', requireRedeemOps('tasks.manage'), ctrl.createCadence);
 // AI draft — same authoring gate; limiter AFTER auth so req.user keys the window.
-router.post('/cadences/suggest', requireRedeemOps('settings.manage'), cadenceAiLimiter, ctrl.suggestCadence);
-router.post('/cadences/:cadenceId/versions', requireRedeemOps('settings.manage'), ctrl.createCadenceVersion);
-router.post('/cadences/:cadenceId/retire', requireRedeemOps('settings.manage'), ctrl.retireCadence);
+router.post('/cadences/suggest', requireRedeemOps('tasks.manage'), cadenceAiLimiter, ctrl.suggestCadence);
+router.post('/cadences/:cadenceId/versions', requireRedeemOps('tasks.manage'), ctrl.createCadenceVersion);
+router.post('/cadences/:cadenceId/retire', requireRedeemOps('tasks.manage'), ctrl.retireCadence);
+router.post('/cadences/:cadenceId/publish', requireRedeemOps('tasks.manage'), ctrl.publishCadence);
 
 // Partner-scoped enrollment lifecycle (owner/manager checks in the service).
 router.get('/partners/:partnerId/cadence', requireRedeemOps(), ctrl.getPartnerCadence);

--- a/backend/src/services/redeemOps/cadenceSeeds.js
+++ b/backend/src/services/redeemOps/cadenceSeeds.js
@@ -82,6 +82,7 @@ export async function ensureCadences() {
       const cadence = await OutreachCadence.create({
         key: seed.key, version: seed.version, name: seed.name,
         description: seed.description, createdBy: creator.id,
+        publishedAt: new Date(), // seeds are team-wide, never drafts
       }, { transaction: t });
 
       const idByOrder = {};

--- a/backend/src/services/redeemOps/cadenceService.js
+++ b/backend/src/services/redeemOps/cadenceService.js
@@ -6,6 +6,7 @@ import {
 } from '../../models/index.js';
 import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';
+import { hasCapability } from './permissions.js';
 import { makeRedeemOpsAuditService } from './auditService.js';
 import { makeTaskService } from './taskService.js';
 import { makePartnerService } from './partnerService.js';
@@ -114,11 +115,23 @@ export function makeCadenceService(overrides = {}) {
 
   const canActOnPartner = (user, partner) => isManager(user) || partner.ownerUserId === user.id;
 
+  // Drafts (publishedAt NULL) are private to their creator + admins. "Admins"
+  // = the settings.manage tier — the set that could author everything before
+  // drafts existed. bdm manages partners, not other people's unfinished work.
+  const isCadenceAdmin = (user) => hasCapability(user, 'settings.manage');
+  const canSeeCadence = (user, cadence) =>
+    !!cadence.publishedAt || (!!user && (isCadenceAdmin(user) || cadence.createdBy === user.id));
+  const canAuthorRow = (user, cadence) => isCadenceAdmin(user) || cadence.createdBy === user.id;
+
   // ── Definition lookup ──────────────────────────────────────────────────────
 
-  async function listCadences({ includeRetired = false } = {}) {
+  async function listCadences({ includeRetired = false, forUser = null } = {}) {
+    // No forUser (internal callers) = the safe view: published only.
+    const draftScope = forUser && isCadenceAdmin(forUser)
+      ? {}
+      : { [Op.or]: [{ publishedAt: { [Op.ne]: null } }, ...(forUser ? [{ createdBy: forUser.id }] : [])] };
     return d.OutreachCadence.findAll({
-      where: includeRetired ? {} : { isActive: true },
+      where: { ...(includeRetired ? {} : { isActive: true }), ...draftScope },
       include: [
         { model: d.OutreachCadenceStep, as: 'steps' },
         { model: d.OutreachCadenceTransition, as: 'transitions' },
@@ -173,9 +186,9 @@ export function makeCadenceService(overrides = {}) {
     return { name, description: def.description ? String(def.description).slice(0, 2000) : null, steps };
   }
 
-  async function insertDefinitionTx({ key, version, name, description, steps }, user, t) {
+  async function insertDefinitionTx({ key, version, name, description, steps, publishedAt = null }, user, t) {
     const cadence = await d.OutreachCadence.create({
-      key, version, name, description, createdBy: user.id,
+      key, version, name, description, publishedAt, createdBy: user.id,
     }, { transaction: t });
     const created = [];
     for (let i = 0; i < steps.length; i += 1) {
@@ -203,15 +216,17 @@ export function makeCadenceService(overrides = {}) {
 
   async function createCadence(def, user, requestId = null) {
     const norm = validateBuilderDefinition(def);
+    // publish defaults TRUE (pre-draft behavior); a draft is the explicit opt-in.
+    const publishedAt = def.publish === false ? null : d.now();
     return d.sequelize.transaction(async (t) => {
       await d.sequelize.query('SELECT pg_advisory_xact_lock(9157002)', { transaction: t });
       let key = slugifyKey(norm.name);
       const clashes = await d.OutreachCadence.count({ where: { key }, transaction: t });
       if (clashes > 0) key = `${key}_${Date.now().toString(36)}`.slice(0, 64);
-      const cadence = await insertDefinitionTx({ ...norm, key, version: 1 }, user, t);
+      const cadence = await insertDefinitionTx({ ...norm, key, version: 1, publishedAt }, user, t);
       await d.audit.recordAuditEvent({
         actorUser: user, action: 'cadence.created', entityType: 'outreach_cadence',
-        entityId: cadence.id, after: { key, name: norm.name, steps: norm.steps.length },
+        entityId: cadence.id, after: { key, name: norm.name, steps: norm.steps.length, draft: !publishedAt },
         requestId, transaction: t,
       });
       return cadence;
@@ -228,13 +243,20 @@ export function makeCadenceService(overrides = {}) {
     return d.sequelize.transaction(async (t) => {
       await d.sequelize.query('SELECT pg_advisory_xact_lock(9157002)', { transaction: t });
       const base = await d.OutreachCadence.findByPk(cadenceId, { transaction: t, lock: t.LOCK.UPDATE });
-      if (!base) throw new AppError('Cadence not found', 404);
+      // Invisible draft = same 404 as missing, so its existence never leaks.
+      if (!base || !canSeeCadence(user, base)) throw new AppError('Cadence not found', 404);
+      if (!canAuthorRow(user, base)) {
+        throw new AppError('Only the creator or an admin can edit this cadence', 403);
+      }
+      // Draft-ness carries over; publish:true flips a draft live at save time.
+      // Once published there is no unpublish — the team may already rely on it.
+      const publishedAt = base.publishedAt || (def.publish === true ? d.now() : null);
       const latest = await d.OutreachCadence.max('version', { where: { key: base.key }, transaction: t });
       await d.OutreachCadence.update(
         { isActive: false },
         { where: { key: base.key, isActive: true }, transaction: t }
       );
-      const cadence = await insertDefinitionTx({ ...norm, key: base.key, version: latest + 1 }, user, t);
+      const cadence = await insertDefinitionTx({ ...norm, key: base.key, version: latest + 1, publishedAt }, user, t);
       await d.audit.recordAuditEvent({
         actorUser: user, action: 'cadence.version_created', entityType: 'outreach_cadence',
         entityId: cadence.id,
@@ -248,7 +270,10 @@ export function makeCadenceService(overrides = {}) {
   async function retireCadence(cadenceId, user, requestId = null) {
     return d.sequelize.transaction(async (t) => {
       const cadence = await d.OutreachCadence.findByPk(cadenceId, { transaction: t, lock: t.LOCK.UPDATE });
-      if (!cadence) throw new AppError('Cadence not found', 404);
+      if (!cadence || !canSeeCadence(user, cadence)) throw new AppError('Cadence not found', 404);
+      if (!canAuthorRow(user, cadence)) {
+        throw new AppError('Only the creator or an admin can retire this cadence', 403);
+      }
       if (!cadence.isActive) return cadence;
       await cadence.update({ isActive: false }, { transaction: t });
       await d.audit.recordAuditEvent({
@@ -260,10 +285,33 @@ export function makeCadenceService(overrides = {}) {
     });
   }
 
-  async function resolveCadenceTx({ cadenceId, cadenceKey }, t) {
+  /** Publish a draft team-wide. Creator or admin; idempotent; no unpublish. */
+  async function publishCadence(cadenceId, user, requestId = null) {
+    return d.sequelize.transaction(async (t) => {
+      const cadence = await d.OutreachCadence.findByPk(cadenceId, { transaction: t, lock: t.LOCK.UPDATE });
+      if (!cadence || !canSeeCadence(user, cadence)) throw new AppError('Cadence not found', 404);
+      if (!canAuthorRow(user, cadence)) {
+        throw new AppError('Only the creator or an admin can publish this cadence', 403);
+      }
+      if (!cadence.isActive) throw new AppError('A retired version cannot be published', 409);
+      if (cadence.publishedAt) return cadence;
+      await cadence.update({ publishedAt: d.now() }, { transaction: t });
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'cadence.published', entityType: 'outreach_cadence',
+        entityId: cadence.id, after: { key: cadence.key, version: cadence.version },
+        requestId, transaction: t,
+      });
+      return cadence;
+    });
+  }
+
+  async function resolveCadenceTx({ cadenceId, cadenceKey }, user, t) {
+    // Drafts resolve only for their creator + admins — same 404 as a missing
+    // cadence so their existence never leaks to peers.
+    const visible = (c) => c && c.isActive && canSeeCadence(user, c);
     if (cadenceId) {
       const cadence = await d.OutreachCadence.findByPk(cadenceId, { transaction: t });
-      if (!cadence || !cadence.isActive) throw new AppError('Cadence not found or retired', 404);
+      if (!visible(cadence)) throw new AppError('Cadence not found or retired', 404);
       return cadence;
     }
     if (cadenceKey) {
@@ -272,7 +320,7 @@ export function makeCadenceService(overrides = {}) {
         order: [['version', 'DESC']],
         transaction: t,
       });
-      if (!cadence) throw new AppError('Cadence not found or retired', 404);
+      if (!visible(cadence)) throw new AppError('Cadence not found or retired', 404);
       return cadence;
     }
     throw new AppError('cadenceId or cadenceKey is required', 400);
@@ -469,7 +517,7 @@ export function makeCadenceService(overrides = {}) {
         throw new AppError(`A ${partner.pipelineStage === 'LOST' ? 'Lost' : 'Partnered'} business cannot be enrolled — revive it first`, 409);
       }
 
-      const cadence = await resolveCadenceTx({ cadenceId, cadenceKey }, t);
+      const cadence = await resolveCadenceTx({ cadenceId, cadenceKey }, user, t);
 
       const existing = await liveEnrollmentForPartnerTx(partnerId, t);
       if (existing) throw new AppError('This business is already in a cadence', 409);
@@ -832,7 +880,7 @@ export function makeCadenceService(overrides = {}) {
   }
 
   return {
-    listCadences, createCadence, createCadenceVersion, retireCadence,
+    listCadences, createCadence, createCadenceVersion, retireCadence, publishCadence,
     enrollPartner, completeCadenceTask,
     pauseEnrollment, resumeEnrollment, stopEnrollment,
     getPartnerCadence, hookHandlers, reconcile,

--- a/backend/test/redeemOpsCadences.test.js
+++ b/backend/test/redeemOpsCadences.test.js
@@ -21,7 +21,7 @@ import { makeTaskService } from '../src/services/redeemOps/taskService.js';
 import { runRedeemOpsStaleSweep } from '../src/services/redeemOps/staleSweep.js';
 
 let app;
-let admin, execA, execB;
+let admin, execA, execB, analyst;
 const svc = makeCadenceService();
 const partnerSvc = makePartnerService();
 const claimSvc = makeClaimService();
@@ -35,6 +35,7 @@ beforeAll(async () => {
   admin = await createTestUser({ role: 'admin' });
   execA = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
   execB = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
+  analyst = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'analyst' }); // no tasks.manage
   // the app boot may have created the system agent already — don't collide
   await User.findOrCreate({
     where: { email: 'system@mktr.local' },
@@ -75,6 +76,7 @@ describe('seeds', () => {
     expect(again.seeded).toBe(0);
     const fnb = await OutreachCadence.findOne({ where: { key: 'fnb_call_first', version: 1 } });
     expect(fnb).toBeTruthy();
+    expect(fnb.publishedAt).toBeTruthy(); // seeds are team-wide, never drafts
     const cadences = await svc.listCadences();
     const keys = cadences.map((c) => c.key).sort();
     expect(keys).toEqual(['fnb_call_first', 'revival_60d']);
@@ -375,7 +377,7 @@ describe('authoring (builder)', () => {
     expect(r2.nextTask.title).toBe('Drop by the salon');
   });
 
-  test('validation: terminal continueOn and channel mismatches are refused; execs are not allowed', async () => {
+  test('validation: terminal continueOn and channel mismatches are refused; non-authoring roles are not allowed', async () => {
     const bad = {
       name: 'Bad def',
       steps: [
@@ -386,7 +388,8 @@ describe('authoring (builder)', () => {
     const res = await request(app).post('/api/redeem-ops/cadences').set(auth(admin.token)).send(bad);
     expect(res.status).toBe(400);
 
-    const denied = await request(app).post('/api/redeem-ops/cadences').set(auth(execA.token)).send(builderDef);
+    // authoring is tasks.manage — an analyst has no business creating cadences
+    const denied = await request(app).post('/api/redeem-ops/cadences').set(auth(analyst.token)).send(builderDef);
     expect(denied.status).toBe(403);
   });
 
@@ -397,8 +400,8 @@ describe('authoring (builder)', () => {
     const anthropicBefore = process.env.ANTHROPIC_API_KEY;
     try {
       process.env.REDEEM_OPS_CADENCES_AI_ENABLED = 'true';
-      // settings.manage gate — same as create/version/retire
-      const denied = await request(app).post(url).set(auth(execA.token)).send({ prompt: 'cafés chase' });
+      // tasks.manage gate — same as create/version/retire/publish
+      const denied = await request(app).post(url).set(auth(analyst.token)).send({ prompt: 'cafés chase' });
       expect(denied.status).toBe(403);
 
       // Joi: prompt too short / stepCount out of the UI's 2-12 range
@@ -479,6 +482,101 @@ describe('authoring (builder)', () => {
     expect(active.some((c) => c.id === created.id)).toBe(false);
     const all = await svc.listCadences({ includeRetired: true });
     expect(all.some((c) => c.id === created.id)).toBe(true);
+  });
+});
+
+describe('drafts (private until published)', () => {
+  const draftDef = (name) => ({
+    name,
+    publish: false,
+    steps: [
+      { channel: 'call', title: 'Draft intro call', delayDays: 0, continueOn: 'no_answer' },
+      { channel: 'whatsapp', title: 'Draft WhatsApp', delayDays: 1 },
+    ],
+  });
+  const createDraft = async (name, who = execA) => {
+    const res = await request(app).post('/api/redeem-ops/cadences').set(auth(who.token)).send(draftDef(name));
+    expect(res.status).toBe(201);
+    expect(res.body.data.cadence.publishedAt).toBeNull();
+    return res.body.data.cadence;
+  };
+  const listedIds = async (who) => {
+    const res = await request(app).get('/api/redeem-ops/cadences').set(auth(who.token));
+    return res.body.data.cadences.map((c) => c.id);
+  };
+
+  test('publish omitted = published immediately (pre-draft behavior preserved)', async () => {
+    const res = await request(app).post('/api/redeem-ops/cadences').set(auth(execA.token))
+      .send({ name: 'Exec public chase', steps: draftDef('x').steps });
+    expect(res.status).toBe(201);
+    expect(res.body.data.cadence.publishedAt).toBeTruthy();
+    expect(await listedIds(execB)).toContain(res.body.data.cadence.id);
+  });
+
+  test('a draft is listed for its creator and admins, never for peers', async () => {
+    const cadence = await createDraft('Exec private chase');
+    expect(await listedIds(execA)).toContain(cadence.id);
+    expect(await listedIds(admin)).toContain(cadence.id);
+    expect(await listedIds(execB)).not.toContain(cadence.id);
+  });
+
+  test('peers cannot enroll into (or even probe) a draft; the creator can', async () => {
+    const cadence = await createDraft('Draft enroll gate');
+
+    const peerPartner = await ownedPartner('Peer Draft Cafe', execB);
+    const denied = await request(app)
+      .post(`/api/redeem-ops/partners/${peerPartner.id}/cadence/enroll`)
+      .set(auth(execB.token)).send({ cadenceId: cadence.id });
+    expect(denied.status).toBe(404); // existence never leaks
+
+    const ownPartner = await ownedPartner('Creator Draft Cafe', execA);
+    const ok = await request(app)
+      .post(`/api/redeem-ops/partners/${ownPartner.id}/cadence/enroll`)
+      .set(auth(execA.token)).send({ cadenceId: cadence.id });
+    expect(ok.status).toBe(201);
+    expect(ok.body.data.firstTask.title).toBe('Draft intro call');
+  });
+
+  test('row rules: peers get 404 on drafts and 403 on published rows; publish opens it team-wide', async () => {
+    const cadence = await createDraft('Draft to publish');
+
+    // invisible draft — every authoring verb answers "not found"
+    expect((await request(app).post(`/api/redeem-ops/cadences/${cadence.id}/publish`)
+      .set(auth(execB.token))).status).toBe(404);
+    expect((await request(app).post(`/api/redeem-ops/cadences/${cadence.id}/versions`)
+      .set(auth(execB.token)).send(draftDef('x'))).status).toBe(404);
+    expect((await request(app).post(`/api/redeem-ops/cadences/${cadence.id}/retire`)
+      .set(auth(execB.token))).status).toBe(404);
+
+    // creator edits their draft → the new version is still a draft
+    const v2 = await request(app).post(`/api/redeem-ops/cadences/${cadence.id}/versions`)
+      .set(auth(execA.token)).send(draftDef('Draft to publish'));
+    expect(v2.status).toBe(201);
+    expect(v2.body.data.cadence.publishedAt).toBeNull();
+    const v2id = v2.body.data.cadence.id;
+
+    // creator publishes → peers now list it and can enroll
+    const pub = await request(app).post(`/api/redeem-ops/cadences/${v2id}/publish`).set(auth(execA.token));
+    expect(pub.status).toBe(200);
+    expect(pub.body.data.cadence.publishedAt).toBeTruthy();
+    expect(await listedIds(execB)).toContain(v2id);
+
+    // visible but not theirs: peer edits of a published row are a plain 403
+    expect((await request(app).post(`/api/redeem-ops/cadences/${v2id}/versions`)
+      .set(auth(execB.token)).send(draftDef('nope'))).status).toBe(403);
+
+    // once published there is no way back — a later save stays published
+    const v3 = await request(app).post(`/api/redeem-ops/cadences/${v2id}/versions`)
+      .set(auth(execA.token)).send(draftDef('Draft to publish'));
+    expect(v3.body.data.cadence.publishedAt).toBeTruthy();
+  });
+
+  test('save & publish in one step: a version save with publish:true flips a draft live', async () => {
+    const cadence = await createDraft('Draft flip on save');
+    const v2 = await request(app).post(`/api/redeem-ops/cadences/${cadence.id}/versions`)
+      .set(auth(execA.token)).send({ ...draftDef('Draft flip on save'), publish: true });
+    expect(v2.status).toBe(201);
+    expect(v2.body.data.cadence.publishedAt).toBeTruthy();
   });
 });
 

--- a/docs/plans/redeem-ops-cadences.md
+++ b/docs/plans/redeem-ops-cadences.md
@@ -257,7 +257,11 @@ mail). Bounce/complaint webhooks → `outreach_suppressions` BEFORE auto mode sh
 ## 9. Permissions & flags
 
 - Enroll/pause/stop/complete: partner owner; managers (existing `isManager` set) any.
-- Definitions (create/retire versions — even before builder UI, via seeds): `settings.manage`.
+- Definitions — UPDATED (draft visibility, migration 066): authoring is `tasks.manage` (any rep);
+  a cadence saves as a private **draft** (`publishedAt` NULL — listed/enrollable only by its
+  creator + admins, i.e. `settings.manage`) or publishes team-wide. Edit/retire/publish are
+  row-ruled to creator-or-admin; invisible drafts 404 so they never leak. Version bumps carry
+  draft-ness; publishing is one-way. (Originally: `settings.manage` for all authoring.)
 - Flags: backend `REDEEM_OPS_CADENCES_ENABLED` (routes + tick + hooks no-op when off), frontend
   `VITE_REDEEM_OPS_CADENCES_ENABLED` (SPA has only the master flag today — verified).
 

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -399,6 +399,10 @@ export const redeemOpsApi = {
     const res = await apiClient.post(`/redeem-ops/cadences/${cadenceId}/retire`);
     return res.data?.cadence;
   },
+  async publishCadence(cadenceId) {
+    const res = await apiClient.post(`/redeem-ops/cadences/${cadenceId}/publish`);
+    return res.data?.cadence;
+  },
   async getPartnerCadence(partnerId) {
     const res = await apiClient.get(`/redeem-ops/partners/${partnerId}/cadence`);
     return res.data;

--- a/src/components/redeemops/CadenceStudio.jsx
+++ b/src/components/redeemops/CadenceStudio.jsx
@@ -32,6 +32,15 @@ export default function CadenceStudio() {
     onError: (err) => toast.error('Could not retire', { description: err.message }),
   });
 
+  const publishMutation = useMutation({
+    mutationFn: (id) => redeemOpsApi.publishCadence(id),
+    onSuccess: () => {
+      toast.success('Published — it’s in every Start cadence picker now');
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'cadences'] });
+    },
+    onError: (err) => toast.error('Could not publish', { description: err.message }),
+  });
+
   if (!CADENCES_ENABLED) return null;
 
   const cadences = listQuery.data?.cadences || [];
@@ -43,7 +52,8 @@ export default function CadenceStudio() {
           <CardTitle className="text-base">Cadences</CardTitle>
           <CardDescription>
             The outreach sequences your team can enroll businesses into. Editing creates a new
-            version — businesses mid-cadence finish on the version they started.
+            version — businesses mid-cadence finish on the version they started. Drafts are
+            visible only to their creator and admins until published.
           </CardDescription>
         </div>
         <Button size="sm" asChild>
@@ -58,11 +68,28 @@ export default function CadenceStudio() {
             <div className="min-w-0 flex-1">
               <p className="text-sm font-semibold m-0">
                 {c.name} <span className="font-normal" style={{ color: 'var(--ro-text-3)' }}>v{c.version}</span>
+                {!c.publishedAt && (
+                  <span
+                    className="ml-2 inline-block align-middle rounded-full border border-dashed border-border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide"
+                    style={{ color: 'var(--ro-text-2)' }}
+                  >
+                    Draft
+                  </span>
+                )}
               </p>
               <p className="text-xs m-0 mt-0.5 truncate" style={{ color: 'var(--ro-text-2)' }}>
                 {(c.steps || []).length} steps — {(c.steps || []).map((s) => CHANNEL_LABEL[s.channel] || s.channel).join(' → ')}
               </p>
             </div>
+            {!c.publishedAt && (
+              <Button
+                size="sm" variant="outline"
+                disabled={publishMutation.isPending}
+                onClick={() => publishMutation.mutate(c.id)}
+              >
+                Publish
+              </Button>
+            )}
             <Button size="sm" variant="ghost" aria-label={`Edit ${c.name}`} asChild>
               <Link to={`/redeem-ops/cadences/${c.id}/edit`}>
                 <Pencil className="w-3.5 h-3.5" aria-hidden="true" />

--- a/src/components/redeemops/__tests__/cadence.test.jsx
+++ b/src/components/redeemops/__tests__/cadence.test.jsx
@@ -141,8 +141,8 @@ describe('CadenceEditorPage (full-page builder)', () => {
     );
   }
 
-  it('creates a cadence from the mapped builder state', async () => {
-    api.createCadence.mockResolvedValue({ id: 'c-new', version: 1 });
+  it('creates & publishes a cadence from the mapped builder state', async () => {
+    api.createCadence.mockResolvedValue({ id: 'c-new', version: 1, publishedAt: new Date().toISOString() });
     const user = userEvent.setup();
     renderNew();
 
@@ -152,19 +152,36 @@ describe('CadenceEditorPage (full-page builder)', () => {
     const titles = screen.getAllByPlaceholderText(/what the rep sees/i);
     await user.type(titles[1], 'WhatsApp follow-up');
 
-    await user.click(screen.getByRole('button', { name: /create cadence/i }));
+    await user.click(screen.getByRole('button', { name: /create & publish/i }));
     await waitFor(() => expect(api.createCadence).toHaveBeenCalledTimes(1));
     const payload = api.createCadence.mock.calls[0][0];
     expect(payload.name).toBe('Fitness studios chase');
+    expect(payload.publish).toBe(true);
     expect(payload.steps).toHaveLength(2);
     expect(payload.steps[0]).toMatchObject({ channel: 'call', title: 'Intro call', continueOn: 'no_answer' });
     expect(payload.steps[1]).toMatchObject({ channel: 'whatsapp', title: 'WhatsApp follow-up' });
   });
 
+  it('"Save as draft" sends publish:false and says who can see it', async () => {
+    api.createCadence.mockResolvedValue({ id: 'c-draft', version: 1, publishedAt: null });
+    const user = userEvent.setup();
+    renderNew();
+
+    await user.type(screen.getByPlaceholderText(/beauty salons/i), 'My private chase');
+    await user.type(screen.getByPlaceholderText(/what the rep sees/i), 'Intro call');
+    await user.click(screen.getByRole('button', { name: /save as draft/i }));
+
+    await waitFor(() => expect(api.createCadence).toHaveBeenCalledTimes(1));
+    expect(api.createCadence.mock.calls[0][0].publish).toBe(false);
+    await waitFor(() => expect(toastMock.success).toHaveBeenCalledWith(
+      expect.stringMatching(/only you and admins/i)
+    ));
+  });
+
   it('refuses to save without a name', async () => {
     const user = userEvent.setup();
     renderNew();
-    await user.click(screen.getByRole('button', { name: /create cadence/i }));
+    await user.click(screen.getByRole('button', { name: /create & publish/i }));
     expect(api.createCadence).not.toHaveBeenCalled();
     expect(toastMock.error).toHaveBeenCalled();
   });

--- a/src/components/redeemops/cadence.jsx
+++ b/src/components/redeemops/cadence.jsx
@@ -1,9 +1,13 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import Zap from 'lucide-react/icons/zap';
 import Eye from 'lucide-react/icons/eye';
+import Plus from 'lucide-react/icons/plus';
 import { redeemOpsApi } from '@/api/redeemOps';
+import { useAuthStore } from '@/stores/authStore';
+import { hasCapability } from '@/lib/redeemOpsPermissions';
 import { Button } from '@/components/ui/button';
 import {
   Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
@@ -184,6 +188,9 @@ export function CadencePanel({ partner, canManage = true, variant = 'card' }) {
   const queryClient = useQueryClient();
   const [enrollOpen, setEnrollOpen] = useState(false);
   const partnerId = partner?.id;
+  const authUser = useAuthStore((s) => s.user);
+  // Anyone who works tasks can author; unpublished saves stay private drafts.
+  const canAuthor = hasCapability(authUser, 'tasks.manage');
 
   const cadenceQuery = useQuery({
     queryKey: ['redeem-ops', 'partner-cadence', partnerId],
@@ -355,7 +362,18 @@ export function CadencePanel({ partner, canManage = true, variant = 'card' }) {
                 disabled={enrollMutation.isPending}
                 onClick={() => enrollMutation.mutate({ cadenceId: c.id })}
               >
-                <p className="text-sm font-semibold m-0">{c.name}</p>
+                <p className="text-sm font-semibold m-0">
+                  {c.name}
+                  {/* drafts only reach their creator + admins — flag them */}
+                  {!c.publishedAt && (
+                    <span
+                      className="ml-2 inline-block align-middle rounded-full border border-dashed border-border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide"
+                      style={{ color: 'var(--ro-text-2)' }}
+                    >
+                      Draft
+                    </span>
+                  )}
+                </p>
                 <p className="text-xs m-0 mt-0.5" style={{ color: 'var(--ro-text-2)' }}>
                   {c.steps?.length || 0} steps — {(c.steps || []).map((s) => CHANNEL_LABELS[s.channel] || s.channel).join(' → ')}
                 </p>
@@ -364,6 +382,14 @@ export function CadencePanel({ partner, canManage = true, variant = 'card' }) {
             {defsQuery.isLoading && <p className="text-sm m-0" style={{ color: 'var(--ro-text-2)' }}>Loading cadences…</p>}
             {!defsQuery.isLoading && cadenceDefs.length === 0 && (
               <p className="text-sm m-0" style={{ color: 'var(--ro-text-2)' }}>No cadences defined yet.</p>
+            )}
+            {canAuthor && (
+              <Button size="sm" variant="ghost" className="w-full" asChild>
+                <Link to="/redeem-ops/cadences/new">
+                  <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" />
+                  New cadence — yours stays a private draft until you publish it
+                </Link>
+              </Button>
             )}
           </div>
         </DialogContent>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -135,9 +135,11 @@ function redeemOpsRouteElements() {
     { path: '/redeem-ops/profile', capability: null, Page: RedeemOpsProfile },
     { path: '/redeem-ops/settings', capability: 'settings.manage', Page: RedeemOpsSettings },
     // Full-page cadence editor (a dialog was too cramped for a step editor).
+    // tasks.manage: any rep can author — unpublished saves stay private drafts
+    // (creator + admins); the service enforces per-row edit rights.
     ...(CADENCES_ENABLED ? [
-      { path: '/redeem-ops/cadences/new', capability: 'settings.manage', Page: RedeemOpsCadenceEditor },
-      { path: '/redeem-ops/cadences/:cadenceId/edit', capability: 'settings.manage', Page: RedeemOpsCadenceEditor },
+      { path: '/redeem-ops/cadences/new', capability: 'tasks.manage', Page: RedeemOpsCadenceEditor },
+      { path: '/redeem-ops/cadences/:cadenceId/edit', capability: 'tasks.manage', Page: RedeemOpsCadenceEditor },
     ] : []),
   ];
   return routes.map(({ path, capability, Page }) => (

--- a/src/pages/redeemops/CadenceEditorPage.jsx
+++ b/src/pages/redeemops/CadenceEditorPage.jsx
@@ -9,6 +9,8 @@ import ArrowDown from 'lucide-react/icons/arrow-down';
 import Zap from 'lucide-react/icons/zap';
 import Sparkles from 'lucide-react/icons/sparkles';
 import { redeemOpsApi } from '@/api/redeemOps';
+import { useAuthStore } from '@/stores/authStore';
+import { hasCapability } from '@/lib/redeemOpsPermissions';
 import { Button } from '@/components/ui/button';
 import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
@@ -160,6 +162,10 @@ export default function CadenceEditorPage() {
   });
   const base = isNew ? null : (listQuery.data?.cadences || []).find((c) => c.id === cadenceId);
   const aiEnabled = listQuery.data?.aiEnabled === true;
+  const baseIsDraft = !!base && !base.publishedAt;
+  // Non-admins can't open Settings — send them back to their queue instead.
+  const user = useAuthStore((s) => s.user);
+  const backTo = hasCapability(user, 'settings.manage') ? '/redeem-ops/settings' : '/redeem-ops/queue';
 
   useEffect(() => {
     if (base && loadedFrom !== base.id) {
@@ -173,9 +179,9 @@ export default function CadenceEditorPage() {
   useEffect(() => {
     if (!isNew && listQuery.isSuccess && !base) {
       toast.error('Cadence not found');
-      navigate('/redeem-ops/settings', { replace: true });
+      navigate(backTo, { replace: true });
     }
-  }, [isNew, listQuery.isSuccess, base, navigate]);
+  }, [isNew, listQuery.isSuccess, base, navigate, backTo]);
 
   const saveMutation = useMutation({
     mutationFn: (payload) => (isNew
@@ -183,18 +189,23 @@ export default function CadenceEditorPage() {
       : redeemOpsApi.createCadenceVersion(cadenceId, payload)),
     onSuccess: (cadence) => {
       queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'cadences'] });
+      const stillDraft = !cadence?.publishedAt;
       toast.success(isNew
-        ? 'Cadence created — it’s in every Start cadence picker now'
-        : `Saved as v${cadence?.version} — businesses already enrolled finish on their current version`);
-      navigate('/redeem-ops/settings');
+        ? (stillDraft
+          ? 'Draft saved — only you and admins can see it until you publish'
+          : 'Cadence created — it’s in every Start cadence picker now')
+        : `Saved as v${cadence?.version}${stillDraft ? ' (still a draft)' : ''} — businesses already enrolled finish on their current version`);
+      navigate(backTo);
     },
     onError: (err) => toast.error('Could not save the cadence', { description: err.message }),
   });
 
-  const save = () => {
+  // publish=false keeps it a private draft; on a published base the flag is
+  // moot (the server never unpublishes).
+  const save = (publish) => {
     if (!name.trim()) return toast.error('Give the cadence a name');
     if (steps.some((s) => !s.title.trim())) return toast.error('Every step needs a title');
-    return saveMutation.mutate(toPayload({ name, description, steps }));
+    return saveMutation.mutate({ ...toPayload({ name, description, steps }), publish });
   };
 
   // The AI draft only POPULATES the builder — creating still goes through the
@@ -237,17 +248,26 @@ export default function CadenceEditorPage() {
   return (
     <div className="p-4 md:p-8 max-w-6xl mx-auto space-y-5">
       <RoPageHeader
-        title={isNew ? 'New cadence' : `Edit — ${base?.name || ''}`}
+        title={isNew ? 'New cadence' : `Edit — ${base?.name || ''}${baseIsDraft ? ' (draft)' : ''}`}
         sub={isNew
           ? 'Each step becomes a task in the owner’s queue at the right time. Replies and “not interested” always end the cadence early.'
-          : `Saving creates v${(base?.version || 1) + 1}. Businesses already enrolled keep following v${base?.version}.`}
+          : `Saving creates v${(base?.version || 1) + 1}. Businesses already enrolled keep following v${base?.version}.${
+            baseIsDraft ? ' This cadence is an unpublished draft — only you and admins can see it.' : ''}`}
         actions={(
           <span className="inline-flex gap-2">
             <Button variant="outline" asChild>
-              <Link to="/redeem-ops/settings">Cancel</Link>
+              <Link to={backTo}>Cancel</Link>
             </Button>
-            <Button disabled={saveMutation.isPending} onClick={save}>
-              {saveMutation.isPending ? 'Saving…' : isNew ? 'Create cadence' : `Save as v${(base?.version || 1) + 1}`}
+            {(isNew || baseIsDraft) && (
+              <Button variant="outline" disabled={saveMutation.isPending} onClick={() => save(false)}>
+                {isNew ? 'Save as draft' : 'Save draft'}
+              </Button>
+            )}
+            <Button disabled={saveMutation.isPending} onClick={() => save(true)}>
+              {saveMutation.isPending ? 'Saving…'
+                : isNew ? 'Create & publish'
+                  : baseIsDraft ? 'Save & publish'
+                    : `Save as v${(base?.version || 1) + 1}`}
             </Button>
           </span>
         )}


### PR DESCRIPTION
## What

Saving a cadence can now keep it a **private draft**: only the creator and admins can see it. Peers see nothing until it's **published** team-wide.

## Behavior

- **Draft** = `outreach_cadences.publishedAt IS NULL` (migration 066; every existing row backfills as published, so nothing changes for current cadences or the two seeds).
- **Who sees a draft:** its creator + admins (`settings.manage` tier). It appears in their cadence list and Start-cadence picker with a **Draft** badge, and they can enroll partners into it (version-pinned as usual). For everyone else it does not exist — list, enroll, edit, retire and publish all answer 404, so drafts never leak.
- **Authoring opens to reps:** create/edit routes move from `settings.manage` to `tasks.manage` (the AI-draft endpoint follows). Row rules live in the service: only the **creator or an admin** may edit, retire or publish a given cadence; edits of someone else's *published* cadence are a plain 403.
- **Publishing is one-way** (no unpublish — the team may already rely on it). Version bumps carry draft-ness; a draft can be flipped live either via `POST /cadences/:id/publish` or by saving a version with `publish: true`.
- **API compat:** `publish` omitted on create = published immediately (exact pre-draft behavior for existing callers/tests).

## UI

- **Editor** (`/redeem-ops/cadences/new`): **Save as draft** / **Create & publish**. Editing a draft: **Save draft** / **Save & publish**, with draft status called out in the header. Non-admins are routed back to their queue instead of Settings.
- **Settings → Cadences:** Draft badge + **Publish** button on draft rows.
- **Start-cadence picker:** drafts badged; reps get a **New cadence** entry point (their saves stay private drafts until published).

## Tests

- 5 new route-level tests: draft listing matrix (creator/admin/peer), enroll gate (peer 404 / creator 201), row rules (404 invisible vs 403 visible-not-yours), publish-opens-team-wide, save-and-publish-in-one-step, plus published-by-default compat and seed assertions.
- Backend: all 20 `redeemOps*` suites — 276/277 pass; the 1 failure is the known pre-existing `redeemOpsRewards` onboarding-checklist failure (baseline-verified previously, untouched by this PR).
- Frontend: cadence + permission-drift suites pass; `vite build` green.

## Notes

- "Admins" for draft visibility = `settings.manage` (admin / super_admin / ops_admin) — deliberately **not** bdm.
- Conflicts: none expected with PR #155 (`{{rep_name}}`) — different regions of `cadenceService.js`/editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)