### PR TITLE
feat(consumer-spine): durable cross-campaign person entity + identity integrity (PR A)

### DIFF
--- a/backend/scripts/rebuild-consumer-spine.js
+++ b/backend/scripts/rebuild-consumer-spine.js
@@ -1,0 +1,26 @@
+/**
+ * Rebuild/heal the consumer spine — the drift repair tool the projection
+ * design leans on (docs/plans/consumer-spine-and-consent-ledger.md §2.4).
+ *
+ * Runs the SAME reconciler as migration 079: assigns complete projections
+ * from prospect rows (never increments), heals wrong/missing links, unlinks
+ * call_bot rows, links entitlements. Idempotent — safe to run anytime.
+ *
+ * Usage: node scripts/rebuild-consumer-spine.js
+ */
+import dotenv from 'dotenv';
+dotenv.config({ path: new URL('../.env', import.meta.url) });
+
+const { sequelize } = await import('../src/database/connection.js');
+const { reconcileConsumerSpine } = await import('../src/services/consumerService.js');
+
+try {
+  await sequelize.authenticate();
+  const stats = await reconcileConsumerSpine();
+  console.log('[rebuild-consumer-spine] done:', JSON.stringify(stats, null, 2));
+  await sequelize.close();
+  process.exit(0);
+} catch (err) {
+  console.error('[rebuild-consumer-spine] failed:', err?.message || err);
+  process.exit(1);
+}

--- a/backend/src/controllers/consumerController.js
+++ b/backend/src/controllers/consumerController.js
@@ -1,0 +1,22 @@
+import { asyncHandler, AppError } from '../middleware/errorHandler.js';
+import { getConsumerJourney } from '../services/consumerService.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * One person's cross-campaign journey (consumer spine). Route-gated to admin —
+ * this aggregates PII across campaigns, unlike the per-lead prospect detail.
+ * Malformed ids 404 up front (a raw uuid-cast error would surface as a 500 —
+ * the AdminCampaignDesigner lesson).
+ */
+export const getConsumer = asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  if (!UUID_RE.test(String(id || ''))) {
+    throw new AppError('Consumer not found', 404);
+  }
+  const journey = await getConsumerJourney(id);
+  if (!journey) {
+    throw new AppError('Consumer not found', 404);
+  }
+  res.json({ success: true, data: journey });
+});

--- a/backend/src/database/migrations/078-consumer-spine.js
+++ b/backend/src/database/migrations/078-consumer-spine.js
@@ -1,0 +1,91 @@
+/**
+ * 078 — Consumer spine (docs/plans/consumer-spine-and-consent-ledger.md §2.1).
+ *
+ * `consumers` = the durable cross-campaign person, keyed by E.164 phone (one
+ * row per human; prospects stay one-row-per-campaign-signup). Additive only:
+ * nullable `consumerId` FKs on prospects + reward_entitlements, no behavior
+ * change on existing paths. 079 backfills/reconciles the projection.
+ *
+ * Guarded/idempotent like 052–077 AND sync-tolerant: in test boot,
+ * sequelize.sync({force:true}) creates these tables/indexes from the models
+ * FIRST (bootstrap.js) — every statement here must no-op cleanly on top of
+ * that (IF NOT EXISTS by the exact names the models declare; FK adds check
+ * information_schema because sync names its FKs differently).
+ */
+export async function up(queryInterface) {
+  const q = (sql) => queryInterface.sequelize.query(sql);
+
+  await q(`CREATE TABLE IF NOT EXISTS consumers (
+    id UUID PRIMARY KEY,
+    phone VARCHAR(20),
+    "phoneHash" VARCHAR(64) NOT NULL,
+    "firstName" VARCHAR(255),
+    "lastName" VARCHAR(255),
+    email VARCHAR(255),
+    "firstSeenAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "lastSeenAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "signupCount" INTEGER NOT NULL DEFAULT 0,
+    "verifiedSignupCount" INTEGER NOT NULL DEFAULT 0,
+    "unsubTokenHash" VARCHAR(64),
+    "erasedAt" TIMESTAMP WITH TIME ZONE,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+  )`);
+
+  // Identity key: one live consumer per phone; null (erased) rows exempt.
+  await q(`CREATE UNIQUE INDEX IF NOT EXISTS uq_consumers_phone
+             ON consumers (phone) WHERE phone IS NOT NULL`);
+  await q(`CREATE INDEX IF NOT EXISTS idx_consumers_phone_hash ON consumers ("phoneHash")`);
+  await q(`CREATE INDEX IF NOT EXISTS idx_consumers_last_seen ON consumers ("lastSeenAt")`);
+
+  // Integrity CHECKs (name-guarded — ADD CONSTRAINT has no IF NOT EXISTS).
+  await q(`DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_consumers_phone_e164') THEN
+      ALTER TABLE consumers ADD CONSTRAINT chk_consumers_phone_e164
+        CHECK (phone IS NULL OR phone ~ '^\\+[1-9][0-9]{9,14}$');
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_consumers_phone_hash_hex') THEN
+      ALTER TABLE consumers ADD CONSTRAINT chk_consumers_phone_hash_hex
+        CHECK ("phoneHash" ~ '^[0-9a-f]{64}$');
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_consumers_counts') THEN
+      ALTER TABLE consumers ADD CONSTRAINT chk_consumers_counts
+        CHECK ("signupCount" >= 0 AND "verifiedSignupCount" >= 0);
+    END IF;
+  END $$`);
+
+  await q(`ALTER TABLE prospects ADD COLUMN IF NOT EXISTS "consumerId" UUID`);
+  await q(`ALTER TABLE reward_entitlements ADD COLUMN IF NOT EXISTS "consumerId" UUID`);
+  await q(`CREATE INDEX IF NOT EXISTS idx_prospects_consumer ON prospects ("consumerId")`);
+  await q(`CREATE INDEX IF NOT EXISTS idx_re_consumer ON reward_entitlements ("consumerId")`);
+
+  // FKs: SET NULL on consumer delete (history survives). Column-level existence
+  // check — sync-created FKs carry Sequelize's own constraint names.
+  await q(`DO $$ BEGIN
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
+       WHERE tc.table_name = 'prospects' AND tc.constraint_type = 'FOREIGN KEY'
+         AND kcu.column_name = 'consumerId'
+    ) THEN
+      ALTER TABLE prospects ADD CONSTRAINT fk_prospects_consumer
+        FOREIGN KEY ("consumerId") REFERENCES consumers(id) ON DELETE SET NULL;
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
+       WHERE tc.table_name = 'reward_entitlements' AND tc.constraint_type = 'FOREIGN KEY'
+         AND kcu.column_name = 'consumerId'
+    ) THEN
+      ALTER TABLE reward_entitlements ADD CONSTRAINT fk_re_consumer
+        FOREIGN KEY ("consumerId") REFERENCES consumers(id) ON DELETE SET NULL;
+    END IF;
+  END $$`);
+}
+
+export async function down(queryInterface) {
+  const q = (sql) => queryInterface.sequelize.query(sql);
+  await q('ALTER TABLE reward_entitlements DROP COLUMN IF EXISTS "consumerId"');
+  await q('ALTER TABLE prospects DROP COLUMN IF EXISTS "consumerId"');
+  await q('DROP TABLE IF EXISTS consumers');
+}

--- a/backend/src/database/migrations/078-consumer-spine.js
+++ b/backend/src/database/migrations/078-consumer-spine.js
@@ -18,7 +18,7 @@ export async function up(queryInterface) {
   await q(`CREATE TABLE IF NOT EXISTS consumers (
     id UUID PRIMARY KEY,
     phone VARCHAR(20),
-    "phoneHash" VARCHAR(64) NOT NULL,
+    "phoneHash" VARCHAR(64),
     "firstName" VARCHAR(255),
     "lastName" VARCHAR(255),
     email VARCHAR(255),
@@ -45,8 +45,10 @@ export async function up(queryInterface) {
         CHECK (phone IS NULL OR phone ~ '^\\+[1-9][0-9]{9,14}$');
     END IF;
     IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_consumers_phone_hash_hex') THEN
+      -- Nullable: PR C's erasure nulls the hash too (no pseudonymous tombstone
+      -- — PDPC anonymisation posture, Codex R1 #17 / R2 #6).
       ALTER TABLE consumers ADD CONSTRAINT chk_consumers_phone_hash_hex
-        CHECK ("phoneHash" ~ '^[0-9a-f]{64}$');
+        CHECK ("phoneHash" IS NULL OR "phoneHash" ~ '^[0-9a-f]{64}$');
     END IF;
     IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_consumers_counts') THEN
       ALTER TABLE consumers ADD CONSTRAINT chk_consumers_counts

--- a/backend/src/database/migrations/079-consumer-reconcile.js
+++ b/backend/src/database/migrations/079-consumer-reconcile.js
@@ -1,0 +1,25 @@
+/**
+ * 079 — Consumer-spine backfill/reconcile (plan §2.4).
+ *
+ * Runs the SAME reconciler as scripts/rebuild-consumer-spine.js (shared module
+ * — migration/script parity by construction): JS-normalizes phones with the
+ * capture path's normalizePhone, ASSIGNS complete projections (never
+ * increments), heals wrong links, unlinks call_bot rows, links entitlements
+ * via prospect then phoneKey. Idempotent — re-running yields identical state,
+ * and the runner's advisory lock serializes concurrent boots.
+ *
+ * ~135 prospects / 130 phones at ship time (2026-07-19 preflight).
+ */
+export async function up() {
+  const { reconcileConsumerSpine } = await import('../../services/consumerService.js');
+  const { logger } = await import('../../utils/logger.js');
+  const stats = await reconcileConsumerSpine();
+  logger.info('[079] consumer spine reconciled', stats);
+}
+
+export async function down(queryInterface) {
+  const q = (sql) => queryInterface.sequelize.query(sql);
+  await q('UPDATE reward_entitlements SET "consumerId" = NULL WHERE "consumerId" IS NOT NULL');
+  await q('UPDATE prospects SET "consumerId" = NULL WHERE "consumerId" IS NOT NULL');
+  await q('DELETE FROM consumers');
+}

--- a/backend/src/database/runMigrations.js
+++ b/backend/src/database/runMigrations.js
@@ -19,6 +19,20 @@ const MIGRATIONS_DIR = path.join(__dirname, 'migrations');
  * This keeps both old-style (instance) and new-style (class) migrations happy.
  */
 export async function runMigrations() {
+  // Serialize concurrent runners — rolling deploys briefly run old+new
+  // instances together, and this runner has no other coordination. The
+  // advisory lock is session-scoped and auto-released at COMMIT; the wrapping
+  // transaction does nothing else, so each migration still executes its own
+  // statements on other pool connections exactly as before. A second runner
+  // blocks on the lock, then re-reads _migrations and skips everything the
+  // first one applied.
+  await sequelize.transaction(async (lockTx) => {
+    await sequelize.query('SELECT pg_advisory_xact_lock(870778001)', { transaction: lockTx });
+    await runPendingMigrations();
+  });
+}
+
+async function runPendingMigrations() {
   const qi = sequelize.getQueryInterface();
 
   // Build a merged context so migrations can use both

--- a/backend/src/middleware/internalRouteHostGuard.js
+++ b/backend/src/middleware/internalRouteHostGuard.js
@@ -20,6 +20,7 @@ import { logger } from '../utils/logger.js';
 const BLOCKED_PATH_PREFIXES = [
   '/api/auth',
   '/api/admin',
+  '/api/consumers',
   '/api/agents',
   '/api/fleet',
   '/api/devices',

--- a/backend/src/models/Consumer.js
+++ b/backend/src/models/Consumer.js
@@ -28,7 +28,7 @@ const Consumer = sequelize.define('Consumer', {
   },
   phoneHash: {
     type: DataTypes.STRING(64),
-    allowNull: false,
+    allowNull: true, // nulled together with phone on PR-C erasure — no tombstone
     comment: 'sha256 hex of the E.164 phone (same recipe as sourceMetadata.phoneVerifiedFor)'
   },
   firstName: { type: DataTypes.STRING, allowNull: true },

--- a/backend/src/models/Consumer.js
+++ b/backend/src/models/Consumer.js
@@ -1,0 +1,65 @@
+import { DataTypes, Op } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * The durable cross-campaign person (docs/plans/consumer-spine-and-consent-ledger.md).
+ *
+ * Identity key = E.164 phone; prospects stay one-row-per-campaign-signup and
+ * FK here via `consumerId`. This table is a REBUILDABLE PROJECTION of
+ * prospects: the capture resolver writes it best-effort behind a savepoint and
+ * reconcileConsumerSpine() (migration 079 / scripts/rebuild-consumer-spine.js)
+ * re-derives every row, so drift is always repairable — never trust a counter
+ * over a recompute.
+ *
+ * call_bot (Retell) prospects are deliberately NOT linked: prospect.phone is
+ * the call's to_number, which for inbound calls is MKTR's own DDI
+ * (retellService.js §DNC note) — linking would merge strangers.
+ *
+ * `unsubTokenHash`/`erasedAt` land dark here (PR A) for the consent-ledger and
+ * erasure PRs — nothing reads them yet.
+ */
+const Consumer = sequelize.define('Consumer', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  phone: {
+    type: DataTypes.STRING(20),
+    allowNull: true, // null only after erasure (PR C); live rows always have one
+    validate: { is: /^\+[1-9]\d{9,14}$/ },
+    comment: 'E.164 identity key — one live consumer per phone (uq_consumers_phone)'
+  },
+  phoneHash: {
+    type: DataTypes.STRING(64),
+    allowNull: false,
+    comment: 'sha256 hex of the E.164 phone (same recipe as sourceMetadata.phoneVerifiedFor)'
+  },
+  firstName: { type: DataTypes.STRING, allowNull: true },
+  lastName: { type: DataTypes.STRING, allowNull: true },
+  email: {
+    type: DataTypes.STRING,
+    allowNull: true,
+    comment: 'Latest real (non-synthetic) email seen — an attribute, never an identity key'
+  },
+  firstSeenAt: { type: DataTypes.DATE, allowNull: false },
+  lastSeenAt: { type: DataTypes.DATE, allowNull: false },
+  signupCount: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  verifiedSignupCount: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    defaultValue: 0,
+    comment: 'Signups carrying a live-at-capture OTP stamp — only these can ever mint marketing authority (PR B)'
+  },
+  unsubTokenHash: { type: DataTypes.STRING(64), allowNull: true, comment: 'PR B: sha256 of the opaque unsubscribe token' },
+  erasedAt: { type: DataTypes.DATE, allowNull: true, comment: 'PR C: PDPA erasure timestamp' },
+}, {
+  tableName: 'consumers',
+  indexes: [
+    // Mirrored on the model because test boot builds schema via
+    // sync({force:true}) BEFORE migrations (bootstrap.js) — a migration-only
+    // index would silently vanish there (the Prospect (campaignId,phone)
+    // lesson; see RewardEntitlement.js for the same pattern).
+    { unique: true, fields: ['phone'], name: 'uq_consumers_phone', where: { phone: { [Op.ne]: null } } },
+    { fields: ['phoneHash'], name: 'idx_consumers_phone_hash' },
+    { fields: ['lastSeenAt'], name: 'idx_consumers_last_seen' },
+  ]
+});
+
+export default Consumer;

--- a/backend/src/models/Prospect.js
+++ b/backend/src/models/Prospect.js
@@ -206,6 +206,12 @@ const Prospect = sequelize.define('Prospect', {
       key: 'id'
     }
   },
+  consumerId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    references: { model: 'consumers', key: 'id' },
+    comment: 'Cross-campaign person link (consumer spine, migration 078) — SET NULL on consumer delete; null for call_bot leads and pre-spine rows until reconciled'
+  },
   sessionId: {
     type: DataTypes.STRING(64),
     allowNull: true
@@ -314,6 +320,7 @@ const Prospect = sequelize.define('Prospect', {
     {
       fields: ['nextFollowUpDate']
     },
+    { fields: ['consumerId'], name: 'idx_prospects_consumer' },
     { fields: ['createdAt'], name: 'idx_prospects_createdat' },
     { fields: ['conversionDate'], name: 'idx_prospects_conversiondate', where: { conversionDate: { [Op.ne]: null } } },
     { fields: ['assignedAgentId', 'leadStatus'], name: 'idx_prospects_agent_status' },

--- a/backend/src/models/Prospect.js
+++ b/backend/src/models/Prospect.js
@@ -321,6 +321,17 @@ const Prospect = sequelize.define('Prospect', {
       fields: ['nextFollowUpDate']
     },
     { fields: ['consumerId'], name: 'idx_prospects_consumer' },
+    // Managed by migration 010 in prod; mirrored here because test boot builds
+    // schema via sync({force:true}) AFTER _migrations already records 010 —
+    // without this mirror, local test DBs silently LOSE the dedupe unique on
+    // every boot after the first (proven by the concurrent-duplicate test in
+    // consumerSpine.test.js: both inserts returned 201).
+    {
+      unique: true,
+      fields: ['campaignId', 'phone'],
+      name: 'prospects_campaign_id_phone',
+      where: { phone: { [Op.and]: [{ [Op.ne]: null }, { [Op.ne]: '' }] } },
+    },
     { fields: ['createdAt'], name: 'idx_prospects_createdat' },
     { fields: ['conversionDate'], name: 'idx_prospects_conversiondate', where: { conversionDate: { [Op.ne]: null } } },
     { fields: ['assignedAgentId', 'leadStatus'], name: 'idx_prospects_agent_status' },

--- a/backend/src/models/RewardEntitlement.js
+++ b/backend/src/models/RewardEntitlement.js
@@ -23,6 +23,12 @@ const RewardEntitlement = sequelize.define('RewardEntitlement', {
     references: { model: 'prospects', key: 'id' },
     comment: 'Canonical MKTR lead reference — SET NULL on lead delete; entitlement survives PII removal'
   },
+  consumerId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    references: { model: 'consumers', key: 'id' },
+    comment: 'Cross-campaign person link (consumer spine, migration 078) — set unconditionally at issuance from the prospect, phoneKey fallback for legacy rows'
+  },
   status: {
     type: DataTypes.STRING(16),
     allowNull: false,
@@ -67,6 +73,7 @@ const RewardEntitlement = sequelize.define('RewardEntitlement', {
     { unique: true, fields: ['tokenHash'], name: 'uq_re_voucher_token', where: { tokenHash: { [Op.ne]: null } } },
     { fields: ['activationId', 'status'], name: 'idx_re_activation_status' },
     { fields: ['prospectId'], name: 'idx_re_prospect' },
+    { fields: ['consumerId'], name: 'idx_re_consumer' },
     { fields: ['expiresAt'], name: 'idx_re_expiry_eligible', where: { status: 'eligible' } }
   ]
 });

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -79,6 +79,13 @@ function defineAssociations() {
   // QrScan associations
   QrScan.belongsTo(QrTag, { foreignKey: 'qrTagId', as: 'qrTag', onDelete: 'CASCADE' });
 
+  // Consumer spine (migration 078) — the durable cross-campaign person.
+  // SET NULL both ways: deleting a consumer never cascades into leads/rewards,
+  // and deleting a lead leaves the person's other history intact.
+  const { Consumer } = models;
+  Consumer.hasMany(Prospect, { foreignKey: 'consumerId', as: 'signups', onDelete: 'SET NULL' });
+  Prospect.belongsTo(Consumer, { foreignKey: 'consumerId', as: 'consumer', onDelete: 'SET NULL' });
+
   // Prospect associations
   Prospect.belongsTo(User, { foreignKey: 'assignedAgentId', as: 'assignedAgent', onDelete: 'SET NULL' });
   Prospect.belongsTo(Campaign, { foreignKey: 'campaignId', as: 'campaign', onDelete: 'SET NULL' });
@@ -238,6 +245,11 @@ function defineAssociations() {
   RewardEntitlement.belongsTo(Activation, { foreignKey: 'activationId', as: 'activation', onDelete: 'RESTRICT' });
   RewardEntitlement.belongsTo(Prospect, { foreignKey: 'prospectId', as: 'prospect', onDelete: 'SET NULL' });
   RewardEntitlement.belongsTo(User, { foreignKey: 'unlockedByUserId', as: 'unlockedBy', onDelete: 'SET NULL' });
+  // Consumer spine: person-level reward history (journey view). hasOne
+  // redemption mirrors the UNIQUE redemptions.entitlementId.
+  models.Consumer.hasMany(RewardEntitlement, { foreignKey: 'consumerId', as: 'entitlements', onDelete: 'SET NULL' });
+  RewardEntitlement.belongsTo(models.Consumer, { foreignKey: 'consumerId', as: 'consumer', onDelete: 'SET NULL' });
+  RewardEntitlement.hasOne(Redemption, { foreignKey: 'entitlementId', as: 'redemption' });
   Activation.hasMany(RewardEntitlement, { foreignKey: 'activationId', as: 'entitlements', onDelete: 'RESTRICT' });
   Redemption.belongsTo(RewardEntitlement, { foreignKey: 'entitlementId', as: 'entitlement', onDelete: 'RESTRICT' });
   Redemption.belongsTo(RewardOffer, { foreignKey: 'rewardOfferId', as: 'rewardOffer', onDelete: 'RESTRICT' });
@@ -346,7 +358,7 @@ export const {
   DiscoveryRun, DiscoveryCandidate,
   DiscoveryPlaceMemory, OutreachCadence, OutreachCadenceStep,
   OutreachCadenceTransition, OutreachCadenceEnrollment, OutreachSuppression,
-  AiSettings, WalletLedger
+  AiSettings, WalletLedger, Consumer
 } = models;
 
 export { sequelize };

--- a/backend/src/routes/consumers.js
+++ b/backend/src/routes/consumers.js
@@ -1,0 +1,14 @@
+import express from 'express';
+import { authenticateToken, requireAdmin } from '../middleware/auth.js';
+import * as consumerController from '../controllers/consumerController.js';
+
+export const meta = { path: '/api/consumers' };
+
+const router = express.Router();
+
+// Cross-campaign person journey — ADMIN ONLY, explicitly. The prospects
+// detail route is deliberately looser (agents open their own leads); this one
+// aggregates a person's history across every campaign and must not be.
+router.get('/:id', authenticateToken, requireAdmin, consumerController.getConsumer);
+
+export default router;

--- a/backend/src/services/consumerService.js
+++ b/backend/src/services/consumerService.js
@@ -1,0 +1,415 @@
+import { createHash, randomUUID } from 'crypto';
+import { sequelize, Consumer, Prospect, RewardEntitlement } from '../models/index.js';
+import { logger } from '../utils/logger.js';
+import { emailNormKey } from './repeatSignup.js';
+import { normalizePhone } from './prospectHelpers.js';
+
+/**
+ * Consumer spine (docs/plans/consumer-spine-and-consent-ledger.md §2).
+ *
+ * `consumers` is a REBUILDABLE PROJECTION of `prospects`, keyed by E.164
+ * phone. Three invariants every writer here preserves:
+ *
+ *  1. Capture is sacred — the resolver runs inside a SAVEPOINT and returns
+ *     null on ANY failure; a lead is never lost to spine trouble. (A plain
+ *     catch inside the outer transaction would be useless: Postgres poisons
+ *     the whole txn on the first error — the savepoint is what makes
+ *     "non-blocking" real. Codex R1 #2.)
+ *  2. call_bot (Retell) rows never link: prospect.phone is the call's
+ *     to_number — for inbound calls that is MKTR's own DDI, and linking would
+ *     merge strangers onto one consumer (retellService.js DNC note, R1 #4).
+ *  3. Counters are ASSIGNED by recompute/reconcile, only ever incremented by
+ *     the capture resolver — drift always heals toward the row-derived truth.
+ */
+
+export const E164_RE = /^\+[1-9]\d{9,14}$/;
+
+/** sha256 hex — same recipe as sourceMetadata.phoneVerifiedFor (prospectService §2.0). */
+export function phoneHashOf(phone) {
+  return createHash('sha256').update(String(phone)).digest('hex');
+}
+
+/**
+ * Is the prospect's OTP verification stamp valid for its CURRENT phone?
+ * `phoneVerifiedFor` binds the stamp to the number it was earned for — a staff
+ * phone edit must not inherit verified status (Codex R1 #6). Legacy stamps
+ * without the binding stay valid (they predate it).
+ */
+export function phoneVerificationIsCurrent(prospect) {
+  const sm = prospect?.sourceMetadata;
+  if (!sm?.phoneVerifiedAt) return false;
+  if (!sm.phoneVerifiedFor) return true;
+  return sm.phoneVerifiedFor === phoneHashOf(String(prospect.phone || ''));
+}
+
+/** Trimmed real email for consumer attributes; null for missing/synthetic. */
+function displayEmailOf(email) {
+  return emailNormKey(email) ? String(email).trim() : null;
+}
+
+const defaultDeps = { sequelize, Consumer, Prospect, RewardEntitlement, logger };
+
+export function makeConsumerService(overrides = {}) {
+  const d = { ...defaultDeps, ...overrides };
+
+  /**
+   * Resolve-or-create the consumer for an (already-normalized) E.164 phone,
+   * inside a SAVEPOINT on `outerTx`. One atomic upsert — no 23505 is ever
+   * raised for the concurrent-capture race. Returns the consumer id, or null
+   * (no/invalid phone, or any failure — logged; the reconciler heals).
+   *
+   * `verified` = the caller's single OTP-marker read (otpMarkerLive). Names
+   * refresh on verified signups (or fill when empty); email only when real.
+   */
+  async function resolveConsumerForCaptureTx(outerTx, {
+    phone, firstName, lastName, email, verified = false, at = new Date(),
+  } = {}) {
+    try {
+      if (typeof phone !== 'string' || !E164_RE.test(phone)) return null;
+      const fn = typeof firstName === 'string' && firstName.trim() ? firstName.trim() : null;
+      const ln = typeof lastName === 'string' && lastName.trim() ? lastName.trim() : null;
+      const cleanEmail = displayEmailOf(email);
+      const isVerified = verified === true;
+
+      const run = async (sp) => {
+        const [rows] = await d.sequelize.query(
+          `INSERT INTO consumers
+             (id, phone, "phoneHash", "firstName", "lastName", email,
+              "firstSeenAt", "lastSeenAt", "signupCount", "verifiedSignupCount",
+              "createdAt", "updatedAt")
+           VALUES
+             (:id, :phone, :phoneHash, :firstName, :lastName, :email,
+              :at, :at, 1, :verifiedInc, now(), now())
+           ON CONFLICT (phone) WHERE phone IS NOT NULL DO UPDATE SET
+             "firstSeenAt" = LEAST(consumers."firstSeenAt", EXCLUDED."firstSeenAt"),
+             "lastSeenAt"  = GREATEST(consumers."lastSeenAt", EXCLUDED."lastSeenAt"),
+             "signupCount" = consumers."signupCount" + 1,
+             "verifiedSignupCount" = consumers."verifiedSignupCount" + :verifiedInc,
+             "firstName" = CASE WHEN :firstName IS NOT NULL AND (:verified OR consumers."firstName" IS NULL)
+                                THEN :firstName ELSE consumers."firstName" END,
+             "lastName"  = CASE WHEN :firstName IS NOT NULL AND (:verified OR consumers."firstName" IS NULL)
+                                THEN :lastName ELSE consumers."lastName" END,
+             email       = CASE WHEN :email IS NOT NULL AND (:verified OR consumers.email IS NULL)
+                                THEN :email ELSE consumers.email END,
+             "updatedAt" = now()
+           RETURNING id`,
+          {
+            replacements: {
+              id: randomUUID(), phone, phoneHash: phoneHashOf(phone),
+              firstName: fn, lastName: ln, email: cleanEmail,
+              at, verified: isVerified, verifiedInc: isVerified ? 1 : 0,
+            },
+            transaction: sp,
+          }
+        );
+        return rows?.[0]?.id || null;
+      };
+
+      // Nested managed transaction = SAVEPOINT when outerTx is present.
+      return outerTx
+        ? await d.sequelize.transaction({ transaction: outerTx }, run)
+        : await d.sequelize.transaction(run);
+    } catch (err) {
+      d.logger.warn('[consumer] resolve failed (non-blocking — reconciler heals)', {
+        error: err?.message || String(err),
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Deterministic per-phone projection recompute — ASSIGNS the full projection
+   * from prospect rows (never increments) and relinks rows on that phone.
+   * Used after phone/email edits and deletes. Best-effort by design.
+   *
+   * Known limit: rows whose STORED phone isn't E.164 (Meta keeps the provider
+   * raw value in this PR) are counted by the full reconciler (which
+   * JS-normalizes) but not by this per-phone SQL aggregate.
+   */
+  async function recomputeConsumersByPhone(phones, { transaction = null } = {}) {
+    try {
+      const clean = [...new Set((phones || []).filter((p) => typeof p === 'string' && E164_RE.test(p)))];
+      for (const phone of clean) {
+        const [aggRows] = await d.sequelize.query(
+          `SELECT MIN("createdAt") AS first, MAX("createdAt") AS last, COUNT(*)::int AS n,
+                  COUNT(*) FILTER (WHERE "sourceMetadata"->>'phoneVerifiedAt' IS NOT NULL)::int AS v
+             FROM prospects
+            WHERE phone = :phone AND "leadSource" <> 'call_bot'`,
+          { replacements: { phone }, transaction }
+        );
+        const agg = aggRows?.[0];
+        if (!agg || Number(agg.n) === 0) {
+          await d.sequelize.query(
+            `UPDATE consumers SET "signupCount" = 0, "verifiedSignupCount" = 0, "updatedAt" = now()
+              WHERE phone = :phone`,
+            { replacements: { phone }, transaction }
+          );
+          continue;
+        }
+        const [latestRows] = await d.sequelize.query(
+          `SELECT "firstName", "lastName", email FROM prospects
+            WHERE phone = :phone AND "leadSource" <> 'call_bot'
+            ORDER BY "createdAt" DESC, id DESC LIMIT 1`,
+          { replacements: { phone }, transaction }
+        );
+        const latest = latestRows?.[0] || {};
+        await d.sequelize.query(
+          `INSERT INTO consumers
+             (id, phone, "phoneHash", "firstName", "lastName", email,
+              "firstSeenAt", "lastSeenAt", "signupCount", "verifiedSignupCount",
+              "createdAt", "updatedAt")
+           VALUES (:id, :phone, :phoneHash, :fn, :ln, :email, :first, :last, :n, :v, now(), now())
+           ON CONFLICT (phone) WHERE phone IS NOT NULL DO UPDATE SET
+             "firstSeenAt" = EXCLUDED."firstSeenAt",
+             "lastSeenAt" = EXCLUDED."lastSeenAt",
+             "signupCount" = EXCLUDED."signupCount",
+             "verifiedSignupCount" = EXCLUDED."verifiedSignupCount",
+             "firstName" = EXCLUDED."firstName",
+             "lastName" = EXCLUDED."lastName",
+             email = EXCLUDED.email,
+             "updatedAt" = now()`,
+          {
+            replacements: {
+              id: randomUUID(), phone, phoneHash: phoneHashOf(phone),
+              fn: latest.firstName || null, ln: latest.lastName || null,
+              email: displayEmailOf(latest.email),
+              first: agg.first, last: agg.last, n: Number(agg.n), v: Number(agg.v),
+            },
+            transaction,
+          }
+        );
+        await d.sequelize.query(
+          `UPDATE prospects p SET "consumerId" = c.id
+             FROM consumers c
+            WHERE c.phone = :phone AND p.phone = :phone
+              AND p."leadSource" <> 'call_bot'
+              AND p."consumerId" IS DISTINCT FROM c.id`,
+          { replacements: { phone }, transaction }
+        );
+      }
+    } catch (err) {
+      d.logger.warn('[consumer] recompute failed (reconciler heals)', {
+        error: err?.message || String(err),
+      });
+    }
+  }
+
+  /**
+   * Full spine reconcile — migration 079 + scripts/rebuild-consumer-spine.js.
+   * JS-normalizes phones with the SAME normalizePhone as capture (raw-stored
+   * Meta rows group correctly), ASSIGNS complete projections, heals wrong and
+   * missing links, unlinks call_bot rows, links entitlements via prospect then
+   * phoneKey, and zeroes consumers whose phone no longer has rows. Idempotent.
+   */
+  async function reconcileConsumerSpine({ transaction = null } = {}) {
+    const runIn = async (t) => {
+      const stats = {
+        consumersUpserted: 0, prospectsLinked: 0, callBotUnlinked: 0,
+        entitlementsViaProspect: 0, entitlementsViaPhoneKey: 0,
+        consumersZeroed: 0, skippedInvalidPhone: 0,
+      };
+
+      const [rows] = await d.sequelize.query(
+        `SELECT id, phone, "firstName", "lastName", email, "createdAt",
+                ("sourceMetadata"->>'phoneVerifiedAt') IS NOT NULL AS verified
+           FROM prospects
+          WHERE phone IS NOT NULL AND phone <> '' AND "leadSource" <> 'call_bot'
+          ORDER BY "createdAt" ASC, id ASC`,
+        { transaction: t }
+      );
+
+      // Group by capture-normalized phone (exact same rule as the live path).
+      const groups = new Map();
+      for (const r of rows) {
+        const norm = normalizePhone(r.phone);
+        if (!E164_RE.test(norm)) { stats.skippedInvalidPhone += 1; continue; }
+        if (!groups.has(norm)) groups.set(norm, []);
+        groups.get(norm).push(r);
+      }
+
+      const linkPairs = []; // [prospectId, consumerId]
+      for (const [phone, members] of groups) {
+        const first = members[0];
+        const latest = members[members.length - 1];
+        const [ins] = await d.sequelize.query(
+          `INSERT INTO consumers
+             (id, phone, "phoneHash", "firstName", "lastName", email,
+              "firstSeenAt", "lastSeenAt", "signupCount", "verifiedSignupCount",
+              "createdAt", "updatedAt")
+           VALUES (:id, :phone, :phoneHash, :fn, :ln, :email, :first, :last, :n, :v, now(), now())
+           ON CONFLICT (phone) WHERE phone IS NOT NULL DO UPDATE SET
+             "firstSeenAt" = EXCLUDED."firstSeenAt",
+             "lastSeenAt" = EXCLUDED."lastSeenAt",
+             "signupCount" = EXCLUDED."signupCount",
+             "verifiedSignupCount" = EXCLUDED."verifiedSignupCount",
+             "firstName" = EXCLUDED."firstName",
+             "lastName" = EXCLUDED."lastName",
+             email = EXCLUDED.email,
+             "updatedAt" = now()
+           RETURNING id`,
+          {
+            replacements: {
+              id: randomUUID(), phone, phoneHash: phoneHashOf(phone),
+              fn: latest.firstName || null, ln: latest.lastName || null,
+              email: displayEmailOf(latest.email),
+              first: first.createdAt, last: latest.createdAt,
+              n: members.length, v: members.filter((m) => m.verified === true).length,
+            },
+            transaction: t,
+          }
+        );
+        const consumerId = ins?.[0]?.id;
+        stats.consumersUpserted += 1;
+        for (const m of members) linkPairs.push([m.id, consumerId]);
+      }
+
+      // Relink in batches — fixes wrong links, not just nulls.
+      const BATCH = 300;
+      for (let i = 0; i < linkPairs.length; i += BATCH) {
+        const slice = linkPairs.slice(i, i + BATCH);
+        const values = slice.map((_, j) => `(:p${j}::uuid, :c${j}::uuid)`).join(',');
+        const repl = {};
+        slice.forEach(([pid, cid], j) => { repl[`p${j}`] = pid; repl[`c${j}`] = cid; });
+        const [, meta] = await d.sequelize.query(
+          `UPDATE prospects AS p SET "consumerId" = v.cid
+             FROM (VALUES ${values}) AS v(pid, cid)
+            WHERE p.id = v.pid AND p."consumerId" IS DISTINCT FROM v.cid`,
+          { replacements: repl, transaction: t }
+        );
+        stats.prospectsLinked += meta?.rowCount ?? 0;
+      }
+
+      const [, cbMeta] = await d.sequelize.query(
+        `UPDATE prospects SET "consumerId" = NULL
+          WHERE "leadSource" = 'call_bot' AND "consumerId" IS NOT NULL`,
+        { transaction: t }
+      );
+      stats.callBotUnlinked = cbMeta?.rowCount ?? 0;
+
+      const [, reP] = await d.sequelize.query(
+        `UPDATE reward_entitlements re SET "consumerId" = p."consumerId"
+           FROM prospects p
+          WHERE re."prospectId" = p.id AND p."consumerId" IS NOT NULL
+            AND re."consumerId" IS DISTINCT FROM p."consumerId"`,
+        { transaction: t }
+      );
+      stats.entitlementsViaProspect = reP?.rowCount ?? 0;
+
+      // Legacy/unlinked entitlements: phoneKey is digits incl. country code,
+      // consumers.phone is '+'+digits.
+      const [, reK] = await d.sequelize.query(
+        `UPDATE reward_entitlements re SET "consumerId" = c.id
+           FROM consumers c
+          WHERE (re."prospectId" IS NULL OR re."consumerId" IS NULL)
+            AND re."phoneKey" IS NOT NULL
+            AND c.phone = '+' || re."phoneKey"
+            AND re."consumerId" IS DISTINCT FROM c.id`,
+        { transaction: t }
+      );
+      stats.entitlementsViaPhoneKey = reK?.rowCount ?? 0;
+
+      // A consumer whose phone no longer matches any live row (edits moved
+      // them all away) keeps the row but drops to zero counts.
+      const seen = [...groups.keys()];
+      const [, zMeta] = await d.sequelize.query(
+        seen.length
+          ? `UPDATE consumers SET "signupCount" = 0, "verifiedSignupCount" = 0, "updatedAt" = now()
+              WHERE phone IS NOT NULL AND "signupCount" <> 0 AND NOT (phone = ANY(ARRAY[:seen]::text[]))`
+          : `UPDATE consumers SET "signupCount" = 0, "verifiedSignupCount" = 0, "updatedAt" = now()
+              WHERE phone IS NOT NULL AND "signupCount" <> 0`,
+        { replacements: seen.length ? { seen } : {}, transaction: t }
+      );
+      stats.consumersZeroed = zMeta?.rowCount ?? 0;
+
+      return stats;
+    };
+
+    if (transaction) return runIn(transaction);
+    return d.sequelize.transaction(runIn);
+  }
+
+  /**
+   * One person's full history (admin journey view). Returns null when the
+   * consumer doesn't exist. Deliberately returns DERIVED fields only — no raw
+   * sourceMetadata (agents/admins get PII-heavy metadata elsewhere; this
+   * endpoint aggregates cross-campaign and stays lean).
+   */
+  async function getConsumerJourney(consumerId) {
+    const consumer = await d.Consumer.findByPk(consumerId);
+    if (!consumer) return null;
+
+    const [signups, entitlements] = await Promise.all([
+      d.Prospect.findAll({
+        where: { consumerId },
+        attributes: [
+          'id', 'firstName', 'lastName', 'phone', 'campaignId', 'leadStatus', 'leadSource',
+          'createdAt', 'conversionDate', 'quarantinedAt', 'quarantineReason', 'sourceMetadata',
+        ],
+        include: [{ association: 'campaign', attributes: ['id', 'name', 'status'] }],
+        order: [['createdAt', 'DESC'], ['id', 'DESC']],
+      }),
+      d.RewardEntitlement.findAll({
+        where: { consumerId },
+        attributes: ['id', 'status', 'createdAt', 'unlockedAt', 'expiresAt'],
+        include: [
+          { association: 'rewardOffer', attributes: ['id', 'title', 'publicTitle'] },
+          { association: 'activation', attributes: ['id', 'campaignId', 'campaignNameSnapshot'] },
+          { association: 'redemption', attributes: ['id', 'redeemedAt', 'status'] },
+        ],
+        order: [['createdAt', 'DESC'], ['id', 'DESC']],
+      }),
+    ]);
+
+    return {
+      consumer: {
+        id: consumer.id,
+        phone: consumer.phone,
+        firstName: consumer.firstName,
+        lastName: consumer.lastName,
+        email: consumer.email,
+        firstSeenAt: consumer.firstSeenAt,
+        lastSeenAt: consumer.lastSeenAt,
+        signupCount: consumer.signupCount,
+        verifiedSignupCount: consumer.verifiedSignupCount,
+        erasedAt: consumer.erasedAt,
+      },
+      signups: signups.map((s) => ({
+        prospectId: s.id,
+        firstName: s.firstName,
+        lastName: s.lastName,
+        campaign: s.campaign ? { id: s.campaign.id, name: s.campaign.name, status: s.campaign.status } : null,
+        leadStatus: s.leadStatus,
+        leadSource: s.leadSource,
+        createdAt: s.createdAt,
+        conversionDate: s.conversionDate,
+        held: !!s.quarantinedAt,
+        heldReason: s.quarantineReason || null,
+        verified: phoneVerificationIsCurrent(s),
+      })),
+      entitlements: entitlements.map((e) => ({
+        id: e.id,
+        status: e.status,
+        createdAt: e.createdAt,
+        unlockedAt: e.unlockedAt,
+        expiresAt: e.expiresAt,
+        rewardTitle: e.rewardOffer ? (e.rewardOffer.publicTitle || e.rewardOffer.title) : null,
+        campaignName: e.activation?.campaignNameSnapshot || null,
+        campaignId: e.activation?.campaignId || null,
+        redeemedAt: e.redemption?.redeemedAt || null,
+      })),
+    };
+  }
+
+  return {
+    resolveConsumerForCaptureTx,
+    recomputeConsumersByPhone,
+    reconcileConsumerSpine,
+    getConsumerJourney,
+  };
+}
+
+const _default = makeConsumerService();
+export const resolveConsumerForCaptureTx = _default.resolveConsumerForCaptureTx;
+export const recomputeConsumersByPhone = _default.recomputeConsumersByPhone;
+export const reconcileConsumerSpine = _default.reconcileConsumerSpine;
+export const getConsumerJourney = _default.getConsumerJourney;

--- a/backend/src/services/consumerService.js
+++ b/backend/src/services/consumerService.js
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from 'crypto';
-import { sequelize, Consumer, Prospect, RewardEntitlement } from '../models/index.js';
+import { Transaction } from 'sequelize';
+import { sequelize, Consumer, Prospect, RewardEntitlement, DrawEntry } from '../models/index.js';
 import { logger } from '../utils/logger.js';
 import { emailNormKey } from './repeatSignup.js';
 import { normalizePhone } from './prospectHelpers.js';
@@ -18,8 +19,9 @@ import { normalizePhone } from './prospectHelpers.js';
  *  2. call_bot (Retell) rows never link: prospect.phone is the call's
  *     to_number — for inbound calls that is MKTR's own DDI, and linking would
  *     merge strangers onto one consumer (retellService.js DNC note, R1 #4).
- *  3. Counters are ASSIGNED by recompute/reconcile, only ever incremented by
- *     the capture resolver — drift always heals toward the row-derived truth.
+ *  3. Counters and attributes are ASSIGNED by recompute/reconcile from one
+ *     shared projection reducer, only ever incremented by the capture
+ *     resolver — drift always heals toward the row-derived truth.
  */
 
 export const E164_RE = /^\+[1-9]\d{9,14}$/;
@@ -47,10 +49,75 @@ function displayEmailOf(email) {
   return emailNormKey(email) ? String(email).trim() : null;
 }
 
-const defaultDeps = { sequelize, Consumer, Prospect, RewardEntitlement, logger };
+/**
+ * The ONE projection reducer (Codex R2 #2) — recompute and reconcile both
+ * derive a consumer row from its member prospects through this, so the two
+ * rebuild paths can never disagree. Attributes are independent (R2 #1):
+ * newest non-empty VERIFIED value per attribute, else newest non-empty value.
+ * `verified` uses the binding-aware check, never the raw stamp.
+ *
+ * @param {Array} members - prospect rows ASC by (createdAt, id), each with
+ *   firstName/lastName/email/phone/sourceMetadata/createdAt.
+ */
+function buildProjection(members) {
+  let fn = null; let ln = null; let email = null;
+  let vFn = null; let vLn = null; let vEmail = null;
+  let verifiedCount = 0;
+  for (const m of members) {
+    const isVerified = phoneVerificationIsCurrent(m);
+    if (isVerified) verifiedCount += 1;
+    const first = typeof m.firstName === 'string' && m.firstName.trim() ? m.firstName.trim() : null;
+    const last = typeof m.lastName === 'string' && m.lastName.trim() ? m.lastName.trim() : null;
+    const em = displayEmailOf(m.email);
+    if (first) { fn = first; if (isVerified) vFn = first; }
+    if (last) { ln = last; if (isVerified) vLn = last; }
+    if (em) { email = em; if (isVerified) vEmail = em; }
+  }
+  return {
+    first: members[0].createdAt,
+    last: members[members.length - 1].createdAt,
+    n: members.length,
+    v: verifiedCount,
+    fn: vFn ?? fn,
+    ln: vLn ?? ln,
+    email: vEmail ?? email,
+  };
+}
+
+const MEMBER_FIELDS = `id, phone, "firstName", "lastName", email, "createdAt", "sourceMetadata"`;
+
+const defaultDeps = { sequelize, Consumer, Prospect, RewardEntitlement, DrawEntry, logger };
 
 export function makeConsumerService(overrides = {}) {
   const d = { ...defaultDeps, ...overrides };
+
+  /** Assign-upsert one consumer row from a reduced projection. */
+  async function upsertProjection(phone, proj, transaction) {
+    await d.sequelize.query(
+      `INSERT INTO consumers
+         (id, phone, "phoneHash", "firstName", "lastName", email,
+          "firstSeenAt", "lastSeenAt", "signupCount", "verifiedSignupCount",
+          "createdAt", "updatedAt")
+       VALUES (:id, :phone, :phoneHash, :fn, :ln, :email, :first, :last, :n, :v, now(), now())
+       ON CONFLICT (phone) WHERE phone IS NOT NULL DO UPDATE SET
+         "firstSeenAt" = EXCLUDED."firstSeenAt",
+         "lastSeenAt" = EXCLUDED."lastSeenAt",
+         "signupCount" = EXCLUDED."signupCount",
+         "verifiedSignupCount" = EXCLUDED."verifiedSignupCount",
+         "firstName" = EXCLUDED."firstName",
+         "lastName" = EXCLUDED."lastName",
+         email = EXCLUDED.email,
+         "updatedAt" = now()`,
+      {
+        replacements: {
+          id: randomUUID(), phone, phoneHash: phoneHashOf(phone),
+          fn: proj.fn, ln: proj.ln, email: proj.email,
+          first: proj.first, last: proj.last, n: proj.n, v: proj.v,
+        },
+        transaction,
+      }
+    );
+  }
 
   /**
    * Resolve-or-create the consumer for an (already-normalized) E.164 phone,
@@ -58,8 +125,9 @@ export function makeConsumerService(overrides = {}) {
    * raised for the concurrent-capture race. Returns the consumer id, or null
    * (no/invalid phone, or any failure — logged; the reconciler heals).
    *
-   * `verified` = the caller's single OTP-marker read (otpMarkerLive). Names
-   * refresh on verified signups (or fill when empty); email only when real.
+   * `verified` = the caller's single OTP-marker read (otpMarkerLive). Each
+   * attribute refreshes independently on verified signups (or fills when
+   * empty); email only when real.
    */
   async function resolveConsumerForCaptureTx(outerTx, {
     phone, firstName, lastName, email, verified = false, at = new Date(),
@@ -87,7 +155,7 @@ export function makeConsumerService(overrides = {}) {
              "verifiedSignupCount" = consumers."verifiedSignupCount" + :verifiedInc,
              "firstName" = CASE WHEN :firstName IS NOT NULL AND (:verified OR consumers."firstName" IS NULL)
                                 THEN :firstName ELSE consumers."firstName" END,
-             "lastName"  = CASE WHEN :firstName IS NOT NULL AND (:verified OR consumers."firstName" IS NULL)
+             "lastName"  = CASE WHEN :lastName IS NOT NULL AND (:verified OR consumers."lastName" IS NULL)
                                 THEN :lastName ELSE consumers."lastName" END,
              email       = CASE WHEN :email IS NOT NULL AND (:verified OR consumers.email IS NULL)
                                 THEN :email ELSE consumers.email END,
@@ -119,26 +187,25 @@ export function makeConsumerService(overrides = {}) {
 
   /**
    * Deterministic per-phone projection recompute — ASSIGNS the full projection
-   * from prospect rows (never increments) and relinks rows on that phone.
-   * Used after phone/email edits and deletes. Best-effort by design.
+   * from prospect rows via the shared reducer (never increments) and relinks
+   * rows on that phone. Used after phone/email edits and deletes. Best-effort
+   * by design.
    *
    * Known limit: rows whose STORED phone isn't E.164 (Meta keeps the provider
    * raw value in this PR) are counted by the full reconciler (which
-   * JS-normalizes) but not by this per-phone SQL aggregate.
+   * JS-normalizes) but not by this per-phone SQL match.
    */
   async function recomputeConsumersByPhone(phones, { transaction = null } = {}) {
     try {
       const clean = [...new Set((phones || []).filter((p) => typeof p === 'string' && E164_RE.test(p)))];
       for (const phone of clean) {
-        const [aggRows] = await d.sequelize.query(
-          `SELECT MIN("createdAt") AS first, MAX("createdAt") AS last, COUNT(*)::int AS n,
-                  COUNT(*) FILTER (WHERE "sourceMetadata"->>'phoneVerifiedAt' IS NOT NULL)::int AS v
-             FROM prospects
-            WHERE phone = :phone AND "leadSource" <> 'call_bot'`,
+        const [rows] = await d.sequelize.query(
+          `SELECT ${MEMBER_FIELDS} FROM prospects
+            WHERE phone = :phone AND "leadSource" <> 'call_bot'
+            ORDER BY "createdAt" ASC, id ASC`,
           { replacements: { phone }, transaction }
         );
-        const agg = aggRows?.[0];
-        if (!agg || Number(agg.n) === 0) {
+        if (!rows.length) {
           await d.sequelize.query(
             `UPDATE consumers SET "signupCount" = 0, "verifiedSignupCount" = 0, "updatedAt" = now()
               WHERE phone = :phone`,
@@ -146,38 +213,7 @@ export function makeConsumerService(overrides = {}) {
           );
           continue;
         }
-        const [latestRows] = await d.sequelize.query(
-          `SELECT "firstName", "lastName", email FROM prospects
-            WHERE phone = :phone AND "leadSource" <> 'call_bot'
-            ORDER BY "createdAt" DESC, id DESC LIMIT 1`,
-          { replacements: { phone }, transaction }
-        );
-        const latest = latestRows?.[0] || {};
-        await d.sequelize.query(
-          `INSERT INTO consumers
-             (id, phone, "phoneHash", "firstName", "lastName", email,
-              "firstSeenAt", "lastSeenAt", "signupCount", "verifiedSignupCount",
-              "createdAt", "updatedAt")
-           VALUES (:id, :phone, :phoneHash, :fn, :ln, :email, :first, :last, :n, :v, now(), now())
-           ON CONFLICT (phone) WHERE phone IS NOT NULL DO UPDATE SET
-             "firstSeenAt" = EXCLUDED."firstSeenAt",
-             "lastSeenAt" = EXCLUDED."lastSeenAt",
-             "signupCount" = EXCLUDED."signupCount",
-             "verifiedSignupCount" = EXCLUDED."verifiedSignupCount",
-             "firstName" = EXCLUDED."firstName",
-             "lastName" = EXCLUDED."lastName",
-             email = EXCLUDED.email,
-             "updatedAt" = now()`,
-          {
-            replacements: {
-              id: randomUUID(), phone, phoneHash: phoneHashOf(phone),
-              fn: latest.firstName || null, ln: latest.lastName || null,
-              email: displayEmailOf(latest.email),
-              first: agg.first, last: agg.last, n: Number(agg.n), v: Number(agg.v),
-            },
-            transaction,
-          }
-        );
+        await upsertProjection(phone, buildProjection(rows), transaction);
         await d.sequelize.query(
           `UPDATE prospects p SET "consumerId" = c.id
              FROM consumers c
@@ -197,22 +233,25 @@ export function makeConsumerService(overrides = {}) {
   /**
    * Full spine reconcile — migration 079 + scripts/rebuild-consumer-spine.js.
    * JS-normalizes phones with the SAME normalizePhone as capture (raw-stored
-   * Meta rows group correctly), ASSIGNS complete projections, heals wrong and
-   * missing links, unlinks call_bot rows, links entitlements via prospect then
+   * Meta rows group correctly), reduces each group through buildProjection,
+   * ASSIGNS complete projections, heals wrong/missing/stale links, unlinks
+   * call_bot and empty-phone rows, links entitlements via prospect then
    * phoneKey, and zeroes consumers whose phone no longer has rows. Idempotent.
+   *
+   * Runs SERIALIZABLE with retry (Codex R2 #3): the snapshot-then-assign shape
+   * would otherwise let a capture that commits mid-reconcile be overwritten
+   * with a stale count — SSI aborts the reconcile instead, and we retry.
    */
   async function reconcileConsumerSpine({ transaction = null } = {}) {
     const runIn = async (t) => {
       const stats = {
         consumersUpserted: 0, prospectsLinked: 0, callBotUnlinked: 0,
-        entitlementsViaProspect: 0, entitlementsViaPhoneKey: 0,
+        emptyPhoneUnlinked: 0, entitlementsViaProspect: 0, entitlementsViaPhoneKey: 0,
         consumersZeroed: 0, skippedInvalidPhone: 0,
       };
 
       const [rows] = await d.sequelize.query(
-        `SELECT id, phone, "firstName", "lastName", email, "createdAt",
-                ("sourceMetadata"->>'phoneVerifiedAt') IS NOT NULL AS verified
-           FROM prospects
+        `SELECT ${MEMBER_FIELDS} FROM prospects
           WHERE phone IS NOT NULL AND phone <> '' AND "leadSource" <> 'call_bot'
           ORDER BY "createdAt" ASC, id ASC`,
         { transaction: t }
@@ -229,8 +268,7 @@ export function makeConsumerService(overrides = {}) {
 
       const linkPairs = []; // [prospectId, consumerId]
       for (const [phone, members] of groups) {
-        const first = members[0];
-        const latest = members[members.length - 1];
+        const proj = buildProjection(members);
         const [ins] = await d.sequelize.query(
           `INSERT INTO consumers
              (id, phone, "phoneHash", "firstName", "lastName", email,
@@ -250,10 +288,8 @@ export function makeConsumerService(overrides = {}) {
           {
             replacements: {
               id: randomUUID(), phone, phoneHash: phoneHashOf(phone),
-              fn: latest.firstName || null, ln: latest.lastName || null,
-              email: displayEmailOf(latest.email),
-              first: first.createdAt, last: latest.createdAt,
-              n: members.length, v: members.filter((m) => m.verified === true).length,
+              fn: proj.fn, ln: proj.ln, email: proj.email,
+              first: proj.first, last: proj.last, n: proj.n, v: proj.v,
             },
             transaction: t,
           }
@@ -285,6 +321,16 @@ export function makeConsumerService(overrides = {}) {
         { transaction: t }
       );
       stats.callBotUnlinked = cbMeta?.rowCount ?? 0;
+
+      // A phone cleared to null/empty (PUT-to-blank) takes its link with it
+      // (Codex R2 #4). Invalid-but-present phones are NOT touched: those are
+      // capture-linked raw-format rows (Meta) whose links are healed above.
+      const [, epMeta] = await d.sequelize.query(
+        `UPDATE prospects SET "consumerId" = NULL
+          WHERE "consumerId" IS NOT NULL AND (phone IS NULL OR phone = '')`,
+        { transaction: t }
+      );
+      stats.emptyPhoneUnlinked = epMeta?.rowCount ?? 0;
 
       const [, reP] = await d.sequelize.query(
         `UPDATE reward_entitlements re SET "consumerId" = p."consumerId"
@@ -325,7 +371,25 @@ export function makeConsumerService(overrides = {}) {
     };
 
     if (transaction) return runIn(transaction);
-    return d.sequelize.transaction(runIn);
+
+    // SERIALIZABLE + retry: a concurrent capture upsert conflicts with our
+    // read-then-assign; PG aborts one side with 40001 and we re-derive from
+    // the fresh state. Boot/script cadence makes retries cheap and rare.
+    let lastErr = null;
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      try {
+        return await d.sequelize.transaction(
+          { isolationLevel: Transaction.ISOLATION_LEVELS.SERIALIZABLE },
+          runIn
+        );
+      } catch (err) {
+        const code = err?.original?.code || err?.parent?.code;
+        if (code !== '40001') throw err;
+        lastErr = err;
+        d.logger.warn('[consumer] reconcile serialization conflict — retrying', { attempt });
+      }
+    }
+    throw lastErr;
   }
 
   /**
@@ -359,6 +423,10 @@ export function makeConsumerService(overrides = {}) {
         order: [['createdAt', 'DESC'], ['id', 'DESC']],
       }),
     ]);
+
+    const drawEntries = signups.length
+      ? await d.DrawEntry.count({ where: { prospectId: signups.map((s) => s.id) } })
+      : 0;
 
     return {
       consumer: {
@@ -397,6 +465,7 @@ export function makeConsumerService(overrides = {}) {
         campaignId: e.activation?.campaignId || null,
         redeemedAt: e.redemption?.redeemedAt || null,
       })),
+      drawEntries,
     };
   }
 

--- a/backend/src/services/metaLeadService.js
+++ b/backend/src/services/metaLeadService.js
@@ -242,10 +242,13 @@ export function makeMetaLeadService(overrides = {}) {
       assignedAgentId = quarantined ? null : (decision.assignedAgentId ?? null);
 
       // Consumer spine (plan §2.3): link by NORMALIZED phone as the matching
-      // key only — the stored prospect.phone keeps Meta's raw value in this
-      // PR. Meta identities are UNVERIFIED (no OTP): they link for visibility
-      // but can never mint marketing authority. Savepoint-isolated; any
-      // failure ⇒ null (the reconciler heals).
+      // key. Storage is untouched — and in practice already E.164: the
+      // Prospect model VALIDATES E.164 at create, so a loosely-formatted Meta
+      // phone fails the whole create (pre-existing behavior); normalizePhone
+      // here just guards spaced/local variants for the link. Meta identities
+      // are UNVERIFIED (no OTP): they link for visibility but can never mint
+      // marketing authority. Savepoint-isolated; any failure ⇒ null (the
+      // reconciler heals).
       const consumerId = parsed.phone
         ? await d.resolveConsumerForCaptureTx(t, {
             phone: d.normalizePhone(parsed.phone),

--- a/backend/src/services/metaLeadService.js
+++ b/backend/src/services/metaLeadService.js
@@ -8,7 +8,8 @@ import { dispatchEvent } from './webhookService.js';
 import { sendLeadAssignmentEmail } from './mailer.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
-import { destinationForAgent, externalIdForDestination, buildLeadHeldPayload } from './prospectHelpers.js';
+import { destinationForAgent, externalIdForDestination, buildLeadHeldPayload, normalizePhone } from './prospectHelpers.js';
+import { resolveConsumerForCaptureTx } from './consumerService.js';
 
 const IDEMPOTENCY_SCOPE = 'meta:lead';
 const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -31,6 +32,8 @@ const defaultDeps = {
   AppError,
   logger,
   fetch: globalThis.fetch,
+  resolveConsumerForCaptureTx,
+  normalizePhone,
 };
 
 /**
@@ -238,11 +241,27 @@ export function makeMetaLeadService(overrides = {}) {
       quarantined = decision.action === 'quarantine';
       assignedAgentId = quarantined ? null : (decision.assignedAgentId ?? null);
 
+      // Consumer spine (plan §2.3): link by NORMALIZED phone as the matching
+      // key only — the stored prospect.phone keeps Meta's raw value in this
+      // PR. Meta identities are UNVERIFIED (no OTP): they link for visibility
+      // but can never mint marketing authority. Savepoint-isolated; any
+      // failure ⇒ null (the reconciler heals).
+      const consumerId = parsed.phone
+        ? await d.resolveConsumerForCaptureTx(t, {
+            phone: d.normalizePhone(parsed.phone),
+            firstName: parsed.firstName,
+            lastName: parsed.lastName,
+            email: parsed.email,
+            verified: false,
+          })
+        : null;
+
       const prospect = await d.Prospect.create({
         firstName: parsed.firstName,
         lastName: parsed.lastName,
         email: parsed.email,
         phone: parsed.phone,
+        consumerId,
         company: parsed.company,
         jobTitle: parsed.jobTitle,
         leadSource: 'social_media',

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -34,6 +34,11 @@ import {
 } from './tiktokEventsService.js';
 import { getOrCreateProspectShareLink } from './shortlinkService.js';
 import { isPhoneRecentlyVerified } from './verifiedPhoneStore.js';
+import {
+  resolveConsumerForCaptureTx,
+  recomputeConsumersByPhone,
+  getConsumerJourney,
+} from './consumerService.js';
 import { customerHostOrigin, normalizeCustomerHostChoice } from '../utils/customerHost.js';
 import { sgtDayEndExclusiveMs } from '../utils/sgtTime.js';
 
@@ -168,6 +173,9 @@ const defaultDeps = {
   sendTikTokCompleteRegistrationEvent,
   getOrCreateProspectShareLink,
   isPhoneRecentlyVerified,
+  resolveConsumerForCaptureTx,
+  recomputeConsumersByPhone,
+  getConsumerJourney,
   onLeadCaptured: (prospect) => (_leadCapturedHook ? _leadCapturedHook(prospect) : null),
   AppError,
   logger,
@@ -849,9 +857,27 @@ export function makeProspectService(overrides = {}) {
       heldReason = quarantined ? decision.quarantineReason : null;
       finalAgentId = quarantined ? null : (decision.assignedAgentId ?? null);
 
+      // Consumer spine (docs/plans/consumer-spine-and-consent-ledger.md §2.3):
+      // resolve-or-create the cross-campaign person for this already-normalized
+      // phone INSIDE A SAVEPOINT — a spine failure rolls back the savepoint
+      // only and capture proceeds with consumerId null (reconciler heals).
+      // Runs AFTER the per-campaign 409 dupe check so duplicates never bump
+      // signupCount. call_bot never links (to_number ambiguity — see
+      // consumerService.js); `verified` is the single OTP-marker read above.
+      const consumerId = incoming.leadSource === 'call_bot'
+        ? null
+        : await d.resolveConsumerForCaptureTx(t, {
+            phone: incoming.phone,
+            firstName: incoming.firstName,
+            lastName: incoming.lastName,
+            email: incoming.email,
+            verified: otpMarkerLive,
+          });
+
       const newProspect = await m.Prospect.create(
         {
           ...incoming,
+          consumerId,
           assignedAgentId: finalAgentId,
           externalAgentId,
           quarantinedAt: quarantined ? new Date() : null,
@@ -1217,13 +1243,20 @@ export function makeProspectService(overrides = {}) {
     // view, and the timeline degrades to ProspectActivity-only on a Supabase miss).
     if (user?.role === 'admin') {
       const wantTimeline = !!process.env.SUPABASE_LEAD_ACTIVITIES_URL;
-      const [repeatSignup, timelineFetch] = await Promise.all([
+      const [repeatSignup, timelineFetch, consumerJourney] = await Promise.all([
         repeatSignupDetail(d.sequelize, { phone: prospect.phone, email: prospect.email }).catch(() => null),
         wantTimeline
           ? fetchLeadActivitiesFromSupabase(prospect.id).catch(() => ({ rows: [], ok: false }))
           : Promise.resolve(null),
+        // Consumer spine: the person's cross-campaign journey (signups +
+        // rewards) for the admin drawer's Person card. Resilient like its
+        // siblings — a miss never breaks the detail view.
+        prospect.consumerId
+          ? d.getConsumerJourney(prospect.consumerId).catch(() => null)
+          : Promise.resolve(null),
       ]);
       if (repeatSignup) prospect.setDataValue('repeatSignup', repeatSignup);
+      if (consumerJourney) prospect.setDataValue('consumer', consumerJourney);
       if (timelineFetch) {
         prospect.setDataValue(
           'timeline',
@@ -1256,7 +1289,42 @@ export function makeProspectService(overrides = {}) {
     const oldAssignedAgent = prospect.assignedAgent;
 
     const safeUpdates = Object.fromEntries(Object.entries(body).filter(([k]) => PROSPECT_UPDATE_FIELDS.includes(k)));
-    await prospect.update(safeUpdates);
+
+    // Identity-integrity on phone edits (plan §2.3, Codex R1 #6): normalize
+    // exactly like capture, and strip the OTP verification stamp — it is bound
+    // to the OLD number via phoneVerifiedFor, so it must not survive the edit
+    // (entitlement issuance independently re-checks the binding).
+    const oldPhone = prospect.phone;
+    if (typeof safeUpdates.phone === 'string' && safeUpdates.phone.trim()) {
+      safeUpdates.phone = normalizePhone(safeUpdates.phone);
+    }
+    const phoneChanged = safeUpdates.phone !== undefined && safeUpdates.phone !== oldPhone;
+    const emailChanged = safeUpdates.email !== undefined && safeUpdates.email !== prospect.email;
+    if (phoneChanged && prospect.sourceMetadata?.phoneVerifiedAt) {
+      const sm = { ...(prospect.sourceMetadata || {}) };
+      delete sm.phoneVerifiedAt;
+      delete sm.phoneVerifiedFor;
+      safeUpdates.sourceMetadata = sm;
+    }
+
+    try {
+      await prospect.update(safeUpdates);
+    } catch (err) {
+      if (err?.name === 'SequelizeUniqueConstraintError') {
+        // (campaignId, phone) partial unique — the edited number already has a
+        // signup in this campaign.
+        throw new d.AppError('Another lead in this campaign already has this phone number.', 409);
+      }
+      throw err;
+    }
+
+    // Consumer-spine projection upkeep: recompute BOTH phones' consumers from
+    // rows (assign, never adjust) — this also relinks this row's consumerId.
+    // Best-effort by design; the reconciler heals any miss.
+    if ((phoneChanged || emailChanged) && prospect.leadSource !== 'call_bot') {
+      await d.recomputeConsumersByPhone([oldPhone, prospect.phone].filter(Boolean));
+      await prospect.reload().catch(() => {});
+    }
 
     // (Reassignment / unassignment is handled exclusively by assignProspect — see the
     // PROSPECT_UPDATE_FIELDS note — so PUT no longer needs unassignment side-effects.)
@@ -1314,6 +1382,8 @@ export function makeProspectService(overrides = {}) {
     // txn auto-commits on resolve / auto-rolls-back (and rethrows) on a throw, so
     // a hard error => delete fails + admin retries, with NO orphan/partial state.
     let deliveryPairs = [];
+    let deletedPhone = null;
+    let deletedSource = null;
     await d.sequelize.transaction(async (t) => {
       const prospect = await m.Prospect.findOne({
         where: { id, ...scopeFilter },
@@ -1323,6 +1393,8 @@ export function makeProspectService(overrides = {}) {
       if (!prospect) {
         throw new d.AppError('Prospect not found or access denied', 404);
       }
+      deletedPhone = prospect.phone;
+      deletedSource = prospect.leadSource;
 
       // Only the mktr-leads receiver handles lead.deleted. Held / unassigned /
       // System-Agent (no assignee) or a non-mktr_leads destination => no mirrored
@@ -1357,6 +1429,12 @@ export function makeProspectService(overrides = {}) {
     });
 
     d.flushDeliveries(deliveryPairs); // post-commit, fire-and-forget
+
+    // Consumer-spine projection upkeep (assign-from-rows; best-effort — the
+    // reconciler heals). call_bot rows never linked, so nothing to recompute.
+    if (deletedPhone && deletedSource !== 'call_bot') {
+      await d.recomputeConsumersByPhone([deletedPhone]);
+    }
   }
 
   /**

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -583,31 +583,35 @@ export function makeProspectService(overrides = {}) {
           phone: incoming.phone,
         },
       });
-      if (existing) {
-        // Already registered: hand back THIS lead's canonical, attributed share link so the
-        // share dialog shows their stable /share/{slug} (not a fresh anonymous ref=1 mint on
-        // every open). Submit is OTP-gated, so the caller has proven they own this phone —
-        // safe to return their referral link. Best-effort: a mint failure must never turn the
-        // clean 409 into a 500 (the SPA can still resolve the link via prospectId).
-        const err = new d.AppError('This phone number has already signed up for this campaign.', 409);
-        err.data = { alreadyRegistered: true, prospectId: existing.id };
-        try {
-          const hostChoice = normalizeCustomerHostChoice(sourceCampaign?.design_config?.customerHost);
-          const origin = customerHostOrigin(hostChoice);
-          const { url } = await d.getOrCreateProspectShareLink({
-            prospectId: existing.id,
-            campaignId: incoming.campaignId,
-            origin,
-          });
-          err.data.shareUrl = `${origin}${url}`;
-        } catch (e) {
-          d.logger.warn('Duplicate-signup share link mint failed (non-blocking)', {
-            prospectId: existing.id,
-            err: e?.message,
-          });
-        }
-        throw err;
+      if (existing) await throwDuplicateSignup(existing);
+    }
+
+    // Already registered: hand back THIS lead's canonical, attributed share link so the
+    // share dialog shows their stable /share/{slug} (not a fresh anonymous ref=1 mint on
+    // every open). Submit is OTP-gated, so the caller has proven they own this phone —
+    // safe to return their referral link. Best-effort: a mint failure must never turn the
+    // clean 409 into a 500 (the SPA can still resolve the link via prospectId).
+    // Hoisted into a helper because BOTH the precheck above and the
+    // concurrent-race catch below must emit the identical structured 409.
+    async function throwDuplicateSignup(existing) {
+      const err = new d.AppError('This phone number has already signed up for this campaign.', 409);
+      err.data = { alreadyRegistered: true, prospectId: existing.id };
+      try {
+        const hostChoice = normalizeCustomerHostChoice(sourceCampaign?.design_config?.customerHost);
+        const origin = customerHostOrigin(hostChoice);
+        const { url } = await d.getOrCreateProspectShareLink({
+          prospectId: existing.id,
+          campaignId: incoming.campaignId,
+          origin,
+        });
+        err.data.shareUrl = `${origin}${url}`;
+      } catch (e) {
+        d.logger.warn('Duplicate-signup share link mint failed (non-blocking)', {
+          prospectId: existing.id,
+          err: e?.message,
+        });
       }
+      throw err;
     }
 
     // Handle Date of Birth -> Age mapping + campaign age gate (defense-in-depth;
@@ -822,7 +826,7 @@ export function makeProspectService(overrides = {}) {
     let dncHeld = false;
     let dncIntendedAgentId = null;
     let dncAlreadyCharged = false;
-    const prospect = await d.sequelize.transaction(async (t) => {
+    const runCreateTx = () => d.sequelize.transaction(async (t) => {
       // The internal quota gate applies ONLY to the internal path. For external
       // leads default to a plain "assign" directive so the shared activity/deduct
       // code below stays correct (external is charged authoritatively, not metered).
@@ -988,6 +992,29 @@ export function makeProspectService(overrides = {}) {
 
       return newProspect;
     });
+
+    let prospect;
+    try {
+      prospect = await runCreateTx();
+    } catch (err) {
+      // Concurrent same-campaign duplicate: both requests passed the precheck;
+      // the unique-index loser lands here AFTER a full rollback (including the
+      // resolver savepoint's signupCount increment). Surface the SAME
+      // structured 409 the precheck emits — errorHandler would otherwise map
+      // the Sequelize ValidationError subclass to a generic 400 (Codex R2 #5).
+      const constraint = err?.original?.constraint || err?.parent?.constraint;
+      if (
+        err?.name === 'SequelizeUniqueConstraintError' &&
+        constraint === 'prospects_campaign_id_phone' &&
+        incoming.phone && incoming.campaignId
+      ) {
+        const winner = await m.Prospect.findOne({
+          where: { campaignId: incoming.campaignId, phone: incoming.phone },
+        });
+        if (winner) await throwDuplicateSignup(winner);
+      }
+      throw err;
+    }
 
     // Reflect the committed outcome (null when quarantined) for the rest of the
     // function — webhook dispatch, agent load, and the returned payload.
@@ -1295,8 +1322,10 @@ export function makeProspectService(overrides = {}) {
     // to the OLD number via phoneVerifiedFor, so it must not survive the edit
     // (entitlement issuance independently re-checks the binding).
     const oldPhone = prospect.phone;
-    if (typeof safeUpdates.phone === 'string' && safeUpdates.phone.trim()) {
-      safeUpdates.phone = normalizePhone(safeUpdates.phone);
+    if (safeUpdates.phone !== undefined && safeUpdates.phone !== null) {
+      const trimmed = String(safeUpdates.phone).trim();
+      // Blank clears the number — and the person link goes with it (R2 #4).
+      safeUpdates.phone = trimmed ? normalizePhone(trimmed) : null;
     }
     const phoneChanged = safeUpdates.phone !== undefined && safeUpdates.phone !== oldPhone;
     const emailChanged = safeUpdates.email !== undefined && safeUpdates.email !== prospect.email;
@@ -1305,6 +1334,12 @@ export function makeProspectService(overrides = {}) {
       delete sm.phoneVerifiedAt;
       delete sm.phoneVerifiedFor;
       safeUpdates.sourceMetadata = sm;
+    }
+    if (phoneChanged && !safeUpdates.phone) {
+      // Phone cleared entirely: no number, no person link (recompute below
+      // only handles E.164 values; the reconciler's empty-phone step is the
+      // backstop).
+      safeUpdates.consumerId = null;
     }
 
     try {

--- a/backend/src/services/redeemOps/entitlementService.js
+++ b/backend/src/services/redeemOps/entitlementService.js
@@ -1,8 +1,9 @@
 import { Op } from 'sequelize';
 import {
   RewardEntitlement, RedemptionEvent, Activation, ActivationIssuanceSkip, RewardOffer,
-  PartnerOrganisation, Prospect, User, sequelize,
+  PartnerOrganisation, Prospect, User, Consumer, sequelize,
 } from '../../models/index.js';
+import { phoneVerificationIsCurrent } from '../consumerService.js';
 import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';
 import { makeInventoryService } from './inventoryService.js';
@@ -59,7 +60,7 @@ export async function flushDeliveries() {
 export function makeEntitlementService(overrides = {}) {
   const d = {
     RewardEntitlement, RedemptionEvent, Activation, ActivationIssuanceSkip, RewardOffer,
-    PartnerOrganisation, Prospect, User, sequelize, logger,
+    PartnerOrganisation, Prospect, User, Consumer, sequelize, logger,
     inventory: makeInventoryService(),
     audit: makeRedeemOpsAuditService(),
     notifyUnlock: null, // injected by entitlementWiring (voucher email) — null-safe
@@ -89,7 +90,10 @@ export function makeEntitlementService(overrides = {}) {
   }
 
   function verificationStampOf(prospect) {
-    return prospect?.sourceMetadata?.phoneVerifiedAt || null;
+    // Bound stamp (plan §2.3, Codex R1 #6): phoneVerifiedFor ties the OTP
+    // evidence to the number it was earned for — a staff phone edit must not
+    // inherit verified status. Legacy stamps without the binding stay valid.
+    return phoneVerificationIsCurrent(prospect) ? prospect.sourceMetadata.phoneVerifiedAt : null;
   }
 
   /**
@@ -273,11 +277,22 @@ export function makeEntitlementService(overrides = {}) {
           offerId: offer.id, activationId: activation.id, transaction: t,
         });
 
+        // Consumer spine: person link at issuance — unconditional (the journey
+        // view depends on it). Prefer the prospect's own link; fall back to the
+        // phoneKey (consumers.phone = '+'+digits) for pre-spine prospects.
+        let entitlementConsumerId = prospect.consumerId || null;
+        if (!entitlementConsumerId && phoneKey) {
+          entitlementConsumerId = (await d.Consumer.findOne({
+            where: { phone: `+${phoneKey}` }, attributes: ['id'], transaction: t,
+          }))?.id || null;
+        }
+
         const created = await d.RewardEntitlement.create(
           {
             rewardOfferId: offer.id,
             activationId: activation.id,
             prospectId: prospect.id,
+            consumerId: entitlementConsumerId,
             status: onCapture ? 'issued' : 'eligible',
             unlockedAt: onCapture ? new Date() : null,
             unlockedVia: onCapture ? 'auto_on_capture' : null,

--- a/backend/test/integration/consumerSpine.test.js
+++ b/backend/test/integration/consumerSpine.test.js
@@ -1,8 +1,10 @@
+import { jest } from '@jest/globals';
 import request from 'supertest';
 import { getApp, closeDb, createTestUser, createTestCampaign } from '../helpers.js';
 import { sequelize, Consumer, Prospect } from '../../src/models/index.js';
 import { markPhoneVerified } from '../../src/services/verifiedPhoneStore.js';
 import { reconcileConsumerSpine } from '../../src/services/consumerService.js';
+import { makeMetaLeadService } from '../../src/services/metaLeadService.js';
 
 /**
  * Consumer spine — integration (real Postgres; savepoint/ON CONFLICT semantics
@@ -11,6 +13,8 @@ import { reconcileConsumerSpine } from '../../src/services/consumerService.js';
 
 const RUN = Date.now();
 const PHONE_A = '+65911100019';
+// Distinct 8-digit SG mobiles per scenario, collision-free within the run.
+const p8 = (offset) => `9${String(RUN + offset).slice(-7)}`;
 // 8-digit SG numbers (normalizePhone adds +65)
 const phoneA = `9${String(RUN).slice(-7)}`;          // person A, raw 8-digit
 const phoneAE164 = `+65${phoneA}`;
@@ -231,5 +235,139 @@ describe('consumer spine — read surfaces', () => {
     expect(r.status).toBe(200);
     expect(r.body.data.prospect.consumer).toBeTruthy();
     expect(r.body.data.prospect.consumer.consumer.signupCount).toBe(1);
+  });
+});
+
+describe('consumer spine — Codex R2 additions', () => {
+  test('CONCURRENT captures across two campaigns → one consumer, count 2', async () => {
+    const ph = p8(3);
+    const [r1, r2] = await Promise.all([
+      request(app).post('/api/prospects')
+        .send(capturePayload({ campaignId: campaign1.id, phone: ph, email: `cc-a-${RUN}@test.com` })),
+      request(app).post('/api/prospects')
+        .send(capturePayload({ campaignId: campaign2.id, phone: ph, email: `cc-b-${RUN}@test.com` })),
+    ]);
+    expect([r1.status, r2.status]).toEqual([201, 201]);
+    const consumers = await Consumer.findAll({ where: { phone: `+65${ph}` } });
+    expect(consumers).toHaveLength(1);
+    expect(consumers[0].signupCount).toBe(2);
+  });
+
+  test('CONCURRENT duplicates in ONE campaign → exactly one 201 + one structured 409, count 1', async () => {
+    // Outcome contract: whichever side loses (precheck or the unique-index
+    // catch after full rollback), the caller sees the SAME structured 409 and
+    // the winner's consumer counts exactly one signup.
+    const ph = p8(4);
+    const results = await Promise.all([
+      request(app).post('/api/prospects')
+        .send(capturePayload({ campaignId: campaign1.id, phone: ph, email: `dup-a-${RUN}@test.com` })),
+      request(app).post('/api/prospects')
+        .send(capturePayload({ campaignId: campaign1.id, phone: ph, email: `dup-b-${RUN}@test.com` })),
+    ]);
+    expect(results.map((r) => r.status).sort()).toEqual([201, 409]);
+    const dup = results.find((r) => r.status === 409);
+    expect(JSON.stringify(dup.body)).toContain('alreadyRegistered');
+    const c = await Consumer.findOne({ where: { phone: `+65${ph}` } });
+    expect(c.signupCount).toBe(1);
+    expect(await Prospect.count({ where: { phone: `+65${ph}` } })).toBe(1);
+  });
+
+  test('Meta lead links to the same consumer as a web signup (unverified)', async () => {
+    // NOTE: the Prospect model validates E.164 at create, so Meta phones are
+    // ALWAYS stored E.164 or the create fails (pre-existing behavior — a raw
+    // 8-digit payload was tried here and correctly rejected). Realistic Meta
+    // payloads carry the profile number as +E.164.
+    const ph = p8(5);
+    await request(app).post('/api/prospects')
+      .send(capturePayload({ campaignId: campaign1.id, phone: ph, email: `meta-web-${RUN}@test.com` }))
+      .expect(201);
+
+    const metaSvc = makeMetaLeadService({
+      fetch: jest.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          field_data: [
+            { name: 'full_name', values: ['Meta Person'] },
+            { name: 'phone_number', values: [`+65${ph}`] },
+            { name: 'email', values: [`meta-lead-${RUN}@test.com`] },
+          ],
+        }),
+      })),
+    });
+    process.env.META_PAGE_ACCESS_TOKEN = 'test-token';
+    const res = await metaSvc.processMetaLead(`lg-${RUN}`, 'page-1', null, Math.floor(RUN / 1000));
+    expect(res.status).toBe('created');
+
+    const metaProspect = await Prospect.findByPk(res.prospectId);
+    expect(metaProspect.phone).toBe(`+65${ph}`);
+    const c = await Consumer.findOne({ where: { phone: `+65${ph}` } });
+    expect(c.signupCount).toBe(2); // web + meta
+    expect(metaProspect.consumerId).toBe(c.id);
+    // Meta is never OTP-verified.
+    expect(c.verifiedSignupCount).toBe(0);
+  });
+
+  test('PUT phone to blank clears the number AND the person link', async () => {
+    const ph = p8(6);
+    await request(app).post('/api/prospects')
+      .send(capturePayload({ campaignId: campaign2.id, phone: ph, email: `blank-${RUN}@test.com` }))
+      .expect(201);
+    const { id } = await Prospect.findOne({ where: { phone: `+65${ph}` } });
+    const r = await request(app)
+      .put(`/api/prospects/${id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ phone: '' });
+    expect(r.status).toBe(200);
+    const p = await Prospect.findByPk(id);
+    expect(p.phone).toBeNull();
+    expect(p.consumerId).toBeNull();
+    const c = await Consumer.findOne({ where: { phone: `+65${ph}` } });
+    expect(c.signupCount).toBe(0);
+  });
+
+  test('PUT phone onto ANOTHER person merges the signup into their consumer', async () => {
+    const phKeep = p8(7);
+    const phMove = p8(8);
+    await request(app).post('/api/prospects')
+      .send(capturePayload({ campaignId: campaign1.id, phone: phKeep, email: `keep-${RUN}@test.com` }))
+      .expect(201);
+    await request(app).post('/api/prospects')
+      .send(capturePayload({ campaignId: campaign2.id, phone: phMove, email: `move-${RUN}@test.com` }))
+      .expect(201);
+    const { id: movedId } = await Prospect.findOne({ where: { phone: `+65${phMove}` } });
+
+    await request(app)
+      .put(`/api/prospects/${movedId}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ phone: phKeep })
+      .expect(200);
+
+    const keepC = await Consumer.findOne({ where: { phone: `+65${phKeep}` } });
+    const moveC = await Consumer.findOne({ where: { phone: `+65${phMove}` } });
+    const movedRow = await Prospect.findByPk(movedId);
+    expect(movedRow.consumerId).toBe(keepC.id);
+    expect(keepC.signupCount).toBe(2);
+    expect(moveC.signupCount).toBe(0);
+  });
+
+  test('verified lastName survives a later verified signup that omits it (R2 #1)', async () => {
+    const ph = p8(9);
+    markPhoneVerified(`+65${ph}`);
+    await request(app).post('/api/prospects')
+      .send(capturePayload({
+        campaignId: campaign1.id, phone: ph, firstName: 'First', lastName: 'Keeper',
+        email: `ln-a-${RUN}@test.com`,
+      }))
+      .expect(201);
+    markPhoneVerified(`+65${ph}`);
+    await request(app).post('/api/prospects')
+      .send(capturePayload({
+        campaignId: campaign2.id, phone: ph, firstName: 'Second', lastName: undefined,
+        email: `ln-b-${RUN}@test.com`,
+      }))
+      .expect(201);
+    const c = await Consumer.findOne({ where: { phone: `+65${ph}` } });
+    expect(c.firstName).toBe('Second');
+    expect(c.lastName).toBe('Keeper');
   });
 });

--- a/backend/test/integration/consumerSpine.test.js
+++ b/backend/test/integration/consumerSpine.test.js
@@ -1,0 +1,235 @@
+import request from 'supertest';
+import { getApp, closeDb, createTestUser, createTestCampaign } from '../helpers.js';
+import { sequelize, Consumer, Prospect } from '../../src/models/index.js';
+import { markPhoneVerified } from '../../src/services/verifiedPhoneStore.js';
+import { reconcileConsumerSpine } from '../../src/services/consumerService.js';
+
+/**
+ * Consumer spine — integration (real Postgres; savepoint/ON CONFLICT semantics
+ * cannot be proven with mocks). Plan §6: docs/plans/consumer-spine-and-consent-ledger.md.
+ */
+
+const RUN = Date.now();
+const PHONE_A = '+65911100019';
+// 8-digit SG numbers (normalizePhone adds +65)
+const phoneA = `9${String(RUN).slice(-7)}`;          // person A, raw 8-digit
+const phoneAE164 = `+65${phoneA}`;
+const phoneB = `8${String(RUN).slice(-7)}`;          // person B
+const phoneBE164 = `+65${phoneB}`;
+
+let app;
+let adminToken;
+let agentToken;
+let campaign1;
+let campaign2;
+
+function capturePayload(overrides = {}) {
+  return {
+    firstName: 'Spine',
+    lastName: 'Tester',
+    email: `spine-${RUN}@test.com`,
+    phone: phoneA,
+    leadSource: 'website',
+    consent_contact: true,
+    consent_terms: true,
+    ...overrides,
+  };
+}
+
+beforeAll(async () => {
+  app = await getApp();
+  const admin = await createTestUser({ role: 'admin' });
+  adminToken = admin.token;
+  const agent = await createTestUser({ role: 'agent', phone: `+657${String(RUN).slice(-7)}` });
+  agentToken = agent.token;
+  campaign1 = await createTestCampaign(admin.user.id, { name: `Spine C1 ${RUN}` });
+  campaign2 = await createTestCampaign(admin.user.id, { name: `Spine C2 ${RUN}` });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+describe('consumer spine — capture linkage', () => {
+  test('same phone across two campaigns → ONE consumer, both signups linked', async () => {
+    markPhoneVerified(phoneAE164); // first signup is OTP-verified
+    const r1 = await request(app).post('/api/prospects')
+      .send(capturePayload({ campaignId: campaign1.id }));
+    expect(r1.status).toBe(201);
+
+    const r2 = await request(app).post('/api/prospects')
+      .send(capturePayload({ campaignId: campaign2.id }));
+    expect(r2.status).toBe(201);
+
+    const consumers = await Consumer.findAll({ where: { phone: phoneAE164 } });
+    expect(consumers).toHaveLength(1);
+    const c = consumers[0];
+    expect(c.signupCount).toBe(2);
+    // Only the first signup ran inside the 10-min OTP window with a marker we set;
+    // the marker is single-use per capture read but keyed+TTL'd, so both may pass
+    // depending on store semantics — assert the invariant that holds either way:
+    expect(c.verifiedSignupCount).toBeGreaterThanOrEqual(1);
+    expect(c.verifiedSignupCount).toBeLessThanOrEqual(2);
+
+    const linked = await Prospect.findAll({ where: { phone: phoneAE164 } });
+    expect(linked).toHaveLength(2);
+    for (const p of linked) expect(p.consumerId).toBe(c.id);
+  });
+
+  test('duplicate signup in the SAME campaign → 409, signupCount unchanged', async () => {
+    const before = await Consumer.findOne({ where: { phone: phoneAE164 } });
+    const dup = await request(app).post('/api/prospects')
+      .send(capturePayload({ campaignId: campaign1.id }));
+    expect(dup.status).toBe(409);
+    const after = await Consumer.findOne({ where: { phone: phoneAE164 } });
+    expect(after.signupCount).toBe(before.signupCount);
+  });
+
+  test('spine failure never blocks capture (savepoint isolation, real PG)', async () => {
+    await sequelize.query('ALTER TABLE consumers RENAME TO consumers_hidden');
+    try {
+      const r = await request(app).post('/api/prospects')
+        .send(capturePayload({ campaignId: campaign1.id, phone: phoneB, email: `b-${RUN}@test.com` }));
+      expect(r.status).toBe(201);
+      const p = await Prospect.findOne({ where: { phone: phoneBE164 } });
+      expect(p).toBeTruthy();
+      expect(p.consumerId).toBeNull();
+    } finally {
+      await sequelize.query('ALTER TABLE consumers_hidden RENAME TO consumers');
+    }
+  });
+});
+
+describe('consumer spine — reconciler', () => {
+  test('heals the unlinked row, assigns (not increments) counts, and is idempotent', async () => {
+    const s1 = await reconcileConsumerSpine();
+    expect(s1.consumersUpserted).toBeGreaterThanOrEqual(2);
+
+    // The savepoint-test row (phoneB) is now linked.
+    const pb = await Prospect.findOne({ where: { phone: phoneBE164 } });
+    expect(pb.consumerId).toBeTruthy();
+
+    // Corrupt a counter → reconcile assigns the row-derived truth back.
+    await sequelize.query(
+      `UPDATE consumers SET "signupCount" = 99 WHERE phone = :phone`,
+      { replacements: { phone: phoneAE164 } }
+    );
+    await reconcileConsumerSpine();
+    const healed = await Consumer.findOne({ where: { phone: phoneAE164 } });
+    expect(healed.signupCount).toBe(2);
+
+    // Idempotent: a second run changes nothing.
+    const snapshotBefore = JSON.stringify(
+      (await Consumer.findAll({ order: [['phone', 'ASC']] }))
+        .map((c) => ({ p: c.phone, n: c.signupCount, v: c.verifiedSignupCount }))
+    );
+    await reconcileConsumerSpine();
+    const snapshotAfter = JSON.stringify(
+      (await Consumer.findAll({ order: [['phone', 'ASC']] }))
+        .map((c) => ({ p: c.phone, n: c.signupCount, v: c.verifiedSignupCount }))
+    );
+    expect(snapshotAfter).toBe(snapshotBefore);
+  });
+
+  test('call_bot rows never link and get unlinked if they somehow were', async () => {
+    const cb = await Prospect.create({
+      firstName: 'Voice', email: null, phone: PHONE_A,
+      leadSource: 'call_bot', leadStatus: 'new', campaignId: campaign1.id,
+    });
+    // Force a bogus link, then reconcile.
+    const anyConsumer = await Consumer.findOne({ where: { phone: phoneAE164 } });
+    await sequelize.query(
+      `UPDATE prospects SET "consumerId" = :cid WHERE id = :pid`,
+      { replacements: { cid: anyConsumer.id, pid: cb.id } }
+    );
+    await reconcileConsumerSpine();
+    await cb.reload();
+    expect(cb.consumerId).toBeNull();
+    // And no consumer was minted for the call_bot number.
+    expect(await Consumer.findOne({ where: { phone: PHONE_A } })).toBeNull();
+  });
+});
+
+describe('consumer spine — identity integrity on edits/deletes', () => {
+  test('phone edit relinks, recomputes both consumers, and strips the OTP stamp', async () => {
+    const p1 = await Prospect.findOne({ where: { phone: phoneAE164, campaignId: campaign1.id } });
+    const newPhone8 = `9${String(RUN + 1).slice(-7)}`;
+    const newPhoneE164 = `+65${newPhone8}`;
+
+    const r = await request(app)
+      .put(`/api/prospects/${p1.id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ phone: newPhone8 });
+    expect(r.status).toBe(200);
+
+    await p1.reload();
+    expect(p1.phone).toBe(newPhoneE164);
+    expect(p1.sourceMetadata?.phoneVerifiedAt).toBeUndefined();
+    expect(p1.sourceMetadata?.phoneVerifiedFor).toBeUndefined();
+
+    const oldC = await Consumer.findOne({ where: { phone: phoneAE164 } });
+    const newC = await Consumer.findOne({ where: { phone: newPhoneE164 } });
+    expect(oldC.signupCount).toBe(1);
+    expect(newC).toBeTruthy();
+    expect(newC.signupCount).toBe(1);
+    expect(p1.consumerId).toBe(newC.id);
+
+    // Move it back for the later tests (also exercises the reverse path).
+    await request(app)
+      .put(`/api/prospects/${p1.id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ phone: phoneA })
+      .expect(200);
+  });
+
+  test('delete recomputes the consumer projection', async () => {
+    const victim = await Prospect.findOne({ where: { phone: phoneAE164, campaignId: campaign2.id } });
+    const r = await request(app)
+      .delete(`/api/prospects/${victim.id}`)
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(r.status).toBe(200);
+    const c = await Consumer.findOne({ where: { phone: phoneAE164 } });
+    expect(c.signupCount).toBe(1);
+  });
+});
+
+describe('consumer spine — read surfaces', () => {
+  test('GET /api/consumers/:id → admin-only journey; 403 for agents; 404s clean', async () => {
+    const c = await Consumer.findOne({ where: { phone: phoneAE164 } });
+
+    const ok = await request(app)
+      .get(`/api/consumers/${c.id}`)
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(ok.status).toBe(200);
+    expect(ok.body.data.consumer.id).toBe(c.id);
+    expect(ok.body.data.consumer.signupCount).toBe(1);
+    expect(Array.isArray(ok.body.data.signups)).toBe(true);
+    expect(ok.body.data.signups[0].campaign?.name).toBeTruthy();
+    // Journey rows are DERIVED — no raw sourceMetadata leaves this endpoint.
+    expect(JSON.stringify(ok.body.data)).not.toContain('sourceMetadata');
+
+    const forbidden = await request(app)
+      .get(`/api/consumers/${c.id}`)
+      .set('Authorization', `Bearer ${agentToken}`);
+    expect(forbidden.status).toBe(403);
+
+    await request(app)
+      .get('/api/consumers/not-a-uuid')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .expect(404);
+    await request(app)
+      .get('/api/consumers/00000000-0000-4000-8000-000000000000')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .expect(404);
+  });
+
+  test('GET /api/prospects/:id (admin) carries the consumer journey block', async () => {
+    const p = await Prospect.findOne({ where: { phone: phoneAE164 } });
+    const r = await request(app)
+      .get(`/api/prospects/${p.id}`)
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(r.status).toBe(200);
+    expect(r.body.data.prospect.consumer).toBeTruthy();
+    expect(r.body.data.prospect.consumer.consumer.signupCount).toBe(1);
+  });
+});

--- a/backend/test/redeemOpsHostGuard.test.js
+++ b/backend/test/redeemOpsHostGuard.test.js
@@ -37,6 +37,13 @@ describe('internalRouteHostGuard — redeem-ops + ops-host policy', () => {
     expect(run('/api/admin/campaigns', 'redeem.sg').statusCode).toBe(403);
   });
 
+  test('consumer spine: /api/consumers is blocked from both customer-facing hosts', () => {
+    // Cross-campaign PII journey — admin surface only (consumer-spine PR A).
+    expect(run('/api/consumers/some-id', 'redeem.sg').statusCode).toBe(403);
+    expect(run('/api/consumers/some-id', 'ops.redeem.sg').statusCode).toBe(403);
+    expect(run('/api/consumers/some-id', 'mktr.sg').nextCalled).toBe(true);
+  });
+
   test('ops.redeem.sg may reach auth, redeem-ops, and notifications', () => {
     expect(run('/api/auth/login', 'ops.redeem.sg').nextCalled).toBe(true);
     expect(run('/api/redeem-ops/team', 'ops.redeem.sg').nextCalled).toBe(true);

--- a/backend/test/redeemOpsPhoneDedupe.test.js
+++ b/backend/test/redeemOpsPhoneDedupe.test.js
@@ -7,6 +7,14 @@
  * burning allocation for the whole reservation window. `phoneKey` +
  * uq_re_activation_phone (partial: eligible/issued/redeemed) make the DB the
  * authoritative guard; expired/cancelled rows free the slot.
+ *
+ * FIXTURE NOTE (consumer-spine PR A): the prospects (campaignId, phone)
+ * partial unique is now mirrored on the model, so test DBs finally carry it —
+ * same-campaign same-phone prospect rows are impossible here, exactly as in
+ * prod since migration 010. "Second signup" fixtures therefore ride
+ * campaignId:null + an explicit activationId, which is the surviving real
+ * path this entitlement-layer guard exists for (sweep/manual/null-campaign
+ * issuance, historical dupes).
  */
 process.env.REDEEM_OPS_ENABLED = 'true';
 process.env.REDEEM_OPS_ENTITLEMENTS_ENABLED = 'true';
@@ -87,13 +95,13 @@ describe('one live reward per phone per activation', () => {
   test('second signup with the same phone collapses to the FIRST entitlement', async () => {
     const phone = freshPhone();
     const p1 = await makeVerifiedProspect(phone);
-    const p2 = await makeVerifiedProspect(phone); // same human, second form submit
+    const p2 = await makeVerifiedProspect(phone, { campaignId: null }); // same human, second row
 
     const first = await svc.issueForProspect(p1);
     expect(first.reason).toBeNull();
     expect(first.entitlement.phoneKey).toBe(phoneKeyOf(phone));
 
-    const second = await svc.issueForProspect(p2);
+    const second = await svc.issueForProspect(p2, { activationId: activationA.id });
     expect(second.reason).toBe('duplicate_phone');
     expect(second.entitlement.id).toBe(first.entitlement.id); // points at the winner
 
@@ -106,11 +114,11 @@ describe('one live reward per phone per activation', () => {
   test('CONCURRENT same-phone signups → exactly one entitlement (DB index is the guard)', async () => {
     const phone = freshPhone();
     const p1 = await makeVerifiedProspect(phone);
-    const p2 = await makeVerifiedProspect(phone);
+    const p2 = await makeVerifiedProspect(phone, { campaignId: null });
 
     const [a, b] = await Promise.all([
       svc.issueForProspect(p1),
-      svc.issueForProspect(p2),
+      svc.issueForProspect(p2, { activationId: activationA.id }),
     ]);
     const fresh = [a, b].filter((r) => r.reason === null);
     const blocked = [a, b].filter((r) => r.reason === 'duplicate_phone');
@@ -142,8 +150,8 @@ describe('one live reward per phone per activation', () => {
     await svc.expireReservations();
     expect((await RewardEntitlement.findByPk(first.entitlement.id)).status).toBe('expired');
 
-    const p2 = await makeVerifiedProspect(phone);
-    const second = await svc.issueForProspect(p2);
+    const p2 = await makeVerifiedProspect(phone, { campaignId: null });
+    const second = await svc.issueForProspect(p2, { activationId: activationA.id });
     expect(second.reason).toBeNull(); // slot freed
     expect(second.entitlement.id).not.toBe(first.entitlement.id);
   });
@@ -154,8 +162,8 @@ describe('one live reward per phone per activation', () => {
     const first = await svc.issueForProspect(p1);
     await svc.cancelEntitlement(first.entitlement.id, admin.user, 'dedupe test');
 
-    const p2 = await makeVerifiedProspect(phone);
-    const second = await svc.issueForProspect(p2);
+    const p2 = await makeVerifiedProspect(phone, { campaignId: null });
+    const second = await svc.issueForProspect(p2, { activationId: activationA.id });
     expect(second.reason).toBeNull();
   });
 
@@ -167,8 +175,8 @@ describe('one live reward per phone per activation', () => {
     await redemptions.complete(unlock.voucherToken, {}, admin.user);
     expect((await RewardEntitlement.findByPk(first.entitlement.id)).status).toBe('redeemed');
 
-    const p2 = await makeVerifiedProspect(phone);
-    const second = await svc.issueForProspect(p2);
+    const p2 = await makeVerifiedProspect(phone, { campaignId: null });
+    const second = await svc.issueForProspect(p2, { activationId: activationA.id });
     expect(second.reason).toBe('duplicate_phone');
   });
 
@@ -207,7 +215,7 @@ describe('no-phone rules', () => {
     const p1 = await makeVerifiedProspect(phone);
     await svc.issueForProspect(p1);
 
-    const p2 = await makeVerifiedProspect(phone);
+    const p2 = await makeVerifiedProspect(phone, { campaignId: null });
     await expect(
       svc.issueManual({ activationId: activationA.id, prospectId: p2.id }, admin.user)
     ).rejects.toMatchObject({ statusCode: 409, message: expect.stringContaining('duplicate_phone') });

--- a/backend/test/unit/consumerSpineUnit.test.js
+++ b/backend/test/unit/consumerSpineUnit.test.js
@@ -1,0 +1,120 @@
+import { jest } from '@jest/globals';
+import '../setup.js';
+import { createHash } from 'crypto';
+import { phoneVerificationIsCurrent, phoneHashOf, E164_RE } from '../../src/services/consumerService.js';
+import { buildLeadCreatedPayload, buildLeadDeletedPayload, buildLeadAssignedPayload } from '../../src/services/prospectHelpers.js';
+import { makeEntitlementService } from '../../src/services/redeemOps/entitlementService.js';
+
+const sha = (v) => createHash('sha256').update(v).digest('hex');
+
+describe('phoneVerificationIsCurrent (stamp↔phone binding, Codex R1 #6)', () => {
+  const phone = '+6591234567';
+  test('no stamp → false', () => {
+    expect(phoneVerificationIsCurrent({ phone, sourceMetadata: {} })).toBe(false);
+    expect(phoneVerificationIsCurrent(null)).toBe(false);
+  });
+  test('legacy stamp without binding → true', () => {
+    expect(phoneVerificationIsCurrent({ phone, sourceMetadata: { phoneVerifiedAt: '2026-01-01T00:00:00Z' } })).toBe(true);
+  });
+  test('bound stamp matching the current phone → true', () => {
+    expect(phoneVerificationIsCurrent({
+      phone, sourceMetadata: { phoneVerifiedAt: '2026-01-01T00:00:00Z', phoneVerifiedFor: sha(phone) },
+    })).toBe(true);
+  });
+  test('bound stamp for a DIFFERENT phone (post-edit) → false', () => {
+    expect(phoneVerificationIsCurrent({
+      phone: '+6598765432',
+      sourceMetadata: { phoneVerifiedAt: '2026-01-01T00:00:00Z', phoneVerifiedFor: sha(phone) },
+    })).toBe(false);
+  });
+  test('phoneHashOf matches the stamp recipe', () => {
+    expect(phoneHashOf(phone)).toBe(sha(phone));
+    expect(E164_RE.test(phone)).toBe(true);
+  });
+});
+
+describe('webhook payload contract — consumerId NEVER leaves the system (plan §2.3)', () => {
+  const prospect = {
+    id: 'p-1', consumerId: '11111111-1111-4111-8111-111111111111',
+    firstName: 'A', lastName: 'B', phone: '+6591234567', email: 'a@b.c',
+    company: null, jobTitle: null, industry: null, leadSource: 'website',
+    interests: null, budget: null, preferences: null, demographics: null,
+    location: null, tags: null, notes: null,
+    sourceMetadata: { utm: { utm_source: 'fb' } }, dncStatus: null,
+    createdAt: new Date('2026-01-01'),
+  };
+  test('lead.created carries no consumerId', () => {
+    const payload = buildLeadCreatedPayload(prospect, 'round_robin', { phone: '+65', email: 'x', name: 'X', id: 'agent-ext' }, 'agent-1', { id: 'c1', name: 'C' }, null, null);
+    expect(JSON.stringify(payload)).not.toContain('consumerId');
+    expect(payload.data.lead.externalId).toBe('p-1');
+  });
+  test('lead.deleted carries no consumerId', () => {
+    const payload = buildLeadDeletedPayload(prospect);
+    expect(JSON.stringify(payload)).not.toContain('consumerId');
+  });
+  test('lead.assigned carries no consumerId', () => {
+    const payload = buildLeadAssignedPayload(prospect, { id: 'a1', phone: '+65', email: 'x@y.z', firstName: 'Ag', lastName: 'Ent' }, { campaign: null }, {});
+    expect(JSON.stringify(payload)).not.toContain('consumerId');
+  });
+});
+
+describe('entitlement issuance — consumer link + bound-stamp gate', () => {
+  function buildService({ prospectOverrides = {}, consumerLookup = null } = {}) {
+    const phone = '+6591234567';
+    const prospect = {
+      id: 'p-1', campaignId: 'c-1', phone, consumerId: 'consumer-1', quarantinedAt: null,
+      sourceMetadata: { phoneVerifiedAt: '2026-01-01T00:00:00Z', phoneVerifiedFor: sha(phone) },
+      ...prospectOverrides,
+    };
+    const activation = {
+      id: 'act-1', campaignId: 'c-1', status: 'active', unlockPolicy: 'agent_unlock',
+      endDate: null, rewardOffer: { id: 'offer-1', status: 'active', claimExpiryDays: 30, redemptionExpiryDays: 90 },
+    };
+    const create = jest.fn(async (v) => ({ id: 'ent-1', ...v }));
+    const svc = makeEntitlementService({
+      Activation: { findOne: jest.fn(async () => activation) },
+      RewardEntitlement: { findOne: jest.fn(async () => null), create },
+      RedemptionEvent: { create: jest.fn(async () => ({})) },
+      ActivationIssuanceSkip: { create: jest.fn(async () => ({})) },
+      Consumer: { findOne: jest.fn(async () => consumerLookup) },
+      inventory: { recordIssued: jest.fn(async () => ({})) },
+      audit: {},
+      sequelize: {
+        transaction: async (cb) => cb({ __tx: true }),
+        query: jest.fn(async () => [[{ id: 'act-1' }]]),
+      },
+      logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    });
+    return { svc, create, prospect };
+  }
+
+  test('links consumerId from the prospect at create', async () => {
+    const { svc, create, prospect } = buildService();
+    const res = await svc.issueForProspect(prospect, { via: 'hook' });
+    expect(res.entitlement).toBeTruthy();
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(create.mock.calls[0][0].consumerId).toBe('consumer-1');
+    expect(create.mock.calls[0][0].phoneKey).toBe('6591234567');
+  });
+
+  test('falls back to a phoneKey consumer lookup for pre-spine prospects', async () => {
+    const { svc, create, prospect } = buildService({
+      prospectOverrides: { consumerId: null },
+      consumerLookup: { id: 'consumer-legacy' },
+    });
+    await svc.issueForProspect(prospect, { via: 'hook' });
+    expect(create.mock.calls[0][0].consumerId).toBe('consumer-legacy');
+  });
+
+  test('bound stamp for a different phone → phone_not_verified, nothing created', async () => {
+    const { svc, create, prospect } = buildService({
+      prospectOverrides: {
+        sourceMetadata: { phoneVerifiedAt: '2026-01-01T00:00:00Z', phoneVerifiedFor: sha('+6500000000') },
+      },
+    });
+    const res = await svc.issueForProspect(prospect, { via: 'hook' });
+    expect(res.entitlement).toBeNull();
+    expect(res.reason).toBe('phone_not_verified');
+    expect(create).not.toHaveBeenCalled();
+  });
+});

--- a/docs/plans/consumer-spine-and-consent-ledger.md
+++ b/docs/plans/consumer-spine-and-consent-ledger.md
@@ -1,0 +1,205 @@
+# Consumer Spine + Consent Ledger — Implementation Plan v2 (post-Codex round 1)
+
+**Date:** 2026-07-20 · **Status:** PLAN v2 — Codex round-1 findings (25) verified against code and folded; pending Shawn's sign-off on the Decisions list, then implement (or Codex round 2)
+**Scope:** now **three PRs**. PR A = consumer spine + identity-integrity hooks. PR B = purpose-scoped consent ledger + suppression + unsubscribe. PR C = PDPA erasure.
+**Out of scope (later phases):** OTP wallet / prefill / cross-sell (Phase 2 — now also carries the **global marketing opt-in capture**, see §3.1); consumer journeys, segments, inclusion audiences (Phase 3); WhatsApp STOP webhook (WABA go-live); retention TTL policy; Lyfe-side person merge; downstream (Lyfe/mktr-leads) suppression-propagation contract; B12 list serializer.
+
+## 0. Why + what changed in v2
+
+Goal unchanged: one consumer (phone-keyed) across many campaigns, with consent you can lawfully re-market on. The v1 design had five structural errors, all confirmed by Codex round 1 and re-verified against the code:
+
+1. "Non-blocking resolver inside the capture transaction" violated Postgres semantics — any SQL error poisons the outer txn (`current transaction is aborted`); catch-and-continue is impossible without a savepoint. v2 uses an **atomic upsert inside a SAVEPOINT**.
+2. There are **three** prospect creators, not two — Meta Lead Ads creates directly (`metaLeadService.js:241-274`) with a **non-normalized phone** and rawFields PII. v2 hooks all three through one primitive.
+3. **Retell stores `to_number` as `prospect.phone`** (`retellService.js:260-263` says so explicitly — inbound calls would make the consumer `from_number`). Linking Retell rows could collapse strangers onto MKTR's own DDI. v2 **excludes `call_bot` leads from the spine** until leg selection is fixed (this is also why `repeatSignup.js` excludes call_bot).
+4. **Consent is campaign/purpose-scoped, not global** — the two live surfaces grant contact consent "for the purposes identified in this form" (`CampaignSignupForm.jsx:903-908`) / "about this redemption" (`MarketplaceFlow.jsx:812-828`). A latest-event-wins global state would misrepresent what was collected. v2 scopes the ledger and **blocks cross-campaign marketing until an explicit global opt-in exists** (product implication, §3.1).
+5. Erasure was a denylist over a subset of the PII that actually exists. v2 is an **allowlist rebuild + a table-by-table matrix** (§5), with lock ordering and webhook-payload-copy scrubbing.
+
+**Design principle (revised): the spine is a rebuildable projection of `prospects`, written best-effort behind savepoints, healed by a deterministic reconciler.** Capture is never blocked by spine failures; drift is repaired by re-running the reconciler (which *assigns* complete projections, never increments). Erasure (PR C) is the deliberate exception — it mutates source rows.
+
+## 1. Verified ground truth (v2-corrected anchors)
+
+- Prospect creators (ALL must be hooked or explicitly excluded):
+  1. `prospectService.createProspect` — txn `:817`, `Prospect.create :852`; phone normalized at `:413-414`; OTP marker single-read `:416`; per-campaign dupe 409 `:570-603`; consent intents `:200-211`; server evidence `:279-296`; verified stamp `:498-503` (written iff OTP marker live; **plain unverified direct-API POSTs still capture** — `routes/prospects.js:26-29` is public by design).
+  2. `retellService.processRetellCall` — txn `:276`, create `:305`; `phone = to_number`; **EXCLUDED from spine in PR A** (leg ambiguity, `:260-263`).
+  3. `metaLeadService` — own txn `:227`, create `:241`; phone NOT normalized; `sourceMetadata.rawFields :265-273`; linked as **unverified**.
+- Phone/email are freely editable via `PUT` (`PROSPECT_UPDATE_FIELDS`, `prospectService.js:120-140`) and `updateProspect` applies them with no identity maintenance (`:1241-1260`); hard delete `:1305-1357` (persists `lead.deleted` deliveries in-txn — reuse this pattern) and bulk delete `:2592-2618`.
+- **Pre-existing bug to fix in PR A:** entitlement issuance verifies only `phoneVerifiedAt` and never compares `phoneVerifiedFor` to the current phone (`entitlementService.js:91-92, 196-199`) — a staff phone edit keeps stale verification. Fix `verificationStampOf` to require `phoneVerifiedFor === sha256(prospect.phone)`.
+- Entitlement creation choke point: ALL issuance paths (hook `:184-219`, sweep `:468-482`, manual `:666-688`) funnel into `issueForProspect`, insert at `:276-292` → set `consumerId` there **unconditionally** (no "optional cut").
+- Model/migration index mirroring: `Prospect.js:283-323` does NOT mirror the partial unique (comments only, `:287-289`) — that is the anti-pattern; `RewardEntitlement.js:54-65` is the correct pattern. All new tables mirror every correctness index on the model.
+- Test bootstrap runs `sequelize.sync({ force: true })` BEFORE migrations (`bootstrap.js:27-30`) → new migrations must tolerate tables/indexes already created from models.
+- `runMigrations` (`runMigrations.js:35-66`) has **no advisory lock, no per-migration transaction**; boot listens before init (`server.js:18-38`, routes installed `server_internal.js:240-268`) → rolling deploys can race. PR A adds `pg_advisory_lock` around the runner and wraps each new migration in a transaction.
+- Lyfe webhook subscriber events = `lead.created/assigned/unassigned` ONLY (`bootstrap.js:328-353`) — `lead.deleted` never reaches Lyfe; `WebhookDelivery.payload` retains full payload copies and successful deliveries are never purged (`WebhookDelivery.js:23-30`, `webhookService.js:416-427`).
+- Consent evidence pattern to mirror: `externalConsent.js` (`*_CONSENT_VERSION`, `build*Evidence`, `hasValid*`), `dncConsent.js`. `consent_contact`/`consent_terms` today: bare booleans in `sourceMetadata` (`prospectService.js:263-264`), written only when present in the payload (absent ≠ false — Retell/Meta never write them).
+- Admin drawer opens from the LIST ROW, never calls `getProspect` (`AdminV2Prospects.jsx:197-210, 421-459`), and `?lead=` deep-links only resolve on the current page (`:216-230`); prospect detail route is authenticated-but-not-admin-only (`routes/prospects.js:34-38`).
+- Mailer: `sendEmail` `mailer.js:67`, no headers passthrough (`:86`); templates render `{{fields}}` with unknown-placeholder preservation (`:346-351`). SES DKIM exists for both sender domains — **verify at impl that the DKIM signature covers `List-Unsubscribe*` headers** (RFC 8058 requirement).
+- Suppression precedent is partner-only (`OutreachSuppression.js`, consulted only by `cadenceService.js:377-406`).
+- Marketing/audience surfaces that must consult the new state: `redeemedAudienceService.js:66-100` (selects by email/phone + old consent boolean), delayed down-funnel CAPI `leadOutcomeService.js:113-159` → `metaCapiService.js:42-64` (hashes em/ph when the stale signup boolean is true), WhatsApp `canWhatsAppProspect` (`whatsappService.js:80-84`; its `:39-47` comment leaves transactional-vs-marketing undecided).
+
+### Preflight data (run 2026-07-19 against prod `dpg-d2s2h7nfte5s739gnl7g-a`; re-run before implementing)
+
+```sql
+WITH pc AS (SELECT phone, count(*) s, count(DISTINCT "campaignId") c FROM prospects WHERE phone IS NOT NULL GROUP BY phone)
+SELECT (SELECT count(*) FROM prospects) total, (SELECT count(*) FROM pc) phones,
+       count(*) FILTER (WHERE c>=2) multi, max(c) maxc FROM pc;
+-- 2026-07-19: total=135, phones=130, multi=5, maxc=2; 135/135 phones ~ '^\+65[0-9]{8}$'; consentMetadata on 60/135
+```
+
+## 2. PR A — Consumer spine + identity integrity
+
+### 2.1 Migration `078-consumer-spine.js`
+
+Guarded for test-sync'd schemas (skip create-if-exists, follow the pattern of recent migrations); wrapped in a transaction; `runMigrations` gains `pg_advisory_lock(<constant>)` around the whole run (benefits every future migration; release on completion; existing single-row-ledger semantics unchanged).
+
+**`consumers`** (model `Consumer`, all correctness indexes mirrored on the model):
+
+| column | type | notes |
+|---|---|---|
+| `id` | UUID PK v4 | |
+| `phone` | VARCHAR nullable | E.164; CHECK `phone ~ '^\+[1-9][0-9]{9,14}$' OR phone IS NULL`; null only post-erasure |
+| `phoneHash` | VARCHAR(64) nullable | sha256 hex, CHECK 64-hex-or-null; **nulled on erasure** (PDPC: unsalted hash of an enumerable space is pseudonymous, not anonymous — no tombstone) |
+| `firstName`/`lastName`/`email` | VARCHAR nullable | latest VERIFIED-signup values preferred, else latest; email via `emailNormKey` filter |
+| `firstSeenAt`/`lastSeenAt` | timestamptz NOT NULL | |
+| `signupCount` | INTEGER NOT NULL ≥0 (CHECK) | assigned by reconciler/resolver, never trusted blindly |
+| `verifiedSignupCount` | INTEGER NOT NULL ≥0 | signups carrying a valid OTP stamp |
+| `unsubTokenHash` | VARCHAR(64) nullable | PR B: sha256 of the opaque unsubscribe token |
+| `erasedAt` | timestamptz nullable | PR C |
+| timestamps | | |
+
+Indexes: `uq_consumers_phone` UNIQUE partial `(phone) WHERE phone IS NOT NULL`; `idx_consumers_phone_hash`; `idx_consumers_last_seen`.
+
+Columns added: `prospects.consumerId`, `reward_entitlements.consumerId` (UUID nullable, FK SET NULL, indexed). Associations: `Consumer.hasMany(Prospect,'signups')`, `Prospect.belongsTo(Consumer)`, `Consumer.hasMany(RewardEntitlement)`, `RewardEntitlement.belongsTo(Consumer)`, plus `RewardEntitlement.hasOne(Redemption, as:'redemption')` (missing today, needed by the journey query — `models/index.js:236-249`).
+
+### 2.2 Resolver — atomic, savepoint-isolated (`services/consumerService.js`)
+
+```
+resolveConsumerTx(outerTx, { phone, firstName, lastName, email, verified, at })
+```
+- Requires an ALREADY-normalized E.164 phone; returns null when absent. `verified` = the OTP-stamp decision the caller already made (`otpMarkerLive` in web capture; `false` for Meta).
+- Runs inside `sequelize.transaction({ transaction: outerTx })` — a **SAVEPOINT**, so any failure rolls back the savepoint only and the outer capture txn stays healthy (this is what makes "non-blocking" true; v1's catch-and-continue was impossible).
+- One raw statement, no 23505 ever raised:
+  `INSERT INTO consumers (…) VALUES (…) ON CONFLICT (phone) WHERE phone IS NOT NULL DO UPDATE SET "lastSeenAt"=GREATEST(consumers."lastSeenAt", EXCLUDED."lastSeenAt"), "signupCount"=consumers."signupCount"+1, "verifiedSignupCount"=consumers."verifiedSignupCount" + <verified?1:0>, <attribute refresh with CASE/COALESCE> RETURNING id`
+  (conflict target MUST carry the `WHERE phone IS NOT NULL` predicate to infer the partial index). Attribute refresh: names always-if-nonempty when `verified`, else only-if-null; email only when `emailNormKey` non-null.
+- On any error: rollback savepoint, `logger.warn`, return null. Real-Postgres test: drop `consumers`, capture still 201s.
+
+### 2.3 Hooks (all writers)
+
+1. `createProspect` — after the 409 dupe check (`:570`) so duplicates never bump counters, before `Prospect.create` (`:852`): resolve with `verified = otpMarkerLive`, put `consumerId` in the create payload. **Unverified direct-API rows DO link** but are second-class: they can never mint marketing authority (PR B) and are badged in the journey UI. (Deviation from Codex's stricter "leave unlinked" — rationale in Decisions #3.)
+2. `metaLeadService` — same hook inside its txn (`:227-274`); **normalize the phone for the MATCHING KEY only** (through `normalizePhone`) without changing what's stored on the prospect in this PR; `verified:false`.
+3. `retellService` — **no hook** (call_bot excluded). Follow-up ticket: resolve the consumer leg from call direction, then link.
+4. `entitlementService.issueForProspect` — set `consumerId` at the insert (`:276-292`) from `prospect.consumerId`, falling back to phone-digit lookup; unconditional.
+5. **`updateProspect` phone/email edits** (`:1241-1260`): wrap in a txn; when phone changes — normalize it (today's PUT doesn't), savepoint-resolve the NEW consumer, relink the prospect, **recompute both old and new consumers' projections from rows** (assign, not adjust), and **clear `sourceMetadata.phoneVerifiedAt/phoneVerifiedFor`** (verification doesn't survive a phone change). Email change: refresh consumer email per resolver rules.
+6. **Drive-by fix:** `verificationStampOf` (`entitlementService.js:91-92`) additionally requires `phoneVerifiedFor === sha256(prospect.phone)` — closes the stale-verification hole independently of the spine.
+7. `deleteProspect` / bulk delete: after the delete txn, recompute the affected consumer's projection (savepoint best-effort; reconciler is the backstop).
+
+**Webhook contract: `consumerId` is deliberately EXCLUDED from every webhook payload** (`prospectHelpers.js:79-105` + the Meta/Retell inline builders) — no stable cross-campaign identifier leaves the system until a versioned downstream contract + privacy review exist. Tests assert its absence.
+
+### 2.4 Migration `079-consumer-reconcile.js` + `scripts/rebuild-consumer-spine.js`
+
+One deterministic **reconciler** (shared module; the migration and the script both call it):
+- Aggregate `prospects` (`phone IS NOT NULL AND phone <> ''`, `leadSource <> 'call_bot'`) → per-phone `{firstSeen, lastSeen, count, verifiedCount, latest attrs (tie-break createdAt,id)}`.
+- UPSERT consumers with **assignment** (`ON CONFLICT (phone) WHERE phone IS NOT NULL DO UPDATE SET … = EXCLUDED.…`) — heals stale counts/attributes, not just missing rows.
+- Relink: `UPDATE prospects SET "consumerId" = c.id FROM consumers c WHERE prospects.phone = c.phone AND (prospects."consumerId" IS DISTINCT FROM c.id) AND "leadSource" <> 'call_bot'` — fixes wrong links, not only nulls; then null out `consumerId` on any call_bot rows.
+- Entitlements: via `prospectId` join first, then `phoneKey` = digits of `consumers.phone`, `WHERE "consumerId" IS DISTINCT FROM` target.
+- Safe to run concurrently with live captures (assignment semantics + advisory-locked runner).
+
+### 2.5 Read surfaces
+
+- `GET /api/consumers/:id` — new `routes/consumers.js`, **explicitly `authenticateToken, requireAdmin`** (do NOT copy the prospects detail route, which is authenticated-only). Returns journey: signups (campaign, status, createdAt, `verified` badge, quarantine), entitlements (+`redemption` via the new association), draw-entry count.
+- `getProspect` detail: attach `consumerId` + compact summary (admin-only, beside the existing `repeatSignup` block at `:1220-1226`; `repeatSignup.js` itself stays untouched).
+- `LeadDrawer` (`AdminV2Prospects.jsx`): the drawer must FETCH on open (it currently renders the list row only) — fetch the consumer journey when `consumerId` present; render the "Person" card with unverified badges; make `?lead=` deep-links fetch by id independent of the current page (fixes the `:216-230` limitation the sibling links would otherwise hit).
+
+## 3. PR B — Purpose-scoped consent ledger, suppression, unsubscribe
+
+### 3.1 The consent model (and its product consequence)
+
+`consent_events` (append-only): as v1 **plus** `surface` VARCHAR(32) (`lead_capture`|`marketplace_flow`|`meta_lead_ad`|`backfill`|`unsubscribe`|`admin`|`erasure`), `verified` BOOLEAN (the signup's OTP status), CHECKs on kind/source enums, and the campaign scope is semantic, not decorative:
+
+- **Current state is computed per `(kind, campaignId)`** for `contact`/`campaign_terms`/`third_party`/`dnc_override` — matching what the copy actually says on both surfaces.
+- **Suppression is global** (withdrawal in the stronger direction is always safe).
+- **`canMarketTo(consumer, {channel, campaignId})`** = latest `contact` event for THAT campaign is `granted:true` AND `verified:true` AND no global suppression AND (channel-specific suppression absent). Unverified grants never authorize marketing.
+- **Consequence: cross-campaign marketing is NOT licensed by any consent we currently collect.** The "audience grows with us" flywheel needs an explicit global opt-in (e.g. "Keep me posted about new Redeem offers") — that capture surface is a headline Phase-2 (wallet/confirmation) deliverable, and until it ships, `canMarketTo` has no global variant. Stated here so nobody "fixes" the scoping later by broadening reads.
+- `contact` events are recorded whenever the field is present in the payload — including explicit `granted:false` (the box is default-ticked; an untick is evidence) — but **absent ≠ false**: Retell/Meta never send it, so nothing is written (matches `prospectService.js:199-201` semantics).
+- New `services/contactConsent.js` with `CONTACT_CONSENT_VERSION` (+ copy hash), mirroring `externalConsent.js:74`.
+
+Writes: in the `createProspect` hook (savepoint-shared with the resolver) and nowhere else in PR B. Backfill = migration `081`: **only when the JSON key exists** on the prospect; `occurredAt = createdAt`, `version 'legacy-backfill'`; idempotent via partial unique `(prospectId, kind) WHERE source='backfill'` (mirrored on the model).
+
+`consumer_suppressions`: as v1 + CHECKs; reasons `unsubscribe|complaint|admin|erasure`. **Semantics: `erasure` blocks everything including transactional; other reasons block marketing only.**
+
+### 3.2 Fail-closed enforcement (works for unlinked rows too)
+
+Enforcement keys on **normalized phone digits, not on `consumerId`** — a row the resolver failed to link is still suppressed:
+- `redeemedAudienceService` (`:66-100`): join prospects→consumers by phone; exclude suppressed and non-`canMarketTo` people from the upload sets. (Known limitation stays documented: add-mode can't remove already-uploaded hashes; removal = next `replace` run.)
+- Delayed down-funnel CAPI (`leadOutcomeService.js:113-159`): re-evaluate consent/suppression **at send time** before `metaCapiService` hashes em/ph (`:42-64`); on withdrawal, send the event without contact identifiers (fbp/fbc/ip/ua only) or skip per `shouldFireCapi` posture.
+- WhatsApp: `canWhatsAppProspect(prospect, { purpose })` — `purpose:'transactional'` (reservation pass, voucher, resend) ignores marketing suppressions but respects `erasure`; `purpose:'marketing'` requires full `canMarketTo`. This resolves the `whatsappService.js:39-47` ambiguity explicitly instead of inheriting it.
+- Downstream copies (Lyfe `leads`, mktr-leads): out of scope; documented as the suppression-propagation contract gap (Phase 3+).
+
+### 3.3 Unsubscribe (mutate on POST only)
+
+- Token: **opaque random 32-byte value, stored as sha256 in `consumers.unsubTokenHash`**, minted lazily at first consumer-email send. No JWT_SECRET coupling (rotation-safe), no consumer UUID in URLs, revocable. (Replaces v1's HMAC design.)
+- `GET /api/unsubscribe?t=…` → **no mutation**; renders a minimal confirmation form (mail scanners prefetch GETs). `POST` (same handler; accepts both the human form and RFC 8058 `List-Unsubscribe=One-Click` body) → upsert suppression (`unsubscribe`, global marketing) + `contact granted:false, source:'unsubscribe'` ledger event → plain confirmation page. Idempotent.
+- `sendEmail`: add `headers` passthrough (`mailer.js:86`); consumer templates get footer link + `{{unsubscribeUrl}}` (update `fields`/`escapeFields` `:330-343` together with the templates); headers `List-Unsubscribe` + `List-Unsubscribe-Post`. **Impl-time check:** SES DKIM must cover these headers; if not, header-only until resolved.
+
+## 4. PR C — PDPA erasure (admin)
+
+`POST /api/admin/consumers/:id/erase` (admin + explicit confirm). **Lock ordering: the Consumer row is locked FIRST (`FOR UPDATE`) in BOTH capture-resolver and erasure**, and the consumer is marked `erasing` before enumeration, so a concurrent capture cannot re-attach PII mid-erasure; related prospects are enumerated AFTER the lock. Queued fulfilment senders (`entitlementService.js:300-309` passes a raw prospect object post-commit; `fulfilmentNotify.js:100-159`, `whatsappService.js:162-171`) must **reload prospect+consumer state immediately before sending** and abort if erased — that reload lands in PR C regardless of erasure frequency.
+
+**Erasure = allowlist rebuild, not a scrub list.** Post-erasure, a prospect row retains ONLY: `id`, `campaignId`, `consumerId`, `leadSource`, `leadStatus`, `priority`, `score`, `createdAt/updatedAt`, quarantine fields, and a minimal `sourceMetadata` allowlist (`utm.{source,medium,campaign}` and non-identifying booleans). Everything else — names (→ `'Erased'`/null), email, phone, company/jobTitle/industry, interests, budget, location, demographics, preferences, notes, tags, click/event ids (fbp/fbc/eventId/ttclid/ttp), IP/UA, full URLs, quiz payloads, marketplace child fields, referral names, retell block, `dncMetadata`, `consentMetadata` (→ `{erased:true}`) — is dropped.
+
+Table matrix (each row = explicit step + test):
+
+| Table | Action |
+|---|---|
+| `prospects` | allowlist rebuild above; `sessionId`/`attributionId` → null (unlinks session/scan streams) |
+| `prospect_activities` | scrub `metadata` (update snapshots embed full before/after PII), keep type/timestamps |
+| `commissions` | scrub lead name from `description` (`prospectService.js:1272-1288`), keep financials |
+| `reward_entitlements` | `phoneKey`/`tokenHint` null; cancel `eligible/issued`; keep `redeemed` rows PII-free |
+| `redemptions` / `redemption_events` | scrub free-text `notes`, reversal reasons, masked destinations in event payloads |
+| `draw_entries` | `prospectId` → null (erased people must not be pickable — `luckyDrawService.js:427-474` only excludes null), scrub `phoneLast4`/hash/masked-name snapshots; **decide + test the erased-pending-winner path** (before freeze / after freeze / after pick) |
+| `short_links` | deactivate the person's `ref=` share links (`shortLinkService.js:121-134`); clicks keep only non-identifying aggregates |
+| `session_visits` / `attributions` / `qr_scans` | unlinked via prospect nulling; rows keep no direct identity (hashed ip/UA — acceptable residual, documented) |
+| `webhook_deliveries` | **in-txn scrub of `payload` for every delivery of this prospect** (copies live forever otherwise — `webhookService.js:416-427`) |
+| `consumers` | `phone`, `phoneHash`, names, email, `unsubTokenHash` → null; `erasedAt`; suppression (`all`,`erasure`); ledger event (`source:'erasure'`) |
+
+Deletion notification: **inside the erasure txn**, persist `lead.deleted` deliveries for every destination that ever received this prospect (reuse the `deleteProspect` in-txn pattern at `:1308-1359`, extended to external-agent destinations); flush post-commit. **Known gap, stated:** Lyfe's subscriber doesn't include `lead.deleted` (`bootstrap.js:328-353`) and `receive-mktr-lead` has no handler — cross-repo follow-up (subscribe + EF handler in lyfe-app) ships alongside PR C, with a manual SOP in the interim. Re-signup after erasure = new consumer, fresh consent (no tombstone — `phoneHash` is nulled per PDPC anonymisation guidance).
+
+## 5. Decisions (v2 — challenge these, then we implement)
+
+1. Phone = identity key; email = attribute (unchanged).
+2. **Retell/call_bot excluded from the spine** until consumer-leg selection is trustworthy (REVERSED from v1 — `to_number` evidence).
+3. **Unverified rows link but carry no authority**: linkage gives ops visibility; consent authority requires the OTP stamp (`verified` on events; `canMarketTo` demands it). Softer than Codex's "leave unlinked": journey pollution by a hostile direct-API poster is cosmetic and badged, while unlinked-but-suppressible rows would make suppression fail open. Phone-keyed fail-closed enforcement (§3.2) is the backstop either way.
+4. **Consent is campaign-scoped; cross-campaign marketing waits for an explicit global opt-in (Phase 2).** The flywheel's legal basis gets built, not assumed.
+5. Opaque stored unsubscribe token; GET never mutates (both REVERSED from v1).
+6. Suppression reasons: `erasure` blocks all sends; others block marketing only; WhatsApp sends declare `purpose`.
+7. No `phoneHash` tombstone after erasure (REVERSED from v1).
+8. `consumerId` excluded from all webhook payloads in these PRs (test-asserted).
+9. Entitlement `consumerId` set unconditionally at issuance (v1's "optional cut" dropped).
+10. Boot-run migrations stay, hardened: advisory lock + per-migration txn + sync-tolerant guards; deploy order = PR A schema+dual-write in one deploy (savepoint isolation covers the seconds-long window), reconciler heals.
+11. No `tenant_id` on new tables (unchanged).
+
+## 6. Test plan (v2 — folds Codex's list)
+
+Real-Postgres (5433 throwaway) unless noted:
+- Concurrent captures of one phone: same campaign (one 409, one create) and different campaigns (both create, one consumer, count=2) — no 23505 surfaces (upsert), savepoint isolation proven by injected SQL failure inside the outer txn (capture still commits, consumerId null).
+- Dropped `consumers` table → capture 201s (savepoint rollback, warn logged).
+- Meta linkage: non-normalized provider phone matches the same consumer as a web signup of the same number; `verified:false`; Retell rows never link and reconciler nulls any that did.
+- Phone edit: old→new relink, both projections recomputed, verification stamp cleared, entitlement issuance now fails `phone_not_verified` until re-OTP (drive-by fix covered); edit-to-existing-consumer merge collision; hard/bulk delete recompute.
+- Reconciler: run twice → byte-identical projections; heals a wrong link and a stale count; concurrent live capture during reconcile.
+- Migrations: `sync({force:true})` then 078-081 (guards hold); two concurrent runners (advisory lock — second waits, applies nothing); crash mid-079 → rerun completes.
+- Ledger: per-kind writes with correct scope/version/verified; explicit-false vs absent distinction (Retell/Meta write nothing); backfill only where keys exist; backfill unique holds on rerun; `canMarketTo` matrix incl. unverified-grant denial and campaign-scope isolation (grant in campaign A ≠ authority in campaign B).
+- Enforcement: suppression by phone-join catches an UNLINKED prospect; redeemedAudience excludes suppressed; delayed CAPI after withdrawal sends no em/ph; WhatsApp transactional-vs-marketing purpose matrix.
+- Unsubscribe: GET mutates nothing (scanner simulation), POST one-click + form both suppress idempotently; token invalid after erasure.
+- Erasure: full matrix assertions (every table above), webhook payload copies scrubbed, `lead.deleted` persisted in-txn for all historical destinations, capture-vs-erase race (lock order), queued voucher send aborts on erased state, draw-entry exclusion + pending-winner path, crash-after-commit retry idempotent.
+- Payload contract: `consumerId` absent from every webhook builder's output.
+- Admin: consumers route rejects non-admin; drawer fetches detail; `?lead=` resolves off-page.
+
+## 7. Rollout & verification
+
+1. **Preflight** (same day as deploy): re-run the §1 SQL; capture output into the PR description.
+2. PR A deploy → advisory-locked migrations 078/079 at boot. Probes: consumers == distinct eligible phones; zero non-call_bot prospects with null `consumerId` and non-empty phone; zero call_bot rows linked; the 5 known Fairprice repeats each = one consumer, `signupCount=2`; entitlements 5/5 linked. Live check: one fresh signup links at create; LeadDrawer Person card on a repeat lead; a phone edit relinks and clears verification.
+3. PR B deploy → 080/081. Probes: event counts vs prospects-with-consent-keys; a test-address email carries both unsubscribe headers; GET is inert, POST suppresses; suppressed test consumer drops out of the next audience-sync selection set.
+4. PR C deploy: erasure dry-run on a synthetic consumer seeded across all matrix tables; verify every row class post-erase; confirm the Lyfe `lead.deleted` follow-up is scheduled (cross-repo).
+5. Standard loop per PR: Codex review → fold → merge → Render deploy-verify (backend origin probe; frontend chunk check only for the PR A drawer change).
+
+## 8. Codex round-1 disposition (for the record)
+
+25 findings: all anchors re-verified in code. Folded: #1-2 (txn semantics → savepoint+upsert), #4 (Retell exclusion), #5 (Meta hook), #6 (edit/delete hooks + stale-verification drive-by), #7 (purpose scoping), #8/#9/#10/#11 (migration hardening, reconciler-assign, backfill uniqueness, model mirroring + CHECKs), #12 (fail-closed by phone + send-time CAPI gate), #13 (WhatsApp purpose), #14 (POST-only mutation), #15 (opaque stored token), #16-#21 (erasure allowlist, matrix, races, webhook copies, draw entries, no tombstone), #22 (unconditional entitlement link + association), #23 (payload exclusion), #24 (drawer fetch + explicit admin gate), #25 (test list). Partially adopted: #3 — linked-but-unauthorized instead of unlinked (Decisions #3). Pre-existing bugs surfaced for their own attention: entitlement verification ignores `phoneVerifiedFor` (fixed in PR A); Lyfe lacks `lead.deleted` (cross-repo follow-up); Meta stores non-normalized phones (matching-key workaround now; storage normalization later).

--- a/src/api/adminV2.js
+++ b/src/api/adminV2.js
@@ -46,6 +46,16 @@ export async function fetchProspects(params = {}) {
   };
 }
 
+/**
+ * Full prospect detail (drawer): the list row is a thin projection — this adds
+ * the admin enrichments (repeatSignup, timeline, and the consumer-spine
+ * `consumer` journey block) and lets deep-links open off-page leads.
+ */
+export async function fetchProspectDetail(id) {
+  const resp = await apiClient.get(`/prospects/${encodeURIComponent(id)}`);
+  return resp?.data?.prospect ?? null;
+}
+
 /** Campaign leaderboard source — extended admin list (B6). */
 export async function fetchCampaignsList(period) {
   const resp = await apiClient.get(`/campaigns?period=${encodeURIComponent(period)}&limit=100`);

--- a/src/hooks/queries/useAdminV2.js
+++ b/src/hooks/queries/useAdminV2.js
@@ -5,11 +5,21 @@
 import { useQuery } from '@tanstack/react-query';
 import {
   fetchOverview, fetchAttention, fetchSeries, fetchFunnel,
-  fetchProspects, fetchCampaignsList, fetchAgentOptions,
+  fetchProspects, fetchProspectDetail, fetchCampaignsList, fetchAgentOptions,
   fetchAgentsRoster, fetchCampaignSummary, fetchWallets, fetchWalletLedger, fetchAgentGroups,
 } from '@/api/adminV2';
 
 const STALE_MS = 30_000;
+
+/** Full prospect detail for the drawer — includes the consumer-spine journey. */
+export function useProspectDetail(id) {
+  return useQuery({
+    queryKey: ['adminV2', 'prospectDetail', id],
+    queryFn: () => fetchProspectDetail(id),
+    staleTime: STALE_MS,
+    enabled: !!id,
+  });
+}
 
 export function useOverview(period) {
   return useQuery({ queryKey: ['adminV2', 'overview', period], queryFn: () => fetchOverview(period), staleTime: STALE_MS });

--- a/src/pages/adminv2/AdminV2Prospects.jsx
+++ b/src/pages/adminv2/AdminV2Prospects.jsx
@@ -114,6 +114,11 @@ function LeadDrawer({ prospect, onClose, onOpenLead }) {
           </div>
         </SheetHeader>
         <div style={{ padding: 16, overflowY: 'auto', display: 'grid', gap: 18 }}>
+          {detail.isError && !p.phone && (
+            <div className="av2-kv" style={{ color: 'var(--ink-2)' }}>
+              Couldn&apos;t load this lead — it may have been deleted.
+            </div>
+          )}
           <section>
             <div className="av2-microcaps" style={{ marginBottom: 6 }}>Contact</div>
             <div className="av2-kv"><span>phone</span><span>{p.phone || '—'}</span></div>
@@ -145,6 +150,9 @@ function LeadDrawer({ prospect, onClose, onOpenLead }) {
                   <span>rewards</span>
                   <span>{consumer.entitlements.length} · {consumer.entitlements.filter((e) => e.redeemedAt).length} redeemed</span>
                 </div>
+              )}
+              {consumer.drawEntries > 0 && (
+                <div className="av2-kv"><span>draw entries</span><span>{consumer.drawEntries}</span></div>
               )}
               {otherSignups.length > 0 && (
                 <div style={{ marginTop: 8, display: 'grid', gap: 4 }}>
@@ -299,7 +307,12 @@ export default function AdminV2Prospects() {
   ];
 
   // ── Bulk actions (live endpoints) ──────────────────────────────────────────
-  const invalidate = () => queryClient.invalidateQueries({ queryKey: ['adminV2', 'prospects'] });
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ['adminV2', 'prospects'] });
+    // The drawer's detail cache carries the same lead + the Person journey —
+    // keep it in step with row mutations (assign / return / delete).
+    queryClient.invalidateQueries({ queryKey: ['adminV2', 'prospectDetail'] });
+  };
   const ids = [...selected];
   const agentOptions = useAgentOptions(selected.size > 0);
 

--- a/src/pages/adminv2/AdminV2Prospects.jsx
+++ b/src/pages/adminv2/AdminV2Prospects.jsx
@@ -9,7 +9,7 @@ import { useMemo, useState, useEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { useProspects, useAgentOptions } from '@/hooks/queries/useAdminV2';
+import { useProspects, useProspectDetail, useAgentOptions } from '@/hooks/queries/useAdminV2';
 import { bulkAssign, bulkReturnToHeld, bulkDelete } from '@/api/adminV2';
 import {
   LEAD_STATUSES, LEAD_SOURCES, STATUS_LABELS, STATUS_CHIP_CLASS,
@@ -82,9 +82,18 @@ function SortHeader({ label, field, sort, onSort, width, align }) {
   );
 }
 
-function LeadDrawer({ prospect, onClose }) {
+function LeadDrawer({ prospect, onClose, onOpenLead }) {
+  // Detail fetch on open (consumer spine): the list row is a thin projection —
+  // the detail endpoint adds the admin enrichments (repeatSignup, timeline,
+  // the `consumer` journey for the Person card) and lets ?lead= deep-links
+  // open leads that aren't on the current page. Row data paints instantly;
+  // the detail enriches when it lands. Hook runs unconditionally (enabled
+  // gate), so the early return below stays hooks-safe.
+  const detail = useProspectDetail(prospect?.id);
   if (!prospect) return null;
-  const p = prospect;
+  const p = detail.data || prospect;
+  const consumer = detail.data?.consumer || null;
+  const otherSignups = consumer ? consumer.signups.filter((s) => s.prospectId !== p.id) : [];
   const utm = p.sourceMetadata?.utm || {};
   const held = !!p.quarantinedAt;
   return (
@@ -92,7 +101,9 @@ function LeadDrawer({ prospect, onClose }) {
       <SheetContent side="right" className="admin-v2" style={{ width: 432, maxWidth: '90vw', padding: 0, background: 'var(--surface)', color: 'var(--ink)', borderLeft: '1px solid var(--line)' }}>
         <SheetHeader style={{ padding: '14px 16px', borderBottom: '1px solid var(--line)' }}>
           <SheetTitle style={{ fontSize: 15, fontWeight: 800, color: 'var(--ink)', fontFamily: 'var(--font-ui)', textAlign: 'left' }}>
-            {p.firstName} {p.lastName}
+            {(p.firstName || p.lastName)
+              ? `${p.firstName || ''} ${p.lastName || ''}`.trim()
+              : (detail.isLoading ? 'Loading…' : 'Lead')}
           </SheetTitle>
           <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
             <Chip tone={STATUS_CHIP_CLASS[p.leadStatus]?.replace('av2-chip--', '') || ''}>{STATUS_LABELS[p.leadStatus] || p.leadStatus}</Chip>
@@ -117,6 +128,46 @@ function LeadDrawer({ prospect, onClose }) {
             {p.qrTag && <div className="av2-kv"><span>qr tag</span><span>{p.qrTag.name}</span></div>}
             <div className="av2-kv"><span>campaign</span><span>{p.campaign?.name || '—'}</span></div>
           </section>
+          {consumer && (
+            <section>
+              <div className="av2-microcaps" style={{ marginBottom: 6 }}>Person</div>
+              <div className="av2-kv">
+                <span>signups</span>
+                <span>
+                  {consumer.consumer.signupCount}
+                  {consumer.consumer.verifiedSignupCount !== consumer.consumer.signupCount
+                    ? ` (${consumer.consumer.verifiedSignupCount} verified)` : ''}
+                </span>
+              </div>
+              <div className="av2-kv"><span>first seen</span><span>{fmtDateTime(consumer.consumer.firstSeenAt)}</span></div>
+              {consumer.entitlements.length > 0 && (
+                <div className="av2-kv">
+                  <span>rewards</span>
+                  <span>{consumer.entitlements.length} · {consumer.entitlements.filter((e) => e.redeemedAt).length} redeemed</span>
+                </div>
+              )}
+              {otherSignups.length > 0 && (
+                <div style={{ marginTop: 8, display: 'grid', gap: 4 }}>
+                  <div className="av2-microcaps" style={{ color: 'var(--ink-2)' }}>Also in</div>
+                  {otherSignups.map((s) => (
+                    <button
+                      key={s.prospectId}
+                      type="button"
+                      onClick={() => onOpenLead?.(s.prospectId)}
+                      style={{
+                        textAlign: 'left', background: 'none', border: '1px solid var(--line)',
+                        borderRadius: 8, padding: '6px 8px', cursor: 'pointer', color: 'var(--ink)',
+                        fontFamily: 'var(--font-ui)', fontSize: 12,
+                      }}
+                    >
+                      {s.campaign?.name || 'No campaign'} · {fmtRelative(s.createdAt)}
+                      {!s.verified && <span style={{ color: 'var(--ink-2)' }}> · unverified</span>}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </section>
+          )}
           <section>
             <div className="av2-microcaps" style={{ marginBottom: 6 }}>Routing</div>
             <div className="av2-kv"><span>agent</span><span>{p.assignedAgent ? `${p.assignedAgent.firstName || ''} ${p.assignedAgent.lastName || ''}`.trim() : p.externalAgentId ? 'external buyer' : held ? 'held' : 'unassigned'}</span></div>
@@ -224,7 +275,9 @@ export default function AdminV2Prospects() {
   useEffect(() => {
     if (!leadParam || prospects.isFetching || prospects.isError) return;
     const hit = rows.find((r) => r.id === leadParam);
-    if (hit) setDrawer(hit);
+    // Off-page ids open too: the drawer detail-fetches by id, so palette /
+    // Person-card deep-links work from any filter or page.
+    setDrawer(hit || { id: leadParam });
     patch({ lead: null });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [leadParam, prospects.isFetching, prospects.isError]);
@@ -519,7 +572,11 @@ export default function AdminV2Prospects() {
         </AlertDialogContent>
       </AlertDialog>
 
-      <LeadDrawer prospect={drawer} onClose={() => setDrawer(null)} />
+      <LeadDrawer
+        prospect={drawer}
+        onClose={() => setDrawer(null)}
+        onOpenLead={(id) => setDrawer({ id })}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## What

PR A of the data-powerhouse track (plan: `docs/plans/consumer-spine-and-consent-ledger.md`, included in this PR — v2, post-Codex-round-1): a durable cross-campaign person entity keyed by E.164 phone, with the identity-integrity hooks that keep it truthful.

**Design principle: the spine is a rebuildable projection of `prospects`.** The capture resolver writes it best-effort behind a SAVEPOINT (a plain catch inside the outer txn cannot work — Postgres poisons the transaction); any drift heals via the assign-not-increment reconciler. Capture is never blocked by spine failures.

## Changes

- **Schema (078, sync-tolerant + guarded):** `consumers` (phone partial-unique, phoneHash, latest attrs, signup/verified counters, dark `unsubTokenHash`/`erasedAt` slots for PRs B/C) + nullable `consumerId` on `prospects` and `reward_entitlements`; every correctness index mirrored on the models (test boot syncs from models first).
- **Resolver:** single `INSERT … ON CONFLICT (phone) WHERE phone IS NOT NULL DO UPDATE … RETURNING` inside a savepoint — no 23505 under concurrent capture, non-blocking by construction.
- **All three prospect creators hooked:** web/marketplace (`verified` = the existing single OTP-marker read), Meta Lead Ads (linked UNVERIFIED, normalized matching key only — stored phone untouched), Retell/call_bot **excluded** (`prospect.phone` = `to_number`; inbound calls would merge strangers onto the DDI).
- **Identity integrity:** PUT phone edits normalize like capture, relink + recompute BOTH consumers, strip the OTP stamp (bound to the old number via `phoneVerifiedFor`), and map the (campaignId, phone) unique collision to a clean 409; deletes recompute. **Drive-by fix:** entitlement issuance now enforces the `phoneVerifiedFor` binding — a staff phone edit no longer inherits verified status.
- **Reconciler (079 + `backend/scripts/rebuild-consumer-spine.js`):** shared module, JS-normalizes phones with the capture path's `normalizePhone`, assigns complete projections, heals wrong links, unlinks call_bot, links entitlements via prospect then phoneKey. Idempotent.
- **Migration runner:** `pg_advisory_xact_lock` serializes concurrent rolling-deploy boots.
- **Read surfaces:** `GET /api/consumers/:id` (explicitly `authenticateToken, requireAdmin` — aggregates cross-campaign PII; returns derived fields only, no raw sourceMetadata), prospect-detail `consumer` block (admin enrichment), LeadDrawer Person card (detail-fetch on open, unverified badges, sibling deep-links) + off-page `?lead=` resolution.
- **Webhook contract:** `consumerId` never leaves the system — asserted in tests against the payload builders.

## Evidence

- 20 new tests: real-PG savepoint isolation (table renamed away → capture still 201s), reconciler idempotency + counter healing + call_bot unlink, phone-edit relink + stamp strip + 409 collision, journey authz (admin 200 / agent 403 / malformed-id 404), payload exclusion, entitlement consumer linkage + bound-stamp gate.
- Full backend jest: 3672 passed; the 6 failing suites fail **identically on the pristine base** (stash-verified pre-existing — the chronically-red set).
- Frontend: eslint clean, vitest 1600/1600.

## Deploy notes

Migrations auto-apply at boot (advisory-locked). Post-deploy probes (read-only):
- `consumers` count == distinct non-empty, non-call_bot prospect phones (~130 per 2026-07-19 preflight);
- zero non-call_bot prospects with a phone and null `consumerId`;
- the 5 known Fairprice repeat phones → one consumer each with `signupCount = 2`;
- entitlements 5/5 linked (phoneKey arm covers the 4 rows without `prospectId`).

Rollback story: columns sit unused (additive); `scripts/rebuild-consumer-spine.js` re-derives everything from prospects at any time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrXgaygxd7V5bgctd1rqV8