### PR TITLE
feat(reward-claim): voucher page flips to a Redeemed stamp without a reload

### DIFF
--- a/src/pages/RewardClaim.jsx
+++ b/src/pages/RewardClaim.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { apiClient } from '@/api/client';
 
@@ -7,19 +7,101 @@ import { apiClient } from '@/api/client';
  * One stable link, state-dependent render: reservation pass while locked,
  * scannable voucher once the consultant unlocks it. Public + token-authenticated;
  * deliberately dependency-light (no dashboard chrome).
+ *
+ * Live-ish state: redemption happens on the MERCHANT's device (the ops scanner),
+ * so this page can't be told directly. Instead of polling (the claim endpoint is
+ * rate-limited and it'd be wasteful), we RE-CHECK on the moments the holder
+ * actually looks at their phone — tab re-focus, visibility regain, bfcache
+ * restore, or a tap — which is exactly when the merchant has just scanned and
+ * handed it back. Terminal states stop re-checking.
  */
+const TERMINAL = new Set(['redeemed', 'expired', 'cancelled', 'blocked']);
+// Loose enough to protect the rate-limited claim endpoint (60/15min per IP)
+// from a fidgety tapper, tight enough that the first glance after a scan lands.
+const REFRESH_THROTTLE_MS = 5000;
+
 export default function RewardClaim() {
   const { token } = useParams();
   const [data, setData] = useState(null);
   const [error, setError] = useState(null);
+  // True only when THIS session watched it flip to redeemed (for the "just now"
+  // emphasis) — a fresh load of an already-redeemed link stays calm.
+  const [justRedeemed, setJustRedeemed] = useState(false);
 
-  useEffect(() => {
-    let cancelled = false;
-    apiClient.get(`/reward-claim/${encodeURIComponent(token)}`)
-      .then((res) => { if (!cancelled) setData(res.data); })
-      .catch((err) => { if (!cancelled) setError(err.status === 404 ? 'This link is not valid.' : 'Something went wrong — try again shortly.'); });
-    return () => { cancelled = true; };
+  const stateRef = useRef(null); // latest state, read by listeners without re-binding
+  const lastFetchRef = useRef(0);
+  const inFlightRef = useRef(false);
+  const pendingRef = useRef(false); // an event arrived mid-flight → refetch after
+  const genRef = useRef(0);         // bumps on token change; stale responses discarded
+
+  const refresh = useCallback(async ({ force = false } = {}) => {
+    // Coalesce: a request already running → remember to re-check when it lands
+    // (so a redeem that happens mid-flight isn't missed until the next tap).
+    if (inFlightRef.current) { pendingRef.current = true; return; }
+    const now = Date.now();
+    if (!force && now - lastFetchRef.current < REFRESH_THROTTLE_MS) return;
+    lastFetchRef.current = now;
+    inFlightRef.current = true;
+    const gen = genRef.current; // ownership — discard if the token changed under us
+    try {
+      const res = await apiClient.get(`/reward-claim/${encodeURIComponent(token)}`);
+      if (gen !== genRef.current) return;
+      const next = res.data;
+      const prev = stateRef.current;
+      stateRef.current = next?.state ?? null;
+      if (prev === 'unlocked' && next?.state === 'redeemed') setJustRedeemed(true);
+      setData(next);
+      setError(null);
+    } catch (err) {
+      if (gen !== genRef.current) return;
+      // Only the FIRST load surfaces an error; a failed re-check must never wipe
+      // a voucher already on screen (offline blip, transient 429, etc.).
+      if (stateRef.current === null) {
+        setError(err.status === 404 ? 'This link is not valid.' : 'Something went wrong — try again shortly.');
+      }
+    } finally {
+      // Only the still-current generation owns the shared flight lock (a stale
+      // A-response must not unlock or re-trigger B's fetch).
+      if (gen === genRef.current) {
+        inFlightRef.current = false;
+        if (pendingRef.current) { pendingRef.current = false; refresh({ force: true }); }
+      }
+    }
   }, [token]);
+
+  // Initial load (and full reset when the token changes — new generation, so a
+  // prior token's in-flight request can neither paint here nor hold the lock).
+  useEffect(() => {
+    genRef.current += 1;
+    stateRef.current = null;
+    lastFetchRef.current = 0;
+    inFlightRef.current = false;
+    pendingRef.current = false;
+    setData(null);
+    setError(null);
+    setJustRedeemed(false);
+    refresh({ force: true });
+  }, [refresh]);
+
+  // Re-check when the holder returns to / touches the page — but not once the
+  // reward has reached a terminal state (nothing left to change).
+  useEffect(() => {
+    const maybeRefresh = () => {
+      if (TERMINAL.has(stateRef.current)) return;
+      refresh();
+    };
+    const onVisibility = () => { if (document.visibilityState === 'visible') maybeRefresh(); };
+    window.addEventListener('focus', maybeRefresh);
+    window.addEventListener('pageshow', maybeRefresh);
+    document.addEventListener('visibilitychange', onVisibility);
+    document.addEventListener('pointerdown', maybeRefresh);
+    return () => {
+      window.removeEventListener('focus', maybeRefresh);
+      window.removeEventListener('pageshow', maybeRefresh);
+      document.removeEventListener('visibilitychange', onVisibility);
+      document.removeEventListener('pointerdown', maybeRefresh);
+    };
+  }, [refresh]);
 
   if (error) {
     return (
@@ -38,10 +120,23 @@ export default function RewardClaim() {
 
   const { state, reward, firstName, expiresAt, pass, voucher, bookingUrl } = data;
   const expiry = expiresAt ? new Date(expiresAt).toLocaleDateString('en-SG', { day: 'numeric', month: 'short', year: 'numeric' }) : null;
+  // Screen-reader announcement — the state can flip asynchronously (a merchant
+  // scan elsewhere), so a live region voices the change without a visual cue.
+  const statusMessage = {
+    reserved: 'Reward reserved. Show the pass to your consultant to unlock it.',
+    unlocked: 'Voucher ready to redeem. Show it at the counter.',
+    redeemed: 'This reward has been redeemed.',
+    expired: 'This reward has expired.',
+    cancelled: 'This reward has been cancelled.',
+    blocked: 'This reward is no longer available.',
+  }[state] || null;
 
   return (
     <div className="min-h-screen bg-background flex items-center justify-center p-6">
       <div className="w-full max-w-md rounded-2xl border border-border bg-card p-8 text-center space-y-4 shadow-sm">
+        {statusMessage && (
+          <p className="sr-only" role="status" aria-live="polite">{statusMessage}</p>
+        )}
         <p className="text-sm text-muted-foreground">
           {firstName ? `Hi ${firstName},` : 'Hello,'}
         </p>
@@ -98,14 +193,32 @@ export default function RewardClaim() {
                 ))}
               </div>
             )}
-            <p className="text-xs text-muted-foreground">One-time use.{expiry ? ` Valid until ${expiry}.` : ''}</p>
+            <p className="text-xs text-muted-foreground">
+              One-time use.{expiry ? ` Valid until ${expiry}.` : ''}
+              <br />
+              <span className="text-muted-foreground/70">Updates automatically once the counter scans it — tap if it doesn’t.</span>
+            </p>
           </>
         )}
 
         {state === 'redeemed' && (
-          <div className="rounded-xl bg-muted p-4 text-sm">
-            <p className="font-medium">Already redeemed ✔</p>
-            <p className="text-muted-foreground mt-1">This reward has been used. Enjoy!</p>
+          <div className="space-y-4">
+            {/* Rubber-stamp "REDEEMED" — the visible confirmation the holder wanted.
+                Decorative; the status is voiced by the live region above. */}
+            <div className="relative mx-auto w-56 h-56 flex items-center justify-center" aria-hidden="true">
+              <div className="absolute inset-0 rounded-2xl bg-emerald-50 dark:bg-emerald-950/20 border border-emerald-200" />
+              <div
+                className={`relative select-none rounded-xl border-4 border-emerald-600 px-6 py-3 ${justRedeemed ? 'animate-in zoom-in-75 duration-300' : ''}`}
+                style={{ transform: 'rotate(-11deg)' }}
+              >
+                <span className="block text-2xl font-black tracking-[0.15em] text-emerald-700 dark:text-emerald-400">REDEEMED</span>
+                <span className="block text-center text-emerald-700/80 dark:text-emerald-400/80 text-lg leading-none">✓</span>
+              </div>
+            </div>
+            <div className="rounded-xl bg-muted p-4 text-sm">
+              <p className="font-medium">{justRedeemed ? 'Redeemed just now ✔' : 'Already redeemed ✔'}</p>
+              <p className="text-muted-foreground mt-1">This reward has been used. Enjoy!</p>
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
The consumer voucher page (`redeem.sg/r/:token`) fetched its state once on mount. When a merchant redeems it on the ops scanner (a different device), the holder's page had no idea — they had to **reopen it** to see "Redeemed."

## What
Now the page **re-checks its state on interaction** — window focus, `visibilitychange`→visible, `pageshow` (bfcache), and a throttled tap — which is exactly when the holder glances back at their phone after the merchant scans. It then renders a **rubber-stamp "REDEEMED"** badge, with a "Redeemed just now" emphasis when this session watched the flip.

**No polling** — the `/reward-claim/:token` endpoint is rate-limited (60/15min per IP), and interaction-triggered refetch fires precisely when it matters, at near-zero cost. (SSE was considered and rejected: overkill here, and mobile browsers suspend event-streams on lock/background anyway.)

## Correctness (single-flight, throttled, generation-guarded)
- One request in flight at a time; a decisive event arriving mid-flight queues a trailing forced refetch.
- **Generation guard**: on token change a stale in-flight response is discarded and can't paint the new page or hold the lock (Codex High).
- A failed re-check never wipes an on-screen voucher — only the first load can error.
- Terminal states (redeemed/expired/cancelled/blocked) stop re-checking.

## Review
Codex (xhigh) **fix-then-ship**; all four applied: the cross-token race (High), mid-flight event loss (Medium), throttle 2s→5s vs the rate limit (Medium), and an `aria-live` status announcement + `aria-hidden` on the decorative stamp (Low). ESLint clean; `vite build` green.

## Known limitation
Interaction refetch covers the real counter flow but not a perfectly motionless, untouched, screen-on phone; a subtle "tap if it doesn't update" hint covers that. Shared-NAT 429s (many holders behind one IP) are a backend concern better solved later by a dedicated cheap status endpoint, not client throttling.

## Deploy
Frontend-only; ships on **`redeem-frontend`** (the redeem.sg consumer site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)