### PR TITLE
feat(taxonomy): one-source campaign categories + Studio section + cohort filter

### DIFF
--- a/backend/src/routes/cohorts.js
+++ b/backend/src/routes/cohorts.js
@@ -2,6 +2,7 @@ import express from 'express';
 import Joi from 'joi';
 import { authenticateToken, requireAdmin } from '../middleware/auth.js';
 import { validate } from '../middleware/validation.js';
+import { CONSUMER_CATEGORIES } from '../utils/marketplaceContent.js';
 import * as cohortController from '../controllers/cohortController.js';
 
 export const meta = { path: '/api/cohorts' };
@@ -26,6 +27,9 @@ const definitionSchema = Joi.object({
     drawIds: Joi.array().items(uuid).max(50),
     anyDraw: Joi.boolean(),
     campaignTags: Joi.array().items(shortStr(64)).max(20),
+    campaignCategories: Joi.array()
+      .items(Joi.string().valid(...CONSUMER_CATEGORIES))
+      .max(CONSUMER_CATEGORIES.length),
     attributes: Joi.object({
       postalPrefixes: Joi.array().items(Joi.string().pattern(/^[0-9]{2,6}$/)).max(20),
       incomes: Joi.array().items(shortStr(64)).max(20),

--- a/backend/src/services/cohortService.js
+++ b/backend/src/services/cohortService.js
@@ -1,6 +1,8 @@
 import { sequelize, Cohort, Campaign } from '../models/index.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
+import { CONSUMER_CATEGORIES, CONSUMER_CATEGORY_DEFS } from '../utils/marketplaceContent.js';
+import { getStoredCategory } from '../utils/designConfigV2Clamp.js';
 
 /**
  * Cohort builder (tracker "cohortapi", docs/plans/cohort-builder-backend.md).
@@ -48,6 +50,11 @@ import { logger } from '../utils/logger.js';
  *  - campaigns.tags is unchecked TEXT holding JSON; it is parsed in JS
  *    (malformed rows are skipped) and NEVER cast to jsonb in SQL, where one
  *    bad row would abort the whole cohort query.
+ *  - campaignCategories (tracker "taxonomy") resolves the same way: campaign
+ *    design_configs are read in JS through the version-aware getStoredCategory
+ *    (v1 flat `category` / v2 `distribution.marketplace.category`), never cast
+ *    in SQL. Values are validated against CONSUMER_CATEGORIES — the taxonomy
+ *    has exactly one definition (utils/marketplaceContent.js).
  */
 
 export const COHORT_CHANNELS = ['all', 'email', 'whatsapp', 'sms', 'voice'];
@@ -61,7 +68,11 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 const TAG_RE = /^[^\s]([\s\S]{0,62}[^\s])?$/; // 1..64 chars, no leading/trailing whitespace
 const POSTAL_PREFIX_RE = /^[0-9]{2,6}$/;
 
-const MAX_LIST = { campaignIds: 50, drawIds: 50, campaignTags: 20, postalPrefixes: 20, incomes: 20, educations: 20, genders: 10 };
+const MAX_LIST = {
+  campaignIds: 50, drawIds: 50, campaignTags: 20,
+  campaignCategories: CONSUMER_CATEGORIES.length,
+  postalPrefixes: 20, incomes: 20, educations: 20, genders: 10,
+};
 
 function cleanStringList(value, { max, re, label }) {
   if (value === undefined || value === null) return [];
@@ -94,11 +105,19 @@ export function normalizeDefinition(definition) {
   const a = f.attributes || {};
   if (typeof a !== 'object' || Array.isArray(a)) throw new AppError('filters.attributes must be an object', 422);
 
+  const campaignCategories = cleanStringList(f.campaignCategories, { max: MAX_LIST.campaignCategories, re: TAG_RE, label: 'filters.campaignCategories' });
+  for (const cat of campaignCategories) {
+    if (!CONSUMER_CATEGORIES.includes(cat)) {
+      throw new AppError(`filters.campaignCategories entry "${cat.slice(0, 40)}" is not a known category`, 422);
+    }
+  }
+
   const filters = {
     campaignIds: cleanStringList(f.campaignIds, { max: MAX_LIST.campaignIds, re: UUID_RE, label: 'filters.campaignIds' }),
     drawIds: cleanStringList(f.drawIds, { max: MAX_LIST.drawIds, re: UUID_RE, label: 'filters.drawIds' }),
     anyDraw: f.anyDraw === true,
     campaignTags: cleanStringList(f.campaignTags, { max: MAX_LIST.campaignTags, re: TAG_RE, label: 'filters.campaignTags' }),
+    campaignCategories,
     attributes: {
       postalPrefixes: cleanStringList(a.postalPrefixes, { max: MAX_LIST.postalPrefixes, re: POSTAL_PREFIX_RE, label: 'filters.attributes.postalPrefixes' }),
       incomes: cleanStringList(a.incomes, { max: MAX_LIST.incomes, re: TAG_RE, label: 'filters.attributes.incomes' }),
@@ -209,6 +228,18 @@ async function buildResolution(d, def, channel) {
       conds.push(`EXISTS (
         SELECT 1 FROM prospects tp
          WHERE tp."consumerId" = c.id AND tp."campaignId" IN (:tagCampaignIds))`);
+    }
+  }
+
+  if (filters.campaignCategories.length) {
+    const categoryCampaignIds = await resolveCategoryCampaignIds(d, filters.campaignCategories);
+    if (!categoryCampaignIds.length) {
+      conds.push('false'); // categories no campaign carries → empty cohort, loudly countable
+    } else {
+      repl.categoryCampaignIds = categoryCampaignIds;
+      conds.push(`EXISTS (
+        SELECT 1 FROM prospects catp
+         WHERE catp."consumerId" = c.id AND catp."campaignId" IN (:categoryCampaignIds))`);
     }
   }
 
@@ -337,6 +368,30 @@ async function resolveTagCampaignIds(d, tags) {
     if (Array.isArray(parsed) && parsed.some((t) => typeof t === 'string' && wanted.has(t))) {
       out.push(r.id);
     }
+  }
+  return out;
+}
+
+/** design_config arrives parsed (JSON column) but old rows can be strings or
+ * garbage — normalize defensively, then read the version-aware key. */
+function storedCategoryOf(rawDesignConfig) {
+  let dc = rawDesignConfig;
+  if (typeof dc === 'string') {
+    try { dc = JSON.parse(dc); } catch { return undefined; }
+  }
+  return getStoredCategory(dc);
+}
+
+/** Campaign taxonomy analog of resolveTagCampaignIds: categories live inside
+ * design_config (v1 root / v2 distribution.marketplace), so they are read in
+ * JS through the same accessor every other reader uses — never cast in SQL. */
+async function resolveCategoryCampaignIds(d, categories) {
+  const rows = await d.Campaign.findAll({ attributes: ['id', 'design_config'], raw: true });
+  const wanted = new Set(categories);
+  const out = [];
+  for (const r of rows) {
+    const cat = storedCategoryOf(r.design_config);
+    if (cat && wanted.has(cat)) out.push(r.id);
   }
   return out;
 }
@@ -553,9 +608,12 @@ export function makeCohortService(overrides = {}) {
       distinctVals('income'), distinctVals('education'), distinctVals('gender'),
     ]);
 
-    const campaigns = await d.Campaign.findAll({ attributes: ['id', 'name', 'tags', 'status'], raw: true });
+    const campaigns = await d.Campaign.findAll({ attributes: ['id', 'name', 'tags', 'status', 'design_config'], raw: true });
     const tagSet = new Set();
+    const categoryCounts = new Map();
     for (const r of campaigns) {
+      const cat = storedCategoryOf(r.design_config);
+      if (cat) categoryCounts.set(cat, (categoryCounts.get(cat) || 0) + 1);
       if (typeof r.tags !== 'string' || !r.tags) continue;
       try {
         const parsed = JSON.parse(r.tags);
@@ -571,7 +629,16 @@ export function makeCohortService(overrides = {}) {
     return {
       attributes: { incomes, educations, genders },
       campaignTags: [...tagSet].sort(),
-      campaigns: campaigns.map((r) => ({ id: r.id, name: r.name, status: r.status })),
+      // The FULL taxonomy, not just categories in use — a definition may
+      // pre-select a category future campaigns will carry; counts let the UI
+      // show which are live today.
+      campaignCategories: CONSUMER_CATEGORY_DEFS.map(({ id, label }) => ({
+        id, label, count: categoryCounts.get(id) || 0,
+      })),
+      campaigns: campaigns.map((r) => ({
+        id: r.id, name: r.name, status: r.status,
+        category: storedCategoryOf(r.design_config) || null,
+      })),
       draws,
     };
   }

--- a/backend/src/utils/designConfigV2Clamp.js
+++ b/backend/src/utils/designConfigV2Clamp.js
@@ -94,6 +94,15 @@ export function getStoredMarketplaceListed(doc) {
   return classifyDesignConfigVersion(doc) === 'v2' ? doc.distribution?.marketplace?.listed : doc.marketplaceListed;
 }
 
+/** Campaign taxonomy category (tracker "taxonomy") — save paths keep it valid
+ * (normalizeMarketplaceContent enum-drops anything else), so readers get a
+ * CONSUMER_CATEGORIES id or undefined. */
+export function getStoredCategory(doc) {
+  if (!isPlainObject(doc)) return undefined;
+  const raw = classifyDesignConfigVersion(doc) === 'v2' ? doc.distribution?.marketplace?.category : doc.category;
+  return typeof raw === 'string' && raw ? raw : undefined;
+}
+
 export function getStoredLuckyDraw(doc) {
   // Top-level in BOTH versions (admin-API-managed, editor-invisible).
   return isPlainObject(doc) ? doc.luckyDraw : undefined;

--- a/backend/src/utils/marketplaceContent.js
+++ b/backend/src/utils/marketplaceContent.js
@@ -13,18 +13,40 @@
  * is_active/status alone must never publish a campaign).
  */
 
-export const CONSUMER_CATEGORIES = [
-  'art_creativity',
-  'coding_robotics',
-  'speech_performance',
-  'sports_movement',
-  'music_dance',
-  'academic',
-  'family_lifestyle',
-  'wellness',
-  'dining',
-  'financial_education',
+/**
+ * THE campaign taxonomy (tracker "taxonomy") — the ONLY place a consumer
+ * category is added or removed. Everything else derives from this array:
+ *  - backend validation (CONSUMER_CATEGORIES → normalizeMarketplaceContent,
+ *    the v2 clamp, and the /api/cohorts campaignCategories filter)
+ *  - marketplace nav, /c/:id routes and labels (src/pages/marketplace/content.js)
+ *  - Studio + classic editor pickers and AI pick rows
+ *    (src/components/studio/marketplaceOptions.js)
+ *  - cohort facet vocabulary (cohortService.getCohortFacets)
+ *
+ * Stored on campaigns as design_config.category (v1 flat) /
+ * design_config.distribution.marketplace.category (v2) — read cross-version
+ * via getStoredCategory (designConfigV2Clamp.js). NOT the same taxonomy as
+ * Redeem Ops' partner categories (redeemOps/categoryService — admin-managed
+ * DB rows for partner CRM / Discover verticals); the two serve different
+ * domains on purpose.
+ */
+export const CONSUMER_CATEGORY_DEFS = [
+  { id: 'art_creativity', label: 'Art & Creativity', group: 'education', blurb: 'Drawing, painting and portfolio discovery' },
+  { id: 'coding_robotics', label: 'Coding & Robotics', group: 'education', blurb: 'Build, program and problem-solve' },
+  { id: 'speech_performance', label: 'Speech & Performance', group: 'education', blurb: 'Confidence on stage and in class' },
+  { id: 'sports_movement', label: 'Sports & Movement', group: 'education', blurb: 'Swim, play and move well' },
+  { id: 'music_dance', label: 'Music & Dance', group: 'education', blurb: 'Instruments, voice and rhythm' },
+  { id: 'academic', label: 'Academic', group: 'education', blurb: 'Diagnostics and subject support' },
+  { id: 'family_lifestyle', label: 'Family & Lifestyle', group: 'lifestyle', blurb: 'Experiences to share together' },
+  { id: 'wellness', label: 'Wellness', group: 'lifestyle', blurb: 'Self-care that earns its slot' },
+  { id: 'dining', label: 'Dining', group: 'lifestyle', blurb: 'Tables worth booking' },
+  { id: 'financial_education', label: 'Financial Education', group: 'lifestyle', blurb: 'Understand your money better' },
 ];
+
+export const CONSUMER_CATEGORIES = CONSUMER_CATEGORY_DEFS.map((c) => c.id);
+
+export const consumerCategoryLabel = (id) =>
+  CONSUMER_CATEGORY_DEFS.find((c) => c.id === id)?.label || id;
 
 export const OFFER_TYPES = ['trial', 'assessment', 'workshop', 'reward', 'consultation'];
 export const MODES = ['physical', 'online', 'hybrid'];

--- a/backend/test/cohortRoutes.test.js
+++ b/backend/test/cohortRoutes.test.js
@@ -208,3 +208,22 @@ describe('CRUD lifecycle', () => {
     expect(res.status).toBe(404);
   });
 });
+
+describe('campaignCategories filter (tracker "taxonomy")', () => {
+  test('preview accepts a known category id', async () => {
+    const res = await request(app)
+      .post('/api/cohorts/preview')
+      .set(auth(adminToken))
+      .send({ definition: { filters: { campaignCategories: ['dining'] } } });
+    expect(res.status).toBe(200);
+    expect(res.body.data.definition.filters.campaignCategories).toEqual(['dining']);
+  });
+
+  test('unknown category ids are a loud 400 at the boundary', async () => {
+    const res = await request(app)
+      .post('/api/cohorts/preview')
+      .set(auth(adminToken))
+      .send({ definition: { filters: { campaignCategories: ['bogus'] } } });
+    expect(res.status).toBe(400);
+  });
+});

--- a/backend/test/cohortService.test.js
+++ b/backend/test/cohortService.test.js
@@ -484,3 +484,71 @@ describe('definition hygiene', () => {
     expect(() => normalizeDefinition({ filters: { attributes: { postalPrefixes: ['52%'] } } })).toThrow(/invalid/);
   });
 });
+
+describe('campaignCategories (tracker "taxonomy")', () => {
+  // Category ids chosen to be UNIQUE to this suite (no other test file
+  // creates campaigns carrying them) so exact member sets stay deterministic
+  // with parallel jest workers on the shared DB.
+  let campCatV1; let campCatV2;
+
+  beforeAll(async () => {
+    campCatV1 = await createTestCampaign(admin.user.id, {
+      name: `Cohort Cat V1 ${RUN}`,
+      design_config: { category: 'speech_performance' }, // v1 flat key
+    });
+    campCatV2 = await createTestCampaign(admin.user.id, {
+      name: `Cohort Cat V2 ${RUN}`,
+      // v2 shape — the category lives under distribution.marketplace
+      design_config: { version: 2, distribution: { marketplace: { category: 'coding_robotics' } } },
+    });
+    await makeConsumer('CAT_SPEECH');
+    await signup(C.CAT_SPEECH, campCatV1);
+    await makeConsumer('CAT_CODE');
+    await signup(C.CAT_CODE, campCatV2);
+  });
+
+  test('matches signups whose campaign carries the category — across BOTH design_config versions', async () => {
+    expect(await memberIds({ filters: { campaignCategories: ['speech_performance'] } }))
+      .toEqual(idOf('CAT_SPEECH'));
+    expect(await memberIds({ filters: { campaignCategories: ['coding_robotics'] } }))
+      .toEqual(idOf('CAT_CODE'));
+    expect(await memberIds({ filters: { campaignCategories: ['speech_performance', 'coding_robotics'] } }))
+      .toEqual(idOf('CAT_SPEECH', 'CAT_CODE'));
+  });
+
+  test('composes with other filters as AND', async () => {
+    const got = await memberIds({
+      filters: { campaignIds: [campCatV1.id, campCatV2.id], campaignCategories: ['coding_robotics'] },
+    });
+    expect(got).toEqual(idOf('CAT_CODE'));
+  });
+
+  test('a category the fixtures do not carry yields an empty cohort, not an error', async () => {
+    const got = await memberIds({
+      filters: { campaignIds: [campCatV1.id, campCatV2.id], campaignCategories: ['music_dance'] },
+    });
+    expect(got).toEqual([]);
+  });
+
+  test('unknown category ids are rejected (422), never silently ignored', () => {
+    expect(() => normalizeDefinition({ filters: { campaignCategories: ['bogus'] } }))
+      .toThrow(/not a known category/);
+  });
+
+  test('normalize dedupes and echoes the canonical list', () => {
+    const def = normalizeDefinition({ filters: { campaignCategories: ['dining', 'dining'] } });
+    expect(def.filters.campaignCategories).toEqual(['dining']);
+  });
+
+  test('facets expose the FULL taxonomy with counts + per-campaign category', async () => {
+    const facets = await getCohortFacets();
+    const byId = Object.fromEntries(facets.campaignCategories.map((c) => [c.id, c]));
+    expect(Object.keys(byId).length).toBe(10);
+    expect(byId.speech_performance.count).toBeGreaterThanOrEqual(1);
+    expect(byId.speech_performance.label).toBe('Speech & Performance');
+    const v1Row = facets.campaigns.find((c) => c.id === campCatV1.id);
+    const v2Row = facets.campaigns.find((c) => c.id === campCatV2.id);
+    expect(v1Row.category).toBe('speech_performance');
+    expect(v2Row.category).toBe('coding_robotics');
+  });
+});

--- a/backend/test/marketplaceContent.test.js
+++ b/backend/test/marketplaceContent.test.js
@@ -1,4 +1,7 @@
-import { normalizeMarketplaceContent, applyMarketplacePolicy, MARKETPLACE_CAMPAIGN_TYPES } from '../src/utils/marketplaceContent.js';
+import {
+  normalizeMarketplaceContent, applyMarketplacePolicy, MARKETPLACE_CAMPAIGN_TYPES,
+  CONSUMER_CATEGORY_DEFS, CONSUMER_CATEGORIES, consumerCategoryLabel,
+} from '../src/utils/marketplaceContent.js';
 
 describe('normalizeMarketplaceContent', () => {
   test('non-objects normalize to empty', () => {
@@ -81,5 +84,23 @@ describe('applyMarketplacePolicy', () => {
     expect(MARKETPLACE_CAMPAIGN_TYPES).not.toContain('quiz');
     expect(MARKETPLACE_CAMPAIGN_TYPES).not.toContain('guided_review');
     expect(MARKETPLACE_CAMPAIGN_TYPES).toContain('lead_generation');
+  });
+});
+
+describe('CONSUMER_CATEGORY_DEFS (tracker "taxonomy" — the ONE category source)', () => {
+  test('ids are unique and CONSUMER_CATEGORIES derives 1:1', () => {
+    const ids = CONSUMER_CATEGORY_DEFS.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(CONSUMER_CATEGORIES).toEqual(ids);
+  });
+
+  test('every def carries a label and a known group', () => {
+    for (const def of CONSUMER_CATEGORY_DEFS) {
+      expect(typeof def.label).toBe('string');
+      expect(def.label.length).toBeGreaterThan(0);
+      expect(['education', 'lifestyle']).toContain(def.group);
+    }
+    expect(consumerCategoryLabel('dining')).toBe('Dining');
+    expect(consumerCategoryLabel('unknown_thing')).toBe('unknown_thing');
   });
 });

--- a/src/components/adminv2/CohortBuilder.jsx
+++ b/src/components/adminv2/CohortBuilder.jsx
@@ -200,7 +200,25 @@ export default function CohortBuilder({ cohort = null, onClose, onSaved }) {
             )}
           </Section>
 
-          <Section label="Campaign tags" hint={(f?.campaignTags || []).length === 0 ? 'no tags exist yet (taxonomy pending)' : 'signed up for any campaign carrying one'}>
+          <Section label="Category" hint="signed up for any campaign in one of these — the campaign taxonomy, set in Studio">
+            {facets.isLoading ? <Skeleton height={30} /> : (
+              <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                {(f?.campaignCategories || []).map((c) => (
+                  <TogglePill
+                    key={c.id}
+                    active={definition.filters.campaignCategories.includes(c.id)}
+                    onClick={() => patch((d) => { d.filters.campaignCategories = toggle(d.filters.campaignCategories, c.id); })}
+                    title={`${c.count} campaign${c.count === 1 ? '' : 's'} today`}
+                  >
+                    {c.label}{c.count > 0 ? ` · ${c.count}` : ''}
+                  </TogglePill>
+                ))}
+                {(f?.campaignCategories || []).length === 0 && <span className="av2-caption">No categories.</span>}
+              </div>
+            )}
+          </Section>
+
+          <Section label="Campaign tags" hint={(f?.campaignTags || []).length === 0 ? 'no freeform tags exist yet — Category above is the curated taxonomy' : 'freeform labels — signed up for any campaign carrying one'}>
             <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
               {(f?.campaignTags || []).map((t) => (
                 <TogglePill

--- a/src/components/adminv2/__tests__/CohortBuilder.test.jsx
+++ b/src/components/adminv2/__tests__/CohortBuilder.test.jsx
@@ -12,9 +12,13 @@ vi.mock('@/api/adminV2', () => ({
   fetchCohortFacets: vi.fn(async () => ({
     attributes: { incomes: ['$3,000 - $4,999'], educations: ['Degree'], genders: ['female'] },
     campaignTags: ['parenting'],
+    campaignCategories: [
+      { id: 'dining', label: 'Dining', count: 1 },
+      { id: 'wellness', label: 'Wellness', count: 0 },
+    ],
     campaigns: [
-      { id: 'c1', name: 'Tokyo Getaway Lucky Draw', status: 'active' },
-      { id: 'c2', name: 'NTUC $20', status: 'active' },
+      { id: 'c1', name: 'Tokyo Getaway Lucky Draw', status: 'active', category: 'dining' },
+      { id: 'c2', name: 'NTUC $20', status: 'active', category: null },
     ],
     draws: [{ id: 'd1', campaignId: 'c1', campaignName: 'Tokyo Getaway Lucky Draw', status: 'open', closesAt: '2026-10-30T00:00:00Z' }],
   })),
@@ -82,6 +86,19 @@ describe('CohortBuilder', () => {
         ageGate: { minAge: 18, maxAge: null },
       }),
     })));
+  });
+
+  it('toggling a category pill re-previews with that category in the definition', async () => {
+    setup();
+    // In-use categories show their live campaign count; empty ones just the label.
+    const pill = await screen.findByRole('button', { name: 'Dining · 1' });
+    fireEvent.click(pill);
+    expect(pill).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Wellness' })).toHaveAttribute('aria-pressed', 'false');
+    await waitFor(() => {
+      const defs = previewCohortDefinition.mock.calls.map(([def]) => def);
+      expect(defs.some((d) => d.filters.campaignCategories.includes('dining'))).toBe(true);
+    }, { timeout: 3000 });
   });
 
   it('postal input keeps only valid digit prefixes', async () => {

--- a/src/components/campaigns/editor/MarketplacePanel.jsx
+++ b/src/components/campaigns/editor/MarketplacePanel.jsx
@@ -9,6 +9,7 @@ import { Switch } from '@/components/ui/switch';
 import { AlertCircle, CheckCircle2, Loader2, Store } from 'lucide-react';
 import { apiClient } from '@/api/client';
 import { marketplaceInheritEnabled, deriveListingPreview } from '@/lib/listingDerivation';
+import { CATEGORY_OPTIONS, OFFER_TYPES, MODES } from '@/components/studio/marketplaceOptions';
 
 /**
  * Marketplace panel — authors the design_config marketplace keys
@@ -20,15 +21,6 @@ import { marketplaceInheritEnabled, deriveListingPreview } from '@/lib/listingDe
  * save path here — it locks permanently once the campaign is first activated.
  */
 
-const CATEGORY_OPTIONS = [
-  ['art_creativity', 'Art & Creativity'], ['coding_robotics', 'Coding & Robotics'],
-  ['speech_performance', 'Speech & Performance'], ['sports_movement', 'Sports & Movement'],
-  ['music_dance', 'Music & Dance'], ['academic', 'Academic'],
-  ['family_lifestyle', 'Family & Lifestyle'], ['wellness', 'Wellness'],
-  ['dining', 'Dining'], ['financial_education', 'Financial Education'],
-];
-const OFFER_TYPES = ['trial', 'assessment', 'workshop', 'reward', 'consultation'];
-const MODES = ['physical', 'online', 'hybrid'];
 const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
 function Section({ title, hint, children }) {

--- a/src/components/studio/__tests__/DistributionSubjects.test.jsx
+++ b/src/components/studio/__tests__/DistributionSubjects.test.jsx
@@ -170,8 +170,8 @@ describe('DistributionPanel — single-door mode (inheritance flag on)', () => {
     expect(screen.queryByLabelText('Consumer title')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Value line')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Image alt text')).not.toBeInTheDocument();
-    // …picks stay…
-    expect(screen.getByLabelText('Category')).toBeInTheDocument();
+    // …picks stay… (Category moved to its own campaign-wide taxonomy section)
+    expect(screen.getByLabelText('Campaign category')).toBeInTheDocument();
     expect(screen.getByLabelText('Audience age min')).toBeInTheDocument();
     // …and the inherited preview names the sources.
     const preview = screen.getByTestId('dist-inherited-preview');

--- a/src/components/studio/marketplaceOptions.js
+++ b/src/components/studio/marketplaceOptions.js
@@ -1,22 +1,14 @@
 /**
- * Marketplace listing option lists shared by the Distribution panel and the
- * AI review panel (pick-row display labels). Values mirror the backend
- * validator (backend/src/utils/marketplaceContent.js) — the save clamp
- * re-validates, so a drifted id degrades to a dropped value, never a write.
+ * Marketplace listing option lists shared by the Distribution panel, the
+ * classic MarketplacePanel and the AI review panel (pick-row display labels).
+ * Derived DIRECTLY from the backend taxonomy (tracker "taxonomy") — adding or
+ * removing a category happens in backend/src/utils/marketplaceContent.js and
+ * nowhere else. The save clamp re-validates against the same source, so the
+ * two can never drift.
  */
 
-export const CATEGORY_OPTIONS = [
-  ['art_creativity', 'Art & Creativity'],
-  ['coding_robotics', 'Coding & Robotics'],
-  ['speech_performance', 'Speech & Performance'],
-  ['sports_movement', 'Sports & Movement'],
-  ['music_dance', 'Music & Dance'],
-  ['academic', 'Academic'],
-  ['family_lifestyle', 'Family & Lifestyle'],
-  ['wellness', 'Wellness'],
-  ['dining', 'Dining'],
-  ['financial_education', 'Financial Education'],
-];
+import { CONSUMER_CATEGORY_DEFS } from '../../../backend/src/utils/marketplaceContent.js';
 
-export const OFFER_TYPES = ['trial', 'assessment', 'workshop', 'reward', 'consultation'];
-export const MODES = ['physical', 'online', 'hybrid'];
+export { OFFER_TYPES, MODES } from '../../../backend/src/utils/marketplaceContent.js';
+
+export const CATEGORY_OPTIONS = CONSUMER_CATEGORY_DEFS.map((c) => [c.id, c.label]);

--- a/src/components/studio/panels/DistributionPanel.jsx
+++ b/src/components/studio/panels/DistributionPanel.jsx
@@ -124,6 +124,24 @@ export default function DistributionPanel({
         </p>
       </PanelSection>
 
+      <PanelSection title="CATEGORY">
+        <div>
+          <FieldLabel htmlFor="studio-mk-category">Campaign category</FieldLabel>
+          <select id="studio-mk-category" style={selectStyle} value={mk.category || ''} onChange={(e) => setMk({ category: e.target.value || undefined })}>
+            <option value="">—</option>
+            {CATEGORY_OPTIONS.map(([v, l]) => (
+              <option key={v} value={v}>
+                {l}
+              </option>
+            ))}
+          </select>
+        </div>
+        <p style={{ margin: 0, fontSize: 10.5, color: 'var(--ink-3, #9BA0AB)', lineHeight: 1.5 }}>
+          The campaign taxonomy — powers marketplace browse, cohort filters and cross-sell. Set one for every
+          campaign, listed on the marketplace or not.
+        </p>
+      </PanelSection>
+
       <PanelSection title="FEATURED DROP — REDEEM.SG HOMEPAGE">
         <ToggleRow
           id="studio-drop-enabled"
@@ -201,17 +219,6 @@ export default function DistributionPanel({
         {!inherit && (
           <TextField id="studio-mk-title" label="Consumer title" bind={bind('distribution.marketplace.title', 120)} onSuggest={suggest('distribution.marketplace.title', 'Consumer title')} />
         )}
-        <div>
-          <FieldLabel htmlFor="studio-mk-category">Category</FieldLabel>
-          <select id="studio-mk-category" style={selectStyle} value={mk.category || ''} onChange={(e) => setMk({ category: e.target.value || undefined })}>
-            <option value="">—</option>
-            {CATEGORY_OPTIONS.map(([v, l]) => (
-              <option key={v} value={v}>
-                {l}
-              </option>
-            ))}
-          </select>
-        </div>
         <div style={{ display: 'flex', gap: 8 }}>
           <div style={{ flex: 1 }}>
             <FieldLabel htmlFor="studio-mk-offer">Offer type</FieldLabel>

--- a/src/lib/adminV2/cohorts.js
+++ b/src/lib/adminV2/cohorts.js
@@ -45,6 +45,7 @@ export function emptyDefinition() {
       drawIds: [],
       anyDraw: false,
       campaignTags: [],
+      campaignCategories: [],
       attributes: { postalPrefixes: [], incomes: [], educations: [], genders: [] },
     },
     ageGate: { minAge: 18, maxAge: null },
@@ -64,6 +65,7 @@ export function normalizeDefinitionShape(def) {
       drawIds: Array.isArray(f.drawIds) ? f.drawIds : [],
       anyDraw: f.anyDraw === true,
       campaignTags: Array.isArray(f.campaignTags) ? f.campaignTags : [],
+      campaignCategories: Array.isArray(f.campaignCategories) ? f.campaignCategories : [],
       attributes: {
         postalPrefixes: Array.isArray(a.postalPrefixes) ? a.postalPrefixes : [],
         incomes: Array.isArray(a.incomes) ? a.incomes : [],
@@ -92,6 +94,10 @@ export function summarizeDefinition(def, facets = null) {
   }
   if (d.filters.drawIds.length) parts.push(`${d.filters.drawIds.length} draw${d.filters.drawIds.length > 1 ? 's' : ''}`);
   else if (d.filters.anyDraw) parts.push('any draw');
+  if (d.filters.campaignCategories.length) {
+    const labelOf = (id) => facets?.campaignCategories?.find((c) => c.id === id)?.label || id;
+    parts.push(`category: ${d.filters.campaignCategories.map(labelOf).join(', ')}`);
+  }
   if (d.filters.campaignTags.length) parts.push(`tags: ${d.filters.campaignTags.join(', ')}`);
   const attrs = d.filters.attributes;
   const attrBits = [];

--- a/src/pages/marketplace/content.js
+++ b/src/pages/marketplace/content.js
@@ -1,22 +1,13 @@
 /**
  * Marketplace static content + display helpers (from the approved
- * claude.ai/design Prototype v2). Categories mirror the backend consumer
- * taxonomy (backend/src/utils/marketplaceContent.js CONSUMER_CATEGORIES) —
- * change them together.
+ * claude.ai/design Prototype v2). Categories come from THE taxonomy
+ * (backend/src/utils/marketplaceContent.js, tracker "taxonomy") — add or
+ * remove a category there and only there.
  */
 
-export const CATEGORIES = [
-  { id: 'art_creativity', label: 'Art & Creativity', group: 'education', blurb: 'Drawing, painting and portfolio discovery' },
-  { id: 'coding_robotics', label: 'Coding & Robotics', group: 'education', blurb: 'Build, program and problem-solve' },
-  { id: 'speech_performance', label: 'Speech & Performance', group: 'education', blurb: 'Confidence on stage and in class' },
-  { id: 'sports_movement', label: 'Sports & Movement', group: 'education', blurb: 'Swim, play and move well' },
-  { id: 'music_dance', label: 'Music & Dance', group: 'education', blurb: 'Instruments, voice and rhythm' },
-  { id: 'academic', label: 'Academic', group: 'education', blurb: 'Diagnostics and subject support' },
-  { id: 'family_lifestyle', label: 'Family & Lifestyle', group: 'lifestyle', blurb: 'Experiences to share together' },
-  { id: 'wellness', label: 'Wellness', group: 'lifestyle', blurb: 'Self-care that earns its slot' },
-  { id: 'dining', label: 'Dining', group: 'lifestyle', blurb: 'Tables worth booking' },
-  { id: 'financial_education', label: 'Financial Education', group: 'lifestyle', blurb: 'Understand your money better' },
-];
+import { CONSUMER_CATEGORY_DEFS } from '../../../backend/src/utils/marketplaceContent.js';
+
+export const CATEGORIES = CONSUMER_CATEGORY_DEFS;
 
 export const categoryLabel = (id) => CATEGORIES.find((c) => c.id === id)?.label || id;
 


### PR DESCRIPTION
Tracker item **"taxonomy"**: define the category set, store it on campaigns, Studio UI, cohort filter. Backfill of existing campaigns follows as prod data ops after merge.

## The one-place rule
The category list previously existed in **four** hand-mirrored copies. Now `backend/src/utils/marketplaceContent.js` `CONSUMER_CATEGORY_DEFS` is the only place to add/remove a category:
- backend validator derives `CONSUMER_CATEGORIES` from it (save clamp + v2 clamp + cohort validation)
- `src/pages/marketplace/content.js` (browse/nav//c/:id) re-exports it
- `src/components/studio/marketplaceOptions.js` (Studio picker + AI pick rows + classic MarketplacePanel) derives `[id,label]` pairs
- cohort facets serve it with live campaign counts

Checked per Shawn's note: **Redeem Ops categories are a different registry** (`redeemOps/categoryService` — admin-managed partner-vertical rows for CRM/Discover with search terms/IG hashtags). Not merged, by design; the taxonomy header documents the distinction.

## Storage: design_config.category (justified)
Category was already a clamped, normalized marketplace key (`design_config.category` v1 / `distribution.marketplace.category` v2), rendered on redeem.sg. Making it the canonical campaign taxonomy avoids a second driftable copy; `tags` (TEXT holding JSON, already a separate freeform cohort facet) and `targetAudience` (dead JSONB) stay untouched. New `getStoredCategory()` accessor gives version-aware reads next to its siblings.

## Cohorts
`filters.campaignCategories`: enum-validated (loud 400 at Joi, binding 422 in `normalizeDefinition` — saved rows re-pass), resolved in JS to campaign ids exactly like `campaignTags` (never cast in SQL), ANDed with other filters. `/facets` returns the full 10-entry taxonomy + counts + per-campaign category. Builder gets a Category pill row; definition summaries include labels.

## Studio
Category moved out of MARKETPLACE LISTING into its own **CATEGORY** section (campaign-wide taxonomy, set for every campaign, listed or not). Same doc path — no data migration.

## Tests
- backend: 226 tests / 10 suites green on real Postgres, incl. cross-version (v1 flat + v2 nested) resolution, AND-composition, unknown-id 422, facets counts
- frontend: vitest 1792/1792; production build green (backend module bundles as a shared chunk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqsFKDVK45eCqwTQJuyEbo