### PR TITLE
feat(redeem-ops): consumer WhatsApp delivery channel, dark (trial-reward PR E)

### DIFF
--- a/backend/src/config/envValidation.js
+++ b/backend/src/config/envValidation.js
@@ -54,4 +54,16 @@ export function validateEnv() {
   if (Boolean(waId) !== Boolean(waToken)) {
     console.warn('⚠️ WhatsApp OTP partially configured — both META_WA_PHONE_NUMBER_ID and META_WA_ACCESS_TOKEN are required. WhatsApp sends will fail and fall back to SMS until both are set.');
   }
+
+  // Redeem-Ops consumer WhatsApp delivery (trial-reward PR E) ships dark —
+  // REDEEM_OPS_WHATSAPP_ENABLED defaults false. Warn only when the flag is ON
+  // but the dedicated Redeem WABA creds are missing: every reward send would
+  // fail (truthfully receipted as notify_failed, but still silence for the
+  // customer). Template names have code defaults (reward_pass/reward_voucher).
+  if (String(process.env.REDEEM_OPS_WHATSAPP_ENABLED || '').toLowerCase() === 'true') {
+    const missingRewardWa = ['WHATSAPP_TOKEN', 'WHATSAPP_PHONE_NUMBER_ID'].filter((k) => !process.env[k]);
+    if (missingRewardWa.length > 0) {
+      console.warn(`⚠️ REDEEM_OPS_WHATSAPP_ENABLED=true but ${missingRewardWa.join(', ')} not set — reward WhatsApp sends will all fail (notify_failed receipts).`);
+    }
+  }
 }

--- a/backend/src/controllers/redeemOps/fulfilmentController.js
+++ b/backend/src/controllers/redeemOps/fulfilmentController.js
@@ -52,7 +52,7 @@ export const unlockEntitlement = asyncHandler(async (req, res) => {
 
 export const resendPass = asyncHandler(async (req, res) => {
   const body = validateBody(
-    Joi.object({ channel: Joi.string().valid('email', 'link').default('email') }),
+    Joi.object({ channel: Joi.string().valid('email', 'whatsapp', 'link').default('email') }),
     req.body || {}
   );
   const result = await entitlementService.resendDelivery(
@@ -63,7 +63,9 @@ export const resendPass = asyncHandler(async (req, res) => {
   const oldCredential = result.kind === 'pass' ? 'pass QR/link' : 'voucher code/QR';
   const message = result.channel === 'email'
     ? `New ${noun} emailed — the previous ${oldCredential} no longer works.`
-    : `New ${noun} link created — the previous ${oldCredential} no longer works. Share it with the customer yourself.`;
+    : result.channel === 'whatsapp'
+      ? `New ${noun} sent to the customer's WhatsApp — the previous ${oldCredential} no longer works.`
+      : `New ${noun} link created — the previous ${oldCredential} no longer works. Share it with the customer yourself.`;
   // The link channel returns a LIVE bearer credential in the body — it must
   // never be cached by any intermediary or the browser.
   res.set('Cache-Control', 'no-store');

--- a/backend/src/services/redeemOps/entitlementService.js
+++ b/backend/src/services/redeemOps/entitlementService.js
@@ -9,6 +9,7 @@ import { makeInventoryService } from './inventoryService.js';
 import { makeRedeemOpsAuditService } from './auditService.js';
 import { mintToken, hashToken, tokenHintOf } from './tokens.js';
 import { canEmailProspect, makeFulfilmentNotify } from './fulfilmentNotify.js';
+import { canWhatsAppProspect, waEnabled, waRecipient } from './whatsappService.js';
 
 const DEFAULT_RESERVATION_DAYS = 30;
 const DEFAULT_REDEMPTION_DAYS = 90;
@@ -63,6 +64,8 @@ export function makeEntitlementService(overrides = {}) {
     audit: makeRedeemOpsAuditService(),
     notifyUnlock: null, // injected by entitlementWiring (voucher email) — null-safe
     notifyReservation: null, // injected by entitlementWiring (reservation-pass email) — null-safe
+    notifyUnlockWa: null, // injected by entitlementWiring (voucher WhatsApp, PR E) — null-safe
+    notifyReservationWa: null, // injected by entitlementWiring (reservation-pass WhatsApp, PR E) — null-safe
     builders: null, // share/claim-URL builders; defaults lazily to makeFulfilmentNotify()
     ...overrides,
   };
@@ -118,30 +121,42 @@ export function makeEntitlementService(overrides = {}) {
   }
 
   /**
-   * Post-commit, fire-and-forget email delivery + truthful receipt. Returns
-   * whether a FRESH attempt was scheduled (the `emailQueued` the routes
-   * surface). Receipts: `notified` on accepted hand-off, `notify_failed` on
-   * mailer failure — never on a no-email skip (nothing was attempted).
+   * Post-commit, fire-and-forget delivery + truthful per-channel receipts.
+   * Email and WhatsApp (PR E) are INDEPENDENT legs — one failing/skipping can
+   * never block or fail the other, and each writes its own receipt tagged with
+   * its channel. The boolean return keeps PR A's contract: "a fresh EMAIL
+   * attempt was scheduled" (the `emailQueued` the routes surface) — WhatsApp
+   * never affects it. The WhatsApp sender self-guards flag/consent/phone via
+   * `skipped` results (no receipt on a skip: nothing was attempted), so a
+   * no-email Retell lead still gets its WhatsApp leg — the email guard below
+   * deliberately gates only the email leg.
    */
   function queueDelivery({ entitlement, prospect, kind, presentationToken = null, voucherToken = null }) {
-    const fn = kind === 'voucher' ? d.notifyUnlock : d.notifyReservation;
-    if (typeof fn !== 'function' || !canEmailProspect(prospect)) return false;
     const args = kind === 'voucher'
       ? { entitlement, prospect, voucherToken }
       : { entitlement, prospect, presentationToken };
-    const delivery = Promise.resolve()
-      .then(() => fn(args))
-      .then((r) => {
-        if (r?.skipped) return null;
-        return writeDeliveryReceipt(entitlement.id, kind, r || { sent: false, error: 'no sender result' });
-      })
-      .catch((err) => writeDeliveryReceipt(entitlement.id, kind, { sent: false, error: err?.message }));
-    pendingDeliveries.add(delivery);
-    delivery.finally(() => pendingDeliveries.delete(delivery));
+    const fire = (fn, channel) => {
+      const delivery = Promise.resolve()
+        .then(() => fn(args))
+        .then((r) => {
+          if (r?.skipped) return null;
+          return writeDeliveryReceipt(entitlement.id, kind, r || { sent: false, error: 'no sender result' }, channel);
+        })
+        .catch((err) => writeDeliveryReceipt(entitlement.id, kind, { sent: false, error: err?.message }, channel));
+      pendingDeliveries.add(delivery);
+      delivery.finally(() => pendingDeliveries.delete(delivery));
+    };
+
+    const waFn = kind === 'voucher' ? d.notifyUnlockWa : d.notifyReservationWa;
+    if (typeof waFn === 'function') fire(waFn, 'whatsapp');
+
+    const fn = kind === 'voucher' ? d.notifyUnlock : d.notifyReservation;
+    if (typeof fn !== 'function' || !canEmailProspect(prospect)) return false;
+    fire(fn, 'email');
     return true;
   }
 
-  async function writeDeliveryReceipt(entitlementId, kind, r) {
+  async function writeDeliveryReceipt(entitlementId, kind, r, channel = 'email') {
     try {
       await d.RedemptionEvent.create({
         entitlementId,
@@ -149,13 +164,13 @@ export function makeEntitlementService(overrides = {}) {
         actorType: 'system',
         metadata: {
           kind,
-          channel: 'email',
+          channel,
           to: r.to || null, // already masked by the sender
           ...(r.error ? { error: String(r.error).slice(0, 200) } : {}),
         },
       });
     } catch (err) {
-      d.logger.error('redeem_ops.delivery.receipt_failed', { entitlementId, error: err?.message });
+      d.logger.error('redeem_ops.delivery.receipt_failed', { entitlementId, channel, error: err?.message });
     }
   }
 
@@ -463,9 +478,14 @@ export function makeEntitlementService(overrides = {}) {
    * Re-mints the CURRENT credential (pass while eligible, voucher once issued)
    * as an ATOMIC conditional transition — racing unlock/redeem/expiry loses
    * cleanly with a typed 409 instead of rotating hashes for the wrong state.
-   * channel 'email' re-sends via the notify seam; channel 'link' returns the
-   * branded /r/ url + WhatsApp-paste bundle ONCE (the no-email path).
-   * The OLD credential of that kind stops working — deliberate.
+   * channel 'email' re-sends via the notify seam; channel 'whatsapp' (PR E)
+   * validates WhatsApp deliverability then re-sends via the same seam; channel
+   * 'link' returns the branded /r/ url + WhatsApp-paste bundle ONCE (the
+   * no-email path). Because the token ROTATES, email+whatsapp resends fan out
+   * to every wired channel (the un-picked channel's old link would otherwise
+   * die silently) — the picked channel is what was VALIDATED and is recorded
+   * in the manual_override metadata. The OLD credential of that kind stops
+   * working — deliberate.
    */
   async function resendDelivery(id, user, { channel = 'email' } = {}, requestId = null) {
     const entitlement = await d.RewardEntitlement.findByPk(id);
@@ -481,6 +501,9 @@ export function makeEntitlementService(overrides = {}) {
     const prospect = entitlement.prospectId ? await d.Prospect.findByPk(entitlement.prospectId) : null;
     if (channel === 'email' && !canEmailProspect(prospect)) {
       throw new AppError('No usable email on file — use the copy-link option instead', 409);
+    }
+    if (channel === 'whatsapp' && !(waEnabled() && canWhatsAppProspect(prospect))) {
+      throw new AppError('WhatsApp delivery is not available for this customer — use email or the copy-link option', 409);
     }
 
     // Per-entitlement cooldown: any delivery/rotation for this kind in the
@@ -784,9 +807,16 @@ export function makeEntitlementService(overrides = {}) {
     const masked = rows.map((r) => {
       const j = r.toJSON();
       j.emailDeliverable = canEmailProspect(j.prospect);
+      // Capability only (the list projection carries no sourceMetadata, so the
+      // D2 consent arm can't be evaluated here) — send-time canWhatsAppProspect
+      // stays authoritative. Flag off ⇒ false everywhere, so the console never
+      // offers a channel that can't fire.
+      j.whatsappDeliverable = waEnabled() && Boolean(waRecipient(j.prospect?.phone));
       const em = latestReceipt.get(`${j.id}:email`);
+      const wa = latestReceipt.get(`${j.id}:whatsapp`);
       j.delivery = {
         email: em ? { kind: em.metadata?.kind || null, at: em.createdAt, ok: em.type === 'notified' } : null,
+        whatsapp: wa ? { kind: wa.metadata?.kind || null, at: wa.createdAt, ok: wa.type === 'notified' } : null,
       };
       if (j.prospect) {
         if (j.prospect.phone) j.prospect.phone = `••••${String(j.prospect.phone).slice(-4)}`;
@@ -801,6 +831,7 @@ export function makeEntitlementService(overrides = {}) {
     issueForProspect, unlockEntitlement, issueManual, cancelEntitlement, resendDelivery,
     expireReservations, reconcileMissedLeads, reconcileMissedDeliveries, purgeIssuanceSkips,
     listEntitlements, verificationStampOf,
+    queueDelivery, // exported for tests: the per-channel fan-out contract (PR E)
   };
 }
 

--- a/backend/src/services/redeemOps/entitlementWiring.js
+++ b/backend/src/services/redeemOps/entitlementWiring.js
@@ -1,21 +1,30 @@
 import { makeEntitlementService } from './entitlementService.js';
 import { makeFulfilmentNotify } from './fulfilmentNotify.js';
+import { makeWhatsappService } from './whatsappService.js';
 
 /**
  * The ONE place a fully-delivering entitlement service is assembled
- * (voucher email on unlock + reservation email on issue). Every unlock
+ * (voucher + reservation, email and — PR E — WhatsApp). Every unlock
  * surface and both bootstrap instances use this factory — a bare
  * `makeEntitlementService()` has null notify deps and sends NOTHING, which
  * is exactly how the voucher email silently never fired before PR A
  * (docs/plans/trial-reward-funnel-hardening-prompt.md, defect 1).
  *
+ * The WhatsApp legs are always wired but self-guard on
+ * REDEEM_OPS_WHATSAPP_ENABLED (default false) at call time — flag off, the
+ * sender resolves `skipped` and nothing is sent or receipted, byte-identical
+ * to PR A behavior.
+ *
  * `overrides` spread last so tests keep full DI control.
  */
 export function makeWiredEntitlementService(overrides = {}) {
   const notify = makeFulfilmentNotify();
+  const wa = makeWhatsappService();
   return makeEntitlementService({
     notifyReservation: (args) => notify.sendReservationEmail(args),
     notifyUnlock: (args) => notify.sendVoucherEmail(args),
+    notifyReservationWa: (args) => wa.sendReservationWhatsApp(args),
+    notifyUnlockWa: (args) => wa.sendVoucherWhatsApp(args),
     ...overrides,
   });
 }

--- a/backend/src/services/redeemOps/whatsappService.js
+++ b/backend/src/services/redeemOps/whatsappService.js
@@ -1,3 +1,4 @@
+import QRCode from 'qrcode';
 import { RewardOffer } from '../../models/index.js';
 import { logger } from '../../utils/logger.js';
 
@@ -7,18 +8,26 @@ import { logger } from '../../utils/logger.js';
  * pass at issue and the voucher at unlock as Meta Cloud API UTILITY templates.
  *
  * Ships DARK: REDEEM_OPS_WHATSAPP_ENABLED (default false) gates every send at
- * call time, so wiring these senders in is a no-op until the flag flips. The
- * templates hardcode the redeem.sg /r/ host and carry ONLY the token as the
- * link variable — the /r/ page renders the live QR (pass while locked, voucher
- * once unlocked), so no media header and nothing in the message goes stale
- * semantically after unlock. Fire-and-forget one-shot like the email senders:
- * resolve a normalized { sent, skipped?, to?, error? }, NEVER throw — the
- * entitlement service writes the truthful per-channel receipt.
+ * call time, so wiring these senders in is a no-op until the flag flips.
  *
- * Templates (submitted for Meta approval as UTILITY, lang 'en'):
+ * Message shape (SG anti-scam posture — people distrust bare links, so the
+ * credential leads with a QR IMAGE HEADER, mirroring the voucher email's
+ * inline QR): header = per-customer QR uploaded to the Graph media API at
+ * send time; body = utility text carrying the redeem.sg/r/ link as the
+ * tap-fallback. The pass QR encodes the claim LINK (a human scanning it lands
+ * on the branded pass page; the consultant scanner strips the prefix); the
+ * voucher QR encodes the RAW token (merchant-scan parity with the email).
+ * WHATSAPP_QR_HEADER=false drops the header component for body-only templates
+ * — the template shape on Meta and this flag must agree or sends fail.
+ *
+ * Fire-and-forget one-shot like the email senders: resolve a normalized
+ * { sent, skipped?, to?, error? }, NEVER throw — the entitlement service
+ * writes the truthful per-channel receipt.
+ *
+ * Templates (submitted for Meta approval as UTILITY, lang 'en', IMAGE header):
  *   reward_pass:    "Hi {{1}}, your {{2}} is reserved. Show this pass to your
  *                    consultant when you meet and they'll activate it on the
- *                    spot: redeem.sg/r/{{3}}"
+ *                    spot: redeem.sg/r/{{3}} Keep this link handy."
  *   reward_voucher: "Hi {{1}}, your {{2}} is activated. Show the QR on this
  *                    page to redeem: redeem.sg/r/{{3}} It's valid until {{4}}."
  */
@@ -38,6 +47,16 @@ const WA_REQUIRES_CONTACT_CONSENT = true;
 
 export function waEnabled() {
   return String(process.env.REDEEM_OPS_WHATSAPP_ENABLED || '').toLowerCase() === 'true';
+}
+
+/** QR image header on/off — must match the approved templates' shape. */
+function qrHeaderEnabled() {
+  return String(process.env.WHATSAPP_QR_HEADER ?? 'true').toLowerCase() !== 'false';
+}
+
+/** Host baked into the templates' body link — the WA channel standardizes on redeem.sg. */
+function claimOrigin() {
+  return process.env.WHATSAPP_CLAIM_ORIGIN || 'https://redeem.sg';
 }
 
 /**
@@ -81,7 +100,7 @@ function cleanParam(value, fallback) {
 }
 
 export function makeWhatsappService(overrides = {}) {
-  const d = { RewardOffer, logger, fetch: (...args) => fetch(...args), ...overrides };
+  const d = { RewardOffer, logger, QRCode, fetch: (...args) => fetch(...args), ...overrides };
 
   async function rewardNameOf(entitlement) {
     try {
@@ -94,8 +113,37 @@ export function makeWhatsappService(overrides = {}) {
     }
   }
 
+  /**
+   * Upload one PNG to the Graph media API → media id for the header
+   * component. Throws on failure — sendTemplate catches and receipts it
+   * (an image-header template cannot be sent without its header, so there
+   * is deliberately no body-only fallback).
+   */
+  async function uploadQrPng(phoneId, token, buffer) {
+    const form = new FormData();
+    form.append('messaging_product', 'whatsapp');
+    form.append('type', 'image/png');
+    form.append('file', new Blob([buffer], { type: 'image/png' }), 'reward-qr.png');
+    const res = await d.fetch(`https://graph.facebook.com/${META_GRAPH_VERSION}/${phoneId}/media`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: form,
+    });
+    if (!res.ok) {
+      let detail = `HTTP ${res.status}`;
+      try {
+        const err = await res.json();
+        detail = err?.error ? `${err.error.code || res.status}: ${err.error.message || ''}` : detail;
+      } catch { /* non-JSON error body — keep the status */ }
+      throw new Error(`media upload failed — ${detail}`);
+    }
+    const json = await res.json();
+    if (!json?.id) throw new Error('media upload returned no id');
+    return json.id;
+  }
+
   /** One template send. Resolves normalized result, never throws. */
-  async function sendTemplate({ prospect, templateName, params }) {
+  async function sendTemplate({ prospect, templateName, params, qrContent }) {
     if (!waEnabled()) return { sent: false, skipped: 'disabled' };
     if (!canWhatsAppProspect(prospect)) return { sent: false, skipped: 'no_whatsapp' };
 
@@ -106,21 +154,30 @@ export function makeWhatsappService(overrides = {}) {
       return { sent: false, to: maskPhone(prospect.phone), error: 'whatsapp not configured' };
     }
 
-    const to = waRecipient(prospect.phone);
-    const body = {
-      messaging_product: 'whatsapp',
-      to,
-      type: 'template',
-      template: {
-        name: templateName,
-        language: { code: process.env.WHATSAPP_TEMPLATE_LANG || 'en' },
-        components: [
-          { type: 'body', parameters: params.map((text) => ({ type: 'text', text })) },
-        ],
-      },
-    };
-
     try {
+      const components = [
+        { type: 'body', parameters: params.map((text) => ({ type: 'text', text })) },
+      ];
+      if (qrHeaderEnabled() && qrContent) {
+        const png = await d.QRCode.toBuffer(qrContent, { width: 512, margin: 2 });
+        const mediaId = await uploadQrPng(phoneId, token, png);
+        components.unshift({
+          type: 'header',
+          parameters: [{ type: 'image', image: { id: mediaId } }],
+        });
+      }
+
+      const body = {
+        messaging_product: 'whatsapp',
+        to: waRecipient(prospect.phone),
+        type: 'template',
+        template: {
+          name: templateName,
+          language: { code: process.env.WHATSAPP_TEMPLATE_LANG || 'en' },
+          components,
+        },
+      };
+
       const res = await d.fetch(`https://graph.facebook.com/${META_GRAPH_VERSION}/${phoneId}/messages`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
@@ -140,12 +197,13 @@ export function makeWhatsappService(overrides = {}) {
     }
   }
 
-  /** Reservation pass at capture (agent_unlock policy). */
+  /** Reservation pass at capture (agent_unlock policy). QR = the claim link. */
   async function sendReservationWhatsApp({ entitlement, prospect, presentationToken }) {
     const rewardName = await rewardNameOf(entitlement);
     return sendTemplate({
       prospect,
       templateName: process.env.WHATSAPP_TEMPLATE_PASS || 'reward_pass',
+      qrContent: `${claimOrigin()}/r/${presentationToken}`,
       params: [
         cleanParam(prospect?.firstName, 'there'),
         cleanParam(rewardName, 'your reward'),
@@ -154,7 +212,7 @@ export function makeWhatsappService(overrides = {}) {
     });
   }
 
-  /** Voucher at unlock. */
+  /** Voucher at unlock. QR = the raw voucher token (merchant-scan parity with the email). */
   async function sendVoucherWhatsApp({ entitlement, prospect, voucherToken }) {
     const rewardName = await rewardNameOf(entitlement);
     const expiry = entitlement.expiresAt
@@ -163,6 +221,7 @@ export function makeWhatsappService(overrides = {}) {
     return sendTemplate({
       prospect,
       templateName: process.env.WHATSAPP_TEMPLATE_VOUCHER || 'reward_voucher',
+      qrContent: voucherToken,
       params: [
         cleanParam(prospect?.firstName, 'there'),
         cleanParam(rewardName, 'your reward'),

--- a/backend/src/services/redeemOps/whatsappService.js
+++ b/backend/src/services/redeemOps/whatsappService.js
@@ -1,0 +1,179 @@
+import { RewardOffer } from '../../models/index.js';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Consumer WhatsApp delivery for reward credentials (trial-reward PR E,
+ * docs/plans/trial-reward-funnel-hardening-prompt.md). Sends the reservation
+ * pass at issue and the voucher at unlock as Meta Cloud API UTILITY templates.
+ *
+ * Ships DARK: REDEEM_OPS_WHATSAPP_ENABLED (default false) gates every send at
+ * call time, so wiring these senders in is a no-op until the flag flips. The
+ * templates hardcode the redeem.sg /r/ host and carry ONLY the token as the
+ * link variable — the /r/ page renders the live QR (pass while locked, voucher
+ * once unlocked), so no media header and nothing in the message goes stale
+ * semantically after unlock. Fire-and-forget one-shot like the email senders:
+ * resolve a normalized { sent, skipped?, to?, error? }, NEVER throw — the
+ * entitlement service writes the truthful per-channel receipt.
+ *
+ * Templates (submitted for Meta approval as UTILITY, lang 'en'):
+ *   reward_pass:    "Hi {{1}}, your {{2}} is reserved. Show this pass to your
+ *                    consultant when you meet and they'll activate it on the
+ *                    spot: redeem.sg/r/{{3}}"
+ *   reward_voucher: "Hi {{1}}, your {{2}} is activated. Show the QR on this
+ *                    page to redeem: redeem.sg/r/{{3}} It's valid until {{4}}."
+ */
+
+// Version aligned with verificationService.js / metaCapiService.js.
+const META_GRAPH_VERSION = process.env.META_GRAPH_API_VERSION || 'v21.0';
+
+/**
+ * DECISION D2 (pending, Shawn): gate automated consumer WhatsApp on the
+ * optional signup `consent_contact` tick, or document a transactional-delivery
+ * basis (delivering the reward the lead just requested) that covers
+ * non-consented rows. Until decided we default to the SAFE side — no consent
+ * flag, no automated WhatsApp (staff still have the audited copy-link bridge).
+ * Choosing "transactional" = flip this constant to false.
+ */
+const WA_REQUIRES_CONTACT_CONSENT = true;
+
+export function waEnabled() {
+  return String(process.env.REDEEM_OPS_WHATSAPP_ENABLED || '').toLowerCase() === 'true';
+}
+
+/**
+ * Digits-only Graph API recipient. Prospect phones are stored `+65XXXXXXXX`
+ * (prospectHelpers.normalizePhone); bare 8-digit SG mobiles get the country
+ * code. Anything under 10 digits can't be an international number → null.
+ */
+export function waRecipient(phone) {
+  const digits = String(phone || '').replace(/\D/g, '');
+  if (/^[89]\d{7}$/.test(digits)) return `65${digits}`;
+  return digits.length >= 10 ? digits : null;
+}
+
+/**
+ * Capability + policy gate for automated consumer WhatsApp. Phone gives the
+ * capability; the consent arm is the D2 safe default above. Mirrors
+ * canEmailProspect's role for the email channel — each channel decides its own
+ * deliverability and neither suppresses the other.
+ */
+export function canWhatsAppProspect(prospect) {
+  if (!prospect || !waRecipient(prospect.phone)) return false;
+  if (WA_REQUIRES_CONTACT_CONSENT && prospect.sourceMetadata?.consent_contact !== true) return false;
+  return true;
+}
+
+/** `+6591234567` → `••••4567` — same masking idiom as the ops list payload. */
+function maskPhone(phone) {
+  const digits = String(phone || '').replace(/\D/g, '');
+  return digits ? `••••${digits.slice(-4)}` : null;
+}
+
+/**
+ * Meta rejects body params containing newlines/tabs/4+ spaces; URL-ish person
+ * names must never ride a template (same rule as the mktr-leads wa-intro).
+ */
+function cleanParam(value, fallback) {
+  const s = String(value ?? '').replace(/\s+/g, ' ').trim().slice(0, 60);
+  if (!s) return fallback;
+  if (/https?:|www\.|wa\.me/i.test(s)) return fallback;
+  return s;
+}
+
+export function makeWhatsappService(overrides = {}) {
+  const d = { RewardOffer, logger, fetch: (...args) => fetch(...args), ...overrides };
+
+  async function rewardNameOf(entitlement) {
+    try {
+      const offer = await d.RewardOffer.findByPk(entitlement.rewardOfferId, {
+        attributes: ['id', 'title', 'publicTitle'],
+      });
+      return offer?.publicTitle || offer?.title || 'your reward';
+    } catch {
+      return 'your reward';
+    }
+  }
+
+  /** One template send. Resolves normalized result, never throws. */
+  async function sendTemplate({ prospect, templateName, params }) {
+    if (!waEnabled()) return { sent: false, skipped: 'disabled' };
+    if (!canWhatsAppProspect(prospect)) return { sent: false, skipped: 'no_whatsapp' };
+
+    const token = process.env.WHATSAPP_TOKEN;
+    const phoneId = process.env.WHATSAPP_PHONE_NUMBER_ID;
+    if (!token || !phoneId) {
+      d.logger.error('redeem_ops.whatsapp.not_configured', { template: templateName });
+      return { sent: false, to: maskPhone(prospect.phone), error: 'whatsapp not configured' };
+    }
+
+    const to = waRecipient(prospect.phone);
+    const body = {
+      messaging_product: 'whatsapp',
+      to,
+      type: 'template',
+      template: {
+        name: templateName,
+        language: { code: process.env.WHATSAPP_TEMPLATE_LANG || 'en' },
+        components: [
+          { type: 'body', parameters: params.map((text) => ({ type: 'text', text })) },
+        ],
+      },
+    };
+
+    try {
+      const res = await d.fetch(`https://graph.facebook.com/${META_GRAPH_VERSION}/${phoneId}/messages`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        let detail = `HTTP ${res.status}`;
+        try {
+          const err = await res.json();
+          detail = err?.error ? `${err.error.code || res.status}: ${err.error.message || ''}` : detail;
+        } catch { /* non-JSON error body — keep the status */ }
+        return { sent: false, to: maskPhone(prospect.phone), error: `Meta API: ${detail}` };
+      }
+      return { sent: true, to: maskPhone(prospect.phone) };
+    } catch (err) {
+      return { sent: false, to: maskPhone(prospect.phone), error: err?.message || 'send failed' };
+    }
+  }
+
+  /** Reservation pass at capture (agent_unlock policy). */
+  async function sendReservationWhatsApp({ entitlement, prospect, presentationToken }) {
+    const rewardName = await rewardNameOf(entitlement);
+    return sendTemplate({
+      prospect,
+      templateName: process.env.WHATSAPP_TEMPLATE_PASS || 'reward_pass',
+      params: [
+        cleanParam(prospect?.firstName, 'there'),
+        cleanParam(rewardName, 'your reward'),
+        presentationToken,
+      ],
+    });
+  }
+
+  /** Voucher at unlock. */
+  async function sendVoucherWhatsApp({ entitlement, prospect, voucherToken }) {
+    const rewardName = await rewardNameOf(entitlement);
+    const expiry = entitlement.expiresAt
+      ? new Date(entitlement.expiresAt).toLocaleDateString('en-SG', { day: 'numeric', month: 'short', year: 'numeric' })
+      : 'further notice';
+    return sendTemplate({
+      prospect,
+      templateName: process.env.WHATSAPP_TEMPLATE_VOUCHER || 'reward_voucher',
+      params: [
+        cleanParam(prospect?.firstName, 'there'),
+        cleanParam(rewardName, 'your reward'),
+        voucherToken,
+        expiry,
+      ],
+    });
+  }
+
+  return { sendReservationWhatsApp, sendVoucherWhatsApp };
+}
+
+const _default = makeWhatsappService();
+export default _default;

--- a/backend/src/tests/entitlementDeliveryFanout.test.js
+++ b/backend/src/tests/entitlementDeliveryFanout.test.js
@@ -1,0 +1,127 @@
+import { makeEntitlementService, flushDeliveries } from '../services/redeemOps/entitlementService.js';
+
+// Trial-reward PR E — the per-channel delivery fan-out contract, DB-free:
+// queueDelivery is exercised directly (exported for exactly this) with fake
+// senders + a fake RedemptionEvent, and flushDeliveries() is the barrier.
+// The three promises of the contract:
+//   1. email and WhatsApp are INDEPENDENT (one failing never blocks the other),
+//   2. the boolean return stays PR A's `emailQueued` (WhatsApp never affects it),
+//   3. receipts are truthful per channel; `skipped` writes none.
+
+const entitlement = { id: 'ent-1' };
+const emailable = { email: 'sarah@example.com', phone: '+6591234567', sourceMetadata: { consent_contact: true } };
+const retellLead = { email: null, phone: '+6591234567', sourceMetadata: { consent_contact: true } };
+const silentLogger = { error: () => {}, warn: () => {}, info: () => {} };
+
+function makeSvc({ events, email = null, wa = null, emailReservation = null, waReservation = null }) {
+  return makeEntitlementService({
+    RedemptionEvent: { create: async (row) => { events.push(row); return row; } },
+    notifyUnlock: email,
+    notifyReservation: emailReservation,
+    notifyUnlockWa: wa,
+    notifyReservationWa: waReservation,
+    logger: silentLogger,
+  });
+}
+
+const receiptsBy = (events, channel) => events.filter((e) => e.metadata?.channel === channel);
+
+describe('queueDelivery — per-channel fan-out (PR E)', () => {
+  it('email sender throwing never blocks the WhatsApp leg (and vice-versa receipts are truthful)', async () => {
+    const events = [];
+    const svc = makeSvc({
+      events,
+      email: async () => { throw new Error('smtp down'); },
+      wa: async () => ({ sent: true, to: '••••4567' }),
+    });
+    const queued = svc.queueDelivery({ entitlement, prospect: emailable, kind: 'voucher', voucherToken: 'v' });
+    expect(queued).toBe(true); // a fresh EMAIL attempt was scheduled (it later failed)
+    await flushDeliveries();
+
+    const em = receiptsBy(events, 'email');
+    const wa = receiptsBy(events, 'whatsapp');
+    expect(em.length).toBe(1);
+    expect(em[0].type).toBe('notify_failed');
+    expect(em[0].metadata.error).toContain('smtp down');
+    expect(wa.length).toBe(1);
+    expect(wa[0].type).toBe('notified');
+    expect(wa[0].metadata).toMatchObject({ kind: 'voucher', channel: 'whatsapp', to: '••••4567' });
+  });
+
+  it('WhatsApp sender rejecting never blocks the email leg', async () => {
+    const events = [];
+    const svc = makeSvc({
+      events,
+      email: async () => ({ sent: true, to: 's***@example.com' }),
+      wa: async () => { throw new Error('graph 500'); },
+    });
+    expect(svc.queueDelivery({ entitlement, prospect: emailable, kind: 'voucher', voucherToken: 'v' })).toBe(true);
+    await flushDeliveries();
+
+    expect(receiptsBy(events, 'email')[0].type).toBe('notified');
+    const wa = receiptsBy(events, 'whatsapp')[0];
+    expect(wa.type).toBe('notify_failed');
+    expect(wa.metadata.error).toContain('graph 500');
+  });
+
+  it('no-email lead (Retell): returns false, email never called, WhatsApp STILL fires', async () => {
+    const events = [];
+    let emailCalls = 0;
+    const svc = makeSvc({
+      events,
+      email: async () => { emailCalls += 1; return { sent: true, to: 'x' }; },
+      wa: async () => ({ sent: true, to: '••••4567' }),
+    });
+    const queued = svc.queueDelivery({ entitlement, prospect: retellLead, kind: 'voucher', voucherToken: 'v' });
+    expect(queued).toBe(false); // emailQueued contract: no fresh email attempt
+    await flushDeliveries();
+
+    expect(emailCalls).toBe(0);
+    expect(receiptsBy(events, 'email').length).toBe(0);
+    expect(receiptsBy(events, 'whatsapp').length).toBe(1);
+    expect(receiptsBy(events, 'whatsapp')[0].type).toBe('notified');
+  });
+
+  it('flag-off parity: a `skipped` WhatsApp result writes no receipt — behavior is PR A byte-identical', async () => {
+    const events = [];
+    const svc = makeSvc({
+      events,
+      email: async () => ({ sent: true, to: 's***@example.com' }),
+      wa: async () => ({ sent: false, skipped: 'disabled' }),
+    });
+    expect(svc.queueDelivery({ entitlement, prospect: emailable, kind: 'voucher', voucherToken: 'v' })).toBe(true);
+    await flushDeliveries();
+
+    expect(receiptsBy(events, 'whatsapp').length).toBe(0);
+    expect(receiptsBy(events, 'email').length).toBe(1);
+  });
+
+  it('bare instance (no WhatsApp deps wired): exactly the pre-PR-E email behavior', async () => {
+    const events = [];
+    const svc = makeSvc({
+      events,
+      email: async () => ({ sent: true, to: 's***@example.com' }),
+    });
+    expect(svc.queueDelivery({ entitlement, prospect: emailable, kind: 'voucher', voucherToken: 'v' })).toBe(true);
+    await flushDeliveries();
+
+    expect(events.length).toBe(1);
+    expect(events[0].metadata.channel).toBe('email');
+  });
+
+  it('reservation kind routes to the reservation senders with kind-tagged receipts', async () => {
+    const events = [];
+    const seen = [];
+    const svc = makeSvc({
+      events,
+      emailReservation: async (args) => { seen.push(['email', args.presentationToken]); return { sent: true, to: 'x' }; },
+      waReservation: async (args) => { seen.push(['wa', args.presentationToken]); return { sent: true, to: 'y' }; },
+    });
+    expect(svc.queueDelivery({ entitlement, prospect: emailable, kind: 'pass', presentationToken: 'ptok' })).toBe(true);
+    await flushDeliveries();
+
+    expect(seen).toEqual(expect.arrayContaining([['email', 'ptok'], ['wa', 'ptok']]));
+    expect(events.every((e) => e.metadata.kind === 'pass')).toBe(true);
+    expect(events.map((e) => e.metadata.channel).sort()).toEqual(['email', 'whatsapp']);
+  });
+});

--- a/backend/src/tests/whatsappService.test.js
+++ b/backend/src/tests/whatsappService.test.js
@@ -1,0 +1,183 @@
+import { makeWhatsappService, canWhatsAppProspect, waRecipient } from '../services/redeemOps/whatsappService.js';
+
+// Trial-reward PR E — template payload shape + gates, all DB-free (RewardOffer
+// and fetch are DI fakes). The fan-out contract (email ≠ WhatsApp independence)
+// lives in entitlementDeliveryFanout.test.js; this file covers the sender.
+
+const ENV_KEYS = [
+  'REDEEM_OPS_WHATSAPP_ENABLED', 'WHATSAPP_TOKEN', 'WHATSAPP_PHONE_NUMBER_ID',
+  'WHATSAPP_TEMPLATE_PASS', 'WHATSAPP_TEMPLATE_VOUCHER', 'WHATSAPP_TEMPLATE_LANG',
+];
+let savedEnv;
+beforeEach(() => {
+  savedEnv = {};
+  for (const k of ENV_KEYS) { savedEnv[k] = process.env[k]; delete process.env[k]; }
+});
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+const consented = { firstName: 'Sarah', phone: '+6591234567', sourceMetadata: { consent_contact: true } };
+const entitlement = { id: 'e1', rewardOfferId: 'offer-1', expiresAt: new Date('2026-08-17T12:00:00+08:00') };
+const offerFake = { findByPk: async () => ({ publicTitle: 'S$10 FairPrice voucher', title: 'FP10' }) };
+const silentLogger = { error: () => {}, warn: () => {}, info: () => {} };
+
+function fetchRecorder(response = { ok: true, json: async () => ({}) }) {
+  const calls = [];
+  const fn = async (url, opts) => { calls.push({ url, opts, body: JSON.parse(opts.body) }); return response; };
+  fn.calls = calls;
+  return fn;
+}
+
+function enableWithCreds() {
+  process.env.REDEEM_OPS_WHATSAPP_ENABLED = 'true';
+  process.env.WHATSAPP_TOKEN = 'tok-123';
+  process.env.WHATSAPP_PHONE_NUMBER_ID = '555000111';
+}
+
+describe('waRecipient — Graph API recipient normalization', () => {
+  it('prefixes 65 onto bare 8-digit SG mobiles', () => {
+    expect(waRecipient('91234567')).toBe('6591234567');
+    expect(waRecipient('81234567')).toBe('6581234567');
+  });
+  it('strips formatting from stored +65 numbers', () => {
+    expect(waRecipient('+6591234567')).toBe('6591234567');
+    expect(waRecipient('+65 9123 4567')).toBe('6591234567');
+  });
+  it('rejects garbage and too-short values', () => {
+    expect(waRecipient('')).toBeNull();
+    expect(waRecipient(null)).toBeNull();
+    expect(waRecipient('12345')).toBeNull();
+  });
+});
+
+describe('canWhatsAppProspect — capability + D2 safe-default consent gate', () => {
+  it('true only with a WA-able phone AND consent_contact === true (D2 pending)', () => {
+    expect(canWhatsAppProspect(consented)).toBe(true);
+    expect(canWhatsAppProspect({ ...consented, sourceMetadata: {} })).toBe(false);
+    expect(canWhatsAppProspect({ ...consented, sourceMetadata: { consent_contact: false } })).toBe(false);
+    expect(canWhatsAppProspect({ firstName: 'S', sourceMetadata: { consent_contact: true } })).toBe(false);
+    expect(canWhatsAppProspect(null)).toBe(false);
+  });
+});
+
+describe('sendReservationWhatsApp / sendVoucherWhatsApp', () => {
+  it('flag off → skipped, no network call', async () => {
+    const fetch = fetchRecorder();
+    const svc = makeWhatsappService({ RewardOffer: offerFake, fetch, logger: silentLogger });
+    const r = await svc.sendReservationWhatsApp({ entitlement, prospect: consented, presentationToken: 'ptok' });
+    expect(r).toEqual({ sent: false, skipped: 'disabled' });
+    expect(fetch.calls.length).toBe(0);
+  });
+
+  it('flag on but no consent → skipped no_whatsapp, no network call', async () => {
+    enableWithCreds();
+    const fetch = fetchRecorder();
+    const svc = makeWhatsappService({ RewardOffer: offerFake, fetch, logger: silentLogger });
+    const r = await svc.sendReservationWhatsApp({
+      entitlement, prospect: { ...consented, sourceMetadata: {} }, presentationToken: 'ptok',
+    });
+    expect(r).toEqual({ sent: false, skipped: 'no_whatsapp' });
+    expect(fetch.calls.length).toBe(0);
+  });
+
+  it('flag on but creds missing → error result (receipt-worthy), no network call', async () => {
+    process.env.REDEEM_OPS_WHATSAPP_ENABLED = 'true';
+    const fetch = fetchRecorder();
+    const svc = makeWhatsappService({ RewardOffer: offerFake, fetch, logger: silentLogger });
+    const r = await svc.sendReservationWhatsApp({ entitlement, prospect: consented, presentationToken: 'ptok' });
+    expect(r.sent).toBe(false);
+    expect(r.skipped).toBeUndefined();
+    expect(r.error).toMatch(/not configured/);
+    expect(fetch.calls.length).toBe(0);
+  });
+
+  it('reservation payload: template, lang, recipient, 3 body params, auth header', async () => {
+    enableWithCreds();
+    const fetch = fetchRecorder();
+    const svc = makeWhatsappService({ RewardOffer: offerFake, fetch, logger: silentLogger });
+    const r = await svc.sendReservationWhatsApp({ entitlement, prospect: consented, presentationToken: 'ptok-raw' });
+    expect(r.sent).toBe(true);
+    expect(r.to).toBe('••••4567');
+    expect(fetch.calls.length).toBe(1);
+    const { url, opts, body } = fetch.calls[0];
+    expect(url).toContain('/555000111/messages');
+    expect(opts.headers.Authorization).toBe('Bearer tok-123');
+    expect(body.messaging_product).toBe('whatsapp');
+    expect(body.to).toBe('6591234567');
+    expect(body.template.name).toBe('reward_pass');
+    expect(body.template.language.code).toBe('en');
+    expect(body.template.components).toEqual([
+      {
+        type: 'body',
+        parameters: [
+          { type: 'text', text: 'Sarah' },
+          { type: 'text', text: 'S$10 FairPrice voucher' },
+          { type: 'text', text: 'ptok-raw' },
+        ],
+      },
+    ]);
+  });
+
+  it('voucher payload: 4 params with en-SG short-month expiry; env template name wins', async () => {
+    enableWithCreds();
+    process.env.WHATSAPP_TEMPLATE_VOUCHER = 'reward_voucher_v2';
+    const fetch = fetchRecorder();
+    const svc = makeWhatsappService({ RewardOffer: offerFake, fetch, logger: silentLogger });
+    const r = await svc.sendVoucherWhatsApp({ entitlement, prospect: consented, voucherToken: 'vtok-raw' });
+    expect(r.sent).toBe(true);
+    const { body } = fetch.calls[0];
+    expect(body.template.name).toBe('reward_voucher_v2');
+    const params = body.template.components[0].parameters.map((p) => p.text);
+    expect(params.length).toBe(4);
+    expect(params[2]).toBe('vtok-raw');
+    expect(params[3]).toBe('17 Aug 2026');
+  });
+
+  it('URL-ish first names never ride the template (falls back to "there")', async () => {
+    enableWithCreds();
+    const fetch = fetchRecorder();
+    const svc = makeWhatsappService({ RewardOffer: offerFake, fetch, logger: silentLogger });
+    await svc.sendReservationWhatsApp({
+      entitlement,
+      prospect: { ...consented, firstName: 'http://spam.example' },
+      presentationToken: 'p',
+    });
+    expect(fetch.calls[0].body.template.components[0].parameters[0].text).toBe('there');
+  });
+
+  it('Graph API error → sent:false with the Meta error code, never a throw', async () => {
+    enableWithCreds();
+    const fetch = fetchRecorder({
+      ok: false, status: 400,
+      json: async () => ({ error: { code: 131026, message: 'undeliverable' } }),
+    });
+    const svc = makeWhatsappService({ RewardOffer: offerFake, fetch, logger: silentLogger });
+    const r = await svc.sendVoucherWhatsApp({ entitlement, prospect: consented, voucherToken: 'v' });
+    expect(r.sent).toBe(false);
+    expect(r.error).toContain('131026');
+  });
+
+  it('network failure → sent:false result, never a throw', async () => {
+    enableWithCreds();
+    const fetch = async () => { throw new Error('ECONNRESET'); };
+    const svc = makeWhatsappService({ RewardOffer: offerFake, fetch, logger: silentLogger });
+    const r = await svc.sendVoucherWhatsApp({ entitlement, prospect: consented, voucherToken: 'v' });
+    expect(r).toMatchObject({ sent: false, error: 'ECONNRESET' });
+  });
+
+  it('reward name lookup failure degrades to "your reward", still sends', async () => {
+    enableWithCreds();
+    const fetch = fetchRecorder();
+    const svc = makeWhatsappService({
+      RewardOffer: { findByPk: async () => { throw new Error('db down'); } },
+      fetch, logger: silentLogger,
+    });
+    const r = await svc.sendReservationWhatsApp({ entitlement, prospect: consented, presentationToken: 'p' });
+    expect(r.sent).toBe(true);
+    expect(fetch.calls[0].body.template.components[0].parameters[1].text).toBe('your reward');
+  });
+});

--- a/backend/src/tests/whatsappService.test.js
+++ b/backend/src/tests/whatsappService.test.js
@@ -1,12 +1,15 @@
 import { makeWhatsappService, canWhatsAppProspect, waRecipient } from '../services/redeemOps/whatsappService.js';
 
-// Trial-reward PR E — template payload shape + gates, all DB-free (RewardOffer
-// and fetch are DI fakes). The fan-out contract (email ≠ WhatsApp independence)
-// lives in entitlementDeliveryFanout.test.js; this file covers the sender.
+// Trial-reward PR E — template payload shape + gates, all DB-free (RewardOffer,
+// QRCode and fetch are DI fakes). The fan-out contract (email ≠ WhatsApp
+// independence) lives in entitlementDeliveryFanout.test.js; this covers the
+// sender: gate order, the QR-header media upload → template send sequence, and
+// the WHATSAPP_QR_HEADER=false body-only shape.
 
 const ENV_KEYS = [
   'REDEEM_OPS_WHATSAPP_ENABLED', 'WHATSAPP_TOKEN', 'WHATSAPP_PHONE_NUMBER_ID',
   'WHATSAPP_TEMPLATE_PASS', 'WHATSAPP_TEMPLATE_VOUCHER', 'WHATSAPP_TEMPLATE_LANG',
+  'WHATSAPP_QR_HEADER', 'WHATSAPP_CLAIM_ORIGIN',
 ];
 let savedEnv;
 beforeEach(() => {
@@ -25,17 +28,37 @@ const entitlement = { id: 'e1', rewardOfferId: 'offer-1', expiresAt: new Date('2
 const offerFake = { findByPk: async () => ({ publicTitle: 'S$10 FairPrice voucher', title: 'FP10' }) };
 const silentLogger = { error: () => {}, warn: () => {}, info: () => {} };
 
-function fetchRecorder(response = { ok: true, json: async () => ({}) }) {
+const uploadOk = { ok: true, json: async () => ({ id: 'MEDIA-1' }) };
+const sendOk = { ok: true, json: async () => ({}) };
+
+/** Sequenced fetch fake: responses served in order; FormData bodies kept raw. */
+function fetchRecorder(responses = [uploadOk, sendOk]) {
   const calls = [];
-  const fn = async (url, opts) => { calls.push({ url, opts, body: JSON.parse(opts.body) }); return response; };
+  const fn = async (url, opts) => {
+    const body = typeof opts?.body === 'string' ? JSON.parse(opts.body) : opts?.body;
+    calls.push({ url, opts, body });
+    return responses[Math.min(calls.length - 1, responses.length - 1)];
+  };
   fn.calls = calls;
   return fn;
+}
+
+function qrRecorder() {
+  const contents = [];
+  return {
+    contents,
+    toBuffer: async (content) => { contents.push(content); return Buffer.from('fake-png'); },
+  };
 }
 
 function enableWithCreds() {
   process.env.REDEEM_OPS_WHATSAPP_ENABLED = 'true';
   process.env.WHATSAPP_TOKEN = 'tok-123';
   process.env.WHATSAPP_PHONE_NUMBER_ID = '555000111';
+}
+
+function makeSvc({ fetch, qr = qrRecorder(), RewardOffer = offerFake } = {}) {
+  return makeWhatsappService({ RewardOffer, fetch, QRCode: qr, logger: silentLogger });
 }
 
 describe('waRecipient — Graph API recipient normalization', () => {
@@ -64,19 +87,19 @@ describe('canWhatsAppProspect — capability + D2 safe-default consent gate', ()
   });
 });
 
-describe('sendReservationWhatsApp / sendVoucherWhatsApp', () => {
-  it('flag off → skipped, no network call', async () => {
+describe('gates fire before any network call', () => {
+  it('flag off → skipped, no fetch', async () => {
     const fetch = fetchRecorder();
-    const svc = makeWhatsappService({ RewardOffer: offerFake, fetch, logger: silentLogger });
+    const svc = makeSvc({ fetch });
     const r = await svc.sendReservationWhatsApp({ entitlement, prospect: consented, presentationToken: 'ptok' });
     expect(r).toEqual({ sent: false, skipped: 'disabled' });
     expect(fetch.calls.length).toBe(0);
   });
 
-  it('flag on but no consent → skipped no_whatsapp, no network call', async () => {
+  it('flag on but no consent → skipped no_whatsapp, no fetch', async () => {
     enableWithCreds();
     const fetch = fetchRecorder();
-    const svc = makeWhatsappService({ RewardOffer: offerFake, fetch, logger: silentLogger });
+    const svc = makeSvc({ fetch });
     const r = await svc.sendReservationWhatsApp({
       entitlement, prospect: { ...consented, sourceMetadata: {} }, presentationToken: 'ptok',
     });
@@ -84,100 +107,143 @@ describe('sendReservationWhatsApp / sendVoucherWhatsApp', () => {
     expect(fetch.calls.length).toBe(0);
   });
 
-  it('flag on but creds missing → error result (receipt-worthy), no network call', async () => {
+  it('flag on but creds missing → error result (receipt-worthy), no fetch', async () => {
     process.env.REDEEM_OPS_WHATSAPP_ENABLED = 'true';
     const fetch = fetchRecorder();
-    const svc = makeWhatsappService({ RewardOffer: offerFake, fetch, logger: silentLogger });
+    const svc = makeSvc({ fetch });
     const r = await svc.sendReservationWhatsApp({ entitlement, prospect: consented, presentationToken: 'ptok' });
     expect(r.sent).toBe(false);
     expect(r.skipped).toBeUndefined();
     expect(r.error).toMatch(/not configured/);
     expect(fetch.calls.length).toBe(0);
   });
+});
 
-  it('reservation payload: template, lang, recipient, 3 body params, auth header', async () => {
+describe('QR-header send sequence (default: header ON)', () => {
+  it('reservation: uploads the QR PNG then sends header+body; QR encodes the claim link', async () => {
     enableWithCreds();
     const fetch = fetchRecorder();
-    const svc = makeWhatsappService({ RewardOffer: offerFake, fetch, logger: silentLogger });
+    const qr = qrRecorder();
+    const svc = makeSvc({ fetch, qr });
     const r = await svc.sendReservationWhatsApp({ entitlement, prospect: consented, presentationToken: 'ptok-raw' });
-    expect(r.sent).toBe(true);
-    expect(r.to).toBe('••••4567');
-    expect(fetch.calls.length).toBe(1);
-    const { url, opts, body } = fetch.calls[0];
-    expect(url).toContain('/555000111/messages');
-    expect(opts.headers.Authorization).toBe('Bearer tok-123');
-    expect(body.messaging_product).toBe('whatsapp');
-    expect(body.to).toBe('6591234567');
-    expect(body.template.name).toBe('reward_pass');
-    expect(body.template.language.code).toBe('en');
-    expect(body.template.components).toEqual([
-      {
-        type: 'body',
-        parameters: [
-          { type: 'text', text: 'Sarah' },
-          { type: 'text', text: 'S$10 FairPrice voucher' },
-          { type: 'text', text: 'ptok-raw' },
-        ],
-      },
-    ]);
+    expect(r).toEqual({ sent: true, to: '••••4567' });
+    expect(qr.contents).toEqual(['https://redeem.sg/r/ptok-raw']);
+    expect(fetch.calls.length).toBe(2);
+
+    const upload = fetch.calls[0];
+    expect(upload.url).toContain('/555000111/media');
+    expect(upload.opts.headers.Authorization).toBe('Bearer tok-123');
+    expect(upload.body).toBeInstanceOf(FormData);
+
+    const send = fetch.calls[1];
+    expect(send.url).toContain('/555000111/messages');
+    expect(send.body.to).toBe('6591234567');
+    expect(send.body.template.name).toBe('reward_pass');
+    expect(send.body.template.language.code).toBe('en');
+    expect(send.body.template.components[0]).toEqual({
+      type: 'header',
+      parameters: [{ type: 'image', image: { id: 'MEDIA-1' } }],
+    });
+    expect(send.body.template.components[1]).toEqual({
+      type: 'body',
+      parameters: [
+        { type: 'text', text: 'Sarah' },
+        { type: 'text', text: 'S$10 FairPrice voucher' },
+        { type: 'text', text: 'ptok-raw' },
+      ],
+    });
   });
 
-  it('voucher payload: 4 params with en-SG short-month expiry; env template name wins', async () => {
+  it('voucher: QR encodes the RAW token; 4 body params with en-SG expiry; env template name wins', async () => {
     enableWithCreds();
     process.env.WHATSAPP_TEMPLATE_VOUCHER = 'reward_voucher_v2';
     const fetch = fetchRecorder();
-    const svc = makeWhatsappService({ RewardOffer: offerFake, fetch, logger: silentLogger });
+    const qr = qrRecorder();
+    const svc = makeSvc({ fetch, qr });
     const r = await svc.sendVoucherWhatsApp({ entitlement, prospect: consented, voucherToken: 'vtok-raw' });
     expect(r.sent).toBe(true);
-    const { body } = fetch.calls[0];
-    expect(body.template.name).toBe('reward_voucher_v2');
-    const params = body.template.components[0].parameters.map((p) => p.text);
+    expect(qr.contents).toEqual(['vtok-raw']);
+    const send = fetch.calls[1];
+    expect(send.body.template.name).toBe('reward_voucher_v2');
+    const params = send.body.template.components[1].parameters.map((p) => p.text);
     expect(params.length).toBe(4);
     expect(params[2]).toBe('vtok-raw');
     expect(params[3]).toBe('17 Aug 2026');
   });
 
-  it('URL-ish first names never ride the template (falls back to "there")', async () => {
+  it('WHATSAPP_CLAIM_ORIGIN overrides the pass-QR host', async () => {
     enableWithCreds();
-    const fetch = fetchRecorder();
-    const svc = makeWhatsappService({ RewardOffer: offerFake, fetch, logger: silentLogger });
-    await svc.sendReservationWhatsApp({
-      entitlement,
-      prospect: { ...consented, firstName: 'http://spam.example' },
-      presentationToken: 'p',
-    });
-    expect(fetch.calls[0].body.template.components[0].parameters[0].text).toBe('there');
+    process.env.WHATSAPP_CLAIM_ORIGIN = 'https://mktr.sg';
+    const qr = qrRecorder();
+    const svc = makeSvc({ fetch: fetchRecorder(), qr });
+    await svc.sendReservationWhatsApp({ entitlement, prospect: consented, presentationToken: 'p' });
+    expect(qr.contents).toEqual(['https://mktr.sg/r/p']);
   });
 
-  it('Graph API error → sent:false with the Meta error code, never a throw', async () => {
+  it('media upload failure → sent:false, message send never attempted (no body-only fallback)', async () => {
     enableWithCreds();
-    const fetch = fetchRecorder({
-      ok: false, status: 400,
-      json: async () => ({ error: { code: 131026, message: 'undeliverable' } }),
-    });
-    const svc = makeWhatsappService({ RewardOffer: offerFake, fetch, logger: silentLogger });
+    const fetch = fetchRecorder([{ ok: false, status: 400, json: async () => ({ error: { code: 100, message: 'bad media' } }) }]);
+    const svc = makeSvc({ fetch });
+    const r = await svc.sendVoucherWhatsApp({ entitlement, prospect: consented, voucherToken: 'v' });
+    expect(r.sent).toBe(false);
+    expect(r.error).toMatch(/media upload failed/);
+    expect(fetch.calls.length).toBe(1);
+  });
+});
+
+describe('WHATSAPP_QR_HEADER=false — body-only template shape', () => {
+  it('sends a single call with no header component', async () => {
+    enableWithCreds();
+    process.env.WHATSAPP_QR_HEADER = 'false';
+    const fetch = fetchRecorder([sendOk]);
+    const qr = qrRecorder();
+    const svc = makeSvc({ fetch, qr });
+    const r = await svc.sendReservationWhatsApp({ entitlement, prospect: consented, presentationToken: 'p' });
+    expect(r.sent).toBe(true);
+    expect(qr.contents.length).toBe(0);
+    expect(fetch.calls.length).toBe(1);
+    expect(fetch.calls[0].url).toContain('/messages');
+    expect(fetch.calls[0].body.template.components.length).toBe(1);
+    expect(fetch.calls[0].body.template.components[0].type).toBe('body');
+  });
+});
+
+describe('failure normalization — never throws', () => {
+  it('Graph send error → sent:false with the Meta error code', async () => {
+    enableWithCreds();
+    const fetch = fetchRecorder([uploadOk, { ok: false, status: 400, json: async () => ({ error: { code: 131026, message: 'undeliverable' } }) }]);
+    const svc = makeSvc({ fetch });
     const r = await svc.sendVoucherWhatsApp({ entitlement, prospect: consented, voucherToken: 'v' });
     expect(r.sent).toBe(false);
     expect(r.error).toContain('131026');
   });
 
-  it('network failure → sent:false result, never a throw', async () => {
+  it('network failure → sent:false result', async () => {
     enableWithCreds();
     const fetch = async () => { throw new Error('ECONNRESET'); };
-    const svc = makeWhatsappService({ RewardOffer: offerFake, fetch, logger: silentLogger });
+    const svc = makeWhatsappService({ RewardOffer: offerFake, fetch, QRCode: qrRecorder(), logger: silentLogger });
     const r = await svc.sendVoucherWhatsApp({ entitlement, prospect: consented, voucherToken: 'v' });
     expect(r).toMatchObject({ sent: false, error: 'ECONNRESET' });
+  });
+
+  it('URL-ish first names never ride the template (falls back to "there")', async () => {
+    enableWithCreds();
+    const fetch = fetchRecorder();
+    const svc = makeSvc({ fetch });
+    await svc.sendReservationWhatsApp({
+      entitlement,
+      prospect: { ...consented, firstName: 'http://spam.example' },
+      presentationToken: 'p',
+    });
+    expect(fetch.calls[1].body.template.components[1].parameters[0].text).toBe('there');
   });
 
   it('reward name lookup failure degrades to "your reward", still sends', async () => {
     enableWithCreds();
     const fetch = fetchRecorder();
-    const svc = makeWhatsappService({
-      RewardOffer: { findByPk: async () => { throw new Error('db down'); } },
-      fetch, logger: silentLogger,
-    });
+    const svc = makeSvc({ fetch, RewardOffer: { findByPk: async () => { throw new Error('db down'); } } });
     const r = await svc.sendReservationWhatsApp({ entitlement, prospect: consented, presentationToken: 'p' });
     expect(r.sent).toBe(true);
-    expect(fetch.calls[0].body.template.components[0].parameters[1].text).toBe('your reward');
+    expect(fetch.calls[1].body.template.components[1].parameters[1].text).toBe('your reward');
   });
 });


### PR DESCRIPTION
## What

Trial-reward **PR E** (docs/plans/trial-reward-funnel-hardening-prompt.md §PR E): the reservation pass at issue and the voucher at unlock are delivered to the customer's **WhatsApp** as Meta Cloud API UTILITY templates, alongside the existing email. **Ships dark** behind `REDEEM_OPS_WHATSAPP_ENABLED` (default false) — flag off, the sender resolves `skipped` and nothing is sent or receipted: byte-identical to PR A behavior (test-asserted).

## How

- **`whatsappService.js`** (new): `reward_pass` / `reward_voucher` template sends via the Graph API (version aligned with verificationService/metaCapiService). Templates hardcode the `redeem.sg/r/` host and carry only the token as the link variable — the /r/ page renders the live QR (pass → voucher on the same link), so nothing baked into a message goes stale after unlock or token rotation. Digits-only recipient normalization (`+65…` storage and bare 8-digit SG mobiles), param hygiene (whitespace collapse, URL-ish person names → "there"), normalized `{ sent, skipped?, to?, error? }` results — never throws.
- **`queueDelivery`**: independent per-channel fire-and-forget legs. Email and WhatsApp can never block or fail each other; a **no-email Retell lead still gets its WhatsApp leg** (the email guard now gates only the email leg). The boolean return keeps PR A's `emailQueued` contract untouched — no API shape changes.
- **Receipts**: `writeDeliveryReceipt` gains a `channel` param; `notified`/`notify_failed` events are channel-tagged. `listEntitlements` adds `delivery.whatsapp` next to `delivery.email` (the per-channel receipt map PR A prepared) plus `whatsappDeliverable` (capability-only + flag-gated; the D2 consent arm stays send-time authoritative since the list projection carries no `sourceMetadata`).
- **Resend**: `channel: 'whatsapp'` accepted and validated (409 when WhatsApp isn't available for the customer). Because resend **rotates the token**, both wired channels refresh regardless of the picked channel — otherwise the un-picked channel's previously delivered link would die silently; the picked channel is what was validated and is recorded in the `manual_override` metadata.
- **`envValidation`**: warns when the flag is ON without `WHATSAPP_TOKEN` / `WHATSAPP_PHONE_NUMBER_ID`.

## Decision D2 (pending, Shawn) — consent basis

`canWhatsAppProspect` defaults to the **safe side**: automated WhatsApp requires `sourceMetadata.consent_contact === true`. Choosing the documented transactional-delivery basis instead = flip `WA_REQUIRES_CONTACT_CONSENT` to false (one line, commented at the decision site).

## Tests

19 new, all DB-free (`whatsappService.test.js`, `entitlementDeliveryFanout.test.js`): template payload shape + gates; fan-out independence (email failure ≠ WhatsApp failure, both directions); flag-off parity; the Retell no-email leg; per-channel receipt truthfulness. `npx jest` on both suites: **2 passed, 19 passed**. ESLint clean on all touched files. No other suite imports the touched modules.

## Not in this PR (deliberately)

- Meta-side prereqs (Shawn): Redeem WABA + sender number, template approval. The build slots in whenever approvals land — flip the flag + set env then.
- Known follow-up: `reconcileMissedDeliveries` treats *any* `notified` receipt for a kind as delivered (cross-channel) — acceptable crash-recovery semantics for v1, noted for a later per-channel sweep if wanted.
- Per-activation "Customer delivery" policy (decision D3) — proposed as a small follow-up PR after real sends prove out.

## Go-live checklist (after template approval)

1. Render env: `WHATSAPP_TOKEN`, `WHATSAPP_PHONE_NUMBER_ID` (+ optional `WHATSAPP_TEMPLATE_PASS`/`WHATSAPP_TEMPLATE_VOUCHER`/`WHATSAPP_TEMPLATE_LANG`) → **Manual Deploy**.
2. `REDEEM_OPS_WHATSAPP_ENABLED=true`.
3. Smoke: test-activation signup with own phone → pass on WhatsApp → unlock via ops console → voucher on WhatsApp → both receipts `channel:'whatsapp', ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)