### PR TITLE
feat(marketplace): Redeem.sg marketplace v2 — consumer browse/offer/flow (dark launch)

### DIFF
--- a/TRACKER.md
+++ b/TRACKER.md
@@ -123,6 +123,7 @@ Retell AI performs the call and provides analysis natively. MKTR stores the resu
 | Latency monitoring | NONE | No p95/p99 tracking on the webhook delivery path |
 | Alerting | NONE | No alerting on webhook failure rates or lead delivery failures |
 | Rate limiting (Retell webhook) | NONE | `/api/retell/webhook` has no auth or rate limit — only signature check |
+| Redeem marketplace v2 (consumer browse/offer/flow) | DONE (dark) | 2026-07-14, `docs/plans/redeem-marketplace-v2.md`. Public composed API `GET /api/marketplace/campaigns[/:slug]` (flag `MARKETPLACE_PUBLIC_API_ENABLED`), campaigns.slug + firstActivatedAt (066), partner public profile (067), admin-only `marketplaceListed` gate, redeem-build SPA (`/explore`, `/offers/:slug`, `/flow/:slug`, `/dsa`, statics; flag `VITE_REDEEM_MARKETPLACE_ENABLED`), designer Marketplace tab, tracker `qr_entry` branch (flag `MARKETPLACE_QR_REDIRECT_ENABLED`), pixel predicate + `vc:{campaign_id}` session guard + custom funnel events, `sourceMetadata.marketplace` intake, previews/public design_config whitelist hardening. All three flags default OFF. |
 
 ---
 

--- a/backend/src/controllers/campaignController.js
+++ b/backend/src/controllers/campaignController.js
@@ -1,6 +1,7 @@
 import { asyncHandler, AppError } from '../middleware/errorHandler.js';
 import * as campaignService from '../services/campaignService.js';
 import * as featuredDropsService from '../services/featuredDropsService.js';
+import * as marketplaceService from '../services/marketplaceService.js';
 import * as leadPackageService from '../services/leadPackageService.js';
 import { loadCampaignReadiness } from '../services/campaignReadinessService.js';
 import { loadQuizAnalytics } from '../services/quizAnalyticsService.js';
@@ -11,6 +12,24 @@ export const getFeaturedDrops = asyncHandler(async (req, res) => {
   const drops = await featuredDropsService.getFeaturedDrops();
   res.set('Cache-Control', 'public, max-age=60');
   res.json({ success: true, data: { drops } });
+});
+
+// Authenticated designer support (docs/plans/redeem-marketplace-v2.md Phase 1):
+// the composed marketplace DTO for ANY campaign (drafts/unlisted included —
+// no publication gate) so the designer can preview what consumers would see,
+// plus a slug-availability check. Both independent of the public feature flag.
+export const getMarketplacePreview = asyncHandler(async (req, res) => {
+  const preview = await marketplaceService.previewMarketplaceCampaign(req.params.id);
+  if (!preview) throw new AppError('Campaign not found', 404);
+  res.json({ success: true, data: { campaign: preview } });
+});
+
+export const checkSlugAvailability = asyncHandler(async (req, res) => {
+  const result = await marketplaceService.checkSlugAvailability(
+    String(req.query.slug || ''),
+    { excludeCampaignId: req.query.excludeCampaignId || undefined }
+  );
+  res.json({ success: true, data: result });
 });
 
 export const listCampaigns = asyncHandler(async (req, res) => {

--- a/backend/src/controllers/campaignController.js
+++ b/backend/src/controllers/campaignController.js
@@ -19,8 +19,8 @@ export const getFeaturedDrops = asyncHandler(async (req, res) => {
 // no publication gate) so the designer can preview what consumers would see,
 // plus a slug-availability check. Both independent of the public feature flag.
 export const getMarketplacePreview = asyncHandler(async (req, res) => {
-  const preview = await marketplaceService.previewMarketplaceCampaign(req.params.id);
-  if (!preview) throw new AppError('Campaign not found', 404);
+  const preview = await marketplaceService.previewMarketplaceCampaign(req.params.id, { user: req.user });
+  if (!preview) throw new AppError('Campaign not found or access denied', 404);
   res.json({ success: true, data: { campaign: preview } });
 });
 

--- a/backend/src/controllers/redeemOps/partnersController.js
+++ b/backend/src/controllers/redeemOps/partnersController.js
@@ -27,6 +27,11 @@ const partnerBodySchema = Joi.object({
   tags: Joi.array().items(Joi.string().max(48)).max(20),
   notes: Joi.string().max(5000).allow('', null),
   overrideReason: Joi.string().max(255).allow('', null),
+  // Marketplace public profile (migration 067). `verified` is a request
+  // intent — admin-only, mapped to verifiedAt by the service.
+  publicBlurb: Joi.string().max(600).allow('', null),
+  partnerSince: Joi.number().integer().min(2000).max(2100).allow(null),
+  verified: Joi.boolean(),
 });
 
 function validateBody(schema, body) {

--- a/backend/src/controllers/trackerController.js
+++ b/backend/src/controllers/trackerController.js
@@ -2,6 +2,33 @@ import { asyncHandler } from '../middleware/errorHandler.js';
 import * as trackerService from '../services/trackerService.js';
 import { publicHostFromRequest, cookieDomainForPublicHost } from '../utils/publicHost.js';
 import { frontendBaseForHost } from '../utils/frontendBase.js';
+import { Campaign } from '../models/index.js';
+import { passesStaticGate } from '../services/marketplaceService.js';
+
+/**
+ * qr_entry branch (docs/plans/redeem-marketplace-v2.md Phase 5): a marketplace
+ * campaign can opt its QR scans into the offer-detail page instead of the
+ * direct flow. Own flag (flipped only AFTER the SPA routes deploy), redeem
+ * host only (frontendBaseForHost deliberately returns mktr.sg for mktr
+ * requests, and /offers doesn't exist on the mktr build), and the campaign
+ * must pass the marketplace publication gate. Anything else keeps today's
+ * /LeadCapture redirect byte-for-byte.
+ */
+async function marketplaceDetailPath(qrTag, publicHost) {
+  if (process.env.MARKETPLACE_QR_REDIRECT_ENABLED !== 'true') return null;
+  if (!publicHost || !String(publicHost).endsWith('redeem.sg')) return null;
+  if (!qrTag.campaignId) return null;
+  try {
+    const campaign = await Campaign.findByPk(qrTag.campaignId, {
+      attributes: ['id', 'slug', 'type', 'status', 'is_active', 'design_config'],
+    });
+    if (!campaign || !passesStaticGate(campaign)) return null;
+    if (campaign.design_config?.qr_entry !== 'detail') return null;
+    return `/offers/${campaign.slug}`;
+  } catch {
+    return null; // attribution must never break over a marketplace lookup
+  }
+}
 
 export const trackSlug = asyncHandler(async (req, res) => {
   res.set('X-Robots-Tag', 'noindex, nofollow');
@@ -60,6 +87,10 @@ export const trackSlug = asyncHandler(async (req, res) => {
   }
 
   const search = trackerService.buildRedirectParams(qrTag);
+  const detailPath = await marketplaceDetailPath(qrTag, publicHost);
+  if (detailPath) {
+    return res.redirect(302, `${frontendBase}${detailPath}?${search}`);
+  }
   return res.redirect(302, `${frontendBase}/LeadCapture?${search}`);
 });
 

--- a/backend/src/database/migrations/066-add-campaign-slug.js
+++ b/backend/src/database/migrations/066-add-campaign-slug.js
@@ -1,0 +1,30 @@
+/**
+ * 066 — Marketplace campaign slug + first-activation anchor.
+ *
+ * `slug` is the consumer-facing URL handle for /offers/:slug and /flow/:slug
+ * ONLY (QR tags and previews keep their own slug namespaces). Nullable —
+ * existing campaigns are not marketplace-addressable until an admin authors
+ * one. Partial unique index (also mirrored on the model — sync({force:true})
+ * in test boot clobbers migration indexes otherwise, see lucky-draw lesson).
+ *
+ * `firstActivatedAt` is the durable "ever activated" anchor: campaignService
+ * stamps it the first time is_active flips true, and slug becomes immutable
+ * from then on. Guarded/idempotent like 052–065.
+ */
+export async function up(queryInterface) {
+  await queryInterface.sequelize.query(
+    'ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS "slug" VARCHAR(80)'
+  );
+  await queryInterface.sequelize.query(
+    'ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS "firstActivatedAt" TIMESTAMP WITH TIME ZONE'
+  );
+  await queryInterface.sequelize.query(
+    'CREATE UNIQUE INDEX IF NOT EXISTS uq_campaigns_slug ON campaigns ("slug") WHERE "slug" IS NOT NULL'
+  );
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query('DROP INDEX IF EXISTS uq_campaigns_slug');
+  await queryInterface.sequelize.query('ALTER TABLE campaigns DROP COLUMN IF EXISTS "slug"');
+  await queryInterface.sequelize.query('ALTER TABLE campaigns DROP COLUMN IF EXISTS "firstActivatedAt"');
+}

--- a/backend/src/database/migrations/066-add-campaign-slug.js
+++ b/backend/src/database/migrations/066-add-campaign-slug.js
@@ -21,6 +21,15 @@ export async function up(queryInterface) {
   await queryInterface.sequelize.query(
     'CREATE UNIQUE INDEX IF NOT EXISTS uq_campaigns_slug ON campaigns ("slug") WHERE "slug" IS NOT NULL'
   );
+  // Backfill: campaigns already live when this migration runs get their
+  // activation anchor immediately — otherwise a legacy active campaign could
+  // set AND repeatedly change a live marketplace slug (the lock only fires
+  // when firstActivatedAt is present). Guarded on NULL → idempotent.
+  await queryInterface.sequelize.query(
+    `UPDATE campaigns
+       SET "firstActivatedAt" = COALESCE("updatedAt", now())
+     WHERE "firstActivatedAt" IS NULL AND is_active = true AND status = 'active'`
+  );
 }
 
 export async function down(queryInterface) {

--- a/backend/src/database/migrations/067-partner-public-profile.js
+++ b/backend/src/database/migrations/067-partner-public-profile.js
@@ -1,0 +1,26 @@
+/**
+ * 067 — Consumer-facing partner profile fields for the marketplace.
+ *
+ * The existing PartnerOrganisation fields are CRM-internal (notes, pipeline)
+ * and must never surface publicly, so the marketplace gets three dedicated
+ * columns: publicBlurb (consumer copy), verifiedAt (verification stamp —
+ * null = unverified; admin-set only), partnerSince (display year).
+ * camelCase DDL (sequelize underscored:false). Guarded/idempotent.
+ */
+export async function up(queryInterface) {
+  await queryInterface.sequelize.query(
+    'ALTER TABLE partner_organisations ADD COLUMN IF NOT EXISTS "publicBlurb" TEXT'
+  );
+  await queryInterface.sequelize.query(
+    'ALTER TABLE partner_organisations ADD COLUMN IF NOT EXISTS "verifiedAt" TIMESTAMP WITH TIME ZONE'
+  );
+  await queryInterface.sequelize.query(
+    'ALTER TABLE partner_organisations ADD COLUMN IF NOT EXISTS "partnerSince" SMALLINT'
+  );
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query('ALTER TABLE partner_organisations DROP COLUMN IF EXISTS "publicBlurb"');
+  await queryInterface.sequelize.query('ALTER TABLE partner_organisations DROP COLUMN IF EXISTS "verifiedAt"');
+  await queryInterface.sequelize.query('ALTER TABLE partner_organisations DROP COLUMN IF EXISTS "partnerSince"');
+}

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -106,7 +106,9 @@ export const schemas = {
     ad_playlist: Joi.array().items(Joi.object()).optional(),
     enforceLeadQuota: Joi.boolean().optional(),
     metaPixelId: Joi.string().max(64).optional().allow(null, ''),
-    tiktokPixelId: Joi.string().max(64).optional().allow(null, '')
+    tiktokPixelId: Joi.string().max(64).optional().allow(null, ''),
+    // Marketplace URL handle — service enforces charset/lock; format-only here.
+    slug: Joi.string().max(80).optional().allow(null, '')
   }),
 
   campaignUpdate: Joi.object({
@@ -125,7 +127,9 @@ export const schemas = {
     ad_playlist: Joi.array().items(Joi.object()).optional(),
     enforceLeadQuota: Joi.boolean().optional(),
     metaPixelId: Joi.string().max(64).optional().allow(null, ''),
-    tiktokPixelId: Joi.string().max(64).optional().allow(null, '')
+    tiktokPixelId: Joi.string().max(64).optional().allow(null, ''),
+    // Marketplace URL handle — service enforces charset + post-activation lock.
+    slug: Joi.string().max(80).optional().allow(null, '')
   }).min(1),
 
   // Car schemas
@@ -232,6 +236,17 @@ export const schemas = {
     // client; this flag only records that the person ticked the box. That evidence is what
     // releases an otherwise-held DNC-registered lead (services/dncConsent.hasValidDncConsent).
     consent_dnc: Joi.boolean().optional(),
+    // Marketplace flow extras (redeem.sg /flow/:slug — docs/plans/
+    // redeem-marketplace-v2.md Phase 4). Whitelisted here (this endpoint runs
+    // stripUnknown, so an unlisted key is silently dropped); prospectService
+    // VALIDATES the values against the campaign's config before stashing them
+    // at sourceMetadata.marketplace — never trusted as free text downstream.
+    marketplace: Joi.object({
+      child_name: Joi.string().max(120).optional().allow(''),
+      child_school_level: Joi.string().max(120).optional().allow(''),
+      preferred_branch: Joi.string().max(120).optional().allow(''),
+      preferred_timing: Joi.string().max(120).optional().allow('')
+    }).optional(),
     // Quiz funnel: raw answers + an advisory client-computed result. The server
     // RE-SCORES authoritatively from campaign.design_config.quiz (see
     // prospectService.createProspect) and stashes the result in

--- a/backend/src/models/Campaign.js
+++ b/backend/src/models/Campaign.js
@@ -1,4 +1,4 @@
-import { DataTypes } from 'sequelize';
+import { DataTypes, Op } from 'sequelize';
 import { sequelize } from '../database/connection.js';
 
 const Campaign = sequelize.define('Campaign', {
@@ -208,10 +208,27 @@ const Campaign = sequelize.define('Campaign', {
     allowNull: true,
     field: 'agent_notes',
     comment: 'string[] agent obligations; NULL treated as [] by the catalog'
+  },
+  slug: {
+    type: DataTypes.STRING(80),
+    allowNull: true,
+    validate: { is: /^[a-z0-9-]{3,80}$/ },
+    comment: 'Marketplace URL handle (/offers/:slug, /flow/:slug only). Immutable once firstActivatedAt is set.'
+  },
+  firstActivatedAt: {
+    type: DataTypes.DATE,
+    allowNull: true,
+    comment: 'Stamped the first time is_active flips true; locks the slug'
   }
 }, {
   tableName: 'campaigns',
   indexes: [
+    {
+      unique: true,
+      fields: ['slug'],
+      where: { slug: { [Op.ne]: null } },
+      name: 'uq_campaigns_slug'
+    },
     {
       fields: ['status']
     },

--- a/backend/src/models/PartnerOrganisation.js
+++ b/backend/src/models/PartnerOrganisation.js
@@ -64,6 +64,12 @@ const PartnerOrganisation = sequelize.define('PartnerOrganisation', {
 
   mergedIntoId: { type: DataTypes.UUID, allowNull: true, references: { model: 'partner_organisations', key: 'id' }, comment: 'Set on merge; row retained, hidden from lists' },
   archivedAt: { type: DataTypes.DATE, allowNull: true },
+
+  // Consumer-facing marketplace profile (migration 067). Everything else on
+  // this model is CRM-internal and must never surface publicly.
+  publicBlurb: { type: DataTypes.TEXT, allowNull: true, comment: 'Consumer-facing partner blurb (marketplace)' },
+  verifiedAt: { type: DataTypes.DATE, allowNull: true, comment: 'Verification stamp — null = unverified; admin-set only' },
+  partnerSince: { type: DataTypes.SMALLINT, allowNull: true, comment: 'Display year for "on Redeem since"' },
   createdBy: { type: DataTypes.UUID, allowNull: false, references: { model: 'users', key: 'id' } }
 }, {
   tableName: 'partner_organisations',

--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -28,6 +28,12 @@ const router = express.Router();
 // paths and would create /api/previews/featured-drops aliases.
 router.get('/featured-drops', campaignController.getFeaturedDrops);
 
+// Authenticated designer support — declared before /:id so "slug-availability"
+// can't be captured as a campaign id. Flag-independent (the designer must be
+// able to stage marketplace content before the public API is enabled).
+router.get('/slug-availability', authenticateToken, campaignController.checkSlugAvailability);
+router.get('/:id/marketplace-preview', authenticateToken, campaignController.getMarketplacePreview);
+
 /**
  * @openapi
  * /campaigns:

--- a/backend/src/routes/marketplace.js
+++ b/backend/src/routes/marketplace.js
@@ -1,0 +1,45 @@
+import express from 'express';
+import rateLimit from 'express-rate-limit';
+import { asyncHandler } from '../middleware/errorHandler.js';
+import * as marketplaceService from '../services/marketplaceService.js';
+
+/**
+ * PUBLIC marketplace read API — backs redeem.sg /explore, /offers/:slug and
+ * /flow/:slug (docs/plans/redeem-marketplace-v2.md Phase 1).
+ *
+ * Read-only. Every response is a rebuilt DTO (design_config + ops) — never a
+ * raw campaign row. Dark-launched behind MARKETPLACE_PUBLIC_API_ENABLED.
+ */
+export const meta = {
+  path: '/api/marketplace',
+  flag: 'MARKETPLACE_PUBLIC_API_ENABLED',
+  flagDefault: 'false',
+};
+
+const listLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 120, // browse-heavy surface; generous for humans, hostile to scrapers
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { success: false, message: 'Too many requests — try again later.' },
+});
+
+const router = express.Router();
+
+router.get('/campaigns', listLimiter, asyncHandler(async (req, res) => {
+  const campaigns = await marketplaceService.listMarketplaceCampaigns();
+  res.set('Cache-Control', 'public, max-age=60');
+  res.json({ success: true, data: { campaigns } });
+}));
+
+router.get('/campaigns/:slug', listLimiter, asyncHandler(async (req, res) => {
+  const campaign = await marketplaceService.getMarketplaceCampaign(String(req.params.slug || ''));
+  if (!campaign) {
+    return res.status(404).json({ success: false, message: 'Campaign not found' });
+  }
+  // Detail is composed live (sold-out/paused must be immediate) — short edge cache only.
+  res.set('Cache-Control', 'public, max-age=30');
+  res.json({ success: true, data: { campaign } });
+}));
+
+export default router;

--- a/backend/src/services/campaignPreviewService.js
+++ b/backend/src/services/campaignPreviewService.js
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import { Campaign, CampaignPreview } from '../models/index.js';
+import { buildPublicDesignConfig } from '../utils/publicDesignConfig.js';
 
 function generateSlug() {
   return crypto.randomBytes(16).toString('hex');
@@ -66,13 +67,17 @@ export async function resolveSlug(slug) {
   if (campaign) {
     snapshot = {
       ...snapshot,
-      design_config: campaign.design_config || {},
+      // Public endpoint: whitelist-rebuild, never the raw JSONB (it carries
+      // internal luckyDraw activation/terms ids).
+      design_config: buildPublicDesignConfig(campaign.design_config),
       name: campaign.name,
       type: campaign.type,
       min_age: campaign.min_age,
       max_age: campaign.max_age,
       is_active: true
     };
+  } else if (snapshot && typeof snapshot === 'object' && snapshot.design_config) {
+    snapshot = { ...snapshot, design_config: buildPublicDesignConfig(snapshot.design_config) };
   }
 
   return { snapshot, campaignId: preview.campaignId };
@@ -97,5 +102,10 @@ export async function getPublicCampaign(id) {
     throw err;
   }
 
-  return campaign;
+  // design_config is an unconstrained JSONB that also carries INTERNAL state
+  // (luckyDraw activation/terms ids, future keys). This endpoint is public —
+  // rebuild through the whitelist, never dump the raw column.
+  const plain = campaign.toJSON();
+  plain.design_config = buildPublicDesignConfig(plain.design_config);
+  return plain;
 }

--- a/backend/src/services/campaignService.js
+++ b/backend/src/services/campaignService.js
@@ -7,6 +7,18 @@ import { AppError } from '../middleware/errorHandler.js';
 import { normalizeCustomerHostChoice } from '../utils/customerHost.js';
 import { applyFeaturedDropPolicy } from '../utils/featuredDrop.js';
 import { applyLuckyDrawPolicy } from '../utils/luckyDraw.js';
+import { normalizeMarketplaceContent, applyMarketplacePolicy } from '../utils/marketplaceContent.js';
+import { invalidateMarketplaceCache } from './marketplaceCache.js';
+
+const SLUG_RE = /^[a-z0-9-]{3,80}$/;
+
+// design_config keys owned by the marketplace normalizer — raw incoming values
+// for these are replaced wholesale by their normalized versions (or dropped).
+const MARKETPLACE_CONTENT_KEYS = [
+  'name', 'category', 'offer_type', 'mode', 'qr_entry', 'age_range',
+  'school_levels', 'dsa_related', 'showCapacity', 'availability', 'inclusions',
+  'image_label', 'activation', 'sponsor', 'value_line', 'content_blocks',
+];
 
 /**
  * Clamp the security-sensitive keys of a design_config before persisting.
@@ -33,6 +45,21 @@ function clampDesignConfig(incoming, storedConfig, role) {
   });
   if (luckyDraw === undefined) delete clamped.luckyDraw;
   else clamped.luckyDraw = luckyDraw;
+
+  // Marketplace content keys: normalized wholesale (echoed on public
+  // /offers pages — see utils/marketplaceContent.js). Raw values replaced.
+  for (const key of MARKETPLACE_CONTENT_KEYS) delete clamped[key];
+  Object.assign(clamped, normalizeMarketplaceContent(incoming));
+
+  // marketplaceListed is the ONLY consumer-exposure switch — admin-only, like
+  // featuredDrop (campaign PUT is open to agents, who can flip is_active).
+  const listed = applyMarketplacePolicy({
+    incoming: incoming.marketplaceListed,
+    stored: storedConfig?.marketplaceListed,
+    role,
+  });
+  if (listed === undefined) delete clamped.marketplaceListed;
+  else clamped.marketplaceListed = listed;
   return clamped;
 }
 
@@ -274,6 +301,14 @@ export async function createCampaign(body, user) {
     status: is_active ? 'active' : 'draft',
     type: body.type || 'lead_generation'
   };
+  if (campaignData.is_active) campaignData.firstActivatedAt = new Date();
+  if (body.slug !== undefined && body.slug !== null && body.slug !== '') {
+    const slug = String(body.slug).trim().toLowerCase();
+    if (!SLUG_RE.test(slug)) {
+      throw new AppError('Slug must be 3-80 chars of lowercase letters, digits and hyphens.', 422);
+    }
+    campaignData.slug = slug;
+  }
   if (commission_amount_driver !== undefined) campaignData.commission_amount_driver = commission_amount_driver;
   if (commission_amount_fleet !== undefined) campaignData.commission_amount_fleet = commission_amount_fleet;
   if (defaultAssignmentMode !== undefined) campaignData.defaultAssignmentMode = defaultAssignmentMode;
@@ -307,7 +342,16 @@ export async function createCampaign(body, user) {
     }
   }
 
-  const campaign = await Campaign.create(campaignData);
+  let campaign;
+  try {
+    campaign = await Campaign.create(campaignData);
+  } catch (err) {
+    if (err?.name === 'SequelizeUniqueConstraintError') {
+      throw new AppError('That marketplace slug is already taken by another campaign.', 409);
+    }
+    throw err;
+  }
+  invalidateMarketplaceCache();
 
   if (campaignData.design_config?.luckyDraw?.enabled === true) {
     const withTerms = await ensureDrawTermsVersion(campaignData.design_config, campaign.id, user.id);
@@ -360,6 +404,23 @@ export async function updateCampaign(id, body, req) {
   if (is_active !== undefined) {
     updateData.is_active = is_active;
     updateData.status = is_active ? 'active' : 'draft';
+    // Durable "ever activated" anchor — locks the marketplace slug (066).
+    if (is_active && !campaign.firstActivatedAt) updateData.firstActivatedAt = new Date();
+  }
+  if (body.slug !== undefined) {
+    const incomingSlug = body.slug === null || body.slug === ''
+      ? null
+      : String(body.slug).trim().toLowerCase();
+    const stored = campaign.slug || null;
+    if (incomingSlug !== stored) {
+      if (campaign.firstActivatedAt) {
+        throw new AppError('The marketplace slug is locked once a campaign has been activated.', 409);
+      }
+      if (incomingSlug !== null && !SLUG_RE.test(incomingSlug)) {
+        throw new AppError('Slug must be 3-80 chars of lowercase letters, digits and hyphens.', 422);
+      }
+      updateData.slug = incomingSlug;
+    }
   }
   if (design_config !== undefined) {
     // Clamp the per-campaign customer host to the enum (never trust a raw host
@@ -378,7 +439,15 @@ export async function updateCampaign(id, body, req) {
   if (body.metaPixelId !== undefined) updateData.metaPixelId = body.metaPixelId || null;
   if (body.tiktokPixelId !== undefined) updateData.tiktokPixelId = body.tiktokPixelId || null;
 
-  await campaign.update(updateData);
+  try {
+    await campaign.update(updateData);
+  } catch (err) {
+    if (err?.name === 'SequelizeUniqueConstraintError') {
+      throw new AppError('That marketplace slug is already taken by another campaign.', 409);
+    }
+    throw err;
+  }
+  invalidateMarketplaceCache();
 
   // Sync agent assignments to join table when assigned_agents is provided
   if (assigned_agents !== undefined) {
@@ -432,7 +501,12 @@ export async function setCampaignLaunchState(id, state, req) {
   }
 
   const isActive = state === 'active';
-  await campaign.update({ is_active: isActive, status: isActive ? 'active' : 'paused' });
+  await campaign.update({
+    is_active: isActive,
+    status: isActive ? 'active' : 'paused',
+    ...(isActive && !campaign.firstActivatedAt ? { firstActivatedAt: new Date() } : {}),
+  });
+  invalidateMarketplaceCache();
 
   // Fan-out: refresh device manifests (same as updateCampaign content changes).
   await notifyDevices(id);
@@ -514,7 +588,9 @@ export async function duplicateCampaign(id, body, req) {
   // deliberately re-enabled as its own draw.
   const dupDesign = (() => {
     if (!rest.design_config || typeof rest.design_config !== 'object') return rest.design_config;
-    const { luckyDraw: _neverCloneDraw, ...base } = rest.design_config;
+    // marketplaceListed never clones either — a duplicate of a listed campaign
+    // must not silently appear on the public marketplace when activated.
+    const { luckyDraw: _neverCloneDraw, marketplaceListed: _neverCloneListing, ...base } = rest.design_config;
     return {
       ...base,
       ...(rest.design_config.featuredDrop && typeof rest.design_config.featuredDrop === 'object'
@@ -530,6 +606,10 @@ export async function duplicateCampaign(id, body, req) {
     status: 'draft',
     createdBy: req.user.id,
     spentAmount: 0,
+    // slug is unique and locked to the original; firstActivatedAt is the
+    // original's activation history — a copy starts with neither.
+    slug: null,
+    firstActivatedAt: null,
     createdAt: undefined,
     updatedAt: undefined
   });

--- a/backend/src/services/campaignService.js
+++ b/backend/src/services/campaignService.js
@@ -413,7 +413,12 @@ export async function updateCampaign(id, body, req) {
       : String(body.slug).trim().toLowerCase();
     const stored = campaign.slug || null;
     if (incomingSlug !== stored) {
-      if (campaign.firstActivatedAt) {
+      // Lock rule: once activated, an EXISTING slug can never change or clear
+      // (its /offers URL may be printed/shared). Setting a slug for the first
+      // time (null → value) stays allowed — no URL exists yet to break, and
+      // legacy campaigns backfilled by migration 066 must still be able to
+      // join the marketplace.
+      if (stored !== null && campaign.firstActivatedAt) {
         throw new AppError('The marketplace slug is locked once a campaign has been activated.', 409);
       }
       if (incomingSlug !== null && !SLUG_RE.test(incomingSlug)) {

--- a/backend/src/services/marketplaceCache.js
+++ b/backend/src/services/marketplaceCache.js
@@ -1,0 +1,21 @@
+/**
+ * Marketplace list cache state — deliberately model-free so WRITE-side
+ * services (campaignService, redeem-ops activation/reward services) can bust
+ * the cache without transitively importing the marketplace read model (and
+ * its Redeem Ops model imports) into their own module graphs / test mocks.
+ */
+
+let cache = { data: null, ts: 0 };
+
+export function getMarketplaceCacheState() {
+  return cache;
+}
+
+export function setMarketplaceCacheState(data, ts) {
+  cache = { data, ts };
+}
+
+/** Write-side invalidation — admin actions show within one request. */
+export function invalidateMarketplaceCache() {
+  cache = { data: null, ts: 0 };
+}

--- a/backend/src/services/marketplaceService.js
+++ b/backend/src/services/marketplaceService.js
@@ -1,0 +1,317 @@
+/**
+ * Marketplace read model — the public campaign list/detail behind
+ * GET /api/marketplace/campaigns[/:slug] (redeem.sg consumer marketplace).
+ * Design: docs/plans/redeem-marketplace-v2.md.
+ *
+ * Every campaign is served as exactly two layers:
+ *   design_config — designer-authored copy, REBUILT field-by-field via
+ *     normalizeMarketplaceContent + an explicit passthrough of the public
+ *     flow keys. Raw design_config is never spread into a response
+ *     (luckyDraw carries internal activation/terms ids; quiz/customerHost/
+ *     internal keys must not leak).
+ *   ops — derived, read-only, composed from Redeem Ops entities:
+ *     Activation (capacity/dates) ⋈ RewardOffer (value/windows/status)
+ *     ⋈ PartnerOrganisation (public profile) ⋈ RewardOfferLocation
+ *     (offer-specific branches) + the open Draw row (boost tier).
+ *
+ * Publication gate (list AND detail — no unlisted semantics): admin-set
+ * design_config.marketplaceListed AND slug AND is_active AND status='active'
+ * AND redeem customer host AND a supported campaign type AND resolvable ops.
+ * marketplaceListed is the only exposure switch because campaign PUT is open
+ * to agents (they can flip is_active, so is_active must never publish).
+ */
+
+import { Op } from 'sequelize';
+import {
+  Campaign, Activation, RewardOffer, PartnerOrganisation, PartnerLocation,
+  RewardOfferLocation, Draw,
+} from '../models/index.js';
+import {
+  normalizeMarketplaceContent, MARKETPLACE_CAMPAIGN_TYPES,
+} from '../utils/marketplaceContent.js';
+import { publicLuckyDraw } from '../utils/publicDesignConfig.js';
+import { normalizeCustomerHostChoice } from '../utils/customerHost.js';
+import { getMarketplaceCacheState, setMarketplaceCacheState } from './marketplaceCache.js';
+import { logger } from '../utils/logger.js';
+
+const TTL_MS = 60_000;
+// Stale-on-error is bounded: offers are inventory-backed (unlike the
+// editorial featured-drops cards), so a paused/sold-out offer must not stay
+// visible indefinitely behind a broken refresh.
+const MAX_STALE_MS = 5 * 60_000;
+
+let inflight = null;
+
+// Cache state + write-side invalidation live in marketplaceCache.js (model-free)
+// so writer services can bust it without importing this read model.
+export { invalidateMarketplaceCache } from './marketplaceCache.js';
+
+const LIVE_ACTIVATION_STATUSES = ['active'];
+
+function toNumber(v) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function minDate(a, b) {
+  if (!a) return b || null;
+  if (!b) return a;
+  return new Date(a) <= new Date(b) ? a : b;
+}
+
+/**
+ * Compose the ops layer for one campaign from its live Activation chain.
+ * Returns null when the chain is not resolvable/serviceable (no live
+ * activation, offer not active, outside validity) — gate treats null as
+ * not listable. `now` injectable for tests.
+ */
+export async function composeOps(campaignId, { now = new Date() } = {}) {
+  const activations = await Activation.findAll({
+    where: { campaignId, status: { [Op.in]: LIVE_ACTIVATION_STATUSES } },
+    include: [
+      {
+        model: RewardOffer,
+        as: 'rewardOffer',
+        attributes: [
+          'id', 'status', 'retailValue', 'validityStart', 'validityEnd',
+          'claimExpiryDays', 'redemptionExpiryDays',
+        ],
+        include: [
+          {
+            model: PartnerOrganisation,
+            as: 'partner',
+            attributes: ['id', 'brandName', 'tradingName', 'publicBlurb', 'verifiedAt', 'partnerSince'],
+          },
+          {
+            model: RewardOfferLocation,
+            as: 'offerLocations',
+            include: [{ model: PartnerLocation, as: 'location', attributes: ['name', 'area', 'isActive'] }],
+          },
+        ],
+      },
+    ],
+  });
+
+  if (activations.length === 0) return null;
+  if (activations.length > 1) {
+    // A partial unique index enforces one live activation per campaign —
+    // more than one is data corruption, not a selection problem.
+    logger.error({ campaignId, count: activations.length }, 'marketplace.multiple_live_activations');
+    return null;
+  }
+
+  const activation = activations[0];
+  const offer = activation.rewardOffer;
+  if (!offer || offer.status !== 'active') return null;
+  if (offer.validityStart && now < new Date(offer.validityStart)) return null;
+  if (offer.validityEnd && now > new Date(offer.validityEnd)) return null;
+  if (activation.startDate && now < new Date(activation.startDate)) return null;
+  if (activation.endDate && now > new Date(activation.endDate)) return null;
+
+  const partner = offer.partner;
+  const locations = (offer.offerLocations || [])
+    .map((ol) => ol.location)
+    .filter((l) => l && l.isActive !== false)
+    .map((l) => ({ name: l.name || null, area: l.area || null }));
+
+  const total = activation.allocatedQuantity || 0;
+  const remaining = Math.max(0, total - (activation.issuedCount || 0));
+
+  const ops = {
+    partner: partner
+      ? {
+          name: partner.brandName || partner.tradingName || null,
+          verified: !!partner.verifiedAt,
+          since: partner.partnerSince || null,
+          blurb: partner.publicBlurb || null,
+          locations,
+        }
+      : null,
+    capacity: { total, remaining },
+    expiry: minDate(activation.endDate, offer.validityEnd),
+    retail_value: toNumber(offer.retailValue),
+    claim_expiry_days: offer.claimExpiryDays ?? null,
+    redemption_expiry_days: offer.redemptionExpiryDays ?? null,
+    draw: null,
+  };
+
+  const draw = await Draw.findOne({
+    where: { campaignId, status: 'open' },
+    attributes: ['closesAt', 'boostClosesAt', 'multiplier', 'status'],
+  });
+  if (draw) {
+    ops.draw = {
+      closesAt: draw.closesAt,
+      boostClosesAt: draw.boostClosesAt,
+      multiplier: draw.multiplier,
+    };
+  }
+
+  return ops;
+}
+
+/**
+ * Rebuild the PUBLIC design_config: normalized marketplace content + the
+ * public flow keys, never a raw spread. luckyDraw is sanitized to display
+ * fields only (internal activation/terms ids stripped).
+ */
+export function buildPublicDesignConfig(raw) {
+  const dc = raw || {};
+  const out = normalizeMarketplaceContent(dc);
+
+  // Flow/production keys the consumer flow renders from — passthrough of
+  // known-safe primitives only.
+  if (dc.sgPrOnly === true) out.sgPrOnly = true;
+  if (dc.excludeAdvisors === true) out.excludeAdvisors = true;
+  if (dc.dncCheckAtSubmit === true) out.dncCheckAtSubmit = true;
+  out.otpChannel = dc.otpChannel === 'whatsapp' ? 'whatsapp' : 'sms';
+  if (typeof dc.themeColor === 'string') out.themeColor = dc.themeColor.slice(0, 32);
+  if (typeof dc.termsContent === 'string') out.termsContent = dc.termsContent;
+  if (Array.isArray(dc.fieldOrder)) out.fieldOrder = dc.fieldOrder;
+  if (dc.visibleFields && typeof dc.visibleFields === 'object') out.visibleFields = dc.visibleFields;
+  if (dc.requiredFields && typeof dc.requiredFields === 'object') out.requiredFields = dc.requiredFields;
+
+  // Display-safe draw view — internal activation/terms ids are NEVER public.
+  const ld = publicLuckyDraw(dc.luckyDraw);
+  if (ld) out.luckyDraw = ld;
+
+  return out;
+}
+
+/** Static publication gate (no ops query) — exported for the QR tracker's
+ * qr_entry branch, which must never send traffic to an unpublished detail page. */
+export function passesStaticGate(campaign) {
+  if (!campaign.slug) return false;
+  if (campaign.is_active !== true || campaign.status !== 'active') return false;
+  const dc = campaign.design_config || {};
+  if (dc.marketplaceListed !== true) return false;
+  if (normalizeCustomerHostChoice(dc.customerHost) !== 'redeem') return false;
+  const type = campaign.type || 'lead_generation';
+  if (!MARKETPLACE_CAMPAIGN_TYPES.includes(type)) return false;
+  return true;
+}
+
+const CAMPAIGN_ATTRS = [
+  'id', 'slug', 'name', 'type', 'status', 'is_active', 'min_age', 'max_age',
+  'metaPixelId', 'tiktokPixelId', 'design_config',
+];
+
+function toDto(campaign, ops) {
+  return {
+    id: campaign.id,
+    slug: campaign.slug,
+    name: campaign.name,
+    min_age: campaign.min_age ?? null,
+    max_age: campaign.max_age ?? null,
+    metaPixelId: campaign.metaPixelId || null,
+    tiktokPixelId: campaign.tiktokPixelId || null,
+    design_config: buildPublicDesignConfig(campaign.design_config),
+    ops,
+  };
+}
+
+async function fetchAll(now) {
+  const campaigns = await Campaign.findAll({
+    where: { slug: { [Op.ne]: null }, is_active: true, status: 'active' },
+    attributes: CAMPAIGN_ATTRS,
+  });
+
+  const out = [];
+  for (const campaign of campaigns) {
+    if (!passesStaticGate(campaign)) continue;
+    const ops = await composeOps(campaign.id, { now: new Date(now) });
+    if (!ops) continue;
+    // Sold-out / fully issued offers drop off the list; the detail endpoint
+    // re-composes live so a direct link shows the sold-out state instead.
+    if (ops.capacity.total > 0 && ops.capacity.remaining <= 0) continue;
+    out.push(toDto(campaign, ops));
+  }
+
+  // Deterministic ordering: featured first, then soonest expiry, then slug.
+  out.sort((a, b) => {
+    const af = a.design_config.featuredDrop ? 0 : 1;
+    const bf = b.design_config.featuredDrop ? 0 : 1;
+    if (af !== bf) return af - bf;
+    const ae = a.ops.expiry ? new Date(a.ops.expiry).getTime() : Infinity;
+    const be = b.ops.expiry ? new Date(b.ops.expiry).getTime() : Infinity;
+    if (ae !== be) return ae - be;
+    return String(a.slug).localeCompare(String(b.slug));
+  });
+  return out;
+}
+
+/** Public list — 60s TTL, coalesced, stale-on-error bounded to MAX_STALE_MS. */
+export async function listMarketplaceCampaigns({ now = Date.now() } = {}) {
+  const cache = getMarketplaceCacheState();
+  if (cache.data && now - cache.ts < TTL_MS) return cache.data;
+  if (inflight) return inflight;
+  inflight = fetchAll(now)
+    .then((data) => {
+      setMarketplaceCacheState(data, now);
+      return data;
+    })
+    .catch((err) => {
+      logger.error({ err: err?.message }, 'marketplace.refresh_failed');
+      const stale = getMarketplaceCacheState();
+      if (stale.data && now - stale.ts < MAX_STALE_MS) return stale.data;
+      throw err;
+    })
+    .finally(() => {
+      inflight = null;
+    });
+  return inflight;
+}
+
+/**
+ * Public detail by slug — always composed live (no cache) so state changes
+ * (sold out, paused) are immediate. Returns null when the campaign fails the
+ * publication gate entirely; returns a DTO with ops:null when the campaign is
+ * listed but its ops chain is currently unserviceable (front-end renders the
+ * ended/sold-out state).
+ */
+export async function getMarketplaceCampaign(slug, { now = new Date() } = {}) {
+  if (typeof slug !== 'string' || !/^[a-z0-9-]{3,80}$/.test(slug)) return null;
+  const campaign = await Campaign.findOne({ where: { slug }, attributes: CAMPAIGN_ATTRS });
+  if (!campaign || !passesStaticGate(campaign)) return null;
+  const ops = await composeOps(campaign.id, { now });
+  return toDto(campaign, ops);
+}
+
+/**
+ * Authenticated designer preview — same DTO composition WITHOUT the
+ * publication gate (drafts, unlisted, pre-slug campaigns all preview).
+ * Routed behind authenticateToken; never mounted publicly.
+ */
+export async function previewMarketplaceCampaign(campaignId, { now = new Date() } = {}) {
+  const campaign = await Campaign.findByPk(campaignId, { attributes: CAMPAIGN_ATTRS });
+  if (!campaign) return null;
+  const ops = await composeOps(campaign.id, { now });
+  const dto = toDto(campaign, ops);
+  dto.gate = {
+    listed: passesStaticGate(campaign) && !!ops,
+    slug: !!campaign.slug,
+    active: campaign.is_active === true && campaign.status === 'active',
+    marketplaceListed: campaign.design_config?.marketplaceListed === true,
+    redeemHost: normalizeCustomerHostChoice(campaign.design_config?.customerHost) === 'redeem',
+    supportedType: MARKETPLACE_CAMPAIGN_TYPES.includes(campaign.type || 'lead_generation'),
+    opsResolvable: !!ops,
+  };
+  return dto;
+}
+
+/** Slug availability for the designer (authenticated). */
+export async function checkSlugAvailability(slug, { excludeCampaignId } = {}) {
+  if (typeof slug !== 'string' || !/^[a-z0-9-]{3,80}$/.test(slug)) {
+    return { valid: false, available: false };
+  }
+  const where = { slug };
+  if (excludeCampaignId) where.id = { [Op.ne]: excludeCampaignId };
+  const existing = await Campaign.findOne({ where, attributes: ['id'] });
+  return { valid: true, available: !existing };
+}
+
+/** Test hook — module cache is process state; reset between cases. */
+export function __resetMarketplaceCache() {
+  setMarketplaceCacheState(null, 0);
+  inflight = null;
+}

--- a/backend/src/services/marketplaceService.js
+++ b/backend/src/services/marketplaceService.js
@@ -31,6 +31,7 @@ import {
 } from '../utils/marketplaceContent.js';
 import { publicLuckyDraw } from '../utils/publicDesignConfig.js';
 import { normalizeCustomerHostChoice } from '../utils/customerHost.js';
+import { sgtDayEndExclusiveMs } from '../utils/sgtTime.js';
 import { getMarketplaceCacheState, setMarketplaceCacheState } from './marketplaceCache.js';
 import { logger } from '../utils/logger.js';
 
@@ -175,7 +176,23 @@ export function buildPublicDesignConfig(raw) {
   const ld = publicLuckyDraw(dc.luckyDraw);
   if (ld) out.luckyDraw = ld;
 
+  // Featured flag as a plain boolean (the stored value is the featuredDrop
+  // OBJECT with homepage display metadata — none of that is marketplace data).
+  if (dc.featuredDrop?.enabled === true) out.featuredDrop = true;
+
   return out;
+}
+
+/** A draw campaign stops being marketable once its entry cutoff has passed
+ * (intake 410s after sgtDayEndExclusiveMs(closesAt) — mirror that here). */
+export function isDrawEnded(dc, nowMs = Date.now()) {
+  const ld = dc?.luckyDraw;
+  if (!ld || ld.enabled !== true || !ld.closesAt) return false;
+  try {
+    return nowMs >= sgtDayEndExclusiveMs(ld.closesAt);
+  } catch {
+    return false;
+  }
 }
 
 /** Static publication gate (no ops query) — exported for the QR tracker's
@@ -219,11 +236,15 @@ async function fetchAll(now) {
   const out = [];
   for (const campaign of campaigns) {
     if (!passesStaticGate(campaign)) continue;
+    // Draws past their entry cutoff drop off the list (intake 410s them).
+    if (isDrawEnded(campaign.design_config, now)) continue;
     const ops = await composeOps(campaign.id, { now: new Date(now) });
     if (!ops) continue;
-    // Sold-out / fully issued offers drop off the list; the detail endpoint
-    // re-composes live so a direct link shows the sold-out state instead.
-    if (ops.capacity.total > 0 && ops.capacity.remaining <= 0) continue;
+    // No remaining capacity = not redeemable (a zero-allocation activation
+    // can never issue — entitlementService requires issued < allocated), so
+    // it drops off the list; the detail endpoint re-composes live so a
+    // direct link shows the sold-out state instead.
+    if (ops.capacity.remaining <= 0) continue;
     out.push(toDto(campaign, ops));
   }
 
@@ -280,10 +301,16 @@ export async function getMarketplaceCampaign(slug, { now = new Date() } = {}) {
 /**
  * Authenticated designer preview — same DTO composition WITHOUT the
  * publication gate (drafts, unlisted, pre-slug campaigns all preview).
- * Routed behind authenticateToken; never mounted publicly.
+ * Routed behind authenticateToken; never mounted publicly. Scoped like
+ * campaignService reads: non-admins see only their own or staff-public
+ * campaigns — a bare token must not preview arbitrary drafts by UUID.
  */
-export async function previewMarketplaceCampaign(campaignId, { now = new Date() } = {}) {
-  const campaign = await Campaign.findByPk(campaignId, { attributes: CAMPAIGN_ATTRS });
+export async function previewMarketplaceCampaign(campaignId, { now = new Date(), user } = {}) {
+  const where = { id: campaignId };
+  if (user && user.role !== 'admin') {
+    where[Op.or] = [{ createdBy: user.id }, { isPublic: true }];
+  }
+  const campaign = await Campaign.findOne({ where, attributes: [...CAMPAIGN_ATTRS, 'createdBy', 'isPublic'] });
   if (!campaign) return null;
   const ops = await composeOps(campaign.id, { now });
   const dto = toDto(campaign, ops);

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -200,9 +200,20 @@ export function makeProspectService(overrides = {}) {
       consentMetadata: _cm,
       quizResult: _qr, referralRef: _rref,
       utm_source: _us, utm_medium: _um, utm_campaign: _ucmp, utm_content: _ucnt, utm_term: _utm,
+      // Marketplace flow extras — validated against the campaign config below
+      // (never free text into sourceMetadata). NOTE: a caller-supplied
+      // sourceMetadata object itself is preserved for internal callers (the
+      // public route strips it via Joi stripUnknown), but its `marketplace`
+      // subkey is server-built ONLY — scrubbed below before the validated
+      // values are written, so it can never be forged through the body.
+      marketplace: marketplaceRaw,
       ...bodyWithoutMeta
     } = safeBody;
     const incoming = { ...bodyWithoutMeta };
+    if (incoming.sourceMetadata && typeof incoming.sourceMetadata === 'object') {
+      const { marketplace: _forgedMk, ...restSm } = incoming.sourceMetadata;
+      incoming.sourceMetadata = restSm;
+    }
 
     const capiSourceMetadata = {
       ...(eventId ? { eventId } : {}),
@@ -465,6 +476,44 @@ export function makeProspectService(overrides = {}) {
           acceptedAt: new Date().toISOString(),
         },
       };
+    }
+
+    // Marketplace flow extras (docs/plans/redeem-marketplace-v2.md Phase 4).
+    // Values are validated against the campaign's own config — chip-select
+    // fields must match the options the designer authored (mismatches are
+    // dropped + logged, never 4xx'd: losing a lead over a stale label is worse
+    // than losing the preference). child_name is charset-sanitised free text.
+    // NOTE: sourceMetadata (incl. these keys) is forwarded verbatim to the
+    // Lyfe lead.created webhook — child_name is a minor's first name, so the
+    // campaign's data_use copy must disclose it (plan decision 9).
+    if (marketplaceRaw && typeof marketplaceRaw === 'object') {
+      const dcfg = sourceCampaign?.design_config || {};
+      const cleanText = (v) => {
+        if (typeof v !== 'string') return undefined;
+        const t = v.trim().replace(/[<>]/g, '').slice(0, 120);
+        return t || undefined;
+      };
+      const mk = {};
+      const childName = cleanText(marketplaceRaw.child_name);
+      if (childName) mk.child_name = childName;
+      const level = cleanText(marketplaceRaw.child_school_level);
+      if (level && Array.isArray(dcfg.school_levels) && dcfg.school_levels.includes(level)) {
+        mk.child_school_level = level;
+      }
+      const branch = cleanText(marketplaceRaw.preferred_branch);
+      if (branch) mk.preferred_branch = branch;
+      const timing = cleanText(marketplaceRaw.preferred_timing);
+      if (timing) {
+        const days = dcfg.availability?.days || [];
+        const slots = dcfg.availability?.slots || [];
+        const parts = timing.split(/\s+/);
+        const valid = parts.length >= 1 && parts.length <= 2
+          && parts.every((p) => days.includes(p) || slots.includes(p));
+        if (valid) mk.preferred_timing = timing;
+      }
+      if (Object.keys(mk).length > 0) {
+        incoming.sourceMetadata = { ...(incoming.sourceMetadata || {}), marketplace: mk };
+      }
     }
 
     // DNC (Do Not Call) scrubbing mode for this lead. 'off' unless scrubbing is configured

--- a/backend/src/services/redeemOps/activationService.js
+++ b/backend/src/services/redeemOps/activationService.js
@@ -5,6 +5,7 @@ import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';
 import { makeRedeemOpsAuditService } from './auditService.js';
 import { makeInventoryService } from './inventoryService.js';
+import { invalidateMarketplaceCache } from '../marketplaceCache.js';
 
 const ACTIVATION_STATUSES = ['draft', 'preparing', 'active', 'paused', 'completed', 'cancelled'];
 const LIVE_STATUSES = ['preparing', 'active', 'paused'];
@@ -215,7 +216,19 @@ export function makeActivationService(overrides = {}) {
     return activation;
   }
 
-  return { listActivations, getActivation, createActivation, linkCampaign, changeAllocation, setStatus, setRenewal };
+  // Marketplace read cache: activation changes alter public offer state
+  // (capacity, live window) — bust on every mutation so admin actions show
+  // within one request (docs/plans/redeem-marketplace-v2.md Phase 1).
+  const service = { listActivations, getActivation, createActivation, linkCampaign, changeAllocation, setStatus, setRenewal };
+  for (const k of ['createActivation', 'linkCampaign', 'changeAllocation', 'setStatus', 'setRenewal']) {
+    const fn = service[k];
+    service[k] = async (...args) => {
+      const result = await fn(...args);
+      invalidateMarketplaceCache();
+      return result;
+    };
+  }
+  return service;
 }
 
 const _default = makeActivationService();

--- a/backend/src/services/redeemOps/partnerService.js
+++ b/backend/src/services/redeemOps/partnerService.js
@@ -187,6 +187,8 @@ export function makePartnerService(overrides = {}) {
     'legalName', 'tradingName', 'brandName', 'uen', 'website', 'primaryPhone', 'primaryEmail',
     'instagramHandle', 'tiktokHandle', 'facebookUrl', 'linkedinUrl', 'category', 'subcategory',
     'source', 'tags', 'notes',
+    // Marketplace public profile (067) — echoed on public /offers pages.
+    'publicBlurb', 'partnerSince',
   ];
 
   async function updatePartner(id, body, user, requestId = null) {
@@ -196,6 +198,11 @@ export function makePartnerService(overrides = {}) {
     }
     const updates = {};
     for (const f of EDITABLE_FIELDS) if (body[f] !== undefined) updates[f] = body[f];
+    // Verification is a public trust badge, not ordinary partner data —
+    // admin-only; non-admin attempts are ignored (policy-strip pattern).
+    if (body.verified !== undefined && user?.role === 'admin') {
+      updates.verifiedAt = body.verified === true ? new Date() : null;
+    }
     if (updates.category !== undefined) {
       // currentValue pass-through: an admin rename/retire must never 422 an
       // unrelated edit (the SPA sends category on every save).

--- a/backend/src/services/redeemOps/rewardService.js
+++ b/backend/src/services/redeemOps/rewardService.js
@@ -6,6 +6,7 @@ import {
 import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';
 import { makeRedeemOpsAuditService } from './auditService.js';
+import { invalidateMarketplaceCache } from '../marketplaceCache.js';
 import { makeInventoryService } from './inventoryService.js';
 import { makeCategoryService } from './categoryService.js';
 import { REWARD_TYPES } from './constants.js';
@@ -237,10 +238,22 @@ export function makeRewardService(overrides = {}) {
     return events;
   }
 
-  return {
+  // Marketplace read cache: offer changes alter public offer state (value,
+  // validity, status, locations) — bust on every mutation so admin actions
+  // show within one request (docs/plans/redeem-marketplace-v2.md Phase 1).
+  const service = {
     listOffers, getOffer, createOffer, updateOffer, setOfferStatus,
     addTermsVersion, setLocations, adjustInventory, getLedger,
   };
+  for (const k of ['createOffer', 'updateOffer', 'setOfferStatus', 'setLocations', 'adjustInventory']) {
+    const fn = service[k];
+    service[k] = async (...args) => {
+      const result = await fn(...args);
+      invalidateMarketplaceCache();
+      return result;
+    };
+  }
+  return service;
 }
 
 const _default = makeRewardService();

--- a/backend/src/services/trackerService.js
+++ b/backend/src/services/trackerService.js
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import { QrTag, QrScan, Attribution, Campaign } from '../models/index.js';
+import { buildPublicDesignConfig } from '../utils/publicDesignConfig.js';
 
 const isProd = process.env.NODE_ENV === 'production';
 if (isProd && !process.env.IP_HASH_SALT) {
@@ -158,9 +159,17 @@ export async function resolveSession(sid, atkCookie) {
     // Must match the attribute list in campaignPreviewService.getPublicCampaign
     // — the QR-scan path (this fn) and the direct campaign_id link path both
     // hydrate the same form.
-    campaign = await Campaign.findByPk(qrTag.campaignId, {
+    const row = await Campaign.findByPk(qrTag.campaignId, {
       attributes: ['id', 'name', 'design_config', 'is_active', 'metaPixelId', 'tiktokPixelId', 'min_age', 'max_age']
     });
+    if (row) {
+      // Public endpoint: same design_config whitelist as previews/public —
+      // the QR path must not become a side door for internal config keys
+      // (luckyDraw activation/terms ids etc.). toJSON-tolerant: DI test mocks
+      // return plain objects.
+      campaign = typeof row.toJSON === 'function' ? row.toJSON() : { ...row };
+      campaign.design_config = buildPublicDesignConfig(campaign.design_config);
+    }
   }
 
   return {

--- a/backend/src/tests/marketplaceIntake.test.js
+++ b/backend/src/tests/marketplaceIntake.test.js
@@ -1,0 +1,130 @@
+import { makeProspectService } from '../services/prospectService.js';
+
+// Marketplace flow intake (docs/plans/redeem-marketplace-v2.md Phase 4), DB-free
+// via makeProspectService DI (same harness as campaignStatusGateAndShare.test.js):
+//   1. body.marketplace values are VALIDATED against the campaign's config —
+//      chip-select fields must match designer-authored options; mismatches drop.
+//   2. Client-supplied sourceMetadata is discarded outright (server-composed only).
+
+function buildService({ campaign } = {}) {
+  const created = [];
+  const fakeTx = {};
+  const overrides = {
+    models: {
+      Attribution: { findOne: async () => null },
+      QrTag: { findByPk: async () => null, update: async () => [0, []] },
+      Campaign: {
+        findByPk: async () =>
+          campaign ?? {
+            id: 'camp-1',
+            status: 'active',
+            design_config: {
+              school_levels: ['P3', 'P4'],
+              availability: { days: ['Sat', 'Sun'], slots: ['10:00', '14:00'] },
+            },
+          },
+      },
+      Prospect: {
+        findOne: async () => null,
+        create: async (data) => {
+          created.push(data);
+          return { id: 'prospect-new', ...data };
+        },
+        findByPk: async () => null,
+      },
+      ProspectActivity: { create: async () => ({}) },
+      User: { findByPk: async () => null, findOne: async () => null },
+      AgentGroup: { findByPk: async () => null },
+      AgentGroupMember: { findAll: async () => [] },
+    },
+    sequelize: { transaction: async (fn) => fn(fakeTx), literal: (s) => s },
+    resolveAssignedAgentId: async () => null,
+    resolveLeadRouting: async () => ({ agentId: null, via: 'fallback' }),
+    getSystemAgentId: async () => null,
+    deductLeadCredit: async () => true,
+    buildProspectWhere: async () => ({}),
+    dispatchEvent: () => Promise.resolve(),
+    sendLeadEvent: () => Promise.resolve(),
+    getOrCreateProspectShareLink: async () => ({ slug: 'stub1234', url: '/share/stub1234' }),
+    AppError: class AppError extends Error { constructor(m, s) { super(m); this.statusCode = s; } },
+    logger: { error: () => {}, info: () => {}, warn: () => {} },
+  };
+  return { svc: makeProspectService(overrides), created };
+}
+
+const baseBody = {
+  firstName: 'Parent',
+  email: 'parent@example.com',
+  leadSource: 'website',
+  campaignId: 'camp-1',
+};
+
+const ctx = { cookies: {}, headers: {}, meta: {} };
+
+describe('marketplace metadata intake', () => {
+  test('validated values land at sourceMetadata.marketplace', async () => {
+    const { svc, created } = buildService();
+    await svc.createProspect(
+      {
+        ...baseBody,
+        marketplace: {
+          child_name: '  Kai Lim ',
+          child_school_level: 'P4',
+          preferred_branch: 'Artelier @ Bugis',
+          preferred_timing: 'Sat 10:00',
+        },
+      },
+      null,
+      ctx
+    );
+    expect(created[0].sourceMetadata.marketplace).toEqual({
+      child_name: 'Kai Lim',
+      child_school_level: 'P4',
+      preferred_branch: 'Artelier @ Bugis',
+      preferred_timing: 'Sat 10:00',
+    });
+  });
+
+  test('values outside the campaign config are dropped, not 4xxed', async () => {
+    const { svc, created } = buildService();
+    const { prospect } = await svc.createProspect(
+      {
+        ...baseBody,
+        marketplace: {
+          child_school_level: 'P6', // not in school_levels
+          preferred_timing: 'Mon 09:00', // day+slot not in availability
+          child_name: '<img onerror=x>Kai',
+        },
+      },
+      null,
+      ctx
+    );
+    expect(prospect).toBeTruthy(); // lead still captured
+    const mk = created[0].sourceMetadata?.marketplace || {};
+    expect(mk.child_school_level).toBeUndefined();
+    expect(mk.preferred_timing).toBeUndefined();
+    expect(mk.child_name).toBe('img onerror=xKai'); // angle brackets stripped
+  });
+
+  test('a forged sourceMetadata.marketplace subkey is scrubbed (server-built only)', async () => {
+    const { svc, created } = buildService();
+    await svc.createProspect(
+      {
+        ...baseBody,
+        // Internal callers may pass sourceMetadata (preserved — see
+        // prospectServiceCapi.test.js), but marketplace is server-built only.
+        sourceMetadata: { keepMe: true, marketplace: { child_name: 'Forged' } },
+      },
+      null,
+      ctx
+    );
+    expect(created[0].sourceMetadata.keepMe).toBe(true);
+    expect(created[0].sourceMetadata.marketplace).toBeUndefined();
+  });
+
+  test('no marketplace key → no marketplace metadata', async () => {
+    const { svc, created } = buildService();
+    await svc.createProspect({ ...baseBody }, null, ctx);
+    expect(created[0].sourceMetadata?.marketplace).toBeUndefined();
+  });
+});

--- a/backend/src/utils/luckyDraw.js
+++ b/backend/src/utils/luckyDraw.js
@@ -66,6 +66,11 @@ export function normalizeLuckyDraw(raw) {
       ? multiplier
       : DEFAULT_MULTIPLIER;
 
+  // Display-only winners count for marketplace copy ("5 winners drawn").
+  // No draw mechanics read it.
+  const winners = Number(raw.winners);
+  if (Number.isInteger(winners) && winners >= 1 && winners <= 1000) out.winners = winners;
+
   for (const key of ['activationId', 'termsVersionId']) {
     if (typeof raw[key] === 'string' && UUID_RE.test(raw[key].trim())) {
       out[key] = raw[key].trim().toLowerCase();

--- a/backend/src/utils/marketplaceContent.js
+++ b/backend/src/utils/marketplaceContent.js
@@ -1,0 +1,181 @@
+/**
+ * design_config marketplace keys — normalization + publication policy.
+ *
+ * The marketplace surfaces (redeem.sg /offers, /flow, /explore) echo these
+ * values on PUBLIC pages, so like featuredDrop/luckyDraw they are normalized
+ * both when saved (campaignService.clampDesignConfig) and again when building
+ * the public DTO (marketplaceService) — old rows, duplicates, seeds, or future
+ * write paths must not be able to smuggle arbitrary content or internal keys
+ * onto a public page.
+ *
+ * `marketplaceListed` is the ONLY consumer-exposure switch and is admin-gated
+ * (campaign PUT is open to agents, and agents can flip is_active — so
+ * is_active/status alone must never publish a campaign).
+ */
+
+export const CONSUMER_CATEGORIES = [
+  'art_creativity',
+  'coding_robotics',
+  'speech_performance',
+  'sports_movement',
+  'music_dance',
+  'academic',
+  'family_lifestyle',
+  'wellness',
+  'dining',
+  'financial_education',
+];
+
+export const OFFER_TYPES = ['trial', 'assessment', 'workshop', 'reward', 'consultation'];
+export const MODES = ['physical', 'online', 'hybrid'];
+export const QR_ENTRIES = ['direct', 'detail'];
+const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+/** Campaign types that can be marketplace-listed. quiz/guided_review have
+ * their own qualification funnels the generic flow would silently bypass. */
+export const MARKETPLACE_CAMPAIGN_TYPES = ['lead_generation', 'brand_awareness', 'product_promotion', 'event_marketing'];
+
+const SLOT_RE = /^\d{2}:\d{2}$/;
+
+function isPlainObject(v) {
+  return Object.prototype.toString.call(v) === '[object Object]';
+}
+
+function cleanString(v, max) {
+  if (typeof v !== 'string') return undefined;
+  const t = v.trim();
+  if (!t) return undefined;
+  return t.slice(0, max);
+}
+
+function cleanEnum(v, allowed) {
+  return typeof v === 'string' && allowed.includes(v) ? v : undefined;
+}
+
+function cleanStringArray(v, { maxItems, maxLen }) {
+  if (!Array.isArray(v)) return undefined;
+  const out = [];
+  for (const item of v) {
+    const s = cleanString(item, maxLen);
+    if (s) out.push(s);
+    if (out.length >= maxItems) break;
+  }
+  return out;
+}
+
+function cleanInt(v, min, max) {
+  const n = Number(v);
+  return Number.isInteger(n) && n >= min && n <= max ? n : undefined;
+}
+
+/**
+ * Normalize the marketplace content keys out of a raw design_config-shaped
+ * object. Returns ONLY the clean marketplace keys (absent = dropped) — callers
+ * merge over/into the rest of design_config. Used on save AND on public read.
+ */
+export function normalizeMarketplaceContent(raw) {
+  if (!isPlainObject(raw)) return {};
+  const out = {};
+
+  const name = cleanString(raw.name, 120);
+  if (name) out.name = name;
+
+  const category = cleanEnum(raw.category, CONSUMER_CATEGORIES);
+  if (category) out.category = category;
+
+  const offerType = cleanEnum(raw.offer_type, OFFER_TYPES);
+  if (offerType) out.offer_type = offerType;
+
+  const mode = cleanEnum(raw.mode, MODES);
+  if (mode) out.mode = mode;
+
+  const qrEntry = cleanEnum(raw.qr_entry, QR_ENTRIES);
+  if (qrEntry) out.qr_entry = qrEntry;
+
+  if (isPlainObject(raw.age_range)) {
+    const min = cleanInt(raw.age_range.min, 0, 99);
+    const max = cleanInt(raw.age_range.max, 0, 99);
+    if (min !== undefined && max !== undefined && max >= min) out.age_range = { min, max };
+  }
+
+  const levels = cleanStringArray(raw.school_levels, { maxItems: 12, maxLen: 8 });
+  if (levels && levels.length) out.school_levels = levels;
+
+  if (typeof raw.dsa_related === 'boolean') out.dsa_related = raw.dsa_related;
+  if (typeof raw.showCapacity === 'boolean') out.showCapacity = raw.showCapacity;
+
+  if (isPlainObject(raw.availability)) {
+    const days = Array.isArray(raw.availability.days)
+      ? raw.availability.days.filter((d) => DAYS.includes(d)).slice(0, 7)
+      : [];
+    const slots = Array.isArray(raw.availability.slots)
+      ? raw.availability.slots.filter((s) => typeof s === 'string' && SLOT_RE.test(s.trim())).map((s) => s.trim()).slice(0, 8)
+      : [];
+    if (days.length || slots.length) out.availability = { days, slots };
+  }
+
+  const inclusions = cleanStringArray(raw.inclusions, { maxItems: 8, maxLen: 120 });
+  if (inclusions && inclusions.length) out.inclusions = inclusions;
+
+  const imageLabel = cleanString(raw.image_label, 120);
+  if (imageLabel) out.image_label = imageLabel;
+
+  if (isPlainObject(raw.activation)) {
+    const activation = { required: raw.activation.required === true };
+    const type = cleanString(raw.activation.type, 40);
+    if (type) activation.type = type;
+    const mins = cleanInt(raw.activation.duration_mins, 5, 240);
+    if (mins !== undefined) activation.duration_mins = mins;
+    const summary = cleanString(raw.activation.summary, 160);
+    if (summary) activation.summary = summary;
+    const detail = cleanString(raw.activation.detail, 600);
+    if (detail) activation.detail = detail;
+    out.activation = activation;
+  }
+
+  if (raw.sponsor === null) {
+    out.sponsor = null;
+  } else if (isPlainObject(raw.sponsor)) {
+    const kind = cleanString(raw.sponsor.kind, 40);
+    const disclosure = cleanString(raw.sponsor.disclosure, 400);
+    if (kind || disclosure) out.sponsor = { ...(kind ? { kind } : {}), ...(disclosure ? { disclosure } : {}) };
+  }
+
+  const valueLine = cleanString(raw.value_line, 80);
+  if (valueLine) out.value_line = valueLine;
+
+  if (isPlainObject(raw.content_blocks)) {
+    const blocks = {};
+    const dataUse = cleanString(raw.content_blocks.data_use, 400);
+    if (dataUse) blocks.data_use = dataUse;
+    const cancellation = cleanString(raw.content_blocks.cancellation, 400);
+    if (cancellation) blocks.cancellation = cancellation;
+    if (Array.isArray(raw.content_blocks.faq)) {
+      const faq = [];
+      for (const f of raw.content_blocks.faq) {
+        if (!isPlainObject(f)) continue;
+        const q = cleanString(f.q, 160);
+        const a = cleanString(f.a, 400);
+        if (q && a) faq.push({ q, a });
+        if (faq.length >= 6) break;
+      }
+      if (faq.length) blocks.faq = faq;
+    }
+    if (Object.keys(blocks).length) out.content_blocks = blocks;
+  }
+
+  return out;
+}
+
+/**
+ * Publication policy for design_config.marketplaceListed — mirrors
+ * applyFeaturedDropPolicy: admins decide; everyone else preserves the stored
+ * value. Returns a boolean, or undefined when the key should be absent.
+ */
+export function applyMarketplacePolicy({ incoming, stored, role }) {
+  const norm = (v) => (v === true ? true : v === false ? false : undefined);
+  if (role === 'admin') {
+    return incoming === undefined ? norm(stored) : norm(incoming);
+  }
+  return norm(stored);
+}

--- a/backend/src/utils/publicDesignConfig.js
+++ b/backend/src/utils/publicDesignConfig.js
@@ -17,8 +17,9 @@
 import { normalizeLuckyDraw } from './luckyDraw.js';
 
 const PUBLIC_PASSTHROUGH_KEYS = [
-  // Lead-capture page chrome + copy
-  'themeColor', 'heroFont', 'imageUrl', 'videoUrl', 'storyText', 'storyEmphasis',
+  // Lead-capture page chrome + copy (mediaType drives the none/image/video
+  // hero switch in LeadCaptureLayout — omitting it breaks video campaigns)
+  'themeColor', 'heroFont', 'imageUrl', 'videoUrl', 'mediaType', 'storyText', 'storyEmphasis',
   'heroCtaLabel', 'ctaText', 'formHeadline', 'formSubheadline', 'formWidth',
   'brandWordmark', 'brandFooter', 'regulatoryFooter', 'termsContent', 'customerHost',
   // Form contract (flat production keys; fieldOrder is string[] OR row objects)

--- a/backend/src/utils/publicDesignConfig.js
+++ b/backend/src/utils/publicDesignConfig.js
@@ -1,0 +1,61 @@
+/**
+ * Public design_config whitelist — everything the UNAUTHENTICATED surfaces
+ * (GET /api/previews/public/:id → LeadCapture, and the marketplace DTO) are
+ * allowed to see of a campaign's design_config.
+ *
+ * design_config is an unconstrained JSONB column that also carries INTERNAL
+ * state — luckyDraw.activationId / termsVersionId / termsHash, plus whatever
+ * future write paths add — so public reads must rebuild, never dump raw.
+ * (docs/plans/redeem-marketplace-v2.md Phase 1: previews/public hardening.)
+ *
+ * Key list = the union of what the public pages actually read:
+ * LeadCapture.jsx / leadCaptureContent.js / CampaignSignupForm.jsx /
+ * CampaignQuiz.jsx / public/Preview.jsx, plus the marketplace content keys
+ * (already normalized on save by campaignService.clampDesignConfig).
+ */
+
+import { normalizeLuckyDraw } from './luckyDraw.js';
+
+const PUBLIC_PASSTHROUGH_KEYS = [
+  // Lead-capture page chrome + copy
+  'themeColor', 'heroFont', 'imageUrl', 'videoUrl', 'storyText', 'storyEmphasis',
+  'heroCtaLabel', 'ctaText', 'formHeadline', 'formSubheadline', 'formWidth',
+  'brandWordmark', 'brandFooter', 'regulatoryFooter', 'termsContent', 'customerHost',
+  // Form contract (flat production keys; fieldOrder is string[] OR row objects)
+  'fieldOrder', 'visibleFields', 'requiredFields',
+  // Flow gates + channel
+  'sgPrOnly', 'excludeAdvisors', 'dncCheckAtSubmit', 'otpChannel',
+  // Funnel variants (public quiz/guided-review campaigns render from these)
+  'quiz', 'guidedReview',
+  // Marketplace content (clamped on save by normalizeMarketplaceContent)
+  'name', 'category', 'offer_type', 'mode', 'qr_entry', 'age_range',
+  'school_levels', 'dsa_related', 'showCapacity', 'availability', 'inclusions',
+  'image_label', 'activation', 'sponsor', 'value_line', 'content_blocks',
+];
+
+/** Display-safe luckyDraw view — internal ids are NEVER public. */
+export function publicLuckyDraw(raw) {
+  const ld = normalizeLuckyDraw(raw);
+  if (!ld || ld.enabled !== true) return undefined;
+  return {
+    enabled: true,
+    ...(ld.prize ? { prize: ld.prize } : {}),
+    ...(ld.closesAt ? { closesAt: ld.closesAt } : {}),
+    ...(ld.boostClosesAt ? { boostClosesAt: ld.boostClosesAt } : {}),
+    ...(ld.drawOn ? { drawOn: ld.drawOn } : {}),
+    multiplier: ld.multiplier,
+    ...(ld.winners ? { winners: ld.winners } : {}),
+  };
+}
+
+/** Rebuild a public-safe design_config from a raw stored one. */
+export function buildPublicDesignConfig(raw) {
+  const dc = raw && typeof raw === 'object' ? raw : {};
+  const out = {};
+  for (const key of PUBLIC_PASSTHROUGH_KEYS) {
+    if (dc[key] !== undefined) out[key] = dc[key];
+  }
+  const ld = publicLuckyDraw(dc.luckyDraw);
+  if (ld) out.luckyDraw = ld;
+  return out;
+}

--- a/backend/test/marketplaceContent.test.js
+++ b/backend/test/marketplaceContent.test.js
@@ -1,0 +1,85 @@
+import { normalizeMarketplaceContent, applyMarketplacePolicy, MARKETPLACE_CAMPAIGN_TYPES } from '../src/utils/marketplaceContent.js';
+
+describe('normalizeMarketplaceContent', () => {
+  test('non-objects normalize to empty', () => {
+    for (const v of [undefined, null, 'x', 42, []]) {
+      expect(normalizeMarketplaceContent(v)).toEqual({});
+    }
+  });
+
+  test('enums clamp: unknown values are dropped', () => {
+    const out = normalizeMarketplaceContent({
+      category: 'not_a_category',
+      offer_type: 'freebie',
+      mode: 'teleport',
+      qr_entry: 'somewhere',
+    });
+    expect(out).toEqual({});
+  });
+
+  test('valid enums pass through', () => {
+    const out = normalizeMarketplaceContent({
+      category: 'wellness', offer_type: 'trial', mode: 'hybrid', qr_entry: 'detail',
+    });
+    expect(out).toEqual({ category: 'wellness', offer_type: 'trial', mode: 'hybrid', qr_entry: 'detail' });
+  });
+
+  test('age_range requires valid min<=max ints', () => {
+    expect(normalizeMarketplaceContent({ age_range: { min: 9, max: 12 } }).age_range).toEqual({ min: 9, max: 12 });
+    expect(normalizeMarketplaceContent({ age_range: { min: 12, max: 9 } }).age_range).toBeUndefined();
+    expect(normalizeMarketplaceContent({ age_range: { min: 'x', max: 12 } }).age_range).toBeUndefined();
+  });
+
+  test('availability filters unknown days and malformed slots', () => {
+    const out = normalizeMarketplaceContent({
+      availability: { days: ['Sat', 'Caturday', 'Sun'], slots: ['10:00', 'noonish', '14:30'] },
+    });
+    expect(out.availability).toEqual({ days: ['Sat', 'Sun'], slots: ['10:00', '14:30'] });
+  });
+
+  test('activation coerces required and clamps copy lengths', () => {
+    const out = normalizeMarketplaceContent({
+      activation: { required: 'yes', type: 'financial_consult', duration_mins: 20, summary: 'S', detail: 'D', extra: 'dropme' },
+    });
+    expect(out.activation).toEqual({ required: false, type: 'financial_consult', duration_mins: 20, summary: 'S', detail: 'D' });
+  });
+
+  test('sponsor null is preserved; junk sponsor keys are stripped', () => {
+    expect(normalizeMarketplaceContent({ sponsor: null }).sponsor).toBeNull();
+    const out = normalizeMarketplaceContent({ sponsor: { kind: 'financial_consultant', disclosure: 'x', internalId: 'no' } });
+    expect(out.sponsor).toEqual({ kind: 'financial_consultant', disclosure: 'x' });
+  });
+
+  test('content_blocks faq pairs require both q and a, capped at 6', () => {
+    const faq = Array.from({ length: 9 }, (_, i) => ({ q: `q${i}`, a: `a${i}` }));
+    faq.push({ q: 'orphan' });
+    const out = normalizeMarketplaceContent({ content_blocks: { data_use: 'du', faq } });
+    expect(out.content_blocks.faq).toHaveLength(6);
+    expect(out.content_blocks.data_use).toBe('du');
+  });
+
+  test('unknown top-level keys never survive', () => {
+    const out = normalizeMarketplaceContent({ hax: true, name: 'Title' });
+    expect(out).toEqual({ name: 'Title' });
+  });
+});
+
+describe('applyMarketplacePolicy', () => {
+  test('admin sets and clears the listing', () => {
+    expect(applyMarketplacePolicy({ incoming: true, stored: undefined, role: 'admin' })).toBe(true);
+    expect(applyMarketplacePolicy({ incoming: false, stored: true, role: 'admin' })).toBe(false);
+    expect(applyMarketplacePolicy({ incoming: undefined, stored: true, role: 'admin' })).toBe(true);
+  });
+
+  test('non-admins can never flip the listing', () => {
+    expect(applyMarketplacePolicy({ incoming: true, stored: undefined, role: 'agent' })).toBeUndefined();
+    expect(applyMarketplacePolicy({ incoming: false, stored: true, role: 'agent' })).toBe(true);
+    expect(applyMarketplacePolicy({ incoming: true, stored: false, role: 'driver' })).toBe(false);
+  });
+
+  test('quiz and guided_review are not marketplace types', () => {
+    expect(MARKETPLACE_CAMPAIGN_TYPES).not.toContain('quiz');
+    expect(MARKETPLACE_CAMPAIGN_TYPES).not.toContain('guided_review');
+    expect(MARKETPLACE_CAMPAIGN_TYPES).toContain('lead_generation');
+  });
+});

--- a/backend/test/marketplaceService.test.js
+++ b/backend/test/marketplaceService.test.js
@@ -24,7 +24,7 @@ jest.unstable_mockModule('../src/utils/logger.js', () => ({
 
 const {
   listMarketplaceCampaigns, getMarketplaceCampaign, composeOps, passesStaticGate,
-  buildPublicDesignConfig, __resetMarketplaceCache,
+  buildPublicDesignConfig, previewMarketplaceCampaign, isDrawEnded, __resetMarketplaceCache,
 } = await import('../src/services/marketplaceService.js');
 
 const NOW = Date.parse('2026-07-14T04:00:00Z');
@@ -168,22 +168,46 @@ describe('DTO exclusions (the public-data boundary)', () => {
     expect(dc.marketplaceListed).toBeUndefined();
     expect(dc.luckyDraw).toEqual({ enabled: true, closesAt: '2026-08-31', multiplier: 10, winners: 5 });
   });
+
+  test('featuredDrop surfaces as a plain boolean (homepage metadata never leaks)', () => {
+    const dc = buildPublicDesignConfig({ featuredDrop: { enabled: true, cap: 100, valueLabel: '$50' } });
+    expect(dc.featuredDrop).toBe(true);
+    expect(buildPublicDesignConfig({ featuredDrop: { enabled: false } }).featuredDrop).toBeUndefined();
+  });
 });
 
 describe('listMarketplaceCampaigns', () => {
-  test('lists only gated campaigns with resolvable ops; sold-out drops off', async () => {
+  test('lists only gated campaigns with resolvable ops; sold-out AND zero-allocation drop off', async () => {
     campaignFindAll.mockResolvedValue([
       listedCampaign(),
       listedCampaign({ id: 'cmp-2', slug: 'unlisted', design_config: { marketplaceListed: false } }),
       listedCampaign({ id: 'cmp-3', slug: 'sold-out-offer' }),
+      // Zero allocation can never issue a reward (entitlementService requires
+      // issued < allocated) — must not appear available.
+      listedCampaign({ id: 'cmp-4', slug: 'zero-allocation' }),
     ]);
     activationFindAll.mockImplementation(async ({ where }) => {
       if (where.campaignId === 'cmp-3') return [liveActivation({ allocatedQuantity: 10, issuedCount: 10 })];
+      if (where.campaignId === 'cmp-4') return [liveActivation({ allocatedQuantity: 0, issuedCount: 0 })];
       return [liveActivation()];
     });
     const list = await listMarketplaceCampaigns({ now: NOW });
     expect(list.map((c) => c.slug)).toEqual(['visual-arts-discovery']);
     expect(list[0].ops.capacity.remaining).toBe(30);
+  });
+
+  test('draws past their entry cutoff drop off the list (intake would 410)', async () => {
+    campaignFindAll.mockResolvedValue([
+      listedCampaign({
+        id: 'cmp-d', slug: 'ended-draw',
+        design_config: { marketplaceListed: true, customerHost: 'redeem', luckyDraw: { enabled: true, closesAt: '2026-07-01' } },
+      }),
+    ]);
+    activationFindAll.mockResolvedValue([liveActivation()]);
+    const list = await listMarketplaceCampaigns({ now: NOW }); // NOW = 2026-07-14
+    expect(list).toEqual([]);
+    expect(isDrawEnded({ luckyDraw: { enabled: true, closesAt: '2026-07-01' } }, NOW)).toBe(true);
+    expect(isDrawEnded({ luckyDraw: { enabled: true, closesAt: '2026-08-31' } }, NOW)).toBe(false);
   });
 
   test('stale-on-error serves the last good list within the bound', async () => {
@@ -214,5 +238,26 @@ describe('getMarketplaceCampaign', () => {
     const dto = await getMarketplaceCampaign('visual-arts-discovery');
     expect(dto.slug).toBe('visual-arts-discovery');
     expect(dto.ops.partner.name).toBe('Artelier Studio');
+  });
+});
+
+describe('previewMarketplaceCampaign (authenticated designer preview)', () => {
+  test('non-admins are scoped to own or staff-public campaigns', async () => {
+    campaignFindOne.mockResolvedValue(null);
+    activationFindAll.mockResolvedValue([]);
+    const result = await previewMarketplaceCampaign('cmp-1', { user: { id: 'agent-1', role: 'agent' } });
+    expect(result).toBeNull();
+    const where = campaignFindOne.mock.calls[0][0].where;
+    // The scoping clause must be present for non-admins (createdBy OR isPublic).
+    expect(Object.getOwnPropertySymbols(where).length).toBeGreaterThan(0);
+  });
+
+  test('admins preview any campaign without the scoping clause', async () => {
+    campaignFindOne.mockResolvedValue(listedCampaign());
+    activationFindAll.mockResolvedValue([liveActivation()]);
+    const result = await previewMarketplaceCampaign('cmp-1', { user: { id: 'admin-1', role: 'admin' } });
+    expect(result.gate.listed).toBe(true);
+    const where = campaignFindOne.mock.calls[0][0].where;
+    expect(Object.getOwnPropertySymbols(where).length).toBe(0);
   });
 });

--- a/backend/test/marketplaceService.test.js
+++ b/backend/test/marketplaceService.test.js
@@ -1,0 +1,218 @@
+import { jest } from '@jest/globals';
+
+// Mock models BEFORE the SUT is imported (Jest ESM pattern) — no DB needed.
+const campaignFindAll = jest.fn();
+const campaignFindOne = jest.fn();
+const campaignFindByPk = jest.fn();
+const activationFindAll = jest.fn();
+const drawFindOne = jest.fn();
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  Campaign: { findAll: campaignFindAll, findOne: campaignFindOne, findByPk: campaignFindByPk },
+  Activation: { findAll: activationFindAll },
+  RewardOffer: {},
+  PartnerOrganisation: {},
+  PartnerLocation: {},
+  RewardOfferLocation: {},
+  Draw: { findOne: drawFindOne },
+}));
+
+const loggerErrorMock = jest.fn();
+jest.unstable_mockModule('../src/utils/logger.js', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: loggerErrorMock, debug: jest.fn() },
+}));
+
+const {
+  listMarketplaceCampaigns, getMarketplaceCampaign, composeOps, passesStaticGate,
+  buildPublicDesignConfig, __resetMarketplaceCache,
+} = await import('../src/services/marketplaceService.js');
+
+const NOW = Date.parse('2026-07-14T04:00:00Z');
+
+const liveActivation = (over = {}) => ({
+  allocatedQuantity: 40,
+  issuedCount: 10,
+  startDate: null,
+  endDate: '2026-09-30T00:00:00Z',
+  rewardOffer: {
+    status: 'active',
+    retailValue: '180.00',
+    validityStart: null,
+    validityEnd: '2026-08-31T00:00:00Z',
+    claimExpiryDays: 14,
+    redemptionExpiryDays: 60,
+    partner: {
+      brandName: 'Artelier Studio', tradingName: 'Artelier Pte Ltd',
+      publicBlurb: 'Independent art school.', verifiedAt: '2026-01-01T00:00:00Z', partnerSince: 2019,
+    },
+    offerLocations: [
+      { location: { name: 'Artelier @ Bugis', area: 'Central', isActive: true } },
+      { location: { name: 'Closed Branch', area: 'West', isActive: false } },
+    ],
+  },
+  ...over,
+});
+
+const listedCampaign = (over = {}) => ({
+  id: 'cmp-1',
+  slug: 'visual-arts-discovery',
+  name: 'Visual Arts',
+  type: 'lead_generation',
+  status: 'active',
+  is_active: true,
+  min_age: null,
+  max_age: null,
+  metaPixelId: null,
+  tiktokPixelId: null,
+  design_config: {
+    marketplaceListed: true,
+    customerHost: 'redeem',
+    category: 'art_creativity',
+    ...over.design_config,
+  },
+  ...over,
+});
+
+beforeEach(() => {
+  __resetMarketplaceCache();
+  campaignFindAll.mockReset();
+  campaignFindOne.mockReset();
+  campaignFindByPk.mockReset();
+  activationFindAll.mockReset();
+  drawFindOne.mockReset();
+  drawFindOne.mockResolvedValue(null);
+});
+
+describe('passesStaticGate', () => {
+  test('agent flipping is_active alone can NEVER publish (marketplaceListed is the switch)', () => {
+    expect(passesStaticGate(listedCampaign({ design_config: { marketplaceListed: false } }))).toBe(false);
+    expect(passesStaticGate(listedCampaign({ design_config: {} }))).toBe(false);
+  });
+
+  test('archived/paused lifecycle never publishes even when flagged', () => {
+    expect(passesStaticGate(listedCampaign({ status: 'archived' }))).toBe(false);
+    expect(passesStaticGate(listedCampaign({ status: 'paused' }))).toBe(false);
+    expect(passesStaticGate(listedCampaign({ is_active: false }))).toBe(false);
+  });
+
+  test('mktr-host campaigns and unsupported types are excluded', () => {
+    expect(passesStaticGate(listedCampaign({ design_config: { marketplaceListed: true, customerHost: 'mktr' } }))).toBe(false);
+    expect(passesStaticGate(listedCampaign({ type: 'quiz' }))).toBe(false);
+    expect(passesStaticGate(listedCampaign({ type: 'guided_review' }))).toBe(false);
+  });
+
+  test('missing slug never publishes; full gate passes', () => {
+    expect(passesStaticGate(listedCampaign({ slug: null }))).toBe(false);
+    expect(passesStaticGate(listedCampaign())).toBe(true);
+  });
+});
+
+describe('composeOps', () => {
+  test('composes partner/capacity/expiry from the live chain; DECIMAL cast; offer locations only', async () => {
+    activationFindAll.mockResolvedValue([liveActivation()]);
+    const ops = await composeOps('cmp-1', { now: new Date(NOW) });
+    expect(ops.partner.name).toBe('Artelier Studio');
+    expect(ops.partner.verified).toBe(true);
+    expect(ops.partner.since).toBe(2019);
+    expect(ops.partner.locations).toEqual([{ name: 'Artelier @ Bugis', area: 'Central' }]); // inactive filtered
+    expect(ops.capacity).toEqual({ total: 40, remaining: 30 });
+    expect(ops.retail_value).toBe(180); // Number, not the Sequelize DECIMAL string
+    // min(activation.endDate, offer.validityEnd)
+    expect(new Date(ops.expiry).toISOString()).toBe('2026-08-31T00:00:00.000Z');
+  });
+
+  test('paused offer / expired validity / not-yet-started activation → null', async () => {
+    activationFindAll.mockResolvedValue([liveActivation({ rewardOffer: { ...liveActivation().rewardOffer, status: 'paused' } })]);
+    expect(await composeOps('cmp-1', { now: new Date(NOW) })).toBeNull();
+
+    activationFindAll.mockResolvedValue([liveActivation({ rewardOffer: { ...liveActivation().rewardOffer, validityEnd: '2026-01-01T00:00:00Z' } })]);
+    expect(await composeOps('cmp-1', { now: new Date(NOW) })).toBeNull();
+
+    activationFindAll.mockResolvedValue([liveActivation({ startDate: '2027-01-01T00:00:00Z' })]);
+    expect(await composeOps('cmp-1', { now: new Date(NOW) })).toBeNull();
+  });
+
+  test('multiple live activations = data corruption → null + error log', async () => {
+    activationFindAll.mockResolvedValue([liveActivation(), liveActivation()]);
+    expect(await composeOps('cmp-1', { now: new Date(NOW) })).toBeNull();
+    expect(loggerErrorMock).toHaveBeenCalled();
+  });
+
+  test('only an OPEN draw feeds ops.draw', async () => {
+    activationFindAll.mockResolvedValue([liveActivation()]);
+    drawFindOne.mockResolvedValue({ closesAt: '2026-08-31', boostClosesAt: '2026-08-24', multiplier: 10, status: 'open' });
+    const ops = await composeOps('cmp-1', { now: new Date(NOW) });
+    expect(drawFindOne).toHaveBeenCalledWith(expect.objectContaining({ where: { campaignId: 'cmp-1', status: 'open' } }));
+    expect(ops.draw).toEqual({ closesAt: '2026-08-31', boostClosesAt: '2026-08-24', multiplier: 10 });
+  });
+});
+
+describe('DTO exclusions (the public-data boundary)', () => {
+  test('luckyDraw internals, quiz config and unknown keys never appear', () => {
+    const dc = buildPublicDesignConfig({
+      marketplaceListed: true,
+      customerHost: 'redeem',
+      category: 'wellness',
+      quiz: { questions: ['secret scoring'] },
+      internalNotes: 'never',
+      luckyDraw: {
+        enabled: true, closesAt: '2026-08-31', winners: 5,
+        activationId: '2a2a2a2a-2a2a-4a2a-8a2a-2a2a2a2a2a2a',
+        termsVersionId: '3b3b3b3b-3b3b-4b3b-8b3b-3b3b3b3b3b3b',
+        termsHash: 'c'.repeat(64),
+      },
+    });
+    expect(dc.quiz).toBeUndefined();
+    expect(dc.internalNotes).toBeUndefined();
+    expect(dc.customerHost).toBeUndefined();
+    expect(dc.marketplaceListed).toBeUndefined();
+    expect(dc.luckyDraw).toEqual({ enabled: true, closesAt: '2026-08-31', multiplier: 10, winners: 5 });
+  });
+});
+
+describe('listMarketplaceCampaigns', () => {
+  test('lists only gated campaigns with resolvable ops; sold-out drops off', async () => {
+    campaignFindAll.mockResolvedValue([
+      listedCampaign(),
+      listedCampaign({ id: 'cmp-2', slug: 'unlisted', design_config: { marketplaceListed: false } }),
+      listedCampaign({ id: 'cmp-3', slug: 'sold-out-offer' }),
+    ]);
+    activationFindAll.mockImplementation(async ({ where }) => {
+      if (where.campaignId === 'cmp-3') return [liveActivation({ allocatedQuantity: 10, issuedCount: 10 })];
+      return [liveActivation()];
+    });
+    const list = await listMarketplaceCampaigns({ now: NOW });
+    expect(list.map((c) => c.slug)).toEqual(['visual-arts-discovery']);
+    expect(list[0].ops.capacity.remaining).toBe(30);
+  });
+
+  test('stale-on-error serves the last good list within the bound', async () => {
+    campaignFindAll.mockResolvedValue([listedCampaign()]);
+    activationFindAll.mockResolvedValue([liveActivation()]);
+    const first = await listMarketplaceCampaigns({ now: NOW });
+    expect(first).toHaveLength(1);
+    campaignFindAll.mockRejectedValue(new Error('db down'));
+    const second = await listMarketplaceCampaigns({ now: NOW + 120_000 }); // past TTL, inside stale bound
+    expect(second).toHaveLength(1);
+    await expect(listMarketplaceCampaigns({ now: NOW + 10 * 60_000 })).rejects.toThrow('db down'); // past bound
+  });
+});
+
+describe('getMarketplaceCampaign', () => {
+  test('rejects malformed slugs without touching the DB', async () => {
+    expect(await getMarketplaceCampaign('../../etc/passwd')).toBeNull();
+    expect(await getMarketplaceCampaign('UPPER')).toBeNull();
+    expect(campaignFindOne).not.toHaveBeenCalled();
+  });
+
+  test('gated-out campaigns 404 (null); listed ones compose live', async () => {
+    campaignFindOne.mockResolvedValue(listedCampaign({ design_config: { marketplaceListed: false } }));
+    expect(await getMarketplaceCampaign('visual-arts-discovery')).toBeNull();
+
+    campaignFindOne.mockResolvedValue(listedCampaign());
+    activationFindAll.mockResolvedValue([liveActivation()]);
+    const dto = await getMarketplaceCampaign('visual-arts-discovery');
+    expect(dto.slug).toBe('visual-arts-discovery');
+    expect(dto.ops.partner.name).toBe('Artelier Studio');
+  });
+});

--- a/backend/test/publicDesignConfig.test.js
+++ b/backend/test/publicDesignConfig.test.js
@@ -53,7 +53,7 @@ describe('buildPublicDesignConfig', () => {
 
   test('regression: every key the public LeadCapture surface reads survives', () => {
     const keys = [
-      'themeColor', 'heroFont', 'imageUrl', 'videoUrl', 'storyText', 'storyEmphasis',
+      'themeColor', 'heroFont', 'imageUrl', 'videoUrl', 'mediaType', 'storyText', 'storyEmphasis',
       'heroCtaLabel', 'ctaText', 'formHeadline', 'formSubheadline', 'formWidth',
       'brandWordmark', 'brandFooter', 'regulatoryFooter', 'termsContent', 'customerHost',
       'fieldOrder', 'visibleFields', 'requiredFields',

--- a/backend/test/publicDesignConfig.test.js
+++ b/backend/test/publicDesignConfig.test.js
@@ -1,0 +1,66 @@
+import { buildPublicDesignConfig, publicLuckyDraw } from '../src/utils/publicDesignConfig.js';
+
+describe('publicLuckyDraw', () => {
+  test('strips internal activation/terms ids from an enabled draw', () => {
+    const out = publicLuckyDraw({
+      enabled: true,
+      closesAt: '2026-08-31',
+      boostClosesAt: '2026-08-24',
+      multiplier: 10,
+      winners: 5,
+      activationId: '2a2a2a2a-2a2a-4a2a-8a2a-2a2a2a2a2a2a',
+      termsVersionId: '3b3b3b3b-3b3b-4b3b-8b3b-3b3b3b3b3b3b',
+      termsHash: 'a'.repeat(64),
+    });
+    expect(out).toEqual({
+      enabled: true, closesAt: '2026-08-31', boostClosesAt: '2026-08-24', multiplier: 10, winners: 5,
+    });
+    expect(out.activationId).toBeUndefined();
+    expect(out.termsVersionId).toBeUndefined();
+    expect(out.termsHash).toBeUndefined();
+  });
+
+  test('disabled/absent draws return undefined', () => {
+    expect(publicLuckyDraw(undefined)).toBeUndefined();
+    expect(publicLuckyDraw({ enabled: false, closesAt: '2026-08-31' })).toBeUndefined();
+  });
+});
+
+describe('buildPublicDesignConfig', () => {
+  test('unknown keys never leak; known lead-capture keys pass through', () => {
+    const out = buildPublicDesignConfig({
+      themeColor: '#fff',
+      storyText: 'story',
+      visibleFields: { dob: false },
+      requiredFields: { email: false },
+      fieldOrder: [{ id: 'r1', columns: ['name', 'phone'] }],
+      sgPrOnly: true,
+      excludeAdvisors: true,
+      otpChannel: 'whatsapp',
+      quiz: { questions: [] },
+      termsContent: '<p>t</p>',
+      // must NOT survive:
+      internalRoutingNote: 'secret',
+      buyerPriceCents: 12345,
+      luckyDraw: { enabled: true, closesAt: '2026-08-31', termsHash: 'b'.repeat(64) },
+    });
+    expect(out.internalRoutingNote).toBeUndefined();
+    expect(out.buyerPriceCents).toBeUndefined();
+    expect(out.storyText).toBe('story');
+    expect(out.fieldOrder).toEqual([{ id: 'r1', columns: ['name', 'phone'] }]);
+    expect(out.luckyDraw).toEqual({ enabled: true, closesAt: '2026-08-31', multiplier: 10 });
+  });
+
+  test('regression: every key the public LeadCapture surface reads survives', () => {
+    const keys = [
+      'themeColor', 'heroFont', 'imageUrl', 'videoUrl', 'storyText', 'storyEmphasis',
+      'heroCtaLabel', 'ctaText', 'formHeadline', 'formSubheadline', 'formWidth',
+      'brandWordmark', 'brandFooter', 'regulatoryFooter', 'termsContent', 'customerHost',
+      'fieldOrder', 'visibleFields', 'requiredFields',
+      'sgPrOnly', 'excludeAdvisors', 'dncCheckAtSubmit', 'otpChannel', 'quiz', 'guidedReview',
+    ];
+    const raw = Object.fromEntries(keys.map((k) => [k, `v-${k}`]));
+    const out = buildPublicDesignConfig(raw);
+    for (const k of keys) expect(out[k]).toBe(`v-${k}`);
+  });
+});

--- a/docs/plans/redeem-marketplace-v2.md
+++ b/docs/plans/redeem-marketplace-v2.md
@@ -1,0 +1,328 @@
+# Redeem.sg Marketplace v2 — Implementation Plan
+
+**Date:** 2026-07-14 · **Status:** IMPLEMENTED 2026-07-14 (branch `feat/redeem-marketplace-v2`; all flags dark). Implementation notes: (a) partner-enquiry Phase 7 shipped as mailto CTA per the deferral; (b) `preferred_branch` intake uses charset-sanitisation rather than an ops-location identity check (avoids a per-submit redeem-ops query; school level + timing ARE config-validated); (c) marketplace list cache state lives in model-free `services/marketplaceCache.js` so writer services can invalidate without importing the read model; (d) client-supplied `sourceMetadata` remains passthrough for internal callers (documented contract in prospectServiceCapi.test.js — public route strips it via Joi) with the `marketplace` subkey scrubbed server-side.
+**Design source of truth:** claude.ai/design project `6ae0fb7b-3773-4695-950f-1dbbc1dd1b9f`
+(`Redeem.sg Prototype v2.dc.html`, `Design Config Schema.dc.html`, `Analytics Event
+Taxonomy.dc.html`, `mock-api-v2.js`, `OfferCardV2.dc.html`). Design reconciled against the
+repo twice (2026-07-14); plan reviewed by Codex (gpt-5.6-sol, xhigh) with all findings
+verified against code and folded in.
+
+## What we're building
+
+A consumer marketplace on **redeem.sg**: browse/explore/category pages, per-campaign offer
+detail pages (`/offers/:slug`), a step-based redemption flow (`/flow/:slug`), a DSA guide,
+and supporting content pages — reading campaigns as a **two-layer object**: `design_config`
+(designer-authored, existing JSONB) + `ops` (composed server-side, read-only, from Redeem Ops
+entities: PartnerOrganisation / PartnerLocation / RewardOffer / RewardOfferLocation /
+Activation / Draw). Lead submission, routing, OTP, DNC, consents, CAPI/pixels, and the
+reward pass all reuse the existing production pipeline.
+
+**This supersedes the Concept-B drop-culture homepage** (`RedeemHome.jsx`) at the redeem apex
+once the flag flips; RedeemHome stays live until then (dark launch).
+
+## Non-negotiable ground truth (verified in code — do not fork these)
+
+| Contract | Reality |
+|---|---|
+| Form config | `design_config.visibleFields` / `requiredFields` ({key: bool}) + `fieldOrder` which is **either** legacy `string[]` **or** row objects `{id, columns: [fieldId…]}` — the current designer normalizes TO row shape (`DesignEditor.jsx:21`), and `CampaignSignupForm.jsx:813` renders both. Field rendering lives in `signup/FieldRenderer.jsx`. The marketplace renderer must accept both shapes |
+| Age gate | `campaigns.min_age` / `max_age` columns; server re-checks and 422s (`prospectService.js:532-541`); already exposed via `/api/previews/public/:id` |
+| Lucky draw | `design_config.luckyDraw {enabled, closesAt, multiplier, activationId, termsVersionId, termsHash}` (normalized by `backend/src/utils/luckyDraw.js`) — **contains internal IDs that must never reach a public DTO**. Ops-side `Draw` row: statuses `open\|frozen\|sealed\|drawn\|published\|claimed\|void` (no `cancelled`). Intake gates on `luckyDraw.closesAt` (`prospectService.js:373-384`); a created Draw snapshots its own cutoff (`luckyDrawService.js:132`) |
+| Featured | `design_config.featuredDrop` + public `GET /api/campaigns/featured-drops` (60s cache; admin-only publication via `applyFeaturedDropPolicy`; gate = `is_active: true` AND `status: 'active'` — `featuredDropsService.js:30`) |
+| Submit | `POST /api/prospects`, public + rate-limited, Joi `prospectCreate` with `stripUnknown: true` (`prospects.js:26`, `validation.js:171`): **flat camelCase** — `firstName` (required), `lastName`, `email` (required), `phone`, `leadSource` (required), `campaignId`, `qrTagId`, `date_of_birth`, `postal_code`, `education_level`, `monthly_income`, `eventId`, `fbp/fbc/ttclid/ttp`, consent flags, `referralRef`. Unknown keys are silently stripped — new fields MUST be added to the Joi schema |
+| Duplicate | 409; apiClient throws with `err.status === 409` and `err.data?.alreadyRegistered === true` (nested under `data` — `prospectService.js:490`, `src/api/client.js:156`) |
+| Success | 201 `{success, data: {prospect: {id}, shareUrl}}`; `shareUrl` (shortlink) targets `/LeadCapture` only — `shortlinkService.js:51,102` |
+| OTP | `POST /api/verify/send` / `POST /api/verify/check` (`skipAuth`); channel from `design_config.otpChannel`, WhatsApp falls back to SMS (`verificationService.js:131`). **No other SMS path exists** — confirmations are email (`prospectController.js:58`; reservation/voucher email via `fulfilmentNotify.js`) |
+| DNC | `POST /api/dnc/check` → `{registered}`; consent submitted as `consent_dnc` |
+| Gates | `design_config.sgPrOnly`, `design_config.excludeAdvisors` (both exist) |
+| Consents | `consent_contact` (pre-ticked opt-out; gates hashed em/ph in CAPI + direct-marketing follow-up), `consent_terms` (required), `consent_third_party` (opt-in; gates **external-buyer** routing — `prospectService.js:390` — NOT a general "consultant will contact you" switch) |
+| Campaign auth | `PUT /api/campaigns/:id` is `requireAgentOrAdmin` (`campaigns.js:87`) and accepts `is_active` — agents can activate campaigns. Archive changes `status` only. `isPublic` = intra-staff visibility, not a consumer gate |
+| Campaign types | `type ∈ {…, quiz, guided_review, …}` — quiz/guided-review campaigns have their own funnels and are NOT marketplace-compatible in v1 |
+| Activation | Partial unique index enforces **one live Activation per campaign** across preparing/active/paused (`Activation.js:55`, migration 049) — multiple live rows = data corruption, not a selection problem. Exhaustion does NOT change status; issuance fails its atomic counter (`entitlementService.js:85`) |
+| Reward locations | Offer-specific `RewardOfferLocation` join (the claim API already uses it — `rewardClaim.js:72`), NOT all partner branches |
+| Reward issuance | Requires `REDEEM_OPS_ENABLED` + `REDEEM_OPS_ENTITLEMENTS_ENABLED`; post-commit fire-and-forget (`prospectService.js:1011`); a 201 lead does NOT guarantee an entitlement |
+| `/t/:slug` | QR-TAG slug namespace. Tracker sets `atk`/`sid` cookies then 302 → `{frontendBaseForHost(publicHost)}/LeadCapture?{params}` — `frontendBaseForHost` returns mktr.sg for mktr hosts |
+| `/p/:slug` | Preview-slug namespace (`campaignPreviews.js`) |
+| Public campaign fetch | `GET /api/previews/public/:id` returns the **entire** `design_config` (`campaignPreviewService.js:85-91`) — pre-existing over-exposure, in scope to harden (see Phase 1) |
+| Reward pass | `/r/:token` + `GET /api/reward-claim/:token` LIVE (flag-gated); the SPA page already renders `blocked` and `locations` (`RewardClaim.jsx:83,102`) — **no parity work needed** |
+| Sequelize | `underscored: false` (`connection.js:28`) — model attributes map to camelCase column names; DDL must be camelCase (or use explicit `field`) |
+| Route mounting | `backend/src/routes/index.js` auto-mounts modules exporting `meta = {path, flag, flagDefault}` |
+| Model indexes | `sync({force: true})` clobbers migration indexes AND test bootstrap syncs before migrations (`bootstrap.js:25`); migration runner is non-transactional — migrations must be idempotent (`describeTable` guards, `IF NOT EXISTS`), indexes mirrored on models |
+| Build | One shared `index.html` for both brands; redeem sitemap routes are hard-coded in `vite.config.js:50` |
+
+## Decisions
+
+1. **Publication gate (list AND detail)** = `design_config.marketplaceListed === true`
+   (admin-only via new `applyMarketplacePolicy`, mirroring `applyFeaturedDropPolicy`) AND
+   `slug` set AND `is_active === true` AND `status === 'active'` AND
+   `resolveCustomerHost(design_config.customerHost) === 'redeem.sg'` AND
+   `type` in the supported set (standard lead-capture types; quiz/guided_review excluded)
+   AND ops resolvable. **No "unlisted link" semantics in v1** — detail 404s unless listed.
+   Rationale: agents can flip `is_active` via PUT, so the ONLY consumer-exposure switch must
+   be the admin-gated `marketplaceListed`.
+2. **Campaign slug**: new nullable unique column, charset `[a-z0-9-]{3,80}`. Immutable once
+   `firstActivatedAt` (new column) is set — stamped by `updateCampaign` the first time
+   `is_active` flips true. `duplicateCampaign` explicitly clears `slug`, `marketplaceListed`,
+   and `firstActivatedAt`. Slug added to the campaign create/update Joi schemas and saved as
+   a top-level field (the designer today saves only `design_config` —
+   `AdminCampaignWorkspace.jsx:82` — so the save path gains the top-level field).
+3. **`/LeadCapture` is untouched.** The marketplace flow is a NEW component tree reusing the
+   same endpoints. No `CampaignSignupForm.jsx` changes in v1.
+4. **qr_entry** honored inside the tracker redirect behind its OWN flag
+   `MARKETPLACE_QR_REDIRECT_ENABLED` (flipped only AFTER the SPA routes are live), and only
+   when the validated public host is redeem.sg AND the campaign passes the decision-1 gate.
+   Everything else keeps today's `/LeadCapture` redirect. Cookies set in both branches.
+5. **ops composition**: THE single live Activation (unique index — if >1, log error and
+   return `ops: null`). Include `RewardOffer.status === 'active'` and validity window; list
+   excludes exhausted (`remaining <= 0`) or out-of-validity offers; detail shows a sold-out /
+   ended state. `ops.expiry = min(Activation.endDate, RewardOffer.validityEnd)` null-safe.
+   `ops.partner.locations` from **RewardOfferLocation** (fallback: none — never all partner
+   branches). `ops.draw` from the campaign's Draw row with `status === 'open'` only.
+6. **Draw single-source rule**: consumer-facing close date = `design_config.luckyDraw.closesAt`
+   (the intake gate); boost multiplier + boost deadline = the open Draw row. Designer shows a
+   warning when `luckyDraw.closesAt` ≠ the open Draw's snapshotted `closesAt` (admin edits
+   after Draw creation can otherwise accept entries the frozen pool excludes). T&C content =
+   existing `design_config.termsContent` (sanitized dialog, same as production forms); terms
+   version pinning stays server-side as today.
+7. **New Partner columns** (camelCase DDL per `underscored: false`): `publicBlurb` TEXT,
+   `verifiedAt` DATE, `partnerSince` SMALLINT. Wired into `partnersController` validation +
+   `partnerService` editable-fields list; `verifiedAt` settable only by admin (not ordinary
+   partner-edit capability). `notes`/CRM fields never leave the backend.
+8. **Dark launch flags**: backend `MARKETPLACE_PUBLIC_API_ENABLED` (route `meta.flag`,
+   default false) + `MARKETPLACE_QR_REDIRECT_ENABLED` (default false); frontend
+   `VITE_REDEEM_MARKETPLACE_ENABLED` (redeem build only; also switches apex `/`).
+9. **Marketplace metadata**: submit body gains a `marketplace` object — added to the Joi
+   `prospectCreate` schema (else `stripUnknown` silently drops it) and **validated
+   server-side against campaign config**: `preferred_branch` must match an offer location
+   name, `child_school_level` ∈ `design_config.school_levels`, `preferred_timing` composed
+   from `design_config.availability` values, `child_name` trimmed ≤120 chars. Stored at
+   `sourceMetadata.marketplace`. The service explicitly ignores any client-supplied raw
+   `sourceMetadata` key. **Webhook note:** `sourceMetadata` is forwarded verbatim to the
+   Lyfe `lead.created` webhook (`prospectHelpers.js:79`) — `child_name` (minor's first name)
+   therefore reaches Lyfe; the campaign `data_use` copy must disclose it, and the Lyfe
+   receiver needs no change (stores metadata opaquely) but gets a contract-note in
+   lyfe-master docs.
+10. **Draw confirmation copy**: boost arrangement is communicated via the confirmation
+    EMAIL (no SMS exists) and, when `consent_contact` is on, the assigned consultant's
+    outreach at the verified number. No copy references `consent_third_party` (that consent
+    gates external-buyer routing only) and none references SMS.
+11. **shareUrl limitation (v1, documented)**: the confirmation's referral link targets
+    `/LeadCapture?campaign_id=…` (shortlink service allows only that). Friends land on the
+    legacy form — lead still captured + attributed via `ref`. Marketplace-aware share links
+    are a fast-follow (shortlink target allowlist + `/offers/:slug` support).
+12. **Fonts/visuals**: single shared `index.html` — fonts load via CSS `@import` inside the
+    marketplace stylesheet (`rm-` prefixed, mirrors `redeemHome.css` conventions), so the
+    mktr bundle is untouched. New static routes added to the redeem sitemap list in
+    `vite.config.js`.
+
+## Phase 0 — Migrations + models (idempotent)
+
+- **066-add-campaign-slug.js**: `campaigns.slug` STRING(80) NULL, `campaigns.firstActivatedAt`
+  DATE NULL, partial unique index `uq_campaigns_slug WHERE slug IS NOT NULL`
+  (`CREATE UNIQUE INDEX IF NOT EXISTS`), `describeTable` guards. Mirror index + attributes
+  (with `is: /^[a-z0-9-]{3,80}$/`) on `Campaign.js`.
+- **067-partner-public-profile.js**: `partner_organisations."publicBlurb"` TEXT NULL,
+  `"verifiedAt"` DATE NULL, `"partnerSince"` SMALLINT NULL (camelCase, guards as above).
+  Mirror on `PartnerOrganisation.js`.
+- No prospects migration (JSONB) and no min_age migration (columns exist).
+
+## Phase 1 — Public marketplace API
+
+New `backend/src/services/marketplaceService.js` + `backend/src/routes/marketplace.js`
+(`meta = {path: '/api/marketplace', flag: 'MARKETPLACE_PUBLIC_API_ENABLED', flagDefault: 'false'}`),
+rate-limited like `rewardClaim.js`.
+
+- `GET /api/marketplace/campaigns` (list) and `GET /api/marketplace/campaigns/:slug`
+  (detail) — both apply the FULL decision-1 gate; 404 otherwise.
+- **DTO is reconstructed field-by-field — no nested-object passthrough:**
+  - campaign: `id, slug, name, min_age, max_age, metaPixelId, tiktokPixelId`
+  - design_config (rebuilt): `name, category, offer_type, qr_entry, age_range,
+    school_levels, dsa_related, mode, availability {days, slots}, inclusions, image_label,
+    showCapacity, activation {required, type, duration_mins, summary, detail},
+    sponsor {kind, disclosure} | null, value_line, featuredDrop, sgPrOnly, dncCheckAtSubmit,
+    excludeAdvisors, otpChannel, termsContent, content_blocks {data_use, cancellation, faq},
+    themeColor, fieldOrder (normalized), visibleFields, requiredFields,
+    luckyDraw: {enabled, closesAt, winners} ONLY` — **never** `activationId`,
+    `termsVersionId`, `termsHash`, quiz config, customerHost, or unknown keys.
+  - ops (rebuilt): `partner {name ← brandName||tradingName, verified ← !!verifiedAt,
+    since ← partnerSince, blurb ← publicBlurb, locations[{name, area}] ← RewardOfferLocation}`,
+    `capacity {total, remaining}`, `expiry`, `retail_value` (Number-cast from DECIMAL),
+    `claim_expiry_days`, `redemption_expiry_days`,
+    `draw {closesAt, boostClosesAt, multiplier} | null` (open Draw only).
+- **Cache**: 60s in-process with coalescing, stale-on-error **bounded to 5 minutes** (then
+  fail empty), and a write-side version bump (campaign/activation/reward-offer mutations call
+  `marketplaceService.invalidate()`); the cache is display-only, never consulted for
+  issuance decisions.
+- **Harden the pre-existing leak**: `campaignPreviewService.getPublicCampaign` (used by
+  `/api/previews/public/:id`) gets the same design_config key whitelist (superset needed by
+  LeadCapture: adds `quiz`, `termsContent`, `heroFont`, layout/copy keys — enumerated from
+  actual `LeadCapture`/`CampaignSignupForm`/`PreviewFrame` reads) so full raw
+  `design_config` (incl. luckyDraw internals) stops being publicly dumpable. Regression-test
+  LeadCapture + quiz + preview against the whitelist.
+
+- **Designer-support endpoints (authenticated, flag-independent):**
+  `GET /api/campaigns/:id/marketplace-preview` (composed DTO for drafts — powers the
+  designer ops-preview panel) and `GET /api/campaigns/slug-availability?slug=…`.
+
+## Phase 2 — Designer + service clamps (operator side)
+
+- `campaignService.updateCampaign`: accept top-level `slug` (Joi added; immutability per
+  decision 2), stamp `firstActivatedAt`, clamp new design_config enums server-side
+  (`qr_entry ∈ {direct, detail}`, `offer_type`, `mode`, `category ∈ CONSUMER_CATEGORIES`),
+  shape-check `age_range/availability/inclusions/content_blocks/activation/sponsor` (drop
+  unknown keys), apply `applyMarketplacePolicy` (agents can't set/unset `marketplaceListed`;
+  also strips it on the bulk paths, mirroring featuredDrop).
+- `duplicateCampaign`: clear `slug`, `firstActivatedAt`, `design_config.marketplaceListed`.
+- Designer UI (`editor/ContentPanel.jsx` + new `MarketplacePanel.jsx`): slug field w/
+  availability check, listing toggle (admin-only render), category/offer_type/mode,
+  age_range + school_levels ("Audience (display/filter)" — labeled distinctly from the
+  min_age/max_age "Submitter age gate"), availability chips, inclusions editor, activation
+  copy block, sponsor block, value_line override, showCapacity, qr_entry, content_blocks,
+  draw-cutoff consistency warning (decision 6), read-only ops preview via the authenticated
+  preview endpoint.
+
+## Phase 3 — Consumer SPA (redeem build, dark)
+
+New `src/pages/marketplace/` + `src/components/marketplace/`:
+
+- **Routes** (gated `IS_REDEEM_BUILD && VITE_REDEEM_MARKETPLACE_ENABLED === 'true'`):
+  `/` (Home — replaces RedeemHome element when on), `/explore`, `/c/:id`, `/dsa`,
+  `/offers/:slug`, `/flow/:slug`, `/how-it-works`, `/businesses`, `/about` (**replace** the
+  existing `/about` element on the redeem build — no duplicate route), legal links reuse the
+  EXISTING `/personal-data-policy` and `/leads/privacy` routes (+ small new `/legal/terms`,
+  `/legal/dnc` static pages). `/winners`, `/r/:token`, `/LeadCapture` unchanged. Nothing
+  mounts on the mktr build. Sitemap list in `vite.config.js` updated.
+- **Components**: `OfferCard` (per OfferCardV2 spec), nav/footer, `JourneyProgress`, flow
+  steps (`Screen` SC/PR, `Advisor`, `Details`, `Child`, `Prefs`, `Otp`, `Dnc`, `Consent`,
+  `Confirmation`, `Duplicate`).
+- **Details renderer**: reuse/extract the production primitives — the row/legacy `fieldOrder`
+  normalization (from `DesignEditor.normalizeFieldOrder` / `CampaignSignupForm`) and
+  `signup/FieldRenderer.jsx` field defs — so both config shapes render identically to
+  production. No parallel field-def table.
+- **Flow machine** (`useMarketplaceFlow`): steps `[screen?] → [advisor?] → details →
+  [child?] → [prefs?] → otp → [dnc?] → consent → done`. Endpoints: `/verify/send`,
+  `/verify/check`, `/dnc/check`, `POST /prospects`. Submit payload = the REAL contract:
+  split name → `firstName`/`lastName`, `email`, `phone`, `leadSource: 'website'` (or
+  `qr_code` when session-attributed), `campaignId`, `date_of_birth`, `postal_code`,
+  `education_level`, `monthly_income`, `eventId`, `fbp/fbc/ttclid/ttp`, `eventSourceUrl`,
+  consent flags incl. `consent_dnc`, `referralRef`, plus `marketplace: {child_name,
+  child_school_level, preferred_branch, preferred_timing}`. Duplicate = catch
+  `err.status === 409 && err.data?.alreadyRegistered`. QR attribution: `GET /qrcodes/session`
+  → attach `qrTagId` (same as LeadCapture).
+- Age validation client-side from `min_age`/`max_age` (reuse `getAgeValidationError`);
+  server 422 authoritative.
+- **Draw UI**: mechanics + boost tier per decision 6; T&C required with terms dialog from
+  `termsContent`; confirmation copy per decision 10; confirmation share block uses the
+  returned `shareUrl` (decision-11 limitation noted in code comment).
+- **Confirmation makes no reward-state claims**: "what happens next" copy only (issuance is
+  async + flag-dependent; reward-pass link arrives by email via `fulfilmentNotify` when
+  entitlements are enabled).
+- Home/Explore/Category/DSA use the list endpoint + client-side filters.
+
+## Phase 4 — Prospect intake (backend)
+
+- Joi `prospectCreate` += `marketplace: Joi.object({child_name, child_school_level,
+  preferred_branch, preferred_timing}).optional()` (each string, max 120).
+- `prospectService.createProspect`: validate `marketplace` values against the campaign
+  (decision 9), write `sourceMetadata.marketplace`, explicitly drop any client-supplied
+  `sourceMetadata`. Everything else (eventId/CAPI, consents, OTP stamp, draw gate, DNC,
+  routing, entitlement hook) is untouched.
+- Add a contract note to `lyfe-master` docs: `lead.created` webhook `sourceMetadata` may now
+  include `marketplace.*` (incl. child first name) — receiver stores opaquely, no change.
+
+## Phase 5 — Tracker `qr_entry` branching (backend)
+
+`trackerController.trackSlug`: behind `MARKETPLACE_QR_REDIRECT_ENABLED`, when the validated
+public host resolves to redeem.sg AND the bound campaign passes the decision-1 gate AND
+`design_config.qr_entry === 'detail'` → `302 {frontendBase}/offers/{slug}?{search}`; else
+current behaviour. Cookies in both branches. Lean campaign fetch
+(`attributes: ['slug', 'is_active', 'status', 'design_config']`). Tests: mktr host, flag
+off, unlisted, missing slug, happy path.
+
+## Phase 6 — Analytics
+
+- **Suppression predicate**: allow `/offers/` + `/flow/` (same preview/test-data
+  suppressions).
+- **Landing capture**: run `captureFbcFromUrl` / `captureTtclidFromUrl` / `captureUtmsFromUrl`
+  on offer-detail AND flow mounts (they persist to session/local storage already), so
+  detail-landing → flow navigation keeps attribution.
+- **VC session guard**: `getOrCreateVcState(campaignId)` → sessionStorage `vc:{campaign_id}`
+  holding `{eventId, firedMeta, firedTiktok}` (per-platform flags — Meta and TikTok fire
+  independently). Marketplace surfaces use it; refactor `LeadCapture.jsx`'s refs onto it
+  (existing single-mount behaviour preserved). In-memory fallback when sessionStorage
+  unavailable.
+- **Custom events**: `trackCustomEvent` helper (Meta `fbq('trackCustom')`, TikTok custom
+  `ttq.track`) firing `otp_sent`, `otp_verified`, `dnc_gate_shown`, `dnc_consent_given`,
+  `duplicate_blocked`, `draw_entry_confirmed` from the marketplace flow only.
+- **Lead**: mechanics unchanged. **No value/currency in v1** — browser-only value would
+  desync from CAPI (which sends none — `metaCapiService.js:82`); ship browser+server value
+  parity together as a fast-follow.
+- `content_ids = [campaign_id]`, `content_name = campaign.name`,
+  `content_category = design_config.category`.
+
+## Phase 7 — Partner enquiry — DEFERRED
+
+The `/businesses` page ships with a `mailto:partnerships@redeem.sg` CTA in v1. The
+unauthenticated CRM-write endpoint is cut: `normalizedName` matching lets strangers append
+content to real CRM orgs (column not unique), `createdBy` is NOT NULL, `PartnerContact` uses
+`mobile`, and `PartnerStageEvent` requires real stage transitions. Fast-follow design: a
+standalone `marketplace_enquiries` staging table + admin review/promote action in Redeem Ops
+— never direct public writes into `partner_organisations`.
+
+## Testing
+
+- **Backend (jest, mock-model pattern — no DB):** marketplace DTO (asserts luckyDraw
+  internals/termsHash/customerHost/quiz NEVER appear; ops reconstruction incl.
+  RewardOfferLocation + sold-out/validity exclusions), publication gate matrix (agent
+  `is_active` flip does NOT expose; archived/status≠active excluded; mktr-host excluded;
+  quiz type excluded), slug clamp + immutability + duplicate-clears, preview/slug-check
+  endpoints, tracker branch matrix, marketplace-metadata validation (rejects unknown branch/
+  level; drops raw sourceMetadata), previews/public whitelist regression (LeadCapture + quiz
+  keys still present).
+- **Frontend:** flow-machine step permutations; details renderer against BOTH fieldOrder
+  shapes; OfferCard draw/standard/sold-out; duplicate path from a thrown 409.
+- **E2E:** `/verify` skill (Playwright, both brands) — marketplace live on redeem preview
+  with flag on; mktr bundle has zero marketplace chunks; `/LeadCapture` regression both
+  hosts; full flow submit on a seeded campaign (throwaway pg recipe).
+- **Pixel sanity:** test-event codes — single VC across detail→flow→back, per-platform
+  independence, Lead on 201 only, nothing on `/r/:token`.
+
+## Rollout
+
+1. Merge, all three flags OFF. Verify deploys per push≠live checklist.
+2. Flip `MARKETPLACE_PUBLIC_API_ENABLED`; smoke the API directly (expect empty list until a
+   campaign is gated in).
+3. Seed pilot: redeem-ops partner (+ `publicBlurb`/`verifiedAt`/`partnerSince`) →
+   RewardOffer (+ RewardOfferLocation) → Activation → designer (slug, content,
+   marketplaceListed). Note: the reward-pass leg additionally requires `REDEEM_OPS_ENABLED`
+   + `REDEEM_OPS_ENTITLEMENTS_ENABLED` (currently off) — leads flow regardless.
+4. Flip `VITE_REDEEM_MARKETPLACE_ENABLED` on `redeem-frontend` → redeploy → Playwright
+   verify → Cloudflare purge (user-side).
+5. Flip `MARKETPLACE_QR_REDIRECT_ENABLED` last (SPA routes must exist first).
+6. Watch: Render logs, Meta/TikTok test events, lead arrival + round-robin, Sentry.
+
+## Non-goals (explicit)
+
+- No `CampaignSignupForm.jsx`/quiz/guided-review changes; those types can't be listed.
+- No CAPI/browser Lead value (fast-follow, shipped together).
+- No marketplace-aware share links (decision 11) or repeat-redeemer submit block.
+- No partner-enquiry endpoint (Phase 7 deferred), no SEO prerender, no mktr.sg marketplace.
+- `reconcileMissedLeads` discards the raw token making reconciled entitlements
+  consumer-unreachable (`entitlementService.js:319`) — pre-existing bug, tracked separately,
+  not in this scope.
+
+## Codex review log (2026-07-14, gpt-5.6-sol xhigh)
+
+7 BLOCKER / 12 MAJOR / 4 MINOR / 3 NIT findings; all spot-verified against code and folded:
+DTO nested-object reconstruction + previews/public hardening (B1), fieldOrder dual shape
+(B2), real prospect Joi contract + stripUnknown (B3), publication gate vs agent `is_active`
+access + customerHost/type checks, no unlisted semantics (B4), reward-issuance flags +
+no-reward-claims confirmation copy + no-SMS copy (B5, M10), draw cutoff single-source +
+termsContent (B6), partner-enquiry deferral (B7, N3), slug lifecycle `firstActivatedAt` +
+Joi + duplicate-clear (M1), RewardOffer status/validity + RewardOfferLocation + sold-out
+handling (M2), Draw `open`-only selection (M3), camelCase partner DDL + authoring path
+(M4), marketplace metadata validation + webhook PII note (M5), QR redirect brand/flag gate
+(M6), authenticated preview + slug-check endpoints (M7), type restriction (M8), shareUrl
+limitation documented (M9), bounded stale cache + invalidation (M11), landing attribution
+capture + per-platform VC flags + Lead value deferred (M12), 409 `err.data` shape (m1),
+single-Activation invariant (m2), `/about` replace + sitemap + fonts-via-CSS (m3),
+idempotent migrations (m4), reward-pass parity removed (n1), legal route reuse (n2).

--- a/src/api/marketplace.js
+++ b/src/api/marketplace.js
@@ -1,0 +1,47 @@
+import { apiClient } from '@/api/client';
+
+/**
+ * Marketplace read API (redeem.sg consumer surfaces).
+ * Backend: GET /api/marketplace/campaigns[/:slug] — composed two-layer DTOs
+ * (design_config + ops), publication-gated server-side, 60s service cache.
+ * A short module-level cache avoids refetching the list on every route change
+ * within one session (the browse surfaces share it).
+ */
+
+const LIST_TTL_MS = 60_000;
+let listCache = { data: null, ts: 0 };
+let listInflight = null;
+
+export async function listMarketplaceCampaigns() {
+  const now = Date.now();
+  if (listCache.data && now - listCache.ts < LIST_TTL_MS) return listCache.data;
+  if (listInflight) return listInflight;
+  listInflight = apiClient
+    .get('/marketplace/campaigns', { skipAuth: true })
+    .then((resp) => {
+      const campaigns = resp?.data?.campaigns || [];
+      listCache = { data: campaigns, ts: Date.now() };
+      return campaigns;
+    })
+    .finally(() => {
+      listInflight = null;
+    });
+  return listInflight;
+}
+
+/** Detail is always fetched live (sold-out/paused must be immediate). */
+export async function getMarketplaceCampaign(slug) {
+  try {
+    const resp = await apiClient.get(`/marketplace/campaigns/${encodeURIComponent(slug)}`, { skipAuth: true });
+    return resp?.data?.campaign || null;
+  } catch (err) {
+    if (err?.status === 404) return null;
+    throw err;
+  }
+}
+
+/** Test hook. */
+export function __resetMarketplaceListCache() {
+  listCache = { data: null, ts: 0 };
+  listInflight = null;
+}

--- a/src/components/campaigns/DesignEditor.jsx
+++ b/src/components/campaigns/DesignEditor.jsx
@@ -7,13 +7,15 @@ import {
  LayoutTemplate,
  ListChecks,
  PanelLeftClose,
- PanelLeft
+ PanelLeft,
+ Store
 } from"lucide-react";
 
 import ContentPanel from"./editor/ContentPanel";
 import DesignPanel from"./editor/DesignPanel";
 import LayoutPanel from"./editor/LayoutPanel";
 import QuizPanel from"./editor/QuizPanel";
+import MarketplacePanel from"./editor/MarketplacePanel";
 import PreviewFrame from"./editor/PreviewFrame";
 import { genId } from"./editor/constants";
 import GuidedReviewDesigner from"./guided-review/GuidedReviewDesigner";
@@ -41,7 +43,8 @@ const TABS = [
  { id: 'content', label: 'Content', icon: Type },
  { id: 'design', label: 'Design', icon: Palette },
  { id: 'layout', label: 'Layout', icon: LayoutTemplate },
- { id: 'quiz', label: 'Quiz', icon: ListChecks }
+ { id: 'quiz', label: 'Quiz', icon: ListChecks },
+ { id: 'marketplace', label: 'Marketplace', icon: Store }
 ];
 
 function ClassicDesignEditor({ campaign, onSave, heightClass = 'h-[calc(100vh-8rem)]' }) {
@@ -130,6 +133,8 @@ function ClassicDesignEditor({ campaign, onSave, heightClass = 'h-[calc(100vh-8r
  return <LayoutPanel currentDesign={currentDesign} onDesignChange={handleDesignChange} />;
  case 'quiz':
  return <QuizPanel currentDesign={currentDesign} onDesignChange={handleDesignChange} />;
+ case 'marketplace':
+ return <MarketplacePanel currentDesign={currentDesign} onDesignChange={handleDesignChange} campaign={campaign} />;
  default:
  return null;
  }

--- a/src/components/campaigns/DesignEditor.jsx
+++ b/src/components/campaigns/DesignEditor.jsx
@@ -87,6 +87,19 @@ function ClassicDesignEditor({ campaign, onSave, heightClass = 'h-[calc(100vh-8r
  videoUrl: design.videoUrl || '',
  termsContent: design.termsContent || '',
  quiz: design.quiz || null,
+ // Marketplace content (Marketplace tab) — carried through so an ordinary
+ // designer save round-trips it. clampDesignConfig replaces these keys
+ // WHOLESALE from the incoming object (unlike featuredDrop/luckyDraw, which
+ // have preserve-when-omitted policies), so omitting them here would erase
+ // stored marketplace content on every save.
+ ...Object.fromEntries(
+ [
+ 'name', 'category', 'offer_type', 'mode', 'qr_entry', 'age_range',
+ 'school_levels', 'dsa_related', 'showCapacity', 'availability',
+ 'inclusions', 'image_label', 'activation', 'sponsor', 'value_line',
+ 'content_blocks', 'marketplaceListed',
+ ].filter((k) => design[k] !== undefined).map((k) => [k, design[k]])
+ ),
  });
 
  const [saving, setSaving] = useState(false);

--- a/src/components/campaigns/editor/MarketplacePanel.jsx
+++ b/src/components/campaigns/editor/MarketplacePanel.jsx
@@ -1,0 +1,366 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { AlertCircle, CheckCircle2, Loader2, Store } from 'lucide-react';
+import { apiClient } from '@/api/client';
+
+/**
+ * Marketplace panel — authors the design_config marketplace keys
+ * (docs/plans/redeem-marketplace-v2.md Phase 2). Values are clamped
+ * server-side (utils/marketplaceContent.js); marketplaceListed is admin-only
+ * on the server (non-admin saves preserve the stored value).
+ *
+ * The slug is a TOP-LEVEL campaign column (not design_config) with its own
+ * save path here — it locks permanently once the campaign is first activated.
+ */
+
+const CATEGORY_OPTIONS = [
+  ['art_creativity', 'Art & Creativity'], ['coding_robotics', 'Coding & Robotics'],
+  ['speech_performance', 'Speech & Performance'], ['sports_movement', 'Sports & Movement'],
+  ['music_dance', 'Music & Dance'], ['academic', 'Academic'],
+  ['family_lifestyle', 'Family & Lifestyle'], ['wellness', 'Wellness'],
+  ['dining', 'Dining'], ['financial_education', 'Financial Education'],
+];
+const OFFER_TYPES = ['trial', 'assessment', 'workshop', 'reward', 'consultation'];
+const MODES = ['physical', 'online', 'hybrid'];
+const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+function Section({ title, hint, children }) {
+  return (
+    <div className="space-y-3 border-t border-border pt-4 first:border-t-0 first:pt-0">
+      <Label className="text-sm font-semibold text-foreground">{title}</Label>
+      {hint && <p className="text-xs text-muted-foreground -mt-1">{hint}</p>}
+      {children}
+    </div>
+  );
+}
+
+export default function MarketplacePanel({ currentDesign, onDesignChange, campaign }) {
+  const dc = currentDesign || {};
+  const activation = dc.activation || {};
+  const sponsor = dc.sponsor || null;
+  const blocks = dc.content_blocks || {};
+  const availability = dc.availability || { days: [], slots: [] };
+
+  const setActivation = (patch) => onDesignChange('activation', { ...activation, required: activation.required === true, ...patch });
+  const setBlocks = (patch) => onDesignChange('content_blocks', { ...blocks, ...patch });
+
+  /* ---------- slug (top-level column, own save path) ---------- */
+  const [slug, setSlug] = useState(campaign?.slug || '');
+  const [slugState, setSlugState] = useState('idle'); // idle|checking|available|taken|invalid|saving
+  const slugLocked = !!campaign?.firstActivatedAt;
+
+  useEffect(() => {
+    setSlug(campaign?.slug || '');
+  }, [campaign?.slug]);
+
+  const checkSlug = useCallback(async (value) => {
+    if (!value) return setSlugState('idle');
+    if (!/^[a-z0-9-]{3,80}$/.test(value)) return setSlugState('invalid');
+    if (value === campaign?.slug) return setSlugState('available');
+    setSlugState('checking');
+    try {
+      const resp = await apiClient.get(`/campaigns/slug-availability?slug=${encodeURIComponent(value)}&excludeCampaignId=${campaign?.id || ''}`);
+      setSlugState(resp?.data?.available ? 'available' : 'taken');
+    } catch {
+      setSlugState('idle');
+    }
+  }, [campaign?.id, campaign?.slug]);
+
+  useEffect(() => {
+    const t = setTimeout(() => checkSlug(slug), 400);
+    return () => clearTimeout(t);
+  }, [slug, checkSlug]);
+
+  const saveSlug = async () => {
+    setSlugState('saving');
+    try {
+      await apiClient.put(`/campaigns/${campaign.id}`, { slug: slug || null });
+      toast.success(slug ? `Slug saved — /offers/${slug}` : 'Slug cleared');
+      setSlugState(slug ? 'available' : 'idle');
+    } catch (err) {
+      toast.error(err?.message || 'Could not save the slug.');
+      setSlugState('idle');
+    }
+  };
+
+  /* ---------- ops preview (composed DTO + gate checklist) ---------- */
+  const [preview, setPreview] = useState(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const loadPreview = useCallback(async () => {
+    if (!campaign?.id) return;
+    setPreviewLoading(true);
+    try {
+      const resp = await apiClient.get(`/campaigns/${campaign.id}/marketplace-preview`);
+      setPreview(resp?.data?.campaign || null);
+    } catch {
+      setPreview(null);
+    } finally {
+      setPreviewLoading(false);
+    }
+  }, [campaign?.id]);
+
+  useEffect(() => {
+    loadPreview();
+  }, [loadPreview]);
+
+  const drawMismatch = useMemo(() => {
+    const opsDraw = preview?.ops?.draw;
+    const ldCloses = dc.luckyDraw?.closesAt;
+    if (!opsDraw?.closesAt || !ldCloses) return false;
+    return String(opsDraw.closesAt).slice(0, 10) !== String(ldCloses).slice(0, 10);
+  }, [preview, dc.luckyDraw?.closesAt]);
+
+  const gate = preview?.gate;
+
+  return (
+    <div className="space-y-6">
+      <Section
+        title="Marketplace URL (slug)"
+        hint={slugLocked
+          ? 'Locked — the slug can no longer change because this campaign has been activated.'
+          : 'Lowercase letters, digits and hyphens. Powers /offers/:slug and /flow/:slug on redeem.sg. Locks permanently on first activation.'}
+      >
+        <div className="flex gap-2">
+          <Input
+            value={slug}
+            disabled={slugLocked}
+            placeholder="visual-arts-discovery"
+            onChange={(e) => setSlug(e.target.value.toLowerCase().trim())}
+          />
+          <Button size="sm" disabled={slugLocked || slugState === 'taken' || slugState === 'invalid' || slugState === 'saving' || slug === (campaign?.slug || '')} onClick={saveSlug}>
+            {slugState === 'saving' ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : 'Save'}
+          </Button>
+        </div>
+        {slugState === 'taken' && <p className="text-xs text-destructive">That slug is taken by another campaign.</p>}
+        {slugState === 'invalid' && <p className="text-xs text-destructive">3–80 chars: lowercase letters, digits, hyphens.</p>}
+        {slugState === 'available' && slug && <p className="text-xs text-emerald-600">redeem.sg/offers/{slug}</p>}
+      </Section>
+
+      <Section
+        title="List on the marketplace"
+        hint="The ONLY switch that exposes this campaign on redeem.sg browse + detail pages. Admin-only — saves from other roles keep the previous setting. Also requires: slug, campaign active, redeem.sg customer domain, and a live Redeem Ops activation."
+      >
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">design_config.marketplaceListed</span>
+          <Switch
+            checked={dc.marketplaceListed === true}
+            onCheckedChange={(v) => onDesignChange('marketplaceListed', v === true)}
+          />
+        </div>
+      </Section>
+
+      <Section title="Consumer listing" hint="What browsers see on cards and the offer page. The title falls back to the campaign name.">
+        <Input value={dc.name || ''} placeholder="Consumer-facing title (optional override)" onChange={(e) => onDesignChange('name', e.target.value)} />
+        <div className="grid grid-cols-2 gap-2">
+          <Select value={dc.category || ''} onValueChange={(v) => onDesignChange('category', v)}>
+            <SelectTrigger><SelectValue placeholder="Category" /></SelectTrigger>
+            <SelectContent>
+              {CATEGORY_OPTIONS.map(([id, label]) => <SelectItem key={id} value={id}>{label}</SelectItem>)}
+            </SelectContent>
+          </Select>
+          <Select value={dc.offer_type || ''} onValueChange={(v) => onDesignChange('offer_type', v)}>
+            <SelectTrigger><SelectValue placeholder="Offer type" /></SelectTrigger>
+            <SelectContent>
+              {OFFER_TYPES.map((t) => <SelectItem key={t} value={t}>{t}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="grid grid-cols-2 gap-2">
+          <Select value={dc.mode || ''} onValueChange={(v) => onDesignChange('mode', v)}>
+            <SelectTrigger><SelectValue placeholder="Mode" /></SelectTrigger>
+            <SelectContent>
+              {MODES.map((m) => <SelectItem key={m} value={m}>{m}</SelectItem>)}
+            </SelectContent>
+          </Select>
+          <Input value={dc.image_label || ''} placeholder="Image alt label" onChange={(e) => onDesignChange('image_label', e.target.value)} />
+        </div>
+        <Input value={dc.value_line || ''} placeholder='Value line override (blank = "Worth S$<retail> · free…")' onChange={(e) => onDesignChange('value_line', e.target.value)} />
+        <Textarea
+          rows={3}
+          value={(dc.inclusions || []).join('\n')}
+          placeholder={'What’s included — one item per line'}
+          onChange={(e) => onDesignChange('inclusions', e.target.value.split('\n').map((s) => s.trim()).filter(Boolean))}
+        />
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">Show remaining capacity to consumers</span>
+          <Switch checked={dc.showCapacity === true} onCheckedChange={(v) => onDesignChange('showCapacity', v === true)} />
+        </div>
+      </Section>
+
+      <Section title="Audience (display & filters)" hint="Browse targeting — who the offer is FOR (e.g. the child). Distinct from the submitter age gate (campaign min/max age on the Details tab), which validates the ADULT filling the form.">
+        <div className="grid grid-cols-2 gap-2">
+          <Input
+            type="number"
+            value={dc.age_range?.min ?? ''}
+            placeholder="Age min"
+            onChange={(e) => onDesignChange('age_range', { min: e.target.value === '' ? undefined : Number(e.target.value), max: dc.age_range?.max })}
+          />
+          <Input
+            type="number"
+            value={dc.age_range?.max ?? ''}
+            placeholder="Age max"
+            onChange={(e) => onDesignChange('age_range', { min: dc.age_range?.min, max: e.target.value === '' ? undefined : Number(e.target.value) })}
+          />
+        </div>
+        <Input
+          value={(dc.school_levels || []).join(', ')}
+          placeholder="School levels (comma-separated, e.g. P3, P4, P5)"
+          onChange={(e) => onDesignChange('school_levels', e.target.value.split(',').map((s) => s.trim()).filter(Boolean))}
+        />
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">DSA-related (appears on /dsa)</span>
+          <Switch checked={dc.dsa_related === true} onCheckedChange={(v) => onDesignChange('dsa_related', v === true)} />
+        </div>
+      </Section>
+
+      <Section title="Availability (indicative)" hint="Shown on the offer page and as preference chips in the flow — the partner confirms the final slot.">
+        <div className="flex gap-1 flex-wrap">
+          {DAYS.map((d) => {
+            const active = (availability.days || []).includes(d);
+            return (
+              <button
+                key={d}
+                type="button"
+                className={`px-2 py-1 text-xs rounded-md border ${active ? 'bg-primary text-primary-foreground border-primary' : 'border-border text-muted-foreground'}`}
+                onClick={() => onDesignChange('availability', {
+                  ...availability,
+                  days: active ? (availability.days || []).filter((x) => x !== d) : [...(availability.days || []), d],
+                })}
+              >
+                {d}
+              </button>
+            );
+          })}
+        </div>
+        <Input
+          value={(availability.slots || []).join(', ')}
+          placeholder="Slots (HH:MM, comma-separated, e.g. 10:00, 14:00)"
+          onChange={(e) => onDesignChange('availability', { ...availability, slots: e.target.value.split(',').map((s) => s.trim()).filter(Boolean) })}
+        />
+      </Section>
+
+      <Section title="Activation requirement" hint="The requirement COPY shown before submission — the claim window itself comes from the Redeem Ops offer.">
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">This campaign has a requirement</span>
+          <Switch checked={activation.required === true} onCheckedChange={(v) => setActivation({ required: v === true })} />
+        </div>
+        <div className="grid grid-cols-2 gap-2">
+          <Input value={activation.type || ''} placeholder="Type (e.g. financial_consult)" onChange={(e) => setActivation({ type: e.target.value })} />
+          <Input type="number" value={activation.duration_mins ?? ''} placeholder="Duration (mins)" onChange={(e) => setActivation({ duration_mins: e.target.value === '' ? undefined : Number(e.target.value) })} />
+        </div>
+        <Input value={activation.summary || ''} placeholder="One-line summary (cards, reminders)" onChange={(e) => setActivation({ summary: e.target.value })} />
+        <Textarea rows={3} value={activation.detail || ''} placeholder="Full detail (offer page + consent step)" onChange={(e) => setActivation({ detail: e.target.value })} />
+      </Section>
+
+      <Section title="Sponsor disclosure" hint="Shown on the offer page and consent step when the campaign is sponsored.">
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">Sponsored campaign</span>
+          <Switch
+            checked={!!sponsor}
+            onCheckedChange={(v) => onDesignChange('sponsor', v ? { kind: sponsor?.kind || 'financial_consultant', disclosure: sponsor?.disclosure || '' } : null)}
+          />
+        </div>
+        {sponsor && (
+          <>
+            <Input value={sponsor.kind || ''} placeholder="Kind (e.g. financial_consultant)" onChange={(e) => onDesignChange('sponsor', { ...sponsor, kind: e.target.value })} />
+            <Textarea rows={2} value={sponsor.disclosure || ''} placeholder="Disclosure copy" onChange={(e) => onDesignChange('sponsor', { ...sponsor, disclosure: e.target.value })} />
+          </>
+        )}
+      </Section>
+
+      <Section title="Disclosures & FAQ">
+        <Textarea rows={2} value={blocks.data_use || ''} placeholder="Data use (shown on the offer page)" onChange={(e) => setBlocks({ data_use: e.target.value })} />
+        <Textarea rows={2} value={blocks.cancellation || ''} placeholder="Cancellation policy" onChange={(e) => setBlocks({ cancellation: e.target.value })} />
+        <Textarea
+          rows={4}
+          value={(blocks.faq || []).map((f) => `${f.q} | ${f.a}`).join('\n')}
+          placeholder={'FAQ — one per line as: Question | Answer'}
+          onChange={(e) => setBlocks({
+            faq: e.target.value
+              .split('\n')
+              .map((line) => {
+                const [q, ...a] = line.split('|');
+                return { q: (q || '').trim(), a: a.join('|').trim() };
+              })
+              .filter((f) => f.q && f.a),
+          })}
+        />
+      </Section>
+
+      <Section
+        title="QR scan landing"
+        hint="Where a /t/:slug QR scan lands for this campaign. Direct (default) preserves today's straight-to-form behaviour; Detail sends scanners to the offer page first (requires the marketplace + QR-redirect flags)."
+      >
+        <div className="bg-muted p-1 rounded-lg flex gap-1">
+          {[
+            { id: 'direct', label: 'Direct to form' },
+            { id: 'detail', label: 'Offer detail first' },
+          ].map((opt) => (
+            <button
+              key={opt.id}
+              type="button"
+              onClick={() => onDesignChange('qr_entry', opt.id)}
+              className={`flex-1 py-1.5 px-2 text-xs font-medium rounded-md transition-colors ${
+                (dc.qr_entry || 'direct') === opt.id
+                  ? 'bg-card text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </Section>
+
+      <Section title="Consumer preview (composed)" hint="What the public marketplace API would serve for this campaign — including the read-only ops layer from Redeem Ops.">
+        <Button variant="outline" size="sm" onClick={loadPreview} disabled={previewLoading}>
+          {previewLoading ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Store className="w-3.5 h-3.5" />}
+          <span className="ml-1.5">Refresh preview</span>
+        </Button>
+        {gate && (
+          <div className="space-y-1 text-xs">
+            {[
+              ['Slug set', gate.slug],
+              ['Campaign active', gate.active],
+              ['Listed (admin toggle)', gate.marketplaceListed],
+              ['redeem.sg customer domain', gate.redeemHost],
+              ['Supported campaign type', gate.supportedType],
+              ['Redeem Ops activation resolvable', gate.opsResolvable],
+            ].map(([label, ok]) => (
+              <div key={label} className="flex items-center gap-1.5">
+                {ok ? <CheckCircle2 className="w-3.5 h-3.5 text-emerald-600" /> : <AlertCircle className="w-3.5 h-3.5 text-amber-600" />}
+                <span className={ok ? 'text-muted-foreground' : 'text-amber-700 dark:text-amber-500'}>{label}</span>
+              </div>
+            ))}
+            <p className={`pt-1 font-medium ${gate.listed ? 'text-emerald-600' : 'text-muted-foreground'}`}>
+              {gate.listed ? 'This campaign is publicly listed.' : 'Not publicly visible until every check passes.'}
+            </p>
+          </div>
+        )}
+        {preview?.ops && (
+          <div className="text-xs text-muted-foreground space-y-0.5 border border-border rounded-md p-2">
+            <div>Partner: {preview.ops.partner?.name || '—'}{preview.ops.partner?.verified ? ' · verified' : ''}</div>
+            <div>Capacity: {preview.ops.capacity?.remaining}/{preview.ops.capacity?.total} · expires {preview.ops.expiry ? String(preview.ops.expiry).slice(0, 10) : '—'}</div>
+            <div>Retail value: {preview.ops.retail_value != null ? `S$${preview.ops.retail_value}` : '—'}</div>
+            {preview.ops.draw && <div>Draw: closes {String(preview.ops.draw.closesAt).slice(0, 10)} · boost ×{preview.ops.draw.multiplier}</div>}
+          </div>
+        )}
+        {drawMismatch && (
+          <div className="flex items-start gap-1.5 text-xs text-amber-700 dark:text-amber-500">
+            <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+            <span>
+              The draw close date here (luckyDraw.closesAt) differs from the live Draw row's snapshot — entries accepted after the
+              snapshot are excluded from the frozen pool. Align them before launch.
+            </span>
+          </div>
+        )}
+      </Section>
+    </div>
+  );
+}

--- a/src/lib/metaPixel.js
+++ b/src/lib/metaPixel.js
@@ -166,3 +166,13 @@ export function trackCompleteRegistration(params = {}, eventId) {
 export function trackSubscribe(params = {}) {
   trackEvent('Subscribe', params);
 }
+
+/**
+ * Non-conversion CUSTOM event (fbq('trackCustom')) — funnel diagnostics only
+ * (otp_sent, dnc_gate_shown, duplicate_blocked, …). Never optimised on; safe
+ * to drop without touching conversion integrity (Analytics Event Taxonomy §03).
+ */
+export function trackCustomEvent(eventName, params = {}) {
+  if (typeof window === 'undefined' || typeof window.fbq !== 'function') return;
+  window.fbq('trackCustom', eventName, params);
+}

--- a/src/lib/pixelSession.js
+++ b/src/lib/pixelSession.js
@@ -1,0 +1,71 @@
+/**
+ * Per-campaign ViewContent session guard (Analytics Event Taxonomy §02).
+ *
+ * ViewContent fires ONCE per campaign per session, at the FIRST public content
+ * surface (offer detail for marketplace traffic; the flow/LeadCapture page for
+ * direct links). The guard stores the client-generated event_id plus
+ * per-platform fired flags under sessionStorage `vc:{campaignId}` so
+ * detail → flow navigation (and back) reuses the SAME id and never re-fires —
+ * while Meta and TikTok still fire independently (one platform being
+ * unconfigured must not suppress the other).
+ *
+ * sessionStorage-unavailable environments (some private modes) fall back to an
+ * in-memory map — worst case matches today's per-mount behaviour.
+ */
+
+import { generateEventId } from './metaPixel';
+
+const memoryStore = new Map();
+
+function storageKey(campaignId) {
+  return `vc:${campaignId}`;
+}
+
+function readState(campaignId) {
+  const key = storageKey(campaignId);
+  try {
+    const raw = window.sessionStorage.getItem(key);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed.eventId === 'string') return parsed;
+    }
+  } catch {
+    /* sessionStorage unavailable/corrupt — fall through to memory */
+  }
+  return memoryStore.get(key) || null;
+}
+
+function writeState(campaignId, state) {
+  const key = storageKey(campaignId);
+  memoryStore.set(key, state);
+  try {
+    window.sessionStorage.setItem(key, JSON.stringify(state));
+  } catch {
+    /* memory fallback already holds it */
+  }
+}
+
+/** Get (or mint) the campaign's ViewContent state for this session. */
+export function getOrCreateVcState(campaignId) {
+  if (!campaignId) return { eventId: generateEventId(), firedMeta: false, firedTiktok: false };
+  const existing = readState(campaignId);
+  if (existing) {
+    return {
+      eventId: existing.eventId,
+      firedMeta: existing.firedMeta === true,
+      firedTiktok: existing.firedTiktok === true,
+    };
+  }
+  const fresh = { eventId: generateEventId(), firedMeta: false, firedTiktok: false };
+  writeState(campaignId, fresh);
+  return fresh;
+}
+
+/** Record that a platform's ViewContent fired for this campaign this session. */
+export function markVcFired(campaignId, platform) {
+  if (!campaignId) return;
+  const state = getOrCreateVcState(campaignId);
+  if (platform === 'meta') state.firedMeta = true;
+  if (platform === 'tiktok') state.firedTiktok = true;
+  writeState(campaignId, state);
+}

--- a/src/lib/pixelSuppression.js
+++ b/src/lib/pixelSuppression.js
@@ -17,7 +17,10 @@
  *   - any URL with `?preview=true`
  *   - test-data campaigns (`campaign.is_test_data === true`)
  *
- * Returns true ONLY for the live `/LeadCapture` page. SSR-safe.
+ * Returns true ONLY for the live `/LeadCapture` page and the marketplace
+ * campaign surfaces `/offers/:slug` + `/flow/:slug` (Analytics Event Taxonomy:
+ * ViewContent fires at the FIRST public content surface for a campaign; every
+ * other route stays suppressed). SSR-safe.
  */
 export function isTrackableLeadCapture({ campaign, pathname, search } = {}) {
   const path = (pathname || '').toLowerCase();
@@ -36,5 +39,9 @@ export function isTrackableLeadCapture({ campaign, pathname, search } = {}) {
 
   if (campaign?.is_test_data === true) return false;
 
-  return path === '/leadcapture';
+  if (path === '/leadcapture') return true;
+  // Marketplace campaign surfaces — a slug segment must be present.
+  if (/^\/offers\/[a-z0-9-]+$/.test(path)) return true;
+  if (/^\/flow\/[a-z0-9-]+$/.test(path)) return true;
+  return false;
 }

--- a/src/pages/LeadCapture.jsx
+++ b/src/pages/LeadCapture.jsx
@@ -36,6 +36,7 @@ import {
   trackTikTokCompleteRegistration,
   trackTikTokLead,
 } from '../lib/tiktokPixel';
+import { getOrCreateVcState, markVcFired } from '../lib/pixelSession';
 
 export default function LeadCapture() {
   const location = useLocation();
@@ -76,7 +77,6 @@ export default function LeadCapture() {
   // event_id matches any future references, and the Lead event_id matches the
   // CAPI dispatch. UTMs ride along to the submit for sourceMetadata.utm.
   useEffect(() => {
-    if (!viewEventIdRef.current) viewEventIdRef.current = generateEventId();
     if (!leadEventIdRef.current) leadEventIdRef.current = generateEventId();
     if (!registrationEventIdRef.current) registrationEventIdRef.current = generateEventId();
     captureFbcFromUrl(location.search);
@@ -96,8 +96,16 @@ export default function LeadCapture() {
   useEffect(() => {
     if (!campaign) return;
     const trackCtx = { campaign, pathname: location.pathname, search: location.search };
+    // Session-level once-per-campaign guard (vc:{campaign_id}): marketplace
+    // traffic fires ViewContent on the offer detail page first, so a
+    // detail → flow → /LeadCapture navigation must reuse the SAME event_id and
+    // not re-fire. Per-platform flags stay independent (one platform being
+    // unconfigured must not suppress the other). Direct traffic keeps today's
+    // behaviour: first load fires once.
+    const vc = getOrCreateVcState(campaign.id);
+    viewEventIdRef.current = vc.eventId;
 
-    if (!viewContentFiredRef.current && shouldTrack(trackCtx)) {
+    if (!viewContentFiredRef.current && !vc.firedMeta && shouldTrack(trackCtx)) {
       const pixelId = campaign.metaPixelId || import.meta.env.VITE_META_PIXEL_ID;
       if (pixelId) {
         initPixel(pixelId);
@@ -107,21 +115,23 @@ export default function LeadCapture() {
         trackEvent(
           'ViewContent',
           { content_name: campaign.name, content_category: 'lead_capture' },
-          { eventID: viewEventIdRef.current }
+          { eventID: vc.eventId }
         );
         viewContentFiredRef.current = true;
+        markVcFired(campaign.id, 'meta');
       }
     }
 
-    if (!ttViewContentFiredRef.current && shouldTrackTikTok(trackCtx)) {
+    if (!ttViewContentFiredRef.current && !vc.firedTiktok && shouldTrackTikTok(trackCtx)) {
       const ttPixelId = campaign?.tiktokPixelId || import.meta.env.VITE_TIKTOK_PIXEL_ID;
       if (ttPixelId) {
         initTikTokPixel(ttPixelId);
         trackTikTokViewContent(
           { content_name: campaign.name, content_type: 'lead_capture' },
-          viewEventIdRef.current
+          vc.eventId
         );
         ttViewContentFiredRef.current = true;
+        markVcFired(campaign.id, 'tiktok');
       }
     }
   }, [campaign, location.pathname, location.search]);

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -28,6 +28,17 @@ const SpecimenPreview = lazy(() => import('./preview/SpecimenPreview'));
 const Homepage = lazy(() => import('./Homepage'));
 const RedeemHome = lazy(() => import('./RedeemHome'));
 const RedeemWinners = lazy(() => import('./RedeemWinners'));
+// Marketplace v2 (redeem build only, dark behind VITE_REDEEM_MARKETPLACE_ENABLED —
+// docs/plans/redeem-marketplace-v2.md Phase 3). None of these chunks are
+// referenced on the mktr build or while the flag is off.
+const MarketplaceHome = lazy(() => import('./marketplace/MarketplaceHome'));
+const MarketplaceBrowse = lazy(() => import('./marketplace/MarketplaceBrowse'));
+const MarketplaceOffer = lazy(() => import('./marketplace/MarketplaceOffer'));
+const MarketplaceFlow = lazy(() => import('./marketplace/MarketplaceFlow'));
+const MarketplaceStatic = lazy(() => import('./marketplace/MarketplaceStatic'));
+
+const MARKETPLACE_ON =
+  IS_REDEEM_BUILD && import.meta.env.VITE_REDEEM_MARKETPLACE_ENABLED === 'true';
 const Features = lazy(() => import('./Features'));
 const Pricing = lazy(() => import('./Pricing'));
 const About = lazy(() => import('./About'));
@@ -199,9 +210,22 @@ function PagesContent() {
  {IS_OPS_SURFACE ? <OpsSurfaceRoutes /> : (
  <Routes>
  {/* Public routes - no protection needed. Lead capture flow stays on both brands. */}
- <Route path="/" element={brand.showHomepage ? <Homepage /> : (IS_REDEEM_BUILD ? <RedeemHome /> : <LeadCapture />)} />
+ <Route path="/" element={brand.showHomepage ? <Homepage /> : (MARKETPLACE_ON ? <MarketplaceHome /> : IS_REDEEM_BUILD ? <RedeemHome /> : <LeadCapture />)} />
  <Route path="/LeadCapture" element={<LeadCapture />} />
  <Route path="/winners" element={IS_REDEEM_BUILD ? <RedeemWinners /> : <NotFoundForBrand />} />
+ {/* Marketplace v2 surfaces (redeem build, flag-gated) */}
+ {MARKETPLACE_ON && (
+ <>
+ <Route path="/explore" element={<MarketplaceBrowse mode="explore" />} />
+ <Route path="/c/:id" element={<MarketplaceBrowse mode="category" />} />
+ <Route path="/dsa" element={<MarketplaceBrowse mode="dsa" />} />
+ <Route path="/offers/:slug" element={<MarketplaceOffer />} />
+ <Route path="/flow/:slug" element={<MarketplaceFlow />} />
+ <Route path="/how-it-works" element={<MarketplaceStatic mode="how" />} />
+ <Route path="/businesses" element={<MarketplaceStatic mode="businesses" />} />
+ <Route path="/legal/:doc" element={<MarketplaceStatic mode="legal" />} />
+ </>
+ )}
  <Route path="/LeadCapture/demo" element={<LeadCaptureDemo />} />
  <Route path="/p/:slug" element={<PublicPreview />} />
  <Route path="/t/:slug" element={<TrackRedirect />} />
@@ -219,7 +243,7 @@ function PagesContent() {
  <Route path="/Homepage" element={brand.showHomepage ? <Homepage /> : <NotFoundForBrand />} />
  <Route path="/features" element={brand.showFeatures ? <Features /> : <NotFoundForBrand />} />
  <Route path="/pricing" element={brand.showPricing ? <Pricing /> : <NotFoundForBrand />} />
- <Route path="/about" element={brand.showAbout ? <About /> : <NotFoundForBrand />} />
+ <Route path="/about" element={brand.showAbout ? <About /> : MARKETPLACE_ON ? <MarketplaceStatic mode="about" /> : <NotFoundForBrand />} />
  <Route path="/Contact" element={<Contact />} />
  <Route path="/personal-data-policy" element={<PersonalDataPolicy />} />
  <Route path="/leads/privacy" element={<LeadsPrivacy />} />

--- a/src/pages/marketplace/MarketplaceBrowse.jsx
+++ b/src/pages/marketplace/MarketplaceBrowse.jsx
@@ -1,0 +1,316 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import MarketplaceLayout from './MarketplaceLayout';
+import OfferCard from './OfferCard';
+import { listMarketplaceCampaigns } from '@/api/marketplace';
+import { CATEGORIES, DSA_CONTENT, categoryLabel } from './content';
+
+/**
+ * Browse surfaces — /explore (mode="explore"), /c/:id (mode="category",
+ * umbrella ids education/lifestyle or a concrete category) and /dsa
+ * (mode="dsa"). One chunk, shared list fetch, client-side filters (the public
+ * list is small and 60s-cached server-side).
+ */
+
+const AGE_BANDS = { '3–6': [3, 6], '7–9': [7, 9], '10–12': [10, 12], '13–16': [13, 16], Adults: [21, 99] };
+
+function useCampaignList() {
+  const [campaigns, setCampaigns] = useState(null);
+  useEffect(() => {
+    let alive = true;
+    listMarketplaceCampaigns()
+      .then((cs) => alive && setCampaigns(cs))
+      .catch(() => alive && setCampaigns([]));
+    return () => {
+      alive = false;
+    };
+  }, []);
+  return campaigns;
+}
+
+function CardGrid({ campaigns, emptyTitle, emptyBody }) {
+  if (campaigns === null) {
+    return (
+      <div className="rm-grid-cards">
+        {[0, 1, 2].map((i) => <div key={i} className="rm-shimmer" style={{ height: 440 }} />)}
+      </div>
+    );
+  }
+  if (campaigns.length === 0) {
+    return (
+      <div className="rm-card" style={{ padding: '44px 28px', textAlign: 'center' }}>
+        <div className="rm-serif" style={{ fontSize: 24 }}>{emptyTitle}</div>
+        <div style={{ fontSize: 14, color: 'var(--rm-sub)', marginTop: 8 }}>{emptyBody}</div>
+        <Link className="rm-btn" to="/explore" style={{ marginTop: 18 }}>Explore live offers</Link>
+      </div>
+    );
+  }
+  return (
+    <div className="rm-grid-cards">
+      {campaigns.map((c) => <OfferCard key={c.slug} campaign={c} />)}
+    </div>
+  );
+}
+
+function Chip({ active, onClick, children }) {
+  return (
+    <button className={`rm-chip${active ? ' is-active' : ''}`} onClick={onClick}>
+      {children}
+    </button>
+  );
+}
+
+function ExplorePage() {
+  const campaigns = useCampaignList();
+  const [q, setQ] = useState('');
+  const [cat, setCat] = useState('all');
+  const [type, setType] = useState('all');
+  const [mode, setMode] = useState('all');
+  const [day, setDay] = useState('all');
+  const [age, setAge] = useState('all');
+  const [dsa, setDsa] = useState(false);
+  const [sort, setSort] = useState('featured');
+
+  const results = useMemo(() => {
+    if (!campaigns) return null;
+    let list = campaigns.filter((c) => {
+      const dc = c.design_config || {};
+      if (cat !== 'all' && dc.category !== cat) return false;
+      if (type !== 'all' && dc.offer_type !== type) return false;
+      if (mode !== 'all' && dc.mode !== mode) return false;
+      const days = dc.availability?.days || [];
+      if (day === 'weekend' && !days.some((d) => d === 'Sat' || d === 'Sun')) return false;
+      if (day === 'weekday' && !days.some((d) => d !== 'Sat' && d !== 'Sun')) return false;
+      if (dsa && !dc.dsa_related) return false;
+      if (age !== 'all') {
+        const r = AGE_BANDS[age];
+        const ar = dc.age_range;
+        if (!ar || !(ar.min <= r[1] && ar.max >= r[0])) return false;
+      }
+      if (q) {
+        const hay = `${dc.name || c.name} ${c.ops?.partner?.name || ''} ${categoryLabel(dc.category)}`.toLowerCase();
+        if (!hay.includes(q.toLowerCase())) return false;
+      }
+      return true;
+    });
+    if (sort === 'ending') {
+      list = [...list].sort((a, b) => String(a.ops?.expiry || '9999').localeCompare(String(b.ops?.expiry || '9999')));
+    } else {
+      list = [...list].sort((a, b) => (b.design_config?.featuredDrop ? 1 : 0) - (a.design_config?.featuredDrop ? 1 : 0));
+    }
+    return list;
+  }, [campaigns, q, cat, type, mode, day, age, dsa, sort]);
+
+  const reset = () => {
+    setQ(''); setCat('all'); setType('all'); setMode('all'); setDay('all'); setAge('all'); setDsa(false); setSort('featured');
+  };
+
+  const filterRow = (label, chips) => (
+    <div style={{ display: 'flex', gap: 7, flexWrap: 'wrap', alignItems: 'center' }}>
+      <span className="rm-mono-label" style={{ fontSize: 10, width: 74, flexShrink: 0 }}>{label}</span>
+      {chips}
+    </div>
+  );
+
+  return (
+    <MarketplaceLayout>
+      <div className="rm-shell" style={{ paddingTop: 'clamp(28px,4vw,48px)', paddingBottom: 'clamp(48px,6vw,80px)' }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 16, flexWrap: 'wrap' }}>
+          <h1 className="rm-serif" style={{ margin: 0, fontSize: 'clamp(30px,3.6vw,42px)' }}>Explore offers</h1>
+          <span className="rm-mono-note" style={{ fontSize: 11.5 }}>
+            {results ? `${results.length} offer${results.length === 1 ? '' : 's'}` : '…'}
+          </span>
+        </div>
+
+        <div className="rm-card" style={{ marginTop: 20, display: 'flex', flexDirection: 'column', gap: 13, padding: '16px 18px' }}>
+          <input
+            type="search"
+            aria-label="Search offers"
+            placeholder="Search offers, partners or categories…"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            className="rm-input"
+            style={{ borderRadius: 12 }}
+          />
+          {filterRow('Category', [
+            <Chip key="all" active={cat === 'all'} onClick={() => setCat('all')}>All</Chip>,
+            ...CATEGORIES.map((c) => (
+              <Chip key={c.id} active={cat === c.id} onClick={() => setCat(cat === c.id ? 'all' : c.id)}>{c.label}</Chip>
+            )),
+          ])}
+          {filterRow('Type', ['all', 'trial', 'assessment', 'workshop', 'reward', 'consultation'].map((t) => (
+            <Chip key={t} active={type === t} onClick={() => setType(t)}>{t === 'all' ? 'Any type' : t.charAt(0).toUpperCase() + t.slice(1)}</Chip>
+          )))}
+          {filterRow('Age', ['all', ...Object.keys(AGE_BANDS)].map((a) => (
+            <Chip key={a} active={age === a} onClick={() => setAge(a)}>{a === 'all' ? 'Any age' : a}</Chip>
+          )))}
+          {filterRow('When', [
+            ...['all', 'weekend', 'weekday'].map((d) => (
+              <Chip key={d} active={day === d} onClick={() => setDay(d)}>{d === 'all' ? 'Any day' : d === 'weekend' ? 'Weekends' : 'Weekdays'}</Chip>
+            )),
+            ...['all', 'physical', 'online', 'hybrid'].map((m) => (
+              <Chip key={`m-${m}`} active={mode === m} onClick={() => setMode(m)}>{m === 'all' ? 'Anywhere' : m === 'physical' ? 'In-person' : m.charAt(0).toUpperCase() + m.slice(1)}</Chip>
+            )),
+          ])}
+          <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', alignItems: 'center', borderTop: '1px solid var(--rm-line)', paddingTop: 13 }}>
+            <Chip active={dsa} onClick={() => setDsa(!dsa)}>DSA-related{dsa ? ' ✓' : ''}</Chip>
+            <select aria-label="Sort offers" value={sort} onChange={(e) => setSort(e.target.value)} className="rm-select" style={{ width: 'auto', marginLeft: 'auto', borderRadius: 10, padding: '8px 12px', fontSize: 13, background: 'var(--rm-card)' }}>
+              <option value="featured">Featured first</option>
+              <option value="ending">Ending soon</option>
+            </select>
+            <button className="rm-link-btn" onClick={reset}>Reset all</button>
+          </div>
+        </div>
+
+        <div style={{ marginTop: 26 }}>
+          <CardGrid
+            campaigns={results}
+            emptyTitle="No offers match those filters"
+            emptyBody="Try widening the age range or clearing a category."
+          />
+        </div>
+      </div>
+    </MarketplaceLayout>
+  );
+}
+
+const UMBRELLAS = {
+  education: { id: 'education', label: 'Education', blurb: 'Trials, assessments and enrichment across every subject and talent.', group: 'education' },
+  lifestyle: { id: 'lifestyle', label: 'Lifestyle', blurb: 'Wellness, dining, family experiences and useful rewards.', group: 'lifestyle' },
+};
+
+function CategoryPage() {
+  const { id } = useParams();
+  const campaigns = useCampaignList();
+  const info = UMBRELLAS[id] || CATEGORIES.find((c) => c.id === id) || null;
+
+  const catOffers = useMemo(() => {
+    if (!campaigns || !info) return campaigns === null ? null : [];
+    if (UMBRELLAS[id]) {
+      return campaigns.filter((c) => CATEGORIES.find((m) => m.id === c.design_config?.category)?.group === info.group);
+    }
+    return campaigns.filter((c) => c.design_config?.category === info.id);
+  }, [campaigns, info, id]);
+
+  const cross = info ? CATEGORIES.filter((c) => c.group === (info.group || info.id) && c.id !== info.id).slice(0, 4) : [];
+
+  if (!info) {
+    return (
+      <MarketplaceLayout>
+        <div className="rm-shell" style={{ padding: '48px 0' }}>
+          <div className="rm-card" style={{ padding: '44px 28px', textAlign: 'center' }}>
+            <div className="rm-serif" style={{ fontSize: 24 }}>That category doesn't exist</div>
+            <Link className="rm-btn" to="/explore" style={{ marginTop: 18 }}>Explore everything</Link>
+          </div>
+        </div>
+      </MarketplaceLayout>
+    );
+  }
+
+  return (
+    <MarketplaceLayout>
+      <section style={{ background: 'var(--rm-sage)', borderBottom: '1px solid var(--rm-line)' }}>
+        <div className="rm-shell" style={{ padding: 'clamp(36px,5vw,60px) 0' }}>
+          <div className="rm-mono-label" style={{ color: 'var(--rm-pine)' }}>Category</div>
+          <h1 className="rm-serif" style={{ margin: '10px 0 0', fontSize: 'clamp(30px,3.8vw,44px)' }}>{info.label}</h1>
+          <p style={{ margin: '12px 0 0', fontSize: 15, lineHeight: 1.6, color: 'var(--rm-sub)', maxWidth: '56ch' }}>{info.blurb}</p>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 18 }}>
+            {cross.map((c) => (
+              <Link key={c.id} to={`/c/${c.id}`} className="rm-chip">{c.label}</Link>
+            ))}
+            <Link to="/explore" className="rm-chip" style={{ borderColor: 'var(--rm-pine)', color: 'var(--rm-pine)' }}>Explore everything →</Link>
+          </div>
+        </div>
+      </section>
+      <div className="rm-shell" style={{ paddingTop: 'clamp(28px,4vw,44px)', paddingBottom: 'clamp(48px,6vw,72px)' }}>
+        <CardGrid
+          campaigns={catOffers}
+          emptyTitle="Nothing live here right now"
+          emptyBody="New campaigns launch weekly — explore everything in the meantime."
+        />
+        <div style={{ marginTop: 34, background: 'var(--rm-pine)', borderRadius: 18, padding: '24px 26px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <div className="rm-serif" style={{ fontSize: 21, color: '#F6F2E6', lineHeight: 1.25 }}>Run a campaign in {info.label}</div>
+          <div style={{ fontSize: 13, lineHeight: 1.6, color: '#CFE0D4' }}>Contribute trial capacity, receive OTP-verified customers. Enquiry takes two minutes.</div>
+          <Link className="rm-btn rm-btn--apricot" to="/businesses" style={{ alignSelf: 'flex-start' }}>Become a partner</Link>
+        </div>
+      </div>
+    </MarketplaceLayout>
+  );
+}
+
+function DsaPage() {
+  const campaigns = useCampaignList();
+  const dsaOffers = campaigns === null ? null : campaigns.filter((c) => c.design_config?.dsa_related);
+
+  return (
+    <MarketplaceLayout>
+      <section style={{ background: 'var(--rm-sage)', borderBottom: '1px solid var(--rm-line)' }}>
+        <div className="rm-shell" style={{ padding: 'clamp(36px,5vw,64px) 0' }}>
+          <div className="rm-mono-label" style={{ color: 'var(--rm-pine)' }}>DSA discovery</div>
+          <h1 className="rm-serif" style={{ margin: '12px 0 0', fontSize: 'clamp(28px,3.6vw,42px)', lineHeight: 1.12, maxWidth: '24ch' }}>
+            Explore programmes that may support your child's talent-development journey.
+          </h1>
+          <p style={{ margin: '14px 0 0', fontSize: 15, lineHeight: 1.65, color: 'var(--rm-sub)', maxWidth: '64ch' }}>
+            The Direct School Admission (DSA) exercise lets students seek secondary-school places through talents and achievements beyond PSLE scores. Discovery sessions and assessments below help you explore — calmly, and without commitment.
+          </p>
+        </div>
+      </section>
+      <div className="rm-shell" style={{ paddingTop: 'clamp(28px,4vw,44px)', paddingBottom: 'clamp(48px,6vw,72px)', display: 'flex', flexDirection: 'column', gap: 30 }}>
+        <div className="rm-warn-box">
+          <span className="rm-ticket" style={{ width: 11, height: 14, background: 'var(--rm-warn)', marginTop: 3, flexShrink: 0 }} />
+          <div style={{ fontSize: 13.5, lineHeight: 1.6, color: '#5C4A18' }}>
+            <strong>Admission is determined entirely by schools.</strong> No provider can guarantee DSA outcomes — treat success-rate claims and admission promises as a red flag. Redeem lists discovery and preparation programmes only.
+          </div>
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(300px,1fr))', gap: 20 }}>
+          <div className="rm-card rm-card--pad">
+            <div className="rm-mono-label" style={{ marginBottom: 12 }}>DSA talent areas</div>
+            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+              {DSA_CONTENT.talents.map((t) => (
+                <span key={t} className="rm-chip" style={{ cursor: 'default' }}>{t}</span>
+              ))}
+            </div>
+            <div className="rm-mono-label" style={{ margin: '20px 0 10px' }}>Typical preparation</div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 9 }}>
+              {DSA_CONTENT.prep.map((p) => (
+                <div key={p} style={{ display: 'flex', gap: 10, fontSize: 13.5, lineHeight: 1.6, color: 'var(--rm-sub)' }}>
+                  <span style={{ color: 'var(--rm-pine)', fontWeight: 700 }}>—</span><span>{p}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="rm-card rm-card--pad">
+            <div className="rm-mono-label" style={{ marginBottom: 12 }}>How to evaluate a provider</div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 9 }}>
+              {DSA_CONTENT.evaluate.map((e2) => (
+                <div key={e2} style={{ display: 'flex', gap: 10, fontSize: 13.5, lineHeight: 1.6, color: 'var(--rm-sub)' }}>
+                  <span style={{ color: 'var(--rm-pine)', fontWeight: 700 }}>✓</span><span>{e2}</span>
+                </div>
+              ))}
+            </div>
+            <div className="rm-mono-label" style={{ margin: '20px 0 10px' }}>Questions worth asking</div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {DSA_CONTENT.questions.map((qq) => (
+                <div key={qq} style={{ fontSize: 13.5, lineHeight: 1.55, fontStyle: 'italic' }}>"{qq}"</div>
+              ))}
+            </div>
+          </div>
+        </div>
+        <div>
+          <h2 className="rm-serif" style={{ margin: '0 0 18px', fontSize: 'clamp(22px,2.6vw,28px)' }}>DSA-related offers, live now</h2>
+          <CardGrid
+            campaigns={dsaOffers}
+            emptyTitle="No DSA-related offers live right now"
+            emptyBody="New discovery sessions launch regularly — explore everything in the meantime."
+          />
+        </div>
+      </div>
+    </MarketplaceLayout>
+  );
+}
+
+export default function MarketplaceBrowse({ mode }) {
+  if (mode === 'category') return <CategoryPage />;
+  if (mode === 'dsa') return <DsaPage />;
+  return <ExplorePage />;
+}

--- a/src/pages/marketplace/MarketplaceFlow.jsx
+++ b/src/pages/marketplace/MarketplaceFlow.jsx
@@ -4,7 +4,7 @@ import MarketplaceLayout from './MarketplaceLayout';
 import MarketingConsentDialog from '@/components/legal/MarketingConsentDialog';
 import { apiClient } from '@/api/client';
 import { getMarketplaceCampaign } from '@/api/marketplace';
-import { composeValueLine, fmtDateLong, isDrawCampaign, boostOf } from './content';
+import { composeValueLine, fmtDateLong, isDrawCampaign, boostOf, offerUnavailability, UNAVAILABLE_COPY } from './content';
 import { formatDateInput, getAgeValidationError } from '@/components/campaigns/signup/dateUtils';
 import {
   shouldTrack, generateEventId, captureFbcFromUrl, captureUtmsFromUrl,
@@ -59,6 +59,31 @@ const FIELD_DEFS = {
 };
 
 const ALWAYS_VISIBLE = new Set(['name', 'email', 'phone']);
+// Production visibility semantics (CampaignSignupForm submit validation is
+// the authority): dob/postal render unless explicitly hidden; education/
+// income are opt-IN; required only when requiredFields[key] === true.
+const OPT_IN_VISIBLE = new Set(['education_level', 'monthly_income']);
+
+/** Exported for tests — mirrors the live form's field visibility contract. */
+export function isFieldVisible(key, visibleFields = {}) {
+  if (ALWAYS_VISIBLE.has(key)) return true;
+  if (FIELD_DEFS[key]) {
+    return OPT_IN_VISIBLE.has(key) ? visibleFields[key] === true : visibleFields[key] !== false;
+  }
+  return visibleFields[key] === true; // marketplace extras are opt-in
+}
+
+/** Exported for tests — required ONLY on an explicit true (live-form parity). */
+export function isFieldRequired(key, requiredFields = {}) {
+  if (ALWAYS_VISIBLE.has(key)) return true;
+  return requiredFields[key] === true;
+}
+
+/** DD/MM/YYYY (display mask) → YYYY-MM-DD (API contract, live-form parity). */
+export function dobToIso(v) {
+  const m = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec((v || '').trim());
+  return m ? `${m[3]}-${m[2]}-${m[1]}` : '';
+}
 const STEP_LABELS = { screen: 'Eligibility', advisor: 'Industry check', details: 'Your details', child: 'Your child', prefs: 'Preferences', otp: 'Verify', dnc: 'DNC consent', consent: 'Confirm' };
 
 export default function MarketplaceFlow() {
@@ -155,13 +180,8 @@ export default function MarketplaceFlow() {
   const dc = campaign?.design_config || {};
   const visibleFields = dc.visibleFields || {};
   const requiredFields = dc.requiredFields || {};
-  const isVisible = (key) => ALWAYS_VISIBLE.has(key) || (FIELD_DEFS[key] ? visibleFields[key] !== false : visibleFields[key] === true);
-  const isRequired = (key) => {
-    const v = requiredFields[key];
-    if (v === false || v === 'optional') return false;
-    if (FIELD_DEFS[key]) return true; // production default: required unless opted out
-    return v === true; // marketplace extras: opt-in
-  };
+  const isVisible = (key) => isFieldVisible(key, visibleFields);
+  const isRequired = (key) => isFieldRequired(key, requiredFields);
 
   const isDraw = isDrawCampaign(campaign);
   const boost = boostOf(campaign);
@@ -313,7 +333,9 @@ export default function MarketplaceFlow() {
         lastName: restName.join(' '),
         email: form.email,
         phone: form.phone,
-        date_of_birth: form.dob,
+        // API contract is ISO YYYY-MM-DD (live-form parity) — the display
+        // mask is DD/MM/YYYY, which new Date() misparses server-side.
+        date_of_birth: dobToIso(form.dob),
         postal_code: form.postal_code,
         education_level: form.education_level,
         monthly_income: form.monthly_income,
@@ -394,6 +416,25 @@ export default function MarketplaceFlow() {
           <div className="rm-card" style={{ padding: '48px 28px', textAlign: 'center' }}>
             <div className="rm-serif" style={{ fontSize: 26 }}>This campaign isn't available</div>
             <Link className="rm-btn" to="/explore" style={{ marginTop: 18 }}>Explore live offers</Link>
+          </div>
+        </div>
+      </MarketplaceLayout>
+    );
+  }
+
+  // The flow must never accept submissions the pipeline can't service —
+  // sold-out / ended / closed-draw campaigns get a courteous stop, not a form
+  // (mid-flow submits on a just-exhausted offer still surface server-side).
+  const unavailable = offerUnavailability(campaign);
+  if (unavailable && !result) {
+    const copy = UNAVAILABLE_COPY[unavailable];
+    return (
+      <MarketplaceLayout>
+        <div className="rm-shell rm-shell--flow" style={{ padding: 'clamp(24px,3.5vw,40px) 0 clamp(56px,7vw,88px)' }}>
+          <div className="rm-card rm-fadeup" style={{ padding: '48px 28px', textAlign: 'center' }}>
+            <div className="rm-serif" style={{ fontSize: 26 }}>{copy.title}</div>
+            <p style={{ margin: '10px auto 20px', fontSize: 14, lineHeight: 1.65, color: 'var(--rm-sub)', maxWidth: '46ch' }}>{copy.body}</p>
+            <Link className="rm-btn" to="/explore">Explore live offers</Link>
           </div>
         </div>
       </MarketplaceLayout>
@@ -534,6 +575,13 @@ export default function MarketplaceFlow() {
                             let digits = v.replace(/\D/g, '');
                             if (digits.startsWith('65') && digits.length > 8) digits = digits.substring(2);
                             v = digits.slice(0, 8);
+                            // Verification is bound to the number it was earned
+                            // for — editing the phone invalidates OTP + DNC state
+                            // (otherwise verify A, back-navigate, submit B).
+                            if (v !== form.phone && otp.status !== 'idle') {
+                              setOtp({ status: 'idle', code: '', cooldown: 0, error: '' });
+                              setDnc({ checked: false, hit: false, consent: false });
+                            }
                           }
                           setField(key, v);
                         }}

--- a/src/pages/marketplace/MarketplaceFlow.jsx
+++ b/src/pages/marketplace/MarketplaceFlow.jsx
@@ -1,0 +1,909 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import MarketplaceLayout from './MarketplaceLayout';
+import MarketingConsentDialog from '@/components/legal/MarketingConsentDialog';
+import { apiClient } from '@/api/client';
+import { getMarketplaceCampaign } from '@/api/marketplace';
+import { composeValueLine, fmtDateLong, isDrawCampaign, boostOf } from './content';
+import { formatDateInput, getAgeValidationError } from '@/components/campaigns/signup/dateUtils';
+import {
+  shouldTrack, generateEventId, captureFbcFromUrl, captureUtmsFromUrl,
+  readFbc, readFbp, readUtms, ensureFbp, initPixel, trackEvent, trackLead, trackCustomEvent,
+} from '@/lib/metaPixel';
+import {
+  shouldTrackTikTok, captureTtclidFromUrl, readTtclid, readTtp,
+  initTikTokPixel, trackTikTokViewContent, trackTikTokEvent, trackTikTokLead,
+} from '@/lib/tiktokPixel';
+import { getOrCreateVcState, markVcFired } from '@/lib/pixelSession';
+
+/**
+ * Marketplace redemption flow (/flow/:slug) — the step machine from the
+ * approved Prototype v2, submitting into the EXISTING production pipeline:
+ * POST /verify/send + /verify/check (OTP), POST /dnc/check, POST /prospects.
+ *
+ * Steps: [SC/PR screen?] → [advisor screen?] → details → [child?] → [prefs?]
+ *        → otp → [dnc?] → consent → confirmation | duplicate.
+ *
+ * Form contract = the FLAT production keys (fieldOrder — legacy string[] OR
+ * row objects {id, columns[]} — plus visibleFields / requiredFields).
+ * Production fields default VISIBLE + REQUIRED unless explicitly false
+ * (matching CampaignSignupForm semantics); the marketplace-only child/prefs
+ * fields are opt-IN via visibleFields so existing campaigns are unaffected.
+ */
+
+/** Flatten both production fieldOrder shapes into an ordered id list. */
+export function flattenFieldOrder(fieldOrder) {
+  const fallback = ['name', 'phone', 'email', 'dob', 'postal_code', 'education_level', 'monthly_income'];
+  if (!Array.isArray(fieldOrder) || fieldOrder.length === 0) return fallback;
+  const out = [];
+  for (const item of fieldOrder) {
+    if (typeof item === 'string') out.push(item);
+    else if (item && Array.isArray(item.columns)) out.push(...item.columns.filter((c) => typeof c === 'string'));
+  }
+  return out.length ? out : fallback;
+}
+
+// Production select options — these values map to prospect columns consumed
+// downstream (FieldRenderer.jsx is the source of truth; keep in lock-step).
+const EDUCATION_OPTIONS = ['Secondary School or below', 'O Levels', 'Diploma', 'Degree', 'Masters and above'];
+const INCOME_OPTIONS = ['<$3000', '$3000 - $4999', '$5000 - $7999', '>$8000'];
+
+const FIELD_DEFS = {
+  name: { label: 'Full name', autoComplete: 'name', placeholder: 'John Tan' },
+  phone: { label: 'Mobile number', type: 'tel', inputMode: 'numeric', autoComplete: 'tel', placeholder: '8-digit SG mobile' },
+  email: { label: 'Email', type: 'email', autoComplete: 'email', placeholder: 'you@example.com' },
+  dob: { label: 'Date of birth', inputMode: 'numeric', placeholder: 'DD/MM/YYYY' },
+  postal_code: { label: 'Postal code', inputMode: 'numeric', placeholder: '6-digit postal code' },
+  education_level: { label: 'Education level', options: EDUCATION_OPTIONS },
+  monthly_income: { label: 'Monthly income', options: INCOME_OPTIONS },
+};
+
+const ALWAYS_VISIBLE = new Set(['name', 'email', 'phone']);
+const STEP_LABELS = { screen: 'Eligibility', advisor: 'Industry check', details: 'Your details', child: 'Your child', prefs: 'Preferences', otp: 'Verify', dnc: 'DNC consent', consent: 'Confirm' };
+
+export default function MarketplaceFlow() {
+  const { slug } = useParams();
+  const navigate = useNavigate();
+  const [campaign, setCampaign] = useState(undefined);
+  const [qrTagId, setQrTagId] = useState(null);
+  const leadEventIdRef = useRef(null);
+
+  const [stepIdx, setStepIdx] = useState(0);
+  const [blocked, setBlocked] = useState(null); // null | 'scpr' | 'advisor'
+  const [form, setForm] = useState({
+    name: '', phone: '', email: '', dob: '', postal_code: '', education_level: '', monthly_income: '',
+    child_name: '', child_level: '', branch: '', day: '', time: '',
+  });
+  const [errors, setErrors] = useState({});
+  const [otp, setOtp] = useState({ status: 'idle', code: '', cooldown: 0, error: '' });
+  const [dnc, setDnc] = useState({ checked: false, hit: false, consent: false });
+  const [consent, setConsent] = useState({ contact: true, terms: false, third: false });
+  const [ack, setAck] = useState(false);
+  const [termsOpen, setTermsOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState(null); // {kind:'done', ...} | {kind:'duplicate'}
+  const [toast, setToast] = useState('');
+
+  useEffect(() => {
+    if (!leadEventIdRef.current) leadEventIdRef.current = generateEventId();
+    captureFbcFromUrl(window.location.search);
+    captureTtclidFromUrl(window.location.search);
+    captureUtmsFromUrl(window.location.search);
+  }, []);
+
+  useEffect(() => {
+    let alive = true;
+    getMarketplaceCampaign(slug)
+      .then((c) => alive && setCampaign(c))
+      .catch(() => alive && setCampaign(null));
+    // QR attribution: same session lookup LeadCapture uses, so tracker-set
+    // cookies still bind the lead to its scanned tag.
+    apiClient
+      .get('/qrcodes/session', { skipAuth: true })
+      .then((resp) => {
+        if (alive && resp?.data?.qrTag?.id) setQrTagId(resp.data.qrTag.id);
+      })
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, [slug]);
+
+  // Session-guarded ViewContent — fires here only when this is the FIRST
+  // public content surface this session (direct links); detail-first traffic
+  // already fired with the same event_id.
+  useEffect(() => {
+    if (!campaign) return;
+    const trackCtx = { campaign, pathname: window.location.pathname, search: window.location.search };
+    const vc = getOrCreateVcState(campaign.id);
+    if (!vc.firedMeta && shouldTrack(trackCtx)) {
+      const pixelId = campaign.metaPixelId || import.meta.env.VITE_META_PIXEL_ID;
+      if (pixelId) {
+        initPixel(pixelId);
+        ensureFbp();
+        trackEvent(
+          'ViewContent',
+          { content_ids: [campaign.id], content_name: campaign.name, content_category: campaign.design_config?.category || 'marketplace' },
+          { eventID: vc.eventId }
+        );
+        markVcFired(campaign.id, 'meta');
+      }
+    }
+    if (!vc.firedTiktok && shouldTrackTikTok(trackCtx)) {
+      const ttPixelId = campaign.tiktokPixelId || import.meta.env.VITE_TIKTOK_PIXEL_ID;
+      if (ttPixelId) {
+        initTikTokPixel(ttPixelId);
+        trackTikTokViewContent({ content_name: campaign.name, content_type: 'marketplace' }, vc.eventId);
+        markVcFired(campaign.id, 'tiktok');
+      }
+    }
+  }, [campaign]);
+
+  // OTP resend cooldown tick
+  useEffect(() => {
+    if (otp.cooldown <= 0) return;
+    const t = setTimeout(() => setOtp((p) => ({ ...p, cooldown: p.cooldown - 1 })), 1000);
+    return () => clearTimeout(t);
+  }, [otp.cooldown]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(''), 2800);
+    return () => clearTimeout(t);
+  }, [toast]);
+
+  const dc = campaign?.design_config || {};
+  const visibleFields = dc.visibleFields || {};
+  const requiredFields = dc.requiredFields || {};
+  const isVisible = (key) => ALWAYS_VISIBLE.has(key) || (FIELD_DEFS[key] ? visibleFields[key] !== false : visibleFields[key] === true);
+  const isRequired = (key) => {
+    const v = requiredFields[key];
+    if (v === false || v === 'optional') return false;
+    if (FIELD_DEFS[key]) return true; // production default: required unless opted out
+    return v === true; // marketplace extras: opt-in
+  };
+
+  const isDraw = isDrawCampaign(campaign);
+  const boost = boostOf(campaign);
+  const act = dc.activation || {};
+  const needAck = act.required === true;
+  const trackCustom = (name, params = {}) => {
+    const trackCtx = { campaign, pathname: window.location.pathname, search: window.location.search };
+    if (shouldTrack(trackCtx)) trackCustomEvent(name, params);
+    if (shouldTrackTikTok(trackCtx)) trackTikTokEvent(name, params);
+  };
+
+  const steps = useMemo(() => {
+    if (!campaign) return [];
+    const s = [];
+    if (dc.sgPrOnly === true) s.push('screen');
+    if (dc.excludeAdvisors === true) s.push('advisor');
+    s.push('details');
+    if (isVisible('child_name') || isVisible('child_school_level')) s.push('child');
+    if (isVisible('preferred_branch') || isVisible('preferred_timing')) s.push('prefs');
+    s.push('otp');
+    if (dnc.hit) s.push('dnc');
+    s.push('consent');
+    return s;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [campaign, dnc.hit]);
+
+  const idx = Math.min(stepIdx, Math.max(steps.length - 1, 0));
+  const current = steps[idx];
+
+  const setField = (key, value) => {
+    setForm((p) => ({ ...p, [key]: value }));
+    setErrors((p) => ({ ...p, [key]: undefined }));
+  };
+
+  const validateDetails = () => {
+    const errs = {};
+    for (const key of flattenFieldOrder(dc.fieldOrder)) {
+      if (!FIELD_DEFS[key] || !isVisible(key)) continue;
+      const v = (form[key] || '').trim();
+      if (!v) {
+        if (isRequired(key)) errs[key] = 'This field is required.';
+        continue;
+      }
+      if (key === 'name' && v.length < 2) errs.name = 'Please enter your full name.';
+      if (key === 'phone' && !/^[89]\d{7}$/.test(v.replace(/\s/g, ''))) errs.phone = 'Enter an 8-digit Singapore mobile starting with 8 or 9.';
+      if (key === 'email' && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v)) errs.email = 'Enter a valid email address.';
+      if (key === 'postal_code' && !/^\d{6}$/.test(v)) errs.postal_code = 'Enter a 6-digit Singapore postal code.';
+      if (key === 'dob') {
+        // Age gate = campaign min_age/max_age COLUMNS (server re-checks, 422).
+        const ageErr = getAgeValidationError(v, campaign);
+        if (v.replace(/\D/g, '').length !== 8) errs.dob = 'Enter a valid date as DD/MM/YYYY.';
+        else if (ageErr) errs.dob = ageErr;
+      }
+    }
+    return errs;
+  };
+
+  const validateStep = (stepId) => {
+    if (stepId === 'details') return validateDetails();
+    const errs = {};
+    if (stepId === 'child') {
+      if (isVisible('child_name') && isRequired('child_name') && form.child_name.trim().length < 2) errs.child_name = "Please enter your child's name.";
+      if (isVisible('child_school_level') && isRequired('child_school_level') && !form.child_level) errs.child_level = 'Select a level.';
+    }
+    if (stepId === 'prefs') {
+      if (isVisible('preferred_branch') && isRequired('preferred_branch') && !form.branch) errs.branch = 'Pick a branch.';
+    }
+    return errs;
+  };
+
+  const advance = () => {
+    const errs = validateStep(current);
+    if (Object.keys(errs).length) {
+      setErrors(errs);
+      return;
+    }
+    setErrors({});
+    setStepIdx(Math.min(idx + 1, steps.length - 1));
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const goBack = () => {
+    if (idx === 0) {
+      navigate(`/offers/${slug}`);
+      return;
+    }
+    setErrors({});
+    setStepIdx(idx - 1);
+  };
+
+  const sendOtp = async () => {
+    setOtp((p) => ({ ...p, status: 'sending', error: '' }));
+    try {
+      const resp = await apiClient.post('/verify/send', { phone: form.phone, countryCode: '+65', campaignId: campaign.id }, { skipAuth: true });
+      if (resp?.success) {
+        setOtp((p) => ({ ...p, status: 'pending', cooldown: 30 }));
+        trackCustom('otp_sent');
+      } else {
+        setOtp((p) => ({ ...p, status: 'idle', error: resp?.message || "We couldn't send the code — try again." }));
+      }
+    } catch (err) {
+      setOtp((p) => ({ ...p, status: 'idle', error: err?.message || "We couldn't send the code — try again." }));
+    }
+  };
+
+  const verifyOtp = async () => {
+    setOtp((p) => ({ ...p, status: 'verifying', error: '' }));
+    setDnc({ checked: false, hit: false, consent: false });
+    try {
+      const resp = await apiClient.post('/verify/check', { phone: form.phone, code: otp.code, countryCode: '+65' }, { skipAuth: true });
+      const verified = resp?.success && (resp?.data?.verified === true || resp?.data?.status === 'approved');
+      if (!verified) {
+        setOtp((p) => ({ ...p, status: 'pending', error: "That code didn't match. Check the 6 digits and try again." }));
+        return;
+      }
+      setOtp((p) => ({ ...p, status: 'verified', error: '' }));
+      trackCustom('otp_verified');
+      if (dc.dncCheckAtSubmit === true) {
+        try {
+          const d = await apiClient.post('/dnc/check', { phone: form.phone, countryCode: '+65', campaignId: campaign.id }, { skipAuth: true });
+          const hit = d?.data?.registered === true;
+          setDnc({ checked: true, hit, consent: false });
+          if (hit) trackCustom('dnc_gate_shown');
+        } catch {
+          setDnc({ checked: true, hit: false, consent: false }); // fails open, like production
+        }
+      } else {
+        setDnc({ checked: true, hit: false, consent: false });
+      }
+    } catch (err) {
+      setOtp((p) => ({ ...p, status: 'pending', error: err?.message || 'Verification failed — try again.' }));
+    }
+  };
+
+  const submit = async () => {
+    if (!consent.terms || (needAck && !ack) || (dnc.hit && !dnc.consent) || submitting) return;
+    setSubmitting(true);
+    try {
+      const name = form.name.trim();
+      const [firstName, ...restName] = name.split(/\s+/);
+      const marketplaceMeta = {
+        ...(form.child_name ? { child_name: form.child_name.trim() } : {}),
+        ...(form.child_level ? { child_school_level: form.child_level } : {}),
+        ...(form.branch ? { preferred_branch: form.branch } : {}),
+        ...([form.day, form.time].filter(Boolean).length ? { preferred_timing: [form.day, form.time].filter(Boolean).join(' ') } : {}),
+      };
+      const basePayload = {
+        firstName,
+        lastName: restName.join(' '),
+        email: form.email,
+        phone: form.phone,
+        date_of_birth: form.dob,
+        postal_code: form.postal_code,
+        education_level: form.education_level,
+        monthly_income: form.monthly_income,
+        consent_contact: consent.contact,
+        consent_terms: consent.terms,
+        consent_third_party: consent.third,
+        ...(dnc.hit ? { consent_dnc: dnc.consent } : {}),
+        leadSource: qrTagId ? 'qr_code' : 'website',
+        campaignId: campaign.id,
+        qrTagId: qrTagId || undefined,
+        eventId: leadEventIdRef.current,
+        fbp: readFbp(),
+        fbc: readFbc(),
+        eventSourceUrl: typeof window !== 'undefined' ? window.location.href : undefined,
+        ...(readUtms() || {}),
+        ttclid: readTtclid() || undefined,
+        ttp: readTtp() || undefined,
+        ...(Object.keys(marketplaceMeta).length ? { marketplace: marketplaceMeta } : {}),
+      };
+      const payload = Object.fromEntries(
+        Object.entries(basePayload).filter(([k, v]) => {
+          if (k === 'lastName' && v === '') return true;
+          return v !== null && v !== undefined && v !== '';
+        })
+      );
+
+      const resp = await apiClient.post('/prospects', payload, { skipAuth: true });
+      if (resp?.success) {
+        const trackCtx = { campaign, pathname: window.location.pathname, search: window.location.search };
+        if (shouldTrack(trackCtx)) {
+          trackLead(
+            { content_ids: [campaign.id], content_name: campaign.name, content_category: dc.category || 'marketplace' },
+            leadEventIdRef.current
+          );
+        }
+        if (shouldTrackTikTok(trackCtx)) {
+          trackTikTokLead({ content_name: campaign.name }, leadEventIdRef.current);
+        }
+        if (isDraw) trackCustom('draw_entry_confirmed');
+        setResult({
+          kind: 'done',
+          ref: resp?.data?.prospect?.id || '',
+          shareUrl: resp?.data?.shareUrl || '',
+        });
+        window.scrollTo({ top: 0 });
+      } else {
+        setToast(resp?.message || 'Something went wrong — please try again.');
+      }
+    } catch (err) {
+      if (err?.status === 409 && err?.data?.alreadyRegistered) {
+        trackCustom('duplicate_blocked');
+        setResult({ kind: 'duplicate' });
+        window.scrollTo({ top: 0 });
+      } else {
+        setToast(err?.message || 'Something went wrong — please try again.');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  /* ---------- render ---------- */
+
+  if (campaign === undefined) {
+    return (
+      <MarketplaceLayout>
+        <div className="rm-shell rm-shell--flow" style={{ padding: 'clamp(24px,3.5vw,40px) 0' }}>
+          <div className="rm-shimmer" style={{ height: 380, borderRadius: 22 }} />
+        </div>
+      </MarketplaceLayout>
+    );
+  }
+
+  if (campaign === null) {
+    return (
+      <MarketplaceLayout>
+        <div className="rm-shell rm-shell--flow" style={{ padding: 'clamp(24px,3.5vw,40px) 0 clamp(56px,7vw,88px)' }}>
+          <div className="rm-card" style={{ padding: '48px 28px', textAlign: 'center' }}>
+            <div className="rm-serif" style={{ fontSize: 26 }}>This campaign isn't available</div>
+            <Link className="rm-btn" to="/explore" style={{ marginTop: 18 }}>Explore live offers</Link>
+          </div>
+        </div>
+      </MarketplaceLayout>
+    );
+  }
+
+  const partnerName = campaign.ops?.partner?.name || '';
+  const valueLine = composeValueLine(campaign);
+  const otpChannelLabel = dc.otpChannel === 'whatsapp' ? 'WhatsApp' : 'SMS';
+  const phoneMasked = form.phone ? `${form.phone.slice(0, 4)} ${form.phone.slice(4)}` : '';
+  const submitReady = consent.terms && (!needAck || ack) && (!dnc.hit || dnc.consent) && !submitting;
+  const missingText = submitting
+    ? ''
+    : `${!consent.terms ? 'Campaign terms consent is required. ' : ''}${needAck && !ack ? 'Please acknowledge the activation requirement.' : ''}`;
+
+  const orderedFields = flattenFieldOrder(dc.fieldOrder).filter((k) => FIELD_DEFS[k] && isVisible(k));
+  const branches = (campaign.ops?.partner?.locations || []).filter((l) => l.name);
+  const dncChecking = otp.status === 'verified' && !dnc.checked;
+
+  return (
+    <MarketplaceLayout>
+      <div className="rm-shell rm-shell--flow" style={{ paddingTop: 'clamp(24px,3.5vw,40px)', paddingBottom: 'clamp(56px,7vw,88px)' }}>
+        <button className="rm-link-btn" style={{ color: 'var(--rm-mut)' }} onClick={() => navigate(`/offers/${slug}`)}>
+          ← Back to offer
+        </button>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 10, flexWrap: 'wrap', marginTop: 4 }}>
+          <h1 className="rm-serif" style={{ margin: 0, fontSize: 'clamp(24px,3vw,30px)' }}>{dc.name || campaign.name}</h1>
+          <span className="rm-mono-note" style={{ fontSize: 11 }}>{partnerName}</span>
+        </div>
+        {valueLine && <div style={{ fontSize: 13.5, fontWeight: 700, color: 'var(--rm-pine)', marginTop: 6 }}>{valueLine}</div>}
+
+        {!result && !blocked && (
+          <div className="rm-progress">
+            <div className="rm-progress-line" aria-hidden="true" />
+            <div className="rm-progress-steps">
+              {steps.map((s, i) => (
+                <div key={s} className={`rm-progress-step${i === idx ? ' is-current' : ''}${i < idx ? ' is-done' : ''}`}>
+                  <span className="rm-progress-dot">{i + 1}</span>
+                  <span className="rm-progress-label">{STEP_LABELS[s]}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="rm-card" style={{ borderRadius: 22, padding: 'clamp(22px,4vw,36px)', boxShadow: 'var(--rm-sh)', marginTop: result || blocked ? 22 : 0 }}>
+          {blocked ? (
+            <div className="rm-fadeup" style={{ textAlign: 'center', padding: '12px 0' }}>
+              <div style={{ width: 56, height: 70, borderRadius: '28px 28px 5px 5px', background: 'var(--rm-sage)', margin: '0 auto 18px' }} />
+              <h2 className="rm-serif" style={{ margin: 0, fontSize: 23 }}>Thanks for checking this one out</h2>
+              <p style={{ margin: '10px auto 20px', fontSize: 14, lineHeight: 1.65, color: 'var(--rm-sub)', maxWidth: '46ch' }}>
+                {blocked === 'scpr'
+                  ? "This particular campaign is only open to Singapore Citizens and PRs, so we can't take your details for it. Plenty of others don't have this condition."
+                  : "This campaign's sponsor excludes financial-advisory and insurance industry members, so we can't take your details for it. Plenty of other offers are open to you."}
+              </p>
+              <Link className="rm-btn" to="/explore">Browse open offers</Link>
+            </div>
+          ) : result?.kind === 'duplicate' ? (
+            <div className="rm-fadeup" style={{ textAlign: 'center', padding: '10px 0' }}>
+              <div style={{ width: 56, height: 70, borderRadius: '28px 28px 5px 5px', background: 'var(--rm-sage)', margin: '0 auto 16px', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 22 }}>👋</div>
+              <h2 className="rm-serif" style={{ margin: 0, fontSize: 24 }}>You've already redeemed this one</h2>
+              <p style={{ margin: '10px auto 20px', fontSize: 14, lineHeight: 1.65, color: 'var(--rm-sub)', maxWidth: '46ch' }}>
+                Good news — your original redemption stands, and the details are in your email. Each offer is one per person, so this submission wasn't recorded twice.
+              </p>
+              <Link className="rm-btn" to="/explore">See what else is on</Link>
+            </div>
+          ) : result?.kind === 'done' ? (
+            <Confirmation
+              campaign={campaign}
+              isDraw={isDraw}
+              boost={boost}
+              needAck={needAck}
+              actSummary={act.summary}
+              consentContact={consent.contact}
+              result={result}
+              partnerName={partnerName}
+              onCopyShare={() => {
+                if (result.shareUrl && navigator.clipboard) navigator.clipboard.writeText(result.shareUrl);
+                setToast('Referral link copied');
+              }}
+            />
+          ) : current === 'screen' ? (
+            <div className="rm-fadeup">
+              <h2 className="rm-serif" style={{ margin: 0, fontSize: 23, lineHeight: 1.25 }}>Are you a Singapore Citizen or Permanent Resident?</h2>
+              <p style={{ margin: '10px 0 22px', fontSize: 13.5, lineHeight: 1.6, color: 'var(--rm-sub)' }}>
+                This campaign's sponsor requires it — we ask before you share any details.
+              </p>
+              <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+                <button className="rm-btn rm-btn--big" style={{ flex: 1, minWidth: 140, borderRadius: 14 }} onClick={advance}>Yes, I am</button>
+                <button className="rm-btn rm-btn--outline" style={{ flex: 1, minWidth: 140, borderRadius: 14 }} onClick={() => setBlocked('scpr')}>No, I'm not</button>
+              </div>
+            </div>
+          ) : current === 'advisor' ? (
+            <div className="rm-fadeup">
+              <h2 className="rm-serif" style={{ margin: 0, fontSize: 23, lineHeight: 1.25 }}>Do you work in financial advisory or insurance distribution?</h2>
+              <p style={{ margin: '10px 0 22px', fontSize: 13.5, lineHeight: 1.6, color: 'var(--rm-sub)' }}>
+                This campaign's sponsor excludes industry members — we ask before you share any details.
+              </p>
+              <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+                <button className="rm-btn rm-btn--big" style={{ flex: 1, minWidth: 140, borderRadius: 14 }} onClick={advance}>No, I'm not</button>
+                <button className="rm-btn rm-btn--outline" style={{ flex: 1, minWidth: 140, borderRadius: 14 }} onClick={() => setBlocked('advisor')}>Yes, I am</button>
+              </div>
+            </div>
+          ) : current === 'details' ? (
+            <div className="rm-fadeup" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <div>
+                <h2 className="rm-serif" style={{ margin: 0, fontSize: 23 }}>Your details</h2>
+                <p style={{ margin: '8px 0 0', fontSize: 13, lineHeight: 1.55, color: 'var(--rm-sub)' }}>
+                  Only what's needed to arrange your redemption — nothing more.
+                </p>
+              </div>
+              {orderedFields.map((key) => {
+                const def = FIELD_DEFS[key];
+                const optional = !isRequired(key);
+                return (
+                  <label key={key} style={{ display: 'block' }}>
+                    <span className="rm-label">
+                      {def.label} {optional && <span className="rm-opt">(optional)</span>}
+                    </span>
+                    {def.options ? (
+                      <select className="rm-select" name={key} value={form[key]} onChange={(e) => setField(key, e.target.value)}>
+                        <option value="">Select…</option>
+                        {def.options.map((op) => <option key={op} value={op}>{op}</option>)}
+                      </select>
+                    ) : (
+                      <input
+                        className="rm-input"
+                        name={key}
+                        type={def.type || 'text'}
+                        inputMode={def.inputMode}
+                        autoComplete={def.autoComplete}
+                        placeholder={def.placeholder}
+                        value={form[key]}
+                        onChange={(e) => {
+                          let v = e.target.value;
+                          if (key === 'dob') v = formatDateInput(v);
+                          if (key === 'phone') {
+                            let digits = v.replace(/\D/g, '');
+                            if (digits.startsWith('65') && digits.length > 8) digits = digits.substring(2);
+                            v = digits.slice(0, 8);
+                          }
+                          setField(key, v);
+                        }}
+                      />
+                    )}
+                    <span className="rm-err">{errors[key] || ''}</span>
+                  </label>
+                );
+              })}
+              <StepNav onBack={goBack} onNext={advance} />
+            </div>
+          ) : current === 'child' ? (
+            <div className="rm-fadeup" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <div>
+                <h2 className="rm-serif" style={{ margin: 0, fontSize: 23 }}>About your child</h2>
+                <p style={{ margin: '8px 0 0', fontSize: 13, lineHeight: 1.55, color: 'var(--rm-sub)' }}>
+                  So {partnerName || 'the partner'} can pitch the session at the right level.
+                </p>
+              </div>
+              {isVisible('child_name') && (
+                <label style={{ display: 'block' }}>
+                  <span className="rm-label">Child's name {!isRequired('child_name') && <span className="rm-opt">(optional)</span>}</span>
+                  <input className="rm-input" value={form.child_name} onChange={(e) => setField('child_name', e.target.value)} />
+                  <span className="rm-err">{errors.child_name || ''}</span>
+                </label>
+              )}
+              {isVisible('child_school_level') && (dc.school_levels || []).length > 0 && (
+                <div>
+                  <span className="rm-label" style={{ marginBottom: 8 }}>School level {!isRequired('child_school_level') && <span className="rm-opt">(optional)</span>}</span>
+                  <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                    {dc.school_levels.map((lv) => (
+                      <button key={lv} className={`rm-chip rm-chip--pick${form.child_level === lv ? ' is-active' : ''}`} onClick={() => setField('child_level', lv)}>
+                        {lv}
+                      </button>
+                    ))}
+                  </div>
+                  <span className="rm-err">{errors.child_level || ''}</span>
+                </div>
+              )}
+              <StepNav onBack={goBack} onNext={advance} />
+            </div>
+          ) : current === 'prefs' ? (
+            <div className="rm-fadeup" style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+              <div>
+                <h2 className="rm-serif" style={{ margin: 0, fontSize: 23 }}>Your preferences</h2>
+                <p style={{ margin: '8px 0 0', fontSize: 13, lineHeight: 1.55, color: 'var(--rm-sub)' }}>
+                  The partner confirms the final slot with you directly.
+                </p>
+              </div>
+              {isVisible('preferred_branch') && branches.length > 0 && (
+                <div>
+                  <span className="rm-label" style={{ marginBottom: 8 }}>Preferred branch {!isRequired('preferred_branch') && <span className="rm-opt">(optional)</span>}</span>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    {branches.map((b) => (
+                      <button
+                        key={b.name}
+                        className={`rm-check${form.branch === b.name ? ' is-checked' : ''}`}
+                        style={{ justifyContent: 'space-between', alignItems: 'center' }}
+                        onClick={() => setField('branch', b.name)}
+                      >
+                        <span style={{ fontSize: 14, fontWeight: 600 }}>{b.name}</span>
+                        {b.area && <span className="rm-mono-label" style={{ fontSize: 10 }}>{b.area}</span>}
+                      </button>
+                    ))}
+                  </div>
+                  <span className="rm-err">{errors.branch || ''}</span>
+                </div>
+              )}
+              {isVisible('preferred_timing') && (
+                <>
+                  {(dc.availability?.days || []).length > 0 && (
+                    <div>
+                      <span className="rm-label" style={{ marginBottom: 8 }}>Preferred day <span className="rm-opt">(optional)</span></span>
+                      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                        {dc.availability.days.map((d) => (
+                          <button key={d} className={`rm-chip rm-chip--pick${form.day === d ? ' is-active' : ''}`} onClick={() => setField('day', form.day === d ? '' : d)}>{d}</button>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  {(dc.availability?.slots || []).length > 0 && (
+                    <div>
+                      <span className="rm-label" style={{ marginBottom: 8 }}>Preferred time <span className="rm-opt">(optional)</span></span>
+                      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                        {dc.availability.slots.map((t) => (
+                          <button key={t} className={`rm-chip rm-chip--pick${form.time === t ? ' is-active' : ''}`} onClick={() => setField('time', form.time === t ? '' : t)}>{t}</button>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </>
+              )}
+              <StepNav onBack={goBack} onNext={advance} />
+            </div>
+          ) : current === 'otp' ? (
+            <div className="rm-fadeup" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <div>
+                <h2 className="rm-serif" style={{ margin: 0, fontSize: 23 }}>Verify your number</h2>
+                <p style={{ margin: '8px 0 0', fontSize: 13, lineHeight: 1.6, color: 'var(--rm-sub)' }}>
+                  We'll send a one-time code to <strong style={{ color: 'var(--rm-ink)' }}>{phoneMasked}</strong> via {otpChannelLabel}. This confirms it's really you — no account is created.
+                </p>
+              </div>
+              {otp.status === 'idle' && (
+                <>
+                  <button className="rm-btn rm-btn--big" style={{ alignSelf: 'flex-start' }} onClick={sendOtp}>
+                    Send code via {otpChannelLabel}
+                  </button>
+                  {otp.error && <span className="rm-err">{otp.error}</span>}
+                </>
+              )}
+              {otp.status === 'sending' && (
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 14, color: 'var(--rm-sub)' }}>
+                  <span className="rm-spin" />Sending your code…
+                </div>
+              )}
+              {(otp.status === 'pending') && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                  <label style={{ display: 'block' }}>
+                    <span className="rm-label">Enter the 6-digit code</span>
+                    <input
+                      className="rm-input"
+                      inputMode="numeric"
+                      autoComplete="one-time-code"
+                      value={otp.code}
+                      onChange={(e) => setOtp((p) => ({ ...p, code: e.target.value.replace(/\D/g, '').slice(0, 6) }))}
+                      placeholder="••••••"
+                      style={{ maxWidth: 240, fontFamily: 'var(--rm-mono)', fontSize: 22, letterSpacing: '0.4em', borderRadius: 12 }}
+                    />
+                  </label>
+                  {otp.error && <span className="rm-err" style={{ minHeight: 0 }}>{otp.error}</span>}
+                  <div style={{ display: 'flex', gap: 14, alignItems: 'center', flexWrap: 'wrap' }}>
+                    <button className="rm-btn rm-btn--big" onClick={verifyOtp} disabled={otp.code.length !== 6}>Verify</button>
+                    {otp.cooldown > 0 ? (
+                      <span className="rm-mono-note" style={{ fontSize: 11.5 }}>Resend in {otp.cooldown}s</span>
+                    ) : (
+                      <button className="rm-link-btn" onClick={sendOtp}>Resend code</button>
+                    )}
+                  </div>
+                </div>
+              )}
+              {otp.status === 'verifying' && (
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 14, color: 'var(--rm-sub)' }}>
+                  <span className="rm-spin" />Checking your code…
+                </div>
+              )}
+              {otp.status === 'verified' && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                    <span style={{ width: 40, height: 40, borderRadius: '50%', background: 'var(--rm-ok)', color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 19, fontWeight: 700, animation: 'rmPop 0.4s ease both' }}>✓</span>
+                    <div>
+                      <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--rm-ok)' }}>Number verified</div>
+                      <div style={{ fontSize: 12.5, color: 'var(--rm-sub)' }}>{phoneMasked} is confirmed as yours.</div>
+                    </div>
+                  </div>
+                  {dncChecking ? (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 10, alignItems: 'flex-start' }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 13, color: 'var(--rm-sub)' }}>
+                        <span className="rm-spin" style={{ width: 14, height: 14 }} />Checking your number against the Do-Not-Call registry…
+                      </div>
+                      <button className="rm-btn rm-btn--big rm-btn--disabled" disabled>Continue</button>
+                    </div>
+                  ) : (
+                    <button className="rm-btn rm-btn--big" style={{ alignSelf: 'flex-start' }} onClick={advance}>Continue</button>
+                  )}
+                </div>
+              )}
+              <div>
+                <button className="rm-link-btn" style={{ color: 'var(--rm-mut)' }} onClick={goBack}>Back</button>
+              </div>
+            </div>
+          ) : current === 'dnc' ? (
+            <div className="rm-fadeup" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <div>
+                <h2 className="rm-serif" style={{ margin: 0, fontSize: 23, lineHeight: 1.25 }}>One more consent — your number is on the Do-Not-Call registry</h2>
+                <p style={{ margin: '10px 0 0', fontSize: 13.5, lineHeight: 1.65, color: 'var(--rm-sub)' }}>
+                  You've registered this number on Singapore's DNC registry, which we respect. To proceed with this campaign, the partner and sponsor need your explicit permission to contact you about it. Nothing happens without it.
+                </p>
+              </div>
+              <button
+                className={`rm-check${dnc.consent ? ' is-checked' : ''}`}
+                role="checkbox"
+                aria-checked={dnc.consent}
+                style={{ background: 'var(--rm-bg)', borderRadius: 14, padding: 16 }}
+                onClick={() => {
+                  const next = !dnc.consent;
+                  setDnc((p) => ({ ...p, consent: next }));
+                  if (next) trackCustom('dnc_consent_given');
+                }}
+              >
+                <span className="rm-check-box">{dnc.consent ? '✓' : ''}</span>
+                <span className="rm-check-text" style={{ fontSize: 13.5 }}>
+                  I consent to being contacted about this campaign at the number I verified, even though it is listed on the DNC registry.
+                </span>
+              </button>
+              <div style={{ fontSize: 12, lineHeight: 1.55, color: 'var(--rm-mut)' }}>
+                Declining simply means we can't proceed with this campaign — your DNC registration stays fully respected.
+              </div>
+              <StepNav onBack={goBack} onNext={advance} nextDisabled={!dnc.consent} />
+            </div>
+          ) : current === 'consent' ? (
+            <div className="rm-fadeup" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <div>
+                <h2 className="rm-serif" style={{ margin: 0, fontSize: 23 }}>Almost there</h2>
+                <p style={{ margin: '8px 0 0', fontSize: 13, lineHeight: 1.55, color: 'var(--rm-sub)' }}>
+                  Read once, tick what you agree to. No surprises later.
+                </p>
+              </div>
+              {needAck && (
+                <div style={{ background: '#F2F6EF', border: '1.5px solid var(--rm-pine)', borderRadius: 14, padding: '16px 18px' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+                    <span className="rm-ticket" style={{ width: 10, height: 13 }} />
+                    <span className="rm-mono-label" style={{ color: 'var(--rm-pine)', fontSize: 10 }}>Activation requirement</span>
+                  </div>
+                  <div style={{ fontSize: 13, lineHeight: 1.6 }}>{act.detail}</div>
+                  <button
+                    className={`rm-check${ack ? ' is-checked' : ''}`}
+                    role="checkbox"
+                    aria-checked={ack}
+                    style={{ border: 'none', padding: '12px 0 0', minHeight: 44 }}
+                    onClick={() => setAck(!ack)}
+                  >
+                    <span className="rm-check-box">{ack ? '✓' : ''}</span>
+                    <span className="rm-check-text" style={{ fontWeight: 600 }}>I understand and accept this requirement.</span>
+                  </button>
+                </div>
+              )}
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                <ConsentCheck checked={consent.contact} onToggle={() => setConsent((p) => ({ ...p, contact: !p.contact }))}>
+                  Contact me about this redemption using the details I've provided. <span style={{ color: 'var(--rm-mut)' }}>(Pre-ticked — untick if you'd rather we didn't.)</span>
+                </ConsentCheck>
+                <ConsentCheck checked={consent.terms} onToggle={() => setConsent((p) => ({ ...p, terms: !p.terms }))}>
+                  I agree to this campaign's{' '}
+                  {dc.termsContent ? (
+                    <button className="rm-underline" style={{ color: 'var(--rm-pine)', fontWeight: 600 }} onClick={(e) => { e.stopPropagation(); setTermsOpen(true); }}>
+                      terms &amp; conditions
+                    </button>
+                  ) : (
+                    'terms & conditions'
+                  )}
+                  . <span style={{ fontFamily: 'var(--rm-mono)', fontSize: 9.5, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--rm-err)' }}>Required</span>
+                </ConsentCheck>
+                <ConsentCheck checked={consent.third} onToggle={() => setConsent((p) => ({ ...p, third: !p.third }))}>
+                  Share my contact details with the sponsoring licensed financial-advisory representative for this campaign. <span style={{ color: 'var(--rm-mut)' }}>(Optional — a separate choice from the two above.)</span>
+                </ConsentCheck>
+                {dc.sponsor?.disclosure && (
+                  <div style={{ fontSize: 11.5, lineHeight: 1.55, color: 'var(--rm-mut)', padding: '0 4px' }}>{dc.sponsor.disclosure}</div>
+                )}
+              </div>
+              <div style={{ display: 'flex', gap: 10, justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap' }}>
+                <button className="rm-link-btn" style={{ color: 'var(--rm-mut)' }} onClick={goBack}>Back</button>
+                <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 6 }}>
+                  <button className={`rm-btn rm-btn--big${!submitReady ? ' rm-btn--disabled' : ''}`} disabled={!submitReady} onClick={submit}>
+                    {submitting ? 'Submitting…' : isDraw ? 'Confirm my entry' : 'Confirm redemption'}
+                  </button>
+                  {missingText && <span style={{ fontFamily: 'var(--rm-mono)', fontSize: 10, color: 'var(--rm-warn)', maxWidth: 300, textAlign: 'right' }}>{missingText}</span>}
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="rm-mono-note" style={{ fontSize: 10, letterSpacing: '0.05em', textAlign: 'center', marginTop: 16 }}>
+          OTP-verified · consent recorded with submission · data used only as stated on the offer
+        </div>
+      </div>
+
+      <MarketingConsentDialog open={termsOpen} onOpenChange={setTermsOpen} content={dc.termsContent} />
+
+      {toast && (
+        <div role="status" style={{ position: 'fixed', bottom: 26, left: '50%', transform: 'translateX(-50%)', zIndex: 90, background: 'var(--rm-ink)', color: '#F6F2E6', fontSize: 13.5, fontWeight: 500, padding: '12px 22px', borderRadius: 999, boxShadow: '0 12px 30px rgba(23,37,31,0.3)' }}>
+          {toast}
+        </div>
+      )}
+    </MarketplaceLayout>
+  );
+}
+
+function StepNav({ onBack, onNext, nextDisabled }) {
+  return (
+    <div style={{ display: 'flex', gap: 10, justifyContent: 'space-between', marginTop: 6 }}>
+      <button className="rm-link-btn" style={{ color: 'var(--rm-mut)' }} onClick={onBack}>Back</button>
+      <button className={`rm-btn rm-btn--big${nextDisabled ? ' rm-btn--disabled' : ''}`} disabled={nextDisabled} onClick={onNext}>
+        Continue
+      </button>
+    </div>
+  );
+}
+
+function ConsentCheck({ checked, onToggle, children }) {
+  return (
+    <button className={`rm-check${checked ? ' is-checked' : ''}`} role="checkbox" aria-checked={checked} onClick={onToggle}>
+      <span className="rm-check-box">{checked ? '✓' : ''}</span>
+      <span className="rm-check-text">{children}</span>
+    </button>
+  );
+}
+
+function Confirmation({ campaign, isDraw, boost, needAck, actSummary, consentContact, result, partnerName, onCopyShare }) {
+  const dc = campaign.design_config || {};
+  return (
+    <div className="rm-fadeup" style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+      <div style={{ textAlign: 'center', padding: '8px 0 4px' }}>
+        <span style={{ width: 62, height: 62, borderRadius: '50%', background: 'var(--rm-ok)', color: '#fff', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: 28, fontWeight: 700, animation: 'rmPop 0.45s ease both' }}>✓</span>
+        <h2 className="rm-serif" style={{ margin: '14px 0 0', fontSize: 26 }}>{isDraw ? "You're in the draw" : 'Redemption confirmed'}</h2>
+        <div className="rm-mono-note" style={{ fontSize: 11, marginTop: 6 }}>
+          {result.ref ? `Reference ${String(result.ref).slice(0, 8).toUpperCase()} · ` : ''}{dc.name || campaign.name}
+        </div>
+      </div>
+
+      <div style={{ background: 'var(--rm-bg)', border: '1px solid var(--rm-line)', borderRadius: 14, padding: '18px 20px' }}>
+        <div className="rm-mono-label" style={{ fontSize: 10, marginBottom: 10 }}>What happens next</div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 9, fontSize: 13.5, lineHeight: 1.6 }}>
+          {isDraw ? (
+            <>
+              <Step n="1" apricot>Your entry is recorded — one chance in the draw, nothing more to do.</Step>
+              {boost && (
+                <Step n="2" apricot>
+                  <strong>Boost your odds:</strong> complete the activation step before {fmtDateLong(boost.boostClosesAt)} and this entry counts ×{boost.multiplier}.{' '}
+                  {consentContact ? 'The details are in your confirmation email, and the consultant can reach you at your verified number.' : 'The details are in your confirmation email.'}
+                </Step>
+              )}
+              <Step n={boost ? '3' : '2'} apricot>
+                Entries close on {fmtDateLong(dc.luckyDraw?.closesAt)};{dc.luckyDraw?.winners ? ` ${dc.luckyDraw.winners}` : ''} winners are drawn within seven days.
+              </Step>
+              <Step n={boost ? '4' : '3'} apricot>
+                Winners are contacted at the number you verified and listed on the <Link to="/winners" className="rm-underline">winners page</Link>.
+              </Step>
+            </>
+          ) : (
+            <>
+              <Step n="1">{partnerName || 'The partner'} will contact you to confirm your slot.</Step>
+              <Step n="2">Expect first contact within one working day{consentContact ? ', at the number you verified' : ''}.</Step>
+              <Step n="3">A confirmation has also been sent to your email.</Step>
+            </>
+          )}
+        </div>
+      </div>
+
+      {needAck && !isDraw && (
+        <div style={{ background: '#F2F6EF', border: '1px solid #CFDDD2', borderRadius: 14, padding: '14px 18px', display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+          <span className="rm-ticket" style={{ width: 10, height: 13, marginTop: 3, flexShrink: 0 }} />
+          <span style={{ fontSize: 12.5, lineHeight: 1.6, color: 'var(--rm-pine2)' }}>
+            <strong>Reminder:</strong> {actSummary} — your experience is confirmed after this step.
+          </span>
+        </div>
+      )}
+
+      {result.shareUrl && (
+        <div style={{ background: 'var(--rm-bg)', border: '1px solid var(--rm-line)', borderRadius: 14, padding: '14px 18px', display: 'flex', gap: 12, alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap' }}>
+          <div style={{ minWidth: 0 }}>
+            <div className="rm-mono-label" style={{ fontSize: 10, marginBottom: 4 }}>Share with a friend</div>
+            <div style={{ fontFamily: 'var(--rm-mono)', fontSize: 11.5, color: 'var(--rm-sub)', overflowWrap: 'anywhere' }}>{result.shareUrl}</div>
+          </div>
+          <button className="rm-btn rm-btn--outline" onClick={onCopyShare} style={{ flexShrink: 0 }}>Copy link</button>
+        </div>
+      )}
+
+      <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', justifyContent: 'center' }}>
+        <Link className="rm-btn" to="/explore">Explore more offers</Link>
+      </div>
+      <div className="rm-mono-note" style={{ fontSize: 10.5, textAlign: 'center' }}>Need help? support@redeem.sg</div>
+    </div>
+  );
+}
+
+function Step({ n, apricot, children }) {
+  return (
+    <div style={{ display: 'flex', gap: 10 }}>
+      <span style={{ color: apricot ? 'var(--rm-apr2)' : 'var(--rm-pine)', fontWeight: 700 }}>{n}</span>
+      <span>{children}</span>
+    </div>
+  );
+}

--- a/src/pages/marketplace/MarketplaceHome.jsx
+++ b/src/pages/marketplace/MarketplaceHome.jsx
@@ -1,0 +1,220 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import MarketplaceLayout from './MarketplaceLayout';
+import OfferCard from './OfferCard';
+import { listMarketplaceCampaigns } from '@/api/marketplace';
+import { CATEGORIES, HOW_STEPS, TRUST_POINTS, HOME_FAQ } from './content';
+
+const TINTS = ['#F1EBDC', '#E9F0E6', '#F5EADF', '#EDEFE3'];
+
+export default function MarketplaceHome() {
+  const [campaigns, setCampaigns] = useState(null);
+  const [faqOpen, setFaqOpen] = useState(-1);
+
+  useEffect(() => {
+    let alive = true;
+    listMarketplaceCampaigns()
+      .then((cs) => alive && setCampaigns(cs))
+      .catch(() => alive && setCampaigns([]));
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const featured = (campaigns || []).filter((c) => c.design_config?.featuredDrop).slice(0, 6);
+  const fallback = (campaigns || []).slice(0, 6);
+  const shown = featured.length ? featured : fallback;
+
+  return (
+    <MarketplaceLayout>
+      {/* Hero */}
+      <section className="rm-shell" style={{ padding: 'clamp(40px,6vw,84px) 0 clamp(36px,5vw,64px)', display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(320px,1fr))', gap: 'clamp(28px,4vw,56px)', alignItems: 'center' }}>
+        <div className="rm-fadeup" style={{ display: 'flex', flexDirection: 'column', gap: 22 }}>
+          <div className="rm-mono-label" style={{ color: 'var(--rm-pine)', fontSize: 11.5 }}>Experiences from verified Singapore brands</div>
+          <h1 className="rm-serif" style={{ margin: 0, fontSize: 'clamp(38px,4.8vw,58px)', lineHeight: 1.06, letterSpacing: '-0.015em', maxWidth: '14ch' }}>
+            Redeem your next experience.
+          </h1>
+          <p style={{ margin: 0, fontSize: 16.5, lineHeight: 1.65, color: 'var(--rm-sub)', maxWidth: '50ch' }}>
+            Enrichment trials, family experiences, wellness sessions and useful rewards from verified Singapore brands — each one a door worth stepping through.
+          </p>
+          <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+            <Link className="rm-btn rm-btn--big" to="/explore">Explore experiences</Link>
+            <Link className="rm-btn rm-btn--outline" to="/how-it-works">How Redeem works</Link>
+          </div>
+        </div>
+        <div className="rm-fadeup" style={{ position: 'relative' }}>
+          <div style={{ display: 'flex', alignItems: 'flex-end', gap: 14, justifyContent: 'center' }}>
+            <div className="rm-arch" style={{ flex: 1.2, maxWidth: 260, height: 380, borderRadius: '200px 200px 12px 12px', background: 'repeating-linear-gradient(45deg,#DEE8DC 0 12px,#E9F0E6 12px 24px)' }}>
+              <span className="rm-arch-tag">family pottery</span>
+            </div>
+            <div className="rm-arch" style={{ flex: 1, maxWidth: 220, height: 310, borderRadius: '200px 200px 12px 12px', background: 'repeating-linear-gradient(45deg,#F0E2D4 0 12px,#F6EBDF 12px 24px)' }}>
+              <span className="rm-arch-tag">robotics trial</span>
+            </div>
+          </div>
+          <div className="rm-card" style={{ position: 'absolute', left: 0, bottom: 44, boxShadow: 'var(--rm-sh)', borderRadius: 12, padding: '11px 14px', maxWidth: 250, display: 'flex', gap: 9, alignItems: 'flex-start' }}>
+            <span className="rm-ticket" style={{ width: 9, height: 12, marginTop: 3, flexShrink: 0 }} />
+            <span style={{ fontSize: 11.5, lineHeight: 1.5, color: 'var(--rm-sub)' }}>
+              <strong className="rm-mono-label" style={{ color: 'var(--rm-pine)', fontSize: 9 }}>Always shown first</strong>
+              <br />
+              Requires: 20-min planning chat — on the card, never in fine print.
+            </span>
+          </div>
+        </div>
+      </section>
+
+      {/* Categories */}
+      <section className="rm-shell" style={{ paddingTop: 'clamp(20px,3vw,36px)', paddingBottom: 'clamp(20px,3vw,36px)' }}>
+        <h2 className="rm-serif" style={{ margin: '0 0 22px', fontSize: 'clamp(26px,3vw,34px)' }}>Browse by what matters</h2>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(200px,1fr))', gap: 14 }}>
+          {CATEGORIES.map((cat, i) => (
+            <Link
+              key={cat.id}
+              to={`/c/${cat.id}`}
+              className="rm-card"
+              style={{ background: TINTS[i % 4], padding: 18, display: 'flex', flexDirection: 'column', gap: 8, minHeight: 108 }}
+            >
+              <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span className="rm-ticket" style={{ width: 13, height: 17, opacity: 0.85, flexShrink: 0 }} />
+                <span style={{ fontSize: 15, fontWeight: 700, color: 'var(--rm-ink)', lineHeight: 1.25 }}>{cat.label}</span>
+              </span>
+              <span style={{ fontSize: 11.5, lineHeight: 1.5, color: 'var(--rm-sub)' }}>{cat.blurb}</span>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {/* Featured */}
+      <section className="rm-shell" style={{ paddingTop: 'clamp(28px,4vw,52px)', paddingBottom: 'clamp(28px,4vw,52px)' }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 16, flexWrap: 'wrap', marginBottom: 22 }}>
+          <h2 className="rm-serif" style={{ margin: 0, fontSize: 'clamp(26px,3vw,34px)' }}>Featured this week</h2>
+          <Link to="/explore" className="rm-underline" style={{ fontSize: 14, fontWeight: 600 }}>View all offers →</Link>
+        </div>
+        {campaigns === null ? (
+          <div className="rm-grid-cards">
+            {[0, 1, 2].map((i) => <div key={i} className="rm-shimmer" style={{ height: 440 }} />)}
+          </div>
+        ) : shown.length === 0 ? (
+          <div className="rm-card rm-card--pad" style={{ textAlign: 'center', padding: '44px 28px' }}>
+            <div className="rm-serif" style={{ fontSize: 24 }}>New campaigns launch weekly</div>
+            <div style={{ fontSize: 14, color: 'var(--rm-sub)', marginTop: 8 }}>The first offers are being prepared — check back soon.</div>
+          </div>
+        ) : (
+          <div className="rm-grid-cards">
+            {shown.map((c) => <OfferCard key={c.slug} campaign={c} />)}
+          </div>
+        )}
+      </section>
+
+      {/* How it works */}
+      <section className="rm-shell" style={{ paddingTop: 'clamp(28px,4vw,52px)', paddingBottom: 'clamp(28px,4vw,52px)' }}>
+        <h2 className="rm-serif" style={{ margin: '0 0 8px', fontSize: 'clamp(26px,3vw,34px)' }}>How Redeem works</h2>
+        <p style={{ margin: '0 0 34px', fontSize: 14.5, color: 'var(--rm-sub)', maxWidth: '56ch' }}>
+          Three steps, no account, no membership. One clearly stated requirement when a campaign has one.
+        </p>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(200px,1fr))', gap: 22 }}>
+          {HOW_STEPS.map((h) => (
+            <div key={h.n} style={{ display: 'flex', flexDirection: 'column', gap: 10, alignItems: 'center', textAlign: 'center' }}>
+              <span style={{ width: 46, height: 46, borderRadius: '50%', background: 'var(--rm-pine)', color: '#F6F2E6', display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'var(--rm-mono)', fontSize: 14 }}>{h.n}</span>
+              <span style={{ fontSize: 16, fontWeight: 700 }}>{h.t}</span>
+              <span style={{ fontSize: 13, lineHeight: 1.6, color: 'var(--rm-sub)' }}>{h.d}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Trust */}
+      <section className="rm-shell" style={{ paddingTop: 'clamp(28px,4vw,52px)', paddingBottom: 'clamp(28px,4vw,52px)' }}>
+        <div className="rm-card" style={{ borderRadius: 22, padding: 'clamp(24px,4vw,44px)' }}>
+          <h2 className="rm-serif" style={{ margin: '0 0 26px', fontSize: 'clamp(24px,2.6vw,30px)' }}>Why people trust Redeem</h2>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(250px,1fr))', gap: '22px 32px' }}>
+            {TRUST_POINTS.map((tp) => (
+              <div key={tp.t} style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
+                <span className="rm-ticket" style={{ width: 11, height: 14, marginTop: 3, flexShrink: 0 }} />
+                <div>
+                  <div style={{ fontSize: 14.5, fontWeight: 700 }}>{tp.t}</div>
+                  <div style={{ fontSize: 12.5, lineHeight: 1.55, color: 'var(--rm-sub)', marginTop: 3 }}>{tp.d}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="rm-mono-note" style={{ borderTop: '1px solid var(--rm-line)', marginTop: 26, paddingTop: 16, letterSpacing: '0.06em' }}>
+            Redeem is operated by MKTR PTE. LTD. · UEN 202507548M · Singapore
+          </div>
+        </div>
+      </section>
+
+      {/* Parents band */}
+      <section style={{ background: 'var(--rm-sage)', marginTop: 24 }}>
+        <div className="rm-shell" style={{ padding: 'clamp(40px,6vw,72px) 0', display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(320px,1fr))', gap: 'clamp(28px,4vw,56px)', alignItems: 'center' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+            <div className="rm-mono-label" style={{ color: 'var(--rm-pine)' }}>For parents</div>
+            <h2 className="rm-serif" style={{ margin: 0, fontSize: 'clamp(26px,3.2vw,38px)', lineHeight: 1.15, maxWidth: '18ch' }}>
+              Let your child try it before you commit to it.
+            </h2>
+            <p style={{ margin: 0, fontSize: 15, lineHeight: 1.65, color: 'var(--rm-sub)', maxWidth: '52ch' }}>
+              Explore suitable programmes, discover your child's interests, and understand possible development pathways — through real trial sessions and assessments, not brochures.
+            </p>
+            <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+              <Link className="rm-btn" to="/dsa">DSA discovery guide</Link>
+              <Link className="rm-btn rm-btn--outline" to="/c/education" style={{ borderColor: 'var(--rm-sage2)', color: 'var(--rm-pine2)' }}>All education offers</Link>
+            </div>
+            <div style={{ fontSize: 12, color: 'var(--rm-mut)' }}>Admission decisions rest with schools — Redeem never promises outcomes.</div>
+          </div>
+          <div style={{ display: 'flex', justifyContent: 'center' }}>
+            <div className="rm-arch" style={{ width: 'min(340px,90%)', height: 280, background: 'repeating-linear-gradient(45deg,#D5E2D2 0 12px,#E0EADC 12px 24px)' }}>
+              <span className="rm-arch-tag">parent &amp; child at trial class</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Business teaser */}
+      <section className="rm-shell" style={{ paddingTop: 'clamp(24px,3vw,40px)', paddingBottom: 'clamp(24px,3vw,40px)' }}>
+        <div style={{ background: 'var(--rm-pine)', borderRadius: 22, padding: 'clamp(28px,4.5vw,52px)', display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(300px,1fr))', gap: 28, alignItems: 'center' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+            <div className="rm-mono-label" style={{ color: '#A8C3B4' }}>For businesses</div>
+            <h2 className="rm-serif" style={{ margin: 0, fontSize: 'clamp(24px,3vw,34px)', lineHeight: 1.15, color: '#F6F2E6', maxWidth: '20ch' }}>
+              Fill your quiet slots with the right families.
+            </h2>
+            <p style={{ margin: 0, fontSize: 14.5, lineHeight: 1.6, color: '#CFE0D4', maxWidth: '52ch' }}>
+              Turn unused trial-class and appointment capacity into qualified, OTP-verified customers — with campaign infrastructure handled for you.
+            </p>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12, justifySelf: 'end', alignItems: 'flex-end' }}>
+            <Link className="rm-btn rm-btn--apricot rm-btn--big" to="/businesses">Become a partner</Link>
+            <span style={{ fontFamily: 'var(--rm-mono)', fontSize: 10.5, color: '#A8C3B4' }}>Enquiry only — no dashboards here</span>
+          </div>
+        </div>
+      </section>
+
+      {/* Consultant context */}
+      <section className="rm-shell" style={{ paddingTop: 'clamp(12px,2vw,24px)', paddingBottom: 'clamp(12px,2vw,24px)' }}>
+        <div className="rm-card" style={{ borderRadius: 16, padding: '20px 24px', display: 'flex', gap: 14, alignItems: 'flex-start' }}>
+          <span className="rm-ticket" style={{ width: 11, height: 14, background: 'var(--rm-apr)', marginTop: 4, flexShrink: 0 }} />
+          <div>
+            <div style={{ fontSize: 14.5, fontWeight: 700 }}>Why do some offers include a financial-planning conversation?</div>
+            <div style={{ fontSize: 13, lineHeight: 1.6, color: 'var(--rm-sub)', marginTop: 4, maxWidth: '90ch' }}>
+              Selected campaigns are sponsored by licensed financial consultants — their sponsorship is what makes the experience free. When this applies, the requirement is shown clearly before you redeem. No purchase is ever required.
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="rm-shell rm-shell--narrow" style={{ paddingTop: 'clamp(28px,4vw,56px)', paddingBottom: 'clamp(48px,6vw,80px)' }}>
+        <h2 className="rm-serif" style={{ margin: '0 0 26px', fontSize: 'clamp(26px,3vw,34px)' }}>Questions, answered</h2>
+        <div>
+          {HOME_FAQ.map((f, i) => (
+            <div key={f.q} className="rm-faq-row">
+              <button className="rm-faq-q" aria-expanded={faqOpen === i} onClick={() => setFaqOpen(faqOpen === i ? -1 : i)}>
+                <span>{f.q}</span>
+                <span className="rm-faq-sym">{faqOpen === i ? '−' : '+'}</span>
+              </button>
+              {faqOpen === i && <div className="rm-faq-a">{f.a}</div>}
+            </div>
+          ))}
+        </div>
+      </section>
+    </MarketplaceLayout>
+  );
+}

--- a/src/pages/marketplace/MarketplaceLayout.jsx
+++ b/src/pages/marketplace/MarketplaceLayout.jsx
@@ -1,0 +1,162 @@
+import { useEffect, useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { CATEGORIES } from './content';
+import './marketplace.css';
+
+/**
+ * Marketplace shell — fixed nav (desktop links / mobile drawer) + dark footer.
+ * Pine/cream editorial system from the approved Prototype v2. Redeem build
+ * only (routes are gated in pages/index.jsx).
+ */
+export default function MarketplaceLayout({ children, minimalChrome = false, chromeLabel }) {
+  const [drawer, setDrawer] = useState(false);
+  const location = useLocation();
+
+  useEffect(() => {
+    setDrawer(false);
+    window.scrollTo({ top: 0 });
+  }, [location.pathname]);
+
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === 'Escape') setDrawer(false);
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, []);
+
+  const eduCats = CATEGORIES.filter((c) => c.group === 'education');
+  const lifeCats = CATEGORIES.filter((c) => c.group === 'lifestyle');
+
+  if (minimalChrome) {
+    return (
+      <div className="rm-page">
+        <header className="rm-nav">
+          <div className="rm-shell rm-nav-inner" style={{ maxWidth: 720, justifyContent: 'space-between' }}>
+            <span className="rm-mono-label" style={{ color: 'var(--rm-sub)' }}>{chromeLabel || 'Campaign'}</span>
+            <span className="rm-mono-note" style={{ display: 'inline-flex', alignItems: 'center', gap: 7 }}>
+              <span className="rm-ticket" style={{ width: 11, height: 14 }} />
+              Secured by Redeem
+            </span>
+          </div>
+        </header>
+        <main style={{ flex: 1, paddingTop: 66 }}>{children}</main>
+        <footer style={{ marginTop: 'auto', padding: '20px 16px 28px', textAlign: 'center' }} className="rm-mono-note">
+          Powered by Redeem · MKTR PTE. LTD. · support@redeem.sg
+        </footer>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rm-page">
+      <a
+        href="#rm-main"
+        style={{ position: 'fixed', left: -9999, top: 16, zIndex: 99, background: '#17251F', color: '#FFFDF6', padding: '10px 16px', borderRadius: 8 }}
+      >
+        Skip to content
+      </a>
+      <header className="rm-nav">
+        <div className="rm-shell rm-nav-inner">
+          <Link to="/" aria-label="Redeem home" className="rm-wordmark">
+            <span className="rm-ticket" />
+            redeem
+          </Link>
+          <nav aria-label="Primary" className="rm-nav-links">
+            <Link className="rm-nav-link" to="/explore">Explore</Link>
+            <Link className="rm-nav-link" to="/c/education">Education</Link>
+            <Link className="rm-nav-link" to="/c/lifestyle">Lifestyle</Link>
+            <Link className="rm-nav-link" to="/dsa">DSA guide</Link>
+            <Link className="rm-nav-link" to="/how-it-works">How it works</Link>
+            <Link className="rm-nav-link" to="/businesses">For businesses</Link>
+            <Link className="rm-nav-link" to="/about">About</Link>
+            <Link className="rm-btn rm-nav-cta" to="/explore">Explore offers</Link>
+          </nav>
+          <button className="rm-burger" aria-label="Menu" onClick={() => setDrawer(true)}>
+            <span /><span /><span />
+          </button>
+        </div>
+      </header>
+
+      {drawer && (
+        <>
+          <div className="rm-drawer-scrim" onClick={() => setDrawer(false)} />
+          <div role="dialog" aria-label="Menu" className="rm-drawer">
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14 }}>
+              <span className="rm-serif" style={{ fontSize: 20 }}>redeem</span>
+              <button onClick={() => setDrawer(false)} aria-label="Close menu" style={{ fontSize: 22, color: 'var(--rm-mut)', minWidth: 44, minHeight: 44 }}>✕</button>
+            </div>
+            <Link to="/explore" style={{ fontWeight: 700 }}>Explore</Link>
+            <div className="rm-mono-label" style={{ padding: '12px 0 4px' }}>Education</div>
+            {eduCats.map((c) => (
+              <Link key={c.id} to={`/c/${c.id}`} style={{ paddingLeft: 12, fontSize: 14, color: 'var(--rm-sub)' }}>{c.label}</Link>
+            ))}
+            <Link to="/dsa" style={{ paddingLeft: 12, fontSize: 14, color: 'var(--rm-pine)', fontWeight: 600 }}>DSA discovery guide</Link>
+            <div className="rm-mono-label" style={{ padding: '12px 0 4px' }}>Lifestyle</div>
+            {lifeCats.map((c) => (
+              <Link key={c.id} to={`/c/${c.id}`} style={{ paddingLeft: 12, fontSize: 14, color: 'var(--rm-sub)' }}>{c.label}</Link>
+            ))}
+            <div style={{ height: 1, background: 'var(--rm-line)', margin: '14px 0' }} />
+            <Link to="/how-it-works">How it works</Link>
+            <Link to="/businesses">For businesses</Link>
+            <Link to="/about">About</Link>
+            <Link to="/winners">Lucky-draw winners</Link>
+            <Link className="rm-btn" to="/explore" style={{ marginTop: 16, width: '100%' }}>Explore offers</Link>
+          </div>
+        </>
+      )}
+
+      <main id="rm-main" style={{ flex: 1, paddingTop: 66 }}>{children}</main>
+
+      <footer className="rm-footer">
+        <div className="rm-shell" style={{ paddingTop: 'clamp(40px, 5vw, 64px)', paddingBottom: 28 }}>
+          <div className="rm-footer-cols">
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12, minWidth: 220 }}>
+              <span className="rm-wordmark" style={{ color: '#F6F2E6' }}>
+                <span className="rm-ticket" style={{ background: '#E4854F' }} />
+                redeem
+              </span>
+              <div style={{ fontSize: 12.5, lineHeight: 1.6, color: '#9DB3A3', maxWidth: '30ch' }}>
+                Discover experiences and rewards worth showing up for — from verified Singapore businesses.
+              </div>
+              <div style={{ fontFamily: 'var(--rm-mono)', fontSize: 10, lineHeight: 1.7, color: '#7E958A' }}>
+                MKTR PTE. LTD. · UEN 202507548M<br />support@redeem.sg
+              </div>
+            </div>
+            <div>
+              <div className="rm-footer-head">Discover</div>
+              <div className="rm-footer-links">
+                <Link to="/explore">Explore all offers</Link>
+                <Link to="/c/education">Education</Link>
+                <Link to="/c/lifestyle">Lifestyle</Link>
+                <Link to="/dsa">DSA discovery</Link>
+                <Link to="/winners">Lucky-draw winners</Link>
+              </div>
+            </div>
+            <div>
+              <div className="rm-footer-head">Company</div>
+              <div className="rm-footer-links">
+                <Link to="/how-it-works">How it works</Link>
+                <Link to="/businesses">For businesses</Link>
+                <Link to="/about">About &amp; trust</Link>
+              </div>
+            </div>
+            <div>
+              <div className="rm-footer-head">Legal</div>
+              <div className="rm-footer-links">
+                <Link to="/personal-data-policy">Personal Data Protection Policy</Link>
+                <Link to="/leads/privacy">Leads privacy</Link>
+                <Link to="/legal/terms">Terms of use</Link>
+                <Link to="/legal/dnc">DNC information</Link>
+              </div>
+            </div>
+          </div>
+          <div style={{ borderTop: '1px solid rgba(200,213,203,0.18)', marginTop: 36, paddingTop: 18, display: 'flex', justifyContent: 'space-between', gap: 14, flexWrap: 'wrap', fontFamily: 'var(--rm-mono)', fontSize: 10, color: '#7E958A' }}>
+            <span>© {new Date().getFullYear()} MKTR PTE. LTD. All rights reserved.</span>
+            <span>Redeem is a service of MKTR PTE. LTD.</span>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/pages/marketplace/MarketplaceOffer.jsx
+++ b/src/pages/marketplace/MarketplaceOffer.jsx
@@ -3,7 +3,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import MarketplaceLayout from './MarketplaceLayout';
 import OfferCard from './OfferCard';
 import { getMarketplaceCampaign, listMarketplaceCampaigns } from '@/api/marketplace';
-import { composeValueLine, ageLabelOf, fmtDateLong, categoryLabel, isDrawCampaign, boostOf } from './content';
+import { composeValueLine, ageLabelOf, fmtDateLong, categoryLabel, isDrawCampaign, boostOf, offerUnavailability, UNAVAILABLE_COPY } from './content';
 import { shouldTrack, initPixel, ensureFbp, trackEvent, captureFbcFromUrl, captureUtmsFromUrl } from '@/lib/metaPixel';
 import { shouldTrackTikTok, initTikTokPixel, trackTikTokViewContent, captureTtclidFromUrl } from '@/lib/tiktokPixel';
 import { getOrCreateVcState, markVcFired } from '@/lib/pixelSession';
@@ -108,7 +108,8 @@ export default function MarketplaceOffer() {
   const act = dc.activation || {};
   const isDraw = isDrawCampaign(campaign);
   const boost = boostOf(campaign);
-  const soldOut = !ops || (ops.capacity && ops.capacity.total > 0 && ops.capacity.remaining <= 0);
+  const unavailable = offerUnavailability(campaign);
+  const soldOut = unavailable !== null;
   const valueLine = composeValueLine(campaign);
   const days = (dc.availability?.days || []).join(' · ');
   const slots = (dc.availability?.slots || []).join(' / ');
@@ -116,7 +117,7 @@ export default function MarketplaceOffer() {
   const locNames = (partner.locations || []).map((l) => l.name).filter(Boolean).join(' · ') || (dc.mode === 'online' ? 'Online — enter from anywhere' : '—');
   const otpLabel = dc.otpChannel === 'whatsapp' ? 'WhatsApp' : 'SMS';
   const relatedCards = related.filter((c) => c.slug !== slug).slice(0, 3);
-  const ctaLabel = soldOut ? (isDraw ? 'Draw closed' : 'Fully redeemed') : isDraw ? 'Enter the draw' : 'Redeem this offer';
+  const ctaLabel = unavailable ? UNAVAILABLE_COPY[unavailable].cta : isDraw ? 'Enter the draw' : 'Redeem this offer';
 
   return (
     <MarketplaceLayout>
@@ -166,8 +167,8 @@ export default function MarketplaceOffer() {
                 <Detail
                   label="Availability"
                   value={
-                    soldOut
-                      ? 'Fully redeemed'
+                    unavailable
+                      ? UNAVAILABLE_COPY[unavailable].cta
                       : `${dc.showCapacity && ops?.capacity ? `${ops.capacity.remaining} of ${ops.capacity.total} slots left` : 'Available'}${ops?.expiry ? ` · until ${fmtDateLong(ops.expiry)}` : ''}`
                   }
                 />
@@ -246,7 +247,7 @@ export default function MarketplaceOffer() {
               <h1 className="rm-serif" style={{ margin: '10px 0 0', fontSize: 'clamp(26px,2.8vw,33px)', lineHeight: 1.15 }}>{dc.name || campaign.name}</h1>
               {valueLine && <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--rm-pine)', marginTop: 10 }}>{valueLine}</div>}
               <div className="rm-mono-note" style={{ fontSize: 11, marginTop: 6 }}>
-                {[ageLabel, soldOut ? 'fully redeemed' : dc.showCapacity && ops?.capacity ? `${ops.capacity.remaining} of ${ops.capacity.total} slots left` : 'Available'].filter(Boolean).join(' · ')}
+                {[ageLabel, unavailable ? UNAVAILABLE_COPY[unavailable].cta : dc.showCapacity && ops?.capacity ? `${ops.capacity.remaining} of ${ops.capacity.total} slots left` : 'Available'].filter(Boolean).join(' · ')}
               </div>
             </div>
 

--- a/src/pages/marketplace/MarketplaceOffer.jsx
+++ b/src/pages/marketplace/MarketplaceOffer.jsx
@@ -1,0 +1,328 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import MarketplaceLayout from './MarketplaceLayout';
+import OfferCard from './OfferCard';
+import { getMarketplaceCampaign, listMarketplaceCampaigns } from '@/api/marketplace';
+import { composeValueLine, ageLabelOf, fmtDateLong, categoryLabel, isDrawCampaign, boostOf } from './content';
+import { shouldTrack, initPixel, ensureFbp, trackEvent, captureFbcFromUrl, captureUtmsFromUrl } from '@/lib/metaPixel';
+import { shouldTrackTikTok, initTikTokPixel, trackTikTokViewContent, captureTtclidFromUrl } from '@/lib/tiktokPixel';
+import { getOrCreateVcState, markVcFired } from '@/lib/pixelSession';
+
+/**
+ * Offer detail (/offers/:slug) — the FIRST public content surface for
+ * marketplace traffic, so ViewContent fires here (session-guarded per
+ * campaign: navigating on to /flow reuses the same event_id and never
+ * re-fires). Attribution params (fbclid/ttclid/UTMs) are captured on THIS
+ * landing too, so a detail-first QR/ad click keeps attribution through to
+ * the flow submit.
+ */
+export default function MarketplaceOffer() {
+  const { slug } = useParams();
+  const navigate = useNavigate();
+  const [campaign, setCampaign] = useState(undefined); // undefined=loading, null=missing
+  const [related, setRelated] = useState([]);
+  const [faqOpen, setFaqOpen] = useState(-1);
+
+  useEffect(() => {
+    let alive = true;
+    setCampaign(undefined);
+    getMarketplaceCampaign(slug)
+      .then((c) => alive && setCampaign(c))
+      .catch(() => alive && setCampaign(null));
+    listMarketplaceCampaigns()
+      .then((cs) => alive && setRelated(cs))
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, [slug]);
+
+  // Attribution capture + session-guarded ViewContent.
+  useEffect(() => {
+    captureFbcFromUrl(window.location.search);
+    captureTtclidFromUrl(window.location.search);
+    captureUtmsFromUrl(window.location.search);
+  }, [slug]);
+
+  useEffect(() => {
+    if (!campaign) return;
+    const trackCtx = { campaign, pathname: window.location.pathname, search: window.location.search };
+    const vc = getOrCreateVcState(campaign.id);
+    if (!vc.firedMeta && shouldTrack(trackCtx)) {
+      const pixelId = campaign.metaPixelId || import.meta.env.VITE_META_PIXEL_ID;
+      if (pixelId) {
+        initPixel(pixelId);
+        ensureFbp();
+        trackEvent(
+          'ViewContent',
+          {
+            content_ids: [campaign.id],
+            content_name: campaign.name,
+            content_category: campaign.design_config?.category || 'marketplace',
+          },
+          { eventID: vc.eventId }
+        );
+        markVcFired(campaign.id, 'meta');
+      }
+    }
+    if (!vc.firedTiktok && shouldTrackTikTok(trackCtx)) {
+      const ttPixelId = campaign.tiktokPixelId || import.meta.env.VITE_TIKTOK_PIXEL_ID;
+      if (ttPixelId) {
+        initTikTokPixel(ttPixelId);
+        trackTikTokViewContent(
+          { content_name: campaign.name, content_type: 'marketplace' },
+          vc.eventId
+        );
+        markVcFired(campaign.id, 'tiktok');
+      }
+    }
+  }, [campaign]);
+
+  if (campaign === undefined) {
+    return (
+      <MarketplaceLayout>
+        <div className="rm-shell" style={{ padding: 'clamp(24px,3.5vw,40px) 0' }}>
+          <div className="rm-shimmer" style={{ height: 420, borderRadius: 22 }} />
+        </div>
+      </MarketplaceLayout>
+    );
+  }
+
+  if (campaign === null) {
+    return (
+      <MarketplaceLayout>
+        <div className="rm-shell" style={{ padding: 'clamp(24px,3.5vw,40px) 0 clamp(56px,7vw,88px)' }}>
+          <div className="rm-card" style={{ padding: '48px 28px', textAlign: 'center' }}>
+            <div className="rm-serif" style={{ fontSize: 26 }}>This campaign isn't available</div>
+            <div style={{ fontSize: 14, color: 'var(--rm-sub)', marginTop: 8 }}>It may have ended or the link is out of date.</div>
+            <Link className="rm-btn" to="/explore" style={{ marginTop: 18 }}>Explore live offers</Link>
+          </div>
+        </div>
+      </MarketplaceLayout>
+    );
+  }
+
+  const dc = campaign.design_config || {};
+  const ops = campaign.ops;
+  const partner = ops?.partner || {};
+  const act = dc.activation || {};
+  const isDraw = isDrawCampaign(campaign);
+  const boost = boostOf(campaign);
+  const soldOut = !ops || (ops.capacity && ops.capacity.total > 0 && ops.capacity.remaining <= 0);
+  const valueLine = composeValueLine(campaign);
+  const days = (dc.availability?.days || []).join(' · ');
+  const slots = (dc.availability?.slots || []).join(' / ');
+  const ageLabel = ageLabelOf(dc);
+  const locNames = (partner.locations || []).map((l) => l.name).filter(Boolean).join(' · ') || (dc.mode === 'online' ? 'Online — enter from anywhere' : '—');
+  const otpLabel = dc.otpChannel === 'whatsapp' ? 'WhatsApp' : 'SMS';
+  const relatedCards = related.filter((c) => c.slug !== slug).slice(0, 3);
+  const ctaLabel = soldOut ? (isDraw ? 'Draw closed' : 'Fully redeemed') : isDraw ? 'Enter the draw' : 'Redeem this offer';
+
+  return (
+    <MarketplaceLayout>
+      <div className="rm-shell" style={{ paddingTop: 'clamp(24px,3.5vw,40px)', paddingBottom: 'clamp(56px,7vw,88px)' }}>
+        <nav aria-label="Breadcrumb" className="rm-mono-note" style={{ fontSize: 11, marginBottom: 18 }}>
+          <Link to="/explore" style={{ color: 'var(--rm-mut)' }}>Explore</Link>
+          {' / '}
+          <Link to={`/c/${dc.category}`} style={{ color: 'var(--rm-mut)' }}>{categoryLabel(dc.category)}</Link>
+          {' / '}
+          <span style={{ color: 'var(--rm-ink)' }}>{dc.name || campaign.name}</span>
+        </nav>
+
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(min(100%,340px),1fr))', gap: 28, alignItems: 'start' }}>
+          {/* Left column */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 22 }}>
+            <div className="rm-arch" style={{ height: 300 }}>
+              {dc.imageUrl ? (
+                <img src={dc.imageUrl} alt={dc.image_label || dc.name || campaign.name} />
+              ) : (
+                <span className="rm-arch-tag">{dc.image_label || 'experience photo'}</span>
+              )}
+            </div>
+
+            {(dc.inclusions || []).length > 0 && (
+              <div className="rm-card rm-card--pad">
+                <div className="rm-mono-label" style={{ marginBottom: 12 }}>What's included</div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 9 }}>
+                  {dc.inclusions.map((inc) => (
+                    <div key={inc} style={{ display: 'flex', gap: 10, fontSize: 14 }}>
+                      <span style={{ color: 'var(--rm-pine)', fontWeight: 700 }}>✓</span>
+                      <span>{inc}</span>
+                    </div>
+                  ))}
+                </div>
+                {valueLine && (
+                  <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--rm-pine)', borderTop: '1px solid var(--rm-line)', marginTop: 14, paddingTop: 12 }}>{valueLine}</div>
+                )}
+              </div>
+            )}
+
+            <div className="rm-card rm-card--pad">
+              <div className="rm-mono-label" style={{ marginBottom: 14 }}>The details</div>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(200px,1fr))', gap: '16px 24px' }}>
+                <Detail label="When" value={isDraw ? (dc.luckyDraw?.closesAt ? `Entries close ${fmtDateLong(dc.luckyDraw.closesAt)}` : '—') : `${days}${slots ? ` — ${slots}` : ''}` || '—'} />
+                <Detail label="Where" value={locNames} />
+                <Detail label="Who it's for" value={`${ageLabel || 'Everyone'}${dc.sgPrOnly ? ' · Singapore Citizens & PRs' : ''}`} />
+                <Detail
+                  label="Availability"
+                  value={
+                    soldOut
+                      ? 'Fully redeemed'
+                      : `${dc.showCapacity && ops?.capacity ? `${ops.capacity.remaining} of ${ops.capacity.total} slots left` : 'Available'}${ops?.expiry ? ` · until ${fmtDateLong(ops.expiry)}` : ''}`
+                  }
+                />
+                <Detail label="Format" value={`${isDraw ? 'Lucky draw' : (dc.offer_type || 'offer').replace(/^./, (m) => m.toUpperCase())} · ${categoryLabel(dc.category)}`} />
+                <Detail label="Verification" value={`One-time code via ${otpLabel}`} />
+              </div>
+            </div>
+
+            {partner.name && (
+              <div className="rm-card rm-card--pad">
+                <div className="rm-mono-label" style={{ marginBottom: 10 }}>About {partner.name}</div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+                  {partner.verified && <span className="rm-verified">Verified partner</span>}
+                  {partner.since && <span className="rm-mono-note" style={{ fontSize: 10 }}>· on Redeem since {partner.since}</span>}
+                </div>
+                {partner.blurb && <div style={{ fontSize: 13.5, lineHeight: 1.6, color: 'var(--rm-sub)' }}>{partner.blurb}</div>}
+              </div>
+            )}
+
+            {isDraw && (
+              <div style={{ background: '#FDF3EA', border: '1.5px solid var(--rm-apr)', borderRadius: 18, padding: '22px 24px' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 9, marginBottom: 12 }}>
+                  <span className="rm-ticket" style={{ width: 11, height: 14, background: 'var(--rm-apr)' }} />
+                  <span className="rm-mono-label" style={{ color: 'var(--rm-apr2)', fontSize: 11 }}>How this draw works</span>
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 9, fontSize: 13.5, lineHeight: 1.6 }}>
+                  <DrawStep n="1">Sign up and verify your number — that's one chance in the draw.</DrawStep>
+                  {boost && (
+                    <DrawStep n="2">
+                      <strong>Boost:</strong> complete the activation step before {fmtDateLong(boost.boostClosesAt)} and your entry counts ×{boost.multiplier}.
+                    </DrawStep>
+                  )}
+                  <DrawStep n={boost ? '3' : '2'}>
+                    Entries close on {fmtDateLong(dc.luckyDraw?.closesAt)}.{dc.luckyDraw?.winners ? ` ${dc.luckyDraw.winners} winners are drawn within seven days.` : ' Winners are drawn within seven days.'}
+                  </DrawStep>
+                  <DrawStep n={boost ? '4' : '3'}>
+                    Winners are contacted at their verified number and listed (partially masked) on the <Link to="/winners" className="rm-underline">winners page</Link>.
+                  </DrawStep>
+                </div>
+                <div className="rm-mono-note" style={{ fontSize: 10, lineHeight: 1.6, borderTop: '1px dashed #F0CDB2', marginTop: 12, paddingTop: 10 }}>
+                  Entry requires accepting the campaign T&amp;Cs — the exact version you accept is recorded with your entry.
+                </div>
+              </div>
+            )}
+
+            {(dc.content_blocks?.data_use || dc.content_blocks?.cancellation) && (
+              <div style={{ border: '1px solid var(--rm-line)', borderRadius: 18, padding: '20px 24px', background: 'var(--rm-bg)' }}>
+                <div className="rm-mono-label" style={{ marginBottom: 10 }}>Your data &amp; cancellation</div>
+                {dc.content_blocks.data_use && <div style={{ fontSize: 13, lineHeight: 1.65, color: 'var(--rm-sub)' }}>{dc.content_blocks.data_use}</div>}
+                {dc.content_blocks.cancellation && <div style={{ fontSize: 13, lineHeight: 1.65, color: 'var(--rm-sub)', marginTop: 8 }}>{dc.content_blocks.cancellation}</div>}
+              </div>
+            )}
+
+            {(dc.content_blocks?.faq || []).length > 0 && (
+              <div className="rm-card" style={{ padding: '4px 24px 12px' }}>
+                {dc.content_blocks.faq.map((f, i) => (
+                  <div key={f.q} className="rm-faq-row" style={i === 0 ? { borderTop: 'none' } : undefined}>
+                    <button className="rm-faq-q" aria-expanded={faqOpen === i} onClick={() => setFaqOpen(faqOpen === i ? -1 : i)}>
+                      <span>{f.q}</span>
+                      <span className="rm-faq-sym">{faqOpen === i ? '−' : '+'}</span>
+                    </button>
+                    {faqOpen === i && <div className="rm-faq-a">{f.a}</div>}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Right column */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 18, position: 'sticky', top: 86 }}>
+            <div className="rm-card" style={{ padding: '24px 26px' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span className="rm-mono-label" style={{ fontSize: 10.5 }}>{partner.name}</span>
+                {partner.verified && <span className="rm-verified">Verified</span>}
+              </div>
+              <h1 className="rm-serif" style={{ margin: '10px 0 0', fontSize: 'clamp(26px,2.8vw,33px)', lineHeight: 1.15 }}>{dc.name || campaign.name}</h1>
+              {valueLine && <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--rm-pine)', marginTop: 10 }}>{valueLine}</div>}
+              <div className="rm-mono-note" style={{ fontSize: 11, marginTop: 6 }}>
+                {[ageLabel, soldOut ? 'fully redeemed' : dc.showCapacity && ops?.capacity ? `${ops.capacity.remaining} of ${ops.capacity.total} slots left` : 'Available'].filter(Boolean).join(' · ')}
+              </div>
+            </div>
+
+            <div style={{ background: '#F2F6EF', border: '1.5px solid var(--rm-pine)', borderRadius: 18, padding: '22px 24px', display: 'flex', flexDirection: 'column', gap: 13 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+                <span className="rm-ticket" style={{ width: 11, height: 14 }} />
+                <span className="rm-mono-label" style={{ color: 'var(--rm-pine)', fontSize: 11 }}>Before you redeem</span>
+              </div>
+              {act.detail && <div style={{ fontSize: 13.5, lineHeight: 1.65 }}>{act.detail}</div>}
+              {dc.sponsor?.disclosure && (
+                <div style={{ background: 'rgba(255,253,246,0.8)', border: '1px solid #CFDDD2', borderRadius: 11, padding: '11px 13px' }}>
+                  <div className="rm-mono-label" style={{ fontSize: 9, marginBottom: 4 }}>Sponsor disclosure</div>
+                  <div style={{ fontSize: 12, lineHeight: 1.55, color: 'var(--rm-sub)' }}>{dc.sponsor.disclosure}</div>
+                </div>
+              )}
+              {act.required && (
+                <div style={{ fontSize: 12, lineHeight: 1.55, color: 'var(--rm-mut)' }}>
+                  You'll confirm this requirement once, inside the redemption flow — nothing to tick here.
+                </div>
+              )}
+              <button
+                className={`rm-btn rm-btn--big${soldOut ? ' rm-btn--disabled' : ''}`}
+                disabled={soldOut}
+                onClick={() => !soldOut && navigate(`/flow/${campaign.slug}`)}
+              >
+                {ctaLabel}
+              </button>
+              <div className="rm-mono-note" style={{ fontSize: 10, textAlign: 'center' }}>
+                Verified by {otpLabel} one-time code · no account needed
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {relatedCards.length > 0 && (
+          <div style={{ marginTop: 44 }}>
+            <h2 className="rm-serif" style={{ margin: '0 0 18px', fontSize: 24 }}>Similar offers</h2>
+            <div className="rm-grid-cards">
+              {relatedCards.map((c) => <OfferCard key={c.slug} campaign={c} />)}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Mobile sticky CTA */}
+      <div className="rm-sticky-cta">
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 13, fontWeight: 700, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{dc.name || campaign.name}</div>
+          {valueLine && <div style={{ fontSize: 11.5, color: 'var(--rm-pine)', fontWeight: 600 }}>{valueLine}</div>}
+        </div>
+        <button
+          className={`rm-btn${soldOut ? ' rm-btn--disabled' : ''}`}
+          disabled={soldOut}
+          onClick={() => !soldOut && navigate(`/flow/${campaign.slug}`)}
+        >
+          {soldOut ? 'Unavailable' : isDraw ? 'Enter draw' : 'Redeem'}
+        </button>
+      </div>
+    </MarketplaceLayout>
+  );
+}
+
+function Detail({ label, value }) {
+  return (
+    <div>
+      <div className="rm-mono-label" style={{ fontSize: 9.5 }}>{label}</div>
+      <div style={{ fontSize: 13.5, lineHeight: 1.5, marginTop: 3 }}>{value}</div>
+    </div>
+  );
+}
+
+function DrawStep({ n, children }) {
+  return (
+    <div style={{ display: 'flex', gap: 10 }}>
+      <span style={{ color: 'var(--rm-apr2)', fontWeight: 700 }}>{n}</span>
+      <span>{children}</span>
+    </div>
+  );
+}

--- a/src/pages/marketplace/MarketplaceStatic.jsx
+++ b/src/pages/marketplace/MarketplaceStatic.jsx
@@ -1,0 +1,220 @@
+import { Link, useParams } from 'react-router-dom';
+import MarketplaceLayout from './MarketplaceLayout';
+import { HOW_STEPS, BIZ_PROPS, BIZ_STEPS, LEGAL_DOCS } from './content';
+
+/**
+ * Marketplace static pages — /how-it-works, /businesses, /about, /legal/:doc.
+ * One chunk (mode-switched). The businesses page is enquiry-by-email in v1
+ * (the public CRM-write endpoint was deliberately deferred — see
+ * docs/plans/redeem-marketplace-v2.md Phase 7).
+ */
+export default function MarketplaceStatic({ mode }) {
+  if (mode === 'businesses') return <BusinessesPage />;
+  if (mode === 'about') return <AboutPage />;
+  if (mode === 'legal') return <LegalPage />;
+  return <HowItWorksPage />;
+}
+
+function HowItWorksPage() {
+  return (
+    <MarketplaceLayout>
+      <div className="rm-shell rm-shell--narrow" style={{ paddingTop: 'clamp(32px,4.5vw,56px)', paddingBottom: 'clamp(48px,6vw,80px)' }}>
+        <h1 className="rm-serif" style={{ margin: 0, fontSize: 'clamp(30px,3.8vw,44px)' }}>How Redeem works</h1>
+        <p style={{ margin: '14px 0 30px', fontSize: 15, lineHeight: 1.65, color: 'var(--rm-sub)', maxWidth: '58ch' }}>
+          No account, no membership, no points. Three steps, start to finish.
+        </p>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+          {HOW_STEPS.map((h) => (
+            <div key={h.n} className="rm-card" style={{ display: 'flex', gap: 18, padding: '20px 22px', alignItems: 'flex-start', borderRadius: 16 }}>
+              <span style={{ width: 42, height: 42, borderRadius: '50%', background: 'var(--rm-pine)', color: '#F6F2E6', display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'var(--rm-mono)', fontSize: 14, flexShrink: 0 }}>{h.n}</span>
+              <div>
+                <div style={{ fontSize: 16, fontWeight: 700 }}>{h.t}</div>
+                <div style={{ fontSize: 13.5, lineHeight: 1.6, color: 'var(--rm-sub)', marginTop: 4 }}>{h.d}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div style={{ background: '#F2F6EF', border: '1.5px solid var(--rm-pine)', borderRadius: 18, padding: '24px 26px', marginTop: 28 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 9, marginBottom: 10 }}>
+            <span className="rm-ticket" style={{ width: 11, height: 14 }} />
+            <span className="rm-mono-label" style={{ color: 'var(--rm-pine)', fontSize: 11 }}>What's an activation requirement?</span>
+          </div>
+          <p style={{ margin: 0, fontSize: 14, lineHeight: 1.7, maxWidth: '70ch' }}>
+            Some offers ask you to complete one clearly stated step before the experience is confirmed — most commonly a 20-minute financial-planning conversation with a licensed consultant, whose sponsorship is what makes the offer free. It's always printed on the offer card and page <strong>before</strong> you give any details, and no purchase is ever required.
+          </p>
+        </div>
+        <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', marginTop: 26 }}>
+          <Link className="rm-btn rm-btn--big" to="/explore">Explore experiences</Link>
+          <Link className="rm-btn rm-btn--outline" to="/">Read the FAQ</Link>
+        </div>
+      </div>
+    </MarketplaceLayout>
+  );
+}
+
+function BusinessesPage() {
+  return (
+    <MarketplaceLayout>
+      <section style={{ background: 'var(--rm-pine)' }}>
+        <div className="rm-shell" style={{ padding: 'clamp(40px,6vw,72px) 0' }}>
+          <div className="rm-mono-label" style={{ color: '#A8C3B4' }}>For businesses</div>
+          <h1 className="rm-serif" style={{ margin: '12px 0 0', fontSize: 'clamp(30px,4vw,48px)', lineHeight: 1.1, color: '#F6F2E6', maxWidth: '20ch' }}>
+            Reach families already looking for you.
+          </h1>
+          <p style={{ margin: '14px 0 0', fontSize: 15.5, lineHeight: 1.65, color: '#CFE0D4', maxWidth: '58ch' }}>
+            Contribute trial or introductory capacity; receive OTP-verified, consented customers who chose your offer knowing every condition. Campaign pages, verification and lead routing are handled for you.
+          </p>
+          <a className="rm-btn rm-btn--apricot rm-btn--big" href="mailto:partnerships@redeem.sg?subject=Partner%20enquiry" style={{ marginTop: 24 }}>
+            Make an enquiry
+          </a>
+        </div>
+      </section>
+      <div className="rm-shell" style={{ paddingTop: 'clamp(32px,4.5vw,52px)', paddingBottom: 'clamp(48px,6vw,80px)', display: 'flex', flexDirection: 'column', gap: 36 }}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(260px,1fr))', gap: 18 }}>
+          {BIZ_PROPS.map((bp) => (
+            <div key={bp.t} className="rm-card" style={{ padding: '20px 22px', borderRadius: 16 }}>
+              <span className="rm-ticket" style={{ width: 11, height: 14 }} />
+              <div style={{ fontSize: 15, fontWeight: 700, marginTop: 10 }}>{bp.t}</div>
+              <div style={{ fontSize: 13, lineHeight: 1.6, color: 'var(--rm-sub)', marginTop: 5 }}>{bp.d}</div>
+            </div>
+          ))}
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(300px,1fr))', gap: 20 }}>
+          <div className="rm-card" style={{ padding: '24px 26px' }}>
+            <div className="rm-mono-label" style={{ marginBottom: 14 }}>How a campaign works</div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+              {BIZ_STEPS.map((bs) => (
+                <div key={bs.n} style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
+                  <span style={{ width: 26, height: 26, borderRadius: '50%', background: 'var(--rm-sage)', color: 'var(--rm-pine2)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: 'var(--rm-mono)', fontSize: 11, flexShrink: 0 }}>{bs.n}</span>
+                  <span style={{ fontSize: 13.5, lineHeight: 1.6, color: 'var(--rm-sub)' }}>
+                    <strong style={{ color: 'var(--rm-ink)' }}>{bs.t}</strong> — {bs.d}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div style={{ background: '#132720', borderRadius: 18, padding: '24px 26px' }}>
+            <div className="rm-mono-label" style={{ color: '#7E958A', marginBottom: 14 }}>Example campaign economics</div>
+            <div style={{ fontFamily: 'var(--rm-mono)', fontSize: 12, lineHeight: 2.1, color: '#C8D5CB' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}><span>You contribute</span><span style={{ color: '#F6F2E6' }}>20 trial-class slots</span></div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}><span>Sponsor funds</span><span style={{ color: '#F6F2E6' }}>consumer acquisition</span></div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}><span>You receive</span><span style={{ color: '#F6F2E6' }}>OTP-verified bookings</span></div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, borderTop: '1px solid rgba(200,213,203,0.2)', marginTop: 6, paddingTop: 8 }}><span>You pay for</span><span style={{ color: '#E4854F' }}>attended visits only</span></div>
+            </div>
+            <div style={{ fontSize: 12, lineHeight: 1.6, color: '#9DB3A3', marginTop: 14 }}>
+              Qualification options: age / level targeting, SC-PR screening, DNC checking, attendance confirmation. Exact terms are agreed per campaign.
+            </div>
+          </div>
+        </div>
+        <div className="rm-card" style={{ borderRadius: 22, padding: 'clamp(24px,4vw,40px)', display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(300px,1fr))', gap: 32, alignItems: 'center' }}>
+          <div>
+            <h2 className="rm-serif" style={{ margin: 0, fontSize: 'clamp(24px,2.8vw,30px)' }}>Partner enquiry</h2>
+            <p style={{ margin: '10px 0 0', fontSize: 14, lineHeight: 1.65, color: 'var(--rm-sub)' }}>
+              Tell us about your business and we'll reply within two working days with campaign options and economics. Onboarding covers business verification (ACRA, licensing where relevant) — most partners go live within two weeks.
+            </p>
+            <div className="rm-mono-note" style={{ fontSize: 10.5, lineHeight: 1.8, marginTop: 16 }}>
+              No dashboards or logins here — campaign operations run on our operator platform.
+            </div>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12, alignItems: 'flex-start' }}>
+            <a className="rm-btn rm-btn--big" href="mailto:partnerships@redeem.sg?subject=Partner%20enquiry&body=Business%20name%3A%0ACategory%3A%0AWhat%20we%27d%20like%20to%20run%3A%0AContact%20number%3A">
+              Email partnerships@redeem.sg
+            </a>
+            <div style={{ fontSize: 12.5, lineHeight: 1.6, color: 'var(--rm-sub)' }}>
+              Include your business name, category, and what you'd like to run — we take it from there.
+            </div>
+          </div>
+        </div>
+      </div>
+    </MarketplaceLayout>
+  );
+}
+
+function AboutPage() {
+  return (
+    <MarketplaceLayout>
+      <div className="rm-shell rm-shell--narrow" style={{ paddingTop: 'clamp(32px,4.5vw,56px)', paddingBottom: 'clamp(48px,6vw,80px)' }}>
+        <h1 className="rm-serif" style={{ margin: 0, fontSize: 'clamp(30px,3.8vw,44px)' }}>About Redeem</h1>
+        <p style={{ margin: '16px 0 0', fontSize: 15.5, lineHeight: 1.7, color: 'var(--rm-sub)', maxWidth: '62ch' }}>
+          Redeem exists so Singapore consumers can try worthwhile experiences — enrichment classes, assessments, wellness sessions, dining and useful rewards — from verified local businesses, with every condition stated before any details change hands.
+        </p>
+        <p style={{ margin: '12px 0 0', fontSize: 15.5, lineHeight: 1.7, color: 'var(--rm-sub)', maxWidth: '62ch' }}>
+          Offers are funded by the businesses themselves and, for selected campaigns, by licensed financial consultants who sponsor them. That sponsorship is always disclosed on the offer — it's the reason the experience is free, never a hidden catch.
+        </p>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(280px,1fr))', gap: 18, marginTop: 30 }}>
+          <div className="rm-card rm-card--pad" style={{ borderRadius: 16 }}>
+            <div className="rm-mono-label" style={{ marginBottom: 10 }}>The company</div>
+            <div style={{ fontSize: 14, lineHeight: 1.7 }}>
+              Redeem.sg is the consumer brand of <strong>MKTR PTE. LTD.</strong>
+              <br />
+              <span className="rm-mono-note" style={{ fontSize: 11.5 }}>UEN 202507548M · Registered in Singapore</span>
+            </div>
+            <div style={{ fontSize: 13, lineHeight: 1.6, color: 'var(--rm-sub)', marginTop: 8 }}>
+              Campaign operations, lead management and partner tooling run on a separate operator platform — this site is purely for consumers and prospective partners.
+            </div>
+          </div>
+          <div className="rm-card rm-card--pad" style={{ borderRadius: 16 }}>
+            <div className="rm-mono-label" style={{ marginBottom: 10 }}>How partners are verified</div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, fontSize: 13.5, lineHeight: 1.6, color: 'var(--rm-sub)' }}>
+              {[
+                'ACRA business-registration check',
+                'Licensing checks where the vertical requires them',
+                'Venue and offer accuracy review before launch',
+                'Ongoing review — complaints can suspend a partnership',
+              ].map((s, i) => (
+                <div key={s} style={{ display: 'flex', gap: 9 }}>
+                  <span style={{ color: 'var(--rm-pine)', fontWeight: 700 }}>{i + 1}</span><span>{s}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+        <div className="rm-card rm-card--pad" style={{ borderRadius: 16, marginTop: 18 }}>
+          <div className="rm-mono-label" style={{ marginBottom: 10 }}>Consumer-protection principles</div>
+          <div style={{ fontSize: 13.5, lineHeight: 1.8, color: 'var(--rm-sub)' }}>
+            Conditions before contact details, always · one redemption per person · real capacity and expiry only · consent recorded with every submission · DNC registry respected · no-hard-sell terms written into sponsored campaigns · support that answers: <a className="rm-underline" href="mailto:support@redeem.sg">support@redeem.sg</a>
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', marginTop: 24, fontSize: 13.5, fontWeight: 600 }}>
+          <Link className="rm-underline" to="/personal-data-policy">Personal Data Protection Policy</Link>
+          <span style={{ color: 'var(--rm-line2)' }}>·</span>
+          <Link className="rm-underline" to="/legal/terms">Terms of use</Link>
+          <span style={{ color: 'var(--rm-line2)' }}>·</span>
+          <Link className="rm-underline" to="/legal/dnc">DNC information</Link>
+        </div>
+      </div>
+    </MarketplaceLayout>
+  );
+}
+
+function LegalPage() {
+  const { doc } = useParams();
+  const legal = LEGAL_DOCS[doc] || LEGAL_DOCS.terms;
+  return (
+    <MarketplaceLayout>
+      <div className="rm-shell rm-shell--narrow" style={{ maxWidth: 760, paddingTop: 'clamp(32px,4.5vw,56px)', paddingBottom: 'clamp(48px,6vw,80px)' }}>
+        <h1 className="rm-serif" style={{ margin: 0, fontSize: 'clamp(26px,3.2vw,38px)' }}>{legal.title}</h1>
+        <div style={{ display: 'inline-block', fontFamily: 'var(--rm-mono)', fontSize: 10, letterSpacing: '0.08em', textTransform: 'uppercase', color: '#7A5A1C', background: '#F8EED3', border: '1px solid #E8D9AE', borderRadius: 999, padding: '5px 12px', marginTop: 12 }}>
+          {legal.updated}
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 20, marginTop: 28 }}>
+          {legal.blocks.map((b) => (
+            <div key={b.h} className="rm-card" style={{ borderRadius: 14, padding: '20px 24px' }}>
+              <h2 style={{ margin: 0, fontSize: 16, fontWeight: 700 }}>{b.h}</h2>
+              <p style={{ margin: '8px 0 0', fontSize: 14, lineHeight: 1.7, color: 'var(--rm-sub)' }}>{b.body}</p>
+            </div>
+          ))}
+        </div>
+        <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', marginTop: 26, fontSize: 13 }}>
+          <Link className="rm-underline" to="/personal-data-policy">PDPA Policy</Link>
+          <span style={{ color: 'var(--rm-line2)' }}>·</span>
+          <Link className="rm-underline" to="/leads/privacy">Leads privacy</Link>
+          <span style={{ color: 'var(--rm-line2)' }}>·</span>
+          <Link className="rm-underline" to="/legal/terms">Terms</Link>
+          <span style={{ color: 'var(--rm-line2)' }}>·</span>
+          <Link className="rm-underline" to="/legal/dnc">DNC</Link>
+        </div>
+      </div>
+    </MarketplaceLayout>
+  );
+}

--- a/src/pages/marketplace/OfferCard.jsx
+++ b/src/pages/marketplace/OfferCard.jsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { composeValueLine, ageLabelOf, fmtDateShort, isDrawCampaign, boostOf } from './content';
+import { composeValueLine, ageLabelOf, fmtDateShort, isDrawCampaign, boostOf, offerUnavailability } from './content';
 
 /**
  * Marketplace offer card (OfferCardV2 spec): reads the two-layer campaign DTO
@@ -13,7 +13,7 @@ export default function OfferCard({ campaign }) {
   const act = dc.activation || {};
   const isDraw = isDrawCampaign(campaign);
   const boost = boostOf(campaign);
-  const soldOut = ops.capacity && ops.capacity.total > 0 && ops.capacity.remaining <= 0;
+  const unavailable = offerUnavailability(campaign);
 
   const areas = [...new Set((partner.locations || []).map((l) => l.area).filter(Boolean))];
   const locLabel = areas.length > 2 ? `${areas[0]} +${areas.length - 1}` : areas.join(' · ');
@@ -24,9 +24,10 @@ export default function OfferCard({ campaign }) {
 
   const facts = [];
   if (isDraw) {
-    if (dc.luckyDraw?.closesAt) facts.push(`closes ${fmtDateShort(dc.luckyDraw.closesAt)}`);
+    if (unavailable === 'draw_closed') facts.push('draw closed');
+    else if (dc.luckyDraw?.closesAt) facts.push(`closes ${fmtDateShort(dc.luckyDraw.closesAt)}`);
   } else {
-    if (soldOut) facts.push('fully redeemed');
+    if (unavailable) facts.push(unavailable === 'sold_out' ? 'fully redeemed' : 'unavailable');
     else if (dc.showCapacity && ops.capacity) facts.push(`${ops.capacity.remaining} left`);
     if (ops.expiry) facts.push(`ends ${fmtDateShort(ops.expiry)}`);
   }

--- a/src/pages/marketplace/OfferCard.jsx
+++ b/src/pages/marketplace/OfferCard.jsx
@@ -1,0 +1,100 @@
+import { useNavigate } from 'react-router-dom';
+import { composeValueLine, ageLabelOf, fmtDateShort, isDrawCampaign, boostOf } from './content';
+
+/**
+ * Marketplace offer card (OfferCardV2 spec): reads the two-layer campaign DTO
+ * strictly — design_config (authored) + ops (derived, read-only).
+ */
+export default function OfferCard({ campaign }) {
+  const navigate = useNavigate();
+  const dc = campaign.design_config || {};
+  const ops = campaign.ops || {};
+  const partner = ops.partner || {};
+  const act = dc.activation || {};
+  const isDraw = isDrawCampaign(campaign);
+  const boost = boostOf(campaign);
+  const soldOut = ops.capacity && ops.capacity.total > 0 && ops.capacity.remaining <= 0;
+
+  const areas = [...new Set((partner.locations || []).map((l) => l.area).filter(Boolean))];
+  const locLabel = areas.length > 2 ? `${areas[0]} +${areas.length - 1}` : areas.join(' · ');
+  const modeLabel = dc.mode === 'hybrid' ? 'in-person / online' : dc.mode === 'online' ? 'online' : 'in-person';
+  const metaLine = [ageLabelOf(dc), locLabel, modeLabel].filter(Boolean).join(' · ');
+  const inc = dc.inclusions || [];
+  const incLine = inc.slice(0, 3).join(', ') + (inc.length > 3 ? ` +${inc.length - 3}` : '');
+
+  const facts = [];
+  if (isDraw) {
+    if (dc.luckyDraw?.closesAt) facts.push(`closes ${fmtDateShort(dc.luckyDraw.closesAt)}`);
+  } else {
+    if (soldOut) facts.push('fully redeemed');
+    else if (dc.showCapacity && ops.capacity) facts.push(`${ops.capacity.remaining} left`);
+    if (ops.expiry) facts.push(`ends ${fmtDateShort(ops.expiry)}`);
+  }
+
+  return (
+    <div
+      className="rm-card rm-offercard"
+      role="link"
+      tabIndex={0}
+      onClick={() => navigate(`/offers/${campaign.slug}`)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          navigate(`/offers/${campaign.slug}`);
+        }
+      }}
+    >
+      <div className="rm-offercard-img">
+        {dc.imageUrl && <img src={dc.imageUrl} alt={dc.image_label || dc.name || campaign.name} loading="lazy" />}
+        {isDraw && (
+          <span style={{ position: 'absolute', top: 14, left: '50%', transform: 'translateX(-50%)', fontFamily: 'var(--rm-mono)', fontSize: 9, letterSpacing: '0.1em', textTransform: 'uppercase', background: 'var(--rm-apr)', color: '#2A1608', borderRadius: 999, padding: '5px 12px', whiteSpace: 'nowrap' }}>
+            Lucky draw
+          </span>
+        )}
+        {!dc.imageUrl && <span className="rm-arch-tag">{dc.image_label || 'experience photo'}</span>}
+      </div>
+      <div className="rm-offercard-body">
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span className="rm-mono-label" style={{ fontSize: 10 }}>{partner.name}</span>
+          {partner.verified && <span className="rm-verified">Verified</span>}
+        </div>
+        <div className="rm-serif" style={{ fontSize: 19, fontWeight: 600, lineHeight: 1.22 }}>{dc.name || campaign.name}</div>
+        {metaLine && <div className="rm-mono-note">{metaLine}</div>}
+        {incLine && <div style={{ fontSize: 12.5, lineHeight: 1.5, color: 'var(--rm-sub)' }}>Includes: {incLine}</div>}
+        {isDraw ? (
+          <div className="rm-draw-box">
+            <span style={{ display: 'inline-block', width: 9, height: 12, borderRadius: '5px 5px 1px 1px', background: 'var(--rm-apr)', marginTop: 2, flexShrink: 0 }} />
+            <span style={{ fontSize: 11.5, lineHeight: 1.45, color: '#6B3A1B' }}>
+              <strong style={{ fontFamily: 'var(--rm-mono)', fontSize: 9.5, letterSpacing: '0.08em', textTransform: 'uppercase' }}>Lucky draw</strong>
+              <br />
+              Verified sign-up = 1 chance{boost ? ` · boost ×${boost.multiplier} by completing the activation step` : ''}.
+            </span>
+          </div>
+        ) : act.required ? (
+          <div className="rm-req-box">
+            <span style={{ display: 'inline-block', width: 9, height: 12, borderRadius: '5px 5px 1px 1px', background: 'var(--rm-pine)', marginTop: 2, flexShrink: 0 }} />
+            <span style={{ fontSize: 11.5, lineHeight: 1.45, color: 'var(--rm-pine2)' }}>
+              <strong style={{ fontFamily: 'var(--rm-mono)', fontSize: 9.5, letterSpacing: '0.08em', textTransform: 'uppercase' }}>Requires</strong>
+              <br />
+              {act.summary}
+            </span>
+          </div>
+        ) : (
+          <div style={{ border: '1px solid var(--rm-line)', background: 'var(--rm-bg)', borderRadius: 9, padding: '8px 10px', fontSize: 11.5, lineHeight: 1.45, color: 'var(--rm-sub)' }}>
+            <strong className="rm-mono-label" style={{ fontSize: 9.5 }}>No added requirement</strong>
+            <br />
+            Just attend your booked slot.
+          </div>
+        )}
+        <div style={{ marginTop: 'auto', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, paddingTop: 6 }}>
+          <span style={{ fontSize: 12.5, fontWeight: 700, color: 'var(--rm-pine)' }}>{composeValueLine(campaign)}</span>
+          <span className="rm-mono-note" style={{ fontSize: 10, textAlign: 'right' }}>{facts.join(' · ')}</span>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', borderTop: '1px solid var(--rm-line)', paddingTop: 10, marginTop: 2 }}>
+          <span style={{ fontSize: 13, fontWeight: 600 }}>{isDraw ? 'View draw' : 'View offer'}</span>
+          <span style={{ color: 'var(--rm-apr)', fontWeight: 700 }}>→</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/marketplace/__tests__/marketplaceFlow.test.js
+++ b/src/pages/marketplace/__tests__/marketplaceFlow.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
-import { flattenFieldOrder } from '../MarketplaceFlow';
+import { flattenFieldOrder, isFieldVisible, isFieldRequired, dobToIso } from '../MarketplaceFlow';
+import { offerUnavailability } from '../content';
 import { isTrackableLeadCapture } from '@/lib/pixelSuppression';
 
 describe('flattenFieldOrder — both production fieldOrder shapes', () => {
@@ -25,6 +26,71 @@ describe('flattenFieldOrder — both production fieldOrder shapes', () => {
 
   test('junk entries are ignored', () => {
     expect(flattenFieldOrder([{ id: 'x' }, 42, { columns: ['email', 7] }])).toEqual(['email']);
+  });
+});
+
+describe('field visibility/required — live-form parity (CampaignSignupForm submit validation)', () => {
+  test('name/phone/email are always visible and required', () => {
+    for (const f of ['name', 'phone', 'email']) {
+      expect(isFieldVisible(f, { [f]: false })).toBe(true);
+      expect(isFieldRequired(f, {})).toBe(true);
+    }
+  });
+
+  test('dob/postal render unless hidden but are optional unless required===true', () => {
+    for (const f of ['dob', 'postal_code']) {
+      expect(isFieldVisible(f, {})).toBe(true);
+      expect(isFieldVisible(f, { [f]: false })).toBe(false);
+      expect(isFieldRequired(f, {})).toBe(false);
+      expect(isFieldRequired(f, { [f]: 'optional' })).toBe(false);
+      expect(isFieldRequired(f, { [f]: true })).toBe(true);
+    }
+  });
+
+  test('education/income are opt-IN visible (an empty config never shows them)', () => {
+    for (const f of ['education_level', 'monthly_income']) {
+      expect(isFieldVisible(f, {})).toBe(false);
+      expect(isFieldVisible(f, { [f]: true })).toBe(true);
+      expect(isFieldRequired(f, {})).toBe(false);
+    }
+  });
+
+  test('marketplace extras (child/prefs) are opt-in on both axes', () => {
+    expect(isFieldVisible('child_name', {})).toBe(false);
+    expect(isFieldVisible('child_name', { child_name: true })).toBe(true);
+    expect(isFieldRequired('child_name', { child_name: true })).toBe(true);
+  });
+});
+
+describe('dobToIso — API contract is YYYY-MM-DD', () => {
+  test('converts the display mask; passes empties/partials through as empty', () => {
+    expect(dobToIso('14/03/1988')).toBe('1988-03-14');
+    expect(dobToIso('')).toBe('');
+    expect(dobToIso('14/03')).toBe('');
+  });
+});
+
+describe('offerUnavailability — the flow must refuse what the pipeline cannot service', () => {
+  const base = (over = {}) => ({
+    design_config: {},
+    ops: { capacity: { total: 40, remaining: 10 } },
+    ...over,
+  });
+
+  test('serviceable offer → null', () => {
+    expect(offerUnavailability(base())).toBeNull();
+  });
+
+  test('null ops / sold out / zero-allocation are unavailable', () => {
+    expect(offerUnavailability(base({ ops: null }))).toBe('unserviceable');
+    expect(offerUnavailability(base({ ops: { capacity: { total: 10, remaining: 0 } } }))).toBe('sold_out');
+    expect(offerUnavailability(base({ ops: { capacity: { total: 0, remaining: 0 } } }))).toBe('sold_out');
+  });
+
+  test('draws past their SGT cutoff are closed even with capacity left', () => {
+    const past = { design_config: { luckyDraw: { enabled: true, closesAt: '2026-07-01' } }, ops: { capacity: { total: 100, remaining: 50 } } };
+    expect(offerUnavailability(past, new Date('2026-07-14T00:00:00Z'))).toBe('draw_closed');
+    expect(offerUnavailability(past, new Date('2026-07-01T10:00:00Z'))).toBeNull();
   });
 });
 

--- a/src/pages/marketplace/__tests__/marketplaceFlow.test.js
+++ b/src/pages/marketplace/__tests__/marketplaceFlow.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'vitest';
+import { flattenFieldOrder } from '../MarketplaceFlow';
+import { isTrackableLeadCapture } from '@/lib/pixelSuppression';
+
+describe('flattenFieldOrder — both production fieldOrder shapes', () => {
+  test('legacy flat string[] passes through', () => {
+    expect(flattenFieldOrder(['name', 'phone', 'email'])).toEqual(['name', 'phone', 'email']);
+  });
+
+  test('designer row objects {id, columns[]} flatten in order (multi-column rows included)', () => {
+    expect(
+      flattenFieldOrder([
+        { id: 'r1', columns: ['name'] },
+        { id: 'r2', columns: ['phone', 'email'] },
+        { id: 'r3', columns: ['dob'] },
+      ])
+    ).toEqual(['name', 'phone', 'email', 'dob']);
+  });
+
+  test('missing/empty config falls back to the full production field set', () => {
+    const fallback = ['name', 'phone', 'email', 'dob', 'postal_code', 'education_level', 'monthly_income'];
+    expect(flattenFieldOrder(undefined)).toEqual(fallback);
+    expect(flattenFieldOrder([])).toEqual(fallback);
+  });
+
+  test('junk entries are ignored', () => {
+    expect(flattenFieldOrder([{ id: 'x' }, 42, { columns: ['email', 7] }])).toEqual(['email']);
+  });
+});
+
+describe('pixel suppression — marketplace routes', () => {
+  test('offer detail and flow are trackable; browse and reward pass stay suppressed', () => {
+    expect(isTrackableLeadCapture({ pathname: '/offers/visual-arts-discovery' })).toBe(true);
+    expect(isTrackableLeadCapture({ pathname: '/flow/visual-arts-discovery' })).toBe(true);
+    expect(isTrackableLeadCapture({ pathname: '/LeadCapture' })).toBe(true);
+    expect(isTrackableLeadCapture({ pathname: '/explore' })).toBe(false);
+    expect(isTrackableLeadCapture({ pathname: '/' })).toBe(false);
+    expect(isTrackableLeadCapture({ pathname: '/r/some-token' })).toBe(false);
+    expect(isTrackableLeadCapture({ pathname: '/offers/' })).toBe(false);
+    expect(isTrackableLeadCapture({ pathname: '/offers/x/edit' })).toBe(false);
+  });
+
+  test('preview + test-data suppressions still apply on marketplace routes', () => {
+    expect(isTrackableLeadCapture({ pathname: '/offers/some-offer', search: '?preview=true' })).toBe(false);
+    expect(isTrackableLeadCapture({ pathname: '/flow/some-offer', campaign: { is_test_data: true } })).toBe(false);
+  });
+});

--- a/src/pages/marketplace/content.js
+++ b/src/pages/marketplace/content.js
@@ -154,6 +154,34 @@ export function fmtDateShort(iso) {
 
 export const isDrawCampaign = (campaign) => campaign?.design_config?.luckyDraw?.enabled === true;
 
+/**
+ * Why an offer can't be redeemed right now, or null when it can.
+ * 'draw_closed'   — draw entry cutoff passed (intake would 410; SGT day-end,
+ *                   mirroring the backend's sgtDayEndExclusiveMs gate)
+ * 'sold_out'      — no remaining capacity (zero-allocation activations
+ *                   included: they can never issue a reward)
+ * 'unserviceable' — ops chain unresolvable (activation/offer paused, expired)
+ * Used by the card, the detail CTA AND the flow — the flow must never accept
+ * submissions the pipeline can't service.
+ */
+export function offerUnavailability(campaign, now = new Date()) {
+  const dc = campaign?.design_config || {};
+  if (dc.luckyDraw?.enabled === true && dc.luckyDraw.closesAt) {
+    const end = new Date(`${dc.luckyDraw.closesAt}T23:59:59.999+08:00`);
+    if (!Number.isNaN(end.getTime()) && now > end) return 'draw_closed';
+  }
+  const ops = campaign?.ops;
+  if (!ops) return 'unserviceable';
+  if (ops.capacity && ops.capacity.remaining <= 0) return 'sold_out';
+  return null;
+}
+
+export const UNAVAILABLE_COPY = {
+  draw_closed: { cta: 'Draw closed', title: 'This draw has closed', body: 'Entries are no longer being accepted. Winners are contacted directly and listed on the winners page.' },
+  sold_out: { cta: 'Fully redeemed', title: 'This offer is fully redeemed', body: 'All available slots have been claimed. New campaigns launch weekly.' },
+  unserviceable: { cta: 'Currently unavailable', title: "This offer isn't available right now", body: 'It may have ended or been paused. Plenty of other offers are live.' },
+};
+
 /** Boost tier facts — luckyDraw (authored dates) + ops.draw (live Draw row). */
 export function boostOf(campaign) {
   const ld = campaign?.design_config?.luckyDraw;

--- a/src/pages/marketplace/content.js
+++ b/src/pages/marketplace/content.js
@@ -1,0 +1,166 @@
+/**
+ * Marketplace static content + display helpers (from the approved
+ * claude.ai/design Prototype v2). Categories mirror the backend consumer
+ * taxonomy (backend/src/utils/marketplaceContent.js CONSUMER_CATEGORIES) —
+ * change them together.
+ */
+
+export const CATEGORIES = [
+  { id: 'art_creativity', label: 'Art & Creativity', group: 'education', blurb: 'Drawing, painting and portfolio discovery' },
+  { id: 'coding_robotics', label: 'Coding & Robotics', group: 'education', blurb: 'Build, program and problem-solve' },
+  { id: 'speech_performance', label: 'Speech & Performance', group: 'education', blurb: 'Confidence on stage and in class' },
+  { id: 'sports_movement', label: 'Sports & Movement', group: 'education', blurb: 'Swim, play and move well' },
+  { id: 'music_dance', label: 'Music & Dance', group: 'education', blurb: 'Instruments, voice and rhythm' },
+  { id: 'academic', label: 'Academic', group: 'education', blurb: 'Diagnostics and subject support' },
+  { id: 'family_lifestyle', label: 'Family & Lifestyle', group: 'lifestyle', blurb: 'Experiences to share together' },
+  { id: 'wellness', label: 'Wellness', group: 'lifestyle', blurb: 'Self-care that earns its slot' },
+  { id: 'dining', label: 'Dining', group: 'lifestyle', blurb: 'Tables worth booking' },
+  { id: 'financial_education', label: 'Financial Education', group: 'lifestyle', blurb: 'Understand your money better' },
+];
+
+export const categoryLabel = (id) => CATEGORIES.find((c) => c.id === id)?.label || id;
+
+export const HOW_STEPS = [
+  { n: '1', t: 'Discover and submit interest', d: 'Browse experiences from verified Singapore partners, check the details and any activation requirement, then submit and verify your number with a one-time code.' },
+  { n: '2', t: 'Complete the activation step', d: "If the campaign has one — for example a 20-minute financial-planning conversation — complete it. It's always stated before you submit, and no purchase is ever required." },
+  { n: '3', t: 'Enjoy your experience', d: "The partner confirms your slot. Show up and enjoy — that's it." },
+];
+
+export const TRUST_POINTS = [
+  { t: 'Verified Singapore businesses', d: 'Registration, licensing and venues checked before a partner can list.' },
+  { t: 'OTP-verified redemptions', d: 'Every submission is confirmed by a one-time code — no bots, no duplicates.' },
+  { t: 'Clear activation conditions', d: 'Any requirement is on the offer card and page before you submit. Always.' },
+  { t: 'No membership, no card', d: 'Free to use. No points to collect, nothing to subscribe to.' },
+  { t: 'Consent you control', d: 'Plain-language consent choices, including Do-Not-Call protection.' },
+  { t: 'Real availability only', d: 'Capacity and expiry shown are real. No fake countdowns, ever.' },
+];
+
+export const HOME_FAQ = [
+  { q: 'Is Redeem really free to use?', a: 'Yes. Offers are funded by the businesses themselves and, for selected campaigns, by licensed financial consultants who sponsor them. You never pay Redeem anything.' },
+  { q: "What's the catch with sponsored offers?", a: "There isn't a hidden one — the condition is printed on the offer before you give any details. Sponsored campaigns ask you to complete one clearly stated step, most commonly a 20-minute financial-planning conversation. No purchase is ever required." },
+  { q: 'Why do you need my phone number?', a: "It's how we verify you're a real person (one-time code) and how the partner confirms your booking. One redemption per person keeps offers honest for everyone." },
+  { q: 'Will I get marketing calls?', a: 'Only what you consent to. Contact consent is a choice you control at submission, and numbers on the Do-Not-Call registry get an extra explicit consent step.' },
+  { q: 'Who is behind Redeem?', a: 'Redeem.sg is the consumer brand of MKTR PTE. LTD. (UEN 202507548M), registered in Singapore.' },
+  { q: 'How do lucky draws work?', a: 'Sign up and verify your number — one entry per person. Some draws let you multiply your entry by completing the activation step before the boost deadline. Winners are contacted directly and listed (partially masked) on the winners page.' },
+];
+
+export const DSA_CONTENT = {
+  talents: ['Art', 'Music', 'Sports', 'STEM & Robotics', 'Debate & Oratory', 'Drama', 'Dance', 'Leadership', 'Languages'],
+  prep: [
+    'Portfolio or audition preparation in the talent area',
+    'Trial sessions to confirm genuine interest before committing',
+    'Skill assessments that identify strengths and gaps',
+    'Interview confidence and communication practice',
+  ],
+  evaluate: [
+    'Verified business registration and teaching credentials',
+    'Structured feedback after trials — not just "it went well"',
+    'Transparent pricing for anything beyond the free session',
+    'No admission guarantees — schools decide, full stop',
+    'Willingness to say a programme is NOT a fit',
+  ],
+  questions: [
+    'What does progress look like after three months?',
+    'How do you assess whether my child has an aptitude here?',
+    'What proportion of your students continue after the trial?',
+    'What would make you advise us not to continue?',
+  ],
+};
+
+export const BIZ_PROPS = [
+  { t: 'Fill unused capacity', d: 'Turn empty trial-class seats and appointment slots into booked, confirmed visits.' },
+  { t: 'Qualified, verified customers', d: 'Every redemption is OTP-verified and consented — no bot lists, no cold data.' },
+  { t: 'Campaigns without the build', d: 'Offer pages, forms, verification and consent handling are our infrastructure, not your project.' },
+  { t: 'Conditions shown up front', d: 'Customers arrive knowing the offer, the value and any requirement — better attendance, better conversations.' },
+  { t: 'Outcome-based economics', d: 'Structure around attended visits or qualified leads — agreed per campaign, not per click.' },
+  { t: 'A brand-safe environment', d: 'Verified partners only, no fake urgency, clear consumer protections you can point to.' },
+];
+
+export const BIZ_STEPS = [
+  { n: '1', t: 'Scope the offer', d: 'you define capacity, audience and any qualification rules with us.' },
+  { n: '2', t: 'We build the campaign', d: 'page, form config, OTP channel and disclosures set up on our side.' },
+  { n: '3', t: 'Verified redemptions arrive', d: 'routed to you with consent records attached.' },
+  { n: '4', t: 'You fulfil and confirm', d: 'host the visit, mark attendance, and settle on agreed outcomes.' },
+];
+
+export const LEGAL_DOCS = {
+  terms: {
+    title: 'Terms of use',
+    updated: 'Updated 14 July 2026',
+    blocks: [
+      { h: 'What Redeem is', body: 'Redeem.sg lists experiences and rewards from verified Singapore businesses. Redeem is operated by MKTR PTE. LTD. (UEN 202507548M). We are the campaign operator — the experience itself is provided by the named partner.' },
+      { h: 'One redemption per person', body: 'Each offer is limited to one redemption per verified person unless the offer states otherwise. Duplicate submissions are not recorded.' },
+      { h: 'Activation requirements', body: 'Some campaigns require one clearly stated step (for example a sponsored financial-planning conversation) before the experience is confirmed. The requirement is always shown before you submit any details. No purchase is ever required.' },
+      { h: 'Campaign terms', body: "Individual campaigns (including lucky draws) carry their own terms, shown at submission. The version you accept is recorded with your entry." },
+      { h: 'Fair use', body: 'We may decline or cancel redemptions that are fraudulent, automated, or abusive. Partners may reschedule sessions with reasonable notice.' },
+    ],
+  },
+  dnc: {
+    title: 'DNC information',
+    updated: 'Updated 14 July 2026',
+    blocks: [
+      { h: 'We respect the Do-Not-Call registry', body: "If your verified number is registered on Singapore's DNC registry, we tell you during submission and ask for explicit, campaign-specific consent before the partner or sponsor may contact you about it." },
+      { h: 'Declining is fine', body: 'If you decline, we simply do not proceed with that campaign — your DNC registration stays fully respected and nothing is stored beyond the attempt.' },
+      { h: 'Withdrawing consent', body: 'You can withdraw consent at any time by writing to support@redeem.sg — we action withdrawals within 5 working days.' },
+    ],
+  },
+  'leads-privacy': {
+    title: 'Leads privacy',
+    updated: 'Updated 14 July 2026',
+    blocks: [
+      { h: 'What we collect', body: 'The details you submit on an offer (name, verified mobile number, email, and any campaign-specific fields shown on the form), plus your consent choices.' },
+      { h: 'How they are used', body: 'To arrange your redemption with the named partner and, only with your explicit third-party consent, with the sponsoring consultant. Consent records are stored with every submission.' },
+      { h: 'Where they go', body: 'Your details are delivered to the partner fulfilling your redemption through our operator platform. We never sell your data.' },
+      { h: 'Your rights', body: 'Ask for access, correction, or deletion any time: support@redeem.sg. See the full Personal Data Protection Policy for details.' },
+    ],
+  },
+};
+
+/* ---------- Display helpers (design_config + ops) ---------- */
+
+export function composeValueLine(campaign) {
+  const dc = campaign?.design_config || {};
+  const ops = campaign?.ops;
+  if (dc.value_line) return dc.value_line;
+  if (!ops || ops.retail_value == null) return null;
+  return `Worth S$${ops.retail_value}${dc.activation?.required ? ' · free with activation' : ' · free'}`;
+}
+
+export function ageLabelOf(dc = {}) {
+  const lv = dc.school_levels || [];
+  const ar = dc.age_range || {};
+  if (lv.length) return lv.length > 1 ? `${lv[0]}–${lv[lv.length - 1]}` : lv[0];
+  if (ar.min == null) return null;
+  if (ar.max >= 99) return ar.min >= 21 ? 'Adults (21+)' : `Ages ${ar.min}+`;
+  return `Ages ${ar.min}–${ar.max}`;
+}
+
+const MONTHS_LONG = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+const MONTHS_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+export function fmtDateLong(iso) {
+  if (!iso) return '';
+  const d = new Date(String(iso).length > 10 ? iso : `${iso}T00:00:00`);
+  if (Number.isNaN(d.getTime())) return '';
+  return `${d.getDate()} ${MONTHS_LONG[d.getMonth()]} ${d.getFullYear()}`;
+}
+
+export function fmtDateShort(iso) {
+  if (!iso) return '';
+  const d = new Date(String(iso).length > 10 ? iso : `${iso}T00:00:00`);
+  if (Number.isNaN(d.getTime())) return '';
+  return `${d.getDate()} ${MONTHS_SHORT[d.getMonth()]}`;
+}
+
+export const isDrawCampaign = (campaign) => campaign?.design_config?.luckyDraw?.enabled === true;
+
+/** Boost tier facts — luckyDraw (authored dates) + ops.draw (live Draw row). */
+export function boostOf(campaign) {
+  const ld = campaign?.design_config?.luckyDraw;
+  const draw = campaign?.ops?.draw;
+  if (!ld?.enabled) return null;
+  const boostClosesAt = draw?.boostClosesAt || ld.boostClosesAt || null;
+  const multiplier = draw?.multiplier || ld.multiplier || 10;
+  if (!boostClosesAt) return null;
+  return { boostClosesAt, multiplier };
+}

--- a/src/pages/marketplace/marketplace.css
+++ b/src/pages/marketplace/marketplace.css
@@ -1,0 +1,166 @@
+/* Redeem marketplace (v2) — pine/cream editorial system from the approved
+   claude.ai/design Prototype v2. rm- prefixed, mirrors redeemHome.css
+   conventions. Fonts load HERE (not index.html — that file is shared with the
+   mktr build) so the mktr bundle never pulls them. */
+@import url('https://fonts.googleapis.com/css2?family=Figtree:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,400..700&display=swap');
+
+.rm-page {
+  --rm-bg: #f7f3e9;
+  --rm-card: #fffdf6;
+  --rm-tint: #efe8d8;
+  --rm-sage: #e3ece2;
+  --rm-sage2: #cbd9cb;
+  --rm-pine: #1e5748;
+  --rm-pine2: #123b30;
+  --rm-ink: #17251f;
+  --rm-sub: #49514a;
+  --rm-mut: #83806f;
+  --rm-apr: #e4854f;
+  --rm-apr2: #c96a38;
+  --rm-line: #e5decb;
+  --rm-line2: #d5cdb4;
+  --rm-ok: #2e7d5b;
+  --rm-warn: #a97514;
+  --rm-err: #b3402e;
+  --rm-serif: 'Source Serif 4', Georgia, serif;
+  --rm-sans: 'Figtree', 'Helvetica Neue', Helvetica, sans-serif;
+  --rm-mono: 'IBM Plex Mono', monospace;
+  --rm-sh: 0 1px 2px rgba(23, 37, 31, 0.04), 0 10px 30px rgba(23, 37, 31, 0.07);
+
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--rm-bg);
+  color: var(--rm-ink);
+  font-family: var(--rm-sans);
+  -webkit-font-smoothing: antialiased;
+}
+
+.rm-page a { color: var(--rm-pine); text-decoration: none; }
+.rm-page a.rm-underline { border-bottom: 1px solid rgba(30, 87, 72, 0.3); }
+.rm-page a.rm-underline:hover { color: var(--rm-pine2); border-bottom-color: var(--rm-pine2); }
+.rm-page button { font: inherit; cursor: pointer; border: none; background: none; padding: 0; color: inherit; text-align: inherit; }
+.rm-page input, .rm-page select, .rm-page textarea { font: inherit; color: inherit; }
+.rm-page input:focus, .rm-page select:focus, .rm-page textarea:focus,
+.rm-page button:focus-visible, .rm-page a:focus-visible { outline: 2px solid var(--rm-pine); outline-offset: 2px; }
+.rm-page ::selection { background: #e5dbc0; }
+
+@keyframes rmFadeUp { from { opacity: 0; transform: translateY(14px); } to { opacity: 1; transform: none; } }
+@keyframes rmShimmer { 0% { opacity: 0.5; } 50% { opacity: 1; } 100% { opacity: 0.5; } }
+@keyframes rmPop { 0% { transform: scale(0.5); opacity: 0; } 70% { transform: scale(1.08); } 100% { transform: scale(1); opacity: 1; } }
+@keyframes rmSpin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+  .rm-page * { animation: none !important; transition: none !important; }
+}
+
+.rm-fadeup { animation: rmFadeUp 0.35s ease both; }
+.rm-shimmer { background: var(--rm-tint); border-radius: 18px; animation: rmShimmer 1.4s ease infinite; }
+.rm-spin { width: 16px; height: 16px; border: 2px solid var(--rm-line2); border-top-color: var(--rm-pine); border-radius: 50%; display: inline-block; animation: rmSpin 0.8s linear infinite; }
+
+.rm-shell { max-width: 1180px; margin: 0 auto; padding-left: clamp(16px, 4vw, 44px); padding-right: clamp(16px, 4vw, 44px); width: 100%; box-sizing: border-box; }
+.rm-shell--narrow { max-width: 860px; }
+.rm-shell--flow { max-width: 720px; }
+
+.rm-serif { font-family: var(--rm-serif); font-weight: 700; letter-spacing: -0.01em; }
+.rm-mono-label { font-family: var(--rm-mono); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--rm-mut); }
+.rm-mono-note { font-family: var(--rm-mono); font-size: 10.5px; color: var(--rm-mut); }
+
+/* ---------- Nav ---------- */
+.rm-nav { position: fixed; top: 0; left: 0; right: 0; z-index: 50; background: rgba(247, 243, 233, 0.94); backdrop-filter: blur(10px); border-bottom: 1px solid var(--rm-line); }
+.rm-nav-inner { height: 66px; display: flex; align-items: center; gap: 22px; }
+.rm-wordmark { display: inline-flex; align-items: center; gap: 9px; color: var(--rm-ink); font-family: var(--rm-serif); font-size: 22px; font-weight: 700; }
+.rm-ticket { position: relative; display: inline-block; width: 15px; height: 19px; border-radius: 8px 8px 2px 2px; background: var(--rm-pine); }
+.rm-ticket::after { content: ''; position: absolute; right: 3px; top: 11px; width: 2.5px; height: 2.5px; border-radius: 50%; background: #f6f2e6; }
+.rm-nav-links { display: flex; align-items: center; gap: 2px; flex: 1; }
+.rm-nav-link { color: var(--rm-sub); font-size: 14px; font-weight: 500; padding: 8px 12px; border-radius: 8px; white-space: nowrap; }
+.rm-nav-link:hover { background: var(--rm-tint); color: var(--rm-ink); }
+.rm-nav-cta { margin-left: auto; }
+.rm-burger { margin-left: auto; display: none; flex-direction: column; gap: 5px; padding: 10px; min-width: 44px; min-height: 44px; justify-content: center; align-items: center; }
+.rm-burger span { display: block; width: 20px; height: 2px; background: var(--rm-ink); border-radius: 2px; }
+.rm-burger span:last-child { width: 14px; }
+@media (max-width: 940px) {
+  .rm-nav-links { display: none; }
+  .rm-burger { display: flex; }
+}
+.rm-drawer-scrim { position: fixed; inset: 0; z-index: 70; background: rgba(23, 37, 31, 0.35); }
+.rm-drawer { position: fixed; top: 0; right: 0; bottom: 0; width: min(320px, 85vw); z-index: 71; background: var(--rm-card); box-shadow: -12px 0 40px rgba(23, 37, 31, 0.18); padding: 20px 22px 32px; overflow-y: auto; animation: rmFadeUp 0.25s ease both; }
+.rm-drawer a { display: block; padding: 10px 0; font-size: 15px; color: var(--rm-ink); font-weight: 500; }
+
+/* ---------- Buttons / chips ---------- */
+.rm-btn { display: inline-flex; align-items: center; justify-content: center; gap: 8px; background: var(--rm-pine); color: #f6f2e6; font-size: 14.5px; font-weight: 600; padding: 12px 24px; border-radius: 999px; min-height: 44px; transition: background 0.2s ease, transform 0.2s ease; text-align: center; box-sizing: border-box; }
+.rm-btn:hover { background: var(--rm-pine2); color: #ffffff; }
+.rm-btn--big { font-size: 15.5px; font-weight: 700; padding: 14px 28px; }
+.rm-btn--outline { background: transparent; color: var(--rm-ink); border: 1.5px solid var(--rm-line2); }
+.rm-btn--outline:hover { background: transparent; border-color: var(--rm-pine); color: var(--rm-pine); }
+.rm-btn--apricot { background: var(--rm-apr); color: #2a1608; font-weight: 700; }
+.rm-btn--apricot:hover { background: #ef9663; color: #2a1608; }
+.rm-btn--disabled, .rm-btn--disabled:hover { background: #d8d2be; color: #8a8672; cursor: not-allowed; }
+.rm-link-btn { font-size: 13.5px; font-weight: 600; color: var(--rm-pine); min-height: 44px; display: inline-flex; align-items: center; }
+.rm-link-btn:hover { color: var(--rm-pine2); }
+
+.rm-chip { background: #fffdf6; color: var(--rm-sub); border: 1px solid var(--rm-line2); border-radius: 999px; padding: 7px 14px; font-size: 12.5px; font-weight: 600; min-height: 34px; white-space: nowrap; flex-shrink: 0; transition: all 0.15s ease; display: inline-flex; align-items: center; }
+.rm-chip:hover { border-color: var(--rm-pine); color: var(--rm-pine); }
+.rm-chip.is-active { background: var(--rm-pine); color: #f6f2e6; border-color: var(--rm-pine); }
+.rm-chip--pick { min-height: 40px; padding: 9px 16px; font-size: 13px; }
+
+/* ---------- Cards / boxes ---------- */
+.rm-card { background: var(--rm-card); border: 1px solid var(--rm-line); border-radius: 18px; }
+.rm-card--pad { padding: 22px 24px; }
+.rm-grid-cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 20px; }
+.rm-req-box { border: 1px solid #cfddd2; background: #f2f6ef; border-radius: 10px; padding: 9px 12px; display: flex; gap: 8px; align-items: flex-start; }
+.rm-draw-box { border: 1px solid #f0cdb2; background: #fdf3ea; border-radius: 10px; padding: 9px 12px; display: flex; gap: 8px; align-items: flex-start; }
+.rm-warn-box { background: #fbf3e0; border: 1px solid #e8d9ae; border-radius: 16px; padding: 18px 22px; display: flex; gap: 12px; align-items: flex-start; }
+
+.rm-arch { border-radius: 170px 170px 14px 14px; background: repeating-linear-gradient(45deg, #ebe3cf 0 12px, #f3eddd 12px 24px); display: flex; align-items: flex-end; justify-content: center; padding-bottom: 12px; overflow: hidden; }
+.rm-arch img { width: 100%; height: 100%; object-fit: cover; }
+.rm-arch-tag { font-family: var(--rm-mono); font-size: 9.5px; letter-spacing: 0.07em; text-transform: uppercase; color: #a29d8a; background: rgba(255, 253, 246, 0.85); padding: 3px 9px; border-radius: 999px; }
+
+/* ---------- Forms ---------- */
+.rm-label { display: block; font-size: 12.5px; font-weight: 600; margin-bottom: 6px; color: var(--rm-ink); }
+.rm-label .rm-opt { font-weight: 400; color: var(--rm-mut); }
+.rm-input, .rm-select, .rm-textarea { width: 100%; box-sizing: border-box; border: 1px solid var(--rm-line2); border-radius: 11px; padding: 13px 15px; font-size: 15px; background: var(--rm-bg); }
+.rm-err { display: block; font-size: 12px; color: var(--rm-err); margin-top: 4px; min-height: 14px; }
+.rm-check { display: flex; gap: 12px; align-items: flex-start; border: 1px solid var(--rm-line); border-radius: 12px; padding: 13px 15px; min-height: 44px; width: 100%; box-sizing: border-box; }
+.rm-check-box { width: 20px; height: 20px; border-radius: 6px; border: 2px solid var(--rm-line2); background: var(--rm-card); flex-shrink: 0; margin-top: 1px; display: flex; align-items: center; justify-content: center; font-size: 13px; font-weight: 700; }
+.rm-check.is-checked .rm-check-box { border-color: var(--rm-pine); background: var(--rm-pine); color: #f6f2e6; }
+.rm-check-text { font-size: 13px; line-height: 1.55; color: var(--rm-ink); text-align: left; }
+
+/* ---------- Flow progress ---------- */
+.rm-progress { position: relative; margin: 26px 0 22px; }
+.rm-progress-line { position: absolute; left: 16px; right: 16px; top: 15px; border-top: 2px dotted var(--rm-line2); }
+.rm-progress-steps { display: flex; justify-content: space-between; position: relative; }
+.rm-progress-step { display: flex; flex-direction: column; align-items: center; gap: 6px; min-width: 0; }
+.rm-progress-dot { width: 32px; height: 32px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-family: var(--rm-mono); font-size: 11px; background: var(--rm-tint); border: 2px solid var(--rm-line2); color: var(--rm-mut); transition: all 0.3s ease; }
+.rm-progress-step.is-current .rm-progress-dot { background: var(--rm-card); border-color: var(--rm-pine); color: var(--rm-pine); }
+.rm-progress-step.is-done .rm-progress-dot { background: var(--rm-pine); border-color: var(--rm-pine); color: #f6f2e6; }
+.rm-progress-label { font-size: 10px; font-weight: 500; color: var(--rm-mut); text-align: center; max-width: 76px; line-height: 1.25; }
+.rm-progress-step.is-current .rm-progress-label { color: var(--rm-ink); font-weight: 700; }
+
+/* ---------- Footer ---------- */
+.rm-footer { background: #132720; color: #c8d5cb; margin-top: auto; }
+.rm-footer a { color: #c8d5cb; }
+.rm-footer a:hover { color: #ffffff; }
+.rm-footer-cols { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 32px; }
+.rm-footer-head { font-family: var(--rm-mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: #7e958a; margin-bottom: 12px; }
+.rm-footer-links { display: flex; flex-direction: column; gap: 9px; font-size: 13.5px; }
+
+/* ---------- Offer card ---------- */
+.rm-offercard { display: flex; flex-direction: column; height: 100%; padding: 10px; box-shadow: var(--rm-sh); cursor: pointer; transition: transform 0.25s ease, box-shadow 0.25s ease; box-sizing: border-box; }
+.rm-offercard:hover { transform: translateY(-4px); box-shadow: 0 2px 4px rgba(23, 37, 31, 0.05), 0 18px 40px rgba(23, 37, 31, 0.11); }
+.rm-offercard-img { position: relative; height: 158px; border-radius: 110px 110px 10px 10px; background: repeating-linear-gradient(45deg, #efe8d8 0 12px, #f5efe1 12px 24px); display: flex; align-items: flex-end; justify-content: center; padding-bottom: 12px; overflow: hidden; }
+.rm-offercard-img img { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; }
+.rm-offercard-body { padding: 14px 10px 8px; display: flex; flex-direction: column; gap: 9px; flex: 1; }
+
+/* ---------- FAQ rows ---------- */
+.rm-faq-row { border-top: 1px solid var(--rm-line); }
+.rm-faq-q { width: 100%; display: flex; justify-content: space-between; align-items: center; gap: 16px; padding: 15px 2px; min-height: 44px; font-size: 14.5px; font-weight: 600; color: var(--rm-ink); }
+.rm-faq-sym { font-family: var(--rm-mono); font-size: 16px; color: var(--rm-pine); flex-shrink: 0; }
+.rm-faq-a { padding: 0 2px 16px; font-size: 13.5px; line-height: 1.65; color: var(--rm-sub); max-width: 70ch; animation: rmFadeUp 0.25s ease both; }
+
+/* ---------- Verified badge ---------- */
+.rm-verified { display: inline-flex; align-items: center; gap: 4px; font-family: var(--rm-mono); font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--rm-pine); }
+.rm-verified::before { content: ''; display: inline-block; width: 7px; height: 9px; border-radius: 4px 4px 1px 1px; background: var(--rm-pine); }
+
+/* ---------- Mobile sticky CTA ---------- */
+.rm-sticky-cta { position: fixed; left: 0; right: 0; bottom: 0; z-index: 60; background: var(--rm-card); border-top: 1px solid var(--rm-line); box-shadow: 0 -8px 24px rgba(23, 37, 31, 0.08); padding: 12px 16px calc(12px + env(safe-area-inset-bottom)); display: none; align-items: center; gap: 14px; }
+@media (max-width: 940px) { .rm-sticky-cta { display: flex; } }

--- a/vite.config.js
+++ b/vite.config.js
@@ -54,12 +54,17 @@ function brandSeoFiles() {
   // /features, /pricing, /about are hidden (show* flags false) pending a rewrite,
   // so they're intentionally excluded from the sitemap to avoid advertising 404s.
   const mktrOnlyRoutes = []
-  // Marketplace v2 static surfaces (flag-gated in the SPA; harmless in the
-  // sitemap while dark — they fall back to the apex). /offers/:slug pages are
-  // dynamic and get indexed via crawl, not enumerated here.
+  // Marketplace v2 static surfaces — only advertised once the SPA flag is
+  // baked ON for this build (while dark those routes 404, and a sitemap must
+  // never advertise 404s). /offers/:slug pages are dynamic and get indexed
+  // via crawl, not enumerated here.
+  const marketplaceOn = process.env.VITE_REDEEM_MARKETPLACE_ENABLED === 'true'
   const redeemOnlyRoutes = [
-    '/winners', '/explore', '/dsa', '/how-it-works', '/businesses', '/about',
-    '/c/education', '/c/lifestyle', '/legal/terms', '/legal/dnc', '/leads/privacy',
+    '/winners',
+    ...(marketplaceOn
+      ? ['/explore', '/dsa', '/how-it-works', '/businesses', '/about',
+         '/c/education', '/c/lifestyle', '/legal/terms', '/legal/dnc', '/leads/privacy']
+      : []),
   ]
   const routes = BRAND === 'redeem' ? [...sharedRoutes, ...redeemOnlyRoutes] : [...sharedRoutes, ...mktrOnlyRoutes]
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -54,7 +54,13 @@ function brandSeoFiles() {
   // /features, /pricing, /about are hidden (show* flags false) pending a rewrite,
   // so they're intentionally excluded from the sitemap to avoid advertising 404s.
   const mktrOnlyRoutes = []
-  const redeemOnlyRoutes = ['/winners']
+  // Marketplace v2 static surfaces (flag-gated in the SPA; harmless in the
+  // sitemap while dark — they fall back to the apex). /offers/:slug pages are
+  // dynamic and get indexed via crawl, not enumerated here.
+  const redeemOnlyRoutes = [
+    '/winners', '/explore', '/dsa', '/how-it-works', '/businesses', '/about',
+    '/c/education', '/c/lifestyle', '/legal/terms', '/legal/dnc', '/leads/privacy',
+  ]
   const routes = BRAND === 'redeem' ? [...sharedRoutes, ...redeemOnlyRoutes] : [...sharedRoutes, ...mktrOnlyRoutes]
 
   const robots = [


### PR DESCRIPTION
## What

Implements the approved Redeem.sg Prototype v2 design (claude.ai/design `6ae0fb7b`, reconciled against production twice) per **docs/plans/redeem-marketplace-v2.md** — plan was Codex-reviewed (gpt-5.6-sol, xhigh); all 7 BLOCKER / 12 MAJOR findings are folded in.

A consumer marketplace on redeem.sg: browse (`/explore`, `/c/:id`, `/dsa`), offer detail (`/offers/:slug`), a step-based redemption flow (`/flow/:slug`) submitting into the **existing production pipeline** (OTP `/verify/*`, `/dnc/check`, `POST /prospects`, round-robin routing, CAPI/pixels, confirmation email), plus static pages — all reading campaigns as `design_config` (authored) + `ops` (composed read-only from Redeem Ops: Activation ⋈ RewardOffer ⋈ Partner ⋈ RewardOfferLocation + open Draw row).

## Dark launch — zero behaviour change on merge

| Flag | Component | Effect when ON |
|---|---|---|
| `MARKETPLACE_PUBLIC_API_ENABLED` | backend | mounts `/api/marketplace` |
| `VITE_REDEEM_MARKETPLACE_ENABLED` | redeem-frontend | mounts SPA routes + swaps apex `/` from RedeemHome to marketplace Home |
| `MARKETPLACE_QR_REDIRECT_ENABLED` | backend | tracker honors `qr_entry: detail` (flip LAST, after SPA is live) |

`/LeadCapture`, QR attribution, quiz funnel, existing campaigns: byte-for-byte untouched.

## Security highlights

- **Publication gate**: `marketplaceListed` (admin-only policy, agents stripped) AND slug AND `is_active` AND `status='active'` AND redeem customer host AND supported type AND resolvable ops. Agents flipping `is_active` via PUT can never expose a campaign.
- **Public-data boundary**: marketplace DTOs are rebuilt field-by-field; **also hardens the pre-existing `GET /api/previews/public/:id` + `/p/:slug` leak** — raw `design_config` (incl. `luckyDraw.activationId/termsVersionId/termsHash`) is no longer publicly dumpable.
- `sourceMetadata.marketplace` is server-built only (values validated against campaign config; forged subkey scrubbed); slug immutable once `firstActivatedAt` set.

## Notable implementation decisions (deviations documented in the plan)

- Phase 7 partner enquiry = mailto CTA (public CRM-write endpoint deferred per review).
- `preferred_branch` intake uses charset-sanitisation, not an ops-location identity query (school level + timing ARE config-validated).
- Cache state lives in model-free `marketplaceCache.js` so writer services invalidate without importing the read model.
- Client `sourceMetadata` passthrough for internal callers preserved (documented contract; public route strips via Joi `stripUnknown`) with the `marketplace` subkey scrubbed.

## Testing

- 4 new backend suites (38 cases): DTO exclusions, gate matrix, composeOps rules, normalizer/policy, previews whitelist regression, intake validation.
- New vitest suite: fieldOrder both shapes + pixel-predicate matrix.
- Full backend jest + full vitest: failures identical to main's pre-existing baseline (verified against a clean main worktree — no new failures).
- Both brand builds green; mktr build never mounts marketplace routes.

## Rollout (after merge)

1. Verify deploys (push ≠ live). 2. Flip backend API flag, smoke `/api/marketplace/campaigns` (empty list expected). 3. Seed pilot campaign end-to-end (redeem-ops partner → RewardOffer + locations → Activation → designer Marketplace tab: slug + content + listing). 4. Flip `VITE_REDEEM_MARKETPLACE_ENABLED` on redeem-frontend → Playwright verify → Cloudflare purge. 5. Flip QR redirect flag last. Reward-pass leg additionally needs `REDEEM_OPS_ENTITLEMENTS_ENABLED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)