### PR TITLE
feat(consent-ledger): person-level consent events, suppressions, unsubscribe (PR B)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -325,3 +325,9 @@ DISCOVERY_CANDIDATE_TTL_DAYS=90              # retention: purge scraped candidat
 # ── Redeem Ops — Outreach cadences (sequencing engine; migration 057) ──────────
 REDEEM_OPS_CADENCES_ENABLED=false             # routes + hook wiring + seeds + reconcile tick (needs REDEEM_OPS_ENABLED too)
 REDEEM_OPS_CADENCE_CAP=60                     # max live enrollments per owner (managers may override per-enroll)
+
+# Consent ledger (PR B)
+# Dedicated unsubscribe-token secret (optional; falls back to JWT_SECRET with a context salt — rotating whichever is in use invalidates outstanding unsubscribe links)
+UNSUB_TOKEN_SECRET=
+# Public API origin baked into unsubscribe links (default https://api.mktr.sg)
+API_PUBLIC_ORIGIN=

--- a/backend/env.example
+++ b/backend/env.example
@@ -155,3 +155,9 @@ DNC_REVALIDATE_DAYS=5
 DNC_TIMEOUT_MS=5000
 # Hourly credit budget — safety cap below EVERY paid DNC call (create/Retell/backfill/form).
 DNC_HOURLY_BUDGET=1000
+
+# Consent ledger (PR B)
+# Dedicated unsubscribe-token secret (optional; falls back to JWT_SECRET with a context salt — rotating whichever is in use invalidates outstanding unsubscribe links)
+UNSUB_TOKEN_SECRET=
+# Public API origin baked into unsubscribe links (default https://api.mktr.sg)
+API_PUBLIC_ORIGIN=

--- a/backend/src/controllers/unsubscribeController.js
+++ b/backend/src/controllers/unsubscribeController.js
@@ -1,0 +1,55 @@
+import { asyncHandler } from '../middleware/errorHandler.js';
+import { findConsumerByUnsubToken, applyUnsubscribe } from '../services/consentService.js';
+
+/**
+ * Public unsubscribe endpoint (PR B, plan §3.4).
+ *
+ * GET renders a confirm form and NEVER mutates — mail scanners prefetch
+ * unsubscribe URLs, which is the whole reason RFC 8058 exists (Codex R1 #14).
+ * POST is the mutation: the human form and the RFC 8058 one-click body both
+ * land here; idempotent. The token is opaque and looked up BY HASH, so the
+ * URL never exposes the cross-campaign consumer id.
+ */
+
+const page = (body) => `<!doctype html>
+<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="robots" content="noindex"><title>Marketing preferences</title></head>
+<body style="font-family:-apple-system,'Segoe UI',Roboto,Arial,sans-serif;background:#f7f7f8;margin:0;padding:40px 16px;">
+<div style="max-width:440px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;border-radius:16px;padding:28px;color:#0d1619;">
+${body}
+<p style="color:#6b7280;font-size:12px;margin-top:24px;">Redeem &middot; MKTR PTE. LTD. (UEN 202507548M)</p>
+</div></body></html>`;
+
+const NOT_FOUND = page(
+  '<h2 style="margin:0 0 8px;font-size:18px;">Link not recognised</h2>'
+  + '<p style="font-size:14px;line-height:1.5;color:#374151;">This unsubscribe link is invalid or no longer active.</p>'
+);
+
+export const showUnsubscribe = asyncHandler(async (req, res) => {
+  const token = String(req.query.t || '');
+  const consumer = await findConsumerByUnsubToken(token);
+  if (!consumer) return res.status(404).send(NOT_FOUND);
+  return res.send(page(
+    '<h2 style="margin:0 0 8px;font-size:18px;">Unsubscribe from marketing messages?</h2>'
+    + '<p style="font-size:14px;line-height:1.5;color:#374151;">You will stop receiving marketing messages from Redeem. '
+    + 'Service messages about rewards you have already claimed may still be sent.</p>'
+    + `<form method="POST" action="/api/unsubscribe?t=${encodeURIComponent(token)}">`
+    + '<button type="submit" style="background:#0d1619;color:#ffffff;border:0;border-radius:10px;padding:10px 18px;font-size:14px;cursor:pointer;">Unsubscribe</button>'
+    + '</form>'
+  ));
+});
+
+export const confirmUnsubscribe = asyncHandler(async (req, res) => {
+  const token = String(req.query.t || req.body?.t || '');
+  const consumer = await findConsumerByUnsubToken(token);
+  if (!consumer) return res.status(404).send(NOT_FOUND);
+  await applyUnsubscribe(consumer, { source: 'unsubscribe_link' });
+  if ((req.get('accept') || '').includes('application/json')) {
+    return res.json({ success: true });
+  }
+  return res.send(page(
+    '<h2 style="margin:0 0 8px;font-size:18px;">You are unsubscribed</h2>'
+    + '<p style="font-size:14px;line-height:1.5;color:#374151;">You will no longer receive marketing messages. '
+    + 'Service messages about rewards you have already claimed may still be sent.</p>'
+  ));
+});

--- a/backend/src/database/migrations/080-consent-ledger.js
+++ b/backend/src/database/migrations/080-consent-ledger.js
@@ -1,0 +1,122 @@
+/**
+ * 080 — Person-level consent ledger + consumer suppressions (PR B,
+ * docs/plans/consumer-spine-and-consent-ledger.md §3).
+ *
+ * consent_events: APPEND-ONLY evidence of consent acts, person-scoped
+ * (consumerId RESTRICT — history must survive everything; erasure never
+ * deletes consumers) and PURPOSE-scoped (campaignId — the live consent copy
+ * is campaign-scoped on both surfaces; a campaign-null row = an explicit
+ * GLOBAL act, e.g. unsubscribe). Reads resolve latest-wins within
+ * (kind, campaignId-or-global).
+ *
+ * consumer_suppressions: the exit door. channel 'all' + reason 'unsubscribe'
+ * blocks marketing everywhere; reason 'erasure' (PR C) blocks even
+ * transactional sends.
+ *
+ * Guarded/idempotent + sync-tolerant like 078 (test boot syncs models first).
+ */
+export async function up(queryInterface) {
+  const q = (sql) => queryInterface.sequelize.query(sql);
+
+  await q(`CREATE TABLE IF NOT EXISTS consent_events (
+    id UUID PRIMARY KEY,
+    "consumerId" UUID NOT NULL,
+    "prospectId" UUID,
+    "campaignId" UUID,
+    kind VARCHAR(32) NOT NULL,
+    granted BOOLEAN NOT NULL,
+    channels JSONB,
+    version VARCHAR(64) NOT NULL,
+    source VARCHAR(32) NOT NULL,
+    "sourceUrl" TEXT,
+    verified BOOLEAN NOT NULL DEFAULT false,
+    "actorUserId" UUID,
+    metadata JSONB,
+    "occurredAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+  )`);
+
+  await q(`CREATE INDEX IF NOT EXISTS idx_ce_consumer_kind_time
+             ON consent_events ("consumerId", kind, "occurredAt" DESC)`);
+  await q(`CREATE INDEX IF NOT EXISTS idx_ce_prospect ON consent_events ("prospectId")`);
+  // Backfill idempotency anchor (Codex R1 R2 lineage: no DB uniqueness = rerun dupes).
+  await q(`CREATE UNIQUE INDEX IF NOT EXISTS uq_ce_backfill
+             ON consent_events ("prospectId", kind) WHERE source = 'backfill'`);
+
+  await q(`CREATE TABLE IF NOT EXISTS consumer_suppressions (
+    id UUID PRIMARY KEY,
+    "consumerId" UUID NOT NULL,
+    channel VARCHAR(16) NOT NULL,
+    reason VARCHAR(32) NOT NULL,
+    source VARCHAR(255),
+    "actorUserId" UUID,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+  )`);
+  await q(`CREATE UNIQUE INDEX IF NOT EXISTS uq_cs_consumer_channel
+             ON consumer_suppressions ("consumerId", channel)`);
+
+  // Unsubscribe-token lookup (mailer mints lazily; the public endpoint finds
+  // the consumer by hash so the URL never carries the cross-campaign UUID).
+  await q(`CREATE INDEX IF NOT EXISTS idx_consumers_unsub_token
+             ON consumers ("unsubTokenHash") WHERE "unsubTokenHash" IS NOT NULL`);
+
+  // Enum + integrity CHECKs (name-guarded).
+  await q(`DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_ce_kind') THEN
+      ALTER TABLE consent_events ADD CONSTRAINT chk_ce_kind
+        CHECK (kind IN ('contact','campaign_terms','third_party','dnc_override','draw_terms'));
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_ce_source') THEN
+      ALTER TABLE consent_events ADD CONSTRAINT chk_ce_source
+        CHECK (source IN ('signup','backfill','unsubscribe','admin','erasure'));
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_cs_channel') THEN
+      ALTER TABLE consumer_suppressions ADD CONSTRAINT chk_cs_channel
+        CHECK (channel IN ('all','email','whatsapp','sms','voice'));
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_cs_reason') THEN
+      ALTER TABLE consumer_suppressions ADD CONSTRAINT chk_cs_reason
+        CHECK (reason IN ('unsubscribe','complaint','admin','erasure'));
+    END IF;
+  END $$`);
+
+  // FKs — column-level existence checks (sync names its own constraints).
+  await q(`DO $$ BEGIN
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
+       WHERE tc.table_name = 'consent_events' AND tc.constraint_type = 'FOREIGN KEY'
+         AND kcu.column_name = 'consumerId'
+    ) THEN
+      ALTER TABLE consent_events ADD CONSTRAINT fk_ce_consumer
+        FOREIGN KEY ("consumerId") REFERENCES consumers(id) ON DELETE RESTRICT;
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
+       WHERE tc.table_name = 'consent_events' AND tc.constraint_type = 'FOREIGN KEY'
+         AND kcu.column_name = 'prospectId'
+    ) THEN
+      ALTER TABLE consent_events ADD CONSTRAINT fk_ce_prospect
+        FOREIGN KEY ("prospectId") REFERENCES prospects(id) ON DELETE SET NULL;
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
+       WHERE tc.table_name = 'consumer_suppressions' AND tc.constraint_type = 'FOREIGN KEY'
+         AND kcu.column_name = 'consumerId'
+    ) THEN
+      ALTER TABLE consumer_suppressions ADD CONSTRAINT fk_cs_consumer
+        FOREIGN KEY ("consumerId") REFERENCES consumers(id) ON DELETE RESTRICT;
+    END IF;
+  END $$`);
+}
+
+export async function down(queryInterface) {
+  const q = (sql) => queryInterface.sequelize.query(sql);
+  await q('DROP INDEX IF EXISTS idx_consumers_unsub_token');
+  await q('DROP TABLE IF EXISTS consumer_suppressions');
+  await q('DROP TABLE IF EXISTS consent_events');
+}

--- a/backend/src/database/migrations/081-consent-backfill.js
+++ b/backend/src/database/migrations/081-consent-backfill.js
@@ -1,0 +1,25 @@
+/**
+ * 081 — Consent-ledger backfill (PR B, plan §3.1).
+ *
+ * Re-derives person-level consent events from what capture already stored on
+ * prospects: the consent_contact/consent_terms booleans (ONLY where the key
+ * exists — absent ≠ false; Retell/Meta never send them) and the
+ * consentMetadata evidence blocks (with their real embedded timestamps).
+ * `version: 'legacy-backfill'` marks boolean-derived rows.
+ *
+ * Idempotent: the uq_ce_backfill partial unique + ON CONFLICT DO NOTHING make
+ * reruns no-ops. Shares backfillConsentEvents() with any future healing run
+ * (heal order: spine reconciler first, then this).
+ */
+export async function up() {
+  const { backfillConsentEvents } = await import('../../services/consentService.js');
+  const { logger } = await import('../../utils/logger.js');
+  const stats = await backfillConsentEvents();
+  logger.info('[081] consent ledger backfilled', stats);
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query(
+    `DELETE FROM consent_events WHERE source = 'backfill'`
+  );
+}

--- a/backend/src/models/ConsentEvent.js
+++ b/backend/src/models/ConsentEvent.js
@@ -1,0 +1,60 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * APPEND-ONLY person-level consent evidence (PR B, plan §3.1).
+ *
+ * One row = one consent ACT: a signup checkbox (including an explicit UNTICK
+ * of the default-on contact box — that denial is evidence too), a server-built
+ * evidence block (third_party/dnc_override/draw_terms), an unsubscribe, an
+ * admin/erasure act. Never UPDATE or DELETE rows — state is derived
+ * latest-wins per (kind, campaignId-or-global) by consentService.
+ *
+ * Purpose scoping: the live consent copy is campaign-scoped on both capture
+ * surfaces, so `campaignId` is semantic; campaignId NULL = an explicitly
+ * GLOBAL act (unsubscribe/erasure). Cross-campaign marketing has NO basis
+ * until a global opt-in surface ships (Phase 2) — resist "fixing" reads.
+ *
+ * `verified` = the signup carried a live OTP stamp; only verified grants can
+ * ever mint marketing authority (canMarketTo).
+ */
+const ConsentEvent = sequelize.define('ConsentEvent', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  consumerId: { type: DataTypes.UUID, allowNull: false, references: { model: 'consumers', key: 'id' } },
+  prospectId: { type: DataTypes.UUID, allowNull: true, references: { model: 'prospects', key: 'id' } },
+  campaignId: { type: DataTypes.UUID, allowNull: true, comment: 'Purpose scope; NULL = explicit global act' },
+  kind: {
+    type: DataTypes.STRING(32),
+    allowNull: false,
+    validate: { isIn: [['contact', 'campaign_terms', 'third_party', 'dnc_override', 'draw_terms']] },
+  },
+  granted: { type: DataTypes.BOOLEAN, allowNull: false },
+  channels: { type: DataTypes.JSONB, allowNull: true, comment: "e.g. ['phone','whatsapp','email'] from the evidence builders" },
+  version: { type: DataTypes.STRING(64), allowNull: false, comment: "Consent-copy version; 'legacy-backfill' for pre-evidence rows" },
+  source: {
+    type: DataTypes.STRING(32),
+    allowNull: false,
+    validate: { isIn: [['signup', 'backfill', 'unsubscribe', 'admin', 'erasure']] },
+  },
+  sourceUrl: { type: DataTypes.TEXT, allowNull: true },
+  verified: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+  actorUserId: { type: DataTypes.UUID, allowNull: true },
+  metadata: { type: DataTypes.JSONB, allowNull: true, comment: 'e.g. dncTransactionId, termsVersionId' },
+  occurredAt: { type: DataTypes.DATE, allowNull: false },
+}, {
+  tableName: 'consent_events',
+  indexes: [
+    { fields: ['consumerId', 'kind', 'occurredAt'], name: 'idx_ce_consumer_kind_time' },
+    { fields: ['prospectId'], name: 'idx_ce_prospect' },
+    // Backfill idempotency — mirrored because test boot syncs from models
+    // (the migration-index-loss lesson, proven in consumerSpine.test.js).
+    {
+      unique: true,
+      fields: ['prospectId', 'kind'],
+      name: 'uq_ce_backfill',
+      where: { source: 'backfill' },
+    },
+  ],
+});
+
+export default ConsentEvent;

--- a/backend/src/models/ConsumerSuppression.js
+++ b/backend/src/models/ConsumerSuppression.js
@@ -1,0 +1,39 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * The consumer exit door (PR B, plan §3.1) — deliberately SEPARATE from the
+ * partner-side OutreachSuppression.
+ *
+ * Semantics (enforced by consentService, not here):
+ *  - reason 'erasure' blocks EVERY send including transactional (PR C writes it);
+ *  - every other reason blocks MARKETING only — voucher/pass delivery for a
+ *    reward the person claimed keeps flowing (service communication);
+ *  - channel 'all' covers every channel; channel rows allow future granularity
+ *    (the unsubscribe endpoint writes 'all' in v1).
+ */
+const ConsumerSuppression = sequelize.define('ConsumerSuppression', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  consumerId: { type: DataTypes.UUID, allowNull: false, references: { model: 'consumers', key: 'id' } },
+  channel: {
+    type: DataTypes.STRING(16),
+    allowNull: false,
+    defaultValue: 'all',
+    validate: { isIn: [['all', 'email', 'whatsapp', 'sms', 'voice']] },
+  },
+  reason: {
+    type: DataTypes.STRING(32),
+    allowNull: false,
+    validate: { isIn: [['unsubscribe', 'complaint', 'admin', 'erasure']] },
+  },
+  source: { type: DataTypes.STRING(255), allowNull: true, comment: 'breadcrumb: unsubscribe_link, admin ui, …' },
+  actorUserId: { type: DataTypes.UUID, allowNull: true },
+}, {
+  tableName: 'consumer_suppressions',
+  indexes: [
+    // Mirrored on the model (sync-built test schemas).
+    { unique: true, fields: ['consumerId', 'channel'], name: 'uq_cs_consumer_channel' },
+  ],
+});
+
+export default ConsumerSuppression;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -86,6 +86,17 @@ function defineAssociations() {
   Consumer.hasMany(Prospect, { foreignKey: 'consumerId', as: 'signups', onDelete: 'SET NULL' });
   Prospect.belongsTo(Consumer, { foreignKey: 'consumerId', as: 'consumer', onDelete: 'SET NULL' });
 
+  // Consent ledger + suppressions (PR B) — append-only person-level evidence.
+  // RESTRICT from consumers: consent history must survive everything (erasure
+  // nulls PII on the consumer row, never deletes it).
+  const { ConsentEvent, ConsumerSuppression } = models;
+  Consumer.hasMany(ConsentEvent, { foreignKey: 'consumerId', as: 'consentEvents', onDelete: 'RESTRICT' });
+  ConsentEvent.belongsTo(Consumer, { foreignKey: 'consumerId', as: 'consumer', onDelete: 'RESTRICT' });
+  ConsentEvent.belongsTo(Prospect, { foreignKey: 'prospectId', as: 'prospect', onDelete: 'SET NULL' });
+  ConsentEvent.belongsTo(Campaign, { foreignKey: 'campaignId', as: 'campaign', onDelete: 'SET NULL' });
+  Consumer.hasMany(ConsumerSuppression, { foreignKey: 'consumerId', as: 'suppressions', onDelete: 'RESTRICT' });
+  ConsumerSuppression.belongsTo(Consumer, { foreignKey: 'consumerId', as: 'consumer', onDelete: 'RESTRICT' });
+
   // Prospect associations
   Prospect.belongsTo(User, { foreignKey: 'assignedAgentId', as: 'assignedAgent', onDelete: 'SET NULL' });
   Prospect.belongsTo(Campaign, { foreignKey: 'campaignId', as: 'campaign', onDelete: 'SET NULL' });
@@ -358,7 +369,7 @@ export const {
   DiscoveryRun, DiscoveryCandidate,
   DiscoveryPlaceMemory, OutreachCadence, OutreachCadenceStep,
   OutreachCadenceTransition, OutreachCadenceEnrollment, OutreachSuppression,
-  AiSettings, WalletLedger, Consumer
+  AiSettings, WalletLedger, Consumer, ConsentEvent, ConsumerSuppression
 } = models;
 
 export { sequelize };

--- a/backend/src/routes/unsubscribe.js
+++ b/backend/src/routes/unsubscribe.js
@@ -1,0 +1,22 @@
+import express from 'express';
+import rateLimit from 'express-rate-limit';
+import { showUnsubscribe, confirmUnsubscribe } from '../controllers/unsubscribeController.js';
+
+export const meta = { path: '/api/unsubscribe' };
+
+const router = express.Router();
+
+const unsubLimit = rateLimit({
+  windowMs: 60 * 1000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === 'test',
+});
+
+// GET renders the confirm form only (no mutation — scanners prefetch).
+router.get('/', unsubLimit, showUnsubscribe);
+// POST mutates: human form + RFC 8058 one-click (form-urlencoded body).
+router.post('/', unsubLimit, express.urlencoded({ extended: false }), confirmUnsubscribe);
+
+export default router;

--- a/backend/src/services/consentService.js
+++ b/backend/src/services/consentService.js
@@ -1,0 +1,381 @@
+import { createHash, createHmac, randomUUID } from 'crypto';
+import { Op } from 'sequelize';
+import {
+  sequelize, Consumer, ConsentEvent, ConsumerSuppression, Prospect,
+} from '../models/index.js';
+import { logger } from '../utils/logger.js';
+import { phoneVerificationIsCurrent, E164_RE } from './consumerService.js';
+import {
+  CONTACT_CONSENT_VERSION, CONTACT_CONSENT_COPY_HASH, CONTACT_CONSENT_CHANNELS,
+} from './contactConsent.js';
+
+/**
+ * Person-level consent ledger + suppression (PR B, plan §3).
+ *
+ * THE RULES, in one place:
+ *  - consent_events is APPEND-ONLY; current state = latest event per
+ *    (kind, campaign scope), where a campaignId:null event is an explicit
+ *    GLOBAL act that competes on recency (an unsubscribe after a scoped grant
+ *    wins; a NEW scoped grant after an unsubscribe re-permits THAT campaign).
+ *  - `canMarketTo` is THE mandatory gate for every marketing send/upload:
+ *    verified campaign-scoped contact grant ∧ no suppression. There is NO
+ *    global variant — today's copy licenses nothing cross-campaign (a global
+ *    opt-in surface is a Phase-2 deliverable; do not widen reads instead).
+ *  - Suppression semantics: reason 'erasure' blocks EVERYTHING including
+ *    transactional; other reasons block marketing only. Enforcement is
+ *    FAIL-CLOSED BY PHONE: rows the spine failed to link still suppress via
+ *    the phone join (Codex R1 #12).
+ *  - Ledger writes at capture are savepoint-isolated and non-blocking, like
+ *    the consumer resolver: every input lives on the prospect row, so
+ *    backfillConsentEvents() can always re-derive a missed write.
+ */
+
+const MARKETING_REASONS_BLOCK_ALL = ['erasure'];
+
+function unsubSecret() {
+  // Dedicated secret preferred; the JWT_SECRET fallback is context-separated.
+  // Rotating whichever is in use invalidates outstanding links (documented
+  // v1 limitation — keyring later if it ever matters).
+  return process.env.UNSUB_TOKEN_SECRET || `${process.env.JWT_SECRET}:mktr-unsub-v1`;
+}
+
+/** Deterministic opaque unsubscribe token — every email rebuilds the same URL. */
+export function unsubTokenFor(consumerId) {
+  return createHmac('sha256', unsubSecret()).update(String(consumerId)).digest('hex');
+}
+export function unsubTokenHashOf(token) {
+  return createHash('sha256').update(String(token)).digest('hex');
+}
+
+const defaultDeps = { sequelize, Consumer, ConsentEvent, ConsumerSuppression, Prospect, logger };
+
+export function makeConsentService(overrides = {}) {
+  const d = { ...defaultDeps, ...overrides };
+
+  /**
+   * Write the consent events for one capture, inside a SAVEPOINT on the
+   * capture transaction. Non-blocking: any failure rolls back the savepoint
+   * only and is healed later by backfillConsentEvents. No-op when the capture
+   * has no consumer link (call_bot / resolver miss / no phone) — person-level
+   * evidence needs a person; linkage healing re-derives events afterwards.
+   */
+  async function recordCaptureConsentEventsTx(outerTx, {
+    consumerId, prospectId, campaignId = null, sourceUrl = null, verified = false,
+    contact,            // boolean | undefined — record BOTH true and explicit false
+    terms,              // boolean | undefined — the required campaign T&C tick
+    externalConsent,    // consentMetadata.external evidence | null
+    dncConsent,         // consentMetadata.dnc evidence | null
+    drawTerms,          // consentMetadata.drawTerms evidence | null
+  } = {}) {
+    try {
+      if (!consumerId) return 0;
+      const now = new Date();
+      const base = {
+        consumerId, prospectId: prospectId || null, campaignId,
+        source: 'signup', sourceUrl: sourceUrl || null, verified: verified === true,
+        occurredAt: now,
+      };
+      const rows = [];
+      if (contact !== undefined) {
+        rows.push({
+          ...base, id: randomUUID(), kind: 'contact', granted: contact === true,
+          channels: [...CONTACT_CONSENT_CHANNELS], version: CONTACT_CONSENT_VERSION,
+          metadata: { copyHash: CONTACT_CONSENT_COPY_HASH },
+        });
+      }
+      if (terms !== undefined) {
+        rows.push({
+          ...base, id: randomUUID(), kind: 'campaign_terms', granted: terms === true,
+          channels: null, version: 'campaign-tnc', metadata: null,
+        });
+      }
+      if (externalConsent) {
+        rows.push({
+          ...base, id: randomUUID(), kind: 'third_party', granted: true,
+          channels: externalConsent.channels || null,
+          version: externalConsent.version || 'unknown',
+          occurredAt: new Date(externalConsent.consentedAt || now),
+          metadata: null,
+        });
+      }
+      if (dncConsent) {
+        rows.push({
+          ...base, id: randomUUID(), kind: 'dnc_override', granted: true,
+          channels: dncConsent.channels || null,
+          version: dncConsent.version || 'unknown',
+          occurredAt: new Date(dncConsent.consentedAt || now),
+          metadata: dncConsent.dncTransactionId ? { dncTransactionId: dncConsent.dncTransactionId } : null,
+        });
+      }
+      if (drawTerms) {
+        rows.push({
+          ...base, id: randomUUID(), kind: 'draw_terms', granted: true,
+          channels: null,
+          version: String(drawTerms.termsVersionId || 'unknown').slice(0, 64),
+          occurredAt: new Date(drawTerms.acceptedAt || now),
+          metadata: drawTerms.termsHash ? { termsHash: drawTerms.termsHash } : null,
+        });
+      }
+      if (!rows.length) return 0;
+
+      const run = (sp) => d.ConsentEvent.bulkCreate(rows, { transaction: sp, validate: true });
+      if (outerTx) await d.sequelize.transaction({ transaction: outerTx }, run);
+      else await d.sequelize.transaction(run);
+      return rows.length;
+    } catch (err) {
+      d.logger.warn('[consent] capture ledger write failed (non-blocking — backfill heals)', {
+        error: err?.message || String(err),
+      });
+      return 0;
+    }
+  }
+
+  /**
+   * Re-derive ledger rows from prospects (migration 081 + healing). Writes
+   * ONLY where the source key exists (absent ≠ false — Retell/Meta never send
+   * the booleans, Codex R1 #10); idempotent via the uq_ce_backfill partial
+   * unique + ignoreDuplicates. Only linked prospects produce rows — run the
+   * spine reconciler first when healing.
+   */
+  async function backfillConsentEvents({ transaction = null } = {}) {
+    // Skip prospects whose capture already wrote signup-source events — the
+    // hook writes all kinds atomically (one savepoint bulkCreate), so a
+    // healing rerun must not double the evidence for live-captured rows.
+    const [rows] = await d.sequelize.query(
+      `SELECT p.id, p."consumerId", p."campaignId", p."createdAt", p.phone,
+              p."sourceMetadata", p."consentMetadata"
+         FROM prospects p
+        WHERE p."consumerId" IS NOT NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM consent_events ce
+             WHERE ce."prospectId" = p.id AND ce.source = 'signup'
+          )`,
+      { transaction }
+    );
+    const events = [];
+    for (const p of rows) {
+      const sm = p.sourceMetadata || {};
+      const cm = p.consentMetadata || {};
+      const verified = phoneVerificationIsCurrent(p);
+      const base = {
+        consumerId: p.consumerId, prospectId: p.id, campaignId: p.campaignId,
+        source: 'backfill', sourceUrl: sm.eventSourceUrl || null, verified,
+        occurredAt: p.createdAt,
+      };
+      if (Object.prototype.hasOwnProperty.call(sm, 'consent_contact')) {
+        events.push({
+          ...base, id: randomUUID(), kind: 'contact', granted: sm.consent_contact === true,
+          channels: [...CONTACT_CONSENT_CHANNELS], version: 'legacy-backfill', metadata: null,
+        });
+      }
+      if (Object.prototype.hasOwnProperty.call(sm, 'consent_terms')) {
+        events.push({
+          ...base, id: randomUUID(), kind: 'campaign_terms', granted: sm.consent_terms === true,
+          channels: null, version: 'legacy-backfill', metadata: null,
+        });
+      }
+      if (cm.external) {
+        events.push({
+          ...base, id: randomUUID(), kind: 'third_party', granted: true,
+          channels: cm.external.channels || null, version: cm.external.version || 'legacy-backfill',
+          occurredAt: new Date(cm.external.consentedAt || p.createdAt), metadata: null,
+        });
+      }
+      if (cm.dnc) {
+        events.push({
+          ...base, id: randomUUID(), kind: 'dnc_override', granted: cm.dnc.consented === true,
+          channels: cm.dnc.channels || null, version: cm.dnc.version || 'legacy-backfill',
+          occurredAt: new Date(cm.dnc.consentedAt || p.createdAt),
+          metadata: cm.dnc.dncTransactionId ? { dncTransactionId: cm.dnc.dncTransactionId } : null,
+        });
+      }
+      if (cm.drawTerms) {
+        events.push({
+          ...base, id: randomUUID(), kind: 'draw_terms', granted: true,
+          channels: null, version: String(cm.drawTerms.termsVersionId || 'legacy-backfill').slice(0, 64),
+          occurredAt: new Date(cm.drawTerms.acceptedAt || p.createdAt),
+          metadata: cm.drawTerms.termsHash ? { termsHash: cm.drawTerms.termsHash } : null,
+        });
+      }
+    }
+    if (!events.length) return { written: 0, scanned: rows.length };
+    // ignoreDuplicates → ON CONFLICT DO NOTHING; the uq_ce_backfill partial
+    // unique is the arbiter, so reruns are DB no-ops. bulkCreate's return
+    // includes skipped rows, so `written` is measured as a count delta.
+    const before = await d.ConsentEvent.count({ where: { source: 'backfill' }, transaction });
+    await d.ConsentEvent.bulkCreate(events, { transaction, ignoreDuplicates: true });
+    const after = await d.ConsentEvent.count({ where: { source: 'backfill' }, transaction });
+    return { written: after - before, scanned: rows.length };
+  }
+
+  /** Latest-wins state per kind within (campaignId | global) scope. */
+  async function getConsentState(consumerId, { campaignId = null } = {}) {
+    const where = {
+      consumerId,
+      ...(campaignId
+        ? { [Op.or]: [{ campaignId }, { campaignId: null }] }
+        : { campaignId: null }),
+    };
+    const events = await d.ConsentEvent.findAll({
+      where,
+      order: [['occurredAt', 'DESC'], ['createdAt', 'DESC'], ['id', 'DESC']],
+    });
+    const state = {};
+    for (const e of events) {
+      if (!state[e.kind]) {
+        state[e.kind] = {
+          granted: e.granted === true,
+          verified: e.verified === true,
+          version: e.version,
+          occurredAt: e.occurredAt,
+          scope: e.campaignId ? 'campaign' : 'global',
+        };
+      }
+    }
+    const suppressions = await d.ConsumerSuppression.findAll({ where: { consumerId } });
+    state.suppressions = suppressions.map((s) => ({ channel: s.channel, reason: s.reason }));
+    return state;
+  }
+
+  /** Resolve a consumer by id, else FAIL-CLOSED by phone (unlinked rows still match). */
+  async function resolveConsumerRef({ consumerId = null, phone = null }) {
+    if (consumerId) {
+      const byId = await d.Consumer.findByPk(consumerId);
+      if (byId) return byId;
+    }
+    if (typeof phone === 'string' && E164_RE.test(phone)) {
+      return d.Consumer.findOne({ where: { phone } });
+    }
+    return null;
+  }
+
+  /**
+   * Suppression check. `purpose: 'transactional'` is blocked ONLY by
+   * erasure-reason rows; 'marketing' by any row covering the channel.
+   */
+  async function isSuppressed({ consumerId = null, phone = null, channel = 'all', purpose = 'marketing' }) {
+    const consumer = await resolveConsumerRef({ consumerId, phone });
+    if (!consumer) return false;
+    const rows = await d.ConsumerSuppression.findAll({
+      where: { consumerId: consumer.id, channel: { [Op.in]: ['all', channel] } },
+    });
+    if (!rows.length) return false;
+    if (purpose === 'transactional') {
+      return rows.some((r) => MARKETING_REASONS_BLOCK_ALL.includes(r.reason));
+    }
+    return true;
+  }
+
+  /**
+   * THE marketing gate (plan §3.1): verified campaign-scoped contact grant ∧
+   * not suppressed. No consumer resolvable → false (fail closed). Every
+   * future marketing send/upload calls this — no exceptions.
+   */
+  async function canMarketTo({ consumerId = null, phone = null, channel = 'all', campaignId = null }) {
+    const consumer = await resolveConsumerRef({ consumerId, phone });
+    if (!consumer || consumer.erasedAt) return false;
+    const suppressed = await isSuppressed({ consumerId: consumer.id, channel, purpose: 'marketing' });
+    if (suppressed) return false;
+    const state = await getConsentState(consumer.id, { campaignId });
+    return state.contact?.granted === true && state.contact?.verified === true;
+  }
+
+  /**
+   * Async send gate for channel senders (WhatsApp today; the sync capability
+   * checks like canWhatsAppProspect stay sync — this runs at the actual send
+   * choke point). Transactional sends pass unless erased.
+   */
+  async function isSendBlocked(prospect, { channel, purpose = 'transactional' }) {
+    try {
+      if (purpose === 'transactional') {
+        return await isSuppressed({
+          consumerId: prospect?.consumerId, phone: prospect?.phone, channel, purpose: 'transactional',
+        });
+      }
+      return !(await canMarketTo({
+        consumerId: prospect?.consumerId, phone: prospect?.phone, channel, campaignId: prospect?.campaignId || null,
+      }));
+    } catch (err) {
+      d.logger.warn('[consent] send gate errored — failing CLOSED for marketing, OPEN for transactional', {
+        error: err?.message || String(err), purpose,
+      });
+      return purpose !== 'transactional';
+    }
+  }
+
+  /** Suppressed phone set for audience uploads — ANY suppression row excludes. */
+  async function getSuppressedPhoneSet() {
+    const [rows] = await d.sequelize.query(
+      `SELECT DISTINCT c.phone FROM consumer_suppressions s
+         JOIN consumers c ON c.id = s."consumerId"
+        WHERE c.phone IS NOT NULL`
+    );
+    return new Set(rows.map((r) => r.phone));
+  }
+
+  /**
+   * Deterministic unsubscribe token for a consumer; persists the hash on
+   * first use so the public endpoint can find the consumer BY HASH (the URL
+   * never carries the cross-campaign UUID).
+   */
+  async function ensureUnsubToken(consumerId) {
+    const token = unsubTokenFor(consumerId);
+    await d.Consumer.update(
+      { unsubTokenHash: unsubTokenHashOf(token) },
+      { where: { id: consumerId, unsubTokenHash: null } }
+    );
+    return token;
+  }
+
+  async function findConsumerByUnsubToken(token) {
+    if (!token || typeof token !== 'string' || token.length < 32) return null;
+    return d.Consumer.findOne({ where: { unsubTokenHash: unsubTokenHashOf(token) } });
+  }
+
+  /** Idempotent global marketing unsubscribe + ledger evidence. */
+  async function applyUnsubscribe(consumer, { source = 'unsubscribe_link' } = {}) {
+    return d.sequelize.transaction(async (t) => {
+      const [, created] = await d.ConsumerSuppression.findOrCreate({
+        where: { consumerId: consumer.id, channel: 'all' },
+        defaults: { id: randomUUID(), reason: 'unsubscribe', source },
+        transaction: t,
+      });
+      if (created) {
+        await d.ConsentEvent.create({
+          id: randomUUID(), consumerId: consumer.id, prospectId: null,
+          campaignId: null, // explicit GLOBAL withdrawal
+          kind: 'contact', granted: false, channels: null,
+          version: CONTACT_CONSENT_VERSION, source: 'unsubscribe',
+          sourceUrl: null, verified: false, metadata: { via: source },
+          occurredAt: new Date(),
+        }, { transaction: t });
+      }
+      return { alreadySuppressed: !created };
+    });
+  }
+
+  return {
+    recordCaptureConsentEventsTx,
+    backfillConsentEvents,
+    getConsentState,
+    isSuppressed,
+    canMarketTo,
+    isSendBlocked,
+    getSuppressedPhoneSet,
+    ensureUnsubToken,
+    findConsumerByUnsubToken,
+    applyUnsubscribe,
+  };
+}
+
+const _default = makeConsentService();
+export const recordCaptureConsentEventsTx = _default.recordCaptureConsentEventsTx;
+export const backfillConsentEvents = _default.backfillConsentEvents;
+export const getConsentState = _default.getConsentState;
+export const isSuppressed = _default.isSuppressed;
+export const canMarketTo = _default.canMarketTo;
+export const isSendBlocked = _default.isSendBlocked;
+export const getSuppressedPhoneSet = _default.getSuppressedPhoneSet;
+export const ensureUnsubToken = _default.ensureUnsubToken;
+export const findConsumerByUnsubToken = _default.findConsumerByUnsubToken;
+export const applyUnsubscribe = _default.applyUnsubscribe;

--- a/backend/src/services/contactConsent.js
+++ b/backend/src/services/contactConsent.js
@@ -1,0 +1,37 @@
+import { createHash } from 'crypto';
+
+/**
+ * Marketing-contact consent contract (PR B, plan §3.1) — the evidence-grade
+ * upgrade of the bare `sourceMetadata.consent_contact` boolean, mirroring
+ * externalConsent.js / dncConsent.js.
+ *
+ * The checkbox is DEFAULT-TICKED (opt-out model) on both capture surfaces, so
+ * an untick is an explicit act — the ledger records granted:false too.
+ *
+ * PURPOSE SCOPE: the live copy grants contact "for the purposes identified in
+ * this form" (CampaignSignupForm) / "about this redemption" (MarketplaceFlow)
+ * — i.e. CAMPAIGN-scoped. This version label + copy hash pin exactly what was
+ * agreed; a future GLOBAL opt-in ("keep me posted about new offers") must use
+ * a NEW version and campaignId:null events, never a reinterpretation of these.
+ */
+
+/**
+ * Current contact-consent wording version. BUMP (to the date the copy
+ * changes) whenever the consent_contact checkbox wording on either capture
+ * surface is edited (CampaignSignupForm.jsx / MarketplaceFlow.jsx).
+ */
+export const CONTACT_CONSENT_VERSION = '2026-07-20';
+
+/**
+ * Canonical digest of the consent copy in force for CONTACT_CONSENT_VERSION.
+ * Snapshot of the LeadCapture wording (the marketplace variant is narrower);
+ * stored in event metadata so evidence survives future copy edits verbatim.
+ */
+export const CONTACT_CONSENT_COPY =
+  'I consent to being contacted (phone call, text or email) using the particulars provided, for the purposes identified in this form.';
+export const CONTACT_CONSENT_COPY_HASH = createHash('sha256')
+  .update(CONTACT_CONSENT_COPY)
+  .digest('hex');
+
+/** Channels the ticked box covers — keep in sync with the checkbox copy. */
+export const CONTACT_CONSENT_CHANNELS = Object.freeze(['phone', 'text', 'email']);

--- a/backend/src/services/email-templates/confirmation-email-draw.html
+++ b/backend/src/services/email-templates/confirmation-email-draw.html
@@ -277,6 +277,11 @@
                   </td>
                 </tr>
                 <tr>
+                  <td align="center" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:12px; line-height:18px; color:#8A6B49; padding-bottom:6px;">
+                    {{unsubscribeLine}}
+                  </td>
+                </tr>
+                <tr>
                   <td align="center" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:12px; line-height:18px; color:#8A6B49;">
                     {{footerEntity}}
                   </td>

--- a/backend/src/services/email-templates/confirmation-email-draw.txt
+++ b/backend/src/services/email-templates/confirmation-email-draw.txt
@@ -27,5 +27,6 @@ The {{brandName}} team
 
 {{brandWordmark}}
 You are receiving this because you submitted a request to {{brandName}}.
+{{unsubscribeTextLine}}
 {{footerEntity}}
 (c) {{year}} {{brandName}}. All rights reserved.

--- a/backend/src/services/email-templates/confirmation-email.html
+++ b/backend/src/services/email-templates/confirmation-email.html
@@ -277,6 +277,11 @@
                   </td>
                 </tr>
                 <tr>
+                  <td align="center" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:12px; line-height:18px; color:#8A6B49; padding-bottom:6px;">
+                    {{unsubscribeLine}}
+                  </td>
+                </tr>
+                <tr>
                   <td align="center" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:12px; line-height:18px; color:#8A6B49;">
                     {{footerEntity}}
                   </td>

--- a/backend/src/services/email-templates/confirmation-email.txt
+++ b/backend/src/services/email-templates/confirmation-email.txt
@@ -26,5 +26,6 @@ The {{brandName}} team
 
 {{brandWordmark}}
 You are receiving this because you submitted a request to {{brandName}}.
+{{unsubscribeTextLine}}
 {{footerEntity}}
 (c) {{year}} {{brandName}}. All rights reserved.

--- a/backend/src/services/leadOutcomeService.js
+++ b/backend/src/services/leadOutcomeService.js
@@ -113,6 +113,29 @@ export function makeLeadOutcomeService(overrides = {}) {
     const prospect = await m.Prospect.findByPk(externalId);
     if (!prospect) return { skipped: 'no_prospect' };
 
+    // Send-time consent gate (PR B, Codex R1 #12): a withdrawal AFTER capture
+    // must strip contact identifiers from these DELAYED down-funnel events —
+    // the stored signup boolean alone is stale. On a positive suppression
+    // match we hand the dispatcher a clone with consent_contact:false, so
+    // metaCapiService omits em/ph (fbp/fbc/ip/ua/external_id still ride —
+    // browser/session identifiers, not contact PII). Lookup errors keep the
+    // stored behavior (byte-identical when consent tables are unreachable).
+    let sendProspect = prospect;
+    try {
+      const { isSuppressed } = await import('./consentService.js');
+      const suppressed = await isSuppressed({
+        consumerId: prospect.consumerId, phone: prospect.phone, channel: 'all', purpose: 'marketing',
+      });
+      if (suppressed) {
+        const plain = typeof prospect.get === 'function' ? prospect.get({ plain: true }) : { ...prospect };
+        sendProspect = { ...plain, sourceMetadata: { ...(plain.sourceMetadata || {}), consent_contact: false } };
+      }
+    } catch (err) {
+      logger.warn('[lead-outcome] suppression lookup failed — sending with stored consent', {
+        error: err?.message || String(err),
+      });
+    }
+
     // Per-campaign pixel override (mirrors prospectService submit-time dispatch).
     let pixelIdOverride;
     if (prospect.campaignId) {
@@ -150,7 +173,7 @@ export function makeLeadOutcomeService(overrides = {}) {
         ...(pixelIdOverride ? { pixelIdOverride } : {}),
       };
 
-      const result = await dispatchWithRetry(prospect, ctx, { eventName });
+      const result = await dispatchWithRetry(sendProspect, ctx, { eventName });
 
       if (result?.sent) {
         const capi = { ...(prospect.sourceMetadata?.capi || {}), [markerKey]: new Date().toISOString() };

--- a/backend/src/services/mailer.js
+++ b/backend/src/services/mailer.js
@@ -6,6 +6,7 @@ import { logger } from '../utils/logger.js';
 import { maskEmail } from '../utils/redactTokens.js';
 import { normalizeCustomerHostChoice, customerHostOrigin } from '../utils/customerHost.js';
 import { getOrCreateProspectShareLink } from './shortlinkService.js';
+import { ensureUnsubToken } from './consentService.js';
 
 // Lead-capture confirmation email: the designer's production, table-based HTML email
 // (design_handoff_lead_confirmation_email). Read once at boot from the co-located copy so it
@@ -64,7 +65,7 @@ export function getTransporter() {
 }
 
 
-export async function sendEmail({ to, subject, html, text, context, from, attachments }) {
+export async function sendEmail({ to, subject, html, text, context, from, attachments, headers }) {
   // Resolve from-address by context (lead-capture flows pass context='redeem',
   // admin flows omit it). An explicit `from` arg overrides both.
   const resolvedFrom = from || resolveEmailFrom(context);
@@ -83,7 +84,9 @@ export async function sendEmail({ to, subject, html, text, context, from, attach
     // the Redeem Ops voucher QR ships as an attachment, not a remote URL, so it
     // renders with remote images blocked and the token stays out of image-proxy
     // logs (docs/redeem-ops/MKTR_INTEGRATION.md §2).
-    await transporter.sendMail({ from: resolvedFrom, to, subject, html, text, ...(attachments ? { attachments } : {}) });
+    // `headers` (optional, nodemailer passthrough) carries List-Unsubscribe /
+    // List-Unsubscribe-Post on consumer emails (PR B).
+    await transporter.sendMail({ from: resolvedFrom, to, subject, html, text, ...(attachments ? { attachments } : {}), ...(headers ? { headers } : {}) });
     return { success: true };
   } catch (err) {
     // Surface SES/SMTP rejection details — Nodemailer attaches `code`,
@@ -327,10 +330,41 @@ export async function sendLeadConfirmationEmail(prospect, { shareUrl: shareUrlOv
   // derived, so they are HTML-escaped exactly as before; heroLogo is intentional markup and
   // the brand literals and year are controlled, so they pass through raw. The plain-text part
   // is never escaped. Unknown placeholders are left intact so a render check can flag them.
+  // Unsubscribe plumbing (PR B, plan §3.4): consumer-linked leads get a
+  // working List-Unsubscribe header pair + footer link. The deterministic
+  // token means every email rebuilds the same URL, and the URL carries ONLY
+  // the token — never the cross-campaign consumer id. Unlinked rows send
+  // without it (nothing to unsubscribe person-level yet). Mint failure never
+  // blocks the email.
+  let unsubscribeUrl = '';
+  if (prospect.consumerId) {
+    try {
+      const token = await ensureUnsubToken(prospect.consumerId);
+      const apiOrigin = process.env.API_PUBLIC_ORIGIN || 'https://api.mktr.sg';
+      unsubscribeUrl = `${apiOrigin}/api/unsubscribe?t=${token}`;
+    } catch (err) {
+      logger.warn('Unsubscribe link mint failed (email sends without it)', { err: err?.message });
+    }
+  }
+  const unsubscribeLine = unsubscribeUrl
+    ? `<a href="${escapeHtml(unsubscribeUrl)}" style="color:inherit;text-decoration:underline;">Unsubscribe from marketing messages</a>`
+    : '';
+  const unsubscribeTextLine = unsubscribeUrl
+    ? `Unsubscribe from marketing messages: ${unsubscribeUrl}`
+    : '';
+  const unsubHeaders = unsubscribeUrl
+    ? {
+        'List-Unsubscribe': `<${unsubscribeUrl}>`,
+        'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+      }
+    : undefined;
+
   const fields = {
     firstName,
     campaignName,
     shareUrl: shareUrl || '',
+    unsubscribeLine,
+    unsubscribeTextLine,
     brandName,
     brandWordmark,
     footerEntity,
@@ -358,6 +392,7 @@ export async function sendLeadConfirmationEmail(prospect, { shareUrl: shareUrlOv
     html,
     text,
     context: hostChoice,
+    ...(unsubHeaders ? { headers: unsubHeaders } : {}),
   });
 }
 

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -39,6 +39,7 @@ import {
   recomputeConsumersByPhone,
   getConsumerJourney,
 } from './consumerService.js';
+import { recordCaptureConsentEventsTx } from './consentService.js';
 import { customerHostOrigin, normalizeCustomerHostChoice } from '../utils/customerHost.js';
 import { sgtDayEndExclusiveMs } from '../utils/sgtTime.js';
 
@@ -176,6 +177,7 @@ const defaultDeps = {
   resolveConsumerForCaptureTx,
   recomputeConsumersByPhone,
   getConsumerJourney,
+  recordCaptureConsentEventsTx,
   onLeadCaptured: (prospect) => (_leadCapturedHook ? _leadCapturedHook(prospect) : null),
   AppError,
   logger,
@@ -893,6 +895,24 @@ export function makeProspectService(overrides = {}) {
         },
         { transaction: t }
       );
+
+      // Consent ledger (PR B, plan §3.1): person-level evidence for this
+      // capture — savepoint-isolated + non-blocking like the resolver; every
+      // input also lives on the prospect row, so backfillConsentEvents can
+      // re-derive a missed write. No-op when consumerId is null (call_bot /
+      // unlinked rows carry no person-level evidence until reconciled).
+      await d.recordCaptureConsentEventsTx(t, {
+        consumerId,
+        prospectId: newProspect.id,
+        campaignId: newProspect.campaignId || null,
+        sourceUrl: eventSourceUrl || null,
+        verified: otpMarkerLive,
+        contact: consentContact,
+        terms: consentTerms,
+        externalConsent,
+        dncConsent,
+        drawTerms: incoming.consentMetadata?.drawTerms || null,
+      });
 
       const campaignName = sourceCampaign?.name || 'Unknown Campaign';
       // Source-aware phrase ("via TikTok ad" / "via web form" / "via {name} QR

--- a/backend/src/services/redeemOps/whatsappService.js
+++ b/backend/src/services/redeemOps/whatsappService.js
@@ -1,6 +1,7 @@
 import QRCode from 'qrcode';
 import { RewardOffer } from '../../models/index.js';
 import { logger } from '../../utils/logger.js';
+import { isSendBlocked } from '../consentService.js';
 
 /**
  * Consumer WhatsApp delivery for reward credentials (trial-reward PR E,
@@ -146,6 +147,15 @@ export function makeWhatsappService(overrides = {}) {
   async function sendTemplate({ prospect, templateName, params, qrContent }) {
     if (!waEnabled()) return { sent: false, skipped: 'disabled' };
     if (!canWhatsAppProspect(prospect)) return { sent: false, skipped: 'no_whatsapp' };
+    // PR B suppression gate: these sends are TRANSACTIONAL (delivering the
+    // reward the person claimed) — only an erasure-reason suppression blocks
+    // them; a marketing unsubscribe does not. Future marketing templates must
+    // gate on consentService.canMarketTo with purpose:'marketing' instead.
+    // isSendBlocked fails OPEN for transactional on lookup errors, so DB-less
+    // unit runs are unaffected.
+    if (await isSendBlocked(prospect, { channel: 'whatsapp', purpose: 'transactional' })) {
+      return { sent: false, skipped: 'suppressed' };
+    }
 
     const token = process.env.WHATSAPP_TOKEN;
     const phoneId = process.env.WHATSAPP_PHONE_NUMBER_ID;

--- a/backend/src/services/redeemedAudienceService.js
+++ b/backend/src/services/redeemedAudienceService.js
@@ -81,13 +81,16 @@ export async function selectRedeemers(deps = {}) {
  * Turn prospect rows into hashed multi-key audience rows `[emailHash, phoneHash]`.
  * - Drops synthetic Retell emails (@calls.mktr.sg).
  * - When consent is required, drops rows without consent_contact === true.
+ * - Drops SUPPRESSED people (PR B): matched BY PHONE so rows the consumer
+ *   spine failed to link still suppress — fail-closed, never by FK.
  * - Drops rows with neither a usable email nor phone.
  * - Missing key → empty string (Meta multi-key allows blanks).
  */
-export function buildUserRows(prospects, { requireConsent = true } = {}) {
+export function buildUserRows(prospects, { requireConsent = true, suppressedPhones = null } = {}) {
   const rows = [];
   for (const p of prospects || []) {
     if (requireConsent && p?.sourceMetadata?.consent_contact !== true) continue;
+    if (suppressedPhones && p?.phone && suppressedPhones.has(p.phone)) continue;
     const email =
       p?.email && !String(p.email).toLowerCase().endsWith(SYNTHETIC_EMAIL_SUFFIX)
         ? p.email
@@ -177,10 +180,14 @@ export async function syncRedeemedAudience(deps = {}) {
   const version = graphVersion();
   const mode = (process.env.REDEEMED_AUDIENCE_SYNC_MODE || 'add').toLowerCase();
   const requireConsent = requireConsentEnabled();
+  // Fail-closed by construction: if the suppression lookup throws, the sync
+  // run aborts — we never upload while blind to withdrawals (Codex R1 #12).
+  const { getSuppressedPhoneSet } = await import('./consentService.js');
+  const suppressedPhones = await getSuppressedPhoneSet();
 
   try {
     const prospects = await selectRedeemers(d);
-    const rows = buildUserRows(prospects, { requireConsent });
+    const rows = buildUserRows(prospects, { requireConsent, suppressedPhones });
     logger.info(
       { selected: prospects.length, eligible: rows.length, requireConsent, mode },
       'redeemed_audience.sync.start'

--- a/backend/test/integration/consentLedger.test.js
+++ b/backend/test/integration/consentLedger.test.js
@@ -1,0 +1,251 @@
+import request from 'supertest';
+import { getApp, closeDb, createTestUser, createTestCampaign } from '../helpers.js';
+import { Consumer, Prospect, ConsentEvent, ConsumerSuppression,
+} from '../../src/models/index.js';
+import { markPhoneVerified } from '../../src/services/verifiedPhoneStore.js';
+import { reconcileConsumerSpine } from '../../src/services/consumerService.js';
+import {
+  backfillConsentEvents, getConsentState, canMarketTo, isSendBlocked,
+  ensureUnsubToken, unsubTokenFor,
+} from '../../src/services/consentService.js';
+import { CONTACT_CONSENT_VERSION } from '../../src/services/contactConsent.js';
+import { THIRD_PARTY_CONSENT_VERSION } from '../../src/services/externalConsent.js';
+
+/**
+ * Consent ledger — integration (PR B, plan §3). Real Postgres: the ledger's
+ * latest-wins scope resolution, the backfill's idempotency anchor, and the
+ * fail-closed phone joins are all DB semantics.
+ */
+
+const RUN = Date.now();
+const p8 = (offset) => `9${String(RUN + offset).slice(-7)}`;
+
+let app;
+let adminToken;
+let campaign1;
+let campaign2;
+
+function capturePayload(overrides = {}) {
+  return {
+    firstName: 'Ledger',
+    lastName: 'Tester',
+    email: `ledger-${RUN}-${Math.random().toString(36).slice(2, 6)}@test.com`,
+    leadSource: 'website',
+    ...overrides,
+  };
+}
+
+beforeAll(async () => {
+  app = await getApp();
+  const admin = await createTestUser({ role: 'admin' });
+  adminToken = admin.token;
+  campaign1 = await createTestCampaign(admin.user.id, { name: `Ledger C1 ${RUN}` });
+  campaign2 = await createTestCampaign(admin.user.id, { name: `Ledger C2 ${RUN}` });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+describe('capture → ledger events', () => {
+  const ph = p8(11);
+  const phE164 = `+65${ph}`;
+
+  test('verified signup writes contact + terms + third_party events with real versions', async () => {
+    markPhoneVerified(phE164);
+    await request(app).post('/api/prospects')
+      .send(capturePayload({
+        campaignId: campaign1.id, phone: ph,
+        consent_contact: true, consent_terms: true, consent_third_party: true,
+      }))
+      .expect(201);
+
+    const consumer = await Consumer.findOne({ where: { phone: phE164 } });
+    const events = await ConsentEvent.findAll({ where: { consumerId: consumer.id } });
+    const byKind = Object.fromEntries(events.map((e) => [e.kind, e]));
+
+    expect(byKind.contact.granted).toBe(true);
+    expect(byKind.contact.verified).toBe(true);
+    expect(byKind.contact.version).toBe(CONTACT_CONSENT_VERSION);
+    expect(byKind.contact.campaignId).toBe(campaign1.id);
+    expect(byKind.contact.source).toBe('signup');
+
+    expect(byKind.campaign_terms.granted).toBe(true);
+    expect(byKind.third_party.granted).toBe(true);
+    expect(byKind.third_party.version).toBe(THIRD_PARTY_CONSENT_VERSION);
+    expect(Array.isArray(byKind.third_party.channels)).toBe(true);
+  });
+
+  test('explicit contact UNTICK is recorded as granted:false; absent keys write nothing', async () => {
+    await request(app).post('/api/prospects')
+      .send(capturePayload({
+        campaignId: campaign2.id, phone: ph,
+        consent_contact: false, consent_terms: true,
+      }))
+      .expect(201);
+
+    const consumer = await Consumer.findOne({ where: { phone: phE164 } });
+    const c2Contact = await ConsentEvent.findOne({
+      where: { consumerId: consumer.id, kind: 'contact', campaignId: campaign2.id },
+    });
+    expect(c2Contact.granted).toBe(false);
+
+    // A capture with NO consent keys at all writes no contact/terms events.
+    const phNone = p8(12);
+    await request(app).post('/api/prospects')
+      .send(capturePayload({ campaignId: campaign1.id, phone: phNone }))
+      .expect(201);
+    const cNone = await Consumer.findOne({ where: { phone: `+65${phNone}` } });
+    expect(await ConsentEvent.count({ where: { consumerId: cNone.id } })).toBe(0);
+  });
+
+  test('canMarketTo: campaign-scoped, verified-only, fail-closed', async () => {
+    // campaign1: verified grant → true.
+    expect(await canMarketTo({ phone: phE164, campaignId: campaign1.id })).toBe(true);
+    // campaign2: explicit false → false (scope isolation both directions).
+    expect(await canMarketTo({ phone: phE164, campaignId: campaign2.id })).toBe(false);
+    // No GLOBAL grant exists — cross-campaign marketing has no basis.
+    expect(await canMarketTo({ phone: phE164, campaignId: null })).toBe(false);
+    // Unknown person → fail closed.
+    expect(await canMarketTo({ phone: '+6590000001', campaignId: campaign1.id })).toBe(false);
+  });
+
+  test('an UNVERIFIED grant never mints marketing authority', async () => {
+    const phU = p8(13);
+    await request(app).post('/api/prospects')
+      .send(capturePayload({
+        campaignId: campaign1.id, phone: phU,
+        consent_contact: true, consent_terms: true,
+      }))
+      .expect(201); // no OTP marker → verified:false on the event
+    expect(await canMarketTo({ phone: `+65${phU}`, campaignId: campaign1.id })).toBe(false);
+  });
+});
+
+describe('unsubscribe endpoint', () => {
+  const ph = p8(14);
+  const phE164 = `+65${ph}`;
+  let token;
+
+  beforeAll(async () => {
+    markPhoneVerified(phE164);
+    await request(app).post('/api/prospects')
+      .send(capturePayload({
+        campaignId: campaign1.id, phone: ph,
+        consent_contact: true, consent_terms: true,
+      }))
+      .expect(201);
+    const consumer = await Consumer.findOne({ where: { phone: phE164 } });
+    token = await ensureUnsubToken(consumer.id);
+    expect(token).toBe(unsubTokenFor(consumer.id)); // deterministic
+  });
+
+  test('GET renders the confirm form and MUTATES NOTHING (scanner safety)', async () => {
+    const r = await request(app).get(`/api/unsubscribe?t=${token}`);
+    expect(r.status).toBe(200);
+    expect(r.text).toContain('Unsubscribe from marketing messages?');
+    const consumer = await Consumer.findOne({ where: { phone: phE164 } });
+    expect(await ConsumerSuppression.count({ where: { consumerId: consumer.id } })).toBe(0);
+    expect(await canMarketTo({ phone: phE164, campaignId: campaign1.id })).toBe(true);
+  });
+
+  test('POST suppresses globally + writes the withdrawal event; idempotent; bad token 404s', async () => {
+    await request(app)
+      .post(`/api/unsubscribe?t=${token}`)
+      .type('form')
+      .send('List-Unsubscribe=One-Click')
+      .expect(200);
+
+    const consumer = await Consumer.findOne({ where: { phone: phE164 } });
+    const supp = await ConsumerSuppression.findAll({ where: { consumerId: consumer.id } });
+    expect(supp).toHaveLength(1);
+    expect(supp[0].channel).toBe('all');
+    expect(supp[0].reason).toBe('unsubscribe');
+
+    const withdrawal = await ConsentEvent.findOne({
+      where: { consumerId: consumer.id, source: 'unsubscribe' },
+    });
+    expect(withdrawal.kind).toBe('contact');
+    expect(withdrawal.granted).toBe(false);
+    expect(withdrawal.campaignId).toBeNull(); // explicit GLOBAL act
+
+    // The verified scoped grant is now overridden by recency + suppression.
+    expect(await canMarketTo({ phone: phE164, campaignId: campaign1.id })).toBe(false);
+
+    // Idempotent: second POST adds nothing.
+    await request(app).post(`/api/unsubscribe?t=${token}`).type('form').send('').expect(200);
+    expect(await ConsumerSuppression.count({ where: { consumerId: consumer.id } })).toBe(1);
+    expect(await ConsentEvent.count({ where: { consumerId: consumer.id, source: 'unsubscribe' } })).toBe(1);
+
+    await request(app).get('/api/unsubscribe?t=deadbeef').expect(404);
+  });
+
+  test('suppression semantics: transactional passes on unsubscribe, blocks on erasure', async () => {
+    const consumer = await Consumer.findOne({ where: { phone: phE164 } });
+    const prospect = await Prospect.findOne({ where: { phone: phE164 } });
+
+    // Marketing unsubscribe does NOT block transactional delivery…
+    expect(await isSendBlocked(prospect, { channel: 'whatsapp', purpose: 'transactional' })).toBe(false);
+    // …but marketing sends are blocked.
+    expect(await isSendBlocked(prospect, { channel: 'whatsapp', purpose: 'marketing' })).toBe(true);
+
+    // An erasure-reason suppression blocks everything (PR C writes these).
+    await ConsumerSuppression.create({ consumerId: consumer.id, channel: 'email', reason: 'erasure' });
+    expect(await isSendBlocked(prospect, { channel: 'email', purpose: 'transactional' })).toBe(true);
+  });
+});
+
+describe('backfill (081 semantics)', () => {
+  test('re-derives events for pre-ledger rows, skips live-captured rows, and is idempotent', async () => {
+    // A "legacy" prospect: created directly (no capture hook), then linked by
+    // the reconciler — exactly the 081 deploy shape.
+    const ph = p8(15);
+    const legacy = await Prospect.create({
+      firstName: 'Legacy', email: `legacy-${RUN}@test.com`, phone: `+65${ph}`,
+      leadSource: 'website', campaignId: campaign1.id,
+      sourceMetadata: { consent_contact: true, consent_terms: true },
+      consentMetadata: { external: { version: '2026-06-26', consentedAt: '2026-07-01T00:00:00Z', channels: ['phone'] } },
+    });
+    await reconcileConsumerSpine();
+
+    const first = await backfillConsentEvents();
+    expect(first.written).toBeGreaterThanOrEqual(3);
+
+    const rows = await ConsentEvent.findAll({ where: { prospectId: legacy.id } });
+    const kinds = rows.map((r) => r.kind).sort();
+    expect(kinds).toEqual(['campaign_terms', 'contact', 'third_party']);
+    for (const r of rows) {
+      expect(r.source).toBe('backfill');
+    }
+    const contact = rows.find((r) => r.kind === 'contact');
+    expect(contact.version).toBe('legacy-backfill');
+    expect(new Date(contact.occurredAt).getTime()).toBe(new Date(legacy.createdAt).getTime());
+
+    // Idempotent rerun: nothing new (uq_ce_backfill + signup-skip clause) —
+    // asserted on the RETURN COUNT and on the actual DB rows.
+    const second = await backfillConsentEvents();
+    expect(second.written).toBe(0);
+    expect(await ConsentEvent.count({ where: { prospectId: legacy.id } })).toBe(3);
+
+    // Live-captured prospects (signup-source events) are never double-written.
+    const captured = await ConsentEvent.findOne({ where: { source: 'signup' } });
+    if (captured) {
+      const dupes = await ConsentEvent.count({
+        where: { prospectId: captured.prospectId, kind: captured.kind, source: 'backfill' },
+      });
+      expect(dupes).toBe(0);
+    }
+  });
+});
+
+describe('consent state reads', () => {
+  test('getConsentState resolves latest-wins within scope and surfaces suppressions', async () => {
+    const ph = p8(14);
+    const consumer = await Consumer.findOne({ where: { phone: `+65${ph}` } });
+    const state = await getConsentState(consumer.id, { campaignId: campaign1.id });
+    // The GLOBAL unsubscribe (later) beats the earlier scoped grant.
+    expect(state.contact.granted).toBe(false);
+    expect(state.contact.scope).toBe('global');
+    expect(state.suppressions.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/backend/test/unit/consentLedgerUnit.test.js
+++ b/backend/test/unit/consentLedgerUnit.test.js
@@ -1,0 +1,47 @@
+import '../setup.js';
+import { buildUserRows } from '../../src/services/redeemedAudienceService.js';
+import { unsubTokenFor, unsubTokenHashOf } from '../../src/services/consentService.js';
+import {
+  CONTACT_CONSENT_VERSION, CONTACT_CONSENT_COPY, CONTACT_CONSENT_COPY_HASH, CONTACT_CONSENT_CHANNELS,
+} from '../../src/services/contactConsent.js';
+import { createHash } from 'crypto';
+
+describe('audience rows — fail-closed suppression BY PHONE (Codex R1 #12)', () => {
+  const consented = (phone, email = 'a@b.co') => ({
+    phone, email, sourceMetadata: { consent_contact: true },
+  });
+
+  test('suppressed phones are dropped even when the row is spine-unlinked', () => {
+    const suppressed = new Set(['+6591112222']);
+    const rows = buildUserRows(
+      [consented('+6591112222'), consented('+6593334444')],
+      { requireConsent: true, suppressedPhones: suppressed }
+    );
+    expect(rows).toHaveLength(1); // only the non-suppressed person survives
+  });
+
+  test('no suppression set → behavior unchanged (back-compat)', () => {
+    const rows = buildUserRows([consented('+6591112222')], { requireConsent: true });
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe('unsubscribe token', () => {
+  test('deterministic per consumer, hash-addressable, secret-dependent', () => {
+    const a1 = unsubTokenFor('11111111-1111-4111-8111-111111111111');
+    const a2 = unsubTokenFor('11111111-1111-4111-8111-111111111111');
+    const b = unsubTokenFor('22222222-2222-4222-8222-222222222222');
+    expect(a1).toBe(a2);
+    expect(a1).not.toBe(b);
+    expect(a1).toMatch(/^[0-9a-f]{64}$/);
+    expect(unsubTokenHashOf(a1)).toBe(createHash('sha256').update(a1).digest('hex'));
+  });
+});
+
+describe('contact consent contract', () => {
+  test('version, copy hash, and channels are pinned together', () => {
+    expect(CONTACT_CONSENT_VERSION).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(CONTACT_CONSENT_COPY_HASH).toBe(createHash('sha256').update(CONTACT_CONSENT_COPY).digest('hex'));
+    expect(CONTACT_CONSENT_CHANNELS).toEqual(['phone', 'text', 'email']);
+  });
+});


### PR DESCRIPTION
## What

PR B of the data-powerhouse track (plan §3, `docs/plans/consumer-spine-and-consent-ledger.md`), building on the PR A spine (#204): the **licence layer** — evidence-grade consent, suppression, and the exit door — that any future re-engagement must stand on.

## Changes

- **`consent_events`** (migration 080): append-only, person- AND purpose-scoped. `campaignId` is semantic (the live consent copy is campaign-scoped on both surfaces); `campaignId:null` = an explicit GLOBAL act (unsubscribe). Rows carry `verified` (OTP-stamp, binding-aware), copy `version` + hash — `consent_contact` finally becomes evidence-grade (it was an untimestamped boolean). Explicit unticks of the default-on box are recorded as `granted:false`.
- **`consumer_suppressions`**: `erasure` reason blocks everything including transactional (PR C will write it); every other reason blocks marketing only. Separate from the partner-side `OutreachSuppression` on purpose.
- **Capture hook**: savepoint-isolated + non-blocking (same posture as the spine resolver); every input also lives on the prospect row, so **081** backfills legacy rows key-exists-only (absent ≠ false — Retell/Meta never send the booleans) with `legacy-backfill` versions, idempotent via a partial unique + a signup-skip clause (healing reruns can't double live-captured evidence).
- **`canMarketTo` — THE marketing gate**: verified campaign-scoped contact grant ∧ not suppressed, **fail-closed by phone** (rows the spine failed to link still suppress). Deliberately NO global variant: today's copy licenses nothing cross-campaign; the global opt-in is a Phase-2 capture surface, not a read-side widening.
- **Enforcement now**: redeemed-audience sync drops suppressed phones and aborts if the lookup fails (never uploads blind); delayed down-funnel CAPI re-checks at send time and strips em/ph on withdrawal (prospect clone with `consent_contact:false` — `metaCapiService` untouched); WhatsApp `sendTemplate` gates by purpose (transactional passes a marketing unsubscribe, fails open on lookup errors so DB-less unit runs are unaffected — and the diff to `whatsappService.js` is 12 lines, minimal on purpose given in-flight WABA work).
- **Unsubscribe**: deterministic opaque token, hash-addressed (`?t=` only — the URL never carries the cross-campaign consumer UUID). **GET renders a confirm form and never mutates** (mail scanners prefetch — the reason RFC 8058 exists); POST serves both the human form and the one-click body, idempotently. `sendEmail` gains a `headers` passthrough; both brands' confirmation templates (incl. draw variants) ship `List-Unsubscribe` + `List-Unsubscribe-Post` and a footer link.

## Evidence

13 new tests (real PG): event kinds/versions/scopes at capture, explicit-false vs absent, the `canMarketTo` matrix (verified-only, campaign-scope isolation both directions, no-global-basis, unknown-person fail-closed), GET-inert/POST-mutate/idempotent/404 unsubscribe, transactional-vs-erasure suppression semantics, backfill idempotency asserted on return count AND rows. Full backend: 3,692 passed; the same 6 pre-existing suites fail identically to base.

## Deploy notes

Migrations 080/081 auto-apply (advisory-locked). Post-deploy probes: `consent_events` count ≥ prospects with any consent key (~all 127 linked rows); one test-address confirmation email carries both unsubscribe headers and a working link (GET inert → POST suppresses); a suppressed test consumer disappears from the next audience-sync selection. **Impl-noted follow-up**: verify SES DKIM covers the `List-Unsubscribe*` headers (RFC 8058 requirement) before relying on one-click in the wild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrXgaygxd7V5bgctd1rqV8