### PR TITLE
feat(consent): lead.suppressed propagation — durable projection + reconciler (tracker "propagate")

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -114,6 +114,14 @@ LYFE_WEBHOOK_URL=https://<project>.supabase.co/functions/v1/receive-mktr-lead
 # Shared HMAC secret (must match MKTR_WEBHOOK_SECRET in Supabase edge function)
 LYFE_WEBHOOK_SECRET=your-shared-webhook-secret
 
+# lead.suppressed propagation (tracker "propagate") — per-destination opt-in.
+# DANGER: flip ONLY after that consumer's handler is DEPLOYED — the receivers
+# 400 unknown events, and 50 consecutive failures auto-disable the subscriber
+# (stopping ALL lead delivery to that app). Runbook:
+# docs/reference/webhook-propagation-contract.md
+LYFE_LEAD_SUPPRESSED_ENABLED=false
+MKTR_LEADS_LEAD_SUPPRESSED_ENABLED=false
+
 # Lyfe Supabase (agent sync)
 LYFE_SUPABASE_URL=https://<project>.supabase.co
 LYFE_SUPABASE_SERVICE_ROLE_KEY=your-service-role-key

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -58,6 +58,16 @@ export async function bootstrapDatabase() {
     await recoverPendingRetries();
   });
 
+  // Suppression-propagation reconcile (tracker "propagate"): project + queue
+  // lead.suppressed pairs from current state. Runs dark until a subscriber
+  // carries the event (env flags above); the boot pass doubles as the
+  // flag-flip backfill.
+  await safeRun('Suppression propagation reconcile', async () => {
+    const { reconcileSuppressionPropagation } = await import('../services/suppressionPropagationService.js');
+    await reconcileSuppressionPropagation();
+    logger.info('suppression propagation reconciler armed (dark until a subscriber carries lead.suppressed)');
+  });
+
   // Poll for stale webhook retries every 60 seconds (skip in test mode)
   if (process.env.NODE_ENV !== 'test') {
     setInterval(async () => {
@@ -68,6 +78,13 @@ export async function bootstrapDatabase() {
         logger.warn('[Webhook] periodic recovery failed', { error: err?.message });
       }
     }, 60_000);
+
+    // Suppression-propagation backstop pass every 60 minutes — heals lost
+    // triggers, races, and dark-period backlogs (never throws internally).
+    setInterval(async () => {
+      const { reconcileSuppressionPropagation } = await import('../services/suppressionPropagationService.js');
+      await reconcileSuppressionPropagation();
+    }, 3_600_000);
 
     // Purge expired idempotency keys every hour
     setInterval(async () => {
@@ -311,7 +328,7 @@ async function safeRun(label, fn) {
  * are forwarded to the Lyfe Edge Function automatically.
  * Reads URL and secret from env vars; skips silently if not configured.
  */
-async function ensureLyfeWebhookSubscriber() {
+export async function ensureLyfeWebhookSubscriber() {
   const adapter = adapterRegistry.get('lyfe');
   const url = adapter.outboundWebhookUrl?.();
   const secret = adapter.outboundWebhookSecret?.();
@@ -325,7 +342,16 @@ async function ensureLyfeWebhookSubscriber() {
 
   const existing = await WebhookSubscriber.findOne({ where: { name: SUBSCRIBER_NAME } });
 
-  const requiredEvents = ['lead.created', 'lead.assigned', 'lead.unassigned'];
+  // lead.suppressed is env-gated per destination (tracker "propagate"): the
+  // receiver 400s unknown events, and 50 consecutive failures auto-disable the
+  // subscriber — flip ONLY after the consumer's handler is deployed
+  // (docs/reference/webhook-propagation-contract.md runbook). The self-heal
+  // below makes the flag authoritative in both directions on every boot.
+  const requiredEvents = [
+    'lead.created', 'lead.assigned', 'lead.unassigned',
+    ...(String(process.env.LYFE_LEAD_SUPPRESSED_ENABLED || 'false').toLowerCase() === 'true'
+      ? ['lead.suppressed'] : []),
+  ];
 
   if (existing) {
     const needsUpdate = existing.url !== url || existing.secret !== secret || !existing.enabled
@@ -350,7 +376,7 @@ async function ensureLyfeWebhookSubscriber() {
     name: SUBSCRIBER_NAME,
     url,
     secret,
-    events: ['lead.created', 'lead.assigned', 'lead.unassigned'],
+    events: requiredEvents,
     enabled: true,
     description: 'Forward leads to Lyfe mobile app via Supabase Edge Function',
     metadata: { destination: 'lyfe' },
@@ -366,7 +392,7 @@ async function ensureLyfeWebhookSubscriber() {
  * dispatcher delivers ONLY mktr-leads-destined leads here. Env-gated: skips
  * silently if the URL/secret aren't configured (mirrors the Lyfe subscriber).
  */
-async function ensureMktrLeadsWebhookSubscriber() {
+export async function ensureMktrLeadsWebhookSubscriber() {
   const adapter = adapterRegistry.get('mktr_leads');
   const url = adapter.outboundWebhookUrl?.();
   const secret = adapter.outboundWebhookSecret?.();
@@ -380,7 +406,13 @@ async function ensureMktrLeadsWebhookSubscriber() {
   // lead.held → the admin held-queue ping (only the mktr-leads app has that surface;
   // the Lyfe subscriber intentionally does NOT subscribe to it). The events-diff in
   // the update guard below self-heals this onto the existing subscriber on deploy.
-  const requiredEvents = ['lead.created', 'lead.assigned', 'lead.unassigned', 'lead.held', 'lead.deleted'];
+  // lead.suppressed is env-gated (tracker "propagate") — flip ONLY after the
+  // mktr-leads EF handler is deployed; see the Lyfe block above for why.
+  const requiredEvents = [
+    'lead.created', 'lead.assigned', 'lead.unassigned', 'lead.held', 'lead.deleted',
+    ...(String(process.env.MKTR_LEADS_LEAD_SUPPRESSED_ENABLED || 'false').toLowerCase() === 'true'
+      ? ['lead.suppressed'] : []),
+  ];
 
   const existing = await WebhookSubscriber.findOne({ where: { name: SUBSCRIBER_NAME } });
 

--- a/backend/src/database/migrations/083-suppression-propagation.js
+++ b/backend/src/database/migrations/083-suppression-propagation.js
@@ -1,0 +1,70 @@
+/**
+ * 083 — Suppression-propagation projection (tracker "propagate",
+ * docs/plans/suppression-propagation-plan.md §1).
+ *
+ * One row = "subscriber X must be told (at scope S) to stop contacting the
+ * person behind lead P". Rows are DERIVED from current state (consumer
+ * suppressions/erasure ⨝ the person's prospects ⨝ delivery history) by a
+ * deterministic reconciler — never trusted, always recomputable. The partial
+ * unique is the real idempotency: concurrent reconcilers INSERT … ON CONFLICT
+ * DO NOTHING. Scope is monotonic: a 'marketing' pair may later be joined by an
+ * 'all' pair (erasure escalation); nothing ever downgrades or deletes short of
+ * the lead itself going away (CASCADE).
+ *
+ * Guarded/idempotent + sync-tolerant like 078/080 (test boot syncs models
+ * first); runner holds the advisory lock.
+ */
+export async function up(queryInterface) {
+  const q = (sql) => queryInterface.sequelize.query(sql);
+
+  await q(`CREATE TABLE IF NOT EXISTS suppression_propagations (
+    id UUID PRIMARY KEY,
+    "consumerId" UUID NOT NULL,
+    "prospectId" UUID NOT NULL,
+    "subscriberId" UUID NOT NULL,
+    scope VARCHAR(16) NOT NULL,
+    reason VARCHAR(32) NOT NULL,
+    "occurredAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "deliveryId" UUID,
+    "queuedAt" TIMESTAMP WITH TIME ZONE,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+  )`);
+
+  await q(`DO $$ BEGIN
+    ALTER TABLE suppression_propagations
+      ADD CONSTRAINT fk_sp_consumer FOREIGN KEY ("consumerId")
+        REFERENCES consumers (id) ON DELETE RESTRICT;
+  EXCEPTION WHEN duplicate_object THEN NULL; END $$`);
+  await q(`DO $$ BEGIN
+    ALTER TABLE suppression_propagations
+      ADD CONSTRAINT fk_sp_prospect FOREIGN KEY ("prospectId")
+        REFERENCES prospects (id) ON DELETE CASCADE;
+  EXCEPTION WHEN duplicate_object THEN NULL; END $$`);
+  await q(`DO $$ BEGIN
+    ALTER TABLE suppression_propagations
+      ADD CONSTRAINT fk_sp_subscriber FOREIGN KEY ("subscriberId")
+        REFERENCES webhook_subscribers (id) ON DELETE CASCADE;
+  EXCEPTION WHEN duplicate_object THEN NULL; END $$`);
+
+  await q(`DO $$ BEGIN
+    ALTER TABLE suppression_propagations
+      ADD CONSTRAINT chk_sp_scope CHECK (scope IN ('marketing', 'all'));
+  EXCEPTION WHEN duplicate_object THEN NULL; END $$`);
+  await q(`DO $$ BEGIN
+    ALTER TABLE suppression_propagations
+      ADD CONSTRAINT chk_sp_reason
+        CHECK (reason IN ('unsubscribe', 'complaint', 'admin', 'erasure'));
+  EXCEPTION WHEN duplicate_object THEN NULL; END $$`);
+
+  await q(`CREATE UNIQUE INDEX IF NOT EXISTS uq_sp_sub_prospect_scope
+             ON suppression_propagations ("subscriberId", "prospectId", scope)`);
+  await q(`CREATE INDEX IF NOT EXISTS idx_sp_needs_queue
+             ON suppression_propagations ("createdAt") WHERE "queuedAt" IS NULL`);
+  await q(`CREATE INDEX IF NOT EXISTS idx_sp_consumer
+             ON suppression_propagations ("consumerId")`);
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query('DROP TABLE IF EXISTS suppression_propagations');
+}

--- a/backend/src/models/SuppressionPropagation.js
+++ b/backend/src/models/SuppressionPropagation.js
@@ -1,0 +1,49 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * The suppression-propagation projection (tracker "propagate", plan §1): one
+ * row per (subscriber, lead, scope) that must receive — or has received — a
+ * `lead.suppressed` webhook. DERIVED state: the reconciler recomputes rows
+ * from consumer_suppressions/consumers.erasedAt ⨝ prospects ⨝ delivery
+ * history; the unique index makes concurrent reconciles idempotent
+ * (ON CONFLICT DO NOTHING). `queuedAt IS NULL` = delivery row not yet
+ * created. Scope is monotonic — 'all' joins 'marketing', never replaces it;
+ * there is no unsuppression event in v1.
+ *
+ * consumerId is provenance ONLY and never appears in webhook payloads
+ * (spine payload contract, Decisions #8).
+ */
+const SuppressionPropagation = sequelize.define('SuppressionPropagation', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  consumerId: { type: DataTypes.UUID, allowNull: false, references: { model: 'consumers', key: 'id' } },
+  prospectId: { type: DataTypes.UUID, allowNull: false, references: { model: 'prospects', key: 'id' } },
+  subscriberId: { type: DataTypes.UUID, allowNull: false, references: { model: 'webhook_subscribers', key: 'id' } },
+  scope: {
+    type: DataTypes.STRING(16),
+    allowNull: false,
+    validate: { isIn: [['marketing', 'all']] },
+  },
+  reason: {
+    type: DataTypes.STRING(32),
+    allowNull: false,
+    validate: { isIn: [['unsubscribe', 'complaint', 'admin', 'erasure']] },
+  },
+  occurredAt: {
+    type: DataTypes.DATE,
+    allowNull: false,
+    comment: 'Authoritative transition time (suppression.createdAt / consumer.erasedAt) — stable across repairs',
+  },
+  deliveryId: { type: DataTypes.UUID, allowNull: true },
+  queuedAt: { type: DataTypes.DATE, allowNull: true },
+}, {
+  tableName: 'suppression_propagations',
+  indexes: [
+    // Mirrored on the model (sync-built test schemas) — the idempotency key.
+    { unique: true, fields: ['subscriberId', 'prospectId', 'scope'], name: 'uq_sp_sub_prospect_scope' },
+    { fields: ['consumerId'], name: 'idx_sp_consumer' },
+    { fields: ['createdAt'], name: 'idx_sp_needs_queue', where: { queuedAt: null } },
+  ],
+});
+
+export default SuppressionPropagation;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -97,6 +97,14 @@ function defineAssociations() {
   Consumer.hasMany(ConsumerSuppression, { foreignKey: 'consumerId', as: 'suppressions', onDelete: 'RESTRICT' });
   ConsumerSuppression.belongsTo(Consumer, { foreignKey: 'consumerId', as: 'consumer', onDelete: 'RESTRICT' });
 
+  // Suppression-propagation projection (tracker "propagate") — derived rows,
+  // reconciler-owned. CASCADE from prospect/subscriber (a vanished lead or
+  // subscriber voids the pair); RESTRICT from consumers like the ledger.
+  const { SuppressionPropagation } = models;
+  SuppressionPropagation.belongsTo(Consumer, { foreignKey: 'consumerId', as: 'consumer', onDelete: 'RESTRICT' });
+  SuppressionPropagation.belongsTo(Prospect, { foreignKey: 'prospectId', as: 'prospect', onDelete: 'CASCADE' });
+  SuppressionPropagation.belongsTo(WebhookSubscriber, { foreignKey: 'subscriberId', as: 'subscriber', onDelete: 'CASCADE' });
+
   // Prospect associations
   Prospect.belongsTo(User, { foreignKey: 'assignedAgentId', as: 'assignedAgent', onDelete: 'SET NULL' });
   Prospect.belongsTo(Campaign, { foreignKey: 'campaignId', as: 'campaign', onDelete: 'SET NULL' });
@@ -369,7 +377,8 @@ export const {
   DiscoveryRun, DiscoveryCandidate,
   DiscoveryPlaceMemory, OutreachCadence, OutreachCadenceStep,
   OutreachCadenceTransition, OutreachCadenceEnrollment, OutreachSuppression,
-  AiSettings, WalletLedger, Consumer, ConsentEvent, ConsumerSuppression
+  AiSettings, WalletLedger, Consumer, ConsentEvent, ConsumerSuppression,
+  SuppressionPropagation
 } = models;
 
 export { sequelize };

--- a/backend/src/services/consentService.js
+++ b/backend/src/services/consentService.js
@@ -5,6 +5,7 @@ import {
 } from '../models/index.js';
 import { logger } from '../utils/logger.js';
 import { phoneVerificationIsCurrent, E164_RE } from './consumerService.js';
+import { reconcileSuppressionPropagation } from './suppressionPropagationService.js';
 import {
   CONTACT_CONSENT_VERSION, CONTACT_CONSENT_CHANNELS,
   CONTACT_CONSENT_VERSIONS, isKnownConsentCopyVersion,
@@ -52,7 +53,10 @@ export function unsubTokenHashOf(token) {
   return createHash('sha256').update(String(token)).digest('hex');
 }
 
-const defaultDeps = { sequelize, Consumer, ConsentEvent, ConsumerSuppression, Prospect, logger };
+const defaultDeps = {
+  sequelize, Consumer, ConsentEvent, ConsumerSuppression, Prospect, logger,
+  reconcileSuppressionPropagation, // tracker "propagate" — post-commit trigger
+};
 
 export function makeConsentService(overrides = {}) {
   const d = { ...defaultDeps, ...overrides };
@@ -437,7 +441,7 @@ export function makeConsentService(overrides = {}) {
 
   /** Idempotent global marketing unsubscribe + ledger evidence. */
   async function applyUnsubscribe(consumer, { source = 'unsubscribe_link' } = {}) {
-    return d.sequelize.transaction(async (t) => {
+    const result = await d.sequelize.transaction(async (t) => {
       const [, created] = await d.ConsumerSuppression.findOrCreate({
         where: { consumerId: consumer.id, channel: 'all' },
         defaults: { id: randomUUID(), reason: 'unsubscribe', source },
@@ -455,6 +459,19 @@ export function makeConsentService(overrides = {}) {
       }
       return { alreadySuppressed: !created };
     });
+    // Post-commit, fire-and-forget: project lead.suppressed pairs for the
+    // person's delivered leads (tracker "propagate"). ALSO on the
+    // already-suppressed path — a re-unsubscribe is a free healing trigger.
+    // A lost trigger costs nothing: the periodic reconcile pass is the
+    // durability, the projection table is the state.
+    if (d.reconcileSuppressionPropagation) {
+      Promise.resolve(d.reconcileSuppressionPropagation({ consumerId: consumer.id })).catch((err) => {
+        d.logger.warn('[consent] suppression propagation trigger failed (periodic pass heals)', {
+          consumerId: consumer.id, error: err?.message || String(err),
+        });
+      });
+    }
+    return result;
   }
 
   return {

--- a/backend/src/services/erasureService.js
+++ b/backend/src/services/erasureService.js
@@ -10,7 +10,8 @@ import { emailNormKey } from './repeatSignup.js';
 import { makeInventoryService } from './redeemOps/inventoryService.js';
 import { makeRedeemOpsAuditService } from './redeemOps/auditService.js';
 import { buildLeadDeletedPayload } from './prospectHelpers.js';
-import { flushDeliveries } from './webhookService.js';
+import { flushDeliveries, historicallyTargetedSubscribers } from './webhookService.js';
+import { reconcileSuppressionPropagation } from './suppressionPropagationService.js';
 import { evictVerifiedPhone } from './verifiedPhoneStore.js';
 import { evictDncCheckCache } from './dncCheckService.js';
 
@@ -58,15 +59,13 @@ import { evictDncCheckCache } from './dncCheckService.js';
 /** draw_entries.phoneHash is NOT NULL — erasure writes this obviously-fake sentinel. */
 export const ERASED_PHONE_HASH = '0'.repeat(64);
 
-/** Events whose payloads embed the full lead PII (the "ever received" markers). */
-const RECEIVED_EVENT_TYPES = ['lead.created', 'lead.assigned'];
-
 const digitsOf = (v) => String(v || '').replace(/\D/g, '');
 
 const defaultDeps = {
   sequelize, Consumer, Prospect, RewardEntitlement, RedemptionEvent,
   ConsentEvent, ConsumerSuppression, WebhookSubscriber, WebhookDelivery,
-  logger, flushDeliveries, evictVerifiedPhone, evictDncCheckCache,
+  logger, flushDeliveries, historicallyTargetedSubscribers, reconcileSuppressionPropagation,
+  evictVerifiedPhone, evictDncCheckCache,
   inventory: makeInventoryService(),
   audit: makeRedeemOpsAuditService(),
 };
@@ -188,15 +187,10 @@ export function makeErasureService(overrides = {}) {
         .filter(Boolean))];
 
       if (pids.length) {
-        // 4. Who ever RECEIVED this lead (before payloads are scrubbed).
-        const [recipientRows] = await d.sequelize.query(
-          `SELECT DISTINCT wd."subscriberId" AS id,
-                  (wd.payload::jsonb #>> '{data,lead,externalId}') AS pid
-             FROM webhook_deliveries wd
-            WHERE wd."eventType" IN (:eventTypes)
-              AND (wd.payload::jsonb #>> '{data,lead,externalId}') IN (:pids)`,
-          { replacements: { eventTypes: RECEIVED_EVENT_TYPES, pids }, transaction: t }
-        );
+        // 4. Who was ever TARGETED with this lead's payload (before payloads
+        // are scrubbed) — shared helper (tracker "propagate").
+        const recipientRows = (await d.historicallyTargetedSubscribers(pids, t))
+          .map((r) => ({ id: r.subscriberId, pid: r.prospectId }));
 
         // 5a. A pending delivery still carrying PII must never fire later.
         // (The in-memory instance a flush already queued is fenced too:
@@ -205,7 +199,7 @@ export function makeErasureService(overrides = {}) {
           `UPDATE webhook_deliveries
               SET status = 'failed', "errorMessage" = 'cancelled: person erased', "updatedAt" = now()
             WHERE status = 'pending'
-              AND "eventType" <> 'lead.deleted'
+              AND "eventType" NOT IN ('lead.deleted', 'lead.suppressed')
               AND (payload::jsonb #>> '{data,lead,externalId}') IN (:pids)`,
           { replacements: { pids }, transaction: t }
         );
@@ -213,7 +207,10 @@ export function makeErasureService(overrides = {}) {
 
         // 5b. Scrub every historical payload copy down to its envelope. Runs
         // BEFORE the lead.deleted outbox rows are written; earlier repair-run
-        // outbox rows are excluded by event type.
+        // outbox rows are excluded by event type. lead.suppressed is exempt
+        // like lead.deleted: its payload is PII-free by contract, and
+        // cancelling/scrubbing it would only make the suppression reconciler
+        // re-queue an identical delivery (tracker "propagate").
         const [, scrubMeta] = await d.sequelize.query(
           `UPDATE webhook_deliveries
               SET payload = json_build_object(
@@ -224,7 +221,7 @@ export function makeErasureService(overrides = {}) {
                       'externalId', payload::jsonb #>> '{data,lead,externalId}'))),
                   "responseBody" = NULL,
                   "updatedAt" = now()
-            WHERE "eventType" <> 'lead.deleted'
+            WHERE "eventType" NOT IN ('lead.deleted', 'lead.suppressed')
               AND (payload::jsonb #>> '{data,lead,externalId}') IN (:pids)
               AND (payload::jsonb -> 'erased') IS NULL`,
           { replacements: { pids }, transaction: t }
@@ -652,8 +649,17 @@ export function makeErasureService(overrides = {}) {
     });
 
     // Post-commit: fire the persisted lead.deleted outbox rows + evict the
-    // in-memory phone caches (OTP-verified marker, DNC result cache).
+    // in-memory phone caches (OTP-verified marker, DNC result cache), then
+    // trigger the suppression reconciler — subscribers that handle
+    // lead.suppressed but not lead.deleted learn "stop contact" this way
+    // (fallback rule, tracker "propagate"). Fire-and-forget: the periodic
+    // pass heals a lost trigger.
     d.flushDeliveries(outboxPairs);
+    Promise.resolve(d.reconcileSuppressionPropagation({ consumerId })).catch((err) => {
+      d.logger.warn('[erasure] suppression propagation trigger failed (periodic pass heals)', {
+        consumerId, error: err?.message || String(err),
+      });
+    });
     if (erasedPhone) {
       try {
         d.evictVerifiedPhone(erasedPhone);

--- a/backend/src/services/metaLeadService.js
+++ b/backend/src/services/metaLeadService.js
@@ -366,6 +366,8 @@ export function makeMetaLeadService(overrides = {}) {
           campaign: campaign ? { externalId: campaign.id, name: campaign.name } : null
         }
       }), { destination: metaDestination });
+      // Suppressed-person new-lead propagation rides the webhookService
+      // flush-time catchup (tracker "propagate").
 
       // Held → ping the mktr-leads admin held queue so a pending lead is never silent.
       // Explicitly require no_funded_agent (the only reason that lands in that queue) so

--- a/backend/src/services/prospectHelpers.js
+++ b/backend/src/services/prospectHelpers.js
@@ -252,6 +252,33 @@ export function buildLeadDeletedPayload(prospect) {
   };
 }
 
+/**
+ * lead.suppressed v1 (tracker "propagate", docs/reference/webhook-propagation-contract.md):
+ * "stop contacting the person behind this lead; keep the lead."
+ * Data-minimized by contract: lead externalId + suppression facts only —
+ * no consumerId, no phone/name/email. Consumers act on `scope`
+ * ('all' blocks everything incl. transactional; 'marketing' blocks marketing);
+ * `reason` is diagnostic. `occurredAt` is the authoritative transition time
+ * (suppression.createdAt / consumer.erasedAt) — stable across repairs, used
+ * for the consumer's monotonic merge.
+ */
+export function buildLeadSuppressedPayload(prospectId, { scope, reason, channel = 'all', occurredAt }) {
+  return {
+    event: 'lead.suppressed',
+    timestamp: new Date().toISOString(),
+    data: {
+      lead: { externalId: prospectId },
+      suppression: {
+        schemaVersion: 1,
+        scope,
+        reason,
+        channel,
+        occurredAt: occurredAt instanceof Date ? occurredAt.toISOString() : occurredAt,
+      },
+    },
+  };
+}
+
 /** Format a budget object ({ min, max, currency, timeframe }) into one display string, or null. */
 function formatBudget(budget) {
   if (!budget || typeof budget !== 'object') return null;

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -1108,6 +1108,9 @@ export function makeProspectService(overrides = {}) {
       ).catch((err) => {
         d.logger.error('[Webhook] dispatch error', { error: err?.message || String(err) });
       });
+      // Suppressed-person new-lead propagation rides webhookService's
+      // flush-time catchup choke point (tracker "propagate") — no per-site
+      // hook needed here.
     }
 
     // Held (no_funded_agent) → ping the mktr-leads admin held queue so a pending

--- a/backend/src/services/suppressionPropagationService.js
+++ b/backend/src/services/suppressionPropagationService.js
@@ -1,0 +1,307 @@
+import { randomUUID } from 'crypto';
+import { Op } from 'sequelize';
+import {
+  sequelize, Consumer, Prospect, ConsumerSuppression, WebhookSubscriber,
+  WebhookDelivery, SuppressionPropagation,
+} from '../models/index.js';
+import { logger } from '../utils/logger.js';
+import { buildLeadSuppressedPayload } from './prospectHelpers.js';
+import { flushDeliveries, historicallyTargetedSubscribers } from './webhookService.js';
+
+/**
+ * Suppression propagation (tracker "propagate",
+ * docs/plans/suppression-propagation-plan.md + the wire contract in
+ * docs/reference/webhook-propagation-contract.md).
+ *
+ * NOT a fanout — a RECONCILER over a durable projection. The v1 fanout design
+ * was rejected by Codex round 1 for being lossy (dark-period suppressions,
+ * future leads of an already-suppressed person, capture races, savepoint
+ * rollbacks — all permanently silent). Instead:
+ *
+ *   current state (consumer_suppressions + consumers.erasedAt)
+ *     ⨝ the person's prospects
+ *     ⨝ delivery history (who was ever TARGETED with the lead's payload)
+ *     ⨝ current subscriptions (events includes 'lead.suppressed')
+ *   ⇒ suppression_propagations pairs (subscriberId, prospectId, scope)
+ *
+ * The pass is deterministic and assignment-shaped: safe to run anytime,
+ * repeatedly, concurrently (DB unique + ON CONFLICT DO NOTHING; queue claims
+ * are CAS updates). Every loss mode heals on the next pass — including the
+ * dark→flip backfill: while no subscriber carries the event nothing is
+ * created, and the first pass after a bootstrap flag flip projects the entire
+ * backlog from state.
+ *
+ * Scope is monotonic: 'marketing' (unsubscribe/complaint/admin) may later be
+ * joined by 'all' (erasure); nothing downgrades — there is no unsuppression
+ * event in v1.
+ *
+ * Erasure-fallback rule: for erasure-scope pairs, subscribers whose events
+ * include 'lead.deleted' get NO pair — their signal is the erasure outbox
+ * (erasureService) with its dead-letter repair. Subscribers that only handle
+ * 'lead.suppressed' get reason:'erasure', scope:'all' so stop-contact ships
+ * before their deletion handler exists.
+ */
+
+const digitsOf = (v) => String(v || '').replace(/\D/g, '');
+
+const defaultDeps = {
+  sequelize, Consumer, Prospect, ConsumerSuppression, WebhookSubscriber,
+  WebhookDelivery, SuppressionPropagation,
+  logger, buildLeadSuppressedPayload, flushDeliveries, historicallyTargetedSubscribers,
+};
+
+export function makeSuppressionPropagationService(overrides = {}) {
+  const d = { ...defaultDeps, ...overrides };
+
+  /** The person's leads: consumer link + (identity intact only) phone arms. */
+  async function prospectIdsOf(consumer) {
+    const orArms = [`"consumerId" = :cid`];
+    const repl = { cid: consumer.id };
+    const phoneDigits = consumer.erasedAt ? null : digitsOf(consumer.phone);
+    if (phoneDigits) {
+      // digitsOf output is \d+ only — safe to bind as a plain param.
+      // Plain-phone arm EXCLUDES call_bot: their `phone` is MKTR's DDI, not
+      // the caller (spine precedent, consumerService) — a consumer whose
+      // number equals the DDI must not suppress strangers' call leads. The
+      // caller leg is matched via fromNumber instead (Codex diff-round #6).
+      orArms.push(`("leadSource" <> 'call_bot' AND regexp_replace(COALESCE(phone, ''), '\\D', '', 'g') = :digits)`);
+      orArms.push(`("leadSource" = 'call_bot' AND regexp_replace(COALESCE("sourceMetadata"->>'fromNumber', ''), '\\D', '', 'g') = :digits)`);
+      repl.digits = phoneDigits;
+    }
+    const [rows] = await d.sequelize.query(
+      `SELECT id FROM prospects WHERE ${orArms.join(' OR ')}`,
+      { replacements: repl }
+    );
+    return rows.map((r) => r.id);
+  }
+
+  /**
+   * One reconcile pass. `consumerId` narrows to one person (writer triggers,
+   * capture hook); omitted = full pass (boot, interval, flag-flip backfill).
+   * Returns counts. Never throws — callers are post-commit fire-and-forget.
+   */
+  async function reconcileSuppressionPropagation({ consumerId = null } = {}) {
+    const counts = { consumers: 0, pairsInserted: 0, queued: 0, requeued: 0 };
+    try {
+      // 1. Suppressed-or-erased consumers with their transition facts.
+      // channel='all' rows only: v1 writers never produce channel rows, and a
+      // future per-channel suppression (WA STOP) must NOT be promoted to a
+      // global scope — that lands with a schemaVersion bump (Codex #3).
+      const [targets] = await d.sequelize.query(
+        `SELECT c.id, c.phone, c."erasedAt",
+                s.reason AS "sReason", s."createdAt" AS "sAt"
+           FROM consumers c
+           LEFT JOIN consumer_suppressions s
+             ON s."consumerId" = c.id AND s.channel = 'all'
+          WHERE (s.id IS NOT NULL OR c."erasedAt" IS NOT NULL)
+            ${consumerId ? 'AND c.id = :consumerId' : ''}
+          ORDER BY c.id, s."createdAt" ASC`,
+        { replacements: consumerId ? { consumerId } : {} }
+      );
+      if (!targets.length) return counts;
+
+      // Group rows per consumer → the scopes this person's pairs need.
+      const byConsumer = new Map();
+      for (const row of targets) {
+        if (!byConsumer.has(row.id)) {
+          byConsumer.set(row.id, { id: row.id, phone: row.phone, erasedAt: row.erasedAt, suppressions: [] });
+        }
+        if (row.sReason) byConsumer.get(row.id).suppressions.push({ reason: row.sReason, at: row.sAt });
+      }
+
+      // Array.isArray guard: subscriber CRUD accepts arbitrary JSON for
+      // events — a malformed row must not poison the pass (Codex #7).
+      const subscribed = (await d.WebhookSubscriber.findAll({ where: { enabled: true } }))
+        .filter((s) => Array.isArray(s.events) && s.events.includes('lead.suppressed'));
+      if (!subscribed.length) return counts; // dark — pairs appear on the first pass after a flip
+      const subscribedById = new Map(subscribed.map((s) => [s.id, s]));
+
+      for (const consumer of byConsumer.values()) {
+        try {
+        counts.consumers += 1;
+        // Scope transitions (monotonic; earliest evidence wins as occurredAt).
+        const erasure = consumer.erasedAt
+          ? { at: consumer.erasedAt, reason: 'erasure' }
+          : (consumer.suppressions.find((s) => s.reason === 'erasure')
+            ? { at: consumer.suppressions.find((s) => s.reason === 'erasure').at, reason: 'erasure' }
+            : null);
+        const marketing = consumer.suppressions.find((s) => s.reason !== 'erasure') || null;
+        const transitions = [
+          ...(marketing ? [{ scope: 'marketing', reason: marketing.reason, occurredAt: marketing.at }] : []),
+          ...(erasure ? [{ scope: 'all', reason: 'erasure', occurredAt: erasure.at }] : []),
+        ];
+        if (!transitions.length) continue;
+
+        const pids = await prospectIdsOf(consumer);
+        if (!pids.length) continue;
+        const targeted = await d.historicallyTargetedSubscribers(pids);
+
+        // Erasure-fallback rule, OUTCOME-based (Codex #2): a lead.deleted
+        // handler is skipped only when its lead.deleted delivery row actually
+        // EXISTS for that lead — an erasure that ran while webhooks were
+        // disabled queued nothing, and the person's stop-contact must not be
+        // silently dropped on capability alone. If the deleted row appears
+        // later (re-erase repair), both signals having fired is harmless:
+        // consumer merge is monotonic.
+        let deletedRowSet = new Set();
+        const anyErasure = transitions.some((tr) => tr.scope === 'all');
+        if (anyErasure) {
+          const [deletedRows] = await d.sequelize.query(
+            `SELECT DISTINCT "subscriberId",
+                    (payload::jsonb #>> '{data,lead,externalId}') AS pid
+               FROM webhook_deliveries
+              WHERE "eventType" = 'lead.deleted'
+                AND (payload::jsonb #>> '{data,lead,externalId}') IN (:pids)`,
+            { replacements: { pids } }
+          );
+          deletedRowSet = new Set(deletedRows.map((r) => `${r.subscriberId}:${r.pid}`));
+        }
+
+        const values = [];
+        for (const { subscriberId, prospectId } of targeted) {
+          const sub = subscribedById.get(subscriberId);
+          if (!sub) continue;
+          for (const tr of transitions) {
+            if (
+              tr.scope === 'all'
+              && sub.events.includes('lead.deleted')
+              && deletedRowSet.has(`${subscriberId}:${prospectId}`)
+            ) continue;
+            values.push({ subscriberId, prospectId, scope: tr.scope, reason: tr.reason, occurredAt: tr.occurredAt });
+          }
+        }
+        if (!values.length) continue;
+
+        // 2. Project missing pairs — the unique index is the idempotency.
+        const params = [];
+        const tuples = values.map((v, i) => {
+          const b = i * 7;
+          params.push(randomUUID(), consumer.id, v.prospectId, v.subscriberId, v.scope, v.reason, v.occurredAt);
+          return `($${b + 1}, $${b + 2}, $${b + 3}, $${b + 4}, $${b + 5}, $${b + 6}, $${b + 7}, now(), now())`;
+        });
+        // RETURNING id so the inserted count is dialect-quirk-proof
+        // (sequelize's INSERT metadata is not a pg rowCount).
+        const [insertedRows] = await d.sequelize.query(
+          `INSERT INTO suppression_propagations
+             (id, "consumerId", "prospectId", "subscriberId", scope, reason, "occurredAt", "createdAt", "updatedAt")
+           VALUES ${tuples.join(', ')}
+           ON CONFLICT ("subscriberId", "prospectId", scope) DO NOTHING
+           RETURNING id`,
+          { bind: params }
+        );
+        counts.pairsInserted += insertedRows?.length ?? 0;
+        } catch (err) {
+          // Per-consumer isolation: one bad person/record must not poison the
+          // whole pass (Codex #7).
+          d.logger.warn('[suppression-propagation] consumer projection failed — continuing pass', {
+            consumerId: consumer.id, error: err?.message || String(err),
+          });
+        }
+      }
+
+      // 3. Queue phase — pairs without a delivery, plus terminally-failed OR
+      // PURGED ones (dead-letter purge deletes failed rows; the LEFT JOIN's
+      // null arm catches the dangling pair — Codex #5). Re-queued at most
+      // once per pass, only while still subscribed.
+      if (String(process.env.WEBHOOK_ENABLED || 'false').toLowerCase() !== 'true') {
+        d.logger.info('[suppression-propagation] webhooks disabled — pairs projected, queueing deferred', counts);
+        return counts;
+      }
+      const pending = await d.SuppressionPropagation.findAll({
+        where: { queuedAt: null, ...(consumerId ? { consumerId } : {}) },
+      });
+      const [failedRows] = await d.sequelize.query(
+        `SELECT sp.id FROM suppression_propagations sp
+           LEFT JOIN webhook_deliveries wd ON wd."deliveryId" = sp."deliveryId"
+          WHERE sp."queuedAt" IS NOT NULL
+            AND (wd.status = 'failed' OR wd.id IS NULL)
+            ${consumerId ? 'AND sp."consumerId" = :consumerId' : ''}`,
+        { replacements: consumerId ? { consumerId } : {} }
+      );
+      const failedIds = new Set(failedRows.map((r) => r.id));
+      const work = [
+        ...pending.map((p) => ({ pair: p, requeue: false })),
+        ...(failedIds.size
+          ? (await d.SuppressionPropagation.findAll({ where: { id: { [Op.in]: [...failedIds] } } }))
+            .map((p) => ({ pair: p, requeue: true }))
+          : []),
+      ];
+
+      const outbox = [];
+      for (const { pair, requeue } of work) {
+        const sub = subscribedById.get(pair.subscriberId);
+        if (!sub) continue; // unsubscribed since projection — kill-switch semantics
+        const deliveryId = randomUUID();
+        try {
+        await d.sequelize.transaction(async (t) => {
+          // CAS claim so concurrent passes cannot double-queue.
+          const [, claimMeta] = await d.sequelize.query(
+            `UPDATE suppression_propagations
+                SET "deliveryId" = :deliveryId, "queuedAt" = now(), "updatedAt" = now()
+              WHERE id = :id AND ${requeue ? '"deliveryId" = :prevDeliveryId' : '"queuedAt" IS NULL'}`,
+            {
+              replacements: {
+                deliveryId, id: pair.id,
+                ...(requeue ? { prevDeliveryId: pair.deliveryId } : {}),
+              },
+              transaction: t,
+            }
+          );
+          if ((claimMeta?.rowCount ?? 0) !== 1) return; // lost the claim — another pass owns it
+          // In-txn rechecks (Codex #4): the pass-level subscriber snapshot and
+          // failed-set are stale by now — a kill-switch flip or an admin
+          // manual retry may have raced this pass. Throwing rolls the claim
+          // back so a later pass re-evaluates from fresh state.
+          const subNow = await d.WebhookSubscriber.findByPk(pair.subscriberId, { transaction: t });
+          if (!subNow?.enabled || !Array.isArray(subNow.events) || !subNow.events.includes('lead.suppressed')) {
+            throw new Error('recheck: subscription gone');
+          }
+          if (requeue && pair.deliveryId) {
+            const [prevRows] = await d.sequelize.query(
+              'SELECT status FROM webhook_deliveries WHERE "deliveryId" = :prev FOR UPDATE',
+              { replacements: { prev: pair.deliveryId }, transaction: t }
+            );
+            if (prevRows.length && prevRows[0].status !== 'failed') {
+              throw new Error('recheck: previous delivery revived by manual retry');
+            }
+          }
+          const payload = {
+            ...d.buildLeadSuppressedPayload(pair.prospectId, {
+              scope: pair.scope, reason: pair.reason, occurredAt: pair.occurredAt,
+            }),
+            deliveryId,
+          };
+          const delivery = await d.WebhookDelivery.create({
+            subscriberId: pair.subscriberId, deliveryId, eventType: 'lead.suppressed',
+            payload, status: 'pending',
+          }, { transaction: t });
+          outbox.push({ delivery, subscriber: sub });
+          if (requeue) counts.requeued += 1; else counts.queued += 1;
+        });
+        } catch (err) {
+          // A rolled-back claim (recheck fired) or a transient txn error skips
+          // only THIS pair; the pass continues and a later pass re-evaluates.
+          d.logger.info('[suppression-propagation] pair skipped', {
+            pairId: pair.id, error: err?.message || String(err),
+          });
+        }
+      }
+      if (outbox.length) d.flushDeliveries(outbox);
+      if (counts.pairsInserted || counts.queued || counts.requeued) {
+        d.logger.info('[suppression-propagation] reconciled', counts);
+      }
+      return counts;
+    } catch (err) {
+      // Never throws — the projection heals on the next pass.
+      d.logger.warn('[suppression-propagation] reconcile pass failed (will heal on next pass)', {
+        error: err?.message || String(err), consumerId,
+      });
+      return counts;
+    }
+  }
+
+  return { reconcileSuppressionPropagation };
+}
+
+const _default = makeSuppressionPropagationService();
+export const reconcileSuppressionPropagation = _default.reconcileSuppressionPropagation;

--- a/backend/src/services/webhookService.js
+++ b/backend/src/services/webhookService.js
@@ -7,11 +7,49 @@ import { Sentry } from '../utils/sentryInit.js';
 
 const AUTO_DISABLE_THRESHOLD = 50;
 
+/** Events whose payloads embed the full lead PII — the "historically targeted" markers. */
+export const PAYLOAD_EVENT_TYPES = ['lead.created', 'lead.assigned'];
+
+/**
+ * After a flush that targeted leads with payload events, nudge the
+ * suppression reconciler for any lead whose person is spine-linked — this is
+ * how a suppressed person's NEW targeting (later signup, reassignment, held
+ * release) propagates promptly instead of waiting for the hourly pass.
+ * Dynamic import: suppressionPropagationService statically imports this
+ * module, so the reverse edge must stay lazy.
+ */
+async function defaultPropagationCatchup(pairs) {
+  try {
+    const ids = [...new Set(
+      (pairs || [])
+        .filter((p) => PAYLOAD_EVENT_TYPES.includes(p?.delivery?.eventType))
+        .map((p) => p?.delivery?.payload?.data?.lead?.externalId)
+        .filter(Boolean)
+    )];
+    if (!ids.length) return;
+    const [rows] = await sequelize.query(
+      'SELECT DISTINCT "consumerId" FROM prospects WHERE id IN (:ids) AND "consumerId" IS NOT NULL',
+      { replacements: { ids } }
+    );
+    if (!rows.length) return;
+    const { reconcileSuppressionPropagation } = await import('./suppressionPropagationService.js');
+    for (const r of rows) {
+      reconcileSuppressionPropagation({ consumerId: r.consumerId }).catch((err) => {
+        logger.warn('[Webhook] propagation catchup reconcile failed', { error: err?.message || String(err) });
+      });
+    }
+  } catch (err) {
+    logger.warn('[Webhook] propagation catchup failed', { error: err?.message || String(err) });
+  }
+}
+
 // --- Default dependencies ---
 const defaultDeps = {
   WebhookSubscriber,
   WebhookDelivery,
+  sequelize,
   logger,
+  propagationCatchup: defaultPropagationCatchup,
   fetch: globalThis.fetch,
   // OBS-01: alert on the two silent failure modes that stop lead delivery
   // without a trace (subscriber auto-disable, dropped deliveries). Injected so
@@ -168,6 +206,13 @@ export function makeWebhookService(overrides = {}) {
     for (const { delivery, subscriber } of (pairs || [])) {
       enqueueDelivery(delivery, subscriber);
     }
+    // Suppression catch-up (tracker "propagate", Codex diff-round #1): EVERY
+    // payload-carrying delivery flows through this choke point — capture,
+    // assignment (manual/bulk/cross-app), held release, DNC release, sweep.
+    // If the lead's person is suppressed, the new targeting must be projected
+    // promptly (the mktr-leads create-time wa_intro is gated by the tombstone
+    // arriving BEFORE/with the lead). Fire-and-forget; hourly pass heals.
+    d.propagationCatchup(pairs);
   }
 
   /**
@@ -540,9 +585,31 @@ export function makeWebhookService(overrides = {}) {
     );
   }
 
+  /**
+   * Subscribers HISTORICALLY TARGETED with these leads' payload-carrying
+   * events (lead.created/lead.assigned), from delivery history — any status:
+   * a pending/failed row still means the payload was addressed to them, so
+   * erasure/suppression must reach them too (conservative over-notify).
+   * Returns [{ subscriberId, prospectId }]. Extracted from erasureService
+   * (tracker "propagate"); shared by erasure fanout + the suppression
+   * reconciler.
+   */
+  async function historicallyTargetedSubscribers(prospectIds, transaction = null) {
+    if (!prospectIds?.length) return [];
+    const [rows] = await d.sequelize.query(
+      `SELECT DISTINCT wd."subscriberId" AS "subscriberId",
+              (wd.payload::jsonb #>> '{data,lead,externalId}') AS "prospectId"
+         FROM webhook_deliveries wd
+        WHERE wd."eventType" IN (:eventTypes)
+          AND (wd.payload::jsonb #>> '{data,lead,externalId}') IN (:prospectIds)`,
+      { replacements: { eventTypes: PAYLOAD_EVENT_TYPES, prospectIds }, transaction }
+    );
+    return rows;
+  }
+
   return { dispatchEvent, persistEventDeliveries, flushDeliveries, attemptDelivery, retryDelivery, retryAllFailed,
            getDeadLetterQueue, purgeDeadLetters, getDeliveryStats, getQueueStats, recoverPendingRetries,
-           hasDeliverableSubscriber };
+           hasDeliverableSubscriber, historicallyTargetedSubscribers };
 }
 
 // --- Backward-compatible named exports ---
@@ -558,3 +625,4 @@ export const purgeDeadLetters = _default.purgeDeadLetters;
 export const getDeliveryStats = _default.getDeliveryStats;
 export const recoverPendingRetries = _default.recoverPendingRetries;
 export const hasDeliverableSubscriber = _default.hasDeliverableSubscriber;
+export const historicallyTargetedSubscribers = _default.historicallyTargetedSubscribers;

--- a/backend/test/integration/suppressionPropagation.test.js
+++ b/backend/test/integration/suppressionPropagation.test.js
@@ -1,0 +1,555 @@
+/**
+ * Suppression propagation (tracker "propagate") — the durable projection +
+ * reconciler behind the lead.suppressed webhook. Real Postgres: the DB unique
+ * is the idempotency and the CAS claims are the concurrency story — mocks
+ * cannot prove either. Plan: docs/plans/suppression-propagation-plan.md §5.
+ */
+process.env.WEBHOOK_ENABLED = 'true';
+
+import { jest } from '@jest/globals';
+import crypto from 'crypto';
+import request from 'supertest';
+import {
+  getApp, closeDb, createTestUser, createTestCampaign,
+} from '../helpers.js';
+import { Consumer, Prospect, WebhookSubscriber, WebhookDelivery,
+  SuppressionPropagation, ConsumerSuppression,
+} from '../../src/models/index.js';
+import { makeSuppressionPropagationService } from '../../src/services/suppressionPropagationService.js';
+import { makeConsentService, ensureUnsubToken } from '../../src/services/consentService.js';
+import { makeErasureService } from '../../src/services/erasureService.js';
+import { buildLeadSuppressedPayload } from '../../src/services/prospectHelpers.js';
+import {
+  ensureLyfeWebhookSubscriber, ensureMktrLeadsWebhookSubscriber,
+} from '../../src/database/bootstrap.js';
+
+const RUN = Date.now();
+const p8 = (offset) => `8${String(RUN + offset).slice(-7)}`;
+
+let app;
+let admin;
+let campaign;
+let campaign2;
+
+/** Capture through the real public route so the spine resolver links a consumer. */
+async function capture(phone8, campaignArg = campaign) {
+  const res = await request(app).post('/api/prospects').send({
+    firstName: 'Prop',
+    lastName: 'Agate',
+    email: `prop-${phone8}@test.com`,
+    phone: phone8,
+    campaignId: campaignArg.id,
+    leadSource: 'website',
+    consent_contact: true,
+    consent_terms: true,
+  });
+  expect(res.status).toBe(201);
+  return Prospect.findByPk(res.body.data.prospect.id);
+}
+
+let subSeq = 0;
+async function mkSubscriber(events, { destination = 'lyfe' } = {}) {
+  subSeq += 1;
+  return WebhookSubscriber.create({
+    name: `Propagate Test ${RUN}-${subSeq}`,
+    url: `https://propagate-test-${subSeq}.invalid/hook`,
+    secret: 'test-secret',
+    events,
+    enabled: true,
+    metadata: { destination },
+  });
+}
+
+async function seedHistory(subscriber, prospectId, eventType = 'lead.created') {
+  const deliveryId = crypto.randomUUID();
+  return WebhookDelivery.create({
+    subscriberId: subscriber.id,
+    deliveryId,
+    eventType,
+    payload: { event: eventType, deliveryId, data: { lead: { externalId: prospectId } } },
+    status: 'success',
+  });
+}
+
+/** Service under test with the network flush captured, not fired. */
+function svcWithSpy() {
+  const flushed = [];
+  const svc = makeSuppressionPropagationService({ flushDeliveries: (pairs) => flushed.push(...pairs) });
+  return { svc, flushed };
+}
+
+const pairsOf = (subscriberId) => SuppressionPropagation.findAll({
+  where: { subscriberId }, order: [['createdAt', 'ASC']],
+});
+
+beforeAll(async () => {
+  app = await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  campaign = await createTestCampaign(admin.user.id, { name: `propagate-c1-${RUN}` });
+  campaign2 = await createTestCampaign(admin.user.id, { name: `propagate-c2-${RUN}` });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+describe('reconcile — projection from state', () => {
+  test('projects pairs for suppressed consumer: linked + phone-matched leads, subscribed subscribers only; payload is spec-shaped and PII-free', async () => {
+    const phone = p8(1);
+    const prospect = await capture(phone);
+    expect(prospect.consumerId).toBeTruthy();
+    const consumer = await Consumer.findByPk(prospect.consumerId);
+
+    // An UNLINKED row with the same digits (spine miss) — the phone arm must catch it.
+    const orphan = await Prospect.create({
+      firstName: 'Orphan', phone: `+65${phone}`, campaignId: campaign2.id,
+      leadSource: 'website', consumerId: null,
+    });
+
+    // Suppression written DIRECTLY (not via applyUnsubscribe): the real
+    // writer's post-commit trigger is fire-and-forget and would race the
+    // explicit pass below for insert counts. Trigger wiring is covered by the
+    // spy + end-to-end tests.
+    await ConsumerSuppression.create({ consumerId: consumer.id, channel: 'all', reason: 'unsubscribe', source: 'test' });
+    const suppression = await ConsumerSuppression.findOne({ where: { consumerId: consumer.id } });
+
+    const s1 = await mkSubscriber(['lead.created', 'lead.suppressed']);
+    const s2 = await mkSubscriber(['lead.created']); // not subscribed to the event
+    await seedHistory(s1, prospect.id);
+    await seedHistory(s1, orphan.id, 'lead.assigned');
+    await seedHistory(s2, prospect.id);
+
+    const { svc, flushed } = svcWithSpy();
+    const counts = await svc.reconcileSuppressionPropagation({ consumerId: consumer.id });
+    expect(counts.pairsInserted).toBe(2);
+    expect(counts.queued).toBe(2);
+
+    const pairs = await pairsOf(s1.id);
+    expect(pairs.map((p) => p.prospectId).sort()).toEqual([prospect.id, orphan.id].sort());
+    for (const pair of pairs) {
+      expect(pair.scope).toBe('marketing');
+      expect(pair.reason).toBe('unsubscribe');
+      expect(pair.queuedAt).toBeTruthy();
+      expect(new Date(pair.occurredAt).getTime()).toBe(new Date(suppression.createdAt).getTime());
+    }
+    expect(await pairsOf(s2.id)).toHaveLength(0);
+
+    const delivery = await WebhookDelivery.findOne({
+      where: { subscriberId: s1.id, eventType: 'lead.suppressed', deliveryId: pairs[0].deliveryId },
+    });
+    expect(delivery).toBeTruthy();
+    const raw = JSON.stringify(delivery.payload);
+    expect(delivery.payload.data.suppression).toMatchObject({
+      schemaVersion: 1, scope: 'marketing', reason: 'unsubscribe', channel: 'all',
+    });
+    expect(delivery.payload.data.lead.externalId).toBe(pairs[0].prospectId);
+    expect(raw).not.toContain(consumer.id);        // no consumerId — payload contract
+    expect(raw).not.toContain(phone);              // no phone
+    expect(raw).not.toContain('Prop');             // no name
+    expect(flushed.filter((f) => f.subscriber.id === s1.id)).toHaveLength(2);
+  });
+
+  test('deterministic and concurrency-safe: repeat + parallel passes add nothing', async () => {
+    const phone = p8(2);
+    const prospect = await capture(phone);
+    const consumer = await Consumer.findByPk(prospect.consumerId);
+    await ConsumerSuppression.create({ consumerId: consumer.id, channel: 'all', reason: 'unsubscribe', source: 'test' });
+    const s1 = await mkSubscriber(['lead.suppressed']);
+    await seedHistory(s1, prospect.id);
+
+    // TRUE contention (Codex diff-round #11): project pairs UNQUEUED first
+    // (webhooks disabled), then race two live passes for both the INSERT
+    // conflict and the CAS queue claim.
+    const { svc } = svcWithSpy();
+    process.env.WEBHOOK_ENABLED = 'false';
+    try {
+      await svc.reconcileSuppressionPropagation({ consumerId: consumer.id });
+    } finally {
+      process.env.WEBHOOK_ENABLED = 'true';
+    }
+    expect((await pairsOf(s1.id))[0].queuedAt).toBeNull();
+
+    const { svc: svcB } = svcWithSpy();
+    const [a, b] = await Promise.all([
+      svc.reconcileSuppressionPropagation({ consumerId: consumer.id }),
+      svcB.reconcileSuppressionPropagation({ consumerId: consumer.id }),
+    ]);
+    expect((await pairsOf(s1.id)).length).toBe(1);
+    expect(a.pairsInserted + b.pairsInserted).toBe(0); // both hit ON CONFLICT
+    expect(a.queued + b.queued).toBe(1); // exactly one CAS claim won
+    expect(
+      await WebhookDelivery.count({ where: { subscriberId: s1.id, eventType: 'lead.suppressed' } })
+    ).toBe(1);
+
+    // Third pass: fully settled, nothing to do.
+    const c = await svc.reconcileSuppressionPropagation({ consumerId: consumer.id });
+    expect(c.pairsInserted + c.queued + c.requeued).toBe(0);
+  });
+
+  test('call_bot arms: DDI-phone rows never match; inbound callers match via fromNumber', async () => {
+    const phone = p8(21);
+    const prospect = await capture(phone);
+    const consumer = await Consumer.findByPk(prospect.consumerId);
+    await ConsumerSuppression.create({ consumerId: consumer.id, channel: 'all', reason: 'unsubscribe', source: 'test' });
+
+    // A STRANGER's call_bot lead whose stored phone (the DDI) happens to
+    // equal this consumer's number — must NOT be suppressed.
+    const strangerCall = await Prospect.create({
+      firstName: 'Stranger', phone: `+65${phone}`, campaignId: campaign2.id,
+      leadSource: 'call_bot', consumerId: null,
+      sourceMetadata: { fromNumber: '+6560000001' },
+    });
+    // THIS person calling in: DDI stored as phone, THEIR number in fromNumber.
+    const inboundCall = await Prospect.create({
+      firstName: 'Caller', phone: '+6562773210', campaignId: campaign2.id,
+      leadSource: 'call_bot', consumerId: null,
+      sourceMetadata: { fromNumber: `+65${phone}` },
+    });
+    const s1 = await mkSubscriber(['lead.suppressed']);
+    await seedHistory(s1, prospect.id);
+    await seedHistory(s1, strangerCall.id);
+    await seedHistory(s1, inboundCall.id);
+
+    const { svc } = svcWithSpy();
+    await svc.reconcileSuppressionPropagation({ consumerId: consumer.id });
+    const pairedProspects = (await pairsOf(s1.id)).map((p) => p.prospectId).sort();
+    expect(pairedProspects).toEqual([prospect.id, inboundCall.id].sort());
+    expect(pairedProspects).not.toContain(strangerCall.id);
+  });
+
+  test('dark → flip backfill: nothing while unsubscribed, whole backlog on the first pass after', async () => {
+    const phone = p8(3);
+    const prospect = await capture(phone);
+    const consumer = await Consumer.findByPk(prospect.consumerId);
+    const s1 = await mkSubscriber(['lead.created']); // dark: event not carried
+    await seedHistory(s1, prospect.id);
+    await ConsumerSuppression.create({ consumerId: consumer.id, channel: 'all', reason: 'unsubscribe', source: 'test' });
+
+    const { svc } = svcWithSpy();
+    await svc.reconcileSuppressionPropagation({ consumerId: consumer.id });
+    expect(await pairsOf(s1.id)).toHaveLength(0);
+
+    await s1.update({ events: ['lead.created', 'lead.suppressed'] }); // the "flag flip"
+    await svc.reconcileSuppressionPropagation({ consumerId: consumer.id });
+    const pairs = await pairsOf(s1.id);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].queuedAt).toBeTruthy();
+  });
+
+  test('future lead: a new signup by an already-suppressed person projects on the next pass', async () => {
+    const phone = p8(4);
+    const prospect = await capture(phone);
+    const consumer = await Consumer.findByPk(prospect.consumerId);
+    await ConsumerSuppression.create({ consumerId: consumer.id, channel: 'all', reason: 'unsubscribe', source: 'test' });
+    const s1 = await mkSubscriber(['lead.suppressed']);
+    await seedHistory(s1, prospect.id);
+
+    const { svc } = svcWithSpy();
+    await svc.reconcileSuppressionPropagation({ consumerId: consumer.id });
+    expect(await pairsOf(s1.id)).toHaveLength(1);
+
+    const later = await capture(phone, campaign2); // same person, new campaign
+    expect(later.consumerId).toBe(consumer.id);
+    await seedHistory(s1, later.id); // its lead.created delivery
+    await svc.reconcileSuppressionPropagation({ consumerId: consumer.id });
+    const pairs = await pairsOf(s1.id);
+    expect(pairs.map((p) => p.prospectId).sort()).toEqual([prospect.id, later.id].sort());
+  });
+});
+
+describe('erasure escalation + interplay', () => {
+  test('escalation matrix: marketing pair joined by all-pair; lead.deleted handlers get the outbox, not a pair; pending lead.suppressed survives erasure', async () => {
+    const phone = p8(5);
+    const prospect = await capture(phone);
+    const consumer = await Consumer.findByPk(prospect.consumerId);
+    await ConsumerSuppression.create({ consumerId: consumer.id, channel: 'all', reason: 'unsubscribe', source: 'test' });
+    const sSuppOnly = await mkSubscriber(['lead.suppressed']);
+    const sBoth = await mkSubscriber(['lead.suppressed', 'lead.deleted']);
+    await seedHistory(sSuppOnly, prospect.id);
+    await seedHistory(sBoth, prospect.id);
+
+    const { svc, flushed } = svcWithSpy();
+    await svc.reconcileSuppressionPropagation({ consumerId: consumer.id });
+    expect((await pairsOf(sSuppOnly.id)).map((p) => p.scope)).toEqual(['marketing']);
+    expect((await pairsOf(sBoth.id)).map((p) => p.scope)).toEqual(['marketing']);
+    const pendingBefore = await WebhookDelivery.findOne({
+      where: { subscriberId: sSuppOnly.id, eventType: 'lead.suppressed' },
+    });
+    await pendingBefore.update({ status: 'pending' }); // simulate not-yet-attempted
+
+    // Erase — build with flush spy + the same reconciler wiring as prod.
+    const erasure = makeErasureService({
+      flushDeliveries: (pairs) => flushed.push(...pairs),
+      reconcileSuppressionPropagation: svc.reconcileSuppressionPropagation,
+    });
+    const report = await erasure.eraseConsumer(consumer.id, { actorUser: admin.user });
+    expect(report.alreadyErased).toBe(false);
+    // The erasure's own trigger is fire-and-forget; run a deterministic pass.
+    await svc.reconcileSuppressionPropagation({ consumerId: consumer.id });
+
+    const suppOnlyScopes = (await pairsOf(sSuppOnly.id)).map((p) => p.scope).sort();
+    expect(suppOnlyScopes).toEqual(['all', 'marketing']);
+    const allPair = (await pairsOf(sSuppOnly.id)).find((p) => p.scope === 'all');
+    expect(allPair.reason).toBe('erasure');
+    expect(new Date(allPair.occurredAt).getTime()).toBe(
+      new Date((await Consumer.findByPk(consumer.id)).erasedAt).getTime()
+    );
+
+    // lead.deleted-handling subscriber: NO all-pair, but the erasure outbox row exists.
+    expect((await pairsOf(sBoth.id)).map((p) => p.scope)).toEqual(['marketing']);
+    expect(await WebhookDelivery.count({
+      where: { subscriberId: sBoth.id, eventType: 'lead.deleted' },
+    })).toBe(1);
+
+    // The pending lead.suppressed delivery was neither cancelled nor scrubbed.
+    await pendingBefore.reload();
+    expect(pendingBefore.status).toBe('pending');
+    expect(pendingBefore.payload.data.suppression.scope).toBe('marketing');
+  });
+});
+
+describe('queue durability', () => {
+  test('terminally-failed delivery re-queues once per pass while subscribed; not after unsubscribing', async () => {
+    const phone = p8(6);
+    const prospect = await capture(phone);
+    const consumer = await Consumer.findByPk(prospect.consumerId);
+    await ConsumerSuppression.create({ consumerId: consumer.id, channel: 'all', reason: 'unsubscribe', source: 'test' });
+    const s1 = await mkSubscriber(['lead.suppressed']);
+    await seedHistory(s1, prospect.id);
+
+    const { svc } = svcWithSpy();
+    await svc.reconcileSuppressionPropagation({ consumerId: consumer.id });
+    const pair = (await pairsOf(s1.id))[0];
+    const firstDeliveryId = pair.deliveryId;
+    await WebhookDelivery.update(
+      { status: 'failed' }, { where: { deliveryId: firstDeliveryId } }
+    );
+
+    const counts = await svc.reconcileSuppressionPropagation({ consumerId: consumer.id });
+    expect(counts.requeued).toBe(1);
+    await pair.reload();
+    expect(pair.deliveryId).not.toBe(firstDeliveryId);
+    expect(await WebhookDelivery.count({
+      where: { subscriberId: s1.id, eventType: 'lead.suppressed' },
+    })).toBe(2);
+
+    // New delivery pending → nothing further this pass.
+    const again = await svc.reconcileSuppressionPropagation({ consumerId: consumer.id });
+    expect(again.requeued + again.queued).toBe(0);
+
+    // Kill switch: no longer subscribed → a failed row stays dead.
+    await WebhookDelivery.update({ status: 'failed' }, { where: { deliveryId: pair.deliveryId } });
+    await s1.update({ events: ['lead.created'] });
+    const dark = await svc.reconcileSuppressionPropagation({ consumerId: consumer.id });
+    expect(dark.requeued).toBe(0);
+
+    // Purged dead-letter (Codex diff-round #5): delete the failed row outright
+    // — the dangling pair must still requeue once re-subscribed (re-flip).
+    await WebhookDelivery.destroy({ where: { deliveryId: pair.deliveryId } });
+    await s1.update({ events: ['lead.suppressed'] });
+    const revived = await svc.reconcileSuppressionPropagation({ consumerId: consumer.id });
+    expect(revived.requeued).toBe(1);
+    await pair.reload();
+    expect(await WebhookDelivery.count({ where: { deliveryId: pair.deliveryId } })).toBe(1);
+  });
+
+  test('dark erasure: deleted-capable subscriber still gets the scope-all fallback when no lead.deleted row exists (outcome-based rule)', async () => {
+    const phone = p8(22);
+    const prospect = await capture(phone);
+    const consumer = await Consumer.findByPk(prospect.consumerId);
+    const sBoth = await mkSubscriber(['lead.suppressed', 'lead.deleted']);
+    await seedHistory(sBoth, prospect.id);
+
+    // Erase while webhooks are DISABLED — PR C queues no lead.deleted outbox.
+    const erasure = makeErasureService({
+      flushDeliveries: () => {},
+      reconcileSuppressionPropagation: async () => ({}),
+    });
+    process.env.WEBHOOK_ENABLED = 'false';
+    try {
+      await erasure.eraseConsumer(consumer.id, { actorUser: admin.user });
+    } finally {
+      process.env.WEBHOOK_ENABLED = 'true';
+    }
+    expect(await WebhookDelivery.count({
+      where: { subscriberId: sBoth.id, eventType: 'lead.deleted' },
+    })).toBe(0);
+
+    // The reconciler must NOT skip on capability alone — no deleted row exists,
+    // so the stop-contact ships as the suppression fallback.
+    const { svc } = svcWithSpy();
+    await svc.reconcileSuppressionPropagation({ consumerId: consumer.id });
+    const pairs = await pairsOf(sBoth.id);
+    expect(pairs.map((p) => p.scope)).toEqual(['all']);
+    expect(pairs[0].reason).toBe('erasure');
+  });
+
+  test('flush-time catchup: payload-event flushes nudge the reconciler for spine-linked leads (assignment/release choke point)', async () => {
+    const phone = p8(23);
+    const prospect = await capture(phone);
+    const consumer = await Consumer.findByPk(prospect.consumerId);
+    await ConsumerSuppression.create({ consumerId: consumer.id, channel: 'all', reason: 'unsubscribe', source: 'test' });
+    const s1 = await mkSubscriber(['lead.created', 'lead.suppressed']);
+
+    // Wiring proof: makeWebhookService with a spy catchup — flushDeliveries
+    // forwards the pairs.
+    const catchupSpy = jest.fn();
+    const { makeWebhookService } = await import('../../src/services/webhookService.js');
+    const wh = makeWebhookService({ propagationCatchup: catchupSpy });
+    const fakePair = {
+      delivery: { eventType: 'lead.assigned', payload: { data: { lead: { externalId: prospect.id } } } },
+      subscriber: s1,
+    };
+    // enqueueDelivery will attempt this fake pair; give it harmless model-less
+    // stubs so background failure handling has something to call.
+    fakePair.delivery.update = async () => fakePair.delivery;
+    wh.flushDeliveries([fakePair]);
+    expect(catchupSpy).toHaveBeenCalledWith([fakePair]);
+
+    // End-to-end proof through the DEFAULT chain: a real lead.assigned
+    // delivery row flushed → catchup reconciles → the pair appears.
+    const history = await seedHistory(s1, prospect.id, 'lead.assigned');
+    await history.update({ status: 'pending' });
+    const { flushDeliveries: realFlush } = await import('../../src/services/webhookService.js');
+    realFlush([{ delivery: history, subscriber: s1 }]);
+    const deadline = Date.now() + 4000;
+    let pairs = [];
+    while (Date.now() < deadline) {
+      pairs = await pairsOf(s1.id);
+      if (pairs.length) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].prospectId).toBe(prospect.id);
+  });
+
+  test('WEBHOOK_ENABLED=false: pairs projected (durability), queueing deferred until re-enabled', async () => {
+    const phone = p8(7);
+    const prospect = await capture(phone);
+    const consumer = await Consumer.findByPk(prospect.consumerId);
+    await ConsumerSuppression.create({ consumerId: consumer.id, channel: 'all', reason: 'unsubscribe', source: 'test' });
+    const s1 = await mkSubscriber(['lead.suppressed']);
+    await seedHistory(s1, prospect.id);
+
+    const { svc } = svcWithSpy();
+    process.env.WEBHOOK_ENABLED = 'false';
+    try {
+      const counts = await svc.reconcileSuppressionPropagation({ consumerId: consumer.id });
+      expect(counts.pairsInserted).toBe(1);
+      expect(counts.queued).toBe(0);
+      expect((await pairsOf(s1.id))[0].queuedAt).toBeNull();
+    } finally {
+      process.env.WEBHOOK_ENABLED = 'true';
+    }
+    const counts2 = await svc.reconcileSuppressionPropagation({ consumerId: consumer.id });
+    expect(counts2.queued).toBe(1);
+    expect((await pairsOf(s1.id))[0].queuedAt).toBeTruthy();
+  });
+});
+
+describe('writer triggers + end-to-end', () => {
+  test('applyUnsubscribe fires the reconciler on both first and repeat calls', async () => {
+    const phone = p8(8);
+    const prospect = await capture(phone);
+    const consumer = await Consumer.findByPk(prospect.consumerId);
+    const spy = jest.fn().mockResolvedValue({});
+    const consent = makeConsentService({ reconcileSuppressionPropagation: spy });
+
+    const r1 = await consent.applyUnsubscribe(consumer, { source: 'test' });
+    expect(r1.alreadySuppressed).toBe(false);
+    const r2 = await consent.applyUnsubscribe(consumer, { source: 'test' });
+    expect(r2.alreadySuppressed).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledWith({ consumerId: consumer.id });
+  });
+
+  test('POST /api/unsubscribe projects pairs through the real default chain', async () => {
+    const phone = p8(9);
+    const prospect = await capture(phone);
+    const consumer = await Consumer.findByPk(prospect.consumerId);
+    const s1 = await mkSubscriber(['lead.suppressed']);
+    await seedHistory(s1, prospect.id);
+    const token = await ensureUnsubToken(consumer.id);
+
+    const res = await request(app).post(`/api/unsubscribe?t=${token}`).send({});
+    expect(res.status).toBe(200);
+
+    // The trigger is post-commit fire-and-forget — poll briefly.
+    const deadline = Date.now() + 4000;
+    let pairs = [];
+    while (Date.now() < deadline) {
+      pairs = await pairsOf(s1.id);
+      if (pairs.length) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].prospectId).toBe(prospect.id);
+    expect(await WebhookDelivery.count({
+      where: { subscriberId: s1.id, eventType: 'lead.suppressed' },
+    })).toBe(1);
+  });
+});
+
+describe('bootstrap env-gated subscription', () => {
+  const ORIG = { ...process.env };
+  afterEach(() => {
+    for (const k of ['LYFE_WEBHOOK_URL', 'LYFE_WEBHOOK_SECRET', 'LYFE_LEAD_SUPPRESSED_ENABLED',
+      'MKTR_LEADS_WEBHOOK_URL', 'MKTR_LEADS_WEBHOOK_SECRET', 'MKTR_LEADS_LEAD_SUPPRESSED_ENABLED']) {
+      if (ORIG[k] === undefined) delete process.env[k]; else process.env[k] = ORIG[k];
+    }
+  });
+
+  test('flag on → events gain lead.suppressed (update AND create paths); flag off → removed', async () => {
+    process.env.LYFE_WEBHOOK_URL = 'https://lyfe-test.invalid/hook';
+    process.env.LYFE_WEBHOOK_SECRET = 'shh';
+
+    // CREATE path with the flag on (Codex #15 — the literal-array hole).
+    await WebhookSubscriber.destroy({ where: { name: 'Lyfe App' } });
+    process.env.LYFE_LEAD_SUPPRESSED_ENABLED = 'true';
+    await ensureLyfeWebhookSubscriber();
+    let sub = await WebhookSubscriber.findOne({ where: { name: 'Lyfe App' } });
+    expect(sub.events).toContain('lead.suppressed');
+
+    // Self-heal removal on flag off (UPDATE path).
+    process.env.LYFE_LEAD_SUPPRESSED_ENABLED = 'false';
+    await ensureLyfeWebhookSubscriber();
+    sub = await WebhookSubscriber.findOne({ where: { name: 'Lyfe App' } });
+    expect(sub.events).not.toContain('lead.suppressed');
+
+    // UPDATE path addition on flag on.
+    process.env.LYFE_LEAD_SUPPRESSED_ENABLED = 'true';
+    await ensureLyfeWebhookSubscriber();
+    sub = await WebhookSubscriber.findOne({ where: { name: 'Lyfe App' } });
+    expect(sub.events).toContain('lead.suppressed');
+    await WebhookSubscriber.destroy({ where: { name: 'Lyfe App' } });
+  });
+
+  test('mktr-leads flag mirrors the same behavior', async () => {
+    process.env.MKTR_LEADS_WEBHOOK_URL = 'https://ml-test.invalid/hook';
+    process.env.MKTR_LEADS_WEBHOOK_SECRET = 'shh';
+    await WebhookSubscriber.destroy({ where: { name: 'MKTR Leads App' } });
+    process.env.MKTR_LEADS_LEAD_SUPPRESSED_ENABLED = 'true';
+    await ensureMktrLeadsWebhookSubscriber();
+    let sub = await WebhookSubscriber.findOne({ where: { name: 'MKTR Leads App' } });
+    expect(sub.events).toEqual(expect.arrayContaining(['lead.deleted', 'lead.suppressed']));
+    process.env.MKTR_LEADS_LEAD_SUPPRESSED_ENABLED = 'false';
+    await ensureMktrLeadsWebhookSubscriber();
+    sub = await WebhookSubscriber.findOne({ where: { name: 'MKTR Leads App' } });
+    expect(sub.events).not.toContain('lead.suppressed');
+    await WebhookSubscriber.destroy({ where: { name: 'MKTR Leads App' } });
+  });
+});
+
+describe('payload builder contract', () => {
+  test('buildLeadSuppressedPayload: exact v1 shape, Date and string occurredAt both normalize', () => {
+    const at = new Date('2026-07-21T06:00:00.000Z');
+    const p = buildLeadSuppressedPayload('abc-123', { scope: 'all', reason: 'erasure', occurredAt: at });
+    expect(p.event).toBe('lead.suppressed');
+    expect(p.data.lead).toEqual({ externalId: 'abc-123' });
+    expect(p.data.suppression).toEqual({
+      schemaVersion: 1, scope: 'all', reason: 'erasure', channel: 'all',
+      occurredAt: '2026-07-21T06:00:00.000Z',
+    });
+    expect(Object.keys(p.data)).toEqual(['lead', 'suppression']); // nothing else rides along
+  });
+});

--- a/backend/test/unit/consumerSpineUnit.test.js
+++ b/backend/test/unit/consumerSpineUnit.test.js
@@ -2,7 +2,10 @@ import { jest } from '@jest/globals';
 import '../setup.js';
 import { createHash } from 'crypto';
 import { phoneVerificationIsCurrent, phoneHashOf, E164_RE } from '../../src/services/consumerService.js';
-import { buildLeadCreatedPayload, buildLeadDeletedPayload, buildLeadAssignedPayload } from '../../src/services/prospectHelpers.js';
+import {
+  buildLeadCreatedPayload, buildLeadDeletedPayload, buildLeadAssignedPayload,
+  buildLeadUnassignedPayload, buildLeadHeldPayload, buildLeadSuppressedPayload,
+} from '../../src/services/prospectHelpers.js';
 import { makeEntitlementService } from '../../src/services/redeemOps/entitlementService.js';
 
 const sha = (v) => createHash('sha256').update(v).digest('hex');
@@ -55,6 +58,24 @@ describe('webhook payload contract — consumerId NEVER leaves the system (plan 
   test('lead.assigned carries no consumerId', () => {
     const payload = buildLeadAssignedPayload(prospect, { id: 'a1', phone: '+65', email: 'x@y.z', firstName: 'Ag', lastName: 'Ent' }, { campaign: null }, {});
     expect(JSON.stringify(payload)).not.toContain('consumerId');
+  });
+  // Codex propagate-round #3: the guard was created/assigned/deleted only.
+  test('lead.unassigned carries no consumerId', () => {
+    const payload = buildLeadUnassignedPayload(prospect, 'prev-agent-lyfe-id', {});
+    expect(JSON.stringify(payload)).not.toContain('consumerId');
+  });
+  test('lead.held carries no consumerId', () => {
+    const payload = buildLeadHeldPayload(prospect, { id: 'c1', name: 'C' }, 'no_funded_agent');
+    expect(JSON.stringify(payload)).not.toContain('consumerId');
+  });
+  test('lead.suppressed carries no consumerId AND no direct identifiers', () => {
+    const payload = buildLeadSuppressedPayload(prospect.id, {
+      scope: 'all', reason: 'erasure', occurredAt: new Date('2026-01-01'),
+    });
+    const raw = JSON.stringify(payload);
+    expect(raw).not.toContain('consumerId');
+    expect(raw).not.toContain(prospect.phone);
+    expect(raw).not.toContain(prospect.email);
   });
 });
 

--- a/docs/plans/propagate-consumer-lyfe.md
+++ b/docs/plans/propagate-consumer-lyfe.md
@@ -1,0 +1,107 @@
+# lead.suppressed consumer plan — lyfe-app (for Shawn to apply in lyfe-app)
+
+**Contract:** `docs/reference/webhook-propagation-contract.md` (mktr-platform repo). Emitter is LIVE-dark; `LYFE_LEAD_SUPPRESSED_ENABLED` stays false until step 5.
+**Anchors below were mapped from lyfe-app on 2026-07-21 — RE-VERIFY in-repo before applying** (receiver: `supabase/functions/receive-mktr-lead/index.ts`; migrations: `supabase/migrations/`).
+
+## 1. Migration (canonical location: `lyfe-app/supabase/migrations/`)
+
+```sql
+-- leads: suppression columns (timestamp-as-flag matches archived_at house style)
+ALTER TABLE leads
+  ADD COLUMN IF NOT EXISTS do_not_contact_at timestamptz,
+  ADD COLUMN IF NOT EXISTS do_not_contact_scope text
+    CHECK (do_not_contact_scope IN ('marketing','all') OR do_not_contact_scope IS NULL);
+
+-- Tombstone: suppression that arrived before (or without) its lead —
+-- consulted by lead.created/assigned handlers, applied on arrival.
+CREATE TABLE IF NOT EXISTS mktr_lead_suppressions (
+  source_name text NOT NULL,
+  external_id text NOT NULL,
+  scope text NOT NULL CHECK (scope IN ('marketing','all')),
+  reason text NOT NULL,
+  occurred_at timestamptz NOT NULL,
+  delivery_id uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (source_name, external_id)
+);
+-- Service-role only: ENFORCED, not commented (Codex diff-round #10) — RLS on
+-- with no policies denies app roles; service_role bypasses RLS.
+ALTER TABLE mktr_lead_suppressions ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON mktr_lead_suppressions FROM anon, authenticated;
+
+-- Activity enum (precedent: 20260427180000 added 'unassignment')
+ALTER TYPE lead_activity_type ADD VALUE IF NOT EXISTS 'suppressed';
+
+-- One RPC = the atomic monotonic merge (lyfe has NO delivery-dedup table, so
+-- atomicity must live here; Codex #19). search_path pinned (SECURITY DEFINER
+-- hygiene, Codex diff-round #10).
+CREATE OR REPLACE FUNCTION apply_mktr_lead_suppression(
+  p_source_name text, p_external_id text, p_scope text, p_reason text,
+  p_occurred_at timestamptz, p_delivery_id uuid
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE v_lead leads%ROWTYPE; v_found boolean := false; v_changed boolean := false;
+BEGIN
+  -- Monotonic tombstone upsert: 'all' dominates; newer occurred_at wins within a scope.
+  INSERT INTO mktr_lead_suppressions AS t
+    (source_name, external_id, scope, reason, occurred_at, delivery_id)
+  VALUES (p_source_name, p_external_id, p_scope, p_reason, p_occurred_at, p_delivery_id)
+  ON CONFLICT (source_name, external_id) DO UPDATE SET
+    scope = CASE WHEN t.scope = 'all' THEN 'all' ELSE excluded.scope END,
+    reason = CASE WHEN t.scope = 'all' AND excluded.scope <> 'all' THEN t.reason ELSE excluded.reason END,
+    occurred_at = GREATEST(t.occurred_at, excluded.occurred_at),
+    delivery_id = excluded.delivery_id,
+    updated_at = now();
+
+  SELECT * INTO v_lead FROM leads
+   WHERE external_id = p_external_id AND source_name = p_source_name;
+  v_found := FOUND;  -- captured: later statements overwrite FOUND (Codex diff-round #9)
+  IF v_found THEN
+    -- Effect-idempotent: fires only when the merged state actually CHANGES
+    -- (first application, or a marketing→all escalation) — repairs with new
+    -- delivery ids must not duplicate activities.
+    UPDATE leads SET
+      do_not_contact_at = COALESCE(do_not_contact_at, p_occurred_at),
+      do_not_contact_scope = CASE
+        WHEN do_not_contact_scope = 'all' THEN 'all' ELSE p_scope END,
+      updated_at = now()
+     WHERE id = v_lead.id
+       AND (do_not_contact_at IS NULL
+            OR (do_not_contact_scope IS DISTINCT FROM 'all' AND p_scope = 'all'));
+    v_changed := FOUND;
+    IF v_changed THEN
+      INSERT INTO lead_activities (lead_id, user_id, type, description, metadata)
+      VALUES (v_lead.id, v_lead.created_by, 'suppressed',
+              'Do-not-contact from MKTR (' || p_scope || ')',
+              jsonb_build_object('delivery_id', p_delivery_id, 'reason', p_reason, 'scope', p_scope));
+    END IF;
+  END IF;
+  RETURN jsonb_build_object('lead_found', v_found, 'changed', v_changed);
+END $$;
+REVOKE ALL ON FUNCTION apply_mktr_lead_suppression FROM anon, authenticated;
+```
+
+Then `npm run gen:types` + `sync:types` per house rules.
+
+## 2. Edge function (`receive-mktr-lead/index.ts`)
+
+1. `SUPPORTED_EVENTS` gains `'lead.suppressed'` (today it 400s — index.ts:128-131).
+2. Handler (model on the `lead.unassigned` branch, :161-202): validate `data.suppression` strictly per contract §3.2 (400 on malformed); call `apply_mktr_lead_suppression(...)` once; ALWAYS 200 on success paths — including lead-not-found (`lead_found:false`), which is the tombstone case, NOT an error.
+3. **Lead-arrival hook**: in the `lead.created` / `lead.assigned` insert paths, after upsert, `SELECT ... FROM mktr_lead_suppressions WHERE source_name='mktr' AND external_id=...` — if present, stamp `do_not_contact_at/scope` on the new row (one UPDATE; or fold into the insert). This closes the suppression-before-created race.
+
+## 3. App surface
+
+- Lead list + `[leadId]` detail: render a DNC badge when `do_not_contact_at` set — `all` = red "Erased — do not contact"; `marketing` = amber "No marketing". Gate the call/WhatsApp affordances on the detail screen for scope `all` (hard block with explanation), warn-on-tap for `marketing`.
+- Optional phase 2: `notifications` insert to `assigned_to` on suppression of an assigned lead (needs `chk_notification_type` extended with `'lead_suppressed'` — `20260401000000` precedent).
+
+## 4. Synthetic verification (BEFORE the mktr flip — contract §5.2)
+
+lyfe verifies v1 (body-only HMAC + timestamp header, ±5 min): craft the payload from contract §2, sign `sha256=HMAC(secret, rawBody)` with `MKTR_WEBHOOK_SECRET`, POST to the EF. Assert: 200 + tombstone row; re-POST same body → 200, no duplicate activity; then a synthetic `lead.created` for that external_id → lead lands already-flagged.
+
+## 5. Go-live
+
+Flip `LYFE_LEAD_SUPPRESSED_ENABLED=true` on the mktr backend Render service (env change triggers redeploy; the boot pass adds the event to the 'Lyfe App' subscriber and backfills all dark-period pairs). Verify per contract §5.4.
+
+## 6. Later (separate item)
+
+Adopting `lead.deleted` (PR C's documented Lyfe gap) should reuse this exact shape — tombstone precedent, RPC, allowlist entry. Until then, erasures reach lyfe as `lead.suppressed scope:'all'` via the emitter's fallback rule; switching the subscriber to `lead.deleted` handling later automatically stops the fallback pairs for NEW erasures (already-projected pairs are harmless history).

--- a/docs/plans/propagate-consumer-mktr-leads.md
+++ b/docs/plans/propagate-consumer-mktr-leads.md
@@ -1,0 +1,96 @@
+# lead.suppressed consumer plan — mktr-leads (for Shawn to apply in mktr-leads)
+
+**Contract:** `docs/reference/webhook-propagation-contract.md` (mktr-platform repo). Emitter LIVE-dark; `MKTR_LEADS_LEAD_SUPPRESSED_ENABLED` stays false until step 5.
+**Anchors mapped 2026-07-21 — RE-VERIFY in-repo** (receiver: `supabase/functions/receive-mktr-lead/index.ts`; deletion precedent: `supabase/migrations/20260701000000_mktr_lead_deletion.sql`). Deploys via `supabase db push` + `functions deploy` (no write creds in .env — Shawn runs those).
+
+## 1. Migration (follow the deletion-RPC precedent exactly)
+
+```sql
+ALTER TABLE leads
+  ADD COLUMN IF NOT EXISTS do_not_contact_at timestamptz,
+  ADD COLUMN IF NOT EXISTS do_not_contact_scope text
+    CHECK (do_not_contact_scope IN ('marketing','all') OR do_not_contact_scope IS NULL);
+
+CREATE TABLE IF NOT EXISTS mktr_lead_suppressions (
+  source_name text NOT NULL,
+  external_id text NOT NULL,
+  scope text NOT NULL CHECK (scope IN ('marketing','all')),
+  reason text NOT NULL,
+  occurred_at timestamptz NOT NULL,
+  delivery_id uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (source_name, external_id)
+);
+-- Service-role only: ENFORCED like deleted_lead_sources (Codex diff-round #10).
+ALTER TABLE mktr_lead_suppressions ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON mktr_lead_suppressions FROM anon, authenticated;
+
+CREATE OR REPLACE FUNCTION process_mktr_lead_suppression(
+  p_source_name text, p_external_id text, p_scope text, p_reason text,
+  p_occurred_at timestamptz, p_delivery_id uuid
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE v_lead leads%ROWTYPE; v_found boolean := false; v_changed boolean := false;
+BEGIN
+  -- Claim the delivery id first (processed_deliveries PK) — TRANSPORT dedup
+  -- only. Repairs mint NEW delivery ids, so lead effects below must be
+  -- EFFECT-idempotent too (Codex diff-round #8): they fire only when the
+  -- merged state actually changes.
+  INSERT INTO processed_deliveries (delivery_id) VALUES (p_delivery_id)
+  ON CONFLICT (delivery_id) DO NOTHING;
+  IF NOT FOUND THEN RETURN jsonb_build_object('duplicate', true); END IF;
+
+  INSERT INTO mktr_lead_suppressions AS t
+    (source_name, external_id, scope, reason, occurred_at, delivery_id)
+  VALUES (p_source_name, p_external_id, p_scope, p_reason, p_occurred_at, p_delivery_id)
+  ON CONFLICT (source_name, external_id) DO UPDATE SET
+    scope = CASE WHEN t.scope = 'all' THEN 'all' ELSE excluded.scope END,
+    reason = CASE WHEN t.scope = 'all' AND excluded.scope <> 'all' THEN t.reason ELSE excluded.reason END,
+    occurred_at = GREATEST(t.occurred_at, excluded.occurred_at),
+    delivery_id = excluded.delivery_id,
+    updated_at = now();
+
+  SELECT * INTO v_lead FROM leads
+   WHERE source_name = p_source_name AND external_id = p_external_id;
+  v_found := FOUND;
+  IF v_found THEN
+    UPDATE leads SET
+      do_not_contact_at = COALESCE(do_not_contact_at, p_occurred_at),
+      do_not_contact_scope = CASE WHEN do_not_contact_scope = 'all' THEN 'all' ELSE p_scope END,
+      updated_at = now()
+     WHERE id = v_lead.id
+       AND (do_not_contact_at IS NULL
+            OR (do_not_contact_scope IS DISTINCT FROM 'all' AND p_scope = 'all'));
+    v_changed := FOUND;
+    IF v_changed THEN
+      INSERT INTO lead_activities (lead_id, user_id, type, description, metadata)
+      VALUES (v_lead.id, NULL, 'suppressed',
+              'Do-not-contact from MKTR (' || p_scope || ')',
+              jsonb_build_object('delivery_id', p_delivery_id, 'reason', p_reason, 'scope', p_scope));
+    END IF;
+  END IF;
+  RETURN jsonb_build_object('lead_found', v_found, 'changed', v_changed);
+END $$;
+REVOKE ALL ON FUNCTION process_mktr_lead_suppression FROM anon, authenticated;
+```
+
+(`lead_activities.type` is free text here — no enum migration needed, unlike lyfe.)
+
+## 2. Edge function
+
+1. `SUPPORTED_EVENTS` (index.ts:101) gains `'lead.suppressed'`.
+2. Handler: after the shared verify/guard chain (v1+v2 signatures, deliveryId header↔body binding, 256KB cap, fast-path dedup — all already generic), validate `data.suppression` per contract §3.2 and call `process_mktr_lead_suppression`. 200 always on success paths incl. `lead_found:false` (tombstone).
+3. **Lead-arrival hook**: the creation RPC (`20260717010000_mktr_lead_creation_rpc.sql`) additionally consults `mktr_lead_suppressions` — if a tombstone exists for `(source_name, external_id)`: stamp the new lead's `do_not_contact_*` AND **skip `enqueue_wa_intro`** (Codex #20 — a suppressed person's later lead must not fire create-time outreach). Scope `marketing` also skips wa_intro (it is marketing-adjacent outreach); scope `all` skips everything.
+   Note: the existing tombstone short-circuit for DELETED sources (index.ts:188-203) stays as-is — deletion outranks suppression.
+
+## 3. App surface
+
+- Board + detail (`app/(tabs)/leads/*`, data via `lib/leads.ts` — rows already carry all columns): DNC badge (scope `all` red / `marketing` amber). Gate contact affordances on detail for scope `all`; warn for `marketing`. Status flow untouched (`invalid`/`disputed` remain quality states, not consent states).
+
+## 4. Synthetic verification (BEFORE the mktr flip)
+
+mktr-leads verifies v1 AND v2; its subscriber is v1 today — test v1 exactly: sign body-only HMAC, include `X-Webhook-Delivery-Id` equal to body `deliveryId` (the guard binds them). Assert: 200 + tombstone; same-delivery re-POST → `{duplicate:true}`; NEW delivery id, same person → state unchanged except merge rules; synthetic `lead.created` after tombstone → lead lands flagged + wa_intro skipped.
+
+## 5. Go-live
+
+Flip `MKTR_LEADS_LEAD_SUPPRESSED_ENABLED=true` on the mktr backend Render service; boot adds the event to the 'MKTR Leads App' subscriber + backfills dark-period pairs. Verify per contract §5.4. (mktr-leads already handles `lead.deleted`, so erasures continue arriving as deletions — this event adds the unsubscribe/marketing layer.)

--- a/docs/plans/suppression-propagation-plan.md
+++ b/docs/plans/suppression-propagation-plan.md
@@ -1,0 +1,108 @@
+# Suppression/erasure propagation — plan v2 (post-Codex round 1, tracker "propagate")
+
+**Base:** origin/main @ 0b7c8dd. **Codex round 1:** 25 findings, verdict "rethink" — the v1 point-in-time fanout was lossy (dark-period loss #4, future leads #5, capture races #6, erasure self-sabotage #8, fake idempotency #10, savepoint loss #11). v2 adopts Codex's prescribed shape: **a durable suppression-propagation projection + deterministic reconciler** — the same state-derived, assignment-not-increment pattern as the consumer spine. All 25 findings dispositioned in §7.
+
+**Scope:** emitter side (mktr-platform) to DONE-AND-LIVE, dark; spec doc; two cross-repo consumer PLAN docs (Shawn applies). Event name `lead.suppressed` (Codex: accept).
+
+## 1. Architecture — projection, not fanout
+
+**Source of truth** (already exists): `consumer_suppressions` + `consumers.erasedAt`. Target scope per consumer = `'all'` when erased/reason-erasure else `'marketing'`.
+
+**NEW table `suppression_propagations`** (migration 083 + model, indexes mirrored, sync-tolerant guards, advisory-locked runner):
+
+| column | type | notes |
+|---|---|---|
+| `id` | UUID PK v4 | |
+| `consumerId` | UUID NOT NULL FK consumers RESTRICT | provenance; NEVER in payloads |
+| `prospectId` | UUID NOT NULL FK prospects CASCADE | the lead (externalId downstream) |
+| `subscriberId` | UUID NOT NULL FK webhook_subscribers CASCADE | |
+| `scope` | VARCHAR(16) NOT NULL CHECK in ('marketing','all') | monotonic: 'all' row may join a 'marketing' row, never replaces it |
+| `reason` | VARCHAR(32) NOT NULL | diagnostic copy (unsubscribe/complaint/admin/erasure) |
+| `occurredAt` | timestamptz NOT NULL | authoritative transition time: suppression.createdAt / consumer.erasedAt (Codex #12) |
+| `deliveryId` | UUID nullable | the WebhookDelivery this pair queued |
+| `queuedAt` | timestamptz nullable | null = needs queueing |
+| timestamps | | |
+
+**UNIQUE `uq_sp_sub_prospect_scope` (subscriberId, prospectId, scope)** — DB-level idempotency (kills #10; concurrent reconcilers: `ON CONFLICT DO NOTHING`). Index `idx_sp_needs_queue (queuedAt) WHERE queuedAt IS NULL`; `idx_sp_consumer (consumerId)`.
+
+**Reconciler `reconcileSuppressionPropagation({ consumerId = null })`** (new `backend/src/services/suppressionPropagationService.js`, DI factory) — deterministic, safe to run anytime, concurrently, repeatedly:
+1. Load suppressed-or-erased consumers (optionally one): `consumers c JOIN consumer_suppressions s ON s."consumerId"=c.id` UNION erased (`erasedAt IS NOT NULL`); compute scope + occurredAt per consumer (erasure dominates).
+2. Their leads: prospects by `consumerId` arm + (non-erased only) digits-phone arm + call_bot `fromNumber` arm (erasure already relinks its rows to the consumer, so erased consumers need only the id arm).
+3. Targeted subscribers per lead = **`historicallyTargetedSubscribers(prospectIds)`** (extracted from erasureService, renamed per Codex #2 — delivery HISTORY rows of `lead.created`/`lead.assigned`, any status: conservative over-notify, documented) ∩ `enabled:true` ∩ `events.includes('lead.suppressed')` (subscription checked at reconcile time — **this is what makes the dark→flip backfill automatic**: pairs for a newly-subscribed consumer app appear on the first pass after the flip, healing the entire dark period; kills #4).
+4. **Erasure-fallback rule** (Codex: accept with durability): for scope-'all'-via-erasure consumers, subscribers whose `events` include `lead.deleted` get NO pair — their signal is the erasure outbox (+ its dead-letter repair; contract states this reliance explicitly, #23).
+5. INSERT missing `(subscriberId, prospectId, scope)` pairs `ON CONFLICT DO NOTHING` (scope escalation marketing→all = a second pair; downgrade impossible — no unsuppression exists, #9 contract side).
+6. Queue phase: pairs `queuedAt IS NULL` (or whose delivery row is terminally `failed` — re-queue at most once per pass, only while the subscriber still carries the event) → create `WebhookDelivery` rows (payload §2) + set `queuedAt`/`deliveryId` in the SAME txn as the delivery row; flush post-commit. Requeue-vs-auto-disable pressure documented (#14): suppressions are rare and the flip-ordering runbook is the real guard.
+
+**Triggers** (all post-commit, fire-and-forget with `.catch(warn)` — replaces v1's savepoint fanout; a lost trigger costs nothing because state heals, kills #11):
+- `applyUnsubscribe` — after txn commit (both created AND alreadySuppressed paths — re-unsubscribe after a missed pass still heals, #4).
+- `eraseConsumer` — post-commit, targeted.
+- **Capture** — after `dispatchEvent('lead.created')` in `prospectService` + `metaLeadService` (so the history row exists): `if (prospect.consumerId) reconcile({consumerId}).catch(...)` — the reconciler no-ops cheaply when the consumer isn't suppressed. Retell path: consumerId always null (spine-excluded) → naturally no-op, comment only. This closes future-leads #5 and the capture race #6 deterministically; the periodic pass is the backstop.
+- **Boot + every 60 min** (`bootstrap.js` setInterval, house pattern) — the backstop + the flag-flip backfill executor.
+
+## 2. Wire contract (spec doc `docs/reference/webhook-propagation-contract.md`, deliverable)
+
+```json
+{
+  "event": "lead.suppressed",
+  "deliveryId": "<uuid>",
+  "timestamp": "<ISO now>",
+  "data": {
+    "lead": { "externalId": "<prospect uuid>" },
+    "suppression": {
+      "schemaVersion": 1,
+      "scope": "marketing" | "all",
+      "reason": "unsubscribe" | "complaint" | "admin" | "erasure",
+      "channel": "all",
+      "occurredAt": "<ISO — authoritative transition time, stable across repairs>"
+    }
+  }
+}
+```
+- Explicit `schemaVersion` (#17). `channel` fixed 'all' in v1, carried for WA-STOP future (dedupe key gains channel on that schema bump, #6.7-accepted).
+- **Data-minimized, NOT "PII-free"** (#16): externalId+reason+timestamp is pseudonymous person-related data. Contract states: deliver only to the app that already holds the lead; no re-sharing; log deliveryIds not payloads; `reason` retained as diagnostic (consumers act on `scope` only).
+- Transport identical to existing events (HMAC v1/v2 per subscriber, same headers). Consumer MUST: verify signature+timestamp, bind body deliveryId to header where it has that machinery, validate fields strictly (#17), respond 2xx fast, treat unknown `lead.externalId` as a **tombstone to store, not a no-op** (#7), merge monotonically ('all' dominates; older occurredAt never downgrades newer state, #9).
+- Sender-side facts stated honestly: retries = 3 attempts (delays 1s, 4s — no 16s, #1); failed rows → dead-letter, admin-retryable; rolling-50 all-failed auto-disable is subscriber-wide (#14) and bootstrap re-enables managed subscribers at boot (#14) — the runbook's kill-switch section covers: flip env flag off (stops new pairs at reconcile) **+ cancel pending `lead.suppressed` delivery rows via admin SQL** (recovery ignores events arrays, #13); re-queue after re-flip is automatic (failed-pair rule §1.6).
+
+## 3. Emitter changes (mktr-platform, all dark)
+
+1. **Migration 083 + `SuppressionPropagation` model** (§1 table).
+2. **`suppressionPropagationService.js`**: reconciler + `buildLeadSuppressedPayload` (in `prospectHelpers.js` beside the other builders, exercised by the payload-contract guard — which also gains the missing unassigned/held/inline-builder coverage, #3).
+3. **`webhookService.js`**: extract + rename `historicallyTargetedSubscribers(prospectIds, tx)`; erasureService switches to it (tests pin behavior).
+4. **`erasureService.js`**: (a) helper swap; (b) **add `lead.suppressed` to the cancel+scrub EXCLUSION list** beside `lead.deleted` (#8 — payload is PII-free-by-contract; cancelling pending ones just to have the reconciler re-queue them is churn and breaks history); (c) post-commit targeted reconcile trigger.
+5. **`consentService.applyUnsubscribe`**: post-commit trigger (no in-txn work — v1's savepoint fanout deleted).
+6. **Capture hooks**: `prospectService` + `metaLeadService` post-dispatch trigger (3 lines each).
+7. **`bootstrap.js`**: env-gated `requiredEvents` (`LYFE_LEAD_SUPPRESSED_ENABLED`, `MKTR_LEADS_LEAD_SUPPRESSED_ENABLED`) applied to **both the update AND create paths** (#15); reconciler boot-run + 60-min interval.
+8. **`env.example`** + spec doc + two consumer plan docs.
+
+## 4. Consumer plans v2 (deliverable docs; tombstone-first, monotonic)
+
+**Shared shape (both repos):** a `mktr_lead_suppressions` tombstone table keyed `(source_name, external_id)` storing `scope, reason, occurred_at, delivery_id, created_at` — **insert-or-escalate RPC** (atomic; scope 'all' dominates 'marketing'; older occurredAt never downgrades, #9/#19/#21): claim delivery id (where dedup machinery exists), upsert tombstone, and IF the lead exists apply `do_not_contact_at/do_not_contact_scope` columns + activity row in the same txn. **Lead-arrival hook**: `lead.created`/`lead.assigned` handlers consult the tombstone and stamp new rows on insert (#7 — suppression-before-created safe). Outreach gating (#20): every in-app contact affordance (call/WA buttons, wa_intro enqueue in mktr-leads' create RPC) checks scope ('all' = hard block; 'marketing' = warn badge; v1 minimum = mktr-leads gates `enqueue_wa_intro` via the tombstone at create time — which also fixes the suppressed-person-re-signup wa_intro hole #20).
+- **lyfe-app**: migration (columns + tombstone + `lead_activity_type` enum value 'suppressed'); EF: allowlist + handler as a single RPC call (atomicity substitute for its missing dedup table, #19); UI badge; `gen:types`. Flip `LYFE_LEAD_SUPPRESSED_ENABLED` LAST.
+- **mktr-leads**: migration (columns + tombstone + `process_mktr_lead_suppression` RPC following the deletion-RPC precedent); EF allowlist + handler; badge + wa_intro gate. Flip `MKTR_LEADS_LEAD_SUPPRESSED_ENABLED` LAST.
+- Both: synthetic verification BEFORE the flip **in the subscriber's actual signature mode** (v1 today; command recipe in each doc, #22); the 400-until-flipped warning; strict payload validation table (#17). Anchors marked "verify in-repo before applying" (#25 — consumer repos absent from this checkout; my anchors came from a mapping pass of those repos this session, restated as assumptions to re-verify).
+
+## 5. Tests (backend jest, real PG; suites: new `suppressionPropagation.test.js` + touched regressions)
+
+1. Reconcile from state: suppressed consumer with 3 leads (linked / phone-matched / call_bot-fromNumber), history to S1(subscribed)+S2(not) → pairs+deliveries exactly S1×3, payload spec-shaped (schemaVersion, scope, no consumerId/phone/name), occurredAt == suppression.createdAt across repeated runs.
+2. Determinism/idempotency: run twice → zero new rows (DB unique proof: two CONCURRENT reconcilers via parallel txns → no dup, no error).
+3. **Dark→flip backfill** (#4): suppress while S1 lacks the event → 0 pairs; add event → next pass creates pairs (the whole dark cohort).
+4. **Future lead** (#5): unsubscribe, THEN new capture same consumer → capture-hook pass (or periodic) yields the new pair.
+5. Race shape (#6): capture committed but reconcile ran before its delivery row → 0 pairs; after dispatch → pair appears (periodic heals).
+6. Escalation (#9): unsubscribe→pairs(marketing); erase → 'all' pairs added for suppressed-only subscriber; lead.deleted-handling subscriber gets NO suppression pair but keeps its lead.deleted row (fallback matrix, both arms).
+7. Erasure interplay (#8): pending lead.suppressed delivery survives erasure's cancel+scrub (exclusion list); erasure suite regression green after the helper swap.
+8. Failed-pair requeue: delivery row forced 'failed' → next pass requeues ONCE while subscribed; not when unsubscribed (kill-switch semantics) — plus runbook SQL cancels pendings (asserted inert afterward).
+9. Triggers: unsubscribe/erase/capture each fire reconcile (spy); trigger failure (dep throws) → suppression/capture still commits (post-commit isolation — a REAL SQL error inside the reconciler against a live outer flow, per #24's savepoint-test critique... reconciler is post-commit so the assertion is: writer unaffected, next pass heals).
+10. Bootstrap: flag on → events gain lead.suppressed on BOTH update and create paths (#15); flag off → removed; reconcile interval registered.
+11. Payload-contract guard extended: consumerId absent from ALL builders incl. new one + unassigned/held/inline Meta/Retell (#3).
+12. WEBHOOK_ENABLED=false: reconcile creates pairs but queues nothing; flip → queued (pairs are the durability).
+
+Regressions: erasure.test.js, consentLedger.test.js(+unit), webhook suites, prospectService suites, migrations test. Frontend: vitest contract run.
+
+## 6. Rollout
+
+Deploy backend (migration 083 runs at boot, advisory-locked). Flags OFF: reconciler runs but matches zero subscribed subscribers → creates zero pairs; zero deliveries; zero behavior change. Live proof: NEW Render deploy; `psql` (read-only MCP) `SELECT count(*) FROM suppression_propagations` (=0) + boot log line `suppression propagation reconciler armed (dark)` in Render logs; admin subscribers listing shows unchanged events arrays. Tracker: emitter live-dark + plans delivered → seed per contract gate (consumer side awaits Shawn).
+
+## 7. Codex round-1 disposition
+
+Folded: #1 (doc), #2 (rename+doc), #3 (guard coverage), #4 (reconciler = backfill; alreadySuppressed re-triggers), #5 (capture hook + periodic), #6 (post-dispatch ordering + periodic heal), #7 (consumer tombstones), #8 (scrub exclusion + dedupe moved out of payload JSON), #9 (monotonic scope pairs + consumer merge rules), #10 (DB unique + ON CONFLICT), #11 (durable pairs replace savepoint fanout), #12 (persisted occurredAt), #13 (runbook cancel + reconcile-side gate), #14 (documented; event-scoped breaker declined as out-of-scope rework of the shared webhook layer — suppressions are low-volume and flip-ordering is the operative guard), #15 (both paths), #16 (language + confidentiality clauses), #17 (schemaVersion + validation tables), #18 (dedupe out of JSON; history scan stays — one-off per reconcile over a small table, measured acceptable; index follow-up noted), #19/#20/#21 (consumer plans v2), #22 (signature-mode recipe), #23 (reliance stated), #24 (test list §5), #25 (anchors flagged as re-verify).
+Declined: none outright; #14/#18 partially (documented bounds instead of rework), rationale above.

--- a/docs/reference/webhook-propagation-contract.md
+++ b/docs/reference/webhook-propagation-contract.md
@@ -1,0 +1,73 @@
+# Webhook propagation contract — `lead.suppressed` v1
+
+**Status:** emitter LIVE-dark since 2026-07-21 (tracker "propagate"); no subscriber carries the event until its per-destination env flag flips.
+**Design:** durable projection + reconciler, NOT point-in-time fanout — `docs/plans/suppression-propagation-plan.md` (v2, post-Codex).
+**Consumer plans:** `docs/plans/propagate-consumer-lyfe.md` · `docs/plans/propagate-consumer-mktr-leads.md`.
+
+## 1. What the event means
+
+**"Stop contacting the person behind this lead; keep the lead."** Emitted to every subscriber that was ever targeted with the lead's payload (`lead.created`/`lead.assigned` delivery history — any status, conservative over-notify) once the person unsubscribes, is admin-suppressed, or is erased.
+
+Relationship to `lead.deleted` (PR C erasure): the fallback is **outcome-based** — a subscriber is skipped for the `scope:'all'` pair only when its `lead.deleted` delivery row for that lead actually EXISTS (not merely because it declares the capability). Deletion implies stop-contact, so when the deletion signal was queued, no duplicate suppression fires; but an erasure that ran while webhooks were disabled queued nothing, and the reconciler then projects the suppression fallback even to deleted-capable subscribers rather than silently dropping stop-contact. If a later repair also queues the deletion, receiving both is harmless — consumer merge is monotonic. A subscriber that handles `lead.suppressed` but not `lead.deleted` always gets the fallback `reason:'erasure', scope:'all'` — so stop-contact coverage can ship before a deletion handler exists.
+
+There is **no un-suppression event** in v1. Consumer state is monotonic; if a lift path ever ships it will be a NEW event type, not a semantics change here.
+
+## 2. Wire format
+
+Transport identical to every existing event: `POST` to the subscriber URL, headers `X-Webhook-Event`, `X-Webhook-Delivery-Id`, `X-Webhook-Signature` (`sha256=<hex>` HMAC), `X-Webhook-Timestamp`, plus `X-Webhook-Signature-Version: v2` when the subscriber is v2 (v1 signs the raw body; v2 signs `${timestamp}.${rawBody}`). `deliveryId` is also merged into the JSON body.
+
+```json
+{
+  "event": "lead.suppressed",
+  "deliveryId": "<uuid>",
+  "timestamp": "<ISO — send time>",
+  "data": {
+    "lead": { "externalId": "<prospect uuid — your stored external_id>" },
+    "suppression": {
+      "schemaVersion": 1,
+      "scope": "marketing" | "all",
+      "reason": "unsubscribe" | "complaint" | "admin" | "erasure",
+      "channel": "all",
+      "occurredAt": "<ISO — authoritative transition time, stable across repairs>"
+    }
+  }
+}
+```
+
+- `scope` is what consumers act on: `all` = block every contact including transactional/service messages; `marketing` = block marketing, service messages may flow. `reason` is diagnostic only.
+- `channel` is fixed `'all'` in v1 and carried for forward-compat (a future WhatsApp-STOP writes `channel:'whatsapp'` under a `schemaVersion` bump). Correspondingly, the emitter projects only `channel='all'` suppression rows — a per-channel suppression row is never promoted to a global scope.
+- `timestamp` is queue/build time, not send time — retries and repairs re-send the same body. Use `occurredAt` for ordering, never `timestamp`.
+- **Data minimization, stated honestly:** the payload carries no name/phone/email/consumerId, but `externalId + reason + occurredAt` is still pseudonymous person-related data. Consumers must not re-share it, must restrict it to the app that already holds the lead, and should log delivery ids, not payloads.
+
+## 3. Consumer requirements (both apps)
+
+1. Verify signature + timestamp exactly as for existing events; bind body `deliveryId` to the header where that machinery exists (mktr-leads).
+2. Validate strictly: `event === 'lead.suppressed'`, `externalId` uuid, `scope ∈ {marketing, all}`, `reason ∈` the enum, `occurredAt` parseable. Unknown `schemaVersion` > 1 → still 2xx, apply what you understand.
+3. Respond 2xx fast; the sender retries 3 attempts (delays 1s, 4s) then dead-letters (admin-retryable). A 4xx/5xx counts toward the subscriber-wide rolling-50 auto-disable.
+4. **Idempotent + monotonic merge**: repairs re-send with a NEW deliveryId, and deliveries are unordered/concurrent. Keyed by `(source_name, external_id)`: `all` dominates `marketing`; an older `occurredAt` never downgrades newer state.
+5. **Unknown lead = tombstone, not no-op**: a suppression can arrive before its `lead.created` (delivery concurrency). Store the suppression keyed by `(source_name, external_id)` and apply it when the lead later arrives (the created/assigned handlers must consult the tombstone).
+6. Suppression state must actually gate outreach affordances (buttons, auto-sends), not just render a badge — `all` is a hard block.
+
+## 4. Emitter internals (mktr-platform — for operators)
+
+- State: `suppression_propagations` — one row per (subscriber, lead, scope); UNIQUE `(subscriberId, prospectId, scope)`; `queuedAt`/`deliveryId` track the outbox linkage. Rows are DERIVED — the reconciler (`suppressionPropagationService`) recomputes from `consumer_suppressions` + `consumers.erasedAt` ⨝ prospects (consumer link + phone-digit + call_bot fromNumber arms) ⨝ delivery history ⨝ current subscriptions.
+- Passes: on boot; every 60 min; post-commit after unsubscribe/erasure; after capture of a lead whose consumer is linked (covers new-lead-while-suppressed). Any lost trigger heals on the next pass — the projection is the durability, including the ENTIRE dark period before a flag flip (the first pass after the flip is the backfill).
+- A terminally-failed delivery is re-queued at most once per pass while the subscriber still carries the event.
+- Erasure's payload cancel/scrub explicitly exempts `lead.deleted` AND `lead.suppressed` rows (neither carries direct identifiers — pseudonymous envelopes only).
+- A dead-letter purge that deletes a failed `lead.suppressed` row does NOT strand its pair: the requeue query treats a missing delivery row like a failed one.
+
+## 5. Go-live runbook (per consumer — ORDER IS THE SAFETY)
+
+1. Apply the consumer plan in that repo (migration + EF allowlist + handler + gating). Deploy it.
+2. **Synthetic verification BEFORE the flip**, in the subscriber's actual signature mode (both are v1 today): hand-sign a `lead.suppressed` POST with the shared secret directly against the EF; assert 200 + state landed + idempotent on re-send + unknown-lead tombstone path.
+3. Flip the env flag on the mktr backend Render service (`LYFE_LEAD_SUPPRESSED_ENABLED` / `MKTR_LEADS_LEAD_SUPPRESSED_ENABLED`) → the restart's boot pass adds the event to the subscriber AND backfills the dark-period pairs.
+4. Verify: `suppression_propagations` rows appear for that subscriber; deliveries flow `success`; consumer-side rows updated.
+
+**Why the order is load-bearing:** both receivers 400 unknown events; the sender's auto-disable trips after the newest 50 delivery rows are all `failed` — a premature flip can disable the subscriber and stop ALL lead delivery to that app. Also note: bootstrap force-re-enables managed subscribers at boot, so an auto-disable during a bad rollout will resurrect on the next deploy while the flag is still on — the flag itself is the kill switch, flip it off first.
+
+**Kill switch:** flip the flag off (next boot removes the event → reconciler stops queueing for that subscriber; projected pairs persist harmlessly) and, if deliveries are already pending, cancel them:
+```sql
+UPDATE webhook_deliveries SET status='failed', "errorMessage"='cancelled: rollout aborted'
+ WHERE "eventType"='lead.suppressed' AND status='pending';
+```
+(Recovery/timers ignore event arrays — pending rows would otherwise keep attempting.) Re-flipping later re-queues from the pairs automatically.


### PR DESCRIPTION
## What

Downstream apps (Lyfe, mktr-leads) holding a delivered lead are never told when the person unsubscribes or is erased — agents keep calling in good faith. This PR adds the **`lead.suppressed` webhook** ("stop contacting the person behind this lead; keep the lead"), emitted from a **durable projection + deterministic reconciler**, live-dark behind per-destination env flags.

## Design (2 Codex xhigh rounds)

Plan round verdict was **rethink** (25 findings): a point-in-time fanout permanently loses suppressions (dark rollout, future leads, capture races, savepoint rollbacks). v2 is state-derived: `suppression_propagations` (subscriber×lead×scope, DB-unique) recomputed from `consumer_suppressions`/`erasedAt` ⨝ the person's leads ⨝ delivery history ⨝ current subscriptions. Passes: boot / hourly / post-writer / **flush-time catch-up** (every payload delivery — capture, assignment, bulk, held/DNC release — flows through `flushDeliveries`, so new targeting of a suppressed person propagates promptly). Diff round verdict **ship with fixes** — all 12 folded, incl. the two blockers: assignment/release paths now reconcile via the flush choke point, and the erasure fallback is **outcome-based** (a deleted-capable subscriber is skipped only when its `lead.deleted` row actually exists — a dark-mode erasure still ships stop-contact).

- Scope monotonic (`marketing` → `all`), `occurredAt` authoritative from the suppression/erasure transition; payload data-minimized (no consumerId/phone/name — test-asserted).
- CAS queue claims + in-txn subscription/manual-retry rechecks; purged dead-letters re-queue; channel-scoped suppression rows are never promoted to global.
- Erasure cancel/scrub exempts both PII-free event types; `historicallyTargetedSubscribers` extracted and shared with erasureService.
- **Zero prod behavior change at merge**: `LYFE_LEAD_SUPPRESSED_ENABLED` / `MKTR_LEADS_LEAD_SUPPRESSED_ENABLED` default off; both receivers 400 unknown events and 50 straight failures auto-disable a subscriber, so the flip must follow the consumer deploy (runbook: `docs/reference/webhook-propagation-contract.md`).

## Cross-repo (plans, per the tracker prompt — Shawn applies)

`docs/plans/propagate-consumer-lyfe.md` + `docs/plans/propagate-consumer-mktr-leads.md`: tombstone tables keyed (source_name, external_id), atomic monotonic-merge RPCs (RLS-enforced, search_path-pinned), lead-arrival hooks (suppression-before-created safe), wa_intro gating, synthetic-verification recipes, per-repo flip steps.

## Tests

15-test integration suite on real Postgres: projection incl. unlinked + call_bot fromNumber arms, true INSERT/CAS contention, dark→flip backfill, future leads, erasure escalation + outcome-based dark-erasure fallback, pending-delivery survival of erasure, failed + purged requeue, kill-switch semantics, WEBHOOK_ENABLED durability, writer triggers, end-to-end POST /api/unsubscribe, flush catch-up (wiring + default chain), bootstrap flag on both create/update paths, payload-guard extension (now covers all 6 builders). Targeted regressions green: 276 backend (erasure 25/25 over the helper swap, consentLedger, all 5 webhook suites, migrations, prospects) + vitest 1625/1625.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcTxp7my3HZ6rLDym67waw