### PR TITLE
feat(campaigns): Lucky Draw option in the new-campaign type chooser

### DIFF
--- a/src/components/campaigns/CampaignTypeSelectionDialog.jsx
+++ b/src/components/campaigns/CampaignTypeSelectionDialog.jsx
@@ -6,7 +6,7 @@ import {
  DialogTitle,
 } from"@/components/ui/dialog";
 import { Button } from"@/components/ui/button";
-import { ClipboardCheck, QrCode, Sparkles } from"lucide-react";
+import { ClipboardCheck, Gift, QrCode, Sparkles } from"lucide-react";
 
 export default function CampaignTypeSelectionDialog({ open, onOpenChange, onSelect }) {
  return (
@@ -30,6 +30,22 @@ export default function CampaignTypeSelectionDialog({ open, onOpenChange, onSele
  <h3 className="font-semibold text-foreground">Regular Campaign</h3>
  <p className="text-sm text-muted-foreground font-normal mt-1 text-wrap">
  Standard QR code campaigns for lead generation. Perfect for events and direct sign-ups.
+ </p>
+ </div>
+ </div>
+ </Button>
+
+ <Button
+ variant="outline" className="h-auto p-4 flex flex-col items-start gap-2 border-2 hover:border-ring hover:bg-primary/10 transition-colors text-left group" onClick={() => onSelect("lucky_draw")}
+ >
+ <div className="flex items-center w-full gap-3">
+ <div className="p-2 bg-primary/10 rounded-lg group-hover:bg-primary/15 text-primary transition-colors">
+ <Gift className="w-6 h-6"/>
+ </div>
+ <div>
+ <h3 className="font-semibold text-foreground">Lucky Draw Campaign</h3>
+ <p className="text-sm text-muted-foreground font-normal mt-1 text-wrap">
+ One prize, verified entries. SMS-verified signups earn one chance; completing a review session multiplies it. Server-enforced entries, witnessed draw, masked results.
  </p>
  </div>
  </div>

--- a/src/components/campaigns/workspace/CampaignDetailsTab.jsx
+++ b/src/components/campaigns/workspace/CampaignDetailsTab.jsx
@@ -4,7 +4,8 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
-import { Loader2 } from 'lucide-react';
+import { Loader2, Gift } from 'lucide-react';
+import { buildDrawTermsHtml, formatLongDate } from './drawTermsTemplate';
 
 const toDateInput = (v) => {
   if (!v) return '';
@@ -17,7 +18,7 @@ const toDateInput = (v) => {
  * (enforceLeadQuota) and per-campaign tracking pixels. Controlled form; the
  * workspace owns create-vs-update. PHV tablet media stays in the classic editor.
  */
-export default function CampaignDetailsTab({ initial, type, isEdit, saving, onSubmit }) {
+export default function CampaignDetailsTab({ initial, type, draw = false, isEdit, saving, onSubmit }) {
   const campaignType = initial?.type || type || 'lead_generation';
   const [form, setForm] = useState({
     name: initial?.name || '',
@@ -31,19 +32,51 @@ export default function CampaignDetailsTab({ initial, type, isEdit, saving, onSu
     leadPriceDollars: initial?.leadPriceCents != null ? String(initial.leadPriceCents / 100) : '',
     metaPixelId: initial?.metaPixelId || '',
     tiktokPixelId: initial?.tiktokPixelId || '',
+    // Lucky-draw create flow only (draw prop) — never shown on edit.
+    drawPrize: '',
+    drawClosesAt: '',
+    drawBoostClosesAt: '',
+    drawMultiplier: 10,
   });
   const set = (k, v) => setForm((f) => ({ ...f, [k]: v }));
 
   const handleSubmit = (e) => {
     e.preventDefault();
     if (!form.name.trim()) return;
+    if (draw && (!form.drawPrize.trim() || !form.drawClosesAt)) return; // inputs are required; belt for non-native submits
+    const drawConfig = draw
+      ? {
+          design_config: {
+            luckyDraw: {
+              enabled: true,
+              prize: form.drawPrize.trim(),
+              closesAt: form.drawClosesAt,
+              boostClosesAt: form.drawBoostClosesAt || form.drawClosesAt,
+              multiplier: Number(form.drawMultiplier) || 10,
+            },
+            // Starter T&C generated from these details; the server pins it as
+            // draw_terms_versions v1. Edit in the designer before launch —
+            // edits mint a new version, entrants keep what they accepted.
+            termsContent: buildDrawTermsHtml({
+              campaignName: form.name.trim(),
+              prize: form.drawPrize.trim(),
+              closesAt: form.drawClosesAt,
+              boostClosesAt: form.drawBoostClosesAt || form.drawClosesAt,
+              multiplier: Number(form.drawMultiplier) || 10,
+            }),
+          },
+        }
+      : {};
     onSubmit({
+      ...drawConfig,
       name: form.name.trim(),
       type: campaignType,
       min_age: Number(form.min_age) || 18,
       max_age: Number(form.max_age) || 65,
       start_date: form.start_date ? new Date(form.start_date).toISOString() : undefined,
-      end_date: form.end_date ? new Date(form.end_date).toISOString() : undefined,
+      end_date: form.end_date
+        ? new Date(form.end_date).toISOString()
+        : (draw && form.drawClosesAt ? new Date(form.drawClosesAt).toISOString() : undefined),
       commission_amount_driver: form.commission_amount_driver === '' ? null : Number(form.commission_amount_driver),
       commission_amount_fleet: form.commission_amount_fleet === '' ? null : Number(form.commission_amount_fleet),
       enforceLeadQuota: form.enforceLeadQuota,
@@ -78,6 +111,46 @@ export default function CampaignDetailsTab({ initial, type, isEdit, saving, onSu
           </div>
         </CardContent>
       </Card>
+
+      {draw && (
+        <Card data-testid="draw-setup-card">
+          <CardHeader>
+            <CardTitle className="text-base flex items-center gap-2"><Gift className="w-4 h-4" /> Lucky draw</CardTitle>
+            <CardDescription>
+              Entries are server-enforced: SMS-verified number, accepted T&Cs, one entry per phone,
+              hard close at 23:59 SGT. A starter T&C is generated from these details and pinned as
+              version 1 — review it in the designer before launch.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="draw_prize">Prize</Label>
+              <Input id="draw_prize" value={form.drawPrize} onChange={(e) => set('drawPrize', e.target.value)} placeholder="e.g. One (1) iPhone 17 Pro 256GB" required maxLength={80} />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="draw_closes">Entries close</Label>
+                <Input id="draw_closes" type="date" value={form.drawClosesAt} onChange={(e) => set('drawClosesAt', e.target.value)} required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="draw_boost">Session boost deadline</Label>
+                <Input id="draw_boost" type="date" value={form.drawBoostClosesAt} onChange={(e) => set('drawBoostClosesAt', e.target.value)} />
+                <p className="text-xs text-muted-foreground">Empty = same as close date.</p>
+              </div>
+            </div>
+            <div className="space-y-2 max-w-[160px]">
+              <Label htmlFor="draw_multiplier">Session multiplier</Label>
+              <Input id="draw_multiplier" type="number" min={2} max={100} value={form.drawMultiplier} onChange={(e) => set('drawMultiplier', e.target.value)} />
+              <p className="text-xs text-muted-foreground">A completed, consultant-scanned review session multiplies the entry.</p>
+            </div>
+            {form.drawClosesAt ? (
+              <p className="text-xs text-muted-foreground">
+                Closes {formatLongDate(form.drawClosesAt)}, 23:59 SGT · boost until {formatLongDate(form.drawBoostClosesAt || form.drawClosesAt)} · ×{Number(form.drawMultiplier) || 10} after a scanned session.
+              </p>
+            ) : null}
+          </CardContent>
+        </Card>
+      )}
 
       <Card>
         <CardHeader><CardTitle className="text-base">Lead delivery</CardTitle></CardHeader>

--- a/src/components/campaigns/workspace/__tests__/CampaignDetailsTab.test.jsx
+++ b/src/components/campaigns/workspace/__tests__/CampaignDetailsTab.test.jsx
@@ -77,3 +77,83 @@ describe('CampaignDetailsTab', () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 });
+
+describe('CampaignDetailsTab — lucky-draw create flow', () => {
+  const fillBasics = () => {
+    fireEvent.change(screen.getByLabelText('Campaign name'), { target: { value: 'iPhone Lucky Draw' } });
+    fireEvent.change(screen.getByLabelText('Prize'), { target: { value: 'One (1) iPhone 17 Pro' } });
+    fireEvent.change(screen.getByLabelText('Entries close'), { target: { value: '2026-08-31' } });
+  };
+
+  it('renders the draw card only when draw is set', () => {
+    const { unmount } = render(
+      <CampaignDetailsTab initial={null} type="lead_generation" isEdit={false} saving={false} onSubmit={vi.fn()} />
+    );
+    expect(screen.queryByTestId('draw-setup-card')).not.toBeInTheDocument();
+    unmount();
+    render(
+      <CampaignDetailsTab initial={null} type="lead_generation" draw isEdit={false} saving={false} onSubmit={vi.fn()} />
+    );
+    expect(screen.getByTestId('draw-setup-card')).toBeInTheDocument();
+  });
+
+  it('arms design_config.luckyDraw + seeded terms on submit; boost defaults to close; end_date follows the close', () => {
+    const onSubmit = vi.fn();
+    render(
+      <CampaignDetailsTab initial={null} type="lead_generation" draw isEdit={false} saving={false} onSubmit={onSubmit} />
+    );
+    fillBasics();
+    fireEvent.click(screen.getByRole('button', { name: /Create draft/i }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const payload = onSubmit.mock.calls[0][0];
+    expect(payload.type).toBe('lead_generation');
+    expect(payload.design_config.luckyDraw).toEqual({
+      enabled: true,
+      prize: 'One (1) iPhone 17 Pro',
+      closesAt: '2026-08-31',
+      boostClosesAt: '2026-08-31',
+      multiplier: 10,
+    });
+    expect(payload.design_config.termsContent).toContain('iPhone Lucky Draw');
+    expect(payload.design_config.termsContent).toContain('One (1) iPhone 17 Pro');
+    expect(payload.design_config.termsContent).toContain('31 August 2026');
+    expect(payload.design_config.termsContent).toContain('10 entries instead of one');
+    expect(payload.design_config.termsContent).toContain('never ask you to pay a fee');
+    // end_date empty → aligned to the draw close
+    expect(payload.end_date).toBe(new Date('2026-08-31').toISOString());
+  });
+
+  it('a distinct boost deadline and multiplier flow through', () => {
+    const onSubmit = vi.fn();
+    render(
+      <CampaignDetailsTab initial={null} type="lead_generation" draw isEdit={false} saving={false} onSubmit={onSubmit} />
+    );
+    fillBasics();
+    fireEvent.change(screen.getByLabelText('Session boost deadline'), { target: { value: '2026-08-15' } });
+    fireEvent.change(screen.getByLabelText('Session multiplier'), { target: { value: '20' } });
+    fireEvent.click(screen.getByRole('button', { name: /Create draft/i }));
+    const ld = onSubmit.mock.calls[0][0].design_config.luckyDraw;
+    expect(ld.boostClosesAt).toBe('2026-08-15');
+    expect(ld.multiplier).toBe(20);
+  });
+
+  it('refuses to submit without a prize or close date', () => {
+    const onSubmit = vi.fn();
+    render(
+      <CampaignDetailsTab initial={null} type="lead_generation" draw isEdit={false} saving={false} onSubmit={onSubmit} />
+    );
+    fireEvent.change(screen.getByLabelText('Campaign name'), { target: { value: 'Draw' } });
+    fireEvent.submit(screen.getByRole('button', { name: /Create draft/i }).closest('form'));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('non-draw submits never carry design_config', () => {
+    const onSubmit = vi.fn();
+    render(
+      <CampaignDetailsTab initial={null} type="lead_generation" isEdit={false} saving={false} onSubmit={onSubmit} />
+    );
+    fireEvent.change(screen.getByLabelText('Campaign name'), { target: { value: 'Plain' } });
+    fireEvent.click(screen.getByRole('button', { name: /Create draft/i }));
+    expect(onSubmit.mock.calls[0][0].design_config).toBeUndefined();
+  });
+});

--- a/src/components/campaigns/workspace/__tests__/drawTermsTemplate.test.js
+++ b/src/components/campaigns/workspace/__tests__/drawTermsTemplate.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { buildDrawTermsHtml, formatLongDate } from '../drawTermsTemplate';
+
+describe('formatLongDate', () => {
+  it('renders D Month YYYY and rejects junk', () => {
+    expect(formatLongDate('2026-08-31')).toBe('31 August 2026');
+    expect(formatLongDate('2026-13-01')).toBe('');
+    expect(formatLongDate('junk')).toBe('');
+    expect(formatLongDate(undefined)).toBe('');
+  });
+});
+
+describe('buildDrawTermsHtml', () => {
+  it('interpolates name, prize, dates, and multiplier', () => {
+    const html = buildDrawTermsHtml({
+      campaignName: 'iPhone Lucky Draw',
+      prize: 'One (1) iPhone 17 Pro',
+      closesAt: '2026-08-31',
+      boostClosesAt: '2026-08-15',
+      multiplier: 10,
+    });
+    expect(html).toContain('Redeem &times; MKTR &mdash; iPhone Lucky Draw');
+    expect(html).toContain('One (1) iPhone 17 Pro');
+    expect(html).toContain('23:59 (SGT) on 31 August 2026');
+    expect(html).toContain('on or before 15 August 2026 earns you 10 entries instead of one');
+    expect(html).toContain('fourteen (14) days');
+    expect(html).toContain('redeem.sg/winners');
+    expect(html).toContain('Do Not Call registry');
+  });
+
+  it('boost defaults to the close date and HTML in inputs is escaped', () => {
+    const html = buildDrawTermsHtml({
+      campaignName: 'X<script>alert(1)</script>',
+      prize: 'A & B <b>prize</b>',
+      closesAt: '2026-08-31',
+    });
+    expect(html).toContain('on or before 31 August 2026');
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('A &amp; B &lt;b&gt;prize&lt;/b&gt;');
+  });
+});

--- a/src/components/campaigns/workspace/drawTermsTemplate.js
+++ b/src/components/campaigns/workspace/drawTermsTemplate.js
@@ -1,0 +1,59 @@
+/**
+ * Starter Terms & Conditions for a lucky-draw campaign created from the
+ * workspace. Modeled clause-for-clause on the live Tokyo Getaway draw terms
+ * (the first pinned draw_terms_versions row): promoter, prize, verified-entry
+ * eligibility, SGT close, witnessed draw + session ×N boost, 14-day claim and
+ * redraw, masked results, DNC posture, and the never-pay-for-a-prize line.
+ *
+ * The server pins whatever is saved as an immutable draw_terms_versions row
+ * (campaignService.ensureDrawTermsVersion), and later edits mint a NEW
+ * version — so this scaffold is a safe starting point, not final legal copy.
+ * Campaigns start as drafts; review the generated terms in the designer
+ * before launching.
+ */
+
+const MONTHS = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+/** '2026-10-30' → '30 October 2026' (string split — SGT calendar date). */
+export function formatLongDate(ymd) {
+  const m = typeof ymd === 'string' ? ymd.match(/^(\d{4})-(\d{2})-(\d{2})$/) : null;
+  if (!m) return '';
+  const month = MONTHS[Number(m[2]) - 1];
+  return month ? `${Number(m[3])} ${month} ${m[1]}` : '';
+}
+
+function escapeHtml(s) {
+  return String(s ?? '').replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+  ));
+}
+
+/**
+ * @param {object} opts
+ * @param {string} opts.campaignName  e.g. "iPhone Lucky Draw — August 2026"
+ * @param {string} opts.prize        e.g. "One (1) iPhone 17 Pro"
+ * @param {string} opts.closesAt     YYYY-MM-DD (SGT)
+ * @param {string} [opts.boostClosesAt]  YYYY-MM-DD; defaults to closesAt
+ * @param {number} [opts.multiplier]     default 10
+ */
+export function buildDrawTermsHtml({ campaignName, prize, closesAt, boostClosesAt, multiplier = 10 }) {
+  const name = escapeHtml((campaignName || '').trim() || 'Lucky Draw');
+  const prizeText = escapeHtml((prize || '').trim());
+  const closesLong = formatLongDate(closesAt);
+  const boostLong = formatLongDate(boostClosesAt || closesAt) || closesLong;
+  const m = Number.isInteger(multiplier) && multiplier >= 2 ? multiplier : 10;
+  return [
+    `<h3>Redeem &times; MKTR &mdash; ${name}</h3>`,
+    '<p><strong>Promoter:</strong> MKTR PTE. LTD. (UEN 202507548M), Singapore. Redeem is a service of MKTR PTE. LTD.</p>',
+    `<p><strong>Prize:</strong> ${prizeText}. The prize is not exchangeable for cash and is subject to availability and any conditions advised to the winner.</p>`,
+    '<p><strong>Eligibility &amp; entry:</strong> Open to Singapore residents aged 18 and above. Entry is free. Complete the form and verify your mobile number with the one-time SMS code &mdash; one entry per verified mobile number.</p>',
+    `<p><strong>Entry period:</strong> Entries close at 23:59 (SGT) on ${closesLong}. Entries received after that time are not eligible.</p>`,
+    `<p><strong>The draw:</strong> One winner is drawn at random from all verified entries after the entry period closes, in a process witnessed by MKTR staff. Completing a complimentary financial-review session on or before ${boostLong} earns you ${m} entries instead of one.</p>`,
+    "<p><strong>Winner notification &amp; claim:</strong> The winner is contacted directly by phone or SMS using the details provided and has fourteen (14) days to respond and claim. If unclaimed within 14 days, a replacement winner is drawn. Results are posted, with the winner's masked details, at redeem.sg/winners.</p>",
+    '<p><strong>Data &amp; contact:</strong> By entering you agree to be contacted by MKTR and its financial-advisory representatives about this promotion and related services, in line with our Personal Data Policy. We honour the Do Not Call registry and every opt-out.</p>',
+    '<p><strong>Integrity:</strong> MKTR will never ask you to pay a fee to release a prize. Anyone requesting payment is not us &mdash; report them to hello@redeem.sg.</p>',
+  ].join('\n');
+}

--- a/src/pages/AdminCampaignWorkspace.jsx
+++ b/src/pages/AdminCampaignWorkspace.jsx
@@ -32,7 +32,12 @@ export default function AdminCampaignWorkspace() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const isCreate = !id;
-  const typeParam = searchParams.get('type') || 'lead_generation';
+  const rawType = searchParams.get('type') || 'lead_generation';
+  // 'lucky_draw' is a CREATE-FLOW choice, not a backend type: it creates a
+  // lead_generation campaign with design_config.luckyDraw pre-armed (the
+  // server validates closesAt + terms and pins the terms version on create).
+  const isDrawCreate = isCreate && rawType === 'lucky_draw';
+  const typeParam = rawType === 'lucky_draw' ? 'lead_generation' : rawType;
   const tabParam = searchParams.get('tab');
 
   const [activeTab, setActiveTab] = useState(
@@ -204,6 +209,7 @@ export default function AdminCampaignWorkspace() {
             <CampaignDetailsTab
               initial={isCreate ? null : campaign}
               type={typeParam}
+              draw={isDrawCreate}
               isEdit={!isCreate}
               saving={savingDetails}
               onSubmit={handleSaveDetails}

--- a/src/pages/AdminCampaigns.jsx
+++ b/src/pages/AdminCampaigns.jsx
@@ -95,7 +95,9 @@ export default function AdminCampaigns() {
  // else the classic create form. Ships dark (flag off) until set on the
  // mktr-platform static site.
  const workspace = import.meta.env.VITE_CAMPAIGN_WORKSPACE_ENABLED === 'true';
- navigate(workspace ? `/admin/campaigns/workspace?type=${type}` : `/admin/campaigns/new?type=${type}`);
+ // lucky_draw only exists as a workspace create flow (the classic form cannot
+ // arm design_config.luckyDraw) — route it there regardless of the flag.
+ navigate(workspace || type === 'lucky_draw' ? `/admin/campaigns/workspace?type=${type}` : `/admin/campaigns/new?type=${type}`);
  };
 
  const handleCopyLink = (campaign) => {

--- a/src/pages/adminv2/__tests__/AdminV2Campaigns.typeChooser.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2Campaigns.typeChooser.test.jsx
@@ -48,6 +48,14 @@ describe('AdminV2Campaigns — new-campaign type chooser', () => {
     expect(navigateMock).toHaveBeenCalledWith(`${newCampaignHref()}?type=guided_review`);
   });
 
+  it('offers Lucky Draw and navigates with ?type=lucky_draw', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByRole('button', { name: '+ New campaign' }));
+    await user.click(screen.getByText('Lucky Draw Campaign'));
+    expect(navigateMock).toHaveBeenCalledWith(`${newCampaignHref()}?type=lucky_draw`);
+  });
+
   it('the retired PHV (brand_awareness) option is gone', async () => {
     const user = userEvent.setup();
     renderPage();


### PR DESCRIPTION
Follow-up to #227: the chooser now offers **Lucky Draw**.

- New dialog card → `?type=lucky_draw` → workspace maps it to a `lead_generation` create with a **Lucky draw** section in Details (prize, entries close, session-boost deadline, multiplier ×N).
- On create the payload arms `design_config.luckyDraw{enabled…}` and seeds **starter T&Cs** interpolated from those details (modeled clause-for-clause on the live Tokyo draw terms). The existing backend create path validates `closesAt` + terms (typed 422s) and pins the content as `draw_terms_versions` v1 — so the campaign is born draw-armed with immutable versioned terms, as a **draft** for review before launch.
- Classic page safeguard: `lucky_draw` always routes to the workspace (the legacy form can't arm `luckyDraw`).
- Previously draw campaigns were CLI/SQL-only (Tokyo was created that way).

Tests: +10 new; full vitest **1681/1681**. No backend changes required — the create path shipped draw-ready in the Phase-1 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDco6HwKLHpmRgE5YR8Za2