### PR TITLE
feat(redeem-ops): one live reward per phone per activation (trial-reward PR B)

### DIFF
--- a/backend/src/database/migrations/075-entitlement-phone-dedupe.js
+++ b/backend/src/database/migrations/075-entitlement-phone-dedupe.js
@@ -1,0 +1,40 @@
+/**
+ * 075 — Anti-farming phone dedupe (trial-reward hardening PR B).
+ *
+ * One LIVE reward per phone per activation: `phoneKey` is the digits-only
+ * holder phone stamped at issuance, and the partial unique covers only
+ * eligible/issued/redeemed rows — an expired or cancelled reward frees the
+ * slot for that person. Without this, one human could re-submit the signup
+ * form inside the 10-min OTP window and drain an activation's allocation
+ * (N prospect rows → N reservations).
+ *
+ * Numbering note: 074 is deliberately absent until PR D renames
+ * 066-cadence-draft-visibility → 074. The migration runner tracks by
+ * FILENAME (runMigrations.js), so out-of-numeric-order execution is fine —
+ * do not "fix" the gap.
+ *
+ * No backfill: reward_entitlements is empty in prod at ship time.
+ */
+export async function up(queryInterface, Sequelize) {
+  const table = await queryInterface.describeTable('reward_entitlements');
+  if (!table.phoneKey) {
+    await queryInterface.addColumn('reward_entitlements', 'phoneKey', {
+      type: Sequelize.STRING(20),
+      allowNull: true,
+      comment: 'Digits-only holder phone at issuance — anti-farming dedupe key (one live reward per phone per activation)',
+    });
+  }
+  await queryInterface.sequelize.query(
+    `CREATE UNIQUE INDEX IF NOT EXISTS uq_re_activation_phone
+       ON reward_entitlements ("activationId", "phoneKey")
+       WHERE "phoneKey" IS NOT NULL AND status IN ('eligible','issued','redeemed')`
+  );
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query('DROP INDEX IF EXISTS uq_re_activation_phone');
+  const table = await queryInterface.describeTable('reward_entitlements');
+  if (table.phoneKey) {
+    await queryInterface.removeColumn('reward_entitlements', 'phoneKey');
+  }
+}

--- a/backend/src/models/RewardEntitlement.js
+++ b/backend/src/models/RewardEntitlement.js
@@ -42,6 +42,11 @@ const RewardEntitlement = sequelize.define('RewardEntitlement', {
   tokenHash: { type: DataTypes.STRING(64), allowNull: true, comment: 'SHA-256 of the redemption voucher token — minted at unlock' },
   tokenHint: { type: DataTypes.STRING(8), allowNull: true, comment: 'Last 4 of the voucher code, for support' },
   issuedVia: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'hook', comment: 'hook|sweep|manual' },
+  phoneKey: {
+    type: DataTypes.STRING(20),
+    allowNull: true,
+    comment: 'Digits-only holder phone at issuance — anti-farming dedupe key (one live reward per phone per activation)'
+  },
   createdBy: { type: DataTypes.UUID, allowNull: true }
 }, {
   tableName: 'reward_entitlements',
@@ -49,6 +54,15 @@ const RewardEntitlement = sequelize.define('RewardEntitlement', {
     // Idempotency anchor for hook+sweep issuance — partial because deleted
     // prospects SET-NULL and Postgres treats NULLs as distinct (ERD.md §3.16)
     { unique: true, fields: ['activationId', 'prospectId'], name: 'uq_re_activation_prospect', where: { prospectId: { [Op.ne]: null } } },
+    // Anti-farming (migration 075): one LIVE reward per phone per activation —
+    // expired/cancelled rows leave the partial set and free the slot. Mirrored
+    // here because test mode builds schema from models via sync({force:true}).
+    {
+      unique: true,
+      fields: ['activationId', 'phoneKey'],
+      name: 'uq_re_activation_phone',
+      where: { phoneKey: { [Op.ne]: null }, status: { [Op.in]: ['eligible', 'issued', 'redeemed'] } }
+    },
     { unique: true, fields: ['presentationTokenHash'], name: 'uq_re_presentation_token' },
     { unique: true, fields: ['tokenHash'], name: 'uq_re_voucher_token', where: { tokenHash: { [Op.ne]: null } } },
     { fields: ['activationId', 'status'], name: 'idx_re_activation_status' },

--- a/backend/src/services/redeemOps/entitlementService.js
+++ b/backend/src/services/redeemOps/entitlementService.js
@@ -13,6 +13,18 @@ import { canEmailProspect, makeFulfilmentNotify } from './fulfilmentNotify.js';
 const DEFAULT_RESERVATION_DAYS = 30;
 const DEFAULT_REDEMPTION_DAYS = 90;
 const RESEND_COOLDOWN_MS = 60 * 1000;
+// Statuses that hold the per-phone slot (matches uq_re_activation_phone's
+// partial WHERE) — expired/cancelled rows free it.
+const LIVE_PHONE_STATUSES = ['eligible', 'issued', 'redeemed'];
+
+/**
+ * Anti-farming dedupe key: digits-only phone (`+65 9123 4567` → `6591234567`).
+ * Null for missing/garbage values so junk can never occupy a slot.
+ */
+export function phoneKeyOf(phone) {
+  const digits = String(phone || '').replace(/\D/g, '');
+  return digits.length >= 8 ? digits : null;
+}
 
 // In-flight fire-and-forget deliveries (all service instances share this).
 // flushDeliveries() lets tests — and anything else that needs a barrier —
@@ -152,6 +164,22 @@ export function makeEntitlementService(overrides = {}) {
       });
       if (existing) return { entitlement: existing, reason: 'duplicate' };
 
+      // Anti-farming (migration 075): one LIVE reward per phone per activation.
+      // Hook/sweep issuance REQUIRES a phone key — a null key would bypass the
+      // dedupe entirely (OTP-verified leads always have one; this guards the
+      // theoretical hole). Manual issue without a phone stays allowed (audited
+      // escape hatch; NULL keys never collide). The pre-check is UX — the
+      // partial unique index is the authoritative guard (see the catch below).
+      const phoneKey = phoneKeyOf(prospect.phone);
+      if (!phoneKey && via !== 'manual') return { entitlement: null, reason: 'no_phone' };
+      if (phoneKey) {
+        const livePhone = await d.RewardEntitlement.findOne({
+          where: { activationId: activation.id, phoneKey, status: { [Op.in]: LIVE_PHONE_STATUSES } },
+          order: [['createdAt', 'DESC']],
+        });
+        if (livePhone) return { entitlement: livePhone, reason: 'duplicate_phone' };
+      }
+
       const offer = activation.rewardOffer;
       const onCapture = activation.unlockPolicy === 'on_capture';
       const reservationDays = offer.claimExpiryDays || DEFAULT_RESERVATION_DAYS;
@@ -190,6 +218,7 @@ export function makeEntitlementService(overrides = {}) {
             tokenHash: voucher ? voucher.hash : null,
             tokenHint: voucher ? tokenHintOf(voucher.raw) : null,
             issuedVia: via,
+            phoneKey,
           },
           { transaction: t }
         );
@@ -222,6 +251,19 @@ export function makeEntitlementService(overrides = {}) {
     } catch (err) {
       if (err?._soft) return { entitlement: null, reason: err.message };
       if (err?.name === 'SequelizeUniqueConstraintError') {
+        // Two partial uniques can fire: the (activationId, prospectId)
+        // idempotency anchor → 'duplicate', or the (activationId, phoneKey)
+        // anti-farming guard → 'duplicate_phone' (a concurrent same-phone
+        // signup lost the race). The transaction rolled back, so counters are
+        // intact either way.
+        const constraint = err?.parent?.constraint || err?.original?.constraint || '';
+        if (constraint === 'uq_re_activation_phone') {
+          const winner = await d.RewardEntitlement.findOne({
+            where: { phoneKey: phoneKeyOf(prospect.phone), status: { [Op.in]: LIVE_PHONE_STATUSES } },
+            order: [['createdAt', 'DESC']],
+          });
+          return { entitlement: winner, reason: 'duplicate_phone' };
+        }
         const existing = await d.RewardEntitlement.findOne({
           where: { prospectId: prospect.id },
           order: [['createdAt', 'DESC']],
@@ -328,6 +370,11 @@ export function makeEntitlementService(overrides = {}) {
       { via: 'manual', activationId }
     );
     if (!result.entitlement) throw new AppError(`Cannot issue: ${result.reason}`, 409);
+    if (result.reason === 'duplicate_phone') {
+      // The returned entitlement belongs to ANOTHER prospect with the same
+      // phone — never report that as a successful manual issue.
+      throw new AppError('Cannot issue: duplicate_phone — this phone already holds a live reward for this activation', 409);
+    }
     await d.audit.recordAuditEvent({
       actorUser: user, action: 'entitlement.issued_manual', entityType: 'reward_entitlement',
       entityId: result.entitlement.id, after: { activationId, prospectId }, requestId,

--- a/backend/test/redeemOpsFulfilmentDelivery.test.js
+++ b/backend/test/redeemOpsFulfilmentDelivery.test.js
@@ -464,7 +464,16 @@ describe('resend / share', () => {
   });
 
   test('link channel without a phone: waUrl null + typed reason', async () => {
-    const { issue } = await issueBackdated({ phone: null });
+    // Since PR B, hook/sweep issuance REQUIRES a phone (no_phone guard), so a
+    // phoneless entitlement is only reachable via MANUAL issue — the audited
+    // escape hatch.
+    const prospect = await makeProspect({ phone: null });
+    const issue = await svc.issueManual(
+      { activationId: activationA.id, prospectId: prospect.id }, admin.user
+    );
+    await settle();
+    await backdateHistory(issue.entitlement.id, 15);
+    sendEmailMock.mockClear();
     const res = await request(app)
       .post(`/api/redeem-ops/entitlements/${issue.entitlement.id}/resend-pass`)
       .set(auth(redemptionOps.token))

--- a/backend/test/redeemOpsPhoneDedupe.test.js
+++ b/backend/test/redeemOpsPhoneDedupe.test.js
@@ -1,0 +1,215 @@
+/**
+ * PR B — anti-farming: one LIVE reward per phone per activation
+ * (docs/plans/trial-reward-funnel-hardening-prompt.md, migration 075).
+ *
+ * The hole being closed: the OTP marker lives ~10 min, so one human could
+ * re-submit the signup form N times → N prospect rows → N entitlements, each
+ * burning allocation for the whole reservation window. `phoneKey` +
+ * uq_re_activation_phone (partial: eligible/issued/redeemed) make the DB the
+ * authoritative guard; expired/cancelled rows free the slot.
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+process.env.REDEEM_OPS_ENTITLEMENTS_ENABLED = 'true';
+
+import { getApp, closeDb, createTestUser, createTestCampaign } from './helpers.js';
+import {
+  Prospect, RewardOffer, Activation, RewardEntitlement, PartnerOrganisation,
+} from '../src/models/index.js';
+import { makeEntitlementService, phoneKeyOf } from '../src/services/redeemOps/entitlementService.js';
+import { makeRedemptionService } from '../src/services/redeemOps/redemptionService.js';
+
+// Bare service: null notify deps — no emails, pure dedupe mechanics.
+const svc = makeEntitlementService();
+const redemptions = makeRedemptionService();
+
+let admin, agent;
+let partner, offer, campaignA, campaignB, activationA, activationB;
+
+let phoneSeq = 90000000;
+const freshPhone = () => `+65${phoneSeq++}`;
+
+async function makeVerifiedProspect(phone, overrides = {}) {
+  return Prospect.create({
+    firstName: 'Dedupe',
+    lastName: 'Holder',
+    phone,
+    email: `dedupe-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@test.com`,
+    leadSource: 'website',
+    campaignId: campaignA.id,
+    assignedAgentId: agent.user.id,
+    sourceMetadata: { phoneVerifiedAt: new Date().toISOString() },
+    ...overrides,
+  });
+}
+
+beforeAll(async () => {
+  await getApp(); // boots the DB schema (models → sync in test mode)
+  admin = await createTestUser({ role: 'admin' });
+  agent = await createTestUser({ role: 'agent' });
+
+  partner = await PartnerOrganisation.create({
+    tradingName: 'Dedupe Test Studio', normalizedName: 'dedupe test studio', createdBy: admin.user.id,
+  });
+  campaignA = await createTestCampaign(admin.user.id, { name: 'Dedupe Campaign A' });
+  campaignB = await createTestCampaign(admin.user.id, { name: 'Dedupe Campaign B' });
+  offer = await RewardOffer.create({
+    partnerOrganisationId: partner.id, title: 'Free Dedupe Trial',
+    committedQuantity: 200, allocatedQuantity: 150, status: 'active',
+    claimExpiryDays: 30, redemptionExpiryDays: 90, createdBy: admin.user.id,
+  });
+  activationA = await Activation.create({
+    partnerOrganisationId: partner.id, rewardOfferId: offer.id, campaignId: campaignA.id,
+    campaignNameSnapshot: campaignA.name, allocatedQuantity: 60, status: 'active',
+    unlockPolicy: 'agent_unlock', createdBy: admin.user.id,
+  });
+  activationB = await Activation.create({
+    partnerOrganisationId: partner.id, rewardOfferId: offer.id, campaignId: campaignB.id,
+    campaignNameSnapshot: campaignB.name, allocatedQuantity: 60, status: 'active',
+    unlockPolicy: 'agent_unlock', createdBy: admin.user.id,
+  });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+describe('phoneKeyOf', () => {
+  test('normalizes to digits and rejects junk', () => {
+    expect(phoneKeyOf('+6591234567')).toBe('6591234567');
+    expect(phoneKeyOf('+65 9123 4567')).toBe('6591234567');
+    expect(phoneKeyOf(null)).toBeNull();
+    expect(phoneKeyOf('abc')).toBeNull();
+    expect(phoneKeyOf('123')).toBeNull(); // too short to be a phone
+  });
+});
+
+describe('one live reward per phone per activation', () => {
+  test('second signup with the same phone collapses to the FIRST entitlement', async () => {
+    const phone = freshPhone();
+    const p1 = await makeVerifiedProspect(phone);
+    const p2 = await makeVerifiedProspect(phone); // same human, second form submit
+
+    const first = await svc.issueForProspect(p1);
+    expect(first.reason).toBeNull();
+    expect(first.entitlement.phoneKey).toBe(phoneKeyOf(phone));
+
+    const second = await svc.issueForProspect(p2);
+    expect(second.reason).toBe('duplicate_phone');
+    expect(second.entitlement.id).toBe(first.entitlement.id); // points at the winner
+
+    const rows = await RewardEntitlement.findAll({
+      where: { activationId: activationA.id, phoneKey: phoneKeyOf(phone) },
+    });
+    expect(rows).toHaveLength(1);
+  });
+
+  test('CONCURRENT same-phone signups → exactly one entitlement (DB index is the guard)', async () => {
+    const phone = freshPhone();
+    const p1 = await makeVerifiedProspect(phone);
+    const p2 = await makeVerifiedProspect(phone);
+
+    const [a, b] = await Promise.all([
+      svc.issueForProspect(p1),
+      svc.issueForProspect(p2),
+    ]);
+    const fresh = [a, b].filter((r) => r.reason === null);
+    const blocked = [a, b].filter((r) => r.reason === 'duplicate_phone');
+    expect(fresh).toHaveLength(1);
+    expect(blocked).toHaveLength(1);
+
+    const rows = await RewardEntitlement.findAll({
+      where: { activationId: activationA.id, phoneKey: phoneKeyOf(phone) },
+    });
+    expect(rows).toHaveLength(1);
+
+    // Loser's rolled-back transaction must not have leaked counters:
+    // issuedCount reflects exactly the winners.
+    const act = await Activation.findByPk(activationA.id);
+    const live = await RewardEntitlement.count({ where: { activationId: activationA.id } });
+    expect(act.issuedCount).toBe(live);
+  });
+
+  test('an EXPIRED reservation frees the slot for the same phone', async () => {
+    const phone = freshPhone();
+    const p1 = await makeVerifiedProspect(phone);
+    const first = await svc.issueForProspect(p1);
+    expect(first.reason).toBeNull();
+
+    await RewardEntitlement.update(
+      { expiresAt: new Date(Date.now() - 1000) },
+      { where: { id: first.entitlement.id } }
+    );
+    await svc.expireReservations();
+    expect((await RewardEntitlement.findByPk(first.entitlement.id)).status).toBe('expired');
+
+    const p2 = await makeVerifiedProspect(phone);
+    const second = await svc.issueForProspect(p2);
+    expect(second.reason).toBeNull(); // slot freed
+    expect(second.entitlement.id).not.toBe(first.entitlement.id);
+  });
+
+  test('a CANCELLED entitlement frees the slot', async () => {
+    const phone = freshPhone();
+    const p1 = await makeVerifiedProspect(phone);
+    const first = await svc.issueForProspect(p1);
+    await svc.cancelEntitlement(first.entitlement.id, admin.user, 'dedupe test');
+
+    const p2 = await makeVerifiedProspect(phone);
+    const second = await svc.issueForProspect(p2);
+    expect(second.reason).toBeNull();
+  });
+
+  test('a REDEEMED reward still blocks the phone (no farm-after-redeem)', async () => {
+    const phone = freshPhone();
+    const p1 = await makeVerifiedProspect(phone);
+    const first = await svc.issueForProspect(p1);
+    const unlock = await svc.unlockEntitlement({ presentationToken: first.presentationToken }, admin.user, 'manual');
+    await redemptions.complete(unlock.voucherToken, {}, admin.user);
+    expect((await RewardEntitlement.findByPk(first.entitlement.id)).status).toBe('redeemed');
+
+    const p2 = await makeVerifiedProspect(phone);
+    const second = await svc.issueForProspect(p2);
+    expect(second.reason).toBe('duplicate_phone');
+  });
+
+  test('a different activation is unaffected by the same phone', async () => {
+    const phone = freshPhone();
+    const p1 = await makeVerifiedProspect(phone);
+    const onA = await svc.issueForProspect(p1);
+    expect(onA.reason).toBeNull();
+
+    const p2 = await makeVerifiedProspect(phone, { campaignId: campaignB.id });
+    const onB = await svc.issueForProspect(p2);
+    expect(onB.reason).toBeNull();
+    expect(onB.entitlement.activationId).toBe(activationB.id);
+  });
+});
+
+describe('no-phone rules', () => {
+  test('hook/sweep issuance without a phone is refused (dedupe bypass guard)', async () => {
+    const p = await makeVerifiedProspect(null);
+    const r = await svc.issueForProspect(p, { via: 'hook' });
+    expect(r.entitlement).toBeNull();
+    expect(r.reason).toBe('no_phone');
+  });
+
+  test('manual issue without a phone is allowed, and NULL keys never collide', async () => {
+    const p1 = await makeVerifiedProspect(null);
+    const p2 = await makeVerifiedProspect(null);
+    const first = await svc.issueManual({ activationId: activationA.id, prospectId: p1.id }, admin.user);
+    expect(first.entitlement.phoneKey).toBeNull();
+    const second = await svc.issueManual({ activationId: activationA.id, prospectId: p2.id }, admin.user);
+    expect(second.entitlement.phoneKey).toBeNull(); // no unique violation
+  });
+
+  test('manual issue for a phone that already holds a live reward → typed 409', async () => {
+    const phone = freshPhone();
+    const p1 = await makeVerifiedProspect(phone);
+    await svc.issueForProspect(p1);
+
+    const p2 = await makeVerifiedProspect(phone);
+    await expect(
+      svc.issueManual({ activationId: activationA.id, prospectId: p2.id }, admin.user)
+    ).rejects.toMatchObject({ statusCode: 409, message: expect.stringContaining('duplicate_phone') });
+  });
+});


### PR DESCRIPTION
## What this fixes

PR B of `docs/plans/trial-reward-funnel-hardening-prompt.md` (defect 3, P0): nothing dedupes a **human** — the OTP marker lives ~10 minutes, so one person can re-submit the signup form N times → N prospect rows → N entitlements, each burning allocation for the full 30-day reservation window. The prod activation has `allocated=10`; one bored person could drain it in a minute.

## How

- **Migration `075-entitlement-phone-dedupe.js`** — nullable `phoneKey` (digits-only holder phone at issuance) + partial unique `uq_re_activation_phone (activationId, phoneKey) WHERE phoneKey IS NOT NULL AND status IN ('eligible','issued','redeemed')`. Expired/cancelled rows leave the partial set, so the *same person* can get a reward again after a no-show — but never hold two live ones. Index mirrored on the model (test schema comes from `sync({force:true})` — the lucky-draw lesson). No backfill; prod table is empty.
- **`issueForProspect`** stamps `phoneKey`, pre-checks for a friendly typed `duplicate_phone` (UX only — the **DB index is the authoritative guard**), and the unique-error catch distinguishes the two partial uniques by constraint name so a concurrent same-phone race collapses to one row with counters intact (transaction rollback).
- **No-phone rules** (Codex-verified plan note): hook/sweep issuance without a phone → typed `no_phone` (a NULL key would bypass the dedupe entirely; OTP-verified leads always have a phone, so this guards the theoretical hole). Manual issue without a phone stays **allowed** — the audited escape hatch; NULL keys never collide.
- **`issueManual` on a duplicate phone throws the typed 409** — previously my pre-check design would have silently returned *another prospect's* entitlement as a "successful" manual issue.

## ⚠ Migration numbering

**074 is deliberately absent** until PR D renames `066-cadence-draft-visibility` → `074`. The `_migrations` runner tracks by **filename**, so out-of-numeric-order execution is safe — do not "fix" the gap.

## Tests

`redeemOpsPhoneDedupe.test.js` (10): second signup collapses to the winner entitlement; **concurrent** same-phone signups → exactly one row + `issuedCount` matches (rollback proof); expired frees the slot; cancelled frees the slot; **redeemed still blocks** (no farm-after-redeem); different activation unaffected; `phoneKeyOf` normalization; hook `no_phone` refusal; manual no-phone allowed twice (NULLs don't collide); manual duplicate-phone 409.

The PR A delivery suite's no-phone fixture now issues manually (the only legitimate path to a phoneless entitlement post-B). Full regression set green: 137/137 across 8 suites (phone-dedupe, delivery, fulfilment, unlock-via, redaction, prospects, repeatSignup, drawGate). `migrations.test.js` still fails only on the documented pre-existing 066 duplicate (PR D fixes it) — 075 adds no duplicate.

## Live behavior on merge

Flags are ON: repeat signups from the same phone stop earning extra reservations immediately. Lead capture itself is unaffected (rewards are a bonus layer; the form still succeeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MxmXMaNdrvqrQgZrLpvUb