### PR TITLE
fix(sms): key the OTP limiter on the real visitor, not the Cloudflare edge

### DIFF
--- a/backend/src/middleware/pgRateLimitStore.js
+++ b/backend/src/middleware/pgRateLimitStore.js
@@ -72,8 +72,8 @@ export class PostgresRateLimitStore {
  * address would let one client mint unlimited windows. Handles `::` compression
  * and zone ids, which a naive split(':') gets wrong.
  */
-function ipv6Prefix64(addr) {
-  const bare = addr.split('%')[0];
+function expandIpv6(addr) {
+  const bare = String(addr).split('%')[0];
   let groups;
   if (bare.includes('::')) {
     const [head, tail] = bare.split('::');
@@ -83,16 +83,118 @@ function ipv6Prefix64(addr) {
   } else {
     groups = bare.split(':');
   }
-  return groups.slice(0, 4).map((g) => (g || '0').toLowerCase().padStart(4, '0')).join(':');
+  if (groups.length !== 8) return null;
+  return groups.map((g) => (g || '0').toLowerCase().padStart(4, '0'));
+}
+
+function ipv6Prefix64(addr) {
+  const groups = expandIpv6(addr);
+  return groups ? groups.slice(0, 4).join(':') : String(addr);
 }
 
 /**
- * Client key for the limiter. express-rate-limit's default keyGenerator uses the
- * raw req.ip, which treats every address in an IPv6 /64 as a separate client.
+ * Cloudflare's published edge ranges — https://www.cloudflare.com/ips/
+ *
+ * These change rarely (a few times a decade). If Cloudflare adds a range and this
+ * list goes stale, the only consequence is that traffic via the new edge falls
+ * back to keying on the edge address — the same coarse-but-safe behaviour we had
+ * before. It never fails open.
  */
-export function clientKey(req) {
-  const ip = req.ip || req.socket?.remoteAddress || 'unknown';
+const CF_IPV4 = [
+  '173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22',
+  '141.101.64.0/18', '108.162.192.0/18', '190.93.240.0/20', '188.114.96.0/20',
+  '197.234.240.0/22', '198.41.128.0/17', '162.158.0.0/15', '104.16.0.0/13',
+  '104.24.0.0/14', '172.64.0.0/13', '131.0.72.0/22',
+];
+const CF_IPV6 = [
+  '2400:cb00::/32', '2606:4700::/32', '2803:f800::/32', '2405:b500::/32',
+  '2405:8100::/32', '2a06:98c0::/29', '2c0f:f248::/32',
+];
+
+function ipv4ToInt(ip) {
+  const parts = String(ip).split('.');
+  if (parts.length !== 4) return null;
+  let n = 0;
+  for (const p of parts) {
+    const v = Number(p);
+    if (!Number.isInteger(v) || v < 0 || v > 255) return null;
+    n = n * 256 + v;
+  }
+  return n;
+}
+
+function inIpv4Cidr(ip, cidr) {
+  const [net, bitsRaw] = cidr.split('/');
+  const bits = Number(bitsRaw);
+  const a = ipv4ToInt(ip);
+  const b = ipv4ToInt(net);
+  if (a === null || b === null) return false;
+  if (bits === 0) return true;
+  const size = 2 ** (32 - bits);
+  return Math.floor(a / size) === Math.floor(b / size);
+}
+
+function ipv6ToBigInt(addr) {
+  const groups = expandIpv6(addr);
+  if (!groups) return null;
+  let n = 0n;
+  for (const g of groups) {
+    const v = Number.parseInt(g, 16);
+    if (!Number.isInteger(v) || v < 0 || v > 0xffff) return null;
+    n = (n << 16n) + BigInt(v);
+  }
+  return n;
+}
+
+function inIpv6Cidr(ip, cidr) {
+  const [net, bitsRaw] = cidr.split('/');
+  const bits = BigInt(Number(bitsRaw));
+  const a = ipv6ToBigInt(ip);
+  const b = ipv6ToBigInt(net);
+  if (a === null || b === null) return false;
+  const shift = 128n - bits;
+  return (a >> shift) === (b >> shift);
+}
+
+/** Did this request genuinely arrive from a Cloudflare edge? */
+function isCloudflareIp(ip) {
+  if (!ip) return false;
+  const bare = ip.startsWith('::ffff:') ? ip.slice(7) : String(ip).split('%')[0];
+  return bare.includes(':')
+    ? CF_IPV6.some((c) => inIpv6Cidr(bare, c))
+    : CF_IPV4.some((c) => inIpv4Cidr(bare, c));
+}
+
+/** Collapse an address to its rate-limiting identity. */
+function normalizeIp(ip) {
+  if (!ip) return 'unknown';
   if (ip.startsWith('::ffff:')) return ip.slice(7); // IPv4-mapped IPv6
   if (ip.includes(':')) return ipv6Prefix64(ip);
   return ip;
+}
+
+/**
+ * Client key for the limiter.
+ *
+ * api.mktr.sg sits behind Cloudflare, and `trust proxy` is 1, so `req.ip` resolves
+ * to the Cloudflare EDGE address, not the visitor. Keying on that bucketed many
+ * real users together while letting one attacker spread across edges — confirmed
+ * in production, where every limiter row was keyed `162.158.x.x`.
+ *
+ * So prefer CF-Connecting-IP, but ONLY when the request actually came from a
+ * Cloudflare range. The Render origin is publicly reachable, so an unvalidated
+ * header read would be strictly worse than the bug it fixes: anyone could send a
+ * random CF-Connecting-IP per request and mint unlimited buckets. Validating the
+ * edge means a spoofer bypassing Cloudflare is keyed on their real socket address.
+ *
+ * Note this limiter is defence-in-depth regardless — the control that actually
+ * protects the sender ID is the per-number daily cap in services/smsQuota.js.
+ */
+export function clientKey(req) {
+  const edge = req.ip || req.socket?.remoteAddress || '';
+  const forwarded = req.headers?.['cf-connecting-ip'];
+  const trusted = forwarded && isCloudflareIp(edge)
+    ? String(forwarded).split(',')[0].trim()
+    : edge;
+  return normalizeIp(trusted);
 }

--- a/backend/src/services/verificationService.js
+++ b/backend/src/services/verificationService.js
@@ -55,6 +55,19 @@ const WA_TEMPLATE_LANG = process.env.META_WA_TEMPLATE_LANG || 'en_US';
 // Helper to generate 6-digit code using cryptographically secure randomness
 const generateCode = () => crypto.randomInt(100000, 1000000).toString();
 
+/**
+ * Mask a phone number for logging: `+6591234567` → `+65****4567`.
+ *
+ * Application logs are outside the consent ledger and the PDPA erasure matrix —
+ * an erasure request rebuilds the database, not Render's log stream. Keeping raw
+ * numbers out of them means there is nothing there to erase. Mirrors the same
+ * helper in lyfe-app's custom-sms-hook.
+ */
+const maskPhone = (phone) => {
+  const s = String(phone || '');
+  return s.length < 7 ? '***' : `${s.slice(0, 3)}****${s.slice(-4)}`;
+};
+
 // Helper to send WhatsApp via Meta Graph API
 const sendWhatsAppOtpMeta = async (phone, code) => {
   const phoneId = process.env.META_WA_PHONE_NUMBER_ID;
@@ -197,7 +210,11 @@ export async function sendVerificationCode({ phone, countryCode = '+65', campaig
     }
   }
 
-  logger.info('Sending OTP', { channel: channel.toUpperCase() });
+  // pino's signature is (mergingObject, message) — passing the object SECOND
+  // silently drops it, which is why these lines logged a bare "Sending OTP" with
+  // no channel and made a live SMS incident harder to diagnose than it should
+  // have been. Same fix applied to every call below.
+  logger.info({ channel: channel.toUpperCase() }, 'Sending OTP');
 
   try {
     // 1. Save to DB (upsert) - Expires in 10 minutes
@@ -219,18 +236,19 @@ export async function sendVerificationCode({ phone, countryCode = '+65', campaig
       try {
         const waResponse = await sendWhatsAppOtpMeta(fullPhone, code);
         messageId = waResponse.messages?.[0]?.id;
-        logger.info('WhatsApp sent', { phone: fullPhone, messageId });
+        logger.info({ phone: maskPhone(fullPhone), messageId }, 'WhatsApp sent');
       } catch (waErr) {
-        logger.error('WhatsApp OTP failed — falling back to SMS', {
-          error: waErr?.message || String(waErr)
-        });
+        logger.error(
+          { error: waErr?.message || String(waErr) },
+          'WhatsApp OTP failed — falling back to SMS',
+        );
         sentChannel = 'sms';
         messageId = await sendSmsOtp(fullPhone, code);
-        logger.info('SMS sent (WhatsApp fallback)', { phone: fullPhone, messageId });
+        logger.info({ phone: maskPhone(fullPhone), messageId }, 'SMS sent (WhatsApp fallback)');
       }
     } else {
       messageId = await sendSmsOtp(fullPhone, code);
-      logger.info('SMS sent', { phone: fullPhone, messageId });
+      logger.info({ phone: maskPhone(fullPhone), messageId }, 'SMS sent');
     }
 
     return { status: 'pending', messageId, channel: sentChannel };
@@ -241,7 +259,7 @@ export async function sendVerificationCode({ phone, countryCode = '+65', campaig
     // Preserve deliberate status codes (the 429 from the global ceiling gate);
     // only genuine faults get flattened into a 500.
     if (err instanceof AppError) throw err;
-    logger.error('Failed to send OTP', { channel, error: err?.message || String(err) });
+    logger.error({ channel, error: err?.message || String(err) }, 'Failed to send OTP');
     throw new AppError(`Failed to send code: ${err.message}`, 500);
   }
 }

--- a/backend/test/unit/pgRateLimitStore.test.js
+++ b/backend/test/unit/pgRateLimitStore.test.js
@@ -95,4 +95,50 @@ describe('clientKey', () => {
   it('falls back when no address is available', () => {
     expect(clientKey({})).toBe('unknown');
   });
+
+  // ── Cloudflare edge handling ──
+  // api.mktr.sg is Cloudflare-fronted, so req.ip is the EDGE address. Keying on
+  // it bucketed unrelated visitors together and let one attacker spread across
+  // edges. Observed in production: every limiter row was keyed 162.158.x.x.
+
+  const cfReq = (edgeIp, cfHeader) => ({ ip: edgeIp, headers: { 'cf-connecting-ip': cfHeader } });
+
+  it('uses the real visitor IP when the request came from a Cloudflare edge', () => {
+    // Exactly the production case: edge 162.158.26.189 (in 162.158.0.0/15).
+    expect(clientKey(cfReq('162.158.26.189', '115.164.36.13'))).toBe('115.164.36.13');
+  });
+
+  it('IGNORES a spoofed CF-Connecting-IP when the request bypassed Cloudflare', () => {
+    // Hitting the Render origin directly. Trusting the header here would let an
+    // attacker mint a fresh bucket per request — worse than the bug being fixed.
+    expect(clientKey(cfReq('203.0.113.9', '1.2.3.4'))).toBe('203.0.113.9');
+  });
+
+  it('separates two visitors arriving through the same Cloudflare edge', () => {
+    const a = clientKey(cfReq('162.158.26.189', '115.164.36.13'));
+    const b = clientKey(cfReq('162.158.26.189', '203.0.113.50'));
+    expect(a).not.toBe(b); // previously these collided into one bucket
+  });
+
+  it('takes only the first hop if the header carries a list', () => {
+    expect(clientKey(cfReq('104.16.0.1', '115.164.36.13, 10.0.0.1'))).toBe('115.164.36.13');
+  });
+
+  it('recognises Cloudflare IPv6 edges too', () => {
+    expect(clientKey(cfReq('2606:4700::1111', '115.164.36.13'))).toBe('115.164.36.13');
+  });
+
+  it('normalises a visitor IPv6 address behind Cloudflare to its /64', () => {
+    expect(clientKey(cfReq('162.158.26.189', '2001:db8:85a3:8d3::9')))
+      .toBe('2001:0db8:85a3:08d3');
+  });
+
+  it('falls back to the edge address when no CF header is present', () => {
+    expect(clientKey({ ip: '162.158.26.189', headers: {} })).toBe('162.158.26.189');
+  });
+
+  it('does not treat a near-miss range as Cloudflare', () => {
+    // 162.160.x is outside 162.158.0.0/15 — must not be trusted.
+    expect(clientKey(cfReq('162.160.0.1', '1.2.3.4'))).toBe('162.160.0.1');
+  });
 });

--- a/backend/test/unit/verificationService.test.js
+++ b/backend/test/unit/verificationService.test.js
@@ -107,7 +107,7 @@ describe('verificationService (unit)', () => {
       const result = await sendVerificationCode({ phone: '91234567', countryCode: '+65', campaignId: 'camp-1' });
 
       expect(result.status).toBe('pending');
-      expect(logger.info).toHaveBeenCalledWith('Sending OTP', { channel: 'WHATSAPP' });
+      expect(logger.info).toHaveBeenCalledWith({ channel: 'WHATSAPP' }, 'Sending OTP');
     });
 
     it('falls back to SMS when the WhatsApp send fails', async () => {
@@ -128,7 +128,7 @@ describe('verificationService (unit)', () => {
       const result = await sendVerificationCode({ phone: '91234567' });
 
       expect(result.status).toBe('pending');
-      expect(logger.info).toHaveBeenCalledWith('Sending OTP', { channel: 'SMS' });
+      expect(logger.info).toHaveBeenCalledWith({ channel: 'SMS' }, 'Sending OTP');
     });
 
     it('stores code with 10 minute expiry', async () => {
@@ -260,6 +260,6 @@ describe('design_config v2 (Campaign Studio)', () => {
     const result = await sendVerificationCode({ phone: '91234567', countryCode: '+65', campaignId: 'camp-v2' });
 
     expect(result.status).toBe('pending');
-    expect(logger.info).toHaveBeenCalledWith('Sending OTP', { channel: 'WHATSAPP' });
+    expect(logger.info).toHaveBeenCalledWith({ channel: 'WHATSAPP' }, 'Sending OTP');
   });
 });

--- a/docs/reference/sms-sender-id-compliance.md
+++ b/docs/reference/sms-sender-id-compliance.md
@@ -3,24 +3,29 @@
 Our posture against the SGNIC advisory of **21 Jul 2026** ("Advisory to secure your
 SMS account(s) and Sender ID(s)") and SSIR User Agreement **cl. 2.3.2**.
 
+Verified end-to-end against the live AWS account on **2026-07-22**. Where this
+document previously guessed, it now states what was measured.
+
 ---
 
 ## 1. What we actually send
 
 | | |
 |---|---|
-| Registered Sender ID | **`MKTR`** — Live, case-sensitive, registered in `ap-southeast-1` |
-| Transport | **AWS SNS** (`@aws-sdk/client-sns`). We do **not** hold a direct account with a Singapore Participating Aggregator — the "SMS account" the advisory refers to is our **AWS account**, and the "API keys" are **AWS IAM access keys**. |
+| Registered Sender ID | **`MKTR`** (`SG`, Transactional + Promotional) |
+| Registration | `arn:aws:sms-voice:ap-southeast-1:872926860708:sender-id/MKTR/SG` — **registered through AWS** as an `SG_SENDER_ID_REGISTRATION`, status `COMPLETE`. See §4. |
+| Transport | **AWS SNS** (`@aws-sdk/client-sns`), `ap-southeast-1`. We hold no direct account with a Singapore Participating Aggregator — the "SMS account" the advisory refers to is our **AWS account**, and the "API keys" are **AWS IAM access keys**. |
 | Message type | `Transactional` only. One template: `Your verification code is: NNNNNN` |
 | Geography | +65 only, enforced server-side |
+| Measured price | **$0.03918 per message** (TPG Telecom, MCC 525) |
 
-Three code paths publish under this sender ID:
+Code paths that publish under this sender ID:
 
 | Path | File | Notes |
 |---|---|---|
-| Lead-capture OTP | `backend/src/services/verificationService.js` | Public, unauthenticated, highest volume |
-| Supabase Auth phone OTP | `lyfe-app/supabase/functions/custom-sms-hook/index.ts` | Already uses a scoped `lyfe-sns-sms` IAM user; gated by an invitation allowlist |
-| SA61 weekly reminder | `backend/scripts/sa61-weekly-reminder.js` | Utility script. Defaults to `us-east-1`, where the SID is **not** registered — messages sent from it can be relabelled "Likely-SCAM" |
+| Lead-capture OTP | `backend/src/services/verificationService.js` | Public, unauthenticated, highest volume. Uses `mktr-sns-sms`. |
+| Supabase Auth phone OTP | `lyfe-app/supabase/functions/custom-sms-hook/index.ts` | Separate scoped `lyfe-sns-sms` IAM user; gated by an invitation allowlist |
+| SA61 weekly reminder | `backend/scripts/sa61-weekly-reminder.js` | **Cron is suspended.** Also defaults to `us-east-1`, where the SID is not registered — fix the region before ever re-enabling it |
 
 ---
 
@@ -37,141 +42,160 @@ is uptime, not just paperwork.
 |---|---|---|
 | **Per-number daily cap — 7/day** | `services/smsQuota.js` | Keyed on the *number* (IPs rotate for free; the victim's number cannot). Counts SMS **and** WhatsApp. Fails closed. Returns `429`. |
 | **Global daily ceiling — 500/day** | `services/smsQuota.js` | Hard stop; refuses to publish past it. Counts only real SNS publishes, including the WhatsApp→SMS fallback. |
-| **Spike alert — 250/day** | `services/smsQuota.js` | Error log + Sentry + email to `SMS_ALERT_EMAIL`. Fires at most once per kind per day (atomic claim, so parallel instances can't double-send). |
-| **Durable rate limiting** | `middleware/pgRateLimitStore.js` | Replaces MemoryStore, which counted per-process and reset on every redeploy. IPv6 collapsed to /64. Fails **open** on DB error — the quota layer above is what fails closed. |
-| **Least-privilege creds** | `services/verificationService.js` | Prefers `SNS_AWS_*` over the shared `AWS_*` pair (which also carries SES). All-or-nothing pairing. |
+| **Spike alert — 250/day** | `services/smsQuota.js` | Error log + email to `SMS_ALERT_EMAIL`. At most once per kind per day (atomic claim, so parallel instances can't double-send). |
+| **Durable rate limiting** | `middleware/pgRateLimitStore.js` | Replaces MemoryStore, which counted per-process and reset on every redeploy. Fails **open** on DB error — the quota layer above is what fails closed. |
+| **Real-visitor keying** | `middleware/pgRateLimitStore.js` | `api.mktr.sg` is Cloudflare-fronted, so `req.ip` is the *edge* address. We use `CF-Connecting-IP`, but only when the request genuinely arrived from a published Cloudflare range — otherwise a direct-to-origin caller could spoof the header and mint unlimited buckets. |
+| **Least-privilege creds** | `services/verificationService.js` | Prefers the SNS-only `SNS_AWS_*` pair, all-or-nothing, falling back to `AWS_*`. |
 | **No PII in counters** | `services/rateCounter.js` | Phone numbers are HMAC-blinded before becoming counter keys, so PDPA erasure has nothing to rebuild. |
+| **No PII in logs** | `services/verificationService.js` | Numbers are masked (`+65****4567`). Render logs sit outside the erasure matrix. |
 
-Counters live in `rate_counters` (migration `083`), are atomic (`INSERT … ON
-CONFLICT … RETURNING`, verified against live Postgres under 25-way concurrency),
-self-heal on window expiry, and are swept daily from `bootstrap.js`.
+Counters live in `rate_counters` (migration `083`), are atomic
+(`INSERT … ON CONFLICT … RETURNING`, verified under 25-way concurrency), self-heal
+on window expiry, and are swept daily from `bootstrap.js`.
 
 **Sizing rationale:** 60-day traffic to 2026-07-21 — busiest day ever **16 leads**,
 mean **5.7** per active day. OTP sends run ~2–3× leads once drop-off and resends are
-counted, so the worst real day was ≈50 SMS. 500 leaves ~10× headroom; 250 alerts at
-~5× peak. Both env-tunable — **raise them deliberately before a big launch rather
-than letting an alert be ignored.**
+counted, so the worst real day was ≈50 SMS. Both caps are env-tunable — **raise them
+deliberately before a big launch rather than letting an alert be ignored.** But see
+the spend ceiling in §3d first: AWS, not this cap, is the binding constraint.
 
 ---
 
-## 3. Manual steps (AWS console — cannot be done from code)
+## 3. AWS-side posture
 
-### a. MFA audit — advisory §3, bullet 4
-IAM → Users. Confirm MFA on the root account and every human user. Root without
-MFA is the single worst finding an auditor could make here.
+### a. Root MFA ✅
+`AccountMFAEnabled = 1`. There are no human IAM users — every IAM user is a service
+account with console access disabled — so **root is the "admin account"** the
+advisory's §3 bullet 4 refers to, and it is protected.
 
-### b. Create an SNS-only IAM user — advisory §3, bullets 2 & 3
-Today the backend's `AWS_ACCESS_KEY_ID` is **shared between SNS and SES**. Split it:
+### b. Credential separation ✅ (done 2026-07-22)
+Previously `AWS_ACCESS_KEY_ID` on the backend belonged to
+**`ses-smtp-user.20251229-003043`**, which carried *both*:
 
-1. IAM → Users → Create user, e.g. `mktr-sns-sms`.
-2. Attach an inline policy:
+- `AmazonSesSendingAccess` — inline, via group `AWSSESSendingGroupDoNotRename`
+- `AmazonSNSFullAccess` — **attached directly**, i.e. `sns:*`, not `sns:Publish`
 
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "PublishSmsOnly",
-      "Effect": "Allow",
-      "Action": "sns:Publish",
-      "Resource": "*",
-      "Condition": {
-        "IpAddress": {
-          "aws:SourceIp": ["REPLACE_WITH_RENDER_OUTBOUND_IP_1/32",
-                           "REPLACE_WITH_RENDER_OUTBOUND_IP_2/32"]
-        }
-      }
-    }
-  ]
-}
+So one credential could send all our email *and* do anything in SNS. Now:
+
+| User | Policy | Used for |
+|---|---|---|
+| `mktr-sns-sms` | `MktrSnsSmsPublish` — `sns:Publish` only | OTP SMS (`SNS_AWS_*`) |
+| `ses-smtp-user.20251229-003043` | `AmazonSesSendingAccess` via group only | Email (SMTP) |
+
+`AmazonSNSFullAccess` has been detached, and that user's never-used 129-day-old
+second key deleted. `sns:Publish` is provably sufficient — `PublishCommand` is the
+only SNS call anywhere in the backend.
+
+> **IP whitelisting (advisory §3 bullet 5) is not yet applied.** The policy can be
+> conditioned on `aws:SourceIp` using Render's outbound IPs
+> (Render → `mktr-backend-jo6r` → Settings → Outbound IPs). Deferred because it
+> breaks local development against real SNS.
+
+### c. Delivery status logging ✅
+Enabled in `ap-southeast-1` at 100% success sampling, writing to
+`sns/ap-southeast-1/872926860708/DirectPublishToPhoneNumber` with **30-day
+retention**. Retention matters: these records contain **full destination phone
+numbers** and sit outside the consent ledger and PDPA erasure matrix.
+
+First captured record:
+
+```
+status           : SUCCESS
+providerResponse : Message has been accepted by phone carrier
+dwellTimeMs      : 36
+priceInUSD       : 0.03918
+phoneCarrier     : TPG Telecom  (MCC 525 / MNC 10)
+smsType          : Transactional
 ```
 
-`Resource: "*"` is required — direct-to-phone publishing has no topic ARN to scope
-to. The `IpAddress` condition is advisory §3 bullet 5 (IP whitelisting); get the
-addresses from **Render → mktr-backend-jo6r → Settings → Outbound IPs**. Omit the
-whole `Condition` block if you want to defer this — the policy is still a large
-improvement without it, but note that a leaked key is then usable from anywhere.
+**AWS hands off in 36 ms and Singapore carriers accept `MKTR` cleanly.** Any
+user-perceived OTP delay is downstream of the carrier — typically the roaming leg
+when the handset is abroad. Do not chase it in our code.
 
-> The IP condition will also block local development against real SNS. Use the
-> WhatsApp channel or a stub locally.
+### d. Spend ceiling ⚠️ the real constraint
+```
+TEXT_MESSAGE_MONTHLY_SPEND_LIMIT   EnforcedLimit: 50   MaxLimit: 50
+```
+`MaxLimit: 50` is the **account maximum** — it cannot be raised in the console and
+requires an **AWS support ticket**. At $0.03918/message that is a hard ceiling of
+**~1,276 SMS/month (~42/day sustained)**.
 
-3. Create an access key for the new user and set on `mktr-backend-jo6r`:
-   - `SNS_AWS_ACCESS_KEY_ID`
-   - `SNS_AWS_SECRET_ACCESS_KEY`
+Sustained at our historical peak (~50/day) that is ~$59/month — **over the cap**,
+so SMS would stop mid-month and take lead capture with it. Our app-level 500/day
+(≈$588/month) would never be reached first.
 
-   Set **both or neither** — a half-set pair is deliberately ignored (mixing a new
-   key id with an old secret would fail every publish).
+**Request headroom before a campaign, not during one.**
 
-4. Deploy, send one real OTP to confirm delivery, **then** remove `sns:Publish`
-   from whatever policy the shared `AWS_*` user carries.
+### e. Spend alarms ✅
+Two CloudWatch alarms on `AWS/SNS → SMSMonthToDateSpentUSD`, notifying SNS topic
+`mktr-sms-spend-alerts`:
 
-### c. Rotate and prune keys — advisory §3, bullets 1 & 3
-IAM → Users → Security credentials. Delete keys that are inactive or unused
-(check "Last used"). Note the age of each surviving key and set a rotation
-reminder — the advisory asks for *regular* rotation, and "never rotated" is the
-finding to avoid.
+| Alarm | Threshold |
+|---|---|
+| `MKTR-SMS-spend-warning-25USD` | $25 — halfway to the ceiling |
+| `MKTR-SMS-spend-critical-45USD` | $45 — imminent outage |
 
-### d. Cap SMS spend — advisory §3, bullet 6
-AWS End User Messaging (or SNS console) → Text messaging preferences → set the
-**account monthly SMS spend limit**. This is the backstop *below* our application
-cap: even a total application bypass cannot exceed it. Lowering is self-service;
-raising above the account limit needs a support ticket.
-
-### e. Alarm on spend — advisory §3, bullet 6
-CloudWatch → Alarms → create on namespace `AWS/SNS`, metric
-`SMSMonthToDateSpentUSD`, threshold at roughly half the spend limit → SNS email
-topic. This is the AWS-side twin of our in-app 250/day alert; it still fires if the
-application is bypassed entirely.
-
-### f. Set the alert address
-On `mktr-backend-jo6r`, set `SMS_ALERT_EMAIL` — without it, spike and ceiling
-alerts are log/Sentry only and nobody gets paged.
-
-### g. Fix the SA61 script region
-`backend/scripts/sa61-weekly-reminder.js` defaults to `us-east-1`, where `MKTR` is
-not registered. Either set `AWS_REGION=ap-southeast-1` wherever it runs, or retire
-the script.
+### f. Key rotation ⚠️ outstanding
+Several keys are 92–138 days old (AWS flags ≥90 days). Rotate them and set a
+recurring reminder — "never rotated" is exactly what advisory §3 bullet 1 targets.
 
 ---
 
-## 4. Open question — the Letter of Authorisation (advisory §4)
+## 4. The Letter of Authorisation question — resolved
 
 Advisory §4 requires an LOA when a **third-party provider sends SMS bearing your
 registered SID on your behalf**, lodged with the Participating Aggregator and
 copied to `smsregistry@sgnic.sg`.
 
-We send via AWS rather than holding a PA account directly, so whether AWS counts as
-that third party depends on **how `MKTR` was registered**:
+`describe-sender-ids` shows `MKTR` held as an **AWS-managed
+`SG_SENDER_ID_REGISTRATION`, status `COMPLETE`**, inside our own account. AWS
+submitted the SSIR registration on our behalf and owns the aggregator relationship
+behind it.
 
-- If **we** registered it with SGNIC directly and merely send through AWS → §4
-  arguably bites and an LOA should be filed.
-- If **AWS** submitted the registration on our behalf through its own aggregator →
-  likely already covered.
+That is not the arrangement §4 targets. The clause addresses registering a SID
+directly with SGNIC and then handing it to a third party who sends through a
+*different* PA account. Here **AWS is the registered route**, not a third party
+bolted onto a separately-registered SID. An LOA is very likely unnecessary.
 
-**Action: email `smsregistry@sgnic.sg` and ask.** It is cheap, and it puts a
-good-faith enquiry on the record either way. Until answered, treat this as the one
-genuinely unresolved item in this document.
+**Residual action:** a one-line confirmation to `smsregistry@sgnic.sg` to put the
+answer on record. Not a live risk.
 
-**Forward-looking (Prudential LTS and similar):** if MKTR ever sends SMS on behalf
-of a client under *their* SID, that client must file an LOA with their PA naming
-MKTR as an authorised representative. Build it into the vendor checklist — in a
-compliance-led sale it reads as a credibility signal, not overhead.
+**Forward-looking:** if MKTR ever sends SMS on behalf of a client under *their* SID
+(e.g. the Prudential LTS engagement), that client must file an LOA with their PA
+naming MKTR as an authorised representative. Build it into the vendor checklist.
 
 ---
 
 ## 5. When an alert fires
 
-1. **Is it real traffic?** Check leads created today against the SMS count. A
+1. **Is it real traffic?** Compare leads created today against the SMS count. A
    genuine campaign spike shows leads roughly tracking sends.
-2. **If real** → raise `SMS_DAILY_GLOBAL_CAP` on `mktr-backend-jo6r` and redeploy.
-   Do not leave it hitting the ceiling; a hard stop means real users cannot verify.
+2. **If real** → raise `SMS_DAILY_GLOBAL_CAP` **and check the AWS spend ceiling
+   (§3d)** — raising ours alone achieves nothing if AWS cuts you off at $50.
 3. **If not real** → the public OTP endpoint is being driven. Every one of those
    messages carries `MKTR`.
    - Drop `SMS_DAILY_CAP_PER_PHONE` to 2–3 to blunt it immediately.
    - Inspect `/api/verify/send` traffic for the source pattern.
    - Consider a CAPTCHA or campaign-validity requirement on send — the endpoint
      currently accepts any `campaignId`, including none at all.
-   - Ceiling breaches are logged as `sms.global_ceiling_exceeded`; per-number
-     rejections as `otp.phone_daily_cap_exceeded`.
+   - Ceiling breaches log as `sms.global_ceiling_exceeded`; per-number rejections
+     as `otp.phone_daily_cap_exceeded`.
 4. Get ahead of SGNIC rather than waiting for a complaint. Under §7 they may
    suspend a SID immediately on a regulator's request.
+
+## 6. Diagnosing "no SMS arrived"
+
+In order, because each step rules out a layer:
+
+1. **Backend logs** — `Sending OTP` / `SMS sent` with no error means SNS accepted it
+   and returned a message ID. Credentials and permissions are then proven fine.
+2. **`rate_counters`** — confirms the caps aren't silently rejecting
+   (`otp:phone:<hmac>:<sgt-day>`, `sms:global:<sgt-day>`).
+3. **Delivery logs** (§3c) — `providerResponse` gives the carrier's verdict and
+   `dwellTimeMs` the real latency. A missing `…/Failure` log group means nothing has
+   failed at all.
+4. **Only then** suspect the handset: roaming, opt-out list, or carrier filtering.
+
+SNS `Publish` is asynchronous — it returns success the moment AWS queues the
+message, so "accepted" never proves "delivered". That gap is exactly what delivery
+status logging closes.


### PR DESCRIPTION
Follow-up to #221. Three fixes found while verifying that work against the **live AWS account**, plus a correction to the compliance doc where I'd got something wrong.

## 1. The limiter was bucketing on Cloudflare's edge address

`api.mktr.sg` is Cloudflare-fronted and `trust proxy` is `1`, so `req.ip` resolves to the **edge**, not the visitor. Confirmed in production — every `rate_counters` row was keyed `162.158.x.x`:

```
rl:verify-send:162.158.26.189:1784659500000
```

That lumped unrelated visitors into one bucket while letting a single attacker spread across edges.

Now we prefer `CF-Connecting-IP`, **but only when the request genuinely arrived from a published Cloudflare range**. The Render origin is publicly reachable, so an unvalidated header read would be *strictly worse than the bug*: anyone could send a random `CF-Connecting-IP` per request and mint unlimited buckets. A spoofer bypassing Cloudflare gets keyed on their real socket address.

If Cloudflare adds a range and the list goes stale, we fall back to edge keying — coarse, but never open.

## 2. Every logger call in the OTP path used pino's arguments backwards

`logger.info('msg', obj)` silently drops `obj` — pino's signature is `(obj, msg)`. Production logged a bare `"Sending OTP"` with no channel and `"SMS sent"` with no message id, which made tonight's live SMS investigation materially harder than it needed to be. All six calls fixed.

## 3. Phone numbers were logged in full

Now masked (`+65****4567`), matching lyfe-app's `custom-sms-hook`. Render logs sit outside the consent ledger and the PDPA erasure matrix, so the only safe amount of PII there is none.

## Doc correction — verified against the live account

The doc claimed the backend's AWS key was "shared with SES". I'd inferred that from *code usage* rather than IAM permissions, then over-corrected and said it wasn't. The truth, from the console:

- The credential was **`ses-smtp-user.20251229-003043`**, carrying `AmazonSesSendingAccess` via group **and `AmazonSNSFullAccess` attached directly** — `sns:*`, not `sns:Publish`.
- Now split: **`mktr-sns-sms`** holds `sns:Publish` only; the SES user keeps email. SNS policy detached, unused 129-day key deleted. Verified `last used` shows the new key doing all SNS work.
- **Root MFA is enabled.** There are no human IAM users, so root *is* the admin account the advisory means.
- **The LOA question is resolved.** `MKTR` is an AWS-managed `SG_SENDER_ID_REGISTRATION` (status `COMPLETE`) in our own account — AWS registered it with SGNIC on our behalf, so §4's third-party scenario doesn't apply.
- **Delivery status logging on**, 30-day retention. First record: `SUCCESS`, `dwellTimeMs: 36`, `$0.03918`, TPG Telecom. AWS is not the source of OTP latency — that's the carrier/roaming leg.
- ⚠️ **`TEXT_MESSAGE_MONTHLY_SPEND_LIMIT` has `MaxLimit: 50`** — an account maximum requiring an AWS support ticket to raise, i.e. **~1,276 SMS/month**. *That*, not our 500/day, is the binding constraint, and sustained peak traffic would exceed it. Request headroom before a campaign, not during one.

## Tests

58/58 across the four SMS suites, 8 new — including the exact production case (edge `162.158.26.189` + CF header), spoof rejection from a non-Cloudflare origin, IPv6 Cloudflare edges, and a near-miss range (`162.160.x` must not be trusted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CN1e6xAQXiB2z1sm7tD2qw