### PR TITLE
feat(admin-api): Phase B — dashboard aggregates, filters, rebuild contracts

### DIFF
--- a/backend/src/controllers/campaignController.js
+++ b/backend/src/controllers/campaignController.js
@@ -39,6 +39,12 @@ export const listCampaigns = asyncHandler(async (req, res) => {
   res.json({ success: true, data });
 });
 
+// Admin campaign-detail composite (Phase B) — one round-trip for the rebuild.
+export const getCampaignSummary = asyncHandler(async (req, res) => {
+  const data = await campaignService.getCampaignSummary(req.params.id, req);
+  res.json({ success: true, data });
+});
+
 export const createCampaign = asyncHandler(async (req, res) => {
   const campaign = await campaignService.createCampaign(req.body, req.user);
 

--- a/backend/src/controllers/dashboardController.js
+++ b/backend/src/controllers/dashboardController.js
@@ -28,6 +28,28 @@ export async function getAnalytics(req, res) {
   });
 }
 
+// ── Admin rebuild Phase B (docs/plans/mktr-admin-rebuild-implementation.md) ──
+
+// Needs-attention aggregates (admin-only; the UI composes queue rows from facts)
+export async function getAttention(req, res) {
+  const data = await dashboardService.getAttention();
+  res.json({ success: true, data });
+}
+
+// Daily lead series, SGT-midnight buckets
+export async function getSeries(req, res) {
+  const period = dashboardService.normalizePeriod(req.query.period);
+  const data = await dashboardService.getLeadSeries(period);
+  res.json({ success: true, data: { period, ...data } });
+}
+
+// Scans→submits→assigned→won funnel (scans prorated + flagged estimated)
+export async function getFunnel(req, res) {
+  const period = dashboardService.normalizePeriod(req.query.period);
+  const data = await dashboardService.getFunnel(period);
+  res.json({ success: true, data: { period, ...data } });
+}
+
 // Driver Partner: successful submissions trend
 export async function getDriverScans(req, res) {
   const data = await dashboardService.getDriverScans(req.user.id, req.query.period);

--- a/backend/src/database/migrations/072-phase-b-aggregate-indexes.js
+++ b/backend/src/database/migrations/072-phase-b-aggregate-indexes.js
@@ -1,0 +1,28 @@
+/**
+ * 072 — Composite indexes behind the Phase B admin aggregates.
+ *
+ * The campaign/agent list endpoints run correlated per-row counts on
+ * (campaignId, createdAt) and (assignedAgentId, createdAt), and the
+ * attention rail scans open wallet commitments — none of which the existing
+ * single-column indexes serve well at 200-row admin pages. All additive.
+ * camelCase DDL. Guarded/idempotent.
+ */
+export async function up(queryInterface) {
+  await queryInterface.sequelize.query(
+    'CREATE INDEX IF NOT EXISTS idx_prospects_campaign_created ON prospects ("campaignId", "createdAt")'
+  );
+  await queryInterface.sequelize.query(
+    'CREATE INDEX IF NOT EXISTS idx_prospects_agent_created ON prospects ("assignedAgentId", "createdAt")'
+  );
+  await queryInterface.sequelize.query(
+    `CREATE INDEX IF NOT EXISTS idx_lpa_open_wallet
+       ON lead_package_assignments ("leadPackageId", "agentId")
+       WHERE "source" = 'wallet' AND "status" = 'active' AND "leadsRemaining" > 0`
+  );
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query('DROP INDEX IF EXISTS idx_prospects_campaign_created');
+  await queryInterface.sequelize.query('DROP INDEX IF EXISTS idx_prospects_agent_created');
+  await queryInterface.sequelize.query('DROP INDEX IF EXISTS idx_lpa_open_wallet');
+}

--- a/backend/src/models/LeadPackageAssignment.js
+++ b/backend/src/models/LeadPackageAssignment.js
@@ -1,4 +1,4 @@
-import { DataTypes } from 'sequelize';
+import { DataTypes, Op } from 'sequelize';
 import { sequelize } from '../database/connection.js';
 
 const LeadPackageAssignment = sequelize.define('LeadPackageAssignment', {
@@ -82,7 +82,13 @@ const LeadPackageAssignment = sequelize.define('LeadPackageAssignment', {
         {
             fields: ['status']
         },
-        { fields: ['agentId', 'status', 'leadsRemaining'], name: 'idx_lpa_agent_status_remaining' }
+        { fields: ['agentId', 'status', 'leadsRemaining'], name: 'idx_lpa_agent_status_remaining' },
+        // Phase B attention rail (migration 072): open wallet commitments scan.
+        {
+            fields: ['leadPackageId', 'agentId'],
+            where: { source: 'wallet', status: 'active', leadsRemaining: { [Op.gt]: 0 } },
+            name: 'idx_lpa_open_wallet'
+        }
     ]
 });
 

--- a/backend/src/models/Prospect.js
+++ b/backend/src/models/Prospect.js
@@ -316,7 +316,10 @@ const Prospect = sequelize.define('Prospect', {
     },
     { fields: ['createdAt'], name: 'idx_prospects_createdat' },
     { fields: ['conversionDate'], name: 'idx_prospects_conversiondate', where: { conversionDate: { [Op.ne]: null } } },
-    { fields: ['assignedAgentId', 'leadStatus'], name: 'idx_prospects_agent_status' }
+    { fields: ['assignedAgentId', 'leadStatus'], name: 'idx_prospects_agent_status' },
+    // Phase B admin aggregates (migration 072): per-campaign / per-agent period counts.
+    { fields: ['campaignId', 'createdAt'], name: 'idx_prospects_campaign_created' },
+    { fields: ['assignedAgentId', 'createdAt'], name: 'idx_prospects_agent_created' }
   ]
 });
 

--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -87,6 +87,9 @@ router.get('/', authenticateToken, campaignController.listCampaigns);
 router.post('/', authenticateToken, requireAgentOrAdmin, validate(schemas.campaignCreate), campaignController.createCampaign);
 
 // Get campaign by ID
+// Admin campaign-detail composite (Phase B rebuild) — read-only aggregation
+router.get('/:id/summary', authenticateToken, requireAdmin, campaignController.getCampaignSummary);
+
 router.get('/:id', authenticateToken, campaignController.getCampaign);
 
 // Update campaign

--- a/backend/src/routes/dashboard.js
+++ b/backend/src/routes/dashboard.js
@@ -13,6 +13,11 @@ router.get('/overview', authenticateToken, asyncHandler(ctrl.getOverview));
 // Get analytics data for charts
 router.get('/analytics', authenticateToken, requireAgentOrAdmin, asyncHandler(ctrl.getAnalytics));
 
+// Admin rebuild Phase B — needs-attention aggregates, lead series, funnel (admin-only)
+router.get('/attention', authenticateToken, requireRole('admin'), asyncHandler(ctrl.getAttention));
+router.get('/series', authenticateToken, requireRole('admin'), asyncHandler(ctrl.getSeries));
+router.get('/funnel', authenticateToken, requireRole('admin'), asyncHandler(ctrl.getFunnel));
+
 // Driver Partner: successful submissions trend
 router.get('/driver/scans', authenticateToken, requireRole('driver_partner', 'admin'), asyncHandler(ctrl.getDriverScans));
 

--- a/backend/src/services/agentService.js
+++ b/backend/src/services/agentService.js
@@ -58,12 +58,17 @@ export function normalizeAgentSort(sortBy, order) {
  * List agents with pagination, search, and computed stats.
  */
 export async function listAgents(query) {
-  const { page = 1, limit = 10, search, status, sortBy = 'createdAt', order = 'DESC' } = query;
+  const { page = 1, limit = 10, search, status, sortBy = 'createdAt', order = 'DESC', period } = query;
   // Clamp pagination so malformed query params (?page=0, ?limit=-1) don't reach
   // Sequelize as a negative/NaN LIMIT/OFFSET, which throws → 500.
   const pageNum = Math.max(1, parseInt(page, 10) || 1);
   const limitNum = Math.min(Math.max(1, parseInt(limit, 10) || 10), 200);
   const offset = (pageNum - 1) * limitNum;
+
+  // Phase B: validated rolling window for assignedThisPeriod (additive keys).
+  // Server-computed ISO literal — never user input.
+  const periodDays = { '7d': 7, '30d': 30, '90d': 90 }[period] || 30;
+  const periodStartIso = new Date(Date.now() - periodDays * 24 * 3600e3).toISOString();
 
   const whereConditions = { role: 'agent' };
 
@@ -102,6 +107,13 @@ export async function listAgents(query) {
         [sequelize.literal('(SELECT COALESCE(SUM(amount), 0) FROM commissions WHERE commissions."agentId" = "User".id AND commissions.status = \'paid\')'), 'paidCommissions'],
         [sequelize.literal('(SELECT COUNT(*) FROM campaigns WHERE campaigns."createdBy" = "User".id)'), 'createdCampaignsCount'],
         [sequelize.literal('(SELECT COUNT(*) FROM campaigns WHERE campaigns."createdBy" = "User".id AND campaigns.status = \'active\')'), 'activeCampaignsCount'],
+        // Phase B roster aggregates (admin rebuild): period assignment volume,
+        // recency, and open wallet-commitment demand (0s for internal agents —
+        // the UI renders "—" when mktrLeadsId is null).
+        [sequelize.literal(`(SELECT COUNT(*) FROM prospects WHERE prospects."assignedAgentId" = "User".id AND prospects."createdAt" >= '${periodStartIso}')`), 'assignedThisPeriod'],
+        [sequelize.literal('(SELECT MAX(prospects."createdAt") FROM prospects WHERE prospects."assignedAgentId" = "User".id)'), 'lastAssignedAt'],
+        [sequelize.literal('(SELECT COALESCE(SUM(lpa."leadsRemaining"), 0)::int FROM lead_package_assignments lpa WHERE lpa."agentId" = "User".id AND lpa."source" = \'wallet\' AND lpa.status = \'active\')'), 'committedLeads'],
+        [sequelize.literal('(SELECT COALESCE(SUM(lpa."leadsRemaining" * lpa."unitPriceCents"), 0)::bigint FROM lead_package_assignments lpa WHERE lpa."agentId" = "User".id AND lpa."source" = \'wallet\' AND lpa.status = \'active\' AND lpa."unitPriceCents" IS NOT NULL)'), 'committedValueCents'],
       ]
     },
     include: [

--- a/backend/src/services/agentService.js
+++ b/backend/src/services/agentService.js
@@ -110,10 +110,10 @@ export async function listAgents(query) {
         // Phase B roster aggregates (admin rebuild): period assignment volume,
         // recency, and open wallet-commitment demand (0s for internal agents —
         // the UI renders "—" when mktrLeadsId is null).
-        [sequelize.literal(`(SELECT COUNT(*) FROM prospects WHERE prospects."assignedAgentId" = "User".id AND prospects."createdAt" >= '${periodStartIso}')`), 'assignedThisPeriod'],
+        [sequelize.literal(`(SELECT COUNT(*) FROM prospects WHERE prospects."assignedAgentId" = "User".id AND prospects."createdAt" >= '${periodStartIso}')::int`), 'assignedThisPeriod'],
         [sequelize.literal('(SELECT MAX(prospects."createdAt") FROM prospects WHERE prospects."assignedAgentId" = "User".id)'), 'lastAssignedAt'],
         [sequelize.literal('(SELECT COALESCE(SUM(lpa."leadsRemaining"), 0)::int FROM lead_package_assignments lpa WHERE lpa."agentId" = "User".id AND lpa."source" = \'wallet\' AND lpa.status = \'active\')'), 'committedLeads'],
-        [sequelize.literal('(SELECT COALESCE(SUM(lpa."leadsRemaining" * lpa."unitPriceCents"), 0)::bigint FROM lead_package_assignments lpa WHERE lpa."agentId" = "User".id AND lpa."source" = \'wallet\' AND lpa.status = \'active\' AND lpa."unitPriceCents" IS NOT NULL)'), 'committedValueCents'],
+        [sequelize.literal('(SELECT COALESCE(SUM(lpa."leadsRemaining" * lpa."unitPriceCents"), 0)::int FROM lead_package_assignments lpa WHERE lpa."agentId" = "User".id AND lpa."source" = \'wallet\' AND lpa.status = \'active\' AND lpa."unitPriceCents" IS NOT NULL)'), 'committedValueCents'],
       ]
     },
     include: [

--- a/backend/src/services/agentStatsHelpers.js
+++ b/backend/src/services/agentStatsHelpers.js
@@ -129,8 +129,21 @@ export function computeAgentStatsFromCounts(agent, assignedCounts, packageBreakd
     : 0;
   const totalLeadsOwed = manualLeads + packageLeads;
 
+  // Wallet columns are meaningful for EXTERNAL (mktr-leads) agents only —
+  // internal agents read null (the UI renders "—"), never a misleading 0.
+  const isExternal = plain.mktrLeadsId != null;
+  const walletFields = isExternal
+    ? {
+        walletBalanceCents: parseInt(plain.walletBalanceCents, 10) || 0,
+        committedLeads: parseInt(plain.committedLeads, 10) || 0,
+        committedValueCents: parseInt(plain.committedValueCents, 10) || 0,
+      }
+    : { walletBalanceCents: null, committedLeads: null, committedValueCents: null };
+
   return {
     ...plain,
+    ...walletFields,
+    assignedThisPeriod: parseInt(plain.assignedThisPeriod, 10) || 0,
     owed_leads_count: totalLeadsOwed,
     owed_leads_manual_count: manualLeads,
     // Per-campaign split of the package portion — credits are campaign-scoped

--- a/backend/src/services/campaignService.js
+++ b/backend/src/services/campaignService.js
@@ -196,12 +196,18 @@ function buildOwnerWhere(req, extra = {}) {
  * List campaigns with pagination, filtering, and role-based scoping.
  */
 export async function listCampaigns(user, query, req) {
-  const { page = 1, limit = 10, status, type, search, createdBy } = query;
+  const { page = 1, limit = 10, status, type, search, createdBy, period } = query;
   // Clamp pagination so malformed query params (?page=-1&limit=-5, ?page=abc)
   // don't reach Sequelize as a negative/NaN LIMIT/OFFSET, which throws → 500.
   const pageNum = Math.max(1, parseInt(page, 10) || 1);
   const limitNum = Math.min(Math.max(1, parseInt(limit, 10) || 10), 200);
   const offset = (pageNum - 1) * limitNum;
+
+  // Phase B: validated rolling window for leadsThisPeriod (additive — every
+  // existing key keeps its all-time semantics). The start date is computed
+  // server-side and interpolated as an ISO literal (never user input).
+  const periodDays = { '7d': 7, '30d': 30, '90d': 90 }[period] || 30;
+  const periodStartIso = new Date(Date.now() - periodDays * 24 * 3600e3).toISOString();
 
   const where = buildCampaignWhere(req);
 
@@ -227,6 +233,10 @@ export async function listCampaigns(user, query, req) {
         [sequelize.literal('(SELECT COUNT(*) FROM prospects WHERE prospects."campaignId" = "Campaign".id)'), 'prospectCount'],
         [sequelize.literal('(SELECT COUNT(*) FROM qr_tags WHERE qr_tags."campaignId" = "Campaign".id)'), 'qrTagCount'],
         [sequelize.literal('(SELECT COALESCE(SUM("scanCount"), 0) FROM qr_tags WHERE qr_tags."campaignId" = "Campaign".id)'), 'totalScans'],
+        // Phase B aggregates (admin rebuild): period leads + open wallet-commitment demand.
+        [sequelize.literal(`(SELECT COUNT(*) FROM prospects WHERE prospects."campaignId" = "Campaign".id AND prospects."createdAt" >= '${periodStartIso}')`), 'leadsThisPeriod'],
+        [sequelize.literal('(SELECT COALESCE(SUM(lpa."leadsRemaining"), 0)::int FROM lead_package_assignments lpa JOIN lead_packages lp ON lpa."leadPackageId" = lp.id WHERE lp."campaignId" = "Campaign".id AND lpa."source" = \'wallet\' AND lpa.status = \'active\')'), 'committedRemaining'],
+        [sequelize.literal('(SELECT COALESCE(SUM(lpa."leadsRemaining" * lpa."unitPriceCents"), 0)::bigint FROM lead_package_assignments lpa JOIN lead_packages lp ON lpa."leadPackageId" = lp.id WHERE lp."campaignId" = "Campaign".id AND lpa."source" = \'wallet\' AND lpa.status = \'active\' AND lpa."unitPriceCents" IS NOT NULL)'), 'committedValueCents'],
       ]
     },
     include: [
@@ -501,6 +511,62 @@ export async function updateCampaign(id, body, req) {
   plain.ad_playlist = mediaItemsToPlaylist(plain.mediaItems);
   plain.assigned_agents = agentRows.map(r => r.agentId);
   return plain;
+}
+
+/**
+ * Admin campaign-detail composite (Phase B): one round-trip for the rebuild's
+ * detail screen — campaign row + 30d SGT lead series + open wallet commitments
+ * + latest leads + QR tags. Read-only aggregation over existing data.
+ */
+export async function getCampaignSummary(id, req) {
+  const where = buildOwnerWhere(req, { id });
+  const campaign = await Campaign.findOne({ where });
+  if (!campaign) throw new AppError('Campaign not found or access denied', 404);
+
+  const { getLeadSeries } = await import('./dashboardService.js');
+  const { LeadPackageAssignment, Prospect: ProspectModel, QrTag: QrTagModel } = await import('../models/index.js');
+
+  const [series, commitmentRows, recent, qrTags] = await Promise.all([
+    getLeadSeries('30d', { campaignId: id }),
+    LeadPackageAssignment.findAll({
+      where: { source: 'wallet', status: 'active', leadsRemaining: { [Op.gt]: 0 } },
+      include: [
+        { association: 'package', attributes: [], where: { campaignId: id }, required: true },
+        { association: 'agent', attributes: ['id', 'firstName', 'lastName', 'fullName', 'email'] },
+      ],
+      order: [['purchaseDate', 'ASC']],
+    }),
+    ProspectModel.findAll({
+      where: { campaignId: id },
+      attributes: ['id', 'firstName', 'lastName', 'leadStatus', 'leadSource', 'quarantinedAt', 'quarantineReason', 'assignedAgentId', 'createdAt'],
+      order: [['createdAt', 'DESC']],
+      limit: 6,
+    }),
+    QrTagModel.findAll({
+      where: { campaignId: id },
+      attributes: ['id', 'name', 'scanCount', 'uniqueScanCount', 'lastScanned', 'active'],
+      order: [['scanCount', 'DESC']],
+    }),
+  ]);
+
+  const commitments = commitmentRows.map((r) => ({
+    assignmentId: r.id,
+    agentId: r.agent?.id ?? r.agentId,
+    agent: r.agent ? (r.agent.fullName || `${r.agent.firstName || ''} ${r.agent.lastName || ''}`.trim() || r.agent.email) : null,
+    remaining: r.leadsRemaining,
+    unitPriceCents: r.unitPriceCents,
+    valueCents: Number.isInteger(r.unitPriceCents) ? r.leadsRemaining * r.unitPriceCents : null,
+  }));
+
+  return {
+    campaign: campaign.toJSON(),
+    series,
+    commitments,
+    committedRemaining: commitments.reduce((s, c) => s + c.remaining, 0),
+    committedValueCents: commitments.reduce((s, c) => s + (c.valueCents || 0), 0),
+    recent,
+    qrTags,
+  };
 }
 
 /**

--- a/backend/src/services/campaignService.js
+++ b/backend/src/services/campaignService.js
@@ -233,10 +233,14 @@ export async function listCampaigns(user, query, req) {
         [sequelize.literal('(SELECT COUNT(*) FROM prospects WHERE prospects."campaignId" = "Campaign".id)'), 'prospectCount'],
         [sequelize.literal('(SELECT COUNT(*) FROM qr_tags WHERE qr_tags."campaignId" = "Campaign".id)'), 'qrTagCount'],
         [sequelize.literal('(SELECT COALESCE(SUM("scanCount"), 0) FROM qr_tags WHERE qr_tags."campaignId" = "Campaign".id)'), 'totalScans'],
-        // Phase B aggregates (admin rebuild): period leads + open wallet-commitment demand.
-        [sequelize.literal(`(SELECT COUNT(*) FROM prospects WHERE prospects."campaignId" = "Campaign".id AND prospects."createdAt" >= '${periodStartIso}')`), 'leadsThisPeriod'],
+        // Phase B aggregates (admin rebuild): period leads + open wallet-commitment
+        // demand. All cast ::int so they serialize as JSON numbers (pg returns
+        // bigint COUNT/SUM as strings otherwise); int32 bounds are ample here
+        // (committedValueCents caps at ~S$21M before overflow — far beyond scale).
+        [sequelize.literal('(SELECT COUNT(*) FROM prospects WHERE prospects."campaignId" = "Campaign".id)::int'), 'leadsTotal'],
+        [sequelize.literal(`(SELECT COUNT(*) FROM prospects WHERE prospects."campaignId" = "Campaign".id AND prospects."createdAt" >= '${periodStartIso}')::int`), 'leadsThisPeriod'],
         [sequelize.literal('(SELECT COALESCE(SUM(lpa."leadsRemaining"), 0)::int FROM lead_package_assignments lpa JOIN lead_packages lp ON lpa."leadPackageId" = lp.id WHERE lp."campaignId" = "Campaign".id AND lpa."source" = \'wallet\' AND lpa.status = \'active\')'), 'committedRemaining'],
-        [sequelize.literal('(SELECT COALESCE(SUM(lpa."leadsRemaining" * lpa."unitPriceCents"), 0)::bigint FROM lead_package_assignments lpa JOIN lead_packages lp ON lpa."leadPackageId" = lp.id WHERE lp."campaignId" = "Campaign".id AND lpa."source" = \'wallet\' AND lpa.status = \'active\' AND lpa."unitPriceCents" IS NOT NULL)'), 'committedValueCents'],
+        [sequelize.literal('(SELECT COALESCE(SUM(lpa."leadsRemaining" * lpa."unitPriceCents"), 0)::int FROM lead_package_assignments lpa JOIN lead_packages lp ON lpa."leadPackageId" = lp.id WHERE lp."campaignId" = "Campaign".id AND lpa."source" = \'wallet\' AND lpa.status = \'active\' AND lpa."unitPriceCents" IS NOT NULL)'), 'committedValueCents'],
       ]
     },
     include: [

--- a/backend/src/services/dashboardService.js
+++ b/backend/src/services/dashboardService.js
@@ -1,8 +1,41 @@
 import { Op } from 'sequelize';
 import {
   User, Campaign, Prospect, QrTag, Commission,
-  Car, Driver, FleetOwner, Impression, sequelize
+  Car, Driver, FleetOwner, Impression,
+  WebhookDelivery, WebhookSubscriber, LeadPackageAssignment, sequelize
 } from '../models/index.js';
+
+// ── Period plumbing (admin rebuild Phase B) ───────────────────────────────────
+// Everything admin-dashboard is SGT-anchored: "today" = since 00:00 SGT.
+const VALID_PERIODS = ['7d', '30d', '90d'];
+const PERIOD_DAYS = { '7d': 7, '30d': 30, '90d': 90 };
+const SGT_OFFSET_MS = 8 * 3600e3;
+const DAY_MS = 24 * 3600e3;
+// Wallets below S$50 are "low" on the attention rail (design constant).
+const LOW_WALLET_CENTS = 5000;
+
+export function normalizePeriod(period) {
+  return VALID_PERIODS.includes(period) ? period : '30d';
+}
+
+/** UTC instant of the most recent SGT midnight. */
+function sgtMidnightUtc(now = new Date()) {
+  const shifted = new Date(now.getTime() + SGT_OFFSET_MS);
+  shifted.setUTCHours(0, 0, 0, 0);
+  return new Date(shifted.getTime() - SGT_OFFSET_MS);
+}
+
+/** Rolling period window anchored to SGT midnight: [start of (days-1) ago, now]. */
+function periodStartUtc(period, now = new Date()) {
+  return new Date(sgtMidnightUtc(now).getTime() - (PERIOD_DAYS[normalizePeriod(period)] - 1) * DAY_MS);
+}
+
+/** design_config.luckyDraw closesAt/boostClosesAt are YYYY-MM-DD with SGT end-of-day semantics. */
+function sgtDayEndMs(yyyyMmDd) {
+  if (typeof yyyyMmDd !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(yyyyMmDd)) return null;
+  const t = Date.parse(`${yyyyMmDd}T23:59:59+08:00`);
+  return Number.isNaN(t) ? null : t;
+}
 
 // Defensive helpers for optional columns / missing tables
 const safeSum = async (model, column, options = {}) => {
@@ -20,42 +53,50 @@ const safeCount = async (model, options = {}) => {
  */
 export async function getOverview(userId, userRole, period = '30d') {
   const now = new Date();
-  const days = period === '7d' ? 7 : period === '30d' ? 30 : 90;
+  const safePeriod = normalizePeriod(period);
+  const days = PERIOD_DAYS[safePeriod];
   const startDate = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
 
   switch (userRole) {
-    case 'admin': return getAdminStats(startDate, now);
+    case 'admin': return getAdminStats(startDate, now, safePeriod);
     case 'agent': return getAgentStats(userId, startDate, now);
     case 'fleet_owner': return getFleetOwnerStats(userId, startDate, now);
     default: return getCustomerStats(userId);
   }
 }
 
-// ---- Admin Stats (with simple TTL cache) ----
+// ---- Admin Stats (simple TTL cache, KEYED BY PERIOD) ----
+// The old single global cache served 90d numbers to a 7d request made within
+// the TTL — period switches on the dashboard silently lied. One entry per
+// period fixes it without losing the burst protection.
 
-let adminStatsCache = null;
-let adminStatsCacheTime = 0;
+const adminStatsCache = new Map(); // period → { result, time }
 const ADMIN_CACHE_TTL_MS = 30000; // 30 seconds
 
 /** Reset admin stats cache (useful for tests that change period between calls). */
 export function resetAdminStatsCache() {
-  adminStatsCache = null;
-  adminStatsCacheTime = 0;
+  adminStatsCache.clear();
 }
 
-async function getAdminStats(startDate, endDate) {
+async function getAdminStats(startDate, endDate, period = '30d') {
   const now = Date.now();
-  if (adminStatsCache && (now - adminStatsCacheTime) < ADMIN_CACHE_TTL_MS) {
-    return adminStatsCache;
+  const cached = adminStatsCache.get(period);
+  if (cached && (now - cached.time) < ADMIN_CACHE_TTL_MS) {
+    return cached.result;
   }
 
   const todayStart = new Date();
   todayStart.setHours(0, 0, 0, 0);
 
+  // Prospects can be assigned through EITHER assignee FK (internal users OR
+  // the ExternalAgent buyer pool) — "assigned" must count both.
+  const anyAssignee = { [Op.or]: [{ assignedAgentId: { [Op.ne]: null } }, { externalAgentId: { [Op.ne]: null } }] };
+
   const [
     totalUsers, activeUsers, totalCampaigns, activeCampaigns,
     totalProspects, newProspects, totalCommissions, pendingCommissions,
-    totalQrTags, totalScans, totalCars, activeCars, impressionsToday
+    totalQrTags, totalScans, totalCars, activeCars, impressionsToday,
+    periodTotal, periodAssigned, periodConverted
   ] = await Promise.all([
     safeCount(User),
     safeCount(User, { where: { isActive: true } }),
@@ -69,7 +110,12 @@ async function getAdminStats(startDate, endDate) {
     safeSum(QrTag, 'scanCount'),
     safeCount(Car),
     safeCount(Car, { where: { status: 'active' } }),
-    safeCount(Impression, { where: { occurredAt: { [Op.gte]: todayStart } } })
+    safeCount(Impression, { where: { occurredAt: { [Op.gte]: todayStart } } }),
+    // Phase B additions — period-scoped; existing `total` (all-time) and `new`
+    // keep their semantics for the legacy dashboard during coexistence.
+    safeCount(Prospect, { where: { createdAt: { [Op.gte]: startDate } } }),
+    safeCount(Prospect, { where: { createdAt: { [Op.gte]: startDate }, ...anyAssignee } }),
+    safeCount(Prospect, { where: { leadStatus: 'won', conversionDate: { [Op.gte]: startDate } } })
   ]);
 
   const userGrowth = await getUserGrowthTrend(startDate, endDate);
@@ -78,7 +124,14 @@ async function getAdminStats(startDate, endDate) {
   const result = {
     users: { total: totalUsers, active: activeUsers, growth: userGrowth },
     campaigns: { total: totalCampaigns, active: activeCampaigns },
-    prospects: { total: totalProspects, new: newProspects },
+    prospects: {
+      total: totalProspects,
+      new: newProspects,
+      periodTotal,
+      assigned: periodAssigned,
+      converted: periodConverted,
+      conversionRate: periodTotal > 0 ? Number(((periodConverted / periodTotal) * 100).toFixed(1)) : 0
+    },
     commissions: { total: totalCommissions, pending: pendingCommissions },
     qrCodes: { total: totalQrTags, totalScans },
     fleet: { totalCars, activeCars },
@@ -86,9 +139,199 @@ async function getAdminStats(startDate, endDate) {
     recentActivities
   };
 
-  adminStatsCache = result;
-  adminStatsCacheTime = Date.now();
+  adminStatsCache.set(period, { result, time: Date.now() });
   return result;
+}
+
+// ---- Admin attention / series / funnel (Phase B — the Switchboard rebuild's data) ----
+
+const KNOWN_HOLD_REASONS = ['no_funded_agent', 'no_funded_external_buyer', 'dnc_pending', 'dnc_registered', 'returned_by_admin'];
+
+/**
+ * Structured aggregates behind the dashboard's needs-attention rail. The UI
+ * composes the queue rows/copy; this returns facts only. Definitions locked to
+ * docs/plans/mktr-admin-rebuild-implementation.md B2.
+ */
+export async function getAttention() {
+  const now = new Date();
+  const cutoff24h = new Date(now.getTime() - DAY_MS);
+  const horizon7d = now.getTime() + 7 * DAY_MS;
+
+  const [
+    webhookPending, webhookFailed24h, disabledSubscribers,
+    heldRows, unassigned,
+    externalAgents, committedRows, activeCampaigns
+  ] = await Promise.all([
+    safeCount(WebhookDelivery, { where: { status: 'pending' } }),
+    safeCount(WebhookDelivery, { where: { status: 'failed', updatedAt: { [Op.gte]: cutoff24h } } }),
+    safeCount(WebhookSubscriber, { where: { enabled: false } }),
+    Prospect.findAll({
+      where: { quarantinedAt: { [Op.ne]: null } },
+      attributes: ['quarantineReason', [sequelize.fn('COUNT', sequelize.col('id')), 'n']],
+      group: ['quarantineReason'],
+      raw: true
+    }).catch(() => []),
+    safeCount(Prospect, { where: { assignedAgentId: null, externalAgentId: null, quarantinedAt: null } }),
+    User.findAll({
+      where: { mktrLeadsId: { [Op.ne]: null }, role: 'agent', isActive: true },
+      attributes: ['id', 'firstName', 'lastName', 'fullName', 'email', 'walletBalanceCents'],
+      raw: true
+    }).catch(() => []),
+    LeadPackageAssignment.findAll({
+      where: { source: 'wallet', status: 'active', leadsRemaining: { [Op.gt]: 0 } },
+      attributes: ['leadsRemaining', 'unitPriceCents'],
+      include: [{ association: 'package', attributes: ['campaignId'], required: true }],
+    }).catch(() => []),
+    Campaign.findAll({
+      where: { status: 'active', is_active: true },
+      attributes: ['id', 'name', 'end_date', 'leadPriceCents', 'design_config'],
+    }).catch(() => [])
+  ]);
+
+  // Held, grouped over the real reason set; anything unknown/null reconciles into `other`.
+  const byReason = Object.fromEntries(KNOWN_HOLD_REASONS.map((r) => [r, 0]));
+  byReason.other = 0;
+  let heldTotal = 0;
+  for (const row of heldRows) {
+    const n = Number(row.n) || 0;
+    heldTotal += n;
+    if (KNOWN_HOLD_REASONS.includes(row.quarantineReason)) byReason[row.quarantineReason] += n;
+    else byReason.other += n;
+  }
+
+  // Wallets — EXTERNAL agents only (v1 cohort).
+  const name = (a) => a.fullName || `${a.firstName || ''} ${a.lastName || ''}`.trim() || a.email;
+  const zero = externalAgents.filter((a) => a.walletBalanceCents === 0).map((a) => ({ id: a.id, name: name(a) }));
+  const low = externalAgents
+    .filter((a) => a.walletBalanceCents > 0 && a.walletBalanceCents < LOW_WALLET_CENTS)
+    .map((a) => ({ id: a.id, name: name(a), balanceCents: a.walletBalanceCents }));
+  const floatCents = externalAgents.reduce((s, a) => s + (a.walletBalanceCents || 0), 0);
+
+  // Committed demand — open wallet commitments across all campaigns.
+  const fundedCampaignIds = new Set();
+  let committedLeads = 0;
+  let committedValueCents = 0;
+  for (const r of committedRows) {
+    committedLeads += r.leadsRemaining;
+    if (Number.isInteger(r.unitPriceCents)) committedValueCents += r.leadsRemaining * r.unitPriceCents;
+    if (r.package?.campaignId) fundedCampaignIds.add(r.package.campaignId);
+  }
+
+  // Zero-commitment incidents: ACTIVE + PRICED campaigns with no open funded
+  // assignment at all (wallet OR package — a package-funded campaign is still
+  // covered during drain-down). Unpriced campaigns are never incidents.
+  const pricedActive = activeCampaigns.filter((c) => Number.isInteger(c.leadPriceCents) && c.leadPriceCents > 0);
+  let coveredIds = new Set();
+  if (pricedActive.length > 0) {
+    const covered = await LeadPackageAssignment.findAll({
+      where: { status: 'active', leadsRemaining: { [Op.gt]: 0 } },
+      attributes: [],
+      include: [{
+        association: 'package',
+        attributes: ['campaignId'],
+        required: true,
+        where: { campaignId: pricedActive.map((c) => c.id) },
+      }],
+      raw: true,
+    }).catch(() => []);
+    coveredIds = new Set(covered.map((r) => r['package.campaignId']));
+  }
+  const zeroCommitCampaigns = pricedActive
+    .filter((c) => !coveredIds.has(c.id))
+    .map((c) => ({ id: c.id, name: c.name, endsAt: c.end_date ?? null }));
+
+  // Draw deadlines (≤7d) and plain campaign endings (≤7d, draws excluded so a
+  // campaign never appears in both lists).
+  const drawsClosing = [];
+  const endingCampaigns = [];
+  for (const c of activeCampaigns) {
+    const draw = c.design_config?.luckyDraw;
+    if (draw?.enabled === true) {
+      const closesMs = sgtDayEndMs(draw.closesAt);
+      if (closesMs !== null && closesMs > now.getTime() && closesMs <= horizon7d) {
+        drawsClosing.push({
+          id: c.id, name: c.name,
+          closesAt: draw.closesAt,
+          boostClosesAt: draw.boostClosesAt ?? null,
+          multiplier: draw.multiplier ?? null,
+          winners: draw.winners ?? null,
+        });
+      }
+      continue;
+    }
+    const endsMs = c.end_date ? new Date(c.end_date).getTime() : null;
+    if (endsMs !== null && endsMs > now.getTime() && endsMs <= horizon7d) {
+      endingCampaigns.push({ id: c.id, name: c.name, endsAt: c.end_date });
+    }
+  }
+
+  return {
+    webhooks: { pending: webhookPending, failedLast24h: webhookFailed24h, subscriberDisabled: disabledSubscribers > 0 },
+    held: { total: heldTotal, byReason },
+    unassigned,
+    zeroCommitCampaigns,
+    wallets: { total: externalAgents.length, zero, low, floatCents },
+    committed: { leads: committedLeads, valueCents: committedValueCents, campaigns: fundedCampaignIds.size },
+    drawsClosing,
+    endingCampaigns,
+  };
+}
+
+/**
+ * Daily lead counts, SGT-midnight buckets. `today` = the current (partial) SGT
+ * day; avgPerDay excludes it so the delta baseline is honest.
+ */
+export async function getLeadSeries(period = '30d', { campaignId = null } = {}) {
+  const safePeriod = normalizePeriod(period);
+  const days = PERIOD_DAYS[safePeriod];
+  const now = new Date();
+  const start = periodStartUtc(safePeriod, now);
+
+  const campaignFilter = campaignId ? 'AND "campaignId" = :campaignId' : '';
+  const [rows] = await sequelize.query(`
+    SELECT (("createdAt" AT TIME ZONE 'Asia/Singapore')::date)::text AS day, COUNT(*)::int AS count
+    FROM prospects
+    WHERE "createdAt" >= :start ${campaignFilter}
+    GROUP BY day
+    ORDER BY day
+  `, { replacements: { start, campaignId } });
+
+  const byDay = new Map(rows.map((r) => [r.day, r.count]));
+  const daysOut = [];
+  for (let i = 0; i < days; i++) {
+    const dayStartUtc = new Date(start.getTime() + i * DAY_MS);
+    const key = new Date(dayStartUtc.getTime() + SGT_OFFSET_MS).toISOString().slice(0, 10);
+    daysOut.push({ date: key, count: byDay.get(key) || 0, isToday: i === days - 1 });
+  }
+  const today = daysOut[daysOut.length - 1].count;
+  const prior = daysOut.slice(0, -1);
+  const avgPerDay = prior.length ? Number((prior.reduce((s, d) => s + d.count, 0) / prior.length).toFixed(1)) : 0;
+  return { days: daysOut, today, avgPerDay, total: daysOut.reduce((s, d) => s + d.count, 0) };
+}
+
+/**
+ * Funnel: scans → submits → assigned → won. QR scanCounts are LIFETIME, so the
+ * top of the funnel is prorated to the period and flagged `estimated` — the
+ * honest fix is a per-period scan series (wishlist). Floored at submits so the
+ * funnel never inverts.
+ */
+const SCAN_PRORATION_LIFETIME_DAYS = 90; // assumed average tag lifetime for the estimate
+
+export async function getFunnel(period = '30d') {
+  const safePeriod = normalizePeriod(period);
+  const days = PERIOD_DAYS[safePeriod];
+  const start = periodStartUtc(safePeriod, new Date());
+  const anyAssignee = { [Op.or]: [{ assignedAgentId: { [Op.ne]: null } }, { externalAgentId: { [Op.ne]: null } }] };
+
+  const [lifetimeScans, submits, assigned, won] = await Promise.all([
+    safeSum(QrTag, 'scanCount'),
+    safeCount(Prospect, { where: { createdAt: { [Op.gte]: start } } }),
+    safeCount(Prospect, { where: { createdAt: { [Op.gte]: start }, ...anyAssignee } }),
+    safeCount(Prospect, { where: { leadStatus: 'won', conversionDate: { [Op.gte]: start } } }),
+  ]);
+
+  const prorated = Math.round(lifetimeScans * (days / SCAN_PRORATION_LIFETIME_DAYS));
+  return { scans: Math.max(prorated, submits), submits, assigned, won, estimated: true };
 }
 
 // ---- Agent Stats ----

--- a/backend/src/services/dashboardService.js
+++ b/backend/src/services/dashboardService.js
@@ -172,9 +172,12 @@ export async function getAttention() {
       raw: true
     }).catch(() => []),
     safeCount(Prospect, { where: { assignedAgentId: null, externalAgentId: null, quarantinedAt: null } }),
+    // FULL external cohort, including inactive agents — the agent-sync can
+    // deactivate a user who still holds a balance, and money must never
+    // vanish from the float. Rows carry isActive so the UI can badge them.
     User.findAll({
-      where: { mktrLeadsId: { [Op.ne]: null }, role: 'agent', isActive: true },
-      attributes: ['id', 'firstName', 'lastName', 'fullName', 'email', 'walletBalanceCents'],
+      where: { mktrLeadsId: { [Op.ne]: null }, role: 'agent' },
+      attributes: ['id', 'firstName', 'lastName', 'fullName', 'email', 'walletBalanceCents', 'isActive'],
       raw: true
     }).catch(() => []),
     LeadPackageAssignment.findAll({
@@ -199,12 +202,14 @@ export async function getAttention() {
     else byReason.other += n;
   }
 
-  // Wallets — EXTERNAL agents only (v1 cohort).
+  // Wallets — EXTERNAL agents only (v1 cohort), inactive included.
   const name = (a) => a.fullName || `${a.firstName || ''} ${a.lastName || ''}`.trim() || a.email;
-  const zero = externalAgents.filter((a) => a.walletBalanceCents === 0).map((a) => ({ id: a.id, name: name(a) }));
+  const zero = externalAgents
+    .filter((a) => a.walletBalanceCents === 0)
+    .map((a) => ({ id: a.id, name: name(a), isActive: a.isActive }));
   const low = externalAgents
     .filter((a) => a.walletBalanceCents > 0 && a.walletBalanceCents < LOW_WALLET_CENTS)
-    .map((a) => ({ id: a.id, name: name(a), balanceCents: a.walletBalanceCents }));
+    .map((a) => ({ id: a.id, name: name(a), balanceCents: a.walletBalanceCents, isActive: a.isActive }));
   const floatCents = externalAgents.reduce((s, a) => s + (a.walletBalanceCents || 0), 0);
 
   // Committed demand — open wallet commitments across all campaigns.

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -74,6 +74,40 @@ const VALID_LEAD_STATUSES = ['new', 'contacted', 'qualified', 'proposal_sent', '
 // an empty page (same pattern as VALID_LEAD_STATUSES).
 const VALID_ASSIGNMENT_FILTERS = ['assigned', 'unassigned', 'held'];
 
+// Mirrors the Prospect.leadSource ENUM (same enum-cast protection as statuses).
+const VALID_LEAD_SOURCES = ['qr_code', 'website', 'referral', 'social_media', 'advertisement', 'direct', 'call_bot', 'other'];
+
+// List-endpoint sort whitelist (admin rebuild Phase B). `-` prefix = DESC.
+// Anything outside the map falls back to the default — never a 500, never an
+// unindexed free-form ORDER BY.
+const PROSPECT_SORT_FIELDS = ['firstName', 'leadStatus', 'createdAt'];
+const DEFAULT_PROSPECT_SORT = '-createdAt';
+
+/**
+ * Comma-list enum filter: split, trim, dedupe, whitelist. Returns
+ *  { skip: true }               when the param is absent (no filter),
+ *  { values: [...] }            when ≥1 token is valid (Op.in / Op.eq),
+ *  { empty: true }              when a value was given but NO token is valid —
+ * the caller degrades to an empty page, matching the long-standing single-value
+ * behavior (a bad filter never errors AND never silently shows everything).
+ */
+function parseEnumFilter(value, allowed) {
+  if (value === undefined || value === null || value === '') return { skip: true };
+  const tokens = [...new Set(String(value).split(',').map((s) => s.trim()).filter(Boolean))];
+  const valid = tokens.filter((t) => allowed.includes(t));
+  if (valid.length === 0) return { empty: true };
+  return { values: valid };
+}
+
+/** Sort param → Sequelize order tuple, whitelisted with default fallback. */
+function parseProspectSort(sort) {
+  const raw = typeof sort === 'string' && sort.trim() ? sort.trim() : DEFAULT_PROSPECT_SORT;
+  const desc = raw.startsWith('-');
+  const field = desc ? raw.slice(1) : raw;
+  if (!PROSPECT_SORT_FIELDS.includes(field)) return [['createdAt', 'DESC']];
+  return [[field, desc ? 'DESC' : 'ASC']];
+}
+
 // Hold reasons a MANUAL admin (re)assign may release. Everything else is fenced:
 // 'no_funded_external_buyer' (external buyer pool), 'dnc_pending'/'dnc_registered'
 // (DNC gate). 'returned_by_admin' is the web-admin return flavor — deliberately
@@ -1808,6 +1842,7 @@ export function makeProspectService(overrides = {}) {
       dateFrom,
       dateTo,
       qrTagId,
+      sort,
     } = params;
 
     // Clamp pagination so malformed query params (e.g. ?page=-1&limit=-5) don't
@@ -1818,9 +1853,14 @@ export function makeProspectService(overrides = {}) {
     const scopeFilter = await d.buildProspectWhere(user);
     const whereConditions = { ...scopeFilter };
 
-    // Unknown leadStatus would hit the Postgres enum and 500; degrade to "no
-    // matches" so a bad filter value returns an empty page rather than erroring.
-    if (leadStatus && !VALID_LEAD_STATUSES.includes(leadStatus)) {
+    // leadStatus / leadSource accept comma-lists (Phase B multi-select filters);
+    // single values stay backward-compatible. Tokens are whitelisted against
+    // the enum so nothing unknown ever reaches a Postgres enum cast (→ 500);
+    // an all-invalid value degrades to an empty page — the long-standing
+    // single-value behavior.
+    const statusFilter = parseEnumFilter(leadStatus, VALID_LEAD_STATUSES);
+    const sourceFilter = parseEnumFilter(leadSource, VALID_LEAD_SOURCES);
+    if (statusFilter.empty || sourceFilter.empty) {
       return { prospects: [], pagination: { currentPage: pageNum, totalPages: 0, totalItems: 0, itemsPerPage: limitNum } };
     }
     if (assignment && !VALID_ASSIGNMENT_FILTERS.includes(assignment)) {
@@ -1836,9 +1876,13 @@ export function makeProspectService(overrides = {}) {
     } else if (assignment === 'held') whereConditions.quarantinedAt = { [Op.ne]: null };
 
     if (qrTagId) whereConditions.qrTagId = qrTagId;
-    if (leadStatus) whereConditions.leadStatus = leadStatus;
+    if (statusFilter.values) {
+      whereConditions.leadStatus = statusFilter.values.length === 1 ? statusFilter.values[0] : { [Op.in]: statusFilter.values };
+    }
     if (priority) whereConditions.priority = priority;
-    if (leadSource) whereConditions.leadSource = leadSource;
+    if (sourceFilter.values) {
+      whereConditions.leadSource = sourceFilter.values.length === 1 ? sourceFilter.values[0] : { [Op.in]: sourceFilter.values };
+    }
     if (assignedAgentId) whereConditions.assignedAgentId = assignedAgentId;
     if (campaignId) whereConditions.campaignId = campaignId;
 
@@ -1863,7 +1907,7 @@ export function makeProspectService(overrides = {}) {
       where: whereConditions,
       limit: limitNum,
       offset,
-      order: [['createdAt', 'DESC']],
+      order: parseProspectSort(sort),
       include: [
         {
           association: 'assignedAgent',

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -1869,9 +1869,17 @@ export function makeProspectService(overrides = {}) {
 
     // Assignment-state filter: 'unassigned' means truly in limbo (not held — held rows
     // have their own bucket so the admin's pending pool and the strays stay separable).
-    if (assignment === 'assigned') whereConditions.assignedAgentId = { [Op.ne]: null };
-    else if (assignment === 'unassigned') {
+    // Prospects carry TWO mutually-exclusive assignee FKs (assignedAgentId for users,
+    // externalAgentId for the ExternalAgent buyer pool) — both count as "assigned".
+    // The Op.or lives inside Op.and so it can never clobber the search Op.or below.
+    if (assignment === 'assigned') {
+      whereConditions[Op.and] = [
+        ...(whereConditions[Op.and] || []),
+        { [Op.or]: [{ assignedAgentId: { [Op.ne]: null } }, { externalAgentId: { [Op.ne]: null } }] },
+      ];
+    } else if (assignment === 'unassigned') {
       whereConditions.assignedAgentId = null;
+      whereConditions.externalAgentId = null;
       whereConditions.quarantinedAt = null;
     } else if (assignment === 'held') whereConditions.quarantinedAt = { [Op.ne]: null };
 

--- a/backend/test/adminDashboardExtensions.test.js
+++ b/backend/test/adminDashboardExtensions.test.js
@@ -1,0 +1,307 @@
+import request from 'supertest'
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect, createTestQrTag } from './helpers.js'
+import { resetAdminStatsCache } from '../src/services/dashboardService.js'
+import { LeadPackage, LeadPackageAssignment, WebhookSubscriber, WebhookDelivery } from '../src/models/index.js'
+
+/**
+ * Admin rebuild Phase B — API extensions (docs/plans/mktr-admin-rebuild-implementation.md).
+ * DB-backed contract tests for:
+ *   B1 overview periodTotal/assigned/converted/conversionRate + period-keyed cache
+ *   B2 /api/dashboard/attention structured aggregates
+ *   B3 /api/dashboard/series SGT daily buckets
+ *   B4 /api/dashboard/funnel (prorated scans, floored, estimated flag)
+ *   B5 prospects comma-list filters + sort whitelist
+ *   B6 campaign list aggregates + /api/campaigns/:id/summary composite
+ *   B7 agents roster aggregates
+ */
+
+const DAY_MS = 24 * 3600e3
+
+let app, admin, adminToken, agent, agentToken, externalAgent
+let campaign, pricedCoveredCampaign, pricedUncoveredCampaign, drawCampaign
+let walletPkg, walletAssignment
+
+beforeAll(async () => {
+  app = await getApp()
+  ;({ user: admin, token: adminToken } = await createTestUser({ role: 'admin' }))
+  ;({ user: agent, token: agentToken } = await createTestUser({ role: 'agent' }))
+
+  // External (mktr-leads) agent with a wallet balance below the S$50 low-water mark.
+  ;({ user: externalAgent } = await createTestUser({
+    role: 'agent',
+    mktrLeadsId: `mktr-ext-${Date.now()}`,
+    walletBalanceCents: 2500,
+  }))
+
+  campaign = await createTestCampaign(admin.id)
+
+  // Priced + covered: an open wallet commitment keeps it OFF the zero-commit rail.
+  pricedCoveredCampaign = await createTestCampaign(admin.id, { leadPriceCents: 800 })
+  walletPkg = await LeadPackage.create({
+    name: 'Wallet commitments', type: 'custom', kind: 'wallet', campaignId: pricedCoveredCampaign.id,
+    isPublic: false, status: 'active', currency: 'SGD', price: 0, leadCount: 0, createdBy: admin.id,
+  })
+  walletAssignment = await LeadPackageAssignment.create({
+    agentId: externalAgent.id, leadPackageId: walletPkg.id, source: 'wallet',
+    unitPriceCents: 800, leadsTotal: 5, leadsRemaining: 3, priceSnapshot: '40.00', status: 'active',
+  })
+
+  // Priced + uncovered: no funded assignment at all → zero-commit incident.
+  pricedUncoveredCampaign = await createTestCampaign(admin.id, { leadPriceCents: 600 })
+
+  // Draw closing inside the 7-day horizon (YYYY-MM-DD, SGT end-of-day).
+  const in3d = new Date(Date.now() + 3 * DAY_MS).toISOString().slice(0, 10)
+  drawCampaign = await createTestCampaign(admin.id, {
+    design_config: { luckyDraw: { enabled: true, closesAt: in3d, multiplier: 10, winners: 1 } },
+  })
+
+  // Prospects: one older than 7d (period boundary), assigned recents, a won
+  // conversion, held rows across known + unknown reasons, and one unassigned.
+  await createTestProspect(campaign.id, {
+    assignedAgentId: agent.id, createdAt: new Date(Date.now() - 10 * DAY_MS),
+  })
+  await createTestProspect(campaign.id, { assignedAgentId: agent.id })
+  await createTestProspect(campaign.id, {
+    assignedAgentId: agent.id, leadStatus: 'won', conversionDate: new Date(),
+    firstName: 'Zz-Won',
+  })
+  await createTestProspect(campaign.id, {
+    quarantinedAt: new Date(), quarantineReason: 'no_funded_agent', firstName: 'Held-A',
+  })
+  await createTestProspect(campaign.id, {
+    quarantinedAt: new Date(), quarantineReason: 'dnc_pending', leadSource: 'website',
+  })
+  await createTestProspect(campaign.id, {
+    quarantinedAt: new Date(), quarantineReason: 'some_future_reason',
+  })
+  await createTestProspect(campaign.id, { firstName: 'Aa-Unassigned', leadSource: 'website' })
+
+  await createTestQrTag(campaign.id, admin.id, { scanCount: 90 })
+
+  // Webhook health rows: one pending, one failed-now, one disabled subscriber.
+  const sub = await WebhookSubscriber.create({
+    name: 'Test Sub', url: 'https://example.test/hook', secret: 's3cret',
+    events: ['lead.created'], enabled: true,
+  })
+  await WebhookSubscriber.create({
+    name: 'Disabled Sub', url: 'https://example.test/hook2', secret: 's3cret',
+    events: ['lead.created'], enabled: false,
+  })
+  await WebhookDelivery.create({ subscriberId: sub.id, eventType: 'lead.created', payload: {}, status: 'pending' })
+  await WebhookDelivery.create({ subscriberId: sub.id, eventType: 'lead.created', payload: {}, status: 'failed' })
+
+  resetAdminStatsCache()
+}, 30000)
+
+afterAll(async () => {
+  await closeDb()
+})
+
+// ── B1 — overview extension + period-keyed cache ─────────────────────────────
+
+describe('B1 — GET /api/dashboard/overview (admin extension)', () => {
+  it('returns period-scoped periodTotal/assigned/converted/conversionRate; total stays all-time', async () => {
+    resetAdminStatsCache()
+    const res = await request(app).get('/api/dashboard/overview?period=30d').set('Authorization', `Bearer ${adminToken}`)
+    expect(res.status).toBe(200)
+    const p = res.body.data.stats.prospects
+    expect(p.total).toBeGreaterThanOrEqual(7)
+    expect(p.periodTotal).toBeGreaterThanOrEqual(7) // the 10d-old row is inside 30d
+    expect(p.assigned).toBeGreaterThanOrEqual(3)
+    expect(p.converted).toBeGreaterThanOrEqual(1)
+    expect(typeof p.conversionRate).toBe('number')
+  })
+
+  it('period cache is keyed: back-to-back 30d vs 7d differ (the old global-cache bug)', async () => {
+    resetAdminStatsCache()
+    const r30 = await request(app).get('/api/dashboard/overview?period=30d').set('Authorization', `Bearer ${adminToken}`)
+    const r7 = await request(app).get('/api/dashboard/overview?period=7d').set('Authorization', `Bearer ${adminToken}`)
+    // Within the same 30s TTL window — the 7d response must NOT be the cached 30d value.
+    expect(r7.body.data.stats.prospects.periodTotal).toBe(r30.body.data.stats.prospects.periodTotal - 1)
+  })
+})
+
+// ── B2 — attention aggregates ────────────────────────────────────────────────
+
+describe('B2 — GET /api/dashboard/attention', () => {
+  it('is admin-only', async () => {
+    const res = await request(app).get('/api/dashboard/attention').set('Authorization', `Bearer ${agentToken}`)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns the full structured aggregate with real-schema semantics', async () => {
+    const res = await request(app).get('/api/dashboard/attention').set('Authorization', `Bearer ${adminToken}`)
+    expect(res.status).toBe(200)
+    const d = res.body.data
+
+    // webhooks
+    expect(d.webhooks.pending).toBeGreaterThanOrEqual(1)
+    expect(d.webhooks.failedLast24h).toBeGreaterThanOrEqual(1)
+    expect(d.webhooks.subscriberDisabled).toBe(true)
+
+    // held: all five known reasons present, unknown reconciles into `other`
+    expect(d.held.byReason.no_funded_agent).toBeGreaterThanOrEqual(1)
+    expect(d.held.byReason.dnc_pending).toBeGreaterThanOrEqual(1)
+    expect(d.held.byReason.other).toBeGreaterThanOrEqual(1)
+    expect(Object.keys(d.held.byReason)).toEqual(
+      expect.arrayContaining(['no_funded_agent', 'no_funded_external_buyer', 'dnc_pending', 'dnc_registered', 'returned_by_admin', 'other'])
+    )
+    const reasonSum = Object.values(d.held.byReason).reduce((s, n) => s + n, 0)
+    expect(d.held.total).toBe(reasonSum)
+
+    // unassigned = no assignee (either FK) AND not held
+    expect(d.unassigned).toBeGreaterThanOrEqual(1)
+
+    // zero-commit: uncovered priced campaign flagged; covered one is NOT; unpriced never
+    const zcIds = d.zeroCommitCampaigns.map((c) => c.id)
+    expect(zcIds).toContain(pricedUncoveredCampaign.id)
+    expect(zcIds).not.toContain(pricedCoveredCampaign.id)
+    expect(zcIds).not.toContain(campaign.id)
+
+    // wallets: external cohort only — low (< S$50) includes our agent
+    expect(d.wallets.low.map((a) => a.id)).toContain(externalAgent.id)
+    expect(d.wallets.floatCents).toBeGreaterThanOrEqual(2500)
+
+    // committed demand from the open wallet assignment (3 × 800)
+    expect(d.committed.leads).toBeGreaterThanOrEqual(3)
+    expect(d.committed.valueCents).toBeGreaterThanOrEqual(2400)
+    expect(d.committed.campaigns).toBeGreaterThanOrEqual(1)
+
+    // draw closing inside 7d; draw campaigns never appear under endings
+    expect(d.drawsClosing.map((c) => c.id)).toContain(drawCampaign.id)
+    expect(d.endingCampaigns.map((c) => c.id)).not.toContain(drawCampaign.id)
+  })
+})
+
+// ── B3 — series ──────────────────────────────────────────────────────────────
+
+describe('B3 — GET /api/dashboard/series', () => {
+  it('returns SGT daily buckets with isToday on the last bucket', async () => {
+    const res = await request(app).get('/api/dashboard/series?period=7d').set('Authorization', `Bearer ${adminToken}`)
+    expect(res.status).toBe(200)
+    const d = res.body.data
+    expect(d.days).toHaveLength(7)
+    expect(d.days[6].isToday).toBe(true)
+    expect(d.days.slice(0, 6).every((x) => x.isToday === false)).toBe(true)
+    // 6 prospects created "now" land in today's SGT bucket; the 10d-old one doesn't.
+    expect(d.today).toBeGreaterThanOrEqual(6)
+    expect(d.total).toBe(d.days.reduce((s, x) => s + x.count, 0))
+    expect(typeof d.avgPerDay).toBe('number')
+  })
+
+  it('normalizes junk periods to 30d', async () => {
+    const res = await request(app).get('/api/dashboard/series?period=bogus').set('Authorization', `Bearer ${adminToken}`)
+    expect(res.body.data.period).toBe('30d')
+    expect(res.body.data.days).toHaveLength(30)
+  })
+})
+
+// ── B4 — funnel ──────────────────────────────────────────────────────────────
+
+describe('B4 — GET /api/dashboard/funnel', () => {
+  it('prorates lifetime scans, floors at submits, and flags the estimate', async () => {
+    const res = await request(app).get('/api/dashboard/funnel?period=7d').set('Authorization', `Bearer ${adminToken}`)
+    expect(res.status).toBe(200)
+    const d = res.body.data
+    expect(d.estimated).toBe(true)
+    expect(d.scans).toBeGreaterThanOrEqual(d.submits) // floored — the funnel never inverts
+    expect(d.submits).toBeGreaterThanOrEqual(d.assigned)
+    expect(d.assigned).toBeGreaterThanOrEqual(d.won)
+    expect(d.won).toBeGreaterThanOrEqual(1)
+  })
+})
+
+// ── B5 — prospects comma-list filters + sort ─────────────────────────────────
+
+describe('B5 — GET /api/prospects multi-select + sort', () => {
+  it('comma-list leadStatus filters with Op.in; invalid tokens are dropped', async () => {
+    const res = await request(app)
+      .get('/api/prospects?leadStatus=won,nurturing,not_a_status&limit=50')
+      .set('Authorization', `Bearer ${adminToken}`)
+    expect(res.status).toBe(200)
+    const statuses = new Set(res.body.data.prospects.map((p) => p.leadStatus))
+    expect(statuses.has('won')).toBe(true)
+    for (const s of statuses) expect(['won', 'nurturing']).toContain(s)
+  })
+
+  it('an all-invalid filter degrades to an empty page (never 500, never unfiltered)', async () => {
+    const res = await request(app)
+      .get('/api/prospects?leadSource=carrier_pigeon')
+      .set('Authorization', `Bearer ${adminToken}`)
+    expect(res.status).toBe(200)
+    expect(res.body.data.prospects).toHaveLength(0)
+  })
+
+  it('sort=firstName orders ascending; junk sort falls back to -createdAt', async () => {
+    const asc = await request(app)
+      .get('/api/prospects?sort=firstName&limit=100')
+      .set('Authorization', `Bearer ${adminToken}`)
+    const names = asc.body.data.prospects.map((p) => p.firstName)
+    expect([...names].sort((a, b) => a.localeCompare(b))).toEqual(names)
+
+    const junk = await request(app)
+      .get('/api/prospects?sort=;DROP TABLE&limit=5')
+      .set('Authorization', `Bearer ${adminToken}`)
+    expect(junk.status).toBe(200) // whitelist fallback, no error
+  })
+})
+
+// ── B6 — campaign list aggregates + summary composite ───────────────────────
+
+describe('B6 — campaign aggregates', () => {
+  it('list carries leadsThisPeriod + committedRemaining + committedValueCents', async () => {
+    const res = await request(app)
+      .get('/api/campaigns?period=7d&limit=50')
+      .set('Authorization', `Bearer ${adminToken}`)
+    expect(res.status).toBe(200)
+    const rows = res.body.data.campaigns
+    const covered = rows.find((c) => c.id === pricedCoveredCampaign.id)
+    expect(Number(covered.committedRemaining)).toBe(3)
+    expect(Number(covered.committedValueCents)).toBe(2400)
+    const main = rows.find((c) => c.id === campaign.id)
+    expect(Number(main.leadsThisPeriod)).toBeGreaterThanOrEqual(6) // 10d-old row outside 7d
+    expect(Number(main.prospectCount)).toBeGreaterThanOrEqual(7)   // all-time key untouched
+  })
+
+  it('GET /api/campaigns/:id/summary is admin-only and composes the detail payload', async () => {
+    const forbidden = await request(app)
+      .get(`/api/campaigns/${campaign.id}/summary`)
+      .set('Authorization', `Bearer ${agentToken}`)
+    expect(forbidden.status).toBe(403)
+
+    const res = await request(app)
+      .get(`/api/campaigns/${pricedCoveredCampaign.id}/summary`)
+      .set('Authorization', `Bearer ${adminToken}`)
+    expect(res.status).toBe(200)
+    const d = res.body.data
+    expect(d.campaign.id).toBe(pricedCoveredCampaign.id)
+    expect(d.series.days).toHaveLength(30)
+    expect(d.commitments).toHaveLength(1)
+    expect(d.commitments[0]).toMatchObject({ remaining: 3, unitPriceCents: 800, valueCents: 2400 })
+    expect(d.committedRemaining).toBe(3)
+    expect(d.committedValueCents).toBe(2400)
+    expect(Array.isArray(d.recent)).toBe(true)
+    expect(Array.isArray(d.qrTags)).toBe(true)
+  })
+})
+
+// ── B7 — agents roster aggregates ────────────────────────────────────────────
+
+describe('B7 — GET /api/agents roster aggregates', () => {
+  it('carries assignedThisPeriod, lastAssignedAt, wallet columns', async () => {
+    const res = await request(app)
+      .get('/api/agents?limit=100&period=30d')
+      .set('Authorization', `Bearer ${adminToken}`)
+    expect(res.status).toBe(200)
+    const rows = res.body.data.agents
+    const internal = rows.find((a) => a.id === agent.id)
+    expect(Number(internal.assignedThisPeriod)).toBeGreaterThanOrEqual(3)
+    expect(internal.lastAssignedAt).toBeTruthy()
+    expect(Number(internal.committedLeads)).toBe(0)
+
+    const external = rows.find((a) => a.id === externalAgent.id)
+    expect(external.walletBalanceCents).toBe(2500)
+    expect(Number(external.committedLeads)).toBe(3)
+    expect(Number(external.committedValueCents)).toBe(2400)
+  })
+})

--- a/backend/test/adminDashboardExtensions.test.js
+++ b/backend/test/adminDashboardExtensions.test.js
@@ -1,7 +1,7 @@
 import request from 'supertest'
 import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect, createTestQrTag } from './helpers.js'
 import { resetAdminStatsCache } from '../src/services/dashboardService.js'
-import { LeadPackage, LeadPackageAssignment, WebhookSubscriber, WebhookDelivery } from '../src/models/index.js'
+import { LeadPackage, LeadPackageAssignment, WebhookSubscriber, WebhookDelivery, ExternalAgent } from '../src/models/index.js'
 
 /**
  * Admin rebuild Phase B — API extensions (docs/plans/mktr-admin-rebuild-implementation.md).
@@ -75,6 +75,11 @@ beforeAll(async () => {
     quarantinedAt: new Date(), quarantineReason: 'some_future_reason',
   })
   await createTestProspect(campaign.id, { firstName: 'Aa-Unassigned', leadSource: 'website' })
+
+  // Externally-assigned prospect (the SECOND assignee FK): must count as
+  // "assigned", never appear under "unassigned".
+  const extBuyer = await ExternalAgent.create({ phone: `+65${String(Date.now()).slice(-8)}`, name: 'Ext Buyer' })
+  await createTestProspect(campaign.id, { firstName: 'Ext-Assigned', externalAgentId: extBuyer.id })
 
   await createTestQrTag(campaign.id, admin.id, { scanCount: 90 })
 
@@ -232,6 +237,30 @@ describe('B5 — GET /api/prospects multi-select + sort', () => {
     expect(res.body.data.prospects).toHaveLength(0)
   })
 
+  it('assignment filters see BOTH assignee FKs (external-assigned is never "unassigned")', async () => {
+    const assigned = await request(app)
+      .get('/api/prospects?assignment=assigned&limit=100')
+      .set('Authorization', `Bearer ${adminToken}`)
+    expect(assigned.body.data.prospects.map((p) => p.firstName)).toContain('Ext-Assigned')
+
+    const unassigned = await request(app)
+      .get('/api/prospects?assignment=unassigned&limit=100')
+      .set('Authorization', `Bearer ${adminToken}`)
+    const names = unassigned.body.data.prospects.map((p) => p.firstName)
+    expect(names).toContain('Aa-Unassigned')
+    expect(names).not.toContain('Ext-Assigned')
+  })
+
+  it('assignment=assigned composes with search (Op.or collision guard)', async () => {
+    const res = await request(app)
+      .get('/api/prospects?assignment=assigned&search=Zz-Won&limit=50')
+      .set('Authorization', `Bearer ${adminToken}`)
+    expect(res.status).toBe(200)
+    const names = res.body.data.prospects.map((p) => p.firstName)
+    expect(names).toContain('Zz-Won')
+    expect(names).not.toContain('Ext-Assigned') // search still narrows
+  })
+
   it('sort=firstName orders ascending; junk sort falls back to -createdAt', async () => {
     const asc = await request(app)
       .get('/api/prospects?sort=firstName&limit=100')
@@ -256,11 +285,13 @@ describe('B6 — campaign aggregates', () => {
     expect(res.status).toBe(200)
     const rows = res.body.data.campaigns
     const covered = rows.find((c) => c.id === pricedCoveredCampaign.id)
-    expect(Number(covered.committedRemaining)).toBe(3)
-    expect(Number(covered.committedValueCents)).toBe(2400)
+    // JSON numbers, not pg-bigint strings — asserted WITHOUT coercion.
+    expect(covered.committedRemaining).toBe(3)
+    expect(covered.committedValueCents).toBe(2400)
     const main = rows.find((c) => c.id === campaign.id)
-    expect(Number(main.leadsThisPeriod)).toBeGreaterThanOrEqual(6) // 10d-old row outside 7d
-    expect(Number(main.prospectCount)).toBeGreaterThanOrEqual(7)   // all-time key untouched
+    expect(main.leadsThisPeriod).toBeGreaterThanOrEqual(6) // 10d-old row outside 7d
+    expect(main.leadsTotal).toBeGreaterThanOrEqual(7)      // Phase C contract key
+    expect(Number(main.prospectCount)).toBeGreaterThanOrEqual(7) // legacy key untouched
   })
 
   it('GET /api/campaigns/:id/summary is admin-only and composes the detail payload', async () => {
@@ -295,13 +326,16 @@ describe('B7 — GET /api/agents roster aggregates', () => {
     expect(res.status).toBe(200)
     const rows = res.body.data.agents
     const internal = rows.find((a) => a.id === agent.id)
-    expect(Number(internal.assignedThisPeriod)).toBeGreaterThanOrEqual(3)
+    expect(internal.assignedThisPeriod).toBeGreaterThanOrEqual(3)
     expect(internal.lastAssignedAt).toBeTruthy()
-    expect(Number(internal.committedLeads)).toBe(0)
+    // Internal agents have no wallet — null, never a misleading 0.
+    expect(internal.walletBalanceCents).toBeNull()
+    expect(internal.committedLeads).toBeNull()
+    expect(internal.committedValueCents).toBeNull()
 
     const external = rows.find((a) => a.id === externalAgent.id)
     expect(external.walletBalanceCents).toBe(2500)
-    expect(Number(external.committedLeads)).toBe(3)
-    expect(Number(external.committedValueCents)).toBe(2400)
+    expect(external.committedLeads).toBe(3)
+    expect(external.committedValueCents).toBe(2400)
   })
 })

--- a/backend/test/unit/dashboardService.test.js
+++ b/backend/test/unit/dashboardService.test.js
@@ -49,6 +49,17 @@ function buildMocks() {
     count: jest.fn().mockResolvedValue(42),
   };
 
+  // Phase B (attention/committed aggregates) deps — inert defaults.
+  const WebhookDelivery = {
+    count: jest.fn().mockResolvedValue(0),
+  };
+  const WebhookSubscriber = {
+    count: jest.fn().mockResolvedValue(0),
+  };
+  const LeadPackageAssignment = {
+    findAll: jest.fn().mockResolvedValue([]),
+  };
+
   const sequelize = {
     query: jest.fn().mockResolvedValue([[]]),
     fn: jest.fn((fnName, col) => `${fnName}(${col})`),
@@ -59,6 +70,7 @@ function buildMocks() {
   return {
     User, Campaign, Prospect, QrTag, Commission,
     Car, Driver, FleetOwner, Impression, sequelize,
+    WebhookDelivery, WebhookSubscriber, LeadPackageAssignment,
   };
 }
 
@@ -78,6 +90,9 @@ beforeEach(async () => {
     Driver: mocks.Driver,
     FleetOwner: mocks.FleetOwner,
     Impression: mocks.Impression,
+    WebhookDelivery: mocks.WebhookDelivery,
+    WebhookSubscriber: mocks.WebhookSubscriber,
+    LeadPackageAssignment: mocks.LeadPackageAssignment,
     sequelize: mocks.sequelize,
   }));
 

--- a/docs/plans/mktr-admin-rebuild-implementation.md
+++ b/docs/plans/mktr-admin-rebuild-implementation.md
@@ -159,7 +159,10 @@ straight to the service): `sort` param — whitelist
 `leadSource` accept comma-lists (`IN` filter), single value stays
 backward-compatible. Comma-list handling: split, trim, dedupe, whitelist
 every token against the enum and DROP invalid tokens (never let an unknown
-string reach a Postgres enum cast → 500); all-invalid ⇒ ignore the filter.
+string reach a Postgres enum cast → 500); **all-invalid ⇒ EMPTY PAGE** — the
+long-standing single-value degrade semantic. (Amended at implementation:
+"ignore the filter" would silently show everything when the caller asked to
+narrow — an explicitly typed filter must never widen the result.)
 
 ### B6. Campaign aggregates:
 - Extend the admin campaigns list payload with `leadsThisPeriod`,
@@ -348,6 +351,22 @@ Phased per the standing direction (hide → dark-flag → drop models later):
   the existing package join (regression-tested).
 
 ---
+
+## Codex review log — Phase B post-implementation (2026-07-15, gpt-5.6-sol xhigh)
+
+Verdict "not merge-ready" on 4 MAJORs / 3 MINORs; core plumbing (period-keyed
+cache, SGT alignment, injection surface, raw-include key, additive envelopes,
+summary auth) explicitly confirmed sound. All verified and resolved:
+
+| # | Finding | Disposition |
+|---|---|---|
+| 1 | Campaign list missing the contract's `leadsTotal` key | Fixed — `leadsTotal` literal added; legacy `prospectCount` untouched |
+| 2 | `assignment=assigned/unassigned` ignored `externalAgentId` | Fixed — both FKs, composed under `Op.and` so the search `Op.or` never collides; collision regression test added |
+| 3 | All-invalid enum list: plan said "ignore filter", code returns empty page | **Plan text amended** — empty page is the deliberate semantic (a typed filter must never silently widen) |
+| 4 | Internal agents got wallet `0`s instead of `null` | Fixed in the DTO (`computeAgentStatsFromCounts`) — null for non-external, numbers for external |
+| 5 | Attention wallet cohort excluded inactive external agents (money vanishes from float) | Fixed — full cohort; zero/low entries carry `isActive` for UI badging |
+| 6 | Aggregate JSON types inconsistent (pg bigint strings) | Fixed — all new aggregates cast `::int` (bounds documented); tests assert types WITHOUT coercion |
+| 7 | Missing composite indexes for the period aggregates | Migration 072: prospects (campaignId, createdAt) + (assignedAgentId, createdAt) + partial open-wallet-assignment index, mirrored on models |
 
 ## Codex review log (round 1 — 2026-07-15, gpt-5.6-sol xhigh)
 


### PR DESCRIPTION
## What

Phase B (PR2) of `docs/plans/mktr-admin-rebuild-implementation.md` — the **data layer the Switchboard admin rebuild consumes**. All additive and unflagged: every existing response key keeps its exact semantics, new keys ride alongside.

### Endpoints & extensions

| Piece | Change |
|---|---|
| **B1** `GET /api/dashboard/overview` | `prospects` gains period-scoped `periodTotal` / `assigned` (either assignee FK) / `converted` (won, by `conversionDate`) / `conversionRate`. **Fixes a live bug**: the admin stats cache was one global slot regardless of period — a 7d request within 30s of a 90d request served 90d numbers. Now keyed by period. |
| **B2** `GET /api/dashboard/attention` (admin) | Structured aggregates: webhook health, held grouped over **all five** real quarantine reasons + `other` (total always reconciles), unassigned (both FKs null AND not held), zero-commitment incidents (active + priced with no open funded assignment — wallet OR package), external-agent wallets (zero / low < S$50 / float — **inactive agents included**, money never vanishes), committed demand, draws closing ≤7d (SGT end-of-day), plain endings ≤7d (draws excluded). |
| **B3** `GET /api/dashboard/series` (admin) | Daily lead counts in SGT-midnight buckets (one grouped query at `Asia/Singapore`), `isToday`, `avgPerDay` excluding the partial today. |
| **B4** `GET /api/dashboard/funnel` (admin) | scans→submits→assigned→won; lifetime QR scans prorated, **floored at submits**, flagged `estimated: true`. |
| **B5** `GET /api/prospects` | `sort` whitelist (`firstName\|leadStatus\|createdAt`, `-` prefix, junk → default) + comma-list `leadStatus`/`leadSource` (tokens whitelisted — nothing unknown reaches a Postgres enum cast; all-invalid → empty page, the long-standing degrade). `assignment=assigned/unassigned` now sees **both** assignee FKs. |
| **B6** `GET /api/campaigns` | Validated `period` + `leadsTotal`, `leadsThisPeriod`, `committedRemaining`, `committedValueCents` (grouped subqueries, `::int` JSON numbers). New `GET /api/campaigns/:id/summary` (admin): campaign + 30d SGT series + open wallet commitments + latest leads + QR tags in one round-trip. |
| **B7** `GET /api/agents` | Validated `period` + `assignedThisPeriod`, `lastAssignedAt`, wallet columns — **null for internal agents** (UI renders "—"), numbers for external. |
| **Migration 072** | Composite indexes for the period aggregates: prospects `(campaignId, createdAt)` + `(assignedAgentId, createdAt)`, partial open-wallet-assignment index. Mirrored on models. |

## Review

Post-implementation Codex review (gpt-5.6-sol xhigh): 4 MAJORs + 3 MINORs, all verified against code — six fixed in `42abb4e` (leadsTotal contract key, both-FK assignment filter with an `Op.and` collision guard, null wallet columns for internal agents, inactive-inclusive wallet cohort, `::int` JSON types asserted without coercion, the 072 indexes); one resolved by amending the **plan** (all-invalid filter → empty page is the deliberate semantic — a typed filter must never silently widen). Core plumbing (cache keying, SGT alignment, injection surface, additive envelopes, summary auth) explicitly confirmed sound. Full log in the plan doc.

## Tests

New `adminDashboardExtensions` suite — 15 DB-backed contract cases (cache period-keying, five-reason held reconciliation, zero-commit covered-vs-uncovered, SGT buckets, funnel floor, comma-list + sort, both-FK assignment + search-collision guard, summary composite + 403, roster aggregates incl. null-vs-number wallet columns). Full backend suite in two shards: failure set = exactly the 7 pre-existing chronic reds. **Zero regressions.**

## After merge

Deploy is inert-additive (migration 072 = three CREATE INDEX IF NOT EXISTS). Unblocks **Phase C** — the Switchboard UI rebuild behind `VITE_ADMIN_V2_ENABLED`, which consumes exactly these contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)