### PR TITLE
fix(admin-v2): sidebar logo mark invisible on the four campaign-editor routes

### DIFF
--- a/src/components/adminv2/AdminV2Shell.jsx
+++ b/src/components/adminv2/AdminV2Shell.jsx
@@ -203,7 +203,10 @@ export default function AdminV2Shell({ children, fullBleed = false, legacyBridge
             </div>
           </header>
 
-          <main style={fullBleed
+          {/* legacyBridge remaps the shadcn token set for the pre-rebuild editors.
+              It lands HERE, not on the shell root: its --accent is an HSL triplet
+              and the chrome above reads var(--accent) raw. */}
+          <main className={legacyBridge ? 'av2-bridge-tokens' : undefined} style={fullBleed
             ? { flex: 1, width: '100%', minWidth: 0 }
             : { flex: 1, width: '100%', maxWidth: 1520, margin: '0 auto', padding: '20px 24px 48px', boxSizing: 'border-box' }}>
             {children}

--- a/src/styles/adminV2.css
+++ b/src/styles/adminV2.css
@@ -249,12 +249,19 @@ body[data-theme='dark'] .admin-v2 {
    .gr-designer-chrome. The customer-facing design preview opts back out via
    .av2-theme-reset below.
 
-   SCOPED to .av2-legacy-bridge (AdminV2Shell `legacyBridge` — only the five
-   editor routes), NOT bare .admin-v2: shadcn's token set collides with
-   Switchboard's own --accent, and declaring the triplet later on the same
-   selector clobbered `var(--accent)` for every v2 screen (invisible primary
-   buttons / checked checkboxes — live bug 2026-07-15). */
-.admin-v2.av2-legacy-bridge {
+   SCOPED to .av2-bridge-tokens — the shell's <main>, i.e. the legacy page body
+   ONLY — never the token root: shadcn's set collides with Switchboard's own
+   --accent, and an HSL triplet winning `var(--accent)` makes raw consumers
+   invalid-at-computed-value-time (they drop to `initial`, they do NOT fall
+   back). Declared on bare .admin-v2 it broke every v2 screen (invisible primary
+   buttons / checked checkboxes — live bug 2026-07-15); re-scoping it to the
+   root's .av2-legacy-bridge left the SHELL CHROME broken on the four editor
+   routes, since the chrome renders inside that root too (invisible sidebar logo
+   mark — live bug 2026-07-22). Keep the triples off anything the chrome reads.
+   .av2-legacy-bridge stays on the root for `color-scheme` (inherits to <main>). */
+.admin-v2.av2-legacy-bridge[data-theme='dark'] { color-scheme: dark; }
+
+.admin-v2 .av2-bridge-tokens {
   --background: 220 27.3% 95.7%;
   --foreground: 220 21.4% 11%;
   --card: 0 0% 100%;
@@ -277,8 +284,7 @@ body[data-theme='dark'] .admin-v2 {
   --radius: 0.625rem;
 }
 
-.admin-v2.av2-legacy-bridge[data-theme='dark'] {
-  color-scheme: dark;
+.admin-v2[data-theme='dark'] .av2-bridge-tokens {
   --background: 222.9 18.9% 7.3%;
   --foreground: 220 36% 95.1%;
   --card: 222 17.9% 11%;


### PR DESCRIPTION
The MKTR logo tile in the admin sidebar renders **invisible** on `/admin/campaigns/new`, `/admin/campaigns/:id/edit` and both `workspace` routes — in **both** light and dark theme.


## Cause

Those four routes render `<AdminV2Shell legacyBridge>` (`src/pages/index.jsx:379–425`), which puts `av2-legacy-bridge` on the **token root** — the same element as `admin-v2`. The bridge exists to remap shadcn's variables for the pre-rebuild campaign editors, and shadcn ships `--accent` as a bare HSL **triplet** (meant for `hsl(var(--accent))`):

```css
.admin-v2.av2-legacy-bridge[data-theme="dark"] { --accent: 230.2 38.1% 22.2%; }  /* 3 parts */
.admin-v2[data-theme="dark"]                   { --accent: #6D7FFF; }            /* 2 parts — loses */
```

So on those routes `background: var(--accent)` substitutes to `background: 230.2 38.1% 22.2%`, which is **invalid at computed-value time**. That drops the property to `initial` — it does *not* fall back to the earlier declaration — so the logo tile's background becomes `transparent`.

`--accent-ink` is not part of shadcn's set, so the bridge never touches it and the `M` keeps `#0F1116`. Near-black glyph, no tile, dark sidebar → **1.05:1**. In light mode it fails the other way: `#FFFFFF` ink on a transparent tile over a white sidebar.

**This is the second time this collision has shipped.** The 2026-07-15 fix (invisible primary buttons / checked checkboxes) scoped the triples from bare `.admin-v2` to `.av2-legacy-bridge` — which saved every other v2 screen, but not these, because the shell chrome renders inside that same root.

## Fix

Move the triples off the token root and onto the legacy page body — `<main class="av2-bridge-tokens">` — so they reach the legacy editors and nothing above them. `color-scheme: dark` stays on the root and inherits down, so native controls and scrollbars are untouched. The comment block in `adminV2.css` now records both recurrences.

## Verification

Computed styles read out of the **built** `dist-mktr/assets/adminV2-*.css` in headless Chrome, against the shell's real DOM shape:

| | before | after |
|---|---|---|
| Logo tile bg (dark) | `transparent` | `rgb(109,127,255)` = `#6D7FFF` |
| Logo contrast (dark) | ~1.05:1 | **5.51:1** |
| Logo contrast (light) | ~1:1 | **6.72:1** |
| `<main>` legacy tokens | ✓ | ✓ unchanged — `--accent` `--card` `--primary` `--radius`, inherits to descendants |
| `color-scheme` root / main | dark / dark | dark / dark |
| Non-bridge route | `#6D7FFF` | `#6D7FFF`, no shadcn leak into `<main>` |

Also un-breaks `.av2-btn--primary`, the active nav pill and focus rings on those four routes — all three read `var(--accent)` raw.

Portals are unaffected: `portalContainer` is `undefined` outside the Studio DeviceFrame, so editor dialogs portal to `document.body` and never had the bridge tokens.

**1601/1601 vitest green** (128 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTLqszccDKe8wYHjU1sf1G
