### PR TITLE
feat(consent): layered presentation — full agreement in a dialog, one line inline

### DIFF
--- a/backend/node_modules
+++ b/backend/node_modules
@@ -1,1 +1,0 @@
-../../consent-agree-all/backend/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-../consent-agree-all/node_modules

--- a/src/components/campaigns/CampaignSignupForm.jsx
+++ b/src/components/campaigns/CampaignSignupForm.jsx
@@ -4,11 +4,11 @@ import { apiClient } from '@/api/client';
 import FieldRenderer from '@/components/campaigns/signup/FieldRenderer';
 import OTPVerification from '@/components/campaigns/signup/OTPVerification';
 import DncConsentGate from '@/components/campaigns/signup/DncConsentGate';
-import MarketingConsentDialog from '@/components/legal/MarketingConsentDialog';
+import ConsentAgreementDialog from '@/components/campaigns/signup/ConsentAgreementDialog';
 import { useCampaignTheme } from '@/components/campaignPage/themeContext';
 import { heroFontStack } from '@/lib/heroFonts';
 import {
-  CONSENT_COPY, CONSENT_COPY_VERSION, CONSENT_BLOCK_HELPER,
+  CONSENT_INLINE, CONSENT_COPY_VERSION, CONSENT_BLOCK_HELPER,
   isSponsoredCampaign, sponsorNameLine,
 } from '@/lib/consentCopy';
 import { formatDateInput, getAgeValidationError, getAgeRestrictionHint, displayPhone } from '@/components/campaigns/signup/dateUtils';
@@ -908,83 +908,47 @@ export default function CampaignSignupForm({
           </div>
         )}
 
-        {/* Mandatory agree-all consent block (wording era CONSENT_COPY_VERSION;
-            strings live in src/lib/consentCopy.js — never inline-edit copy here).
+        {/* Agree-all consent — layered presentation: ONE summary sentence
+            inline (chrome, not hashed) + the full clause list and campaign
+            T&Cs in ConsentAgreementDialog. The evidence strings are unchanged
+            (CONSENT_COPY.clause*, rendered in the dialog); sponsored campaigns
+            keep the named-sponsor line ON the page ("named on this page").
             The DNC gate above is a separate consent and stays independent. */}
         <div style={{ marginTop: 8, marginBottom: 24 }}>
-          <div
-            style={{
-              fontFamily: 'Albert Sans, system-ui, sans-serif',
-              fontWeight: 600,
-              fontSize: 14,
-              color: TOKENS.body,
-              marginBottom: 4,
-            }}
-          >
-            {CONSENT_COPY.heading}
-          </div>
           <p
             style={{
-              margin: '0 0 8px',
+              margin: '0 0 10px',
               fontFamily: 'Albert Sans, system-ui, sans-serif',
               fontSize: 13.5,
               lineHeight: 1.55,
               color: TOKENS.body,
             }}
           >
-            {CONSENT_COPY.intro}
+            {sponsoredClause ? CONSENT_INLINE.summarySponsored : CONSENT_INLINE.summaryBase}
+            <button
+              type="button"
+              onClick={() => setConsentOpen(true)}
+              style={{
+                color: TOKENS.body,
+                fontWeight: 600,
+                background: 'none',
+                border: 'none',
+                padding: 0,
+                cursor: 'pointer',
+                textDecoration: 'underline',
+                textUnderlineOffset: 3,
+                fontSize: 'inherit',
+                fontFamily: 'inherit',
+              }}
+            >
+              {CONSENT_INLINE.summaryLinkText}
+            </button>
+            {CONSENT_INLINE.summarySuffix}
           </p>
-          <ul
-            style={{
-              margin: '0 0 12px',
-              paddingLeft: 20,
-              display: 'grid',
-              gap: 6,
-              fontFamily: 'Albert Sans, system-ui, sans-serif',
-              fontSize: 13.5,
-              lineHeight: 1.55,
-              color: TOKENS.body,
-            }}
-          >
-            <li>
-              <strong style={{ color: TOKENS.ink }}>{CONSENT_COPY.clauseContactHeadline}</strong>{' '}
-              {CONSENT_COPY.clauseContactBody}
-            </li>
-            <li>
-              <strong style={{ color: TOKENS.ink }}>{CONSENT_COPY.clauseTermsHeadline}</strong>{' '}
-              {CONSENT_COPY.clauseTermsPrefix}
-              <button
-                type="button"
-                onClick={() => setConsentOpen(true)}
-                style={{
-                  color: TOKENS.body,
-                  fontWeight: 600,
-                  background: 'none',
-                  border: 'none',
-                  padding: 0,
-                  cursor: 'pointer',
-                  textDecoration: 'underline',
-                  textUnderlineOffset: 3,
-                  fontSize: 'inherit',
-                  fontFamily: 'inherit',
-                }}
-              >
-                {CONSENT_COPY.clauseTermsLinkText}
-              </button>
-              {CONSENT_COPY.clauseTermsSuffix}
-            </li>
-            {sponsoredClause && (
-              <li>
-                <strong style={{ color: TOKENS.ink }}>{CONSENT_COPY.clauseThirdPartyHeadline}</strong>{' '}
-                {CONSENT_COPY.clauseThirdPartyBody}
-              </li>
-            )}
-          </ul>
           {sponsoredClause && (
             <p
               style={{
-                margin: '0 0 12px',
-                paddingLeft: 20,
+                margin: '0 0 10px',
                 fontFamily: 'Albert Sans, system-ui, sans-serif',
                 fontSize: 12,
                 lineHeight: 1.5,
@@ -1001,7 +965,7 @@ export default function CampaignSignupForm({
             id="consent_all"
             required
           >
-            {CONSENT_COPY.checkboxLabel} <span style={{ color: TOKENS.required }}>*</span>
+            {CONSENT_INLINE.checkboxLabel} <span style={{ color: TOKENS.required }}>*</span>
           </ConsentCheckbox>
         </div>
 
@@ -1038,12 +1002,19 @@ export default function CampaignSignupForm({
       </form>
       </motion.div>
 
-      {/* Marketing consent modal */}
-      <MarketingConsentDialog
+      {/* The full agreement (clause list + campaign T&Cs). Its "I agree" is a
+          real consent gesture — the dialog shows the ENTIRE deal, so agreeing
+          there ticks the block's checkbox. */}
+      <ConsentAgreementDialog
         open={consentOpen}
         onOpenChange={setConsentOpen}
-        content={termsContent}
+        designConfig={campaign?.design_config}
+        termsContent={termsContent}
         themeColor={accent}
+        onAgree={() => {
+          setConsentAll(true);
+          setConsentOpen(false);
+        }}
       />
     </>
   );

--- a/src/components/campaigns/__tests__/CampaignSignupForm.test.jsx
+++ b/src/components/campaigns/__tests__/CampaignSignupForm.test.jsx
@@ -8,7 +8,7 @@ vi.mock('@/api/client', () => ({
 
 import CampaignSignupForm from '@/components/campaigns/CampaignSignupForm';
 import { apiClient } from '@/api/client';
-import { CONSENT_COPY, CONSENT_COPY_VERSION } from '@/lib/consentCopy';
+import { CONSENT_COPY, CONSENT_INLINE, CONSENT_COPY_VERSION } from '@/lib/consentCopy';
 
 const baseCampaign = (designOverrides = {}) => ({
   id: 'camp-1',
@@ -436,41 +436,60 @@ describe('CampaignSignupForm — mandatory agree-all consent block', () => {
     await waitFor(() => expect(screen.getByText('Verified')).toBeInTheDocument(), { timeout: 2500 });
   };
 
-  it('renders every copy string from the consentCopy module (no inline drift)', () => {
+  it('layered inline residue: summary + link + checkbox, clause text only in the dialog', async () => {
+    const user = userEvent.setup();
     renderForm();
-    expect(screen.getByText(CONSENT_COPY.heading)).toBeInTheDocument();
+    // Inline: the base summary sentence, the dialog link, and the checkbox.
+    expect(screen.getByText(new RegExp(CONSENT_INLINE.summaryBase.slice(0, 40)))).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: CONSENT_INLINE.summaryLinkText })).toBeInTheDocument();
+    expect(screen.getByText(CONSENT_INLINE.checkboxLabel)).toBeInTheDocument();
+    // Exactly ONE consent checkbox — the legacy trio is gone.
+    expect(document.getElementById('consent_all')).toBeTruthy();
+    expect(document.getElementById('consent_terms')).toBeNull();
+    expect(document.getElementById('consent_contact')).toBeNull();
+    expect(document.getElementById('consent_third_party')).toBeNull();
+    // The full agreement lives in the dialog ONLY.
+    expect(screen.queryByText(CONSENT_COPY.heading)).toBeNull();
+    expect(screen.queryByText(CONSENT_COPY.clauseContactHeadline)).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: CONSENT_INLINE.summaryLinkText }));
+    expect(await screen.findByText(CONSENT_COPY.heading)).toBeInTheDocument();
     expect(screen.getByText(CONSENT_COPY.intro)).toBeInTheDocument();
-    // Headline renders bold; the body text rides in the same <li>.
     const contactHeadline = screen.getByText(CONSENT_COPY.clauseContactHeadline);
     expect(contactHeadline.closest('li').textContent).toContain(CONSENT_COPY.clauseContactBody);
     expect(screen.getByText(CONSENT_COPY.clauseTermsHeadline)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: CONSENT_COPY.clauseTermsLinkText })).toBeInTheDocument();
     // No sponsor configured => the disclosure clause must NOT render (§9.5-1).
     expect(screen.queryByText(CONSENT_COPY.clauseThirdPartyHeadline)).toBeNull();
-    expect(screen.getByText(CONSENT_COPY.checkboxLabel)).toBeInTheDocument();
-    // Exactly ONE consent checkbox — the legacy trio is gone.
-    expect(document.getElementById('consent_all')).toBeTruthy();
-    expect(document.getElementById('consent_terms')).toBeNull();
-    expect(document.getElementById('consent_contact')).toBeNull();
-    expect(document.getElementById('consent_third_party')).toBeNull();
+    // Section 2 renders the brand-default T&C fallback when no termsContent.
+    expect(screen.getByText(CONSENT_INLINE.sectionTermsTitle)).toBeInTheDocument();
+    expect(screen.getByText(/Non-Superseding Consent/)).toBeInTheDocument();
   });
 
-  it('a NAMED sponsor renders the disclosure clause AND the mandatory named line', () => {
+  it('a NAMED sponsor: sponsored summary + named line INLINE (no dialog needed), clause in the dialog', async () => {
+    const user = userEvent.setup();
     renderForm({ design: { sponsor: { name: 'Acme FA' } } });
-    expect(screen.getByText(CONSENT_COPY.clauseThirdPartyHeadline)).toBeInTheDocument();
+    // "(named on this page)" stays literally true without opening the dialog.
+    expect(screen.getByText(new RegExp('sharing your details with this campaign'))).toBeInTheDocument();
     expect(screen.getByText('Sponsored by Acme FA.')).toBeInTheDocument();
+    expect(screen.queryByText(CONSENT_COPY.clauseThirdPartyHeadline)).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: CONSENT_INLINE.summaryLinkText }));
+    expect(await screen.findByText(CONSENT_COPY.clauseThirdPartyHeadline)).toBeInTheDocument();
+    // The named line renders in the dialog too (adjacent to the clause).
+    expect(screen.getAllByText('Sponsored by Acme FA.').length).toBeGreaterThanOrEqual(2);
   });
 
-  it('a name-less sponsor object falls back to the base block (§9.5-1 fail-closed)', () => {
+  it('a name-less sponsor object falls back to the base summary (§9.5-1 fail-closed)', () => {
     renderForm({ design: { sponsor: { disclosure: 'Sponsored by someone' } } });
-    expect(screen.queryByText(CONSENT_COPY.clauseThirdPartyHeadline)).toBeNull();
+    expect(screen.queryByText(new RegExp('sharing your details with this campaign'))).toBeNull();
     expect(screen.queryByText('Sponsored by someone')).toBeNull();
   });
 
   it('thirdPartyDisclosure:false is a kill-switch even with a named sponsor', () => {
     renderForm({ design: { sponsor: { name: 'Acme FA' }, thirdPartyDisclosure: false } });
-    expect(screen.queryByText(CONSENT_COPY.clauseThirdPartyHeadline)).toBeNull();
-    expect(screen.getByText(CONSENT_COPY.clauseContactHeadline)).toBeInTheDocument();
+    expect(screen.queryByText(new RegExp('sharing your details with this campaign'))).toBeNull();
+    expect(screen.getByText(new RegExp(CONSENT_INLINE.summaryBase.slice(0, 40)))).toBeInTheDocument();
   });
 
   it('live submit: disabled until agreed, then derived flags + the copy version (base)', async () => {
@@ -512,16 +531,20 @@ describe('CampaignSignupForm — mandatory agree-all consent block', () => {
     });
   });
 
-  it('the T&C dialog is READ-ONLY: no "I agree" button, and reading it never ticks the block', async () => {
+  it('dialog "I agree" IS a consent gesture: ticks the block and closes; Cancel does not', async () => {
+    // Supersedes the old read-only-dialog rule (copy pack §5 #16): that rule
+    // existed because the T&C dialog covered only PART of the deal. This
+    // dialog holds the ENTIRE agreement, so agreeing there ticks the block.
     const user = userEvent.setup();
     renderForm();
-    await user.click(screen.getByRole('button', { name: CONSENT_COPY.clauseTermsLinkText }));
-    // The dialog covers only the T&Cs; the block covers more — so the only
-    // consent gesture is the block's own tick (copy pack §5 #16).
-    expect(await screen.findByRole('button', { name: 'Cancel' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /I agree/i })).toBeNull();
-    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await user.click(screen.getByRole('button', { name: CONSENT_INLINE.summaryLinkText }));
+    await user.click(await screen.findByRole('button', { name: 'Cancel' }));
     expect(document.getElementById('consent_all').checked).toBe(false);
+
+    await user.click(screen.getByRole('button', { name: CONSENT_INLINE.summaryLinkText }));
+    await user.click(await screen.findByRole('button', { name: CONSENT_INLINE.dialogAgreeCta }));
+    expect(document.getElementById('consent_all').checked).toBe(true);
+    await waitFor(() => expect(screen.queryByText(CONSENT_COPY.heading)).toBeNull());
   });
 });
 

--- a/src/components/campaigns/signup/ConsentAgreementDialog.jsx
+++ b/src/components/campaigns/signup/ConsentAgreementDialog.jsx
@@ -1,0 +1,210 @@
+import { useMemo, useRef } from 'react';
+import DOMPurify from 'dompurify';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { useCampaignTheme } from '@/components/campaignPage/themeContext';
+import { DefaultConsentCopy } from '@/components/legal/MarketingConsentDialog';
+import {
+  CONSENT_COPY, CONSENT_INLINE, isSponsoredCampaign, sponsorNameLine,
+} from '@/lib/consentCopy';
+
+/**
+ * The FULL agree-all agreement in a dialog (layered presentation, 2026-07-21):
+ *
+ *   Section 1 — "What you're agreeing to": the §9.4 clause list, byte-identical
+ *   to the evidence strings the ledger hashes (CONSENT_COPY.clause*), plus the
+ *   named-sponsor line on sponsored campaigns.
+ *   Section 2 — "Terms & conditions": the campaign's own T&C HTML, or the
+ *   brand-default fallback.
+ *
+ * Unlike the old read-only T&C dialog, this one holds the ENTIRE deal, so its
+ * "I agree" is a real consent gesture: the parent ticks the block's checkbox.
+ * The in-clause "terms & conditions" link scrolls to Section 2 (same dialog),
+ * never opens a second one.
+ */
+export default function ConsentAgreementDialog({
+  open, onOpenChange, designConfig, termsContent, themeColor, onAgree,
+}) {
+  const { tokens: TOKENS, radius: RADIUS, onAccent } = useCampaignTheme();
+  const sanitized = useMemo(
+    () => (termsContent ? DOMPurify.sanitize(termsContent) : null),
+    [termsContent]
+  );
+  const accent = themeColor || TOKENS.accent;
+  const sponsored = isSponsoredCampaign(designConfig);
+  const termsRef = useRef(null);
+
+  const sectionTitleStyle = {
+    fontFamily: 'Albert Sans, system-ui, sans-serif',
+    fontSize: 11,
+    fontWeight: 700,
+    letterSpacing: '0.16em',
+    textTransform: 'uppercase',
+    color: TOKENS.muted,
+    margin: '0 0 10px',
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="border-0 p-0 gap-0"
+        style={{
+          backgroundColor: TOKENS.modal,
+          borderRadius: RADIUS.modal,
+          maxWidth: 520,
+          width: 'calc(100vw - 32px)',
+          maxHeight: '85vh',
+          padding: 0,
+          boxShadow: '0 24px 64px rgba(60, 40, 20, 0.18), 0 4px 16px rgba(60, 40, 20, 0.08)',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        {/* Header — eyebrow + display title */}
+        <div style={{ padding: '28px 28px 20px' }}>
+          <div style={sectionTitleStyle}>{CONSENT_INLINE.dialogEyebrow}</div>
+          <h2
+            style={{
+              fontFamily: 'Fraunces, serif',
+              fontWeight: 800,
+              fontSize: 30,
+              lineHeight: 1.05,
+              letterSpacing: '-0.015em',
+              color: TOKENS.ink,
+              margin: 0,
+            }}
+          >
+            {CONSENT_COPY.heading}
+          </h2>
+        </div>
+
+        {/* Scrollable body — Section 1: the agreement list */}
+        <div
+          style={{
+            flex: 1,
+            overflowY: 'auto',
+            padding: '0 28px 24px',
+            fontFamily: 'Albert Sans, system-ui, sans-serif',
+            fontSize: 15,
+            lineHeight: 1.65,
+            color: TOKENS.body,
+          }}
+        >
+          <div style={sectionTitleStyle}>{CONSENT_INLINE.sectionAgreeTitle}</div>
+          <p style={{ margin: '0 0 12px' }}>{CONSENT_COPY.intro}</p>
+          <ul style={{ margin: '0 0 16px', paddingLeft: 20, display: 'grid', gap: 10 }}>
+            <li>
+              <strong style={{ color: TOKENS.ink }}>{CONSENT_COPY.clauseContactHeadline}</strong>{' '}
+              {CONSENT_COPY.clauseContactBody}
+            </li>
+            <li>
+              <strong style={{ color: TOKENS.ink }}>{CONSENT_COPY.clauseTermsHeadline}</strong>{' '}
+              {CONSENT_COPY.clauseTermsPrefix}
+              <button
+                type="button"
+                onClick={() => termsRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
+                style={{
+                  color: TOKENS.body,
+                  fontWeight: 600,
+                  background: 'none',
+                  border: 'none',
+                  padding: 0,
+                  cursor: 'pointer',
+                  textDecoration: 'underline',
+                  textUnderlineOffset: 3,
+                  fontSize: 'inherit',
+                  fontFamily: 'inherit',
+                }}
+              >
+                {CONSENT_COPY.clauseTermsLinkText}
+              </button>
+              {CONSENT_COPY.clauseTermsSuffix}
+            </li>
+            {sponsored && (
+              <li>
+                <strong style={{ color: TOKENS.ink }}>{CONSENT_COPY.clauseThirdPartyHeadline}</strong>{' '}
+                {CONSENT_COPY.clauseThirdPartyBody}
+              </li>
+            )}
+          </ul>
+          {sponsored && (
+            <p style={{ margin: '0 0 16px', fontSize: 13, color: TOKENS.muted }}>
+              {sponsorNameLine(designConfig)}
+            </p>
+          )}
+
+          {/* Section 2: the campaign's terms & conditions */}
+          <div
+            ref={termsRef}
+            style={{
+              borderTop: `1px solid ${TOKENS.hairline}`,
+              paddingTop: 20,
+              marginTop: 4,
+              scrollMarginTop: 8,
+            }}
+          >
+            <div style={sectionTitleStyle}>{CONSENT_INLINE.sectionTermsTitle}</div>
+            {sanitized ? (
+              <div dangerouslySetInnerHTML={{ __html: sanitized }} />
+            ) : (
+              <DefaultConsentCopy />
+            )}
+          </div>
+        </div>
+
+        {/* Footer — Cancel / I agree (a real consent gesture: parent ticks the box) */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: 12,
+            padding: '20px 28px 28px',
+            borderTop: `1px solid ${TOKENS.hairline}`,
+          }}
+        >
+          <button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            style={{
+              height: 48,
+              paddingLeft: 24,
+              paddingRight: 24,
+              borderRadius: RADIUS.pill,
+              backgroundColor: '#ffffff',
+              color: TOKENS.body,
+              border: `1px solid ${TOKENS.hairline}`,
+              cursor: 'pointer',
+              fontFamily: 'Albert Sans, system-ui, sans-serif',
+              fontWeight: 600,
+              fontSize: 15,
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onAgree}
+            style={{
+              height: 48,
+              paddingLeft: 28,
+              paddingRight: 28,
+              borderRadius: RADIUS.pill,
+              backgroundColor: accent,
+              color: onAccent,
+              border: 'none',
+              cursor: 'pointer',
+              fontFamily: 'Albert Sans, system-ui, sans-serif',
+              fontWeight: 600,
+              fontSize: 15,
+              minWidth: 110,
+              boxShadow: '0 4px 14px rgba(209, 112, 41, 0.18)',
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = TOKENS.accentDeep)}
+            onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = accent)}
+          >
+            {CONSENT_INLINE.dialogAgreeCta}
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/legal/MarketingConsentDialog.jsx
+++ b/src/components/legal/MarketingConsentDialog.jsx
@@ -145,7 +145,7 @@ export default function MarketingConsentDialog({ open, onOpenChange, content, th
   );
 }
 
-function DefaultConsentCopy() {
+export function DefaultConsentCopy() {
   const { tokens: TOKENS, radius: RADIUS } = useCampaignTheme();
   // Legal data controller stays MKTR PTE. LTD. per D3. Consumer-facing brand
   // references swap with the active build's brand (Redeem on redeem.sg).

--- a/src/lib/consentCopy.js
+++ b/src/lib/consentCopy.js
@@ -42,6 +42,30 @@ export const CONSENT_COPY = Object.freeze({
 export const CONSENT_BLOCK_HELPER = "You'll need to agree to the above to submit.";
 
 /**
+ * Layered presentation chrome (2026-07-21 dialog rework): the clause list
+ * lives in ConsentAgreementDialog; the form keeps ONE summary sentence +
+ * "read the full agreement" link + the required checkbox. Everything here is
+ * chrome, NOT hashed — the evidence strings remain CONSENT_COPY.clause*
+ * (byte-locked to the backend, presentation-independent). The summary must
+ * never contradict the clauses; sponsored campaigns use the sponsored variant
+ * AND keep sponsorNameLine visible inline, so "(named on this page)" stays
+ * literally true without opening the dialog.
+ */
+export const CONSENT_INLINE = Object.freeze({
+  summaryBase:
+    "By submitting, you agree to be contacted by Redeem about this offer and future ones, and to this campaign's terms — ",
+  summarySponsored:
+    "By submitting, you agree to be contacted by Redeem about this offer and future ones, to this campaign's terms, and to sharing your details with this campaign's sponsor — ",
+  summaryLinkText: 'read the full agreement',
+  summarySuffix: '.',
+  checkboxLabel: 'I agree to the agreement above.',
+  dialogEyebrow: 'Agreement',
+  sectionAgreeTitle: "What you're agreeing to",
+  sectionTermsTitle: 'Terms & conditions',
+  dialogAgreeCta: 'I agree',
+});
+
+/**
  * Sponsored predicate — the disclosure clause renders iff design_config has a
  * sponsor object WITH A NON-EMPTY NAME (§9.5-1: the clause says the sponsor
  * is "(named on this page)", so a name-less sponsor object falls back to the

--- a/src/pages/marketplace/MarketplaceFlow.jsx
+++ b/src/pages/marketplace/MarketplaceFlow.jsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import MarketplaceLayout from './MarketplaceLayout';
-import MarketingConsentDialog from '@/components/legal/MarketingConsentDialog';
+import ConsentAgreementDialog from '@/components/campaigns/signup/ConsentAgreementDialog';
 import {
-  CONSENT_COPY, CONSENT_COPY_VERSION, CONSENT_BLOCK_HELPER,
+  CONSENT_INLINE, CONSENT_COPY_VERSION, CONSENT_BLOCK_HELPER,
   isSponsoredCampaign, sponsorNameLine,
 } from '@/lib/consentCopy';
 import { apiClient } from '@/api/client';
@@ -821,49 +821,27 @@ export default function MarketplaceFlow() {
                   </button>
                 </div>
               )}
-              {/* Agree-all block — words from src/lib/consentCopy.js (hashed
-                  twin); one required tick, matching the main funnel exactly. */}
+              {/* Agree-all — layered presentation matching the main funnel:
+                  one summary sentence (chrome) + the full clause list and
+                  campaign T&Cs in ConsentAgreementDialog; sponsored campaigns
+                  keep the named-sponsor line ON the page. Evidence strings
+                  unchanged (CONSENT_COPY.clause*, rendered in the dialog). */}
               <div style={{ background: 'var(--rm-bg)', border: '1px solid var(--rm-line)', borderRadius: 14, padding: '16px 18px' }}>
-                <div style={{ fontSize: 15, fontWeight: 700 }}>{CONSENT_COPY.heading}</div>
-                <p style={{ margin: '6px 0 12px', fontSize: 13, lineHeight: 1.6, color: 'var(--rm-sub)' }}>{CONSENT_COPY.intro}</p>
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 10, fontSize: 13.5, lineHeight: 1.6, marginBottom: 12 }}>
-                  <div style={{ display: 'flex', gap: 9 }}>
-                    <span aria-hidden="true" style={{ color: 'var(--rm-pine)', fontWeight: 700, flexShrink: 0 }}>•</span>
-                    <span>
-                      <strong>{CONSENT_COPY.clauseContactHeadline}</strong> {CONSENT_COPY.clauseContactBody}
-                    </span>
-                  </div>
-                  <div style={{ display: 'flex', gap: 9 }}>
-                    <span aria-hidden="true" style={{ color: 'var(--rm-pine)', fontWeight: 700, flexShrink: 0 }}>•</span>
-                    <span>
-                      <strong>{CONSENT_COPY.clauseTermsHeadline}</strong> {CONSENT_COPY.clauseTermsPrefix}
-                      {dc.termsContent ? (
-                        <button className="rm-underline" style={{ color: 'var(--rm-pine)', fontWeight: 600 }} onClick={() => setTermsOpen(true)}>
-                          {CONSENT_COPY.clauseTermsLinkText}
-                        </button>
-                      ) : (
-                        CONSENT_COPY.clauseTermsLinkText
-                      )}
-                      {CONSENT_COPY.clauseTermsSuffix}
-                    </span>
-                  </div>
-                  {sponsoredClause && (
-                    <div style={{ display: 'flex', gap: 9 }}>
-                      <span aria-hidden="true" style={{ color: 'var(--rm-pine)', fontWeight: 700, flexShrink: 0 }}>•</span>
-                      <span>
-                        <strong>{CONSENT_COPY.clauseThirdPartyHeadline}</strong> {CONSENT_COPY.clauseThirdPartyBody}
-                      </span>
-                    </div>
-                  )}
-                </div>
+                <p style={{ margin: '0 0 12px', fontSize: 13.5, lineHeight: 1.6 }}>
+                  {sponsoredClause ? CONSENT_INLINE.summarySponsored : CONSENT_INLINE.summaryBase}
+                  <button className="rm-underline" style={{ color: 'var(--rm-pine)', fontWeight: 600 }} onClick={() => setTermsOpen(true)}>
+                    {CONSENT_INLINE.summaryLinkText}
+                  </button>
+                  {CONSENT_INLINE.summarySuffix}
+                </p>
                 {sponsoredClause && (
-                  <div style={{ fontSize: 11.5, lineHeight: 1.55, color: 'var(--rm-mut)', margin: '0 0 12px 21px' }}>
+                  <div style={{ fontSize: 11.5, lineHeight: 1.55, color: 'var(--rm-mut)', margin: '0 0 12px' }}>
                     {sponsorNameLine(dc)}
                   </div>
                 )}
                 <div style={{ borderTop: '1px solid var(--rm-line)', paddingTop: 12 }}>
                   <ConsentCheck checked={agreeAll} onToggle={() => setAgreeAll((p) => !p)}>
-                    <strong>{CONSENT_COPY.checkboxLabel}</strong>{' '}
+                    <strong>{CONSENT_INLINE.checkboxLabel}</strong>{' '}
                     <span style={{ fontFamily: 'var(--rm-mono)', fontSize: 9.5, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--rm-err)' }}>Required</span>
                   </ConsentCheck>
                 </div>
@@ -886,7 +864,18 @@ export default function MarketplaceFlow() {
         </div>
       </div>
 
-      <MarketingConsentDialog open={termsOpen} onOpenChange={setTermsOpen} content={dc.termsContent} />
+      {/* The full agreement (clause list + campaign T&Cs); its "I agree" ticks
+          the block — the dialog shows the entire deal. */}
+      <ConsentAgreementDialog
+        open={termsOpen}
+        onOpenChange={setTermsOpen}
+        designConfig={dc}
+        termsContent={dc.termsContent}
+        onAgree={() => {
+          setAgreeAll(true);
+          setTermsOpen(false);
+        }}
+      />
 
       {toast && (
         <div role="status" style={{ position: 'fixed', bottom: 26, left: '50%', transform: 'translateX(-50%)', zIndex: 90, background: 'var(--rm-ink)', color: '#F6F2E6', fontSize: 13.5, fontWeight: 500, padding: '12px 22px', borderRadius: 999, boxShadow: '0 12px 30px rgba(23,37,31,0.3)' }}>

--- a/src/pages/marketplace/__tests__/marketplaceFlowConsent.test.jsx
+++ b/src/pages/marketplace/__tests__/marketplaceFlowConsent.test.jsx
@@ -26,7 +26,7 @@ vi.mock('../MarketplaceLayout', () => ({ default: ({ children }) => <div>{childr
 import MarketplaceFlow from '../MarketplaceFlow';
 import { apiClient } from '@/api/client';
 import { getMarketplaceCampaign } from '@/api/marketplace';
-import { CONSENT_COPY_VERSION } from '@/lib/consentCopy';
+import { CONSENT_COPY, CONSENT_INLINE, CONSENT_COPY_VERSION } from '@/lib/consentCopy';
 
 /**
  * mktui behavioral proof: the marketplace consent step IS the agree-all block
@@ -90,7 +90,7 @@ beforeEach(() => {
 });
 
 describe('MarketplaceFlow — agree-all consent step (mktui)', () => {
-  it('base campaign: block renders 2 clauses, submit locked until the single tick, derived flags on the wire', async () => {
+  it('base campaign: layered summary inline, full clauses in the dialog, submit locked until the tick, derived flags on the wire', async () => {
     const user = userEvent.setup();
     getMarketplaceCampaign.mockResolvedValue(baseCampaign());
     mockApi();
@@ -99,18 +99,27 @@ describe('MarketplaceFlow — agree-all consent step (mktui)', () => {
     await driveToConsentStep(user);
     await user.click(screen.getByRole('button', { name: 'Continue' }));
 
-    // The agree-all block, from the shared twin copy.
-    expect(await screen.findByText('One agreement — read once')).toBeInTheDocument();
-    expect(screen.getByText('Contact from Redeem — this offer and future ones.')).toBeInTheDocument();
-    expect(screen.getByText("This campaign's terms.")).toBeInTheDocument();
-    expect(screen.queryByText("Sharing with this campaign's sponsor.")).toBeNull();
+    // Inline residue: base summary + dialog link; clause text NOT on the page.
+    expect(await screen.findByText(new RegExp(CONSENT_INLINE.summaryBase.slice(0, 40)))).toBeInTheDocument();
+    expect(screen.queryByText(CONSENT_COPY.heading)).toBeNull();
+    expect(screen.queryByText(CONSENT_COPY.clauseContactHeadline)).toBeNull();
+    expect(screen.queryByText(CONSENT_COPY.clauseThirdPartyHeadline)).toBeNull();
+
+    // The full agreement in the dialog: clause list + T&C section.
+    await user.click(screen.getByRole('button', { name: CONSENT_INLINE.summaryLinkText }));
+    expect(await screen.findByText(CONSENT_COPY.heading)).toBeInTheDocument();
+    expect(screen.getByText(CONSENT_COPY.clauseContactHeadline)).toBeInTheDocument();
+    expect(screen.getByText(CONSENT_COPY.clauseTermsHeadline)).toBeInTheDocument();
+    expect(screen.getByText(CONSENT_INLINE.sectionTermsTitle)).toBeInTheDocument();
+    expect(screen.getByText('The terms.')).toBeInTheDocument(); // campaign termsContent HTML
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
 
     // All-required-to-submit: locked + helper until the tick.
     const confirm = screen.getByRole('button', { name: 'Confirm redemption' });
     expect(confirm).toBeDisabled();
     expect(screen.getByText(/You'll need to agree to the above to submit\./)).toBeInTheDocument();
 
-    await user.click(screen.getByRole('checkbox', { name: /I agree to all of the above\./ }));
+    await user.click(screen.getByRole('checkbox', { name: /I agree to the agreement above\./ }));
     expect(confirm).toBeEnabled();
     await user.click(confirm);
 
@@ -126,7 +135,26 @@ describe('MarketplaceFlow — agree-all consent step (mktui)', () => {
     );
   });
 
-  it('sponsored campaign: disclosure clause + named sponsor line render; third-party flag goes true', async () => {
+  it('dialog "I agree" ticks the block (full agreement shown there) and closes', async () => {
+    const user = userEvent.setup();
+    getMarketplaceCampaign.mockResolvedValue(baseCampaign());
+    mockApi();
+    renderFlow();
+
+    await driveToConsentStep(user);
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+    await screen.findByText(new RegExp(CONSENT_INLINE.summaryBase.slice(0, 40)));
+
+    expect(screen.getByRole('checkbox', { name: /I agree to the agreement above\./ }))
+      .toHaveAttribute('aria-checked', 'false');
+    await user.click(screen.getByRole('button', { name: CONSENT_INLINE.summaryLinkText }));
+    await user.click(await screen.findByRole('button', { name: CONSENT_INLINE.dialogAgreeCta }));
+    expect(screen.getByRole('checkbox', { name: /I agree to the agreement above\./ }))
+      .toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('button', { name: 'Confirm redemption' })).toBeEnabled();
+  });
+
+  it('sponsored campaign: sponsored summary + named line INLINE; clause in the dialog; third-party flag true', async () => {
     const user = userEvent.setup();
     getMarketplaceCampaign.mockResolvedValue(baseCampaign({ sponsor: { name: 'Acme FA' } }));
     mockApi();
@@ -135,10 +163,15 @@ describe('MarketplaceFlow — agree-all consent step (mktui)', () => {
     await driveToConsentStep(user);
     await user.click(screen.getByRole('button', { name: 'Continue' }));
 
-    expect(await screen.findByText("Sharing with this campaign's sponsor.")).toBeInTheDocument();
+    // "(named on this page)" holds without opening the dialog.
+    expect(await screen.findByText(new RegExp('sharing your details with this campaign'))).toBeInTheDocument();
     expect(screen.getByText('Sponsored by Acme FA.')).toBeInTheDocument();
 
-    await user.click(screen.getByRole('checkbox', { name: /I agree to all of the above\./ }));
+    await user.click(screen.getByRole('button', { name: CONSENT_INLINE.summaryLinkText }));
+    expect(await screen.findByText(CONSENT_COPY.clauseThirdPartyHeadline)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await user.click(screen.getByRole('checkbox', { name: /I agree to the agreement above\./ }));
     await user.click(screen.getByRole('button', { name: 'Confirm redemption' }));
 
     await screen.findByText('Redemption confirmed');
@@ -155,10 +188,11 @@ describe('MarketplaceFlow — agree-all consent step (mktui)', () => {
     await driveToConsentStep(user);
     await user.click(screen.getByRole('button', { name: 'Continue' }));
 
-    await screen.findByText('One agreement — read once');
-    expect(screen.queryByText("Sharing with this campaign's sponsor.")).toBeNull();
+    await screen.findByText(new RegExp(CONSENT_INLINE.summaryBase.slice(0, 40)));
+    expect(screen.queryByText(new RegExp('sharing your details with this campaign'))).toBeNull();
+    expect(screen.queryByText('Sponsored by someone')).toBeNull();
 
-    await user.click(screen.getByRole('checkbox', { name: /I agree to all of the above\./ }));
+    await user.click(screen.getByRole('checkbox', { name: /I agree to the agreement above\./ }));
     await user.click(screen.getByRole('button', { name: 'Confirm redemption' }));
     await screen.findByText('Redemption confirmed');
     const prospectCall = apiClient.post.mock.calls.find(([url]) => url === '/prospects');
@@ -183,9 +217,9 @@ describe('MarketplaceFlow — agree-all consent step (mktui)', () => {
     await user.click(cont);
 
     // Then the agree-all step, still all-required.
-    expect(await screen.findByText('One agreement — read once')).toBeInTheDocument();
+    expect(await screen.findByText(new RegExp(CONSENT_INLINE.summaryBase.slice(0, 40)))).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Confirm redemption' })).toBeDisabled();
-    await user.click(screen.getByRole('checkbox', { name: /I agree to all of the above\./ }));
+    await user.click(screen.getByRole('checkbox', { name: /I agree to the agreement above\./ }));
     await user.click(screen.getByRole('button', { name: 'Confirm redemption' }));
 
     await screen.findByText('Redemption confirmed');


### PR DESCRIPTION
Per Shawn's feedback on the live block ("enormous chunky block of text… put it in a dialog box, one whole list of what the person agrees + a terms & conditions section"):

## What

**Inline (both funnels)** — the block shrinks to one sentence + link + the required checkbox:
> By submitting, you agree to be contacted by Redeem about this offer and future ones, and to this campaign's terms — **read the full agreement**.
> ☐ I agree to the agreement above. *

Sponsored campaigns use a sponsored sentence variant AND keep the named-sponsor line on the page — "(named on this page)" in the hashed clause stays literally true without opening anything.

**New `ConsentAgreementDialog`** (MarketingConsentDialog scaffold, shared by CampaignSignupForm + MarketplaceFlow):
- Section 1 "What you're agreeing to" — the §9.4 clause list, byte-identical evidence strings.
- Section 2 "Terms & conditions" — campaign T&C HTML, else the brand default (Referral-Partners wording untouched — deferred on Shawn's instruction).
- Footer "I agree" ticks the block's checkbox and closes. This supersedes the read-only-dialog rule (copy pack §5 #16) — that rule existed because the old dialog held only the T&Cs; this one holds the ENTIRE deal. The in-clause terms link scrolls to Section 2.

## Evidence posture

Presentation-only: era label `2026-07-21-agree-all-v1`, all hashed clause strings, channels, and backend untouched. New `CONSENT_INLINE` constants are chrome, not hashed. The lockstep drift test runs unchanged. One line to add to the open legal-pack item: presentation moved to a layered dialog 2026-07-21, wording/hashes unchanged.

Also rides along: `chore` commit untracking the `node_modules` symlinks accidentally committed by #215.

## Verification

- Vitest **130 files / 1619 tests green** (form + marketplace consent describes reworked for the layered flow; dialog-Agree-ticks test replaces the read-only test).
- Playwright **34/34 on both brand builds**: clause text absent from the page until the dialog opens; dialog shows both sections; Agree ticks + closes; submit still OTP-gated after agreeing; sponsored variant keeps the sponsor name inline; 390 px mobile zero overflow, dialog usable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDA1rRU4PjRec9dJT7q9eK