### PR TITLE
feat(marketplace): Phase B — single-door editors + client derivation twin (dark)

### DIFF
--- a/backend/src/middleware/appError.js
+++ b/backend/src/middleware/appError.js
@@ -1,0 +1,17 @@
+/**
+ * AppError lives alone so pure utils (luckyDraw → designConfigV2Clamp →
+ * listingDerivation) can throw operational errors WITHOUT dragging in
+ * errorHandler's sequelize/pino imports — the frontend lockstep tests load
+ * that util chain inside vitest, where backend deps are not installed.
+ * errorHandler.js re-exports this class; existing imports keep working.
+ */
+export class AppError extends Error {
+  constructor(message, statusCode, details = null) {
+    super(message);
+    this.statusCode = statusCode;
+    this.details = details;
+    this.isOperational = true;
+
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -116,16 +116,7 @@ export const errorHandler = (err, req, res, _next) => {
 };
 
 // Custom error class
-export class AppError extends Error {
-  constructor(message, statusCode, details = null) {
-    super(message);
-    this.statusCode = statusCode;
-    this.details = details;
-    this.isOperational = true;
-
-    Error.captureStackTrace(this, this.constructor);
-  }
-}
+export { AppError } from './appError.js';
 
 // Async error wrapper
 export const asyncHandler = (fn) => (req, res, next) => {

--- a/backend/src/services/campaignCopyAiService.js
+++ b/backend/src/services/campaignCopyAiService.js
@@ -25,6 +25,7 @@ import {
   getStoredHostChoice,
 } from '../utils/designConfigV2Clamp.js';
 import { CONSUMER_CATEGORIES, OFFER_TYPES, MODES, MARKETPLACE_CAMPAIGN_TYPES } from '../utils/marketplaceContent.js';
+import { marketplaceInheritEnabled } from '../utils/listingDerivation.js';
 import { composeOps, passesStaticGate } from './marketplaceService.js';
 
 /**
@@ -111,12 +112,12 @@ export const COPY_FIELDS = [
   { path: 'quiz.reveal.valueExchange', label: 'Value-exchange line', section: 'Quiz', limit: QUIZ_COPY_LIMITS.valueExchange, when: (ctx) => ctx.quizEnabled },
   { path: 'quiz.reveal.ctaSubtext', label: 'Reveal CTA subtext', section: 'Quiz', limit: QUIZ_COPY_LIMITS.ctaSubtext, when: (ctx) => ctx.quizEnabled },
   { path: 'quiz.scoring.readiness.label', label: 'Readiness meter label', section: 'Quiz', limit: QUIZ_COPY_LIMITS.readinessLabel, when: (ctx) => ctx.quizEnabled && ctx.readinessEnabled },
-  { path: 'distribution.featuredDrop.title', label: 'Drop title', section: 'Distribution', limit: LIMITS.dropTitle },
+  { path: 'distribution.featuredDrop.title', label: 'Drop title', section: 'Distribution', limit: LIMITS.dropTitle, when: () => !marketplaceInheritEnabled() },
   { path: 'distribution.featuredDrop.valueLabel', label: 'Drop value label', section: 'Distribution', limit: LIMITS.dropValue },
   { path: 'distribution.featuredDrop.emoji', label: 'Drop emoji', section: 'Distribution', limit: LIMITS.dropEmoji },
-  { path: 'distribution.marketplace.title', label: 'Consumer title', section: 'Distribution', limit: LIMITS.mkTitle },
-  { path: 'distribution.marketplace.valueLine', label: 'Marketplace value line', section: 'Distribution', limit: LIMITS.mkValue },
-  { path: 'distribution.marketplace.imageAlt', label: 'Listing image alt text', section: 'Distribution', limit: LIMITS.mkAlt },
+  { path: 'distribution.marketplace.title', label: 'Consumer title', section: 'Distribution', limit: LIMITS.mkTitle, when: () => !marketplaceInheritEnabled() },
+  { path: 'distribution.marketplace.valueLine', label: 'Marketplace value line', section: 'Distribution', limit: LIMITS.mkValue, when: () => !marketplaceInheritEnabled() },
+  { path: 'distribution.marketplace.imageAlt', label: 'Listing image alt text', section: 'Distribution', limit: LIMITS.mkAlt, when: () => !marketplaceInheritEnabled() },
   { path: 'distribution.marketplace.dataUse', label: 'Data use', section: 'Distribution', limit: LIMITS.mkNote },
   { path: 'distribution.marketplace.cancellation', label: 'Cancellation', section: 'Distribution', limit: LIMITS.mkNote },
 ];
@@ -290,19 +291,21 @@ export function buildCampaignContext(campaign, gate = null) {
       : null,
     currentDistribution: {
       featuredDrop: {
-        title: drop?.title || '',
+        // Derived-copy echoes go blank under inheritance — stored values are
+        // dead reads there and would only mislead the model (Phase B §9c.3).
+        title: marketplaceInheritEnabled() ? '' : (drop?.title || ''),
         valueLabel: drop?.valueLabel || '',
         emoji: drop?.emoji || '',
       },
       marketplace: {
-        title: legacy.name || '',
+        title: marketplaceInheritEnabled() ? '' : (legacy.name || ''),
         category: legacy.category || null,
         offerType: legacy.offer_type || null,
         mode: legacy.mode || null,
         qrLanding: QR_V1_TO_V2[legacy.qr_entry] || legacy.qr_entry || null,
-        valueLine: legacy.value_line || '',
+        valueLine: marketplaceInheritEnabled() ? '' : (legacy.value_line || ''),
         inclusions: Array.isArray(legacy.inclusions) ? legacy.inclusions : [],
-        imageAlt: legacy.image_label || '',
+        imageAlt: marketplaceInheritEnabled() ? '' : (legacy.image_label || ''),
         dataUse: blocks.data_use || '',
         cancellation: blocks.cancellation || '',
       },
@@ -661,7 +664,7 @@ const DRAW_LOOKS_EXTRA = [
   'This campaign runs a lucky draw. Five draw-focused templates exist: postcard (warm prize postcard), gazette (newspaper fact-table), nightfall (dark cinematic), stub (raffle-ticket), checklist (step rail). Prefer a draw template for most looks, and pair draw templates with LIGHT theme presets (nightfall excepted).',
 ].join('\n');
 
-export function buildCopyDraftPrompts({ mode, scope, regen, templateId, brief, ctx, fields, settings }) {
+export function buildCopyDraftPrompts({ mode, scope, regen, templateId, brief, ctx, fields, settings, inclusionsAllowed = true }) {
   const everything = mode === 'copy' && !scope;
   const system = withOrgStyle(
     mode === 'full'
@@ -686,7 +689,9 @@ export function buildCopyDraftPrompts({ mode, scope, regen, templateId, brief, c
       ...(everything
         ? {
             marketplaceMeta: PICK_FIELDS.map((f) => ({ key: f.key, label: f.label, values: f.values })),
-            inclusions: { label: INCLUSIONS_FIELD.label, maxItems: INCLUSIONS_FIELD.maxItems, itemLimit: INCLUSIONS_FIELD.itemLimit },
+            ...(inclusionsAllowed
+              ? { inclusions: { label: INCLUSIONS_FIELD.label, maxItems: INCLUSIONS_FIELD.maxItems, itemLimit: INCLUSIONS_FIELD.itemLimit } }
+              : {}),
             recommendationTopics: REC_TOPICS,
           }
         : {}),
@@ -773,11 +778,11 @@ const termsSchema = {
  * + inclusions + fields + terms + advisory recommendations. Strict-schema
  * style matches fullModeSchema: every property required, nullable where
  * optional. */
-export function everythingModeSchema(paths) {
+export function everythingModeSchema(paths, { inclusions = true } = {}) {
   return {
     type: 'object',
     additionalProperties: false,
-    required: ['draft', 'marketplaceMeta', 'inclusions', 'fields', 'terms', 'recommendations'],
+    required: ['draft', 'marketplaceMeta', ...(inclusions ? ['inclusions'] : []), 'fields', 'terms', 'recommendations'],
     properties: {
       draft: draftArraySchema(paths),
       fields: fieldsSchema,
@@ -790,11 +795,15 @@ export function everythingModeSchema(paths) {
           PICK_FIELDS.map((f) => [f.key, { type: ['string', 'null'], enum: [...f.values, null] }])
         ),
       },
-      inclusions: {
-        type: ['array', 'null'],
-        maxItems: INCLUSIONS_FIELD.maxItems,
-        items: { type: 'string', minLength: 1, maxLength: 200 },
-      },
+      ...(inclusions
+        ? {
+            inclusions: {
+              type: ['array', 'null'],
+              maxItems: INCLUSIONS_FIELD.maxItems,
+              items: { type: 'string', minLength: 1, maxLength: 200 },
+            },
+          }
+        : {}),
       recommendations: {
         type: 'array',
         maxItems: REC_TOPICS.length,
@@ -900,6 +909,14 @@ export async function generateCampaignCopyDraft(body, userId, overrides = {}) {
   const ctx = buildCampaignContext(campaign, gate);
   const fields = allowedCopyFields(ctx, body.templateId);
   const scopeIsInclusions = scope === INCLUSIONS_FIELD.path;
+  // Single-door (plan §3B): a draw's marketplace "inclusions" ARE the prize
+  // rows under inheritance — there is nothing for the AI to write, in EITHER
+  // the scoped flow (422 below) or Fill-everything (prompt/schema/result all
+  // omit the slot — Phase B review finding 3).
+  const inclusionsAllowed = !(marketplaceInheritEnabled() && ctx.draw?.enabled === true);
+  if (scopeIsInclusions && !inclusionsAllowed) {
+    throw new AppError('Inclusions are derived from the draw prize list under marketplace inheritance.', 422);
+  }
   if (scope && !scopeIsInclusions && !fields.some((f) => f.path === scope)) {
     throw new AppError('That field is not AI-writable for this campaign right now.', 422);
   }
@@ -919,6 +936,7 @@ export async function generateCampaignCopyDraft(body, userId, overrides = {}) {
         ? [{ path: INCLUSIONS_FIELD.path, label: INCLUSIONS_FIELD.label, limit: INCLUSIONS_FIELD.itemLimit }]
         : requestFields,
     settings,
+    inclusionsAllowed,
   });
 
   // Full mode needs every look-writable path available to the model
@@ -928,7 +946,7 @@ export async function generateCampaignCopyDraft(body, userId, overrides = {}) {
     : scopeIsInclusions
       ? inclusionsModeSchema()
       : everything
-        ? everythingModeSchema(requestFields.map((f) => f.path))
+        ? everythingModeSchema(requestFields.map((f) => f.path), { inclusions: inclusionsAllowed })
         : copyModeSchema(requestFields.map((f) => f.path));
   const schemaName = body.mode === 'full'
     ? 'campaign_look_proposals'
@@ -993,7 +1011,7 @@ export async function generateCampaignCopyDraft(body, userId, overrides = {}) {
 
   const draft = sanitizeDraftRows(parsed?.draft, requestFields);
   const picks = everything ? sanitizePicks(parsed?.marketplaceMeta) : [];
-  const inclusions = everything ? sanitizeInclusions(parsed?.inclusions) : null;
+  const inclusions = everything && inclusionsAllowed ? sanitizeInclusions(parsed?.inclusions) : null;
   const aiFields = everything ? clampAiFields(parsed?.fields) : null;
   const aiTerms = everything ? clampAiTerms(parsed?.terms, ctx) : null;
   const drawTerms = everything ? ctx.drawTerms || null : null;

--- a/backend/src/tests/aiCopyDraft.test.js
+++ b/backend/src/tests/aiCopyDraft.test.js
@@ -1,5 +1,7 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import {
+  everythingModeSchema,
+  buildCopyDraftPrompts,
   generateCampaignCopyDraft,
   buildCampaignContext,
   computeMarketplaceGate,
@@ -815,5 +817,47 @@ describe('create-everything amendment — fields, terms, draw awareness', () => 
     expect(plainSystem).toContain('STARTING DRAFT');
     expect(plainSystem).toContain('MKTR PTE. LTD.');
     expect(REC_TOPICS.map((t) => t.topic)).not.toContain('formFields');
+  });
+});
+
+
+describe('marketplace inheritance gates the derived-copy AI fields (plan §3B)', () => {
+  afterEach(() => { delete process.env.MARKETPLACE_INHERIT_ENABLED; });
+
+  it('Fill-everything omits draw inclusions end to end under inheritance (schema + prompt meta)', () => {
+    process.env.MARKETPLACE_INHERIT_ENABLED = 'true';
+    const schema = everythingModeSchema(['content.headline'], { inclusions: false });
+    expect(schema.required).not.toContain('inclusions');
+    expect(schema.properties.inclusions).toBeUndefined();
+    const withInc = everythingModeSchema(['content.headline']);
+    expect(withInc.required).toContain('inclusions');
+    const prompts = buildCopyDraftPrompts({
+      mode: 'copy', scope: null, regen: 0, templateId: 'editorial',
+      brief: { topic: 'x', audience: '', objective: '', mustInclude: '', tone: 'Friendly' },
+      ctx: { campaignName: 'C' }, fields: [], settings: {}, inclusionsAllowed: false,
+    });
+    expect(prompts.user).not.toContain('"inclusions"');
+  });
+
+  it('flag on: drop title + marketplace title/value/alt leave the writable set; picks and notes stay', () => {
+    const ctx = { hasMedia: true, hasImage: true, quizEnabled: false, readinessEnabled: false };
+    const before = allowedCopyFields(ctx, 'editorial').map((f) => f.path);
+    expect(before).toEqual(expect.arrayContaining([
+      'distribution.featuredDrop.title',
+      'distribution.marketplace.title',
+      'distribution.marketplace.valueLine',
+      'distribution.marketplace.imageAlt',
+    ]));
+    process.env.MARKETPLACE_INHERIT_ENABLED = 'true';
+    const after = allowedCopyFields(ctx, 'editorial').map((f) => f.path);
+    for (const gone of ['distribution.featuredDrop.title', 'distribution.marketplace.title', 'distribution.marketplace.valueLine', 'distribution.marketplace.imageAlt']) {
+      expect(after).not.toContain(gone);
+    }
+    expect(after).toEqual(expect.arrayContaining([
+      'distribution.featuredDrop.valueLabel',
+      'distribution.marketplace.dataUse',
+      'distribution.marketplace.cancellation',
+      'content.headline',
+    ]));
   });
 });

--- a/backend/src/utils/luckyDraw.js
+++ b/backend/src/utils/luckyDraw.js
@@ -20,7 +20,7 @@
  * (legacy campaigns are byte-identical).
  */
 
-import { AppError } from '../middleware/errorHandler.js';
+import { AppError } from '../middleware/appError.js';
 
 const MAX_PRIZE = 80; // legacy manual `prize` cap — unchanged so stored rows never drift
 const MAX_PRIZE_NAME = 80;

--- a/docs/plans/marketplace-inherits-campaign-page.md
+++ b/docs/plans/marketplace-inherits-campaign-page.md
@@ -101,3 +101,17 @@ Phase A: M · Phase B: M–L (two editors + AI contract + twin) · Phase C: S. E
 | 7 | MAJOR | Adopted — derived value_line clamps to the 80-char cap; full names live in `prize_breakdown`. |
 | 8 | MAJOR | Adopted — script rewritten: listed-gate filter, full key-union DTO diff incl. effective title + card image, separate featured-drop title diff for every enabled drop. |
 | 9 | MAJOR | Adopted (backend half) — toDto-level flag on/off tests, cache mode/generation tests, featured-title rule tests, media-kind positives incl. v1, value-cap and "Sign Up"-is-valid cases. Endpoint-level matrix + script fixture noted for Phase B/C hardening. |
+
+## 9c. Phase-B diff review — Codex (gpt-5.6-sol, xhigh), 2026-07-22, 7 findings + two-flag matrix
+
+| # | Sev | Disposition |
+|---|---|---|
+| 1 | MAJOR | Adopted — the client twin mirrors the backend prize normalizer exactly (trim+cap names WITHOUT whitespace-collapse, qty 1–99 coerce, ≤8 rows, summary from normalized rows); the lockstep now builds its server input through the REAL `publicLuckyDraw` and pins dirty-row + all-media-kind fixtures. The lockstep caught one genuine drift (whitespace collapse) before merge — working as designed. |
+| 2 | MAJOR | Adopted — the classic editor detects draws from the CAMPAIGN row (its doc strips luckyDraw), hides the inclusions box correctly, and gains the read-only inherited preview (recombined preview doc). |
+| 3 | MAJOR | Adopted — Fill-everything omits draw inclusions end to end under inheritance (prompt meta, strict schema, result assembly), stored derived-copy echoes go blank in the model context, and the Studio apply path refuses the four derived paths + draw inclusions at receipt AND apply (`rowDisabledReason`). |
+| 4 | MAJOR | **Adopted by DOCUMENTATION** — the neutral "records your completed session" wording is a deliberate COPY BUG FIX (virtual-session entrants were told a scan is mandatory), unconditional like Phase A's featured-drops freshness fix. The tracking-name unification (content_name = listing title when one serves) is likewise deliberate and flag-independent; real-world flag-off delta is nil today (no live campaign has a stored listing title that differs from its headline). |
+| 5 | MAJOR | Adopted — the featured-drop canvas previews the derived tile title via the client twin; the generic-headline readiness warning now also covers featured-only campaigns. |
+| 6 | MINOR | Adopted — `regulatory_line` renders after the FAQ, at the true bottom of the door column. |
+| 7 | MINOR | Adopted in part — lockstep dirty/media fixtures, canvas flag-on tests, AI everything-mode omission test added; full tracking-payload + classic-panel render matrix noted for Phase C hardening. |
+
+**Two-flag matrix (runbook):** both flags flip together. Off/Off = legacy reads + legacy editors (wording/tracking fixes stay, deliberately). On/On = single-door. Off/On = editors preview inheritance while the server still serves stored copy (harmless, temporary). On/Off = served copy is inherited while editors still show dead inputs (avoid; flip frontend first is the safe order: VITE first, backend second — or same deploy).

--- a/src/components/campaignPage/drawTemplates.jsx
+++ b/src/components/campaignPage/drawTemplates.jsx
@@ -27,6 +27,7 @@ import {
 } from './CampaignPageRenderer';
 import { MediaBlock } from './templates';
 import { accentTextOn, resolveTheme } from '@/lib/designConfigV2';
+import { DRAW_RECORD_PHRASE } from '@/lib/drawCopy';
 
 const SANS = "'Albert Sans', system-ui, sans-serif";
 const SERIF = "'Fraunces', Georgia, serif";
@@ -84,11 +85,11 @@ function drawStrings(luckyDraw, campaignName) {
     closesMono: closesFull ? closesFull.toUpperCase() : '',
     boostFull,
     kicker: (campaignName || '').toUpperCase(),
-    boostBody: `Meet a consultant for a complimentary 20-minute financial review before ${boostFull} — they scan your entry pass at the session and your 1 entry becomes ${m}.`,
+    boostBody: `Meet a consultant for a complimentary 20-minute financial review before ${boostFull} — when ${DRAW_RECORD_PHRASE}, your 1 entry becomes ${m}.`,
     steps: [
       'Your entry pass arrives by WhatsApp and email.',
       `Book your complimentary ~20-min financial review — any time before ${boostFull}.`,
-      `Your consultant meets you and scans your pass — your 1 entry becomes ${m} entries.`,
+      `Meet your consultant — when they record your completed session, your 1 entry becomes ${m} entries.`,
     ],
     closedBody: winners > 1
       ? `The ${winners} winners are being drawn in a witnessed process and will be contacted directly by phone or SMS.`

--- a/src/components/campaigns/editor/MarketplacePanel.jsx
+++ b/src/components/campaigns/editor/MarketplacePanel.jsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { AlertCircle, CheckCircle2, Loader2, Store } from 'lucide-react';
 import { apiClient } from '@/api/client';
+import { marketplaceInheritEnabled, deriveListingPreview } from '@/lib/listingDerivation';
 
 /**
  * Marketplace panel — authors the design_config marketplace keys
@@ -42,6 +43,12 @@ function Section({ title, hint, children }) {
 
 export default function MarketplacePanel({ currentDesign, onDesignChange, campaign }) {
   const dc = currentDesign || {};
+  // The classic editor deliberately strips luckyDraw from currentDesign — the
+  // CAMPAIGN row is the truth for draw detection (Phase B finding 2), and the
+  // preview doc recombines it so the inherited rows derive correctly.
+  const storedLucky = campaign?.design_config?.luckyDraw;
+  const isDrawCampaign = storedLucky?.enabled === true;
+  const inheritPreviewDoc = marketplaceInheritEnabled() ? { ...dc, luckyDraw: storedLucky } : null;
   const activation = dc.activation || {};
   const sponsor = dc.sponsor || null;
   const blocks = dc.content_blocks || {};
@@ -155,8 +162,25 @@ export default function MarketplacePanel({ currentDesign, onDesignChange, campai
         </div>
       </Section>
 
-      <Section title="Consumer listing" hint="What browsers see on cards and the offer page. The title falls back to the campaign name.">
-        <Input value={dc.name || ''} placeholder="Consumer-facing title (optional override)" onChange={(e) => onDesignChange('name', e.target.value)} />
+      {inheritPreviewDoc && (
+        <Section title="Inherited from the campaign page" hint="One door: edit these in the designer; they reflect on redeem.sg after saving.">
+          <div data-testid="classic-inherited-preview" className="space-y-1">
+            {deriveListingPreview(inheritPreviewDoc, campaign?.name).map((row) => (
+              <div key={row.label} className="flex gap-2 text-xs">
+                <span className="w-24 shrink-0 text-muted-foreground">{row.label}</span>
+                <span className="flex-1 min-w-0 truncate">{row.value}</span>
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      <Section title="Consumer listing" hint={marketplaceInheritEnabled()
+        ? 'Single door: title, value line, image alt and (for draws) the prize list inherit the campaign page — edit them in the designer/Studio.'
+        : 'What browsers see on cards and the offer page. The title falls back to the campaign name.'}>
+        {!marketplaceInheritEnabled() && (
+          <Input value={dc.name || ''} placeholder="Consumer-facing title (optional override)" onChange={(e) => onDesignChange('name', e.target.value)} />
+        )}
         <div className="grid grid-cols-2 gap-2">
           <Select value={dc.category || ''} onValueChange={(v) => onDesignChange('category', v)}>
             <SelectTrigger><SelectValue placeholder="Category" /></SelectTrigger>
@@ -178,15 +202,21 @@ export default function MarketplacePanel({ currentDesign, onDesignChange, campai
               {MODES.map((m) => <SelectItem key={m} value={m}>{m}</SelectItem>)}
             </SelectContent>
           </Select>
-          <Input value={dc.image_label || ''} placeholder="Image alt label" onChange={(e) => onDesignChange('image_label', e.target.value)} />
+          {!marketplaceInheritEnabled() ? (
+            <Input value={dc.image_label || ''} placeholder="Image alt label" onChange={(e) => onDesignChange('image_label', e.target.value)} />
+          ) : <div />}
         </div>
-        <Input value={dc.value_line || ''} placeholder='Value line override (blank = "Worth S$<retail> · free…")' onChange={(e) => onDesignChange('value_line', e.target.value)} />
-        <Textarea
-          rows={3}
-          value={(dc.inclusions || []).join('\n')}
-          placeholder={'What’s included — one item per line'}
-          onChange={(e) => onDesignChange('inclusions', e.target.value.split('\n').map((s) => s.trim()).filter(Boolean))}
-        />
+        {!marketplaceInheritEnabled() && (
+          <Input value={dc.value_line || ''} placeholder='Value line override (blank = "Worth S$<retail> · free…")' onChange={(e) => onDesignChange('value_line', e.target.value)} />
+        )}
+        {!(marketplaceInheritEnabled() && isDrawCampaign) && (
+          <Textarea
+            rows={3}
+            value={(dc.inclusions || []).join('\n')}
+            placeholder={'What’s included — one item per line'}
+            onChange={(e) => onDesignChange('inclusions', e.target.value.split('\n').map((s) => s.trim()).filter(Boolean))}
+          />
+        )}
         <div className="flex items-center justify-between">
           <span className="text-xs text-muted-foreground">Show remaining capacity to consumers</span>
           <Switch checked={dc.showCapacity === true} onCheckedChange={(v) => onDesignChange('showCapacity', v === true)} />

--- a/src/components/studio/CanvasDropSubject.jsx
+++ b/src/components/studio/CanvasDropSubject.jsx
@@ -14,6 +14,8 @@ const YMD_RE = /^\d{4}-\d{2}-\d{2}$/;
 const todayYmdSgt = () =>
   new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Singapore' }).format(new Date());
 
+import { marketplaceInheritEnabled, deriveFeaturedDropTitleClient } from '@/lib/listingDerivation';
+
 export default function CanvasDropSubject({ doc }) {
   const drop = doc?.distribution?.featuredDrop;
   if (drop?.enabled !== true) {
@@ -40,7 +42,7 @@ export default function CanvasDropSubject({ doc }) {
           </span>
         </div>
         <div style={{ font: "700 17px 'Fraunces', serif", color: '#2B2317', lineHeight: 1.2, marginBottom: 6 }}>
-          {drop.title || 'Untitled drop'}
+          {(marketplaceInheritEnabled() ? deriveFeaturedDropTitleClient(doc) : drop.title) || (marketplaceInheritEnabled() ? drop.title : null) || 'Untitled drop'}
         </div>
         <div style={{ fontSize: 11, color: '#8D8371', marginBottom: 12 }}>{metaBits.join(' · ')}</div>
         <div style={{ background: '#2B2317', color: '#FBF7EF', borderRadius: 999, textAlign: 'center', padding: 9, font: "700 12.5px 'Albert Sans', sans-serif" }}>

--- a/src/components/studio/CanvasMarketplaceSubject.jsx
+++ b/src/components/studio/CanvasMarketplaceSubject.jsx
@@ -1,5 +1,6 @@
 import OfferCard from '@/pages/marketplace/OfferCard';
 import { marketplaceToV1 } from '@/lib/designConfigV2';
+import { applyClientInheritance, marketplaceInheritEnabled } from '@/lib/listingDerivation';
 import { GATE_LABELS, drawCloseMismatchWithLive, sgtYmdFromInstant } from './studioReadiness';
 import '@/pages/marketplace/marketplace.css';
 
@@ -17,12 +18,19 @@ import '@/pages/marketplace/marketplace.css';
  */
 export default function CanvasMarketplaceSubject({ campaign, doc, preview, previewStatus }) {
   const mkDoc = marketplaceToV1(doc?.distribution?.marketplace || {});
+  // Single-door preview (plan §3B): under inheritance the card renders the
+  // UNSAVED doc's derived listing via the client twin — exactly what the
+  // server overlay will emit after save (lockstep-tested).
+  const baseDc = { ...(preview?.design_config || {}), ...mkDoc };
+  const cardDc = marketplaceInheritEnabled()
+    ? applyClientInheritance(baseDc, doc, campaign?.name)
+    : baseDc;
   const cardCampaign = {
     ...(preview || {}),
     id: campaign?.id,
     slug: campaign?.slug || preview?.slug || null,
     name: campaign?.name,
-    design_config: { ...(preview?.design_config || {}), ...mkDoc },
+    design_config: cardDc,
     ops: preview?.ops || null,
   };
   const gate = preview?.gate || null;

--- a/src/components/studio/__tests__/DistributionSubjects.test.jsx
+++ b/src/components/studio/__tests__/DistributionSubjects.test.jsx
@@ -152,3 +152,78 @@ describe('Canvas subjects', () => {
     expect(screen.queryByText(/disagrees with the live draw record/)).toBeNull();
   });
 });
+
+describe('DistributionPanel — single-door mode (inheritance flag on)', () => {
+  it('hides the derived-copy inputs, keeps picks, and shows the inherited preview', () => {
+    vi.stubEnv('VITE_MARKETPLACE_INHERIT_ENABLED', 'true');
+    render(
+      <PanelHarness
+        v1={{
+          formHeadline: 'Win a 4D3N Tokyo Getaway',
+          storyText: 'Story here.',
+          marketplaceListed: true,
+          customerHost: 'redeem',
+        }}
+      />
+    );
+    // Derived-copy inputs gone…
+    expect(screen.queryByLabelText('Consumer title')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Value line')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Image alt text')).not.toBeInTheDocument();
+    // …picks stay…
+    expect(screen.getByLabelText('Category')).toBeInTheDocument();
+    expect(screen.getByLabelText('Audience age min')).toBeInTheDocument();
+    // …and the inherited preview names the sources.
+    const preview = screen.getByTestId('dist-inherited-preview');
+    expect(preview).toHaveTextContent('Win a 4D3N Tokyo Getaway');
+    expect(preview).toHaveTextContent('Page → headline');
+    vi.unstubAllEnvs();
+  });
+
+  it('flag off keeps the legacy copy inputs (emergency-brake UI)', () => {
+    render(<PanelHarness v1={{ marketplaceListed: true, customerHost: 'redeem' }} />);
+    expect(screen.getByLabelText('Consumer title')).toBeInTheDocument();
+    expect(screen.getByLabelText('Value line')).toBeInTheDocument();
+    expect(screen.queryByTestId('dist-inherited-preview')).not.toBeInTheDocument();
+  });
+});
+
+
+describe('canvas subjects — single-door previews (flag on)', () => {
+  it('the marketplace card previews the UNSAVED doc through the client twin', () => {
+    vi.stubEnv('VITE_MARKETPLACE_INHERIT_ENABLED', 'true');
+    render(
+      <MemoryRouter>
+        <CanvasMarketplaceSubject
+          campaign={{ id: 'c1', name: 'Internal Name', slug: 's' }}
+          doc={{
+            version: 2,
+            content: { headline: 'Win a 4D3N Tokyo Getaway', story: 'S', media: { kind: 'none', src: '' }, footer: {} },
+            distribution: { marketplace: { listed: true, title: 'STORED TITLE' } },
+          }}
+          preview={null}
+          previewStatus="success"
+        />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Win a 4D3N Tokyo Getaway')).toBeInTheDocument();
+    expect(screen.queryByText('STORED TITLE')).not.toBeInTheDocument();
+    vi.unstubAllEnvs();
+  });
+
+  it('the drop tile previews the derived headline, never the stored title', () => {
+    vi.stubEnv('VITE_MARKETPLACE_INHERIT_ENABLED', 'true');
+    render(
+      <CanvasDropSubject
+        doc={{
+          version: 2,
+          content: { headline: 'Win a 4D3N Tokyo Getaway', media: { kind: 'none', src: '' }, footer: {} },
+          distribution: { featuredDrop: { enabled: true, title: 'STORED DROP TITLE' } },
+        }}
+      />
+    );
+    expect(screen.getByText('Win a 4D3N Tokyo Getaway')).toBeInTheDocument();
+    expect(screen.queryByText('STORED DROP TITLE')).not.toBeInTheDocument();
+    vi.unstubAllEnvs();
+  });
+});

--- a/src/components/studio/panels/DistributionPanel.jsx
+++ b/src/components/studio/panels/DistributionPanel.jsx
@@ -3,6 +3,7 @@ import { apiClient } from '@/api/client';
 import { GATE_LABELS } from '../studioReadiness';
 import { CATEGORY_OPTIONS, OFFER_TYPES, MODES } from '../marketplaceOptions';
 import { makeBind, PanelSection, TextField, TextAreaField, Seg, ToggleRow, WarnNote, FieldLabel, SuggestButton } from './panelKit';
+import { marketplaceInheritEnabled, deriveListingPreview } from '@/lib/listingDerivation';
 
 /**
  * Distribution panel (Studio PR 3) — customer domain, featured drop
@@ -52,6 +53,11 @@ export default function DistributionPanel({
   const drop = doc.distribution?.featuredDrop || {};
   const mk = doc.distribution?.marketplace || {};
   const gate = marketplacePreview?.gate || null;
+  // Single-door mode (plan §3B): derived listing copy is edited on the PAGE
+  // panel; here it renders read-only with its sources. The legacy copy inputs
+  // return if the emergency brake is pulled (both flags off together).
+  const inherit = marketplaceInheritEnabled();
+  const isDraw = doc?.luckyDraw?.enabled === true;
 
   const storedSlug = campaign?.slug || '';
   const slugValue = slugDraft !== null ? slugDraft : storedSlug;
@@ -128,7 +134,14 @@ export default function DistributionPanel({
         />
         {drop.enabled === true ? (
           <>
-            <TextField id="studio-drop-title" label="Drop title" bind={bind('distribution.featuredDrop.title', 40)} onSuggest={suggest('distribution.featuredDrop.title', 'Drop title')} />
+            {!inherit && (
+              <TextField id="studio-drop-title" label="Drop title" bind={bind('distribution.featuredDrop.title', 40)} onSuggest={suggest('distribution.featuredDrop.title', 'Drop title')} />
+            )}
+            {inherit && (
+              <p style={{ margin: 0, fontSize: 10.5, color: 'var(--ink-3, #9BA0AB)' }}>
+                Tile title inherits the campaign headline (Page panel).
+              </p>
+            )}
             <div style={{ display: 'flex', gap: 8 }}>
               <div style={{ flex: 1 }}>
                 <TextField id="studio-drop-value" label="Value label" bind={bind('distribution.featuredDrop.valueLabel', 12)} placeholder="$10" />
@@ -185,7 +198,9 @@ export default function DistributionPanel({
         ) : (
           <p style={{ margin: 0, fontSize: 10.5, color: 'var(--ink-3)' }}>Publication gate loads from the server…</p>
         )}
-        <TextField id="studio-mk-title" label="Consumer title" bind={bind('distribution.marketplace.title', 120)} onSuggest={suggest('distribution.marketplace.title', 'Consumer title')} />
+        {!inherit && (
+          <TextField id="studio-mk-title" label="Consumer title" bind={bind('distribution.marketplace.title', 120)} onSuggest={suggest('distribution.marketplace.title', 'Consumer title')} />
+        )}
         <div>
           <FieldLabel htmlFor="studio-mk-category">Category</FieldLabel>
           <select id="studio-mk-category" style={selectStyle} value={mk.category || ''} onChange={(e) => setMk({ category: e.target.value || undefined })}>
@@ -221,8 +236,10 @@ export default function DistributionPanel({
             </select>
           </div>
         </div>
-        <TextField id="studio-mk-value" label="Value line" bind={bind('distribution.marketplace.valueLine', 80)} onSuggest={suggest('distribution.marketplace.valueLine', 'Value line')} />
-        <div>
+        {!inherit && (
+          <TextField id="studio-mk-value" label="Value line" bind={bind('distribution.marketplace.valueLine', 80)} onSuggest={suggest('distribution.marketplace.valueLine', 'Value line')} />
+        )}
+        <div style={{ display: inherit && isDraw ? 'none' : undefined }} data-testid="dist-inclusions-block">
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
             <FieldLabel htmlFor="studio-mk-inclusions">Inclusions (one per line, max 8)</FieldLabel>
             <SuggestButton onSuggest={suggest('distribution.marketplace.inclusions', 'Inclusions')} label="Inclusions" />
@@ -247,7 +264,9 @@ export default function DistributionPanel({
       </PanelSection>
 
       <PanelSection title="MORE LISTING DETAILS">
-        <TextField id="studio-mk-alt" label="Image alt text" bind={bind('distribution.marketplace.imageAlt', 120)} />
+        {!inherit && (
+          <TextField id="studio-mk-alt" label="Image alt text" bind={bind('distribution.marketplace.imageAlt', 120)} />
+        )}
         <ToggleRow id="studio-mk-cap" label="Show capacity" checked={mk.showCapacity === true} onChange={(v) => setMk({ showCapacity: v })} />
         <ToggleRow id="studio-mk-dsa" label="DSA-related" checked={mk.dsaRelated === true} onChange={(v) => setMk({ dsaRelated: v })} />
         <div style={{ display: 'flex', gap: 8 }}>
@@ -288,6 +307,26 @@ export default function DistributionPanel({
           disclosure · FAQ. Marketplace expiry comes from the live activation window, not this document.
         </WarnNote>
       </PanelSection>
+
+      {inherit && (
+        <PanelSection title="INHERITED FROM THE CAMPAIGN PAGE">
+          <div data-testid="dist-inherited-preview" style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {deriveListingPreview(doc, campaign?.name).map((row) => (
+              <div key={row.label} style={{ display: 'flex', gap: 8, fontSize: 11.5, lineHeight: 1.45 }}>
+                <span style={{ width: 96, flexShrink: 0, color: 'var(--ink-3, #9BA0AB)' }}>{row.label}</span>
+                <span style={{ flex: 1, minWidth: 0, color: 'var(--ink-2, #5B616E)', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  {row.value}
+                  <span style={{ display: 'block', fontSize: 9.5, color: 'var(--ink-3, #9BA0AB)' }}>{row.source}</span>
+                </span>
+              </div>
+            ))}
+          </div>
+          <WarnNote tone="info">
+            One door: edit these on the Page panel (and draw facts in ops). Saves reach redeem.sg
+            immediately on the offer page and within a minute on the homepage/explore grids.
+          </WarnNote>
+        </PanelSection>
+      )}
 
       <PanelSection title="URL SLUG — CAMPAIGN FACT, OWN SAVE">
         <div>

--- a/src/components/studio/studioLooks.js
+++ b/src/components/studio/studioLooks.js
@@ -6,6 +6,7 @@
  * machine, the API layer and the panel, and stays trivially testable.
  */
 import { DRAW_TEMPLATE_IDS } from '@/lib/designConfigV2';
+import { marketplaceInheritEnabled } from '@/lib/listingDerivation';
 
 const DRAW_TEMPLATE_ID_SET = new Set(DRAW_TEMPLATE_IDS);
 
@@ -46,6 +47,17 @@ function quizOn(doc) {
 export function rowDisabledReason(doc, path) {
   if (!doc) return 'No document';
   switch (path) {
+    // Single-door (plan §3B): derived listing copy has no writable home while
+    // inheritance is on — receipt AND apply both refuse (Phase B finding 3).
+    case 'distribution.featuredDrop.title':
+    case 'distribution.marketplace.title':
+    case 'distribution.marketplace.valueLine':
+    case 'distribution.marketplace.imageAlt':
+      return marketplaceInheritEnabled() ? 'Inherited from the campaign page' : null;
+    case 'distribution.marketplace.inclusions':
+      return marketplaceInheritEnabled() && doc.luckyDraw?.enabled === true
+        ? 'Derived from the draw prize list'
+        : null;
     case 'content.heroCtaLabel':
       return (doc.content?.media?.kind || 'none') !== 'none' ? null : 'No hero media on the page right now';
     case 'content.media.alt':

--- a/src/components/studio/studioReadiness.js
+++ b/src/components/studio/studioReadiness.js
@@ -1,4 +1,5 @@
 import { resolveTheme } from '@/lib/designConfigV2';
+import { marketplaceInheritEnabled, deriveListingTitle } from '@/lib/listingDerivation';
 import { colorContrastRatio } from '@/lib/contrast';
 import { isValidYmd } from './useStudioDoc';
 
@@ -82,6 +83,13 @@ export function computeDesignChecks({ campaign, doc, marketplacePreview }) {
     if (!isValidYmd(doc.luckyDraw?.closesAt)) {
       out.push({ sev: 'block', sec: 'form', msg: 'Lucky draw needs a valid close date on the draw record (server invariant).' });
     }
+  }
+  if (
+    marketplaceInheritEnabled() &&
+    (doc.distribution?.marketplace?.listed === true || doc.distribution?.featuredDrop?.enabled === true) &&
+    !deriveListingTitle(doc)
+  ) {
+    out.push({ sev: 'warn', sec: 'page', msg: 'Headline is empty or the template default — it IS the marketplace listing title now; write a real one (the internal campaign name shows until then).' });
   }
   if ((doc.content?.heroCtaLabel || '').trim() && (doc.content?.media?.kind || 'none') === 'none') {
     out.push({ sev: 'warn', sec: 'page', msg: 'Hero button label is set but there is no media — it will not render.' });

--- a/src/lib/__tests__/listingDerivation.lockstep.test.js
+++ b/src/lib/__tests__/listingDerivation.lockstep.test.js
@@ -1,0 +1,116 @@
+/**
+ * CLIENT ↔ SERVER derivation lockstep (plan §3B): the Studio's unsaved-doc
+ * preview must derive exactly what the server overlay will emit after save.
+ * Same discipline as designConfigV2.lockstep — the backend module is imported
+ * directly (pure utils, no models).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  applyClientInheritance,
+  deriveListingTitle as clientTitle,
+  marketplaceInheritEnabled,
+  listingTitleOf,
+} from '../listingDerivation';
+import {
+  applyListingInheritance as serverOverlay,
+  deriveListingTitle as serverTitle,
+} from '../../../backend/src/utils/listingDerivation.js';
+import { readLegacyViewSafe } from '../../../backend/src/utils/designConfigV2Clamp.js';
+import { publicLuckyDraw } from '../../../backend/src/utils/publicDesignConfig.js';
+
+const DERIVED_KEYS = ['name', 'description', 'regulatory_line', 'value_line', 'imageUrl', 'image_label', 'prize_breakdown', 'inclusions'];
+
+const v2Draw = {
+  version: 2,
+  content: {
+    headline: 'Win a 4D3N Tokyo Getaway',
+    story: 'Drop your details and you are in the draw.',
+    footer: { regulatory: 'Organised by MKTR. No purchase necessary.', brand: '' },
+    media: { kind: 'image', src: '/uploads/tokyo.jpg', alt: 'Tokyo at dusk' },
+  },
+  distribution: { host: 'redeem', marketplace: { listed: true } },
+  luckyDraw: { enabled: true, prize: '1× iPhone 17 Pro + 3× AirPods', prizes: [{ qty: 1, name: 'iPhone 17 Pro' }, { qty: 3, name: 'AirPods' }], closesAt: '2026-10-30', multiplier: 10 },
+};
+const v2Plain = { ...structuredClone(v2Draw), luckyDraw: undefined };
+const v2Generic = (() => { const d = structuredClone(v2Draw); d.content.headline = 'Get Started'; return d; })();
+const v2Video = (() => { const d = structuredClone(v2Draw); d.content.media = { kind: 'youtube', src: 'https://youtu.be/x', alt: 'ig' }; return d; })();
+const v1Doc = {
+  formHeadline: 'V1 Headline',
+  storyText: 'V1 story.',
+  regulatoryFooter: 'V1 regulatory.',
+  imageUrl: '/uploads/x.jpg',
+  mediaType: 'image',
+  image_label: 'v1 stored label',
+  marketplaceListed: true,
+  customerHost: 'redeem',
+};
+
+const BASE = {
+  name: 'STORED TITLE', value_line: 'STORED VALUE', image_label: 'STORED ALT',
+  inclusions: ['stored'], category: 'family_lifestyle',
+  luckyDraw: undefined, // overridden per doc below
+};
+
+/** The REAL public pipeline builds the server's luckyDraw view (Phase B
+ * review finding 1: hand-mirrored fixtures hid normalization drift). */
+const baseFor = (doc) => {
+  const ld = publicLuckyDraw(doc.luckyDraw);
+  return { ...structuredClone(BASE), ...(ld ? { luckyDraw: ld } : {}) };
+};
+
+const v2Dirty = (() => {
+  const d = structuredClone(v2Draw);
+  d.luckyDraw.prizes = [
+    { qty: '3', name: '  Padded  Voucher  ' },
+    { qty: 0, name: 'Zero Coerces' },
+    { qty: 2.5, name: 'Fractional Coerces' },
+    ...Array.from({ length: 9 }, (_, i) => ({ qty: 2, name: `Overflow Row ${i + 1}` })),
+  ];
+  d.luckyDraw.prize = 'STALE STORED SUMMARY';
+  return d;
+})();
+const v2VideoKind = (() => { const d = structuredClone(v2Draw); d.content.media = { kind: 'video', src: '/uploads/v.mp4' }; return d; })();
+const v2NoneKind = (() => { const d = structuredClone(v2Draw); d.content.media = { kind: 'none', src: '' }; return d; })();
+
+describe('client twin ↔ server overlay lockstep', () => {
+  it.each([
+    ['v2 draw', v2Draw],
+    ['v2 plain', v2Plain],
+    ['v2 generic headline', v2Generic],
+    ['v2 video media', v2Video],
+    ['v1 doc', v1Doc],
+    ['v2 dirty prize rows', v2Dirty],
+    ['v2 video media', v2VideoKind],
+    ['v2 none media', v2NoneKind],
+  ])('%s derives identically on every derived key', (_label, doc) => {
+    const base = baseFor(doc);
+    const server = serverOverlay({ campaign: { name: 'Camp' }, publicDc: structuredClone(base), rawDc: doc });
+    const client = applyClientInheritance(structuredClone(base), doc, 'Camp');
+    for (const k of DERIVED_KEYS) {
+      expect(client[k]).toEqual(server[k]);
+    }
+  });
+
+  it('the title rule is one rule', () => {
+    for (const doc of [v2Draw, v2Generic, v1Doc, {}]) {
+      expect(clientTitle(doc)).toEqual(serverTitle(doc, readLegacyViewSafe(doc || {}, {})));
+    }
+  });
+});
+
+describe('listingTitleOf (consumer-side effective title incl. tracking)', () => {
+  it('served dc.name wins, campaign name falls back', () => {
+    expect(listingTitleOf({ name: 'Internal', design_config: { name: 'Listing Title' } })).toBe('Listing Title');
+    expect(listingTitleOf({ name: 'Internal', design_config: {} })).toBe('Internal');
+    expect(listingTitleOf(null)).toBe('');
+  });
+});
+
+describe('flag plumbing', () => {
+  afterEach(() => vi.unstubAllEnvs());
+  it('reads VITE_MARKETPLACE_INHERIT_ENABLED', () => {
+    expect(marketplaceInheritEnabled()).toBe(false);
+    vi.stubEnv('VITE_MARKETPLACE_INHERIT_ENABLED', 'true');
+    expect(marketplaceInheritEnabled()).toBe(true);
+  });
+});

--- a/src/lib/drawCopy.js
+++ b/src/lib/drawCopy.js
@@ -1,0 +1,16 @@
+/**
+ * The ONE neutral phrasing for how a draw's ×N boost is earned (plan §9.11):
+ * boost evidence can be a consultant QR SCAN or an approved virtual-session
+ * confirmation, so customer copy says "records", never "scans" — a
+ * virtual-session entrant must not be told a scan is mandatory. Imported by
+ * the marketplace surfaces AND the campaign-page draw templates so the two
+ * doors can never drift on this sentence.
+ */
+
+export const DRAW_RECORD_PHRASE = 'your consultant records your completed session';
+
+/** e.g. "×10 when your consultant records your completed session — any time before 30 October 2026." */
+export function drawBoostLine(multiplier, boostDateLong) {
+  const m = multiplier || 10;
+  return `×${m} when ${DRAW_RECORD_PHRASE}${boostDateLong ? ` — any time before ${boostDateLong}` : ''}.`;
+}

--- a/src/lib/listingDerivation.js
+++ b/src/lib/listingDerivation.js
@@ -1,0 +1,166 @@
+/**
+ * Marketplace-inherits-the-campaign-page — CLIENT twin of
+ * backend/src/utils/listingDerivation.js (Phase B, plan §3B).
+ *
+ * Purpose: Studio/classic editors preview the UNSAVED doc's inherited listing
+ * before any save reaches the server. The derivation rules MUST match the
+ * backend overlay — pinned by the lockstep test (listingDerivation.lockstep),
+ * same discipline as the designConfigV2 twins.
+ *
+ * `VITE_MARKETPLACE_INHERIT_ENABLED` pairs with the backend's
+ * MARKETPLACE_INHERIT_ENABLED — the runbook flips BOTH in one sitting
+ * (frontend controls editor/preview chrome; the server controls what actually
+ * serves, so a brief mismatch degrades to stale UI, never wrong data).
+ */
+
+import { readLegacyView, isV2 } from './designConfigV2';
+
+export function marketplaceInheritEnabled() {
+  return import.meta.env.VITE_MARKETPLACE_INHERIT_ENABLED === 'true';
+}
+
+/** Exactly the template default — mirror of the backend set. */
+const GENERIC_HEADLINES = new Set(['get started']);
+
+const clean = (v, max) => {
+  if (typeof v !== 'string') return undefined;
+  const s = v.replace(/\s+/g, ' ').trim().slice(0, max);
+  return s || undefined;
+};
+
+/** Mirror of the backend prize-row normalizer (luckyDraw.js cleanPrizes):
+ * qty coerced to an int 1–99 (else 1), names trimmed/clamped to 80, empty
+ * rows dropped, at most 8 rows. */
+function normalizePrizeRows(prizes) {
+  if (!Array.isArray(prizes)) return [];
+  return prizes
+    .map((p) => {
+      // Mirror backend cleanString: trim + cap ONLY (inner whitespace kept).
+      const name = typeof p?.name === 'string' ? p.name.trim().slice(0, 80) : '';
+      const q = Number(p?.qty);
+      const qty = Number.isInteger(q) && q >= 1 && q <= 99 ? q : 1;
+      return { qty, name };
+    })
+    .filter((p) => p.name)
+    .slice(0, 8);
+}
+
+/** Mirror of derivePrizeSummary — "name" / "3× name", joined with " + ". */
+function summarizePrizes(rows) {
+  return rows.map((p) => (p.qty === 1 ? p.name : `${p.qty}× ${p.name}`)).join(' + ');
+}
+
+function legacyOf(doc) {
+  try {
+    return isV2(doc) ? readLegacyView(doc) : (doc || {});
+  } catch {
+    return {};
+  }
+}
+
+/** The one title rule (backend deriveListingTitle mirror). */
+export function deriveListingTitle(doc) {
+  const legacy = legacyOf(doc);
+  const headline = clean(isV2(doc) ? doc?.content?.headline : legacy.formHeadline, 120);
+  if (!headline || GENERIC_HEADLINES.has(headline.toLowerCase())) return undefined;
+  return headline;
+}
+
+/**
+ * Consumer-side effective listing title — visible copy, browse/search, image
+ * alt fallback AND the Meta/TikTok tracking name all route through here
+ * (plan §9b.6): the served `dc.name` (derived when inheritance is on, stored
+ * otherwise), else the campaign's internal name.
+ */
+export function listingTitleOf(campaign) {
+  const dcName = campaign?.design_config?.name;
+  return (typeof dcName === 'string' && dcName) || campaign?.name || '';
+}
+
+/**
+ * The derived listing view of an (unsaved) doc — v1-flat keys, mirroring the
+ * backend overlay's derived set. `base` (optional) plays the role of the
+ * stored public dc the overlay mutates; keys the derivation owns are REPLACED
+ * or DELETED exactly like the server.
+ */
+export function applyClientInheritance(base, doc, campaignName) {
+  const out = { ...(base || {}) };
+  const legacy = legacyOf(doc);
+  const v2 = isV2(doc);
+  const draw = doc?.luckyDraw?.enabled === true;
+
+  const title = deriveListingTitle(doc);
+  if (title) out.name = title;
+  else delete out.name;
+
+  const description = clean(legacy.storyText, 1200);
+  if (description) out.description = description;
+  else delete out.description;
+
+  const regulatory = clean(legacy.regulatoryFooter, 1000);
+  if (regulatory) out.regulatory_line = regulatory;
+  else delete out.regulatory_line;
+
+  // Prize facts mirror the server's normalize-then-summarize pipeline
+  // (publicLuckyDraw → derivePrizeSummary): structured rows win, the stored
+  // summary is only the legacy fallback (Phase B review finding 1).
+  const drawRows = draw ? normalizePrizeRows(doc?.luckyDraw?.prizes) : [];
+  const prizeFact = draw
+    ? clean(drawRows.length ? summarizePrizes(drawRows) : doc?.luckyDraw?.prize, 80)
+    : undefined;
+  if (prizeFact) out.value_line = prizeFact;
+  else delete out.value_line;
+
+  const mediaKind = v2
+    ? (doc?.content?.media?.kind || 'none')
+    : (legacy.mediaType || (legacy.imageUrl ? 'image' : 'none'));
+  const mediaSrc = v2 ? doc?.content?.media?.src : legacy.imageUrl;
+  if (mediaKind === 'image' && typeof mediaSrc === 'string' && mediaSrc) {
+    out.imageUrl = mediaSrc.slice(0, 2048);
+    if (v2) {
+      const alt = clean(doc?.content?.media?.alt, 120);
+      if (alt) out.image_label = alt;
+      else delete out.image_label;
+    }
+  } else {
+    delete out.imageUrl;
+    delete out.image_label;
+  }
+
+  if (draw) {
+    const rows = normalizePrizeRows(doc?.luckyDraw?.prizes);
+    if (rows.length) out.prize_breakdown = rows;
+    else delete out.prize_breakdown;
+    delete out.inclusions;
+  } else {
+    delete out.prize_breakdown;
+  }
+
+  void campaignName; // shape parity with the server signature
+  return out;
+}
+
+/** Featured-drop tile title twin (backend deriveFeaturedDropTitle mirror). */
+export function deriveFeaturedDropTitleClient(doc) {
+  const title = deriveListingTitle(doc);
+  return title ? title.slice(0, 40) : undefined;
+}
+
+/** Editor-preview rows: what the marketplace will show, with sources named. */
+export function deriveListingPreview(doc, campaignName) {
+  const d = applyClientInheritance({}, doc, campaignName);
+  return [
+    { label: 'Listing title', source: 'Page → headline', value: d.name || `${campaignName || 'campaign name'} (fallback)` },
+    { label: 'Description', source: 'Page → story', value: d.description || '—' },
+    {
+      label: 'Value line',
+      source: doc?.luckyDraw?.enabled === true ? 'Draw → prize facts' : 'Ops → retail value',
+      value: d.value_line || (doc?.luckyDraw?.enabled === true ? '—' : 'Worth S$<retail> (from the live offer)'),
+    },
+    { label: 'Card image', source: 'Page → hero media', value: d.imageUrl ? d.imageUrl.split('/').pop() : 'none (non-image media)' },
+    ...(doc?.luckyDraw?.enabled === true
+      ? [{ label: 'Prizes', source: 'Draw → prize rows', value: (d.prize_breakdown || []).map((p) => `${p.qty}× ${p.name}`).join(' · ') || d.value_line || '—' }]
+      : []),
+    { label: 'Regulatory line', source: 'Page → footer', value: d.regulatory_line || '—' },
+  ];
+}

--- a/src/pages/marketplace/MarketplaceBrowse.jsx
+++ b/src/pages/marketplace/MarketplaceBrowse.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { listingTitleOf } from '@/lib/listingDerivation';
 import { Link, useParams } from 'react-router-dom';
 import MarketplaceLayout from './MarketplaceLayout';
 import OfferCard from './OfferCard';
@@ -88,7 +89,7 @@ function ExplorePage() {
         if (!ar || !(ar.min <= r[1] && ar.max >= r[0])) return false;
       }
       if (q) {
-        const hay = `${dc.name || c.name} ${c.ops?.partner?.name || ''} ${categoryLabel(dc.category)}`.toLowerCase();
+        const hay = `${listingTitleOf(c)} ${c.ops?.partner?.name || ''} ${categoryLabel(dc.category)}`.toLowerCase();
         if (!hay.includes(q.toLowerCase())) return false;
       }
       return true;

--- a/src/pages/marketplace/MarketplaceFlow.jsx
+++ b/src/pages/marketplace/MarketplaceFlow.jsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { listingTitleOf } from '@/lib/listingDerivation';
+import { DRAW_RECORD_PHRASE } from '@/lib/drawCopy';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import MarketplaceLayout from './MarketplaceLayout';
 import ConsentAgreementDialog from '@/components/campaigns/signup/ConsentAgreementDialog';
@@ -157,7 +159,7 @@ export default function MarketplaceFlow() {
         ensureFbp();
         trackEvent(
           'ViewContent',
-          { content_ids: [campaign.id], content_name: campaign.name, content_category: campaign.design_config?.category || 'marketplace' },
+          { content_ids: [campaign.id], content_name: listingTitleOf(campaign), content_category: campaign.design_config?.category || 'marketplace' },
           { eventID: vc.eventId }
         );
         markVcFired(campaign.id, 'meta');
@@ -167,7 +169,7 @@ export default function MarketplaceFlow() {
       const ttPixelId = campaign.tiktokPixelId || import.meta.env.VITE_TIKTOK_PIXEL_ID;
       if (ttPixelId) {
         initTikTokPixel(ttPixelId);
-        trackTikTokViewContent({ content_name: campaign.name, content_type: 'marketplace' }, vc.eventId);
+        trackTikTokViewContent({ content_name: listingTitleOf(campaign), content_type: 'marketplace' }, vc.eventId);
         markVcFired(campaign.id, 'tiktok');
       }
     }
@@ -380,12 +382,12 @@ export default function MarketplaceFlow() {
         const trackCtx = { campaign, pathname: window.location.pathname, search: window.location.search };
         if (shouldTrack(trackCtx)) {
           trackLead(
-            { content_ids: [campaign.id], content_name: campaign.name, content_category: dc.category || 'marketplace' },
+            { content_ids: [campaign.id], content_name: listingTitleOf(campaign), content_category: dc.category || 'marketplace' },
             leadEventIdRef.current
           );
         }
         if (shouldTrackTikTok(trackCtx)) {
-          trackTikTokLead({ content_name: campaign.name }, leadEventIdRef.current);
+          trackTikTokLead({ content_name: listingTitleOf(campaign) }, leadEventIdRef.current);
         }
         if (isDraw) trackCustom('draw_entry_confirmed');
         setResult({
@@ -475,7 +477,7 @@ export default function MarketplaceFlow() {
           ← Back to offer
         </button>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 10, flexWrap: 'wrap', marginTop: 4 }}>
-          <h1 className="rm-serif" style={{ margin: 0, fontSize: 'clamp(24px,3vw,30px)' }}>{dc.name || campaign.name}</h1>
+          <h1 className="rm-serif" style={{ margin: 0, fontSize: 'clamp(24px,3vw,30px)' }}>{listingTitleOf(campaign)}</h1>
           <span className="rm-mono-note" style={{ fontSize: 11 }}>{partnerName}</span>
         </div>
         {valueLine && <div style={{ fontSize: 13.5, fontWeight: 700, color: 'var(--rm-pine)', marginTop: 6 }}>{valueLine}</div>}
@@ -914,7 +916,7 @@ function Confirmation({ campaign, isDraw, boost, needAck, actSummary, result, pa
         <span style={{ width: 62, height: 62, borderRadius: '50%', background: 'var(--rm-ok)', color: '#fff', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: 28, fontWeight: 700, animation: 'rmPop 0.45s ease both' }}>✓</span>
         <h2 className="rm-serif" style={{ margin: '14px 0 0', fontSize: 26 }}>{isDraw ? "You're in the draw" : 'Redemption confirmed'}</h2>
         <div className="rm-mono-note" style={{ fontSize: 11, marginTop: 6 }}>
-          {result.ref ? `Reference ${String(result.ref).slice(0, 8).toUpperCase()} · ` : ''}{dc.name || campaign.name}
+          {result.ref ? `Reference ${String(result.ref).slice(0, 8).toUpperCase()} · ` : ''}{listingTitleOf(campaign)}
         </div>
       </div>
 
@@ -926,7 +928,7 @@ function Confirmation({ campaign, isDraw, boost, needAck, actSummary, result, pa
               <Step n="1" apricot>Your entry is recorded — one chance in the draw, nothing more to do.</Step>
               {boost && (
                 <Step n="2" apricot>
-                  <strong>Boost your odds:</strong> complete the activation step before {fmtDateLong(boost.boostClosesAt)} and this entry counts ×{boost.multiplier}.{' '}
+                  <strong>Boost your odds:</strong> this entry counts ×{boost.multiplier} when {DRAW_RECORD_PHRASE} — any time before {fmtDateLong(boost.boostClosesAt)}.{' '}
                   The details are in your confirmation email, and the consultant can reach you at your verified number.
                 </Step>
               )}

--- a/src/pages/marketplace/MarketplaceOffer.jsx
+++ b/src/pages/marketplace/MarketplaceOffer.jsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import { listingTitleOf } from '@/lib/listingDerivation';
+import { DRAW_RECORD_PHRASE } from '@/lib/drawCopy';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import MarketplaceLayout from './MarketplaceLayout';
 import OfferCard from './OfferCard';
@@ -57,7 +59,7 @@ export default function MarketplaceOffer() {
           'ViewContent',
           {
             content_ids: [campaign.id],
-            content_name: campaign.name,
+            content_name: listingTitleOf(campaign),
             content_category: campaign.design_config?.category || 'marketplace',
           },
           { eventID: vc.eventId }
@@ -70,7 +72,7 @@ export default function MarketplaceOffer() {
       if (ttPixelId) {
         initTikTokPixel(ttPixelId);
         trackTikTokViewContent(
-          { content_name: campaign.name, content_type: 'marketplace' },
+          { content_name: listingTitleOf(campaign), content_type: 'marketplace' },
           vc.eventId
         );
         markVcFired(campaign.id, 'tiktok');
@@ -127,7 +129,7 @@ export default function MarketplaceOffer() {
           {' / '}
           <Link to={`/c/${dc.category}`} style={{ color: 'var(--rm-mut)' }}>{categoryLabel(dc.category)}</Link>
           {' / '}
-          <span style={{ color: 'var(--rm-ink)' }}>{dc.name || campaign.name}</span>
+          <span style={{ color: 'var(--rm-ink)' }}>{listingTitleOf(campaign)}</span>
         </nav>
 
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(min(100%,340px),1fr))', gap: 28, alignItems: 'start' }}>
@@ -135,11 +137,35 @@ export default function MarketplaceOffer() {
           <div style={{ display: 'flex', flexDirection: 'column', gap: 22 }}>
             <div className="rm-arch" style={{ height: 300 }}>
               {dc.imageUrl ? (
-                <img src={dc.imageUrl} alt={dc.image_label || dc.name || campaign.name} />
+                <img src={dc.imageUrl} alt={dc.image_label || listingTitleOf(campaign)} />
               ) : (
                 <span className="rm-arch-tag">{dc.image_label || 'experience photo'}</span>
               )}
             </div>
+
+            {dc.description && (
+              <div className="rm-card rm-card--pad" data-testid="offer-description">
+                <div className="rm-mono-label" style={{ marginBottom: 10 }}>About this offer</div>
+                <p style={{ margin: 0, fontSize: 14, lineHeight: 1.65, color: 'var(--rm-sub)', whiteSpace: 'pre-line' }}>{dc.description}</p>
+              </div>
+            )}
+
+            {Array.isArray(dc.prize_breakdown) && dc.prize_breakdown.length > 0 && (
+              <div className="rm-card rm-card--pad" data-testid="offer-prizes">
+                <div className="rm-mono-label" style={{ marginBottom: 12 }}>Prizes</div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 9 }}>
+                  {dc.prize_breakdown.map((row, i) => (
+                    <div key={`${row.name}-${i}`} style={{ display: 'flex', gap: 10, fontSize: 14, alignItems: 'baseline' }}>
+                      <span className="rm-mono-note" style={{ fontSize: 11, color: 'var(--rm-apr2)', fontWeight: 700, width: 30, flexShrink: 0 }}>{row.qty}×</span>
+                      <span>{row.name}</span>
+                    </div>
+                  ))}
+                </div>
+                <div className="rm-mono-note" style={{ fontSize: 10, borderTop: '1px dashed var(--rm-line)', marginTop: 12, paddingTop: 10 }}>
+                  Awarded in this order — one prize per winning entry.
+                </div>
+              </div>
+            )}
 
             {(dc.inclusions || []).length > 0 && (
               <div className="rm-card rm-card--pad">
@@ -198,7 +224,7 @@ export default function MarketplaceOffer() {
                   <DrawStep n="1">Sign up and verify your number — that's one chance in the draw.</DrawStep>
                   {boost && (
                     <DrawStep n="2">
-                      <strong>Boost:</strong> complete the activation step before {fmtDateLong(boost.boostClosesAt)} and your entry counts ×{boost.multiplier}.
+                      <strong>Boost:</strong> your entry counts ×{boost.multiplier} when {DRAW_RECORD_PHRASE} — any time before {fmtDateLong(boost.boostClosesAt)}.
                     </DrawStep>
                   )}
                   <DrawStep n={boost ? '3' : '2'}>
@@ -239,6 +265,12 @@ export default function MarketplaceOffer() {
                 ))}
               </div>
             )}
+
+            {dc.regulatory_line && (
+              <div className="rm-mono-note" data-testid="offer-regulatory" style={{ fontSize: 10, lineHeight: 1.6, letterSpacing: '0.05em' }}>
+                {dc.regulatory_line}
+              </div>
+            )}
           </div>
 
           {/* Right column */}
@@ -248,7 +280,7 @@ export default function MarketplaceOffer() {
                 <span className="rm-mono-label" style={{ fontSize: 10.5 }}>{partner.name}</span>
                 {partner.verified && <span className="rm-verified">Verified</span>}
               </div>
-              <h1 className="rm-serif" style={{ margin: '10px 0 0', fontSize: 'clamp(26px,2.8vw,33px)', lineHeight: 1.15 }}>{dc.name || campaign.name}</h1>
+              <h1 className="rm-serif" style={{ margin: '10px 0 0', fontSize: 'clamp(26px,2.8vw,33px)', lineHeight: 1.15 }}>{listingTitleOf(campaign)}</h1>
               {valueLine && <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--rm-pine)', marginTop: 10 }}>{valueLine}</div>}
               <div className="rm-mono-note" style={{ fontSize: 11, marginTop: 6 }}>
                 {[ageLabel, unavailable ? UNAVAILABLE_COPY[unavailable].cta : dc.showCapacity && ops?.capacity ? `${ops.capacity.remaining} of ${ops.capacity.total} slots left` : 'Available'].filter(Boolean).join(' · ')}
@@ -299,7 +331,7 @@ export default function MarketplaceOffer() {
       {/* Mobile sticky CTA */}
       <div className="rm-sticky-cta">
         <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ fontSize: 13, fontWeight: 700, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{dc.name || campaign.name}</div>
+          <div style={{ fontSize: 13, fontWeight: 700, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{listingTitleOf(campaign)}</div>
           {valueLine && <div style={{ fontSize: 11.5, color: 'var(--rm-pine)', fontWeight: 600 }}>{valueLine}</div>}
         </div>
         <button

--- a/src/pages/marketplace/OfferCard.jsx
+++ b/src/pages/marketplace/OfferCard.jsx
@@ -1,5 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { composeValueLine, ageLabelOf, fmtDateShort, isDrawCampaign, boostOf, offerUnavailability } from './content';
+import { listingTitleOf } from '@/lib/listingDerivation';
+import { DRAW_RECORD_PHRASE } from '@/lib/drawCopy';
 
 /**
  * Marketplace offer card (OfferCardV2 spec): reads the two-layer campaign DTO
@@ -21,6 +23,10 @@ export default function OfferCard({ campaign }) {
   const metaLine = [ageLabelOf(dc), locLabel, modeLabel].filter(Boolean).join(' · ');
   const inc = dc.inclusions || [];
   const incLine = inc.slice(0, 3).join(', ') + (inc.length > 3 ? ` +${inc.length - 3}` : '');
+  // Draw prize rows (inherited listings): rendered as PRIZES, never "Includes".
+  const prizeRows = Array.isArray(dc.prize_breakdown) ? dc.prize_breakdown : [];
+  const prizeLine = prizeRows.slice(0, 3).map((p) => (p.qty === 1 ? p.name : `${p.qty}× ${p.name}`)).join(', ')
+    + (prizeRows.length > 3 ? ` +${prizeRows.length - 3}` : '');
 
   const facts = [];
   if (isDraw) {
@@ -46,7 +52,7 @@ export default function OfferCard({ campaign }) {
       }}
     >
       <div className="rm-offercard-img">
-        {dc.imageUrl && <img src={dc.imageUrl} alt={dc.image_label || dc.name || campaign.name} loading="lazy" />}
+        {dc.imageUrl && <img src={dc.imageUrl} alt={dc.image_label || listingTitleOf(campaign)} loading="lazy" />}
         {isDraw && (
           <span style={{ position: 'absolute', top: 14, left: '50%', transform: 'translateX(-50%)', fontFamily: 'var(--rm-mono)', fontSize: 9, letterSpacing: '0.1em', textTransform: 'uppercase', background: 'var(--rm-apr)', color: '#2A1608', borderRadius: 999, padding: '5px 12px', whiteSpace: 'nowrap' }}>
             Lucky draw
@@ -59,16 +65,20 @@ export default function OfferCard({ campaign }) {
           <span className="rm-mono-label" style={{ fontSize: 10 }}>{partner.name}</span>
           {partner.verified && <span className="rm-verified">Verified</span>}
         </div>
-        <div className="rm-serif" style={{ fontSize: 19, fontWeight: 600, lineHeight: 1.22 }}>{dc.name || campaign.name}</div>
+        <div className="rm-serif" style={{ fontSize: 19, fontWeight: 600, lineHeight: 1.22 }}>{listingTitleOf(campaign)}</div>
         {metaLine && <div className="rm-mono-note">{metaLine}</div>}
-        {incLine && <div style={{ fontSize: 12.5, lineHeight: 1.5, color: 'var(--rm-sub)' }}>Includes: {incLine}</div>}
+        {isDraw && prizeLine ? (
+          <div style={{ fontSize: 12.5, lineHeight: 1.5, color: 'var(--rm-sub)' }}>Prizes: {prizeLine}</div>
+        ) : incLine ? (
+          <div style={{ fontSize: 12.5, lineHeight: 1.5, color: 'var(--rm-sub)' }}>Includes: {incLine}</div>
+        ) : null}
         {isDraw ? (
           <div className="rm-draw-box">
             <span style={{ display: 'inline-block', width: 9, height: 12, borderRadius: '5px 5px 1px 1px', background: 'var(--rm-apr)', marginTop: 2, flexShrink: 0 }} />
             <span style={{ fontSize: 11.5, lineHeight: 1.45, color: '#6B3A1B' }}>
               <strong style={{ fontFamily: 'var(--rm-mono)', fontSize: 9.5, letterSpacing: '0.08em', textTransform: 'uppercase' }}>Lucky draw</strong>
               <br />
-              Verified sign-up = 1 chance{boost ? ` · boost ×${boost.multiplier} by completing the activation step` : ''}.
+              Verified sign-up = 1 chance{boost ? ` · ×${boost.multiplier} when ${DRAW_RECORD_PHRASE}` : ''}.
             </span>
           </div>
         ) : act.required ? (

--- a/src/pages/marketplace/__tests__/inheritedListing.test.jsx
+++ b/src/pages/marketplace/__tests__/inheritedListing.test.jsx
@@ -1,0 +1,76 @@
+/**
+ * Phase B renders of the inherited listing keys: card prizes line + neutral
+ * boost wording + unified title; door description/prizes/regulatory blocks.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import OfferCard from '../OfferCard';
+
+const drawCampaign = {
+  id: 'c1',
+  name: 'Internal Draw Name',
+  slug: 'tokyo-draw',
+  design_config: {
+    name: 'Win a 4D3N Tokyo Getaway',
+    imageUrl: '/uploads/tokyo.jpg',
+    image_label: 'Tokyo at dusk',
+    value_line: '4D3N Tokyo getaway (flights + hotel)',
+    prize_breakdown: [{ qty: 1, name: 'iPhone 17 Pro' }, { qty: 3, name: 'AirPods' }],
+    luckyDraw: { enabled: true, closesAt: '2099-10-30', boostClosesAt: '2099-10-30', multiplier: 10 },
+    category: 'family_lifestyle',
+    mode: 'hybrid',
+  },
+  ops: { partner: { name: 'Redeem', verified: true }, capacity: { total: 500, remaining: 500 } },
+};
+
+const renderCard = (campaign) =>
+  render(
+    <MemoryRouter>
+      <OfferCard campaign={campaign} />
+    </MemoryRouter>
+  );
+
+describe('OfferCard — inherited draw listing', () => {
+  it('renders the derived title, the Prizes line (never "Includes"), and neutral boost wording', () => {
+    renderCard(drawCampaign);
+    expect(screen.getByText('Win a 4D3N Tokyo Getaway')).toBeInTheDocument();
+    expect(screen.getByText(/Prizes: iPhone 17 Pro, 3× AirPods/)).toBeInTheDocument();
+    expect(screen.queryByText(/Includes:/)).not.toBeInTheDocument();
+    expect(screen.getByText(/when your consultant records your completed session/)).toBeInTheDocument();
+    expect(screen.queryByText(/activation step/)).not.toBeInTheDocument();
+  });
+
+  it('falls back to the campaign name when no listing title serves', () => {
+    const noTitle = structuredClone(drawCampaign);
+    delete noTitle.design_config.name;
+    renderCard(noTitle);
+    expect(screen.getByText('Internal Draw Name')).toBeInTheDocument();
+  });
+
+  it('non-draw cards keep the Includes line', () => {
+    const plain = structuredClone(drawCampaign);
+    delete plain.design_config.luckyDraw;
+    delete plain.design_config.prize_breakdown;
+    plain.design_config.inclusions = ['One night stay', 'Breakfast'];
+    renderCard(plain);
+    expect(screen.getByText(/Includes: One night stay, Breakfast/)).toBeInTheDocument();
+  });
+});
+
+describe('studioReadiness — generic headline warning (flag on)', () => {
+  it('warns when a listed campaign has no real headline', async () => {
+    vi.stubEnv('VITE_MARKETPLACE_INHERIT_ENABLED', 'true');
+    const { computeDesignChecks } = await import('@/components/studio/studioReadiness');
+    const doc = {
+      version: 2,
+      content: { headline: 'Get Started', media: { kind: 'none' } },
+      form: { terms: { html: '<p>t</p>' } },
+      theme: {},
+      distribution: { marketplace: { listed: true } },
+    };
+    const out = computeDesignChecks({ campaign: { type: 'lead_generation' }, doc, marketplacePreview: null });
+    expect(out.some((r) => /marketplace listing title/.test(r.msg))).toBe(true);
+    vi.unstubAllEnvs();
+  });
+});


### PR DESCRIPTION
Phase B of `docs/plans/marketplace-inherits-campaign-page.md` (§3B). Phase A (server derivation, #235) merged dark; this is the editor/consumer half. **Everything is dark behind `VITE_MARKETPLACE_INHERIT_ENABLED`** (flipped together with backend `MARKETPLACE_INHERIT_ENABLED` per the runbook) except two deliberate unconditional fixes noted below.

## What's in it

**Client derivation twin** — `src/lib/listingDerivation.js` mirrors the backend overlay so editors can preview the inherited listing from the *unsaved* doc. The prize normalizer byte-matches backend `cleanPrizes` (trim+cap names **without** whitespace collapse; qty `Number.isInteger` 1..99 else 1). A lockstep test builds the server-side input through the real `publicLuckyDraw` pipeline and pins dirty/fractional/media-kind fixtures — it caught one real drift (whitespace collapse) before merge.

**Single door (flag on)** — Studio Distribution panel and the classic Marketplace panel hide the derived inputs (drop title, consumer title, value line, image alt; inclusions for draws) and show an "Inherited from the campaign page" preview instead. The classic panel detects draws from the campaign row since its doc strips `luckyDraw`. `studioLooks.rowDisabledReason` refuses AI-apply onto derived paths; `campaignCopyAiService` omits them from the Fill-everything schema/prompts and blanks stored echoes from model context. Canvas subjects preview derived titles; readiness warns on a generic headline for listed **or** featured campaigns.

**Consumer surfaces** — OfferCard renders a "Prizes:" line from `prize_breakdown` (never "Includes:" for draws); the offer door gains description/prizes/regulatory blocks (regulatory after FAQ, true bottom); browse/search/tracking titles unify through `listingTitleOf`.

**Unconditional (deliberate, documented in plan §9c):** the neutral draw wording "your consultant records your completed session" (`src/lib/drawCopy.js`, shared with the campaign-page draw templates — virtual-session entrants were being told a scan is mandatory), and the `content_name` tracking unification (real-world flag-off delta nil today).

## Review

Codex diff review (gpt-5.6-sol, xhigh, synced worktree): **5 MAJOR + 2 MINOR — all folded** (finding 4 adopted by documentation). Dispositions + two-flag matrix appended as plan §9c.

## Tests

- vitest: **143 files / 1752 passed** (adds lockstep, inheritedListing, DistributionSubjects flag-on cases)
- backend targeted: listingDerivation + aiCopyDraft + marketplaceService + goldens + publicDesignConfig — **118 passed**
- Chronic red pair (shortlinkService/emailService) unrelated, fails on main too.

## Rollout

No behavior change until both flags flip (one sitting; VITE first or same deploy). Gate = `backend/scripts/marketplace-inherit-diff.js` output. Phase C (clamp removal) waits ≥1wk soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDco6HwKLHpmRgE5YR8Za2