### PR TITLE
feat(wa-push): WhatsApp MARKETING template pack + submit/status script (watemplates)

### DIFF
--- a/backend/scripts/submit-wa-marketing-templates.mjs
+++ b/backend/scripts/submit-wa-marketing-templates.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+/**
+ * Submit the cohort-push MARKETING template pack to the Redeem WABA
+ * (tracker item "watemplates"; pack doc: docs/plans/wa-marketing-template-pack.md).
+ *
+ * The Cloud API creds live ONLY on Render (mktr-backend-jo6r → Environment tab),
+ * so run this with the token pasted inline — it is never printed:
+ *
+ *   WHATSAPP_TOKEN=…  node backend/scripts/submit-wa-marketing-templates.mjs
+ *
+ * Modes:
+ *   (default)  idempotent submit — reads existing templates first, POSTs only
+ *              the missing ones, then prints a status table
+ *   --status   read-only status poll (use while waiting on Meta review)
+ *   --dry      print the exact JSON payloads, no network, no token needed
+ *
+ * Optional env:
+ *   WHATSAPP_WABA_ID          skip WABA auto-resolve (needed only if the token
+ *                             spans several WABAs and WHATSAPP_PHONE_NUMBER_ID
+ *                             isn't set to disambiguate)
+ *   WHATSAPP_PHONE_NUMBER_ID  used to pick the right WABA when several match
+ *   META_GRAPH_API_VERSION    default v21.0 (matches whatsappService.js)
+ */
+
+import { pathToFileURL } from 'node:url';
+
+const VERSION = process.env.META_GRAPH_API_VERSION || 'v21.0';
+const BASE = `https://graph.facebook.com/${VERSION}`;
+
+// Language must stay 'en' — whatsappService sends language.code from
+// WHATSAPP_TEMPLATE_LANG which defaults to 'en'; a template approved only as
+// en_US would make every send 404 with error 132001 (template not found).
+const LANGUAGE = 'en';
+
+const FOOTER = 'MKTR Pte. Ltd. · Reply STOP to unsubscribe';
+const STOP_BUTTON = { type: 'QUICK_REPLY', text: 'Stop promotions' };
+
+// Dynamic-suffix URL button: {{1}} carries path + query, so one shape serves
+// campaign pages, draws, and the marketplace, including utm tags for
+// pushmeasure. Example values must be the fully expanded URL.
+const cta = (text, exampleSuffix) => ({
+  type: 'URL',
+  text,
+  url: 'https://redeem.sg/{{1}}',
+  example: [`https://redeem.sg/${exampleSuffix}`],
+});
+
+export const TEMPLATES = [
+  {
+    name: 'marketing_new_campaign',
+    language: LANGUAGE,
+    category: 'MARKETING',
+    allow_category_change: true,
+    components: [
+      {
+        type: 'HEADER',
+        format: 'TEXT',
+        text: 'New reward: {{1}}',
+        example: { header_text: ['FairPrice $20 Voucher'] },
+      },
+      {
+        type: 'BODY',
+        text:
+          "Hi {{1}}, a new reward just went live on Redeem — {{2}}, from {{3}}. Quantities are limited and it's first come, first served.\n\nTap below to view the reward and claim yours in about a minute.",
+        example: {
+          body_text: [['Shawn', 'a $20 FairPrice voucher for new sign-ups', 'FairPrice']],
+        },
+      },
+      { type: 'FOOTER', text: FOOTER },
+      {
+        type: 'BUTTONS',
+        buttons: [
+          cta('View reward', 'LeadCapture?campaign_id=1a2b3c4d&utm_source=wa_push'),
+          STOP_BUTTON,
+        ],
+      },
+    ],
+  },
+  {
+    name: 'marketing_new_draw',
+    language: LANGUAGE,
+    category: 'MARKETING',
+    allow_category_change: true,
+    components: [
+      {
+        type: 'HEADER',
+        format: 'TEXT',
+        text: 'Lucky draw: {{1}}',
+        example: { header_text: ['Tokyo Getaway'] },
+      },
+      {
+        type: 'BODY',
+        text:
+          'Hi {{1}}, the {{2}} is open for entries — stand a chance to win {{3}}. Entries close {{4}}, and entering takes about a minute.\n\nGood luck 🍀',
+        example: {
+          body_text: [['Shawn', 'Tokyo Getaway Lucky Draw', 'a 4D3N trip for two to Tokyo', '30 Oct 2026']],
+        },
+      },
+      { type: 'FOOTER', text: FOOTER },
+      {
+        type: 'BUTTONS',
+        buttons: [
+          cta('Enter the draw', 'LeadCapture?campaign_id=85b78a81&utm_source=wa_push'),
+          STOP_BUTTON,
+        ],
+      },
+    ],
+  },
+  {
+    name: 'marketing_offer',
+    language: LANGUAGE,
+    category: 'MARKETING',
+    allow_category_change: true,
+    components: [
+      {
+        type: 'HEADER',
+        format: 'TEXT',
+        text: 'A little something for you',
+      },
+      {
+        type: 'BODY',
+        text:
+          "Hi {{1}}, here's something we think you'll like: {{2}}. {{3}}.\n\nTap below to see the details — it takes less than a minute.",
+        example: {
+          body_text: [['Shawn', 'a $10 GrabFood voucher when you sign up this week', 'Available while stocks last']],
+        },
+      },
+      { type: 'FOOTER', text: FOOTER },
+      {
+        type: 'BUTTONS',
+        buttons: [
+          cta('See details', 'LeadCapture?campaign_id=1a2b3c4d&utm_source=wa_push'),
+          STOP_BUTTON,
+        ],
+      },
+    ],
+  },
+];
+
+const OUR_NAMES = new Set(TEMPLATES.map((t) => t.name));
+
+async function graphGet(path, token) {
+  const res = await fetch(`${BASE}${path}`, { headers: { Authorization: `Bearer ${token}` } });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const e = json?.error;
+    throw new Error(`GET ${path.split('?')[0]} → ${res.status}${e ? ` ${e.code}: ${e.message}` : ''}`);
+  }
+  return json;
+}
+
+/**
+ * WABA id: env override → debug_token granular scopes. With several WABAs on
+ * the token, WHATSAPP_PHONE_NUMBER_ID picks the one that owns our sender.
+ */
+async function resolveWabaId(token) {
+  if (process.env.WHATSAPP_WABA_ID) return process.env.WHATSAPP_WABA_ID;
+  const dbg = await graphGet(`/debug_token?input_token=${encodeURIComponent(token)}`, token);
+  const scopes = dbg?.data?.granular_scopes || [];
+  const ids = [
+    ...new Set(
+      scopes
+        .filter((s) => ['whatsapp_business_management', 'whatsapp_business_messaging'].includes(s.scope))
+        .flatMap((s) => s.target_ids || []),
+    ),
+  ];
+  if (ids.length === 1) return ids[0];
+  const phoneId = process.env.WHATSAPP_PHONE_NUMBER_ID;
+  if (ids.length > 1 && phoneId) {
+    for (const id of ids) {
+      const phones = await graphGet(`/${id}/phone_numbers?fields=id&limit=50`, token).catch(() => null);
+      if (phones?.data?.some((p) => p.id === phoneId)) return id;
+    }
+  }
+  throw new Error(
+    ids.length
+      ? `Token spans ${ids.length} WABAs (${ids.join(', ')}) — set WHATSAPP_WABA_ID or WHATSAPP_PHONE_NUMBER_ID.`
+      : 'Could not auto-resolve the WABA from the token — set WHATSAPP_WABA_ID (WhatsApp Manager URL shows it as asset_id).',
+  );
+}
+
+async function fetchExisting(wabaId, token) {
+  const json = await graphGet(
+    `/${wabaId}/message_templates?fields=name,status,category,language,quality_score,rejected_reason&limit=200`,
+    token,
+  );
+  return json?.data || [];
+}
+
+function printStatusTable(existing) {
+  const byName = new Map(existing.filter((t) => OUR_NAMES.has(t.name)).map((t) => [t.name, t]));
+  for (const t of TEMPLATES) {
+    const row = byName.get(t.name);
+    if (!row) {
+      console.log(`  ${t.name.padEnd(24)} NOT SUBMITTED`);
+    } else {
+      const extra = [
+        row.category !== 'MARKETING' ? `category=${row.category}` : null,
+        row.rejected_reason && row.rejected_reason !== 'NONE' ? `reason=${row.rejected_reason}` : null,
+        row.quality_score?.score ? `quality=${row.quality_score.score}` : null,
+      ].filter(Boolean).join(' ');
+      console.log(`  ${t.name.padEnd(24)} ${row.status}${extra ? `  (${extra})` : ''}`);
+    }
+  }
+  const sanity = existing.some((t) => ['reward_pass', 'reward_voucher'].includes(t.name));
+  console.log(
+    sanity
+      ? '  ✓ reward_pass/reward_voucher present — this is the Redeem sender WABA'
+      : '  ⚠ reward_pass/reward_voucher NOT on this WABA — check you are on the Redeem sender WABA',
+  );
+}
+
+async function main() {
+  const dry = process.argv.includes('--dry');
+  const statusOnly = process.argv.includes('--status');
+
+  if (dry) {
+    console.log(JSON.stringify(TEMPLATES, null, 2));
+    return;
+  }
+
+  const token = process.env.WHATSAPP_TOKEN;
+  if (!token) {
+    console.error(
+      'WHATSAPP_TOKEN not set. Copy it from Render → mktr-backend-jo6r → Environment → WHATSAPP_TOKEN, then:\n' +
+        '  WHATSAPP_TOKEN=… node backend/scripts/submit-wa-marketing-templates.mjs',
+    );
+    process.exit(1);
+  }
+
+  const wabaId = await resolveWabaId(token);
+  console.log(`WABA ${wabaId} (Graph ${VERSION})`);
+  let existing = await fetchExisting(wabaId, token);
+
+  if (statusOnly) {
+    printStatusTable(existing);
+    return;
+  }
+
+  const have = new Set(existing.filter((t) => t.language === LANGUAGE).map((t) => t.name));
+  let failed = 0;
+  for (const t of TEMPLATES) {
+    if (have.has(t.name)) {
+      console.log(`  ${t.name} already on the WABA — skipped (idempotent)`);
+      continue;
+    }
+    const res = await fetch(`${BASE}/${wabaId}/message_templates`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(t),
+    });
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      failed += 1;
+      const e = json?.error;
+      console.error(`  ✗ ${t.name} — ${e?.code || res.status}: ${e?.error_user_msg || e?.message || 'submit failed'}`);
+    } else {
+      console.log(`  ✓ ${t.name} submitted — id ${json.id}, status ${json.status}${json.category !== 'MARKETING' ? `, category ${json.category}` : ''}`);
+    }
+  }
+
+  console.log('\nCurrent status on the WABA:');
+  existing = await fetchExisting(wabaId, token);
+  printStatusTable(existing);
+  console.log('\nApproval is usually minutes-to-hours (Meta SLA: up to 24h). Poll with --status.');
+  if (failed) process.exit(1);
+}
+
+// Guarded so tests/tooling can import TEMPLATES without triggering a run.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(err?.message || err);
+    process.exit(1);
+  });
+}

--- a/docs/plans/wa-marketing-template-pack.md
+++ b/docs/plans/wa-marketing-template-pack.md
@@ -1,0 +1,137 @@
+# WhatsApp MARKETING template pack — cohort pushes (`watemplates`)
+
+**Status:** drafted 2026-07-22 · submission pending (creds are Render-only — see §5) · Meta approval external
+**Submission tool:** `backend/scripts/submit-wa-marketing-templates.mjs` (the canonical JSON lives there; `--dry` prints it)
+**Consumers:** `wapush` (WhatsApp option on the cohort Push button, rides `whatsappService.js` + the email-broadcast runner) and `pushmeasure` (utm contract on the CTA button)
+
+## 1. Scope & where these live
+
+Three English MARKETING templates for curated cohort pushes: **new-campaign push**, **new-draw push**, and a **generic offer**. They are submitted to the **dedicated Redeem WABA** — the one that already holds the approved UTILITY templates `reward_pass` / `reward_voucher` and whose creds the backend uses as `WHATSAPP_TOKEN` / `WHATSAPP_PHONE_NUMBER_ID` (see `envValidation.js`). Do **not** submit them under the OTP setup (`META_WA_*`) — that is a different sender.
+
+Locked-in conventions (must match `whatsappService.js`):
+
+| Convention | Value | Why |
+|---|---|---|
+| Language | `en` (plain "English", **not** "English (US)") | `WHATSAPP_TEMPLATE_LANG` defaults to `en`; an `en_US`-only approval makes every send fail with error 132001 template-not-found |
+| Graph version | `v21.0` | `META_GRAPH_VERSION` default |
+| Header style | TEXT (no image) | Marketing sends don't have a per-customer QR; text headers approve faster and need no media upload at send time |
+| Names | `marketing_new_campaign` · `marketing_new_draw` · `marketing_offer` | Same terse snake style as `reward_pass`; the `marketing_` prefix makes the category obvious in Manager and in future env defaults |
+
+## 2. The three templates
+
+The exact submission payloads are in the script (single source of truth). Human-readable view:
+
+### 2.1 `marketing_new_campaign` — a new reward campaign is live
+
+> **New reward: FairPrice $20 Voucher**
+>
+> Hi Shawn, a new reward just went live on Redeem — a $20 FairPrice voucher for new sign-ups, from FairPrice. Quantities are limited and it's first come, first served.
+>
+> Tap below to view the reward and claim yours in about a minute.
+>
+> _MKTR Pte. Ltd. · Reply STOP to unsubscribe_
+>
+> **[ View reward ]** **[ Stop promotions ]**
+
+| Slot | Content | Variables |
+|---|---|---|
+| Header (TEXT) | `New reward: {{1}}` | {{1}} campaign/reward title |
+| Body | `Hi {{1}}, a new reward just went live on Redeem — {{2}}, from {{3}}. Quantities are limited and it's first come, first served.` ¶ `Tap below to view the reward and claim yours in about a minute.` | {{1}} first name · {{2}} offer one-liner (lowercase, mid-sentence) · {{3}} partner name |
+| Footer | `MKTR Pte. Ltd. · Reply STOP to unsubscribe` | — |
+| Button 1 (URL) | `View reward` → `https://redeem.sg/{{1}}` | {{1}} path+query suffix |
+| Button 2 (quick reply) | `Stop promotions` | — |
+
+### 2.2 `marketing_new_draw` — a lucky draw is open
+
+> **Lucky draw: Tokyo Getaway**
+>
+> Hi Shawn, the Tokyo Getaway Lucky Draw is open for entries — stand a chance to win a 4D3N trip for two to Tokyo. Entries close 30 Oct 2026, and entering takes about a minute.
+>
+> Good luck 🍀
+>
+> _MKTR Pte. Ltd. · Reply STOP to unsubscribe_
+>
+> **[ Enter the draw ]** **[ Stop promotions ]**
+
+| Slot | Content | Variables |
+|---|---|---|
+| Header (TEXT) | `Lucky draw: {{1}}` | {{1}} draw short name |
+| Body | `Hi {{1}}, the {{2}} is open for entries — stand a chance to win {{3}}. Entries close {{4}}, and entering takes about a minute.` ¶ `Good luck 🍀` | {{1}} first name · {{2}} full draw name · {{3}} prize phrase · {{4}} close date |
+| Footer / buttons | as 2.1, CTA label `Enter the draw` | |
+
+### 2.3 `marketing_offer` — generic offer (reusable)
+
+> **A little something for you**
+>
+> Hi Shawn, here's something we think you'll like: a $10 GrabFood voucher when you sign up this week. Available while stocks last.
+>
+> Tap below to see the details — it takes less than a minute.
+>
+> _MKTR Pte. Ltd. · Reply STOP to unsubscribe_
+>
+> **[ See details ]** **[ Stop promotions ]**
+
+| Slot | Content | Variables |
+|---|---|---|
+| Header (TEXT, static) | `A little something for you` | — |
+| Body | `Hi {{1}}, here's something we think you'll like: {{2}}. {{3}}.` ¶ `Tap below to see the details — it takes less than a minute.` | {{1}} first name · {{2}} offer one-liner · {{3}} availability/urgency line — **no trailing period** (template adds it) |
+| Footer / buttons | as 2.1, CTA label `See details` | |
+
+## 3. Variable → data contract (for `wapush`)
+
+| Variable | Source | Rules |
+|---|---|---|
+| First name | `prospect.firstName` via `cleanParam(x, 'there')` | cleanParam already strips newlines/URLs and caps at 60 chars — Meta rejects params containing newlines/tabs/4+ spaces |
+| Campaign / draw title | campaign public title (design_config v2 heading or admin name) | ≤60 chars through cleanParam; composer should show a preview |
+| Partner name | `RewardOffer.partner` tradingName → brandName → legalName, fallback `MKTR` | same fallback chain as `offerContextOf` |
+| Prize phrase | draw `prizes[0]` name phrased as "a …" | human-written in the composer, not auto-derived |
+| Close date | `toLocaleDateString('en-SG', { day:'numeric', month:'short', year:'numeric' })` | same formatter as the voucher expiry — "30 Oct 2026" |
+| CTA suffix | `LeadCapture?campaign_id=<id>&utm_source=wa_push&utm_campaign=broadcast-<id8>` | URL button base is `https://redeem.sg/` + suffix; carries the pushmeasure utm contract; matches `customerLeadCaptureUrl` shape |
+
+## 4. Compliance rails baked into the copy
+
+- **Category MARKETING**, submitted with `allow_category_change: true` so Meta recategorizes instead of rejecting on a category dispute.
+- **Opt-out, twice:** footer text `Reply STOP to unsubscribe` **and** a `Stop promotions` quick-reply button (Meta's recommended marketing pattern — protects quality rating). The `wapush` STOP handler must treat **`STOP`, `UNSUBSCRIBE`, and the literal button text `Stop promotions`** (button taps arrive as a plain inbound message of the button text) as opt-out → write a whatsapp-channel suppression to the consent ledger. The inbound message opens a free 24-h service window, so the confirmation reply costs nothing.
+- **Sender identification:** `MKTR Pte. Ltd.` in the footer (Spam Control Act identification requirement; the WABA display name adds the brand).
+- **Audience is consent-gated upstream:** recipients only ever come from a cohort, i.e. `canMarketToBatch` / `canMarketTo purpose:'marketing'` (verified campaign-scoped grant + no suppression + 18+ binding), **plus** the DNC send-time scrub the `wapush` prompt makes binding (§9.5 safeguard — holds until counsel expressly blesses agree-all as a DNC override). The templates assume nothing about the audience beyond that.
+- **Format rules obeyed** (Meta rejects otherwise): body ≤1024 chars, doesn't start/end with a variable, no adjacent variables; header ≤60 chars, ≤1 variable; footer ≤60 chars, no variables; button labels ≤25 chars; every variable ships an example value.
+
+## 5. Submitting — two paths
+
+Creds situation (verified 2026-07-22): `WHATSAPP_TOKEN` exists **only** in Render (`mktr-backend-jo6r` → Environment). No local `.env`, the Render MCP can't read env values, and Render SSH refuses this machine's keys — so submission needs Shawn once, either path, ~3 minutes.
+
+### Path A — script (recommended)
+
+```bash
+# token: Render dashboard → mktr-backend-jo6r → Environment → WHATSAPP_TOKEN (reveal+copy)
+WHATSAPP_TOKEN=… node backend/scripts/submit-wa-marketing-templates.mjs
+```
+
+Idempotent (skips names already on the WABA), auto-resolves the WABA id from the token (`WHATSAPP_WABA_ID` overrides), prints a status table, and sanity-checks it landed on the WABA that holds `reward_pass`. `--dry` prints the payloads without network.
+
+### Path B — WhatsApp Manager (manual)
+
+1. business.facebook.com → **WhatsApp Manager** → pick the MKTR portfolio and the **Redeem WABA** (the account whose template list shows `reward_pass` / `reward_voucher` — that's how you know you're on the right one).
+2. **Message templates → Create template** → Category **Marketing → Custom**.
+3. Name exactly `marketing_new_campaign` (lowercase, underscores). Language **English** — *not* English (US).
+4. Header **Text**, paste from §2, **Add variable** where `{{1}}` appears, fill the sample value.
+5. Paste body and footer; fill a sample for every body variable (samples are mandatory).
+6. Buttons → **Visit website**, label from §2, URL type **Dynamic**, `https://redeem.sg/{{1}}`, sample = a full LeadCapture URL. Then **Custom** quick reply `Stop promotions`.
+7. Submit. Repeat for `marketing_new_draw` and `marketing_offer` (§2.3 has a static header — skip the variable).
+
+## 6. Approval: expected wait & tracking
+
+- **Wait:** review is mostly automated — typically **minutes to a few hours**; Meta's stated SLA is **up to 24 h**. Budget one day; it runs in parallel with everything else (that's why this item ships before `wapush`).
+- **Outcomes:** `PENDING → APPROVED` or `REJECTED` (reason shown in Manager and on the API as `rejected_reason`). Rejected → edit the same template and resubmit (rejected names are editable immediately; approved ones allow 1 edit/24 h, 10/month, each edit re-enters review). Deleting a name blocks reusing it for 30 days — prefer edit over delete.
+- **Tracking:**
+  - `WHATSAPP_TOKEN=… node backend/scripts/submit-wa-marketing-templates.mjs --status` — poll table (status, category, quality, rejection reason).
+  - WhatsApp Manager → Message templates (status column; Meta also emails business admins on decisions).
+  - Optional later: subscribe the app to the `message_template_status_update` webhook field for push notifications — nice-to-have, not needed for three templates.
+- **Hard gate downstream:** `wapush` must verify `status === APPROVED` (script `--status` or a boot-time check) before the WhatsApp channel flag flips. A send against a pending/paused template fails receipted, not silently.
+
+## 7. Ops notes for the send channel
+
+- **Pricing:** SG marketing messages are per-message (rate-card, roughly US$0.07–0.08); confirm the current rate in WhatsApp Manager → Insights before the first big push.
+- **Per-user marketing caps:** Meta frequency-caps marketing templates per recipient across all businesses — send error **131049** means "cap hit, retry later"; `wapush` should receipt it as a soft skip, never a hard failure.
+- **Quality pausing:** poor engagement/blocks can set a template to `PAUSED` (3 h → 6 h → `DISABLED` ladder). The `--status` poll surfaces `quality_score`; cohort curation is the real defence.
+- **TTL:** marketing template messages default to a 30-day delivery window; fine for us.


### PR DESCRIPTION
Tracker item **watemplates** (Phase 3 — cohorts & push).

- 3 EN `MARKETING` templates for cohort pushes: `marketing_new_campaign`, `marketing_new_draw`, `marketing_offer` — TEXT headers, footer `MKTR Pte. Ltd. · Reply STOP to unsubscribe` + `Stop promotions` quick reply, dynamic `https://redeem.sg/{{1}}` CTA (carries `utm_source=wa_push` for pushmeasure). Language pinned `en` (= `WHATSAPP_TEMPLATE_LANG` default — an en_US-only approval would 132001 every send).
- `backend/scripts/submit-wa-marketing-templates.mjs` — canonical payloads; `--dry` / idempotent submit / `--status` poll; auto-resolves the WABA from the token and sanity-checks it's the Redeem WABA (reward_pass co-residency).
- `docs/plans/wa-marketing-template-pack.md` — copy previews, variable→data contract for wapush, compliance rails (opt-out keywords incl. button-text, DNC scrub stance), Manager walkthrough, approval SLA + tracking.

Verification: `node --check` OK; `--dry` payloads machine-lint'd against Meta format constraints (body ≤1024 / no leading-trailing-adjacent vars / header ≤60 ≤1 var / footer ≤60 / button labels ≤25 / ≤2 URL buttons / examples complete) — all pass; no-token error path exercised. No runtime import touches this script — zero impact on jest/vitest surfaces.

Submission + Meta approval are external (token is Render-only): one-command path in the doc §5A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDco6HwKLHpmRgE5YR8Za2