### PR TITLE
feat(admin-v2): real ⌘K global-search palette + live attention bell

### DIFF
--- a/src/components/adminv2/AdminV2Shell.jsx
+++ b/src/components/adminv2/AdminV2Shell.jsx
@@ -2,13 +2,17 @@
  * Switchboard shell — chrome laid out 1:1 with the design source
  * (claude.ai/design 57e68763 "MKTR Admin.dc.html"): fixed 228px sidebar
  * (M logo tile, mono group labels, glyphless nav, Redeem Ops footer card) and
- * a 64px canvas topbar (search → Prospects, SGT clock, theme toggle, bell,
- * avatar menu). [data-theme] dark swap persisted to localStorage. Wraps every
- * v2 admin screen; legacy pages keep their own shell until their PR lands.
+ * a 64px canvas topbar (⌘K global-search palette, SGT clock, theme toggle,
+ * attention bell, avatar menu). [data-theme] dark swap persisted to
+ * localStorage. Wraps every v2 admin screen; legacy pages keep their own
+ * shell until their PR lands.
  */
 import { useEffect, useState } from 'react';
 import { Link, NavLink, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
+import { NAV } from '@/lib/adminV2/nav';
+import GlobalSearch from './GlobalSearch';
+import NotificationsBell from './NotificationsBell';
 import '@/styles/adminV2.css';
 
 const THEME_KEY = 'mktr_admin_v2_theme';
@@ -16,33 +20,6 @@ const THEME_KEY = 'mktr_admin_v2_theme';
 // Same flag that registers the /redeem-ops routes (src/pages/index.jsx) — a
 // build without it must not render a dead link in the sidebar footer.
 const REDEEM_OPS_ENABLED = import.meta.env.VITE_REDEEM_OPS_ENABLED === 'true';
-
-// Mock IA order — Agents/Groups ahead of Campaigns (design source sidebar).
-const NAV = [
-  {
-    label: 'Overview',
-    items: [{ to: '/AdminDashboard', label: 'Dashboard' }],
-  },
-  {
-    label: 'Lead Generation',
-    items: [
-      { to: '/AdminProspects', label: 'Prospects' },
-      { to: '/AdminAgents', label: 'Agents' },
-      { to: '/AdminAgentGroups', label: 'Agent Groups' },
-      { to: '/AdminCampaigns', label: 'Campaigns' },
-      { to: '/AdminWallets', label: 'Wallets & Commitments' },
-      { to: '/AdminQRCodes', label: 'QR Codes' },
-      { to: '/AdminShortLinks', label: 'Short Links' },
-    ],
-  },
-  {
-    label: 'System',
-    items: [
-      { to: '/AdminUsers', label: 'Users' },
-      { to: '/AdminAISettings', label: 'AI Settings' },
-    ],
-  },
-];
 
 export function useAdminV2Theme() {
   const [theme, setTheme] = useState(() => localStorage.getItem(THEME_KEY) || 'light');
@@ -78,19 +55,14 @@ export default function AdminV2Shell({ children, fullBleed = false, legacyBridge
     return () => clearInterval(t);
   }, []);
 
-  // ⌘K / Ctrl+K jumps to the searchable Prospects table (the global-search
-  // affordance from the design — a dedicated palette is a later pass).
+  // ⌘K lives in <GlobalSearch/>; the shell only closes its own avatar menu.
   useEffect(() => {
     const onKey = (e) => {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
-        e.preventDefault();
-        navigate('/AdminProspects');
-      }
       if (e.key === 'Escape') setMenuOpen(false);
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [navigate]);
+  }, []);
 
   const handleSignOut = async () => {
     try {
@@ -153,23 +125,7 @@ export default function AdminV2Shell({ children, fullBleed = false, legacyBridge
               background: 'var(--canvas)', borderBottom: '1px solid var(--line)',
             }}
           >
-            <button
-              type="button"
-              onClick={() => navigate('/AdminProspects')}
-              title="Search leads — opens Prospects (⌘K)"
-              style={{
-                flex: '0 1 320px', height: 40, display: 'flex', alignItems: 'center', gap: 8, padding: '0 12px',
-                background: 'var(--surface)', border: '1px solid var(--line)', borderRadius: 10,
-                boxSizing: 'border-box', cursor: 'pointer', fontFamily: 'var(--font-ui)',
-              }}
-            >
-              <svg viewBox="0 0 24 24" style={{ width: 15, height: 15, flex: 'none' }} aria-hidden="true">
-                <path d="M10.5 3a7.5 7.5 0 1 1 0 15 7.5 7.5 0 0 1 0-15Z" fill="none" stroke="var(--ink-3)" strokeWidth="2" />
-                <path d="M16.2 16.2 21 21" fill="none" stroke="var(--ink-3)" strokeWidth="2" strokeLinecap="round" />
-              </svg>
-              <span style={{ flex: 1, fontSize: 13, color: 'var(--ink-3)', whiteSpace: 'nowrap', overflow: 'hidden', textAlign: 'left' }}>Search leads, campaigns, agents</span>
-              <span className="av2-mono" style={{ fontSize: 10, color: 'var(--ink-3)', border: '1px solid var(--line-strong)', borderRadius: 5, padding: '1px 5px' }}>⌘K</span>
-            </button>
+            <GlobalSearch />
             <span style={{ flex: 1 }} />
             <span className="av2-mono" style={{ fontSize: 12, color: 'var(--ink-2)', display: 'flex', alignItems: 'center', gap: 7 }}>
               <span className="av2-pulse" aria-hidden="true" />
@@ -198,20 +154,7 @@ export default function AdminV2Shell({ children, fullBleed = false, legacyBridge
               )}
               <span style={{ fontSize: 12.5, fontWeight: 600, color: 'var(--ink-2)' }}>{theme === 'light' ? 'Light' : 'Dark'}</span>
             </button>
-            <button
-              type="button"
-              title="Notifications — coming soon"
-              aria-label="Notifications (coming soon)"
-              style={{
-                width: 40, height: 40, flex: 'none', display: 'flex', alignItems: 'center', justifyContent: 'center',
-                background: 'var(--surface)', border: '1px solid var(--line-strong)', borderRadius: 10, cursor: 'default',
-              }}
-            >
-              <svg viewBox="0 0 24 24" style={{ width: 16, height: 16 }} aria-hidden="true">
-                <path d="M12 3a6 6 0 0 0-6 6v4l-2 3h16l-2-3V9a6 6 0 0 0-6-6Z" fill="none" stroke="var(--ink-2)" strokeWidth="2" strokeLinejoin="round" />
-                <path d="M10 19a2 2 0 0 0 4 0" fill="none" stroke="var(--ink-2)" strokeWidth="2" />
-              </svg>
-            </button>
+            <NotificationsBell />
             <div style={{ position: 'relative' }}>
               <button
                 type="button"

--- a/src/components/adminv2/GlobalSearch.jsx
+++ b/src/components/adminv2/GlobalSearch.jsx
@@ -1,0 +1,311 @@
+/**
+ * Global search palette (⌘K) — the topbar pill is a real search, not a
+ * Prospects shortcut. Leads hit GET /prospects?search= server-side; campaigns
+ * and agents filter already-cached rosters client-side (same query keys as the
+ * dashboard leaderboard / assign picker, so a warm cache costs zero requests);
+ * page routes match on their sidebar labels. Selection deep-links: a lead
+ * lands on Prospects pre-filtered with its drawer auto-opened (?q=…&lead=…),
+ * a campaign opens /admin/campaigns/:id, an agent lands on the roster
+ * pre-filtered (?q=…). The last row is always "search in Prospects", so ↵
+ * never dead-ends.
+ */
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { fetchProspects, fetchCampaignsList, fetchAgentOptions } from '@/api/adminV2';
+import { NAV } from '@/lib/adminV2/nav';
+
+const MIN_QUERY = 2; // entity endpoints; page-label matching starts at 1 char
+const GROUP_LIMIT = 5;
+
+export default function GlobalSearch() {
+  const [open, setOpen] = useState(false);
+  const [q, setQ] = useState('');
+  const [dq, setDq] = useState('');
+  const [active, setActive] = useState(0);
+  const navigate = useNavigate();
+  const inputRef = useRef(null);
+  const pillRef = useRef(null);
+  const wasOpen = useRef(false);
+
+  // ⌘K / Ctrl+K toggles the palette from anywhere in the admin shell.
+  useEffect(() => {
+    const onKey = (e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setOpen((v) => !v);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      wasOpen.current = true;
+      setQ('');
+      setDq('');
+      setActive(0);
+    } else if (wasOpen.current) {
+      // Restore focus to the trigger on close (never on initial mount).
+      wasOpen.current = false;
+      pillRef.current?.focus();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    const t = setTimeout(() => setDq(q.trim()), 250);
+    return () => clearTimeout(t);
+  }, [q]);
+
+  const searching = open && dq.length >= MIN_QUERY;
+
+  const leads = useQuery({
+    queryKey: ['adminV2', 'palette', 'leads', dq],
+    queryFn: () => fetchProspects({ search: dq, limit: GROUP_LIMIT, sort: '-createdAt' }),
+    enabled: searching,
+    staleTime: 15_000,
+    placeholderData: (prev) => prev,
+  });
+  const campaigns = useQuery({
+    queryKey: ['adminV2', 'campaigns', '30d'],
+    queryFn: () => fetchCampaignsList('30d'),
+    enabled: searching,
+    staleTime: 60_000,
+  });
+  const agents = useQuery({
+    queryKey: ['adminV2', 'agentOptions'],
+    queryFn: fetchAgentOptions,
+    enabled: searching,
+    staleTime: 300_000,
+  });
+
+  const groups = useMemo(() => {
+    const needle = dq.toLowerCase();
+    const trimmed = q.trim().toLowerCase();
+    const out = [];
+
+    if (searching) {
+      out.push({
+        label: 'Leads',
+        busy: leads.isFetching,
+        rows: (leads.data?.rows || []).map((p) => {
+          const name = `${p.firstName || ''} ${p.lastName || ''}`.trim() || p.email || p.phone || 'Lead';
+          return {
+            id: `av2-opt-lead-${p.id}`,
+            title: name,
+            sub: [p.phone, p.campaign?.name].filter(Boolean).join(' · ') || p.email || '',
+            to: `/AdminProspects?q=${encodeURIComponent(p.phone || p.email || name)}&lead=${encodeURIComponent(p.id)}`,
+          };
+        }),
+      });
+      out.push({
+        label: 'Campaigns',
+        busy: campaigns.isFetching,
+        rows: (campaigns.data?.rows || [])
+          .filter((c) => (c.name || '').toLowerCase().includes(needle))
+          .slice(0, GROUP_LIMIT)
+          .map((c) => ({
+            id: `av2-opt-campaign-${c.id}`,
+            title: c.name || 'Campaign',
+            sub: c.status || '',
+            to: `/admin/campaigns/${c.id}`,
+          })),
+      });
+      out.push({
+        label: 'Agents',
+        busy: agents.isFetching,
+        rows: (agents.data || [])
+          .filter((a) => [a.name, a.email, a.phone].filter(Boolean).some((s) => s.toLowerCase().includes(needle)))
+          .slice(0, GROUP_LIMIT)
+          .map((a) => ({
+            id: `av2-opt-agent-${a.id}`,
+            title: a.name || a.email || 'Agent',
+            sub: [a.phone, a.email].filter(Boolean).join(' · '),
+            to: `/AdminAgents?q=${encodeURIComponent(a.name || a.email || '')}`,
+          })),
+      });
+    }
+
+    if (trimmed.length >= 1) {
+      out.push({
+        label: 'Pages',
+        rows: NAV.flatMap((s) => s.items.map((i) => ({ ...i, section: s.label })))
+          .filter((i) => i.label.toLowerCase().includes(trimmed))
+          .map((i) => ({ id: `av2-opt-page-${i.to}`, title: i.label, sub: i.section, to: i.to })),
+      });
+    }
+
+    if (searching) {
+      out.push({
+        label: null,
+        rows: [{
+          id: 'av2-opt-fallback',
+          title: `Search “${dq}” in Prospects`,
+          sub: 'full table search',
+          to: `/AdminProspects?q=${encodeURIComponent(dq)}`,
+        }],
+      });
+    }
+    return out;
+  }, [searching, dq, q, leads.data, leads.isFetching, campaigns.data, campaigns.isFetching, agents.data, agents.isFetching]);
+
+  const flat = useMemo(() => groups.flatMap((g) => g.rows), [groups]);
+  const settled = !leads.isFetching && !campaigns.isFetching && !agents.isFetching;
+  const anyError = leads.isError || campaigns.isError || agents.isError;
+  const nothingFound = searching && settled && !anyError && flat.length === 1; // fallback row only
+
+  useEffect(() => { setActive(0); }, [dq]);
+  useEffect(() => {
+    if (active > 0 && active >= flat.length) setActive(Math.max(0, flat.length - 1));
+  }, [flat.length, active]);
+  useEffect(() => {
+    // Optional call — jsdom has no scrollIntoView.
+    if (flat[active]) document.getElementById(flat[active].id)?.scrollIntoView?.({ block: 'nearest' });
+  }, [active, flat]);
+
+  const select = (row) => {
+    if (!row) return;
+    setOpen(false);
+    navigate(row.to);
+  };
+
+  const onInputKey = (e) => {
+    if (e.key === 'ArrowDown') { e.preventDefault(); setActive((a) => Math.min(a + 1, Math.max(0, flat.length - 1))); }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setActive((a) => Math.max(a - 1, 0)); }
+    else if (e.key === 'Enter') { e.preventDefault(); select(flat[active]); }
+    else if (e.key === 'Escape') { e.preventDefault(); setOpen(false); }
+  };
+
+  let optionIndex = -1;
+
+  return (
+    <>
+      <button
+        ref={pillRef}
+        type="button"
+        onClick={() => setOpen(true)}
+        title="Search leads, campaigns, agents (⌘K)"
+        style={{
+          flex: '0 1 320px', height: 40, display: 'flex', alignItems: 'center', gap: 8, padding: '0 12px',
+          background: 'var(--surface)', border: '1px solid var(--line)', borderRadius: 10,
+          boxSizing: 'border-box', cursor: 'pointer', fontFamily: 'var(--font-ui)',
+        }}
+      >
+        <svg viewBox="0 0 24 24" style={{ width: 15, height: 15, flex: 'none' }} aria-hidden="true">
+          <path d="M10.5 3a7.5 7.5 0 1 1 0 15 7.5 7.5 0 0 1 0-15Z" fill="none" stroke="var(--ink-3)" strokeWidth="2" />
+          <path d="M16.2 16.2 21 21" fill="none" stroke="var(--ink-3)" strokeWidth="2" strokeLinecap="round" />
+        </svg>
+        <span style={{ flex: 1, fontSize: 13, color: 'var(--ink-3)', whiteSpace: 'nowrap', overflow: 'hidden', textAlign: 'left' }}>Search leads, campaigns, agents</span>
+        <span className="av2-mono" style={{ fontSize: 10, color: 'var(--ink-3)', border: '1px solid var(--line-strong)', borderRadius: 5, padding: '1px 5px' }}>⌘K</span>
+      </button>
+
+      {open && (
+        // Plain fixed divs (no portal) so the palette stays inside the
+        // .admin-v2 subtree and inherits the [data-theme] CSS variables.
+        <div
+          onMouseDown={() => setOpen(false)}
+          style={{ position: 'fixed', inset: 0, zIndex: 90, background: 'rgba(9, 11, 16, .42)', display: 'flex', justifyContent: 'center', alignItems: 'flex-start' }}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Global search"
+            onMouseDown={(e) => e.stopPropagation()}
+            // The input is the dialog's only tab stop (options are pointer/
+            // arrow-key targets) — swallow Tab so focus can't reach the page
+            // behind the overlay.
+            onKeyDown={(e) => { if (e.key === 'Tab') e.preventDefault(); }}
+            style={{
+              width: 'min(600px, 92vw)', marginTop: '12vh', background: 'var(--surface)',
+              border: '1px solid var(--line-strong)', borderRadius: 14, boxShadow: 'var(--shadow)',
+              overflow: 'hidden', boxSizing: 'border-box',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '0 14px', height: 50, borderBottom: '1px solid var(--line)' }}>
+              <svg viewBox="0 0 24 24" style={{ width: 16, height: 16, flex: 'none' }} aria-hidden="true">
+                <path d="M10.5 3a7.5 7.5 0 1 1 0 15 7.5 7.5 0 0 1 0-15Z" fill="none" stroke="var(--ink-3)" strokeWidth="2" />
+                <path d="M16.2 16.2 21 21" fill="none" stroke="var(--ink-3)" strokeWidth="2" strokeLinecap="round" />
+              </svg>
+              <input
+                ref={inputRef}
+                autoFocus
+                value={q}
+                onChange={(e) => setQ(e.target.value)}
+                onKeyDown={onInputKey}
+                placeholder="Search leads, campaigns, agents…"
+                aria-label="Global search"
+                role="combobox"
+                aria-expanded="true"
+                aria-controls="av2-palette-list"
+                aria-activedescendant={flat[active]?.id}
+                style={{ flex: 1, border: 'none', outline: 'none', background: 'transparent', fontFamily: 'var(--font-ui)', fontSize: 14, color: 'var(--ink)' }}
+              />
+              <span className="av2-mono" style={{ fontSize: 10, color: 'var(--ink-3)', border: '1px solid var(--line-strong)', borderRadius: 5, padding: '1px 5px', flex: 'none' }}>esc</span>
+            </div>
+
+            <div id="av2-palette-list" role="listbox" aria-label="Search results" style={{ maxHeight: 400, overflowY: 'auto', padding: 6 }}>
+              {!searching && q.trim().length < 1 && (
+                <div className="av2-mono" style={{ padding: '18px 12px', fontSize: 11, color: 'var(--ink-3)', textAlign: 'center' }}>
+                  Type to search leads, campaigns, agents and pages
+                </div>
+              )}
+              {nothingFound && (
+                <div className="av2-mono" style={{ padding: '14px 12px 6px', fontSize: 11, color: 'var(--ink-3)', textAlign: 'center' }}>
+                  No direct matches for “{dq}”
+                </div>
+              )}
+              {searching && anyError && settled && (
+                <div className="av2-mono" style={{ padding: '14px 12px 6px', fontSize: 11, color: 'var(--bad)', textAlign: 'center' }}>
+                  Search hit an error — results may be incomplete
+                </div>
+              )}
+              {groups.map((g, gi) => {
+                if (g.rows.length === 0) return null;
+                return (
+                  <div key={g.label || `group-${gi}`} style={{ paddingTop: gi === 0 ? 0 : 4 }}>
+                    {g.label && (
+                      <div className="av2-microcaps" aria-hidden="true" style={{ padding: '8px 10px 4px', display: 'flex', alignItems: 'center', gap: 6 }}>
+                        {g.label}
+                        {g.busy && <span className="av2-mono" style={{ fontSize: 9, color: 'var(--ink-3)', textTransform: 'none', letterSpacing: 0 }}>searching…</span>}
+                      </div>
+                    )}
+                    {g.rows.map((r) => {
+                      optionIndex += 1;
+                      const i = optionIndex;
+                      const isActive = i === active;
+                      return (
+                        <div
+                          key={r.id}
+                          id={r.id}
+                          role="option"
+                          aria-selected={isActive}
+                          onMouseEnter={() => setActive(i)}
+                          onClick={() => select(r)}
+                          style={{
+                            display: 'flex', alignItems: 'baseline', gap: 10, padding: '9px 10px',
+                            borderRadius: 8, cursor: 'pointer',
+                            background: isActive ? 'var(--surface-2)' : 'transparent',
+                          }}
+                        >
+                          <span style={{ fontSize: 13, fontWeight: 700, color: 'var(--ink)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{r.title}</span>
+                          <span className="av2-mono" style={{ fontSize: 10.5, color: 'var(--ink-3)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', flex: 1, textAlign: 'right' }}>{r.sub}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                );
+              })}
+            </div>
+
+            <div className="av2-mono" style={{ padding: '8px 14px', borderTop: '1px solid var(--line)', fontSize: 10, color: 'var(--ink-3)', display: 'flex', gap: 14 }}>
+              <span>↑↓ navigate</span>
+              <span>↵ open</span>
+              <span>esc close</span>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/adminv2/NotificationsBell.jsx
+++ b/src/components/adminv2/NotificationsBell.jsx
@@ -1,0 +1,172 @@
+/**
+ * Topbar attention bell — live alerts, not a placeholder. Reads the same
+ * GET /dashboard/attention aggregate as the dashboard (shared query key, plus
+ * a gentle 2-min poll since refetchOnWindowFocus is off globally) composed
+ * through composeAttentionRows, so the bell and the "Needs attention" queue
+ * can never disagree. The badge counts actionable severities
+ * (incident / held / warning); watch-tier rows list in the panel unbadged.
+ * Every row deep-links to its pre-filtered screen.
+ */
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { fetchAttention } from '@/api/adminV2';
+import { composeAttentionRows, SEVERITY_GLYPH } from '@/lib/adminV2/attention';
+import { fmtRelative } from '@/lib/adminV2/format';
+import { Skeleton } from '@/components/adminv2/primitives';
+
+const ACTIONABLE = new Set(['incident', 'held', 'warning']);
+const TONE = { incident: 'var(--bad)', held: 'var(--hold)', warning: 'var(--warn)', watch: 'var(--ink-3)' };
+
+export default function NotificationsBell() {
+  const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
+
+  const attention = useQuery({
+    queryKey: ['adminV2', 'attention'],
+    queryFn: fetchAttention,
+    staleTime: 30_000,
+    refetchInterval: 120_000,
+  });
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const onKey = (e) => { if (e.key === 'Escape') setOpen(false); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  const rows = composeAttentionRows(attention.data);
+  const actionable = rows.filter((r) => ACTIONABLE.has(r.severity));
+  const badge = actionable.length;
+  // Rows arrive severity-sorted, so the first actionable row is the worst.
+  const badgeTone = TONE[actionable[0]?.severity] || 'var(--warn)';
+
+  // Zero rows only means "all clear" once the feed actually loaded.
+  const bellLabel = attention.isLoading
+    ? 'Notifications — loading'
+    : attention.isError
+      ? 'Notifications — couldn’t load alerts'
+      : badge > 0
+        ? `Notifications — ${badge} item${badge === 1 ? '' : 's'} need attention`
+        : 'Notifications — all clear';
+
+  const go = (href) => {
+    setOpen(false);
+    navigate(href);
+  };
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        title={bellLabel}
+        aria-label={bellLabel}
+        aria-expanded={open}
+        style={{
+          width: 40, height: 40, flex: 'none', display: 'flex', alignItems: 'center', justifyContent: 'center',
+          background: 'var(--surface)', border: '1px solid var(--line-strong)', borderRadius: 10, cursor: 'pointer',
+          position: 'relative',
+        }}
+      >
+        <svg viewBox="0 0 24 24" style={{ width: 16, height: 16 }} aria-hidden="true">
+          <path d="M12 3a6 6 0 0 0-6 6v4l-2 3h16l-2-3V9a6 6 0 0 0-6-6Z" fill="none" stroke="var(--ink-2)" strokeWidth="2" strokeLinejoin="round" />
+          <path d="M10 19a2 2 0 0 0 4 0" fill="none" stroke="var(--ink-2)" strokeWidth="2" />
+        </svg>
+        {badge > 0 && (
+          <span
+            className="av2-mono"
+            aria-hidden="true"
+            style={{
+              position: 'absolute', top: -5, right: -5, minWidth: 17, height: 17, padding: '0 4px',
+              borderRadius: 9, background: badgeTone, color: '#fff', fontSize: 9.5, fontWeight: 700,
+              display: 'flex', alignItems: 'center', justifyContent: 'center', boxSizing: 'border-box',
+              border: '2px solid var(--canvas)',
+            }}
+          >
+            {badge > 9 ? '9+' : badge}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <>
+          <div onClick={() => setOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 60 }} aria-hidden="true" />
+          {/* Plain popover of buttons/links — deliberately NOT role="menu",
+              which would promise arrow-key/focus semantics this doesn't have.
+              Tab walks the real <button>s; Escape closes. */}
+          <div
+            aria-label="Notifications"
+            style={{
+              position: 'absolute', right: 0, top: 44, zIndex: 70, width: 340,
+              background: 'var(--surface)', border: '1px solid var(--line-strong)', borderRadius: 12,
+              boxShadow: 'var(--shadow)', boxSizing: 'border-box', overflow: 'hidden',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, padding: '10px 12px', borderBottom: '1px solid var(--line)' }}>
+              <span className="av2-microcaps">Needs attention</span>
+              <span style={{ flex: 1 }} />
+              <span className="av2-mono" style={{ fontSize: 9.5, color: 'var(--ink-3)' }}>
+                {attention.dataUpdatedAt ? `updated ${fmtRelative(attention.dataUpdatedAt)}` : ''}
+              </span>
+            </div>
+
+            <div style={{ maxHeight: 380, overflowY: 'auto', padding: 6 }}>
+              {attention.isLoading && [0, 1].map((i) => (
+                <div key={i} style={{ padding: 4 }}><Skeleton height={40} /></div>
+              ))}
+              {attention.isError && (
+                <div style={{ padding: '14px 10px', display: 'grid', gap: 8, justifyItems: 'start' }}>
+                  <span style={{ fontSize: 12.5, color: 'var(--ink-2)' }}>Couldn’t load alerts.</span>
+                  <button type="button" className="av2-btn av2-btn--sm" onClick={() => attention.refetch()}>Retry</button>
+                </div>
+              )}
+              {!attention.isLoading && !attention.isError && rows.length === 0 && (
+                <div style={{ padding: '18px 10px', textAlign: 'center' }}>
+                  <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--ink)' }}>All clear</div>
+                  <div className="av2-mono" style={{ fontSize: 10.5, color: 'var(--ink-3)', marginTop: 3 }}>nothing needs attention right now</div>
+                </div>
+              )}
+              {rows.map((r) => (
+                <button
+                  key={r.id}
+                  type="button"
+                  onClick={() => go(r.href)}
+                  style={{
+                    display: 'flex', width: '100%', alignItems: 'flex-start', gap: 9, textAlign: 'left',
+                    background: 'transparent', border: 'none', borderRadius: 8, padding: '8px 10px',
+                    cursor: 'pointer', fontFamily: 'var(--font-ui)',
+                  }}
+                  onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--surface-2)'; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+                >
+                  <span aria-hidden="true" style={{ flex: 'none', fontSize: 11, lineHeight: '17px', color: TONE[r.severity] || 'var(--ink-3)' }}>
+                    {SEVERITY_GLYPH[r.severity] || '●'}
+                  </span>
+                  <span style={{ minWidth: 0 }}>
+                    <span style={{ display: 'block', fontSize: 12.5, fontWeight: 700, color: 'var(--ink)' }}>{r.title}</span>
+                    <span className="av2-mono" style={{ display: 'block', fontSize: 10, color: 'var(--ink-3)', marginTop: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.detail}</span>
+                  </span>
+                </button>
+              ))}
+            </div>
+
+            <button
+              type="button"
+              onClick={() => go('/AdminDashboard')}
+              className="av2-mono"
+              style={{
+                display: 'block', width: '100%', padding: '9px 12px', textAlign: 'left',
+                background: 'transparent', border: 'none', borderTop: '1px solid var(--line)',
+                fontSize: 10.5, color: 'var(--ink-2)', cursor: 'pointer',
+              }}
+            >
+              Open dashboard →
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/adminv2/__tests__/GlobalSearch.test.jsx
+++ b/src/components/adminv2/__tests__/GlobalSearch.test.jsx
@@ -1,0 +1,135 @@
+/**
+ * ⌘K palette — open/close affordances, grouped results across all four
+ * sources (server-searched leads, cached campaigns/agents, page labels),
+ * keyboard selection, and the never-dead-end fallback row. API layer mocked;
+ * navigation asserted through a real MemoryRouter location probe.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import GlobalSearch from '../GlobalSearch';
+
+vi.mock('@/api/adminV2', () => ({
+  fetchProspects: vi.fn(async ({ search }) => ({
+    rows: String(search).toLowerCase().includes('sa')
+      ? [{ id: 'p1', firstName: 'Sam', lastName: 'Tan', phone: '+6589279750', email: 'sam@x.com', campaign: { name: 'Redeem $10 Fairprice Voucher' } }]
+      : [],
+    total: 1, page: 1, totalPages: 1,
+  })),
+  fetchCampaignsList: vi.fn(async () => ({
+    rows: [{ id: 'c1', name: 'Tokyo Getaway Lucky Draw', status: 'active' }],
+    total: 1,
+  })),
+  fetchAgentOptions: vi.fn(async () => ([
+    { id: 'a1', name: 'Lee Wei', phone: '+6591111111', email: 'lee@x.com' },
+  ])),
+}));
+
+function LocationProbe() {
+  const loc = useLocation();
+  return <div data-testid="loc">{loc.pathname + loc.search}</div>;
+}
+
+function setup() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/AdminDashboard']}>
+        <GlobalSearch />
+        <LocationProbe />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+const openPalette = () => {
+  fireEvent.click(screen.getByRole('button', { name: /search leads, campaigns, agents/i }));
+  return screen.getByRole('combobox', { name: 'Global search' });
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('GlobalSearch', () => {
+  it('pill opens a real palette; Escape closes it', () => {
+    setup();
+    const input = openPalette();
+    expect(screen.getByRole('dialog', { name: 'Global search' })).toBeInTheDocument();
+    expect(input).toHaveFocus();
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('⌘K toggles the palette', () => {
+    setup();
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+    expect(screen.getByRole('dialog', { name: 'Global search' })).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('typing surfaces lead results and Enter deep-links with the drawer param', async () => {
+    setup();
+    const input = openPalette();
+    fireEvent.change(input, { target: { value: 'sam' } });
+    await screen.findByText('Sam Tan');
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(screen.getByTestId('loc')).toHaveTextContent('/AdminProspects?q=%2B6589279750&lead=p1');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('matches campaigns from the cached leaderboard and opens the detail page', async () => {
+    setup();
+    const input = openPalette();
+    fireEvent.change(input, { target: { value: 'tokyo' } });
+    fireEvent.click(await screen.findByText('Tokyo Getaway Lucky Draw'));
+    expect(screen.getByTestId('loc')).toHaveTextContent('/admin/campaigns/c1');
+  });
+
+  it('matches agents and lands on the roster pre-filtered', async () => {
+    setup();
+    const input = openPalette();
+    fireEvent.change(input, { target: { value: 'lee wei' } });
+    fireEvent.click(await screen.findByText('Lee Wei'));
+    expect(screen.getByTestId('loc')).toHaveTextContent('/AdminAgents?q=Lee%20Wei');
+  });
+
+  it('matches page routes by sidebar label', async () => {
+    setup();
+    const input = openPalette();
+    fireEvent.change(input, { target: { value: 'wallet' } });
+    fireEvent.click(await screen.findByText('Wallets & Commitments'));
+    expect(screen.getByTestId('loc')).toHaveTextContent('/AdminWallets');
+  });
+
+  it('arrow keys walk the flat list; the fallback row never dead-ends Enter', async () => {
+    setup();
+    const input = openPalette();
+    fireEvent.change(input, { target: { value: 'sam' } });
+    await screen.findByText('Sam Tan');
+    // flat list: [Sam Tan, fallback] — one step down lands on the fallback.
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(screen.getByTestId('loc')).toHaveTextContent('/AdminProspects?q=sam');
+  });
+
+  it('shows a no-match note plus the fallback when nothing hits', async () => {
+    setup();
+    const input = openPalette();
+    fireEvent.change(input, { target: { value: 'zzz' } });
+    await screen.findByText(/no direct matches for/i);
+    expect(screen.getByText('Search “zzz” in Prospects')).toBeInTheDocument();
+  });
+
+  it('reports an error instead of claiming no matches when a source fails', async () => {
+    const { fetchProspects } = await import('@/api/adminV2');
+    fetchProspects.mockRejectedValueOnce(new Error('boom'));
+    setup();
+    const input = openPalette();
+    fireEvent.change(input, { target: { value: 'err' } });
+    await screen.findByText(/search hit an error/i);
+    expect(screen.queryByText(/no direct matches/i)).not.toBeInTheDocument();
+    // The fallback row still gives Enter somewhere to go.
+    expect(screen.getByText('Search “err” in Prospects')).toBeInTheDocument();
+  });
+});

--- a/src/components/adminv2/__tests__/NotificationsBell.test.jsx
+++ b/src/components/adminv2/__tests__/NotificationsBell.test.jsx
@@ -1,0 +1,89 @@
+/**
+ * Attention bell — badge counts only actionable severities, the panel lists
+ * every composed row (watch tier included), rows deep-link, and an empty
+ * payload reads as "all clear" with no badge. fetchAttention mocked; rows
+ * come through the real composeAttentionRows.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import NotificationsBell from '../NotificationsBell';
+import { fetchAttention } from '@/api/adminV2';
+
+vi.mock('@/api/adminV2', () => ({
+  fetchAttention: vi.fn(async () => ({})),
+}));
+
+const PAYLOAD = {
+  webhooks: { pending: 3, failedLast24h: 2, subscriberDisabled: false },
+  held: { total: 3, byReason: { no_funded_agent: 2, dnc_pending: 1 } },
+  unassigned: 4,
+  wallets: { zero: [], low: [], floatCents: 0 },
+  zeroCommitCampaigns: [],
+  drawsClosing: [{ id: 'd1', name: 'Tokyo Getaway Lucky Draw', closesAt: new Date(Date.now() + 3 * 86400000).toISOString(), multiplier: 2, winners: 1 }],
+  endingCampaigns: [],
+};
+
+function LocationProbe() {
+  const loc = useLocation();
+  return <div data-testid="loc">{loc.pathname + loc.search}</div>;
+}
+
+function setup() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/AdminDashboard']}>
+        <NotificationsBell />
+        <LocationProbe />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('NotificationsBell', () => {
+  it('badges the actionable count — watch-tier rows are listed but not counted', async () => {
+    fetchAttention.mockResolvedValue(PAYLOAD);
+    setup();
+    // incident (webhooks) + held + warning (unassigned) = 3; the draw is watch.
+    const bell = await screen.findByRole('button', { name: /3 items need attention/i });
+    expect(bell).toHaveTextContent('3');
+
+    fireEvent.click(bell);
+    expect(await screen.findByText('2 Lyfe deliveries failed in 24h')).toBeInTheDocument();
+    expect(screen.getByText('3 leads held')).toBeInTheDocument();
+    expect(screen.getByText('4 leads unassigned')).toBeInTheDocument();
+    expect(screen.getByText(/draw closes in \d+d/)).toBeInTheDocument();
+  });
+
+  it('rows deep-link to their pre-filtered screens and close the panel', async () => {
+    fetchAttention.mockResolvedValue(PAYLOAD);
+    setup();
+    fireEvent.click(await screen.findByRole('button', { name: /need attention/i }));
+    fireEvent.click(await screen.findByText('3 leads held'));
+    expect(screen.getByTestId('loc')).toHaveTextContent('/AdminProspects?assignment=held');
+    expect(screen.queryByText('Needs attention')).not.toBeInTheDocument();
+  });
+
+  it('reads all-clear with no badge when nothing needs attention', async () => {
+    fetchAttention.mockResolvedValue({});
+    setup();
+    const bell = await screen.findByRole('button', { name: /all clear/i });
+    expect(bell).not.toHaveTextContent(/\d/);
+    fireEvent.click(bell);
+    expect(await screen.findByText('All clear')).toBeInTheDocument();
+  });
+
+  it('never claims all-clear on a failed feed — label and panel say so, retry offered', async () => {
+    fetchAttention.mockRejectedValue(new Error('boom'));
+    setup();
+    const bell = await screen.findByRole('button', { name: /couldn.t load alerts/i });
+    fireEvent.click(bell);
+    expect(await screen.findByText('Couldn’t load alerts.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    expect(screen.queryByText('All clear')).not.toBeInTheDocument();
+  });
+});

--- a/src/lib/adminV2/nav.js
+++ b/src/lib/adminV2/nav.js
@@ -1,0 +1,30 @@
+/**
+ * Admin v2 sidebar IA — one list, two consumers: the shell renders it as the
+ * sidebar, the ⌘K palette matches page routes against its labels. Mock IA
+ * order — Agents/Groups ahead of Campaigns (design source sidebar).
+ */
+export const NAV = [
+  {
+    label: 'Overview',
+    items: [{ to: '/AdminDashboard', label: 'Dashboard' }],
+  },
+  {
+    label: 'Lead Generation',
+    items: [
+      { to: '/AdminProspects', label: 'Prospects' },
+      { to: '/AdminAgents', label: 'Agents' },
+      { to: '/AdminAgentGroups', label: 'Agent Groups' },
+      { to: '/AdminCampaigns', label: 'Campaigns' },
+      { to: '/AdminWallets', label: 'Wallets & Commitments' },
+      { to: '/AdminQRCodes', label: 'QR Codes' },
+      { to: '/AdminShortLinks', label: 'Short Links' },
+    ],
+  },
+  {
+    label: 'System',
+    items: [
+      { to: '/AdminUsers', label: 'Users' },
+      { to: '/AdminAISettings', label: 'AI Settings' },
+    ],
+  },
+];

--- a/src/pages/adminv2/AdminV2Agents.jsx
+++ b/src/pages/adminv2/AdminV2Agents.jsx
@@ -7,7 +7,7 @@
  * Internal agents render "—" for wallet fields (null from the API — they have
  * no wallets in v1) and sort after the external roster.
  */
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useAgentsRoster } from '@/hooks/queries/useAdminV2';
 import { fmtNumber, fmtSGD, fmtSGDExact, fmtRelative } from '@/lib/adminV2/format';
@@ -117,20 +117,36 @@ export default function AdminV2Agents() {
   const setPeriod = (p) => patch({ period: p === '30d' ? null : p });
   const setStatus = (v) => patch({ status: v === 'active' ? null : v });
   const setWFilter = (v) => patch({ w: v || null });
-  // Debounce the search into the URL (functional — never clobbers other params).
+  // Live view of the params for timers created in older renders — RR v7's
+  // setSearchParams (functional form included) closes over its render's
+  // params and always navigates, so a stale timer would rewind the URL.
+  const paramsRef = useRef(searchParams);
+  paramsRef.current = searchParams;
+
+  // Debounce the search into the URL, reading LIVE params at fire time and
+  // skipping navigation entirely when q is already in sync.
   useEffect(() => {
     const t = setTimeout(() => {
-      setSearchParams((prev) => {
-        if ((prev.get('q') || '') === search) return prev;
-        const next = new URLSearchParams(prev);
-        if (search) next.set('q', search);
-        else next.delete('q');
-        return next;
-      }, { replace: true });
+      const prev = paramsRef.current;
+      if ((prev.get('q') || '') === search) return;
+      const next = new URLSearchParams(prev);
+      if (search) next.set('q', search);
+      else next.delete('q');
+      setSearchParams(next, { replace: true });
     }, 350);
     return () => clearTimeout(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [search]);
+
+  // ?q can change while mounted (⌘K palette pick, back/forward) — resync the
+  // input unless the operator is mid-typing. The roster query already follows
+  // urlSearch; without this the box would show stale text.
+  useEffect(() => {
+    if (document.activeElement?.getAttribute('aria-label') !== 'Search agents' && urlSearch !== search) {
+      setSearch(urlSearch);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlSearch]);
   const roster = useAgentsRoster({ period, search: urlSearch, status });
   const rows = roster.data?.rows || [];
 

--- a/src/pages/adminv2/AdminV2Prospects.jsx
+++ b/src/pages/adminv2/AdminV2Prospects.jsx
@@ -5,7 +5,7 @@
  * the bulk bar drives the REAL bulk endpoints (assign / return-to-held /
  * delete) plus a client-side CSV export.
  */
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState, useEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -150,19 +150,25 @@ export default function AdminV2Prospects() {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const queryClient = useQueryClient();
 
-  // Debounced search → URL (which drives the query). The timer applies its
-  // change FUNCTIONALLY over the latest params, so a filter clicked during the
-  // 350ms window is never clobbered by the stale closure.
+  // Live view of the params for timers created in older renders. RR v7's
+  // setSearchParams closes over ITS render's params (even the functional
+  // form receives that stale snapshot and always navigates), so a 350ms-old
+  // updater would rewind the URL — clobbering filters clicked inside the
+  // window and resurrecting consumed params like `lead`.
+  const paramsRef = useRef(searchParams);
+  paramsRef.current = searchParams;
+
+  // Debounced search → URL (which drives the query). Reads the LIVE params at
+  // fire time and skips navigation entirely when q is already in sync.
   useEffect(() => {
     const t = setTimeout(() => {
-      setSearchParams((prev) => {
-        if ((prev.get('q') || '') === searchDraft) return prev;
-        const next = new URLSearchParams(prev);
-        if (searchDraft) next.set('q', searchDraft);
-        else next.delete('q');
-        next.delete('page');
-        return next;
-      }, { replace: true });
+      const prev = paramsRef.current;
+      if ((prev.get('q') || '') === searchDraft) return;
+      const next = new URLSearchParams(prev);
+      if (searchDraft) next.set('q', searchDraft);
+      else next.delete('q');
+      next.delete('page');
+      setSearchParams(next, { replace: true });
     }, 350);
     return () => clearTimeout(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -206,6 +212,22 @@ export default function AdminV2Prospects() {
 
   // Selection is per-page; changing the result set clears it.
   useEffect(() => { setSelected(new Set()); }, [queryParams]);
+
+  // Palette deep-link: /AdminProspects?q=…&lead=<id> auto-opens that lead's
+  // drawer once the row set arrives, then consumes the param (found or not —
+  // a stale id must not re-trigger on every later fetch). Guard on isFetching,
+  // not isLoading: when the palette navigates while this page is already
+  // mounted, only isFetching flips — isLoading is first-load-only in RQ v5,
+  // and matching against the previous filter's rows would eat the param.
+  // On error, keep the param so a retry can still open the drawer.
+  const leadParam = searchParams.get('lead');
+  useEffect(() => {
+    if (!leadParam || prospects.isFetching || prospects.isError) return;
+    const hit = rows.find((r) => r.id === leadParam);
+    if (hit) setDrawer(hit);
+    patch({ lead: null });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [leadParam, prospects.isFetching, prospects.isError]);
 
   const toggleList = (key, value) => {
     const current = new Set(filters[key]);


### PR DESCRIPTION
## What

Two dead affordances in the admin v2 topbar, made real:

**1. Search pill → actual ⌘K palette.** It was a disguised button (`onClick → navigate('/AdminProspects')`) — you couldn't type in it. Now click or ⌘K opens a command palette:
- **Leads** — server-side `GET /prospects?search=` (top 5, debounced 250ms)
- **Campaigns** — filtered from the already-cached leaderboard query (`['adminV2','campaigns','30d']` — zero extra requests when the dashboard is warm)
- **Agents** — filtered from the cached assign-picker roster
- **Pages** — sidebar routes matched by label ("wall" → Wallets & Commitments)
- Arrow/Enter keyboard nav, esc closes, focus restored to the trigger on close, Tab trapped inside the dialog, and a final **"Search "q" in Prospects"** row so Enter never dead-ends
- Lead results deep-link `/AdminProspects?q=<phone>&lead=<id>` — Prospects consumes `lead` to auto-open that lead's drawer (found or not, but never while fetching or on error)

**2. Bell → live attention alerts.** Was `title="Notifications — coming soon"` with no handler. Now fed by the same `GET /dashboard/attention` aggregate as the dashboard's "Needs attention" queue, composed through the existing vitest-covered `composeAttentionRows` — bell and dashboard can never disagree. Badge counts actionable severities only (incident/held/warning; watch-tier rows like draws-closing list unbadged), tone follows the worst severity, every row deep-links pre-filtered (`?assignment=held`, etc.). 2-min poll since `refetchOnWindowFocus` is globally off. Loading/error/all-clear states, and the aria-label never claims "all clear" while loading or failed.

Also: `NAV` moved out of the shell into `src/lib/adminV2/nav.js` so the palette can match page routes without a circular import.

## Codex review round (gpt-5.6-sol xhigh) — folded

- **RR v7 stale-params rewind (real pre-existing bug, now fixed in both pages):** `setSearchParams`'s functional form closes over its render's params and *always navigates*, so a 350ms-stale debounce timer rewound the URL — clobbering filters clicked inside the window and resurrecting the consumed `lead` param. Both Prospects and Agents debounces now read a live `paramsRef` at fire time and skip navigation entirely when `q` is already in sync.
- `?lead=` guard is `isFetching`-based (RQ v5: `isLoading` is first-load-only — the in-page palette pick would have matched stale rows), and the param survives fetch errors so retry can still open the drawer.
- AdminV2Agents now resyncs its search input when `?q` changes while mounted (palette pick, back/forward) — the roster query already followed the URL; the box showed stale text.
- Palette shows "Search hit an error" instead of claiming "No direct matches" when a source fails.
- Bell popover dropped `role="menu"`/`menuitem` (it doesn't implement menu keyboard semantics — they're plain focusable buttons).

Declined: hiding entity results until the debounced query matches the input keystroke-for-keystroke — visible-equals-selectable during the debounce window is standard palette behavior (cmdk/kbar do the same), and hiding causes result flicker on every keystroke.

## Verification

- 12 tests for the new surfaces (palette open/close/⌘K/all four groups/keyboard/fallback/error-state; bell badge semantics/deep-link/all-clear/failed-feed) — full frontend suite **1480/1480**
- `npx eslint` — 0 errors on all touched files (2 pre-existing warnings)
- `npx vite build` clean
- No backend changes; no new endpoints — both features compose existing Phase B contracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)