### PR TITLE
fix(agent-sync): exclude is_test_data agents from the mktr-leads feed

### DIFF
--- a/backend/src/integrations/adapters/mktr-leads/mktrLeadsClient.js
+++ b/backend/src/integrations/adapters/mktr-leads/mktrLeadsClient.js
@@ -116,6 +116,14 @@ const SELECT_COLUMNS = 'mktr_user_id,full_name,email,phone,role,is_active,agency
  * two-phase deletion would then hard-delete the local row after the grace
  * window, cascading away its lead-package assignments. Only rows truly absent
  * from this list (account deleted / promoted to admin) may be retired.
+ *
+ * `is_test_data=false` IS filtered at source (like Lyfe's users feed). A QA/staging
+ * agent flagged at provisioning never enters this feed, so it is never mirrored and
+ * can never receive a paid lead — and because it was never established locally, its
+ * absence is a non-import, not a retirement (contrast is_active above). Flipping an
+ * already-synced real agent to is_test_data=true would retire it; don't — the flag
+ * is for agents that are test from creation. Column added 2026-07-17
+ * (`20260717000000_agents_is_test_data.sql`); default false ⇒ today a no-op.
  */
 export async function fetchAgents() {
   const cacheKey = 'agents';
@@ -127,7 +135,7 @@ export async function fetchAgents() {
   let rows;
   try {
     rows = await breaker.fire(
-      `${url}/rest/v1/agents?role=in.(agent,manager)&select=${SELECT_COLUMNS}&order=full_name`,
+      `${url}/rest/v1/agents?role=in.(agent,manager)&is_test_data=eq.false&select=${SELECT_COLUMNS}&order=full_name`,
       authHeaders(key)
     );
   } catch (err) {
@@ -155,7 +163,7 @@ export async function fetchAgentById(externalId) {
   let rows;
   try {
     rows = await breaker.fire(
-      `${url}/rest/v1/agents?mktr_user_id=eq.${encodeURIComponent(externalId)}&select=${SELECT_COLUMNS}`,
+      `${url}/rest/v1/agents?mktr_user_id=eq.${encodeURIComponent(externalId)}&is_test_data=eq.false&select=${SELECT_COLUMNS}`,
       authHeaders(key)
     );
   } catch (err) {

--- a/backend/test/unit/mktrLeadsAdapter.test.js
+++ b/backend/test/unit/mktrLeadsAdapter.test.js
@@ -73,7 +73,7 @@ describe('mktrLeadsClient', () => {
     delete process.env.MKTR_LEADS_SUPABASE_SERVICE_ROLE_KEY;
   });
 
-  it('fetchAgents filters role to agent+manager at the source (NOT is_active — inactive rows are mirrored) and normalizes', async () => {
+  it('fetchAgents filters role to agent+manager AND is_test_data=false at the source (NOT is_active — inactive rows are mirrored) and normalizes', async () => {
     const agents = await client.fetchAgents();
 
     const url = fetchMock.mock.calls[0][0];
@@ -81,6 +81,9 @@ describe('mktrLeadsClient', () => {
     // Managers are lead buyers and must stay in the feed — leaving it trips the
     // two-phase retirement (F09). Admins remain excluded at the source.
     expect(url).toContain('role=in.(agent,manager)');
+    // QA/staging agents must never mirror in and become assignable lead recipients
+    // (parity with the Lyfe users feed). Filtered at source, not row-wise.
+    expect(url).toContain('is_test_data=eq.false');
     // Deactivated agents must stay in the fetched set: absence means DELETED
     // upstream (two-phase hard-delete). is_active is mirrored row-wise instead.
     expect(url).not.toContain('is_active=eq.true');
@@ -117,6 +120,9 @@ describe('mktrLeadsClient', () => {
     fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => [ROWS[0]], text: async () => '' });
     const agent = await client.fetchAgentById('mu_1');
     expect(fetchMock.mock.calls[0][0]).toContain('mktr_user_id=eq.mu_1');
+    // Single-agent lookup also excludes test rows, so a flagged mktr_user_id
+    // cannot be resolved into an assignable agent by id.
+    expect(fetchMock.mock.calls[0][0]).toContain('is_test_data=eq.false');
     expect(agent.externalId).toBe('mu_1');
   });
 


### PR DESCRIPTION
## Wave 0 hardening — closes the mktr-leads test-data gap

The Lyfe users feed filters `is_test_data=eq.false` at source (`lyfeClient.js`), but the mktr-leads adapter did not — a QA/staging agent in the mktr-leads project could mirror into `users` and become an assignable, paid-lead recipient.

**Correction to the plan's assumption:** the mktr-leads `agents` table had **no** `is_test_data` column (verified: `select=is_test_data` → 400). Blindly mirroring the Lyfe filter would have 400'd the entire agent sync. So this ships in two safe parts:

1. **mktr-leads migration `20260717000000_agents_is_test_data.sql`** (already applied to the live project via `db push`): additive `is_test_data boolean not null default false`. Zero behavior change — every existing agent reads false.
2. **This PR (mktr-platform):** filter `is_test_data=eq.false` at source in `fetchAgents` + `fetchAgentById`.

Because the column defaults false and nothing sets it true yet, the filter is a **no-op today** and becomes a guard the moment a QA agent is flagged (via service-role SQL; no UI yet). Unlike `is_active` (mirrored row-wise so deactivation ≠ deletion), test rows are excluded at source: a from-creation test agent never establishes a local row, so its absence is a non-import, not a two-phase retirement.

Tests: `mktrLeadsAdapter.test.js` 9/9 (asserts the filter on both query paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)