### PR TITLE
feat(campaigns): one Details brief creates AND designs the whole campaign

### DIFF
--- a/src/components/campaigns/workspace/CampaignDetailsTab.jsx
+++ b/src/components/campaigns/workspace/CampaignDetailsTab.jsx
@@ -38,7 +38,7 @@ const prizeSummary = (rows) =>
  * (enforceLeadQuota) and per-campaign tracking pixels. Controlled form; the
  * workspace owns create-vs-update. PHV tablet media stays in the classic editor.
  */
-export default function CampaignDetailsTab({ initial, type, draw = false, isEdit, saving, onSubmit }) {
+export default function CampaignDetailsTab({ initial, type, draw = false, isEdit, saving, designing = false, onSubmit }) {
   const campaignType = initial?.type || type || 'lead_generation';
   const [form, setForm] = useState({
     name: initial?.name || '',
@@ -153,6 +153,9 @@ export default function CampaignDetailsTab({ initial, type, draw = false, isEdit
           },
         }
       : {};
+    // Second arg = the brief the operator typed (create only; edit never shows
+    // the box). The workspace uses a non-empty brief to auto-design the whole
+    // page after create — it is transient input, never persisted as a field.
     onSubmit({
       ...drawConfig,
       name: form.name.trim(),
@@ -172,7 +175,7 @@ export default function CampaignDetailsTab({ initial, type, draw = false, isEdit
       })(),
       metaPixelId: form.metaPixelId.trim() || null,
       tiktokPixelId: form.tiktokPixelId.trim() || null,
-    });
+    }, aiBrief.trim());
   };
 
   return (
@@ -344,9 +347,12 @@ export default function CampaignDetailsTab({ initial, type, draw = false, isEdit
       </Card>
 
       <div className="flex justify-end">
-        <Button type="submit" disabled={saving || !form.name.trim()}>
-          {saving && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
-          {isEdit ? 'Save details' : 'Create draft & continue'}
+        {/* `designing` = the post-create AI page-design pass (create flow, when
+            a brief was used). It reuses this button so the operator sees the
+            work continue, not a frozen "Create" button. */}
+        <Button type="submit" disabled={saving || designing || !form.name.trim()}>
+          {(saving || designing) && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+          {designing ? 'Designing your page…' : isEdit ? 'Save details' : 'Create draft & continue'}
         </Button>
       </div>
     </form>

--- a/src/components/campaigns/workspace/__tests__/CampaignDetailsTab.test.jsx
+++ b/src/components/campaigns/workspace/__tests__/CampaignDetailsTab.test.jsx
@@ -309,3 +309,30 @@ describe('CampaignDetailsTab — AI fill Codex folds', () => {
     expect(screen.getByLabelText('End date').value).toBe('');
   });
 });
+
+describe('CampaignDetailsTab — brief handoff + designing state', () => {
+  it('forwards the typed brief to onSubmit as the second argument (create)', () => {
+    const onSubmit = vi.fn();
+    render(<CampaignDetailsTab initial={null} type="lead_generation" isEdit={false} saving={false} onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByLabelText('Campaign name'), { target: { value: 'Voucher Push' } });
+    fireEvent.change(screen.getByLabelText('Campaign brief for AI draft'), { target: { value: '  $20 NTUC voucher for verified sign-ups  ' } });
+    fireEvent.click(screen.getByRole('button', { name: /Create draft/i }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][1]).toBe('$20 NTUC voucher for verified sign-ups'); // trimmed
+  });
+
+  it('passes an empty second argument when no brief was typed', () => {
+    const onSubmit = vi.fn();
+    render(<CampaignDetailsTab initial={null} type="lead_generation" isEdit={false} saving={false} onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByLabelText('Campaign name'), { target: { value: 'Plain' } });
+    fireEvent.click(screen.getByRole('button', { name: /Create draft/i }));
+    expect(onSubmit.mock.calls[0][1]).toBe('');
+  });
+
+  it('the submit button reads as designing (disabled) while the post-create AI pass runs', () => {
+    render(<CampaignDetailsTab initial={null} type="lead_generation" isEdit={false} saving designing onSubmit={vi.fn()} />);
+    const btn = screen.getByRole('button', { name: /Designing your page/i });
+    expect(btn).toBeDisabled();
+    expect(screen.queryByRole('button', { name: /Create draft/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/campaigns/workspace/__tests__/autoDesign.test.js
+++ b/src/components/campaigns/workspace/__tests__/autoDesign.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock only the network boundary — the real requestCopyDraft, studioLooks
+// composer and designConfigV2 upgrade all run, so the composed document is
+// asserted through the genuine buildLookDoc semantics (never mocked away).
+vi.mock('@/api/client', () => ({ apiClient: { post: vi.fn() } }));
+
+import { apiClient } from '@/api/client';
+import { generateCampaignDesign } from '../autoDesign';
+
+const POSTER_LOOK = {
+  name: 'Dusk Poster',
+  template: { id: 'poster', params: { overlay: 'dusk' } },
+  theme: { preset: 'ink-slate', accent: null },
+  media: { kind: 'image', note: 'Warm hawker-centre scene' },
+  draft: [{ path: 'content.headline', label: 'Headline', section: 'page', value: 'Look headline' }],
+};
+const SPOTLIGHT_LOOK = {
+  name: 'Quiz Spotlight',
+  template: { id: 'spotlight', params: {} },
+  theme: { preset: 'warm-cream' },
+  draft: [],
+};
+const draftResolves = (proposals) => apiClient.post.mockResolvedValueOnce({ data: { proposals } });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('generateCampaignDesign', () => {
+  it('requests full mode from the base template and composes the first usable look', async () => {
+    draftResolves([POSTER_LOOK]);
+    const doc = await generateCampaignDesign({
+      campaign: { id: 'c1', design_config: {} },
+      brief: '1 x iphone 17 pro lucky draw for singaporeans or pr. 21 to 65 years old only.',
+    });
+
+    // Mirrors the Studio's full-mode request exactly.
+    expect(apiClient.post).toHaveBeenCalledTimes(1);
+    const [url, body] = apiClient.post.mock.calls[0];
+    expect(url).toBe('/admin/ai/copy-draft');
+    expect(body).toMatchObject({ campaignId: 'c1', templateId: 'editorial', mode: 'full', scope: null, regen: 0 });
+    expect(body.brief.topic).toBe('1 x iphone 17 pro lucky draw for singaporeans or pr. 21 to 65 years old only.');
+
+    // The composed doc genuinely carries the look's template + theme + copy.
+    expect(doc.template.id).toBe('poster');
+    expect(doc.template.params.poster).toMatchObject({ overlay: 'dusk' });
+    expect(doc.theme.preset).toBe('ink-slate');
+    expect(doc.content.headline).toBe('Look headline');
+  });
+
+  it('skips a blocked look (Spotlight needs a quiz) and picks the next usable one', async () => {
+    draftResolves([SPOTLIGHT_LOOK, POSTER_LOOK]);
+    const doc = await generateCampaignDesign({ campaign: { id: 'c1', design_config: {} }, brief: 'voucher push' });
+    expect(doc.template.id).toBe('poster');
+  });
+
+  it('returns null when every proposal is blocked', async () => {
+    draftResolves([SPOTLIGHT_LOOK]); // no quiz on this campaign → blocked
+    const doc = await generateCampaignDesign({ campaign: { id: 'c1', design_config: {} }, brief: 'voucher push' });
+    expect(doc).toBeNull();
+  });
+
+  it('returns null when the provider returns no proposals', async () => {
+    draftResolves([]);
+    const doc = await generateCampaignDesign({ campaign: { id: 'c1', design_config: {} }, brief: 'voucher push' });
+    expect(doc).toBeNull();
+  });
+
+  it('a draw campaign keeps luckyDraw enabled so draw-template looks stay usable', async () => {
+    const DRAW_LOOK = { name: 'Postcard', template: { id: 'postcard', params: {} }, theme: { preset: 'warm-cream' }, draft: [] };
+    draftResolves([DRAW_LOOK]);
+    const doc = await generateCampaignDesign({
+      campaign: {
+        id: 'c-draw',
+        design_config: { luckyDraw: { enabled: true, prize: 'iPhone 17 Pro', closesAt: '2026-08-31' }, termsContent: '<p>terms</p>' },
+      },
+      brief: 'iphone draw',
+    });
+    expect(doc.template.id).toBe('postcard');
+    expect(doc.luckyDraw.enabled).toBe(true); // seed carried through
+  });
+
+  it('propagates a thrown copy-draft error to the caller (create flow catches it)', async () => {
+    apiClient.post.mockRejectedValueOnce(Object.assign(new Error('nope'), { status: 409 }));
+    await expect(
+      generateCampaignDesign({ campaign: { id: 'c1', design_config: {} }, brief: 'voucher push' })
+    ).rejects.toBeTruthy();
+  });
+});

--- a/src/components/campaigns/workspace/autoDesign.js
+++ b/src/components/campaigns/workspace/autoDesign.js
@@ -1,0 +1,44 @@
+import { upgradeDesignConfig } from '@/lib/designConfigV2';
+import { requestCopyDraft } from '@/components/studio/studioAiApi';
+import { buildLookDoc, lookBlockedReason } from '@/components/studio/studioLooks';
+
+/**
+ * Headless "Fill everything with AI" — the Studio's full-mode look pass with no
+ * UI, so one Details brief can design the whole page at create time (the
+ * operator never has to open the Studio and click the button by hand).
+ *
+ * Mirrors useStudioAi's full-mode request exactly (mode:'full', scope:null,
+ * regen:0) so the manual and automatic paths hit the identical server route,
+ * and composes with the pure studioLooks helpers — the look gate and doc
+ * builder are single-sourced, never re-implemented here.
+ *
+ * Returns the composed v2 document, or null when the provider gave back no
+ * proposal this campaign can actually use (empty list / every look blocked).
+ * The create flow treats a null and a thrown error the same graceful way, so
+ * this never has to signal failure any other way than by returning null.
+ */
+export async function generateCampaignDesign({ campaign, brief, signal } = {}) {
+  // Seed from the just-created draft's stored config so draw campaigns keep
+  // luckyDraw.enabled (draw-template looks stay allowed) and the template id
+  // we send back is the campaign's real starting template.
+  const base = upgradeDesignConfig(campaign?.design_config || {});
+  const data = await requestCopyDraft(
+    {
+      campaignId: campaign?.id,
+      templateId: base.template?.id || 'editorial',
+      mode: 'full',
+      scope: null,
+      regen: 0,
+      // The operator's free-text brief is the topic; the rest match the
+      // Studio's EMPTY_BRIEF defaults so both paths shape the request alike.
+      brief: { topic: brief, audience: '', objective: '', mustInclude: '', tone: 'Friendly' },
+    },
+    { signal }
+  );
+  const proposals = Array.isArray(data?.proposals) ? data.proposals : [];
+  // First look this document can actually adopt (Spotlight needs a quiz, draw
+  // templates need an enabled draw) — re-gated against the seed doc, same as
+  // the Studio gallery does at pick time.
+  const look = proposals.find((p) => lookBlockedReason(base, p) === null);
+  return look ? buildLookDoc(base, look, {}) : null;
+}

--- a/src/pages/AdminCampaignWorkspace.jsx
+++ b/src/pages/AdminCampaignWorkspace.jsx
@@ -17,6 +17,7 @@ import CampaignQRManager from '@/components/qrcodes/CampaignQRManager';
 import CampaignDetailsTab from '@/components/campaigns/workspace/CampaignDetailsTab';
 import CampaignDeliveryPoolTab from '@/components/campaigns/workspace/CampaignDeliveryPoolTab';
 import CampaignLaunchTab from '@/components/campaigns/workspace/CampaignLaunchTab';
+import { generateCampaignDesign } from '@/components/campaigns/workspace/autoDesign';
 
 const TABS = [
   { id: 'details', label: 'Details' },
@@ -44,6 +45,10 @@ export default function AdminCampaignWorkspace() {
     !isCreate && TAB_IDS.includes(tabParam) ? tabParam : 'details'
   );
   const [savingDetails, setSavingDetails] = useState(false);
+  // Distinct from savingDetails: the post-create AI page-design pass. Drives a
+  // separate "Designing…" button label so the many-second AI call never reads
+  // as a stuck Create.
+  const [designingPage, setDesigningPage] = useState(false);
 
   const { data: campaign, isLoading } = useCampaign(id);
   const launchMutation = useSetCampaignLaunchState(id);
@@ -62,7 +67,35 @@ export default function AdminCampaignWorkspace() {
     }
   };
 
-  const handleSaveDetails = async (payload) => {
+  // Post-create AI page-design pass. Self-contained + never throws: on ANY
+  // failure (provider off, rate-limited, network, no usable look) it just warns
+  // and returns, leaving the created draft intact for the manual Studio button.
+  const autoDesignCampaign = async (newId, designConfig, brief) => {
+    setDesigningPage(true);
+    const toastId = toast.loading('Designing your campaign page…');
+    try {
+      const nextDoc = await generateCampaignDesign({
+        campaign: { id: newId, design_config: designConfig },
+        brief,
+      });
+      if (!nextDoc) {
+        toast.warning('Draft created — open the Design tab and click “Fill everything with AI” to design the page.', { id: toastId });
+        return;
+      }
+      // Same save + cache-invalidation the manual design save does, so the
+      // Design tab renders the freshly generated document.
+      await Campaign.update(newId, { design_config: nextDoc });
+      queryClient.invalidateQueries({ queryKey: ['campaigns'] });
+      queryClient.invalidateQueries({ queryKey: ['campaigns', 'detail', newId] });
+      toast.success('Page designed', { id: toastId });
+    } catch {
+      toast.warning('Draft created, but the page wasn’t auto-designed — open the Design tab and click “Fill everything with AI”.', { id: toastId });
+    } finally {
+      setDesigningPage(false);
+    }
+  };
+
+  const handleSaveDetails = async (payload, brief) => {
     setSavingDetails(true);
     try {
       if (isCreate) {
@@ -72,6 +105,14 @@ export default function AdminCampaignWorkspace() {
         const newId = created?.id || created?.campaign?.id;
         queryClient.invalidateQueries({ queryKey: ['campaigns'] });
         toast.success('Draft created');
+        // One brief → also design the whole page (the Studio's "Fill everything
+        // with AI", run headlessly here). Best-effort ONLY: the draft is already
+        // saved, so any AI failure just lands the operator on the Design tab with
+        // the manual button — it must never undo or block the create.
+        const trimmedBrief = typeof brief === 'string' ? brief.trim() : '';
+        if (newId && trimmedBrief) {
+          await autoDesignCampaign(newId, created?.design_config ?? payload.design_config, trimmedBrief);
+        }
         if (newId) navigate(`/admin/campaigns/${newId}/workspace?tab=design`);
         else navigate('/AdminCampaigns');
       } else {
@@ -212,6 +253,7 @@ export default function AdminCampaignWorkspace() {
               draw={isDrawCreate}
               isEdit={!isCreate}
               saving={savingDetails}
+              designing={designingPage}
               onSubmit={handleSaveDetails}
             />
           </div>

--- a/src/pages/__tests__/AdminCampaignWorkspace.test.jsx
+++ b/src/pages/__tests__/AdminCampaignWorkspace.test.jsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+
+const mockUseCampaign = vi.fn(() => ({ data: undefined, isLoading: false }));
+const mockUseSetLaunchState = vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false }));
+
+vi.mock('@/hooks/queries/useCampaignsQuery', () => ({
+  useCampaign: (...a) => mockUseCampaign(...a),
+  useSetCampaignLaunchState: (...a) => mockUseSetLaunchState(...a),
+}));
+vi.mock('@/api/entities', () => ({ Campaign: { create: vi.fn(), update: vi.fn() } }));
+vi.mock('@/api/client', () => ({ apiClient: { post: vi.fn(), get: vi.fn().mockResolvedValue({ data: {} }) } }));
+vi.mock('@/lib/queryClient', () => ({ queryClient: { invalidateQueries: vi.fn() } }));
+vi.mock('sonner', () => {
+  const toast = Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    loading: vi.fn(() => 'tid'),
+    dismiss: vi.fn(),
+  });
+  return { toast };
+});
+// Create mode only mounts CampaignDetailsTab; stub the tabs it never shows.
+vi.mock('@/components/campaigns/DesignEditor', () => ({ default: () => null }));
+vi.mock('@/components/studio/OpenInStudioCard', () => ({ default: () => null }));
+vi.mock('@/components/campaigns/QuizAnalyticsCard', () => ({ default: () => null }));
+vi.mock('@/components/qrcodes/CampaignQRManager', () => ({ default: () => null }));
+vi.mock('@/components/campaigns/workspace/CampaignDeliveryPoolTab', () => ({ default: () => null }));
+vi.mock('@/components/campaigns/workspace/CampaignLaunchTab', () => ({ default: () => null }));
+
+import { toast } from 'sonner';
+import { apiClient } from '@/api/client';
+import { Campaign } from '@/api/entities';
+import { queryClient } from '@/lib/queryClient';
+import AdminCampaignWorkspace from '../AdminCampaignWorkspace';
+
+const POSTER_LOOK = {
+  name: 'Dusk Poster',
+  template: { id: 'poster', params: { overlay: 'dusk' } },
+  theme: { preset: 'ink-slate', accent: null },
+  media: { kind: 'image', note: 'Warm hawker-centre scene' },
+  draft: [{ path: 'content.headline', label: 'Headline', section: 'page', value: 'Look headline' }],
+};
+
+function LocationProbe() {
+  const loc = useLocation();
+  return <div data-testid="loc">{`${loc.pathname}${loc.search}`}</div>;
+}
+
+function renderCreate() {
+  return render(
+    <MemoryRouter initialEntries={['/admin/campaigns/workspace?type=lead_generation']}>
+      <Routes>
+        <Route path="/admin/campaigns/workspace" element={<AdminCampaignWorkspace />} />
+        <Route path="/admin/campaigns/:id/workspace" element={<LocationProbe />} />
+        <Route path="/AdminCampaigns" element={<div>CAMPAIGNS-LIST</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+// Drive the create form: name is required to enable the button; the brief in
+// the "Fill it for me" box is what gets forwarded to the auto-design step.
+async function createWith({ name = 'My Campaign', brief } = {}) {
+  const user = userEvent.setup();
+  await user.type(screen.getByLabelText('Campaign name'), name);
+  if (brief) await user.type(screen.getByLabelText('Campaign brief for AI draft'), brief);
+  await user.click(screen.getByRole('button', { name: /Create draft/i }));
+  return user;
+}
+
+const copyDraftResolves = (proposals) =>
+  apiClient.post.mockImplementation((url) =>
+    url === '/admin/ai/copy-draft' ? Promise.resolve({ data: { proposals } }) : Promise.resolve({ data: {} })
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Campaign.create.mockResolvedValue({ id: 'new-1', design_config: {} });
+  Campaign.update.mockResolvedValue({});
+});
+
+describe('AdminCampaignWorkspace — auto-design on create', () => {
+  it('brief present → creates, runs full-mode copy-draft, saves the composed design, then lands on the Design tab', async () => {
+    copyDraftResolves([POSTER_LOOK]);
+    renderCreate();
+    await createWith({ brief: '1 x iphone 17 pro lucky draw for singaporeans or pr. 21 to 65 years old only.' });
+
+    await waitFor(() => expect(screen.getByTestId('loc')).toHaveTextContent('/admin/campaigns/new-1/workspace?tab=design'));
+
+    // Draft created first, then the design pass.
+    expect(Campaign.create).toHaveBeenCalledTimes(1);
+    const copyCall = apiClient.post.mock.calls.find((c) => c[0] === '/admin/ai/copy-draft');
+    expect(copyCall).toBeTruthy();
+    expect(copyCall[1]).toMatchObject({ campaignId: 'new-1', mode: 'full', scope: null, regen: 0 });
+
+    // The composed v2 document is persisted with the look's template + copy.
+    expect(Campaign.update).toHaveBeenCalledTimes(1);
+    const [savedId, savedBody] = Campaign.update.mock.calls[0];
+    expect(savedId).toBe('new-1');
+    expect(savedBody.design_config.template.id).toBe('poster');
+    expect(savedBody.design_config.content.headline).toBe('Look headline');
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['campaigns', 'detail', 'new-1'] });
+  });
+
+  it('brief present but the AI step throws → draft survives, still navigates, warns, no design saved', async () => {
+    apiClient.post.mockImplementation((url) =>
+      url === '/admin/ai/copy-draft'
+        ? Promise.reject(Object.assign(new Error('AI off'), { status: 409 }))
+        : Promise.resolve({ data: {} })
+    );
+    renderCreate();
+    await createWith({ brief: 'voucher push for verified adults' });
+
+    await waitFor(() => expect(screen.getByTestId('loc')).toHaveTextContent('/admin/campaigns/new-1/workspace?tab=design'));
+    expect(Campaign.create).toHaveBeenCalledTimes(1);
+    expect(Campaign.update).not.toHaveBeenCalled(); // no design persisted
+    expect(toast.warning).toHaveBeenCalled(); // non-blocking fallback notice
+    expect(toast.error).not.toHaveBeenCalled(); // create itself did not fail
+  });
+
+  it('no usable proposal (empty / all blocked) → same graceful path: navigate, warn, no design saved', async () => {
+    copyDraftResolves([]); // provider returned nothing usable
+    renderCreate();
+    await createWith({ brief: 'voucher push for verified adults' });
+
+    await waitFor(() => expect(screen.getByTestId('loc')).toHaveTextContent('/admin/campaigns/new-1/workspace?tab=design'));
+    expect(apiClient.post.mock.calls.some((c) => c[0] === '/admin/ai/copy-draft')).toBe(true);
+    expect(Campaign.update).not.toHaveBeenCalled();
+    expect(toast.warning).toHaveBeenCalled();
+  });
+
+  it('no brief → no AI call at all, still creates and navigates to the Design tab', async () => {
+    renderCreate();
+    await createWith({}); // name only, brief left empty
+
+    await waitFor(() => expect(screen.getByTestId('loc')).toHaveTextContent('/admin/campaigns/new-1/workspace?tab=design'));
+    expect(Campaign.create).toHaveBeenCalledTimes(1);
+    expect(apiClient.post).not.toHaveBeenCalled(); // never touched copy-draft or details-draft
+    expect(Campaign.update).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
The new-campaign **Details** brief ("Fill it for me") now also runs the Studio's **"Fill everything with AI" headlessly** after `Campaign.create`. One brief → the draft is created **and** the whole page is designed and saved — template layout, theme/colours, page copy, legal wording, distribution picks — before the operator lands on the Design tab. The Design-tab button stays as the manual fallback; the operator never *needs* to click it.

## How

- **`autoDesign.js`** (new, headless): seeds `upgradeDesignConfig(created.design_config)`, sends the Studio's exact full-mode request (`mode:'full', scope:null, regen:0`, `brief.topic` = the operator's text — matches `copyDraftSchema` including the tone enum), picks the first proposal that passes the real `lookBlockedReason` (Spotlight-needs-quiz **and** draw-templates-need-an-enabled-draw), and composes with the same pure `buildLookDoc` the Studio gallery uses. No apply logic duplicated — manual and automatic paths are the identical code.
- **Draw creates**: the Details payload already writes `design_config.luckyDraw.enabled = true`, so seeding from the created draft keeps draw-template looks eligible.
- **`CampaignDetailsTab`**: forwards the trimmed brief as `onSubmit`'s second arg (transient input, never persisted). A `designing` prop flips the submit button to *"Designing your page…"* so the many-second AI call never reads as a stuck Create.
- **`AdminCampaignWorkspace`**: create + non-empty brief → run the pass, persist via the same `Campaign.update` + cache invalidation the manual design save uses, then navigate to `?tab=design`.

## Failure behaviour (the invariant)

**The AI step can never fail or block a create.** On 409 provider-off, 429 rate limit, network error, or no usable proposal: `toast.warning` pointing at the manual button, no design write, and the operator still lands on the Design tab with the draft intact. No brief → no AI call at all; manual creates are byte-identical to today.

## Verification (re-run independently after review)

- 13 new tests — helper unit + workspace integration driving the **real** composer with only the network mocked: request shape, composed doc carries the look's template/theme/copy, AI-throws path, empty/all-blocked path, no-brief path, brief plumbing, `designing` button state.
- Full suite **143 files / 1746 tests** green; eslint clean; production build clean.
- Reviewed on Fable 5 against the live server schema (`copyDraftSchema`), the sonner 2.x toast API, the `Campaign.create` response shapes, and both `lookBlockedReason` gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTLqszccDKe8wYHjU1sf1G