### PR TITLE
security: per-subscriber webhook v2 signing (SEC-03 Step B, sender)

### DIFF
--- a/backend/src/services/webhookService.js
+++ b/backend/src/services/webhookService.js
@@ -2,6 +2,7 @@ import crypto from 'crypto';
 import { Op } from 'sequelize';
 import { WebhookSubscriber, WebhookDelivery, sequelize } from '../models/index.js';
 import { logger } from '../utils/logger.js';
+import { signWebhookAttempt, signatureVersionForSubscriber } from './webhookSigning.js';
 
 const AUTO_DISABLE_THRESHOLD = 50;
 
@@ -171,21 +172,30 @@ export function makeWebhookService(overrides = {}) {
   async function attemptDelivery(delivery, subscriber) {
     const rawBody = JSON.stringify(delivery.payload);
     const timestamp = new Date().toISOString();
-    const hmac = crypto.createHmac('sha256', subscriber.secret).update(rawBody).digest('hex');
+    const signatureVersion = signatureVersionForSubscriber(subscriber);
+    const signature = signWebhookAttempt({
+      secret: subscriber.secret,
+      rawBody,
+      timestamp,
+      signatureVersion,
+    });
 
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 10000);
 
     try {
+      const headers = {
+        'Content-Type': 'application/json',
+        'X-Webhook-Event': delivery.eventType,
+        'X-Webhook-Delivery-Id': delivery.deliveryId,
+        'X-Webhook-Signature': signature,
+        'X-Webhook-Timestamp': timestamp
+      };
+      if (signatureVersion === 'v2') headers['X-Webhook-Signature-Version'] = 'v2';
+
       const response = await d.fetch(subscriber.url, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Webhook-Event': delivery.eventType,
-          'X-Webhook-Delivery-Id': delivery.deliveryId,
-          'X-Webhook-Signature': `sha256=${hmac}`,
-          'X-Webhook-Timestamp': timestamp
-        },
+        headers,
         body: rawBody,
         signal: controller.signal
       });

--- a/backend/src/services/webhookSigning.js
+++ b/backend/src/services/webhookSigning.js
@@ -1,0 +1,13 @@
+import crypto from 'crypto';
+
+/** Only an explicit per-subscriber v2 opt-in changes the legacy wire format. */
+export function signatureVersionForSubscriber(subscriber) {
+  return subscriber?.metadata?.signatureVersion === 'v2' ? 'v2' : 'v1';
+}
+
+/** Build the HMAC header for one delivery attempt. */
+export function signWebhookAttempt({ secret, rawBody, timestamp, signatureVersion }) {
+  const signedContent = signatureVersion === 'v2' ? `${timestamp}.${rawBody}` : rawBody;
+  const digest = crypto.createHmac('sha256', secret).update(signedContent).digest('hex');
+  return `sha256=${digest}`;
+}

--- a/backend/test/unit/webhookSignatureVersions.test.js
+++ b/backend/test/unit/webhookSignatureVersions.test.js
@@ -1,0 +1,148 @@
+import { jest } from '@jest/globals';
+import '../setup.js';
+import { readFileSync } from 'node:fs';
+import { makeWebhookService } from '../../src/services/webhookService.js';
+import { signWebhookAttempt, signatureVersionForSubscriber } from '../../src/services/webhookSigning.js';
+
+const vector = JSON.parse(readFileSync(new URL('../webhookSigningVector.json', import.meta.url), 'utf8'));
+const payload = JSON.parse(vector.rawBody);
+
+function delivery(id, subscriber) {
+  return {
+    id,
+    deliveryId: payload.deliveryId,
+    subscriberId: subscriber.id,
+    eventType: payload.event,
+    payload,
+    attempts: 0,
+    maxAttempts: 3,
+    status: 'pending',
+    subscriber,
+    update: jest.fn().mockResolvedValue(true),
+  };
+}
+
+describe('per-subscriber webhook signature versions', () => {
+  const lyfe = {
+    id: 'lyfe',
+    name: 'Lyfe App',
+    url: 'https://lyfe.example/webhook',
+    secret: vector.secret,
+    metadata: { destination: 'lyfe' },
+  };
+  const mktrLeads = {
+    id: 'mktr-leads',
+    name: 'MKTR Leads App',
+    url: 'https://leads.example/webhook',
+    secret: vector.secret,
+    metadata: { destination: 'mktr_leads', signatureVersion: 'v2' },
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(vector.timestamp));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('matches the mirrored v1/v2 contract fixture', () => {
+    expect(signWebhookAttempt({
+      secret: vector.secret,
+      rawBody: vector.rawBody,
+      timestamp: vector.timestamp,
+      signatureVersion: 'v1',
+    })).toBe(vector.v1Signature);
+    expect(signWebhookAttempt({
+      secret: vector.secret,
+      rawBody: vector.rawBody,
+      timestamp: vector.timestamp,
+      signatureVersion: 'v2',
+    })).toBe(vector.v2Signature);
+  });
+
+  it('defaults absent and unknown metadata to byte-identical v1 behavior', () => {
+    expect(signatureVersionForSubscriber(lyfe)).toBe('v1');
+    expect(signatureVersionForSubscriber({ metadata: { signatureVersion: 'typo' } })).toBe('v1');
+    expect(signatureVersionForSubscriber(mktrLeads)).toBe('v2');
+  });
+
+  it('keeps Lyfe on v1 and mktr_leads on v2 for one event and later attempts', async () => {
+    const fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+    const service = makeWebhookService({
+      fetch,
+      WebhookSubscriber: { findAll: jest.fn() },
+      WebhookDelivery: {},
+      logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+    });
+    const lyfeDelivery = delivery('delivery-lyfe', lyfe);
+    const mktrDelivery = delivery('delivery-mktr', mktrLeads);
+
+    await service.attemptDelivery(lyfeDelivery, lyfe);
+    await service.attemptDelivery(mktrDelivery, mktrLeads);
+    // Exercise the same attempt path used by scheduled, recovered, and manual retries.
+    await service.attemptDelivery(lyfeDelivery, lyfe);
+    await service.attemptDelivery(mktrDelivery, mktrLeads);
+
+    expect(fetch).toHaveBeenCalledTimes(4);
+    for (const index of [0, 2]) {
+      const options = fetch.mock.calls[index][1];
+      expect(options.headers['X-Webhook-Signature']).toBe(vector.v1Signature);
+      expect(options.headers['X-Webhook-Signature-Version']).toBeUndefined();
+      expect(options.body).toBe(vector.rawBody);
+    }
+    for (const index of [1, 3]) {
+      const options = fetch.mock.calls[index][1];
+      expect(options.headers['X-Webhook-Signature']).toBe(vector.v2Signature);
+      expect(options.headers['X-Webhook-Signature-Version']).toBe('v2');
+      expect(options.body).toBe(vector.rawBody);
+    }
+  });
+
+  it.each([
+    ['Lyfe', lyfe, undefined],
+    ['mktr_leads', mktrLeads, 'v2'],
+  ])('preserves the %s subscriber version on an automatic retry', async (_name, subscriber, expectedVersion) => {
+    const fetch = jest.fn()
+      .mockResolvedValueOnce({ ok: false, status: 503, text: async () => 'retry' })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    const service = makeWebhookService({
+      fetch,
+      WebhookSubscriber: { findAll: jest.fn() },
+      WebhookDelivery: {},
+      logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+    });
+    const retrying = delivery(`automatic-${subscriber.id}`, subscriber);
+    retrying.maxAttempts = 2;
+    retrying.update.mockImplementation(async (updates) => Object.assign(retrying, updates));
+
+    await service.attemptDelivery(retrying, subscriber);
+    await jest.advanceTimersByTimeAsync(1_000);
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    for (const call of fetch.mock.calls) {
+      expect(call[1].headers['X-Webhook-Signature-Version']).toBe(expectedVersion);
+    }
+  });
+
+  it.each([
+    ['Lyfe', lyfe, undefined],
+    ['mktr_leads', mktrLeads, 'v2'],
+  ])('preserves the %s subscriber version on a manual retry', async (_name, subscriber, expectedVersion) => {
+    const fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+    const retried = delivery(`manual-${subscriber.id}`, subscriber);
+    const service = makeWebhookService({
+      fetch,
+      WebhookSubscriber: { findAll: jest.fn() },
+      WebhookDelivery: { findByPk: jest.fn().mockResolvedValue(retried) },
+      logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+    });
+
+    await service.retryDelivery(retried.id);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch.mock.calls[0][1].headers['X-Webhook-Signature-Version']).toBe(expectedVersion);
+  });
+});

--- a/backend/test/webhookSigningVector.json
+++ b/backend/test/webhookSigningVector.json
@@ -1,0 +1,7 @@
+{
+  "secret": "mktr-webhook-test-secret-v2",
+  "timestamp": "2026-07-10T08:30:00.000Z",
+  "rawBody": "{\"event\":\"lead.created\",\"deliveryId\":\"00000000-0000-4000-8000-000000000123\",\"data\":{\"lead\":{\"externalId\":\"lead-vector-1\"}}}",
+  "v1Signature": "sha256=33676a030236d50a294feb6fdef9e4ec260e4b5c24904a6b740f3713197acff4",
+  "v2Signature": "sha256=92b56af9010cf7308d1184c245ec63298ea64db7e79feb4d9b980b6b597574ec"
+}


### PR DESCRIPTION
Sender half of the per-subscriber v2 timestamp-bound signing (remediation plan §7.3 C1). Cherry-picked from the local `security/webhook-v2-sender` branch onto current main (the other two commits on that branch — receipt PDFs + campaign-grouped catalog — are already on main via #183-era work, so this isolates just the signing change).

- `webhookSigning.js`: `signatureVersionForSubscriber(subscriber)` reads `subscriber.metadata.signatureVersion` (absent ⇒ v1). `signWebhookAttempt` signs `timestamp.body` for v2, body-only for v1.
- `webhookService.js`: adds `X-Webhook-Signature-Version: v2` header only when the subscriber opts in.
- Shared signing vector (`backend/test/webhookSigningVector.json`) is byte-identical to the mktr-leads receiver's copy — the two implementations are pinned to the same test vector so they can't drift.

**Behavior-preserving on merge:** no subscriber has `metadata.signatureVersion` set, so every delivery stays v1. Going live is a later, separate step: after the receiver EF is deployed (done), flip ONLY the mktr-leads subscriber's `metadata.signatureVersion='v2'`; the Lyfe subscriber stays v1. Rollback = unset the metadata, no redeploy.

Tests: `webhookSignatureVersions.test.js` 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)