### PR TITLE
fix(admin-v2): restore the campaign-type chooser on + New campaign

### DIFF
--- a/src/components/campaigns/CampaignTypeSelectionDialog.jsx
+++ b/src/components/campaigns/CampaignTypeSelectionDialog.jsx
@@ -6,7 +6,7 @@ import {
  DialogTitle,
 } from"@/components/ui/dialog";
 import { Button } from"@/components/ui/button";
-import { Car, ClipboardCheck, QrCode, Sparkles } from"lucide-react";
+import { ClipboardCheck, QrCode, Sparkles } from"lucide-react";
 
 export default function CampaignTypeSelectionDialog({ open, onOpenChange, onSelect }) {
  return (
@@ -19,22 +19,6 @@ export default function CampaignTypeSelectionDialog({ open, onOpenChange, onSele
  </DialogDescription>
  </DialogHeader>
  <div className="grid grid-cols-1 gap-4 py-4">
- <Button
- variant="outline" className="h-auto p-4 flex flex-col items-start gap-2 border-2 hover:border-ring hover:bg-primary/10 transition-colors text-left group" onClick={() => onSelect("brand_awareness")}
- >
- <div className="flex items-center w-full gap-3">
- <div className="p-2 bg-info/15 rounded-lg group-hover:bg-info/20 text-primary transition-colors">
- <Car className="w-6 h-6"/>
- </div>
- <div>
- <h3 className="font-semibold text-foreground">PHV Campaign</h3>
- <p className="text-sm text-muted-foreground font-normal mt-1 text-wrap">
- Display video or image ads on Private Hire Vehicles tablets. High visibility brand awareness.
- </p>
- </div>
- </div>
- </Button>
-
  <Button
  variant="outline" className="h-auto p-4 flex flex-col items-start gap-2 border-2 hover:border-success hover:bg-success/10 transition-colors text-left group" onClick={() => onSelect("lead_generation")}
  >

--- a/src/pages/adminv2/AdminV2Campaigns.jsx
+++ b/src/pages/adminv2/AdminV2Campaigns.jsx
@@ -5,12 +5,13 @@
  * and design stay on the existing flows (workspace / designer) — this screen
  * observes and navigates, it does not fork the editing surface.
  */
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { getMarketplaceListedFromDoc } from '@/lib/designConfigV2';
-import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useCampaignLeaderboard, useAttention } from '@/hooks/queries/useAdminV2';
 import { fmtNumber, fmtSGD, fmtDate, daysUntil } from '@/lib/adminV2/format';
 import { Chip, PageHeader, PeriodSwitch, Skeleton, ErrorState, EmptyState } from '@/components/adminv2/primitives';
+import CampaignTypeSelectionDialog from '@/components/campaigns/CampaignTypeSelectionDialog';
 
 const STATUS_TONE = { active: 'ok', draft: '', paused: 'warn', completed: '', archived: '' };
 const TYPE_LABELS = {
@@ -43,6 +44,14 @@ export default function AdminV2Campaigns() {
   const setPeriod = (p) => patch({ period: p === '30d' ? null : p });
   const setStatusFilter = (v) => patch({ status: v || null });
   const navigate = useNavigate();
+  // "+ New campaign" opens the type chooser first — the v2 rebuild had linked
+  // straight to the workspace, silently defaulting every campaign to
+  // lead_generation (the workspace honors ?type=; classic always sent it).
+  const [typeSelectOpen, setTypeSelectOpen] = useState(false);
+  const handleCreateCampaign = (type) => {
+    setTypeSelectOpen(false);
+    navigate(`${newCampaignHref()}?type=${type}`);
+  };
   const campaigns = useCampaignLeaderboard(period);
   const attention = useAttention();
   const zeroCommitIds = useMemo(
@@ -62,9 +71,13 @@ export default function AdminV2Campaigns() {
     <div>
       <PageHeader title="Campaigns" meta={`${fmtNumber(rows.length)} SHOWN${campaigns.data?.total > (campaigns.data?.rows || []).length ? ` OF ${fmtNumber(campaigns.data.total)} (NEWEST FIRST)` : ''} · SORTED BY LEADS · LAST ${period.toUpperCase()}`}>
         <PeriodSwitch value={period} onChange={setPeriod} />
-        <Link to={newCampaignHref()} className="av2-btn av2-btn--primary" style={{ textDecoration: 'none' }}>
+        <button
+          type="button"
+          className="av2-btn av2-btn--primary"
+          onClick={() => setTypeSelectOpen(true)}
+        >
           + New campaign
-        </Link>
+        </button>
       </PageHeader>
 
       {attention.isError && (
@@ -139,6 +152,11 @@ export default function AdminV2Campaigns() {
           );
         })}
       </div>
+      <CampaignTypeSelectionDialog
+        open={typeSelectOpen}
+        onOpenChange={setTypeSelectOpen}
+        onSelect={handleCreateCampaign}
+      />
     </div>
   );
 }

--- a/src/pages/adminv2/__tests__/AdminV2Campaigns.typeChooser.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2Campaigns.typeChooser.test.jsx
@@ -1,0 +1,59 @@
+/**
+ * "+ New campaign" must open the campaign-type chooser and thread the chosen
+ * type to the workspace as ?type= — the admin-v2 rebuild had linked straight
+ * to the workspace, silently creating every campaign as lead_generation.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+vi.mock('@/hooks/queries/useAdminV2', () => ({
+  useCampaignLeaderboard: () => ({ data: { rows: [], total: 0 }, isLoading: false, isError: false }),
+  useAttention: () => ({ data: { zeroCommitCampaigns: [] }, isLoading: false, isError: false }),
+}));
+
+import AdminV2Campaigns, { newCampaignHref } from '../AdminV2Campaigns';
+
+beforeEach(() => navigateMock.mockClear());
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <AdminV2Campaigns />
+    </MemoryRouter>
+  );
+
+describe('AdminV2Campaigns — new-campaign type chooser', () => {
+  it('opens the type dialog instead of navigating directly', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    expect(screen.queryByText('Create New Campaign')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: '+ New campaign' }));
+    expect(screen.getByText('Create New Campaign')).toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('selecting a type navigates to the workspace with ?type=', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByRole('button', { name: '+ New campaign' }));
+    await user.click(screen.getByText('Guided Review Campaign'));
+    expect(navigateMock).toHaveBeenCalledWith(`${newCampaignHref()}?type=guided_review`);
+  });
+
+  it('the retired PHV (brand_awareness) option is gone', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByRole('button', { name: '+ New campaign' }));
+    expect(screen.queryByText('PHV Campaign')).not.toBeInTheDocument();
+    expect(screen.getByText('Regular Campaign')).toBeInTheDocument();
+    expect(screen.getByText('Quiz Campaign')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Clicking **+ New campaign** on the v2 Campaigns board went straight to `/admin/campaigns/workspace` with no `?type=` — the classic page's type-selection step (`CampaignTypeSelectionDialog`) was dropped in the admin-v2 rebuild, so every new campaign silently became `lead_generation`. The workspace still honors `?type=` (classic always sent it); only the chooser was missing.

- `+ New campaign` now opens the shared type dialog; picking a type navigates to the workspace with `?type=<choice>`.
- Removed the dialog's **PHV (brand_awareness)** card — fleet/PHV was retired 2026-07-15; new PHV campaigns shouldn't be creatable. (Affects the classic page too, deliberately.)
- 3 new tests (dialog-not-navigate, `?type=` threading, PHV gone). Full vitest **1672/1672**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDco6HwKLHpmRgE5YR8Za2