### PR TITLE
feat(taxonomy): migration 087 — category backfill for pre-taxonomy campaigns

### DIFF
--- a/backend/src/database/migrations/087-campaign-category-backfill.js
+++ b/backend/src/database/migrations/087-campaign-category-backfill.js
@@ -1,0 +1,74 @@
+/**
+ * 087 — Campaign taxonomy backfill (tracker "taxonomy", PR #244 follow-up).
+ *
+ * Stamps design_config category onto the specific production campaigns that
+ * predate the taxonomy, version-aware: v2 docs get
+ * distribution.marketplace.category (parents created if absent), anything
+ * else gets the flat v1 key. Values come from CONSUMER_CATEGORIES
+ * (utils/marketplaceContent.js — the one place categories are defined).
+ *
+ * Safe by construction:
+ *  - Matched by production UUID — fresh dev/test DBs simply no-op.
+ *  - Only fills where NO category exists on either path, so an operator
+ *    choice made between merge and deploy is never overwritten.
+ *  - Idempotent: the second run finds the category present and skips.
+ */
+
+const BACKFILL = [
+  ['35b723aa-27be-44af-b9ba-d9f53ef48e01', 'family_lifestyle'], // Free Pet Hotel 1 Night Trial
+  ['bbd2c577-13ce-4ac5-a9cd-fd1b690ef9fd', 'family_lifestyle'], // iPhone 17 Pro Lucky Draw, August 2026
+  ['2821c916-9d6c-4b76-b103-805f45195b21', 'family_lifestyle'], // Redeem $10 Fairprice Voucher
+  ['7f7c6524-6adb-4fe2-a187-40b4e68c26b4', 'family_lifestyle'], // Redeem $20 NTUC Fairprice Vouchers
+  ['88cde84b-4805-40fa-8866-c0eb806a5dee', 'financial_education'], // [Retell] Luggage - CPF CareShield Life
+];
+
+export async function up(queryInterface) {
+  const { CONSUMER_CATEGORIES } = await import('../../utils/marketplaceContent.js');
+  const { logger } = await import('../../utils/logger.js');
+  const { sequelize } = queryInterface;
+
+  let stamped = 0;
+  for (const [id, category] of BACKFILL) {
+    if (!CONSUMER_CATEGORIES.includes(category)) {
+      throw new Error(`[087] '${category}' is not in CONSUMER_CATEGORIES`);
+    }
+    const [, meta] = await sequelize.query(
+      `UPDATE campaigns
+          SET design_config = CASE
+            WHEN design_config::jsonb->>'version' = '2' THEN (
+              jsonb_set(
+                jsonb_set(
+                  jsonb_set(
+                    design_config::jsonb,
+                    '{distribution}',
+                    COALESCE(design_config::jsonb->'distribution', '{}'::jsonb),
+                    true
+                  ),
+                  '{distribution,marketplace}',
+                  COALESCE(design_config::jsonb->'distribution'->'marketplace', '{}'::jsonb),
+                  true
+                ),
+                '{distribution,marketplace,category}',
+                to_jsonb(:category::text),
+                true
+              )
+            )::json
+            ELSE (COALESCE(design_config::jsonb, '{}'::jsonb)
+                  || jsonb_build_object('category', :category::text))::json
+          END
+        WHERE id = :id
+          AND COALESCE(
+                design_config::jsonb#>>'{distribution,marketplace,category}',
+                design_config::jsonb->>'category'
+              ) IS NULL`,
+      { replacements: { id, category } }
+    );
+    stamped += meta?.rowCount ?? 0;
+  }
+  logger.info('[087] campaign category backfill', { candidates: BACKFILL.length, stamped });
+}
+
+export async function down() {
+  // Data backfill of previously-empty slots — nothing safe to reverse
+  // (operators may have re-saved the same value through Studio since).
+}

--- a/backend/test/migration087CategoryBackfill.test.js
+++ b/backend/test/migration087CategoryBackfill.test.js
@@ -1,0 +1,66 @@
+import { getApp, closeDb, createTestUser, createTestCampaign } from './helpers.js';
+import { sequelize, Campaign } from '../src/models/index.js';
+import { up } from '../src/database/migrations/087-campaign-category-backfill.js';
+
+/**
+ * 087 backfill semantics on real Postgres: v2 docs get the nested
+ * distribution.marketplace.category (parents created when absent), v1/flat
+ * docs get the root key, existing categories are NEVER overwritten, and the
+ * whole thing is idempotent. Rows are keyed by the REAL production UUIDs the
+ * migration targets — anything else must be untouched.
+ */
+
+const PET_HOTEL = '35b723aa-27be-44af-b9ba-d9f53ef48e01'; // → family_lifestyle
+const RETELL_CS = '88cde84b-4805-40fa-8866-c0eb806a5dee'; // → financial_education
+const FP_10 = '2821c916-9d6c-4b76-b103-805f45195b21'; // → family_lifestyle
+
+let admin;
+
+beforeAll(async () => {
+  await getApp();
+  admin = await createTestUser({ role: 'admin' });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+const reload = async (id) => (await Campaign.findByPk(id)).design_config;
+
+test('backfills version-aware, respects existing values, and is idempotent', async () => {
+  // v2 doc WITHOUT a marketplace object — parents must be created.
+  await createTestCampaign(admin.user.id, {
+    id: PET_HOTEL,
+    name: 'Backfill Pet Hotel',
+    design_config: { version: 2, distribution: { host: 'redeem' } },
+  });
+  // v2 doc with an OPERATOR-SET category — the guard must keep it.
+  await createTestCampaign(admin.user.id, {
+    id: RETELL_CS,
+    name: 'Backfill Retell',
+    design_config: { version: 2, distribution: { marketplace: { category: 'dining' } } },
+  });
+  // Flat/v1-shaped doc — the ELSE branch writes the root key.
+  await createTestCampaign(admin.user.id, {
+    id: FP_10,
+    name: 'Backfill FP10',
+    design_config: {},
+  });
+
+  await up(sequelize.getQueryInterface());
+
+  const petHotel = await reload(PET_HOTEL);
+  expect(petHotel.distribution.marketplace.category).toBe('family_lifestyle');
+  expect(petHotel.distribution.host).toBe('redeem'); // siblings preserved
+
+  const retell = await reload(RETELL_CS);
+  expect(retell.distribution.marketplace.category).toBe('dining'); // NOT overwritten
+
+  const fp10 = await reload(FP_10);
+  expect(fp10.category).toBe('family_lifestyle'); // v1 root key
+
+  // Idempotent rerun changes nothing.
+  await up(sequelize.getQueryInterface());
+  expect((await reload(PET_HOTEL)).distribution.marketplace.category).toBe('family_lifestyle');
+  expect((await reload(RETELL_CS)).distribution.marketplace.category).toBe('dining');
+});


### PR DESCRIPTION
Follow-up to #244 (tracker "taxonomy") — the backfill leg. A boot-runner migration stamps categories onto the 5 production campaigns that predate the taxonomy, keyed by UUID:

| Campaign | Category |
|---|---|
| Free Pet Hotel 1 Night Trial | family_lifestyle |
| iPhone 17 Pro Lucky Draw, August 2026 | family_lifestyle |
| Redeem $10 Fairprice Voucher | family_lifestyle |
| Redeem $20 NTUC Fairprice Vouchers | family_lifestyle |
| [Retell] Luggage - CPF CareShield Life | financial_education |

(Tokyo Getaway already carries family_lifestyle — untouched.)

Version-aware writes (v2 → `distribution.marketplace.category`, creating `distribution`/`marketplace` parents when absent; flat docs → root key), **fill-only** (an operator category set between merge and deploy is never overwritten), idempotent, values validated against `CONSUMER_CATEGORIES` at run time. Fresh dev/test DBs no-op on the UUID match.

Test on real Postgres proves parent creation, the no-overwrite guard, the v1 fallback branch, and idempotent rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqsFKDVK45eCqwTQJuyEbo