### PR TITLE
fix(studio): make every layout honour every colour preset (11 × 10 audit)

### DIFF
--- a/backend/src/utils/designConfigV2.js
+++ b/backend/src/utils/designConfigV2.js
@@ -297,6 +297,42 @@ function hexToRgb(hex) {
   return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
 }
 
+const toHex = (rgb) => '#' + rgb.map((v) => Math.round(Math.min(255, Math.max(0, v))).toString(16).padStart(2, '0')).join('').toUpperCase();
+
+/**
+ * Blend `hex` toward `target` by `amount` (0..1). Returns `hex` unchanged when
+ * either side is unparseable, so a malformed operator accent can never blank a
+ * surface. The warm-cream input fill depends on the exact arithmetic here:
+ * mix('#FFFAF0', '#FFFFFF', .4) === '#FFFCF6', the frozen production value.
+ */
+export function mixHex(hex, target, amount) {
+  const a = hexToRgb(hex);
+  const b = hexToRgb(target);
+  if (!a || !b) return hex;
+  return toHex(a.map((v, i) => v + (b[i] - v) * amount));
+}
+
+/**
+ * An accent that is legible AS TEXT on `bg` — the accent itself when it already
+ * clears `min`, otherwise stepped toward the surface's opposite pole until it
+ * does. Light accents (lime, periwinkle) are unreadable as text on white; this
+ * keeps the campaign's hue while making the label readable. Falls back to the
+ * ink/light pole when even the extreme cannot clear the bar.
+ */
+export function accentTextOn(accent, bg, min = 4.5, ink = '#3D1F0B') {
+  const bgL = luminance(bg);
+  const accentL = luminance(accent);
+  if (bgL == null || accentL == null) return accent;
+  if (contrastRatio(accentL, bgL) >= min) return accent;
+  const pole = bgL > 0.5 ? '#000000' : '#FFFFFF';
+  for (let step = 1; step <= 10; step += 1) {
+    const candidate = mixHex(accent, pole, step / 10);
+    const l = luminance(candidate);
+    if (l != null && contrastRatio(l, bgL) >= min) return candidate;
+  }
+  return bgL > 0.5 ? ink : '#FFFFFF';
+}
+
 /** Nearest preset by accent RGB distance; invalid/absent hex → warm-cream. */
 export function nearestPresetForAccent(hex) {
   const rgb = hexToRgb(hex);
@@ -576,6 +612,7 @@ export function resolveTheme(theme = {}) {
   const fontId = FONT_IDS.includes(theme.font) ? theme.font : p.font;
   let r = RADII[theme.radius || p.radius] || RADII.soft;
   if (p.rx && (!theme.radius || theme.radius === p.radius)) r = p.rx;
+  const disabledBg = p.hairline || mixHex(p.card, p.dark ? '#FFFFFF' : '#000000', p.dark ? 0.16 : 0.1);
   return {
     ...p,
     accent,
@@ -587,10 +624,27 @@ export function resolveTheme(theme = {}) {
     bodyText: p.bodyText || p.ink,
     divider: p.divider || p.hairline || (p.dark ? 'rgba(255,255,255,.2)' : 'rgba(0,0,0,.16)'),
     accentDeep: p.accentDeep || accent,
-    danger: p.danger || '#B4443C',
-    success: p.success || '#2F6B43',
+    // Status colors are surface-aware: the light-theme pair sits at ~2:1 on a
+    // dark card, so dark presets get lifted variants. warm-cream declares both
+    // explicitly and is untouched (frozen parity).
+    danger: p.danger || (p.dark ? '#F2938B' : '#B4443C'),
+    success: p.success || (p.dark ? '#7FD1A0' : '#2F6B43'),
     line: p.hairline || (p.dark ? 'rgba(255,255,255,.14)' : 'rgba(0,0,0,.1)'),
     soft: p.dark ? 'rgba(255,255,255,.07)' : 'rgba(0,0,0,.045)',
+    // OPAQUE input fill. The funnel paints typed text in `ink`, so this must
+    // track the theme or the text goes invisible (dark presets sat at 1.1:1 on
+    // the old hardcoded '#FFFCF6'). Lightening the card by .4 reproduces the
+    // frozen warm-cream value byte-exactly; dark presets lift off the card
+    // instead so the field still reads as a well.
+    inputBg: p.inputBg || mixHex(p.card, '#FFFFFF', p.dark ? 0.08 : 0.4),
+    // Disabled control fill + its label. `hairline` was being used as a surface
+    // AND fed to a hex-only contrast helper, which returned white for the 9
+    // presets whose hairline is an rgba() string. These are always opaque hex.
+    disabledBg,
+    onDisabled: onColor(disabledBg),
+    // The accent, stepped until it is legible AS TEXT on the form card — lime
+    // and periwinkle accents are ~1.8:1 on white and vanish as link/label text.
+    accentText: accentTextOn(accent, p.card),
     bgCss: theme.background === 'wash'
       ? `linear-gradient(180deg, ${accent}18, ${p.bg} 320px)`
       : theme.background === 'grain'

--- a/docs/reference/studio-layout-theme-audit-2026-07-22.md
+++ b/docs/reference/studio-layout-theme-audit-2026-07-22.md
@@ -1,0 +1,203 @@
+# Campaign Studio — layout × colour-preset audit (2026-07-22)
+
+Audit of **all 11 v2 page layouts × all 10 curated colour presets** (110
+combinations), plus the reused signup funnel that every layout embeds.
+
+> Scope note: `main` locally was 23 commits behind. The five new layouts landed
+> in **PR #226** (`3a7e3a5`). This audit is against `origin/main` @ `a198bc3`.
+
+## Headline
+
+**The five new draw layouts (Postcard, Gazette, Nightfall, Stub, Checklist) do
+not respond to the colour presets at all — and the form inside them does.**
+
+That split is the whole bug. PR #226 deliberately art-directed the five new
+templates with *"fixed neutral palettes + the campaign theme's accent"*. But the
+embedded funnel is still themed from the **preset** via
+`buildFunnelTokens(resolveTheme(doc.theme))`. So one page ends up painted from
+two different palettes that never agree:
+
+- template chrome → a **fixed** neutral (cream, paper, or near-black)
+- form text/labels → the **preset's** `ink` / `bodyText` / `muted`
+
+Pick a dark preset and the form's near-white text lands on the template's
+hardcoded light card. **The form goes invisible.**
+
+### Proof — distinct page backgrounds rendered across the 10 presets
+
+Measured with `getComputedStyle()` on the real renderer, 390px viewport:
+
+| layout | distinct backgrounds / 10 | |
+|---|---|---|
+| editorial | **10** | follows the preset |
+| poster | **10** | follows the preset |
+| postcard | **1** | ignores it — always `rgb(246,244,238)` |
+| gazette | **1** | ignores it — always `rgb(251,247,238)` |
+| nightfall | **1** | ignores it — always `rgb(20,22,31)` |
+| stub | **1** | ignores it — always `rgb(239,235,224)` |
+| checklist | **1** | ignores it — always `rgb(255,255,255)` |
+
+And on every one of the five, the funnel input still reports
+`color: rgb(242,242,239)` (graphite's ink) on `background: rgb(255,252,246)`.
+
+### Why nothing caught it
+
+- PR #226 shipped **22 new tests** — all structural (does the prize chip render,
+  does the CTA open the sheet). **None asserts a colour or a preset.**
+- `PagePanel.jsx:345` does note *"Draw-focused template — art-directed neutrals
+  with the theme accent."* — but the **Theme panel has no such warning**. It
+  presents all 10 presets as live choices with full-colour swatches. The
+  operator picks Graphite, the swatch highlights, and the page does not change.
+- PR #226 called itself "dormant on merge — no existing campaign references the
+  new template ids". That is **no longer true**: see production exposure below.
+
+---
+
+## The five new layouts, one by one
+
+Screenshots: `scratchpad/sheets-new/sheet-<template>.png` (10 presets each).
+
+### Checklist — BLOCKER on the 3 dark presets
+Page is hardcoded `#FFFFFF`. On graphite / ink-lime / violet-hour the form
+headline, every field label, the intro copy and the consent line render in the
+preset's near-white ink **on white**. This is exactly the ghosted form in the
+reported screenshot. **Reproduced identically.**
+
+### Gazette — BLOCKER on the 3 dark presets
+Page is hardcoded `#FBF7EE`. Same failure. The upper fact table (PRIZE / CLOSES /
+ENTRY / BOOST) uses hardcoded dark ink so it stays readable — meaning the top
+half of the page looks *identical* on all 10 presets while the bottom half
+breaks on 3 of them.
+
+### Postcard — BLOCKER on the 3 dark presets
+Page is hardcoded `#F6F4EE`. Same failure inside the floating card.
+
+### Stub — BLOCKER on the 3 dark presets
+Ticket body is hardcoded `#EFEBE0`. Same failure across the whole stub.
+
+### Nightfall — the inverse: MAJOR on all 7 light presets
+Page is hardcoded `#141614` near-black on every preset. An operator choosing
+Warm Cream, Paper White, Kopi, Botanic, Peranakan, Straits Teal or Tangerine
+gets a fully dark page; only the CTA changes colour. Not a legibility failure —
+the template is internally consistent and the CTA-revealed form sheet carries its
+own light surface — but the preset is decorative.
+*(Verified the CTA reveal works: 0 visible inputs before click → 6 after.)*
+
+### Cross-cutting on all five
+`content.headline` is painted by the layout **and** again by the form (the
+funnel receives the same string as `formHeadline` via `funnelAdapter.js:43`), so
+the headline renders twice on every draw template. With empty content both
+default to `'Get Started'` — the doubled "Get Started" visible in the report.
+
+---
+
+## Pre-existing: the original 6 layouts + the shared funnel
+
+These are **separate from** the new-layout problem and were already live. Full
+contrast run: 300 pairs across 10 presets → 87 FAIL / 33 WARN.
+
+### Blockers in the shared funnel (hit all 11 layouts)
+
+| # | What | Where | Effect |
+|---|---|---|---|
+| B1 | Input fill hardcoded `#FFFCF6` with `color: TOKENS.ink` | `FieldRenderer.jsx:39-40` | Typed text **1.07–1.10:1** on the 3 dark presets — invisible. `inputBg` is never emitted by `buildFunnelTokens()`, so the `\|\|` fallback always wins. |
+| B2 | OTP code field `backgroundColor: '#ffffff'` | `OTPVerification.jsx:165-166` | The 6-digit code is invisible on dark presets — verification cannot complete. Panel at `:97` (`#FFFCF6`) hides its helper text, phone number, Edit and Resend too. |
+| B3 | `'#ffffff'` + `color: TOKENS.body` buttons | `CampaignSignupForm.jsx:555` (SG/PR "No"), `:692` (advisor "Yes"), `MarketingConsentDialog.jsx:106` ("Cancel") | **1.03:1** on dark presets — blank white pills. These gates are the *first* screen of a gated campaign. |
+| B4 | `readableTextOn(TOKENS.hairline)` | `FieldRenderer.jsx:275-276` | `contrast.js` parses hex only; 9/10 presets have an `rgba()` hairline → returns `#ffffff`. Disabled "Verify"/"Wait 9:59" is white on ~`#E6E6E6` (**1.27:1**) on 6 light presets. Verified at runtime. |
+| B5 | Outcome screens never call `useCampaignTheme()` | `LeadCaptureOutcomes.jsx:5, 40, 53` | "You're all set." is `#3D1F0B` on `#2C2E33` = **1.15:1**. The confirmation screen is unreadable on dark presets. `:140` also hardcodes a terracotta CTA on all 9 non-warm presets. |
+| B6 | Poster hero: `#FFF` over a fade ending at `t.bg` | `templates.jsx:200, 206, 216, 220` | Default `overlay: 'dusk'` sets `fade = t.bg`. Headline **1.05–1.33:1** on the 7 light presets; unreadable with no media. |
+| B7 | Consent tick `stroke="#ffffff"` on `accent` | `CampaignSignupForm.jsx:1038` | ~1.8:1 on ink-lime/violet-hour. User cannot tell whether the **required** T&C box is ticked. `onAccent` already holds the right value; `ConsentCheckbox:1000` never reads it. |
+
+### Systemic root causes
+
+1. `buildFunnelTokens()` (`themeContext.jsx:53-83`) emits no input surface — no `inputBg`.
+2. `danger` `#B4443C` / `success` `#2F6B43` are preset-blind (`designConfigV2.js:559-560`) → 1.93–2.75:1 on dark cards. The "Verified" badge is unreadable.
+3. `line`/`hairline` is an `rgba()` string on 9/10 presets, used both as a *fill* and fed to a hex-only parser.
+4. `onColor()` falls back to `#3D1F0B` — warm-cream's ink — so all 3 dark presets get warm-brown button labels.
+5. Three components never consume the theme: `LeadCaptureOutcomes`, `DncConsentGate` (a cream/sage card that *locks the form*), `ShareCampaignDialog` (paints from the app-global Tailwind palette).
+6. No `-webkit-autofill` rule anywhere in `src/` — Chrome repaints autofilled fields pale-blue via `!important`. Any B1 fix must ship with one.
+7. No `color-scheme: dark` on the campaign root — native selects, caret and scrollbars stay light on dark presets.
+
+### Original-6 layout notes
+- **Split / Poster**: hardcoded `#17181B` media panel — an empty black slab when there is no media, on every preset.
+- **Spotlight**: uses `t.muted` for *body* paragraphs → 2.86:1 on warm-cream.
+- **Journey**: step numerals are `t.accent` on a `t.soft` band → 2.36:1 warm-cream; the band vanishes on dark presets. Renders the headline three times.
+- **Editorial / Express**: cleanest — only themed tokens.
+
+---
+
+## Production exposure (checked live, `campaigns` table)
+
+| campaign | template | preset | risk |
+|---|---|---|---|
+| Redeem $20 NTUC Fairprice Vouchers | editorial | **violet-hour** (dark) | **B1 live** — typed text invisible in every field |
+| Tokyo Getaway Lucky Draw | **checklist** | paper-white | safe by luck — light preset on a light fixed template |
+| Free Pet Hotel 1 Night Trial | poster | tangerine | B6 — white hero copy over a light fade |
+| Redeem $10 Fairprice Voucher | editorial | tangerine | funnel blockers only |
+| [Retell] Luggage | editorial | warm-cream | parity baseline, fine |
+
+The NTUC campaign is **active and taking leads on a dark preset today.**
+
+---
+
+## Fixes applied — branch `fix/studio-preset-theming`
+
+### Token layer (`designConfigV2.js` twins, backend first)
+New derived tokens on `resolveTheme()`, plus `mixHex()` and `accentTextOn()`:
+
+| token | why |
+|---|---|
+| `inputBg` | opaque input fill that tracks the theme. `mixHex(card,'#FFFFFF',.4)` reproduces warm-cream's frozen `#FFFCF6` **byte-exactly**; dark presets lift off the card instead. |
+| `disabledBg` / `onDisabled` | disabled control fill + label. `hairline` was being used as a fill *and* fed to a hex-only contrast helper that returned white for the 9 presets whose hairline is `rgba()`. |
+| `accentText` | the accent stepped until it is legible as TEXT on the card — lime/periwinkle accents were 1.8:1. |
+| `danger` / `success` | now surface-aware; the light pair sat at ~2:1 on dark cards. |
+
+Measured after (was 1.07–1.10:1 on the three dark presets):
+
+```
+preset        inputBg   ink-on-input   danger-on-card  success-on-card  accentText-on-card
+warm-cream    #FFFCF6      14.66            5.67            3.49              4.89
+graphite      #3D3F43       9.41            6.03            7.46              5.15
+ink-lime      #373831      10.83            6.69            8.28              8.18
+violet-hour   #4A3F66       8.46            5.44            6.72              9.09
+```
+
+### Funnel
+`buildFunnelTokens` now emits the new tokens (`DEFAULT_CAMPAIGN_THEME` deliberately does **not**, so unprovidered v1 mounts keep falling back to their original literals). Fixed: input + OTP fills (B1/B2), screening-gate and Cancel buttons (B3), disabled Verify/Submit (B4), outcome screens now consume the theme (B5), consent tick uses `onAccent` (B7), accent-derived button glow, and a root `<style>` supplying the previously absent `-webkit-autofill` and `::placeholder` rules plus `color-scheme`.
+
+### Original six templates
+Poster's hero copy now follows `onColor(t.bg)` so it stays legible wherever the dusk gradient lands (B6); Split/Poster media backdrops follow the preset; Spotlight body copy moved from `muted` to `bodyText`; Journey numerals use `accentTextOn`.
+
+### The five draw layouts — light/dark twins
+`drawTemplates.jsx` gains `PALETTES` (5 templates × light/dark) and an exported
+`drawPalette(id, t)` resolver; each template shadows its own palette name so the
+~100 existing `PC.x`/`GZ.x`/… references are untouched. The shared helpers
+(`Perforation`, `StubHeader`, `ChecklistHeader`, `GazetteMasthead`,
+`ChancesRow`, `NextSteps`) now take their colours as props, and both the success
+and closed-page `chrome` tables resolve from `pal`. Every `#fff` that hosts the
+funnel or a card became `pal.card` — that is the fix for the invisible form.
+
+Accent handling: every `#fff` on an accent fill became `t.onAccent`; every
+accent-coloured *text* node became `accentTextOn(accent, <its surface>)`.
+Two unconditional AA failures that had nothing to do with theming were also
+fixed — Gazette's gold (2.39:1) and Checklist's `#8B8477` mono captions (3.28:1).
+
+Light presets are byte-identical except where an accent genuinely failed AA.
+**Nightfall is the exception**: its existing palette *was* the dark variant, so
+it now flips to a light body on light presets while keeping its dark hero plate
+(pinned to `NF_HERO`, since the hero scrims are translucent over the page).
+
+Measured after — form headline + field labels, 5 draw templates × 6 presets,
+30 combinations: **worst case 10.49:1** (was 1.02–1.13:1 on the dark presets).
+
+### Result
+Contrast matrix **87 FAIL → 30 FAIL**. All 30 remaining are decorative card hairlines at 1.25–1.56:1 — the frozen v1 baseline is 1.36:1, and they are card edges, not control boundaries. Full suite **1715/1715**, including the frozen warm-cream parity and twin-lockstep tests.
+
+## Reproducing
+
+Worktree `audit/studio-theme-matrix` @ `origin/main`, harness
+`theme-audit.html` + `src/dev/themeAudit.jsx` (uncommitted).
+`npx vite --port 5199`, then
+`theme-audit.html?template=<id>&preset=<id>&media=0|1&jump=<state>`.
+Drivers (`shoot.mjs`, `probe.mjs`, `respond.mjs`, `contrast-audit.mjs`) and
+contact sheets in the session scratchpad.

--- a/src/components/campaignPage/CampaignPageRenderer.jsx
+++ b/src/components/campaignPage/CampaignPageRenderer.jsx
@@ -23,7 +23,7 @@ import { brand } from '@/lib/brand';
 import { heroFontStack } from '@/lib/heroFonts';
 import { QuizGate } from '@/components/campaigns/CampaignQuiz';
 import CampaignSignupForm from '@/components/campaigns/CampaignSignupForm';
-import { CampaignThemeProvider } from './themeContext';
+import { CampaignThemeProvider, DEFAULT_CAMPAIGN_THEME } from './themeContext';
 import { adaptCampaignForFunnel, deriveFunnelProps } from './funnelAdapter';
 import { resolveJumpFixtures } from './previewJumpFixtures';
 import { TEMPLATES } from './templates';
@@ -225,6 +225,9 @@ export default function CampaignPageRenderer({
     [adapted.theme]
   );
   const content = useMemo(() => deriveCampaignPageContent(doc), [doc]);
+  // The funnel's own token bag — also drives the root-level bits inline styles
+  // cannot reach (color-scheme, autofill, ::placeholder, the locked-field vars).
+  const funnelTokens = adapted.funnelTheme?.tokens || DEFAULT_CAMPAIGN_THEME.tokens;
   const rootRef = useRef(null);
   const mobile = useIsMobile(rootRef);
   const [stage, setStage] = useState('quiz');
@@ -296,7 +299,38 @@ export default function CampaignPageRenderer({
   const params = doc.template?.params?.[templateId] || {};
 
   return (
-    <div ref={rootRef} data-campaign-page-template={templateId} data-campaign-page-ready="true">
+    <div
+      ref={rootRef}
+      data-campaign-page-template={templateId}
+      data-campaign-page-ready="true"
+      style={{
+        colorScheme: funnelTokens.colorScheme,
+        // Consumed by FieldRenderer's LOCKED_FIELD_CSS, which needs !important
+        // to beat the inputs' inline styles and therefore cannot read tokens.
+        '--lc-locked-bg': funnelTokens.lockedBg,
+        '--lc-locked-line': funnelTokens.lockedLine,
+        '--lc-locked-ink': funnelTokens.lockedInk,
+      }}
+    >
+      {/* Chrome repaints autofilled inputs with an !important UA style that
+          inline styles cannot touch — without this the most common real-world
+          state of the form ignores the theme entirely. Placeholder colour is
+          equally unreachable from inline styles. */}
+      <style>{`
+        [data-campaign-page-template] input:-webkit-autofill,
+        [data-campaign-page-template] input:-webkit-autofill:hover,
+        [data-campaign-page-template] input:-webkit-autofill:focus {
+          -webkit-text-fill-color: ${funnelTokens.ink};
+          -webkit-box-shadow: 0 0 0 1000px ${funnelTokens.inputBg} inset;
+          box-shadow: 0 0 0 1000px ${funnelTokens.inputBg} inset;
+          caret-color: ${funnelTokens.ink};
+        }
+        [data-campaign-page-template] input::placeholder,
+        [data-campaign-page-template] textarea::placeholder {
+          color: ${funnelTokens.muted};
+          opacity: 1;
+        }
+      `}</style>
       <Template
         t={t}
         content={content}

--- a/src/components/campaignPage/drawTemplates.jsx
+++ b/src/components/campaignPage/drawTemplates.jsx
@@ -26,7 +26,7 @@ import {
   formatDrawDate,
 } from './CampaignPageRenderer';
 import { MediaBlock } from './templates';
-import { resolveTheme } from '@/lib/designConfigV2';
+import { accentTextOn, resolveTheme } from '@/lib/designConfigV2';
 
 const SANS = "'Albert Sans', system-ui, sans-serif";
 const SERIF = "'Fraunces', Georgia, serif";
@@ -99,6 +99,46 @@ function drawStrings(luckyDraw, campaignName) {
 
 const accentSoftOf = (accent) => `${accent}1A`;
 
+/**
+ * The art-directed neutrals, in both polarities. `light` is the frozen palette
+ * each direction shipped with; `dark` is its twin. Without the flip a dark
+ * preset left the page cream while the funnel painted its own text from the
+ * preset's near-white `ink` — the whole form went light-on-light.
+ * `card` is the surface that HOSTS the funnel (every '#fff' box reads it);
+ * `line` is the single divider key the success/closed chrome reads for all
+ * five. Nightfall is the one direction whose shipped palette WAS the dark
+ * block, so its `light` twin is new rather than frozen.
+ */
+const PALETTES = {
+  postcard: {
+    light: { bg: '#F6F4EE', ink: '#17181B', body: '#4A463C', mut: '#8B8477', faint: '#9A948A', line: '#E4E1D6', heroInk: '#17191E', card: '#FFFFFF' },
+    dark: { bg: '#16171A', ink: '#F4F3EF', body: '#C8C5BC', mut: '#928D82', faint: '#7C776D', line: '#2C2E31', heroInk: '#0E0F12', card: '#202226' },
+  },
+  gazette: {
+    light: { bg: '#FBF7EE', ink: '#1B1A17', body: '#4A463C', mut: '#6B6558', faint: '#9A948A', hair: '#E6E0D1', line: '#E6E0D1', gold: '#A97B1E', card: '#FBF7EE' },
+    dark: { bg: '#171613', ink: '#F5F2EA', body: '#CFCABD', mut: '#A39D8F', faint: '#7E7969', hair: '#33302A', line: '#33302A', gold: '#E3B85C', card: '#1F1E1A' },
+  },
+  nightfall: {
+    light: { bg: '#F5F4F0', ink: '#16171B', body: '#3E4048', mut: '#6E7180', faint: '#8B8E9A', border: 'rgba(22,23,27,.14)', line: 'rgba(22,23,27,.14)', card: '#FFFFFF' },
+    dark: { bg: '#14161F', ink: '#F2F1EC', body: '#C9CBD6', mut: '#A7A9B8', faint: '#6E7180', border: 'rgba(242,241,236,.18)', line: 'rgba(242,241,236,.18)', card: '#1E212C' },
+  },
+  stub: {
+    light: { bg: '#EFEBE0', ink: '#1B1A17', body: '#4A463C', mut: '#6B6558', faint: '#9A948A', dash: '#D9D4C8', line: '#DDD8CB', card: '#FFFFFF' },
+    dark: { bg: '#171613', ink: '#F3F0E8', body: '#CBC6BA', mut: '#A09A8C', faint: '#807A6C', dash: '#3A372F', line: '#33302A', card: '#201F1B' },
+  },
+  checklist: {
+    light: { bg: '#FFFFFF', ink: '#17181B', body: '#4A463C', mut: '#6B6558', faint: '#9A948A', line: '#E9E6DD', railBg: '#F3F1EA', card: '#FFFFFF' },
+    dark: { bg: '#15161A', ink: '#F3F3F0', body: '#C7C5BE', mut: '#9C9A92', faint: '#7B7972', line: '#2B2D31', railBg: '#212227', card: '#1D1F23' },
+  },
+};
+
+/** Art-directed neutrals, flipped by the preset's light/dark polarity. */
+export const drawPalette = (id, t) => PALETTES[id]?.[t?.dark ? 'dark' : 'light'] || PALETTES.postcard.light;
+
+/** Nightfall's hero is a hardcoded dark plate — its scrims are translucent and
+ *  its type is white — so the plate keeps the dark base on every preset. */
+const NF_HERO = PALETTES.nightfall.dark.bg;
+
 /** Absolute-fill hero media (poster-template pattern) behind a scrim. */
 function BackdropMedia({ t, media }) {
   if (!media || media.kind === 'none' || !media.src) return null;
@@ -146,7 +186,7 @@ function DrawFootnotes({ draw, linkColor, mutedColor, faintColor, content, cente
 
 // ───────────────────────── shared SUCCESS building blocks ─────────────────────────
 
-function ChancesRow({ accent, inkColor, mutedColor, multiplier }) {
+function ChancesRow({ accent, accentLabel, inkColor, mutedColor, multiplier }) {
   const cell = (big, label, color, labelColor) => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
       <div style={{ fontFamily: SERIF, fontWeight: 600, fontSize: 38, lineHeight: 1, color }}>{big}</div>
@@ -157,15 +197,17 @@ function ChancesRow({ accent, inkColor, mutedColor, multiplier }) {
     <div style={{ display: 'flex', alignItems: 'center', gap: 20 }}>
       {cell('1x', 'NOW', inkColor, mutedColor)}
       <div style={{ fontSize: 22, color: mutedColor }}>→</div>
-      {cell(`${multiplier}x`, 'AFTER YOUR REVIEW', accent, accent)}
+      {cell(`${multiplier}x`, 'AFTER YOUR REVIEW', accent, accentLabel || accent)}
     </div>
   );
 }
 
-function NextSteps({ s, accent, stepBg, stepColor, bodyColor, lastColor, mutedColor, label, bookingUrl, ctaRadius = 9 }) {
+// `accent` fills the CTA; `accentText` is the same accent stepped until it is
+// legible AS TEXT on the card, and `onAccent` is what sits ON the fill.
+function NextSteps({ s, accent, accentText, onAccent, stepBg, stepColor, bodyColor, lastColor, mutedColor, label, bookingUrl, ctaRadius = 9 }) {
   return (
     <>
-      <div style={mono(11, { letterSpacing: 1.5, color: accent, fontWeight: 600 })}>{label}</div>
+      <div style={mono(11, { letterSpacing: 1.5, color: accentText, fontWeight: 600 })}>{label}</div>
       {s.steps.map((step, i) => (
         <div key={i} style={{ display: 'flex', gap: 10 }}>
           <div style={{ width: 20, height: 20, borderRadius: '50%', background: stepBg, color: stepColor, fontSize: 11, fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, fontFamily: SANS }}>{i + 1}</div>
@@ -177,7 +219,7 @@ function NextSteps({ s, accent, stepBg, stepColor, bodyColor, lastColor, mutedCo
           href={bookingUrl}
           target="_blank"
           rel="noopener noreferrer"
-          style={{ background: accent, color: '#fff', border: 'none', borderRadius: ctaRadius, padding: 13, fontSize: 14.5, fontWeight: 700, fontFamily: SANS, textAlign: 'center', textDecoration: 'none', display: 'block' }}
+          style={{ background: accent, color: onAccent, border: 'none', borderRadius: ctaRadius, padding: 13, fontSize: 14.5, fontWeight: 700, fontFamily: SANS, textAlign: 'center', textDecoration: 'none', display: 'block' }}
         >
           Book your 20-min review
         </a>
@@ -194,14 +236,14 @@ function successSubOf(submittedPhone) {
 
 // ═══════════════════════════════ POSTCARD ═══════════════════════════════
 
-const PC = { bg: '#F6F4EE', ink: '#17181B', body: '#4A463C', mut: '#8B8477', faint: '#9A948A', line: '#E4E1D6', heroInk: '#17191E' };
-
 function Postcard({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile, referrerName, campaignName }) {
   const accent = t.accent;
+  const PC = drawPalette('postcard', t);
+  const accentInk = accentTextOn(accent, PC.bg);
   const s = drawStrings(luckyDraw, campaignName);
   const flush = params.cardStyle === 'flush';
   const cardFrame = {
-    background: '#fff',
+    background: PC.card,
     borderRadius: 14,
     ...(flush
       ? { border: `1px solid ${PC.line}`, margin: '14px 16px 0' }
@@ -234,7 +276,7 @@ function Postcard({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile
   );
   const cardHeader = s.draw && (
     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-      <div style={{ background: accentSoftOf(accent), color: accent, fontSize: 11, fontWeight: 700, letterSpacing: 1, padding: '5px 10px', borderRadius: 99, fontFamily: SANS, textTransform: 'uppercase' }}>
+      <div style={{ background: accentSoftOf(accent), color: accentInk, fontSize: 11, fontWeight: 700, letterSpacing: 1, padding: '5px 10px', borderRadius: 99, fontFamily: SANS, textTransform: 'uppercase' }}>
         {s.prize || 'LUCKY DRAW'}
       </div>
       {s.closesMono && <div style={mono(10.5, { color: PC.mut })}>{`CLOSES ${s.closesMono}`}</div>}
@@ -255,7 +297,7 @@ function Postcard({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile
           <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
             {facts.map((f, i) => (
               <div key={i} style={{ display: 'flex', gap: 12 }}>
-                <div style={mono(12, { color: accent, fontWeight: 600 })}>{`0${i + 1}`}</div>
+                <div style={mono(12, { color: accentInk, fontWeight: 600 })}>{`0${i + 1}`}</div>
                 <div style={{ fontSize: 13, lineHeight: 1.5, color: PC.body, fontFamily: SANS }}>{f}</div>
               </div>
             ))}
@@ -263,7 +305,7 @@ function Postcard({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile
         )
       )}
       <div style={{ borderTop: `1px solid ${PC.line}`, paddingTop: 14 }}>
-        <DrawFootnotes draw={s.draw} linkColor={accent} mutedColor={PC.mut} faintColor={PC.faint} content={content} t={t} />
+        <DrawFootnotes draw={s.draw} linkColor={accentInk} mutedColor={PC.mut} faintColor={PC.faint} content={content} t={t} />
       </div>
     </div>
   );
@@ -280,7 +322,7 @@ function Postcard({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile
     const formPane = (
       <div style={{ width: '50%', padding: '44px 48px', display: 'flex', flexDirection: 'column', gap: 18, boxSizing: 'border-box' }}>
         {cardHeader}
-        <div style={{ background: '#fff', borderRadius: 14, boxShadow: flush ? 'none' : '0 8px 28px rgba(23,24,27,.08)', border: flush ? `1px solid ${PC.line}` : 'none', padding: 22 }} ref={formAnchorRef}>
+        <div style={{ background: PC.card, borderRadius: 14, boxShadow: flush ? 'none' : '0 8px 28px rgba(23,24,27,.08)', border: flush ? `1px solid ${PC.line}` : 'none', padding: 22 }} ref={formAnchorRef}>
           <ReferredBadge t={t} referrerName={referrerName} />
           {funnel}
         </div>
@@ -289,7 +331,7 @@ function Postcard({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile
           <div key={i} style={{ fontSize: 13.5, lineHeight: 1.55, color: PC.body, fontFamily: SANS }}>{p}</div>
         ))}
         <div style={{ marginTop: 'auto' }}>
-          <DrawFootnotes draw={s.draw} linkColor={accent} mutedColor={PC.mut} faintColor={PC.faint} content={content} t={t} />
+          <DrawFootnotes draw={s.draw} linkColor={accentInk} mutedColor={PC.mut} faintColor={PC.faint} content={content} t={t} />
         </div>
       </div>
     );
@@ -319,8 +361,6 @@ function Postcard({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile
 
 // ═══════════════════════════════ GAZETTE ═══════════════════════════════
 
-const GZ = { bg: '#FBF7EE', ink: '#1B1A17', body: '#4A463C', mut: '#6B6558', faint: '#9A948A', hair: '#E6E0D1', gold: '#C89B3C' };
-
 function gazetteSerial(campaignName, closesAt) {
   const initials = (campaignName || '')
     .split(/\s+/)
@@ -333,21 +373,25 @@ function gazetteSerial(campaignName, closesAt) {
   return `SER. ${initials}${year ? `-${year}` : ''}`;
 }
 
-function GazetteMasthead({ content, kickerText }) {
+/** Rendered by the open, success AND closed gazette states — each passes its
+ *  own resolved neutrals rather than closing over one frozen palette. */
+function GazetteMasthead({ content, kickerText, inkColor, mutedColor }) {
   return (
-    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', borderBottom: `2px solid ${GZ.ink}`, paddingBottom: 10, gap: 12 }}>
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', borderBottom: `2px solid ${inkColor}`, paddingBottom: 10, gap: 12 }}>
       <div style={{ fontWeight: 800, fontSize: 17, fontFamily: SANS }}>{content.wordmark}</div>
-      <div style={mono(10, { letterSpacing: 1.6, color: GZ.mut, textAlign: 'right' })}>{kickerText}</div>
+      <div style={mono(10, { letterSpacing: 1.6, color: mutedColor, textAlign: 'right' })}>{kickerText}</div>
     </div>
   );
 }
 
 function Gazette({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile, referrerName, campaignName }) {
   const accent = t.accent;
+  const GZ = drawPalette('gazette', t);
+  const accentInk = accentTextOn(accent, GZ.bg);
   const s = drawStrings(luckyDraw, campaignName);
   const dense = params.ruleDensity === 'dense';
   const rowPad = dense ? '6px 0' : '10px 0';
-  const linkColor = params.accentUse === 'text' ? GZ.ink : accent;
+  const linkColor = params.accentUse === 'text' ? GZ.ink : accentInk;
   const factRow = (label, node, last = false) => (
     <div key={label} style={{ display: 'flex', gap: 14, borderTop: `1px solid ${GZ.hair}`, ...(last ? { borderBottom: `1px solid ${GZ.hair}` } : {}), padding: rowPad }}>
       <div style={mono(10.5, { letterSpacing: 1, color: GZ.mut, paddingTop: 2, width: mobile ? 72 : 86, flexShrink: 0 })}>{label}</div>
@@ -371,7 +415,7 @@ function Gazette({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile,
     </div>
   ) : null;
   const formBox = (
-    <div ref={formAnchorRef} style={{ border: `1.5px solid ${GZ.ink}`, padding: 16, display: 'flex', flexDirection: 'column', gap: 12 }}>
+    <div ref={formAnchorRef} style={{ background: GZ.card, border: `1.5px solid ${GZ.ink}`, padding: 16, display: 'flex', flexDirection: 'column', gap: 12 }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <div style={mono(10.5, { letterSpacing: 1.6, fontWeight: 600 })}>ENTRY FORM — 01</div>
         {params.showSerial !== false && <div style={mono(10, { color: GZ.mut })}>{gazetteSerial(campaignName, s.draw?.closesAt)}</div>}
@@ -387,7 +431,7 @@ function Gazette({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile,
   if (!mobile) {
     return (
       <div style={{ minHeight: '100vh', background: GZ.bg, padding: '36px 56px', boxSizing: 'border-box', display: 'flex', flexDirection: 'column', gap: 26, fontFamily: SANS, color: GZ.ink }}>
-        <GazetteMasthead content={content} kickerText={`OFFICIAL ENTRY FORM${s.kicker ? ` · ${s.kicker}` : ''}`} />
+        <GazetteMasthead content={content} kickerText={`OFFICIAL ENTRY FORM${s.kicker ? ` · ${s.kicker}` : ''}`} inkColor={GZ.ink} mutedColor={GZ.mut} />
         <div style={{ display: 'flex', gap: 56 }}>
           <div style={{ flex: 1.1, display: 'flex', flexDirection: 'column', gap: 20 }}>
             <div style={{ fontFamily: SERIF, fontWeight: 600, fontSize: 52, lineHeight: 1.08 }}>{content.headline}</div>
@@ -406,7 +450,7 @@ function Gazette({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile,
   }
   return (
     <div style={{ minHeight: '100vh', background: GZ.bg, display: 'flex', flexDirection: 'column', padding: '18px 20px 24px', boxSizing: 'border-box', fontFamily: SANS, color: GZ.ink }}>
-      <GazetteMasthead content={content} kickerText="OFFICIAL ENTRY FORM" />
+      <GazetteMasthead content={content} kickerText="OFFICIAL ENTRY FORM" inkColor={GZ.ink} mutedColor={GZ.mut} />
       <div style={{ display: 'flex', flexDirection: 'column', gap: 18, paddingTop: 20 }}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
           <div style={{ fontFamily: SERIF, fontWeight: 600, fontSize: 36, lineHeight: 1.1 }}>{content.headline}</div>
@@ -423,10 +467,10 @@ function Gazette({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile,
 
 // ═══════════════════════════════ NIGHTFALL ═══════════════════════════════
 
-const NF = { bg: '#14161F', ink: '#F2F1EC', body: '#C9CBD6', mut: '#A7A9B8', faint: '#6E7180', border: 'rgba(242,241,236,.18)' };
-
 function Nightfall({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile, referrerName, campaignName, formJumpActive = false }) {
   const accent = t.accent;
+  const NF = drawPalette('nightfall', t);
+  const accentInk = accentTextOn(accent, NF.bg);
   const s = drawStrings(luckyDraw, campaignName);
   const [sheetOpen, setSheetOpen] = useState(formJumpActive);
   const days = s.draw && params.showCountdown !== false ? drawDaysLeft(s.draw.closesAt) : null;
@@ -444,7 +488,7 @@ function Nightfall({ t, content, params, luckyDraw, funnel, formAnchorRef, mobil
   );
   if (!mobile) {
     return (
-      <div style={{ minHeight: '100vh', background: NF.bg, position: 'relative', display: 'flex', flexDirection: 'column', fontFamily: SANS }}>
+      <div style={{ minHeight: '100vh', background: NF_HERO, position: 'relative', display: 'flex', flexDirection: 'column', fontFamily: SANS }}>
         <BackdropMedia t={t} media={content.media} />
         <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(100deg, rgba(20,22,31,.9) 34%, rgba(20,22,31,.35))' }} />
         <div style={{ position: 'relative', display: 'flex', justifyContent: 'space-between', padding: '26px 40px' }}>
@@ -463,8 +507,8 @@ function Nightfall({ t, content, params, luckyDraw, funnel, formAnchorRef, mobil
               </div>
             )}
           </div>
-          <div ref={formAnchorRef} style={{ width: 400, flexShrink: 0, background: '#fff', borderRadius: 16, padding: 24, boxShadow: '0 24px 60px rgba(0,0,0,.45)', display: 'flex', flexDirection: 'column', gap: 12 }}>
-            {content.emphasis && <div style={{ ...serifItalic(20), color: '#17181B' }}>{content.emphasis}</div>}
+          <div ref={formAnchorRef} style={{ width: 400, flexShrink: 0, background: NF.card, borderRadius: 16, padding: 24, boxShadow: '0 24px 60px rgba(0,0,0,.45)', display: 'flex', flexDirection: 'column', gap: 12 }}>
+            {content.emphasis && <div style={{ ...serifItalic(20), color: NF.ink }}>{content.emphasis}</div>}
             <ReferredBadge t={t} referrerName={referrerName} />
             {funnel}
           </div>
@@ -474,7 +518,7 @@ function Nightfall({ t, content, params, luckyDraw, funnel, formAnchorRef, mobil
   }
   return (
     <div style={{ minHeight: '100vh', background: NF.bg, color: NF.ink, display: 'flex', flexDirection: 'column', position: 'relative', fontFamily: SANS }}>
-      <div style={{ position: 'relative', minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <div style={{ position: 'relative', minHeight: '100vh', background: NF_HERO, display: 'flex', flexDirection: 'column' }}>
         <BackdropMedia t={t} media={content.media} />
         <div style={{ position: 'absolute', inset: 0, background: scrim }} />
         <div style={{ position: 'relative', display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '18px 20px' }}>
@@ -490,7 +534,7 @@ function Nightfall({ t, content, params, luckyDraw, funnel, formAnchorRef, mobil
           <button
             type="button"
             onClick={() => setSheetOpen(true)}
-            style={{ background: accent, color: '#fff', border: 'none', borderRadius: ctaRadius, padding: 16, fontSize: 16, fontWeight: 700, fontFamily: SANS, cursor: 'pointer' }}
+            style={{ background: accent, color: t.onAccent, border: 'none', borderRadius: ctaRadius, padding: 16, fontSize: 16, fontWeight: 700, fontFamily: SANS, cursor: 'pointer' }}
           >
             {content.submitLabel}
           </button>
@@ -509,13 +553,13 @@ function Nightfall({ t, content, params, luckyDraw, funnel, formAnchorRef, mobil
         ))}
         {s.draw && (
           <div style={{ border: `1px solid ${NF.border}`, borderRadius: 12, padding: 16, display: 'flex', flexDirection: 'column', gap: 8 }}>
-            <div style={mono(11, { letterSpacing: 1.5, color: accent, fontWeight: 600 })}>{`MAKE IT ×${s.multiplier}`}</div>
+            <div style={mono(11, { letterSpacing: 1.5, color: accentInk, fontWeight: 600 })}>{`MAKE IT ×${s.multiplier}`}</div>
             <div style={{ fontSize: 13.5, lineHeight: 1.55, color: NF.body }}>{s.boostBody}</div>
           </div>
         )}
         {s.draw && (
           <div style={{ fontSize: 12.5, color: NF.mut }}>
-            {s.winners > 1 ? 'Winners contacted directly.' : 'Winner contacted directly.'} Masked results at <WinnersLink color="#fff" />.
+            {s.winners > 1 ? 'Winners contacted directly.' : 'Winner contacted directly.'} Masked results at <WinnersLink color={NF.ink} />.
           </div>
         )}
         <div style={{ fontSize: 11, color: NF.faint }}>{content.regulatory}</div>
@@ -529,14 +573,14 @@ function Nightfall({ t, content, params, luckyDraw, funnel, formAnchorRef, mobil
       <div
         style={{
           position: 'fixed', left: 0, right: 0, bottom: 0, zIndex: 41,
-          background: '#fff', color: '#17181B', borderRadius: '18px 18px 0 0',
+          background: NF.card, color: NF.ink, borderRadius: '18px 18px 0 0',
           padding: '18px 20px 22px', boxShadow: '0 -12px 40px rgba(0,0,0,.4)',
           maxHeight: '88vh', overflowY: 'auto',
           display: sheetOpen ? 'flex' : 'none', flexDirection: 'column', gap: 14,
         }}
       >
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 10 }}>
-          <div style={serifItalic(19, { color: '#17181B' })}>{content.emphasis || content.headline}</div>
+          <div style={serifItalic(19, { color: NF.ink })}>{content.emphasis || content.headline}</div>
           <button
             type="button"
             onClick={() => setSheetOpen(false)}
@@ -550,7 +594,7 @@ function Nightfall({ t, content, params, luckyDraw, funnel, formAnchorRef, mobil
           <ReferredBadge t={t} referrerName={referrerName} />
           {funnel}
         </div>
-        {s.draw && <div style={mono(9.5, { letterSpacing: 0.8, color: '#8B8477', textAlign: 'center' })}>{TRUST_ROW}</div>}
+        {s.draw && <div style={mono(9.5, { letterSpacing: 0.8, color: NF.mut, textAlign: 'center' })}>{TRUST_ROW}</div>}
       </div>
     </div>
   );
@@ -558,11 +602,11 @@ function Nightfall({ t, content, params, luckyDraw, funnel, formAnchorRef, mobil
 
 // ═══════════════════════════════ STUB ═══════════════════════════════
 
-const ST = { bg: '#EFEBE0', ink: '#1B1A17', body: '#4A463C', mut: '#6B6558', faint: '#9A948A', dash: '#D9D4C8', line: '#DDD8CB' };
-
-function Perforation({ children, notchColor }) {
+/** Ticket tear line. `dashColor`/`notchColor` are passed in — the open and the
+ *  success states resolve their own polarity. */
+function Perforation({ children, notchColor, dashColor }) {
   return (
-    <div style={{ position: 'relative', borderTop: `2px dashed ${ST.dash}` }}>
+    <div style={{ position: 'relative', borderTop: `2px dashed ${dashColor}` }}>
       <div style={{ position: 'absolute', left: -9, top: -9, width: 18, height: 18, borderRadius: '50%', background: notchColor }} />
       <div style={{ position: 'absolute', right: -9, top: -9, width: 18, height: 18, borderRadius: '50%', background: notchColor }} />
       {children}
@@ -570,36 +614,43 @@ function Perforation({ children, notchColor }) {
   );
 }
 
-function StubHeader({ content }) {
+/** Also the header of the stub + checklist closed states, so the muted tone
+ *  arrives as a prop instead of being read off one frozen palette. */
+function StubHeader({ content, mutedColor }) {
   return (
     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '0 4px' }}>
       <div style={{ fontWeight: 800, fontSize: 17, fontFamily: SANS }}>{content.wordmark}</div>
-      <div style={mono(10, { letterSpacing: 1.5, color: ST.mut })}>FREE ENTRY · 18+</div>
+      <div style={mono(10, { letterSpacing: 1.5, color: mutedColor })}>FREE ENTRY · 18+</div>
     </div>
   );
 }
 
 function Stub({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile, referrerName, campaignName }) {
   const accent = t.accent;
+  const ST = drawPalette('stub', t);
+  const accentInk = accentTextOn(accent, ST.bg);
   const s = drawStrings(luckyDraw, campaignName);
   const accentTone = params.ticketTone === 'accent';
   const hasMedia = content.media.kind !== 'none' && !!content.media.src;
+  // The `paper` head is a hardcoded dark plate (white type is right on it); the
+  // `accent` head paints on the accent, so its type follows onAccent.
+  const headInk = accentTone ? t.onAccent : '#fff';
   const ticketHead = (
     <div style={{ position: 'relative', padding: mobile ? '16px 18px' : '22px 28px', display: 'flex', flexDirection: 'column', gap: 6, overflow: 'hidden', background: accentTone ? accent : '#17181B' }}>
       {!accentTone && hasMedia && <BackdropMedia t={t} media={content.media} />}
       {!accentTone && <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(rgba(23,24,27,.34), rgba(23,24,27,.62))' }} />}
-      <div style={{ position: 'relative', display: 'flex', justifyContent: 'space-between', gap: 10 }}>
-        <div style={mono(10, { letterSpacing: 1.6, color: 'rgba(255,255,255,.92)', fontWeight: 600 })}>{s.kicker || content.wordmark.toUpperCase()}</div>
-        {s.draw && <div style={mono(10, { letterSpacing: 1.6, color: 'rgba(255,255,255,.92)', fontWeight: 600 })}>ADMIT 1 ENTRY</div>}
+      <div style={{ position: 'relative', display: 'flex', justifyContent: 'space-between', gap: 10, opacity: 0.92 }}>
+        <div style={mono(10, { letterSpacing: 1.6, color: headInk, fontWeight: 600 })}>{s.kicker || content.wordmark.toUpperCase()}</div>
+        {s.draw && <div style={mono(10, { letterSpacing: 1.6, color: headInk, fontWeight: 600 })}>ADMIT 1 ENTRY</div>}
       </div>
-      <div style={{ position: 'relative', fontFamily: SERIF, fontWeight: 600, fontSize: mobile ? 29 : 36, lineHeight: 1.12, color: '#fff' }}>{content.headline}</div>
-      {content.subheadline && <div style={{ position: 'relative', fontSize: mobile ? 13.5 : 14.5, color: 'rgba(255,255,255,.88)', fontFamily: SANS, whiteSpace: 'pre-line' }}>{content.subheadline}</div>}
+      <div style={{ position: 'relative', fontFamily: SERIF, fontWeight: 600, fontSize: mobile ? 29 : 36, lineHeight: 1.12, color: headInk }}>{content.headline}</div>
+      {content.subheadline && <div style={{ position: 'relative', fontSize: mobile ? 13.5 : 14.5, color: headInk, opacity: 0.88, fontFamily: SANS, whiteSpace: 'pre-line' }}>{content.subheadline}</div>}
     </div>
   );
   const stubLine = s.draw && (
     <div style={{ padding: '13px 18px', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 10 }}>
       <div style={mono(10.5, { letterSpacing: 1, color: ST.ink, fontWeight: 600 })}>{`CLOSES ${s.closesMono} · 23:59 SGT`}</div>
-      {params.showSerial !== false && <div style={mono(10.5, { color: '#8B8477' })}>NO. 0000001</div>}
+      {params.showSerial !== false && <div style={mono(10.5, { color: ST.mut })}>NO. 0000001</div>}
     </div>
   );
   const formBody = (
@@ -615,7 +666,7 @@ function Stub({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile, re
           <div style={{ fontWeight: 800, fontSize: 20 }}>{content.wordmark}</div>
           <div style={mono(11, { letterSpacing: 1.5, color: ST.mut })}>FREE ENTRY · 18+</div>
         </div>
-        <div style={{ width: 760, maxWidth: 'calc(100vw - 48px)', background: '#fff', borderRadius: 14, boxShadow: '0 10px 30px rgba(27,26,23,.09)', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+        <div style={{ width: 760, maxWidth: 'calc(100vw - 48px)', background: ST.card, borderRadius: 14, boxShadow: '0 10px 30px rgba(27,26,23,.09)', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
           {ticketHead}
           <div style={{ display: 'flex' }}>
             <div style={{ flex: 1, borderRight: `2px dashed ${ST.dash}` }}>{formBody}</div>
@@ -626,22 +677,22 @@ function Stub({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile, re
                   <strong>Make it ×{s.multiplier}.</strong> {s.boostBody}
                 </div>
               )}
-              {params.showSerial !== false && <div style={{ marginTop: 'auto', ...mono(10, { color: '#8B8477' }) }}>NO. 0000001</div>}
+              {params.showSerial !== false && <div style={{ marginTop: 'auto', ...mono(10, { color: ST.mut }) }}>NO. 0000001</div>}
             </div>
           </div>
         </div>
         <div style={{ width: 760, maxWidth: 'calc(100vw - 48px)', display: 'flex', flexDirection: 'column', gap: 8, textAlign: 'center' }}>
-          {s.draw && <div style={mono(10, { letterSpacing: 0.8, color: '#8B8477' })}>{TRUST_ROW}</div>}
-          <DrawFootnotes draw={s.draw} linkColor={accent} mutedColor={ST.mut} faintColor={ST.faint} content={content} t={t} center />
+          {s.draw && <div style={mono(10, { letterSpacing: 0.8, color: ST.mut })}>{TRUST_ROW}</div>}
+          <DrawFootnotes draw={s.draw} linkColor={accentInk} mutedColor={ST.mut} faintColor={ST.faint} content={content} t={t} center />
         </div>
       </div>
     );
   }
   const ticket = (
-    <div style={{ background: '#fff', borderRadius: 12, boxShadow: '0 6px 22px rgba(27,26,23,.08)', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+    <div style={{ background: ST.card, borderRadius: 12, boxShadow: '0 6px 22px rgba(27,26,23,.08)', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
       {params.stubEdge === 'top' ? (
         <>
-          {stubLine && <div>{stubLine}<Perforation notchColor="#FFFFFF"><span /></Perforation></div>}
+          {stubLine && <div>{stubLine}<Perforation notchColor={ST.card} dashColor={ST.dash}><span /></Perforation></div>}
           {ticketHead}
           {formBody}
         </>
@@ -649,19 +700,19 @@ function Stub({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile, re
         <>
           {ticketHead}
           {formBody}
-          {stubLine && <Perforation notchColor={ST.bg}>{stubLine}</Perforation>}
+          {stubLine && <Perforation notchColor={ST.bg} dashColor={ST.dash}>{stubLine}</Perforation>}
         </>
       )}
     </div>
   );
   return (
     <div style={{ minHeight: '100vh', background: ST.bg, display: 'flex', flexDirection: 'column', padding: '18px 16px 26px', boxSizing: 'border-box', gap: 14, fontFamily: SANS, color: ST.ink }}>
-      <StubHeader content={content} />
+      <StubHeader content={content} mutedColor={ST.mut} />
       {ticket}
-      {s.draw && <div style={mono(9.5, { letterSpacing: 0.8, color: '#8B8477', textAlign: 'center' })}>{TRUST_ROW}</div>}
+      {s.draw && <div style={mono(9.5, { letterSpacing: 0.8, color: ST.mut, textAlign: 'center' })}>{TRUST_ROW}</div>}
       {s.draw && (
-        <div style={{ background: '#fff', borderRadius: 12, padding: '16px 18px', display: 'flex', flexDirection: 'column', gap: 8 }}>
-          <div style={mono(11, { letterSpacing: 1.5, color: accent, fontWeight: 600 })}>{`MAKE IT ×${s.multiplier}`}</div>
+        <div style={{ background: ST.card, borderRadius: 12, padding: '16px 18px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <div style={mono(11, { letterSpacing: 1.5, color: accentInk, fontWeight: 600 })}>{`MAKE IT ×${s.multiplier}`}</div>
           <div style={{ fontSize: 13.5, lineHeight: 1.55, color: ST.body }}>{s.boostBody}</div>
         </div>
       )}
@@ -670,7 +721,7 @@ function Stub({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile, re
       ))}
       {content.emphasis && <div style={{ fontSize: 15, fontWeight: 700, color: ST.ink, padding: '0 6px' }}>{content.emphasis}</div>}
       <div style={{ borderTop: `1px solid ${ST.line}`, padding: '12px 6px 0' }}>
-        <DrawFootnotes draw={s.draw} linkColor={accent} mutedColor={ST.mut} faintColor={ST.faint} content={content} t={t} />
+        <DrawFootnotes draw={s.draw} linkColor={accentInk} mutedColor={ST.mut} faintColor={ST.faint} content={content} t={t} />
       </div>
     </div>
   );
@@ -678,19 +729,20 @@ function Stub({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile, re
 
 // ═══════════════════════════════ CHECKLIST ═══════════════════════════════
 
-const CL = { bg: '#FFFFFF', ink: '#17181B', body: '#4A463C', mut: '#6B6558', faint: '#9A948A', line: '#E9E6DD', railBg: '#F3F1EA' };
-
-function ChecklistHeader({ content, s }) {
+/** Shared by the checklist open + success states, so the muted tone is a prop. */
+function ChecklistHeader({ content, s, mutedColor }) {
   return (
     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
       <div style={{ fontWeight: 800, fontSize: 17, fontFamily: SANS }}>{content.wordmark}</div>
-      {s.closesMono && <div style={mono(10, { letterSpacing: 1.5, color: '#8B8477' })}>{`CLOSES ${s.closesMono}`}</div>}
+      {s.closesMono && <div style={mono(10, { letterSpacing: 1.5, color: mutedColor })}>{`CLOSES ${s.closesMono}`}</div>}
     </div>
   );
 }
 
 function Checklist({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile, referrerName, campaignName }) {
   const accent = t.accent;
+  const CL = drawPalette('checklist', t);
+  const accentInk = accentTextOn(accent, CL.bg);
   const s = drawStrings(luckyDraw, campaignName);
   const hasMedia = content.media.kind !== 'none' && !!content.media.src;
   const showBand = params.heroBand !== false && hasMedia;
@@ -703,9 +755,9 @@ function Checklist({ t, content, params, luckyDraw, funnel, formAnchorRef, mobil
         width: 26, height: 26, borderRadius: '50%', flexShrink: 0, boxSizing: 'border-box',
         display: 'flex', alignItems: 'center', justifyContent: 'center',
         fontFamily: kind === 'plus' ? MONO : SANS, fontSize: kind === 'plus' ? 10 : 12, fontWeight: 700,
-        ...(kind === 'filled' ? { background: accent, color: '#fff' } : {}),
-        ...(kind === 'outline' ? { border: `2px solid ${accent}`, color: accent } : {}),
-        ...(kind === 'plus' ? { background: CL.railBg, color: '#8B8477', fontWeight: 600 } : {}),
+        ...(kind === 'filled' ? { background: accent, color: t.onAccent } : {}),
+        ...(kind === 'outline' ? { border: `2px solid ${accentInk}`, color: accentInk } : {}),
+        ...(kind === 'plus' ? { background: CL.railBg, color: CL.mut, fontWeight: 600 } : {}),
       }}
     >
       {inner}
@@ -729,7 +781,7 @@ function Checklist({ t, content, params, luckyDraw, funnel, formAnchorRef, mobil
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       {spineStep('s1', circle('1', 'filled'), 'Drop your details', null, {
         children: (
-          <div ref={formAnchorRef} style={{ border: `1px solid ${CL.line}`, borderRadius: 12, padding: 14 }}>
+          <div ref={formAnchorRef} style={{ background: CL.card, border: `1px solid ${CL.line}`, borderRadius: 12, padding: 14 }}>
             <ReferredBadge t={t} referrerName={referrerName} />
             {funnel}
           </div>
@@ -751,15 +803,15 @@ function Checklist({ t, content, params, luckyDraw, funnel, formAnchorRef, mobil
   );
   const footer = (
     <div style={{ borderTop: `1px solid ${CL.line}`, paddingTop: 14, display: 'flex', flexDirection: 'column', gap: 8 }}>
-      {s.draw && <div style={mono(9.5, { letterSpacing: 0.8, color: '#8B8477', textAlign: 'center' })}>{TRUST_ROW}</div>}
+      {s.draw && <div style={mono(9.5, { letterSpacing: 0.8, color: CL.mut, textAlign: 'center' })}>{TRUST_ROW}</div>}
       {footnote}
-      <DrawFootnotes draw={s.draw} linkColor={accent} mutedColor={CL.mut} faintColor={CL.faint} content={content} t={t} center />
+      <DrawFootnotes draw={s.draw} linkColor={accentInk} mutedColor={CL.mut} faintColor={CL.faint} content={content} t={t} center />
     </div>
   );
   if (!mobile) {
     return (
       <div style={{ minHeight: '100vh', background: CL.bg, padding: '34px 56px', boxSizing: 'border-box', display: 'flex', flexDirection: 'column', gap: 24, fontFamily: SANS, color: CL.ink }}>
-        <ChecklistHeader content={content} s={s} />
+        <ChecklistHeader content={content} s={s} mutedColor={CL.mut} />
         {showBand && (
           <div style={{ position: 'relative', height: 190, borderRadius: 14, overflow: 'hidden' }}>
             <BackdropMedia t={t} media={content.media} />
@@ -780,27 +832,27 @@ function Checklist({ t, content, params, luckyDraw, funnel, formAnchorRef, mobil
             </div>
             {s.draw && (
               <div style={{ fontSize: 13, color: CL.mut }}>
-                {SCAM_LINE} Masked results at <WinnersLink color={accent} />.
+                {SCAM_LINE} Masked results at <WinnersLink color={accentInk} />.
               </div>
             )}
           </div>
           <div style={{ width: 400, flexShrink: 0 }}>
-            <div ref={formAnchorRef} style={{ border: `1px solid ${CL.line}`, borderRadius: 14, padding: 22, display: 'flex', flexDirection: 'column', gap: 12 }}>
+            <div ref={formAnchorRef} style={{ background: CL.card, border: `1px solid ${CL.line}`, borderRadius: 14, padding: 22, display: 'flex', flexDirection: 'column', gap: 12 }}>
               <ReferredBadge t={t} referrerName={referrerName} />
               {funnel}
-              {s.draw && <div style={mono(9.5, { letterSpacing: 0.6, color: '#8B8477', textAlign: 'center' })}>{TRUST_ROW}</div>}
+              {s.draw && <div style={mono(9.5, { letterSpacing: 0.6, color: CL.mut, textAlign: 'center' })}>{TRUST_ROW}</div>}
             </div>
           </div>
         </div>
         <div style={{ marginTop: 'auto', borderTop: `1px solid ${CL.line}`, paddingTop: 12 }}>
-          <DrawFootnotes draw={null} linkColor={accent} mutedColor={CL.mut} faintColor={CL.faint} content={content} t={t} />
+          <DrawFootnotes draw={null} linkColor={accentInk} mutedColor={CL.mut} faintColor={CL.faint} content={content} t={t} />
         </div>
       </div>
     );
   }
   return (
     <div style={{ minHeight: '100vh', background: CL.bg, display: 'flex', flexDirection: 'column', padding: '18px 20px 26px', boxSizing: 'border-box', gap: 16, fontFamily: SANS, color: CL.ink }}>
-      <ChecklistHeader content={content} s={s} />
+      <ChecklistHeader content={content} s={s} mutedColor={CL.mut} />
       {showBand && (
         <div style={{ position: 'relative', height: 150, margin: '0 -20px', overflow: 'hidden' }}>
           <BackdropMedia t={t} media={content.media} />
@@ -834,45 +886,51 @@ export function DrawSuccessPage({ campaign, submittedPhone = null }) {
   const sub = successSubOf(submittedPhone);
   const bookingUrl = s.draw?.bookingUrl || null;
   const closesLine = s.closesMono ? `ENTRIES CLOSE ${s.closesMono} · 23:59 SGT` : '';
+  const pal = drawPalette(templateId, theme);
+  // Accent AS TEXT, stepped for the surface it actually lands on: postcard is
+  // the only filled box, the other four are border-only over the page.
+  const accentOnCard = accentTextOn(accent, pal.card);
+  const accentOnPage = accentTextOn(accent, pal.bg);
+  const accentOnBox = templateId === 'postcard' ? accentOnCard : accentOnPage;
 
   const chrome = {
     postcard: {
-      pageBg: PC.bg, ink: PC.ink, body: PC.body, mut: PC.mut, divider: PC.line,
-      title: "You're in.", dot: accent, tenX: accent, label: 'NEXT STEP · EARN ×10 CHANCES',
-      box: { background: '#fff', borderRadius: 14, boxShadow: '0 8px 28px rgba(23,24,27,.08)' },
-      stepBg: accentSoftOf(accent), stepColor: accent, wordmark: true,
+      pageBg: pal.bg, ink: pal.ink, body: pal.body, mut: pal.mut, divider: pal.line,
+      title: "You're in.", dot: accent, tenX: accentOnBox, label: 'NEXT STEP · EARN ×10 CHANCES',
+      box: { background: pal.card, borderRadius: 14, boxShadow: '0 8px 28px rgba(23,24,27,.08)' },
+      stepBg: accentSoftOf(accent), stepColor: accentOnCard, wordmark: true,
     },
     gazette: {
-      pageBg: GZ.bg, ink: GZ.ink, body: GZ.body, mut: GZ.mut, divider: GZ.hair,
-      title: 'Entered.', dot: GZ.gold, tenX: GZ.gold, label: 'NEXT STEP · EARN ×10 CHANCES',
-      box: { border: `1.5px solid ${GZ.ink}` },
-      stepBg: accentSoftOf(accent), stepColor: accent, masthead: true,
+      pageBg: pal.bg, ink: pal.ink, body: pal.body, mut: pal.mut, divider: pal.line,
+      title: 'Entered.', dot: pal.gold, tenX: pal.gold, label: 'NEXT STEP · EARN ×10 CHANCES',
+      box: { border: `1.5px solid ${pal.ink}` },
+      stepBg: accentSoftOf(accent), stepColor: accentOnCard, masthead: true,
     },
     nightfall: {
-      pageBg: NF.bg, ink: NF.ink, body: NF.body, mut: NF.faint, divider: 'rgba(242,241,236,.14)',
-      title: "You're in.", dot: accent, tenX: accent, label: 'NEXT STEP · EARN ×10 CHANCES',
-      box: { border: `1px solid ${NF.border}`, borderRadius: 12 },
-      stepBg: 'rgba(242,241,236,.14)', stepColor: NF.ink, wordmark: true, dark: true,
+      pageBg: pal.bg, ink: pal.ink, body: pal.body, mut: pal.faint, divider: pal.line,
+      title: "You're in.", dot: accent, tenX: accentOnBox, label: 'NEXT STEP · EARN ×10 CHANCES',
+      box: { border: `1px solid ${pal.border}`, borderRadius: 12 },
+      stepBg: pal.line, stepColor: pal.ink, wordmark: true,
     },
     stub: {
-      pageBg: ST.bg, ink: ST.ink, body: ST.body, mut: ST.mut, divider: ST.line,
-      title: "You're in.", dot: accent, tenX: accent, label: 'NEXT STEP · EARN ×10 CHANCES',
-      box: {}, stepBg: accentSoftOf(accent), stepColor: accent, ticket: true, header: true,
+      pageBg: pal.bg, ink: pal.ink, body: pal.body, mut: pal.mut, divider: pal.line,
+      title: "You're in.", dot: accent, tenX: accentOnBox, label: 'NEXT STEP · EARN ×10 CHANCES',
+      box: {}, stepBg: accentSoftOf(accent), stepColor: accentOnCard, ticket: true, header: true,
     },
     checklist: {
-      pageBg: CL.bg, ink: CL.ink, body: CL.body, mut: CL.mut, divider: CL.line,
-      title: "You're in.", dot: accent, tenX: accent, label: 'ONE STEP LEFT · EARN ×10 CHANCES',
-      box: { border: `1px solid ${CL.line}`, borderRadius: 12 },
-      stepBg: accentSoftOf(accent), stepColor: accent, check: true, header: true,
+      pageBg: pal.bg, ink: pal.ink, body: pal.body, mut: pal.mut, divider: pal.line,
+      title: "You're in.", dot: accent, tenX: accentOnBox, label: 'ONE STEP LEFT · EARN ×10 CHANCES',
+      box: { border: `1px solid ${pal.line}`, borderRadius: 12 },
+      stepBg: accentSoftOf(accent), stepColor: accentOnCard, check: true, header: true,
     },
   }[templateId];
 
   const label = chrome.label.replace('×10', `×${s.multiplier}`);
-  const monoMut = chrome.dark ? NF.faint : '#8B8477';
+  const monoMut = pal.mut;
   const chances = (
     <div style={{ ...chrome.box, padding: '14px 20px', display: 'flex', flexDirection: 'column', gap: 10 }}>
-      <div style={mono(11, { letterSpacing: 1.5, color: templateId === 'gazette' ? GZ.ink : accent, fontWeight: 600 })}>CHANCES</div>
-      <ChancesRow accent={chrome.tenX} inkColor={chrome.ink} mutedColor={monoMut} multiplier={s.multiplier} />
+      <div style={mono(11, { letterSpacing: 1.5, color: templateId === 'gazette' ? pal.ink : accentOnBox, fontWeight: 600 })}>CHANCES</div>
+      <ChancesRow accent={chrome.tenX} accentLabel={accentTextOn(chrome.tenX, chrome.pageBg)} inkColor={chrome.ink} mutedColor={monoMut} multiplier={s.multiplier} />
     </div>
   );
   const nextSteps = (
@@ -880,6 +938,8 @@ export function DrawSuccessPage({ campaign, submittedPhone = null }) {
       <NextSteps
         s={s}
         accent={templateId === 'gazette' ? accent : accent}
+        accentText={accentOnBox}
+        onAccent={theme.onAccent}
         stepBg={chrome.stepBg}
         stepColor={chrome.stepColor}
         bodyColor={chrome.body}
@@ -894,8 +954,8 @@ export function DrawSuccessPage({ campaign, submittedPhone = null }) {
     <div style={{ display: 'flex', flexDirection: 'column', gap: 12, alignItems: 'flex-start' }}>
       {chrome.check ? (
         <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
-          <div style={{ width: 26, height: 26, borderRadius: '50%', background: accent, color: '#fff', fontSize: 13, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>✓</div>
-          <div style={mono(10.5, { letterSpacing: 1.5, color: '#8B8477' })}>ENTRY VERIFIED · YOU'RE IN THE DRAW</div>
+          <div style={{ width: 26, height: 26, borderRadius: '50%', background: accent, color: theme.onAccent, fontSize: 13, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>✓</div>
+          <div style={mono(10.5, { letterSpacing: 1.5, color: monoMut })}>ENTRY VERIFIED · YOU'RE IN THE DRAW</div>
         </div>
       ) : (
         <div style={{ width: 14, height: 14, borderRadius: '50%', background: chrome.dot }} />
@@ -905,8 +965,8 @@ export function DrawSuccessPage({ campaign, submittedPhone = null }) {
     </div>
   );
   const footerLine = (
-    <div style={{ marginTop: 'auto', fontSize: 12.5, color: chrome.dark ? NF.mut : chrome.mut, borderTop: `1px solid ${chrome.divider}`, paddingTop: 14, fontFamily: SANS }}>
-      {SCAM_LINE} Results at <WinnersLink color={chrome.dark ? '#fff' : accent} />.
+    <div style={{ marginTop: 'auto', fontSize: 12.5, color: pal.mut, borderTop: `1px solid ${chrome.divider}`, paddingTop: 14, fontFamily: SANS }}>
+      {SCAM_LINE} Results at <WinnersLink color={theme.dark ? pal.ink : accentOnPage} />.
     </div>
   );
 
@@ -914,35 +974,35 @@ export function DrawSuccessPage({ campaign, submittedPhone = null }) {
   if (chrome.ticket) {
     body = (
       <>
-        <StubHeader content={content} />
-        <div style={{ background: '#fff', borderRadius: 12, boxShadow: '0 6px 22px rgba(27,26,23,.08)', overflow: 'hidden', marginTop: 20 }}>
+        <StubHeader content={content} mutedColor={pal.mut} />
+        <div style={{ background: pal.card, borderRadius: 12, boxShadow: '0 6px 22px rgba(27,26,23,.08)', overflow: 'hidden', marginTop: 20 }}>
           <div style={{ background: accentSoftOf(accent), padding: 18, display: 'flex', flexDirection: 'column', gap: 8 }}>
             <div style={{ width: 14, height: 14, borderRadius: '50%', background: accent }} />
-            <div style={serifItalic(38, { color: ST.ink })}>{chrome.title}</div>
-            <div style={{ fontSize: 14, lineHeight: 1.55, color: ST.body, fontFamily: SANS }}>{sub}</div>
+            <div style={serifItalic(38, { color: pal.ink })}>{chrome.title}</div>
+            <div style={{ fontSize: 14, lineHeight: 1.55, color: pal.body, fontFamily: SANS }}>{sub}</div>
           </div>
           <div style={{ padding: '16px 18px 0', display: 'flex', flexDirection: 'column', gap: 10 }}>
-            <div style={mono(11, { letterSpacing: 1.5, color: accent, fontWeight: 600 })}>CHANCES</div>
-            <ChancesRow accent={accent} inkColor={ST.ink} mutedColor="#8B8477" multiplier={s.multiplier} />
+            <div style={mono(11, { letterSpacing: 1.5, color: accentOnCard, fontWeight: 600 })}>CHANCES</div>
+            <ChancesRow accent={accentOnCard} accentLabel={accentTextOn(accentOnCard, pal.card)} inkColor={pal.ink} mutedColor={monoMut} multiplier={s.multiplier} />
           </div>
           <div style={{ padding: '16px 18px', display: 'flex', flexDirection: 'column', gap: 12 }}>
-            <NextSteps s={s} accent={accent} stepBg={accentSoftOf(accent)} stepColor={accent} bodyColor={ST.body} lastColor={ST.ink} mutedColor="#8B8477" label={label} bookingUrl={bookingUrl} />
+            <NextSteps s={s} accent={accent} accentText={accentOnCard} onAccent={theme.onAccent} stepBg={accentSoftOf(accent)} stepColor={accentOnCard} bodyColor={pal.body} lastColor={pal.ink} mutedColor={monoMut} label={label} bookingUrl={bookingUrl} />
           </div>
           {s.closesMono && (
-            <Perforation notchColor={ST.bg}>
-              <div style={{ padding: '13px 18px', ...mono(10.5, { letterSpacing: 1, color: ST.ink, fontWeight: 600 }) }}>{`ENTRY HELD · CLOSES ${s.closesMono}`}</div>
+            <Perforation notchColor={pal.bg} dashColor={pal.dash}>
+              <div style={{ padding: '13px 18px', ...mono(10.5, { letterSpacing: 1, color: pal.ink, fontWeight: 600 }) }}>{`ENTRY HELD · CLOSES ${s.closesMono}`}</div>
             </Perforation>
           )}
         </div>
-        <div style={{ marginTop: 'auto', fontSize: 12.5, color: ST.mut, padding: '0 6px', fontFamily: SANS }}>{SCAM_LINE}</div>
+        <div style={{ marginTop: 'auto', fontSize: 12.5, color: pal.mut, padding: '0 6px', fontFamily: SANS }}>{SCAM_LINE}</div>
       </>
     );
   } else {
     body = (
       <>
-        {chrome.masthead && <GazetteMasthead content={content} kickerText="OFFICIAL ENTRY FORM" />}
-        {chrome.header && !chrome.masthead && <ChecklistHeader content={content} s={s} />}
-        {chrome.wordmark && <div style={{ fontWeight: 800, fontSize: 17, color: chrome.dark ? '#fff' : chrome.ink, fontFamily: SANS }}>{content.wordmark}</div>}
+        {chrome.masthead && <GazetteMasthead content={content} kickerText="OFFICIAL ENTRY FORM" inkColor={pal.ink} mutedColor={pal.mut} />}
+        {chrome.header && !chrome.masthead && <ChecklistHeader content={content} s={s} mutedColor={pal.mut} />}
+        {chrome.wordmark && <div style={{ fontWeight: 800, fontSize: 17, color: chrome.ink, fontFamily: SANS }}>{content.wordmark}</div>}
         <div style={{ marginTop: chrome.masthead || chrome.header ? 22 : 26, display: 'flex', flexDirection: 'column', gap: 16 }}>
           {intro}
           {chances}
@@ -976,18 +1036,22 @@ export function DrawSuccessPage({ campaign, submittedPhone = null }) {
 export function DrawClosedPage({ templateId, t, content, luckyDraw, campaignName }) {
   const accent = t.accent;
   const s = drawStrings(luckyDraw, campaignName);
+  const pal = drawPalette(templateId, t);
   const chrome = {
-    postcard: { pageBg: PC.bg, ink: PC.ink, body: PC.body, mut: '#8B8477', faint: PC.faint, divider: PC.line, cta: 'fill', wordmark: true },
-    gazette: { pageBg: GZ.bg, ink: GZ.ink, body: GZ.body, mut: '#8B8477', faint: GZ.faint, divider: GZ.hair, cta: 'outline', masthead: true },
-    nightfall: { pageBg: NF.bg, ink: '#fff', body: NF.body, mut: NF.faint, faint: NF.faint, divider: 'rgba(242,241,236,.14)', cta: 'fill', wordmark: true, dark: true },
-    stub: { pageBg: ST.bg, ink: ST.ink, body: ST.body, mut: '#8B8477', faint: ST.faint, divider: ST.line, cta: 'fill', header: true, card: true },
-    checklist: { pageBg: CL.bg, ink: CL.ink, body: CL.body, mut: '#8B8477', faint: CL.faint, divider: CL.line, cta: 'fill', header: true },
+    postcard: { pageBg: pal.bg, ink: pal.ink, body: pal.body, mut: pal.mut, faint: pal.faint, divider: pal.line, cta: 'fill', wordmark: true },
+    gazette: { pageBg: pal.bg, ink: pal.ink, body: pal.body, mut: pal.mut, faint: pal.faint, divider: pal.line, cta: 'outline', masthead: true },
+    nightfall: { pageBg: pal.bg, ink: pal.ink, body: pal.body, mut: pal.mut, faint: pal.faint, divider: pal.line, cta: 'fill', wordmark: true },
+    stub: { pageBg: pal.bg, ink: pal.ink, body: pal.body, mut: pal.mut, faint: pal.faint, divider: pal.line, cta: 'fill', header: true, card: true },
+    checklist: { pageBg: pal.bg, ink: pal.ink, body: pal.body, mut: pal.mut, faint: pal.faint, divider: pal.line, cta: 'fill', header: true },
   }[templateId];
   if (!chrome) return null;
 
+  // Secondary scam line: the frozen light tone on every template, the palette's
+  // own muted once the preset flips dark.
+  const scamMut = t.dark ? pal.mut : '#6B6558';
   const ctaStyle = chrome.cta === 'outline'
-    ? { border: `1.5px solid ${GZ.ink}`, color: GZ.ink, background: 'transparent' }
-    : { background: accent, color: '#fff', border: 'none', borderRadius: 9 };
+    ? { border: `1.5px solid ${pal.ink}`, color: pal.ink, background: 'transparent' }
+    : { background: accent, color: t.onAccent, border: 'none', borderRadius: 9 };
   const cta = (
     <a
       href={WINNERS_URL}
@@ -1004,7 +1068,7 @@ export function DrawClosedPage({ templateId, t, content, luckyDraw, campaignName
       <div style={serifItalic(42, { color: chrome.ink })}>Entries closed.</div>
       {s.closesMono && <div style={mono(11, { color: chrome.mut })}>{`${s.closesMono} · 23:59 SGT`}</div>}
       <div style={{ fontSize: 14.5, lineHeight: 1.55, color: chrome.body, fontFamily: SANS }}>{s.closedBody}</div>
-      <div style={{ fontSize: 13, color: chrome.dark ? NF.mut : '#6B6558', fontFamily: SANS }}>{SCAM_LINE}</div>
+      <div style={{ fontSize: 13, color: scamMut, fontFamily: SANS }}>{SCAM_LINE}</div>
     </>
   );
   return (
@@ -1014,11 +1078,11 @@ export function DrawClosedPage({ templateId, t, content, luckyDraw, campaignName
       style={{ minHeight: '100vh', background: chrome.pageBg, color: chrome.ink, fontFamily: SANS, display: 'flex', flexDirection: 'column', boxSizing: 'border-box', padding: 20 }}
     >
       <div style={{ width: '100%', maxWidth: 560, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 14, flex: 1 }}>
-        {chrome.masthead && <GazetteMasthead content={content} kickerText="OFFICIAL ENTRY FORM" />}
-        {chrome.header && <StubHeader content={content} />}
+        {chrome.masthead && <GazetteMasthead content={content} kickerText="OFFICIAL ENTRY FORM" inkColor={pal.ink} mutedColor={pal.mut} />}
+        {chrome.header && <StubHeader content={content} mutedColor={pal.mut} />}
         {chrome.wordmark && <div style={{ fontWeight: 800, fontSize: 17, color: chrome.ink, fontFamily: SANS }}>{content.wordmark}</div>}
         {chrome.card ? (
-          <div style={{ background: '#fff', borderRadius: 12, boxShadow: '0 6px 22px rgba(27,26,23,.08)', padding: '22px 18px', display: 'flex', flexDirection: 'column', gap: 12, marginTop: 26 }}>
+          <div style={{ background: pal.card, borderRadius: 12, boxShadow: '0 6px 22px rgba(27,26,23,.08)', padding: '22px 18px', display: 'flex', flexDirection: 'column', gap: 12, marginTop: 26 }}>
             {core}
             {cta}
           </div>

--- a/src/components/campaignPage/templates.jsx
+++ b/src/components/campaignPage/templates.jsx
@@ -16,7 +16,7 @@
  */
 import { useRef, useEffect } from 'react';
 import { resolveImageUrl } from '@/components/campaigns/LeadCaptureLayout';
-import { youTubeIdFrom } from '@/lib/designConfigV2';
+import { youTubeIdFrom, onColor, accentTextOn } from '@/lib/designConfigV2';
 import { BrandFooter, DrawBadge, ReferredBadge, formatDrawDate } from './CampaignPageRenderer';
 
 const SANS = "'Albert Sans', system-ui, sans-serif";
@@ -197,11 +197,16 @@ function Editorial({ t, content, params, luckyDraw, funnel, formAnchorRef, scrol
 // ─────────────────────────────────── Poster ───────────────────────────────────
 
 function Poster({ t, content, params, luckyDraw, funnel, formAnchorRef, scrollToForm, mobile, referrerName }) {
-  const fade = params.overlay === 'plain' ? 'rgba(12,10,8,.45)' : t.bg;
+  const dusk = params.overlay !== 'plain';
+  const fade = dusk ? t.bg : 'rgba(12,10,8,.45)';
+  // The hero copy sits where the gradient has already reached `fade`, so its
+  // colour has to follow that surface — a fixed white vanished on light presets.
+  const heroInk = dusk ? onColor(t.bg) : '#FFF';
+  const heroBackdrop = t.dark ? t.card : '#17191E';
   const showCta = content.media.kind !== 'none' && !!content.heroCtaLabel;
   return (
     <div style={{ minHeight: '100vh', background: t.bg, fontFamily: SANS, color: t.ink }}>
-      <div style={{ position: 'relative', height: mobile ? 430 : 480, background: '#17191E', overflow: 'hidden' }}>
+      <div style={{ position: 'relative', height: mobile ? 430 : 480, background: heroBackdrop, overflow: 'hidden' }}>
         <MediaBlock t={t} media={content.media} radius={0} style={{ position: 'absolute', inset: 0, aspectRatio: 'auto', height: '100%' }} />
         <div style={{ position: 'absolute', inset: 0, background: `linear-gradient(to top, ${fade} 4%, rgba(12,10,8,.28) 55%, rgba(12,10,8,.2))` }} />
         <div style={{ position: 'absolute', top: 16, left: 18, fontFamily: t.fontStack, fontSize: 18, fontWeight: 700, color: '#FFF' }}>
@@ -209,15 +214,15 @@ function Poster({ t, content, params, luckyDraw, funnel, formAnchorRef, scrollTo
         </div>
         <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0, padding: mobile ? 16 : 26, maxWidth: 620, margin: '0 auto', boxSizing: 'border-box' }}>
           {luckyDraw?.enabled === true && (
-            <div style={{ display: 'inline-block', font: "600 10px ui-monospace, 'SF Mono', Menlo, monospace", background: 'rgba(255,255,255,.14)', color: '#FFE9A8', borderRadius: 999, padding: '5px 11px', marginBottom: 10, backdropFilter: 'blur(4px)' }}>
+            <div style={{ display: 'inline-block', font: "600 10px ui-monospace, 'SF Mono', Menlo, monospace", background: dusk ? t.soft : 'rgba(255,255,255,.14)', color: heroInk, borderRadius: 999, padding: '5px 11px', marginBottom: 10, backdropFilter: 'blur(4px)' }}>
               <DrawBadgeText luckyDraw={luckyDraw} />
             </div>
           )}
-          <div style={{ fontFamily: t.fontStack, fontSize: mobile ? 32 : 46, lineHeight: 1.06, fontWeight: 700, color: '#FFF', letterSpacing: '-0.01em' }}>
+          <div style={{ fontFamily: t.fontStack, fontSize: mobile ? 32 : 46, lineHeight: 1.06, fontWeight: 700, color: heroInk, letterSpacing: '-0.01em' }}>
             {content.headline}
           </div>
           {content.subheadline && (
-            <div style={{ fontSize: 14, lineHeight: 1.5, color: 'rgba(255,255,255,.85)', margin: '10px 0 14px', maxWidth: 440, whiteSpace: 'pre-line' }}>
+            <div style={{ fontSize: 14, lineHeight: 1.5, color: heroInk, opacity: 0.85, margin: '10px 0 14px', maxWidth: 440, whiteSpace: 'pre-line' }}>
               {content.subheadline}
             </div>
           )}
@@ -251,7 +256,7 @@ function DrawBadgeText({ luckyDraw }) {
 function Split({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile, referrerName }) {
   const mediaSide = params.mediaSide === 'right' ? 'right' : 'left';
   const mediaPanel = (
-    <div style={{ position: 'relative', background: '#17191E', minHeight: mobile ? 220 : 'auto', overflow: 'hidden' }}>
+    <div style={{ position: 'relative', background: t.dark ? t.card : '#17191E', minHeight: mobile ? 220 : 'auto', overflow: 'hidden' }}>
       <MediaBlock t={t} media={content.media} radius={0} style={{ position: 'absolute', inset: 0, aspectRatio: 'auto', height: '100%', objectFit: params.mediaFit === 'contain' ? 'contain' : 'cover' }} />
       {luckyDraw?.enabled === true && (
         <span style={{ position: 'absolute', top: 14, left: 14, font: "600 10px ui-monospace, 'SF Mono', Menlo, monospace", background: 'rgba(12,10,8,.72)', color: '#FFE9A8', borderRadius: 999, padding: '5px 11px' }}>
@@ -308,7 +313,7 @@ function Spotlight({ t, content, luckyDraw, funnel, formAnchorRef, stage, referr
           <div>
             <div style={{ fontFamily: t.fontStack, fontSize: 24, lineHeight: 1.15, fontWeight: 700, marginBottom: 7 }}>{content.headline}</div>
             {content.paragraphs.map((p, i) => (
-              <p key={i} style={{ fontSize: 13.5, lineHeight: 1.6, margin: '0 0 8px', color: t.muted }}>{p}</p>
+              <p key={i} style={{ fontSize: 13.5, lineHeight: 1.6, margin: '0 0 8px', color: t.bodyText }}>{p}</p>
             ))}
             {content.emphasis && <p style={{ fontSize: 14, fontWeight: 700, margin: 0 }}>{content.emphasis}</p>}
           </div>
@@ -368,7 +373,7 @@ function Journey({ t, content, params, luckyDraw, funnel, formAnchorRef, scrollT
         <MediaBlock t={t} media={content.media} />
         {content.paragraphs.map((p, i) => (
           <div key={i} style={{ background: alternate && i % 2 === 0 ? t.soft : 'transparent', borderRadius: t.r.card, padding: alternate && i % 2 === 0 ? '16px 17px' : '4px 17px' }}>
-            <div style={{ font: "600 10px ui-monospace, 'SF Mono', Menlo, monospace", letterSpacing: '.12em', color: t.accent, marginBottom: 7 }}>
+            <div style={{ font: "600 10px ui-monospace, 'SF Mono', Menlo, monospace", letterSpacing: '.12em', color: accentTextOn(t.accent, t.bg), marginBottom: 7 }}>
               {`0${i + 1}`}
             </div>
             <p style={{ fontSize: 14.5, lineHeight: 1.7, margin: 0, color: t.bodyText }}>{p}</p>

--- a/src/components/campaignPage/themeContext.jsx
+++ b/src/components/campaignPage/themeContext.jsx
@@ -41,6 +41,11 @@ export const DEFAULT_CAMPAIGN_THEME = Object.freeze({
   onAccent: '#ffffff',
 });
 
+// NOTE: `tokens` above is the frozen 13-key production constant. The v2-only
+// keys (inputBg, disabledBg, onDisabled, accentText, locked*, accentShadow,
+// colorScheme) are deliberately ABSENT here — every call site falls back to the
+// literal it used to inline, so an unprovidered v1 mount stays byte-identical.
+
 const CampaignThemeContext = createContext(DEFAULT_CAMPAIGN_THEME);
 export const CampaignThemeProvider = CampaignThemeContext.Provider;
 export const useCampaignTheme = () => useContext(CampaignThemeContext);
@@ -66,6 +71,22 @@ export function buildFunnelTokens(t) {
       accentDeep: t.accentDeep,
       required: t.danger,
       success: t.success,
+      // Opaque control surfaces — the funnel previously inlined warm-cream
+      // literals for these, which is why every dark preset rendered
+      // near-white text on a near-white field.
+      inputBg: t.inputBg,
+      disabledBg: t.disabledBg,
+      onDisabled: t.onDisabled,
+      accentText: t.accentText,
+      lockedBg: t.dark ? t.disabledBg : '#F0E7D4',
+      lockedLine: t.dark ? t.line : '#E2D6BC',
+      lockedInk: t.dark ? t.muted : '#A8916E',
+      // Button glow derived from the campaign accent instead of the baked
+      // terracotta; dark surfaces swallow a light shadow, so they get a scrim.
+      accentShadow: t.dark ? 'rgba(0,0,0,.45)' : `${t.accent}2E`,
+      // Drives `color-scheme` so the native caret, select popups and
+      // scrollbars follow the preset instead of staying light.
+      colorScheme: t.dark ? 'dark' : 'light',
     },
     radius: {
       pill: t.r.btn === 999 ? 999 : t.r.btn,

--- a/src/components/campaigns/CampaignSignupForm.jsx
+++ b/src/components/campaigns/CampaignSignupForm.jsx
@@ -554,7 +554,7 @@ export default function CampaignSignupForm({
                   fontFamily: 'Albert Sans, system-ui, sans-serif',
                   fontWeight: 600,
                   fontSize: 16,
-                  boxShadow: '0 4px 14px rgba(209, 112, 41, 0.18)',
+                  boxShadow: `0 4px 14px ${TOKENS.accentShadow || 'rgba(209, 112, 41, 0.18)'}`,
                 }}
               >
                 Yes, I am
@@ -566,7 +566,7 @@ export default function CampaignSignupForm({
                   flex: 1,
                   height: 56,
                   borderRadius: RADIUS.pill,
-                  backgroundColor: '#ffffff',
+                  backgroundColor: TOKENS.inputBg || '#ffffff',
                   color: TOKENS.body,
                   border: `1px solid ${TOKENS.hairline}`,
                   cursor: 'pointer',
@@ -691,7 +691,7 @@ export default function CampaignSignupForm({
                   fontFamily: 'Albert Sans, system-ui, sans-serif',
                   fontWeight: 600,
                   fontSize: 16,
-                  boxShadow: '0 4px 14px rgba(209, 112, 41, 0.18)',
+                  boxShadow: `0 4px 14px ${TOKENS.accentShadow || 'rgba(209, 112, 41, 0.18)'}`,
                 }}
               >
                 No, I am not
@@ -703,7 +703,7 @@ export default function CampaignSignupForm({
                   flex: 1,
                   height: 56,
                   borderRadius: RADIUS.pill,
-                  backgroundColor: '#ffffff',
+                  backgroundColor: TOKENS.inputBg || '#ffffff',
                   color: TOKENS.body,
                   border: `1px solid ${TOKENS.hairline}`,
                   cursor: 'pointer',
@@ -978,7 +978,7 @@ export default function CampaignSignupForm({
             paddingLeft: 36,
             paddingRight: 36,
             borderRadius: RADIUS.pill,
-            backgroundColor: submitDisabled ? TOKENS.hairline : accent,
+            backgroundColor: submitDisabled ? (TOKENS.disabledBg || TOKENS.hairline) : accent,
             color: onAccent,
             border: 'none',
             cursor: submitDisabled ? 'not-allowed' : 'pointer',
@@ -986,7 +986,7 @@ export default function CampaignSignupForm({
             fontWeight: 600,
             fontSize: 16,
             letterSpacing: '0.005em',
-            boxShadow: submitDisabled ? 'none' : '0 4px 14px rgba(209, 112, 41, 0.18)',
+            boxShadow: submitDisabled ? 'none' : `0 4px 14px ${TOKENS.accentShadow || 'rgba(209, 112, 41, 0.18)'}`,
             transition: 'background-color 200ms ease, opacity 200ms ease, transform 120ms ease',
             opacity: submitDisabled ? 0.6 : 1,
           }}
@@ -1021,7 +1021,7 @@ export default function CampaignSignupForm({
 }
 
 function ConsentCheckbox({ id, checked, onChange, children, accent, required }) {
-  const { tokens: TOKENS, radius: RADIUS } = useCampaignTheme();
+  const { tokens: TOKENS, radius: RADIUS, onAccent } = useCampaignTheme();
   return (
     <label
       htmlFor={id}
@@ -1049,7 +1049,7 @@ function ConsentCheckbox({ id, checked, onChange, children, accent, required }) 
           height: 22,
           marginTop: 1,
           borderRadius: RADIUS.checkbox,
-          backgroundColor: checked ? accent : '#ffffff',
+          backgroundColor: checked ? accent : (TOKENS.inputBg || '#ffffff'),
           border: `1px solid ${checked ? accent : TOKENS.hairline}`,
           display: 'inline-flex',
           alignItems: 'center',
@@ -1059,7 +1059,7 @@ function ConsentCheckbox({ id, checked, onChange, children, accent, required }) 
       >
         {checked && (
           <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
-            <path d="M3 6.8L5.5 9.2L10 4" stroke="#ffffff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M3 6.8L5.5 9.2L10 4" stroke={onAccent} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
           </svg>
         )}
       </span>

--- a/src/components/campaigns/LeadCaptureOutcomes.jsx
+++ b/src/components/campaigns/LeadCaptureOutcomes.jsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 import AlertTriangle from 'lucide-react/icons/alert-triangle';
 import CheckCircle from 'lucide-react/icons/check-circle';
 import ArrowLeft from 'lucide-react/icons/arrow-left';
-import { TOKENS, RADIUS } from './LeadCaptureLayout';
+import { useCampaignTheme } from '@/components/campaignPage/themeContext';
 
 /**
  * Lead-capture OUTCOME states — extracted verbatim from LeadCapture.jsx
@@ -16,6 +16,7 @@ import { TOKENS, RADIUS } from './LeadCaptureLayout';
  */
 
 export function SuccessState({ onShare }) {
+  const { tokens: TOKENS, radius: RADIUS } = useCampaignTheme();
   return (
     <div style={{ textAlign: 'center', padding: '24px 0 16px' }}>
       <div
@@ -65,7 +66,7 @@ export function SuccessState({ onShare }) {
           paddingLeft: 28,
           paddingRight: 28,
           borderRadius: RADIUS.pill,
-          backgroundColor: '#ffffff',
+          backgroundColor: TOKENS.inputBg || '#ffffff',
           color: TOKENS.body,
           border: `1px solid ${TOKENS.hairline}`,
           fontFamily: 'Albert Sans, system-ui, sans-serif',
@@ -81,6 +82,7 @@ export function SuccessState({ onShare }) {
 }
 
 export function ErrorState({ duplicateDetected, duplicateCountdown, message, onShare }) {
+  const { tokens: TOKENS, radius: RADIUS, onAccent } = useCampaignTheme();
   return (
     <div style={{ textAlign: 'center', padding: '16px 0' }}>
       <div
@@ -138,7 +140,7 @@ export function ErrorState({ duplicateDetected, duplicateCountdown, message, onS
               paddingRight: 32,
               borderRadius: RADIUS.pill,
               backgroundColor: TOKENS.accent,
-              color: '#ffffff',
+              color: onAccent,
               border: 'none',
               fontFamily: 'Albert Sans, system-ui, sans-serif',
               fontWeight: 600,

--- a/src/components/campaigns/signup/ConsentAgreementDialog.jsx
+++ b/src/components/campaigns/signup/ConsentAgreementDialog.jsx
@@ -54,7 +54,9 @@ export default function ConsentAgreementDialog({
           width: 'calc(100vw - 32px)',
           maxHeight: '85vh',
           padding: 0,
-          boxShadow: '0 24px 64px rgba(60, 40, 20, 0.18), 0 4px 16px rgba(60, 40, 20, 0.08)',
+          boxShadow: TOKENS.colorScheme === 'dark'
+            ? '0 24px 64px rgba(0,0,0,.55), 0 4px 16px rgba(0,0,0,.4)'
+            : '0 24px 64px rgba(60, 40, 20, 0.18), 0 4px 16px rgba(60, 40, 20, 0.08)',
           display: 'flex',
           flexDirection: 'column',
         }}
@@ -169,7 +171,7 @@ export default function ConsentAgreementDialog({
               paddingLeft: 24,
               paddingRight: 24,
               borderRadius: RADIUS.pill,
-              backgroundColor: '#ffffff',
+              backgroundColor: TOKENS.inputBg || '#ffffff',
               color: TOKENS.body,
               border: `1px solid ${TOKENS.hairline}`,
               cursor: 'pointer',
@@ -196,7 +198,7 @@ export default function ConsentAgreementDialog({
               fontWeight: 600,
               fontSize: 15,
               minWidth: 110,
-              boxShadow: '0 4px 14px rgba(209, 112, 41, 0.18)',
+              boxShadow: `0 4px 14px ${TOKENS.accentShadow || 'rgba(209, 112, 41, 0.18)'}`,
             }}
             onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = TOKENS.accentDeep)}
             onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = accent)}

--- a/src/components/campaigns/signup/FieldRenderer.jsx
+++ b/src/components/campaigns/signup/FieldRenderer.jsx
@@ -6,9 +6,9 @@ import { readableTextOn } from '@/lib/contrast';
 // !important overrides the inputs' inline styles; pointer-events:none blocks editing.
 const LOCKED_FIELD_CSS = `
   .lc-field-locked input, .lc-field-locked select {
-    background-color: #F0E7D4 !important;
-    border-color: #E2D6BC !important;
-    color: #A8916E !important;
+    background-color: var(--lc-locked-bg, #F0E7D4) !important;
+    border-color: var(--lc-locked-line, #E2D6BC) !important;
+    color: var(--lc-locked-ink, #A8916E) !important;
     pointer-events: none;
   }
   .lc-field-locked select { cursor: default !important; }
@@ -38,6 +38,7 @@ const makeInputBaseStyle = (TOKENS, RADIUS) => ({
   fontFamily: 'Albert Sans, system-ui, sans-serif',
   color: TOKENS.ink,
   backgroundColor: TOKENS.inputBg || '#FFFCF6',
+  colorScheme: TOKENS.colorScheme || 'light',
   border: `1px solid ${TOKENS.hairline}`,
   borderRadius: RADIUS.input,
   outline: 'none',
@@ -272,8 +273,8 @@ export default function FieldRenderer({
                     fontFamily: 'Albert Sans, system-ui, sans-serif',
                     fontWeight: 600,
                     fontSize: 14,
-                    color: readableTextOn(canSend ? themeColor || TOKENS.accent : TOKENS.hairline),
-                    backgroundColor: canSend ? themeColor || TOKENS.accent : TOKENS.hairline,
+                    color: canSend ? readableTextOn(themeColor || TOKENS.accent) : (TOKENS.onDisabled || readableTextOn(TOKENS.hairline)),
+                    backgroundColor: canSend ? themeColor || TOKENS.accent : (TOKENS.disabledBg || TOKENS.hairline),
                     transition: 'background-color 200ms ease',
                     whiteSpace: 'nowrap',
                     minWidth: 100,
@@ -460,7 +461,7 @@ export default function FieldRenderer({
       <Lock
         size={14}
         aria-hidden="true"
-        style={{ position: 'absolute', right: 18, top: 42, stroke: '#B6A07C', pointerEvents: 'none' }}
+        style={{ position: 'absolute', right: 18, top: 42, stroke: TOKENS.muted, pointerEvents: 'none' }}
       />
     </div>
   );

--- a/src/components/campaigns/signup/OTPVerification.jsx
+++ b/src/components/campaigns/signup/OTPVerification.jsx
@@ -94,7 +94,7 @@ export default function OTPVerification({
         <div
           style={{
             padding: 16,
-            backgroundColor: '#FFFCF6',
+            backgroundColor: TOKENS.modal || '#FFFCF6',
             border: `1px solid ${TOKENS.hairline}`,
             borderRadius: RADIUS.image,
             animation: reduce ? undefined : 'lc-reveal 260ms cubic-bezier(0.16, 1, 0.3, 1)',
@@ -163,7 +163,8 @@ export default function OTPVerification({
                 letterSpacing: otp ? '0.3em' : 'normal',
                 fontFamily: 'Albert Sans, system-ui, sans-serif',
                 color: TOKENS.ink,
-                backgroundColor: '#ffffff',
+                backgroundColor: TOKENS.inputBg || '#ffffff',
+                colorScheme: TOKENS.colorScheme || 'light',
                 border: `1px solid ${error ? TOKENS.required : TOKENS.hairline}`,
                 borderRadius: RADIUS.pill,
                 outline: 'none',

--- a/src/lib/designConfigV2.js
+++ b/src/lib/designConfigV2.js
@@ -275,6 +275,42 @@ function hexToRgb(hex) {
   return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
 }
 
+const toHex = (rgb) => '#' + rgb.map((v) => Math.round(Math.min(255, Math.max(0, v))).toString(16).padStart(2, '0')).join('').toUpperCase();
+
+/**
+ * Blend `hex` toward `target` by `amount` (0..1). Returns `hex` unchanged when
+ * either side is unparseable, so a malformed operator accent can never blank a
+ * surface. The warm-cream input fill depends on the exact arithmetic here:
+ * mix('#FFFAF0', '#FFFFFF', .4) === '#FFFCF6', the frozen production value.
+ */
+export function mixHex(hex, target, amount) {
+  const a = hexToRgb(hex);
+  const b = hexToRgb(target);
+  if (!a || !b) return hex;
+  return toHex(a.map((v, i) => v + (b[i] - v) * amount));
+}
+
+/**
+ * An accent that is legible AS TEXT on `bg` — the accent itself when it already
+ * clears `min`, otherwise stepped toward the surface's opposite pole until it
+ * does. Light accents (lime, periwinkle) are unreadable as text on white; this
+ * keeps the campaign's hue while making the label readable. Falls back to the
+ * ink/light pole when even the extreme cannot clear the bar.
+ */
+export function accentTextOn(accent, bg, min = 4.5, ink = '#3D1F0B') {
+  const bgL = luminance(bg);
+  const accentL = luminance(accent);
+  if (bgL == null || accentL == null) return accent;
+  if (contrastRatio(accentL, bgL) >= min) return accent;
+  const pole = bgL > 0.5 ? '#000000' : '#FFFFFF';
+  for (let step = 1; step <= 10; step += 1) {
+    const candidate = mixHex(accent, pole, step / 10);
+    const l = luminance(candidate);
+    if (l != null && contrastRatio(l, bgL) >= min) return candidate;
+  }
+  return bgL > 0.5 ? ink : '#FFFFFF';
+}
+
 /** Nearest preset by accent RGB distance; invalid/absent hex → warm-cream. */
 export function nearestPresetForAccent(hex) {
   const rgb = hexToRgb(hex);
@@ -554,6 +590,7 @@ export function resolveTheme(theme = {}) {
   const fontId = FONT_IDS.includes(theme.font) ? theme.font : p.font;
   let r = RADII[theme.radius || p.radius] || RADII.soft;
   if (p.rx && (!theme.radius || theme.radius === p.radius)) r = p.rx;
+  const disabledBg = p.hairline || mixHex(p.card, p.dark ? '#FFFFFF' : '#000000', p.dark ? 0.16 : 0.1);
   return {
     ...p,
     accent,
@@ -565,10 +602,27 @@ export function resolveTheme(theme = {}) {
     bodyText: p.bodyText || p.ink,
     divider: p.divider || p.hairline || (p.dark ? 'rgba(255,255,255,.2)' : 'rgba(0,0,0,.16)'),
     accentDeep: p.accentDeep || accent,
-    danger: p.danger || '#B4443C',
-    success: p.success || '#2F6B43',
+    // Status colors are surface-aware: the light-theme pair sits at ~2:1 on a
+    // dark card, so dark presets get lifted variants. warm-cream declares both
+    // explicitly and is untouched (frozen parity).
+    danger: p.danger || (p.dark ? '#F2938B' : '#B4443C'),
+    success: p.success || (p.dark ? '#7FD1A0' : '#2F6B43'),
     line: p.hairline || (p.dark ? 'rgba(255,255,255,.14)' : 'rgba(0,0,0,.1)'),
     soft: p.dark ? 'rgba(255,255,255,.07)' : 'rgba(0,0,0,.045)',
+    // OPAQUE input fill. The funnel paints typed text in `ink`, so this must
+    // track the theme or the text goes invisible (dark presets sat at 1.1:1 on
+    // the old hardcoded '#FFFCF6'). Lightening the card by .4 reproduces the
+    // frozen warm-cream value byte-exactly; dark presets lift off the card
+    // instead so the field still reads as a well.
+    inputBg: p.inputBg || mixHex(p.card, '#FFFFFF', p.dark ? 0.08 : 0.4),
+    // Disabled control fill + its label. `hairline` was being used as a surface
+    // AND fed to a hex-only contrast helper, which returned white for the 9
+    // presets whose hairline is an rgba() string. These are always opaque hex.
+    disabledBg,
+    onDisabled: onColor(disabledBg),
+    // The accent, stepped until it is legible AS TEXT on the form card — lime
+    // and periwinkle accents are ~1.8:1 on white and vanish as link/label text.
+    accentText: accentTextOn(accent, p.card),
     bgCss: theme.background === 'wash'
       ? `linear-gradient(180deg, ${accent}18, ${p.bg} 320px)`
       : theme.background === 'grain'


### PR DESCRIPTION
Audit of **all 11 v2 layouts × all 10 curated presets** (110 combinations) plus the reused signup funnel — and the fixes for what it found.

## The core defect

PR #226 art-directed the five draw layouts with fixed neutral palettes plus the theme accent — a deliberate choice. But the funnel embedded inside them is themed from the **preset** (`buildFunnelTokens(resolveTheme(...))`), so one page was painted from two palettes that never agreed. On a dark preset the form's near-white `ink` landed on the template's hardcoded white card:

```
graphite   typed text rgb(242,242,239) on rgb(255,252,246)   →  1.10:1
```

Distinct page backgrounds rendered across the 10 presets, `getComputedStyle` on the real renderer:

| layout | before | after |
|---|---|---|
| editorial, poster | 10 | 10 |
| postcard, gazette, nightfall, stub, checklist | **1** | **2** (light + dark twin) |

Nothing caught it: PR #226's 22 tests are all structural, and while the Page panel notes "art-directed neutrals", the **Theme panel offers all 10 presets with no warning**.

## Production exposure at the time of the audit

| campaign | template | preset | |
|---|---|---|---|
| Redeem $20 NTUC Fairprice Vouchers | editorial | **violet-hour** | active, form text invisible |
| Free Pet Hotel 1 Night Trial | poster | tangerine | white hero copy over a light fade |
| Tokyo Getaway Lucky Draw | checklist | paper-white | safe by luck (light preset, light template) |

## What changed

**Token layer** — `resolveTheme()` gains `inputBg`, `disabledBg`/`onDisabled`, `accentText`, surface-aware `danger`/`success`, plus `mixHex()` and `accentTextOn()`. The mix ratio is chosen so warm-cream resolves to `#FFFCF6` and `#E8D7B8`/`#3D1F0B` **byte-exactly** — the frozen parity contract is untouched. Both twins edited together, backend first.

**Funnel** (hit all 11 layouts) — input/OTP fills, screening gates and the T&C Cancel button (`'#ffffff'` + themed label = white-on-white), disabled Verify/Submit (`hairline` was used as a *fill* and fed to a hex-only contrast helper that returned white for the 9 presets with `rgba()` hairlines), the outcome screens (importing the frozen warm-cream constants statically while mounted inside a themed card — "You're all set." was 1.15:1), and the consent tick. Added the `-webkit-autofill`, `::placeholder` and `color-scheme` rules that existed nowhere in `src/` — without the autofill rule the fix would be cosmetic, since Chrome repaints autofilled fields with `!important` UA styles.

`DEFAULT_CAMPAIGN_THEME` deliberately does **not** carry the new keys, so every unprovidered v1 mount keeps falling back to its original literal.

**Draw layouts** — light/dark palette twins on `t.dark`; shared helpers take colours as props; every `#fff` hosting the funnel became `pal.card`. Also fixes two unconditional AA failures unrelated to theming: Gazette's gold (2.39:1) and Checklist's mono captions (3.28:1).

**Original six** — Poster's hero copy follows `onColor(t.bg)` (the `dusk` overlay fades to the page colour, so fixed white was invisible on all 7 light presets); Spotlight body copy moved off `muted` (2.86:1 even on warm-cream); Journey numerals use the stepped accent.

## Verification

- typed text on dark presets **1.07:1 → 8.5–10.8:1**
- form text, 5 draw templates × 6 presets: **worst case 10.49:1**
- contrast matrix **87 FAIL → 30**; all 30 remaining are decorative card hairlines at the frozen v1 baseline (production warm-cream is 1.36:1 there)
- **1715/1715** frontend · **35/35** backend designConfigV2 · production build clean

## Reviewer notes

- **Nightfall** is the one deliberate visual change on light presets: its existing palette *was* the dark variant, so it now flips to a light body while keeping its dark hero plate. Easy to revert to always-dark if that reads wrong.
- The **headline still renders twice** on Poster/Split/Spotlight/Journey and all five draw templates (the layout paints `content.headline`, the funnel paints the same string as `formHeadline`). Left alone — it needs a per-template product decision, not a colour fix.

Audit + repro harness: `docs/reference/studio-layout-theme-audit-2026-07-22.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTLqszccDKe8wYHjU1sf1G