### PR TITLE
feat(redeem-ops): Discover category allowlist (Apify categoryFilterWords)

### DIFF
--- a/backend/src/controllers/redeemOps/adminController.js
+++ b/backend/src/controllers/redeemOps/adminController.js
@@ -231,6 +231,7 @@ const categoryCreateSchema = Joi.object({
   name: Joi.string().min(1).max(64).required(),
   searchTerms: Joi.array().items(Joi.string().min(1).max(64)).max(20),
   igHashtags: Joi.array().items(Joi.string().min(1).max(64)).max(20),
+  categoryFilterWords: Joi.array().items(Joi.string().min(1).max(64)).max(20),
 });
 
 const categoryUpdateSchema = Joi.object({
@@ -238,6 +239,7 @@ const categoryUpdateSchema = Joi.object({
   isActive: Joi.boolean(),
   searchTerms: Joi.array().items(Joi.string().min(1).max(64)).max(20),
   igHashtags: Joi.array().items(Joi.string().min(1).max(64)).max(20),
+  categoryFilterWords: Joi.array().items(Joi.string().min(1).max(64)).max(20),
 }).min(1);
 
 const categoryMergeSchema = Joi.object({

--- a/backend/src/controllers/redeemOps/discoveryController.js
+++ b/backend/src/controllers/redeemOps/discoveryController.js
@@ -16,6 +16,9 @@ const startSchema = Joi.object({
   // Maps quality inputs (actor-native — filter before paying). Empty/absent = no filter.
   minStars: Joi.string().valid('', 'three', 'threeAndHalf', 'four', 'fourAndHalf'),
   skipClosed: Joi.boolean(),
+  // Ad-hoc Google Maps category allowlist (actor `categoryFilterWords`) — keeps
+  // only places whose category matches, overriding the category's saved words.
+  categoryFilterWords: Joi.array().items(Joi.string().min(1).max(64)).max(20),
 });
 const idsSchema = Joi.object({
   // .max(500): each id can become a PAID scrape — sanity-bound to one full run's

--- a/backend/src/database/migrations/074-redeem-ops-category-filter-words.js
+++ b/backend/src/database/migrations/074-redeem-ops-category-filter-words.js
@@ -1,0 +1,27 @@
+/**
+ * 074 — Google Maps category-filter words for the Redeem Ops category taxonomy.
+ *
+ * The quality analog of 062's providerSearchTerms: admin-curated Google Maps
+ * *category* names the Maps actor keeps (its native `categoryFilterWords` input).
+ * Search terms decide WHAT Google is asked; these decide WHICH categories of the
+ * answer are kept — dropping the off-vertical padding Google pads a niche query
+ * with (a Korean restaurant surfacing on a "kids robotics" search, live 2026-07-16).
+ *
+ * Nullable with NO backfill and NO name fallback (unlike search terms): a CRM
+ * category name is rarely a real Google category, and auto-applying one would
+ * silently filter every existing category run and drop real partners. NULL/empty
+ * means "no category filter" — the actor input stays byte-identical to before,
+ * exactly like the opt-in minStars/skipClosed inputs. Guarded/idempotent like
+ * 052–073 and safe under NODE_ENV=test's sync-first empty tables.
+ */
+export async function up(queryInterface) {
+  await queryInterface.sequelize.query(
+    'ALTER TABLE redeem_ops_categories ADD COLUMN IF NOT EXISTS "categoryFilterWords" text[]'
+  );
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query(
+    'ALTER TABLE redeem_ops_categories DROP COLUMN IF EXISTS "categoryFilterWords"'
+  );
+}

--- a/backend/src/models/RedeemOpsCategory.js
+++ b/backend/src/models/RedeemOpsCategory.js
@@ -14,6 +14,10 @@ const RedeemOpsCategory = sequelize.define('RedeemOpsCategory', {
   // Instagram hashtag-discovery tags (migration 065). NULL = not curated yet —
   // there is deliberately no name fallback (a category name is not a hashtag).
   igHashtags: { type: DataTypes.ARRAY(DataTypes.TEXT), allowNull: true },
+  // Google Maps actor `categoryFilterWords` — categories of the answer to KEEP
+  // (migration 074). NULL/empty = no filter (byte-identical actor input); no name
+  // fallback (a CRM name is rarely a real Google category). Opt-in, like minStars.
+  categoryFilterWords: { type: DataTypes.ARRAY(DataTypes.TEXT), allowNull: true },
   isActive: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
 }, {
   tableName: 'redeem_ops_categories',

--- a/backend/src/services/redeemOps/categoryService.js
+++ b/backend/src/services/redeemOps/categoryService.js
@@ -70,6 +70,27 @@ export function makeCategoryService(overrides = {}) {
     return cleaned.length > 0 ? cleaned : null;
   }
 
+  /** Google Maps category-filter words (migration 074). Like cleanHashtags there
+   *  is NO name fallback — a CRM category name is rarely a real Google category,
+   *  so an emptied list stores NULL ("no category filter"; the actor input stays
+   *  byte-identical to before). Case is preserved for display; the actor matches
+   *  categories case-insensitively either way. */
+  function cleanCategoryFilterWords(raw) {
+    if (raw === undefined) return undefined;
+    const values = Array.isArray(raw) ? raw : [raw];
+    const seen = new Set();
+    const cleaned = [];
+    for (const value of values) {
+      const word = String(value ?? '').trim().slice(0, 64);
+      const key = word.toLowerCase();
+      if (!word || seen.has(key)) continue;
+      seen.add(key);
+      cleaned.push(word);
+      if (cleaned.length === 20) break;
+    }
+    return cleaned.length > 0 ? cleaned : null;
+  }
+
   function whereNameCi(name) {
     return d.sequelize.where(d.sequelize.fn('LOWER', d.sequelize.col('name')), name.toLowerCase());
   }
@@ -95,14 +116,19 @@ export function makeCategoryService(overrides = {}) {
     const name = cleanName(body?.name);
     const providerSearchTerms = cleanSearchTerms(body?.searchTerms, name) ?? [name];
     const igHashtags = cleanHashtags(body?.igHashtags) ?? null;
+    const categoryFilterWords = cleanCategoryFilterWords(body?.categoryFilterWords) ?? null;
     const existing = await d.RedeemOpsCategory.findOne({ where: whereNameCi(name) });
     if (existing) throw new AppError(`Category '${existing.name}' already exists`, 409);
     try {
-      const category = await d.RedeemOpsCategory.create({ name, providerSearchTerms, igHashtags });
+      const category = await d.RedeemOpsCategory.create({ name, providerSearchTerms, igHashtags, categoryFilterWords });
       await d.audit.recordAuditEvent({
         actorUser: user, action: 'settings.category_created',
         entityType: 'redeem_ops_category', entityId: category.id,
-        after: { name, searchTerms: providerSearchTerms, ...(igHashtags ? { igHashtags } : {}) },
+        after: {
+          name, searchTerms: providerSearchTerms,
+          ...(igHashtags ? { igHashtags } : {}),
+          ...(categoryFilterWords ? { categoryFilterWords } : {}),
+        },
         requestId,
       });
       return category;
@@ -146,14 +172,19 @@ export function makeCategoryService(overrides = {}) {
       updates.providerSearchTerms = cleanSearchTerms(body.searchTerms, effectiveName);
     }
     if (body?.igHashtags !== undefined) updates.igHashtags = cleanHashtags(body.igHashtags);
+    if (body?.categoryFilterWords !== undefined) {
+      updates.categoryFilterWords = cleanCategoryFilterWords(body.categoryFilterWords);
+    }
     if (Object.keys(updates).length === 0) return category;
 
     const touchesHashtags = 'igHashtags' in updates;
+    const touchesFilterWords = 'categoryFilterWords' in updates;
     const before = {
       name: category.name,
       isActive: category.isActive,
       searchTerms: category.providerSearchTerms,
       ...(touchesHashtags ? { igHashtags: category.igHashtags } : {}),
+      ...(touchesFilterWords ? { categoryFilterWords: category.categoryFilterWords } : {}),
     };
     await d.sequelize.transaction(async (t) => {
       await category.update(updates, { transaction: t });
@@ -174,6 +205,7 @@ export function makeCategoryService(overrides = {}) {
           isActive: updates.isActive ?? before.isActive,
           searchTerms: updates.providerSearchTerms ?? before.searchTerms,
           ...(touchesHashtags ? { igHashtags: updates.igHashtags } : {}),
+          ...(touchesFilterWords ? { categoryFilterWords: updates.categoryFilterWords } : {}),
         },
         requestId, transaction: t,
       });
@@ -215,7 +247,15 @@ export function makeCategoryService(overrides = {}) {
         ...(source.providerSearchTerms || []),
         source.name,
       ], target.name);
-      await target.update({ providerSearchTerms: mergedSearchTerms }, { transaction: t });
+      // Category-filter words union (no name fallback — see cleanCategoryFilterWords).
+      const mergedFilterWords = cleanCategoryFilterWords([
+        ...(target.categoryFilterWords || []),
+        ...(source.categoryFilterWords || []),
+      ]);
+      await target.update(
+        { providerSearchTerms: mergedSearchTerms, categoryFilterWords: mergedFilterWords },
+        { transaction: t },
+      );
       await source.destroy({ transaction: t });
       await d.audit.recordAuditEvent({
         actorUser: user, action: 'settings.category_merged',
@@ -224,6 +264,7 @@ export function makeCategoryService(overrides = {}) {
         after: {
           mergedInto: target.name, targetId: target.id, rowsMoved,
           searchTerms: mergedSearchTerms,
+          ...(mergedFilterWords ? { categoryFilterWords: mergedFilterWords } : {}),
         },
         requestId, transaction: t,
       });
@@ -288,6 +329,10 @@ export function makeCategoryService(overrides = {}) {
       searchTerms: match.providerSearchTerms?.length
         ? match.providerSearchTerms
         : [match.name],
+      // Opt-in, like minStars: the key is present only when curated, so the
+      // resolver shape stays byte-identical for categories without a filter
+      // (no name fallback — a CRM name is rarely a real Google category).
+      ...(match.categoryFilterWords?.length ? { categoryFilterWords: match.categoryFilterWords } : {}),
     };
   }
 

--- a/backend/src/services/redeemOps/discoveryService.js
+++ b/backend/src/services/redeemOps/discoveryService.js
@@ -194,6 +194,7 @@ export function makeDiscoveryService(overrides = {}) {
   async function startDiscovery({
     category, area, limit, provider = 'google_maps',
     searchTerms: adHocTerms, hashtags: adHocTags, minStars, skipClosed,
+    categoryFilterWords: adHocFilterWords,
   }, user, requestId = null) {
     assertEnabled();
     const isInstagram = provider === 'instagram_hashtag';
@@ -212,6 +213,7 @@ export function makeDiscoveryService(overrides = {}) {
       : []);
     const overrideTerms = cleanList(adHocTerms);
     const overrideTags = cleanList(adHocTags);
+    const overrideFilterWords = cleanList(adHocFilterWords);
     const hasCategory = !!(category && String(category).trim());
     const override = isInstagram ? overrideTags : overrideTerms;
     if (!hasCategory && override.length === 0) {
@@ -239,6 +241,12 @@ export function makeDiscoveryService(overrides = {}) {
     const searchTermsUsed = isInstagram ? null
       : (overrideTerms.length ? overrideTerms
         : (c.searchTermsEnabled ? resolved.searchTerms : [canonicalCategory]));
+    // Category allowlist (actor `categoryFilterWords`): ad-hoc words override the
+    // category's saved list; either may be empty → no filter, so the actor input
+    // stays byte-identical to before (opt-in, like minStars/skipClosed). Maps-only.
+    const filterWordsUsed = isInstagram ? []
+      : (overrideFilterWords.length ? overrideFilterWords
+        : (resolved?.categoryFilterWords || []));
     // The Maps actor applies this cap to EACH search string, so divide the requested
     // total across terms to avoid multiplying crawl cost by N (a single term = full limit).
     const perSearchLimit = isInstagram ? null
@@ -256,7 +264,7 @@ export function makeDiscoveryService(overrides = {}) {
     // materialization's soft filter; both never re-resolve a mid-run category edit.
     const searchPayload = isInstagram
       ? { hashtags: igHashtagsUsed, territory: runValues.area }
-      : { searchTerms: searchTermsUsed };
+      : { searchTerms: searchTermsUsed, ...(filterWordsUsed.length ? { categoryFilterWords: filterWordsUsed } : {}) };
     let run;
     if (c.resultQuotaEnabled) {
       const sgDate = sgDateKey();
@@ -305,6 +313,9 @@ export function makeDiscoveryService(overrides = {}) {
           // (no-filter) input stays byte-identical to before.
           ...(minStars ? { placeMinimumStars: minStars } : {}),
           ...(skipClosed ? { skipClosedPlaces: true } : {}),
+          // Category allowlist: keep only places whose Google category matches one
+          // of these words (drops the off-vertical padding a niche query pulls in).
+          ...(filterWordsUsed.length ? { categoryFilterWords: filterWordsUsed } : {}),
         };
       }
       const started = await d.apify.startRun(actorId, input, { webhookUrl: webhookUrl() });
@@ -339,7 +350,7 @@ export function makeDiscoveryService(overrides = {}) {
           // igHashtagsUsed, NOT resolved.hashtags — ad-hoc IG runs have no category,
           // so `resolved` is null and reading it here crashed AFTER Apify spend began.
           ? { provider: 'apify_instagram_hashtag', hashtags: igHashtagsUsed }
-          : { searchTerms: searchTermsUsed }),
+          : { searchTerms: searchTermsUsed, ...(filterWordsUsed.length ? { categoryFilterWords: filterWordsUsed } : {}) }),
       },
       requestId,
     });

--- a/backend/test/redeemOpsCategories.test.js
+++ b/backend/test/redeemOpsCategories.test.js
@@ -275,6 +275,44 @@ describe('resolveCategoryForSearch', () => {
   });
 });
 
+describe('categoryFilterWords (Maps category allowlist)', () => {
+  const categoryService = makeCategoryService();
+
+  test('create persists categoryFilterWords and the resolver returns them', async () => {
+    const name = uniq('Filtered Salon');
+    const res = await request(app).post('/api/redeem-ops/categories').set(auth(admin.token))
+      .send({ name, categoryFilterWords: ['Nail salon', 'Beauty salon'] });
+    expect(res.body?.data?.category?.id).toBeTruthy();
+    const stored = await RedeemOpsCategory.findByPk(res.body.data.category.id);
+    expect(stored.categoryFilterWords).toEqual(['Nail salon', 'Beauty salon']);
+    await expect(categoryService.resolveCategoryForSearch(name)).resolves.toEqual({
+      name, searchTerms: [name], categoryFilterWords: ['Nail salon', 'Beauty salon'],
+    });
+  });
+
+  test('updating categoryFilterWords to [] clears it and the resolver omits the key', async () => {
+    const name = uniq('Clearable Cafe');
+    const created = await request(app).post('/api/redeem-ops/categories').set(auth(admin.token))
+      .send({ name, categoryFilterWords: ['Cafe'] });
+    const id = created.body.data.category.id;
+    const upd = await request(app).patch(`/api/redeem-ops/categories/${id}`).set(auth(admin.token))
+      .send({ categoryFilterWords: [] });
+    expect(upd.status).toBe(200);
+    expect((await RedeemOpsCategory.findByPk(id)).categoryFilterWords).toBeNull();
+    await expect(categoryService.resolveCategoryForSearch(name)).resolves.toEqual({
+      name, searchTerms: [name],
+    });
+  });
+
+  test('categoryFilterWords are trimmed and de-duped case-insensitively', async () => {
+    const name = uniq('Deduped Cat');
+    const res = await request(app).post('/api/redeem-ops/categories').set(auth(admin.token))
+      .send({ name, categoryFilterWords: ['Spa', 'spa', '  SPA  ', 'Gym'] });
+    expect((await RedeemOpsCategory.findByPk(res.body.data.category.id)).categoryFilterWords)
+      .toEqual(['Spa', 'Gym']);
+  });
+});
+
 describe('delete reference guard', () => {
   test('unreferenced category deletes; referenced one → 409', async () => {
     const unused = await createCategory(admin.token, uniq('Unused'));

--- a/backend/test/redeemOpsDiscovery.test.js
+++ b/backend/test/redeemOpsDiscovery.test.js
@@ -816,3 +816,57 @@ describe('cross-run place memory', () => {
     expect(cand.matchedPartnerId).toBe(partner.id);
   });
 });
+
+describe('categoryFilterWords (Maps category allowlist)', () => {
+  // These tests only assert the actor input, but startDiscovery still writes a run
+  // row — lift the shared per-day caps so they never trip the suite-wide budget.
+  beforeEach(() => {
+    process.env.DISCOVERY_MAX_RUNS_PER_DAY = '1000';
+    process.env.DISCOVERY_MAX_RUNS_PER_USER_DAY = '1000';
+  });
+
+  async function startWith(body) {
+    const apify = makeApifyStub();
+    apify.startRun.mockImplementation(async () => uniqueRunId());
+    const svc = makeDiscoveryService({ apify });
+    const { user } = await createTestUser({ role: 'admin' });
+    const run = await svc.startDiscovery({ area: 'Tampines', limit: 60, ...body }, user);
+    return { input: apify.startRun.mock.calls[0][1], run };
+  }
+
+  test('ad-hoc categoryFilterWords are passed straight to the actor input', async () => {
+    const { input } = await startWith({ searchTerms: ['nail salon'], categoryFilterWords: ['Nail salon', 'Beauty salon'] });
+    expect(input.categoryFilterWords).toEqual(['Nail salon', 'Beauty salon']);
+  });
+
+  test('no categoryFilterWords key when none supplied (default stays byte-identical)', async () => {
+    const { input, run } = await startWith({ searchTerms: ['nail salon'] });
+    expect(input).not.toHaveProperty('categoryFilterWords');
+    // Not just the actor input — the run snapshot must stay clean too.
+    expect(run.rawPayload).not.toHaveProperty('categoryFilterWords');
+  });
+
+  test('instagram_hashtag runs never receive categoryFilterWords', async () => {
+    process.env.DISCOVERY_IG_ENABLED = 'true';
+    const { input, run } = await startWith({
+      provider: 'instagram_hashtag', area: 'All Singapore',
+      hashtags: ['sgnails'], categoryFilterWords: ['Nail salon'],
+    });
+    expect(input).not.toHaveProperty('categoryFilterWords'); // Maps-only filter
+    expect(input.hashtags).toEqual(['sgnails']);
+    expect(run.rawPayload).not.toHaveProperty('categoryFilterWords');
+  });
+
+  test("a category's saved categoryFilterWords are used and snapshotted on the run", async () => {
+    await seedRedeemOpsCategory('Cafe', { categoryFilterWords: ['Cafe', 'Coffee shop'] });
+    const { input, run } = await startWith({ category: 'Cafe' });
+    expect(input.categoryFilterWords).toEqual(['Cafe', 'Coffee shop']);
+    expect(run.rawPayload.categoryFilterWords).toEqual(['Cafe', 'Coffee shop']);
+  });
+
+  test('ad-hoc words override the category saved words', async () => {
+    await seedRedeemOpsCategory('Restaurant', { categoryFilterWords: ['Restaurant'] });
+    const { input } = await startWith({ category: 'Restaurant', categoryFilterWords: ['Bakery'] });
+    expect(input.categoryFilterWords).toEqual(['Bakery']);
+  });
+});

--- a/src/pages/redeemops/DiscoverPage.jsx
+++ b/src/pages/redeemops/DiscoverPage.jsx
@@ -81,7 +81,7 @@ export default function DiscoverPage() {
   const queryClient = useQueryClient();
   const [form, setForm] = useState({
     area: '', limit: '30', provider: 'google_maps',
-    adhoc: '', minStars: 'any', skipClosed: false,
+    adhoc: '', minStars: 'any', skipClosed: false, filterWords: '',
   });
   const [runId, setRunId] = useState(null);
   const [selected, setSelected] = useState(() => new Set());
@@ -273,6 +273,8 @@ export default function DiscoverPage() {
       body.searchTerms = terms;
       if (form.minStars && form.minStars !== 'any') body.minStars = form.minStars;
       if (form.skipClosed) body.skipClosed = true;
+      const filterWords = parseCsv(form.filterWords);
+      if (filterWords.length) body.categoryFilterWords = filterWords;
     }
     startMutation.mutate(body);
   };
@@ -382,25 +384,35 @@ export default function DiscoverPage() {
               </div>
             )}
             {!isIg && (
-              <div className="flex items-end gap-3 mt-3">
-                <div className="space-y-1">
-                  <Label>Min rating</Label>
-                  <Select value={form.minStars} onValueChange={(v) => setForm((f) => ({ ...f, minStars: v }))}>
-                    <SelectTrigger className="w-full min-w-[104px]"><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="any">Any</SelectItem>
-                      <SelectItem value="three">3.0★+</SelectItem>
-                      <SelectItem value="threeAndHalf">3.5★+</SelectItem>
-                      <SelectItem value="four">4.0★+</SelectItem>
-                    </SelectContent>
-                  </Select>
+              <>
+                <div className="flex items-end gap-3 mt-3">
+                  <div className="space-y-1">
+                    <Label>Min rating</Label>
+                    <Select value={form.minStars} onValueChange={(v) => setForm((f) => ({ ...f, minStars: v }))}>
+                      <SelectTrigger className="w-full min-w-[104px]"><SelectValue /></SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="any">Any</SelectItem>
+                        <SelectItem value="three">3.0★+</SelectItem>
+                        <SelectItem value="threeAndHalf">3.5★+</SelectItem>
+                        <SelectItem value="four">4.0★+</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <label className="flex items-center gap-2 h-9 px-1 text-[13px] font-semibold cursor-pointer whitespace-nowrap" style={{ color: 'var(--ro-text-2)' }}>
+                    <input type="checkbox" className="w-4 h-4 accent-[var(--ro-bunker)]"
+                      checked={form.skipClosed} onChange={(e) => setForm((f) => ({ ...f, skipClosed: e.target.checked }))} />
+                    Skip closed
+                  </label>
                 </div>
-                <label className="flex items-center gap-2 h-9 px-1 text-[13px] font-semibold cursor-pointer whitespace-nowrap" style={{ color: 'var(--ro-text-2)' }}>
-                  <input type="checkbox" className="w-4 h-4 accent-[var(--ro-bunker)]"
-                    checked={form.skipClosed} onChange={(e) => setForm((f) => ({ ...f, skipClosed: e.target.checked }))} />
-                  Skip closed
-                </label>
-              </div>
+                <div className="space-y-1 mt-3">
+                  <Label htmlFor="disc-filter-words">
+                    Categories to keep <span style={{ color: 'var(--ro-text-3)', fontWeight: 400 }}>· optional</span>
+                  </Label>
+                  <Input id="disc-filter-words" value={form.filterWords}
+                    placeholder="restaurant, cafe, bakery — drops off-category results"
+                    onChange={(e) => setForm((f) => ({ ...f, filterWords: e.target.value }))} />
+                </div>
+              </>
             )}
             <div className="flex flex-wrap items-center gap-2 mt-3">
               {!territoriesEnabled && !isIg && (
@@ -488,6 +500,8 @@ export default function DiscoverPage() {
               // was filed under one (ad-hoc runs have none — no more bare "—").
               ...(runTerms ? [[isIgRun ? 'Hashtags' : 'Terms', runTerms, true]] : []),
               ...(run?.category ? [['Category', run.category, false]] : []),
+              ...(run?.rawPayload?.categoryFilterWords?.length
+                ? [['Categories', run.rawPayload.categoryFilterWords.join(', '), true]] : []),
               ['Area', run?.area, false], ['Results', run?.requestedLimit, false],
               ...(run?.actualCostUsd != null ? [['Cost', `$${Number(run.actualCostUsd).toFixed(2)}`, false]] : []),
             ].map(([k, v, truncate]) => (

--- a/src/pages/redeemops/SettingsPage.jsx
+++ b/src/pages/redeemops/SettingsPage.jsx
@@ -19,6 +19,7 @@ import Search from 'lucide-react/icons/search';
 import Instagram from 'lucide-react/icons/instagram';
 import Merge from 'lucide-react/icons/merge';
 import Trash2 from 'lucide-react/icons/trash-2';
+import Tags from 'lucide-react/icons/tags';
 import { RoPageHeader, RoTag } from '@/components/redeemops/ui';
 
 const CATEGORIES_KEY = ['redeem-ops', 'categories'];
@@ -113,6 +114,21 @@ export default function SettingsPage() {
       invalidate();
     },
     onError: onError('Could not update Instagram hashtags'),
+  });
+
+  // ── Google Maps categories to keep (Discover quality filter) ───────────
+  const [filterWordsTarget, setFilterWordsTarget] = useState(null);
+  const [filterWordsText, setFilterWordsText] = useState('');
+  const filterWordsMutation = useMutation({
+    mutationFn: () => redeemOpsApi.updateCategory(filterWordsTarget.id, {
+      categoryFilterWords: parseSearchTerms(filterWordsText),
+    }),
+    onSuccess: () => {
+      toast.success('Categories to keep updated');
+      setFilterWordsTarget(null);
+      invalidate();
+    },
+    onError: onError('Could not update categories to keep'),
   });
 
   // ── Retire / restore ───────────────────────────────────────────────────
@@ -282,6 +298,15 @@ export default function SettingsPage() {
                     }}
                   >
                     <Instagram className="w-3.5 h-3.5" aria-hidden="true" />
+                  </Button>
+                  <Button
+                    variant="ghost" size="sm" aria-label={`Edit categories to keep for ${cat.name}`}
+                    onClick={() => {
+                      setFilterWordsTarget(cat);
+                      setFilterWordsText((cat.categoryFilterWords || []).join(', '));
+                    }}
+                  >
+                    <Tags className="w-3.5 h-3.5" aria-hidden="true" />
                   </Button>
                   <Button
                     variant="ghost" size="sm" aria-label={`Merge ${cat.name} into another category`}
@@ -487,6 +512,36 @@ export default function SettingsPage() {
               onClick={() => igHashtagsMutation.mutate()}
             >
               {igHashtagsMutation.isPending ? 'Saving…' : 'Save'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={!!filterWordsTarget} onOpenChange={(open) => { if (!open) setFilterWordsTarget(null); }}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Categories to keep</DialogTitle>
+            <DialogDescription>
+              Google Maps categories Discover keeps for this category — e.g. hair salon,
+              nail salon, spa. Comma-separated; matched loosely and case-insensitively.
+              Leave empty to keep every result (no filter).
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-1.5 py-2">
+            <Label htmlFor="category-filter-words">Categories to keep</Label>
+            <Input
+              id="category-filter-words"
+              value={filterWordsText}
+              onChange={(e) => setFilterWordsText(e.target.value)}
+              placeholder="hair salon, nail salon, spa"
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              disabled={filterWordsMutation.isPending}
+              onClick={() => filterWordsMutation.mutate()}
+            >
+              {filterWordsMutation.isPending ? 'Saving…' : 'Save'}
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## What

Adds a Google Maps **category allowlist** to the Redeem Ops **Discover** partner-sourcing tool, so off-vertical scrape results (e.g. a Korean restaurant surfacing on a "kids robotics" search) are dropped **at the source** via the Compass actor's native `categoryFilterWords` input — you stop paying for the padding instead of just hiding it.

## Why

A live search for kids-robotics terms returned a Korean buffet, an HR recruiter, and ITE. Google Maps pads a niche query to fill the requested result count, and Discover applied **zero** category/relevance filtering on the returned rows.

## How

- **Opt-in, byte-identical when unset.** The `categoryFilterWords` key only reaches the actor when curated — same posture as the existing `minStars`/`skipClosed` inputs. No new feature flag.
- **Two entry points:**
  - **Per-category** — `RedeemOpsCategory.categoryFilterWords` (migration 074), edited in the Settings "Categories to keep" dialog; `resolveCategoryForSearch` returns it.
  - **Ad-hoc** — an optional "Categories to keep" field on the Discover form, which overrides the category's saved list.
- **Instagram (hashtag) runs never receive it** — Maps-only.
- Fired words are snapshotted on the run `rawPayload` + audit event, and shown as a chip in the results summary bar.

## Tests

+7 tests locking the invariants: empty-key omission on actor input / run snapshot / audit / resolver, IG exclusion, and category CRUD round-trip + dedupe. Backend `redeemOpsDiscovery` + `redeemOpsCategories` + `redeemOpsDiscoveryInstagram` = **87 green**; frontend `DiscoverPage` **12 green**; lint clean. Codex review pass: **no High findings**.

## Notes

- Migration 074 adds a nullable `text[]` column (no backfill, no name fallback — a CRM name is rarely a real Google category).
- The per-category Settings editor only fires for category-launched runs; the Discover UI launches ad-hoc (no category picker, by design), so that editor is currently an API/latent capability — the ad-hoc field is the live UI path.
