### PR TITLE
fix(campaigns): empty agent pool warns on launch instead of blocking

### DIFF
--- a/backend/src/controllers/campaignController.js
+++ b/backend/src/controllers/campaignController.js
@@ -116,8 +116,10 @@ export const setLaunchState = asyncHandler(async (req, res) => {
     throw new AppError('state must be "active" or "paused"', 400);
   }
 
-  // Readiness gate on activate: block go-live when the campaign would drop
-  // leads (empty funded pool / webhook off), unless explicitly forced.
+  // Readiness gate on activate: block go-live only when capture itself is
+  // broken (webhook off, OTP unconfigured, guided-review misconfig), unless
+  // explicitly forced. An empty funded pool is a warning, not a blocker
+  // (2026-07-18): leads dead-end on the System Agent but remain recoverable.
   if (state === 'active' && !force) {
     const readiness = await loadCampaignReadiness(req.params.id);
     if (readiness.applicable && !readiness.ready) {

--- a/backend/src/services/campaignReadinessService.js
+++ b/backend/src/services/campaignReadinessService.js
@@ -3,9 +3,12 @@
  * leads?" check for the admin (Phase 3 of the quiz campaign work).
  *
  * The #1 go-live risk: a lead-capture / quiz campaign launched with NO agent
- * lead-package pool routes every lead to the phone-less System Agent, which the
- * Lyfe edge function rejects (422) — leads are silently lost. This surfaces that
- * (and a disabled webhook / phone-less agents) BEFORE ad spend starts.
+ * lead-package pool routes every lead to the phone-less System Agent — leads
+ * are captured but undelivered (recoverable via admin reassign). This surfaces
+ * that (and a disabled webhook / phone-less agents) BEFORE ad spend starts.
+ * Since 2026-07-18 the empty pool is a WARNING, not a blocker — reward-only
+ * and test campaigns launch without a funded pool by design; the hard blocks
+ * are the states where capture itself breaks (webhook off, OTP unconfigured).
  *
  * `computeReadiness` is pure + dependency-free (no model imports) so it unit-tests
  * without a DB and stays decoupled from the (currently in-flux) models layer.
@@ -81,13 +84,16 @@ export function computeReadiness(facts) {
 
   const issues = [];
 
-  // CRITICAL — empty pool → System Agent → lost at Lyfe (422). The whole point.
+  // WARNING — empty pool → leads dead-end on the System Agent (undelivered but
+  // retained in MKTR, admin-recoverable via reassign/held dispatch). Downgraded
+  // from critical 2026-07-18 (Shawn): reward-only and test campaigns legitimately
+  // launch with no funded pool, so this warns loudly but never blocks activation.
   if (assignableAgents === 0) {
     issues.push({
-      level: 'critical',
+      level: 'warning',
       code: 'no_agent_pool',
       message:
-        'No agent has an active lead package for this campaign. Leads will route to the System Agent and will NOT be delivered. Assign a lead package to at least one active agent before launching.',
+        'No agent has an active lead package for this campaign — leads will sit with the System Agent, undelivered, until a package is assigned (they stay in MKTR and can be reassigned later). Fine for reward-only or test campaigns; assign a package before real ad spend.',
     });
   }
 

--- a/backend/src/tests/campaignReadiness.test.js
+++ b/backend/src/tests/campaignReadiness.test.js
@@ -31,11 +31,11 @@ describe('campaignReadinessService.computeReadiness', () => {
     expect(r.issues).toHaveLength(0);
   });
 
-  it('flags an empty agent pool as critical (not ready)', () => {
+  it('flags an empty agent pool as a WARNING only — activation stays allowed (2026-07-18)', () => {
     const r = computeReadiness({ ...healthy, assignableAgents: 0 });
-    expect(r.ready).toBe(false);
+    expect(r.ready).toBe(true);
     expect(codes(r)).toContain('no_agent_pool');
-    expect(r.issues.find((i) => i.code === 'no_agent_pool').level).toBe('critical');
+    expect(r.issues.find((i) => i.code === 'no_agent_pool').level).toBe('warning');
   });
 
   it('flags a disabled webhook as critical (not ready)', () => {


### PR DESCRIPTION
Downgrades `no_agent_pool` from critical to warning per Shawn's 2026-07-18 decision: reward-only/test campaigns launch without a funded pool by design — leads dead-end on the System Agent (captured, undelivered, admin-recoverable) and the Launch banner still warns loudly. Hard blocks remain for broken-capture states (webhook off, OTP unconfigured, guided-review misconfig). Readiness suite updated, 22 green; the banner styles by level so no frontend change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)