### PR TITLE
feat(studio-ai): fill-everything panel — sectioned review, pick/list rows, advisory rec cards, Distribution ✦

### DIFF
--- a/src/components/studio/StudioAiPanel.jsx
+++ b/src/components/studio/StudioAiPanel.jsx
@@ -3,14 +3,18 @@ import { AI_TONES } from './useStudioAi';
 import { buildLookDoc, lookBlockedReason } from './studioLooks';
 import DeviceFrame from './DeviceFrame';
 import CanvasPageSubject from './CanvasPageSubject';
+import { CATEGORY_OPTIONS } from './marketplaceOptions';
 
 /**
- * "✦ Write it for me" — the Studio AI panel (PR 4), the mock's 392px right
- * slide-in. Views: brief (mode toggle + tone chips), loading skeletons,
- * copy review (struck-through old values, accept / keep-mine / ↻, sticky
- * apply-all), looks gallery (LIVE mini-previews — the real renderer inside a
- * DeviceFrame, fed each look's composed doc), proposal (keep-my-template/
- * theme/copy + Adopt/Discard), error retry, 429 countdown.
+ * "✦ Write it for me" — the Studio AI panel (PR 4 + the full-coverage
+ * amendment), the mock's 392px right slide-in. Views: brief (mode toggle +
+ * tone chips), loading skeletons, review (rows grouped by section with
+ * per-section apply; string/pick/list kinds; struck-through old values,
+ * accept / keep-mine / ↻, sticky apply-all) + ADVISORY recommendation cards
+ * (never in apply-all — per-card Apply-to-draft / Go-to-control), looks
+ * gallery (LIVE mini-previews — the real renderer inside a DeviceFrame, fed
+ * each look's composed doc), proposal (keep-my-template/theme/copy +
+ * Adopt/Discard), error retry, 429 countdown.
  */
 
 const mono = "500 10px ui-monospace, 'SF Mono', Menlo, monospace";
@@ -24,6 +28,27 @@ const TEMPLATE_NAMES = {
   journey: 'Journey',
 };
 
+const CATEGORY_LABELS = Object.fromEntries(CATEGORY_OPTIONS);
+
+/** Human display for a row value (pick ids → their panel labels). */
+function displayValue(row) {
+  if (row.kind === 'pick' && row.path?.endsWith('.category')) return CATEGORY_LABELS[row.value] || row.value;
+  return row.value;
+}
+
+/** Multi-line text for a value that may be a string or a bullet list. */
+function ValueLines({ value, struck = false }) {
+  const style = struck
+    ? { fontSize: 11, color: 'var(--ink-3, #9BA0AB)', textDecoration: 'line-through', marginBottom: 3, whiteSpace: 'pre-line' }
+    : { fontSize: 12.5, lineHeight: 1.5, whiteSpace: 'pre-line', marginBottom: 8 };
+  if (Array.isArray(value)) {
+    if (!value.length) return null;
+    return <div style={style}>{value.map((v) => `• ${v}`).join('\n')}</div>;
+  }
+  if (!value) return null;
+  return <div style={style}>{value}</div>;
+}
+
 /** Mini device preview — true 390-wide viewport scaled down, inert. */
 function LookPreview({ campaign, lookDoc }) {
   return (
@@ -36,7 +61,7 @@ function LookPreview({ campaign, lookDoc }) {
 }
 
 export default function StudioAiPanel({ ai, campaign, doc }) {
-  const { mode, setMode, phase, brief, setBrief, sugs, scope, looks, proposal, error, retryIn, budget } = ai;
+  const { mode, setMode, phase, brief, setBrief, sugs, recs = [], scope, looks, proposal, error, retryIn, budget } = ai;
 
   // Looks always compose against the PRE-proposal doc mid-proposal (the
   // mock's rule: regenerating looks starts from the previous design).
@@ -45,6 +70,18 @@ export default function StudioAiPanel({ ai, campaign, doc }) {
     () => (looks || []).map((look) => (lookBase ? buildLookDoc(lookBase, look, {}) : null)),
     [looks, lookBase]
   );
+
+  // Review rows grouped by section, in order of first appearance (the server
+  // already sorts rows by whitelist order, which is section-contiguous).
+  const rowSections = useMemo(() => {
+    const map = new Map();
+    (sugs || []).forEach((row, index) => {
+      const key = row.section || 'Other';
+      if (!map.has(key)) map.set(key, []);
+      map.get(key).push({ row, index });
+    });
+    return [...map.entries()];
+  }, [sugs]);
 
   if (!ai.open) return null;
 
@@ -91,7 +128,7 @@ export default function StudioAiPanel({ ai, campaign, doc }) {
                 onClick={() => setMode('copy')}
                 style={{ flex: 1, cursor: 'pointer', border: 'none', borderRadius: 5, padding: '6px 0', fontSize: 11, fontWeight: 600, background: mode === 'copy' ? '#fff' : 'transparent', color: mode === 'copy' ? 'var(--ink)' : 'var(--ink-2)' }}
               >
-                Write the copy
+                Fill everything
               </button>
               <button
                 type="button"
@@ -101,10 +138,18 @@ export default function StudioAiPanel({ ai, campaign, doc }) {
                 Design the whole page
               </button>
             </div>
+            {mode === 'copy' && (
+              <div style={{ fontSize: 10.5, lineHeight: 1.5, color: 'var(--ink-2, #7A8090)' }}>
+                Drafts every fillable detail in one pass — page, form and quiz copy, marketplace metadata, inclusions —
+                plus advisory recommendations for the publication switches, domain and slug. Nothing is applied without
+                your review; publication switches are only ever flipped by you.
+              </div>
+            )}
             {mode === 'full' && (
               <div style={{ fontSize: 10.5, lineHeight: 1.5, color: 'var(--ink-2, #7A8090)' }}>
                 Proposes template + theme + copy together, as up to 3 complete looks — chosen only from documented
-                schema values. Gates, consents, legal text, fields, verification and distribution are never touched.
+                schema values. Gates, consents, legal text, form fields, verification and publication switches are
+                never touched.
               </div>
             )}
 
@@ -162,7 +207,7 @@ export default function StudioAiPanel({ ai, campaign, doc }) {
                 ? 'Drafting up to 3 complete looks — template + theme + copy, one budget call…'
                 : scope
                   ? `Drafting a suggestion for ${scope.label}…`
-                  : 'Drafting against your current template…'}
+                  : 'Filling every section — copy, marketplace metadata and recommendations, one budget call…'}
             </div>
             {(phase === 'looksLoading' ? [1, 2, 3] : [1, 2, 3, 4, 5]).map((k) => (
               <div key={k} className="av2-skeleton" style={{ height: phase === 'looksLoading' ? 120 : 52, borderRadius: 8 }} />
@@ -201,38 +246,96 @@ export default function StudioAiPanel({ ai, campaign, doc }) {
                 Edit brief
               </button>
             </div>
-            {sugs.map((row, i) => {
-              const blocked = !!row.disabledReason;
-              const stateLabel = row.state === 'applied' ? '✓ APPLIED' : row.state === 'kept' ? 'KEPT YOURS' : blocked ? 'UNAVAILABLE' : '';
-              return (
-                <div key={row.path} data-testid={`ai-sug-${row.path}`} style={{ background: 'var(--surface-2, #F7F8FA)', border: `1px solid ${row.state === 'applied' ? '#BFD9C6' : 'var(--line, #E3E6EB)'}`, borderRadius: 9, padding: '10px 11px', opacity: blocked && row.state === 'open' ? 0.75 : 1 }}>
-                  <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 5 }}>
-                    <span style={{ font: mono, color: 'var(--ink-3, #9BA0AB)' }}>
-                      {row.section.toUpperCase()} · {row.label}
+            {rowSections.map(([section, entries]) => (
+              <div key={section} style={{ display: 'flex', flexDirection: 'column', gap: 9 }}>
+                {rowSections.length > 1 ? (
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 2 }}>
+                    <span style={{ font: mono, letterSpacing: '.08em', color: 'var(--ink-3, #9BA0AB)' }}>
+                      {section.toUpperCase()} · {entries.length}
                     </span>
-                    <span style={{ fontSize: 9.5, fontWeight: 600, color: row.state === 'applied' ? '#1F7A46' : 'var(--ink-3)' }}>{stateLabel}</span>
+                    {entries.some(({ row }) => row.state === 'open' && !row.disabledReason) ? (
+                      <button
+                        type="button"
+                        onClick={() => ai.applySection(section)}
+                        style={{ cursor: 'pointer', border: 'none', background: 'none', color: 'var(--accent, #4059C8)', fontSize: 10.5, fontWeight: 600 }}
+                      >
+                        Apply section
+                      </button>
+                    ) : null}
                   </div>
-                  {row.old ? (
-                    <div style={{ fontSize: 11, color: 'var(--ink-3, #9BA0AB)', textDecoration: 'line-through', marginBottom: 3, whiteSpace: 'pre-line' }}>{row.old}</div>
-                  ) : null}
-                  <div style={{ fontSize: 12.5, lineHeight: 1.5, whiteSpace: 'pre-line', marginBottom: 8 }}>{row.value}</div>
-                  {blocked ? (
-                    <div style={{ fontSize: 10.5, color: '#8A5B07', marginBottom: 8 }}>{row.disabledReason}</div>
-                  ) : null}
-                  <div style={{ display: 'flex', gap: 6 }}>
-                    <button type="button" className="av2-btn av2-btn--primary av2-btn--sm" disabled={row.state !== 'open' || blocked} onClick={() => ai.acceptRow(i)}>
-                      Accept
-                    </button>
-                    <button type="button" className="av2-btn av2-btn--ghost av2-btn--sm" disabled={row.state === 'kept'} onClick={() => ai.keepRow(i)}>
-                      Keep mine
-                    </button>
-                    <button type="button" className="av2-btn av2-btn--ghost av2-btn--sm" title="Regenerate this field" onClick={() => ai.regenRow(i)} style={{ marginLeft: 'auto' }}>
-                      ↻
-                    </button>
-                  </div>
+                ) : null}
+                {entries.map(({ row, index }) => {
+                  const blocked = !!row.disabledReason;
+                  const stateLabel = row.state === 'applied' ? '✓ APPLIED' : row.state === 'kept' ? 'KEPT YOURS' : blocked ? 'UNAVAILABLE' : '';
+                  const oldEmpty = Array.isArray(row.old) ? row.old.length === 0 : !row.old;
+                  return (
+                    <div key={row.path} data-testid={`ai-sug-${row.path}`} style={{ background: 'var(--surface-2, #F7F8FA)', border: `1px solid ${row.state === 'applied' ? '#BFD9C6' : 'var(--line, #E3E6EB)'}`, borderRadius: 9, padding: '10px 11px', opacity: blocked && row.state === 'open' ? 0.75 : 1 }}>
+                      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 5 }}>
+                        <span style={{ font: mono, color: 'var(--ink-3, #9BA0AB)' }}>
+                          {row.section.toUpperCase()} · {row.label}
+                        </span>
+                        <span style={{ fontSize: 9.5, fontWeight: 600, color: row.state === 'applied' ? '#1F7A46' : 'var(--ink-3)' }}>{stateLabel}</span>
+                      </div>
+                      {oldEmpty ? null : <ValueLines value={row.old} struck />}
+                      <ValueLines value={row.kind === 'pick' ? displayValue(row) : row.value} />
+                      {blocked ? (
+                        <div style={{ fontSize: 10.5, color: '#8A5B07', marginBottom: 8 }}>{row.disabledReason}</div>
+                      ) : null}
+                      <div style={{ display: 'flex', gap: 6 }}>
+                        <button type="button" className="av2-btn av2-btn--primary av2-btn--sm" disabled={row.state !== 'open' || blocked} onClick={() => ai.acceptRow(index)}>
+                          Accept
+                        </button>
+                        <button type="button" className="av2-btn av2-btn--ghost av2-btn--sm" disabled={row.state === 'kept'} onClick={() => ai.keepRow(index)}>
+                          Keep mine
+                        </button>
+                        {row.kind !== 'pick' ? (
+                          <button type="button" className="av2-btn av2-btn--ghost av2-btn--sm" title="Regenerate this field" onClick={() => ai.regenRow(index)} style={{ marginLeft: 'auto' }}>
+                            ↻
+                          </button>
+                        ) : null}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ))}
+
+            {recs.length > 0 && (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 9 }} data-testid="ai-recs">
+                <div style={{ font: mono, letterSpacing: '.08em', color: 'var(--ink-3, #9BA0AB)', marginTop: 2 }}>
+                  RECOMMENDATIONS — ADVISORY
                 </div>
-              );
-            })}
+                {recs.map((rec, index) => (
+                  <div key={rec.topic} data-testid={`ai-rec-${rec.topic}`} style={{ background: '#FBF8EF', border: '1px dashed #D8C9A2', borderRadius: 9, padding: '10px 11px' }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 5 }}>
+                      <span style={{ font: mono, color: '#8A5B07' }}>{(rec.label || rec.topic).toUpperCase()}</span>
+                      {rec.state === 'applied' ? (
+                        <span style={{ fontSize: 9.5, fontWeight: 600, color: '#1F7A46' }}>✓ APPLIED TO DRAFT</span>
+                      ) : null}
+                    </div>
+                    <div style={{ fontSize: 12, lineHeight: 1.55, marginBottom: rec.suggestedValue ? 4 : 8 }}>{rec.advice}</div>
+                    {rec.suggestedValue ? (
+                      <div style={{ font: mono, color: 'var(--ink-2, #5B616E)', marginBottom: 8 }}>suggested: {rec.suggestedValue}</div>
+                    ) : null}
+                    <div style={{ display: 'flex', gap: 6 }}>
+                      {rec.suggestedValue && rec.state !== 'applied' ? (
+                        <button type="button" className="av2-btn av2-btn--primary av2-btn--sm" onClick={() => ai.applyRec(index)}>
+                          Apply to draft
+                        </button>
+                      ) : null}
+                      <button type="button" className="av2-btn av2-btn--ghost av2-btn--sm" onClick={() => ai.jumpRec(index)}>
+                        Go to control
+                      </button>
+                    </div>
+                  </div>
+                ))}
+                <div style={{ fontSize: 10, color: 'var(--ink-3, #9BA0AB)' }}>
+                  Advisory only — never part of “Apply all”. Applying a switch edits the unsaved draft; publication
+                  still passes the server gate after you save.
+                </div>
+              </div>
+            )}
+
             <div style={{ display: 'flex', gap: 8, position: 'sticky', bottom: 0, background: 'var(--surface, #fff)', padding: '8px 0' }}>
               <button type="button" className="av2-btn av2-btn--primary" style={{ flex: 1, justifyContent: 'center' }} onClick={ai.applyAll}>
                 Apply all remaining

--- a/src/components/studio/StudioAiPanel.jsx
+++ b/src/components/studio/StudioAiPanel.jsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { AI_TONES } from './useStudioAi';
-import { buildLookDoc, lookBlockedReason } from './studioLooks';
+import { buildLookDoc, lookBlockedReason, rowDisabledReason } from './studioLooks';
 import DeviceFrame from './DeviceFrame';
 import CanvasPageSubject from './CanvasPageSubject';
 import { CATEGORY_OPTIONS } from './marketplaceOptions';
@@ -73,15 +73,20 @@ export default function StudioAiPanel({ ai, campaign, doc }) {
 
   // Review rows grouped by section, in order of first appearance (the server
   // already sorts rows by whitelist order, which is section-contiguous).
+  // The RENDERED gate re-derives from the live unsaved doc every render
+  // (Codex #198-5): the row's stored disabledReason is receipt-time only —
+  // an operator enabling the surface (quiz on, image back) must re-enable
+  // Accept without a regen. The hook still re-gates at action time.
   const rowSections = useMemo(() => {
     const map = new Map();
     (sugs || []).forEach((row, index) => {
       const key = row.section || 'Other';
       if (!map.has(key)) map.set(key, []);
-      map.get(key).push({ row, index });
+      const liveReason = row.state === 'open' && doc ? rowDisabledReason(doc, row.path) : row.disabledReason;
+      map.get(key).push({ row, index, liveReason });
     });
     return [...map.entries()];
-  }, [sugs]);
+  }, [sugs, doc]);
 
   if (!ai.open) return null;
 
@@ -253,7 +258,7 @@ export default function StudioAiPanel({ ai, campaign, doc }) {
                     <span style={{ font: mono, letterSpacing: '.08em', color: 'var(--ink-3, #9BA0AB)' }}>
                       {section.toUpperCase()} · {entries.length}
                     </span>
-                    {entries.some(({ row }) => row.state === 'open' && !row.disabledReason) ? (
+                    {entries.some(({ row, liveReason }) => row.state === 'open' && !liveReason) ? (
                       <button
                         type="button"
                         onClick={() => ai.applySection(section)}
@@ -264,8 +269,8 @@ export default function StudioAiPanel({ ai, campaign, doc }) {
                     ) : null}
                   </div>
                 ) : null}
-                {entries.map(({ row, index }) => {
-                  const blocked = !!row.disabledReason;
+                {entries.map(({ row, index, liveReason }) => {
+                  const blocked = !!liveReason;
                   const stateLabel = row.state === 'applied' ? '✓ APPLIED' : row.state === 'kept' ? 'KEPT YOURS' : blocked ? 'UNAVAILABLE' : '';
                   const oldEmpty = Array.isArray(row.old) ? row.old.length === 0 : !row.old;
                   return (
@@ -279,7 +284,7 @@ export default function StudioAiPanel({ ai, campaign, doc }) {
                       {oldEmpty ? null : <ValueLines value={row.old} struck />}
                       <ValueLines value={row.kind === 'pick' ? displayValue(row) : row.value} />
                       {blocked ? (
-                        <div style={{ fontSize: 10.5, color: '#8A5B07', marginBottom: 8 }}>{row.disabledReason}</div>
+                        <div style={{ fontSize: 10.5, color: '#8A5B07', marginBottom: 8 }}>{liveReason}</div>
                       ) : null}
                       <div style={{ display: 'flex', gap: 6 }}>
                         <button type="button" className="av2-btn av2-btn--primary av2-btn--sm" disabled={row.state !== 'open' || blocked} onClick={() => ai.acceptRow(index)}>
@@ -314,6 +319,14 @@ export default function StudioAiPanel({ ai, campaign, doc }) {
                       ) : null}
                     </div>
                     <div style={{ fontSize: 12, lineHeight: 1.55, marginBottom: rec.suggestedValue ? 4 : 8 }}>{rec.advice}</div>
+                    {rec.topic === 'customerHost' ? (
+                      // Trusted, server-independent blast-radius warning (Codex
+                      // #197-3) — model advice can never omit it away.
+                      <div style={{ fontSize: 10.5, lineHeight: 1.5, color: '#8A5B07', marginBottom: 6 }}>
+                        Switching the domain changes page chrome, pixels, regulatory copy and the confirmation-email
+                        brand — and the drafted copy was written for the current domain's voice.
+                      </div>
+                    ) : null}
                     {rec.suggestedValue ? (
                       <div style={{ font: mono, color: 'var(--ink-2, #5B616E)', marginBottom: 8 }}>suggested: {rec.suggestedValue}</div>
                     ) : null}

--- a/src/components/studio/__tests__/StudioAiPanel.test.jsx
+++ b/src/components/studio/__tests__/StudioAiPanel.test.jsx
@@ -267,6 +267,37 @@ describe('StudioAiPanel — full-coverage review (sections, picks, lists, recomm
     expect(screen.getByText('✓ APPLIED TO DRAFT')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Apply to draft' })).toBeNull();
   });
+
+  it('customerHost cards always carry the trusted blast-radius warning (Codex #197-3)', () => {
+    const hostRec = [{ topic: 'customerHost', label: 'Customer domain', advice: 'Use redeem.sg.', suggestedValue: 'redeem', state: 'open' }];
+    render(<StudioAiPanel ai={fakeAi({ phase: 'ready', sugs: [PAGE_ROW], recs: hostRec })} />);
+    expect(screen.getByText(/chrome, pixels, regulatory copy and the confirmation-email/i)).toBeInTheDocument();
+    expect(screen.getByText(/written for the current domain's voice/i)).toBeInTheDocument();
+  });
+
+  it('a receipt-time gated row re-enables from the LIVE doc (Codex #198-5)', () => {
+    const gatedQuizRow = {
+      path: 'quiz.intro.headline',
+      label: 'Quiz intro headline',
+      section: 'Quiz',
+      value: 'AI quiz intro',
+      old: '',
+      state: 'open',
+      disabledReason: 'The quiz is disabled or has no questions', // receipt-time
+    };
+    const quizOnDoc = {
+      ...BASE_DOC,
+      quiz: { enabled: true, steps: [{ questions: [{ id: 'q1' }] }] },
+    };
+    // surface enabled since receipt → Accept must be live again
+    render(<StudioAiPanel ai={fakeAi({ phase: 'ready', sugs: [gatedQuizRow] })} campaign={{ id: 'c1' }} doc={quizOnDoc} />);
+    expect(screen.getByRole('button', { name: 'Accept' })).toBeEnabled();
+    expect(screen.queryByText('The quiz is disabled or has no questions')).toBeNull();
+
+    // still off → stays blocked
+    render(<StudioAiPanel ai={fakeAi({ phase: 'ready', sugs: [gatedQuizRow] })} campaign={{ id: 'c1' }} doc={BASE_DOC} />);
+    expect(screen.getAllByRole('button', { name: 'Accept' })[1]).toBeDisabled();
+  });
 });
 
 describe('StudioAiPanel — looks gallery + proposal (CO-1)', () => {

--- a/src/components/studio/__tests__/StudioAiPanel.test.jsx
+++ b/src/components/studio/__tests__/StudioAiPanel.test.jsx
@@ -33,6 +33,7 @@ function fakeAi(overrides = {}) {
     brief: { topic: '', audience: '', objective: '', mustInclude: '', tone: 'Friendly' },
     setBrief: vi.fn(),
     sugs: [],
+    recs: [],
     scope: null,
     looks: [],
     proposal: null,
@@ -47,6 +48,9 @@ function fakeAi(overrides = {}) {
     keepRow: vi.fn(),
     regenRow: vi.fn(),
     applyAll: vi.fn(),
+    applySection: vi.fn(),
+    applyRec: vi.fn(),
+    jumpRec: vi.fn(),
     discard: vi.fn(),
     backToBrief: vi.fn(),
     generateLooks: vi.fn(),
@@ -98,6 +102,10 @@ describe('StudioAiPanel', () => {
     const ai = fakeAi();
     render(<StudioAiPanel ai={ai} />);
     expect(screen.getByRole('button', { name: 'Generate suggestions' })).toBeDisabled();
+    // full-coverage amendment: the first tab is "Fill everything" with the
+    // everything explainer (recommendations never auto-apply)
+    expect(screen.getByRole('button', { name: 'Fill everything' })).toBeInTheDocument();
+    expect(screen.getByText(/publication switches are only ever flipped by you/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Design the whole page' }));
     expect(ai.setMode).toHaveBeenCalledWith('full');
     fireEvent.click(screen.getByRole('button', { name: 'Friendly' }));
@@ -110,6 +118,9 @@ describe('StudioAiPanel', () => {
       brief: { topic: 'Voucher giveaway', audience: '', objective: '', mustInclude: '', tone: 'Friendly' },
     });
     render(<StudioAiPanel ai={ai} />);
+    // amended disclaimer: distribution copy now belongs to the other tab, but
+    // looks still never touch switches/fields/verification
+    expect(screen.getByText(/publication switches are\s+never touched/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Generate looks' }));
     expect(ai.generateLooks).toHaveBeenCalled();
     expect(ai.generate).not.toHaveBeenCalled();
@@ -170,6 +181,91 @@ describe('StudioAiPanel', () => {
   it('budget meter renders the estimate', () => {
     render(<StudioAiPanel ai={fakeAi({ budget: { used: 3, max: 10 } })} />);
     expect(screen.getByText(/3\/10 this minute/)).toBeInTheDocument();
+  });
+});
+
+describe('StudioAiPanel — full-coverage review (sections, picks, lists, recommendations)', () => {
+  const PAGE_ROW = { ...ROW, section: 'Page' };
+  const PICK_ROW = {
+    path: 'distribution.marketplace.category',
+    label: 'Category',
+    section: 'Distribution',
+    value: 'family_lifestyle',
+    old: '',
+    state: 'open',
+    disabledReason: null,
+    kind: 'pick',
+  };
+  const LIST_ROW = {
+    path: 'distribution.marketplace.inclusions',
+    label: 'Inclusions',
+    section: 'Distribution',
+    value: ['1 night stay', 'Daily photo updates'],
+    old: [],
+    state: 'open',
+    disabledReason: null,
+    kind: 'list',
+  };
+  const RECS = [
+    { topic: 'listMarketplace', label: 'Marketplace listing', advice: 'Flip it on once the slug is set.', suggestedValue: 'on', state: 'open' },
+    { topic: 'formGates', label: 'Eligibility gates', advice: 'Consider the SG/PR gate.', suggestedValue: null, state: 'open' },
+  ];
+
+  it('groups rows by section with per-section apply; single-section lists render no headers', () => {
+    const ai = fakeAi({ phase: 'ready', sugs: [PAGE_ROW, PICK_ROW, LIST_ROW] });
+    render(<StudioAiPanel ai={ai} />);
+
+    expect(screen.getByText('PAGE · 1')).toBeInTheDocument();
+    expect(screen.getByText('DISTRIBUTION · 2')).toBeInTheDocument();
+    const sectionApplies = screen.getAllByRole('button', { name: 'Apply section' });
+    expect(sectionApplies).toHaveLength(2);
+    fireEvent.click(sectionApplies[1]);
+    expect(ai.applySection).toHaveBeenCalledWith('Distribution');
+
+    const { container } = render(<StudioAiPanel ai={fakeAi({ phase: 'ready', sugs: [PAGE_ROW] })} />);
+    expect(container.textContent).not.toContain('PAGE · 1');
+  });
+
+  it('pick rows show the human category label and have no regenerate button', () => {
+    render(<StudioAiPanel ai={fakeAi({ phase: 'ready', sugs: [PICK_ROW] })} />);
+    expect(screen.getByText('Family & Lifestyle')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '↻' })).toBeNull();
+  });
+
+  it('list rows render bullets; array old renders struck bullets', () => {
+    const withOld = { ...LIST_ROW, old: ['Old inclusion'] };
+    render(<StudioAiPanel ai={fakeAi({ phase: 'ready', sugs: [withOld] })} />);
+    expect(screen.getByText(/• 1 night stay/)).toBeInTheDocument();
+    expect(screen.getByText(/• Old inclusion/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '↻' })).toBeInTheDocument(); // lists DO regen
+  });
+
+  it('recommendation cards are advisory: Apply-to-draft only with a suggestedValue, Go-to-control always', () => {
+    const ai = fakeAi({ phase: 'ready', sugs: [PAGE_ROW], recs: RECS });
+    render(<StudioAiPanel ai={ai} />);
+
+    expect(screen.getByTestId('ai-recs')).toBeInTheDocument();
+    expect(screen.getByText('RECOMMENDATIONS — ADVISORY')).toBeInTheDocument();
+    expect(screen.getByText(/Flip it on once the slug is set/)).toBeInTheDocument();
+    expect(screen.getByText('suggested: on')).toBeInTheDocument();
+
+    // one Apply (the toggle rec) — the advice-only card offers none
+    const applies = screen.getAllByRole('button', { name: 'Apply to draft' });
+    expect(applies).toHaveLength(1);
+    fireEvent.click(applies[0]);
+    expect(ai.applyRec).toHaveBeenCalledWith(0);
+
+    const jumps = screen.getAllByRole('button', { name: 'Go to control' });
+    expect(jumps).toHaveLength(2);
+    fireEvent.click(jumps[1]);
+    expect(ai.jumpRec).toHaveBeenCalledWith(1);
+  });
+
+  it('an applied recommendation shows the applied chip and loses its Apply button', () => {
+    const applied = [{ ...RECS[0], state: 'applied' }];
+    render(<StudioAiPanel ai={fakeAi({ phase: 'ready', sugs: [PAGE_ROW], recs: applied })} />);
+    expect(screen.getByText('✓ APPLIED TO DRAFT')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Apply to draft' })).toBeNull();
   });
 });
 

--- a/src/components/studio/__tests__/studioLooks.test.js
+++ b/src/components/studio/__tests__/studioLooks.test.js
@@ -23,7 +23,10 @@ const LOOK = {
   media: { kind: 'image', note: 'Warm hawker-centre scene' },
   draft: [
     { path: 'content.headline', label: 'Form headline', section: 'page', value: 'New headline' },
-    { path: 'distribution.featuredDrop.title', label: 'Drop title', section: 'distribution', value: 'Drop!' },
+    // The gated example: quiz copy while the quiz is off. (Drop/marketplace
+    // copy is UNGATED since the full-coverage amendment, and look drafts are
+    // page-scoped server-side anyway.)
+    { path: 'quiz.intro.headline', label: 'Quiz intro headline', section: 'quiz', value: 'Quiz me!' },
   ],
 };
 
@@ -42,10 +45,10 @@ describe('buildLookDoc', () => {
     expect(doc.theme.font).toBe('schibsted'); // look omitted font → base survives
   });
 
-  it('applies copy rows re-gated against the doc AS BUILT (drop row skipped while the drop is off)', () => {
+  it('applies copy rows re-gated against the doc AS BUILT (quiz row skipped while the quiz is off)', () => {
     const doc = buildLookDoc(base(), LOOK, {});
     expect(doc.content.headline).toBe('New headline');
-    expect(doc.distribution.featuredDrop.title).toBeUndefined();
+    expect(doc.quiz?.intro?.headline).toBeUndefined();
   });
 
   it('express trust line lands only when the look makes express the EFFECTIVE template (F4)', () => {
@@ -93,7 +96,7 @@ describe('adoptedCopyRows', () => {
     const prev = base();
     const lookDoc = buildLookDoc(prev, LOOK, {});
     const rows = adoptedCopyRows(LOOK, prev, lookDoc);
-    expect(rows).toHaveLength(1); // the gated drop-title row never landed
+    expect(rows).toHaveLength(1); // the gated quiz-intro row never landed
     expect(rows[0]).toMatchObject({
       path: 'content.headline',
       value: 'New headline',
@@ -115,9 +118,11 @@ describe('lookBlockedReason', () => {
 });
 
 describe('rowDisabledReason — moved home (re-exported via studioAiApi)', () => {
-  it('still gates the five conditional paths', () => {
+  it('gates the conditional paths; distribution copy is ungated (full-coverage amendment)', () => {
     expect(rowDisabledReason(base(), 'content.headline')).toBeNull();
     expect(rowDisabledReason(base(), 'content.heroCtaLabel')).toMatch(/no hero media/i);
-    expect(rowDisabledReason(base(), 'distribution.featuredDrop.title')).toMatch(/featured drop/i);
+    expect(rowDisabledReason(base(), 'quiz.intro.headline')).toMatch(/quiz is disabled/i);
+    expect(rowDisabledReason(base(), 'distribution.featuredDrop.title')).toBeNull();
+    expect(rowDisabledReason(base(), 'distribution.marketplace.valueLine')).toBeNull();
   });
 });

--- a/src/components/studio/__tests__/useStudioAi.test.jsx
+++ b/src/components/studio/__tests__/useStudioAi.test.jsx
@@ -296,7 +296,7 @@ describe('useStudioAi — full-coverage rows (picks + inclusions) and recommenda
     expect(result.current.ai.recs[0].state).toBe('open');
   });
 
-  it('accept writes picks (enum) and lists (array); keep-mine restores the array old', async () => {
+  it('accept writes picks (enum) and lists (array); keep-mine on an ABSENT original restores absence, not \'\'/[] (Codex #198-1)', async () => {
     const { result } = renderAi();
     await generateReady(result, okFull());
 
@@ -307,8 +307,28 @@ describe('useStudioAi — full-coverage rows (picks + inclusions) and recommenda
     expect(result.current.docApi.doc.distribution.marketplace.inclusions).toEqual(['1 night stay', 'Daily photo updates']);
 
     act(() => result.current.ai.keepRow(3));
-    expect(result.current.docApi.doc.distribution.marketplace.inclusions).toEqual([]);
+    act(() => result.current.ai.keepRow(2));
+    // both fields were absent before accept — restore must NOT leave ''/[]
+    expect(result.current.docApi.doc.distribution.marketplace.inclusions).toBeUndefined();
+    expect(result.current.docApi.doc.distribution.marketplace.category).toBeUndefined();
     expect(result.current.ai.sugs[3].state).toBe('kept');
+    // and the dirty flag self-corrects: the JSON doc equals baseline again
+    expect(JSON.stringify(result.current.docApi.doc)).not.toContain('"category"');
+    expect(result.current.docApi.dirty).toBe(false);
+  });
+
+  it('keep-mine still restores a PRESENT original verbatim', async () => {
+    const campaign = v2Campaign('c1', {
+      distribution: { host: 'redeem', featuredDrop: { enabled: false }, marketplace: { listed: false, category: 'wellness' } },
+    });
+    const { result } = renderAi(campaign);
+    await generateReady(result, okFull());
+
+    act(() => result.current.ai.acceptRow(2));
+    expect(result.current.docApi.doc.distribution.marketplace.category).toBe('family_lifestyle');
+    act(() => result.current.ai.keepRow(2));
+    expect(result.current.docApi.doc.distribution.marketplace.category).toBe('wellness');
+    expect(result.current.docApi.dirty).toBe(false);
   });
 
   it('apply-all applies rows but NEVER recommendations (advisory contract)', async () => {
@@ -333,7 +353,7 @@ describe('useStudioAi — full-coverage rows (picks + inclusions) and recommenda
   });
 
   it('applyRec: toggles write the unsaved doc, slug prefills via onSlugPrefill, advice-only no-ops', async () => {
-    const onSlugPrefill = vi.fn();
+    const onSlugPrefill = vi.fn(() => true);
     const { result } = renderAi(v2Campaign(), undefined, { onSlugPrefill });
     await generateReady(result, okFull());
 
@@ -347,6 +367,34 @@ describe('useStudioAi — full-coverage rows (picks + inclusions) and recommenda
 
     act(() => result.current.ai.applyRec(2)); // advice-only (null suggestedValue)
     expect(result.current.ai.recs[2].state).toBe('open');
+  });
+
+  it('a VETOED slug prefill (callback returns false) leaves the card open (Codex #198-3)', async () => {
+    const onSlugPrefill = vi.fn(() => false); // page-side re-check: slug exists/locked now
+    const { result } = renderAi(v2Campaign(), undefined, { onSlugPrefill });
+    await generateReady(result, okFull());
+
+    act(() => result.current.ai.applyRec(1));
+    expect(onSlugPrefill).toHaveBeenCalledWith('pet-hotel-trial');
+    expect(result.current.ai.recs[1].state).toBe('open'); // not marked applied
+  });
+
+  it('entering looks mode invalidates copy-mode recommendation cards (Codex #198-4)', async () => {
+    const { result } = renderAi();
+    await generateReady(result, okFull());
+    expect(result.current.ai.recs).toHaveLength(3);
+
+    apiClient.post.mockResolvedValueOnce({ success: true, data: { proposals: [LOOK] } });
+    await act(async () => {
+      await result.current.ai.generateLooks();
+    });
+    expect(result.current.ai.recs).toEqual([]);
+
+    // and an adopted look's ready view carries NO stale advisory cards
+    act(() => result.current.ai.pickLook(0));
+    act(() => result.current.ai.adoptLook());
+    expect(result.current.ai.phase).toBe('ready');
+    expect(result.current.ai.recs).toEqual([]);
   });
 
   it('jumpRec deep-links the mapped rail section', async () => {

--- a/src/components/studio/__tests__/useStudioAi.test.jsx
+++ b/src/components/studio/__tests__/useStudioAi.test.jsx
@@ -10,9 +10,9 @@ import useStudioAi from '../useStudioAi';
 import { rowDisabledReason, requestCopyDraft } from '../studioAiApi';
 
 /**
- * Studio AI copy-mode state machine (PR 4 CP2) — composed with the REAL
- * useStudioDoc so accept/keep-mine/regen semantics run against a live doc,
- * with only the HTTP layer mocked.
+ * Studio AI copy-mode state machine (PR 4 CP2 + the full-coverage amendment)
+ * — composed with the REAL useStudioDoc so accept/keep-mine/regen semantics
+ * run against a live doc, with only the HTTP layer mocked.
  */
 
 function v2Campaign(id = 'c1', overrides = {}) {
@@ -38,14 +38,19 @@ function v2Campaign(id = 'c1', overrides = {}) {
   };
 }
 
+const LIVE_QUIZ = { enabled: true, steps: [{ id: 's1', questions: [{ id: 'q1', prompt: 'P', options: [] }] }] };
+
+// Row 0 is unconditional; row 1 (quiz intro) is gated while the quiz is off —
+// the drop-title row that used to play this part is UNGATED since the
+// full-coverage amendment.
 const DRAFT = [
-  { path: 'content.headline', label: 'Form headline', section: 'page', value: 'Fresh AI headline', limit: 80 },
-  { path: 'distribution.featuredDrop.title', label: 'Drop title', section: 'distribution', value: 'AI drop title', limit: 60 },
+  { path: 'content.headline', label: 'Form headline', section: 'Page', value: 'Fresh AI headline', limit: 80 },
+  { path: 'quiz.intro.headline', label: 'Quiz intro headline', section: 'Quiz', value: 'AI quiz intro', limit: 80 },
 ];
 
 const ok = (draft = DRAFT) => ({ success: true, data: { draft } });
 
-function useHarness(campaign, onPickLook) {
+function useHarness(campaign, onPickLook, extra = {}) {
   const docApi = useStudioDoc(campaign);
   const ai = useStudioAi({
     campaign,
@@ -53,18 +58,19 @@ function useHarness(campaign, onPickLook) {
     setPath: docApi.setPath,
     replaceDoc: docApi.replaceDoc,
     onPickLook,
+    ...extra,
   });
   return { docApi, ai };
 }
 
-function renderAi(campaign = v2Campaign(), onPickLook) {
-  return renderHook(({ c }) => useHarness(c, onPickLook), { initialProps: { c: campaign } });
+function renderAi(campaign = v2Campaign(), onPickLook, extra) {
+  return renderHook(({ c }) => useHarness(c, onPickLook, extra), { initialProps: { c: campaign } });
 }
 
 const FULL_BRIEF = { topic: 'FairPrice voucher giveaway', audience: '', objective: '', mustInclude: '', tone: 'Friendly' };
 
-async function generateReady(result, draft = DRAFT) {
-  apiClient.post.mockResolvedValueOnce(ok(draft));
+async function generateReady(result, payload = ok(DRAFT)) {
+  apiClient.post.mockResolvedValueOnce(payload);
   act(() => result.current.ai.setBrief(FULL_BRIEF));
   await act(async () => {
     await result.current.ai.generate();
@@ -93,10 +99,10 @@ describe('useStudioAi — generate (copy mode)', () => {
     await generateReady(result);
 
     expect(result.current.ai.phase).toBe('ready');
-    const [headline, dropTitle] = result.current.ai.sugs;
-    expect(headline).toMatchObject({ state: 'open', old: 'Old headline', disabledReason: null });
-    // featuredDrop is OFF in the doc → the row arrives visibly gated
-    expect(dropTitle.disabledReason).toMatch(/featured drop is off/i);
+    const [headline, quizIntro] = result.current.ai.sugs;
+    expect(headline).toMatchObject({ state: 'open', old: 'Old headline', disabledReason: null, kind: 'copy' });
+    // the quiz is OFF in the doc → the row arrives visibly gated
+    expect(quizIntro.disabledReason).toMatch(/quiz is disabled/i);
 
     const [, body] = apiClient.post.mock.calls[0];
     expect(body).toMatchObject({ campaignId: 'c1', templateId: 'editorial', mode: 'copy', scope: null, regen: 0 });
@@ -133,7 +139,7 @@ describe('useStudioAi — generate (copy mode)', () => {
     await generateReady(result);
 
     act(() => result.current.ai.acceptRow(1));
-    expect(result.current.docApi.doc.distribution.featuredDrop.title).toBeUndefined();
+    expect(result.current.docApi.doc.quiz?.intro?.headline).toBeUndefined();
     expect(result.current.ai.sugs[1].state).toBe('open');
     expect(result.current.ai.sugs[1].disabledReason).toBeTruthy();
   });
@@ -142,9 +148,9 @@ describe('useStudioAi — generate (copy mode)', () => {
     const { result } = renderAi();
     await generateReady(result);
 
-    act(() => result.current.docApi.setPath('distribution.featuredDrop.enabled', true));
+    act(() => result.current.docApi.setPath('quiz', LIVE_QUIZ));
     act(() => result.current.ai.acceptRow(1));
-    expect(result.current.docApi.doc.distribution.featuredDrop.title).toBe('AI drop title');
+    expect(result.current.docApi.doc.quiz.intro.headline).toBe('AI quiz intro');
     expect(result.current.ai.sugs[1].state).toBe('applied');
   });
 
@@ -156,7 +162,7 @@ describe('useStudioAi — generate (copy mode)', () => {
     act(() => result.current.ai.applyAll());
 
     expect(result.current.docApi.doc.content.headline).toBe('Old headline');
-    expect(result.current.docApi.doc.distribution.featuredDrop.title).toBeUndefined(); // gated
+    expect(result.current.docApi.doc.quiz?.intro?.headline).toBeUndefined(); // gated
     expect(result.current.ai.sugs[1].disabledReason).toBeTruthy();
   });
 
@@ -195,22 +201,22 @@ describe('useStudioAi — generate (copy mode)', () => {
     const { result } = renderAi();
     await generateReady(result);
 
-    // Enable the drop, accept its title, then disable the drop again — the
-    // stored title value remains, so the applied-untouched branch would have
+    // Enable the quiz, accept its intro, then disable the quiz again — the
+    // stored intro value remains, so the applied-untouched branch would have
     // silently overwritten it without the re-gate.
-    act(() => result.current.docApi.setPath('distribution.featuredDrop.enabled', true));
+    act(() => result.current.docApi.setPath('quiz', LIVE_QUIZ));
     act(() => result.current.ai.acceptRow(1));
-    expect(result.current.docApi.doc.distribution.featuredDrop.title).toBe('AI drop title');
-    act(() => result.current.docApi.setPath('distribution.featuredDrop.enabled', false));
+    expect(result.current.docApi.doc.quiz.intro.headline).toBe('AI quiz intro');
+    act(() => result.current.docApi.setPath('quiz.enabled', false));
 
-    apiClient.post.mockResolvedValueOnce(ok([{ ...DRAFT[1], value: 'Regenerated drop title' }]));
+    apiClient.post.mockResolvedValueOnce(ok([{ ...DRAFT[1], value: 'Regenerated intro' }]));
     await act(async () => {
       await result.current.ai.regenRow(1);
     });
 
-    expect(result.current.docApi.doc.distribution.featuredDrop.title).toBe('AI drop title'); // untouched
-    expect(result.current.ai.sugs[1]).toMatchObject({ state: 'open', value: 'Regenerated drop title' });
-    expect(result.current.ai.sugs[1].disabledReason).toMatch(/featured drop is off/i);
+    expect(result.current.docApi.doc.quiz.intro.headline).toBe('AI quiz intro'); // untouched
+    expect(result.current.ai.sugs[1]).toMatchObject({ state: 'open', value: 'Regenerated intro' });
+    expect(result.current.ai.sugs[1].disabledReason).toMatch(/quiz is disabled/i);
   });
 
   it('newest request wins: a second generate aborts the first, whose late response never lands (Codex diff #2)', async () => {
@@ -244,6 +250,175 @@ describe('useStudioAi — generate (copy mode)', () => {
       resolvers[0]({ success: true, data: { draft: [{ ...DRAFT[0], value: 'From request 1' }] } });
     });
     expect(result.current.ai.sugs[0].value).toBe('From request 2');
+  });
+});
+
+// ─────────────── full-coverage rows + advisory recommendations ───────────────
+
+const FULL_DATA = {
+  draft: [
+    { path: 'content.headline', label: 'Headline', section: 'Page', value: 'Fresh AI headline' },
+    { path: 'distribution.marketplace.title', label: 'Consumer title', section: 'Distribution', value: 'Free Pet Hotel Trial' },
+  ],
+  picks: [
+    { path: 'distribution.marketplace.category', label: 'Category', section: 'Distribution', value: 'family_lifestyle' },
+  ],
+  inclusions: {
+    path: 'distribution.marketplace.inclusions',
+    label: 'Inclusions',
+    section: 'Distribution',
+    values: ['1 night stay', 'Daily photo updates'],
+  },
+  recommendations: [
+    { topic: 'listMarketplace', label: 'Marketplace listing', advice: 'Flip the listing on once the slug is set.', suggestedValue: 'on' },
+    { topic: 'slug', label: 'URL slug', advice: 'A short slug helps QR and sharing.', suggestedValue: 'pet-hotel-trial' },
+    { topic: 'formGates', label: 'Eligibility gates', advice: 'Consider the SG/PR gate for lead quality.', suggestedValue: null },
+  ],
+};
+
+const okFull = () => ({ success: true, data: JSON.parse(JSON.stringify(FULL_DATA)) });
+
+describe('useStudioAi — full-coverage rows (picks + inclusions) and recommendations', () => {
+  it('merges draft + picks + inclusions into ONE typed review stream; distribution copy is UNGATED with both switches off', async () => {
+    const { result } = renderAi();
+    await generateReady(result, okFull());
+
+    const rows = result.current.ai.sugs;
+    expect(rows.map((r) => r.kind)).toEqual(['copy', 'copy', 'pick', 'list']);
+    const mkTitle = rows[1];
+    expect(mkTitle.disabledReason).toBeNull(); // no publication-switch gate any more
+    const pick = rows[2];
+    expect(pick).toMatchObject({ path: 'distribution.marketplace.category', value: 'family_lifestyle', state: 'open' });
+    const list = rows[3];
+    expect(list.value).toEqual(['1 night stay', 'Daily photo updates']);
+    expect(list.old).toEqual([]); // array-kind old from the unset doc
+    expect(result.current.ai.recs).toHaveLength(3);
+    expect(result.current.ai.recs[0].state).toBe('open');
+  });
+
+  it('accept writes picks (enum) and lists (array); keep-mine restores the array old', async () => {
+    const { result } = renderAi();
+    await generateReady(result, okFull());
+
+    act(() => result.current.ai.acceptRow(2));
+    expect(result.current.docApi.doc.distribution.marketplace.category).toBe('family_lifestyle');
+
+    act(() => result.current.ai.acceptRow(3));
+    expect(result.current.docApi.doc.distribution.marketplace.inclusions).toEqual(['1 night stay', 'Daily photo updates']);
+
+    act(() => result.current.ai.keepRow(3));
+    expect(result.current.docApi.doc.distribution.marketplace.inclusions).toEqual([]);
+    expect(result.current.ai.sugs[3].state).toBe('kept');
+  });
+
+  it('apply-all applies rows but NEVER recommendations (advisory contract)', async () => {
+    const { result } = renderAi();
+    await generateReady(result, okFull());
+
+    act(() => result.current.ai.applyAll());
+    expect(result.current.docApi.doc.distribution.marketplace.category).toBe('family_lifestyle');
+    expect(result.current.docApi.doc.distribution.marketplace.listed).toBe(false); // the rec's toggle untouched
+    expect(result.current.ai.recs.every((r) => r.state === 'open')).toBe(true);
+  });
+
+  it('applySection applies only that section, leaving the rest open', async () => {
+    const { result } = renderAi();
+    await generateReady(result, okFull());
+
+    act(() => result.current.ai.applySection('Distribution'));
+    expect(result.current.docApi.doc.content.headline).toBe('Old headline'); // Page row untouched
+    expect(result.current.ai.sugs[0].state).toBe('open');
+    expect(result.current.docApi.doc.distribution.marketplace.title).toBe('Free Pet Hotel Trial');
+    expect(result.current.ai.sugs[2].state).toBe('applied');
+  });
+
+  it('applyRec: toggles write the unsaved doc, slug prefills via onSlugPrefill, advice-only no-ops', async () => {
+    const onSlugPrefill = vi.fn();
+    const { result } = renderAi(v2Campaign(), undefined, { onSlugPrefill });
+    await generateReady(result, okFull());
+
+    act(() => result.current.ai.applyRec(0));
+    expect(result.current.docApi.doc.distribution.marketplace.listed).toBe(true);
+    expect(result.current.ai.recs[0].state).toBe('applied');
+
+    act(() => result.current.ai.applyRec(1));
+    expect(onSlugPrefill).toHaveBeenCalledWith('pet-hotel-trial');
+    expect(result.current.ai.recs[1].state).toBe('applied');
+
+    act(() => result.current.ai.applyRec(2)); // advice-only (null suggestedValue)
+    expect(result.current.ai.recs[2].state).toBe('open');
+  });
+
+  it('jumpRec deep-links the mapped rail section', async () => {
+    const onJumpSection = vi.fn();
+    const { result } = renderAi(v2Campaign(), undefined, { onJumpSection });
+    await generateReady(result, okFull());
+
+    act(() => result.current.ai.jumpRec(0));
+    expect(onJumpSection).toHaveBeenLastCalledWith('dist');
+    act(() => result.current.ai.jumpRec(2));
+    expect(onJumpSection).toHaveBeenLastCalledWith('form');
+  });
+
+  it('pick rows have no regen (no provider call)', async () => {
+    const { result } = renderAi();
+    await generateReady(result, okFull());
+    const calls = apiClient.post.mock.calls.length;
+    await act(async () => {
+      await result.current.ai.regenRow(2);
+    });
+    expect(apiClient.post.mock.calls.length).toBe(calls);
+  });
+
+  it('regen of the inclusions row swaps the untouched applied array in place', async () => {
+    const { result } = renderAi();
+    await generateReady(result, okFull());
+    act(() => result.current.ai.acceptRow(3));
+
+    apiClient.post.mockResolvedValueOnce({
+      success: true,
+      data: {
+        draft: [],
+        picks: [],
+        inclusions: { ...FULL_DATA.inclusions, values: ['Fresh towels', 'Play area access'] },
+        recommendations: [],
+      },
+    });
+    await act(async () => {
+      await result.current.ai.regenRow(3);
+    });
+
+    expect(result.current.docApi.doc.distribution.marketplace.inclusions).toEqual(['Fresh towels', 'Play area access']);
+    expect(result.current.ai.sugs[3]).toMatchObject({ state: 'applied' });
+    const [, body] = apiClient.post.mock.calls[1];
+    expect(body).toMatchObject({ scope: 'distribution.marketplace.inclusions', regen: 1 });
+  });
+
+  it('a scoped per-field ✦ clears stale recommendation cards; discard clears both', async () => {
+    const { result } = renderAi();
+    await generateReady(result, okFull());
+    expect(result.current.ai.recs).toHaveLength(3);
+
+    apiClient.post.mockResolvedValueOnce(ok([DRAFT[0]]));
+    await act(async () => {
+      await result.current.ai.suggestField('content.headline', 'Form headline');
+    });
+    expect(result.current.ai.recs).toEqual([]);
+
+    await generateReady(result, okFull());
+    act(() => result.current.ai.discard());
+    expect(result.current.ai.sugs).toEqual([]);
+    expect(result.current.ai.recs).toEqual([]);
+  });
+
+  it('campaign switch clears recommendations with everything else (F10)', async () => {
+    const { result, rerender } = renderAi();
+    await generateReady(result, okFull());
+    expect(result.current.ai.recs).toHaveLength(3);
+
+    rerender({ c: v2Campaign('c2') });
+    expect(result.current.ai.recs).toEqual([]);
+    expect(result.current.ai.phase).toBe('brief');
   });
 });
 
@@ -559,25 +734,35 @@ describe('useStudioAi — full mode (CO-1 looks)', () => {
 
 describe('studioAiApi — rowDisabledReason (the conditional whitelist vs the unsaved doc)', () => {
   const base = v2Campaign().design_config;
-  const withQuiz = (enabled, questions) => ({
+  const withQuiz = (enabled, questions, scoring = undefined) => ({
     ...base,
-    quiz: { enabled, steps: questions > 0 ? [{ questions: Array.from({ length: questions }, (_, i) => ({ id: `q${i}` })) }] : [] },
+    quiz: {
+      enabled,
+      steps: questions > 0 ? [{ questions: Array.from({ length: questions }, (_, i) => ({ id: `q${i}` })) }] : [],
+      ...(scoring ? { scoring } : {}),
+    },
   });
 
   it.each([
     ['content.headline', base, null],
     ['content.heroCtaLabel', base, /no hero media/i],
     ['content.heroCtaLabel', { ...base, content: { ...base.content, media: { kind: 'image', src: 'x.jpg' } } }, null],
+    ['content.media.alt', base, /no hero image/i],
+    ['content.media.alt', { ...base, content: { ...base.content, media: { kind: 'video', src: 'x.mp4' } } }, /no hero image/i],
+    ['content.media.alt', { ...base, content: { ...base.content, media: { kind: 'image', src: 'x.jpg' } } }, null],
     ['quiz.intro.headline', base, /quiz is disabled/i],
     ['quiz.intro.headline', withQuiz(true, 0), /quiz is disabled/i],
     ['quiz.intro.ctaLabel', withQuiz(true, 2), null],
-    ['distribution.featuredDrop.title', base, /featured drop is off/i],
-    ['distribution.marketplace.valueLine', base, /marketplace listing is off/i],
-    [
-      'distribution.marketplace.valueLine',
-      { ...base, distribution: { ...base.distribution, marketplace: { listed: true } } },
-      null,
-    ],
+    ['quiz.reveal.gapTemplate', base, /quiz is disabled/i],
+    ['quiz.reveal.valueExchange', withQuiz(true, 2), null],
+    ['quiz.scoring.readiness.label', withQuiz(true, 2), /readiness meter is off/i],
+    ['quiz.scoring.readiness.label', withQuiz(true, 2, { readiness: { enabled: true } }), null],
+    // Full-coverage amendment: distribution copy has NO publication-switch gate
+    ['distribution.featuredDrop.title', base, null],
+    ['distribution.featuredDrop.valueLabel', base, null],
+    ['distribution.marketplace.title', base, null],
+    ['distribution.marketplace.valueLine', base, null],
+    ['distribution.marketplace.inclusions', base, null],
     ['template.params.express.trustLine', base, /express template/i],
     ['template.params.express.trustLine', { ...base, template: { id: 'express', params: {} } }, null],
   ])('%s', (path, doc, expected) => {

--- a/src/components/studio/marketplaceOptions.js
+++ b/src/components/studio/marketplaceOptions.js
@@ -1,0 +1,22 @@
+/**
+ * Marketplace listing option lists shared by the Distribution panel and the
+ * AI review panel (pick-row display labels). Values mirror the backend
+ * validator (backend/src/utils/marketplaceContent.js) — the save clamp
+ * re-validates, so a drifted id degrades to a dropped value, never a write.
+ */
+
+export const CATEGORY_OPTIONS = [
+  ['art_creativity', 'Art & Creativity'],
+  ['coding_robotics', 'Coding & Robotics'],
+  ['speech_performance', 'Speech & Performance'],
+  ['sports_movement', 'Sports & Movement'],
+  ['music_dance', 'Music & Dance'],
+  ['academic', 'Academic'],
+  ['family_lifestyle', 'Family & Lifestyle'],
+  ['wellness', 'Wellness'],
+  ['dining', 'Dining'],
+  ['financial_education', 'Financial Education'],
+];
+
+export const OFFER_TYPES = ['trial', 'assessment', 'workshop', 'reward', 'consultation'];
+export const MODES = ['physical', 'online', 'hybrid'];

--- a/src/components/studio/panels/DistributionPanel.jsx
+++ b/src/components/studio/panels/DistributionPanel.jsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { apiClient } from '@/api/client';
 import { GATE_LABELS } from '../studioReadiness';
-import { makeBind, PanelSection, TextField, TextAreaField, Seg, ToggleRow, WarnNote, FieldLabel } from './panelKit';
+import { CATEGORY_OPTIONS, OFFER_TYPES, MODES } from '../marketplaceOptions';
+import { makeBind, PanelSection, TextField, TextAreaField, Seg, ToggleRow, WarnNote, FieldLabel, SuggestButton } from './panelKit';
 
 /**
  * Distribution panel (Studio PR 3) — customer domain, featured drop
@@ -10,24 +11,14 @@ import { makeBind, PanelSection, TextField, TextAreaField, Seg, ToggleRow, WarnN
  * save path (a campaign column, never in the doc; permanent lock once an
  * activated campaign has one — production rule: null→value stays allowed).
  *
+ * Full-coverage amendment: the marketplace copy fields carry the per-field ✦
+ * (same affordance as the Page identity fields) — distribution details are
+ * AI-draftable before the publication switches are on.
+ *
  * §03 STATIC row: schoolLevels · slots · activation · sponsor · FAQ stay
  * documented-but-read-only (server/ops-managed or JSON-only).
  */
 
-const CATEGORY_OPTIONS = [
-  ['art_creativity', 'Art & Creativity'],
-  ['coding_robotics', 'Coding & Robotics'],
-  ['speech_performance', 'Speech & Performance'],
-  ['sports_movement', 'Sports & Movement'],
-  ['music_dance', 'Music & Dance'],
-  ['academic', 'Academic'],
-  ['family_lifestyle', 'Family & Lifestyle'],
-  ['wellness', 'Wellness'],
-  ['dining', 'Dining'],
-  ['financial_education', 'Financial Education'],
-];
-const OFFER_TYPES = ['trial', 'assessment', 'workshop', 'reward', 'consultation'];
-const MODES = ['physical', 'online', 'hybrid'];
 const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 const SLUG_RE = /^[a-z0-9-]{3,80}$/;
 
@@ -53,7 +44,9 @@ export default function DistributionPanel({
   onSlugSave,
   slugSaving,
   slugError,
+  onSuggest = null,
 }) {
+  const suggest = (path, label) => (onSuggest ? () => onSuggest(path, label) : undefined);
   const bind = makeBind(doc, setPath);
   const host = doc.distribution?.host === 'mktr' ? 'mktr' : 'redeem';
   const drop = doc.distribution?.featuredDrop || {};
@@ -135,7 +128,7 @@ export default function DistributionPanel({
         />
         {drop.enabled === true ? (
           <>
-            <TextField id="studio-drop-title" label="Drop title" bind={bind('distribution.featuredDrop.title', 40)} />
+            <TextField id="studio-drop-title" label="Drop title" bind={bind('distribution.featuredDrop.title', 40)} onSuggest={suggest('distribution.featuredDrop.title', 'Drop title')} />
             <div style={{ display: 'flex', gap: 8 }}>
               <div style={{ flex: 1 }}>
                 <TextField id="studio-drop-value" label="Value label" bind={bind('distribution.featuredDrop.valueLabel', 12)} placeholder="$10" />
@@ -192,7 +185,7 @@ export default function DistributionPanel({
         ) : (
           <p style={{ margin: 0, fontSize: 10.5, color: 'var(--ink-3)' }}>Publication gate loads from the server…</p>
         )}
-        <TextField id="studio-mk-title" label="Consumer title" bind={bind('distribution.marketplace.title', 120)} />
+        <TextField id="studio-mk-title" label="Consumer title" bind={bind('distribution.marketplace.title', 120)} onSuggest={suggest('distribution.marketplace.title', 'Consumer title')} />
         <div>
           <FieldLabel htmlFor="studio-mk-category">Category</FieldLabel>
           <select id="studio-mk-category" style={selectStyle} value={mk.category || ''} onChange={(e) => setMk({ category: e.target.value || undefined })}>
@@ -228,9 +221,12 @@ export default function DistributionPanel({
             </select>
           </div>
         </div>
-        <TextField id="studio-mk-value" label="Value line" bind={bind('distribution.marketplace.valueLine', 80)} />
+        <TextField id="studio-mk-value" label="Value line" bind={bind('distribution.marketplace.valueLine', 80)} onSuggest={suggest('distribution.marketplace.valueLine', 'Value line')} />
         <div>
-          <FieldLabel htmlFor="studio-mk-inclusions">Inclusions (one per line, max 8)</FieldLabel>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+            <FieldLabel htmlFor="studio-mk-inclusions">Inclusions (one per line, max 8)</FieldLabel>
+            <SuggestButton onSuggest={suggest('distribution.marketplace.inclusions', 'Inclusions')} label="Inclusions" />
+          </div>
           <textarea
             id="studio-mk-inclusions"
             rows={4}

--- a/src/components/studio/panels/panelKit.jsx
+++ b/src/components/studio/panels/panelKit.jsx
@@ -73,8 +73,9 @@ const inputStyle = {
 };
 
 /** Optional per-field AI affordance (Studio PR 4) — a tiny ✦ beside the
- * counter; renders only when the field is given an `onSuggest`. */
-function SuggestButton({ onSuggest, label }) {
+ * counter; renders only when the field is given an `onSuggest`. Exported for
+ * panels whose control isn't a panelKit field (e.g. the inclusions textarea). */
+export function SuggestButton({ onSuggest, label }) {
   if (!onSuggest) return null;
   return (
     <button

--- a/src/components/studio/studioLooks.js
+++ b/src/components/studio/studioLooks.js
@@ -72,6 +72,15 @@ export function rowCurrentValue(doc, row) {
   return currentValueAt(doc, row?.path || '');
 }
 
+/** True when the row's path holds NO value in the doc — rowCurrentValue
+ * normalizes absence to ''/[], which keep-mine must not write back (Codex
+ * #198-1: restoring ''/[] onto an absent key leaves the doc forever dirty
+ * against baseline; restoring `undefined` keeps the getter behavior AND
+ * JSON-serializes away, so dirty self-corrects). */
+export function rowValueAbsent(doc, row) {
+  return getAtPath(doc, row?.path || '') === undefined;
+}
+
 /** Structural equality across row value types (string | string[]). */
 export function rowValuesEqual(a, b) {
   return JSON.stringify(a) === JSON.stringify(b);
@@ -144,6 +153,7 @@ export function adoptedCopyRows(look, prevDoc, lookDoc) {
     .map((row) => ({
       ...row,
       old: currentValueAt(prevDoc, row.path),
+      oldAbsent: getAtPath(prevDoc, row.path) === undefined,
       state: 'applied',
       disabledReason: null,
     }));

--- a/src/components/studio/studioLooks.js
+++ b/src/components/studio/studioLooks.js
@@ -35,26 +35,46 @@ function quizOn(doc) {
 /** Reasons mirror the server's conditional whitelist, evaluated on the
  * UNSAVED doc. Returns null (allowed) or the human reason it is not. The
  * server gates from the STORED doc; the panel re-checks at receipt AND at
- * apply time (F6 — accepting a drop title while the unsaved drop is disabled
- * would be a latent overwrite). */
+ * apply time (F6). Full-coverage amendment: drop/marketplace copy has NO
+ * publication-switch gate any more — filling those details BEFORE flipping
+ * the switch is the point, and the canvas previews both surfaces. */
 export function rowDisabledReason(doc, path) {
   if (!doc) return 'No document';
   switch (path) {
     case 'content.heroCtaLabel':
       return (doc.content?.media?.kind || 'none') !== 'none' ? null : 'No hero media on the page right now';
+    case 'content.media.alt':
+      return doc.content?.media?.kind === 'image' ? null : 'No hero image on the page right now';
     case 'quiz.intro.headline':
     case 'quiz.intro.subhead':
     case 'quiz.intro.ctaLabel':
+    case 'quiz.reveal.gapTemplate':
+    case 'quiz.reveal.valueExchange':
+    case 'quiz.reveal.ctaSubtext':
       return quizOn(doc) ? null : 'The quiz is disabled or has no questions';
-    case 'distribution.featuredDrop.title':
-      return doc.distribution?.featuredDrop?.enabled === true ? null : 'The featured drop is off';
-    case 'distribution.marketplace.valueLine':
-      return doc.distribution?.marketplace?.listed === true ? null : 'The marketplace listing is off';
+    case 'quiz.scoring.readiness.label':
+      if (!quizOn(doc)) return 'The quiz is disabled or has no questions';
+      return doc.quiz?.scoring?.readiness?.enabled === true ? null : 'The readiness meter is off';
     case 'template.params.express.trustLine':
       return (doc.template?.id || 'editorial') === 'express' ? null : 'Only the Express template shows the trust line';
     default:
-      return null; // unconditional copy paths
+      return null; // unconditional copy paths (incl. all distribution copy)
   }
+}
+
+/** Kind-aware current value for a review row: strings for copy/pick rows,
+ * arrays for the inclusions list row ([] when unset). */
+export function rowCurrentValue(doc, row) {
+  if (row?.kind === 'list') {
+    const v = getAtPath(doc, row.path);
+    return Array.isArray(v) ? v : [];
+  }
+  return currentValueAt(doc, row?.path || '');
+}
+
+/** Structural equality across row value types (string | string[]). */
+export function rowValuesEqual(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
 }
 
 /** Why a look can't be picked against the CURRENT doc (re-checked at pick

--- a/src/components/studio/useStudioAi.js
+++ b/src/components/studio/useStudioAi.js
@@ -1,6 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { requestCopyDraft } from './studioAiApi';
-import { rowDisabledReason, currentValueAt, buildLookDoc, lookBlockedReason, adoptedCopyRows } from './studioLooks';
+import {
+  rowDisabledReason,
+  rowCurrentValue,
+  rowValuesEqual,
+  buildLookDoc,
+  lookBlockedReason,
+  adoptedCopyRows,
+} from './studioLooks';
 
 /**
  * Studio AI assist state machine (PR 4) — the mock's semantics with the
@@ -8,13 +15,22 @@ import { rowDisabledReason, currentValueAt, buildLookDoc, lookBlockedReason, ado
  *
  *  - phases: brief | loading | looksLoading | ready | looks | proposal |
  *    error | rate; Generate is disabled until the brief has a topic.
- *  - copy review rows: {path, label, section, value, old, state} where state ∈
- *    open | applied | kept. Accept re-gates the path against the CURRENT doc
- *    (action-time TOCTOU guard) and writes via setPath; Keep-mine restores
- *    `old` ONLY while the doc still holds the accepted AI value (operator
- *    edits always win); per-field ↻ regenerates scoped (regens[path]+1) and
- *    updates the doc only if the row was applied AND untouched, else the new
- *    value arrives as `open`.
+ *  - review rows: {path, label, section, value, old, state, kind} where state
+ *    ∈ open | applied | kept and kind ∈ copy | pick | list (full-coverage
+ *    amendment: the server merges string draft rows, marketplace enum PICKS
+ *    and the inclusions LIST into one reviewable stream; equality checks are
+ *    kind-aware via rowCurrentValue/rowValuesEqual). Accept re-gates the path
+ *    against the CURRENT doc (action-time TOCTOU guard) and writes via
+ *    setPath; Keep-mine restores `old` ONLY while the doc still holds the
+ *    accepted AI value (operator edits always win); per-field ↻ regenerates
+ *    scoped (regens[path]+1) and updates the doc only if the row was applied
+ *    AND untouched, else the new value arrives as `open`. Pick rows have no ↻
+ *    (an enum re-roll is noise; the server 422s pick scopes anyway).
+ *  - recommendations: advisory {topic, label, advice, suggestedValue, state}
+ *    cards — NEVER part of apply-all. applyRec is an explicit per-card action
+ *    that writes the unsaved doc (publication toggles, host) or prefills the
+ *    slug draft via onSlugPrefill; advice-only cards (null suggestedValue)
+ *    offer only a rail deep-link via onJumpSection.
  *  - full mode (CO-1): ≤3 complete looks in ONE provider call. Picking a look
  *    swaps the WHOLE doc (replaceDoc) built from the PRE-proposal doc; keep
  *    toggles rebuild from `prev.doc`; Adopt turns the look's copy into an
@@ -34,12 +50,24 @@ export const AI_TONES = ['Friendly', 'Formal', 'Urgent', 'Playful'];
 const EMPTY_BRIEF = { topic: '', audience: '', objective: '', mustInclude: '', tone: 'Friendly' };
 const clone = (v) => JSON.parse(JSON.stringify(v));
 
-export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPickLook }) {
+/** Rail section a recommendation topic deep-links to. */
+const REC_SECTIONS = {
+  listMarketplace: 'dist',
+  featureDrop: 'dist',
+  customerHost: 'dist',
+  slug: 'dist',
+  formGates: 'form',
+  formFields: 'form',
+  verification: 'form',
+};
+
+export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPickLook, onSlugPrefill, onJumpSection }) {
   const [open, setOpen] = useState(false);
   const [mode, setMode] = useState('copy');
   const [phase, setPhase] = useState('brief');
   const [brief, setBrief] = useState(EMPTY_BRIEF);
   const [sugs, setSugs] = useState([]);
+  const [recs, setRecs] = useState([]); // advisory cards — never in apply-all
   const [scope, setScope] = useState(null); // {path, label} | null
   const [looks, setLooks] = useState([]);
   const [proposal, setProposal] = useState(null); // {prev:{doc}, look, keep, adopted}
@@ -59,15 +87,25 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
   // in the handler, never inside a state updater (updaters run at render time).
   const sugsRef = useRef(sugs);
   sugsRef.current = sugs;
+  const recsRef = useRef(recs);
+  recsRef.current = recs;
   const looksRef = useRef(looks);
   looksRef.current = looks;
   const proposalRef = useRef(proposal);
   proposalRef.current = proposal;
   const onPickLookRef = useRef(onPickLook);
   onPickLookRef.current = onPickLook;
+  const onSlugPrefillRef = useRef(onSlugPrefill);
+  onSlugPrefillRef.current = onSlugPrefill;
+  const onJumpSectionRef = useRef(onJumpSection);
+  onJumpSectionRef.current = onJumpSection;
 
   const patchRow = useCallback((index, patch) => {
     setSugs((prev) => prev.map((row, i) => (i === index ? { ...row, ...patch } : row)));
+  }, []);
+
+  const patchRec = useCallback((index, patch) => {
+    setRecs((prev) => prev.map((rec, i) => (i === index ? { ...rec, ...patch } : rec)));
   }, []);
 
   // Campaign scoping (Codex F10): full reset + abort in-flight + stale fence.
@@ -80,6 +118,7 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
     setPhase('brief');
     setBrief(EMPTY_BRIEF);
     setSugs([]);
+    setRecs([]);
     setScope(null);
     setLooks([]);
     setProposal(null);
@@ -119,11 +158,19 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
 
   const templateId = doc?.template?.id || 'editorial';
 
-  const toRows = useCallback((draft) => {
+  /** Merge the response's typed sections into ONE review stream: string draft
+   * rows, marketplace enum picks, the inclusions list. Old servers send only
+   * `draft` — every section is optional. */
+  const toRows = useCallback((data) => {
     const current = docRef.current;
-    return (draft || []).map((row) => ({
+    const merged = [
+      ...(data?.draft || []).map((row) => ({ ...row, kind: 'copy' })),
+      ...(data?.picks || []).map((row) => ({ ...row, kind: 'pick' })),
+      ...(data?.inclusions ? [{ ...data.inclusions, kind: 'list', value: data.inclusions.values }] : []),
+    ];
+    return merged.map((row) => ({
       ...row,
-      old: currentValueAt(current, row.path),
+      old: rowCurrentValue(current, row),
       state: 'open',
       disabledReason: rowDisabledReason(current, row.path),
     }));
@@ -180,7 +227,8 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
         { signal }
       );
       if (generation !== generationRef.current) return; // stale campaign
-      setSugs(toRows(data.draft));
+      setSugs(toRows(data));
+      setRecs((data.recommendations || []).map((rec) => ({ ...rec, state: 'open' })));
       setPhase('ready');
     } catch (err) {
       if (generation !== generationRef.current) return;
@@ -214,7 +262,8 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
           { signal }
         );
         if (generation !== generationRef.current) return;
-        setSugs(toRows(data.draft));
+        setSugs(toRows(data));
+        setRecs([]); // scoped view — a full generate rebuilds the advisory cards
         setPhase('ready');
       } catch (err) {
         if (generation !== generationRef.current) return;
@@ -245,7 +294,7 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
     (index) => {
       const row = sugsRef.current[index];
       if (!row || row.state === 'kept') return;
-      if (row.state === 'applied' && currentValueAt(docRef.current, row.path) === row.value) {
+      if (row.state === 'applied' && rowValuesEqual(rowCurrentValue(docRef.current, row), row.value)) {
         setPath(row.path, row.old);
       }
       patchRow(index, { state: 'kept' });
@@ -253,11 +302,12 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
     [setPath, patchRow]
   );
 
-  /** Scoped per-row regenerate (regens[path]+1), replace in place. */
+  /** Scoped per-row regenerate (regens[path]+1), replace in place. Pick rows
+   * have no regen (enum re-rolls are noise; the server 422s pick scopes). */
   const regenRow = useCallback(
     async (index) => {
       const row = sugsRef.current[index];
-      if (!row || !campaign?.id) return;
+      if (!row || row.kind === 'pick' || !campaign?.id) return;
       const { generation, signal } = startRequest();
       const n = (regensRef.current[row.path] || 0) + 1;
       noteCall();
@@ -275,7 +325,9 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
         );
         if (generation !== generationRef.current) return;
         regensRef.current[row.path] = n;
-        const fresh = data.draft?.[0];
+        const fresh = row.kind === 'list'
+          ? (data.inclusions ? { value: data.inclusions.values } : null)
+          : data.draft?.[0];
         if (!fresh) return;
         const cur = sugsRef.current[index];
         if (!cur || cur.path !== row.path) return;
@@ -284,7 +336,7 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
         // untouched row on a now-disabled path must fall back to open+reason —
         // never a silent write.
         const reason = rowDisabledReason(docRef.current, cur.path);
-        if (!reason && cur.state === 'applied' && currentValueAt(docRef.current, cur.path) === cur.value) {
+        if (!reason && cur.state === 'applied' && rowValuesEqual(rowCurrentValue(docRef.current, cur), cur.value)) {
           // untouched applied row on a live surface: swap the doc value, stay applied
           setPath(cur.path, fresh.value);
           patchRow(index, { value: fresh.value });
@@ -299,12 +351,14 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
     [campaign?.id, templateId, briefOrName, startRequest, noteCall, fail, setPath, patchRow]
   );
 
-  /** Apply every remaining OPEN row (each re-gated). Copy writes can't change
-   * any gate (gates hang off toggles/enums, never copy paths), so re-gating
-   * against the pre-batch doc is sound. */
-  const applyAll = useCallback(() => {
+  /** Apply every remaining OPEN row (each re-gated), optionally limited to one
+   * section. Recommendations are NEVER part of this — advisory by contract.
+   * Copy writes can't change any gate (gates hang off toggles/enums, never
+   * copy paths), so re-gating against the pre-batch doc is sound. */
+  const applyOpenRows = useCallback((section) => {
     const patches = sugsRef.current.map((row) => {
       if (row.state !== 'open') return null;
+      if (section && row.section !== section) return null;
       const reason = rowDisabledReason(docRef.current, row.path);
       if (reason) return { disabledReason: reason };
       setPath(row.path, row.value);
@@ -313,8 +367,49 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
     setSugs((prev) => prev.map((row, i) => (patches[i] ? { ...row, ...patches[i] } : row)));
   }, [setPath]);
 
+  // applyAll stays zero-arg: it is wired straight into onClick, and a DOM
+  // event leaking into the section filter would silently apply nothing.
+  const applyAll = useCallback(() => applyOpenRows(null), [applyOpenRows]);
+  const applySection = useCallback((section) => applyOpenRows(section), [applyOpenRows]);
+
+  /** Explicit per-card apply for a recommendation with a suggestedValue —
+   * writes the UNSAVED doc (or prefills the slug draft); nothing persists
+   * until the operator saves, and the server publication gate still rules. */
+  const applyRec = useCallback(
+    (index) => {
+      const rec = recsRef.current[index];
+      if (!rec || rec.state === 'applied' || !rec.suggestedValue) return;
+      switch (rec.topic) {
+        case 'listMarketplace':
+          setPath('distribution.marketplace.listed', rec.suggestedValue === 'on');
+          break;
+        case 'featureDrop':
+          setPath('distribution.featuredDrop.enabled', rec.suggestedValue === 'on');
+          break;
+        case 'customerHost':
+          setPath('distribution.host', rec.suggestedValue);
+          break;
+        case 'slug':
+          onSlugPrefillRef.current?.(rec.suggestedValue);
+          break;
+        default:
+          return; // advice-only topics have nothing to apply
+      }
+      patchRec(index, { state: 'applied' });
+    },
+    [setPath, patchRec]
+  );
+
+  /** Deep-link the rail to the control a recommendation talks about. */
+  const jumpRec = useCallback((index) => {
+    const rec = recsRef.current[index];
+    if (!rec) return;
+    onJumpSectionRef.current?.(REC_SECTIONS[rec.topic] || 'dist');
+  }, []);
+
   const discard = useCallback(() => {
     setSugs([]);
+    setRecs([]);
     setScope(null);
     setPhase('brief');
   }, []);
@@ -482,6 +577,7 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
     brief,
     setBrief,
     sugs,
+    recs,
     scope,
     looks,
     proposal,
@@ -496,6 +592,9 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
     keepRow,
     regenRow,
     applyAll,
+    applySection,
+    applyRec,
+    jumpRec,
     discard,
     backToBrief,
     generateLooks,

--- a/src/components/studio/useStudioAi.js
+++ b/src/components/studio/useStudioAi.js
@@ -3,6 +3,7 @@ import { requestCopyDraft } from './studioAiApi';
 import {
   rowDisabledReason,
   rowCurrentValue,
+  rowValueAbsent,
   rowValuesEqual,
   buildLookDoc,
   lookBlockedReason,
@@ -171,6 +172,7 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
     return merged.map((row) => ({
       ...row,
       old: rowCurrentValue(current, row),
+      oldAbsent: rowValueAbsent(current, row),
       state: 'open',
       disabledReason: rowDisabledReason(current, row.path),
     }));
@@ -289,13 +291,17 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
     [setPath, patchRow]
   );
 
-  /** Keep-mine — restores old ONLY if the doc still holds the AI value. */
+  /** Keep-mine — restores old ONLY if the doc still holds the AI value.
+   * An originally-ABSENT value restores as `undefined`, not the normalized
+   * ''/[] (Codex #198-1): getters treat both as empty, but ''/[] would leave
+   * the doc dirty against baseline forever — undefined JSON-serializes away,
+   * so the dirty flag (JSON-compare) self-corrects. */
   const keepRow = useCallback(
     (index) => {
       const row = sugsRef.current[index];
       if (!row || row.state === 'kept') return;
       if (row.state === 'applied' && rowValuesEqual(rowCurrentValue(docRef.current, row), row.value)) {
-        setPath(row.path, row.old);
+        setPath(row.path, row.oldAbsent ? undefined : row.old);
       }
       patchRow(index, { state: 'kept' });
     },
@@ -374,7 +380,11 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
 
   /** Explicit per-card apply for a recommendation with a suggestedValue —
    * writes the UNSAVED doc (or prefills the slug draft); nothing persists
-   * until the operator saves, and the server publication gate still rules. */
+   * until the operator saves, and the server publication gate still rules.
+   * The slug callback may VETO by returning false (Codex #198-3: the card was
+   * generated against an older campaign state — if a slug has been saved or
+   * locked since, prefilling would feed a doomed value into a disabled
+   * input); a vetoed card stays open. */
   const applyRec = useCallback(
     (index) => {
       const rec = recsRef.current[index];
@@ -389,9 +399,10 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
         case 'customerHost':
           setPath('distribution.host', rec.suggestedValue);
           break;
-        case 'slug':
-          onSlugPrefillRef.current?.(rec.suggestedValue);
+        case 'slug': {
+          if (onSlugPrefillRef.current?.(rec.suggestedValue) === false) return;
           break;
+        }
         default:
           return; // advice-only topics have nothing to apply
       }
@@ -427,11 +438,14 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
     []
   );
 
-  /** Generate ≤3 complete looks — one budget call. */
+  /** Generate ≤3 complete looks — one budget call. Copy-mode recommendation
+   * cards are invalidated here (Codex #198-4): looks never produce recs, and
+   * stale cards must not resurface under an adopted look's review list. */
   const generateLooks = useCallback(async () => {
     if (!brief.topic.trim() || !campaign?.id) return;
     const { generation, signal } = startRequest();
     setPhase('looksLoading');
+    setRecs([]);
     setError('');
     noteCall();
     try {
@@ -506,6 +520,7 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
       setProposal({ prev: { doc: baseDoc }, look, keep, adopted: false });
       setMediaHint(look.media?.note ? { kind: look.media.kind || 'none', note: look.media.note } : null);
       setSugs([]);
+      setRecs([]); // belt for #198-4 — a picked look owns the ready view next
       setScope(null);
       setPhase('proposal');
       onPickLookRef.current?.(); // F12: subject → page, jump cleared, funnel remount

--- a/src/pages/AdminCampaignStudio.jsx
+++ b/src/pages/AdminCampaignStudio.jsx
@@ -100,11 +100,23 @@ export default function AdminCampaignStudio() {
     setJump(null);
     setResetKey((k) => k + 1);
   }, []);
-  const onSlugPrefill = useCallback((value) => {
-    setSlugDraft(value);
-    setSlugError(null);
-    setSection('dist');
-  }, []);
+  // Action-time re-check (Codex #198-3): the recommendation was generated
+  // against an older campaign state — if a slug has been saved (or locked by
+  // activation) since, the card is stale and must veto, not feed a doomed
+  // value into the disabled input / the next global save.
+  const onSlugPrefill = useCallback(
+    (value) => {
+      if (campaign?.slug) {
+        toast.error('This campaign already has a slug — the AI suggestion no longer applies.');
+        return false;
+      }
+      setSlugDraft(value);
+      setSlugError(null);
+      setSection('dist');
+      return true;
+    },
+    [campaign?.slug]
+  );
   const ai = useStudioAi({ campaign, doc, setPath, replaceDoc, onPickLook, onSlugPrefill, onJumpSection: setSection });
   const aiRef = useRef(ai);
   aiRef.current = ai;

--- a/src/pages/AdminCampaignStudio.jsx
+++ b/src/pages/AdminCampaignStudio.jsx
@@ -89,15 +89,23 @@ export default function AdminCampaignStudio() {
     campaignId: campaign?.id,
   });
 
-  // "✦ Write it for me" (Studio PR 4) — copy suggestions + CO-1 look
-  // proposals; fully campaign-scoped (the hook resets + aborts on switch).
-  // Picking a look forces a coherent page-subject remount (F12).
+  // "✦ Write it for me" (Studio PR 4 + full-coverage amendment) — fill-
+  // everything suggestions, advisory recommendations + CO-1 look proposals;
+  // fully campaign-scoped (the hook resets + aborts on switch). Picking a
+  // look forces a coherent page-subject remount (F12). A slug recommendation
+  // only PREFILLS the draft (own save path, post-activation lock) and lands
+  // the operator on the Distribution panel to see it.
   const onPickLook = useCallback(() => {
     setSubject('page');
     setJump(null);
     setResetKey((k) => k + 1);
   }, []);
-  const ai = useStudioAi({ campaign, doc, setPath, replaceDoc, onPickLook });
+  const onSlugPrefill = useCallback((value) => {
+    setSlugDraft(value);
+    setSlugError(null);
+    setSection('dist');
+  }, []);
+  const ai = useStudioAi({ campaign, doc, setPath, replaceDoc, onPickLook, onSlugPrefill, onJumpSection: setSection });
   const aiRef = useRef(ai);
   aiRef.current = ai;
 
@@ -407,6 +415,7 @@ export default function AdminCampaignStudio() {
               onSlugSave={handleSlugSave}
               slugSaving={slugSaving}
               slugError={slugError}
+              onSuggest={ai.suggestField}
             />
           )}
         </section>


### PR DESCRIPTION
## What

Frontend half of the Studio AI **full-coverage amendment** (scope doc lands with the backend PR #197). The "Write it for me" panel becomes **Fill everything**: one generate reviews every fillable slot — grouped by section — plus advisory publication recommendations.

- **useStudioAi**: draft + picks + inclusions merge into one typed review stream (`kind ∈ copy|pick|list`) with kind-aware old/equality (arrays for inclusions). Recommendations are held apart from rows and are **never** part of apply-all; `applyRec` is an explicit per-card action that edits the unsaved doc (listing/drop toggles, customer host) or **prefills the slug draft only** (own save path, activation lock respected); `jumpRec` deep-links the rail. `applySection` gives per-section apply — `applyAll` deliberately stays zero-arg because it's wired straight into `onClick` (a leaked DOM event in a section filter would silently apply nothing).
- **studioLooks** gate mirror follows the server: drop/marketplace copy ungated (fill-before-you-flip), new gates for hero-image alt and quiz reveal/readiness label.
- **StudioAiPanel**: sectioned review with Apply-section, bullet rendering for the inclusions list, human category labels via the new `marketplaceOptions.js` (shared with the Distribution panel — no third copy of the enum), dashed **RECOMMENDATIONS — ADVISORY** cards (Apply-to-draft only when a validated `suggestedValue` exists; Go-to-control always), honest explainers on both tabs.
- **DistributionPanel**: per-field ✦ on consumer title, value line, drop title and inclusions (`SuggestButton` now exported from panelKit).
- **AdminCampaignStudio**: slug prefill lands the operator on the Distribution panel with the draft visible; `onJumpSection = setSection`.

**Deploy order**: merge #197 first and verify its Render deploy — the passive panel degrades cleanly against the old backend (no picks/recs arrive), but the NEW Distribution ✦ scoped requests would 422 on it (Codex #198-2), so the backend must be live before this ships.

## Tests

Full vitest run: **1591 passed (128 files)**, including the reworked `useStudioAi` (typed rows, rec semantics, applySection, slug prefill, regen-of-list), `StudioAiPanel` (sections, pick labels, bullets, rec cards, applied chip) and `studioLooks` (new gate matrix) suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Codex fold (11608a1):** absent-field keep-mine restore (dirty self-corrects), slug prefill veto on stale cards, rec invalidation entering looks mode, live-derived row gates, trusted customerHost blast-radius warning. Studio suites: 232 passed.
