### PR TITLE
feat(redeem-ops): Void action to remove a redeemed reward (frees the phone slot)

### DIFF
--- a/backend/src/services/redeemOps/entitlementService.js
+++ b/backend/src/services/redeemOps/entitlementService.js
@@ -1,6 +1,6 @@
 import { Op } from 'sequelize';
 import {
-  RewardEntitlement, RedemptionEvent, Activation, ActivationIssuanceSkip, RewardOffer,
+  RewardEntitlement, RedemptionEvent, Redemption, Activation, ActivationIssuanceSkip, RewardOffer,
   PartnerOrganisation, Prospect, User, Consumer, sequelize,
 } from '../../models/index.js';
 import { phoneVerificationIsCurrent } from '../consumerService.js';
@@ -59,7 +59,7 @@ export async function flushDeliveries() {
  */
 export function makeEntitlementService(overrides = {}) {
   const d = {
-    RewardEntitlement, RedemptionEvent, Activation, ActivationIssuanceSkip, RewardOffer,
+    RewardEntitlement, RedemptionEvent, Redemption, Activation, ActivationIssuanceSkip, RewardOffer,
     PartnerOrganisation, Prospect, User, Consumer, sequelize, logger,
     inventory: makeInventoryService(),
     audit: makeRedeemOpsAuditService(),
@@ -815,6 +815,10 @@ export function makeEntitlementService(overrides = {}) {
           ...(query.search ? { where: prospectWhere, required: true } : {}),
         },
         { model: d.RewardOffer, as: 'rewardOffer', attributes: ['id', 'title'] },
+        // The redemption backing a redeemed row — its id is what the Void
+        // action reverses (POST /redemptions/:id/reverse), which flips the
+        // entitlement to cancelled and frees the one-live-reward-per-phone slot.
+        { model: d.Redemption, as: 'redemption', attributes: ['id', 'status', 'redeemedAt'], required: false },
         {
           model: d.Activation,
           as: 'activation',
@@ -863,6 +867,11 @@ export function makeEntitlementService(overrides = {}) {
         if (j.prospect.phone) j.prospect.phone = `••••${String(j.prospect.phone).slice(-4)}`;
         delete j.prospect.email;
       }
+      // Surface the redemption id (+ whether it is already reversed) so the
+      // console can offer Void on redeemed rows without a second fetch.
+      j.redemptionId = j.redemption?.id || null;
+      j.redemptionReversed = j.redemption?.status === 'reversed';
+      delete j.redemption;
       return j;
     });
     return { entitlements: masked, pagination: { page, limit, total: count, totalPages: Math.ceil(count / limit) } };

--- a/backend/test/redeemOpsVoidRedemption.test.js
+++ b/backend/test/redeemOpsVoidRedemption.test.js
@@ -1,0 +1,111 @@
+/**
+ * Void a REDEEMED reward (ops.redeem.sg RedemptionsPage "Void"): reversing the
+ * redemption cancels the entitlement, which leaves the uq_re_activation_phone
+ * partial-unique set (eligible/issued/redeemed) and FREES the one-live-reward-
+ * per-phone slot so the number can earn a new reward on that activation.
+ *
+ * This pins the exact need behind Shawn's request: a redeemed entitlement on a
+ * phone was un-removable (cancel is eligible/issued-only), stranding the slot.
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+process.env.REDEEM_OPS_ENTITLEMENTS_ENABLED = 'true';
+
+import { getApp, closeDb, createTestUser, createTestCampaign } from './helpers.js';
+import {
+  Prospect, RewardOffer, Activation, RewardEntitlement, Redemption, PartnerOrganisation,
+} from '../src/models/index.js';
+import { makeEntitlementService, phoneKeyOf } from '../src/services/redeemOps/entitlementService.js';
+import { makeRedemptionService } from '../src/services/redeemOps/redemptionService.js';
+
+const svc = makeEntitlementService();
+const redemptions = makeRedemptionService();
+
+let admin, agent;
+let partner, offer, campaignA, activationA;
+let phoneSeq = 95000000;
+const freshPhone = () => `+65${phoneSeq++}`;
+
+async function makeVerifiedProspect(phone, overrides = {}) {
+  return Prospect.create({
+    firstName: 'Void', lastName: 'Holder', phone,
+    email: `void-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@test.com`,
+    leadSource: 'website', campaignId: campaignA.id, assignedAgentId: agent.user.id,
+    sourceMetadata: { phoneVerifiedAt: new Date().toISOString() },
+    ...overrides,
+  });
+}
+
+beforeAll(async () => {
+  await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  agent = await createTestUser({ role: 'agent' });
+  partner = await PartnerOrganisation.create({
+    tradingName: 'Void Test Studio', normalizedName: 'void test studio', createdBy: admin.user.id,
+  });
+  campaignA = await createTestCampaign(admin.user.id, { name: 'Void Campaign A' });
+  offer = await RewardOffer.create({
+    partnerOrganisationId: partner.id, title: 'Free Void Trial',
+    committedQuantity: 200, allocatedQuantity: 150, status: 'active',
+    claimExpiryDays: 30, redemptionExpiryDays: 90, createdBy: admin.user.id,
+  });
+  activationA = await Activation.create({
+    partnerOrganisationId: partner.id, rewardOfferId: offer.id, campaignId: campaignA.id,
+    campaignNameSnapshot: campaignA.name, allocatedQuantity: 60, status: 'active',
+    unlockPolicy: 'agent_unlock', createdBy: admin.user.id,
+  });
+});
+
+afterAll(async () => { await closeDb(); });
+
+async function issueUnlockRedeem(phone) {
+  const p = await makeVerifiedProspect(phone);
+  // The raw presentation token is returned ONCE at issue (hashed at rest), so
+  // read it off the issue RESULT, not the entitlement instance.
+  const issued = await svc.issueForProspect(p);
+  const unlock = await svc.unlockEntitlement({ presentationToken: issued.presentationToken }, admin.user, 'manual');
+  await redemptions.complete(unlock.voucherToken, {}, admin.user);
+  return issued.entitlement;
+}
+
+describe('void a redeemed reward frees the phone slot', () => {
+  test('redeemed blocks a re-issue; voiding the redemption frees the slot', async () => {
+    const phone = freshPhone();
+    const first = await issueUnlockRedeem(phone);
+    expect((await RewardEntitlement.findByPk(first.id)).status).toBe('redeemed');
+
+    // Slot is pinned: a second signup on the same phone/activation is blocked.
+    const p2 = await makeVerifiedProspect(phone, { campaignId: null });
+    const blocked = await svc.issueForProspect(p2, { activationId: activationA.id });
+    expect(blocked.reason).toBe('duplicate_phone');
+
+    // Void = reverse the redemption (what the ops Void button calls).
+    const redemption = await Redemption.findOne({ where: { entitlementId: first.id } });
+    expect(redemption).toBeTruthy();
+    await redemptions.reverse(redemption.id, admin.user, 'testing — free the slot');
+
+    // Entitlement is now cancelled → outside the partial-unique set.
+    expect((await RewardEntitlement.findByPk(first.id)).status).toBe('cancelled');
+    expect((await Redemption.findByPk(redemption.id)).status).toBe('reversed');
+
+    // The phone can earn a NEW reward on the same activation.
+    const p3 = await makeVerifiedProspect(phone, { campaignId: null });
+    const reissued = await svc.issueForProspect(p3, { activationId: activationA.id });
+    expect(reissued.reason).toBeNull();
+    expect(reissued.entitlement.activationId).toBe(activationA.id);
+    expect(reissued.entitlement.phoneKey).toBe(phoneKeyOf(phone));
+  });
+
+  test('listEntitlements surfaces redemptionId on the redeemed row (drives the Void button)', async () => {
+    const phone = freshPhone();
+    const ent = await issueUnlockRedeem(phone);
+    const { entitlements } = await svc.listEntitlements({ search: phone });
+    const row = entitlements.find((r) => r.id === (ent.id));
+    expect(row).toBeTruthy();
+    expect(row.status).toBe('redeemed');
+    expect(row.redemptionId).toBeTruthy();
+    expect(row.redemptionReversed).toBe(false);
+    // PII posture unchanged: phone masked, email stripped.
+    expect(row.prospect.phone).toMatch(/^••••\d{4}$/);
+    expect(row.prospect.email).toBeUndefined();
+  });
+});

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -353,6 +353,14 @@ export const redeemOpsApi = {
     const res = await apiClient.patch(`/redeem-ops/entitlements/${id}/cancel`, { reason });
     return res.data;
   },
+  async reverseRedemption(redemptionId, { reason } = {}) {
+    // Voids a REDEEMED reward: reverses the redemption (terminal) and cancels
+    // the entitlement, which frees the one-live-reward-per-phone slot so the
+    // number can earn a new reward on that activation. Audited; requires the
+    // redemptions.override capability + a non-empty reason.
+    const res = await apiClient.post(`/redeem-ops/redemptions/${redemptionId}/reverse`, { reason });
+    return res.data;
+  },
   async verifyVoucher(token) {
     const res = await apiClient.post('/redeem-ops/redemptions/verify', { token });
     return res.data;

--- a/src/pages/redeemops/RedemptionsPage.jsx
+++ b/src/pages/redeemops/RedemptionsPage.jsx
@@ -94,6 +94,11 @@ export default function RedemptionsPage() {
   // { entitlement } — voids the reward; requires a reason (audited server-side).
   const [cancelDialog, setCancelDialog] = useState(null);
   const [cancelReason, setCancelReason] = useState('');
+  // { entitlement } — voids a REDEEMED reward by reversing its redemption
+  // (terminal) so the one-live-reward-per-phone slot frees. Reason required.
+  const [voidDialog, setVoidDialog] = useState(null);
+  const [voidReason, setVoidReason] = useState('');
+  const canOverrideRedemption = hasCapability(user, 'redemptions.override');
   const [scanOpen, setScanOpen] = useState(false);
   // presentationToken pending an explicit "Activate" confirm after a pass scan.
   const [activateToken, setActivateToken] = useState(null);
@@ -158,6 +163,17 @@ export default function RedemptionsPage() {
       queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'entitlements'] });
     },
     onError: (err) => toast.error('Cancel failed', { description: err.message }),
+  });
+
+  const voidMutation = useMutation({
+    mutationFn: ({ redemptionId, reason }) => redeemOpsApi.reverseRedemption(redemptionId, { reason }),
+    onSuccess: () => {
+      toast.success('Redemption voided — the reward is cancelled and the phone can earn a new one');
+      setVoidDialog(null);
+      setVoidReason('');
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'entitlements'] });
+    },
+    onError: (err) => toast.error('Void failed', { description: err.message }),
   });
 
   const verifyMutation = useMutation({
@@ -307,6 +323,23 @@ export default function RedemptionsPage() {
         Cancel
       </Button>
     ) : null;
+    // Void undoes a REDEEMED reward: reverses the redemption (terminal) so the
+    // one-live-reward-per-phone slot frees. Gated on redemptions.override (the
+    // same capability the reverse route requires) and a live, not-yet-reversed
+    // redemption id from the list.
+    const voidButton = e.status === 'redeemed' && canOverrideRedemption
+      && e.redemptionId && !e.redemptionReversed ? (
+        <Button
+          size="sm"
+          variant="ghost"
+          className="text-destructive hover:text-destructive"
+          aria-label={`Void redemption — ${holderName}`}
+          disabled={voidMutation.isPending}
+          onClick={() => { setVoidReason(''); setVoidDialog({ entitlement: e }); }}
+        >
+          Void
+        </Button>
+      ) : null;
     return (
       <div
         key={e.id}
@@ -355,6 +388,7 @@ export default function RedemptionsPage() {
           )}
           {unlockButton}
           {cancelButton}
+          {voidButton}
         </span>
       </div>
     );
@@ -744,6 +778,53 @@ export default function RedemptionsPage() {
               onClick={() => cancelMutation.mutate({ id: cancelDialog.entitlement.id, reason: cancelReason.trim() })}
             >
               {cancelMutation.isPending ? 'Cancelling…' : 'Cancel reward'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Void — reverses a REDEEMED redemption. Destructive + reason-gated (audited). */}
+      <Dialog
+        open={!!voidDialog}
+        onOpenChange={(open) => {
+          // Same mid-flight guard as Cancel: the reverse is irreversible, so a
+          // dialog vanishing while the POST runs must not read as "aborted".
+          if (!open && !voidMutation.isPending) { setVoidDialog(null); setVoidReason(''); }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Void this redeemed reward?</DialogTitle>
+            <DialogDescription>
+              {[voidDialog?.entitlement?.prospect?.firstName, voidDialog?.entitlement?.prospect?.lastName]
+                .filter(Boolean).join(' ') || 'The customer'}
+              {"'s reward is already redeemed. Voiding reverses that redemption"}
+              {' and cancels the reward, so this phone number can earn a new one on'}
+              {' this activation. The redemption record is kept and marked reversed'}
+              {' (audited). This cannot be undone.'}
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            value={voidReason}
+            onChange={(ev) => setVoidReason(ev.target.value)}
+            placeholder="Reason (required) — e.g. testing, mistaken redemption, customer request"
+            aria-label="Reason for voiding this redemption"
+            autoFocus
+          />
+          <DialogFooter>
+            <Button
+              variant="outline"
+              disabled={voidMutation.isPending}
+              onClick={() => { setVoidDialog(null); setVoidReason(''); }}
+            >
+              Keep it
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={!voidReason.trim() || voidMutation.isPending}
+              onClick={() => voidMutation.mutate({ redemptionId: voidDialog.entitlement.redemptionId, reason: voidReason.trim() })}
+            >
+              {voidMutation.isPending ? 'Voiding…' : 'Void redemption'}
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## Why

Cancel is eligible/issued-only, so a **redeemed** entitlement pinned the one-live-reward-per-phone slot (`uq_re_activation_phone` covers eligible/issued/redeemed) with no way to clear it — e.g. 96989089's redeemed voucher on the sole Pet Hotel activation, which currently blocks that number from earning a new Pet Hotel reward.

## What

The reverse-redemption path already existed end-to-end (`redemptionService.reverse` → entitlement cancelled; route `POST /redemptions/:id/reverse`, cap `redemptions.override`) — it just wasn't surfaced in the console.

- **`listEntitlements`**: include the backing `Redemption` (via the `hasOne('redemption')` assoc from PR A) and surface `redemptionId` + `redemptionReversed` on the row. PII posture unchanged — phone masked, email stripped.
- **api**: `reverseRedemption(redemptionId, { reason })`.
- **RedemptionsPage**: a **Void** action on redeemed rows, gated on `redemptions.override` + a live non-reversed `redemptionId`, with a reason-required confirm dialog and the same mid-flight guard as Cancel.

Voiding reverses the redemption (**kept**, marked `reversed` — audited) and cancels the entitlement, dropping it out of the partial-unique set so the phone can earn a new reward on that activation. **Inventory is intentionally not returned** — matches the shipped `reverse()` semantics (the reward was physically delivered then clawed back; re-fulfilment is a manual re-issue). Flagged here in case you'd prefer stock to return on void — easy to add, but it's a policy call and I kept the audited existing behavior.

## Test

`redeemOpsVoidRedemption`: redeemed blocks a re-issue → void → slot frees + re-issue succeeds; list row carries `redemptionId`. Full backend **3695 passed** (6 pre-existing failures unchanged); eslint + permission-drift green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrXgaygxd7V5bgctd1rqV8