### PR TITLE
fix(campaigns): gate the duplicate write path against ungated v2 docs

### DIFF
--- a/backend/src/services/campaignService.js
+++ b/backend/src/services/campaignService.js
@@ -756,9 +756,22 @@ export async function duplicateCampaign(id, body, req) {
     }
     return copy;
   })();
+  // A versioned (v2 Studio) duplicate goes through the SAME write gate as
+  // create/update — the never-clone transform above is not a substitute for it.
+  // Renderer dispatch is version-driven, not flag-gated, so a v2 doc minted here
+  // would be immediately customer-facing: while DESIGN_CONFIG_V2_WRITES_ENABLED
+  // is off this throws 422 (a duplicate must never propagate v2 rows behind the
+  // flag), and when on it re-clamps at the v2 paths. Legacy (v1) duplicates keep
+  // their verbatim transform above — clamping them would drop the disabled
+  // featuredDrop for non-admins (applyFeaturedDropPolicy returns stored), a
+  // behavior change the v1 clamp golden does not cover.
+  const dupDesignFinal =
+    dupDesign && typeof dupDesign === 'object' && classifyDesignConfigVersion(dupDesign) !== 'legacy'
+      ? clampDesignConfig(dupDesign, undefined, req.user?.role)
+      : dupDesign;
   const copy = await Campaign.create({
     ...rest,
-    design_config: dupDesign,
+    design_config: dupDesignFinal,
     id: undefined,
     name: body.name || `${original.name} (Copy)`,
     status: 'draft',

--- a/backend/test/designConfigV2.util.test.js
+++ b/backend/test/designConfigV2.util.test.js
@@ -247,7 +247,8 @@ describe('campaignService guards', () => {
     ).rejects.toMatchObject({ statusCode: 409, data: { code: 'DESIGN_CONFIG_VERSION_CONFLICT' } });
   });
 
-  it('duplicateCampaign strips v2 publication state at the v2 paths', async () => {
+  it('duplicateCampaign strips v2 publication state at the v2 paths (flag on)', async () => {
+    flagOn(); // a versioned duplicate is only allowed to persist while the gate is open
     const original = {
       toJSON: () => ({
         id: 'c2', name: 'Rich', status: 'active', design_config: structuredClone(v2Rich),
@@ -267,6 +268,44 @@ describe('campaignService guards', () => {
     expect(created.design_config.distribution.marketplace.listed).toBeUndefined();
     expect(created.design_config.version).toBe(2);
     expect(created.slug).toBeNull();
+  });
+
+  it('duplicateCampaign of a v2 campaign is REJECTED while the flag is off (no ungated v2 mint)', async () => {
+    // Regression: duplicate must not be a back door around the write gate.
+    // A v2 doc can outlive a flag-on window (rollout then rollback); cloning it
+    // while the flag is off would propagate v2 rows the cleanup can't freeze,
+    // and the renderer dispatch (version-driven) would serve them immediately.
+    const original = {
+      toJSON: () => ({
+        id: 'c2', name: 'Rich', status: 'active', design_config: structuredClone(v2Rich),
+        slug: 'rich', firstActivatedAt: new Date(),
+      }),
+    };
+    models.Campaign.findOne.mockResolvedValue(original);
+    models.Campaign.create.mockResolvedValue({ id: 'c3', toJSON: () => ({ id: 'c3' }) });
+    await expect(
+      duplicateCampaign('c2', {}, { user: { id: 'u1', role: 'agent' } })
+    ).rejects.toMatchObject({ statusCode: 422, data: { code: 'DESIGN_CONFIG_VERSION_UNSUPPORTED' } });
+    expect(models.Campaign.create).not.toHaveBeenCalled();
+  });
+
+  it('duplicateCampaign of a legacy (v1) campaign is never gated (flag off)', async () => {
+    // The fix is surgical: only versioned duplicates hit the gate. A v1 clone
+    // still persists verbatim (its disabled featuredDrop preserved, not dropped).
+    const original = {
+      toJSON: () => ({
+        id: 'c2', name: 'V1', status: 'active',
+        design_config: structuredClone(adminRichDoc), // untagged v1 doc
+        slug: 'v1', firstActivatedAt: new Date(),
+      }),
+    };
+    models.Campaign.findOne.mockResolvedValue(original);
+    models.Campaign.create.mockImplementation(async (data) => ({ id: 'c3', ...data, toJSON: () => ({ id: 'c3' }) }));
+    await duplicateCampaign('c2', {}, { user: { id: 'u1', role: 'agent' } });
+    const created = models.Campaign.create.mock.calls[0][0];
+    expect(created.design_config.version).toBeUndefined();
+    expect(created.design_config.marketplaceListed).toBeUndefined(); // never-clone
+    expect(created.design_config.featuredDrop.enabled).toBe(false); // preserved, disabled
   });
 
   it('ensureDrawTermsVersion pins terms from form.terms.html on a v2 doc', async () => {


### PR DESCRIPTION
## What

`duplicateCampaign` persisted `design_config` **verbatim** — no `clampDesignConfig`, no version gate — even though its own transform explicitly handles v2 docs (the `distribution.*` never-clone branch at `campaignService.js:746`). Create (`:375`) and update (`:501`) route through the gate; **duplicate did not**, so it was an ungated write path. Found during adversarial review of the Campaign Studio revamp (PRs #180–#182).

## Why it matters

The renderer cutover is **version-driven, not flag-gated**: a `design_config.version === 2` doc renders through the new template renderer the moment it exists, regardless of `DESIGN_CONFIG_V2_WRITES_ENABLED`. A v2 doc can outlive a flag-on rollout window (rollout → rollback). Before this fix, an agent or admin could duplicate it — and `buildCampaignWhere` lets a non-admin agent duplicate **any `isPublic` campaign** — minting new v2 rows the flag-off cleanup can't freeze, each immediately customer-facing. So "every write path is gated" and "flipping the flag off freezes the v2 population" were not actually true.

## Fix

Surgical: only a **versioned (non-legacy)** duplicate goes through `clampDesignConfig` — `422 DESIGN_CONFIG_VERSION_UNSUPPORTED` while the flag is off, re-clamped at the v2 paths when on. **Legacy (v1) duplicates keep their verbatim never-clone transform** — routing them through the clamp would drop a non-admin's disabled `featuredDrop` (`applyFeaturedDropPolicy` returns the *stored* value, which is `undefined` for a fresh copy), a v1 behavior change the clamp golden does not cover.

## Tests

- **New:** v2 duplicate rejected `422` (and `Campaign.create` never called) while the flag is off — the F1 regression guard.
- **New:** v1 (legacy) duplicate stays ungated + verbatim (disabled `featuredDrop` preserved).
- **Updated:** the existing "strips v2 publication state" test now runs flag-on (a versioned duplicate only persists while the gate is open); assertions unchanged.
- v1-clamp **golden** + full design-config/campaign/marketplace suites green (166 tests across 11 suites).

## Risk

None today — prod has **0 of 15** campaigns carrying a v2 tag (SQL-verified). Feature is dark; this closes the gate ahead of any flag flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ET9bWV4VQwY7LFJ9RxLFe