### PR TITLE
feat(redeem-ops): camera QR scanner on the Redemptions page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "input-otp": "^1.4.2",
         "jspdf": "^2.5.2",
         "jspdf-autotable": "^3.8.4",
+        "jsqr": "^1.4.0",
         "lucide-react": "^0.475.0",
         "next-themes": "^0.4.4",
         "react": "^18.2.0",
@@ -7700,6 +7701,12 @@
       "integrity": "sha512-i6mvVmWN4xo9LrhCOZrDgSs9noW6nOahbrmzjRbPF36YPyj5Ue5lgok0MHDWkG7xzpWFO2OYttXdzM7rJxHvNA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true
+    },
+    "node_modules/jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
+      "license": "Apache-2.0"
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "input-otp": "^1.4.2",
     "jspdf": "^2.5.2",
     "jspdf-autotable": "^3.8.4",
+    "jsqr": "^1.4.0",
     "lucide-react": "^0.475.0",
     "next-themes": "^0.4.4",
     "react": "^18.2.0",

--- a/src/components/redeemops/QrScannerDialog.jsx
+++ b/src/components/redeemops/QrScannerDialog.jsx
@@ -1,0 +1,217 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import jsQR from 'jsqr';
+import {
+  Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+/**
+ * Camera QR scanner for the Redemptions console. Scanning is IDENTIFICATION
+ * only — it decodes a value and hands it to `onDetect`; the caller resolves
+ * what it is (pass vs voucher) and always confirms before any irreversible
+ * action. Never auto-fires.
+ *
+ * getUserMedia needs HTTPS (ops.redeem.sg qualifies). The <video> stays mounted
+ * for the whole open lifetime so its ref is stable across permission/error
+ * re-renders; error/empty states overlay it. Camera tracks are released on
+ * close, unmount, and tab-hide.
+ */
+export default function QrScannerDialog({
+  open,
+  onOpenChange,
+  onDetect,
+  onPasteFallback,
+  title = 'Scan QR',
+  hint = "Point the camera at the customer's reward QR",
+}) {
+  const videoRef = useRef(null);
+  const canvasRef = useRef(null);
+  const rafRef = useRef(0);
+  const streamRef = useRef(null);
+  const lockedRef = useRef(false); // true once a code is found — stops the loop
+  const lastDecodeRef = useRef(0);
+  // Latest onDetect held in a ref so its identity changing never restarts the
+  // camera (the start-effect depends on `tick`, which must stay stable).
+  const onDetectRef = useRef(onDetect);
+  // Live `open` for the async getUserMedia guard (dialog may close mid-request).
+  const openRef = useRef(open);
+  const [phase, setPhase] = useState('starting'); // starting | scanning | denied | nocamera | error
+  const [torchOn, setTorchOn] = useState(false);
+  const [torchable, setTorchable] = useState(false);
+
+  useEffect(() => { onDetectRef.current = onDetect; }, [onDetect]);
+  useEffect(() => { openRef.current = open; }, [open]);
+
+  const stopCamera = useCallback(() => {
+    if (rafRef.current) { cancelAnimationFrame(rafRef.current); rafRef.current = 0; }
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+    }
+    if (videoRef.current) videoRef.current.srcObject = null;
+    setTorchOn(false);
+    setTorchable(false);
+  }, []);
+
+  const tick = useCallback(() => {
+    rafRef.current = 0;
+    const video = videoRef.current;
+    const canvas = canvasRef.current;
+    if (!video || !canvas || lockedRef.current) return;
+
+    if (video.readyState === video.HAVE_ENOUGH_DATA) {
+      const now = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+      if (now - lastDecodeRef.current >= 100) { // throttle decode to ~10fps
+        lastDecodeRef.current = now;
+        const vw = video.videoWidth;
+        const vh = video.videoHeight;
+        if (vw && vh) {
+          // Center-square crop, capped at 640px — QRs are held centered, and a
+          // smaller frame keeps jsQR fast enough for a live loop.
+          const side = Math.min(vw, vh);
+          const cap = Math.min(side, 640);
+          canvas.width = cap;
+          canvas.height = cap;
+          const ctx = canvas.getContext('2d', { willReadFrequently: true });
+          ctx.drawImage(video, (vw - side) / 2, (vh - side) / 2, side, side, 0, 0, cap, cap);
+          const img = ctx.getImageData(0, 0, cap, cap);
+          const code = jsQR(img.data, img.width, img.height, { inversionAttempts: 'dontInvert' });
+          if (code && code.data) {
+            lockedRef.current = true;
+            onDetectRef.current(code.data.trim());
+            return; // parent handles/closes; do not reschedule
+          }
+        }
+      }
+    }
+    rafRef.current = requestAnimationFrame(tick);
+  }, []);
+
+  const startCamera = useCallback(async () => {
+    lockedRef.current = false;
+    lastDecodeRef.current = 0;
+    setPhase('starting');
+    if (!navigator.mediaDevices?.getUserMedia) { setPhase('nocamera'); return; }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: { ideal: 'environment' } },
+        audio: false,
+      });
+      // Bail if the dialog closed or the tab hid while the prompt was open —
+      // otherwise the granted stream leaks (camera light stays on).
+      if (!openRef.current || document.hidden) { stream.getTracks().forEach((t) => t.stop()); return; }
+      const video = videoRef.current;
+      if (!video) { stream.getTracks().forEach((t) => t.stop()); return; }
+      streamRef.current = stream;
+      video.srcObject = stream;
+      await video.play().catch(() => {});
+      const track = stream.getVideoTracks()[0];
+      const caps = track?.getCapabilities?.();
+      setTorchable(Boolean(caps && 'torch' in caps && caps.torch));
+      setPhase('scanning');
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(tick);
+    } catch (err) {
+      if (err?.name === 'NotAllowedError' || err?.name === 'SecurityError') setPhase('denied');
+      else if (err?.name === 'NotFoundError' || err?.name === 'OverconstrainedError') setPhase('nocamera');
+      else setPhase('error');
+    }
+  }, [tick]);
+
+  // Start on open, fully release on close/unmount.
+  useEffect(() => {
+    if (!open) return undefined;
+    startCamera();
+    return () => stopCamera();
+  }, [open, startCamera, stopCamera]);
+
+  // Fully release the camera while the tab is hidden (not just the decode loop
+  // — the indicator light must go off); re-acquire on return. (Codex review.)
+  useEffect(() => {
+    if (!open) return undefined;
+    const onVis = () => { if (document.hidden) stopCamera(); else startCamera(); };
+    document.addEventListener('visibilitychange', onVis);
+    return () => document.removeEventListener('visibilitychange', onVis);
+  }, [open, startCamera, stopCamera]);
+
+  const toggleTorch = async () => {
+    const track = streamRef.current?.getVideoTracks?.()[0];
+    if (!track) return;
+    try {
+      await track.applyConstraints({ advanced: [{ torch: !torchOn }] });
+      setTorchOn((v) => !v);
+    } catch { /* torch not applicable — ignore */ }
+  };
+
+  const errorText = {
+    denied: { title: 'Camera access is off', body: 'Allow the camera in your browser’s site settings, or paste the code instead.' },
+    nocamera: { title: 'No camera found', body: 'Use a device with a camera, or paste the code instead.' },
+    error: { title: 'Couldn’t start the camera', body: 'Close and try again, or paste the code instead.' },
+  }[phase];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{hint}</DialogDescription>
+        </DialogHeader>
+
+        <div className="relative w-full aspect-square overflow-hidden rounded-xl bg-black">
+          {/* Always mounted so the ref is stable; hidden black frame under errors. */}
+          <video
+            ref={videoRef}
+            className="w-full h-full object-cover"
+            playsInline
+            muted
+            aria-label="Camera preview"
+          />
+          {phase === 'scanning' && (
+            <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+              <div
+                className="w-2/3 h-2/3 rounded-lg"
+                style={{ boxShadow: '0 0 0 3px rgba(255,255,255,.92), 0 0 0 9999px rgba(0,0,0,.38)' }}
+              />
+            </div>
+          )}
+          {phase === 'starting' && (
+            <div className="absolute inset-0 grid place-items-center text-white/90 text-sm">
+              Starting camera…
+            </div>
+          )}
+          {errorText && (
+            <div className="absolute inset-0 grid place-items-center p-6 text-center bg-black/70">
+              <div>
+                <p className="text-white font-semibold m-0">{errorText.title}</p>
+                <p className="text-white/70 text-sm mt-1 mb-0">{errorText.body}</p>
+              </div>
+            </div>
+          )}
+          {torchable && phase === 'scanning' && (
+            <button
+              type="button"
+              onClick={toggleTorch}
+              className="absolute bottom-2 right-2 rounded-full bg-black/60 text-white text-xs px-3 py-1.5"
+            >
+              {torchOn ? 'Torch off' : 'Torch'}
+            </button>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between gap-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>Close</Button>
+          {onPasteFallback && (
+            <Button
+              variant="ghost"
+              onClick={() => { onOpenChange(false); onPasteFallback(); }}
+            >
+              Paste code instead
+            </Button>
+          )}
+        </div>
+
+        <canvas ref={canvasRef} className="hidden" />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/pages/redeemops/RedemptionsPage.jsx
+++ b/src/pages/redeemops/RedemptionsPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { redeemOpsApi } from '@/api/redeemOps';
@@ -15,6 +15,23 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import ScanLine from 'lucide-react/icons/scan-line';
 import { RoMobileCard, RoPageHeader, RoTag, prettyEnum } from '@/components/redeemops/ui';
+import QrScannerDialog from '@/components/redeemops/QrScannerDialog';
+
+/**
+ * A scanned reward QR is one of two shapes:
+ *  - a reservation-pass LINK ending in /r/<presentationToken> → activate (unlock)
+ *  - a bare voucher token → verify → redeem
+ * Returns { kind: 'pass'|'voucher', value } or null when it isn't a reward code.
+ */
+function parseRewardQr(raw) {
+  const s = String(raw || '').trim();
+  // Require a known reward host — a foreign `.../r/<token>` URL must not be
+  // treated as an activation pass (Codex review).
+  const passMatch = s.match(/(?:https?:\/\/)?(?:www\.)?(?:redeem|mktr)\.sg\/r\/([A-Za-z0-9_-]{12,128})\/?$/i);
+  if (passMatch) return { kind: 'pass', value: passMatch[1] };
+  if (/^[A-Za-z0-9_-]{12,128}$/.test(s)) return { kind: 'voucher', value: s };
+  return null;
+}
 
 /** Per-row delivery truth from the receipts the backend now records. */
 function deliveryStatus(e) {
@@ -46,6 +63,10 @@ export default function RedemptionsPage() {
   // { entitlement } — voids the reward; requires a reason (audited server-side).
   const [cancelDialog, setCancelDialog] = useState(null);
   const [cancelReason, setCancelReason] = useState('');
+  const [scanOpen, setScanOpen] = useState(false);
+  // presentationToken pending an explicit "Activate" confirm after a pass scan.
+  const [activateToken, setActivateToken] = useState(null);
+  const pasteRef = useRef(null);
 
   const historyQuery = useQuery({
     queryKey: ['redeem-ops', 'redemptions'],
@@ -58,7 +79,8 @@ export default function RedemptionsPage() {
   });
 
   const unlockMutation = useMutation({
-    mutationFn: (prospectId) => redeemOpsApi.unlockEntitlement({ prospectId }),
+    // body is { prospectId } (row button) or { presentationToken } (pass scan).
+    mutationFn: (body) => redeemOpsApi.unlockEntitlement(body),
     onSuccess: (data) => {
       // Truthful toast: only claim an email went out when one was queued.
       toast.success(
@@ -68,6 +90,7 @@ export default function RedemptionsPage() {
             ? 'Voucher unlocked — email with QR sent to the customer'
             : 'Voucher unlocked — no email on file; use Copy link to share the voucher'
       );
+      setActivateToken(null);
       queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'entitlements'] });
     },
     onError: (err) => toast.error('Unlock failed', { description: err.message }),
@@ -100,8 +123,15 @@ export default function RedemptionsPage() {
   });
 
   const verifyMutation = useMutation({
-    mutationFn: () => redeemOpsApi.verifyVoucher(token.trim()),
-    onSuccess: (data) => setVerified(data),
+    // Always pass the token explicitly (the field or a scan) — never read it
+    // through a stale closure.
+    mutationFn: (t) => redeemOpsApi.verifyVoucher(t.trim()),
+    // Bind the result to the token that produced it, and drop a stale response
+    // if the field changed while it was in flight — the irreversible redeem
+    // must act on the reward SHOWN, never on whatever text is in the box now.
+    onSuccess: (data, t) => {
+      if (t.trim() === token.trim()) setVerified({ ...data, token: t.trim() });
+    },
     onError: (err) => {
       setVerified(null);
       toast.error('Verification failed', { description: err.message });
@@ -109,7 +139,8 @@ export default function RedemptionsPage() {
   });
 
   const completeMutation = useMutation({
-    mutationFn: () => redeemOpsApi.completeRedemption(token.trim()),
+    // Redeem the token the verified card is bound to, not the live field.
+    mutationFn: () => redeemOpsApi.completeRedemption((verified?.token ?? token).trim()),
     onSuccess: (data) => {
       toast.success(data?.already ? 'Already redeemed' : 'Redeemed ✔');
       setVerified(null); setToken('');
@@ -119,6 +150,25 @@ export default function RedemptionsPage() {
   });
 
   const redemptions = historyQuery.data?.redemptions || [];
+
+  // A scanned QR is either a pass link (→ activate) or a voucher token (→ verify).
+  const handleScanDetect = useCallback((raw) => {
+    setScanOpen(false);
+    const parsed = parseRewardQr(raw);
+    if (!parsed) { toast.error("That QR isn't a MKTR reward code"); return; }
+    if (parsed.kind === 'pass') {
+      setActivateToken(parsed.value); // opens the Activate confirm dialog
+    } else {
+      setVerified(null);
+      setToken(parsed.value);
+      verifyMutation.mutate(parsed.value); // explicit token — no stale closure
+    }
+  }, [verifyMutation]);
+
+  const focusPaste = useCallback(() => {
+    // Defer so the scanner dialog has finished closing before we steal focus.
+    setTimeout(() => pasteRef.current?.focus(), 0);
+  }, []);
 
   const copyText = async (text, label) => {
     try {
@@ -141,19 +191,28 @@ export default function RedemptionsPage() {
       <Card>
         <CardHeader>
           <CardTitle className="text-base flex items-center gap-2">
-            <ScanLine className="w-4 h-4" aria-hidden="true" /> Verify a voucher
+            <ScanLine className="w-4 h-4" aria-hidden="true" /> Scan or verify a reward
           </CardTitle>
-          <CardDescription>Paste the scanned QR value or the full voucher code.</CardDescription>
+          <CardDescription>
+            Scan the customer&apos;s QR to activate a reservation or redeem a voucher — or paste the code.
+          </CardDescription>
         </CardHeader>
         <CardContent className="space-y-3">
+          <Button className="w-full" onClick={() => setScanOpen(true)}>
+            <ScanLine className="w-4 h-4 mr-2" aria-hidden="true" /> Scan QR
+          </Button>
+          <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--ro-text-3)' }}>
+            <span className="h-px flex-1 bg-border" /> or enter the code <span className="h-px flex-1 bg-border" />
+          </div>
           <div className="flex gap-2">
             <Input
+              ref={pasteRef}
               value={token}
               onChange={(e) => { setToken(e.target.value); setVerified(null); }}
               placeholder="Voucher code…"
               className="font-mono"
             />
-            <Button disabled={!token.trim() || verifyMutation.isPending} onClick={() => verifyMutation.mutate()}>
+            <Button disabled={!token.trim() || verifyMutation.isPending} onClick={() => verifyMutation.mutate(token)}>
               {verifyMutation.isPending ? 'Checking…' : 'Verify'}
             </Button>
           </div>
@@ -219,7 +278,7 @@ export default function RedemptionsPage() {
                   size="sm"
                   variant="outline"
                   disabled={unlockMutation.isPending}
-                  onClick={() => unlockMutation.mutate(e.prospect.id)}
+                  onClick={() => unlockMutation.mutate({ prospectId: e.prospect.id })}
                 >
                   Unlock
                 </Button>
@@ -486,6 +545,45 @@ export default function RedemptionsPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Activate — scanning a reservation pass issues the voucher. Confirm
+          before firing (it sends the voucher + draws from allocation). */}
+      <Dialog
+        open={!!activateToken}
+        onOpenChange={(open) => { if (!open && !unlockMutation.isPending) setActivateToken(null); }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Activate this reward?</DialogTitle>
+            <DialogDescription>
+              This issues the customer&apos;s voucher now and sends it to them, drawing from the
+              campaign&apos;s allocation. You can cancel it afterwards if it was a mistake.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              disabled={unlockMutation.isPending}
+              onClick={() => setActivateToken(null)}
+            >
+              Not now
+            </Button>
+            <Button
+              disabled={unlockMutation.isPending}
+              onClick={() => unlockMutation.mutate({ presentationToken: activateToken })}
+            >
+              {unlockMutation.isPending ? 'Activating…' : 'Activate reward'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <QrScannerDialog
+        open={scanOpen}
+        onOpenChange={setScanOpen}
+        onDetect={handleScanDetect}
+        onPasteFallback={focusPaste}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Adds a **Scan QR** button to the Redemptions console (ops.redeem.sg) so staff can scan a reward QR instead of hunting a row or pasting a code.

## UX
Scan **identifies**, a human **confirms** — no irreversible action ever auto-fires.
- Reservation-pass QR (`…/r/<token>`) → "Activate reward?" confirm → unlock (issues + sends the voucher).
- Voucher QR (bare token) → fills the field + runs the existing verify → existing result card → "Confirm redemption".
- **Paste stays** as the fallback (camera denied, desktop, damaged QR).

New `QrScannerDialog`: rear camera, framing reticle, torch toggle, clean denied / no-camera / error states (each offering paste-instead).

## Correctness / privacy
- Camera released on close, unmount, **and tab-hide** (indicator light goes off), re-acquired on return.
- Decode loop locks after the first hit; `onDetect` is ref-held so its identity never restarts the camera.
- jsQR is code-split into the lazy Redemptions chunk (loads only when that page opens).

## Frontend-only
The unlock route already accepts `presentationToken`; on the ops console an unlock records `via: manual` by design (the scan-for-draw-boost is the consultant app flow, not this one). No backend change.

## Review
Codex (xhigh) **fix-then-ship**; all five findings applied:
1. **High** — existing row Unlock button now sends `{ prospectId }` (the mutation became a body object; a scalar would 422). Regression I introduced, caught + fixed.
2. **High** — verify result is now bound to its token; a stale in-flight response is dropped, so **Confirm redemption redeems the reward SHOWN**, never the current field text.
3. **Medium** — tab-hide fully stops the camera (was pausing only the loop, leaving the light on).
4. **Low** — pass-link parsing requires a known host (`redeem.sg`/`mktr.sg`); a foreign `/r/<token>` isn't treated as an activation.
5. **High** — `package-lock.json` committed with `package.json` (npm ci parity).

ESLint clean; `vite build` green.

## Deploy
Ships on **`redeem-ops-frontend`** (Manual Deploy that service), separate from the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)