### PR TITLE
feat(admin-v2): Switchboard shell + Dashboard + Prospects (dark, Phase C PR3)

### DIFF
--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -1,5 +1,5 @@
 import { randomUUID, createHash } from 'crypto';
-import { Op, Transaction } from 'sequelize';
+import { Op, Transaction, fn as sqlFn, col as sqlCol, where as sqlWhere } from 'sequelize';
 import {
   Prospect,
   User,
@@ -1605,6 +1605,11 @@ export function makeProspectService(overrides = {}) {
         // a bare Op.ne would also exclude unassigned NULL rows). Re-assigning a
         // no-op row used to double-charge the agent for a lead they already held.
         { [Op.or]: [{ assignedAgentId: null }, { assignedAgentId: { [Op.ne]: agentId } }] },
+        // External-buyer-owned rows are fenced: assignedAgentId and
+        // externalAgentId are mutually exclusive owners, and writing the
+        // internal FK without clearing the external one would double-own the
+        // lead. Transfers from the external pool are not a bulk operation.
+        { externalAgentId: null },
       ],
     };
 
@@ -1638,7 +1643,7 @@ export function makeProspectService(overrides = {}) {
       // classification matches what the locked UPDATE saw.
       requestedRows = await m.Prospect.findAll({
         where: { id: { [Op.in]: requestedIds }, ...scopeFilter },
-        attributes: ['id', 'assignedAgentId', 'quarantinedAt', 'quarantineReason'],
+        attributes: ['id', 'assignedAgentId', 'externalAgentId', 'quarantinedAt', 'quarantineReason'],
         transaction,
       });
     });
@@ -1649,7 +1654,7 @@ export function makeProspectService(overrides = {}) {
     // Skip accounting for the UI toast: classify every requested id that did NOT change.
     // (Post-UPDATE snapshot: affected rows are classified off the pre-UPDATE lock set.)
     const requestedById = new Map(requestedRows.map((r) => [r.id, r]));
-    const skipped = { notFound: 0, alreadyAssigned: 0, heldFenced: 0 };
+    const skipped = { notFound: 0, alreadyAssigned: 0, heldFenced: 0, externalOwned: 0 };
     let releasedCount = 0;
     for (const id of requestedIds) {
       if (lockedById.has(id)) {
@@ -1658,6 +1663,7 @@ export function makeProspectService(overrides = {}) {
       }
       const row = requestedById.get(id);
       if (!row) skipped.notFound += 1;
+      else if (row.externalAgentId) skipped.externalOwned += 1;
       else if (row.quarantinedAt && !RELEASABLE_HOLD_REASONS.includes(row.quarantineReason)) skipped.heldFenced += 1;
       else skipped.alreadyAssigned += 1;
     }
@@ -1902,6 +1908,13 @@ export function makeProspectService(overrides = {}) {
         { lastName: { [likeOp]: `%${sanitizedSearch}%` } },
         { email: { [likeOp]: `%${sanitizedSearch}%` } },
         { company: { [likeOp]: `%${sanitizedSearch}%` } },
+        // Phone matches ignore spacing (stored "+65 9231 8804", operators type
+        // digits) — strip spaces on both sides of the comparison. Sequelize
+        // STATICS (not instance methods) so DI-mocked unit suites stay valid.
+        sqlWhere(
+          sqlFn('REPLACE', sqlCol('Prospect.phone'), ' ', ''),
+          { [likeOp]: `%${sanitizedSearch.replace(/\s+/g, '')}%` }
+        ),
       ];
     }
 
@@ -2422,6 +2435,10 @@ export function makeProspectService(overrides = {}) {
     // ── Promotion arm (web-admin only): an unassigned, unheld stray joins the held pool.
     // No webhook — it has no owner app copy to vanish. Conditional UPDATE = race-safe.
     if (!previousAgentId) {
+      // External-buyer-owned rows are NOT strays: externalAgentId is the other
+      // mutually-exclusive owner FK, and quarantining such a row would hold a
+      // lead an external buyer already paid for and holds a copy of.
+      if (prospect.externalAgentId) return { status: 'undeliverable' };
       if (!promoteUnassigned) return { status: 'already_handled' };
       const pt = await d.sequelize.transaction();
       try {

--- a/backend/test/adminDashboardExtensions.test.js
+++ b/backend/test/adminDashboardExtensions.test.js
@@ -19,7 +19,7 @@ const DAY_MS = 24 * 3600e3
 
 let app, admin, adminToken, agent, agentToken, externalAgent
 let campaign, pricedCoveredCampaign, pricedUncoveredCampaign, drawCampaign
-let walletPkg, walletAssignment
+let walletPkg, walletAssignment, extProspect
 
 beforeAll(async () => {
   app = await getApp()
@@ -79,7 +79,7 @@ beforeAll(async () => {
   // Externally-assigned prospect (the SECOND assignee FK): must count as
   // "assigned", never appear under "unassigned".
   const extBuyer = await ExternalAgent.create({ phone: `+65${String(Date.now()).slice(-8)}`, name: 'Ext Buyer' })
-  await createTestProspect(campaign.id, { firstName: 'Ext-Assigned', externalAgentId: extBuyer.id })
+  extProspect = await createTestProspect(campaign.id, { firstName: 'Ext-Assigned', externalAgentId: extBuyer.id })
 
   await createTestQrTag(campaign.id, admin.id, { scanCount: 90 })
 
@@ -249,6 +249,32 @@ describe('B5 — GET /api/prospects multi-select + sort', () => {
     const names = unassigned.body.data.prospects.map((p) => p.firstName)
     expect(names).toContain('Aa-Unassigned')
     expect(names).not.toContain('Ext-Assigned')
+  })
+
+  it('bulk assign FENCES external-buyer-owned rows (ownership invariant)', async () => {
+    const res = await request(app)
+      .patch('/api/prospects/bulk/assign')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ prospectIds: [extProspect.id], agentId: agent.id })
+    expect(res.status).toBe(200)
+    expect(res.body.data.affectedCount).toBe(0)
+    expect(res.body.data.skipped.externalOwned).toBe(1)
+
+    await extProspect.reload()
+    expect(extProspect.assignedAgentId).toBeNull() // never double-owned
+    expect(extProspect.externalAgentId).not.toBeNull()
+  })
+
+  it('bulk return-to-held never quarantines an external-buyer-owned row', async () => {
+    const res = await request(app)
+      .patch('/api/prospects/bulk/return-to-held')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ prospectIds: [extProspect.id] })
+    expect(res.status).toBe(200)
+    expect(res.body.data.returned).toBe(0)
+
+    await extProspect.reload()
+    expect(extProspect.quarantinedAt).toBeNull()
   })
 
   it('assignment=assigned composes with search (Op.or collision guard)', async () => {

--- a/backend/test/prospectServiceBulkOps.test.js
+++ b/backend/test/prospectServiceBulkOps.test.js
@@ -111,7 +111,7 @@ describe('bulkAssignProspects — held release, batch context, skip accounting',
 
     expect(res.affectedCount).toBe(2);
     expect(res.releasedCount).toBe(1);
-    expect(res.skipped).toEqual({ notFound: 0, alreadyAssigned: 0, heldFenced: 0 });
+    expect(res.skipped).toEqual({ notFound: 0, alreadyAssigned: 0, heldFenced: 0, externalOwned: 0 });
 
     // The atomic UPDATE clears the hold alongside the assignment.
     const updateArgs = deps.models.Prospect.update.mock.calls[0][0];
@@ -155,7 +155,7 @@ describe('bulkAssignProspects — held release, batch context, skip accounting',
     const res = await svc.bulkAssignProspects(['p-dnc', 'p-ext', 'p-mine', 'p-gone'], 'agent-1', ADMIN);
 
     expect(res.affectedCount).toBe(0);
-    expect(res.skipped).toEqual({ notFound: 1, alreadyAssigned: 1, heldFenced: 2 });
+    expect(res.skipped).toEqual({ notFound: 1, alreadyAssigned: 1, heldFenced: 2, externalOwned: 0 });
     expect(deps.dispatchEvent).not.toHaveBeenCalled();
   });
 

--- a/backend/test/prospects.test.js
+++ b/backend/test/prospects.test.js
@@ -558,7 +558,7 @@ describe('Bulk return-to-held / bulk delete / assignment filter', () => {
 
     expect(res.status).toBe(200)
     expect(res.body.data.affectedCount).toBe(0)
-    expect(res.body.data.skipped).toEqual({ notFound: 1, alreadyAssigned: 1, heldFenced: 0 })
+    expect(res.body.data.skipped).toEqual({ notFound: 1, alreadyAssigned: 1, heldFenced: 0, externalOwned: 0 })
   })
 
   it('POST /bulk/delete — deletes rows, counts unknown ids, never aborts the batch', async () => {

--- a/backend/test/unit/prospectService.test.js
+++ b/backend/test/unit/prospectService.test.js
@@ -838,7 +838,7 @@ describe('prospectService (unit)', () => {
       // Op.or should contain iLike conditions
       const orConditions = whereArg[Op.or];
       expect(orConditions).toBeDefined();
-      expect(orConditions).toHaveLength(4); // firstName, lastName, email, company
+      expect(orConditions).toHaveLength(5); // firstName, lastName, email, company + space-insensitive phone
 
       // Verify at least one uses iLike pattern
       const firstCondition = orConditions[0];

--- a/backend/test/unit/securityRemediation.test.js
+++ b/backend/test/unit/securityRemediation.test.js
@@ -117,10 +117,12 @@ describe('LIKE injection protection (prospectService.listProspects)', () => {
     await service.listProspects({ id: 'user-1', role: 'admin' }, { search: 'test' });
 
     const orClause = capturedWhere[Op.or];
-    expect(orClause).toHaveLength(4);
+    expect(orClause).toHaveLength(5); // + space-insensitive phone (sequelize.where AST)
 
-    const fieldNames = orClause.map((condition) => Object.keys(condition)[0]);
+    const fieldNames = orClause.slice(0, 4).map((condition) => Object.keys(condition)[0]);
     expect(fieldNames).toEqual(['firstName', 'lastName', 'email', 'company']);
+    // The fifth entry is the REPLACE(phone) comparison — still iLike-escaped.
+    expect(orClause[4].attribute).toMatchObject({ fn: 'REPLACE' });
   });
 
   it('does not add search conditions when search param is absent', async () => {

--- a/docs/plans/mktr-admin-rebuild-implementation.md
+++ b/docs/plans/mktr-admin-rebuild-implementation.md
@@ -352,6 +352,28 @@ Phased per the standing direction (hide → dark-flag → drop models later):
 
 ---
 
+## Codex review log — Phase C PR3 post-implementation (2026-07-15, gpt-5.6-sol xhigh)
+
+1 BLOCKER / 7 MAJOR / 6 MINOR; verdict confirmed flag-off leaves legacy chunks
+untouched and the adapters faithful. Dispositions (all verified first):
+
+| # | Finding | Disposition |
+|---|---|---|
+| 1 | BLOCKER: bulk assign/return could double-own or quarantine EXTERNAL-buyer leads (backend hole, made reachable by the new UI) | **Backend fixed** — `externalAgentId IS NULL` fence in bulkAssign's WHERE + `skipped.externalOwned` accounting; return-to-held promotion arm returns `undeliverable` for external-owned rows. Two DB-backed fence tests. UI labels external rows ("External" chip / "external buyer" in drawer) |
+| 2 | Legacy `?campaign=` / `?qrTagId=` deep links ignored | Fixed — read/pass/removable chips |
+| 3 | Debounce race + back/forward desync | Fixed — functional `setSearchParams` in the timer + draft resync when q changes externally |
+| 4 | Toasts reported assumed counts | Fixed (pre-review commit + refined) — server counts incl. summed `skipped` object; zero-work warns |
+| 5 | Bulk delete leaves a live Lyfe-app orphan | **Accepted parity** — the legacy web admin exposes the same delete with the same documented backend limitation; `lead.deleted` propagation is a backend fast-follow, not a UI gate |
+| 6 | Leaderboard zero-commit drifted from the server definition | Fixed — consumes `attention.zeroCommitCampaigns` (authoritative). Top-6-of-newest-100 window accepted at current scale |
+| 7 | Disabled subscriber displayed "Healthy" | Fixed — value prioritizes "Subscriber disabled" |
+| 8 | Row keyboard semantics | Fixed targeted (Space activates, checkbox keydown never bubbles); full grid/columnheader semantics deferred to PR4 polish |
+| 9 | Search placeholder promised phone | **Backend delivers it** — space-insensitive phone iLike added to listProspects search |
+| 10 | Drawer skips detail endpoint + consent | Consent section added (submit-flag display mapping from sourceMetadata — the list rows already carry every drawer field); activities/detail fetch lands with PR4's drawer story |
+| 11 | Partial-payload NaN guards | Fixed — series/funnel normalized defensively |
+| 12 | CSV guard missed leading whitespace/control chars | Fixed + test |
+| 13 | Double sonner Toaster | Fixed — App.jsx's global instance is the only mount |
+| 14 | /AdminWallets registered flag-off | Fixed — route exists only when ADMIN_V2 |
+
 ## Codex review log — Phase B post-implementation (2026-07-15, gpt-5.6-sol xhigh)
 
 Verdict "not merge-ready" on 4 MAJORs / 3 MINORs; core plumbing (period-keyed

--- a/src/api/adminV2.js
+++ b/src/api/adminV2.js
@@ -1,0 +1,78 @@
+/**
+ * Switchboard admin v2 data layer — thin fetchers over the authed apiClient,
+ * one per Phase B contract (docs/plans/mktr-admin-rebuild-implementation.md).
+ * Adapters unwrap each endpoint's REAL envelope and normalize list results to
+ * { rows, total } so table components never learn per-endpoint shapes.
+ */
+import { apiClient } from '@/api/client';
+
+export async function fetchOverview(period) {
+  const resp = await apiClient.get(`/dashboard/overview?period=${encodeURIComponent(period)}`);
+  return resp?.data?.stats ?? null;
+}
+
+export async function fetchAttention() {
+  const resp = await apiClient.get('/dashboard/attention');
+  return resp?.data ?? null;
+}
+
+export async function fetchSeries(period) {
+  const resp = await apiClient.get(`/dashboard/series?period=${encodeURIComponent(period)}`);
+  return resp?.data ?? null;
+}
+
+export async function fetchFunnel(period) {
+  const resp = await apiClient.get(`/dashboard/funnel?period=${encodeURIComponent(period)}`);
+  return resp?.data ?? null;
+}
+
+/**
+ * Prospects list. params: { page, limit, leadStatus (csv), leadSource (csv),
+ * assignment ('held'|'unassigned'|'assigned'), search, sort, campaignId }.
+ * Returns { rows, total, page, totalPages }.
+ */
+export async function fetchProspects(params = {}) {
+  const qs = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined && v !== null && v !== '') qs.set(k, v);
+  }
+  const resp = await apiClient.get(`/prospects?${qs.toString()}`);
+  const data = resp?.data ?? {};
+  return {
+    rows: data.prospects || [],
+    total: data.pagination?.totalItems ?? 0,
+    page: data.pagination?.currentPage ?? 1,
+    totalPages: data.pagination?.totalPages ?? 0,
+  };
+}
+
+/** Campaign leaderboard source — extended admin list (B6). */
+export async function fetchCampaignsList(period) {
+  const resp = await apiClient.get(`/campaigns?period=${encodeURIComponent(period)}&limit=100`);
+  const data = resp?.data ?? {};
+  return { rows: data.campaigns || [], total: data.pagination?.totalItems ?? (data.campaigns || []).length };
+}
+
+/** Agent picker for the bulk assign action (staff-facing lightweight list). */
+export async function fetchAgentOptions() {
+  const resp = await apiClient.get('/agents?limit=200&status=active');
+  const data = resp?.data ?? {};
+  return (data.agents || []).map((a) => ({
+    id: a.id,
+    name: a.fullName || `${a.firstName || ''} ${a.lastName || ''}`.trim() || a.email,
+  }));
+}
+
+// ── Bulk actions (existing endpoints — wired LIVE, not stubbed) ──────────────
+
+export function bulkAssign(prospectIds, agentId) {
+  return apiClient.patch('/prospects/bulk/assign', { prospectIds, agentId });
+}
+
+export function bulkReturnToHeld(prospectIds) {
+  return apiClient.patch('/prospects/bulk/return-to-held', { prospectIds });
+}
+
+export function bulkDelete(prospectIds) {
+  return apiClient.post('/prospects/bulk/delete', { prospectIds });
+}

--- a/src/components/adminv2/AdminV2Shell.jsx
+++ b/src/components/adminv2/AdminV2Shell.jsx
@@ -1,0 +1,131 @@
+/**
+ * Switchboard shell — fixed 228px sidebar with the rebuilt IA (no fleet /
+ * finance / APK slots by design), 64px sticky topbar, [data-theme] dark swap
+ * persisted to localStorage. Wraps every v2 admin screen; legacy pages keep
+ * their own shell until their PR lands.
+ */
+import { useEffect, useState } from 'react';
+import { NavLink, useNavigate } from 'react-router-dom';
+import { useAuthStore } from '@/stores/authStore';
+import { Toaster } from '@/components/ui/sonner';
+import '@/styles/adminV2.css';
+
+const THEME_KEY = 'mktr_admin_v2_theme';
+
+const NAV = [
+  {
+    label: 'Overview',
+    items: [{ to: '/AdminDashboard', label: 'Dashboard', glyph: '◳' }],
+  },
+  {
+    label: 'Lead Generation',
+    items: [
+      { to: '/AdminProspects', label: 'Prospects', glyph: '☰' },
+      { to: '/AdminCampaigns', label: 'Campaigns', glyph: '▶' },
+      { to: '/AdminAgents', label: 'Agents', glyph: '◉' },
+      { to: '/AdminAgentGroups', label: 'Agent Groups', glyph: '◎' },
+      { to: '/AdminWallets', label: 'Wallets & Commitments', glyph: '▣' },
+      { to: '/AdminQRCodes', label: 'QR Codes', glyph: '⊞' },
+      { to: '/AdminShortLinks', label: 'Short Links', glyph: '⤳' },
+    ],
+  },
+  {
+    label: 'System',
+    items: [
+      { to: '/AdminUsers', label: 'Users', glyph: '⚉' },
+      { to: '/AdminAISettings', label: 'AI Settings', glyph: '✳' },
+    ],
+  },
+];
+
+export function useAdminV2Theme() {
+  const [theme, setTheme] = useState(() => localStorage.getItem(THEME_KEY) || 'light');
+  useEffect(() => {
+    localStorage.setItem(THEME_KEY, theme);
+  }, [theme]);
+  return [theme, setTheme];
+}
+
+export default function AdminV2Shell({ children }) {
+  const [theme, setTheme] = useAdminV2Theme();
+  const navigate = useNavigate();
+  const logout = useAuthStore((s) => s.logout);
+  const user = useAuthStore((s) => s.user);
+
+  const handleSignOut = async () => {
+    try {
+      await logout?.();
+    } finally {
+      navigate('/CustomerLogin');
+    }
+  };
+
+  return (
+    <div className="admin-v2" data-theme={theme}>
+      <div style={{ display: 'flex', minHeight: '100vh' }}>
+        {/* ── Sidebar (228px fixed) ── */}
+        <aside
+          style={{
+            width: 228, flex: 'none', background: 'var(--surface)',
+            borderRight: '1px solid var(--line)', padding: '16px 12px',
+            display: 'flex', flexDirection: 'column', gap: 4,
+            position: 'sticky', top: 0, height: '100vh', overflowY: 'auto',
+          }}
+        >
+          <div style={{ padding: '4px 12px 14px' }}>
+            <div style={{ fontSize: 17, fontWeight: 800, letterSpacing: '-0.02em' }}>MKTR</div>
+            <div className="av2-meta">ADMIN · SWITCHBOARD</div>
+          </div>
+          <nav className="av2-nav" aria-label="Admin">
+            {NAV.map((section) => (
+              <div key={section.label} style={{ marginBottom: 14 }}>
+                <div className="av2-microcaps" style={{ padding: '0 12px 6px' }}>{section.label}</div>
+                {section.items.map((item) => (
+                  <NavLink key={item.to} to={item.to}>
+                    <span aria-hidden="true" style={{ width: 16, textAlign: 'center', fontSize: 12 }}>{item.glyph}</span>
+                    {item.label}
+                  </NavLink>
+                ))}
+              </div>
+            ))}
+          </nav>
+          <div style={{ marginTop: 'auto', padding: '10px 12px 4px', borderTop: '1px solid var(--line)' }}>
+            <div className="av2-caption" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {user?.email || 'admin'}
+            </div>
+          </div>
+        </aside>
+
+        {/* ── Main column ── */}
+        <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
+          <div
+            style={{
+              height: 64, flex: 'none', position: 'sticky', top: 0, zIndex: 40,
+              display: 'flex', alignItems: 'center', gap: 12, padding: '0 24px',
+              background: 'var(--surface)', borderBottom: '1px solid var(--line)',
+            }}
+          >
+            <span className="av2-meta">MKTR LEAD GENERATION · {new Date().toLocaleDateString('en-SG', { day: 'numeric', month: 'short', year: 'numeric', timeZone: 'Asia/Singapore' }).toUpperCase()}</span>
+            <span style={{ flex: 1 }} />
+            <button
+              type="button"
+              className="av2-btn av2-btn--ghost av2-btn--sm"
+              onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+              aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} theme`}
+            >
+              {theme === 'dark' ? '☀ Light' : '☾ Dark'}
+            </button>
+            <button type="button" className="av2-btn av2-btn--sm" onClick={handleSignOut}>
+              Sign out
+            </button>
+          </div>
+
+          <main style={{ flex: 1, width: '100%', maxWidth: 1520, margin: '0 auto', padding: 24 }}>
+            {children}
+          </main>
+        </div>
+      </div>
+      <Toaster position="bottom-right" theme={theme} />
+    </div>
+  );
+}

--- a/src/components/adminv2/AdminV2Shell.jsx
+++ b/src/components/adminv2/AdminV2Shell.jsx
@@ -7,7 +7,6 @@
 import { useEffect, useState } from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
-import { Toaster } from '@/components/ui/sonner';
 import '@/styles/adminV2.css';
 
 const THEME_KEY = 'mktr_admin_v2_theme';
@@ -125,7 +124,8 @@ export default function AdminV2Shell({ children }) {
           </main>
         </div>
       </div>
-      <Toaster position="bottom-right" theme={theme} />
+      {/* Toasts render through the app-wide sonner Toaster (App.jsx) — a second
+          mount here would double-render every toast. */}
     </div>
   );
 }

--- a/src/components/adminv2/primitives.jsx
+++ b/src/components/adminv2/primitives.jsx
@@ -1,0 +1,87 @@
+/**
+ * Switchboard primitives — the small set of composable pieces every v2 screen
+ * uses. All token-driven via src/styles/adminV2.css; state is never color
+ * alone (glyph/label rides along).
+ */
+import { PERIODS } from '@/lib/adminV2/constants';
+
+export function Card({ title, meta, action, children, span, style }) {
+  return (
+    <section className="av2-card" style={{ gridColumn: span ? `span ${span}` : undefined, ...style }}>
+      {(title || action) && (
+        <div className="av2-card-head">
+          <h2 className="av2-h2" style={{ margin: 0, flex: 1 }}>{title}</h2>
+          {meta && <span className="av2-caption">{meta}</span>}
+          {action}
+        </div>
+      )}
+      {children}
+    </section>
+  );
+}
+
+export function Chip({ tone = '', children, glyph }) {
+  return (
+    <span className={`av2-chip ${tone ? `av2-chip--${tone}` : ''}`.trim()}>
+      {glyph && <span aria-hidden="true">{glyph}</span>}
+      {children}
+    </span>
+  );
+}
+
+export function PeriodSwitch({ value, onChange }) {
+  return (
+    <div className="av2-seg" role="group" aria-label="Period">
+      {PERIODS.map((p) => (
+        <button key={p} type="button" aria-pressed={value === p} onClick={() => onChange(p)}>
+          {p}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function Skeleton({ height = 32, width = '100%', style }) {
+  return <div className="av2-skeleton" aria-hidden="true" style={{ height, width, ...style }} />;
+}
+
+export function ErrorState({ error, onRetry }) {
+  return (
+    <div style={{ padding: '28px 16px', textAlign: 'center' }}>
+      <div className="av2-qicon" style={{ background: 'var(--bad-soft)', color: 'var(--bad)', margin: '0 auto 10px' }} aria-hidden="true">▲</div>
+      <div style={{ fontSize: 13.5, fontWeight: 700 }}>Couldn’t load this panel</div>
+      <div className="av2-mono" style={{ fontSize: 11, color: 'var(--ink-3)', marginTop: 4 }}>
+        {error?.message || 'Request failed'}
+      </div>
+      {onRetry && (
+        <button type="button" className="av2-btn av2-btn--sm" style={{ marginTop: 12 }} onClick={onRetry}>
+          Retry
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function EmptyState({ icon = '○', title, hint, action }) {
+  return (
+    <div style={{ padding: '28px 16px', textAlign: 'center' }}>
+      <div className="av2-qicon" style={{ background: 'var(--surface-2)', color: 'var(--ink-3)', margin: '0 auto 10px' }} aria-hidden="true">{icon}</div>
+      <div style={{ fontSize: 13.5, fontWeight: 700 }}>{title}</div>
+      {hint && <div className="av2-caption" style={{ marginTop: 4 }}>{hint}</div>}
+      {action && <div style={{ marginTop: 12 }}>{action}</div>}
+    </div>
+  );
+}
+
+/** Page header: title + mono meta line left, actions right (max one primary). */
+export function PageHeader({ title, meta, children }) {
+  return (
+    <header style={{ display: 'flex', alignItems: 'flex-end', gap: 16, flexWrap: 'wrap', marginBottom: 16 }}>
+      <div style={{ flex: 1, minWidth: 220 }}>
+        <h1 className="av2-h1" style={{ margin: 0 }}>{title}</h1>
+        {meta && <div className="av2-meta" style={{ marginTop: 4 }}>{meta}</div>}
+      </div>
+      {children}
+    </header>
+  );
+}

--- a/src/hooks/queries/useAdminV2.js
+++ b/src/hooks/queries/useAdminV2.js
@@ -1,0 +1,44 @@
+/**
+ * Switchboard admin v2 — react-query hooks. Query keys carry period/filters so
+ * period switches and filter changes are cache-correct by construction.
+ */
+import { useQuery } from '@tanstack/react-query';
+import {
+  fetchOverview, fetchAttention, fetchSeries, fetchFunnel,
+  fetchProspects, fetchCampaignsList, fetchAgentOptions,
+} from '@/api/adminV2';
+
+const STALE_MS = 30_000;
+
+export function useOverview(period) {
+  return useQuery({ queryKey: ['adminV2', 'overview', period], queryFn: () => fetchOverview(period), staleTime: STALE_MS });
+}
+
+export function useAttention() {
+  return useQuery({ queryKey: ['adminV2', 'attention'], queryFn: fetchAttention, staleTime: STALE_MS });
+}
+
+export function useSeries(period) {
+  return useQuery({ queryKey: ['adminV2', 'series', period], queryFn: () => fetchSeries(period), staleTime: STALE_MS });
+}
+
+export function useFunnel(period) {
+  return useQuery({ queryKey: ['adminV2', 'funnel', period], queryFn: () => fetchFunnel(period), staleTime: STALE_MS });
+}
+
+export function useProspects(params) {
+  return useQuery({
+    queryKey: ['adminV2', 'prospects', params],
+    queryFn: () => fetchProspects(params),
+    staleTime: 10_000,
+    keepPreviousData: true,
+  });
+}
+
+export function useCampaignLeaderboard(period) {
+  return useQuery({ queryKey: ['adminV2', 'campaigns', period], queryFn: () => fetchCampaignsList(period), staleTime: STALE_MS });
+}
+
+export function useAgentOptions(enabled) {
+  return useQuery({ queryKey: ['adminV2', 'agentOptions'], queryFn: fetchAgentOptions, staleTime: 300_000, enabled });
+}

--- a/src/lib/adminV2/__tests__/adminV2.test.js
+++ b/src/lib/adminV2/__tests__/adminV2.test.js
@@ -106,6 +106,16 @@ describe('prospectsToCsv', () => {
     expect(csv).toContain("\"'=HYPERLINK(\"\"http://evil\"\")\"");
   });
 
+  it('neutralizes formula markers hidden behind leading whitespace/control chars', () => {
+    for (const hostile of ['  =2+5', '\t+cmd', '\r@SUM(A1)']) {
+      const csv = prospectsToCsv([{ ...lead, firstName: hostile }]);
+      const cell = csv.split('\r\n')[1].split(',')[1];
+      // The stored cell must begin with the neutralizing apostrophe (possibly
+      // inside RFC-4180 quotes when the payload carries commas/CRs).
+      expect(cell.replace(/^"/, '').startsWith("'")).toBe(true);
+    }
+  });
+
   it('held rows carry the reason; assigned-held never both', () => {
     const csv = prospectsToCsv([{ ...lead, quarantinedAt: '2026-07-15T02:00:00Z', quarantineReason: 'dnc_pending', assignedAgent: null }]);
     expect(csv.split('\r\n')[1]).toContain('dnc_pending');

--- a/src/lib/adminV2/__tests__/adminV2.test.js
+++ b/src/lib/adminV2/__tests__/adminV2.test.js
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import { composeAttentionRows, composeHealthCells, SEVERITY_ORDER } from '../attention.js';
+import { prospectsToCsv } from '../csv.js';
+import { fmtSGD, fmtSGDExact, fmtDateTime, fmtRelative, daysUntil, fmtNumber } from '../format.js';
+import { HELD_REASON_LABELS, STATUS_LABELS, STATUS_CHIP_CLASS, SOURCE_LABELS, LEAD_STATUSES, LEAD_SOURCES } from '../constants.js';
+
+describe('constants — vocabulary completeness', () => {
+  it('every real lead status has a label and a chip mapping', () => {
+    for (const s of LEAD_STATUSES) {
+      expect(STATUS_LABELS[s]).toBeTruthy();
+      expect(STATUS_CHIP_CLASS[s]).not.toBeUndefined();
+    }
+  });
+
+  it('every real lead source has a label', () => {
+    for (const s of LEAD_SOURCES) expect(SOURCE_LABELS[s]).toBeTruthy();
+  });
+
+  it('all five real quarantine reasons + other have operator copy', () => {
+    for (const r of ['no_funded_agent', 'no_funded_external_buyer', 'dnc_pending', 'dnc_registered', 'returned_by_admin', 'other']) {
+      expect(HELD_REASON_LABELS[r]).toBeTruthy();
+    }
+  });
+});
+
+describe('composeAttentionRows — severity ordering + deep links', () => {
+  const fullPayload = {
+    webhooks: { pending: 3, failedLast24h: 2, subscriberDisabled: false },
+    held: { total: 3, byReason: { no_funded_agent: 2, dnc_pending: 1 } },
+    unassigned: 4,
+    zeroCommitCampaigns: [{ id: 'c9', name: 'Priced but empty', endsAt: null }],
+    wallets: { total: 5, zero: [{ id: 'a1', name: 'Melvin Tan' }], low: [{ id: 'a2', name: 'Siti Nur', balanceCents: 2500 }], floatCents: 2500 },
+    committed: { leads: 10, valueCents: 8000, campaigns: 2 },
+    drawsClosing: [{ id: 'c1', name: 'Tokyo Getaway Lucky Draw', closesAt: '2099-01-01', multiplier: 10, winners: 1 }],
+    endingCampaigns: [{ id: 'c2', name: 'Voucher Blitz', endsAt: new Date(Date.now() + 3 * 86400000).toISOString() }],
+  };
+
+  it('orders incident → held → warning → watch, always', () => {
+    const rows = composeAttentionRows(fullPayload);
+    const severities = rows.map((r) => SEVERITY_ORDER[r.severity]);
+    expect([...severities].sort((a, b) => a - b)).toEqual(severities);
+    expect(rows[0].severity).toBe('incident');
+    expect(rows[rows.length - 1].severity).toBe('watch');
+  });
+
+  it('held row aggregates reason copy and deep-links pre-filtered', () => {
+    const rows = composeAttentionRows(fullPayload);
+    const held = rows.find((r) => r.id === 'att-held');
+    expect(held.title).toBe('3 leads held');
+    expect(held.detail).toContain('2 no funded agent');
+    expect(held.detail).toContain('1 dnc check pending');
+    expect(held.href).toBe('/AdminProspects?assignment=held');
+  });
+
+  it('disabled subscriber is an incident even with zero failures', () => {
+    const rows = composeAttentionRows({ webhooks: { pending: 0, failedLast24h: 0, subscriberDisabled: true } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].severity).toBe('incident');
+    expect(rows[0].title).toContain('disabled');
+  });
+
+  it('a quiet day composes to an empty rail (never fake rows)', () => {
+    expect(composeAttentionRows({
+      webhooks: { pending: 0, failedLast24h: 0, subscriberDisabled: false },
+      held: { total: 0, byReason: {} }, unassigned: 0,
+      zeroCommitCampaigns: [], wallets: { zero: [], low: [], floatCents: 0 },
+      committed: {}, drawsClosing: [], endingCampaigns: [],
+    })).toEqual([]);
+    expect(composeAttentionRows(null)).toEqual([]);
+  });
+});
+
+describe('composeHealthCells', () => {
+  it('webhook cell turns bad on failures; float warns on zero wallets', () => {
+    const cells = composeHealthCells({
+      webhooks: { failedLast24h: 2, pending: 1, subscriberDisabled: false },
+      committed: { leads: 189, valueCents: 207000 },
+      wallets: { total: 5, zero: [{ id: 'a1' }], low: [], floatCents: 12400 },
+      held: { total: 3 },
+    });
+    expect(cells.find((c) => c.id === 'webhooks')).toMatchObject({ value: '2 failed', tone: 'bad' });
+    expect(cells.find((c) => c.id === 'committed').value).toBe('S$2,070');
+    expect(cells.find((c) => c.id === 'float')).toMatchObject({ value: 'S$124', tone: 'warn' });
+    expect(cells.find((c) => c.id === 'held')).toMatchObject({ value: '3', tone: 'hold' });
+  });
+});
+
+describe('prospectsToCsv', () => {
+  const lead = {
+    id: 'p-1', firstName: 'Xin Yi', lastName: 'Tan', email: 'x@t.co', phone: '+65 9231 8804',
+    leadStatus: 'new', leadSource: 'qr_code', createdAt: '2026-07-15T01:41:00Z',
+    campaign: { name: 'Tokyo, "Getaway"' }, assignedAgent: { firstName: 'Melvin', lastName: 'Tan' },
+    quarantinedAt: null, quarantineReason: null,
+  };
+
+  it('quotes RFC-4180 style and joins with CRLF', () => {
+    const csv = prospectsToCsv([lead]);
+    const [header, row] = csv.split('\r\n');
+    expect(header).toBe('id,first_name,last_name,email,phone,status,source,campaign,agent,held_reason,created_at');
+    expect(row).toContain('"Tokyo, ""Getaway"""');
+    expect(row).toContain('Melvin Tan');
+  });
+
+  it('neutralizes formula injection in hostile names', () => {
+    const csv = prospectsToCsv([{ ...lead, firstName: '=HYPERLINK("http://evil")' }]);
+    expect(csv).toContain("\"'=HYPERLINK(\"\"http://evil\"\")\"");
+  });
+
+  it('held rows carry the reason; assigned-held never both', () => {
+    const csv = prospectsToCsv([{ ...lead, quarantinedAt: '2026-07-15T02:00:00Z', quarantineReason: 'dnc_pending', assignedAgent: null }]);
+    expect(csv.split('\r\n')[1]).toContain('dnc_pending');
+  });
+});
+
+describe('formatters', () => {
+  it('fmtSGD rounds to whole dollars; exact keeps cents', () => {
+    expect(fmtSGD(207000)).toBe('S$2,070');
+    expect(fmtSGD(0)).toBe('S$0');
+    expect(fmtSGD(null)).toBe('—');
+    expect(fmtSGDExact(1250)).toBe('S$12.50');
+  });
+
+  it('fmtDateTime renders SGT regardless of host timezone', () => {
+    // 2026-07-15T01:41Z = 09:41 SGT
+    expect(fmtDateTime('2026-07-15T01:41:00Z')).toBe('15 Jul 09:41');
+  });
+
+  it('fmtRelative buckets sanely', () => {
+    const now = Date.parse('2026-07-15T10:00:00Z');
+    expect(fmtRelative('2026-07-15T09:59:40Z', now)).toBe('just now');
+    expect(fmtRelative('2026-07-15T09:41:00Z', now)).toBe('19m ago');
+    expect(fmtRelative('2026-07-14T10:00:00Z', now)).toBe('1d ago');
+  });
+
+  it('daysUntil parses YYYY-MM-DD as SGT end-of-day', () => {
+    const now = Date.parse('2026-07-15T00:00:00+08:00');
+    expect(daysUntil('2026-07-15', now)).toBe(1); // ends tonight SGT
+    expect(daysUntil('2026-07-18', now)).toBe(4);
+    expect(daysUntil('not-a-date', now)).toBeNull();
+  });
+
+  it('fmtNumber handles nullish', () => {
+    expect(fmtNumber(1024)).toBe('1,024');
+    expect(fmtNumber(undefined)).toBe('—');
+  });
+});

--- a/src/lib/adminV2/attention.js
+++ b/src/lib/adminV2/attention.js
@@ -1,0 +1,146 @@
+/**
+ * Compose the needs-attention queue from GET /api/dashboard/attention facts.
+ * The server returns aggregates only; copy + severity ordering live here
+ * (pure function, vitest-covered). Severity: incident → held → warning → watch.
+ * Every row deep-links pre-filtered — whole-row links, per the design.
+ */
+import { HELD_REASON_LABELS } from './constants.js';
+import { fmtSGD, daysUntil } from './format.js';
+
+export const SEVERITY_ORDER = { incident: 0, held: 1, warning: 2, watch: 3 };
+
+// Glyph + tone per severity (▲ incident/warning, ◆ held, ● watch — DS §4).
+export const SEVERITY_GLYPH = { incident: '▲', held: '◆', warning: '▲', watch: '●' };
+
+export function composeAttentionRows(data) {
+  if (!data) return [];
+  const rows = [];
+
+  const wh = data.webhooks || {};
+  if (wh.failedLast24h > 0 || wh.subscriberDisabled) {
+    rows.push({
+      id: 'att-webhooks',
+      severity: 'incident',
+      title: wh.subscriberDisabled
+        ? 'A Lyfe webhook subscriber is disabled'
+        : `${wh.failedLast24h} Lyfe deliveries failed in 24h`,
+      detail: `${wh.failedLast24h} failed · ${wh.pending || 0} pending in queue${wh.subscriberDisabled ? ' · subscriber disabled' : ''}`,
+      href: '/AdminProspects',
+      cta: 'Investigate',
+    });
+  }
+
+  for (const c of data.zeroCommitCampaigns || []) {
+    rows.push({
+      id: `att-zc-${c.id}`,
+      severity: 'incident',
+      title: `“${c.name}” has 0 open commitments`,
+      detail: 'New leads will quarantine (no funded agent)',
+      href: `/AdminCampaigns`,
+      cta: 'Review',
+    });
+  }
+
+  const held = data.held || { total: 0, byReason: {} };
+  if (held.total > 0) {
+    const parts = Object.entries(held.byReason || {})
+      .filter(([, n]) => n > 0)
+      .map(([reason, n]) => `${n} ${(HELD_REASON_LABELS[reason] || reason).toLowerCase()}`);
+    rows.push({
+      id: 'att-held',
+      severity: 'held',
+      title: `${held.total} lead${held.total === 1 ? '' : 's'} held`,
+      detail: parts.join(' · '),
+      href: '/AdminProspects?assignment=held',
+      cta: 'Triage',
+    });
+  }
+
+  if (data.unassigned > 0) {
+    rows.push({
+      id: 'att-unassigned',
+      severity: 'warning',
+      title: `${data.unassigned} lead${data.unassigned === 1 ? '' : 's'} unassigned`,
+      detail: 'Captured but not delivered · check commitments',
+      href: '/AdminProspects?assignment=unassigned',
+      cta: 'Review',
+    });
+  }
+
+  const w = data.wallets || {};
+  const zeroN = (w.zero || []).length;
+  const lowN = (w.low || []).length;
+  if (zeroN > 0 || lowN > 0) {
+    const names = [...(w.zero || []), ...(w.low || [])].map((a) => a.name.split(' ')[0]).slice(0, 4);
+    rows.push({
+      id: 'att-wallets',
+      severity: 'warning',
+      title: `${zeroN} wallet${zeroN === 1 ? '' : 's'} at S$0${lowN ? ` · ${lowN} below S$50` : ''}`,
+      detail: `${names.join(', ')}${names.length < zeroN + lowN ? '…' : ''} · can’t take new commitments`,
+      href: '/AdminWallets',
+      cta: 'View wallets',
+    });
+  }
+
+  for (const c of data.drawsClosing || []) {
+    const dd = daysUntil(c.closesAt);
+    rows.push({
+      id: `att-draw-${c.id}`,
+      severity: 'watch',
+      title: `${c.name.replace(' Lucky Draw', '')} draw closes in ${dd}d`,
+      detail: `${c.multiplier ? `×${c.multiplier} boost` : 'Draw'} · ${c.winners || 1} winner${(c.winners || 1) > 1 ? 's' : ''}`,
+      href: `/AdminCampaigns`,
+      cta: 'View draw',
+    });
+  }
+
+  for (const c of data.endingCampaigns || []) {
+    const dd = daysUntil(c.endsAt);
+    rows.push({
+      id: `att-end-${c.id}`,
+      severity: 'watch',
+      title: `“${c.name}” ends in ${dd}d`,
+      detail: 'Extend, archive, or let it lapse',
+      href: `/AdminCampaigns`,
+      cta: 'Review',
+    });
+  }
+
+  rows.sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]);
+  return rows;
+}
+
+/** Health-strip cells from the same payload (mono value + caption). */
+export function composeHealthCells(data) {
+  if (!data) return [];
+  const wh = data.webhooks || {};
+  const committed = data.committed || {};
+  const wallets = data.wallets || {};
+  const held = data.held || {};
+  return [
+    {
+      id: 'webhooks',
+      value: wh.failedLast24h > 0 ? `${wh.failedLast24h} failed` : 'Healthy',
+      caption: 'Lyfe webhooks · 24h',
+      tone: wh.failedLast24h > 0 || wh.subscriberDisabled ? 'bad' : 'ok',
+    },
+    {
+      id: 'committed',
+      value: fmtSGD(committed.valueCents || 0),
+      caption: `Committed demand · ${committed.leads || 0} leads pre-sold`,
+      tone: 'accent',
+    },
+    {
+      id: 'float',
+      value: fmtSGD(wallets.floatCents || 0),
+      caption: `Wallet float · ${wallets.total || 0} external agents`,
+      tone: (wallets.zero || []).length > 0 ? 'warn' : 'neutral',
+    },
+    {
+      id: 'held',
+      value: String(held.total || 0),
+      caption: 'Leads held',
+      tone: (held.total || 0) > 0 ? 'hold' : 'neutral',
+    },
+  ];
+}

--- a/src/lib/adminV2/attention.js
+++ b/src/lib/adminV2/attention.js
@@ -120,7 +120,8 @@ export function composeHealthCells(data) {
   return [
     {
       id: 'webhooks',
-      value: wh.failedLast24h > 0 ? `${wh.failedLast24h} failed` : 'Healthy',
+      // A disabled subscriber outranks failure counts — deliveries are OFF.
+      value: wh.subscriberDisabled ? 'Subscriber disabled' : wh.failedLast24h > 0 ? `${wh.failedLast24h} failed` : 'Healthy',
       caption: 'Lyfe webhooks · 24h',
       tone: wh.failedLast24h > 0 || wh.subscriberDisabled ? 'bad' : 'ok',
     },

--- a/src/lib/adminV2/constants.js
+++ b/src/lib/adminV2/constants.js
@@ -1,0 +1,68 @@
+/**
+ * Switchboard admin v2 — shared vocabulary. One map per enum so the queue,
+ * table chips and drawer never drift (design assumption: state is always
+ * glyph/label + color, never color alone).
+ */
+
+export const PERIODS = ['7d', '30d', '90d'];
+
+// Real prospect enums (Prospect model — verified in the design reconciliation).
+export const LEAD_STATUSES = ['new', 'contacted', 'qualified', 'proposal_sent', 'negotiating', 'won', 'lost', 'nurturing'];
+export const LEAD_SOURCES = ['qr_code', 'website', 'referral', 'social_media', 'advertisement', 'direct', 'call_bot', 'other'];
+
+export const STATUS_LABELS = {
+  new: 'New',
+  contacted: 'Contacted',
+  qualified: 'Qualified',
+  proposal_sent: 'Proposal sent',
+  negotiating: 'Negotiating',
+  won: '✓ Won',
+  lost: 'Lost',
+  nurturing: 'Nurturing',
+};
+
+// Mid-pipeline stays neutral; color is reserved for entry (new), terminal
+// (won/lost) and operator signals (held/unassigned) — DS §4.
+export const STATUS_CHIP_CLASS = {
+  new: 'av2-chip--accent',
+  contacted: '',
+  qualified: '',
+  proposal_sent: '',
+  negotiating: '',
+  won: 'av2-chip--ok',
+  lost: 'av2-chip--bad',
+  nurturing: '',
+};
+
+export const SOURCE_LABELS = {
+  qr_code: 'QR code',
+  website: 'Website',
+  referral: 'Referral',
+  social_media: 'Social',
+  advertisement: 'Ad',
+  direct: 'Direct',
+  call_bot: 'Call bot',
+  other: 'Other',
+};
+
+// ALL five real quarantine reasons + the reconciling `other` bucket
+// (attention endpoint contract — never render a raw enum at the operator).
+export const HELD_REASON_LABELS = {
+  no_funded_agent: 'No funded agent',
+  no_funded_external_buyer: 'No funded external buyer',
+  dnc_pending: 'DNC check pending',
+  dnc_registered: 'DNC-registered',
+  returned_by_admin: 'Returned by admin',
+  other: 'Other',
+};
+
+// utm_source → display label (matches the tracked ad platforms).
+export const UTM_LABELS = {
+  fb: 'Facebook',
+  ig: 'Instagram',
+  tiktok: 'TikTok',
+  an: 'Audience Network',
+  msg: 'Messenger',
+};
+
+export const PAGE_SIZE = 25;

--- a/src/lib/adminV2/csv.js
+++ b/src/lib/adminV2/csv.js
@@ -7,7 +7,10 @@
 function csvCell(value) {
   if (value === null || value === undefined) return '';
   let s = String(value);
-  if (/^[=+\-@]/.test(s)) s = `'${s}`;
+  // Formula markers can hide behind leading whitespace/control chars in
+  // spreadsheets - guard the first meaningful character, not position zero.
+  // eslint-disable-next-line no-control-regex
+  if (/^[\s\u0000-\u001F]*[=+\-@]/.test(s)) s = `'${s}`;
   if (/[",\n\r]/.test(s)) s = `"${s.replace(/"/g, '""')}"`;
   return s;
 }

--- a/src/lib/adminV2/csv.js
+++ b/src/lib/adminV2/csv.js
@@ -1,0 +1,46 @@
+/**
+ * Client-side CSV export for the Prospects table (selection or current page).
+ * RFC-4180 quoting; formula-injection guarded (a leading =+-@ gets a ' prefix
+ * so a hostile lead name can never execute in Excel/Sheets).
+ */
+
+function csvCell(value) {
+  if (value === null || value === undefined) return '';
+  let s = String(value);
+  if (/^[=+\-@]/.test(s)) s = `'${s}`;
+  if (/[",\n\r]/.test(s)) s = `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+const COLUMNS = [
+  ['id', (p) => p.id],
+  ['first_name', (p) => p.firstName],
+  ['last_name', (p) => p.lastName],
+  ['email', (p) => p.email],
+  ['phone', (p) => p.phone],
+  ['status', (p) => p.leadStatus],
+  ['source', (p) => p.leadSource],
+  ['campaign', (p) => p.campaign?.name ?? ''],
+  ['agent', (p) => (p.assignedAgent ? `${p.assignedAgent.firstName || ''} ${p.assignedAgent.lastName || ''}`.trim() : '')],
+  ['held_reason', (p) => (p.quarantinedAt ? (p.quarantineReason || 'held') : '')],
+  ['created_at', (p) => p.createdAt],
+];
+
+export function prospectsToCsv(prospects) {
+  const header = COLUMNS.map(([name]) => name).join(',');
+  const lines = (prospects || []).map((p) => COLUMNS.map(([, get]) => csvCell(get(p))).join(','));
+  return [header, ...lines].join('\r\n');
+}
+
+export function downloadCsv(filename, csvText) {
+  // \uFEFF BOM so Excel opens the UTF-8 file with names intact.
+  const blob = new Blob(['\uFEFF', csvText], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/src/lib/adminV2/format.js
+++ b/src/lib/adminV2/format.js
@@ -1,0 +1,64 @@
+/**
+ * Switchboard formatters — SGT timestamps, S$ amounts, mono-friendly numbers.
+ * Pure functions (vitest-covered); every numeral on screen flows through here.
+ */
+
+const SGT = 'Asia/Singapore';
+
+/** Cents → "S$1,234" (whole dollars — the UI rounds, the ledger stays exact). */
+export function fmtSGD(cents) {
+  if (cents === null || cents === undefined || Number.isNaN(Number(cents))) return '—';
+  const dollars = Math.round(Number(cents) / 100);
+  return `S$${dollars.toLocaleString('en-SG')}`;
+}
+
+/** Cents → "S$12.50" (exact, for ledger rows). */
+export function fmtSGDExact(cents) {
+  if (cents === null || cents === undefined || Number.isNaN(Number(cents))) return '—';
+  return `S$${(Number(cents) / 100).toLocaleString('en-SG', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+export function fmtNumber(n) {
+  if (n === null || n === undefined || Number.isNaN(Number(n))) return '—';
+  return Number(n).toLocaleString('en-SG');
+}
+
+/** ISO/date → "15 Jul 09:41" in SGT. */
+export function fmtDateTime(value) {
+  if (!value) return '—';
+  const d = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(d.getTime())) return '—';
+  const date = d.toLocaleDateString('en-SG', { day: 'numeric', month: 'short', timeZone: SGT });
+  const time = d.toLocaleTimeString('en-SG', { hour: '2-digit', minute: '2-digit', hour12: false, timeZone: SGT });
+  return `${date} ${time}`;
+}
+
+/** ISO/date → "15 Jul 2026" in SGT. */
+export function fmtDate(value) {
+  if (!value) return '—';
+  const d = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(d.getTime())) return '—';
+  return d.toLocaleDateString('en-SG', { day: 'numeric', month: 'short', year: 'numeric', timeZone: SGT });
+}
+
+/** Rough relative time for stream rows ("4m ago", "2h ago", "3d ago"). */
+export function fmtRelative(value, now = Date.now()) {
+  if (!value) return '—';
+  const t = value instanceof Date ? value.getTime() : new Date(value).getTime();
+  if (Number.isNaN(t)) return '—';
+  const s = Math.max(0, Math.floor((now - t) / 1000));
+  if (s < 60) return 'just now';
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`;
+  return `${Math.floor(s / 86400)}d ago`;
+}
+
+/** "days until" for deadlines (SGT end-of-day strings or ISO dates). */
+export function daysUntil(value, now = Date.now()) {
+  if (!value) return null;
+  const t = typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value)
+    ? Date.parse(`${value}T23:59:59+08:00`)
+    : new Date(value).getTime();
+  if (Number.isNaN(t)) return null;
+  return Math.ceil((t - now) / 86400000);
+}

--- a/src/pages/adminv2/AdminV2Dashboard.jsx
+++ b/src/pages/adminv2/AdminV2Dashboard.jsx
@@ -1,0 +1,294 @@
+/**
+ * Switchboard Dashboard — the operator cockpit. Every number derives from the
+ * Phase B endpoints (overview / attention / series / funnel / campaigns);
+ * nothing is hardcoded. Period recomputes every widget; charts are token-driven
+ * div bars (exact design fidelity, no chart lib).
+ */
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useOverview, useAttention, useSeries, useFunnel, useCampaignLeaderboard, useProspects } from '@/hooks/queries/useAdminV2';
+import { composeAttentionRows, composeHealthCells, SEVERITY_GLYPH } from '@/lib/adminV2/attention';
+import { fmtNumber, fmtSGD, fmtRelative, daysUntil } from '@/lib/adminV2/format';
+import { STATUS_LABELS, STATUS_CHIP_CLASS, SOURCE_LABELS, HELD_REASON_LABELS, UTM_LABELS } from '@/lib/adminV2/constants';
+import { Card, Chip, PeriodSwitch, Skeleton, ErrorState, EmptyState, PageHeader } from '@/components/adminv2/primitives';
+
+const SEVERITY_STYLE = {
+  incident: { bg: 'var(--bad-soft)', fg: 'var(--bad)' },
+  held: { bg: 'var(--hold-soft)', fg: 'var(--hold)' },
+  warning: { bg: 'var(--warn-soft)', fg: 'var(--warn)' },
+  watch: { bg: 'var(--accent-soft)', fg: 'var(--accent-text)' },
+};
+
+const TONE_FG = { bad: 'var(--bad)', warn: 'var(--warn)', ok: 'var(--ok)', hold: 'var(--hold)', accent: 'var(--ink)', neutral: 'var(--ink)' };
+
+function Sparkline({ days }) {
+  const max = Math.max(1, ...days.map((d) => d.count));
+  return (
+    <div style={{ display: 'flex', alignItems: 'flex-end', gap: 2, height: 44 }} aria-hidden="true">
+      {days.map((d) => (
+        <div
+          key={d.date}
+          title={`${d.date}: ${d.count}`}
+          style={{
+            flex: 1,
+            height: `${Math.max(4, (d.count / max) * 100)}%`,
+            borderRadius: 2,
+            background: d.isToday ? 'var(--accent)' : 'var(--accent-soft)',
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function KpiCard({ period }) {
+  const series = useSeries(period);
+  const overview = useOverview(period);
+  if (series.isLoading || overview.isLoading) {
+    return (
+      <Card span={5}><div style={{ padding: 16 }}><Skeleton height={42} width={120} /><Skeleton height={44} style={{ marginTop: 14 }} /><Skeleton height={14} width={220} style={{ marginTop: 10 }} /></div></Card>
+    );
+  }
+  if (series.isError) return <Card span={5}><ErrorState error={series.error} onRetry={series.refetch} /></Card>;
+
+  const s = series.data;
+  const p = overview.data?.prospects;
+  const delta = s.avgPerDay > 0 ? Math.round(((s.today - s.avgPerDay) / s.avgPerDay) * 100) : null;
+  return (
+    <Card span={5}>
+      <div style={{ padding: 16 }}>
+        <div className="av2-microcaps">Leads today</div>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 10 }}>
+          <span className="av2-kpi av2-mono">{fmtNumber(s.today)}</span>
+          {delta !== null && (
+            <span className="av2-mono" style={{ fontSize: 12.5, fontWeight: 600, color: delta >= 0 ? 'var(--ok)' : 'var(--ink-3)' }}>
+              {delta >= 0 ? '+' : ''}{delta}% vs {s.avgPerDay}/day avg
+            </span>
+          )}
+        </div>
+        <div style={{ marginTop: 12 }}><Sparkline days={s.days} /></div>
+        <div className="av2-caption" style={{ marginTop: 10 }}>
+          {fmtNumber(s.total)} OTP-verified submissions · last {period}
+          {p && <> · {fmtNumber(p.assigned)} assigned · {fmtNumber(p.converted)} won ({p.conversionRate}%)</>}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function HealthStrip() {
+  const attention = useAttention();
+  if (attention.isLoading) return <Card span={7}><div style={{ display: 'flex', gap: 12, padding: 16 }}>{[0, 1, 2, 3].map((i) => <Skeleton key={i} height={62} style={{ flex: 1 }} />)}</div></Card>;
+  if (attention.isError) return <Card span={7}><ErrorState error={attention.error} onRetry={attention.refetch} /></Card>;
+
+  const cells = composeHealthCells(attention.data);
+  return (
+    <Card span={7}>
+      <div style={{ display: 'flex' }}>
+        {cells.map((c, i) => (
+          <div key={c.id} style={{ flex: 1, padding: '16px', borderRight: i < cells.length - 1 ? '1px solid var(--line)' : 'none' }}>
+            <div className="av2-mono" style={{ fontSize: 17, fontWeight: 600, color: TONE_FG[c.tone] || 'var(--ink)' }}>{c.value}</div>
+            <div className="av2-caption" style={{ marginTop: 4 }}>{c.caption}</div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+function AttentionQueue() {
+  const attention = useAttention();
+  if (attention.isLoading) return <Card span={5} title="Needs attention"><div style={{ padding: 16, display: 'grid', gap: 10 }}>{[0, 1, 2].map((i) => <Skeleton key={i} height={44} />)}</div></Card>;
+  if (attention.isError) return <Card span={5} title="Needs attention"><ErrorState error={attention.error} onRetry={attention.refetch} /></Card>;
+
+  const rows = composeAttentionRows(attention.data);
+  return (
+    <Card span={5} title="Needs attention" meta={rows.length ? `${rows.length} item${rows.length === 1 ? '' : 's'}` : undefined}>
+      {rows.length === 0 ? (
+        <EmptyState icon="✓" title="All clear" hint="No incidents, holds, or deadlines on the rail." />
+      ) : (
+        rows.map((r) => {
+          const sv = SEVERITY_STYLE[r.severity];
+          return (
+            <Link key={r.id} to={r.href} className="av2-qrow">
+              <span className="av2-qicon" style={{ background: sv.bg, color: sv.fg }} aria-hidden="true">{SEVERITY_GLYPH[r.severity]}</span>
+              <span style={{ flex: 1, minWidth: 0 }}>
+                <span style={{ display: 'block', fontSize: 13.5, fontWeight: 700 }}>{r.title}</span>
+                <span className="av2-caption" style={{ display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.detail}</span>
+              </span>
+              <span style={{ fontSize: 12, fontWeight: 700, color: 'var(--accent-text)', flex: 'none' }}>{r.cta} →</span>
+            </Link>
+          );
+        })
+      )}
+    </Card>
+  );
+}
+
+function LeadFlow({ period }) {
+  const series = useSeries(period);
+  if (series.isLoading) return <Card span={7} title="Lead flow"><div style={{ padding: 16 }}><Skeleton height={160} /></div></Card>;
+  if (series.isError) return <Card span={7} title="Lead flow"><ErrorState error={series.error} onRetry={series.refetch} /></Card>;
+
+  const { days } = series.data;
+  const max = Math.max(1, ...days.map((d) => d.count));
+  const labelEvery = Math.max(1, Math.floor(days.length / 6));
+  return (
+    <Card span={7} title="Lead flow" meta={`daily · SGT midnight buckets · last ${period}`}>
+      <div style={{ padding: 16 }}>
+        <div style={{ display: 'flex', alignItems: 'flex-end', gap: days.length > 40 ? 1 : 3, height: 150 }}>
+          {days.map((d) => (
+            <div key={d.date} style={{ flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'flex-end', height: '100%' }} title={`${d.date}: ${d.count} leads`}>
+              <div style={{ height: `${Math.max(2, (d.count / max) * 100)}%`, borderRadius: 2, background: d.isToday ? 'var(--accent)' : 'var(--accent-soft)' }} />
+            </div>
+          ))}
+        </div>
+        <div style={{ display: 'flex', marginTop: 6 }}>
+          {days.map((d, i) => (
+            <span key={d.date} className="av2-mono" style={{ flex: 1, fontSize: 9, color: 'var(--ink-3)', textAlign: 'center' }}>
+              {i % labelEvery === 0 ? d.date.slice(5).split('-').reverse().join('/') : ''}
+            </span>
+          ))}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function Funnel({ period }) {
+  const funnel = useFunnel(period);
+  if (funnel.isLoading) return <Card span={5} title="Funnel"><div style={{ padding: 16, display: 'grid', gap: 10 }}>{[0, 1, 2, 3].map((i) => <Skeleton key={i} height={30} />)}</div></Card>;
+  if (funnel.isError) return <Card span={5} title="Funnel"><ErrorState error={funnel.error} onRetry={funnel.refetch} /></Card>;
+
+  const f = funnel.data;
+  const stages = [
+    { label: `Scans${f.estimated ? ' (est.)' : ''}`, value: f.scans },
+    { label: 'Submits', value: f.submits },
+    { label: 'Assigned', value: f.assigned },
+    { label: 'Won', value: f.won },
+  ];
+  const max = Math.max(1, ...stages.map((s) => s.value));
+  return (
+    <Card span={5} title="Funnel" meta={`last ${period}`}>
+      <div style={{ padding: 16, display: 'grid', gap: 10 }}>
+        {stages.map((s) => (
+          <div key={s.label}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 3 }}>
+              <span className="av2-caption">{s.label}</span>
+              <span className="av2-mono" style={{ fontSize: 12, fontWeight: 600 }}>{fmtNumber(s.value)}</span>
+            </div>
+            <div style={{ height: 10, borderRadius: 5, background: 'var(--surface-2)' }}>
+              <div style={{ width: `${(s.value / max) * 100}%`, height: '100%', borderRadius: 5, background: 'var(--accent)' }} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+function RecentLeads() {
+  const recent = useProspects({ limit: 8, sort: '-createdAt' });
+  if (recent.isLoading) return <Card span={7} title="Recent leads"><div style={{ padding: 16, display: 'grid', gap: 10 }}>{[0, 1, 2, 3].map((i) => <Skeleton key={i} height={36} />)}</div></Card>;
+  if (recent.isError) return <Card span={7} title="Recent leads"><ErrorState error={recent.error} onRetry={recent.refetch} /></Card>;
+
+  const rows = recent.data.rows;
+  return (
+    <Card span={7} title="Recent leads" action={<Link to="/AdminProspects" style={{ fontSize: 12, fontWeight: 700, color: 'var(--accent-text)', textDecoration: 'none' }}>All prospects →</Link>}>
+      {rows.length === 0 ? (
+        <EmptyState title="No leads yet" hint="New submissions stream in here live." />
+      ) : (
+        rows.map((p) => {
+          const held = !!p.quarantinedAt;
+          const utm = p.sourceMetadata?.utm?.utm_source;
+          return (
+            <div key={p.id} className="av2-qrow" style={{ cursor: 'default' }}>
+              <span style={{ flex: 1.3, minWidth: 0 }}>
+                <span style={{ display: 'block', fontSize: 13, fontWeight: 700 }}>{p.firstName} {p.lastName}</span>
+                <span className="av2-caption" style={{ display: 'block' }}>
+                  {SOURCE_LABELS[p.leadSource] || p.leadSource}{utm ? ` · ${UTM_LABELS[utm] || utm}` : ''}{p.campaign ? ` · ${p.campaign.name}` : ''}
+                </span>
+              </span>
+              {held ? (
+                <Chip tone="hold" glyph="◆">{HELD_REASON_LABELS[p.quarantineReason] || 'Held'}</Chip>
+              ) : p.assignedAgent ? (
+                <Chip tone="">{p.assignedAgent.firstName}</Chip>
+              ) : (
+                <Chip tone="warn">Unassigned</Chip>
+              )}
+              <Chip tone={STATUS_CHIP_CLASS[p.leadStatus]?.replace('av2-chip--', '') || ''}>{STATUS_LABELS[p.leadStatus] || p.leadStatus}</Chip>
+              <span className="av2-mono" style={{ fontSize: 10.5, color: 'var(--ink-3)', width: 64, textAlign: 'right', flex: 'none' }}>{fmtRelative(p.createdAt)}</span>
+            </div>
+          );
+        })
+      )}
+    </Card>
+  );
+}
+
+function Leaderboard({ period }) {
+  const campaigns = useCampaignLeaderboard(period);
+  if (campaigns.isLoading) return <Card span={12} title="Campaign leaderboard"><div style={{ padding: 16, display: 'grid', gap: 10 }}>{[0, 1, 2].map((i) => <Skeleton key={i} height={36} />)}</div></Card>;
+  if (campaigns.isError) return <Card span={12} title="Campaign leaderboard"><ErrorState error={campaigns.error} onRetry={campaigns.refetch} /></Card>;
+
+  const rows = [...campaigns.data.rows]
+    .filter((c) => c.status !== 'archived' && c.status !== 'draft')
+    .sort((a, b) => (b.leadsThisPeriod || 0) - (a.leadsThisPeriod || 0))
+    .slice(0, 6);
+  const max = Math.max(1, ...rows.map((c) => c.leadsThisPeriod || 0));
+
+  return (
+    <Card span={12} title="Campaign leaderboard" meta={`top ${rows.length} by leads · last ${period}`}>
+      {rows.length === 0 ? (
+        <EmptyState title="No active campaigns" hint="Launch a campaign to start the board." />
+      ) : (
+        rows.map((c) => {
+          const draw = c.design_config?.luckyDraw;
+          const drawDays = draw?.enabled ? daysUntil(draw.closesAt) : null;
+          const priced = Number.isInteger(c.leadPriceCents) && c.leadPriceCents > 0;
+          const zeroCommit = priced && c.status === 'active' && !(c.committedRemaining > 0);
+          return (
+            <div key={c.id} className="av2-qrow" style={{ cursor: 'default' }}>
+              <span style={{ flex: 1.4, minWidth: 0 }}>
+                <span style={{ display: 'block', fontSize: 13, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{c.name}</span>
+                <span className="av2-caption">{c.status}{priced ? ` · ${fmtSGD(c.leadPriceCents)}/lead` : ''}</span>
+              </span>
+              <span style={{ flex: 1.2, display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                {zeroCommit && <Chip tone="bad" glyph="▲">0 commitments</Chip>}
+                {c.committedRemaining > 0 && <Chip tone="accent">{fmtNumber(c.committedRemaining)} committed · {fmtSGD(c.committedValueCents)}</Chip>}
+                {drawDays !== null && drawDays > 0 && <Chip tone="warn">Draw closes {drawDays}d</Chip>}
+                {c.design_config?.marketplaceListed === true && <Chip tone="accent">Marketplace</Chip>}
+              </span>
+              <span style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span style={{ flex: 1, height: 8, borderRadius: 4, background: 'var(--surface-2)' }}>
+                  <span style={{ display: 'block', width: `${((c.leadsThisPeriod || 0) / max) * 100}%`, height: '100%', borderRadius: 4, background: 'var(--accent)' }} />
+                </span>
+                <span className="av2-mono" style={{ fontSize: 12, fontWeight: 600, width: 44, textAlign: 'right' }}>{fmtNumber(c.leadsThisPeriod || 0)}</span>
+              </span>
+            </div>
+          );
+        })
+      )}
+    </Card>
+  );
+}
+
+export default function AdminV2Dashboard() {
+  const [period, setPeriod] = useState('30d');
+  return (
+    <div>
+      <PageHeader title="Dashboard" meta="LEAD GENERATION · OTP-VERIFIED SUBMISSIONS · SGT">
+        <PeriodSwitch value={period} onChange={setPeriod} />
+      </PageHeader>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 16 }}>
+        <KpiCard period={period} />
+        <HealthStrip />
+        <AttentionQueue />
+        <LeadFlow period={period} />
+        <Funnel period={period} />
+        <RecentLeads />
+        <Leaderboard period={period} />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/adminv2/AdminV2Dashboard.jsx
+++ b/src/pages/adminv2/AdminV2Dashboard.jsx
@@ -51,7 +51,7 @@ function KpiCard({ period }) {
   }
   if (series.isError) return <Card span={5}><ErrorState error={series.error} onRetry={series.refetch} /></Card>;
 
-  const s = series.data;
+  const s = { days: [], today: 0, avgPerDay: 0, total: 0, ...(series.data || {}) };
   const p = overview.data?.prospects;
   const delta = s.avgPerDay > 0 ? Math.round(((s.today - s.avgPerDay) / s.avgPerDay) * 100) : null;
   return (
@@ -130,7 +130,7 @@ function LeadFlow({ period }) {
   if (series.isLoading) return <Card span={7} title="Lead flow"><div style={{ padding: 16 }}><Skeleton height={160} /></div></Card>;
   if (series.isError) return <Card span={7} title="Lead flow"><ErrorState error={series.error} onRetry={series.refetch} /></Card>;
 
-  const { days } = series.data;
+  const days = series.data?.days || [];
   const max = Math.max(1, ...days.map((d) => d.count));
   const labelEvery = Math.max(1, Math.floor(days.length / 6));
   return (
@@ -160,12 +160,13 @@ function Funnel({ period }) {
   if (funnel.isLoading) return <Card span={5} title="Funnel"><div style={{ padding: 16, display: 'grid', gap: 10 }}>{[0, 1, 2, 3].map((i) => <Skeleton key={i} height={30} />)}</div></Card>;
   if (funnel.isError) return <Card span={5} title="Funnel"><ErrorState error={funnel.error} onRetry={funnel.refetch} /></Card>;
 
-  const f = funnel.data;
+  const f = funnel.data || {};
+  const num = (v) => (Number.isFinite(Number(v)) ? Number(v) : 0);
   const stages = [
-    { label: `Scans${f.estimated ? ' (est.)' : ''}`, value: f.scans },
-    { label: 'Submits', value: f.submits },
-    { label: 'Assigned', value: f.assigned },
-    { label: 'Won', value: f.won },
+    { label: `Scans${f.estimated ? ' (est.)' : ''}`, value: num(f.scans) },
+    { label: 'Submits', value: num(f.submits) },
+    { label: 'Assigned', value: num(f.assigned) },
+    { label: 'Won', value: num(f.won) },
   ];
   const max = Math.max(1, ...stages.map((s) => s.value));
   return (
@@ -228,6 +229,12 @@ function RecentLeads() {
 
 function Leaderboard({ period }) {
   const campaigns = useCampaignLeaderboard(period);
+  // The zero-commitment incident set comes from /attention — the server's
+  // authoritative definition (wallet OR package funding, active+priced).
+  // Deriving it client-side from committedRemaining (wallet-only) would flag
+  // package-funded campaigns with a false red badge.
+  const attention = useAttention();
+  const zeroCommitIds = new Set((attention.data?.zeroCommitCampaigns || []).map((c) => c.id));
   if (campaigns.isLoading) return <Card span={12} title="Campaign leaderboard"><div style={{ padding: 16, display: 'grid', gap: 10 }}>{[0, 1, 2].map((i) => <Skeleton key={i} height={36} />)}</div></Card>;
   if (campaigns.isError) return <Card span={12} title="Campaign leaderboard"><ErrorState error={campaigns.error} onRetry={campaigns.refetch} /></Card>;
 
@@ -246,7 +253,7 @@ function Leaderboard({ period }) {
           const draw = c.design_config?.luckyDraw;
           const drawDays = draw?.enabled ? daysUntil(draw.closesAt) : null;
           const priced = Number.isInteger(c.leadPriceCents) && c.leadPriceCents > 0;
-          const zeroCommit = priced && c.status === 'active' && !(c.committedRemaining > 0);
+          const zeroCommit = zeroCommitIds.has(c.id);
           return (
             <div key={c.id} className="av2-qrow" style={{ cursor: 'default' }}>
               <span style={{ flex: 1.4, minWidth: 0 }}>

--- a/src/pages/adminv2/AdminV2Prospects.jsx
+++ b/src/pages/adminv2/AdminV2Prospects.jsx
@@ -38,6 +38,10 @@ function readFilters(searchParams) {
     search: searchParams.get('q') || '',
     sort: searchParams.get('sort') || '-createdAt',
     page: Math.max(1, parseInt(searchParams.get('page'), 10) || 1),
+    // Legacy deep-link params — AdminCampaigns links ?campaign=<id>, the QR
+    // tables link ?qrTagId=<id>. Both must keep narrowing the table.
+    campaign: searchParams.get('campaign') || searchParams.get('campaignId') || '',
+    qrTagId: searchParams.get('qrTagId') || '',
   };
 }
 
@@ -115,9 +119,15 @@ function LeadDrawer({ prospect, onClose }) {
           </section>
           <section>
             <div className="av2-microcaps" style={{ marginBottom: 6 }}>Routing</div>
-            <div className="av2-kv"><span>agent</span><span>{p.assignedAgent ? `${p.assignedAgent.firstName || ''} ${p.assignedAgent.lastName || ''}`.trim() : held ? 'held' : 'unassigned'}</span></div>
+            <div className="av2-kv"><span>agent</span><span>{p.assignedAgent ? `${p.assignedAgent.firstName || ''} ${p.assignedAgent.lastName || ''}`.trim() : p.externalAgentId ? 'external buyer' : held ? 'held' : 'unassigned'}</span></div>
             {held && <div className="av2-kv"><span>held since</span><span>{fmtDateTime(p.quarantinedAt)}</span></div>}
             {held && <div className="av2-kv"><span>reason</span><span>{HELD_REASON_LABELS[p.quarantineReason] || p.quarantineReason || '—'}</span></div>}
+          </section>
+          <section>
+            <div className="av2-microcaps" style={{ marginBottom: 6 }}>Consent</div>
+            <div className="av2-kv"><span>marketing</span><span>{p.sourceMetadata?.consent_contact === true ? 'yes' : p.sourceMetadata?.consent_contact === false ? 'no' : '—'}</span></div>
+            <div className="av2-kv"><span>terms</span><span>{p.sourceMetadata?.consent_terms === true ? 'yes' : p.sourceMetadata?.consent_terms === false ? 'no' : '—'}</span></div>
+            <div className="av2-kv"><span>third-party</span><span>{p.sourceMetadata?.consent_third_party === true ? 'yes' : p.sourceMetadata?.consent_third_party === false ? 'no' : '—'}</span></div>
           </section>
           <section>
             <div className="av2-microcaps" style={{ marginBottom: 6 }}>Timeline</div>
@@ -140,22 +150,42 @@ export default function AdminV2Prospects() {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const queryClient = useQueryClient();
 
-  // Debounced search → URL (which drives the query)
+  // Debounced search → URL (which drives the query). The timer applies its
+  // change FUNCTIONALLY over the latest params, so a filter clicked during the
+  // 350ms window is never clobbered by the stale closure.
   useEffect(() => {
     const t = setTimeout(() => {
-      if (searchDraft !== filters.search) patch({ q: searchDraft || null, page: null });
+      setSearchParams((prev) => {
+        if ((prev.get('q') || '') === searchDraft) return prev;
+        const next = new URLSearchParams(prev);
+        if (searchDraft) next.set('q', searchDraft);
+        else next.delete('q');
+        next.delete('page');
+        return next;
+      }, { replace: true });
     }, 350);
     return () => clearTimeout(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchDraft]);
 
-  function patch(changes) {
-    const next = new URLSearchParams(searchParams);
-    for (const [k, v] of Object.entries(changes)) {
-      if (v === null || v === '' || v === undefined) next.delete(k);
-      else next.set(k, v);
+  // Back/forward (or a pasted URL) changes q outside the input — resync the
+  // draft unless the operator is mid-typing.
+  useEffect(() => {
+    if (document.activeElement?.getAttribute('aria-label') !== 'Search prospects' && filters.search !== searchDraft) {
+      setSearchDraft(filters.search);
     }
-    setSearchParams(next, { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filters.search]);
+
+  function patch(changes) {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      for (const [k, v] of Object.entries(changes)) {
+        if (v === null || v === '' || v === undefined) next.delete(k);
+        else next.set(k, v);
+      }
+      return next;
+    }, { replace: true });
   }
 
   const queryParams = useMemo(() => ({
@@ -165,6 +195,8 @@ export default function AdminV2Prospects() {
     ...(filters.source.length ? { leadSource: filters.source.join(',') } : {}),
     ...(filters.assignment ? { assignment: filters.assignment } : {}),
     ...(filters.search ? { search: filters.search } : {}),
+    ...(filters.campaign ? { campaignId: filters.campaign } : {}),
+    ...(filters.qrTagId ? { qrTagId: filters.qrTagId } : {}),
     sort: filters.sort,
   }), [filters]);
 
@@ -187,6 +219,8 @@ export default function AdminV2Prospects() {
     ...filters.source.map((s) => ({ key: `source:${s}`, label: SOURCE_LABELS[s] || s, clear: () => toggleList('source', s) })),
     ...(filters.assignment ? [{ key: 'assignment', label: `${filters.assignment} only`, clear: () => patch({ assignment: null, page: null }) }] : []),
     ...(filters.search ? [{ key: 'q', label: `“${filters.search}”`, clear: () => { setSearchDraft(''); patch({ q: null, page: null }); } }] : []),
+    ...(filters.campaign ? [{ key: 'campaign', label: 'campaign filter', clear: () => patch({ campaign: null, campaignId: null, page: null }) }] : []),
+    ...(filters.qrTagId ? [{ key: 'qrTagId', label: 'QR tag filter', clear: () => patch({ qrTagId: null, page: null }) }] : []),
   ];
 
   // ── Bulk actions (live endpoints) ──────────────────────────────────────────
@@ -194,19 +228,43 @@ export default function AdminV2Prospects() {
   const ids = [...selected];
   const agentOptions = useAgentOptions(selected.size > 0);
 
+  // Toasts report the SERVER's counts — the backend legitimately skips rows
+  // (e.g. DNC-held leads are not releasable via assign), and the operator must
+  // see that, never an assumed "N done".
   const assignMutation = useMutation({
     mutationFn: ({ agentId }) => bulkAssign(ids, agentId),
-    onSuccess: (_r, { agentName }) => { toast.success(`${ids.length} lead${ids.length === 1 ? '' : 's'} assigned to ${agentName}`); setSelected(new Set()); invalidate(); },
+    onSuccess: (r, { agentName }) => {
+      const n = r?.data?.affectedCount ?? 0;
+      const skippedObj = r?.data?.skipped || {};
+      const skipped = Object.values(skippedObj).reduce((a, b) => a + (Number(b) || 0), 0);
+      if (n > 0) toast.success(`${n} lead${n === 1 ? '' : 's'} assigned to ${agentName}${skipped ? ` · ${skipped} skipped (not releasable)` : ''}`);
+      else toast.warning(`Nothing assigned — ${skipped || ids.length} lead${(skipped || ids.length) === 1 ? ' was' : 's were'} not eligible`);
+      setSelected(new Set()); invalidate();
+    },
     onError: (e) => toast.error(e?.message || 'Assign failed'),
   });
   const returnMutation = useMutation({
     mutationFn: () => bulkReturnToHeld(ids),
-    onSuccess: () => { toast.success(`${ids.length} lead${ids.length === 1 ? '' : 's'} returned to held`); setSelected(new Set()); invalidate(); },
+    onSuccess: (r) => {
+      const c = r?.data || {};
+      const n = c.returned ?? 0;
+      const rest = (c.alreadyHeld || 0) + (c.undeliverable || 0) + (c.notFound || 0);
+      if (n > 0) toast.success(`${n} lead${n === 1 ? '' : 's'} returned to held${rest ? ` · ${rest} skipped` : ''}`);
+      else toast.warning('Nothing returned — the selection was already held or not eligible');
+      setSelected(new Set()); invalidate();
+    },
     onError: (e) => toast.error(e?.message || 'Return failed'),
   });
   const deleteMutation = useMutation({
     mutationFn: () => bulkDelete(ids),
-    onSuccess: () => { toast.success(`${ids.length} lead${ids.length === 1 ? '' : 's'} deleted`); setSelected(new Set()); setConfirmDelete(false); invalidate(); },
+    onSuccess: (r) => {
+      const c = r?.data || {};
+      const n = c.deleted ?? 0;
+      const rest = (c.notFound || 0) + (c.failed || 0);
+      if (n > 0) toast.success(`${n} lead${n === 1 ? '' : 's'} deleted${rest ? ` · ${rest} skipped` : ''}`);
+      else toast.warning('Nothing deleted');
+      setSelected(new Set()); setConfirmDelete(false); invalidate();
+    },
     onError: (e) => { toast.error(e?.message || 'Delete failed'); setConfirmDelete(false); },
   });
 
@@ -344,11 +402,12 @@ export default function AdminV2Prospects() {
           return (
             <div key={p.id} className="av2-row" data-selected={isSelected} role="button" tabIndex={0}
               onClick={() => setDrawer(p)}
-              onKeyDown={(e) => { if (e.key === 'Enter') setDrawer(p); }}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setDrawer(p); } }}
             >
               <button
                 type="button"
                 onClick={(e) => { e.stopPropagation(); toggleOne(p.id); }}
+                onKeyDown={(e) => e.stopPropagation()}
                 aria-label={isSelected ? 'Deselect' : 'Select'}
                 style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', display: 'flex' }}
               >
@@ -366,7 +425,11 @@ export default function AdminV2Prospects() {
               </span>
               <span style={{ flex: 1, fontSize: 12, color: 'var(--ink-2)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.campaign?.name || '—'}</span>
               <span style={{ width: 100, flex: 'none', fontSize: 12, color: 'var(--ink-2)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                {p.assignedAgent ? `${p.assignedAgent.firstName || ''}` : held ? '—' : <Chip tone="warn">none</Chip>}
+                {p.assignedAgent
+                  ? `${p.assignedAgent.firstName || ''}`
+                  : p.externalAgentId
+                    ? <Chip tone="accent">External</Chip>
+                    : held ? '—' : <Chip tone="warn">none</Chip>}
               </span>
               <span className="av2-mono" style={{ width: 100, flex: 'none', fontSize: 10, color: 'var(--ink-3)', textAlign: 'right' }} title={fmtDateTime(p.createdAt)}>
                 {fmtRelative(p.createdAt)}

--- a/src/pages/adminv2/AdminV2Prospects.jsx
+++ b/src/pages/adminv2/AdminV2Prospects.jsx
@@ -1,0 +1,440 @@
+/**
+ * Switchboard Prospects — the operator lead table. Filters live in the URL
+ * (removable chips, shareable links, back/forward safe), pagination + sort are
+ * server-side (Phase B contracts), the drawer tells the whole lead story, and
+ * the bulk bar drives the REAL bulk endpoints (assign / return-to-held /
+ * delete) plus a client-side CSV export.
+ */
+import { useMemo, useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { useProspects, useAgentOptions } from '@/hooks/queries/useAdminV2';
+import { bulkAssign, bulkReturnToHeld, bulkDelete } from '@/api/adminV2';
+import {
+  LEAD_STATUSES, LEAD_SOURCES, STATUS_LABELS, STATUS_CHIP_CLASS,
+  SOURCE_LABELS, HELD_REASON_LABELS, UTM_LABELS, PAGE_SIZE,
+} from '@/lib/adminV2/constants';
+import { fmtDateTime, fmtRelative } from '@/lib/adminV2/format';
+import { prospectsToCsv, downloadCsv } from '@/lib/adminV2/csv';
+import { Chip, PageHeader, Skeleton, ErrorState, EmptyState } from '@/components/adminv2/primitives';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import {
+  DropdownMenu, DropdownMenuTrigger, DropdownMenuContent,
+  DropdownMenuCheckboxItem, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator,
+} from '@/components/ui/dropdown-menu';
+import {
+  AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction,
+} from '@/components/ui/alert-dialog';
+
+// ── URL param helpers (the URL is the single source of filter truth) ────────
+
+function readFilters(searchParams) {
+  return {
+    status: (searchParams.get('status') || '').split(',').filter(Boolean),
+    source: (searchParams.get('source') || '').split(',').filter(Boolean),
+    assignment: searchParams.get('assignment') || '',
+    search: searchParams.get('q') || '',
+    sort: searchParams.get('sort') || '-createdAt',
+    page: Math.max(1, parseInt(searchParams.get('page'), 10) || 1),
+  };
+}
+
+function CheckboxGlyph({ checked }) {
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        width: 18, height: 18, flex: 'none', borderRadius: 5, boxSizing: 'border-box',
+        border: `2px solid ${checked ? 'var(--accent)' : 'var(--line-strong)'}`,
+        background: checked ? 'var(--accent)' : 'transparent',
+        display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+        color: 'var(--accent-ink)', fontSize: 11, fontWeight: 800, lineHeight: 1,
+      }}
+    >
+      {checked ? '✓' : ''}
+    </span>
+  );
+}
+
+function SortHeader({ label, field, sort, onSort, width, align }) {
+  const active = sort === field || sort === `-${field}`;
+  const desc = sort === `-${field}`;
+  return (
+    <button
+      type="button"
+      onClick={() => onSort(active && !desc ? `-${field}` : field)}
+      className="av2-microcaps"
+      style={{
+        width, flex: width ? 'none' : 1, textAlign: align || 'left', background: 'none',
+        border: 'none', cursor: 'pointer', padding: 0, fontFamily: 'var(--font-ui)',
+        color: active ? 'var(--ink)' : 'var(--ink-2)',
+      }}
+      aria-sort={active ? (desc ? 'descending' : 'ascending') : 'none'}
+    >
+      {label}{active ? (desc ? ' ▼' : ' ▲') : ''}
+    </button>
+  );
+}
+
+function LeadDrawer({ prospect, onClose }) {
+  if (!prospect) return null;
+  const p = prospect;
+  const utm = p.sourceMetadata?.utm || {};
+  const held = !!p.quarantinedAt;
+  return (
+    <Sheet open onOpenChange={(open) => { if (!open) onClose(); }}>
+      <SheetContent side="right" className="admin-v2" style={{ width: 432, maxWidth: '90vw', padding: 0, background: 'var(--surface)', color: 'var(--ink)', borderLeft: '1px solid var(--line)' }}>
+        <SheetHeader style={{ padding: '14px 16px', borderBottom: '1px solid var(--line)' }}>
+          <SheetTitle style={{ fontSize: 15, fontWeight: 800, color: 'var(--ink)', fontFamily: 'var(--font-ui)', textAlign: 'left' }}>
+            {p.firstName} {p.lastName}
+          </SheetTitle>
+          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+            <Chip tone={STATUS_CHIP_CLASS[p.leadStatus]?.replace('av2-chip--', '') || ''}>{STATUS_LABELS[p.leadStatus] || p.leadStatus}</Chip>
+            {held && <Chip tone="hold" glyph="◆">{HELD_REASON_LABELS[p.quarantineReason] || 'Held'}</Chip>}
+            {!held && !p.assignedAgent && <Chip tone="warn">Unassigned</Chip>}
+            {p.priority && <Chip>{p.priority}</Chip>}
+            {Number.isFinite(Number(p.score)) && p.score !== null && <Chip>score {p.score}</Chip>}
+          </div>
+        </SheetHeader>
+        <div style={{ padding: 16, overflowY: 'auto', display: 'grid', gap: 18 }}>
+          <section>
+            <div className="av2-microcaps" style={{ marginBottom: 6 }}>Contact</div>
+            <div className="av2-kv"><span>phone</span><span>{p.phone || '—'}</span></div>
+            <div className="av2-kv"><span>email</span><span>{p.email || '—'}</span></div>
+          </section>
+          <section>
+            <div className="av2-microcaps" style={{ marginBottom: 6 }}>Attribution</div>
+            <div className="av2-kv"><span>source</span><span>{SOURCE_LABELS[p.leadSource] || p.leadSource}</span></div>
+            {utm.utm_source && <div className="av2-kv"><span>utm_source</span><span>{UTM_LABELS[utm.utm_source] || utm.utm_source}</span></div>}
+            {utm.utm_medium && <div className="av2-kv"><span>utm_medium</span><span>{utm.utm_medium}</span></div>}
+            {utm.utm_campaign && <div className="av2-kv"><span>utm_campaign</span><span>{utm.utm_campaign}</span></div>}
+            {p.qrTag && <div className="av2-kv"><span>qr tag</span><span>{p.qrTag.name}</span></div>}
+            <div className="av2-kv"><span>campaign</span><span>{p.campaign?.name || '—'}</span></div>
+          </section>
+          <section>
+            <div className="av2-microcaps" style={{ marginBottom: 6 }}>Routing</div>
+            <div className="av2-kv"><span>agent</span><span>{p.assignedAgent ? `${p.assignedAgent.firstName || ''} ${p.assignedAgent.lastName || ''}`.trim() : held ? 'held' : 'unassigned'}</span></div>
+            {held && <div className="av2-kv"><span>held since</span><span>{fmtDateTime(p.quarantinedAt)}</span></div>}
+            {held && <div className="av2-kv"><span>reason</span><span>{HELD_REASON_LABELS[p.quarantineReason] || p.quarantineReason || '—'}</span></div>}
+          </section>
+          <section>
+            <div className="av2-microcaps" style={{ marginBottom: 6 }}>Timeline</div>
+            <div className="av2-kv"><span>created</span><span>{fmtDateTime(p.createdAt)}</span></div>
+            <div className="av2-kv"><span>last contact</span><span>{fmtDateTime(p.lastContactDate)}</span></div>
+            <div className="av2-kv"><span>converted</span><span>{fmtDateTime(p.conversionDate)}</span></div>
+          </section>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export default function AdminV2Prospects() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filters = useMemo(() => readFilters(searchParams), [searchParams]);
+  const [searchDraft, setSearchDraft] = useState(filters.search);
+  const [selected, setSelected] = useState(() => new Set());
+  const [drawer, setDrawer] = useState(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const queryClient = useQueryClient();
+
+  // Debounced search → URL (which drives the query)
+  useEffect(() => {
+    const t = setTimeout(() => {
+      if (searchDraft !== filters.search) patch({ q: searchDraft || null, page: null });
+    }, 350);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchDraft]);
+
+  function patch(changes) {
+    const next = new URLSearchParams(searchParams);
+    for (const [k, v] of Object.entries(changes)) {
+      if (v === null || v === '' || v === undefined) next.delete(k);
+      else next.set(k, v);
+    }
+    setSearchParams(next, { replace: true });
+  }
+
+  const queryParams = useMemo(() => ({
+    page: filters.page,
+    limit: PAGE_SIZE,
+    ...(filters.status.length ? { leadStatus: filters.status.join(',') } : {}),
+    ...(filters.source.length ? { leadSource: filters.source.join(',') } : {}),
+    ...(filters.assignment ? { assignment: filters.assignment } : {}),
+    ...(filters.search ? { search: filters.search } : {}),
+    sort: filters.sort,
+  }), [filters]);
+
+  const prospects = useProspects(queryParams);
+  const rows = prospects.data?.rows || [];
+  const total = prospects.data?.total ?? 0;
+
+  // Selection is per-page; changing the result set clears it.
+  useEffect(() => { setSelected(new Set()); }, [queryParams]);
+
+  const toggleList = (key, value) => {
+    const current = new Set(filters[key]);
+    if (current.has(value)) current.delete(value);
+    else current.add(value);
+    patch({ [key === 'status' ? 'status' : 'source']: [...current].join(',') || null, page: null });
+  };
+
+  const activeChips = [
+    ...filters.status.map((s) => ({ key: `status:${s}`, label: STATUS_LABELS[s] || s, clear: () => toggleList('status', s) })),
+    ...filters.source.map((s) => ({ key: `source:${s}`, label: SOURCE_LABELS[s] || s, clear: () => toggleList('source', s) })),
+    ...(filters.assignment ? [{ key: 'assignment', label: `${filters.assignment} only`, clear: () => patch({ assignment: null, page: null }) }] : []),
+    ...(filters.search ? [{ key: 'q', label: `“${filters.search}”`, clear: () => { setSearchDraft(''); patch({ q: null, page: null }); } }] : []),
+  ];
+
+  // ── Bulk actions (live endpoints) ──────────────────────────────────────────
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ['adminV2', 'prospects'] });
+  const ids = [...selected];
+  const agentOptions = useAgentOptions(selected.size > 0);
+
+  const assignMutation = useMutation({
+    mutationFn: ({ agentId }) => bulkAssign(ids, agentId),
+    onSuccess: (_r, { agentName }) => { toast.success(`${ids.length} lead${ids.length === 1 ? '' : 's'} assigned to ${agentName}`); setSelected(new Set()); invalidate(); },
+    onError: (e) => toast.error(e?.message || 'Assign failed'),
+  });
+  const returnMutation = useMutation({
+    mutationFn: () => bulkReturnToHeld(ids),
+    onSuccess: () => { toast.success(`${ids.length} lead${ids.length === 1 ? '' : 's'} returned to held`); setSelected(new Set()); invalidate(); },
+    onError: (e) => toast.error(e?.message || 'Return failed'),
+  });
+  const deleteMutation = useMutation({
+    mutationFn: () => bulkDelete(ids),
+    onSuccess: () => { toast.success(`${ids.length} lead${ids.length === 1 ? '' : 's'} deleted`); setSelected(new Set()); setConfirmDelete(false); invalidate(); },
+    onError: (e) => { toast.error(e?.message || 'Delete failed'); setConfirmDelete(false); },
+  });
+
+  const exportSelection = () => {
+    const chosen = rows.filter((r) => selected.has(r.id));
+    const data = chosen.length ? chosen : rows;
+    downloadCsv(`prospects-${new Date().toISOString().slice(0, 10)}.csv`, prospectsToCsv(data));
+    toast.success(`Exported ${data.length} row${data.length === 1 ? '' : 's'}`);
+  };
+
+  const allOnPageSelected = rows.length > 0 && rows.every((r) => selected.has(r.id));
+  const toggleAll = () => {
+    setSelected(allOnPageSelected ? new Set() : new Set(rows.map((r) => r.id)));
+  };
+  const toggleOne = (id) => {
+    const next = new Set(selected);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    setSelected(next);
+  };
+
+  const totalPages = prospects.data?.totalPages ?? 0;
+  const rangeStart = total === 0 ? 0 : (filters.page - 1) * PAGE_SIZE + 1;
+  const rangeEnd = Math.min(filters.page * PAGE_SIZE, total);
+
+  return (
+    <div>
+      <PageHeader title="Prospects" meta={`${total.toLocaleString('en-SG')} LEADS · SERVER-SIDE 25/PAGE`}>
+        <button type="button" className="av2-btn" onClick={exportSelection}>Export CSV</button>
+      </PageHeader>
+
+      {/* ── Filter toolbar ── */}
+      <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', marginBottom: activeChips.length ? 8 : 16 }}>
+        <div className="av2-input" style={{ maxWidth: 320 }}>
+          <span aria-hidden="true" style={{ color: 'var(--ink-3)' }}>⌕</span>
+          <input
+            value={searchDraft}
+            onChange={(e) => setSearchDraft(e.target.value)}
+            placeholder="Search name, phone, email"
+            aria-label="Search prospects"
+            style={{ border: 'none', outline: 'none', background: 'transparent', flex: 1, font: 'inherit', color: 'inherit' }}
+          />
+        </div>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button type="button" className="av2-btn">Status{filters.status.length ? ` · ${filters.status.length}` : ''} ▾</button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="admin-v2" align="start">
+            <DropdownMenuLabel>Lead status</DropdownMenuLabel>
+            {LEAD_STATUSES.map((s) => (
+              <DropdownMenuCheckboxItem key={s} checked={filters.status.includes(s)} onCheckedChange={() => toggleList('status', s)}>
+                {STATUS_LABELS[s] || s}
+              </DropdownMenuCheckboxItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button type="button" className="av2-btn">Source{filters.source.length ? ` · ${filters.source.length}` : ''} ▾</button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="admin-v2" align="start">
+            <DropdownMenuLabel>Lead source</DropdownMenuLabel>
+            {LEAD_SOURCES.map((s) => (
+              <DropdownMenuCheckboxItem key={s} checked={filters.source.includes(s)} onCheckedChange={() => toggleList('source', s)}>
+                {SOURCE_LABELS[s] || s}
+              </DropdownMenuCheckboxItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {['held', 'unassigned'].map((a) => (
+          <button
+            key={a}
+            type="button"
+            className="av2-btn"
+            aria-pressed={filters.assignment === a}
+            style={filters.assignment === a ? { background: 'var(--hold-soft)', color: 'var(--hold)', borderColor: 'var(--hold)' } : undefined}
+            onClick={() => patch({ assignment: filters.assignment === a ? null : a, page: null })}
+          >
+            {a === 'held' ? '◆ Held' : 'Unassigned'}
+          </button>
+        ))}
+      </div>
+
+      {/* ── Active filter chips ── */}
+      {activeChips.length > 0 && (
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 16 }}>
+          {activeChips.map((c) => (
+            <button key={c.key} type="button" className="av2-filterchip" onClick={c.clear} aria-label={`Remove filter ${c.label}`}>
+              {c.label} ✕
+            </button>
+          ))}
+          <button
+            type="button" className="av2-filterchip" style={{ background: 'transparent', color: 'var(--ink-3)' }}
+            onClick={() => { setSearchDraft(''); setSearchParams(new URLSearchParams(), { replace: true }); }}
+          >
+            Clear all
+          </button>
+        </div>
+      )}
+
+      {/* ── Table ── */}
+      <div className="av2-card" style={{ overflow: 'hidden' }}>
+        <div className="av2-thead">
+          <button type="button" onClick={toggleAll} aria-label={allOnPageSelected ? 'Deselect all on page' : 'Select all on page'} style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', display: 'flex' }}>
+            <CheckboxGlyph checked={allOnPageSelected} />
+          </button>
+          <SortHeader label="Lead" field="firstName" sort={filters.sort} onSort={(s) => patch({ sort: s, page: null })} />
+          <span className="av2-microcaps" style={{ width: 110, flex: 'none' }}>Phone</span>
+          <SortHeader label="Status" field="leadStatus" sort={filters.sort} onSort={(s) => patch({ sort: s, page: null })} width={130} />
+          <span className="av2-microcaps" style={{ flex: 1 }}>Campaign</span>
+          <span className="av2-microcaps" style={{ width: 100, flex: 'none' }}>Agent</span>
+          <SortHeader label="Created" field="createdAt" sort={filters.sort} onSort={(s) => patch({ sort: s, page: null })} width={100} align="right" />
+        </div>
+
+        {prospects.isLoading && [0, 1, 2, 3, 4].map((i) => (
+          <div key={i} className="av2-row" style={{ cursor: 'default' }}><Skeleton height={32} /></div>
+        ))}
+        {prospects.isError && <ErrorState error={prospects.error} onRetry={prospects.refetch} />}
+        {!prospects.isLoading && !prospects.isError && rows.length === 0 && (
+          <EmptyState
+            title="No leads match these filters"
+            hint="Loosen a filter or clear them all."
+            action={activeChips.length > 0 && (
+              <button type="button" className="av2-btn av2-btn--sm" onClick={() => { setSearchDraft(''); setSearchParams(new URLSearchParams(), { replace: true }); }}>Clear all filters</button>
+            )}
+          />
+        )}
+
+        {rows.map((p) => {
+          const held = !!p.quarantinedAt;
+          const isSelected = selected.has(p.id);
+          return (
+            <div key={p.id} className="av2-row" data-selected={isSelected} role="button" tabIndex={0}
+              onClick={() => setDrawer(p)}
+              onKeyDown={(e) => { if (e.key === 'Enter') setDrawer(p); }}
+            >
+              <button
+                type="button"
+                onClick={(e) => { e.stopPropagation(); toggleOne(p.id); }}
+                aria-label={isSelected ? 'Deselect' : 'Select'}
+                style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', display: 'flex' }}
+              >
+                <CheckboxGlyph checked={isSelected} />
+              </button>
+              <span style={{ flex: 1, minWidth: 0 }}>
+                <span style={{ display: 'block', fontSize: 13, fontWeight: 700 }}>{p.firstName} {p.lastName}</span>
+                <span className="av2-mono" style={{ display: 'block', fontSize: 10, color: 'var(--ink-3)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.email || '—'}</span>
+              </span>
+              <span className="av2-mono" style={{ width: 110, flex: 'none', fontSize: 11, color: 'var(--ink-2)' }}>{p.phone || '—'}</span>
+              <span style={{ width: 130, flex: 'none' }}>
+                {held
+                  ? <Chip tone="hold" glyph="◆">{HELD_REASON_LABELS[p.quarantineReason]?.split(' ').slice(0, 2).join(' ') || 'Held'}</Chip>
+                  : <Chip tone={STATUS_CHIP_CLASS[p.leadStatus]?.replace('av2-chip--', '') || ''}>{STATUS_LABELS[p.leadStatus] || p.leadStatus}</Chip>}
+              </span>
+              <span style={{ flex: 1, fontSize: 12, color: 'var(--ink-2)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.campaign?.name || '—'}</span>
+              <span style={{ width: 100, flex: 'none', fontSize: 12, color: 'var(--ink-2)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {p.assignedAgent ? `${p.assignedAgent.firstName || ''}` : held ? '—' : <Chip tone="warn">none</Chip>}
+              </span>
+              <span className="av2-mono" style={{ width: 100, flex: 'none', fontSize: 10, color: 'var(--ink-3)', textAlign: 'right' }} title={fmtDateTime(p.createdAt)}>
+                {fmtRelative(p.createdAt)}
+              </span>
+            </div>
+          );
+        })}
+
+        {/* ── Pagination footer ── */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '10px 16px' }}>
+          <span className="av2-mono" style={{ fontSize: 11, color: 'var(--ink-3)' }}>
+            {rangeStart}–{rangeEnd} of {total.toLocaleString('en-SG')}
+          </span>
+          <span style={{ flex: 1 }} />
+          <button type="button" className="av2-btn av2-btn--sm" disabled={filters.page <= 1} onClick={() => patch({ page: String(filters.page - 1) })}>← Prev</button>
+          <button type="button" className="av2-btn av2-btn--sm" disabled={filters.page >= totalPages} onClick={() => patch({ page: String(filters.page + 1) })}>Next →</button>
+        </div>
+      </div>
+
+      {/* ── Bulk bar (floats only while a selection exists) ── */}
+      {selected.size > 0 && (
+        <div className="av2-bulkbar" role="toolbar" aria-label="Bulk actions">
+          <span className="av2-mono" style={{ fontSize: 12, fontWeight: 600 }}>{selected.size} selected</span>
+          <span style={{ width: 1, height: 20, background: 'var(--ink-2)' }} aria-hidden="true" />
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button type="button" className="av2-btn av2-btn--sm" disabled={assignMutation.isPending}>Assign to agent ▾</button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="admin-v2" align="center" side="top">
+              <DropdownMenuLabel>Assign {selected.size} lead{selected.size === 1 ? '' : 's'} to</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              {(agentOptions.data || []).map((a) => (
+                <DropdownMenuItem key={a.id} onSelect={() => assignMutation.mutate({ agentId: a.id, agentName: a.name })}>
+                  {a.name}
+                </DropdownMenuItem>
+              ))}
+              {agentOptions.isLoading && <DropdownMenuItem disabled>Loading agents…</DropdownMenuItem>}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <button type="button" className="av2-btn av2-btn--sm" disabled={returnMutation.isPending} onClick={() => returnMutation.mutate()}>Return to held</button>
+          <button type="button" className="av2-btn av2-btn--sm" onClick={exportSelection}>Export CSV</button>
+          <button type="button" className="av2-btn av2-btn--sm" style={{ borderColor: 'var(--bad)', color: 'var(--bad)' }} onClick={() => setConfirmDelete(true)}>Delete</button>
+          <button type="button" onClick={() => setSelected(new Set())} aria-label="Clear selection" style={{ background: 'none', border: 'none', color: 'var(--canvas)', fontSize: 14, fontWeight: 700, cursor: 'pointer' }}>✕</button>
+        </div>
+      )}
+
+      <AlertDialog open={confirmDelete} onOpenChange={setConfirmDelete}>
+        <AlertDialogContent className="admin-v2" style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)' }}>
+          <AlertDialogHeader>
+            <AlertDialogTitle style={{ color: 'var(--ink)' }}>Delete {selected.size} lead{selected.size === 1 ? '' : 's'}?</AlertDialogTitle>
+            <AlertDialogDescription style={{ color: 'var(--ink-2)' }}>
+              This permanently removes the selected leads and their activity history. It cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => { e.preventDefault(); deleteMutation.mutate(); }}
+              disabled={deleteMutation.isPending}
+              style={{ background: 'var(--bad)', color: '#fff' }}
+            >
+              {deleteMutation.isPending ? 'Deleting…' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <LeadDrawer prospect={drawer} onClose={() => setDrawer(null)} />
+    </div>
+  );
+}

--- a/src/pages/adminv2/AdminV2Stub.jsx
+++ b/src/pages/adminv2/AdminV2Stub.jsx
@@ -1,0 +1,24 @@
+/**
+ * Labeled stub for v2 routes whose screens land in a later PR — the same
+ * honesty rule as the prototype: never a blank panel, never a fake screen,
+ * and incoming query state is preserved for when the real screen arrives.
+ */
+import { useLocation } from 'react-router-dom';
+import { PageHeader } from '@/components/adminv2/primitives';
+
+export default function AdminV2Stub({ title, arrives = 'a later release' }) {
+  const location = useLocation();
+  return (
+    <div>
+      <PageHeader title={title} meta="SWITCHBOARD · COMING SOON" />
+      <div className="av2-card" style={{ padding: '40px 24px', textAlign: 'center' }}>
+        <div className="av2-qicon" style={{ background: 'var(--accent-soft)', color: 'var(--accent-text)', margin: '0 auto 12px' }} aria-hidden="true">◳</div>
+        <div style={{ fontSize: 14, fontWeight: 700 }}>This screen arrives with {arrives}.</div>
+        <div className="av2-caption" style={{ marginTop: 6 }}>
+          Your link{location.search ? ' and its filters' : ''} will keep working when it does
+          {location.search && <span className="av2-mono" style={{ display: 'block', marginTop: 4, color: 'var(--ink-3)' }}>{location.search}</span>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -312,19 +312,17 @@ function PagesContent() {
  </ProtectedRoute>
  }
  />
+ {ADMIN_V2 && (
  <Route
  path="/AdminWallets" element={
  <ProtectedRoute requiredRole="admin">
- {ADMIN_V2 ? (
  <AdminV2Shell>
  <AdminV2Stub title="Wallets & Commitments" arrives="the next release (PR4)" />
  </AdminV2Shell>
- ) : (
- <Navigate to="/AdminDashboard" replace />
- )}
  </ProtectedRoute>
  }
  />
+ )}
  <Route
  path="/AdminCampaigns" element={
  <ProtectedRoute requiredRole="admin">

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -56,6 +56,16 @@ const DevRoutes = lazy(() => import('../dev/DevRoutes'));
 
 const AdminDashboard = lazy(() => import('./AdminDashboard'));
 const AdminProspects = lazy(() => import('./AdminProspects'));
+
+// ── Switchboard admin v2 (docs/plans/mktr-admin-rebuild-implementation.md
+// Phase C) — dark until VITE_ADMIN_V2_ENABLED=true is baked into the build.
+// Flag ON swaps the SAME admin URLs onto the v2 screens (bookmarks survive);
+// un-rebuilt routes keep their legacy pages until their PR lands.
+const ADMIN_V2 = import.meta.env.VITE_ADMIN_V2_ENABLED === 'true';
+const AdminV2Shell = lazy(() => import('@/components/adminv2/AdminV2Shell'));
+const AdminV2Dashboard = lazy(() => import('./adminv2/AdminV2Dashboard'));
+const AdminV2Prospects = lazy(() => import('./adminv2/AdminV2Prospects'));
+const AdminV2Stub = lazy(() => import('./adminv2/AdminV2Stub'));
 const AdminCampaigns = lazy(() => import('./AdminCampaigns'));
 const AdminCampaignForm = lazy(() => import('./AdminCampaignForm'));
 const AdminQRCodes = lazy(() => import('./AdminQRCodes'));
@@ -266,9 +276,15 @@ function PagesContent() {
  <Route
  path="/AdminDashboard" element={
  <ProtectedRoute requiredRole="admin">
+ {ADMIN_V2 ? (
+ <AdminV2Shell>
+ <AdminV2Dashboard />
+ </AdminV2Shell>
+ ) : (
  <DashboardLayout>
  <AdminDashboard />
  </DashboardLayout>
+ )}
  </ProtectedRoute>
  }
  />
@@ -284,9 +300,28 @@ function PagesContent() {
  <Route
  path="/AdminProspects" element={
  <ProtectedRoute requiredRole="admin">
+ {ADMIN_V2 ? (
+ <AdminV2Shell>
+ <AdminV2Prospects />
+ </AdminV2Shell>
+ ) : (
  <DashboardLayout>
  <AdminProspects />
  </DashboardLayout>
+ )}
+ </ProtectedRoute>
+ }
+ />
+ <Route
+ path="/AdminWallets" element={
+ <ProtectedRoute requiredRole="admin">
+ {ADMIN_V2 ? (
+ <AdminV2Shell>
+ <AdminV2Stub title="Wallets & Commitments" arrives="the next release (PR4)" />
+ </AdminV2Shell>
+ ) : (
+ <Navigate to="/AdminDashboard" replace />
+ )}
  </ProtectedRoute>
  }
  />

--- a/src/styles/adminV2.css
+++ b/src/styles/adminV2.css
@@ -1,0 +1,213 @@
+/**
+ * Switchboard — Admin v2 design tokens + primitives.
+ * Source of truth: claude.ai/design project 57e68763 "Design System" (§1–4).
+ * Scoped under .admin-v2 so legacy admin pages are untouched; dark theme is a
+ * [data-theme="dark"] attribute swap on the same root (AA re-checked per pair).
+ */
+@import url('https://fonts.googleapis.com/css2?family=Schibsted+Grotesk:wght@400;500;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap');
+
+.admin-v2 {
+  --canvas: #F1F3F7;
+  --surface: #FFFFFF;
+  --surface-2: #F6F7FA;
+  --ink: #161A22;
+  --ink-2: #535B6E;
+  --ink-3: #8A92A6;
+  --line: #E2E6EE;
+  --line-strong: #C9CFDC;
+  --accent: #2C46E6;
+  --accent-ink: #FFFFFF;
+  --accent-soft: #E8ECFE;
+  --accent-text: #2440CC;
+  --ok: #0B7A44;
+  --ok-soft: #DDF3E6;
+  --warn: #9A5B00;
+  --warn-soft: #FEF0D8;
+  --bad: #C42B1C;
+  --bad-soft: #FCE4E0;
+  --hold: #6440D4;
+  --hold-soft: #ECE6FC;
+  --shadow: 0 1px 2px rgba(22, 26, 34, .04), 0 6px 20px rgba(22, 26, 34, .05);
+  --font-ui: 'Schibsted Grotesk', system-ui, sans-serif;
+  --font-mono: 'IBM Plex Mono', ui-monospace, monospace;
+
+  background: var(--canvas);
+  color: var(--ink);
+  font-family: var(--font-ui);
+  -webkit-font-smoothing: antialiased;
+  min-height: 100vh;
+}
+
+.admin-v2[data-theme='dark'] {
+  --canvas: #0F1116;
+  --surface: #171A21;
+  --surface-2: #1E222B;
+  --ink: #EEF1F7;
+  --ink-2: #A6AEC1;
+  --ink-3: #707A8E;
+  --line: #272C38;
+  --line-strong: #3A4150;
+  --accent: #6D7FFF;
+  --accent-ink: #0F1116;
+  --accent-soft: #232A4E;
+  --accent-text: #96A3FF;
+  --ok: #4CC38A;
+  --ok-soft: #153226;
+  --warn: #F0A33A;
+  --warn-soft: #37280F;
+  --bad: #F0655A;
+  --bad-soft: #3B1815;
+  --hold: #A78BFF;
+  --hold-soft: #251D48;
+  --shadow: 0 1px 2px rgba(0, 0, 0, .35), 0 6px 20px rgba(0, 0, 0, .28);
+}
+
+/* ── Focus (DS §4: 2px accent outline, 2px offset, everywhere) ── */
+.admin-v2 :focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* ── Type scale (DS §2) ── */
+.av2-h1 { font-size: 23px; font-weight: 800; letter-spacing: -0.015em; color: var(--ink); }
+.av2-kpi { font-size: 42px; font-weight: 800; letter-spacing: -0.03em; color: var(--ink); line-height: 1.05; }
+.av2-h2 { font-size: 15px; font-weight: 800; letter-spacing: -0.01em; color: var(--ink); }
+.av2-caption { font-size: 11.5px; font-weight: 600; color: var(--ink-2); }
+.av2-microcaps {
+  font-size: 10.5px; font-weight: 700; letter-spacing: .05em;
+  text-transform: uppercase; color: var(--ink-2);
+}
+.av2-mono { font-family: var(--font-mono); }
+.av2-meta { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; color: var(--ink-3); }
+
+/* ── Card (DS §3/§4: radius 14, one shadow token, hairline border) ── */
+.av2-card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  box-shadow: var(--shadow);
+}
+.av2-card-head {
+  display: flex; align-items: center; gap: 10px;
+  padding: 13px 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+/* ── Chips (DS §4: 10.5/700, radius 6; color never alone — glyph/label carries state) ── */
+.av2-chip {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-size: 10.5px; font-weight: 700;
+  border-radius: 6px; padding: 2px 8px;
+  background: var(--surface-2); color: var(--ink-2);
+  white-space: nowrap;
+}
+.av2-chip--accent { background: var(--accent-soft); color: var(--accent-text); }
+.av2-chip--ok { background: var(--ok-soft); color: var(--ok); }
+.av2-chip--warn { background: var(--warn-soft); color: var(--warn); }
+.av2-chip--bad { background: var(--bad-soft); color: var(--bad); }
+.av2-chip--hold { background: var(--hold-soft); color: var(--hold); }
+
+/* Removable filter chip (mono, accent-soft) */
+.av2-filterchip {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  background: var(--accent-soft); color: var(--accent-text);
+  border-radius: 7px; padding: 4px 9px; border: none; cursor: pointer;
+}
+
+/* ── Buttons (DS §4: one primary per screen) ── */
+.av2-btn {
+  height: 40px; display: inline-flex; align-items: center; gap: 8px;
+  padding: 0 14px; border-radius: 10px; font-size: 13px; font-weight: 600;
+  background: var(--surface); color: var(--ink);
+  border: 1px solid var(--line-strong); cursor: pointer;
+  font-family: var(--font-ui);
+}
+.av2-btn--primary { background: var(--accent); color: var(--accent-ink); border-color: var(--accent); font-weight: 700; }
+.av2-btn--ghost { background: var(--surface-2); color: var(--ink-2); border-color: transparent; font-weight: 700; font-size: 12.5px; padding: 0 12px; }
+.av2-btn--danger { background: var(--bad); color: #fff; border-color: var(--bad); font-weight: 700; }
+.av2-btn--sm { height: 32px; border-radius: 9px; font-size: 12.5px; padding: 0 12px; }
+.av2-btn:disabled { opacity: .5; cursor: not-allowed; }
+
+/* Segmented period control (ink-filled active) */
+.av2-seg { display: inline-flex; background: var(--surface); border: 1px solid var(--line); border-radius: 10px; padding: 3px; }
+.av2-seg button {
+  height: 34px; padding: 0 14px; border: none; background: transparent;
+  color: var(--ink-2); font-size: 12.5px; font-weight: 700; border-radius: 8px;
+  cursor: pointer; font-family: var(--font-ui);
+}
+.av2-seg button[aria-pressed='true'] { background: var(--ink); color: var(--canvas); }
+
+/* ── Inputs ── */
+.av2-input {
+  height: 40px; display: flex; align-items: center; gap: 8px; width: 100%;
+  padding: 0 12px; background: var(--surface);
+  border: 1px solid var(--line-strong); border-radius: 10px;
+  font-size: 13px; color: var(--ink); font-family: var(--font-ui);
+}
+.av2-input::placeholder { color: var(--ink-3); }
+
+/* ── Table anatomy (DS §4: header 38px surface-2 micro-caps, rows ≥44px) ── */
+.av2-thead {
+  display: flex; align-items: center; gap: 12px; padding: 0 16px; height: 38px;
+  background: var(--surface-2); border-bottom: 1px solid var(--line);
+}
+.av2-row {
+  display: flex; align-items: center; gap: 12px; padding: 6px 16px;
+  min-height: 48px; border-bottom: 1px solid var(--line);
+  cursor: pointer; text-align: left; width: 100%;
+  background: transparent; border-left: none; border-right: none; border-top: none;
+  font-family: var(--font-ui); color: var(--ink);
+}
+.av2-row:hover { background: var(--surface-2); }
+.av2-row[data-selected='true'] { background: var(--accent-soft); }
+
+/* ── Attention queue rows (severity grammar ▲◆●) ── */
+.av2-qrow {
+  display: flex; align-items: center; gap: 12px; padding: 10px 16px;
+  border-bottom: 1px solid var(--line); text-decoration: none; color: inherit;
+}
+.av2-qrow:hover { background: var(--surface-2); }
+.av2-qicon {
+  width: 32px; height: 32px; flex: none; border-radius: 9px;
+  display: flex; align-items: center; justify-content: center; font-size: 13px;
+}
+
+/* ── Skeleton (mirrors final geometry, zero reflow) ── */
+.av2-skeleton {
+  border-radius: 8px;
+  background: linear-gradient(90deg, var(--line) 30%, var(--surface-2) 50%, var(--line) 70%);
+  background-size: 200% 100%;
+  animation: av2-shimmer 1.4s ease-in-out infinite;
+}
+@keyframes av2-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* ── Bulk bar (ink-filled, floating bottom-center while selection exists) ── */
+.av2-bulkbar {
+  position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%);
+  display: flex; align-items: center; gap: 10px;
+  background: var(--ink); color: var(--canvas);
+  border-radius: 14px; padding: 10px 14px; z-index: 60;
+  box-shadow: var(--shadow);
+}
+.av2-bulkbar .av2-btn--sm {
+  background: transparent; color: var(--canvas); border: 1px solid var(--ink-2);
+}
+
+/* ── Sidebar nav ── */
+.av2-nav a {
+  display: flex; align-items: center; gap: 10px;
+  height: 36px; padding: 0 12px; border-radius: 9px;
+  font-size: 13px; font-weight: 600; color: var(--ink-2); text-decoration: none;
+}
+.av2-nav a:hover { background: var(--surface-2); color: var(--ink); }
+.av2-nav a[aria-current='page'] { background: var(--accent); color: var(--accent-ink); font-weight: 700; }
+
+/* KV rows in the drawer */
+.av2-kv { display: flex; gap: 12px; font-size: 12.5px; padding: 3px 0; }
+.av2-kv > span:first-child { width: 110px; flex: none; color: var(--ink-3); }
+.av2-kv > span:last-child { font-family: var(--font-mono); color: var(--ink); overflow-wrap: anywhere; }


### PR DESCRIPTION
## What

PR3 of Phase C (`docs/plans/mktr-admin-rebuild-implementation.md`) — the first slice of the **Switchboard admin rebuild** on the finalized design (claude.ai/design `57e68763`), **dark behind `VITE_ADMIN_V2_ENABLED`**. Flag ON swaps the same admin URLs onto v2 screens (bookmarks survive); flag OFF builds byte-equivalent legacy behavior (verified: adminV2 CSS/fonts stay in the lazy shell chunk; the one new route registers only when the flag is on).

### Included
- **Theme layer** — the full Switchboard token set (light + `[data-theme=dark]`, AA-checked), Schibsted Grotesk + IBM Plex Mono, scoped under `.admin-v2`; token-driven primitives (cards, chips, table anatomy, skeletons, bulk bar, severity glyphs ▲◆●).
- **Shell** — 228px sidebar with the rebuilt IA (no fleet/finance/APK slots), sticky topbar, persisted theme toggle.
- **Dashboard** — period control recomputes everything; KPI + sparkline (`/series`), health strip + needs-attention queue composed from `/attention` facts (severity-ordered, whole-row pre-filtered deep links), funnel with honest "est." scans, recent-leads stream, campaign leaderboard with committed-demand badges and the **server-authoritative** zero-commitment set.
- **Prospects** — URL-as-filter-truth (shareable, back/forward safe, removable chips incl. legacy `?campaign=`/`?qrTagId=` deep links), multi-select status/source, held/unassigned toggles, debounced race-safe search, server sort + 25/page, 432px drawer (contact / attribution / routing / consent / timeline), and a **live** bulk bar: assign-to-agent, return-to-held, delete-with-confirm (server-count toasts), CSV export (RFC-4180, formula-injection guarded, BOM'd).
- **Honest stubs** — `/AdminWallets` renders a labeled "arrives with PR4" page preserving query state.

### Backend riders (from the review)
- **BLOCKER fix**: bulk assign/return-to-held now **fence external-buyer-owned leads** — the pre-existing hole could double-own a lead (`assignedAgentId` written while `externalAgentId` stayed) or quarantine a lead a buyer paid for. Fence + `skipped.externalOwned` accounting + two DB-backed tests.
- Prospects search now matches **phone** (space-insensitive), delivering the UI's placeholder promise.

## Review

Post-implementation Codex review (gpt-5.6-sol xhigh): 1 BLOCKER / 7 MAJOR / 6 MINOR — all verified against code; 12 fixed, 2 documented as accepted parity (bulk-delete's Lyfe-orphan limitation exists identically in the legacy admin; full grid a11y semantics deferred to PR4 polish). Full disposition table in the plan doc.

## Tests

- 17 vitest cases on the pure core (attention composition, severity ordering, five-reason copy completeness, CSV injection guards incl. hidden-marker variants, SGT formatters).
- 2 new DB-backed fence tests + 2 updated search-shape expectations (backend).
- Full sweeps: vitest 1175/1176 (pre-existing PublicPreview red), `vite build` green flag ON and OFF, backend two-shard = exactly the 7 chronic baseline reds. **Zero regressions.**

## After merge

Stays dark. To preview: set `VITE_ADMIN_V2_ENABLED=true` locally (or on the static site when ready) — Dashboard + Prospects go v2, everything else stays legacy until PR4 (Campaigns/Agents/Groups/Wallets) and PR5 (QR/Links/Users/AI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)