### PR TITLE
feat(consent): PR C — PDPA person-level erasure (tracker "erasure")

### DIFF
--- a/backend/src/controllers/consumerController.js
+++ b/backend/src/controllers/consumerController.js
@@ -1,5 +1,6 @@
 import { asyncHandler, AppError } from '../middleware/errorHandler.js';
 import { getConsumerJourney } from '../services/consumerService.js';
+import { eraseConsumer as eraseConsumerSvc } from '../services/erasureService.js';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -19,4 +20,26 @@ export const getConsumer = asyncHandler(async (req, res) => {
     throw new AppError('Consumer not found', 404);
   }
   res.json({ success: true, data: journey });
+});
+
+/**
+ * PDPA erasure (PR C) — destructive and irreversible, so the body must carry
+ * the literal confirm token; admin-gated at the route. Idempotent: re-POSTing
+ * an erased consumer returns { alreadyErased: true } without side effects.
+ */
+export const eraseConsumer = asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  if (!UUID_RE.test(String(id || ''))) {
+    throw new AppError('Consumer not found', 404);
+  }
+  if (req.body?.confirm !== 'ERASE') {
+    throw new AppError("Erasure requires body.confirm = 'ERASE'", 422);
+  }
+  const reason = typeof req.body?.reason === 'string' && req.body.reason.trim()
+    ? req.body.reason.trim().slice(0, 255)
+    : null;
+  const report = await eraseConsumerSvc(id, {
+    actorUser: req.user, reason, requestId: req.id || null,
+  });
+  res.json({ success: true, data: report });
 });

--- a/backend/src/routes/consumers.js
+++ b/backend/src/routes/consumers.js
@@ -11,4 +11,7 @@ const router = express.Router();
 // aggregates a person's history across every campaign and must not be.
 router.get('/:id', authenticateToken, requireAdmin, consumerController.getConsumer);
 
+// PDPA person-level erasure (PR C) — admin + explicit body.confirm='ERASE'.
+router.post('/:id/erase', authenticateToken, requireAdmin, consumerController.eraseConsumer);
+
 export default router;

--- a/backend/src/services/dncCheckService.js
+++ b/backend/src/services/dncCheckService.js
@@ -58,6 +58,19 @@ function setCached(number, registered, now = Date.now()) {
   resultCache.set(cacheKey(number), { registered, expiresAt: now + cacheTtlMs() });
 }
 
+/**
+ * PR C erasure: evict any cached DNC result for this phone (post-commit).
+ * The cache is keyed by the formatDncNumber output, so all plausible key
+ * variants of the erased phone are dropped.
+ */
+export function evictDncCheckCache(phoneish) {
+  const digits = String(phoneish || '').replace(/\D/g, '');
+  if (!digits) return;
+  for (const variant of new Set([String(phoneish), digits, digits.slice(-8), `+${digits}`])) {
+    resultCache.delete(cacheKey(variant));
+  }
+}
+
 /** Test helper — clear the per-number result cache. */
 export function _resetDncCheckCache() {
   resultCache.clear();

--- a/backend/src/services/erasureService.js
+++ b/backend/src/services/erasureService.js
@@ -1,0 +1,673 @@
+import { randomUUID } from 'crypto';
+import { Op, Transaction } from 'sequelize';
+import {
+  sequelize, Consumer, Prospect, RewardEntitlement, RedemptionEvent,
+  ConsentEvent, ConsumerSuppression, WebhookSubscriber, WebhookDelivery,
+} from '../models/index.js';
+import { AppError } from '../middleware/errorHandler.js';
+import { logger } from '../utils/logger.js';
+import { emailNormKey } from './repeatSignup.js';
+import { makeInventoryService } from './redeemOps/inventoryService.js';
+import { makeRedeemOpsAuditService } from './redeemOps/auditService.js';
+import { buildLeadDeletedPayload } from './prospectHelpers.js';
+import { flushDeliveries } from './webhookService.js';
+import { evictVerifiedPhone } from './verifiedPhoneStore.js';
+import { evictDncCheckCache } from './dncCheckService.js';
+
+/**
+ * PDPA person-level erasure (PR C, docs/plans/consumer-spine-and-consent-ledger.md §4).
+ *
+ * ERASURE = ALLOWLIST REBUILD, NOT A SCRUB LIST: a prospect row keeps only its
+ * non-personal skeleton (ids, campaign, status/priority/score, quarantine,
+ * conversionDate, utm source labels) and EVERYTHING else goes — including the
+ * copies PII leaked into over its lifetime: activity update-snapshots,
+ * commission descriptions, webhook delivery payloads, draw-entry masked-name
+ * snapshots, referral-name copies on OTHER people's rows, provider idempotency
+ * responses, OTP rows, waitlist rows, session/attribution browsing records.
+ *
+ * Concurrency contract (§4 lock ordering): the Consumer row is locked FOR
+ * UPDATE **first**, and capture takes the same lock first too (the resolver's
+ * consumers upsert runs BEFORE Prospect.create — prospectService §capture), so
+ * capture-vs-erase serializes cleanly: capture-first → the new prospect is
+ * visible to the erasure's enumeration; erasure-first → the capture upsert
+ * waits, sees the phone freed at commit (phone nulled ⇒ out of
+ * uq_consumers_phone), and mints a NEW consumer. Re-signup after erasure is a
+ * new person with fresh consent, by construction — no tombstone (PDPC: an
+ * unsalted hash of an enumerable space is pseudonymous, so phoneHash is
+ * nulled too).
+ *
+ * Re-POSTing an erased consumer runs a REPAIR pass (Codex R1 #2): the same
+ * scrub over every consumerId-linked row, so PII that leaked back in through a
+ * race (a concurrent staff edit, a draw freeze mid-erase) is removable by
+ * simply erasing again. Identity-derived arms (phone/email matching) are dead
+ * on repair — the identity is already null — which is exactly why writers are
+ * also guarded (updateProspect 410s on erased rows).
+ *
+ * The deliberate exception to the spine's "rebuildable projection" principle:
+ * this mutates source rows. The reconciler never resurrects an erased
+ * consumer — its groups require prospects.phone IS NOT NULL (all nulled here)
+ * and its zeroing branch targets phone IS NOT NULL consumers only.
+ *
+ * Retained-skeleton stance (Codex R1 #10, decided): business/transaction
+ * records (redemptions, commissions, draw audit chain, counters) are kept
+ * under PDPA's business-records basis, admin-gated; person FKs stay so the
+ * suppression keeps meaning something. What must never remain is CONTENT
+ * about the person — and that is what the matrix removes.
+ */
+
+/** draw_entries.phoneHash is NOT NULL — erasure writes this obviously-fake sentinel. */
+export const ERASED_PHONE_HASH = '0'.repeat(64);
+
+/** Events whose payloads embed the full lead PII (the "ever received" markers). */
+const RECEIVED_EVENT_TYPES = ['lead.created', 'lead.assigned'];
+
+const digitsOf = (v) => String(v || '').replace(/\D/g, '');
+
+const defaultDeps = {
+  sequelize, Consumer, Prospect, RewardEntitlement, RedemptionEvent,
+  ConsentEvent, ConsumerSuppression, WebhookSubscriber, WebhookDelivery,
+  logger, flushDeliveries, evictVerifiedPhone, evictDncCheckCache,
+  inventory: makeInventoryService(),
+  audit: makeRedeemOpsAuditService(),
+};
+
+export function makeErasureService(overrides = {}) {
+  const d = { ...defaultDeps, ...overrides };
+
+  /** The sourceMetadata allowlist rebuild: utm source labels + the erased marker. */
+  function erasedSourceMetadata(sm) {
+    const utmIn = sm && typeof sm === 'object' && sm.utm && typeof sm.utm === 'object' ? sm.utm : null;
+    const utm = utmIn
+      ? {
+          ...(typeof utmIn.utm_source === 'string' && utmIn.utm_source ? { utm_source: utmIn.utm_source } : {}),
+          ...(typeof utmIn.utm_medium === 'string' && utmIn.utm_medium ? { utm_medium: utmIn.utm_medium } : {}),
+          ...(typeof utmIn.utm_campaign === 'string' && utmIn.utm_campaign ? { utm_campaign: utmIn.utm_campaign } : {}),
+        }
+      : null;
+    return { ...(utm && Object.keys(utm).length ? { utm } : {}), erased: true };
+  }
+
+  const rowCount = (meta) => meta?.rowCount ?? 0;
+
+  /**
+   * Erase one consumer: one transaction over the full table matrix, then a
+   * post-commit flush of the lead.deleted outbox rows + in-memory cache
+   * evictions. Idempotent AND self-repairing — a second call (or a
+   * crash-after-commit retry) re-runs the scrub over consumer-linked rows
+   * without re-doing counters/suppression/ledger.
+   *
+   * Returns a per-table report so the admin (and the audit trail) can see
+   * exactly what was touched — including what could NOT be done (fanout
+   * skipped, inventory reversal failures, provider call ids needing external
+   * deletion).
+   */
+  async function eraseConsumer(consumerId, { actorUser = null, reason = null, requestId = null } = {}) {
+    const report = {
+      consumerId,
+      alreadyErased: false,
+      repair: false,
+      prospects: 0,
+      referralCopiesScrubbed: 0,
+      activities: 0,
+      commissions: 0,
+      entitlementsCancelled: 0,
+      entitlementsScrubbed: 0,
+      inventoryReversalFailures: 0,
+      redemptions: 0,
+      redemptionEvents: 0,
+      inventoryEventReasons: 0,
+      auditReasons: 0,
+      drawEntries: 0,
+      drawAttemptsClosed: 0,
+      boostReviewReasons: 0,
+      shortLinks: 0,
+      sessionVisits: 0,
+      attributions: 0,
+      webhookDeliveriesScrubbed: 0,
+      webhookDeliveriesCancelled: 0,
+      leadDeletedQueued: 0,
+      webhooksDisabled: false,
+      idempotencyKeys: 0,
+      verifications: 0,
+      waitlistSignups: 0,
+      consentSourceUrlsScrubbed: 0,
+      retellCallIds: [], // provider-side deletion SOP: delete these calls in Retell
+    };
+    let outboxPairs = [];
+    let erasedPhone = null;
+
+    await d.sequelize.transaction(async (t) => {
+      // 1. THE lock — every capture of this phone serializes behind this row.
+      const consumer = await d.Consumer.findByPk(consumerId, {
+        transaction: t,
+        lock: Transaction.LOCK.UPDATE,
+      });
+      if (!consumer) throw new AppError('Consumer not found', 404);
+      report.alreadyErased = Boolean(consumer.erasedAt);
+      report.repair = report.alreadyErased;
+
+      const now = new Date();
+      const phone = consumer.phone || null;
+      erasedPhone = phone;
+      const phoneDigits = phone ? digitsOf(phone) : null;
+
+      // 2. Mark erasing BEFORE enumeration (§4) — inside this txn the flag and
+      // the scrub commit together; the early write is ordering hygiene.
+      if (!consumer.erasedAt) {
+        await consumer.update({ erasedAt: now }, { transaction: t });
+      }
+
+      // 3. Enumerate + lock the person's prospects:
+      //    - by consumer link,
+      //    - by DIGITS-normalized phone (raw-format Meta rows, spacing
+      //      variants — exact-match would miss them; Codex R1 #1),
+      //    - call_bot rows whose sourceMetadata.fromNumber is this person
+      //      (inbound calls store MKTR's DDI as `phone`, the CALLER in
+      //      fromNumber — the transcript/summary/recording live on that row).
+      //    Inbound rows for OTHER callers (DDI phone, different fromNumber)
+      //    stay untouched.
+      const orArms = [{ consumerId }];
+      if (phoneDigits) {
+        // phoneDigits is digitsOf() output — \d+ only, safe to inline.
+        orArms.push(
+          d.sequelize.literal(`regexp_replace(COALESCE("Prospect"."phone", ''), '\\D', '', 'g') = '${phoneDigits}'`),
+          d.sequelize.literal(`("Prospect"."leadSource" = 'call_bot' AND regexp_replace(COALESCE("Prospect"."sourceMetadata"->>'fromNumber', ''), '\\D', '', 'g') = '${phoneDigits}')`)
+        );
+      }
+      const prospects = await d.Prospect.findAll({
+        where: { [Op.or]: orArms },
+        transaction: t,
+        lock: Transaction.LOCK.UPDATE,
+      });
+      const pids = prospects.map((p) => p.id);
+      const prospectEmails = prospects.map((p) => emailNormKey(p.email)).filter(Boolean);
+      const sessionIds = [...new Set(prospects.map((p) => p.sessionId).filter(Boolean))];
+      const attributionIds = [...new Set(prospects.map((p) => p.attributionId).filter(Boolean))];
+      report.retellCallIds = [...new Set(prospects
+        .map((p) => p.retellCallId || p.sourceMetadata?.retellCallId)
+        .filter(Boolean))];
+
+      if (pids.length) {
+        // 4. Who ever RECEIVED this lead (before payloads are scrubbed).
+        const [recipientRows] = await d.sequelize.query(
+          `SELECT DISTINCT wd."subscriberId" AS id,
+                  (wd.payload::jsonb #>> '{data,lead,externalId}') AS pid
+             FROM webhook_deliveries wd
+            WHERE wd."eventType" IN (:eventTypes)
+              AND (wd.payload::jsonb #>> '{data,lead,externalId}') IN (:pids)`,
+          { replacements: { eventTypes: RECEIVED_EVENT_TYPES, pids }, transaction: t }
+        );
+
+        // 5a. A pending delivery still carrying PII must never fire later.
+        // (The in-memory instance a flush already queued is fenced too:
+        // attemptDelivery reloads the row and refuses non-pending — PR C.)
+        const [, cancelMeta] = await d.sequelize.query(
+          `UPDATE webhook_deliveries
+              SET status = 'failed', "errorMessage" = 'cancelled: person erased', "updatedAt" = now()
+            WHERE status = 'pending'
+              AND "eventType" <> 'lead.deleted'
+              AND (payload::jsonb #>> '{data,lead,externalId}') IN (:pids)`,
+          { replacements: { pids }, transaction: t }
+        );
+        report.webhookDeliveriesCancelled = rowCount(cancelMeta);
+
+        // 5b. Scrub every historical payload copy down to its envelope. Runs
+        // BEFORE the lead.deleted outbox rows are written; earlier repair-run
+        // outbox rows are excluded by event type.
+        const [, scrubMeta] = await d.sequelize.query(
+          `UPDATE webhook_deliveries
+              SET payload = json_build_object(
+                    'event', "eventType",
+                    'deliveryId', payload::jsonb ->> 'deliveryId',
+                    'erased', true,
+                    'data', json_build_object('lead', json_build_object(
+                      'externalId', payload::jsonb #>> '{data,lead,externalId}'))),
+                  "responseBody" = NULL,
+                  "updatedAt" = now()
+            WHERE "eventType" <> 'lead.deleted'
+              AND (payload::jsonb #>> '{data,lead,externalId}') IN (:pids)
+              AND (payload::jsonb -> 'erased') IS NULL`,
+          { replacements: { pids }, transaction: t }
+        );
+        report.webhookDeliveriesScrubbed = rowCount(scrubMeta);
+
+        // 5c. Referral copies on OTHER people's rows (Codex R1 #8): capture
+        // denormalizes the referrer's NAME into each referred prospect's
+        // sourceMetadata.referral — and their webhook payloads copied it.
+        const [refRows] = await d.sequelize.query(
+          `SELECT id, "sourceMetadata" FROM prospects
+            WHERE ("sourceMetadata"::jsonb #>> '{referral,referrerProspectId}') IN (:pids)
+              AND ("sourceMetadata"::jsonb #> '{referral}') ? 'referrerName'
+              FOR UPDATE`,
+          { replacements: { pids }, transaction: t }
+        );
+        for (const r of refRows) {
+          const sm = r.sourceMetadata || {};
+          const referral = { ...(sm.referral || {}) };
+          delete referral.referrerName;
+          await d.sequelize.query(
+            'UPDATE prospects SET "sourceMetadata" = :sm, "updatedAt" = now() WHERE id = :id',
+            { replacements: { sm: JSON.stringify({ ...sm, referral }), id: r.id }, transaction: t }
+          );
+        }
+        report.referralCopiesScrubbed = refRows.length;
+        await d.sequelize.query(
+          `UPDATE webhook_deliveries
+              SET payload = jsonb_set(payload::jsonb, '{data,lead,sourceMetadata,referral,referrerName}', '"[erased]"'::jsonb)::json
+            WHERE (payload::jsonb #>> '{data,lead,sourceMetadata,referral,referrerProspectId}') IN (:pids)
+              AND (payload::jsonb #> '{data,lead,sourceMetadata,referral}') ? 'referrerName'`,
+          { replacements: { pids }, transaction: t }
+        );
+
+        // 6. lead.deleted outbox, in-txn (the deleteProspect transactional-
+        // outbox pattern) for every enabled subscriber that both received this
+        // lead and handles lead.deleted — deduped against earlier runs, so a
+        // repair pass only queues what a crash lost. Lyfe's subscriber does
+        // NOT handle it (known §4 gap — cross-repo follow-up; manual SOP until
+        // then). Webhooks disabled ⇒ surfaced on the report, and a later
+        // repair POST re-attempts (best-effort posture, never blocks erasure).
+        if (String(process.env.WEBHOOK_ENABLED || 'false').toLowerCase() !== 'true') {
+          report.webhooksDisabled = true;
+          if (recipientRows.length) {
+            d.logger.warn('[erasure] lead.deleted not queued (webhooks disabled) — erase again to re-attempt', {
+              consumerId, prospects: pids.length,
+            });
+          }
+        } else if (recipientRows.length) {
+          const subIds = [...new Set(recipientRows.map((r) => r.id))];
+          const subscribers = await d.WebhookSubscriber.findAll({
+            where: { id: { [Op.in]: subIds }, enabled: true },
+            transaction: t,
+          });
+          const handlers = subscribers.filter((s) => (s.events || []).includes('lead.deleted'));
+          const receivedBySub = new Map();
+          for (const r of recipientRows) {
+            if (!receivedBySub.has(r.id)) receivedBySub.set(r.id, new Set());
+            receivedBySub.get(r.id).add(r.pid);
+          }
+          for (const sub of handlers) {
+            for (const pid of receivedBySub.get(sub.id) || []) {
+              const [dupRows] = await d.sequelize.query(
+                `SELECT 1 FROM webhook_deliveries
+                  WHERE "subscriberId" = :sid AND "eventType" = 'lead.deleted'
+                    AND (payload::jsonb #>> '{data,lead,externalId}') = :pid
+                  LIMIT 1`,
+                { replacements: { sid: sub.id, pid }, transaction: t }
+              );
+              if (dupRows.length) continue;
+              const deliveryId = randomUUID();
+              const payload = { ...buildLeadDeletedPayload({ id: pid }), deliveryId };
+              const delivery = await d.WebhookDelivery.create({
+                subscriberId: sub.id, deliveryId, eventType: 'lead.deleted', payload, status: 'pending',
+              }, { transaction: t });
+              outboxPairs.push({ delivery, subscriber: sub });
+            }
+          }
+          report.leadDeletedQueued = outboxPairs.length;
+        }
+
+        // 7. Prospect allowlist rebuild. KEPT: id, campaignId, consumerId,
+        // leadSource, leadStatus, priority, score, conversionDate, agent/qr
+        // refs, quarantine fields, timestamps (business-records basis).
+        // Everything else is PII or a PII pointer and goes.
+        const [, pMeta] = await d.sequelize.query(
+          `UPDATE prospects SET
+              "firstName" = 'Erased', "lastName" = NULL, email = NULL, phone = NULL,
+              company = NULL, "jobTitle" = NULL, industry = NULL,
+              interests = '[]', budget = NULL, location = NULL, demographics = NULL,
+              preferences = NULL, notes = NULL, tags = '[]',
+              "lastContactDate" = NULL, "nextFollowUpDate" = NULL,
+              "sessionId" = NULL, "attributionId" = NULL, "retellCallId" = NULL,
+              "dncStatus" = NULL, "dncNoVoiceCall" = NULL, "dncNoTextMessage" = NULL,
+              "dncNoFax" = NULL, "dncCheckedAt" = NULL, "dncValidUntil" = NULL,
+              "dncMetadata" = NULL,
+              "consentMetadata" = '{"erased":true}'::jsonb,
+              "consumerId" = :consumerId,
+              "updatedAt" = now()
+            WHERE id IN (:pids)`,
+          { replacements: { pids, consumerId }, transaction: t }
+        );
+        report.prospects = rowCount(pMeta);
+
+        // sourceMetadata is a json column with heterogeneous shapes — the
+        // allowlist is rebuilt in JS per row (a person has a handful of rows).
+        for (const p of prospects) {
+          await d.sequelize.query(
+            'UPDATE prospects SET "sourceMetadata" = :sm WHERE id = :id',
+            { replacements: { sm: JSON.stringify(erasedSourceMetadata(p.sourceMetadata)), id: p.id }, transaction: t }
+          );
+        }
+
+        // The person's browsing records (Codex R1 #9): sessions + attribution
+        // rows are deleted outright once no other prospect references them;
+        // qr_scans keep only device-level aggregates (no person link left).
+        if (sessionIds.length) {
+          const [, svMeta] = await d.sequelize.query(
+            `DELETE FROM session_visits sv
+              WHERE sv."sessionId" IN (:sessionIds)
+                AND NOT EXISTS (SELECT 1 FROM prospects p2 WHERE p2."sessionId" = sv."sessionId")`,
+            { replacements: { sessionIds }, transaction: t }
+          );
+          report.sessionVisits = rowCount(svMeta);
+        }
+        if (attributionIds.length) {
+          const [, atMeta] = await d.sequelize.query(
+            `DELETE FROM attributions a
+              WHERE a.id IN (:attributionIds)
+                AND NOT EXISTS (SELECT 1 FROM prospects p2 WHERE p2."attributionId" = a.id)`,
+            { replacements: { attributionIds }, transaction: t }
+          );
+          report.attributions = rowCount(atMeta);
+        }
+
+        // Provider idempotency responses persist the prospect link (+ payload
+        // echoes) — delete them; replay protection matters less than the
+        // person (rows TTL out anyway).
+        const [, ikMeta] = await d.sequelize.query(
+          `DELETE FROM idempotency_keys
+            WHERE ("responseBody"::jsonb ->> 'prospectId') IN (:pids)`,
+          { replacements: { pids }, transaction: t }
+        );
+        report.idempotencyKeys = rowCount(ikMeta);
+
+        // 8. Activity metadata (update snapshots embed full before/after PII).
+        // Descriptions reference campaign/staff names only — kept for ops history.
+        const [, aMeta] = await d.sequelize.query(
+          `UPDATE prospect_activities SET metadata = '{"erased":true}', "updatedAt" = now()
+            WHERE "prospectId" IN (:pids)`,
+          { replacements: { pids }, transaction: t }
+        );
+        report.activities = rowCount(aMeta);
+
+        // 9. Commission free text embeds the lead's name ("Lead conversion:
+        // First Last"); metadata is operator-supplied JSON — both scrubbed.
+        // Financials/status/paymentInfo (the AGENT's payout data) stay.
+        const [, cMeta] = await d.sequelize.query(
+          `UPDATE commissions SET description = NULL, metadata = '{"erased":true}', "updatedAt" = now()
+            WHERE "prospectId" IN (:pids)`,
+          { replacements: { pids }, transaction: t }
+        );
+        report.commissions = rowCount(cMeta);
+
+        // 13. Share links: expire + unlink + strip the ref= param out of the
+        // public target (clicks are the VISITORS' data and keep aggregates).
+        const [linkRows] = await d.sequelize.query(
+          'SELECT id, "targetUrl" FROM short_links WHERE "prospectId" IN (:pids) FOR UPDATE',
+          { replacements: { pids }, transaction: t }
+        );
+        for (const link of linkRows) {
+          let target = link.targetUrl;
+          try {
+            const u = new URL(link.targetUrl);
+            u.searchParams.delete('ref');
+            target = u.toString();
+          } catch { /* keep original on parse failure */ }
+          await d.sequelize.query(
+            `UPDATE short_links SET "prospectId" = NULL, "targetUrl" = :target,
+                    "expiresAt" = now(), "updatedAt" = now()
+              WHERE id = :id`,
+            { replacements: { target, id: link.id }, transaction: t }
+          );
+        }
+        report.shortLinks = linkRows.length;
+      }
+
+      // 10. Entitlements — by prospect, by consumer, and by phoneKey (legacy
+      // rows that predate the spine). Live ones cancel WITH the full
+      // cancelEntitlement bookkeeping; every row drops phoneKey/tokenHint.
+      const entitlements = await d.RewardEntitlement.findAll({
+        where: {
+          [Op.or]: [
+            ...(pids.length ? [{ prospectId: { [Op.in]: pids } }] : []),
+            { consumerId },
+            ...(phoneDigits ? [{ phoneKey: phoneDigits }] : []),
+          ],
+        },
+        transaction: t,
+        lock: Transaction.LOCK.UPDATE,
+      });
+      const eids = entitlements.map((e) => e.id);
+      for (const ent of entitlements) {
+        const live = ['eligible', 'issued'].includes(ent.status);
+        if (ent.phoneKey !== null || ent.tokenHint !== null || live) {
+          await d.RewardEntitlement.update(
+            { ...(live ? { status: 'cancelled' } : {}), phoneKey: null, tokenHint: null },
+            { where: { id: ent.id }, transaction: t }
+          );
+        }
+        if (live) {
+          report.entitlementsCancelled += 1;
+          // Counter bookkeeping runs behind a SAVEPOINT: a skewed ledger must
+          // never abort a PDPA erasure — but a swallowed failure is SURFACED
+          // (report + event metadata), never silent (Codex R1 #4).
+          let reversalOk = true;
+          try {
+            await d.sequelize.transaction({ transaction: t }, async (sp) => {
+              await d.inventory.reverseIssued({
+                offerId: ent.rewardOfferId, activationId: ent.activationId,
+                entitlementId: ent.id, type: 'cancelled', actorType: 'staff',
+                reason: 'erasure', transaction: sp,
+              });
+              await d.sequelize.query(
+                `UPDATE activations SET "issuedCount" = "issuedCount" - 1, "updatedAt" = NOW()
+                  WHERE id = :id AND "issuedCount" > 0`,
+                { replacements: { id: ent.activationId }, transaction: sp }
+              );
+            });
+          } catch (err) {
+            reversalOk = false;
+            report.inventoryReversalFailures += 1;
+            d.logger.error('[erasure] inventory reversal FAILED — counters need manual reconcile', {
+              entitlementId: ent.id, error: err?.message || String(err),
+            });
+          }
+          await d.RedemptionEvent.create({
+            entitlementId: ent.id, type: 'manual_override', actorType: 'staff',
+            actorUserId: actorUser?.id || null,
+            metadata: { action: 'erased', ...(reversalOk ? {} : { inventoryReversalFailed: true }) },
+          }, { transaction: t });
+        } else {
+          report.entitlementsScrubbed += 1;
+        }
+      }
+
+      // 11. Redemption free-text + receipt metadata (masked destinations,
+      // reversal reasons, error strings) + inventory/audit operator text
+      // (Codex R1 #13). The strip runs AFTER the 'erased' override events
+      // above, but those carry only {action} — unaffected.
+      if (eids.length) {
+        const [, rMeta] = await d.sequelize.query(
+          `UPDATE redemptions SET notes = NULL, "updatedAt" = now()
+            WHERE "entitlementId" IN (:eids) AND notes IS NOT NULL`,
+          { replacements: { eids }, transaction: t }
+        );
+        report.redemptions = rowCount(rMeta);
+        const [, reMeta] = await d.sequelize.query(
+          `UPDATE redemption_events
+              SET metadata = (metadata - 'to' - 'reason' - 'error')
+            WHERE "entitlementId" IN (:eids) AND metadata IS NOT NULL
+              AND (metadata ? 'to' OR metadata ? 'reason' OR metadata ? 'error')`,
+          { replacements: { eids }, transaction: t }
+        );
+        report.redemptionEvents = rowCount(reMeta);
+        const [, ivMeta] = await d.sequelize.query(
+          `UPDATE reward_inventory_events SET reason = NULL
+            WHERE "entitlementId" IN (:eids) AND reason IS NOT NULL AND reason <> 'erasure'`,
+          { replacements: { eids }, transaction: t }
+        );
+        report.inventoryEventReasons = rowCount(ivMeta);
+        const auditEntityIds = [...eids, ...pids];
+        const [, arMeta] = await d.sequelize.query(
+          `UPDATE redeem_ops_audit_events SET reason = NULL
+            WHERE "entityType" IN ('reward_entitlement', 'redemption', 'prospect')
+              AND "entityId" IN (:auditEntityIds) AND reason IS NOT NULL`,
+          { replacements: { auditEntityIds }, transaction: t }
+        );
+        report.auditReasons = rowCount(arMeta);
+      }
+
+      // 12. Draw entries (prospect join + phoneHash fallback — draw_entries
+      // has no consumerId until tracker "drawlink"): unpickable + snapshot
+      // scrubbed. phoneHash is NOT NULL ⇒ the all-zeros sentinel. Boost-review
+      // operator text follows the entries.
+      const [entryRows] = await d.sequelize.query(
+        `SELECT id FROM draw_entries
+          WHERE ${pids.length ? '"prospectId" IN (:pids) OR' : ''} "phoneHash" = :ph
+          FOR UPDATE`,
+        {
+          replacements: { ...(pids.length ? { pids } : {}), ph: consumer.phoneHash || '__none__' },
+          transaction: t,
+        }
+      );
+      const entryIds = entryRows.map((r) => r.id);
+      if (entryIds.length) {
+        const [, deMeta] = await d.sequelize.query(
+          `UPDATE draw_entries
+              SET "prospectId" = NULL, "phoneLast4" = NULL, "displayName" = NULL,
+                  "verifiedAtFreeze" = NULL, "phoneHash" = :sentinel
+            WHERE id IN (:entryIds)`,
+          { replacements: { entryIds, sentinel: ERASED_PHONE_HASH }, transaction: t }
+        );
+        report.drawEntries = rowCount(deMeta);
+
+        // The erased-pending-winner decision (§4): a pending attempt on this
+        // person closes as 'ineligible' — for a sealed/drawn draw the redraw
+        // chain stays legal ('ineligible' is an allowed redraw reason). A
+        // PUBLISHED draw needs the manual winners-wall SOP on top (no
+        // unpublish flow exists). Claimed attempts stay claimed: the prize
+        // was handed over and attempt rows hold no PII.
+        const [, daMeta] = await d.sequelize.query(
+          `UPDATE draw_attempts SET outcome = 'ineligible', "updatedAt" = now()
+            WHERE "pickedEntryId" IN (:entryIds) AND outcome = 'pending'`,
+          { replacements: { entryIds }, transaction: t }
+        );
+        report.drawAttemptsClosed = rowCount(daMeta);
+      }
+      {
+        const dbrArms = [];
+        const dbrRepl = {};
+        if (pids.length) { dbrArms.push('"prospectId" IN (:pids)'); dbrRepl.pids = pids; }
+        if (eids.length) { dbrArms.push('"entitlementId" IN (:eids)'); dbrRepl.eids = eids; }
+        if (dbrArms.length) {
+          const [, dbrMeta] = await d.sequelize.query(
+            `UPDATE draw_boost_reviews SET reason = NULL, "updatedAt" = now()
+              WHERE (${dbrArms.join(' OR ')}) AND reason IS NOT NULL`,
+            { replacements: dbrRepl, transaction: t }
+          );
+          report.boostReviewReasons = rowCount(dbrMeta);
+        }
+      }
+
+      // 14. OTP verification rows are keyed by the E.164 phone and hold codes.
+      if (phone) {
+        const [, vMeta] = await d.sequelize.query(
+          'DELETE FROM verifications WHERE phone IN (:variants)',
+          { replacements: { variants: [phone, phoneDigits] }, transaction: t }
+        );
+        report.verifications = rowCount(vMeta);
+      }
+
+      // 15. Waitlist rows are pure PII (email/name/phone/ip/ua) — deleted, not
+      // husked. Matched on the person's known emails + phone digits.
+      const emails = [...new Set([emailNormKey(consumer.email), ...prospectEmails].filter(Boolean))];
+      if (emails.length || phoneDigits) {
+        const [, wMeta] = await d.sequelize.query(
+          `DELETE FROM waitlist_signups
+            WHERE ${emails.length ? 'lower(trim(email)) IN (:emails)' : 'false'}
+               OR ${phoneDigits ? "regexp_replace(COALESCE(phone, ''), '\\D', '', 'g') = :digits" : 'false'}`,
+          { replacements: { ...(emails.length ? { emails } : {}), ...(phoneDigits ? { digits: phoneDigits } : {}) }, transaction: t }
+        );
+        report.waitlistSignups = rowCount(wMeta);
+      }
+
+      // 16. The person's consent-evidence rows keep their semantic core
+      // (kind/granted/version/verified/when) but drop the page-URL locator
+      // (Codex R1 #11) — the explicit append-only exception, like erasure
+      // itself.
+      const [, csMeta] = await d.sequelize.query(
+        `UPDATE consent_events SET "sourceUrl" = NULL
+          WHERE "consumerId" = :consumerId AND "sourceUrl" IS NOT NULL`,
+        { replacements: { consumerId }, transaction: t }
+      );
+      report.consentSourceUrlsScrubbed = rowCount(csMeta);
+
+      // 17. The consumer itself: identity + attributes + unsub token all null.
+      // phone leaving uq_consumers_phone at commit is what frees the number
+      // for a genuinely-new signup.
+      if (!report.repair) {
+        await consumer.update({
+          phone: null, phoneHash: null, firstName: null, lastName: null,
+          email: null, unsubTokenHash: null,
+        }, { transaction: t });
+      }
+
+      // 18. Suppression: reason 'erasure' blocks EVERYTHING including
+      // transactional (consentService semantics). An existing weaker row
+      // (e.g. a prior unsubscribe) is UPGRADED — findOrCreate alone would
+      // leave 'unsubscribe' in place and transactional sends flowing.
+      const [suppression, created] = await d.ConsumerSuppression.findOrCreate({
+        where: { consumerId, channel: 'all' },
+        defaults: {
+          id: randomUUID(), reason: 'erasure',
+          source: 'erasure_endpoint', actorUserId: actorUser?.id || null,
+        },
+        transaction: t,
+      });
+      if (!created && suppression.reason !== 'erasure') {
+        await suppression.update(
+          { reason: 'erasure', source: 'erasure_endpoint', actorUserId: actorUser?.id || null },
+          { transaction: t }
+        );
+      }
+
+      // 19. Ledger evidence: one explicit GLOBAL denial, source 'erasure'.
+      // The free-text reason stays in the ACCESS-CONTROLLED audit row only —
+      // never in the ledger (Codex R1 #11).
+      const priorErasureEvent = await d.ConsentEvent.findOne({
+        where: { consumerId, source: 'erasure' }, transaction: t,
+      });
+      if (!priorErasureEvent) {
+        await d.ConsentEvent.create({
+          id: randomUUID(), consumerId, prospectId: null, campaignId: null,
+          kind: 'contact', granted: false, channels: null,
+          version: 'erasure-v1', source: 'erasure', sourceUrl: null,
+          verified: false, actorUserId: actorUser?.id || null,
+          metadata: null, occurredAt: now,
+        }, { transaction: t });
+      }
+
+      // 20. Audit trail (admin action on a person). Repair runs get their own
+      // action label so the trail shows the retry.
+      await d.audit.recordAuditEvent({
+        actorUser, action: report.repair ? 'consumer.erased_repair' : 'consumer.erased',
+        entityType: 'consumer', entityId: consumerId, reason, requestId,
+        after: {
+          prospects: report.prospects,
+          entitlementsCancelled: report.entitlementsCancelled,
+          leadDeletedQueued: report.leadDeletedQueued,
+          inventoryReversalFailures: report.inventoryReversalFailures,
+        },
+        transaction: t,
+      });
+    });
+
+    // Post-commit: fire the persisted lead.deleted outbox rows + evict the
+    // in-memory phone caches (OTP-verified marker, DNC result cache).
+    d.flushDeliveries(outboxPairs);
+    if (erasedPhone) {
+      try {
+        d.evictVerifiedPhone(erasedPhone);
+        d.evictDncCheckCache(erasedPhone);
+      } catch (err) {
+        d.logger.warn('[erasure] cache eviction failed', { error: err?.message || String(err) });
+      }
+    }
+    d.logger.info('[erasure] consumer erased', { consumerId, ...report, retellCallIds: report.retellCallIds.length });
+    return report;
+  }
+
+  return { eraseConsumer };
+}
+
+const _default = makeErasureService();
+export const eraseConsumer = _default.eraseConsumer;

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -1341,6 +1341,12 @@ export function makeProspectService(overrides = {}) {
       throw new d.AppError('Prospect not found or access denied', 404);
     }
 
+    // PR C: an erased row is a legal skeleton — staff edits must not be able
+    // to re-attach PII to it (a re-signup creates a fresh row instead).
+    if (prospect.sourceMetadata?.erased === true) {
+      throw new d.AppError('This lead was erased (PDPA) and can no longer be edited', 410);
+    }
+
     const oldStatus = prospect.leadStatus;
     const oldAssignedAgentId = prospect.assignedAgentId;
     const oldAssignedAgent = prospect.assignedAgent;

--- a/backend/src/services/redeemOps/entitlementService.js
+++ b/backend/src/services/redeemOps/entitlementService.js
@@ -11,6 +11,7 @@ import { makeRedeemOpsAuditService } from './auditService.js';
 import { mintToken, hashToken, tokenHintOf } from './tokens.js';
 import { canEmailProspect, makeFulfilmentNotify } from './fulfilmentNotify.js';
 import { canWhatsAppProspect, waEnabled, waRecipient } from './whatsappService.js';
+import { isSendBlocked } from '../consentService.js';
 
 const DEFAULT_RESERVATION_DAYS = 30;
 const DEFAULT_REDEMPTION_DAYS = 90;
@@ -68,6 +69,7 @@ export function makeEntitlementService(overrides = {}) {
     notifyUnlockWa: null, // injected by entitlementWiring (voucher WhatsApp, PR E) — null-safe
     notifyReservationWa: null, // injected by entitlementWiring (reservation-pass WhatsApp, PR E) — null-safe
     builders: null, // share/claim-URL builders; defaults lazily to makeFulfilmentNotify()
+    isSendBlocked, // PR C: erasure stop at the send choke point (transactional purpose)
     ...overrides,
   };
   const builders = () => {
@@ -145,11 +147,33 @@ export function makeEntitlementService(overrides = {}) {
     channels = ['whatsapp', 'email'],
   }) {
     const args = kind === 'voucher'
-      ? { entitlement, prospect, voucherToken }
-      : { entitlement, prospect, presentationToken };
+      ? { entitlement, voucherToken }
+      : { entitlement, presentationToken };
     const fire = (fn, channel) => {
       const delivery = Promise.resolve()
-        .then(() => fn(args))
+        .then(async () => {
+          // PR C erasure stop: these sends are queued with a point-in-time
+          // prospect object, and an erasure can land between the queue and the
+          // fire. Reload the row and re-check right before sending — an erased
+          // person's voucher/pass must never leave the building. Post-erasure
+          // the reloaded row also has null email/phone, so the sender's own
+          // guards skip too (defence in depth). isSendBlocked fails OPEN for
+          // transactional purpose: a consent-infra hiccup never strands a
+          // legitimate voucher. Only persisted prospects are re-checked — an
+          // id-less object has no row to reload (and no erasure to observe).
+          let target = prospect;
+          if (prospect?.id) {
+            const fresh = await d.Prospect.findByPk(prospect.id);
+            if (fresh) target = fresh;
+            if (await d.isSendBlocked(target, { channel, purpose: 'transactional' })) {
+              d.logger.info('redeem_ops.delivery.blocked', {
+                entitlementId: entitlement.id, channel, reason: 'suppressed_or_erased',
+              });
+              return { skipped: 'suppressed' };
+            }
+          }
+          return fn({ ...args, prospect: target });
+        })
         .then((r) => {
           if (r?.skipped) return null;
           return writeDeliveryReceipt(entitlement.id, kind, r || { sent: false, error: 'no sender result' }, channel);
@@ -606,7 +630,18 @@ export function makeEntitlementService(overrides = {}) {
     await entitlement.reload();
 
     if (channel === 'link') {
-      const bundle = await builders().buildShareBundle({ entitlement, prospect, kind, rawToken: fresh.raw });
+      // PR C: the share bundle embeds the person's name + raw phone and skips
+      // queueDelivery's erasure fence — re-check on a FRESH row here (the
+      // stale `prospect` was loaded before the token rotation).
+      const freshProspect = entitlement.prospectId
+        ? await d.Prospect.findByPk(entitlement.prospectId)
+        : prospect;
+      if (await d.isSendBlocked(freshProspect || prospect, { channel: 'all', purpose: 'transactional' })) {
+        throw new AppError('This customer was erased (PDPA) — nothing can be shared', 410);
+      }
+      const bundle = await builders().buildShareBundle({
+        entitlement, prospect: freshProspect || prospect, kind, rawToken: fresh.raw,
+      });
       return { entitlement, kind, channel, emailQueued: false, ...bundle };
     }
     const emailQueued = queueDelivery({

--- a/backend/src/services/verifiedPhoneStore.js
+++ b/backend/src/services/verifiedPhoneStore.js
@@ -65,9 +65,14 @@ export function isPhoneRecentlyVerified(fullPhone, now = Date.now()) {
   return true;
 }
 
+/** PR C erasure: drop one phone's marker immediately (post-commit eviction). */
+export function evictVerifiedPhone(fullPhone) {
+  if (fullPhone) verifiedPhones.delete(fullPhone);
+}
+
 /** Test helper — clear all markers. */
 export function _resetVerifiedPhones() {
   verifiedPhones.clear();
 }
 
-export default { markPhoneVerified, isPhoneRecentlyVerified, _resetVerifiedPhones };
+export default { markPhoneVerified, isPhoneRecentlyVerified, evictVerifiedPhone, _resetVerifiedPhones };

--- a/backend/src/services/webhookService.js
+++ b/backend/src/services/webhookService.js
@@ -187,6 +187,24 @@ export function makeWebhookService(overrides = {}) {
    * Attempt to deliver a webhook payload to a subscriber.
    */
   async function attemptDelivery(delivery, subscriber) {
+    // PR C erasure fence: an enqueued/retrying delivery is an IN-MEMORY copy —
+    // an erasure that cancelled+scrubbed the row after the enqueue would
+    // otherwise still send the original PII payload. Reload and use the DB
+    // truth for both liveness and body. (Unit fakes without .reload() skip
+    // the fence — they have no row to be erased.)
+    if (typeof delivery.reload === 'function') {
+      try {
+        await delivery.reload();
+      } catch (_) {
+        return; // row deleted under us — nothing to send
+      }
+      if (delivery.status !== 'pending') {
+        d.logger.info('[Webhook] delivery skipped (no longer pending)', {
+          deliveryId: delivery.deliveryId, status: delivery.status,
+        });
+        return;
+      }
+    }
     const rawBody = JSON.stringify(delivery.payload);
     const timestamp = new Date().toISOString();
     const signatureVersion = signatureVersionForSubscriber(subscriber);

--- a/backend/test/integration/erasure.test.js
+++ b/backend/test/integration/erasure.test.js
@@ -1,0 +1,748 @@
+/**
+ * PR C — PDPA erasure, full-matrix integration (real Postgres; the lock
+ * ordering, partial-unique interactions and json scrubs cannot be proven with
+ * mocks). Plan: docs/plans/consumer-spine-and-consent-ledger.md §4.
+ */
+process.env.WEBHOOK_ENABLED = 'true';
+
+import { jest } from '@jest/globals';
+import crypto from 'crypto';
+import request from 'supertest';
+import { Transaction } from 'sequelize';
+import {
+  getApp, closeDb, createTestUser, createTestCampaign, createTestQrTag, createTestAttribution,
+} from '../helpers.js';
+import {
+  sequelize, Consumer, Prospect, ProspectActivity, Commission,
+  RewardEntitlement, RedemptionEvent, Redemption, Draw, DrawEntry, DrawAttempt,
+  ShortLink, WebhookSubscriber, WebhookDelivery, Verification, WaitlistSignup,
+  ConsentEvent, ConsumerSuppression, PartnerOrganisation, RewardOffer, Activation,
+  SessionVisit, IdempotencyKey,
+} from '../../src/models/index.js';
+import { markPhoneVerified, isPhoneRecentlyVerified } from '../../src/services/verifiedPhoneStore.js';
+import { phoneHashOf } from '../../src/services/consumerService.js';
+import { eraseConsumer, ERASED_PHONE_HASH } from '../../src/services/erasureService.js';
+import { isSuppressed, canMarketTo, applyUnsubscribe } from '../../src/services/consentService.js';
+import { makeEntitlementService, flushDeliveries as flushEntDeliveries } from '../../src/services/redeemOps/entitlementService.js';
+import { makeWebhookService } from '../../src/services/webhookService.js';
+import { makeLuckyDrawService } from '../../src/services/luckyDrawService.js';
+
+const RUN = Date.now();
+const p8 = (offset) => `9${String(RUN + offset).slice(-7)}`; // distinct SG mobiles
+const hash = () => crypto.randomBytes(32).toString('hex');
+const auth = (t) => ({ Authorization: `Bearer ${t}` });
+
+let app;
+let admin;
+let agent;
+let campaign1;
+let campaign2;
+
+beforeAll(async () => {
+  app = await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  agent = await createTestUser({ role: 'agent', phone: `+656${String(RUN).slice(-7)}` });
+  campaign1 = await createTestCampaign(admin.user.id, { name: `Erasure C1 ${RUN}` });
+  campaign2 = await createTestCampaign(admin.user.id, { name: `Erasure C2 ${RUN}` });
+});
+
+afterAll(async () => {
+  // Leave nothing enabled behind for suites sharing this jest worker: the
+  // test subscribers would otherwise receive every later capture's events.
+  await WebhookSubscriber.update({ enabled: false }, { where: { name: [`mktr-leads mirror ${RUN}`, `other app ${RUN}`] } });
+  process.env.WEBHOOK_ENABLED = 'false';
+  await closeDb();
+});
+
+/** Capture through the real funnel so sourceMetadata/ledger all populate. */
+async function captureProspect(phone8, campaign, { verified = true, email, firstName = 'Erin', lastName = 'Tan' } = {}) {
+  const e164 = `+65${phone8}`;
+  if (verified) markPhoneVerified(e164);
+  const res = await request(app).post('/api/prospects').send({
+    firstName,
+    lastName,
+    email: email === undefined ? `erase-${phone8}@test.com` : email,
+    phone: phone8,
+    campaignId: campaign.id,
+    leadSource: 'website',
+    consent_contact: true,
+    consent_terms: true,
+    utm_source: 'fb',
+    utm_medium: 'cpc',
+    utm_campaign: 'tokyo',
+    utm_content: 'creative-7',
+    fbp: 'fb.1.123.456',
+    eventId: `evt-${phone8}`,
+    eventSourceUrl: 'https://redeem.sg/LeadCapture?x=1',
+  });
+  expect(res.status).toBe(201);
+  const prospect = await Prospect.findByPk(res.body.data.prospect.id);
+  return prospect;
+}
+
+describe('PDPA erasure — full matrix', () => {
+  const phone8 = p8(1);
+  const e164 = `+65${phone8}`;
+  let consumer;
+  let prospect1;
+  let prospect2;
+  let unlinked;
+  let callBot;
+  let callBotInbound;
+  let referred;
+  let sessionVisit;
+  let attribution;
+  let partner;
+  let offer;
+  let activation;
+  let entitlement;
+  let redemption;
+  let draw;
+  let entry;
+  let attempt;
+  let shortLink;
+  let subscriberYes;
+  let subscriberNo;
+  let deliveryCreated;
+  let deliveryPending;
+  let deliveryReferral;
+
+  beforeAll(async () => {
+    prospect1 = await captureProspect(phone8, campaign1);
+    prospect2 = await captureProspect(phone8, campaign2);
+    consumer = await Consumer.findOne({ where: { phone: e164 } });
+    expect(consumer).toBeTruthy();
+    expect(prospect1.consumerId).toBe(consumer.id);
+
+    // An UNLINKED row on the same phone stored in a NON-normalized format
+    // (raw insert — the digits arm must still catch it), an inbound call_bot
+    // row whose CALLER (sourceMetadata.fromNumber) is this person (must be
+    // scrubbed — the transcript lives in notes), and an inbound call_bot row
+    // for a DIFFERENT caller (must stay untouched).
+    unlinked = await Prospect.create({
+      firstName: 'Erin', lastName: 'Unlinked', email: `unlinked-${phone8}@test.com`,
+      phone: e164, leadSource: 'website', campaignId: null, consumerId: null,
+      sourceMetadata: { clientIp: '1.2.3.4' },
+    });
+    await sequelize.query(
+      `UPDATE prospects SET phone = :spaced WHERE id = :id`,
+      { replacements: { spaced: `+65 ${phone8.slice(0, 4)} ${phone8.slice(4)}`, id: unlinked.id } }
+    );
+    callBotInbound = await Prospect.create({
+      firstName: 'Caller', lastName: 'Bot', email: `retell-in-${RUN}@calls.mktr.sg`,
+      phone: '+6562773210', leadSource: 'call_bot', campaignId: campaign1.id,
+      notes: `Transcript: Erin Tan asked about the Tokyo draw from ${e164}`,
+      retellCallId: `call-in-${RUN}`,
+      sourceMetadata: { retellCallId: `call-in-${RUN}`, fromNumber: e164, recordingUrl: 'https://retell.example/rec.mp3' },
+    });
+    callBot = await Prospect.create({
+      firstName: 'Caller', lastName: 'Bot', email: `retell-${RUN}@calls.mktr.sg`,
+      phone: '+6562773211', leadSource: 'call_bot', campaignId: campaign1.id,
+      sourceMetadata: { retellCallId: `call-${RUN}`, fromNumber: '+6588881234' },
+    });
+
+    // Referral copy on ANOTHER person's row: capture denormalized the erased
+    // referrer's name into the referred prospect's sourceMetadata (+ webhook copy).
+    referred = await Prospect.create({
+      firstName: 'Rafi', lastName: 'Referred', email: `referred-${RUN}@test.com`,
+      phone: `+658${String(RUN + 7).slice(-7)}`, leadSource: 'website', campaignId: campaign1.id,
+      sourceMetadata: { referral: { referrerProspectId: prospect1.id, referrerName: 'Erin Tan', code: 'ETAN' } },
+    });
+
+    // Browsing records: a session visit + attribution chain hung off prospect1.
+    const qrTag = await createTestQrTag(campaign1.id, admin.user.id);
+    sessionVisit = await SessionVisit.create({
+      sessionId: `sess-${RUN}`, landingPath: '/lead-capture', utmSource: 'fb',
+      eventsJson: [{ type: 'form_view', ts: new Date().toISOString() }],
+    });
+    attribution = await createTestAttribution(qrTag.id, `sess-${RUN}`);
+    await sequelize.query(
+      'UPDATE prospects SET "sessionId" = :sid, "attributionId" = :aid WHERE id = :id',
+      { replacements: { sid: `sess-${RUN}`, aid: attribution.id, id: prospect1.id } }
+    );
+
+    // Provider idempotency row echoing the prospect link.
+    await IdempotencyKey.create({
+      key: `retell:call:call-in-${RUN}`, scope: 'retell:call',
+      responseBody: { prospectId: prospect1.id, status: 'created' },
+      expiresAt: new Date(Date.now() + 24 * 3600_000),
+    });
+
+    // Redeem-ops chain: offer → activation → issued entitlement + redemption.
+    partner = await PartnerOrganisation.create({
+      tradingName: `Erasure Partner ${RUN}`, normalizedName: `erasure partner ${RUN}`, createdBy: admin.user.id,
+    });
+    offer = await RewardOffer.create({
+      partnerOrganisationId: partner.id, title: 'Erasure Trial Reward',
+      committedQuantity: 50, allocatedQuantity: 30, issuedQuantity: 2, status: 'active',
+      claimExpiryDays: 30, redemptionExpiryDays: 90, createdBy: admin.user.id,
+    });
+    activation = await Activation.create({
+      partnerOrganisationId: partner.id, rewardOfferId: offer.id, campaignId: campaign1.id,
+      campaignNameSnapshot: campaign1.name, allocatedQuantity: 30, issuedCount: 1, status: 'active',
+      unlockPolicy: 'agent_unlock', createdBy: admin.user.id,
+    });
+    // The anti-farming partial unique allows one LIVE reward per phone per
+    // activation — the redeemed history row lives on a second activation.
+    const activation2 = await Activation.create({
+      partnerOrganisationId: partner.id, rewardOfferId: offer.id, campaignId: campaign2.id,
+      campaignNameSnapshot: campaign2.name, allocatedQuantity: 30, issuedCount: 1, status: 'active',
+      unlockPolicy: 'agent_unlock', createdBy: admin.user.id,
+    });
+    entitlement = await RewardEntitlement.create({
+      rewardOfferId: offer.id, activationId: activation.id, prospectId: prospect1.id,
+      consumerId: consumer.id, status: 'issued', unlockedAt: new Date(),
+      presentationTokenHash: hash(), tokenHash: hash(), tokenHint: 'AB12',
+      issuedVia: 'hook', phoneKey: `65${phone8}`,
+    });
+    const redeemedEnt = await RewardEntitlement.create({
+      rewardOfferId: offer.id, activationId: activation2.id, prospectId: prospect2.id,
+      consumerId: consumer.id, status: 'redeemed',
+      presentationTokenHash: hash(), tokenHash: hash(), tokenHint: 'CD34',
+      issuedVia: 'hook', phoneKey: `65${phone8}`,
+    });
+    redemption = await Redemption.create({
+      entitlementId: redeemedEnt.id, rewardOfferId: offer.id, activationId: activation2.id,
+      partnerOrganisationId: partner.id, method: 'code', status: 'completed',
+      actorType: 'staff', actorUserId: admin.user.id, notes: `Handled in person for Erin Tan ${e164}`,
+    });
+    await RedemptionEvent.create({
+      entitlementId: entitlement.id, type: 'notified', actorType: 'system',
+      metadata: { kind: 'voucher', channel: 'email', to: 'e***@test.com' },
+    });
+    await RedemptionEvent.create({
+      entitlementId: redeemedEnt.id, type: 'reversed', actorType: 'staff',
+      metadata: { reason: `customer Erin Tan asked at ${e164}`, redemptionId: redemption.id },
+    });
+
+    // Sealed draw with this person's frozen entry + a PENDING attempt that
+    // picked them (the erased-pending-winner path).
+    draw = await Draw.create({
+      campaignId: campaign1.id, closesAt: new Date(Date.now() - 3600_000),
+      multiplier: 10, status: 'drawn', poolHash: hash(), createdBy: admin.user.id,
+    });
+    entry = await DrawEntry.create({
+      drawId: draw.id, prospectId: prospect1.id, phoneHash: phoneHashOf(e164),
+      phoneLast4: phone8.slice(-4), displayName: 'Erin T.', chances: 10,
+      verifiedAtFreeze: new Date(), boostVia: 'agent_scan',
+    });
+    attempt = await DrawAttempt.create({
+      drawId: draw.id, attemptNo: 1, seed: hash(), totalChances: 10,
+      eligibleHash: hash(), pickedEntryId: entry.id, reason: 'initial',
+      drawnAt: new Date(), claimDeadline: new Date(Date.now() + 14 * 24 * 3600_000),
+      outcome: 'pending',
+    });
+
+    // Capture may have auto-minted the canonical share link (one per prospect,
+    // partial unique) — reuse it, else seed one.
+    shortLink = await ShortLink.findOne({ where: { prospectId: prospect1.id } });
+    if (!shortLink) {
+      shortLink = await ShortLink.create({
+        slug: `er${RUN}`, targetUrl: `https://redeem.sg/LeadCapture?campaign_id=${campaign1.id}&ref=${prospect1.id}`,
+        purpose: 'share', campaignId: campaign1.id, prospectId: prospect1.id,
+      });
+    }
+
+    // Webhook history: one subscriber that handles lead.deleted and received
+    // the lead (gets the outbox row), one that never received it.
+    subscriberYes = await WebhookSubscriber.create({
+      name: `mktr-leads mirror ${RUN}`, url: 'https://mirror.invalid/webhook', secret: 's1',
+      events: ['lead.created', 'lead.deleted'], enabled: true, metadata: { destination: 'mktr_leads' },
+    });
+    subscriberNo = await WebhookSubscriber.create({
+      name: `other app ${RUN}`, url: 'https://other.invalid/webhook', secret: 's2',
+      events: ['lead.created', 'lead.deleted'], enabled: true, metadata: { destination: 'mktr_leads' },
+    });
+    const piiPayload = (pid, deliveryId) => ({
+      event: 'lead.created', deliveryId,
+      data: {
+        lead: {
+          externalId: pid, firstName: 'Erin', lastName: 'Tan', phone: e164,
+          email: `erase-${phone8}@test.com`, sourceMetadata: { clientIp: '9.9.9.9' },
+        },
+        routing: { agentPhone: '+6590000000' },
+      },
+    });
+    const d1 = crypto.randomUUID();
+    deliveryCreated = await WebhookDelivery.create({
+      subscriberId: subscriberYes.id, deliveryId: d1, eventType: 'lead.created',
+      payload: piiPayload(prospect1.id, d1), status: 'success', responseCode: 200,
+      responseBody: JSON.stringify({ echoed: `Erin Tan ${e164}` }),
+    });
+    const d2 = crypto.randomUUID();
+    deliveryPending = await WebhookDelivery.create({
+      subscriberId: subscriberYes.id, deliveryId: d2, eventType: 'lead.created',
+      payload: piiPayload(prospect2.id, d2), status: 'pending',
+    });
+    // The REFERRED person's delivery embeds the erased referrer's name.
+    const d3 = crypto.randomUUID();
+    deliveryReferral = await WebhookDelivery.create({
+      subscriberId: subscriberYes.id, deliveryId: d3, eventType: 'lead.created',
+      payload: {
+        event: 'lead.created', deliveryId: d3,
+        data: {
+          lead: {
+            externalId: referred.id, firstName: 'Rafi',
+            sourceMetadata: { referral: { referrerProspectId: prospect1.id, referrerName: 'Erin Tan' } },
+          },
+        },
+      },
+      status: 'success', responseCode: 200,
+    });
+
+    // Commission with the lead's name; activity metadata with a full snapshot.
+    await Commission.create({
+      type: 'conversion', amount: 50, status: 'pending',
+      description: 'Lead conversion: Erin Tan', agentId: agent.user.id,
+      campaignId: campaign1.id, prospectId: prospect1.id, earnedDate: new Date(),
+    });
+    await ProspectActivity.create({
+      prospectId: prospect1.id, type: 'updated', actorUserId: admin.user.id,
+      description: 'Prospect updated by admin',
+      metadata: { before: { firstName: 'Erin', phone: e164 }, after: { firstName: 'Erin2' } },
+    });
+
+    // OTP row + waitlist row for the same person.
+    await Verification.upsert({ phone: e164, code: '123456', attempts: 0, expiresAt: new Date(Date.now() + 600_000) });
+    await WaitlistSignup.create({
+      email: `erase-${phone8}@test.com`, name: 'Erin Tan', phone: `65${phone8}`,
+      source: 'homepage', ipAddress: '8.8.8.8', userAgent: 'jest',
+    });
+  });
+
+  let report;
+
+  test('erase endpoint requires admin + explicit confirm', async () => {
+    const agentRes = await request(app)
+      .post(`/api/consumers/${consumer.id}/erase`)
+      .set(auth(agent.token))
+      .send({ confirm: 'ERASE' });
+    expect(agentRes.status).toBe(403);
+
+    const noConfirm = await request(app)
+      .post(`/api/consumers/${consumer.id}/erase`)
+      .set(auth(admin.token))
+      .send({});
+    expect(noConfirm.status).toBe(422);
+
+    const badId = await request(app)
+      .post('/api/consumers/not-a-uuid/erase')
+      .set(auth(admin.token))
+      .send({ confirm: 'ERASE' });
+    expect(badId.status).toBe(404);
+  });
+
+  test('POST /erase succeeds and returns the matrix report', async () => {
+    const res = await request(app)
+      .post(`/api/consumers/${consumer.id}/erase`)
+      .set(auth(admin.token))
+      .send({ confirm: 'ERASE', reason: 'PDPA request via email' });
+    expect(res.status).toBe(200);
+    report = res.body.data;
+    expect(report.alreadyErased).toBe(false);
+    expect(report.repair).toBe(false);
+    // prospect1 + prospect2 + the spaced-format unlinked row + the inbound
+    // call_bot row for THIS caller; NOT the other caller's DDI row.
+    expect(report.prospects).toBe(4);
+    expect(report.entitlementsCancelled).toBe(1); // the issued one
+    expect(report.entitlementsScrubbed).toBe(1); // the redeemed one
+    expect(report.inventoryReversalFailures).toBe(0);
+    expect(report.drawEntries).toBe(1);
+    expect(report.drawAttemptsClosed).toBe(1);
+    expect(report.shortLinks).toBe(2); // capture auto-mints one share link per funnel prospect
+    expect(report.verifications).toBe(1);
+    expect(report.waitlistSignups).toBe(1);
+    expect(report.referralCopiesScrubbed).toBe(1);
+    expect(report.sessionVisits).toBe(1);
+    expect(report.attributions).toBe(1);
+    expect(report.idempotencyKeys).toBe(1);
+    expect(report.retellCallIds).toContain(`call-in-${RUN}`);
+    expect(report.leadDeletedQueued).toBeGreaterThanOrEqual(1);
+    expect(report.webhooksDisabled).toBe(false);
+  });
+
+  test('prospects: allowlist rebuild (PII gone, skeleton + utm kept)', async () => {
+    const p = await Prospect.findByPk(prospect1.id);
+    expect(p.firstName).toBe('Erased');
+    expect(p.lastName).toBeNull();
+    expect(p.email).toBeNull();
+    expect(p.phone).toBeNull();
+    expect(p.notes).toBeNull();
+    expect(p.budget).toBeNull();
+    expect(p.location).toBeNull();
+    expect(p.demographics).toBeNull();
+    expect(p.preferences).toBeNull();
+    expect(p.interests).toEqual([]);
+    expect(p.tags).toEqual([]);
+    expect(p.sessionId).toBeNull();
+    expect(p.attributionId).toBeNull();
+    expect(p.dncStatus).toBeNull();
+    expect(p.dncMetadata).toBeNull();
+    expect(p.consentMetadata).toEqual({ erased: true });
+    // skeleton survives
+    expect(p.campaignId).toBe(campaign1.id);
+    expect(p.consumerId).toBe(consumer.id);
+    expect(p.leadSource).toBe('website');
+    // sourceMetadata = utm(source/medium/campaign) + erased marker ONLY
+    expect(p.sourceMetadata).toEqual({
+      utm: { utm_source: 'fb', utm_medium: 'cpc', utm_campaign: 'tokyo' },
+      erased: true,
+    });
+
+    const u = await Prospect.findByPk(unlinked.id);
+    expect(u.firstName).toBe('Erased'); // spaced-format phone still caught (digits arm)
+    expect(u.phone).toBeNull();
+    expect(u.sourceMetadata).toEqual({ erased: true });
+    expect(u.consumerId).toBe(consumer.id); // repair anchor
+
+    // Inbound call for THIS person (fromNumber match): transcript + call
+    // pointer + recording locator all gone.
+    const cbi = await Prospect.findByPk(callBotInbound.id);
+    expect(cbi.firstName).toBe('Erased');
+    expect(cbi.notes).toBeNull();
+    expect(cbi.retellCallId).toBeNull();
+    expect(cbi.sourceMetadata).toEqual({ erased: true });
+
+    // Inbound call for a DIFFERENT caller on the same DDI: untouched.
+    const cb = await Prospect.findByPk(callBot.id);
+    expect(cb.firstName).toBe('Caller');
+    expect(cb.phone).toBe('+6562773211');
+    expect(cb.sourceMetadata.fromNumber).toBe('+6588881234');
+  });
+
+  test('referral copies on OTHER rows: name gone from sourceMetadata + webhook payload', async () => {
+    const r = await Prospect.findByPk(referred.id);
+    expect(r.firstName).toBe('Rafi'); // the referred person is NOT erased
+    expect(r.sourceMetadata.referral.referrerName).toBeUndefined();
+    expect(r.sourceMetadata.referral.referrerProspectId).toBe(prospect1.id);
+    expect(r.sourceMetadata.referral.code).toBe('ETAN');
+    const wd = await WebhookDelivery.findByPk(deliveryReferral.id);
+    expect(wd.payload.data.lead.sourceMetadata.referral.referrerName).toBe('[erased]');
+    expect(wd.payload.data.lead.firstName).toBe('Rafi'); // rest of the payload intact
+  });
+
+  test('browsing records: session visit + attribution rows deleted, prospect unlinked', async () => {
+    expect(await SessionVisit.findByPk(sessionVisit.id)).toBeNull();
+    const [attrRows] = await sequelize.query(
+      'SELECT 1 FROM attributions WHERE id = :id', { replacements: { id: attribution.id } }
+    );
+    expect(attrRows.length).toBe(0);
+  });
+
+  test('provider idempotency rows referencing the person are deleted', async () => {
+    expect(await IdempotencyKey.findByPk(`retell:call:call-in-${RUN}`)).toBeNull();
+  });
+
+  test('in-memory phone caches evicted post-commit', () => {
+    expect(isPhoneRecentlyVerified(e164)).toBe(false);
+  });
+
+  test('activities: metadata snapshots scrubbed, rows/types kept', async () => {
+    const acts = await ProspectActivity.findAll({ where: { prospectId: prospect1.id } });
+    expect(acts.length).toBeGreaterThanOrEqual(2);
+    for (const a of acts) {
+      expect(a.metadata).toEqual({ erased: true });
+    }
+  });
+
+  test('commissions: description scrubbed, financials kept', async () => {
+    const c = await Commission.findOne({ where: { prospectId: prospect1.id } });
+    expect(c.description).toBeNull();
+    expect(Number(c.amount)).toBe(50);
+    expect(c.status).toBe('pending');
+  });
+
+  test('entitlements: live cancelled with bookkeeping, redeemed keeps status; phoneKey/tokenHint null everywhere', async () => {
+    const e1 = await RewardEntitlement.findByPk(entitlement.id);
+    expect(e1.status).toBe('cancelled');
+    expect(e1.phoneKey).toBeNull();
+    expect(e1.tokenHint).toBeNull();
+    const all = await RewardEntitlement.findAll({ where: { consumerId: consumer.id } });
+    expect(all.length).toBe(2);
+    for (const e of all) {
+      expect(e.phoneKey).toBeNull();
+      expect(e.tokenHint).toBeNull();
+    }
+    expect(all.map((e) => e.status).sort()).toEqual(['cancelled', 'redeemed']);
+    // activation1 issuedCount 1 → 0 (one live cancellation), offer issuedQuantity 2 → 1
+    const act = await Activation.findByPk(activation.id);
+    expect(act.issuedCount).toBe(0);
+    const off = await RewardOffer.findByPk(offer.id);
+    expect(off.issuedQuantity).toBe(1);
+    // the erased override event exists
+    const overrides = await RedemptionEvent.findAll({
+      where: { entitlementId: entitlement.id, type: 'manual_override' },
+    });
+    expect(overrides.some((e) => e.metadata?.action === 'erased')).toBe(true);
+  });
+
+  test('redemptions + receipt events: free text and destinations stripped', async () => {
+    const r = await Redemption.findByPk(redemption.id);
+    expect(r.notes).toBeNull();
+    const events = await RedemptionEvent.findAll({
+      where: { entitlementId: [entitlement.id, redemption.entitlementId] },
+    });
+    for (const ev of events) {
+      if (!ev.metadata) continue;
+      expect(ev.metadata.to).toBeUndefined();
+      expect(ev.metadata.reason).toBeUndefined();
+      expect(ev.metadata.error).toBeUndefined();
+    }
+    // non-PII receipt keys survive
+    const notified = events.find((ev) => ev.type === 'notified');
+    expect(notified.metadata).toMatchObject({ kind: 'voucher', channel: 'email' });
+  });
+
+  test('draw: entry unpickable + snapshot scrubbed; pending attempt → ineligible; redraw chain stays legal', async () => {
+    const en = await DrawEntry.findByPk(entry.id);
+    expect(en.prospectId).toBeNull();
+    expect(en.phoneLast4).toBeNull();
+    expect(en.displayName).toBeNull();
+    expect(en.verifiedAtFreeze).toBeNull();
+    expect(en.phoneHash).toBe(ERASED_PHONE_HASH);
+    const at = await DrawAttempt.findByPk(attempt.id);
+    expect(at.outcome).toBe('ineligible');
+
+    // Redraw with reason = prior outcome is accepted; the erased entry cannot
+    // be picked again (prospectId null filter) — with no other entries the
+    // pool is empty, which IS the erased-entry exclusion.
+    const drawSvc = makeLuckyDrawService();
+    await expect(
+      drawSvc.runDrawAttempt(draw.id, { reason: 'ineligible' }, admin.user)
+    ).rejects.toThrow(/No eligible entries left/);
+  });
+
+  test('short link deactivated, unlinked, and ref= stripped from the public target', async () => {
+    const sl = await ShortLink.findByPk(shortLink.id);
+    expect(sl.expiresAt).not.toBeNull();
+    expect(new Date(sl.expiresAt).getTime()).toBeLessThanOrEqual(Date.now());
+    expect(sl.prospectId).toBeNull();
+    expect(sl.targetUrl).not.toContain('ref=');
+    expect(sl.targetUrl).not.toContain(prospect1.id);
+  });
+
+  test('webhook deliveries: payload copies scrubbed to envelope, pending cancelled, lead.deleted outbox persisted for receivers only', async () => {
+    const dc = await WebhookDelivery.findByPk(deliveryCreated.id);
+    expect(dc.payload.erased).toBe(true);
+    expect(dc.payload.data.lead).toEqual({ externalId: prospect1.id });
+    expect(dc.payload.deliveryId).toBe(deliveryCreated.deliveryId);
+    expect(JSON.stringify(dc.payload)).not.toContain('Erin');
+    expect(JSON.stringify(dc.payload)).not.toContain(phone8);
+    expect(dc.responseBody).toBeNull();
+
+    const dp = await WebhookDelivery.findByPk(deliveryPending.id);
+    expect(dp.status).toBe('failed');
+    expect(dp.errorMessage).toContain('erased');
+    expect(dp.payload.erased).toBe(true);
+
+    const outbox = await WebhookDelivery.findAll({
+      where: { eventType: 'lead.deleted', subscriberId: subscriberYes.id },
+    });
+    const pids = new Set(outbox.map((o) => o.payload?.data?.lead?.externalId));
+    expect(pids.has(prospect1.id)).toBe(true);
+    expect(pids.has(prospect2.id)).toBe(true);
+    const noRows = await WebhookDelivery.findAll({
+      where: { eventType: 'lead.deleted', subscriberId: subscriberNo.id },
+    });
+    expect(noRows.length).toBe(0);
+  });
+
+  test('consumer nulled; suppression reason=erasure; global denial ledger event; gates closed', async () => {
+    const c = await Consumer.findByPk(consumer.id);
+    expect(c.erasedAt).not.toBeNull();
+    expect(c.phone).toBeNull();
+    expect(c.phoneHash).toBeNull();
+    expect(c.firstName).toBeNull();
+    expect(c.lastName).toBeNull();
+    expect(c.email).toBeNull();
+    expect(c.unsubTokenHash).toBeNull();
+
+    const sup = await ConsumerSuppression.findOne({ where: { consumerId: consumer.id, channel: 'all' } });
+    expect(sup.reason).toBe('erasure');
+
+    const ev = await ConsentEvent.findOne({ where: { consumerId: consumer.id, source: 'erasure' } });
+    expect(ev).toBeTruthy();
+    expect(ev.granted).toBe(false);
+    expect(ev.campaignId).toBeNull();
+    // The free-text reason lives ONLY in the access-controlled audit row,
+    // never in the ledger (Codex R1 #11).
+    expect(ev.metadata).toBeNull();
+    expect(ev.sourceUrl).toBeNull();
+
+    expect(await isSuppressed({ consumerId: consumer.id, purpose: 'transactional' })).toBe(true);
+    expect(await canMarketTo({ consumerId: consumer.id, campaignId: campaign1.id })).toBe(false);
+  });
+
+  test('verification + waitlist rows deleted', async () => {
+    expect(await Verification.findByPk(e164)).toBeNull();
+    expect(await WaitlistSignup.findOne({ where: { email: `erase-${phone8}@test.com` } })).toBeNull();
+  });
+
+  test('re-erase = REPAIR pass: no double bookkeeping, and resurrected PII is scrubbed again', async () => {
+    // Simulate PII leaking back onto an erased skeleton (e.g. a racing write).
+    await sequelize.query(
+      `UPDATE prospects SET "firstName" = 'Sneaky', notes = 'resurrected note' WHERE id = :id`,
+      { replacements: { id: prospect1.id } }
+    );
+    const res = await request(app)
+      .post(`/api/consumers/${consumer.id}/erase`)
+      .set(auth(admin.token))
+      .send({ confirm: 'ERASE' });
+    expect(res.status).toBe(200);
+    expect(res.body.data.alreadyErased).toBe(true);
+    expect(res.body.data.repair).toBe(true);
+    const p = await Prospect.findByPk(prospect1.id);
+    expect(p.firstName).toBe('Erased'); // repair re-scrubbed it
+    expect(p.notes).toBeNull();
+    const act = await Activation.findByPk(activation.id);
+    expect(act.issuedCount).toBe(0); // NOT decremented again (nothing live)
+    const sups = await ConsumerSuppression.findAll({ where: { consumerId: consumer.id } });
+    expect(sups.length).toBe(1);
+    const evs = await ConsentEvent.findAll({ where: { consumerId: consumer.id, source: 'erasure' } });
+    expect(evs.length).toBe(1); // single ledger denial, not one per run
+    const outbox = await WebhookDelivery.findAll({
+      where: { eventType: 'lead.deleted', subscriberId: subscriberYes.id },
+    });
+    expect(outbox.length).toBe(2); // still one per prospect — repair deduped
+  });
+
+  test('erased skeleton rejects staff edits (PUT → 410)', async () => {
+    const res = await request(app)
+      .put(`/api/prospects/${prospect1.id}`)
+      .set(auth(admin.token))
+      .send({ firstName: 'Undo', notes: 'try to bring them back' });
+    expect(res.status).toBe(410);
+  });
+
+  test('an already-enqueued in-memory delivery refuses to fire after erasure (reload fence)', async () => {
+    // deliveryPending's in-memory instance still holds the ORIGINAL PII
+    // payload; the erasure cancelled+scrubbed the row underneath it.
+    expect(deliveryPending.payload.data.lead.firstName).toBe('Erin'); // stale copy
+    const fetchSpy = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+    const svc = makeWebhookService({ fetch: fetchSpy, logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} } });
+    await svc.attemptDelivery(deliveryPending, subscriberYes);
+    expect(fetchSpy).not.toHaveBeenCalled(); // fence reloaded → status failed → no send
+  });
+
+  test('link-channel resend on an erased person is refused (410) even with a live entitlement', async () => {
+    // Erasure cancels the person's entitlements, so a live one can only exist
+    // through a race — construct that state directly. (The unlinked row keeps
+    // the (activationId, prospectId) partial unique clear of the original.)
+    const raceEnt = await RewardEntitlement.create({
+      rewardOfferId: offer.id, activationId: activation.id, prospectId: unlinked.id,
+      consumerId: consumer.id, status: 'issued', unlockedAt: new Date(),
+      presentationTokenHash: hash(), tokenHash: hash(), tokenHint: 'ZZ99', issuedVia: 'manual',
+    });
+    const svc = makeEntitlementService({ logger: { error: () => {}, warn: () => {}, info: () => {} } });
+    await expect(
+      svc.resendDelivery(raceEnt.id, admin.user, { channel: 'link' })
+    ).rejects.toMatchObject({ statusCode: 410 });
+  });
+
+  test('re-signup after erasure mints a NEW consumer with fresh counts', async () => {
+    const again = await captureProspect(phone8, campaign1, { firstName: 'Erin', lastName: 'Again' });
+    expect(again.consumerId).toBeTruthy();
+    expect(again.consumerId).not.toBe(consumer.id);
+    const fresh = await Consumer.findByPk(again.consumerId);
+    expect(fresh.phone).toBe(e164);
+    expect(fresh.signupCount).toBe(1);
+    const erased = await Consumer.findByPk(consumer.id);
+    expect(erased.phone).toBeNull(); // untouched by the new signup
+  });
+});
+
+describe('erasure — lock ordering vs concurrent capture', () => {
+  test('capture of the same phone waits behind the erasure lock, then mints a NEW consumer', async () => {
+    const phone = p8(500);
+    const e164 = `+65${phone}`;
+    const first = await captureProspect(phone, campaign1);
+    const consumer = await Consumer.findOne({ where: { phone: e164 } });
+    expect(first.consumerId).toBe(consumer.id);
+
+    // Manually run an "erasure txn": lock the consumer FOR UPDATE, null the
+    // identity, hold the lock while a capture races in, then commit.
+    let captureResolved = false;
+    let capturePromise;
+    await sequelize.transaction(async (t) => {
+      await Consumer.findByPk(consumer.id, { transaction: t, lock: Transaction.LOCK.UPDATE });
+      await Consumer.update(
+        { erasedAt: new Date(), phone: null, phoneHash: null, firstName: null, lastName: null, email: null },
+        { where: { id: consumer.id }, transaction: t }
+      );
+      // Race a real capture while the lock is held (campaign2 avoids the
+      // same-campaign dupe 409).
+      markPhoneVerified(e164);
+      capturePromise = request(app).post('/api/prospects').send({
+        firstName: 'Racer', lastName: 'Tan', email: `race-${phone}@test.com`,
+        phone, campaignId: campaign2.id, leadSource: 'website',
+        consent_contact: true, consent_terms: true,
+      }).then((r) => { captureResolved = true; return r; });
+      // Give the capture time to reach the resolver upsert and block.
+      await new Promise((r) => setTimeout(r, 700));
+      expect(captureResolved).toBe(false); // still waiting on our lock
+    });
+
+    const res = await capturePromise;
+    expect(res.status).toBe(201);
+    const p = await Prospect.findByPk(res.body.data.prospect.id);
+    expect(p.consumerId).toBeTruthy();
+    expect(p.consumerId).not.toBe(consumer.id); // NEW person, erased row untouched
+    const fresh = await Consumer.findByPk(p.consumerId);
+    expect(fresh.phone).toBe(e164);
+    expect(fresh.erasedAt).toBeNull();
+  });
+});
+
+describe('erasure — queued sender reload guard (queueDelivery)', () => {
+  test('a stale queued send aborts when the person was erased in between; a live one sends with the FRESH row', async () => {
+    const phone = p8(900);
+    const prospect = await captureProspect(phone, campaign2, { firstName: 'Queue', lastName: 'Guard' });
+    const stale = prospect.toJSON(); // point-in-time copy, as the senders hold
+
+    const sent = [];
+    const events = [];
+    const svc = makeEntitlementService({
+      RedemptionEvent: { create: async (row) => { events.push(row); return row; } },
+      notifyUnlock: async ({ prospect: p }) => { sent.push(p); return { sent: true, to: 'x' }; },
+      logger: { error: () => {}, warn: () => {}, info: () => {} },
+    });
+
+    // Live control: fires, and with the FRESH reloaded row.
+    svc.queueDelivery({ entitlement: { id: crypto.randomUUID() }, prospect: stale, kind: 'voucher', voucherToken: 'v', channels: ['email'] });
+    await flushEntDeliveries();
+    expect(sent.length).toBe(1);
+    expect(sent[0].id).toBe(prospect.id);
+
+    // Erase, then fire the SAME stale object again — must abort, no receipt.
+    const c = await Consumer.findByPk(prospect.consumerId);
+    const report = await eraseConsumer(c.id, { actorUser: admin.user, reason: 'guard test' });
+    expect(report.prospects).toBeGreaterThanOrEqual(1);
+    const before = events.length;
+    svc.queueDelivery({ entitlement: { id: crypto.randomUUID() }, prospect: stale, kind: 'voucher', voucherToken: 'v2', channels: ['email'] });
+    await flushEntDeliveries();
+    expect(sent.length).toBe(1); // no second send
+    expect(events.length).toBe(before); // skip writes no receipt
+  });
+});
+
+describe('erasure — suppression upgrade over a prior unsubscribe', () => {
+  test('an unsubscribed consumer erased later ends with reason=erasure (transactional now blocked)', async () => {
+    const phone = p8(1300);
+    const prospect = await captureProspect(phone, campaign1, { firstName: 'Unsub', lastName: 'First' });
+    const consumer = await Consumer.findByPk(prospect.consumerId);
+    await applyUnsubscribe(consumer, { source: 'unsubscribe_link' });
+    expect(await isSuppressed({ consumerId: consumer.id, purpose: 'transactional' })).toBe(false);
+
+    const report = await eraseConsumer(consumer.id, { actorUser: admin.user });
+    expect(report.alreadyErased).toBe(false);
+    const sup = await ConsumerSuppression.findOne({ where: { consumerId: consumer.id, channel: 'all' } });
+    expect(sup.reason).toBe('erasure');
+    expect(await isSuppressed({ consumerId: consumer.id, purpose: 'transactional' })).toBe(true);
+  });
+});
+
+describe('erasure — service-level 404', () => {
+  test('unknown consumer id rejects with 404 AppError', async () => {
+    await expect(eraseConsumer(crypto.randomUUID(), {})).rejects.toMatchObject({ statusCode: 404 });
+  });
+});


### PR DESCRIPTION
PR C of the consumer-spine plan (docs/plans/consumer-spine-and-consent-ledger.md §4): one admin action that removes a person's PII everywhere it lives, leaves a suppression that blocks every future send including transactional, and writes ledger + audit evidence. Tracker item `erasure`.

## What ships

**`POST /api/consumers/:id/erase`** (admin + `body.confirm='ERASE'`, optional `reason`) → `services/erasureService.js`, one transaction:

| Surface | Action |
|---|---|
| `consumers` | `erasedAt` + phone/phoneHash/names/email/unsubTokenHash → NULL (no tombstone — PDPC: unsalted hash of an enumerable space is pseudonymous) |
| `prospects` | **allowlist rebuild** — keeps id/campaign/consumer/leadSource/status/priority/score/conversionDate/agent+qr refs/quarantine; PII, DNC block, retellCallId, session/attribution links, quiz/marketplace/referral blobs all dropped; `sourceMetadata` → `{utm(source/medium/campaign), erased:true}`; catches **unlinked rows by digits-normalized phone** (fail-closed, any stored format) and **inbound call_bot rows whose `fromNumber` is this person** (transcript/recording pointer scrubbed); other callers' DDI rows stay untouched |
| `prospect_activities` | `metadata` → `{erased:true}` (update snapshots embed full before/after PII); descriptions kept (staff/campaign names only) |
| `commissions` | description (embeds lead name) → NULL; financials kept |
| `reward_entitlements` | by prospect ∪ consumer ∪ phoneKey: eligible/issued → **cancelled with full bookkeeping** (inventory reversal + activation issuedCount, savepoint-guarded so a skewed counter can never abort an erasure) + `manual_override {action:'erased'}`; phoneKey/tokenHint → NULL everywhere |
| `redemptions` / `redemption_events` | notes → NULL; receipt metadata stripped of `to`/`reason`/`error` |
| `draw_entries` | prospectId → NULL (unpickable), phoneLast4/displayName/verifiedAtFreeze → NULL, phoneHash → 64-zero sentinel (NOT NULL col, no migration); matched via prospect join + phoneHash fallback (tracker `drawlink` not yet built) |
| `draw_attempts` | **erased pending winner → outcome `ineligible`** — the redraw chain stays legal (`reason` must equal prior outcome); claimed attempts untouched |
| `short_links` | person's share links expire now (`resolveSlug` → expired), unlinked, `ref=` stripped from the public target |
| `webhook_deliveries` | every historical payload copy scrubbed to `{event, deliveryId, erased, data.lead.externalId}`; pending ones cancelled first; **`lead.deleted` persisted in-txn** (transactional outbox) for every enabled subscriber that ever received the lead AND handles the event — flushed post-commit |
| `verifications` | OTP rows for the phone deleted |
| `waitlist_signups` | rows matching the person's emails/phone deleted (pure-PII rows) |
| ledger + suppression | `consent_events` global denial (`source:'erasure'`, `version:'erasure-v1'`); `consumer_suppressions (all)` upserted to reason `erasure` — **upgrades a prior `unsubscribe` row**, otherwise transactional sends would keep flowing |
| audit | `consumer.erased` RedeemOpsAuditEvent |

**Queued-sender erasure stop** (`entitlementService.queueDelivery`): every email/WhatsApp leg (issuance, unlock, resend, recovery sweep) now reloads the prospect row and re-checks `isSendBlocked(purpose:'transactional')` at fire time — closes the §4 race where a voucher queued pre-erasure sends post-erasure. Fails OPEN on consent-infra error (vouchers never stranded); id-less unit fixtures skip the guard (nothing to reload).

## Concurrency (§4 lock ordering)

Consumer row locked FOR UPDATE first — same order as capture (resolver upsert precedes `Prospect.create`), so capture-vs-erase serializes: capture-first → new prospect visible to enumeration; erasure-first → capture's upsert waits, sees the phone freed at commit, mints a NEW consumer. Re-signup after erasure = new person, fresh consent, proven in-suite with a held lock. Idempotent: re-POST → `{alreadyErased:true}`, no double bookkeeping.

## Known gaps (documented, not new)

- Lyfe's subscriber doesn't include `lead.deleted` (`bootstrap.js`) and `receive-mktr-lead` has no handler — cross-repo follow-up + manual SOP; the mirror (mktr-leads destination) does receive it. Tracker item `propagate` covers pushing suppression/erasure downstream.
- `session_visits`/`attributions`/`qr_scans` rows keep non-identity aggregates; the person-edge is severed via `sessionId`/`attributionId` nulling (plan §4 residual).
- Published winners wall is a static frontend file — erasing a published winner needs the manual content edit SOP.

## Codex round (gpt-5.6-sol, xhigh) — 16 findings, disposition

**Folded:** digits-normalized prospect enumeration + **inbound-Retell `fromNumber` rows** (transcript/summary/recording pointer scrubbed — the plan's original "call_bot untouched" was wrong for inbound calls of the person themselves); re-erase = **repair pass** (re-scrubs consumer-linked rows, dedupes fanout — recovery path for any PII that leaks back through a race); `attemptDelivery` **reload fence** (an already-enqueued in-memory delivery refuses to fire once the row is cancelled/scrubbed — also closes a pre-existing double-send window); PUT on an erased skeleton → **410**; link-channel resend re-checks a fresh row → **410**; inventory-reversal failures **surfaced** (report + event metadata) instead of silent; **referral-name copies on OTHER people's rows + their webhook payloads** scrubbed; session_visits + attributions **deleted** (guarded for shared references); idempotency-key rows deleted; short links also unlinked + `ref=` stripped from the public target; inventory/audit/boost-review free-text reasons redacted; consent-event `sourceUrl` nulled for the person and the admin reason kept **out of the ledger** (audit row only); in-memory OTP-marker + DNC-cache eviction post-commit; `webhooksDisabled` + `retellCallIds` surfaced on the report (provider-side deletion SOP).

**Declined (rationale in-thread):** draw freeze/pick transactional rework and a full outbox linearization (millisecond admin-vs-admin races; recoverable via the repair pass, and the pick already excludes erased entries); an erasure-propagation obligation ledger (tracker item `propagate`); a send-time fence on capture-time confirmation emails/CAPI (the person just submitted the form); FK detachment/timestamp coarsening of the retained skeleton (lawful business-records retention is the plan's documented stance); automated Retell provider deletion (surfaced call ids + SOP instead).

## Tests

New `backend/test/integration/erasure.test.js` (25, real Postgres): full-matrix assertions per table, repair-pass re-erase (resurrected PII re-scrubbed, no double bookkeeping), suppression upgrade over prior unsubscribe, re-signup mints new consumer, **held-lock capture race**, queued-sender guard (stale object aborts, fresh row sends), enqueued-delivery reload fence, PUT-on-erased 410, link-resend 410, inbound-vs-other call_bot split, referral cross-row scrub, browsing-record deletion, idempotency-key deletion, cache eviction, redraw-after-erasure chain, lead.deleted outbox targeting + dedupe, route gates (403/422/404).

Regressions green: consumerSpine, consentLedger (+unit), entitlementDeliveryFanout, whatsappService, luckyDrawService, redeemOpsFulfilmentDelivery, entitlementUnlockVia, redeemOpsPhoneDedupe, migrations. Frontend untouched; vitest 1618/1618.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDco6HwKLHpmRgE5YR8Za2
