### PR TITLE
feat(wallet): agent wallet + per-campaign lead commitments backend (dark)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -284,6 +284,15 @@ HITPAY_WEBHOOK_URL=                          # full URL to /api/external/billing
 HITPAY_REDIRECT_URL=                         # app deep link back after pay (optional; webhook is source of truth)
 # NOTE: EXTERNAL_APP_SECRET (set above) also authenticates the agent-facing billing routes.
 
+# -----------------------------------------------------------------------------
+# Agent wallet + per-campaign commitments — DEPLOY-INERT until AGENT_WALLET_ENABLED=true
+# (docs/plans/agent-wallet-commitments.md). Gates /api/external/wallet (summary/
+# ledger/catalog/commit). Top-ups ride /api/external/billing (kind:'wallet_topup'),
+# so BILLING_ENABLED must also be true for money-in. Admin endpoints
+# (/api/admin/wallets) are always mounted — admin-authed reads + audited adjustment.
+# -----------------------------------------------------------------------------
+AGENT_WALLET_ENABLED=false
+
 # ── Redeem Ops — Discover tool (Apify prospecting; migration 053) ──────────────
 DISCOVERY_ENABLED=false                       # master switch (also gates the reconcile sweep)
 DISCOVERY_IG_ENABLED=false                    # Instagram hashtag-discovery pilot (provider kill switch; Maps stays primary)

--- a/backend/src/controllers/adminWalletController.js
+++ b/backend/src/controllers/adminWalletController.js
@@ -19,7 +19,9 @@ export async function getAgentLedger(req, res) {
 
 export async function adjust(req, res) {
   const { agentId } = req.params;
-  const { amountCents, note } = req.body || {};
-  const result = await walletService.adminAdjust(agentId, amountCents, note, req.user?.id ?? null);
-  res.status(201).json({ success: true, data: result });
+  const { amountCents, note, requestId } = req.body || {};
+  const result = await walletService.adminAdjust(agentId, amountCents, note, req.user?.id ?? null, {
+    requestId: typeof requestId === 'string' && requestId.trim() ? requestId.trim() : undefined,
+  });
+  res.status(result.replayed ? 200 : 201).json({ success: true, data: result });
 }

--- a/backend/src/controllers/adminWalletController.js
+++ b/backend/src/controllers/adminWalletController.js
@@ -1,0 +1,25 @@
+/**
+ * @file adminWalletController — admin reads of agent wallets + manual adjustment.
+ * Thin over walletService; the roster is EXTERNAL agents only in v1
+ * (users.mktrLeadsId non-null — internal agents have no wallets yet).
+ */
+import * as walletService from '../services/walletService.js';
+
+export async function listWallets(req, res) {
+  const wallets = await walletService.listWallets();
+  res.json({ success: true, data: { wallets } });
+}
+
+export async function getAgentLedger(req, res) {
+  const { agentId } = req.params;
+  const { page, limit } = req.query;
+  const data = await walletService.getLedger(agentId, { page, limit });
+  res.json({ success: true, data });
+}
+
+export async function adjust(req, res) {
+  const { agentId } = req.params;
+  const { amountCents, note } = req.body || {};
+  const result = await walletService.adminAdjust(agentId, amountCents, note, req.user?.id ?? null);
+  res.status(201).json({ success: true, data: result });
+}

--- a/backend/src/controllers/externalBillingController.js
+++ b/backend/src/controllers/externalBillingController.js
@@ -21,7 +21,7 @@
 import crypto from 'crypto';
 import { logger } from '../utils/logger.js';
 import { verifyWebhook as verifyHitpayWebhook } from '../services/hitpayClient.js';
-import { getCatalog, createCheckout, getPurchaseStatus, getHistory, getDocument, fulfillFromWebhook } from '../services/billingService.js';
+import { getCatalog, createCheckout, createWalletTopupCheckout, getPurchaseStatus, getHistory, getDocument, fulfillFromWebhook } from '../services/billingService.js';
 
 const MAX_AGE_MS = 5 * 60 * 1000;
 const MAX_FUTURE_MS = 2 * 60 * 1000; // tolerate clock skew
@@ -92,9 +92,28 @@ export async function catalog(req, res) {
   }
 }
 
-// ── Checkout (create purchase) ────────────────────────────────────────────────
+// ── Checkout (create purchase OR wallet top-up) ───────────────────────────────
 export async function checkout(req, res) {
-  const { agentMktrUserId, packageId, beneficiaryMktrUserId } = req.body || {};
+  const { agentMktrUserId, packageId, beneficiaryMktrUserId, kind, amountCents } = req.body || {};
+
+  // Wallet top-up branch (kind:'wallet_topup'): no package — amount preset only.
+  // Shipped app cohorts never send `kind`, so the package path below is untouched.
+  if (kind === 'wallet_topup') {
+    if (!agentMktrUserId) {
+      return res.status(400).json({ success: false, error: 'agentMktrUserId is required' });
+    }
+    try {
+      const r = await createWalletTopupCheckout({ agentMktrUserId, amountCents });
+      if (r.status === 'created') {
+        return res.status(201).json({ success: true, checkoutUrl: r.url, purchaseId: r.purchaseId });
+      }
+      const codeByStatus = { invalid_agent: 400, invalid_amount: 400, provider_error: 502 };
+      return res.status(codeByStatus[r.status] || 500).json({ success: false, status: r.status, ...(r.presets ? { presets: r.presets } : {}) });
+    } catch (err) {
+      return sendError(res, err, 'topup-checkout');
+    }
+  }
+
   if (!agentMktrUserId || !packageId) {
     return res.status(400).json({ success: false, error: 'agentMktrUserId and packageId are required' });
   }

--- a/backend/src/controllers/externalWalletController.js
+++ b/backend/src/controllers/externalWalletController.js
@@ -1,0 +1,96 @@
+/**
+ * @file externalWalletController — the MKTR Leads agent app's wallet surface.
+ *
+ * ── Endpoints (mounted at /api/external/wallet, gated by AGENT_WALLET_ENABLED) ──
+ *   POST /summary  → { balanceCents, openCommitments }
+ *   POST /ledger   → paginated wallet_ledger entries
+ *   POST /catalog  → commit-able campaigns (active + priced; whitelisted fields)
+ *   POST /commit   → { campaignId, quantity } → debit wallet + create commitment
+ *
+ * No cancel endpoint exists BY DESIGN (product decision: no self-cancel; the only
+ * refund is the automatic campaign-takedown refund). Top-ups live on
+ * /api/external/billing (kind:'wallet_topup') because they ride HitPay settlement.
+ *
+ * Auth: the same HMAC-SHA256-over-rawBody scheme as the other /api/external/
+ * surfaces (EXTERNAL_APP_SECRET, signed body timestamp ±5 min) — reused from
+ * externalBillingController.requireExternalHmac. The mktr-leads broker self-scopes
+ * agentMktrUserId, so every action resolves the caller via mktrLeadsId.
+ */
+import { User } from '../models/index.js';
+import { getSummary, getLedger, getCatalog, commit } from '../services/walletService.js';
+import { logger } from '../utils/logger.js';
+
+export { requireExternalHmac } from './externalBillingController.js';
+
+/** Same self-scope guard as billingService.resolveAgent: mktrLeadsId + live agent. */
+async function resolveAgent(agentMktrUserId) {
+  if (!agentMktrUserId || typeof agentMktrUserId !== 'string') return null;
+  return User.findOne({
+    where: { mktrLeadsId: agentMktrUserId, role: 'agent', isActive: true },
+    attributes: ['id'],
+  });
+}
+
+function sendError(res, err, op) {
+  // AppError carries a deliberate statusCode (404/409/400); anything else is a 500.
+  const code = Number.isInteger(err?.statusCode) ? err.statusCode : 500;
+  if (code >= 500) {
+    logger.error(`[external-wallet] ${op} failed`, { error: err?.message || String(err) });
+    return res.status(500).json({ success: false, error: 'Internal server error' });
+  }
+  return res.status(code).json({ success: false, error: err.message });
+}
+
+export async function summary(req, res) {
+  const { agentMktrUserId } = req.body || {};
+  if (!agentMktrUserId) return res.status(400).json({ success: false, error: 'agentMktrUserId is required' });
+  try {
+    const agent = await resolveAgent(agentMktrUserId);
+    if (!agent) return res.status(400).json({ success: false, error: 'invalid_agent' });
+    const data = await getSummary(agent.id);
+    return res.json({ success: true, ...data });
+  } catch (err) {
+    return sendError(res, err, 'summary');
+  }
+}
+
+export async function ledger(req, res) {
+  const { agentMktrUserId, page, limit } = req.body || {};
+  if (!agentMktrUserId) return res.status(400).json({ success: false, error: 'agentMktrUserId is required' });
+  try {
+    const agent = await resolveAgent(agentMktrUserId);
+    if (!agent) return res.status(400).json({ success: false, error: 'invalid_agent' });
+    const data = await getLedger(agent.id, { page, limit });
+    return res.json({ success: true, ...data });
+  } catch (err) {
+    return sendError(res, err, 'ledger');
+  }
+}
+
+export async function catalog(req, res) {
+  const { agentMktrUserId } = req.body || {};
+  if (!agentMktrUserId) return res.status(400).json({ success: false, error: 'agentMktrUserId is required' });
+  try {
+    const agent = await resolveAgent(agentMktrUserId);
+    if (!agent) return res.status(400).json({ success: false, error: 'invalid_agent' });
+    const campaigns = await getCatalog();
+    return res.json({ success: true, campaigns });
+  } catch (err) {
+    return sendError(res, err, 'catalog');
+  }
+}
+
+export async function commitHandler(req, res) {
+  const { agentMktrUserId, campaignId, quantity } = req.body || {};
+  if (!agentMktrUserId || !campaignId) {
+    return res.status(400).json({ success: false, error: 'agentMktrUserId and campaignId are required' });
+  }
+  try {
+    const agent = await resolveAgent(agentMktrUserId);
+    if (!agent) return res.status(400).json({ success: false, error: 'invalid_agent' });
+    const result = await commit(agent.id, campaignId, quantity);
+    return res.status(201).json({ success: true, ...result });
+  } catch (err) {
+    return sendError(res, err, 'commit');
+  }
+}

--- a/backend/src/controllers/externalWalletController.js
+++ b/backend/src/controllers/externalWalletController.js
@@ -81,15 +81,21 @@ export async function catalog(req, res) {
 }
 
 export async function commitHandler(req, res) {
-  const { agentMktrUserId, campaignId, quantity } = req.body || {};
+  const { agentMktrUserId, campaignId, quantity, requestId } = req.body || {};
   if (!agentMktrUserId || !campaignId) {
     return res.status(400).json({ success: false, error: 'agentMktrUserId and campaignId are required' });
+  }
+  // Mandatory idempotency: a broker/client retry after a lost response must
+  // return the SAME commitment, never a second debit. The app generates a
+  // UUID per user action and reuses it across retries.
+  if (typeof requestId !== 'string' || !requestId.trim()) {
+    return res.status(400).json({ success: false, error: 'requestId is required (idempotency key)' });
   }
   try {
     const agent = await resolveAgent(agentMktrUserId);
     if (!agent) return res.status(400).json({ success: false, error: 'invalid_agent' });
-    const result = await commit(agent.id, campaignId, quantity);
-    return res.status(201).json({ success: true, ...result });
+    const result = await commit(agent.id, campaignId, quantity, { requestId: requestId.trim() });
+    return res.status(result.replayed ? 200 : 201).json({ success: true, ...result });
   } catch (err) {
     return sendError(res, err, 'commit');
   }

--- a/backend/src/database/migrations/068-campaign-lead-price.js
+++ b/backend/src/database/migrations/068-campaign-lead-price.js
@@ -1,0 +1,19 @@
+/**
+ * 068 — Per-campaign lead price for agent-wallet commitments.
+ *
+ * `leadPriceCents` INTEGER NULL: the admin-set price external (mktr-leads)
+ * agents pay per lead when committing wallet credits to this campaign.
+ * NULL = campaign is not commit-able (hidden from the wallet catalog).
+ * Deliberately independent of `externalEligible` (the inert ExternalAgent
+ * buyer-pool flag) — see docs/plans/agent-wallet-commitments.md.
+ * camelCase DDL (sequelize underscored:false). Guarded/idempotent.
+ */
+export async function up(queryInterface) {
+  await queryInterface.sequelize.query(
+    'ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS "leadPriceCents" INTEGER'
+  );
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query('ALTER TABLE campaigns DROP COLUMN IF EXISTS "leadPriceCents"');
+}

--- a/backend/src/database/migrations/069-wallet-package-kinds.js
+++ b/backend/src/database/migrations/069-wallet-package-kinds.js
@@ -26,9 +26,18 @@ export async function up(queryInterface) {
   await queryInterface.sequelize.query(
     'ALTER TABLE lead_package_assignments ADD COLUMN IF NOT EXISTS "unitPriceCents" INTEGER'
   );
+  // Wallet commitments must always be refundable: positive per-lead snapshot.
+  await queryInterface.sequelize.query(`
+    DO $$ BEGIN
+      ALTER TABLE lead_package_assignments
+        ADD CONSTRAINT chk_lpa_wallet_unit_price
+        CHECK ("source" <> 'wallet' OR ("unitPriceCents" IS NOT NULL AND "unitPriceCents" > 0));
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+  `);
 }
 
 export async function down(queryInterface) {
+  await queryInterface.sequelize.query('ALTER TABLE lead_package_assignments DROP CONSTRAINT IF EXISTS chk_lpa_wallet_unit_price');
   await queryInterface.sequelize.query('DROP INDEX IF EXISTS uq_lead_packages_wallet_campaign');
   await queryInterface.sequelize.query('ALTER TABLE lead_packages DROP COLUMN IF EXISTS "kind"');
   await queryInterface.sequelize.query('ALTER TABLE lead_package_assignments DROP COLUMN IF EXISTS "source"');

--- a/backend/src/database/migrations/069-wallet-package-kinds.js
+++ b/backend/src/database/migrations/069-wallet-package-kinds.js
@@ -1,0 +1,36 @@
+/**
+ * 069 — Discriminators for wallet-backed commitments on the package rails.
+ *
+ * A wallet commitment is a normal LeadPackageAssignment under a hidden
+ * per-campaign "wallet" LeadPackage, so routing/charging/drain-down are
+ * untouched (docs/plans/agent-wallet-commitments.md). This migration adds:
+ *  - lead_packages.kind          'catalog' | 'wallet' (hidden container)
+ *  - one-wallet-package-per-campaign UNIQUE partial index (the race guard
+ *    behind walletService.commit's find-or-create + retry)
+ *  - lead_package_assignments.source        'package' | 'wallet'
+ *  - lead_package_assignments.unitPriceCents per-lead snapshot at commit
+ *    time (takedown refunds = leadsRemaining × unitPriceCents)
+ * camelCase DDL. Guarded/idempotent.
+ */
+export async function up(queryInterface) {
+  await queryInterface.sequelize.query(
+    "ALTER TABLE lead_packages ADD COLUMN IF NOT EXISTS \"kind\" VARCHAR(16) NOT NULL DEFAULT 'catalog'"
+  );
+  await queryInterface.sequelize.query(
+    `CREATE UNIQUE INDEX IF NOT EXISTS uq_lead_packages_wallet_campaign
+       ON lead_packages ("campaignId") WHERE "kind" = 'wallet'`
+  );
+  await queryInterface.sequelize.query(
+    "ALTER TABLE lead_package_assignments ADD COLUMN IF NOT EXISTS \"source\" VARCHAR(16) NOT NULL DEFAULT 'package'"
+  );
+  await queryInterface.sequelize.query(
+    'ALTER TABLE lead_package_assignments ADD COLUMN IF NOT EXISTS "unitPriceCents" INTEGER'
+  );
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query('DROP INDEX IF EXISTS uq_lead_packages_wallet_campaign');
+  await queryInterface.sequelize.query('ALTER TABLE lead_packages DROP COLUMN IF EXISTS "kind"');
+  await queryInterface.sequelize.query('ALTER TABLE lead_package_assignments DROP COLUMN IF EXISTS "source"');
+  await queryInterface.sequelize.query('ALTER TABLE lead_package_assignments DROP COLUMN IF EXISTS "unitPriceCents"');
+}

--- a/backend/src/database/migrations/070-wallet-ledger.js
+++ b/backend/src/database/migrations/070-wallet-ledger.js
@@ -1,0 +1,46 @@
+/**
+ * 070 — Append-only wallet ledger (the audit truth for agent credits).
+ *
+ * Every balance mutation writes exactly one row here, in the SAME transaction
+ * as the users.walletBalanceCents update (071). No UPDATE/DELETE path exists
+ * by design. agentId is ON DELETE RESTRICT: financial history blocks user
+ * hard-deletion (userService pre-checks give the friendly 409).
+ *
+ * Unique partial indexes are the double-spend guards:
+ *  - one 'takedown_refund' per assignment (double-archive race)
+ *  - one 'topup' per payment (HitPay webhook replay)
+ * camelCase DDL. Guarded/idempotent. NOTE: no updatedAt — the WalletLedger
+ * model sets timestamps:false with an explicit createdAt.
+ */
+export async function up(queryInterface) {
+  await queryInterface.sequelize.query(`
+    CREATE TABLE IF NOT EXISTS wallet_ledger (
+      "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      "agentId" UUID NOT NULL REFERENCES users("id") ON DELETE RESTRICT,
+      "type" VARCHAR(24) NOT NULL,
+      "amountCents" INTEGER NOT NULL,
+      "balanceAfterCents" INTEGER NOT NULL,
+      "paymentId" UUID REFERENCES payments("id") ON DELETE SET NULL,
+      "assignmentId" UUID REFERENCES lead_package_assignments("id") ON DELETE SET NULL,
+      "campaignId" UUID REFERENCES campaigns("id") ON DELETE SET NULL,
+      "note" TEXT,
+      "createdBy" UUID REFERENCES users("id") ON DELETE SET NULL,
+      "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+    )
+  `);
+  await queryInterface.sequelize.query(
+    'CREATE INDEX IF NOT EXISTS idx_wallet_ledger_agent_created ON wallet_ledger ("agentId", "createdAt")'
+  );
+  await queryInterface.sequelize.query(
+    `CREATE UNIQUE INDEX IF NOT EXISTS uq_wallet_ledger_refund_assignment
+       ON wallet_ledger ("assignmentId") WHERE "type" = 'takedown_refund'`
+  );
+  await queryInterface.sequelize.query(
+    `CREATE UNIQUE INDEX IF NOT EXISTS uq_wallet_ledger_topup_payment
+       ON wallet_ledger ("paymentId") WHERE "type" = 'topup'`
+  );
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query('DROP TABLE IF EXISTS wallet_ledger');
+}

--- a/backend/src/database/migrations/071-wallet-balance-payment-kind.js
+++ b/backend/src/database/migrations/071-wallet-balance-payment-kind.js
@@ -1,0 +1,25 @@
+/**
+ * 071 — Fast-read wallet balance + Payment kind discriminator.
+ *
+ * users.walletBalanceCents is the denormalized read of the wallet_ledger
+ * (070) — maintained atomically in the same transaction as every ledger
+ * insert, with a >= 0 guard in the UPDATE itself.
+ *
+ * payments.kind branches HitPay checkout/settlement between the existing
+ * package purchase and the new wallet top-up (top-ups carry no package;
+ * settlement credits the wallet inside the same locked transaction).
+ * camelCase DDL. Guarded/idempotent.
+ */
+export async function up(queryInterface) {
+  await queryInterface.sequelize.query(
+    'ALTER TABLE users ADD COLUMN IF NOT EXISTS "walletBalanceCents" INTEGER NOT NULL DEFAULT 0'
+  );
+  await queryInterface.sequelize.query(
+    "ALTER TABLE payments ADD COLUMN IF NOT EXISTS \"kind\" VARCHAR(24) NOT NULL DEFAULT 'package_purchase'"
+  );
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query('ALTER TABLE users DROP COLUMN IF EXISTS "walletBalanceCents"');
+  await queryInterface.sequelize.query('ALTER TABLE payments DROP COLUMN IF EXISTS "kind"');
+}

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -107,6 +107,8 @@ export const schemas = {
     enforceLeadQuota: Joi.boolean().optional(),
     metaPixelId: Joi.string().max(64).optional().allow(null, ''),
     tiktokPixelId: Joi.string().max(64).optional().allow(null, ''),
+    // Wallet commit price (cents) — service enforces the admin-only clamp.
+    leadPriceCents: Joi.number().integer().min(1).max(100000000).optional().allow(null),
     // Marketplace URL handle — service enforces charset/lock; format-only here.
     slug: Joi.string().max(80).optional().allow(null, '')
   }),
@@ -128,6 +130,8 @@ export const schemas = {
     enforceLeadQuota: Joi.boolean().optional(),
     metaPixelId: Joi.string().max(64).optional().allow(null, ''),
     tiktokPixelId: Joi.string().max(64).optional().allow(null, ''),
+    // Wallet commit price (cents) — service enforces the admin-only clamp.
+    leadPriceCents: Joi.number().integer().min(1).max(100000000).optional().allow(null),
     // Marketplace URL handle — service enforces charset + post-activation lock.
     slug: Joi.string().max(80).optional().allow(null, '')
   }).min(1),

--- a/backend/src/models/Campaign.js
+++ b/backend/src/models/Campaign.js
@@ -219,6 +219,14 @@ const Campaign = sequelize.define('Campaign', {
     type: DataTypes.DATE,
     allowNull: true,
     comment: 'Stamped the first time is_active flips true; locks the slug'
+  },
+  // Agent-wallet commit price (migration 068). Admin-set, positive cents;
+  // NULL = not commit-able by external agents (hidden from the wallet
+  // catalog). Independent of externalEligible (inert buyer-pool flag).
+  leadPriceCents: {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+    validate: { min: 1 }
   }
 }, {
   tableName: 'campaigns',

--- a/backend/src/models/LeadPackage.js
+++ b/backend/src/models/LeadPackage.js
@@ -47,7 +47,16 @@ const LeadPackage = sequelize.define('LeadPackage', {
     type: DataTypes.INTEGER,
     allowNull: false,
     validate: {
-      min: 1
+      // Kind-aware: catalog SKUs sell ≥1 lead; the hidden wallet container is
+      // a pure grouping row and MUST stay 0 (commitments carry their own counts).
+      leadCountMatchesKind(value) {
+        const kind = this.kind || 'catalog';
+        if (kind === 'wallet') {
+          if (Number(value) !== 0) throw new Error('Wallet packages must have leadCount 0');
+        } else if (!(Number(value) >= 1)) {
+          throw new Error('Validation min on leadCount failed');
+        }
+      }
     }
   },
   qualityScore: {

--- a/backend/src/models/LeadPackage.js
+++ b/backend/src/models/LeadPackage.js
@@ -111,10 +111,26 @@ const LeadPackage = sequelize.define('LeadPackage', {
       model: 'campaigns',
       key: 'id'
     }
+  },
+  // 'catalog' = normal buyable SKU; 'wallet' = the hidden per-campaign
+  // container that wallet commitments hang off (migration 069). Wallet
+  // packages are isPublic:false + price 0, so the buy catalog never shows
+  // them; the unique partial index below enforces one per campaign.
+  kind: {
+    type: DataTypes.STRING(16),
+    allowNull: false,
+    defaultValue: 'catalog',
+    validate: { isIn: [['catalog', 'wallet']] }
   }
 }, {
   tableName: 'lead_packages',
   indexes: [
+    {
+      unique: true,
+      fields: ['campaignId'],
+      where: { kind: 'wallet' },
+      name: 'uq_lead_packages_wallet_campaign'
+    },
     {
       fields: ['status']
     },

--- a/backend/src/models/LeadPackageAssignment.js
+++ b/backend/src/models/LeadPackageAssignment.js
@@ -47,6 +47,19 @@ const LeadPackageAssignment = sequelize.define('LeadPackageAssignment', {
         type: DataTypes.DECIMAL(10, 2),
         allowNull: false,
         comment: 'Snapshot of price at time of assignment'
+    },
+    // Wallet commitments ride the package rails (migration 069): source marks
+    // the origin; unitPriceCents snapshots the per-lead price at commit time
+    // (takedown refund = leadsRemaining × unitPriceCents).
+    source: {
+        type: DataTypes.STRING(16),
+        allowNull: false,
+        defaultValue: 'package',
+        validate: { isIn: [['package', 'wallet']] }
+    },
+    unitPriceCents: {
+        type: DataTypes.INTEGER,
+        allowNull: true
     }
 }, {
     tableName: 'lead_package_assignments',

--- a/backend/src/models/LeadPackageAssignment.js
+++ b/backend/src/models/LeadPackageAssignment.js
@@ -59,7 +59,16 @@ const LeadPackageAssignment = sequelize.define('LeadPackageAssignment', {
     },
     unitPriceCents: {
         type: DataTypes.INTEGER,
-        allowNull: true
+        allowNull: true,
+        validate: {
+            // Wallet commitments MUST carry a positive per-lead snapshot — the
+            // takedown refund is leadsRemaining × unitPriceCents (DB CHECK in 069).
+            requiredForWallet(value) {
+                if (this.source === 'wallet' && !(Number.isInteger(value) && value > 0)) {
+                    throw new Error('Wallet assignments require a positive unitPriceCents');
+                }
+            }
+        }
     }
 }, {
     tableName: 'lead_package_assignments',

--- a/backend/src/models/Payment.js
+++ b/backend/src/models/Payment.js
@@ -100,6 +100,15 @@ const Payment = sequelize.define('Payment', {
     allowNull: false,
     defaultValue: 'pending',
   },
+  // Branches checkout + settlement (migration 071): 'package_purchase' rides
+  // the assignment-granting path; 'wallet_topup' credits the agent wallet
+  // inside the same locked settlement transaction (no package involved).
+  kind: {
+    type: DataTypes.STRING(24),
+    allowNull: false,
+    defaultValue: 'package_purchase',
+    validate: { isIn: [['package_purchase', 'wallet_topup']] },
+  },
   source: {
     type: DataTypes.ENUM('mktr_leads_app', 'web', 'admin_comp'),
     allowNull: false,

--- a/backend/src/models/Payment.js
+++ b/backend/src/models/Payment.js
@@ -1,4 +1,4 @@
-import { DataTypes } from 'sequelize';
+import { DataTypes, Op } from 'sequelize';
 import { sequelize } from '../database/connection.js';
 
 /**
@@ -85,7 +85,18 @@ const Payment = sequelize.define('Payment', {
   leadCount: {
     type: DataTypes.INTEGER,
     allowNull: false,
-    validate: { min: 1 },
+    validate: {
+      // Kind-aware: package purchases snapshot ≥1 lead; wallet top-ups carry
+      // no leads at all and MUST stay 0.
+      leadCountMatchesKind(value) {
+        const kind = this.kind || 'package_purchase';
+        if (kind === 'wallet_topup') {
+          if (Number(value) !== 0) throw new Error('Wallet top-ups must have leadCount 0');
+        } else if (!(Number(value) >= 1)) {
+          throw new Error('Validation min on leadCount failed');
+        }
+      },
+    },
   },
   packageName: {
     type: DataTypes.STRING,
@@ -124,8 +135,26 @@ const Payment = sequelize.define('Payment', {
   indexes: [
     { fields: ['agentId', 'status'], name: 'idx_payments_agent_status' },
     { fields: ['status'] },
-    { fields: ['providerRequestId'] },
-    { fields: ['providerPaymentId'] },
+    // Mirror migration 040's unique partials so test sync({force:true})
+    // reproduces prod constraints (provider replay + one payment per assignment).
+    {
+      unique: true,
+      fields: ['providerRequestId'],
+      where: { providerRequestId: { [Op.ne]: null } },
+      name: 'uniq_payments_provider_request',
+    },
+    {
+      unique: true,
+      fields: ['providerPaymentId'],
+      where: { providerPaymentId: { [Op.ne]: null } },
+      name: 'uniq_payments_provider_payment',
+    },
+    {
+      unique: true,
+      fields: ['leadPackageAssignmentId'],
+      where: { leadPackageAssignmentId: { [Op.ne]: null } },
+      name: 'uniq_payments_assignment',
+    },
   ],
 });
 

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -151,6 +151,14 @@ const User = sequelize.define('User', {
     allowNull: true,
     unique: true
   },
+  // Agent-wallet fast read (migration 071). The wallet_ledger is the audit
+  // truth — this column is maintained atomically with every ledger insert
+  // (walletService) and must never be written anywhere else.
+  walletBalanceCents: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    defaultValue: 0
+  },
   // Phase 2 — preserves upstream platform role (agent|manager|director).
   // Internal MKTR `role` keeps using 'agent' for permission purposes;
   // external_role is the lossless mirror for read-side filtering.

--- a/backend/src/models/WalletLedger.js
+++ b/backend/src/models/WalletLedger.js
@@ -1,0 +1,88 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Append-only agent-wallet ledger (migration 070) — the audit truth behind
+ * users.walletBalanceCents. Rows are only ever INSERTed, in the same
+ * transaction as the balance update (walletService.applyLedgerEntry).
+ * No updatedAt by design; agentId RESTRICTs user hard-deletion.
+ */
+const WALLET_LEDGER_TYPES = ['topup', 'commit', 'takedown_refund', 'adjustment'];
+
+const WalletLedger = sequelize.define('WalletLedger', {
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    primaryKey: true
+  },
+  agentId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'users', key: 'id' }
+  },
+  type: {
+    type: DataTypes.STRING(24),
+    allowNull: false,
+    validate: { isIn: [WALLET_LEDGER_TYPES] }
+  },
+  amountCents: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    comment: 'Signed: credits positive, debits negative'
+  },
+  balanceAfterCents: {
+    type: DataTypes.INTEGER,
+    allowNull: false
+  },
+  paymentId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    references: { model: 'payments', key: 'id' }
+  },
+  assignmentId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    references: { model: 'lead_package_assignments', key: 'id' }
+  },
+  campaignId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    references: { model: 'campaigns', key: 'id' }
+  },
+  note: {
+    type: DataTypes.TEXT,
+    allowNull: true
+  },
+  createdBy: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    comment: 'Acting admin for adjustments; null = system',
+    references: { model: 'users', key: 'id' }
+  },
+  createdAt: {
+    type: DataTypes.DATE,
+    allowNull: false,
+    defaultValue: DataTypes.NOW
+  }
+}, {
+  tableName: 'wallet_ledger',
+  timestamps: false, // append-only: explicit createdAt, no updatedAt (070)
+  indexes: [
+    { fields: ['agentId', 'createdAt'], name: 'idx_wallet_ledger_agent_created' },
+    {
+      unique: true,
+      fields: ['assignmentId'],
+      where: { type: 'takedown_refund' },
+      name: 'uq_wallet_ledger_refund_assignment'
+    },
+    {
+      unique: true,
+      fields: ['paymentId'],
+      where: { type: 'topup' },
+      name: 'uq_wallet_ledger_topup_payment'
+    }
+  ]
+});
+
+export { WALLET_LEDGER_TYPES };
+export default WalletLedger;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -29,7 +29,8 @@ function defineAssociations() {
     Device, BeaconEvent, Impression, ShortLink, ShortLinkClick,
     Vehicle, WebhookSubscriber, WebhookDelivery, AgentGroup,
     AgentGroupMember, DeviceCampaignAssignment, VehicleCampaignAssignment,
-    CampaignMediaItem, CampaignAgentAssignment, ExternalAgent, ExternalCampaignAgent
+    CampaignMediaItem, CampaignAgentAssignment, ExternalAgent, ExternalCampaignAgent,
+    WalletLedger
   } = models;
 
   // User associations
@@ -124,6 +125,16 @@ function defineAssociations() {
   Payment.belongsTo(LeadPackage, { foreignKey: 'leadPackageId', as: 'package', onDelete: 'SET NULL' });
   LeadPackageAssignment.hasOne(Payment, { foreignKey: 'leadPackageAssignmentId', as: 'payment', onDelete: 'SET NULL' });
   Payment.belongsTo(LeadPackageAssignment, { foreignKey: 'leadPackageAssignmentId', as: 'assignment', onDelete: 'SET NULL' });
+
+  // WalletLedger associations — append-only financial history. RESTRICT on the
+  // agent (history blocks user hard-deletion; userService pre-checks 409),
+  // SET NULL on refs (a deleted campaign/payment/assignment never erases rows).
+  User.hasMany(WalletLedger, { foreignKey: 'agentId', as: 'walletLedger', onDelete: 'RESTRICT' });
+  WalletLedger.belongsTo(User, { foreignKey: 'agentId', as: 'agent', onDelete: 'RESTRICT' });
+  WalletLedger.belongsTo(User, { foreignKey: 'createdBy', as: 'actor', onDelete: 'SET NULL' });
+  WalletLedger.belongsTo(Payment, { foreignKey: 'paymentId', as: 'payment', onDelete: 'SET NULL' });
+  WalletLedger.belongsTo(LeadPackageAssignment, { foreignKey: 'assignmentId', as: 'assignment', onDelete: 'SET NULL' });
+  WalletLedger.belongsTo(Campaign, { foreignKey: 'campaignId', as: 'campaign', onDelete: 'SET NULL' });
 
   // Device associations
   Device.hasMany(BeaconEvent, { foreignKey: 'deviceId', as: 'events', onDelete: 'CASCADE' });
@@ -335,7 +346,7 @@ export const {
   DiscoveryRun, DiscoveryCandidate,
   DiscoveryPlaceMemory, OutreachCadence, OutreachCadenceStep,
   OutreachCadenceTransition, OutreachCadenceEnrollment, OutreachSuppression,
-  AiSettings
+  AiSettings, WalletLedger
 } = models;
 
 export { sequelize };

--- a/backend/src/routes/adminWallets.js
+++ b/backend/src/routes/adminWallets.js
@@ -1,0 +1,26 @@
+/**
+ * Admin wallet observability + the manual-adjustment exception path.
+ *
+ * Mounted at `/api/admin/wallets` (admin JWT — NOT flag-gated: reads render
+ * honest zeros pre-launch, and the adjustment is admin-authed + fully audited
+ * in wallet_ledger). The admin never sells or cancels here: top-ups happen in
+ * the agents' own app, refunds only via campaign takedown; `adjust` (signed
+ * cents + MANDATORY note) is the sole escape hatch that keeps "no refunds"
+ * enforceable without DB surgery.
+ */
+import express from 'express';
+import { authenticateToken, requireAdmin } from '../middleware/auth.js';
+import { asyncHandler } from '../middleware/errorHandler.js';
+import * as ctrl from '../controllers/adminWalletController.js';
+
+export const meta = { path: '/api/admin/wallets' };
+
+const router = express.Router();
+
+router.use(authenticateToken, requireAdmin);
+
+router.get('/', asyncHandler(ctrl.listWallets));
+router.get('/:agentId/ledger', asyncHandler(ctrl.getAgentLedger));
+router.post('/:agentId/adjust', asyncHandler(ctrl.adjust));
+
+export default router;

--- a/backend/src/routes/externalWallet.js
+++ b/backend/src/routes/externalWallet.js
@@ -1,0 +1,35 @@
+/**
+ * MKTR Leads agent app → wallet (balance, ledger, catalog, commit).
+ *
+ * Mounted at `/api/external/wallet`, HMAC-SHA256 over the raw body
+ * (EXTERNAL_APP_SECRET) like the other external surfaces; rawBody capture +
+ * the rate-limiter exemption for `/api/external/` are wired in
+ * server_internal.js. Gated behind AGENT_WALLET_ENABLED so the route stays
+ * UNMOUNTED until the wallet goes live (deploy-inert). Top-ups are NOT here —
+ * they ride /api/external/billing (kind:'wallet_topup') for HitPay settlement.
+ * There is deliberately no cancel endpoint (no self-cancel of commitments).
+ */
+import express from 'express';
+import {
+  requireExternalHmac,
+  summary,
+  ledger,
+  catalog,
+  commitHandler,
+} from '../controllers/externalWalletController.js';
+
+const router = express.Router();
+
+export const meta = {
+  path: '/api/external/wallet',
+  flag: 'AGENT_WALLET_ENABLED',
+  flagDefault: 'false',
+};
+
+// POST so the body carries the signed `timestamp` (same as external billing).
+router.post('/summary', requireExternalHmac, summary);
+router.post('/ledger', requireExternalHmac, ledger);
+router.post('/catalog', requireExternalHmac, catalog);
+router.post('/commit', requireExternalHmac, commitHandler);
+
+export default router;

--- a/backend/src/services/agentSyncService.js
+++ b/backend/src/services/agentSyncService.js
@@ -470,7 +470,8 @@ async function runSync(adapter, localIdField, startedAt) {
             AND "${localIdField}" IS NOT NULL
             AND "${localIdField}" NOT IN (:upstreamExternalIds)
             AND pending_deletion_at IS NULL
-            AND id NOT IN (SELECT DISTINCT "assignedAgentId" FROM prospects WHERE "assignedAgentId" IS NOT NULL)`,
+            AND id NOT IN (SELECT DISTINCT "assignedAgentId" FROM prospects WHERE "assignedAgentId" IS NOT NULL)
+            AND id NOT IN (SELECT DISTINCT "agentId" FROM wallet_ledger)`,
         { replacements: { upstreamExternalIds } }
       );
 
@@ -487,6 +488,7 @@ async function runSync(adapter, localIdField, startedAt) {
                AND pending_deletion_at IS NOT NULL
                AND pending_deletion_at < NOW() - INTERVAL '${DELETE_GRACE_HOURS} hours'
                AND id NOT IN (SELECT DISTINCT "assignedAgentId" FROM prospects WHERE "assignedAgentId" IS NOT NULL)
+               AND id NOT IN (SELECT DISTINCT "agentId" FROM wallet_ledger)
             RETURNING id
          )
          SELECT COUNT(*)::int AS count FROM deleted`,

--- a/backend/src/services/billingService.js
+++ b/backend/src/services/billingService.js
@@ -15,10 +15,14 @@ import { Op } from 'sequelize';
 import { Payment, LeadPackage, LeadPackageAssignment, User, Campaign, sequelize } from '../models/index.js';
 import * as hitpay from './hitpayClient.js';
 import { buildPurchaseDocument, docTypeForStatus } from './billingDocumentService.js';
+import { credit as walletCredit } from './walletService.js';
 import { logger } from '../utils/logger.js';
 
 const VALID_CHECKOUT_MODES = ['in_app', 'web', 'off'];
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+// Wallet top-up presets (cents). Strict whitelist — the app UI offers exactly
+// these; anything else is rejected before a Payment row exists.
+const WALLET_TOPUP_PRESETS_CENTS = [10000, 50000, 200000];
 
 /**
  * Strict money string → integer cents. Rejects non-canonical input (exponent, >2 decimals,
@@ -61,7 +65,7 @@ function campaignNotes(c) {
 }
 
 export function makeBillingService(overrides = {}) {
-  const d = { Payment, LeadPackage, LeadPackageAssignment, User, Campaign, sequelize, hitpay, buildPurchaseDocument, logger, ...overrides };
+  const d = { Payment, LeadPackage, LeadPackageAssignment, User, Campaign, sequelize, hitpay, buildPurchaseDocument, walletCredit, logger, ...overrides };
 
   /** Server-controlled in-app-checkout kill switch (App-Store mitigation). */
   function checkoutMode() {
@@ -222,6 +226,58 @@ export function makeBillingService(overrides = {}) {
     }
   }
 
+  /**
+   * Create a pending wallet TOP-UP Payment + HitPay request (kind:'wallet_topup').
+   * No package involved: leadPackageId null, leadCount 0. Amount must be one of
+   * the preset whitelist. Settlement (fulfillFromWebhook) credits the wallet
+   * inside the same locked transaction that flips the Payment to paid.
+   * Typed outcomes: created | invalid_agent | invalid_amount | provider_error.
+   */
+  async function createWalletTopupCheckout({ agentMktrUserId, amountCents }) {
+    const agent = await resolveAgent(agentMktrUserId);
+    if (!agent) return { status: 'invalid_agent' };
+    if (!Number.isInteger(amountCents) || !WALLET_TOPUP_PRESETS_CENTS.includes(amountCents)) {
+      return { status: 'invalid_amount', presets: WALLET_TOPUP_PRESETS_CENTS };
+    }
+    const amountDollars = (amountCents / 100).toFixed(2);
+
+    const payment = await d.Payment.create({
+      agentId: agent.id,
+      beneficiaryUserId: null,
+      forTeam: false,
+      beneficiaryName: null,
+      leadPackageId: null,
+      kind: 'wallet_topup',
+      provider: 'hitpay',
+      amount: amountDollars,
+      currency: 'SGD',
+      leadCount: 0,
+      packageName: 'Wallet top-up',
+      campaignName: null,
+      status: 'pending',
+      source: 'mktr_leads_app',
+    });
+
+    try {
+      const { id, url } = await d.hitpay.createPaymentRequest({
+        amount: amountDollars,
+        referenceNumber: payment.id,
+        name: agent.fullName || `${agent.firstName || ''} ${agent.lastName || ''}`.trim() || undefined,
+        email: agent.email || undefined,
+        redirectUrl: process.env.HITPAY_REDIRECT_URL || undefined,
+        webhookUrl: process.env.HITPAY_WEBHOOK_URL || undefined,
+        purpose: 'Wallet top-up',
+      });
+      await payment.update({ providerRequestId: id });
+      d.logger.info('[billing] topup.checkout.created', { purchaseId: payment.id, agentId: agent.id, amountCents });
+      return { status: 'created', url, purchaseId: payment.id };
+    } catch (err) {
+      await payment.update({ status: 'failed' }).catch(() => {});
+      d.logger.error('[billing] topup checkout HitPay create failed', { purchaseId: payment.id, error: err?.message || String(err) });
+      return { status: 'provider_error' };
+    }
+  }
+
   /** Poll one of the agent's OWN purchases (self-scoped). */
   async function getPurchaseStatus({ agentMktrUserId, purchaseId }) {
     const agent = await resolveAgent(agentMktrUserId);
@@ -371,6 +427,39 @@ export function makeBillingService(overrides = {}) {
         return { status: 'rejected' };
       }
 
+      // ── Wallet top-up branch (kind:'wallet_topup') ─────────────────────────
+      // No package is involved: credit the agent's wallet INSIDE this locked
+      // transaction, then flip the Payment to paid. The row lock + only-pending
+      // flip give idempotency; the unique (paymentId WHERE type='topup') ledger
+      // index is defense in depth. Must run BEFORE the package path so a top-up
+      // can never fall into paid_unfulfilled.
+      if (payment.kind === 'wallet_topup') {
+        if (!payment.agentId) {
+          await payment.update(
+            { status: 'paid', providerPaymentId: providerPaymentId ? String(providerPaymentId) : payment.providerPaymentId, rawWebhook: payload },
+            { transaction: t },
+          );
+          d.logger.error('[billing] topup.unfulfillable — paid but agent missing; manual review', { ref });
+          return { status: 'paid_unfulfilled' };
+        }
+        const creditCents = toCents(payment.amount);
+        await d.walletCredit(payment.agentId, creditCents, {
+          type: 'topup',
+          paymentId: payment.id,
+          transaction: t,
+        });
+        await payment.update(
+          {
+            status: 'paid',
+            providerPaymentId: providerPaymentId ? String(providerPaymentId) : payment.providerPaymentId,
+            rawWebhook: payload,
+          },
+          { transaction: t },
+        );
+        d.logger.info('[billing] topup.fulfilled', { ref, agentId: payment.agentId, amountCents: creditCents });
+        return { status: 'fulfilled', walletTopup: true };
+      }
+
       // The GRANTEE: the snapshotted beneficiary for a team purchase, else the payer.
       // forTeam is immutable and survives the beneficiary FK SET NULL, so an explicit
       // team purchase NEVER silently falls back to crediting the payer.
@@ -428,13 +517,14 @@ export function makeBillingService(overrides = {}) {
     return result;
   }
 
-  return { getCatalog, createCheckout, getPurchaseStatus, getHistory, getDocument, fulfillFromWebhook, checkoutMode };
+  return { getCatalog, createCheckout, createWalletTopupCheckout, getPurchaseStatus, getHistory, getDocument, fulfillFromWebhook, checkoutMode };
 }
 
 // --- Backward-compatible named exports (house pattern) ---
 const _default = makeBillingService();
 export const getCatalog = _default.getCatalog;
 export const createCheckout = _default.createCheckout;
+export const createWalletTopupCheckout = _default.createWalletTopupCheckout;
 export const getPurchaseStatus = _default.getPurchaseStatus;
 export const getHistory = _default.getHistory;
 export const getDocument = _default.getDocument;

--- a/backend/src/services/campaignService.js
+++ b/backend/src/services/campaignService.js
@@ -9,8 +9,19 @@ import { applyFeaturedDropPolicy } from '../utils/featuredDrop.js';
 import { applyLuckyDrawPolicy } from '../utils/luckyDraw.js';
 import { normalizeMarketplaceContent, applyMarketplacePolicy } from '../utils/marketplaceContent.js';
 import { invalidateMarketplaceCache } from './marketplaceCache.js';
+import { refundCampaignCommitments } from './walletService.js';
 
 const SLUG_RE = /^[a-z0-9-]{3,80}$/;
+
+/** Wallet commit price: null/'' clears; else a positive integer in cents. */
+function normalizeLeadPriceCents(value) {
+  if (value === null || value === '') return null;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1 || n > 100000000) {
+    throw new AppError('leadPriceCents must be a positive integer (cents) or null', 422);
+  }
+  return n;
+}
 
 // design_config keys owned by the marketplace normalizer — raw incoming values
 // for these are replaced wholesale by their normalized versions (or dropped).
@@ -315,6 +326,11 @@ export async function createCampaign(body, user) {
   if (enforceLeadQuota !== undefined) campaignData.enforceLeadQuota = enforceLeadQuota;
   if (body.metaPixelId !== undefined) campaignData.metaPixelId = body.metaPixelId || null;
   if (body.tiktokPixelId !== undefined) campaignData.tiktokPixelId = body.tiktokPixelId || null;
+  // Wallet commit price — admin-only (campaign POST is open to agents; the
+  // same silent-clamp policy as design_config's admin-gated keys).
+  if (body.leadPriceCents !== undefined && user?.role === 'admin') {
+    campaignData.leadPriceCents = normalizeLeadPriceCents(body.leadPriceCents);
+  }
   // Allow design_config at creation time (mirrors updateCampaign) so a campaign
   // can be created with its designer config in one call, not create-then-update.
   if (body.design_config !== undefined) {
@@ -443,6 +459,10 @@ export async function updateCampaign(id, body, req) {
   if (enforceLeadQuota !== undefined) updateData.enforceLeadQuota = enforceLeadQuota;
   if (body.metaPixelId !== undefined) updateData.metaPixelId = body.metaPixelId || null;
   if (body.tiktokPixelId !== undefined) updateData.tiktokPixelId = body.tiktokPixelId || null;
+  // Wallet commit price — admin-only silent clamp (non-admin edits never touch it).
+  if (body.leadPriceCents !== undefined && req.user?.role === 'admin') {
+    updateData.leadPriceCents = normalizeLeadPriceCents(body.leadPriceCents);
+  }
 
   try {
     await campaign.update(updateData);
@@ -520,18 +540,30 @@ export async function setCampaignLaunchState(id, state, req) {
 }
 
 /**
- * Soft-delete (archive) a campaign.
+ * Soft-delete (archive) a campaign. Transactional: the campaign row is locked,
+ * open wallet commitments are refunded (takedown refund — the ONLY refund path,
+ * see walletService), and the status flips, all-or-nothing. A concurrent
+ * archive either loses the row lock and sees 'archived' (400) or the unique
+ * per-assignment refund index blocks the double-credit. QR detach stays
+ * post-commit (best-effort side effect, as before). NOTE: if a 'completed'
+ * status transition is ever added, it MUST route through this same
+ * refund-then-flip transaction — 'completed' is takedown too (product
+ * decision 5 in docs/plans/agent-wallet-commitments.md).
  */
 export async function archiveCampaign(id, req) {
   const where = buildOwnerWhere(req, { id });
-  const campaign = await Campaign.findOne({ where });
-  if (!campaign) throw new AppError('Campaign not found or access denied', 404);
+  const campaign = await sequelize.transaction(async (t) => {
+    const row = await Campaign.findOne({ where, transaction: t, lock: t.LOCK.UPDATE });
+    if (!row) throw new AppError('Campaign not found or access denied', 404);
+    if (row.status === 'archived') {
+      throw new AppError('Campaign is already archived', 400);
+    }
 
-  if (campaign.status === 'archived') {
-    throw new AppError('Campaign is already archived', 400);
-  }
+    await refundCampaignCommitments(id, { reason: 'campaign_archived', transaction: t });
+    await row.update({ status: 'archived' }, { transaction: t });
+    return row;
+  });
 
-  await campaign.update({ status: 'archived' });
   await detachCarQrTags(id);
   return campaign;
 }

--- a/backend/src/services/campaignService.js
+++ b/backend/src/services/campaignService.js
@@ -647,6 +647,10 @@ export async function duplicateCampaign(id, body, req) {
     // original's activation history — a copy starts with neither.
     slug: null,
     firstActivatedAt: null,
+    // Never clone the wallet commit price: it is admin-only policy, and a
+    // non-admin duplicating a priced public campaign must not mint a new
+    // commit-able campaign (an admin re-prices the copy deliberately).
+    leadPriceCents: null,
     createdAt: undefined,
     updatedAt: undefined
   });

--- a/backend/src/services/leadPackageService.js
+++ b/backend/src/services/leadPackageService.js
@@ -8,7 +8,8 @@ import { logger } from '../utils/logger.js';
  * Agents only see active + public packages.
  */
 export async function listPackages({ status, campaignId, userRole }) {
-  const where = {};
+  // Hidden wallet containers are managed by the wallet service, never here.
+  const where = { kind: { [Op.ne]: 'wallet' } };
   if (status) where.status = status;
   if (campaignId) where.campaignId = campaignId;
 
@@ -103,6 +104,7 @@ export async function updatePackage(id, fields) {
   if (!pkg) {
     throw new AppError('Package not found', 404);
   }
+  rejectWalletPackage(pkg);
 
   // NOTE: `currency` is deliberately absent — it is forced SGD at create and is
   // never editable (length-only validation on the column would otherwise accept
@@ -333,6 +335,8 @@ export async function resolveCreator(actorMktrUserId) {
 /** Catalog list for the admin app — full fields + per-package assignmentCount (Archive vs Delete). */
 export async function getExternalAdminCatalog() {
   const packages = await LeadPackage.findAll({
+    // Wallet containers are not grantable SKUs — hidden from the admin catalog.
+    where: { kind: { [Op.ne]: 'wallet' } },
     include: [{ model: Campaign, as: 'campaign', attributes: ['id', 'name', 'status'] }],
     order: [['createdAt', 'DESC']],
   });
@@ -456,6 +460,24 @@ async function loadMktrLeadsAssignment(assignmentId) {
 }
 
 /**
+ * Wallet commitments are PAID financial records with their own lifecycle
+ * (walletService: debit at commit, refund only on campaign takedown). No
+ * generic package-admin mutation may touch them — inflating, cancelling,
+ * moving or destroying one corrupts the ledger's audit trail.
+ */
+function rejectWalletAssignment(assignment) {
+  if (assignment?.source === 'wallet') {
+    throw new AppError('Wallet commitments cannot be modified here — they resolve only by delivery or campaign takedown.', 409);
+  }
+}
+
+function rejectWalletPackage(pkg) {
+  if (pkg?.kind === 'wallet') {
+    throw new AppError('This is a hidden wallet-commitment container managed by the wallet service — it cannot be edited or deleted.', 409);
+  }
+}
+
+/**
  * Assign an ACTIVE catalog package to a mktr-leads agent. Active-only guard +
  * duplicate guard under the same per-package advisory lock bulkAssignPackage uses
  * (no unique (agentId,leadPackageId) index). Optional custom leadsTotal override.
@@ -520,6 +542,7 @@ export async function assignPackageExternal({ agentMktrUserId, packageId, leadsT
 export async function topUpAssignment({ assignmentId, addLeads, setRemaining }) {
   const a = await loadMktrLeadsAssignment(assignmentId);
   if (!a) throw new AppError('Assignment not found', 404);
+  rejectWalletAssignment(a);
   if (a.status !== 'active' && a.status !== 'completed') {
     throw new AppError('Cannot modify a cancelled or expired assignment', 409);
   }
@@ -550,6 +573,7 @@ export async function topUpAssignment({ assignmentId, addLeads, setRemaining }) 
 export async function cancelAssignment(assignmentId) {
   const a = await loadMktrLeadsAssignment(assignmentId);
   if (!a) throw new AppError('Assignment not found', 404);
+  rejectWalletAssignment(a);
   if (a.status === 'cancelled') return { assignment: a };
   await a.update({ status: 'cancelled' });
   return { assignment: a };
@@ -559,6 +583,7 @@ export async function cancelAssignment(assignmentId) {
 export async function removeAssignmentExternal(assignmentId) {
   const a = await loadMktrLeadsAssignment(assignmentId);
   if (!a) throw new AppError('Assignment not found', 404);
+  rejectWalletAssignment(a);
   await a.destroy();
   return { ok: true };
 }
@@ -571,6 +596,7 @@ export async function deleteAssignment(id) {
   if (!assignment) {
     throw new AppError('Assignment not found', 404);
   }
+  rejectWalletAssignment(assignment);
 
   await assignment.destroy();
 }
@@ -583,6 +609,7 @@ export async function updateAssignment(id, { leadsRemaining }) {
   if (!assignment) {
     throw new AppError('Assignment not found', 404);
   }
+  rejectWalletAssignment(assignment);
 
   if (leadsRemaining !== undefined) {
     const newCount = parseInt(leadsRemaining, 10);
@@ -622,6 +649,7 @@ export async function deletePackage(id) {
   if (!pkg) {
     throw new AppError('Package not found', 404);
   }
+  rejectWalletPackage(pkg);
 
   const assignmentCount = await LeadPackageAssignment.count({
     where: { leadPackageId: id }

--- a/backend/src/services/leadQuota.js
+++ b/backend/src/services/leadQuota.js
@@ -35,7 +35,13 @@ const EXEMPT_ROUTES = new Set(['self', 'admin']);
 export async function decideAssignment({ campaign, routing, campaignId, transaction = null, charge }) {
   const via = routing?.via ?? 'fallback';
   const agentId = routing?.agentId ?? null;
-  const quota = campaign?.enforceLeadQuota === true;
+  // Priced campaigns (agent-wallet commitments, leadPriceCents set) are ALWAYS
+  // quota-enforced: their leads are pre-sold, so a failed charge must hold the
+  // lead, never deliver it free — independent of the admin's enforceLeadQuota
+  // toggle (which stays the knob for unpriced/package campaigns). Exempt human
+  // routes (self/admin) keep their deliberate-override semantics.
+  const priced = Number.isInteger(campaign?.leadPriceCents) && campaign.leadPriceCents > 0;
+  const quota = campaign?.enforceLeadQuota === true || priced;
   const exempt = EXEMPT_ROUTES.has(via);
 
   // Soft campaigns, or exempt human/explicit routes: deliver exactly as today. The

--- a/backend/src/services/userService.js
+++ b/backend/src/services/userService.js
@@ -1,6 +1,30 @@
 import { Op } from 'sequelize';
-import { User, Campaign, Commission, sequelize, Prospect, LeadPackageAssignment, ProspectActivity } from '../models/index.js';
+import { User, Campaign, Commission, sequelize, Prospect, LeadPackageAssignment, ProspectActivity, WalletLedger } from '../models/index.js';
 import { AppError } from '../middleware/errorHandler.js';
+
+/**
+ * Wallet-account closure policy (docs/plans/agent-wallet-commitments.md):
+ * deactivation/deletion must never erase or strand paid credits. Throws 409
+ * when the user holds a balance or open wallet commitments — the admin
+ * resolves those first (campaign takedown, or a manual adjustment to zero).
+ */
+async function assertNoOpenWalletState(userIds, { transaction } = {}) {
+  const ids = Array.isArray(userIds) ? userIds : [userIds];
+  const funded = await User.count({
+    where: { id: { [Op.in]: ids }, walletBalanceCents: { [Op.gt]: 0 } },
+    transaction
+  });
+  if (funded > 0) {
+    throw new AppError('User has a wallet balance. Zero it (manual adjustment, note required) before deactivating or deleting.', 409);
+  }
+  const openCommitments = await LeadPackageAssignment.count({
+    where: { agentId: { [Op.in]: ids }, source: 'wallet', status: 'active', leadsRemaining: { [Op.gt]: 0 } },
+    transaction
+  });
+  if (openCommitments > 0) {
+    throw new AppError('User has open wallet commitments. They resolve only by delivery or campaign takedown.', 409);
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -336,6 +360,8 @@ export async function deactivateUser(userId, actorId) {
     throw new AppError('User not found', 404);
   }
 
+  await assertNoOpenWalletState(userId);
+
   await sequelize.transaction(async (t) => {
     const assignedProspects = await Prospect.findAll({
       where: { assignedAgentId: userId },
@@ -355,8 +381,10 @@ export async function deactivateUser(userId, actorId) {
       { where: { assignedAgentId: userId }, transaction: t }
     );
 
+    // Wallet-source rows are financial history — never destroyed here (the
+    // pre-check above guarantees none are still open).
     await LeadPackageAssignment.destroy({
-      where: { agentId: userId }, transaction: t
+      where: { agentId: userId, source: { [Op.ne]: 'wallet' } }, transaction: t
     });
 
     await user.update({ isActive: false }, { transaction: t });
@@ -384,6 +412,14 @@ export async function permanentlyDeleteUser(userId, actorId) {
   const commissionCount = await Commission.count({ where: { agentId: userId } });
   if (commissionCount > 0) {
     throw new AppError('Cannot delete user with commissions. Archive commissions first.', 409);
+  }
+
+  // Wallet history is a DB-level RESTRICT (wallet_ledger.agentId) — pre-check
+  // for a friendly 409 instead of a raw FK error. Any ledger row blocks
+  // hard-deletion permanently: financial history is never erased.
+  const walletHistoryCount = await WalletLedger.count({ where: { agentId: userId } });
+  if (walletHistoryCount > 0) {
+    throw new AppError('Cannot delete user with wallet history. Deactivate the account instead.', 409);
   }
 
   await sequelize.transaction(async (t) => {
@@ -415,6 +451,14 @@ export async function permanentlyDeleteUser(userId, actorId) {
 export async function bulkDeleteUsers(userIds, actorId) {
   let deletedCount = 0;
 
+  // Same wallet guards as single delete: open state 409s, and ANY ledger
+  // history blocks hard-deletion (DB RESTRICT would abort the tx anyway).
+  await assertNoOpenWalletState(userIds);
+  const walletHistoryCount = await WalletLedger.count({ where: { agentId: { [Op.in]: userIds } } });
+  if (walletHistoryCount > 0) {
+    throw new AppError('One or more users have wallet history and cannot be hard-deleted. Deactivate them instead.', 409);
+  }
+
   await sequelize.transaction(async (t) => {
     // Fetch agent info for activity logs
     const agents = await User.findAll({
@@ -444,7 +488,7 @@ export async function bulkDeleteUsers(userIds, actorId) {
     );
 
     await LeadPackageAssignment.destroy({
-      where: { agentId: { [Op.in]: userIds } },
+      where: { agentId: { [Op.in]: userIds }, source: { [Op.ne]: 'wallet' } },
       transaction: t
     });
 

--- a/backend/src/services/userService.js
+++ b/backend/src/services/userService.js
@@ -360,9 +360,13 @@ export async function deactivateUser(userId, actorId) {
     throw new AppError('User not found', 404);
   }
 
-  await assertNoOpenWalletState(userId);
-
   await sequelize.transaction(async (t) => {
+    // Lock the user row FIRST, then run the wallet guard INSIDE the same
+    // transaction — serializes against walletService.commit's own user lock,
+    // so a commit can't slip between the guard check and the deactivation.
+    await User.findByPk(userId, { transaction: t, lock: t.LOCK.UPDATE });
+    await assertNoOpenWalletState(userId, { transaction: t });
+
     const assignedProspects = await Prospect.findAll({
       where: { assignedAgentId: userId },
       attributes: ['id'],

--- a/backend/src/services/walletService.js
+++ b/backend/src/services/walletService.js
@@ -81,30 +81,33 @@ export function makeWalletService(overrides = {}) {
    * Find-or-create the campaign's hidden wallet package. The UNIQUE partial index
    * (campaignId WHERE kind='wallet') makes the create race-safe: a concurrent first
    * commit loses the insert and re-reads the winner's row.
+   *
+   * Runs OUTSIDE the money transaction on purpose: catching a unique violation
+   * INSIDE an open Postgres transaction leaves it aborted (25P02 — every later
+   * statement fails), so the lose-and-re-read retry only works standalone. A
+   * stray empty wallet package from a commit that later fails is harmless
+   * (isPublic:false, price 0 — invisible to the buy catalog and to routing).
    */
-  async function ensureWalletPackage(campaignId, transaction) {
-    const existing = await d.LeadPackage.findOne({ where: { campaignId, kind: 'wallet' }, transaction });
+  async function ensureWalletPackage(campaignId) {
+    const existing = await d.LeadPackage.findOne({ where: { campaignId, kind: 'wallet' } });
     if (existing) return existing;
     const systemAgentId = await d.getSystemAgentId();
     try {
-      return await d.LeadPackage.create(
-        {
-          name: 'Wallet commitments',
-          type: 'custom',
-          kind: 'wallet',
-          campaignId,
-          isPublic: false,
-          status: 'active',
-          currency: 'SGD',
-          price: 0,
-          leadCount: 0,
-          createdBy: systemAgentId,
-        },
-        { transaction }
-      );
+      return await d.LeadPackage.create({
+        name: 'Wallet commitments',
+        type: 'custom',
+        kind: 'wallet',
+        campaignId,
+        isPublic: false,
+        status: 'active',
+        currency: 'SGD',
+        price: 0,
+        leadCount: 0,
+        createdBy: systemAgentId,
+      });
     } catch (err) {
       if (err?.name === 'SequelizeUniqueConstraintError') {
-        const winner = await d.LeadPackage.findOne({ where: { campaignId, kind: 'wallet' }, transaction });
+        const winner = await d.LeadPackage.findOne({ where: { campaignId, kind: 'wallet' } });
         if (winner) return winner;
       }
       throw err;
@@ -113,16 +116,25 @@ export function makeWalletService(overrides = {}) {
 
   /**
    * Agent self-serve commit: N leads of campaign X at the admin-set price.
-   * One transaction: validate → ensure wallet package → create assignment →
-   * debit (guarded; overdraft rolls the assignment back). No cancel path exists.
+   * Wallet package is ensured up front (own retry, see above); then one money
+   * transaction: validate campaign under a SHARE row lock → create assignment →
+   * debit (guarded; overdraft rolls the assignment back). The SHARE lock
+   * serializes against archiveCampaign's FOR UPDATE, so a commit either lands
+   * BEFORE the archive (and its refund sweep sees the new assignment) or sees
+   * 'archived' and rejects — no window for an orphaned paid commitment.
+   * No cancel path exists.
    */
   async function commit(agentId, campaignId, quantity) {
     if (!Number.isInteger(quantity) || quantity < 1 || quantity > MAX_COMMIT_QUANTITY) {
       throw new AppError(`Quantity must be an integer between 1 and ${MAX_COMMIT_QUANTITY}`, 400);
     }
 
+    const exists = await d.Campaign.findByPk(campaignId, { attributes: ['id'] });
+    if (!exists) throw new AppError('Campaign not found', 404);
+    const pkg = await ensureWalletPackage(campaignId);
+
     const result = await d.sequelize.transaction(async (t) => {
-      const campaign = await d.Campaign.findByPk(campaignId, { transaction: t });
+      const campaign = await d.Campaign.findByPk(campaignId, { transaction: t, lock: t.LOCK.SHARE });
       if (!campaign) throw new AppError('Campaign not found', 404);
       const priced = Number.isInteger(campaign.leadPriceCents) && campaign.leadPriceCents > 0;
       if (campaign.status !== 'active' || campaign.is_active !== true || !priced) {
@@ -130,7 +142,6 @@ export function makeWalletService(overrides = {}) {
       }
 
       const totalCents = quantity * campaign.leadPriceCents;
-      const pkg = await ensureWalletPackage(campaignId, t);
       const assignment = await d.LeadPackageAssignment.create(
         {
           agentId,
@@ -201,21 +212,20 @@ export function makeWalletService(overrides = {}) {
         continue;
       }
       const refundCents = row.leadsRemaining * row.unitPriceCents;
-      try {
-        await credit(row.agentId, refundCents, {
-          type: 'takedown_refund',
-          assignmentId: row.id,
-          campaignId,
-          note: reason,
-          transaction,
-        });
-      } catch (err) {
-        if (err?.name === 'SequelizeUniqueConstraintError') {
-          d.logger.warn('[wallet] refund.replay — assignment already refunded', { assignmentId: row.id, campaignId });
-          continue;
-        }
-        throw err;
-      }
+      // NOTE: no catch-and-continue here. The unique partial index (one
+      // takedown_refund per assignment) is unreachable in normal operation —
+      // ledger row + assignment completion commit together, and the row locks
+      // + re-check above serialize concurrent archives. If it EVER fires it
+      // signals a code bug, and swallowing it inside this open transaction
+      // would poison it anyway (Postgres 25P02) — so it aborts loudly and the
+      // whole archive rolls back.
+      await credit(row.agentId, refundCents, {
+        type: 'takedown_refund',
+        assignmentId: row.id,
+        campaignId,
+        note: reason,
+        transaction,
+      });
       await row.update({ leadsRemaining: 0, status: 'completed' }, { transaction });
       refunded += 1;
       totalCents += refundCents;

--- a/backend/src/services/walletService.js
+++ b/backend/src/services/walletService.js
@@ -1,0 +1,382 @@
+/**
+ * Agent wallet + per-campaign lead commitments (docs/plans/agent-wallet-commitments.md).
+ *
+ * Money-path invariants:
+ *  1. Every balance mutation = ONE ledger INSERT + ONE guarded balance UPDATE in the
+ *     SAME transaction (applyLedgerEntry). The guarded UPDATE
+ *     (`walletBalanceCents + :amount >= 0` in the WHERE) is the atomic overdraft check —
+ *     no read-modify-write race.
+ *  2. wallet_ledger is append-only audit truth; users.walletBalanceCents is the fast read.
+ *  3. A commitment is a normal LeadPackageAssignment (source:'wallet') under a hidden
+ *     per-campaign wallet LeadPackage (kind:'wallet', isPublic:false, price 0) — routing,
+ *     charging and drain-down are untouched (systemAgent.js joins assignments through
+ *     LeadPackage.campaignId regardless of kind/source).
+ *  4. The ONLY refund is the campaign-takedown refund (archive; 'completed' is unreachable
+ *     today). Pause holds. No self-cancel. Manual admin `adjustment` (note required) is
+ *     the sole escape hatch.
+ *  5. Commit-ability = campaign active + leadPriceCents non-null. It never reads
+ *     campaign.externalEligible (the inert ExternalAgent buyer-pool flag).
+ *
+ * DI-factory (house pattern) so it unit-tests without a DB.
+ */
+import { Op } from 'sequelize';
+import { User, Campaign, LeadPackage, LeadPackageAssignment, WalletLedger, sequelize } from '../models/index.js';
+import { getSystemAgentId } from './systemAgent.js';
+import { AppError } from '../middleware/errorHandler.js';
+import { logger } from '../utils/logger.js';
+
+const MAX_COMMIT_QUANTITY = 10000; // fat-finger guard; the wallet balance is the real bound
+
+export function makeWalletService(overrides = {}) {
+  const d = { User, Campaign, LeadPackage, LeadPackageAssignment, WalletLedger, sequelize, getSystemAgentId, logger, ...overrides };
+
+  /**
+   * The single write path: guarded atomic balance UPDATE + ledger INSERT, in the
+   * caller's transaction (or its own). `amountCents` is SIGNED. Throws:
+   *  - 409 insufficient_balance when a debit would go below zero
+   *  - 404 when the agent row doesn't exist
+   * Returns the created ledger row (with balanceAfterCents).
+   */
+  async function applyLedgerEntry(agentId, amountCents, { type, paymentId = null, assignmentId = null, campaignId = null, note = null, createdBy = null, transaction = null } = {}) {
+    if (!Number.isInteger(amountCents) || amountCents === 0) {
+      throw new AppError('Ledger amount must be a non-zero integer (cents)', 400);
+    }
+    if (!type) throw new AppError('Ledger type is required', 400);
+
+    const run = async (t) => {
+      const [rows] = await d.sequelize.query(
+        `UPDATE users
+            SET "walletBalanceCents" = "walletBalanceCents" + :amount
+          WHERE id = :agentId AND "walletBalanceCents" + :amount >= 0
+          RETURNING "walletBalanceCents"`,
+        { replacements: { amount: amountCents, agentId }, transaction: t }
+      );
+      if (!rows || rows.length === 0) {
+        // Distinguish missing user from overdraft for a truthful error.
+        const exists = await d.User.count({ where: { id: agentId }, transaction: t });
+        if (!exists) throw new AppError('Agent not found', 404);
+        throw new AppError('Insufficient wallet balance', 409);
+      }
+      const balanceAfterCents = rows[0].walletBalanceCents;
+      const entry = await d.WalletLedger.create(
+        { agentId, type, amountCents, balanceAfterCents, paymentId, assignmentId, campaignId, note, createdBy },
+        { transaction: t }
+      );
+      return entry;
+    };
+
+    return transaction ? run(transaction) : d.sequelize.transaction(run);
+  }
+
+  const credit = (agentId, amountCents, opts = {}) => {
+    if (!Number.isInteger(amountCents) || amountCents <= 0) throw new AppError('Credit amount must be a positive integer (cents)', 400);
+    return applyLedgerEntry(agentId, amountCents, opts);
+  };
+  const debit = (agentId, amountCents, opts = {}) => {
+    if (!Number.isInteger(amountCents) || amountCents <= 0) throw new AppError('Debit amount must be a positive integer (cents)', 400);
+    return applyLedgerEntry(agentId, -amountCents, opts);
+  };
+
+  /**
+   * Find-or-create the campaign's hidden wallet package. The UNIQUE partial index
+   * (campaignId WHERE kind='wallet') makes the create race-safe: a concurrent first
+   * commit loses the insert and re-reads the winner's row.
+   */
+  async function ensureWalletPackage(campaignId, transaction) {
+    const existing = await d.LeadPackage.findOne({ where: { campaignId, kind: 'wallet' }, transaction });
+    if (existing) return existing;
+    const systemAgentId = await d.getSystemAgentId();
+    try {
+      return await d.LeadPackage.create(
+        {
+          name: 'Wallet commitments',
+          type: 'custom',
+          kind: 'wallet',
+          campaignId,
+          isPublic: false,
+          status: 'active',
+          currency: 'SGD',
+          price: 0,
+          leadCount: 0,
+          createdBy: systemAgentId,
+        },
+        { transaction }
+      );
+    } catch (err) {
+      if (err?.name === 'SequelizeUniqueConstraintError') {
+        const winner = await d.LeadPackage.findOne({ where: { campaignId, kind: 'wallet' }, transaction });
+        if (winner) return winner;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Agent self-serve commit: N leads of campaign X at the admin-set price.
+   * One transaction: validate → ensure wallet package → create assignment →
+   * debit (guarded; overdraft rolls the assignment back). No cancel path exists.
+   */
+  async function commit(agentId, campaignId, quantity) {
+    if (!Number.isInteger(quantity) || quantity < 1 || quantity > MAX_COMMIT_QUANTITY) {
+      throw new AppError(`Quantity must be an integer between 1 and ${MAX_COMMIT_QUANTITY}`, 400);
+    }
+
+    const result = await d.sequelize.transaction(async (t) => {
+      const campaign = await d.Campaign.findByPk(campaignId, { transaction: t });
+      if (!campaign) throw new AppError('Campaign not found', 404);
+      const priced = Number.isInteger(campaign.leadPriceCents) && campaign.leadPriceCents > 0;
+      if (campaign.status !== 'active' || campaign.is_active !== true || !priced) {
+        throw new AppError('This campaign is not open for commitments', 409);
+      }
+
+      const totalCents = quantity * campaign.leadPriceCents;
+      const pkg = await ensureWalletPackage(campaignId, t);
+      const assignment = await d.LeadPackageAssignment.create(
+        {
+          agentId,
+          leadPackageId: pkg.id,
+          source: 'wallet',
+          unitPriceCents: campaign.leadPriceCents,
+          leadsTotal: quantity,
+          leadsRemaining: quantity,
+          priceSnapshot: (totalCents / 100).toFixed(2),
+          status: 'active',
+          purchaseDate: new Date(),
+        },
+        { transaction: t }
+      );
+      const entry = await debit(agentId, totalCents, {
+        type: 'commit',
+        assignmentId: assignment.id,
+        campaignId,
+        transaction: t,
+      });
+
+      return {
+        assignmentId: assignment.id,
+        campaignId,
+        campaignName: campaign.name,
+        quantity,
+        unitPriceCents: campaign.leadPriceCents,
+        totalCents,
+        balanceCents: entry.balanceAfterCents,
+      };
+    });
+
+    d.logger.info('[wallet] commit.created', { agentId, campaignId, quantity, totalCents: result.totalCents, assignmentId: result.assignmentId });
+    return result;
+  }
+
+  /**
+   * Campaign-takedown refund: every open wallet commitment returns its undelivered
+   * remainder as credits (leadsRemaining × unitPriceCents). MUST run inside the
+   * caller's transaction (archiveCampaign owns the campaign lock). Concurrency-safe:
+   * rows are re-selected FOR UPDATE and re-checked; the unique partial ledger index
+   * (one takedown_refund per assignment) is the backstop against double-credit.
+   */
+  async function refundCampaignCommitments(campaignId, { reason = 'campaign_archived', transaction } = {}) {
+    if (!transaction) throw new AppError('refundCampaignCommitments requires the caller transaction', 500);
+
+    const candidates = await d.LeadPackageAssignment.findAll({
+      attributes: ['id'],
+      where: { source: 'wallet', status: 'active', leadsRemaining: { [Op.gt]: 0 } },
+      include: [{ model: d.LeadPackage, as: 'package', where: { campaignId }, required: true, attributes: [] }],
+      transaction,
+    });
+    if (candidates.length === 0) return { refunded: 0, totalCents: 0 };
+
+    const locked = await d.LeadPackageAssignment.findAll({
+      where: { id: candidates.map((r) => r.id) },
+      transaction,
+      lock: transaction.LOCK.UPDATE,
+    });
+
+    let refunded = 0;
+    let totalCents = 0;
+    for (const row of locked) {
+      // Re-check under the lock — a concurrent archive may have completed it.
+      if (row.source !== 'wallet' || row.status !== 'active' || !(row.leadsRemaining > 0)) continue;
+      if (!Number.isInteger(row.unitPriceCents) || row.unitPriceCents <= 0) {
+        d.logger.error('[wallet] refund.skipped — wallet assignment missing unitPriceCents', { assignmentId: row.id, campaignId });
+        continue;
+      }
+      const refundCents = row.leadsRemaining * row.unitPriceCents;
+      try {
+        await credit(row.agentId, refundCents, {
+          type: 'takedown_refund',
+          assignmentId: row.id,
+          campaignId,
+          note: reason,
+          transaction,
+        });
+      } catch (err) {
+        if (err?.name === 'SequelizeUniqueConstraintError') {
+          d.logger.warn('[wallet] refund.replay — assignment already refunded', { assignmentId: row.id, campaignId });
+          continue;
+        }
+        throw err;
+      }
+      await row.update({ leadsRemaining: 0, status: 'completed' }, { transaction });
+      refunded += 1;
+      totalCents += refundCents;
+    }
+
+    if (refunded > 0) d.logger.info('[wallet] takedown_refund.applied', { campaignId, refunded, totalCents, reason });
+    return { refunded, totalCents };
+  }
+
+  /** Commit-able campaigns for the external catalog — whitelisted fields only. */
+  async function getCatalog() {
+    const rows = await d.Campaign.findAll({
+      where: { status: 'active', is_active: true, leadPriceCents: { [Op.ne]: null } },
+      attributes: ['id', 'name', 'description', 'leadPriceCents', 'start_date', 'end_date'],
+      order: [['createdAt', 'DESC']],
+    });
+    return rows
+      .filter((c) => Number.isInteger(c.leadPriceCents) && c.leadPriceCents > 0)
+      .map((c) => ({
+        id: c.id,
+        name: c.name,
+        description: typeof c.description === 'string' && c.description.trim() ? c.description.trim() : null,
+        leadPriceCents: c.leadPriceCents,
+        startDate: c.start_date ?? null,
+        endDate: c.end_date ?? null,
+      }));
+  }
+
+  /** Open wallet commitments for one agent (active, remainder > 0), campaign-labelled. */
+  async function openCommitmentsFor(agentIds) {
+    const rows = await d.LeadPackageAssignment.findAll({
+      where: { agentId: agentIds, source: 'wallet', status: 'active', leadsRemaining: { [Op.gt]: 0 } },
+      include: [{ model: d.LeadPackage, as: 'package', attributes: ['campaignId'], include: [{ model: d.Campaign, as: 'campaign', attributes: ['id', 'name'] }] }],
+      order: [['purchaseDate', 'ASC']],
+    });
+    return rows.map((r) => ({
+      agentId: r.agentId,
+      assignmentId: r.id,
+      campaignId: r.package?.campaignId ?? null,
+      campaign: r.package?.campaign?.name ?? null,
+      remaining: r.leadsRemaining,
+      unitPriceCents: r.unitPriceCents,
+      committedValueCents: Number.isInteger(r.unitPriceCents) ? r.leadsRemaining * r.unitPriceCents : null,
+    }));
+  }
+
+  /** Balance + open commitments for the agent app. */
+  async function getSummary(agentId) {
+    const user = await d.User.findByPk(agentId, { attributes: ['id', 'walletBalanceCents'] });
+    if (!user) throw new AppError('Agent not found', 404);
+    const openCommitments = await openCommitmentsFor([agentId]);
+    return {
+      balanceCents: user.walletBalanceCents,
+      openCommitments: openCommitments.map(({ agentId: _drop, ...rest }) => rest),
+    };
+  }
+
+  /** Paginated ledger, newest first. */
+  async function getLedger(agentId, { page = 1, limit = 25 } = {}) {
+    const safeLimit = Math.min(Math.max(parseInt(limit, 10) || 25, 1), 100);
+    const safePage = Math.max(parseInt(page, 10) || 1, 1);
+    const { rows, count } = await d.WalletLedger.findAndCountAll({
+      where: { agentId },
+      order: [['createdAt', 'DESC']],
+      limit: safeLimit,
+      offset: (safePage - 1) * safeLimit,
+    });
+    return {
+      entries: rows.map((e) => ({
+        id: e.id,
+        type: e.type,
+        amountCents: e.amountCents,
+        balanceAfterCents: e.balanceAfterCents,
+        campaignId: e.campaignId,
+        assignmentId: e.assignmentId,
+        paymentId: e.paymentId,
+        note: e.note,
+        createdAt: (e.createdAt instanceof Date ? e.createdAt : new Date(e.createdAt)).toISOString(),
+      })),
+      total: count,
+      page: safePage,
+      limit: safeLimit,
+    };
+  }
+
+  /**
+   * Admin roster: EXTERNAL agents only (mktrLeadsId non-null — the v1 wallet
+   * cohort), balances + open commitments + last ledger activity.
+   */
+  async function listWallets() {
+    const agents = await d.User.findAll({
+      where: { mktrLeadsId: { [Op.ne]: null }, role: 'agent' },
+      attributes: ['id', 'firstName', 'lastName', 'fullName', 'email', 'isActive', 'walletBalanceCents'],
+      order: [['createdAt', 'ASC']],
+    });
+    if (agents.length === 0) return [];
+
+    const ids = agents.map((a) => a.id);
+    const commitments = await openCommitmentsFor(ids);
+    const byAgent = new Map();
+    for (const c of commitments) {
+      if (!byAgent.has(c.agentId)) byAgent.set(c.agentId, []);
+      byAgent.get(c.agentId).push(c);
+    }
+
+    const [lastRows] = await d.sequelize.query(
+      'SELECT "agentId", MAX("createdAt") AS "lastActivityAt" FROM wallet_ledger WHERE "agentId" IN (:ids) GROUP BY "agentId"',
+      { replacements: { ids } }
+    );
+    const lastByAgent = new Map((lastRows || []).map((r) => [String(r.agentId), r.lastActivityAt]));
+
+    return agents.map((a) => {
+      const mine = (byAgent.get(a.id) || []).map(({ agentId: _drop, ...rest }) => rest);
+      return {
+        id: a.id,
+        name: a.fullName || `${a.firstName || ''} ${a.lastName || ''}`.trim() || a.email,
+        email: a.email,
+        isActive: a.isActive,
+        walletBalanceCents: a.walletBalanceCents,
+        openCommitments: mine,
+        committedLeads: mine.reduce((s, o) => s + (o.remaining || 0), 0),
+        committedValueCents: mine.reduce((s, o) => s + (o.committedValueCents || 0), 0),
+        lastActivityAt: lastByAgent.get(String(a.id)) ?? null,
+      };
+    });
+  }
+
+  /**
+   * Admin manual adjustment — the ONLY admin-side ledger mutation. Signed cents,
+   * mandatory note, actor recorded. Negative adjustments obey the >= 0 guard.
+   */
+  async function adminAdjust(agentId, amountCents, note, actorId) {
+    if (!Number.isInteger(amountCents) || amountCents === 0) {
+      throw new AppError('Adjustment amount must be a non-zero integer (cents)', 400);
+    }
+    if (typeof note !== 'string' || !note.trim()) {
+      throw new AppError('A note is required for manual adjustments', 400);
+    }
+    const target = await d.User.findOne({ where: { id: agentId, mktrLeadsId: { [Op.ne]: null } }, attributes: ['id'] });
+    if (!target) throw new AppError('Agent not found or not an external (wallet) agent', 404);
+
+    const entry = await applyLedgerEntry(agentId, amountCents, {
+      type: 'adjustment',
+      note: note.trim(),
+      createdBy: actorId ?? null,
+    });
+    d.logger.info('[wallet] adjustment.applied', { agentId, amountCents, actorId: actorId ?? null });
+    return { balanceCents: entry.balanceAfterCents, entryId: entry.id };
+  }
+
+  return { applyLedgerEntry, credit, debit, commit, refundCampaignCommitments, getCatalog, getSummary, getLedger, listWallets, adminAdjust, ensureWalletPackage };
+}
+
+// --- Backward-compatible named exports (house pattern) ---
+const _default = makeWalletService();
+export const credit = _default.credit;
+export const debit = _default.debit;
+export const commit = _default.commit;
+export const refundCampaignCommitments = _default.refundCampaignCommitments;
+export const getCatalog = _default.getCatalog;
+export const getSummary = _default.getSummary;
+export const getLedger = _default.getLedger;
+export const listWallets = _default.listWallets;
+export const adminAdjust = _default.adminAdjust;

--- a/backend/src/services/walletService.js
+++ b/backend/src/services/walletService.js
@@ -20,15 +20,44 @@
  * DI-factory (house pattern) so it unit-tests without a DB.
  */
 import { Op } from 'sequelize';
-import { User, Campaign, LeadPackage, LeadPackageAssignment, WalletLedger, sequelize } from '../models/index.js';
+import { User, Campaign, LeadPackage, LeadPackageAssignment, WalletLedger, IdempotencyKey, sequelize } from '../models/index.js';
 import { getSystemAgentId } from './systemAgent.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
 
 const MAX_COMMIT_QUANTITY = 10000; // fat-finger guard; the wallet balance is the real bound
+const IDEMPOTENCY_TTL_MS = 24 * 3600e3;
+const REQUEST_ID_RE = /^[A-Za-z0-9_-]{8,64}$/;
 
 export function makeWalletService(overrides = {}) {
-  const d = { User, Campaign, LeadPackage, LeadPackageAssignment, WalletLedger, sequelize, getSystemAgentId, logger, ...overrides };
+  const d = { User, Campaign, LeadPackage, LeadPackageAssignment, WalletLedger, IdempotencyKey, sequelize, getSystemAgentId, logger, ...overrides };
+
+  /**
+   * Money-op replay shield over the house IdempotencyKey table (key = PK, so
+   * keys are namespaced). The key row is created as the FIRST statement of the
+   * money transaction and its response stored in the SAME transaction — so a
+   * stored row implies the op committed, and a concurrent duplicate aborts the
+   * whole duplicate transaction on the PK collision (caught OUT here, never
+   * inside the open tx). requestId is caller-supplied (broker/admin UI).
+   */
+  async function withIdempotency(scope, requestId, run) {
+    if (requestId === undefined || requestId === null) return run(null);
+    if (typeof requestId !== 'string' || !REQUEST_ID_RE.test(requestId)) {
+      throw new AppError('requestId must be 8-64 chars of [A-Za-z0-9_-]', 400);
+    }
+    const key = `${scope}:${requestId}`;
+    const prior = await d.IdempotencyKey.findByPk(key);
+    if (prior) return { ...(prior.responseBody || {}), replayed: true };
+    try {
+      return await run(key);
+    } catch (err) {
+      if (err?.name === 'SequelizeUniqueConstraintError') {
+        const winner = await d.IdempotencyKey.findByPk(key);
+        if (winner) return { ...(winner.responseBody || {}), replayed: true };
+      }
+      throw err;
+    }
+  }
 
   /**
    * The single write path: guarded atomic balance UPDATE + ledger INSERT, in the
@@ -124,7 +153,7 @@ export function makeWalletService(overrides = {}) {
    * 'archived' and rejects — no window for an orphaned paid commitment.
    * No cancel path exists.
    */
-  async function commit(agentId, campaignId, quantity) {
+  async function commit(agentId, campaignId, quantity, { requestId } = {}) {
     if (!Number.isInteger(quantity) || quantity < 1 || quantity > MAX_COMMIT_QUANTITY) {
       throw new AppError(`Quantity must be an integer between 1 and ${MAX_COMMIT_QUANTITY}`, 400);
     }
@@ -133,48 +162,78 @@ export function makeWalletService(overrides = {}) {
     if (!exists) throw new AppError('Campaign not found', 404);
     const pkg = await ensureWalletPackage(campaignId);
 
-    const result = await d.sequelize.transaction(async (t) => {
-      const campaign = await d.Campaign.findByPk(campaignId, { transaction: t, lock: t.LOCK.SHARE });
-      if (!campaign) throw new AppError('Campaign not found', 404);
-      const priced = Number.isInteger(campaign.leadPriceCents) && campaign.leadPriceCents > 0;
-      if (campaign.status !== 'active' || campaign.is_active !== true || !priced) {
-        throw new AppError('This campaign is not open for commitments', 409);
-      }
+    const result = await withIdempotency(`wallet:commit:${agentId}`, requestId, (idemKey) =>
+      d.sequelize.transaction(async (t) => {
+        // Replay shield first: a duplicate request collides on the PK and
+        // aborts this whole transaction before any money moves.
+        if (idemKey) {
+          await d.IdempotencyKey.create(
+            { key: idemKey, scope: 'wallet:commit', expiresAt: new Date(Date.now() + IDEMPOTENCY_TTL_MS) },
+            { transaction: t }
+          );
+        }
 
-      const totalCents = quantity * campaign.leadPriceCents;
-      const assignment = await d.LeadPackageAssignment.create(
-        {
-          agentId,
-          leadPackageId: pkg.id,
-          source: 'wallet',
+        // Re-validate the agent UNDER LOCK: serializes against deactivation so
+        // a wallet can't be debited for an agent leaving the routing pool.
+        const agent = await d.User.findOne({
+          where: { id: agentId, isActive: true, mktrLeadsId: { [Op.ne]: null } },
+          attributes: ['id'],
+          transaction: t,
+          lock: t.LOCK.UPDATE,
+        });
+        if (!agent) throw new AppError('Agent is not an active external (wallet) agent', 409);
+
+        const campaign = await d.Campaign.findByPk(campaignId, { transaction: t, lock: t.LOCK.SHARE });
+        if (!campaign) throw new AppError('Campaign not found', 404);
+        const priced = Number.isInteger(campaign.leadPriceCents) && campaign.leadPriceCents > 0;
+        if (campaign.status !== 'active' || campaign.is_active !== true || !priced) {
+          throw new AppError('This campaign is not open for commitments', 409);
+        }
+
+        const totalCents = quantity * campaign.leadPriceCents;
+        const assignment = await d.LeadPackageAssignment.create(
+          {
+            agentId,
+            leadPackageId: pkg.id,
+            source: 'wallet',
+            unitPriceCents: campaign.leadPriceCents,
+            leadsTotal: quantity,
+            leadsRemaining: quantity,
+            priceSnapshot: (totalCents / 100).toFixed(2),
+            status: 'active',
+            purchaseDate: new Date(),
+          },
+          { transaction: t }
+        );
+        const entry = await debit(agentId, totalCents, {
+          type: 'commit',
+          assignmentId: assignment.id,
+          campaignId,
+          transaction: t,
+        });
+
+        const response = {
+          assignmentId: assignment.id,
+          campaignId,
+          campaignName: campaign.name,
+          quantity,
           unitPriceCents: campaign.leadPriceCents,
-          leadsTotal: quantity,
-          leadsRemaining: quantity,
-          priceSnapshot: (totalCents / 100).toFixed(2),
-          status: 'active',
-          purchaseDate: new Date(),
-        },
-        { transaction: t }
-      );
-      const entry = await debit(agentId, totalCents, {
-        type: 'commit',
-        assignmentId: assignment.id,
-        campaignId,
-        transaction: t,
-      });
+          totalCents,
+          balanceCents: entry.balanceAfterCents,
+        };
+        if (idemKey) {
+          await d.IdempotencyKey.update(
+            { responseBody: response, responseCode: 201 },
+            { where: { key: idemKey }, transaction: t }
+          );
+        }
+        return response;
+      })
+    );
 
-      return {
-        assignmentId: assignment.id,
-        campaignId,
-        campaignName: campaign.name,
-        quantity,
-        unitPriceCents: campaign.leadPriceCents,
-        totalCents,
-        balanceCents: entry.balanceAfterCents,
-      };
-    });
-
-    d.logger.info('[wallet] commit.created', { agentId, campaignId, quantity, totalCents: result.totalCents, assignmentId: result.assignmentId });
+    if (!result.replayed) {
+      d.logger.info('[wallet] commit.created', { agentId, campaignId, quantity, totalCents: result.totalCents, assignmentId: result.assignmentId });
+    }
     return result;
   }
 
@@ -208,8 +267,11 @@ export function makeWalletService(overrides = {}) {
       // Re-check under the lock — a concurrent archive may have completed it.
       if (row.source !== 'wallet' || row.status !== 'active' || !(row.leadsRemaining > 0)) continue;
       if (!Number.isInteger(row.unitPriceCents) || row.unitPriceCents <= 0) {
-        d.logger.error('[wallet] refund.skipped — wallet assignment missing unitPriceCents', { assignmentId: row.id, campaignId });
-        continue;
+        // Data corruption (commit always snapshots a positive price; the DB
+        // CHECK in 069 enforces it). Skipping would archive the campaign with
+        // an open, unrefundable paid commitment stranded — abort instead.
+        d.logger.error('[wallet] refund.aborted — wallet assignment missing unitPriceCents', { assignmentId: row.id, campaignId });
+        throw new AppError('A wallet commitment on this campaign has no unit price; resolve it before archiving.', 500);
       }
       const refundCents = row.leadsRemaining * row.unitPriceCents;
       // NOTE: no catch-and-continue here. The unique partial index (one
@@ -357,7 +419,7 @@ export function makeWalletService(overrides = {}) {
    * Admin manual adjustment — the ONLY admin-side ledger mutation. Signed cents,
    * mandatory note, actor recorded. Negative adjustments obey the >= 0 guard.
    */
-  async function adminAdjust(agentId, amountCents, note, actorId) {
+  async function adminAdjust(agentId, amountCents, note, actorId, { requestId } = {}) {
     if (!Number.isInteger(amountCents) || amountCents === 0) {
       throw new AppError('Adjustment amount must be a non-zero integer (cents)', 400);
     }
@@ -367,13 +429,32 @@ export function makeWalletService(overrides = {}) {
     const target = await d.User.findOne({ where: { id: agentId, mktrLeadsId: { [Op.ne]: null } }, attributes: ['id'] });
     if (!target) throw new AppError('Agent not found or not an external (wallet) agent', 404);
 
-    const entry = await applyLedgerEntry(agentId, amountCents, {
-      type: 'adjustment',
-      note: note.trim(),
-      createdBy: actorId ?? null,
-    });
-    d.logger.info('[wallet] adjustment.applied', { agentId, amountCents, actorId: actorId ?? null });
-    return { balanceCents: entry.balanceAfterCents, entryId: entry.id };
+    const result = await withIdempotency(`wallet:adjust:${agentId}`, requestId, (idemKey) =>
+      d.sequelize.transaction(async (t) => {
+        if (idemKey) {
+          await d.IdempotencyKey.create(
+            { key: idemKey, scope: 'wallet:adjust', expiresAt: new Date(Date.now() + IDEMPOTENCY_TTL_MS) },
+            { transaction: t }
+          );
+        }
+        const entry = await applyLedgerEntry(agentId, amountCents, {
+          type: 'adjustment',
+          note: note.trim(),
+          createdBy: actorId ?? null,
+          transaction: t,
+        });
+        const response = { balanceCents: entry.balanceAfterCents, entryId: entry.id };
+        if (idemKey) {
+          await d.IdempotencyKey.update(
+            { responseBody: response, responseCode: 201 },
+            { where: { key: idemKey }, transaction: t }
+          );
+        }
+        return response;
+      })
+    );
+    if (!result.replayed) d.logger.info('[wallet] adjustment.applied', { agentId, amountCents, actorId: actorId ?? null });
+    return result;
   }
 
   return { applyLedgerEntry, credit, debit, commit, refundCampaignCommitments, getCatalog, getSummary, getLedger, listWallets, adminAdjust, ensureWalletPackage };

--- a/backend/test/leadQuota.test.js
+++ b/backend/test/leadQuota.test.js
@@ -144,6 +144,31 @@ describe('createProspect under quota (web capture)', () => {
     expect(p.quarantinedAt).toBeNull();
     expect(p.assignedAgentId).not.toBeNull(); // System-Agent fallback, as before
   });
+
+  // ── Priced campaigns (agent-wallet commitments) are ALWAYS enforced ──
+  // leadPriceCents non-null means every lead is pre-sold: a failed/absent
+  // charge must hold the lead even when the admin left enforceLeadQuota off.
+
+  it('priced + soft + unfunded → quarantined (a pre-sold lead is never delivered free)', async () => {
+    const c = await createTestCampaign(admin.id, { enforceLeadQuota: false, leadPriceCents: 800 });
+    const p = await prospectFromRes(await postLead(c.id));
+    expect(p.assignedAgentId).toBeNull();
+    expect(p.quarantinedAt).not.toBeNull();
+    expect(p.quarantineReason).toBe('no_funded_agent');
+  });
+
+  it('priced + soft + funded → delivered AND charged (authoritative gate, not best-effort)', async () => {
+    const c = await createTestCampaign(admin.id, { enforceLeadQuota: false, leadPriceCents: 800 });
+    const { agent, assignment } = await fundedAgent(c.id, 1);
+
+    const p = await prospectFromRes(await postLead(c.id));
+    expect(p.assignedAgentId).toBe(agent.id);
+    expect(p.quarantinedAt).toBeNull();
+
+    await assignment.reload();
+    expect(assignment.leadsRemaining).toBe(0);
+    expect(assignment.status).toBe('completed');
+  });
 });
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/backend/test/unit/campaignDeviceSync.test.js
+++ b/backend/test/unit/campaignDeviceSync.test.js
@@ -117,6 +117,12 @@ jest.unstable_mockModule('../../src/services/pushService.js', () => ({
   pushService: mockPushService,
 }));
 
+// Wallet takedown-refund dep of archiveCampaign — mocked so this suite never
+// loads walletService's transitive model graph (systemAgent, WalletLedger…).
+jest.unstable_mockModule('../../src/services/walletService.js', () => ({
+  refundCampaignCommitments: jest.fn(async () => ({ refunded: 0, totalCents: 0 })),
+}));
+
 const campaignService = await import('../../src/services/campaignService.js');
 
 // ── Tests ──

--- a/backend/test/unit/campaignService.test.js
+++ b/backend/test/unit/campaignService.test.js
@@ -10,6 +10,7 @@ import { Op } from 'sequelize';
 const mockTransaction = {
   commit: jest.fn(),
   rollback: jest.fn(),
+  LOCK: { UPDATE: 'UPDATE', SHARE: 'SHARE' },
 };
 
 const Campaign = {
@@ -104,6 +105,13 @@ jest.unstable_mockModule('../../src/middleware/errorHandler.js', () => ({
 
 jest.unstable_mockModule('../../src/services/pushService.js', () => ({
   pushService: { sendEvent: pushSendEvent },
+}));
+
+// Wallet takedown-refund dep of archiveCampaign — mocked so this suite never
+// loads walletService's transitive model graph (systemAgent, WalletLedger…).
+const refundCampaignCommitments = jest.fn(async () => ({ refunded: 0, totalCents: 0 }));
+jest.unstable_mockModule('../../src/services/walletService.js', () => ({
+  refundCampaignCommitments,
 }));
 
 // Dynamic import AFTER mocks are registered
@@ -557,13 +565,29 @@ describe('campaignService (unit)', () => {
   // ────────────────────────────────────────────────
 
   describe('archiveCampaign', () => {
-    it('sets status to archived on success', async () => {
+    it('locks the row, refunds wallet commitments, then archives — one transaction', async () => {
       const inst = makeCampaignInstance({ status: 'active' });
       Campaign.findOne.mockResolvedValue(inst);
 
       await campaignService.archiveCampaign('camp-1', makeReq());
 
-      expect(inst.update).toHaveBeenCalledWith({ status: 'archived' });
+      expect(Campaign.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({ transaction: mockTransaction, lock: 'UPDATE' })
+      );
+      expect(refundCampaignCommitments).toHaveBeenCalledWith(
+        'camp-1',
+        expect.objectContaining({ reason: 'campaign_archived', transaction: mockTransaction })
+      );
+      expect(inst.update).toHaveBeenCalledWith({ status: 'archived' }, { transaction: mockTransaction });
+    });
+
+    it('a failing refund aborts the archive (status never flips)', async () => {
+      const inst = makeCampaignInstance({ status: 'active' });
+      Campaign.findOne.mockResolvedValue(inst);
+      refundCampaignCommitments.mockRejectedValueOnce(new Error('corrupt wallet assignment'));
+
+      await expect(campaignService.archiveCampaign('camp-1', makeReq())).rejects.toThrow('corrupt wallet assignment');
+      expect(inst.update).not.toHaveBeenCalled();
     });
 
     it('throws 400 when campaign is already archived', async () => {

--- a/backend/test/unit/userService.test.js
+++ b/backend/test/unit/userService.test.js
@@ -17,8 +17,11 @@ const User = {
 const Campaign = { count: jest.fn() };
 const Commission = { count: jest.fn() };
 const Prospect = { findAll: jest.fn(), update: jest.fn() };
-const LeadPackageAssignment = { destroy: jest.fn() };
+const LeadPackageAssignment = { destroy: jest.fn(), count: jest.fn() };
 const ProspectActivity = { bulkCreate: jest.fn() };
+// Wallet guards (agent-wallet build): ledger history RESTRICTs hard-deletes;
+// open wallet state (balance / open commitments) 409s deactivate + delete.
+const WalletLedger = { count: jest.fn() };
 
 const mockTransaction = {
   commit: jest.fn(),
@@ -39,7 +42,7 @@ const AppError = class extends Error {
 };
 
 jest.unstable_mockModule('../../src/models/index.js', () => ({
-  User, Campaign, Commission, Prospect, LeadPackageAssignment, ProspectActivity, sequelize, Op,
+  User, Campaign, Commission, Prospect, LeadPackageAssignment, ProspectActivity, WalletLedger, sequelize, Op,
 }));
 jest.unstable_mockModule('../../src/middleware/errorHandler.js', () => ({ AppError }));
 
@@ -79,6 +82,8 @@ describe('userService (unit)', () => {
     Prospect.findAll.mockResolvedValue([]);
     Prospect.update.mockResolvedValue([0]);
     LeadPackageAssignment.destroy.mockResolvedValue(0);
+    LeadPackageAssignment.count.mockResolvedValue(0);
+    WalletLedger.count.mockResolvedValue(0);
     ProspectActivity.bulkCreate.mockResolvedValue([]);
   });
 
@@ -213,11 +218,26 @@ describe('userService (unit)', () => {
         expect.objectContaining({ where: { assignedAgentId: 'user-1' } })
       );
       expect(LeadPackageAssignment.destroy).toHaveBeenCalled();
+      // wallet-source rows are financial history — never destroyed here
+      expect(LeadPackageAssignment.destroy.mock.calls[0][0].where.source).toEqual({ [Op.ne]: 'wallet' });
       expect(mockUser.update).toHaveBeenCalledWith(
         { isActive: false },
         expect.objectContaining({ transaction: mockTransaction })
       );
       expect(result.message).toContain('deactivated');
+    });
+
+    it('409s when the user still holds a wallet balance', async () => {
+      User.count.mockResolvedValueOnce(1); // walletBalanceCents > 0 check
+      await expect(deactivateUser('user-1', 'admin-1')).rejects.toMatchObject({ statusCode: 409 });
+      expect(LeadPackageAssignment.destroy).not.toHaveBeenCalled();
+    });
+
+    it('409s when the user has open wallet commitments', async () => {
+      User.count.mockResolvedValueOnce(0);
+      LeadPackageAssignment.count.mockResolvedValueOnce(3);
+      await expect(deactivateUser('user-1', 'admin-1')).rejects.toMatchObject({ statusCode: 409 });
+      expect(LeadPackageAssignment.destroy).not.toHaveBeenCalled();
     });
   });
 
@@ -236,6 +256,14 @@ describe('userService (unit)', () => {
 
       await expect(permanentlyDeleteUser('user-1', 'admin-1'))
         .rejects.toThrow('Cannot delete user with commissions');
+    });
+
+    it('throws 409 when user has wallet history (financial records are never erased)', async () => {
+      WalletLedger.count.mockResolvedValueOnce(4);
+
+      await expect(permanentlyDeleteUser('user-1', 'admin-1'))
+        .rejects.toThrow('Cannot delete user with wallet history');
+      expect(mockUser.destroy).not.toHaveBeenCalled();
     });
 
     it('destroys user record in transaction', async () => {

--- a/backend/test/unit/userService.test.js
+++ b/backend/test/unit/userService.test.js
@@ -26,6 +26,7 @@ const WalletLedger = { count: jest.fn() };
 const mockTransaction = {
   commit: jest.fn(),
   rollback: jest.fn(),
+  LOCK: { UPDATE: 'UPDATE', SHARE: 'SHARE' },
 };
 
 const sequelize = {

--- a/backend/test/unit/walletService.test.js
+++ b/backend/test/unit/walletService.test.js
@@ -1,0 +1,340 @@
+import { jest } from '@jest/globals';
+import '../setup.js';
+import { makeWalletService } from '../../src/services/walletService.js';
+
+/**
+ * Money-path tests for the REAL walletService via the DI factory.
+ * Invariants under test:
+ *  - every balance mutation = guarded atomic UPDATE + ledger INSERT in ONE tx;
+ *    overdraft is a 409 (never a negative balance), missing agent a 404;
+ *  - commit debits exactly quantity × leadPriceCents, snapshots unitPriceCents,
+ *    and rides the hidden wallet package (kind:'wallet') race-safely;
+ *  - takedown refund credits leadsRemaining × unitPriceCents once per assignment
+ *    (unique-violation replays are skipped) and only inside the caller's tx;
+ *  - adminAdjust demands a non-zero amount + a note and records the actor.
+ */
+
+const FAKE_TX = { LOCK: { UPDATE: 'UPDATE' } };
+
+function uniqueViolation() {
+  const err = new Error('duplicate key value violates unique constraint');
+  err.name = 'SequelizeUniqueConstraintError';
+  return err;
+}
+
+function build({
+  balanceAfter = 900,
+  guardedUpdateEmpty = false,
+  userCount = 1,
+  campaign = null,
+  walletPkg = null,
+  pkgCreateThrowsUnique = false,
+  raceWinner = null,
+  refundCandidates = [],
+  lockedRows = [],
+  catalogRows = [],
+  user = { id: 'agent-1', walletBalanceCents: 900 },
+  externalTarget = { id: 'agent-1' },
+} = {}) {
+  const ledgerRows = [];
+  const WalletLedger = {
+    create: jest.fn(async (attrs) => {
+      const row = { id: 'led-' + (ledgerRows.length + 1), ...attrs };
+      ledgerRows.push(row);
+      return row;
+    }),
+    findAndCountAll: jest.fn(async () => ({ rows: [], count: 0 })),
+  };
+  const User = {
+    count: jest.fn(async () => userCount),
+    findByPk: jest.fn(async () => user),
+    findOne: jest.fn(async () => externalTarget),
+    findAll: jest.fn(async () => []),
+  };
+  const Campaign = {
+    findByPk: jest.fn(async () => campaign),
+    findAll: jest.fn(async () => catalogRows),
+  };
+  let pkgCreated = false;
+  const LeadPackage = {
+    findOne: jest.fn(async () => (pkgCreated && raceWinner ? raceWinner : walletPkg)),
+    create: jest.fn(async (attrs) => {
+      if (pkgCreateThrowsUnique) {
+        pkgCreated = true;
+        throw uniqueViolation();
+      }
+      return { id: 'wpkg-1', ...attrs };
+    }),
+  };
+  const createdAssignments = [];
+  const LeadPackageAssignment = {
+    create: jest.fn(async (attrs) => {
+      const row = { id: 'asg-' + (createdAssignments.length + 1), ...attrs };
+      createdAssignments.push(row);
+      return row;
+    }),
+    findAll: jest.fn(async (q) => {
+      // First call (candidates: attributes ['id']) vs second (locked rows).
+      if (q?.lock) return lockedRows;
+      if (q?.attributes && q.attributes.length === 1 && q.attributes[0] === 'id') return refundCandidates;
+      return [];
+    }),
+  };
+  const sequelize = {
+    transaction: jest.fn(async (cb) => cb(FAKE_TX)),
+    query: jest.fn(async (sql) => {
+      if (String(sql).trim().startsWith('UPDATE users')) {
+        return [guardedUpdateEmpty ? [] : [{ walletBalanceCents: balanceAfter }]];
+      }
+      return [[]];
+    }),
+  };
+  const getSystemAgentId = jest.fn(async () => 'sys-agent');
+  const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+  const svc = makeWalletService({ User, Campaign, LeadPackage, LeadPackageAssignment, WalletLedger, sequelize, getSystemAgentId, logger });
+  return { svc, User, Campaign, LeadPackage, LeadPackageAssignment, WalletLedger, sequelize, logger, ledgerRows, createdAssignments };
+}
+
+describe('walletService credit/debit (applyLedgerEntry)', () => {
+  test('credit writes ledger row with the RETURNING balance, inside the caller tx', async () => {
+    const { svc, WalletLedger, sequelize } = build({ balanceAfter: 12345 });
+    const entry = await svc.credit('agent-1', 500, { type: 'topup', paymentId: 'pay-9', transaction: FAKE_TX });
+    expect(entry.balanceAfterCents).toBe(12345);
+    expect(WalletLedger.create).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: 'agent-1', type: 'topup', amountCents: 500, balanceAfterCents: 12345, paymentId: 'pay-9' }),
+      { transaction: FAKE_TX }
+    );
+    // caller tx → no NEW transaction opened
+    expect(sequelize.transaction).not.toHaveBeenCalled();
+  });
+
+  test('debit overdraft → 409, no ledger row', async () => {
+    const { svc, WalletLedger } = build({ guardedUpdateEmpty: true, userCount: 1 });
+    await expect(svc.debit('agent-1', 999999, { type: 'commit', transaction: FAKE_TX }))
+      .rejects.toMatchObject({ statusCode: 409 });
+    expect(WalletLedger.create).not.toHaveBeenCalled();
+  });
+
+  test('missing agent → 404 (distinguished from overdraft)', async () => {
+    const { svc } = build({ guardedUpdateEmpty: true, userCount: 0 });
+    await expect(svc.credit('ghost', 100, { type: 'topup', transaction: FAKE_TX }))
+      .rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  test('zero / negative / non-integer amounts are rejected up front (sync throw)', () => {
+    const { svc } = build();
+    expect(() => svc.credit('a', 0, { type: 'topup' })).toThrow('Credit amount must be a positive integer');
+    expect(() => svc.credit('a', -5, { type: 'topup' })).toThrow('Credit amount must be a positive integer');
+    expect(() => svc.debit('a', 1.5, { type: 'commit' })).toThrow('Debit amount must be a positive integer');
+  });
+
+  test('opens its own transaction when the caller has none', async () => {
+    const { svc, sequelize } = build();
+    await svc.credit('agent-1', 100, { type: 'adjustment', note: 'x' });
+    expect(sequelize.transaction).toHaveBeenCalledTimes(1);
+  });
+});
+
+const activeCampaign = (over = {}) => ({
+  id: 'c-1', name: 'Tokyo Draw', status: 'active', is_active: true, leadPriceCents: 800, ...over,
+});
+
+describe('walletService.commit', () => {
+  test('quantity must be an integer in [1, 10000]', async () => {
+    const { svc } = build({ campaign: activeCampaign() });
+    for (const q of [0, -1, 1.5, 10001, NaN, undefined]) {
+      await expect(svc.commit('agent-1', 'c-1', q)).rejects.toMatchObject({ statusCode: 400 });
+    }
+  });
+
+  test('campaign missing → 404; paused/unpriced → 409', async () => {
+    await expect(build({ campaign: null }).svc.commit('a', 'c-x', 5)).rejects.toMatchObject({ statusCode: 404 });
+    await expect(build({ campaign: activeCampaign({ status: 'paused', is_active: false }) }).svc.commit('a', 'c-1', 5)).rejects.toMatchObject({ statusCode: 409 });
+    await expect(build({ campaign: activeCampaign({ leadPriceCents: null }) }).svc.commit('a', 'c-1', 5)).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  test('happy path: assignment snapshots + ledger debit of quantity × price', async () => {
+    const { svc, LeadPackage, LeadPackageAssignment, WalletLedger } = build({ campaign: activeCampaign(), balanceAfter: 200 });
+    const r = await svc.commit('agent-1', 'c-1', 12);
+
+    // Hidden wallet package created with complete NOT NULL values
+    expect(LeadPackage.create).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'wallet', campaignId: 'c-1', isPublic: false, status: 'active', price: 0, leadCount: 0, createdBy: 'sys-agent' }),
+      expect.anything()
+    );
+    // Assignment: source wallet + per-lead snapshot + dollars priceSnapshot
+    expect(LeadPackageAssignment.create).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: 'agent-1', source: 'wallet', unitPriceCents: 800, leadsTotal: 12, leadsRemaining: 12, priceSnapshot: '96.00', status: 'active' }),
+      expect.anything()
+    );
+    // Ledger: commit debit of -9600 with refs
+    expect(WalletLedger.create).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'commit', amountCents: -9600, campaignId: 'c-1', assignmentId: 'asg-1' }),
+      expect.anything()
+    );
+    expect(r).toMatchObject({ quantity: 12, unitPriceCents: 800, totalCents: 9600, balanceCents: 200, campaignId: 'c-1' });
+  });
+
+  test('reuses the existing wallet package (no second create)', async () => {
+    const { svc, LeadPackage } = build({ campaign: activeCampaign(), walletPkg: { id: 'wpkg-existing' } });
+    await svc.commit('agent-1', 'c-1', 1);
+    expect(LeadPackage.create).not.toHaveBeenCalled();
+  });
+
+  test('find-or-create race: unique violation re-reads the winner row', async () => {
+    const { svc, LeadPackageAssignment } = build({
+      campaign: activeCampaign(),
+      walletPkg: null,
+      pkgCreateThrowsUnique: true,
+      raceWinner: { id: 'wpkg-winner' },
+    });
+    await svc.commit('agent-1', 'c-1', 2);
+    expect(LeadPackageAssignment.create).toHaveBeenCalledWith(
+      expect.objectContaining({ leadPackageId: 'wpkg-winner' }),
+      expect.anything()
+    );
+  });
+
+  test('insufficient balance rolls the whole commit back (debit throws inside tx)', async () => {
+    const { svc } = build({ campaign: activeCampaign(), guardedUpdateEmpty: true, userCount: 1 });
+    await expect(svc.commit('agent-1', 'c-1', 5)).rejects.toMatchObject({ statusCode: 409 });
+  });
+});
+
+function refundableRow(over = {}) {
+  const row = {
+    id: 'asg-1', agentId: 'agent-1', source: 'wallet', status: 'active',
+    leadsRemaining: 7, unitPriceCents: 800, ...over,
+  };
+  row.update = jest.fn(async (u) => Object.assign(row, u));
+  return row;
+}
+
+describe('walletService.refundCampaignCommitments', () => {
+  test('requires the caller transaction', async () => {
+    const { svc } = build();
+    await expect(svc.refundCampaignCommitments('c-1', {})).rejects.toMatchObject({ statusCode: 500 });
+  });
+
+  test('no open commitments → zero result, no writes', async () => {
+    const { svc, WalletLedger } = build({ refundCandidates: [] });
+    const r = await svc.refundCampaignCommitments('c-1', { transaction: FAKE_TX });
+    expect(r).toEqual({ refunded: 0, totalCents: 0 });
+    expect(WalletLedger.create).not.toHaveBeenCalled();
+  });
+
+  test('refunds leadsRemaining × unitPriceCents, zeroes and completes the row', async () => {
+    const row = refundableRow();
+    const { svc, WalletLedger } = build({ refundCandidates: [{ id: 'asg-1' }], lockedRows: [row] });
+    const r = await svc.refundCampaignCommitments('c-1', { transaction: FAKE_TX, reason: 'campaign_archived' });
+    expect(WalletLedger.create).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'takedown_refund', amountCents: 5600, assignmentId: 'asg-1', campaignId: 'c-1', note: 'campaign_archived' }),
+      expect.anything()
+    );
+    expect(row.update).toHaveBeenCalledWith({ leadsRemaining: 0, status: 'completed' }, { transaction: FAKE_TX });
+    expect(r).toEqual({ refunded: 1, totalCents: 5600 });
+  });
+
+  test('re-check under lock: a row completed by a concurrent archive is skipped', async () => {
+    const row = refundableRow({ status: 'completed' });
+    const { svc, WalletLedger } = build({ refundCandidates: [{ id: 'asg-1' }], lockedRows: [row] });
+    const r = await svc.refundCampaignCommitments('c-1', { transaction: FAKE_TX });
+    expect(r.refunded).toBe(0);
+    expect(WalletLedger.create).not.toHaveBeenCalled();
+  });
+
+  test('unique-violation on the refund ledger row = replay → skipped, others continue', async () => {
+    const rowA = refundableRow({ id: 'asg-1' });
+    const rowB = refundableRow({ id: 'asg-2', agentId: 'agent-2', leadsRemaining: 3 });
+    const { svc, WalletLedger, sequelize } = build({
+      refundCandidates: [{ id: 'asg-1' }, { id: 'asg-2' }],
+      lockedRows: [rowA, rowB],
+    });
+    // First credit hits the unique partial index (already refunded), second succeeds.
+    let call = 0;
+    sequelize.query.mockImplementation(async (sql) => {
+      if (String(sql).trim().startsWith('UPDATE users')) {
+        call += 1;
+        if (call === 1) throw uniqueViolation();
+        return [[{ walletBalanceCents: 111 }]];
+      }
+      return [[]];
+    });
+    const r = await svc.refundCampaignCommitments('c-1', { transaction: FAKE_TX });
+    expect(r).toEqual({ refunded: 1, totalCents: 2400 });
+    expect(rowA.update).not.toHaveBeenCalled();
+    expect(rowB.update).toHaveBeenCalled();
+    expect(WalletLedger.create).toHaveBeenCalledTimes(1);
+  });
+
+  test('wallet assignment without unitPriceCents is skipped (logged, never guessed)', async () => {
+    const row = refundableRow({ unitPriceCents: null });
+    const { svc, logger, WalletLedger } = build({ refundCandidates: [{ id: 'asg-1' }], lockedRows: [row] });
+    const r = await svc.refundCampaignCommitments('c-1', { transaction: FAKE_TX });
+    expect(r.refunded).toBe(0);
+    expect(WalletLedger.create).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
+  });
+});
+
+describe('walletService.adminAdjust', () => {
+  test('rejects zero amount and missing note', async () => {
+    const { svc } = build();
+    await expect(svc.adminAdjust('agent-1', 0, 'note', 'admin-1')).rejects.toMatchObject({ statusCode: 400 });
+    await expect(svc.adminAdjust('agent-1', 500, '', 'admin-1')).rejects.toMatchObject({ statusCode: 400 });
+    await expect(svc.adminAdjust('agent-1', 500, '   ', 'admin-1')).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  test('rejects non-external targets (no mktrLeadsId) with 404', async () => {
+    const { svc } = build({ externalTarget: null });
+    await expect(svc.adminAdjust('internal-agent', 500, 'goodwill', 'admin-1')).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  test('applies a signed adjustment with the actor recorded', async () => {
+    const { svc, WalletLedger } = build({ balanceAfter: 4200 });
+    const r = await svc.adminAdjust('agent-1', -300, ' duplicate delivery credit-back ', 'admin-7');
+    expect(WalletLedger.create).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'adjustment', amountCents: -300, note: 'duplicate delivery credit-back', createdBy: 'admin-7' }),
+      expect.anything()
+    );
+    expect(r.balanceCents).toBe(4200);
+  });
+});
+
+describe('walletService.getCatalog', () => {
+  test('returns whitelisted fields and drops non-positive prices defensively', async () => {
+    const { svc } = build({
+      catalogRows: [
+        { id: 'c-1', name: 'A', description: '  Great campaign  ', leadPriceCents: 800, start_date: 's', end_date: 'e' },
+        { id: 'c-2', name: 'B', description: null, leadPriceCents: 0, start_date: null, end_date: null },
+      ],
+    });
+    const rows = await svc.getCatalog();
+    expect(rows).toEqual([
+      { id: 'c-1', name: 'A', description: 'Great campaign', leadPriceCents: 800, startDate: 's', endDate: 'e' },
+    ]);
+  });
+});
+
+describe('walletService.getSummary', () => {
+  test('404 for an unknown agent', async () => {
+    const { svc } = build({ user: null });
+    await expect(svc.getSummary('ghost')).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  test('returns balance + open commitments without leaking agentId per row', async () => {
+    const { svc, LeadPackageAssignment } = build({ user: { id: 'agent-1', walletBalanceCents: 777 } });
+    LeadPackageAssignment.findAll.mockResolvedValueOnce([
+      {
+        id: 'asg-1', agentId: 'agent-1', leadsRemaining: 4, unitPriceCents: 800,
+        package: { campaignId: 'c-1', campaign: { id: 'c-1', name: 'Tokyo Draw' } },
+      },
+    ]);
+    const s = await svc.getSummary('agent-1');
+    expect(s.balanceCents).toBe(777);
+    expect(s.openCommitments).toEqual([
+      expect.objectContaining({ assignmentId: 'asg-1', campaign: 'Tokyo Draw', remaining: 4, unitPriceCents: 800, committedValueCents: 3200 }),
+    ]);
+    expect(s.openCommitments[0].agentId).toBeUndefined();
+  });
+});

--- a/backend/test/unit/walletService.test.js
+++ b/backend/test/unit/walletService.test.js
@@ -90,9 +90,14 @@ function build({
     }),
   };
   const getSystemAgentId = jest.fn(async () => 'sys-agent');
+  const IdempotencyKey = {
+    findByPk: jest.fn(async () => null),
+    create: jest.fn(async (attrs) => attrs),
+    update: jest.fn(async () => [1]),
+  };
   const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
-  const svc = makeWalletService({ User, Campaign, LeadPackage, LeadPackageAssignment, WalletLedger, sequelize, getSystemAgentId, logger });
-  return { svc, User, Campaign, LeadPackage, LeadPackageAssignment, WalletLedger, sequelize, logger, ledgerRows, createdAssignments };
+  const svc = makeWalletService({ User, Campaign, LeadPackage, LeadPackageAssignment, WalletLedger, IdempotencyKey, sequelize, getSystemAgentId, logger });
+  return { svc, User, Campaign, LeadPackage, LeadPackageAssignment, WalletLedger, IdempotencyKey, sequelize, logger, ledgerRows, createdAssignments };
 }
 
 describe('walletService credit/debit (applyLedgerEntry)', () => {
@@ -199,6 +204,50 @@ describe('walletService.commit', () => {
     const { svc } = build({ campaign: activeCampaign(), guardedUpdateEmpty: true, userCount: 1 });
     await expect(svc.commit('agent-1', 'c-1', 5)).rejects.toMatchObject({ statusCode: 409 });
   });
+
+  test('rejects when the agent is no longer an active external agent (in-tx revalidation)', async () => {
+    const { svc, WalletLedger } = build({ campaign: activeCampaign(), externalTarget: null });
+    await expect(svc.commit('agent-1', 'c-1', 5)).rejects.toMatchObject({ statusCode: 409 });
+    expect(WalletLedger.create).not.toHaveBeenCalled();
+  });
+
+  test('idempotent commit: the key row is written FIRST inside the tx and the response stored', async () => {
+    const { svc, IdempotencyKey } = build({ campaign: activeCampaign() });
+    const r = await svc.commit('agent-1', 'c-1', 2, { requestId: 'req-abc-12345' });
+    expect(r.replayed).toBeUndefined();
+    expect(IdempotencyKey.create).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'wallet:commit:agent-1:req-abc-12345', scope: 'wallet:commit' }),
+      { transaction: FAKE_TX }
+    );
+    expect(IdempotencyKey.update).toHaveBeenCalledWith(
+      expect.objectContaining({ responseBody: expect.objectContaining({ totalCents: 1600 }), responseCode: 201 }),
+      expect.objectContaining({ where: { key: 'wallet:commit:agent-1:req-abc-12345' } })
+    );
+  });
+
+  test('idempotent commit replay: stored response returned, no money moves', async () => {
+    const { svc, IdempotencyKey, WalletLedger, sequelize } = build({ campaign: activeCampaign() });
+    IdempotencyKey.findByPk.mockResolvedValueOnce({ responseBody: { assignmentId: 'asg-prior', totalCents: 1600 } });
+    const r = await svc.commit('agent-1', 'c-1', 2, { requestId: 'req-abc-12345' });
+    expect(r).toEqual({ assignmentId: 'asg-prior', totalCents: 1600, replayed: true });
+    expect(sequelize.transaction).not.toHaveBeenCalled();
+    expect(WalletLedger.create).not.toHaveBeenCalled();
+  });
+
+  test('concurrent duplicate: PK collision aborts the duplicate tx and returns the winner', async () => {
+    const { svc, IdempotencyKey } = build({ campaign: activeCampaign() });
+    IdempotencyKey.create.mockRejectedValueOnce(uniqueViolation());
+    IdempotencyKey.findByPk
+      .mockResolvedValueOnce(null) // pre-check: not yet written
+      .mockResolvedValueOnce({ responseBody: { assignmentId: 'asg-winner' } }); // after collision
+    const r = await svc.commit('agent-1', 'c-1', 2, { requestId: 'req-abc-12345' });
+    expect(r).toEqual({ assignmentId: 'asg-winner', replayed: true });
+  });
+
+  test('malformed requestId is rejected before any read', async () => {
+    const { svc } = build({ campaign: activeCampaign() });
+    await expect(svc.commit('agent-1', 'c-1', 2, { requestId: 'no spaces!' })).rejects.toMatchObject({ statusCode: 400 });
+  });
 });
 
 function refundableRow(over = {}) {
@@ -257,13 +306,13 @@ describe('walletService.refundCampaignCommitments', () => {
     expect(rowA.update).not.toHaveBeenCalled();
   });
 
-  test('wallet assignment without unitPriceCents is skipped (logged, never guessed)', async () => {
+  test('wallet assignment without unitPriceCents ABORTS the archive (data corruption, never strand)', async () => {
     const row = refundableRow({ unitPriceCents: null });
     const { svc, logger, WalletLedger } = build({ refundCandidates: [{ id: 'asg-1' }], lockedRows: [row] });
-    const r = await svc.refundCampaignCommitments('c-1', { transaction: FAKE_TX });
-    expect(r.refunded).toBe(0);
+    await expect(svc.refundCampaignCommitments('c-1', { transaction: FAKE_TX })).rejects.toMatchObject({ statusCode: 500 });
     expect(WalletLedger.create).not.toHaveBeenCalled();
     expect(logger.error).toHaveBeenCalled();
+    expect(row.update).not.toHaveBeenCalled();
   });
 });
 

--- a/backend/test/unit/walletService.test.js
+++ b/backend/test/unit/walletService.test.js
@@ -157,10 +157,10 @@ describe('walletService.commit', () => {
     const { svc, LeadPackage, LeadPackageAssignment, WalletLedger } = build({ campaign: activeCampaign(), balanceAfter: 200 });
     const r = await svc.commit('agent-1', 'c-1', 12);
 
-    // Hidden wallet package created with complete NOT NULL values
+    // Hidden wallet package created with complete NOT NULL values — OUTSIDE the
+    // money tx (unique-violation retry can't live inside an open pg transaction)
     expect(LeadPackage.create).toHaveBeenCalledWith(
-      expect.objectContaining({ kind: 'wallet', campaignId: 'c-1', isPublic: false, status: 'active', price: 0, leadCount: 0, createdBy: 'sys-agent' }),
-      expect.anything()
+      expect.objectContaining({ kind: 'wallet', campaignId: 'c-1', isPublic: false, status: 'active', price: 0, leadCount: 0, createdBy: 'sys-agent' })
     );
     // Assignment: source wallet + per-lead snapshot + dollars priceSnapshot
     expect(LeadPackageAssignment.create).toHaveBeenCalledWith(
@@ -243,28 +243,18 @@ describe('walletService.refundCampaignCommitments', () => {
     expect(WalletLedger.create).not.toHaveBeenCalled();
   });
 
-  test('unique-violation on the refund ledger row = replay → skipped, others continue', async () => {
+  test('a unique violation on the refund ledger aborts loudly (code-bug signal, whole archive rolls back)', async () => {
     const rowA = refundableRow({ id: 'asg-1' });
-    const rowB = refundableRow({ id: 'asg-2', agentId: 'agent-2', leadsRemaining: 3 });
-    const { svc, WalletLedger, sequelize } = build({
-      refundCandidates: [{ id: 'asg-1' }, { id: 'asg-2' }],
-      lockedRows: [rowA, rowB],
+    const { svc, WalletLedger } = build({
+      refundCandidates: [{ id: 'asg-1' }],
+      lockedRows: [rowA],
     });
-    // First credit hits the unique partial index (already refunded), second succeeds.
-    let call = 0;
-    sequelize.query.mockImplementation(async (sql) => {
-      if (String(sql).trim().startsWith('UPDATE users')) {
-        call += 1;
-        if (call === 1) throw uniqueViolation();
-        return [[{ walletBalanceCents: 111 }]];
-      }
-      return [[]];
-    });
-    const r = await svc.refundCampaignCommitments('c-1', { transaction: FAKE_TX });
-    expect(r).toEqual({ refunded: 1, totalCents: 2400 });
+    // The unique partial index fires only on a genuine double-refund bug —
+    // swallowing it inside the open transaction would poison it (pg 25P02),
+    // so it must PROPAGATE and take the archive down with it.
+    WalletLedger.create.mockImplementationOnce(async () => { throw uniqueViolation(); });
+    await expect(svc.refundCampaignCommitments('c-1', { transaction: FAKE_TX })).rejects.toMatchObject({ name: 'SequelizeUniqueConstraintError' });
     expect(rowA.update).not.toHaveBeenCalled();
-    expect(rowB.update).toHaveBeenCalled();
-    expect(WalletLedger.create).toHaveBeenCalledTimes(1);
   });
 
   test('wallet assignment without unitPriceCents is skipped (logged, never guessed)', async () => {

--- a/backend/test/unit/walletTopup.test.js
+++ b/backend/test/unit/walletTopup.test.js
@@ -1,0 +1,155 @@
+import { jest } from '@jest/globals';
+import '../setup.js';
+import { makeBillingService } from '../../src/services/billingService.js';
+
+/**
+ * Wallet TOP-UP branch of the billing money-path (kind:'wallet_topup').
+ * Invariants:
+ *  - checkout only accepts the preset whitelist and writes a package-less
+ *    Payment snapshot (leadPackageId null, leadCount 0);
+ *  - settlement credits the wallet INSIDE the locked transaction and can never
+ *    fall into paid_unfulfilled while an agent exists;
+ *  - replays (status already 'paid') never double-credit;
+ *  - an amount mismatch is rejected BEFORE any wallet credit;
+ *  - package purchases (no kind / kind:'package_purchase') never touch the wallet.
+ */
+
+function fakePayment(over = {}) {
+  const row = {
+    id: 'pay-1',
+    agentId: 'agent-1',
+    leadPackageId: null,
+    kind: 'wallet_topup',
+    leadCount: 0,
+    amount: '100.00',
+    currency: 'SGD',
+    providerRequestId: 'hp-req-1',
+    providerPaymentId: null,
+    leadPackageAssignmentId: null,
+    status: 'pending',
+    ...over,
+  };
+  row.update = jest.fn(async (u) => Object.assign(row, u));
+  return row;
+}
+
+function build({ agent = null, payment = null, hitpayThrows = false } = {}) {
+  const createdPayments = [];
+  const Payment = {
+    create: jest.fn(async (attrs) => {
+      const row = { ...attrs, id: 'pay-1', update: jest.fn(async (u) => Object.assign(row, u)) };
+      createdPayments.push(row);
+      return row;
+    }),
+    findOne: jest.fn(async () => payment),
+    findAll: jest.fn(async () => []),
+  };
+  const LeadPackage = { findByPk: jest.fn(async () => null) };
+  const LeadPackageAssignment = { create: jest.fn(async () => ({ id: 'asg-1' })) };
+  const User = { findOne: jest.fn(async () => agent), findAll: jest.fn(async () => []) };
+  const sequelize = { transaction: jest.fn(async (cb) => cb({ LOCK: { UPDATE: 'UPDATE' } })) };
+  const hitpay = {
+    createPaymentRequest: jest.fn(async () => {
+      if (hitpayThrows) throw new Error('hitpay down');
+      return { id: 'hp-req-1', url: 'https://hit-pay.com/pay/topup' };
+    }),
+  };
+  const walletCredit = jest.fn(async () => ({ id: 'led-1', balanceAfterCents: 10000 }));
+  const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+  const svc = makeBillingService({ Payment, LeadPackage, LeadPackageAssignment, User, Campaign: {}, sequelize, hitpay, walletCredit, logger });
+  return { svc, Payment, LeadPackageAssignment, walletCredit, createdPayments };
+}
+
+const okAgent = { id: 'agent-1', firstName: 'A', lastName: 'B', fullName: 'A B', email: 'a@b.co' };
+const topupWebhook = (over = {}) => ({
+  reference_number: 'pay-1', payment_request_id: 'hp-req-1', payment_id: 'hp-pay-9',
+  status: 'completed', amount: '100.00', currency: 'SGD', ...over,
+});
+
+describe('billingService.createWalletTopupCheckout', () => {
+  test('invalid_agent when no synced active agent', async () => {
+    const { svc } = build({ agent: null });
+    expect((await svc.createWalletTopupCheckout({ agentMktrUserId: 'm1', amountCents: 10000 })).status).toBe('invalid_agent');
+  });
+
+  test('invalid_amount outside the preset whitelist (with presets echoed)', async () => {
+    const { svc, Payment } = build({ agent: okAgent });
+    for (const amountCents of [9999, 0, -100, 12345, '10000', null, undefined]) {
+      const r = await svc.createWalletTopupCheckout({ agentMktrUserId: 'm1', amountCents });
+      expect(r.status).toBe('invalid_amount');
+      expect(r.presets).toEqual([10000, 50000, 200000]);
+    }
+    expect(Payment.create).not.toHaveBeenCalled();
+  });
+
+  test('created — package-less Payment snapshot with kind wallet_topup', async () => {
+    const { svc, Payment, createdPayments } = build({ agent: okAgent });
+    const r = await svc.createWalletTopupCheckout({ agentMktrUserId: 'm1', amountCents: 50000 });
+    expect(r.status).toBe('created');
+    expect(Payment.create).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'wallet_topup', leadPackageId: null, leadCount: 0, amount: '500.00',
+      packageName: 'Wallet top-up', status: 'pending', forTeam: false,
+    }));
+    expect(createdPayments[0].update).toHaveBeenCalledWith({ providerRequestId: 'hp-req-1' });
+  });
+
+  test('provider_error marks the pending Payment failed', async () => {
+    const { svc, createdPayments } = build({ agent: okAgent, hitpayThrows: true });
+    const r = await svc.createWalletTopupCheckout({ agentMktrUserId: 'm1', amountCents: 10000 });
+    expect(r.status).toBe('provider_error');
+    expect(createdPayments[0].update).toHaveBeenCalledWith({ status: 'failed' });
+  });
+});
+
+describe('billingService.fulfillFromWebhook — wallet_topup branch', () => {
+  test('credits the wallet inside the locked tx and flips the Payment to paid', async () => {
+    const payment = fakePayment();
+    const { svc, walletCredit, LeadPackageAssignment } = build({ payment });
+    const r = await svc.fulfillFromWebhook(topupWebhook());
+    expect(r).toEqual({ status: 'fulfilled', walletTopup: true });
+    expect(walletCredit).toHaveBeenCalledWith('agent-1', 10000, expect.objectContaining({
+      type: 'topup', paymentId: 'pay-1', transaction: expect.anything(),
+    }));
+    expect(payment.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'paid', providerPaymentId: 'hp-pay-9' }),
+      expect.anything()
+    );
+    // never grants a package assignment
+    expect(LeadPackageAssignment.create).not.toHaveBeenCalled();
+  });
+
+  test('replay (already paid) never double-credits', async () => {
+    const payment = fakePayment({ status: 'paid' });
+    const { svc, walletCredit } = build({ payment });
+    const r = await svc.fulfillFromWebhook(topupWebhook());
+    expect(r.status).toBe('replay');
+    expect(walletCredit).not.toHaveBeenCalled();
+  });
+
+  test('amount mismatch is rejected BEFORE any credit (payment → failed)', async () => {
+    const payment = fakePayment();
+    const { svc, walletCredit } = build({ payment });
+    const r = await svc.fulfillFromWebhook(topupWebhook({ amount: '999.00' }));
+    expect(r.status).toBe('rejected');
+    expect(walletCredit).not.toHaveBeenCalled();
+    expect(payment.update).toHaveBeenCalledWith(expect.objectContaining({ status: 'failed' }), expect.anything());
+  });
+
+  test('vanished agent → paid_unfulfilled (money recorded, no credit)', async () => {
+    const payment = fakePayment({ agentId: null });
+    const { svc, walletCredit } = build({ payment });
+    const r = await svc.fulfillFromWebhook(topupWebhook());
+    expect(r.status).toBe('paid_unfulfilled');
+    expect(walletCredit).not.toHaveBeenCalled();
+    expect(payment.update).toHaveBeenCalledWith(expect.objectContaining({ status: 'paid' }), expect.anything());
+  });
+
+  test('package purchases never touch the wallet (kind default path intact)', async () => {
+    const payment = fakePayment({ kind: 'package_purchase', leadPackageId: 'pkg-1', leadCount: 20, amount: '200.00' });
+    const { svc, walletCredit, LeadPackageAssignment } = build({ payment });
+    const r = await svc.fulfillFromWebhook(topupWebhook({ amount: '200.00' }));
+    expect(r.status).toBe('fulfilled');
+    expect(walletCredit).not.toHaveBeenCalled();
+    expect(LeadPackageAssignment.create).toHaveBeenCalled();
+  });
+});

--- a/docs/plans/agent-wallet-commitments.md
+++ b/docs/plans/agent-wallet-commitments.md
@@ -1,0 +1,240 @@
+# Agent wallet + per-campaign lead commitments (mktr-leads external agents)
+
+**Date:** 2026-07-15 · **Status:** REVIEWED — Codex round 1 (gpt-5.6-sol
+xhigh) findings verified against code and folded in below (see "Codex round 1
+resolutions"). Supersedes ambiguities in the original draft where marked.
+**Replaces:** admin-administered lead packages for EXTERNAL agents (drain-down,
+no conversion). Internal Lyfe agents are explicitly out of scope (later phase).
+
+## Product decisions (locked with Shawn, 2026-07-15)
+
+1. **Wallet**: $1 = 1 credit (store cents; SGD). Top-ups non-refundable to
+   cash, no expiry — credits can only become leads.
+2. **Per-campaign lead price**: admin-set `leadPriceCents` on the campaign
+   (server-clamped, admin-only — campaign PUT is open to agents).
+3. **Commitment**: agent self-serves "N leads of campaign X @ price" — debits
+   wallet instantly, no admin involvement. The commitment size is the spend
+   bound; NO other caps.
+4. **Delivery unchanged**: round-robin among open commitments, instant webhook
+   push to the mktr-leads app. No browsable inventory.
+5. **No self-cancel** of commitments. The ONLY refund path: campaign
+   **archived or completed** → undelivered remainder auto-returns to wallet as
+   credits. **Paused → delivery stops, commitment holds** (no refund).
+6. **Migration = drain-down**: verified in prod 2026-07-15 — only 2 external
+   agents / 5 active assignments / 156 leads remaining. Existing package
+   assignments keep delivering through the same routing until exhausted; no
+   balance conversion. Package SALES stop at cutover.
+7. **v2 (not this build)**: uncovered-lead push loop — when a lead quarantines
+   with `no_funded_agent`, notify all external agents "commit now"; first
+   committer releases it.
+
+## Ground truth (verified in code)
+
+| Piece | Reality |
+|---|---|
+| Routing pool | `systemAgent.js:119` — assignments `status:'active', leadsRemaining>0` joined through `LeadPackage.campaignId`. Campaign scoping lives on the PACKAGE, not the assignment |
+| Charging | `leadCredits.js` — `deductLeadCredit` / `deductExternalLeadBalance` decrement `leadsRemaining` |
+| Held leads | quarantine with `heldReason:'no_funded_agent'` when no funded agent — unchanged |
+| External auth | HMAC-SHA256 over raw body (`EXTERNAL_APP_SECRET`), POST-only endpoints under `/api/external/*`, rate-limiter exempt (server_internal.js) |
+| Billing scaffold | `/api/external/billing` (flag `BILLING_ENABLED`, currently unmounted): `catalog/checkout/status/history/document` + `hitpay-webhook` (HitPay-signature-authed). `Payment` model records provider/amount/status; `hitpayClient.js` + unit tests exist |
+| Delivery to app | `lead.created` webhook routed by destination (`prospectHelpers.js:42` — `agent.mktrLeadsId → 'mktr_leads'`); the app already pushes on arrival |
+| Assignment model | `LeadPackageAssignment`: `status active/completed/cancelled/expired`, `leadsRemaining`, leads/price snapshots |
+
+## Design
+
+### Zero-routing-change trick
+A commitment = a normal `LeadPackageAssignment` under an **auto-created hidden
+wallet package** per campaign (`LeadPackage` row: `type:'custom'`,
+`name:'Wallet commitments'`, `campaignId`, `isPublic:false`, `status:'active'`,
+created lazily on first commit). Routing, charging, drain-down coexistence and
+held-lead behaviour all work untouched. New columns mark and price the
+commitment (below).
+
+### Data model (migrations 068+, guarded/idempotent, camelCase DDL)
+- `campaigns.leadPriceCents` INTEGER NULL — no price = campaign not
+  commit-able by external agents (catalog hides it).
+- `lead_package_assignments.source` STRING(16) NOT NULL DEFAULT `'package'`
+  (`package|wallet`) + `unitPriceCents` INTEGER NULL (per-lead snapshot at
+  commit time — refunds = `leadsRemaining × unitPriceCents`).
+- New `wallet_ledger` (append-only): `id`, `agentId` (users FK),
+  `type: topup|commit|takedown_refund|adjustment`, `amountCents` (signed),
+  `balanceAfterCents`, refs (`paymentId`, `assignmentId`, `campaignId`
+  nullable), `note`, `createdBy` (null = system), `createdAt`. Indexes on
+  (agentId, createdAt).
+- `users.walletBalanceCents` INTEGER NOT NULL DEFAULT 0 — maintained in the
+  SAME transaction as every ledger insert (atomic increment with a
+  `balance + amount >= 0` guard; ledger is the audit truth, column is the
+  fast read). Mirror indexes on models (sync-clobber lesson).
+
+### Backend service — `walletService.js`
+- `credit(agentId, amountCents, {type, refs, tx})` / `debit(...)` — single
+  place that writes ledger + balance atomically; debit fails (409
+  `insufficient_balance`) rather than going negative.
+- `commit(agentId, campaignId, quantity)`: validate campaign is **active +
+  priced (`leadPriceCents` non-null)** — commit-ability is priced-only; it
+  does NOT read or write `campaign.externalEligible`, which belongs to the
+  inert ExternalAgent buyer-marketplace gate (see resolutions #1/#2); `total =
+  quantity × leadPriceCents`; debit wallet; find-or-create the campaign's
+  wallet package; create assignment (`source:'wallet'`, `unitPriceCents`,
+  `leadsTotal/leadsRemaining = quantity`, `status:'active'`) — one
+  transaction. **Concrete row shapes (required NOT NULLs verified):** wallet
+  package = `{ name:'Wallet commitments', type:'custom', campaignId,
+  isPublic:false, status:'active', currency:'SGD', price:0, leadCount:0,
+  createdBy: system-agent id }`; assignment `priceSnapshot = total/100` (SGD
+  dollars, model requires it) alongside `unitPriceCents`. **Race safety:**
+  `findOrCreate` alone is racy — migration adds `lead_packages.kind`
+  STRING(16) NOT NULL DEFAULT `'catalog'` (`catalog|wallet`) + a UNIQUE
+  partial index `(campaignId) WHERE kind='wallet'`, and commit retries once
+  on unique-violation.
+- `refundCampaignCommitments(campaignId, {reason, tx})`: for each wallet-source
+  assignment with `leadsRemaining > 0` and status active → credit
+  `leadsRemaining × unitPriceCents` (`type:'takedown_refund'`), zero the
+  remainder, set assignment `status:'completed'` + note. **Concurrency-safe
+  idempotency, not just skip-completed:** runs INSIDE one transaction with the
+  campaign row locked (`SELECT … FOR UPDATE`) and assignments locked; plus a
+  UNIQUE partial index on `wallet_ledger (assignmentId) WHERE
+  type='takedown_refund'` so a double-archive race cannot double-credit.
+- Hook: `campaignService.archiveCampaign` becomes transactional (it currently
+  updates status + detaches QR tags with NO transaction — verified
+  campaignService.js:525–534): lock campaign → refund → set `archived` in one
+  tx; QR-tag detach moves after commit. `status:'completed'` is unreachable
+  in code today (enum-only); guard comment requires any future completed
+  transition to route through the same function. **Pause does NOT refund**
+  (decision 5). setCampaignLaunchState pause path untouched.
+
+### Top-up (reuse the billing scaffold — with an explicit `Payment.kind` branch)
+Verified constraints: `checkout` currently 400s without `packageId`
+(externalBillingController.js:96), `Payment.leadCount` is NOT NULL, and
+settlement either creates a package assignment or marks `paid_unfulfilled`
+when the package is missing (billingService.js:379–392). So `wallet_topup`
+cannot ride the existing shape untouched:
+- Migration adds `payments.kind` STRING(24) NOT NULL DEFAULT
+  `'package_purchase'` (`package_purchase|wallet_topup`), relaxes nothing on
+  existing rows; top-up rows set `leadPackageId` null, `leadCount 0`,
+  `packageName 'Wallet top-up'`, amount from a preset whitelist
+  ($100/$500/$2000 → cents).
+- `checkout` branches on `kind`: `wallet_topup` skips packageId validation,
+  creates the HitPay request + Payment(kind wallet_topup).
+- Settlement: the existing handler already locks the Payment row
+  (`findOne … lock: t.LOCK.UPDATE`) and short-circuits on `status==='paid'` —
+  the wallet credit happens INSIDE that same locked transaction, branching on
+  `payment.kind` BEFORE the package-fulfillment path (so a top-up can never
+  fall into `paid_unfulfilled`). Idempotency = the existing status check +
+  paid short-circuit, **plus** a UNIQUE partial index on `wallet_ledger
+  (paymentId) WHERE type='topup'` as defense in depth.
+- Receipts via the existing `document` endpoint.
+
+### New external endpoints (HMAC POST, one router `/api/external/wallet`,
+flag `AGENT_WALLET_ENABLED`, default false)
+- `/summary` — balance + open commitments (campaign, remaining, unit price)
+- `/ledger` — paginated ledger entries
+- `/catalog` — commit-able campaigns: name, `leadPriceCents`, blurb/dates
+  (whitelisted fields only — external surface, no design_config dump)
+- `/commit` — `{campaignId, quantity}` → walletService.commit; returns new
+  summary. No cancel endpoint exists (decision: no self-cancel).
+
+### mktr-leads app (SEPARATE repo — screens only; backend is all mktr-platform)
+- Wallet screen: balance, ledger, top-up (HitPay via expo-linking, same
+  pattern as the built Buy Leads flow — App-Store-safe external browser).
+- Commit flow: catalog → quantity picker → confirm ("160 credits · no
+  cancellation · refunded as credits only if the campaign is taken down") →
+  success. Copy must state the no-cash-refund rule at BOTH top-up and commit.
+- Lead push: unchanged (already live).
+- Note: repo has no write creds server-side — Shawn deploys the app/OTA.
+
+### Admin (mktr-platform)
+- Campaign form/designer: `leadPriceCents` input (admin-only server clamp in
+  campaignService, same policy pattern as marketplaceListed).
+- Agents/packages admin: wallet balance + committed-demand column; per-
+  campaign committed-undelivered total (this is the ad-spend demand signal —
+  also feeds the dashboard-redesign "agent supply" view).
+- Admin adjustment endpoint (admin-auth): manual ledger `adjustment` with
+  required note — the escape hatch that keeps "no refunds" enforceable
+  without DB surgery.
+
+### Cutover / rollout
+1. Ship dark (`AGENT_WALLET_ENABLED=false`; `BILLING_ENABLED` still gates
+   HitPay). Migrations are inert.
+2. Provision HitPay (already scoped for Buy Leads), flip `BILLING_ENABLED`,
+   test a $1 top-up end-to-end (webhook → ledger → balance).
+3. Flip `AGENT_WALLET_ENABLED`; OTA the app screens.
+4. Stop package sales to external agents (catalog switch); existing 5
+   assignments drain naturally.
+5. Watch: first commit → first routed lead → wallet debit trail; takedown
+   refund on a test campaign.
+
+### Tests
+- walletService: atomic debit/credit, insufficient-balance 409, negative
+  guard, ledger/balance consistency, commit transaction (package find-or-
+  create, assignment shape), refund idempotency + pause-does-nothing.
+- hitpay settlement idempotency (double webhook = single credit).
+- Routing regression: wallet-source assignments join the pool exactly like
+  package ones (existing decideAssignment tests extended).
+- External endpoints: HMAC required, flag-off unmounted, catalog hides
+  unpriced campaigns.
+
+### Wallet-account lifecycle policy (new — closes the paid-commitment eraser)
+Verified hazards: `deactivateUser` DESTROYS all the user's package assignments
+(userService.js:358), bulk permanent delete does the same + FK-cascades
+(userService.js:446, migration 014), and the mktr-leads sync hard-deletes
+inactive agents absent upstream when they have no PROSPECTS — without checking
+assignments or ledger rows (agentSyncService.js:477). With real money these
+paths erase paid commitments. Policy:
+- `deactivateUser` / bulk-delete: **reject (409)** when the user has open
+  wallet-source commitments (`source='wallet'`, remaining > 0) or
+  `walletBalanceCents > 0` — admin must resolve the balance first (takedown
+  or manual `adjustment` to zero, note required). Assignment destroy keeps
+  skipping `source='wallet'` rows in all cases: wallet history is never
+  deleted, terminal states only.
+- Users with ANY wallet_ledger history are excluded from the sync's
+  pending-deletion + hard-delete queries (`NOT IN (SELECT DISTINCT "agentId"
+  FROM wallet_ledger)`), mirroring the existing prospects guard.
+- No silent refund on deactivation/deletion — refunds happen ONLY on campaign
+  takedown (product decision 5); everything else is a manual adjustment with
+  a note.
+
+### Codex round 1 resolutions (2026-07-15, all verified against code)
+
+1. **"Consent bypass" finding — REJECTED as a new hazard, kept as a
+   documented stance.** mktr-leads agents ARE `users` rows (mktrLeadsId) and
+   route through the internal package pool TODAY by design (the 2026-06 pivot:
+   external agents = second team; webhook destination derives from
+   `mktrLeadsId` in prospectHelpers). Wallet commitments are the same class of
+   assignment for the same users — no new path. Codex's proposed fix
+   (exclude mktrLeadsId users from resolveLeadRouting) would BREAK live
+   delivery for the draining package agents and the wallet itself. The
+   separate consent-gated resolver (`resolveLeadAssignment` + `allowExternal`)
+   guards the INERT ExternalAgent buyer pool, not mktr-leads users. Flag for
+   Shawn (product, not this build): whether `consent_third_party` should gate
+   delivery to mktr-leads agents is a policy question about the pivot-era
+   stance, unchanged by wallets.
+2. **ExternalAgent/ExternalCampaignAgent parallel pool — stays INERT and out
+   of scope.** Wallet eligibility = `leadPriceCents` non-null ONLY; the plan
+   no longer says "external-eligible" anywhere near commit-ability (that word
+   collided with `campaign.externalEligible`, the buyer-pool flag). Admin
+   wallet roster filters `users.mktrLeadsId IS NOT NULL`. Do not set
+   `externalEligible` on campaigns as part of this build.
+3. Hidden-package NOT NULLs + race → concrete row shape, `lead_packages.kind`
+   column + unique partial index (folded into `commit` above).
+4. Payment/settlement fit → `payments.kind` branch inside the existing locked
+   settlement transaction + unique topup ledger index (folded into Top-up).
+5. Archive refund atomicity → transactional archiveCampaign + per-assignment
+   unique takedown_refund index (folded into refund section).
+6. User-lifecycle eraser → lifecycle policy section above.
+7. WalletLedger model parity: register a `WalletLedger` model with
+   `timestamps:false` + explicit `createdAt` (global Sequelize config defaults
+   BOTH timestamps on; migration 070 has no updatedAt) and mirror ALL new
+   columns/indexes on models (Campaign.leadPriceCents, User.walletBalanceCents,
+   assignment source/unitPriceCents, package kind, every unique partial) so
+   test `sync({force:true})` reproduces prod constraints.
+8. `leadPriceCents` reaches the DB: add to `schemas.campaignCreate/Update`
+   Joi (nullable positive int) AND to campaignService create/update persisted
+   fields, with the admin-only clamp on both paths (verified: current schemas
+   reject/strip it and the service ignores it).
+
+### Non-goals
+- Internal (Lyfe) agents — later migration, same rails.
+- Uncovered-lead "commit now" push loop (v2).
+- Self-cancel of commitments; cash refunds; credit expiry.
+- Browsable lead inventory (rejected — freshness/coverage).
+- Activating the ExternalAgent buyer pool / `externalEligible` semantics.

--- a/docs/plans/agent-wallet-commitments.md
+++ b/docs/plans/agent-wallet-commitments.md
@@ -232,6 +232,52 @@ paths erase paid commitments. Policy:
    fields, with the admin-only clamp on both paths (verified: current schemas
    reject/strip it and the service ignores it).
 
+### Codex round 2 — post-implementation review (2026-07-15, PR #159)
+
+Reviewed the built diff at commit 184f339; verdict "do not merge yet" on
+3 BLOCKERs / 4 MAJORs. All verified against code and FIXED in the follow-up
+commit, except one accepted risk (below):
+
+1. **Model validation rejected both entry paths** (LeadPackage.leadCount +
+   Payment.leadCount had `min:1`; wallet rows carry 0 — my DI-mocked unit
+   tests bypassed model validation entirely, which is why they were green).
+   → kind-aware validators on both models.
+2. **Soft-quota overdelivery**: priced campaigns on the default
+   `enforceLeadQuota:false` path could deliver free leads on a failed/raced
+   charge. → `leadQuota.decideAssignment` now treats **priced (leadPriceCents
+   set) as always-enforced** — a pre-sold lead is never delivered free;
+   the existing SKIP-LOCKED concurrency guarantee now covers wallet
+   campaigns. Integration tests added (priced+soft+unfunded → held;
+   priced+soft+funded → delivered + charged).
+3. **Legacy package-admin paths could mutate paid commitments**
+   (topUp/cancel/remove/delete/updateAssignment; updatePackage/deletePackage
+   on the hidden container; catalogs listing it). → `rejectWalletAssignment`
+   / `rejectWalletPackage` fences on all six mutation paths; wallet
+   containers excluded from listPackages + getExternalAdminCatalog (the buy
+   catalog already excluded them via price>0 + isPublic).
+4. **duplicateCampaign spread leadPriceCents** — a non-admin could mint a
+   priced campaign by duplicating a public one. → duplicates always start
+   with `leadPriceCents: null`.
+5. **Refund skipped malformed rows**, stranding an open commitment on an
+   archived campaign. → refund now ABORTS the archive (500) on a wallet
+   assignment without a positive unitPriceCents; DB CHECK
+   `chk_lpa_wallet_unit_price` added in 069 + model validator.
+6. **Lifecycle races**: deactivation guard now runs INSIDE the transaction
+   under a user row lock, and `commit()` revalidates the agent (active +
+   mktrLeadsId) under `FOR UPDATE` — commit and deactivate serialize.
+   **Accepted risk (documented, not fixed):** `toggleUserStatus`/`updateUser`
+   can still flip `isActive` without the wallet guard — but they destroy
+   NOTHING; the commitment simply pauses with the agent and resumes on
+   reactivation. Money cannot be lost through those paths.
+7. **No idempotency on commit/adjust** — a broker retry after a lost
+   response double-debited. → `withIdempotency` over the house
+   IdempotencyKey table (key = `wallet:commit:{agentId}:{requestId}`,
+   PK-collision aborts the duplicate transaction atomically, response stored
+   in the same tx). `requestId` is REQUIRED on `/commit`, optional on admin
+   adjust. 24h TTL.
+8. Payment model now mirrors migration 040's three unique partial indexes
+   (test `sync({force:true})` parity).
+
 ### Non-goals
 - Internal (Lyfe) agents — later migration, same rails.
 - Uncovered-lead "commit now" push loop (v2).

--- a/docs/plans/mktr-admin-rebuild-implementation.md
+++ b/docs/plans/mktr-admin-rebuild-implementation.md
@@ -1,0 +1,372 @@
+# MKTR Admin rebuild — combined implementation plan
+
+**Date:** 2026-07-15 · **Status:** REVIEWED — Codex round 1 (gpt-5.6-sol
+xhigh, 6 BLOCKER / 6 MAJOR / 2 MINOR) verified against code and folded in;
+one Codex fix overruled with evidence (see review log at the bottom).
+**Sources of truth:** final design (claude.ai/design project
+`57e68763-9fd1-47ed-b5f9-14224a016ff4`: `MKTR Admin.dc.html`,
+`Design System.dc.html`, `mock-api.js`), `docs/plans/
+mktr-admin-redesign-reconciliation.md` (DESIGN FINAL + net-new inventory),
+`docs/plans/agent-wallet-commitments.md` (wallet spec — the detailed contract;
+this plan sequences it, it does not restate it).
+
+**Sequencing (locked):** wallet backend → admin API extensions → Switchboard
+UI rebuild (flagged) → fleet/commissions/APK teardown rides the flag flip.
+Four phases ≈ six PRs. Everything ships dark or additive until the flip.
+
+---
+
+## Phase A — Wallet & commitments backend (PR1, dark)
+
+Implements `agent-wallet-commitments.md` verbatim — **as revised by the Codex
+round 1 resolutions in that doc** (hidden-package concrete shape + unique
+partial index, `payments.kind` settlement branch, transactional
+archive-refund, user-lifecycle closure policy, priced-only commit-ability
+that never touches `campaign.externalEligible`) — plus the **admin surface
+the redesign consumes** (the wallet plan sketched it; the design fixed its
+contract):
+
+### A1. Migrations `068`–`071` (guarded/idempotent, camelCase DDL, indexes
+mirrored on models — the `sync({force:true})` clobber lesson)
+
+| # | Change |
+|---|---|
+| 068 | `campaigns.leadPriceCents` INTEGER NULL (+ Joi `campaignCreate`/`campaignUpdate` schema entries + campaignService create/update persist, admin-only clamp — the current schemas strip it and the service ignores it) |
+| 069 | `lead_package_assignments.source` STRING(16) NOT NULL DEFAULT `'package'` + `unitPriceCents` INTEGER NULL; `lead_packages.kind` STRING(16) NOT NULL DEFAULT `'catalog'` + UNIQUE partial index `(campaignId) WHERE kind='wallet'` |
+| 070 | `wallet_ledger` table: id, agentId (users FK), type `topup\|commit\|takedown_refund\|adjustment`, amountCents (signed), balanceAfterCents, paymentId/assignmentId/campaignId (nullable refs), note, createdBy (null = system), createdAt; index (agentId, createdAt); UNIQUE partials `(assignmentId) WHERE type='takedown_refund'` and `(paymentId) WHERE type='topup'`; registered `WalletLedger` model with `timestamps:false` + explicit createdAt (global config defaults both timestamps on) |
+| 071 | `users.walletBalanceCents` INTEGER NOT NULL DEFAULT 0; `payments.kind` STRING(24) NOT NULL DEFAULT `'package_purchase'` |
+
+All columns/indexes mirrored on models so test `sync({force:true})`
+reproduces prod constraints (bootstrap runs migrations after sync in tests).
+
+Note: the migrations dir already has TWO `066-*` files — **verified harmless**:
+`runMigrations.js` tracks applied migrations by FULL FILENAME in `_migrations`
+(lexicographic sort, filename-keyed set), so both 066 files run and 068+ is
+collision-safe.
+
+### A2. `backend/src/services/walletService.js`
+Per the wallet plan: atomic `credit`/`debit` (ledger insert + balance update in
+one transaction, `balance + amount >= 0` guard, 409 `insufficient_balance`),
+`commit(agentId, campaignId, quantity)` (active + priced + external-eligible
+validation; find-or-create hidden wallet `LeadPackage` per campaign —
+`type:'custom'`, `isPublic:false`; create assignment `source:'wallet'` with
+`unitPriceCents` snapshot), `refundCampaignCommitments(campaignId)` (idempotent
+takedown refund: remaining × unitPriceCents per open wallet assignment, zero +
+complete each). Hook: **`campaignService.archiveCampaign` is the ONLY real
+trigger** — verified: no code path ever sets `status:'completed'` (transitions
+are draft↔active↔paused via `is_active`/launch-state + archive/restore; the
+enum value exists but is unreachable). Wire the refund into archiveCampaign;
+leave a guard comment that any future completed-transition must call it too.
+**Pause does not refund** (decision 5).
+
+### A3. External endpoints — `/api/external/wallet` (HMAC POST, flag
+`AGENT_WALLET_ENABLED` default false, rate-limiter exempt like the other
+external routers): `/summary`, `/ledger`, `/catalog` (whitelisted fields;
+hides unpriced campaigns), `/commit`. No cancel endpoint.
+
+### A4. Top-up via the billing scaffold: `/api/external/billing` checkout
+gains `kind:'wallet_topup'`; HitPay webhook settlement calls
+`walletService.credit(type:'topup')`, idempotent by `providerPaymentId`.
+Still gated by `BILLING_ENABLED` (HitPay provisioning is Shawn-side).
+
+### A5. Admin wallet endpoints (NEW ROUTER `backend/src/routes/adminWallets.js`,
+mount `/api/admin/wallets`, admin JWT auth, NOT flag-gated — read-only +
+audited adjustment, safe to ship live):
+
+| Endpoint | Returns / does |
+|---|---|
+| `GET /` | roster of EXTERNAL agents (**filter: `users.mktrLeadsId IS NOT NULL`**) with `walletBalanceCents`, `openCommitments[{campaignId, campaign, remaining, unitPriceCents}]` (wallet-source assignments only), derived `committedLeads`/`committedValueCents`, `lastActivityAt` (latest ledger row). Sort attention-first (S$0 top) is client-side |
+| `GET /:agentId/ledger` | paginated ledger, newest first |
+| `POST /:agentId/adjust` | body `{amountCents (signed, non-zero int), note (required, non-empty)}` → ledger `adjustment` with `createdBy = req.user.id`; 400 without note/amount; uses the same atomic credit/debit (negative adjustments obey the ≥0 guard) |
+
+### A6. Campaign designer/form: `leadPriceCents` admin-only input;
+`campaignService.updateCampaign` server-clamps it admin-only (same policy
+pattern as `marketplaceListed`).
+
+### A7. Tests (backend jest): everything in the wallet plan's matrix + admin
+endpoints (auth, note-required 400, adjustment ledger shape, external-only
+roster filter).
+
+**mktr-leads app work (separate repo, parallel track after PR1):** wallet
+screen + commit flow per the wallet plan; Shawn deploys/OTAs. Not in this
+repo's PRs.
+
+---
+
+## Phase B — Admin API extensions (PR2, additive, unflagged)
+
+The net-new inventory from the reconciliation, shaped to the mock's fetcher
+contracts. All endpoints admin-JWT'd under existing routers unless noted.
+
+### B1. Overview extension — `dashboardService.getAdminStats(startDate, endDate)`
+ADD period-scoped `prospects.periodTotal`, `assigned` (**either assignee FK:
+`assignedAgentId` OR `externalAgentId` non-null** — prospects carry two
+mutually-exclusive assignee columns), `converted` (leadStatus = won, by
+conversion in period), `conversionRate` (converted/periodTotal, 1dp). **Do
+NOT change existing `total` (all-time) — the old dashboard consumes it during
+coexistence.** New UI binds the new keys.
+
+**Fix the cache while here (live bug):** `adminStatsCache` is a single global
+with a 30s TTL, NOT keyed by date range (dashboardService.js:34–46) — a 7d
+request right after a 90d request serves 90d numbers to the CURRENT dashboard
+too. Key the cache by `period` (validated to `7d|30d|90d`) or drop it for
+admin stats.
+
+### B2. `GET /api/dashboard/attention` (new handler in `dashboard.js`) —
+returns **structured aggregates**; the UI composes the queue rows/copy:
+
+```json
+{
+  "webhooks": { "pending": n, "failedLast24h": n, "subscriberDisabled": bool },
+  "held": { "total": n, "byReason": { "no_funded_agent": n, "no_funded_external_buyer": n, "dnc_pending": n, "dnc_registered": n, "returned_by_admin": n, "other": n } },
+  "unassigned": n,
+  "zeroCommitCampaigns": [{ "id", "name", "endsAt" }],
+  "wallets": { "total": n, "zero": [{id,name}], "low": [{id,name,balanceCents}], "floatCents": n },
+  "committed": { "leads": n, "valueCents": n, "campaigns": n },
+  "drawsClosing": [{ "id", "name", "closesAt", "boostClosesAt", "multiplier", "winners" }],
+  "endingCampaigns": [{ "id", "name", "endsAt" }]
+}
+```
+
+Definitions corrected to the REAL schema (Codex finding 10, verified): held =
+`quarantinedAt` non-null, grouped over ALL five real reasons —
+`no_funded_agent`, `no_funded_external_buyer`, `dnc_pending`,
+`dnc_registered`, `returned_by_admin` — plus `other` so total always
+reconciles with byReason; **unassigned = `assignedAgentId` IS NULL AND
+`externalAgentId` IS NULL AND `quarantinedAt` IS NULL** (two assignee FKs);
+zero-commit = ACTIVE campaign with non-null `leadPriceCents` and no open
+funded assignment (wallet OR package — during drain-down a package-funded
+campaign is covered); wallets = external agents only (`mktrLeadsId` non-null),
+low threshold S$50 (constant, documented); draws/endings ≤ 7 days. Webhook
+numbers aggregate `WebhookDelivery`/`WebhookSubscriber` (failed in 24h,
+pending, any disabled subscriber). The UI's Release-hold bulk action applies
+only to the RELEASABLE reasons (`no_funded_agent`, `returned_by_admin` — the
+service's own whitelist); DNC/external holds are not releasable from the bar.
+
+### B3. `GET /api/dashboard/series?period=7d|30d|90d` — daily lead counts,
+SGT-midnight buckets, `{date, count, isToday}[]` + `{today, avgPerDay, total}`.
+One grouped query (`date_trunc` at +08), not N per day.
+
+### B4. `GET /api/dashboard/funnel?period=` — `{scans, submits, assigned, won}`;
+scans = lifetime `qr_tags.scanCount` prorated to the period, flagged
+`"estimated": true` in the payload (design assumption 3), floored at submits.
+
+### B5. `listProspects` extensions (`prospectService.js` only — verified the
+`GET /api/prospects` route has NO query-schema validation; `req.query` flows
+straight to the service): `sort` param — whitelist
+`firstName|leadStatus|createdAt` with `-` prefix for DESC, default
+`-createdAt`, unknown values fall back to default (never 500); `leadStatus`/
+`leadSource` accept comma-lists (`IN` filter), single value stays
+backward-compatible. Comma-list handling: split, trim, dedupe, whitelist
+every token against the enum and DROP invalid tokens (never let an unknown
+string reach a Postgres enum cast → 500); all-invalid ⇒ ignore the filter.
+
+### B6. Campaign aggregates:
+- Extend the admin campaigns list payload with `leadsThisPeriod`,
+  `leadsTotal`, `qrTagCount`, `committedRemaining`, `committedValueCents`
+  (grouped COUNT/SUM subqueries — no N+1). The list gains a validated
+  `period` query param (`7d|30d|90d`, default 30d) driving `leadsThisPeriod`
+  — today it accepts none (campaignService.js:187). New keys are additive
+  inside the existing `{campaigns, pagination}` envelope.
+- `GET /api/campaigns/:id/summary` (new, admin): campaign row + 30d daily
+  series + open commitments (agent, remaining, unitPriceCents, valueCents) +
+  latest 6 leads + its QR tags. One composite endpoint = one round-trip for
+  the detail screen.
+
+### B7. Agents roster aggregates: extend the admin agents listing with
+`assignedThisPeriod` and `lastAssignedAt` (from prospects), plus wallet
+columns joined for external agents (null for internal → UI renders "—").
+Same period contract as B6: the agents list gains a validated `period` param
+(it accepts none today — agentService.js:60); keys additive.
+
+### B8. Tests: unit per aggregate (held/unassigned/zero-commit definitions,
+SGT bucketing, comma-list + sort whitelist, funnel floor).
+
+---
+
+## Phase C — Switchboard UI rebuild (PR3–PR5, flag `VITE_ADMIN_V2_ENABLED`)
+
+### C1. Theme + shell (PR3)
+- `src/styles/adminV2.css`: the Switchboard tokens verbatim from the Design
+  System (`:root/[data-theme="light"]` + `[data-theme="dark"]`), scoped under
+  a `.admin-v2` wrapper class so legacy pages are untouched. Fonts follow the
+  existing idiom (Google Fonts CSS `@import`): Schibsted Grotesk
+  400/500/700/800 + IBM Plex Mono 400/500/600.
+- Tailwind: extend `theme.colors` with a var-backed `sb` namespace
+  (`sb-canvas`, `sb-surface`, `sb-ink`, `sb-accent`, `sb-ok`, `sb-warn`,
+  `sb-bad`, `sb-hold`, soft variants…) so screens use utility classes, not
+  inline styles. Radii/shadow per the DS (chip 6 / control 10 / card 14, one
+  shadow token).
+- `src/components/adminv2/AdminV2Shell.jsx`: fixed 228px sidebar with the
+  final IA — **Overview** (Dashboard) · **Lead Generation** (Prospects,
+  Campaigns, Agents, Agent Groups, Wallets & Commitments, QR Codes, Short
+  Links) · **System** (Users, AI Settings) — plus 64px sticky topbar (period
+  segmented control in page headers, theme toggle via the existing
+  `next-themes` + `data-theme` stamp, sign-out). No fleet/finance/APK slots.
+- Routing: in `src/pages/index.jsx`, when `import.meta.env
+  .VITE_ADMIN_V2_ENABLED === 'true'`, the existing admin paths
+  (`/AdminDashboard`, `/AdminProspects`, `/AdminCampaigns`, `/AdminAgents`,
+  `/AdminAgentGroups`, `/AdminQRCodes`, `/AdminShortLinks`, `/AdminUsers`,
+  `/AdminAISettings`, + new `/AdminWallets`, `/admin/campaigns/:id`) render
+  the v2 screens inside `AdminV2Shell`; flag off → legacy pages unchanged.
+  Same URLs = bookmarks/deep links survive.
+- **Kept on the legacy shell, reachable from v2** (not rebuilt now):
+  AdminCampaignDesigner / AdminCampaignForm / AdminCampaignWorkspace
+  (campaign detail links out to them), AdminLeadPackages (linked from the
+  Wallets screen header as "Legacy packages →" during drain-down).
+
+### C2. Screens (PR3: Dashboard + Prospects; PR4: Campaigns list/detail,
+Agents, Agent Groups, Wallets & Commitments; PR5: QR Codes, Short Links,
+Users, AI Settings)
+
+Mock fetcher → real endpoint mapping (the design consumed these shapes):
+
+| Mock fetcher | Real call |
+|---|---|
+| `fetchOverview(period)` | `GET /api/dashboard/overview?period=` (extended B1; bind periodTotal/assigned/converted/conversionRate) |
+| `fetchAttention()` | `GET /api/dashboard/attention` (B2; UI composes severity rows: incident → held → warning → watch) |
+| `fetchLeadSeries(period)` | `GET /api/dashboard/series` (B3) |
+| `fetchFunnel(period)` | `GET /api/dashboard/funnel` (B4) |
+| `fetchRecentLeads(8)` | `GET /api/prospects?limit=8&sort=-createdAt` |
+| `fetchCampaignLeaderboard(period)` | extended campaigns list (B6), client top-6 by period leads |
+| `fetchProspects(opts)` | `GET /api/prospects` with `assignment=held\|unassigned`, comma-list `leadStatus`/`leadSource`, `search`, `campaignId`, `sort`, `page`/`limit` (B5) |
+| `fetchProspectById` | existing prospect detail (drawer: priority, score, utm, qrTag label, consent flags, lastContactDate, conversionDate; heldReason ← DTO alias of `quarantineReason`) |
+| `fetchCampaign(id)` | `GET /api/campaigns/:id/summary` (B6) |
+| `fetchCampaignsList()` | extended campaigns list (B6) |
+| `fetchAgents()` | extended agents listing (B7) |
+| `fetchAgentGroups()` | `GET /api/admin/agent-groups` + members; `funded` derived client-side against wallet roster |
+| `fetchWallets()` / ledger / `applyAdjustment` | `GET /api/admin/wallets`, `GET /:id/ledger`, `POST /:id/adjust` (A5) |
+| `fetchQrTags()` | existing QR admin listing |
+| `fetchShortLinks()` | `GET /api/shortlinks` (`active` derived from `expiresAt`) |
+| `fetchUsers()` | `GET /api/users` (staff filter; `lastActiveAt` ← `lastLogin`; `invited` ← invitationToken set + never logged in) |
+| `fetchAiSettings()` | `GET /api/admin/ai/settings` + `PUT` (existing; key hints + replace-key + guardrails/workstyle) |
+
+Interaction parity with the prototype: period recompute on every dashboard
+widget, filters-as-removable-chips synced to the URL query, server
+pagination 25/page, bulk-select bar — **wired LIVE, not stubbed**: the repo
+already has `PATCH /api/prospects/bulk/assign`, `PATCH /bulk/return-to-held`
+and `POST /bulk/delete` (agent-or-admin auth, Joi'd), so the v1 bulk bar ships
+Assign-to-agent (picker), Return to held, Delete (destructive confirm) plus
+client-side Export CSV of the selection, 432px right drawer (Radix
+Dialog/Sheet), client-side CSV export, skeletons mirroring final geometry,
+error states with retry, sonner toasts. Charts are token-driven div bars per
+the prototype (recharts stays out of the new screens — fewer moving parts,
+exact design fidelity).
+
+### C3. Data layer: `src/api/adminV2.js` (thin fetch wrappers over the
+existing authed api client) + react-query hooks (`useOverview(period)`,
+`useAttention()`, …) with query keys carrying period/filters. **Adapters
+unwrap each endpoint's REAL envelope** (verified: campaigns →
+`{campaigns, pagination}`, shortlinks → `{items, total}`, users →
+`{users, pagination}` with default `limit=10`): every list hook sends
+explicit `limit=25` (users additionally `role=admin` server-side — never
+client-filter the default first page) and normalizes to `{rows, total}` for
+the table components. The five held-reason chips (+ `other`) get copy in one
+`HELD_REASON_LABELS` map shared by queue, table chips, and drawer.
+
+### C4. Frontend tests (vitest): filter-chip ↔ query-param round-trip, CSV
+serializer, severity ordering, currency/date formatters (SGT, S$),
+held/unassigned param mapping. Playwright smoke (existing setup): flag-on
+boot → dashboard renders → navigate all 10 routes → drawer opens.
+
+---
+
+## Phase D — Teardown (PR6, after flag flip + soak)
+
+**Scope statement (Codex finding 13, verified): PR6 is HTTP-surface + UI
+darkening, NOT a subsystem retirement.** The route loader imports every
+module before checking mount flags, so import-time side effects keep running
+(e.g. `pushService` starts its heartbeat/cleanup `setInterval`s in the
+constructor at import — pushService.js:14–15), and unflagged domain behavior
+stays live: commission creation on lead conversion (prospectService.js:1225),
+commission checks in campaign deletion, device notify fan-out in
+campaignService, car references in qrCodeService. That code is harmless with
+zero fleet/device rows and gets deleted in the LATER code-removal pass, not
+flagged now. What PR6 actually does:
+
+Phased per the standing direction (hide → dark-flag → drop models later):
+
+1. **Already hidden by the flip** — the v2 shell has no fleet/finance/APK
+   nav. PR6 then removes: legacy pages `AdminFleet`, `AdminVehicles`,
+   `AdminFleetMap`, `AdminDevices`, `AdminDeviceLogs`, `AdminCommissions`,
+   `AdminApkManager`, `ProvisionDevice`, `FleetOwnerDashboard`,
+   `DriverDashboard`/`DriverPayoutHistory`/`DriverPayslip`/`DriverProfile` +
+   their routes/lazy imports + legacy `DashboardLayout` nav entries.
+2. **Backend dark-flag** — mount `fleet.js`, `vehicles.js`, `devices.js`,
+   `deviceEvents.js`, `provisioning.js`, `commissions.js`, `apk.js`,
+   `adtechBeacons.js`, `adtechManifest.js` only when `FLEET_ROUTES_ENABLED
+   === 'true'` (default off in prod) — flagging EVERY existing mount entry
+   (fleet.js declares two, one already behind `ENABLE_DOMAIN_PREFIXES`).
+   Reversible; code deletion is a later pass.
+3. **`getAdminStats`** — strip fleet/impressions/commissions blocks (old
+   dashboard is gone by then). Keep response keys additive-compatible until
+   the legacy dashboard file is deleted in the same PR.
+4. **Models/tables stay** (Car/Vehicle/Device/Commission/…): no destructive
+   DB work without an explicit ask — DB safety rules.
+5. Driver/fleet_owner **roles** remain in the enum (users may exist);
+   login routing for those roles points at a "retired" notice page.
+
+---
+
+## Rollout
+
+1. **PR1** (wallet, dark) → deploy → migrations auto-run → `AGENT_WALLET_
+   ENABLED` stays unset. Verify: admin wallets endpoints return zeros;
+   routing regression suite green.
+2. **PR2** (API extensions) → deploy → curl-verify the five new/extended
+   endpoints against prod data.
+3. **PR3–5** (UI) → merge dark (`VITE_ADMIN_V2_ENABLED` unset on the static
+   site) → verify locally with the flag on against prod API → set the env
+   var on `mktr-platform` static site (srv-d2s3che3jp1c738qlgjg) → redeploy
+   → deploy-verify (bundle hash + `curl` for a v2-only string, per the
+   push≠live rules).
+4. Soak a few days. Rollback = unset `VITE_ADMIN_V2_ENABLED` **and rebuild/
+   redeploy the static site** — VITE_* flags are baked into the bundle at
+   build time, so rollback is a ~3-minute redeploy, not instantaneous. (If
+   instant rollback ever matters, that's a runtime-config change out of
+   scope here.)
+5. **PR6** teardown.
+6. Wallet go-live is independent of the UI: HitPay provisioning →
+   `BILLING_ENABLED` → $1 top-up e2e → `AGENT_WALLET_ENABLED` → app OTA
+   (mktr-leads repo) → stop external package sales; drain-down continues.
+
+## Risks / gotchas
+
+- **Two 066 migrations exist** — verify runner collision behavior before 068.
+- **Overview `total` semantics** — solved additively (B1); never mutate the
+  key the legacy dashboard reads while both UIs are alive.
+- **sync({force:true}) clobbers migration-created indexes** — mirror every
+  new index/unique on the model definitions (lucky-draw lesson).
+- **Committed-demand widgets before any commitments exist** — all wallet
+  aggregates must render honest zeros (design has empty states), not error.
+- **External-only wallets** (design assumption 16) — Agents roster joins
+  wallet data as nullable; internal agents show "—" and never block.
+- **CI is chronically red on main** (5 pre-existing suites + npm audit) —
+  baseline against a clean worktree before attributing failures.
+- **Meta CAPI untouched** — none of this touches prospect intake paths;
+  Phase B is read-only aggregation, Phase A adds routing-pool rows through
+  the existing package join (regression-tested).
+
+---
+
+## Codex review log (round 1 — 2026-07-15, gpt-5.6-sol xhigh)
+
+Raw verdict: "not implementation-ready" on 6 BLOCKERs / 6 MAJORs / 2 MINORs.
+Every finding was verified against the code before folding in:
+
+| # | Finding | Disposition |
+|---|---|---|
+| 1 | Wallet trick bypasses consent boundary | **Overruled as stated, kept as documented stance** — mktr-leads agents are `users` rows routed through the internal package pool TODAY (2026-06 pivot design); the consent gate guards the INERT ExternalAgent buyer pool. Codex's fix (exclude mktrLeadsId from resolveLeadRouting) would break live delivery. Real fix folded: commit-ability = priced-only, never touches `campaign.externalEligible`; product question (consent_third_party vs mktr-leads delivery) flagged to Shawn separately |
+| 2 | Parallel ExternalAgent pool | Verified inert (hasValidExternalConsent false for all data). Folded: stays inert + out of scope; roster filters `mktrLeadsId IS NOT NULL` |
+| 3 | Hidden package NOT NULLs + findOrCreate race | **Confirmed** — folded (concrete row shape, `lead_packages.kind`, unique partial index) |
+| 4 | wallet_topup doesn't fit Payment path | **Confirmed** — folded (`payments.kind` branch inside the existing locked settlement tx + unique topup ledger index) |
+| 5 | Archive/refund not transactional | **Confirmed** (archiveCampaign has no tx) — folded (transactional archive + per-assignment unique takedown_refund index) |
+| 6 | User lifecycle erases paid commitments | **Confirmed** (deactivate/bulk-delete destroy assignments; sync hard-delete ignores wallet rows) — folded (lifecycle policy in the wallet doc) |
+| 7 | WalletLedger model/timestamps parity | Confirmed — folded into migration table |
+| 8 | leadPriceCents stripped by Joi + ignored by service | Confirmed — folded into 068 row |
+| 9 | Global 30s admin-stats cache ignores period (live bug today) | Confirmed — folded into B1 |
+| 10 | externalAgentId second assignee FK + 5 real held reasons | Confirmed — folded into B1/B2 + C3 label map |
+| 11 | Comma-list enum-cast safety | Confirmed — folded into B5 |
+| 12 | Period contracts + payload envelopes ({campaigns,pagination} / {items,total} / {users,pagination} limit 10) | Confirmed — folded into B6/B7/C3 |
+| 13 | Route flags don't retire the fleet subsystem (import-time timers, commission-on-conversion) | Confirmed — folded as Phase D scope statement |
+| 14 | VITE flag rollback needs rebuild | Confirmed — folded into rollout step 4 |

--- a/docs/plans/mktr-admin-redesign-reconciliation.md
+++ b/docs/plans/mktr-admin-redesign-reconciliation.md
@@ -1,0 +1,101 @@
+# MKTR Admin redesign — repo reconciliation (2026-07-15)
+
+> **STATUS: DESIGN FINAL (verified 2026-07-15).** The fix round below was
+> applied by the design conversation and diff-verified: AI Settings redesigned
+> to the real shape (defaultProvider, per-provider model, encrypted keys shown
+> as last-4 hints w/ Replace key, guardrails + workstyle textareas; invented
+> scoring/call-bot/tagging → wishlist); Agent Groups reduced to name/
+> description/members + computed funded-vs-wallets count; Users shows real
+> Admin role only (invited + last-active kept — both real); Design System
+> assumptions 13–16 added (quarantineReason DTO alias, overview extension,
+> single-value filters + no sort param today, wallets external-only v1) and
+> the three invented concepts parked in the wishlist. mock-api.js updated to
+> match on all three shapes. One implementation note: the mock's staff key is
+> `lastActiveAt` — map from `users.lastLogin` in the DTO, same pattern as
+> heldReason/quarantineReason. Next artifact: combined implementation plan
+> (wallet backend → admin rebuild → fleet teardown) + Codex review.
+
+Design project `57e68763-9fd1-47ed-b5f9-14224a016ff4` ("Switchboard" direction):
+`MKTR Admin.dc.html` (all 11 routes + stubs), `MKTR Mobile.dc.html` (approved
+round 2), `Design System.dc.html`, `mock-api.js`. Reviewed against the live
+repo. Verdict: **strong — one design fix round needed (3 screens contain
+invented features), plus a net-new backend inventory for the implementation
+plan.**
+
+## Verified correct against the repo (no change)
+
+- Prospect enums exact: leadSource (8 values incl call_bot), leadStatus (8),
+  priority, score(0–100 nullable), lastContactDate, conversionDate,
+  sourceMetadata.utm (fb/ig/tiktok/an/msg), qrTag label join.
+- Held semantics: quarantinedAt + reasons no_funded_agent/dnc_pending/
+  dnc_registered ✓ — AND the real list API already supports the design's
+  filters via `assignment: 'held'|'unassigned'` (unassigned = not assigned AND
+  not held — matches the design's definition exactly), plus search, leadStatus,
+  leadSource, campaignId, page/limit (prospectService.listProspects).
+- Campaign fields: name/status(draft|active|paused|completed|archived)/type/
+  min_age/max_age/start_date/end_date/is_active + slug + marketplaceListed +
+  luckyDraw (with the appendix-10 YYYY-MM-DD SGT parse rule) — all real.
+- QR tags: label/campaignId/scanCount/uniqueScanCount/lastScanned/active ✓.
+- Short links: maps cleanly — short→slug, target→targetUrl, clicks→clickCount;
+  `active` derivable as !expired (expiresAt) ; lastClickedAt also available.
+- Users: `lastLogin` (→ "last active") and invited-state (invitationToken set,
+  no login) are REAL and derivable. Only the 'Ops' ROLE is invented (below).
+- Wallets & Commitments screens are 1:1 with docs/plans/
+  agent-wallet-commitments.md: ledger types topup|commit|takedown_refund|
+  adjustment, mandatory-note manual adjustment (working in the prototype),
+  read-only commitments, no buying UI, no self-cancel. Top-ups "via agent app".
+- Interaction contract + honesty rules fully satisfied: period recompute,
+  filters as removable chips, sort, pagination, bulk bar (actions
+  static-toasted), drawer, working CSV export, theme toggle w/ accent
+  variants, demo modes (normal/quiet-day/API-error), latency knob,
+  seq-guarded fetches, labeled stubs preserving query state.
+
+## Design fixes required (one round)
+
+1. **AI Settings screen is fiction (MAJOR).** The design invents lead-scoring
+   (model/threshold/auto-priority), a call-bot (greeting/hours) and tagging
+   taxonomy. The REAL AiSettings row is: defaultProvider (openai|anthropic),
+   openaiModel/anthropicModel, encrypted API keys with last-4 hints,
+   globalGuardrails (text), workstylePreferences (text). → Redesign the screen
+   around key management + provider/model + guardrails; move scoring/call-bot/
+   tagging to the proposed-metrics wishlist.
+2. **Agent Groups invents fields (MEDIUM).** Real AgentGroup = id/name/
+   description/createdBy + members join. No isActive ("Round-robin on" chip)
+   and no campaign linkage (campaignNames). Groups today are named agent
+   collections used as pickers. → Row = name, description, member count,
+   funded-member count (computed vs wallets); campaign linkage + on/off →
+   wishlist.
+3. **Users 'Ops' role doesn't exist (SMALL).** Real staff roles today: admin
+   (agent/driver/fleet_owner are not back-office staff; fleet roles are being
+   retired). → Show real role chips (Admin; render others as-is if present),
+   keep Invited (real) + last active (lastLogin). An 'ops' staff role is a
+   product proposal → wishlist.
+4. **Appendix additions:** (a) real column is `quarantineReason` — heldReason
+   is a display alias the DTO provides; (b) the real overview endpoint today
+   returns prospects {total(all-time!), new} only — assigned/converted/
+   conversionRate + period-scoped totals are the backend extension named in
+   the net-new inventory; (c) status/source filters are single-value on the
+   real API today (multi-select needs comma-list support) and there is no
+   `sort` param yet; (d) wallets exist for EXTERNAL (mktr-leads) agents only
+   in v1 — internal agents render "—" in wallet columns until migrated.
+
+## Net-new backend inventory (feeds the implementation plan)
+
+| Piece | Status |
+|---|---|
+| Overview extension: period-scoped assigned/converted/conversionRate (+ decide total semantics) | extend `dashboardService.getAdminStats` |
+| Dashboard aggregates: attention queue (held by reason, unassigned, zero-commit campaigns, wallets zero/low, draws ≤7d, webhook health), daily lead series, funnel | new `GET /api/dashboard/attention` + `/series` + `/funnel` (or one composite) |
+| Webhook health aggregate (failedLast24h/pending/subscriberDisabled) | aggregate over existing per-subscriber stats |
+| listProspects: `sort` param + comma-list leadStatus/leadSource | small extension |
+| Campaign list/detail aggregates: leadsThisPeriod/leadsTotal/qrTagCount + committedRemaining/committedValueCents + commitments rows + 30d series + recent leads | extend admin campaign endpoints; committed* comes from the wallet build |
+| Wallets admin endpoints (list w/ balances+commitments, ledger, manual adjustment w/ note) | already scoped in agent-wallet-commitments.md — the design consumes exactly that contract |
+| Agents roster: assignedThisPeriod/lastAssignedAt aggregates | small extension |
+| AI Settings | real page/model already exist — reskin only after design fix |
+| Fleet/commissions/app-versions teardown | phase one of the rebuild (new IA has no slots for them) |
+
+## Sequencing note
+
+The admin rebuild depends on the wallet/commitments backend for: Wallets &
+Commitments screens, committed-demand tiles/badges, zero-commitment incidents,
+and Agents wallet columns. Implementation order: wallet backend (external
+agents) → admin rebuild consuming it → fleet teardown rides the rebuild.

--- a/src/components/campaigns/workspace/CampaignDetailsTab.jsx
+++ b/src/components/campaigns/workspace/CampaignDetailsTab.jsx
@@ -28,6 +28,7 @@ export default function CampaignDetailsTab({ initial, type, isEdit, saving, onSu
     commission_amount_driver: initial?.commission_amount_driver ?? '',
     commission_amount_fleet: initial?.commission_amount_fleet ?? '',
     enforceLeadQuota: initial?.enforceLeadQuota === true,
+    leadPriceDollars: initial?.leadPriceCents != null ? String(initial.leadPriceCents / 100) : '',
     metaPixelId: initial?.metaPixelId || '',
     tiktokPixelId: initial?.tiktokPixelId || '',
   });
@@ -46,6 +47,10 @@ export default function CampaignDetailsTab({ initial, type, isEdit, saving, onSu
       commission_amount_driver: form.commission_amount_driver === '' ? null : Number(form.commission_amount_driver),
       commission_amount_fleet: form.commission_amount_fleet === '' ? null : Number(form.commission_amount_fleet),
       enforceLeadQuota: form.enforceLeadQuota,
+      leadPriceCents: (() => {
+        const n = Number(form.leadPriceDollars);
+        return form.leadPriceDollars !== '' && Number.isFinite(n) && n > 0 ? Math.round(n * 100) : null;
+      })(),
       metaPixelId: form.metaPixelId.trim() || null,
       tiktokPixelId: form.tiktokPixelId.trim() || null,
     });
@@ -85,6 +90,13 @@ export default function CampaignDetailsTab({ initial, type, isEdit, saving, onSu
               </p>
             </div>
             <Switch id="quota" checked={form.enforceLeadQuota} onCheckedChange={(c) => set('enforceLeadQuota', c)} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="leadPrice">Lead price (SGD per lead)</Label>
+            <Input id="leadPrice" type="number" step="0.01" min="0" value={form.leadPriceDollars} onChange={(e) => set('leadPriceDollars', e.target.value)} placeholder="e.g. 8.00" />
+            <p className="text-xs text-muted-foreground">
+              What external agents pay per lead when committing wallet credits to this campaign. Leave blank to keep it closed to commitments.
+            </p>
           </div>
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2"><Label htmlFor="cad">Driver commission (SGD)</Label><Input id="cad" type="number" step="0.01" min="0" value={form.commission_amount_driver} onChange={(e) => set('commission_amount_driver', e.target.value)} placeholder="0.00" /></div>

--- a/src/components/campaigns/workspace/__tests__/CampaignDetailsTab.test.jsx
+++ b/src/components/campaigns/workspace/__tests__/CampaignDetailsTab.test.jsx
@@ -14,6 +14,7 @@ describe('CampaignDetailsTab', () => {
     fireEvent.change(screen.getByLabelText('Campaign name'), { target: { value: 'My Campaign' } });
     fireEvent.change(screen.getByLabelText('Meta Pixel ID'), { target: { value: '123' } });
     fireEvent.change(screen.getByLabelText('TikTok Pixel ID'), { target: { value: 'TT9' } });
+    fireEvent.change(screen.getByLabelText(/Lead price/i), { target: { value: '8.5' } });
     fireEvent.click(screen.getByRole('switch')); // enforce quota on
 
     fireEvent.click(screen.getByRole('button', { name: /Create draft/i }));
@@ -23,9 +24,28 @@ describe('CampaignDetailsTab', () => {
       name: 'My Campaign',
       type: 'quiz',
       enforceLeadQuota: true,
+      leadPriceCents: 850,
       metaPixelId: '123',
       tiktokPixelId: 'TT9',
     });
+  });
+
+  it('blank lead price submits null (campaign closed to commitments); stored cents round-trip to dollars', () => {
+    const onSubmit = vi.fn();
+    render(
+      <CampaignDetailsTab
+        initial={{ name: 'Priced', type: 'lead_generation', leadPriceCents: 1200 }}
+        isEdit
+        saving={false}
+        onSubmit={onSubmit}
+      />
+    );
+    // 1200 cents renders as 12 dollars
+    expect(screen.getByLabelText(/Lead price/i).value).toBe('12');
+    // clearing it sends null
+    fireEvent.change(screen.getByLabelText(/Lead price/i), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: /Save details/i }));
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({ leadPriceCents: null });
   });
 
   it('preserves the existing type in edit mode and shows Save details', () => {


### PR DESCRIPTION
## What

Phase A (PR1) of the admin rebuild plan (`docs/plans/mktr-admin-rebuild-implementation.md`): the **agent wallet + per-campaign commitments backend**, per `docs/plans/agent-wallet-commitments.md` with the Codex round-1 resolutions folded in. **Ships dark** — `AGENT_WALLET_ENABLED` is unset, so `/api/external/wallet` stays unmounted and the migrations are inert additions.

### Model
- External (mktr-leads) agents hold prepaid SGD wallets (**$1 = 1 credit**, cents-exact, non-refundable to cash).
- Admin sets `campaigns.leadPriceCents`; agents self-serve **commitments** (N leads @ price) that debit the wallet instantly.
- A commitment is a normal `LeadPackageAssignment` (`source:'wallet'`) under a hidden per-campaign wallet `LeadPackage` (`kind:'wallet'`) — **routing, charging and package drain-down are untouched**.
- The ONLY refund is the automatic **campaign-takedown refund** (archive): undelivered remainder returns as credits. Pause holds. No self-cancel.

### Money-path safety
- `wallet_ledger` is append-only audit truth; `users.walletBalanceCents` maintained atomically with a `>= 0` guard inside the UPDATE (no read-modify-write).
- Unique partial indexes: one wallet package per campaign (commit race), one `takedown_refund` per assignment (double-archive race), one `topup` per payment (HitPay replay).
- `archiveCampaign` is now transactional: lock → refund → archive; QR detach stays post-commit.
- Top-ups ride the existing HitPay scaffold via `payments.kind='wallet_topup'`; settlement credits the wallet inside the existing locked transaction (can never fall into `paid_unfulfilled` while the agent exists).
- Lifecycle guards: deactivate/bulk-delete 409 on open wallet state; wallet history blocks hard-deletion (pre-check + DB `RESTRICT`); agent-sync hard-delete excludes anyone with ledger rows.

### Surfaces
- `POST /api/external/wallet/{summary,ledger,catalog,commit}` — HMAC, flag-gated, deploy-inert.
- `POST /api/external/billing/checkout` gains `kind:'wallet_topup'` (preset whitelist $100/$500/$2000; shipped app cohorts unaffected — they never send `kind`).
- `GET/POST /api/admin/wallets{,/:id/ledger,/:id/adjust}` — admin JWT; adjustment requires signed cents + a mandatory note, actor recorded.
- Campaign workspace Details tab: **Lead price (SGD per lead)** input (blank = closed to commitments; admin-only server clamp).

## Tests

- New: `walletService` (23) + `walletTopup` (9) unit suites — overdraft/404/409 semantics, commit race retry, refund idempotency + concurrency re-check, preset whitelist, settlement replay/mismatch/unfulfillable, package path untouched.
- Extended: `userService` guard tests (22 total), `CampaignDetailsTab` price round-trip (4).
- Full backend suite vs a **clean-main baseline** on the same throwaway Postgres: identical failure set (the chronic reds incl. the pre-existing double-`066` migration-numbering check) — **zero regressions**.

## Rollout (after merge)

1. Deploy → migrations 068–071 auto-run (inert).
2. Verify `/api/admin/wallets` returns an empty roster; routing regression green.
3. Wallet go-live is a later, separate step: HitPay provisioning → `BILLING_ENABLED` → $1 top-up e2e → `AGENT_WALLET_ENABLED` → mktr-leads app screens (separate repo) → stop external package sales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)