### PR TITLE
feat(redeem-ops): Cancel button on entitlement rows

### DIFF
--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -346,6 +346,13 @@ export const redeemOpsApi = {
     // Full response returned — the toast needs the server's message.
     return apiClient.post(`/redeem-ops/entitlements/${id}/resend-pass`, { channel });
   },
+  async cancelEntitlement(id, { reason } = {}) {
+    // Voids an eligible/issued entitlement: the QR/link dies, inventory is
+    // returned to the activation pool, and the one-live-reward-per-phone slot
+    // is freed. Server requires a non-empty reason (audited).
+    const res = await apiClient.patch(`/redeem-ops/entitlements/${id}/cancel`, { reason });
+    return res.data;
+  },
   async verifyVoucher(token) {
     const res = await apiClient.post('/redeem-ops/redemptions/verify', { token });
     return res.data;

--- a/src/pages/redeemops/RedemptionsPage.jsx
+++ b/src/pages/redeemops/RedemptionsPage.jsx
@@ -43,6 +43,9 @@ export default function RedemptionsPage() {
   const [verified, setVerified] = useState(null);
   // { entitlement, mode: 'email'|'link', phase: 'confirm'|'result', result }
   const [shareDialog, setShareDialog] = useState(null);
+  // { entitlement } — voids the reward; requires a reason (audited server-side).
+  const [cancelDialog, setCancelDialog] = useState(null);
+  const [cancelReason, setCancelReason] = useState('');
 
   const historyQuery = useQuery({
     queryKey: ['redeem-ops', 'redemptions'],
@@ -83,6 +86,17 @@ export default function RedemptionsPage() {
       }
     },
     onError: (err) => toast.error('Could not re-mint', { description: err.message }),
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: ({ id, reason }) => redeemOpsApi.cancelEntitlement(id, { reason }),
+    onSuccess: () => {
+      toast.success('Reward cancelled — inventory returned, the phone can earn a new one');
+      setCancelDialog(null);
+      setCancelReason('');
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'entitlements'] });
+    },
+    onError: (err) => toast.error('Cancel failed', { description: err.message }),
   });
 
   const verifyMutation = useMutation({
@@ -210,6 +224,25 @@ export default function RedemptionsPage() {
                   Unlock
                 </Button>
               ) : null;
+              // Cancel voids the reward (QR dies, inventory returns, phone slot
+              // frees). Same capability the server requires for the cancel route.
+              const cancelButton = canIssueManual && ['eligible', 'issued'].includes(e.status) ? (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-destructive hover:text-destructive"
+                  disabled={cancelMutation.isPending}
+                  onClick={() => { setCancelReason(''); setCancelDialog({ entitlement: e }); }}
+                >
+                  Cancel
+                </Button>
+              ) : null;
+              const rowActions = (
+                <>
+                  {unlockButton}
+                  {cancelButton}
+                </>
+              );
               return (
                 <div key={e.id} className="flex flex-wrap items-center gap-x-3 gap-y-1.5 py-2.5 border-t border-border first:border-t-0">
                   <div className="min-w-0 flex-1 basis-52">
@@ -259,9 +292,9 @@ export default function RedemptionsPage() {
                       >
                         Copy link
                       </Button>
-                      {unlockButton}
+                      {rowActions}
                     </span>
-                  ) : unlockButton}
+                  ) : rowActions}
                 </div>
               );
             })}
@@ -401,6 +434,56 @@ export default function RedemptionsPage() {
               </DialogFooter>
             </>
           )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Cancel — voids the reward. Destructive + reason-gated (audited). */}
+      <Dialog
+        open={!!cancelDialog}
+        onOpenChange={(open) => {
+          // Don't let Escape / overlay / X dismiss mid-flight: the PATCH is
+          // irreversible, and a dialog that vanishes while it's still running
+          // reads as "aborted" when it actually completed (Codex review).
+          if (!open && !cancelMutation.isPending) { setCancelDialog(null); setCancelReason(''); }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              Cancel this {cancelDialog?.entitlement?.status === 'issued' ? 'voucher' : 'reservation'}?
+            </DialogTitle>
+            <DialogDescription>
+              {[cancelDialog?.entitlement?.prospect?.firstName, cancelDialog?.entitlement?.prospect?.lastName]
+                .filter(Boolean).join(' ') || 'The customer'}
+              {"'s "}
+              {cancelDialog?.entitlement?.status === 'issued' ? 'voucher QR/code' : 'reservation pass'}
+              {' stops working immediately, the reward returns to the activation pool, and this'}
+              {' phone number can earn a new reward. This cannot be undone.'}
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            value={cancelReason}
+            onChange={(ev) => setCancelReason(ev.target.value)}
+            placeholder="Reason (required) — e.g. duplicate, testing, customer request"
+            aria-label="Reason for cancelling this reward"
+            autoFocus
+          />
+          <DialogFooter>
+            <Button
+              variant="outline"
+              disabled={cancelMutation.isPending}
+              onClick={() => { setCancelDialog(null); setCancelReason(''); }}
+            >
+              Keep it
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={!cancelReason.trim() || cancelMutation.isPending}
+              onClick={() => cancelMutation.mutate({ id: cancelDialog.entitlement.id, reason: cancelReason.trim() })}
+            >
+              {cancelMutation.isPending ? 'Cancelling…' : 'Cancel reward'}
+            </Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>


### PR DESCRIPTION
Adds a **Cancel** action to each reward-entitlement row on the Redemptions page (ops.redeem.sg), for `eligible` (reservation) and `issued` (voucher) entitlements.

## Why
Cancelling voids the reward (QR/link stops working), returns inventory to the activation pool, and **frees the one-live-reward-per-phone slot** so the same number can earn a new reward. Needed for testing and for genuine duplicate/mistake/customer-request cases. Until now this was only reachable via a hand-run API call in the browser console.

## What
- `redeemOpsApi.cancelEntitlement(id, { reason })` → the existing `PATCH /api/redeem-ops/entitlements/:id/cancel` (no backend change; route already gated by `entitlements.issue_manual` and requires a non-empty reason).
- Per-row **Cancel** button (ghost/destructive), shown on eligible/issued rows, gated on `canIssueManual` to match the server.
- Reason-required confirm dialog; mutation follows the page's `unlock`/`resend` pattern (toast + `invalidateQueries(['redeem-ops','entitlements'])`, which prefix-matches the resSearch-keyed list query in react-query v5).

## Review
Codex (xhigh) verdict **fix-then-ship**; both findings applied:
- **Medium** — dialog could be dismissed mid-flight on an irreversible action, implying it aborted → now locked closed while the PATCH is pending (Escape/overlay/Keep-it all disabled).
- **Low** — reason input had only a placeholder → added `aria-label`.

Frontend-only; ESLint clean. Ships on the next `redeem-ops-frontend` deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)