### PR TITLE
fix(studio): outcome screens actually receive the theme — the #236 fix was inert at both mounts

### DIFF
--- a/src/components/campaigns/CampaignQuiz.jsx
+++ b/src/components/campaigns/CampaignQuiz.jsx
@@ -284,7 +284,7 @@ function PillButton({ accent, onClick, children }) {
         fontWeight: 600,
         fontSize: 16,
         cursor: 'pointer',
-        boxShadow: '0 4px 14px rgba(60, 40, 20, 0.18)',
+        boxShadow: `0 4px 14px ${TOKENS.accentShadow || 'rgba(60, 40, 20, 0.18)'}`,
       }}
     >
       {children}

--- a/src/components/campaigns/CampaignSignupForm.jsx
+++ b/src/components/campaigns/CampaignSignupForm.jsx
@@ -979,7 +979,7 @@ export default function CampaignSignupForm({
             paddingRight: 36,
             borderRadius: RADIUS.pill,
             backgroundColor: submitDisabled ? (TOKENS.disabledBg || TOKENS.hairline) : accent,
-            color: onAccent,
+            color: submitDisabled ? (TOKENS.onDisabled || onAccent) : onAccent,
             border: 'none',
             cursor: submitDisabled ? 'not-allowed' : 'pointer',
             fontFamily: 'Albert Sans, system-ui, sans-serif',

--- a/src/components/studio/CanvasPageSubject.jsx
+++ b/src/components/studio/CanvasPageSubject.jsx
@@ -4,6 +4,7 @@ import { HARNESS_JUMPS } from '@/components/campaignPage/previewJumpFixtures';
 import { SuccessState, ErrorState } from '@/components/campaigns/LeadCaptureOutcomes';
 import ShareCampaignDialog from '@/components/campaigns/ShareCampaignDialog';
 import { resolveTheme } from '@/lib/designConfigV2';
+import { CampaignThemeProvider, buildFunnelTokens } from '@/components/campaignPage/themeContext';
 import { customerLeadCaptureUrl, resolveCustomerHost } from '@/lib/brand';
 
 const noop = () => {};
@@ -54,16 +55,20 @@ function HarnessOutcome({ campaign, doc, jump }) {
           padding: '28px 24px 32px',
         }}
       >
-        {jump === 'success' ? (
-          <SuccessState onShare={() => setShareOpen(true)} />
-        ) : (
-          <ErrorState
-            duplicateDetected={jump === 'duplicate'}
-            duplicateCountdown={5}
-            message={jump === 'duplicate' ? DUPLICATE_MESSAGE : GENERIC_ERROR_MESSAGE}
-            onShare={() => setShareOpen(true)}
-          />
-        )}
+        {/* Same provider the live LeadCapture mount supplies — the outcome
+            components read the funnel theme context. */}
+        <CampaignThemeProvider value={buildFunnelTokens(vt)}>
+          {jump === 'success' ? (
+            <SuccessState onShare={() => setShareOpen(true)} />
+          ) : (
+            <ErrorState
+              duplicateDetected={jump === 'duplicate'}
+              duplicateCountdown={5}
+              message={jump === 'duplicate' ? DUPLICATE_MESSAGE : GENERIC_ERROR_MESSAGE}
+              onShare={() => setShareOpen(true)}
+            />
+          )}
+        </CampaignThemeProvider>
       </div>
       <ShareCampaignDialog
         open={shareOpen}

--- a/src/pages/LeadCapture.jsx
+++ b/src/pages/LeadCapture.jsx
@@ -15,6 +15,7 @@ import GuidedReviewPage, { GuidedReviewSuccess } from '../components/campaigns/g
 import CampaignPageRenderer from '../components/campaignPage/CampaignPageRenderer';
 import { DrawSuccessPage, DRAW_TEMPLATE_IDS } from '../components/campaignPage/drawTemplates';
 import { isV2, resolveTheme } from '@/lib/designConfigV2';
+import { CampaignThemeProvider, buildFunnelTokens } from '@/components/campaignPage/themeContext';
 import {
   shouldTrack,
   generateEventId,
@@ -616,7 +617,12 @@ export default function LeadCapture() {
               padding: '28px 24px 32px',
             }}
           >
-            {submitted ? <SuccessState onShare={() => setShareOpen(true)} /> : captureExperience}
+            {/* Without this provider the outcome components fall back to the
+                frozen warm-cream default and paint brown-on-dark (#236 made
+                them context-aware, but the mount never supplied the context). */}
+            <CampaignThemeProvider value={buildFunnelTokens(vt)}>
+              {submitted ? <SuccessState onShare={() => setShareOpen(true)} /> : captureExperience}
+            </CampaignThemeProvider>
           </div>
           {shareDialog}
         </div>


### PR DESCRIPTION
Post-merge verification of #236 with jump-state screenshots on the dark presets caught that **B5 (outcome screens) was not actually fixed**: #236 made `SuccessState`/`ErrorState` consume `useCampaignTheme()`, but neither mount ever supplied the context. Both `LeadCapture`'s v2 outcome branch and the Studio harness rendered them bare → the components fell back to the frozen warm-cream **default** and painted brown-on-dark ("You're all set." ~1.15:1) with a terracotta CTA regardless of preset.

## Changes

- **`LeadCapture.jsx` (v2 outcome branch) + `CanvasPageSubject.jsx` (harness)** — wrap the outcome components in `CampaignThemeProvider value={buildFunnelTokens(vt)}`. The v1 mount stays bare on purpose: the default context *is* v1's palette.
- **Disabled submit label** — #236 themed the disabled *fill* but left the label on `onAccent` (computed for the accent fill), ~1.7:1 on dark presets. Now `TOKENS.onDisabled` when disabled.
- **Quiz Start/Continue CTA** — the last baked warm glow in the funnel now follows `TOKENS.accentShadow`.

## Verification

Re-shot `success` / `duplicate` / `otp-open` / `tnc-dialog` on graphite, ink-lime, violet-hour: headline near-white on the dark card, CTA in the preset accent with `onAccent` text. Full suite **141 files / 1733 tests** green twice; production build clean.

Deliberately still fixed-palette (documented design decisions, not regressions): `DncConsentGate` (editorial seal card), `ShareCampaignDialog` (app-chrome sheet), `TypingLoader`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTLqszccDKe8wYHjU1sf1G