### PR TITLE
feat(campaigns): structured multi-prize lucky draw (qty × name)

### DIFF
--- a/backend/src/services/campaignReadinessService.js
+++ b/backend/src/services/campaignReadinessService.js
@@ -46,6 +46,7 @@
  * @param {boolean} facts.drawCloseMismatch      LIVE record cutoff ≠ doc closesAt (instant-exact)
  * @param {string}  facts.docDrawClosesAt        display YMD (doc)
  * @param {string}  facts.drawRecordClosesAt     display YMD (record, SGT)
+ * @param {number}  facts.drawTotalPrizes        Σqty of structured luckyDraw.prizes (0 = unstructured)
  * @returns {{ applicable: boolean, ready: boolean, issues: Array<{level,code,message}> }}
  */
 export function computeReadiness(facts) {
@@ -75,6 +76,7 @@ export function computeReadiness(facts) {
     drawCloseMismatch = false,
     docDrawClosesAt = null,
     drawRecordClosesAt = null,
+    drawTotalPrizes = 0,
   } = facts || {};
 
   // Brand-awareness (PHV tablet) campaigns don't capture leads → readiness N/A.
@@ -204,6 +206,19 @@ export function computeReadiness(facts) {
     });
   }
 
+  // CRITICAL — the draw engine resolves exactly one claimed winner today, so a
+  // multi-prize draw would collect entries under T&Cs the platform cannot
+  // honour. The service layer 422s activation regardless
+  // (DRAW_MULTI_PRIZE_UNSUPPORTED, non-forceable) — this row is the visible
+  // reason in the Launch tab. Phase 3 (multi-winner engine) removes both.
+  if (drawEnabled && drawTotalPrizes > 1) {
+    issues.push({
+      level: 'critical',
+      code: 'draw_multi_prize_unsupported',
+      message: `This draw lists ${drawTotalPrizes} prizes, but multi-winner draw execution isn't live yet — the campaign can be saved and reviewed as a draft, not activated.`,
+    });
+  }
+
   // INFO — not yet live.
   if (!isActive) {
     issues.push({
@@ -220,7 +235,7 @@ export function computeReadiness(facts) {
 // Model-free static imports — the pure export above must stay import-light
 // (utils only, no model graph).
 import { readLegacyViewSafe, getStoredLuckyDraw } from '../utils/designConfigV2Clamp.js';
-import { normalizeLuckyDraw } from '../utils/luckyDraw.js';
+import { normalizeLuckyDraw, totalPrizeQuantity } from '../utils/luckyDraw.js';
 import { sgtDayEndExclusiveMs } from '../utils/sgtTime.js';
 
 /** Display YMD (SGT) for a draw record's exclusive cutoff instant — minus 1ms
@@ -359,6 +374,7 @@ export async function loadCampaignReadiness(campaignId) {
     drawCloseMismatch,
     docDrawClosesAt,
     drawRecordClosesAt,
+    drawTotalPrizes: totalPrizeQuantity(ld),
   });
 
   return {

--- a/backend/src/services/campaignService.js
+++ b/backend/src/services/campaignService.js
@@ -7,13 +7,14 @@ import { AppError } from '../middleware/errorHandler.js';
 import { normalizeCustomerHostChoice } from '../utils/customerHost.js';
 import { sgtDayEndExclusiveMs } from '../utils/sgtTime.js';
 import { applyFeaturedDropPolicy } from '../utils/featuredDrop.js';
-import { applyLuckyDrawPolicy } from '../utils/luckyDraw.js';
+import { applyLuckyDrawPolicy, normalizeLuckyDraw, totalPrizeQuantity } from '../utils/luckyDraw.js';
 import { normalizeMarketplaceContent, applyMarketplacePolicy } from '../utils/marketplaceContent.js';
 import {
   classifyDesignConfigVersion,
   clampDesignConfigV2,
   designConfigV2WritesEnabled,
   getStoredTermsHtml,
+  getStoredLuckyDraw,
 } from '../utils/designConfigV2Clamp.js';
 import { invalidateMarketplaceCache } from './marketplaceCache.js';
 import { refundCampaignCommitments } from './walletService.js';
@@ -358,6 +359,30 @@ export async function getCampaign(id, req) {
 }
 
 /**
+ * Fail-closed activation gate (docs/plans/lucky-draw-multi-prize-plan.md §3.5):
+ * the draw engine resolves exactly ONE claimed winner per campaign
+ * (luckyDrawService — a claimed attempt is terminal), so a campaign whose
+ * structured prizes total more than one unit must not BE active: it would
+ * collect entries under T&Cs the platform cannot honour. Enforced at the
+ * service layer on every path that can leave a campaign active (create /
+ * update / setCampaignLaunchState) plus createDraw — the launch `force` flag
+ * only skips READINESS, never this. Phase 3 (multi-winner engine) removes it.
+ */
+export function assertDrawActivatable(designConfig) {
+  const ld = normalizeLuckyDraw(getStoredLuckyDraw(designConfig));
+  if (!ld || ld.enabled !== true) return;
+  const total = totalPrizeQuantity(ld);
+  if (total > 1) {
+    const err = new AppError(
+      `This draw promises ${total} prizes, but multi-winner draw execution isn't live yet — the campaign can stay a draft (or paused) but cannot be active.`,
+      422
+    );
+    err.data = { code: 'DRAW_MULTI_PRIZE_UNSUPPORTED' };
+    throw err;
+  }
+}
+
+/**
  * Create a new campaign.
  */
 export async function createCampaign(body, user) {
@@ -427,6 +452,10 @@ export async function createCampaign(body, user) {
       throw err;
     }
   }
+  // is_active DEFAULTS TO TRUE when omitted (above) — an API create of a
+  // multi-prize draw must be an explicit draft (the workspace sends
+  // is_active:false), never born active.
+  if (campaignData.is_active) assertDrawActivatable(campaignData.design_config);
 
   let campaign;
   try {
@@ -564,6 +593,15 @@ export async function updateCampaign(id, body, req) {
     updateData.leadPriceCents = normalizeLeadPriceCents(body.leadPriceCents);
   }
 
+  // Fail-closed: a campaign may not END UP active with a multi-prize draw —
+  // whether this save flips is_active or edits the design under an active one.
+  const willBeActive = is_active !== undefined ? is_active === true : campaign.is_active === true;
+  if (willBeActive) {
+    assertDrawActivatable(
+      updateData.design_config !== undefined ? updateData.design_config : campaign.design_config
+    );
+  }
+
   try {
     await campaign.update(updateData);
   } catch (err) {
@@ -687,6 +725,9 @@ export async function setCampaignLaunchState(id, state, req) {
   if (campaign.status === 'archived') {
     throw new AppError('Archived campaigns cannot be activated or paused. Restore it first.', 400);
   }
+  // Fail-closed: this is the path `force` reaches (the controller only skips
+  // readiness on force) — the multi-prize gate must hold here regardless.
+  if (state === 'active') assertDrawActivatable(campaign.design_config);
 
   const isActive = state === 'active';
   await campaign.update({

--- a/backend/src/services/email-templates/confirmation-email-draw.html
+++ b/backend/src/services/email-templates/confirmation-email-draw.html
@@ -145,7 +145,7 @@
                 </tr>
                 <tr>
                   <td align="center" class="anim-2" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:16px; line-height:26px; color:#5A301A; padding:14px 8px 0 8px;">
-                    You&rsquo;re in the running for <strong>{{prize}}</strong>. Want {{multiplier}}&times; the chances? Complete your complimentary financial review session &mdash; when your consultant records it, your entry is multiplied. We contact the winner directly after the draw, and we never ask for payment to release a prize.
+                    You&rsquo;re in the running for <strong>{{prize}}</strong>. Want {{multiplier}}&times; the chances? Complete your complimentary financial review session &mdash; when your consultant records it, your entry is multiplied. If you win, we contact you directly after the draw &mdash; and we never ask for payment to release a prize.
                   </td>
                 </tr>
               </table>

--- a/backend/src/services/email-templates/confirmation-email-draw.txt
+++ b/backend/src/services/email-templates/confirmation-email-draw.txt
@@ -6,7 +6,7 @@ Your entry for {{campaignName}} is in — you're in the running for {{prize}}.
 
 Want {{multiplier}}x the chances? Complete your complimentary financial review session — when your consultant records it, your entry is multiplied.
 
-We contact the winner directly after the draw, and we never ask for payment to release a prize.
+If you win, we contact you directly after the draw — and we never ask for payment to release a prize.
 
 ------------------------------------------------------------
 

--- a/backend/src/services/luckyDrawService.js
+++ b/backend/src/services/luckyDrawService.js
@@ -8,6 +8,7 @@ import {
 import { AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
 import { sgtDayEndExclusiveMs } from '../utils/sgtTime.js';
+import { normalizeLuckyDraw, totalPrizeQuantity } from '../utils/luckyDraw.js';
 
 /**
  * Lucky-draw lifecycle (docs/plans/lucky-draw-10x.md §4.2–§4.3).
@@ -139,6 +140,18 @@ export function makeLuckyDrawService(overrides = {}) {
     const ld = campaign.design_config?.luckyDraw;
     if (ld?.enabled !== true) {
       throw new AppError('Campaign has no enabled luckyDraw config (designer → luckyDraw)', 422);
+    }
+    // Fail-closed until the multi-winner engine ships: this engine resolves
+    // exactly ONE claimed winner per draw (a claimed attempt is terminal), so
+    // a multi-prize config must not mint a record it cannot deliver.
+    const totalPrizes = totalPrizeQuantity(normalizeLuckyDraw(ld));
+    if (totalPrizes > 1) {
+      const err = new AppError(
+        `This draw promises ${totalPrizes} prizes, but multi-winner draw execution isn't live yet.`,
+        422
+      );
+      err.data = { code: 'DRAW_MULTI_PRIZE_UNSUPPORTED' };
+      throw err;
     }
     const closesAtMs = ld.closesAt ? sgtDayEndExclusiveMs(ld.closesAt) : null;
     if (closesAtMs === null) {

--- a/backend/src/utils/luckyDraw.js
+++ b/backend/src/utils/luckyDraw.js
@@ -11,9 +11,24 @@
  * draw_terms_versions row and stamps them after the clamp) but are normalized
  * here so stored values survive round-trips and hand-written rows can't
  * smuggle arbitrary content.
+ *
+ * prizes[] (docs/plans/lucky-draw-multi-prize-plan.md) is the structured
+ * prize list — [{qty, name}], array order = award order. When valid rows
+ * exist they are CANONICAL: `prize` (display summary) and `winners` (Σqty)
+ * are derived here, overwriting whatever the client sent, so no save path
+ * can make them disagree. Without prizes, `prize`/`winners` stay manual
+ * (legacy campaigns are byte-identical).
  */
 
-const MAX_PRIZE = 80;
+import { AppError } from '../middleware/errorHandler.js';
+
+const MAX_PRIZE = 80; // legacy manual `prize` cap — unchanged so stored rows never drift
+const MAX_PRIZE_NAME = 80;
+const MAX_PRIZE_ROWS = 8;
+const MAX_PRIZE_QTY = 99;
+// Derived summaries are bounded by construction (8 × (4 + 80) + 7 × 3 = 693);
+// this slice is a belt that should never cut.
+const MAX_PRIZE_SUMMARY = 700;
 const MAX_BOOKING_URL = 300;
 const MIN_MULTIPLIER = 2;
 const MAX_MULTIPLIER = 100;
@@ -45,6 +60,35 @@ function cleanYmd(v) {
   return s;
 }
 
+/** Valid structured rows only: plain objects with a non-empty name; qty coerced to 1..MAX_PRIZE_QTY. */
+function cleanPrizes(raw) {
+  if (!Array.isArray(raw)) return [];
+  const out = [];
+  for (const row of raw) {
+    if (out.length >= MAX_PRIZE_ROWS) break;
+    if (!isPlainObject(row)) continue;
+    const name = cleanString(row.name, MAX_PRIZE_NAME);
+    if (!name) continue;
+    const qty = Number(row.qty);
+    out.push({ qty: Number.isInteger(qty) && qty >= 1 && qty <= MAX_PRIZE_QTY ? qty : 1, name });
+  }
+  return out;
+}
+
+/** Compact display summary: "iPhone 17 Pro + 3× $100 FairPrice Voucher". */
+export function derivePrizeSummary(prizes) {
+  return prizes
+    .map((p) => (p.qty === 1 ? p.name : `${p.qty}× ${p.name}`))
+    .join(' + ')
+    .slice(0, MAX_PRIZE_SUMMARY);
+}
+
+/** Σqty of a NORMALIZED luckyDraw's prizes; 0 when unstructured (legacy). */
+export function totalPrizeQuantity(ld) {
+  if (!ld || !Array.isArray(ld.prizes)) return 0;
+  return ld.prizes.reduce((sum, p) => sum + (Number.isInteger(p?.qty) ? p.qty : 0), 0);
+}
+
 /**
  * Normalize a raw luckyDraw value into the canonical shape, or undefined when
  * the input isn't a plain object (caller should drop the key entirely).
@@ -53,8 +97,19 @@ export function normalizeLuckyDraw(raw) {
   if (!isPlainObject(raw)) return undefined;
   const out = { enabled: raw.enabled === true };
 
-  const prize = cleanString(raw.prize, MAX_PRIZE);
-  if (prize) out.prize = prize;
+  const prizes = cleanPrizes(raw.prizes);
+  if (prizes.length > 0) {
+    out.prizes = prizes;
+    out.prize = derivePrizeSummary(prizes);
+    out.winners = Math.min(prizes.reduce((s, p) => s + p.qty, 0), 1000);
+  } else {
+    const prize = cleanString(raw.prize, MAX_PRIZE);
+    if (prize) out.prize = prize;
+    // Display-only winners count for marketplace copy ("5 winners drawn") —
+    // manual only in legacy mode; derived from prizes when they exist.
+    const winners = Number(raw.winners);
+    if (Number.isInteger(winners) && winners >= 1 && winners <= 1000) out.winners = winners;
+  }
 
   for (const key of ['closesAt', 'boostClosesAt', 'drawOn']) {
     const ymd = cleanYmd(raw[key]);
@@ -66,11 +121,6 @@ export function normalizeLuckyDraw(raw) {
     Number.isInteger(multiplier) && multiplier >= MIN_MULTIPLIER && multiplier <= MAX_MULTIPLIER
       ? multiplier
       : DEFAULT_MULTIPLIER;
-
-  // Display-only winners count for marketplace copy ("5 winners drawn").
-  // No draw mechanics read it.
-  const winners = Number(raw.winners);
-  if (Number.isInteger(winners) && winners >= 1 && winners <= 1000) out.winners = winners;
 
   // Session-booking link for the success screen's "Book your 20-min review"
   // CTA (drawTemplates.jsx). Display-only — no draw mechanics read it. Absent
@@ -101,7 +151,20 @@ export function normalizeLuckyDraw(raw) {
  */
 export function applyLuckyDrawPolicy({ incoming, stored, role }) {
   if (role === 'admin') {
-    return incoming === undefined ? normalizeLuckyDraw(stored) : normalizeLuckyDraw(incoming);
+    if (incoming === undefined) return normalizeLuckyDraw(stored);
+    // Write-path guard: an explicit `prizes` key that normalizes to zero valid
+    // rows would silently downgrade a structured campaign to manual mode —
+    // reject the save instead. Stored-side garbage never throws (this policy
+    // and normalizeLuckyDraw also run on read paths).
+    if (isPlainObject(incoming) && incoming.prizes !== undefined && cleanPrizes(incoming.prizes).length === 0) {
+      const err = new AppError(
+        'luckyDraw.prizes was provided but contains no valid rows — omit it to use a manual prize string, or fix the rows.',
+        422
+      );
+      err.data = { code: 'DRAW_PRIZES_INVALID' };
+      throw err;
+    }
+    return normalizeLuckyDraw(incoming);
   }
   return normalizeLuckyDraw(stored);
 }

--- a/backend/src/utils/publicDesignConfig.js
+++ b/backend/src/utils/publicDesignConfig.js
@@ -43,6 +43,7 @@ export function publicLuckyDraw(raw) {
   return {
     enabled: true,
     ...(ld.prize ? { prize: ld.prize } : {}),
+    ...(ld.prizes ? { prizes: ld.prizes } : {}),
     ...(ld.closesAt ? { closesAt: ld.closesAt } : {}),
     ...(ld.boostClosesAt ? { boostClosesAt: ld.boostClosesAt } : {}),
     ...(ld.drawOn ? { drawOn: ld.drawOn } : {}),

--- a/backend/test/designConfigV2StudioClamp.test.js
+++ b/backend/test/designConfigV2StudioClamp.test.js
@@ -91,6 +91,22 @@ describe('clampDesignConfigV2 over Studio-authored docs', () => {
     expect(out.customerHost).toBe('redeem'); // derived mirror
   });
 
+  it('structured luckyDraw.prizes survive the v2 clamp with derived prize + winners', () => {
+    const doc = studioDoc();
+    doc.luckyDraw = {
+      enabled: true,
+      closesAt: '2026-10-30',
+      multiplier: 10,
+      prizes: [{ qty: 1, name: 'iPhone 17 Pro' }, { qty: 3, name: '$100 FairPrice Voucher' }],
+      prize: 'stale summary',
+      winners: 77,
+    };
+    const out = clampDesignConfigV2(doc, undefined, 'admin');
+    expect(out.luckyDraw.prizes).toEqual([{ qty: 1, name: 'iPhone 17 Pro' }, { qty: 3, name: '$100 FairPrice Voucher' }]);
+    expect(out.luckyDraw.prize).toBe('iPhone 17 Pro + 3× $100 FairPrice Voucher');
+    expect(out.luckyDraw.winners).toBe(4);
+  });
+
   it('PR 5: the clamp DROPS marketplace.endsAt (expiry is ops-derived — pins the schema decision)', () => {
     const doc = studioDoc();
     doc.distribution.marketplace.endsAt = '2026-12-31';

--- a/backend/test/drawMultiPrizeGate.test.js
+++ b/backend/test/drawMultiPrizeGate.test.js
@@ -1,0 +1,58 @@
+/**
+ * Fail-closed multi-prize activation gate
+ * (docs/plans/lucky-draw-multi-prize-plan.md §3.5): until the multi-winner
+ * draw engine ships, a campaign whose structured prizes total more than one
+ * unit must not BE active — assertDrawActivatable 422s on every service path
+ * that can leave it active, and readiness surfaces the reason as a critical.
+ * Both under test here are pure (no DB).
+ */
+import { computeReadiness } from '../src/services/campaignReadinessService.js';
+import { assertDrawActivatable } from '../src/services/campaignService.js';
+
+const MULTI = {
+  luckyDraw: {
+    enabled: true,
+    closesAt: '2026-10-30',
+    prizes: [{ qty: 1, name: 'iPhone 17 Pro' }, { qty: 3, name: '$100 FairPrice Voucher' }],
+  },
+};
+
+describe('assertDrawActivatable', () => {
+  it('422s with DRAW_MULTI_PRIZE_UNSUPPORTED when Σqty > 1', () => {
+    let thrown;
+    try { assertDrawActivatable(MULTI); } catch (e) { thrown = e; }
+    expect(thrown?.statusCode).toBe(422);
+    expect(thrown?.data?.code).toBe('DRAW_MULTI_PRIZE_UNSUPPORTED');
+  });
+
+  it('passes for single-structured, legacy, disabled, and absent draws', () => {
+    expect(() => assertDrawActivatable({
+      luckyDraw: { enabled: true, closesAt: '2026-10-30', prizes: [{ qty: 1, name: 'iPhone 17 Pro' }] },
+    })).not.toThrow();
+    expect(() => assertDrawActivatable({
+      luckyDraw: { enabled: true, closesAt: '2026-10-30', prize: '4D3N Tokyo getaway for two' },
+    })).not.toThrow();
+    expect(() => assertDrawActivatable({ luckyDraw: { ...MULTI.luckyDraw, enabled: false } })).not.toThrow();
+    expect(() => assertDrawActivatable({})).not.toThrow();
+    expect(() => assertDrawActivatable(undefined)).not.toThrow();
+  });
+});
+
+describe('computeReadiness — draw_multi_prize_unsupported', () => {
+  const base = { type: 'lead_generation', webhookEnabled: true, smsOtpConfigured: true, assignableAgents: 1 };
+
+  it('emits a CRITICAL (ready:false) for an enabled draw with Σqty > 1', () => {
+    const out = computeReadiness({ ...base, drawEnabled: true, drawTotalPrizes: 4 });
+    const issue = out.issues.find((i) => i.code === 'draw_multi_prize_unsupported');
+    expect(issue?.level).toBe('critical');
+    expect(issue?.message).toContain('4 prizes');
+    expect(out.ready).toBe(false);
+  });
+
+  it('stays silent for single-prize draws and for non-draw campaigns', () => {
+    const single = computeReadiness({ ...base, drawEnabled: true, drawTotalPrizes: 1 });
+    expect(single.issues.some((i) => i.code === 'draw_multi_prize_unsupported')).toBe(false);
+    const nonDraw = computeReadiness({ ...base, drawEnabled: false, drawTotalPrizes: 4 });
+    expect(nonDraw.issues.some((i) => i.code === 'draw_multi_prize_unsupported')).toBe(false);
+  });
+});

--- a/backend/test/luckyDraw.util.test.js
+++ b/backend/test/luckyDraw.util.test.js
@@ -4,7 +4,7 @@
  * Mirrors featuredDrop.util.test.js — these values gate PUBLIC signup
  * enforcement, so the clamp is the security boundary.
  */
-import { normalizeLuckyDraw, applyLuckyDrawPolicy } from '../src/utils/luckyDraw.js';
+import { normalizeLuckyDraw, applyLuckyDrawPolicy, derivePrizeSummary, totalPrizeQuantity } from '../src/utils/luckyDraw.js';
 import { sgtDayEndExclusiveMs } from '../src/utils/sgtTime.js';
 
 const UUID = '123e4567-e89b-42d3-a456-426614174000';
@@ -79,6 +79,107 @@ describe('normalizeLuckyDraw — bookingUrl (draw success CTA)', () => {
     // The 300-char cap truncates into an invalid URL with whitespace-free tail — still http ok:
     const long = `https://redeem.sg/${'a'.repeat(400)}`;
     expect(normalizeLuckyDraw({ enabled: true, bookingUrl: long }).bookingUrl.length).toBeLessThanOrEqual(300);
+  });
+});
+
+describe('normalizeLuckyDraw — structured prizes', () => {
+  const ROWS = [{ qty: 1, name: 'iPhone 17 Pro' }, { qty: 3, name: '$100 FairPrice Voucher' }];
+
+  it('keeps valid rows and derives prize + winners from them (overwriting client input)', () => {
+    const out = normalizeLuckyDraw({ enabled: true, prizes: ROWS, prize: 'LIES', winners: 100 });
+    expect(out.prizes).toEqual(ROWS);
+    expect(out.prize).toBe('iPhone 17 Pro + 3× $100 FairPrice Voucher');
+    expect(out.winners).toBe(4);
+  });
+
+  it('drops junk rows, coerces bad qty to 1, trims/caps names, caps at 8 rows', () => {
+    const out = normalizeLuckyDraw({
+      enabled: true,
+      prizes: [
+        { qty: 'x', name: '  Prize A  ' },
+        { qty: 0, name: 'B' },
+        { qty: 2.5, name: 'C' },
+        { qty: 100, name: 'D' },
+        'not-an-object',
+        { qty: 2, name: '   ' },
+        { qty: 2 },
+        { qty: 2, name: 'E'.repeat(200) },
+      ],
+    });
+    expect(out.prizes).toEqual([
+      { qty: 1, name: 'Prize A' },
+      { qty: 1, name: 'B' },
+      { qty: 1, name: 'C' },
+      { qty: 1, name: 'D' },
+      { qty: 2, name: 'E'.repeat(80) },
+    ]);
+    const nine = Array.from({ length: 9 }, (_, i) => ({ qty: 1, name: `P${i}` }));
+    expect(normalizeLuckyDraw({ enabled: true, prizes: nine }).prizes).toHaveLength(8);
+  });
+
+  it('empty/invalid prizes fall back to legacy manual fields (read-safe)', () => {
+    const out = normalizeLuckyDraw({ enabled: true, prizes: [], prize: 'Manual', winners: 5 });
+    expect(out.prizes).toBeUndefined();
+    expect(out.prize).toBe('Manual');
+    expect(out.winners).toBe(5);
+  });
+
+  it('legacy manual prize keeps its 80-char cap (no drift for stored rows)', () => {
+    const out = normalizeLuckyDraw({ enabled: true, prize: 'Z'.repeat(200) });
+    expect(out.prize).toBe('Z'.repeat(80));
+  });
+
+  it('long multi-prize summaries are NOT cut at the legacy 80-char cap', () => {
+    const rows = Array.from({ length: 8 }, (_, i) => ({ qty: 99, name: `${'N'.repeat(78)}${i}` }));
+    const out = normalizeLuckyDraw({ enabled: true, prizes: rows });
+    expect(out.prize.length).toBeGreaterThan(80);
+    expect(out.prize.length).toBeLessThanOrEqual(700);
+    expect(out.winners).toBe(8 * 99);
+  });
+
+  it('is idempotent: normalize(normalize(x)) === normalize(x)', () => {
+    const once = normalizeLuckyDraw({ enabled: true, prizes: ROWS, closesAt: '2026-10-30', multiplier: 10 });
+    expect(normalizeLuckyDraw(once)).toEqual(once);
+  });
+
+  it('derivePrizeSummary / totalPrizeQuantity helpers', () => {
+    expect(derivePrizeSummary([{ qty: 1, name: 'A' }])).toBe('A');
+    expect(derivePrizeSummary(ROWS)).toBe('iPhone 17 Pro + 3× $100 FairPrice Voucher');
+    expect(totalPrizeQuantity(normalizeLuckyDraw({ enabled: true, prizes: ROWS }))).toBe(4);
+    expect(totalPrizeQuantity(normalizeLuckyDraw({ enabled: true, prize: 'Manual', winners: 9 }))).toBe(0);
+    expect(totalPrizeQuantity(undefined)).toBe(0);
+  });
+});
+
+describe('applyLuckyDrawPolicy — structured prizes write guard', () => {
+  const storedStructured = { enabled: true, prizes: [{ qty: 1, name: 'A' }, { qty: 3, name: 'B' }] };
+
+  it('admin sending a prizes key that normalizes empty is a 422 (DRAW_PRIZES_INVALID), not a silent downgrade', () => {
+    for (const bad of [[], [{ qty: 2 }], [{ name: '   ' }], 'garbage', 42]) {
+      let thrown;
+      try {
+        applyLuckyDrawPolicy({ incoming: { enabled: true, prizes: bad }, stored: storedStructured, role: 'admin' });
+      } catch (e) { thrown = e; }
+      expect(thrown?.statusCode).toBe(422);
+      expect(thrown?.data?.code).toBe('DRAW_PRIZES_INVALID');
+    }
+  });
+
+  it('admin omitting the prizes key replaces wholesale (documented incoming-wins semantics)', () => {
+    const out = applyLuckyDrawPolicy({ incoming: { enabled: true, prize: 'Manual' }, stored: storedStructured, role: 'admin' });
+    expect(out.prizes).toBeUndefined();
+    expect(out.prize).toBe('Manual');
+  });
+
+  it('non-admin incoming garbage prizes never throws and never lands', () => {
+    const out = applyLuckyDrawPolicy({ incoming: { enabled: true, prizes: [] }, stored: storedStructured, role: 'agent' });
+    expect(out.prizes).toEqual(storedStructured.prizes);
+  });
+
+  it('stored-side garbage prizes (direct-DB) reads as legacy, never throws', () => {
+    const out = applyLuckyDrawPolicy({ incoming: undefined, stored: { enabled: true, prizes: [], prize: 'Manual' }, role: 'admin' });
+    expect(out.prizes).toBeUndefined();
+    expect(out.prize).toBe('Manual');
   });
 });
 

--- a/backend/test/luckyDrawService.test.js
+++ b/backend/test/luckyDrawService.test.js
@@ -190,6 +190,38 @@ describe('createDraw', () => {
     await expect(svc.createDraw({ campaignId: CAMPAIGN_ID }, ADMIN)).rejects.toMatchObject({ statusCode: 422 });
   });
 
+  it('422s (DRAW_MULTI_PRIZE_UNSUPPORTED) when structured prizes total more than one unit', async () => {
+    const { deps } = buildDeps();
+    deps.Campaign.findByPk.mockResolvedValue({
+      id: CAMPAIGN_ID,
+      design_config: {
+        luckyDraw: {
+          enabled: true,
+          closesAt: '2026-08-31',
+          prizes: [{ qty: 1, name: 'iPhone 17 Pro' }, { qty: 3, name: '$100 FairPrice Voucher' }],
+        },
+      },
+    });
+    const svc = makeLuckyDrawService(deps);
+    await expect(svc.createDraw({ campaignId: CAMPAIGN_ID }, ADMIN)).rejects.toMatchObject({
+      statusCode: 422,
+      data: { code: 'DRAW_MULTI_PRIZE_UNSUPPORTED' },
+    });
+  });
+
+  it('a single structured prize (one row, qty 1) still creates the draw', async () => {
+    const { deps } = buildDeps();
+    deps.Campaign.findByPk.mockResolvedValue({
+      id: CAMPAIGN_ID,
+      design_config: {
+        luckyDraw: { enabled: true, closesAt: '2026-08-31', prizes: [{ qty: 1, name: 'iPhone 17 Pro' }] },
+      },
+    });
+    const svc = makeLuckyDrawService(deps);
+    const draw = await svc.createDraw({ campaignId: CAMPAIGN_ID }, ADMIN);
+    expect(draw.status).toBe('open');
+  });
+
   it('derives fixed SGT-exclusive instants and persists config', async () => {
     const { deps } = buildDeps();
     deps.Campaign.findByPk.mockResolvedValue({

--- a/backend/test/publicDesignConfig.test.js
+++ b/backend/test/publicDesignConfig.test.js
@@ -25,6 +25,27 @@ describe('publicLuckyDraw', () => {
     expect(publicLuckyDraw({ enabled: false, closesAt: '2026-08-31' })).toBeUndefined();
   });
 
+  test('structured prizes are exposed with the derived summary + winners; ids still stripped', () => {
+    const out = publicLuckyDraw({
+      enabled: true,
+      closesAt: '2026-10-30',
+      prizes: [{ qty: 1, name: 'iPhone 17 Pro' }, { qty: 3, name: '$100 FairPrice Voucher' }],
+      prize: 'stale client summary',
+      winners: 500,
+      activationId: '2a2a2a2a-2a2a-4a2a-8a2a-2a2a2a2a2a2a',
+      termsVersionId: '3b3b3b3b-3b3b-4b3b-8b3b-3b3b3b3b3b3b',
+      termsHash: 'a'.repeat(64),
+    });
+    expect(out).toEqual({
+      enabled: true,
+      prize: 'iPhone 17 Pro + 3× $100 FairPrice Voucher',
+      prizes: [{ qty: 1, name: 'iPhone 17 Pro' }, { qty: 3, name: '$100 FairPrice Voucher' }],
+      closesAt: '2026-10-30',
+      multiplier: 10,
+      winners: 4,
+    });
+  });
+
   it('exposes bookingUrl (display-only success CTA) but never internal ids', () => {
     const out = publicLuckyDraw({
       enabled: true,

--- a/docs/plans/lucky-draw-10x.md
+++ b/docs/plans/lucky-draw-10x.md
@@ -73,11 +73,17 @@ first; Lyfe app (internal agents) later. The paid `ExternalAgent` buyer rail is
 
 A lucky draw is a **Regular (`lead_generation`) campaign** with:
 
-- `design_config.luckyDraw = { enabled: true, closesAt: 'YYYY-MM-DD', boostClosesAt: 'YYYY-MM-DD', drawOn?: 'YYYY-MM-DD', prize: '…', multiplier: 10, activationId: '<uuid>', termsVersionId: '<uuid>' }`
+- `design_config.luckyDraw = { enabled: true, closesAt: 'YYYY-MM-DD', boostClosesAt: 'YYYY-MM-DD', drawOn?: 'YYYY-MM-DD', prize: '…', prizes?: [{ qty, name }], multiplier: 10, activationId: '<uuid>', termsVersionId: '<uuid>' }`
   — admin-gated on write like `featuredDrop` (`applyFeaturedDropPolicy` pattern),
   clamped server-side in `campaignService`. `duplicateCampaign` must strip
   `luckyDraw` (it currently copies design config wholesale and disables only
   `featuredDrop` — `campaignService.js:412`).
+  `prizes` (docs/plans/lucky-draw-multi-prize-plan.md) is the structured prize
+  list — [{qty 1..99, name ≤80}], ≤8 rows, array order = award order. When
+  present, `prize` (compact summary) and `winners` (Σqty) are DERIVED by
+  `normalizeLuckyDraw`, overwriting client input. Until the multi-winner
+  engine ships, Σqty > 1 cannot activate or mint a draw record
+  (`DRAW_MULTI_PRIZE_UNSUPPORTED`, non-forceable).
 - A live Redeem Ops **Activation** (`luckyDraw.activationId`, validated to belong
   to this campaign). Recommended: pair the draw with the guaranteed session
   voucher — one Activation powers the voucher AND the ×10 evidence.

--- a/docs/plans/lucky-draw-multi-prize-plan.md
+++ b/docs/plans/lucky-draw-multi-prize-plan.md
@@ -1,0 +1,139 @@
+# Lucky Draw — structured multi-prize (qty × name) — implementation plan v2
+
+**Date:** 2026-07-22 · **v1** written against `origin/main @ 482e305` (#230); **v2** folds the Codex CLI adversarial review (gpt-5.6-sol, xhigh) after verifying every finding against the code. Baseline for implementation: `origin/main @ 04898a1` (#231; no overlap with these files).
+⚠️ File:line references are origin/main. Implement in a **disposable worktree** — the shared checkout has unrelated uncommitted work.
+
+## 0. Codex review disposition (v1 → v2)
+
+Codex verdict on v1: **REDESIGN** — "either ship the multi-winner engine now or keep multi-quantity campaigns impossible to activate until that engine exists." v2 adopts the second arm (fail-closed gates) and keeps the storage design, which Codex confirmed sound.
+
+| # | Codex finding | Verified? | v2 action |
+|---|---|---|---|
+| B1 | **BLOCKER** — multi-winner campaigns can launch but the draw engine is single-winner: `createDraw` copies only dates/multiplier (`luckyDrawService.js:162`), a second pick is refused once any attempt is `claimed` (`:451`), claim makes the draw terminal (`:559`); readiness draw issues are warnings by design (`campaignReadinessService.js:188+`) and activation `force` skips readiness entirely (`campaignController.js:119`) | CONFIRMED in code | **Fail-closed gates** (§3.5): non-forceable 422 `DRAW_MULTI_PRIZE_UNSUPPORTED` at every activation path (create-with-`is_active` — note the API defaults it to *true* (`campaignService.js:377`), update, `setCampaignLaunchState`) and at `createDraw`; plus a `critical` readiness issue for UI visibility. Multi-prize campaigns save as **drafts** (workspace already creates `is_active:false`, `AdminCampaignWorkspace.jsx:71`); launching one needs the Phase-3 engine. Single-total-prize campaigns are fully live today. |
+| M1 | Customer-facing singular copy missed: drawTemplates `:87` (`closedBody` in the shared `drawStrings`), `:208` Gazette "One winner", `:510` Nightfall "Winner contacted directly", `:733` Checklist "One winner drawn after…"; both confirmation-email variants "we contact the winner" (`confirmation-email-draw.html:148`, `.txt:9`); marketplace prints "1 winners" for winners=1 (`MarketplaceOffer.jsx:205`, `MarketplaceFlow.jsx:934` — latent today, universal once winners is derived) | CONFIRMED | §3.6: count-aware `drawStrings` (all four spots), count-neutral email rewording ("If you win, we'll contact you directly…"), shared `winnersSentence(n)` helper for both marketplace sites, chooser copy update |
+| M2 | T&C award-order wording wrong for qty>1 rows ("first name drawn receives the first listed prize" maps names to rows, not units); "Three (3) $100 FairPrice Voucher" grammatically singular; "winner's masked details" not pluralized | CONFIRMED (wording defect in v1 §3.2) | §3.2 rewritten: exhaust-each-quantity award rule, `Three (3) × $100 FairPrice Voucher` item format, "each winner's masked details" |
+| M3 | 240-char summary cap silently truncates (true max ≈693: 8×(4+80)+7×3); v1 both claimed no truncation and permitted it; also raising the shared `MAX_PRIZE` would lengthen public output for any legacy manual prize >80 (public DTO re-normalizes every read, `publicDesignConfig.js:41`) | CONFIRMED | §3.1: **`MAX_PRIZE` stays 80 for legacy manual `prize`** (zero legacy drift); derived summary is bounded by construction (≤693) and stored un-sliced with a 700 belt cap; consumers that need short text truncate visually (CSS), never data |
+| M4 | `prizes: []` (or all-invalid) on an admin PUT silently downgrades a structured campaign to manual mode | CONFIRMED (v1 §4 row 3 was wrong) | §3.4: write-path 422 `DRAW_PRIZES_INVALID` when an admin's incoming `luckyDraw` *includes* a `prizes` key that normalizes empty; read paths still treat it as absent (never throw on stored data) |
+| m5 | `type=number min/max` native validation can block submit before the promised coercion runs; extra rows must not be `required` | CONFIRMED (behavioral) | §3.3: clamp qty on change/blur; only row 1's name is `required`; empty extra rows dropped at submit; tests drive a real button click |
+| m6 | Missed consumers: chooser advertises "One prize" (`CampaignTypeSelectionDialog.jsx:46`); admin surfaces read `winners`; v1 misattributed `drawTemplates:230` to Stub (it's the Postcard chip; Stub `:574+` renders no prize) | PARTIAL — chooser + line corrections confirmed; `dashboardService.js:255` block reads `enabled/closesAt` only (not winners); `AdminV2CampaignDetail.jsx:89` does read winners but is already plural-safe | §2.4 inventory corrected; chooser copy updated; no admin-surface code change needed (derived winners is more correct there) |
+| — | Codex confirms: save-path coherence (create `:404`/update `:549`/duplicate `:826` all clamp; Studio v2 passthrough + backend clamp policy; non-admin cannot inject/strip; public DTO re-normalizes), no hidden 80-cap consumer, per-name escaping, legacy-signature adaptation, terms never regenerated on later saves (`campaignService.js:151`) | — | v1 §2 claims stand |
+
+## 1. Problem
+
+The lucky-draw create flow (#230) takes the prize as one free-text string. Shawn wants structured entry — quantity × prize name, multiple rows: **(1) × iPhone 17 Pro, (3) × $100 FairPrice Voucher**. That implies real semantics: total winners = Σqty, prizes have an award order, the generated starter T&Cs must stop hardcoding "One winner", and — per B1 — the platform must not promise winners the draw engine cannot deliver.
+
+## 2. Current state (v1 §2, corrected)
+
+Unchanged from v1 except these corrections; see v1 history in git for the full walk-through:
+
+- `design_config.luckyDraw` normalized by `normalizeLuckyDraw` (`backend/src/utils/luckyDraw.js`) on every write (v1 path `campaignService.js:404/549/826` via `clampDesignConfig`; v2 path `designConfigV2Clamp.js:355`) and on public reads (`publicDesignConfig.js:40`). Unknown keys stripped — `prizes` must be taught to the normalizer.
+- Route-level Joi is not an obstacle: `design_config: Joi.object().optional()` (`validation.js:102/125`), no stripUnknown on campaign routes.
+- **§2.4 consumer inventory (corrected)**: mailer `:373` (`{{prize}}`, escaped); AI copy `:213`; drawTemplates — `drawStrings()` subject at `:76`, **Postcard** chip `:230`, Gazette factRow `:351` (Stub renders no prize); singular-winner copy at `:87/:208/:510/:733`; both draw email templates (singular "the winner"); marketplace winners copy `MarketplaceOffer.jsx:205` + `MarketplaceFlow.jsx:934` (unpluralized "1 winners" hazard); `AdminV2CampaignDetail.jsx:89` (winners, already plural-safe); chooser "One prize" copy `CampaignTypeSelectionDialog.jsx:46`.
+- **Draw engine reality (B1)**: one live draw per campaign; picks are `draw_attempts`; a `claimed` attempt is terminal for the draw; `createDraw` snapshots dates/multiplier only. Winner never stored on `draws`.
+- Not affected (verified): entry gate (`prospectService.js:442-533`), studio readiness blocks, DrawEntry/terms models, redeem.sg/winners static content, guided-review sample copy.
+
+## 3. Design (v2)
+
+### 3.1 Schema & derivation
+
+```
+luckyDraw.prizes = [ { qty: int 1..99, name: string 1..80 }, … ]   // ≤ 8 rows, order = award order
+```
+
+- `prizes` canonical when present & non-empty. Then server-derived, overwriting client input:
+  - `prize` := compact summary — qty 1 → `name`, else `` `${qty}× ${name}` ``, joined `' + '`. **Not sliced to MAX_PRIZE**; bounded by construction ≤693, belt-capped at `MAX_PRIZE_SUMMARY = 700`. (M3)
+  - `winners` := `Math.min(Σqty, 1000)`.
+- Legacy (no `prizes` key): `prize` manual, cap **stays `MAX_PRIZE = 80`** — no behavior change for any stored row (M3); `winners` manual as today.
+- New constants: `MAX_PRIZE_NAME = 80`, `MAX_PRIZE_ROWS = 8`, `MAX_PRIZE_QTY = 99`, `MAX_PRIZE_SUMMARY = 700`.
+- New exports from `utils/luckyDraw.js`: `derivePrizeSummary(prizes)`, `totalPrizeQuantity(normalizedLuckyDraw) → int` (0 when no prizes) — the gate predicate (§3.5).
+
+### 3.2 Starter T&C wording (`drawTermsTemplate.js`) (M2)
+
+- Signature: `buildDrawTermsHtml({ campaignName, prizes, prize, closesAt, boostClosesAt, multiplier })`; legacy `prize` string adapts to `[{qty:1, name}]`. **Byte-identical output for the legacy single-prize call** (regression-tested with exact equality).
+- `numberWords(n)` 1..99 ("One", "Three", "Twenty-five"), used as `Three (3)`.
+- Prize clause — one prize-unit total: today's sentence unchanged. Multi: `<p><strong>Prizes:</strong></p><ol><li>One (1) × iPhone 17 Pro</li><li>Three (3) × $100 FairPrice Voucher</li></ol><p>Prizes are not exchangeable for cash and are subject to availability and any conditions advised to winners.</p>` — each name individually escaped.
+- Draw clause — total = Σqty. 1: verbatim today. >1: `"Four (4) winners are drawn at random from all verified entries after the entry period closes, in a process witnessed by MKTR staff. Prizes are awarded in the order listed above, with each prize awarded the stated number of times before the draw moves to the next — the first winners drawn receive the first listed prize until its quantity is exhausted, and so on. Each verified mobile number can win at most one prize."` (exhaust-quantity rule — matches future attempt→unit mapping; the one-prize-per-person line is flagged to counsel, review already queued).
+- Notification clause >1: "Winners are contacted directly by phone or SMS using the details provided, and each has fourteen (14) days to respond and claim. If a prize is unclaimed within 14 days, a replacement winner is drawn for that prize. Results are posted, with **each winner's masked details**, at redeem.sg/winners."
+- Boost sentence unchanged.
+
+### 3.3 Form UI (`CampaignDetailsTab.jsx`, draw card, create-only as today) (m5)
+
+- state `drawPrizes: [{ qty: '1', name: '' }]`; row = qty `<Input type="number" min=1 max=99>` (clamped to 1..99 digits **on change/blur**, so native range validation can never block submit) × name `<Input maxLength={80} placeholder="e.g. iPhone 17 Pro 256GB">` + remove (rows>1); `+ Add prize` capped at 8; helper: "Row order is award order — top prize first."
+- Only **row 1's name** is `required`; extra rows optional, empty ones dropped at submit; guard: ≥1 named row + closesAt.
+- Payload: `luckyDraw: { enabled, prizes, prize: <client summary>, closesAt, boostClosesAt, multiplier }` (server re-derives authoritatively) + `termsContent: buildDrawTermsHtml({ campaignName, prizes, … })`.
+- Summary line gains `· N winners` when Σqty > 1, plus a muted note when Σqty > 1: "Saves as a draft — multi-prize draws can't go live until multi-winner draw ops ship." (honest UI for the §3.5 gate).
+- Placeholder changes to name-only (no more "One (1) …" in the name).
+
+### 3.4 Normalizer & policy (`backend/src/utils/luckyDraw.js`) (M4)
+
+- `normalizeLuckyDraw`: clean `prizes` (drop non-object rows, trim/slice names, coerce/clamp qty, cap 8); non-empty → set `prizes` + derived `prize`/`winners`; empty/absent → legacy branch. **Never throws** (runs on read paths).
+- `applyLuckyDrawPolicy`: when `role === 'admin'` and the **incoming** `luckyDraw` object has a `prizes` key that normalizes to zero rows → throw `AppError(422)` code `DRAW_PRIZES_INVALID` ("prizes was provided but contains no valid rows — omit it for a manual prize, or fix the rows"). Stored-side garbage never throws (treated as absent). Non-admin unchanged (incoming ignored).
+
+### 3.5 Fail-closed activation gates (B1) — new
+
+Predicate: normalized stored/final `luckyDraw` has `enabled === true && totalPrizeQuantity(ld) > 1`. Typed error: `AppError(422)`, `data.code = 'DRAW_MULTI_PRIZE_UNSUPPORTED'`, message "This draw promises N prizes, but multi-winner draw execution isn't live yet — the campaign can be saved as a draft but not activated." Four enforcement points (server-side, none forceable):
+
+1. `campaignService.createCampaign` — after `clampDesignConfig`, if `campaignData.is_active` would be true (**API defaults it true when omitted**, `:377`) and predicate holds → 422. Workspace draw-create is unaffected (sends `is_active:false`).
+2. `campaignService.updateCampaign` — when `is_active` transitions to true; evaluate the **final** design (clamped incoming if provided, else stored).
+3. `campaignService.setCampaignLaunchState('active')` — same check; this path is what `force` reaches (`campaignController.js:119` only skips *readiness*), so the gate is force-immune.
+4. `luckyDrawService.createDraw` — refuse to mint a draw record for a multi-prize config (the engine can't deliver it).
+
+Plus visibility: `campaignReadinessService` emits `level: 'critical'`, `code: 'draw_multi_prize_unsupported'` when the predicate holds (critical ⇒ `ready: false`, so the un-forced activate path 409s with a visible reason; the service gates make force irrelevant).
+
+Removal path: Phase 3 (multi-winner engine: attempt→prize-unit mapping in row order, per-unit claim windows, N-winner publish) deletes the four gates + flips the readiness issue. `prizes[]` is already the engine's input contract.
+
+### 3.6 Count-aware customer copy (M1) — new
+
+- `drawTemplates.jsx` — `drawStrings()` gains `winners` (from `draw.winners`, default 1) and count-aware strings; fix the four spots: `closedBody` (`:87`), Gazette "One winner, drawn in a witnessed process" (`:208`), Nightfall "Winner contacted directly" (`:510`), Checklist "One winner drawn after {date}" (`:733`). Singular output byte-preserved when winners ≤ 1.
+- Email templates (`confirmation-email-draw.html:148`, `.txt:9`): count-neutral rewording — "If you win, we'll contact you directly after the draw — and we never ask for payment to release a prize." (no new template fields).
+- Marketplace: `winnersSentence(n)` helper exported from `src/pages/marketplace/content.js`; used at `MarketplaceOffer.jsx:205` and `MarketplaceFlow.jsx:934` — fixes the latent "1 winners" bug for any manually-set winners=1 today, and for derived single-prize configs tomorrow.
+- Chooser (`CampaignTypeSelectionDialog.jsx:46`): "One prize, verified entries." → "Your prizes, verified entries." (rest unchanged).
+
+### 3.7 Public exposure
+
+`publicLuckyDraw` additionally exposes `...(ld.prizes ? { prizes: ld.prizes } : {})` (plain qty/name only).
+
+## 4. Edge cases (v2)
+
+| # | case | handling |
+|---|---|---|
+| 1 | Legacy campaigns (Tokyo): manual `prize`, no `prizes` | byte-identical: legacy cap stays 80, winners manual, no backfill |
+| 2 | `prizes` + contradictory `prize`/`winners` from any client | normalizer overwrites both — cannot disagree |
+| 3 | Admin PUT with `prizes: []` / all-invalid rows | **422 `DRAW_PRIZES_INVALID`** (M4); stored-side garbage reads as absent, never throws |
+| 4 | Admin PUT sending `luckyDraw` *without* the `prizes` key while stored has prizes | incoming-wins-wholesale drops them — **existing semantics for every luckyDraw field** (same as closesAt today); Studio round-trips the doc verbatim so the real editors are safe; documented, not changed |
+| 5 | XSS via prize name | per-name `escapeHtml` in T&Cs; email `{{prize}}` already escaped |
+| 6 | Derived summary length | ≤693 by construction; belt 700; consumers ellipsize visually, data never silently loses a prize (M3) |
+| 7 | Post-create prize edits (API) don't regenerate pinned T&Cs | same as today for every field; terms stay version-pinned (`campaignService.js:151`); Phase-3 review UI concern |
+| 8 | Manual marketing `winners` vs derived | derived wins when prizes present (truth); admin detail tile already plural-safe |
+| 9 | Non-admin PUT injecting/stripping prizes | policy ignores non-admin incoming — inherited |
+| 10 | Multi-prize campaign tries to go live / mint a draw | 422 `DRAW_MULTI_PRIZE_UNSUPPORTED` at all four points (§3.5); UI note at create; readiness critical explains in Launch tab |
+| 11 | `is_active` omitted on API create (defaults true) with multi-prize config | gate #1 catches it |
+
+## 5. Tests
+
+Vitest baseline at #231: **1686/1686** — full run stays green. Backend jest: touched suites only, baseline-diff vs origin/main (ECONNREFUSED-without-pg suites are inherited).
+
+Backend:
+- `luckyDraw.util.test.js`: prizes cleaning (invalid rows dropped, qty coercion/clamp, name slice, 8-row cap), derivation (`prize` summary incl. un-sliced long case, `winners` sum), overwrite-wins, legacy passthrough incl. >80 manual prize still sliced at 80, idempotence, non-admin ignore, `DRAW_PRIZES_INVALID` throw matrix (admin+key present+empty ⇒ throw; stored-empty ⇒ no throw), `totalPrizeQuantity`.
+- `publicDesignConfig.test.js`: prizes exposed; ids still never leak.
+- `designConfigV2StudioClamp.test.js`: prizes survive the v2 clamp.
+- `luckyDrawService` suite: `createDraw` 422 on multi-prize (DI-mocked like neighbors).
+- campaign service/controller suites (follow existing patterns): create-active 422 / update-to-active 422 / `setCampaignLaunchState` 422 (force-immune by construction), draft create OK; readiness emits the critical.
+- Email templates: no `{{` orphan (existing template lint if present; else snapshot of reworded line).
+
+Frontend:
+- `drawTermsTemplate.test.js`: multi-prize `<ol>` + numberWords, exhaust-quantity award sentence, plural notification/masked-details, **exact-equality legacy regression**, escaping.
+- `CampaignDetailsTab.test.jsx`: rows add/remove/cap, real-click submit with empty extra row + out-of-range qty (payload drops/coerces), refusal with no named row, single-row payload shape, multi-prize draft note renders.
+- `drawTemplates.test.jsx`: winners:4 across all five templates ⇒ no "One winner"/singular strings; winners:1 ⇒ no "1 winners"/plural bleed.
+- `marketplaceFlow.test.js` (+content): `winnersSentence(1|4)`.
+- Chooser test: update copy assertion if it pins "One prize".
+
+## 6. Rollout
+
+Unchanged from v1: no flag, no migration, one PR (`feat(campaigns): structured multi-prize lucky draw (qty × name)`), disposable worktree, deploy-verify backend + mktr-platform static site (fresh deploys, chunk-grep), then live-verify: create a **draft** 2-row draw campaign on mktr.sg, confirm DB `prizes` + derived `prize`/`winners`, pinned terms v1 enumerates both prizes and the 4-winner draw clause, and activation of that draft returns `DRAW_MULTI_PRIZE_UNSUPPORTED`. Single-prize structured campaigns remain fully launchable.
+
+## 7. Out of scope
+
+- Multi-winner draw execution (Phase 3): attempt→prize-unit mapping, per-unit claim/redraw, N-winner publish + winners wall. The §3.5 gates are its placeholder and removal checklist.
+- Editing prizes post-create in workspace/Studio (no luckyDraw editor exists post-create today).
+- Rendering the structured list on public templates/marketplace (they use the derived summary; `publicLuckyDraw.prizes` makes it a follow-up).

--- a/src/components/campaignPage/__tests__/drawTemplates.test.jsx
+++ b/src/components/campaignPage/__tests__/drawTemplates.test.jsx
@@ -124,6 +124,49 @@ describe('open states', () => {
   });
 });
 
+describe('winner-count copy (structured multi-prize)', () => {
+  const withWinners = (id, winners) => {
+    const campaign = drawCampaign(id);
+    campaign.design_config.luckyDraw = { ...campaign.design_config.luckyDraw, winners };
+    return campaign;
+  };
+
+  it.each(DRAW_TEMPLATE_IDS)('%s open state never claims "One winner" when 4 winners are configured', (id) => {
+    render(<CampaignPageRenderer campaign={withWinners(id, 4)} previewMode onSubmit={vi.fn()} />);
+    expect(document.body.textContent).not.toContain('One winner');
+  });
+
+  it.each(DRAW_TEMPLATE_IDS)('%s open state never prints "1 winners" for the default single-winner fixture', (id) => {
+    render(<CampaignPageRenderer campaign={drawCampaign(id)} previewMode onSubmit={vi.fn()} />);
+    expect(document.body.textContent).not.toContain('1 winners');
+  });
+
+  it('postcard mobile fact list (factStyle: list) speaks in the configured count', () => {
+    setViewport(390); // belowCard (the facts) renders on the mobile branch only
+    const campaign = drawCampaign('postcard', { factStyle: 'list' });
+    campaign.design_config.luckyDraw = { ...campaign.design_config.luckyDraw, winners: 4 };
+    render(<CampaignPageRenderer campaign={campaign} previewMode onSubmit={vi.fn()} />);
+    expect(document.body.textContent).toContain('4 winners, drawn in a witnessed process.');
+  });
+
+  it('checklist names the count after the close date', () => {
+    render(<CampaignPageRenderer campaign={withWinners('checklist', 4)} previewMode onSubmit={vi.fn()} />);
+    expect(document.body.textContent).toContain('4 winners drawn after');
+  });
+
+  it('the closed page pluralizes its being-drawn line (and keeps the singular verbatim for one winner)', () => {
+    const multi = withWinners('postcard', 4);
+    multi.design_config.luckyDraw.closesAt = '2020-01-01';
+    const { unmount } = render(<CampaignPageRenderer campaign={multi} previewMode onSubmit={vi.fn()} />);
+    expect(document.body.textContent).toContain('The 4 winners are being drawn in a witnessed process');
+    unmount();
+    const single = withWinners('postcard', 1);
+    single.design_config.luckyDraw.closesAt = '2020-01-01';
+    render(<CampaignPageRenderer campaign={single} previewMode onSubmit={vi.fn()} />);
+    expect(document.body.textContent).toContain('The winner is being drawn in a witnessed process');
+  });
+});
+
 describe('closed state', () => {
   it('draw templates get their designed closed page', () => {
     const campaign = drawCampaign('postcard');

--- a/src/components/campaignPage/drawTemplates.jsx
+++ b/src/components/campaignPage/drawTemplates.jsx
@@ -70,10 +70,16 @@ function drawStrings(luckyDraw, campaignName) {
   const m = draw?.multiplier || 10;
   const closesFull = draw ? formatDrawDateFull(draw.closesAt) : '';
   const boostFull = draw ? formatDrawDateFull(draw.boostClosesAt || draw.closesAt) : '';
+  // Winner-count-aware copy: `winners` is derived from structured prizes on
+  // the server (Σqty) and defaults to 1 for legacy single-prize draws — the
+  // singular strings below stay byte-identical when winners ≤ 1.
+  const winners = Number.isInteger(draw?.winners) && draw.winners > 1 ? draw.winners : 1;
   return {
     draw,
     multiplier: m,
     prize: draw?.prize || '',
+    winners,
+    winnersLine: winners > 1 ? `${winners} winners, drawn in a witnessed process.` : 'One winner, drawn in a witnessed process.',
     closesFull,
     closesMono: closesFull ? closesFull.toUpperCase() : '',
     boostFull,
@@ -84,7 +90,9 @@ function drawStrings(luckyDraw, campaignName) {
       `Book your complimentary ~20-min financial review — any time before ${boostFull}.`,
       `Your consultant meets you and scans your pass — your 1 entry becomes ${m} entries.`,
     ],
-    closedBody: 'The winner is being drawn in a witnessed process and will be contacted directly by phone or SMS.',
+    closedBody: winners > 1
+      ? `The ${winners} winners are being drawn in a witnessed process and will be contacted directly by phone or SMS.`
+      : 'The winner is being drawn in a witnessed process and will be contacted directly by phone or SMS.',
     freeSessionLine: `FREE SESSION · NO PAYMENT EVER · BEFORE ${boostFull.toUpperCase()}`,
   };
 }
@@ -205,7 +213,7 @@ function Postcard({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile
   };
   const facts = s.draw ? [
     <><strong style={{ color: PC.ink }}>One verified entry.</strong> SMS code confirms your number — one entry per person, no bots.</>,
-    <><strong style={{ color: PC.ink }}>Entries close {s.closesFull},</strong> 23:59 SGT. One winner, drawn in a witnessed process.</>,
+    <><strong style={{ color: PC.ink }}>Entries close {s.closesFull},</strong> 23:59 SGT. {s.winnersLine}</>,
     <><strong style={{ color: PC.ink }}>Make it ×{s.multiplier}.</strong> {s.boostBody}</>,
   ] : [];
   const hero = (
@@ -507,7 +515,7 @@ function Nightfall({ t, content, params, luckyDraw, funnel, formAnchorRef, mobil
         )}
         {s.draw && (
           <div style={{ fontSize: 12.5, color: NF.mut }}>
-            Winner contacted directly. Masked results at <WinnersLink color="#fff" />.
+            {s.winners > 1 ? 'Winners contacted directly.' : 'Winner contacted directly.'} Masked results at <WinnersLink color="#fff" />.
           </div>
         )}
         <div style={{ fontSize: 11, color: NF.faint }}>{content.regulatory}</div>
@@ -730,7 +738,7 @@ function Checklist({ t, content, params, luckyDraw, funnel, formAnchorRef, mobil
       {spineStep('s2', circle('2', 'outline'), 'Verify with an SMS code', 'One entry per verified number — no bots, no multiple entries. Free, 18+.')}
       {spineStep('s3', circle('3', 'outline'), s.draw ? "You're in the draw" : "You're in",
         s.draw
-          ? `Your entry pass arrives by WhatsApp and email. One winner drawn after ${s.closesFull} in a witnessed process.`
+          ? `Your entry pass arrives by WhatsApp and email. ${s.winners > 1 ? `${s.winners} winners` : 'One winner'} drawn after ${s.closesFull} in a witnessed process.`
           : 'Your details are received securely and confirmed by email.',
         { last: !boostInline })}
       {boostInline && spineStep('s4', circle('+', 'plus'), `Bonus: make it ×${s.multiplier}`, s.boostBody, { last: true })}
@@ -767,7 +775,7 @@ function Checklist({ t, content, params, luckyDraw, funnel, formAnchorRef, mobil
             <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
               <div style={{ display: 'flex', gap: 14 }}>{circle('1', 'filled')}<div style={{ fontSize: 14.5, lineHeight: 1.5, color: CL.body, paddingTop: 3 }}><strong>Drop your details</strong> in the form.</div></div>
               <div style={{ display: 'flex', gap: 14 }}>{circle('2', 'outline')}<div style={{ fontSize: 14.5, lineHeight: 1.5, color: CL.body, paddingTop: 3 }}><strong>Verify with an SMS code</strong> — one entry per verified number.</div></div>
-              <div style={{ display: 'flex', gap: 14 }}>{circle('3', 'outline')}<div style={{ fontSize: 14.5, lineHeight: 1.5, color: CL.body, paddingTop: 3 }}><strong>{s.draw ? "You're in." : 'Done.'}</strong> {s.draw ? `Pass by WhatsApp/email; winner drawn after ${s.closesFull}.` : 'Your details are received securely.'}</div></div>
+              <div style={{ display: 'flex', gap: 14 }}>{circle('3', 'outline')}<div style={{ fontSize: 14.5, lineHeight: 1.5, color: CL.body, paddingTop: 3 }}><strong>{s.draw ? "You're in." : 'Done.'}</strong> {s.draw ? `Pass by WhatsApp/email; ${s.winners > 1 ? `${s.winners} winners` : 'winner'} drawn after ${s.closesFull}.` : 'Your details are received securely.'}</div></div>
               {s.draw && <div style={{ display: 'flex', gap: 14 }}>{circle('+', 'plus')}<div style={{ fontSize: 14.5, lineHeight: 1.5, color: CL.body, paddingTop: 3 }}><strong>Bonus ×{s.multiplier}:</strong> {s.boostBody}</div></div>}
             </div>
             {s.draw && (

--- a/src/components/campaigns/CampaignTypeSelectionDialog.jsx
+++ b/src/components/campaigns/CampaignTypeSelectionDialog.jsx
@@ -45,7 +45,7 @@ export default function CampaignTypeSelectionDialog({ open, onOpenChange, onSele
  <div>
  <h3 className="font-semibold text-foreground">Lucky Draw Campaign</h3>
  <p className="text-sm text-muted-foreground font-normal mt-1 text-wrap">
- One prize, verified entries. SMS-verified signups earn one chance; completing a review session multiplies it. Server-enforced entries, witnessed draw, masked results.
+ Your prizes, verified entries. SMS-verified signups earn one chance; completing a review session multiplies it. Server-enforced entries, witnessed draw, masked results.
  </p>
  </div>
  </div>

--- a/src/components/campaigns/workspace/CampaignDetailsTab.jsx
+++ b/src/components/campaigns/workspace/CampaignDetailsTab.jsx
@@ -4,7 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
-import { Loader2, Gift } from 'lucide-react';
+import { Loader2, Gift, Plus, X } from 'lucide-react';
 import { buildDrawTermsHtml, formatLongDate } from './drawTermsTemplate';
 
 const toDateInput = (v) => {
@@ -12,6 +12,23 @@ const toDateInput = (v) => {
   const d = new Date(v);
   return Number.isNaN(d.getTime()) ? '' : d.toISOString().slice(0, 10);
 };
+
+const MAX_PRIZE_ROWS = 8; // mirrors backend utils/luckyDraw.js
+
+const clampQty = (v) => {
+  const n = Math.floor(Number(v));
+  if (!Number.isFinite(n)) return 1;
+  return Math.min(99, Math.max(1, n));
+};
+
+/** Rows worth submitting: named, qty coerced to 1..99. Empty extra rows drop. */
+const cleanPrizeRows = (rows) =>
+  rows
+    .filter((r) => r.name.trim())
+    .map((r) => ({ qty: clampQty(r.qty), name: r.name.trim() }));
+
+const prizeSummary = (rows) =>
+  rows.map((p) => (p.qty === 1 ? p.name : `${p.qty}× ${p.name}`)).join(' + ');
 
 /**
  * Details tab — core campaign metadata + the previously-hidden delivery controls
@@ -33,23 +50,41 @@ export default function CampaignDetailsTab({ initial, type, draw = false, isEdit
     metaPixelId: initial?.metaPixelId || '',
     tiktokPixelId: initial?.tiktokPixelId || '',
     // Lucky-draw create flow only (draw prop) — never shown on edit.
-    drawPrize: '',
+    drawPrizes: [{ qty: '1', name: '' }],
     drawClosesAt: '',
     drawBoostClosesAt: '',
     drawMultiplier: 10,
   });
   const set = (k, v) => setForm((f) => ({ ...f, [k]: v }));
+  const setPrizeRow = (i, key, value) =>
+    setForm((f) => ({
+      ...f,
+      drawPrizes: f.drawPrizes.map((row, idx) => (idx === i ? { ...row, [key]: value } : row)),
+    }));
+  const addPrizeRow = () =>
+    setForm((f) =>
+      f.drawPrizes.length >= MAX_PRIZE_ROWS ? f : { ...f, drawPrizes: [...f.drawPrizes, { qty: '1', name: '' }] }
+    );
+  const removePrizeRow = (i) =>
+    setForm((f) => ({ ...f, drawPrizes: f.drawPrizes.filter((_, idx) => idx !== i) }));
+
+  const prizeRows = cleanPrizeRows(form.drawPrizes);
+  const totalPrizeQty = prizeRows.reduce((sum, p) => sum + p.qty, 0);
 
   const handleSubmit = (e) => {
     e.preventDefault();
     if (!form.name.trim()) return;
-    if (draw && (!form.drawPrize.trim() || !form.drawClosesAt)) return; // inputs are required; belt for non-native submits
+    if (draw && (prizeRows.length === 0 || !form.drawClosesAt)) return; // row 1 + close date are required; belt for non-native submits
     const drawConfig = draw
       ? {
           design_config: {
             luckyDraw: {
               enabled: true,
-              prize: form.drawPrize.trim(),
+              // prizes[] is canonical (award order); the summary `prize` and
+              // winners count are re-derived server-side (utils/luckyDraw.js),
+              // this copy just keeps the payload self-consistent.
+              prizes: prizeRows,
+              prize: prizeSummary(prizeRows),
               closesAt: form.drawClosesAt,
               boostClosesAt: form.drawBoostClosesAt || form.drawClosesAt,
               multiplier: Number(form.drawMultiplier) || 10,
@@ -59,7 +94,7 @@ export default function CampaignDetailsTab({ initial, type, draw = false, isEdit
             // edits mint a new version, entrants keep what they accepted.
             termsContent: buildDrawTermsHtml({
               campaignName: form.name.trim(),
-              prize: form.drawPrize.trim(),
+              prizes: prizeRows,
               closesAt: form.drawClosesAt,
               boostClosesAt: form.drawBoostClosesAt || form.drawClosesAt,
               multiplier: Number(form.drawMultiplier) || 10,
@@ -124,8 +159,50 @@ export default function CampaignDetailsTab({ initial, type, draw = false, isEdit
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="draw_prize">Prize</Label>
-              <Input id="draw_prize" value={form.drawPrize} onChange={(e) => set('drawPrize', e.target.value)} placeholder="e.g. One (1) iPhone 17 Pro 256GB" required maxLength={80} />
+              <Label htmlFor="draw_prize_name_0">Prizes</Label>
+              {form.drawPrizes.map((row, i) => (
+                <div key={i} className="flex items-center gap-2" data-testid="draw-prize-row">
+                  <Input
+                    id={`draw_prize_qty_${i}`}
+                    aria-label={`Prize ${i + 1} quantity`}
+                    type="number"
+                    min={1}
+                    max={99}
+                    className="w-20 shrink-0"
+                    value={row.qty}
+                    onChange={(e) => setPrizeRow(i, 'qty', e.target.value)}
+                    onBlur={(e) => setPrizeRow(i, 'qty', String(clampQty(e.target.value)))}
+                  />
+                  <span className="text-muted-foreground text-sm shrink-0">×</span>
+                  <Input
+                    id={`draw_prize_name_${i}`}
+                    aria-label={`Prize ${i + 1} name`}
+                    value={row.name}
+                    onChange={(e) => setPrizeRow(i, 'name', e.target.value)}
+                    placeholder={i === 0 ? 'e.g. iPhone 17 Pro 256GB' : 'e.g. $100 FairPrice Voucher'}
+                    required={i === 0}
+                    maxLength={80}
+                  />
+                  {form.drawPrizes.length > 1 && (
+                    <Button type="button" variant="ghost" size="icon" aria-label={`Remove prize ${i + 1}`} onClick={() => removePrizeRow(i)}>
+                      <X className="w-4 h-4" />
+                    </Button>
+                  )}
+                </div>
+              ))}
+              <div className="flex items-center justify-between gap-2">
+                {form.drawPrizes.length < MAX_PRIZE_ROWS ? (
+                  <Button type="button" variant="outline" size="sm" onClick={addPrizeRow} data-testid="add-prize-row">
+                    <Plus className="w-4 h-4 mr-1" /> Add prize
+                  </Button>
+                ) : <span />}
+                <p className="text-xs text-muted-foreground">Row order is award order — top prize first.</p>
+              </div>
+              {totalPrizeQty > 1 && (
+                <p className="text-xs text-amber-600 dark:text-amber-500" data-testid="multi-prize-note">
+                  Multi-prize draws save as drafts — going live needs the multi-winner draw engine (Phase 3). A single-prize draw launches as usual.
+                </p>
+              )}
             </div>
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
@@ -145,7 +222,7 @@ export default function CampaignDetailsTab({ initial, type, draw = false, isEdit
             </div>
             {form.drawClosesAt ? (
               <p className="text-xs text-muted-foreground">
-                Closes {formatLongDate(form.drawClosesAt)}, 23:59 SGT · boost until {formatLongDate(form.drawBoostClosesAt || form.drawClosesAt)} · ×{Number(form.drawMultiplier) || 10} after a scanned session.
+                Closes {formatLongDate(form.drawClosesAt)}, 23:59 SGT · boost until {formatLongDate(form.drawBoostClosesAt || form.drawClosesAt)} · ×{Number(form.drawMultiplier) || 10} after a scanned session.{totalPrizeQty > 1 ? ` · ${totalPrizeQty} winners` : ''}
               </p>
             ) : null}
           </CardContent>

--- a/src/components/campaigns/workspace/__tests__/CampaignDetailsTab.test.jsx
+++ b/src/components/campaigns/workspace/__tests__/CampaignDetailsTab.test.jsx
@@ -81,8 +81,13 @@ describe('CampaignDetailsTab', () => {
 describe('CampaignDetailsTab — lucky-draw create flow', () => {
   const fillBasics = () => {
     fireEvent.change(screen.getByLabelText('Campaign name'), { target: { value: 'iPhone Lucky Draw' } });
-    fireEvent.change(screen.getByLabelText('Prize'), { target: { value: 'One (1) iPhone 17 Pro' } });
+    fireEvent.change(screen.getByLabelText('Prize 1 name'), { target: { value: 'iPhone 17 Pro' } });
     fireEvent.change(screen.getByLabelText('Entries close'), { target: { value: '2026-08-31' } });
+  };
+  const addSecondPrize = (qty, name) => {
+    fireEvent.click(screen.getByTestId('add-prize-row'));
+    fireEvent.change(screen.getByLabelText('Prize 2 quantity'), { target: { value: String(qty) } });
+    fireEvent.change(screen.getByLabelText('Prize 2 name'), { target: { value: name } });
   };
 
   it('renders the draw card only when draw is set', () => {
@@ -97,7 +102,7 @@ describe('CampaignDetailsTab — lucky-draw create flow', () => {
     expect(screen.getByTestId('draw-setup-card')).toBeInTheDocument();
   });
 
-  it('arms design_config.luckyDraw + seeded terms on submit; boost defaults to close; end_date follows the close', () => {
+  it('arms structured prizes + seeded terms on submit; boost defaults to close; end_date follows the close', () => {
     const onSubmit = vi.fn();
     render(
       <CampaignDetailsTab initial={null} type="lead_generation" draw isEdit={false} saving={false} onSubmit={onSubmit} />
@@ -109,18 +114,73 @@ describe('CampaignDetailsTab — lucky-draw create flow', () => {
     expect(payload.type).toBe('lead_generation');
     expect(payload.design_config.luckyDraw).toEqual({
       enabled: true,
-      prize: 'One (1) iPhone 17 Pro',
+      prizes: [{ qty: 1, name: 'iPhone 17 Pro' }],
+      prize: 'iPhone 17 Pro',
       closesAt: '2026-08-31',
       boostClosesAt: '2026-08-31',
       multiplier: 10,
     });
     expect(payload.design_config.termsContent).toContain('iPhone Lucky Draw');
-    expect(payload.design_config.termsContent).toContain('One (1) iPhone 17 Pro');
+    expect(payload.design_config.termsContent).toContain('iPhone 17 Pro');
+    expect(payload.design_config.termsContent).toContain('One winner is drawn at random');
     expect(payload.design_config.termsContent).toContain('31 August 2026');
     expect(payload.design_config.termsContent).toContain('10 entries instead of one');
     expect(payload.design_config.termsContent).toContain('never ask you to pay a fee');
     // end_date empty → aligned to the draw close
     expect(payload.end_date).toBe(new Date('2026-08-31').toISOString());
+  });
+
+  it('multiple prize rows arm ordered prizes, a derived summary, and N-winner terms', () => {
+    const onSubmit = vi.fn();
+    render(
+      <CampaignDetailsTab initial={null} type="lead_generation" draw isEdit={false} saving={false} onSubmit={onSubmit} />
+    );
+    fillBasics();
+    addSecondPrize(3, '$100 FairPrice Voucher');
+    expect(screen.getByTestId('multi-prize-note')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Create draft/i }));
+    const dc = onSubmit.mock.calls[0][0].design_config;
+    expect(dc.luckyDraw.prizes).toEqual([
+      { qty: 1, name: 'iPhone 17 Pro' },
+      { qty: 3, name: '$100 FairPrice Voucher' },
+    ]);
+    expect(dc.luckyDraw.prize).toBe('iPhone 17 Pro + 3× $100 FairPrice Voucher');
+    expect(dc.termsContent).toContain('One (1) &times; iPhone 17 Pro');
+    expect(dc.termsContent).toContain('Three (3) &times; $100 FairPrice Voucher');
+    expect(dc.termsContent).toContain('Four (4) winners are drawn at random');
+    expect(dc.termsContent).toContain('Each verified mobile number can win at most one prize');
+  });
+
+  it('empty extra rows are dropped and out-of-range quantities clamp on blur', () => {
+    const onSubmit = vi.fn();
+    render(
+      <CampaignDetailsTab initial={null} type="lead_generation" draw isEdit={false} saving={false} onSubmit={onSubmit} />
+    );
+    fillBasics();
+    fireEvent.click(screen.getByTestId('add-prize-row')); // row 2 left empty
+    fireEvent.click(screen.getByTestId('add-prize-row'));
+    fireEvent.change(screen.getByLabelText('Prize 3 quantity'), { target: { value: '150' } });
+    fireEvent.blur(screen.getByLabelText('Prize 3 quantity'));
+    expect(screen.getByLabelText('Prize 3 quantity').value).toBe('99');
+    fireEvent.change(screen.getByLabelText('Prize 3 name'), { target: { value: 'Voucher' } });
+    fireEvent.click(screen.getByRole('button', { name: /Create draft/i }));
+    expect(onSubmit.mock.calls[0][0].design_config.luckyDraw.prizes).toEqual([
+      { qty: 1, name: 'iPhone 17 Pro' },
+      { qty: 99, name: 'Voucher' },
+    ]);
+  });
+
+  it('remove buttons drop a row; the cap stops at 8 rows', () => {
+    render(
+      <CampaignDetailsTab initial={null} type="lead_generation" draw isEdit={false} saving={false} onSubmit={vi.fn()} />
+    );
+    for (let i = 0; i < 10; i += 1) {
+      const btn = screen.queryByTestId('add-prize-row');
+      if (btn) fireEvent.click(btn);
+    }
+    expect(screen.getAllByTestId('draw-prize-row')).toHaveLength(8);
+    fireEvent.click(screen.getByLabelText('Remove prize 8'));
+    expect(screen.getAllByTestId('draw-prize-row')).toHaveLength(7);
   });
 
   it('a distinct boost deadline and multiplier flow through', () => {
@@ -137,7 +197,7 @@ describe('CampaignDetailsTab — lucky-draw create flow', () => {
     expect(ld.multiplier).toBe(20);
   });
 
-  it('refuses to submit without a prize or close date', () => {
+  it('refuses to submit without a named prize row or close date', () => {
     const onSubmit = vi.fn();
     render(
       <CampaignDetailsTab initial={null} type="lead_generation" draw isEdit={false} saving={false} onSubmit={onSubmit} />

--- a/src/components/campaigns/workspace/__tests__/drawTermsTemplate.test.js
+++ b/src/components/campaigns/workspace/__tests__/drawTermsTemplate.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildDrawTermsHtml, formatLongDate } from '../drawTermsTemplate';
+import { buildDrawTermsHtml, formatLongDate, numberWords } from '../drawTermsTemplate';
 
 describe('formatLongDate', () => {
   it('renders D Month YYYY and rejects junk', () => {
@@ -38,5 +38,66 @@ describe('buildDrawTermsHtml', () => {
     expect(html).not.toContain('<script>');
     expect(html).toContain('&lt;script&gt;');
     expect(html).toContain('A &amp; B &lt;b&gt;prize&lt;/b&gt;');
+  });
+
+  it('pins the exact legacy singular clauses (regression: structured rollout must not shift them)', () => {
+    const html = buildDrawTermsHtml({ campaignName: 'D', prize: 'One (1) iPhone 17 Pro', closesAt: '2026-08-31' });
+    expect(html).toContain('<p><strong>Prize:</strong> One (1) iPhone 17 Pro. The prize is not exchangeable for cash and is subject to availability and any conditions advised to the winner.</p>');
+    expect(html).toContain('One winner is drawn at random from all verified entries');
+    expect(html).toContain("with the winner's masked details");
+  });
+
+  it('a structured single row (qty 1) emits byte-identical output to the legacy string signature', () => {
+    const opts = { campaignName: 'D', closesAt: '2026-08-31', boostClosesAt: '2026-08-15', multiplier: 10 };
+    expect(buildDrawTermsHtml({ ...opts, prizes: [{ qty: 1, name: 'One (1) iPhone 17 Pro' }] }))
+      .toBe(buildDrawTermsHtml({ ...opts, prize: 'One (1) iPhone 17 Pro' }));
+  });
+});
+
+describe('buildDrawTermsHtml — structured multi-prize', () => {
+  const opts = {
+    campaignName: 'Mega Draw',
+    prizes: [{ qty: 1, name: 'iPhone 17 Pro' }, { qty: 3, name: '$100 FairPrice Voucher' }],
+    closesAt: '2026-08-31',
+  };
+
+  it('enumerates prizes in award order and states the winner total + award rule', () => {
+    const html = buildDrawTermsHtml(opts);
+    expect(html).toContain('<p><strong>Prizes:</strong></p>');
+    expect(html.indexOf('One (1) &times; iPhone 17 Pro')).toBeLessThan(html.indexOf('Three (3) &times; $100 FairPrice Voucher'));
+    expect(html).toContain('Four (4) winners are drawn at random from all verified entries');
+    expect(html).toContain('Prizes are awarded in the order listed above, with each prize awarded its stated number of times');
+    expect(html).toContain('Each verified mobile number can win at most one prize');
+    expect(html).toContain('Winners are contacted directly by phone or SMS');
+    expect(html).toContain("with each winner's masked details");
+    expect(html).toContain('a replacement winner is drawn for that prize');
+  });
+
+  it('a single row with qty > 1 is already plural (quantity, not row count, drives the wording)', () => {
+    const html = buildDrawTermsHtml({ campaignName: 'V', prizes: [{ qty: 3, name: '$100 Voucher' }], closesAt: '2026-08-31' });
+    expect(html).toContain('Three (3) &times; $100 Voucher');
+    expect(html).toContain('Three (3) winners are drawn at random');
+    expect(html).not.toContain('One winner is drawn');
+  });
+
+  it('escapes each prize name individually in the list', () => {
+    const html = buildDrawTermsHtml({
+      campaignName: 'E',
+      prizes: [{ qty: 2, name: '<img src=x onerror=alert(1)>' }, { qty: 1, name: 'A & B' }],
+      closesAt: '2026-08-31',
+    });
+    expect(html).not.toContain('<img');
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+    expect(html).toContain('A &amp; B');
+  });
+
+  it('numberWords covers legal-style counts', () => {
+    expect(numberWords(1)).toBe('One');
+    expect(numberWords(4)).toBe('Four');
+    expect(numberWords(19)).toBe('Nineteen');
+    expect(numberWords(20)).toBe('Twenty');
+    expect(numberWords(25)).toBe('Twenty-five');
+    expect(numberWords(99)).toBe('Ninety-nine');
+    expect(numberWords(100)).toBe('100');
   });
 });

--- a/src/components/campaigns/workspace/drawTermsTemplate.js
+++ b/src/components/campaigns/workspace/drawTermsTemplate.js
@@ -1,15 +1,17 @@
 /**
  * Starter Terms & Conditions for a lucky-draw campaign created from the
  * workspace. Modeled clause-for-clause on the live Tokyo Getaway draw terms
- * (the first pinned draw_terms_versions row): promoter, prize, verified-entry
+ * (the first pinned draw_terms_versions row): promoter, prize(s), verified-entry
  * eligibility, SGT close, witnessed draw + session ×N boost, 14-day claim and
  * redraw, masked results, DNC posture, and the never-pay-for-a-prize line.
  *
- * The server pins whatever is saved as an immutable draw_terms_versions row
- * (campaignService.ensureDrawTermsVersion), and later edits mint a NEW
- * version — so this scaffold is a safe starting point, not final legal copy.
- * Campaigns start as drafts; review the generated terms in the designer
- * before launching.
+ * Structured prizes ([{qty, name}], array order = award order) pluralize the
+ * prize/draw/notification clauses; a single prize unit produces the exact
+ * legacy wording. The server pins whatever is saved as an immutable
+ * draw_terms_versions row (campaignService.ensureDrawTermsVersion), and later
+ * edits mint a NEW version — so this scaffold is a safe starting point, not
+ * final legal copy. Campaigns start as drafts; review the generated terms in
+ * the designer before launching.
  */
 
 const MONTHS = [
@@ -31,28 +33,75 @@ function escapeHtml(s) {
   ));
 }
 
+const ONES = ['', 'One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight', 'Nine', 'Ten',
+  'Eleven', 'Twelve', 'Thirteen', 'Fourteen', 'Fifteen', 'Sixteen', 'Seventeen', 'Eighteen', 'Nineteen'];
+const TENS = ['', '', 'Twenty', 'Thirty', 'Forty', 'Fifty', 'Sixty', 'Seventy', 'Eighty', 'Ninety'];
+
+/** Legal-style count words, 1..99 ("One", "Three", "Twenty-five"); digits beyond. */
+export function numberWords(n) {
+  if (!Number.isInteger(n) || n < 1 || n > 99) return String(n);
+  if (n < 20) return ONES[n];
+  const tens = TENS[Math.floor(n / 10)];
+  const one = n % 10;
+  return one ? `${tens}-${ONES[one].toLowerCase()}` : tens;
+}
+
+/** Valid rows only: {qty 1.., name non-empty}; mirrors the server normalizer's shape. */
+function cleanRows(prizes) {
+  if (!Array.isArray(prizes)) return [];
+  return prizes
+    .filter((p) => p && typeof p.name === 'string' && p.name.trim())
+    .map((p) => ({
+      qty: Number.isInteger(Number(p.qty)) && Number(p.qty) >= 1 ? Number(p.qty) : 1,
+      name: p.name.trim(),
+    }));
+}
+
 /**
  * @param {object} opts
  * @param {string} opts.campaignName  e.g. "iPhone Lucky Draw — August 2026"
- * @param {string} opts.prize        e.g. "One (1) iPhone 17 Pro"
+ * @param {Array<{qty:number,name:string}>} [opts.prizes]  structured prizes, award order
+ * @param {string} [opts.prize]      legacy single free-text prize (used when prizes absent)
  * @param {string} opts.closesAt     YYYY-MM-DD (SGT)
  * @param {string} [opts.boostClosesAt]  YYYY-MM-DD; defaults to closesAt
  * @param {number} [opts.multiplier]     default 10
  */
-export function buildDrawTermsHtml({ campaignName, prize, closesAt, boostClosesAt, multiplier = 10 }) {
+export function buildDrawTermsHtml({ campaignName, prizes, prize, closesAt, boostClosesAt, multiplier = 10 }) {
   const name = escapeHtml((campaignName || '').trim() || 'Lucky Draw');
-  const prizeText = escapeHtml((prize || '').trim());
+  const rows = cleanRows(prizes);
+  const legacyRows = rows.length ? rows : cleanRows(prize ? [{ qty: 1, name: prize }] : []);
+  const total = legacyRows.reduce((sum, p) => sum + p.qty, 0);
   const closesLong = formatLongDate(closesAt);
   const boostLong = formatLongDate(boostClosesAt || closesAt) || closesLong;
   const m = Number.isInteger(multiplier) && multiplier >= 2 ? multiplier : 10;
+
+  // One prize unit → the exact legacy singular wording (regression-pinned);
+  // multiple units → enumerated prizes, N winners, exhaust-quantity award order.
+  const single = total <= 1;
+  const prizeClause = single
+    ? `<p><strong>Prize:</strong> ${escapeHtml(legacyRows[0]?.name || '')}. The prize is not exchangeable for cash and is subject to availability and any conditions advised to the winner.</p>`
+    : [
+        '<p><strong>Prizes:</strong></p>',
+        '<ol>',
+        ...legacyRows.map((p) => `<li>${numberWords(p.qty)} (${p.qty}) &times; ${escapeHtml(p.name)}</li>`),
+        '</ol>',
+        '<p>Prizes are not exchangeable for cash and are subject to availability and any conditions advised to winners.</p>',
+      ].join('\n');
+  const drawClause = single
+    ? `<p><strong>The draw:</strong> One winner is drawn at random from all verified entries after the entry period closes, in a process witnessed by MKTR staff. Completing a complimentary financial-review session on or before ${boostLong} earns you ${m} entries instead of one.</p>`
+    : `<p><strong>The draw:</strong> ${numberWords(total)} (${total}) winners are drawn at random from all verified entries after the entry period closes, in a process witnessed by MKTR staff. Prizes are awarded in the order listed above, with each prize awarded its stated number of times before the draw moves to the next. Each verified mobile number can win at most one prize. Completing a complimentary financial-review session on or before ${boostLong} earns you ${m} entries instead of one.</p>`;
+  const notifyClause = single
+    ? "<p><strong>Winner notification &amp; claim:</strong> The winner is contacted directly by phone or SMS using the details provided and has fourteen (14) days to respond and claim. If unclaimed within 14 days, a replacement winner is drawn. Results are posted, with the winner's masked details, at redeem.sg/winners.</p>"
+    : "<p><strong>Winner notification &amp; claim:</strong> Winners are contacted directly by phone or SMS using the details provided, and each has fourteen (14) days to respond and claim. If a prize is unclaimed within 14 days, a replacement winner is drawn for that prize. Results are posted, with each winner's masked details, at redeem.sg/winners.</p>";
+
   return [
     `<h3>Redeem &times; MKTR &mdash; ${name}</h3>`,
     '<p><strong>Promoter:</strong> MKTR PTE. LTD. (UEN 202507548M), Singapore. Redeem is a service of MKTR PTE. LTD.</p>',
-    `<p><strong>Prize:</strong> ${prizeText}. The prize is not exchangeable for cash and is subject to availability and any conditions advised to the winner.</p>`,
+    prizeClause,
     '<p><strong>Eligibility &amp; entry:</strong> Open to Singapore residents aged 18 and above. Entry is free. Complete the form and verify your mobile number with the one-time SMS code &mdash; one entry per verified mobile number.</p>',
     `<p><strong>Entry period:</strong> Entries close at 23:59 (SGT) on ${closesLong}. Entries received after that time are not eligible.</p>`,
-    `<p><strong>The draw:</strong> One winner is drawn at random from all verified entries after the entry period closes, in a process witnessed by MKTR staff. Completing a complimentary financial-review session on or before ${boostLong} earns you ${m} entries instead of one.</p>`,
-    "<p><strong>Winner notification &amp; claim:</strong> The winner is contacted directly by phone or SMS using the details provided and has fourteen (14) days to respond and claim. If unclaimed within 14 days, a replacement winner is drawn. Results are posted, with the winner's masked details, at redeem.sg/winners.</p>",
+    drawClause,
+    notifyClause,
     '<p><strong>Data &amp; contact:</strong> By entering you agree to be contacted by MKTR and its financial-advisory representatives about this promotion and related services, in line with our Personal Data Policy. We honour the Do Not Call registry and every opt-out.</p>',
     '<p><strong>Integrity:</strong> MKTR will never ask you to pay a fee to release a prize. Anyone requesting payment is not us &mdash; report them to hello@redeem.sg.</p>',
   ].join('\n');

--- a/src/pages/marketplace/MarketplaceFlow.jsx
+++ b/src/pages/marketplace/MarketplaceFlow.jsx
@@ -8,7 +8,7 @@ import {
 } from '@/lib/consentCopy';
 import { apiClient } from '@/api/client';
 import { getMarketplaceCampaign } from '@/api/marketplace';
-import { composeValueLine, fmtDateLong, isDrawCampaign, boostOf, offerUnavailability, UNAVAILABLE_COPY } from './content';
+import { composeValueLine, fmtDateLong, isDrawCampaign, boostOf, offerUnavailability, UNAVAILABLE_COPY, winnersDrawnSentence } from './content';
 import { formatDateInput, getAgeValidationError } from '@/components/campaigns/signup/dateUtils';
 import {
   shouldTrack, generateEventId, captureFbcFromUrl, captureUtmsFromUrl,
@@ -931,7 +931,7 @@ function Confirmation({ campaign, isDraw, boost, needAck, actSummary, result, pa
                 </Step>
               )}
               <Step n={boost ? '3' : '2'} apricot>
-                Entries close on {fmtDateLong(dc.luckyDraw?.closesAt)};{dc.luckyDraw?.winners ? ` ${dc.luckyDraw.winners}` : ''} winners are drawn within seven days.
+                Entries close on {fmtDateLong(dc.luckyDraw?.closesAt)}; {winnersDrawnSentence(dc.luckyDraw?.winners, { capitalize: false })}
               </Step>
               <Step n={boost ? '4' : '3'} apricot>
                 Winners are contacted at the number you verified and listed on the <Link to="/winners" className="rm-underline">winners page</Link>.

--- a/src/pages/marketplace/MarketplaceOffer.jsx
+++ b/src/pages/marketplace/MarketplaceOffer.jsx
@@ -3,7 +3,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import MarketplaceLayout from './MarketplaceLayout';
 import OfferCard from './OfferCard';
 import { getMarketplaceCampaign, listMarketplaceCampaigns } from '@/api/marketplace';
-import { composeValueLine, ageLabelOf, fmtDateLong, categoryLabel, isDrawCampaign, boostOf, offerUnavailability, UNAVAILABLE_COPY } from './content';
+import { composeValueLine, ageLabelOf, fmtDateLong, categoryLabel, isDrawCampaign, boostOf, offerUnavailability, UNAVAILABLE_COPY, winnersDrawnSentence } from './content';
 import { shouldTrack, initPixel, ensureFbp, trackEvent, captureFbcFromUrl, captureUtmsFromUrl } from '@/lib/metaPixel';
 import { shouldTrackTikTok, initTikTokPixel, trackTikTokViewContent, captureTtclidFromUrl } from '@/lib/tiktokPixel';
 import { getOrCreateVcState, markVcFired } from '@/lib/pixelSession';
@@ -202,7 +202,7 @@ export default function MarketplaceOffer() {
                     </DrawStep>
                   )}
                   <DrawStep n={boost ? '3' : '2'}>
-                    Entries close on {fmtDateLong(dc.luckyDraw?.closesAt)}.{dc.luckyDraw?.winners ? ` ${dc.luckyDraw.winners} winners are drawn within seven days.` : ' Winners are drawn within seven days.'}
+                    Entries close on {fmtDateLong(dc.luckyDraw?.closesAt)}. {winnersDrawnSentence(dc.luckyDraw?.winners)}
                   </DrawStep>
                   <DrawStep n={boost ? '4' : '3'}>
                     Winners are contacted at their verified number and listed (partially masked) on the <Link to="/winners" className="rm-underline">winners page</Link>.

--- a/src/pages/marketplace/__tests__/marketplaceFlow.test.js
+++ b/src/pages/marketplace/__tests__/marketplaceFlow.test.js
@@ -1,7 +1,21 @@
 import { describe, expect, test } from 'vitest';
 import { flattenFieldOrder, isFieldVisible, isFieldRequired, dobToIso } from '../MarketplaceFlow';
-import { offerUnavailability } from '../content';
+import { offerUnavailability, winnersDrawnSentence } from '../content';
 import { isTrackableLeadCapture } from '@/lib/pixelSuppression';
+
+describe('winnersDrawnSentence — verb-agreed draw copy', () => {
+  test('pluralizes by count and never prints "1 winners"', () => {
+    expect(winnersDrawnSentence(1)).toBe('1 winner is drawn within seven days.');
+    expect(winnersDrawnSentence(4)).toBe('4 winners are drawn within seven days.');
+  });
+
+  test('countless fallback capitalizes for sentence start, lowercases mid-sentence', () => {
+    expect(winnersDrawnSentence(undefined)).toBe('Winners are drawn within seven days.');
+    expect(winnersDrawnSentence(0)).toBe('Winners are drawn within seven days.');
+    expect(winnersDrawnSentence(null, { capitalize: false })).toBe('winners are drawn within seven days.');
+    expect(winnersDrawnSentence(4, { capitalize: false })).toBe('4 winners are drawn within seven days.');
+  });
+});
 
 describe('flattenFieldOrder — both production fieldOrder shapes', () => {
   test('legacy flat string[] passes through', () => {

--- a/src/pages/marketplace/content.js
+++ b/src/pages/marketplace/content.js
@@ -309,6 +309,17 @@ export const UNAVAILABLE_COPY = {
   unserviceable: { cta: 'Currently unavailable', title: "This offer isn't available right now", body: 'It may have ended or been paused. Plenty of other offers are live.' },
 };
 
+/**
+ * Verb-agreed winners sentence for draw copy: "4 winners are drawn within
+ * seven days." / "1 winner is drawn within seven days." / countless fallback
+ * "Winners are drawn within seven days." (capitalize:false for mid-sentence).
+ */
+export function winnersDrawnSentence(n, { capitalize = true } = {}) {
+  const c = Number.isInteger(n) && n > 0 ? n : null;
+  if (c) return `${c} ${c === 1 ? 'winner is' : 'winners are'} drawn within seven days.`;
+  return `${capitalize ? 'W' : 'w'}inners are drawn within seven days.`;
+}
+
 /** Boost tier facts — luckyDraw (authored dates) + ops.draw (live Draw row). */
 export function boostOf(campaign) {
   const ld = campaign?.design_config?.luckyDraw;


### PR DESCRIPTION
## What

The lucky-draw create flow's single free-text **Prize** field becomes structured rows of **(quantity) × (prize name)** — e.g. `(1) × iPhone 17 Pro` + `(3) × $100 FairPrice Voucher`.

- `design_config.luckyDraw.prizes = [{qty, name}]` (≤8 rows, qty 1..99, array order = award order) is canonical; `prize` (compact summary) and `winners` (Σqty) are **derived server-side** in `normalizeLuckyDraw` on every save path (v1 clamp + v2 Studio clamp), so no client can make them disagree. Explicitly-empty `prizes` on an admin write is a 422 (`DRAW_PRIZES_INVALID`), never a silent downgrade.
- Starter T&Cs pluralize: enumerated `<ol>` prize list with legal number words ("Three (3) × …"), "Four (4) winners are drawn…", exhaust-quantity award order, per-prize redraw, "each winner's masked details". Single-prize output is **byte-identical** (exact-equality regression test).
- **Fail-closed gate (Codex review BLOCKER)**: the live draw engine resolves exactly ONE claimed winner (a claimed `draw_attempts` row is terminal), so a campaign with Σqty > 1 can never BE active — non-forceable 422 `DRAW_MULTI_PRIZE_UNSUPPORTED` at `createCampaign` (API defaults `is_active` true!), `updateCampaign`, `setCampaignLaunchState`, and `createDraw`, plus a `critical` readiness row. Multi-prize draws save as drafts (workspace note says so); single-prize structured draws launch as usual. Phase 3 (multi-winner engine) removes the gates.
- Count-aware customer copy: the five draw templates' winner lines, both draw confirmation emails (count-neutral), marketplace `winnersDrawnSentence()` (also fixes the latent "1 winners" pluralization), chooser blurb. `publicLuckyDraw` exposes `prizes`.
- Legacy campaigns (hand-written `prize` string, e.g. Tokyo): byte-identical behavior, 80-char cap retained.

## Process

Plan → Codex CLI (gpt-5.6-sol, xhigh) adversarial review → every finding verified against origin/main code → v2 plan with disposition table (`docs/plans/lucky-draw-multi-prize-plan.md`) → implement. Codex verdict was REDESIGN on v1 (launchable-but-undeliverable multi-prize); v2 adopts its fail-closed remedy.

## Tests

- vitest **1710/1710** (baseline 1686 at #231; +24)
- backend touched suites **68/68**: `luckyDraw.util`, `publicDesignConfig`, `designConfigV2StudioClamp`, `luckyDrawService` (createDraw gate), new `drawMultiPrizeGate` (pure `assertDrawActivatable` + `computeReadiness` critical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHfU1pgowt39uxqq6MKmBe