### PR TITLE
feat(studio-ai): eligibility gates + verification are AI WRITES, not advice

### DIFF
--- a/backend/src/services/campaignCopyAiService.js
+++ b/backend/src/services/campaignCopyAiService.js
@@ -75,8 +75,17 @@ import { composeOps, passesStaticGate } from './marketplaceService.js';
  * freshly-fetched campaign, never model output) and the client composes the
  * document with the same deterministic template the create flow uses. Full
  * mode's template enum excludes the draw templates for non-draw campaigns.
- * Still never writable: consents, regulatory footer, form gates/verification,
- * luckyDraw, media sources, the publication switches.
+ * Still never writable: consents, regulatory footer, luckyDraw, media sources,
+ * the publication switches.
+ *
+ * ELIGIBILITY-GATES AMENDMENT (2026-07-22): both modes also return `gates`
+ * (the sgPr / advisorExclusion screening cards) and `verification` (the OTP
+ * channel) as review-gated WRITES, retiring the formGates + verification
+ * advisory topics. Advice was the wrong shape: a brief reading "Singaporean
+ * citizens and PRs only" wrote that promise into the headline while the gate
+ * stayed off, so the page advertised a restriction it never enforced. The DNC
+ * gate stays operator-only (AI_GATE_IDS) and WhatsApp is only selectable when
+ * the server actually has Meta credentials.
  */
 
 // ─────────────────────────── whitelist ───────────────────────────
@@ -171,10 +180,13 @@ export const REC_TOPICS = [
   { topic: 'featureDrop', label: 'Featured drop' },
   { topic: 'customerHost', label: 'Customer domain' },
   { topic: 'slug', label: 'URL slug' },
-  { topic: 'formGates', label: 'Eligibility gates' },
   // formFields retired 2026-07-22: field selection is a review-gated WRITE
   // row now (create-everything amendment), not advice.
-  { topic: 'verification', label: 'Verification channel' },
+  // formGates + verification retired 2026-07-22 (eligibility-gates amendment):
+  // both are review-gated WRITE rows now. Advice-only was the wrong shape —
+  // a brief that says "Singaporean citizens and PRs only" would write that
+  // promise into the page copy while the screening gate stayed off, so the
+  // page advertised a restriction it never enforced.
 ];
 const REC_TOPIC_IDS = REC_TOPICS.map((t) => t.topic);
 const REC_LABELS = Object.fromEntries(REC_TOPICS.map((t) => [t.topic, t.label]));
@@ -264,6 +276,16 @@ export function buildCampaignContext(campaign, gate = null) {
       template: (isObj(doc) && doc.version === 2 ? doc.form?.terms?.template : null) || 'default',
       hasHtml: !!String((isObj(doc) && doc.version === 2 ? doc.form?.terms?.html : legacy.termsContent) || '').trim(),
     },
+    // Eligibility-gates amendment: the two AI-writable screening gates (dncCheck
+    // is deliberately absent — see AI_GATE_IDS) plus the verification channel,
+    // read version-agnostically through the legacy view.
+    currentGates: { sgPr: legacy.sgPrOnly === true, advisorExclusion: legacy.excludeAdvisors === true },
+    currentVerification: legacy.otpChannel === 'whatsapp' ? 'whatsapp' : 'sms',
+    // Server env fact, same probe campaignReadinessService uses. The model may
+    // only pick WhatsApp when the send path actually exists; the clamp enforces
+    // it (a model-chosen WhatsApp on a bare server would silently fall back to
+    // SMS and raise a readiness warning the operator never asked for).
+    whatsappConfigured: Boolean(process.env.META_WA_PHONE_NUMBER_ID) && Boolean(process.env.META_WA_ACCESS_TOKEN),
     minAge: campaign.min_age ?? 18,
     maxAge: campaign.max_age ?? 65,
     slug: campaign.slug || null,
@@ -434,7 +456,9 @@ export function sanitizeRecommendations(rows, ctx) {
       suggestedValue = suggestedValue ? suggestedValue.toLowerCase() : null;
       if (!suggestedValue || !SLUG_RE.test(suggestedValue) || ctx.slug || ctx.slugLocked) suggestedValue = null;
     } else {
-      suggestedValue = null; // formGates / formFields / verification: advice-only
+      // Defensive default: every live topic is handled above, so this only
+      // catches a topic added to REC_TOPICS without a validator.
+      suggestedValue = null;
     }
     seen.add(topic);
     out.push({ topic, label: REC_LABELS[topic], advice, suggestedValue });
@@ -511,6 +535,41 @@ export function sanitizeAiTermsHtml(raw) {
  * terms — the client composes the document from ctx.drawTerms facts with the
  * deterministic template (create-flow parity); model output is discarded.
  */
+/**
+ * The eligibility gates the AI may propose. `dncCheck` is DELIBERATELY not
+ * here: it is an ops/compliance switch bound to the server-side PDPC DNC
+ * onboarding, not a campaign-copy decision — an LLM turning it on because a
+ * brief mentioned "no spam" would add a live consent step to the funnel that
+ * nobody asked for. It stays operator-only and is preserved untouched at apply.
+ */
+export const AI_GATE_IDS = ['sgPr', 'advisorExclusion'];
+
+/**
+ * Gates row value {sgPr, advisorExclusion} or null. Full-object-or-null (the
+ * fields/terms convention): a partial gate map is meaningless because the
+ * operator reviews the whole screening posture as one decision. Missing keys
+ * read as false — the model omitting a gate means "not this campaign", never
+ * "keep whatever is there".
+ */
+export function clampAiGates(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const out = {};
+  for (const id of AI_GATE_IDS) out[id] = raw[id] === true;
+  return out;
+}
+
+/**
+ * Verification channel 'sms' | 'whatsapp', or null when the model said nothing
+ * usable. WhatsApp downgrades to null (leave the campaign alone) when the
+ * server has no Meta credentials — picking an undeliverable channel is worse
+ * than leaving the default.
+ */
+export function clampAiVerification(raw, ctx) {
+  if (raw !== 'sms' && raw !== 'whatsapp') return null;
+  if (raw === 'whatsapp' && ctx?.whatsappConfigured !== true) return null;
+  return raw;
+}
+
 export function clampAiTerms(raw, ctx) {
   if (ctx?.draw) return null;
   if (!raw || typeof raw !== 'object') return null;
@@ -633,7 +692,7 @@ const EVERYTHING_MODE_EXTRA = [
   'The drop emoji field may contain a single emoji; emojis stay forbidden everywhere else unless the current copy already uses them.',
   'recommendations are ADVISORY notes for the operator on publication decisions; they are never applied automatically. Ground each one in the campaign context and the marketplaceGate snapshot (false keys = unmet publication requirements); never promise that a listing or feature will go live. Only include topics with something concrete to say.',
   'When marketplaceGate.supportedType is false, say the marketplace is unavailable for this campaign type — do not recommend listing.',
-  'suggestedValue: "on"/"off" for listMarketplace/featureDrop, "redeem"/"mktr" for customerHost, a lowercase-dash slug (3-80 chars) for slug ONLY when the campaign has none, otherwise null. formGates/verification are advice-only (null).',
+  'suggestedValue: "on"/"off" for listMarketplace/featureDrop, "redeem"/"mktr" for customerHost, a lowercase-dash slug (3-80 chars) for slug ONLY when the campaign has none, otherwise null.',
 ].join('\n');
 
 /** fields + terms guidance — shared by the everything AND full modes
@@ -643,6 +702,13 @@ function fieldsTermsExtra(ctx) {
   const lines = [
     '',
     'fields: choose which sign-up fields this campaign should capture, in display order. name/email/phone are always visible and required (locked). Only include dob/postal/education/salary when the brief or campaign objective supports them — fewer fields converts better; qualification objectives justify more. Or return null to leave the form unchanged.',
+    // Eligibility-gates amendment: the copy and the gate must agree. The page
+    // stating "for Singaporeans and PRs" while the screening card is off is
+    // the exact failure this section exists to prevent.
+    'gates: the screening cards shown BEFORE the form. sgPr = a Yes/No "are you a Singapore Citizen or PR?" card — set it true whenever the brief restricts entry to citizens/PRs/locals, or whenever your own copy tells the reader the offer is for Singaporeans or PRs. advisorExclusion = a second card excluding financial advisers/insurance agents — set it true only when the brief asks to exclude them or the offer is an adviser-facing conflict. Never claim an eligibility restriction in the copy without setting the matching gate. Return null only when the brief implies no screening at all.',
+    ctx.whatsappConfigured
+      ? 'verification: "sms" or "whatsapp" — the channel the one-time code is sent on. Default to "sms"; pick "whatsapp" only when the brief asks for it or the audience is explicitly WhatsApp-first. Or null to leave it unchanged.'
+      : 'verification: return "sms" or null — this server has no WhatsApp sending credentials, so WhatsApp is not selectable.',
   ];
   if (ctx.draw) {
     lines.push(
@@ -773,6 +839,15 @@ const termsSchema = {
     html: { type: ['string', 'null'], maxLength: 12000 },
   },
 };
+/** Eligibility-gates amendment — shared by BOTH modes, same nullable-required
+ * strict-schema style. dncCheck is absent by design (AI_GATE_IDS). */
+const gatesSchema = {
+  type: ['object', 'null'],
+  additionalProperties: false,
+  required: AI_GATE_IDS,
+  properties: Object.fromEntries(AI_GATE_IDS.map((id) => [id, { type: 'boolean' }])),
+};
+const verificationSchema = { type: ['string', 'null'], enum: ['sms', 'whatsapp', null] };
 
 /** Unscoped copy mode fills EVERYTHING in one call: string draft + enum picks
  * + inclusions + fields + terms + advisory recommendations. Strict-schema
@@ -782,11 +857,13 @@ export function everythingModeSchema(paths, { inclusions = true } = {}) {
   return {
     type: 'object',
     additionalProperties: false,
-    required: ['draft', 'marketplaceMeta', ...(inclusions ? ['inclusions'] : []), 'fields', 'terms', 'recommendations'],
+    required: ['draft', 'marketplaceMeta', ...(inclusions ? ['inclusions'] : []), 'fields', 'terms', 'gates', 'verification', 'recommendations'],
     properties: {
       draft: draftArraySchema(paths),
       fields: fieldsSchema,
       terms: termsSchema,
+      gates: gatesSchema,
+      verification: verificationSchema,
       marketplaceMeta: {
         type: 'object',
         additionalProperties: false,
@@ -829,10 +906,12 @@ export function fullModeSchema(paths, { draw = false } = {}) {
   return {
     type: 'object',
     additionalProperties: false,
-    required: ['proposals', 'fields', 'terms'],
+    required: ['proposals', 'fields', 'terms', 'gates', 'verification'],
     properties: {
       fields: fieldsSchema,
       terms: termsSchema,
+      gates: gatesSchema,
+      verification: verificationSchema,
       proposals: {
         type: 'array',
         minItems: 1,
@@ -993,11 +1072,20 @@ export async function generateCampaignCopyDraft(body, userId, overrides = {}) {
     }
     const aiFields = clampAiFields(parsed?.fields);
     const aiTerms = clampAiTerms(parsed?.terms, ctx);
+    const aiGates = clampAiGates(parsed?.gates);
+    const aiVerification = clampAiVerification(parsed?.verification, ctx);
     logger.info(
-      { userId, campaignId: body.campaignId, proposals: proposals.length, fields: !!aiFields, terms: !!aiTerms },
+      { userId, campaignId: body.campaignId, proposals: proposals.length, fields: !!aiFields, terms: !!aiTerms, gates: !!aiGates, verification: aiVerification },
       'ai.copy_draft.full'
     );
-    return { proposals, fields: aiFields, terms: aiTerms, drawTerms: ctx.drawTerms || null };
+    return {
+      proposals,
+      fields: aiFields,
+      terms: aiTerms,
+      gates: aiGates,
+      verification: aiVerification,
+      drawTerms: ctx.drawTerms || null,
+    };
   }
 
   if (scopeIsInclusions) {
@@ -1006,7 +1094,17 @@ export async function generateCampaignCopyDraft(body, userId, overrides = {}) {
       throw new AppError('The AI provider returned no usable draft.', 502);
     }
     logger.info({ userId, campaignId: body.campaignId, rows: 0, scope }, 'ai.copy_draft.copy');
-    return { draft: [], picks: [], inclusions, recommendations: [], fields: null, terms: null, drawTerms: null };
+    return {
+      draft: [],
+      picks: [],
+      inclusions,
+      recommendations: [],
+      fields: null,
+      terms: null,
+      gates: null,
+      verification: null,
+      drawTerms: null,
+    };
   }
 
   const draft = sanitizeDraftRows(parsed?.draft, requestFields);
@@ -1014,16 +1112,19 @@ export async function generateCampaignCopyDraft(body, userId, overrides = {}) {
   const inclusions = everything && inclusionsAllowed ? sanitizeInclusions(parsed?.inclusions) : null;
   const aiFields = everything ? clampAiFields(parsed?.fields) : null;
   const aiTerms = everything ? clampAiTerms(parsed?.terms, ctx) : null;
+  const aiGates = everything ? clampAiGates(parsed?.gates) : null;
+  const aiVerification = everything ? clampAiVerification(parsed?.verification, ctx) : null;
   const drawTerms = everything ? ctx.drawTerms || null : null;
   const recommendations = everything ? sanitizeRecommendations(parsed?.recommendations, ctx) : [];
   // drawTerms is deterministic context (not model output) — it never makes a
-  // dead model response "usable".
-  if (draft.length === 0 && picks.length === 0 && !inclusions && !aiFields && !aiTerms) {
+  // dead model response "usable". gates/verification CAN: a run whose only
+  // useful answer is "switch the SG/PR screening on" is a real result.
+  if (draft.length === 0 && picks.length === 0 && !inclusions && !aiFields && !aiTerms && !aiGates && !aiVerification) {
     throw new AppError('The AI provider returned no usable draft.', 502);
   }
   logger.info(
-    { userId, campaignId: body.campaignId, rows: draft.length, picks: picks.length, recs: recommendations.length, fields: !!aiFields, terms: !!aiTerms, scope },
+    { userId, campaignId: body.campaignId, rows: draft.length, picks: picks.length, recs: recommendations.length, fields: !!aiFields, terms: !!aiTerms, gates: !!aiGates, verification: aiVerification, scope },
     'ai.copy_draft.copy'
   );
-  return { draft, picks, inclusions, recommendations, fields: aiFields, terms: aiTerms, drawTerms };
+  return { draft, picks, inclusions, recommendations, fields: aiFields, terms: aiTerms, gates: aiGates, verification: aiVerification, drawTerms };
 }

--- a/backend/src/tests/aiCopyDraft.test.js
+++ b/backend/src/tests/aiCopyDraft.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import {
   everythingModeSchema,
+  fullModeSchema,
   buildCopyDraftPrompts,
   generateCampaignCopyDraft,
   buildCampaignContext,
@@ -15,7 +16,10 @@ import {
   contrastRatioHex,
   clampAiFields,
   clampAiTerms,
+  clampAiGates,
+  clampAiVerification,
   sanitizeAiTermsHtml,
+  AI_GATE_IDS,
   REC_TOPICS,
   COPY_FIELDS,
   PICK_FIELDS,
@@ -322,14 +326,13 @@ describe('picks + inclusions + recommendations', () => {
       { topic: 'listMarketplace', advice: 'a', suggestedValue: 'yes' }, // not on/off
       { topic: 'featureDrop', advice: 'b', suggestedValue: 'off' },
       { topic: 'customerHost', advice: 'c', suggestedValue: 'redeem.sg' }, // not the enum
-      { topic: 'formGates', advice: 'd', suggestedValue: 'on' }, // advice-only topic
+      { topic: 'formGates', advice: 'd', suggestedValue: 'on' }, // RETIRED topic → dropped entirely
       { topic: 'slug', advice: 'e', suggestedValue: 'Free Pet Hotel!' }, // bad slug format
     ], ctxBare);
     expect(Object.fromEntries(recs.map((r) => [r.topic, r.suggestedValue]))).toEqual({
       listMarketplace: null,
       featureDrop: 'off',
       customerHost: null,
-      formGates: null,
       slug: null,
     });
   });
@@ -501,10 +504,11 @@ describe('transport + prompts + error taxonomy', () => {
     expect(captured.url).toBe('https://api.openai.com/v1/responses');
     expect(captured.body.text.format).toMatchObject({ type: 'json_schema', name: 'campaign_fill_draft', strict: true });
     const schemaProps = captured.body.text.format.schema.properties;
-    // create-everything amendment: fields + terms join the everything schema.
-    expect(Object.keys(schemaProps)).toEqual(['draft', 'fields', 'terms', 'marketplaceMeta', 'inclusions', 'recommendations']);
+    // create-everything amendment: fields + terms join the everything schema;
+    // eligibility-gates amendment adds gates + verification beside them.
+    expect(Object.keys(schemaProps)).toEqual(['draft', 'fields', 'terms', 'gates', 'verification', 'marketplaceMeta', 'inclusions', 'recommendations']);
     expect(captured.body.text.format.schema.required).toEqual(
-      expect.arrayContaining(['fields', 'terms'])
+      expect.arrayContaining(['fields', 'terms', 'gates', 'verification'])
     );
     expect(Object.keys(schemaProps.marketplaceMeta.properties)).toEqual(PICK_FIELDS.map((f) => f.key));
     const system = captured.body.input.find((m) => m.role === 'system').content;
@@ -859,5 +863,132 @@ describe('marketplace inheritance gates the derived-copy AI fields (plan §3B)',
       'distribution.marketplace.cancellation',
       'content.headline',
     ]));
+  });
+});
+
+describe('eligibility-gates amendment — gates + verification are WRITES, not advice', () => {
+  const ctxWaOn = { whatsappConfigured: true };
+  const ctxWaOff = { whatsappConfigured: false };
+
+  it('clampAiGates: only the two AI gates survive; dncCheck can never be written', () => {
+    expect(AI_GATE_IDS).toEqual(['sgPr', 'advisorExclusion']);
+    const out = clampAiGates({ sgPr: true, advisorExclusion: false, dncCheck: true, bogus: true });
+    expect(out).toEqual({ sgPr: true, advisorExclusion: false });
+    expect(out).not.toHaveProperty('dncCheck');
+  });
+
+  it('clampAiGates: missing keys read as false (omission = "not this campaign"), junk → null', () => {
+    expect(clampAiGates({ sgPr: true })).toEqual({ sgPr: true, advisorExclusion: false });
+    expect(clampAiGates({ sgPr: 'yes' })).toEqual({ sgPr: false, advisorExclusion: false });
+    expect(clampAiGates(null)).toBe(null);
+    expect(clampAiGates('garbage')).toBe(null);
+    expect(clampAiGates(undefined)).toBe(null);
+  });
+
+  it('clampAiVerification: WhatsApp only when the server can actually send it', () => {
+    expect(clampAiVerification('whatsapp', ctxWaOn)).toBe('whatsapp');
+    expect(clampAiVerification('whatsapp', ctxWaOff)).toBe(null);
+    expect(clampAiVerification('sms', ctxWaOff)).toBe('sms');
+    expect(clampAiVerification('telegram', ctxWaOn)).toBe(null);
+    expect(clampAiVerification(null, ctxWaOn)).toBe(null);
+  });
+
+  it('the advisory topics they replaced are retired', () => {
+    const topics = REC_TOPICS.map((t) => t.topic);
+    expect(topics).not.toContain('formGates');
+    expect(topics).not.toContain('verification');
+    // A model that answers with a retired topic is dropped, not surfaced.
+    const recs = sanitizeRecommendations(
+      [{ topic: 'formGates', advice: 'Turn on the SG/PR gate', suggestedValue: 'on' }],
+      { marketplaceGate: null }
+    );
+    expect(recs).toEqual([]);
+  });
+
+  it('both modes carry gates + verification in the schema', () => {
+    const everything = everythingModeSchema(['content.headline']);
+    expect(everything.required).toEqual(expect.arrayContaining(['gates', 'verification']));
+    expect(everything.properties.gates.required).toEqual(['sgPr', 'advisorExclusion']);
+    expect(everything.properties.gates.properties).not.toHaveProperty('dncCheck');
+    expect(everything.properties.verification.enum).toEqual(['sms', 'whatsapp', null]);
+    const full = fullModeSchema(['content.headline'], { draw: true });
+    expect(full.required).toEqual(expect.arrayContaining(['gates', 'verification']));
+  });
+
+  it('context exposes the current gates + the WhatsApp send-path fact', () => {
+    const ctx = buildCampaignContext({
+      ...BARE_CAMPAIGN,
+      design_config: { ...BARE_CAMPAIGN.design_config, sgPrOnly: true, excludeAdvisors: false, otpChannel: 'whatsapp' },
+    });
+    expect(ctx.currentGates).toEqual({ sgPr: true, advisorExclusion: false });
+    expect(ctx.currentVerification).toBe('whatsapp');
+    expect(typeof ctx.whatsappConfigured).toBe('boolean');
+  });
+
+  it('the prompt tells the model the copy and the gate must agree', () => {
+    const prompts = buildCopyDraftPrompts({
+      mode: 'copy', scope: null, regen: 0, templateId: 'editorial',
+      brief: { topic: 'x', audience: '', objective: '', mustInclude: '', tone: 'Friendly' },
+      ctx: { campaignName: 'C', whatsappConfigured: true }, fields: [], settings: {},
+    });
+    expect(prompts.system).toContain('sgPr');
+    expect(prompts.system).toContain('Never claim an eligibility restriction in the copy without setting the matching gate');
+  });
+
+  it('no WhatsApp credentials → the prompt refuses to offer the channel', () => {
+    const prompts = buildCopyDraftPrompts({
+      mode: 'copy', scope: null, regen: 0, templateId: 'editorial',
+      brief: { topic: 'x', audience: '', objective: '', mustInclude: '', tone: 'Friendly' },
+      ctx: { campaignName: 'C', whatsappConfigured: false }, fields: [], settings: {},
+    });
+    expect(prompts.system).toContain('WhatsApp is not selectable');
+  });
+
+  it('END TO END: "citizens and PRs only" brief → Fill-everything returns the SG/PR gate on', async () => {
+    const res = await run(baseBody(), {
+      draft: [{ path: 'content.headline', value: 'Win an iPhone 17 Pro' }],
+      marketplaceMeta: {},
+      inclusions: null,
+      fields: null,
+      terms: null,
+      gates: { sgPr: true, advisorExclusion: false, dncCheck: true },
+      verification: 'sms',
+      recommendations: [],
+    });
+    expect(res.gates).toEqual({ sgPr: true, advisorExclusion: false });
+    expect(res.verification).toBe('sms');
+  });
+
+  it('END TO END: full mode carries the gates beside the looks', async () => {
+    const res = await run(baseBody({ mode: 'full' }), {
+      proposals: [{
+        name: 'Stub', rationale: 'r', templateId: 'stub',
+        theme: { preset: 'warm-cream', font: null, radius: null, background: null, accent: null },
+        media: { kind: 'none', note: '' },
+        draft: [{ path: 'content.headline', value: 'Win an iPhone 17 Pro' }],
+      }],
+      fields: null,
+      terms: null,
+      gates: { sgPr: true, advisorExclusion: false },
+      verification: 'whatsapp',
+    });
+    expect(res.gates).toEqual({ sgPr: true, advisorExclusion: false });
+    // No Meta creds in the test env → WhatsApp is refused rather than promised.
+    expect(res.verification).toBe(null);
+  });
+
+  it('a run whose ONLY useful answer is a gate is still a result, not a 502', async () => {
+    const res = await run(baseBody(), {
+      draft: [],
+      marketplaceMeta: {},
+      inclusions: null,
+      fields: null,
+      terms: null,
+      gates: { sgPr: true, advisorExclusion: false },
+      verification: null,
+      recommendations: [],
+    });
+    expect(res.gates).toEqual({ sgPr: true, advisorExclusion: false });
+    expect(res.draft).toEqual([]);
   });
 });

--- a/src/components/campaigns/workspace/CampaignDetailsTab.jsx
+++ b/src/components/campaigns/workspace/CampaignDetailsTab.jsx
@@ -149,6 +149,11 @@ export default function CampaignDetailsTab({ initial, type, draw = false, isEdit
               closesAt: form.drawClosesAt,
               boostClosesAt: form.drawBoostClosesAt || form.drawClosesAt,
               multiplier: Number(form.drawMultiplier) || 10,
+              // The eligibility clause must state THIS campaign's floor, not
+              // the template default: seeding an 18+ clause onto a 21-65 draw
+              // published terms that contradicted both the page copy and the
+              // age gate the server enforces.
+              minAge: Number(form.min_age) || 18,
             }),
           },
         }

--- a/src/components/campaigns/workspace/__tests__/CampaignDetailsTab.test.jsx
+++ b/src/components/campaigns/workspace/__tests__/CampaignDetailsTab.test.jsx
@@ -133,6 +133,30 @@ describe('CampaignDetailsTab — lucky-draw create flow', () => {
     expect(payload.end_date).toBe(new Date('2026-08-31').toISOString());
   });
 
+  it('the seeded eligibility clause states THIS campaign age floor, not the template default', () => {
+    const onSubmit = vi.fn();
+    render(
+      <CampaignDetailsTab initial={null} type="lead_generation" draw isEdit={false} saving={false} onSubmit={onSubmit} />
+    );
+    fillBasics();
+    fireEvent.change(screen.getByLabelText('Min age'), { target: { value: '21' } });
+    fireEvent.click(screen.getByRole('button', { name: /Create draft/i }));
+    const terms = onSubmit.mock.calls[0][0].design_config.termsContent;
+    expect(terms).toContain('aged 21 and above');
+    expect(terms).not.toContain('aged 18 and above');
+  });
+
+  it('a below-floor min age still seeds the legal 18+ clause', () => {
+    const onSubmit = vi.fn();
+    render(
+      <CampaignDetailsTab initial={null} type="lead_generation" draw isEdit={false} saving={false} onSubmit={onSubmit} />
+    );
+    fillBasics();
+    fireEvent.change(screen.getByLabelText('Min age'), { target: { value: '16' } });
+    fireEvent.click(screen.getByRole('button', { name: /Create draft/i }));
+    expect(onSubmit.mock.calls[0][0].design_config.termsContent).toContain('aged 18 and above');
+  });
+
   it('multiple prize rows arm ordered prizes, a derived summary, and N-winner terms', () => {
     const onSubmit = vi.fn();
     render(

--- a/src/components/campaigns/workspace/__tests__/autoDesign.test.js
+++ b/src/components/campaigns/workspace/__tests__/autoDesign.test.js
@@ -87,4 +87,64 @@ describe('generateCampaignDesign', () => {
       generateCampaignDesign({ campaign: { id: 'c1', design_config: {} }, brief: 'voucher push' })
     ).rejects.toBeTruthy();
   });
+
+  it('applies the common FIELDS + TERMS sections beside the look (rowApplyValue shapes)', async () => {
+    apiClient.post.mockResolvedValueOnce({
+      data: {
+        proposals: [POSTER_LOOK],
+        fields: [
+          { id: 'name', visible: true, required: true },
+          { id: 'email', visible: true, required: true },
+          { id: 'phone', visible: true, required: true },
+          { id: 'dob', visible: true, required: true },
+          { id: 'postal', visible: false },
+          { id: 'education', visible: false },
+          { id: 'salary', visible: false },
+        ],
+        terms: { template: 'default', html: '<h3>Terms</h3><p>Drafted legal copy.</p>' },
+      },
+    });
+    const doc = await generateCampaignDesign({ campaign: { id: 'c1', design_config: {} }, brief: 'voucher push' });
+    expect(doc.template.id).toBe('poster'); // look still composed
+    expect(doc.form.terms).toEqual({ template: 'default', html: '<h3>Terms</h3><p>Drafted legal copy.</p>' });
+    expect(doc.form.fields).toHaveLength(7);
+    expect(doc.form.fields[3]).toEqual({ id: 'dob', visible: true, required: true, row: null });
+    expect(doc.form.fields[4]).toEqual({ id: 'postal', visible: false, required: false, row: null });
+  });
+
+  it('draw campaigns compose terms from the deterministic drawTerms FACTS, never LLM text', async () => {
+    apiClient.post.mockResolvedValueOnce({
+      data: {
+        proposals: [{ name: 'Postcard', template: { id: 'postcard', params: {} }, theme: { preset: 'warm-cream' }, draft: [] }],
+        drawTerms: {
+          campaignName: 'iPhone 17 Pro Lucky Draw',
+          prizes: [{ qty: 1, name: 'iPhone 17 Pro' }],
+          closesAt: '2026-08-31',
+          multiplier: 10,
+          minAge: 21,
+          verification: 'sms',
+        },
+      },
+    });
+    const doc = await generateCampaignDesign({
+      campaign: { id: 'c-draw', design_config: { luckyDraw: { enabled: true, prize: 'iPhone 17 Pro', closesAt: '2026-08-31' } } },
+      brief: 'iphone draw',
+    });
+    expect(doc.form.terms.template).toBe('default');
+    expect(doc.form.terms.html).toContain('iPhone 17 Pro Lucky Draw'); // platform template output
+    expect(doc.form.terms.html).toContain('21'); // minAge interpolated
+  });
+
+  it('terms/fields still land when NO look is usable — legal + form beat returning nothing', async () => {
+    apiClient.post.mockResolvedValueOnce({
+      data: {
+        proposals: [SPOTLIGHT_LOOK], // blocked (no quiz)
+        terms: { template: 'default', html: '<p>Drafted terms.</p>' },
+      },
+    });
+    const doc = await generateCampaignDesign({ campaign: { id: 'c1', design_config: {} }, brief: 'voucher push' });
+    expect(doc).not.toBeNull();
+    expect(doc.template.id).toBe('editorial'); // base template untouched — no look adopted
+    expect(doc.form.terms.html).toBe('<p>Drafted terms.</p>');
+  });
 });

--- a/src/components/campaigns/workspace/__tests__/autoDesign.test.js
+++ b/src/components/campaigns/workspace/__tests__/autoDesign.test.js
@@ -148,3 +148,63 @@ describe('generateCampaignDesign', () => {
     expect(doc.form.terms.html).toBe('<p>Drafted terms.</p>');
   });
 });
+
+describe('generateCampaignDesign — eligibility gates + verification (headless)', () => {
+  const resolvesWith = (data) => apiClient.post.mockResolvedValueOnce({ data });
+
+  it('applies the gates the brief earned, MERGING so the DNC gate survives', async () => {
+    resolvesWith({ proposals: [POSTER_LOOK], gates: { sgPr: true, advisorExclusion: false } });
+    const doc = await generateCampaignDesign({
+      campaign: {
+        id: 'c1',
+        design_config: { version: 2, form: { gates: { sgPr: false, advisorExclusion: false, dncCheck: true } } },
+      },
+      brief: '1 x iphone 17 pro lucky draw for singaporeans or pr. 21 to 65 years old only.',
+    });
+    expect(doc.form.gates).toEqual({ sgPr: true, advisorExclusion: false, dncCheck: true });
+  });
+
+  it('applies the verification channel the server cleared', async () => {
+    resolvesWith({ proposals: [POSTER_LOOK], verification: 'whatsapp' });
+    const doc = await generateCampaignDesign({ campaign: { id: 'c1', design_config: {} }, brief: 'x' });
+    expect(doc.form.verification).toBe('whatsapp');
+  });
+
+  it('ignores a verification value the server did not clamp to the enum', async () => {
+    resolvesWith({ proposals: [POSTER_LOOK], verification: 'telegram' });
+    const doc = await generateCampaignDesign({ campaign: { id: 'c1', design_config: {} }, brief: 'x' });
+    expect(doc.form?.verification).not.toBe('telegram');
+  });
+
+  it('draw terms quote the channel this pass just APPLIED, not the stored one', async () => {
+    resolvesWith({
+      proposals: [{ name: 'Postcard', template: { id: 'postcard', params: {} }, theme: { preset: 'warm-cream' }, draft: [] }],
+      verification: 'whatsapp',
+      drawTerms: {
+        campaignName: 'iPhone 17 Pro Lucky Draw',
+        prizes: [{ qty: 1, name: 'iPhone 17 Pro' }],
+        closesAt: '2026-09-02',
+        boostClosesAt: '2026-09-02',
+        multiplier: 10,
+        minAge: 21,
+        verification: 'sms', // STORED channel — superseded by the applied one
+      },
+    });
+    const doc = await generateCampaignDesign({
+      campaign: { id: 'c-draw', design_config: { luckyDraw: { enabled: true, closesAt: '2026-09-02' } } },
+      brief: 'iphone draw',
+    });
+    expect(doc.form.verification).toBe('whatsapp');
+    expect(doc.form.terms.html).toContain('one-time WhatsApp code');
+    expect(doc.form.terms.html).not.toContain('one-time SMS code');
+    // …and the age floor is the campaign's, not the template default.
+    expect(doc.form.terms.html).toContain('aged 21 and above');
+  });
+
+  it('gates still land when every look is blocked (screening beats returning nothing)', async () => {
+    resolvesWith({ proposals: [SPOTLIGHT_LOOK], gates: { sgPr: true, advisorExclusion: false } });
+    const doc = await generateCampaignDesign({ campaign: { id: 'c1', design_config: {} }, brief: 'x' });
+    expect(doc).not.toBeNull();
+    expect(doc.form.gates.sgPr).toBe(true);
+  });
+});

--- a/src/components/campaigns/workspace/autoDesign.js
+++ b/src/components/campaigns/workspace/autoDesign.js
@@ -23,6 +23,18 @@ function applyCommonSections(doc, data) {
       row: null,
     }));
   }
+  // Eligibility-gates amendment: gates MERGE (the AI proposes only sgPr and
+  // advisorExclusion — a whole-object write would clear the operator-owned DNC
+  // gate), verification is a straight enum the server already clamped against
+  // the WhatsApp send path.
+  if (data?.gates && typeof data.gates === 'object') {
+    doc.form = doc.form || {};
+    doc.form.gates = { ...(doc.form.gates || {}), ...data.gates };
+  }
+  if (data?.verification === 'sms' || data?.verification === 'whatsapp') {
+    doc.form = doc.form || {};
+    doc.form.verification = data.verification;
+  }
   let terms = null;
   if (data?.terms && typeof data.terms.html === 'string' && data.terms.html) {
     terms = { template: data.terms.template || 'default', html: data.terms.html };
@@ -38,7 +50,10 @@ function applyCommonSections(doc, data) {
         boostClosesAt: facts.boostClosesAt || undefined,
         multiplier: facts.multiplier,
         minAge: facts.minAge,
-        verification: facts.verification,
+        // The APPLIED channel, not the stored one: the same pass may have just
+        // switched the campaign to WhatsApp, and terms that promise an SMS
+        // code the funnel never sends are wrong the moment they are written.
+        verification: doc.form?.verification || facts.verification,
       }),
     };
   }
@@ -87,11 +102,14 @@ export async function generateCampaignDesign({ campaign, brief, signal } = {}) {
   // templates need an enabled draw) — re-gated against the seed doc, same as
   // the Studio gallery does at pick time.
   const look = proposals.find((p) => lookBlockedReason(base, p) === null);
-  // Terms + fields apply even when no look is usable — a campaign with legal
-  // wording and the right form beats returning nothing. Copy/theme need a look.
+  // Terms + fields + gates apply even when no look is usable — a campaign with
+  // legal wording, the right form and the right screening beats returning
+  // nothing. Copy/theme need a look.
   const hasCommon = (Array.isArray(data?.fields) && data.fields.length) ||
     (data?.terms && typeof data.terms.html === 'string' && data.terms.html) ||
-    (data?.drawTerms && data.drawTerms.closesAt);
+    (data?.drawTerms && data.drawTerms.closesAt) ||
+    (data?.gates && typeof data.gates === 'object') ||
+    data?.verification === 'sms' || data?.verification === 'whatsapp';
   if (!look && !hasCommon) return null;
   return applyCommonSections(look ? buildLookDoc(base, look, {}) : structuredClone(base), data);
 }

--- a/src/components/campaigns/workspace/autoDesign.js
+++ b/src/components/campaigns/workspace/autoDesign.js
@@ -1,6 +1,53 @@
 import { upgradeDesignConfig } from '@/lib/designConfigV2';
 import { requestCopyDraft } from '@/components/studio/studioAiApi';
 import { buildLookDoc, lookBlockedReason } from '@/components/studio/studioLooks';
+import { buildDrawTermsHtml } from '@/components/campaigns/workspace/drawTermsTemplate';
+
+/**
+ * The full-mode response carries the sign-up FIELDS and TERMS sections BESIDE
+ * the look proposals (create-everything amendment) — the Studio panel applies
+ * them at adoption via review rows, so buildLookDoc alone would drop them.
+ * Write shapes mirror useStudioAi's rowApplyValue exactly: fields land as
+ * canonical row:null entries, terms atomically as {template, html} (a terms
+ * object without html would be dropped by the save clamp). Draw campaigns
+ * NEVER take LLM legal text — the deterministic drawTerms FACTS compose
+ * through the same platform template the create flow seeds.
+ */
+function applyCommonSections(doc, data) {
+  if (Array.isArray(data?.fields) && data.fields.length) {
+    doc.form = doc.form || {};
+    doc.form.fields = data.fields.map((f) => ({
+      id: f.id,
+      visible: f.visible !== false,
+      required: f.required === true,
+      row: null,
+    }));
+  }
+  let terms = null;
+  if (data?.terms && typeof data.terms.html === 'string' && data.terms.html) {
+    terms = { template: data.terms.template || 'default', html: data.terms.html };
+  } else if (data?.drawTerms && data.drawTerms.closesAt) {
+    const facts = data.drawTerms;
+    terms = {
+      template: 'default',
+      html: buildDrawTermsHtml({
+        campaignName: facts.campaignName,
+        prizes: facts.prizes || undefined,
+        prize: facts.prize || undefined,
+        closesAt: facts.closesAt,
+        boostClosesAt: facts.boostClosesAt || undefined,
+        multiplier: facts.multiplier,
+        minAge: facts.minAge,
+        verification: facts.verification,
+      }),
+    };
+  }
+  if (terms) {
+    doc.form = doc.form || {};
+    doc.form.terms = terms;
+  }
+  return doc;
+}
 
 /**
  * Headless "Fill everything with AI" — the Studio's full-mode look pass with no
@@ -40,5 +87,11 @@ export async function generateCampaignDesign({ campaign, brief, signal } = {}) {
   // templates need an enabled draw) — re-gated against the seed doc, same as
   // the Studio gallery does at pick time.
   const look = proposals.find((p) => lookBlockedReason(base, p) === null);
-  return look ? buildLookDoc(base, look, {}) : null;
+  // Terms + fields apply even when no look is usable — a campaign with legal
+  // wording and the right form beats returning nothing. Copy/theme need a look.
+  const hasCommon = (Array.isArray(data?.fields) && data.fields.length) ||
+    (data?.terms && typeof data.terms.html === 'string' && data.terms.html) ||
+    (data?.drawTerms && data.drawTerms.closesAt);
+  if (!look && !hasCommon) return null;
+  return applyCommonSections(look ? buildLookDoc(base, look, {}) : structuredClone(base), data);
 }

--- a/src/components/studio/StudioAiPanel.jsx
+++ b/src/components/studio/StudioAiPanel.jsx
@@ -46,6 +46,18 @@ function fieldsLines(value) {
   return lines;
 }
 
+/** Gate ids → the FormPanel's own labels (the operator must recognise the row
+ * as the switches they'd otherwise flip by hand). */
+const GATE_LABELS = { sgPr: 'Singapore Citizen / PR gate', advisorExclusion: 'Exclude financial advisors' };
+
+/** Gates row → display lines ("Singapore Citizen / PR gate: ON"). */
+function gatesLines(value) {
+  if (!value || typeof value !== 'object') return [];
+  return Object.entries(value).map(([id, on]) => `${GATE_LABELS[id] || id}: ${on === true ? 'ON' : 'off'}`);
+}
+
+const VERIFICATION_LABELS = { sms: 'SMS OTP', whatsapp: 'WhatsApp OTP' };
+
 /** Terms row value → compact preview: template chip + tag-stripped excerpt +
  * size, and the legal-draft framing line (platform template vs AI scaffold). */
 function TermsValue({ row, oldEmpty }) {
@@ -334,6 +346,16 @@ export default function StudioAiPanel({ ai, campaign, doc }) {
                         </>
                       ) : row.kind === 'terms' ? (
                         <TermsValue row={row} oldEmpty={oldEmpty} />
+                      ) : row.kind === 'gates' ? (
+                        <>
+                          <ValueLines value={gatesLines(row.old)} struck />
+                          <ValueLines value={gatesLines(row.value)} />
+                        </>
+                      ) : row.kind === 'verification' ? (
+                        <>
+                          {oldEmpty ? null : <ValueLines value={VERIFICATION_LABELS[row.old] || row.old} struck />}
+                          <ValueLines value={VERIFICATION_LABELS[row.value] || row.value} />
+                        </>
                       ) : (
                         <>
                           {oldEmpty ? null : <ValueLines value={row.old} struck />}
@@ -350,7 +372,7 @@ export default function StudioAiPanel({ ai, campaign, doc }) {
                         <button type="button" className="av2-btn av2-btn--ghost av2-btn--sm" disabled={row.state === 'kept'} onClick={() => ai.keepRow(index)}>
                           Keep mine
                         </button>
-                        {row.kind !== 'pick' && row.kind !== 'fields' && row.kind !== 'terms' ? (
+                        {!['pick', 'fields', 'terms', 'gates', 'verification'].includes(row.kind) ? (
                           <button type="button" className="av2-btn av2-btn--ghost av2-btn--sm" title="Regenerate this field" onClick={() => ai.regenRow(index)} style={{ marginLeft: 'auto' }}>
                             ↻
                           </button>

--- a/src/components/studio/__tests__/studioLooks.test.js
+++ b/src/components/studio/__tests__/studioLooks.test.js
@@ -153,3 +153,22 @@ describe('create-everything amendment — fields/terms kinds + draw look gate', 
     expect(lookBlockedReason({}, { template: { id: 'poster' } })).toBe(null);
   });
 });
+
+describe('rowCurrentValue — gates rows read through the proposal key set', () => {
+  const gatesRow = { path: 'form.gates', kind: 'gates', value: { sgPr: true, advisorExclusion: false } };
+
+  it('returns only the keys the AI proposed — dncCheck never appears as a phantom "off"', () => {
+    const doc = { form: { gates: { sgPr: false, advisorExclusion: true, dncCheck: true } } };
+    expect(rowCurrentValue(doc, gatesRow)).toEqual({ sgPr: false, advisorExclusion: true });
+  });
+
+  it('missing/!== true values normalize to false so equality is stable', () => {
+    expect(rowCurrentValue({ form: {} }, gatesRow)).toEqual({ sgPr: false, advisorExclusion: false });
+    expect(rowCurrentValue({ form: { gates: { sgPr: 'yes' } } }, gatesRow)).toEqual({ sgPr: false, advisorExclusion: false });
+  });
+
+  it('an identical posture compares equal (that is what suppresses a no-op row)', () => {
+    const doc = { form: { gates: { sgPr: true, advisorExclusion: false, dncCheck: true } } };
+    expect(rowValuesEqual(rowCurrentValue(doc, gatesRow), gatesRow.value)).toBe(true);
+  });
+});

--- a/src/components/studio/__tests__/studioReadiness.test.js
+++ b/src/components/studio/__tests__/studioReadiness.test.js
@@ -195,3 +195,43 @@ describe('PR 5 — server code mapping + WhatsApp dedupe + draw-date math', () =
     expect(sgtYmdFromInstant('garbage')).toBeNull();
   });
 });
+
+describe('computeDesignChecks — draw T&Cs drifting from the campaign settings', () => {
+  const drawDoc = (termsHtml, extras = {}) =>
+    docWith({}, {
+      luckyDraw: { enabled: true, closesAt: '2026-09-02' },
+      form: { verification: 'sms', terms: { template: 'default', html: termsHtml }, ...extras },
+    });
+  const TERMS_18_SMS = '<p><strong>Eligibility &amp; entry:</strong> Open to Singapore residents aged 18 and above. Verify with the one-time SMS code.</p>';
+
+  it('T&Cs stating 18+ on a 21+ campaign → warn (the exact prod drift)', () => {
+    const items = computeDesignChecks({ campaign: { ...CAMPAIGN, min_age: 21 }, doc: drawDoc(TERMS_18_SMS) });
+    expect(items).toContainEqual(
+      expect.objectContaining({ sev: 'warn', sec: 'form', msg: expect.stringContaining('must be 18 and above') })
+    );
+  });
+
+  it('matching age → no warning', () => {
+    const items = computeDesignChecks({ campaign: { ...CAMPAIGN, min_age: 18 }, doc: drawDoc(TERMS_18_SMS) });
+    expect(items.filter((i) => /and above/.test(i.msg || ''))).toHaveLength(0);
+  });
+
+  it('a min_age under the legal draw floor compares against 18, not the raw value', () => {
+    const items = computeDesignChecks({ campaign: { ...CAMPAIGN, min_age: 16 }, doc: drawDoc(TERMS_18_SMS) });
+    expect(items.filter((i) => /and above/.test(i.msg || ''))).toHaveLength(0);
+  });
+
+  it('T&Cs promising an SMS code while the form verifies by WhatsApp → warn', () => {
+    const doc = drawDoc(TERMS_18_SMS, { verification: 'whatsapp' });
+    const items = computeDesignChecks({ campaign: { ...CAMPAIGN, min_age: 18 }, doc });
+    expect(items).toContainEqual(
+      expect.objectContaining({ sev: 'warn', msg: expect.stringContaining('one-time SMS code') })
+    );
+  });
+
+  it('hand-written terms that use neither phrase never warn', () => {
+    const doc = drawDoc('<p>Bespoke legal wording with no template phrasing at all.</p>');
+    const items = computeDesignChecks({ campaign: { ...CAMPAIGN, min_age: 21 }, doc });
+    expect(items.filter((i) => i.sev === 'warn')).toHaveLength(0);
+  });
+});

--- a/src/components/studio/__tests__/studioReadiness.test.js
+++ b/src/components/studio/__tests__/studioReadiness.test.js
@@ -216,9 +216,12 @@ describe('computeDesignChecks — draw T&Cs drifting from the campaign settings'
     expect(items.filter((i) => /and above/.test(i.msg || ''))).toHaveLength(0);
   });
 
-  it('a min_age under the legal draw floor compares against 18, not the raw value', () => {
+  it('an under-18 draw warns TWICE: the illegal floor, and the 18+ terms that contradict it', () => {
+    // Codex MAJOR #2: comparing against a raised floor hid the worst case —
+    // terms promising 18+ while prospectService happily accepts a 16-year-old.
     const items = computeDesignChecks({ campaign: { ...CAMPAIGN, min_age: 16 }, doc: drawDoc(TERMS_18_SMS) });
-    expect(items.filter((i) => /and above/.test(i.msg || ''))).toHaveLength(0);
+    expect(items).toContainEqual(expect.objectContaining({ sev: 'warn', msg: expect.stringContaining('accepts entrants from age 16') }));
+    expect(items).toContainEqual(expect.objectContaining({ sev: 'warn', msg: expect.stringContaining('must be 18 and above') }));
   });
 
   it('T&Cs promising an SMS code while the form verifies by WhatsApp → warn', () => {

--- a/src/components/studio/__tests__/useStudioAi.test.jsx
+++ b/src/components/studio/__tests__/useStudioAi.test.jsx
@@ -983,3 +983,78 @@ describe('create-everything amendment — fields + terms rows, beginFull', () =>
     expect(apiClient.post.mock.calls[0][1].brief.topic).toBe('Voucher Blast');
   });
 });
+
+describe('useStudioAi — eligibility gates + verification are review-gated WRITES', () => {
+  const withCommon = (over = {}) => ({
+    success: true,
+    data: { draft: [DRAFT[0]], gates: { sgPr: true, advisorExclusion: false }, verification: 'sms', ...over },
+  });
+
+  it('a gates row appears and Accept MERGES, leaving the operator-owned DNC gate alone', async () => {
+    const campaign = v2Campaign();
+    campaign.design_config.form.gates = { sgPr: false, advisorExclusion: false, dncCheck: true };
+    const { result } = renderAi(campaign);
+    await generateReady(result, withCommon());
+
+    const idx = result.current.ai.sugs.findIndex((r) => r.kind === 'gates');
+    expect(idx).toBeGreaterThan(-1);
+    expect(result.current.ai.sugs[idx]).toMatchObject({
+      path: 'form.gates',
+      section: 'Form',
+      value: { sgPr: true, advisorExclusion: false },
+      old: { sgPr: false, advisorExclusion: false },
+    });
+
+    act(() => result.current.ai.acceptRow(idx));
+    // dncCheck SURVIVES — the AI never proposed it and must not clear it.
+    expect(result.current.docApi.doc.form.gates).toEqual({ sgPr: true, advisorExclusion: false, dncCheck: true });
+  });
+
+  it('keep-mine restores the AI keys without wiping the DNC gate', async () => {
+    const campaign = v2Campaign();
+    campaign.design_config.form.gates = { sgPr: false, advisorExclusion: false, dncCheck: true };
+    const { result } = renderAi(campaign);
+    await generateReady(result, withCommon());
+    const idx = result.current.ai.sugs.findIndex((r) => r.kind === 'gates');
+
+    act(() => result.current.ai.acceptRow(idx));
+    act(() => result.current.ai.keepRow(idx));
+    expect(result.current.docApi.doc.form.gates).toEqual({ sgPr: false, advisorExclusion: false, dncCheck: true });
+    expect(result.current.ai.sugs[idx].state).toBe('kept');
+  });
+
+  it('a no-op proposal never becomes a row (nothing to decide, so nothing to click)', async () => {
+    const { result } = renderAi(); // doc already sgPr:false, advisorExclusion:false, verification 'sms'
+    await generateReady(result, withCommon({ gates: { sgPr: false, advisorExclusion: false }, verification: 'sms' }));
+    expect(result.current.ai.sugs.some((r) => r.kind === 'gates')).toBe(false);
+    expect(result.current.ai.sugs.some((r) => r.kind === 'verification')).toBe(false);
+  });
+
+  it('a verification row applies as a plain enum write', async () => {
+    const { result } = renderAi();
+    await generateReady(result, withCommon({ verification: 'whatsapp' }));
+    const idx = result.current.ai.sugs.findIndex((r) => r.kind === 'verification');
+    expect(result.current.ai.sugs[idx]).toMatchObject({ path: 'form.verification', value: 'whatsapp', old: 'sms' });
+    act(() => result.current.ai.acceptRow(idx));
+    expect(result.current.docApi.doc.form.verification).toBe('whatsapp');
+  });
+
+  it('neither row offers a per-row regenerate (their scopes are not server-writable)', async () => {
+    const { result } = renderAi();
+    await generateReady(result, withCommon({ verification: 'whatsapp' }));
+    const gatesIdx = result.current.ai.sugs.findIndex((r) => r.kind === 'gates');
+    apiClient.post.mockClear();
+    await act(async () => {
+      await result.current.ai.regenRow(gatesIdx);
+    });
+    expect(apiClient.post).not.toHaveBeenCalled();
+  });
+
+  it('apply-all writes the gates row along with the copy rows', async () => {
+    const { result } = renderAi();
+    await generateReady(result, withCommon());
+    act(() => result.current.ai.applyAll());
+    expect(result.current.docApi.doc.form.gates.sgPr).toBe(true);
+    expect(result.current.docApi.doc.content.headline).toBe('Fresh AI headline');
+  });
+});

--- a/src/components/studio/__tests__/useStudioAi.test.jsx
+++ b/src/components/studio/__tests__/useStudioAi.test.jsx
@@ -1058,3 +1058,50 @@ describe('useStudioAi — eligibility gates + verification are review-gated WRIT
     expect(result.current.docApi.doc.content.headline).toBe('Fresh AI headline');
   });
 });
+
+describe('useStudioAi — draw T&Cs never contradict the channel in the same response', () => {
+  it('a WhatsApp proposal composes WhatsApp terms (Codex MAJOR #1)', async () => {
+    const campaign = v2Campaign();
+    campaign.design_config.luckyDraw = { enabled: true, closesAt: '2026-09-02' };
+    const { result } = renderAi(campaign);
+    await generateReady(result, {
+      success: true,
+      data: {
+        draft: [DRAFT[0]],
+        verification: 'whatsapp',
+        drawTerms: {
+          campaignName: 'iPhone Draw',
+          prizes: [{ qty: 1, name: 'iPhone 17 Pro' }],
+          closesAt: '2026-09-02',
+          boostClosesAt: '2026-09-02',
+          multiplier: 10,
+          minAge: 21,
+          verification: 'sms', // stored channel, superseded by the proposal
+        },
+      },
+    });
+    act(() => result.current.ai.applyAll());
+    expect(result.current.docApi.doc.form.verification).toBe('whatsapp');
+    expect(result.current.docApi.doc.form.terms.html).toContain('one-time WhatsApp code');
+    expect(result.current.docApi.doc.form.terms.html).not.toContain('one-time SMS code');
+  });
+
+  it('no verification proposal → the stored channel still composes the terms', async () => {
+    const campaign = v2Campaign();
+    campaign.design_config.luckyDraw = { enabled: true, closesAt: '2026-09-02' };
+    const { result } = renderAi(campaign);
+    await generateReady(result, {
+      success: true,
+      data: {
+        draft: [DRAFT[0]],
+        verification: null,
+        drawTerms: {
+          campaignName: 'iPhone Draw', prizes: [{ qty: 1, name: 'iPhone 17 Pro' }],
+          closesAt: '2026-09-02', boostClosesAt: '2026-09-02', multiplier: 10, minAge: 21, verification: 'sms',
+        },
+      },
+    });
+    const termsRow = result.current.ai.sugs.find((r) => r.kind === 'terms');
+    expect(termsRow.value.html).toContain('one-time SMS code');
+  });
+});

--- a/src/components/studio/studioLooks.js
+++ b/src/components/studio/studioLooks.js
@@ -97,6 +97,15 @@ export function rowCurrentValue(doc, row) {
     if (!v || typeof v !== 'object') return '';
     return { template: v.template || 'default', html: typeof v.html === 'string' ? v.html : '' };
   }
+  // Gates read through the PROPOSAL's key set (never a local copy of the
+  // server's AI_GATE_IDS): the row is the server's answer, so the shapes stay
+  // aligned by construction — and dncCheck, which the AI never proposes, is
+  // absent from both sides instead of showing up as a phantom "off".
+  if (row?.kind === 'gates') {
+    const v = getAtPath(doc, row.path);
+    const cur = v && typeof v === 'object' ? v : {};
+    return Object.fromEntries(Object.keys(row.value || {}).map((k) => [k, cur[k] === true]));
+  }
   return currentValueAt(doc, row?.path || '');
 }
 

--- a/src/components/studio/studioReadiness.js
+++ b/src/components/studio/studioReadiness.js
@@ -88,8 +88,19 @@ export function computeDesignChecks({ campaign, doc, marketplacePreview }) {
     // verification channel afterwards leaves the legal text behind — and the
     // text is what gets PINNED as the version entrants accept. Both checks key
     // on the template's own phrasing, so hand-written terms never warn.
+    // The campaign's REAL floor, not the terms template's 18-clamp: min_age is
+    // what prospectService actually enforces, so comparing against a raised
+    // value would hide the worst case — terms promising 18+ on a draw the
+    // funnel lets a 16-year-old into.
+    const ageFloor = Number.isInteger(campaign?.min_age) ? campaign.min_age : 18;
+    if (ageFloor < 18) {
+      out.push({
+        sev: 'warn',
+        sec: 'form',
+        msg: `This draw accepts entrants from age ${ageFloor} — draws are 18+ and the platform terms template says so. Raise the minimum age on the Details tab.`,
+      });
+    }
     const statedAge = /aged\s+(\d{1,2})\s+and above/i.exec(terms);
-    const ageFloor = Math.max(18, Number.isInteger(campaign?.min_age) ? campaign.min_age : 18);
     if (statedAge && Number(statedAge[1]) !== ageFloor) {
       out.push({
         sev: 'warn',

--- a/src/components/studio/studioReadiness.js
+++ b/src/components/studio/studioReadiness.js
@@ -83,6 +83,29 @@ export function computeDesignChecks({ campaign, doc, marketplacePreview }) {
     if (!isValidYmd(doc.luckyDraw?.closesAt)) {
       out.push({ sev: 'block', sec: 'form', msg: 'Lucky draw needs a valid close date on the draw record (server invariant).' });
     }
+    // Terms-vs-settings drift. The platform draw-terms template states the age
+    // floor and the OTP channel in prose, so changing min_age or the
+    // verification channel afterwards leaves the legal text behind — and the
+    // text is what gets PINNED as the version entrants accept. Both checks key
+    // on the template's own phrasing, so hand-written terms never warn.
+    const statedAge = /aged\s+(\d{1,2})\s+and above/i.exec(terms);
+    const ageFloor = Math.max(18, Number.isInteger(campaign?.min_age) ? campaign.min_age : 18);
+    if (statedAge && Number(statedAge[1]) !== ageFloor) {
+      out.push({
+        sev: 'warn',
+        sec: 'form',
+        msg: `Draw T&Cs say entrants must be ${statedAge[1]} and above, but this campaign is set to ${ageFloor}+ — update the terms before launch.`,
+      });
+    }
+    const statedChannel = /one-time (SMS|WhatsApp) code/i.exec(terms);
+    const channel = doc.form?.verification === 'whatsapp' ? 'whatsapp' : 'sms';
+    if (statedChannel && statedChannel[1].toLowerCase() !== channel) {
+      out.push({
+        sev: 'warn',
+        sec: 'form',
+        msg: `Draw T&Cs promise a one-time ${statedChannel[1]} code but this campaign verifies by ${channel === 'whatsapp' ? 'WhatsApp' : 'SMS'}.`,
+      });
+    }
   }
   if (
     marketplaceInheritEnabled() &&

--- a/src/components/studio/useStudioAi.js
+++ b/src/components/studio/useStudioAi.js
@@ -192,6 +192,15 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
       termsValue = { template: data.terms.template || 'default', html: data.terms.html };
     } else if (data?.drawTerms && data.drawTerms.closesAt) {
       drawFacts = data.drawTerms;
+      // Compose against the channel this response PROPOSES, falling back to the
+      // stored one — otherwise apply-all writes terms promising an SMS code
+      // next to a form.verification of 'whatsapp', and the save pins that
+      // contradiction as the version entrants accept. Accepting one row and
+      // keeping the other can still diverge; the readiness drift check is the
+      // backstop for that.
+      const proposedChannel = data.verification === 'sms' || data.verification === 'whatsapp'
+        ? data.verification
+        : drawFacts.verification;
       termsValue = {
         template: 'default',
         html: buildDrawTermsHtml({
@@ -202,7 +211,7 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
           boostClosesAt: drawFacts.boostClosesAt || undefined,
           multiplier: drawFacts.multiplier,
           minAge: drawFacts.minAge,
-          verification: drawFacts.verification,
+          verification: proposedChannel,
         }),
       };
     }

--- a/src/components/studio/useStudioAi.js
+++ b/src/components/studio/useStudioAi.js
@@ -72,10 +72,11 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
   const [recs, setRecs] = useState([]); // advisory cards — never in apply-all
   const [scope, setScope] = useState(null); // {path, label} | null
   const [looks, setLooks] = useState([]);
-  // Full-mode common sections (create-everything amendment): the raw
-  // fields/terms/drawTerms response parts, held until a look is ADOPTED —
-  // then assembled into review rows against the pre-look doc, so they
-  // survive pick/keep/revert cycles.
+  // Full-mode common sections (create-everything amendment, extended by the
+  // eligibility-gates amendment): the raw fields/terms/gates/verification/
+  // drawTerms response parts, held until a look is ADOPTED — then assembled
+  // into review rows against the pre-look doc, so they survive pick/keep/
+  // revert cycles.
   const [commonSections, setCommonSections] = useState(null);
   const [proposal, setProposal] = useState(null); // {prev:{doc}, look, keep, adopted}
   const [mediaHint, setMediaHint] = useState(null); // {kind, note} | null
@@ -215,6 +216,20 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
         ...(drawFacts ? { deterministic: true } : {}),
       });
     }
+    // Eligibility-gates amendment. Both rows are dropped when they match the
+    // doc already: an Accept button that changes nothing reads as a pending
+    // decision, and these two are exactly the rows an operator must be able to
+    // trust at a glance.
+    const proposed = [];
+    if (data?.gates && typeof data.gates === 'object') {
+      proposed.push({ path: 'form.gates', label: 'Eligibility gates', section: 'Form', kind: 'gates', value: data.gates });
+    }
+    if (data?.verification === 'sms' || data?.verification === 'whatsapp') {
+      proposed.push({ path: 'form.verification', label: 'Verification channel', section: 'Form', kind: 'verification', value: data.verification });
+    }
+    for (const row of proposed) {
+      if (!rowValuesEqual(rowCurrentValue(base, row), row.value)) rows.push(row);
+    }
     return annotateRows(rows, base);
   }, [annotateRows]);
 
@@ -338,6 +353,13 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
       return row.value.map((f) => ({ id: f.id, visible: f.visible !== false, required: f.required === true, row: null }));
     }
     if (row.kind === 'terms') return { template: row.value.template || 'default', html: row.value.html || '' };
+    // Gates MERGE into the live object — the AI proposes only sgPr and
+    // advisorExclusion, so a whole-object write would silently clear the
+    // operator-owned DNC gate.
+    if (row.kind === 'gates') {
+      const cur = docRef.current?.form?.gates;
+      return { ...(cur && typeof cur === 'object' ? cur : {}), ...row.value };
+    }
     return row.value;
   };
 
@@ -367,7 +389,13 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
       const row = sugsRef.current[index];
       if (!row || row.state === 'kept') return;
       if (row.state === 'applied' && rowValuesEqual(rowCurrentValue(docRef.current, row), row.value)) {
-        setPath(row.path, row.oldAbsent ? undefined : row.old);
+        // Gates restore through the same MERGE as apply: `old` holds only the
+        // two AI-proposed keys, so a whole-object write here would delete the
+        // operator's DNC gate on the way back out.
+        const restore = row.kind === 'gates' && !row.oldAbsent
+          ? { ...(docRef.current?.form?.gates || {}), ...row.old }
+          : row.oldAbsent ? undefined : row.old;
+        setPath(row.path, restore);
       }
       patchRow(index, { state: 'kept' });
     },
@@ -381,7 +409,7 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
   const regenRow = useCallback(
     async (index) => {
       const row = sugsRef.current[index];
-      if (!row || row.kind === 'pick' || row.kind === 'fields' || row.kind === 'terms' || !campaign?.id) return;
+      if (!row || row.kind === 'pick' || row.kind === 'fields' || row.kind === 'terms' || row.kind === 'gates' || row.kind === 'verification' || !campaign?.id) return;
       const { generation, signal } = startRequest();
       const n = (regensRef.current[row.path] || 0) + 1;
       noteCall();
@@ -427,8 +455,10 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
 
   /** Apply every remaining OPEN row (each re-gated), optionally limited to one
    * section. Recommendations are NEVER part of this — advisory by contract.
-   * Copy writes can't change any gate (gates hang off toggles/enums, never
-   * copy paths), so re-gating against the pre-batch doc is sound. */
+   * No row kind in the batch can flip another row's availability
+   * (rowDisabledReason keys on media/quiz/template/inheritance only — never on
+   * form.gates or form.verification), so re-gating against the pre-batch doc
+   * stays sound. */
   const applyOpenRows = useCallback((section) => {
     const patches = sugsRef.current.map((row) => {
       if (row.state !== 'open') return null;
@@ -530,7 +560,13 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
       );
       if (generation !== generationRef.current) return;
       setLooks(Array.isArray(data.proposals) ? data.proposals : []);
-      setCommonSections({ fields: data.fields || null, terms: data.terms || null, drawTerms: data.drawTerms || null });
+      setCommonSections({
+        fields: data.fields || null,
+        terms: data.terms || null,
+        gates: data.gates || null,
+        verification: data.verification || null,
+        drawTerms: data.drawTerms || null,
+      });
       setPhase('looks');
     } catch (err) {
       if (generation !== generationRef.current) return;
@@ -565,7 +601,13 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
       );
       if (generation !== generationRef.current) return;
       setLooks(Array.isArray(data.proposals) ? data.proposals : []);
-      setCommonSections({ fields: data.fields || null, terms: data.terms || null, drawTerms: data.drawTerms || null });
+      setCommonSections({
+        fields: data.fields || null,
+        terms: data.terms || null,
+        gates: data.gates || null,
+        verification: data.verification || null,
+        drawTerms: data.drawTerms || null,
+      });
       setPhase('looks');
     } catch (err) {
       if (generation !== generationRef.current) return;


### PR DESCRIPTION
## The bug

Briefing the create flow with *"1 x iPhone 17 Pro lucky draw for Singaporeans or PR, 21 to 65 years old only"* produced a page whose subheadline read **"A lucky draw for Singaporeans and PRs aged 21 to 65"** — with the **Singapore Citizen / PR gate switched off**. The page advertised a restriction it never enforced.

Not a model problem (prod runs `gpt-5.6-terra`, and it correctly set `min_age: 21` / `max_age: 65` and picked a draw template). The gate was simply not in any AI-writable surface:

| Path | Could set `form.gates.sgPr`? |
|---|---|
| Details "Fill it for me" | No — schema is name/dates/ages/prizes only |
| Headless auto-design (full mode) | No — and full mode emits no recommendations at all |
| Studio "Fill everything" | Advice only — `suggestedValue` forced to `null`, nothing to click |

## The fix

`gates` and `verification` become review-gated **WRITE** rows — the same treatment `fields` got in the create-everything amendment — on both the Studio panel and the headless create pass.

**Server is the enforcement point** (`campaignCopyAiService`):
- `AI_GATE_IDS = ['sgPr', 'advisorExclusion']`. **`dncCheck` is deliberately excluded** — it is an ops switch bound to the PDPC DNC onboarding, not a copy decision. An LLM enabling a live consent step because a brief said "no spam" is exactly the friction we don't add.
- WhatsApp is selectable **only** when `META_WA_*` credentials exist; otherwise it degrades to `null` rather than promising an undeliverable channel and manufacturing a readiness warning.
- Prompt states the invariant: *never claim an eligibility restriction in the copy without setting the matching gate.*
- `formGates` + `verification` retired from `REC_TOPICS`.

**Client:**
- Gates **MERGE** on apply *and* on keep-mine — `old` carries only the two AI keys, so a whole-object write would silently delete the operator's DNC gate.
- No-op rows are suppressed (an Accept that changes nothing reads as a pending decision).
- `autoDesign` applies both headlessly and composes draw T&Cs with the channel **this pass just applied**, not the stored one.

## Drift this exposed (fixed here too)

- `CampaignDetailsTab` seeded draw T&Cs **without `minAge`** — so the live iPhone draw carries *"Open to Singapore residents aged 18 and above"* while the row says 21–65 and the page says 21–65. Three sources, two answers.
- `studioReadiness` now warns when pinned draw terms state an age floor or OTP channel that no longer matches the campaign. Keyed on the platform template's own phrasing, so hand-written terms never warn — and it **warns rather than rewrites**, because those terms are what entrants accepted.

## Included from an orphaned commit

`3508a3c` (from #239's session, pushed after the squash-merge with no PR) made the headless pass apply the response's `fields` + `terms`. Cherry-picked here, plus a fix its own test suite surfaced: `hasCommon` didn't count the new sections, so gates were lost whenever every look was blocked.

## Tests

- vitest **145 files / 1789 green**; production build clean
- backend `aiCopyDraft` + `campaignReadiness` **89 green**
- +25 new: clamp matrix (dncCheck unwritable, WhatsApp gated on creds), retired-topic drop, both schemas, end-to-end "citizens and PRs" → gate on, gates-survive-blocked-looks, merge-preserves-dncCheck on apply and keep-mine, no-op suppression, draw-terms channel/age composition, readiness drift both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEWmDbzT8RbS2LNEt9Y5bk