### PR TITLE
fix(admin-v2): shadcn bridge clobbered Switchboard --accent — invisible primary buttons (live)

### DIFF
--- a/src/components/adminv2/AdminV2Shell.jsx
+++ b/src/components/adminv2/AdminV2Shell.jsx
@@ -45,7 +45,7 @@ export function useAdminV2Theme() {
   return [theme, setTheme];
 }
 
-export default function AdminV2Shell({ children, fullBleed = false }) {
+export default function AdminV2Shell({ children, fullBleed = false, legacyBridge = false }) {
   const [theme, setTheme] = useAdminV2Theme();
   const navigate = useNavigate();
   const logout = useAuthStore((s) => s.logout);
@@ -60,7 +60,7 @@ export default function AdminV2Shell({ children, fullBleed = false }) {
   };
 
   return (
-    <div className="admin-v2" data-theme={theme}>
+    <div className={legacyBridge ? 'admin-v2 av2-legacy-bridge' : 'admin-v2'} data-theme={theme}>
       <div style={{ display: 'flex', minHeight: '100vh' }}>
         {/* ── Sidebar (228px fixed) ── */}
         <aside

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -368,7 +368,7 @@ function PagesContent() {
  path="/admin/campaigns/new" element={
  <ProtectedRoute requiredRole="admin">
  {ADMIN_V2 ? (
- <AdminV2Shell>
+ <AdminV2Shell legacyBridge>
  <AdminCampaignForm />
  </AdminV2Shell>
  ) : (
@@ -383,7 +383,7 @@ function PagesContent() {
  path="/admin/campaigns/:id/edit" element={
  <ProtectedRoute requiredRole="admin">
  {ADMIN_V2 ? (
- <AdminV2Shell>
+ <AdminV2Shell legacyBridge>
  <AdminCampaignForm />
  </AdminV2Shell>
  ) : (
@@ -399,7 +399,7 @@ function PagesContent() {
  path="/admin/campaigns/workspace" element={
  <ProtectedRoute requiredRole="admin">
  {ADMIN_V2 ? (
- <AdminV2Shell fullBleed>
+ <AdminV2Shell fullBleed legacyBridge>
  <AdminCampaignWorkspace />
  </AdminV2Shell>
  ) : (
@@ -414,7 +414,7 @@ function PagesContent() {
  path="/admin/campaigns/:id/workspace" element={
  <ProtectedRoute requiredRole="admin">
  {ADMIN_V2 ? (
- <AdminV2Shell fullBleed>
+ <AdminV2Shell fullBleed legacyBridge>
  <AdminCampaignWorkspace />
  </AdminV2Shell>
  ) : (
@@ -507,7 +507,7 @@ function PagesContent() {
  path="/AdminCampaignDesigner" element={
  <ProtectedRoute requiredRole="admin">
  {ADMIN_V2 ? (
- <AdminV2Shell fullBleed>
+ <AdminV2Shell fullBleed legacyBridge>
  <AdminCampaignDesigner />
  </AdminV2Shell>
  ) : (

--- a/src/styles/adminV2.css
+++ b/src/styles/adminV2.css
@@ -215,10 +215,16 @@
 /* ── Legacy-token bridge (campaign editors inside the v2 shell) ──────────────
    The pre-rebuild editors (workspace / designer / form) are styled entirely
    with shadcn/Tropic tokens (bg-card, text-primary, border-border…). Remapping
-   those variables inside .admin-v2 reskins them to Switchboard wholesale —
-   same pattern as .gr-designer-chrome. The customer-facing design preview
-   opts back out via .av2-theme-reset below. */
-.admin-v2 {
+   those variables reskins them to Switchboard wholesale — same pattern as
+   .gr-designer-chrome. The customer-facing design preview opts back out via
+   .av2-theme-reset below.
+
+   SCOPED to .av2-legacy-bridge (AdminV2Shell `legacyBridge` — only the five
+   editor routes), NOT bare .admin-v2: shadcn's token set collides with
+   Switchboard's own --accent, and declaring the triplet later on the same
+   selector clobbered `var(--accent)` for every v2 screen (invisible primary
+   buttons / checked checkboxes — live bug 2026-07-15). */
+.admin-v2.av2-legacy-bridge {
   --background: 220 27.3% 95.7%;
   --foreground: 220 21.4% 11%;
   --card: 0 0% 100%;
@@ -241,7 +247,7 @@
   --radius: 0.625rem;
 }
 
-.admin-v2[data-theme='dark'] {
+.admin-v2.av2-legacy-bridge[data-theme='dark'] {
   color-scheme: dark;
   --background: 222.9 18.9% 7.3%;
   --foreground: 220 36% 95.1%;


### PR DESCRIPTION
## Live visual break on mktr.sg admin (light + dark)

**Symptom** (Shawn's screenshot, /AdminCampaigns): the **+ New campaign** primary button renders white-on-white. Also broken everywhere in v2: checked checkbox glyphs on Prospects, accent chips (Marketplace / committed), accent links, dashboard series bars' accent.

**Cause**: shadcn's token set includes its own `--accent`. PR #165's editor bridge declared the shadcn triplets on bare `.admin-v2` *below* the Switchboard token block, so the cascade replaced Switchboard's `--accent: #2C46E6` with the raw triplet `229.1 91.7% 95.3%` — an invalid color for every `background: var(--accent)` consumer → transparent background under `--accent-ink` white text.

**Fix**: the bridge moves to `.admin-v2.av2-legacy-bridge`, applied through a new `legacyBridge` prop on `AdminV2Shell` by exactly the five legacy-editor routes (workspace ×2, form ×2, designer). The v2 screens never needed the bridge — they're pure Switchboard tokens — so this restores their tested state while the editors keep the full reskin. `.av2-theme-reset` (the customer preview opt-out) is untouched.

**Verified**: compiled `AdminV2Shell` chunk has bare `.admin-v2 → --accent: #2C46E6` and bridge triplets only under the scoped class; zero unscoped triplet blocks; build green flag-on; component tests green (only the pre-existing `PublicPreview` failure, reproduced on pristine main).

Codex skipped — live P0 precedent (#164). No conflict with open PR #166 (disjoint files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)