### PR TITLE
feat(admin-v2): cohort builder UI — build, preview, save, and see WHY people are excluded (tracker "cohortui")

### DIFF
--- a/backend/src/middleware/internalRouteHostGuard.js
+++ b/backend/src/middleware/internalRouteHostGuard.js
@@ -21,6 +21,7 @@ const BLOCKED_PATH_PREFIXES = [
   '/api/auth',
   '/api/admin',
   '/api/consumers',
+  '/api/cohorts',
   '/api/agents',
   '/api/fleet',
   '/api/devices',

--- a/src/api/adminV2.js
+++ b/src/api/adminV2.js
@@ -142,3 +142,50 @@ export function bulkReturnToHeld(prospectIds) {
 export function bulkDelete(prospectIds) {
   return apiClient.post('/prospects/bulk/delete', { prospectIds });
 }
+
+// ── Cohorts (tracker "cohortui" — /api/cohorts, cohortapi backend) ───────────
+
+export async function fetchCohorts() {
+  const resp = await apiClient.get('/cohorts');
+  const rows = resp?.data || [];
+  return { rows, total: rows.length };
+}
+
+/** refresh=1 recomputes counts server-side and persists the snapshot. */
+export async function fetchCohort(id, { refresh = false } = {}) {
+  const resp = await apiClient.get(`/cohorts/${id}${refresh ? '?refresh=1' : ''}`);
+  return resp?.data ?? null;
+}
+
+export async function fetchCohortFacets() {
+  const resp = await apiClient.get('/cohorts/facets');
+  return resp?.data ?? null;
+}
+
+/** Stateless preview: definition (+channel) → counts with byReason. */
+export async function previewCohortDefinition(definition, channel) {
+  const resp = await apiClient.post('/cohorts/preview', {
+    definition,
+    ...(channel && channel !== 'all' ? { channel } : {}),
+  });
+  return resp?.data ?? null;
+}
+
+export async function fetchCohortMembers(id, { status = 'all', channel, limit = 50, offset = 0 } = {}) {
+  const qs = new URLSearchParams({ status, limit: String(limit), offset: String(offset) });
+  if (channel && channel !== 'all') qs.set('channel', channel);
+  const resp = await apiClient.get(`/cohorts/${id}/members?${qs.toString()}`);
+  return resp?.data ?? { total: 0, members: [] };
+}
+
+export function createCohort({ name, description, definition }) {
+  return apiClient.post('/cohorts', { name, description, definition });
+}
+
+export function updateCohort(id, patch) {
+  return apiClient.put(`/cohorts/${id}`, patch);
+}
+
+export function archiveCohort(id) {
+  return apiClient.delete(`/cohorts/${id}`);
+}

--- a/src/components/adminv2/CohortBuilder.jsx
+++ b/src/components/adminv2/CohortBuilder.jsx
@@ -1,0 +1,320 @@
+/**
+ * Cohort builder dialog (tracker "cohortui") — create/edit a cohort
+ * definition with a LIVE reachable-count preview from POST /cohorts/preview
+ * (debounced; the same resolution the backend uses for real, so the number
+ * you see is the number a push would get).
+ *
+ * Vocabulary comes from GET /cohorts/facets — attribute values are the
+ * verbatim strings capture stored ("Degree", "$3,000 - $4,999"), so pickers
+ * never guess. minAge is clamped to the §9.5-2 floor of 18 in the UI AND
+ * rejected server-side; the field says why.
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import {
+  fetchCohortFacets, previewCohortDefinition, createCohort, updateCohort,
+} from '@/api/adminV2';
+import { fmtNumber } from '@/lib/adminV2/format';
+import {
+  emptyDefinition, normalizeDefinitionShape, REASON_ORDER, REASON_META, CHANNEL_OPTIONS,
+} from '@/lib/adminV2/cohorts';
+import { Chip, Skeleton } from '@/components/adminv2/primitives';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+
+function TogglePill({ active, onClick, children, title }) {
+  return (
+    <button
+      type="button"
+      className="av2-btn av2-btn--sm"
+      aria-pressed={active}
+      title={title}
+      onClick={onClick}
+      style={active
+        ? { background: 'var(--accent-soft)', borderColor: 'var(--accent)', color: 'var(--accent-text)', fontWeight: 700 }
+        : { color: 'var(--ink-2)' }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function Section({ label, hint, children }) {
+  return (
+    <div style={{ display: 'grid', gap: 6 }}>
+      <div>
+        <span className="av2-microcaps">{label}</span>
+        {hint && <span className="av2-caption" style={{ marginLeft: 8 }}>{hint}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+const toggle = (list, value) => (list.includes(value) ? list.filter((v) => v !== value) : [...list, value]);
+
+export default function CohortBuilder({ cohort = null, onClose, onSaved }) {
+  const editing = !!cohort;
+  const [name, setName] = useState(cohort?.name || '');
+  const [description, setDescription] = useState(cohort?.description || '');
+  const [definition, setDefinition] = useState(() => (cohort ? normalizeDefinitionShape(cohort.definition) : emptyDefinition()));
+  const [channel, setChannel] = useState('all');
+  const [postalText, setPostalText] = useState((cohort?.definition?.filters?.attributes?.postalPrefixes || []).join(', '));
+  const queryClient = useQueryClient();
+
+  const facets = useQuery({ queryKey: ['adminV2', 'cohortFacets'], queryFn: fetchCohortFacets, staleTime: 60_000 });
+
+  // Debounce the definition into the preview query — every knob change
+  // re-resolves ~400ms after the user stops touching it.
+  const [debouncedDef, setDebouncedDef] = useState(definition);
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedDef(definition), 400);
+    return () => clearTimeout(t);
+  }, [definition]);
+
+  const preview = useQuery({
+    queryKey: ['adminV2', 'cohortPreview', JSON.stringify(debouncedDef), channel],
+    queryFn: () => previewCohortDefinition(debouncedDef, channel),
+    placeholderData: (prev) => prev, // keep last counts on screen while the next resolves
+  });
+
+  const patch = (fn) => setDefinition((d) => {
+    const next = structuredClone(d);
+    fn(next);
+    return next;
+  });
+
+  const setPostal = (text) => {
+    setPostalText(text);
+    const prefixes = [...new Set(text.split(/[\s,]+/).map((s) => s.trim()).filter((s) => /^[0-9]{2,6}$/.test(s)))].slice(0, 20);
+    patch((d) => { d.filters.attributes.postalPrefixes = prefixes; });
+  };
+
+  const save = useMutation({
+    mutationFn: () => {
+      const payload = { name: name.trim(), description: description.trim() || null, definition };
+      return editing ? updateCohort(cohort.id, payload) : createCohort(payload);
+    },
+    onSuccess: (r) => {
+      toast.success(editing ? 'Cohort updated' : 'Cohort saved');
+      queryClient.invalidateQueries({ queryKey: ['adminV2', 'cohorts'] });
+      queryClient.invalidateQueries({ queryKey: ['adminV2', 'cohort'] });
+      onSaved?.(r?.data || null);
+      onClose();
+    },
+    onError: (e) => toast.error(e?.message || 'Save failed'),
+  });
+
+  const f = facets.data;
+  const p = preview.data;
+  const nonZeroReasons = useMemo(
+    () => REASON_ORDER.filter((r) => (p?.byReason?.[r] ?? 0) > 0),
+    [p],
+  );
+  const minAgeBelowFloor = definition.ageGate.minAge < 18;
+  const canSave = name.trim().length > 0 && !minAgeBelowFloor && !save.isPending;
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open && !save.isPending) onClose(); }}>
+      <DialogContent
+        className="admin-v2"
+        style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)', maxWidth: 760, maxHeight: '86vh', display: 'flex', flexDirection: 'column' }}
+      >
+        <DialogHeader>
+          <DialogTitle style={{ color: 'var(--ink)', fontFamily: 'var(--font-ui)', fontSize: 15, fontWeight: 800, textAlign: 'left' }}>
+            {editing ? `Edit “${cohort.name}”` : 'New cohort'}
+          </DialogTitle>
+          <DialogDescription style={{ color: 'var(--ink-2)', fontSize: 11.5, textAlign: 'left' }}>
+            Membership resolves live at every use — saving stores the definition, never a list.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Live preview strip — always visible while scrolling the form */}
+        <div className="av2-card" style={{ padding: '10px 14px', display: 'flex', alignItems: 'center', gap: 14, flexWrap: 'wrap' }} aria-live="polite">
+          {preview.isError ? (
+            <span className="av2-caption" style={{ color: 'var(--bad)' }}>{preview.error?.message || 'Preview failed'}</span>
+          ) : !p ? (
+            <Skeleton height={22} width={220} />
+          ) : (
+            <>
+              <span className="av2-mono" style={{ fontSize: 18, fontWeight: 700 }}>{fmtNumber(p.total)}</span>
+              <span className="av2-caption">people match</span>
+              <span className="av2-mono" style={{ fontSize: 18, fontWeight: 700, color: 'var(--ok)' }}>{fmtNumber(p.reachable)}</span>
+              <span className="av2-caption">reachable{preview.isFetching ? ' · refreshing…' : ''}</span>
+              <span style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginLeft: 'auto' }}>
+                {nonZeroReasons.map((r) => (
+                  <Chip key={r} tone={REASON_META[r].tone} >{`${REASON_META[r].label} ${fmtNumber(p.byReason[r])}`}</Chip>
+                ))}
+              </span>
+            </>
+          )}
+        </div>
+
+        <div style={{ overflowY: 'auto', display: 'grid', gap: 16, padding: '14px 2px', flex: 1 }}>
+          <Section label="Name">
+            <input className="av2-input" value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Tokyo draw entrants" maxLength={120} />
+          </Section>
+
+          <Section label="Description" hint="optional">
+            <input className="av2-input" value={description} onChange={(e) => setDescription(e.target.value)} placeholder="What this group is for" maxLength={2000} />
+          </Section>
+
+          <Section label="Campaigns" hint="signed up for ANY selected">
+            {facets.isLoading ? <Skeleton height={30} /> : (
+              <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                {(f?.campaigns || []).map((c) => (
+                  <TogglePill
+                    key={c.id}
+                    active={definition.filters.campaignIds.includes(c.id)}
+                    onClick={() => patch((d) => { d.filters.campaignIds = toggle(d.filters.campaignIds, c.id); })}
+                    title={c.status}
+                  >
+                    {c.name}
+                  </TogglePill>
+                ))}
+                {(f?.campaigns || []).length === 0 && <span className="av2-caption">No campaigns.</span>}
+              </div>
+            )}
+          </Section>
+
+          <Section label="Lucky draws" hint="entered ANY selected">
+            {facets.isLoading ? <Skeleton height={30} /> : (
+              <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                <TogglePill
+                  active={definition.filters.anyDraw}
+                  onClick={() => patch((d) => { d.filters.anyDraw = !d.filters.anyDraw; })}
+                >
+                  Any draw
+                </TogglePill>
+                {(f?.draws || []).map((dr) => (
+                  <TogglePill
+                    key={dr.id}
+                    active={definition.filters.drawIds.includes(dr.id)}
+                    onClick={() => patch((d) => { d.filters.drawIds = toggle(d.filters.drawIds, dr.id); })}
+                    title={dr.status}
+                  >
+                    {dr.campaignName || 'Draw'} · {String(dr.closesAt).slice(0, 10)}
+                  </TogglePill>
+                ))}
+              </div>
+            )}
+          </Section>
+
+          <Section label="Campaign tags" hint={(f?.campaignTags || []).length === 0 ? 'no tags exist yet (taxonomy pending)' : 'signed up for any campaign carrying one'}>
+            <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+              {(f?.campaignTags || []).map((t) => (
+                <TogglePill
+                  key={t}
+                  active={definition.filters.campaignTags.includes(t)}
+                  onClick={() => patch((d) => { d.filters.campaignTags = toggle(d.filters.campaignTags, t); })}
+                >
+                  {t}
+                </TogglePill>
+              ))}
+            </div>
+          </Section>
+
+          <Section label="Attributes" hint="from signup answers — values shown are what people actually chose">
+            <div style={{ display: 'grid', gap: 10 }}>
+              {[['incomes', 'Income'], ['educations', 'Education'], ['genders', 'Gender']].map(([key, label]) => (
+                (f?.attributes?.[key] || []).length > 0 && (
+                  <div key={key} style={{ display: 'flex', gap: 6, flexWrap: 'wrap', alignItems: 'center' }}>
+                    <span className="av2-caption" style={{ width: 70, flex: 'none' }}>{label}</span>
+                    {(f?.attributes?.[key] || []).map((v) => (
+                      <TogglePill
+                        key={v}
+                        active={definition.filters.attributes[key].includes(v)}
+                        onClick={() => patch((d) => { d.filters.attributes[key] = toggle(d.filters.attributes[key], v); })}
+                      >
+                        {v}
+                      </TogglePill>
+                    ))}
+                  </div>
+                )
+              ))}
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                <span className="av2-caption" style={{ width: 70, flex: 'none' }}>Postal</span>
+                <input
+                  className="av2-input"
+                  value={postalText}
+                  onChange={(e) => setPostal(e.target.value)}
+                  placeholder="prefixes, e.g. 52, 53"
+                  style={{ maxWidth: 240 }}
+                  aria-label="Postal prefixes"
+                />
+                <span className="av2-caption">2–6 digits each</span>
+              </div>
+            </div>
+          </Section>
+
+          <Section label="Age" hint="18+ is a consent-policy floor (§9.5-2) — it cannot go lower">
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+              <input
+                className="av2-input"
+                type="number"
+                min={18}
+                max={120}
+                value={definition.ageGate.minAge}
+                onChange={(e) => patch((d) => { d.ageGate.minAge = e.target.value === '' ? 18 : Number(e.target.value); })}
+                style={{ width: 84 }}
+                aria-label="Minimum age"
+              />
+              <span className="av2-caption">to</span>
+              <input
+                className="av2-input"
+                type="number"
+                min={18}
+                max={120}
+                value={definition.ageGate.maxAge ?? ''}
+                placeholder="—"
+                onChange={(e) => patch((d) => { d.ageGate.maxAge = e.target.value === '' ? null : Number(e.target.value); })}
+                style={{ width: 84 }}
+                aria-label="Maximum age"
+              />
+              <span className="av2-caption">no upper limit when blank · people with no valid birthdate are excluded</span>
+            </div>
+            {minAgeBelowFloor && (
+              <div className="av2-caption" style={{ color: 'var(--bad)' }}>Minimum age cannot go below 18.</div>
+            )}
+          </Section>
+
+          <Section label="Consent scope" hint="which grants count — a push about a specific campaign may use that campaign’s own signups">
+            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+              <select
+                className="av2-input"
+                value={definition.marketingContext.campaignId || ''}
+                onChange={(e) => patch((d) => { d.marketingContext.campaignId = e.target.value || null; })}
+                aria-label="Consent scope"
+                style={{ maxWidth: 320 }}
+              >
+                <option value="">Brand-wide (global consent only)</option>
+                {(f?.campaigns || []).map((c) => (
+                  <option key={c.id} value={c.id}>About: {c.name}</option>
+                ))}
+              </select>
+              <select
+                className="av2-input"
+                value={channel}
+                onChange={(e) => setChannel(e.target.value)}
+                aria-label="Preview channel"
+                style={{ maxWidth: 220 }}
+              >
+                {CHANNEL_OPTIONS.map((c) => <option key={c.value} value={c.value}>Preview: {c.label}</option>)}
+              </select>
+            </div>
+            <span className="av2-caption">
+              Sends always re-check per person at send time — this preview uses the exact same gate.
+            </span>
+          </Section>
+        </div>
+
+        <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end', paddingTop: 8, borderTop: '1px solid var(--line)' }}>
+          <button type="button" className="av2-btn" disabled={save.isPending} onClick={onClose}>Cancel</button>
+          <button type="button" className="av2-btn av2-btn--primary" disabled={!canSave} onClick={() => save.mutate()}>
+            {save.isPending ? 'Saving…' : editing ? 'Save changes' : 'Save cohort'}
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/adminv2/__tests__/CohortBuilder.test.jsx
+++ b/src/components/adminv2/__tests__/CohortBuilder.test.jsx
@@ -1,0 +1,96 @@
+/**
+ * Cohort builder dialog (tracker "cohortui") — facet pills drive the
+ * definition, the preview re-resolves debounced with the edited definition,
+ * the §9.5-2 age floor blocks save, and save sends the canonical payload.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import CohortBuilder from '../CohortBuilder';
+
+vi.mock('@/api/adminV2', () => ({
+  fetchCohortFacets: vi.fn(async () => ({
+    attributes: { incomes: ['$3,000 - $4,999'], educations: ['Degree'], genders: ['female'] },
+    campaignTags: ['parenting'],
+    campaigns: [
+      { id: 'c1', name: 'Tokyo Getaway Lucky Draw', status: 'active' },
+      { id: 'c2', name: 'NTUC $20', status: 'active' },
+    ],
+    draws: [{ id: 'd1', campaignId: 'c1', campaignName: 'Tokyo Getaway Lucky Draw', status: 'open', closesAt: '2026-10-30T00:00:00Z' }],
+  })),
+  previewCohortDefinition: vi.fn(async () => ({
+    total: 10, reachable: 4, excluded: 6,
+    byReason: { age_unknown: 1, age_conflict: 0, age_ineligible: 1, missing_email: 0, missing_phone: 0, suppressed: 0, not_consented: 3, not_verified: 1 },
+    gate: { channel: 'all', campaignId: null, minAge: 18, maxAge: null },
+  })),
+  createCohort: vi.fn(async () => ({ data: { id: 'co-new' } })),
+  updateCohort: vi.fn(async () => ({ data: { id: 'co1' } })),
+}));
+
+import { previewCohortDefinition, createCohort } from '@/api/adminV2';
+
+function setup(props = {}) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <CohortBuilder onClose={() => {}} {...props} />
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('CohortBuilder', () => {
+  it('toggling a campaign pill re-previews with that campaign in the definition', async () => {
+    setup();
+    const pill = await screen.findByRole('button', { name: 'Tokyo Getaway Lucky Draw' });
+    fireEvent.click(pill);
+    expect(pill).toHaveAttribute('aria-pressed', 'true');
+    await waitFor(() => {
+      const defs = previewCohortDefinition.mock.calls.map(([def]) => def);
+      expect(defs.some((d) => d.filters.campaignIds.includes('c1'))).toBe(true);
+    }, { timeout: 3000 });
+  });
+
+  it('shows the live counts and non-zero reason chips', async () => {
+    setup();
+    expect(await screen.findByText('people match', {}, { timeout: 3000 })).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('No consent 3')).toBeInTheDocument();
+    expect(screen.queryByText(/Unsubscribed/)).not.toBeInTheDocument(); // zero count → no chip
+  });
+
+  it('enforces the 18+ floor: value below 18 blocks save with the policy note', async () => {
+    setup();
+    await screen.findByRole('button', { name: 'Tokyo Getaway Lucky Draw' });
+    fireEvent.change(screen.getByLabelText('Minimum age'), { target: { value: '16' } });
+    expect(await screen.findByText('Minimum age cannot go below 18.')).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText('e.g. Tokyo draw entrants'), { target: { value: 'Teens' } });
+    expect(screen.getByRole('button', { name: 'Save cohort' })).toBeDisabled();
+  });
+
+  it('save posts name + canonical definition', async () => {
+    setup();
+    fireEvent.click(await screen.findByRole('button', { name: 'NTUC $20' }));
+    fireEvent.change(screen.getByPlaceholderText('e.g. Tokyo draw entrants'), { target: { value: 'NTUC people' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save cohort' }));
+    await waitFor(() => expect(createCohort).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'NTUC people',
+      definition: expect.objectContaining({
+        filters: expect.objectContaining({ campaignIds: ['c2'] }),
+        ageGate: { minAge: 18, maxAge: null },
+      }),
+    })));
+  });
+
+  it('postal input keeps only valid digit prefixes', async () => {
+    setup();
+    await screen.findByRole('button', { name: 'NTUC $20' });
+    fireEvent.change(screen.getByLabelText('Postal prefixes'), { target: { value: '52, 5x, 530' } });
+    await waitFor(() => {
+      const defs = previewCohortDefinition.mock.calls.map(([def]) => def);
+      expect(defs.some((d) => JSON.stringify(d.filters.attributes.postalPrefixes) === JSON.stringify(['52', '530']))).toBe(true);
+    }, { timeout: 3000 });
+  });
+});

--- a/src/lib/adminV2/cohorts.js
+++ b/src/lib/adminV2/cohorts.js
@@ -1,0 +1,110 @@
+/**
+ * Cohort UI vocabulary (tracker "cohortui") — shared by the builder, list and
+ * detail screens so reason language and definition summaries never fork.
+ * Mirrors backend cohortService (docs/plans/cohort-builder-backend.md):
+ * reasons are OVERLAPPING per person; minAge 18 is a consent-policy FLOOR
+ * (§9.5-2), not a preference.
+ */
+
+export const REASON_META = {
+  not_consented: { label: 'No consent', tone: 'bad', hint: 'No verified marketing grant in this scope — legacy signups have no brand-wide basis.' },
+  not_verified: { label: 'Unverified', tone: 'warn', hint: 'Consent exists but the signup never carried a live OTP stamp.' },
+  suppressed: { label: 'Unsubscribed', tone: 'bad', hint: 'A suppression covers this channel — unsubscribe, complaint or admin block.' },
+  age_unknown: { label: 'Age unknown', tone: 'hold', hint: 'No valid date of birth on any signup — excluded by the 18+ safeguard.' },
+  age_ineligible: { label: 'Outside age range', tone: 'hold', hint: 'Date of birth falls outside this cohort’s age window.' },
+  age_conflict: { label: 'Conflicting ages', tone: 'hold', hint: 'One signup claims under-18 — disqualified outright, no matter what other signups say.' },
+  missing_email: { label: 'No email', tone: '', hint: 'Consented but we hold no email address to send to.' },
+  missing_phone: { label: 'No phone', tone: '', hint: 'Consented but we hold no phone number for this channel.' },
+  erased: { label: 'Erased', tone: 'bad', hint: 'PDPA-erased — permanently out.' },
+  not_found: { label: 'Not found', tone: 'bad', hint: 'Consumer no longer exists.' },
+};
+
+export const REASON_ORDER = [
+  'not_consented', 'not_verified', 'suppressed',
+  'age_unknown', 'age_conflict', 'age_ineligible',
+  'missing_email', 'missing_phone',
+];
+
+export const CHANNEL_OPTIONS = [
+  { value: 'all', label: 'Any channel (consent only)' },
+  { value: 'email', label: 'Email' },
+  { value: 'whatsapp', label: 'WhatsApp' },
+  { value: 'sms', label: 'SMS' },
+  { value: 'voice', label: 'Voice' },
+];
+
+export function reasonLabel(reason) {
+  return REASON_META[reason]?.label || reason;
+}
+
+/** Blank definition in the backend's canonical shape. */
+export function emptyDefinition() {
+  return {
+    filters: {
+      campaignIds: [],
+      drawIds: [],
+      anyDraw: false,
+      campaignTags: [],
+      attributes: { postalPrefixes: [], incomes: [], educations: [], genders: [] },
+    },
+    ageGate: { minAge: 18, maxAge: null },
+    marketingContext: { campaignId: null },
+  };
+}
+
+/** Re-shape a stored definition defensively (old rows, partial JSON). */
+export function normalizeDefinitionShape(def) {
+  const base = emptyDefinition();
+  if (!def || typeof def !== 'object') return base;
+  const f = def.filters || {};
+  const a = f.attributes || {};
+  return {
+    filters: {
+      campaignIds: Array.isArray(f.campaignIds) ? f.campaignIds : [],
+      drawIds: Array.isArray(f.drawIds) ? f.drawIds : [],
+      anyDraw: f.anyDraw === true,
+      campaignTags: Array.isArray(f.campaignTags) ? f.campaignTags : [],
+      attributes: {
+        postalPrefixes: Array.isArray(a.postalPrefixes) ? a.postalPrefixes : [],
+        incomes: Array.isArray(a.incomes) ? a.incomes : [],
+        educations: Array.isArray(a.educations) ? a.educations : [],
+        genders: Array.isArray(a.genders) ? a.genders : [],
+      },
+    },
+    ageGate: {
+      minAge: Number.isInteger(def.ageGate?.minAge) ? def.ageGate.minAge : 18,
+      maxAge: Number.isInteger(def.ageGate?.maxAge) ? def.ageGate.maxAge : null,
+    },
+    marketingContext: { campaignId: def.marketingContext?.campaignId || null },
+  };
+}
+
+/** Human summary of a definition for list rows and detail headers. */
+export function summarizeDefinition(def, facets = null) {
+  const d = normalizeDefinitionShape(def);
+  const parts = [];
+  const nameOf = (id) => facets?.campaigns?.find((c) => c.id === id)?.name || null;
+  if (d.filters.campaignIds.length) {
+    const first = nameOf(d.filters.campaignIds[0]);
+    parts.push(d.filters.campaignIds.length === 1 && first
+      ? `campaign “${first}”`
+      : `${d.filters.campaignIds.length} campaign${d.filters.campaignIds.length > 1 ? 's' : ''}`);
+  }
+  if (d.filters.drawIds.length) parts.push(`${d.filters.drawIds.length} draw${d.filters.drawIds.length > 1 ? 's' : ''}`);
+  else if (d.filters.anyDraw) parts.push('any draw');
+  if (d.filters.campaignTags.length) parts.push(`tags: ${d.filters.campaignTags.join(', ')}`);
+  const attrs = d.filters.attributes;
+  const attrBits = [];
+  if (attrs.postalPrefixes.length) attrBits.push(`postal ${attrs.postalPrefixes.join('/')}`);
+  if (attrs.incomes.length) attrBits.push(`${attrs.incomes.length} income band${attrs.incomes.length > 1 ? 's' : ''}`);
+  if (attrs.educations.length) attrBits.push(`${attrs.educations.length} education`);
+  if (attrs.genders.length) attrBits.push(attrs.genders.join('/'));
+  if (attrBits.length) parts.push(attrBits.join(' · '));
+  if (!parts.length) parts.push('everyone');
+  const age = d.ageGate.maxAge ? `${d.ageGate.minAge}–${d.ageGate.maxAge}` : `${d.ageGate.minAge}+`;
+  parts.push(`ages ${age}`);
+  parts.push(d.marketingContext.campaignId
+    ? `scope: ${nameOf(d.marketingContext.campaignId) || 'campaign'}`
+    : 'brand-wide consent');
+  return parts.join(' · ');
+}

--- a/src/lib/adminV2/nav.js
+++ b/src/lib/adminV2/nav.js
@@ -12,6 +12,7 @@ export const NAV = [
     label: 'Lead Generation',
     items: [
       { to: '/AdminProspects', label: 'Prospects' },
+      { to: '/AdminCohorts', label: 'Cohorts' },
       { to: '/AdminAgents', label: 'Agents' },
       { to: '/AdminAgentGroups', label: 'Agent Groups' },
       { to: '/AdminCampaigns', label: 'Campaigns' },

--- a/src/pages/adminv2/AdminV2CohortDetail.jsx
+++ b/src/pages/adminv2/AdminV2CohortDetail.jsx
@@ -1,0 +1,220 @@
+/**
+ * Switchboard Cohort detail (tracker "cohortui") — the WHY screen. Opens
+ * with a fresh server-side resolution (?refresh=1 persists the snapshot),
+ * shows the reachable split, a per-reason exclusion breakdown with plain
+ * explanations, and the paged member list where every excluded person
+ * carries their actual reasons. A channel switch re-asks the same question
+ * per channel (email needs an address, WhatsApp needs a phone…).
+ */
+import { useMemo, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { fetchCohort, fetchCohortMembers, fetchCohortFacets, archiveCohort } from '@/api/adminV2';
+import { fmtNumber, fmtRelative, fmtDateTime } from '@/lib/adminV2/format';
+import { summarizeDefinition, REASON_ORDER, REASON_META, reasonLabel, CHANNEL_OPTIONS } from '@/lib/adminV2/cohorts';
+import { Card, Chip, PageHeader, Skeleton, ErrorState, EmptyState, StateRow } from '@/components/adminv2/primitives';
+import CohortBuilder from '@/components/adminv2/CohortBuilder';
+
+const PAGE_SIZE = 50;
+
+function Tile({ label, value, caption, tone }) {
+  return (
+    <div style={{ flex: 1, padding: 16, borderRight: '1px solid var(--line)' }}>
+      <div className="av2-microcaps">{label}</div>
+      <div className="av2-mono" style={{ fontSize: 20, fontWeight: 600, marginTop: 4, color: tone || 'var(--ink)' }}>{value}</div>
+      {caption && <div className="av2-caption" style={{ marginTop: 2 }}>{caption}</div>}
+    </div>
+  );
+}
+
+export default function AdminV2CohortDetail() {
+  const { id } = useParams();
+  const [channel, setChannel] = useState('all');
+  const [status, setStatus] = useState('excluded'); // the WHY view is the point — land on it
+  const [page, setPage] = useState(0);
+  const [editing, setEditing] = useState(false);
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  // refresh=1: recompute + persist the snapshot every time the screen opens.
+  const cohort = useQuery({
+    queryKey: ['adminV2', 'cohort', id],
+    queryFn: () => fetchCohort(id, { refresh: true }),
+  });
+  const facets = useQuery({ queryKey: ['adminV2', 'cohortFacets'], queryFn: fetchCohortFacets, staleTime: 60_000 });
+  const members = useQuery({
+    queryKey: ['adminV2', 'cohortMembers', id, status, channel, page],
+    queryFn: () => fetchCohortMembers(id, { status, channel, limit: PAGE_SIZE, offset: page * PAGE_SIZE }),
+    enabled: cohort.isSuccess,
+    placeholderData: (prev) => prev,
+  });
+
+  const archive = useMutation({
+    mutationFn: () => archiveCohort(id),
+    onSuccess: () => {
+      toast.success('Cohort archived');
+      queryClient.invalidateQueries({ queryKey: ['adminV2', 'cohorts'] });
+      navigate('/AdminCohorts');
+    },
+    onError: (e) => toast.error(e?.message || 'Archive failed'),
+  });
+
+  const preview = cohort.data?.preview;
+  const byReason = preview?.byReason || {};
+  const excluded = preview ? preview.excluded : null;
+  const reasonsPresent = useMemo(
+    () => REASON_ORDER.filter((r) => (byReason[r] ?? 0) > 0),
+    [byReason],
+  );
+
+  if (cohort.isLoading) {
+    return (
+      <div>
+        <Skeleton height={30} width={340} />
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 16, marginTop: 20 }}>
+          {[12, 5, 7].map((span, i) => <div key={i} style={{ gridColumn: `span ${span}` }}><Skeleton height={140} /></div>)}
+        </div>
+      </div>
+    );
+  }
+  if (cohort.isError) return <ErrorState error={cohort.error} onRetry={cohort.refetch} />;
+
+  const c = cohort.data;
+
+  return (
+    <div>
+      <PageHeader
+        title={c.name}
+        meta={`${summarizeDefinition(c.definition, facets.data).toUpperCase()} · RESOLVED ${c.lastPreviewAt ? fmtRelative(c.lastPreviewAt) : 'NOW'}`}
+      >
+        <Link to="/AdminCohorts" className="av2-btn av2-btn--sm" style={{ textDecoration: 'none' }}>← All cohorts</Link>
+        <button type="button" className="av2-btn av2-btn--sm" onClick={() => setEditing(true)}>Edit definition</button>
+        <button
+          type="button"
+          className="av2-btn av2-btn--sm"
+          style={{ borderColor: 'var(--bad)', color: 'var(--bad)' }}
+          disabled={archive.isPending}
+          onClick={() => archive.mutate()}
+        >
+          {archive.isPending ? 'Archiving…' : 'Archive'}
+        </button>
+      </PageHeader>
+
+      {c.description && <div className="av2-caption" style={{ marginTop: -8, marginBottom: 14 }}>{c.description}</div>}
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 16 }}>
+        <Card span={12}>
+          <div style={{ display: 'flex' }}>
+            <Tile label="Match the filters" value={preview ? fmtNumber(preview.total) : '—'} caption="people in the group" />
+            <Tile label="Reachable" value={preview ? fmtNumber(preview.reachable) : '—'} tone="var(--ok)" caption="consented · verified · not unsubscribed · 18+" />
+            <Tile label="Excluded" value={excluded !== null ? fmtNumber(excluded) : '—'} tone={excluded ? 'var(--warn)' : undefined} caption="see why below" />
+            <Tile
+              label="Gate"
+              value={preview?.gate ? (preview.gate.campaignId ? 'campaign' : 'brand-wide') : '—'}
+              caption={preview?.gate ? `ages ${preview.gate.minAge}${preview.gate.maxAge ? `–${preview.gate.maxAge}` : '+'} · channel ${preview.gate.channel}` : undefined}
+            />
+          </div>
+        </Card>
+
+        <Card span={5} title="Why people are excluded" meta={excluded ? `${fmtNumber(excluded)} people` : undefined}>
+          {!preview ? <div style={{ padding: 16 }}><Skeleton height={80} /></div> : reasonsPresent.length === 0 ? (
+            <EmptyState icon="✓" title="Nobody is excluded" hint="Everyone matching the filters can be messaged." />
+          ) : (
+            <div style={{ padding: '6px 0' }}>
+              {reasonsPresent.map((r) => (
+                <div key={r} className="av2-qrow" style={{ cursor: 'default', alignItems: 'flex-start' }}>
+                  <span style={{ width: 130, flex: 'none', paddingTop: 1 }}>
+                    <Chip tone={REASON_META[r].tone}>{REASON_META[r].label}</Chip>
+                  </span>
+                  <span className="av2-caption" style={{ flex: 1 }}>{REASON_META[r].hint}</span>
+                  <span className="av2-mono" style={{ fontSize: 13, fontWeight: 700 }}>{fmtNumber(byReason[r])}</span>
+                </div>
+              ))}
+              <div className="av2-caption" style={{ padding: '8px 14px 10px' }}>
+                A person can be excluded for several reasons at once — counts overlap.
+              </div>
+            </div>
+          )}
+        </Card>
+
+        <Card
+          span={7}
+          title="Members"
+          meta={members.data ? `${fmtNumber(members.data.total)} ${status}` : undefined}
+          action={(
+            <span style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+              <div className="av2-seg" role="group" aria-label="Member status">
+                {['reachable', 'excluded', 'all'].map((s) => (
+                  <button key={s} type="button" aria-pressed={status === s} onClick={() => { setStatus(s); setPage(0); }}>
+                    {s}
+                  </button>
+                ))}
+              </div>
+              <select
+                className="av2-input"
+                value={channel}
+                onChange={(e) => { setChannel(e.target.value); setPage(0); }}
+                aria-label="Channel"
+                style={{ width: 150, padding: '4px 8px', fontSize: 12 }}
+              >
+                {CHANNEL_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
+            </span>
+          )}
+        >
+          <div role="table" aria-label="Cohort members">
+            <div className="av2-thead" role="row">
+              <span className="av2-microcaps" role="columnheader" style={{ flex: 1.2 }}>Person</span>
+              <span className="av2-microcaps" role="columnheader" style={{ width: 120, flex: 'none' }}>Phone</span>
+              <span className="av2-microcaps" role="columnheader" style={{ flex: 1.4 }}>{status === 'reachable' ? 'Email' : 'Why excluded'}</span>
+              <span className="av2-microcaps" role="columnheader" style={{ width: 80, flex: 'none', textAlign: 'right' }}>Seen</span>
+            </div>
+
+            {members.isLoading && <StateRow><div style={{ padding: 12 }}><Skeleton height={60} /></div></StateRow>}
+            {members.isError && <StateRow><ErrorState error={members.error} onRetry={members.refetch} /></StateRow>}
+            {members.isSuccess && members.data.members.length === 0 && (
+              <StateRow><EmptyState title={`No ${status} members`} hint={status === 'excluded' ? 'Everyone here can be messaged.' : 'Loosen the filters or check the exclusion panel.'} /></StateRow>
+            )}
+
+            {(members.data?.members || []).map((m) => (
+              <div key={m.consumerId} className="av2-row" role="row" style={{ cursor: 'default' }}>
+                <span role="cell" style={{ flex: 1.2, fontSize: 12.5, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {(m.firstName || m.lastName) ? `${m.firstName || ''} ${m.lastName || ''}`.trim() : '—'}
+                  {m.reachable && <Chip tone="ok">✓</Chip>}
+                </span>
+                <span role="cell" className="av2-mono" style={{ width: 120, flex: 'none', fontSize: 11.5 }}>{m.phone || '—'}</span>
+                <span role="cell" style={{ flex: 1.4, display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+                  {m.reachable
+                    ? <span className="av2-mono" style={{ fontSize: 11, color: 'var(--ink-2)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{m.email || '—'}</span>
+                    : (m.reasons || []).map((r) => <Chip key={r} tone={REASON_META[r]?.tone || ''}>{reasonLabel(r)}</Chip>)}
+                </span>
+                <span role="cell" className="av2-mono" style={{ width: 80, flex: 'none', fontSize: 10.5, color: 'var(--ink-3)', textAlign: 'right' }} title={m.lastSeenAt ? fmtDateTime(m.lastSeenAt) : ''}>
+                  {m.lastSeenAt ? fmtRelative(m.lastSeenAt) : '—'}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          {members.isSuccess && members.data.total > PAGE_SIZE && (
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center', justifyContent: 'flex-end', padding: '10px 14px' }}>
+              <span className="av2-caption">
+                {fmtNumber(page * PAGE_SIZE + 1)}–{fmtNumber(Math.min((page + 1) * PAGE_SIZE, members.data.total))} of {fmtNumber(members.data.total)}
+              </span>
+              <button type="button" className="av2-btn av2-btn--sm" disabled={page === 0} onClick={() => setPage((p) => p - 1)}>← Prev</button>
+              <button type="button" className="av2-btn av2-btn--sm" disabled={(page + 1) * PAGE_SIZE >= members.data.total} onClick={() => setPage((p) => p + 1)}>Next →</button>
+            </div>
+          )}
+        </Card>
+      </div>
+
+      {editing && (
+        <CohortBuilder
+          cohort={c}
+          onClose={() => setEditing(false)}
+          onSaved={() => queryClient.invalidateQueries({ queryKey: ['adminV2', 'cohort', id] })}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/pages/adminv2/AdminV2Cohorts.jsx
+++ b/src/pages/adminv2/AdminV2Cohorts.jsx
@@ -1,0 +1,145 @@
+/**
+ * Switchboard Cohorts (tracker "cohortui") — saved audience definitions for
+ * curated pushes. List shows the last-known reachable/total snapshot (counts
+ * re-resolve live on open); create/edit runs through CohortBuilder's
+ * preview-as-you-type dialog; rows open the detail screen that explains WHY
+ * each excluded person is excluded.
+ */
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { fetchCohorts, fetchCohortFacets, archiveCohort } from '@/api/adminV2';
+import { fmtNumber, fmtRelative } from '@/lib/adminV2/format';
+import { summarizeDefinition } from '@/lib/adminV2/cohorts';
+import { PageHeader, Skeleton, ErrorState, EmptyState, StateRow } from '@/components/adminv2/primitives';
+import CohortBuilder from '@/components/adminv2/CohortBuilder';
+import {
+  AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction,
+} from '@/components/ui/alert-dialog';
+
+export default function AdminV2Cohorts() {
+  const cohorts = useQuery({ queryKey: ['adminV2', 'cohorts'], queryFn: fetchCohorts, staleTime: 30_000 });
+  const facets = useQuery({ queryKey: ['adminV2', 'cohortFacets'], queryFn: fetchCohortFacets, staleTime: 60_000 });
+  const [building, setBuilding] = useState(false);
+  const [confirmArchive, setConfirmArchive] = useState(null);
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const archive = useMutation({
+    mutationFn: (id) => archiveCohort(id),
+    onSuccess: () => {
+      toast.success('Cohort archived');
+      queryClient.invalidateQueries({ queryKey: ['adminV2', 'cohorts'] });
+      setConfirmArchive(null);
+    },
+    onError: (e) => { toast.error(e?.message || 'Archive failed'); setConfirmArchive(null); },
+  });
+
+  const rows = cohorts.data?.rows || [];
+
+  return (
+    <div>
+      <PageHeader
+        title="Cohorts"
+        meta={`${fmtNumber(rows.length)} SAVED · MEMBERSHIP RESOLVES LIVE · COUNTS BELOW ARE LAST SNAPSHOT`}
+      >
+        <button type="button" className="av2-btn av2-btn--primary" onClick={() => setBuilding(true)}>+ New cohort</button>
+      </PageHeader>
+
+      <div className="av2-card" style={{ overflow: 'hidden' }} role="table" aria-label="Cohorts">
+        <div className="av2-thead" role="row">
+          <span className="av2-microcaps" role="columnheader" style={{ flex: 1.2 }}>Name</span>
+          <span className="av2-microcaps" role="columnheader" style={{ flex: 2 }}>Definition</span>
+          <span className="av2-microcaps" role="columnheader" style={{ width: 140, flex: 'none', textAlign: 'right' }}>Reachable / total</span>
+          <span className="av2-microcaps" role="columnheader" style={{ width: 100, flex: 'none', textAlign: 'right' }}>Snapshot</span>
+          <span className="av2-microcaps" role="columnheader" style={{ width: 130, flex: 'none', textAlign: 'right' }}>Actions</span>
+        </div>
+
+        {cohorts.isLoading && [0, 1, 2].map((i) => (
+          <div key={i} className="av2-row" role="row" style={{ cursor: 'default' }}><span role="cell" style={{ flex: 1 }}><Skeleton height={30} /></span></div>
+        ))}
+        {cohorts.isError && <StateRow><ErrorState error={cohorts.error} onRetry={cohorts.refetch} /></StateRow>}
+        {!cohorts.isLoading && !cohorts.isError && rows.length === 0 && (
+          <StateRow>
+            <EmptyState
+              title="No cohorts yet"
+              hint="A cohort is a saved audience definition — “everyone from the Tokyo draw” — that stays current on its own."
+              action={<button type="button" className="av2-btn av2-btn--primary av2-btn--sm" onClick={() => setBuilding(true)}>Build the first one</button>}
+            />
+          </StateRow>
+        )}
+
+        {rows.map((c) => (
+          <div
+            key={c.id}
+            className="av2-row"
+            role="row"
+            tabIndex={0}
+            onClick={() => navigate(`/admin/cohorts/${c.id}`)}
+            onKeyDown={(e) => { if (e.key === 'Enter') navigate(`/admin/cohorts/${c.id}`); }}
+          >
+            <span role="cell" style={{ flex: 1.2, fontSize: 13, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{c.name}</span>
+            <span role="cell" className="av2-caption" style={{ flex: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={summarizeDefinition(c.definition, facets.data)}>
+              {summarizeDefinition(c.definition, facets.data)}
+            </span>
+            <span role="cell" className="av2-mono" style={{ width: 140, flex: 'none', fontSize: 12.5, textAlign: 'right' }}>
+              {c.lastReachableCount === null || c.lastReachableCount === undefined
+                ? '—'
+                : <><span style={{ color: 'var(--ok)', fontWeight: 700 }}>{fmtNumber(c.lastReachableCount)}</span><span style={{ color: 'var(--ink-3)' }}> / {fmtNumber(c.lastTotalCount ?? 0)}</span></>}
+            </span>
+            <span role="cell" className="av2-mono" style={{ width: 100, flex: 'none', fontSize: 10.5, color: 'var(--ink-3)', textAlign: 'right' }}>
+              {c.lastPreviewAt ? fmtRelative(c.lastPreviewAt) : '—'}
+            </span>
+            <span role="cell" style={{ width: 130, flex: 'none', display: 'flex', gap: 6, justifyContent: 'flex-end' }}>
+              <Link
+                to={`/admin/cohorts/${c.id}`}
+                className="av2-btn av2-btn--sm"
+                style={{ textDecoration: 'none' }}
+                onClick={(e) => e.stopPropagation()}
+              >
+                Open
+              </Link>
+              <button
+                type="button"
+                className="av2-btn av2-btn--sm"
+                style={{ borderColor: 'var(--bad)', color: 'var(--bad)' }}
+                onClick={(e) => { e.stopPropagation(); setConfirmArchive(c); }}
+              >
+                Archive
+              </button>
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <div className="av2-caption" style={{ marginTop: 10 }}>
+        Reachable = consented ∧ phone-verified ∧ not unsubscribed ∧ 18+ (binding safeguard) — every send re-checks each person again at send time.
+      </div>
+
+      {building && <CohortBuilder onClose={() => setBuilding(false)} onSaved={(c) => { if (c?.id) navigate(`/admin/cohorts/${c.id}`); }} />}
+
+      <AlertDialog open={!!confirmArchive} onOpenChange={(open) => { if (!open) setConfirmArchive(null); }}>
+        <AlertDialogContent className="admin-v2" style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)' }}>
+          <AlertDialogHeader>
+            <AlertDialogTitle style={{ color: 'var(--ink)' }}>Archive “{confirmArchive?.name}”?</AlertDialogTitle>
+            <AlertDialogDescription style={{ color: 'var(--ink-2)' }}>
+              It disappears from this list. Nothing is deleted — past sends keep their history.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => { e.preventDefault(); archive.mutate(confirmArchive.id); }}
+              disabled={archive.isPending}
+              style={{ background: 'var(--bad)', color: '#fff' }}
+            >
+              {archive.isPending ? 'Archiving…' : 'Archive'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/pages/adminv2/__tests__/AdminV2CohortDetail.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2CohortDetail.test.jsx
@@ -1,0 +1,102 @@
+/**
+ * Cohort detail (tracker "cohortui") — the WHY screen: fresh-resolution
+ * tiles, per-reason exclusion breakdown with hints, member rows carrying
+ * their actual reasons, status/channel switches re-querying.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import AdminV2CohortDetail from '../AdminV2CohortDetail';
+
+vi.mock('@/api/adminV2', () => ({
+  fetchCohort: vi.fn(async () => ({
+    id: 'co1',
+    name: 'Tokyo draw entrants',
+    description: 'Everyone from the Tokyo draw',
+    definition: {
+      filters: { campaignIds: ['c1'], drawIds: [], anyDraw: false, campaignTags: [], attributes: { postalPrefixes: [], incomes: [], educations: [], genders: [] } },
+      ageGate: { minAge: 18, maxAge: null },
+      marketingContext: { campaignId: null },
+    },
+    lastPreviewAt: new Date().toISOString(),
+    preview: {
+      total: 212, reachable: 180, excluded: 32,
+      byReason: { age_unknown: 1, age_conflict: 0, age_ineligible: 2, missing_email: 0, missing_phone: 0, suppressed: 6, not_consented: 15, not_verified: 9 },
+      gate: { channel: 'all', campaignId: null, minAge: 18, maxAge: null },
+    },
+  })),
+  fetchCohortFacets: vi.fn(async () => ({
+    attributes: { incomes: [], educations: [], genders: [] },
+    campaignTags: [],
+    campaigns: [{ id: 'c1', name: 'Tokyo Getaway Lucky Draw', status: 'active' }],
+    draws: [],
+  })),
+  fetchCohortMembers: vi.fn(async (id, { status }) => (status === 'reachable'
+    ? { total: 1, limit: 50, offset: 0, members: [{ consumerId: 'u2', firstName: 'Ready', lastName: 'Person', phone: '+6591112222', email: 'ready@x.com', lastSeenAt: new Date().toISOString(), reachable: true, reasons: [] }] }
+    : { total: 2, limit: 50, offset: 0, members: [
+        { consumerId: 'u1', firstName: 'Blocked', lastName: 'Person', phone: '+6590001111', email: null, lastSeenAt: new Date().toISOString(), reachable: false, reasons: ['not_consented'] },
+        { consumerId: 'u3', firstName: 'Silent', lastName: 'Minor', phone: '+6590002222', email: null, lastSeenAt: new Date().toISOString(), reachable: false, reasons: ['age_ineligible', 'not_verified'] },
+      ] })),
+  archiveCohort: vi.fn(async () => ({ success: true })),
+  previewCohortDefinition: vi.fn(async () => ({ total: 212, reachable: 180, excluded: 32, byReason: {}, gate: { channel: 'all', campaignId: null, minAge: 18, maxAge: null } })),
+  createCohort: vi.fn(),
+  updateCohort: vi.fn(),
+  fetchCohorts: vi.fn(),
+}));
+
+import { fetchCohort, fetchCohortMembers } from '@/api/adminV2';
+
+function setup() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/admin/cohorts/co1']}>
+        <Routes>
+          <Route path="/admin/cohorts/:id" element={<AdminV2CohortDetail />} />
+          <Route path="/AdminCohorts" element={<div>LIST</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('AdminV2CohortDetail', () => {
+  it('opens with a fresh resolution and shows the split tiles', async () => {
+    setup();
+    expect(await screen.findByText('Tokyo draw entrants')).toBeInTheDocument();
+    expect(fetchCohort).toHaveBeenCalledWith('co1', { refresh: true });
+    expect(screen.getByText('212')).toBeInTheDocument();
+    expect(screen.getByText('180')).toBeInTheDocument();
+    expect(screen.getByText('32')).toBeInTheDocument();
+  });
+
+  it('explains WHY people are excluded, with counts per reason', async () => {
+    setup();
+    await screen.findByText('Why people are excluded');
+    expect(screen.getAllByText('No consent').length).toBeGreaterThan(0);
+    expect(screen.getByText('15')).toBeInTheDocument();
+    expect(screen.getAllByText('Unsubscribed').length).toBeGreaterThan(0);
+    expect(screen.getByText(/counts overlap/i)).toBeInTheDocument();
+  });
+
+  it('lands on excluded members with their reason chips', async () => {
+    setup();
+    expect(await screen.findByText('Blocked Person')).toBeInTheDocument();
+    const reasons = screen.getAllByText('No consent');
+    expect(reasons.length).toBeGreaterThan(1); // breakdown row + member chip
+    expect(screen.getAllByText('Outside age range').length).toBeGreaterThan(1); // breakdown + chip
+    expect(screen.getAllByText('Unverified').length).toBeGreaterThan(1);
+
+  });
+
+  it('status switch re-queries members', async () => {
+    setup();
+    await screen.findByText('Blocked Person');
+    fireEvent.click(screen.getByRole('button', { name: 'reachable' }));
+    expect(await screen.findByText('Ready Person')).toBeInTheDocument();
+    await waitFor(() => expect(fetchCohortMembers).toHaveBeenLastCalledWith('co1', expect.objectContaining({ status: 'reachable' })));
+  });
+});

--- a/src/pages/adminv2/__tests__/AdminV2Cohorts.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2Cohorts.test.jsx
@@ -1,0 +1,105 @@
+/**
+ * Cohorts list (tracker "cohortui") — snapshot rows, empty state, archive
+ * confirm flow, and the builder opening with a live preview. API layer
+ * mocked; navigation asserted through a MemoryRouter location probe.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import AdminV2Cohorts from '../AdminV2Cohorts';
+
+const cohortRow = {
+  id: 'co1',
+  name: 'Tokyo draw entrants',
+  description: null,
+  definition: {
+    filters: { campaignIds: ['c1'], drawIds: [], anyDraw: false, campaignTags: [], attributes: { postalPrefixes: [], incomes: [], educations: [], genders: [] } },
+    ageGate: { minAge: 18, maxAge: null },
+    marketingContext: { campaignId: null },
+  },
+  lastTotalCount: 212,
+  lastReachableCount: 180,
+  lastPreviewAt: new Date().toISOString(),
+};
+
+vi.mock('@/api/adminV2', () => ({
+  fetchCohorts: vi.fn(async () => ({ rows: [], total: 0 })),
+  fetchCohortFacets: vi.fn(async () => ({
+    attributes: { incomes: ['$3,000 - $4,999'], educations: ['Degree'], genders: [] },
+    campaignTags: ['parenting'],
+    campaigns: [{ id: 'c1', name: 'Tokyo Getaway Lucky Draw', status: 'active' }],
+    draws: [{ id: 'd1', campaignId: 'c1', campaignName: 'Tokyo Getaway Lucky Draw', status: 'open', closesAt: '2026-10-30T00:00:00Z' }],
+  })),
+  previewCohortDefinition: vi.fn(async () => ({
+    total: 212, reachable: 180, excluded: 32,
+    byReason: { age_unknown: 0, age_conflict: 0, age_ineligible: 2, missing_email: 0, missing_phone: 0, suppressed: 6, not_consented: 15, not_verified: 9 },
+    gate: { channel: 'all', campaignId: null, minAge: 18, maxAge: null },
+  })),
+  archiveCohort: vi.fn(async () => ({ success: true })),
+  createCohort: vi.fn(async () => ({ data: { id: 'co-new' } })),
+  updateCohort: vi.fn(async () => ({ data: { id: 'co1' } })),
+  fetchCohort: vi.fn(),
+  fetchCohortMembers: vi.fn(),
+}));
+
+import { fetchCohorts, archiveCohort } from '@/api/adminV2';
+
+function LocationProbe() {
+  const loc = useLocation();
+  return <div data-testid="loc">{loc.pathname}</div>;
+}
+
+function setup() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/AdminCohorts']}>
+        <Routes>
+          <Route path="/AdminCohorts" element={<AdminV2Cohorts />} />
+          <Route path="/admin/cohorts/:id" element={<div>DETAIL</div>} />
+        </Routes>
+        <LocationProbe />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('AdminV2Cohorts', () => {
+  it('shows the empty state with a build CTA', async () => {
+    setup();
+    expect(await screen.findByText('No cohorts yet')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Build the first one' })).toBeInTheDocument();
+  });
+
+  it('renders snapshot counts and opens the detail on row click', async () => {
+    fetchCohorts.mockResolvedValueOnce({ rows: [cohortRow], total: 1 });
+    setup();
+    expect(await screen.findByText('Tokyo draw entrants')).toBeInTheDocument();
+    expect(screen.getByText('180')).toBeInTheDocument();
+    expect(screen.getByText('/ 212')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Tokyo draw entrants'));
+    await waitFor(() => expect(screen.getByTestId('loc')).toHaveTextContent('/admin/cohorts/co1'));
+  });
+
+  it('archive asks for confirmation and calls the API', async () => {
+    fetchCohorts.mockResolvedValueOnce({ rows: [cohortRow], total: 1 });
+    setup();
+    await screen.findByText('Tokyo draw entrants');
+    fireEvent.click(screen.getByRole('button', { name: 'Archive' }));
+    expect(await screen.findByText(/Archive “Tokyo draw entrants”\?/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^Archive$/ }));
+    await waitFor(() => expect(archiveCohort).toHaveBeenCalledWith('co1'));
+  });
+
+  it('+ New cohort opens the builder with a live preview strip', async () => {
+    setup();
+    fireEvent.click(await screen.findByRole('button', { name: '+ New cohort' }));
+    expect(await screen.findByText('New cohort')).toBeInTheDocument();
+    // Debounced preview lands with the mocked counts.
+    expect(await screen.findByText('people match', {}, { timeout: 3000 })).toBeInTheDocument();
+    expect(await screen.findByText('212')).toBeInTheDocument();
+  });
+});

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -72,6 +72,8 @@ const ADMIN_V2 = import.meta.env.VITE_ADMIN_V2_ENABLED === 'true';
 const AdminV2Shell = lazy(() => import('@/components/adminv2/AdminV2Shell'));
 const AdminV2Dashboard = lazy(() => import('./adminv2/AdminV2Dashboard'));
 const AdminV2Prospects = lazy(() => import('./adminv2/AdminV2Prospects'));
+const AdminV2Cohorts = lazy(() => import('./adminv2/AdminV2Cohorts'));
+const AdminV2CohortDetail = lazy(() => import('./adminv2/AdminV2CohortDetail'));
 const AdminV2Campaigns = lazy(() => import('./adminv2/AdminV2Campaigns'));
 const AdminV2CampaignDetail = lazy(() => import('./adminv2/AdminV2CampaignDetail'));
 const AdminV2Agents = lazy(() => import('./adminv2/AdminV2Agents'));
@@ -341,6 +343,28 @@ function PagesContent() {
  <ProtectedRoute requiredRole="admin">
  <AdminV2Shell>
  <AdminV2CampaignDetail />
+ </AdminV2Shell>
+ </ProtectedRoute>
+ }
+ />
+ )}
+ {ADMIN_V2 && (
+ <Route
+ path="/AdminCohorts" element={
+ <ProtectedRoute requiredRole="admin">
+ <AdminV2Shell>
+ <AdminV2Cohorts />
+ </AdminV2Shell>
+ </ProtectedRoute>
+ }
+ />
+ )}
+ {ADMIN_V2 && (
+ <Route
+ path="/admin/cohorts/:id" element={
+ <ProtectedRoute requiredRole="admin">
+ <AdminV2Shell>
+ <AdminV2CohortDetail />
  </AdminV2Shell>
  </ProtectedRoute>
  }


### PR DESCRIPTION
## What

The admin surface for the cohortapi backend (#222), in the Switchboard dark language:

- **`/AdminCohorts`** — saved-cohorts list (snapshot reachable/total, definition summary, archive with confirm), nav entry under Lead Generation, ⌘K palette picks it up automatically via the shared NAV list.
- **CohortBuilder dialog** (create + edit) — facet pills from `GET /cohorts/facets` (campaigns, draws, tags, verbatim attribute values like `"$3,000 - $4,999"`), postal-prefix input with digit hygiene, age window floored at 18 with the §9.5-2 note, consent-scope + preview-channel selects, and a **live reachable-count strip** that re-resolves ~400ms after every knob change via `POST /cohorts/preview` — the exact gate a real push would use.
- **`/admin/cohorts/:id`** — the WHY screen: fresh resolution on open (`?refresh=1` persists the snapshot), reachable/excluded tiles, per-reason breakdown with plain-language hints, and paged members where each excluded person carries their actual reason chips (No consent / Unverified / Unsubscribed / Age unknown / Conflicting ages / Outside age range / No email / No phone). Lands on the excluded tab deliberately. Channel switch re-asks per channel.
- **Host guard**: `/api/cohorts` added to the internal-route blocklist (same cross-campaign-PII class as `/api/consumers`).

## Tests

13 new vitest (builder floor/preview-payload/postal hygiene, list flows, detail reasons + status re-query) — **full vitest 1638/1638**; backend `cohortRoutes` + `cohortService` + `redeemOpsHostGuard` **48/48**; production build clean with lazy chunks per screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDco6HwKLHpmRgE5YR8Za2