### PR TITLE
fix(redeem-ops): resend confirm — clarify it invalidates all prior copies

### DIFF
--- a/src/pages/redeemops/RedemptionsPage.jsx
+++ b/src/pages/redeemops/RedemptionsPage.jsx
@@ -712,12 +712,17 @@ export default function RedemptionsPage() {
                         : 'Create a new share link?'}
                 </DialogTitle>
                 <DialogDescription>
-                  This mints a fresh QR/link for{' '}
+                  This mints a fresh {dialogIsVoucher ? 'voucher code/QR' : 'pass QR/link'} for{' '}
                   {[shareDialog.entitlement?.prospect?.firstName, shareDialog.entitlement?.prospect?.lastName]
                     .filter(Boolean).join(' ') || 'the customer'}
-                  {' — the previous '}
-                  {dialogIsVoucher ? 'voucher code/QR' : 'pass QR/link'}
-                  {' stops working immediately.'}
+                  {'. Every earlier copy — including any already sent by email or WhatsApp — stops working immediately.'}
+                  {(shareDialog.mode === 'email' || shareDialog.mode === 'whatsapp') && (
+                    <>
+                      {' The new one goes out on '}
+                      {shareDialog.mode === 'email' ? 'email' : 'WhatsApp'}
+                      {' only — pick '}<strong>Both</strong>{' to keep it working on both channels.'}
+                    </>
+                  )}
                 </DialogDescription>
               </DialogHeader>
               <DialogFooter>


### PR DESCRIPTION
A single-channel resend rotates the **one shared credential** (the raw token is never stored — only its hash — so any resend *must* mint a fresh token), invalidating the customer's earlier copy on **every** channel including an already-emailed QR, while re-delivering only on the chosen channel. The prior copy ("the previous pass QR/link stops working immediately") read as channel-specific next to a "Resend on WhatsApp" button. Now the dialog states plainly that every earlier copy — email or WhatsApp — stops working, and a single-channel resend nudges toward **Both** to keep the customer covered.

Copy-only. RedemptionsPage vitest 10/10, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrXgaygxd7V5bgctd1rqV8