### PR TITLE
feat(redeem-ops): cadence & outstanding tasks on the business detail rail

### DIFF
--- a/src/components/redeemops/__tests__/cadence.test.jsx
+++ b/src/components/redeemops/__tests__/cadence.test.jsx
@@ -27,6 +27,8 @@ const api = vi.hoisted(() => ({
   createCadenceVersion: vi.fn(),
   retireCadence: vi.fn(),
   suggestCadence: vi.fn(),
+  listTasks: vi.fn(),
+  updateTask: vi.fn(),
 }));
 vi.mock('@/api/redeemOps', () => ({ redeemOpsApi: api }));
 
@@ -65,6 +67,8 @@ beforeEach(() => {
   api.completeCadenceTask.mockResolvedValue({ nextTask: null });
   // The editor fetches the list in NEW mode too (it carries aiEnabled).
   api.listCadences.mockResolvedValue({ cadences: [], aiEnabled: false });
+  api.listTasks.mockResolvedValue({ tasks: [] });
+  api.updateTask.mockResolvedValue({});
 });
 
 describe('CadenceChip', () => {
@@ -257,5 +261,98 @@ describe('CadencePanel', () => {
     api.getPartnerCadence.mockResolvedValue({ enrollment: null, openTask: null });
     wrap(<CadencePanel partner={{ id: 'p-1', ownerUserId: 'u-1', pipelineStage: 'NEW' }} />);
     expect(await screen.findByRole('button', { name: /start cadence/i })).toBeInTheDocument();
+  });
+});
+
+/* ── The Cadence & Tasks rail section (Business Detail design) ── */
+
+const activeEnrollment = {
+  id: 'e-1', state: 'active',
+  cadence: { id: 'c-1', name: 'F&B call-first', version: 1, steps: [
+    { id: 's-1', stepOrder: 1, title: 'Intro call' },
+    { id: 's-2', stepOrder: 2, title: 'WhatsApp intro' },
+  ] },
+  currentStep: { id: 's-2', stepOrder: 2 },
+};
+
+function isoDaysFromToday(days) {
+  const d = new Date(); d.setHours(9, 0, 0, 0); d.setDate(d.getDate() + days);
+  return d.toISOString();
+}
+
+const cadenceRowTask = {
+  id: 'task-c', title: 'WhatsApp intro', partnerOrganisationId: 'p-1', status: 'open',
+  dueAt: isoDaysFromToday(0), snapshotRecipient: '+6581234567',
+  cadenceStep: { id: 's-2', stepOrder: 2, channel: 'whatsapp', title: 'WhatsApp intro', cadence: { id: 'c-1', name: 'F&B call-first', version: 1 } },
+};
+const overdueManualTask = {
+  id: 'task-m1', title: 'Prepare partnership one-pager', partnerOrganisationId: 'p-1',
+  status: 'open', dueAt: isoDaysFromToday(-1), cadenceStep: null,
+};
+const laterManualTask = {
+  id: 'task-m2', title: 'Call Sarah re: trial-class slots', partnerOrganisationId: 'p-1',
+  status: 'open', dueAt: isoDaysFromToday(3), cadenceStep: null,
+};
+
+describe('CadencePanel — outstanding tasks zone', () => {
+  it('lists the cadence task first (Outcome) and manual tasks with one-click complete', async () => {
+    api.getPartnerCadence.mockResolvedValue({ enrollment: activeEnrollment, openTask: cadenceRowTask });
+    api.listTasks.mockResolvedValue({ tasks: [overdueManualTask, cadenceRowTask, laterManualTask] });
+    const user = userEvent.setup();
+    wrap(<CadencePanel partner={{ id: 'p-1', ownerUserId: 'u-1', pipelineStage: 'MEETING' }} />);
+
+    // header count + overdue tally
+    expect(await screen.findByText('· 3')).toBeInTheDocument();
+    expect(screen.getByText('1 overdue')).toBeInTheDocument();
+
+    // the cadence task is actionable via Outcome, never a checkbox
+    expect(screen.getByRole('button', { name: /outcome/i })).toBeEnabled();
+    expect(screen.queryByRole('button', { name: /complete whatsapp intro/i })).not.toBeInTheDocument();
+
+    // manual tasks complete through the generic PATCH
+    await user.click(screen.getByRole('button', { name: /complete prepare partnership one-pager/i }));
+    await waitFor(() => expect(api.updateTask).toHaveBeenCalledWith('task-m1', { status: 'completed' }));
+  });
+
+  it('a paused enrollment freezes the cadence task row', async () => {
+    api.getPartnerCadence.mockResolvedValue({
+      enrollment: { ...activeEnrollment, state: 'paused' },
+      openTask: cadenceRowTask,
+    });
+    api.listTasks.mockResolvedValue({ tasks: [cadenceRowTask] });
+    wrap(<CadencePanel partner={{ id: 'p-1', ownerUserId: 'u-1', pipelineStage: 'MEETING' }} />);
+    expect(await screen.findByText(/no tasks will be scheduled until resumed/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /outcome/i })).toBeDisabled();
+  });
+
+  it('truncates past four rows into "View all n" linking to the filtered Tasks page', async () => {
+    api.getPartnerCadence.mockResolvedValue({ enrollment: null, openTask: null });
+    api.listTasks.mockResolvedValue({
+      tasks: [1, 2, 3, 4, 5, 6].map((n) => ({
+        id: `t-${n}`, title: `Manual task ${n}`, partnerOrganisationId: 'p-1',
+        status: 'open', dueAt: isoDaysFromToday(n), cadenceStep: null,
+      })),
+    });
+    wrap(<CadencePanel partner={{ id: 'p-1', ownerUserId: 'u-1', pipelineStage: 'NEW' }} />);
+    const viewAll = await screen.findByRole('link', { name: /view all 6/i });
+    expect(viewAll).toHaveAttribute('href', '/redeem-ops/tasks?partnerId=p-1');
+    expect(screen.getByText('Manual task 4')).toBeInTheDocument();
+    expect(screen.queryByText('Manual task 5')).not.toBeInTheDocument();
+  });
+
+  it('the ghost add opens the page dialog; terminal stages hide it', async () => {
+    api.getPartnerCadence.mockResolvedValue({ enrollment: null, openTask: null });
+    const onAddTask = vi.fn();
+    const user = userEvent.setup();
+    const { unmount } = wrap(
+      <CadencePanel partner={{ id: 'p-1', ownerUserId: 'u-1', pipelineStage: 'NEW' }} onAddTask={onAddTask} />
+    );
+    await user.click(await screen.findByRole('button', { name: /add task/i }));
+    expect(onAddTask).toHaveBeenCalledTimes(1);
+    unmount();
+
+    wrap(<CadencePanel partner={{ id: 'p-1', ownerUserId: 'u-1', pipelineStage: 'LOST' }} onAddTask={onAddTask} />);
+    await screen.findByText(/no open tasks/i);
+    expect(screen.queryByRole('button', { name: /add task/i })).not.toBeInTheDocument();
   });
 });

--- a/src/components/redeemops/cadence.jsx
+++ b/src/components/redeemops/cadence.jsx
@@ -5,6 +5,9 @@ import { toast } from 'sonner';
 import Zap from 'lucide-react/icons/zap';
 import Eye from 'lucide-react/icons/eye';
 import Plus from 'lucide-react/icons/plus';
+import Check from 'lucide-react/icons/check';
+import Copy from 'lucide-react/icons/copy';
+import Ellipsis from 'lucide-react/icons/ellipsis';
 import { redeemOpsApi } from '@/api/redeemOps';
 import { useAuthStore } from '@/stores/authStore';
 import { hasCapability } from '@/lib/redeemOpsPermissions';
@@ -41,6 +44,9 @@ const CHANNEL_LABELS = {
   instagram_dm: 'Instagram DM', visit: 'Visit', custom: 'Step',
 };
 
+/* The rail shows at most this many rows; the rest sit behind "View all n". */
+const MAX_VISIBLE_TASKS = 4;
+
 function invalidateCadenceData(queryClient, partnerId) {
   queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'queue'] });
   queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'tasks'] });
@@ -48,6 +54,31 @@ function invalidateCadenceData(queryClient, partnerId) {
     queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partner', partnerId] });
     queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partner-cadence', partnerId] });
   }
+}
+
+/**
+ * Due label per the Cadence & Tasks spec: overdue reads "Overdue · 14 Jul" in
+ * red, today/tomorrow are words, anything later is "Wed 18 Jul" in gray.
+ */
+export function taskDueMeta(task) {
+  const due = new Date(task.dueAt);
+  const today = new Date(); today.setHours(0, 0, 0, 0);
+  const tomorrow = new Date(today); tomorrow.setDate(tomorrow.getDate() + 1);
+  const dayAfter = new Date(today); dayAfter.setDate(dayAfter.getDate() + 2);
+  if (due < today) {
+    return {
+      text: `Overdue · ${due.toLocaleDateString(undefined, { day: 'numeric', month: 'short' })}`,
+      color: 'var(--ro-tag-red-fg, #BD3A2E)',
+      overdue: true,
+    };
+  }
+  if (due < tomorrow) return { text: 'Due today', color: 'var(--ro-bunker, #0D1619)', overdue: false };
+  if (due < dayAfter) return { text: 'Due tomorrow', color: 'var(--ro-text-2)', overdue: false };
+  return {
+    text: due.toLocaleDateString(undefined, { weekday: 'short', day: 'numeric', month: 'short' }),
+    color: 'var(--ro-text-2)',
+    overdue: false,
+  };
 }
 
 /** Small pill marking a task as cadence-driven: "⚡ F&B call-first · 3". */
@@ -71,9 +102,9 @@ export function CadenceChip({ task }) {
  * an "Outcome" menu with only the channel-valid dispositions. One choice
  * completes the task, logs the honest activity, and schedules the next step.
  * `not_interested` confirms first and offers marking the business Lost in the
- * same transaction.
+ * same transaction. `disabled` freezes the button (paused enrollment).
  */
-export function CadenceOutcomeButton({ task, size = 'sm' }) {
+export function CadenceOutcomeButton({ task, size = 'sm', disabled = false, disabledHint }) {
   const queryClient = useQueryClient();
   const [confirmNI, setConfirmNI] = useState(false);
   const [alsoMarkLost, setAlsoMarkLost] = useState(true);
@@ -108,11 +139,26 @@ export function CadenceOutcomeButton({ task, size = 'sm' }) {
     completeMutation.mutate({ disposition });
   };
 
+  const copyScript = async () => {
+    try {
+      await navigator.clipboard.writeText(task.description);
+      toast.success('Message copied');
+    } catch {
+      toast.error('Could not copy — select the text instead');
+    }
+  };
+
   return (
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button size={size} variant="outline" className="ml-1 shrink-0" disabled={completeMutation.isPending}>
+          <Button
+            size={size}
+            variant="outline"
+            className="ml-1 shrink-0"
+            disabled={completeMutation.isPending || disabled}
+            title={disabled ? disabledHint : undefined}
+          >
             {completeMutation.isPending ? 'Saving…' : 'Outcome'}
           </Button>
         </DropdownMenuTrigger>
@@ -173,20 +219,127 @@ export function CadenceOutcomeButton({ task, size = 'sm' }) {
           <p className="text-sm whitespace-pre-wrap m-0" style={{ color: 'var(--ro-text-2)' }}>
             {task.description || 'No script for this step.'}
           </p>
+          {task.description && (
+            <DialogFooter>
+              <Button variant="outline" onClick={copyScript}>
+                <Copy className="w-3.5 h-3.5 mr-1.5" aria-hidden="true" /> Copy message
+              </Button>
+            </DialogFooter>
+          )}
         </DialogContent>
       </Dialog>
     </>
   );
 }
 
+/* 18px circle checkbox — one click completes a manual task (strike + fade
+   while the mutation is in flight, the invalidate removes the row). */
+function CompleteCircle({ task, busy, onComplete }) {
+  return (
+    <button
+      type="button"
+      aria-label={`Complete ${task.title}`}
+      disabled={busy}
+      onClick={() => onComplete(task.id)}
+      className="shrink-0 mt-0.5 grid place-items-center rounded-full transition-colors cursor-pointer"
+      style={{
+        width: 18, height: 18, padding: 0,
+        border: `1.8px solid ${busy ? 'var(--ro-azure, #037AFF)' : 'var(--ro-border-strong)'}`,
+        background: busy ? 'var(--ro-azure, #037AFF)' : '#fff',
+      }}
+    >
+      {busy && <Check className="w-3 h-3" strokeWidth={3} style={{ color: '#fff' }} aria-hidden="true" />}
+    </button>
+  );
+}
+
+/* One outstanding-task row in the rail card (spec note ③/④). */
+function PartnerTaskRow({
+  task, viewerId, canManage, frozen, terminal, onEditTask, onComplete, onCancel, completingId,
+}) {
+  const isCadence = !!task.cadenceStep;
+  const due = taskDueMeta(task);
+  const completing = completingId === task.id;
+  const assigneeNote = task.assignee && task.assignee.id !== viewerId ? task.assignee.fullName : null;
+
+  return (
+    <div
+      className={`relative flex items-start gap-2.5 px-5 py-3 border-t transition-opacity duration-300 ${frozen ? 'opacity-55' : ''} ${completing ? 'opacity-40' : ''}`}
+      style={{ borderTopColor: '#F0F2F4' }}
+    >
+      {due.overdue && !frozen && (
+        <span
+          aria-hidden="true"
+          className="absolute left-0 w-[3px] rounded-r"
+          style={{ top: 9, bottom: 9, background: 'var(--ro-tag-red-fg, #BD3A2E)' }}
+        />
+      )}
+      {!isCadence && canManage && (
+        <CompleteCircle task={task} busy={completing} onComplete={onComplete} />
+      )}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-start justify-between gap-2">
+          <p className={`text-[13.5px] font-semibold m-0 leading-snug flex-1 min-w-0 ${completing ? 'line-through' : ''}`}>
+            {task.title}
+          </p>
+          {isCadence && canManage && (
+            <span className="-mt-0.5">
+              <CadenceOutcomeButton task={task} disabled={frozen} disabledHint="Cadence paused" />
+            </span>
+          )}
+          {!isCadence && canManage && !terminal && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button size="sm" variant="ghost" className="-mt-0.5 h-7 w-7 p-0 shrink-0" aria-label={`Actions for ${task.title}`}>
+                  <Ellipsis className="w-4 h-4" style={{ color: 'var(--ro-text-3)' }} aria-hidden="true" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {onEditTask && (
+                  <DropdownMenuItem onSelect={() => onEditTask(task)}>Edit task</DropdownMenuItem>
+                )}
+                <DropdownMenuItem
+                  className="text-destructive focus:text-destructive"
+                  onSelect={() => onCancel(task.id)}
+                >
+                  Cancel task
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 mt-1">
+          {isCadence && <CadenceChip task={task} />}
+          <span className="text-xs font-semibold" style={{ color: due.color }}>{due.text}</span>
+          {task.snapshotRecipient && (
+            <span className="text-xs" style={{ color: 'var(--ro-text-3)' }}>→ {task.snapshotRecipient}</span>
+          )}
+          {assigneeNote && (
+            <span className="text-xs" style={{ color: 'var(--ro-text-3)' }}>for {assigneeNote}</span>
+          )}
+          {frozen && (
+            <span className="text-[11px] italic" style={{ color: 'var(--ro-text-3)' }}>paused</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 /**
- * Partner Detail cadence card (§8.2): live enrollment with step progress and
- * Pause/Resume/Stop, or an Enroll picker. `variant="summary"` renders the
- * compact mobile strip. Renders nothing while the feature flag is off.
+ * Partner Detail "Cadence & Tasks" rail section (design: claude.ai/design
+ * "Business Detail - Cadence & Tasks"): one card, two zones. Zone 1 is the
+ * cadence state (enrollment + step progress + Pause/Resume/Stop, or the
+ * Enroll picker; hidden while the feature flag is off). Zone 2 lists every
+ * outstanding task on the business — the live cadence task first (actionable
+ * via the Outcome menu), then manual tasks with one-click complete. The
+ * passive "Next: …" line is gone; the task row replaced it.
+ * `variant="summary"` renders the compact actionable mobile strip.
  */
-export function CadencePanel({ partner, canManage = true, variant = 'card' }) {
+export function CadencePanel({ partner, canManage = true, variant = 'card', onAddTask, onEditTask }) {
   const queryClient = useQueryClient();
   const [enrollOpen, setEnrollOpen] = useState(false);
+  const [stripExpanded, setStripExpanded] = useState(false);
   const partnerId = partner?.id;
   const authUser = useAuthStore((s) => s.user);
   // Anyone who works tasks can author; unpublished saves stay private drafts.
@@ -196,6 +349,13 @@ export function CadencePanel({ partner, canManage = true, variant = 'card' }) {
     queryKey: ['redeem-ops', 'partner-cadence', partnerId],
     queryFn: () => redeemOpsApi.getPartnerCadence(partnerId),
     enabled: CADENCES_ENABLED && !!partnerId,
+  });
+  // Outstanding tasks on THIS business. scope:'team' lets managers see every
+  // assignee's tasks; the backend ignores it for non-managers (own tasks only).
+  const tasksQuery = useQuery({
+    queryKey: ['redeem-ops', 'tasks', { partnerId }],
+    queryFn: () => redeemOpsApi.listTasks({ partnerId, scope: 'team' }),
+    enabled: !!partnerId,
   });
   const defsQuery = useQuery({
     queryKey: ['redeem-ops', 'cadences'],
@@ -232,17 +392,55 @@ export function CadencePanel({ partner, canManage = true, variant = 'card' }) {
     onSuccess: () => { toast.success('Cadence stopped'); invalidateCadenceData(queryClient, partnerId); },
     onError: (err) => toast.error('Could not stop', { description: err.message }),
   });
+  const completeTaskMutation = useMutation({
+    mutationFn: (taskId) => redeemOpsApi.updateTask(taskId, { status: 'completed' }),
+    onSuccess: () => { toast.success('Task completed'); invalidateCadenceData(queryClient, partnerId); },
+    onError: (err) => toast.error('Could not complete the task', { description: err.message }),
+  });
+  const cancelTaskMutation = useMutation({
+    mutationFn: (taskId) => redeemOpsApi.updateTask(taskId, { status: 'cancelled' }),
+    onSuccess: () => { toast.success('Task cancelled'); invalidateCadenceData(queryClient, partnerId); },
+    onError: (err) => toast.error('Could not cancel the task', { description: err.message }),
+  });
 
-  if (!CADENCES_ENABLED || !partnerId) return null;
+  if (!partnerId) return null;
 
-  const enrollment = cadenceQuery.data?.enrollment;
-  const openTask = cadenceQuery.data?.openTask;
+  const enrollment = CADENCES_ENABLED ? cadenceQuery.data?.enrollment : null;
   const live = enrollment && ['active', 'paused'].includes(enrollment.state);
+  const paused = enrollment?.state === 'paused';
   const steps = enrollment?.cadence?.steps || [];
   const currentOrder = enrollment?.currentStep?.stepOrder || 0;
   const terminalStage = ['PARTNERED', 'LOST'].includes(partner?.pipelineStage);
 
-  const enrollButton = canManage && !terminalStage && (
+  // Rows: the live cadence task always leads; manual tasks follow in the
+  // backend's dueAt-ascending order (overdue first by construction).
+  const openTasks = (tasksQuery.data?.tasks || [])
+    .filter((t) => t.status === 'open' || t.status === 'in_progress');
+  const cadenceTask = openTasks.find((t) => t.cadenceStep);
+  const manualTasks = openTasks.filter((t) => !t.cadenceStep);
+  const rows = [...(cadenceTask ? [cadenceTask] : []), ...manualTasks];
+  const overdueCount = rows.reduce((n, t) => n + (taskDueMeta(t).overdue ? 1 : 0), 0);
+  const visibleRows = rows.slice(0, MAX_VISIBLE_TASKS);
+  const truncated = rows.length > MAX_VISIBLE_TASKS;
+
+  const completingId = completeTaskMutation.isPending ? completeTaskMutation.variables : null;
+  const completeTask = (taskId) => completeTaskMutation.mutate(taskId);
+  const cancelTask = (taskId) => {
+    if (window.confirm('Cancel this task? It stays on the timeline as cancelled.')) {
+      cancelTaskMutation.mutate(taskId);
+    }
+  };
+  const rowProps = {
+    viewerId: authUser?.id,
+    canManage,
+    terminal: terminalStage,
+    onEditTask,
+    onComplete: completeTask,
+    onCancel: cancelTask,
+    completingId,
+  };
+
+  const enrollButton = CADENCES_ENABLED && canManage && !terminalStage && (
     <Button
       size="sm"
       className={variant === 'summary' ? 'shrink-0' : 'w-full'}
@@ -254,94 +452,210 @@ export function CadencePanel({ partner, canManage = true, variant = 'card' }) {
     </Button>
   );
 
-  const body = live ? (
-    <>
-      <div className="flex items-center justify-between gap-2">
-        <p className="text-sm font-semibold m-0 truncate">
-          {enrollment.cadence?.name}
-          <span className="font-normal" style={{ color: 'var(--ro-text-3)' }}> · v{enrollment.cadence?.version}</span>
+  /* ── Zone 1: cadence state (flag-gated) ── */
+  const cadenceZone = CADENCES_ENABLED && (
+    <div className="px-5 pt-5">
+      <div className="flex items-center justify-between gap-2 mb-3">
+        <p className="text-[15px] font-bold m-0 inline-flex items-center gap-1.5">
+          <Zap className="w-4 h-4" aria-hidden="true" /> Cadence
         </p>
-        <RoTag tone={enrollment.state === 'active' ? 'open' : 'follow_up_later'} size="sm">
-          {enrollment.state}
-        </RoTag>
+        {live && (
+          <RoTag tone={paused ? 'paused' : 'open'} size="sm">{enrollment.state}</RoTag>
+        )}
       </div>
-      {steps.length > 0 && (
-        <div className="flex items-center gap-1.5 mt-2.5" aria-label={`Step ${currentOrder} of ${steps.length}`}>
-          {steps.map((s) => (
-            <span
-              key={s.id}
-              className="h-1.5 rounded-full flex-1"
-              title={`${s.stepOrder}. ${s.title}`}
-              style={{
-                background: s.stepOrder < currentOrder
-                  ? 'var(--ro-azure, #037AFF)'
-                  : s.stepOrder === currentOrder ? 'var(--ro-bunker, #0D1619)' : 'var(--ro-subtle)',
-              }}
-            />
-          ))}
-        </div>
-      )}
-      <p className="text-[13px] mt-2 mb-0" style={{ color: 'var(--ro-text-2)' }}>
-        {enrollment.state === 'paused'
-          ? 'Paused — no tasks will be scheduled until resumed.'
-          : openTask
-            ? <>Next: <span className="font-semibold">{openTask.title}</span> · {new Date(openTask.dueAt).toLocaleDateString(undefined, { weekday: 'short', day: 'numeric', month: 'short' })}</>
-            : 'Scheduling next step…'}
-      </p>
-      {canManage && (
-        <div className="flex gap-1.5 mt-3">
-          {enrollment.state === 'active' ? (
-            <Button size="sm" variant="outline" disabled={pauseMutation.isPending} onClick={() => pauseMutation.mutate()}>Pause</Button>
-          ) : (
-            <Button size="sm" variant="outline" disabled={resumeMutation.isPending} onClick={() => resumeMutation.mutate()}>Resume</Button>
+      {cadenceQuery.isLoading ? (
+        <p className="text-[13px] m-0" style={{ color: 'var(--ro-text-2)' }}>Loading…</p>
+      ) : live ? (
+        <>
+          <div className="flex items-baseline justify-between gap-2">
+            <p className="text-[13.5px] font-semibold m-0 truncate">
+              {enrollment.cadence?.name}
+              <span className="font-normal" style={{ color: 'var(--ro-text-3)' }}> · v{enrollment.cadence?.version}</span>
+            </p>
+            {steps.length > 0 && (
+              <span className="text-[11.5px] font-semibold shrink-0" style={{ color: 'var(--ro-text-3)' }}>
+                Step {currentOrder} of {steps.length}
+              </span>
+            )}
+          </div>
+          {steps.length > 0 && (
+            <div className="flex items-center gap-1.5 mt-2.5" aria-label={`Step ${currentOrder} of ${steps.length}`}>
+              {steps.map((s) => (
+                <span
+                  key={s.id}
+                  className="h-1.5 rounded-full flex-1"
+                  title={`${s.stepOrder}. ${s.title}`}
+                  style={{
+                    background: s.stepOrder < currentOrder
+                      ? 'var(--ro-azure, #037AFF)'
+                      : s.stepOrder === currentOrder ? 'var(--ro-bunker, #0D1619)' : 'var(--ro-subtle)',
+                  }}
+                />
+              ))}
+            </div>
           )}
-          <Button size="sm" variant="ghost" disabled={stopMutation.isPending} onClick={() => stopMutation.mutate()}>Stop</Button>
+          {paused && (
+            <p className="text-[12.5px] mt-2 mb-0" style={{ color: 'var(--ro-tag-yellow-fg, #8F6400)' }}>
+              Paused — no tasks will be scheduled until resumed.
+            </p>
+          )}
+          {canManage && (
+            <div className="flex gap-1.5 mt-3">
+              {enrollment.state === 'active' ? (
+                <Button size="sm" variant="outline" disabled={pauseMutation.isPending} onClick={() => pauseMutation.mutate()}>Pause</Button>
+              ) : (
+                <Button size="sm" variant="outline" disabled={resumeMutation.isPending} onClick={() => resumeMutation.mutate()}>Resume</Button>
+              )}
+              <Button size="sm" variant="ghost" disabled={stopMutation.isPending} onClick={() => stopMutation.mutate()}>Stop</Button>
+            </div>
+          )}
+        </>
+      ) : (
+        <>
+          <p className="text-[13px] m-0 leading-relaxed" style={{ color: 'var(--ro-text-2)' }}>
+            {enrollment
+              ? `Last cadence ${enrollment.state === 'completed' ? 'finished' : `ended (${(enrollment.exitReason || '').replace(/_/g, ' ')})`}.`
+              : 'No cadence yet — enroll to auto-schedule every follow-up touch.'}
+          </p>
+          {enrollButton && <div className="mt-3">{enrollButton}</div>}
+        </>
+      )}
+    </div>
+  );
+
+  /* ── Zone 2: outstanding tasks on this business ── */
+  const tasksZone = (
+    <div className={CADENCES_ENABLED ? 'mt-4 border-t border-border' : ''}>
+      <div className="flex items-baseline justify-between gap-2 px-5 pt-3 pb-1">
+        <p className="text-[12.5px] font-bold m-0">
+          Tasks{rows.length > 0 && <span className="font-semibold" style={{ color: 'var(--ro-text-3)' }}> · {rows.length}</span>}
+        </p>
+        {overdueCount > 0 && (
+          <span className="text-[11.5px] font-semibold" style={{ color: 'var(--ro-tag-red-fg, #BD3A2E)' }}>
+            {overdueCount} overdue
+          </span>
+        )}
+      </div>
+      {visibleRows.map((t) => (
+        <PartnerTaskRow key={t.id} task={t} frozen={paused && !!t.cadenceStep} {...rowProps} />
+      ))}
+      {rows.length === 0 && !tasksQuery.isLoading && (
+        <p className="text-[12.5px] m-0 px-5 pb-3.5 leading-relaxed" style={{ color: 'var(--ro-text-3)' }}>
+          {canManage && !terminalStage
+            ? `No open tasks — add one${CADENCES_ENABLED ? ' or start a cadence' : ''}.`
+            : 'No open tasks.'}
+        </p>
+      )}
+      {truncated && (
+        <Link
+          to={`/redeem-ops/tasks?partnerId=${partnerId}`}
+          className="ro-link block px-5 py-1 text-[12.5px] font-semibold"
+        >
+          View all {rows.length}
+        </Link>
+      )}
+      {canManage && !terminalStage && onAddTask ? (
+        <div className="px-3 pt-1 pb-2.5">
+          <Button size="sm" variant="ghost" onClick={onAddTask} style={{ color: 'var(--ro-text-2)' }}>
+            <Plus className="w-3.5 h-3.5 mr-1" aria-hidden="true" /> Add task
+          </Button>
+        </div>
+      ) : (
+        rows.length > 0 && <div className="h-2.5" aria-hidden="true" />
+      )}
+    </div>
+  );
+
+  /* ── Mobile strip: the primary owed task, actionable in place ── */
+  const primary = rows[0];
+  const others = rows.slice(1);
+  const othersOverdue = others.reduce((n, t) => n + (taskDueMeta(t).overdue ? 1 : 0), 0);
+  const primaryDue = primary ? taskDueMeta(primary) : null;
+  const primaryContext = primary?.cadenceStep
+    ? `${primary.cadenceStep.cadence?.name || 'Cadence'} · ${primary.cadenceStep.stepOrder}`
+    : primary?.assignee && primary.assignee.id !== authUser?.id ? `for ${primary.assignee.fullName}` : null;
+
+  const strip = primary ? (
+    <>
+      <div className="flex items-center gap-2.5">
+        {primary.cadenceStep ? (
+          <Zap className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+        ) : canManage ? (
+          <CompleteCircle task={primary} busy={completingId === primary.id} onComplete={completeTask} />
+        ) : null}
+        <div className="flex-1 min-w-0">
+          <p className="text-[13px] font-semibold m-0 truncate">{primary.title}</p>
+          <p className="text-[11.5px] m-0 mt-0.5 truncate" style={{ color: 'var(--ro-text-3)' }}>
+            <span className="font-semibold" style={{ color: primaryDue.color }}>{primaryDue.text}</span>
+            {primaryContext && <span> · {primaryContext}</span>}
+            {paused && primary.cadenceStep && <span className="italic"> · paused</span>}
+          </p>
+        </div>
+        {canManage && (primary.cadenceStep ? (
+          <CadenceOutcomeButton task={primary} disabled={paused} disabledHint="Cadence paused" />
+        ) : (
+          <Button
+            size="sm" variant="outline" className="shrink-0"
+            disabled={completingId === primary.id}
+            onClick={() => completeTask(primary.id)}
+          >
+            Complete
+          </Button>
+        ))}
+      </div>
+      {others.length > 0 && (
+        <button
+          type="button"
+          className="ro-link block mt-1.5 p-0 border-0 bg-transparent text-xs font-semibold cursor-pointer"
+          onClick={() => setStripExpanded((v) => !v)}
+        >
+          {stripExpanded
+            ? 'Show less'
+            : `+${others.length} more${othersOverdue > 0 ? ` · ${othersOverdue} overdue` : ''}`}
+        </button>
+      )}
+      {stripExpanded && (
+        <div className="mt-2 border-t" style={{ borderTopColor: '#F0F2F4' }}>
+          {others.map((t) => {
+            const due = taskDueMeta(t);
+            return (
+              <div key={t.id} className="flex items-center gap-2 py-2 border-t first:border-t-0" style={{ borderTopColor: '#F0F2F4' }}>
+                {canManage && !t.cadenceStep && (
+                  <CompleteCircle task={t} busy={completingId === t.id} onComplete={completeTask} />
+                )}
+                <p className="text-[12.5px] font-semibold m-0 flex-1 min-w-0 truncate">{t.title}</p>
+                <span className="text-[11.5px] font-semibold shrink-0" style={{ color: due.color }}>{due.text}</span>
+              </div>
+            );
+          })}
         </div>
       )}
     </>
+  ) : live ? (
+    <p className="text-[13px] m-0" style={{ color: 'var(--ro-text-2)' }}>
+      <Zap className="w-3.5 h-3.5 inline mr-1 -mt-0.5" aria-hidden="true" />
+      <span className="font-semibold" style={{ color: 'var(--ro-bunker)' }}>
+        {enrollment.cadence?.name} · step {currentOrder}/{steps.length}
+      </span>
+      {paused ? ' · paused' : ' · scheduling next step…'}
+    </p>
   ) : (
-    <>
-      <p className="text-[13px] m-0 leading-relaxed" style={{ color: 'var(--ro-text-2)' }}>
-        {enrollment
-          ? `Last cadence ${enrollment.state === 'completed' ? 'finished' : `ended (${(enrollment.exitReason || '').replace(/_/g, ' ')})`}.`
-          : 'No cadence yet — enroll to auto-schedule every follow-up touch.'}
-      </p>
-      <div className="mt-3">{enrollButton}</div>
-    </>
+    <div className="flex items-center justify-between gap-2">
+      <p className="text-[13px] m-0" style={{ color: 'var(--ro-text-2)' }}>No open tasks</p>
+      {enrollButton}
+    </div>
   );
 
   return (
     <>
       {variant === 'summary' ? (
         <div className="rounded-2xl border border-border bg-white px-4 py-3 lg:hidden">
-          {live ? (
-            <div className="flex items-center justify-between gap-2">
-              <p className="text-[13px] font-semibold m-0 truncate">
-                <Zap className="w-3.5 h-3.5 inline mr-1 -mt-0.5" aria-hidden="true" />
-                {enrollment.cadence?.name} · step {currentOrder}/{steps.length}
-                {enrollment.state === 'paused' && <span style={{ color: 'var(--ro-text-3)' }}> · paused</span>}
-              </p>
-              {openTask && (
-                <span className="text-xs font-semibold shrink-0" style={{ color: 'var(--ro-text-2)' }}>
-                  {new Date(openTask.dueAt).toLocaleDateString(undefined, { day: 'numeric', month: 'short' })}
-                </span>
-              )}
-            </div>
-          ) : (
-            <div className="flex items-center justify-between gap-2">
-              <p className="text-[13px] m-0" style={{ color: 'var(--ro-text-2)' }}>No active cadence</p>
-              {enrollButton}
-            </div>
-          )}
+          {strip}
         </div>
       ) : (
-        <div className="rounded-2xl border border-border bg-white p-5">
-          <p className="text-[15px] font-bold m-0 mb-3">
-            <Zap className="w-4 h-4 inline mr-1 -mt-0.5" aria-hidden="true" /> Cadence
-          </p>
-          {cadenceQuery.isLoading ? (
-            <p className="text-[13px] m-0" style={{ color: 'var(--ro-text-2)' }}>Loading…</p>
-          ) : body}
+        <div className="rounded-2xl border border-border bg-white overflow-hidden">
+          {cadenceZone}
+          {tasksZone}
         </div>
       )}
 

--- a/src/pages/redeemops/PartnerDetail.jsx
+++ b/src/pages/redeemops/PartnerDetail.jsx
@@ -266,6 +266,7 @@ function OnboardingChecklist({ partnerId }) {
 const EMPTY_ACTIVITY = { type: 'call_attempt', summary: '', details: '', outcome: '', contactId: '' };
 const EMPTY_CONTACT = { name: '', roleTitle: '', mobile: '', email: '' };
 const EMPTY_LOCATION = { name: '', addressLine: '', postalCode: '', phone: '' };
+const EMPTY_TASK_FORM = { title: '', dueDate: '', priority: 'medium', description: '', assigneeUserId: '' };
 
 export default function PartnerDetail() {
   const { id } = useParams();
@@ -289,7 +290,8 @@ export default function PartnerDetail() {
   const teamQuery = useQuery({
     queryKey: ['redeem-ops', 'team'],
     queryFn: redeemOpsApi.getTeam,
-    enabled: hasCapability(user, 'partners.reassign'),
+    // Reassign pickers AND the task-dialog assignee select both need the roster.
+    enabled: hasCapability(user, 'partners.reassign') || hasCapability(user, 'pipeline.view_team'),
   });
 
   const invalidate = () => {
@@ -350,23 +352,56 @@ export default function PartnerDetail() {
   });
 
   const [taskOpen, setTaskOpen] = useState(false);
-  const [task, setTask] = useState({ title: '', dueDate: '', priority: 'medium' });
+  const [task, setTask] = useState(EMPTY_TASK_FORM);
+  const invalidateTasks = () => {
+    queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'tasks'] });
+    queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'queue'] });
+    queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partner', id, 'timeline'] });
+  };
   const taskMutation = useMutation({
     mutationFn: () => redeemOpsApi.createTask({
       partnerOrganisationId: id,
       title: task.title.trim(),
       dueAt: new Date(`${task.dueDate}T09:00:00`).toISOString(),
       priority: task.priority,
+      ...(task.description.trim() ? { description: task.description.trim() } : {}),
+      ...(task.assigneeUserId ? { assigneeUserId: task.assigneeUserId } : {}),
     }),
     onSuccess: () => {
       toast.success('Task created');
       setTaskOpen(false);
-      setTask({ title: '', dueDate: '', priority: 'medium' });
-      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'tasks'] });
-      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'queue'] });
-      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partner', id, 'timeline'] });
+      setTask(EMPTY_TASK_FORM);
+      invalidateTasks();
     },
     onError: (err) => toast.error('Could not create task', { description: err.message }),
+  });
+
+  // Edit an outstanding manual task in place (rail card ⋯ menu).
+  const [taskEdit, setTaskEdit] = useState(null); // { id, title, dueDate, priority, description, assigneeUserId }
+  const taskEditMutation = useMutation({
+    mutationFn: () => redeemOpsApi.updateTask(taskEdit.id, {
+      title: taskEdit.title.trim(),
+      dueAt: new Date(`${taskEdit.dueDate}T09:00:00`).toISOString(),
+      priority: taskEdit.priority,
+      description: taskEdit.description.trim() || null,
+      ...(hasCapability(user, 'pipeline.view_team') && taskEdit.assigneeUserId
+        ? { assigneeUserId: taskEdit.assigneeUserId }
+        : {}),
+    }),
+    onSuccess: () => {
+      toast.success('Task updated');
+      setTaskEdit(null);
+      invalidateTasks();
+    },
+    onError: (err) => toast.error('Could not update task', { description: err.message }),
+  });
+  const openTaskEdit = (t) => setTaskEdit({
+    id: t.id,
+    title: t.title,
+    dueDate: new Date(t.dueAt).toISOString().slice(0, 10),
+    priority: t.priority,
+    description: t.description || '',
+    assigneeUserId: t.assigneeUserId || '',
   });
 
   const [editForm, setEditForm] = useState(null); // null = closed; object = open
@@ -624,10 +659,16 @@ export default function PartnerDetail() {
         </div>
       </div>
 
-      {/* Mobile: the cadence state sits right under the header — the 320px rail
-          lands below all tab content on small screens (cadence.jsx renders
-          nothing while the feature flag is off). */}
-      <CadencePanel partner={partner} canManage={hasCapability(user, 'tasks.manage')} variant="summary" />
+      {/* Mobile: the primary owed task (cadence or manual) is actionable right
+          under the header — the 320px rail lands below all tab content on
+          small screens, so the strip is the mobile surface for tasks. */}
+      <CadencePanel
+        partner={partner}
+        canManage={hasCapability(user, 'tasks.manage')}
+        variant="summary"
+        onAddTask={() => setTaskOpen(true)}
+        onEditTask={openTaskEdit}
+      />
 
       <div className="grid gap-5 lg:grid-cols-[1fr_320px] items-start">
         <Tabs defaultValue="timeline">
@@ -754,9 +795,6 @@ export default function PartnerDetail() {
         </Tabs>
 
         <div className="space-y-4">
-          <div className="hidden lg:block">
-            <CadencePanel partner={partner} canManage={hasCapability(user, 'tasks.manage')} />
-          </div>
           <div className="rounded-2xl border border-border bg-white p-5">
             <p className="text-[15px] font-bold m-0 mb-3">Owner</p>
             {partner.owner ? (
@@ -776,6 +814,15 @@ export default function PartnerDetail() {
                 Unowned — claim it to start outreach.
               </p>
             )}
+          </div>
+
+          <div className="hidden lg:block">
+            <CadencePanel
+              partner={partner}
+              canManage={hasCapability(user, 'tasks.manage')}
+              onAddTask={() => setTaskOpen(true)}
+              onEditTask={openTaskEdit}
+            />
           </div>
 
           {partner.notes && (
@@ -851,6 +898,28 @@ export default function PartnerDetail() {
                 </Select>
               </div>
             </div>
+            {hasCapability(user, 'pipeline.view_team') && (teamQuery.data || []).filter((m) => m.isActive).length > 0 && (
+              <div className="space-y-1.5">
+                <Label>Assign to</Label>
+                <Select value={task.assigneeUserId} onValueChange={(assigneeUserId) => setTask((t) => ({ ...t, assigneeUserId }))}>
+                  <SelectTrigger><SelectValue placeholder="Myself" /></SelectTrigger>
+                  <SelectContent>
+                    {(teamQuery.data || []).filter((m) => m.isActive).map((m) => (
+                      <SelectItem key={m.id} value={m.id}>{m.fullName || m.email}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+            <div className="space-y-1.5">
+              <Label>Description <span className="font-normal" style={{ color: 'var(--ro-text-3)' }}>(optional — scripts live here)</span></Label>
+              <Textarea
+                rows={3}
+                value={task.description}
+                onChange={(e) => setTask((t) => ({ ...t, description: e.target.value }))}
+                placeholder="Call script, context, links…"
+              />
+            </div>
           </div>
           <DialogFooter>
             <Button
@@ -858,6 +927,75 @@ export default function PartnerDetail() {
               disabled={!task.title.trim() || !task.dueDate || taskMutation.isPending}
             >
               {taskMutation.isPending ? 'Saving…' : 'Create task'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={!!taskEdit} onOpenChange={(open) => { if (!open) setTaskEdit(null); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit task</DialogTitle>
+          </DialogHeader>
+          {taskEdit && (
+            <div className="space-y-3 py-2">
+              <div className="space-y-1.5">
+                <Label>What needs doing? *</Label>
+                <Input
+                  value={taskEdit.title}
+                  onChange={(e) => setTaskEdit((t) => ({ ...t, title: e.target.value }))}
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label>Due date *</Label>
+                  <Input
+                    type="date"
+                    value={taskEdit.dueDate}
+                    onChange={(e) => setTaskEdit((t) => ({ ...t, dueDate: e.target.value }))}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label>Priority</Label>
+                  <Select value={taskEdit.priority} onValueChange={(priority) => setTaskEdit((t) => ({ ...t, priority }))}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="low">Low</SelectItem>
+                      <SelectItem value="medium">Medium</SelectItem>
+                      <SelectItem value="high">High</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              {hasCapability(user, 'pipeline.view_team') && (teamQuery.data || []).filter((m) => m.isActive).length > 0 && (
+                <div className="space-y-1.5">
+                  <Label>Assignee</Label>
+                  <Select value={taskEdit.assigneeUserId} onValueChange={(assigneeUserId) => setTaskEdit((t) => ({ ...t, assigneeUserId }))}>
+                    <SelectTrigger><SelectValue placeholder="Unchanged" /></SelectTrigger>
+                    <SelectContent>
+                      {(teamQuery.data || []).filter((m) => m.isActive).map((m) => (
+                        <SelectItem key={m.id} value={m.id}>{m.fullName || m.email}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+              <div className="space-y-1.5">
+                <Label>Description <span className="font-normal" style={{ color: 'var(--ro-text-3)' }}>(optional — scripts live here)</span></Label>
+                <Textarea
+                  rows={3}
+                  value={taskEdit.description}
+                  onChange={(e) => setTaskEdit((t) => ({ ...t, description: e.target.value }))}
+                />
+              </div>
+            </div>
+          )}
+          <DialogFooter>
+            <Button
+              disabled={!taskEdit?.title?.trim() || !taskEdit?.dueDate || taskEditMutation.isPending}
+              onClick={() => taskEditMutation.mutate()}
+            >
+              {taskEditMutation.isPending ? 'Saving…' : 'Save changes'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/pages/redeemops/TasksPage.jsx
+++ b/src/pages/redeemops/TasksPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { redeemOpsApi } from '@/api/redeemOps';
@@ -20,6 +20,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import Plus from 'lucide-react/icons/plus';
 import Pencil from 'lucide-react/icons/pencil';
+import X from 'lucide-react/icons/x';
 import { RoMobileCard, RoPageHeader, RoTag, RoAvatar, prettyEnum } from '@/components/redeemops/ui';
 import { CadenceChip, CadenceOutcomeButton } from '@/components/redeemops/cadence';
 
@@ -112,13 +113,22 @@ export default function TasksPage() {
   const user = useAuthStore((s) => s.user);
   const isManager = hasCapability(user, 'pipeline.view_team');
   const queryClient = useQueryClient();
-  const [view, setView] = useState('today');
+  // "View all n" on a business detail page deep-links here pre-filtered.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const partnerId = searchParams.get('partnerId') || '';
+  const [view, setView] = useState(partnerId ? 'mine' : 'today');
 
   const activeView = VIEWS.find((v) => v.key === view) || VIEWS[0];
+  const listParams = { ...activeView.params, ...(partnerId ? { partnerId } : {}) };
   const tasksQuery = useQuery({
-    queryKey: ['redeem-ops', 'tasks', activeView.params],
-    queryFn: () => redeemOpsApi.listTasks({ ...activeView.params, limit: 50 }),
+    queryKey: ['redeem-ops', 'tasks', listParams],
+    queryFn: () => redeemOpsApi.listTasks({ ...listParams, limit: 50 }),
     placeholderData: keepPreviousData,
+  });
+  const filterPartnerQuery = useQuery({
+    queryKey: ['redeem-ops', 'partner', partnerId],
+    queryFn: () => redeemOpsApi.getPartner(partnerId),
+    enabled: !!partnerId,
   });
   const teamQuery = useQuery({
     queryKey: ['redeem-ops', 'team'],
@@ -195,6 +205,25 @@ export default function TasksPage() {
         </TabsList>
         </div>
       </Tabs>
+
+      {partnerId && (
+        <span
+          className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-[12.5px] font-semibold"
+          style={{ background: 'var(--ro-tag-blue-bg)', color: 'var(--ro-tag-blue-fg)' }}
+        >
+          {filterPartnerQuery.data
+            ? (filterPartnerQuery.data.tradingName || filterPartnerQuery.data.brandName || filterPartnerQuery.data.legalName)
+            : 'One business'}
+          <button
+            type="button"
+            aria-label="Clear business filter"
+            className="grid place-items-center rounded-full cursor-pointer border-0 bg-transparent p-0"
+            onClick={() => setSearchParams({}, { replace: true })}
+          >
+            <X className="w-3.5 h-3.5" aria-hidden="true" />
+          </button>
+        </span>
+      )}
 
       <div className="rounded-2xl border border-border bg-white overflow-hidden">
         <div className="md:hidden">


### PR DESCRIPTION
## What

Implements the claude.ai/design **"Business Detail - Cadence & Tasks"** mock (project `148b676f`, spec note included there): the business detail page's right rail becomes the single "what's owed on this business" surface — cadence state **plus** an actionable outstanding-tasks list, as one two-zone card under the Cadence heading.

## Changes

- **`src/components/redeemops/cadence.jsx`** — `CadencePanel` rework:
  - Zone 1: cadence name·version, active/paused pill, "Step n of m", segmented progress, Pause/Resume/Stop. The passive "Next: …" line is **removed** (replaced by the task row).
  - Zone 2: "Tasks · n" header with red "k overdue" tally; the live cadence task first (⚡ chip, due label, "→ recipient", **Outcome** menu — disabled + row frozen at 55% opacity while paused); manual tasks with one-click circle-checkbox complete and ⋯ Edit/Cancel overflow; overdue rows get the red date + 3px left accent; >4 rows truncate to **View all n** → Tasks page pre-filtered.
  - Mobile summary strip is now actionable: primary task with Outcome/Complete inline + "+n more · k overdue" expander.
  - New `taskDueMeta` due-label helper (Overdue · d MMM / Due today / Due tomorrow / EEE d MMM); Copy-message button in the View-script dialog; tasks zone renders even with the cadences flag off.
- **`src/pages/redeemops/PartnerDetail.jsx`** — wires `onAddTask`/`onEditTask` into both panel instances; adds the Edit-task dialog; Add-task gains description ("scripts live here") + manager-only assignee; rail reordered Owner → Cadence & Tasks → Notes per the mock.
- **`src/pages/redeemops/TasksPage.jsx`** — supports `?partnerId=` deep-links with a dismissible business-filter chip.
- **`src/components/redeemops/__tests__/cadence.test.jsx`** — 4 new tests for the tasks-zone contract.

## Guardrails

- Cadence tasks complete **only** through `completeCadenceTask`; the generic PATCH is never offered for them (backend enforces this too).
- Disposition menus stay verbatim per channel (`CHANNEL_DISPOSITIONS`).
- No new API surface — reads existing `listTasks({ partnerId, scope: 'team' })` (backend ignores `scope` for non-managers) and the partner-cadence endpoint.

## Verification

- `cadence.test.jsx`: 17/17 green. Full vitest suite: 1181 passed, 1 pre-existing unrelated failure (`PublicPreview.test.jsx` brand wordmark).
- `vite build` clean on both brands.
- Drove the built mktr surface with Playwright + mocked API: desktop rail, Outcome menu (Instagram DM contract), mobile strip + expander all match the mock; zero horizontal overflow at 390px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BC9V8UgLeFxJ4y7oV8xbVw