### PR TITLE
feat(campaigns): five draw-focused page templates (Postcard/Gazette/Nightfall/Stub/Checklist)

### DIFF
--- a/backend/src/utils/designConfigV2.js
+++ b/backend/src/utils/designConfigV2.js
@@ -36,7 +36,11 @@
 
 export const DESIGN_CONFIG_VERSION = 2;
 
-export const TEMPLATE_IDS = ['editorial', 'poster', 'split', 'spotlight', 'express', 'journey'];
+export const TEMPLATE_IDS = [
+  'editorial', 'poster', 'split', 'spotlight', 'express', 'journey',
+  // Draw-focused directions (drawTemplates.jsx, design review 2026-07-22).
+  'postcard', 'gazette', 'nightfall', 'stub', 'checklist',
+];
 
 /** Per-template parameter defaults — one bag, every template persists its
  * params across switches; first Studio use seeds these. Migration seeds the
@@ -49,6 +53,11 @@ export const TEMPLATE_PARAM_DEFAULTS = {
   spotlight: { introStyle: 'immersive', revealArt: 'meter' },
   express: { trustLine: '', storyFold: false },
   journey: { sectionRhythm: 'alternate', stickyCta: true },
+  postcard: { mediaSide: 'left', cardStyle: 'float', factStyle: 'numbered' },
+  gazette: { ruleDensity: 'airy', accentUse: 'fill', showSerial: true },
+  nightfall: { overlayTone: 'ink', showCountdown: true, ctaStyle: 'bar' },
+  stub: { ticketTone: 'paper', showSerial: true, stubEdge: 'bottom' },
+  checklist: { boostStep: 'inline', heroBand: true, railStyle: 'line' },
 };
 
 export const THEME_RADIUS_IDS = ['soft', 'sharp', 'round'];

--- a/backend/src/utils/designConfigV2Clamp.js
+++ b/backend/src/utils/designConfigV2Clamp.js
@@ -151,6 +151,29 @@ function clampTemplate(raw) {
     }
     if (tpl === 'express') out.trustLine = cleanString(inc.trustLine, LIMITS.trustLine) ?? '';
     if (tpl === 'journey') out.sectionRhythm = cleanEnum(out.sectionRhythm, ['alternate', 'stacked'], 'alternate');
+    // Draw-focused templates (drawTemplates.jsx) — booleans (showSerial,
+    // showCountdown, heroBand) are already typed by the generic pass above.
+    if (tpl === 'postcard') {
+      out.mediaSide = cleanEnum(out.mediaSide, ['left', 'right'], 'left');
+      out.cardStyle = cleanEnum(out.cardStyle, ['float', 'flush'], 'float');
+      out.factStyle = cleanEnum(out.factStyle, ['numbered', 'inline'], 'numbered');
+    }
+    if (tpl === 'gazette') {
+      out.ruleDensity = cleanEnum(out.ruleDensity, ['airy', 'dense'], 'airy');
+      out.accentUse = cleanEnum(out.accentUse, ['text', 'fill'], 'fill');
+    }
+    if (tpl === 'nightfall') {
+      out.overlayTone = cleanEnum(out.overlayTone, ['dusk', 'ink'], 'ink');
+      out.ctaStyle = cleanEnum(out.ctaStyle, ['bar', 'pill'], 'bar');
+    }
+    if (tpl === 'stub') {
+      out.ticketTone = cleanEnum(out.ticketTone, ['paper', 'accent'], 'paper');
+      out.stubEdge = cleanEnum(out.stubEdge, ['top', 'bottom'], 'bottom');
+    }
+    if (tpl === 'checklist') {
+      out.boostStep = cleanEnum(out.boostStep, ['inline', 'footnote'], 'inline');
+      out.railStyle = cleanEnum(out.railStyle, ['line', 'dots'], 'line');
+    }
     params[tpl] = out;
   }
   return { id, params };

--- a/backend/src/utils/luckyDraw.js
+++ b/backend/src/utils/luckyDraw.js
@@ -14,6 +14,7 @@
  */
 
 const MAX_PRIZE = 80;
+const MAX_BOOKING_URL = 300;
 const MIN_MULTIPLIER = 2;
 const MAX_MULTIPLIER = 100;
 const DEFAULT_MULTIPLIER = 10;
@@ -70,6 +71,12 @@ export function normalizeLuckyDraw(raw) {
   // No draw mechanics read it.
   const winners = Number(raw.winners);
   if (Number.isInteger(winners) && winners >= 1 && winners <= 1000) out.winners = winners;
+
+  // Session-booking link for the success screen's "Book your 20-min review"
+  // CTA (drawTemplates.jsx). Display-only — no draw mechanics read it. Absent
+  // or non-http(s) → CTA simply doesn't render.
+  const bookingUrl = cleanString(raw.bookingUrl, MAX_BOOKING_URL);
+  if (bookingUrl && /^https?:\/\/\S+$/i.test(bookingUrl)) out.bookingUrl = bookingUrl;
 
   for (const key of ['activationId', 'termsVersionId']) {
     if (typeof raw[key] === 'string' && UUID_RE.test(raw[key].trim())) {

--- a/backend/src/utils/publicDesignConfig.js
+++ b/backend/src/utils/publicDesignConfig.js
@@ -47,6 +47,7 @@ export function publicLuckyDraw(raw) {
     ...(ld.drawOn ? { drawOn: ld.drawOn } : {}),
     multiplier: ld.multiplier,
     ...(ld.winners ? { winners: ld.winners } : {}),
+    ...(ld.bookingUrl ? { bookingUrl: ld.bookingUrl } : {}),
   };
 }
 

--- a/backend/test/designConfigV2StudioClamp.test.js
+++ b/backend/test/designConfigV2StudioClamp.test.js
@@ -37,6 +37,35 @@ function studioDoc() {
   return doc;
 }
 
+describe('draw-template ids + params (drawTemplates.jsx)', () => {
+  it('accepts the five draw template ids and clamps their enum params to defaults on junk', () => {
+    const doc = studioDoc();
+    doc.template = {
+      id: 'nightfall',
+      params: {
+        ...doc.template.params,
+        nightfall: { overlayTone: 'neon', showCountdown: 'yes', ctaStyle: 'pill' },
+        postcard: { mediaSide: 'top', cardStyle: 'float', factStyle: 'inline' },
+        stub: { ticketTone: 'gold', stubEdge: 'left', showSerial: false },
+      },
+    };
+    const out = clampDesignConfigV2(doc, undefined, 'admin');
+    expect(out.template.id).toBe('nightfall');
+    expect(out.template.params.nightfall).toEqual({ overlayTone: 'ink', showCountdown: false, ctaStyle: 'pill' });
+    expect(out.template.params.postcard).toEqual({ mediaSide: 'left', cardStyle: 'float', factStyle: 'inline' });
+    expect(out.template.params.stub).toEqual({ ticketTone: 'paper', stubEdge: 'bottom', showSerial: false });
+    // Untouched draw templates keep seeded defaults.
+    expect(out.template.params.gazette).toEqual({ ruleDensity: 'airy', accentUse: 'fill', showSerial: true });
+    expect(out.template.params.checklist).toEqual({ boostStep: 'inline', heroBand: true, railStyle: 'line' });
+  });
+
+  it('unknown template id still falls back to editorial', () => {
+    const doc = studioDoc();
+    doc.template = { id: 'brutalist', params: doc.template.params };
+    expect(clampDesignConfigV2(doc, undefined, 'admin').template.id).toBe('editorial');
+  });
+});
+
 describe('clampDesignConfigV2 over Studio-authored docs', () => {
   it('is IDEMPOTENT for admins: clamp(clamp(x)) is byte-identical to clamp(x)', () => {
     const once = clampDesignConfigV2(studioDoc(), undefined, 'admin');

--- a/backend/test/luckyDraw.util.test.js
+++ b/backend/test/luckyDraw.util.test.js
@@ -68,6 +68,20 @@ describe('normalizeLuckyDraw', () => {
   });
 });
 
+describe('normalizeLuckyDraw — bookingUrl (draw success CTA)', () => {
+  it('keeps http(s) urls, capped, and drops everything else', () => {
+    expect(normalizeLuckyDraw({ enabled: true, bookingUrl: 'https://redeem.sg/book' }).bookingUrl).toBe('https://redeem.sg/book');
+    expect(normalizeLuckyDraw({ enabled: true, bookingUrl: 'http://redeem.sg/book' }).bookingUrl).toBe('http://redeem.sg/book');
+    expect(normalizeLuckyDraw({ enabled: true, bookingUrl: 'javascript:alert(1)' }).bookingUrl).toBeUndefined();
+    expect(normalizeLuckyDraw({ enabled: true, bookingUrl: 'ftp://x' }).bookingUrl).toBeUndefined();
+    expect(normalizeLuckyDraw({ enabled: true, bookingUrl: 'redeem.sg/book' }).bookingUrl).toBeUndefined();
+    expect(normalizeLuckyDraw({ enabled: true, bookingUrl: 42 }).bookingUrl).toBeUndefined();
+    // The 300-char cap truncates into an invalid URL with whitespace-free tail — still http ok:
+    const long = `https://redeem.sg/${'a'.repeat(400)}`;
+    expect(normalizeLuckyDraw({ enabled: true, bookingUrl: long }).bookingUrl.length).toBeLessThanOrEqual(300);
+  });
+});
+
 describe('applyLuckyDrawPolicy', () => {
   const stored = { enabled: true, prize: 'Luggage', multiplier: 10 };
 

--- a/backend/test/publicDesignConfig.test.js
+++ b/backend/test/publicDesignConfig.test.js
@@ -24,6 +24,17 @@ describe('publicLuckyDraw', () => {
     expect(publicLuckyDraw(undefined)).toBeUndefined();
     expect(publicLuckyDraw({ enabled: false, closesAt: '2026-08-31' })).toBeUndefined();
   });
+
+  it('exposes bookingUrl (display-only success CTA) but never internal ids', () => {
+    const out = publicLuckyDraw({
+      enabled: true,
+      closesAt: '2026-10-30',
+      bookingUrl: 'https://redeem.sg/book',
+      activationId: '2c8ba713-ac13-4e2f-89a8-fb5c25bd6371',
+    });
+    expect(out.bookingUrl).toBe('https://redeem.sg/book');
+    expect(out.activationId).toBeUndefined();
+  });
 });
 
 describe('buildPublicDesignConfig', () => {

--- a/docs/plans/lucky-draw-page-templates-claude-design-prompt.md
+++ b/docs/plans/lucky-draw-page-templates-claude-design-prompt.md
@@ -1,0 +1,79 @@
+# Lucky-Draw Campaign Page — Multiple Template Directions — claude.ai/design prompt
+
+**Date:** 2026-07-22
+**Target:** claude.ai/design, as a fresh project (suggested name: **"Redeem Draw Page Templates"**). Attach when pasting: screenshots of the six current templates from Campaign Studio's preview (Editorial, Poster, Split, Spotlight, Express, Journey — any campaign, mobile width), and the Tokyo hero image.
+**Goal:** a gallery of **distinct, selectable campaign-page templates purpose-built for lucky-draw campaigns**, so a draw campaign's page can be chosen per-campaign in the Campaign Studio template picker instead of borrowing a generic lead-capture layout with a small badge.
+**After the design:** engineering implements the chosen direction(s) as new template ids in the design_config v2 renderer + Studio picker, so every direction must be reproducible under the constraints in §1.6.
+
+---
+
+## Paste everything below this line into claude.ai/design
+
+---
+
+You are a senior conversion/brand designer creating **new page templates** for an existing campaign-page system. The system, its form component, and its config contract already exist and are fixed — you are designing the compositions around them. Invent nothing outside the scope below.
+
+# 0. Ground rules
+
+You do **not** have access to the codebase and must not ask for it. Section 1 is ground truth — do not invent capabilities beyond it. Build an interactive prototype: a template **gallery/switcher** where each direction renders the same seed campaign (§1.5) as a full page — mobile-first, with a desktop pass — including all three page states (§2). Realistic seeded content only; the attached screenshots show the incumbent templates your directions must be clearly distinct from.
+
+# 1. Platform context (ground truth)
+
+## 1.1 What this page is
+
+redeem.sg runs consumer reward campaigns in Singapore. A campaign page is a single-purpose lead-capture landing page: nearly all traffic is **paid social clicks on phones** (Instagram/Facebook/TikTok in-app browsers). The page's one job is form completion; everything else exists to earn that. Brand: **redeem.sg** wordmark, consumer-friendly, institutional-trust posture (SG audiences are highly scam-wary — especially of prize draws).
+
+## 1.2 The lucky-draw mechanic (what the page must communicate)
+
+- Signing up = **one verified entry** in a prize draw. Free to enter, 18+.
+- Entry requires SMS OTP verification of the mobile number — **one entry per verified number** (a genuine trust marker: verified, no bots, no multiple entries).
+- Entries close at a fixed date (seed: **30 Oct 2026, 23:59 SGT**).
+- **×10 boost:** complete a complimentary ~20-min financial review before the close date → the entry becomes ten. After signup the person receives a pass by WhatsApp/email; the consultant scans it at the session. The page should plant this (it's also how the business wins) without burying the primary signup action.
+- One winner, drawn in a witnessed process after close; contacted directly; masked results published at redeem.sg/winners (a real page — linkable trust element).
+- Anti-scam assurance is brand policy: **we never ask for payment to release a prize.**
+- Full T&Cs open in a dialog from the form's consent checkbox; the page may also reference them.
+
+## 1.3 The config contract (the slots a template composes)
+
+Every template renders from the same campaign config. Slots available:
+
+- **content**: `headline`, `subheadline`, `story` (a short paragraph), `emphasis` (one punchy line), `submitLabel` (form button text), `wordmark`, optional `heroCtaLabel`, `footer.regulatory`, and **media** (one hero image or video).
+- **theme**: an `accent` color (seed: `#3B82F6` — but treat accent as a variable) and a light/dark `preset`.
+- **form**: which fields show (seed: name, phone, email; others hidden), SMS verification on, terms HTML.
+- **luckyDraw**: `enabled`, `closesAt`, `prize` string, `multiplier` (10). **Today the renderer shows only a small pill — "🎁 LUCKY DRAW · CLOSES 30 Oct 2026" — and the prize string is never rendered anywhere on the page.** Your templates own fixing that.
+- Each template may additionally expose **2–3 template params** (knobs an admin can flip in Studio, e.g. media side, card style, overlay tone). Define yours per direction.
+
+## 1.4 The form is a fixed component (hard contract)
+
+One shared signup form component is dropped into every template: field inputs → SMS OTP send/verify step → required T&C consent checkbox (opens the terms dialog) → submit button. Templates decide its **container** (width, framing, position, reveal behavior) and receive its states, but must not reorder or redesign its internals. Assume it needs ~320–420px of comfortable width.
+
+## 1.5 Seed campaign (use verbatim)
+
+- **Tokyo Getaway Lucky Draw** — prize: **4D3N Tokyo getaway (flights + hotel)**, one winner, one pax.
+- headline "Win a 4D3N Tokyo Getaway" · subheadline "Return flights + 3 nights' hotel, for one lucky winner. Free to enter." · emphasis "One winner. Flights + hotel. On us." · story "Drop your details and you're in the draw for a 4-day, 3-night Tokyo getaway — flights and hotel covered for one. Verified by a one-time SMS code: one entry per person, no app, no catch." · submitLabel "Enter the draw" · wordmark "redeem.sg"
+- Hero: the attached Tokyo dusk image (Tokyo Tower, Mt Fuji, blossoms — clean sky area usable for type).
+- closesAt/boost deadline: 30 Oct 2026 · multiplier ×10 · winners page: redeem.sg/winners
+
+## 1.6 Hard production constraints
+
+- **Mobile-first inside ad in-app browsers**: the signup path must be obvious within the first viewport-and-a-half on a 390×844 screen. Desktop is the adaptation, not the design.
+- **Implementable in a React renderer with plain CSS capabilities**: flat color, gradients, borders, standard transforms/transitions are fine; no WebGL/shaders/canvas effects, no scroll-jacking, no heavy animation libraries, no new webfonts per template (system/site font stack + weight/size/spacing do the typographic work).
+- **Performance**: one hero asset max above the fold; nothing that delays the form.
+- **The close date is a fixed calendar fact.** A live countdown to `closesAt` is allowed if a direction earns it; fake scarcity (entry counters, "3 spots left") is forbidden.
+- **Every direction must design all three states**: OPEN (the page), **DRAW CLOSED** (post-`closesAt`: entries no longer accepted, winner-notification explanation, link to winners page — today this is a plain gray fallback page; make it a designed moment), and **SUCCESS** (post-submit: today it's a generic "You're all set." — design the "you're in the draw" moment: entry confirmed, check WhatsApp/email for your pass, complete your session before the close date for ×10).
+- Accent color and light/dark preset must be swappable without breaking any direction (show at least one direction in a second accent to prove it).
+
+# 2. The brief — deliverables
+
+**A. 4–6 named template directions**, each a genuinely different composition strategy for a draw page — not palette swaps of one layout. Each direction must place, deliberately: the **prize** (currently unrendered — hero it), the **close date** (urgency without scam-stink), the **×10 session mechanic** (secondary but present), the **verified-entry trust markers** (SMS-verified · one entry per number · free to enter · 18+), the **anti-scam line**, the **winners-page link**, and the **form container**. For each direction supply: name, one-line thesis, mobile comp, desktop comp, the three states (§1.6), the slot map (which config slot feeds which element), and its 2–3 template params with all values.
+
+**B. The gallery switcher** — one prototype where I flip between directions (and states within a direction) on the same Tokyo seed data at mobile width, so choosing among them takes seconds.
+
+**C. A recommendation** — which direction you'd ship as the default draw template and why, one short paragraph, conversion-first reasoning.
+
+# 3. What NOT to do
+
+- Don't redesign the form component's internals, the OTP flow, or the consent checkbox — containers only.
+- Don't resemble the six incumbent templates (attached) — those already exist as choices; new directions must read as new.
+- Don't add claims beyond §1.2 (no "guaranteed win", no fake urgency, no prize-value inflation, no partner/airline logos).
+- Don't rely on photography beyond the one hero slot — campaigns swap heroes; compositions must survive a mediocre hero (show one direction with media hidden/none).

--- a/docs/plans/lucky-draw-whatsapp-pass-claude-design-prompt.md
+++ b/docs/plans/lucky-draw-whatsapp-pass-claude-design-prompt.md
@@ -1,0 +1,87 @@
+# Lucky-Draw Signup WhatsApp — Entry Pass Card + Message — claude.ai/design prompt
+
+**Date:** 2026-07-22
+**Target:** claude.ai/design, inside the **"QR Card Frames"** project (it holds the Editorial family — 1c — that shipped as the pass/voucher cards). Attach the two reference renders (`qr-card-pass-reference.png`, `qr-card-voucher-reference.png`) when pasting.
+**Goal:** design the WhatsApp message a person receives the moment they sign up for a lucky-draw campaign (first live one: Tokyo Getaway Lucky Draw) — a new **draw-entry state** of the Editorial QR card family (the image header) plus the **template body copy** under it.
+**After the design:** engineering re-implements the card in the satori compositor (`qrCardRenderer.js`) as a third state and submits the body to Meta as a UTILITY template, so every visual choice must be reproducible under the constraints in §1.4.
+
+---
+
+## Paste everything below this line into claude.ai/design
+
+---
+
+You are a senior brand/product designer extending the existing **Editorial QR card family** (the attached pass + voucher references are the family; match them exactly in construction and voice). This is a **new state of an existing artifact plus its message copy** — not a rebrand, not a new layout system. Invent nothing outside the scope below.
+
+# 0. Ground rules
+
+You do **not** have access to the codebase and must not ask for it. Section 1 is ground truth — do not invent capabilities beyond it. Deliverables are §2. Use the realistic seed data in §1.5 — no lorem ipsum, no placeholder gray boxes. The QR itself may be a realistic dummy QR.
+
+# 1. Platform context (ground truth)
+
+## 1.1 The moment this message lands
+
+redeem.sg runs consumer reward campaigns in Singapore. A person finds the campaign page, fills a short form (name, mobile, email), verifies their mobile with a one-time SMS code, and submits. For **lucky-draw campaigns** that signup = one verified entry in the draw. Seconds later they get this WhatsApp (and a confirmation email). It is the only WhatsApp they receive at signup.
+
+The draw mechanic they just agreed to (it's in the T&Cs they ticked):
+
+- One entry per verified mobile number. Free to enter.
+- Entries close at a fixed date (Tokyo: **23:59 SGT, 30 October 2026**).
+- **×10 boost:** complete a complimentary ~20-min financial review before the close date, and the entry becomes **ten entries**. The consultant records the completed session by **scanning this exact pass** at the meeting.
+- One winner, drawn after close in a witnessed process; contacted directly by phone/SMS; 14 days to claim; masked results published at redeem.sg/winners.
+- Anti-scam posture is a brand pillar: **we never ask for payment to release a prize** (draw scams are rampant in SG — this message must feel institutional, not like a prize-scam blast).
+
+So this one message must do three jobs at once: **confirm the entry** ("you're in"), **hand over the pass** (the QR the consultant will scan), and **plant the ×10 reason to book the session** — without reading as marketing spam.
+
+## 1.2 The message anatomy (fixed)
+
+Meta WhatsApp Cloud API **UTILITY template**: an **image header** (the 1080×1080 card PNG, rendered per-customer and uploaded at send time) above a short **body text** with numbered placeholders. That's the whole message — no buttons, no footer, no document attachments. The existing sibling message (reservation pass for non-draw campaigns) uses exactly this anatomy.
+
+## 1.3 The Editorial card family (what you are extending — see attached references)
+
+One 1080×1080 canvas, vertical flex stack, two existing states:
+
+| Slot (top→bottom) | Spec | 'pass' state (cream) | 'voucher' state (terracotta) |
+|---|---|---|---|
+| Header row | wordmark left, kicker right, margin 40px top / 48px sides | "Redeem" 34px Albert Sans 800 + accent-dot period `#D6552B` | same, ink `#FBF7EE` |
+| Kicker | 24px Albert Sans 600, letter-spacing 4.8 | `RESERVATION PASS` in `#6B6558` | `VOUCHER · UNLOCKED` in `#F7E7DC` |
+| Display word | Fraunces italic 600, 64px, centered | *Reserved.* in gold `#C89B3C` | *Unlocked.* in `#F7E7DC` |
+| Partner line | 24px 600, ls 3.8, flanked by 2px hairlines, 120px side padding | partner name uppercase, `#6B6558` / hairline `#E6E0D1` | same, cream on `rgba(251,247,238,.38)` hairlines |
+| Title | Fraunces 600, 42px, centered, 80px side padding | reward name, `#1B1A17` | reward name, `#FBF7EE` |
+| **QR panel** | **594×594 white panel, centered; 450×450 QR inside (the white margin is the quiet zone). SACRED — geometry and whiteness never change.** | 2px border `#E6E0D1` | borderless (white floats on terracotta) |
+| Status line | 13px dot + Fraunces italic 400, 30px | "Held for {name} — unlock at your appointment" | "Unlocked — present once to redeem" |
+| Footer stack | bottom-anchored, centered, 28px bottom pad | JetBrains Mono 600 28px code line → 24px ls 3.4 expiry line → 24px fine print `#8B8477` → `POWERED BY MKTR` mono 24px ls 2.9 | same in cream tones |
+
+Palettes: **pass** = bg `#FBF7EE`, ink `#1B1A17`, gold `#C89B3C`, accent `#D6552B`, muted `#6B6558`, hairline `#E6E0D1`, fine print `#8B8477`. **voucher** = bg `#D6552B`, ink/cream `#FBF7EE`, soft cream `#F7E7DC`.
+
+Family voice: editorial restraint. Flat fills, hairlines, one italic display word doing the emotional work, mono for machine-ish lines. No gradients, no shadows, no illustration, no photos.
+
+## 1.4 Hard production constraints
+
+- **WhatsApp crop:** the chat bubble preview crops toward the middle band — the display word, title, and QR must survive the crop; header/footer may be lost in preview. (The references already obey this; keep their vertical rhythm.)
+- **Compositor:** the card is rebuilt in satori (flexbox-only layout, the three family fonts above, flat colors, simple borders/hairlines only). If your design needs masks, gradients, rotation, or new fonts, it won't ship — don't.
+- **Dynamic text is single-line and clamped:** customer first name ≤24 chars, reward/prize title ≤70, partner ≤48, dates render like `30 Oct 2026`. Design the slots to tolerate the max lengths.
+- **QR encodes a claim link** (`redeem.sg/r/…`). A human who scans it lands on a branded pass page; the consultant's scanner is what records the ×10 session. Don't caption the QR with anything that contradicts either use.
+- **Template body (Meta rules):** ≤1024 chars, plain text + emoji, numbered `{{n}}` params; params are single-line, ≤60 chars, and may not contain URLs (the one link, `redeem.sg/r/{{token}}`, lives in the fixed template text). The template must plausibly pass Meta's **UTILITY** review: it confirms a transaction the person just initiated (their entry) — confirmational statements, not promotional questions/exclamations, or Meta reclassifies it as MARKETING.
+
+## 1.5 Seed data (use verbatim)
+
+- Campaign: **Tokyo Getaway Lucky Draw** · prize **4D3N Tokyo getaway (flights + hotel)** · entries close **30 Oct 2026** (23:59 SGT) · multiplier **×10**
+- Customer: **Sarah**, +65 9•••• 4312
+- Partner/consultant context: the session is a complimentary financial review with an MKTR-partnered consultant (no external partner brand on draw cards — the partner-line slot needs a draw-appropriate treatment, e.g. campaign or issuer language; your call, in-family)
+- Wordmark: **Redeem.** · footer keeps **POWERED BY MKTR**
+- The pass has no manual code (nothing to type); it may show an entry/serial-style mono line if that slot earns its place. Expiry-slot equivalent: the close date.
+
+# 2. The brief — deliverables
+
+**A. The draw-entry card state.** Design the third state of the family: the card that confirms "you're in the draw" AND works as the scannable ×10 session pass. Explore **2–3 directions within the family** — e.g. cream with the draw treated in gold; a third colorway (if you introduce one, it must sit naturally beside cream + terracotta and keep the sacred white QR panel); a ticket/entry-stub accent achievable with hairlines alone — then recommend one. For the chosen direction, specify every slot exactly as §1.3 does: kicker text, display word, partner-line treatment, title content (prize vs campaign name — your call), status line, footer lines (incl. how the close date reads), and all hex values. Show it rendered with the §1.5 seed data at 1080×1080, plus a small mock of how it crops inside a WhatsApp bubble.
+
+**B. The message body copy.** Write the template body that rides under the card: the `{{n}}` parameterized template string (with a param table: position → content → example) AND the rendered Sarah example. It must confirm the entry, state the ×10-by-session mechanic and the close date, carry the fixed `redeem.sg/r/{{token}}` link as the tap fallback, include the never-pay-for-a-prize assurance, and stay UTILITY-classifiable per §1.4. Keep it tight — this sits in a chat bubble under a card that already says most of it.
+
+**C. One-line consistency note.** The same PNG is reused as the inline image of the signup email — confirm the chosen direction reads correctly on a white email background (the cream card currently relies on its own bg; if your direction needs a hairline border for white contexts, say so).
+
+# 3. What NOT to do
+
+- Don't redesign the existing pass/voucher states, the layout skeleton, fonts, or the QR panel geometry.
+- Don't add buttons, links, or claims beyond §1.1 facts (no "guaranteed", no urgency countdown, no prize imagery).
+- Don't produce marketing-tone copy (exclamation-heavy, question hooks) — it must survive Meta's utility review and SG scam-wariness.

--- a/src/components/campaignPage/CampaignPageRenderer.jsx
+++ b/src/components/campaignPage/CampaignPageRenderer.jsx
@@ -27,6 +27,7 @@ import { CampaignThemeProvider } from './themeContext';
 import { adaptCampaignForFunnel, deriveFunnelProps } from './funnelAdapter';
 import { resolveJumpFixtures } from './previewJumpFixtures';
 import { TEMPLATES } from './templates';
+import { DRAW_TEMPLATES, DrawClosedPage } from './drawTemplates';
 
 /** SGT day-end draw cutoff — mirrors marketplace content.js offerUnavailability
  * (entries close 23:59:59.999 SGT on closesAt; server 410s past it). */
@@ -232,12 +233,27 @@ export default function CampaignPageRenderer({
     formAnchorRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }, []);
 
+  const templateId = doc.template?.id || 'editorial';
+
   const blocked = jump === 'inactive' || inactive
     ? 'inactive'
     : jump === 'draw-closed' || isDrawClosed(doc.luckyDraw)
       ? 'draw'
       : null;
   if (blocked) {
+    // The five draw templates own their designed closed page; everything else
+    // (and the inactive state) keeps the shared BlockedPage.
+    if (blocked === 'draw' && DRAW_TEMPLATES[templateId]) {
+      return (
+        <DrawClosedPage
+          templateId={templateId}
+          t={t}
+          content={content}
+          luckyDraw={doc.luckyDraw}
+          campaignName={campaign?.name}
+        />
+      );
+    }
     return <BlockedPage t={t} content={content} reason={blocked} luckyDraw={doc.luckyDraw} />;
   }
 
@@ -273,8 +289,10 @@ export default function CampaignPageRenderer({
     </CampaignThemeProvider>
   );
 
-  const templateId = doc.template?.id || 'editorial';
-  const Template = TEMPLATES[templateId] || TEMPLATES.editorial;
+  // Merged at lookup time (not module scope) — templates.jsx and
+  // drawTemplates.jsx sit in an import cycle with this file, so a module-scope
+  // spread of either registry would hit the const TDZ depending on entry order.
+  const Template = TEMPLATES[templateId] || DRAW_TEMPLATES[templateId] || TEMPLATES.editorial;
   const params = doc.template?.params?.[templateId] || {};
 
   return (
@@ -290,6 +308,8 @@ export default function CampaignPageRenderer({
         mobile={mobile}
         stage={stage}
         referrerName={referrerName}
+        campaignName={campaign?.name}
+        formJumpActive={Boolean(jumpFixtures?.form)}
       />
     </div>
   );

--- a/src/components/campaignPage/__tests__/drawTemplates.test.jsx
+++ b/src/components/campaignPage/__tests__/drawTemplates.test.jsx
@@ -1,0 +1,207 @@
+/**
+ * The five draw-focused templates (drawTemplates.jsx) — open/success/closed
+ * states, draw-chrome conditionality, and the pure helpers. Uses the REAL
+ * migration over the shared v1 fixtures, exactly like CampaignPageRenderer's
+ * own suite.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/api/client', () => ({
+  apiClient: { post: vi.fn(), get: vi.fn(), baseURL: 'http://localhost/api' },
+}));
+
+import CampaignPageRenderer from '../CampaignPageRenderer';
+import {
+  DRAW_TEMPLATE_IDS,
+  DrawSuccessPage,
+  formatDrawDateFull,
+  drawDaysLeft,
+  maskSgPhone,
+} from '../drawTemplates';
+import { upgradeDesignConfig, TEMPLATE_IDS } from '@/lib/designConfigV2';
+import { editorialBaseline, adminRichDoc } from '../../../../test-fixtures/designConfigV1Docs.mjs';
+
+const drawCampaign = (templateId, params = {}, docOver = {}) => {
+  const doc = upgradeDesignConfig(adminRichDoc);
+  doc.template = { ...doc.template, id: templateId };
+  if (Object.keys(params).length) {
+    doc.template.params = {
+      ...doc.template.params,
+      [templateId]: { ...doc.template.params[templateId], ...params },
+    };
+  }
+  Object.assign(doc, docOver);
+  return { id: 'camp-1', name: 'Tokyo Getaway Lucky Draw', is_active: true, design_config: doc };
+};
+
+const plainCampaign = (templateId) => {
+  const doc = upgradeDesignConfig(editorialBaseline);
+  doc.template = { ...doc.template, id: templateId };
+  return { id: 'camp-2', name: 'Plain Campaign', is_active: true, design_config: doc };
+};
+
+/** jsdom defaults to 1024 (desktop branch); mobile-specific assertions set 390. */
+const setViewport = (w) => {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: w });
+  window.dispatchEvent(new Event('resize'));
+};
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => setViewport(1024));
+
+describe('registry', () => {
+  it('the five draw ids are registered in TEMPLATE_IDS (twin contract)', () => {
+    for (const id of DRAW_TEMPLATE_IDS) expect(TEMPLATE_IDS).toContain(id);
+  });
+});
+
+describe('open states', () => {
+  it.each(DRAW_TEMPLATE_IDS)('%s renders headline + draw chrome + funnel through the renderer', (id) => {
+    render(<CampaignPageRenderer campaign={drawCampaign(id)} previewMode onSubmit={vi.fn()} />);
+    expect(document.querySelector(`[data-campaign-page-template="${id}"]`)).toBeTruthy();
+    // Headline from the doc renders somewhere in the page chrome.
+    expect(screen.getAllByText('Win a 4D3N Tokyo getaway for two').length).toBeGreaterThanOrEqual(1);
+    // Draw chrome: the anti-scam brand line is draw-only.
+    expect(screen.getAllByText(/never ask for payment to release a prize/).length).toBeGreaterThanOrEqual(1);
+    // The reused production funnel mounts (adminRichDoc has no SG/PR gate, so
+    // the form's phone field renders directly).
+    expect(screen.getAllByPlaceholderText('9123 4567').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('postcard shows the prize chip and the full close date', () => {
+    render(<CampaignPageRenderer campaign={drawCampaign('postcard')} previewMode onSubmit={vi.fn()} />);
+    expect(screen.getByText('4D3N Tokyo getaway for two')).toBeInTheDocument(); // prize chip
+    expect(screen.getByText('CLOSES 30 AUG 2026')).toBeInTheDocument();
+  });
+
+  it('gazette renders the fact table with prize, close, and boost rows', () => {
+    render(<CampaignPageRenderer campaign={drawCampaign('gazette')} previewMode onSubmit={vi.fn()} />);
+    expect(screen.getByText('PRIZE')).toBeInTheDocument();
+    expect(screen.getByText('30 Aug 2026 · 23:59 SGT')).toBeInTheDocument();
+    expect(screen.getByText(/×10 when a consultant meets you/)).toBeInTheDocument();
+    expect(screen.getByText('SER. TGL-2026')).toBeInTheDocument(); // campaign-name initials + closes year
+  });
+
+  it('nightfall (mobile) opens the form sheet from the CTA — funnel mounted throughout', async () => {
+    setViewport(390);
+    const user = userEvent.setup();
+    render(<CampaignPageRenderer campaign={drawCampaign('nightfall')} previewMode onSubmit={vi.fn()} />);
+    // Funnel is mounted (hidden inside the closed sheet) so form state survives.
+    expect(screen.getAllByPlaceholderText('9123 4567').length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByRole('button', { name: 'Close entry form' })).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Submit Now' }));
+    expect(screen.getByRole('button', { name: 'Close entry form' })).toBeInTheDocument();
+  });
+
+  it('stub renders the ticket stub line with serial, and hides the serial via param', () => {
+    const { unmount } = render(<CampaignPageRenderer campaign={drawCampaign('stub')} previewMode onSubmit={vi.fn()} />);
+    expect(screen.getByText('ADMIT 1 ENTRY')).toBeInTheDocument();
+    expect(screen.getByText('NO. 0000001')).toBeInTheDocument();
+    unmount();
+    render(<CampaignPageRenderer campaign={drawCampaign('stub', { showSerial: false })} previewMode onSubmit={vi.fn()} />);
+    expect(screen.queryByText('NO. 0000001')).not.toBeInTheDocument();
+  });
+
+  it('checklist (mobile) renders the ×10 step in the spine, or as a footnote via param', () => {
+    setViewport(390);
+    const { unmount } = render(<CampaignPageRenderer campaign={drawCampaign('checklist')} previewMode onSubmit={vi.fn()} />);
+    expect(screen.getByText('Verify with an SMS code')).toBeInTheDocument();
+    expect(screen.getByText('Bonus: make it ×10')).toBeInTheDocument();
+    unmount();
+    render(<CampaignPageRenderer campaign={drawCampaign('checklist', { boostStep: 'footnote' })} previewMode onSubmit={vi.fn()} />);
+    expect(screen.queryByText('Bonus: make it ×10')).not.toBeInTheDocument();
+    expect(screen.getByText('Bonus ×10:')).toBeInTheDocument();
+  });
+
+  it('a non-draw campaign on a draw template renders clean (no draw chrome)', () => {
+    render(<CampaignPageRenderer campaign={plainCampaign('postcard')} previewMode onSubmit={vi.fn()} />);
+    expect(document.querySelector('[data-campaign-page-template="postcard"]')).toBeTruthy();
+    expect(screen.queryByText(/LUCKY DRAW/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/never ask for payment/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/SMS-VERIFIED/)).not.toBeInTheDocument();
+  });
+});
+
+describe('closed state', () => {
+  it('draw templates get their designed closed page', () => {
+    const campaign = drawCampaign('postcard');
+    campaign.design_config.luckyDraw = { ...campaign.design_config.luckyDraw, closesAt: '2020-01-01' };
+    render(<CampaignPageRenderer campaign={campaign} previewMode onSubmit={vi.fn()} />);
+    expect(document.querySelector('[data-draw-closed="postcard"]')).toBeTruthy();
+    expect(document.querySelector('[data-campaign-page-blocked="draw"]')).toBeTruthy();
+    expect(screen.getByText('Entries closed.')).toBeInTheDocument();
+    expect(screen.getByText('TOKYO GETAWAY LUCKY DRAW')).toBeInTheDocument(); // campaign-name kicker
+    expect(screen.getByRole('link', { name: /masked results/ })).toHaveAttribute('href', 'https://redeem.sg/winners');
+  });
+
+  it('non-draw templates keep the shared BlockedPage', () => {
+    const campaign = drawCampaign('editorial');
+    campaign.design_config.luckyDraw = { ...campaign.design_config.luckyDraw, closesAt: '2020-01-01' };
+    render(<CampaignPageRenderer campaign={campaign} previewMode onSubmit={vi.fn()} />);
+    expect(screen.getByText('This draw has closed.')).toBeInTheDocument();
+    expect(document.querySelector('[data-draw-closed]')).toBeFalsy();
+  });
+
+  it('jump="draw-closed" forces the designed page on a draw template', () => {
+    render(<CampaignPageRenderer campaign={drawCampaign('gazette')} jump="draw-closed" previewMode onSubmit={vi.fn()} />);
+    expect(document.querySelector('[data-draw-closed="gazette"]')).toBeTruthy();
+  });
+});
+
+describe('DrawSuccessPage', () => {
+  it('renders the postcard success with masked phone, chances, and closes line', () => {
+    render(<DrawSuccessPage campaign={drawCampaign('postcard')} submittedPhone="+6591234312" />);
+    expect(document.querySelector('[data-draw-success="postcard"]')).toBeTruthy();
+    expect(screen.getByText("You're in.")).toBeInTheDocument();
+    expect(screen.getByText(/\+65 9••• 4312/)).toBeInTheDocument();
+    expect(screen.getByText('1x')).toBeInTheDocument();
+    expect(screen.getByText('10x')).toBeInTheDocument();
+    expect(screen.getByText('ENTRIES CLOSE 30 AUG 2026 · 23:59 SGT')).toBeInTheDocument();
+    // No bookingUrl configured → no Book CTA.
+    expect(screen.queryByRole('link', { name: /Book your 20-min review/ })).not.toBeInTheDocument();
+  });
+
+  it('gazette success uses the "Entered." display word', () => {
+    render(<DrawSuccessPage campaign={drawCampaign('gazette')} submittedPhone={null} />);
+    expect(screen.getByText('Entered.')).toBeInTheDocument();
+  });
+
+  it('renders the Book CTA when luckyDraw.bookingUrl is configured', () => {
+    const campaign = drawCampaign('nightfall');
+    campaign.design_config.luckyDraw = {
+      ...campaign.design_config.luckyDraw,
+      bookingUrl: 'https://redeem.sg/book',
+    };
+    render(<DrawSuccessPage campaign={campaign} submittedPhone="+6591234312" />);
+    expect(screen.getByRole('link', { name: 'Book your 20-min review' })).toHaveAttribute('href', 'https://redeem.sg/book');
+  });
+
+  it('stub success renders as a ticket with the ENTRY HELD stub line', () => {
+    render(<DrawSuccessPage campaign={drawCampaign('stub')} submittedPhone={null} />);
+    expect(screen.getByText('ENTRY HELD · CLOSES 30 AUG 2026')).toBeInTheDocument();
+  });
+});
+
+describe('helpers', () => {
+  it('formatDrawDateFull renders day month year and rejects junk', () => {
+    expect(formatDrawDateFull('2026-10-30')).toBe('30 Oct 2026');
+    expect(formatDrawDateFull('junk')).toBe('');
+    expect(formatDrawDateFull(undefined)).toBe('');
+  });
+
+  it('drawDaysLeft counts whole SGT days and clamps at zero', () => {
+    const now = new Date('2026-10-28T00:00:00+08:00').getTime();
+    expect(drawDaysLeft('2026-10-30', now)).toBe(3);
+    expect(drawDaysLeft('2026-10-30', new Date('2026-11-05T00:00:00+08:00').getTime())).toBe(0);
+    expect(drawDaysLeft(undefined, now)).toBe(null);
+  });
+
+  it('maskSgPhone masks +65 numbers and rejects short input', () => {
+    expect(maskSgPhone('+6591234312')).toBe('+65 9••• 4312');
+    expect(maskSgPhone('91234312')).toBe('+65 9••• 4312');
+    expect(maskSgPhone('123')).toBe(null);
+    expect(maskSgPhone(null)).toBe(null);
+  });
+});

--- a/src/components/campaignPage/drawTemplates.jsx
+++ b/src/components/campaignPage/drawTemplates.jsx
@@ -1,0 +1,1039 @@
+/**
+ * The five lucky-draw page templates (claude.ai/design "Design Review: Three
+ * Colorways" → Campaign Templates.dc.html, 2026-07-22) — Postcard (default
+ * recommendation), Gazette, Nightfall, Stub, Checklist. Semantics ported from
+ * the design file, never its markup.
+ *
+ * Unlike the six generic templates (templates.jsx), these are ART-DIRECTED:
+ * each carries its own fixed neutral palette and the Fraunces / Albert Sans /
+ * JetBrains Mono stack (all loaded globally via index.css); only the ACCENT
+ * follows the campaign theme (design proof: accent swap across all five).
+ * The funnel form inside still renders with the campaign's funnelTheme —
+ * pick light presets for these templates.
+ *
+ * Every direction owns all three page states:
+ *  - OPEN      → registry component (same prop bag as templates.jsx)
+ *  - SUCCESS   → DrawSuccessPage (mounted by LeadCapture after submit)
+ *  - CLOSED    → DrawClosedPage (mounted by CampaignPageRenderer past closesAt)
+ * Draw chrome is conditional on luckyDraw.enabled — with no draw these render
+ * as clean lead-capture layouts, so selecting them on a non-draw campaign is
+ * safe (the picker does not restrict them).
+ */
+import { useState } from 'react';
+import {
+  ReferredBadge,
+  deriveCampaignPageContent,
+  formatDrawDate,
+} from './CampaignPageRenderer';
+import { MediaBlock } from './templates';
+import { resolveTheme } from '@/lib/designConfigV2';
+
+const SANS = "'Albert Sans', system-ui, sans-serif";
+const SERIF = "'Fraunces', Georgia, serif";
+const MONO = "'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace";
+
+const TRUST_ROW = 'SMS-VERIFIED · ONE ENTRY PER NUMBER · FREE TO ENTER · 18+';
+const SCAM_LINE = 'We never ask for payment to release a prize.';
+const WINNERS_URL = 'https://redeem.sg/winners';
+
+const mono = (fontSize, extra = {}) => ({ fontFamily: MONO, fontSize, ...extra });
+const serifItalic = (fontSize, extra = {}) => ({
+  fontFamily: SERIF, fontStyle: 'italic', fontWeight: 600, fontSize, ...extra,
+});
+
+/** '2026-10-30' → '30 Oct 2026' (string split — closesAt is an SGT calendar date). */
+export function formatDrawDateFull(ymd) {
+  const short = formatDrawDate(ymd);
+  if (!short) return '';
+  return `${short} ${ymd.slice(0, 4)}`;
+}
+
+/** Whole days until the SGT day-end of closesAt (display-only countdown). */
+export function drawDaysLeft(closesAt, now = Date.now()) {
+  if (!closesAt) return null;
+  const end = new Date(`${closesAt}T23:59:59+08:00`).getTime();
+  if (!Number.isFinite(end)) return null;
+  return Math.max(0, Math.ceil((end - now) / 86400000));
+}
+
+/** '+6591234312' / '91234312' → '+65 9••• 4312' (success-screen confirmation). */
+export function maskSgPhone(phone) {
+  const digits = String(phone || '').replace(/\D/g, '');
+  const local = digits.startsWith('65') && digits.length === 10 ? digits.slice(2) : digits;
+  if (local.length < 5) return null;
+  return `+65 ${local[0]}••• ${local.slice(-4)}`;
+}
+
+/** All the derived draw strings the three states share. */
+function drawStrings(luckyDraw, campaignName) {
+  const draw = luckyDraw?.enabled === true ? luckyDraw : null;
+  const m = draw?.multiplier || 10;
+  const closesFull = draw ? formatDrawDateFull(draw.closesAt) : '';
+  const boostFull = draw ? formatDrawDateFull(draw.boostClosesAt || draw.closesAt) : '';
+  return {
+    draw,
+    multiplier: m,
+    prize: draw?.prize || '',
+    closesFull,
+    closesMono: closesFull ? closesFull.toUpperCase() : '',
+    boostFull,
+    kicker: (campaignName || '').toUpperCase(),
+    boostBody: `Meet a consultant for a complimentary 20-minute financial review before ${boostFull} — they scan your entry pass at the session and your 1 entry becomes ${m}.`,
+    steps: [
+      'Your entry pass arrives by WhatsApp and email.',
+      `Book your complimentary ~20-min financial review — any time before ${boostFull}.`,
+      `Your consultant meets you and scans your pass — your 1 entry becomes ${m} entries.`,
+    ],
+    closedBody: 'The winner is being drawn in a witnessed process and will be contacted directly by phone or SMS.',
+    freeSessionLine: `FREE SESSION · NO PAYMENT EVER · BEFORE ${boostFull.toUpperCase()}`,
+  };
+}
+
+const accentSoftOf = (accent) => `${accent}1A`;
+
+/** Absolute-fill hero media (poster-template pattern) behind a scrim. */
+function BackdropMedia({ t, media }) {
+  if (!media || media.kind === 'none' || !media.src) return null;
+  return (
+    <MediaBlock
+      t={t}
+      media={media}
+      radius={0}
+      style={{ position: 'absolute', inset: 0, aspectRatio: 'auto', height: '100%' }}
+    />
+  );
+}
+
+function WinnersLink({ color }) {
+  return (
+    <a href={WINNERS_URL} target="_blank" rel="noopener noreferrer" style={{ color, textDecoration: 'underline' }}>
+      redeem.sg/winners
+    </a>
+  );
+}
+
+/** scam + winners + regulatory stack used by every open state's footer. */
+function DrawFootnotes({ draw, linkColor, mutedColor, faintColor, content, center = false }) {
+  const align = center ? 'center' : 'left';
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8, textAlign: align }}>
+      {draw && (
+        <div style={{ fontSize: 12.5, color: mutedColor, fontFamily: SANS }}>
+          {SCAM_LINE} Masked results at <WinnersLink color={linkColor} />.
+        </div>
+      )}
+      <div style={{ fontSize: 11, color: faintColor, fontFamily: SANS }}>
+        {content.regulatory}
+        <span style={{ display: 'block', marginTop: 4 }}>
+          {content.brandPre}
+          {content.brandLink && (
+            <a href="https://mktr.sg" target="_blank" rel="noopener noreferrer" style={{ color: faintColor, textDecoration: 'underline' }}>MKTR</a>
+          )}
+          {content.brandPost}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ───────────────────────── shared SUCCESS building blocks ─────────────────────────
+
+function ChancesRow({ accent, inkColor, mutedColor, multiplier }) {
+  const cell = (big, label, color, labelColor) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      <div style={{ fontFamily: SERIF, fontWeight: 600, fontSize: 38, lineHeight: 1, color }}>{big}</div>
+      <div style={mono(9.5, { letterSpacing: 1, color: labelColor })}>{label}</div>
+    </div>
+  );
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 20 }}>
+      {cell('1x', 'NOW', inkColor, mutedColor)}
+      <div style={{ fontSize: 22, color: mutedColor }}>→</div>
+      {cell(`${multiplier}x`, 'AFTER YOUR REVIEW', accent, accent)}
+    </div>
+  );
+}
+
+function NextSteps({ s, accent, stepBg, stepColor, bodyColor, lastColor, mutedColor, label, bookingUrl, ctaRadius = 9 }) {
+  return (
+    <>
+      <div style={mono(11, { letterSpacing: 1.5, color: accent, fontWeight: 600 })}>{label}</div>
+      {s.steps.map((step, i) => (
+        <div key={i} style={{ display: 'flex', gap: 10 }}>
+          <div style={{ width: 20, height: 20, borderRadius: '50%', background: stepBg, color: stepColor, fontSize: 11, fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, fontFamily: SANS }}>{i + 1}</div>
+          <div style={{ fontSize: 13, lineHeight: 1.5, color: i === 2 ? lastColor : bodyColor, fontWeight: i === 2 ? 600 : 400, fontFamily: SANS }}>{step}</div>
+        </div>
+      ))}
+      {bookingUrl && (
+        <a
+          href={bookingUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ background: accent, color: '#fff', border: 'none', borderRadius: ctaRadius, padding: 13, fontSize: 14.5, fontWeight: 700, fontFamily: SANS, textAlign: 'center', textDecoration: 'none', display: 'block' }}
+        >
+          Book your 20-min review
+        </a>
+      )}
+      <div style={mono(9.5, { letterSpacing: 0.8, color: mutedColor, textAlign: 'center' })}>{s.freeSessionLine}</div>
+    </>
+  );
+}
+
+function successSubOf(submittedPhone) {
+  const masked = maskSgPhone(submittedPhone);
+  return `Entry confirmed${masked ? ` for ${masked}` : ''} — you have 1 chance in the draw. Your entry pass is on its way by WhatsApp and email.`;
+}
+
+// ═══════════════════════════════ POSTCARD ═══════════════════════════════
+
+const PC = { bg: '#F6F4EE', ink: '#17181B', body: '#4A463C', mut: '#8B8477', faint: '#9A948A', line: '#E4E1D6', heroInk: '#17191E' };
+
+function Postcard({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile, referrerName, campaignName }) {
+  const accent = t.accent;
+  const s = drawStrings(luckyDraw, campaignName);
+  const flush = params.cardStyle === 'flush';
+  const cardFrame = {
+    background: '#fff',
+    borderRadius: 14,
+    ...(flush
+      ? { border: `1px solid ${PC.line}`, margin: '14px 16px 0' }
+      : { boxShadow: '0 8px 28px rgba(23,24,27,.10)', margin: '-36px 16px 0', position: 'relative' }),
+    padding: '18px 18px 20px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 14,
+  };
+  const facts = s.draw ? [
+    <><strong style={{ color: PC.ink }}>One verified entry.</strong> SMS code confirms your number — one entry per person, no bots.</>,
+    <><strong style={{ color: PC.ink }}>Entries close {s.closesFull},</strong> 23:59 SGT. One winner, drawn in a witnessed process.</>,
+    <><strong style={{ color: PC.ink }}>Make it ×{s.multiplier}.</strong> {s.boostBody}</>,
+  ] : [];
+  const hero = (
+    <div style={{ position: 'relative', height: mobile ? 300 : 'auto', minHeight: mobile ? 300 : '100%', flexShrink: 0, background: PC.heroInk }}>
+      <BackdropMedia t={t} media={content.media} />
+      <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(rgba(18,19,28,.15) 40%, rgba(18,19,28,.68))' }} />
+      <div style={{ position: 'absolute', top: 16, left: 20, right: 20, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div style={{ fontWeight: 800, fontSize: 17, color: '#fff', fontFamily: SANS }}>{content.wordmark}</div>
+        {s.draw && <div style={mono(10, { letterSpacing: 1.5, color: 'rgba(255,255,255,.85)' })}>LUCKY DRAW · FREE ENTRY</div>}
+      </div>
+      <div style={{ position: 'absolute', left: 20, right: 20, bottom: mobile ? 56 : 36, color: '#fff' }}>
+        <div style={{ fontFamily: SERIF, fontWeight: 600, fontSize: mobile ? 33 : 46, lineHeight: 1.12 }}>{content.headline}</div>
+        {content.subheadline && (
+          <div style={{ marginTop: 6, fontSize: mobile ? 14 : 17, color: 'rgba(255,255,255,.88)', fontFamily: SANS, whiteSpace: 'pre-line' }}>{content.subheadline}</div>
+        )}
+      </div>
+    </div>
+  );
+  const cardHeader = s.draw && (
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+      <div style={{ background: accentSoftOf(accent), color: accent, fontSize: 11, fontWeight: 700, letterSpacing: 1, padding: '5px 10px', borderRadius: 99, fontFamily: SANS, textTransform: 'uppercase' }}>
+        {s.prize || 'LUCKY DRAW'}
+      </div>
+      {s.closesMono && <div style={mono(10.5, { color: PC.mut })}>{`CLOSES ${s.closesMono}`}</div>}
+    </div>
+  );
+  const belowCard = (
+    <div style={{ padding: '22px 24px 26px', display: 'flex', flexDirection: 'column', gap: 18 }}>
+      {content.paragraphs.map((p, i) => (
+        <div key={i} style={{ fontSize: 14, lineHeight: 1.55, color: PC.body, fontFamily: SANS }}>{p}</div>
+      ))}
+      {content.emphasis && <div style={{ fontSize: 15, fontWeight: 700, color: PC.ink, fontFamily: SANS }}>{content.emphasis}</div>}
+      {facts.length > 0 && (
+        params.factStyle === 'inline' ? (
+          <div style={{ fontSize: 13, lineHeight: 1.6, color: PC.body, fontFamily: SANS }}>
+            One verified entry per number · Entries close {s.closesFull}, 23:59 SGT · ×{s.multiplier} after your complimentary review.
+          </div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            {facts.map((f, i) => (
+              <div key={i} style={{ display: 'flex', gap: 12 }}>
+                <div style={mono(12, { color: accent, fontWeight: 600 })}>{`0${i + 1}`}</div>
+                <div style={{ fontSize: 13, lineHeight: 1.5, color: PC.body, fontFamily: SANS }}>{f}</div>
+              </div>
+            ))}
+          </div>
+        )
+      )}
+      <div style={{ borderTop: `1px solid ${PC.line}`, paddingTop: 14 }}>
+        <DrawFootnotes draw={s.draw} linkColor={accent} mutedColor={PC.mut} faintColor={PC.faint} content={content} t={t} />
+      </div>
+    </div>
+  );
+  const formCard = (
+    <div style={cardFrame} ref={formAnchorRef}>
+      {cardHeader}
+      <ReferredBadge t={t} referrerName={referrerName} />
+      {funnel}
+      {s.draw && <div style={mono(9.5, { letterSpacing: 0.8, color: PC.mut, textAlign: 'center' })}>{TRUST_ROW}</div>}
+    </div>
+  );
+  if (!mobile) {
+    const mediaLeft = params.mediaSide !== 'right';
+    const formPane = (
+      <div style={{ width: '50%', padding: '44px 48px', display: 'flex', flexDirection: 'column', gap: 18, boxSizing: 'border-box' }}>
+        {cardHeader}
+        <div style={{ background: '#fff', borderRadius: 14, boxShadow: flush ? 'none' : '0 8px 28px rgba(23,24,27,.08)', border: flush ? `1px solid ${PC.line}` : 'none', padding: 22 }} ref={formAnchorRef}>
+          <ReferredBadge t={t} referrerName={referrerName} />
+          {funnel}
+        </div>
+        {s.draw && <div style={mono(10.5, { letterSpacing: 0.8, color: PC.mut, textAlign: 'center' })}>{TRUST_ROW}</div>}
+        {content.paragraphs.map((p, i) => (
+          <div key={i} style={{ fontSize: 13.5, lineHeight: 1.55, color: PC.body, fontFamily: SANS }}>{p}</div>
+        ))}
+        <div style={{ marginTop: 'auto' }}>
+          <DrawFootnotes draw={s.draw} linkColor={accent} mutedColor={PC.mut} faintColor={PC.faint} content={content} t={t} />
+        </div>
+      </div>
+    );
+    const heroPane = <div style={{ width: '50%', position: 'relative', background: PC.heroInk }}>
+      <BackdropMedia t={t} media={content.media} />
+      <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(rgba(18,19,28,.1) 40%, rgba(18,19,28,.7))' }} />
+      <div style={{ position: 'absolute', top: 26, left: 32, fontWeight: 800, fontSize: 20, color: '#fff', fontFamily: SANS }}>{content.wordmark}</div>
+      <div style={{ position: 'absolute', left: 32, right: 32, bottom: 36, color: '#fff', display: 'flex', flexDirection: 'column', gap: 10 }}>
+        <div style={{ fontFamily: SERIF, fontWeight: 600, fontSize: 46, lineHeight: 1.1 }}>{content.headline}</div>
+        {content.subheadline && <div style={{ fontSize: 17, color: 'rgba(255,255,255,.88)', fontFamily: SANS, whiteSpace: 'pre-line' }}>{content.subheadline}</div>}
+      </div>
+    </div>;
+    return (
+      <div style={{ minHeight: '100vh', background: PC.bg, display: 'flex', fontFamily: SANS, color: PC.ink }}>
+        {mediaLeft ? <>{heroPane}{formPane}</> : <>{formPane}{heroPane}</>}
+      </div>
+    );
+  }
+  return (
+    <div style={{ minHeight: '100vh', background: PC.bg, display: 'flex', flexDirection: 'column', fontFamily: SANS, color: PC.ink }}>
+      {hero}
+      {formCard}
+      {belowCard}
+    </div>
+  );
+}
+
+// ═══════════════════════════════ GAZETTE ═══════════════════════════════
+
+const GZ = { bg: '#FBF7EE', ink: '#1B1A17', body: '#4A463C', mut: '#6B6558', faint: '#9A948A', hair: '#E6E0D1', gold: '#C89B3C' };
+
+function gazetteSerial(campaignName, closesAt) {
+  const initials = (campaignName || '')
+    .split(/\s+/)
+    .map((w) => w[0])
+    .filter((c) => /[a-zA-Z]/.test(c || ''))
+    .slice(0, 3)
+    .join('')
+    .toUpperCase() || 'DRW';
+  const year = typeof closesAt === 'string' ? closesAt.slice(0, 4) : '';
+  return `SER. ${initials}${year ? `-${year}` : ''}`;
+}
+
+function GazetteMasthead({ content, kickerText }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', borderBottom: `2px solid ${GZ.ink}`, paddingBottom: 10, gap: 12 }}>
+      <div style={{ fontWeight: 800, fontSize: 17, fontFamily: SANS }}>{content.wordmark}</div>
+      <div style={mono(10, { letterSpacing: 1.6, color: GZ.mut, textAlign: 'right' })}>{kickerText}</div>
+    </div>
+  );
+}
+
+function Gazette({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile, referrerName, campaignName }) {
+  const accent = t.accent;
+  const s = drawStrings(luckyDraw, campaignName);
+  const dense = params.ruleDensity === 'dense';
+  const rowPad = dense ? '6px 0' : '10px 0';
+  const linkColor = params.accentUse === 'text' ? GZ.ink : accent;
+  const factRow = (label, node, last = false) => (
+    <div key={label} style={{ display: 'flex', gap: 14, borderTop: `1px solid ${GZ.hair}`, ...(last ? { borderBottom: `1px solid ${GZ.hair}` } : {}), padding: rowPad }}>
+      <div style={mono(10.5, { letterSpacing: 1, color: GZ.mut, paddingTop: 2, width: mobile ? 72 : 86, flexShrink: 0 })}>{label}</div>
+      <div style={{ fontSize: mobile ? 13.5 : 15, fontFamily: SANS }}>{node}</div>
+    </div>
+  );
+  const factTable = s.draw && (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      {factRow('PRIZE', <strong>{s.prize || content.headline}</strong>)}
+      {factRow('CLOSES', <strong>{s.closesFull} · 23:59 SGT</strong>)}
+      {factRow('ENTRY', 'One per verified mobile · SMS-verified · Free · 18+')}
+      {factRow('BOOST', `×${s.multiplier} when a consultant meets you and scans your pass at a free 20-min review`, true)}
+    </div>
+  );
+  const photoPlate = content.media.kind !== 'none' && content.media.src ? (
+    <div style={{ borderTop: `1px solid ${GZ.hair}`, borderBottom: `1px solid ${GZ.hair}`, padding: '10px 0 8px', display: 'flex', flexDirection: 'column', gap: 7 }}>
+      <div style={{ height: mobile ? 130 : 170, overflow: 'hidden', position: 'relative' }}>
+        <BackdropMedia t={t} media={content.media} />
+      </div>
+      <div style={mono(9, { letterSpacing: 1.2, color: GZ.mut })}>PRIZE DESTINATION</div>
+    </div>
+  ) : null;
+  const formBox = (
+    <div ref={formAnchorRef} style={{ border: `1.5px solid ${GZ.ink}`, padding: 16, display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div style={mono(10.5, { letterSpacing: 1.6, fontWeight: 600 })}>ENTRY FORM — 01</div>
+        {params.showSerial !== false && <div style={mono(10, { color: GZ.mut })}>{gazetteSerial(campaignName, s.draw?.closesAt)}</div>}
+      </div>
+      <ReferredBadge t={t} referrerName={referrerName} />
+      {funnel}
+      {s.draw && <div style={mono(9.5, { letterSpacing: 0.8, color: GZ.mut, textAlign: 'center' })}>{TRUST_ROW}</div>}
+    </div>
+  );
+  const footnotes = (
+    <DrawFootnotes draw={s.draw} linkColor={linkColor} mutedColor={GZ.mut} faintColor={GZ.faint} content={content} t={t} center={mobile} />
+  );
+  if (!mobile) {
+    return (
+      <div style={{ minHeight: '100vh', background: GZ.bg, padding: '36px 56px', boxSizing: 'border-box', display: 'flex', flexDirection: 'column', gap: 26, fontFamily: SANS, color: GZ.ink }}>
+        <GazetteMasthead content={content} kickerText={`OFFICIAL ENTRY FORM${s.kicker ? ` · ${s.kicker}` : ''}`} />
+        <div style={{ display: 'flex', gap: 56 }}>
+          <div style={{ flex: 1.1, display: 'flex', flexDirection: 'column', gap: 20 }}>
+            <div style={{ fontFamily: SERIF, fontWeight: 600, fontSize: 52, lineHeight: 1.08 }}>{content.headline}</div>
+            {content.paragraphs.map((p, i) => (
+              <div key={i} style={{ fontSize: 16, lineHeight: 1.55, color: GZ.mut }}>{p}</div>
+            ))}
+            {photoPlate}
+            {factTable}
+            {content.emphasis && <div style={serifItalic(19, { color: GZ.ink })}>{content.emphasis}</div>}
+            {footnotes}
+          </div>
+          <div style={{ width: 400, flexShrink: 0 }}>{formBox}</div>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div style={{ minHeight: '100vh', background: GZ.bg, display: 'flex', flexDirection: 'column', padding: '18px 20px 24px', boxSizing: 'border-box', fontFamily: SANS, color: GZ.ink }}>
+      <GazetteMasthead content={content} kickerText="OFFICIAL ENTRY FORM" />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 18, paddingTop: 20 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <div style={{ fontFamily: SERIF, fontWeight: 600, fontSize: 36, lineHeight: 1.1 }}>{content.headline}</div>
+          {content.subheadline && <div style={{ fontSize: 14, lineHeight: 1.5, color: GZ.mut, whiteSpace: 'pre-line' }}>{content.subheadline}</div>}
+        </div>
+        {photoPlate}
+        {factTable}
+        {formBox}
+        {footnotes}
+      </div>
+    </div>
+  );
+}
+
+// ═══════════════════════════════ NIGHTFALL ═══════════════════════════════
+
+const NF = { bg: '#14161F', ink: '#F2F1EC', body: '#C9CBD6', mut: '#A7A9B8', faint: '#6E7180', border: 'rgba(242,241,236,.18)' };
+
+function Nightfall({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile, referrerName, campaignName, formJumpActive = false }) {
+  const accent = t.accent;
+  const s = drawStrings(luckyDraw, campaignName);
+  const [sheetOpen, setSheetOpen] = useState(formJumpActive);
+  const days = s.draw && params.showCountdown !== false ? drawDaysLeft(s.draw.closesAt) : null;
+  const scrim = params.overlayTone === 'dusk'
+    ? 'linear-gradient(rgba(43,36,54,.22) 30%, rgba(28,24,38,.86) 78%)'
+    : 'linear-gradient(rgba(20,22,31,.30) 30%, rgba(20,22,31,.92) 78%)';
+  const ctaRadius = params.ctaStyle === 'pill' ? 999 : 10;
+  const countdownChip = days !== null && (
+    <div style={{ alignSelf: 'flex-start', border: '1px solid rgba(255,255,255,.35)', borderRadius: 99, padding: '6px 12px', ...mono(10.5, { letterSpacing: 1.2, color: '#fff' }) }}>
+      {`${days} DAYS LEFT · CLOSES ${s.closesMono}`}
+    </div>
+  );
+  const trustLine = s.draw && (
+    <div style={mono(9.5, { letterSpacing: 0.8, color: 'rgba(255,255,255,.65)' })}>{TRUST_ROW}</div>
+  );
+  if (!mobile) {
+    return (
+      <div style={{ minHeight: '100vh', background: NF.bg, position: 'relative', display: 'flex', flexDirection: 'column', fontFamily: SANS }}>
+        <BackdropMedia t={t} media={content.media} />
+        <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(100deg, rgba(20,22,31,.9) 34%, rgba(20,22,31,.35))' }} />
+        <div style={{ position: 'relative', display: 'flex', justifyContent: 'space-between', padding: '26px 40px' }}>
+          <div style={{ fontWeight: 800, fontSize: 20, color: '#fff' }}>{content.wordmark}</div>
+          {s.draw && <div style={mono(11, { letterSpacing: 1.6, color: 'rgba(255,255,255,.8)' })}>FREE ENTRY · 18+</div>}
+        </div>
+        <div style={{ position: 'relative', flex: 1, display: 'flex', alignItems: 'center', gap: 60, padding: '0 56px 40px' }}>
+          <div style={{ flex: 1, color: '#fff', display: 'flex', flexDirection: 'column', gap: 16 }}>
+            {countdownChip}
+            <div style={{ fontFamily: SERIF, fontWeight: 600, fontSize: 58, lineHeight: 1.06 }}>{content.headline}</div>
+            {content.subheadline && <div style={{ fontSize: 18, lineHeight: 1.5, color: 'rgba(255,255,255,.85)', maxWidth: 440, whiteSpace: 'pre-line' }}>{content.subheadline}</div>}
+            {trustLine}
+            {s.draw && (
+              <div style={{ fontSize: 12.5, color: 'rgba(255,255,255,.6)' }}>
+                {SCAM_LINE} Masked results at <WinnersLink color="#fff" />.
+              </div>
+            )}
+          </div>
+          <div ref={formAnchorRef} style={{ width: 400, flexShrink: 0, background: '#fff', borderRadius: 16, padding: 24, boxShadow: '0 24px 60px rgba(0,0,0,.45)', display: 'flex', flexDirection: 'column', gap: 12 }}>
+            {content.emphasis && <div style={{ ...serifItalic(20), color: '#17181B' }}>{content.emphasis}</div>}
+            <ReferredBadge t={t} referrerName={referrerName} />
+            {funnel}
+          </div>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div style={{ minHeight: '100vh', background: NF.bg, color: NF.ink, display: 'flex', flexDirection: 'column', position: 'relative', fontFamily: SANS }}>
+      <div style={{ position: 'relative', minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+        <BackdropMedia t={t} media={content.media} />
+        <div style={{ position: 'absolute', inset: 0, background: scrim }} />
+        <div style={{ position: 'relative', display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '18px 20px' }}>
+          <div style={{ fontWeight: 800, fontSize: 17, color: '#fff' }}>{content.wordmark}</div>
+          {s.draw && <div style={mono(10, { letterSpacing: 1.5, color: 'rgba(255,255,255,.8)' })}>FREE ENTRY · 18+</div>}
+        </div>
+        <div style={{ position: 'relative', flex: 1 }} />
+        <div style={{ position: 'relative', padding: '0 22px 18px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+          {countdownChip}
+          <div style={{ fontFamily: SERIF, fontWeight: 600, fontSize: 40, lineHeight: 1.08, color: '#fff' }}>{content.headline}</div>
+          {content.subheadline && <div style={{ fontSize: 15, lineHeight: 1.5, color: 'rgba(255,255,255,.85)', whiteSpace: 'pre-line' }}>{content.subheadline}</div>}
+          {trustLine}
+          <button
+            type="button"
+            onClick={() => setSheetOpen(true)}
+            style={{ background: accent, color: '#fff', border: 'none', borderRadius: ctaRadius, padding: 16, fontSize: 16, fontWeight: 700, fontFamily: SANS, cursor: 'pointer' }}
+          >
+            {content.submitLabel}
+          </button>
+          {s.draw && (
+            <div style={mono(9.5, { letterSpacing: 0.8, color: 'rgba(255,255,255,.65)', textAlign: 'center' })}>
+              {`THEN MEET A CONSULTANT · PASS SCANNED · ENTRY ×${s.multiplier}`}
+            </div>
+          )}
+          {s.draw && <div style={{ fontSize: 11.5, color: 'rgba(255,255,255,.6)', textAlign: 'center' }}>{SCAM_LINE}</div>}
+        </div>
+      </div>
+      <div style={{ padding: '26px 22px 30px', display: 'flex', flexDirection: 'column', gap: 16 }}>
+        {content.emphasis && <div style={{ ...serifItalic(20), color: NF.ink }}>{content.emphasis}</div>}
+        {content.paragraphs.map((p, i) => (
+          <div key={i} style={{ fontSize: 14, lineHeight: 1.6, color: NF.mut }}>{p}</div>
+        ))}
+        {s.draw && (
+          <div style={{ border: `1px solid ${NF.border}`, borderRadius: 12, padding: 16, display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <div style={mono(11, { letterSpacing: 1.5, color: accent, fontWeight: 600 })}>{`MAKE IT ×${s.multiplier}`}</div>
+            <div style={{ fontSize: 13.5, lineHeight: 1.55, color: NF.body }}>{s.boostBody}</div>
+          </div>
+        )}
+        {s.draw && (
+          <div style={{ fontSize: 12.5, color: NF.mut }}>
+            Winner contacted directly. Masked results at <WinnersLink color="#fff" />.
+          </div>
+        )}
+        <div style={{ fontSize: 11, color: NF.faint }}>{content.regulatory}</div>
+      </div>
+      {sheetOpen && (
+        <div
+          onClick={() => setSheetOpen(false)}
+          style={{ position: 'fixed', inset: 0, background: 'rgba(10,11,18,.55)', zIndex: 40 }}
+        />
+      )}
+      <div
+        style={{
+          position: 'fixed', left: 0, right: 0, bottom: 0, zIndex: 41,
+          background: '#fff', color: '#17181B', borderRadius: '18px 18px 0 0',
+          padding: '18px 20px 22px', boxShadow: '0 -12px 40px rgba(0,0,0,.4)',
+          maxHeight: '88vh', overflowY: 'auto',
+          display: sheetOpen ? 'flex' : 'none', flexDirection: 'column', gap: 14,
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 10 }}>
+          <div style={serifItalic(19, { color: '#17181B' })}>{content.emphasis || content.headline}</div>
+          <button
+            type="button"
+            onClick={() => setSheetOpen(false)}
+            aria-label="Close entry form"
+            style={{ border: 'none', background: '#F0EDE5', borderRadius: 99, width: 28, height: 28, fontSize: 14, cursor: 'pointer', color: '#6B6558', flexShrink: 0 }}
+          >
+            ✕
+          </button>
+        </div>
+        <div ref={formAnchorRef}>
+          <ReferredBadge t={t} referrerName={referrerName} />
+          {funnel}
+        </div>
+        {s.draw && <div style={mono(9.5, { letterSpacing: 0.8, color: '#8B8477', textAlign: 'center' })}>{TRUST_ROW}</div>}
+      </div>
+    </div>
+  );
+}
+
+// ═══════════════════════════════ STUB ═══════════════════════════════
+
+const ST = { bg: '#EFEBE0', ink: '#1B1A17', body: '#4A463C', mut: '#6B6558', faint: '#9A948A', dash: '#D9D4C8', line: '#DDD8CB' };
+
+function Perforation({ children, notchColor }) {
+  return (
+    <div style={{ position: 'relative', borderTop: `2px dashed ${ST.dash}` }}>
+      <div style={{ position: 'absolute', left: -9, top: -9, width: 18, height: 18, borderRadius: '50%', background: notchColor }} />
+      <div style={{ position: 'absolute', right: -9, top: -9, width: 18, height: 18, borderRadius: '50%', background: notchColor }} />
+      {children}
+    </div>
+  );
+}
+
+function StubHeader({ content }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '0 4px' }}>
+      <div style={{ fontWeight: 800, fontSize: 17, fontFamily: SANS }}>{content.wordmark}</div>
+      <div style={mono(10, { letterSpacing: 1.5, color: ST.mut })}>FREE ENTRY · 18+</div>
+    </div>
+  );
+}
+
+function Stub({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile, referrerName, campaignName }) {
+  const accent = t.accent;
+  const s = drawStrings(luckyDraw, campaignName);
+  const accentTone = params.ticketTone === 'accent';
+  const hasMedia = content.media.kind !== 'none' && !!content.media.src;
+  const ticketHead = (
+    <div style={{ position: 'relative', padding: mobile ? '16px 18px' : '22px 28px', display: 'flex', flexDirection: 'column', gap: 6, overflow: 'hidden', background: accentTone ? accent : '#17181B' }}>
+      {!accentTone && hasMedia && <BackdropMedia t={t} media={content.media} />}
+      {!accentTone && <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(rgba(23,24,27,.34), rgba(23,24,27,.62))' }} />}
+      <div style={{ position: 'relative', display: 'flex', justifyContent: 'space-between', gap: 10 }}>
+        <div style={mono(10, { letterSpacing: 1.6, color: 'rgba(255,255,255,.92)', fontWeight: 600 })}>{s.kicker || content.wordmark.toUpperCase()}</div>
+        {s.draw && <div style={mono(10, { letterSpacing: 1.6, color: 'rgba(255,255,255,.92)', fontWeight: 600 })}>ADMIT 1 ENTRY</div>}
+      </div>
+      <div style={{ position: 'relative', fontFamily: SERIF, fontWeight: 600, fontSize: mobile ? 29 : 36, lineHeight: 1.12, color: '#fff' }}>{content.headline}</div>
+      {content.subheadline && <div style={{ position: 'relative', fontSize: mobile ? 13.5 : 14.5, color: 'rgba(255,255,255,.88)', fontFamily: SANS, whiteSpace: 'pre-line' }}>{content.subheadline}</div>}
+    </div>
+  );
+  const stubLine = s.draw && (
+    <div style={{ padding: '13px 18px', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 10 }}>
+      <div style={mono(10.5, { letterSpacing: 1, color: ST.ink, fontWeight: 600 })}>{`CLOSES ${s.closesMono} · 23:59 SGT`}</div>
+      {params.showSerial !== false && <div style={mono(10.5, { color: '#8B8477' })}>NO. 0000001</div>}
+    </div>
+  );
+  const formBody = (
+    <div ref={formAnchorRef} style={{ padding: mobile ? '16px 18px' : '22px 28px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <ReferredBadge t={t} referrerName={referrerName} />
+      {funnel}
+    </div>
+  );
+  if (!mobile) {
+    return (
+      <div style={{ minHeight: '100vh', background: ST.bg, padding: '34px 0', boxSizing: 'border-box', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 18, fontFamily: SANS, color: ST.ink }}>
+        <div style={{ width: 760, maxWidth: 'calc(100vw - 48px)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <div style={{ fontWeight: 800, fontSize: 20 }}>{content.wordmark}</div>
+          <div style={mono(11, { letterSpacing: 1.5, color: ST.mut })}>FREE ENTRY · 18+</div>
+        </div>
+        <div style={{ width: 760, maxWidth: 'calc(100vw - 48px)', background: '#fff', borderRadius: 14, boxShadow: '0 10px 30px rgba(27,26,23,.09)', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+          {ticketHead}
+          <div style={{ display: 'flex' }}>
+            <div style={{ flex: 1, borderRight: `2px dashed ${ST.dash}` }}>{formBody}</div>
+            <div style={{ width: 250, padding: '22px 24px', display: 'flex', flexDirection: 'column', gap: 14, boxSizing: 'border-box' }}>
+              {s.draw && <div style={mono(10.5, { letterSpacing: 1, fontWeight: 600 })}>{`CLOSES ${s.closesMono}`}<br />23:59 SGT</div>}
+              {s.draw && (
+                <div style={{ fontSize: 12.5, lineHeight: 1.55, color: ST.body }}>
+                  <strong>Make it ×{s.multiplier}.</strong> {s.boostBody}
+                </div>
+              )}
+              {params.showSerial !== false && <div style={{ marginTop: 'auto', ...mono(10, { color: '#8B8477' }) }}>NO. 0000001</div>}
+            </div>
+          </div>
+        </div>
+        <div style={{ width: 760, maxWidth: 'calc(100vw - 48px)', display: 'flex', flexDirection: 'column', gap: 8, textAlign: 'center' }}>
+          {s.draw && <div style={mono(10, { letterSpacing: 0.8, color: '#8B8477' })}>{TRUST_ROW}</div>}
+          <DrawFootnotes draw={s.draw} linkColor={accent} mutedColor={ST.mut} faintColor={ST.faint} content={content} t={t} center />
+        </div>
+      </div>
+    );
+  }
+  const ticket = (
+    <div style={{ background: '#fff', borderRadius: 12, boxShadow: '0 6px 22px rgba(27,26,23,.08)', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+      {params.stubEdge === 'top' ? (
+        <>
+          {stubLine && <div>{stubLine}<Perforation notchColor="#FFFFFF"><span /></Perforation></div>}
+          {ticketHead}
+          {formBody}
+        </>
+      ) : (
+        <>
+          {ticketHead}
+          {formBody}
+          {stubLine && <Perforation notchColor={ST.bg}>{stubLine}</Perforation>}
+        </>
+      )}
+    </div>
+  );
+  return (
+    <div style={{ minHeight: '100vh', background: ST.bg, display: 'flex', flexDirection: 'column', padding: '18px 16px 26px', boxSizing: 'border-box', gap: 14, fontFamily: SANS, color: ST.ink }}>
+      <StubHeader content={content} />
+      {ticket}
+      {s.draw && <div style={mono(9.5, { letterSpacing: 0.8, color: '#8B8477', textAlign: 'center' })}>{TRUST_ROW}</div>}
+      {s.draw && (
+        <div style={{ background: '#fff', borderRadius: 12, padding: '16px 18px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <div style={mono(11, { letterSpacing: 1.5, color: accent, fontWeight: 600 })}>{`MAKE IT ×${s.multiplier}`}</div>
+          <div style={{ fontSize: 13.5, lineHeight: 1.55, color: ST.body }}>{s.boostBody}</div>
+        </div>
+      )}
+      {content.paragraphs.map((p, i) => (
+        <div key={i} style={{ fontSize: 14, lineHeight: 1.55, color: ST.body, padding: '0 6px' }}>{p}</div>
+      ))}
+      {content.emphasis && <div style={{ fontSize: 15, fontWeight: 700, color: ST.ink, padding: '0 6px' }}>{content.emphasis}</div>}
+      <div style={{ borderTop: `1px solid ${ST.line}`, padding: '12px 6px 0' }}>
+        <DrawFootnotes draw={s.draw} linkColor={accent} mutedColor={ST.mut} faintColor={ST.faint} content={content} t={t} />
+      </div>
+    </div>
+  );
+}
+
+// ═══════════════════════════════ CHECKLIST ═══════════════════════════════
+
+const CL = { bg: '#FFFFFF', ink: '#17181B', body: '#4A463C', mut: '#6B6558', faint: '#9A948A', line: '#E9E6DD', railBg: '#F3F1EA' };
+
+function ChecklistHeader({ content, s }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <div style={{ fontWeight: 800, fontSize: 17, fontFamily: SANS }}>{content.wordmark}</div>
+      {s.closesMono && <div style={mono(10, { letterSpacing: 1.5, color: '#8B8477' })}>{`CLOSES ${s.closesMono}`}</div>}
+    </div>
+  );
+}
+
+function Checklist({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile, referrerName, campaignName }) {
+  const accent = t.accent;
+  const s = drawStrings(luckyDraw, campaignName);
+  const hasMedia = content.media.kind !== 'none' && !!content.media.src;
+  const showBand = params.heroBand !== false && hasMedia;
+  const rail = params.railStyle === 'dots'
+    ? { width: 0, borderLeft: `2px dotted ${CL.line}` }
+    : { width: 2, background: CL.line };
+  const circle = (inner, kind) => (
+    <div
+      style={{
+        width: 26, height: 26, borderRadius: '50%', flexShrink: 0, boxSizing: 'border-box',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        fontFamily: kind === 'plus' ? MONO : SANS, fontSize: kind === 'plus' ? 10 : 12, fontWeight: 700,
+        ...(kind === 'filled' ? { background: accent, color: '#fff' } : {}),
+        ...(kind === 'outline' ? { border: `2px solid ${accent}`, color: accent } : {}),
+        ...(kind === 'plus' ? { background: CL.railBg, color: '#8B8477', fontWeight: 600 } : {}),
+      }}
+    >
+      {inner}
+    </div>
+  );
+  const spineStep = (key, circleNode, title, body, { last = false, children = null } = {}) => (
+    <div key={key} style={{ display: 'flex', gap: 14 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        {circleNode}
+        {!last && <div style={{ flex: 1, ...rail }} />}
+      </div>
+      <div style={{ flex: 1, paddingBottom: last ? 0 : 18, minWidth: 0, display: 'flex', flexDirection: 'column', gap: children ? 10 : 0 }}>
+        <div style={{ fontSize: 15, fontWeight: 700, paddingTop: 3, fontFamily: SANS }}>{title}</div>
+        {body && <div style={{ fontSize: 13, lineHeight: 1.5, color: CL.mut, marginTop: 4, fontFamily: SANS }}>{body}</div>}
+        {children}
+      </div>
+    </div>
+  );
+  const boostInline = s.draw && params.boostStep !== 'footnote';
+  const spine = (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      {spineStep('s1', circle('1', 'filled'), 'Drop your details', null, {
+        children: (
+          <div ref={formAnchorRef} style={{ border: `1px solid ${CL.line}`, borderRadius: 12, padding: 14 }}>
+            <ReferredBadge t={t} referrerName={referrerName} />
+            {funnel}
+          </div>
+        ),
+      })}
+      {spineStep('s2', circle('2', 'outline'), 'Verify with an SMS code', 'One entry per verified number — no bots, no multiple entries. Free, 18+.')}
+      {spineStep('s3', circle('3', 'outline'), s.draw ? "You're in the draw" : "You're in",
+        s.draw
+          ? `Your entry pass arrives by WhatsApp and email. One winner drawn after ${s.closesFull} in a witnessed process.`
+          : 'Your details are received securely and confirmed by email.',
+        { last: !boostInline })}
+      {boostInline && spineStep('s4', circle('+', 'plus'), `Bonus: make it ×${s.multiplier}`, s.boostBody, { last: true })}
+    </div>
+  );
+  const footnote = s.draw && params.boostStep === 'footnote' && (
+    <div style={{ fontSize: 12.5, lineHeight: 1.55, color: CL.mut, fontFamily: SANS }}>
+      <strong style={{ color: CL.ink }}>{`Bonus ×${s.multiplier}:`}</strong> {s.boostBody}
+    </div>
+  );
+  const footer = (
+    <div style={{ borderTop: `1px solid ${CL.line}`, paddingTop: 14, display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {s.draw && <div style={mono(9.5, { letterSpacing: 0.8, color: '#8B8477', textAlign: 'center' })}>{TRUST_ROW}</div>}
+      {footnote}
+      <DrawFootnotes draw={s.draw} linkColor={accent} mutedColor={CL.mut} faintColor={CL.faint} content={content} t={t} center />
+    </div>
+  );
+  if (!mobile) {
+    return (
+      <div style={{ minHeight: '100vh', background: CL.bg, padding: '34px 56px', boxSizing: 'border-box', display: 'flex', flexDirection: 'column', gap: 24, fontFamily: SANS, color: CL.ink }}>
+        <ChecklistHeader content={content} s={s} />
+        {showBand && (
+          <div style={{ position: 'relative', height: 190, borderRadius: 14, overflow: 'hidden' }}>
+            <BackdropMedia t={t} media={content.media} />
+            <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(rgba(23,24,27,0), rgba(23,24,27,.2))' }} />
+          </div>
+        )}
+        <div style={{ display: 'flex', gap: 56 }}>
+          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 20 }}>
+            <div style={{ fontFamily: SERIF, fontWeight: 600, fontSize: 48, lineHeight: 1.08 }}>{content.headline}</div>
+            {content.paragraphs.map((p, i) => (
+              <div key={i} style={{ fontSize: 16, lineHeight: 1.55, color: CL.mut }}>{p}</div>
+            ))}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <div style={{ display: 'flex', gap: 14 }}>{circle('1', 'filled')}<div style={{ fontSize: 14.5, lineHeight: 1.5, color: CL.body, paddingTop: 3 }}><strong>Drop your details</strong> in the form.</div></div>
+              <div style={{ display: 'flex', gap: 14 }}>{circle('2', 'outline')}<div style={{ fontSize: 14.5, lineHeight: 1.5, color: CL.body, paddingTop: 3 }}><strong>Verify with an SMS code</strong> — one entry per verified number.</div></div>
+              <div style={{ display: 'flex', gap: 14 }}>{circle('3', 'outline')}<div style={{ fontSize: 14.5, lineHeight: 1.5, color: CL.body, paddingTop: 3 }}><strong>{s.draw ? "You're in." : 'Done.'}</strong> {s.draw ? `Pass by WhatsApp/email; winner drawn after ${s.closesFull}.` : 'Your details are received securely.'}</div></div>
+              {s.draw && <div style={{ display: 'flex', gap: 14 }}>{circle('+', 'plus')}<div style={{ fontSize: 14.5, lineHeight: 1.5, color: CL.body, paddingTop: 3 }}><strong>Bonus ×{s.multiplier}:</strong> {s.boostBody}</div></div>}
+            </div>
+            {s.draw && (
+              <div style={{ fontSize: 13, color: CL.mut }}>
+                {SCAM_LINE} Masked results at <WinnersLink color={accent} />.
+              </div>
+            )}
+          </div>
+          <div style={{ width: 400, flexShrink: 0 }}>
+            <div ref={formAnchorRef} style={{ border: `1px solid ${CL.line}`, borderRadius: 14, padding: 22, display: 'flex', flexDirection: 'column', gap: 12 }}>
+              <ReferredBadge t={t} referrerName={referrerName} />
+              {funnel}
+              {s.draw && <div style={mono(9.5, { letterSpacing: 0.6, color: '#8B8477', textAlign: 'center' })}>{TRUST_ROW}</div>}
+            </div>
+          </div>
+        </div>
+        <div style={{ marginTop: 'auto', borderTop: `1px solid ${CL.line}`, paddingTop: 12 }}>
+          <DrawFootnotes draw={null} linkColor={accent} mutedColor={CL.mut} faintColor={CL.faint} content={content} t={t} />
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div style={{ minHeight: '100vh', background: CL.bg, display: 'flex', flexDirection: 'column', padding: '18px 20px 26px', boxSizing: 'border-box', gap: 16, fontFamily: SANS, color: CL.ink }}>
+      <ChecklistHeader content={content} s={s} />
+      {showBand && (
+        <div style={{ position: 'relative', height: 150, margin: '0 -20px', overflow: 'hidden' }}>
+          <BackdropMedia t={t} media={content.media} />
+          <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(rgba(23,24,27,0), rgba(23,24,27,.25))' }} />
+        </div>
+      )}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <div style={{ fontFamily: SERIF, fontWeight: 600, fontSize: 34, lineHeight: 1.12 }}>{content.headline}</div>
+        {content.subheadline && <div style={{ fontSize: 14, lineHeight: 1.5, color: CL.mut, whiteSpace: 'pre-line' }}>{content.subheadline}</div>}
+      </div>
+      {spine}
+      {footer}
+    </div>
+  );
+}
+
+// ═══════════════════════════════ SUCCESS ═══════════════════════════════
+
+/**
+ * The post-submit "you're in the draw" page. Mounted by LeadCapture instead of
+ * the generic SuccessState when the campaign is a v2 draw on one of the five
+ * draw templates. Chrome follows the template; content is shared.
+ */
+export function DrawSuccessPage({ campaign, submittedPhone = null }) {
+  const doc = campaign?.design_config || {};
+  const theme = resolveTheme(doc.theme || {});
+  const accent = theme.accent;
+  const content = deriveCampaignPageContent(doc);
+  const s = drawStrings(doc.luckyDraw, campaign?.name);
+  const templateId = DRAW_TEMPLATE_IDS.includes(doc.template?.id) ? doc.template.id : 'postcard';
+  const sub = successSubOf(submittedPhone);
+  const bookingUrl = s.draw?.bookingUrl || null;
+  const closesLine = s.closesMono ? `ENTRIES CLOSE ${s.closesMono} · 23:59 SGT` : '';
+
+  const chrome = {
+    postcard: {
+      pageBg: PC.bg, ink: PC.ink, body: PC.body, mut: PC.mut, divider: PC.line,
+      title: "You're in.", dot: accent, tenX: accent, label: 'NEXT STEP · EARN ×10 CHANCES',
+      box: { background: '#fff', borderRadius: 14, boxShadow: '0 8px 28px rgba(23,24,27,.08)' },
+      stepBg: accentSoftOf(accent), stepColor: accent, wordmark: true,
+    },
+    gazette: {
+      pageBg: GZ.bg, ink: GZ.ink, body: GZ.body, mut: GZ.mut, divider: GZ.hair,
+      title: 'Entered.', dot: GZ.gold, tenX: GZ.gold, label: 'NEXT STEP · EARN ×10 CHANCES',
+      box: { border: `1.5px solid ${GZ.ink}` },
+      stepBg: accentSoftOf(accent), stepColor: accent, masthead: true,
+    },
+    nightfall: {
+      pageBg: NF.bg, ink: NF.ink, body: NF.body, mut: NF.faint, divider: 'rgba(242,241,236,.14)',
+      title: "You're in.", dot: accent, tenX: accent, label: 'NEXT STEP · EARN ×10 CHANCES',
+      box: { border: `1px solid ${NF.border}`, borderRadius: 12 },
+      stepBg: 'rgba(242,241,236,.14)', stepColor: NF.ink, wordmark: true, dark: true,
+    },
+    stub: {
+      pageBg: ST.bg, ink: ST.ink, body: ST.body, mut: ST.mut, divider: ST.line,
+      title: "You're in.", dot: accent, tenX: accent, label: 'NEXT STEP · EARN ×10 CHANCES',
+      box: {}, stepBg: accentSoftOf(accent), stepColor: accent, ticket: true, header: true,
+    },
+    checklist: {
+      pageBg: CL.bg, ink: CL.ink, body: CL.body, mut: CL.mut, divider: CL.line,
+      title: "You're in.", dot: accent, tenX: accent, label: 'ONE STEP LEFT · EARN ×10 CHANCES',
+      box: { border: `1px solid ${CL.line}`, borderRadius: 12 },
+      stepBg: accentSoftOf(accent), stepColor: accent, check: true, header: true,
+    },
+  }[templateId];
+
+  const label = chrome.label.replace('×10', `×${s.multiplier}`);
+  const monoMut = chrome.dark ? NF.faint : '#8B8477';
+  const chances = (
+    <div style={{ ...chrome.box, padding: '14px 20px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+      <div style={mono(11, { letterSpacing: 1.5, color: templateId === 'gazette' ? GZ.ink : accent, fontWeight: 600 })}>CHANCES</div>
+      <ChancesRow accent={chrome.tenX} inkColor={chrome.ink} mutedColor={monoMut} multiplier={s.multiplier} />
+    </div>
+  );
+  const nextSteps = (
+    <div style={{ ...chrome.box, padding: 16, display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <NextSteps
+        s={s}
+        accent={templateId === 'gazette' ? accent : accent}
+        stepBg={chrome.stepBg}
+        stepColor={chrome.stepColor}
+        bodyColor={chrome.body}
+        lastColor={chrome.ink}
+        mutedColor={monoMut}
+        label={label}
+        bookingUrl={bookingUrl}
+      />
+    </div>
+  );
+  const intro = (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12, alignItems: 'flex-start' }}>
+      {chrome.check ? (
+        <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+          <div style={{ width: 26, height: 26, borderRadius: '50%', background: accent, color: '#fff', fontSize: 13, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>✓</div>
+          <div style={mono(10.5, { letterSpacing: 1.5, color: '#8B8477' })}>ENTRY VERIFIED · YOU'RE IN THE DRAW</div>
+        </div>
+      ) : (
+        <div style={{ width: 14, height: 14, borderRadius: '50%', background: chrome.dot }} />
+      )}
+      <div style={serifItalic(42, { color: chrome.ink })}>{chrome.title}</div>
+      <div style={{ fontSize: 14.5, lineHeight: 1.55, color: chrome.body, fontFamily: SANS }}>{sub}</div>
+    </div>
+  );
+  const footerLine = (
+    <div style={{ marginTop: 'auto', fontSize: 12.5, color: chrome.dark ? NF.mut : chrome.mut, borderTop: `1px solid ${chrome.divider}`, paddingTop: 14, fontFamily: SANS }}>
+      {SCAM_LINE} Results at <WinnersLink color={chrome.dark ? '#fff' : accent} />.
+    </div>
+  );
+
+  let body;
+  if (chrome.ticket) {
+    body = (
+      <>
+        <StubHeader content={content} />
+        <div style={{ background: '#fff', borderRadius: 12, boxShadow: '0 6px 22px rgba(27,26,23,.08)', overflow: 'hidden', marginTop: 20 }}>
+          <div style={{ background: accentSoftOf(accent), padding: 18, display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <div style={{ width: 14, height: 14, borderRadius: '50%', background: accent }} />
+            <div style={serifItalic(38, { color: ST.ink })}>{chrome.title}</div>
+            <div style={{ fontSize: 14, lineHeight: 1.55, color: ST.body, fontFamily: SANS }}>{sub}</div>
+          </div>
+          <div style={{ padding: '16px 18px 0', display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <div style={mono(11, { letterSpacing: 1.5, color: accent, fontWeight: 600 })}>CHANCES</div>
+            <ChancesRow accent={accent} inkColor={ST.ink} mutedColor="#8B8477" multiplier={s.multiplier} />
+          </div>
+          <div style={{ padding: '16px 18px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+            <NextSteps s={s} accent={accent} stepBg={accentSoftOf(accent)} stepColor={accent} bodyColor={ST.body} lastColor={ST.ink} mutedColor="#8B8477" label={label} bookingUrl={bookingUrl} />
+          </div>
+          {s.closesMono && (
+            <Perforation notchColor={ST.bg}>
+              <div style={{ padding: '13px 18px', ...mono(10.5, { letterSpacing: 1, color: ST.ink, fontWeight: 600 }) }}>{`ENTRY HELD · CLOSES ${s.closesMono}`}</div>
+            </Perforation>
+          )}
+        </div>
+        <div style={{ marginTop: 'auto', fontSize: 12.5, color: ST.mut, padding: '0 6px', fontFamily: SANS }}>{SCAM_LINE}</div>
+      </>
+    );
+  } else {
+    body = (
+      <>
+        {chrome.masthead && <GazetteMasthead content={content} kickerText="OFFICIAL ENTRY FORM" />}
+        {chrome.header && !chrome.masthead && <ChecklistHeader content={content} s={s} />}
+        {chrome.wordmark && <div style={{ fontWeight: 800, fontSize: 17, color: chrome.dark ? '#fff' : chrome.ink, fontFamily: SANS }}>{content.wordmark}</div>}
+        <div style={{ marginTop: chrome.masthead || chrome.header ? 22 : 26, display: 'flex', flexDirection: 'column', gap: 16 }}>
+          {intro}
+          {chances}
+          {nextSteps}
+          {closesLine && <div style={mono(10.5, { color: monoMut })}>{closesLine}</div>}
+        </div>
+        {footerLine}
+      </>
+    );
+  }
+
+  return (
+    <div
+      data-draw-success={templateId}
+      style={{ minHeight: '100vh', background: chrome.pageBg, color: chrome.ink, fontFamily: SANS, display: 'flex', flexDirection: 'column', boxSizing: 'border-box', padding: 20 }}
+    >
+      <div style={{ width: '100%', maxWidth: 560, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 16, flex: 1 }}>
+        {body}
+      </div>
+    </div>
+  );
+}
+
+// ═══════════════════════════════ CLOSED ═══════════════════════════════
+
+/**
+ * The designed draw-closed page for the five draw templates. Returns its
+ * per-template chrome; CampaignPageRenderer falls back to the generic
+ * BlockedPage for every other template.
+ */
+export function DrawClosedPage({ templateId, t, content, luckyDraw, campaignName }) {
+  const accent = t.accent;
+  const s = drawStrings(luckyDraw, campaignName);
+  const chrome = {
+    postcard: { pageBg: PC.bg, ink: PC.ink, body: PC.body, mut: '#8B8477', faint: PC.faint, divider: PC.line, cta: 'fill', wordmark: true },
+    gazette: { pageBg: GZ.bg, ink: GZ.ink, body: GZ.body, mut: '#8B8477', faint: GZ.faint, divider: GZ.hair, cta: 'outline', masthead: true },
+    nightfall: { pageBg: NF.bg, ink: '#fff', body: NF.body, mut: NF.faint, faint: NF.faint, divider: 'rgba(242,241,236,.14)', cta: 'fill', wordmark: true, dark: true },
+    stub: { pageBg: ST.bg, ink: ST.ink, body: ST.body, mut: '#8B8477', faint: ST.faint, divider: ST.line, cta: 'fill', header: true, card: true },
+    checklist: { pageBg: CL.bg, ink: CL.ink, body: CL.body, mut: '#8B8477', faint: CL.faint, divider: CL.line, cta: 'fill', header: true },
+  }[templateId];
+  if (!chrome) return null;
+
+  const ctaStyle = chrome.cta === 'outline'
+    ? { border: `1.5px solid ${GZ.ink}`, color: GZ.ink, background: 'transparent' }
+    : { background: accent, color: '#fff', border: 'none', borderRadius: 9 };
+  const cta = (
+    <a
+      href={WINNERS_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{ ...ctaStyle, textAlign: 'center', padding: 14, fontSize: 15, fontWeight: 700, fontFamily: SANS, textDecoration: 'none', display: 'block' }}
+    >
+      See the masked results — redeem.sg/winners
+    </a>
+  );
+  const core = (
+    <>
+      <div style={mono(11, { letterSpacing: 2, color: chrome.mut })}>{s.kicker}</div>
+      <div style={serifItalic(42, { color: chrome.ink })}>Entries closed.</div>
+      {s.closesMono && <div style={mono(11, { color: chrome.mut })}>{`${s.closesMono} · 23:59 SGT`}</div>}
+      <div style={{ fontSize: 14.5, lineHeight: 1.55, color: chrome.body, fontFamily: SANS }}>{s.closedBody}</div>
+      <div style={{ fontSize: 13, color: chrome.dark ? NF.mut : '#6B6558', fontFamily: SANS }}>{SCAM_LINE}</div>
+    </>
+  );
+  return (
+    <div
+      data-campaign-page-blocked="draw"
+      data-draw-closed={templateId}
+      style={{ minHeight: '100vh', background: chrome.pageBg, color: chrome.ink, fontFamily: SANS, display: 'flex', flexDirection: 'column', boxSizing: 'border-box', padding: 20 }}
+    >
+      <div style={{ width: '100%', maxWidth: 560, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 14, flex: 1 }}>
+        {chrome.masthead && <GazetteMasthead content={content} kickerText="OFFICIAL ENTRY FORM" />}
+        {chrome.header && <StubHeader content={content} />}
+        {chrome.wordmark && <div style={{ fontWeight: 800, fontSize: 17, color: chrome.ink, fontFamily: SANS }}>{content.wordmark}</div>}
+        {chrome.card ? (
+          <div style={{ background: '#fff', borderRadius: 12, boxShadow: '0 6px 22px rgba(27,26,23,.08)', padding: '22px 18px', display: 'flex', flexDirection: 'column', gap: 12, marginTop: 26 }}>
+            {core}
+            {cta}
+          </div>
+        ) : (
+          <div style={{ marginTop: 34, display: 'flex', flexDirection: 'column', gap: 14 }}>
+            {core}
+            {cta}
+          </div>
+        )}
+        <div style={{ marginTop: 'auto', fontSize: 11, color: chrome.faint, borderTop: `1px solid ${chrome.divider}`, paddingTop: 12, fontFamily: SANS }}>
+          {content.regulatory}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const DRAW_TEMPLATES = {
+  postcard: Postcard,
+  gazette: Gazette,
+  nightfall: Nightfall,
+  stub: Stub,
+  checklist: Checklist,
+};
+
+export const DRAW_TEMPLATE_IDS = Object.keys(DRAW_TEMPLATES);

--- a/src/components/studio/panels/PagePanel.jsx
+++ b/src/components/studio/panels/PagePanel.jsx
@@ -21,7 +21,16 @@ const TEMPLATE_NAMES = {
   spotlight: 'Spotlight',
   express: 'Express',
   journey: 'Journey',
+  postcard: 'Postcard',
+  gazette: 'Gazette',
+  nightfall: 'Nightfall',
+  stub: 'Stub',
+  checklist: 'Checklist',
 };
+
+/** The five draw-focused directions (drawTemplates.jsx) — art-directed for
+ * lucky-draw campaigns; safe on non-draw campaigns (draw chrome hides). */
+const DRAW_TEMPLATE_SET = new Set(['postcard', 'gazette', 'nightfall', 'stub', 'checklist']);
 
 export default function PagePanel({ doc, setPath, mut, onSuggest = null, mediaHint = null, onDismissMediaHint = null }) {
   // Per-field ✦ (Studio PR 4) — the five Page identity fields open the AI
@@ -106,8 +115,8 @@ export default function PagePanel({ doc, setPath, mut, onSuggest = null, mediaHi
                   <span
                     style={{
                       position: 'absolute',
-                      inset: id === 'poster' ? 0 : id === 'split' ? '0 52% 0 0' : '12% 8% 55% 8%',
-                      background: id === 'express' ? 'transparent' : t.dark ? 'rgba(255,255,255,.14)' : 'rgba(0,0,0,.08)',
+                      inset: id === 'poster' || id === 'nightfall' ? 0 : id === 'split' ? '0 52% 0 0' : '12% 8% 55% 8%',
+                      background: id === 'express' ? 'transparent' : id === 'nightfall' ? 'rgba(20,22,31,.85)' : t.dark ? 'rgba(255,255,255,.14)' : 'rgba(0,0,0,.08)',
                       borderRadius: 4,
                     }}
                   />
@@ -219,6 +228,124 @@ export default function PagePanel({ doc, setPath, mut, onSuggest = null, mediaHi
               onChange={(v) => setPath('template.params.journey.stickyCta', v)}
             />
           </>
+        )}
+        {templateId === 'postcard' && (
+          <>
+            <Seg
+              label="Desktop media side"
+              options={[{ value: 'left', label: 'Left' }, { value: 'right', label: 'Right' }]}
+              value={params.mediaSide || 'left'}
+              onChange={(v) => setPath('template.params.postcard.mediaSide', v)}
+            />
+            <Seg
+              label="Form card"
+              options={[{ value: 'float', label: 'Float' }, { value: 'flush', label: 'Flush' }]}
+              value={params.cardStyle || 'float'}
+              onChange={(v) => setPath('template.params.postcard.cardStyle', v)}
+            />
+            <Seg
+              label="Trust facts"
+              options={[{ value: 'numbered', label: 'Numbered' }, { value: 'inline', label: 'Inline' }]}
+              value={params.factStyle || 'numbered'}
+              onChange={(v) => setPath('template.params.postcard.factStyle', v)}
+            />
+          </>
+        )}
+        {templateId === 'gazette' && (
+          <>
+            <Seg
+              label="Rule density"
+              options={[{ value: 'airy', label: 'Airy' }, { value: 'dense', label: 'Dense' }]}
+              value={params.ruleDensity || 'airy'}
+              onChange={(v) => setPath('template.params.gazette.ruleDensity', v)}
+            />
+            <Seg
+              label="Accent use"
+              options={[{ value: 'fill', label: 'Fill' }, { value: 'text', label: 'Text' }]}
+              value={params.accentUse || 'fill'}
+              onChange={(v) => setPath('template.params.gazette.accentUse', v)}
+            />
+            <ToggleRow
+              id="studio-gz-serial"
+              label="Serial number"
+              checked={params.showSerial !== false}
+              onChange={(v) => setPath('template.params.gazette.showSerial', v)}
+            />
+          </>
+        )}
+        {templateId === 'nightfall' && (
+          <>
+            <Seg
+              label="Hero scrim"
+              options={[{ value: 'ink', label: 'Ink' }, { value: 'dusk', label: 'Dusk' }]}
+              value={params.overlayTone || 'ink'}
+              onChange={(v) => setPath('template.params.nightfall.overlayTone', v)}
+            />
+            <Seg
+              label="CTA shape"
+              options={[{ value: 'bar', label: 'Bar' }, { value: 'pill', label: 'Pill' }]}
+              value={params.ctaStyle || 'bar'}
+              onChange={(v) => setPath('template.params.nightfall.ctaStyle', v)}
+            />
+            <ToggleRow
+              id="studio-nf-countdown"
+              label="Days-left countdown chip"
+              checked={params.showCountdown !== false}
+              onChange={(v) => setPath('template.params.nightfall.showCountdown', v)}
+            />
+          </>
+        )}
+        {templateId === 'stub' && (
+          <>
+            <Seg
+              label="Ticket header"
+              options={[{ value: 'paper', label: 'Photo' }, { value: 'accent', label: 'Accent' }]}
+              value={params.ticketTone || 'paper'}
+              onChange={(v) => setPath('template.params.stub.ticketTone', v)}
+            />
+            <Seg
+              label="Perforated stub"
+              options={[{ value: 'bottom', label: 'Bottom' }, { value: 'top', label: 'Top' }]}
+              value={params.stubEdge || 'bottom'}
+              onChange={(v) => setPath('template.params.stub.stubEdge', v)}
+            />
+            <ToggleRow
+              id="studio-stub-serial"
+              label="Ticket number"
+              checked={params.showSerial !== false}
+              onChange={(v) => setPath('template.params.stub.showSerial', v)}
+            />
+          </>
+        )}
+        {templateId === 'checklist' && (
+          <>
+            <Seg
+              label="×10 boost step"
+              options={[{ value: 'inline', label: 'In the spine' }, { value: 'footnote', label: 'Footnote' }]}
+              value={params.boostStep || 'inline'}
+              onChange={(v) => setPath('template.params.checklist.boostStep', v)}
+            />
+            <Seg
+              label="Step spine"
+              options={[{ value: 'line', label: 'Line' }, { value: 'dots', label: 'Dots' }]}
+              value={params.railStyle || 'line'}
+              onChange={(v) => setPath('template.params.checklist.railStyle', v)}
+            />
+            <ToggleRow
+              id="studio-cl-heroband"
+              label="Slim hero band"
+              hint="Auto-hides when there is no media"
+              checked={params.heroBand !== false}
+              onChange={(v) => setPath('template.params.checklist.heroBand', v)}
+            />
+          </>
+        )}
+        {DRAW_TEMPLATE_SET.has(templateId) && (
+          <WarnNote tone="info">
+            Draw-focused template — art-directed neutrals with the theme accent.
+            Draw chrome (prize, close date, ×10) renders only when this campaign
+            has luckyDraw enabled.
+          </WarnNote>
         )}
       </PanelSection>
 

--- a/src/lib/designConfigV2.js
+++ b/src/lib/designConfigV2.js
@@ -14,7 +14,11 @@
 
 export const DESIGN_CONFIG_VERSION = 2;
 
-export const TEMPLATE_IDS = ['editorial', 'poster', 'split', 'spotlight', 'express', 'journey'];
+export const TEMPLATE_IDS = [
+  'editorial', 'poster', 'split', 'spotlight', 'express', 'journey',
+  // Draw-focused directions (drawTemplates.jsx, design review 2026-07-22).
+  'postcard', 'gazette', 'nightfall', 'stub', 'checklist',
+];
 
 /** Per-template parameter defaults — one bag, every template persists its
  * params across switches; first Studio use seeds these. Migration seeds the
@@ -27,6 +31,11 @@ export const TEMPLATE_PARAM_DEFAULTS = {
   spotlight: { introStyle: 'immersive', revealArt: 'meter' },
   express: { trustLine: '', storyFold: false },
   journey: { sectionRhythm: 'alternate', stickyCta: true },
+  postcard: { mediaSide: 'left', cardStyle: 'float', factStyle: 'numbered' },
+  gazette: { ruleDensity: 'airy', accentUse: 'fill', showSerial: true },
+  nightfall: { overlayTone: 'ink', showCountdown: true, ctaStyle: 'bar' },
+  stub: { ticketTone: 'paper', showSerial: true, stubEdge: 'bottom' },
+  checklist: { boostStep: 'inline', heroBand: true, railStyle: 'line' },
 };
 
 export const THEME_RADIUS_IDS = ['soft', 'sharp', 'round'];

--- a/src/pages/LeadCapture.jsx
+++ b/src/pages/LeadCapture.jsx
@@ -13,6 +13,7 @@ import LeadCaptureLayout, { TOKENS } from '../components/campaigns/LeadCaptureLa
 import { deriveLeadCaptureContent } from '../components/campaigns/leadCaptureContent';
 import GuidedReviewPage, { GuidedReviewSuccess } from '../components/campaigns/guided-review/GuidedReviewPage';
 import CampaignPageRenderer from '../components/campaignPage/CampaignPageRenderer';
+import { DrawSuccessPage, DRAW_TEMPLATE_IDS } from '../components/campaignPage/drawTemplates';
 import { isV2, resolveTheme } from '@/lib/designConfigV2';
 import {
   shouldTrack,
@@ -65,6 +66,8 @@ export default function LeadCapture() {
   // The created prospect's id — embedded in the share URL (?ref={id}) so a
   // friend's referred submit can be attributed back to this sharer.
   const [submittedProspectId, setSubmittedProspectId] = useState(null);
+  // Kept for the draw success screen's masked "Entry confirmed for +65 …" line.
+  const [submittedPhone, setSubmittedPhone] = useState(null);
   // The canonical short share link the backend minted at creation — identical to the one
   // in the confirmation email. Preferred over the locally-built long URL when present.
   const [serverShareUrl, setServerShareUrl] = useState(null);
@@ -360,6 +363,7 @@ export default function LeadCapture() {
         // Keep the new prospect's id so this submitter's share links carry
         // their identity (?ref={id}) instead of the anonymous ref=1.
         setSubmittedProspectId(result?.data?.prospect?.id || null);
+        setSubmittedPhone(formData.phone || null);
         // Canonical short share link minted server-side (matches the confirmation email).
         setServerShareUrl(result?.data?.shareUrl || null);
         // We email the confirmation (with this link) only when an email was provided.
@@ -568,6 +572,21 @@ export default function LeadCapture() {
   // (success / duplicate / error) keep their v1 behavior on the v2 theme
   // background (themed outcome screens ride the deferred widget-redesign PR).
   if (isV2(campaign?.design_config)) {
+    // Draw campaigns on the five draw templates get the designed "you're in
+    // the draw" page (drawTemplates.jsx) instead of the generic SuccessState.
+    const v2Doc = campaign.design_config;
+    if (
+      submitted &&
+      v2Doc.luckyDraw?.enabled === true &&
+      DRAW_TEMPLATE_IDS.includes(v2Doc.template?.id)
+    ) {
+      return (
+        <>
+          <DrawSuccessPage campaign={campaign} submittedPhone={submittedPhone} />
+          {shareDialog}
+        </>
+      );
+    }
     if (submitted || error) {
       const vt = resolveTheme(campaign.design_config.theme || {});
       return (

--- a/src/pages/__tests__/AdminCampaignStudio.test.jsx
+++ b/src/pages/__tests__/AdminCampaignStudio.test.jsx
@@ -95,7 +95,10 @@ describe('AdminCampaignStudio', () => {
     expect(dialog.textContent).toContain('"version": 2');
   });
 
-  it('F9: an unadopted AI look blocks the save; adopting unblocks it and saving commits (banner gone)', async () => {
+  // Heaviest test in the suite (full Studio render x several interactions);
+  // the 11-template picker put it over vitest's 5s default on the slower
+  // CI runner under coverage — explicit headroom, not a behavior change.
+  it('F9: an unadopted AI look blocks the save; adopting unblocks it and saving commits (banner gone)', { timeout: 15000 }, async () => {
     const LOOK = {
       name: 'Dusk Poster',
       rationale: 'High-contrast hero.',


### PR DESCRIPTION
Implements the chosen claude.ai/design gallery (`Campaign Templates.dc.html`, project "Design Review: Three Colorways") as five selectable design_config v2 templates, purpose-built for lucky-draw campaigns.

## What's in

- **`drawTemplates.jsx`** — Postcard (design's recommended default), Gazette (no-media proof), Nightfall (dark, bottom-sheet form), Stub (ticket metaphor), Checklist (mechanics-first). Art-directed: fixed neutral palettes + the campaign theme's accent; Fraunces / Albert Sans / JetBrains Mono (all already loaded globally).
- **Three states per direction**: OPEN (mobile + desktop), a designed **draw-closed page** (replaces the generic BlockedPage for these five), and a designed **"You're in." success page** (masked submitted phone, 1x→Nx chances, next-steps, optional Book CTA) replacing the generic SuccessState for v2 draw campaigns on these templates.
- **Draw chrome is conditional** on `luckyDraw.enabled` — selecting these templates on a non-draw campaign renders clean layouts (test-pinned).
- **Config twins** (`src/lib/designConfigV2.js` ↔ `backend/src/utils/designConfigV2.js`): `TEMPLATE_IDS` + `TEMPLATE_PARAM_DEFAULTS` extended in lockstep (lockstep test green). **Clamp**: per-template enum validation for every new param.
- **`luckyDraw.bookingUrl`** (new, admin-clamped, http(s) ≤300 chars, exposed in the public payload) powers the success screen's "Book your 20-min review" CTA; absent → CTA doesn't render.
- **Studio**: PagePanel picker entries + per-template param controls (Seg/Toggle per the clamp's enums) + draw-template info note.
- Renderer merges the draw registry at lookup time (module-scope spread would hit the `templates ↔ drawTemplates` import-cycle TDZ, entry-order dependent).

## Verification

- 22 new frontend tests (per-template open render, closed dispatch + fallback, success variants, params, pure helpers) — full vitest **1623/1623**.
- Backend: new bookingUrl / clamp / public-payload cases; draw + campaign + config suites green, incl. `campaigns.test.js` + `campaignPreviews.test.js` against a real throwaway Postgres (73 passing there are the ECONNRETURNED-without-DB pre-existing set).
- Production Vite build clean.

## Deploy safety

Dormant on merge: no existing campaign references the new template ids (all migrated campaigns are on the original six), so nothing changes until a template is picked in Studio. `bookingUrl` is absent on all stored configs → success CTA hidden until configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDco6HwKLHpmRgE5YR8Za2