### PR TITLE
fix(redeem-ops): retry WhatsApp sends + WhatsApp resend (voucher lost to a transient blip)

### DIFF
--- a/backend/src/services/redeemOps/whatsappService.js
+++ b/backend/src/services/redeemOps/whatsappService.js
@@ -110,11 +110,45 @@ function cardWordmark() {
   return 'Redeem.';
 }
 
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
 export function makeWhatsappService(overrides = {}) {
   const d = {
     RewardOffer, logger, QRCode, renderQrCard: renderQrCardPng,
-    fetch: (...args) => fetch(...args), ...overrides,
+    fetch: (...args) => fetch(...args), sleep, ...overrides,
   };
+
+  /**
+   * Graph API fetch with bounded retry on TRANSIENT failures only — a network
+   * throw ("fetch failed": no response received, so the request very likely
+   * never reached Meta) or a 5xx. 4xx (template/permission/bad-request) is
+   * deterministic and returned as-is for the caller to receipt. This closes
+   * the gap that silently lost a voucher WhatsApp on a single connection blip
+   * while email went through (prod, 2026-07-20): the send was fire-and-forget
+   * with no retry.
+   */
+  async function graphFetch(url, opts, { label, attempts = 3 } = {}) {
+    let lastErr;
+    for (let i = 1; i <= attempts; i += 1) {
+      try {
+        const res = await d.fetch(url, opts);
+        if (res.status >= 500 && i < attempts) {
+          d.logger.warn('redeem_ops.whatsapp.retry_5xx', { label, status: res.status, attempt: i });
+          await d.sleep(300 * i);
+          continue;
+        }
+        return res; // ok or 4xx — caller decides
+      } catch (err) {
+        lastErr = err;
+        if (i < attempts) {
+          d.logger.warn('redeem_ops.whatsapp.retry_network', { label, error: err?.message, attempt: i });
+          await d.sleep(300 * i);
+          continue;
+        }
+      }
+    }
+    throw lastErr;
+  }
 
   async function offerContextOf(entitlement) {
     try {
@@ -142,11 +176,11 @@ export function makeWhatsappService(overrides = {}) {
     form.append('messaging_product', 'whatsapp');
     form.append('type', 'image/png');
     form.append('file', new Blob([buffer], { type: 'image/png' }), 'reward-qr.png');
-    const res = await d.fetch(`https://graph.facebook.com/${META_GRAPH_VERSION}/${phoneId}/media`, {
+    const res = await graphFetch(`https://graph.facebook.com/${META_GRAPH_VERSION}/${phoneId}/media`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}` },
       body: form,
-    });
+    }, { label: 'media_upload' });
     if (!res.ok) {
       let detail = `HTTP ${res.status}`;
       try {
@@ -217,11 +251,11 @@ export function makeWhatsappService(overrides = {}) {
         },
       };
 
-      const res = await d.fetch(`https://graph.facebook.com/${META_GRAPH_VERSION}/${phoneId}/messages`, {
+      const res = await graphFetch(`https://graph.facebook.com/${META_GRAPH_VERSION}/${phoneId}/messages`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
-      });
+      }, { label: 'message_send' });
       if (!res.ok) {
         let detail = `HTTP ${res.status}`;
         try {

--- a/backend/src/tests/whatsappService.test.js
+++ b/backend/src/tests/whatsappService.test.js
@@ -66,8 +66,27 @@ function enableWithCreds() {
 }
 
 function makeSvc({ fetch, qr = qrRecorder(), card = cardRecorder(), RewardOffer = offerFake } = {}) {
-  return makeWhatsappService({ RewardOffer, fetch, QRCode: qr, renderQrCard: card, logger: silentLogger });
+  // Inject a no-op sleep so graphFetch's backoff doesn't slow tests.
+  return makeWhatsappService({ RewardOffer, fetch, QRCode: qr, renderQrCard: card, logger: silentLogger, sleep: async () => {} });
 }
+
+/**
+ * Sequenced fetch fake where each response may be a thrown error (network) or
+ * a { ok/status/json } object. Records call urls so retries are observable.
+ */
+function scriptedFetch(script) {
+  const calls = [];
+  const fn = async (url, opts) => {
+    calls.push({ url, opts });
+    const step = script[Math.min(calls.length - 1, script.length - 1)];
+    if (step instanceof Error) throw step;
+    return step;
+  };
+  fn.calls = calls;
+  return fn;
+}
+const mediaCalls = (f) => f.calls.filter((c) => String(c.url).endsWith('/media')).length;
+const msgCalls = (f) => f.calls.filter((c) => String(c.url).endsWith('/messages')).length;
 
 describe('waRecipient — Graph API recipient normalization', () => {
   it('prefixes 65 onto bare 8-digit SG mobiles', () => {
@@ -280,5 +299,61 @@ describe('failure normalization — never throws', () => {
     const r = await svc.sendReservationWhatsApp({ entitlement, prospect: consented, presentationToken: 'p' });
     expect(r.sent).toBe(true);
     expect(fetch.calls[1].body.template.components[1].parameters[1].text).toBe('your reward');
+  });
+});
+
+describe('graphFetch retry — transient failures self-heal (prod 2026-07-20 voucher miss)', () => {
+  const send = (svc) => svc.sendVoucherWhatsApp({ entitlement, prospect: consented, voucherToken: 'vtok' });
+
+  it('media upload "fetch failed" once → retries and the send completes', async () => {
+    enableWithCreds();
+    // [media throws, media ok, messages ok]
+    const fetch = scriptedFetch([new TypeError('fetch failed'), uploadOk, sendOk]);
+    const svc = makeSvc({ fetch });
+    const r = await send(svc);
+    expect(r.sent).toBe(true);
+    expect(mediaCalls(fetch)).toBe(2); // one retry
+    expect(msgCalls(fetch)).toBe(1);
+  });
+
+  it('message send "fetch failed" once → retries and the send completes', async () => {
+    enableWithCreds();
+    // [media ok, messages throws, messages ok]
+    const fetch = scriptedFetch([uploadOk, new TypeError('fetch failed'), sendOk]);
+    const svc = makeSvc({ fetch });
+    const r = await send(svc);
+    expect(r.sent).toBe(true);
+    expect(msgCalls(fetch)).toBe(2); // one retry
+  });
+
+  it('persistent network failure → exhausts 3 attempts then notify_failed', async () => {
+    enableWithCreds();
+    const fetch = scriptedFetch([new TypeError('fetch failed')]); // always throws
+    const svc = makeSvc({ fetch });
+    const r = await send(svc);
+    expect(r.sent).toBe(false);
+    expect(r.error).toMatch(/fetch failed/);
+    expect(mediaCalls(fetch)).toBe(3); // attempts cap
+  });
+
+  it('4xx (template rejected) is deterministic → NO retry, single message attempt', async () => {
+    enableWithCreds();
+    const reject4xx = { ok: false, status: 400, json: async () => ({ error: { code: 132001, message: 'template does not exist' } }) };
+    const fetch = scriptedFetch([uploadOk, reject4xx]);
+    const svc = makeSvc({ fetch });
+    const r = await send(svc);
+    expect(r.sent).toBe(false);
+    expect(r.error).toMatch(/Meta API: 132001/);
+    expect(msgCalls(fetch)).toBe(1); // no retry on 4xx
+  });
+
+  it('5xx is transient → retries the message send', async () => {
+    enableWithCreds();
+    const err500 = { ok: false, status: 503, json: async () => ({}) };
+    const fetch = scriptedFetch([uploadOk, err500, sendOk]);
+    const svc = makeSvc({ fetch });
+    const r = await send(svc);
+    expect(r.sent).toBe(true);
+    expect(msgCalls(fetch)).toBe(2);
   });
 });

--- a/src/pages/redeemops/RedemptionsPage.jsx
+++ b/src/pages/redeemops/RedemptionsPage.jsx
@@ -143,8 +143,9 @@ export default function RedemptionsPage() {
     mutationFn: ({ id, channel }) => redeemOpsApi.resendEntitlementPass(id, { channel }),
     onSuccess: (res, vars) => {
       queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'entitlements'] });
-      if (vars.channel === 'email') {
-        toast.success(res?.message || 'New pass emailed');
+      if (vars.channel === 'email' || vars.channel === 'whatsapp') {
+        // Both re-queue a fire-and-forget send (no one-time link to show).
+        toast.success(res?.message || (vars.channel === 'whatsapp' ? 'Re-sent on WhatsApp' : 'New pass emailed'));
         setShareDialog(null);
       } else {
         // Show the one-time link bundle — it is not retrievable later.
@@ -373,6 +374,17 @@ export default function RedemptionsPage() {
               onClick={() => setShareDialog({ entitlement: e, mode: 'email', phase: 'confirm' })}
             >
               Resend
+            </Button>
+          )}
+          {canShare && e.whatsappDeliverable && (
+            <Button
+              size="sm"
+              variant="outline"
+              aria-label={`Resend on WhatsApp — ${holderName}`}
+              disabled={resendMutation.isPending}
+              onClick={() => setShareDialog({ entitlement: e, mode: 'whatsapp', phase: 'confirm' })}
+            >
+              WhatsApp
             </Button>
           )}
           {canShare && (
@@ -679,7 +691,9 @@ export default function RedemptionsPage() {
                 <DialogTitle>
                   {shareDialog.mode === 'email'
                     ? (dialogIsVoucher ? 'Resend voucher email?' : 'Resend pass email?')
-                    : 'Create a new share link?'}
+                    : shareDialog.mode === 'whatsapp'
+                      ? (dialogIsVoucher ? 'Resend voucher on WhatsApp?' : 'Resend pass on WhatsApp?')
+                      : 'Create a new share link?'}
                 </DialogTitle>
                 <DialogDescription>
                   This mints a fresh QR/link for{' '}
@@ -698,7 +712,9 @@ export default function RedemptionsPage() {
                 >
                   {resendMutation.isPending
                     ? 'Working…'
-                    : shareDialog.mode === 'email' ? 'Resend email' : 'Create new link'}
+                    : shareDialog.mode === 'email' ? 'Resend email'
+                      : shareDialog.mode === 'whatsapp' ? 'Resend on WhatsApp'
+                        : 'Create new link'}
                 </Button>
               </DialogFooter>
             </>


### PR DESCRIPTION
## Root cause (prod, 2026-07-20)

A customer's reservation **pass** delivered on WhatsApp, but the **voucher** (post-unlock) only reached email. The delivery receipts are conclusive:

| kind | channel | result |
|---|---|---|
| pass | email | notified ✓ |
| pass | whatsapp | notified ✓ |
| voucher | whatsapp | **notify_failed — `fetch failed`** |
| voucher | email | notified ✓ |

`fetch failed` is a connection-level rejection (undici), **not** a Meta template rejection — those surface as `Meta API: <code>` from a 4xx. The voucher went through the identical code path as the pass 47s earlier, so it was a transient network blip. Two gaps made it permanent.

## Fix

1. **Retry on the WA sender.** New `graphFetch` wraps both the media upload and the message POST with bounded retry (3 attempts, linear backoff) on **transient** failures only — a thrown network error or a 5xx. **4xx is never retried** (deterministic — template/permission/bad-request, returned as-is to be receipted). `fetch failed` = no response received ⇒ the request very likely never reached Meta ⇒ retry is safe.
2. **WhatsApp resend in ops.** The Resend UI offered email + copy-link only; the backend already supported `channel: 'whatsapp'`. Added a **WhatsApp** resend button (gated on the row's `whatsappDeliverable`), the confirm copy, and `onSuccess` handling — the recovery path that was missing for exactly this case.

## Tests

+5 (media/message transient self-heal, persistent-failure attempt cap, 4xx no-retry, 5xx retry). whatsapp suite 22/22; full backend **3700 passed** (6 pre-existing failures unchanged); eslint + redeemops vitest green.

## Recovery for the stuck voucher

Once deployed, the customer's issued voucher can be re-pushed from ops → Redemptions → their row → **WhatsApp**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrXgaygxd7V5bgctd1rqV8