### PR TITLE
feat(cohorts): cohort builder backend — batch canMarketTo gets its first callers (tracker "cohortapi")

### DIFF
--- a/backend/src/controllers/cohortController.js
+++ b/backend/src/controllers/cohortController.js
@@ -1,0 +1,118 @@
+import { asyncHandler, AppError } from '../middleware/errorHandler.js';
+import { Cohort } from '../models/index.js';
+import {
+  previewCohort as previewCohortSvc,
+  listCohortMembers,
+  getCohortFacets,
+  snapshotCohort,
+  snapshotFields,
+  normalizeDefinition,
+} from '../services/cohortService.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Malformed ids 404 up front (raw uuid-cast errors surface as 500s — the
+ * AdminCampaignDesigner lesson, same as consumerController). */
+async function findCohortOr404(id) {
+  if (!UUID_RE.test(String(id || ''))) throw new AppError('Cohort not found', 404);
+  const cohort = await Cohort.findByPk(id);
+  if (!cohort || cohort.archivedAt) throw new AppError('Cohort not found', 404);
+  return cohort;
+}
+
+function serializeCohort(cohort) {
+  return {
+    id: cohort.id,
+    name: cohort.name,
+    description: cohort.description,
+    definition: cohort.definition,
+    createdBy: cohort.createdBy,
+    lastTotalCount: cohort.lastTotalCount,
+    lastReachableCount: cohort.lastReachableCount,
+    lastPreviewBreakdown: cohort.lastPreviewBreakdown,
+    lastPreviewAt: cohort.lastPreviewAt,
+    createdAt: cohort.createdAt,
+    updatedAt: cohort.updatedAt,
+  };
+}
+
+/** Stateless definition → counts (drives the UI live preview). */
+export const preview = asyncHandler(async (req, res) => {
+  const result = await previewCohortSvc(req.body.definition, { channel: req.body.channel });
+  res.json({ success: true, data: result });
+});
+
+/** Live filter vocabulary (attribute values, tags, campaigns, draws). */
+export const facets = asyncHandler(async (req, res) => {
+  res.json({ success: true, data: await getCohortFacets() });
+});
+
+export const create = asyncHandler(async (req, res) => {
+  // Normalize + preview BEFORE persisting, then write definition and
+  // snapshot in ONE create — a failing resolution leaves no half-created
+  // row, and the stored definition is the canonical shape (deduped lists,
+  // defaulted 18+ gate), not whatever the client typed.
+  const definition = normalizeDefinition(req.body.definition);
+  const previewResult = await previewCohortSvc(definition);
+  const cohort = await Cohort.create({
+    name: req.body.name.trim(),
+    description: req.body.description?.trim() || null,
+    definition,
+    createdBy: req.user?.id || null,
+    ...snapshotFields(previewResult),
+  });
+  res.status(201).json({ success: true, data: { ...serializeCohort(cohort), preview: previewResult } });
+});
+
+export const list = asyncHandler(async (req, res) => {
+  const cohorts = await Cohort.findAll({
+    where: { archivedAt: null },
+    order: [['createdAt', 'DESC']],
+    limit: 200,
+  });
+  res.json({ success: true, data: cohorts.map(serializeCohort) });
+});
+
+export const get = asyncHandler(async (req, res) => {
+  const cohort = await findCohortOr404(req.params.id);
+  let previewResult = null;
+  if (String(req.query.refresh || '') === '1') {
+    previewResult = await snapshotCohort(cohort);
+  }
+  res.json({ success: true, data: { ...serializeCohort(cohort), ...(previewResult ? { preview: previewResult } : {}) } });
+});
+
+export const update = asyncHandler(async (req, res) => {
+  const cohort = await findCohortOr404(req.params.id);
+  const patch = {};
+  if (req.body.name !== undefined) patch.name = req.body.name.trim();
+  if (req.body.description !== undefined) patch.description = req.body.description?.trim() || null;
+  let previewResult = null;
+  if (req.body.definition !== undefined) {
+    // Same order as create: resolve first, persist definition + fresh
+    // snapshot together.
+    patch.definition = normalizeDefinition(req.body.definition);
+    previewResult = await previewCohortSvc(patch.definition);
+    Object.assign(patch, snapshotFields(previewResult));
+  }
+  await cohort.update(patch);
+  res.json({ success: true, data: { ...serializeCohort(cohort), ...(previewResult ? { preview: previewResult } : {}) } });
+});
+
+/** Soft-archive; idempotent (archiving an archived/unknown id 404s like GET). */
+export const archive = asyncHandler(async (req, res) => {
+  const cohort = await findCohortOr404(req.params.id);
+  await cohort.update({ archivedAt: new Date() });
+  res.json({ success: true, data: { id: cohort.id, archivedAt: cohort.archivedAt } });
+});
+
+export const members = asyncHandler(async (req, res) => {
+  const cohort = await findCohortOr404(req.params.id);
+  const result = await listCohortMembers(cohort.definition, {
+    channel: req.query.channel,
+    status: req.query.status || 'all',
+    limit: req.query.limit,
+    offset: req.query.offset,
+  });
+  res.json({ success: true, data: { cohortId: cohort.id, name: cohort.name, ...result } });
+});

--- a/backend/src/database/migrations/084-cohorts.js
+++ b/backend/src/database/migrations/084-cohorts.js
@@ -1,0 +1,60 @@
+/**
+ * 084 — Saved cohorts (tracker "cohortapi",
+ * docs/plans/cohort-builder-backend.md).
+ *
+ * A cohort is a SAVED DEFINITION (filters + age gate + marketing-gate scope),
+ * never a materialized member list — membership and reachability are resolved
+ * live by cohortService at every ask, so consent changes take effect
+ * immediately. Snapshot columns are advisory UI hints only.
+ *
+ * Soft-archive (`archivedAt`), no hard delete: the Phase-3 push senders will
+ * FK send logs to cohorts and history must survive.
+ *
+ * Guarded/idempotent + sync-tolerant like 080 (test boot syncs models first).
+ */
+export async function up(queryInterface) {
+  const q = (sql) => queryInterface.sequelize.query(sql);
+
+  await q(`CREATE TABLE IF NOT EXISTS cohorts (
+    id UUID PRIMARY KEY,
+    name VARCHAR(120) NOT NULL,
+    description TEXT,
+    definition JSONB NOT NULL,
+    "createdBy" UUID,
+    "lastTotalCount" INTEGER,
+    "lastReachableCount" INTEGER,
+    "lastPreviewBreakdown" JSONB,
+    "lastPreviewAt" TIMESTAMP WITH TIME ZONE,
+    "archivedAt" TIMESTAMP WITH TIME ZONE,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+  )`);
+
+  // FK added guarded (the 078 pattern) — sync()-built test schemas already
+  // carry it from the model; prod gets it here.
+  await q(`DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.table_constraints tc
+          JOIN information_schema.key_column_usage kcu
+            ON kcu.constraint_name = tc.constraint_name
+         WHERE tc.table_name = 'cohorts' AND tc.constraint_type = 'FOREIGN KEY'
+           AND kcu.column_name = 'createdBy'
+      ) THEN
+        ALTER TABLE cohorts ADD CONSTRAINT fk_cohorts_created_by
+          FOREIGN KEY ("createdBy") REFERENCES users(id) ON DELETE SET NULL;
+      END IF;
+    END $$`);
+
+  await q(`CREATE INDEX IF NOT EXISTS idx_cohorts_archived_created
+             ON cohorts ("archivedAt", "createdAt" DESC)`);
+
+  // Draw-participation filter: two independently-indexed EXISTS branches —
+  // the phoneHash fallback (entries whose prospect was hard-deleted) and the
+  // prospect-link lookup (uq_de_draw_prospect leads on drawId, so it cannot
+  // serve a bare prospectId probe, e.g. anyDraw).
+  await q(`CREATE INDEX IF NOT EXISTS idx_de_phone_hash
+             ON draw_entries ("phoneHash")`);
+  await q(`CREATE INDEX IF NOT EXISTS idx_de_prospect
+             ON draw_entries ("prospectId") WHERE "prospectId" IS NOT NULL`);
+}

--- a/backend/src/models/Cohort.js
+++ b/backend/src/models/Cohort.js
@@ -1,0 +1,40 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * A saved cohort (tracker "cohortapi", docs/plans/cohort-builder-backend.md):
+ * a named DEFINITION — filters + age gate + marketing-gate scope — never a
+ * member list. cohortService resolves membership and reachability live on
+ * every ask so consent changes bite immediately; the snapshot columns are
+ * advisory UI hints refreshed on save / explicit refresh.
+ *
+ * The definition is validated at the route (Joi, strict) before it ever
+ * reaches this row; cohortService validates shape again defensively because
+ * rows outlive validators.
+ */
+const Cohort = sequelize.define('Cohort', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  name: { type: DataTypes.STRING(120), allowNull: false },
+  description: { type: DataTypes.TEXT, allowNull: true },
+  definition: {
+    type: DataTypes.JSONB,
+    allowNull: false,
+    comment: 'filters + ageGate (minAge ≥ 18, §9.5-2 binding) + marketingContext'
+  },
+  createdBy: { type: DataTypes.UUID, allowNull: true, references: { model: 'users', key: 'id' } },
+  lastTotalCount: { type: DataTypes.INTEGER, allowNull: true },
+  lastReachableCount: { type: DataTypes.INTEGER, allowNull: true },
+  lastPreviewBreakdown: { type: DataTypes.JSONB, allowNull: true, comment: 'byReason counts at last snapshot' },
+  lastPreviewAt: { type: DataTypes.DATE, allowNull: true },
+  archivedAt: { type: DataTypes.DATE, allowNull: true, comment: 'Soft-archive — push send logs will FK cohorts' },
+}, {
+  tableName: 'cohorts',
+  indexes: [
+    // Mirrored on the model because test boot builds schema via
+    // sync({force:true}) BEFORE migrations (the Prospect (campaignId,phone)
+    // lesson — see Consumer.js).
+    { fields: ['archivedAt', 'createdAt'], name: 'idx_cohorts_archived_created' },
+  ]
+});
+
+export default Cohort;

--- a/backend/src/models/DrawEntry.js
+++ b/backend/src/models/DrawEntry.js
@@ -44,6 +44,11 @@ const DrawEntry = sequelize.define('DrawEntry', {
   updatedAt: false,
   indexes: [
     { fields: ['drawId'], name: 'idx_de_draw' },
+    // Cohort draw-filter joins (migration 084) — mirrored here for
+    // sync()-built test schemas: phoneHash fallback branch + bare
+    // prospectId probe (uq_de_draw_prospect leads on drawId).
+    { fields: ['phoneHash'], name: 'idx_de_phone_hash' },
+    { fields: ['prospectId'], name: 'idx_de_prospect', where: { prospectId: { [Op.ne]: null } } },
     // Partial (erasure sets prospectId NULL) — defined here AND in migration
     // 059 so sync()-built schemas enforce it too.
     {

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -97,6 +97,10 @@ function defineAssociations() {
   Consumer.hasMany(ConsumerSuppression, { foreignKey: 'consumerId', as: 'suppressions', onDelete: 'RESTRICT' });
   ConsumerSuppression.belongsTo(Consumer, { foreignKey: 'consumerId', as: 'consumer', onDelete: 'RESTRICT' });
 
+  // Saved cohorts (tracker "cohortapi") — definitions only, resolved live.
+  const { Cohort } = models;
+  Cohort.belongsTo(User, { foreignKey: 'createdBy', as: 'creator', onDelete: 'SET NULL' });
+
   // Suppression-propagation projection (tracker "propagate") — derived rows,
   // reconciler-owned. CASCADE from prospect/subscriber (a vanished lead or
   // subscriber voids the pair); RESTRICT from consumers like the ledger.
@@ -378,7 +382,7 @@ export const {
   DiscoveryPlaceMemory, OutreachCadence, OutreachCadenceStep,
   OutreachCadenceTransition, OutreachCadenceEnrollment, OutreachSuppression,
   AiSettings, WalletLedger, Consumer, ConsentEvent, ConsumerSuppression,
-  SuppressionPropagation
+  SuppressionPropagation, Cohort
 } = models;
 
 export { sequelize };

--- a/backend/src/routes/cohorts.js
+++ b/backend/src/routes/cohorts.js
@@ -1,0 +1,78 @@
+import express from 'express';
+import Joi from 'joi';
+import { authenticateToken, requireAdmin } from '../middleware/auth.js';
+import { validate } from '../middleware/validation.js';
+import * as cohortController from '../controllers/cohortController.js';
+
+export const meta = { path: '/api/cohorts' };
+
+/**
+ * Cohort builder (tracker "cohortapi") — ADMIN ONLY, like /api/consumers:
+ * cohorts aggregate cross-campaign PII and drive marketing pushes.
+ *
+ * Joi here gives live requests loud 400s with field detail; the BINDING
+ * validation (incl. the §9.5-2 minAge≥18 floor) lives in
+ * cohortService.normalizeDefinition, which also re-checks definitions loaded
+ * back out of the DB. Schemas stay in this file on purpose — the shared
+ * validation middleware carries parallel in-flight work.
+ */
+
+const uuid = Joi.string().uuid();
+const shortStr = (max) => Joi.string().trim().min(1).max(max);
+
+const definitionSchema = Joi.object({
+  filters: Joi.object({
+    campaignIds: Joi.array().items(uuid).max(50),
+    drawIds: Joi.array().items(uuid).max(50),
+    anyDraw: Joi.boolean(),
+    campaignTags: Joi.array().items(shortStr(64)).max(20),
+    attributes: Joi.object({
+      postalPrefixes: Joi.array().items(Joi.string().pattern(/^[0-9]{2,6}$/)).max(20),
+      incomes: Joi.array().items(shortStr(64)).max(20),
+      educations: Joi.array().items(shortStr(64)).max(20),
+      genders: Joi.array().items(shortStr(32)).max(10),
+    }),
+  }),
+  ageGate: Joi.object({
+    // §9.5-2: 18 is a FLOOR, not a default — under-18 cohorts are
+    // inexpressible (the service enforces the same rule bindingly).
+    minAge: Joi.number().integer().min(18).max(120),
+    maxAge: Joi.number().integer().min(18).max(120).allow(null),
+  }),
+  marketingContext: Joi.object({
+    campaignId: uuid.allow(null),
+  }),
+});
+
+const channelSchema = Joi.string().valid('all', 'email', 'whatsapp', 'sms', 'voice');
+
+const previewSchema = Joi.object({
+  definition: definitionSchema.required(),
+  channel: channelSchema,
+});
+
+const createSchema = Joi.object({
+  name: shortStr(120).required(),
+  description: Joi.string().allow('', null).max(2000),
+  definition: definitionSchema.required(),
+});
+
+const updateSchema = Joi.object({
+  name: shortStr(120),
+  description: Joi.string().allow('', null).max(2000),
+  definition: definitionSchema,
+}).min(1);
+
+const router = express.Router();
+router.use(authenticateToken, requireAdmin);
+
+router.post('/preview', validate(previewSchema), cohortController.preview);
+router.get('/facets', cohortController.facets); // before /:id — 'facets' is a valid path segment
+router.post('/', validate(createSchema), cohortController.create);
+router.get('/', cohortController.list);
+router.get('/:id', cohortController.get);
+router.put('/:id', validate(updateSchema), cohortController.update);
+router.delete('/:id', cohortController.archive);
+router.get('/:id/members', cohortController.members);
+
+export default router;

--- a/backend/src/services/cohortService.js
+++ b/backend/src/services/cohortService.js
@@ -1,0 +1,622 @@
+import { sequelize, Cohort, Campaign } from '../models/index.js';
+import { AppError } from '../middleware/errorHandler.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Cohort builder (tracker "cohortapi", docs/plans/cohort-builder-backend.md).
+ *
+ * A cohort DEFINITION selects consumers by what they did (campaigns, draws,
+ * campaign tags, prospect-level attributes); resolution then splits the
+ * matched population into reachable vs excluded-with-reasons through the
+ * SAME semantics as consentService.canMarketTo — granted ∧ verified latest
+ * contact event in scope, no marketing suppression, not erased — plus the
+ * binding 18+ age gate (consent doc §9.5-2) and, for concrete channels, a
+ * destination check (an email push cannot reach a person with no email).
+ *
+ * INVARIANTS (Codex review round 1 dispositioned in the plan doc §10):
+ *  - Nothing here widens consent reads. canMarketToBatch reproduces
+ *    canMarketTo exactly over the consumerId domain (same scope rule, same
+ *    three-key tie-break, same channel matching, no destination or age
+ *    logic) and cohortService.test.js proves the equivalence per person,
+ *    including forced timestamp ties. If canMarketTo's semantics ever
+ *    change, that parity suite is the tripwire — and the batch SQL should
+ *    then be folded INTO consentService (kept apart today only to stay off
+ *    files carried by in-flight parallel work).
+ *  - Fail-closed: resolution errors THROW (no partial audiences), unknown
+ *    consumers report not_found, a dob that is missing/garbled/not a real
+ *    calendar date excludes with age_unknown, and ANY valid dob claiming
+ *    the person is under 18 disqualifies them (age_conflict) no matter how
+ *    many adult dobs their other signups carry.
+ *  - The age gate cannot be expressed away: minAge < 18 is rejected, absent
+ *    ageGate defaults to 18. Ages are measured against the Singapore
+ *    calendar day (pinned explicitly — DB session timezone is not). A
+ *    29-Feb birthday counts as reaching the age on 1 Mar of non-leap years
+ *    (the conservative, later direction).
+ *  - marketingContext.campaignId selects which SCOPED grants may count for
+ *    the preview; it must reference a real campaign. It is advisory for
+ *    audience-building only — a future sender MUST gate each send with the
+ *    campaign the message is actually about (equality enforced there), and
+ *    its send log must snapshot the definition + context it resolved with;
+ *    cohort rows are mutable and cannot serve as that audit record.
+ *  - Cohorts are definitions, never materialized lists — every ask
+ *    re-resolves so suppressions/unsubscribes bite immediately.
+ *  - Attribute filters read prospect-level JSON today; tracker item "rollup"
+ *    re-points them at the consumer projection later without changing the
+ *    API shape. Values match EXACTLY what capture stored (display strings,
+ *    e.g. "Degree") — the /facets endpoint exposes the live vocabulary so
+ *    the UI never guesses.
+ *  - campaigns.tags is unchecked TEXT holding JSON; it is parsed in JS
+ *    (malformed rows are skipped) and NEVER cast to jsonb in SQL, where one
+ *    bad row would abort the whole cohort query.
+ */
+
+export const COHORT_CHANNELS = ['all', 'email', 'whatsapp', 'sms', 'voice'];
+export const EXCLUSION_REASONS = [
+  'age_unknown', 'age_conflict', 'age_ineligible',
+  'missing_email', 'missing_phone',
+  'suppressed', 'not_consented', 'not_verified',
+];
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const TAG_RE = /^[^\s]([\s\S]{0,62}[^\s])?$/; // 1..64 chars, no leading/trailing whitespace
+const POSTAL_PREFIX_RE = /^[0-9]{2,6}$/;
+
+const MAX_LIST = { campaignIds: 50, drawIds: 50, campaignTags: 20, postalPrefixes: 20, incomes: 20, educations: 20, genders: 10 };
+
+function cleanStringList(value, { max, re, label }) {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) throw new AppError(`${label} must be an array`, 422);
+  const out = [];
+  for (const raw of value) {
+    if (typeof raw !== 'string') throw new AppError(`${label} entries must be strings`, 422);
+    const v = raw.trim();
+    if (!v) continue;
+    if (re && !re.test(v)) throw new AppError(`${label} entry "${v.slice(0, 40)}" is invalid`, 422);
+    if (!out.includes(v)) out.push(v);
+  }
+  if (out.length > max) throw new AppError(`${label} allows at most ${max} entries`, 422);
+  return out;
+}
+
+/**
+ * The single hard gate on definition shape. Route-level Joi gives loud 400s
+ * for live requests, but SAVED definitions come back out of the DB and must
+ * re-pass here — rows outlive validators, and the §9.5-2 floor must bind
+ * even if an old row (or a future bug) stored something looser.
+ */
+export function normalizeDefinition(definition) {
+  if (definition === null || definition === undefined) definition = {};
+  if (typeof definition !== 'object' || Array.isArray(definition)) {
+    throw new AppError('definition must be an object', 422);
+  }
+  const f = definition.filters || {};
+  if (typeof f !== 'object' || Array.isArray(f)) throw new AppError('filters must be an object', 422);
+  const a = f.attributes || {};
+  if (typeof a !== 'object' || Array.isArray(a)) throw new AppError('filters.attributes must be an object', 422);
+
+  const filters = {
+    campaignIds: cleanStringList(f.campaignIds, { max: MAX_LIST.campaignIds, re: UUID_RE, label: 'filters.campaignIds' }),
+    drawIds: cleanStringList(f.drawIds, { max: MAX_LIST.drawIds, re: UUID_RE, label: 'filters.drawIds' }),
+    anyDraw: f.anyDraw === true,
+    campaignTags: cleanStringList(f.campaignTags, { max: MAX_LIST.campaignTags, re: TAG_RE, label: 'filters.campaignTags' }),
+    attributes: {
+      postalPrefixes: cleanStringList(a.postalPrefixes, { max: MAX_LIST.postalPrefixes, re: POSTAL_PREFIX_RE, label: 'filters.attributes.postalPrefixes' }),
+      incomes: cleanStringList(a.incomes, { max: MAX_LIST.incomes, re: TAG_RE, label: 'filters.attributes.incomes' }),
+      educations: cleanStringList(a.educations, { max: MAX_LIST.educations, re: TAG_RE, label: 'filters.attributes.educations' }),
+      genders: cleanStringList(a.genders, { max: MAX_LIST.genders, re: TAG_RE, label: 'filters.attributes.genders' }),
+    },
+  };
+
+  const ag = definition.ageGate || {};
+  if (typeof ag !== 'object' || Array.isArray(ag)) throw new AppError('ageGate must be an object', 422);
+  const minAge = ag.minAge === undefined || ag.minAge === null ? 18 : ag.minAge;
+  if (!Number.isInteger(minAge) || minAge > 120) throw new AppError('ageGate.minAge must be an integer ≤ 120', 422);
+  if (minAge < 18) {
+    // Binding safeguard, consent doc §9.5-2: cohorts are 18+ until real
+    // counsel says otherwise. Not a default — a floor.
+    throw new AppError('ageGate.minAge below 18 is not permitted (consent policy §9.5-2)', 422);
+  }
+  let maxAge = ag.maxAge === undefined || ag.maxAge === null ? null : ag.maxAge;
+  if (maxAge !== null) {
+    if (!Number.isInteger(maxAge) || maxAge > 120) throw new AppError('ageGate.maxAge must be an integer ≤ 120', 422);
+    if (maxAge < minAge) throw new AppError('ageGate.maxAge must be ≥ minAge', 422);
+  }
+
+  const mc = definition.marketingContext || {};
+  if (typeof mc !== 'object' || Array.isArray(mc)) throw new AppError('marketingContext must be an object', 422);
+  const gateCampaignId = mc.campaignId === undefined || mc.campaignId === null ? null : String(mc.campaignId);
+  if (gateCampaignId !== null && !UUID_RE.test(gateCampaignId)) {
+    throw new AppError('marketingContext.campaignId must be a UUID or null', 422);
+  }
+
+  return { filters, ageGate: { minAge, maxAge }, marketingContext: { campaignId: gateCampaignId } };
+}
+
+function normalizeChannel(channel) {
+  const c = channel === undefined || channel === null ? 'all' : String(channel);
+  if (!COHORT_CHANNELS.includes(c)) {
+    throw new AppError(`channel must be one of ${COHORT_CHANNELS.join(', ')}`, 422);
+  }
+  return c;
+}
+
+// Ages are measured against the SINGAPORE calendar day, explicitly — the
+// Sequelize connection pins no session timezone, and CURRENT_DATE would
+// silently follow whatever the host DB uses.
+const SGT_TODAY = `((now() AT TIME ZONE 'Asia/Singapore')::date)`;
+
+/**
+ * Real-calendar dob validation for a prospects alias: shape-anchored
+ * 'YYYY-MM-DD' AND the day exists in that month (leap-aware). Built from
+ * string ops + a to_date on the always-valid 'YYYY-MM-01', so no input can
+ * ever raise a cast error and abort the cohort query — impossible dates
+ * (2000-02-30) simply fail closed into age_unknown.
+ */
+function validDobSql(alias) {
+  const dob = `(${alias}.demographics->>'dateOfBirth')`;
+  return `(${dob} ~ '^\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])$'
+      AND substring(${dob} from 9 for 2)::int <= extract(day from (
+            to_date(substring(${dob} from 1 for 7) || '-01', 'YYYY-MM-DD')
+            + interval '1 month - 1 day'))::int)`;
+}
+
+/**
+ * Build the population + gate SQL for a normalized definition. Async because
+ * campaignTags resolve to campaign ids in JS first (see header invariant).
+ * Returns { withSql, replacements } — callers append their own SELECT over
+ * `gated`.
+ *
+ * All values ride Sequelize replacements; no user text is ever interpolated.
+ */
+async function buildResolution(d, def, channel) {
+  const repl = {};
+  const conds = ['c."erasedAt" IS NULL'];
+  const { filters, ageGate, marketingContext } = def;
+
+  if (filters.campaignIds.length) {
+    repl.campaignIds = filters.campaignIds;
+    conds.push(`EXISTS (
+      SELECT 1 FROM prospects pc
+       WHERE pc."consumerId" = c.id AND pc."campaignId" IN (:campaignIds))`);
+  }
+
+  if (filters.drawIds.length || filters.anyDraw) {
+    // Two independently-indexed branches (prospect link → idx_de_prospect;
+    // hash fallback → idx_de_phone_hash) instead of one OR-join the planner
+    // cannot serve. The hash branch exists for entries whose prospect was
+    // HARD-DELETED while the person still stands; PDPA erasure is not that
+    // case — it rewrites the entry hash to the all-zeros sentinel and nulls
+    // the consumer's hash, so erased people cannot resurface here (and the
+    // erasedAt condition above already drops them).
+    const drawCond = (alias) => (filters.drawIds.length ? `AND ${alias}."drawId" IN (:drawIds)` : '');
+    if (filters.drawIds.length) repl.drawIds = filters.drawIds;
+    conds.push(`(EXISTS (
+        SELECT 1 FROM draw_entries de
+        JOIN prospects dp ON dp.id = de."prospectId"
+         WHERE dp."consumerId" = c.id ${drawCond('de')})
+      OR EXISTS (
+        SELECT 1 FROM draw_entries de2
+         WHERE c."phoneHash" IS NOT NULL AND de2."phoneHash" = c."phoneHash"
+           ${drawCond('de2')}))`);
+  }
+
+  if (filters.campaignTags.length) {
+    const tagCampaignIds = await resolveTagCampaignIds(d, filters.campaignTags);
+    if (!tagCampaignIds.length) {
+      conds.push('false'); // tags nobody carries → empty cohort, loudly countable
+    } else {
+      repl.tagCampaignIds = tagCampaignIds;
+      conds.push(`EXISTS (
+        SELECT 1 FROM prospects tp
+         WHERE tp."consumerId" = c.id AND tp."campaignId" IN (:tagCampaignIds))`);
+    }
+  }
+
+  // Each attribute list is its own EXISTS: income may come from one signup
+  // and postal from another — both are facts about the person (the same
+  // union "rollup" will later materialize).
+  const attrs = filters.attributes;
+  if (attrs.postalPrefixes.length) {
+    // Prefixes are validated digits-only, so no LIKE metacharacters exist;
+    // patterns are still built server-side, never from raw text.
+    repl.postalPatterns = attrs.postalPrefixes.map((p) => `${p}%`);
+    conds.push(`EXISTS (
+      SELECT 1 FROM prospects pp
+       WHERE pp."consumerId" = c.id
+         AND COALESCE(pp.location->>'postalCode', pp.location->>'zipCode')
+             LIKE ANY ((ARRAY[:postalPatterns])::text[]))`);
+  }
+  const attrIn = { incomes: 'income', educations: 'education', genders: 'gender' };
+  for (const [key, field] of Object.entries(attrIn)) {
+    if (attrs[key].length) {
+      repl[key] = attrs[key];
+      conds.push(`EXISTS (
+        SELECT 1 FROM prospects p_${field}
+         WHERE p_${field}."consumerId" = c.id
+           AND (p_${field}.demographics->>'${field}') IN (:${key}))`);
+    }
+  }
+
+  // ── Age gate (§9.5-2, ALWAYS on) ─────────────────────────────────────────
+  // dob is a 'YYYY-MM-DD' string inside prospects.demographics; compare
+  // STRINGS against to_char cutoffs — ISO dates order lexicographically and
+  // nothing here can raise a cast error (see validDobSql).
+  //
+  // Three per-person facts:
+  //  - in_window: SOME valid dob satisfies the whole [minAge, maxAge] window
+  //    (both bounds on the SAME row — conflicting dobs cannot combine).
+  //  - minor_claim: SOME valid dob puts the person under EIGHTEEN — the
+  //    binding floor, deliberately independent of the cohort's minAge. Any
+  //    under-18 claim disqualifies outright, no matter what other signups say.
+  //  - dob_known: SOME valid dob exists at all.
+  repl.minAge = ageGate.minAge;
+  repl.adultYears = 18;
+  const minCut = `to_char((${SGT_TODAY} - make_interval(years => :minAge)), 'YYYY-MM-DD')`;
+  const adultCut = `to_char((${SGT_TODAY} - make_interval(years => :adultYears)), 'YYYY-MM-DD')`;
+  let windowSql = `(pd.demographics->>'dateOfBirth') <= ${minCut}`;
+  if (ageGate.maxAge !== null) {
+    // age ≤ maxAge ⟺ dob AFTER (today − (maxAge+1) years).
+    repl.maxAgePlus1 = ageGate.maxAge + 1;
+    windowSql += ` AND (pd.demographics->>'dateOfBirth') > to_char((${SGT_TODAY} - make_interval(years => :maxAgePlus1)), 'YYYY-MM-DD')`;
+  }
+  const inWindowSql = `EXISTS (
+    SELECT 1 FROM prospects pd
+     WHERE pd."consumerId" = c.id AND ${validDobSql('pd')} AND ${windowSql})`;
+  const minorClaimSql = `EXISTS (
+    SELECT 1 FROM prospects pm
+     WHERE pm."consumerId" = c.id AND ${validDobSql('pm')}
+       AND (pm.demographics->>'dateOfBirth') > ${adultCut})`;
+  const dobKnownSql = `EXISTS (
+    SELECT 1 FROM prospects pk
+     WHERE pk."consumerId" = c.id AND ${validDobSql('pk')})`;
+
+  // Destination availability for concrete channels: consent alone cannot
+  // make an email push reach a person with no email. Channel 'all' is the
+  // abstract consent question (parity with canMarketTo) and requires none.
+  const hasDestSql = channel === 'email'
+    ? `(c.email IS NOT NULL AND c.email <> '')`
+    : channel === 'all' ? 'true' : `(c.phone IS NOT NULL)`;
+
+  // ── The marketing gate — canMarketTo, set-based ──────────────────────────
+  // Same scope rule (campaign scope competes with explicit GLOBAL acts on
+  // recency; null scope = global acts only), same tie-break (occurredAt,
+  // createdAt, id DESC), same channel matching (channel IN ('all', :channel)).
+  // The parity suite in cohortService.test.js is what licenses this SQL.
+  repl.channel = channel;
+  const scopeCond = marketingContext.campaignId
+    ? `(ce."campaignId" = :gateCampaignId OR ce."campaignId" IS NULL)`
+    : `ce."campaignId" IS NULL`;
+  if (marketingContext.campaignId) repl.gateCampaignId = marketingContext.campaignId;
+
+  const withSql = `
+    WITH pop AS (
+      SELECT c.id, c."firstName", c."lastName", c.phone, c.email,
+             c."verifiedSignupCount", c."lastSeenAt",
+             ${inWindowSql} AS in_window,
+             ${minorClaimSql} AS minor_claim,
+             ${dobKnownSql} AS dob_known,
+             ${hasDestSql} AS has_dest
+        FROM consumers c
+       WHERE ${conds.join('\n         AND ')}
+    ),
+    gated AS (
+      SELECT p.*,
+             EXISTS (
+               SELECT 1 FROM consumer_suppressions s
+                WHERE s."consumerId" = p.id AND s.channel IN ('all', :channel)
+             ) AS suppressed,
+             COALESCE(l.granted, false) AS granted,
+             COALESCE(l.verified, false) AS verified
+        FROM pop p
+        LEFT JOIN LATERAL (
+          SELECT ce.granted, ce.verified
+            FROM consent_events ce
+           WHERE ce."consumerId" = p.id AND ce.kind = 'contact'
+             AND ${scopeCond}
+           ORDER BY ce."occurredAt" DESC, ce."createdAt" DESC, ce.id DESC
+           LIMIT 1
+        ) l ON true
+    )`;
+
+  return { withSql, replacements: repl };
+}
+
+/**
+ * campaigns.tags is TEXT under a JS getter — parse it HERE, skipping
+ * malformed rows, so no cohort query ever casts unchecked text to jsonb.
+ * Case-sensitive exact tag match; /facets exposes the live vocabulary.
+ */
+async function resolveTagCampaignIds(d, tags) {
+  const rows = await d.Campaign.findAll({ attributes: ['id', 'tags'], raw: true });
+  const wanted = new Set(tags);
+  const out = [];
+  for (const r of rows) {
+    if (typeof r.tags !== 'string' || !r.tags) continue;
+    let parsed;
+    try { parsed = JSON.parse(r.tags); } catch { continue; }
+    if (Array.isArray(parsed) && parsed.some((t) => typeof t === 'string' && wanted.has(t))) {
+      out.push(r.id);
+    }
+  }
+  return out;
+}
+
+/** Gate scope must reference a real campaign — a preview against a phantom
+ * scope would silently downgrade to "no scoped grants ever match". */
+async function assertGateCampaignExists(d, def) {
+  const id = def.marketingContext.campaignId;
+  if (!id) return;
+  const n = await d.Campaign.count({ where: { id } });
+  if (!n) throw new AppError('marketingContext.campaignId does not reference a campaign', 422);
+}
+
+const REACHABLE_SQL = '(in_window AND NOT minor_claim AND has_dest AND NOT suppressed AND granted AND verified)';
+
+function reasonsForRow(row, channel) {
+  const reasons = [];
+  if (!row.dob_known) reasons.push('age_unknown');
+  else if (row.minor_claim) reasons.push(row.in_window ? 'age_conflict' : 'age_ineligible');
+  else if (!row.in_window) reasons.push('age_ineligible');
+  if (!row.has_dest) reasons.push(channel === 'email' ? 'missing_email' : 'missing_phone');
+  if (row.suppressed) reasons.push('suppressed');
+  if (!row.granted) reasons.push('not_consented');
+  else if (!row.verified) reasons.push('not_verified');
+  return reasons;
+}
+
+const defaultDeps = { sequelize, Cohort, Campaign, logger };
+
+export function makeCohortService(overrides = {}) {
+  const d = { ...defaultDeps, ...overrides };
+
+  /**
+   * Aggregate preview: filter-matched total, reachable, and overlapping
+   * per-reason exclusion counts — one resolution round trip, no member
+   * materialization.
+   */
+  async function previewCohort(definition, { channel } = {}) {
+    const def = normalizeDefinition(definition);
+    const ch = normalizeChannel(channel);
+    await assertGateCampaignExists(d, def);
+    const { withSql, replacements } = await buildResolution(d, def, ch);
+    const [[agg]] = await d.sequelize.query(`${withSql}
+      SELECT count(*)::int AS total,
+             count(*) FILTER (WHERE ${REACHABLE_SQL})::int AS reachable,
+             count(*) FILTER (WHERE NOT dob_known)::int AS age_unknown,
+             count(*) FILTER (WHERE dob_known AND minor_claim AND in_window)::int AS age_conflict,
+             count(*) FILTER (WHERE dob_known AND NOT in_window)::int AS age_ineligible,
+             count(*) FILTER (WHERE NOT has_dest)::int AS missing_dest,
+             count(*) FILTER (WHERE suppressed)::int AS suppressed,
+             count(*) FILTER (WHERE NOT granted)::int AS not_consented,
+             count(*) FILTER (WHERE granted AND NOT verified)::int AS not_verified
+        FROM gated`, { replacements });
+    return {
+      total: agg.total,
+      reachable: agg.reachable,
+      excluded: agg.total - agg.reachable,
+      byReason: {
+        age_unknown: agg.age_unknown,
+        age_conflict: agg.age_conflict,
+        age_ineligible: agg.age_ineligible,
+        missing_email: ch === 'email' ? agg.missing_dest : 0,
+        missing_phone: ch === 'all' || ch === 'email' ? 0 : agg.missing_dest,
+        suppressed: agg.suppressed,
+        not_consented: agg.not_consented,
+        not_verified: agg.not_verified,
+      },
+      gate: {
+        channel: ch,
+        campaignId: def.marketingContext.campaignId,
+        minAge: def.ageGate.minAge,
+        maxAge: def.ageGate.maxAge,
+      },
+      definition: def,
+    };
+  }
+
+  /**
+   * Paged membership with per-person exclusion reasons (the "why is this
+   * person excluded" surface). status: all | reachable | excluded.
+   */
+  async function listCohortMembers(definition, {
+    channel, status = 'all', limit = 50, offset = 0,
+  } = {}) {
+    const def = normalizeDefinition(definition);
+    const ch = normalizeChannel(channel);
+    if (!['all', 'reachable', 'excluded'].includes(status)) {
+      throw new AppError('status must be all, reachable or excluded', 422);
+    }
+    await assertGateCampaignExists(d, def);
+    const lim = Math.min(Math.max(parseInt(limit, 10) || 50, 1), 200);
+    const off = Math.max(parseInt(offset, 10) || 0, 0);
+    const statusCond = status === 'reachable' ? `WHERE ${REACHABLE_SQL}`
+      : status === 'excluded' ? `WHERE NOT ${REACHABLE_SQL}` : '';
+
+    const { withSql, replacements } = await buildResolution(d, def, ch);
+    const [[{ count }]] = await d.sequelize.query(
+      `${withSql} SELECT count(*)::int AS count FROM gated ${statusCond}`,
+      { replacements },
+    );
+    const [rows] = await d.sequelize.query(`${withSql}
+      SELECT *, ${REACHABLE_SQL} AS reachable FROM gated ${statusCond}
+       ORDER BY "lastSeenAt" DESC, id
+       LIMIT :limit OFFSET :offset`,
+      { replacements: { ...replacements, limit: lim, offset: off } });
+
+    return {
+      total: count,
+      limit: lim,
+      offset: off,
+      members: rows.map((r) => ({
+        consumerId: r.id,
+        firstName: r.firstName,
+        lastName: r.lastName,
+        phone: r.phone,
+        email: r.email,
+        verifiedSignupCount: r.verifiedSignupCount,
+        lastSeenAt: r.lastSeenAt,
+        reachable: r.reachable === true,
+        reasons: r.reachable === true ? [] : reasonsForRow(r, ch),
+      })),
+    };
+  }
+
+  /**
+   * Batch canMarketTo over explicit consumer ids — the reusable CONSENT gate
+   * for the Phase-3 push senders. Domain: consumer ids only (no phone
+   * fallback — callers resolving people by phone use the per-person
+   * canMarketTo, which has one). No destination or age logic here, exactly
+   * like canMarketTo. Senders MUST pass the campaign the message is actually
+   * about, re-check per recipient at send time, and DNC-scrub voice/SMS/
+   * WhatsApp sends regardless of consent (§9.5-2).
+   *
+   * Returns Map<consumerId, {ok, reasons[]}>. Fail-closed: unknown ids
+   * report not_found, erased report erased, and any SQL error THROWS —
+   * never act on a partial verdict. Ids are processed in chunks (bounded
+   * statement size); the verdict set is still atomic-in-effect because any
+   * chunk failure aborts the whole call.
+   */
+  async function canMarketToBatch(consumerIds, { channel = 'all', campaignId = null } = {}) {
+    const ch = normalizeChannel(channel);
+    const gateCampaignId = campaignId === null || campaignId === undefined ? null : String(campaignId);
+    if (gateCampaignId !== null && !UUID_RE.test(gateCampaignId)) {
+      throw new AppError('campaignId must be a UUID or null', 422);
+    }
+    const ids = [...new Set((consumerIds || []).map(String))];
+    for (const id of ids) {
+      if (!UUID_RE.test(id)) throw new AppError(`invalid consumer id ${id.slice(0, 40)}`, 422);
+    }
+    const out = new Map();
+    if (!ids.length) return out;
+
+    const scopeCond = gateCampaignId
+      ? `(ce."campaignId" = :gateCampaignId OR ce."campaignId" IS NULL)`
+      : `ce."campaignId" IS NULL`;
+
+    const CHUNK = 5000;
+    for (let i = 0; i < ids.length; i += CHUNK) {
+      const chunk = ids.slice(i, i + CHUNK);
+      const replacements = { ids: chunk, channel: ch };
+      if (gateCampaignId) replacements.gateCampaignId = gateCampaignId;
+      const [rows] = await d.sequelize.query(`
+        SELECT c.id,
+               (c."erasedAt" IS NOT NULL) AS erased,
+               EXISTS (
+                 SELECT 1 FROM consumer_suppressions s
+                  WHERE s."consumerId" = c.id AND s.channel IN ('all', :channel)
+               ) AS suppressed,
+               COALESCE(l.granted, false) AS granted,
+               COALESCE(l.verified, false) AS verified
+          FROM consumers c
+          LEFT JOIN LATERAL (
+            SELECT ce.granted, ce.verified
+              FROM consent_events ce
+             WHERE ce."consumerId" = c.id AND ce.kind = 'contact'
+               AND ${scopeCond}
+             ORDER BY ce."occurredAt" DESC, ce."createdAt" DESC, ce.id DESC
+             LIMIT 1
+          ) l ON true
+         WHERE c.id IN (:ids)`, { replacements });
+      for (const r of rows) {
+        const reasons = [];
+        if (r.erased) reasons.push('erased');
+        if (r.suppressed) reasons.push('suppressed');
+        if (!r.granted) reasons.push('not_consented');
+        else if (!r.verified) reasons.push('not_verified');
+        out.set(r.id, { ok: reasons.length === 0, reasons });
+      }
+    }
+    for (const id of ids) {
+      if (!out.has(id)) out.set(id, { ok: false, reasons: ['not_found'] });
+    }
+    return out;
+  }
+
+  /**
+   * Live filter vocabulary for the cohort UI: the attribute values, campaign
+   * tags and draws that actually exist. Without this, exact-match filters
+   * against display strings ("Degree", "$3,000 - $3,999") silently match
+   * nothing. Spine-linked prospects only — unlinked rows can never join a
+   * cohort anyway.
+   */
+  async function getCohortFacets() {
+    const distinctVals = async (field) => {
+      const [rows] = await d.sequelize.query(`
+        SELECT DISTINCT (p.demographics->>'${field}') AS v
+          FROM prospects p
+         WHERE p."consumerId" IS NOT NULL
+           AND COALESCE(p.demographics->>'${field}', '') <> ''
+         ORDER BY 1 LIMIT 100`);
+      return rows.map((r) => r.v);
+    };
+    const [incomes, educations, genders] = await Promise.all([
+      distinctVals('income'), distinctVals('education'), distinctVals('gender'),
+    ]);
+
+    const campaigns = await d.Campaign.findAll({ attributes: ['id', 'name', 'tags', 'status'], raw: true });
+    const tagSet = new Set();
+    for (const r of campaigns) {
+      if (typeof r.tags !== 'string' || !r.tags) continue;
+      try {
+        const parsed = JSON.parse(r.tags);
+        if (Array.isArray(parsed)) parsed.forEach((t) => { if (typeof t === 'string' && t) tagSet.add(t); });
+      } catch { /* malformed rows contribute nothing */ }
+    }
+
+    const [draws] = await d.sequelize.query(`
+      SELECT dr.id, dr."campaignId", dr.status, dr."closesAt", ca.name AS "campaignName"
+        FROM draws dr LEFT JOIN campaigns ca ON ca.id = dr."campaignId"
+       ORDER BY dr."closesAt" DESC LIMIT 100`);
+
+    return {
+      attributes: { incomes, educations, genders },
+      campaignTags: [...tagSet].sort(),
+      campaigns: campaigns.map((r) => ({ id: r.id, name: r.name, status: r.status })),
+      draws,
+    };
+  }
+
+  /**
+   * Refresh a saved cohort's advisory snapshot columns from a fresh preview.
+   * Best-effort persist (the preview result is returned regardless — the
+   * counts shown are always the freshly computed ones).
+   */
+  async function snapshotCohort(cohort, { channel } = {}) {
+    const preview = await previewCohort(cohort.definition, { channel });
+    try {
+      await cohort.update(snapshotFields(preview));
+    } catch (err) {
+      d.logger.warn('[cohort] snapshot persist failed (non-blocking)', {
+        cohortId: cohort.id, error: err?.message || String(err),
+      });
+    }
+    return preview;
+  }
+
+  return {
+    normalizeDefinition,
+    previewCohort,
+    listCohortMembers,
+    canMarketToBatch,
+    getCohortFacets,
+    snapshotCohort,
+  };
+}
+
+/** Snapshot column values for a preview result (create/update persist these
+ * in the same write as the definition — no half-created rows). */
+export function snapshotFields(preview) {
+  return {
+    lastTotalCount: preview.total,
+    lastReachableCount: preview.reachable,
+    lastPreviewBreakdown: preview.byReason,
+    lastPreviewAt: new Date(),
+  };
+}
+
+const _default = makeCohortService();
+export const previewCohort = _default.previewCohort;
+export const listCohortMembers = _default.listCohortMembers;
+export const canMarketToBatch = _default.canMarketToBatch;
+export const getCohortFacets = _default.getCohortFacets;
+export const snapshotCohort = _default.snapshotCohort;

--- a/backend/test/cohortRoutes.test.js
+++ b/backend/test/cohortRoutes.test.js
@@ -1,0 +1,210 @@
+import request from 'supertest';
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect } from './helpers.js';
+import { Consumer, ConsentEvent, Cohort } from '../src/models/index.js';
+import { hashPhone } from '../src/utils/piiHashing.js';
+
+/**
+ * /api/cohorts API surface (tracker "cohortapi"): admin gating on every
+ * route, CRUD + snapshot lifecycle, preview, members paging, and loud
+ * validation failures (incl. the §9.5-2 minAge floor at the HTTP boundary).
+ */
+
+const RUN = Date.now() % 1000000000;
+let app;
+let adminToken;
+let agentToken;
+let campaign;
+
+beforeAll(async () => {
+  app = await getApp();
+  const admin = await createTestUser({ role: 'admin' });
+  const agent = await createTestUser({ role: 'agent' });
+  adminToken = admin.token;
+  agentToken = agent.token;
+  campaign = await createTestCampaign(admin.user.id, { name: `Cohort Routes ${RUN}` });
+
+  // One reachable person: adult, verified global grant.
+  const phone = `+659${String(RUN).padStart(7, '0').slice(-7)}`;
+  const consumer = await Consumer.create({
+    phone, phoneHash: hashPhone(phone), firstName: 'Route', lastName: 'Fixture',
+    firstSeenAt: new Date(), lastSeenAt: new Date(), signupCount: 1,
+  });
+  await createTestProspect(campaign.id, {
+    phone, consumerId: consumer.id, demographics: { dateOfBirth: '1991-01-01' },
+  });
+  await ConsentEvent.create({
+    consumerId: consumer.id, campaignId: null, kind: 'contact', granted: true,
+    channels: ['phone'], version: 'cohort-routes-v1', source: 'signup',
+    verified: true, occurredAt: new Date(),
+  });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+const auth = (t) => ({ Authorization: `Bearer ${t}` });
+
+describe('auth gating', () => {
+  test('401 without a token, 403 for non-admin, on every route', async () => {
+    const routes = [
+      ['post', '/api/cohorts/preview'],
+      ['get', '/api/cohorts/facets'],
+      ['post', '/api/cohorts'],
+      ['get', '/api/cohorts'],
+      ['get', '/api/cohorts/00000000-0000-4000-8000-000000000000'],
+      ['put', '/api/cohorts/00000000-0000-4000-8000-000000000000'],
+      ['delete', '/api/cohorts/00000000-0000-4000-8000-000000000000'],
+      ['get', '/api/cohorts/00000000-0000-4000-8000-000000000000/members'],
+    ];
+    for (const [method, path] of routes) {
+      const bare = await request(app)[method](path);
+      expect(bare.status).toBe(401);
+      const asAgent = await request(app)[method](path).set(auth(agentToken));
+      expect(asAgent.status).toBe(403);
+    }
+  });
+});
+
+describe('preview', () => {
+  test('returns counts for a definition without saving anything', async () => {
+    const res = await request(app)
+      .post('/api/cohorts/preview')
+      .set(auth(adminToken))
+      .send({ definition: { filters: { campaignIds: [campaign.id] } } });
+    expect(res.status).toBe(200);
+    expect(res.body.data.total).toBe(1);
+    expect(res.body.data.reachable).toBe(1);
+    expect(res.body.data.gate).toMatchObject({ minAge: 18, campaignId: null, channel: 'all' });
+    expect(await Cohort.count()).toBe(0);
+  });
+
+  test('validation: minAge 16 is a 400 at the boundary', async () => {
+    const res = await request(app)
+      .post('/api/cohorts/preview')
+      .set(auth(adminToken))
+      .send({ definition: { ageGate: { minAge: 16 } } });
+    expect(res.status).toBe(400);
+  });
+
+  test('gate scope referencing a phantom campaign is a 422', async () => {
+    const res = await request(app)
+      .post('/api/cohorts/preview')
+      .set(auth(adminToken))
+      .send({ definition: { marketingContext: { campaignId: '00000000-0000-4000-8000-000000000000' } } });
+    expect(res.status).toBe(422);
+  });
+
+  test('facets returns the live vocabulary', async () => {
+    const res = await request(app).get('/api/cohorts/facets').set(auth(adminToken));
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data.attributes.incomes)).toBe(true);
+    expect(Array.isArray(res.body.data.campaigns)).toBe(true);
+  });
+
+  test('validation: unknown keys and bad uuids fail loudly', async () => {
+    const unknown = await request(app)
+      .post('/api/cohorts/preview')
+      .set(auth(adminToken))
+      .send({ definition: { filters: { campaignIds: [campaign.id] } }, surprise: true });
+    expect(unknown.status).toBe(400);
+    const badUuid = await request(app)
+      .post('/api/cohorts/preview')
+      .set(auth(adminToken))
+      .send({ definition: { filters: { campaignIds: ['nope'] } } });
+    expect(badUuid.status).toBe(400);
+  });
+});
+
+describe('CRUD lifecycle', () => {
+  let cohortId;
+
+  test('create stores the canonical definition and snapshots counts', async () => {
+    const res = await request(app)
+      .post('/api/cohorts')
+      .set(auth(adminToken))
+      .send({
+        name: `Everyone ${RUN}`,
+        description: 'route test cohort',
+        definition: { filters: { campaignIds: [campaign.id, campaign.id] } },
+      });
+    expect(res.status).toBe(201);
+    cohortId = res.body.data.id;
+    expect(res.body.data.definition.filters.campaignIds).toEqual([campaign.id]); // deduped
+    expect(res.body.data.definition.ageGate).toEqual({ minAge: 18, maxAge: null }); // defaulted
+    expect(res.body.data.lastTotalCount).toBe(1);
+    expect(res.body.data.lastReachableCount).toBe(1);
+    expect(res.body.data.preview.byReason).toBeDefined();
+  });
+
+  test('list shows it; get returns it; refresh recomputes', async () => {
+    const list = await request(app).get('/api/cohorts').set(auth(adminToken));
+    expect(list.status).toBe(200);
+    expect(list.body.data.map((c) => c.id)).toContain(cohortId);
+
+    const get = await request(app).get(`/api/cohorts/${cohortId}`).set(auth(adminToken));
+    expect(get.status).toBe(200);
+    expect(get.body.data.preview).toBeUndefined();
+
+    const refreshed = await request(app).get(`/api/cohorts/${cohortId}?refresh=1`).set(auth(adminToken));
+    expect(refreshed.status).toBe(200);
+    expect(refreshed.body.data.preview.total).toBe(1);
+  });
+
+  test('members returns the resolved split for the saved cohort', async () => {
+    const res = await request(app)
+      .get(`/api/cohorts/${cohortId}/members?status=reachable&limit=10`)
+      .set(auth(adminToken));
+    expect(res.status).toBe(200);
+    expect(res.body.data.total).toBe(1);
+    expect(res.body.data.members[0].reachable).toBe(true);
+    expect(res.body.data.members[0].reasons).toEqual([]);
+
+    const bad = await request(app)
+      .get(`/api/cohorts/${cohortId}/members?status=weird`)
+      .set(auth(adminToken));
+    expect(bad.status).toBe(422);
+  });
+
+  test('update re-normalizes and re-snapshots when the definition changes', async () => {
+    const res = await request(app)
+      .put(`/api/cohorts/${cohortId}`)
+      .set(auth(adminToken))
+      .send({ definition: { filters: { campaignIds: [campaign.id] }, ageGate: { minAge: 21 } } });
+    expect(res.status).toBe(200);
+    expect(res.body.data.definition.ageGate.minAge).toBe(21);
+    expect(res.body.data.preview.total).toBe(1);
+
+    const nameOnly = await request(app)
+      .put(`/api/cohorts/${cohortId}`)
+      .set(auth(adminToken))
+      .send({ name: `Renamed ${RUN}` });
+    expect(nameOnly.status).toBe(200);
+    expect(nameOnly.body.data.name).toBe(`Renamed ${RUN}`);
+    expect(nameOnly.body.data.preview).toBeUndefined();
+  });
+
+  test('update with a 17+ definition is rejected at the boundary', async () => {
+    const res = await request(app)
+      .put(`/api/cohorts/${cohortId}`)
+      .set(auth(adminToken))
+      .send({ definition: { ageGate: { minAge: 17 } } });
+    expect(res.status).toBe(400);
+  });
+
+  test('archive hides from list and 404s thereafter', async () => {
+    const del = await request(app).delete(`/api/cohorts/${cohortId}`).set(auth(adminToken));
+    expect(del.status).toBe(200);
+    const list = await request(app).get('/api/cohorts').set(auth(adminToken));
+    expect(list.body.data.map((c) => c.id)).not.toContain(cohortId);
+    const get = await request(app).get(`/api/cohorts/${cohortId}`).set(auth(adminToken));
+    expect(get.status).toBe(404);
+    const again = await request(app).delete(`/api/cohorts/${cohortId}`).set(auth(adminToken));
+    expect(again.status).toBe(404);
+  });
+
+  test('malformed ids 404 cleanly, never 500', async () => {
+    const res = await request(app).get('/api/cohorts/not-a-uuid').set(auth(adminToken));
+    expect(res.status).toBe(404);
+  });
+});

--- a/backend/test/cohortService.test.js
+++ b/backend/test/cohortService.test.js
@@ -1,0 +1,486 @@
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect } from './helpers.js';
+import {
+  Consumer, ConsentEvent, ConsumerSuppression, Draw, DrawEntry,
+} from '../src/models/index.js';
+import {
+  previewCohort, listCohortMembers, canMarketToBatch, getCohortFacets, normalizeDefinition,
+} from '../src/services/cohortService.js';
+import { canMarketTo } from '../src/services/consentService.js';
+import { hashPhone } from '../src/utils/piiHashing.js';
+
+/**
+ * Cohort builder semantics (tracker "cohortapi",
+ * docs/plans/cohort-builder-backend.md) on real Postgres: filter resolution,
+ * the binding 18+ age gate (real-calendar dob validation, under-18 claims
+ * disqualify outright), destination checks, the reachable/excluded split —
+ * and the PARITY suite proving canMarketToBatch === consentService.canMarketTo
+ * per person, including forced timestamp ties down to the uuid tie-break.
+ * That parity is what licenses the batch SQL to exist; if canMarketTo's
+ * semantics change, this file is what breaks.
+ */
+
+const RUN = Date.now() % 1000000000;
+let seq = 0;
+const nextPhone = () => `+658${String(RUN + (seq += 1)).padStart(7, '0').slice(-7)}`;
+
+const T0 = new Date('2026-06-01T00:00:00Z');
+const T1 = new Date('2026-06-02T00:00:00Z');
+const T2 = new Date('2026-06-03T00:00:00Z');
+
+const ADULT_DOB = '1990-05-12';   // 36 in Jul 2026
+const YOUNG_DOB = '2000-01-15';   // 26 in Jul 2026
+const MINOR_DOB = '2015-03-01';   // 11 in Jul 2026
+const IMPOSSIBLE_DOB = '2000-02-30'; // shape-valid, not a real calendar date
+
+let admin;
+let campA; let campB; let campC;
+let draw1;
+const C = {}; // fixture consumers by key
+
+async function makeConsumer(key, { phone = nextPhone(), erased = false, ...rest } = {}) {
+  const consumer = await Consumer.create({
+    phone: erased ? null : phone,
+    phoneHash: erased ? null : hashPhone(phone),
+    firstName: key,
+    lastName: 'Cohort',
+    firstSeenAt: T0,
+    lastSeenAt: T0,
+    signupCount: 1,
+    erasedAt: erased ? T1 : null,
+    ...rest,
+  });
+  consumer._phone = phone;
+  C[key] = consumer;
+  return consumer;
+}
+
+async function signup(consumer, campaign, { dob = ADULT_DOB, demographics = {}, location = {}, phone } = {}) {
+  return createTestProspect(campaign.id, {
+    firstName: consumer.firstName,
+    phone: phone || consumer._phone,
+    consumerId: consumer.id,
+    demographics: dob === null ? { ...demographics } : { dateOfBirth: dob, ...demographics },
+    location,
+  });
+}
+
+async function consent(consumer, {
+  campaignId = null, granted = true, verified = true, occurredAt = T1, createdAt, id,
+} = {}) {
+  return ConsentEvent.create({
+    ...(id ? { id } : {}),
+    consumerId: consumer.id,
+    campaignId,
+    kind: 'contact',
+    granted,
+    channels: ['phone', 'whatsapp', 'email'],
+    version: 'cohort-test-v1',
+    source: 'signup',
+    verified,
+    occurredAt,
+    ...(createdAt ? { createdAt } : {}),
+  });
+}
+
+beforeAll(async () => {
+  await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  campA = await createTestCampaign(admin.user.id, { name: `Cohort A ${RUN}`, tags: ['parenting', 'family'] });
+  campB = await createTestCampaign(admin.user.id, { name: `Cohort B ${RUN}`, tags: ['home'] });
+  campC = await createTestCampaign(admin.user.id, { name: `Cohort C ${RUN}` });
+
+  // ALICE — adult, campA, verified GLOBAL grant, HAS an email → reachable
+  // everywhere including the email channel.
+  await makeConsumer('ALICE', { email: `alice-${RUN}@cohort.test` });
+  await signup(C.ALICE, campA);
+  await consent(C.ALICE, { campaignId: null });
+
+  // BOB — adult, campA, verified grant SCOPED to campA only (legacy era)
+  // → reachable only when the gate asks about campA.
+  await makeConsumer('BOB');
+  await signup(C.BOB, campA);
+  await consent(C.BOB, { campaignId: campA.id });
+
+  // CARA — adult, campB, verified global grant + channel-'all' suppression.
+  await makeConsumer('CARA');
+  await signup(C.CARA, campB);
+  await consent(C.CARA, { campaignId: null });
+  await ConsumerSuppression.create({ consumerId: C.CARA.id, channel: 'all', reason: 'unsubscribe' });
+
+  // DAN — adult, campA, global grant but UNVERIFIED.
+  await makeConsumer('DAN');
+  await signup(C.DAN, campA);
+  await consent(C.DAN, { campaignId: null, verified: false });
+
+  // ERIN — adult, campA, no consent events at all.
+  await makeConsumer('ERIN');
+  await signup(C.ERIN, campA);
+
+  // FAY — minor, campA, verified global grant.
+  await makeConsumer('FAY');
+  await signup(C.FAY, campA, { dob: MINOR_DOB });
+  await consent(C.FAY, { campaignId: null });
+
+  // GUS — no dob anywhere, campA, verified global grant.
+  await makeConsumer('GUS');
+  await signup(C.GUS, campA, { dob: null });
+  await consent(C.GUS, { campaignId: null });
+
+  // HANK — adult (26), campB, income + postal attributes, verified global grant.
+  await makeConsumer('HANK');
+  await signup(C.HANK, campB, {
+    dob: YOUNG_DOB,
+    demographics: { income: '$3,000 - $4,999', education: 'Degree', gender: 'male' },
+    location: { postalCode: '520123' },
+  });
+  await consent(C.HANK, { campaignId: null });
+
+  // IVY — adult, campA, global grant then LATER global revoke (latest wins).
+  await makeConsumer('IVY');
+  await signup(C.IVY, campA);
+  await consent(C.IVY, { campaignId: null, occurredAt: T1 });
+  await consent(C.IVY, { campaignId: null, granted: false, occurredAt: T2 });
+
+  // JOE — adult, campA, draw entry linked via prospectId, verified global grant.
+  await makeConsumer('JOE');
+  const joeProspect = await signup(C.JOE, campA);
+  await consent(C.JOE, { campaignId: null });
+  draw1 = await Draw.create({ campaignId: campA.id, closesAt: new Date('2026-10-30T00:00:00Z'), createdBy: admin.user.id });
+  await DrawEntry.create({ drawId: draw1.id, prospectId: joeProspect.id, phoneHash: hashPhone(C.JOE._phone), phoneLast4: C.JOE._phone.slice(-4), chances: 1 });
+
+  // KIM — adult (dob via her campB signup), draw entry with prospectId NULL
+  // — membership must resolve through the phoneHash fallback branch.
+  await makeConsumer('KIM');
+  await signup(C.KIM, campB);
+  await consent(C.KIM, { campaignId: null });
+  await DrawEntry.create({ drawId: draw1.id, prospectId: null, phoneHash: hashPhone(C.KIM._phone), phoneLast4: C.KIM._phone.slice(-4), chances: 1 });
+
+  // An ERASED person's entry: hash rewritten to the all-zeros sentinel
+  // (erasureService) — must match nobody, ever.
+  await DrawEntry.create({ drawId: draw1.id, prospectId: null, phoneHash: '0'.repeat(64), phoneLast4: null, chances: 1 });
+
+  // LEO — adult, campA, verified global grant, suppressed on EMAIL only —
+  // passes a channel-'all' gate (isSuppressed semantics), fails 'email'.
+  await makeConsumer('LEO');
+  await signup(C.LEO, campA);
+  await consent(C.LEO, { campaignId: null });
+  await ConsumerSuppression.create({ consumerId: C.LEO.id, channel: 'email', reason: 'unsubscribe' });
+
+  // MAX — ERASED person with a campA signup: must never appear in any cohort.
+  await makeConsumer('MAX', { erased: true });
+  await signup(C.MAX, campA, { phone: null });
+
+  // NED — CONFLICTING dobs (adult on campA, under-18 on campB) + verified
+  // global grant. The under-18 claim disqualifies him outright (§9.5-2
+  // fail-closed): reachable NOWHERE, reason age_conflict.
+  await makeConsumer('NED');
+  await signup(C.NED, campA, { dob: '1980-01-01' });
+  await signup(C.NED, campB, { dob: '2012-01-01' });
+  await consent(C.NED, { campaignId: null });
+
+  // OTT — two ADULT dobs (a typo'd year, both ≥ 18) on campC: benign
+  // multi-dob must NOT be treated as a conflict.
+  await makeConsumer('OTT');
+  await signup(C.OTT, campC, { dob: '1985-04-01' });
+  // Second signup carries a different entered phone (unique (campaignId,
+  // phone) index) — the consumerId link is what makes it his.
+  await signup(C.OTT, campC, { dob: '1986-04-01', phone: nextPhone() });
+  await consent(C.OTT, { campaignId: null });
+
+  // PIA — shape-valid but IMPOSSIBLE calendar dob on campC: fails closed as
+  // age_unknown (and must not abort the query).
+  await makeConsumer('PIA');
+  await signup(C.PIA, campC, { dob: IMPOSSIBLE_DOB });
+  await consent(C.PIA, { campaignId: null });
+
+  // TIA — occurredAt TIE, createdAt decides: the later-created grant wins.
+  await makeConsumer('TIA');
+  await signup(C.TIA, campC);
+  await consent(C.TIA, { campaignId: null, granted: false, occurredAt: T2, createdAt: T0 });
+  await consent(C.TIA, { campaignId: null, granted: true, occurredAt: T2, createdAt: T1 });
+
+  // UMA — occurredAt AND createdAt tie, uuid decides (id DESC): the high-id
+  // DENIAL wins over the low-id grant.
+  await makeConsumer('UMA');
+  await signup(C.UMA, campC);
+  await consent(C.UMA, {
+    campaignId: null, granted: true, occurredAt: T2, createdAt: T2,
+    id: '00000000-0000-4000-8000-0000000000aa',
+  });
+  await consent(C.UMA, {
+    campaignId: null, granted: false, occurredAt: T2, createdAt: T2,
+    id: 'ffffffff-ffff-4fff-8fff-ffffffffffff',
+  });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+const ids = (members) => members.map((m) => m.consumerId).sort();
+const idOf = (...keys) => keys.map((k) => C[k].id).sort();
+
+async function memberIds(definition, opts = {}) {
+  const { members } = await listCohortMembers(definition, { limit: 200, ...opts });
+  return ids(members);
+}
+
+describe('filter resolution', () => {
+  test('campaignIds: OR within the list, restricted to those signups', async () => {
+    const got = await memberIds({ filters: { campaignIds: [campA.id] } });
+    expect(got).toEqual(idOf('ALICE', 'BOB', 'DAN', 'ERIN', 'FAY', 'GUS', 'IVY', 'JOE', 'LEO', 'NED'));
+    const both = await memberIds({ filters: { campaignIds: [campA.id, campB.id] } });
+    expect(both).toEqual(idOf('ALICE', 'BOB', 'CARA', 'DAN', 'ERIN', 'FAY', 'GUS', 'HANK', 'IVY', 'JOE', 'KIM', 'LEO', 'NED'));
+  });
+
+  test('erased consumers never appear, even with a matching signup', async () => {
+    const got = await memberIds({ filters: { campaignIds: [campA.id] } });
+    expect(got).not.toContain(C.MAX.id);
+    const batch = await canMarketToBatch([C.MAX.id]);
+    expect(batch.get(C.MAX.id)).toEqual({ ok: false, reasons: ['erased', 'not_consented'] });
+  });
+
+  test('drawIds: via prospect link AND via phoneHash fallback; zero-sentinel matches nobody', async () => {
+    const got = await memberIds({ filters: { drawIds: [draw1.id] } });
+    expect(got).toEqual(idOf('JOE', 'KIM'));
+  });
+
+  test('anyDraw behaves like draw membership without the id restriction', async () => {
+    const got = await memberIds({ filters: { anyDraw: true } });
+    expect(got).toEqual(idOf('JOE', 'KIM'));
+  });
+
+  test('campaignTags: matches signups whose campaign carries ANY listed tag', async () => {
+    const parenting = await memberIds({ filters: { campaignTags: ['parenting'] } });
+    expect(parenting).toEqual(idOf('ALICE', 'BOB', 'DAN', 'ERIN', 'FAY', 'GUS', 'IVY', 'JOE', 'LEO', 'NED'));
+    const home = await memberIds({ filters: { campaignTags: ['home', 'nope'] } });
+    expect(home).toEqual(idOf('CARA', 'HANK', 'KIM', 'NED'));
+    const none = await memberIds({ filters: { campaignTags: ['nonexistent'] } });
+    expect(none).toEqual([]);
+  });
+
+  test('attributes: postal prefix and income, independent EXISTS per list, AND across', async () => {
+    expect(await memberIds({ filters: { attributes: { postalPrefixes: ['52'] } } })).toEqual(idOf('HANK'));
+    expect(await memberIds({ filters: { attributes: { incomes: ['$3,000 - $4,999'] } } })).toEqual(idOf('HANK'));
+    expect(await memberIds({ filters: { attributes: { postalPrefixes: ['99'] } } })).toEqual([]);
+    expect(await memberIds({
+      filters: { campaignIds: [campB.id], attributes: { incomes: ['$3,000 - $4,999'] } },
+    })).toEqual(idOf('HANK'));
+    expect(await memberIds({
+      filters: { campaignIds: [campA.id], attributes: { incomes: ['$3,000 - $4,999'] } },
+    })).toEqual([]);
+  });
+});
+
+describe('age gate (§9.5-2, binding)', () => {
+  test('defaults to 18+; separates under-age, unknown, conflict', async () => {
+    const preview = await previewCohort({ filters: { campaignIds: [campA.id] } });
+    expect(preview.gate.minAge).toBe(18);
+    const { members } = await listCohortMembers({ filters: { campaignIds: [campA.id] } }, { status: 'excluded', limit: 200 });
+    const by = Object.fromEntries(members.map((m) => [m.consumerId, m.reasons]));
+    expect(by[C.FAY.id]).toContain('age_ineligible');
+    expect(by[C.GUS.id]).toContain('age_unknown');
+    expect(by[C.NED.id]).toContain('age_conflict'); // adult dob + under-18 dob → disqualified outright
+  });
+
+  test('an impossible calendar dob fails closed as age_unknown', async () => {
+    const { members } = await listCohortMembers(
+      { filters: { campaignIds: [campC.id] } }, { status: 'excluded', limit: 200 },
+    );
+    const pia = members.find((m) => m.consumerId === C.PIA.id);
+    expect(pia.reasons).toEqual(['age_unknown']);
+  });
+
+  test('benign multi-dob (both adult) is NOT a conflict', async () => {
+    const { members } = await listCohortMembers(
+      { filters: { campaignIds: [campC.id] } }, { status: 'reachable', limit: 200 },
+    );
+    expect(ids(members)).toContain(C.OTT.id);
+  });
+
+  test('minAge below 18 is rejected outright', () => {
+    expect(() => normalizeDefinition({ ageGate: { minAge: 16 } }))
+      .toThrow(/§9.5-2|not permitted/);
+  });
+
+  test('maxAge window: min AND max must hold on the SAME dob', async () => {
+    // [18,30]: HANK (26) passes; ALICE (36) out; NED's two dobs (46 & 14)
+    // must NOT combine to fake a pass.
+    const got = await memberIds({ filters: {}, ageGate: { minAge: 18, maxAge: 30 } });
+    expect(got).toContain(C.HANK.id);
+    const { members } = await listCohortMembers(
+      { filters: {}, ageGate: { minAge: 18, maxAge: 30 } }, { status: 'excluded', limit: 200 },
+    );
+    const by = Object.fromEntries(members.map((m) => [m.consumerId, m.reasons]));
+    expect(by[C.NED.id]).toContain('age_ineligible');
+    expect(by[C.ALICE.id]).toContain('age_ineligible');
+  });
+});
+
+describe('reachability split (the batch canMarketTo + practical checks)', () => {
+  test('reachable = consented ∧ verified ∧ ¬suppressed ∧ adult ∧ has destination', async () => {
+    const { members } = await listCohortMembers(
+      { filters: { campaignIds: [campA.id] } }, { status: 'reachable', limit: 200 },
+    );
+    expect(ids(members)).toEqual(idOf('ALICE', 'JOE', 'LEO'));
+    for (const m of members) expect(m.reasons).toEqual([]);
+  });
+
+  test('exclusion reasons name each failing condition', async () => {
+    const { members } = await listCohortMembers(
+      { filters: { campaignIds: [campA.id] } }, { status: 'excluded', limit: 200 },
+    );
+    const by = Object.fromEntries(members.map((m) => [m.consumerId, m.reasons]));
+    expect(by[C.BOB.id]).toEqual(['not_consented']);      // scoped grant ≠ global basis
+    expect(by[C.DAN.id]).toEqual(['not_verified']);
+    expect(by[C.ERIN.id]).toEqual(['not_consented']);
+    expect(by[C.IVY.id]).toEqual(['not_consented']);      // later global revoke wins
+    expect(by[C.FAY.id]).toEqual(['age_ineligible']);
+    expect(by[C.GUS.id]).toEqual(['age_unknown']);
+    expect(by[C.NED.id]).toEqual(['age_conflict']);
+  });
+
+  test('marketingContext.campaignId re-scopes the gate: legacy scoped grants count for THAT campaign', async () => {
+    const scoped = await listCohortMembers(
+      { filters: { campaignIds: [campA.id] }, marketingContext: { campaignId: campA.id } },
+      { status: 'reachable', limit: 200 },
+    );
+    expect(ids(scoped.members)).toEqual(idOf('ALICE', 'BOB', 'JOE', 'LEO'));
+  });
+
+  test('gate scope must reference a real campaign', async () => {
+    await expect(previewCohort({
+      filters: {}, marketingContext: { campaignId: '00000000-0000-4000-8000-000000000000' },
+    })).rejects.toMatchObject({ statusCode: 422 });
+  });
+
+  test('channel email: destination required AND email suppression bites', async () => {
+    const email = await listCohortMembers(
+      { filters: { campaignIds: [campA.id] } }, { status: 'reachable', channel: 'email', limit: 200 },
+    );
+    expect(ids(email.members)).toEqual(idOf('ALICE')); // only ALICE has an email
+    const excluded = await listCohortMembers(
+      { filters: { campaignIds: [campA.id] } }, { status: 'excluded', channel: 'email', limit: 200 },
+    );
+    const by = Object.fromEntries(excluded.members.map((m) => [m.consumerId, m.reasons]));
+    expect(by[C.JOE.id]).toEqual(['missing_email']);
+    expect(by[C.LEO.id]).toEqual(expect.arrayContaining(['missing_email', 'suppressed']));
+  });
+
+  test('channel whatsapp: phone destination, email-only suppression does not bite', async () => {
+    const wa = await listCohortMembers(
+      { filters: { campaignIds: [campA.id] } }, { status: 'reachable', channel: 'whatsapp', limit: 200 },
+    );
+    expect(ids(wa.members)).toEqual(idOf('ALICE', 'JOE', 'LEO'));
+  });
+
+  test('CARA (all-channel suppression) excluded with reason suppressed', async () => {
+    const { members } = await listCohortMembers(
+      { filters: { campaignIds: [campB.id] } }, { status: 'excluded', limit: 200 },
+    );
+    const cara = members.find((m) => m.consumerId === C.CARA.id);
+    expect(cara.reasons).toEqual(['suppressed']);
+  });
+});
+
+describe('preview aggregates', () => {
+  test('counts line up with the member split', async () => {
+    const def = { filters: { campaignIds: [campA.id] } };
+    const preview = await previewCohort(def);
+    expect(preview.total).toBe(10);
+    expect(preview.reachable).toBe(3);           // ALICE, JOE, LEO
+    expect(preview.excluded).toBe(7);
+    expect(preview.byReason).toEqual({
+      age_unknown: 1,        // GUS
+      age_conflict: 1,       // NED
+      age_ineligible: 1,     // FAY
+      missing_email: 0,
+      missing_phone: 0,
+      suppressed: 0,
+      not_consented: 3,      // BOB, ERIN, IVY
+      not_verified: 1,       // DAN
+    });
+  });
+
+  test('email-channel preview reports missing_email', async () => {
+    const preview = await previewCohort({ filters: { campaignIds: [campA.id] } }, { channel: 'email' });
+    expect(preview.reachable).toBe(1);            // ALICE
+    expect(preview.byReason.missing_email).toBe(9); // everyone else has no email
+  });
+});
+
+describe('canMarketToBatch — the exported consent gate', () => {
+  test('unknown ids are fail-closed not_found; empty input is an empty map', async () => {
+    const ghost = '00000000-0000-4000-8000-000000000000';
+    const map = await canMarketToBatch([ghost, C.ALICE.id]);
+    expect(map.get(ghost)).toEqual({ ok: false, reasons: ['not_found'] });
+    expect(map.get(C.ALICE.id)).toEqual({ ok: true, reasons: [] });
+    expect((await canMarketToBatch([])).size).toBe(0);
+  });
+
+  test('forced ties: createdAt breaks an occurredAt tie; uuid breaks a full tie', async () => {
+    const map = await canMarketToBatch([C.TIA.id, C.UMA.id]);
+    expect(map.get(C.TIA.id).ok).toBe(true);   // later-created grant wins
+    expect(map.get(C.UMA.id)).toEqual({ ok: false, reasons: ['not_consented'] }); // high-id denial wins
+  });
+
+  test('PARITY: batch verdict === consentService.canMarketTo for every fixture × every scope × every channel', async () => {
+    const keys = Object.keys(C);
+    const consumerIds = keys.map((k) => C[k].id);
+    for (const campaignId of [null, campA.id, campB.id]) {
+      for (const channel of ['all', 'email', 'whatsapp', 'sms', 'voice']) {
+        const batch = await canMarketToBatch(consumerIds, { channel, campaignId });
+        for (const key of keys) {
+          const single = await canMarketTo({ consumerId: C[key].id, channel, campaignId });
+          expect({ key, campaignId, channel, ok: batch.get(C[key].id).ok })
+            .toEqual({ key, campaignId, channel, ok: single });
+        }
+      }
+    }
+  });
+});
+
+describe('members paging', () => {
+  test('limit/offset walk the same ordered set', async () => {
+    const def = { filters: { campaignIds: [campA.id, campB.id] } };
+    const all = await listCohortMembers(def, { limit: 200 });
+    expect(all.total).toBe(13);
+    const page1 = await listCohortMembers(def, { limit: 5, offset: 0 });
+    const page2 = await listCohortMembers(def, { limit: 5, offset: 5 });
+    const page3 = await listCohortMembers(def, { limit: 5, offset: 10 });
+    const walked = [...page1.members, ...page2.members, ...page3.members].map((m) => m.consumerId);
+    expect(walked).toEqual(all.members.map((m) => m.consumerId));
+    expect(page1.total).toBe(13);
+  });
+});
+
+describe('facets', () => {
+  test('exposes the live vocabulary (attribute values, tags, draws)', async () => {
+    const facets = await getCohortFacets();
+    expect(facets.attributes.incomes).toContain('$3,000 - $4,999');
+    expect(facets.attributes.educations).toContain('Degree');
+    expect(facets.campaignTags).toEqual(expect.arrayContaining(['parenting', 'family', 'home']));
+    expect(facets.draws.map((d) => d.id)).toContain(draw1.id);
+    expect(facets.campaigns.map((c) => c.id)).toEqual(expect.arrayContaining([campA.id, campB.id, campC.id]));
+  });
+});
+
+describe('definition hygiene', () => {
+  test('normalize dedupes, trims and canonicalizes', () => {
+    const def = normalizeDefinition({
+      filters: { campaignIds: [campA.id, campA.id], campaignTags: [' parenting ', 'parenting'] },
+    });
+    expect(def.filters.campaignIds).toEqual([campA.id]);
+    expect(def.filters.campaignTags).toEqual(['parenting']);
+    expect(def.ageGate).toEqual({ minAge: 18, maxAge: null });
+    expect(def.marketingContext).toEqual({ campaignId: null });
+  });
+
+  test('garbage shapes are rejected, not coerced', () => {
+    expect(() => normalizeDefinition({ filters: { campaignIds: ['not-a-uuid'] } })).toThrow(/invalid/);
+    expect(() => normalizeDefinition({ filters: 'nope' })).toThrow(/filters/);
+    expect(() => normalizeDefinition({ ageGate: { minAge: 21.5 } })).toThrow(/integer/);
+    expect(() => normalizeDefinition({ marketingContext: { campaignId: 'x' } })).toThrow(/UUID/);
+    expect(() => normalizeDefinition({ filters: { attributes: { postalPrefixes: ['52%'] } } })).toThrow(/invalid/);
+  });
+});

--- a/docs/plans/cohort-builder-backend.md
+++ b/docs/plans/cohort-builder-backend.md
@@ -1,0 +1,273 @@
+# Cohort Builder Backend (tracker "cohortapi")
+
+Ships with this PR — the core of data-powerhouse activation (Phase 3): define
+a group of people by what they did, and let the system keep only those we are
+ALLOWED to message. Every future push (emailpush / wapush) starts from one of
+these cohorts.
+
+Design constraint from the consent work: `canMarketTo` (consentService) is THE
+marketing gate. This PR gives it its first batch caller without forking its
+semantics — the batch SQL is proven equivalent by a parity suite that runs
+both implementations over the same fixtures, including forced timestamp ties
+down to the uuid tie-break. Reviewed by Codex (gpt-5.6-sol xhigh) pre-merge;
+§10 records the disposition of all 14 findings.
+
+## 1. What this builds on
+
+- `consumers` — the person spine (phone-keyed, `erasedAt` for PR-C erasure).
+- `consent_events` — append-only ledger; current state = latest event per
+  (kind, campaignId-or-global) with tie-break `occurredAt DESC, createdAt
+  DESC, id DESC` (consentService.getConsentState).
+- `consumer_suppressions` — exit door; channel `all|email|whatsapp|sms|voice`;
+  reason `erasure` blocks everything, others block marketing.
+- `canMarketTo({consumerId, phone, channel, campaignId})` — per-person gate:
+  resolve consumer → not erased → not suppressed (marketing purpose: ANY row
+  matching `channel IN ('all', :channel)`) → latest in-scope contact event
+  granted ∧ verified. Scope: campaignId given ⇒ that campaign's events and
+  global events compete on recency; campaignId null ⇒ ONLY global events
+  count.
+- `prospects` — one row per campaign signup; `consumerId` FK (indexed);
+  `demographics` JSON ({dateOfBirth 'YYYY-MM-DD', income, education,
+  gender…}), `location` JSON ({postalCode…}). Values are stored verbatim as
+  the funnel collected them (display strings like "Degree", "$3,000 -
+  $4,999") — hence the /facets endpoint (§6).
+- `draw_entries` — drawId + prospectId (nullable) + phoneHash. On PDPA
+  erasure the hash is REWRITTEN to an all-zeros sentinel and the consumer's
+  own hash is nulled (erasureService) — erased people cannot re-enter a
+  cohort through a draw. The phoneHash fallback branch exists for entries
+  whose prospect was HARD-DELETED while the person still stands.
+- `campaigns.tags` — TEXT holding a JSON array under a JS getter/setter, with
+  no DB-level JSON constraint. Tracker item "taxonomy" populates it; the
+  filter ships ready.
+
+NOT built yet (tracker "rollup"): person-level attribute projection. The
+attribute filters therefore resolve against prospect-level data via EXISTS —
+documented as the interface that "rollup" later re-points at consumer
+attributes without changing the API shape.
+
+## 2. Data model — migration 084 + Cohort model
+
+`cohorts`: id, name(120), description, `definition` JSONB, createdBy →
+users (SET NULL), advisory snapshot columns (`lastTotalCount`,
+`lastReachableCount`, `lastPreviewBreakdown`, `lastPreviewAt`), `archivedAt`,
+timestamps. Indexes: `(archivedAt, createdAt DESC)` for the list view;
+migration also adds `draw_entries("phoneHash")` and partial
+`draw_entries("prospectId")` for the two draw-filter branches
+(`uq_de_draw_prospect` leads on drawId and cannot serve a bare prospectId
+probe). All guarded/idempotent like 080; models mirror every index because
+test boot builds schema via `sync({force:true})`.
+
+Soft-archive only, never hard-delete. Cohort rows are MUTABLE definitions —
+they are NOT an audit record: when the push senders land, each send log MUST
+snapshot the normalized definition, gate context, channel and counts it
+resolved with (Codex #10). Create/update resolve the preview FIRST and
+persist definition + snapshot in one write — a failing resolution leaves no
+half-created row.
+
+## 3. Cohort definition (the API contract)
+
+```jsonc
+{
+  "filters": {
+    "campaignIds":   ["uuid", …],      // signed up for ANY of these (max 50)
+    "drawIds":       ["uuid", …],      // entered ANY of these draws (max 50)
+    "anyDraw":       true,             // entered at least one draw
+    "campaignTags":  ["parenting", …], // signed up for any campaign carrying ANY of these tags (max 20)
+    "attributes": {                    // person attributes, values per /facets
+      "postalPrefixes": ["52", "53"],  // location.postalCode starts with any (digits only, max 20)
+      "incomes":     ["$3,000 - $4,999", …],
+      "educations":  ["Degree", …],
+      "genders":     ["female", …]
+    }
+  },
+  "ageGate": { "minAge": 18, "maxAge": null },   // §9.5-2: 18 is a FLOOR — minAge < 18 is rejected
+  "marketingContext": { "campaignId": null }     // consent-gate scope, must reference a real campaign; see §5
+}
+```
+
+Combination semantics:
+- ACROSS filter keys: AND. WITHIN a list: OR / ANY.
+- Each attribute list is its own independent EXISTS over the person's signups
+  — income may come from one signup and postal from another; both are facts
+  about the person (matching what "rollup" will later materialize).
+- Empty/absent `filters` ⇒ all consumers; the gate still applies.
+- Route-level Joi gives loud 400s (no stripUnknown — internal admin route);
+  the BINDING validation lives in `cohortService.normalizeDefinition`, which
+  re-checks definitions loaded back out of the DB. Values are deduped,
+  trimmed, length- and shape-checked; postalPrefixes are digits-only so LIKE
+  metacharacters cannot exist, and patterns are built server-side.
+
+## 4. Resolution pipeline
+
+All SQL uses Sequelize `:replacements` (never string interpolation). The
+jsonb `?`/`?|` operators are avoided (Sequelize positional-placeholder
+collision) — and `campaigns.tags` is never cast to jsonb at all: it is
+unchecked TEXT, and one malformed row would abort the whole query (Codex #9).
+Tag filters resolve campaign ids in JS (malformed rows skipped) and the SQL
+sees only a plain `campaignId IN` list.
+
+### 4.1 Population (filters, pre-gate)
+
+`consumers c WHERE c."erasedAt" IS NULL` AND, per requested filter, an
+EXISTS subquery: prospects by campaignId; draw membership as TWO
+independently-indexed branches (prospect-link join OR phoneHash equality);
+tag-resolved campaign ids; postal `LIKE ANY ((ARRAY[:patterns])::text[])`
+over `COALESCE(location->>'postalCode', location->>'zipCode')`; demographic
+exact-IN per attribute list.
+
+### 4.2 Age gate (§9.5-2, binding — always on)
+
+dob is a 'YYYY-MM-DD' string in prospects.demographics. Nothing is ever cast
+to `date`: comparisons are lexicographic against `to_char` cutoffs (ISO
+strings order like dates), and validity is established by a full-anchored
+shape regex PLUS a real-calendar day check (`day ≤ days-in-month`, leap-aware,
+computed from the always-valid 'YYYY-MM-01') — so impossible dates like
+2000-02-30 can neither abort the query nor sneak through as evidence (Codex
+#1). Ages are measured against the SINGAPORE calendar day
+(`now() AT TIME ZONE 'Asia/Singapore'`) — the DB session timezone is
+deliberately not trusted. A 29-Feb birthday reaches an age on 1 Mar of
+non-leap years (the conservative, later direction).
+
+Three per-person facts:
+- `in_window`: SOME valid dob satisfies the whole [minAge, maxAge] window —
+  both bounds on the SAME row; conflicting dobs cannot combine to fake a pass.
+- `minor_claim`: SOME valid dob puts the person under EIGHTEEN — checked
+  against the binding floor independently of the cohort's minAge. ANY
+  under-18 claim disqualifies outright, no matter how many adult dobs the
+  person's other signups carry (fail-closed; Codex #1).
+- `dob_known`: SOME valid dob exists.
+
+Reasons: no valid dob → `age_unknown`; under-18 claim alongside an otherwise
+qualifying dob → `age_conflict`; dob known but outside the window →
+`age_ineligible`. The gate cannot be expressed away: minAge defaults to 18
+and values below 18 are rejected (route 400 + service 422 — floor, not
+default).
+
+### 4.3 The gates
+
+**Consent (batch canMarketTo)** — one LATERAL per person reproducing
+`canMarketTo` EXACTLY: same scope rule, same three-key tie-break, same
+`channel IN ('all', :channel)` suppression matching, same erased/fail-closed
+posture. Note the semantics inherited deliberately: channel 'all' checks only
+channel-'all' suppression rows (a person suppressed ONLY on email passes an
+'all' check, exactly as `isSuppressed` behaves), and `ConsentEvent.channels`
+is evidence, not a filter — parity with the blessed gate, locked by tests.
+
+**Destination (cohort layer only)** — consent alone cannot make an email push
+reach a person with no email (Codex #5). For channel `email` the person needs
+a non-empty email (`missing_email`); for `whatsapp|sms|voice` a phone
+(`missing_phone`); channel `all` is the abstract consent question and
+requires none. This lives OUTSIDE canMarketToBatch to preserve parity.
+
+`canMarketToBatch(consumerIds, {channel, campaignId})` is exported for the
+push senders. Domain: consumer ids only — no phone fallback (per-person
+canMarketTo keeps that); unknown ids report `not_found`; ids are processed in
+bounded chunks and any chunk failure aborts the whole call. It lives in
+cohortService today only to stay off files carried by in-flight parallel
+work; fold it into consentService when that lands (Codex #4 — the parity
+suite is the tripwire either way).
+
+### 4.4 Outputs
+
+Preview (aggregate, one resolution round-trip):
+```jsonc
+{
+  "total": 212, "reachable": 180, "excluded": 32,
+  "byReason": { "age_unknown": 2, "age_conflict": 1, "age_ineligible": 3,
+                "missing_email": 0, "missing_phone": 0,
+                "suppressed": 6, "not_consented": 15, "not_verified": 8 }, // overlapping counts
+  "gate": { "channel": "all", "campaignId": null, "minAge": 18, "maxAge": null }
+}
+```
+`excluded` is a distinct-person count; `byReason` counts overlap.
+
+Members (paged ≤200, `status=all|reachable|excluded`): consumerId, name,
+phone, email, verifiedSignupCount, lastSeenAt, `reachable`, `reasons[]`,
+ordered `lastSeenAt DESC, id`. Full phone deliberately — admin-only surface
+like the consumer journey endpoint.
+
+## 5. The consent-gate scope (`marketingContext.campaignId`)
+
+Default **null = the pure cross-campaign question** — only explicit GLOBAL
+grants (agree-all era) pass. A cohort built to push ABOUT a specific campaign
+sets `campaignId` to it (must reference a REAL campaign — phantom scopes
+422), and people whose legacy scoped grant covers THAT campaign become
+reachable for it. This is scope selection, not scope widening.
+
+**Binding obligation on the senders (Codex #2):** the cohort's gate scope is
+advisory, for audience-building. A sender MUST gate each send with the
+campaign the message is ACTUALLY about (per-recipient, at send time, via the
+per-person gate), and voice/SMS/WhatsApp pushes MUST DNC-scrub at send time
+regardless of consent (§9.5-2). Cohort resolution never substitutes for
+either.
+
+## 6. Endpoints (routes/cohorts.js — all `authenticateToken, requireAdmin`)
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/api/cohorts/preview` | Stateless: definition → counts (UI live preview) |
+| GET | `/api/cohorts/facets` | Live filter vocabulary: attribute values, campaign tags, campaigns, draws |
+| POST | `/api/cohorts` | Create (resolves preview first; persists definition + snapshot together) |
+| GET | `/api/cohorts` | List non-archived, newest first, stored snapshots |
+| GET | `/api/cohorts/:id` | Definition + snapshot; `?refresh=1` recomputes + persists |
+| PUT | `/api/cohorts/:id` | Update; definition change re-resolves before persisting |
+| DELETE | `/api/cohorts/:id` | Soft-archive; idempotent 404 after |
+| GET | `/api/cohorts/:id/members` | Paged resolved membership with per-person `reasons` |
+
+No feature flag: additive admin-only routes (same posture as
+/api/consumers/:id). Live proof = 401 probe on api.mktr.sg.
+
+## 7. Conflict posture (parallel sessions)
+
+ZERO edits to `consentService.js`, `contactConsent.js`,
+`middleware/validation.js` — all carry uncommitted parallel work on the main
+checkout. New files only, plus additive registrations in `models/index.js`
+and index mirrors in `DrawEntry.js` (both clean). Migration 084 (083 =
+propagate, merged). Joi schema lives inside routes/cohorts.js.
+
+## 8. Tests (real-Postgres jest; 40 tests across two suites)
+
+`cohortService.test.js`: filter semantics (campaigns, draws via both
+branches + zero-sentinel, tags, attributes); age gate (default-18 floor,
+`age_unknown` incl. impossible-calendar dob, `age_conflict` disqualification,
+benign multi-dob, same-row maxAge window); reachability split + reasons;
+scoped vs global gate; destination checks per channel; preview aggregates;
+**the parity suite: canMarketToBatch === canMarketTo for every fixture ×
+{null, campaign} scope × all five channels, plus forced createdAt and uuid
+tie-breaks**; paging; facets; normalization hygiene.
+
+`cohortRoutes.test.js`: 401/403 on every route, CRUD + snapshot lifecycle,
+preview, phantom gate campaign 422, facets, validation rejections (minAge
+16, unknown keys, bad uuids), malformed ids 404.
+
+## 9. Non-goals / deferred
+
+- Filling `campaigns.tags` (tracker "taxonomy") — the filter ships ready.
+- Consumer-level attribute projection (tracker "rollup").
+- Attribute-value canonicalization (Codex #8): /facets exposes the live
+  verbatim vocabulary now; a normalizer belongs to "rollup"/"taxonomy".
+- Recency/engagement filters, per-channel aggregate counts in one call,
+  cohort revision history (send logs snapshot instead), materialization.
+- Any send machinery (emailpush/wapush consume this; their obligations are
+  §5).
+
+## 10. Codex review round 1 (gpt-5.6-sol xhigh) — disposition
+
+Verdict "implement with fixes"; all folded or dispositioned:
+
+| # | Finding | Disposition |
+|---|---|---|
+| 1 | BLOCKER Age gate fail-open (shape-only regex, impossible dates, conflicting dobs, unpinned TZ) | FIXED: real-calendar validation, SGT day, minor-claim disqualifier + `age_conflict`, leap policy documented |
+| 2 | BLOCKER Gate scope not bound to send purpose | FIXED in scope available: phantom-campaign 422 + binding sender obligations (§5); equality enforcement lands with the senders |
+| 3 | MAJOR Batch domain narrower than canMarketTo | Documented: consumerId domain, not_found fail-closed; phone fallback stays per-person |
+| 4 | MAJOR Second gate implementation | Accepted for now (§4.3): parallel-work conflict posture; fold-into-consentService noted + tie-break parity locks semantics |
+| 5 | MAJOR 'all' ≠ any-channel; no destination check | FIXED: destination flags + missing_email/missing_phone; 'all' documented as the abstract consent question |
+| 6 | MAJOR Erased-draw phoneHash claim wrong | FIXED: doc corrected (zero-sentinel), zero-sentinel fixture test added |
+| 7 | MAJOR Draw predicate perf | FIXED: two indexed EXISTS branches + partial prospectId index; chunked batch documented |
+| 8 | MAJOR Attribute vocabulary mismatch | FIXED: /facets endpoint; tests use real display-string values |
+| 9 | MAJOR tags::jsonb cast abort | FIXED: JS-side tag resolution, no jsonb cast anywhere |
+| 10 | MAJOR Mutable definitions vs audit | Documented duty on send logs (§2); revisions deferred |
+| 11 | MAJOR Parity lacks tie cases | FIXED: forced createdAt tie + uuid tie fixtures; channels × scopes widened |
+| 12 | MINOR Reason naming | FIXED: age_ineligible + age_conflict + missing_* |
+| 13 | MINOR Snapshot ordering / stale plan | FIXED: preview-before-persist; plan trued |
+| 14 | NIT Doc claims | FIXED: wording trued (in-flight helper, prod-data claims softened) |


### PR DESCRIPTION
## What

The core of data-powerhouse activation (Phase 3): a define-a-cohort API that resolves consumers by what they did and splits them into **reachable vs excluded-with-reasons** through the consent gate — plus saved cohorts, a stateless preview, a facets endpoint, and paged member listings. Admin-only, no feature flag (same posture as `/api/consumers/:id`).

- **Filters**: campaign(s) · draw participation (prospect-link + phoneHash fallback branches, both indexed; erasure's zero-sentinel hash matches nobody) · campaign tags (resolved in JS — unchecked TEXT never cast to jsonb) · attributes (postal prefix / income / education / gender, verbatim display-string values served by `GET /api/cohorts/facets`).
- **Consent gate**: `canMarketToBatch` reproduces `consentService.canMarketTo` exactly over the consumerId domain — same scope rule (global-only default; `marketingContext.campaignId` re-scopes, must reference a real campaign), same `occurredAt/createdAt/id DESC` tie-break, same suppression channel matching, erased/fail-closed. **Parity suite** proves batch === per-person for every fixture × both scopes × all five channels, including forced createdAt and uuid ties.
- **Binding 18+ age gate (consent doc §9.5-2)**: minAge < 18 inexpressible (400/422 floor), dob validated as a real calendar date without a single cast (impossible dates fail closed as `age_unknown`), ANY under-18 claim disqualifies outright (`age_conflict`), ages measured on the Singapore calendar day.
- **Destination checks** (cohort layer only, preserving gate parity): email pushes need an email, phone channels need a phone — `missing_email` / `missing_phone` reasons.
- **Saved cohorts**: preview-before-persist snapshots, soft-archive; documented as mutable definitions — push send logs must snapshot what they resolved. Sender obligations (actual-campaign gate equality + §9.5-2 DNC send-time scrub) written into the plan for emailpush/wapush.

## Review

Codex gpt-5.6-sol **xhigh** design review: 2 BLOCKERs (age-gate fail-open paths; gate-scope purpose binding) + 8 MAJORs — all folded or dispositioned, full table in `docs/plans/cohort-builder-backend.md` §10.

## Tests

40 new (2 suites) + 105 neighboring (consentLedger, consumerSpine, erasure, suppressionPropagation, luckyDraw, drawTerms, drawGate) = 145 green on real Postgres; 1625 vitest green. Migration 084 guarded/idempotent; model mirrors every index (sync-built test schemas).

## Conflict posture

Zero edits to `consentService.js` / `contactConsent.js` / `middleware/validation.js` (all carry uncommitted parallel work on the shared checkout). New files + additive `models/index.js` + `DrawEntry.js` index mirrors. Rebased onto #221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDco6HwKLHpmRgE5YR8Za2