### PR TITLE
feat(marketplace): Phase A — listing copy derives from the campaign page (flagged, read-precedence)

### DIFF
--- a/backend/scripts/marketplace-inherit-diff.js
+++ b/backend/scripts/marketplace-inherit-diff.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * Rollout diff for the marketplace-inheritance flip (plan §4): for every
+ * LISTED campaign (marketplace publication flag + slug — the real gate
+ * inputs) print the full listing design_config diff flag-OFF vs flag-ON,
+ * including the effective title fallback and card image; then diff every
+ * ENABLED featured drop's tile title. Reviewed before
+ * MARKETPLACE_INHERIT_ENABLED goes on — no live copy changes unseen.
+ * Remediation is a page-content edit.
+ *
+ * Run where DB env exists:  node scripts/marketplace-inherit-diff.js
+ */
+import { Campaign } from '../src/models/index.js';
+import { buildPublicDesignConfig, toDto } from '../src/services/marketplaceService.js';
+import { applyListingInheritance, deriveFeaturedDropTitle } from '../src/utils/listingDerivation.js';
+import { getStoredMarketplaceListed, getStoredFeaturedDrop } from '../src/utils/designConfigV2Clamp.js';
+import { normalizeFeaturedDrop } from '../src/utils/featuredDrop.js';
+
+const campaigns = await Campaign.findAll({
+  attributes: ['id', 'slug', 'name', 'status', 'is_active', 'min_age', 'max_age', 'metaPixelId', 'tiktokPixelId', 'design_config'],
+});
+
+const show = (v) => (v === undefined ? '(none)' : JSON.stringify(v));
+
+console.log('════ Marketplace listings (flag OFF → ON) ════');
+for (const c of campaigns) {
+  if (!c.slug || getStoredMarketplaceListed(c.design_config) !== true) continue;
+  const before = buildPublicDesignConfig(c.design_config);
+  const after = applyListingInheritance({ campaign: c, publicDc: before, rawDc: c.design_config });
+  const keys = [...new Set([...Object.keys(before), ...Object.keys(after)])].sort();
+  console.log(`\n■ ${c.name} (${c.slug}) — ${c.status}${c.is_active ? '/active' : '/inactive'}`);
+  console.log(`  effective title: ${show(before.name ?? c.name)} → ${show(after.name ?? c.name)}`);
+  let changed = false;
+  for (const k of keys) {
+    const a = JSON.stringify(before[k]);
+    const b = JSON.stringify(after[k]);
+    if (a !== b) {
+      changed = true;
+      console.log(`  ${k}: ${show(before[k])} → ${show(after[k])}`);
+    }
+  }
+  if (!changed) console.log('  (no key-level change)');
+}
+
+console.log('\n════ Featured drops (tile title, flag OFF → ON) ════');
+for (const c of campaigns) {
+  const fd = normalizeFeaturedDrop(getStoredFeaturedDrop(c.design_config));
+  if (!fd || fd.enabled !== true) continue;
+  const before = fd.title || c.name;
+  const after = deriveFeaturedDropTitle(c.design_config) || c.name;
+  console.log(`■ ${c.name}: ${show(before)} → ${show(after)}${before === after ? '  (unchanged)' : ''}`);
+}
+
+// toDto imported to keep the full-DTO path exercised in CI import checks.
+void toDto;
+process.exit(0);

--- a/backend/src/services/campaignService.js
+++ b/backend/src/services/campaignService.js
@@ -17,6 +17,7 @@ import {
   getStoredLuckyDraw,
 } from '../utils/designConfigV2Clamp.js';
 import { invalidateMarketplaceCache } from './marketplaceCache.js';
+import { invalidateFeaturedDropsCache } from './featuredDropsService.js';
 import { refundCampaignCommitments } from './walletService.js';
 
 const SLUG_RE = /^[a-z0-9-]{3,80}$/;
@@ -467,6 +468,7 @@ export async function createCampaign(body, user) {
     throw err;
   }
   invalidateMarketplaceCache();
+  invalidateFeaturedDropsCache();
 
   if (campaignData.design_config?.luckyDraw?.enabled === true) {
     const withTerms = await ensureDrawTermsVersion(campaignData.design_config, campaign.id, user.id);
@@ -618,6 +620,7 @@ export async function updateCampaign(id, body, req) {
     );
   }
   invalidateMarketplaceCache();
+  invalidateFeaturedDropsCache();
 
   // Sync agent assignments to join table when assigned_agents is provided
   if (assigned_agents !== undefined) {
@@ -736,6 +739,7 @@ export async function setCampaignLaunchState(id, state, req) {
     ...(isActive && !campaign.firstActivatedAt ? { firstActivatedAt: new Date() } : {}),
   });
   invalidateMarketplaceCache();
+  invalidateFeaturedDropsCache();
 
   // Fan-out: refresh device manifests (same as updateCampaign content changes).
   await notifyDevices(id);

--- a/backend/src/services/featuredDropsService.js
+++ b/backend/src/services/featuredDropsService.js
@@ -16,13 +16,35 @@ import { getStoredFeaturedDrop } from '../utils/designConfigV2Clamp.js';
 import { customerHostOrigin } from '../utils/customerHost.js';
 import { sgtDayEndExclusiveMs } from '../utils/sgtTime.js';
 import { logger } from '../utils/logger.js';
+import { deriveFeaturedDropTitle, marketplaceInheritEnabled } from '../utils/listingDerivation.js';
 
 const TTL_MS = 60_000;
 const GONE_RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // gone cards auto-hide 7d after endsAt
 const MAX_DROPS = 6;
 
-let cache = { data: null, ts: 0 };
+let cache = { data: null, ts: 0, mode: null };
+let generation = 0;
 let inflight = null;
+let inflightMode = null;
+let inflightGen = -1;
+
+/** Campaign saves invalidate this cache like the marketplace one — before
+ * this, a homepage tile could serve stale copy for up to 60s after an edit
+ * (and indefinitely across stale-on-error refreshes). */
+export function invalidateFeaturedDropsCache() {
+  generation += 1;
+  cache = { data: null, ts: 0, mode: null };
+}
+
+/** The homepage tile title rule (Phase A review finding 5): with inheritance
+ * ON the stored drop title never wins — derived headline, else campaign name.
+ * Flag OFF keeps the stored-first read byte-identical. */
+export function featuredTitleOf(designConfig, fd, campaignName) {
+  if (marketplaceInheritEnabled()) {
+    return deriveFeaturedDropTitle(designConfig) || campaignName;
+  }
+  return fd.title || campaignName;
+}
 
 // endsAt is inclusive through the whole SGT day: an instant is within the day
 // iff now < sgtDayEndExclusiveMs(endsAt) (shared util — the old private helper
@@ -66,7 +88,7 @@ async function fetchDrops(now) {
     const ended = endMs !== null && now >= endMs;
     const drop = {
       id: c.id,
-      title: fd.title || c.name,
+      title: featuredTitleOf(c.design_config, fd, c.name),
       valueLabel: fd.valueLabel || null,
       emoji: fd.emoji || null,
       status: capReached || ended ? 'gone' : 'live',
@@ -96,16 +118,23 @@ async function fetchDrops(now) {
  * and stale-on-error (a failed refresh serves the last good list).
  */
 export async function getFeaturedDrops({ now = Date.now() } = {}) {
-  if (cache.data && now - cache.ts < TTL_MS) return cache.data;
-  if (inflight) return inflight;
+  const mode = marketplaceInheritEnabled();
+  if (cache.data && cache.mode === mode && now - cache.ts < TTL_MS) return cache.data;
+  if (inflight && inflightMode === mode && inflightGen === generation) return inflight;
+  const gen = generation;
+  inflightMode = mode;
+  inflightGen = gen;
   inflight = fetchDrops(now)
     .then((data) => {
-      cache = { data, ts: now };
+      // Commit only if no save invalidated us mid-flight (review finding 2)
+      // and tag the mode so a flag flip can never serve the other mode's copy
+      // (finding 1) — including via the stale-on-error path below.
+      if (gen === generation) cache = { data, ts: now, mode };
       return data;
     })
     .catch((err) => {
       logger.error({ err: err?.message }, 'featured_drops.refresh_failed');
-      if (cache.data) return cache.data; // stale-on-error
+      if (cache.data && cache.mode === mode) return cache.data; // stale-on-error, same mode only
       throw err;
     })
     .finally(() => {

--- a/backend/src/services/marketplaceCache.js
+++ b/backend/src/services/marketplaceCache.js
@@ -5,17 +5,31 @@
  * its Redeem Ops model imports) into their own module graphs / test mocks.
  */
 
-let cache = { data: null, ts: 0 };
+let cache = { data: null, ts: 0, mode: null };
+let generation = 0;
 
 export function getMarketplaceCacheState() {
   return cache;
 }
 
-export function setMarketplaceCacheState(data, ts) {
-  cache = { data, ts };
+/** Monotonic invalidation counter — a refresh only commits if no mutation
+ * landed while it was in flight (Phase A review finding 2: the old cache
+ * could be repopulated with pre-save data by an already-running refresh). */
+export function getMarketplaceCacheGeneration() {
+  return generation;
+}
+
+/** `mode` tags the entry with the inheritance-flag value it was built under
+ * (finding 1: a flag flip must never serve the other mode's copy, including
+ * via stale-on-error). Returns false when the commit lost to an invalidation. */
+export function setMarketplaceCacheState(data, ts, mode = null, gen = generation) {
+  if (gen !== generation) return false;
+  cache = { data, ts, mode };
+  return true;
 }
 
 /** Write-side invalidation — admin actions show within one request. */
 export function invalidateMarketplaceCache() {
-  cache = { data: null, ts: 0 };
+  generation += 1;
+  cache = { data: null, ts: 0, mode: null };
 }

--- a/backend/src/services/marketplaceService.js
+++ b/backend/src/services/marketplaceService.js
@@ -46,10 +46,14 @@ const TTL_MS = 60_000;
 const MAX_STALE_MS = 5 * 60_000;
 
 let inflight = null;
+let inflightMode = null;
+let inflightGen = -1;
 
 // Cache state + write-side invalidation live in marketplaceCache.js (model-free)
 // so writer services can bust it without importing this read model.
 export { invalidateMarketplaceCache } from './marketplaceCache.js';
+import { getMarketplaceCacheGeneration } from './marketplaceCache.js';
+import { applyListingInheritance, marketplaceInheritEnabled } from '../utils/listingDerivation.js';
 
 const LIVE_ACTIVATION_STATUSES = ['active'];
 
@@ -222,7 +226,15 @@ const CAMPAIGN_ATTRS = [
   'metaPixelId', 'tiktokPixelId', 'design_config',
 ];
 
-function toDto(campaign, ops) {
+export function toDto(campaign, ops) {
+  // Phase A inheritance (plan: marketplace-inherits-campaign-page): behind the
+  // flag, listing COPY derives from page content at this single choke point —
+  // list, detail, and preview all pass through here. Flag off = stored reads,
+  // byte-identical (the emergency brake).
+  const publicDc = buildPublicDesignConfig(campaign.design_config);
+  const design_config = marketplaceInheritEnabled()
+    ? applyListingInheritance({ campaign, publicDc, rawDc: campaign.design_config })
+    : publicDc;
   return {
     id: campaign.id,
     slug: campaign.slug,
@@ -231,7 +243,7 @@ function toDto(campaign, ops) {
     max_age: campaign.max_age ?? null,
     metaPixelId: campaign.metaPixelId || null,
     tiktokPixelId: campaign.tiktokPixelId || null,
-    design_config: buildPublicDesignConfig(campaign.design_config),
+    design_config,
     ops,
   };
 }
@@ -270,20 +282,26 @@ async function fetchAll(now) {
   return out;
 }
 
-/** Public list — 60s TTL, coalesced, stale-on-error bounded to MAX_STALE_MS. */
+/** Public list — 60s TTL, coalesced, stale-on-error bounded to MAX_STALE_MS.
+ * Cache identity includes the inheritance mode, and refreshes commit only when
+ * no invalidation landed mid-flight (Phase A review findings 1–2). */
 export async function listMarketplaceCampaigns({ now = Date.now() } = {}) {
+  const mode = marketplaceInheritEnabled();
   const cache = getMarketplaceCacheState();
-  if (cache.data && now - cache.ts < TTL_MS) return cache.data;
-  if (inflight) return inflight;
+  if (cache.data && cache.mode === mode && now - cache.ts < TTL_MS) return cache.data;
+  if (inflight && inflightMode === mode && inflightGen === getMarketplaceCacheGeneration()) return inflight;
+  const gen = getMarketplaceCacheGeneration();
+  inflightMode = mode;
+  inflightGen = gen;
   inflight = fetchAll(now)
     .then((data) => {
-      setMarketplaceCacheState(data, now);
+      setMarketplaceCacheState(data, now, mode, gen);
       return data;
     })
     .catch((err) => {
       logger.error({ err: err?.message }, 'marketplace.refresh_failed');
       const stale = getMarketplaceCacheState();
-      if (stale.data && now - stale.ts < MAX_STALE_MS) return stale.data;
+      if (stale.data && stale.mode === mode && now - stale.ts < MAX_STALE_MS) return stale.data;
       throw err;
     })
     .finally(() => {

--- a/backend/src/utils/listingDerivation.js
+++ b/backend/src/utils/listingDerivation.js
@@ -1,0 +1,136 @@
+/**
+ * Marketplace-inherits-the-campaign-page — Phase A derivation
+ * (docs/plans/marketplace-inherits-campaign-page.md, Codex-reviewed v2).
+ *
+ * The single place marketplace listing COPY is derived from campaign-page
+ * content. Behind MARKETPLACE_INHERIT_ENABLED (read per call; default off):
+ * flag off, every read is byte-identical to the stored behavior — a true
+ * emergency brake. Flag on, the derived value WINS over stored listing copy
+ * for exactly the DERIVED set below; placement picks (category, mode,
+ * availability, audience age_range, non-draw activation facts, FAQ/data-use,
+ * non-draw inclusions, …) always pass through untouched.
+ *
+ * Derived set (plan §1.1):
+ *   name           ← content headline (generic/empty → dropped so consumers
+ *                    fall back to campaign.name via the usual `dc.name ||`)
+ *   description    ← content story              (NEW key; door block in Phase B)
+ *   regulatory_line← content footer regulatory  (NEW key; door footer in Phase B)
+ *   value_line     ← draws: derived prize summary · non-draws: DROPPED so the
+ *                    frontend's existing ops.retail_value fact-fallback renders
+ *   image_label    ← v2 media alt (image-kind only; v1 docs have no alt source
+ *                    so their stored image_label is left untouched)
+ *   prize_breakdown← draws: luckyDraw.prizes rows (NEW key — rendered as
+ *                    "Prizes" in Phase B, never through `inclusions`)
+ *   inclusions     ← draws only: DROPPED (the "Includes ✓" framing implies
+ *                    entitlement; prize_breakdown replaces it)
+ *
+ * Pure module: no models, no I/O — the same function the Phase B client twin
+ * will mirror (lockstep-tested), and the rollout diff script replays.
+ */
+
+import { readLegacyViewSafe } from './designConfigV2Clamp.js';
+
+export function marketplaceInheritEnabled() {
+  return process.env.MARKETPLACE_INHERIT_ENABLED === 'true';
+}
+
+/** Headlines that are template defaults, not campaign copy — never a title.
+ * Exactly the renderer/editor default (review finding 6: legitimate short
+ * headlines like "Sign Up" must not be suppressed). */
+const GENERIC_HEADLINES = new Set(['get started']);
+
+const clean = (v, max) => {
+  if (typeof v !== 'string') return undefined;
+  const s = v.replace(/\s+/g, ' ').trim().slice(0, max);
+  return s || undefined;
+};
+
+function isV2Doc(raw) {
+  return !!raw && typeof raw === 'object' && raw.version === 2;
+}
+
+/** Derived listing title, shared rule for every consumer (plan: listingTitleOf). */
+export function deriveListingTitle(rawDc, legacy) {
+  const headline = clean(
+    isV2Doc(rawDc) ? rawDc.content?.headline : legacy.formHeadline,
+    120
+  );
+  if (!headline || GENERIC_HEADLINES.has(headline.toLowerCase())) return undefined;
+  return headline;
+}
+
+/** Featured-drop title inherits the same headline, at the drop's 40-char cap. */
+export function deriveFeaturedDropTitle(rawDc) {
+  const legacy = readLegacyViewSafe(rawDc || {}, {});
+  const title = deriveListingTitle(rawDc, legacy);
+  return title ? title.slice(0, 40) : undefined;
+}
+
+/**
+ * Overlay the derived view onto the already-built public design_config.
+ * `publicDc` is buildPublicDesignConfig's output (normalized picks + public
+ * luckyDraw incl. structured prizes); `rawDc` is the stored doc (version-aware
+ * reads); `campaign` supplies nothing yet but stays in the signature so the
+ * client twin and future derivations share one shape.
+ */
+export function applyListingInheritance({ campaign: _campaign, publicDc, rawDc }) {
+  const out = { ...publicDc };
+  const legacy = readLegacyViewSafe(rawDc || {}, {});
+  const v2 = isV2Doc(rawDc);
+  const draw = out.luckyDraw?.enabled === true;
+
+  // Title — derived wins; generic/absent headline deletes the stored title so
+  // the campaign-name fallback (the pre-listing behavior) takes over.
+  const title = deriveListingTitle(rawDc, legacy);
+  if (title) out.name = title;
+  else delete out.name;
+
+  // Description + regulatory line — new keys, page-sourced only.
+  const description = clean(legacy.storyText, 1200);
+  if (description) out.description = description;
+  else delete out.description;
+  const regulatory = clean(legacy.regulatoryFooter, 1000);
+  if (regulatory) out.regulatory_line = regulatory;
+  else delete out.regulatory_line;
+
+  // Value line — facts, not copy (plan §1.1), clamped to the existing
+  // 80-char marketplace cap (review finding 7: a max structured summary is
+  // ~700 chars; complete names live in prize_breakdown).
+  const prizeFact = draw ? clean(out.luckyDraw?.prize, 80) : undefined;
+  if (prizeFact) out.value_line = prizeFact;
+  else delete out.value_line;
+
+  // Card image — the page hero IS the card image (review finding 4: the
+  // marketplace DTO never carried imageUrl at all). Image kind only, both
+  // versions; non-image media has no card image and no alt. v1 docs have no
+  // page-level alt, so their stored image_label survives only alongside a
+  // real page image.
+  const mediaKind = v2
+    ? (rawDc?.content?.media?.kind || 'none')
+    : (legacy.mediaType || (legacy.imageUrl ? 'image' : 'none'));
+  const mediaSrc = v2 ? rawDc?.content?.media?.src : legacy.imageUrl;
+  if (mediaKind === 'image' && typeof mediaSrc === 'string' && mediaSrc) {
+    out.imageUrl = mediaSrc.slice(0, 2048);
+    if (v2) {
+      const alt = clean(rawDc.content?.media?.alt, 120);
+      if (alt) out.image_label = alt;
+      else delete out.image_label;
+    }
+  } else {
+    delete out.imageUrl;
+    delete out.image_label;
+  }
+
+  // Draw prize rows — structured output rendered as "Prizes" (Phase B); the
+  // entitlement-flavored inclusions section is suppressed for draws.
+  if (draw) {
+    const prizes = Array.isArray(out.luckyDraw?.prizes) ? out.luckyDraw.prizes : null;
+    if (prizes && prizes.length) out.prize_breakdown = prizes.map((p) => ({ qty: p.qty, name: p.name }));
+    else delete out.prize_breakdown;
+    delete out.inclusions;
+  } else {
+    delete out.prize_breakdown;
+  }
+
+  return out;
+}

--- a/backend/test/listingDerivation.test.js
+++ b/backend/test/listingDerivation.test.js
@@ -1,0 +1,271 @@
+/**
+ * Marketplace-inherits-campaign-page, Phase A (plan §4 matrix, backend half):
+ * the derivation overlay, the flag-off oracle, and the parity MUST — edit the
+ * page content, the listing view changes.
+ */
+import {
+  applyListingInheritance,
+  deriveListingTitle,
+  deriveFeaturedDropTitle,
+  marketplaceInheritEnabled,
+} from '../src/utils/listingDerivation.js';
+import { buildPublicDesignConfig, toDto } from '../src/services/marketplaceService.js';
+import { featuredTitleOf } from '../src/services/featuredDropsService.js';
+import {
+  getMarketplaceCacheState,
+  setMarketplaceCacheState,
+  getMarketplaceCacheGeneration,
+  invalidateMarketplaceCache,
+} from '../src/services/marketplaceCache.js';
+import { readLegacyViewSafe } from '../src/utils/designConfigV2Clamp.js';
+
+const CAMPAIGN = { id: 'c1', name: 'Internal Campaign Name' };
+
+/** Tokyo-shaped v2 draw doc with STORED listing copy that must lose to the page. */
+const v2DrawDoc = {
+  version: 2,
+  template: { id: 'postcard', params: {} },
+  theme: { preset: 'paper-white', accent: '#3B82F6' },
+  content: {
+    wordmark: 'redeem.sg',
+    headline: 'Win a 4D3N Tokyo Getaway',
+    subheadline: 'Return flights + 3 nights hotel.',
+    story: 'Drop your details and you are in the draw.',
+    footer: { regulatory: 'Organised by MKTR Pte. Ltd. No purchase necessary.', brand: '' },
+    media: { kind: 'image', src: '/uploads/tokyo.jpg', alt: 'Tokyo skyline at dusk' },
+  },
+  form: { fields: [], verification: 'sms', terms: { template: 'default', html: '<p>T</p>' }, gates: {} },
+  distribution: {
+    host: 'redeem',
+    marketplace: {
+      listed: true,
+      title: 'STORED LISTING TITLE',
+      valueLine: 'STORED VALUE LINE',
+      imageAlt: 'STORED ALT',
+      inclusions: ['stored inclusion'],
+      category: 'family_lifestyle',
+      mode: 'hybrid',
+      dataUse: 'Stored data use.',
+    },
+  },
+  luckyDraw: {
+    enabled: true,
+    prizes: [{ qty: 1, name: 'iPhone 17 Pro' }, { qty: 3, name: 'AirPods' }],
+    closesAt: '2026-10-30',
+    boostClosesAt: '2026-10-30',
+    multiplier: 10,
+  },
+};
+
+const overlayOf = (doc, campaign = CAMPAIGN) => {
+  const publicDc = buildPublicDesignConfig(doc);
+  return applyListingInheritance({ campaign, publicDc, rawDc: doc });
+};
+
+describe('flag plumbing', () => {
+  it('defaults off and reads per call', () => {
+    delete process.env.MARKETPLACE_INHERIT_ENABLED;
+    expect(marketplaceInheritEnabled()).toBe(false);
+    process.env.MARKETPLACE_INHERIT_ENABLED = 'true';
+    expect(marketplaceInheritEnabled()).toBe(true);
+    delete process.env.MARKETPLACE_INHERIT_ENABLED;
+  });
+});
+
+describe('applyListingInheritance — v2 draw doc', () => {
+  it('page content WINS over stored listing copy across the derived set', () => {
+    const out = overlayOf(v2DrawDoc);
+    expect(out.name).toBe('Win a 4D3N Tokyo Getaway');           // not STORED LISTING TITLE
+    expect(out.description).toBe('Drop your details and you are in the draw.');
+    expect(out.regulatory_line).toBe('Organised by MKTR Pte. Ltd. No purchase necessary.');
+    expect(out.value_line).toBe(out.luckyDraw.prize);            // derived prize summary fact
+    expect(out.image_label).toBe('Tokyo skyline at dusk');       // not STORED ALT
+    expect(out.imageUrl).toBe('/uploads/tokyo.jpg');             // page hero IS the card image (finding 4)
+    expect(out.prize_breakdown).toEqual([{ qty: 1, name: 'iPhone 17 Pro' }, { qty: 3, name: 'AirPods' }]);
+    expect(out.inclusions).toBeUndefined();                      // draws never say "Includes"
+  });
+
+  it('placement picks pass through untouched', () => {
+    const out = overlayOf(v2DrawDoc);
+    expect(out.category).toBe('family_lifestyle');
+    expect(out.mode).toBe('hybrid');
+    expect(out.content_blocks?.data_use).toBe('Stored data use.');
+    expect(out.luckyDraw.enabled).toBe(true);
+  });
+
+  it('THE MUST: editing page content changes the listing view', () => {
+    const edited = structuredClone(v2DrawDoc);
+    edited.content.headline = 'Win a Trip to Osaka';
+    edited.content.story = 'A new story.';
+    const out = overlayOf(edited);
+    expect(out.name).toBe('Win a Trip to Osaka');
+    expect(out.description).toBe('A new story.');
+  });
+
+  it('generic or missing headline drops the title so campaign.name falls back downstream', () => {
+    const generic = structuredClone(v2DrawDoc);
+    generic.content.headline = 'Get Started';
+    expect(overlayOf(generic).name).toBeUndefined();
+    const missing = structuredClone(v2DrawDoc);
+    missing.content.headline = '';
+    expect(overlayOf(missing).name).toBeUndefined();
+  });
+
+  it('non-image media never emits an image label (or card image)', () => {
+    const video = structuredClone(v2DrawDoc);
+    video.content.media = { kind: 'youtube', src: 'https://youtu.be/x', alt: 'ignored' };
+    const out = overlayOf(video);
+    expect(out.image_label).toBeUndefined();
+    expect(out.imageUrl).toBeUndefined();
+  });
+
+  it('a short legitimate headline like "Sign Up" IS a valid title (only the template default is generic)', () => {
+    const doc = structuredClone(v2DrawDoc);
+    doc.content.headline = 'Sign Up';
+    expect(overlayOf(doc).name).toBe('Sign Up');
+  });
+
+  it('a maximal structured prize summary clamps to the 80-char value cap; full names stay in prize_breakdown', () => {
+    const doc = structuredClone(v2DrawDoc);
+    doc.luckyDraw.prizes = Array.from({ length: 8 }, (_, i) => ({ qty: 9, name: `Extremely Long Prize Name Number ${i + 1} With Extra Words` }));
+    const out = overlayOf(doc);
+    expect(out.value_line.length).toBeLessThanOrEqual(80);
+    expect(out.prize_breakdown).toHaveLength(8);
+  });
+});
+
+describe('applyListingInheritance — non-draw + v1 docs', () => {
+  const v2Plain = {
+    ...structuredClone(v2DrawDoc),
+    luckyDraw: undefined,
+  };
+
+  it('non-draw: value_line drops (frontend renders the ops retail fact); no prize_breakdown; inclusions kept', () => {
+    const out = overlayOf(v2Plain);
+    expect(out.value_line).toBeUndefined();
+    expect(out.prize_breakdown).toBeUndefined();
+    expect(out.inclusions).toEqual(['stored inclusion']); // non-draw pick passes through
+  });
+
+  it('v1 non-image media deletes the stored image_label and card image (image-kind precedence)', () => {
+    const v1video = {
+      formHeadline: 'V1 Video Campaign',
+      mediaType: 'video',
+      videoUrl: '/uploads/v.mp4',
+      marketplaceListed: true,
+      image_label: 'stale stored label',
+      customerHost: 'redeem',
+    };
+    const out = overlayOf(v1video);
+    expect(out.image_label).toBeUndefined();
+    expect(out.imageUrl).toBeUndefined();
+  });
+
+  it('v1 docs derive from v1 keys and keep their stored image_label (no alt source)', () => {
+    const v1 = {
+      formHeadline: 'V1 Headline',
+      storyText: 'V1 story.',
+      regulatoryFooter: 'V1 regulatory.',
+      imageUrl: '/uploads/x.jpg',
+      mediaType: 'image',
+      marketplaceListed: true,
+      name: 'stored v1 title',
+      image_label: 'v1 stored label',
+      customerHost: 'redeem',
+    };
+    const out = overlayOf(v1);
+    expect(out.name).toBe('V1 Headline');
+    expect(out.description).toBe('V1 story.');
+    expect(out.regulatory_line).toBe('V1 regulatory.');
+    expect(out.image_label).toBe('v1 stored label'); // untouched — no page-level alt exists in v1
+    expect(out.imageUrl).toBe('/uploads/x.jpg');     // v1 page image inherits as the card image
+  });
+});
+
+describe('flag-off oracle', () => {
+  it('buildPublicDesignConfig output is untouched by Phase A (stored reads byte-identical)', () => {
+    const publicDc = buildPublicDesignConfig(v2DrawDoc);
+    expect(publicDc.name).toBe('STORED LISTING TITLE');
+    expect(publicDc.value_line).toBe('STORED VALUE LINE');
+    expect(publicDc.image_label).toBe('STORED ALT');
+    expect(publicDc.inclusions).toEqual(['stored inclusion']);
+    expect(publicDc.description).toBeUndefined();
+    expect(publicDc.prize_breakdown).toBeUndefined();
+  });
+});
+
+describe('featured-drop title inheritance', () => {
+  it('derives the headline at the 40-char drop cap; undefined on generic', () => {
+    expect(deriveFeaturedDropTitle(v2DrawDoc)).toBe('Win a 4D3N Tokyo Getaway');
+    const long = structuredClone(v2DrawDoc);
+    long.content.headline = 'A very long headline that exceeds the forty character drop cap easily';
+    expect(deriveFeaturedDropTitle(long)).toHaveLength(40);
+    const generic = structuredClone(v2DrawDoc);
+    generic.content.headline = 'Get Started';
+    expect(deriveFeaturedDropTitle(generic)).toBeUndefined();
+  });
+});
+
+describe('toDto — the real choke point, flag off vs on (review finding 9)', () => {
+  const campaignRow = { ...CAMPAIGN, slug: 'tokyo-draw', min_age: 18, max_age: 99, metaPixelId: null, tiktokPixelId: null, design_config: v2DrawDoc };
+
+  afterEach(() => { delete process.env.MARKETPLACE_INHERIT_ENABLED; });
+
+  it('flag OFF: stored listing copy serves byte-identically through toDto', () => {
+    delete process.env.MARKETPLACE_INHERIT_ENABLED;
+    const dto = toDto(campaignRow, null);
+    expect(dto.design_config.name).toBe('STORED LISTING TITLE');
+    expect(dto.design_config.value_line).toBe('STORED VALUE LINE');
+    expect(dto.design_config.description).toBeUndefined();
+  });
+
+  it('flag ON: the derived view serves through toDto', () => {
+    process.env.MARKETPLACE_INHERIT_ENABLED = 'true';
+    const dto = toDto(campaignRow, null);
+    expect(dto.design_config.name).toBe('Win a 4D3N Tokyo Getaway');
+    expect(dto.design_config.imageUrl).toBe('/uploads/tokyo.jpg');
+    expect(dto.design_config.inclusions).toBeUndefined();
+  });
+});
+
+describe('marketplace cache — mode identity + invalidation generation (findings 1–2)', () => {
+  afterEach(() => invalidateMarketplaceCache());
+
+  it('a refresh that lost to an invalidation does not commit', () => {
+    const gen = getMarketplaceCacheGeneration();
+    invalidateMarketplaceCache(); // mutation lands while the refresh is in flight
+    expect(setMarketplaceCacheState(['stale-data'], Date.now(), false, gen)).toBe(false);
+    expect(getMarketplaceCacheState().data).toBeNull();
+  });
+
+  it('entries are mode-tagged so a flag flip cannot serve the other mode', () => {
+    expect(setMarketplaceCacheState(['off-mode-data'], Date.now(), false)).toBe(true);
+    expect(getMarketplaceCacheState().mode).toBe(false);
+  });
+});
+
+describe('featuredTitleOf (finding 5)', () => {
+  afterEach(() => { delete process.env.MARKETPLACE_INHERIT_ENABLED; });
+
+  it('flag ON: derived headline, else campaign name — the stored drop title never wins', () => {
+    process.env.MARKETPLACE_INHERIT_ENABLED = 'true';
+    expect(featuredTitleOf(v2DrawDoc, { title: 'STORED DROP' }, 'Camp')).toBe('Win a 4D3N Tokyo Getaway');
+    const generic = structuredClone(v2DrawDoc);
+    generic.content.headline = 'Get Started';
+    expect(featuredTitleOf(generic, { title: 'STORED DROP' }, 'Camp')).toBe('Camp');
+  });
+
+  it('flag OFF: stored-first read is unchanged', () => {
+    expect(featuredTitleOf(v2DrawDoc, { title: 'STORED DROP' }, 'Camp')).toBe('STORED DROP');
+    expect(featuredTitleOf(v2DrawDoc, {}, 'Camp')).toBe('Camp');
+  });
+});
+
+describe('deriveListingTitle helper', () => {
+  it('is the one title rule (v2 + v1 + fallback contract)', () => {
+    expect(deriveListingTitle(v2DrawDoc, readLegacyViewSafe(v2DrawDoc, {}))).toBe('Win a 4D3N Tokyo Getaway');
+    const v1 = { formHeadline: '  Spaced   Headline  ' };
+    expect(deriveListingTitle(v1, readLegacyViewSafe(v1, {}))).toBe('Spaced Headline');
+    expect(deriveListingTitle({}, {})).toBeUndefined();
+  });
+});

--- a/docs/plans/marketplace-inherits-campaign-page.md
+++ b/docs/plans/marketplace-inherits-campaign-page.md
@@ -1,0 +1,103 @@
+# Marketplace inherits the campaign page — single-door content, structural parity
+
+**Date:** 2026-07-22 · **Status:** v2 — Codex xhigh review folded (14 findings; disposition in §9) · **Owner intent (Shawn):** "marketplace should inherit the campaign page FULLY, with only one door to make edits. any edit made on the lead capture page MUST be reflected on the same campaign's marketplace sign up page."
+
+## 0. The principle
+
+Today the marketplace renders a second, hand-filled content set (`distribution.marketplace.*`). This plan makes every value that has a home on the campaign page **derived** from it at read time, then — after a verified soak — removes the duplicated inputs so drift becomes schema-impossible. Copy is edited in one place (the campaign page); placement facts that have no page equivalent stay in Distribution. The two **visitor** doors stay; the legal/mechanical single sources (terms version, OTP, draw gate) are already shared and untouched.
+
+## 1. Field-by-field map (post-review)
+
+### 1.1 Derived (page → marketplace)
+
+| Marketplace output | Derived from | Rules |
+|---|---|---|
+| Listing title (`design_config.name`) | `content.headline`, via one `listingTitleOf` helper | falls back to `campaign.name` when the headline is empty or the "Get Started" default; the SAME helper feeds card, browse, search, image-alt fallback AND the Meta/TikTok tracking title (today analytics use the internal name — unify); Studio readiness warns on generic headlines |
+| Offer description (NEW door block, `description`) | `content.story` | plain-text render, existing story cap |
+| `value_line` | **facts, not copy**: draws → derived `luckyDraw.prize` summary (qty×name); non-draws → ops retail value ("Worth S$X · free …") | `content.emphasis` is NOT used (it's a story line, not a value fact — review §9.6) |
+| Card/door image + `image_label` | `content.media` | **only when `media.kind === 'image'`**; video/youtube → no card image (placeholder tag); poster support = future note (§9.8) |
+| Draw prize list (NEW `prize_breakdown[]`) | `luckyDraw.prizes` rows | rendered as **"Prizes"** on card/door — never through `inclusions`, whose "Includes ✓" framing implies every entrant receives them (§9.7) |
+| Draw boost line (card box, door "How this draw works", flow confirmation) | facts from `ops.draw` → fallback `luckyDraw` (multiplier, boostClosesAt) + ONE shared frontend constant in `marketplace/content.js`, imported by `drawTemplates.jsx` too | neutral wording — "when your consultant **records** your completed session" (scan OR approved virtual confirmation both count — §9.11); replaces the hardcoded "activation step" phrasing |
+| Door footer regulatory line (`regulatory_line`) | `content.footer.regulatory` | text render |
+| `featuredDrop.title` | `content.headline` (clamped 40) | via the shared derivation used by BOTH marketplaceService and featuredDropsService (§9.9); `valueLabel` (12-char micro-copy) has no faithful source and STAYS a pick |
+
+### 1.2 Placement picks & mechanical facts (stay in Distribution — no page equivalent)
+
+`listed`, `category`, `offerType`, `mode`, `qrLanding`, `showCapacity`, `schoolLevels`, `dsaRelated`, `availability`, `sponsor`, `dataUse`, `cancellation`, `faq`, **`inclusions` (non-draw offers — describes offer contents, no page source; hidden for draws)**, **audience `age_range` (the OFFER's audience — a P3 enrichment trial's audience is the child; `campaign.min_age/max_age` is the adult SUBMITTER gate and must never masquerade as it — §9.2)**, **`activation.required/type/durationMins/summary/detail` for non-draw offers (mechanical requirement facts driving the flow's blocking acknowledgement — `composeOps` has no derivable source: `publicTitle` is the reward's name, not the required activity — §9.5)**, `featuredDrop.enabled/emoji/cap/endsAt/valueLabel`.
+
+### 1.3 Already single-source (unchanged)
+
+Terms (`form.terms.html` both funnels, pinned versions), OTP/consent/one-entry mechanics, draw facts, gates (`sgPr`/DNC/advisor), host choice, hero image on the page itself.
+
+## 2. The choke point + explicit DTO contract
+
+`deriveListingView(campaign, dc, ops)` in `marketplaceService.js` (pure, exported) emits the EXISTING flat consumer keys plus the new ones — exact contract:
+
+`name` (derived title) · `description` · `regulatory_line` · `prize_breakdown[]` ({qty, name}) · `value_line` · `image_url`/`image_label` (image-kind only) · unchanged pass-throughs for every §1.2 pick · unchanged `termsContent`/gates/flow keys.
+
+Sanitization: derived strings clamped to the existing listing caps; all values plain text. Consumers: OfferCard, MarketplaceBrowse, MarketplaceOffer (incl. tracking via `listingTitleOf`), MarketplaceFlow, featuredDropsService (shared derivation). QR tracker verified clean — reads `qr_entry` + static gate only (§9-clean).
+
+**Freshness:** door/detail composes live per request → Studio saves reflect immediately; public list ≤60s (server cache, invalidated on campaign save) + ≤60s client cache; featuredDrops cache gains the same save-invalidation (today it has none — §9.9). Flag flips invalidate both caches (cache identity includes the flag).
+
+## 3. Rollout — three phases, reversibility preserved (§9.3)
+
+| Phase | Scope | Reversible? |
+|---|---|---|
+| **A — derivation, read-precedence only** (backend, `MARKETPLACE_INHERIT_ENABLED` default off → verified on) | `deriveListingView` + new DTO keys + shared featuredDrop derivation + cache invalidations. Stored listing copy KEEPS persisting exactly as today (clamp untouched); the flag only changes read precedence (derived wins). Flag-off = byte-identical old reads — a true brake. Dual goldens: the existing flag-off oracle stays frozen; a NEW flag-on derivation golden is added (§9.12). | Fully |
+| **B — single-door UI** | BOTH editors converted (Studio DistributionPanel AND the classic MarketplacePanel — the classic editor still edits every derived field and would silently lose writes otherwise, §9.10): picks + a read-only "Inherited from the campaign page" preview. Preview of UNSAVED docs uses a client twin of `deriveListingView` (lockstep-tested against the server fn, same pattern as the designConfigV2 twins). AI "Fill everything" contract shrinks in the same PR: prompts, context echo, strict schema, INCLUSIONS scope (draws), sanitizers, useStudioAi apply paths, and the Studio/Distribution/canvas tests together (§9.13). Door gains the description block + derived wordings. ALSO (from §9b.6): the client `listingTitleOf` helper unifying visible/search/alt/tracking titles, and the generic-headline readiness warning. | UI-only |
+| **C — destructive cleanup** (after A+B soak ≥ a week) | Clamp/normalizers stop accepting the derived-copy keys (both twins + goldens re-pinned); stale stored keys strip on next save. Only NOW does single-door become schema-enforced — and only now is rollback no longer trivial, by explicit sign-off. | By design, no |
+
+## 4. Test matrix (from review §9.14 — pinned, not hoped)
+
+- Parity contract: content-filled doc, no listing copy → DTO mirrors page; **edit content → DTO changes** (the MUST in one assertion).
+- Flag on/off × v1/v2 docs × list/detail/preview; warm-cache transitions incl. stale-on-error; flip invalidation (marketplace + featuredDrops).
+- Precedence in Phase A: stored copy present → stored wins only when flag OFF.
+- Classic editor + unsaved Studio preview (client-twin lockstep).
+- Audience age vs submitter gate: school-level label precedence + browse age filtering unchanged.
+- Activation-required acknowledgement (non-draw) renders operator facts; draws render derived wording; singular/plural prize rendering; "Prizes" never says "Includes".
+- Media kinds: image/video/youtube/none → card image only for image.
+- Visible title vs tracking title unified via `listingTitleOf`; generic-headline readiness warning.
+- Derived description/regulatory caps + no-leak (public whitelist negative tests updated).
+- QR routing unchanged under the flag.
+- Rollout diff script: before/after DTOs for EVERY listed campaign (not a hardcoded pair), reviewed pre-flip; remediation = page-content edits.
+
+## 5. Explicit exclusions from the parity promise
+
+Generic marketplace brand surfaces (homepage hero annotation, How-It-Works steps, static explainer pages, FAQ copy in `content.js`) are brand copy, not campaign copy — they keep their own wording (§9.11). The visitor-facing funnels stay two doors. Quiz/guided-review remain unlistable types.
+
+## 6. Sizing
+
+Phase A: M · Phase B: M–L (two editors + AI contract + twin) · Phase C: S. Each phase is one PR with its own Codex diff review.
+
+## 9. Review log — Codex (gpt-5.6-sol, xhigh), 2026-07-22, 14 findings
+
+| # | Sev | Disposition |
+|---|---|---|
+| 1 | BLOCKER | **False positive — stale checkout.** Reviewed from the shared tree ~20 commits behind; `luckyDraw.prizes` (#232) and `drawTemplates.jsx` (#226) exist on origin/main. Verified. Process note adopted: **Codex reviews must run from a synced worktree.** |
+| 2 | BLOCKER | Adopted — audience age stays a pick; never derived from the submitter gate (§1.2). |
+| 3 | BLOCKER | Adopted — three-phase rollout; Phase A is precedence-only with persistence untouched; caches flag-aware; destructive removal isolated in Phase C (§3). |
+| 4 | MAJOR | Adopted — explicit DTO contract + `listingTitleOf` unifying visible titles and tracking (§2). |
+| 5 | MAJOR | Adopted — non-draw activation facts remain operator inputs; only draw wording derives (§1.2). |
+| 6 | MAJOR | Adopted — emphasis dropped as a value source; value derives from prize/retail facts; generic-headline readiness warning (§1.1). |
+| 7 | MAJOR | Adopted — `prize_breakdown` rendered as "Prizes", never `inclusions` (§1.1). |
+| 8 | MAJOR | Adopted — image-kind-only derivation; poster policy deferred explicitly (§1.1). |
+| 9 | MAJOR | Adopted — shared derivation for featuredDrops + save/flip invalidation; `valueLabel` stays a pick (§1.1, §2). |
+| 10 | MAJOR | Adopted — classic MarketplacePanel converted in Phase B; unsaved previews via lockstep client twin (§3B). |
+| 11 | MAJOR | Adopted — neutral "records your completed session" wording, `ops.draw` precedence, generic surfaces excluded (§1.1, §5). |
+| 12 | MAJOR | Adopted — dual goldens (frozen flag-off oracle + new flag-on golden); twins/archived round-trips untouched until Phase C (§3A). |
+| 13 | MAJOR | Adopted — full AI contract removal enumerated into Phase B (§3B). |
+| 14 | MAJOR | Adopted — §4 test matrix. |
+
+## 9b. Phase-A diff review — Codex (gpt-5.6-sol, xhigh), 2026-07-22, 9 findings
+
+| # | Sev | Disposition |
+|---|---|---|
+| 1 | BLOCKER | Adopted — both caches are mode-tagged (inheritance flag in cache identity, stale-on-error included). |
+| 2 | MAJOR | Adopted — invalidation bumps a generation; refreshes commit only when their generation still holds; in-flight promises from older generations are not reused. |
+| 3 | MAJOR | Adopted by DOCUMENTATION — the featured-drops save-invalidation stays unconditional: it is a deliberate freshness bug-fix (stale tiles pre-dated this plan). Amended guarantee: flag-off read RESULTS are byte-identical; cache freshness improves regardless. |
+| 4 | MAJOR | Adopted — the marketplace DTO never carried `imageUrl` at all (pre-existing gap, runtime-verified); the overlay now inherits the page hero as the card image (image-kind only, both versions) and applies image-kind precedence to `image_label` incl. v1 docs. |
+| 5 | MAJOR | Adopted — `featuredTitleOf`: flag-on = derived headline else campaign name (stored drop title never wins); flag-off = stored-first, unchanged. |
+| 6 | MAJOR | Part-adopted — generic predicate narrowed to exactly the template default ("Get Started"). Client `listingTitleOf` (tracking/search unification) + the generic-headline readiness warning are PHASE B items, now named in §3B. |
+| 7 | MAJOR | Adopted — derived value_line clamps to the 80-char cap; full names live in `prize_breakdown`. |
+| 8 | MAJOR | Adopted — script rewritten: listed-gate filter, full key-union DTO diff incl. effective title + card image, separate featured-drop title diff for every enabled drop. |
+| 9 | MAJOR | Adopted (backend half) — toDto-level flag on/off tests, cache mode/generation tests, featured-title rule tests, media-kind positives incl. v1, value-cap and "Sign Up"-is-valid cases. Endpoint-level matrix + script fixture noted for Phase B/C hardening. |


### PR DESCRIPTION
Phase A of `docs/plans/marketplace-inherits-campaign-page.md` (plan Codex-reviewed: 14 findings folded; this diff Codex-reviewed: 9 findings folded — §9/§9b dispositions in the doc).

**What it does (dark — `MARKETPLACE_INHERIT_ENABLED` default off):** at the single `toDto` choke point (list + door + preview), listing copy derives from the campaign page — title ← headline, description ← story, regulatory ← footer, value line ← prize facts (80-cap), `prize_breakdown` ← structured prize rows (draw `inclusions` suppressed), **card image ← page hero** (the DTO never carried `imageUrl` at all — live cards render placeholders today). Featured drops share the derivation and finally get save-invalidation.

**Safety:** flag-off read results are byte-identical (oracle pinned through `toDto`); storage/clamp untouched; both caches are mode-tagged with an invalidation **generation** so a mid-flight refresh can't repopulate pre-save or cross-mode data (stale-on-error included).

**Evidence:** rollout diff replayed against both live prod listings — Pet Hotel gains title/description/card image, Tokyo gains description/regulatory/card image + canonical prize value line. Nothing changes until the flag flips **after Phase B** renders the new keys.

Tests: 20 new; 147 green across marketplace/goldens/campaign suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDco6HwKLHpmRgE5YR8Za2