### PR TITLE
fix(legal): T&C §2 — don't claim reward businesses pay us; only sponsors do

### DIFF
--- a/src/components/campaigns/__tests__/CampaignSignupForm.test.jsx
+++ b/src/components/campaigns/__tests__/CampaignSignupForm.test.jsx
@@ -463,7 +463,7 @@ describe('CampaignSignupForm — mandatory agree-all consent block', () => {
     expect(screen.queryByText(CONSENT_COPY.clauseThirdPartyHeadline)).toBeNull();
     // Section 2 renders the brand-default T&C fallback when no termsContent.
     expect(screen.getByText(CONSENT_INLINE.sectionTermsTitle)).toBeInTheDocument();
-    expect(screen.getByText(/How campaigns are funded/)).toBeInTheDocument();
+    expect(screen.getByText(/The reward is free to you/)).toBeInTheDocument();
   });
 
   it('a NAMED sponsor: sponsored summary + named line INLINE (no dialog needed), clause in the dialog', async () => {

--- a/src/components/legal/DefaultTermsCopy.jsx
+++ b/src/components/legal/DefaultTermsCopy.jsx
@@ -55,13 +55,12 @@ export default function DefaultTermsCopy() {
         </p>
       </Section>
 
-      <Section title="2. How campaigns are funded">
+      <Section title="2. The reward is free to you">
         <p style={{ margin: 0 }}>
-          The businesses and sponsors behind each campaign pay {brand.name} to run it. That is why
-          the reward is provided to you at no charge — you pay {brand.name} nothing. {brand.name}{' '}
+          The reward is provided to you at no charge — you pay {brand.name} nothing. {brand.name}{' '}
           does not engage introducers or referral agents, and no third party is compensated for
-          referring you to {brand.name}. We do advertise on platforms such as Facebook, Instagram
-          and TikTok; section 10 of our Personal Data Policy sets out what those platforms receive.
+          referring you to {brand.name}. We advertise on platforms such as Facebook, Instagram and
+          TikTok; section 10 of our Personal Data Policy sets out what those platforms receive.
         </p>
       </Section>
 
@@ -74,8 +73,9 @@ export default function DefaultTermsCopy() {
           <li>
             <strong style={{ color: TOKENS.ink }}>By a partner business</strong> — an independent
             third party, such as a studio, enrichment centre, clinic or retailer, which provides
-            the trial, session or product described. That business is responsible for the reward
-            it provides and for the conduct of its own services; {brand.name} is not the provider.
+            the trial, session or product described to introduce its own services. That business
+            is responsible for the reward it provides and for the conduct of its own services;{' '}
+            {brand.name} is not the provider.
           </li>
           <li>
             <strong style={{ color: TOKENS.ink }}>By the sponsoring consultant</strong> — where a

--- a/src/components/legal/__tests__/DefaultTermsCopy.test.jsx
+++ b/src/components/legal/__tests__/DefaultTermsCopy.test.jsx
@@ -14,13 +14,16 @@ import DefaultTermsCopy from '../DefaultTermsCopy';
  * session), and nobody is paid to send consumers here.
  */
 describe('DefaultTermsCopy — the terms describe the real business model', () => {
-  it('states that sponsors/businesses fund campaigns and that nobody is paid to refer consumers in', () => {
-    render(<DefaultTermsCopy />);
-    expect(screen.getByText(/How campaigns are funded/)).toBeInTheDocument();
+  it('says the reward is free and that nobody is paid to refer consumers in', () => {
+    const { container } = render(<DefaultTermsCopy />);
+    expect(screen.getByText(/The reward is free to you/)).toBeInTheDocument();
     expect(
       screen.getByText(/no third party is compensated for referring you/i)
     ).toBeInTheDocument();
     expect(screen.getByText(/does not engage introducers or referral agents/i)).toBeInTheDocument();
+    // Must NOT claim the reward businesses pay us — only sponsors pay (per lead);
+    // partner businesses provide trials to advertise themselves and may pay nothing.
+    expect(container.textContent).not.toMatch(/businesses and sponsors[^.]*pay/i);
   });
 
   it('describes BOTH reward paths: an independent partner business, or the consultant at the session', () => {


### PR DESCRIPTION
Follow-up to #217. Shawn flagged §2 "the businesses and sponsors behind each campaign pay Redeem to run it" as wrong.

## The correction

Only **sponsors** (financial advisory firms) pay Redeem — per lead. **Partner businesses** (a pilates studio, an enrichment centre) provide a trial to advertise *their own services* and may pay Redeem nothing. So "businesses… pay Redeem to run it" is false.

- **§2 → "The reward is free to you"** — trimmed to what a consumer needs: the reward is free, nobody is paid to refer you in, we advertise on Meta/TikTok (→ Personal Data Policy §10). The who-pays-whom mechanics are dropped ("if you don't need to say it, don't").
- **§3 partner path** now states the business provides the trial "to introduce its own services" — the accurate reason a partner gives something free.
- **§6 unchanged** and still correct: Redeem is paid by the *sponsor* for running a sponsored campaign.

## Guard

The business-model test now also fails if the terms ever again assert the reward businesses pay Redeem. Not a consent-evidence change — hashed clauses (`CONSENT_COPY.clause*`) are untouched.

## Verification

- Vitest **131 files / 1625 green**.
- Playwright **14/14 both brands**: §2 retitled, the false "businesses…pay" / "pay Redeem to run it" claims absent, no-introducer statement kept, partner "introduce its own services" present, consultant reward path + 20-min session intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDA1rRU4PjRec9dJT7q9eK