### PR TITLE
feat(campaigns): design_config v2 core — schema twins, migration, gated version-aware clamp (Studio PR 1, dark)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ calls) and delivers them to insurance agents via the Lyfe mobile app:
 | Two-brand routing-guard route lists, URL-helper contracts, prod env tables, DNS, Render IDs | `docs/reference/brand-and-hosting.md` |
 | **Redeem Ops** (partner CRM, tasks, rewards, Discover, cadences) — `ops.redeem.sg` | `src/pages/redeemops/CLAUDE.md` + `docs/redeem-ops/` |
 | Meta tracking / redeemed-audience deep design | `docs/plans/meta-tracking-implementation.md`, `docs/plans/meta-redeemed-audience-sync.md` |
+| **Campaign Studio revamp** (design_config v2 schema twins, v1→v2 migration, write gate `DESIGN_CONFIG_V2_WRITES_ENABLED` — default OFF; version-tagged saves rejected until PR 2/3) | `docs/plans/campaign-studio-implementation-prompt.md` + twins `src/lib/designConfigV2.js` ↔ `backend/src/utils/designConfigV2.js` (+ `designConfigV2Clamp.js`) |
 
 Cross-system (Supabase schema, edge functions, roles) → parent `../CLAUDE.md`.
 

--- a/TRACKER.md
+++ b/TRACKER.md
@@ -116,6 +116,7 @@ Retell AI performs the call and provides analysis natively. MKTR stores the resu
 | Integration tests (lead capture) | DONE | `backend/test/integration/leadCapture.test.js` |
 | Unit tests (webhook dispatch) | DONE | `backend/test/unit/webhookDispatch.test.js` |
 | Unit tests (webhook service) | DONE | `backend/test/unit/webhookService.test.js` |
+| design_config v2 core (Campaign Studio PR 1) | DONE (dark) | Twin schema modules `src/lib/designConfigV2.js` ↔ `backend/src/utils/designConfigV2.js` (lock-step vitest), lossless v1→v2 canonicalizing migration + downgrade/readLegacyView, version-aware clamp + leaf-level public v2 whitelist, hybrid-alias scrub, cross-version accessors. Write gate `DESIGN_CONFIG_V2_WRITES_ENABLED` default OFF — version-tagged saves 422 `DESIGN_CONFIG_VERSION_UNSUPPORTED`; stored-v2 overwrite by v1 save 409 `DESIGN_CONFIG_VERSION_CONFLICT`. v1 clamp behavior frozen by base-commit oracle `test-fixtures/designConfigV1ClampOracle.json` (`backend/test/designConfigV1Golden.test.js`). |
 | Sentry error tracking | PARTIAL | `server.js:9-15` — init only if SENTRY_DSN set; not in edge functions |
 | Structured logging (pino) | DONE | All services use `logger.js` (pino) |
 | Health check | DONE | `GET /health` on monolith |

--- a/backend/src/services/campaignService.js
+++ b/backend/src/services/campaignService.js
@@ -8,6 +8,12 @@ import { normalizeCustomerHostChoice } from '../utils/customerHost.js';
 import { applyFeaturedDropPolicy } from '../utils/featuredDrop.js';
 import { applyLuckyDrawPolicy } from '../utils/luckyDraw.js';
 import { normalizeMarketplaceContent, applyMarketplacePolicy } from '../utils/marketplaceContent.js';
+import {
+  classifyDesignConfigVersion,
+  clampDesignConfigV2,
+  designConfigV2WritesEnabled,
+  getStoredTermsHtml,
+} from '../utils/designConfigV2Clamp.js';
 import { invalidateMarketplaceCache } from './marketplaceCache.js';
 import { refundCampaignCommitments } from './walletService.js';
 
@@ -39,8 +45,25 @@ const MARKETPLACE_CONTENT_KEYS = [
  * luckyDraw: draw-campaign enforcement settings — admin-only, same policy
  * (see utils/luckyDraw.js and docs/plans/lucky-draw-10x.md §4.1).
  */
-function clampDesignConfig(incoming, storedConfig, role) {
+export function clampDesignConfig(incoming, storedConfig, role) {
   if (!incoming || typeof incoming !== 'object') return incoming;
+  // design_config v2 (Campaign Studio) dispatch. Version-tagged documents are
+  // REJECTED until DESIGN_CONFIG_V2_WRITES_ENABLED flips on (PR 2/3 make every
+  // reader version-aware first) — accepting one early would let a hybrid
+  // payload bypass the admin publication policy and break the live v1 readers.
+  // Untagged documents take the v1 path below, byte-for-byte as before.
+  const versionClass = classifyDesignConfigVersion(incoming);
+  if (versionClass !== 'legacy') {
+    if (versionClass !== 'v2' || !designConfigV2WritesEnabled()) {
+      const err = new AppError(
+        'This design_config version is not accepted yet. Campaign Studio (v2) documents are gated until rollout completes.',
+        422
+      );
+      err.data = { code: 'DESIGN_CONFIG_VERSION_UNSUPPORTED' };
+      throw err;
+    }
+    return clampDesignConfigV2(incoming, storedConfig, role);
+  }
   const clamped = { ...incoming, customerHost: normalizeCustomerHostChoice(incoming.customerHost) };
   const featuredDrop = applyFeaturedDropPolicy({
     incoming: incoming.featuredDrop,
@@ -98,7 +121,8 @@ export async function ensureDrawTermsVersion(designConfig, campaignId, userId, d
       422
     );
   }
-  const content = typeof designConfig.termsContent === 'string' ? designConfig.termsContent.trim() : '';
+  // Version-aware terms read: v1 termsContent / v2 form.terms.html.
+  const content = getStoredTermsHtml(designConfig).trim();
   if (!content) {
     throw new AppError(
       'Lucky-draw campaigns need Terms & Conditions content (designer → Terms & Conditions) before they can be enabled.',
@@ -362,8 +386,7 @@ export async function createCampaign(body, user) {
         422
       );
     }
-    const terms = typeof campaignData.design_config.termsContent === 'string'
-      ? campaignData.design_config.termsContent.trim() : '';
+    const terms = getStoredTermsHtml(campaignData.design_config).trim();
     if (!terms) {
       throw new AppError(
         'Lucky-draw campaigns need Terms & Conditions content (designer → Terms & Conditions) before they can be enabled.',
@@ -458,6 +481,20 @@ export async function updateCampaign(id, body, req) {
     }
   }
   if (design_config !== undefined) {
+    // A Studio-saved (v2) document must never be overwritten by an untagged
+    // v1 save — the v1 clamp would wholesale-replace the nested doc. The old
+    // designer gets a read-only guard in the Studio PR; this is its server twin.
+    if (
+      classifyDesignConfigVersion(campaign.design_config) === 'v2' &&
+      classifyDesignConfigVersion(design_config) === 'legacy'
+    ) {
+      const err = new AppError(
+        "This campaign's design was saved by Campaign Studio and cannot be overwritten by the classic designer. Reopen it in the Studio.",
+        409
+      );
+      err.data = { code: 'DESIGN_CONFIG_VERSION_CONFLICT' };
+      throw err;
+    }
     // Clamp the per-campaign customer host to the enum (never trust a raw host
     // from client JSON) and gate featuredDrop/luckyDraw changes to admins;
     // preserve all other design keys untouched.
@@ -698,12 +735,26 @@ export async function duplicateCampaign(id, body, req) {
     // marketplaceListed never clones either — a duplicate of a listed campaign
     // must not silently appear on the public marketplace when activated.
     const { luckyDraw: _neverCloneDraw, marketplaceListed: _neverCloneListing, ...base } = rest.design_config;
-    return {
+    const copy = {
       ...base,
       ...(rest.design_config.featuredDrop && typeof rest.design_config.featuredDrop === 'object'
         ? { featuredDrop: { ...rest.design_config.featuredDrop, enabled: false } }
         : {}),
     };
+    // v2 (Campaign Studio) docs keep publication state under distribution.* —
+    // the same never-clone rules apply at those paths.
+    if (classifyDesignConfigVersion(copy) === 'v2' && copy.distribution && typeof copy.distribution === 'object') {
+      const distribution = { ...copy.distribution };
+      if (distribution.featuredDrop && typeof distribution.featuredDrop === 'object') {
+        distribution.featuredDrop = { ...distribution.featuredDrop, enabled: false };
+      }
+      if (distribution.marketplace && typeof distribution.marketplace === 'object') {
+        const { listed: _neverCloneV2Listing, ...marketplace } = distribution.marketplace;
+        distribution.marketplace = marketplace;
+      }
+      copy.distribution = distribution;
+    }
+    return copy;
   })();
   const copy = await Campaign.create({
     ...rest,

--- a/backend/src/utils/designConfigV2.js
+++ b/backend/src/utils/designConfigV2.js
@@ -1,0 +1,575 @@
+/**
+ * design_config v2 — schema constants, v1↔v2 migration, and theme resolution.
+ *
+ * SOURCE OF TRUTH of a frontend/backend TWIN (quizScoring / redeemOpsPermissions
+ * pattern): src/lib/designConfigV2.js is a byte-mirror of this file's shared
+ * surface, and src/lib/__tests__/designConfigV2.lockstep.test.js imports BOTH
+ * and fails the build if they diverge. Keep this module dependency-free so both
+ * test runners can import it directly. Edit the two files together.
+ *
+ * Contract: claude.ai/design "Campaign Studio" Phase 5 handoff §01/§02 +
+ * studio-data.js, reconciled against production key names/behavior
+ * (docs/plans/campaign-studio-implementation-prompt.md — production wins).
+ * Server-side clamping/policy lives in ./designConfigV2Clamp.js (backend-only);
+ * this module never clamps — upgrade preserves values verbatim, the SAVE path
+ * clamps, exactly like v1's editor-seeds/server-clamps split.
+ *
+ * MIGRATION IS A CANONICALIZATION, NOT BYTE-PARITY. The guarantee is
+ * render-contract equivalence for the Editorial + Warm Cream baseline.
+ * Documented loss ledger (each entry is deliberate + fixture-tested):
+ *  L1 requiredFields canonicalize: false|'optional' → false, other truthy →
+ *     true, absent → false. v1 was self-inconsistent ('optional' displayed as
+ *     optional but submit-enforced; absent displayed required but unenforced) —
+ *     v2 follows enforcement + the customer-visible label promise.
+ *  L2 education/salary ABSENT visibility → visible:false (the handoff-signed
+ *     data-honest rule: v1 rendered them but discarded their values).
+ *  L3 fieldOrder anomalies (mixed string/row arrays, duplicates, omissions,
+ *     empty rows, unknown ids) canonicalize deterministically: flatten
+ *     element-wise, first occurrence wins, unknown ids dropped, missing fields
+ *     appended in default order.
+ *  L4 mediaType absent → media.kind derived ('image' iff imageUrl else 'none',
+ *     the renderer's own default); downgrade emits the derived kind explicitly.
+ *  L5 quiz / guidedReview / luckyDraw / unknown top-level keys (incl. legacy
+ *     dead style keys) pass through VERBATIM in both directions — never
+ *     restructured, never dropped.
+ */
+
+export const DESIGN_CONFIG_VERSION = 2;
+
+export const TEMPLATE_IDS = ['editorial', 'poster', 'split', 'spotlight', 'express', 'journey'];
+
+/** Per-template parameter defaults — one bag, every template persists its
+ * params across switches; first Studio use seeds these. Migration seeds the
+ * bag but copies editorial.formWidth ONLY when v1 stored one (v1's RENDER
+ * default when absent is 480, not the editor-seed 400 — omitting preserves it). */
+export const TEMPLATE_PARAM_DEFAULTS = {
+  editorial: { formWidth: 400, cardStyle: 'raised' },
+  poster: { overlay: 'dusk', formReveal: 'inline' },
+  split: { mediaSide: 'left', mediaFit: 'cover' },
+  spotlight: { introStyle: 'immersive', revealArt: 'meter' },
+  express: { trustLine: '', storyFold: false },
+  journey: { sectionRhythm: 'alternate', stickyCta: true },
+};
+
+export const THEME_RADIUS_IDS = ['soft', 'sharp', 'round'];
+export const THEME_BACKGROUNDS = ['plain', 'wash', 'grain'];
+export const FONT_IDS = ['fraunces', 'playfair', 'space-grotesk', 'albert-sans', 'inter'];
+
+export const RADII = {
+  soft: { card: 14, input: 10, btn: 12, modal: 18, media: 12, check: 4 },
+  sharp: { card: 8, input: 6, btn: 7, modal: 12, media: 8, check: 3 },
+  round: { card: 20, input: 12, btn: 999, modal: 24, media: 14, check: 5 },
+};
+
+/**
+ * The 10 curated theme presets. `warm-cream` is FROZEN to the production
+ * Editorial tokens (LeadCaptureLayout TOKENS + RADIUS, verified byte-exact
+ * 2026-07-17) — it is the migration parity baseline and must never drift from
+ * the live page. `rx` is a preset-exact radii override that wins while
+ * theme.radius is untouched (resolveTheme).
+ */
+export const THEME_PRESETS = [
+  { id: 'warm-cream', name: 'Warm Cream', bg: '#F1DDB8', card: '#FFFAF0', storyCard: '#FAEAD0', modal: '#FBF7F0', ink: '#3D1F0B', bodyText: '#5A301A', muted: '#9A7E5C', hairline: '#E8D7B8', divider: '#D8C09A', accent: '#D17029', accentDeep: '#A85822', danger: '#B33A2E', success: '#7A8C6B', font: 'fraunces', radius: 'soft', rx: { card: 24, input: 999, btn: 999, modal: 28, media: 16, check: 6 }, parity: true, hostDefault: 'redeem' },
+  { id: 'paper-white', name: 'Paper White', bg: '#FAFAF8', card: '#FFFFFF', ink: '#17191E', muted: '#818694', accent: '#4059C8', font: 'space-grotesk', radius: 'sharp', hostDefault: 'mktr' },
+  { id: 'kopi', name: 'Kopi', bg: '#F3EBE0', card: '#FBF6EE', ink: '#3A2E22', muted: '#94836F', accent: '#8A5A2B', font: 'playfair', radius: 'soft' },
+  { id: 'botanic', name: 'Botanic', bg: '#F1F4EC', card: '#FAFCF6', ink: '#26311F', muted: '#7C8A6E', accent: '#4E7A3A', font: 'albert-sans', radius: 'soft' },
+  { id: 'peranakan', name: 'Peranakan', bg: '#FDF3F0', card: '#FFFAF8', ink: '#3B2430', muted: '#9A7A85', accent: '#C24E6A', font: 'fraunces', radius: 'round' },
+  { id: 'graphite', name: 'Graphite', bg: '#232529', card: '#2C2E33', ink: '#F2F2EF', muted: '#9A9DA6', accent: '#7A9BFF', font: 'space-grotesk', radius: 'sharp', dark: true },
+  { id: 'straits-teal', name: 'Straits Teal', bg: '#F2F6F5', card: '#FFFFFF', ink: '#152A28', muted: '#6E8582', accent: '#0E7C6B', font: 'albert-sans', radius: 'soft' },
+  { id: 'ink-lime', name: 'Ink & Lime', bg: '#1C1D18', card: '#26271F', ink: '#F4F6E8', muted: '#9AA08A', accent: '#9CCF35', font: 'space-grotesk', radius: 'sharp', dark: true },
+  { id: 'violet-hour', name: 'Violet Hour', bg: '#2E2447', card: '#3A2E59', ink: '#F3EFFC', muted: '#A99BC8', accent: '#B7F04C', font: 'fraunces', radius: 'round', dark: true },
+  { id: 'tangerine', name: 'Tangerine', bg: '#FFF4EC', card: '#FFFBF7', ink: '#332014', muted: '#A08373', accent: '#F0590C', font: 'albert-sans', radius: 'round' },
+];
+
+export const PRESET_IDS = THEME_PRESETS.map((p) => p.id);
+
+/** Server/editor length + range limits per v2 key (Phase 5 handoff §01). */
+export const LIMITS = {
+  wordmark: 40, headline: 80, subheadline: 150, story: 1200, emphasis: 160,
+  heroCtaLabel: 40, submitLabel: 40, advertiserName: 60, regulatory: 1000,
+  brand: 80, terms: 10000, dropTitle: 40, dropValue: 12, dropEmoji: 8,
+  mkTitle: 120, mkValue: 80, mkAlt: 120, mkNote: 400, quizIntroH: 80,
+  quizIntroS: 160, quizStart: 40, qPrompt: 140, qOption: 80, pTitle: 40,
+  pDesc: 400, pCta: 40, pAngle: 80,
+  mediaAlt: 120, formWidthMin: 300, formWidthMax: 600, trustLine: 80,
+};
+
+/** v2 field ids (array order = render order) and the v1 long-id mapping. */
+export const FIELD_IDS = ['name', 'email', 'phone', 'dob', 'postal', 'education', 'salary'];
+export const LOCKED_FIELD_IDS = ['name', 'email', 'phone'];
+export const V1_TO_V2_FIELD_ID = {
+  name: 'name', email: 'email', phone: 'phone', dob: 'dob',
+  postal_code: 'postal', education_level: 'education', monthly_income: 'salary',
+};
+export const V2_TO_V1_FIELD_ID = Object.fromEntries(
+  Object.entries(V1_TO_V2_FIELD_ID).map(([v1, v2]) => [v2, v1])
+);
+/** v1 default flat order (CampaignSignupForm's fallback when fieldOrder absent). */
+const V1_DEFAULT_ORDER = ['name', 'phone', 'email', 'dob', 'postal_code', 'education_level', 'monthly_income'];
+
+export function defaultFields() {
+  return [
+    { id: 'name', visible: true, required: true, row: null },
+    { id: 'email', visible: true, required: true, row: null },
+    { id: 'phone', visible: true, required: true, row: null },
+    { id: 'dob', visible: true, required: false, row: null },
+    { id: 'postal', visible: true, required: false, row: null },
+    { id: 'education', visible: false, required: false, row: null },
+    { id: 'salary', visible: false, required: false, row: null },
+  ];
+}
+
+/** v1 flat marketplace key ↔ v2 distribution.marketplace key map. */
+export const MARKETPLACE_V1_TO_V2 = {
+  name: 'title', category: 'category', offer_type: 'offerType', mode: 'mode',
+  qr_entry: 'qrLanding', school_levels: 'schoolLevels', dsa_related: 'dsaRelated',
+  showCapacity: 'showCapacity', inclusions: 'inclusions', image_label: 'imageAlt',
+  value_line: 'valueLine',
+};
+
+/** v1 keys CONSUMED by the migration (mapped into v2 structure). Everything
+ * else — quiz, guidedReview, luckyDraw, dead style keys, unknown/future keys —
+ * passes through verbatim (ledger L5). Also the scrub list for the v2 clamp:
+ * none of these may ride along at the top level of a v2 document. */
+export const V1_CONSUMED_KEYS = [
+  'formHeadline', 'formSubheadline', 'brandWordmark', 'storyText', 'storyEmphasis',
+  'heroCtaLabel', 'ctaText', 'regulatoryFooter', 'brandFooter',
+  'imageUrl', 'videoUrl', 'mediaType', 'themeColor', 'heroFont', 'formWidth',
+  'termsContent', 'customerHost', 'otpChannel',
+  'sgPrOnly', 'excludeAdvisors', 'dncCheckAtSubmit',
+  'visibleFields', 'requiredFields', 'fieldOrder',
+  'featuredDrop', 'marketplaceListed',
+  'name', 'category', 'offer_type', 'mode', 'qr_entry', 'age_range',
+  'school_levels', 'dsa_related', 'showCapacity', 'availability', 'inclusions',
+  'image_label', 'activation', 'sponsor', 'value_line', 'content_blocks',
+];
+
+/** Top-level v2 schema keys (used by downgrade + the clamp's alias scrub). */
+export const V2_TOP_KEYS = ['version', 'template', 'theme', 'content', 'form', 'distribution', 'ai'];
+
+// ───────────────────────── helpers (dependency-free) ─────────────────────────
+
+const isPlainObject = (v) => !!v && typeof v === 'object' && !Array.isArray(v);
+const clone = (v) => (v === undefined ? v : JSON.parse(JSON.stringify(v)));
+
+/** WCAG relative luminance — verbatim math of src/lib/contrast.js (production). */
+function luminance(hex) {
+  if (typeof hex !== 'string') return null;
+  let h = hex.replace('#', '').trim();
+  if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+  if (!/^[0-9a-fA-F]{6}$/.test(h)) return null;
+  const lin = (i) => {
+    const c = parseInt(h.slice(i, i + 2), 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * lin(0) + 0.7152 * lin(2) + 0.0722 * lin(4);
+}
+const contrastRatio = (l1, l2) => (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+
+/** Production readableTextOn parity (white floor 3, warm-ink dark, light on invalid). */
+export function onColor(bgHex, dark = '#3D1F0B', light = '#ffffff') {
+  const bg = luminance(bgHex);
+  if (bg == null) return light;
+  return contrastRatio(bg, luminance(light) ?? 1) >= 3 ? light : dark;
+}
+
+/** YouTube id extraction — EXACTLY production's three 11-char forms
+ * (LeadCaptureLayout.getYouTubeEmbedUrl); shorts/loose forms stay 'video'. */
+export function youTubeIdFrom(url) {
+  if (typeof url !== 'string' || !url) return null;
+  const patterns = [
+    /(?:youtube\.com\/watch\?v=)([a-zA-Z0-9_-]{11})/,
+    /(?:youtu\.be\/)([a-zA-Z0-9_-]{11})/,
+    /(?:youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/,
+  ];
+  for (const re of patterns) {
+    const m = url.match(re);
+    if (m) return m[1];
+  }
+  return null;
+}
+
+// ─────────────────────── version classification ───────────────────────
+
+/** 'legacy' (no version field / not an object) · 'v2' (version === 2) ·
+ * 'unsupported' (any other version value, incl. version 3 and '2'). */
+export function classifyDesignConfigVersion(doc) {
+  if (!isPlainObject(doc)) return 'legacy';
+  if (!('version' in doc)) return 'legacy';
+  return doc.version === DESIGN_CONFIG_VERSION ? 'v2' : 'unsupported';
+}
+
+export const isV2 = (doc) => classifyDesignConfigVersion(doc) === 'v2';
+
+// ───────────────────────── field model migration ─────────────────────────
+
+/** Required-flag canonicalization (ledger L1). */
+function canonicalRequired(v1Value) {
+  if (v1Value === false || v1Value === 'optional') return false;
+  if (v1Value === undefined || v1Value === null) return false;
+  return Boolean(v1Value);
+}
+
+/** v1 {visibleFields, requiredFields, fieldOrder} → canonical v2 fields[7]. */
+export function fieldsFromV1(visibleFields = {}, requiredFields = {}, fieldOrder = undefined) {
+  const rawEntries = Array.isArray(fieldOrder) && fieldOrder.length > 0 ? fieldOrder : V1_DEFAULT_ORDER;
+  const seen = new Set();
+  const ordered = [];
+  rawEntries.forEach((entry, index) => {
+    const columns = typeof entry === 'string'
+      ? [entry]
+      : isPlainObject(entry) && Array.isArray(entry.columns) ? entry.columns : [];
+    const rowId = isPlainObject(entry) && typeof entry.id === 'string' && entry.id
+      ? entry.id : `row-${index}`;
+    const valid = columns
+      .map((c) => V1_TO_V2_FIELD_ID[c])
+      .filter((id) => id && !seen.has(id));
+    valid.forEach((id) => {
+      seen.add(id);
+      // A row only pairs fields when ≥2 of its columns survived (ledger L3).
+      ordered.push({ id, row: valid.length >= 2 ? rowId : null });
+    });
+  });
+  for (const id of V1_DEFAULT_ORDER.map((k) => V1_TO_V2_FIELD_ID[k])) {
+    if (!seen.has(id)) ordered.push({ id, row: null });
+  }
+  return ordered.map(({ id, row }) => {
+    const v1Id = V2_TO_V1_FIELD_ID[id];
+    if (LOCKED_FIELD_IDS.includes(id)) return { id, visible: true, required: true, row };
+    const visible = (id === 'education' || id === 'salary')
+      ? visibleFields[v1Id] === true // opt-in fields (ledger L2)
+      : visibleFields[v1Id] !== false; // opt-out fields (dob/postal)
+    return { id, visible, required: canonicalRequired(requiredFields[v1Id]), row };
+  });
+}
+
+/** Canonical v2 fields[] → v1 {visibleFields, requiredFields, fieldOrder}. */
+export function fieldsToV1(fields) {
+  const list = Array.isArray(fields) && fields.length ? fields : defaultFields();
+  const visibleFields = { phone: true };
+  const requiredFields = {};
+  for (const f of list) {
+    if (LOCKED_FIELD_IDS.includes(f.id)) continue;
+    const v1Id = V2_TO_V1_FIELD_ID[f.id];
+    if (!v1Id) continue;
+    visibleFields[v1Id] = f.visible === true;
+    requiredFields[v1Id] = f.required === true;
+  }
+  const fieldOrder = [];
+  for (let i = 0; i < list.length; i += 1) {
+    const f = list[i];
+    const v1Id = V2_TO_V1_FIELD_ID[f.id];
+    if (!v1Id) continue;
+    if (f.row && i + 1 < list.length && list[i + 1].row === f.row) {
+      const partner = list[i + 1];
+      fieldOrder.push({ id: f.row, columns: [v1Id, V2_TO_V1_FIELD_ID[partner.id]] });
+      i += 1;
+    } else {
+      fieldOrder.push({ id: f.row || `row-${v1Id}`, columns: [v1Id] });
+    }
+  }
+  return { visibleFields, requiredFields, fieldOrder };
+}
+
+// ───────────────────────── theme migration helpers ─────────────────────────
+
+function hexToRgb(hex) {
+  if (typeof hex !== 'string') return null;
+  let h = hex.replace('#', '').trim();
+  if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+  if (!/^[0-9a-fA-F]{6}$/.test(h)) return null;
+  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
+}
+
+/** Nearest preset by accent RGB distance; invalid/absent hex → warm-cream. */
+export function nearestPresetForAccent(hex) {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return 'warm-cream';
+  let best = THEME_PRESETS[0];
+  let bestDist = Infinity;
+  for (const p of THEME_PRESETS) {
+    const prgb = hexToRgb(p.accent);
+    const d = (rgb[0] - prgb[0]) ** 2 + (rgb[1] - prgb[1]) ** 2 + (rgb[2] - prgb[2]) ** 2;
+    if (d < bestDist) { bestDist = d; best = p; }
+  }
+  return best.id;
+}
+
+// ───────────────────────── marketplace migration ─────────────────────────
+
+function marketplaceFromV1(dc) {
+  const out = {};
+  for (const [v1Key, v2Key] of Object.entries(MARKETPLACE_V1_TO_V2)) {
+    if (dc[v1Key] !== undefined) out[v2Key] = clone(dc[v1Key]);
+  }
+  if (isPlainObject(dc.age_range)) {
+    if (dc.age_range.min !== undefined) out.audienceAgeMin = dc.age_range.min;
+    if (dc.age_range.max !== undefined) out.audienceAgeMax = dc.age_range.max;
+  }
+  if (isPlainObject(dc.availability)) {
+    if (dc.availability.days !== undefined) out.days = clone(dc.availability.days);
+    if (dc.availability.slots !== undefined) out.slots = clone(dc.availability.slots);
+  }
+  if (isPlainObject(dc.activation)) {
+    const { duration_mins: durationMins, ...rest } = dc.activation;
+    out.activation = { ...clone(rest), ...(durationMins !== undefined ? { durationMins } : {}) };
+  }
+  if (dc.sponsor === null) out.sponsor = null; // explicitly-cleared sponsor is a distinct v1 state
+  else if (isPlainObject(dc.sponsor)) out.sponsor = { disclosed: true, ...clone(dc.sponsor) };
+  if (isPlainObject(dc.content_blocks)) {
+    if (dc.content_blocks.data_use !== undefined) out.dataUse = dc.content_blocks.data_use;
+    if (dc.content_blocks.cancellation !== undefined) out.cancellation = dc.content_blocks.cancellation;
+    if (dc.content_blocks.faq !== undefined) out.faq = clone(dc.content_blocks.faq);
+  }
+  if (dc.marketplaceListed !== undefined) out.listed = dc.marketplaceListed === true;
+  return Object.keys(out).length ? out : undefined;
+}
+
+export function marketplaceToV1(mk) {
+  if (!isPlainObject(mk)) return {};
+  const out = {};
+  for (const [v1Key, v2Key] of Object.entries(MARKETPLACE_V1_TO_V2)) {
+    if (mk[v2Key] !== undefined) out[v1Key] = clone(mk[v2Key]);
+  }
+  if (mk.audienceAgeMin !== undefined || mk.audienceAgeMax !== undefined) {
+    out.age_range = {
+      ...(mk.audienceAgeMin !== undefined ? { min: mk.audienceAgeMin } : {}),
+      ...(mk.audienceAgeMax !== undefined ? { max: mk.audienceAgeMax } : {}),
+    };
+  }
+  if (mk.days !== undefined || mk.slots !== undefined) {
+    out.availability = {
+      ...(mk.days !== undefined ? { days: clone(mk.days) } : {}),
+      ...(mk.slots !== undefined ? { slots: clone(mk.slots) } : {}),
+    };
+  }
+  if (isPlainObject(mk.activation)) {
+    const { durationMins, ...rest } = mk.activation;
+    out.activation = { ...clone(rest), ...(durationMins !== undefined ? { duration_mins: durationMins } : {}) };
+  }
+  if (mk.sponsor === null) out.sponsor = null;
+  else if (isPlainObject(mk.sponsor)) {
+    const { disclosed, ...rest } = mk.sponsor;
+    if (disclosed === true || Object.keys(rest).length) out.sponsor = clone(rest);
+  }
+  if (mk.dataUse !== undefined || mk.cancellation !== undefined || mk.faq !== undefined) {
+    out.content_blocks = {
+      ...(mk.dataUse !== undefined ? { data_use: mk.dataUse } : {}),
+      ...(mk.cancellation !== undefined ? { cancellation: mk.cancellation } : {}),
+      ...(mk.faq !== undefined ? { faq: clone(mk.faq) } : {}),
+    };
+  }
+  if (mk.listed !== undefined) out.marketplaceListed = mk.listed === true;
+  return out;
+}
+
+// ───────────────────────────── upgrade (v1 → v2) ─────────────────────────────
+
+/**
+ * Pure, idempotent, NON-CLAMPING v1→v2 migration. Values are preserved
+ * verbatim (over-limit copy, invalid hex, out-of-range widths survive — the
+ * SAVE clamp normalizes, exactly as it does for v1 today). Throws on
+ * unsupported versions.
+ */
+export function upgradeDesignConfig(doc) {
+  const version = classifyDesignConfigVersion(doc);
+  if (version === 'v2') return clone(doc);
+  if (version === 'unsupported') {
+    throw new Error(`Unsupported design_config version: ${JSON.stringify(doc?.version)}`);
+  }
+  const dc = isPlainObject(doc) ? doc : {};
+  const out = { version: DESIGN_CONFIG_VERSION };
+
+  // template — params bag seeded; editorial.formWidth copied only when stored.
+  const params = clone(TEMPLATE_PARAM_DEFAULTS);
+  delete params.editorial.formWidth;
+  if (dc.formWidth !== undefined) params.editorial.formWidth = clone(dc.formWidth);
+  out.template = { id: 'editorial', params };
+
+  // theme — verbatim values; preset by nearest accent distance.
+  out.theme = {
+    preset: nearestPresetForAccent(dc.themeColor),
+    accent: dc.themeColor !== undefined ? clone(dc.themeColor) : null,
+    ...(dc.heroFont !== undefined ? { font: clone(dc.heroFont) } : {}),
+  };
+
+  // content — slots mapped only when present (no default-stuffing).
+  const content = {};
+  const slot = (v1Key, v2Key) => {
+    if (dc[v1Key] !== undefined) content[v2Key] = clone(dc[v1Key]);
+  };
+  slot('brandWordmark', 'wordmark');
+  slot('formHeadline', 'headline');
+  slot('formSubheadline', 'subheadline');
+  slot('storyText', 'story');
+  slot('storyEmphasis', 'emphasis');
+  slot('heroCtaLabel', 'heroCtaLabel');
+  slot('ctaText', 'submitLabel');
+  const footer = {};
+  if (dc.regulatoryFooter !== undefined) footer.regulatory = clone(dc.regulatoryFooter);
+  if (dc.brandFooter !== undefined) footer.brand = clone(dc.brandFooter);
+  if (Object.keys(footer).length) content.footer = footer;
+  // media — kind per the renderer's own selection rules (ledger L4), inactive
+  // URLs preserved in the internal legacy shadow for exact downgrade.
+  const mediaType = dc.mediaType || (dc.imageUrl ? 'image' : 'none');
+  let kind = 'none';
+  if (mediaType === 'image') kind = 'image';
+  else if (mediaType === 'video') kind = youTubeIdFrom(dc.videoUrl) ? 'youtube' : 'video';
+  const src = kind === 'image' ? (dc.imageUrl || '') : kind === 'none' ? '' : (dc.videoUrl || '');
+  const legacy = {};
+  if (dc.imageUrl !== undefined) legacy.imageUrl = clone(dc.imageUrl);
+  if (dc.videoUrl !== undefined) legacy.videoUrl = clone(dc.videoUrl);
+  content.media = { kind, src, alt: '', ...(Object.keys(legacy).length ? { legacy } : {}) };
+  out.content = content;
+
+  // form
+  out.form = {
+    fields: fieldsFromV1(dc.visibleFields || {}, dc.requiredFields || {}, dc.fieldOrder),
+    verification: dc.otpChannel === 'whatsapp' ? 'whatsapp' : 'sms',
+    gates: {
+      sgPr: dc.sgPrOnly === true,
+      advisorExclusion: dc.excludeAdvisors === true,
+      dncCheck: dc.dncCheckAtSubmit === true,
+    },
+    ...(dc.termsContent !== undefined
+      ? { terms: { template: 'default', html: clone(dc.termsContent) } }
+      : {}),
+  };
+
+  // distribution (+ derived legacy customerHost mirror at top level)
+  const host = dc.customerHost === 'mktr' ? 'mktr' : 'redeem';
+  const marketplace = marketplaceFromV1(dc);
+  out.distribution = {
+    host,
+    ...(dc.featuredDrop !== undefined ? { featuredDrop: clone(dc.featuredDrop) } : {}),
+    ...(marketplace !== undefined ? { marketplace } : {}),
+  };
+  out.customerHost = host;
+
+  // verbatim passthrough: everything the migration did not consume (ledger L5).
+  for (const [key, value] of Object.entries(dc)) {
+    if (key === 'customerHost') continue; // rewritten as the derived mirror above
+    if (V1_CONSUMED_KEYS.includes(key)) continue;
+    out[key] = clone(value);
+  }
+  return out;
+}
+
+// ───────────────────────────── downgrade (v2 → v1) ─────────────────────────────
+
+/**
+ * Pure inverse over the render contract: a downgraded Editorial + Warm Cream
+ * doc drives the v1 renderer identically. PROPOSED/v2-only keys (template,
+ * theme extras, advertiserName, ai, media.alt) drop. Also the legacy-view
+ * adapter for backend readers during the cutover (PR 2/3).
+ */
+export function downgradeDesignConfig(doc) {
+  const version = classifyDesignConfigVersion(doc);
+  if (version === 'legacy') return clone(isPlainObject(doc) ? doc : {});
+  if (version === 'unsupported') {
+    throw new Error(`Unsupported design_config version: ${JSON.stringify(doc?.version)}`);
+  }
+  const out = {};
+
+  // passthrough first (quiz / guidedReview / luckyDraw / unknown top-level).
+  for (const [key, value] of Object.entries(doc)) {
+    if (V2_TOP_KEYS.includes(key) || key === 'customerHost') continue;
+    out[key] = clone(value);
+  }
+
+  const content = isPlainObject(doc.content) ? doc.content : {};
+  const back = (v2Key, v1Key) => {
+    if (content[v2Key] !== undefined) out[v1Key] = clone(content[v2Key]);
+  };
+  back('wordmark', 'brandWordmark');
+  back('headline', 'formHeadline');
+  back('subheadline', 'formSubheadline');
+  back('story', 'storyText');
+  back('emphasis', 'storyEmphasis');
+  back('heroCtaLabel', 'heroCtaLabel');
+  back('submitLabel', 'ctaText');
+  if (isPlainObject(content.footer)) {
+    if (content.footer.regulatory !== undefined) out.regulatoryFooter = clone(content.footer.regulatory);
+    if (content.footer.brand !== undefined) out.brandFooter = clone(content.footer.brand);
+  }
+  const media = isPlainObject(content.media) ? content.media : { kind: 'none', src: '' };
+  out.mediaType = media.kind === 'youtube' ? 'video' : (media.kind || 'none');
+  const legacy = isPlainObject(media.legacy) ? media.legacy : {};
+  if (legacy.imageUrl !== undefined) out.imageUrl = clone(legacy.imageUrl);
+  else if (media.kind === 'image' && media.src) out.imageUrl = clone(media.src);
+  if (legacy.videoUrl !== undefined) out.videoUrl = clone(legacy.videoUrl);
+  else if ((media.kind === 'video' || media.kind === 'youtube') && media.src) out.videoUrl = clone(media.src);
+
+  const theme = isPlainObject(doc.theme) ? doc.theme : {};
+  const preset = THEME_PRESETS.find((p) => p.id === theme.preset) || THEME_PRESETS[0];
+  if (theme.accent !== undefined && theme.accent !== null) out.themeColor = clone(theme.accent);
+  // A null accent means "the preset's own accent". For warm-cream that IS the
+  // v1 renderer's absent-themeColor default, so omitting the key round-trips
+  // exactly; other presets (Studio-authored, no v1 counterpart) bake theirs so
+  // the v1 renderer shows the right color.
+  else if (preset.id !== 'warm-cream') out.themeColor = preset.accent;
+  if (theme.font !== undefined) out.heroFont = clone(theme.font);
+
+  const editorialParams = doc.template?.params?.editorial;
+  if (isPlainObject(editorialParams) && editorialParams.formWidth !== undefined) {
+    out.formWidth = clone(editorialParams.formWidth);
+  }
+
+  const form = isPlainObject(doc.form) ? doc.form : {};
+  const v1Fields = fieldsToV1(form.fields);
+  out.visibleFields = v1Fields.visibleFields;
+  out.requiredFields = v1Fields.requiredFields;
+  out.fieldOrder = v1Fields.fieldOrder;
+  out.otpChannel = form.verification === 'whatsapp' ? 'whatsapp' : 'sms';
+  const gates = isPlainObject(form.gates) ? form.gates : {};
+  out.sgPrOnly = gates.sgPr === true;
+  out.excludeAdvisors = gates.advisorExclusion === true;
+  out.dncCheckAtSubmit = gates.dncCheck === true;
+  if (isPlainObject(form.terms) && form.terms.html !== undefined) out.termsContent = clone(form.terms.html);
+
+  const distribution = isPlainObject(doc.distribution) ? doc.distribution : {};
+  out.customerHost = distribution.host === 'mktr' ? 'mktr' : 'redeem';
+  if (distribution.featuredDrop !== undefined) out.featuredDrop = clone(distribution.featuredDrop);
+  Object.assign(out, marketplaceToV1(distribution.marketplace));
+
+  return out;
+}
+
+/** Backend-reader adapter: any-version doc → the v1 shape readers understand. */
+export const readLegacyView = downgradeDesignConfig;
+
+// ───────────────────────────── theme resolution ─────────────────────────────
+
+/**
+ * Resolve a v2 theme block to concrete tokens (studio-data reference
+ * implementation; onAccent via the production contrast helper). Preset-exact
+ * `rx` radii win while theme.radius is untouched or equals the preset's own.
+ */
+export function resolveTheme(theme = {}) {
+  const p = THEME_PRESETS.find((x) => x.id === theme.preset) || THEME_PRESETS[0];
+  const accent = theme.accent || p.accent;
+  const fontId = FONT_IDS.includes(theme.font) ? theme.font : p.font;
+  let r = RADII[theme.radius || p.radius] || RADII.soft;
+  if (p.rx && (!theme.radius || theme.radius === p.radius)) r = p.rx;
+  return {
+    ...p,
+    accent,
+    onAccent: onColor(accent),
+    fontId,
+    r,
+    storyCard: p.storyCard || p.card,
+    modal: p.modal || p.card,
+    bodyText: p.bodyText || p.ink,
+    divider: p.divider || p.hairline || (p.dark ? 'rgba(255,255,255,.2)' : 'rgba(0,0,0,.16)'),
+    accentDeep: p.accentDeep || accent,
+    danger: p.danger || '#B4443C',
+    success: p.success || '#2F6B43',
+    line: p.hairline || (p.dark ? 'rgba(255,255,255,.14)' : 'rgba(0,0,0,.1)'),
+    soft: p.dark ? 'rgba(255,255,255,.07)' : 'rgba(0,0,0,.045)',
+    bgCss: theme.background === 'wash'
+      ? `linear-gradient(180deg, ${accent}18, ${p.bg} 320px)`
+      : theme.background === 'grain'
+        ? `repeating-linear-gradient(45deg, ${p.dark ? 'rgba(255,255,255,.02)' : 'rgba(0,0,0,.015)'} 0 2px, transparent 2px 4px)`
+        : 'none',
+  };
+}

--- a/backend/src/utils/designConfigV2Clamp.js
+++ b/backend/src/utils/designConfigV2Clamp.js
@@ -1,0 +1,348 @@
+/**
+ * design_config v2 — SERVER-ONLY clamping, write-gating, and cross-version
+ * stored-state accessors. Backend-only by design (never mirrored to src/lib):
+ * the shared schema/migration surface lives in ./designConfigV2.js (the twin);
+ * this module is the policy layer campaignService applies on the save path.
+ *
+ * WRITE GATE: v2 documents are NOT accepted for persistence until
+ * `DESIGN_CONFIG_V2_WRITES_ENABLED === 'true'` (default OFF — the Campaign
+ * Studio revamp lands dark; the flag flips only after PR 2/3 make every
+ * design_config reader version-aware). While the flag is off, campaignService
+ * rejects ANY version-tagged document with a typed 422, so no v2 doc can exist
+ * in the database and every live reader keeps seeing pure v1 shapes.
+ *
+ * ALIAS SCRUB: a v2 document may not carry known v1 keys at the top level.
+ * Existing readers (featuredDropsService homepage, marketplaceService gate)
+ * trust top-level `featuredDrop` / `marketplaceListed`, and campaign PUT/POST
+ * are open to agents — without the scrub, a hybrid `{version:2, featuredDrop:
+ * {enabled:true}}` payload would bypass the admin-only publication policy.
+ * Exceptions: `customerHost` (derived mirror, always rewritten from the
+ * clamped distribution.host) and `luckyDraw` (top-level in both versions,
+ * admin-policy-gated). Unknown non-v1 top-level keys pass through (forward
+ * compatibility); unknown NESTED children inside the v2 schema subtrees are
+ * stripped (the public whitelist and future readers must never meet
+ * unvetted nested state).
+ */
+
+import {
+  classifyDesignConfigVersion,
+  defaultFields,
+  FIELD_IDS,
+  FONT_IDS,
+  LIMITS,
+  LOCKED_FIELD_IDS,
+  MARKETPLACE_V1_TO_V2,
+  marketplaceToV1,
+  PRESET_IDS,
+  TEMPLATE_IDS,
+  TEMPLATE_PARAM_DEFAULTS,
+  THEME_BACKGROUNDS,
+  THEME_PRESETS,
+  THEME_RADIUS_IDS,
+  V1_CONSUMED_KEYS,
+  V2_TOP_KEYS,
+  youTubeIdFrom,
+} from './designConfigV2.js';
+import { applyFeaturedDropPolicy } from './featuredDrop.js';
+import { applyLuckyDrawPolicy } from './luckyDraw.js';
+import { applyMarketplacePolicy, normalizeMarketplaceContent } from './marketplaceContent.js';
+import { normalizeCustomerHostChoice } from './customerHost.js';
+
+const isPlainObject = (v) => !!v && typeof v === 'object' && !Array.isArray(v);
+const clone = (v) => (v === undefined ? v : JSON.parse(JSON.stringify(v)));
+const cleanString = (v, max) => (typeof v === 'string' ? v.slice(0, max) : undefined);
+const cleanEnum = (v, allowed, fallback) => (allowed.includes(v) ? v : fallback);
+
+/** Rollout gate — read per call so tests (and a live env flip) take effect
+ * without a module reload dance. Default OFF. */
+export function designConfigV2WritesEnabled() {
+  return process.env.DESIGN_CONFIG_V2_WRITES_ENABLED === 'true';
+}
+
+export { classifyDesignConfigVersion };
+
+// ───────────────── cross-version stored-state accessors ─────────────────
+// The save path must read stored policy state from the STORED document's own
+// version — a stored-v1 → incoming-v2 transition save would otherwise look up
+// `distribution.*` on a flat doc, find nothing, and silently drop the v1
+// publication state through the non-admin preserve policy.
+
+export function getStoredFeaturedDrop(doc) {
+  if (!isPlainObject(doc)) return undefined;
+  return classifyDesignConfigVersion(doc) === 'v2' ? doc.distribution?.featuredDrop : doc.featuredDrop;
+}
+
+export function getStoredMarketplaceListed(doc) {
+  if (!isPlainObject(doc)) return undefined;
+  return classifyDesignConfigVersion(doc) === 'v2' ? doc.distribution?.marketplace?.listed : doc.marketplaceListed;
+}
+
+export function getStoredLuckyDraw(doc) {
+  // Top-level in BOTH versions (admin-API-managed, editor-invisible).
+  return isPlainObject(doc) ? doc.luckyDraw : undefined;
+}
+
+export function getStoredTermsHtml(doc) {
+  if (!isPlainObject(doc)) return '';
+  const raw = classifyDesignConfigVersion(doc) === 'v2' ? doc.form?.terms?.html : doc.termsContent;
+  return typeof raw === 'string' ? raw : '';
+}
+
+export function getStoredHostChoice(doc) {
+  if (!isPlainObject(doc)) return 'redeem';
+  const raw = classifyDesignConfigVersion(doc) === 'v2' ? doc.distribution?.host : doc.customerHost;
+  return normalizeCustomerHostChoice(raw);
+}
+
+export function getStoredAi(doc) {
+  if (!isPlainObject(doc)) return undefined;
+  return classifyDesignConfigVersion(doc) === 'v2' && isPlainObject(doc.ai) ? doc.ai : undefined;
+}
+
+// ───────────────────────── v2 subtree clamps ─────────────────────────
+
+function clampTemplate(raw) {
+  const id = cleanEnum(isPlainObject(raw) ? raw.id : undefined, TEMPLATE_IDS, 'editorial');
+  const incomingParams = isPlainObject(raw) && isPlainObject(raw.params) ? raw.params : {};
+  const params = {};
+  for (const [tpl, defaults] of Object.entries(TEMPLATE_PARAM_DEFAULTS)) {
+    const inc = isPlainObject(incomingParams[tpl]) ? incomingParams[tpl] : {};
+    const out = {};
+    for (const [key, def] of Object.entries(defaults)) {
+      const v = inc[key];
+      if (typeof def === 'boolean') out[key] = v === undefined ? def : v === true;
+      else if (typeof def === 'number') {
+        const n = Number(v);
+        out[key] = Number.isFinite(n) ? n : def;
+      } else out[key] = typeof v === 'string' ? v : def;
+    }
+    // editorial.formWidth range + express.trustLine length — the only
+    // non-enum params with server limits.
+    if (tpl === 'editorial') {
+      const n = Number(inc.formWidth);
+      if (Number.isFinite(n)) out.formWidth = Math.min(LIMITS.formWidthMax, Math.max(LIMITS.formWidthMin, Math.round(n)));
+      else delete out.formWidth; // absent stays absent (render default 480)
+    }
+    if (tpl === 'poster') out.overlay = cleanEnum(out.overlay, ['dusk', 'plain'], 'dusk');
+    if (tpl === 'split') {
+      out.mediaSide = cleanEnum(out.mediaSide, ['left', 'right'], 'left');
+      out.mediaFit = cleanEnum(out.mediaFit, ['cover', 'contain'], 'cover');
+    }
+    if (tpl === 'spotlight') {
+      out.introStyle = cleanEnum(out.introStyle, ['immersive', 'card'], 'immersive');
+      out.revealArt = cleanEnum(out.revealArt, ['meter', 'plain'], 'meter');
+    }
+    if (tpl === 'express') out.trustLine = cleanString(inc.trustLine, LIMITS.trustLine) ?? '';
+    if (tpl === 'journey') out.sectionRhythm = cleanEnum(out.sectionRhythm, ['alternate', 'stacked'], 'alternate');
+    params[tpl] = out;
+  }
+  return { id, params };
+}
+
+function clampTheme(raw, hostChoice) {
+  const t = isPlainObject(raw) ? raw : {};
+  const hostDefault = THEME_PRESETS.find((p) => p.hostDefault === hostChoice)?.id
+    || (hostChoice === 'mktr' ? 'paper-white' : 'warm-cream');
+  const preset = cleanEnum(t.preset, PRESET_IDS, hostDefault);
+  let accent = null;
+  if (typeof t.accent === 'string') {
+    let h = t.accent.trim();
+    if (/^#?[0-9a-fA-F]{6}$/.test(h)) accent = h.startsWith('#') ? h : `#${h}`;
+  }
+  return {
+    preset,
+    accent,
+    ...(FONT_IDS.includes(t.font) ? { font: t.font } : {}),
+    ...(THEME_RADIUS_IDS.includes(t.radius) ? { radius: t.radius } : {}),
+    ...(THEME_BACKGROUNDS.includes(t.background) ? { background: t.background } : {}),
+  };
+}
+
+function clampContent(raw) {
+  const c = isPlainObject(raw) ? raw : {};
+  const out = {};
+  const str = (key, max) => {
+    const v = cleanString(c[key], max);
+    if (v !== undefined) out[key] = v;
+  };
+  str('wordmark', LIMITS.wordmark);
+  str('headline', LIMITS.headline);
+  str('subheadline', LIMITS.subheadline);
+  str('story', LIMITS.story);
+  str('emphasis', LIMITS.emphasis);
+  str('heroCtaLabel', LIMITS.heroCtaLabel);
+  str('submitLabel', LIMITS.submitLabel);
+  str('advertiserName', LIMITS.advertiserName);
+  if (isPlainObject(c.footer)) {
+    const footer = {};
+    const reg = cleanString(c.footer.regulatory, LIMITS.regulatory);
+    const brand = cleanString(c.footer.brand, LIMITS.brand);
+    if (reg !== undefined) footer.regulatory = reg;
+    if (brand !== undefined) footer.brand = brand;
+    if (Object.keys(footer).length) out.footer = footer;
+  }
+  const m = isPlainObject(c.media) ? c.media : {};
+  let kind = cleanEnum(m.kind, ['none', 'image', 'video', 'youtube'], 'none');
+  const src = typeof m.src === 'string' ? m.src.slice(0, 2048) : '';
+  // A youtube kind must actually be a recognizable YouTube URL; a video kind
+  // that IS one gets reclassified — one honest classification server-side.
+  if (kind === 'youtube' && !youTubeIdFrom(src)) kind = 'video';
+  else if (kind === 'video' && youTubeIdFrom(src)) kind = 'youtube';
+  const media = { kind, src: kind === 'none' ? '' : src, alt: cleanString(m.alt, LIMITS.mediaAlt) ?? '' };
+  if (isPlainObject(m.legacy)) {
+    const legacy = {};
+    if (typeof m.legacy.imageUrl === 'string') legacy.imageUrl = m.legacy.imageUrl.slice(0, 2048);
+    if (typeof m.legacy.videoUrl === 'string') legacy.videoUrl = m.legacy.videoUrl.slice(0, 2048);
+    if (Object.keys(legacy).length) media.legacy = legacy;
+  }
+  out.media = media;
+  return out;
+}
+
+function clampFields(raw) {
+  const canonical = defaultFields();
+  if (!Array.isArray(raw)) return canonical;
+  const seen = new Set();
+  const ordered = [];
+  for (const entry of raw) {
+    if (!isPlainObject(entry) || !FIELD_IDS.includes(entry.id) || seen.has(entry.id)) continue;
+    seen.add(entry.id);
+    const locked = LOCKED_FIELD_IDS.includes(entry.id);
+    ordered.push({
+      id: entry.id,
+      visible: locked ? true : entry.visible === true,
+      required: locked ? true : entry.required === true,
+      row: typeof entry.row === 'string' && entry.row ? entry.row.slice(0, 40) : null,
+    });
+  }
+  for (const f of canonical) if (!seen.has(f.id)) ordered.push(f);
+  return ordered;
+}
+
+function clampForm(raw) {
+  const f = isPlainObject(raw) ? raw : {};
+  const gates = isPlainObject(f.gates) ? f.gates : {};
+  const out = {
+    fields: clampFields(f.fields),
+    verification: f.verification === 'whatsapp' ? 'whatsapp' : 'sms',
+    gates: {
+      sgPr: gates.sgPr === true,
+      advisorExclusion: gates.advisorExclusion === true,
+      dncCheck: gates.dncCheck === true,
+    },
+  };
+  if (isPlainObject(f.terms)) {
+    const html = cleanString(f.terms.html, LIMITS.terms);
+    if (html !== undefined) {
+      out.terms = {
+        template: cleanEnum(f.terms.template, ['default', 'privacy', 'marketing'], 'default'),
+        html,
+      };
+    }
+  }
+  return out;
+}
+
+/** v2 marketplace clamp = rename to v1 → the EXISTING validator → rename back
+ * (same rules as v1 saves, zero duplicated validation). */
+function clampMarketplace(raw) {
+  if (!isPlainObject(raw)) return undefined;
+  const v1 = marketplaceToV1(raw);
+  delete v1.marketplaceListed; // policied separately
+  const normalized = normalizeMarketplaceContent(v1);
+  const out = {};
+  for (const [v1Key, v2Key] of Object.entries(MARKETPLACE_V1_TO_V2)) {
+    if (normalized[v1Key] !== undefined) out[v2Key] = normalized[v1Key];
+  }
+  if (normalized.age_range) {
+    out.audienceAgeMin = normalized.age_range.min;
+    out.audienceAgeMax = normalized.age_range.max;
+  }
+  if (normalized.availability) {
+    if (normalized.availability.days?.length) out.days = normalized.availability.days;
+    if (normalized.availability.slots?.length) out.slots = normalized.availability.slots;
+  }
+  if (normalized.activation) {
+    const { duration_mins: durationMins, ...rest } = normalized.activation;
+    out.activation = { ...rest, ...(durationMins !== undefined ? { durationMins } : {}) };
+  }
+  if (normalized.sponsor === null) out.sponsor = null;
+  else if (normalized.sponsor) out.sponsor = { disclosed: true, ...normalized.sponsor };
+  if (normalized.content_blocks) {
+    if (normalized.content_blocks.data_use !== undefined) out.dataUse = normalized.content_blocks.data_use;
+    if (normalized.content_blocks.cancellation !== undefined) out.cancellation = normalized.content_blocks.cancellation;
+    if (normalized.content_blocks.faq !== undefined) out.faq = normalized.content_blocks.faq;
+  }
+  return Object.keys(out).length ? out : undefined;
+}
+
+// ───────────────────────── the v2 clamp ─────────────────────────
+
+/**
+ * Clamp + policy-gate an incoming v2 document against the stored one (either
+ * version). Mirrors the v1 clamp's contract: lengths/enums normalized,
+ * admin-only subtrees preserved on non-admin saves, unknown top-level keys
+ * preserved, known v1 aliases scrubbed, customerHost mirror derived.
+ */
+export function clampDesignConfigV2(incoming, storedConfig, role) {
+  const dc = isPlainObject(incoming) ? incoming : {};
+  const distributionIn = isPlainObject(dc.distribution) ? dc.distribution : {};
+  const host = normalizeCustomerHostChoice(distributionIn.host);
+
+  const out = {
+    version: 2,
+    template: clampTemplate(dc.template),
+    theme: clampTheme(dc.theme, host),
+    content: clampContent(dc.content),
+    form: clampForm(dc.form),
+  };
+
+  // quiz / guidedReview — verbatim passthrough (documented v1-parity exceptions).
+  if (dc.quiz !== undefined) out.quiz = clone(dc.quiz);
+  if (dc.guidedReview !== undefined) out.guidedReview = clone(dc.guidedReview);
+
+  // Admin-gated subtrees, stored state read from the stored doc's OWN version.
+  const featuredDrop = applyFeaturedDropPolicy({
+    incoming: distributionIn.featuredDrop,
+    stored: getStoredFeaturedDrop(storedConfig),
+    role,
+  });
+  const listed = applyMarketplacePolicy({
+    incoming: isPlainObject(distributionIn.marketplace) ? distributionIn.marketplace.listed : undefined,
+    stored: getStoredMarketplaceListed(storedConfig),
+    role,
+  });
+  const luckyDraw = applyLuckyDrawPolicy({
+    incoming: dc.luckyDraw,
+    stored: getStoredLuckyDraw(storedConfig),
+    role,
+  });
+  const marketplace = clampMarketplace(distributionIn.marketplace);
+
+  out.distribution = {
+    host,
+    ...(featuredDrop !== undefined ? { featuredDrop } : {}),
+    ...(marketplace !== undefined || listed !== undefined
+      ? { marketplace: { ...(marketplace || {}), ...(listed !== undefined ? { listed } : {}) } }
+      : {}),
+  };
+  if (luckyDraw !== undefined) out.luckyDraw = luckyDraw;
+
+  // ai — Studio-internal subtree: admins write it, non-admin saves preserve it.
+  const ai = role === 'admin'
+    ? (isPlainObject(dc.ai) ? clone(dc.ai) : undefined)
+    : getStoredAi(storedConfig);
+  if (ai !== undefined) out.ai = ai;
+
+  // Derived legacy mirror — ALWAYS from the clamped host, never from incoming.
+  out.customerHost = host;
+
+  // Unknown top-level passthrough with the v1-alias scrub.
+  for (const [key, value] of Object.entries(dc)) {
+    if (V2_TOP_KEYS.includes(key)) continue;
+    if (key === 'customerHost' || key === 'luckyDraw' || key === 'quiz' || key === 'guidedReview') continue;
+    if (V1_CONSUMED_KEYS.includes(key)) continue; // the scrub — no smuggled aliases
+    out[key] = clone(value);
+  }
+  return out;
+}

--- a/backend/src/utils/publicDesignConfig.js
+++ b/backend/src/utils/publicDesignConfig.js
@@ -15,6 +15,7 @@
  */
 
 import { normalizeLuckyDraw } from './luckyDraw.js';
+import { classifyDesignConfigVersion, TEMPLATE_PARAM_DEFAULTS } from './designConfigV2.js';
 
 const PUBLIC_PASSTHROUGH_KEYS = [
   // Lead-capture page chrome + copy (mediaType drives the none/image/video
@@ -49,9 +50,90 @@ export function publicLuckyDraw(raw) {
   };
 }
 
-/** Rebuild a public-safe design_config from a raw stored one. */
+// ── design_config v2 (Campaign Studio) public whitelist ──
+// Same rebuild-never-dump invariant as v1, applied at LEAF level: every public
+// subtree is reassembled from known keys so an unknown/internal nested child
+// (a future form.internalNote, media.legacy, ai.*) can never leak by default.
+// quiz + guidedReview are the two documented WHOLESALE exceptions — v1 already
+// exposes them whole and the funnel renders from them; hardening their internals
+// is tracked separately.
+const pick = (src, keys) => {
+  if (!src || typeof src !== 'object') return undefined;
+  const out = {};
+  for (const key of keys) {
+    if (src[key] !== undefined) out[key] = src[key];
+  }
+  return Object.keys(out).length ? out : undefined;
+};
+
+const V2_PUBLIC_MARKETPLACE_KEYS = [
+  'title', 'category', 'offerType', 'mode', 'imageAlt', 'valueLine', 'inclusions',
+  'showCapacity', 'audienceAgeMin', 'audienceAgeMax', 'schoolLevels', 'dsaRelated',
+  'days', 'slots', 'activation', 'sponsor', 'dataUse', 'cancellation', 'faq',
+  'qrLanding', 'endsAt',
+  // NOT 'listed' — publication state stays internal, like v1's marketplaceListed.
+];
+
+function buildPublicDesignConfigV2(dc) {
+  const out = { version: 2 };
+
+  const template = {};
+  if (dc.template?.id !== undefined) template.id = dc.template.id;
+  const paramsIn = dc.template?.params;
+  const params = {};
+  for (const [tpl, defaults] of Object.entries(TEMPLATE_PARAM_DEFAULTS)) {
+    const p = pick(paramsIn?.[tpl], Object.keys(defaults));
+    if (p) params[tpl] = p;
+  }
+  if (Object.keys(params).length) template.params = params;
+  if (Object.keys(template).length) out.template = template;
+
+  const theme = pick(dc.theme, ['preset', 'accent', 'font', 'radius', 'background']);
+  if (theme) out.theme = theme;
+
+  const content = pick(dc.content, [
+    'wordmark', 'headline', 'subheadline', 'story', 'emphasis',
+    'heroCtaLabel', 'submitLabel', 'advertiserName',
+  ]) || {};
+  const footer = pick(dc.content?.footer, ['regulatory', 'brand']);
+  if (footer) content.footer = footer;
+  // media WITHOUT the internal legacy shadow (v1-URL bookkeeping for downgrade).
+  const media = pick(dc.content?.media, ['kind', 'src', 'alt']);
+  if (media) content.media = media;
+  if (Object.keys(content).length) out.content = content;
+
+  const form = pick(dc.form, ['verification']) || {};
+  if (Array.isArray(dc.form?.fields)) {
+    form.fields = dc.form.fields
+      .filter((f) => f && typeof f === 'object')
+      .map((f) => pick(f, ['id', 'visible', 'required', 'row']) || {});
+  }
+  const gates = pick(dc.form?.gates, ['sgPr', 'advisorExclusion', 'dncCheck']);
+  if (gates) form.gates = gates;
+  const terms = pick(dc.form?.terms, ['template', 'html']);
+  if (terms) form.terms = terms;
+  if (Object.keys(form).length) out.form = form;
+
+  if (dc.quiz !== undefined) out.quiz = dc.quiz;
+  if (dc.guidedReview !== undefined) out.guidedReview = dc.guidedReview;
+
+  const distribution = { host: dc.distribution?.host === 'mktr' ? 'mktr' : 'redeem' };
+  const marketplace = pick(dc.distribution?.marketplace, V2_PUBLIC_MARKETPLACE_KEYS);
+  if (marketplace) distribution.marketplace = marketplace;
+  // featuredDrop stays internal here (v1 parity — the homepage service builds
+  // its own DTO from the stored doc).
+  out.distribution = distribution;
+  out.customerHost = distribution.host; // legacy mirror for v1-era readers
+
+  const ld = publicLuckyDraw(dc.luckyDraw);
+  if (ld) out.luckyDraw = ld;
+  return out;
+}
+
+/** Rebuild a public-safe design_config from a raw stored one (version-aware). */
 export function buildPublicDesignConfig(raw) {
   const dc = raw && typeof raw === 'object' ? raw : {};
+  if (classifyDesignConfigVersion(dc) === 'v2') return buildPublicDesignConfigV2(dc);
   const out = {};
   for (const key of PUBLIC_PASSTHROUGH_KEYS) {
     if (dc[key] !== undefined) out[key] = dc[key];

--- a/backend/test/designConfigV1Golden.test.js
+++ b/backend/test/designConfigV1Golden.test.js
@@ -1,0 +1,107 @@
+/**
+ * v1 clamp GOLDEN regression — proves design_config v2 work never changes what
+ * the save path does to UNTAGGED (v1) documents.
+ *
+ * The oracle artifact (test-fixtures/designConfigV1ClampOracle.json) was
+ * captured from the PRE-v2 base commit 7b5f0dd by running THIS file with
+ * CAPTURE_ORACLE=1 before any v2 code existed (see the artifact's provenance
+ * header). Normal runs assert structural equality against it, so any
+ * behavioral drift in clampDesignConfig / buildPublicDesignConfig for v1 docs
+ * fails here. If v1 behavior must ever change deliberately, re-capture and
+ * commit the new artifact in the same PR with the reason.
+ */
+import { jest } from '@jest/globals';
+import './setup.js';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+// Inert module mocks so importing campaignService never touches models/db —
+// same seam set as test/unit/campaignService.test.js. The functions under test
+// (clampDesignConfig / buildPublicDesignConfig) are pure and use none of them.
+import { Op } from 'sequelize';
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  Campaign: {}, QrTag: {}, Prospect: {}, Commission: {}, Device: {},
+  CampaignMediaItem: {}, CampaignAgentAssignment: {},
+  sequelize: { transaction: jest.fn() },
+  DrawTermsVersion: {
+    findOne: async () => null,
+    max: async () => null,
+    create: async (fields) => ({ id: 'dtv-mock', ...fields }),
+  },
+  Op,
+}));
+jest.unstable_mockModule('../src/middleware/tenant.js', () => ({
+  getTenantId: jest.fn(),
+}));
+jest.unstable_mockModule('../src/services/storage.js', () => ({
+  storageService: {},
+}));
+jest.unstable_mockModule('../src/services/pushService.js', () => ({
+  pushService: { sendEvent: jest.fn() },
+}));
+jest.unstable_mockModule('../src/services/walletService.js', () => ({
+  refundCampaignCommitments: jest.fn(async () => ({ refunded: 0, totalCents: 0 })),
+}));
+
+const { clampDesignConfig } = await import('../src/services/campaignService.js');
+const { buildPublicDesignConfig } = await import('../src/utils/publicDesignConfig.js');
+const { V1_DOCS, adminRichDoc } = await import('../../test-fixtures/designConfigV1Docs.mjs');
+
+const ORACLE_PATH = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../test-fixtures/designConfigV1ClampOracle.json'
+);
+
+const ROLES = ['admin', 'agent', undefined];
+const STORED_VARIANTS = { create: undefined, updateOverRich: adminRichDoc };
+
+function captureAll() {
+  const out = {};
+  for (const [docName, doc] of Object.entries(V1_DOCS)) {
+    for (const role of ROLES) {
+      for (const [storedName, stored] of Object.entries(STORED_VARIANTS)) {
+        const key = `${docName}::role=${role ?? 'none'}::stored=${storedName}`;
+        out[key] = clampDesignConfig(structuredClone(doc), structuredClone(stored), role);
+      }
+    }
+    out[`${docName}::public`] = buildPublicDesignConfig(structuredClone(doc));
+  }
+  return out;
+}
+
+describe('design_config v1 golden (oracle captured at base 7b5f0dd)', () => {
+  if (process.env.CAPTURE_ORACLE === '1') {
+    it('captures the oracle artifact (CAPTURE_ORACLE=1)', () => {
+      const artifact = {
+        __provenance: {
+          capturedAt: 'pre-v2 implementation',
+          baseCommit: '7b5f0dd',
+          note: 'Output of clampDesignConfig/buildPublicDesignConfig BEFORE any design_config-v2 code. Do not regenerate casually.',
+        },
+        results: captureAll(),
+      };
+      writeFileSync(ORACLE_PATH, `${JSON.stringify(artifact, null, 2)}\n`);
+      expect(Object.keys(artifact.results).length).toBeGreaterThan(0);
+    });
+    return;
+  }
+
+  const oracle = JSON.parse(readFileSync(ORACLE_PATH, 'utf8'));
+
+  it('covers every fixture × role × stored combo present at capture time', () => {
+    expect(Object.keys(captureAll()).sort()).toEqual(Object.keys(oracle.results).sort());
+  });
+
+  for (const key of Object.keys(V1_DOCS)) {
+    it(`v1 clamp + public output unchanged for fixture "${key}"`, () => {
+      const now = captureAll();
+      for (const [comboKey, expected] of Object.entries(oracle.results)) {
+        if (!comboKey.startsWith(`${key}::`)) continue;
+        // JSON round-trip the live value so undefined-vs-absent matches what
+        // the artifact can represent (structural equality, not byte identity).
+        expect(JSON.parse(JSON.stringify(now[comboKey] ?? null))).toEqual(expected);
+      }
+    });
+  }
+});

--- a/backend/test/designConfigV2.util.test.js
+++ b/backend/test/designConfigV2.util.test.js
@@ -1,0 +1,296 @@
+/**
+ * design_config v2 server policy — the write gate, the hybrid-alias scrub,
+ * clampDesignConfigV2 (limits/enums/policies at v2 paths, role × stored-version
+ * matrix), cross-version accessors, and the campaignService guards
+ * (update-path version conflict, duplicate never-clone at v2 paths,
+ * ensureDrawTermsVersion v2 terms).
+ */
+import { jest } from '@jest/globals';
+import './setup.js';
+import { Op } from 'sequelize';
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  Campaign: { create: jest.fn(), findOne: jest.fn(), findByPk: jest.fn() },
+  QrTag: {}, Prospect: {}, Commission: {}, Device: {},
+  CampaignMediaItem: { findAll: jest.fn(async () => []), bulkCreate: jest.fn(async () => []) },
+  CampaignAgentAssignment: { findAll: jest.fn(async () => []), bulkCreate: jest.fn(async () => []) },
+  sequelize: { transaction: jest.fn() },
+  DrawTermsVersion: {
+    findOne: jest.fn(async () => null),
+    max: jest.fn(async () => null),
+    create: jest.fn(async (fields) => ({ id: 'dtv-1', ...fields })),
+  },
+  Op,
+}));
+jest.unstable_mockModule('../src/middleware/tenant.js', () => ({ getTenantId: jest.fn() }));
+jest.unstable_mockModule('../src/services/storage.js', () => ({ storageService: {} }));
+jest.unstable_mockModule('../src/services/pushService.js', () => ({ pushService: { sendEvent: jest.fn() } }));
+jest.unstable_mockModule('../src/services/walletService.js', () => ({
+  refundCampaignCommitments: jest.fn(async () => ({ refunded: 0, totalCents: 0 })),
+}));
+
+const models = await import('../src/models/index.js');
+const { clampDesignConfig, updateCampaign, duplicateCampaign, ensureDrawTermsVersion } =
+  await import('../src/services/campaignService.js');
+const {
+  clampDesignConfigV2,
+  getStoredFeaturedDrop,
+  getStoredMarketplaceListed,
+  getStoredTermsHtml,
+  getStoredHostChoice,
+} = await import('../src/utils/designConfigV2Clamp.js');
+const { upgradeDesignConfig } = await import('../src/utils/designConfigV2.js');
+const { V1_DOCS, TAGGED_DOCS, adminRichDoc, editorialBaseline } =
+  await import('../../test-fixtures/designConfigV1Docs.mjs');
+
+const flagOn = () => { process.env.DESIGN_CONFIG_V2_WRITES_ENABLED = 'true'; };
+const flagOff = () => { delete process.env.DESIGN_CONFIG_V2_WRITES_ENABLED; };
+afterEach(() => { flagOff(); jest.clearAllMocks(); });
+
+const v2Editorial = upgradeDesignConfig(editorialBaseline);
+const v2Rich = upgradeDesignConfig(adminRichDoc);
+
+describe('write gate (default OFF — the PR ships dark)', () => {
+  it.each(Object.entries(TAGGED_DOCS))(
+    'rejects version-tagged payload "%s" with a typed 422 while the flag is off',
+    (_name, doc) => {
+      expect.assertions(3);
+      try {
+        clampDesignConfig(doc, undefined, 'admin');
+      } catch (err) {
+        expect(err.statusCode).toBe(422);
+        expect(err.data).toEqual({ code: 'DESIGN_CONFIG_VERSION_UNSUPPORTED' });
+        expect(err.isOperational).toBe(true);
+      }
+    }
+  );
+
+  it('still rejects NON-v2 versions (3, "2") even with the flag on', () => {
+    flagOn();
+    for (const doc of [TAGGED_DOCS.futureVersion, TAGGED_DOCS.stringVersion]) {
+      expect(() => clampDesignConfig(doc, undefined, 'admin')).toThrow(
+        expect.objectContaining({ statusCode: 422 })
+      );
+    }
+  });
+
+  it('accepts a v2 document when the flag is on', () => {
+    flagOn();
+    const out = clampDesignConfig(v2Editorial, undefined, 'admin');
+    expect(out.version).toBe(2);
+    expect(out.content.headline).toBe('Get your $10 voucher');
+  });
+
+  it('leaves every untagged (v1) fixture on the untouched v1 path, flag on or off', () => {
+    for (const doc of Object.values(V1_DOCS)) {
+      const off = clampDesignConfig(structuredClone(doc), undefined, 'admin');
+      flagOn();
+      const on = clampDesignConfig(structuredClone(doc), undefined, 'admin');
+      flagOff();
+      expect(on).toEqual(off);
+      expect(on.version).toBeUndefined();
+    }
+  });
+});
+
+describe('hybrid-alias scrub (authorization bypass)', () => {
+  it('strips smuggled top-level v1 publication keys for EVERY role', () => {
+    for (const role of ['admin', 'agent', undefined]) {
+      const out = clampDesignConfigV2(TAGGED_DOCS.hybridAliasSmuggle, undefined, role);
+      expect(out.featuredDrop).toBeUndefined();
+      expect(out.marketplaceListed).toBeUndefined();
+      // …and nothing landed at the policied v2 paths either (none was sent there).
+      expect(out.distribution.featuredDrop).toBeUndefined();
+      expect(out.distribution.marketplace?.listed).toBeUndefined();
+    }
+  });
+
+  it('strips every other known v1 alias while keeping unknown future keys', () => {
+    const out = clampDesignConfigV2(
+      { ...v2Editorial, formHeadline: 'smuggled', themeColor: '#000000', futureKey: { ok: 1 } },
+      undefined,
+      'admin'
+    );
+    expect(out.formHeadline).toBeUndefined();
+    expect(out.themeColor).toBeUndefined();
+    expect(out.futureKey).toEqual({ ok: 1 });
+  });
+});
+
+describe('clampDesignConfigV2 — limits, enums, derived mirror', () => {
+  it('clamps content lengths and template ranges; invalid enums fall back', () => {
+    const noisy = {
+      version: 2,
+      template: { id: 'hologram', params: { editorial: { formWidth: 250 }, express: { trustLine: 'x'.repeat(200) } } },
+      theme: { preset: 'neon', accent: 'D17029', font: 'comic-sans', radius: 'blobby', background: 'lava' },
+      content: { headline: 'H'.repeat(200), media: { kind: 'video', src: 'https://youtu.be/dQw4w9WgXcQ', alt: 'a'.repeat(300) } },
+      form: { verification: 'carrier-pigeon', fields: 'not-an-array', gates: { sgPr: 'yes' } },
+      distribution: { host: 'evil.example' },
+    };
+    const out = clampDesignConfigV2(noisy, undefined, 'admin');
+    expect(out.template.id).toBe('editorial');
+    expect(out.template.params.editorial.formWidth).toBe(300);
+    expect(out.template.params.express.trustLine).toHaveLength(80);
+    expect(out.theme.preset).toBe('warm-cream'); // redeem-host default
+    expect(out.theme.accent).toBe('#D17029'); // 6-hex accepted with or without #
+    expect(out.theme.font).toBeUndefined();
+    expect(out.content.headline).toHaveLength(80);
+    expect(out.content.media.kind).toBe('youtube'); // honest reclassification
+    expect(out.content.media.alt).toHaveLength(120);
+    expect(out.form.verification).toBe('sms');
+    expect(out.form.gates.sgPr).toBe(false); // strict boolean
+    expect(out.form.fields.map((f) => f.id)).toEqual(['name', 'email', 'phone', 'dob', 'postal', 'education', 'salary']);
+    expect(out.distribution.host).toBe('redeem');
+    expect(out.customerHost).toBe('redeem');
+  });
+
+  it('host conflict: canonical distribution.host wins; the mirror is always derived', () => {
+    const out = clampDesignConfigV2(
+      { version: 2, distribution: { host: 'mktr' }, customerHost: 'redeem' },
+      undefined,
+      'admin'
+    );
+    expect(out.distribution.host).toBe('mktr');
+    expect(out.customerHost).toBe('mktr');
+  });
+
+  it('mktr host defaults the theme preset host-aware', () => {
+    const out = clampDesignConfigV2({ version: 2, distribution: { host: 'mktr' } }, undefined, 'admin');
+    expect(out.theme.preset).toBe('paper-white');
+  });
+
+  it('locked fields are forced visible+required; dupes collapse; missing append', () => {
+    const out = clampDesignConfigV2(
+      {
+        version: 2,
+        form: { fields: [
+          { id: 'email', visible: false, required: false, row: null },
+          { id: 'email', visible: true, required: true, row: null },
+          { id: 'salary', visible: true, required: 'yes', row: 'r9' },
+        ] },
+      },
+      undefined,
+      'admin'
+    );
+    const byId = Object.fromEntries(out.form.fields.map((f) => [f.id, f]));
+    expect(byId.email).toEqual({ id: 'email', visible: true, required: true, row: null });
+    expect(byId.salary).toEqual({ id: 'salary', visible: true, required: false, row: 'r9' });
+    expect(out.form.fields).toHaveLength(7);
+  });
+});
+
+describe('role × stored-version policy matrix (publication state)', () => {
+  const incomingDrop = { enabled: true, title: 'New drop', valueLabel: 'S$5', emoji: '🎁' };
+  const v2Incoming = {
+    version: 2,
+    distribution: { host: 'redeem', featuredDrop: incomingDrop, marketplace: { listed: true, title: 'L' } },
+  };
+
+  it('admin incoming wins over stored v1 AND stored v2', () => {
+    for (const stored of [adminRichDoc, v2Rich]) {
+      const out = clampDesignConfigV2(v2Incoming, stored, 'admin');
+      expect(out.distribution.featuredDrop).toMatchObject({ enabled: true, title: 'New drop' });
+      expect(out.distribution.marketplace.listed).toBe(true);
+    }
+  });
+
+  it('non-admin transition save (stored v1) PRESERVES the v1 publication state', () => {
+    const out = clampDesignConfigV2(v2Incoming, adminRichDoc, 'agent');
+    expect(out.distribution.featuredDrop).toMatchObject({
+      enabled: true, title: 'Tokyo Getaway Lucky Draw', valueLabel: 'S$3.8k',
+    });
+    expect(out.distribution.marketplace.listed).toBe(true); // stored value, not the agent's
+    expect(out.luckyDraw).toMatchObject({ enabled: true, prize: adminRichDoc.luckyDraw.prize });
+  });
+
+  it('non-admin save over stored v2 preserves the v2-path stored state', () => {
+    const out = clampDesignConfigV2(
+      { version: 2, distribution: { host: 'redeem', featuredDrop: { enabled: false } } },
+      v2Rich,
+      'agent'
+    );
+    expect(out.distribution.featuredDrop).toEqual(getStoredFeaturedDrop(v2Rich));
+  });
+
+  it('non-admin cannot seed publication state when none is stored', () => {
+    const out = clampDesignConfigV2(v2Incoming, undefined, 'agent');
+    expect(out.distribution.featuredDrop).toBeUndefined();
+    expect(out.distribution.marketplace?.listed).toBeUndefined();
+  });
+});
+
+describe('cross-version stored-state accessors', () => {
+  it('read from the right path per version', () => {
+    expect(getStoredFeaturedDrop(adminRichDoc)).toEqual(adminRichDoc.featuredDrop);
+    expect(getStoredFeaturedDrop(v2Rich)).toEqual(v2Rich.distribution.featuredDrop);
+    expect(getStoredMarketplaceListed(adminRichDoc)).toBe(true);
+    expect(getStoredMarketplaceListed(v2Rich)).toBe(true);
+    expect(getStoredTermsHtml(adminRichDoc)).toBe(adminRichDoc.termsContent);
+    expect(getStoredTermsHtml(v2Rich)).toBe(adminRichDoc.termsContent);
+    expect(getStoredHostChoice(adminRichDoc)).toBe('redeem');
+    expect(getStoredHostChoice(v2Rich)).toBe('redeem');
+    expect(getStoredTermsHtml(null)).toBe('');
+  });
+});
+
+describe('campaignService guards', () => {
+  it('updateCampaign rejects an untagged save over a stored v2 doc (409 + typed code)', async () => {
+    models.Campaign.findOne.mockResolvedValue({
+      id: 'c1',
+      design_config: v2Editorial,
+      slug: null,
+      firstActivatedAt: null,
+      update: jest.fn(),
+    });
+    await expect(
+      updateCampaign('c1', { design_config: { formHeadline: 'old editor save' } }, { user: { id: 'u1', role: 'admin' } })
+    ).rejects.toMatchObject({ statusCode: 409, data: { code: 'DESIGN_CONFIG_VERSION_CONFLICT' } });
+  });
+
+  it('duplicateCampaign strips v2 publication state at the v2 paths', async () => {
+    const original = {
+      toJSON: () => ({
+        id: 'c2', name: 'Rich', status: 'active', design_config: structuredClone(v2Rich),
+        slug: 'rich', firstActivatedAt: new Date(), leadPriceCents: 500,
+      }),
+    };
+    models.Campaign.findOne.mockResolvedValue(original);
+    models.Campaign.create.mockImplementation(async (data) => {
+      const row = { id: 'c3', ...data };
+      row.toJSON = () => ({ ...row });
+      return row;
+    });
+    await duplicateCampaign('c2', {}, { user: { id: 'u1', role: 'admin' } });
+    const created = models.Campaign.create.mock.calls[0][0];
+    expect(created.design_config.luckyDraw).toBeUndefined();
+    expect(created.design_config.distribution.featuredDrop.enabled).toBe(false);
+    expect(created.design_config.distribution.marketplace.listed).toBeUndefined();
+    expect(created.design_config.version).toBe(2);
+    expect(created.slug).toBeNull();
+  });
+
+  it('ensureDrawTermsVersion pins terms from form.terms.html on a v2 doc', async () => {
+    const d = {
+      DrawTermsVersion: {
+        findOne: jest.fn(async () => null),
+        max: jest.fn(async () => 2),
+        create: jest.fn(async (fields) => ({ id: 'dtv-9', ...fields })),
+      },
+    };
+    const doc = { ...structuredClone(v2Rich), luckyDraw: { enabled: true, closesAt: '2026-08-30' } };
+    const out = await ensureDrawTermsVersion(doc, 'c9', 'u1', d);
+    expect(d.DrawTermsVersion.create).toHaveBeenCalledWith(
+      expect.objectContaining({ content: adminRichDoc.termsContent.trim(), version: 3 })
+    );
+    expect(out.luckyDraw.termsVersionId).toBe('dtv-9');
+  });
+
+  it('ensureDrawTermsVersion still 422s a v2 draw without terms', async () => {
+    const doc = {
+      version: 2,
+      form: { terms: { template: 'default', html: '   ' } },
+      luckyDraw: { enabled: true, closesAt: '2026-08-30' },
+    };
+    await expect(ensureDrawTermsVersion(doc, 'c9', 'u1')).rejects.toMatchObject({ statusCode: 422 });
+  });
+});

--- a/backend/test/publicDesignConfig.test.js
+++ b/backend/test/publicDesignConfig.test.js
@@ -64,3 +64,97 @@ describe('buildPublicDesignConfig', () => {
     for (const k of keys) expect(out[k]).toBe(`v-${k}`);
   });
 });
+
+// ── design_config v2 branch (Campaign Studio) — leaf-level rebuild ──
+describe('buildPublicDesignConfig — v2 documents', () => {
+  const v2Doc = {
+    version: 2,
+    template: {
+      id: 'editorial',
+      params: {
+        editorial: { formWidth: 400, cardStyle: 'raised', evil: 'leak-me' },
+        express: { trustLine: 'Trusted by 2,000 households', storyFold: false },
+      },
+    },
+    theme: { preset: 'warm-cream', accent: '#D17029', font: 'fraunces', radius: 'soft', background: 'plain', internalNote: 'leak' },
+    content: {
+      wordmark: 'redeem.sg', headline: 'Get your voucher', subheadline: 'Fast.',
+      story: 'S', emphasis: 'E', heroCtaLabel: 'Claim', submitLabel: 'Redeem Now',
+      advertiserName: 'FairShare Rewards',
+      footer: { regulatory: 'Reg', brand: 'Powered by MKTR' },
+      media: {
+        kind: 'image', src: '/uploads/x.jpg', alt: 'Basket',
+        legacy: { imageUrl: '/uploads/x.jpg', videoUrl: '/uploads/old.mp4' },
+      },
+      routing: { secretFlow: true },
+    },
+    form: {
+      fields: [{ id: 'name', visible: true, required: true, row: null, internalScore: 9 }],
+      verification: 'sms',
+      gates: { sgPr: true, advisorExclusion: false, dncCheck: true, shadowGate: true },
+      terms: { template: 'default', html: '<p>T&C</p>', draftHtml: '<p>unpublished</p>' },
+      internalNote: 'leak',
+    },
+    quiz: { enabled: true, steps: [], scoring: { method: 'profile-sum' } },
+    guidedReview: { templateId: 'financial_readiness' },
+    distribution: {
+      host: 'redeem',
+      featuredDrop: { enabled: true, title: 'Drop', valueLabel: 'S$10', emoji: '🛒', cap: 100, endsAt: '2026-08-15' },
+      marketplace: { listed: true, title: 'Voucher', category: 'dining', valueLine: 'S$10', internalCost: 3.5 },
+    },
+    ai: { brief: { topic: 'secret internal brief' } },
+    luckyDraw: {
+      enabled: true, prize: 'Tokyo trip', closesAt: '2026-08-30', multiplier: 10,
+      activationId: '2a2a2a2a-2a2a-4a2a-8a2a-2a2a2a2a2a2a',
+      termsVersionId: '3b3b3b3b-3b3b-4b3b-8b3b-3b3b3b3b3b3b',
+      termsHash: 'a'.repeat(64),
+    },
+    futureTopLevel: { fine: true },
+  };
+
+  test('every public v2 key survives; version + host mirror present', () => {
+    const out = buildPublicDesignConfig(v2Doc);
+    expect(out.version).toBe(2);
+    expect(out.template.id).toBe('editorial');
+    expect(out.template.params.editorial).toEqual({ formWidth: 400, cardStyle: 'raised' });
+    expect(out.theme).toEqual({ preset: 'warm-cream', accent: '#D17029', font: 'fraunces', radius: 'soft', background: 'plain' });
+    expect(out.content).toMatchObject({
+      wordmark: 'redeem.sg', headline: 'Get your voucher', submitLabel: 'Redeem Now',
+      advertiserName: 'FairShare Rewards',
+      footer: { regulatory: 'Reg', brand: 'Powered by MKTR' },
+      media: { kind: 'image', src: '/uploads/x.jpg', alt: 'Basket' },
+    });
+    expect(out.form.fields).toEqual([{ id: 'name', visible: true, required: true, row: null }]);
+    expect(out.form.verification).toBe('sms');
+    expect(out.form.gates).toEqual({ sgPr: true, advisorExclusion: false, dncCheck: true });
+    expect(out.form.terms).toEqual({ template: 'default', html: '<p>T&C</p>' });
+    expect(out.quiz).toEqual(v2Doc.quiz);
+    expect(out.guidedReview).toEqual(v2Doc.guidedReview);
+    expect(out.distribution.host).toBe('redeem');
+    expect(out.customerHost).toBe('redeem');
+    expect(out.distribution.marketplace).toMatchObject({ title: 'Voucher', category: 'dining', valueLine: 'S$10' });
+    expect(out.luckyDraw).toEqual({ enabled: true, prize: 'Tokyo trip', closesAt: '2026-08-30', multiplier: 10 });
+  });
+
+  test('internal state never leaks: ai, media.legacy, listed, featuredDrop, draw ids, nested poison keys', () => {
+    const out = buildPublicDesignConfig(v2Doc);
+    expect(out.ai).toBeUndefined();
+    expect(out.content.media.legacy).toBeUndefined();
+    expect(out.distribution.marketplace.listed).toBeUndefined();
+    expect(out.distribution.marketplace.internalCost).toBeUndefined();
+    expect(out.distribution.featuredDrop).toBeUndefined();
+    expect(out.luckyDraw.activationId).toBeUndefined();
+    expect(out.luckyDraw.termsVersionId).toBeUndefined();
+    expect(out.luckyDraw.termsHash).toBeUndefined();
+    // Nested poison keys injected at every public subtree.
+    expect(out.template.params.editorial.evil).toBeUndefined();
+    expect(out.theme.internalNote).toBeUndefined();
+    expect(out.content.routing).toBeUndefined();
+    expect(out.form.internalNote).toBeUndefined();
+    expect(out.form.gates.shadowGate).toBeUndefined();
+    expect(out.form.terms.draftHtml).toBeUndefined();
+    expect(out.form.fields[0].internalScore).toBeUndefined();
+    // Unknown top-level keys are NOT public either — the whitelist rebuilds.
+    expect(out.futureTopLevel).toBeUndefined();
+  });
+});

--- a/src/lib/__tests__/designConfigV2.lockstep.test.js
+++ b/src/lib/__tests__/designConfigV2.lockstep.test.js
@@ -1,0 +1,137 @@
+/**
+ * designConfigV2 twin LOCK-STEP — imports BOTH the backend source of truth and
+ * the frontend mirror; fails the build if they diverge (redeemOpsPermissions
+ * drift pattern for constants, quizScoring behavioral-parity pattern for the
+ * migration/theme functions, plus a seeded deterministic fuzz corpus).
+ */
+import { describe, it, expect } from 'vitest';
+
+import * as mirror from '../designConfigV2.js';
+import * as backend from '../../../backend/src/utils/designConfigV2.js';
+import { readableTextOn } from '../contrast.js';
+import { V1_DOCS } from '../../../test-fixtures/designConfigV1Docs.mjs';
+
+const CONSTANT_EXPORTS = [
+  'DESIGN_CONFIG_VERSION', 'TEMPLATE_IDS', 'TEMPLATE_PARAM_DEFAULTS',
+  'THEME_RADIUS_IDS', 'THEME_BACKGROUNDS', 'FONT_IDS', 'RADII', 'THEME_PRESETS',
+  'PRESET_IDS', 'LIMITS', 'FIELD_IDS', 'LOCKED_FIELD_IDS', 'V1_TO_V2_FIELD_ID',
+  'V2_TO_V1_FIELD_ID', 'MARKETPLACE_V1_TO_V2', 'V1_CONSUMED_KEYS', 'V2_TOP_KEYS',
+];
+
+const FUNCTION_EXPORTS = [
+  'classifyDesignConfigVersion', 'isV2', 'upgradeDesignConfig',
+  'downgradeDesignConfig', 'readLegacyView', 'resolveTheme', 'defaultFields',
+  'fieldsFromV1', 'fieldsToV1', 'marketplaceToV1', 'nearestPresetForAccent',
+  'onColor', 'youTubeIdFrom',
+];
+
+describe('designConfigV2 twins — constant drift', () => {
+  it('exports the same surface', () => {
+    for (const name of [...CONSTANT_EXPORTS, ...FUNCTION_EXPORTS]) {
+      expect(mirror[name], `mirror missing ${name}`).toBeDefined();
+      expect(backend[name], `backend missing ${name}`).toBeDefined();
+    }
+  });
+
+  it.each(CONSTANT_EXPORTS)('constant %s is structurally identical', (name) => {
+    expect(mirror[name]).toEqual(backend[name]);
+  });
+});
+
+describe('designConfigV2 twins — behavioral parity over the fixture corpus', () => {
+  for (const [name, doc] of Object.entries(V1_DOCS)) {
+    it(`upgrade + downgrade agree for fixture "${name}"`, () => {
+      const up = mirror.upgradeDesignConfig(doc);
+      expect(up).toEqual(backend.upgradeDesignConfig(doc));
+      expect(mirror.downgradeDesignConfig(up)).toEqual(backend.downgradeDesignConfig(up));
+    });
+  }
+
+  it('classification agrees on every fixture + tagged edge shapes', () => {
+    const shapes = [
+      ...Object.values(V1_DOCS), null, undefined, 'nope', 42, [],
+      { version: 2 }, { version: 3 }, { version: '2' }, { version: null },
+    ];
+    for (const s of shapes) {
+      expect(mirror.classifyDesignConfigVersion(s)).toBe(backend.classifyDesignConfigVersion(s));
+    }
+  });
+});
+
+describe('designConfigV2 twins — resolveTheme parity (exhaustive enumeration)', () => {
+  const radii = [undefined, 'soft', 'sharp', 'round'];
+  const backgrounds = [undefined, 'plain', 'wash', 'grain'];
+  const accents = [undefined, null, '#123456', 'not-a-hex'];
+  it('agrees across 10 presets × radii × backgrounds × accents', () => {
+    for (const preset of backend.PRESET_IDS) {
+      for (const radius of radii) {
+        for (const background of backgrounds) {
+          for (const accent of accents) {
+            const theme = { preset, radius, background, accent };
+            expect(mirror.resolveTheme(theme)).toEqual(backend.resolveTheme(theme));
+          }
+        }
+      }
+    }
+  });
+
+  it('onColor matches the production contrast helper over preset accents + edges', () => {
+    const samples = [
+      ...backend.THEME_PRESETS.map((p) => p.accent),
+      '#FFFFFF', '#000000', '#E8D7B8', 'garbage', '', '#abc',
+    ];
+    for (const hex of samples) {
+      expect(mirror.onColor(hex)).toBe(readableTextOn(hex));
+      expect(backend.onColor(hex)).toBe(readableTextOn(hex));
+    }
+  });
+});
+
+describe('designConfigV2 twins — seeded deterministic fuzz corpus', () => {
+  // Tiny LCG so the corpus is stable across runs/runners (no Math.random).
+  const lcg = (seed) => () => {
+    seed = (seed * 1664525 + 1013904223) % 4294967296;
+    return seed / 4294967296;
+  };
+
+  const buildRandomV1Doc = (rand) => {
+    const maybe = (p, v) => (rand() < p ? v : undefined);
+    const doc = {};
+    const set = (k, v) => { if (v !== undefined) doc[k] = v; };
+    set('formHeadline', maybe(0.7, `Headline ${Math.floor(rand() * 1000)}`));
+    set('ctaText', maybe(0.5, rand() < 0.5 ? '' : 'Go'));
+    set('themeColor', maybe(0.6, rand() < 0.5 ? '#D17029' : 'junk'));
+    set('heroFont', maybe(0.5, rand() < 0.5 ? 'inter' : 'unknown-font'));
+    set('formWidth', maybe(0.4, Math.floor(rand() * 1000)));
+    set('mediaType', maybe(0.6, ['none', 'image', 'video'][Math.floor(rand() * 3)]));
+    set('imageUrl', maybe(0.5, '/uploads/x.jpg'));
+    set('videoUrl', maybe(0.5, rand() < 0.4 ? 'https://youtu.be/dQw4w9WgXcQ' : '/uploads/x.mp4'));
+    set('customerHost', maybe(0.5, rand() < 0.5 ? 'mktr' : 'weird'));
+    set('otpChannel', maybe(0.5, rand() < 0.5 ? 'whatsapp' : 'sms'));
+    set('sgPrOnly', maybe(0.5, rand() < 0.5));
+    set('visibleFields', maybe(0.6, { dob: rand() < 0.5, education_level: rand() < 0.5 }));
+    set('requiredFields', maybe(0.6, { dob: ['optional', true, false, 'yes'][Math.floor(rand() * 4)] }));
+    set('fieldOrder', maybe(0.5, rand() < 0.5
+      ? ['name', 'phone', 'email']
+      : [{ id: 'r1', columns: ['dob', 'postal_code'] }, 'name', { id: 'r2', columns: [] }]));
+    set('featuredDrop', maybe(0.3, { enabled: rand() < 0.5, title: 'T' }));
+    set('quiz', maybe(0.3, { enabled: true, steps: [], scoring: { method: 'profile-sum' } }));
+    set('mysteryKey', maybe(0.3, { nested: Math.floor(rand() * 10) }));
+    return doc;
+  };
+
+  it('200 seeded docs: twins agree, upgrade is idempotent, downgrade(v1) is identity-safe', () => {
+    const rand = lcg(20260717);
+    for (let i = 0; i < 200; i += 1) {
+      const doc = buildRandomV1Doc(rand);
+      const upM = mirror.upgradeDesignConfig(doc);
+      const upB = backend.upgradeDesignConfig(doc);
+      expect(upM).toEqual(upB);
+      expect(mirror.upgradeDesignConfig(upM)).toEqual(upM); // idempotent
+      const downM = mirror.downgradeDesignConfig(upM);
+      expect(downM).toEqual(backend.downgradeDesignConfig(upB));
+      // Second round trip is stable (canonical form reached after one pass).
+      expect(mirror.upgradeDesignConfig(downM)).toEqual(upM);
+    }
+  });
+});

--- a/src/lib/__tests__/designConfigV2.test.js
+++ b/src/lib/__tests__/designConfigV2.test.js
@@ -1,0 +1,309 @@
+/**
+ * design_config v1→v2 migration semantics — every handoff §02 row, the
+ * canonicalization loss ledger (L1–L5), round-trip guarantees, and the frozen
+ * Warm Cream ↔ production-tokens parity.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  upgradeDesignConfig,
+  downgradeDesignConfig,
+  resolveTheme,
+  classifyDesignConfigVersion,
+} from '../designConfigV2.js';
+import { TOKENS, RADIUS } from '../../components/campaigns/LeadCaptureLayout';
+import {
+  editorialBaseline,
+  quizCampaign,
+  adminRichDoc,
+  legacyFlatOrder,
+  anomalousOrder,
+  youtubeDoc,
+  youtubeShortDoc,
+  youtubeShortsUrlDoc,
+  staleMediaDoc,
+  deadStyleKeysDoc,
+  guidedReviewDoc,
+  minimalDoc,
+  overLimitDoc,
+  TAGGED_DOCS,
+} from '../../../test-fixtures/designConfigV1Docs.mjs';
+
+const up = upgradeDesignConfig;
+const down = downgradeDesignConfig;
+
+describe('upgrade — migration table rows (editorial baseline)', () => {
+  const v2 = up(editorialBaseline);
+
+  it('row 1: themeColor → theme.accent + nearest preset (identity for the production accent)', () => {
+    expect(v2.theme.accent).toBe('#D17029');
+    expect(v2.theme.preset).toBe('warm-cream');
+  });
+
+  it('row 2: heroFont → theme.font', () => {
+    expect(v2.theme.font).toBe('fraunces');
+  });
+
+  it('row 3: formWidth → template.params.editorial.formWidth, verbatim (no clamping in upgrade)', () => {
+    expect(v2.template).toEqual({ id: 'editorial', params: expect.objectContaining({ editorial: { formWidth: 400, cardStyle: 'raised' } }) });
+  });
+
+  it('rows 4-7: field order, rows, visibility semantics, required canonicalization', () => {
+    expect(v2.form.fields).toEqual([
+      { id: 'name', visible: true, required: true, row: null },
+      { id: 'phone', visible: true, required: true, row: null },
+      { id: 'email', visible: true, required: true, row: null },
+      { id: 'dob', visible: true, required: true, row: 'r-pair' },
+      { id: 'postal', visible: true, required: false, row: 'r-pair' },
+      { id: 'education', visible: false, required: false, row: null },
+      { id: 'salary', visible: false, required: false, row: null },
+    ]);
+  });
+
+  it('rows 8-9 + L4: image media with preserved legacy shadow', () => {
+    expect(v2.content.media).toEqual({
+      kind: 'image',
+      src: '/uploads/campaign-assets/groceries.jpg',
+      alt: '',
+      legacy: { imageUrl: '/uploads/campaign-assets/groceries.jpg', videoUrl: '' },
+    });
+  });
+
+  it('row 10: customerHost → distribution.host with a derived legacy mirror', () => {
+    expect(v2.distribution.host).toBe('redeem');
+    expect(v2.customerHost).toBe('redeem');
+  });
+
+  it('row 14: termsContent → form.terms with a seeded default template', () => {
+    expect(v2.form.terms).toEqual({ template: 'default', html: editorialBaseline.termsContent });
+  });
+
+  it('row 16: content slots mapped 1:1 (submitLabel from ctaText)', () => {
+    expect(v2.content).toMatchObject({
+      wordmark: 'redeem.sg',
+      headline: 'Get your $10 voucher',
+      subheadline: editorialBaseline.formSubheadline,
+      story: editorialBaseline.storyText,
+      emphasis: editorialBaseline.storyEmphasis,
+      heroCtaLabel: 'Claim my voucher',
+      submitLabel: 'Redeem Now',
+      footer: { regulatory: editorialBaseline.regulatoryFooter, brand: 'Powered by MKTR' },
+    });
+    expect(v2.content.advertiserName).toBeUndefined(); // read-time default, never baked
+  });
+
+  it('gates + verification map explicitly', () => {
+    expect(v2.form.gates).toEqual({ sgPr: true, advisorExclusion: false, dncCheck: true });
+    expect(v2.form.verification).toBe('sms');
+  });
+});
+
+describe('upgrade — passthrough + canonicalization ledger', () => {
+  it('L5: quiz passes through verbatim (production shape, never restructured)', () => {
+    const v2 = up(quizCampaign);
+    expect(v2.quiz).toEqual(quizCampaign.quiz);
+  });
+
+  it('L5: guidedReview + derived quiz coexistence passes through verbatim', () => {
+    const v2 = up(guidedReviewDoc);
+    expect(v2.guidedReview).toEqual(guidedReviewDoc.guidedReview);
+    expect(v2.quiz).toEqual(guidedReviewDoc.quiz);
+  });
+
+  it('L5: dead style keys + unknown future keys survive (never dropped)', () => {
+    const v2 = up(deadStyleKeysDoc);
+    expect(v2.backgroundStyle).toBe('gradient');
+    expect(v2.alignment).toBe('center');
+    expect(v2.spacing).toBe('roomy');
+    expect(v2.headlineSize).toBe('xl');
+    expect(v2.someFutureKey).toEqual({ nested: true });
+    const roundTripped = down(v2);
+    expect(roundTripped.backgroundStyle).toBe('gradient');
+    expect(roundTripped.someFutureKey).toEqual({ nested: true });
+  });
+
+  it('L1: required flags canonicalize (false|optional→false, truthy→true, absent→false)', () => {
+    const v2 = up(legacyFlatOrder);
+    const byId = Object.fromEntries(v2.form.fields.map((f) => [f.id, f]));
+    expect(byId.dob.required).toBe(false); // 'optional'
+    expect(byId.postal.required).toBe(true); // 'yes'
+    expect(byId.education.required).toBe(false); // absent
+    expect(byId.name.required).toBe(true); // locked
+  });
+
+  it('L2: education/salary absent → hidden (data-honest); explicit true stays visible', () => {
+    expect(Object.fromEntries(up(minimalDoc).form.fields.map((f) => [f.id, f.visible]))).toEqual({
+      name: true, email: true, phone: true, dob: true, postal: true, education: false, salary: false,
+    });
+    const v2 = up(quizCampaign);
+    const byId = Object.fromEntries(v2.form.fields.map((f) => [f.id, f]));
+    expect(byId.education.visible).toBe(true);
+    expect(byId.salary.visible).toBe(true);
+    expect(byId.dob.visible).toBe(false); // explicit false
+  });
+
+  it('L3: anomalous fieldOrder canonicalizes deterministically', () => {
+    const v2 = up(anomalousOrder);
+    expect(v2.form.fields.map((f) => f.id)).toEqual([
+      'name', 'phone', 'dob', 'postal', 'email', 'education', 'salary',
+    ]);
+    const byId = Object.fromEntries(v2.form.fields.map((f) => [f.id, f]));
+    expect(byId.phone.row).toBe('r1'); // surviving pair keeps its row id
+    expect(byId.dob.row).toBe('r1');
+    expect(byId.postal.row).toBe(null); // single-column row → unpaired
+    expect(byId.name.row).toBe(null); // duplicate collapsed to first occurrence
+  });
+
+  it('media: youtube derivation uses the PRODUCTION matcher (shorts stay hosted video)', () => {
+    expect(up(youtubeDoc).content.media.kind).toBe('youtube');
+    expect(up(youtubeShortDoc).content.media.kind).toBe('youtube');
+    expect(up(youtubeShortsUrlDoc).content.media.kind).toBe('video');
+  });
+
+  it('media: stale collision keeps kind none but preserves BOTH urls in the legacy shadow', () => {
+    const media = up(staleMediaDoc).content.media;
+    expect(media.kind).toBe('none');
+    expect(media.src).toBe('');
+    expect(media.legacy).toEqual({
+      imageUrl: '/uploads/campaign-assets/old-hero.jpg',
+      videoUrl: '/uploads/campaign-assets/old-hero.mp4',
+    });
+    const v1 = down(up(staleMediaDoc));
+    expect(v1.imageUrl).toBe(staleMediaDoc.imageUrl);
+    expect(v1.videoUrl).toBe(staleMediaDoc.videoUrl);
+    expect(v1.mediaType).toBe('none');
+  });
+
+  it('no clamping in upgrade: over-limit + invalid values survive verbatim', () => {
+    const v2 = up(overLimitDoc);
+    expect(v2.content.headline).toHaveLength(120);
+    expect(v2.template.params.editorial.formWidth).toBe(900);
+    expect(v2.theme.accent).toBe('not-a-hex');
+    expect(v2.theme.preset).toBe('warm-cream'); // invalid hex → parity preset
+    expect(v2.theme.font).toBe('comic-sans');
+    expect(v2.content.submitLabel).toBe('');
+  });
+
+  it('marketplace: full rename round-trip incl. sponsor, partials, listed', () => {
+    const v2 = up(adminRichDoc);
+    expect(v2.distribution.marketplace).toMatchObject({
+      title: adminRichDoc.name,
+      offerType: 'reward',
+      qrLanding: 'offer',
+      audienceAgeMin: 21,
+      audienceAgeMax: 65,
+      imageAlt: adminRichDoc.image_label,
+      valueLine: adminRichDoc.value_line,
+      days: ['sat', 'sun'],
+      slots: ['10:00', '14:00'],
+      activation: { required: true, type: 'consult', durationMins: 20, summary: 'Short activation call' },
+      sponsor: { disclosed: true, kind: 'agency', disclosure: adminRichDoc.sponsor.disclosure },
+      dataUse: adminRichDoc.content_blocks.data_use,
+      listed: true,
+    });
+    expect(v2.distribution.marketplace.cancellation).toBeUndefined(); // partial stays partial
+    const v1 = down(v2);
+    expect(v1.name).toBe(adminRichDoc.name);
+    expect(v1.offer_type).toBe('reward');
+    expect(v1.age_range).toEqual({ min: 21, max: 65 });
+    expect(v1.availability).toEqual({ days: ['sat', 'sun'], slots: ['10:00', '14:00'] });
+    expect(v1.activation).toEqual(adminRichDoc.activation);
+    expect(v1.sponsor).toEqual(adminRichDoc.sponsor);
+    expect(v1.content_blocks).toEqual(adminRichDoc.content_blocks);
+    expect(v1.marketplaceListed).toBe(true);
+    expect(v1.featuredDrop).toEqual(adminRichDoc.featuredDrop);
+    expect(v1.luckyDraw).toEqual(adminRichDoc.luckyDraw); // top-level passthrough both ways
+  });
+
+  it('sponsor: explicit null is preserved as a distinct state', () => {
+    const v2 = up({ sponsor: null });
+    expect(v2.distribution.marketplace.sponsor).toBeNull();
+    expect(down(v2).sponsor).toBeNull();
+  });
+});
+
+describe('round-trip guarantees', () => {
+  const fixtures = {
+    editorialBaseline, quizCampaign, adminRichDoc, legacyFlatOrder, anomalousOrder,
+    youtubeDoc, staleMediaDoc, deadStyleKeysDoc, guidedReviewDoc, minimalDoc, overLimitDoc,
+  };
+
+  it('upgrade(downgrade(v2)) is the exact v2 doc, for every fixture', () => {
+    for (const doc of Object.values(fixtures)) {
+      const v2 = up(doc);
+      expect(up(down(v2))).toEqual(v2);
+    }
+  });
+
+  it('upgrade is idempotent', () => {
+    for (const doc of Object.values(fixtures)) {
+      const v2 = up(doc);
+      expect(up(v2)).toEqual(v2);
+    }
+  });
+
+  it('downgrade(upgrade(editorial)) preserves the renderer contract key-by-key', () => {
+    const v1 = down(up(editorialBaseline));
+    const renderKeys = [
+      'formHeadline', 'formSubheadline', 'brandWordmark', 'storyText', 'storyEmphasis',
+      'heroCtaLabel', 'ctaText', 'regulatoryFooter', 'brandFooter', 'imageUrl', 'videoUrl',
+      'themeColor', 'heroFont', 'formWidth', 'mediaType', 'termsContent', 'customerHost',
+      'otpChannel', 'sgPrOnly', 'excludeAdvisors', 'dncCheckAtSubmit', 'quiz',
+    ];
+    for (const key of renderKeys) {
+      expect(v1[key], key).toEqual(editorialBaseline[key]);
+    }
+    // Field semantics survive canonically (explicit booleans, same pairing).
+    expect(v1.visibleFields).toEqual({
+      phone: true, dob: true, postal_code: true, education_level: false, monthly_income: false,
+    });
+    expect(v1.requiredFields).toEqual({
+      dob: true, postal_code: false, education_level: false, monthly_income: false,
+    });
+    expect(v1.fieldOrder.map((r) => r.columns)).toEqual([
+      ['name'], ['phone'], ['email'], ['dob', 'postal_code'], ['education_level'], ['monthly_income'],
+    ]);
+  });
+
+  it('downgrade doubles as the legacy-view adapter: v1 in → v1 out', () => {
+    expect(down(editorialBaseline)).toEqual(editorialBaseline);
+  });
+});
+
+describe('version classification + unsupported handling', () => {
+  it('classifies legacy / v2 / unsupported', () => {
+    expect(classifyDesignConfigVersion(editorialBaseline)).toBe('legacy');
+    expect(classifyDesignConfigVersion(up(editorialBaseline))).toBe('v2');
+    expect(classifyDesignConfigVersion(TAGGED_DOCS.futureVersion)).toBe('unsupported');
+    expect(classifyDesignConfigVersion(TAGGED_DOCS.stringVersion)).toBe('unsupported');
+    expect(classifyDesignConfigVersion(null)).toBe('legacy');
+  });
+
+  it('upgrade/downgrade throw on unsupported versions', () => {
+    expect(() => up(TAGGED_DOCS.futureVersion)).toThrow(/Unsupported design_config version/);
+    expect(() => down(TAGGED_DOCS.stringVersion)).toThrow(/Unsupported design_config version/);
+  });
+});
+
+describe('Warm Cream preset ↔ production tokens (frozen parity)', () => {
+  it('resolveTheme(warm-cream) reproduces LeadCaptureLayout TOKENS + RADIUS exactly', () => {
+    const t = resolveTheme({ preset: 'warm-cream', accent: null });
+    expect(t.bg).toBe(TOKENS.pagebg);
+    expect(t.storyCard).toBe(TOKENS.storyCard);
+    expect(t.card).toBe(TOKENS.formCard);
+    expect(t.modal).toBe(TOKENS.modal);
+    expect(t.ink).toBe(TOKENS.ink);
+    expect(t.bodyText).toBe(TOKENS.body);
+    expect(t.muted).toBe(TOKENS.muted);
+    expect(t.hairline).toBe(TOKENS.hairline);
+    expect(t.divider).toBe(TOKENS.divider);
+    expect(t.accent).toBe(TOKENS.accent);
+    expect(t.accentDeep).toBe(TOKENS.accentDeep);
+    expect(t.danger).toBe(TOKENS.required);
+    expect(t.success).toBe(TOKENS.success);
+    expect(t.r).toEqual({
+      card: RADIUS.card, input: RADIUS.pill, btn: RADIUS.pill,
+      modal: RADIUS.modal, media: RADIUS.image, check: RADIUS.checkbox,
+    });
+  });
+});

--- a/src/lib/designConfigV2.js
+++ b/src/lib/designConfigV2.js
@@ -1,0 +1,553 @@
+/**
+ * design_config v2 — FRONTEND MIRROR of backend/src/utils/designConfigV2.js.
+ *
+ * The backend file is the SOURCE OF TRUTH; this mirror exists so the SPA
+ * (Studio, renderer, previews) can migrate/resolve without importing across
+ * the package boundary. The two files' shared surface must stay identical —
+ * src/lib/__tests__/designConfigV2.lockstep.test.js imports BOTH and fails the
+ * build on any divergence (constants structurally, functions behaviorally over
+ * the shared fixture corpus). Edit them together, backend first.
+ *
+ * Everything else about the contract, the canonicalization loss ledger (L1-L5),
+ * and the no-clamping rule is documented in the backend twin's header.
+ */
+
+export const DESIGN_CONFIG_VERSION = 2;
+
+export const TEMPLATE_IDS = ['editorial', 'poster', 'split', 'spotlight', 'express', 'journey'];
+
+/** Per-template parameter defaults — one bag, every template persists its
+ * params across switches; first Studio use seeds these. Migration seeds the
+ * bag but copies editorial.formWidth ONLY when v1 stored one (v1's RENDER
+ * default when absent is 480, not the editor-seed 400 — omitting preserves it). */
+export const TEMPLATE_PARAM_DEFAULTS = {
+  editorial: { formWidth: 400, cardStyle: 'raised' },
+  poster: { overlay: 'dusk', formReveal: 'inline' },
+  split: { mediaSide: 'left', mediaFit: 'cover' },
+  spotlight: { introStyle: 'immersive', revealArt: 'meter' },
+  express: { trustLine: '', storyFold: false },
+  journey: { sectionRhythm: 'alternate', stickyCta: true },
+};
+
+export const THEME_RADIUS_IDS = ['soft', 'sharp', 'round'];
+export const THEME_BACKGROUNDS = ['plain', 'wash', 'grain'];
+export const FONT_IDS = ['fraunces', 'playfair', 'space-grotesk', 'albert-sans', 'inter'];
+
+export const RADII = {
+  soft: { card: 14, input: 10, btn: 12, modal: 18, media: 12, check: 4 },
+  sharp: { card: 8, input: 6, btn: 7, modal: 12, media: 8, check: 3 },
+  round: { card: 20, input: 12, btn: 999, modal: 24, media: 14, check: 5 },
+};
+
+/**
+ * The 10 curated theme presets. `warm-cream` is FROZEN to the production
+ * Editorial tokens (LeadCaptureLayout TOKENS + RADIUS, verified byte-exact
+ * 2026-07-17) — it is the migration parity baseline and must never drift from
+ * the live page. `rx` is a preset-exact radii override that wins while
+ * theme.radius is untouched (resolveTheme).
+ */
+export const THEME_PRESETS = [
+  { id: 'warm-cream', name: 'Warm Cream', bg: '#F1DDB8', card: '#FFFAF0', storyCard: '#FAEAD0', modal: '#FBF7F0', ink: '#3D1F0B', bodyText: '#5A301A', muted: '#9A7E5C', hairline: '#E8D7B8', divider: '#D8C09A', accent: '#D17029', accentDeep: '#A85822', danger: '#B33A2E', success: '#7A8C6B', font: 'fraunces', radius: 'soft', rx: { card: 24, input: 999, btn: 999, modal: 28, media: 16, check: 6 }, parity: true, hostDefault: 'redeem' },
+  { id: 'paper-white', name: 'Paper White', bg: '#FAFAF8', card: '#FFFFFF', ink: '#17191E', muted: '#818694', accent: '#4059C8', font: 'space-grotesk', radius: 'sharp', hostDefault: 'mktr' },
+  { id: 'kopi', name: 'Kopi', bg: '#F3EBE0', card: '#FBF6EE', ink: '#3A2E22', muted: '#94836F', accent: '#8A5A2B', font: 'playfair', radius: 'soft' },
+  { id: 'botanic', name: 'Botanic', bg: '#F1F4EC', card: '#FAFCF6', ink: '#26311F', muted: '#7C8A6E', accent: '#4E7A3A', font: 'albert-sans', radius: 'soft' },
+  { id: 'peranakan', name: 'Peranakan', bg: '#FDF3F0', card: '#FFFAF8', ink: '#3B2430', muted: '#9A7A85', accent: '#C24E6A', font: 'fraunces', radius: 'round' },
+  { id: 'graphite', name: 'Graphite', bg: '#232529', card: '#2C2E33', ink: '#F2F2EF', muted: '#9A9DA6', accent: '#7A9BFF', font: 'space-grotesk', radius: 'sharp', dark: true },
+  { id: 'straits-teal', name: 'Straits Teal', bg: '#F2F6F5', card: '#FFFFFF', ink: '#152A28', muted: '#6E8582', accent: '#0E7C6B', font: 'albert-sans', radius: 'soft' },
+  { id: 'ink-lime', name: 'Ink & Lime', bg: '#1C1D18', card: '#26271F', ink: '#F4F6E8', muted: '#9AA08A', accent: '#9CCF35', font: 'space-grotesk', radius: 'sharp', dark: true },
+  { id: 'violet-hour', name: 'Violet Hour', bg: '#2E2447', card: '#3A2E59', ink: '#F3EFFC', muted: '#A99BC8', accent: '#B7F04C', font: 'fraunces', radius: 'round', dark: true },
+  { id: 'tangerine', name: 'Tangerine', bg: '#FFF4EC', card: '#FFFBF7', ink: '#332014', muted: '#A08373', accent: '#F0590C', font: 'albert-sans', radius: 'round' },
+];
+
+export const PRESET_IDS = THEME_PRESETS.map((p) => p.id);
+
+/** Server/editor length + range limits per v2 key (Phase 5 handoff §01). */
+export const LIMITS = {
+  wordmark: 40, headline: 80, subheadline: 150, story: 1200, emphasis: 160,
+  heroCtaLabel: 40, submitLabel: 40, advertiserName: 60, regulatory: 1000,
+  brand: 80, terms: 10000, dropTitle: 40, dropValue: 12, dropEmoji: 8,
+  mkTitle: 120, mkValue: 80, mkAlt: 120, mkNote: 400, quizIntroH: 80,
+  quizIntroS: 160, quizStart: 40, qPrompt: 140, qOption: 80, pTitle: 40,
+  pDesc: 400, pCta: 40, pAngle: 80,
+  mediaAlt: 120, formWidthMin: 300, formWidthMax: 600, trustLine: 80,
+};
+
+/** v2 field ids (array order = render order) and the v1 long-id mapping. */
+export const FIELD_IDS = ['name', 'email', 'phone', 'dob', 'postal', 'education', 'salary'];
+export const LOCKED_FIELD_IDS = ['name', 'email', 'phone'];
+export const V1_TO_V2_FIELD_ID = {
+  name: 'name', email: 'email', phone: 'phone', dob: 'dob',
+  postal_code: 'postal', education_level: 'education', monthly_income: 'salary',
+};
+export const V2_TO_V1_FIELD_ID = Object.fromEntries(
+  Object.entries(V1_TO_V2_FIELD_ID).map(([v1, v2]) => [v2, v1])
+);
+/** v1 default flat order (CampaignSignupForm's fallback when fieldOrder absent). */
+const V1_DEFAULT_ORDER = ['name', 'phone', 'email', 'dob', 'postal_code', 'education_level', 'monthly_income'];
+
+export function defaultFields() {
+  return [
+    { id: 'name', visible: true, required: true, row: null },
+    { id: 'email', visible: true, required: true, row: null },
+    { id: 'phone', visible: true, required: true, row: null },
+    { id: 'dob', visible: true, required: false, row: null },
+    { id: 'postal', visible: true, required: false, row: null },
+    { id: 'education', visible: false, required: false, row: null },
+    { id: 'salary', visible: false, required: false, row: null },
+  ];
+}
+
+/** v1 flat marketplace key ↔ v2 distribution.marketplace key map. */
+export const MARKETPLACE_V1_TO_V2 = {
+  name: 'title', category: 'category', offer_type: 'offerType', mode: 'mode',
+  qr_entry: 'qrLanding', school_levels: 'schoolLevels', dsa_related: 'dsaRelated',
+  showCapacity: 'showCapacity', inclusions: 'inclusions', image_label: 'imageAlt',
+  value_line: 'valueLine',
+};
+
+/** v1 keys CONSUMED by the migration (mapped into v2 structure). Everything
+ * else — quiz, guidedReview, luckyDraw, dead style keys, unknown/future keys —
+ * passes through verbatim (ledger L5). Also the scrub list for the v2 clamp:
+ * none of these may ride along at the top level of a v2 document. */
+export const V1_CONSUMED_KEYS = [
+  'formHeadline', 'formSubheadline', 'brandWordmark', 'storyText', 'storyEmphasis',
+  'heroCtaLabel', 'ctaText', 'regulatoryFooter', 'brandFooter',
+  'imageUrl', 'videoUrl', 'mediaType', 'themeColor', 'heroFont', 'formWidth',
+  'termsContent', 'customerHost', 'otpChannel',
+  'sgPrOnly', 'excludeAdvisors', 'dncCheckAtSubmit',
+  'visibleFields', 'requiredFields', 'fieldOrder',
+  'featuredDrop', 'marketplaceListed',
+  'name', 'category', 'offer_type', 'mode', 'qr_entry', 'age_range',
+  'school_levels', 'dsa_related', 'showCapacity', 'availability', 'inclusions',
+  'image_label', 'activation', 'sponsor', 'value_line', 'content_blocks',
+];
+
+/** Top-level v2 schema keys (used by downgrade + the clamp's alias scrub). */
+export const V2_TOP_KEYS = ['version', 'template', 'theme', 'content', 'form', 'distribution', 'ai'];
+
+// ───────────────────────── helpers (dependency-free) ─────────────────────────
+
+const isPlainObject = (v) => !!v && typeof v === 'object' && !Array.isArray(v);
+const clone = (v) => (v === undefined ? v : JSON.parse(JSON.stringify(v)));
+
+/** WCAG relative luminance — verbatim math of src/lib/contrast.js (production). */
+function luminance(hex) {
+  if (typeof hex !== 'string') return null;
+  let h = hex.replace('#', '').trim();
+  if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+  if (!/^[0-9a-fA-F]{6}$/.test(h)) return null;
+  const lin = (i) => {
+    const c = parseInt(h.slice(i, i + 2), 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * lin(0) + 0.7152 * lin(2) + 0.0722 * lin(4);
+}
+const contrastRatio = (l1, l2) => (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+
+/** Production readableTextOn parity (white floor 3, warm-ink dark, light on invalid). */
+export function onColor(bgHex, dark = '#3D1F0B', light = '#ffffff') {
+  const bg = luminance(bgHex);
+  if (bg == null) return light;
+  return contrastRatio(bg, luminance(light) ?? 1) >= 3 ? light : dark;
+}
+
+/** YouTube id extraction — EXACTLY production's three 11-char forms
+ * (LeadCaptureLayout.getYouTubeEmbedUrl); shorts/loose forms stay 'video'. */
+export function youTubeIdFrom(url) {
+  if (typeof url !== 'string' || !url) return null;
+  const patterns = [
+    /(?:youtube\.com\/watch\?v=)([a-zA-Z0-9_-]{11})/,
+    /(?:youtu\.be\/)([a-zA-Z0-9_-]{11})/,
+    /(?:youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/,
+  ];
+  for (const re of patterns) {
+    const m = url.match(re);
+    if (m) return m[1];
+  }
+  return null;
+}
+
+// ─────────────────────── version classification ───────────────────────
+
+/** 'legacy' (no version field / not an object) · 'v2' (version === 2) ·
+ * 'unsupported' (any other version value, incl. version 3 and '2'). */
+export function classifyDesignConfigVersion(doc) {
+  if (!isPlainObject(doc)) return 'legacy';
+  if (!('version' in doc)) return 'legacy';
+  return doc.version === DESIGN_CONFIG_VERSION ? 'v2' : 'unsupported';
+}
+
+export const isV2 = (doc) => classifyDesignConfigVersion(doc) === 'v2';
+
+// ───────────────────────── field model migration ─────────────────────────
+
+/** Required-flag canonicalization (ledger L1). */
+function canonicalRequired(v1Value) {
+  if (v1Value === false || v1Value === 'optional') return false;
+  if (v1Value === undefined || v1Value === null) return false;
+  return Boolean(v1Value);
+}
+
+/** v1 {visibleFields, requiredFields, fieldOrder} → canonical v2 fields[7]. */
+export function fieldsFromV1(visibleFields = {}, requiredFields = {}, fieldOrder = undefined) {
+  const rawEntries = Array.isArray(fieldOrder) && fieldOrder.length > 0 ? fieldOrder : V1_DEFAULT_ORDER;
+  const seen = new Set();
+  const ordered = [];
+  rawEntries.forEach((entry, index) => {
+    const columns = typeof entry === 'string'
+      ? [entry]
+      : isPlainObject(entry) && Array.isArray(entry.columns) ? entry.columns : [];
+    const rowId = isPlainObject(entry) && typeof entry.id === 'string' && entry.id
+      ? entry.id : `row-${index}`;
+    const valid = columns
+      .map((c) => V1_TO_V2_FIELD_ID[c])
+      .filter((id) => id && !seen.has(id));
+    valid.forEach((id) => {
+      seen.add(id);
+      // A row only pairs fields when ≥2 of its columns survived (ledger L3).
+      ordered.push({ id, row: valid.length >= 2 ? rowId : null });
+    });
+  });
+  for (const id of V1_DEFAULT_ORDER.map((k) => V1_TO_V2_FIELD_ID[k])) {
+    if (!seen.has(id)) ordered.push({ id, row: null });
+  }
+  return ordered.map(({ id, row }) => {
+    const v1Id = V2_TO_V1_FIELD_ID[id];
+    if (LOCKED_FIELD_IDS.includes(id)) return { id, visible: true, required: true, row };
+    const visible = (id === 'education' || id === 'salary')
+      ? visibleFields[v1Id] === true // opt-in fields (ledger L2)
+      : visibleFields[v1Id] !== false; // opt-out fields (dob/postal)
+    return { id, visible, required: canonicalRequired(requiredFields[v1Id]), row };
+  });
+}
+
+/** Canonical v2 fields[] → v1 {visibleFields, requiredFields, fieldOrder}. */
+export function fieldsToV1(fields) {
+  const list = Array.isArray(fields) && fields.length ? fields : defaultFields();
+  const visibleFields = { phone: true };
+  const requiredFields = {};
+  for (const f of list) {
+    if (LOCKED_FIELD_IDS.includes(f.id)) continue;
+    const v1Id = V2_TO_V1_FIELD_ID[f.id];
+    if (!v1Id) continue;
+    visibleFields[v1Id] = f.visible === true;
+    requiredFields[v1Id] = f.required === true;
+  }
+  const fieldOrder = [];
+  for (let i = 0; i < list.length; i += 1) {
+    const f = list[i];
+    const v1Id = V2_TO_V1_FIELD_ID[f.id];
+    if (!v1Id) continue;
+    if (f.row && i + 1 < list.length && list[i + 1].row === f.row) {
+      const partner = list[i + 1];
+      fieldOrder.push({ id: f.row, columns: [v1Id, V2_TO_V1_FIELD_ID[partner.id]] });
+      i += 1;
+    } else {
+      fieldOrder.push({ id: f.row || `row-${v1Id}`, columns: [v1Id] });
+    }
+  }
+  return { visibleFields, requiredFields, fieldOrder };
+}
+
+// ───────────────────────── theme migration helpers ─────────────────────────
+
+function hexToRgb(hex) {
+  if (typeof hex !== 'string') return null;
+  let h = hex.replace('#', '').trim();
+  if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+  if (!/^[0-9a-fA-F]{6}$/.test(h)) return null;
+  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
+}
+
+/** Nearest preset by accent RGB distance; invalid/absent hex → warm-cream. */
+export function nearestPresetForAccent(hex) {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return 'warm-cream';
+  let best = THEME_PRESETS[0];
+  let bestDist = Infinity;
+  for (const p of THEME_PRESETS) {
+    const prgb = hexToRgb(p.accent);
+    const d = (rgb[0] - prgb[0]) ** 2 + (rgb[1] - prgb[1]) ** 2 + (rgb[2] - prgb[2]) ** 2;
+    if (d < bestDist) { bestDist = d; best = p; }
+  }
+  return best.id;
+}
+
+// ───────────────────────── marketplace migration ─────────────────────────
+
+function marketplaceFromV1(dc) {
+  const out = {};
+  for (const [v1Key, v2Key] of Object.entries(MARKETPLACE_V1_TO_V2)) {
+    if (dc[v1Key] !== undefined) out[v2Key] = clone(dc[v1Key]);
+  }
+  if (isPlainObject(dc.age_range)) {
+    if (dc.age_range.min !== undefined) out.audienceAgeMin = dc.age_range.min;
+    if (dc.age_range.max !== undefined) out.audienceAgeMax = dc.age_range.max;
+  }
+  if (isPlainObject(dc.availability)) {
+    if (dc.availability.days !== undefined) out.days = clone(dc.availability.days);
+    if (dc.availability.slots !== undefined) out.slots = clone(dc.availability.slots);
+  }
+  if (isPlainObject(dc.activation)) {
+    const { duration_mins: durationMins, ...rest } = dc.activation;
+    out.activation = { ...clone(rest), ...(durationMins !== undefined ? { durationMins } : {}) };
+  }
+  if (dc.sponsor === null) out.sponsor = null; // explicitly-cleared sponsor is a distinct v1 state
+  else if (isPlainObject(dc.sponsor)) out.sponsor = { disclosed: true, ...clone(dc.sponsor) };
+  if (isPlainObject(dc.content_blocks)) {
+    if (dc.content_blocks.data_use !== undefined) out.dataUse = dc.content_blocks.data_use;
+    if (dc.content_blocks.cancellation !== undefined) out.cancellation = dc.content_blocks.cancellation;
+    if (dc.content_blocks.faq !== undefined) out.faq = clone(dc.content_blocks.faq);
+  }
+  if (dc.marketplaceListed !== undefined) out.listed = dc.marketplaceListed === true;
+  return Object.keys(out).length ? out : undefined;
+}
+
+export function marketplaceToV1(mk) {
+  if (!isPlainObject(mk)) return {};
+  const out = {};
+  for (const [v1Key, v2Key] of Object.entries(MARKETPLACE_V1_TO_V2)) {
+    if (mk[v2Key] !== undefined) out[v1Key] = clone(mk[v2Key]);
+  }
+  if (mk.audienceAgeMin !== undefined || mk.audienceAgeMax !== undefined) {
+    out.age_range = {
+      ...(mk.audienceAgeMin !== undefined ? { min: mk.audienceAgeMin } : {}),
+      ...(mk.audienceAgeMax !== undefined ? { max: mk.audienceAgeMax } : {}),
+    };
+  }
+  if (mk.days !== undefined || mk.slots !== undefined) {
+    out.availability = {
+      ...(mk.days !== undefined ? { days: clone(mk.days) } : {}),
+      ...(mk.slots !== undefined ? { slots: clone(mk.slots) } : {}),
+    };
+  }
+  if (isPlainObject(mk.activation)) {
+    const { durationMins, ...rest } = mk.activation;
+    out.activation = { ...clone(rest), ...(durationMins !== undefined ? { duration_mins: durationMins } : {}) };
+  }
+  if (mk.sponsor === null) out.sponsor = null;
+  else if (isPlainObject(mk.sponsor)) {
+    const { disclosed, ...rest } = mk.sponsor;
+    if (disclosed === true || Object.keys(rest).length) out.sponsor = clone(rest);
+  }
+  if (mk.dataUse !== undefined || mk.cancellation !== undefined || mk.faq !== undefined) {
+    out.content_blocks = {
+      ...(mk.dataUse !== undefined ? { data_use: mk.dataUse } : {}),
+      ...(mk.cancellation !== undefined ? { cancellation: mk.cancellation } : {}),
+      ...(mk.faq !== undefined ? { faq: clone(mk.faq) } : {}),
+    };
+  }
+  if (mk.listed !== undefined) out.marketplaceListed = mk.listed === true;
+  return out;
+}
+
+// ───────────────────────────── upgrade (v1 → v2) ─────────────────────────────
+
+/**
+ * Pure, idempotent, NON-CLAMPING v1→v2 migration. Values are preserved
+ * verbatim (over-limit copy, invalid hex, out-of-range widths survive — the
+ * SAVE clamp normalizes, exactly as it does for v1 today). Throws on
+ * unsupported versions.
+ */
+export function upgradeDesignConfig(doc) {
+  const version = classifyDesignConfigVersion(doc);
+  if (version === 'v2') return clone(doc);
+  if (version === 'unsupported') {
+    throw new Error(`Unsupported design_config version: ${JSON.stringify(doc?.version)}`);
+  }
+  const dc = isPlainObject(doc) ? doc : {};
+  const out = { version: DESIGN_CONFIG_VERSION };
+
+  // template — params bag seeded; editorial.formWidth copied only when stored.
+  const params = clone(TEMPLATE_PARAM_DEFAULTS);
+  delete params.editorial.formWidth;
+  if (dc.formWidth !== undefined) params.editorial.formWidth = clone(dc.formWidth);
+  out.template = { id: 'editorial', params };
+
+  // theme — verbatim values; preset by nearest accent distance.
+  out.theme = {
+    preset: nearestPresetForAccent(dc.themeColor),
+    accent: dc.themeColor !== undefined ? clone(dc.themeColor) : null,
+    ...(dc.heroFont !== undefined ? { font: clone(dc.heroFont) } : {}),
+  };
+
+  // content — slots mapped only when present (no default-stuffing).
+  const content = {};
+  const slot = (v1Key, v2Key) => {
+    if (dc[v1Key] !== undefined) content[v2Key] = clone(dc[v1Key]);
+  };
+  slot('brandWordmark', 'wordmark');
+  slot('formHeadline', 'headline');
+  slot('formSubheadline', 'subheadline');
+  slot('storyText', 'story');
+  slot('storyEmphasis', 'emphasis');
+  slot('heroCtaLabel', 'heroCtaLabel');
+  slot('ctaText', 'submitLabel');
+  const footer = {};
+  if (dc.regulatoryFooter !== undefined) footer.regulatory = clone(dc.regulatoryFooter);
+  if (dc.brandFooter !== undefined) footer.brand = clone(dc.brandFooter);
+  if (Object.keys(footer).length) content.footer = footer;
+  // media — kind per the renderer's own selection rules (ledger L4), inactive
+  // URLs preserved in the internal legacy shadow for exact downgrade.
+  const mediaType = dc.mediaType || (dc.imageUrl ? 'image' : 'none');
+  let kind = 'none';
+  if (mediaType === 'image') kind = 'image';
+  else if (mediaType === 'video') kind = youTubeIdFrom(dc.videoUrl) ? 'youtube' : 'video';
+  const src = kind === 'image' ? (dc.imageUrl || '') : kind === 'none' ? '' : (dc.videoUrl || '');
+  const legacy = {};
+  if (dc.imageUrl !== undefined) legacy.imageUrl = clone(dc.imageUrl);
+  if (dc.videoUrl !== undefined) legacy.videoUrl = clone(dc.videoUrl);
+  content.media = { kind, src, alt: '', ...(Object.keys(legacy).length ? { legacy } : {}) };
+  out.content = content;
+
+  // form
+  out.form = {
+    fields: fieldsFromV1(dc.visibleFields || {}, dc.requiredFields || {}, dc.fieldOrder),
+    verification: dc.otpChannel === 'whatsapp' ? 'whatsapp' : 'sms',
+    gates: {
+      sgPr: dc.sgPrOnly === true,
+      advisorExclusion: dc.excludeAdvisors === true,
+      dncCheck: dc.dncCheckAtSubmit === true,
+    },
+    ...(dc.termsContent !== undefined
+      ? { terms: { template: 'default', html: clone(dc.termsContent) } }
+      : {}),
+  };
+
+  // distribution (+ derived legacy customerHost mirror at top level)
+  const host = dc.customerHost === 'mktr' ? 'mktr' : 'redeem';
+  const marketplace = marketplaceFromV1(dc);
+  out.distribution = {
+    host,
+    ...(dc.featuredDrop !== undefined ? { featuredDrop: clone(dc.featuredDrop) } : {}),
+    ...(marketplace !== undefined ? { marketplace } : {}),
+  };
+  out.customerHost = host;
+
+  // verbatim passthrough: everything the migration did not consume (ledger L5).
+  for (const [key, value] of Object.entries(dc)) {
+    if (key === 'customerHost') continue; // rewritten as the derived mirror above
+    if (V1_CONSUMED_KEYS.includes(key)) continue;
+    out[key] = clone(value);
+  }
+  return out;
+}
+
+// ───────────────────────────── downgrade (v2 → v1) ─────────────────────────────
+
+/**
+ * Pure inverse over the render contract: a downgraded Editorial + Warm Cream
+ * doc drives the v1 renderer identically. PROPOSED/v2-only keys (template,
+ * theme extras, advertiserName, ai, media.alt) drop. Also the legacy-view
+ * adapter for backend readers during the cutover (PR 2/3).
+ */
+export function downgradeDesignConfig(doc) {
+  const version = classifyDesignConfigVersion(doc);
+  if (version === 'legacy') return clone(isPlainObject(doc) ? doc : {});
+  if (version === 'unsupported') {
+    throw new Error(`Unsupported design_config version: ${JSON.stringify(doc?.version)}`);
+  }
+  const out = {};
+
+  // passthrough first (quiz / guidedReview / luckyDraw / unknown top-level).
+  for (const [key, value] of Object.entries(doc)) {
+    if (V2_TOP_KEYS.includes(key) || key === 'customerHost') continue;
+    out[key] = clone(value);
+  }
+
+  const content = isPlainObject(doc.content) ? doc.content : {};
+  const back = (v2Key, v1Key) => {
+    if (content[v2Key] !== undefined) out[v1Key] = clone(content[v2Key]);
+  };
+  back('wordmark', 'brandWordmark');
+  back('headline', 'formHeadline');
+  back('subheadline', 'formSubheadline');
+  back('story', 'storyText');
+  back('emphasis', 'storyEmphasis');
+  back('heroCtaLabel', 'heroCtaLabel');
+  back('submitLabel', 'ctaText');
+  if (isPlainObject(content.footer)) {
+    if (content.footer.regulatory !== undefined) out.regulatoryFooter = clone(content.footer.regulatory);
+    if (content.footer.brand !== undefined) out.brandFooter = clone(content.footer.brand);
+  }
+  const media = isPlainObject(content.media) ? content.media : { kind: 'none', src: '' };
+  out.mediaType = media.kind === 'youtube' ? 'video' : (media.kind || 'none');
+  const legacy = isPlainObject(media.legacy) ? media.legacy : {};
+  if (legacy.imageUrl !== undefined) out.imageUrl = clone(legacy.imageUrl);
+  else if (media.kind === 'image' && media.src) out.imageUrl = clone(media.src);
+  if (legacy.videoUrl !== undefined) out.videoUrl = clone(legacy.videoUrl);
+  else if ((media.kind === 'video' || media.kind === 'youtube') && media.src) out.videoUrl = clone(media.src);
+
+  const theme = isPlainObject(doc.theme) ? doc.theme : {};
+  const preset = THEME_PRESETS.find((p) => p.id === theme.preset) || THEME_PRESETS[0];
+  if (theme.accent !== undefined && theme.accent !== null) out.themeColor = clone(theme.accent);
+  // A null accent means "the preset's own accent". For warm-cream that IS the
+  // v1 renderer's absent-themeColor default, so omitting the key round-trips
+  // exactly; other presets (Studio-authored, no v1 counterpart) bake theirs so
+  // the v1 renderer shows the right color.
+  else if (preset.id !== 'warm-cream') out.themeColor = preset.accent;
+  if (theme.font !== undefined) out.heroFont = clone(theme.font);
+
+  const editorialParams = doc.template?.params?.editorial;
+  if (isPlainObject(editorialParams) && editorialParams.formWidth !== undefined) {
+    out.formWidth = clone(editorialParams.formWidth);
+  }
+
+  const form = isPlainObject(doc.form) ? doc.form : {};
+  const v1Fields = fieldsToV1(form.fields);
+  out.visibleFields = v1Fields.visibleFields;
+  out.requiredFields = v1Fields.requiredFields;
+  out.fieldOrder = v1Fields.fieldOrder;
+  out.otpChannel = form.verification === 'whatsapp' ? 'whatsapp' : 'sms';
+  const gates = isPlainObject(form.gates) ? form.gates : {};
+  out.sgPrOnly = gates.sgPr === true;
+  out.excludeAdvisors = gates.advisorExclusion === true;
+  out.dncCheckAtSubmit = gates.dncCheck === true;
+  if (isPlainObject(form.terms) && form.terms.html !== undefined) out.termsContent = clone(form.terms.html);
+
+  const distribution = isPlainObject(doc.distribution) ? doc.distribution : {};
+  out.customerHost = distribution.host === 'mktr' ? 'mktr' : 'redeem';
+  if (distribution.featuredDrop !== undefined) out.featuredDrop = clone(distribution.featuredDrop);
+  Object.assign(out, marketplaceToV1(distribution.marketplace));
+
+  return out;
+}
+
+/** Backend-reader adapter: any-version doc → the v1 shape readers understand. */
+export const readLegacyView = downgradeDesignConfig;
+
+// ───────────────────────────── theme resolution ─────────────────────────────
+
+/**
+ * Resolve a v2 theme block to concrete tokens (studio-data reference
+ * implementation; onAccent via the production contrast helper). Preset-exact
+ * `rx` radii win while theme.radius is untouched or equals the preset's own.
+ */
+export function resolveTheme(theme = {}) {
+  const p = THEME_PRESETS.find((x) => x.id === theme.preset) || THEME_PRESETS[0];
+  const accent = theme.accent || p.accent;
+  const fontId = FONT_IDS.includes(theme.font) ? theme.font : p.font;
+  let r = RADII[theme.radius || p.radius] || RADII.soft;
+  if (p.rx && (!theme.radius || theme.radius === p.radius)) r = p.rx;
+  return {
+    ...p,
+    accent,
+    onAccent: onColor(accent),
+    fontId,
+    r,
+    storyCard: p.storyCard || p.card,
+    modal: p.modal || p.card,
+    bodyText: p.bodyText || p.ink,
+    divider: p.divider || p.hairline || (p.dark ? 'rgba(255,255,255,.2)' : 'rgba(0,0,0,.16)'),
+    accentDeep: p.accentDeep || accent,
+    danger: p.danger || '#B4443C',
+    success: p.success || '#2F6B43',
+    line: p.hairline || (p.dark ? 'rgba(255,255,255,.14)' : 'rgba(0,0,0,.1)'),
+    soft: p.dark ? 'rgba(255,255,255,.07)' : 'rgba(0,0,0,.045)',
+    bgCss: theme.background === 'wash'
+      ? `linear-gradient(180deg, ${accent}18, ${p.bg} 320px)`
+      : theme.background === 'grain'
+        ? `repeating-linear-gradient(45deg, ${p.dark ? 'rgba(255,255,255,.02)' : 'rgba(0,0,0,.015)'} 0 2px, transparent 2px 4px)`
+        : 'none',
+  };
+}

--- a/test-fixtures/designConfigV1ClampOracle.json
+++ b/test-fixtures/designConfigV1ClampOracle.json
@@ -1,0 +1,4674 @@
+{
+  "__provenance": {
+    "capturedAt": "pre-v2 implementation",
+    "baseCommit": "7b5f0dd",
+    "note": "Output of clampDesignConfig/buildPublicDesignConfig BEFORE any design_config-v2 code. Do not regenerate casually."
+  },
+  "results": {
+    "editorialBaseline::role=admin::stored=create": {
+      "formHeadline": "Get your $10 voucher",
+      "formSubheadline": "Your voucher code arrives by SMS after verification.",
+      "brandWordmark": "redeem.sg",
+      "storyText": "We are celebrating our new rewards programme by giving away 2,000 vouchers to Singapore households.\n\nSign up, verify your mobile number, and your voucher code arrives within minutes.",
+      "storyEmphasis": "S$10, yours in under a minute.",
+      "heroCtaLabel": "Claim my voucher",
+      "ctaText": "Redeem Now",
+      "regulatoryFooter": "Redeem (a service of MKTR PTE. LTD., UEN: 202507548M) operates this referral platform.",
+      "brandFooter": "Powered by MKTR",
+      "imageUrl": "/uploads/campaign-assets/groceries.jpg",
+      "themeColor": "#D17029",
+      "heroFont": "fraunces",
+      "formWidth": 400,
+      "mediaType": "image",
+      "videoUrl": "",
+      "termsContent": "<h4>Campaign Terms</h4><p>One registration per person.</p>",
+      "customerHost": "redeem",
+      "otpChannel": "sms",
+      "sgPrOnly": true,
+      "excludeAdvisors": false,
+      "dncCheckAtSubmit": true,
+      "visibleFields": {
+        "phone": true,
+        "dob": true,
+        "postal_code": true
+      },
+      "requiredFields": {
+        "dob": true,
+        "postal_code": false
+      },
+      "fieldOrder": [
+        {
+          "id": "r-name",
+          "columns": [
+            "name"
+          ]
+        },
+        {
+          "id": "r-phone",
+          "columns": [
+            "phone"
+          ]
+        },
+        {
+          "id": "r-email",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "id": "r-pair",
+          "columns": [
+            "dob",
+            "postal_code"
+          ]
+        },
+        {
+          "id": "r-edu",
+          "columns": [
+            "education_level"
+          ]
+        },
+        {
+          "id": "r-inc",
+          "columns": [
+            "monthly_income"
+          ]
+        }
+      ],
+      "quiz": null
+    },
+    "editorialBaseline::role=admin::stored=updateOverRich": {
+      "formHeadline": "Get your $10 voucher",
+      "formSubheadline": "Your voucher code arrives by SMS after verification.",
+      "brandWordmark": "redeem.sg",
+      "storyText": "We are celebrating our new rewards programme by giving away 2,000 vouchers to Singapore households.\n\nSign up, verify your mobile number, and your voucher code arrives within minutes.",
+      "storyEmphasis": "S$10, yours in under a minute.",
+      "heroCtaLabel": "Claim my voucher",
+      "ctaText": "Redeem Now",
+      "regulatoryFooter": "Redeem (a service of MKTR PTE. LTD., UEN: 202507548M) operates this referral platform.",
+      "brandFooter": "Powered by MKTR",
+      "imageUrl": "/uploads/campaign-assets/groceries.jpg",
+      "themeColor": "#D17029",
+      "heroFont": "fraunces",
+      "formWidth": 400,
+      "mediaType": "image",
+      "videoUrl": "",
+      "termsContent": "<h4>Campaign Terms</h4><p>One registration per person.</p>",
+      "customerHost": "redeem",
+      "otpChannel": "sms",
+      "sgPrOnly": true,
+      "excludeAdvisors": false,
+      "dncCheckAtSubmit": true,
+      "visibleFields": {
+        "phone": true,
+        "dob": true,
+        "postal_code": true
+      },
+      "requiredFields": {
+        "dob": true,
+        "postal_code": false
+      },
+      "fieldOrder": [
+        {
+          "id": "r-name",
+          "columns": [
+            "name"
+          ]
+        },
+        {
+          "id": "r-phone",
+          "columns": [
+            "phone"
+          ]
+        },
+        {
+          "id": "r-email",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "id": "r-pair",
+          "columns": [
+            "dob",
+            "postal_code"
+          ]
+        },
+        {
+          "id": "r-edu",
+          "columns": [
+            "education_level"
+          ]
+        },
+        {
+          "id": "r-inc",
+          "columns": [
+            "monthly_income"
+          ]
+        }
+      ],
+      "quiz": null,
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "editorialBaseline::role=agent::stored=create": {
+      "formHeadline": "Get your $10 voucher",
+      "formSubheadline": "Your voucher code arrives by SMS after verification.",
+      "brandWordmark": "redeem.sg",
+      "storyText": "We are celebrating our new rewards programme by giving away 2,000 vouchers to Singapore households.\n\nSign up, verify your mobile number, and your voucher code arrives within minutes.",
+      "storyEmphasis": "S$10, yours in under a minute.",
+      "heroCtaLabel": "Claim my voucher",
+      "ctaText": "Redeem Now",
+      "regulatoryFooter": "Redeem (a service of MKTR PTE. LTD., UEN: 202507548M) operates this referral platform.",
+      "brandFooter": "Powered by MKTR",
+      "imageUrl": "/uploads/campaign-assets/groceries.jpg",
+      "themeColor": "#D17029",
+      "heroFont": "fraunces",
+      "formWidth": 400,
+      "mediaType": "image",
+      "videoUrl": "",
+      "termsContent": "<h4>Campaign Terms</h4><p>One registration per person.</p>",
+      "customerHost": "redeem",
+      "otpChannel": "sms",
+      "sgPrOnly": true,
+      "excludeAdvisors": false,
+      "dncCheckAtSubmit": true,
+      "visibleFields": {
+        "phone": true,
+        "dob": true,
+        "postal_code": true
+      },
+      "requiredFields": {
+        "dob": true,
+        "postal_code": false
+      },
+      "fieldOrder": [
+        {
+          "id": "r-name",
+          "columns": [
+            "name"
+          ]
+        },
+        {
+          "id": "r-phone",
+          "columns": [
+            "phone"
+          ]
+        },
+        {
+          "id": "r-email",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "id": "r-pair",
+          "columns": [
+            "dob",
+            "postal_code"
+          ]
+        },
+        {
+          "id": "r-edu",
+          "columns": [
+            "education_level"
+          ]
+        },
+        {
+          "id": "r-inc",
+          "columns": [
+            "monthly_income"
+          ]
+        }
+      ],
+      "quiz": null
+    },
+    "editorialBaseline::role=agent::stored=updateOverRich": {
+      "formHeadline": "Get your $10 voucher",
+      "formSubheadline": "Your voucher code arrives by SMS after verification.",
+      "brandWordmark": "redeem.sg",
+      "storyText": "We are celebrating our new rewards programme by giving away 2,000 vouchers to Singapore households.\n\nSign up, verify your mobile number, and your voucher code arrives within minutes.",
+      "storyEmphasis": "S$10, yours in under a minute.",
+      "heroCtaLabel": "Claim my voucher",
+      "ctaText": "Redeem Now",
+      "regulatoryFooter": "Redeem (a service of MKTR PTE. LTD., UEN: 202507548M) operates this referral platform.",
+      "brandFooter": "Powered by MKTR",
+      "imageUrl": "/uploads/campaign-assets/groceries.jpg",
+      "themeColor": "#D17029",
+      "heroFont": "fraunces",
+      "formWidth": 400,
+      "mediaType": "image",
+      "videoUrl": "",
+      "termsContent": "<h4>Campaign Terms</h4><p>One registration per person.</p>",
+      "customerHost": "redeem",
+      "otpChannel": "sms",
+      "sgPrOnly": true,
+      "excludeAdvisors": false,
+      "dncCheckAtSubmit": true,
+      "visibleFields": {
+        "phone": true,
+        "dob": true,
+        "postal_code": true
+      },
+      "requiredFields": {
+        "dob": true,
+        "postal_code": false
+      },
+      "fieldOrder": [
+        {
+          "id": "r-name",
+          "columns": [
+            "name"
+          ]
+        },
+        {
+          "id": "r-phone",
+          "columns": [
+            "phone"
+          ]
+        },
+        {
+          "id": "r-email",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "id": "r-pair",
+          "columns": [
+            "dob",
+            "postal_code"
+          ]
+        },
+        {
+          "id": "r-edu",
+          "columns": [
+            "education_level"
+          ]
+        },
+        {
+          "id": "r-inc",
+          "columns": [
+            "monthly_income"
+          ]
+        }
+      ],
+      "quiz": null,
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "editorialBaseline::role=none::stored=create": {
+      "formHeadline": "Get your $10 voucher",
+      "formSubheadline": "Your voucher code arrives by SMS after verification.",
+      "brandWordmark": "redeem.sg",
+      "storyText": "We are celebrating our new rewards programme by giving away 2,000 vouchers to Singapore households.\n\nSign up, verify your mobile number, and your voucher code arrives within minutes.",
+      "storyEmphasis": "S$10, yours in under a minute.",
+      "heroCtaLabel": "Claim my voucher",
+      "ctaText": "Redeem Now",
+      "regulatoryFooter": "Redeem (a service of MKTR PTE. LTD., UEN: 202507548M) operates this referral platform.",
+      "brandFooter": "Powered by MKTR",
+      "imageUrl": "/uploads/campaign-assets/groceries.jpg",
+      "themeColor": "#D17029",
+      "heroFont": "fraunces",
+      "formWidth": 400,
+      "mediaType": "image",
+      "videoUrl": "",
+      "termsContent": "<h4>Campaign Terms</h4><p>One registration per person.</p>",
+      "customerHost": "redeem",
+      "otpChannel": "sms",
+      "sgPrOnly": true,
+      "excludeAdvisors": false,
+      "dncCheckAtSubmit": true,
+      "visibleFields": {
+        "phone": true,
+        "dob": true,
+        "postal_code": true
+      },
+      "requiredFields": {
+        "dob": true,
+        "postal_code": false
+      },
+      "fieldOrder": [
+        {
+          "id": "r-name",
+          "columns": [
+            "name"
+          ]
+        },
+        {
+          "id": "r-phone",
+          "columns": [
+            "phone"
+          ]
+        },
+        {
+          "id": "r-email",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "id": "r-pair",
+          "columns": [
+            "dob",
+            "postal_code"
+          ]
+        },
+        {
+          "id": "r-edu",
+          "columns": [
+            "education_level"
+          ]
+        },
+        {
+          "id": "r-inc",
+          "columns": [
+            "monthly_income"
+          ]
+        }
+      ],
+      "quiz": null
+    },
+    "editorialBaseline::role=none::stored=updateOverRich": {
+      "formHeadline": "Get your $10 voucher",
+      "formSubheadline": "Your voucher code arrives by SMS after verification.",
+      "brandWordmark": "redeem.sg",
+      "storyText": "We are celebrating our new rewards programme by giving away 2,000 vouchers to Singapore households.\n\nSign up, verify your mobile number, and your voucher code arrives within minutes.",
+      "storyEmphasis": "S$10, yours in under a minute.",
+      "heroCtaLabel": "Claim my voucher",
+      "ctaText": "Redeem Now",
+      "regulatoryFooter": "Redeem (a service of MKTR PTE. LTD., UEN: 202507548M) operates this referral platform.",
+      "brandFooter": "Powered by MKTR",
+      "imageUrl": "/uploads/campaign-assets/groceries.jpg",
+      "themeColor": "#D17029",
+      "heroFont": "fraunces",
+      "formWidth": 400,
+      "mediaType": "image",
+      "videoUrl": "",
+      "termsContent": "<h4>Campaign Terms</h4><p>One registration per person.</p>",
+      "customerHost": "redeem",
+      "otpChannel": "sms",
+      "sgPrOnly": true,
+      "excludeAdvisors": false,
+      "dncCheckAtSubmit": true,
+      "visibleFields": {
+        "phone": true,
+        "dob": true,
+        "postal_code": true
+      },
+      "requiredFields": {
+        "dob": true,
+        "postal_code": false
+      },
+      "fieldOrder": [
+        {
+          "id": "r-name",
+          "columns": [
+            "name"
+          ]
+        },
+        {
+          "id": "r-phone",
+          "columns": [
+            "phone"
+          ]
+        },
+        {
+          "id": "r-email",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "id": "r-pair",
+          "columns": [
+            "dob",
+            "postal_code"
+          ]
+        },
+        {
+          "id": "r-edu",
+          "columns": [
+            "education_level"
+          ]
+        },
+        {
+          "id": "r-inc",
+          "columns": [
+            "monthly_income"
+          ]
+        }
+      ],
+      "quiz": null,
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "editorialBaseline::public": {
+      "themeColor": "#D17029",
+      "heroFont": "fraunces",
+      "imageUrl": "/uploads/campaign-assets/groceries.jpg",
+      "videoUrl": "",
+      "mediaType": "image",
+      "storyText": "We are celebrating our new rewards programme by giving away 2,000 vouchers to Singapore households.\n\nSign up, verify your mobile number, and your voucher code arrives within minutes.",
+      "storyEmphasis": "S$10, yours in under a minute.",
+      "heroCtaLabel": "Claim my voucher",
+      "ctaText": "Redeem Now",
+      "formHeadline": "Get your $10 voucher",
+      "formSubheadline": "Your voucher code arrives by SMS after verification.",
+      "formWidth": 400,
+      "brandWordmark": "redeem.sg",
+      "brandFooter": "Powered by MKTR",
+      "regulatoryFooter": "Redeem (a service of MKTR PTE. LTD., UEN: 202507548M) operates this referral platform.",
+      "termsContent": "<h4>Campaign Terms</h4><p>One registration per person.</p>",
+      "customerHost": "redeem",
+      "fieldOrder": [
+        {
+          "id": "r-name",
+          "columns": [
+            "name"
+          ]
+        },
+        {
+          "id": "r-phone",
+          "columns": [
+            "phone"
+          ]
+        },
+        {
+          "id": "r-email",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "id": "r-pair",
+          "columns": [
+            "dob",
+            "postal_code"
+          ]
+        },
+        {
+          "id": "r-edu",
+          "columns": [
+            "education_level"
+          ]
+        },
+        {
+          "id": "r-inc",
+          "columns": [
+            "monthly_income"
+          ]
+        }
+      ],
+      "visibleFields": {
+        "phone": true,
+        "dob": true,
+        "postal_code": true
+      },
+      "requiredFields": {
+        "dob": true,
+        "postal_code": false
+      },
+      "sgPrOnly": true,
+      "excludeAdvisors": false,
+      "dncCheckAtSubmit": true,
+      "otpChannel": "sms",
+      "quiz": null
+    },
+    "quizCampaign::role=admin::stored=create": {
+      "formHeadline": "Ready to raise your ceiling?",
+      "formSubheadline": "Claim your complimentary 20-minute session.",
+      "themeColor": "#8A5BB8",
+      "heroFont": "space-grotesk",
+      "customerHost": "redeem",
+      "otpChannel": "whatsapp",
+      "sgPrOnly": false,
+      "excludeAdvisors": true,
+      "dncCheckAtSubmit": true,
+      "visibleFields": {
+        "education_level": true,
+        "monthly_income": true,
+        "dob": false,
+        "postal_code": false
+      },
+      "requiredFields": {},
+      "quiz": {
+        "enabled": true,
+        "quizId": "protection-personality",
+        "version": 2,
+        "scoring": {
+          "method": "profile-sum",
+          "tiebreak": "prepared-first",
+          "profileOrder": [
+            "the-rock",
+            "the-strategist",
+            "the-dreamer",
+            "the-free-spirit"
+          ],
+          "readiness": {
+            "enabled": true,
+            "label": "Your Protection Readiness",
+            "rankFactor": {
+              "the-rock": 1,
+              "the-strategist": 0.66,
+              "the-dreamer": 0.33,
+              "the-free-spirit": 0
+            }
+          },
+          "leadScore": {
+            "enabled": true,
+            "tagPoints": {
+              "exposed": 3,
+              "uncertain": 2,
+              "covered": 1,
+              "confident": 0,
+              "family-dependents": 3,
+              "couple": 2,
+              "single": 1,
+              "single-free": 1,
+              "life-income": 2,
+              "savings-retirement": 2,
+              "nurture-warm": 1,
+              "nurture-cold": 0
+            },
+            "bands": [
+              {
+                "gte": 6,
+                "label": "Hot",
+                "badge": "🔥"
+              },
+              {
+                "gte": 3,
+                "label": "Warm",
+                "badge": "🌤️"
+              },
+              {
+                "label": "Cool",
+                "badge": "❄️"
+              }
+            ]
+          }
+        },
+        "steps": [
+          {
+            "id": "step1",
+            "questions": [
+              {
+                "id": "q1_weekend",
+                "prompt": "Pick your ideal weekend",
+                "weight": 1,
+                "options": [
+                  {
+                    "id": "cosy",
+                    "scores": {
+                      "the-rock": 1
+                    }
+                  },
+                  {
+                    "id": "mix",
+                    "scores": {
+                      "the-strategist": 1
+                    }
+                  },
+                  {
+                    "id": "adventure",
+                    "scores": {
+                      "the-dreamer": 1
+                    }
+                  },
+                  {
+                    "id": "night",
+                    "scores": {
+                      "the-free-spirit": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step2",
+            "questions": [
+              {
+                "id": "q2_payday",
+                "prompt": "Payday hits. First move?",
+                "weight": 2,
+                "options": [
+                  {
+                    "id": "save",
+                    "scores": {
+                      "the-rock": 1
+                    }
+                  },
+                  {
+                    "id": "split",
+                    "scores": {
+                      "the-strategist": 1
+                    }
+                  },
+                  {
+                    "id": "bills",
+                    "scores": {
+                      "the-dreamer": 1
+                    }
+                  },
+                  {
+                    "id": "treat",
+                    "scores": {
+                      "the-free-spirit": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step3",
+            "questions": [
+              {
+                "id": "q3_circle",
+                "prompt": "Who's in your circle right now?",
+                "weight": 2,
+                "options": [
+                  {
+                    "id": "family",
+                    "scores": {
+                      "the-rock": 1
+                    },
+                    "tag": "family-dependents"
+                  },
+                  {
+                    "id": "partner",
+                    "scores": {
+                      "the-strategist": 1
+                    },
+                    "tag": "couple"
+                  },
+                  {
+                    "id": "solo",
+                    "scores": {
+                      "the-dreamer": 1
+                    },
+                    "tag": "single"
+                  },
+                  {
+                    "id": "free",
+                    "scores": {
+                      "the-free-spirit": 1
+                    },
+                    "tag": "single-free"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step4",
+            "questions": [
+              {
+                "id": "q4_worry",
+                "prompt": "The 'what if' that nags you most?",
+                "weight": 1,
+                "options": [
+                  {
+                    "id": "family_ok",
+                    "scores": {
+                      "the-rock": 1
+                    },
+                    "tag": "life-income"
+                  },
+                  {
+                    "id": "saving",
+                    "scores": {
+                      "the-strategist": 1
+                    },
+                    "tag": "savings-retirement"
+                  },
+                  {
+                    "id": "eventually",
+                    "scores": {
+                      "the-dreamer": 1
+                    },
+                    "tag": "nurture-warm"
+                  },
+                  {
+                    "id": "avoid",
+                    "scores": {
+                      "the-free-spirit": 1
+                    },
+                    "tag": "nurture-cold"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step5",
+            "questions": [
+              {
+                "id": "q5_protected",
+                "prompt": "How protected do you feel right now?",
+                "weight": 3,
+                "options": [
+                  {
+                    "id": "solid",
+                    "scores": {
+                      "the-rock": 1
+                    },
+                    "tag": "confident"
+                  },
+                  {
+                    "id": "basics",
+                    "scores": {
+                      "the-strategist": 1
+                    },
+                    "tag": "covered"
+                  },
+                  {
+                    "id": "patchy",
+                    "scores": {
+                      "the-dreamer": 1
+                    },
+                    "tag": "uncertain"
+                  },
+                  {
+                    "id": "exposed",
+                    "scores": {
+                      "the-free-spirit": 1
+                    },
+                    "tag": "exposed"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step6",
+            "questions": [
+              {
+                "id": "q6_bill",
+                "prompt": "A surprise $5,000 bill lands tomorrow. You…",
+                "weight": 3,
+                "options": [
+                  {
+                    "id": "fund",
+                    "scores": {
+                      "the-rock": 1
+                    }
+                  },
+                  {
+                    "id": "sting",
+                    "scores": {
+                      "the-strategist": 1
+                    }
+                  },
+                  {
+                    "id": "credit",
+                    "scores": {
+                      "the-dreamer": 1
+                    }
+                  },
+                  {
+                    "id": "later",
+                    "scores": {
+                      "the-free-spirit": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "resultProfiles": [
+          {
+            "id": "the-rock",
+            "title": "The Rock",
+            "agentAngle": "optimise / legacy / wealth transfer"
+          },
+          {
+            "id": "the-strategist",
+            "title": "The Strategist",
+            "agentAngle": "savings / retirement top-up"
+          },
+          {
+            "id": "the-dreamer",
+            "title": "The Big Dreamer",
+            "agentAngle": "starter health + CI, then savings"
+          },
+          {
+            "id": "the-free-spirit",
+            "title": "The Free Spirit",
+            "agentAngle": "affordable starter protection"
+          }
+        ]
+      }
+    },
+    "quizCampaign::role=admin::stored=updateOverRich": {
+      "formHeadline": "Ready to raise your ceiling?",
+      "formSubheadline": "Claim your complimentary 20-minute session.",
+      "themeColor": "#8A5BB8",
+      "heroFont": "space-grotesk",
+      "customerHost": "redeem",
+      "otpChannel": "whatsapp",
+      "sgPrOnly": false,
+      "excludeAdvisors": true,
+      "dncCheckAtSubmit": true,
+      "visibleFields": {
+        "education_level": true,
+        "monthly_income": true,
+        "dob": false,
+        "postal_code": false
+      },
+      "requiredFields": {},
+      "quiz": {
+        "enabled": true,
+        "quizId": "protection-personality",
+        "version": 2,
+        "scoring": {
+          "method": "profile-sum",
+          "tiebreak": "prepared-first",
+          "profileOrder": [
+            "the-rock",
+            "the-strategist",
+            "the-dreamer",
+            "the-free-spirit"
+          ],
+          "readiness": {
+            "enabled": true,
+            "label": "Your Protection Readiness",
+            "rankFactor": {
+              "the-rock": 1,
+              "the-strategist": 0.66,
+              "the-dreamer": 0.33,
+              "the-free-spirit": 0
+            }
+          },
+          "leadScore": {
+            "enabled": true,
+            "tagPoints": {
+              "exposed": 3,
+              "uncertain": 2,
+              "covered": 1,
+              "confident": 0,
+              "family-dependents": 3,
+              "couple": 2,
+              "single": 1,
+              "single-free": 1,
+              "life-income": 2,
+              "savings-retirement": 2,
+              "nurture-warm": 1,
+              "nurture-cold": 0
+            },
+            "bands": [
+              {
+                "gte": 6,
+                "label": "Hot",
+                "badge": "🔥"
+              },
+              {
+                "gte": 3,
+                "label": "Warm",
+                "badge": "🌤️"
+              },
+              {
+                "label": "Cool",
+                "badge": "❄️"
+              }
+            ]
+          }
+        },
+        "steps": [
+          {
+            "id": "step1",
+            "questions": [
+              {
+                "id": "q1_weekend",
+                "prompt": "Pick your ideal weekend",
+                "weight": 1,
+                "options": [
+                  {
+                    "id": "cosy",
+                    "scores": {
+                      "the-rock": 1
+                    }
+                  },
+                  {
+                    "id": "mix",
+                    "scores": {
+                      "the-strategist": 1
+                    }
+                  },
+                  {
+                    "id": "adventure",
+                    "scores": {
+                      "the-dreamer": 1
+                    }
+                  },
+                  {
+                    "id": "night",
+                    "scores": {
+                      "the-free-spirit": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step2",
+            "questions": [
+              {
+                "id": "q2_payday",
+                "prompt": "Payday hits. First move?",
+                "weight": 2,
+                "options": [
+                  {
+                    "id": "save",
+                    "scores": {
+                      "the-rock": 1
+                    }
+                  },
+                  {
+                    "id": "split",
+                    "scores": {
+                      "the-strategist": 1
+                    }
+                  },
+                  {
+                    "id": "bills",
+                    "scores": {
+                      "the-dreamer": 1
+                    }
+                  },
+                  {
+                    "id": "treat",
+                    "scores": {
+                      "the-free-spirit": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step3",
+            "questions": [
+              {
+                "id": "q3_circle",
+                "prompt": "Who's in your circle right now?",
+                "weight": 2,
+                "options": [
+                  {
+                    "id": "family",
+                    "scores": {
+                      "the-rock": 1
+                    },
+                    "tag": "family-dependents"
+                  },
+                  {
+                    "id": "partner",
+                    "scores": {
+                      "the-strategist": 1
+                    },
+                    "tag": "couple"
+                  },
+                  {
+                    "id": "solo",
+                    "scores": {
+                      "the-dreamer": 1
+                    },
+                    "tag": "single"
+                  },
+                  {
+                    "id": "free",
+                    "scores": {
+                      "the-free-spirit": 1
+                    },
+                    "tag": "single-free"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step4",
+            "questions": [
+              {
+                "id": "q4_worry",
+                "prompt": "The 'what if' that nags you most?",
+                "weight": 1,
+                "options": [
+                  {
+                    "id": "family_ok",
+                    "scores": {
+                      "the-rock": 1
+                    },
+                    "tag": "life-income"
+                  },
+                  {
+                    "id": "saving",
+                    "scores": {
+                      "the-strategist": 1
+                    },
+                    "tag": "savings-retirement"
+                  },
+                  {
+                    "id": "eventually",
+                    "scores": {
+                      "the-dreamer": 1
+                    },
+                    "tag": "nurture-warm"
+                  },
+                  {
+                    "id": "avoid",
+                    "scores": {
+                      "the-free-spirit": 1
+                    },
+                    "tag": "nurture-cold"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step5",
+            "questions": [
+              {
+                "id": "q5_protected",
+                "prompt": "How protected do you feel right now?",
+                "weight": 3,
+                "options": [
+                  {
+                    "id": "solid",
+                    "scores": {
+                      "the-rock": 1
+                    },
+                    "tag": "confident"
+                  },
+                  {
+                    "id": "basics",
+                    "scores": {
+                      "the-strategist": 1
+                    },
+                    "tag": "covered"
+                  },
+                  {
+                    "id": "patchy",
+                    "scores": {
+                      "the-dreamer": 1
+                    },
+                    "tag": "uncertain"
+                  },
+                  {
+                    "id": "exposed",
+                    "scores": {
+                      "the-free-spirit": 1
+                    },
+                    "tag": "exposed"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step6",
+            "questions": [
+              {
+                "id": "q6_bill",
+                "prompt": "A surprise $5,000 bill lands tomorrow. You…",
+                "weight": 3,
+                "options": [
+                  {
+                    "id": "fund",
+                    "scores": {
+                      "the-rock": 1
+                    }
+                  },
+                  {
+                    "id": "sting",
+                    "scores": {
+                      "the-strategist": 1
+                    }
+                  },
+                  {
+                    "id": "credit",
+                    "scores": {
+                      "the-dreamer": 1
+                    }
+                  },
+                  {
+                    "id": "later",
+                    "scores": {
+                      "the-free-spirit": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "resultProfiles": [
+          {
+            "id": "the-rock",
+            "title": "The Rock",
+            "agentAngle": "optimise / legacy / wealth transfer"
+          },
+          {
+            "id": "the-strategist",
+            "title": "The Strategist",
+            "agentAngle": "savings / retirement top-up"
+          },
+          {
+            "id": "the-dreamer",
+            "title": "The Big Dreamer",
+            "agentAngle": "starter health + CI, then savings"
+          },
+          {
+            "id": "the-free-spirit",
+            "title": "The Free Spirit",
+            "agentAngle": "affordable starter protection"
+          }
+        ]
+      },
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "quizCampaign::role=agent::stored=create": {
+      "formHeadline": "Ready to raise your ceiling?",
+      "formSubheadline": "Claim your complimentary 20-minute session.",
+      "themeColor": "#8A5BB8",
+      "heroFont": "space-grotesk",
+      "customerHost": "redeem",
+      "otpChannel": "whatsapp",
+      "sgPrOnly": false,
+      "excludeAdvisors": true,
+      "dncCheckAtSubmit": true,
+      "visibleFields": {
+        "education_level": true,
+        "monthly_income": true,
+        "dob": false,
+        "postal_code": false
+      },
+      "requiredFields": {},
+      "quiz": {
+        "enabled": true,
+        "quizId": "protection-personality",
+        "version": 2,
+        "scoring": {
+          "method": "profile-sum",
+          "tiebreak": "prepared-first",
+          "profileOrder": [
+            "the-rock",
+            "the-strategist",
+            "the-dreamer",
+            "the-free-spirit"
+          ],
+          "readiness": {
+            "enabled": true,
+            "label": "Your Protection Readiness",
+            "rankFactor": {
+              "the-rock": 1,
+              "the-strategist": 0.66,
+              "the-dreamer": 0.33,
+              "the-free-spirit": 0
+            }
+          },
+          "leadScore": {
+            "enabled": true,
+            "tagPoints": {
+              "exposed": 3,
+              "uncertain": 2,
+              "covered": 1,
+              "confident": 0,
+              "family-dependents": 3,
+              "couple": 2,
+              "single": 1,
+              "single-free": 1,
+              "life-income": 2,
+              "savings-retirement": 2,
+              "nurture-warm": 1,
+              "nurture-cold": 0
+            },
+            "bands": [
+              {
+                "gte": 6,
+                "label": "Hot",
+                "badge": "🔥"
+              },
+              {
+                "gte": 3,
+                "label": "Warm",
+                "badge": "🌤️"
+              },
+              {
+                "label": "Cool",
+                "badge": "❄️"
+              }
+            ]
+          }
+        },
+        "steps": [
+          {
+            "id": "step1",
+            "questions": [
+              {
+                "id": "q1_weekend",
+                "prompt": "Pick your ideal weekend",
+                "weight": 1,
+                "options": [
+                  {
+                    "id": "cosy",
+                    "scores": {
+                      "the-rock": 1
+                    }
+                  },
+                  {
+                    "id": "mix",
+                    "scores": {
+                      "the-strategist": 1
+                    }
+                  },
+                  {
+                    "id": "adventure",
+                    "scores": {
+                      "the-dreamer": 1
+                    }
+                  },
+                  {
+                    "id": "night",
+                    "scores": {
+                      "the-free-spirit": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step2",
+            "questions": [
+              {
+                "id": "q2_payday",
+                "prompt": "Payday hits. First move?",
+                "weight": 2,
+                "options": [
+                  {
+                    "id": "save",
+                    "scores": {
+                      "the-rock": 1
+                    }
+                  },
+                  {
+                    "id": "split",
+                    "scores": {
+                      "the-strategist": 1
+                    }
+                  },
+                  {
+                    "id": "bills",
+                    "scores": {
+                      "the-dreamer": 1
+                    }
+                  },
+                  {
+                    "id": "treat",
+                    "scores": {
+                      "the-free-spirit": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step3",
+            "questions": [
+              {
+                "id": "q3_circle",
+                "prompt": "Who's in your circle right now?",
+                "weight": 2,
+                "options": [
+                  {
+                    "id": "family",
+                    "scores": {
+                      "the-rock": 1
+                    },
+                    "tag": "family-dependents"
+                  },
+                  {
+                    "id": "partner",
+                    "scores": {
+                      "the-strategist": 1
+                    },
+                    "tag": "couple"
+                  },
+                  {
+                    "id": "solo",
+                    "scores": {
+                      "the-dreamer": 1
+                    },
+                    "tag": "single"
+                  },
+                  {
+                    "id": "free",
+                    "scores": {
+                      "the-free-spirit": 1
+                    },
+                    "tag": "single-free"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step4",
+            "questions": [
+              {
+                "id": "q4_worry",
+                "prompt": "The 'what if' that nags you most?",
+                "weight": 1,
+                "options": [
+                  {
+                    "id": "family_ok",
+                    "scores": {
+                      "the-rock": 1
+                    },
+                    "tag": "life-income"
+                  },
+                  {
+                    "id": "saving",
+                    "scores": {
+                      "the-strategist": 1
+                    },
+                    "tag": "savings-retirement"
+                  },
+                  {
+                    "id": "eventually",
+                    "scores": {
+                      "the-dreamer": 1
+                    },
+                    "tag": "nurture-warm"
+                  },
+                  {
+                    "id": "avoid",
+                    "scores": {
+                      "the-free-spirit": 1
+                    },
+                    "tag": "nurture-cold"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step5",
+            "questions": [
+              {
+                "id": "q5_protected",
+                "prompt": "How protected do you feel right now?",
+                "weight": 3,
+                "options": [
+                  {
+                    "id": "solid",
+                    "scores": {
+                      "the-rock": 1
+                    },
+                    "tag": "confident"
+                  },
+                  {
+                    "id": "basics",
+                    "scores": {
+                      "the-strategist": 1
+                    },
+                    "tag": "covered"
+                  },
+                  {
+                    "id": "patchy",
+                    "scores": {
+                      "the-dreamer": 1
+                    },
+                    "tag": "uncertain"
+                  },
+                  {
+                    "id": "exposed",
+                    "scores": {
+                      "the-free-spirit": 1
+                    },
+                    "tag": "exposed"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step6",
+            "questions": [
+              {
+                "id": "q6_bill",
+                "prompt": "A surprise $5,000 bill lands tomorrow. You…",
+                "weight": 3,
+                "options": [
+                  {
+                    "id": "fund",
+                    "scores": {
+                      "the-rock": 1
+                    }
+                  },
+                  {
+                    "id": "sting",
+                    "scores": {
+                      "the-strategist": 1
+                    }
+                  },
+                  {
+                    "id": "credit",
+                    "scores": {
+                      "the-dreamer": 1
+                    }
+                  },
+                  {
+                    "id": "later",
+                    "scores": {
+                      "the-free-spirit": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "resultProfiles": [
+          {
+            "id": "the-rock",
+            "title": "The Rock",
+            "agentAngle": "optimise / legacy / wealth transfer"
+          },
+          {
+            "id": "the-strategist",
+            "title": "The Strategist",
+            "agentAngle": "savings / retirement top-up"
+          },
+          {
+            "id": "the-dreamer",
+            "title": "The Big Dreamer",
+            "agentAngle": "starter health + CI, then savings"
+          },
+          {
+            "id": "the-free-spirit",
+            "title": "The Free Spirit",
+            "agentAngle": "affordable starter protection"
+          }
+        ]
+      }
+    },
+    "quizCampaign::role=agent::stored=updateOverRich": {
+      "formHeadline": "Ready to raise your ceiling?",
+      "formSubheadline": "Claim your complimentary 20-minute session.",
+      "themeColor": "#8A5BB8",
+      "heroFont": "space-grotesk",
+      "customerHost": "redeem",
+      "otpChannel": "whatsapp",
+      "sgPrOnly": false,
+      "excludeAdvisors": true,
+      "dncCheckAtSubmit": true,
+      "visibleFields": {
+        "education_level": true,
+        "monthly_income": true,
+        "dob": false,
+        "postal_code": false
+      },
+      "requiredFields": {},
+      "quiz": {
+        "enabled": true,
+        "quizId": "protection-personality",
+        "version": 2,
+        "scoring": {
+          "method": "profile-sum",
+          "tiebreak": "prepared-first",
+          "profileOrder": [
+            "the-rock",
+            "the-strategist",
+            "the-dreamer",
+            "the-free-spirit"
+          ],
+          "readiness": {
+            "enabled": true,
+            "label": "Your Protection Readiness",
+            "rankFactor": {
+              "the-rock": 1,
+              "the-strategist": 0.66,
+              "the-dreamer": 0.33,
+              "the-free-spirit": 0
+            }
+          },
+          "leadScore": {
+            "enabled": true,
+            "tagPoints": {
+              "exposed": 3,
+              "uncertain": 2,
+              "covered": 1,
+              "confident": 0,
+              "family-dependents": 3,
+              "couple": 2,
+              "single": 1,
+              "single-free": 1,
+              "life-income": 2,
+              "savings-retirement": 2,
+              "nurture-warm": 1,
+              "nurture-cold": 0
+            },
+            "bands": [
+              {
+                "gte": 6,
+                "label": "Hot",
+                "badge": "🔥"
+              },
+              {
+                "gte": 3,
+                "label": "Warm",
+                "badge": "🌤️"
+              },
+              {
+                "label": "Cool",
+                "badge": "❄️"
+              }
+            ]
+          }
+        },
+        "steps": [
+          {
+            "id": "step1",
+            "questions": [
+              {
+                "id": "q1_weekend",
+                "prompt": "Pick your ideal weekend",
+                "weight": 1,
+                "options": [
+                  {
+                    "id": "cosy",
+                    "scores": {
+                      "the-rock": 1
+                    }
+                  },
+                  {
+                    "id": "mix",
+                    "scores": {
+                      "the-strategist": 1
+                    }
+                  },
+                  {
+                    "id": "adventure",
+                    "scores": {
+                      "the-dreamer": 1
+                    }
+                  },
+                  {
+                    "id": "night",
+                    "scores": {
+                      "the-free-spirit": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step2",
+            "questions": [
+              {
+                "id": "q2_payday",
+                "prompt": "Payday hits. First move?",
+                "weight": 2,
+                "options": [
+                  {
+                    "id": "save",
+                    "scores": {
+                      "the-rock": 1
+                    }
+                  },
+                  {
+                    "id": "split",
+                    "scores": {
+                      "the-strategist": 1
+                    }
+                  },
+                  {
+                    "id": "bills",
+                    "scores": {
+                      "the-dreamer": 1
+                    }
+                  },
+                  {
+                    "id": "treat",
+                    "scores": {
+                      "the-free-spirit": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step3",
+            "questions": [
+              {
+                "id": "q3_circle",
+                "prompt": "Who's in your circle right now?",
+                "weight": 2,
+                "options": [
+                  {
+                    "id": "family",
+                    "scores": {
+                      "the-rock": 1
+                    },
+                    "tag": "family-dependents"
+                  },
+                  {
+                    "id": "partner",
+                    "scores": {
+                      "the-strategist": 1
+                    },
+                    "tag": "couple"
+                  },
+                  {
+                    "id": "solo",
+                    "scores": {
+                      "the-dreamer": 1
+                    },
+                    "tag": "single"
+                  },
+                  {
+                    "id": "free",
+                    "scores": {
+                      "the-free-spirit": 1
+                    },
+                    "tag": "single-free"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step4",
+            "questions": [
+              {
+                "id": "q4_worry",
+                "prompt": "The 'what if' that nags you most?",
+                "weight": 1,
+                "options": [
+                  {
+                    "id": "family_ok",
+                    "scores": {
+                      "the-rock": 1
+                    },
+                    "tag": "life-income"
+                  },
+                  {
+                    "id": "saving",
+                    "scores": {
+                      "the-strategist": 1
+                    },
+                    "tag": "savings-retirement"
+                  },
+                  {
+                    "id": "eventually",
+                    "scores": {
+                      "the-dreamer": 1
+                    },
+                    "tag": "nurture-warm"
+                  },
+                  {
+                    "id": "avoid",
+                    "scores": {
+                      "the-free-spirit": 1
+                    },
+                    "tag": "nurture-cold"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step5",
+            "questions": [
+              {
+                "id": "q5_protected",
+                "prompt": "How protected do you feel right now?",
+                "weight": 3,
+                "options": [
+                  {
+                    "id": "solid",
+                    "scores": {
+                      "the-rock": 1
+                    },
+                    "tag": "confident"
+                  },
+                  {
+                    "id": "basics",
+                    "scores": {
+                      "the-strategist": 1
+                    },
+                    "tag": "covered"
+                  },
+                  {
+                    "id": "patchy",
+                    "scores": {
+                      "the-dreamer": 1
+                    },
+                    "tag": "uncertain"
+                  },
+                  {
+                    "id": "exposed",
+                    "scores": {
+                      "the-free-spirit": 1
+                    },
+                    "tag": "exposed"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step6",
+            "questions": [
+              {
+                "id": "q6_bill",
+                "prompt": "A surprise $5,000 bill lands tomorrow. You…",
+                "weight": 3,
+                "options": [
+                  {
+                    "id": "fund",
+                    "scores": {
+                      "the-rock": 1
+                    }
+                  },
+                  {
+                    "id": "sting",
+                    "scores": {
+                      "the-strategist": 1
+                    }
+                  },
+                  {
+                    "id": "credit",
+                    "scores": {
+                      "the-dreamer": 1
+                    }
+                  },
+                  {
+                    "id": "later",
+                    "scores": {
+                      "the-free-spirit": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "resultProfiles": [
+          {
+            "id": "the-rock",
+            "title": "The Rock",
+            "agentAngle": "optimise / legacy / wealth transfer"
+          },
+          {
+            "id": "the-strategist",
+            "title": "The Strategist",
+            "agentAngle": "savings / retirement top-up"
+          },
+          {
+            "id": "the-dreamer",
+            "title": "The Big Dreamer",
+            "agentAngle": "starter health + CI, then savings"
+          },
+          {
+            "id": "the-free-spirit",
+            "title": "The Free Spirit",
+            "agentAngle": "affordable starter protection"
+          }
+        ]
+      },
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "quizCampaign::role=none::stored=create": {
+      "formHeadline": "Ready to raise your ceiling?",
+      "formSubheadline": "Claim your complimentary 20-minute session.",
+      "themeColor": "#8A5BB8",
+      "heroFont": "space-grotesk",
+      "customerHost": "redeem",
+      "otpChannel": "whatsapp",
+      "sgPrOnly": false,
+      "excludeAdvisors": true,
+      "dncCheckAtSubmit": true,
+      "visibleFields": {
+        "education_level": true,
+        "monthly_income": true,
+        "dob": false,
+        "postal_code": false
+      },
+      "requiredFields": {},
+      "quiz": {
+        "enabled": true,
+        "quizId": "protection-personality",
+        "version": 2,
+        "scoring": {
+          "method": "profile-sum",
+          "tiebreak": "prepared-first",
+          "profileOrder": [
+            "the-rock",
+            "the-strategist",
+            "the-dreamer",
+            "the-free-spirit"
+          ],
+          "readiness": {
+            "enabled": true,
+            "label": "Your Protection Readiness",
+            "rankFactor": {
+              "the-rock": 1,
+              "the-strategist": 0.66,
+              "the-dreamer": 0.33,
+              "the-free-spirit": 0
+            }
+          },
+          "leadScore": {
+            "enabled": true,
+            "tagPoints": {
+              "exposed": 3,
+              "uncertain": 2,
+              "covered": 1,
+              "confident": 0,
+              "family-dependents": 3,
+              "couple": 2,
+              "single": 1,
+              "single-free": 1,
+              "life-income": 2,
+              "savings-retirement": 2,
+              "nurture-warm": 1,
+              "nurture-cold": 0
+            },
+            "bands": [
+              {
+                "gte": 6,
+                "label": "Hot",
+                "badge": "🔥"
+              },
+              {
+                "gte": 3,
+                "label": "Warm",
+                "badge": "🌤️"
+              },
+              {
+                "label": "Cool",
+                "badge": "❄️"
+              }
+            ]
+          }
+        },
+        "steps": [
+          {
+            "id": "step1",
+            "questions": [
+              {
+                "id": "q1_weekend",
+                "prompt": "Pick your ideal weekend",
+                "weight": 1,
+                "options": [
+                  {
+                    "id": "cosy",
+                    "scores": {
+                      "the-rock": 1
+                    }
+                  },
+                  {
+                    "id": "mix",
+                    "scores": {
+                      "the-strategist": 1
+                    }
+                  },
+                  {
+                    "id": "adventure",
+                    "scores": {
+                      "the-dreamer": 1
+                    }
+                  },
+                  {
+                    "id": "night",
+                    "scores": {
+                      "the-free-spirit": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step2",
+            "questions": [
+              {
+                "id": "q2_payday",
+                "prompt": "Payday hits. First move?",
+                "weight": 2,
+                "options": [
+                  {
+                    "id": "save",
+                    "scores": {
+                      "the-rock": 1
+                    }
+                  },
+                  {
+                    "id": "split",
+                    "scores": {
+                      "the-strategist": 1
+                    }
+                  },
+                  {
+                    "id": "bills",
+                    "scores": {
+                      "the-dreamer": 1
+                    }
+                  },
+                  {
+                    "id": "treat",
+                    "scores": {
+                      "the-free-spirit": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step3",
+            "questions": [
+              {
+                "id": "q3_circle",
+                "prompt": "Who's in your circle right now?",
+                "weight": 2,
+                "options": [
+                  {
+                    "id": "family",
+                    "scores": {
+                      "the-rock": 1
+                    },
+                    "tag": "family-dependents"
+                  },
+                  {
+                    "id": "partner",
+                    "scores": {
+                      "the-strategist": 1
+                    },
+                    "tag": "couple"
+                  },
+                  {
+                    "id": "solo",
+                    "scores": {
+                      "the-dreamer": 1
+                    },
+                    "tag": "single"
+                  },
+                  {
+                    "id": "free",
+                    "scores": {
+                      "the-free-spirit": 1
+                    },
+                    "tag": "single-free"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step4",
+            "questions": [
+              {
+                "id": "q4_worry",
+                "prompt": "The 'what if' that nags you most?",
+                "weight": 1,
+                "options": [
+                  {
+                    "id": "family_ok",
+                    "scores": {
+                      "the-rock": 1
+                    },
+                    "tag": "life-income"
+                  },
+                  {
+                    "id": "saving",
+                    "scores": {
+                      "the-strategist": 1
+                    },
+                    "tag": "savings-retirement"
+                  },
+                  {
+                    "id": "eventually",
+                    "scores": {
+                      "the-dreamer": 1
+                    },
+                    "tag": "nurture-warm"
+                  },
+                  {
+                    "id": "avoid",
+                    "scores": {
+                      "the-free-spirit": 1
+                    },
+                    "tag": "nurture-cold"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step5",
+            "questions": [
+              {
+                "id": "q5_protected",
+                "prompt": "How protected do you feel right now?",
+                "weight": 3,
+                "options": [
+                  {
+                    "id": "solid",
+                    "scores": {
+                      "the-rock": 1
+                    },
+                    "tag": "confident"
+                  },
+                  {
+                    "id": "basics",
+                    "scores": {
+                      "the-strategist": 1
+                    },
+                    "tag": "covered"
+                  },
+                  {
+                    "id": "patchy",
+                    "scores": {
+                      "the-dreamer": 1
+                    },
+                    "tag": "uncertain"
+                  },
+                  {
+                    "id": "exposed",
+                    "scores": {
+                      "the-free-spirit": 1
+                    },
+                    "tag": "exposed"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step6",
+            "questions": [
+              {
+                "id": "q6_bill",
+                "prompt": "A surprise $5,000 bill lands tomorrow. You…",
+                "weight": 3,
+                "options": [
+                  {
+                    "id": "fund",
+                    "scores": {
+                      "the-rock": 1
+                    }
+                  },
+                  {
+                    "id": "sting",
+                    "scores": {
+                      "the-strategist": 1
+                    }
+                  },
+                  {
+                    "id": "credit",
+                    "scores": {
+                      "the-dreamer": 1
+                    }
+                  },
+                  {
+                    "id": "later",
+                    "scores": {
+                      "the-free-spirit": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "resultProfiles": [
+          {
+            "id": "the-rock",
+            "title": "The Rock",
+            "agentAngle": "optimise / legacy / wealth transfer"
+          },
+          {
+            "id": "the-strategist",
+            "title": "The Strategist",
+            "agentAngle": "savings / retirement top-up"
+          },
+          {
+            "id": "the-dreamer",
+            "title": "The Big Dreamer",
+            "agentAngle": "starter health + CI, then savings"
+          },
+          {
+            "id": "the-free-spirit",
+            "title": "The Free Spirit",
+            "agentAngle": "affordable starter protection"
+          }
+        ]
+      }
+    },
+    "quizCampaign::role=none::stored=updateOverRich": {
+      "formHeadline": "Ready to raise your ceiling?",
+      "formSubheadline": "Claim your complimentary 20-minute session.",
+      "themeColor": "#8A5BB8",
+      "heroFont": "space-grotesk",
+      "customerHost": "redeem",
+      "otpChannel": "whatsapp",
+      "sgPrOnly": false,
+      "excludeAdvisors": true,
+      "dncCheckAtSubmit": true,
+      "visibleFields": {
+        "education_level": true,
+        "monthly_income": true,
+        "dob": false,
+        "postal_code": false
+      },
+      "requiredFields": {},
+      "quiz": {
+        "enabled": true,
+        "quizId": "protection-personality",
+        "version": 2,
+        "scoring": {
+          "method": "profile-sum",
+          "tiebreak": "prepared-first",
+          "profileOrder": [
+            "the-rock",
+            "the-strategist",
+            "the-dreamer",
+            "the-free-spirit"
+          ],
+          "readiness": {
+            "enabled": true,
+            "label": "Your Protection Readiness",
+            "rankFactor": {
+              "the-rock": 1,
+              "the-strategist": 0.66,
+              "the-dreamer": 0.33,
+              "the-free-spirit": 0
+            }
+          },
+          "leadScore": {
+            "enabled": true,
+            "tagPoints": {
+              "exposed": 3,
+              "uncertain": 2,
+              "covered": 1,
+              "confident": 0,
+              "family-dependents": 3,
+              "couple": 2,
+              "single": 1,
+              "single-free": 1,
+              "life-income": 2,
+              "savings-retirement": 2,
+              "nurture-warm": 1,
+              "nurture-cold": 0
+            },
+            "bands": [
+              {
+                "gte": 6,
+                "label": "Hot",
+                "badge": "🔥"
+              },
+              {
+                "gte": 3,
+                "label": "Warm",
+                "badge": "🌤️"
+              },
+              {
+                "label": "Cool",
+                "badge": "❄️"
+              }
+            ]
+          }
+        },
+        "steps": [
+          {
+            "id": "step1",
+            "questions": [
+              {
+                "id": "q1_weekend",
+                "prompt": "Pick your ideal weekend",
+                "weight": 1,
+                "options": [
+                  {
+                    "id": "cosy",
+                    "scores": {
+                      "the-rock": 1
+                    }
+                  },
+                  {
+                    "id": "mix",
+                    "scores": {
+                      "the-strategist": 1
+                    }
+                  },
+                  {
+                    "id": "adventure",
+                    "scores": {
+                      "the-dreamer": 1
+                    }
+                  },
+                  {
+                    "id": "night",
+                    "scores": {
+                      "the-free-spirit": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step2",
+            "questions": [
+              {
+                "id": "q2_payday",
+                "prompt": "Payday hits. First move?",
+                "weight": 2,
+                "options": [
+                  {
+                    "id": "save",
+                    "scores": {
+                      "the-rock": 1
+                    }
+                  },
+                  {
+                    "id": "split",
+                    "scores": {
+                      "the-strategist": 1
+                    }
+                  },
+                  {
+                    "id": "bills",
+                    "scores": {
+                      "the-dreamer": 1
+                    }
+                  },
+                  {
+                    "id": "treat",
+                    "scores": {
+                      "the-free-spirit": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step3",
+            "questions": [
+              {
+                "id": "q3_circle",
+                "prompt": "Who's in your circle right now?",
+                "weight": 2,
+                "options": [
+                  {
+                    "id": "family",
+                    "scores": {
+                      "the-rock": 1
+                    },
+                    "tag": "family-dependents"
+                  },
+                  {
+                    "id": "partner",
+                    "scores": {
+                      "the-strategist": 1
+                    },
+                    "tag": "couple"
+                  },
+                  {
+                    "id": "solo",
+                    "scores": {
+                      "the-dreamer": 1
+                    },
+                    "tag": "single"
+                  },
+                  {
+                    "id": "free",
+                    "scores": {
+                      "the-free-spirit": 1
+                    },
+                    "tag": "single-free"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step4",
+            "questions": [
+              {
+                "id": "q4_worry",
+                "prompt": "The 'what if' that nags you most?",
+                "weight": 1,
+                "options": [
+                  {
+                    "id": "family_ok",
+                    "scores": {
+                      "the-rock": 1
+                    },
+                    "tag": "life-income"
+                  },
+                  {
+                    "id": "saving",
+                    "scores": {
+                      "the-strategist": 1
+                    },
+                    "tag": "savings-retirement"
+                  },
+                  {
+                    "id": "eventually",
+                    "scores": {
+                      "the-dreamer": 1
+                    },
+                    "tag": "nurture-warm"
+                  },
+                  {
+                    "id": "avoid",
+                    "scores": {
+                      "the-free-spirit": 1
+                    },
+                    "tag": "nurture-cold"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step5",
+            "questions": [
+              {
+                "id": "q5_protected",
+                "prompt": "How protected do you feel right now?",
+                "weight": 3,
+                "options": [
+                  {
+                    "id": "solid",
+                    "scores": {
+                      "the-rock": 1
+                    },
+                    "tag": "confident"
+                  },
+                  {
+                    "id": "basics",
+                    "scores": {
+                      "the-strategist": 1
+                    },
+                    "tag": "covered"
+                  },
+                  {
+                    "id": "patchy",
+                    "scores": {
+                      "the-dreamer": 1
+                    },
+                    "tag": "uncertain"
+                  },
+                  {
+                    "id": "exposed",
+                    "scores": {
+                      "the-free-spirit": 1
+                    },
+                    "tag": "exposed"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step6",
+            "questions": [
+              {
+                "id": "q6_bill",
+                "prompt": "A surprise $5,000 bill lands tomorrow. You…",
+                "weight": 3,
+                "options": [
+                  {
+                    "id": "fund",
+                    "scores": {
+                      "the-rock": 1
+                    }
+                  },
+                  {
+                    "id": "sting",
+                    "scores": {
+                      "the-strategist": 1
+                    }
+                  },
+                  {
+                    "id": "credit",
+                    "scores": {
+                      "the-dreamer": 1
+                    }
+                  },
+                  {
+                    "id": "later",
+                    "scores": {
+                      "the-free-spirit": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "resultProfiles": [
+          {
+            "id": "the-rock",
+            "title": "The Rock",
+            "agentAngle": "optimise / legacy / wealth transfer"
+          },
+          {
+            "id": "the-strategist",
+            "title": "The Strategist",
+            "agentAngle": "savings / retirement top-up"
+          },
+          {
+            "id": "the-dreamer",
+            "title": "The Big Dreamer",
+            "agentAngle": "starter health + CI, then savings"
+          },
+          {
+            "id": "the-free-spirit",
+            "title": "The Free Spirit",
+            "agentAngle": "affordable starter protection"
+          }
+        ]
+      },
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "quizCampaign::public": {
+      "themeColor": "#8A5BB8",
+      "heroFont": "space-grotesk",
+      "formHeadline": "Ready to raise your ceiling?",
+      "formSubheadline": "Claim your complimentary 20-minute session.",
+      "customerHost": "redeem",
+      "visibleFields": {
+        "education_level": true,
+        "monthly_income": true,
+        "dob": false,
+        "postal_code": false
+      },
+      "requiredFields": {},
+      "sgPrOnly": false,
+      "excludeAdvisors": true,
+      "dncCheckAtSubmit": true,
+      "otpChannel": "whatsapp",
+      "quiz": {
+        "enabled": true,
+        "quizId": "protection-personality",
+        "version": 2,
+        "scoring": {
+          "method": "profile-sum",
+          "tiebreak": "prepared-first",
+          "profileOrder": [
+            "the-rock",
+            "the-strategist",
+            "the-dreamer",
+            "the-free-spirit"
+          ],
+          "readiness": {
+            "enabled": true,
+            "label": "Your Protection Readiness",
+            "rankFactor": {
+              "the-rock": 1,
+              "the-strategist": 0.66,
+              "the-dreamer": 0.33,
+              "the-free-spirit": 0
+            }
+          },
+          "leadScore": {
+            "enabled": true,
+            "tagPoints": {
+              "exposed": 3,
+              "uncertain": 2,
+              "covered": 1,
+              "confident": 0,
+              "family-dependents": 3,
+              "couple": 2,
+              "single": 1,
+              "single-free": 1,
+              "life-income": 2,
+              "savings-retirement": 2,
+              "nurture-warm": 1,
+              "nurture-cold": 0
+            },
+            "bands": [
+              {
+                "gte": 6,
+                "label": "Hot",
+                "badge": "🔥"
+              },
+              {
+                "gte": 3,
+                "label": "Warm",
+                "badge": "🌤️"
+              },
+              {
+                "label": "Cool",
+                "badge": "❄️"
+              }
+            ]
+          }
+        },
+        "steps": [
+          {
+            "id": "step1",
+            "questions": [
+              {
+                "id": "q1_weekend",
+                "prompt": "Pick your ideal weekend",
+                "weight": 1,
+                "options": [
+                  {
+                    "id": "cosy",
+                    "scores": {
+                      "the-rock": 1
+                    }
+                  },
+                  {
+                    "id": "mix",
+                    "scores": {
+                      "the-strategist": 1
+                    }
+                  },
+                  {
+                    "id": "adventure",
+                    "scores": {
+                      "the-dreamer": 1
+                    }
+                  },
+                  {
+                    "id": "night",
+                    "scores": {
+                      "the-free-spirit": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step2",
+            "questions": [
+              {
+                "id": "q2_payday",
+                "prompt": "Payday hits. First move?",
+                "weight": 2,
+                "options": [
+                  {
+                    "id": "save",
+                    "scores": {
+                      "the-rock": 1
+                    }
+                  },
+                  {
+                    "id": "split",
+                    "scores": {
+                      "the-strategist": 1
+                    }
+                  },
+                  {
+                    "id": "bills",
+                    "scores": {
+                      "the-dreamer": 1
+                    }
+                  },
+                  {
+                    "id": "treat",
+                    "scores": {
+                      "the-free-spirit": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step3",
+            "questions": [
+              {
+                "id": "q3_circle",
+                "prompt": "Who's in your circle right now?",
+                "weight": 2,
+                "options": [
+                  {
+                    "id": "family",
+                    "scores": {
+                      "the-rock": 1
+                    },
+                    "tag": "family-dependents"
+                  },
+                  {
+                    "id": "partner",
+                    "scores": {
+                      "the-strategist": 1
+                    },
+                    "tag": "couple"
+                  },
+                  {
+                    "id": "solo",
+                    "scores": {
+                      "the-dreamer": 1
+                    },
+                    "tag": "single"
+                  },
+                  {
+                    "id": "free",
+                    "scores": {
+                      "the-free-spirit": 1
+                    },
+                    "tag": "single-free"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step4",
+            "questions": [
+              {
+                "id": "q4_worry",
+                "prompt": "The 'what if' that nags you most?",
+                "weight": 1,
+                "options": [
+                  {
+                    "id": "family_ok",
+                    "scores": {
+                      "the-rock": 1
+                    },
+                    "tag": "life-income"
+                  },
+                  {
+                    "id": "saving",
+                    "scores": {
+                      "the-strategist": 1
+                    },
+                    "tag": "savings-retirement"
+                  },
+                  {
+                    "id": "eventually",
+                    "scores": {
+                      "the-dreamer": 1
+                    },
+                    "tag": "nurture-warm"
+                  },
+                  {
+                    "id": "avoid",
+                    "scores": {
+                      "the-free-spirit": 1
+                    },
+                    "tag": "nurture-cold"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step5",
+            "questions": [
+              {
+                "id": "q5_protected",
+                "prompt": "How protected do you feel right now?",
+                "weight": 3,
+                "options": [
+                  {
+                    "id": "solid",
+                    "scores": {
+                      "the-rock": 1
+                    },
+                    "tag": "confident"
+                  },
+                  {
+                    "id": "basics",
+                    "scores": {
+                      "the-strategist": 1
+                    },
+                    "tag": "covered"
+                  },
+                  {
+                    "id": "patchy",
+                    "scores": {
+                      "the-dreamer": 1
+                    },
+                    "tag": "uncertain"
+                  },
+                  {
+                    "id": "exposed",
+                    "scores": {
+                      "the-free-spirit": 1
+                    },
+                    "tag": "exposed"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "step6",
+            "questions": [
+              {
+                "id": "q6_bill",
+                "prompt": "A surprise $5,000 bill lands tomorrow. You…",
+                "weight": 3,
+                "options": [
+                  {
+                    "id": "fund",
+                    "scores": {
+                      "the-rock": 1
+                    }
+                  },
+                  {
+                    "id": "sting",
+                    "scores": {
+                      "the-strategist": 1
+                    }
+                  },
+                  {
+                    "id": "credit",
+                    "scores": {
+                      "the-dreamer": 1
+                    }
+                  },
+                  {
+                    "id": "later",
+                    "scores": {
+                      "the-free-spirit": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "resultProfiles": [
+          {
+            "id": "the-rock",
+            "title": "The Rock",
+            "agentAngle": "optimise / legacy / wealth transfer"
+          },
+          {
+            "id": "the-strategist",
+            "title": "The Strategist",
+            "agentAngle": "savings / retirement top-up"
+          },
+          {
+            "id": "the-dreamer",
+            "title": "The Big Dreamer",
+            "agentAngle": "starter health + CI, then savings"
+          },
+          {
+            "id": "the-free-spirit",
+            "title": "The Free Spirit",
+            "agentAngle": "affordable starter protection"
+          }
+        ]
+      }
+    },
+    "adminRichDoc::role=admin::stored=create": {
+      "formHeadline": "Win a 4D3N Tokyo getaway for two",
+      "themeColor": "#232529",
+      "heroFont": "playfair",
+      "customerHost": "redeem",
+      "mediaType": "video",
+      "videoUrl": "/uploads/campaign-assets/tokyo-hero.mp4",
+      "imageUrl": "/uploads/campaign-assets/tokyo-fallback.jpg",
+      "termsContent": "<h4>Draw Terms</h4><p>Winner drawn 31 Aug 2026.</p>",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true,
+      "name": "Tokyo Getaway Lucky Draw — 4D3N for two",
+      "offer_type": "reward",
+      "mode": "online",
+      "age_range": {
+        "min": 21,
+        "max": 65
+      },
+      "school_levels": [
+        "primary",
+        "seconda"
+      ],
+      "dsa_related": false,
+      "showCapacity": true,
+      "availability": {
+        "days": [],
+        "slots": [
+          "10:00",
+          "14:00"
+        ]
+      },
+      "inclusions": [
+        "Return flights for two",
+        "3 nights hotel (4-star)"
+      ],
+      "image_label": "Tokyo skyline at dusk",
+      "activation": {
+        "required": true,
+        "type": "consult",
+        "duration_mins": 20,
+        "summary": "Short activation call"
+      },
+      "sponsor": {
+        "kind": "agency",
+        "disclosure": "Sponsored by MKTR Travel Partners."
+      },
+      "value_line": "Grand prize worth S$3,800",
+      "content_blocks": {
+        "data_use": "Used for draw administration only."
+      }
+    },
+    "adminRichDoc::role=admin::stored=updateOverRich": {
+      "formHeadline": "Win a 4D3N Tokyo getaway for two",
+      "themeColor": "#232529",
+      "heroFont": "playfair",
+      "customerHost": "redeem",
+      "mediaType": "video",
+      "videoUrl": "/uploads/campaign-assets/tokyo-hero.mp4",
+      "imageUrl": "/uploads/campaign-assets/tokyo-fallback.jpg",
+      "termsContent": "<h4>Draw Terms</h4><p>Winner drawn 31 Aug 2026.</p>",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true,
+      "name": "Tokyo Getaway Lucky Draw — 4D3N for two",
+      "offer_type": "reward",
+      "mode": "online",
+      "age_range": {
+        "min": 21,
+        "max": 65
+      },
+      "school_levels": [
+        "primary",
+        "seconda"
+      ],
+      "dsa_related": false,
+      "showCapacity": true,
+      "availability": {
+        "days": [],
+        "slots": [
+          "10:00",
+          "14:00"
+        ]
+      },
+      "inclusions": [
+        "Return flights for two",
+        "3 nights hotel (4-star)"
+      ],
+      "image_label": "Tokyo skyline at dusk",
+      "activation": {
+        "required": true,
+        "type": "consult",
+        "duration_mins": 20,
+        "summary": "Short activation call"
+      },
+      "sponsor": {
+        "kind": "agency",
+        "disclosure": "Sponsored by MKTR Travel Partners."
+      },
+      "value_line": "Grand prize worth S$3,800",
+      "content_blocks": {
+        "data_use": "Used for draw administration only."
+      }
+    },
+    "adminRichDoc::role=agent::stored=create": {
+      "formHeadline": "Win a 4D3N Tokyo getaway for two",
+      "themeColor": "#232529",
+      "heroFont": "playfair",
+      "customerHost": "redeem",
+      "mediaType": "video",
+      "videoUrl": "/uploads/campaign-assets/tokyo-hero.mp4",
+      "imageUrl": "/uploads/campaign-assets/tokyo-fallback.jpg",
+      "termsContent": "<h4>Draw Terms</h4><p>Winner drawn 31 Aug 2026.</p>",
+      "name": "Tokyo Getaway Lucky Draw — 4D3N for two",
+      "offer_type": "reward",
+      "mode": "online",
+      "age_range": {
+        "min": 21,
+        "max": 65
+      },
+      "school_levels": [
+        "primary",
+        "seconda"
+      ],
+      "dsa_related": false,
+      "showCapacity": true,
+      "availability": {
+        "days": [],
+        "slots": [
+          "10:00",
+          "14:00"
+        ]
+      },
+      "inclusions": [
+        "Return flights for two",
+        "3 nights hotel (4-star)"
+      ],
+      "image_label": "Tokyo skyline at dusk",
+      "activation": {
+        "required": true,
+        "type": "consult",
+        "duration_mins": 20,
+        "summary": "Short activation call"
+      },
+      "sponsor": {
+        "kind": "agency",
+        "disclosure": "Sponsored by MKTR Travel Partners."
+      },
+      "value_line": "Grand prize worth S$3,800",
+      "content_blocks": {
+        "data_use": "Used for draw administration only."
+      }
+    },
+    "adminRichDoc::role=agent::stored=updateOverRich": {
+      "formHeadline": "Win a 4D3N Tokyo getaway for two",
+      "themeColor": "#232529",
+      "heroFont": "playfair",
+      "customerHost": "redeem",
+      "mediaType": "video",
+      "videoUrl": "/uploads/campaign-assets/tokyo-hero.mp4",
+      "imageUrl": "/uploads/campaign-assets/tokyo-fallback.jpg",
+      "termsContent": "<h4>Draw Terms</h4><p>Winner drawn 31 Aug 2026.</p>",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true,
+      "name": "Tokyo Getaway Lucky Draw — 4D3N for two",
+      "offer_type": "reward",
+      "mode": "online",
+      "age_range": {
+        "min": 21,
+        "max": 65
+      },
+      "school_levels": [
+        "primary",
+        "seconda"
+      ],
+      "dsa_related": false,
+      "showCapacity": true,
+      "availability": {
+        "days": [],
+        "slots": [
+          "10:00",
+          "14:00"
+        ]
+      },
+      "inclusions": [
+        "Return flights for two",
+        "3 nights hotel (4-star)"
+      ],
+      "image_label": "Tokyo skyline at dusk",
+      "activation": {
+        "required": true,
+        "type": "consult",
+        "duration_mins": 20,
+        "summary": "Short activation call"
+      },
+      "sponsor": {
+        "kind": "agency",
+        "disclosure": "Sponsored by MKTR Travel Partners."
+      },
+      "value_line": "Grand prize worth S$3,800",
+      "content_blocks": {
+        "data_use": "Used for draw administration only."
+      }
+    },
+    "adminRichDoc::role=none::stored=create": {
+      "formHeadline": "Win a 4D3N Tokyo getaway for two",
+      "themeColor": "#232529",
+      "heroFont": "playfair",
+      "customerHost": "redeem",
+      "mediaType": "video",
+      "videoUrl": "/uploads/campaign-assets/tokyo-hero.mp4",
+      "imageUrl": "/uploads/campaign-assets/tokyo-fallback.jpg",
+      "termsContent": "<h4>Draw Terms</h4><p>Winner drawn 31 Aug 2026.</p>",
+      "name": "Tokyo Getaway Lucky Draw — 4D3N for two",
+      "offer_type": "reward",
+      "mode": "online",
+      "age_range": {
+        "min": 21,
+        "max": 65
+      },
+      "school_levels": [
+        "primary",
+        "seconda"
+      ],
+      "dsa_related": false,
+      "showCapacity": true,
+      "availability": {
+        "days": [],
+        "slots": [
+          "10:00",
+          "14:00"
+        ]
+      },
+      "inclusions": [
+        "Return flights for two",
+        "3 nights hotel (4-star)"
+      ],
+      "image_label": "Tokyo skyline at dusk",
+      "activation": {
+        "required": true,
+        "type": "consult",
+        "duration_mins": 20,
+        "summary": "Short activation call"
+      },
+      "sponsor": {
+        "kind": "agency",
+        "disclosure": "Sponsored by MKTR Travel Partners."
+      },
+      "value_line": "Grand prize worth S$3,800",
+      "content_blocks": {
+        "data_use": "Used for draw administration only."
+      }
+    },
+    "adminRichDoc::role=none::stored=updateOverRich": {
+      "formHeadline": "Win a 4D3N Tokyo getaway for two",
+      "themeColor": "#232529",
+      "heroFont": "playfair",
+      "customerHost": "redeem",
+      "mediaType": "video",
+      "videoUrl": "/uploads/campaign-assets/tokyo-hero.mp4",
+      "imageUrl": "/uploads/campaign-assets/tokyo-fallback.jpg",
+      "termsContent": "<h4>Draw Terms</h4><p>Winner drawn 31 Aug 2026.</p>",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true,
+      "name": "Tokyo Getaway Lucky Draw — 4D3N for two",
+      "offer_type": "reward",
+      "mode": "online",
+      "age_range": {
+        "min": 21,
+        "max": 65
+      },
+      "school_levels": [
+        "primary",
+        "seconda"
+      ],
+      "dsa_related": false,
+      "showCapacity": true,
+      "availability": {
+        "days": [],
+        "slots": [
+          "10:00",
+          "14:00"
+        ]
+      },
+      "inclusions": [
+        "Return flights for two",
+        "3 nights hotel (4-star)"
+      ],
+      "image_label": "Tokyo skyline at dusk",
+      "activation": {
+        "required": true,
+        "type": "consult",
+        "duration_mins": 20,
+        "summary": "Short activation call"
+      },
+      "sponsor": {
+        "kind": "agency",
+        "disclosure": "Sponsored by MKTR Travel Partners."
+      },
+      "value_line": "Grand prize worth S$3,800",
+      "content_blocks": {
+        "data_use": "Used for draw administration only."
+      }
+    },
+    "adminRichDoc::public": {
+      "themeColor": "#232529",
+      "heroFont": "playfair",
+      "imageUrl": "/uploads/campaign-assets/tokyo-fallback.jpg",
+      "videoUrl": "/uploads/campaign-assets/tokyo-hero.mp4",
+      "mediaType": "video",
+      "formHeadline": "Win a 4D3N Tokyo getaway for two",
+      "termsContent": "<h4>Draw Terms</h4><p>Winner drawn 31 Aug 2026.</p>",
+      "customerHost": "redeem",
+      "name": "Tokyo Getaway Lucky Draw — 4D3N for two",
+      "category": "family & lifestyle",
+      "offer_type": "reward",
+      "mode": "online",
+      "qr_entry": "offer",
+      "age_range": {
+        "min": 21,
+        "max": 65
+      },
+      "school_levels": [
+        "primary",
+        "seconda"
+      ],
+      "dsa_related": false,
+      "showCapacity": true,
+      "availability": {
+        "days": [
+          "sat",
+          "sun"
+        ],
+        "slots": [
+          "10:00",
+          "14:00"
+        ]
+      },
+      "inclusions": [
+        "Return flights for two",
+        "3 nights hotel (4-star)"
+      ],
+      "image_label": "Tokyo skyline at dusk",
+      "activation": {
+        "required": true,
+        "type": "consult",
+        "duration_mins": 20,
+        "summary": "Short activation call"
+      },
+      "sponsor": {
+        "kind": "agency",
+        "disclosure": "Sponsored by MKTR Travel Partners."
+      },
+      "value_line": "Grand prize worth S$3,800",
+      "content_blocks": {
+        "data_use": "Used for draw administration only."
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      }
+    },
+    "legacyFlatOrder::role=admin::stored=create": {
+      "formHeadline": "Legacy campaign",
+      "fieldOrder": [
+        "name",
+        "phone",
+        "email",
+        "dob",
+        "postal_code"
+      ],
+      "visibleFields": {
+        "dob": true
+      },
+      "requiredFields": {
+        "dob": "optional",
+        "postal_code": "yes"
+      },
+      "themeColor": "#3B82F6",
+      "customerHost": "redeem"
+    },
+    "legacyFlatOrder::role=admin::stored=updateOverRich": {
+      "formHeadline": "Legacy campaign",
+      "fieldOrder": [
+        "name",
+        "phone",
+        "email",
+        "dob",
+        "postal_code"
+      ],
+      "visibleFields": {
+        "dob": true
+      },
+      "requiredFields": {
+        "dob": "optional",
+        "postal_code": "yes"
+      },
+      "themeColor": "#3B82F6",
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "legacyFlatOrder::role=agent::stored=create": {
+      "formHeadline": "Legacy campaign",
+      "fieldOrder": [
+        "name",
+        "phone",
+        "email",
+        "dob",
+        "postal_code"
+      ],
+      "visibleFields": {
+        "dob": true
+      },
+      "requiredFields": {
+        "dob": "optional",
+        "postal_code": "yes"
+      },
+      "themeColor": "#3B82F6",
+      "customerHost": "redeem"
+    },
+    "legacyFlatOrder::role=agent::stored=updateOverRich": {
+      "formHeadline": "Legacy campaign",
+      "fieldOrder": [
+        "name",
+        "phone",
+        "email",
+        "dob",
+        "postal_code"
+      ],
+      "visibleFields": {
+        "dob": true
+      },
+      "requiredFields": {
+        "dob": "optional",
+        "postal_code": "yes"
+      },
+      "themeColor": "#3B82F6",
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "legacyFlatOrder::role=none::stored=create": {
+      "formHeadline": "Legacy campaign",
+      "fieldOrder": [
+        "name",
+        "phone",
+        "email",
+        "dob",
+        "postal_code"
+      ],
+      "visibleFields": {
+        "dob": true
+      },
+      "requiredFields": {
+        "dob": "optional",
+        "postal_code": "yes"
+      },
+      "themeColor": "#3B82F6",
+      "customerHost": "redeem"
+    },
+    "legacyFlatOrder::role=none::stored=updateOverRich": {
+      "formHeadline": "Legacy campaign",
+      "fieldOrder": [
+        "name",
+        "phone",
+        "email",
+        "dob",
+        "postal_code"
+      ],
+      "visibleFields": {
+        "dob": true
+      },
+      "requiredFields": {
+        "dob": "optional",
+        "postal_code": "yes"
+      },
+      "themeColor": "#3B82F6",
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "legacyFlatOrder::public": {
+      "themeColor": "#3B82F6",
+      "formHeadline": "Legacy campaign",
+      "fieldOrder": [
+        "name",
+        "phone",
+        "email",
+        "dob",
+        "postal_code"
+      ],
+      "visibleFields": {
+        "dob": true
+      },
+      "requiredFields": {
+        "dob": "optional",
+        "postal_code": "yes"
+      }
+    },
+    "anomalousOrder::role=admin::stored=create": {
+      "fieldOrder": [
+        "name",
+        {
+          "id": "r1",
+          "columns": [
+            "phone",
+            "dob"
+          ]
+        },
+        {
+          "id": "r2",
+          "columns": []
+        },
+        "name",
+        {
+          "id": "r3",
+          "columns": [
+            "mystery_field"
+          ]
+        },
+        {
+          "id": "r4",
+          "columns": [
+            "postal_code"
+          ]
+        }
+      ],
+      "visibleFields": {
+        "education_level": true
+      },
+      "requiredFields": {
+        "education_level": true
+      },
+      "customerHost": "redeem"
+    },
+    "anomalousOrder::role=admin::stored=updateOverRich": {
+      "fieldOrder": [
+        "name",
+        {
+          "id": "r1",
+          "columns": [
+            "phone",
+            "dob"
+          ]
+        },
+        {
+          "id": "r2",
+          "columns": []
+        },
+        "name",
+        {
+          "id": "r3",
+          "columns": [
+            "mystery_field"
+          ]
+        },
+        {
+          "id": "r4",
+          "columns": [
+            "postal_code"
+          ]
+        }
+      ],
+      "visibleFields": {
+        "education_level": true
+      },
+      "requiredFields": {
+        "education_level": true
+      },
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "anomalousOrder::role=agent::stored=create": {
+      "fieldOrder": [
+        "name",
+        {
+          "id": "r1",
+          "columns": [
+            "phone",
+            "dob"
+          ]
+        },
+        {
+          "id": "r2",
+          "columns": []
+        },
+        "name",
+        {
+          "id": "r3",
+          "columns": [
+            "mystery_field"
+          ]
+        },
+        {
+          "id": "r4",
+          "columns": [
+            "postal_code"
+          ]
+        }
+      ],
+      "visibleFields": {
+        "education_level": true
+      },
+      "requiredFields": {
+        "education_level": true
+      },
+      "customerHost": "redeem"
+    },
+    "anomalousOrder::role=agent::stored=updateOverRich": {
+      "fieldOrder": [
+        "name",
+        {
+          "id": "r1",
+          "columns": [
+            "phone",
+            "dob"
+          ]
+        },
+        {
+          "id": "r2",
+          "columns": []
+        },
+        "name",
+        {
+          "id": "r3",
+          "columns": [
+            "mystery_field"
+          ]
+        },
+        {
+          "id": "r4",
+          "columns": [
+            "postal_code"
+          ]
+        }
+      ],
+      "visibleFields": {
+        "education_level": true
+      },
+      "requiredFields": {
+        "education_level": true
+      },
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "anomalousOrder::role=none::stored=create": {
+      "fieldOrder": [
+        "name",
+        {
+          "id": "r1",
+          "columns": [
+            "phone",
+            "dob"
+          ]
+        },
+        {
+          "id": "r2",
+          "columns": []
+        },
+        "name",
+        {
+          "id": "r3",
+          "columns": [
+            "mystery_field"
+          ]
+        },
+        {
+          "id": "r4",
+          "columns": [
+            "postal_code"
+          ]
+        }
+      ],
+      "visibleFields": {
+        "education_level": true
+      },
+      "requiredFields": {
+        "education_level": true
+      },
+      "customerHost": "redeem"
+    },
+    "anomalousOrder::role=none::stored=updateOverRich": {
+      "fieldOrder": [
+        "name",
+        {
+          "id": "r1",
+          "columns": [
+            "phone",
+            "dob"
+          ]
+        },
+        {
+          "id": "r2",
+          "columns": []
+        },
+        "name",
+        {
+          "id": "r3",
+          "columns": [
+            "mystery_field"
+          ]
+        },
+        {
+          "id": "r4",
+          "columns": [
+            "postal_code"
+          ]
+        }
+      ],
+      "visibleFields": {
+        "education_level": true
+      },
+      "requiredFields": {
+        "education_level": true
+      },
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "anomalousOrder::public": {
+      "fieldOrder": [
+        "name",
+        {
+          "id": "r1",
+          "columns": [
+            "phone",
+            "dob"
+          ]
+        },
+        {
+          "id": "r2",
+          "columns": []
+        },
+        "name",
+        {
+          "id": "r3",
+          "columns": [
+            "mystery_field"
+          ]
+        },
+        {
+          "id": "r4",
+          "columns": [
+            "postal_code"
+          ]
+        }
+      ],
+      "visibleFields": {
+        "education_level": true
+      },
+      "requiredFields": {
+        "education_level": true
+      }
+    },
+    "youtubeDoc::role=admin::stored=create": {
+      "mediaType": "video",
+      "videoUrl": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "heroCtaLabel": "Watch and win",
+      "formHeadline": "Video campaign",
+      "customerHost": "redeem"
+    },
+    "youtubeDoc::role=admin::stored=updateOverRich": {
+      "mediaType": "video",
+      "videoUrl": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "heroCtaLabel": "Watch and win",
+      "formHeadline": "Video campaign",
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "youtubeDoc::role=agent::stored=create": {
+      "mediaType": "video",
+      "videoUrl": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "heroCtaLabel": "Watch and win",
+      "formHeadline": "Video campaign",
+      "customerHost": "redeem"
+    },
+    "youtubeDoc::role=agent::stored=updateOverRich": {
+      "mediaType": "video",
+      "videoUrl": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "heroCtaLabel": "Watch and win",
+      "formHeadline": "Video campaign",
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "youtubeDoc::role=none::stored=create": {
+      "mediaType": "video",
+      "videoUrl": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "heroCtaLabel": "Watch and win",
+      "formHeadline": "Video campaign",
+      "customerHost": "redeem"
+    },
+    "youtubeDoc::role=none::stored=updateOverRich": {
+      "mediaType": "video",
+      "videoUrl": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "heroCtaLabel": "Watch and win",
+      "formHeadline": "Video campaign",
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "youtubeDoc::public": {
+      "videoUrl": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "mediaType": "video",
+      "heroCtaLabel": "Watch and win",
+      "formHeadline": "Video campaign"
+    },
+    "youtubeShortDoc::role=admin::stored=create": {
+      "mediaType": "video",
+      "videoUrl": "https://youtu.be/dQw4w9WgXcQ",
+      "customerHost": "redeem"
+    },
+    "youtubeShortDoc::role=admin::stored=updateOverRich": {
+      "mediaType": "video",
+      "videoUrl": "https://youtu.be/dQw4w9WgXcQ",
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "youtubeShortDoc::role=agent::stored=create": {
+      "mediaType": "video",
+      "videoUrl": "https://youtu.be/dQw4w9WgXcQ",
+      "customerHost": "redeem"
+    },
+    "youtubeShortDoc::role=agent::stored=updateOverRich": {
+      "mediaType": "video",
+      "videoUrl": "https://youtu.be/dQw4w9WgXcQ",
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "youtubeShortDoc::role=none::stored=create": {
+      "mediaType": "video",
+      "videoUrl": "https://youtu.be/dQw4w9WgXcQ",
+      "customerHost": "redeem"
+    },
+    "youtubeShortDoc::role=none::stored=updateOverRich": {
+      "mediaType": "video",
+      "videoUrl": "https://youtu.be/dQw4w9WgXcQ",
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "youtubeShortDoc::public": {
+      "videoUrl": "https://youtu.be/dQw4w9WgXcQ",
+      "mediaType": "video"
+    },
+    "youtubeShortsUrlDoc::role=admin::stored=create": {
+      "mediaType": "video",
+      "videoUrl": "https://www.youtube.com/shorts/dQw4w9WgXcQ",
+      "customerHost": "redeem"
+    },
+    "youtubeShortsUrlDoc::role=admin::stored=updateOverRich": {
+      "mediaType": "video",
+      "videoUrl": "https://www.youtube.com/shorts/dQw4w9WgXcQ",
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "youtubeShortsUrlDoc::role=agent::stored=create": {
+      "mediaType": "video",
+      "videoUrl": "https://www.youtube.com/shorts/dQw4w9WgXcQ",
+      "customerHost": "redeem"
+    },
+    "youtubeShortsUrlDoc::role=agent::stored=updateOverRich": {
+      "mediaType": "video",
+      "videoUrl": "https://www.youtube.com/shorts/dQw4w9WgXcQ",
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "youtubeShortsUrlDoc::role=none::stored=create": {
+      "mediaType": "video",
+      "videoUrl": "https://www.youtube.com/shorts/dQw4w9WgXcQ",
+      "customerHost": "redeem"
+    },
+    "youtubeShortsUrlDoc::role=none::stored=updateOverRich": {
+      "mediaType": "video",
+      "videoUrl": "https://www.youtube.com/shorts/dQw4w9WgXcQ",
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "youtubeShortsUrlDoc::public": {
+      "videoUrl": "https://www.youtube.com/shorts/dQw4w9WgXcQ",
+      "mediaType": "video"
+    },
+    "staleMediaDoc::role=admin::stored=create": {
+      "mediaType": "none",
+      "imageUrl": "/uploads/campaign-assets/old-hero.jpg",
+      "videoUrl": "/uploads/campaign-assets/old-hero.mp4",
+      "heroCtaLabel": "Ghost CTA",
+      "customerHost": "redeem"
+    },
+    "staleMediaDoc::role=admin::stored=updateOverRich": {
+      "mediaType": "none",
+      "imageUrl": "/uploads/campaign-assets/old-hero.jpg",
+      "videoUrl": "/uploads/campaign-assets/old-hero.mp4",
+      "heroCtaLabel": "Ghost CTA",
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "staleMediaDoc::role=agent::stored=create": {
+      "mediaType": "none",
+      "imageUrl": "/uploads/campaign-assets/old-hero.jpg",
+      "videoUrl": "/uploads/campaign-assets/old-hero.mp4",
+      "heroCtaLabel": "Ghost CTA",
+      "customerHost": "redeem"
+    },
+    "staleMediaDoc::role=agent::stored=updateOverRich": {
+      "mediaType": "none",
+      "imageUrl": "/uploads/campaign-assets/old-hero.jpg",
+      "videoUrl": "/uploads/campaign-assets/old-hero.mp4",
+      "heroCtaLabel": "Ghost CTA",
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "staleMediaDoc::role=none::stored=create": {
+      "mediaType": "none",
+      "imageUrl": "/uploads/campaign-assets/old-hero.jpg",
+      "videoUrl": "/uploads/campaign-assets/old-hero.mp4",
+      "heroCtaLabel": "Ghost CTA",
+      "customerHost": "redeem"
+    },
+    "staleMediaDoc::role=none::stored=updateOverRich": {
+      "mediaType": "none",
+      "imageUrl": "/uploads/campaign-assets/old-hero.jpg",
+      "videoUrl": "/uploads/campaign-assets/old-hero.mp4",
+      "heroCtaLabel": "Ghost CTA",
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "staleMediaDoc::public": {
+      "imageUrl": "/uploads/campaign-assets/old-hero.jpg",
+      "videoUrl": "/uploads/campaign-assets/old-hero.mp4",
+      "mediaType": "none",
+      "heroCtaLabel": "Ghost CTA"
+    },
+    "deadStyleKeysDoc::role=admin::stored=create": {
+      "formHeadline": "Styled relic",
+      "backgroundStyle": "gradient",
+      "alignment": "center",
+      "spacing": "roomy",
+      "headlineSize": "xl",
+      "someFutureKey": {
+        "nested": true
+      },
+      "customerHost": "redeem"
+    },
+    "deadStyleKeysDoc::role=admin::stored=updateOverRich": {
+      "formHeadline": "Styled relic",
+      "backgroundStyle": "gradient",
+      "alignment": "center",
+      "spacing": "roomy",
+      "headlineSize": "xl",
+      "someFutureKey": {
+        "nested": true
+      },
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "deadStyleKeysDoc::role=agent::stored=create": {
+      "formHeadline": "Styled relic",
+      "backgroundStyle": "gradient",
+      "alignment": "center",
+      "spacing": "roomy",
+      "headlineSize": "xl",
+      "someFutureKey": {
+        "nested": true
+      },
+      "customerHost": "redeem"
+    },
+    "deadStyleKeysDoc::role=agent::stored=updateOverRich": {
+      "formHeadline": "Styled relic",
+      "backgroundStyle": "gradient",
+      "alignment": "center",
+      "spacing": "roomy",
+      "headlineSize": "xl",
+      "someFutureKey": {
+        "nested": true
+      },
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "deadStyleKeysDoc::role=none::stored=create": {
+      "formHeadline": "Styled relic",
+      "backgroundStyle": "gradient",
+      "alignment": "center",
+      "spacing": "roomy",
+      "headlineSize": "xl",
+      "someFutureKey": {
+        "nested": true
+      },
+      "customerHost": "redeem"
+    },
+    "deadStyleKeysDoc::role=none::stored=updateOverRich": {
+      "formHeadline": "Styled relic",
+      "backgroundStyle": "gradient",
+      "alignment": "center",
+      "spacing": "roomy",
+      "headlineSize": "xl",
+      "someFutureKey": {
+        "nested": true
+      },
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "deadStyleKeysDoc::public": {
+      "formHeadline": "Styled relic"
+    },
+    "guidedReviewDoc::role=admin::stored=create": {
+      "guidedReview": {
+        "templateId": "financial_readiness",
+        "hero": {
+          "headline": "Know where your money stands."
+        },
+        "trust": {
+          "partner": "Example Advisory Pte. Ltd."
+        }
+      },
+      "quiz": {
+        "enabled": true,
+        "mode": "qualification",
+        "quizId": "gr-derived",
+        "version": 1
+      },
+      "sgPrOnly": true,
+      "themeColor": "#0E7C6B",
+      "customerHost": "redeem"
+    },
+    "guidedReviewDoc::role=admin::stored=updateOverRich": {
+      "guidedReview": {
+        "templateId": "financial_readiness",
+        "hero": {
+          "headline": "Know where your money stands."
+        },
+        "trust": {
+          "partner": "Example Advisory Pte. Ltd."
+        }
+      },
+      "quiz": {
+        "enabled": true,
+        "mode": "qualification",
+        "quizId": "gr-derived",
+        "version": 1
+      },
+      "sgPrOnly": true,
+      "themeColor": "#0E7C6B",
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "guidedReviewDoc::role=agent::stored=create": {
+      "guidedReview": {
+        "templateId": "financial_readiness",
+        "hero": {
+          "headline": "Know where your money stands."
+        },
+        "trust": {
+          "partner": "Example Advisory Pte. Ltd."
+        }
+      },
+      "quiz": {
+        "enabled": true,
+        "mode": "qualification",
+        "quizId": "gr-derived",
+        "version": 1
+      },
+      "sgPrOnly": true,
+      "themeColor": "#0E7C6B",
+      "customerHost": "redeem"
+    },
+    "guidedReviewDoc::role=agent::stored=updateOverRich": {
+      "guidedReview": {
+        "templateId": "financial_readiness",
+        "hero": {
+          "headline": "Know where your money stands."
+        },
+        "trust": {
+          "partner": "Example Advisory Pte. Ltd."
+        }
+      },
+      "quiz": {
+        "enabled": true,
+        "mode": "qualification",
+        "quizId": "gr-derived",
+        "version": 1
+      },
+      "sgPrOnly": true,
+      "themeColor": "#0E7C6B",
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "guidedReviewDoc::role=none::stored=create": {
+      "guidedReview": {
+        "templateId": "financial_readiness",
+        "hero": {
+          "headline": "Know where your money stands."
+        },
+        "trust": {
+          "partner": "Example Advisory Pte. Ltd."
+        }
+      },
+      "quiz": {
+        "enabled": true,
+        "mode": "qualification",
+        "quizId": "gr-derived",
+        "version": 1
+      },
+      "sgPrOnly": true,
+      "themeColor": "#0E7C6B",
+      "customerHost": "redeem"
+    },
+    "guidedReviewDoc::role=none::stored=updateOverRich": {
+      "guidedReview": {
+        "templateId": "financial_readiness",
+        "hero": {
+          "headline": "Know where your money stands."
+        },
+        "trust": {
+          "partner": "Example Advisory Pte. Ltd."
+        }
+      },
+      "quiz": {
+        "enabled": true,
+        "mode": "qualification",
+        "quizId": "gr-derived",
+        "version": 1
+      },
+      "sgPrOnly": true,
+      "themeColor": "#0E7C6B",
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "guidedReviewDoc::public": {
+      "themeColor": "#0E7C6B",
+      "sgPrOnly": true,
+      "quiz": {
+        "enabled": true,
+        "mode": "qualification",
+        "quizId": "gr-derived",
+        "version": 1
+      },
+      "guidedReview": {
+        "templateId": "financial_readiness",
+        "hero": {
+          "headline": "Know where your money stands."
+        },
+        "trust": {
+          "partner": "Example Advisory Pte. Ltd."
+        }
+      }
+    },
+    "minimalDoc::role=admin::stored=create": {
+      "customerHost": "redeem"
+    },
+    "minimalDoc::role=admin::stored=updateOverRich": {
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "minimalDoc::role=agent::stored=create": {
+      "customerHost": "redeem"
+    },
+    "minimalDoc::role=agent::stored=updateOverRich": {
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "minimalDoc::role=none::stored=create": {
+      "customerHost": "redeem"
+    },
+    "minimalDoc::role=none::stored=updateOverRich": {
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "minimalDoc::public": {},
+    "overLimitDoc::role=admin::stored=create": {
+      "formHeadline": "HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+      "formWidth": 900,
+      "themeColor": "not-a-hex",
+      "heroFont": "comic-sans",
+      "ctaText": "",
+      "customerHost": "redeem"
+    },
+    "overLimitDoc::role=admin::stored=updateOverRich": {
+      "formHeadline": "HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+      "formWidth": 900,
+      "themeColor": "not-a-hex",
+      "heroFont": "comic-sans",
+      "ctaText": "",
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "overLimitDoc::role=agent::stored=create": {
+      "formHeadline": "HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+      "formWidth": 900,
+      "themeColor": "not-a-hex",
+      "heroFont": "comic-sans",
+      "ctaText": "",
+      "customerHost": "redeem"
+    },
+    "overLimitDoc::role=agent::stored=updateOverRich": {
+      "formHeadline": "HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+      "formWidth": 900,
+      "themeColor": "not-a-hex",
+      "heroFont": "comic-sans",
+      "ctaText": "",
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "overLimitDoc::role=none::stored=create": {
+      "formHeadline": "HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+      "formWidth": 900,
+      "themeColor": "not-a-hex",
+      "heroFont": "comic-sans",
+      "ctaText": "",
+      "customerHost": "redeem"
+    },
+    "overLimitDoc::role=none::stored=updateOverRich": {
+      "formHeadline": "HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+      "formWidth": 900,
+      "themeColor": "not-a-hex",
+      "heroFont": "comic-sans",
+      "ctaText": "",
+      "customerHost": "redeem",
+      "featuredDrop": {
+        "enabled": true,
+        "title": "Tokyo Getaway Lucky Draw",
+        "valueLabel": "S$3.8k",
+        "emoji": "🧳",
+        "cap": 2000,
+        "endsAt": "2026-08-15"
+      },
+      "luckyDraw": {
+        "enabled": true,
+        "prize": "4D3N Tokyo getaway for two",
+        "closesAt": "2026-08-30",
+        "boostClosesAt": "2026-08-15",
+        "multiplier": 10,
+        "winners": 1
+      },
+      "marketplaceListed": true
+    },
+    "overLimitDoc::public": {
+      "themeColor": "not-a-hex",
+      "heroFont": "comic-sans",
+      "ctaText": "",
+      "formHeadline": "HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+      "formWidth": 900
+    }
+  }
+}

--- a/test-fixtures/designConfigV1Docs.mjs
+++ b/test-fixtures/designConfigV1Docs.mjs
@@ -1,0 +1,244 @@
+/**
+ * Real-shaped v1 design_config fixtures — the shared corpus for the design_config
+ * v2 migration (upgrade/downgrade), the clamp v1-golden oracle, and the twin
+ * lock-step tests (docs/plans/campaign-studio-implementation-prompt.md, PR 1).
+ *
+ * Shapes mirror what the classic DesignEditor + admin API actually write today
+ * (verified against DesignEditor.jsx seeding, ContentPanel/FieldOrderEditor
+ * writes, normalizeMarketplaceContent, and git history: flat fieldOrder writes
+ * in 494d4ea, row objects since 27acd89). Every migration-table row and every
+ * canonicalization edge in the loss ledger has a fixture here — extend this
+ * file when a new edge is found, never inline one-off docs in tests.
+ */
+
+import { quizDef } from './protectionPersonalityQuiz.mjs';
+
+/** Editorial baseline: Warm-Cream voucher campaign, all copy slots, image hero,
+ * explicit field flags, 2-col row pairing — the parity anchor. */
+export const editorialBaseline = {
+  formHeadline: 'Get your $10 voucher',
+  formSubheadline: 'Your voucher code arrives by SMS after verification.',
+  brandWordmark: 'redeem.sg',
+  storyText:
+    'We are celebrating our new rewards programme by giving away 2,000 vouchers to Singapore households.\n\nSign up, verify your mobile number, and your voucher code arrives within minutes.',
+  storyEmphasis: 'S$10, yours in under a minute.',
+  heroCtaLabel: 'Claim my voucher',
+  ctaText: 'Redeem Now',
+  regulatoryFooter:
+    'Redeem (a service of MKTR PTE. LTD., UEN: 202507548M) operates this referral platform.',
+  brandFooter: 'Powered by MKTR',
+  imageUrl: '/uploads/campaign-assets/groceries.jpg',
+  themeColor: '#D17029',
+  heroFont: 'fraunces',
+  formWidth: 400,
+  mediaType: 'image',
+  videoUrl: '',
+  termsContent: '<h4>Campaign Terms</h4><p>One registration per person.</p>',
+  customerHost: 'redeem',
+  otpChannel: 'sms',
+  sgPrOnly: true,
+  excludeAdvisors: false,
+  dncCheckAtSubmit: true,
+  visibleFields: { phone: true, dob: true, postal_code: true },
+  requiredFields: { dob: true, postal_code: false },
+  fieldOrder: [
+    { id: 'r-name', columns: ['name'] },
+    { id: 'r-phone', columns: ['phone'] },
+    { id: 'r-email', columns: ['email'] },
+    { id: 'r-pair', columns: ['dob', 'postal_code'] },
+    { id: 'r-edu', columns: ['education_level'] },
+    { id: 'r-inc', columns: ['monthly_income'] },
+  ],
+  quiz: null,
+};
+
+/** Quiz campaign carrying the PRODUCTION quiz shape (steps/scoring/resultProfiles)
+ * verbatim from the shared scoring fixture — migration must pass it through 1:1. */
+export const quizCampaign = {
+  formHeadline: 'Ready to raise your ceiling?',
+  formSubheadline: 'Claim your complimentary 20-minute session.',
+  themeColor: '#8A5BB8',
+  heroFont: 'space-grotesk',
+  customerHost: 'redeem',
+  otpChannel: 'whatsapp',
+  sgPrOnly: false,
+  excludeAdvisors: true,
+  dncCheckAtSubmit: true,
+  visibleFields: { education_level: true, monthly_income: true, dob: false, postal_code: false },
+  requiredFields: {},
+  quiz: quizDef,
+};
+
+/** Admin-rich doc: enabled featured drop + lucky draw + full marketplace content
+ * (exactly the key shapes normalizeMarketplaceContent emits, incl. sponsor and
+ * partial content_blocks) + marketplaceListed. */
+export const adminRichDoc = {
+  formHeadline: 'Win a 4D3N Tokyo getaway for two',
+  themeColor: '#232529',
+  heroFont: 'playfair',
+  customerHost: 'redeem',
+  mediaType: 'video',
+  videoUrl: '/uploads/campaign-assets/tokyo-hero.mp4',
+  imageUrl: '/uploads/campaign-assets/tokyo-fallback.jpg',
+  termsContent: '<h4>Draw Terms</h4><p>Winner drawn 31 Aug 2026.</p>',
+  featuredDrop: {
+    enabled: true,
+    title: 'Tokyo Getaway Lucky Draw',
+    valueLabel: 'S$3.8k',
+    emoji: '🧳',
+    cap: 2000,
+    endsAt: '2026-08-15',
+  },
+  luckyDraw: {
+    enabled: true,
+    prize: '4D3N Tokyo getaway for two',
+    closesAt: '2026-08-30',
+    boostClosesAt: '2026-08-15',
+    multiplier: 10,
+    winners: 1,
+  },
+  marketplaceListed: true,
+  name: 'Tokyo Getaway Lucky Draw — 4D3N for two',
+  category: 'family & lifestyle',
+  offer_type: 'reward',
+  mode: 'online',
+  qr_entry: 'offer',
+  age_range: { min: 21, max: 65 },
+  school_levels: ['primary', 'seconda'],
+  dsa_related: false,
+  showCapacity: true,
+  availability: { days: ['sat', 'sun'], slots: ['10:00', '14:00'] },
+  inclusions: ['Return flights for two', '3 nights hotel (4-star)'],
+  image_label: 'Tokyo skyline at dusk',
+  activation: { required: true, type: 'consult', duration_mins: 20, summary: 'Short activation call' },
+  sponsor: { kind: 'agency', disclosure: 'Sponsored by MKTR Travel Partners.' },
+  value_line: 'Grand prize worth S$3,800',
+  content_blocks: { data_use: 'Used for draw administration only.' },
+};
+
+/** Legacy flat fieldOrder (pre-27acd89 write shape) + sparse everything else. */
+export const legacyFlatOrder = {
+  formHeadline: 'Legacy campaign',
+  fieldOrder: ['name', 'phone', 'email', 'dob', 'postal_code'],
+  visibleFields: { dob: true },
+  requiredFields: { dob: 'optional', postal_code: 'yes' },
+  themeColor: '#3B82F6',
+};
+
+/** fieldOrder anomalies the live renderer tolerates element-by-element:
+ * mixed string/row entries, duplicate field, omitted locked field (email),
+ * empty row, unknown field id. Canonicalization must be deterministic. */
+export const anomalousOrder = {
+  fieldOrder: [
+    'name',
+    { id: 'r1', columns: ['phone', 'dob'] },
+    { id: 'r2', columns: [] },
+    'name',
+    { id: 'r3', columns: ['mystery_field'] },
+    { id: 'r4', columns: ['postal_code'] },
+  ],
+  visibleFields: { education_level: true },
+  requiredFields: { education_level: true },
+};
+
+/** YouTube-shaped videoUrl (watch form) — migrates to media.kind 'youtube'. */
+export const youtubeDoc = {
+  mediaType: 'video',
+  videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+  heroCtaLabel: 'Watch and win',
+  formHeadline: 'Video campaign',
+};
+
+/** youtu.be short + shorts-style URL (shorts must stay kind 'video' — the
+ * production matcher accepts only watch/youtu.be/embed 11-char forms). */
+export const youtubeShortDoc = {
+  mediaType: 'video',
+  videoUrl: 'https://youtu.be/dQw4w9WgXcQ',
+};
+export const youtubeShortsUrlDoc = {
+  mediaType: 'video',
+  videoUrl: 'https://www.youtube.com/shorts/dQw4w9WgXcQ',
+};
+
+/** Stale-media collision: mediaType 'none' with BOTH URLs still set (the editor
+ * never clears the inactive key) — media.legacy must preserve both. */
+export const staleMediaDoc = {
+  mediaType: 'none',
+  imageUrl: '/uploads/campaign-assets/old-hero.jpg',
+  videoUrl: '/uploads/campaign-assets/old-hero.mp4',
+  heroCtaLabel: 'Ghost CTA',
+};
+
+/** Dead style keys (authored historically in 494d4ea) + unknown future key —
+ * both must survive as unknown-key passthrough, never be dropped. */
+export const deadStyleKeysDoc = {
+  formHeadline: 'Styled relic',
+  backgroundStyle: 'gradient',
+  alignment: 'center',
+  spacing: 'roomy',
+  headlineSize: 'xl',
+  someFutureKey: { nested: true },
+};
+
+/** guidedReview + derived qualification quiz coexistence — the real shape
+ * GuidedReviewDesigner saves (spread of full stored design). */
+export const guidedReviewDoc = {
+  guidedReview: {
+    templateId: 'financial_readiness',
+    hero: { headline: 'Know where your money stands.' },
+    trust: { partner: 'Example Advisory Pte. Ltd.' },
+  },
+  quiz: { enabled: true, mode: 'qualification', quizId: 'gr-derived', version: 1 },
+  sgPrOnly: true,
+  themeColor: '#0E7C6B',
+};
+
+/** Absent-everything minimal doc. */
+export const minimalDoc = {};
+
+/** Empty-string and boundary values (over-limit copy passes v1 unclamped —
+ * upgrade must NOT clamp; only a v2 SAVE clamps). */
+export const overLimitDoc = {
+  formHeadline: 'H'.repeat(120),
+  formWidth: 900,
+  themeColor: 'not-a-hex',
+  heroFont: 'comic-sans',
+  ctaText: '',
+};
+
+/** All migration/oracle fixtures keyed by name (stable iteration order). */
+export const V1_DOCS = {
+  editorialBaseline,
+  quizCampaign,
+  adminRichDoc,
+  legacyFlatOrder,
+  anomalousOrder,
+  youtubeDoc,
+  youtubeShortDoc,
+  youtubeShortsUrlDoc,
+  staleMediaDoc,
+  deadStyleKeysDoc,
+  guidedReviewDoc,
+  minimalDoc,
+  overLimitDoc,
+};
+
+/** Version-tagged adversarial payloads for the write-gate tests (NOT migration
+ * inputs): hybrid alias smuggling, future version, malformed v2. */
+export const TAGGED_DOCS = {
+  hybridAliasSmuggle: {
+    version: 2,
+    template: { id: 'editorial', params: {} },
+    theme: { preset: 'warm-cream', accent: null, font: 'fraunces', radius: 'soft', background: 'plain' },
+    content: { headline: 'Innocent looking' },
+    form: { fields: [], verification: 'sms', gates: {}, terms: {} },
+    distribution: { host: 'redeem' },
+    // Legacy aliases an agent could smuggle past a naive v2 clamp — existing
+    // readers (featuredDropsService/marketplaceService) trust these paths.
+    featuredDrop: { enabled: true, title: 'Smuggled drop' },
+    marketplaceListed: true,
+  },
+  futureVersion: { version: 3, content: { headline: 'From the future' } },
+  malformedV2: { version: 2, template: 'editorial' },
+  stringVersion: { version: '2', formHeadline: 'Tagged with a string' },
+};


### PR DESCRIPTION
**Campaign Studio revamp — PR 1 of 6** (`docs/plans/campaign-studio-implementation-prompt.md`). The design_config v2 data foundation, landed **dark**: schema twins, a canonicalizing v1→v2 migration with a pure inverse, and a version-aware save path that **rejects** v2 writes behind `DESIGN_CONFIG_V2_WRITES_ENABLED` (default OFF) until PR 2/3 make every reader version-aware. Zero live behavior change — proven, not asserted (see the oracle below). Plan was approved, Codex-reviewed (gpt-5.6-sol xhigh, verdict RETHINK), and every finding re-verified against code before folding.

## What ships

**Twin modules** — `backend/src/utils/designConfigV2.js` (source of truth) ↔ `src/lib/designConfigV2.js` (mirror), following the `quizScoring`/`redeemOpsPermissions` twin pattern with `src/lib/__tests__/designConfigV2.lockstep.test.js` importing both (constants structurally, functions behaviorally over the shared fixture corpus + a 200-doc seeded deterministic fuzz):
- Schema constants: 6 templates + param bags, 10 theme presets — **Warm Cream frozen byte-exact to production `LeadCaptureLayout` TOKENS/RADIUS** (asserted in tests), LIMITS, the 7-field model, marketplace key map.
- `upgradeDesignConfig` — implements the Phase 5 handoff migration table with production key names; **non-clamping** (over-limit/invalid values survive verbatim; only the save clamp normalizes, same as v1); idempotent; throws on unsupported versions.
- `downgradeDesignConfig` / `readLegacyView` — render-contract inverse; `upgrade(downgrade(v2)) ≡ v2` exactly, for every fixture.
- `resolveTheme` — studio-data reference implementation with `onColor` matching production `readableTextOn` (asserted against it).

**Canonicalization loss ledger** (documented in the module header, each entry fixture-tested — this migration is deliberately *not* byte-parity, it is render-contract equivalence):
- L1 required flags: `false|'optional'`→false, other truthy→true, absent→false (v1 was self-inconsistent: `'optional'` displayed optional but was submit-enforced; absent displayed required but unenforced).
- L2 education/salary absent → hidden (the handoff-signed data-honest rule for the render-but-discard quirk).
- L3 fieldOrder anomalies (mixed arrays/dupes/omissions/empty rows — all real shapes) canonicalize deterministically.
- L4 absent mediaType → derived kind (the renderer's own default); **`media.legacy` shadow preserves both stale URLs** (the editor never clears the inactive one) so downgrade is exact.
- L5 quiz/guidedReview/luckyDraw/unknown keys (incl. historical dead style keys) pass through **verbatim** — never restructured, never dropped.

**Write gate + server guards** (`designConfigV2Clamp.js` + `campaignService.js`):
- Any version-tagged doc → 422 `data.code='DESIGN_CONFIG_VERSION_UNSUPPORTED'` while the flag is off, and always for `version !== 2` (create defaults campaigns ACTIVE, so ungated acceptance would have been live instantly — Codex critical #2).
- **Hybrid-alias scrub** — kills the authorization bypass Codex found (critical #1): `{version:2, featuredDrop:{enabled:true}, marketplaceListed:true}` from an agent would have sailed past a naive v2 clamp as "unknown keys" straight into the readers that trust those paths. Known v1 keys are stripped from v2 docs; `customerHost` is always **derived** from the clamped `distribution.host`.
- Cross-version stored-state accessors: featuredDrop/listed/luckyDraw/terms policies read the stored doc's own version, so a stored-v1 → incoming-v2 transition save preserves publication state (admin-wins / non-admin-preserves matrix tested both ways).
- Stored-v2 overwritten by an untagged (classic designer) save → 409 `DESIGN_CONFIG_VERSION_CONFLICT` — the server twin of PR 3's editor guard.
- `ensureDrawTermsVersion` + the create-path draw invariant read terms version-aware (`form.terms.html` on v2); `duplicateCampaign`'s never-clone rules extended to the v2 paths.

**Public whitelist v2 branch** (`publicDesignConfig.js`) — leaf-level rebuild (nested poison keys at any public subtree cannot leak; tested with injected keys at all of them); strips `ai`, `media.legacy`, `marketplace.listed`, `featuredDrop`, draw ids; `quiz`/`guidedReview` stay the two documented wholesale v1-parity exceptions; emits `version` (PR 2's dispatch needs it) + the derived `customerHost` mirror.

## The no-regression proof

`test-fixtures/designConfigV1ClampOracle.json` was captured from base commit `7b5f0dd` **before any v2 code existed** (provenance in the artifact; capture mode documented in `backend/test/designConfigV1Golden.test.js`). The golden test replays 13 real-shaped v1 fixtures × 3 roles × 2 stored-states through `clampDesignConfig` + `buildPublicDesignConfig` and structurally compares against the artifact — it passes with all PR 1 changes in place, and additionally the gate test asserts every untagged fixture clamps identically with the flag on and off.

## Verification

- Backend: **134/134** across 9 suites (v2 util incl. role×version matrix, golden, public whitelist incl. poison keys, featuredDrop/luckyDraw/marketplace/customerHost neighbors, campaignService unit, drawTermsVersioning).
- Frontend: **1278/1279** — the 1 failure is the pre-existing `PublicPreview` red (fails identically on clean `30eb69d`; untouched by this PR).
- Both brand bundles build; eslint clean.
- **Prod audit**: `SELECT count(*) FILTER (WHERE design_config->'version' IS NOT NULL) FROM campaigns` → **0 of 15** (no pre-existing tagged docs; `design_config` is a `json` column, `?` operator N/A).

## Design decisions (flagged for review)

1. **Quiz/guidedReview/luckyDraw stored VERBATIM** — the handoff's flattened quiz table becomes the *Studio's editing view* (PR 3 mappers), not a storage change: the server re-scores from the stored shape (`quizScoringService`), so restructuring storage = scoring risk. Production-wins; handoff §04 itself documents the math against the v1 JSON keys.
2. **`advertiserName` defaults at READ time** (PR 0's DncConsentGate threading), never baked at migration — survives campaign renames, keeps `upgradeDesignConfig` pure.
3. **Warm-cream + null accent downgrades WITHOUT a themeColor key** (v1's absent-default *is* the warm-cream accent) — exact round-trip; other presets bake theirs (no v1 counterpart exists).
4. Codex's alternative of shipping "pure modules only" was extended rather than adopted: the clamp/whitelist code ships now, fully tested but unreachable, so PR 2/3 only flip the flag after wiring readers via `readLegacyView`.

## Rollout

Nothing consumes v2 yet. PR 2 (v2 renderer + reader adapters) and PR 3 (Studio) flip `DESIGN_CONFIG_V2_WRITES_ENABLED` when the funnel + backend readers understand both versions. Until then this backend deploy is inert: v1 saves take the byte-identical path (oracle-proven), v2 saves are politely rejected with a machine-readable code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UkhEDCeEeKJwBDFpUdqvPc
