### PR TITLE
feat(entitlements): agent lookup/summary endpoints + unlock enrichment; authorize before replay/liveness

### DIFF
--- a/backend/src/routes/externalEntitlements.js
+++ b/backend/src/routes/externalEntitlements.js
@@ -1,19 +1,41 @@
 import express from 'express';
+import { Op } from 'sequelize';
 import { asyncHandler } from '../middleware/errorHandler.js';
 import { requireExternalHmac } from '../controllers/externalBillingController.js';
-import { User } from '../models/index.js';
+import {
+  User, RewardEntitlement, RewardOffer, Prospect, Activation, Campaign, Redemption,
+} from '../models/index.js';
+import { hashToken } from '../services/redeemOps/tokens.js';
+import { canEmailProspect } from '../services/redeemOps/fulfilmentNotify.js';
+import { canWhatsAppProspect, waEnabled } from '../services/redeemOps/whatsappService.js';
 import { makeWiredEntitlementService } from '../services/redeemOps/entitlementWiring.js';
 
 /**
- * mktr-leads consultant → voucher unlock (docs/redeem-ops/MKTR_INTEGRATION.md §2).
- * Same posture as the other /api/external/* surfaces: HMAC over the raw body with
- * EXTERNAL_APP_SECRET + signed timestamp (requireExternalHmac), rawBody capture
- * and rate-limiter exemption already wired for the prefix.
+ * mktr-leads consultant surface for reward entitlements
+ * (docs/redeem-ops/MKTR_INTEGRATION.md §2). Same posture as the other
+ * /api/external/* surfaces: HMAC over the raw body with EXTERNAL_APP_SECRET +
+ * signed in-body timestamp (requireExternalHmac); POST-only so the body can
+ * carry that timestamp. Callers are the Supabase brokers, never the device.
  *
- * Body: { timestamp, agentMktrUserId, presentationToken?, prospectId? }
- * unlockedVia is server-derived: presentationToken ⇒ agent_scan,
- * prospectId ⇒ agent_button (a client-sent `via` is ignored).
- * The resolved mirror user must be the lead's assigned consultant.
+ *   POST /unlock  { timestamp, agentMktrUserId, presentationToken? | prospectId? }
+ *     unlockedVia is server-derived: presentationToken ⇒ agent_scan,
+ *     prospectId ⇒ agent_button (a client-sent `via` is ignored). The resolved
+ *     mirror user must be the lead's assigned consultant — enforced in the
+ *     service BEFORE replay/pause responses. The six legacy response fields are
+ *     frozen (ops + Lyfe consumers); everything after them is additive
+ *     enrichment for the app's success screen.
+ *   POST /lookup  { timestamp, agentMktrUserId, token }
+ *     Scan preview for the confirm sheet. Resolves EITHER token hash (the pass
+ *     or the minted voucher — `kind` says which, so the app can name a voucher
+ *     mis-scan). Assignment is checked before ANY payload: a wrong consultant
+ *     gets a bare 403 with zero holder identity.
+ *   POST /summary { timestamp, agentMktrUserId, prospectId }
+ *     Lead-detail CLIENT GIFT card. Entitlement selection matches the manual
+ *     unlock path (latest live first, then latest terminal); `state:'none'`
+ *     when the prospect holds no entitlement at all.
+ *
+ * Error bodies here are route-local `{ success:false, error, code }` — never
+ * routed through the global AppError handler (different shape, no code field).
  */
 export const meta = {
   path: '/api/external/entitlements',
@@ -23,17 +45,198 @@ export const meta = {
 
 const router = express.Router();
 
+/** Minted tokens are 32-byte base64url (43 chars); rewardClaim accepts 16..128. */
+const TOKEN_RE = /^[A-Za-z0-9_-]{16,128}$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// prospect MUST carry email + sourceMetadata — canEmailProspect/canWhatsAppProspect
+// read them; dropping either silently kills the channels computation.
+const ENTITLEMENT_INCLUDE = [
+  { model: RewardOffer, as: 'rewardOffer', attributes: ['id', 'title', 'publicTitle', 'fulfilmentMethod'] },
+  {
+    model: Prospect,
+    as: 'prospect',
+    attributes: ['id', 'firstName', 'phone', 'email', 'sourceMetadata', 'assignedAgentId'],
+  },
+  {
+    model: Activation,
+    as: 'activation',
+    attributes: ['id', 'status', 'campaignNameSnapshot'],
+    include: [{ model: Campaign, as: 'campaign', attributes: ['name'] }],
+  },
+];
+
+async function resolveAgent(agentMktrUserId) {
+  return User.findOne({ where: { mktrLeadsId: String(agentMktrUserId), isActive: true } });
+}
+
+/** Admin override mirrors the unlock service; prospect may be null (lead deleted). */
+function isAssigned(entitlement, agentUser) {
+  if (agentUser.role === 'admin') return true;
+  const prospect = entitlement.prospect;
+  return Boolean(prospect && prospect.assignedAgentId === agentUser.id);
+}
+
+/**
+ * Presentation state. `<=` (not `<`) so presentation can never say "valid" for
+ * an instant the unlock transaction's `expiresAt > now` predicate would reject.
+ * The status column itself can hold 'expired' (sweep) — passed through.
+ */
+function presentState(entitlement) {
+  const expired = entitlement.expiresAt && new Date(entitlement.expiresAt) <= new Date();
+  if (entitlement.status === 'eligible') return expired ? 'expired' : 'reserved';
+  if (entitlement.status === 'issued') return expired ? 'expired' : 'unlocked';
+  return entitlement.status; // redeemed | expired | cancelled | blocked
+}
+
+/**
+ * Display mask, computed server-side so the app never sees more than last-4.
+ * The +65 prefix is shown only when it is actually the number's country code —
+ * prospect phones are general E.164.
+ */
+function maskProspectPhone(phone) {
+  const raw = String(phone || '');
+  const digits = raw.replace(/\D/g, '');
+  if (!digits) return null;
+  const last4 = digits.slice(-4);
+  return raw.startsWith('+65') ? `+65 ···· ${last4}` : `···· ${last4}`;
+}
+
+/** Deliverability CAPABILITY (never delivery confirmation). WA needs the feature flag too. */
+function channelsFor(prospect) {
+  const channels = [];
+  if (waEnabled() && canWhatsAppProspect(prospect)) channels.push('whatsapp');
+  if (canEmailProspect(prospect)) channels.push('email');
+  return channels;
+}
+
+/** Shared projection for lookup/summary (+ reused by unlock enrichment). */
+function giftPayload(entitlement) {
+  const offer = entitlement.rewardOffer;
+  const activation = entitlement.activation;
+  const prospect = entitlement.prospect;
+  const state = presentState(entitlement);
+  return {
+    state,
+    rewardName: offer?.publicTitle || offer?.title || 'Reward',
+    fulfilmentMethod: offer?.fulfilmentMethod || null,
+    holderFirstName: prospect?.firstName || null,
+    holderPhoneMasked: maskProspectPhone(prospect?.phone),
+    campaignName: activation?.campaign?.name ?? activation?.campaignNameSnapshot ?? null,
+    paused: activation?.status === 'paused',
+    channels: channelsFor(prospect),
+    expiresAt: entitlement.expiresAt,
+    unlockedAt: entitlement.unlockedAt,
+    // Token hint only once the voucher exists AND the state still warrants it.
+    ...(state === 'unlocked' || state === 'redeemed' ? { tokenHint: entitlement.tokenHint } : {}),
+  };
+}
+
+/** Route-local error codes (AppError has no code facility; messages are this repo's). */
+function unlockErrorCode(status, message) {
+  if (status === 403) return 'not_assigned';
+  if (status === 404) return 'not_found';
+  if (status === 409) {
+    const m = String(message || '');
+    if (/paused/i.test(m)) return 'paused';
+    if (/is expired/i.test(m)) return 'expired';
+    if (/is blocked/i.test(m)) return 'blocked';
+    if (/is cancelled/i.test(m) || /no longer be unlocked/i.test(m)) return 'cancelled';
+    return 'conflict'; // transactional race: expiry/pause hit at commit time
+  }
+  return 'error';
+}
+
+router.post('/lookup', requireExternalHmac, asyncHandler(async (req, res) => {
+  const { agentMktrUserId, token } = req.body || {};
+  if (!agentMktrUserId || typeof token !== 'string') {
+    return res.status(400).json({ success: false, error: 'agentMktrUserId and token are required' });
+  }
+  const raw = token.trim();
+  if (!TOKEN_RE.test(raw)) {
+    return res.status(400).json({ success: false, error: 'Invalid token', code: 'invalid_token' });
+  }
+  const agent = await resolveAgent(agentMktrUserId);
+  if (!agent) {
+    return res.status(404).json({ success: false, error: 'Unknown agent', code: 'agent_not_found' });
+  }
+
+  const hash = hashToken(raw);
+  const entitlement = await RewardEntitlement.findOne({
+    where: { [Op.or]: [{ presentationTokenHash: hash }, { tokenHash: hash }] },
+    include: ENTITLEMENT_INCLUDE,
+  });
+  if (!entitlement) {
+    return res.status(404).json({ success: false, error: 'Not found', code: 'not_found' });
+  }
+  // Bare 403 BEFORE any payload is assembled — a wrong consultant's scan must
+  // leak no reward, holder, state, or pause signal.
+  if (!isAssigned(entitlement, agent)) {
+    return res.status(403).json({
+      success: false, error: 'Only the assigned consultant can view this pass', code: 'not_assigned',
+    });
+  }
+
+  return res.json({
+    success: true,
+    kind: entitlement.presentationTokenHash === hash ? 'pass' : 'voucher',
+    prospectId: entitlement.prospectId,
+    ...giftPayload(entitlement),
+  });
+}));
+
+router.post('/summary', requireExternalHmac, asyncHandler(async (req, res) => {
+  const { agentMktrUserId, prospectId } = req.body || {};
+  if (!agentMktrUserId || typeof prospectId !== 'string' || !UUID_RE.test(prospectId)) {
+    return res.status(400).json({ success: false, error: 'agentMktrUserId and prospectId (uuid) are required' });
+  }
+  const agent = await resolveAgent(agentMktrUserId);
+  if (!agent) {
+    return res.status(404).json({ success: false, error: 'Unknown agent', code: 'agent_not_found' });
+  }
+
+  // Selection matches the manual-unlock target: the latest LIVE entitlement
+  // wins; only when none exists does the latest terminal row surface (so the
+  // card can show redeemed/expired/cancelled history instead of vanishing).
+  let entitlement = await RewardEntitlement.findOne({
+    where: { prospectId, status: { [Op.in]: ['eligible', 'issued'] } },
+    order: [['createdAt', 'DESC']],
+    include: ENTITLEMENT_INCLUDE,
+  });
+  if (!entitlement) {
+    entitlement = await RewardEntitlement.findOne({
+      where: { prospectId },
+      order: [['createdAt', 'DESC']],
+      include: ENTITLEMENT_INCLUDE,
+    });
+  }
+  if (!entitlement) return res.json({ success: true, state: 'none' });
+  if (!isAssigned(entitlement, agent)) {
+    return res.status(403).json({
+      success: false, error: 'Only the assigned consultant can view this reward', code: 'not_assigned',
+    });
+  }
+
+  // No reverse assoc from entitlement → redemption; the real redeemedAt lives
+  // on the (unique-per-entitlement) redemptions row.
+  let redeemedAt = null;
+  if (entitlement.status === 'redeemed') {
+    const redemption = await Redemption.findOne({ where: { entitlementId: entitlement.id } });
+    redeemedAt = redemption?.redeemedAt ?? null;
+  }
+
+  return res.json({ success: true, ...giftPayload(entitlement), redeemedAt });
+}));
+
 router.post('/unlock', requireExternalHmac, asyncHandler(async (req, res) => {
   const { agentMktrUserId, presentationToken, prospectId } = req.body || {};
   if (!agentMktrUserId || (!presentationToken && !prospectId)) {
     return res.status(400).json({ success: false, error: 'agentMktrUserId and presentationToken or prospectId are required' });
   }
 
-  const agent = await User.findOne({
-    where: { mktrLeadsId: String(agentMktrUserId), isActive: true },
-  });
+  const agent = await resolveAgent(agentMktrUserId);
   if (!agent) {
-    return res.status(404).json({ success: false, error: 'Unknown agent' });
+    return res.status(404).json({ success: false, error: 'Unknown agent', code: 'agent_not_found' });
   }
 
   try {
@@ -46,6 +249,13 @@ router.post('/unlock', requireExternalHmac, asyncHandler(async (req, res) => {
       agent,
       presentationToken ? 'agent_scan' : 'agent_button'
     );
+
+    // Enrichment re-read. The service's return shape is deliberately untouched
+    // (ops console + Lyfe route consume it); the richer payload is safe on both
+    // fresh and replay paths because the service now authorizes BEFORE replying.
+    const full = await RewardEntitlement.findByPk(result.entitlement.id, { include: ENTITLEMENT_INCLUDE });
+    const p = full ? giftPayload(full) : null;
+
     return res.json({
       success: true,
       already: result.already,
@@ -55,11 +265,27 @@ router.post('/unlock', requireExternalHmac, asyncHandler(async (req, res) => {
       entitlementId: result.entitlement.id,
       status: result.entitlement.status,
       tokenHint: result.entitlement.tokenHint,
+      // ── additive enrichment (mktr-leads app success screen) ──
+      ...(p
+        ? {
+            rewardName: p.rewardName,
+            holderFirstName: p.holderFirstName,
+            holderPhoneMasked: p.holderPhoneMasked,
+            campaignName: p.campaignName,
+            channels: p.channels,
+            expiresAt: p.expiresAt,
+            unlockedAt: p.unlockedAt,
+            prospectId: full.prospectId,
+            unlockedByYou: full.unlockedByUserId === agent.id,
+            // "Scheduled", never "sent" — WA delivery is fire-and-forget.
+            waScheduled: result.already !== true && waEnabled() && canWhatsAppProspect(full.prospect),
+          }
+        : {}),
     });
   } catch (err) {
     const code = err.statusCode || 500;
     if (code >= 500) throw err;
-    return res.status(code).json({ success: false, error: err.message });
+    return res.status(code).json({ success: false, error: err.message, code: unlockErrorCode(code, err.message) });
   }
 }));
 

--- a/backend/src/services/redeemOps/entitlementService.js
+++ b/backend/src/services/redeemOps/entitlementService.js
@@ -345,8 +345,11 @@ export function makeEntitlementService(overrides = {}) {
   /**
    * Consultant unlock at the physical meeting (MKTR_INTEGRATION.md §2).
    * `by` = { presentationToken } (scan — proves presence) or { prospectId } (button).
-   * The acting agent must be the lead's assigned consultant (admin override allowed).
-   * Idempotent: an already-unlocked entitlement returns { already: true }.
+   * The acting agent must be the lead's assigned consultant (admin override allowed) —
+   * enforced BEFORE the replay/liveness responses, so an unassigned caller gets a bare
+   * 403 and can never read replay state (token hint) or probe pause status.
+   * Idempotent: an already-unlocked entitlement returns { already: true }, including
+   * when a concurrent unlock wins the conditional transition (double-tap race).
    * `emailQueued` means a FRESH voucher email was scheduled by THIS call —
    * always false on replay (no duplicate mail) and when no usable email exists.
    */
@@ -363,6 +366,19 @@ export function makeEntitlementService(overrides = {}) {
       });
     }
     if (!entitlement) throw new AppError('Entitlement not found', 404);
+
+    // Assigned-consultant binding comes FIRST (admin override audited via
+    // unlockedVia='manual'). Authorization must precede BOTH the replay
+    // carve-out and the liveness gate: an unassigned caller may learn nothing
+    // about the entitlement — not its already-unlocked state (that response
+    // carries the token hint) and not whether its activation is paused.
+    const prospect = entitlement.prospectId ? await d.Prospect.findByPk(entitlement.prospectId) : null;
+    const isAdmin = agentUser.role === 'admin';
+    if (!isAdmin) {
+      if (!prospect || prospect.assignedAgentId !== agentUser.id) {
+        throw new AppError('Only the assigned consultant can unlock this reward', 403);
+      }
+    }
 
     if (['issued', 'redeemed'].includes(entitlement.status)) {
       // Deliberate carve-out: replay stays idempotent even if the activation
@@ -387,19 +403,11 @@ export function makeEntitlementService(overrides = {}) {
       );
     }
 
-    // Assigned-consultant binding (admin override audited via unlockedVia='manual')
-    const prospect = entitlement.prospectId ? await d.Prospect.findByPk(entitlement.prospectId) : null;
-    const isAdmin = agentUser.role === 'admin';
-    if (!isAdmin) {
-      if (!prospect || prospect.assignedAgentId !== agentUser.id) {
-        throw new AppError('Only the assigned consultant can unlock this reward', 403);
-      }
-    }
-
     const offer = await d.RewardOffer.findByPk(entitlement.rewardOfferId);
     const redemptionDays = offer?.redemptionExpiryDays || DEFAULT_REDEMPTION_DAYS;
     const voucher = mintToken();
 
+    let raced = false;
     await d.sequelize.transaction(async (t) => {
       const [count] = await d.RewardEntitlement.update(
         {
@@ -428,13 +436,25 @@ export function makeEntitlementService(overrides = {}) {
         }
       );
       if (count === 0) {
-        throw new AppError('Reservation expired, already unlocked, or its activation is no longer active', 409);
+        raced = true;
+        return;
       }
       await writeEvent(t, {
         entitlementId: entitlement.id, type: 'unlocked',
         actorType: 'agent', actorUserId: agentUser.id, metadata: { via },
       });
     });
+    if (raced) {
+      // The conditional transition lost. A concurrent unlock WINNING is the
+      // idempotent case (the double-tap race) — report it as a replay, not a
+      // scary 409; the caller is already authorized above. Everything else
+      // (expiry passed, activation went non-active at commit time) stays 409.
+      await entitlement.reload();
+      if (['issued', 'redeemed'].includes(entitlement.status)) {
+        return { entitlement, already: true, voucherToken: null, emailQueued: false };
+      }
+      throw new AppError('Reservation expired, already unlocked, or its activation is no longer active', 409);
+    }
 
     await entitlement.reload();
     // Fire-and-forget voucher email (receipt-tracked)

--- a/backend/test/entitlementUnlockVia.test.js
+++ b/backend/test/entitlementUnlockVia.test.js
@@ -27,8 +27,24 @@ const unlockMock = jest.fn();
 jest.unstable_mockModule('../src/services/redeemOps/entitlementWiring.js', () => ({
   makeWiredEntitlementService: () => ({ unlockEntitlement: unlockMock }),
 }));
+// The agent-surface route (lookup/summary + unlock enrichment) statically
+// imports the entitlement graph models and the channel helpers; every named
+// export it touches must exist here or ESM linking fails before any test runs.
 jest.unstable_mockModule('../src/models/index.js', () => ({
   User: { findOne: jest.fn().mockResolvedValue({ id: 'agent-1', role: 'agent' }) },
+  RewardEntitlement: { findOne: jest.fn().mockResolvedValue(null), findByPk: jest.fn().mockResolvedValue(null) },
+  RewardOffer: {},
+  Prospect: {},
+  Activation: {},
+  Campaign: {},
+  Redemption: { findOne: jest.fn().mockResolvedValue(null) },
+}));
+jest.unstable_mockModule('../src/services/redeemOps/fulfilmentNotify.js', () => ({
+  canEmailProspect: () => false,
+}));
+jest.unstable_mockModule('../src/services/redeemOps/whatsappService.js', () => ({
+  waEnabled: () => false,
+  canWhatsAppProspect: () => false,
 }));
 jest.unstable_mockModule('../src/controllers/externalBillingController.js', () => ({
   requireExternalHmac: (_req, _res, next) => next(),

--- a/backend/test/externalEntitlementsAgentSurface.test.js
+++ b/backend/test/externalEntitlementsAgentSurface.test.js
@@ -1,0 +1,336 @@
+/**
+ * /api/external/entitlements agent surface — lookup + summary + unlock
+ * enrichment (mktr-leads Gift Pass Scanner). Route logic only: models,
+ * wiring, channel helpers, and the HMAC middleware are mocked (repo pattern —
+ * see entitlementUnlockVia.test.js); tokens.js is REAL so kind detection runs
+ * the same sha256 path as production.
+ *
+ * The invariants under test:
+ *  - a wrong consultant gets a BARE 403 body (success/error/code, nothing
+ *    else) from lookup and summary — zero holder identity;
+ *  - kind: pass vs voucher is decided by WHICH hash matched (voucher-first
+ *    mis-scan handling in the app depends on it);
+ *  - presentState uses expiresAt <= now and never leaks tokenHint on expired;
+ *  - summary's selection = manual unlock's (latest LIVE first, terminal only
+ *    as fallback) and state:'none' when the prospect holds nothing;
+ *  - unlock keeps the six legacy fields byte-compatible and only ADDS fields;
+ *    waScheduled is capability+flag on fresh unlocks only, never on replay;
+ *  - error → code mapping (route-local; AppError has no code facility).
+ */
+import { jest } from '@jest/globals';
+import { Op } from 'sequelize';
+import express from 'express';
+import request from 'supertest';
+import { hashToken } from '../src/services/redeemOps/tokens.js';
+
+const unlockMock = jest.fn();
+const userFindOne = jest.fn();
+const entFindOne = jest.fn();
+const entFindByPk = jest.fn();
+const redemptionFindOne = jest.fn();
+
+// Mutable channel-helper behavior (the helpers' own logic is covered where
+// they live; here we test the route's gating/composition).
+const channelState = { waEnabled: true, waCapable: true, emailCapable: true };
+
+jest.unstable_mockModule('../src/services/redeemOps/entitlementWiring.js', () => ({
+  makeWiredEntitlementService: () => ({ unlockEntitlement: unlockMock }),
+}));
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  User: { findOne: userFindOne },
+  RewardEntitlement: { findOne: entFindOne, findByPk: entFindByPk },
+  RewardOffer: {},
+  Prospect: {},
+  Activation: {},
+  Campaign: {},
+  Redemption: { findOne: redemptionFindOne },
+}));
+jest.unstable_mockModule('../src/services/redeemOps/fulfilmentNotify.js', () => ({
+  canEmailProspect: () => channelState.emailCapable,
+}));
+jest.unstable_mockModule('../src/services/redeemOps/whatsappService.js', () => ({
+  waEnabled: () => channelState.waEnabled,
+  canWhatsAppProspect: () => channelState.waCapable,
+}));
+jest.unstable_mockModule('../src/controllers/externalBillingController.js', () => ({
+  requireExternalHmac: (_req, _res, next) => next(),
+}));
+
+let router;
+beforeAll(async () => {
+  ({ default: router } = await import('../src/routes/externalEntitlements.js'));
+});
+
+const app = () => express().use(express.json()).use(router);
+
+const AGENT = { id: 'agent-1', role: 'agent' };
+const PASS_TOKEN = 'PassToken_1234567890abcdefBASE64urlSHAPED_43ch';
+const VOUCHER_TOKEN = 'VoucherTok_1234567890abcdefBASE64urlSHAPE43';
+const PROSPECT_ID = '11111111-2222-4333-8444-555555555555';
+const FUTURE = new Date(Date.now() + 7 * 86400000).toISOString();
+const PAST = new Date(Date.now() - 86400000).toISOString();
+
+/** Entitlement row as the include-laden query would return it. */
+function ent(overrides = {}) {
+  return {
+    id: 'ent-1',
+    status: 'eligible',
+    presentationTokenHash: hashToken(PASS_TOKEN),
+    tokenHash: hashToken(VOUCHER_TOKEN),
+    tokenHint: 'K7Q2',
+    expiresAt: FUTURE,
+    unlockedAt: null,
+    unlockedByUserId: null,
+    prospectId: PROSPECT_ID,
+    rewardOffer: { title: 'FairPrice voucher', publicTitle: 'S$10 NTUC FairPrice e-voucher', fulfilmentMethod: 'evoucher' },
+    prospect: {
+      id: PROSPECT_ID,
+      firstName: 'Jasmine',
+      phone: '+6591234821',
+      email: 'jasmine@example.com',
+      sourceMetadata: { consent_contact: true },
+      assignedAgentId: 'agent-1',
+    },
+    activation: { id: 'act-1', status: 'active', campaignNameSnapshot: 'Q3 Motor Switch (snapshot)', campaign: { name: 'Q3 Motor Switch' } },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  channelState.waEnabled = true;
+  channelState.waCapable = true;
+  channelState.emailCapable = true;
+  userFindOne.mockReset().mockResolvedValue(AGENT);
+  entFindOne.mockReset().mockResolvedValue(null);
+  entFindByPk.mockReset().mockResolvedValue(null);
+  redemptionFindOne.mockReset().mockResolvedValue(null);
+  unlockMock.mockReset();
+});
+
+describe('POST /lookup', () => {
+  it('400s a malformed token without touching the models', async () => {
+    const res = await request(app()).post('/lookup').send({ agentMktrUserId: 'm-1', token: 'no' });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('invalid_token');
+    expect(entFindOne).not.toHaveBeenCalled();
+  });
+
+  it('404s an unknown agent with agent_not_found', async () => {
+    userFindOne.mockResolvedValue(null);
+    const res = await request(app()).post('/lookup').send({ agentMktrUserId: 'm-x', token: PASS_TOKEN });
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('agent_not_found');
+  });
+
+  it('404s an unresolvable token with not_found', async () => {
+    const res = await request(app()).post('/lookup').send({ agentMktrUserId: 'm-1', token: PASS_TOKEN });
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('not_found');
+  });
+
+  it('gives the WRONG consultant a bare 403 — no identity keys at all', async () => {
+    entFindOne.mockResolvedValue(ent({ prospect: { ...ent().prospect, assignedAgentId: 'someone-else' } }));
+    const res = await request(app()).post('/lookup').send({ agentMktrUserId: 'm-1', token: PASS_TOKEN });
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({
+      success: false,
+      error: 'Only the assigned consultant can view this pass',
+      code: 'not_assigned',
+    });
+    expect(Object.keys(res.body).sort()).toEqual(['code', 'error', 'success']);
+  });
+
+  it('403s when the prospect row is gone (lead deleted) for non-admins', async () => {
+    entFindOne.mockResolvedValue(ent({ prospect: null }));
+    const res = await request(app()).post('/lookup').send({ agentMktrUserId: 'm-1', token: PASS_TOKEN });
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('not_assigned');
+  });
+
+  it('resolves the PASS hash as kind:pass with the reserved payload', async () => {
+    entFindOne.mockResolvedValue(ent());
+    const res = await request(app()).post('/lookup').send({ agentMktrUserId: 'm-1', token: PASS_TOKEN });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      success: true,
+      kind: 'pass',
+      state: 'reserved',
+      rewardName: 'S$10 NTUC FairPrice e-voucher',
+      holderFirstName: 'Jasmine',
+      holderPhoneMasked: '+65 ···· 4821',
+      campaignName: 'Q3 Motor Switch',
+      paused: false,
+      prospectId: PROSPECT_ID,
+      channels: ['whatsapp', 'email'],
+    });
+    expect(res.body.tokenHint).toBeUndefined(); // reserved never reveals the hint
+  });
+
+  it('resolves the VOUCHER hash as kind:voucher (mis-scan card)', async () => {
+    entFindOne.mockResolvedValue(ent({ status: 'issued', unlockedAt: PAST }));
+    const res = await request(app()).post('/lookup').send({ agentMktrUserId: 'm-1', token: VOUCHER_TOKEN });
+    expect(res.status).toBe(200);
+    expect(res.body.kind).toBe('voucher');
+    expect(res.body.state).toBe('unlocked');
+    expect(res.body.tokenHint).toBe('K7Q2');
+  });
+
+  it('computes expired (expiresAt <= now) for an issued voucher and hides the hint', async () => {
+    entFindOne.mockResolvedValue(ent({ status: 'issued', expiresAt: PAST }));
+    const res = await request(app()).post('/lookup').send({ agentMktrUserId: 'm-1', token: PASS_TOKEN });
+    expect(res.body.state).toBe('expired');
+    expect(res.body.tokenHint).toBeUndefined();
+  });
+
+  it('keeps blocked as its own state and surfaces paused from the activation', async () => {
+    entFindOne.mockResolvedValue(
+      ent({ status: 'blocked', activation: { ...ent().activation, status: 'paused' } }),
+    );
+    const res = await request(app()).post('/lookup').send({ agentMktrUserId: 'm-1', token: PASS_TOKEN });
+    expect(res.body.state).toBe('blocked');
+    expect(res.body.paused).toBe(true);
+  });
+
+  it('drops whatsapp from channels when the feature flag is off', async () => {
+    channelState.waEnabled = false;
+    entFindOne.mockResolvedValue(ent());
+    const res = await request(app()).post('/lookup').send({ agentMktrUserId: 'm-1', token: PASS_TOKEN });
+    expect(res.body.channels).toEqual(['email']);
+  });
+
+  it('falls back to the campaign name snapshot when the campaign row is gone', async () => {
+    entFindOne.mockResolvedValue(ent({ activation: { ...ent().activation, campaign: null } }));
+    const res = await request(app()).post('/lookup').send({ agentMktrUserId: 'm-1', token: PASS_TOKEN });
+    expect(res.body.campaignName).toBe('Q3 Motor Switch (snapshot)');
+  });
+});
+
+describe('POST /summary', () => {
+  it('400s a non-uuid prospectId', async () => {
+    const res = await request(app()).post('/summary').send({ agentMktrUserId: 'm-1', prospectId: 'nope' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns state:none when the prospect holds no entitlement', async () => {
+    const res = await request(app()).post('/summary').send({ agentMktrUserId: 'm-1', prospectId: PROSPECT_ID });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true, state: 'none' });
+  });
+
+  it('queries the LIVE selection first (matches the manual-unlock target)', async () => {
+    entFindOne.mockResolvedValueOnce(ent({ status: 'eligible' }));
+    const res = await request(app()).post('/summary').send({ agentMktrUserId: 'm-1', prospectId: PROSPECT_ID });
+    expect(res.body.state).toBe('reserved');
+    expect(entFindOne).toHaveBeenCalledTimes(1);
+    const firstWhere = entFindOne.mock.calls[0][0].where;
+    expect(firstWhere.prospectId).toBe(PROSPECT_ID);
+    expect(firstWhere.status[Op.in]).toEqual(['eligible', 'issued']); // live filter present
+  });
+
+  it('falls back to the latest terminal row so history still renders', async () => {
+    entFindOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(ent({ status: 'cancelled' }));
+    const res = await request(app()).post('/summary').send({ agentMktrUserId: 'm-1', prospectId: PROSPECT_ID });
+    expect(res.body.state).toBe('cancelled');
+    expect(entFindOne).toHaveBeenCalledTimes(2);
+  });
+
+  it('joins redeemedAt from the redemptions row for redeemed state', async () => {
+    entFindOne.mockResolvedValueOnce(ent({ status: 'redeemed', unlockedAt: PAST }));
+    redemptionFindOne.mockResolvedValue({ redeemedAt: '2026-07-21T08:00:00.000Z' });
+    const res = await request(app()).post('/summary').send({ agentMktrUserId: 'm-1', prospectId: PROSPECT_ID });
+    expect(res.body.state).toBe('redeemed');
+    expect(res.body.redeemedAt).toBe('2026-07-21T08:00:00.000Z');
+    expect(redemptionFindOne).toHaveBeenCalledWith({ where: { entitlementId: 'ent-1' } });
+  });
+
+  it('gives a wrong consultant the bare 403 body', async () => {
+    entFindOne.mockResolvedValueOnce(ent({ prospect: { ...ent().prospect, assignedAgentId: 'other' } }));
+    const res = await request(app()).post('/summary').send({ agentMktrUserId: 'm-1', prospectId: PROSPECT_ID });
+    expect(res.status).toBe(403);
+    expect(Object.keys(res.body).sort()).toEqual(['code', 'error', 'success']);
+  });
+});
+
+describe('POST /unlock — enrichment + code mapping', () => {
+  it('keeps the six legacy fields and adds the enrichment on a fresh unlock', async () => {
+    unlockMock.mockResolvedValue({
+      already: false,
+      emailQueued: true,
+      voucherToken: 'raw',
+      entitlement: { id: 'ent-1', status: 'issued', tokenHint: 'K7Q2' },
+    });
+    entFindByPk.mockResolvedValue(ent({ status: 'issued', unlockedAt: FUTURE, unlockedByUserId: 'agent-1' }));
+    const res = await request(app()).post('/unlock').send({ agentMktrUserId: 'm-1', prospectId: PROSPECT_ID });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      success: true,
+      already: false,
+      emailQueued: true,
+      entitlementId: 'ent-1',
+      status: 'issued',
+      tokenHint: 'K7Q2',
+      rewardName: 'S$10 NTUC FairPrice e-voucher',
+      holderFirstName: 'Jasmine',
+      holderPhoneMasked: '+65 ···· 4821',
+      campaignName: 'Q3 Motor Switch',
+      channels: ['whatsapp', 'email'],
+      prospectId: PROSPECT_ID,
+      unlockedByYou: true,
+      waScheduled: true,
+    });
+  });
+
+  it('never claims waScheduled on replay', async () => {
+    unlockMock.mockResolvedValue({
+      already: true,
+      emailQueued: false,
+      voucherToken: null,
+      entitlement: { id: 'ent-1', status: 'issued', tokenHint: 'K7Q2' },
+    });
+    entFindByPk.mockResolvedValue(ent({ status: 'issued', unlockedByUserId: 'agent-1' }));
+    const res = await request(app()).post('/unlock').send({ agentMktrUserId: 'm-1', prospectId: PROSPECT_ID });
+    expect(res.body.already).toBe(true);
+    expect(res.body.waScheduled).toBe(false);
+    expect(res.body.emailQueued).toBe(false);
+  });
+
+  it('still answers with the legacy shape when the re-read misses (row gone)', async () => {
+    unlockMock.mockResolvedValue({
+      already: false,
+      emailQueued: false,
+      voucherToken: 'raw',
+      entitlement: { id: 'ent-1', status: 'issued', tokenHint: 'K7Q2' },
+    });
+    entFindByPk.mockResolvedValue(null);
+    const res = await request(app()).post('/unlock').send({ agentMktrUserId: 'm-1', prospectId: PROSPECT_ID });
+    expect(res.status).toBe(200);
+    expect(res.body.entitlementId).toBe('ent-1');
+    expect(res.body.rewardName).toBeUndefined();
+  });
+
+  it('404s an unknown agent with agent_not_found before the service runs', async () => {
+    userFindOne.mockResolvedValue(null);
+    const res = await request(app()).post('/unlock').send({ agentMktrUserId: 'm-x', prospectId: PROSPECT_ID });
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('agent_not_found');
+    expect(unlockMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [403, 'Only the assigned consultant can unlock this reward', 'not_assigned'],
+    [404, 'Entitlement not found', 'not_found'],
+    [409, 'Activation is paused — unlocks are temporarily disabled', 'paused'],
+    [409, 'Entitlement is expired', 'expired'],
+    [409, 'Entitlement is blocked', 'blocked'],
+    [409, 'Entitlement is cancelled', 'cancelled'],
+    [409, 'Activation is completed — this reward can no longer be unlocked', 'cancelled'],
+    [409, 'Reservation expired, already unlocked, or its activation is no longer active', 'conflict'],
+  ])('maps a %s "%s" service error to code %s', async (statusCode, message, code) => {
+    unlockMock.mockRejectedValue(Object.assign(new Error(message), { statusCode }));
+    const res = await request(app()).post('/unlock').send({ agentMktrUserId: 'm-1', prospectId: PROSPECT_ID });
+    expect(res.status).toBe(statusCode);
+    expect(res.body).toMatchObject({ success: false, error: message, code });
+  });
+});

--- a/backend/test/redeemOpsFulfilment.test.js
+++ b/backend/test/redeemOpsFulfilment.test.js
@@ -147,6 +147,14 @@ describe('unlock at the meeting', () => {
     globalThis.__presentation = issueResult.presentationToken;
   });
 
+  test('the WRONG consultant cannot even REPLAY an unlocked pass (auth precedes the carve-out)', async () => {
+    // Before the reorder, replay skipped the assignment check entirely and
+    // handed a wrong consultant already:true + the token hint.
+    await expect(
+      entitlements.unlockEntitlement({ presentationToken: issueResult.presentationToken }, agentB.user)
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
   test('verify now unmasks holder + shows VALID; post-unlock the presentation token also verifies', async () => {
     const res = await request(app)
       .post('/api/redeem-ops/redemptions/verify')


### PR DESCRIPTION
Gift Pass Scanner backend surface for the mktr-leads app (design: Gift Pass Scanner.dc.html; broker EF `mktr-agent-gift` consumes these).

## What
- **POST /api/external/entitlements/lookup** — scan preview by either token hash (`kind: pass|voucher` → the app's voucher mis-scan card). Assignment is checked **before any payload**: a wrong consultant gets a bare `{success,error,code:'not_assigned'}` — zero holder identity (pinned by test).
- **POST /api/external/entitlements/summary** — lead-detail CLIENT GIFT card DTO. Entitlement selection matches the manual-unlock target (latest live, else latest terminal); `state:'none'` when the prospect holds nothing; `redeemedAt` joined from the redemptions row.
- **POST /unlock** — additive enrichment only (rewardName / holder / campaign / channels / waScheduled / unlockedByYou / prospectId + route-local error `code`s). The six legacy fields are byte-identical — ops console + Lyfe route unaffected.

## Security fix (unlockEntitlement)
The assigned-consultant check now precedes BOTH the `already:true` replay carve-out and the activation pause gate. Previously a wrong consultant could replay an already-unlocked pass and read the token hint, and could probe pause state. Also: a concurrent unlock that loses the conditional transition now re-reads and reports `already:true` (double-tap race) instead of a generic 409.

## Tests
- New `test/externalEntitlementsAgentSurface.test.js` (29 cases, mocked models — kind detection, bare-403 body shape, state mapping incl. computed expiry, selection rule, enrichment, code map).
- Wrong-consultant **replay** → 403 pinned in the DB-backed fulfilment suite; full DB suites green locally (PG 17).
- The 5 failing suites on this branch (analytics / shortlinkService / referralAttribution / redeemedAudienceService / externalHeldLeadsController) fail **identically on main** — pre-existing standing reds, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSB4DojZGyqPZXBhRXdgG6