### PR TITLE
feat(redeem-ops): voucher/pass delivery actually delivers (trial-reward PR A)

### DIFF
--- a/backend/src/controllers/redeemOps/fulfilmentController.js
+++ b/backend/src/controllers/redeemOps/fulfilmentController.js
@@ -1,7 +1,11 @@
 import Joi from 'joi';
 import { asyncHandler, AppError } from '../../middleware/errorHandler.js';
-import entitlementService from '../../services/redeemOps/entitlementService.js';
+import { makeWiredEntitlementService } from '../../services/redeemOps/entitlementWiring.js';
 import redemptionService from '../../services/redeemOps/redemptionService.js';
+
+// Wired instance (voucher/reservation emails actually send) — the bare default
+// export of entitlementService has null notify deps and delivers nothing.
+const entitlementService = makeWiredEntitlementService();
 
 function validateBody(schema, body) {
   const { error, value } = schema.validate(body, { abortEarly: false });
@@ -30,6 +34,9 @@ export const unlockEntitlement = asyncHandler(async (req, res) => {
     success: true,
     data: {
       already: result.already,
+      // Whether a voucher email was scheduled by THIS unlock — the toast must
+      // not claim "email sent" for replays or no-email leads.
+      emailQueued: result.emailQueued === true,
       // The raw voucher token is NOT returned here — it travels to the
       // consumer via the unlock email; staff see only the hint.
       entitlement: {
@@ -39,6 +46,43 @@ export const unlockEntitlement = asyncHandler(async (req, res) => {
         expiresAt: e.expiresAt,
         unlockedVia: e.unlockedVia,
       },
+    },
+  });
+});
+
+export const resendPass = asyncHandler(async (req, res) => {
+  const body = validateBody(
+    Joi.object({ channel: Joi.string().valid('email', 'link').default('email') }),
+    req.body || {}
+  );
+  const result = await entitlementService.resendDelivery(
+    req.params.id, req.user, { channel: body.channel }, req.id
+  );
+  const e = result.entitlement;
+  const noun = result.kind === 'pass' ? 'reservation pass' : 'voucher';
+  const oldCredential = result.kind === 'pass' ? 'pass QR/link' : 'voucher code/QR';
+  const message = result.channel === 'email'
+    ? `New ${noun} emailed — the previous ${oldCredential} no longer works.`
+    : `New ${noun} link created — the previous ${oldCredential} no longer works. Share it with the customer yourself.`;
+  // The link channel returns a LIVE bearer credential in the body — it must
+  // never be cached by any intermediary or the browser.
+  res.set('Cache-Control', 'no-store');
+  res.json({
+    success: true,
+    message,
+    data: {
+      kind: result.kind,
+      channel: result.channel,
+      emailQueued: result.emailQueued === true,
+      entitlement: { id: e.id, status: e.status, tokenHint: e.tokenHint, expiresAt: e.expiresAt },
+      ...(result.channel === 'link'
+        ? {
+            link: result.link,
+            waMessage: result.waMessage,
+            waUrl: result.waUrl,
+            waUnavailableReason: result.waUnavailableReason,
+          }
+        : {}),
     },
   });
 });
@@ -56,6 +100,9 @@ export const issueManual = asyncHandler(async (req, res) => {
     success: true,
     data: {
       entitlement: result.entitlement,
+      // The customer is also emailed (when a usable address exists) — manual
+      // issue is usually recovery from a failed delivery.
+      emailQueued: result.emailQueued === true,
       // Raw tokens are returned ONCE at manual issue for staff hand-delivery
       presentationToken: result.presentationToken || null,
       voucherToken: result.voucherToken || null,

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -235,37 +235,28 @@ export async function bootstrapDatabase() {
       if (String(process.env.REDEEM_OPS_ENTITLEMENTS_ENABLED || 'false').toLowerCase() === 'true') {
         await safeRun('Redeem Ops entitlement hook', async () => {
           const { registerLeadCapturedHook } = await import('../services/prospectService.js');
-          const { makeEntitlementService } = await import('../services/redeemOps/entitlementService.js');
-          const { makeFulfilmentNotify } = await import('../services/redeemOps/fulfilmentNotify.js');
-          const notify = makeFulfilmentNotify();
-          const entitlements = makeEntitlementService({
-            notifyUnlock: ({ entitlement, prospect, voucherToken }) =>
-              notify.sendVoucherEmail({ entitlement, prospect, voucherToken }),
-          });
+          const { makeWiredEntitlementService } = await import('../services/redeemOps/entitlementWiring.js');
+          // Delivery (reservation + voucher emails, receipt events) lives
+          // INSIDE the wired service now — one choke point for hook, sweep and
+          // manual issuance (trial-reward-funnel-hardening PR A).
+          const entitlements = makeWiredEntitlementService();
           registerLeadCapturedHook(async (prospect) => {
-            const r = await entitlements.issueForProspect(prospect, { via: 'hook' });
-            if (r?.entitlement && r.reason === null && r.presentationToken && !r.voucherToken) {
-              // agent_unlock policy: deliver the reservation pass (fire-and-forget)
-              notify.sendReservationEmail({
-                entitlement: r.entitlement, prospect, presentationToken: r.presentationToken,
-              }).catch((err) => logger.error('[RedeemOps] reservation email failed', { error: err?.message }));
-            } else if (r?.voucherToken) {
-              notify.sendVoucherEmail({
-                entitlement: r.entitlement, prospect, voucherToken: r.voucherToken,
-              }).catch((err) => logger.error('[RedeemOps] voucher email failed', { error: err?.message }));
-            }
+            await entitlements.issueForProspect(prospect, { via: 'hook' });
           });
           logger.info('[RedeemOps] entitlement capture hook registered');
         });
 
-        // Reservation expiry + missed-lead reconciliation (at-least-once backstop
-        // for the hook; idempotent via the unique (activationId, prospectId) anchor).
+        // Reservation expiry + missed-lead reconciliation + delivery recovery
+        // (at-least-once backstops for the hook; issuance stays exactly-once
+        // via the unique (activationId, prospectId) anchor, and delivery
+        // recovery re-mints only rows with no successful `notified` receipt).
         const runFulfilmentSweepSafe = async () => {
           try {
-            const { makeEntitlementService } = await import('../services/redeemOps/entitlementService.js');
-            const svc = makeEntitlementService();
+            const { makeWiredEntitlementService } = await import('../services/redeemOps/entitlementWiring.js');
+            const svc = makeWiredEntitlementService();
             await svc.expireReservations();
             await svc.reconcileMissedLeads();
+            await svc.reconcileMissedDeliveries();
           } catch (err) {
             logger.warn('[RedeemOps] fulfilment sweep failed (non-fatal)', { error: err?.message });
           }

--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -1,5 +1,6 @@
 import { ValidationError, DatabaseError, ConnectionError } from 'sequelize';
 import { logger } from '../utils/logger.js';
+import { maskTokenUrl } from '../utils/redactTokens.js';
 
 export const errorHandler = (err, req, res, _next) => {
   let error = { ...err };
@@ -9,7 +10,7 @@ export const errorHandler = (err, req, res, _next) => {
   logger.error(
     {
       err: { message: err.message, statusCode: err.statusCode, stack: err.stack },
-      req: { method: req.method, url: req.originalUrl, id: req.id },
+      req: { method: req.method, url: maskTokenUrl(req.originalUrl), id: req.id },
     },
     'Request error'
   );

--- a/backend/src/routes/externalEntitlements.js
+++ b/backend/src/routes/externalEntitlements.js
@@ -2,7 +2,7 @@ import express from 'express';
 import { asyncHandler } from '../middleware/errorHandler.js';
 import { requireExternalHmac } from '../controllers/externalBillingController.js';
 import { User } from '../models/index.js';
-import { makeEntitlementService } from '../services/redeemOps/entitlementService.js';
+import { makeWiredEntitlementService } from '../services/redeemOps/entitlementWiring.js';
 
 /**
  * mktr-leads consultant → voucher unlock (docs/redeem-ops/MKTR_INTEGRATION.md §2).
@@ -41,7 +41,7 @@ router.post('/unlock', requireExternalHmac, asyncHandler(async (req, res) => {
     // only a presentation token (the customer's QR pass, presented live) counts
     // as scan evidence; a bare prospectId is always the button path. Draw
     // weighting treats the two differently (docs/plans/lucky-draw-10x.md §4.4).
-    const result = await makeEntitlementService().unlockEntitlement(
+    const result = await makeWiredEntitlementService().unlockEntitlement(
       presentationToken ? { presentationToken } : { prospectId },
       agent,
       presentationToken ? 'agent_scan' : 'agent_button'
@@ -49,6 +49,9 @@ router.post('/unlock', requireExternalHmac, asyncHandler(async (req, res) => {
     return res.json({
       success: true,
       already: result.already,
+      // Whether a voucher email was scheduled by THIS unlock — false on
+      // replay and for no-email leads (client should tell the consultant).
+      emailQueued: result.emailQueued === true,
       entitlementId: result.entitlement.id,
       status: result.entitlement.status,
       tokenHint: result.entitlement.tokenHint,

--- a/backend/src/routes/lyfeEntitlementUnlock.js
+++ b/backend/src/routes/lyfeEntitlementUnlock.js
@@ -2,7 +2,7 @@ import express from 'express';
 import crypto from 'crypto';
 import { asyncHandler } from '../middleware/errorHandler.js';
 import { User } from '../models/index.js';
-import { makeEntitlementService } from '../services/redeemOps/entitlementService.js';
+import { makeWiredEntitlementService } from '../services/redeemOps/entitlementWiring.js';
 import { logger } from '../utils/logger.js';
 
 /**
@@ -78,16 +78,24 @@ router.post('/entitlement-unlock', asyncHandler(async (req, res) => {
     // only a presentation token (the customer's QR pass, presented live) counts
     // as scan evidence; a bare prospectId is always the button path
     // (docs/plans/lucky-draw-10x.md §4.4).
-    const result = await makeEntitlementService().unlockEntitlement(
+    const result = await makeWiredEntitlementService().unlockEntitlement(
       presentationToken ? { presentationToken } : { prospectId },
       agent,
       presentationToken ? 'agent_scan' : 'agent_button'
     );
+    // Truthful messaging: only claim an email went out when one was actually
+    // scheduled (Retell leads have no real address — staff must share the link).
+    const message = result.already
+      ? 'Already unlocked'
+      : result.emailQueued
+        ? 'Voucher unlocked — the customer has been emailed their voucher'
+        : 'Voucher unlocked — no email on file; share the customer\'s pass link with them';
     return res.json({
       success: true,
-      message: result.already ? 'Already unlocked' : 'Voucher unlocked — the customer has been notified',
+      message,
       data: {
         already: result.already,
+        emailQueued: result.emailQueued === true,
         entitlementId: result.entitlement.id,
         status: result.entitlement.status,
         tokenHint: result.entitlement.tokenHint,

--- a/backend/src/routes/redeemOpsFulfilment.js
+++ b/backend/src/routes/redeemOpsFulfilment.js
@@ -22,6 +22,9 @@ router.post('/entitlements', requireRedeemOps('entitlements.issue_manual'), ctrl
 // Manual unlock (testing / counter fallback). The capability gates the route;
 // the service additionally enforces assigned-consultant binding for non-admins.
 router.post('/entitlements/unlock', requireRedeemOps('entitlements.issue_manual'), ctrl.unlockEntitlement);
+// Resend/share: re-mints the current credential (old QR dies — deliberate) and
+// emails it, or returns the link once for staff to WhatsApp themselves.
+router.post('/entitlements/:id/resend-pass', requireRedeemOps('entitlements.issue_manual'), ctrl.resendPass);
 router.patch('/entitlements/:id/cancel', requireRedeemOps('entitlements.issue_manual'), ctrl.cancelEntitlement);
 
 // Redemption console (voucher verify → complete; unmasked holder identity here only)

--- a/backend/src/server_internal.js
+++ b/backend/src/server_internal.js
@@ -20,6 +20,7 @@ import leadCaptureBind from './routes/leadCaptureBind.js';
 import { optionalAuth } from './middleware/auth.js';
 import { blockRedeemForInternalRoutes } from './middleware/internalRouteHostGuard.js';
 import { logger } from './utils/logger.js';
+import { maskTokenUrl } from './utils/redactTokens.js';
 import swaggerUi from 'swagger-ui-express';
 import { swaggerSpec } from './config/swagger.js';
 
@@ -130,8 +131,19 @@ export const init = async (app) => {
   // redeem.sg public-host signature. CORS preflight already passed above.
   app.use('/api', blockRedeemForInternalRoutes);
 
-  // Structured request logging via Pino
-  app.use(pinoHttp({ logger, autoLogging: { ignore: (req) => req.url === '/health' } }));
+  // Structured request logging via Pino. The req serializer masks reward-claim
+  // bearer tokens — /api/reward-claim/:token is a live credential and must
+  // never land in access logs (see utils/redactTokens.js).
+  app.use(pinoHttp({
+    logger,
+    autoLogging: { ignore: (req) => req.url === '/health' },
+    serializers: {
+      req(req) {
+        req.url = maskTokenUrl(req.url);
+        return req;
+      },
+    },
+  }));
 
   // Body parsing middleware
   // The verify callback captures the raw body for webhook signature verification.

--- a/backend/src/services/mailer.js
+++ b/backend/src/services/mailer.js
@@ -3,6 +3,7 @@ import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { logger } from '../utils/logger.js';
+import { maskEmail } from '../utils/redactTokens.js';
 import { normalizeCustomerHostChoice, customerHostOrigin } from '../utils/customerHost.js';
 import { getOrCreateProspectShareLink } from './shortlinkService.js';
 
@@ -70,8 +71,10 @@ export async function sendEmail({ to, subject, html, text, context, from, attach
 
   const transporter = getTransporter();
   if (!transporter) {
-    logger.info('[DEV Fallback] Email not sent (mailer not configured)', { to, subject, from: resolvedFrom });
-    logger.debug('Email body preview', { body: html || text || '(no body)' });
+    // Recipient masked and no body preview — reward emails carry live bearer
+    // tokens in their links/QRs, and log lines outlive the emails.
+    logger.info('[DEV Fallback] Email not sent (mailer not configured)', { to: maskEmail(to), subject, from: resolvedFrom });
+    logger.debug('Email body preview suppressed', { bodyBytes: (html || text || '').length });
     return { success: false, message: 'Mailer not configured; logged instead.' };
   }
 
@@ -89,7 +92,7 @@ export async function sendEmail({ to, subject, html, text, context, from, attach
     // only sees a generic "Mail command failed" string and the actual
     // SES reason (e.g., "Email address is not verified") is lost.
     logger.error('Email send failed', {
-      to,
+      to: maskEmail(to),
       from: resolvedFrom,
       subject,
       code: err.code,

--- a/backend/src/services/redeemOps/entitlementService.js
+++ b/backend/src/services/redeemOps/entitlementService.js
@@ -8,9 +8,21 @@ import { logger } from '../../utils/logger.js';
 import { makeInventoryService } from './inventoryService.js';
 import { makeRedeemOpsAuditService } from './auditService.js';
 import { mintToken, hashToken, tokenHintOf } from './tokens.js';
+import { canEmailProspect, makeFulfilmentNotify } from './fulfilmentNotify.js';
 
 const DEFAULT_RESERVATION_DAYS = 30;
 const DEFAULT_REDEMPTION_DAYS = 90;
+const RESEND_COOLDOWN_MS = 60 * 1000;
+
+// In-flight fire-and-forget deliveries (all service instances share this).
+// flushDeliveries() lets tests — and anything else that needs a barrier —
+// await every queued email + receipt write deterministically.
+const pendingDeliveries = new Set();
+export async function flushDeliveries() {
+  while (pendingDeliveries.size > 0) {
+    await Promise.allSettled([...pendingDeliveries]);
+  }
+}
 
 /**
  * Reward entitlements (docs/redeem-ops/MKTR_INTEGRATION.md §2, ERD.md §3.16).
@@ -23,6 +35,13 @@ const DEFAULT_REDEMPTION_DAYS = 90;
  * unlockPolicy='agent_unlock' (default): capture creates a locked RESERVATION
  * (presentation-pass token only); the lead's assigned consultant unlocks at the
  * physical meeting (scan or button) which mints the voucher token.
+ *
+ * DELIVERY lives in this service (single choke point — hook-, sweep-, and
+ * manual-issued entitlements all deliver): fresh issuance and unlock queue the
+ * reservation/voucher email post-commit via the null-safe notify deps, and
+ * every attempt writes a `notified`/`notify_failed` receipt event. Wire the
+ * deps with makeWiredEntitlementService (entitlementWiring.js) — a bare
+ * instance sends nothing by design (tests, flag-off).
  */
 export function makeEntitlementService(overrides = {}) {
   const d = {
@@ -30,8 +49,14 @@ export function makeEntitlementService(overrides = {}) {
     Prospect, User, sequelize, logger,
     inventory: makeInventoryService(),
     audit: makeRedeemOpsAuditService(),
-    notifyUnlock: null, // injected by fulfilment wiring (email/SMS) — null-safe
+    notifyUnlock: null, // injected by entitlementWiring (voucher email) — null-safe
+    notifyReservation: null, // injected by entitlementWiring (reservation-pass email) — null-safe
+    builders: null, // share/claim-URL builders; defaults lazily to makeFulfilmentNotify()
     ...overrides,
+  };
+  const builders = () => {
+    if (!d.builders) d.builders = makeFulfilmentNotify();
+    return d.builders;
   };
 
   async function writeEvent(t, evt) {
@@ -53,20 +78,74 @@ export function makeEntitlementService(overrides = {}) {
   }
 
   /**
+   * Post-commit, fire-and-forget email delivery + truthful receipt. Returns
+   * whether a FRESH attempt was scheduled (the `emailQueued` the routes
+   * surface). Receipts: `notified` on accepted hand-off, `notify_failed` on
+   * mailer failure — never on a no-email skip (nothing was attempted).
+   */
+  function queueDelivery({ entitlement, prospect, kind, presentationToken = null, voucherToken = null }) {
+    const fn = kind === 'voucher' ? d.notifyUnlock : d.notifyReservation;
+    if (typeof fn !== 'function' || !canEmailProspect(prospect)) return false;
+    const args = kind === 'voucher'
+      ? { entitlement, prospect, voucherToken }
+      : { entitlement, prospect, presentationToken };
+    const delivery = Promise.resolve()
+      .then(() => fn(args))
+      .then((r) => {
+        if (r?.skipped) return null;
+        return writeDeliveryReceipt(entitlement.id, kind, r || { sent: false, error: 'no sender result' });
+      })
+      .catch((err) => writeDeliveryReceipt(entitlement.id, kind, { sent: false, error: err?.message }));
+    pendingDeliveries.add(delivery);
+    delivery.finally(() => pendingDeliveries.delete(delivery));
+    return true;
+  }
+
+  async function writeDeliveryReceipt(entitlementId, kind, r) {
+    try {
+      await d.RedemptionEvent.create({
+        entitlementId,
+        type: r.sent ? 'notified' : 'notify_failed',
+        actorType: 'system',
+        metadata: {
+          kind,
+          channel: 'email',
+          to: r.to || null, // already masked by the sender
+          ...(r.error ? { error: String(r.error).slice(0, 200) } : {}),
+        },
+      });
+    } catch (err) {
+      d.logger.error('redeem_ops.delivery.receipt_failed', { entitlementId, error: err?.message });
+    }
+  }
+
+  /**
    * Issue (reserve) for a captured lead. Returns the entitlement or null with a
    * reason — NEVER throws into the capture path (the hook wraps it anyway).
+   * `activationId` (manual path) pins the EXACT activation staff selected —
+   * without it, issueManual could issue/email a different activation than the
+   * audit row claims (Codex blocker, 2026-07-16).
    */
-  async function issueForProspect(prospect, { via = 'hook' } = {}) {
+  async function issueForProspect(prospect, { via = 'hook', activationId = null } = {}) {
     try {
-      if (!prospect?.campaignId) return { entitlement: null, reason: 'no_campaign' };
-      if (prospect.quarantinedAt) return { entitlement: null, reason: 'quarantined' };
+      if (!activationId && !prospect?.campaignId) return { entitlement: null, reason: 'no_campaign' };
+      if (prospect?.quarantinedAt) return { entitlement: null, reason: 'quarantined' };
       if (!verificationStampOf(prospect)) return { entitlement: null, reason: 'phone_not_verified' };
 
-      const activation = await d.Activation.findOne({
-        where: { campaignId: prospect.campaignId, status: 'active' },
-        include: [{ model: d.RewardOffer, as: 'rewardOffer' }],
-      });
-      if (!activation) return { entitlement: null, reason: 'no_active_activation' };
+      let activation;
+      if (activationId) {
+        activation = await d.Activation.findOne({
+          where: { id: activationId, status: 'active' },
+          include: [{ model: d.RewardOffer, as: 'rewardOffer' }],
+        });
+        if (!activation) return { entitlement: null, reason: 'activation_not_active' };
+      } else {
+        activation = await d.Activation.findOne({
+          where: { campaignId: prospect.campaignId, status: 'active' },
+          include: [{ model: d.RewardOffer, as: 'rewardOffer' }],
+        });
+        if (!activation) return { entitlement: null, reason: 'no_active_activation' };
+      }
 
       const existing = await d.RewardEntitlement.findOne({
         where: { activationId: activation.id, prospectId: prospect.id },
@@ -121,12 +200,24 @@ export function makeEntitlementService(overrides = {}) {
         return created;
       });
 
+      // Post-commit delivery: reservation pass (agent_unlock) or voucher
+      // (on_capture) — fire-and-forget, receipt-tracked. This is the single
+      // delivery choke point for hook, sweep AND manual issuance.
+      const emailQueued = queueDelivery({
+        entitlement,
+        prospect,
+        kind: onCapture ? 'voucher' : 'pass',
+        presentationToken: onCapture ? null : presentation.raw,
+        voucherToken: voucher ? voucher.raw : null,
+      });
+
       // Raw tokens returned ONCE for delivery (email/link); only hashes persist.
       return {
         entitlement,
         reason: null,
         presentationToken: presentation.raw,
         voucherToken: voucher ? voucher.raw : null,
+        emailQueued,
       };
     } catch (err) {
       if (err?._soft) return { entitlement: null, reason: err.message };
@@ -146,6 +237,8 @@ export function makeEntitlementService(overrides = {}) {
    * `by` = { presentationToken } (scan — proves presence) or { prospectId } (button).
    * The acting agent must be the lead's assigned consultant (admin override allowed).
    * Idempotent: an already-unlocked entitlement returns { already: true }.
+   * `emailQueued` means a FRESH voucher email was scheduled by THIS call —
+   * always false on replay (no duplicate mail) and when no usable email exists.
    */
   async function unlockEntitlement(by, agentUser, via = 'agent_scan') {
     let entitlement;
@@ -162,7 +255,7 @@ export function makeEntitlementService(overrides = {}) {
     if (!entitlement) throw new AppError('Entitlement not found', 404);
 
     if (['issued', 'redeemed'].includes(entitlement.status)) {
-      return { entitlement, already: true, voucherToken: null };
+      return { entitlement, already: true, voucherToken: null, emailQueued: false };
     }
     if (entitlement.status !== 'eligible') {
       throw new AppError(`Entitlement is ${entitlement.status}`, 409);
@@ -181,7 +274,7 @@ export function makeEntitlementService(overrides = {}) {
     const redemptionDays = offer?.redemptionExpiryDays || DEFAULT_REDEMPTION_DAYS;
     const voucher = mintToken();
 
-    const result = await d.sequelize.transaction(async (t) => {
+    await d.sequelize.transaction(async (t) => {
       const [count] = await d.RewardEntitlement.update(
         {
           status: 'issued',
@@ -208,16 +301,14 @@ export function makeEntitlementService(overrides = {}) {
         entitlementId: entitlement.id, type: 'unlocked',
         actorType: 'agent', actorUserId: agentUser.id, metadata: { via },
       });
-      return true;
     });
 
     await entitlement.reload();
-    if (result && typeof d.notifyUnlock === 'function') {
-      // Fire-and-forget consumer notification (voucher email w/ QR + link)
-      Promise.resolve(d.notifyUnlock({ entitlement, prospect, voucherToken: voucher.raw }))
-        .catch((err) => d.logger.error('redeem_ops.unlock.notify_failed', { error: err?.message }));
-    }
-    return { entitlement, already: false, voucherToken: voucher.raw };
+    // Fire-and-forget voucher email (receipt-tracked)
+    const emailQueued = queueDelivery({
+      entitlement, prospect, kind: 'voucher', voucherToken: voucher.raw,
+    });
+    return { entitlement, already: false, voucherToken: voucher.raw, emailQueued };
   }
 
   /** Manual issue by redemption_ops (requires an existing lead). */
@@ -229,9 +320,12 @@ export function makeEntitlementService(overrides = {}) {
     const prospect = await d.Prospect.findByPk(prospectId);
     if (!prospect) throw new AppError('Lead not found', 404);
 
+    // activationId is threaded through so the SELECTED activation is the one
+    // issued + emailed + audited (issueForProspect would otherwise re-resolve
+    // by the prospect's campaign and could pick a different activation).
     const result = await issueForProspect(
       { ...prospect.toJSON(), sourceMetadata: { ...(prospect.sourceMetadata || {}), phoneVerifiedAt: prospect.sourceMetadata?.phoneVerifiedAt || new Date().toISOString() } },
-      { via: 'manual' }
+      { via: 'manual', activationId }
     );
     if (!result.entitlement) throw new AppError(`Cannot issue: ${result.reason}`, 409);
     await d.audit.recordAuditEvent({
@@ -239,6 +333,91 @@ export function makeEntitlementService(overrides = {}) {
       entityId: result.entitlement.id, after: { activationId, prospectId }, requestId,
     });
     return result;
+  }
+
+  /**
+   * Ops resend / share (docs/plans/trial-reward-funnel-hardening-prompt.md PR A).
+   * Re-mints the CURRENT credential (pass while eligible, voucher once issued)
+   * as an ATOMIC conditional transition — racing unlock/redeem/expiry loses
+   * cleanly with a typed 409 instead of rotating hashes for the wrong state.
+   * channel 'email' re-sends via the notify seam; channel 'link' returns the
+   * branded /r/ url + WhatsApp-paste bundle ONCE (the no-email path).
+   * The OLD credential of that kind stops working — deliberate.
+   */
+  async function resendDelivery(id, user, { channel = 'email' } = {}, requestId = null) {
+    const entitlement = await d.RewardEntitlement.findByPk(id);
+    if (!entitlement) throw new AppError('Entitlement not found', 404);
+
+    const kind = entitlement.status === 'eligible' ? 'pass'
+      : entitlement.status === 'issued' ? 'voucher' : null;
+    if (!kind) throw new AppError(`Entitlement is ${entitlement.status}`, 409);
+    if (entitlement.expiresAt && new Date(entitlement.expiresAt) <= new Date()) {
+      throw new AppError('Reward has expired — nothing to resend', 409);
+    }
+
+    const prospect = entitlement.prospectId ? await d.Prospect.findByPk(entitlement.prospectId) : null;
+    if (channel === 'email' && !canEmailProspect(prospect)) {
+      throw new AppError('No usable email on file — use the copy-link option instead', 409);
+    }
+
+    // Per-entitlement cooldown: any delivery/rotation for this kind in the
+    // last 60s → 429 (the global per-IP limiter is no protection here).
+    const recent = await d.RedemptionEvent.findAll({
+      where: {
+        entitlementId: id,
+        createdAt: { [Op.gt]: new Date(Date.now() - RESEND_COOLDOWN_MS) },
+        type: { [Op.in]: ['notified', 'notify_failed', 'manual_override'] },
+      },
+      order: [['createdAt', 'DESC']],
+      limit: 10,
+    });
+    const resendAction = kind === 'pass' ? 'resend_pass' : 'resend_voucher';
+    const clash = recent.some((e) => {
+      const m = e.metadata || {};
+      if (e.type === 'manual_override') return m.action === resendAction || (m.action === 'auto_resend' && m.kind === kind);
+      return m.kind === kind;
+    });
+    if (clash) {
+      throw new AppError('A delivery for this reward was attempted less than a minute ago — wait and retry', 429);
+    }
+
+    const fresh = mintToken();
+    const fields = kind === 'pass'
+      ? { presentationTokenHash: fresh.hash }
+      : { tokenHash: fresh.hash, tokenHint: tokenHintOf(fresh.raw) };
+    await d.sequelize.transaction(async (t) => {
+      const [count] = await d.RewardEntitlement.update(fields, {
+        where: {
+          id,
+          status: entitlement.status, // conditional — unlock/redeem/cancel races lose here
+          [Op.or]: [{ expiresAt: null }, { expiresAt: { [Op.gt]: d.sequelize.literal('NOW()') } }],
+        },
+        transaction: t,
+      });
+      if (count === 0) {
+        throw new AppError('Reward state changed (unlocked, redeemed or expired) — refresh and retry', 409);
+      }
+      await writeEvent(t, {
+        entitlementId: id, type: 'manual_override', actorType: 'staff', actorUserId: user.id,
+        metadata: { action: resendAction, channel },
+      });
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'entitlement.resend_delivery', entityType: 'reward_entitlement',
+        entityId: id, after: { kind, channel }, requestId, transaction: t,
+      });
+    });
+    await entitlement.reload();
+
+    if (channel === 'link') {
+      const bundle = await builders().buildShareBundle({ entitlement, prospect, kind, rawToken: fresh.raw });
+      return { entitlement, kind, channel, emailQueued: false, ...bundle };
+    }
+    const emailQueued = queueDelivery({
+      entitlement, prospect, kind,
+      presentationToken: kind === 'pass' ? fresh.raw : null,
+      voucherToken: kind === 'voucher' ? fresh.raw : null,
+    });
+    return { entitlement, kind, channel, emailQueued };
   }
 
   async function cancelEntitlement(id, user, reason, requestId = null) {
@@ -315,6 +494,8 @@ export function makeEntitlementService(overrides = {}) {
    * Reconciliation sweep (at-least-once backstop for the capture hook): recent
    * verified, unquarantined leads on ACTIVE activation campaigns lacking an
    * entitlement get one. The unique anchor dedupes against hook races.
+   * On a WIRED instance, issueForProspect delivers the pass itself — sweep-
+   * issued entitlements are no longer silently undeliverable (defect 2).
    */
   async function reconcileMissedLeads({ sinceHours = 48 } = {}) {
     const activations = await d.Activation.findAll({
@@ -345,6 +526,83 @@ export function makeEntitlementService(overrides = {}) {
     return issued;
   }
 
+  /**
+   * Delivery-recovery sweep (Codex blocker, 2026-07-16): an entitlement whose
+   * email never got a `notified` receipt (crash between commit and send, SMTP
+   * failure) is otherwise stranded FOREVER — the raw token is gone and
+   * reconcileMissedLeads skips existing rows. Re-mint atomically and retry, up
+   * to `maxAttempts` per kind; rows younger than `minAgeMinutes` are skipped so
+   * an in-flight fire-and-forget send isn't pointlessly rotated. Requires the
+   * notify deps to be wired — a bare instance returns 0 (never rotate a
+   * credential we cannot deliver).
+   */
+  async function reconcileMissedDeliveries({ maxAttempts = 3, minAgeMinutes = 10 } = {}) {
+    const cutoff = new Date(Date.now() - minAgeMinutes * 60 * 1000);
+    const candidates = await d.RewardEntitlement.findAll({
+      where: {
+        status: { [Op.in]: ['eligible', 'issued'] },
+        [Op.or]: [{ expiresAt: null }, { expiresAt: { [Op.gt]: new Date() } }],
+      },
+      include: [{ model: d.Prospect, as: 'prospect' }],
+      order: [['createdAt', 'ASC']],
+      limit: 200,
+    });
+    let recovered = 0;
+    for (const ent of candidates) {
+      try {
+        const kind = ent.status === 'eligible' ? 'pass' : 'voucher';
+        const fn = kind === 'voucher' ? d.notifyUnlock : d.notifyReservation;
+        if (typeof fn !== 'function') continue; // unwired — never rotate undeliverably
+        if (!canEmailProspect(ent.prospect)) continue; // link-channel-only customer
+        const stateSince = kind === 'voucher' ? (ent.unlockedAt || ent.createdAt) : ent.createdAt;
+        if (new Date(stateSince) > cutoff) continue; // give the in-flight send its window
+
+        const receipts = await d.RedemptionEvent.findAll({
+          where: { entitlementId: ent.id, type: { [Op.in]: ['notified', 'notify_failed'] } },
+          order: [['createdAt', 'DESC']],
+          limit: 20,
+        });
+        const forKind = receipts.filter((e) => e.metadata?.kind === kind && (e.metadata?.channel || 'email') === 'email');
+        if (forKind.some((e) => e.type === 'notified')) continue; // delivered
+        if (forKind.length >= maxAttempts) continue; // gave up — visible on the console
+
+        const fresh = mintToken();
+        const fields = kind === 'pass'
+          ? { presentationTokenHash: fresh.hash }
+          : { tokenHash: fresh.hash, tokenHint: tokenHintOf(fresh.raw) };
+        let rotated = false;
+        await d.sequelize.transaction(async (t) => {
+          const [count] = await d.RewardEntitlement.update(fields, {
+            where: {
+              id: ent.id,
+              status: ent.status,
+              [Op.or]: [{ expiresAt: null }, { expiresAt: { [Op.gt]: d.sequelize.literal('NOW()') } }],
+            },
+            transaction: t,
+          });
+          if (count === 0) return;
+          rotated = true;
+          await writeEvent(t, {
+            entitlementId: ent.id, type: 'manual_override', actorType: 'system',
+            metadata: { action: 'auto_resend', kind, channel: 'email' },
+          });
+        });
+        if (!rotated) continue;
+        await ent.reload();
+        queueDelivery({
+          entitlement: ent, prospect: ent.prospect, kind,
+          presentationToken: kind === 'pass' ? fresh.raw : null,
+          voucherToken: kind === 'voucher' ? fresh.raw : null,
+        });
+        recovered += 1;
+      } catch (err) {
+        d.logger.warn('redeem_ops.delivery.recover_failed', { id: ent.id, error: err?.message });
+      }
+    }
+    if (recovered > 0) d.logger.info('redeem_ops.deliveries.recovered', { recovered });
+    return recovered;
+  }
+
   /** Ops listing (staff view — lead PII via JOIN at read time, never copied). */
   async function listEntitlements(query = {}) {
     const where = {};
@@ -370,7 +628,9 @@ export function makeEntitlementService(overrides = {}) {
         {
           model: d.Prospect,
           as: 'prospect',
-          attributes: ['id', 'firstName', 'lastName', 'phone'],
+          // email is selected ONLY to compute emailDeliverable — it is
+          // stripped below and never serialized to the console.
+          attributes: ['id', 'firstName', 'lastName', 'phone', 'email'],
           ...(query.search ? { where: prospectWhere, required: true } : {}),
         },
         { model: d.RewardOffer, as: 'rewardOffer', attributes: ['id', 'title'] },
@@ -379,18 +639,45 @@ export function makeEntitlementService(overrides = {}) {
       order: [['createdAt', 'DESC']],
       limit, offset: (page - 1) * limit,
     });
+
+    // Latest delivery receipt per (entitlement, channel) — one batched query.
+    const ids = rows.map((r) => r.id);
+    const receiptRows = ids.length
+      ? await d.RedemptionEvent.findAll({
+          where: {
+            entitlementId: { [Op.in]: ids },
+            type: { [Op.in]: ['notified', 'notify_failed'] },
+          },
+          order: [['createdAt', 'DESC']],
+        })
+      : [];
+    const latestReceipt = new Map();
+    for (const e of receiptRows) {
+      const key = `${e.entitlementId}:${e.metadata?.channel || 'email'}`;
+      if (!latestReceipt.has(key)) latestReceipt.set(key, e); // DESC → first is latest
+    }
+
     // Mask phones by default (redemptions.verify unmasks at the console)
     const masked = rows.map((r) => {
       const j = r.toJSON();
-      if (j.prospect?.phone) j.prospect.phone = `••••${String(j.prospect.phone).slice(-4)}`;
+      j.emailDeliverable = canEmailProspect(j.prospect);
+      const em = latestReceipt.get(`${j.id}:email`);
+      j.delivery = {
+        email: em ? { kind: em.metadata?.kind || null, at: em.createdAt, ok: em.type === 'notified' } : null,
+      };
+      if (j.prospect) {
+        if (j.prospect.phone) j.prospect.phone = `••••${String(j.prospect.phone).slice(-4)}`;
+        delete j.prospect.email;
+      }
       return j;
     });
     return { entitlements: masked, pagination: { page, limit, total: count, totalPages: Math.ceil(count / limit) } };
   }
 
   return {
-    issueForProspect, unlockEntitlement, issueManual, cancelEntitlement,
-    expireReservations, reconcileMissedLeads, listEntitlements, verificationStampOf,
+    issueForProspect, unlockEntitlement, issueManual, cancelEntitlement, resendDelivery,
+    expireReservations, reconcileMissedLeads, reconcileMissedDeliveries,
+    listEntitlements, verificationStampOf,
   };
 }
 

--- a/backend/src/services/redeemOps/entitlementWiring.js
+++ b/backend/src/services/redeemOps/entitlementWiring.js
@@ -1,0 +1,21 @@
+import { makeEntitlementService } from './entitlementService.js';
+import { makeFulfilmentNotify } from './fulfilmentNotify.js';
+
+/**
+ * The ONE place a fully-delivering entitlement service is assembled
+ * (voucher email on unlock + reservation email on issue). Every unlock
+ * surface and both bootstrap instances use this factory — a bare
+ * `makeEntitlementService()` has null notify deps and sends NOTHING, which
+ * is exactly how the voucher email silently never fired before PR A
+ * (docs/plans/trial-reward-funnel-hardening-prompt.md, defect 1).
+ *
+ * `overrides` spread last so tests keep full DI control.
+ */
+export function makeWiredEntitlementService(overrides = {}) {
+  const notify = makeFulfilmentNotify();
+  return makeEntitlementService({
+    notifyReservation: (args) => notify.sendReservationEmail(args),
+    notifyUnlock: (args) => notify.sendVoucherEmail(args),
+    ...overrides,
+  });
+}

--- a/backend/src/services/redeemOps/fulfilmentNotify.js
+++ b/backend/src/services/redeemOps/fulfilmentNotify.js
@@ -2,6 +2,7 @@ import QRCode from 'qrcode';
 import { RewardOffer, PartnerOrganisation, Campaign, Activation } from '../../models/index.js';
 import { sendEmail } from '../mailer.js';
 import { logger } from '../../utils/logger.js';
+import { maskEmail } from '../../utils/redactTokens.js';
 import { customerHostOrigin, normalizeCustomerHostChoice } from '../../utils/customerHost.js';
 
 /**
@@ -9,8 +10,23 @@ import { customerHostOrigin, normalizeCustomerHostChoice } from '../../utils/cus
  * The email carries the reward in three redundant forms: the voucher QR as a
  * CID-INLINE attachment (renders with remote images blocked; token stays out of
  * image-proxy logs), the short code as text, and the live /r/… link (which now
- * renders the voucher). Fire-and-forget — callers never await delivery.
+ * renders the voucher). Fire-and-forget — callers never await delivery for
+ * latency, but senders RESOLVE (never throw) with a normalized result
+ * `{ sent, skipped?, to?, error? }` so the entitlement service can write
+ * truthful delivery receipts.
  */
+
+/**
+ * The single definition of "this prospect can receive reward email":
+ * an address exists and is not a Retell placeholder. Used by the email
+ * sender + receipts + the ops console's emailDeliverable flag. Deliberately
+ * email-only — the notify seam itself stays channel-agnostic (PR E WhatsApp
+ * must not be suppressed by email logic).
+ */
+export function canEmailProspect(prospect) {
+  return Boolean(prospect?.email) && !/@calls\.mktr\.sg$/i.test(prospect.email);
+}
+
 export function makeFulfilmentNotify(overrides = {}) {
   const d = { RewardOffer, PartnerOrganisation, Campaign, Activation, sendEmail, logger, QRCode, ...overrides };
 
@@ -24,17 +40,42 @@ export function makeFulfilmentNotify(overrides = {}) {
     return { origin: customerHostOrigin(hostChoice), hostChoice };
   }
 
-  /** Reservation-pass email at capture (agent_unlock policy). */
-  async function sendReservationEmail({ entitlement, prospect, presentationToken }) {
-    if (!prospect?.email || /@calls\.mktr\.sg$/i.test(prospect.email)) return;
+  /**
+   * Campaign-branded absolute /r/ link — the ONE builder for every surface
+   * that hands out a claim URL (emails here, the ops copy-link channel in
+   * entitlementService). Never duplicate the origin logic.
+   */
+  async function buildClaimUrl(activation, rawToken) {
+    const { origin, hostChoice } = await claimOrigin(activation);
+    return { link: `${origin}/r/${rawToken}`, origin, hostChoice };
+  }
+
+  async function loadOfferContext(entitlement) {
     const offer = await d.RewardOffer.findByPk(entitlement.rewardOfferId, {
       include: [{ model: d.PartnerOrganisation, as: 'partner', attributes: ['tradingName', 'legalName', 'brandName'] }],
     });
     const activation = await d.Activation.findByPk(entitlement.activationId);
-    const { origin, hostChoice } = await claimOrigin(activation);
-    const link = `${origin}/r/${presentationToken}`;
     const rewardName = offer?.publicTitle || offer?.title || 'your reward';
     const partnerName = offer?.partner?.tradingName || offer?.partner?.brandName || offer?.partner?.legalName || 'our partner';
+    return { offer, activation, rewardName, partnerName };
+  }
+
+  /** Wraps sendEmail into the normalized result — resolves, never throws. */
+  async function deliver(mail, to) {
+    try {
+      const r = await d.sendEmail(mail);
+      if (r?.success === true) return { sent: true, to: maskEmail(to) };
+      return { sent: false, to: maskEmail(to), error: r?.message || 'mailer not configured' };
+    } catch (err) {
+      return { sent: false, to: maskEmail(to), error: err?.message || 'send failed' };
+    }
+  }
+
+  /** Reservation-pass email at capture (agent_unlock policy). */
+  async function sendReservationEmail({ entitlement, prospect, presentationToken }) {
+    if (!canEmailProspect(prospect)) return { sent: false, skipped: 'no_email' };
+    const { activation, rewardName, partnerName } = await loadOfferContext(entitlement);
+    const { link, hostChoice } = await buildClaimUrl(activation, presentationToken);
 
     const qrPng = await d.QRCode.toBuffer(link, { width: 320, margin: 1 });
     const html = `
@@ -48,26 +89,21 @@ export function makeFulfilmentNotify(overrides = {}) {
         <p style="color:#6b7280;font-size:12px">This pass is not a voucher yet — it can only be scanned by your consultant.
         Expires ${entitlement.expiresAt ? new Date(entitlement.expiresAt).toLocaleDateString('en-SG') : 'soon'}.</p>
       </div>`;
-    await d.sendEmail({
+    return deliver({
       to: prospect.email,
       subject: `Reserved for you: ${rewardName}`,
       html,
       text: `Your ${rewardName} from ${partnerName} is reserved. Show this link's QR to your consultant at your review to unlock it: ${link}`,
       context: hostChoice === 'mktr' ? 'mktr' : 'redeem',
       attachments: [{ filename: 'reservation.png', content: qrPng, cid: 'reservation-qr' }],
-    });
+    }, prospect.email);
   }
 
   /** Voucher email at unlock. */
   async function sendVoucherEmail({ entitlement, prospect, voucherToken }) {
-    if (!prospect?.email || /@calls\.mktr\.sg$/i.test(prospect.email)) return;
-    const offer = await d.RewardOffer.findByPk(entitlement.rewardOfferId, {
-      include: [{ model: d.PartnerOrganisation, as: 'partner', attributes: ['tradingName', 'legalName', 'brandName'] }],
-    });
-    const activation = await d.Activation.findByPk(entitlement.activationId);
-    const { origin, hostChoice } = await claimOrigin(activation);
-    const rewardName = offer?.publicTitle || offer?.title || 'your reward';
-    const partnerName = offer?.partner?.tradingName || offer?.partner?.brandName || offer?.partner?.legalName || 'our partner';
+    if (!canEmailProspect(prospect)) return { sent: false, skipped: 'no_email' };
+    const { activation, rewardName, partnerName } = await loadOfferContext(entitlement);
+    const { link, origin, hostChoice } = await buildClaimUrl(activation, voucherToken);
     const shortCode = entitlement.tokenHint || voucherToken.slice(-4).toUpperCase();
 
     const qrPng = await d.QRCode.toBuffer(voucherToken, { width: 320, margin: 1 });
@@ -79,21 +115,42 @@ export function makeFulfilmentNotify(overrides = {}) {
         your <strong>${escapeHtml(rewardName)}</strong>.</p>
         <p style="text-align:center;margin:20px 0"><img src="cid:voucher-qr" width="220" height="220" alt="Voucher QR"/></p>
         <p style="text-align:center;font-size:18px">or quote code <strong>${escapeHtml(shortCode)}</strong></p>
-        <p style="text-align:center"><a href="${origin}/r/${voucherToken}" style="color:#2563eb">View your voucher</a></p>
+        <p style="text-align:center"><a href="${link}" style="color:#2563eb">View your voucher</a></p>
         <p style="color:#6b7280;font-size:12px">One-time use.
         ${entitlement.expiresAt ? `Valid until ${new Date(entitlement.expiresAt).toLocaleDateString('en-SG')}.` : ''}</p>
       </div>`;
-    await d.sendEmail({
+    return deliver({
       to: prospect.email,
       subject: `Your voucher: ${rewardName}`,
       html,
       text: `Your ${rewardName} from ${partnerName} is unlocked! Voucher code: ${shortCode}. View it: ${origin}/r/${voucherToken}`,
       context: hostChoice === 'mktr' ? 'mktr' : 'redeem',
       attachments: [{ filename: 'voucher.png', content: qrPng, cid: 'voucher-qr' }],
-    });
+    }, prospect.email);
   }
 
-  return { sendReservationEmail, sendVoucherEmail };
+  /**
+   * WhatsApp-paste bundle for the ops copy-link channel: the branded link, a
+   * ready-to-send message, and a wa.me deep link (null without a phone). The
+   * raw phone in waUrl is deliberate — the endpoint is capability-gated +
+   * audited, and the staffer is about to see the number in WhatsApp anyway.
+   */
+  async function buildShareBundle({ entitlement, prospect, kind, rawToken }) {
+    const { activation, rewardName, partnerName } = await loadOfferContext(entitlement);
+    const { link } = await buildClaimUrl(activation, rawToken);
+    const first = prospect?.firstName || 'there';
+    const expiry = entitlement.expiresAt
+      ? new Date(entitlement.expiresAt).toLocaleDateString('en-SG')
+      : null;
+    const waMessage = kind === 'voucher'
+      ? `Hi ${first}! 🎉 Your ${rewardName} from ${partnerName} is unlocked. Show this voucher to redeem it: ${link}${expiry ? ` (valid until ${expiry})` : ''}`
+      : `Hi ${first}! 🎁 Your ${rewardName} from ${partnerName} is reserved. Show this pass to your consultant at your review to unlock it: ${link}${expiry ? ` (expires ${expiry})` : ''}`;
+    const digits = String(prospect?.phone || '').replace(/\D/g, '');
+    const waUrl = digits.length >= 8 ? `https://wa.me/${digits}?text=${encodeURIComponent(waMessage)}` : null;
+    return { link, waMessage, waUrl, waUnavailableReason: waUrl ? null : 'no_phone' };
+  }
+
+  return { sendReservationEmail, sendVoucherEmail, buildClaimUrl, buildShareBundle };
 }
 
 function escapeHtml(s) {

--- a/backend/src/utils/redactTokens.js
+++ b/backend/src/utils/redactTokens.js
@@ -1,0 +1,21 @@
+/**
+ * Reward-claim bearer tokens ride in URLs (`/api/reward-claim/:token`, consumer
+ * `/r/:token`), so any layer that logs a request URL is logging a live
+ * credential. Every logging/telemetry sink masks URLs through this ONE helper:
+ * pino-http request logs, errorHandler, Sentry scrubbing. The frontend api
+ * client carries its own copy (it cannot import backend code).
+ */
+const TOKEN_PATH_RE = /(\/(?:api\/reward-claim|r)\/)[^/?#\s]+/gi;
+
+export function maskTokenUrl(url) {
+  if (typeof url !== 'string' || url.length === 0) return url;
+  return url.replace(TOKEN_PATH_RE, '$1[token]');
+}
+
+/** `shawn@gmail.com` → `s•••@gmail.com` — log-safe recipient display. */
+export function maskEmail(email) {
+  const s = String(email || '');
+  const at = s.indexOf('@');
+  if (at <= 0) return s ? '•••' : '';
+  return `${s[0]}•••${s.slice(at)}`;
+}

--- a/backend/src/utils/sentryScrub.js
+++ b/backend/src/utils/sentryScrub.js
@@ -3,6 +3,8 @@
 // patterns. Substring-based, case-insensitive match on key names so
 // `agentPhone`, `lead_email`, `staff_full_name`, etc. all get redacted.
 
+import { maskTokenUrl } from './redactTokens.js';
+
 const PII_KEY_PATTERN = /phone|email|nric|name|token|jwt|address|otp|password|signature|secret|private_?key|authorization/i;
 
 export function scrubObject(input) {
@@ -27,6 +29,9 @@ export function scrubEvent(event) {
   if (event.tags) event.tags = scrubObject(event.tags);
   if (event.contexts) event.contexts = scrubObject(event.contexts);
   if (event.request?.data) event.request.data = scrubObject(event.request.data);
+  // Reward-claim URLs carry live bearer tokens — mask the path segment
+  // (scrubObject only matches key NAMES; a token inside a `url` value slips by).
+  if (typeof event.request?.url === 'string') event.request.url = maskTokenUrl(event.request.url);
   // Strip user PII — only id is allowed.
   if (event.user) event.user = { id: event.user.id };
   return event;
@@ -34,6 +39,10 @@ export function scrubEvent(event) {
 
 export function scrubBreadcrumb(breadcrumb) {
   if (!breadcrumb) return breadcrumb;
-  if (breadcrumb.data) breadcrumb.data = scrubObject(breadcrumb.data);
+  if (breadcrumb.data) {
+    breadcrumb.data = scrubObject(breadcrumb.data);
+    if (typeof breadcrumb.data.url === 'string') breadcrumb.data.url = maskTokenUrl(breadcrumb.data.url);
+  }
+  if (typeof breadcrumb.message === 'string') breadcrumb.message = maskTokenUrl(breadcrumb.message);
   return breadcrumb;
 }

--- a/backend/test/entitlementUnlockVia.test.js
+++ b/backend/test/entitlementUnlockVia.test.js
@@ -20,8 +20,12 @@ const LYFE_SECRET = 'test-lyfe-outcome-secret';
 
 const unlockMock = jest.fn();
 
-jest.unstable_mockModule('../src/services/redeemOps/entitlementService.js', () => ({
-  makeEntitlementService: () => ({ unlockEntitlement: unlockMock }),
+// The routes consume the WIRED factory (entitlementWiring.js) since PR A —
+// mocking the wiring here keeps the models mock minimal (the real wiring
+// statically imports fulfilmentNotify, whose model imports the User-only
+// mock below could not satisfy at ESM link time).
+jest.unstable_mockModule('../src/services/redeemOps/entitlementWiring.js', () => ({
+  makeWiredEntitlementService: () => ({ unlockEntitlement: unlockMock }),
 }));
 jest.unstable_mockModule('../src/models/index.js', () => ({
   User: { findOne: jest.fn().mockResolvedValue({ id: 'agent-1', role: 'agent' }) },

--- a/backend/test/redeemOpsFulfilmentDelivery.test.js
+++ b/backend/test/redeemOpsFulfilmentDelivery.test.js
@@ -1,0 +1,595 @@
+/**
+ * PR A — voucher/pass delivery actually delivers
+ * (docs/plans/trial-reward-funnel-hardening-prompt.md).
+ *
+ * The 2026-07-16 audit found ZERO email assertions across the fulfilment
+ * suites — which is exactly how "notifyUnlock only wired in bootstrap" shipped
+ * broken. This battery asserts delivery END-TO-END through the real app with
+ * only the mailer mocked: unlock emails on all three surfaces (external HMAC /
+ * Lyfe HMAC / admin console), truthful emailQueued incl. replay + no-email
+ * leads, sweep-issue delivery, delivery recovery, atomic resend/share, manual
+ * issue pinned to the requested activation, and the receipts the console reads.
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+process.env.REDEEM_OPS_ENTITLEMENTS_ENABLED = 'true';
+process.env.EXTERNAL_APP_SECRET = process.env.EXTERNAL_APP_SECRET || 'test-external-secret';
+process.env.LYFE_LEAD_OUTCOME_SECRET = process.env.LYFE_LEAD_OUTCOME_SECRET || 'test-lyfe-outcome-secret';
+
+import { jest } from '@jest/globals';
+import crypto from 'crypto';
+import request from 'supertest';
+
+const sendEmailMock = jest.fn().mockResolvedValue({ success: true });
+
+// Mirror EVERY named export — a missing name is an ESM link error in any
+// module that imports it.
+jest.unstable_mockModule('../src/services/mailer.js', () => ({
+  resolveEmailFrom: () => 'noreply@test.local',
+  brandFromContext: () => 'Redeem',
+  getTransporter: () => null,
+  sendEmail: (...args) => sendEmailMock(...args),
+  sendLeadAssignmentEmail: jest.fn().mockResolvedValue({ success: true }),
+  sendLeadConfirmationEmail: jest.fn().mockResolvedValue({ success: true }),
+  sendPackageAssignmentEmail: jest.fn().mockResolvedValue({ success: true }),
+}));
+
+let app, closeDb, createTestUser, createTestCampaign;
+let Prospect, RewardOffer, Activation, RewardEntitlement, RedemptionEvent, PartnerOrganisation, sequelize;
+let svc; // WIRED service — the thing production actually runs
+
+let admin, agentExt, agentLyfe, redemptionOps, bdm;
+let partner, offer, campaignA, campaignB, campaignC, activationA, activationB, activationC;
+
+// Deterministic barrier over the service's fire-and-forget deliveries —
+// sleeps would race the real async email + receipt chain.
+let flushDeliveries;
+const settle = () => flushDeliveries();
+const auth = (t) => ({ Authorization: `Bearer ${t}` });
+
+function lastEmail() {
+  return sendEmailMock.mock.calls.at(-1)?.[0] || null;
+}
+function tokenFromEmail(mail) {
+  const m = String(mail?.text || '').match(/\/r\/([A-Za-z0-9_-]+)/);
+  return m ? m[1] : null;
+}
+
+function extUnlock(body) {
+  const bodyString = JSON.stringify({ ...body, timestamp: new Date().toISOString() });
+  const sig = crypto.createHmac('sha256', process.env.EXTERNAL_APP_SECRET).update(Buffer.from(bodyString)).digest('hex');
+  return request(app)
+    .post('/api/external/entitlements/unlock')
+    .set('content-type', 'application/json')
+    .set('x-webhook-signature', `sha256=${sig}`)
+    .send(bodyString);
+}
+
+function lyfeUnlock(body) {
+  const bodyString = JSON.stringify(body);
+  const ts = new Date().toISOString();
+  const sig = crypto.createHmac('sha256', process.env.LYFE_LEAD_OUTCOME_SECRET).update(`${ts}.${bodyString}`).digest('hex');
+  return request(app)
+    .post('/api/integrations/lyfe/entitlement-unlock')
+    .set('content-type', 'application/json')
+    .set('x-webhook-timestamp', ts)
+    .set('x-webhook-signature', `sha256=${sig}`)
+    .send(bodyString);
+}
+
+let prospectSeq = 0;
+async function makeProspect(overrides = {}) {
+  prospectSeq += 1;
+  return Prospect.create({
+    firstName: 'Delivery',
+    lastName: `Holder${prospectSeq}`,
+    phone: `+65${Math.floor(80000000 + Math.random() * 9999999)}`,
+    email: `delivery-${Date.now()}-${prospectSeq}@test.com`,
+    leadSource: 'website',
+    campaignId: campaignA.id,
+    assignedAgentId: agentExt.user.id,
+    sourceMetadata: { phoneVerifiedAt: new Date().toISOString() },
+    ...overrides,
+  });
+}
+
+/** Clear the 60s resend cooldown / recovery in-flight window for an entitlement. */
+async function backdateHistory(entitlementId, minutes = 15) {
+  await sequelize.query(
+    `UPDATE redemption_events SET "createdAt" = NOW() - INTERVAL '${minutes} minutes' WHERE "entitlementId" = :id`,
+    { replacements: { id: entitlementId } }
+  );
+  await sequelize.query(
+    `UPDATE reward_entitlements SET "createdAt" = NOW() - INTERVAL '${minutes} minutes' WHERE id = :id`,
+    { replacements: { id: entitlementId } }
+  );
+}
+
+beforeAll(async () => {
+  const helpers = await import('./helpers.js');
+  ({ closeDb, createTestUser, createTestCampaign } = helpers);
+  app = await helpers.getApp();
+  ({ Prospect, RewardOffer, Activation, RewardEntitlement, RedemptionEvent, PartnerOrganisation, sequelize } =
+    await import('../src/models/index.js'));
+  ({ flushDeliveries } = await import('../src/services/redeemOps/entitlementService.js'));
+  const wiring = await import('../src/services/redeemOps/entitlementWiring.js');
+  svc = wiring.makeWiredEntitlementService();
+
+  admin = await createTestUser({ role: 'admin' });
+  agentExt = await createTestUser({ role: 'agent', mktrLeadsId: `ml-${Date.now()}` });
+  agentLyfe = await createTestUser({ role: 'agent', lyfeId: `ly-${Date.now()}` });
+  redemptionOps = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'redemption_ops' });
+  bdm = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'bdm' });
+
+  partner = await PartnerOrganisation.create({
+    tradingName: 'Delivery Test Studio', normalizedName: 'delivery test studio', createdBy: admin.user.id,
+  });
+  campaignA = await createTestCampaign(admin.user.id, { name: 'Delivery Campaign A' });
+  campaignB = await createTestCampaign(admin.user.id, { name: 'Delivery Campaign B' });
+  campaignC = await createTestCampaign(admin.user.id, { name: 'Delivery Campaign C' });
+
+  offer = await RewardOffer.create({
+    partnerOrganisationId: partner.id, title: 'Free Trial Session',
+    committedQuantity: 300, allocatedQuantity: 200, status: 'active',
+    claimExpiryDays: 30, redemptionExpiryDays: 90, createdBy: admin.user.id,
+  });
+  activationA = await Activation.create({
+    partnerOrganisationId: partner.id, rewardOfferId: offer.id, campaignId: campaignA.id,
+    campaignNameSnapshot: campaignA.name, allocatedQuantity: 60, status: 'active',
+    unlockPolicy: 'agent_unlock', createdBy: admin.user.id,
+  });
+  activationB = await Activation.create({
+    partnerOrganisationId: partner.id, rewardOfferId: offer.id, campaignId: campaignB.id,
+    campaignNameSnapshot: campaignB.name, allocatedQuantity: 60, status: 'active',
+    unlockPolicy: 'agent_unlock', createdBy: admin.user.id,
+  });
+  activationC = await Activation.create({
+    partnerOrganisationId: partner.id, rewardOfferId: offer.id, campaignId: campaignC.id,
+    campaignNameSnapshot: campaignC.name, allocatedQuantity: 60, status: 'active',
+    unlockPolicy: 'on_capture', createdBy: admin.user.id,
+  });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+beforeEach(async () => {
+  await flushDeliveries(); // drain any straggler from the previous test
+  sendEmailMock.mockClear();
+  sendEmailMock.mockResolvedValue({ success: true });
+});
+
+describe('issuance delivers (single choke point)', () => {
+  test('fresh issue sends the reservation pass + writes a notified receipt', async () => {
+    const prospect = await makeProspect();
+    const r = await svc.issueForProspect(prospect, { via: 'hook' });
+    expect(r.reason).toBeNull();
+    expect(r.emailQueued).toBe(true);
+    await settle();
+
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    const mail = lastEmail();
+    expect(mail.subject).toContain('Reserved for you');
+    expect(mail.to).toBe(prospect.email);
+    expect(tokenFromEmail(mail)).toBe(r.presentationToken);
+
+    const receipts = await RedemptionEvent.findAll({
+      where: { entitlementId: r.entitlement.id, type: 'notified' },
+    });
+    expect(receipts).toHaveLength(1);
+    expect(receipts[0].metadata.kind).toBe('pass');
+    expect(receipts[0].metadata.channel).toBe('email');
+    expect(receipts[0].metadata.to).toContain('•'); // masked, never the raw address
+  });
+
+  test('concurrent hook/sweep race → exactly ONE email', async () => {
+    const prospect = await makeProspect();
+    const [a, b] = await Promise.all([
+      svc.issueForProspect(prospect, { via: 'hook' }),
+      svc.issueForProspect(prospect, { via: 'sweep' }),
+    ]);
+    await settle();
+    const fresh = [a, b].filter((r) => r.reason === null);
+    expect(fresh).toHaveLength(1);
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('on_capture policy sends the VOUCHER email at issue', async () => {
+    const prospect = await makeProspect({ campaignId: campaignC.id });
+    const r = await svc.issueForProspect(prospect, { via: 'hook' });
+    expect(r.reason).toBeNull();
+    expect(r.voucherToken).toBeTruthy();
+    expect(r.entitlement.activationId).toBe(activationC.id);
+    await settle();
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(lastEmail().subject).toContain('Your voucher');
+
+    const claim = await request(app).get(`/api/reward-claim/${r.presentationToken}`);
+    expect(claim.status).toBe(200);
+    expect(claim.body.data.state).toBe('unlocked');
+  });
+
+  test('no-email (Retell placeholder) lead: no send, no receipt, emailQueued false', async () => {
+    const prospect = await makeProspect({ email: `retell-${Date.now()}@calls.mktr.sg` });
+    const r = await svc.issueForProspect(prospect, { via: 'hook' });
+    expect(r.reason).toBeNull();
+    expect(r.emailQueued).toBe(false);
+    await settle();
+    expect(sendEmailMock).not.toHaveBeenCalled();
+    const deliveryReceipts = (await RedemptionEvent.findAll({ where: { entitlementId: r.entitlement.id } }))
+      .filter((e) => ['notified', 'notify_failed'].includes(e.type));
+    expect(deliveryReceipts).toHaveLength(0); // nothing attempted → no receipt
+  });
+});
+
+describe('unlock delivers the voucher on all three surfaces', () => {
+  test('external (mktr-leads) scan unlock → voucher email + emailQueued', async () => {
+    const prospect = await makeProspect();
+    const issue = await svc.issueForProspect(prospect);
+    await settle();
+    sendEmailMock.mockClear();
+
+    const res = await extUnlock({
+      agentMktrUserId: agentExt.user.mktrLeadsId,
+      presentationToken: issue.presentationToken,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.emailQueued).toBe(true);
+    await settle();
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(lastEmail().subject).toContain('Your voucher');
+
+    const receipts = (await RedemptionEvent.findAll({ where: { entitlementId: issue.entitlement.id, type: 'notified' } }))
+      .filter((e) => e.metadata?.kind === 'voucher');
+    expect(receipts).toHaveLength(1);
+  });
+
+  test('lyfe button unlock → voucher email + truthful message; replay sends nothing', async () => {
+    const prospect = await makeProspect({ assignedAgentId: agentLyfe.user.id });
+    await svc.issueForProspect(prospect);
+    await settle();
+    sendEmailMock.mockClear();
+
+    const res = await lyfeUnlock({ agentLyfeId: agentLyfe.user.lyfeId, prospectId: prospect.id });
+    expect(res.status).toBe(200);
+    expect(res.body.message).toContain('emailed their voucher');
+    expect(res.body.data.emailQueued).toBe(true);
+    await settle();
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+
+    sendEmailMock.mockClear();
+    const replay = await lyfeUnlock({ agentLyfeId: agentLyfe.user.lyfeId, prospectId: prospect.id });
+    expect(replay.status).toBe(200);
+    expect(replay.body.data.already).toBe(true);
+    expect(replay.body.data.emailQueued).toBe(false);
+    expect(replay.body.message).toBe('Already unlocked');
+    await settle();
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  test('admin console unlock → voucher email + emailQueued in the payload', async () => {
+    const prospect = await makeProspect();
+    await svc.issueForProspect(prospect);
+    await settle();
+    sendEmailMock.mockClear();
+
+    const res = await request(app)
+      .post('/api/redeem-ops/entitlements/unlock')
+      .set(auth(admin.token))
+      .send({ prospectId: prospect.id });
+    expect(res.status).toBe(200);
+    expect(res.body.data.emailQueued).toBe(true);
+    await settle();
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(lastEmail().subject).toContain('Your voucher');
+  });
+
+  test('no-email lead unlock: succeeds, NO email, message says share the link', async () => {
+    const prospect = await makeProspect({
+      email: `retell-${Date.now()}@calls.mktr.sg`,
+      assignedAgentId: agentLyfe.user.id,
+    });
+    await svc.issueForProspect(prospect);
+    await settle();
+    sendEmailMock.mockClear();
+
+    const res = await lyfeUnlock({ agentLyfeId: agentLyfe.user.lyfeId, prospectId: prospect.id });
+    expect(res.status).toBe(200);
+    expect(res.body.data.emailQueued).toBe(false);
+    expect(res.body.message).toContain('no email on file');
+    await settle();
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('sweeps deliver', () => {
+  test('reconcileMissedLeads issues AND emails; the emailed token resolves', async () => {
+    const prospect = await makeProspect(); // no entitlement yet — hook "missed" it
+    sendEmailMock.mockClear();
+    const issued = await svc.reconcileMissedLeads();
+    expect(issued).toBeGreaterThanOrEqual(1);
+    await settle();
+
+    const mine = sendEmailMock.mock.calls.map((c) => c[0]).find((m) => m.to === prospect.email);
+    expect(mine).toBeTruthy();
+    expect(mine.subject).toContain('Reserved for you');
+    const token = tokenFromEmail(mine);
+    const claim = await request(app).get(`/api/reward-claim/${token}`);
+    expect(claim.status).toBe(200);
+    expect(claim.body.data.state).toBe('reserved');
+  });
+
+  test('reconcileMissedDeliveries re-mints + resends when the first send failed', async () => {
+    const prospect = await makeProspect();
+    sendEmailMock.mockResolvedValueOnce({ success: false, message: 'mailer down' });
+    const issue = await svc.issueForProspect(prospect);
+    await settle();
+
+    const failed = (await RedemptionEvent.findAll({ where: { entitlementId: issue.entitlement.id, type: 'notify_failed' } }));
+    expect(failed).toHaveLength(1);
+
+    await backdateHistory(issue.entitlement.id, 15);
+    sendEmailMock.mockClear();
+
+    const recovered = await svc.reconcileMissedDeliveries();
+    expect(recovered).toBeGreaterThanOrEqual(1);
+    await settle();
+
+    const mine = sendEmailMock.mock.calls.map((c) => c[0]).find((m) => m.to === prospect.email);
+    expect(mine).toBeTruthy();
+    const newToken = tokenFromEmail(mine);
+    expect(newToken).not.toBe(issue.presentationToken);
+    expect((await request(app).get(`/api/reward-claim/${issue.presentationToken}`)).status).toBe(404);
+    expect((await request(app).get(`/api/reward-claim/${newToken}`)).status).toBe(200);
+  });
+
+  test('recovery gives up after maxAttempts failures (console shows it instead)', async () => {
+    const prospect = await makeProspect();
+    sendEmailMock.mockResolvedValueOnce({ success: false, message: 'down' });
+    const issue = await svc.issueForProspect(prospect);
+    await settle();
+    // two more failed attempts on record → 3 total
+    for (let i = 0; i < 2; i += 1) {
+      await RedemptionEvent.create({
+        entitlementId: issue.entitlement.id, type: 'notify_failed', actorType: 'system',
+        metadata: { kind: 'pass', channel: 'email' },
+      });
+    }
+    await backdateHistory(issue.entitlement.id, 15);
+    sendEmailMock.mockClear();
+
+    await svc.reconcileMissedDeliveries();
+    await settle();
+    const mine = sendEmailMock.mock.calls.map((c) => c[0]).find((m) => m.to === prospect.email);
+    expect(mine).toBeFalsy();
+  });
+
+  test('recovery skips rows already delivered and rows too young', async () => {
+    const delivered = await makeProspect();
+    const issue = await svc.issueForProspect(delivered); // success receipt
+    await settle(); // let the delivered send land BEFORE arming the failure
+    const young = await makeProspect();
+    sendEmailMock.mockResolvedValueOnce({ success: false, message: 'down' });
+    const youngIssue = await svc.issueForProspect(young); // failed, but < minAge
+    await settle();
+    await backdateHistory(issue.entitlement.id, 15); // delivered one is old but has notified
+    sendEmailMock.mockClear();
+
+    await svc.reconcileMissedDeliveries();
+    await settle();
+    const calls = sendEmailMock.mock.calls.map((c) => c[0].to);
+    expect(calls).not.toContain(delivered.email);
+    expect(calls).not.toContain(young.email);
+    expect(youngIssue.reason).toBeNull();
+  });
+});
+
+describe('resend / share', () => {
+  async function issueBackdated(overrides = {}) {
+    const prospect = await makeProspect(overrides);
+    const issue = await svc.issueForProspect(prospect);
+    expect(issue.reason).toBeNull();
+    await settle();
+    await backdateHistory(issue.entitlement.id, 15);
+    sendEmailMock.mockClear();
+    return { prospect, issue };
+  }
+
+  test('eligible resend (email): old token 404s, new token 200s', async () => {
+    const { issue } = await issueBackdated();
+    const res = await request(app)
+      .post(`/api/redeem-ops/entitlements/${issue.entitlement.id}/resend-pass`)
+      .set(auth(redemptionOps.token))
+      .send({ channel: 'email' });
+    expect(res.status).toBe(200);
+    expect(res.body.message).toContain('no longer works');
+    expect(res.body.data.kind).toBe('pass');
+    expect(res.body.data.emailQueued).toBe(true);
+    await settle();
+
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    const newToken = tokenFromEmail(lastEmail());
+    expect(newToken).not.toBe(issue.presentationToken);
+    expect((await request(app).get(`/api/reward-claim/${issue.presentationToken}`)).status).toBe(404);
+    expect((await request(app).get(`/api/reward-claim/${newToken}`)).status).toBe(200);
+  });
+
+  test('issued resend rotates ONLY the voucher — the presentation link survives', async () => {
+    const { prospect, issue } = await issueBackdated();
+    const unlock = await svc.unlockEntitlement({ presentationToken: issue.presentationToken }, admin.user, 'manual');
+    expect(unlock.already).toBe(false);
+    await settle();
+    await backdateHistory(issue.entitlement.id, 15);
+    sendEmailMock.mockClear();
+
+    const res = await request(app)
+      .post(`/api/redeem-ops/entitlements/${issue.entitlement.id}/resend-pass`)
+      .set(auth(redemptionOps.token))
+      .send({ channel: 'email' });
+    expect(res.status).toBe(200);
+    expect(res.body.data.kind).toBe('voucher');
+    await settle();
+
+    const newVoucher = tokenFromEmail(lastEmail());
+    expect(newVoucher).not.toBe(unlock.voucherToken);
+    // old voucher credential is dead…
+    expect((await request(app).get(`/api/reward-claim/${unlock.voucherToken}`)).status).toBe(404);
+    // …but the post-unlock presentation link still renders the voucher (step-9 design)
+    const viaPass = await request(app).get(`/api/reward-claim/${issue.presentationToken}`);
+    expect(viaPass.status).toBe(200);
+    expect(viaPass.body.data.state).toBe('unlocked');
+    expect((await request(app).get(`/api/reward-claim/${newVoucher}`)).status).toBe(200);
+    expect(prospect.id).toBeTruthy();
+  });
+
+  test('link channel: bundle returned once, nothing emailed, no-store set', async () => {
+    const { prospect, issue } = await issueBackdated();
+    const res = await request(app)
+      .post(`/api/redeem-ops/entitlements/${issue.entitlement.id}/resend-pass`)
+      .set(auth(redemptionOps.token))
+      .send({ channel: 'link' });
+    expect(res.status).toBe(200);
+    expect(res.headers['cache-control']).toBe('no-store');
+    expect(res.body.data.link).toMatch(/\/r\/[A-Za-z0-9_-]+/);
+    expect(res.body.data.waMessage).toContain('Free Trial Session');
+    const digits = prospect.phone.replace(/\D/g, '');
+    expect(res.body.data.waUrl).toContain(`wa.me/${digits}`);
+    expect(res.body.data.waUrl).toContain(encodeURIComponent('reserved'));
+    await settle();
+    expect(sendEmailMock).not.toHaveBeenCalled();
+
+    const newToken = res.body.data.link.split('/r/')[1];
+    expect((await request(app).get(`/api/reward-claim/${issue.presentationToken}`)).status).toBe(404);
+    expect((await request(app).get(`/api/reward-claim/${newToken}`)).status).toBe(200);
+  });
+
+  test('link channel without a phone: waUrl null + typed reason', async () => {
+    const { issue } = await issueBackdated({ phone: null });
+    const res = await request(app)
+      .post(`/api/redeem-ops/entitlements/${issue.entitlement.id}/resend-pass`)
+      .set(auth(redemptionOps.token))
+      .send({ channel: 'link' });
+    expect(res.status).toBe(200);
+    expect(res.body.data.waUrl).toBeNull();
+    expect(res.body.data.waUnavailableReason).toBe('no_phone');
+    expect(res.body.data.link).toMatch(/\/r\//);
+  });
+
+  test('no usable email + email channel → typed 409 (link still possible)', async () => {
+    const { issue } = await issueBackdated({ email: `retell-${Date.now()}@calls.mktr.sg` });
+    const res = await request(app)
+      .post(`/api/redeem-ops/entitlements/${issue.entitlement.id}/resend-pass`)
+      .set(auth(redemptionOps.token))
+      .send({ channel: 'email' });
+    expect(res.status).toBe(409);
+    expect(res.body.message).toContain('copy-link');
+  });
+
+  test('cooldown: immediate second resend → 429', async () => {
+    const { issue } = await issueBackdated();
+    const first = await request(app)
+      .post(`/api/redeem-ops/entitlements/${issue.entitlement.id}/resend-pass`)
+      .set(auth(redemptionOps.token))
+      .send({ channel: 'email' });
+    expect(first.status).toBe(200);
+    const second = await request(app)
+      .post(`/api/redeem-ops/entitlements/${issue.entitlement.id}/resend-pass`)
+      .set(auth(redemptionOps.token))
+      .send({ channel: 'email' });
+    expect(second.status).toBe(429);
+  });
+
+  test('expired / cancelled → typed 409; bdm capability → 403', async () => {
+    const { issue } = await issueBackdated();
+    await RewardEntitlement.update({ expiresAt: new Date(Date.now() - 1000) }, { where: { id: issue.entitlement.id } });
+    const expired = await request(app)
+      .post(`/api/redeem-ops/entitlements/${issue.entitlement.id}/resend-pass`)
+      .set(auth(redemptionOps.token))
+      .send({ channel: 'email' });
+    expect(expired.status).toBe(409);
+    expect(expired.body.message).toContain('expired');
+
+    const { issue: issue2 } = await issueBackdated();
+    const forbidden = await request(app)
+      .post(`/api/redeem-ops/entitlements/${issue2.entitlement.id}/resend-pass`)
+      .set(auth(bdm.token))
+      .send({ channel: 'email' });
+    expect(forbidden.status).toBe(403);
+  });
+
+  test('resend racing a state change loses cleanly (conditional update)', async () => {
+    const { issue } = await issueBackdated();
+    // Simulate the race: state flips to cancelled after the service read it —
+    // the conditional UPDATE (status must still match) must reject.
+    await RewardEntitlement.update({ status: 'cancelled' }, { where: { id: issue.entitlement.id } });
+    const res = await request(app)
+      .post(`/api/redeem-ops/entitlements/${issue.entitlement.id}/resend-pass`)
+      .set(auth(redemptionOps.token))
+      .send({ channel: 'email' });
+    expect(res.status).toBe(409);
+  });
+});
+
+describe('manual issue', () => {
+  test('pins the REQUESTED activation (not the prospect-campaign one) and emails', async () => {
+    const prospectOnB = await makeProspect({ campaignId: campaignB.id, assignedAgentId: agentExt.user.id });
+    sendEmailMock.mockClear();
+    const res = await request(app)
+      .post('/api/redeem-ops/entitlements')
+      .set(auth(admin.token))
+      .send({ activationId: activationA.id, prospectId: prospectOnB.id });
+    expect(res.status).toBe(201);
+    expect(res.body.data.entitlement.activationId).toBe(activationA.id);
+    expect(res.body.data.entitlement.activationId).not.toBe(activationB.id);
+    expect(res.body.data.emailQueued).toBe(true);
+    expect(res.body.data.presentationToken).toBeTruthy(); // staff hand-delivery unchanged
+    await settle();
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('a non-active requested activation is refused with the typed reason', async () => {
+    const prospect = await makeProspect();
+    const draft = await Activation.create({
+      partnerOrganisationId: partner.id, rewardOfferId: offer.id, campaignId: null,
+      campaignNameSnapshot: null, allocatedQuantity: 5, status: 'draft',
+      unlockPolicy: 'agent_unlock', createdBy: admin.user.id,
+    });
+    const res = await request(app)
+      .post('/api/redeem-ops/entitlements')
+      .set(auth(admin.token))
+      .send({ activationId: draft.id, prospectId: prospect.id });
+    expect(res.status).toBe(409);
+    expect(res.body.message).toContain('activation_not_active');
+  });
+});
+
+describe('console list surfaces delivery truth', () => {
+  test('emailDeliverable + per-channel delivery receipt, raw email stripped', async () => {
+    const good = await makeProspect();
+    const goodIssue = await svc.issueForProspect(good);
+    const bad = await makeProspect({ email: `retell-${Date.now()}@calls.mktr.sg` });
+    const badIssue = await svc.issueForProspect(bad);
+    await settle();
+
+    const res = await request(app)
+      .get('/api/redeem-ops/entitlements?limit=100')
+      .set(auth(admin.token));
+    expect(res.status).toBe(200);
+    const rows = res.body.data.entitlements;
+
+    const goodRow = rows.find((r) => r.id === goodIssue.entitlement.id);
+    expect(goodRow.emailDeliverable).toBe(true);
+    expect(goodRow.delivery.email).toBeTruthy();
+    expect(goodRow.delivery.email.ok).toBe(true);
+    expect(goodRow.delivery.email.kind).toBe('pass');
+
+    const badRow = rows.find((r) => r.id === badIssue.entitlement.id);
+    expect(badRow.emailDeliverable).toBe(false);
+    expect(badRow.delivery.email).toBeNull();
+
+    for (const r of rows) {
+      expect(r.prospect === null || !('email' in r.prospect)).toBe(true);
+      if (r.prospect?.phone) expect(r.prospect.phone).toContain('••••');
+    }
+  });
+});

--- a/backend/test/tokenRedaction.test.js
+++ b/backend/test/tokenRedaction.test.js
@@ -1,0 +1,77 @@
+/**
+ * Reward-claim tokens are live bearer credentials that ride in URLs — PR A
+ * masks them at every logging/telemetry layer (Codex blocker: the exposure
+ * predates PR A; pino-http, errorHandler, Sentry request.url and the frontend
+ * client all logged them raw).
+ */
+import { jest } from '@jest/globals';
+import { maskTokenUrl, maskEmail } from '../src/utils/redactTokens.js';
+import { scrubEvent, scrubBreadcrumb } from '../src/utils/sentryScrub.js';
+import { errorHandler } from '../src/middleware/errorHandler.js';
+import { logger } from '../src/utils/logger.js';
+
+const TOKEN = 'aB3xY9zQ7wK2mN8pL5vC1dF6gH4jR0sT_uEiOa-b';
+
+describe('maskTokenUrl', () => {
+  test('masks the reward-claim api path', () => {
+    expect(maskTokenUrl(`/api/reward-claim/${TOKEN}`)).toBe('/api/reward-claim/[token]');
+  });
+
+  test('masks the consumer /r/ path incl. absolute urls and query strings', () => {
+    expect(maskTokenUrl(`https://redeem.sg/r/${TOKEN}?utm_source=x`)).toBe('https://redeem.sg/r/[token]?utm_source=x');
+  });
+
+  test('masks every occurrence, leaves other urls alone', () => {
+    const s = `GET /api/reward-claim/${TOKEN} then /r/${TOKEN} then /api/redeem-ops/entitlements/123`;
+    const masked = maskTokenUrl(s);
+    expect(masked).not.toContain(TOKEN);
+    expect(masked).toContain('/api/redeem-ops/entitlements/123');
+  });
+
+  test('non-string / empty inputs pass through', () => {
+    expect(maskTokenUrl(null)).toBeNull();
+    expect(maskTokenUrl(undefined)).toBeUndefined();
+    expect(maskTokenUrl('')).toBe('');
+  });
+});
+
+describe('maskEmail', () => {
+  test('keeps first char + domain only', () => {
+    expect(maskEmail('shawn@gmail.com')).toBe('s•••@gmail.com');
+  });
+  test('degrades safely on junk', () => {
+    expect(maskEmail('')).toBe('');
+    expect(maskEmail('nodomain')).toBe('•••');
+  });
+});
+
+describe('sentry scrubbing', () => {
+  test('event.request.url is masked', () => {
+    const event = { request: { url: `https://api.mktr.sg/api/reward-claim/${TOKEN}`, data: {} } };
+    const out = scrubEvent(event);
+    expect(out.request.url).toBe('https://api.mktr.sg/api/reward-claim/[token]');
+  });
+
+  test('breadcrumb url + message are masked', () => {
+    const crumb = {
+      message: `GET /api/reward-claim/${TOKEN} failed`,
+      data: { url: `/r/${TOKEN}`, method: 'GET' },
+    };
+    const out = scrubBreadcrumb(crumb);
+    expect(out.data.url).toBe('/r/[token]');
+    expect(out.message).not.toContain(TOKEN);
+  });
+});
+
+describe('errorHandler request logging', () => {
+  test('logs the masked url, never the raw token', () => {
+    const spy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+    const req = { method: 'GET', originalUrl: `/api/reward-claim/${TOKEN}`, id: 'req-1' };
+    const res = { status: () => ({ json: () => {} }) };
+    errorHandler(new Error('boom'), req, res, () => {});
+    const logged = spy.mock.calls.at(-1)[0];
+    expect(logged.req.url).toBe('/api/reward-claim/[token]');
+    expect(JSON.stringify(logged)).not.toContain(TOKEN);
+    spy.mockRestore();
+  });
+});

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -2,6 +2,7 @@
  * MKTR API Client - Replaces Base44 SDK
  * Provides all the same functionality but connects to our custom backend
  */
+import { maskTokenUrl } from '../lib/sentryScrub';
 
 // API Configuration
 const baseURL = import.meta.env.VITE_API_URL;
@@ -163,7 +164,9 @@ class APIClient {
 
  return isJson ? data : { success: false, message: data };
  } catch (error) {
- console.error(`API Error [${config.method} ${endpoint}]:`, error);
+ // maskTokenUrl: /api/reward-claim/:token is a live bearer credential —
+ // it must not land in the console (or Sentry console breadcrumbs).
+ console.error(`API Error [${config.method} ${maskTokenUrl(endpoint)}]:`, error);
  throw error;
  }
  }

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -340,6 +340,12 @@ export const redeemOpsApi = {
     const res = await apiClient.post('/redeem-ops/entitlements/unlock', body);
     return res.data;
   },
+  async resendEntitlementPass(id, { channel = 'email' } = {}) {
+    // Re-mints the current credential (the old QR/link dies) and either emails
+    // it or returns { link, waMessage, waUrl } once for staff to share.
+    // Full response returned — the toast needs the server's message.
+    return apiClient.post(`/redeem-ops/entitlements/${id}/resend-pass`, { channel });
+  },
   async verifyVoucher(token) {
     const res = await apiClient.post('/redeem-ops/redemptions/verify', { token });
     return res.data;

--- a/src/lib/sentryScrub.js
+++ b/src/lib/sentryScrub.js
@@ -6,6 +6,16 @@
 
 const PII_KEY_PATTERN = /phone|email|nric|name|token|jwt|address|otp|password/i;
 
+// Reward-claim bearer tokens ride in URLs (`/api/reward-claim/:token`,
+// consumer `/r/:token`) — mask the path segment anywhere a URL is reported.
+// Mirrors backend/src/utils/redactTokens.js (frontend cannot import it).
+const TOKEN_PATH_RE = /(\/(?:api\/reward-claim|r)\/)[^/?#\s]+/gi;
+
+export function maskTokenUrl(url) {
+  if (typeof url !== 'string' || url.length === 0) return url;
+  return url.replace(TOKEN_PATH_RE, '$1[token]');
+}
+
 export function scrubObject(input) {
   if (input == null || typeof input !== 'object') return input;
   if (Array.isArray(input)) return input.map(scrubObject);
@@ -28,6 +38,8 @@ export function scrubEvent(event) {
   if (event.tags) event.tags = scrubObject(event.tags);
   if (event.contexts) event.contexts = scrubObject(event.contexts);
   if (event.request?.data) event.request.data = scrubObject(event.request.data);
+  // A token inside a `url` VALUE slips past the key-name matcher above.
+  if (typeof event.request?.url === 'string') event.request.url = maskTokenUrl(event.request.url);
   // Strip user PII — only id is allowed.
   if (event.user) event.user = { id: event.user.id };
   return event;
@@ -35,6 +47,10 @@ export function scrubEvent(event) {
 
 export function scrubBreadcrumb(breadcrumb) {
   if (!breadcrumb) return breadcrumb;
-  if (breadcrumb.data) breadcrumb.data = scrubObject(breadcrumb.data);
+  if (breadcrumb.data) {
+    breadcrumb.data = scrubObject(breadcrumb.data);
+    if (typeof breadcrumb.data.url === 'string') breadcrumb.data.url = maskTokenUrl(breadcrumb.data.url);
+  }
+  if (typeof breadcrumb.message === 'string') breadcrumb.message = maskTokenUrl(breadcrumb.message);
   return breadcrumb;
 }

--- a/src/pages/redeemops/RedemptionsPage.jsx
+++ b/src/pages/redeemops/RedemptionsPage.jsx
@@ -3,21 +3,46 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { redeemOpsApi } from '@/api/redeemOps';
 import { useAuthStore } from '@/stores/authStore';
+import { hasCapability } from '@/lib/redeemOpsPermissions';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '@/components/ui/table';
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import ScanLine from 'lucide-react/icons/scan-line';
 import { RoMobileCard, RoPageHeader, RoTag, prettyEnum } from '@/components/redeemops/ui';
 
+/** Per-row delivery truth from the receipts the backend now records. */
+function deliveryStatus(e) {
+  const em = e.delivery?.email;
+  if (em) {
+    const noun = em.kind === 'voucher' ? 'Voucher' : 'Pass';
+    if (em.ok) {
+      const at = new Date(em.at).toLocaleString('en-SG', {
+        day: 'numeric', month: 'short', hour: 'numeric', minute: '2-digit',
+      });
+      return { text: `${noun} emailed · ${at}`, tone: 'ok' };
+    }
+    return { text: `${noun} email failed — resend or share a link`, tone: 'warn' };
+  }
+  if (e.emailDeliverable === false) return { text: 'Never emailed — share a link instead', tone: 'warn' };
+  if (['eligible', 'issued'].includes(e.status)) return { text: 'Not delivered yet', tone: 'muted' };
+  return null;
+}
+
 export default function RedemptionsPage() {
   const queryClient = useQueryClient();
   const user = useAuthStore((s) => s.user);
   const isAdmin = user?.role === 'admin';
+  const canIssueManual = hasCapability(user, 'entitlements.issue_manual');
   const [token, setToken] = useState('');
   const [verified, setVerified] = useState(null);
+  // { entitlement, mode: 'email'|'link', phase: 'confirm'|'result', result }
+  const [shareDialog, setShareDialog] = useState(null);
 
   const historyQuery = useQuery({
     queryKey: ['redeem-ops', 'redemptions'],
@@ -32,10 +57,32 @@ export default function RedemptionsPage() {
   const unlockMutation = useMutation({
     mutationFn: (prospectId) => redeemOpsApi.unlockEntitlement({ prospectId }),
     onSuccess: (data) => {
-      toast.success(data?.already ? 'Already unlocked' : 'Voucher unlocked — email with QR sent to the customer');
+      // Truthful toast: only claim an email went out when one was queued.
+      toast.success(
+        data?.already
+          ? 'Already unlocked'
+          : data?.emailQueued
+            ? 'Voucher unlocked — email with QR sent to the customer'
+            : 'Voucher unlocked — no email on file; use Copy link to share the voucher'
+      );
       queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'entitlements'] });
     },
     onError: (err) => toast.error('Unlock failed', { description: err.message }),
+  });
+
+  const resendMutation = useMutation({
+    mutationFn: ({ id, channel }) => redeemOpsApi.resendEntitlementPass(id, { channel }),
+    onSuccess: (res, vars) => {
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'entitlements'] });
+      if (vars.channel === 'email') {
+        toast.success(res?.message || 'New pass emailed');
+        setShareDialog(null);
+      } else {
+        // Show the one-time link bundle — it is not retrievable later.
+        setShareDialog((d) => (d ? { ...d, phase: 'result', result: res?.data } : d));
+      }
+    },
+    onError: (err) => toast.error('Could not re-mint', { description: err.message }),
   });
 
   const verifyMutation = useMutation({
@@ -58,6 +105,17 @@ export default function RedemptionsPage() {
   });
 
   const redemptions = historyQuery.data?.redemptions || [];
+
+  const copyText = async (text, label) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.success(`${label} copied`);
+    } catch {
+      toast.error('Copy failed — select the text and copy manually');
+    }
+  };
+
+  const dialogIsVoucher = shareDialog?.entitlement?.status === 'issued';
 
   return (
     <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-5">
@@ -126,7 +184,8 @@ export default function RedemptionsPage() {
         <CardHeader>
           <CardTitle className="text-base">Reservations &amp; vouchers</CardTitle>
           <CardDescription>
-            Every captured lead's reward, from locked reservation to redeemed voucher.
+            Every captured lead's reward, from locked reservation to redeemed voucher — with
+            whether the customer actually received it.
             {isAdmin ? ' As admin you can unlock a reservation manually (audited) — normally the assigned consultant does this at the meeting.' : ''}
           </CardDescription>
         </CardHeader>
@@ -138,34 +197,74 @@ export default function RedemptionsPage() {
             onChange={(e) => setResSearch(e.target.value)}
           />
           <div className="space-y-0">
-            {(entitlementsQuery.data?.entitlements || []).map((e) => (
-              <div key={e.id} className="flex items-center gap-3 py-2.5 border-t border-border first:border-t-0">
-                <div className="min-w-0 flex-1">
-                  <p className="text-sm font-semibold m-0 truncate">
-                    {[e.prospect?.firstName, e.prospect?.lastName].filter(Boolean).join(' ') || 'Customer'}
-                    <span className="font-normal" style={{ color: 'var(--ro-text-3)' }}>
-                      {e.prospect?.phone ? ` · ${e.prospect.phone}` : ''}
+            {(entitlementsQuery.data?.entitlements || []).map((e) => {
+              const delivery = deliveryStatus(e);
+              const canShare = canIssueManual && ['eligible', 'issued'].includes(e.status);
+              const unlockButton = isAdmin && e.status === 'eligible' && e.prospect?.id ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={unlockMutation.isPending}
+                  onClick={() => unlockMutation.mutate(e.prospect.id)}
+                >
+                  Unlock
+                </Button>
+              ) : null;
+              return (
+                <div key={e.id} className="flex flex-wrap items-center gap-x-3 gap-y-1.5 py-2.5 border-t border-border first:border-t-0">
+                  <div className="min-w-0 flex-1 basis-52">
+                    <p className="text-sm font-semibold m-0 truncate">
+                      {[e.prospect?.firstName, e.prospect?.lastName].filter(Boolean).join(' ') || 'Customer'}
+                      <span className="font-normal" style={{ color: 'var(--ro-text-3)' }}>
+                        {e.prospect?.phone ? ` · ${e.prospect.phone}` : ''}
+                      </span>
+                    </p>
+                    <p className="text-xs m-0 truncate" style={{ color: 'var(--ro-text-2)' }}>
+                      {e.rewardOffer?.title || '—'}
+                      {e.activation?.campaignNameSnapshot ? ` · ${e.activation.campaignNameSnapshot}` : ''}
+                      {e.tokenHint ? ` · code …${e.tokenHint}` : ''}
+                    </p>
+                    {delivery && (
+                      <p
+                        className="text-[11px] m-0 truncate"
+                        style={{ color: delivery.tone === 'warn' ? '#B45309' : 'var(--ro-text-3)' }}
+                      >
+                        {delivery.tone === 'warn' ? '⚠ ' : ''}{delivery.text}
+                      </p>
+                    )}
+                  </div>
+                  <span className="flex items-center gap-1.5 flex-none">
+                    {e.emailDeliverable === false && ['eligible', 'issued'].includes(e.status) && (
+                      <RoTag tone="medium" size="sm">No email</RoTag>
+                    )}
+                    <RoTag tone={e.status} size="sm">{prettyEnum(e.status)}</RoTag>
+                  </span>
+                  {canShare ? (
+                    <span className="flex items-center gap-1.5 flex-none">
+                      {e.emailDeliverable !== false && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          disabled={resendMutation.isPending}
+                          onClick={() => setShareDialog({ entitlement: e, mode: 'email', phase: 'confirm' })}
+                        >
+                          {e.status === 'issued' ? 'Resend voucher' : 'Resend pass'}
+                        </Button>
+                      )}
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={resendMutation.isPending}
+                        onClick={() => setShareDialog({ entitlement: e, mode: 'link', phase: 'confirm' })}
+                      >
+                        Copy link
+                      </Button>
+                      {unlockButton}
                     </span>
-                  </p>
-                  <p className="text-xs m-0 truncate" style={{ color: 'var(--ro-text-2)' }}>
-                    {e.rewardOffer?.title || '—'}
-                    {e.activation?.campaignNameSnapshot ? ` · ${e.activation.campaignNameSnapshot}` : ''}
-                    {e.tokenHint ? ` · code …${e.tokenHint}` : ''}
-                  </p>
+                  ) : unlockButton}
                 </div>
-                <RoTag tone={e.status} size="sm">{prettyEnum(e.status)}</RoTag>
-                {isAdmin && e.status === 'eligible' && e.prospect?.id && (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    disabled={unlockMutation.isPending}
-                    onClick={() => unlockMutation.mutate(e.prospect.id)}
-                  >
-                    Unlock
-                  </Button>
-                )}
-              </div>
-            ))}
+              );
+            })}
             {!entitlementsQuery.isLoading && (entitlementsQuery.data?.entitlements || []).length === 0 && (
               <p className="text-sm text-center py-6 m-0" style={{ color: 'var(--ro-text-2)' }}>
                 No reservations yet — they appear when customers sign up on an active activation's campaign.
@@ -240,6 +339,70 @@ export default function RedemptionsPage() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Resend / share — explicit confirm BEFORE rotating (opening this dialog
+          must never kill the customer's existing QR by itself). */}
+      <Dialog open={!!shareDialog} onOpenChange={(open) => { if (!open) setShareDialog(null); }}>
+        <DialogContent>
+          {shareDialog?.phase === 'confirm' && (
+            <>
+              <DialogHeader>
+                <DialogTitle>
+                  {shareDialog.mode === 'email'
+                    ? (dialogIsVoucher ? 'Resend voucher email?' : 'Resend pass email?')
+                    : 'Create a new share link?'}
+                </DialogTitle>
+                <DialogDescription>
+                  This mints a fresh QR/link for{' '}
+                  {[shareDialog.entitlement?.prospect?.firstName, shareDialog.entitlement?.prospect?.lastName]
+                    .filter(Boolean).join(' ') || 'the customer'}
+                  {' — the previous '}
+                  {dialogIsVoucher ? 'voucher code/QR' : 'pass QR/link'}
+                  {' stops working immediately.'}
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button variant="outline" onClick={() => setShareDialog(null)}>Cancel</Button>
+                <Button
+                  disabled={resendMutation.isPending}
+                  onClick={() => resendMutation.mutate({ id: shareDialog.entitlement.id, channel: shareDialog.mode })}
+                >
+                  {resendMutation.isPending
+                    ? 'Working…'
+                    : shareDialog.mode === 'email' ? 'Resend email' : 'Create new link'}
+                </Button>
+              </DialogFooter>
+            </>
+          )}
+          {shareDialog?.phase === 'result' && shareDialog.result && (
+            <>
+              <DialogHeader>
+                <DialogTitle>New link ready — shown once</DialogTitle>
+                <DialogDescription>
+                  The previous {dialogIsVoucher ? 'voucher code/QR' : 'pass QR/link'} no longer works.
+                  Share this with the customer now; it cannot be retrieved again (only re-minted).
+                </DialogDescription>
+              </DialogHeader>
+              <p className="font-mono text-xs break-all rounded-md border border-border p-2.5 m-0 select-all">
+                {shareDialog.result.link}
+              </p>
+              <DialogFooter className="flex-wrap gap-2">
+                <Button variant="outline" onClick={() => copyText(shareDialog.result.link, 'Link')}>
+                  Copy link
+                </Button>
+                <Button variant="outline" onClick={() => copyText(shareDialog.result.waMessage, 'Message')}>
+                  Copy message
+                </Button>
+                {shareDialog.result.waUrl && (
+                  <Button asChild>
+                    <a href={shareDialog.result.waUrl} target="_blank" rel="noreferrer">Open in WhatsApp</a>
+                  </Button>
+                )}
+              </DialogFooter>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/pages/redeemops/__tests__/RedemptionsPage.test.jsx
+++ b/src/pages/redeemops/__tests__/RedemptionsPage.test.jsx
@@ -1,0 +1,145 @@
+/**
+ * RedemptionsPage — delivery-truth UI (trial-reward-funnel PR A):
+ * 1. rows show the delivery receipt + a No-email badge, and hide "Resend"
+ *    where an email send is a guaranteed failure;
+ * 2. rotating a credential is confirm-gated — opening the dialog fires nothing;
+ * 3. the link channel surfaces the one-time bundle incl. the wa.me deep link;
+ * 4. the unlock toast never claims "email sent" when none was queued;
+ * 5. staff without entitlements.issue_manual get no resend/share actions.
+ * redeemOpsApi is fully mocked — no network.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+const api = vi.hoisted(() => ({
+  listRedemptions: vi.fn(),
+  listEntitlements: vi.fn(),
+  unlockEntitlement: vi.fn(),
+  resendEntitlementPass: vi.fn(),
+  verifyVoucher: vi.fn(),
+  completeRedemption: vi.fn(),
+}));
+vi.mock('@/api/redeemOps', () => ({ redeemOpsApi: api }));
+
+const toastMock = vi.hoisted(() => {
+  const t = vi.fn();
+  t.success = vi.fn();
+  t.error = vi.fn();
+  return t;
+});
+vi.mock('sonner', () => ({ toast: toastMock }));
+
+const authState = vi.hoisted(() => ({ user: { id: 'u1', role: 'admin' } }));
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: (sel) => sel({ user: authState.user }),
+}));
+
+import RedemptionsPage from '../RedemptionsPage';
+
+const rowBase = {
+  rewardOffer: { title: 'Free Trial Session' },
+  activation: { campaignNameSnapshot: 'Camp A' },
+};
+const deliverableRow = {
+  id: 'e1', status: 'eligible', tokenHint: null,
+  prospect: { id: 'p1', firstName: 'Sarah', lastName: 'Tan', phone: '••••1234' },
+  emailDeliverable: true,
+  delivery: { email: { kind: 'pass', at: '2026-07-16T06:03:00.000Z', ok: true } },
+  ...rowBase,
+};
+const noEmailRow = {
+  id: 'e2', status: 'eligible', tokenHint: null,
+  prospect: { id: 'p2', firstName: 'Retell', lastName: 'Lead', phone: '••••8800' },
+  emailDeliverable: false,
+  delivery: { email: null },
+  ...rowBase,
+};
+
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter><RedemptionsPage /></MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authState.user = { id: 'u1', role: 'admin' };
+  api.listRedemptions.mockResolvedValue({ redemptions: [] });
+  api.listEntitlements.mockResolvedValue({
+    entitlements: [deliverableRow, noEmailRow],
+    pagination: { page: 1, limit: 15, total: 2, totalPages: 1 },
+  });
+});
+
+describe('RedemptionsPage delivery truth', () => {
+  it('shows receipts + No-email badge, and hides Resend where email cannot work', async () => {
+    renderPage();
+    expect(await screen.findByText(/Pass emailed ·/)).toBeInTheDocument();
+    expect(screen.getByText('No email')).toBeInTheDocument();
+    expect(screen.getByText(/Never emailed — share a link instead/)).toBeInTheDocument();
+    // Only Sarah's row offers an email resend; both rows offer Copy link.
+    expect(screen.getAllByRole('button', { name: 'Resend pass' })).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: 'Copy link' })).toHaveLength(2);
+  });
+
+  it('rotation is confirm-gated: opening the dialog fires nothing until confirmed', async () => {
+    api.resendEntitlementPass.mockResolvedValue({
+      message: 'New reservation pass emailed — the previous pass QR/link no longer works.',
+      data: { kind: 'pass', channel: 'email', emailQueued: true, entitlement: {} },
+    });
+    renderPage();
+    await userEvent.click((await screen.findAllByRole('button', { name: 'Resend pass' }))[0]);
+    expect(api.resendEntitlementPass).not.toHaveBeenCalled();
+    expect(screen.getByText(/stops working immediately/)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Resend email' }));
+    await waitFor(() => expect(api.resendEntitlementPass).toHaveBeenCalledWith('e1', { channel: 'email' }));
+    expect(toastMock.success).toHaveBeenCalledWith(expect.stringContaining('no longer works'));
+  });
+
+  it('link channel shows the one-time bundle with the WhatsApp deep link', async () => {
+    api.resendEntitlementPass.mockResolvedValue({
+      message: 'New reservation pass link created…',
+      data: {
+        kind: 'pass', channel: 'link', emailQueued: false, entitlement: {},
+        link: 'https://redeem.sg/r/new-token-abc',
+        waMessage: 'Hi Sarah! 🎁 Your Free Trial Session…',
+        waUrl: 'https://wa.me/6591234567?text=Hi%20Sarah',
+      },
+    });
+    renderPage();
+    // The no-email row still gets Copy link — use it (index 1).
+    await userEvent.click((await screen.findAllByRole('button', { name: 'Copy link' }))[1]);
+    await userEvent.click(screen.getByRole('button', { name: 'Create new link' }));
+    expect(await screen.findByText('https://redeem.sg/r/new-token-abc')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open in WhatsApp' }))
+      .toHaveAttribute('href', expect.stringContaining('wa.me/6591234567'));
+    expect(api.resendEntitlementPass).toHaveBeenCalledWith('e2', { channel: 'link' });
+  });
+
+  it('unlock toast is truthful when no email was queued', async () => {
+    api.unlockEntitlement.mockResolvedValue({ already: false, emailQueued: false, entitlement: {} });
+    renderPage();
+    const unlocks = await screen.findAllByRole('button', { name: 'Unlock' });
+    await userEvent.click(unlocks[0]);
+    await waitFor(() =>
+      expect(toastMock.success).toHaveBeenCalledWith(expect.stringContaining('no email on file')));
+  });
+
+  it('staff without entitlements.issue_manual see no resend/share actions', async () => {
+    authState.user = { id: 'u2', role: 'redeem_ops', redeemOpsRole: 'bdm' };
+    renderPage();
+    expect(await screen.findAllByText(/Free Trial Session/)).toHaveLength(2);
+    expect(screen.queryByRole('button', { name: /Resend/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Copy link' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Unlock' })).toBeNull(); // not admin either
+  });
+});


### PR DESCRIPTION
## What this fixes

PR A of `docs/plans/trial-reward-funnel-hardening-prompt.md` (plan Codex-reviewed 2026-07-16, all findings verified + folded in). The 2026-07-16 audit found the funnel's step-8 promise was false in production: **no voucher email has ever been sent on unlock**, and sweep-rescued signups were permanently undeliverable.

### Delivery is now the service's job (defects 1 + 2)
- `entitlementWiring.makeWiredEntitlementService()` — the one place the delivering service is assembled. All three unlock surfaces (external HMAC, Lyfe HMAC, ops console) + both bootstrap instances use it; previously only bootstrap's capture-hook instance had `notifyUnlock` injected.
- `issueForProspect`/`unlockEntitlement` deliver post-commit themselves (reservation pass or voucher per policy), so hook-, sweep- and manual-issued entitlements all send. Every attempt writes a `notified`/`notify_failed` receipt event (channel-scoped, ready for PR E WhatsApp).
- **Delivery recovery sweep** (Codex blocker): rows with no successful receipt get an atomic re-mint + retry every 15 min (max 3 attempts) — a crash between commit and send no longer strands the customer forever.

### Resend / share (ops escape hatch)
- `POST /api/redeem-ops/entitlements/:id/resend-pass` `{channel: 'email'|'link'}`, capability `entitlements.issue_manual`, audited.
- Re-mint is an **atomic conditional transition** (mirrors unlock/redeem): races with unlock/redemption/expiry lose with typed 409s. 60s per-entitlement cooldown (429).
- `link` channel returns the campaign-branded `/r/` url + WhatsApp-ready message + `wa.me` deep link **once** (`Cache-Control: no-store`) — the only delivery path for no-email Retell leads.
- `issued` resend rotates only the voucher; the post-unlock presentation link deliberately survives (step-9 design, test-pinned).

### Truthful messaging + console
- `emailQueued` = a fresh email attempt was scheduled by THIS call (false on replay / no-email / unwired). Lyfe route message + ops toast stop claiming emails that never went out.
- `issueManual` pins the **requested** activation (previously re-resolved by campaign — could email a different reward than the audit row claimed).
- RedemptionsPage: per-row delivery receipts ("Pass emailed · …" / "email failed" / "Never emailed"), No-email badge, confirm-gated Resend/Copy-link (rotating a live credential requires explicit confirm), open-in-WhatsApp.

### Token redaction (pre-existing exposure, Codex blocker)
`/api/reward-claim/:token` + `/r/:token` are live bearer credentials and were landing raw in pino-http access logs, errorHandler logs, Sentry `request.url`, and the frontend client's console errors. One shared mask (`redactTokens.js`, frontend mirror in `sentryScrub.js`) applied at all four layers. Mailer logs also stop leaking recipients/body previews.

## Tests
- **`redeemOpsFulfilmentDelivery.test.js`** (23 tests, end-to-end through the real app, mailer mocked): delivery on all three unlock surfaces with genuinely-signed HMACs, replay/no-email truthfulness, sweep-issue delivery, recovery sweep (re-mint, cap, skip rules), resend races/cooldown/expiry/capability, link bundle, manual-issue pinning, receipts + PII stripping in the list API.
- **`tokenRedaction.test.js`** (8): mask unit + Sentry + errorHandler layers.
- **`RedemptionsPage.test.jsx`** (5, first page vitest): gating, confirm-before-rotate, link bundle, truthful toast.
- `entitlementUnlockVia.test.js` re-mocked onto the wiring module (the old `entitlementService` mock can't satisfy the new import chain at ESM link time).
- Targeted regression run: 15/16 suites green; the one failure is `redeemOpsRewards` "seeded on PARTNERED transition" — the **documented pre-existing** failure PR D fixes. Frontend: 1191/1192 (one pre-existing `PublicPreview` failure, verified identical on clean main).

## ⚠ Live behavior change on merge
`REDEEM_OPS_ENABLED` + `REDEEM_OPS_ENTITLEMENTS_ENABLED` are ON in prod — merging starts sending real reservation/voucher emails. That is the intended outcome of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MxmXMaNdrvqrQgZrLpvUb