### PR TITLE
feat(emailpush): email broadcast push — cohort-audience campaign mail with send-time consent gating (tracker "emailpush")

### DIFF
--- a/backend/src/controllers/emailBroadcastController.js
+++ b/backend/src/controllers/emailBroadcastController.js
@@ -1,0 +1,178 @@
+import { asyncHandler, AppError } from '../middleware/errorHandler.js';
+import {
+  EmailBroadcast, EmailBroadcastRecipient, Cohort, Campaign,
+} from '../models/index.js';
+import {
+  startBroadcastSend, cancelBroadcast, sendTestEmail, liveBroadcastCounts, buildCtaUrl,
+} from '../services/emailBroadcastService.js';
+import { customerHostOrigin, normalizeCustomerHostChoice } from '../utils/customerHost.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Malformed ids 404 up front (the AdminCampaignDesigner lesson). */
+async function findBroadcastOr404(id, include = []) {
+  if (!UUID_RE.test(String(id || ''))) throw new AppError('Broadcast not found', 404);
+  const broadcast = await EmailBroadcast.findByPk(id, { include });
+  if (!broadcast) throw new AppError('Broadcast not found', 404);
+  return broadcast;
+}
+
+const cohortInclude = { model: Cohort, as: 'cohort', attributes: ['id', 'name', 'definition', 'archivedAt'] };
+const campaignInclude = { model: Campaign, as: 'campaign', attributes: ['id', 'name', 'status', 'is_active', 'design_config'] };
+
+function serializeBroadcast(b, { withDefinition = false } = {}) {
+  return {
+    id: b.id,
+    cohortId: b.cohortId,
+    campaignId: b.campaignId,
+    subject: b.subject,
+    bodyText: b.bodyText,
+    ctaLabel: b.ctaLabel,
+    ctaUrl: b.ctaUrl,
+    hostChoice: b.hostChoice,
+    status: b.status,
+    totalRecipients: b.totalRecipients,
+    sentCount: b.sentCount,
+    skippedCount: b.skippedCount,
+    failedCount: b.failedCount,
+    startedAt: b.startedAt,
+    completedAt: b.completedAt,
+    lastError: b.lastError,
+    createdBy: b.createdBy,
+    createdAt: b.createdAt,
+    updatedAt: b.updatedAt,
+    cohort: b.cohort
+      ? {
+          id: b.cohort.id,
+          name: b.cohort.name,
+          ...(withDefinition ? { definition: b.cohort.definition } : {}),
+        }
+      : null,
+    campaign: b.campaign
+      ? { id: b.campaign.id, name: b.campaign.name, status: b.campaign.status, is_active: b.campaign.is_active }
+      : null,
+  };
+}
+
+export const create = asyncHandler(async (req, res) => {
+  const cohort = await Cohort.findByPk(req.body.cohortId);
+  if (!cohort || cohort.archivedAt) throw new AppError('Cohort not found', 422);
+  const campaign = await Campaign.findByPk(req.body.campaignId);
+  if (!campaign) throw new AppError('Campaign not found', 422);
+
+  const broadcast = await EmailBroadcast.create({
+    cohortId: cohort.id,
+    campaignId: campaign.id,
+    subject: req.body.subject.trim(),
+    bodyText: req.body.bodyText.trim(),
+    ctaLabel: req.body.ctaLabel?.trim() || 'Learn more',
+    createdBy: req.user?.id || null,
+  });
+  const full = await findBroadcastOr404(broadcast.id, [cohortInclude, campaignInclude]);
+  res.status(201).json({ success: true, data: serializeBroadcast(full, { withDefinition: true }) });
+});
+
+export const list = asyncHandler(async (req, res) => {
+  const broadcasts = await EmailBroadcast.findAll({
+    include: [cohortInclude, campaignInclude],
+    order: [['createdAt', 'DESC']],
+    limit: 200,
+  });
+  res.json({ success: true, data: broadcasts.map((b) => serializeBroadcast(b)) });
+});
+
+export const get = asyncHandler(async (req, res) => {
+  const b = await findBroadcastOr404(req.params.id, [cohortInclude, campaignInclude]);
+  // Drafts show what the CTA WILL be; started broadcasts show the frozen truth.
+  let ctaUrlPreview = b.ctaUrl;
+  if (!ctaUrlPreview && b.campaign) {
+    const hostChoice = normalizeCustomerHostChoice(b.campaign.design_config?.customerHost);
+    ctaUrlPreview = buildCtaUrl({ origin: customerHostOrigin(hostChoice), campaignId: b.campaign.id, broadcastId: b.id });
+  }
+  const counts = await liveBroadcastCounts(b.id);
+  res.json({
+    success: true,
+    data: { ...serializeBroadcast(b, { withDefinition: true }), ctaUrlPreview, liveCounts: counts },
+  });
+});
+
+export const update = asyncHandler(async (req, res) => {
+  const b = await findBroadcastOr404(req.params.id);
+  const patch = {};
+  if (req.body.subject !== undefined) patch.subject = req.body.subject.trim();
+  if (req.body.bodyText !== undefined) patch.bodyText = req.body.bodyText.trim();
+  if (req.body.ctaLabel !== undefined) patch.ctaLabel = req.body.ctaLabel?.trim() || 'Learn more';
+  if (req.body.cohortId !== undefined) {
+    const cohort = await Cohort.findByPk(req.body.cohortId);
+    if (!cohort || cohort.archivedAt) throw new AppError('Cohort not found', 422);
+    patch.cohortId = cohort.id;
+  }
+  if (req.body.campaignId !== undefined) {
+    const campaign = await Campaign.findByPk(req.body.campaignId);
+    if (!campaign) throw new AppError('Campaign not found', 422);
+    patch.campaignId = campaign.id;
+  }
+  // Conditional on draft — an edit can never race a started send (§3.1).
+  const [count] = await EmailBroadcast.update(patch, { where: { id: b.id, status: 'draft' } });
+  if (count === 0) throw new AppError(`Broadcast is ${b.status} — only drafts can be edited`, 409);
+  const full = await findBroadcastOr404(b.id, [cohortInclude, campaignInclude]);
+  res.json({ success: true, data: serializeBroadcast(full, { withDefinition: true }) });
+});
+
+export const destroy = asyncHandler(async (req, res) => {
+  const b = await findBroadcastOr404(req.params.id);
+  const count = await EmailBroadcast.destroy({ where: { id: b.id, status: 'draft' } });
+  if (count === 0) throw new AppError(`Broadcast is ${b.status} — only drafts can be deleted (history is audit)`, 409);
+  res.json({ success: true, data: { id: b.id, deleted: true } });
+});
+
+export const send = asyncHandler(async (req, res) => {
+  await findBroadcastOr404(req.params.id);
+  const { broadcast } = await startBroadcastSend(req.params.id, { resume: req.body?.resume === true });
+  // 202-style: the worker runs post-response; the UI polls the detail DTO.
+  res.status(202).json({ success: true, data: { id: broadcast.id, status: broadcast.status, totalRecipients: broadcast.totalRecipients } });
+});
+
+export const cancel = asyncHandler(async (req, res) => {
+  await findBroadcastOr404(req.params.id);
+  const broadcast = await cancelBroadcast(req.params.id);
+  res.json({ success: true, data: { id: broadcast.id, status: broadcast.status } });
+});
+
+export const test = asyncHandler(async (req, res) => {
+  await findBroadcastOr404(req.params.id);
+  const result = await sendTestEmail(req.params.id, req.user);
+  res.json({ success: true, data: { sentTo: result.to } });
+});
+
+export const recipients = asyncHandler(async (req, res) => {
+  const b = await findBroadcastOr404(req.params.id);
+  const status = String(req.query.status || 'all');
+  const limit = Math.min(200, Math.max(1, Number.parseInt(req.query.limit, 10) || 50));
+  const offset = Math.max(0, Number.parseInt(req.query.offset, 10) || 0);
+  const where = { broadcastId: b.id, ...(status !== 'all' ? { status } : {}) };
+  const { rows, count } = await EmailBroadcastRecipient.findAndCountAll({
+    where,
+    order: [['createdAt', 'ASC'], ['id', 'ASC']],
+    limit,
+    offset,
+  });
+  res.json({
+    success: true,
+    data: {
+      broadcastId: b.id,
+      total: count,
+      limit,
+      offset,
+      recipients: rows.map((r) => ({
+        id: r.id,
+        consumerId: r.consumerId,
+        email: r.email,
+        status: r.status,
+        reason: r.reason,
+        error: r.error,
+        sentAt: r.sentAt,
+      })),
+    },
+  });
+});

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -68,6 +68,14 @@ export async function bootstrapDatabase() {
     logger.info('suppression propagation reconciler armed (dark until a subscriber carries lead.suppressed)');
   });
 
+  // Email broadcasts (tracker "emailpush"): flip in-flight broadcasts whose
+  // worker died with the old process to `interrupted`. Resume is a human act
+  // in the admin UI — nothing auto-sends on a deploy/restart.
+  await safeRun('Email broadcast stale sweep', async () => {
+    const { sweepStaleBroadcasts } = await import('../services/emailBroadcastService.js');
+    await sweepStaleBroadcasts();
+  });
+
   // Poll for stale webhook retries every 60 seconds (skip in test mode)
   if (process.env.NODE_ENV !== 'test') {
     setInterval(async () => {
@@ -78,6 +86,18 @@ export async function bootstrapDatabase() {
         logger.warn('[Webhook] periodic recovery failed', { error: err?.message });
       }
     }, 60_000);
+
+    // Email-broadcast stale-sweep backstop (5 min): a worker lost to a deploy
+    // mid-send surfaces as `interrupted` (Resume button) without waiting for
+    // the next boot.
+    setInterval(async () => {
+      try {
+        const { sweepStaleBroadcasts } = await import('../services/emailBroadcastService.js');
+        await sweepStaleBroadcasts();
+      } catch (err) {
+        logger.warn('[EmailBroadcast] stale sweep failed', { error: err?.message });
+      }
+    }, 300_000);
 
     // Suppression-propagation backstop pass every 60 minutes — heals lost
     // triggers, races, and dark-period backlogs (never throws internally).

--- a/backend/src/database/migrations/085-email-broadcasts.js
+++ b/backend/src/database/migrations/085-email-broadcasts.js
@@ -1,0 +1,132 @@
+/**
+ * 085 — Email broadcast push (tracker "emailpush",
+ * docs/plans/email-broadcast-push.md).
+ *
+ * `email_broadcasts` is a composed push (subject/body/CTA about ONE campaign,
+ * aimed at ONE cohort) plus its send-context snapshot, frozen at `preparing`
+ * so a resume can never send under drifted config. `email_broadcast_recipients`
+ * is the send log AND the per-recipient at-most-once claim: the unique
+ * (broadcastId, consumerId) pair plus the pending→attempting CAS is what makes
+ * a crash-resume unable to double-send.
+ *
+ * Erasure contract: recipients rows are consumerId-linked and join the
+ * erasureService matrix (email + error nulled, delivery facts kept on the
+ * retained skeleton).
+ *
+ * Guarded/idempotent + sync-tolerant like 080/084 (test boot syncs models
+ * first; CHECKs and indexes are name-guarded, FKs column-checked).
+ */
+export async function up(queryInterface) {
+  const q = (sql) => queryInterface.sequelize.query(sql);
+
+  await q(`CREATE TABLE IF NOT EXISTS email_broadcasts (
+    id UUID PRIMARY KEY,
+    "cohortId" UUID NOT NULL,
+    "campaignId" UUID,
+    subject VARCHAR(200) NOT NULL,
+    "bodyText" TEXT NOT NULL,
+    "ctaLabel" VARCHAR(80) NOT NULL DEFAULT 'Learn more',
+    "definitionSnapshot" JSONB,
+    "hostChoice" VARCHAR(8),
+    "emailContext" VARCHAR(8),
+    "ctaUrl" TEXT,
+    status VARCHAR(16) NOT NULL DEFAULT 'draft',
+    "totalRecipients" INTEGER NOT NULL DEFAULT 0,
+    "sentCount" INTEGER NOT NULL DEFAULT 0,
+    "skippedCount" INTEGER NOT NULL DEFAULT 0,
+    "failedCount" INTEGER NOT NULL DEFAULT 0,
+    "workerHeartbeatAt" TIMESTAMP WITH TIME ZONE,
+    "startedAt" TIMESTAMP WITH TIME ZONE,
+    "completedAt" TIMESTAMP WITH TIME ZONE,
+    "lastError" TEXT,
+    "createdBy" UUID,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+  )`);
+
+  await q(`CREATE TABLE IF NOT EXISTS email_broadcast_recipients (
+    id UUID PRIMARY KEY,
+    "broadcastId" UUID NOT NULL,
+    "consumerId" UUID NOT NULL,
+    email VARCHAR(320),
+    status VARCHAR(16) NOT NULL DEFAULT 'pending',
+    reason VARCHAR(64),
+    error TEXT,
+    "sentAt" TIMESTAMP WITH TIME ZONE,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+  )`);
+
+  // FKs — column-level existence checks (sync names its own constraints).
+  await q(`DO $$ BEGIN
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
+       WHERE tc.table_name = 'email_broadcasts' AND tc.constraint_type = 'FOREIGN KEY'
+         AND kcu.column_name = 'cohortId'
+    ) THEN
+      ALTER TABLE email_broadcasts ADD CONSTRAINT fk_eb_cohort
+        FOREIGN KEY ("cohortId") REFERENCES cohorts(id) ON DELETE RESTRICT;
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
+       WHERE tc.table_name = 'email_broadcasts' AND tc.constraint_type = 'FOREIGN KEY'
+         AND kcu.column_name = 'campaignId'
+    ) THEN
+      ALTER TABLE email_broadcasts ADD CONSTRAINT fk_eb_campaign
+        FOREIGN KEY ("campaignId") REFERENCES campaigns(id) ON DELETE SET NULL;
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
+       WHERE tc.table_name = 'email_broadcasts' AND tc.constraint_type = 'FOREIGN KEY'
+         AND kcu.column_name = 'createdBy'
+    ) THEN
+      ALTER TABLE email_broadcasts ADD CONSTRAINT fk_eb_created_by
+        FOREIGN KEY ("createdBy") REFERENCES users(id) ON DELETE SET NULL;
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
+       WHERE tc.table_name = 'email_broadcast_recipients' AND tc.constraint_type = 'FOREIGN KEY'
+         AND kcu.column_name = 'broadcastId'
+    ) THEN
+      ALTER TABLE email_broadcast_recipients ADD CONSTRAINT fk_ebr_broadcast
+        FOREIGN KEY ("broadcastId") REFERENCES email_broadcasts(id) ON DELETE CASCADE;
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
+       WHERE tc.table_name = 'email_broadcast_recipients' AND tc.constraint_type = 'FOREIGN KEY'
+         AND kcu.column_name = 'consumerId'
+    ) THEN
+      ALTER TABLE email_broadcast_recipients ADD CONSTRAINT fk_ebr_consumer
+        FOREIGN KEY ("consumerId") REFERENCES consumers(id) ON DELETE RESTRICT;
+    END IF;
+  END $$`);
+
+  // Enum + integrity CHECKs (name-guarded, 080 pattern).
+  await q(`DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_eb_status') THEN
+      ALTER TABLE email_broadcasts ADD CONSTRAINT chk_eb_status
+        CHECK (status IN ('draft','preparing','sending','cancelling','completed','interrupted','failed','cancelled'));
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_eb_counts') THEN
+      ALTER TABLE email_broadcasts ADD CONSTRAINT chk_eb_counts
+        CHECK ("totalRecipients" >= 0 AND "sentCount" >= 0 AND "skippedCount" >= 0 AND "failedCount" >= 0);
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_ebr_status') THEN
+      ALTER TABLE email_broadcast_recipients ADD CONSTRAINT chk_ebr_status
+        CHECK (status IN ('pending','attempting','sent','skipped','failed'));
+    END IF;
+  END $$`);
+
+  await q(`CREATE INDEX IF NOT EXISTS idx_eb_status_created
+             ON email_broadcasts (status, "createdAt" DESC)`);
+  // The at-most-once fence: one row per (broadcast, consumer), ever.
+  await q(`CREATE UNIQUE INDEX IF NOT EXISTS uq_ebr_broadcast_consumer
+             ON email_broadcast_recipients ("broadcastId", "consumerId")`);
+  await q(`CREATE INDEX IF NOT EXISTS idx_ebr_broadcast_status
+             ON email_broadcast_recipients ("broadcastId", status)`);
+}

--- a/backend/src/database/migrations/085-email-broadcasts.js
+++ b/backend/src/database/migrations/085-email-broadcasts.js
@@ -36,6 +36,7 @@ export async function up(queryInterface) {
     "skippedCount" INTEGER NOT NULL DEFAULT 0,
     "failedCount" INTEGER NOT NULL DEFAULT 0,
     "workerHeartbeatAt" TIMESTAMP WITH TIME ZONE,
+    "workerLeaseId" UUID,
     "startedAt" TIMESTAMP WITH TIME ZONE,
     "completedAt" TIMESTAMP WITH TIME ZONE,
     "lastError" TEXT,

--- a/backend/src/middleware/internalRouteHostGuard.js
+++ b/backend/src/middleware/internalRouteHostGuard.js
@@ -22,6 +22,7 @@ const BLOCKED_PATH_PREFIXES = [
   '/api/admin',
   '/api/consumers',
   '/api/cohorts',
+  '/api/email-broadcasts',
   '/api/agents',
   '/api/fleet',
   '/api/devices',

--- a/backend/src/models/EmailBroadcast.js
+++ b/backend/src/models/EmailBroadcast.js
@@ -1,0 +1,66 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * An email broadcast push (tracker "emailpush",
+ * docs/plans/email-broadcast-push.md): admin-composed subject/body/CTA about
+ * ONE campaign, aimed at ONE saved cohort.
+ *
+ * Lifecycle (every transition a conditional UPDATE — CAS, no two processes
+ * can both win one):
+ *   draft → preparing → sending → completed
+ *   preparing/sending → cancelling → cancelled;  crash → interrupted (boot
+ *   sweep / stale heartbeat);  loop error → failed.
+ *
+ * The send-context snapshot (definitionSnapshot/hostChoice/emailContext/
+ * ctaUrl) is frozen at `preparing` — the worker and any resume read ONLY the
+ * snapshot, so cohort edits or config drift can never change what an
+ * in-flight broadcast sends. `completed` means the worker finished; the
+ * OUTCOME (all sent / partial / nothing) is derived from counts — delivery
+ * beyond SMTP acceptance is never claimed.
+ */
+export const EMAIL_BROADCAST_STATUSES = [
+  'draft', 'preparing', 'sending', 'cancelling',
+  'completed', 'interrupted', 'failed', 'cancelled',
+];
+
+const EmailBroadcast = sequelize.define('EmailBroadcast', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  cohortId: { type: DataTypes.UUID, allowNull: false, references: { model: 'cohorts', key: 'id' } },
+  campaignId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    references: { model: 'campaigns', key: 'id' },
+    comment: 'The campaign the email is ABOUT — gate scope + CTA target. SET NULL survives campaign hard-delete; a null campaign fails resume preflight.'
+  },
+  subject: { type: DataTypes.STRING(200), allowNull: false },
+  bodyText: { type: DataTypes.TEXT, allowNull: false },
+  ctaLabel: { type: DataTypes.STRING(80), allowNull: false, defaultValue: 'Learn more' },
+  definitionSnapshot: {
+    type: DataTypes.JSONB,
+    allowNull: true,
+    comment: 'Normalized cohort definition with marketingContext.campaignId overridden to campaignId, frozen at preparing'
+  },
+  hostChoice: { type: DataTypes.STRING(8), allowNull: true, comment: "'redeem'|'mktr' — clamped customer-host enum at preparing" },
+  emailContext: { type: DataTypes.STRING(8), allowNull: true, comment: "mailer from-context ('redeem'|'mktr') at preparing" },
+  ctaUrl: { type: DataTypes.TEXT, allowNull: true, comment: 'Frozen CTA link incl. utm — what actually went out' },
+  status: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'draft' },
+  totalRecipients: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  sentCount: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  skippedCount: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  failedCount: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  workerHeartbeatAt: { type: DataTypes.DATE, allowNull: true, comment: 'Worker liveness; stale ≥120s ⇒ resumable/boot-sweepable' },
+  startedAt: { type: DataTypes.DATE, allowNull: true },
+  completedAt: { type: DataTypes.DATE, allowNull: true },
+  lastError: { type: DataTypes.TEXT, allowNull: true },
+  createdBy: { type: DataTypes.UUID, allowNull: true, references: { model: 'users', key: 'id' } },
+}, {
+  tableName: 'email_broadcasts',
+  indexes: [
+    // Mirrored on the model because test boot builds schema via
+    // sync({force:true}) BEFORE migrations (the Cohort.js lesson).
+    { fields: ['status', 'createdAt'], name: 'idx_eb_status_created' },
+  ]
+});
+
+export default EmailBroadcast;

--- a/backend/src/models/EmailBroadcast.js
+++ b/backend/src/models/EmailBroadcast.js
@@ -50,6 +50,7 @@ const EmailBroadcast = sequelize.define('EmailBroadcast', {
   skippedCount: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
   failedCount: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
   workerHeartbeatAt: { type: DataTypes.DATE, allowNull: true, comment: 'Worker liveness; stale ≥120s ⇒ resumable/boot-sweepable' },
+  workerLeaseId: { type: DataTypes.UUID, allowNull: true, comment: 'Ownership lease minted per start/resume; heartbeats/finalize are keyed to it so superseded workers exit' },
   startedAt: { type: DataTypes.DATE, allowNull: true },
   completedAt: { type: DataTypes.DATE, allowNull: true },
   lastError: { type: DataTypes.TEXT, allowNull: true },

--- a/backend/src/models/EmailBroadcastRecipient.js
+++ b/backend/src/models/EmailBroadcastRecipient.js
@@ -1,0 +1,48 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Per-recipient send log AND at-most-once claim for an email broadcast
+ * (tracker "emailpush"). The unique (broadcastId, consumerId) pair is the
+ * double-send fence; the pending→attempting CAS marks the transport attempt
+ * BEFORE SMTP so a crash in the gap leaves an `attempting` row that resume
+ * marks failed/ambiguous_crash and NEVER retries (at-most-once, chosen
+ * deliberately: a missed marketing mail is recoverable, a double send isn't).
+ *
+ * Erasure contract (erasureService matrix): `email` and `error` are CONTENT
+ * about the person and get nulled; status/reason/sentAt are delivery facts on
+ * the retained skeleton and stay (same stance as redemptions/commissions).
+ */
+export const EMAIL_RECIPIENT_STATUSES = ['pending', 'attempting', 'sent', 'skipped', 'failed'];
+
+/** Skip/fail vocabulary: consent-gate codes verbatim + sender-side codes. */
+export const EMAIL_RECIPIENT_REASONS = [
+  'erased', 'suppressed', 'not_consented', 'not_verified', 'not_found',
+  'missing_email', 'duplicate_email', 'address_suppressed',
+  'unsub_token_error', 'send_error', 'ambiguous_crash', 'cancelled',
+];
+
+const EmailBroadcastRecipient = sequelize.define('EmailBroadcastRecipient', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  broadcastId: { type: DataTypes.UUID, allowNull: false, references: { model: 'email_broadcasts', key: 'id' } },
+  consumerId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'consumers', key: 'id' },
+    comment: 'Erasure keeps an anonymized consumer husk, so this FK never dangles'
+  },
+  email: { type: DataTypes.STRING(320), allowNull: true, comment: 'Address actually attempted (refreshed at send time); nulled by erasure' },
+  status: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'pending' },
+  reason: { type: DataTypes.STRING(64), allowNull: true },
+  error: { type: DataTypes.TEXT, allowNull: true, comment: 'Transport error message; nulled by erasure' },
+  sentAt: { type: DataTypes.DATE, allowNull: true },
+}, {
+  tableName: 'email_broadcast_recipients',
+  indexes: [
+    // Mirrored on the model (sync({force:true}) test boot — Cohort.js lesson).
+    { unique: true, fields: ['broadcastId', 'consumerId'], name: 'uq_ebr_broadcast_consumer' },
+    { fields: ['broadcastId', 'status'], name: 'idx_ebr_broadcast_status' },
+  ]
+});
+
+export default EmailBroadcastRecipient;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -101,6 +101,19 @@ function defineAssociations() {
   const { Cohort } = models;
   Cohort.belongsTo(User, { foreignKey: 'createdBy', as: 'creator', onDelete: 'SET NULL' });
 
+  // Email broadcast push (tracker "emailpush") — send history must survive:
+  // RESTRICT from cohorts (they soft-archive anyway), SET NULL from campaigns
+  // (campaignService can hard-delete archived campaigns; the frozen
+  // ctaUrl/subject keep the audit), RESTRICT from consumers (erasure keeps a
+  // husk row and the matrix nulls recipient email/error instead).
+  const { EmailBroadcast, EmailBroadcastRecipient } = models;
+  EmailBroadcast.belongsTo(Cohort, { foreignKey: 'cohortId', as: 'cohort', onDelete: 'RESTRICT' });
+  EmailBroadcast.belongsTo(Campaign, { foreignKey: 'campaignId', as: 'campaign', onDelete: 'SET NULL' });
+  EmailBroadcast.belongsTo(User, { foreignKey: 'createdBy', as: 'creator', onDelete: 'SET NULL' });
+  EmailBroadcast.hasMany(EmailBroadcastRecipient, { foreignKey: 'broadcastId', as: 'recipients', onDelete: 'CASCADE' });
+  EmailBroadcastRecipient.belongsTo(EmailBroadcast, { foreignKey: 'broadcastId', as: 'broadcast', onDelete: 'CASCADE' });
+  EmailBroadcastRecipient.belongsTo(Consumer, { foreignKey: 'consumerId', as: 'consumer', onDelete: 'RESTRICT' });
+
   // Suppression-propagation projection (tracker "propagate") — derived rows,
   // reconciler-owned. CASCADE from prospect/subscriber (a vanished lead or
   // subscriber voids the pair); RESTRICT from consumers like the ledger.
@@ -382,7 +395,7 @@ export const {
   DiscoveryPlaceMemory, OutreachCadence, OutreachCadenceStep,
   OutreachCadenceTransition, OutreachCadenceEnrollment, OutreachSuppression,
   AiSettings, WalletLedger, Consumer, ConsentEvent, ConsumerSuppression,
-  SuppressionPropagation, Cohort
+  SuppressionPropagation, Cohort, EmailBroadcast, EmailBroadcastRecipient
 } = models;
 
 export { sequelize };

--- a/backend/src/routes/emailBroadcasts.js
+++ b/backend/src/routes/emailBroadcasts.js
@@ -1,0 +1,58 @@
+import express from 'express';
+import Joi from 'joi';
+import { authenticateToken, requireAdmin } from '../middleware/auth.js';
+import { validate } from '../middleware/validation.js';
+import * as emailBroadcastController from '../controllers/emailBroadcastController.js';
+
+export const meta = { path: '/api/email-broadcasts' };
+
+/**
+ * Email broadcast push (tracker "emailpush") — ADMIN ONLY, the /api/cohorts
+ * posture: broadcasts aggregate cross-campaign PII and SEND marketing mail.
+ * Nothing here fires without an explicit admin action; the binding
+ * per-recipient consent gate lives in emailBroadcastService (§3.3), not in
+ * these schemas. Joi stays local to this file on purpose — the shared
+ * validation middleware carries parallel in-flight work.
+ */
+
+const uuid = Joi.string().uuid();
+const shortStr = (max) => Joi.string().trim().min(1).max(max);
+
+const createSchema = Joi.object({
+  cohortId: uuid.required(),
+  campaignId: uuid.required(),
+  subject: shortStr(200).required(),
+  bodyText: shortStr(5000).required(),
+  ctaLabel: shortStr(80),
+});
+
+const updateSchema = Joi.object({
+  cohortId: uuid,
+  campaignId: uuid,
+  subject: shortStr(200),
+  bodyText: shortStr(5000),
+  ctaLabel: shortStr(80),
+}).min(1);
+
+// `resume` continues an interrupted/stale send over remaining pending rows
+// only — it never re-resolves the audience (§3.3).
+const sendSchema = Joi.object({
+  resume: Joi.boolean(),
+});
+
+const router = express.Router();
+router.use(authenticateToken, requireAdmin);
+
+router.post('/', validate(createSchema), emailBroadcastController.create);
+router.get('/', emailBroadcastController.list);
+router.get('/:id', emailBroadcastController.get);
+router.put('/:id', validate(updateSchema), emailBroadcastController.update);
+router.delete('/:id', emailBroadcastController.destroy);
+router.post('/:id/send', validate(sendSchema), emailBroadcastController.send);
+router.post('/:id/cancel', emailBroadcastController.cancel);
+// Test sends go to the REQUESTING admin's own address — deliberately no `to`
+// parameter (an authenticated arbitrary-address relay would be an abuse hole).
+router.post('/:id/test', emailBroadcastController.test);
+router.get('/:id/recipients', emailBroadcastController.recipients);
+
+export default router;

--- a/backend/src/services/emailBroadcastService.js
+++ b/backend/src/services/emailBroadcastService.js
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { QueryTypes } from 'sequelize';
 import {
   sequelize, EmailBroadcast, EmailBroadcastRecipient, Cohort, Campaign, Consumer,
@@ -37,6 +38,10 @@ import { renderBroadcastEmail } from './emailBroadcastTemplate.js';
  */
 
 export const STALE_WORKER_MS = 120_000;
+
+// pg advisory-lock key serializing broadcast state transitions (the
+// runMigrations lock is 870778001; this is the next slot in the family).
+const TRANSITION_LOCK_KEY = 870778002;
 
 const RATE_DEFAULT = 2;
 const MAX_RECIPIENTS_DEFAULT = 5000;
@@ -125,6 +130,19 @@ export function makeEmailBroadcastService(overrides = {}) {
    * `pending` rows only — never re-resolves the audience (§3.3). Returns
    * { broadcast, workerPromise }; callers fire-and-forget, tests await.
    */
+  /** Run a state-transition UPDATE under the broadcast advisory lock — two
+   * concurrent transitions (even on DIFFERENT rows) serialize here, which is
+   * what makes the one-in-flight NOT EXISTS check skew-proof. */
+  async function lockedTransition(sql, replacements) {
+    return d.sequelize.transaction(async (t) => {
+      await d.sequelize.query('SELECT pg_advisory_xact_lock(:key)', {
+        replacements: { key: TRANSITION_LOCK_KEY }, transaction: t,
+      });
+      const [rows] = await d.sequelize.query(sql, { replacements, transaction: t });
+      return rows;
+    });
+  }
+
   async function startBroadcastSend(broadcastId, { resume = false } = {}) {
     if (activeSends.has(broadcastId)) {
       throw new AppError('This broadcast is already sending in this process', 409);
@@ -132,18 +150,25 @@ export function makeEmailBroadcastService(overrides = {}) {
     const broadcast = await d.EmailBroadcast.findByPk(broadcastId);
     if (!broadcast) throw new AppError('Broadcast not found', 404);
 
+    // The worker-ownership lease: every start/resume mints one; heartbeats,
+    // finalization and the crash handler are all keyed to it, so a superseded
+    // (zombie) worker loses its next heartbeat and exits instead of racing.
+    const leaseId = randomUUID();
+
     if (!resume) {
-      // Atomic: win draft→preparing AND assert no other broadcast in flight.
-      const [rows] = await d.sequelize.query(
+      // Atomic under the advisory lock: win draft→preparing AND assert no
+      // other broadcast is in flight (NOT EXISTS alone is write-skewable).
+      const rows = await lockedTransition(
         `UPDATE email_broadcasts
-            SET status = 'preparing', "startedAt" = now(), "workerHeartbeatAt" = now(), "lastError" = NULL, "updatedAt" = now()
+            SET status = 'preparing', "startedAt" = now(), "workerHeartbeatAt" = now(),
+                "workerLeaseId" = :lease, "lastError" = NULL, "updatedAt" = now()
           WHERE id = :id AND status = 'draft'
             AND NOT EXISTS (
               SELECT 1 FROM email_broadcasts b2
                WHERE b2.status IN ('preparing','sending','cancelling') AND b2.id <> :id
             )
           RETURNING id`,
-        { replacements: { id: broadcastId } }
+        { id: broadcastId, lease: leaseId }
       );
       if (rows.length === 0) {
         const inFlight = await d.EmailBroadcast.count({ where: { status: ['preparing', 'sending', 'cancelling'] } });
@@ -152,7 +177,11 @@ export function makeEmailBroadcastService(overrides = {}) {
         throw new AppError('Broadcast could not start', 409);
       }
       try {
-        await prepare(broadcast);
+        // Reload AFTER winning the CAS: edits are draft-conditional, so this
+        // row can no longer change under us — prepare() must never see the
+        // pre-CAS snapshot (a racing edit would split audience vs content).
+        const fresh = await d.EmailBroadcast.findByPk(broadcastId);
+        await prepare(fresh);
       } catch (err) {
         // All-or-back-to-draft: nothing was sent; surface the reason on the row.
         const [reverted] = await d.EmailBroadcast.update(
@@ -175,11 +204,12 @@ export function makeEmailBroadcastService(overrides = {}) {
         throw new AppError('Broadcast has no frozen send context to resume from — cancel it and create a new push', 422);
       }
       // interrupted → sending, or self-heal a `sending` row whose worker died
-      // (stale heartbeat) without waiting for a boot sweep. Same one-in-flight
-      // fence as the draft path.
-      const [rows] = await d.sequelize.query(
+      // (stale heartbeat) without waiting for a boot sweep. Same advisory-lock
+      // + one-in-flight fence as the draft path; the fresh lease dethrones any
+      // zombie worker that later wakes up.
+      const rows = await lockedTransition(
         `UPDATE email_broadcasts
-            SET status = 'sending', "workerHeartbeatAt" = now(), "updatedAt" = now()
+            SET status = 'sending', "workerHeartbeatAt" = now(), "workerLeaseId" = :lease, "updatedAt" = now()
           WHERE id = :id
             AND (status = 'interrupted'
                  OR (status = 'sending' AND ("workerHeartbeatAt" IS NULL OR "workerHeartbeatAt" < now() - interval '120 seconds')))
@@ -188,7 +218,7 @@ export function makeEmailBroadcastService(overrides = {}) {
                WHERE b2.status IN ('preparing','sending','cancelling') AND b2.id <> :id
             )
           RETURNING id`,
-        { replacements: { id: broadcastId } }
+        { id: broadcastId, lease: leaseId }
       );
       if (rows.length === 0) throw new AppError('Broadcast is not resumable (not interrupted/stale, or another broadcast is in flight)', 409);
       // Crash-ambiguous rows are terminal: the mail may or may not have gone
@@ -200,12 +230,15 @@ export function makeEmailBroadcastService(overrides = {}) {
     }
 
     activeSends.add(broadcastId);
-    const workerPromise = runWorker(broadcastId)
+    const workerPromise = runWorker(broadcastId, leaseId)
       .catch(async (err) => {
         d.logger.error('email broadcast worker crashed', { broadcastId, error: err.message });
+        // Crash while cancelling lands cancelled (the stop must stick);
+        // crash while sending (still OUR lease) lands failed.
+        await landCancelledIfCancelling(broadcastId).catch(() => {});
         await d.EmailBroadcast.update(
           { status: 'failed', lastError: err.message || 'worker crashed', completedAt: new Date() },
-          { where: { id: broadcastId, status: ['sending', 'cancelling'] } }
+          { where: { id: broadcastId, status: 'sending', workerLeaseId: leaseId } }
         ).catch(() => {});
       })
       .finally(() => activeSends.delete(broadcastId));
@@ -280,9 +313,9 @@ export function makeEmailBroadcastService(overrides = {}) {
   }
 
   /** The throttled per-recipient loop (§3.3). Reads ONLY the frozen row. */
-  async function runWorker(broadcastId) {
+  async function runWorker(broadcastId, leaseId) {
     const broadcast = await d.EmailBroadcast.findByPk(broadcastId);
-    if (!broadcast || broadcast.status !== 'sending') return;
+    if (!broadcast || broadcast.status !== 'sending' || broadcast.workerLeaseId !== leaseId) return;
 
     const { brandName } = brandForHost(broadcast.hostChoice);
     const brandOrigin = (broadcast.ctaUrl || '').replace(/^https?:\/\//, '').split('/')[0] || null;
@@ -302,16 +335,18 @@ export function makeEmailBroadcastService(overrides = {}) {
     }
 
     for (;;) {
-      // Heartbeat + cancellation in one conditional write: losing it means an
-      // admin cancelled or a sweep/other process took ownership — stop here.
+      // Heartbeat + cancellation + ownership in one conditional write: it is
+      // keyed to OUR lease, so losing it means an admin cancelled, a sweep
+      // fired, or a resume superseded this worker — stop here either way.
       const [hb] = await d.sequelize.query(
         `UPDATE email_broadcasts SET "workerHeartbeatAt" = now(), "updatedAt" = now()
-          WHERE id = :id AND status = 'sending' RETURNING id`,
-        { replacements: { id: broadcastId } }
+          WHERE id = :id AND status = 'sending' AND "workerLeaseId" = :lease RETURNING id`,
+        { replacements: { id: broadcastId, lease: leaseId } }
       );
       if (hb.length === 0) {
         const current = await d.EmailBroadcast.findByPk(broadcastId);
-        if (current?.status === 'cancelling') await finalize(broadcastId, 'cancelled');
+        // Only the cancel path is ours to land; a superseded lease just exits.
+        if (current?.status === 'cancelling') await landCancelledIfCancelling(broadcastId);
         return;
       }
 
@@ -320,7 +355,7 @@ export function makeEmailBroadcastService(overrides = {}) {
         order: [['createdAt', 'ASC'], ['id', 'ASC']],
       });
       if (!row) {
-        await finalize(broadcastId, 'completed');
+        await finalizeCompleted(broadcastId, leaseId);
         return;
       }
 
@@ -335,6 +370,7 @@ export function makeEmailBroadcastService(overrides = {}) {
         await processRecipient(broadcast, row, { attempted, brandName, brandOrigin });
       } catch (err) {
         await row.update({ status: 'failed', reason: 'send_error', error: err.message || 'send failed' });
+        await repairRowIfErased(row.id, row.consumerId);
         d.logger.warn('broadcast recipient failed', { broadcastId, recipientId: row.id, error: err.message });
       }
 
@@ -343,7 +379,10 @@ export function makeEmailBroadcastService(overrides = {}) {
   }
 
   async function processRecipient(broadcast, row, { attempted, brandName, brandOrigin }) {
-    const skip = (reason) => row.update({ status: 'skipped', reason });
+    // Every terminal write self-repairs: a row belonging to an erased person
+    // holds no PII regardless of which path (skip/sent/failed) landed it.
+    const skip = (reason) => row.update({ status: 'skipped', reason })
+      .then(() => repairRowIfErased(row.id, row.consumerId));
 
     // Destination refresh: the claim-time address is a hint, the CURRENT
     // consumer row is the truth (erasure nulls it; newer signups replace it).
@@ -400,6 +439,10 @@ export function makeEmailBroadcastService(overrides = {}) {
 
     const to = String(consumer.email).trim();
     attempted.add(normKey);
+    // Persist the refreshed address BEFORE transport: if we crash mid-SMTP,
+    // a resume rebuilds its dedupe set from rows and must see the address
+    // actually attempted, not the stale claim-time one.
+    await row.update({ email: to });
     const result = await d.sendEmail({
       to,
       subject: broadcast.subject,
@@ -413,49 +456,76 @@ export function makeEmailBroadcastService(overrides = {}) {
       },
     });
     if (result?.success === true) {
-      await row.update({ status: 'sent', email: to, sentAt: new Date(), reason: null });
+      await row.update({ status: 'sent', sentAt: new Date(), reason: null });
     } else {
       // Transporter vanished mid-run — no transport attempt was made. The
       // address stays in `attempted` anyway (under-send over double-send).
       await row.update({ status: 'failed', reason: 'send_error', error: result?.message || 'mailer not configured' });
     }
+    await repairRowIfErased(row.id, row.consumerId);
   }
 
-  /** A cancel that raced the prepare phase has no worker to land it — do it here. */
+  /** An erasure committing between our gate check and our row write would have
+   * its 16b scrub overwritten by us — repair unconditionally after terminal
+   * writes so recipient rows never hold PII of an erased person. */
+  async function repairRowIfErased(rowId, consumerId) {
+    await d.sequelize.query(
+      `UPDATE email_broadcast_recipients r SET email = NULL, error = NULL
+        WHERE r.id = :rowId
+          AND EXISTS (SELECT 1 FROM consumers c WHERE c.id = :consumerId AND c."erasedAt" IS NOT NULL)`,
+      { replacements: { rowId, consumerId } }
+    ).catch(() => {});
+  }
+
+  /** pending → skipped/cancelled; attempting rows keep their ambiguous truth
+   * (they may have reached SMTP) — cancellation must never relabel them. */
+  async function landCancelRows(broadcastId) {
+    await d.EmailBroadcastRecipient.update(
+      { status: 'failed', reason: 'ambiguous_crash' },
+      { where: { broadcastId, status: 'attempting' } }
+    );
+    await d.EmailBroadcastRecipient.update(
+      { status: 'skipped', reason: 'cancelled' },
+      { where: { broadcastId, status: 'pending' } }
+    );
+  }
+
+  /** Land `cancelled` from `cancelling` (used by the worker, a raced prepare,
+   * the crash handler and the sweep — cancels must stick, never be relabeled). */
   async function landCancelledIfCancelling(broadcastId) {
     if (await transition(broadcastId, 'cancelling', 'cancelled', { completedAt: new Date() })) {
-      await d.EmailBroadcastRecipient.update(
-        { status: 'skipped', reason: 'cancelled' },
-        { where: { broadcastId, status: ['pending', 'attempting'] } }
+      await landCancelRows(broadcastId);
+      const counts = await liveCounts(broadcastId);
+      await d.EmailBroadcast.update(
+        { sentCount: counts.sent, skippedCount: counts.skipped, failedCount: counts.failed },
+        { where: { id: broadcastId } }
       );
     }
   }
 
-  /** Recount from rows (authoritative) and land the terminal state. */
-  async function finalize(broadcastId, finalStatus) {
-    if (finalStatus === 'cancelled') {
-      await d.EmailBroadcastRecipient.update(
-        { status: 'skipped', reason: 'cancelled' },
-        { where: { broadcastId, status: 'pending' } }
-      );
-    }
+  /** Empty queue: recount and land `completed` — strictly from `sending` under
+   * OUR lease. Losing that CAS means a cancel raced the last iteration; the
+   * cancel wins and we land it instead. */
+  async function finalizeCompleted(broadcastId, leaseId) {
     const counts = await liveCounts(broadcastId);
-    await d.EmailBroadcast.update(
+    const [won] = await d.EmailBroadcast.update(
       {
-        status: finalStatus,
+        status: 'completed',
         sentCount: counts.sent,
         skippedCount: counts.skipped,
         failedCount: counts.failed,
         completedAt: new Date(),
       },
-      { where: { id: broadcastId, status: ['sending', 'cancelling'] } }
+      { where: { id: broadcastId, status: 'sending', workerLeaseId: leaseId } }
     );
+    if (won === 0) await landCancelledIfCancelling(broadcastId);
   }
 
   /**
    * Emergency stop. preparing/sending → cancelling (the worker lands the
    * final state within one iteration); a dead broadcast (interrupted/failed)
-   * → cancelled directly, remaining pending rows marked.
+   * → cancelled directly, remaining pending rows marked (attempting rows
+   * keep their ambiguous truth).
    */
   async function cancelBroadcast(broadcastId) {
     const broadcast = await d.EmailBroadcast.findByPk(broadcastId);
@@ -464,10 +534,7 @@ export function makeEmailBroadcastService(overrides = {}) {
       return d.EmailBroadcast.findByPk(broadcastId);
     }
     if (await transition(broadcastId, ['interrupted', 'failed'], 'cancelled', { completedAt: new Date() })) {
-      await d.EmailBroadcastRecipient.update(
-        { status: 'skipped', reason: 'cancelled' },
-        { where: { broadcastId, status: ['pending', 'attempting'] } }
-      );
+      await landCancelRows(broadcastId);
       const counts = await liveCounts(broadcastId);
       await d.EmailBroadcast.update(
         { sentCount: counts.sent, skippedCount: counts.skipped, failedCount: counts.failed },
@@ -480,17 +547,24 @@ export function makeEmailBroadcastService(overrides = {}) {
 
   /**
    * Boot sweep (bootstrap.js): any in-flight broadcast whose worker heartbeat
-   * is stale belongs to a dead process → `interrupted`, its crash-ambiguous
-   * rows marked terminal. NO auto-resume — a human presses Resume; nothing
-   * mass-sends just because a deploy restarted the box.
+   * is stale belongs to a dead process. preparing/sending → `interrupted`
+   * (resumable, human decision); a stale `cancelling` lands `cancelled` — an
+   * emergency stop must never be swept back into a resumable state. NO
+   * auto-resume; nothing mass-sends just because a deploy restarted the box.
    */
   async function sweepStaleBroadcasts() {
+    const staleCond = `("workerHeartbeatAt" IS NULL OR "workerHeartbeatAt" < now() - interval '120 seconds')`;
+    const [cancelRows] = await d.sequelize.query(
+      `SELECT id FROM email_broadcasts WHERE status = 'cancelling' AND ${staleCond}`
+    );
+    for (const r of cancelRows) {
+      await landCancelledIfCancelling(r.id);
+    }
     const [rows] = await d.sequelize.query(
       `UPDATE email_broadcasts
           SET status = 'interrupted', "updatedAt" = now(),
               "lastError" = COALESCE("lastError", 'worker lost (deploy/crash) — resume to continue')
-        WHERE status IN ('preparing','sending','cancelling')
-          AND ("workerHeartbeatAt" IS NULL OR "workerHeartbeatAt" < now() - interval '120 seconds')
+        WHERE status IN ('preparing','sending') AND ${staleCond}
         RETURNING id`
     );
     for (const r of rows) {
@@ -499,10 +573,13 @@ export function makeEmailBroadcastService(overrides = {}) {
         { where: { broadcastId: r.id, status: 'attempting' } }
       );
     }
-    if (rows.length > 0) {
-      d.logger.warn('swept stale email broadcasts to interrupted', { count: rows.length, ids: rows.map((r) => r.id) });
+    const swept = rows.length + cancelRows.length;
+    if (swept > 0) {
+      d.logger.warn('swept stale email broadcasts', {
+        interrupted: rows.map((r) => r.id), cancelled: cancelRows.map((r) => r.id),
+      });
     }
-    return rows.length;
+    return swept;
   }
 
   /**

--- a/backend/src/services/emailBroadcastService.js
+++ b/backend/src/services/emailBroadcastService.js
@@ -1,0 +1,565 @@
+import { QueryTypes } from 'sequelize';
+import {
+  sequelize, EmailBroadcast, EmailBroadcastRecipient, Cohort, Campaign, Consumer,
+} from '../models/index.js';
+import { AppError } from '../middleware/errorHandler.js';
+import { logger } from '../utils/logger.js';
+import { sendEmail, getTransporter } from './mailer.js';
+import { ensureUnsubToken, findConsumerByUnsubToken } from './consentService.js';
+import { canMarketToBatch, listCohortMembers, normalizeDefinition } from './cohortService.js';
+import { emailNormKey } from './repeatSignup.js';
+import { customerHostOrigin, normalizeCustomerHostChoice } from '../utils/customerHost.js';
+import { renderBroadcastEmail } from './emailBroadcastTemplate.js';
+
+/**
+ * Email broadcast push (tracker "emailpush",
+ * docs/plans/email-broadcast-push.md). Discharges the §5 sender obligations
+ * of docs/plans/cohort-builder-backend.md for the email channel:
+ *
+ *   - EVERY recipient is re-gated at send time, per person, against the
+ *     campaign the email is ACTUALLY about (canMarketToBatch — parity-proven
+ *     === consentService.canMarketTo). Cohort membership never substitutes.
+ *   - Marketing mail without a WORKING unsubscribe link is never sent: the
+ *     minted PR-B token is verified via findConsumerByUnsubToken before the
+ *     transport attempt.
+ *   - At-most-once per recipient: the unique (broadcastId, consumerId) row is
+ *     the claim, and the pending→attempting CAS lands durably BEFORE SMTP. A
+ *     crash in the gap surfaces as `ambiguous_crash`, never a resend — for
+ *     marketing, a missed mail is recoverable and a double send is not.
+ *   - One broadcast in flight globally (draft→preparing CAS carries a
+ *     NOT EXISTS over active statuses), which also makes the throttle a real
+ *     global cap on the single-instance deployment.
+ *
+ * DNC note: Singapore's DNC registry covers voice/SMS/fax — not email — so
+ * the §9.5-2 send-time DNC scrub obligation binds the future voice/SMS/
+ * WhatsApp senders ("wapush"), not this one. The consent gate above is the
+ * email-channel requirement and it is enforced per send.
+ */
+
+export const STALE_WORKER_MS = 120_000;
+
+const RATE_DEFAULT = 2;
+const MAX_RECIPIENTS_DEFAULT = 5000;
+
+function ratePerSec() {
+  const raw = Number.parseFloat(process.env.EMAIL_BROADCAST_RATE_PER_SEC || '');
+  const rate = Number.isFinite(raw) ? raw : RATE_DEFAULT;
+  return Math.min(10, Math.max(0.2, rate));
+}
+
+function maxRecipients() {
+  const raw = Number.parseInt(process.env.EMAIL_BROADCAST_MAX_RECIPIENTS || '', 10);
+  const cap = Number.isFinite(raw) ? raw : MAX_RECIPIENTS_DEFAULT;
+  return Math.min(20_000, Math.max(1, cap));
+}
+
+function apiPublicOrigin() {
+  return process.env.API_PUBLIC_ORIGIN || 'https://api.mktr.sg';
+}
+
+/** Brand strings for the template, from the clamped host choice. */
+function brandForHost(hostChoice) {
+  return hostChoice === 'mktr'
+    ? { brandName: 'MKTR', emailContext: 'mktr' }
+    : { brandName: 'redeem.sg', emailContext: 'redeem' };
+}
+
+function buildCtaUrl({ origin, campaignId, broadcastId }) {
+  const qs = new URLSearchParams({
+    campaign_id: campaignId,
+    utm_source: 'mktr',
+    utm_medium: 'email',
+    utm_campaign: `broadcast-${String(broadcastId).slice(0, 8)}`,
+  });
+  return `${origin}/LeadCapture?${qs.toString()}`;
+}
+
+const defaultDeps = {
+  sequelize,
+  EmailBroadcast,
+  EmailBroadcastRecipient,
+  Cohort,
+  Campaign,
+  Consumer,
+  sendEmail,
+  getTransporter,
+  ensureUnsubToken,
+  findConsumerByUnsubToken,
+  canMarketToBatch,
+  listCohortMembers,
+  normalizeDefinition,
+  logger,
+  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+};
+
+export function makeEmailBroadcastService(overrides = {}) {
+  const d = { ...defaultDeps, ...overrides };
+
+  // Local short-circuit only — the FENCE is the DB CAS. Two processes racing
+  // still serialize on conditional UPDATEs; this set just stops one process
+  // from spawning two loops for the same broadcast.
+  const activeSends = new Set();
+
+  async function transition(id, from, to, extra = {}) {
+    const [count] = await d.EmailBroadcast.update(
+      { status: to, ...extra },
+      { where: { id, status: from } }
+    );
+    return count === 1;
+  }
+
+  /** Live per-status row counts (the UI's real-time truth while sending). */
+  async function liveCounts(broadcastId) {
+    const rows = await d.sequelize.query(
+      'SELECT status, COUNT(*)::int AS n FROM email_broadcast_recipients WHERE "broadcastId" = :broadcastId GROUP BY status',
+      { type: QueryTypes.SELECT, replacements: { broadcastId } }
+    );
+    const counts = { pending: 0, attempting: 0, sent: 0, skipped: 0, failed: 0 };
+    for (const r of rows) counts[r.status] = r.n;
+    return counts;
+  }
+
+  /**
+   * draft → preparing → sending, then the worker runs post-return.
+   * Resume: interrupted (or stale `sending`) → sending over remaining
+   * `pending` rows only — never re-resolves the audience (§3.3). Returns
+   * { broadcast, workerPromise }; callers fire-and-forget, tests await.
+   */
+  async function startBroadcastSend(broadcastId, { resume = false } = {}) {
+    if (activeSends.has(broadcastId)) {
+      throw new AppError('This broadcast is already sending in this process', 409);
+    }
+    const broadcast = await d.EmailBroadcast.findByPk(broadcastId);
+    if (!broadcast) throw new AppError('Broadcast not found', 404);
+
+    if (!resume) {
+      // Atomic: win draft→preparing AND assert no other broadcast in flight.
+      const [rows] = await d.sequelize.query(
+        `UPDATE email_broadcasts
+            SET status = 'preparing', "startedAt" = now(), "workerHeartbeatAt" = now(), "lastError" = NULL, "updatedAt" = now()
+          WHERE id = :id AND status = 'draft'
+            AND NOT EXISTS (
+              SELECT 1 FROM email_broadcasts b2
+               WHERE b2.status IN ('preparing','sending','cancelling') AND b2.id <> :id
+            )
+          RETURNING id`,
+        { replacements: { id: broadcastId } }
+      );
+      if (rows.length === 0) {
+        const inFlight = await d.EmailBroadcast.count({ where: { status: ['preparing', 'sending', 'cancelling'] } });
+        if (broadcast.status !== 'draft') throw new AppError(`Broadcast is ${broadcast.status}, not draft`, 409);
+        if (inFlight > 0) throw new AppError('Another broadcast is in flight — one at a time', 409);
+        throw new AppError('Broadcast could not start', 409);
+      }
+      try {
+        await prepare(broadcast);
+      } catch (err) {
+        // All-or-back-to-draft: nothing was sent; surface the reason on the row.
+        const [reverted] = await d.EmailBroadcast.update(
+          { status: 'draft', lastError: err.message || 'prepare failed' },
+          { where: { id: broadcastId, status: 'preparing' } }
+        );
+        if (reverted === 0) await landCancelledIfCancelling(broadcastId);
+        throw err;
+      }
+      const won = await transition(broadcastId, 'preparing', 'sending', { workerHeartbeatAt: new Date() });
+      if (!won) {
+        // Cancel raced us mid-prepare — land the terminal state ourselves
+        // (there is no worker yet to notice `cancelling`).
+        await landCancelledIfCancelling(broadcastId);
+        throw new AppError('Broadcast was cancelled during preparation', 409);
+      }
+    } else {
+      const fresh = await d.EmailBroadcast.findByPk(broadcastId);
+      if (!fresh.definitionSnapshot || !fresh.campaignId) {
+        throw new AppError('Broadcast has no frozen send context to resume from — cancel it and create a new push', 422);
+      }
+      // interrupted → sending, or self-heal a `sending` row whose worker died
+      // (stale heartbeat) without waiting for a boot sweep. Same one-in-flight
+      // fence as the draft path.
+      const [rows] = await d.sequelize.query(
+        `UPDATE email_broadcasts
+            SET status = 'sending', "workerHeartbeatAt" = now(), "updatedAt" = now()
+          WHERE id = :id
+            AND (status = 'interrupted'
+                 OR (status = 'sending' AND ("workerHeartbeatAt" IS NULL OR "workerHeartbeatAt" < now() - interval '120 seconds')))
+            AND NOT EXISTS (
+              SELECT 1 FROM email_broadcasts b2
+               WHERE b2.status IN ('preparing','sending','cancelling') AND b2.id <> :id
+            )
+          RETURNING id`,
+        { replacements: { id: broadcastId } }
+      );
+      if (rows.length === 0) throw new AppError('Broadcast is not resumable (not interrupted/stale, or another broadcast is in flight)', 409);
+      // Crash-ambiguous rows are terminal: the mail may or may not have gone
+      // out, so they are NEVER retried (at-most-once).
+      await d.EmailBroadcastRecipient.update(
+        { status: 'failed', reason: 'ambiguous_crash' },
+        { where: { broadcastId, status: 'attempting' } }
+      );
+    }
+
+    activeSends.add(broadcastId);
+    const workerPromise = runWorker(broadcastId)
+      .catch(async (err) => {
+        d.logger.error('email broadcast worker crashed', { broadcastId, error: err.message });
+        await d.EmailBroadcast.update(
+          { status: 'failed', lastError: err.message || 'worker crashed', completedAt: new Date() },
+          { where: { id: broadcastId, status: ['sending', 'cancelling'] } }
+        ).catch(() => {});
+      })
+      .finally(() => activeSends.delete(broadcastId));
+
+    const started = await d.EmailBroadcast.findByPk(broadcastId);
+    return { broadcast: started, workerPromise };
+  }
+
+  /** Preflight + freeze the send context + materialize claims (§3.2). */
+  async function prepare(broadcast) {
+    if (!d.getTransporter()) {
+      throw new AppError('Email transport is not configured — set EMAIL_HOST/EMAIL_USER/EMAIL_PASSWORD', 422);
+    }
+    const campaign = broadcast.campaignId ? await d.Campaign.findByPk(broadcast.campaignId) : null;
+    if (!campaign) throw new AppError('Broadcast campaign no longer exists', 422);
+    // The public surface's own gate: recipients land on this campaign's page.
+    if (campaign.status !== 'active' || campaign.is_active !== true) {
+      throw new AppError('Campaign must be active (status + is_active) before pushing people to it', 422);
+    }
+    const cohort = await d.Cohort.findByPk(broadcast.cohortId);
+    if (!cohort || cohort.archivedAt) throw new AppError('Broadcast cohort no longer exists', 422);
+
+    const hostChoice = normalizeCustomerHostChoice(campaign.design_config?.customerHost);
+    const origin = customerHostOrigin(hostChoice);
+    if (process.env.NODE_ENV === 'production' && !/^https:\/\//.test(origin)) {
+      // A missing PUBLIC_BASE_URL must never leak a localhost CTA into real mail.
+      throw new AppError('Customer origin is not https — check PUBLIC_BASE_URL/MKTR_FRONTEND_URL', 422);
+    }
+
+    // §5 scope rule: the SEND is gated on the campaign the email is actually
+    // about — override the cohort's advisory gate scope in the FROZEN snapshot.
+    const definition = d.normalizeDefinition(cohort.definition);
+    definition.marketingContext = { ...definition.marketingContext, campaignId: broadcast.campaignId };
+
+    const cap = maxRecipients();
+    const members = new Map(); // consumerId → member (page-shift dedupe)
+    let offset = 0;
+    for (;;) {
+      const page = await d.listCohortMembers(definition, {
+        channel: 'email', status: 'reachable', limit: 200, offset,
+      });
+      for (const m of page.members) members.set(m.consumerId, m);
+      if (members.size > cap) {
+        throw new AppError(`Audience exceeds EMAIL_BROADCAST_MAX_RECIPIENTS (${cap})`, 422);
+      }
+      if (page.members.length < 200) break;
+      offset += 200;
+    }
+    if (members.size === 0) {
+      throw new AppError('Cohort has no reachable email recipients for this campaign scope', 422);
+    }
+
+    const { emailContext } = brandForHost(hostChoice);
+    const ctaUrl = buildCtaUrl({ origin, campaignId: broadcast.campaignId, broadcastId: broadcast.id });
+
+    await d.sequelize.transaction(async (t) => {
+      await d.EmailBroadcastRecipient.bulkCreate(
+        [...members.values()].map((m) => ({
+          broadcastId: broadcast.id,
+          consumerId: m.consumerId,
+          email: m.email || null,
+          status: 'pending',
+        })),
+        { ignoreDuplicates: true, transaction: t }
+      );
+      const total = await d.EmailBroadcastRecipient.count({ where: { broadcastId: broadcast.id }, transaction: t });
+      await d.EmailBroadcast.update(
+        { definitionSnapshot: definition, hostChoice, emailContext, ctaUrl, totalRecipients: total },
+        { where: { id: broadcast.id }, transaction: t }
+      );
+    });
+  }
+
+  /** The throttled per-recipient loop (§3.3). Reads ONLY the frozen row. */
+  async function runWorker(broadcastId) {
+    const broadcast = await d.EmailBroadcast.findByPk(broadcastId);
+    if (!broadcast || broadcast.status !== 'sending') return;
+
+    const { brandName } = brandForHost(broadcast.hostChoice);
+    const brandOrigin = (broadcast.ctaUrl || '').replace(/^https?:\/\//, '').split('/')[0] || null;
+    const intervalMs = Math.round(1000 / ratePerSec());
+
+    // One copy per normalized address per broadcast — on resume, rebuild the
+    // attempted set from every row that reached (or ambiguously reached)
+    // transport. Conservative on purpose: an address on a failed row gets no
+    // second copy through a duplicate consumer id either.
+    const attempted = new Set();
+    const prior = await d.EmailBroadcastRecipient.findAll({
+      where: { broadcastId, status: ['sent', 'failed'] }, attributes: ['email'],
+    });
+    for (const row of prior) {
+      const key = emailNormKey(row.email);
+      if (key) attempted.add(key);
+    }
+
+    for (;;) {
+      // Heartbeat + cancellation in one conditional write: losing it means an
+      // admin cancelled or a sweep/other process took ownership — stop here.
+      const [hb] = await d.sequelize.query(
+        `UPDATE email_broadcasts SET "workerHeartbeatAt" = now(), "updatedAt" = now()
+          WHERE id = :id AND status = 'sending' RETURNING id`,
+        { replacements: { id: broadcastId } }
+      );
+      if (hb.length === 0) {
+        const current = await d.EmailBroadcast.findByPk(broadcastId);
+        if (current?.status === 'cancelling') await finalize(broadcastId, 'cancelled');
+        return;
+      }
+
+      const row = await d.EmailBroadcastRecipient.findOne({
+        where: { broadcastId, status: 'pending' },
+        order: [['createdAt', 'ASC'], ['id', 'ASC']],
+      });
+      if (!row) {
+        await finalize(broadcastId, 'completed');
+        return;
+      }
+
+      // The at-most-once fence: attempting lands durably before any transport.
+      const [claimed] = await d.EmailBroadcastRecipient.update(
+        { status: 'attempting' },
+        { where: { id: row.id, status: 'pending' } }
+      );
+      if (claimed === 0) continue; // another worker took it
+
+      try {
+        await processRecipient(broadcast, row, { attempted, brandName, brandOrigin });
+      } catch (err) {
+        await row.update({ status: 'failed', reason: 'send_error', error: err.message || 'send failed' });
+        d.logger.warn('broadcast recipient failed', { broadcastId, recipientId: row.id, error: err.message });
+      }
+
+      await d.sleep(intervalMs);
+    }
+  }
+
+  async function processRecipient(broadcast, row, { attempted, brandName, brandOrigin }) {
+    const skip = (reason) => row.update({ status: 'skipped', reason });
+
+    // Destination refresh: the claim-time address is a hint, the CURRENT
+    // consumer row is the truth (erasure nulls it; newer signups replace it).
+    const consumer = await d.Consumer.findByPk(row.consumerId);
+    if (!consumer) return skip('not_found');
+    const normKey = emailNormKey(consumer.email);
+    if (!normKey) return skip('missing_email');
+    if (attempted.has(normKey)) return skip('duplicate_email');
+
+    // Address-level suppression: consumers are phone-keyed, so a person who
+    // unsubscribed THIS address through another consumer id must still win.
+    const shared = await d.sequelize.query(
+      `SELECT 1 FROM consumer_suppressions cs
+         JOIN consumers c2 ON c2.id = cs."consumerId"
+        WHERE c2.id <> :consumerId AND cs.channel IN ('all','email')
+          AND lower(trim(c2.email)) = :normKey
+        LIMIT 1`,
+      { type: QueryTypes.SELECT, replacements: { consumerId: row.consumerId, normKey } }
+    );
+    if (shared.length > 0) return skip('address_suppressed');
+
+    // THE send-time consent gate (§5): per person, scoped to the campaign the
+    // email is actually about. Absent from the Map ⇒ fail closed.
+    const gate = await d.canMarketToBatch([row.consumerId], {
+      channel: 'email',
+      campaignId: broadcast.campaignId,
+    });
+    const verdict = gate.get(row.consumerId);
+    if (!verdict) return skip('not_found');
+    if (!verdict.ok) return skip(verdict.reasons?.[0] || 'not_consented');
+
+    // Mint AND VERIFY the unsubscribe token — a dead link (e.g. after a secret
+    // rotation) means the mail is not sent at all.
+    let token;
+    try {
+      token = await d.ensureUnsubToken(row.consumerId);
+      const owner = await d.findConsumerByUnsubToken(token);
+      if (!owner || owner.id !== row.consumerId) return skip('unsub_token_error');
+    } catch {
+      return skip('unsub_token_error');
+    }
+    const unsubscribeUrl = `${apiPublicOrigin()}/api/unsubscribe?t=${token}`;
+
+    const { html, text } = renderBroadcastEmail({
+      subject: broadcast.subject,
+      bodyText: broadcast.bodyText,
+      ctaLabel: broadcast.ctaLabel,
+      ctaUrl: broadcast.ctaUrl,
+      brandName,
+      brandOrigin,
+      unsubscribeUrl,
+      recipientFirstName: consumer.firstName,
+    });
+
+    const to = String(consumer.email).trim();
+    attempted.add(normKey);
+    const result = await d.sendEmail({
+      to,
+      subject: broadcast.subject,
+      html,
+      text,
+      context: broadcast.emailContext,
+      // Byte-for-byte the PR-B header pair (mailer.js confirmation-email rail).
+      headers: {
+        'List-Unsubscribe': `<${unsubscribeUrl}>`,
+        'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+      },
+    });
+    if (result?.success === true) {
+      await row.update({ status: 'sent', email: to, sentAt: new Date(), reason: null });
+    } else {
+      // Transporter vanished mid-run — no transport attempt was made. The
+      // address stays in `attempted` anyway (under-send over double-send).
+      await row.update({ status: 'failed', reason: 'send_error', error: result?.message || 'mailer not configured' });
+    }
+  }
+
+  /** A cancel that raced the prepare phase has no worker to land it — do it here. */
+  async function landCancelledIfCancelling(broadcastId) {
+    if (await transition(broadcastId, 'cancelling', 'cancelled', { completedAt: new Date() })) {
+      await d.EmailBroadcastRecipient.update(
+        { status: 'skipped', reason: 'cancelled' },
+        { where: { broadcastId, status: ['pending', 'attempting'] } }
+      );
+    }
+  }
+
+  /** Recount from rows (authoritative) and land the terminal state. */
+  async function finalize(broadcastId, finalStatus) {
+    if (finalStatus === 'cancelled') {
+      await d.EmailBroadcastRecipient.update(
+        { status: 'skipped', reason: 'cancelled' },
+        { where: { broadcastId, status: 'pending' } }
+      );
+    }
+    const counts = await liveCounts(broadcastId);
+    await d.EmailBroadcast.update(
+      {
+        status: finalStatus,
+        sentCount: counts.sent,
+        skippedCount: counts.skipped,
+        failedCount: counts.failed,
+        completedAt: new Date(),
+      },
+      { where: { id: broadcastId, status: ['sending', 'cancelling'] } }
+    );
+  }
+
+  /**
+   * Emergency stop. preparing/sending → cancelling (the worker lands the
+   * final state within one iteration); a dead broadcast (interrupted/failed)
+   * → cancelled directly, remaining pending rows marked.
+   */
+  async function cancelBroadcast(broadcastId) {
+    const broadcast = await d.EmailBroadcast.findByPk(broadcastId);
+    if (!broadcast) throw new AppError('Broadcast not found', 404);
+    if (await transition(broadcastId, ['preparing', 'sending'], 'cancelling')) {
+      return d.EmailBroadcast.findByPk(broadcastId);
+    }
+    if (await transition(broadcastId, ['interrupted', 'failed'], 'cancelled', { completedAt: new Date() })) {
+      await d.EmailBroadcastRecipient.update(
+        { status: 'skipped', reason: 'cancelled' },
+        { where: { broadcastId, status: ['pending', 'attempting'] } }
+      );
+      const counts = await liveCounts(broadcastId);
+      await d.EmailBroadcast.update(
+        { sentCount: counts.sent, skippedCount: counts.skipped, failedCount: counts.failed },
+        { where: { id: broadcastId } }
+      );
+      return d.EmailBroadcast.findByPk(broadcastId);
+    }
+    throw new AppError(`Broadcast is ${broadcast.status} — nothing to cancel`, 409);
+  }
+
+  /**
+   * Boot sweep (bootstrap.js): any in-flight broadcast whose worker heartbeat
+   * is stale belongs to a dead process → `interrupted`, its crash-ambiguous
+   * rows marked terminal. NO auto-resume — a human presses Resume; nothing
+   * mass-sends just because a deploy restarted the box.
+   */
+  async function sweepStaleBroadcasts() {
+    const [rows] = await d.sequelize.query(
+      `UPDATE email_broadcasts
+          SET status = 'interrupted', "updatedAt" = now(),
+              "lastError" = COALESCE("lastError", 'worker lost (deploy/crash) — resume to continue')
+        WHERE status IN ('preparing','sending','cancelling')
+          AND ("workerHeartbeatAt" IS NULL OR "workerHeartbeatAt" < now() - interval '120 seconds')
+        RETURNING id`
+    );
+    for (const r of rows) {
+      await d.EmailBroadcastRecipient.update(
+        { status: 'failed', reason: 'ambiguous_crash' },
+        { where: { broadcastId: r.id, status: 'attempting' } }
+      );
+    }
+    if (rows.length > 0) {
+      d.logger.warn('swept stale email broadcasts to interrupted', { count: rows.length, ids: rows.map((r) => r.id) });
+    }
+    return rows.length;
+  }
+
+  /**
+   * Test send: renders the real thing to the REQUESTING admin only (no
+   * address parameter — an authenticated relay would be an abuse hole),
+   * marked, inert unsubscribe, logged, never in the recipient log.
+   */
+  async function sendTestEmail(broadcastId, user) {
+    const broadcast = await d.EmailBroadcast.findByPk(broadcastId);
+    if (!broadcast) throw new AppError('Broadcast not found', 404);
+    const to = String(user?.email || '').trim();
+    if (!to) throw new AppError('Your admin account has no email address to test to', 422);
+
+    const campaign = broadcast.campaignId ? await d.Campaign.findByPk(broadcast.campaignId) : null;
+    const hostChoice = broadcast.hostChoice
+      || normalizeCustomerHostChoice(campaign?.design_config?.customerHost);
+    const { brandName, emailContext } = brandForHost(hostChoice);
+    const ctaUrl = broadcast.ctaUrl || (campaign
+      ? buildCtaUrl({ origin: customerHostOrigin(hostChoice), campaignId: campaign.id, broadcastId: broadcast.id })
+      : null);
+
+    const { html, text } = renderBroadcastEmail({
+      subject: broadcast.subject,
+      bodyText: broadcast.bodyText,
+      ctaLabel: broadcast.ctaLabel,
+      ctaUrl,
+      brandName,
+      brandOrigin: ctaUrl ? ctaUrl.replace(/^https?:\/\//, '').split('/')[0] : null,
+      unsubscribeUrl: null,
+      recipientFirstName: user?.firstName,
+      testNotice: true,
+    });
+    const result = await d.sendEmail({
+      to, subject: `[TEST] ${broadcast.subject}`, html, text, context: emailContext,
+    });
+    if (result?.success !== true) {
+      throw new AppError(result?.message || 'Email transport is not configured', 422);
+    }
+    d.logger.info('broadcast test send', { broadcastId, actor: user?.id });
+    return { to };
+  }
+
+  return {
+    startBroadcastSend,
+    cancelBroadcast,
+    sweepStaleBroadcasts,
+    sendTestEmail,
+    liveCounts,
+    buildCtaUrl,
+    _activeSends: activeSends,
+  };
+}
+
+const _default = makeEmailBroadcastService();
+export const startBroadcastSend = _default.startBroadcastSend;
+export const cancelBroadcast = _default.cancelBroadcast;
+export const sweepStaleBroadcasts = _default.sweepStaleBroadcasts;
+export const sendTestEmail = _default.sendTestEmail;
+export const liveBroadcastCounts = _default.liveCounts;
+export { buildCtaUrl };

--- a/backend/src/services/emailBroadcastTemplate.js
+++ b/backend/src/services/emailBroadcastTemplate.js
@@ -1,0 +1,124 @@
+/**
+ * The one broadcast email template (tracker "emailpush",
+ * docs/plans/email-broadcast-push.md §3.4).
+ *
+ * Deliberately minimal: 600px single-column table in the visual family of
+ * mailer.js's getModernTemplate (unexported — mailer stays frozen). Every
+ * interpolated field is HTML-escaped; the body is plain text split on blank
+ * lines into paragraphs — there is NO raw-HTML path, so admin copy can never
+ * inject markup into consumer mail.
+ *
+ * The footer carries the Spam Control Act sender identity (MKTR entity line)
+ * and the PR-B unsubscribe link; the pipeline only ever reaches this template
+ * for recipients who passed the send-time consent gate, so nothing rendered
+ * here is unsolicited mail. Final wording sits with the platform-wide counsel
+ * review (docs/plans/consumer-spine-and-consent-ledger.md §9).
+ */
+
+const escapeHtml = (value) => String(value ?? '')
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;')
+  .replace(/'/g, '&#39;');
+
+/** Blank-line-separated plain text → trimmed non-empty paragraph list. */
+export function splitParagraphs(bodyText) {
+  return String(bodyText || '')
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Render the broadcast → { html, text }. `testNotice` (test sends only)
+ * prepends a visible banner and the unsubscribe link renders inert.
+ */
+export function renderBroadcastEmail({
+  subject,
+  bodyText,
+  ctaLabel,
+  ctaUrl,
+  brandName,
+  brandOrigin,
+  unsubscribeUrl,
+  recipientFirstName,
+  testNotice = false,
+} = {}) {
+  const paragraphs = splitParagraphs(bodyText);
+  const greetingName = String(recipientFirstName || '').trim();
+  const greeting = greetingName ? `Hi ${greetingName},` : 'Hi there,';
+  const safeUnsub = unsubscribeUrl ? escapeHtml(unsubscribeUrl) : '#';
+
+  const paragraphHtml = paragraphs
+    .map((p) => `<p style="margin: 0 0 16px 0; font-size: 15px; line-height: 1.6; color: #333333;">${escapeHtml(p).replace(/\n/g, '<br/>')}</p>`)
+    .join('\n            ');
+
+  const testBanner = testNotice
+    ? `<tr><td style="background-color: #fff7e6; border: 1px solid #f0c36d; border-radius: 6px; padding: 10px 14px; font-size: 13px; color: #8a6d3b;">TEST SEND — this is a preview of a broadcast; the unsubscribe link below is inactive.</td></tr>
+        <tr><td style="height: 16px;"></td></tr>`
+    : '';
+
+  const ctaHtml = ctaUrl
+    ? `<table role="presentation" cellpadding="0" cellspacing="0" style="margin: 8px 0 24px 0;">
+              <tr>
+                <td style="border-radius: 6px; background-color: #111111;">
+                  <a href="${escapeHtml(ctaUrl)}" target="_blank" style="display: inline-block; padding: 12px 28px; font-size: 15px; font-weight: 600; color: #ffffff; text-decoration: none; border-radius: 6px;">${escapeHtml(ctaLabel || 'Learn more')}</a>
+                </td>
+              </tr>
+            </table>`
+    : '';
+
+  const html = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>${escapeHtml(subject)}</title>
+  </head>
+  <body style="margin: 0; padding: 0; background-color: #f4f4f5; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f4f4f5; padding: 24px 0;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="width: 600px; max-width: 94%; background-color: #ffffff; border-radius: 8px; overflow: hidden;">
+            <tr>
+              <td style="padding: 28px 32px 8px 32px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                  ${testBanner}
+                  <tr>
+                    <td style="font-size: 13px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: #999999; padding-bottom: 18px;">${escapeHtml(brandName || 'MKTR')}</td>
+                  </tr>
+                </table>
+                <p style="margin: 0 0 16px 0; font-size: 15px; line-height: 1.6; color: #333333;">${escapeHtml(greeting)}</p>
+                ${paragraphHtml}
+                ${ctaHtml}
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: 18px 32px 26px 32px; border-top: 1px solid #ececec;">
+                <p style="margin: 0 0 6px 0; font-size: 12px; line-height: 1.5; color: #999999;">You're receiving this because you signed up with ${escapeHtml(brandName || 'MKTR')}${brandOrigin ? ` (${escapeHtml(brandOrigin)})` : ''}.</p>
+                <p style="margin: 0 0 6px 0; font-size: 12px; line-height: 1.5; color: #999999;"><a href="${safeUnsub}" style="color: #666666; text-decoration: underline;">Unsubscribe</a> from marketing emails at any time.</p>
+                <p style="margin: 0; font-size: 12px; line-height: 1.5; color: #bbbbbb;">MKTR PTE. LTD. (UEN 202507548M), Singapore</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+
+  const textLines = [
+    ...(testNotice ? ['[TEST SEND — unsubscribe link inactive]', ''] : []),
+    greeting,
+    '',
+    ...paragraphs.flatMap((p) => [p, '']),
+    ...(ctaUrl ? [`${ctaLabel || 'Learn more'}: ${ctaUrl}`, ''] : []),
+    '--',
+    `You're receiving this because you signed up with ${brandName || 'MKTR'}${brandOrigin ? ` (${brandOrigin})` : ''}.`,
+    `Unsubscribe: ${unsubscribeUrl || '(test send)'}`,
+    'MKTR PTE. LTD. (UEN 202507548M), Singapore',
+  ];
+
+  return { html, text: textLines.join('\n') };
+}

--- a/backend/src/services/erasureService.js
+++ b/backend/src/services/erasureService.js
@@ -588,6 +588,17 @@ export function makeErasureService(overrides = {}) {
       );
       report.consentSourceUrlsScrubbed = rowCount(csMeta);
 
+      // 16b. Email-broadcast send-log rows (tracker "emailpush"): the address
+      // and any transport-error text are CONTENT about the person — nulled;
+      // delivery facts (status/reason/sentAt) stay on the retained skeleton
+      // (docs/plans/email-broadcast-push.md §5). Runs on repair too.
+      const [, ebrMeta] = await d.sequelize.query(
+        `UPDATE email_broadcast_recipients SET email = NULL, error = NULL
+          WHERE "consumerId" = :consumerId AND (email IS NOT NULL OR error IS NOT NULL)`,
+        { replacements: { consumerId }, transaction: t }
+      );
+      report.broadcastRecipientsScrubbed = rowCount(ebrMeta);
+
       // 17. The consumer itself: identity + attributes + unsub token all null.
       // phone leaving uq_consumers_phone at commit is what frees the number
       // for a genuinely-new signup.

--- a/backend/test/emailBroadcastRoutes.test.js
+++ b/backend/test/emailBroadcastRoutes.test.js
@@ -1,0 +1,257 @@
+import request from 'supertest';
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect } from './helpers.js';
+import {
+  EmailBroadcast, EmailBroadcastRecipient, Cohort, Consumer, ConsentEvent,
+} from '../src/models/index.js';
+import { hashPhone } from '../src/utils/piiHashing.js';
+
+/**
+ * /api/email-broadcasts surface (tracker "emailpush"): admin gating on every
+ * route, draft CRUD + the draft-only edit/delete fences, phantom 422s, the
+ * send preflight at the HTTP boundary, the paged send log, the self-only
+ * test send, and the erasure matrix scrubbing recipient rows.
+ */
+
+const RUN = Date.now() % 1000000000;
+let seq = 0;
+const nextPhone = () => `+657${String(RUN + (seq += 1)).padStart(7, '0').slice(-7)}`;
+
+let app;
+let admin;
+let adminToken;
+let agentToken;
+let campaign;
+let cohort;
+
+const auth = (t) => ({ Authorization: `Bearer ${t}` });
+const NIL = '00000000-0000-4000-8000-000000000000';
+
+async function makeConsumer({ email } = {}) {
+  const phone = nextPhone();
+  const consumer = await Consumer.create({
+    phone, phoneHash: hashPhone(phone), firstName: 'Route', lastName: 'Fixture',
+    email: email || `route-${RUN}-${seq}@example.test`,
+    firstSeenAt: new Date(), lastSeenAt: new Date(), signupCount: 1,
+  });
+  await createTestProspect(campaign.id, {
+    phone, consumerId: consumer.id, demographics: { dateOfBirth: '1992-02-02' },
+  });
+  await ConsentEvent.create({
+    consumerId: consumer.id, campaignId: null, kind: 'contact', granted: true,
+    channels: ['phone'], version: `emailpush-routes-${RUN}`, source: 'signup',
+    verified: true, occurredAt: new Date(),
+  });
+  return consumer;
+}
+
+function validBody(overrides = {}) {
+  return {
+    cohortId: cohort.id,
+    campaignId: campaign.id,
+    subject: 'Route test push',
+    bodyText: 'One paragraph.',
+    ...overrides,
+  };
+}
+
+beforeAll(async () => {
+  app = await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  const agent = await createTestUser({ role: 'agent' });
+  adminToken = admin.token;
+  agentToken = agent.token;
+  campaign = await createTestCampaign(admin.user.id, { name: `Broadcast Routes ${RUN}` });
+  cohort = await Cohort.create({
+    name: `Broadcast Routes Cohort ${RUN}`,
+    definition: {
+      filters: { campaignIds: [campaign.id], drawIds: [], anyDraw: false, campaignTags: [], attributes: { postalPrefixes: [], incomes: [], educations: [], genders: [] } },
+      ageGate: { minAge: 18, maxAge: null },
+      marketingContext: { campaignId: null },
+    },
+  });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+describe('auth gating', () => {
+  test('401 without a token, 403 for non-admin, on every route', async () => {
+    const routes = [
+      ['post', '/api/email-broadcasts'],
+      ['get', '/api/email-broadcasts'],
+      ['get', `/api/email-broadcasts/${NIL}`],
+      ['put', `/api/email-broadcasts/${NIL}`],
+      ['delete', `/api/email-broadcasts/${NIL}`],
+      ['post', `/api/email-broadcasts/${NIL}/send`],
+      ['post', `/api/email-broadcasts/${NIL}/cancel`],
+      ['post', `/api/email-broadcasts/${NIL}/test`],
+      ['get', `/api/email-broadcasts/${NIL}/recipients`],
+    ];
+    for (const [method, path] of routes) {
+      const anon = await request(app)[method](path);
+      expect(anon.status).toBe(401);
+      const nonAdmin = await request(app)[method](path).set(auth(agentToken));
+      expect(nonAdmin.status).toBe(403);
+    }
+  });
+});
+
+describe('draft lifecycle', () => {
+  test('create → detail (with definition + ctaUrlPreview) → edit → delete', async () => {
+    const created = await request(app).post('/api/email-broadcasts').set(auth(adminToken)).send(validBody());
+    expect(created.status).toBe(201);
+    const id = created.body.data.id;
+    expect(created.body.data.status).toBe('draft');
+    expect(created.body.data.ctaLabel).toBe('Learn more');
+    expect(created.body.data.cohort.name).toContain('Broadcast Routes Cohort');
+    expect(created.body.data.campaign.name).toContain('Broadcast Routes');
+
+    const detail = await request(app).get(`/api/email-broadcasts/${id}`).set(auth(adminToken));
+    expect(detail.status).toBe(200);
+    expect(detail.body.data.cohort.definition).toBeTruthy();
+    expect(detail.body.data.ctaUrlPreview).toContain(`campaign_id=${campaign.id}`);
+    expect(detail.body.data.ctaUrlPreview).toContain('utm_medium=email');
+    expect(detail.body.data.liveCounts).toEqual({ pending: 0, attempting: 0, sent: 0, skipped: 0, failed: 0 });
+
+    const listed = await request(app).get('/api/email-broadcasts').set(auth(adminToken));
+    expect(listed.status).toBe(200);
+    expect(listed.body.data.some((b) => b.id === id)).toBe(true);
+
+    const edited = await request(app).put(`/api/email-broadcasts/${id}`).set(auth(adminToken)).send({ subject: 'Edited subject' });
+    expect(edited.status).toBe(200);
+    expect(edited.body.data.subject).toBe('Edited subject');
+
+    const deleted = await request(app).delete(`/api/email-broadcasts/${id}`).set(auth(adminToken));
+    expect(deleted.status).toBe(200);
+    expect(await EmailBroadcast.findByPk(id)).toBeNull();
+  });
+
+  test('phantom cohort / campaign 422; malformed id 404; validation 400s', async () => {
+    const phantomCohort = await request(app).post('/api/email-broadcasts').set(auth(adminToken)).send(validBody({ cohortId: NIL }));
+    expect(phantomCohort.status).toBe(422);
+    const phantomCampaign = await request(app).post('/api/email-broadcasts').set(auth(adminToken)).send(validBody({ campaignId: NIL }));
+    expect(phantomCampaign.status).toBe(422);
+
+    const malformed = await request(app).get('/api/email-broadcasts/not-a-uuid').set(auth(adminToken));
+    expect(malformed.status).toBe(404);
+
+    const missingSubject = await request(app).post('/api/email-broadcasts').set(auth(adminToken)).send(validBody({ subject: undefined }));
+    expect(missingSubject.status).toBe(400);
+    const longSubject = await request(app).post('/api/email-broadcasts').set(auth(adminToken)).send(validBody({ subject: 'x'.repeat(201) }));
+    expect(longSubject.status).toBe(400);
+    const unknownKey = await request(app).post('/api/email-broadcasts').set(auth(adminToken)).send(validBody({ nope: true }));
+    expect(unknownKey.status).toBe(400);
+    const badResume = await request(app).post(`/api/email-broadcasts/${NIL}/send`).set(auth(adminToken)).send({ resume: 'yes' });
+    expect(badResume.status).toBe(400);
+  });
+
+  test('non-draft broadcasts cannot be edited or deleted (409)', async () => {
+    const created = await request(app).post('/api/email-broadcasts').set(auth(adminToken)).send(validBody());
+    const id = created.body.data.id;
+    await EmailBroadcast.update({ status: 'completed' }, { where: { id } });
+
+    const edited = await request(app).put(`/api/email-broadcasts/${id}`).set(auth(adminToken)).send({ subject: 'Nope' });
+    expect(edited.status).toBe(409);
+    const deleted = await request(app).delete(`/api/email-broadcasts/${id}`).set(auth(adminToken));
+    expect(deleted.status).toBe(409);
+  });
+});
+
+describe('send / cancel / test at the HTTP boundary', () => {
+  test('send 422s on the transport preflight (unconfigured test env) and reverts to draft', async () => {
+    await makeConsumer();
+    const created = await request(app).post('/api/email-broadcasts').set(auth(adminToken)).send(validBody());
+    const id = created.body.data.id;
+    const sent = await request(app).post(`/api/email-broadcasts/${id}/send`).set(auth(adminToken)).send({});
+    expect(sent.status).toBe(422);
+    expect(sent.body.message).toMatch(/transport/i);
+    const after = await EmailBroadcast.findByPk(id);
+    expect(after.status).toBe('draft');
+    expect(after.lastError).toMatch(/transport/i);
+  });
+
+  test('cancel on a draft 409s; cancel on an interrupted broadcast lands cancelled', async () => {
+    const created = await request(app).post('/api/email-broadcasts').set(auth(adminToken)).send(validBody());
+    const id = created.body.data.id;
+    const noop = await request(app).post(`/api/email-broadcasts/${id}/cancel`).set(auth(adminToken));
+    expect(noop.status).toBe(409);
+
+    await EmailBroadcast.update({ status: 'interrupted' }, { where: { id } });
+    const consumer = await makeConsumer();
+    await EmailBroadcastRecipient.create({ broadcastId: id, consumerId: consumer.id, email: consumer.email, status: 'pending' });
+
+    const cancelled = await request(app).post(`/api/email-broadcasts/${id}/cancel`).set(auth(adminToken));
+    expect(cancelled.status).toBe(200);
+    expect(cancelled.body.data.status).toBe('cancelled');
+    const rows = await EmailBroadcastRecipient.findAll({ where: { broadcastId: id } });
+    expect(rows[0].status).toBe('skipped');
+    expect(rows[0].reason).toBe('cancelled');
+  });
+
+  test('test send takes NO address parameter and 422s while the mailer is unconfigured', async () => {
+    const created = await request(app).post('/api/email-broadcasts').set(auth(adminToken)).send(validBody());
+    const id = created.body.data.id;
+    const res = await request(app).post(`/api/email-broadcasts/${id}/test`).set(auth(adminToken)).send({ to: 'attacker@example.com' });
+    // The body is ignored (no schema accepts `to`); the send targets the
+    // requesting admin and fails only on the unconfigured transport.
+    expect(res.status).toBe(422);
+    expect(res.body.message).toMatch(/not configured|Mailer/i);
+  });
+});
+
+describe('send log', () => {
+  test('recipients page + filter by status', async () => {
+    const created = await request(app).post('/api/email-broadcasts').set(auth(adminToken)).send(validBody());
+    const id = created.body.data.id;
+    await EmailBroadcast.update({ status: 'completed' }, { where: { id } });
+    const statuses = ['sent', 'sent', 'skipped', 'failed'];
+    for (const status of statuses) {
+      const c = await makeConsumer();
+      await EmailBroadcastRecipient.create({
+        broadcastId: id, consumerId: c.id, email: c.email, status,
+        reason: status === 'skipped' ? 'suppressed' : status === 'failed' ? 'send_error' : null,
+        sentAt: status === 'sent' ? new Date() : null,
+      });
+    }
+
+    const all = await request(app).get(`/api/email-broadcasts/${id}/recipients`).set(auth(adminToken));
+    expect(all.status).toBe(200);
+    expect(all.body.data.total).toBe(4);
+
+    const sentOnly = await request(app).get(`/api/email-broadcasts/${id}/recipients?status=sent`).set(auth(adminToken));
+    expect(sentOnly.body.data.total).toBe(2);
+    expect(sentOnly.body.data.recipients.every((r) => r.status === 'sent')).toBe(true);
+
+    const paged = await request(app).get(`/api/email-broadcasts/${id}/recipients?limit=2&offset=2`).set(auth(adminToken));
+    expect(paged.body.data.recipients).toHaveLength(2);
+    expect(paged.body.data.limit).toBe(2);
+    expect(paged.body.data.offset).toBe(2);
+  });
+});
+
+describe('erasure integration', () => {
+  test('erasing a consumer nulls recipient email + error, keeps delivery facts', async () => {
+    const c = await makeConsumer({ email: `erase-${RUN}@example.test` });
+    const created = await request(app).post('/api/email-broadcasts').set(auth(adminToken)).send(validBody());
+    const id = created.body.data.id;
+    await EmailBroadcast.update({ status: 'completed' }, { where: { id } });
+    const row = await EmailBroadcastRecipient.create({
+      broadcastId: id, consumerId: c.id, email: c.email, status: 'failed',
+      reason: 'send_error', error: `550 mailbox ${c.email} unavailable`, sentAt: null,
+    });
+
+    const erased = await request(app)
+      .post(`/api/consumers/${c.id}/erase`)
+      .set(auth(adminToken))
+      .send({ confirm: 'ERASE' });
+    expect(erased.status).toBe(200);
+
+    const after = await EmailBroadcastRecipient.findByPk(row.id);
+    expect(after.email).toBeNull();
+    expect(after.error).toBeNull();
+    expect(after.status).toBe('failed');
+    expect(after.reason).toBe('send_error');
+    expect(after.consumerId).toBe(c.id);
+  });
+});

--- a/backend/test/emailBroadcastService.test.js
+++ b/backend/test/emailBroadcastService.test.js
@@ -1,0 +1,510 @@
+import { jest } from '@jest/globals';
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect } from './helpers.js';
+import {
+  EmailBroadcast, EmailBroadcastRecipient, Cohort, Consumer, ConsentEvent, ConsumerSuppression,
+} from '../src/models/index.js';
+import { makeEmailBroadcastService } from '../src/services/emailBroadcastService.js';
+import { normalizeDefinition } from '../src/services/cohortService.js';
+import { hashPhone } from '../src/utils/piiHashing.js';
+
+/**
+ * Email broadcast pipeline (tracker "emailpush",
+ * docs/plans/email-broadcast-push.md) on real Postgres with the REAL cohort
+ * resolution + consent gate — only transport (`sendEmail`), transporter
+ * presence and `sleep` are injected. What this file proves is the safety
+ * story: send-time re-gating (post-claim suppression bites), the
+ * at-most-once fence (`attempting` never retried), per-address dedupe +
+ * cross-consumer address suppression, verify-before-send unsubscribe
+ * tokens, cancel, resume-only-pending, the one-in-flight fence, and the
+ * boot sweep.
+ */
+
+const RUN = Date.now() % 1000000000;
+let seq = 0;
+const nextPhone = () => `+658${String(RUN + (seq += 1)).padStart(7, '0').slice(-7)}`;
+const nextEmail = () => `push-${RUN}-${seq += 1}@example.test`;
+
+let admin;
+let campA; let campB;
+
+async function makeConsumer({ email = nextEmail(), campaign = campA, scope = null, granted = true, verified = true } = {}) {
+  const phone = nextPhone();
+  const consumer = await Consumer.create({
+    phone, phoneHash: hashPhone(phone), firstName: 'Push', lastName: 'Fixture', email,
+    firstSeenAt: new Date(), lastSeenAt: new Date(), signupCount: 1,
+  });
+  await createTestProspect(campaign.id, {
+    phone, consumerId: consumer.id, demographics: { dateOfBirth: '1990-05-12' },
+  });
+  if (granted !== null) {
+    await ConsentEvent.create({
+      consumerId: consumer.id, campaignId: scope, kind: 'contact', granted,
+      channels: ['phone'], version: `emailpush-${RUN}`, source: 'signup',
+      verified, occurredAt: new Date(),
+    });
+  }
+  return consumer;
+}
+
+function cohortDefFor(campaign) {
+  return normalizeDefinition({ filters: { campaignIds: [campaign.id] } });
+}
+
+async function makeCohort(campaign, name) {
+  return Cohort.create({ name: `${name} ${RUN}-${seq += 1}`, definition: cohortDefFor(campaign) });
+}
+
+function makeSvc(overrides = {}) {
+  const sendEmail = overrides.sendEmail || jest.fn(async () => ({ success: true }));
+  const sleep = jest.fn(async () => {});
+  const svc = makeEmailBroadcastService({
+    sendEmail,
+    getTransporter: () => ({ fake: true }),
+    sleep,
+    ...overrides,
+  });
+  return { svc, sendEmail, sleep };
+}
+
+async function makeDraft({ cohort, campaign = campA, subject = 'Hello there', bodyText = 'First paragraph.\n\nSecond paragraph.', ctaLabel = 'See it' } = {}) {
+  return EmailBroadcast.create({
+    cohortId: cohort.id, campaignId: campaign.id, subject, bodyText, ctaLabel, createdBy: admin.user.id,
+  });
+}
+
+/** A broadcast frozen mid-flight (for resume/drift tests) with claimed rows. */
+async function makeInterrupted({ cohort, campaign = campA, consumers, subject = 'Resume me' }) {
+  const def = cohortDefFor(campaign);
+  def.marketingContext = { ...def.marketingContext, campaignId: campaign.id };
+  const b = await EmailBroadcast.create({
+    cohortId: cohort.id, campaignId: campaign.id, subject, bodyText: 'Body.',
+    ctaLabel: 'Go', status: 'interrupted', definitionSnapshot: def,
+    hostChoice: 'redeem', emailContext: 'redeem',
+    ctaUrl: `https://redeem.sg/LeadCapture?campaign_id=${campaign.id}`,
+    totalRecipients: consumers.length, startedAt: new Date(),
+  });
+  for (const c of consumers) {
+    await EmailBroadcastRecipient.create({ broadcastId: b.id, consumerId: c.id, email: c.email, status: 'pending' });
+  }
+  return b;
+}
+
+const rowsOf = (b) => EmailBroadcastRecipient.findAll({ where: { broadcastId: b.id }, order: [['createdAt', 'ASC'], ['id', 'ASC']] });
+
+beforeAll(async () => {
+  await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  campA = await createTestCampaign(admin.user.id, { name: `Push A ${RUN}` });
+  campB = await createTestCampaign(admin.user.id, { name: `Push B ${RUN}` });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+afterEach(async () => {
+  // Keep the global one-in-flight fence clean for the next test.
+  await EmailBroadcast.update(
+    { status: 'cancelled' },
+    { where: { status: ['preparing', 'sending', 'cancelling'] } }
+  );
+});
+
+describe('full send happy path', () => {
+  test('resolves, freezes context, gates, sends with PR-B rails, finalizes counts', async () => {
+    const c1 = await makeConsumer(); // global grant
+    const c2 = await makeConsumer({ scope: campA.id }); // scoped to the push campaign
+    const cohort = await makeCohort(campA, 'Happy');
+    const draft = await makeDraft({ cohort, subject: 'Big <news> tonight' });
+
+    const { svc, sendEmail, sleep } = makeSvc();
+    const { workerPromise } = await svc.startBroadcastSend(draft.id);
+    await workerPromise;
+
+    const done = await EmailBroadcast.findByPk(draft.id);
+    expect(done.status).toBe('completed');
+    expect(done.totalRecipients).toBe(2);
+    expect(done.sentCount).toBe(2);
+    expect(done.skippedCount).toBe(0);
+    expect(done.failedCount).toBe(0);
+    expect(done.completedAt).toBeTruthy();
+
+    // Frozen context: snapshot re-aimed at the push campaign, CTA has utm.
+    expect(done.definitionSnapshot.marketingContext.campaignId).toBe(campA.id);
+    expect(done.hostChoice).toBe('redeem');
+    expect(done.ctaUrl).toContain(`campaign_id=${campA.id}`);
+    expect(done.ctaUrl).toContain('utm_source=mktr');
+    expect(done.ctaUrl).toContain('utm_medium=email');
+    expect(done.ctaUrl).toContain(`utm_campaign=broadcast-${draft.id.slice(0, 8)}`);
+
+    const rows = await rowsOf(draft);
+    expect(rows.map((r) => r.status)).toEqual(['sent', 'sent']);
+    expect(rows.map((r) => r.email).sort()).toEqual([c1.email, c2.email].sort());
+    expect(rows.every((r) => r.sentAt)).toBe(true);
+
+    // The PR-B rails on every message, escaping, and the working unsub link.
+    expect(sendEmail).toHaveBeenCalledTimes(2);
+    for (const [args] of sendEmail.mock.calls) {
+      expect(args.headers['List-Unsubscribe']).toMatch(/^<https:\/\/api\.mktr\.sg\/api\/unsubscribe\?t=[0-9a-f]{64}>$/);
+      expect(args.headers['List-Unsubscribe-Post']).toBe('List-Unsubscribe=One-Click');
+      expect(args.context).toBe('redeem');
+      expect(args.subject).toBe('Big <news> tonight');
+      expect(args.html).not.toContain('<news>');
+      expect(args.html).toContain('Big &lt;news&gt; tonight');
+      // The href is attribute-escaped (& → &amp;) — assert the escaped form.
+      expect(args.html).toContain(done.ctaUrl.replace(/&/g, '&amp;'));
+      expect(args.html).toContain('MKTR PTE. LTD. (UEN 202507548M), Singapore');
+      expect(args.text).toContain('Unsubscribe: https://api.mktr.sg/api/unsubscribe?t=');
+    }
+
+    // Throttle: one pause per processed row at the default 2/s.
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(sleep.mock.calls[0][0]).toBe(500);
+  });
+
+  test('body/script escaping never reaches the html raw', async () => {
+    const c = await makeConsumer();
+    const cohort = await makeCohort(campA, 'Escape');
+    const draft = await makeDraft({ cohort, bodyText: 'Look <script>alert(1)</script>\n\nBye.' });
+    const { svc, sendEmail } = makeSvc();
+    const { workerPromise } = await svc.startBroadcastSend(draft.id);
+    await workerPromise;
+    const html = sendEmail.mock.calls.find(([a]) => a.to === c.email)[0].html;
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});
+
+describe('preflight (all-or-back-to-draft)', () => {
+  test('unconfigured transporter reverts to draft with the reason', async () => {
+    await makeConsumer();
+    const cohort = await makeCohort(campA, 'NoSmtp');
+    const draft = await makeDraft({ cohort });
+    const { svc } = makeSvc({ getTransporter: () => null });
+    await expect(svc.startBroadcastSend(draft.id)).rejects.toThrow(/transport is not configured/i);
+    const after = await EmailBroadcast.findByPk(draft.id);
+    expect(after.status).toBe('draft');
+    expect(after.lastError).toMatch(/transport/i);
+  });
+
+  test('inactive campaign (is_active=false with status active) reverts', async () => {
+    const dark = await createTestCampaign(admin.user.id, { name: `Dark ${RUN}`, status: 'active', is_active: false });
+    await makeConsumer({ campaign: dark });
+    const cohort = await makeCohort(dark, 'Dark');
+    const draft = await makeDraft({ cohort, campaign: dark });
+    const { svc } = makeSvc();
+    await expect(svc.startBroadcastSend(draft.id)).rejects.toThrow(/must be active/i);
+    expect((await EmailBroadcast.findByPk(draft.id)).status).toBe('draft');
+  });
+
+  test('empty reachable audience reverts', async () => {
+    const lonely = await createTestCampaign(admin.user.id, { name: `Lonely ${RUN}` });
+    const cohort = await makeCohort(lonely, 'Empty');
+    const draft = await makeDraft({ cohort, campaign: lonely });
+    const { svc } = makeSvc();
+    await expect(svc.startBroadcastSend(draft.id)).rejects.toThrow(/no reachable email recipients/i);
+    expect((await EmailBroadcast.findByPk(draft.id)).status).toBe('draft');
+  });
+
+  test('audience over the recipient cap reverts', async () => {
+    const crowd = await createTestCampaign(admin.user.id, { name: `Crowd ${RUN}` });
+    await makeConsumer({ campaign: crowd });
+    await makeConsumer({ campaign: crowd });
+    const cohort = await makeCohort(crowd, 'Cap');
+    const draft = await makeDraft({ cohort, campaign: crowd });
+    process.env.EMAIL_BROADCAST_MAX_RECIPIENTS = '1';
+    try {
+      const { svc } = makeSvc();
+      await expect(svc.startBroadcastSend(draft.id)).rejects.toThrow(/exceeds EMAIL_BROADCAST_MAX_RECIPIENTS/);
+      expect((await EmailBroadcast.findByPk(draft.id)).status).toBe('draft');
+    } finally {
+      delete process.env.EMAIL_BROADCAST_MAX_RECIPIENTS;
+    }
+  });
+
+  test('audience resolution excludes people outside the PUSH campaign scope', async () => {
+    // Scoped-to-B consumer signs up under campA population but has no basis
+    // for a campA push — resolution (gate re-aimed at campA) leaves them out.
+    const scopedElsewhere = await makeConsumer({ scope: campB.id });
+    const ok = await makeConsumer();
+    const cohort = await makeCohort(campA, 'Scope');
+    const draft = await makeDraft({ cohort });
+    const { svc } = makeSvc();
+    const { workerPromise } = await svc.startBroadcastSend(draft.id);
+    await workerPromise;
+    const rows = await rowsOf(draft);
+    expect(rows.map((r) => r.consumerId)).toContain(ok.id);
+    expect(rows.map((r) => r.consumerId)).not.toContain(scopedElsewhere.id);
+  });
+});
+
+describe('send-time re-gate (the §5 obligation) + drift', () => {
+  test('suppression landing AFTER claim skips at send with the gate reason', async () => {
+    const c1 = await makeConsumer();
+    const c2 = await makeConsumer();
+    const cohort = await makeCohort(campA, 'Drift');
+    const b = await makeInterrupted({ cohort, consumers: [c1, c2] });
+    await ConsumerSuppression.create({ consumerId: c2.id, channel: 'all', reason: 'unsubscribe', source: 'unsubscribe_link' });
+
+    const { svc } = makeSvc();
+    const { workerPromise } = await svc.startBroadcastSend(b.id, { resume: true });
+    await workerPromise;
+
+    const rows = await rowsOf(b);
+    const byConsumer = Object.fromEntries(rows.map((r) => [r.consumerId, r]));
+    expect(byConsumer[c1.id].status).toBe('sent');
+    expect(byConsumer[c2.id].status).toBe('skipped');
+    expect(byConsumer[c2.id].reason).toBe('suppressed');
+    expect((await EmailBroadcast.findByPk(b.id)).status).toBe('completed');
+  });
+
+  test('email removed after claim skips missing_email; changed email sends to the CURRENT address', async () => {
+    const gone = await makeConsumer();
+    const moved = await makeConsumer();
+    const cohort = await makeCohort(campA, 'Dest');
+    const b = await makeInterrupted({ cohort, consumers: [gone, moved] });
+    await gone.update({ email: null });
+    const newAddr = `moved-${RUN}@example.test`;
+    await moved.update({ email: newAddr });
+
+    const { svc, sendEmail } = makeSvc();
+    const { workerPromise } = await svc.startBroadcastSend(b.id, { resume: true });
+    await workerPromise;
+
+    const rows = await rowsOf(b);
+    const byConsumer = Object.fromEntries(rows.map((r) => [r.consumerId, r]));
+    expect(byConsumer[gone.id].status).toBe('skipped');
+    expect(byConsumer[gone.id].reason).toBe('missing_email');
+    expect(byConsumer[moved.id].status).toBe('sent');
+    expect(byConsumer[moved.id].email).toBe(newAddr);
+    expect(sendEmail.mock.calls.some(([a]) => a.to === newAddr)).toBe(true);
+  });
+
+  test('two consumers sharing one normalized address: one copy, one duplicate_email', async () => {
+    const sharedAddr = `shared-${RUN}@example.test`;
+    const one = await makeConsumer({ email: sharedAddr });
+    const two = await makeConsumer({ email: `  ${sharedAddr.toUpperCase()}  ` });
+    const cohort = await makeCohort(campA, 'Dupe');
+    const b = await makeInterrupted({ cohort, consumers: [one, two] });
+
+    const { svc, sendEmail } = makeSvc();
+    const { workerPromise } = await svc.startBroadcastSend(b.id, { resume: true });
+    await workerPromise;
+
+    const rows = await rowsOf(b);
+    const statuses = rows.map((r) => r.status).sort();
+    expect(statuses).toEqual(['sent', 'skipped']);
+    expect(rows.find((r) => r.status === 'skipped').reason).toBe('duplicate_email');
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+  });
+
+  test('an address unsubscribed through ANOTHER consumer id is address_suppressed', async () => {
+    const sharedAddr = `cross-${RUN}@example.test`;
+    // The other identity of this person: same inbox, suppressed, NOT in the push.
+    const otherSelf = await makeConsumer({ email: sharedAddr, campaign: campB });
+    await ConsumerSuppression.create({ consumerId: otherSelf.id, channel: 'email', reason: 'unsubscribe', source: 'unsubscribe_link' });
+    const target = await makeConsumer({ email: sharedAddr });
+    const cohort = await makeCohort(campA, 'Cross');
+    const b = await makeInterrupted({ cohort, consumers: [target] });
+
+    const { svc, sendEmail } = makeSvc();
+    const { workerPromise } = await svc.startBroadcastSend(b.id, { resume: true });
+    await workerPromise;
+
+    const [row] = await rowsOf(b);
+    expect(row.status).toBe('skipped');
+    expect(row.reason).toBe('address_suppressed');
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  test('an unverifiable unsubscribe token blocks the send (verify-before-send)', async () => {
+    const c = await makeConsumer();
+    // A stored hash that cannot match any freshly-derived token (secret
+    // rotation aftermath): ensureUnsubToken keeps the stored value, the
+    // verify step sees the mismatch, the mail is never sent.
+    await c.update({ unsubTokenHash: 'f'.repeat(64) });
+    const cohort = await makeCohort(campA, 'Token');
+    const b = await makeInterrupted({ cohort, consumers: [c] });
+
+    const { svc, sendEmail } = makeSvc();
+    const { workerPromise } = await svc.startBroadcastSend(b.id, { resume: true });
+    await workerPromise;
+
+    const [row] = await rowsOf(b);
+    expect(row.status).toBe('skipped');
+    expect(row.reason).toBe('unsub_token_error');
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+});
+
+describe('transport failures', () => {
+  test('sendEmail {success:false} marks failed/send_error (never sent)', async () => {
+    const c = await makeConsumer();
+    const cohort = await makeCohort(campA, 'SoftFail');
+    const b = await makeInterrupted({ cohort, consumers: [c] });
+    const sendEmail = jest.fn(async () => ({ success: false, message: 'Mailer not configured; logged instead.' }));
+    const { svc } = makeSvc({ sendEmail });
+    const { workerPromise } = await svc.startBroadcastSend(b.id, { resume: true });
+    await workerPromise;
+    const [row] = await rowsOf(b);
+    expect(row.status).toBe('failed');
+    expect(row.reason).toBe('send_error');
+    expect(row.error).toMatch(/not configured/i);
+    const done = await EmailBroadcast.findByPk(b.id);
+    expect(done.status).toBe('completed');
+    expect(done.failedCount).toBe(1);
+  });
+
+  test('a throwing transport marks that row failed and the loop continues', async () => {
+    const bad = await makeConsumer();
+    const good = await makeConsumer();
+    const cohort = await makeCohort(campA, 'Throw');
+    const b = await makeInterrupted({ cohort, consumers: [bad, good] });
+    const sendEmail = jest.fn(async ({ to }) => {
+      if (to === bad.email) throw new Error('SMTP 550 rejected');
+      return { success: true };
+    });
+    const { svc } = makeSvc({ sendEmail });
+    const { workerPromise } = await svc.startBroadcastSend(b.id, { resume: true });
+    await workerPromise;
+    const rows = await rowsOf(b);
+    const byConsumer = Object.fromEntries(rows.map((r) => [r.consumerId, r]));
+    expect(byConsumer[bad.id].status).toBe('failed');
+    expect(byConsumer[bad.id].error).toMatch(/550/);
+    expect(byConsumer[good.id].status).toBe('sent');
+  });
+});
+
+describe('at-most-once + resume + cancel + fences', () => {
+  test('resume marks attempting rows ambiguous_crash and never re-sends them', async () => {
+    const ambiguous = await makeConsumer();
+    const fresh = await makeConsumer();
+    const cohort = await makeCohort(campA, 'Ambig');
+    const b = await makeInterrupted({ cohort, consumers: [ambiguous, fresh] });
+    await EmailBroadcastRecipient.update(
+      { status: 'attempting' },
+      { where: { broadcastId: b.id, consumerId: ambiguous.id } }
+    );
+
+    const { svc, sendEmail } = makeSvc();
+    const { workerPromise } = await svc.startBroadcastSend(b.id, { resume: true });
+    await workerPromise;
+
+    const rows = await rowsOf(b);
+    const byConsumer = Object.fromEntries(rows.map((r) => [r.consumerId, r]));
+    expect(byConsumer[ambiguous.id].status).toBe('failed');
+    expect(byConsumer[ambiguous.id].reason).toBe('ambiguous_crash');
+    expect(byConsumer[fresh.id].status).toBe('sent');
+    // The crashed row's address got NO second copy.
+    expect(sendEmail.mock.calls.map(([a]) => a.to)).toEqual([fresh.email]);
+  });
+
+  test('resume never re-resolves: a new signup after the freeze is not added', async () => {
+    const original = await makeConsumer();
+    const cohort = await makeCohort(campA, 'Frozen');
+    const b = await makeInterrupted({ cohort, consumers: [original] });
+    const late = await makeConsumer(); // matches the cohort NOW, but after the freeze
+
+    const { svc } = makeSvc();
+    const { workerPromise } = await svc.startBroadcastSend(b.id, { resume: true });
+    await workerPromise;
+
+    const rows = await rowsOf(b);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].consumerId).toBe(original.id);
+    expect(rows.map((r) => r.consumerId)).not.toContain(late.id);
+  });
+
+  test('resume of a draft (no snapshot) is rejected', async () => {
+    const cohort = await makeCohort(campA, 'NoSnap');
+    const draft = await makeDraft({ cohort });
+    const { svc } = makeSvc();
+    await expect(svc.startBroadcastSend(draft.id, { resume: true })).rejects.toThrow(/no frozen send context/i);
+  });
+
+  test('cancel mid-loop stops within one iteration and marks the rest cancelled', async () => {
+    const first = await makeConsumer();
+    const second = await makeConsumer();
+    const third = await makeConsumer();
+    const cohort = await makeCohort(campA, 'Cancel');
+    const b = await makeInterrupted({ cohort, consumers: [first, second, third] });
+    const sendEmail = jest.fn(async () => {
+      // An admin hits Cancel while the first mail is in flight.
+      await EmailBroadcast.update({ status: 'cancelling' }, { where: { id: b.id, status: 'sending' } });
+      return { success: true };
+    });
+    const { svc } = makeSvc({ sendEmail });
+    const { workerPromise } = await svc.startBroadcastSend(b.id, { resume: true });
+    await workerPromise;
+
+    const done = await EmailBroadcast.findByPk(b.id);
+    expect(done.status).toBe('cancelled');
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    const rows = await rowsOf(b);
+    expect(rows.filter((r) => r.status === 'sent')).toHaveLength(1);
+    const rest = rows.filter((r) => r.status === 'skipped');
+    expect(rest).toHaveLength(2);
+    expect(rest.every((r) => r.reason === 'cancelled')).toBe(true);
+  });
+
+  test('one broadcast in flight globally', async () => {
+    const c = await makeConsumer();
+    const cohort = await makeCohort(campA, 'Fence');
+    const inFlight = await makeInterrupted({ cohort, consumers: [c] });
+    await inFlight.update({ status: 'sending', workerHeartbeatAt: new Date() });
+    const draft = await makeDraft({ cohort });
+    const { svc } = makeSvc();
+    await expect(svc.startBroadcastSend(draft.id)).rejects.toThrow(/one at a time/i);
+    await inFlight.update({ status: 'cancelled' });
+  });
+
+  test('a fresh-heartbeat sending broadcast cannot be resumed (worker owns it)', async () => {
+    const c = await makeConsumer();
+    const cohort = await makeCohort(campA, 'Owned');
+    const b = await makeInterrupted({ cohort, consumers: [c] });
+    await b.update({ status: 'sending', workerHeartbeatAt: new Date() });
+    const { svc } = makeSvc();
+    await expect(svc.startBroadcastSend(b.id, { resume: true })).rejects.toThrow(/not resumable/i);
+    await b.update({ status: 'cancelled' });
+  });
+
+  test('boot sweep flips stale in-flight broadcasts to interrupted and lands attempting rows', async () => {
+    const c1 = await makeConsumer();
+    const c2 = await makeConsumer();
+    const cohort = await makeCohort(campA, 'Sweep');
+    const b = await makeInterrupted({ cohort, consumers: [c1, c2] });
+    await b.update({ status: 'sending', workerHeartbeatAt: new Date(Date.now() - 10 * 60 * 1000) });
+    await EmailBroadcastRecipient.update(
+      { status: 'attempting' },
+      { where: { broadcastId: b.id, consumerId: c1.id } }
+    );
+
+    const { svc } = makeSvc();
+    const swept = await svc.sweepStaleBroadcasts();
+    expect(swept).toBeGreaterThanOrEqual(1);
+
+    const after = await EmailBroadcast.findByPk(b.id);
+    expect(after.status).toBe('interrupted');
+    const rows = await rowsOf(b);
+    const byConsumer = Object.fromEntries(rows.map((r) => [r.consumerId, r]));
+    expect(byConsumer[c1.id].status).toBe('failed');
+    expect(byConsumer[c1.id].reason).toBe('ambiguous_crash');
+    expect(byConsumer[c2.id].status).toBe('pending');
+  });
+});
+
+describe('test sends', () => {
+  test('goes to the requesting admin only, marked, with an inert unsubscribe', async () => {
+    const cohort = await makeCohort(campA, 'Test');
+    const draft = await makeDraft({ cohort, subject: 'Preview me' });
+    const { svc, sendEmail } = makeSvc();
+    const result = await svc.sendTestEmail(draft.id, admin.user);
+    expect(result.to).toBe(admin.user.email);
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    const [args] = sendEmail.mock.calls[0];
+    expect(args.to).toBe(admin.user.email);
+    expect(args.subject).toBe('[TEST] Preview me');
+    expect(args.html).toContain('TEST SEND');
+    expect(args.headers).toBeUndefined();
+  });
+});

--- a/backend/test/emailBroadcastService.test.js
+++ b/backend/test/emailBroadcastService.test.js
@@ -493,6 +493,118 @@ describe('at-most-once + resume + cancel + fences', () => {
   });
 });
 
+describe('Codex round-2 races (edit/erase/cancel/zombie)', () => {
+  test('erased between claim and send: gate skips, no PII written back', async () => {
+    const erased = await makeConsumer();
+    const cohort = await makeCohort(campA, 'Erased');
+    const b = await makeInterrupted({ cohort, consumers: [erased] });
+    // The erasure core, as 16b + step 17 leave it: suppression row + nulled row.
+    await ConsumerSuppression.create({ consumerId: erased.id, channel: 'all', reason: 'erasure', source: 'erasure' });
+    await erased.update({ email: null, phone: null, firstName: null, lastName: null, unsubTokenHash: null, erasedAt: new Date() });
+
+    const { svc, sendEmail } = makeSvc();
+    const { workerPromise } = await svc.startBroadcastSend(b.id, { resume: true });
+    await workerPromise;
+
+    const [row] = await rowsOf(b);
+    expect(row.status).toBe('skipped');
+    // Destination refresh sees the nulled email before the gate even runs.
+    expect(row.reason).toBe('missing_email');
+    expect(row.email).toBeNull();
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  test('erasure committing DURING transport: the terminal write is repaired', async () => {
+    const c = await makeConsumer();
+    const cohort = await makeCohort(campA, 'MidErase');
+    const b = await makeInterrupted({ cohort, consumers: [c] });
+    const sendEmail = jest.fn(async () => {
+      // Erasure lands while the mail is on the wire.
+      await c.update({ email: null, erasedAt: new Date() });
+      return { success: true };
+    });
+    const { svc } = makeSvc({ sendEmail });
+    const { workerPromise } = await svc.startBroadcastSend(b.id, { resume: true });
+    await workerPromise;
+
+    const [row] = await rowsOf(b);
+    expect(row.status).toBe('sent'); // the delivery fact stands…
+    expect(row.email).toBeNull(); // …but the repair removed the PII again
+    expect(row.error).toBeNull();
+  });
+
+  test('mktr-host campaign freezes mktr brand context and CTA origin', async () => {
+    const mktrCamp = await createTestCampaign(admin.user.id, {
+      name: `Mktr Host ${RUN}`, design_config: { customerHost: 'mktr' },
+    });
+    await makeConsumer({ campaign: mktrCamp });
+    const cohort = await makeCohort(mktrCamp, 'MktrHost');
+    const draft = await makeDraft({ cohort, campaign: mktrCamp });
+    const { svc, sendEmail } = makeSvc();
+    const { workerPromise } = await svc.startBroadcastSend(draft.id);
+    await workerPromise;
+
+    const done = await EmailBroadcast.findByPk(draft.id);
+    expect(done.hostChoice).toBe('mktr');
+    expect(done.emailContext).toBe('mktr');
+    expect(done.ctaUrl).toMatch(/^https:\/\/mktr\.sg\/LeadCapture\?/);
+    expect(sendEmail.mock.calls[0][0].context).toBe('mktr');
+  });
+
+  test('cancel racing the LAST iteration wins over completed', async () => {
+    const c = await makeConsumer();
+    const cohort = await makeCohort(campA, 'LastCancel');
+    const b = await makeInterrupted({ cohort, consumers: [c] });
+    const sendEmail = jest.fn(async () => {
+      // Cancel lands while the final mail is in flight: the queue will be
+      // empty next loop, and finalizeCompleted must LOSE to the cancel.
+      await EmailBroadcast.update({ status: 'cancelling' }, { where: { id: b.id, status: 'sending' } });
+      return { success: true };
+    });
+    const { svc } = makeSvc({ sendEmail });
+    const { workerPromise } = await svc.startBroadcastSend(b.id, { resume: true });
+    await workerPromise;
+
+    const done = await EmailBroadcast.findByPk(b.id);
+    expect(done.status).toBe('cancelled');
+    expect(done.sentCount).toBe(1); // the send that was already in flight stands
+  });
+
+  test('a superseded (zombie) lease loses its heartbeat', async () => {
+    const c = await makeConsumer();
+    const cohort = await makeCohort(campA, 'Zombie');
+    const b = await makeInterrupted({ cohort, consumers: [c] });
+    // A resume mints a fresh lease…
+    const { svc } = makeSvc();
+    const { workerPromise } = await svc.startBroadcastSend(b.id, { resume: true });
+    await workerPromise;
+    // …after which the old worker's lease-keyed heartbeat matches nothing.
+    const staleLease = '00000000-0000-4000-8000-00000000dead';
+    const [hb] = await EmailBroadcast.sequelize.query(
+      `UPDATE email_broadcasts SET "workerHeartbeatAt" = now()
+        WHERE id = :id AND status = 'sending' AND "workerLeaseId" = :lease RETURNING id`,
+      { replacements: { id: b.id, lease: staleLease } }
+    );
+    expect(hb).toHaveLength(0);
+  });
+
+  test('a stale cancelling broadcast is swept to cancelled, never back to resumable', async () => {
+    const c1 = await makeConsumer();
+    const cohort = await makeCohort(campA, 'SweepCancel');
+    const b = await makeInterrupted({ cohort, consumers: [c1] });
+    await b.update({ status: 'cancelling', workerHeartbeatAt: new Date(Date.now() - 10 * 60 * 1000) });
+
+    const { svc } = makeSvc();
+    await svc.sweepStaleBroadcasts();
+
+    const after = await EmailBroadcast.findByPk(b.id);
+    expect(after.status).toBe('cancelled');
+    const [row] = await rowsOf(b);
+    expect(row.status).toBe('skipped');
+    expect(row.reason).toBe('cancelled');
+  });
+});
+
 describe('test sends', () => {
   test('goes to the requesting admin only, marked, with an inert unsubscribe', async () => {
     const cohort = await makeCohort(campA, 'Test');

--- a/docs/plans/email-broadcast-push.md
+++ b/docs/plans/email-broadcast-push.md
@@ -381,7 +381,20 @@ Frontend (vitest, mocked `@/api/adminV2`): `AdminV2Broadcasts.test.jsx`
 | 24 | MAJOR test gaps | FOLDED §8 (single-process-provable set); fleet-harness items §9 |
 | 25 | MAJOR frozen-files incompatibility | PARTIALLY FOLDED §7: erasureService+bootstrap now in scope; consent/cohort/mailer stay frozen with explicit workarounds |
 
-## 11. Env / rollout / live proof
+## 11. Codex round 2 (gpt-5.6-sol xhigh, on the implementation diff) — disposition
+
+| # | Finding | Disposition |
+|---|---|---|
+| 1 | BLOCKER edit/send race (stale pre-CAS row into prepare) | FOLDED: reload after winning the CAS; edits are draft-conditional so the row is immutable from there |
+| 2 | BLOCKER unsub/erasure commit between gate and SMTP | PARTIALLY FOLDED: post-write `repairRowIfErased` guarantees recipient rows never retain an erased person's PII (no manual re-erase needed). The residual ms-window send itself is ACCEPTED (§9): serializing sender/unsubscribe/erasure needs cross-service locks in frozen files; consent held at gate-time ms earlier, erasure repair-pass + suppression are the mop-up |
+| 3 | BLOCKER stale resume lacks ownership fence | FOLDED: `workerLeaseId` minted per start/resume; heartbeat, finalizeCompleted and the crash handler are lease-keyed — a superseded zombie loses its next heartbeat and exits (≤1 in-flight send) |
+| 4 | MAJOR one-in-flight NOT EXISTS write skew | FOLDED: both transitions run under `pg_advisory_xact_lock(870778002)` in a txn — concurrent starts/resumes serialize |
+| 5 | MAJOR address dedupe not durable across crash | FOLDED (right-sized): the REFRESHED address is persisted on the row before transport, so resume's rebuilt set sees what was actually attempted. A durable per-address claim table (Codex's full design) stays out — single-instance, and erasure interplay would need claim-purge machinery |
+| 6 | MAJOR cancel overwritten / rows mislabeled | FOLDED: `completed` only from `sending`+lease (loser lands the cancel); crash handler lands `cancelling→cancelled` before `sending→failed`; direct cancel terminalizes `attempting` as `ambiguous_crash` (never `skipped`); sweep lands stale `cancelling` in `cancelled`, never resumable |
+| 7 | MINOR facets lack `is_active`; no stale-sending Resume in UI | ACCEPTED: facets live in frozen cohortService — the backend's loud 422 covers the picker gap; stale `sending` becomes `interrupted` (Resume button) within ≤5 min via the sweep |
+| 8 | MINOR test gaps vs §8 promises | FOLDED: added erased-at-send, erased-during-SMTP repair, mktr-host branch, cancel-vs-complete landing, zombie-lease heartbeat, stale-cancelling sweep. True multi-process barrier harnesses stay out (§9 single-instance posture) |
+
+## 12. Env / rollout / live proof
 
 - `EMAIL_BROADCAST_RATE_PER_SEC` (default 2, clamp 0.2–10),
   `EMAIL_BROADCAST_MAX_RECIPIENTS` (default 5000, clamp 1–20000); defaults

--- a/docs/plans/email-broadcast-push.md
+++ b/docs/plans/email-broadcast-push.md
@@ -1,0 +1,393 @@
+# Email broadcast push (tracker "emailpush") — v2 post-Codex
+
+Minimal-viable campaign push over email: an admin composes subject/body/CTA
+about ONE campaign, picks a saved cohort, and the backend sends one clean
+templated email to every reachable member — re-gating EVERY recipient through
+the consent gate at send time, with the PR-B unsubscribe rails on every
+message, throttled sending, and a persisted per-recipient send log.
+
+Consumes: cohorts (#222/#223), consent ledger + PR-B unsubscribe rails,
+`mailer.sendEmail`. Discharges the binding sender obligations of
+`docs/plans/cohort-builder-backend.md` §5 for the email channel.
+
+v2 folds a 25-finding Codex xhigh round (disposition table §10). The frame:
+this is an admin-triggered, low-volume (≤5k), single-tenant tool on one
+Render instance — we take every cheap correctness rail (CAS state machine,
+at-most-once fence, address dedupe, erasure integration) and document the
+fleet-scale items we deliberately do not build (§9).
+
+## 1. Scope
+
+In: composer (subject / body paragraphs / CTA label), cohort selection,
+campaign selection (the campaign the message is ABOUT), send-time per-person
+consent gate, per-address dedupe + address-level suppression check,
+unsubscribe footer + verified `List-Unsubscribe` (+ One-Click) on every
+send, sequential throttled sending with a CAS-guarded in-process worker,
+cancel (emergency stop), resume after process death (never re-sending
+ambiguous rows), send log (who/when/status/reason), erasure-matrix
+integration, self-test-send, admin UI (list + composer + detail w/ log).
+
+Out (non-goals, §9): scheduling, rich-text editor, A/B, merge fields beyond
+first name, provider bounce/complaint webhooks, open/click tracking,
+editable utm, multi-instance worker fleet, WhatsApp/SMS push ("wapush").
+
+## 2. Data model — migration `085-email-broadcasts.js`
+
+Migration follows 084's shape: `export async function up(queryInterface)`
+only, raw SQL, `IF NOT EXISTS`-guarded, sync-tolerant; **indexes AND guarded
+CHECK constraints mirrored per the 080 pattern; indexes also declared on
+models** (test boot `sync({force:true})` runs before migrations).
+
+`email_broadcasts` (model `EmailBroadcast`):
+- `id` UUID pk (UUIDV4)
+- `cohortId` UUID notNull, FK → `cohorts.id` ON DELETE RESTRICT (cohorts
+  only soft-archive; sends keep their audit anchor)
+- `campaignId` UUID **nullable**, FK → `campaigns.id` ON DELETE SET NULL
+  (campaignService permanently deletes archived campaigns — history rows
+  survive with the frozen `ctaUrl`/`subject`; a null campaign fails resume
+  preflight, closing the gate correctly)
+- `subject` STRING(200) notNull; `bodyText` TEXT notNull; `ctaLabel`
+  STRING(80) notNull default 'Learn more'
+- **Send-context snapshot, frozen at `preparing`** (cohortService's header
+  contract: senders snapshot definition + context because cohort rows
+  mutate): `definitionSnapshot` JSONB null (normalized definition with the
+  gate campaign already overridden), `hostChoice` STRING(8) null
+  ('redeem'|'mktr'), `emailContext` STRING(8) null, `ctaUrl` TEXT null.
+  Worker + resume read ONLY the snapshot (+ row content), never live config.
+- `status` STRING(16) notNull default 'draft' ∈ draft|preparing|sending|
+  cancelling|completed|interrupted|failed|cancelled (guarded CHECK)
+- `totalRecipients`/`sentCount`/`skippedCount`/`failedCount` INTEGER notNull
+  default 0 (CHECK ≥ 0)
+- `workerHeartbeatAt` DATE null (stale-lease detection, threshold 120s)
+- `startedAt`/`completedAt` DATE null, `lastError` TEXT null
+- `createdBy` UUID null FK → `users.id` SET NULL
+- timestamps. Index `(status, createdAt)`.
+
+`email_broadcast_recipients` (model `EmailBroadcastRecipient`) — send log +
+per-recipient claim:
+- `id` UUID pk
+- `broadcastId` UUID notNull FK → `email_broadcasts.id` ON DELETE CASCADE
+- `consumerId` UUID notNull FK → `consumers.id` (NO cascade action needed:
+  erasure keeps an anonymized husk row, ids never vanish — retained-skeleton
+  stance; person FKs deliberately stay meaningful)
+- `email` STRING(320) null — address actually attempted (refreshed at send
+  time, see §3.4); **nulled by erasure** (§5)
+- `status` STRING(16) notNull default 'pending' ∈ pending|attempting|sent|
+  skipped|failed (guarded CHECK)
+- `reason` STRING(64) null — gate codes verbatim (`erased|suppressed|
+  not_consented|not_verified|not_found`) + sender codes (`missing_email|
+  duplicate_email|address_suppressed|unsub_token_error|send_error|
+  ambiguous_crash|cancelled`)
+- `error` TEXT null (transport message; **nulled by erasure**), `sentAt`
+  DATE null. No `messageId` — nodemailer's result is discarded by the
+  frozen `sendEmail` and we do not edit mailer.js.
+- timestamps. Unique `(broadcastId, consumerId)`, index
+  `(broadcastId, status)`.
+
+`models/index.js` (additive): associations EmailBroadcast→Cohort/Campaign/
+User(creator), EmailBroadcastRecipient→EmailBroadcast/Consumer; exports.
+
+## 3. Send pipeline (`emailBroadcastService.js`)
+
+Factory `makeEmailBroadcastService(overrides = {})` mirroring
+`makeCohortService` — injectable `{ sequelize, models, sendEmail,
+getTransporter, ensureUnsubToken, findConsumerByUnsubToken,
+canMarketToBatch, listCohortMembers, normalizeDefinition, logger, sleep }`;
+default instance + bound exports.
+
+### 3.1 State machine (every transition a conditional UPDATE — CAS)
+
+```
+draft ──send──▶ preparing ──▶ sending ──▶ completed
+  ▲                │              │            (outcome derived from counts)
+  └──(preflight    │              ├──cancel──▶ cancelling ──▶ cancelled
+      failure)◀────┘              ├──crash──▶ (stale heartbeat) ─▶ interrupted
+                                  └──loop error──▶ failed
+interrupted ──resume──▶ sending      interrupted/failed ──cancel──▶ cancelled
+```
+
+- Every transition: `UPDATE email_broadcasts SET status=? WHERE id=? AND
+  status IN (...)` — `rowCount 0` → 409. No two processes can both win a
+  transition; the module-level `activeSends` Set remains only as a cheap
+  local short-circuit, not the fence.
+- **One in-flight broadcast globally**: the draft→preparing CAS runs inside
+  a txn that first counts `status IN ('preparing','sending','cancelling')`
+  → 409 if any. Serializes sends AND makes the throttle globally true on
+  the single-instance deployment (§9 for fleet caveats).
+- PUT/DELETE: conditional on `status='draft'` → else 409. Worker re-reads
+  the row after winning `preparing`, so it can never send stale in-memory
+  content.
+- Boot sweep (`bootstrap.js`, additive call): broadcasts in
+  `preparing|sending|cancelling` with `workerHeartbeatAt` older than 120s
+  (or null) → `interrupted` (+ their `attempting` rows → `failed/
+  ambiguous_crash`). No auto-resume — a human presses Resume; nothing
+  mass-sends on deploy.
+
+### 3.2 preparing — preflight + materialize (all-or-back-to-draft)
+
+1. Transporter configured (`getTransporter()` non-null) else revert +
+   422-style error surfaced on the row (`lastError`).
+2. Campaign exists, `status==='active'` AND `is_active===true` (the public
+   surface's own gate — people land there); cohort exists, not archived.
+3. CTA origin: `customerHostOrigin(normalizeCustomerHostChoice(
+   design_config.customerHost))` MUST be https in production — a missing
+   `PUBLIC_BASE_URL` must never leak a localhost link into real mail.
+   Freeze snapshot: `definitionSnapshot` (normalized cohort definition with
+   `marketingContext.campaignId := broadcast.campaignId` — §5 scope rule:
+   the SEND is gated on the campaign the email is actually about),
+   `hostChoice`, `emailContext` ('mktr' host → 'mktr', else 'redeem'),
+   `ctaUrl` = origin + `/LeadCapture?` + `URLSearchParams({ campaign_id,
+   utm_source:'mktr', utm_medium:'email',
+   utm_campaign:'broadcast-'+id.slice(0,8) })`.
+4. Resolve audience from the SNAPSHOT via `listCohortMembers(def, {
+   channel:'email', status:'reachable', limit:200, offset })` paged
+   back-to-back to exhaustion. Cap `EMAIL_BROADCAST_MAX_RECIPIENTS`
+   (default 5000, clamped) → revert; 0 reachable → revert. Offset-paging
+   drift under concurrent captures is accepted: it can only UNDER-claim
+   (missed member = no mail — safe); over-claims are impossible (unique
+   fence) and wrong sends are impossible (per-send gate). §9.
+5. Bulk-insert claims `pending` (`ignoreDuplicates`), set
+   `totalRecipients`, CAS → `sending`, fire worker (post-commit,
+   fire-and-forget).
+
+### 3.3 Worker loop — per recipient, throttled
+
+Each iteration, in order:
+1. **Heartbeat + cancel check** (one query): `UPDATE email_broadcasts SET
+   workerHeartbeatAt=now() WHERE id=? AND status='sending' RETURNING
+   status` — 0 rows → someone cancelled (or boot-swept): stop; if
+   `cancelling`, CAS → `cancelled` (remaining rows get reason `cancelled`
+   en masse, status stays their truth: `pending`→`skipped/cancelled`).
+2. **Claim** (at-most-once fence): `UPDATE email_broadcast_recipients SET
+   status='attempting' WHERE id=? AND status='pending'` — 0 rows → another
+   worker took it, next. A crash from here until step 7 leaves
+   `attempting` = ambiguous; resume NEVER retries it (→
+   `failed/ambiguous_crash`). At-most-once per recipient, chosen
+   deliberately over at-least-once (marketing mail: a missed send is
+   recoverable, a double send is not).
+3. **Destination refresh + dedupe**: reload consumer; current email through
+   `emailNormKey` (synthetic `@calls.mktr.sg` → null). Missing → skip
+   `missing_email`. Norm-key already attempted in THIS broadcast (in-memory
+   Set, rebuilt from rows on resume) → skip `duplicate_email` (consumers
+   are phone-keyed; two ids can share an address — one copy per address).
+4. **Address-level suppression** (the "other consumer unsubscribed this
+   address" hole): any OTHER consumer sharing the norm-key with a marketing-
+   blocking `consumer_suppressions` row (`channel IN ('all','email')`) →
+   skip `address_suppressed`.
+5. **Send-time consent gate (§5 obligation)**: `canMarketToBatch(
+   [consumerId], { channel:'email', campaignId: snapshotCampaignId })` →
+   **`Map`**; `map.get(consumerId)` absent → fail closed
+   (`not_found`); `.ok === false` → skip `reasons[0]`. Parity-proven ===
+   `consentService.canMarketTo`; catches everyone who unsubscribed/was
+   suppressed/erased between claim and send.
+6. **Unsubscribe mint + VERIFY**: `ensureUnsubToken(consumerId)`, then
+   `findConsumerByUnsubToken(token)` must return this consumer — else skip
+   `unsub_token_error` (catches the known rotate-secret hash-mismatch
+   without touching consentService; keyring rotation stays a platform
+   follow-up). Marketing mail with a dead unsubscribe link is never sent.
+7. **Send**: `sendEmail({to, subject, html, text, context:
+   emailContext, headers})` with the PR-B pair `List-Unsubscribe:
+   <url>` + `List-Unsubscribe-Post: List-Unsubscribe=One-Click`.
+   `result?.success === true` → `sent`+`sentAt` (email column updated to
+   the address actually used); `success:false` (transporter vanished
+   mid-run) → `failed/send_error` (no transport attempt was made); throw →
+   `failed/send_error`+`error`. No per-recipient auto-retry — deterministic
+   failures are visible in the log; a human decides.
+8. **Throttle**: `await sleep(1000 / EMAIL_BROADCAST_RATE_PER_SEC)`
+   (default 2, clamped 0.2–10).
+
+Finalize: recount statuses from rows (authoritative), write counts,
+`completedAt`, CAS `sending → completed`. Loop-level crash → `failed` +
+`lastError` (rows keep truth). Always release the local lock. `completed`
+means "worker finished" — the UI derives the outcome (all-sent / partial /
+nothing-sent) from counts; it never claims delivery beyond SMTP acceptance.
+
+Resume (`POST /:id/send {resume:true}`): allowed from `interrupted`, or
+`sending` whose heartbeat is stale ≥120s (self-heal without waiting for a
+boot). CAS → `sending`, sweep `attempting` → `failed/ambiguous_crash`,
+rebuild the address-dedupe set from existing rows, re-enter the loop over
+`pending` only. Resume NEVER re-resolves the audience or inserts rows.
+
+### 3.4 Template (`emailBroadcastTemplate.js`, new file)
+
+`renderBroadcastEmail({ subject, bodyText, ctaLabel, ctaUrl, brandName,
+brandOrigin, unsubscribeUrl, recipientFirstName, testNotice })` →
+`{ html, text }`. 600px single-column table in `getModernTemplate`'s visual
+family (that fn is unexported; mailer.js untouched): greeting (`Hi
+{firstName},` / `Hi there,`), paragraphs (blank-line split, **every field
+HTML-escaped**, no raw-HTML path), one bulletproof CTA button, footer:
+"You're receiving this because you signed up with {brandName}." +
+unsubscribe link + `MKTR PTE. LTD. (UEN 202507548M), Singapore` identity
+line. Text alt mirrors everything. Consented-recipients-only is a hard
+invariant of the pipeline (gate at send), so this system never sends
+unsolicited mail in the Spam Control Act sense; the platform-wide counsel
+review (already pending for the consent chain) owns the final wording.
+
+## 4. Endpoints — `routes/emailBroadcasts.js`, `meta.path='/api/email-broadcasts'`
+
+`router.use(authenticateToken, requireAdmin)`; Joi local to the route file;
+controller `emailBroadcastController.js` (`asyncHandler`, `{success,data}`)
+— the cohort pattern verbatim.
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/` | Create draft `{cohortId, campaignId, subject, bodyText, ctaLabel?}`; 422 phantom/archived cohort, phantom campaign |
+| GET | `/` | List newest-first, cap 200, incl. cohort/campaign names |
+| GET | `/:id` | Detail DTO: row + cohort `{id,name,definition}` + campaign `{id,name,status,is_active}` + computed ctaUrl preview for drafts |
+| PUT | `/:id` | Draft-only (conditional update, else 409) |
+| DELETE | `/:id` | Draft-only (else 409); hard delete |
+| POST | `/:id/send` | Kick (draft) / `{resume:true}` (interrupted/stale) — 202-style; 409 on CAS loss or another broadcast in flight |
+| POST | `/:id/cancel` | From preparing/sending → cancelling (worker stops ≤1 iteration); from interrupted/failed → cancelled directly |
+| POST | `/:id/test` | Render + send ONE email **to the requesting admin only** (`req.user.email` — no address parameter), `[TEST] `-prefixed subject, visible test banner, unsubscribe link inert (`#`), logged via logger (actor/broadcast/time), not in the recipient log |
+| GET | `/:id/recipients` | Send log, `?status=all\|pending\|attempting\|sent\|skipped\|failed`, paged ≤200 |
+
+`'/api/email-broadcasts'` → `BLOCKED_PATH_PREFIXES` in
+`internalRouteHostGuard.js` (NOT the ops allowlist). No feature flag —
+additive admin-only routes (cohort posture); nothing sends without an
+explicit admin action behind a confirm dialog. Live proof = 401 probe.
+
+## 5. Erasure integration (`erasureService.js` — clean file, in scope)
+
+`email_broadcast_recipients` joins the erasure matrix: for the erased
+consumerId, null `email` + `error` (content about the person), keep
+`status/reason/sentAt` + FK (delivery facts on the retained skeleton —
+same stance as redemptions/commissions). The repair pass re-runs it by
+construction. In-flight interplay: gate-at-send skips erased consumers;
+the destination refresh (§3.3-3) sees the nulled email → `missing_email`.
+
+## 6. Frontend (admin v2, same `VITE_ADMIN_V2_ENABLED` as cohorts)
+
+- `src/api/adminV2.js`: `fetchEmailBroadcasts / fetchEmailBroadcast /
+  createEmailBroadcast / updateEmailBroadcast / deleteEmailBroadcast /
+  sendEmailBroadcast(id,{resume}) / cancelEmailBroadcast /
+  testEmailBroadcast(id) / fetchEmailBroadcastRecipients(id,{status,limit,
+  offset})` — thin `apiClient` fetchers.
+- `AdminV2Broadcasts.jsx` — list (PageHeader + "New push"): subject, cohort,
+  campaign, status chip, sent/skipped/failed, date. Composer dialog (shadcn
+  Dialog + `av2-input`, sonner): cohort select (prefill `?cohort=`),
+  campaign select — **active campaigns only** (filtered client-side from
+  facets), defaulted from the cohort's stored gate scope; subject, body
+  textarea, CTA label. Create → detail.
+- `AdminV2BroadcastDetail.jsx` — status+counts tiles, frozen/preview CTA
+  URL, **Send** behind `AlertDialog` confirm showing a live reachable
+  estimate (`previewCohortDefinition(definition-with-campaign-override,
+  'email')` on the definition from the detail DTO) AND the scope reminder:
+  "This email must be about {campaign} — recipients consented to that."
+  (the §5 free-form-copy obligation, surfaced at the moment of truth);
+  **Cancel** while preparing/sending/cancelling; **Resume** when
+  interrupted/stale; **Send test to my email**; recipients table (status
+  filter + paging; reasons via cohort `reasonLabel` + local labels for the
+  sender codes).
+- `src/pages/index.jsx` (single-space indents): lazy `/AdminBroadcasts` +
+  `/admin/broadcasts/:id`, cohort-route pattern. Nav: `{ to:
+  '/AdminBroadcasts', label: 'Email Pushes' }` after Cohorts.
+  `AdminV2CohortDetail.jsx` header gains **Push email** →
+  `/AdminBroadcasts?cohort=<id>`.
+
+## 7. Conflict posture (parallel sessions) — revised
+
+Frozen (imports only, ZERO edits): `consentService.js`, `contactConsent.js`,
+`middleware/validation.js` (uncommitted parallel work on the main checkout),
+`cohortService.js`, `mailer.js` (stability; workarounds above are explicit:
+no messageId, token verify-don't-fix, offset-paging acceptance).
+In-scope edits (clean files, additive): `models/index.js`,
+`internalRouteHostGuard.js`, `erasureService.js` (one matrix step),
+`bootstrap.js` (one sweep call), `src/api/adminV2.js`, `src/pages/index.jsx`,
+`src/lib/adminV2/nav.js`, `AdminV2CohortDetail.jsx` (one button).
+New files: migration 085, 2 models, service, template, routes, controller,
+2 pages, 4 test files. Branch `feat/email-broadcast`, isolated worktree.
+
+## 8. Tests
+
+Backend (real-Postgres jest, `test/helpers.js` boot; REAL cohortService +
+consentService against the db — no simplified gate mocks; `sendEmail`/
+`sleep` injected via factory):
+- `emailBroadcastService.test.js`: happy path (counts, row statuses, PR-B
+  headers present, escaping of `<script>` subject/body, CTA utm + 'mktr'
+  host branch, from-context); gate-at-send skips (suppress AFTER claim →
+  `suppressed`; scoped grant passes its campaign / skipped for another;
+  erased → skip); destination refresh (email changed after claim → new
+  address used + row updated; nulled → `missing_email`); two consumers one
+  norm-key → one `sent` one `duplicate_email`; OTHER consumer's suppression
+  on shared address → `address_suppressed`; unsub verify failure (corrupt
+  stored hash) → `unsub_token_error`, nothing sent; `sendEmail`
+  `{success:false}` → `failed/send_error`; throttle (`sleep` spy count);
+  claim CAS (row pre-flipped to `attempting` → not re-sent); resume sweeps
+  `attempting`→`ambiguous_crash`, sends only `pending`, never re-resolves
+  (cohort edited between → membership unchanged); cancel mid-loop (status
+  flip → worker stops, `pending`→`skipped/cancelled`); one-in-flight 409;
+  inactive campaign (`is_active:false`, `status:'active'`) revert;
+  empty-audience + over-cap revert; non-https CTA origin revert; finalize
+  recount; boot sweep flips stale `sending`→`interrupted`.
+- `emailBroadcastRoutes.test.js`: 401/403 everywhere; CRUD; draft-only
+  PUT/DELETE 409; phantom cohort/campaign 422; double-send 409; cancel
+  transitions; test-send goes to `req.user.email` only (no `to` accepted);
+  recipients paging/filter; validation rejections; erasure integration
+  (erase → recipient row email/error nulled, facts kept).
+
+Frontend (vitest, mocked `@/api/adminV2`): `AdminV2Broadcasts.test.jsx`
+(list, composer create, `?cohort=` prefill, active-only campaign options),
+`AdminV2BroadcastDetail.test.jsx` (tiles, send-confirm calls
+`sendEmailBroadcast`, cancel button by status, recipients + reasons).
+
+## 9. Accepted limits (explicitly NOT built — single-instance posture)
+
+- **Offset-paging audience drift** (Codex #11): under-send-only; exact
+  `INSERT…SELECT` materialization needs a cohortService change — follow-up
+  when volume warrants.
+- **Multi-instance worker fleet** (#1/#14/#15 tails): CAS + heartbeat +
+  one-in-flight give single-instance correctness and cross-instance
+  *safety* (a second instance can't double-claim rows or run two
+  broadcasts); a distributed limiter/lease-fencing beyond that waits for
+  an actual second instance.
+- **Provider bounce/complaint webhooks** (#19): no SES/SNS wiring exists
+  platform-wide; manual admin suppression + address-level check cover the
+  interim; volume is 3–4 digits, one broadcast at a time.
+- **Unsub-secret keyring rotation** (#5 tail): pre-existing platform issue
+  in frozen consentService; this sender VERIFIES tokens before sending so
+  it can't ship dead links; keyring = platform follow-up.
+- **Email-ownership verification** (#12 tail): consumers verify by phone
+  OTP; email stays typo-prone. Accepted for consented low-volume pushes.
+- Delivery beyond SMTP acceptance is unknowable without provider webhooks;
+  statuses say so (`completed` + counts, never "delivered").
+
+## 10. Codex round 1 (gpt-5.6-sol xhigh, 25 findings) — disposition
+
+| # | Finding | Disposition |
+|---|---|---|
+| 1 | BLOCKER no double-send fence | FOLDED §3.1/§3.3-2: CAS transitions, per-row conditional claim, heartbeat lease, one-in-flight |
+| 2 | BLOCKER crash-after-SMTP resend | FOLDED §3.3-2: `attempting` fence, at-most-once, `ambiguous_crash` never retried |
+| 3 | BLOCKER consumer-keyed dedupe/unsub | FOLDED §3.3-3/4: norm-key dedupe per broadcast + cross-consumer address suppression |
+| 4 | BLOCKER raw email vs erasure | FOLDED §5: FK + erasure-matrix step (email/error nulled, facts kept) |
+| 5 | BLOCKER unsub token after rotation | FOLDED §3.3-6 verify-before-send; keyring = platform follow-up (frozen file) |
+| 6 | MAJOR batch return is a Map | FOLDED §3.3-5 (absent → fail closed); real gate in tests |
+| 7 | MAJOR sendEmail return shape | FOLDED §3.3-7 (`success===true`), §3.2-1 transporter preflight; messageId dropped |
+| 8 | MAJOR resume contradiction | FOLDED §3.1/§3.3: preparing≠resume, resume never re-resolves |
+| 9 | MAJOR missing snapshots | FOLDED §2/§3.2-3: definition/host/context/ctaUrl frozen at preparing |
+| 10 | MAJOR edit/send race | FOLDED §3.1: CAS first, conditional PUT/DELETE, worker re-reads row |
+| 11 | MAJOR offset-paging drift | ACCEPTED §9: under-send-only; fence+gate prevent wrong sends |
+| 12 | MAJOR stale destination | FOLDED §3.3-3 refresh; ownership verification accepted §9 |
+| 13 | MAJOR localhost CTA / is_active | FOLDED §3.2-2/3: https-only origin, `status` AND `is_active` |
+| 14 | MAJOR per-worker rate limit | FOLDED via one-in-flight; fleet limiter §9 |
+| 15 | MAJOR webhook-posture claim false | FOLDED §3.1 boot sweep (no auto-resume); claim removed |
+| 16 | MAJOR no emergency stop | FOLDED §3.3-1/§4: cancelling/cancelled + per-iteration check |
+| 17 | MAJOR ungated test sends | FOLDED §4: self-only, logged, no address param |
+| 18 | MAJOR free-form copy vs scope | SURFACED §6 confirm-dialog reminder + §3.2 snapshot; enforcement is human — documented operator obligation |
+| 19 | MAJOR bounce/complaint loop | ACCEPTED §9 + §3.3-4 covers recorded suppressions; follow-up |
+| 20 | MAJOR 'sent' ≠ sent | FOLDED: `completed` + derived outcome; delivery never claimed |
+| 21 | MAJOR Spam Control Act breadth | FOLDED §3.4: consented-only invariant; wording → pending counsel review |
+| 22 | MINOR CHECKs / FK actions | FOLDED §2: guarded CHECKs, campaign SET NULL, cohort RESTRICT |
+| 23 | MINOR contract gaps | FOLDED §4 DTO / §6 active-only options + local reason labels / list cap |
+| 24 | MAJOR test gaps | FOLDED §8 (single-process-provable set); fleet-harness items §9 |
+| 25 | MAJOR frozen-files incompatibility | PARTIALLY FOLDED §7: erasureService+bootstrap now in scope; consent/cohort/mailer stay frozen with explicit workarounds |
+
+## 11. Env / rollout / live proof
+
+- `EMAIL_BROADCAST_RATE_PER_SEC` (default 2, clamp 0.2–10),
+  `EMAIL_BROADCAST_MAX_RECIPIENTS` (default 5000, clamp 1–20000); defaults
+  safe, no Render env change needed to ship.
+- Deploys: backend (`mktr-backend-jo6r`) + `mktr-platform` static. Live
+  proof: NEW deploys via `list_deploys`, then `api.mktr.sg/api/
+  email-broadcasts` 401 probe + mktr.sg served-bundle grep for a unique
+  string.
+- Nothing sends on deploy; first real send is a human act behind a confirm.

--- a/src/api/adminV2.js
+++ b/src/api/adminV2.js
@@ -189,3 +189,55 @@ export function updateCohort(id, patch) {
 export function archiveCohort(id) {
   return apiClient.delete(`/cohorts/${id}`);
 }
+
+// ── Email broadcasts (tracker "emailpush" — /api/email-broadcasts) ───────────
+
+export async function fetchEmailBroadcasts() {
+  const resp = await apiClient.get('/email-broadcasts');
+  const rows = resp?.data || [];
+  return { rows, total: rows.length };
+}
+
+/** Detail DTO: row + cohort{definition} + campaign + ctaUrlPreview + liveCounts. */
+export async function fetchEmailBroadcast(id) {
+  const resp = await apiClient.get(`/email-broadcasts/${id}`);
+  return resp?.data ?? null;
+}
+
+export function createEmailBroadcast({ cohortId, campaignId, subject, bodyText, ctaLabel }) {
+  return apiClient.post('/email-broadcasts', {
+    cohortId,
+    campaignId,
+    subject,
+    bodyText,
+    ...(ctaLabel ? { ctaLabel } : {}),
+  });
+}
+
+export function updateEmailBroadcast(id, patch) {
+  return apiClient.put(`/email-broadcasts/${id}`, patch);
+}
+
+export function deleteEmailBroadcast(id) {
+  return apiClient.delete(`/email-broadcasts/${id}`);
+}
+
+/** Kick a draft send; { resume: true } continues an interrupted/stale one. */
+export function sendEmailBroadcast(id, { resume = false } = {}) {
+  return apiClient.post(`/email-broadcasts/${id}/send`, resume ? { resume: true } : {});
+}
+
+export function cancelEmailBroadcast(id) {
+  return apiClient.post(`/email-broadcasts/${id}/cancel`, {});
+}
+
+/** Sends a marked test render to the requesting admin's own email. */
+export function testEmailBroadcast(id) {
+  return apiClient.post(`/email-broadcasts/${id}/test`, {});
+}
+
+export async function fetchEmailBroadcastRecipients(id, { status = 'all', limit = 50, offset = 0 } = {}) {
+  const qs = new URLSearchParams({ status, limit: String(limit), offset: String(offset) });
+  const resp = await apiClient.get(`/email-broadcasts/${id}/recipients?${qs.toString()}`);
+  return resp?.data ?? { total: 0, recipients: [] };
+}

--- a/src/lib/adminV2/broadcasts.js
+++ b/src/lib/adminV2/broadcasts.js
@@ -1,0 +1,57 @@
+/**
+ * Email-broadcast UI vocabulary (tracker "emailpush") — status/reason
+ * language shared by the list, composer and detail screens. Sender-side skip
+ * reasons extend the cohort REASON_META (consent-gate codes render through
+ * the same vocabulary so the WHY language never forks).
+ */
+import { REASON_META, reasonLabel as cohortReasonLabel } from './cohorts.js';
+
+export const BROADCAST_STATUS_META = {
+  draft: { label: 'Draft', tone: '' },
+  preparing: { label: 'Preparing', tone: 'warn' },
+  sending: { label: 'Sending', tone: 'warn' },
+  cancelling: { label: 'Cancelling', tone: 'warn' },
+  completed: { label: 'Completed', tone: 'ok' },
+  interrupted: { label: 'Interrupted', tone: 'warn' },
+  failed: { label: 'Failed', tone: 'bad' },
+  cancelled: { label: 'Cancelled', tone: '' },
+};
+
+export const RECIPIENT_STATUS_META = {
+  pending: { label: 'Pending', tone: '' },
+  attempting: { label: 'Attempting', tone: 'warn' },
+  sent: { label: 'Sent', tone: 'ok' },
+  skipped: { label: 'Skipped', tone: 'hold' },
+  failed: { label: 'Failed', tone: 'bad' },
+};
+
+/** Sender-side codes on top of the consent-gate vocabulary. */
+const SENDER_REASON_META = {
+  duplicate_email: { label: 'Duplicate address', tone: 'hold', hint: 'Another person in this push already received this exact address — one copy per inbox.' },
+  address_suppressed: { label: 'Address unsubscribed', tone: 'bad', hint: 'This address unsubscribed through another signup — it wins across all of them.' },
+  unsub_token_error: { label: 'Unsubscribe link broken', tone: 'bad', hint: 'The unsubscribe link could not be verified — marketing mail is never sent without a working one.' },
+  send_error: { label: 'Send failed', tone: 'bad', hint: 'The mail server rejected or failed the send.' },
+  ambiguous_crash: { label: 'Crash — not retried', tone: 'warn', hint: 'The send was interrupted mid-attempt; it may or may not have gone out, so it is never retried.' },
+  cancelled: { label: 'Cancelled', tone: '', hint: 'The push was cancelled before this person was reached.' },
+};
+
+export function broadcastReasonMeta(reason) {
+  return SENDER_REASON_META[reason] || REASON_META[reason] || null;
+}
+
+export function broadcastReasonLabel(reason) {
+  return SENDER_REASON_META[reason]?.label || cohortReasonLabel(reason);
+}
+
+/** The send gate scope: the cohort definition re-aimed at the push campaign
+ * (what the backend freezes at preparing — mirrored for the live estimate). */
+export function definitionWithCampaignScope(definition, campaignId) {
+  if (!definition || typeof definition !== 'object') return definition;
+  return {
+    ...definition,
+    marketingContext: { ...(definition.marketingContext || {}), campaignId: campaignId || null },
+  };
+}
+
+/** Statuses where the worker is (or should be) alive and the UI polls. */
+export const ACTIVE_BROADCAST_STATUSES = ['preparing', 'sending', 'cancelling'];

--- a/src/lib/adminV2/nav.js
+++ b/src/lib/adminV2/nav.js
@@ -13,6 +13,7 @@ export const NAV = [
     items: [
       { to: '/AdminProspects', label: 'Prospects' },
       { to: '/AdminCohorts', label: 'Cohorts' },
+      { to: '/AdminBroadcasts', label: 'Email Pushes' },
       { to: '/AdminAgents', label: 'Agents' },
       { to: '/AdminAgentGroups', label: 'Agent Groups' },
       { to: '/AdminCampaigns', label: 'Campaigns' },

--- a/src/pages/adminv2/AdminV2BroadcastDetail.jsx
+++ b/src/pages/adminv2/AdminV2BroadcastDetail.jsx
@@ -1,0 +1,312 @@
+/**
+ * Email Push detail (tracker "emailpush") — the send console + send log.
+ * Draft → confirm dialog (live reachable estimate under THIS campaign's
+ * consent scope + the "must be about this campaign" reminder) → the backend
+ * worker sends throttled with a per-recipient gate; this screen polls the
+ * live counts while active, offers Cancel (≤1 iteration to stop) and Resume
+ * (continues pending rows only, never re-sends), and renders the
+ * who/when/status/why log.
+ */
+import { useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import {
+  fetchEmailBroadcast, fetchEmailBroadcastRecipients, sendEmailBroadcast,
+  cancelEmailBroadcast, deleteEmailBroadcast, testEmailBroadcast,
+  previewCohortDefinition,
+} from '@/api/adminV2';
+import { fmtNumber, fmtRelative, fmtDateTime } from '@/lib/adminV2/format';
+import {
+  BROADCAST_STATUS_META, RECIPIENT_STATUS_META, broadcastReasonLabel,
+  broadcastReasonMeta, definitionWithCampaignScope, ACTIVE_BROADCAST_STATUSES,
+} from '@/lib/adminV2/broadcasts';
+import { Card, Chip, PageHeader, Skeleton, ErrorState, EmptyState, StateRow } from '@/components/adminv2/primitives';
+import { BroadcastComposer } from './AdminV2Broadcasts';
+import {
+  AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction,
+} from '@/components/ui/alert-dialog';
+
+const PAGE_SIZE = 50;
+
+function Tile({ label, value, caption, tone }) {
+  return (
+    <div style={{ flex: 1, padding: 16, borderRight: '1px solid var(--line)' }}>
+      <div className="av2-microcaps">{label}</div>
+      <div className="av2-mono" style={{ fontSize: 20, fontWeight: 600, marginTop: 4, color: tone || 'var(--ink)' }}>{value}</div>
+      {caption && <div className="av2-caption" style={{ marginTop: 2 }}>{caption}</div>}
+    </div>
+  );
+}
+
+export default function AdminV2BroadcastDetail() {
+  const { id } = useParams();
+  const [status, setStatus] = useState('all');
+  const [page, setPage] = useState(0);
+  const [confirmSend, setConfirmSend] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const broadcast = useQuery({
+    queryKey: ['adminV2', 'emailBroadcast', id],
+    queryFn: () => fetchEmailBroadcast(id),
+    refetchInterval: (q) => (ACTIVE_BROADCAST_STATUSES.includes(q.state.data?.status) ? 3000 : false),
+  });
+  const b = broadcast.data;
+  const active = ACTIVE_BROADCAST_STATUSES.includes(b?.status);
+
+  const recipients = useQuery({
+    queryKey: ['adminV2', 'emailBroadcastRecipients', id, status, page],
+    queryFn: () => fetchEmailBroadcastRecipients(id, { status, limit: PAGE_SIZE, offset: page * PAGE_SIZE }),
+    enabled: broadcast.isSuccess && b?.status !== 'draft',
+    placeholderData: (prev) => prev,
+    refetchInterval: active ? 5000 : false,
+  });
+
+  // The estimate the confirm dialog shows — the definition re-aimed at THIS
+  // campaign (exactly what the backend freezes and gates on).
+  const estimate = useQuery({
+    queryKey: ['adminV2', 'broadcastEstimate', id, b?.campaignId],
+    queryFn: () => previewCohortDefinition(
+      definitionWithCampaignScope(b.cohort.definition, b.campaignId), 'email',
+    ),
+    enabled: confirmSend && !!b?.cohort?.definition && !!b?.campaignId,
+    staleTime: 30_000,
+  });
+
+  const refetchAll = () => {
+    queryClient.invalidateQueries({ queryKey: ['adminV2', 'emailBroadcast', id] });
+    queryClient.invalidateQueries({ queryKey: ['adminV2', 'emailBroadcastRecipients', id] });
+    queryClient.invalidateQueries({ queryKey: ['adminV2', 'emailBroadcasts'] });
+  };
+
+  const send = useMutation({
+    mutationFn: ({ resume = false } = {}) => sendEmailBroadcast(id, { resume }),
+    onSuccess: () => { toast.success('Sending started'); setConfirmSend(false); refetchAll(); },
+    onError: (e) => { toast.error(e?.message || 'Send failed to start'); setConfirmSend(false); refetchAll(); },
+  });
+  const cancel = useMutation({
+    mutationFn: () => cancelEmailBroadcast(id),
+    onSuccess: () => { toast.success('Cancelling — the worker stops within one send'); refetchAll(); },
+    onError: (e) => { toast.error(e?.message || 'Cancel failed'); refetchAll(); },
+  });
+  const test = useMutation({
+    mutationFn: () => testEmailBroadcast(id),
+    onSuccess: (r) => toast.success(`Test sent to ${r?.data?.sentTo || 'your email'}`),
+    onError: (e) => toast.error(e?.message || 'Test send failed'),
+  });
+  const destroy = useMutation({
+    mutationFn: () => deleteEmailBroadcast(id),
+    onSuccess: () => {
+      toast.success('Draft deleted');
+      queryClient.invalidateQueries({ queryKey: ['adminV2', 'emailBroadcasts'] });
+      navigate('/AdminBroadcasts');
+    },
+    onError: (e) => toast.error(e?.message || 'Delete failed'),
+  });
+
+  if (broadcast.isLoading) {
+    return (
+      <div>
+        <Skeleton height={30} width={340} />
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 16, marginTop: 20 }}>
+          {[12, 12].map((span, i) => <div key={i} style={{ gridColumn: `span ${span}` }}><Skeleton height={140} /></div>)}
+        </div>
+      </div>
+    );
+  }
+  if (broadcast.isError) return <ErrorState error={broadcast.error} onRetry={broadcast.refetch} />;
+
+  const st = BROADCAST_STATUS_META[b.status] || { label: b.status, tone: '' };
+  const counts = b.liveCounts || {};
+  const remaining = (counts.pending || 0) + (counts.attempting || 0);
+
+  return (
+    <div>
+      <PageHeader
+        title={b.subject}
+        meta={`${(b.cohort?.name || '—').toUpperCase()} → ${(b.campaign?.name || '—').toUpperCase()} · ${st.label.toUpperCase()}`}
+      >
+        <Link to="/AdminBroadcasts" className="av2-btn av2-btn--sm" style={{ textDecoration: 'none' }}>← All pushes</Link>
+        {b.status === 'draft' && (
+          <>
+            <button type="button" className="av2-btn av2-btn--sm" onClick={() => setEditing(true)}>Edit</button>
+            <button type="button" className="av2-btn av2-btn--sm" disabled={test.isPending} onClick={() => test.mutate()}>
+              {test.isPending ? 'Sending test…' : 'Send test to my email'}
+            </button>
+            <button
+              type="button"
+              className="av2-btn av2-btn--sm"
+              style={{ borderColor: 'var(--bad)', color: 'var(--bad)' }}
+              disabled={destroy.isPending}
+              onClick={() => destroy.mutate()}
+            >
+              Delete
+            </button>
+            <button type="button" className="av2-btn av2-btn--sm av2-btn--primary" onClick={() => setConfirmSend(true)}>Send…</button>
+          </>
+        )}
+        {active && (
+          <button
+            type="button"
+            className="av2-btn av2-btn--sm"
+            style={{ borderColor: 'var(--bad)', color: 'var(--bad)' }}
+            disabled={cancel.isPending || b.status === 'cancelling'}
+            onClick={() => cancel.mutate()}
+          >
+            {b.status === 'cancelling' ? 'Cancelling…' : 'Cancel send'}
+          </button>
+        )}
+        {(b.status === 'interrupted' || b.status === 'failed') && (
+          <>
+            {b.status === 'interrupted' && (
+              <button type="button" className="av2-btn av2-btn--sm av2-btn--primary" disabled={send.isPending} onClick={() => send.mutate({ resume: true })}>
+                Resume
+              </button>
+            )}
+            <button
+              type="button"
+              className="av2-btn av2-btn--sm"
+              style={{ borderColor: 'var(--bad)', color: 'var(--bad)' }}
+              disabled={cancel.isPending}
+              onClick={() => cancel.mutate()}
+            >
+              Cancel remaining
+            </button>
+          </>
+        )}
+      </PageHeader>
+
+      {b.lastError && (
+        <div className="av2-caption" style={{ marginTop: -8, marginBottom: 14, color: 'var(--bad)' }}>{b.lastError}</div>
+      )}
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 16 }}>
+        <Card span={12}>
+          <div style={{ display: 'flex' }}>
+            <Tile label="Recipients" value={b.status === 'draft' ? '—' : fmtNumber(b.totalRecipients)} caption={b.status === 'draft' ? 'resolved at send' : 'claimed at send start'} />
+            <Tile label="Sent" value={fmtNumber(counts.sent ?? b.sentCount)} tone="var(--ok)" caption="accepted by the mail server" />
+            <Tile label="Skipped" value={fmtNumber(counts.skipped ?? b.skippedCount)} tone="var(--warn)" caption="gate said no at send time" />
+            <Tile label="Failed" value={fmtNumber(counts.failed ?? b.failedCount)} tone={(counts.failed ?? b.failedCount) ? 'var(--bad)' : undefined} caption="transport errors" />
+            {active && <Tile label="Remaining" value={fmtNumber(remaining)} caption="throttled queue" />}
+          </div>
+        </Card>
+
+        <Card span={12} title="Message" meta={b.hostChoice ? `BRAND ${b.hostChoice}` : undefined}>
+          <div style={{ padding: 16, display: 'grid', gap: 10 }}>
+            <div className="av2-caption" style={{ whiteSpace: 'pre-wrap' }}>{b.bodyText}</div>
+            <div className="av2-mono" style={{ fontSize: 11.5, color: 'var(--ink-2)', overflowWrap: 'anywhere' }}>
+              CTA “{b.ctaLabel}” → {b.ctaUrl || b.ctaUrlPreview || '—'}
+            </div>
+            <div className="av2-caption">
+              Every mail carries the unsubscribe footer + one-click header (PR-B rails). Recipients are re-checked against the “{b.campaign?.name || '—'}” consent scope at the moment of their send.
+            </div>
+          </div>
+        </Card>
+
+        {b.status !== 'draft' && (
+          <Card
+            span={12}
+            title="Send log"
+            meta={recipients.data ? `${fmtNumber(recipients.data.total)} ${status === 'all' ? 'rows' : status}` : undefined}
+            action={(
+              <div className="av2-seg" role="group" aria-label="Recipient status">
+                {['all', 'sent', 'skipped', 'failed', 'pending'].map((s) => (
+                  <button key={s} type="button" aria-pressed={status === s} onClick={() => { setStatus(s); setPage(0); }}>
+                    {s}
+                  </button>
+                ))}
+              </div>
+            )}
+          >
+            <div role="table" aria-label="Send log">
+              <div className="av2-thead" role="row">
+                <span className="av2-microcaps" role="columnheader" style={{ flex: 1.6 }}>Email</span>
+                <span className="av2-microcaps" role="columnheader" style={{ width: 110, flex: 'none' }}>Status</span>
+                <span className="av2-microcaps" role="columnheader" style={{ flex: 1.4 }}>Why</span>
+                <span className="av2-microcaps" role="columnheader" style={{ width: 130, flex: 'none', textAlign: 'right' }}>When</span>
+              </div>
+
+              {recipients.isLoading && <StateRow><div style={{ padding: 12 }}><Skeleton height={60} /></div></StateRow>}
+              {recipients.isError && <StateRow><ErrorState error={recipients.error} onRetry={recipients.refetch} /></StateRow>}
+              {recipients.isSuccess && recipients.data.recipients.length === 0 && (
+                <StateRow><EmptyState title={`No ${status === 'all' ? '' : status} rows`} hint="Rows appear once the send starts claiming recipients." /></StateRow>
+              )}
+
+              {(recipients.data?.recipients || []).map((r) => {
+                const rst = RECIPIENT_STATUS_META[r.status] || { label: r.status, tone: '' };
+                const meta = r.reason ? broadcastReasonMeta(r.reason) : null;
+                return (
+                  <div key={r.id} className="av2-row" role="row" style={{ cursor: 'default' }}>
+                    <span role="cell" className="av2-mono" style={{ flex: 1.6, fontSize: 11.5, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {r.email || '—'}
+                    </span>
+                    <span role="cell" style={{ width: 110, flex: 'none' }}><Chip tone={rst.tone}>{rst.label}</Chip></span>
+                    <span role="cell" style={{ flex: 1.4, display: 'flex', gap: 4, flexWrap: 'wrap', alignItems: 'center' }}>
+                      {r.reason ? <Chip tone={meta?.tone || ''}>{broadcastReasonLabel(r.reason)}</Chip> : <span className="av2-caption">—</span>}
+                      {r.error && <span className="av2-caption" style={{ color: 'var(--bad)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 260 }} title={r.error}>{r.error}</span>}
+                    </span>
+                    <span role="cell" className="av2-mono" style={{ width: 130, flex: 'none', fontSize: 10.5, color: 'var(--ink-3)', textAlign: 'right' }} title={r.sentAt ? fmtDateTime(r.sentAt) : ''}>
+                      {r.sentAt ? fmtRelative(r.sentAt) : '—'}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+
+            {recipients.isSuccess && recipients.data.total > PAGE_SIZE && (
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center', justifyContent: 'flex-end', padding: '10px 14px' }}>
+                <span className="av2-caption">
+                  {fmtNumber(page * PAGE_SIZE + 1)}–{fmtNumber(Math.min((page + 1) * PAGE_SIZE, recipients.data.total))} of {fmtNumber(recipients.data.total)}
+                </span>
+                <button type="button" className="av2-btn av2-btn--sm" disabled={page === 0} onClick={() => setPage((p) => p - 1)}>← Prev</button>
+                <button type="button" className="av2-btn av2-btn--sm" disabled={(page + 1) * PAGE_SIZE >= recipients.data.total} onClick={() => setPage((p) => p + 1)}>Next →</button>
+              </div>
+            )}
+          </Card>
+        )}
+      </div>
+
+      {editing && (
+        <BroadcastComposer
+          broadcast={b}
+          onClose={() => setEditing(false)}
+          onSaved={() => refetchAll()}
+        />
+      )}
+
+      <AlertDialog open={confirmSend} onOpenChange={(open) => { if (!open) setConfirmSend(false); }}>
+        <AlertDialogContent className="admin-v2" style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)' }}>
+          <AlertDialogHeader>
+            <AlertDialogTitle style={{ color: 'var(--ink)' }}>Send “{b.subject}”?</AlertDialogTitle>
+            <AlertDialogDescription style={{ color: 'var(--ink-2)' }} asChild>
+              <div>
+                <p style={{ margin: '0 0 8px' }}>
+                  {estimate.isLoading && 'Estimating the reachable audience…'}
+                  {estimate.isError && 'Estimate unavailable — the backend still gates every recipient at send time.'}
+                  {estimate.data && (
+                    <>Approximately <b>{fmtNumber(estimate.data.reachable)}</b> of {fmtNumber(estimate.data.total)} people in “{b.cohort?.name}” are reachable under this campaign's consent scope right now. Each one is re-checked at the moment of their send.</>
+                  )}
+                </p>
+                <p style={{ margin: 0 }}>
+                  This email must be ABOUT “{b.campaign?.name}” — recipients consented to that scope, throttled sending starts immediately, and every mail carries the unsubscribe rails.
+                </p>
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Not yet</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => { e.preventDefault(); send.mutate({}); }}
+              disabled={send.isPending}
+            >
+              {send.isPending ? 'Starting…' : 'Send now'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/pages/adminv2/AdminV2Broadcasts.jsx
+++ b/src/pages/adminv2/AdminV2Broadcasts.jsx
@@ -1,0 +1,242 @@
+/**
+ * Email Pushes (tracker "emailpush") — the campaign-push composer + list.
+ * A push is: one cohort, one campaign it is ABOUT, subject/body/CTA. The
+ * backend re-gates EVERY recipient at send time (consent scoped to that
+ * campaign) and carries the PR-B unsubscribe rails on every message; this
+ * screen only composes drafts — sending lives on the detail screen behind a
+ * confirm.
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import {
+  fetchEmailBroadcasts, createEmailBroadcast, updateEmailBroadcast,
+  fetchCohorts, fetchCohortFacets,
+} from '@/api/adminV2';
+import { fmtNumber, fmtRelative } from '@/lib/adminV2/format';
+import { BROADCAST_STATUS_META } from '@/lib/adminV2/broadcasts';
+import { normalizeDefinitionShape } from '@/lib/adminV2/cohorts';
+import { PageHeader, Chip, Skeleton, ErrorState, EmptyState, StateRow } from '@/components/adminv2/primitives';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription,
+} from '@/components/ui/dialog';
+
+function Field({ label, hint, children }) {
+  return (
+    <div>
+      <div className="av2-microcaps" style={{ marginBottom: 6 }}>
+        {label}
+        {hint && <span style={{ opacity: 0.6, fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}> · {hint}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+/** Compose (or edit a draft of) an email push. */
+export function BroadcastComposer({ broadcast = null, initialCohortId = null, onClose, onSaved }) {
+  const editing = !!broadcast;
+  const cohorts = useQuery({ queryKey: ['adminV2', 'cohorts'], queryFn: fetchCohorts, staleTime: 30_000 });
+  const facets = useQuery({ queryKey: ['adminV2', 'cohortFacets'], queryFn: fetchCohortFacets, staleTime: 60_000 });
+
+  const [cohortId, setCohortId] = useState(broadcast?.cohortId || initialCohortId || '');
+  const [campaignId, setCampaignId] = useState(broadcast?.campaignId || '');
+  const [subject, setSubject] = useState(broadcast?.subject || '');
+  const [bodyText, setBodyText] = useState(broadcast?.bodyText || '');
+  const [ctaLabel, setCtaLabel] = useState(broadcast?.ctaLabel || 'Learn more');
+
+  // The send gate is scoped to the campaign the email is ABOUT — active
+  // campaigns only (the backend re-checks status AND is_active at send).
+  const activeCampaigns = useMemo(
+    () => (facets.data?.campaigns || []).filter((c) => c.status === 'active'),
+    [facets.data],
+  );
+
+  // Default the campaign from the cohort's own gate scope when it has one.
+  const cohortRows = cohorts.data?.rows || [];
+  useEffect(() => {
+    if (editing || campaignId || !cohortId) return;
+    const cohort = cohortRows.find((c) => c.id === cohortId);
+    const scoped = normalizeDefinitionShape(cohort?.definition).marketingContext?.campaignId;
+    if (scoped) setCampaignId(scoped);
+  }, [editing, campaignId, cohortId, cohortRows]);
+
+  const save = useMutation({
+    mutationFn: () => {
+      const payload = { cohortId, campaignId, subject: subject.trim(), bodyText: bodyText.trim(), ctaLabel: ctaLabel.trim() || 'Learn more' };
+      return editing ? updateEmailBroadcast(broadcast.id, payload) : createEmailBroadcast(payload);
+    },
+    onSuccess: (r) => {
+      toast.success(editing ? 'Push updated' : 'Draft created — review, test, then send');
+      onSaved?.(r?.data || null);
+      onClose();
+    },
+    onError: (e) => toast.error(e?.message || 'Save failed'),
+  });
+
+  const canSave = cohortId && campaignId && subject.trim() && bodyText.trim() && !save.isPending;
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open && !save.isPending) onClose(); }}>
+      <DialogContent
+        className="admin-v2"
+        style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)', maxWidth: 640, maxHeight: '86vh', display: 'flex', flexDirection: 'column' }}
+      >
+        <DialogHeader>
+          <DialogTitle style={{ color: 'var(--ink)', fontFamily: 'var(--font-ui)', fontSize: 15, fontWeight: 800, textAlign: 'left' }}>
+            {editing ? 'Edit push' : 'New email push'}
+          </DialogTitle>
+          <DialogDescription style={{ color: 'var(--ink-2)', fontSize: 11.5, textAlign: 'left' }}>
+            The email must be ABOUT the campaign you pick — every recipient is re-checked against that consent scope at send time.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div style={{ overflowY: 'auto', display: 'grid', gap: 14, padding: '6px 2px', flex: 1 }}>
+          <Field label="Cohort" hint="who receives it">
+            {cohorts.isLoading ? <Skeleton height={30} /> : (
+              <select className="av2-input" value={cohortId} onChange={(e) => setCohortId(e.target.value)} aria-label="Cohort">
+                <option value="">Select a cohort…</option>
+                {cohortRows.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}{c.lastReachableCount != null ? ` (~${c.lastReachableCount} reachable)` : ''}
+                  </option>
+                ))}
+              </select>
+            )}
+          </Field>
+
+          <Field label="Campaign" hint="what the email is about — CTA links to its page">
+            {facets.isLoading ? <Skeleton height={30} /> : (
+              <select className="av2-input" value={campaignId} onChange={(e) => setCampaignId(e.target.value)} aria-label="Campaign">
+                <option value="">Select an active campaign…</option>
+                {activeCampaigns.map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}
+              </select>
+            )}
+          </Field>
+
+          <Field label="Subject">
+            <input className="av2-input" value={subject} onChange={(e) => setSubject(e.target.value)} maxLength={200} placeholder="e.g. Your Tokyo draw closes this week" />
+          </Field>
+
+          <Field label="Body" hint="plain text — blank line starts a new paragraph">
+            <textarea
+              className="av2-input"
+              value={bodyText}
+              onChange={(e) => setBodyText(e.target.value)}
+              maxLength={5000}
+              rows={8}
+              style={{ resize: 'vertical', minHeight: 140, fontFamily: 'inherit' }}
+              placeholder={'Hi — quick reminder that…\n\nSecond paragraph.'}
+            />
+          </Field>
+
+          <Field label="Button label" hint="links to the campaign page with utm tagging">
+            <input className="av2-input" value={ctaLabel} onChange={(e) => setCtaLabel(e.target.value)} maxLength={80} />
+          </Field>
+        </div>
+
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', paddingTop: 10 }}>
+          <button type="button" className="av2-btn" onClick={onClose} disabled={save.isPending}>Cancel</button>
+          <button type="button" className="av2-btn av2-btn--primary" disabled={!canSave} onClick={() => save.mutate()}>
+            {save.isPending ? 'Saving…' : editing ? 'Save changes' : 'Create draft'}
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default function AdminV2Broadcasts() {
+  const broadcasts = useQuery({ queryKey: ['adminV2', 'emailBroadcasts'], queryFn: fetchEmailBroadcasts, staleTime: 15_000 });
+  const [searchParams, setSearchParams] = useSearchParams();
+  const prefillCohort = searchParams.get('cohort');
+  const [composing, setComposing] = useState(() => !!prefillCohort);
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const rows = broadcasts.data?.rows || [];
+
+  return (
+    <div>
+      <PageHeader
+        title="Email Pushes"
+        meta={`${fmtNumber(rows.length)} PUSHES · EVERY RECIPIENT RE-GATED AT SEND TIME · UNSUBSCRIBE ON EVERY MAIL`}
+      >
+        <button type="button" className="av2-btn av2-btn--primary" onClick={() => setComposing(true)}>+ New push</button>
+      </PageHeader>
+
+      <div className="av2-card" style={{ overflow: 'hidden' }} role="table" aria-label="Email pushes">
+        <div className="av2-thead" role="row">
+          <span className="av2-microcaps" role="columnheader" style={{ flex: 1.6 }}>Subject</span>
+          <span className="av2-microcaps" role="columnheader" style={{ flex: 1 }}>Cohort</span>
+          <span className="av2-microcaps" role="columnheader" style={{ flex: 1 }}>Campaign</span>
+          <span className="av2-microcaps" role="columnheader" style={{ width: 110, flex: 'none' }}>Status</span>
+          <span className="av2-microcaps" role="columnheader" style={{ width: 150, flex: 'none', textAlign: 'right' }}>Sent / skip / fail</span>
+          <span className="av2-microcaps" role="columnheader" style={{ width: 90, flex: 'none', textAlign: 'right' }}>Created</span>
+        </div>
+
+        {broadcasts.isLoading && [0, 1, 2].map((i) => (
+          <div key={i} className="av2-row" role="row" style={{ cursor: 'default' }}><span role="cell" style={{ flex: 1 }}><Skeleton height={30} /></span></div>
+        ))}
+        {broadcasts.isError && <StateRow><ErrorState error={broadcasts.error} onRetry={broadcasts.refetch} /></StateRow>}
+        {!broadcasts.isLoading && !broadcasts.isError && rows.length === 0 && (
+          <StateRow>
+            <EmptyState
+              title="No email pushes yet"
+              hint="Compose a subject/body/CTA about one campaign, pick a cohort, test it to yourself, then send."
+              action={<button type="button" className="av2-btn av2-btn--primary av2-btn--sm" onClick={() => setComposing(true)}>Compose the first one</button>}
+            />
+          </StateRow>
+        )}
+
+        {rows.map((b) => {
+          const st = BROADCAST_STATUS_META[b.status] || { label: b.status, tone: '' };
+          return (
+            <div
+              key={b.id}
+              className="av2-row"
+              role="row"
+              tabIndex={0}
+              onClick={() => navigate(`/admin/broadcasts/${b.id}`)}
+              onKeyDown={(e) => { if (e.key === 'Enter') navigate(`/admin/broadcasts/${b.id}`); }}
+            >
+              <span role="cell" style={{ flex: 1.6, fontSize: 13, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{b.subject}</span>
+              <span role="cell" className="av2-caption" style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{b.cohort?.name || '—'}</span>
+              <span role="cell" className="av2-caption" style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{b.campaign?.name || '—'}</span>
+              <span role="cell" style={{ width: 110, flex: 'none' }}><Chip tone={st.tone}>{st.label}</Chip></span>
+              <span role="cell" className="av2-mono" style={{ width: 150, flex: 'none', fontSize: 12, textAlign: 'right' }}>
+                {b.status === 'draft'
+                  ? '—'
+                  : <>
+                      <span style={{ color: 'var(--ok)', fontWeight: 700 }}>{fmtNumber(b.sentCount)}</span>
+                      <span style={{ color: 'var(--ink-3)' }}> / {fmtNumber(b.skippedCount)} / </span>
+                      <span style={{ color: b.failedCount ? 'var(--bad)' : 'var(--ink-3)' }}>{fmtNumber(b.failedCount)}</span>
+                    </>}
+              </span>
+              <span role="cell" className="av2-mono" style={{ width: 90, flex: 'none', fontSize: 10.5, color: 'var(--ink-3)', textAlign: 'right' }}>{fmtRelative(b.createdAt)}</span>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="av2-caption" style={{ marginTop: 10 }}>
+        Sends are throttled, one push at a time, with the unsubscribe footer + one-click header on every message. Cohort membership never substitutes for the send-time consent check.
+      </div>
+
+      {composing && (
+        <BroadcastComposer
+          initialCohortId={prefillCohort}
+          onClose={() => {
+            setComposing(false);
+            if (prefillCohort) setSearchParams({}, { replace: true });
+          }}
+          onSaved={(b) => {
+            queryClient.invalidateQueries({ queryKey: ['adminV2', 'emailBroadcasts'] });
+            if (b?.id) navigate(`/admin/broadcasts/${b.id}`);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/pages/adminv2/AdminV2CohortDetail.jsx
+++ b/src/pages/adminv2/AdminV2CohortDetail.jsx
@@ -89,6 +89,7 @@ export default function AdminV2CohortDetail() {
         meta={`${summarizeDefinition(c.definition, facets.data).toUpperCase()} · RESOLVED ${c.lastPreviewAt ? fmtRelative(c.lastPreviewAt) : 'NOW'}`}
       >
         <Link to="/AdminCohorts" className="av2-btn av2-btn--sm" style={{ textDecoration: 'none' }}>← All cohorts</Link>
+        <Link to={`/AdminBroadcasts?cohort=${id}`} className="av2-btn av2-btn--sm av2-btn--primary" style={{ textDecoration: 'none' }}>Push email</Link>
         <button type="button" className="av2-btn av2-btn--sm" onClick={() => setEditing(true)}>Edit definition</button>
         <button
           type="button"

--- a/src/pages/adminv2/__tests__/AdminV2BroadcastDetail.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2BroadcastDetail.test.jsx
@@ -1,0 +1,150 @@
+/**
+ * Email Push detail (tracker "emailpush") — status-driven actions (Send/Test
+ * on drafts, Cancel while active, Resume when interrupted), the send-confirm
+ * flow with the live reachable estimate + campaign-scope reminder, and the
+ * send log with reason chips. API layer mocked.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import AdminV2BroadcastDetail from '../AdminV2BroadcastDetail';
+
+const definition = {
+  filters: { campaignIds: ['c1'], drawIds: [], anyDraw: false, campaignTags: [], attributes: { postalPrefixes: [], incomes: [], educations: [], genders: [] } },
+  ageGate: { minAge: 18, maxAge: null },
+  marketingContext: { campaignId: null },
+};
+
+const draft = {
+  id: 'eb1',
+  cohortId: 'co1',
+  campaignId: 'c1',
+  subject: 'Tokyo push',
+  bodyText: 'Come join.',
+  ctaLabel: 'Enter',
+  ctaUrl: null,
+  ctaUrlPreview: 'https://redeem.sg/LeadCapture?campaign_id=c1&utm_source=mktr&utm_medium=email&utm_campaign=broadcast-eb1',
+  status: 'draft',
+  totalRecipients: 0,
+  sentCount: 0,
+  skippedCount: 0,
+  failedCount: 0,
+  lastError: null,
+  createdAt: new Date().toISOString(),
+  cohort: { id: 'co1', name: 'Tokyo entrants', definition },
+  campaign: { id: 'c1', name: 'Tokyo Getaway Lucky Draw', status: 'active', is_active: true },
+  liveCounts: { pending: 0, attempting: 0, sent: 0, skipped: 0, failed: 0 },
+};
+
+vi.mock('@/api/adminV2', () => ({
+  fetchEmailBroadcast: vi.fn(async () => null),
+  fetchEmailBroadcastRecipients: vi.fn(async () => ({ total: 0, limit: 50, offset: 0, recipients: [] })),
+  sendEmailBroadcast: vi.fn(async () => ({ data: { id: 'eb1', status: 'sending' } })),
+  cancelEmailBroadcast: vi.fn(async () => ({ data: { id: 'eb1', status: 'cancelling' } })),
+  deleteEmailBroadcast: vi.fn(async () => ({ data: { id: 'eb1', deleted: true } })),
+  testEmailBroadcast: vi.fn(async () => ({ data: { sentTo: 'admin@mktr.sg' } })),
+  previewCohortDefinition: vi.fn(async () => ({
+    total: 200, reachable: 150, excluded: 50,
+    byReason: {}, gate: { channel: 'email', campaignId: 'c1', minAge: 18, maxAge: null },
+  })),
+  fetchCohorts: vi.fn(async () => ({ rows: [], total: 0 })),
+  fetchCohortFacets: vi.fn(async () => ({ attributes: {}, campaignTags: [], campaigns: [], draws: [] })),
+  createEmailBroadcast: vi.fn(),
+  updateEmailBroadcast: vi.fn(),
+}));
+
+import {
+  fetchEmailBroadcast, fetchEmailBroadcastRecipients, sendEmailBroadcast,
+  cancelEmailBroadcast, previewCohortDefinition,
+} from '@/api/adminV2';
+
+function setup() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/admin/broadcasts/eb1']}>
+        <Routes>
+          <Route path="/admin/broadcasts/:id" element={<AdminV2BroadcastDetail />} />
+          <Route path="/AdminBroadcasts" element={<div>list page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('AdminV2BroadcastDetail', () => {
+  it('drafts offer Send / Test / Edit / Delete and show the CTA preview', async () => {
+    fetchEmailBroadcast.mockResolvedValue(draft);
+    setup();
+    expect(await screen.findByText('Tokyo push')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Send…' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Send test to my email' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeTruthy();
+    expect(screen.getByText(/utm_campaign=broadcast-eb1/)).toBeTruthy();
+    expect(fetchEmailBroadcastRecipients).not.toHaveBeenCalled();
+  });
+
+  it('send confirm shows the live estimate under the push campaign scope, then kicks the send', async () => {
+    fetchEmailBroadcast.mockResolvedValue(draft);
+    setup();
+    fireEvent.click(await screen.findByRole('button', { name: 'Send…' }));
+
+    await waitFor(() => expect(previewCohortDefinition).toHaveBeenCalled());
+    // The estimate re-aims the cohort definition at THIS campaign ('email' channel).
+    const [defArg, channelArg] = previewCohortDefinition.mock.calls[0];
+    expect(defArg.marketingContext.campaignId).toBe('c1');
+    expect(channelArg).toBe('email');
+
+    expect(await screen.findByText(/are reachable under this campaign/)).toBeTruthy();
+    expect(screen.getByText(/must be ABOUT/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send now' }));
+    await waitFor(() => expect(sendEmailBroadcast).toHaveBeenCalledWith('eb1', { resume: false }));
+  });
+
+  it('an active send shows live tiles and Cancel', async () => {
+    fetchEmailBroadcast.mockResolvedValue({
+      ...draft,
+      status: 'sending',
+      totalRecipients: 120,
+      liveCounts: { pending: 40, attempting: 1, sent: 70, skipped: 8, failed: 1 },
+    });
+    setup();
+    expect(await screen.findByRole('button', { name: 'Cancel send' })).toBeTruthy();
+    expect(screen.getByText('70')).toBeTruthy();
+    expect(screen.getByText('41')).toBeTruthy(); // remaining = pending + attempting
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel send' }));
+    await waitFor(() => expect(cancelEmailBroadcast).toHaveBeenCalledWith('eb1'));
+  });
+
+  it('interrupted sends offer Resume (pending rows only) and Cancel remaining', async () => {
+    fetchEmailBroadcast.mockResolvedValue({ ...draft, status: 'interrupted', totalRecipients: 120, lastError: 'worker lost (deploy/crash) — resume to continue' });
+    setup();
+    fireEvent.click(await screen.findByRole('button', { name: 'Resume' }));
+    await waitFor(() => expect(sendEmailBroadcast).toHaveBeenCalledWith('eb1', { resume: true }));
+    expect(screen.getByRole('button', { name: 'Cancel remaining' })).toBeTruthy();
+    expect(screen.getByText(/worker lost/)).toBeTruthy();
+  });
+
+  it('renders the send log with sender-side reason language', async () => {
+    fetchEmailBroadcast.mockResolvedValue({ ...draft, status: 'completed', totalRecipients: 3, sentCount: 1, skippedCount: 2, failedCount: 0, liveCounts: { pending: 0, attempting: 0, sent: 1, skipped: 2, failed: 0 } });
+    fetchEmailBroadcastRecipients.mockResolvedValue({
+      total: 3, limit: 50, offset: 0,
+      recipients: [
+        { id: 'r1', consumerId: 'x1', email: 'a@x.test', status: 'sent', reason: null, error: null, sentAt: new Date().toISOString() },
+        { id: 'r2', consumerId: 'x2', email: 'b@x.test', status: 'skipped', reason: 'address_suppressed', error: null, sentAt: null },
+        { id: 'r3', consumerId: 'x3', email: 'c@x.test', status: 'skipped', reason: 'not_consented', error: null, sentAt: null },
+      ],
+    });
+    setup();
+    expect(await screen.findByText('a@x.test')).toBeTruthy();
+    expect(screen.getByText('Address unsubscribed')).toBeTruthy(); // sender-side vocab
+    expect(screen.getByText('No consent')).toBeTruthy(); // cohort vocab reused
+    fireEvent.click(screen.getByRole('button', { name: 'skipped' }));
+    await waitFor(() => expect(fetchEmailBroadcastRecipients).toHaveBeenLastCalledWith('eb1', { status: 'skipped', limit: 50, offset: 0 }));
+  });
+});

--- a/src/pages/adminv2/__tests__/AdminV2Broadcasts.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2Broadcasts.test.jsx
@@ -1,0 +1,133 @@
+/**
+ * Email Pushes list + composer (tracker "emailpush") — rows, empty state,
+ * the composer create flow (active-campaign options only, cohort-scope
+ * campaign default), and the ?cohort= prefill that the cohort detail's
+ * "Push email" button deep-links to. API layer mocked.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import AdminV2Broadcasts from '../AdminV2Broadcasts';
+
+const broadcastRow = {
+  id: 'eb1',
+  cohortId: 'co1',
+  campaignId: 'c1',
+  subject: 'Tokyo draw closes this week',
+  bodyText: 'Reminder.',
+  ctaLabel: 'Enter now',
+  status: 'completed',
+  totalRecipients: 120,
+  sentCount: 100,
+  skippedCount: 18,
+  failedCount: 2,
+  createdAt: new Date().toISOString(),
+  cohort: { id: 'co1', name: 'Tokyo entrants' },
+  campaign: { id: 'c1', name: 'Tokyo Getaway Lucky Draw', status: 'active', is_active: true },
+};
+
+vi.mock('@/api/adminV2', () => ({
+  fetchEmailBroadcasts: vi.fn(async () => ({ rows: [], total: 0 })),
+  createEmailBroadcast: vi.fn(async () => ({ data: { id: 'eb-new' } })),
+  updateEmailBroadcast: vi.fn(async () => ({ data: { id: 'eb1' } })),
+  fetchCohorts: vi.fn(async () => ({
+    rows: [
+      {
+        id: 'co1',
+        name: 'Tokyo entrants',
+        lastReachableCount: 180,
+        definition: {
+          filters: { campaignIds: ['c1'], drawIds: [], anyDraw: false, campaignTags: [], attributes: { postalPrefixes: [], incomes: [], educations: [], genders: [] } },
+          ageGate: { minAge: 18, maxAge: null },
+          marketingContext: { campaignId: 'c1' },
+        },
+      },
+    ],
+    total: 1,
+  })),
+  fetchCohortFacets: vi.fn(async () => ({
+    attributes: { incomes: [], educations: [], genders: [] },
+    campaignTags: [],
+    campaigns: [
+      { id: 'c1', name: 'Tokyo Getaway Lucky Draw', status: 'active' },
+      { id: 'c2', name: 'Old Thing', status: 'archived' },
+    ],
+    draws: [],
+  })),
+}));
+
+import { fetchEmailBroadcasts, createEmailBroadcast } from '@/api/adminV2';
+
+function LocationProbe() {
+  const loc = useLocation();
+  return <div data-testid="loc">{loc.pathname}</div>;
+}
+
+function setup(initialEntry = '/AdminBroadcasts') {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/AdminBroadcasts" element={<><AdminV2Broadcasts /><LocationProbe /></>} />
+          <Route path="/admin/broadcasts/:id" element={<LocationProbe />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('AdminV2Broadcasts', () => {
+  it('renders the empty state with a compose action', async () => {
+    setup();
+    expect(await screen.findByText('No email pushes yet')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Compose the first one' })).toBeTruthy();
+  });
+
+  it('renders rows with cohort, campaign, status and counts', async () => {
+    fetchEmailBroadcasts.mockResolvedValueOnce({ rows: [broadcastRow], total: 1 });
+    setup();
+    expect(await screen.findByText('Tokyo draw closes this week')).toBeTruthy();
+    expect(screen.getByText('Tokyo entrants')).toBeTruthy();
+    expect(screen.getByText('Tokyo Getaway Lucky Draw')).toBeTruthy();
+    expect(screen.getByText('Completed')).toBeTruthy();
+    expect(screen.getByText('100')).toBeTruthy();
+  });
+
+  it('creates a draft: active campaigns only, campaign defaulted from the cohort scope', async () => {
+    setup();
+    fireEvent.click(await screen.findByRole('button', { name: '+ New push' }));
+
+    const cohortSelect = await screen.findByLabelText('Cohort');
+    fireEvent.change(cohortSelect, { target: { value: 'co1' } });
+
+    // Campaign defaults from the cohort's stored gate scope…
+    const campaignSelect = screen.getByLabelText('Campaign');
+    await waitFor(() => expect(campaignSelect.value).toBe('c1'));
+    // …and archived campaigns are not offered at all.
+    expect(screen.queryByText('Old Thing')).toBeNull();
+
+    fireEvent.change(screen.getByPlaceholderText(/Your Tokyo draw closes/i), { target: { value: 'My subject' } });
+    fireEvent.change(screen.getByPlaceholderText(/quick reminder/i), { target: { value: 'Body copy here.' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create draft' }));
+
+    await waitFor(() => expect(createEmailBroadcast).toHaveBeenCalledWith({
+      cohortId: 'co1',
+      campaignId: 'c1',
+      subject: 'My subject',
+      bodyText: 'Body copy here.',
+      ctaLabel: 'Learn more',
+    }));
+    // Created → navigates to the new draft's detail screen.
+    await waitFor(() => expect(screen.getByTestId('loc').textContent).toBe('/admin/broadcasts/eb-new'));
+  });
+
+  it('?cohort= deep link (the cohort "Push email" button) opens the composer preselected', async () => {
+    setup('/AdminBroadcasts?cohort=co1');
+    const cohortSelect = await screen.findByLabelText('Cohort');
+    await waitFor(() => expect(cohortSelect.value).toBe('co1'));
+  });
+});

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -74,6 +74,8 @@ const AdminV2Dashboard = lazy(() => import('./adminv2/AdminV2Dashboard'));
 const AdminV2Prospects = lazy(() => import('./adminv2/AdminV2Prospects'));
 const AdminV2Cohorts = lazy(() => import('./adminv2/AdminV2Cohorts'));
 const AdminV2CohortDetail = lazy(() => import('./adminv2/AdminV2CohortDetail'));
+const AdminV2Broadcasts = lazy(() => import('./adminv2/AdminV2Broadcasts'));
+const AdminV2BroadcastDetail = lazy(() => import('./adminv2/AdminV2BroadcastDetail'));
 const AdminV2Campaigns = lazy(() => import('./adminv2/AdminV2Campaigns'));
 const AdminV2CampaignDetail = lazy(() => import('./adminv2/AdminV2CampaignDetail'));
 const AdminV2Agents = lazy(() => import('./adminv2/AdminV2Agents'));
@@ -365,6 +367,28 @@ function PagesContent() {
  <ProtectedRoute requiredRole="admin">
  <AdminV2Shell>
  <AdminV2CohortDetail />
+ </AdminV2Shell>
+ </ProtectedRoute>
+ }
+ />
+ )}
+ {ADMIN_V2 && (
+ <Route
+ path="/AdminBroadcasts" element={
+ <ProtectedRoute requiredRole="admin">
+ <AdminV2Shell>
+ <AdminV2Broadcasts />
+ </AdminV2Shell>
+ </ProtectedRoute>
+ }
+ />
+ )}
+ {ADMIN_V2 && (
+ <Route
+ path="/admin/broadcasts/:id" element={
+ <ProtectedRoute requiredRole="admin">
+ <AdminV2Shell>
+ <AdminV2BroadcastDetail />
  </AdminV2Shell>
  </ProtectedRoute>
  }


### PR DESCRIPTION
## What

The "emailpush" tracker item: a minimal-viable email broadcast pipeline. An admin composes subject/body/CTA about ONE active campaign, picks a saved cohort (#222/#223), tests to their own inbox, and sends — throttled, logged, and consent-gated per recipient at send time.

## Consent + safety rails (the point of the design)

- **§5 sender obligation discharged**: every recipient is re-gated at the moment of their send via `canMarketToBatch([id], {channel:'email', campaignId})` — scoped to the campaign the mail is actually about. Cohort membership never substitutes. (Email is outside SG DNC scope; the §9.5-2 DNC scrub binds the future voice/SMS/WhatsApp senders.)
- **PR-B unsubscribe rails on every message**: footer + `List-Unsubscribe` + `List-Unsubscribe-Post: One-Click`, and the minted token is **verified** (`findConsumerByUnsubToken`) before send — a dead unsubscribe link means the mail is not sent.
- **At-most-once per recipient**: unique `(broadcastId, consumerId)` claim + `pending→attempting` CAS lands durably before SMTP; crash-ambiguous rows become `ambiguous_crash` and are never retried.
- **One copy per inbox**: normalized-address dedupe within the push + cross-consumer `address_suppressed` check (consumers are phone-keyed; the person who unsubscribed via another signup still wins).
- **CAS state machine** `draft→preparing→sending→completed` (+ `cancelling/cancelled`, `interrupted`, `failed`) with heartbeat lease, a global one-in-flight fence, cancel that bites within one iteration, resume that only continues `pending` rows, and boot + 5-min stale sweeps (nothing auto-sends on deploy).
- **Send context frozen at `preparing`** (definition re-aimed at the push campaign, host/brand/CTA) — cohort edits or config drift can't change an in-flight send. CTA = campaign public URL + `utm_source=mktr&utm_medium=email&utm_campaign=broadcast-<id8>`.
- **Erasure matrix**: recipient rows null `email`+`error` on erase (repair pass included), delivery facts kept.
- **Test sends** go to the requesting admin only — no address parameter.

## Plan → Codex → implement

`docs/plans/email-broadcast-push.md` — v2 after a 25-finding Codex xhigh round (5 BLOCKER / 17 MAJOR dispositioned in §10; single-instance-accepted limits in §9). A second Codex xhigh pass ran on this diff before merge.

## Surface

Backend: migration 085 (guarded, sync-tolerant, CHECKs), 2 models, service + template + controller + routes (`/api/email-broadcasts`, admin-only, host-guard blocklisted), erasure step 16b, bootstrap sweeps.
Frontend (admin v2): Email Pushes list + composer (active campaigns only, cohort-scope default, `?cohort=` deep link), detail console (live counts, confirm-with-estimate + scope reminder, cancel/resume, paged send log with reason chips), cohort-detail **Push email** button.

## Tests

- Backend 31 (real Postgres, REAL cohort/consent gate; transport/sleep injected): full pipeline, post-claim suppression/destination drift, dupe-address, cross-consumer suppression, token verify, `{success:false}` mailer, throw-continues, ambiguous-crash resume, never-re-resolve resume, cancel mid-loop, one-in-flight, stale sweep, erasure scrub, full route surface.
- Frontend 9 vitest; full suite **1647 green**; `vite build` clean.

## Env (defaults safe, no Render change needed)

`EMAIL_BROADCAST_RATE_PER_SEC` (default 2, clamp 0.2–10) · `EMAIL_BROADCAST_MAX_RECIPIENTS` (default 5000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDco6HwKLHpmRgE5YR8Za2