### PR TITLE
feat(webhook): alert on the two silent lead-loss failure modes (OBS-01)

### DIFF
--- a/backend/src/services/webhookService.js
+++ b/backend/src/services/webhookService.js
@@ -3,6 +3,7 @@ import { Op } from 'sequelize';
 import { WebhookSubscriber, WebhookDelivery, sequelize } from '../models/index.js';
 import { logger } from '../utils/logger.js';
 import { signWebhookAttempt, signatureVersionForSubscriber } from './webhookSigning.js';
+import { Sentry } from '../utils/sentryInit.js';
 
 const AUTO_DISABLE_THRESHOLD = 50;
 
@@ -12,6 +13,10 @@ const defaultDeps = {
   WebhookDelivery,
   logger,
   fetch: globalThis.fetch,
+  // OBS-01: alert on the two silent failure modes that stop lead delivery
+  // without a trace (subscriber auto-disable, dropped deliveries). Injected so
+  // tests can assert the alert; a no-op when SENTRY_DSN is unset.
+  Sentry,
 };
 
 // --- Factory ---
@@ -34,6 +39,18 @@ export function makeWebhookService(overrides = {}) {
         subscriberName: subscriber.name,
         queueDepth: deliveryQueue.length,
         totalDropped: droppedDeliveries,
+      });
+      // OBS-01: a dropped delivery is a lead that never reaches its destination.
+      // Surface it (Sentry groups repeats; totalDropped shows the magnitude).
+      d.Sentry?.captureMessage('[Webhook] delivery dropped — queue full (potential lead loss)', {
+        level: 'warning',
+        tags: { area: 'webhook', event: 'delivery_dropped' },
+        extra: {
+          deliveryId: delivery.deliveryId,
+          subscriberName: subscriber.name,
+          queueDepth: deliveryQueue.length,
+          totalDropped: droppedDeliveries,
+        },
       });
       return Promise.resolve();
     }
@@ -347,6 +364,19 @@ export function makeWebhookService(overrides = {}) {
         subscriberId: subscriber.id,
         subscriberName: subscriber.name,
         consecutiveFailures: AUTO_DISABLE_THRESHOLD
+      });
+      // OBS-01: this is the unmonitored kill switch — lead delivery to this
+      // destination has now STOPPED until an operator re-enables it. Error-level
+      // so a receiver misconfig during a rollout can't become silent lead loss.
+      d.Sentry?.captureMessage('[Webhook] subscriber auto-disabled — lead delivery STOPPED', {
+        level: 'error',
+        tags: { area: 'webhook', event: 'subscriber_auto_disabled' },
+        extra: {
+          subscriberId: subscriber.id,
+          subscriberName: subscriber.name,
+          destination: subscriber.metadata?.destination ?? null,
+          consecutiveFailures: AUTO_DISABLE_THRESHOLD,
+        },
       });
     } catch (err) {
       d.logger.error('[Webhook] checkAutoDisable error', {

--- a/backend/test/unit/webhookService.test.js
+++ b/backend/test/unit/webhookService.test.js
@@ -52,7 +52,9 @@ function buildMocks() {
 
   const mockFetch = jest.fn();
 
-  return { mockSubscriber, mockDelivery, WebhookSubscriber, WebhookDelivery, logger, mockFetch };
+  const Sentry = { captureMessage: jest.fn(), captureException: jest.fn() };
+
+  return { mockSubscriber, mockDelivery, WebhookSubscriber, WebhookDelivery, logger, mockFetch, Sentry };
 }
 
 // ── Tests ──
@@ -69,6 +71,7 @@ describe('webhookService (unit)', () => {
       WebhookDelivery: mocks.WebhookDelivery,
       logger: mocks.logger,
       fetch: mocks.mockFetch,
+      Sentry: mocks.Sentry,
     });
   });
 
@@ -364,6 +367,14 @@ describe('webhookService (unit)', () => {
         expect.stringContaining('auto-disabled'),
         expect.objectContaining({ subscriberId: 'sub-1' })
       );
+      // OBS-01: the kill switch must also raise an error-level Sentry alert.
+      expect(mocks.Sentry.captureMessage).toHaveBeenCalledWith(
+        expect.stringContaining('auto-disabled'),
+        expect.objectContaining({
+          level: 'error',
+          tags: expect.objectContaining({ event: 'subscriber_auto_disabled' }),
+        })
+      );
     });
 
     it('does NOT disable when a recent success breaks the failure streak', async () => {
@@ -396,6 +407,29 @@ describe('webhookService (unit)', () => {
 
       // update(enabled: false) should NOT have been called
       expect(subscriberWithUpdate.update).not.toHaveBeenCalledWith({ enabled: false });
+    });
+  });
+
+  describe('OBS-01 dropped-delivery alert', () => {
+    it('alerts (warning) when a delivery is dropped because the queue is full', () => {
+      // fetch never resolves → the 3 concurrent slots stay busy and the queue fills.
+      mocks.mockFetch.mockReturnValue(new Promise(() => {}));
+
+      // 3 active + 100 queued (MAX_QUEUE_DEPTH) + 1 that must be dropped.
+      const pairs = Array.from({ length: 104 }, (_, i) => ({
+        delivery: { ...mocks.mockDelivery, deliveryId: `d-${i}`, update: jest.fn().mockResolvedValue(true) },
+        subscriber: mocks.mockSubscriber,
+      }));
+
+      service.flushDeliveries(pairs);
+
+      expect(mocks.Sentry.captureMessage).toHaveBeenCalledWith(
+        expect.stringContaining('dropped'),
+        expect.objectContaining({
+          level: 'warning',
+          tags: expect.objectContaining({ event: 'delivery_dropped' }),
+        })
+      );
     });
   });
 


### PR DESCRIPTION
Wave 1 (OBS-01, remediation plan §15). The webhook sender's two silent failure modes — a subscriber **auto-disabling** after 50 consecutive failures (the "unmonitored kill switch") and deliveries **dropped** on queue overflow — only wrote a `logger.warn`. During a receiver rollout (e.g. the v2 signature flip) a misconfig could halt lead delivery to a destination with no alert.

- **Auto-disable → Sentry error** ("lead delivery STOPPED"), with subscriber id/name/destination.
- **Dropped delivery → Sentry warning** ("potential lead loss"), with delivery id + `totalDropped` magnitude.
- Sentry is injected via the service deps (no-op when `SENTRY_DSN` is unset), so both alerts are unit-tested.

This is the observability guard for the money path just hardened in DATA-03/DATA-01 — a receiver misconfig now pages instead of silently dropping leads.

Tests: `webhookService` 21/21. (Outcome dead-letter alerting — `outcome_report_attempts=48` — is mktr-leads-side and a separate follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)