### PR TITLE
fix(lucky-draw): the ×N session boost awards nothing — link the activation

### DIFF
--- a/backend/src/services/campaignReadinessService.js
+++ b/backend/src/services/campaignReadinessService.js
@@ -77,6 +77,8 @@ export function computeReadiness(facts) {
     docDrawClosesAt = null,
     drawRecordClosesAt = null,
     drawTotalPrizes = 0,
+    drawMultiplier = 1,
+    drawHasActiveActivation = true, // SILENT default: absent fact must not cry wolf
   } = facts || {};
 
   // Brand-awareness (PHV tablet) campaigns don't capture leads → readiness N/A.
@@ -219,6 +221,20 @@ export function computeReadiness(facts) {
     });
   }
 
+  // WARNING — the ×N session boost is promised in the draw T&Cs, on the
+  // campaign page, in the marketplace and in the confirmation email, but it is
+  // only awarded against reward entitlements, which hang off a live Activation.
+  // No activation ⇒ every entry seals at one chance and the promise silently
+  // breaks, with `boosted: 0` in the seal log as the only signal — after
+  // entries have closed.
+  if (drawEnabled && drawMultiplier > 1 && !drawHasActiveActivation) {
+    issues.push({
+      level: 'warning',
+      code: 'draw_boost_no_activation',
+      message: `This draw promises ${drawMultiplier}x entries for completing a session, but the campaign has no active Activation — session completions cannot be counted and every entry will seal at one chance. Create/activate the reward activation in Redeem Ops before entries close.`,
+    });
+  }
+
   // INFO — not yet live.
   if (!isActive) {
     issues.push({
@@ -251,7 +267,7 @@ const sgtYmdFromExclusiveInstant = (instant) => {
  * Read-only. Lazy-imports models so the pure export above stays import-light.
  */
 export async function loadCampaignReadiness(campaignId) {
-  const { Campaign, LeadPackage, LeadPackageAssignment, User, Draw } = await import('../models/index.js');
+  const { Campaign, LeadPackage, LeadPackageAssignment, User, Draw, Activation } = await import('../models/index.js');
   const { Op } = await import('sequelize');
 
   const campaign = await Campaign.findByPk(campaignId, {
@@ -328,6 +344,7 @@ export async function loadCampaignReadiness(campaignId) {
   let hasLiveDraw = false;
   let drawIntakeOpen = false;
   let drawCloseMismatch = false;
+  let drawHasActiveActivation = true;
   let docDrawClosesAt = null;
   let drawRecordClosesAt = null;
   if (drawEnabled) {
@@ -337,6 +354,12 @@ export async function loadCampaignReadiness(campaignId) {
       attributes: ['id', 'status', 'closesAt'],
     });
     hasDrawRecord = !!record;
+    // Boost deliverability: entitlements (the boost evidence) hang off a live
+    // Activation, so no activation means the multiplier can never be awarded.
+    drawHasActiveActivation = !!(await Activation.findOne({
+      where: { campaignId, status: 'active' },
+      attributes: ['id'],
+    }));
     hasLiveDraw = !!record && ['open', 'frozen', 'sealed', 'drawn'].includes(record.status);
     const docEndMs = ld?.closesAt ? sgtDayEndExclusiveMs(ld.closesAt) : null;
     docDrawClosesAt = ld?.closesAt || null;
@@ -375,6 +398,8 @@ export async function loadCampaignReadiness(campaignId) {
     docDrawClosesAt,
     drawRecordClosesAt,
     drawTotalPrizes: totalPrizeQuantity(ld),
+    drawMultiplier: Number.isInteger(ld?.multiplier) ? ld.multiplier : 1,
+    drawHasActiveActivation,
   });
 
   return {

--- a/backend/src/services/luckyDrawService.js
+++ b/backend/src/services/luckyDrawService.js
@@ -169,6 +169,16 @@ export function makeLuckyDrawService(overrides = {}) {
         throw new AppError('luckyDraw.activationId does not belong to this campaign', 422);
       }
       activationId = activation.id;
+    } else {
+      // Auto-resolve the campaign's live activation, exactly as entitlement
+      // issuance does. NOTHING in the product ever wrote
+      // design_config.luckyDraw.activationId — no editor, no create flow, no
+      // script — so every draw ever created has had a null activationId, and
+      // collectBoostEvidence short-circuits on that: the ×N session boost was
+      // promised in the T&Cs, on the page, in the marketplace and in the
+      // confirmation email, and awarded nothing.
+      const activation = await d.Activation.findOne({ where: { campaignId, status: 'active' } });
+      if (activation) activationId = activation.id;
     }
 
     try {
@@ -285,13 +295,21 @@ export function makeLuckyDrawService(overrides = {}) {
    * `auto_on_capture` (voucher issued without any meeting) NEVER boosts.
    */
   async function collectBoostEvidence(draw, entries) {
-    if (!draw.activationId) return { byProspect: new Map(), undecidedButtons: [] };
+    // Late-resolve fallback: draws created before their activation existed —
+    // which, until this change, was EVERY draw — carry a null activationId.
+    // Reading the campaign's live activation here rescues those records at
+    // seal/freeze time instead of silently awarding one chance to entrants who
+    // completed a session. Can only ever ADD promised boosts, never remove one.
+    const activationId = draw.activationId
+      || (await d.Activation.findOne({ where: { campaignId: draw.campaignId, status: 'active' } }))?.id
+      || null;
+    if (!activationId) return { byProspect: new Map(), undecidedButtons: [] };
     const prospectIds = entries.map((e) => e.prospectId).filter(Boolean);
     if (prospectIds.length === 0) return { byProspect: new Map(), undecidedButtons: [] };
 
     const entitlements = await d.RewardEntitlement.findAll({
       where: {
-        activationId: draw.activationId,
+        activationId,
         prospectId: { [Op.in]: prospectIds },
         issuedVia: { [Op.ne]: 'manual' },
       },

--- a/backend/src/tests/campaignReadiness.test.js
+++ b/backend/src/tests/campaignReadiness.test.js
@@ -236,3 +236,45 @@ describe('campaignReadinessService.computeReadiness', () => {
     expect(complete.issues).toHaveLength(0);
   });
 });
+
+describe('draw boost deliverability (draw_boost_no_activation)', () => {
+  // Local fixture — the suite's `healthy` is scoped to the describe above.
+  const healthy = {
+    type: 'lead_generation',
+    isActive: true,
+    assignableAgents: 3,
+    agentsMissingPhone: 0,
+    webhookEnabled: true,
+    verificationChannel: 'sms',
+    smsOtpConfigured: true,
+  };
+  const drawBase = { ...healthy, drawEnabled: true, drawMultiplier: 10 };
+
+  it('a multiplier with no active Activation warns — the boost cannot be awarded', () => {
+    const r = computeReadiness({ ...drawBase, drawHasActiveActivation: false });
+    const issue = r.issues.find((i) => i.code === 'draw_boost_no_activation');
+    expect(issue).toBeDefined();
+    expect(issue.level).toBe('warning');
+    expect(issue.message).toContain('10x entries');
+  });
+
+  it('an active Activation is silent', () => {
+    const r = computeReadiness({ ...drawBase, drawHasActiveActivation: true });
+    expect(r.issues.find((i) => i.code === 'draw_boost_no_activation')).toBeUndefined();
+  });
+
+  it('a 1x draw has no boost to promise, so no warning', () => {
+    const r = computeReadiness({ ...drawBase, drawMultiplier: 1, drawHasActiveActivation: false });
+    expect(r.issues.find((i) => i.code === 'draw_boost_no_activation')).toBeUndefined();
+  });
+
+  it('a missing fact stays SILENT rather than crying wolf on every draw', () => {
+    const r = computeReadiness({ ...drawBase }); // drawHasActiveActivation absent
+    expect(r.issues.find((i) => i.code === 'draw_boost_no_activation')).toBeUndefined();
+  });
+
+  it('non-draw campaigns are unaffected', () => {
+    const r = computeReadiness({ ...healthy, drawMultiplier: 10, drawHasActiveActivation: false });
+    expect(r.issues.find((i) => i.code === 'draw_boost_no_activation')).toBeUndefined();
+  });
+});

--- a/backend/test/luckyDrawService.test.js
+++ b/backend/test/luckyDrawService.test.js
@@ -119,7 +119,7 @@ function buildDeps({ draw = null, prospects = [], entries = [], attempts = [], r
       Draw, DrawEntry, DrawAttempt, DrawBoostReview,
       Campaign: { findByPk: jest.fn().mockResolvedValue(null) },
       Prospect: { findAll: jest.fn().mockResolvedValue(prospects) },
-      Activation: { findByPk: jest.fn().mockResolvedValue(null) },
+      Activation: { findByPk: jest.fn().mockResolvedValue(null), findOne: jest.fn().mockResolvedValue(null) },
       RewardEntitlement: { findAll: jest.fn().mockResolvedValue(entitlements), findByPk: jest.fn().mockResolvedValue({ id: 'ent-x', prospectId: 'pros-x' }) },
       RedemptionEvent: { findAll: jest.fn().mockResolvedValue(events) },
       sequelize: { transaction: jest.fn().mockImplementation(async (cb) => cb({})) },
@@ -528,5 +528,46 @@ describe('verifyDraw', () => {
     // …but the attempt's committed eligible set visibly changed.
     expect(report.ok).toBe(false);
     expect(report.checks.some((c) => c.check.includes('eligibleSet') && !c.ok)).toBe(true);
+  });
+});
+
+describe('session boost — the activation link that was never written', () => {
+  it('createDraw auto-resolves the campaign live activation when the config names none', async () => {
+    const { deps } = buildDeps();
+    deps.Campaign.findByPk.mockResolvedValue({
+      id: CAMPAIGN_ID,
+      design_config: { luckyDraw: { enabled: true, closesAt: '2026-09-02', multiplier: 10 } },
+    });
+    deps.Activation.findOne.mockResolvedValue({ id: 'act-auto', campaignId: CAMPAIGN_ID });
+    const svc = makeLuckyDrawService(deps);
+    const draw = await svc.createDraw({ campaignId: CAMPAIGN_ID }, ADMIN);
+    expect(deps.Activation.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { campaignId: CAMPAIGN_ID, status: 'active' } })
+    );
+    expect(draw.activationId).toBe('act-auto');
+  });
+
+  it('no active activation still creates the draw (activationId stays null)', async () => {
+    const { deps } = buildDeps();
+    deps.Campaign.findByPk.mockResolvedValue({
+      id: CAMPAIGN_ID,
+      design_config: { luckyDraw: { enabled: true, closesAt: '2026-09-02', multiplier: 10 } },
+    });
+    deps.Activation.findOne.mockResolvedValue(null);
+    const svc = makeLuckyDrawService(deps);
+    const draw = await svc.createDraw({ campaignId: CAMPAIGN_ID }, ADMIN);
+    expect(draw.activationId).toBe(null);
+  });
+
+  it('an EXPLICIT activationId still wins and is still ownership-checked', async () => {
+    const { deps } = buildDeps();
+    deps.Campaign.findByPk.mockResolvedValue({
+      id: CAMPAIGN_ID,
+      design_config: { luckyDraw: { enabled: true, closesAt: '2026-09-02', activationId: 'act-9' } },
+    });
+    deps.Activation.findByPk.mockResolvedValue({ id: 'act-9', campaignId: 'SOMEONE-ELSE' });
+    const svc = makeLuckyDrawService(deps);
+    await expect(svc.createDraw({ campaignId: CAMPAIGN_ID }, ADMIN)).rejects.toMatchObject({ statusCode: 422 });
+    expect(deps.Activation.findOne).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## The gap

The session boost is promised in four places — the pinned draw T&Cs (*"earns you 10 entries instead of one"*), the campaign page, the marketplace offer, and the confirmation email.

It awards nothing.

`collectBoostEvidence` opens with `if (!draw.activationId) return { byProspect: new Map(), … }`. That id comes only from `design_config.luckyDraw.activationId` — and **nothing in the product has ever written it**: no editor, no create flow, no script, zero hits outside models and migrations. Every draw ever created carries a null `activationId`.

So: consultants run sessions, entitlements get issued, `sealDraw` finds no evidence, every entry seals at one chance, and the winner comes from an unweighted pool. The only signal is `boosted: 0` in the seal log — *after* entries have closed.

## The fix

- **`createDraw`** auto-resolves the campaign's live activation when the config names none — the same `Activation.findOne({campaignId, status:'active'})` that entitlement issuance already uses. An explicit `activationId` still wins and is still ownership-checked (422 on mismatch).
- **`collectBoostEvidence`** late-resolves the same way when `draw.activationId` is null, rescuing records created before their activation existed. It can only ever **add** boosts that were already promised; it can never remove one.
- **Readiness** gains `draw_boost_no_activation`: a draw promising a multiplier with no active Activation now says so in the Launch tab, before entries close. Warning, not block — leads still deliver. The fact defaults silent so an absent fact never cries wolf.

## Prod state — checked, and better than feared

Neither live draw campaign has a `draws` record yet, so **nothing has been sealed wrongly**. The bug would have bitten at draw-creation/seal time:

| Campaign | Status | Multiplier | Active activations | Draw record |
|---|---|---|---|---|
| Tokyo Getaway Lucky Draw | active | 10× | **1** | none |
| iPhone 17 Pro Lucky Draw, August 2026 | draft | 10× | **0** | none |

Tokyo is fine once this merges — `createDraw` will resolve its activation automatically. The iPhone draw promises 10× with **no activation at all**, so it needs one created in Redeem Ops before entries open; the new readiness warning is what will surface that.

## Tests

+3 draw-service (auto-resolve, no-activation-still-creates, explicit-id-still-checked), +5 readiness (warns / silent when active / silent at 1× / silent when fact absent / non-draw unaffected). 7 suites, 160 green.

`test/unit/shortlinkService.test.js` fails identically on clean `origin/main` — inherited and unrelated (its `models/index.js` mock lacks a `Prospect` export). Verified by stashing this branch's changes and re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEWmDbzT8RbS2LNEt9Y5bk
