### PR TITLE
feat(consent): wording-era registry + consent_copy_version intake (agree-all backend)

### DIFF
--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -243,6 +243,13 @@ export const schemas = {
     // client; this flag only records that the person ticked the box. That evidence is what
     // releases an otherwise-held DNC-registered lead (services/dncConsent.hasValidDncConsent).
     consent_dnc: Joi.boolean().optional(),
+    // Which contact-consent wording the form actually displayed. '2026-07-21' =
+    // the mandatory agree-all block (CampaignSignupForm rework); absent = the
+    // legacy three-checkbox copy (MarketplaceFlow + pre-rework cached bundles).
+    // Strict valid() enum, not free string — the consent ledger maps this label
+    // to pinned copy/hash evidence (services/contactConsent.js), and an unknown
+    // label must never mint evidence.
+    consent_copy_version: Joi.string().valid('2026-07-21').optional(),
     // Marketplace flow extras (redeem.sg /flow/:slug — docs/plans/
     // redeem-marketplace-v2.md Phase 4). Whitelisted here (this endpoint runs
     // stripUnknown, so an unlisted key is silently dropped); prospectService

--- a/backend/src/services/consentService.js
+++ b/backend/src/services/consentService.js
@@ -6,7 +6,8 @@ import {
 import { logger } from '../utils/logger.js';
 import { phoneVerificationIsCurrent, E164_RE } from './consumerService.js';
 import {
-  CONTACT_CONSENT_VERSION, CONTACT_CONSENT_COPY_HASH, CONTACT_CONSENT_CHANNELS,
+  CONTACT_CONSENT_VERSION, CONTACT_CONSENT_CHANNELS,
+  CONTACT_CONSENT_VERSIONS, isKnownConsentCopyVersion,
 } from './contactConsent.js';
 
 /**
@@ -62,6 +63,7 @@ export function makeConsentService(overrides = {}) {
   async function recordCaptureConsentEventsTx(outerTx, {
     consumerId, prospectId, campaignId = null, sourceUrl = null, verified = false,
     contact,            // boolean | undefined — record BOTH true and explicit false
+    copyVersion,        // contact wording-era label from the payload | undefined => legacy
     terms,              // boolean | undefined — the required campaign T&C tick
     externalConsent,    // consentMetadata.external evidence | null
     dncConsent,         // consentMetadata.dnc evidence | null
@@ -77,10 +79,16 @@ export function makeConsentService(overrides = {}) {
       };
       const rows = [];
       if (contact !== undefined) {
+        // Wording era: the payload's consent_copy_version when it's a known
+        // registry label (agree-all block), else the legacy default — so an
+        // unknown/absent version can never mint mislabeled evidence.
+        const version = isKnownConsentCopyVersion(copyVersion)
+          ? copyVersion : CONTACT_CONSENT_VERSION;
+        const era = CONTACT_CONSENT_VERSIONS[version];
         rows.push({
           ...base, id: randomUUID(), kind: 'contact', granted: contact === true,
-          channels: [...CONTACT_CONSENT_CHANNELS], version: CONTACT_CONSENT_VERSION,
-          metadata: { copyHash: CONTACT_CONSENT_COPY_HASH },
+          channels: [...era.channels], version,
+          metadata: { copyHash: era.copyHash, scope: era.scope },
         });
       }
       if (terms !== undefined) {

--- a/backend/src/services/contactConsent.js
+++ b/backend/src/services/contactConsent.js
@@ -5,33 +5,73 @@ import { createHash } from 'crypto';
  * upgrade of the bare `sourceMetadata.consent_contact` boolean, mirroring
  * externalConsent.js / dncConsent.js.
  *
- * The checkbox is DEFAULT-TICKED (opt-out model) on both capture surfaces, so
- * an untick is an explicit act — the ledger records granted:false too.
+ * TWO wording eras coexist, selected per capture by the payload's
+ * `consent_copy_version` (absent => legacy):
  *
- * PURPOSE SCOPE: the live copy grants contact "for the purposes identified in
- * this form" (CampaignSignupForm) / "about this redemption" (MarketplaceFlow)
- * — i.e. CAMPAIGN-scoped. This version label + copy hash pin exactly what was
- * agreed; a future GLOBAL opt-in ("keep me posted about new offers") must use
- * a NEW version and campaignId:null events, never a reinterpretation of these.
+ *  - '2026-07-20' LEGACY (campaign-scoped, default-ticked opt-out): the old
+ *    three-checkbox surfaces. Still what MarketplaceFlow shows, so it stays
+ *    the default for any capture that doesn't declare a version. Its copy
+ *    constant is a paraphrase-era artifact — NOT byte-identical to the old
+ *    on-screen wording — kept verbatim so the hash pinned on already-recorded
+ *    events stays meaningful. Do not "fix" it; the era is closed.
+ *  - '2026-07-21' AGREE-ALL (brand-wide, mandatory): the single mandatory
+ *    agreement block (CampaignSignupForm). Submitting is impossible without
+ *    agreeing, so `granted` is always true in this era. The copy below MUST
+ *    stay BYTE-IDENTICAL to CONSENT_COPY.clauseContact in
+ *    src/lib/consentCopy.js — enforced by
+ *    src/lib/__tests__/consentCopy.lockstep.test.js.
+ *
+ * SCOPE: the '2026-07-21' wording grants contact + marketing about "other
+ * Redeem offers" (brand-wide), but ledger events remain CAMPAIGN-scoped —
+ * minting campaignId:null GLOBAL grants from this copy is the separate
+ * "globalev" deliverable (see consentService rules). `scope` is recorded in
+ * event metadata only.
  */
 
+const sha256 = (s) => createHash('sha256').update(s).digest('hex');
+
 /**
- * Current contact-consent wording version. BUMP (to the date the copy
- * changes) whenever the consent_contact checkbox wording on either capture
- * surface is edited (CampaignSignupForm.jsx / MarketplaceFlow.jsx).
+ * LEGACY contact-consent wording version — the default for captures that send
+ * no `consent_copy_version` (MarketplaceFlow, pre-rework cached bundles) and
+ * the label `applyUnsubscribe` stamps on global revokes.
  */
 export const CONTACT_CONSENT_VERSION = '2026-07-20';
 
-/**
- * Canonical digest of the consent copy in force for CONTACT_CONSENT_VERSION.
- * Snapshot of the LeadCapture wording (the marketplace variant is narrower);
- * stored in event metadata so evidence survives future copy edits verbatim.
- */
+/** Canonical legacy digest source — see the era note in the header. */
 export const CONTACT_CONSENT_COPY =
   'I consent to being contacted (phone call, text or email) using the particulars provided, for the purposes identified in this form.';
-export const CONTACT_CONSENT_COPY_HASH = createHash('sha256')
-  .update(CONTACT_CONSENT_COPY)
-  .digest('hex');
+export const CONTACT_CONSENT_COPY_HASH = sha256(CONTACT_CONSENT_COPY);
 
-/** Channels the ticked box covers — keep in sync with the checkbox copy. */
+/** Channels both eras' wording covers — keep in sync with the on-screen copy. */
 export const CONTACT_CONSENT_CHANNELS = Object.freeze(['phone', 'text', 'email']);
+
+/** AGREE-ALL era (mandatory single-block consent, CampaignSignupForm). */
+export const AGREE_ALL_CONSENT_VERSION = '2026-07-21';
+export const AGREE_ALL_CONTACT_COPY =
+  'MKTR PTE. LTD. ("Redeem") may contact me by phone call, text message (including WhatsApp) and email, using the details I provide, about this campaign and about other Redeem offers. I can unsubscribe from marketing at any time.';
+
+/**
+ * The registry the ledger writes from: version label -> the exact evidence
+ * (copy, hash, channels, scope) in force for that era. Adding a wording era =
+ * new entry + new version string; never edit a closed era's copy.
+ */
+export const CONTACT_CONSENT_VERSIONS = Object.freeze({
+  [CONTACT_CONSENT_VERSION]: Object.freeze({
+    copy: CONTACT_CONSENT_COPY,
+    copyHash: CONTACT_CONSENT_COPY_HASH,
+    channels: CONTACT_CONSENT_CHANNELS,
+    scope: 'campaign',
+  }),
+  [AGREE_ALL_CONSENT_VERSION]: Object.freeze({
+    copy: AGREE_ALL_CONTACT_COPY,
+    copyHash: sha256(AGREE_ALL_CONTACT_COPY),
+    channels: CONTACT_CONSENT_CHANNELS,
+    scope: 'brand',
+  }),
+});
+
+/** True only for version labels the registry can turn into pinned evidence. */
+export function isKnownConsentCopyVersion(version) {
+  return typeof version === 'string'
+    && Object.prototype.hasOwnProperty.call(CONTACT_CONSENT_VERSIONS, version);
+}

--- a/backend/src/services/externalConsent.js
+++ b/backend/src/services/externalConsent.js
@@ -74,6 +74,24 @@ export function extractExternalConsent(prospectOrMeta) {
 export const THIRD_PARTY_CONSENT_VERSION = '2026-06-26';
 
 /**
+ * AGREE-ALL era (mandatory single-block consent, CampaignSignupForm since
+ * 2026-07-21): the third-party clause is part of the one required agreement,
+ * shown only when the campaign's `thirdPartyDisclosure` toggle is on. The copy
+ * MUST stay BYTE-IDENTICAL to CONSENT_COPY.clauseThirdParty in
+ * src/lib/consentCopy.js — enforced by
+ * src/lib/__tests__/consentCopy.lockstep.test.js.
+ */
+export const AGREE_ALL_THIRD_PARTY_VERSION = '2026-07-21';
+export const AGREE_ALL_THIRD_PARTY_COPY =
+  'This campaign is sponsored: my contact details will be shared with a partner licensed financial-advisory representative — who may be from a third-party agency — who may contact me about relevant financial products and services.';
+
+/** Version labels buildExternalConsentEvidence may stamp (unknown => default). */
+const KNOWN_THIRD_PARTY_VERSIONS = Object.freeze([
+  THIRD_PARTY_CONSENT_VERSION,
+  AGREE_ALL_THIRD_PARTY_VERSION,
+]);
+
+/**
  * Contact channels the third-party-disclosure consent covers. Recorded on every
  * captured consent so a downstream buyer-agent knows how the person agreed to be
  * reached. Keep in sync with what the privacy policy / consent copy actually says.
@@ -90,12 +108,18 @@ export const THIRD_PARTY_CONSENT_CHANNELS = Object.freeze(['phone', 'whatsapp', 
  * satisfy hasValidExternalConsent().
  *
  * @param {boolean} consented - the consent_third_party flag from the form.
- * @param {{ sourceUrl?: string, at?: string }} [opts] - sourceUrl: capture-page URL
- *   (audit breadcrumb); at: ISO timestamp (missing/unparseable falls back to now).
+ * @param {{ sourceUrl?: string, at?: string, version?: string }} [opts] - sourceUrl:
+ *   capture-page URL (audit breadcrumb); at: ISO timestamp (missing/unparseable
+ *   falls back to now); version: wording-era label from the payload's
+ *   consent_copy_version — stamped only when it's a KNOWN era, else the default.
  * @returns {{version:string,consentedAt:string,channels:string[],sourceUrl?:string}|null}
  */
 export function buildExternalConsentEvidence(consented, opts = {}) {
   if (consented !== true) return null;
+
+  const version = KNOWN_THIRD_PARTY_VERSIONS.includes(opts.version)
+    ? opts.version
+    : THIRD_PARTY_CONSENT_VERSION;
 
   // Use a caller-supplied timestamp only if it actually parses; otherwise fall back to
   // now — so the returned evidence is ALWAYS valid per hasValidExternalConsent().
@@ -107,7 +131,7 @@ export function buildExternalConsentEvidence(consented, opts = {}) {
       : undefined;
 
   return {
-    version: THIRD_PARTY_CONSENT_VERSION,
+    version,
     consentedAt,
     channels: [...THIRD_PARTY_CONSENT_CHANNELS],
     ...(sourceUrl ? { sourceUrl } : {}),

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -219,6 +219,10 @@ export function makeProspectService(overrides = {}) {
     // from the server-side check, never the client). Recorded as consentMetadata.dnc, never
     // a CAPI signal.
     const consentDnc = safeBody.consent_dnc;
+    // Wording-era label from the form ('2026-07-21' agree-all block; absent =
+    // legacy three-checkbox copy). Joi-whitelisted enum; the ledger + external
+    // evidence builders map it to pinned copy/hash (contactConsent.js registry).
+    const consentCopyVersion = safeBody.consent_copy_version;
 
     // Quiz funnel submission (re-scored server-side after the campaign loads),
     // ad attribution (UTM) and referral identity (the sharer's prospect UUID from
@@ -239,6 +243,7 @@ export function makeProspectService(overrides = {}) {
       eventId: _e, fbp: _p, fbc: _c, eventSourceUrl: _u,
       registrationEventId: _re, ttclid: _tc, ttp: _tp,
       consent_contact: _cc, consent_terms: _ct, consent_third_party: _ctp, consent_dnc: _cd,
+      consent_copy_version: _ccv,
       // consentMetadata is SERVER-authoritative — the third-party-consent evidence is
       // built below from consent_third_party. Drop any client-supplied value so external
       // consent can never be forged via the body (defence-in-depth beyond route stripUnknown).
@@ -272,6 +277,7 @@ export function makeProspectService(overrides = {}) {
       ...(ttp ? { ttp } : {}),
       ...(consentContact !== undefined ? { consent_contact: consentContact } : {}),
       ...(consentTerms !== undefined ? { consent_terms: consentTerms } : {}),
+      ...(consentCopyVersion !== undefined ? { consent_copy_version: consentCopyVersion } : {}),
       ...(Object.keys(utm).length > 0 ? { utm } : {}),
     };
     if (Object.keys(capiSourceMetadata).length > 0) {
@@ -288,6 +294,9 @@ export function makeProspectService(overrides = {}) {
     // below (hasValidExternalConsent). Unticked => null => nothing written => never external.
     const externalConsent = d.buildExternalConsentEvidence(consentThirdParty, {
       sourceUrl: eventSourceUrl,
+      // Agree-all submissions pin the disclosure clause's wording era; the
+      // builder whitelists internally, so a legacy/absent label keeps the default.
+      version: consentCopyVersion,
     });
     if (externalConsent) {
       incoming.consentMetadata = { ...(incoming.consentMetadata || {}), external: externalConsent };
@@ -908,6 +917,7 @@ export function makeProspectService(overrides = {}) {
         sourceUrl: eventSourceUrl || null,
         verified: otpMarkerLive,
         contact: consentContact,
+        copyVersion: consentCopyVersion,
         terms: consentTerms,
         externalConsent,
         dncConsent,

--- a/backend/src/utils/publicDesignConfig.js
+++ b/backend/src/utils/publicDesignConfig.js
@@ -25,8 +25,9 @@ const PUBLIC_PASSTHROUGH_KEYS = [
   'brandWordmark', 'brandFooter', 'regulatoryFooter', 'termsContent', 'customerHost',
   // Form contract (flat production keys; fieldOrder is string[] OR row objects)
   'fieldOrder', 'visibleFields', 'requiredFields',
-  // Flow gates + channel
-  'sgPrOnly', 'excludeAdvisors', 'dncCheckAtSubmit', 'otpChannel',
+  // Flow gates + channel (thirdPartyDisclosure: agree-all consent block's
+  // sponsored-campaign clause toggle — default ON, so only `false` matters)
+  'sgPrOnly', 'excludeAdvisors', 'dncCheckAtSubmit', 'otpChannel', 'thirdPartyDisclosure',
   // Funnel variants (public quiz/guided-review campaigns render from these)
   'quiz', 'guidedReview',
   // Marketplace content (clamped on save by normalizeMarketplaceContent)
@@ -119,6 +120,9 @@ function buildPublicDesignConfigV2(dc) {
 
   if (dc.quiz !== undefined) out.quiz = dc.quiz;
   if (dc.guidedReview !== undefined) out.guidedReview = dc.guidedReview;
+  // Agree-all consent block: sponsored-campaign disclosure toggle (top-level in
+  // v1 AND v2 by design — the clamps pass unknown top-level keys through).
+  if (dc.thirdPartyDisclosure !== undefined) out.thirdPartyDisclosure = dc.thirdPartyDisclosure;
 
   const distribution = { host: dc.distribution?.host === 'mktr' ? 'mktr' : 'redeem' };
   const marketplace = pick(dc.distribution?.marketplace, V2_PUBLIC_MARKETPLACE_KEYS);

--- a/backend/test/externalConsent.test.js
+++ b/backend/test/externalConsent.test.js
@@ -4,6 +4,8 @@ import {
   hasValidExternalConsent,
   THIRD_PARTY_CONSENT_VERSION,
   THIRD_PARTY_CONSENT_CHANNELS,
+  AGREE_ALL_THIRD_PARTY_VERSION,
+  AGREE_ALL_THIRD_PARTY_COPY,
 } from '../src/services/externalConsent.js';
 
 describe('buildExternalConsentEvidence', () => {
@@ -56,6 +58,22 @@ describe('buildExternalConsentEvidence', () => {
     const ev = buildExternalConsentEvidence(true);
     expect(ev.channels).toEqual([...THIRD_PARTY_CONSENT_CHANNELS]);
     expect(ev.channels).not.toBe(THIRD_PARTY_CONSENT_CHANNELS);
+  });
+
+  it('stamps a KNOWN wording-era override (agree-all block) and keeps evidence valid', () => {
+    const ev = buildExternalConsentEvidence(true, { version: AGREE_ALL_THIRD_PARTY_VERSION });
+    expect(ev.version).toBe(AGREE_ALL_THIRD_PARTY_VERSION);
+    expect(hasValidExternalConsent({ consentMetadata: { external: ev } })).toBe(true);
+    expect(AGREE_ALL_THIRD_PARTY_COPY.length).toBeGreaterThan(0);
+  });
+
+  it('an unknown/absent version override falls back to the default era', () => {
+    expect(buildExternalConsentEvidence(true, { version: '2026-01-01' }).version)
+      .toBe(THIRD_PARTY_CONSENT_VERSION);
+    expect(buildExternalConsentEvidence(true, { version: 42 }).version)
+      .toBe(THIRD_PARTY_CONSENT_VERSION);
+    expect(buildExternalConsentEvidence(true, {}).version)
+      .toBe(THIRD_PARTY_CONSENT_VERSION);
   });
 });
 

--- a/backend/test/integration/consentLedger.test.js
+++ b/backend/test/integration/consentLedger.test.js
@@ -8,8 +8,12 @@ import {
   backfillConsentEvents, getConsentState, canMarketTo, isSendBlocked,
   ensureUnsubToken, unsubTokenFor,
 } from '../../src/services/consentService.js';
-import { CONTACT_CONSENT_VERSION } from '../../src/services/contactConsent.js';
-import { THIRD_PARTY_CONSENT_VERSION } from '../../src/services/externalConsent.js';
+import {
+  CONTACT_CONSENT_VERSION, CONTACT_CONSENT_VERSIONS, AGREE_ALL_CONSENT_VERSION,
+} from '../../src/services/contactConsent.js';
+import {
+  THIRD_PARTY_CONSENT_VERSION, AGREE_ALL_THIRD_PARTY_VERSION,
+} from '../../src/services/externalConsent.js';
 
 /**
  * Consent ledger — integration (PR B, plan §3). Real Postgres: the ledger's
@@ -119,6 +123,58 @@ describe('capture → ledger events', () => {
       }))
       .expect(201); // no OTP marker → verified:false on the event
     expect(await canMarketTo({ phone: `+65${phU}`, campaignId: campaign1.id })).toBe(false);
+  });
+
+  test('agree-all capture (consent_copy_version) stamps the new era on contact + third_party', async () => {
+    const phA = p8(31);
+    markPhoneVerified(`+65${phA}`);
+    await request(app).post('/api/prospects')
+      .send(capturePayload({
+        campaignId: campaign1.id, phone: phA,
+        consent_contact: true, consent_terms: true, consent_third_party: true,
+        consent_copy_version: AGREE_ALL_CONSENT_VERSION,
+      }))
+      .expect(201);
+
+    const consumer = await Consumer.findOne({ where: { phone: `+65${phA}` } });
+    const events = await ConsentEvent.findAll({ where: { consumerId: consumer.id } });
+    const byKind = Object.fromEntries(events.map((e) => [e.kind, e]));
+
+    const era = CONTACT_CONSENT_VERSIONS[AGREE_ALL_CONSENT_VERSION];
+    expect(byKind.contact.granted).toBe(true);
+    expect(byKind.contact.version).toBe(AGREE_ALL_CONSENT_VERSION);
+    expect(byKind.contact.metadata.copyHash).toBe(era.copyHash);
+    expect(byKind.contact.metadata.scope).toBe('brand');
+    // Brand-wide WORDING, still campaign-scoped EVENT (globalev is separate).
+    expect(byKind.contact.campaignId).toBe(campaign1.id);
+    expect(byKind.third_party.version).toBe(AGREE_ALL_THIRD_PARTY_VERSION);
+
+    // The era label also survives on the prospect for backfill/audit.
+    const prospect = await Prospect.findByPk(byKind.contact.prospectId);
+    expect(prospect.sourceMetadata.consent_copy_version).toBe(AGREE_ALL_CONSENT_VERSION);
+  });
+
+  test('a capture WITHOUT consent_copy_version still stamps the legacy era (marketplace path)', async () => {
+    const phL = p8(32);
+    markPhoneVerified(`+65${phL}`);
+    await request(app).post('/api/prospects')
+      .send(capturePayload({
+        campaignId: campaign2.id, phone: phL,
+        consent_contact: true, consent_terms: true, consent_third_party: true,
+      }))
+      .expect(201);
+
+    const consumer = await Consumer.findOne({ where: { phone: `+65${phL}` } });
+    const contact = await ConsentEvent.findOne({
+      where: { consumerId: consumer.id, kind: 'contact' },
+    });
+    const legacy = CONTACT_CONSENT_VERSIONS[CONTACT_CONSENT_VERSION];
+    expect(contact.version).toBe(CONTACT_CONSENT_VERSION);
+    expect(contact.metadata.copyHash).toBe(legacy.copyHash);
+    const third = await ConsentEvent.findOne({
+      where: { consumerId: consumer.id, kind: 'third_party' },
+    });
+    expect(third.version).toBe(THIRD_PARTY_CONSENT_VERSION);
   });
 });
 

--- a/backend/test/publicDesignConfig.test.js
+++ b/backend/test/publicDesignConfig.test.js
@@ -57,7 +57,8 @@ describe('buildPublicDesignConfig', () => {
       'heroCtaLabel', 'ctaText', 'formHeadline', 'formSubheadline', 'formWidth',
       'brandWordmark', 'brandFooter', 'regulatoryFooter', 'termsContent', 'customerHost',
       'fieldOrder', 'visibleFields', 'requiredFields',
-      'sgPrOnly', 'excludeAdvisors', 'dncCheckAtSubmit', 'otpChannel', 'quiz', 'guidedReview',
+      'sgPrOnly', 'excludeAdvisors', 'dncCheckAtSubmit', 'otpChannel', 'thirdPartyDisclosure',
+      'quiz', 'guidedReview',
     ];
     const raw = Object.fromEntries(keys.map((k) => [k, `v-${k}`]));
     const out = buildPublicDesignConfig(raw);
@@ -102,6 +103,7 @@ describe('buildPublicDesignConfig — v2 documents', () => {
       featuredDrop: { enabled: true, title: 'Drop', valueLabel: 'S$10', emoji: '🛒', cap: 100, endsAt: '2026-08-15' },
       marketplace: { listed: true, title: 'Voucher', category: 'dining', valueLine: 'S$10', internalCost: 3.5 },
     },
+    thirdPartyDisclosure: false,
     ai: { brief: { topic: 'secret internal brief' } },
     luckyDraw: {
       enabled: true, prize: 'Tokyo trip', closesAt: '2026-08-30', multiplier: 10,
@@ -138,6 +140,9 @@ describe('buildPublicDesignConfig — v2 documents', () => {
     expect(out.form.terms).toEqual({ template: 'default', html: '<p>T&C</p>' });
     expect(out.quiz).toEqual(v2Doc.quiz);
     expect(out.guidedReview).toEqual(v2Doc.guidedReview);
+    // Agree-all consent block: the OFF state must reach the public form
+    // (default is ON, so only an explicit false ever matters).
+    expect(out.thirdPartyDisclosure).toBe(false);
     expect(out.distribution.host).toBe('redeem');
     expect(out.customerHost).toBe('redeem');
     expect(out.distribution.marketplace).toMatchObject({ title: 'Voucher', category: 'dining', valueLine: 'S$10' });

--- a/backend/test/unit/consentLedgerUnit.test.js
+++ b/backend/test/unit/consentLedgerUnit.test.js
@@ -3,6 +3,7 @@ import { buildUserRows } from '../../src/services/redeemedAudienceService.js';
 import { unsubTokenFor, unsubTokenHashOf } from '../../src/services/consentService.js';
 import {
   CONTACT_CONSENT_VERSION, CONTACT_CONSENT_COPY, CONTACT_CONSENT_COPY_HASH, CONTACT_CONSENT_CHANNELS,
+  CONTACT_CONSENT_VERSIONS, AGREE_ALL_CONSENT_VERSION, isKnownConsentCopyVersion,
 } from '../../src/services/contactConsent.js';
 import { createHash } from 'crypto';
 
@@ -43,5 +44,29 @@ describe('contact consent contract', () => {
     expect(CONTACT_CONSENT_VERSION).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     expect(CONTACT_CONSENT_COPY_HASH).toBe(createHash('sha256').update(CONTACT_CONSENT_COPY).digest('hex'));
     expect(CONTACT_CONSENT_CHANNELS).toEqual(['phone', 'text', 'email']);
+  });
+
+  test('registry: every era pins a recomputable hash + scope; legacy stays the default', () => {
+    for (const [version, era] of Object.entries(CONTACT_CONSENT_VERSIONS)) {
+      expect(version).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(era.copyHash).toBe(createHash('sha256').update(era.copy).digest('hex'));
+      expect(['campaign', 'brand']).toContain(era.scope);
+      expect(era.channels.length).toBeGreaterThan(0);
+    }
+    // Legacy entry is the CONTACT_CONSENT_* constants verbatim (closed era).
+    expect(CONTACT_CONSENT_VERSIONS[CONTACT_CONSENT_VERSION].copy).toBe(CONTACT_CONSENT_COPY);
+    expect(CONTACT_CONSENT_VERSIONS[CONTACT_CONSENT_VERSION].scope).toBe('campaign');
+    // Agree-all era is brand-scoped and a distinct wording.
+    const agreeAll = CONTACT_CONSENT_VERSIONS[AGREE_ALL_CONSENT_VERSION];
+    expect(agreeAll.scope).toBe('brand');
+    expect(agreeAll.copy).not.toBe(CONTACT_CONSENT_COPY);
+  });
+
+  test('isKnownConsentCopyVersion: registry labels only, prototype keys never', () => {
+    expect(isKnownConsentCopyVersion(AGREE_ALL_CONSENT_VERSION)).toBe(true);
+    expect(isKnownConsentCopyVersion(CONTACT_CONSENT_VERSION)).toBe(true);
+    expect(isKnownConsentCopyVersion('2026-01-01')).toBe(false);
+    expect(isKnownConsentCopyVersion('toString')).toBe(false);
+    expect(isKnownConsentCopyVersion(undefined)).toBe(false);
   });
 });

--- a/backend/test/validation.test.js
+++ b/backend/test/validation.test.js
@@ -272,6 +272,21 @@ describe('schemas.prospectCreate', () => {
     expect(error.details[0].path).toEqual(['consent_third_party']);
   });
 
+  // consent_copy_version is a strict enum: the ledger maps the label to pinned
+  // copy/hash evidence, so an unknown label must 400 rather than mint evidence.
+  it('accepts the agree-all consent_copy_version and its absence', () => {
+    expect(valid(schemas.prospectCreate, { ...validBody, consent_copy_version: '2026-07-21' }).ok)
+      .toBe(true);
+    expect(valid(schemas.prospectCreate, validBody).ok).toBe(true);
+  });
+
+  it('rejects unknown or non-string consent_copy_version labels', () => {
+    const bad = valid(schemas.prospectCreate, { ...validBody, consent_copy_version: '2026-01-01' });
+    expect(bad.ok).toBe(false);
+    expect(bad.error.details[0].path).toEqual(['consent_copy_version']);
+    expect(valid(schemas.prospectCreate, { ...validBody, consent_copy_version: true }).ok).toBe(false);
+  });
+
   // Guard: the fix is surgical — whitelist THIS field only. Until the scoped
   // stripUnknown hardening (Layer 2) ships, the schema must still reject genuinely
   // unknown keys so contract drift on other fields keeps failing loudly.


### PR DESCRIPTION
## What (PR 1 of 2 — merge FIRST, deploy before the frontend PR)

Backend half of the mandatory agree-all consent block (data-powerhouse tracker item `funnelui`, fold-in of `copyhash`):

- **`contactConsent.js`**: `CONTACT_CONSENT_VERSIONS` registry — `'2026-07-20'` legacy era (unchanged default) + `'2026-07-21'` agree-all era (brand-scope wording, byte-pinned copy + sha256). Header now tells the truth about the legacy paraphrase.
- **`externalConsent.js`**: `AGREE_ALL_THIRD_PARTY_VERSION '2026-07-21'` + whitelisted `opts.version` override on `buildExternalConsentEvidence` (unknown → default era).
- **`consentService.recordCaptureConsentEventsTx`**: new `copyVersion` arg selects the era for the contact event (`version`, `channels`, `metadata.copyHash`, `metadata.scope`). Unknown/absent → legacy, so an unrecognized label can never mint mislabeled evidence. **Events stay campaign-scoped** — global `campaignId:null` grants are the separate `globalev` tracker item.
- **`validation.js`**: `consent_copy_version` strict Joi enum (`'2026-07-21'` only).
- **`prospectService`**: read/strip/stash `consent_copy_version` (→ `sourceMetadata`) and thread it into the ledger write + external evidence builder.
- **`publicDesignConfig`**: expose `design_config.thirdPartyDisclosure` through the v1 whitelist AND the v2 rebuild — the agree-all block's sponsored-clause toggle (default ON; only explicit `false` matters). Without this the public form could never see the toggle (the public config is rebuild-never-dump).

## Why backend-first

`POST /prospects` validates with `stripUnknown: true` — an older backend silently drops `consent_copy_version`, so if the frontend shipped first, new-block submissions would be stamped with the *legacy* copy/hash as evidence (wrong evidence, no lost leads). Merge this, confirm the `mktr-backend-jo6r` deploy is live, then merge the frontend PR.

Fully backward-compatible until then: MarketplaceFlow + cached bundles keep stamping the legacy era.

## Tests

- `consentLedger` integration: agree-all capture stamps `'2026-07-21'` + new hash + `scope:'brand'` on `contact`, `'2026-07-21'` on `third_party`; version-less capture still stamps legacy (11/11 green on local pg:5433).
- `consentLedgerUnit`: registry contract (hash recomputes per era, prototype-safe version lookup).
- `validation`: enum accepts `'2026-07-21'`, rejects unknown/non-string.
- `externalConsent`: override honored / unknown falls back.
- `publicDesignConfig`: `thirdPartyDisclosure:false` survives v1 + v2 builders.
- 69 unit + 11 integration tests green; adjacent suites (prospects, campaigns, adtech, dnc*, campaignPreviews, studioClamp) pass serially — the shared-pg parallel flake and the chronically-red CI baseline are pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDA1rRU4PjRec9dJT7q9eK