### PR TITLE
feat(redeem-ops): activation liveness gates + linkage guard + skip visibility (trial-reward PR C)

### DIFF
--- a/backend/src/controllers/redeemOps/activationsController.js
+++ b/backend/src/controllers/redeemOps/activationsController.js
@@ -25,7 +25,10 @@ export const getActivation = asyncHandler(async (req, res) => {
   if (activation.campaignId) {
     campaignRef = await campaignProjection.getCampaignReference(activation.campaignId).catch(() => null);
   }
-  res.json({ success: true, data: { activation, campaign: campaignRef } });
+  // A detached/starved funnel must be visible: last-24h skipped-issuance
+  // reasons (never fails the detail read).
+  const issuanceSkips24h = await activationService.getIssuanceSkips24h(req.params.id).catch(() => []);
+  res.json({ success: true, data: { activation, campaign: campaignRef, issuanceSkips24h } });
 });
 
 export const createActivation = asyncHandler(async (req, res) => {

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -257,6 +257,7 @@ export async function bootstrapDatabase() {
             await svc.expireReservations();
             await svc.reconcileMissedLeads();
             await svc.reconcileMissedDeliveries();
+            await svc.purgeIssuanceSkips(); // 30-day retention on the skip log
           } catch (err) {
             logger.warn('[RedeemOps] fulfilment sweep failed (non-fatal)', { error: err?.message });
           }

--- a/backend/src/database/migrations/076-activation-issuance-skips.js
+++ b/backend/src/database/migrations/076-activation-issuance-skips.js
@@ -1,0 +1,32 @@
+/**
+ * 076 — Persisted issuance-skip log (trial-reward hardening PR C).
+ *
+ * A detached or starved funnel must be VISIBLE: every skipped reward issuance
+ * (no active activation, allocation exhausted, offer paused, activation ended,
+ * quarantined, unverified, no phone, duplicate phone) writes one row here, and
+ * the activation detail endpoint reads a last-24h reason breakdown from it.
+ * Codex-verified plan note: this cannot be derived from structured logs — no
+ * log analytics exists. Rows are ephemeral (30-day purge in the fulfilment
+ * sweep); campaignId/activationId are plain UUIDs on purpose — the row must
+ * survive whatever happens to its subjects.
+ */
+export async function up(queryInterface, Sequelize) {
+  const tables = await queryInterface.showAllTables();
+  if (!tables.includes('activation_issuance_skips')) {
+    await queryInterface.createTable('activation_issuance_skips', {
+      id: { type: Sequelize.UUID, primaryKey: true, allowNull: false },
+      campaignId: { type: Sequelize.UUID, allowNull: true },
+      activationId: { type: Sequelize.UUID, allowNull: true },
+      reason: { type: Sequelize.STRING(32), allowNull: false },
+      via: { type: Sequelize.STRING(16), allowNull: true, comment: 'hook|sweep|manual' },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    });
+  }
+  const idx = (sql) => queryInterface.sequelize.query(sql);
+  await idx('CREATE INDEX IF NOT EXISTS idx_ais_activation_created ON activation_issuance_skips ("activationId", "createdAt")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_ais_campaign_created ON activation_issuance_skips ("campaignId", "createdAt")');
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query('DROP TABLE IF EXISTS activation_issuance_skips');
+}

--- a/backend/src/models/ActivationIssuanceSkip.js
+++ b/backend/src/models/ActivationIssuanceSkip.js
@@ -1,0 +1,32 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * One row per SKIPPED reward issuance (migration 076) — the funnel's
+ * "why didn't they get a reward?" ledger. Written fire-and-forget from
+ * entitlementService.issueForProspect (the single issuance choke point, so
+ * hook, sweep and manual skips all land here); read as a last-24h reason
+ * breakdown on the activation detail; purged after 30 days by the fulfilment
+ * sweep. Plain UUID references by design — a skip must survive its subjects.
+ */
+const ActivationIssuanceSkip = sequelize.define('ActivationIssuanceSkip', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  campaignId: { type: DataTypes.UUID, allowNull: true },
+  activationId: { type: DataTypes.UUID, allowNull: true },
+  reason: {
+    type: DataTypes.STRING(32),
+    allowNull: false,
+    comment: 'no_active_activation|activation_not_active|allocation_exhausted|offer_not_active|activation_ended|quarantined|phone_not_verified|no_phone|duplicate_phone'
+  },
+  via: { type: DataTypes.STRING(16), allowNull: true, comment: 'hook|sweep|manual' }
+}, {
+  tableName: 'activation_issuance_skips',
+  timestamps: true,
+  updatedAt: false,
+  indexes: [
+    { fields: ['activationId', 'createdAt'], name: 'idx_ais_activation_created' },
+    { fields: ['campaignId', 'createdAt'], name: 'idx_ais_campaign_created' }
+  ]
+});
+
+export default ActivationIssuanceSkip;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -341,7 +341,7 @@ export const {
   OutreachTask, ProspectingPool, ProspectingPoolMember, RewardOffer,
   RewardTermsVersion, DrawTermsVersion, Draw, DrawEntry, DrawAttempt,
   DrawBoostReview, RewardOfferLocation, RewardInventoryEvent,
-  PartnerOnboardingItem, Activation, RewardEntitlement, Redemption,
+  PartnerOnboardingItem, Activation, ActivationIssuanceSkip, RewardEntitlement, Redemption,
   RedemptionEvent, RedeemOpsCategory, DiscoveryTerritory, DiscoveryDailyUsage,
   DiscoveryRun, DiscoveryCandidate,
   DiscoveryPlaceMemory, OutreachCadence, OutreachCadenceStep,

--- a/backend/src/services/redeemOps/activationService.js
+++ b/backend/src/services/redeemOps/activationService.js
@@ -1,5 +1,6 @@
+import { Op } from 'sequelize';
 import {
-  Activation, RewardOffer, PartnerOrganisation, Campaign, sequelize,
+  Activation, ActivationIssuanceSkip, RewardOffer, PartnerOrganisation, Campaign, sequelize,
 } from '../../models/index.js';
 import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';
@@ -28,7 +29,7 @@ const UNLOCK_POLICIES = ['on_capture', 'agent_unlock'];
  */
 export function makeActivationService(overrides = {}) {
   const d = {
-    Activation, RewardOffer, PartnerOrganisation, Campaign, sequelize, logger,
+    Activation, ActivationIssuanceSkip, RewardOffer, PartnerOrganisation, Campaign, sequelize, logger,
     audit: makeRedeemOpsAuditService(),
     inventory: makeInventoryService(),
     ...overrides,
@@ -50,6 +51,28 @@ export function makeActivationService(overrides = {}) {
     const activation = await d.Activation.findByPk(id, { include: INCLUDES });
     if (!activation) throw new AppError('Activation not found', 404);
     return activation;
+  }
+
+  /**
+   * Last-24h skipped-issuance breakdown (PR C observability). Includes rows
+   * attributed to this activation AND campaign-level `no_active_activation`
+   * rows (no activation existed to attribute — the detached/starved case).
+   */
+  async function getIssuanceSkips24h(id) {
+    const activation = await getActivation(id);
+    const or = [{ activationId: id }];
+    if (activation.campaignId) or.push({ activationId: null, campaignId: activation.campaignId });
+    const rows = await d.ActivationIssuanceSkip.findAll({
+      attributes: ['reason', [d.sequelize.fn('COUNT', d.sequelize.col('id')), 'count']],
+      where: {
+        createdAt: { [Op.gt]: new Date(Date.now() - 24 * 3600 * 1000) },
+        [Op.or]: or,
+      },
+      group: ['reason'],
+      order: [[d.sequelize.literal('count'), 'DESC']],
+      raw: true,
+    });
+    return rows.map((r) => ({ reason: r.reason, count: Number(r.count) }));
   }
 
   async function createActivation(body, user, requestId = null) {
@@ -94,6 +117,17 @@ export function makeActivationService(overrides = {}) {
   /** Link (or unlink with campaignId=null) the canonical MKTR campaign. */
   async function linkCampaign(id, campaignId, user, requestId = null) {
     const activation = await getActivation(id);
+
+    // Linkage guard (PR C, funnel-audit defect 5): unlinking or relinking a
+    // LIVE activation silently stops issuance — the sweep skips null-campaign
+    // activations while the console still says "active". Only non-live
+    // activations may change campaign.
+    if (LIVE_STATUSES.includes(activation.status)) {
+      throw new AppError(
+        `Activation is ${activation.status} — complete or cancel it first before changing its campaign link`,
+        409
+      );
+    }
 
     if (campaignId === null) {
       const before = { campaignId: activation.campaignId };
@@ -219,7 +253,7 @@ export function makeActivationService(overrides = {}) {
   // Marketplace read cache: activation changes alter public offer state
   // (capacity, live window) — bust on every mutation so admin actions show
   // within one request (docs/plans/redeem-marketplace-v2.md Phase 1).
-  const service = { listActivations, getActivation, createActivation, linkCampaign, changeAllocation, setStatus, setRenewal };
+  const service = { listActivations, getActivation, getIssuanceSkips24h, createActivation, linkCampaign, changeAllocation, setStatus, setRenewal };
   for (const k of ['createActivation', 'linkCampaign', 'changeAllocation', 'setStatus', 'setRenewal']) {
     const fn = service[k];
     service[k] = async (...args) => {

--- a/backend/src/services/redeemOps/entitlementService.js
+++ b/backend/src/services/redeemOps/entitlementService.js
@@ -1,7 +1,7 @@
 import { Op } from 'sequelize';
 import {
-  RewardEntitlement, RedemptionEvent, Activation, RewardOffer, PartnerOrganisation,
-  Prospect, User, sequelize,
+  RewardEntitlement, RedemptionEvent, Activation, ActivationIssuanceSkip, RewardOffer,
+  PartnerOrganisation, Prospect, User, sequelize,
 } from '../../models/index.js';
 import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';
@@ -57,8 +57,8 @@ export async function flushDeliveries() {
  */
 export function makeEntitlementService(overrides = {}) {
   const d = {
-    RewardEntitlement, RedemptionEvent, Activation, RewardOffer, PartnerOrganisation,
-    Prospect, User, sequelize, logger,
+    RewardEntitlement, RedemptionEvent, Activation, ActivationIssuanceSkip, RewardOffer,
+    PartnerOrganisation, Prospect, User, sequelize, logger,
     inventory: makeInventoryService(),
     audit: makeRedeemOpsAuditService(),
     notifyUnlock: null, // injected by entitlementWiring (voucher email) — null-safe
@@ -87,6 +87,34 @@ export function makeEntitlementService(overrides = {}) {
 
   function verificationStampOf(prospect) {
     return prospect?.sourceMetadata?.phoneVerifiedAt || null;
+  }
+
+  /**
+   * Persist + log one skipped issuance (migration 076). Awaited by callers —
+   * it's the FAILURE path (one ~1ms INSERT, never the capture hot path) and
+   * awaiting makes the skip ledger deterministic; errors are swallowed so a
+   * broken skip log can never fail issuance handling itself.
+   * `no_active_activation` rows carry only the campaignId (there IS no
+   * activation) — that's the detached-funnel signature the console surfaces.
+   */
+  async function recordSkip({ prospect, activation = null, reason, via }) {
+    const campaignId = activation?.campaignId || prospect?.campaignId || null;
+    const actId = activation?.id || null;
+    d.logger.info('redeem_ops.issuance.skipped', { reason, via, campaignId, activationId: actId });
+    try {
+      await d.ActivationIssuanceSkip.create({ campaignId, activationId: actId, reason, via });
+    } catch (err) {
+      d.logger.warn('redeem_ops.issuance.skip_record_failed', { reason, error: err?.message });
+    }
+  }
+
+  /** Retention for the skip log — called from the fulfilment sweep. */
+  async function purgeIssuanceSkips({ days = 30 } = {}) {
+    const removed = await d.ActivationIssuanceSkip.destroy({
+      where: { createdAt: { [Op.lt]: new Date(Date.now() - days * 24 * 3600 * 1000) } },
+    });
+    if (removed > 0) d.logger.info('redeem_ops.issuance.skips_purged', { removed });
+    return removed;
   }
 
   /**
@@ -139,10 +167,20 @@ export function makeEntitlementService(overrides = {}) {
    * audit row claims (Codex blocker, 2026-07-16).
    */
   async function issueForProspect(prospect, { via = 'hook', activationId = null } = {}) {
+    // Function-scoped so the unique-constraint catch can attribute skips.
+    let resolvedActivation = null;
+    // Skip recording (migration 076): every funnel-relevant refusal writes one
+    // fire-and-forget row + a structured log line — that's what the activation
+    // detail's 24h breakdown reads. 'duplicate' (idempotent replays) and
+    // 'no_campaign' (non-funnel lead) are deliberate noise exclusions.
+    const fail = async (reason, activation = resolvedActivation) => {
+      await recordSkip({ prospect, activation, reason, via });
+      return { entitlement: null, reason };
+    };
     try {
       if (!activationId && !prospect?.campaignId) return { entitlement: null, reason: 'no_campaign' };
-      if (prospect?.quarantinedAt) return { entitlement: null, reason: 'quarantined' };
-      if (!verificationStampOf(prospect)) return { entitlement: null, reason: 'phone_not_verified' };
+      if (prospect?.quarantinedAt) return fail('quarantined');
+      if (!verificationStampOf(prospect)) return fail('phone_not_verified');
 
       let activation;
       if (activationId) {
@@ -150,14 +188,15 @@ export function makeEntitlementService(overrides = {}) {
           where: { id: activationId, status: 'active' },
           include: [{ model: d.RewardOffer, as: 'rewardOffer' }],
         });
-        if (!activation) return { entitlement: null, reason: 'activation_not_active' };
+        if (!activation) return fail('activation_not_active');
       } else {
         activation = await d.Activation.findOne({
           where: { campaignId: prospect.campaignId, status: 'active' },
           include: [{ model: d.RewardOffer, as: 'rewardOffer' }],
         });
-        if (!activation) return { entitlement: null, reason: 'no_active_activation' };
+        if (!activation) return fail('no_active_activation');
       }
+      resolvedActivation = activation;
 
       const existing = await d.RewardEntitlement.findOne({
         where: { activationId: activation.id, prospectId: prospect.id },
@@ -171,16 +210,25 @@ export function makeEntitlementService(overrides = {}) {
       // escape hatch; NULL keys never collide). The pre-check is UX — the
       // partial unique index is the authoritative guard (see the catch below).
       const phoneKey = phoneKeyOf(prospect.phone);
-      if (!phoneKey && via !== 'manual') return { entitlement: null, reason: 'no_phone' };
+      if (!phoneKey && via !== 'manual') return fail('no_phone');
       if (phoneKey) {
         const livePhone = await d.RewardEntitlement.findOne({
           where: { activationId: activation.id, phoneKey, status: { [Op.in]: LIVE_PHONE_STATUSES } },
           order: [['createdAt', 'DESC']],
         });
-        if (livePhone) return { entitlement: livePhone, reason: 'duplicate_phone' };
+        if (livePhone) {
+          await recordSkip({ prospect, activation, reason: 'duplicate_phone', via });
+          return { entitlement: livePhone, reason: 'duplicate_phone' };
+        }
       }
 
       const offer = activation.rewardOffer;
+      // Liveness gates (PR C): a paused/ended offer or an activation past its
+      // endDate must not issue. Pre-checks give the typed reason; the
+      // transaction predicates below stay authoritative under races.
+      if (!offer || offer.status !== 'active') return fail('offer_not_active');
+      if (activation.endDate && new Date(activation.endDate) <= new Date()) return fail('activation_ended');
+
       const onCapture = activation.unlockPolicy === 'on_capture';
       const reservationDays = offer.claimExpiryDays || DEFAULT_RESERVATION_DAYS;
       const redemptionDays = offer.redemptionExpiryDays || DEFAULT_REDEMPTION_DAYS;
@@ -189,11 +237,16 @@ export function makeEntitlementService(overrides = {}) {
       const voucher = onCapture ? mintToken() : null;
 
       const entitlement = await d.sequelize.transaction(async (t) => {
-        // Activation-level guard: issuedCount < allocatedQuantity (single statement)
+        // Activation-level guard: issuedCount < allocatedQuantity + still
+        // active + not past endDate — one conditional statement, race-proof.
+        // A 0-row result surfaces as the generic 'allocation_exhausted' soft
+        // reason: the pre-checks above already classified the common cases;
+        // this only catches ms-window races.
         const [rows] = await d.sequelize.query(
           `UPDATE activations
               SET "issuedCount" = "issuedCount" + 1, "updatedAt" = NOW()
             WHERE id = :id AND "issuedCount" < "allocatedQuantity" AND status = 'active'
+              AND ("endDate" IS NULL OR "endDate" > NOW())
             RETURNING id`,
           { replacements: { id: activation.id }, transaction: t }
         );
@@ -249,7 +302,7 @@ export function makeEntitlementService(overrides = {}) {
         emailQueued,
       };
     } catch (err) {
-      if (err?._soft) return { entitlement: null, reason: err.message };
+      if (err?._soft) return fail(err.message);
       if (err?.name === 'SequelizeUniqueConstraintError') {
         // Two partial uniques can fire: the (activationId, prospectId)
         // idempotency anchor → 'duplicate', or the (activationId, phoneKey)
@@ -297,10 +350,26 @@ export function makeEntitlementService(overrides = {}) {
     if (!entitlement) throw new AppError('Entitlement not found', 404);
 
     if (['issued', 'redeemed'].includes(entitlement.status)) {
+      // Deliberate carve-out: replay stays idempotent even if the activation
+      // has since paused — THAT unlock already happened.
       return { entitlement, already: true, voucherToken: null, emailQueued: false };
     }
     if (entitlement.status !== 'eligible') {
       throw new AppError(`Entitlement is ${entitlement.status}`, 409);
+    }
+
+    // Liveness gate (PR C — the funnel doc promised this; now it's true):
+    // pause is a full brake, completed/cancelled are terminal. Typed 409s
+    // here are UX; the transaction predicate below is authoritative.
+    const activation = await d.Activation.findByPk(entitlement.activationId, { attributes: ['id', 'status'] });
+    if (!activation || activation.status !== 'active') {
+      const st = activation?.status || 'missing';
+      throw new AppError(
+        st === 'paused'
+          ? 'Activation is paused — unlocks are temporarily disabled'
+          : `Activation is ${st} — this reward can no longer be unlocked`,
+        409
+      );
     }
 
     // Assigned-consultant binding (admin override audited via unlockedVia='manual')
@@ -332,12 +401,19 @@ export function makeEntitlementService(overrides = {}) {
             id: entitlement.id,
             status: 'eligible', // conditional transition — replay-safe
             [Op.or]: [{ expiresAt: null }, { expiresAt: { [Op.gt]: new Date() } }],
+            // Activation must STILL be active at commit time — a pause racing
+            // this unlock loses here, not just at the pre-check (TOCTOU).
+            activationId: {
+              [Op.in]: d.sequelize.literal(
+                `(SELECT id FROM activations WHERE id = '${entitlement.activationId}' AND status = 'active')`
+              ),
+            },
           },
           transaction: t,
         }
       );
       if (count === 0) {
-        throw new AppError('Reservation expired or already unlocked', 409);
+        throw new AppError('Reservation expired, already unlocked, or its activation is no longer active', 409);
       }
       await writeEvent(t, {
         entitlementId: entitlement.id, type: 'unlocked',
@@ -723,7 +799,7 @@ export function makeEntitlementService(overrides = {}) {
 
   return {
     issueForProspect, unlockEntitlement, issueManual, cancelEntitlement, resendDelivery,
-    expireReservations, reconcileMissedLeads, reconcileMissedDeliveries,
+    expireReservations, reconcileMissedLeads, reconcileMissedDeliveries, purgeIssuanceSkips,
     listEntitlements, verificationStampOf,
   };
 }

--- a/backend/src/services/redeemOps/inventoryService.js
+++ b/backend/src/services/redeemOps/inventoryService.js
@@ -116,13 +116,16 @@ export function makeInventoryService(overrides = {}) {
   function recordIssued({ offerId, activationId, entitlementId, actorType = 'system', transaction }) {
     return guardedMove({
       offerId, quantity: 1, transaction,
+      // status = 'active' (PR C): a paused/ended offer must not issue even in
+      // the race window after the service's pre-check passed (TOCTOU).
       guardSql: `UPDATE reward_offers
                     SET "issuedQuantity" = "issuedQuantity" + 1, "updatedAt" = NOW()
                   WHERE id = :offerId
+                    AND status = 'active'
                     AND "allocatedQuantity" - "issuedQuantity" >= 1
                   RETURNING id, "issuedQuantity"`,
       ledger: { type: 'issued', activationId, entitlementId, actorType },
-      failMessage: 'Activation allocation exhausted',
+      failMessage: 'Reward offer is not active or its allocation is exhausted',
     });
   }
 

--- a/backend/test/redeemOpsLivenessGates.test.js
+++ b/backend/test/redeemOpsLivenessGates.test.js
@@ -1,0 +1,261 @@
+/**
+ * PR C — liveness gates + linkage guards + skip observability
+ * (docs/plans/trial-reward-funnel-hardening-prompt.md, defects 4 + 5).
+ *
+ * Battery: unlock refuses paused/completed/cancelled activations (typed 409s)
+ * while replay stays idempotent; the unlock TRANSACTION predicate holds even
+ * when the pre-check is blinded (TOCTOU); issuance refuses paused offers and
+ * ended activations; a live activation's campaign link is immutable; every
+ * skip writes a persisted row surfaced by the detail endpoint; purge works.
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+process.env.REDEEM_OPS_ENTITLEMENTS_ENABLED = 'true';
+
+import request from 'supertest';
+import { getApp, closeDb, createTestUser, createTestCampaign } from './helpers.js';
+import {
+  Prospect, RewardOffer, Activation, RewardEntitlement, ActivationIssuanceSkip,
+  PartnerOrganisation, sequelize,
+} from '../src/models/index.js';
+import { makeEntitlementService } from '../src/services/redeemOps/entitlementService.js';
+import { makeActivationService } from '../src/services/redeemOps/activationService.js';
+
+const svc = makeEntitlementService(); // bare: no emails — gate mechanics only
+const activations = makeActivationService();
+
+let app;
+let admin, agent;
+let partner, offer, pausedOffer;
+let campW, actW; // main happy-path pair
+let phoneSeq = 70000000;
+const freshPhone = () => `+65${phoneSeq++}`;
+const auth = (t) => ({ Authorization: `Bearer ${t}` });
+
+async function makeVerifiedProspect(campaignId, overrides = {}) {
+  return Prospect.create({
+    firstName: 'Gate',
+    lastName: 'Holder',
+    phone: freshPhone(),
+    email: `gates-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@test.com`,
+    leadSource: 'website',
+    campaignId,
+    assignedAgentId: agent.user.id,
+    sourceMetadata: { phoneVerifiedAt: new Date().toISOString() },
+    ...overrides,
+  });
+}
+
+async function makeActivation(campaignId, overrides = {}) {
+  return Activation.create({
+    partnerOrganisationId: partner.id, rewardOfferId: offer.id, campaignId,
+    campaignNameSnapshot: campaignId ? 'snap' : null, allocatedQuantity: 30, status: 'active',
+    unlockPolicy: 'agent_unlock', createdBy: admin.user.id, ...overrides,
+  });
+}
+
+beforeAll(async () => {
+  app = await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  agent = await createTestUser({ role: 'agent' });
+  partner = await PartnerOrganisation.create({
+    tradingName: 'Gates Test Studio', normalizedName: 'gates test studio', createdBy: admin.user.id,
+  });
+  offer = await RewardOffer.create({
+    partnerOrganisationId: partner.id, title: 'Free Gate Trial',
+    committedQuantity: 300, allocatedQuantity: 200, status: 'active',
+    claimExpiryDays: 30, redemptionExpiryDays: 90, createdBy: admin.user.id,
+  });
+  pausedOffer = await RewardOffer.create({
+    partnerOrganisationId: partner.id, title: 'Paused Offer Trial',
+    committedQuantity: 50, allocatedQuantity: 30, status: 'paused',
+    claimExpiryDays: 30, redemptionExpiryDays: 90, createdBy: admin.user.id,
+  });
+  campW = await createTestCampaign(admin.user.id, { name: 'Gates Campaign W' });
+  actW = await makeActivation(campW.id);
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+describe('unlock liveness gate', () => {
+  test('paused / completed / cancelled activations refuse unlock with typed 409s; active unlocks', async () => {
+    const prospect = await makeVerifiedProspect(campW.id);
+    const issue = await svc.issueForProspect(prospect);
+    expect(issue.reason).toBeNull();
+
+    await actW.update({ status: 'paused' });
+    await expect(
+      svc.unlockEntitlement({ presentationToken: issue.presentationToken }, admin.user, 'manual')
+    ).rejects.toMatchObject({ statusCode: 409, message: expect.stringContaining('paused') });
+
+    await actW.update({ status: 'completed' });
+    await expect(
+      svc.unlockEntitlement({ presentationToken: issue.presentationToken }, admin.user, 'manual')
+    ).rejects.toMatchObject({ statusCode: 409, message: expect.stringContaining('completed') });
+
+    await actW.update({ status: 'cancelled' });
+    await expect(
+      svc.unlockEntitlement({ presentationToken: issue.presentationToken }, admin.user, 'manual')
+    ).rejects.toMatchObject({ statusCode: 409, message: expect.stringContaining('cancelled') });
+
+    await actW.update({ status: 'active' });
+    const unlocked = await svc.unlockEntitlement({ presentationToken: issue.presentationToken }, admin.user, 'manual');
+    expect(unlocked.already).toBe(false);
+    expect(unlocked.entitlement.status).toBe('issued');
+
+    // Replay carve-out: the unlock already happened — pausing afterwards must
+    // NOT break idempotent replays.
+    await actW.update({ status: 'paused' });
+    const replay = await svc.unlockEntitlement({ presentationToken: issue.presentationToken }, admin.user, 'manual');
+    expect(replay.already).toBe(true);
+    await actW.update({ status: 'active' });
+  });
+
+  test('TOCTOU: a pause that lands after the pre-check still loses inside the transaction', async () => {
+    const prospect = await makeVerifiedProspect(campW.id);
+    const issue = await svc.issueForProspect(prospect);
+    expect(issue.reason).toBeNull();
+
+    // Blind the pre-check: this instance always sees the activation as active,
+    // simulating a pause committed between pre-check and UPDATE.
+    const blindSvc = makeEntitlementService({
+      Activation: {
+        findByPk: async () => ({ id: actW.id, status: 'active' }),
+        findOne: (...a) => Activation.findOne(...a),
+        findAll: (...a) => Activation.findAll(...a),
+      },
+    });
+    await actW.update({ status: 'paused' });
+    await expect(
+      blindSvc.unlockEntitlement({ presentationToken: issue.presentationToken }, admin.user, 'manual')
+    ).rejects.toMatchObject({ statusCode: 409, message: expect.stringContaining('no longer active') });
+
+    // The entitlement is untouched — still eligible, still unlockable later.
+    await actW.update({ status: 'active' });
+    const row = await RewardEntitlement.findByPk(issue.entitlement.id);
+    expect(row.status).toBe('eligible');
+  });
+});
+
+describe('issuance liveness gates + persisted skips', () => {
+  test('paused OFFER refuses issuance with a typed reason + skip row', async () => {
+    const campX = await createTestCampaign(admin.user.id, { name: 'Gates Campaign X' });
+    const actX = await makeActivation(campX.id, { rewardOfferId: pausedOffer.id });
+    const prospect = await makeVerifiedProspect(campX.id);
+
+    const r = await svc.issueForProspect(prospect);
+    expect(r.entitlement).toBeNull();
+    expect(r.reason).toBe('offer_not_active');
+
+    const skips = await ActivationIssuanceSkip.findAll({ where: { activationId: actX.id } });
+    expect(skips.map((s) => s.reason)).toContain('offer_not_active');
+  });
+
+  test('ended activation refuses issuance; future endDate issues fine', async () => {
+    const campY = await createTestCampaign(admin.user.id, { name: 'Gates Campaign Y' });
+    const actY = await makeActivation(campY.id, { endDate: new Date(Date.now() - 3600 * 1000) });
+    const p1 = await makeVerifiedProspect(campY.id);
+    const ended = await svc.issueForProspect(p1);
+    expect(ended.reason).toBe('activation_ended');
+
+    await actY.update({ endDate: new Date(Date.now() + 7 * 24 * 3600 * 1000) });
+    const p2 = await makeVerifiedProspect(campY.id);
+    const ok = await svc.issueForProspect(p2);
+    expect(ok.reason).toBeNull();
+
+    const skips = await ActivationIssuanceSkip.findAll({ where: { activationId: actY.id } });
+    expect(skips.map((s) => s.reason)).toContain('activation_ended');
+  });
+
+  test('allocation exhaustion writes a skip row', async () => {
+    const campM = await createTestCampaign(admin.user.id, { name: 'Gates Campaign M' });
+    const actM = await makeActivation(campM.id, { allocatedQuantity: 1 });
+    const p1 = await makeVerifiedProspect(campM.id);
+    expect((await svc.issueForProspect(p1)).reason).toBeNull();
+    const p2 = await makeVerifiedProspect(campM.id);
+    const r = await svc.issueForProspect(p2);
+    expect(r.reason).toBe('allocation_exhausted');
+
+    const skips = await ActivationIssuanceSkip.findAll({ where: { activationId: actM.id } });
+    expect(skips.map((s) => s.reason)).toContain('allocation_exhausted');
+  });
+
+  test('no active activation on the campaign: skip is recorded by CAMPAIGN and surfaces on the detail', async () => {
+    const campZ = await createTestCampaign(admin.user.id, { name: 'Gates Campaign Z' });
+    const prospect = await makeVerifiedProspect(campZ.id);
+    const r = await svc.issueForProspect(prospect, { via: 'hook' });
+    expect(r.reason).toBe('no_active_activation');
+
+    const row = await ActivationIssuanceSkip.findOne({ where: { campaignId: campZ.id, reason: 'no_active_activation' } });
+    expect(row).toBeTruthy();
+    expect(row.activationId).toBeNull(); // nothing to attribute — the detached signature
+
+    // A (draft) activation later created on that campaign sees the campaign-level rows.
+    const actZ = await makeActivation(campZ.id, { status: 'draft' });
+    const breakdown = await activations.getIssuanceSkips24h(actZ.id);
+    expect(breakdown.find((b) => b.reason === 'no_active_activation')?.count).toBeGreaterThanOrEqual(1);
+  });
+
+  test('detail endpoint returns the 24h breakdown; purge honors retention', async () => {
+    const campP = await createTestCampaign(admin.user.id, { name: 'Gates Campaign P' });
+    const actP = await makeActivation(campP.id, { rewardOfferId: pausedOffer.id });
+    const prospect = await makeVerifiedProspect(campP.id);
+    await svc.issueForProspect(prospect);
+
+    const res = await request(app)
+      .get(`/api/redeem-ops/activations/${actP.id}`)
+      .set(auth(admin.token));
+    expect(res.status).toBe(200);
+    const entry = (res.body.data.issuanceSkips24h || []).find((b) => b.reason === 'offer_not_active');
+    expect(entry?.count).toBeGreaterThanOrEqual(1);
+
+    // Retention: a >30d-old row is purged, recent rows survive.
+    const old = await ActivationIssuanceSkip.create({
+      campaignId: campP.id, activationId: actP.id, reason: 'offer_not_active', via: 'hook',
+    });
+    await sequelize.query(
+      `UPDATE activation_issuance_skips SET "createdAt" = NOW() - INTERVAL '31 days' WHERE id = :id`,
+      { replacements: { id: old.id } }
+    );
+    const removed = await svc.purgeIssuanceSkips();
+    expect(removed).toBeGreaterThanOrEqual(1);
+    expect(await ActivationIssuanceSkip.findByPk(old.id)).toBeNull();
+    expect(await ActivationIssuanceSkip.count({ where: { activationId: actP.id } })).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('linkage guard — live activations keep their campaign', () => {
+  test('draft may link/unlink; every LIVE status is refused with the typed 409; HTTP surface agrees', async () => {
+    const campL = await createTestCampaign(admin.user.id, { name: 'Gates Campaign L' });
+    const act = await makeActivation(null, { status: 'draft', campaignNameSnapshot: null });
+
+    // draft: link + unlink both fine
+    await activations.linkCampaign(act.id, campL.id, admin.user);
+    expect((await Activation.findByPk(act.id)).campaignId).toBe(campL.id);
+    await activations.linkCampaign(act.id, null, admin.user);
+    expect((await Activation.findByPk(act.id)).campaignId).toBeNull();
+    await activations.linkCampaign(act.id, campL.id, admin.user); // re-link for the live tests
+
+    for (const status of ['preparing', 'active', 'paused']) {
+      await act.update({ status });
+      await expect(activations.linkCampaign(act.id, null, admin.user))
+        .rejects.toMatchObject({ statusCode: 409, message: expect.stringContaining('complete or cancel') });
+      await expect(activations.linkCampaign(act.id, campL.id, admin.user))
+        .rejects.toMatchObject({ statusCode: 409 });
+    }
+
+    // HTTP surface: PATCH campaign on a live activation → 409
+    const res = await request(app)
+      .patch(`/api/redeem-ops/activations/${act.id}/campaign`)
+      .set(auth(admin.token))
+      .send({ campaignId: null });
+    expect(res.status).toBe(409);
+    expect(res.body.message).toMatch(/complete or cancel/i);
+
+    // terminal states may unlink (cleanup is legitimate)
+    await act.update({ status: 'completed' });
+    await activations.linkCampaign(act.id, null, admin.user);
+    expect((await Activation.findByPk(act.id)).campaignId).toBeNull();
+  });
+});

--- a/src/pages/redeemops/ActivationDetail.jsx
+++ b/src/pages/redeemops/ActivationDetail.jsx
@@ -82,6 +82,10 @@ export default function ActivationDetail() {
   const a = data.activation;
   const campaign = data.campaign;
   const acquisition = metricsQuery.data?.acquisition;
+  // Server-enforced linkage guard (PR C): live activations cannot change their
+  // campaign link — relinking/unlinking one silently starves the funnel.
+  const isLive = ['preparing', 'active', 'paused'].includes(a.status);
+  const issuanceSkips = data.issuanceSkips24h || [];
 
   return (
     <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-5">
@@ -114,6 +118,31 @@ export default function ActivationDetail() {
         <RoStatTile label="Redeemed" value={a.redeemedCount} />
       </div>
 
+      {issuanceSkips.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Skipped issuance — last 24h</CardTitle>
+            <CardDescription>
+              Sign-ups that did NOT earn a reward, by reason. A growing count here means the
+              funnel is starved (allocation, offer status, activation link) or being farmed.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap gap-2">
+              {issuanceSkips.map((s) => (
+                <span
+                  key={s.reason}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-xs"
+                  style={{ color: '#B45309' }}
+                >
+                  ⚠ {prettyEnum(s.reason)} <strong>×{s.count}</strong>
+                </span>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       <div className="grid gap-4 lg:grid-cols-2">
         <Card>
           <CardHeader>
@@ -139,11 +168,20 @@ export default function ActivationDetail() {
                       <ExternalLink className="w-3.5 h-3.5 mr-1.5" aria-hidden="true" /> Open in MKTR
                     </a>
                   </Button>
-                  {canLink && (
+                  {canLink && !isLive && (
                     <Button size="sm" variant="ghost" onClick={() => linkMutation.mutate(null)}>Unlink</Button>
                   )}
                 </div>
+                {canLink && isLive && (
+                  <p className="text-xs m-0" style={{ color: 'var(--ro-text-3)' }}>
+                    Complete or cancel the activation to change its campaign link — unlinking a live activation stops issuance.
+                  </p>
+                )}
               </div>
+            ) : canLink && isLive ? (
+              <p className="text-sm text-muted-foreground">
+                No campaign linked — issuance is stopped. Complete or cancel the activation first, then link the campaign on a fresh activation.
+              </p>
             ) : canLink ? (
               <div className="space-y-2">
                 <Input

--- a/src/pages/redeemops/__tests__/ActivationDetail.test.jsx
+++ b/src/pages/redeemops/__tests__/ActivationDetail.test.jsx
@@ -1,0 +1,109 @@
+/**
+ * ActivationDetail — PR C surfaces:
+ * 1. LIVE activations hide Unlink and explain the server's linkage guard;
+ * 2. non-live activations keep the Unlink action;
+ * 3. the last-24h skipped-issuance breakdown renders when present.
+ * redeemOpsApi is fully mocked — no network.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+const api = vi.hoisted(() => ({
+  getActivation: vi.fn(),
+  getActivationMetrics: vi.fn(),
+  searchCampaigns: vi.fn(),
+  linkActivationCampaign: vi.fn(),
+  setActivationStatus: vi.fn(),
+  changeActivationAllocation: vi.fn(),
+}));
+vi.mock('@/api/redeemOps', () => ({ redeemOpsApi: api }));
+
+const toastMock = vi.hoisted(() => {
+  const t = vi.fn();
+  t.success = vi.fn();
+  t.error = vi.fn();
+  return t;
+});
+vi.mock('sonner', () => ({ toast: toastMock }));
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: (sel) => sel({ user: { id: 'u1', role: 'admin' } }),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useParams: () => ({ id: 'act-1' }) };
+});
+
+import ActivationDetail from '../ActivationDetail';
+
+const baseActivation = {
+  id: 'act-1', status: 'active', campaignId: 'camp-1', campaignNameSnapshot: 'July Campaign',
+  allocatedQuantity: 10, issuedCount: 2, redeemedCount: 0, unlockPolicy: 'agent_unlock',
+  rewardOffer: { id: 'o1', title: 'Free Trial Session' },
+  partner: { tradingName: 'Gates Studio' },
+};
+const campaignRef = {
+  id: 'camp-1', name: 'July Campaign', status: 'active', customerHost: 'redeem',
+  publicUrl: 'https://redeem.sg/c/x', mktrAdminUrl: 'https://mktr.sg/admin/x',
+};
+
+function renderPage(detail) {
+  api.getActivation.mockResolvedValue(detail);
+  api.getActivationMetrics.mockResolvedValue({ acquisition: { totalLeads: 5 } });
+  api.searchCampaigns.mockResolvedValue([]);
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter><ActivationDetail /></MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ActivationDetail PR C surfaces', () => {
+  it('hides Unlink on a LIVE activation and explains the guard', async () => {
+    renderPage({ activation: baseActivation, campaign: campaignRef, issuanceSkips24h: [] });
+    expect(await screen.findByText('July Campaign')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Unlink' })).toBeNull();
+    expect(screen.getByText(/Complete or cancel the activation to change its campaign link/)).toBeInTheDocument();
+  });
+
+  it('keeps Unlink on a non-live activation', async () => {
+    renderPage({
+      activation: { ...baseActivation, status: 'draft' },
+      campaign: campaignRef,
+      issuanceSkips24h: [],
+    });
+    expect(await screen.findByRole('button', { name: 'Unlink' })).toBeInTheDocument();
+    expect(screen.queryByText(/Complete or cancel the activation to change/)).toBeNull();
+  });
+
+  it('renders the 24h skipped-issuance breakdown when present', async () => {
+    renderPage({
+      activation: baseActivation,
+      campaign: campaignRef,
+      issuanceSkips24h: [
+        { reason: 'allocation_exhausted', count: 4 },
+        { reason: 'no_active_activation', count: 2 },
+      ],
+    });
+    expect(await screen.findByText(/Skipped issuance — last 24h/)).toBeInTheDocument();
+    expect(screen.getByText(/Allocation exhausted/)).toBeInTheDocument();
+    expect(screen.getByText('×4')).toBeInTheDocument();
+    expect(screen.getByText('×2')).toBeInTheDocument();
+  });
+
+  it('shows no skip card when the window is clean', async () => {
+    renderPage({ activation: baseActivation, campaign: campaignRef, issuanceSkips24h: [] });
+    await screen.findByText('July Campaign');
+    expect(screen.queryByText(/Skipped issuance/)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What this fixes

PR C of `docs/plans/trial-reward-funnel-hardening-prompt.md` — funnel-audit defects **4** and **5** (both P1):

- **Unlock ignored activation status.** `unlockEntitlement` never loaded the activation — paused/completed/cancelled activations still unlocked, though the funnel doc claimed "activation live" was enforced. Issuance also never checked `offer.status` or `endDate`.
- **Live activations could be silently detached.** `PATCH /activations/:id/campaign` had no status guard — unlink/relink on an ACTIVE activation silently stops issuance: the sweep skips null-campaign activations, the console still says "active", and nothing counted the skips.

## How

### Unlock liveness gate
- `paused` → typed 409 *"Activation is paused — unlocks are temporarily disabled"* (full brake — deliberate); `completed`/`cancelled` → typed 409.
- **The pre-check is UX; the transaction is authoritative** (Codex TOCTOU note): the unlock's conditional UPDATE now also requires the activation row to still be `active` via subquery predicate — a pause landing between pre-check and commit loses cleanly. Test proves it by blinding the pre-check with a DI stub.
- **Replay carve-out:** an already-unlocked reward answers `already:true` regardless of activation state — that unlock already happened.

### Issuance gates
`offer.status='active'` (typed `offer_not_active`) + activation `endDate` unset-or-future (typed `activation_ended`) — pre-checks **plus** in-transaction predicates (activation counter UPDATE gains the endDate clause; `inventoryService.recordIssued` gains `status='active'`).

### Linkage guard
Unlink/relink allowed only when the activation is **not live** (`preparing`/`active`/`paused` all refuse) → typed 409 *"complete or cancel it first"* (Codex-corrected wording — paused is itself protected). ActivationDetail hides Unlink on live activations and explains why.

### Skip visibility — persisted, not logs (migration 076)
Every skipped issuance writes one `activation_issuance_skips` row from the single choke point (hook/sweep/manual) + a structured log line. `no_active_activation` rows are campaign-keyed with NULL activationId — the detached-funnel signature. The activation detail returns and renders a **last-24h reason breakdown** (allocation exhausted, offer paused, ended, quarantined, unverified, no phone, duplicate phone); the fulfilment sweep purges rows older than 30 days. A starved or farmed funnel is now visible at a glance instead of silent.

Funnel doc step 7 + §2 updated in the working tree (the doc is untracked in git — committing it into the repo is a PR D decision).

## Tests

`redeemOpsLivenessGates.test.js` (8): typed 409s for all three non-live unlock states, reactivate-then-unlock, replay-on-paused stays idempotent; **TOCTOU race loses inside the transaction** and leaves the entitlement eligible; paused offer / ended activation / exhausted allocation each refuse and write skip rows; future endDate issues; campaign-keyed skips surface on a later activation's breakdown; detail endpoint returns the breakdown; 30-day purge; linkage guard across draft (allowed) / all live states (409, service + HTTP) / terminal (allowed). `ActivationDetail.test.jsx` (4): Unlink hidden + explained on live, kept on draft, breakdown renders, clean window renders nothing.

Full regression: **145/145 backend** across 9 suites (incl. all PR A + B suites), **1195/1196 frontend** (the one failure is the documented pre-existing PublicPreview one). `migrations.test.js` still fails only on the pre-existing 066 duplicate (PR D); 076 adds none.

## Live behavior on merge

Flags are ON: paused activations immediately stop unlocking (that's the point), live activations can no longer be unlinked, and ops gains the skip breakdown. Prod's only activation is draft + unlinked — no live workflow is disrupted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MxmXMaNdrvqrQgZrLpvUb