### PR TITLE
feat(redeem-ops): Resend dropdown — Email / WhatsApp / Both

### DIFF
--- a/backend/src/controllers/redeemOps/fulfilmentController.js
+++ b/backend/src/controllers/redeemOps/fulfilmentController.js
@@ -52,7 +52,7 @@ export const unlockEntitlement = asyncHandler(async (req, res) => {
 
 export const resendPass = asyncHandler(async (req, res) => {
   const body = validateBody(
-    Joi.object({ channel: Joi.string().valid('email', 'whatsapp', 'link').default('email') }),
+    Joi.object({ channel: Joi.string().valid('email', 'whatsapp', 'both', 'link').default('email') }),
     req.body || {}
   );
   const result = await entitlementService.resendDelivery(
@@ -65,7 +65,9 @@ export const resendPass = asyncHandler(async (req, res) => {
     ? `New ${noun} emailed — the previous ${oldCredential} no longer works.`
     : result.channel === 'whatsapp'
       ? `New ${noun} sent to the customer's WhatsApp — the previous ${oldCredential} no longer works.`
-      : `New ${noun} link created — the previous ${oldCredential} no longer works. Share it with the customer yourself.`;
+      : result.channel === 'both'
+        ? `New ${noun} sent to the customer's email and WhatsApp — the previous ${oldCredential} no longer works.`
+        : `New ${noun} link created — the previous ${oldCredential} no longer works. Share it with the customer yourself.`;
   // The link channel returns a LIVE bearer credential in the body — it must
   // never be cached by any intermediary or the browser.
   res.set('Cache-Control', 'no-store');

--- a/backend/src/services/redeemOps/entitlementService.js
+++ b/backend/src/services/redeemOps/entitlementService.js
@@ -134,8 +134,16 @@ export function makeEntitlementService(overrides = {}) {
    * `skipped` results (no receipt on a skip: nothing was attempted), so a
    * no-email Retell lead still gets its WhatsApp leg — the email guard below
    * deliberately gates only the email leg.
+   *
+   * `channels` selects which legs to fire; it defaults to BOTH so capture,
+   * unlock and the sweep are unchanged. The ops Resend passes a specific set
+   * (email / whatsapp / both) so staff can re-send on exactly the channel(s)
+   * they chose — one token rotation, the same fresh credential on each leg.
    */
-  function queueDelivery({ entitlement, prospect, kind, presentationToken = null, voucherToken = null }) {
+  function queueDelivery({
+    entitlement, prospect, kind, presentationToken = null, voucherToken = null,
+    channels = ['whatsapp', 'email'],
+  }) {
     const args = kind === 'voucher'
       ? { entitlement, prospect, voucherToken }
       : { entitlement, prospect, presentationToken };
@@ -151,9 +159,12 @@ export function makeEntitlementService(overrides = {}) {
       delivery.finally(() => pendingDeliveries.delete(delivery));
     };
 
-    const waFn = kind === 'voucher' ? d.notifyUnlockWa : d.notifyReservationWa;
-    if (typeof waFn === 'function') fire(waFn, 'whatsapp');
+    if (channels.includes('whatsapp')) {
+      const waFn = kind === 'voucher' ? d.notifyUnlockWa : d.notifyReservationWa;
+      if (typeof waFn === 'function') fire(waFn, 'whatsapp');
+    }
 
+    if (!channels.includes('email')) return false;
     const fn = kind === 'voucher' ? d.notifyUnlock : d.notifyReservation;
     if (typeof fn !== 'function' || !canEmailProspect(prospect)) return false;
     fire(fn, 'email');
@@ -534,10 +545,15 @@ export function makeEntitlementService(overrides = {}) {
     }
 
     const prospect = entitlement.prospectId ? await d.Prospect.findByPk(entitlement.prospectId) : null;
-    if (channel === 'email' && !canEmailProspect(prospect)) {
-      throw new AppError('No usable email on file — use the copy-link option instead', 409);
+    // 'both' resends on email AND WhatsApp with one token rotation. Each
+    // requested leg must be deliverable (the ops menu only offers a leg when
+    // its row flag says so, so this is defence-in-depth).
+    const wantEmail = channel === 'email' || channel === 'both';
+    const wantWa = channel === 'whatsapp' || channel === 'both';
+    if (wantEmail && !canEmailProspect(prospect)) {
+      throw new AppError('No usable email on file — use WhatsApp or the copy-link option instead', 409);
     }
-    if (channel === 'whatsapp' && !(waEnabled() && canWhatsAppProspect(prospect))) {
+    if (wantWa && !(waEnabled() && canWhatsAppProspect(prospect))) {
       throw new AppError('WhatsApp delivery is not available for this customer — use email or the copy-link option', 409);
     }
 
@@ -597,6 +613,7 @@ export function makeEntitlementService(overrides = {}) {
       entitlement, prospect, kind,
       presentationToken: kind === 'pass' ? fresh.raw : null,
       voucherToken: kind === 'voucher' ? fresh.raw : null,
+      channels: [wantWa ? 'whatsapp' : null, wantEmail ? 'email' : null].filter(Boolean),
     });
     return { entitlement, kind, channel, emailQueued };
   }

--- a/backend/src/tests/entitlementDeliveryFanout.test.js
+++ b/backend/src/tests/entitlementDeliveryFanout.test.js
@@ -125,3 +125,44 @@ describe('queueDelivery — per-channel fan-out (PR E)', () => {
     expect(events.map((e) => e.metadata.channel).sort()).toEqual(['email', 'whatsapp']);
   });
 });
+
+describe('queueDelivery — channel selection (ops Resend: Email / WhatsApp / Both)', () => {
+  const bothSenders = (events) => makeSvc({
+    events,
+    email: async () => ({ sent: true, to: 's***@example.com' }),
+    wa: async () => ({ sent: true, to: '••••4567' }),
+  });
+
+  it('defaults to BOTH when channels is omitted (capture/unlock/sweep unchanged)', async () => {
+    const events = [];
+    bothSenders(events).queueDelivery({ entitlement, prospect: emailable, kind: 'voucher', voucherToken: 'v' });
+    await flushDeliveries();
+    expect(events.map((e) => e.metadata.channel).sort()).toEqual(['email', 'whatsapp']);
+  });
+
+  it("channels ['email'] fires ONLY email — no WhatsApp leg", async () => {
+    const events = [];
+    const queued = bothSenders(events)
+      .queueDelivery({ entitlement, prospect: emailable, kind: 'voucher', voucherToken: 'v', channels: ['email'] });
+    expect(queued).toBe(true);
+    await flushDeliveries();
+    expect(events.map((e) => e.metadata.channel)).toEqual(['email']);
+  });
+
+  it("channels ['whatsapp'] fires ONLY WhatsApp — no email leg, emailQueued false", async () => {
+    const events = [];
+    const queued = bothSenders(events)
+      .queueDelivery({ entitlement, prospect: emailable, kind: 'voucher', voucherToken: 'v', channels: ['whatsapp'] });
+    expect(queued).toBe(false); // no fresh EMAIL attempt
+    await flushDeliveries();
+    expect(events.map((e) => e.metadata.channel)).toEqual(['whatsapp']);
+  });
+
+  it("channels ['whatsapp','email'] fires both (the 'Both' resend)", async () => {
+    const events = [];
+    bothSenders(events)
+      .queueDelivery({ entitlement, prospect: emailable, kind: 'voucher', voucherToken: 'v', channels: ['whatsapp', 'email'] });
+    await flushDeliveries();
+    expect(events.map((e) => e.metadata.channel).sort()).toEqual(['email', 'whatsapp']);
+  });
+});

--- a/src/pages/redeemops/RedemptionsPage.jsx
+++ b/src/pages/redeemops/RedemptionsPage.jsx
@@ -16,6 +16,9 @@ import {
 } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import {
+  DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem,
+} from '@/components/ui/dropdown-menu';
 import ScanLine from 'lucide-react/icons/scan-line';
 import ChevronDown from 'lucide-react/icons/chevron-down';
 import { RoMobileCard, RoPageHeader, RoTag, prettyEnum } from '@/components/redeemops/ui';
@@ -143,9 +146,11 @@ export default function RedemptionsPage() {
     mutationFn: ({ id, channel }) => redeemOpsApi.resendEntitlementPass(id, { channel }),
     onSuccess: (res, vars) => {
       queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'entitlements'] });
-      if (vars.channel === 'email' || vars.channel === 'whatsapp') {
-        // Both re-queue a fire-and-forget send (no one-time link to show).
-        toast.success(res?.message || (vars.channel === 'whatsapp' ? 'Re-sent on WhatsApp' : 'New pass emailed'));
+      if (vars.channel === 'email' || vars.channel === 'whatsapp' || vars.channel === 'both') {
+        // These re-queue a fire-and-forget send (no one-time link to show).
+        const fallback = vars.channel === 'both' ? 'Re-sent on email + WhatsApp'
+          : vars.channel === 'whatsapp' ? 'Re-sent on WhatsApp' : 'New pass emailed';
+        toast.success(res?.message || fallback);
         setShareDialog(null);
       } else {
         // Show the one-time link bundle — it is not retrievable later.
@@ -365,27 +370,36 @@ export default function RedemptionsPage() {
           <RoTag tone={statusTone(e.status)} size="sm">{statusLabel(e.status)}</RoTag>
         </span>
         <span className="flex flex-wrap items-center gap-1.5 md:justify-end">
-          {canShare && e.emailDeliverable !== false && (
-            <Button
-              size="sm"
-              variant="outline"
-              aria-label={`Resend ${credentialNoun} — ${holderName}`}
-              disabled={resendMutation.isPending}
-              onClick={() => setShareDialog({ entitlement: e, mode: 'email', phase: 'confirm' })}
-            >
-              Resend
-            </Button>
-          )}
-          {canShare && e.whatsappDeliverable && (
-            <Button
-              size="sm"
-              variant="outline"
-              aria-label={`Resend on WhatsApp — ${holderName}`}
-              disabled={resendMutation.isPending}
-              onClick={() => setShareDialog({ entitlement: e, mode: 'whatsapp', phase: 'confirm' })}
-            >
-              WhatsApp
-            </Button>
+          {canShare && (e.emailDeliverable !== false || e.whatsappDeliverable) && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  aria-label={`Resend ${credentialNoun} — ${holderName}`}
+                  disabled={resendMutation.isPending}
+                >
+                  Resend <ChevronDown className="ml-1 h-3.5 w-3.5" aria-hidden="true" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {e.emailDeliverable !== false && (
+                  <DropdownMenuItem onSelect={() => setShareDialog({ entitlement: e, mode: 'email', phase: 'confirm' })}>
+                    Email
+                  </DropdownMenuItem>
+                )}
+                {e.whatsappDeliverable && (
+                  <DropdownMenuItem onSelect={() => setShareDialog({ entitlement: e, mode: 'whatsapp', phase: 'confirm' })}>
+                    WhatsApp
+                  </DropdownMenuItem>
+                )}
+                {e.emailDeliverable !== false && e.whatsappDeliverable && (
+                  <DropdownMenuItem onSelect={() => setShareDialog({ entitlement: e, mode: 'both', phase: 'confirm' })}>
+                    Both
+                  </DropdownMenuItem>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
           )}
           {canShare && (
             <Button
@@ -693,7 +707,9 @@ export default function RedemptionsPage() {
                     ? (dialogIsVoucher ? 'Resend voucher email?' : 'Resend pass email?')
                     : shareDialog.mode === 'whatsapp'
                       ? (dialogIsVoucher ? 'Resend voucher on WhatsApp?' : 'Resend pass on WhatsApp?')
-                      : 'Create a new share link?'}
+                      : shareDialog.mode === 'both'
+                        ? (dialogIsVoucher ? 'Resend voucher on email + WhatsApp?' : 'Resend pass on email + WhatsApp?')
+                        : 'Create a new share link?'}
                 </DialogTitle>
                 <DialogDescription>
                   This mints a fresh QR/link for{' '}
@@ -714,7 +730,8 @@ export default function RedemptionsPage() {
                     ? 'Working…'
                     : shareDialog.mode === 'email' ? 'Resend email'
                       : shareDialog.mode === 'whatsapp' ? 'Resend on WhatsApp'
-                        : 'Create new link'}
+                        : shareDialog.mode === 'both' ? 'Resend on both'
+                          : 'Create new link'}
                 </Button>
               </DialogFooter>
             </>

--- a/src/pages/redeemops/__tests__/RedemptionsPage.test.jsx
+++ b/src/pages/redeemops/__tests__/RedemptionsPage.test.jsx
@@ -62,6 +62,7 @@ const deliverableRow = {
   id: 'e1', status: 'eligible', tokenHint: null,
   prospect: { id: 'p1', firstName: 'Sarah', lastName: 'Tan', phone: '••••1234' },
   emailDeliverable: true,
+  whatsappDeliverable: true,
   delivery: { email: { kind: 'pass', at: '2026-07-16T06:03:00.000Z', ok: true } },
   ...rowBase,
 };
@@ -159,13 +160,33 @@ describe('RedemptionsPage campaign stacks + delivery truth', () => {
       data: { kind: 'pass', channel: 'email', emailQueued: true, entitlement: {} },
     });
     renderPage();
+    // Resend is now a dropdown: open it, pick Email → THEN the confirm dialog.
     await userEvent.click((await screen.findAllByRole('button', { name: /^Resend pass/ }))[0]);
+    await userEvent.click(await screen.findByRole('menuitem', { name: 'Email' }));
     expect(api.resendEntitlementPass).not.toHaveBeenCalled();
     expect(screen.getByText(/stops working immediately/)).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: 'Resend email' }));
     await waitFor(() => expect(api.resendEntitlementPass).toHaveBeenCalledWith('e1', { channel: 'email' }));
     expect(toastMock.success).toHaveBeenCalledWith(expect.stringContaining('no longer works'));
+  });
+
+  it('Resend dropdown offers Both when email + WhatsApp are deliverable → channel:both', async () => {
+    api.resendEntitlementPass.mockResolvedValue({
+      message: "New reservation pass sent to the customer's email and WhatsApp — the previous pass QR/link no longer works.",
+      data: { kind: 'pass', channel: 'both', emailQueued: true, entitlement: {} },
+    });
+    renderPage();
+    await userEvent.click((await screen.findAllByRole('button', { name: /^Resend pass/ }))[0]);
+    // All three channel options are present for a both-deliverable row.
+    expect(await screen.findByRole('menuitem', { name: 'Email' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'WhatsApp' })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Both' }));
+    // Still confirm-gated: nothing fires until the dialog is confirmed.
+    expect(api.resendEntitlementPass).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole('button', { name: 'Resend on both' }));
+    await waitFor(() => expect(api.resendEntitlementPass).toHaveBeenCalledWith('e1', { channel: 'both' }));
+    expect(toastMock.success).toHaveBeenCalledWith(expect.stringContaining('email and WhatsApp'));
   });
 
   it('link channel shows the one-time bundle with the WhatsApp deep link', async () => {


### PR DESCRIPTION
Merges the row's separate **Resend** (email) and **WhatsApp** buttons into one **Resend ▾** dropdown with **Email / WhatsApp / Both**, per request.

## The non-obvious part: "Both" is a backend channel, not two client calls

Each resend **rotates the credential token** (invalidating the old QR) and is under a 60s cooldown — so firing two client-side resends would (a) 429 on the second and (b) leave the first channel's QR dead on arrival once the second rotation lands. So Both is one server operation:

- `queueDelivery` gains a `channels` filter, **defaulting to both** so capture / unlock / sweep are byte-unchanged. (It previously *always* fanned out to both, which meant the resend `channel` param only drove the guard + cooldown and never what actually sent — "resend email only" didn't really exist until now.)
- `resendDelivery` maps `channel` → the exact leg(s), **one token rotation**, same fresh credential on each chosen leg. `both` requires both legs deliverable.
- Controller accepts `channel: 'both'`.

## UI

`Resend ▾` dropdown; each option opens the **existing confirm dialog** (rotation stays confirm-gated — a menu pick never silently kills the customer's QR); Both gets its own title/label + success toast. Menu options are gated per the row's `emailDeliverable` / `whatsappDeliverable` flags. Copy link stays its own button.

## Tests

+4 backend channel-selection (default-both, email-only, whatsapp-only, both) + frontend updated for the dropdown→confirm flow and a new Both→`channel:'both'` case. Full backend **3704 passed** (6 pre-existing unchanged); redeemops vitest **28/28**; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrXgaygxd7V5bgctd1rqV8