### PR TITLE
fix(lucky-draw): two draw configs the UI offered and the engine refuses

### DIFF
--- a/backend/src/services/campaignDetailsAiService.js
+++ b/backend/src/services/campaignDetailsAiService.js
@@ -90,7 +90,7 @@ export function buildDetailsDraftPrompts({ type, draw, brief, today, settings = 
     'startDate: today unless the brief implies a later start. endDate: only when the brief implies one; otherwise return an empty string.',
     'minAge/maxAge: a sensible audience range for the offer (defaults 18-65 when the brief is silent).',
     draw
-      ? 'prizes: award order, first row is the grand prize; qty 1-99 each, names concrete and customer-facing. closesAt must be after today; a draw needs a real deadline — if the brief gives none, pick a sensible one 4-8 weeks out. boostClosesAt <= closesAt (use closesAt when unsure). multiplier defaults to 10. minAge is at least 18 for draws. endDate should equal closesAt unless the brief says otherwise.'
+      ? 'prizes: award order, first row is the grand prize; qty 1-99 each, names concrete and customer-facing. closesAt must be after today; a draw needs a real deadline — if the brief gives none, pick a sensible one 4-8 weeks out. boostClosesAt must be ON OR AFTER closesAt (use closesAt when unsure — entrants may complete their session after entries close, never before the deadline you print). multiplier defaults to 10. minAge is at least 18 for draws. endDate should equal closesAt unless the brief says otherwise.'
       : null,
   ].filter(Boolean).join('\n');
   // Org guardrails ride the system prompt (campaign-copy convention); the
@@ -153,7 +153,13 @@ export function sanitizeDetailsDraft(raw, { draw, today }) {
     out.closesAt = closesAt;
     const boost = cleanYmd(raw.boostClosesAt);
     // Same-day boost is legitimate — the SGT day stays open until 23:59.
-    out.boostClosesAt = boost && boost <= closesAt && boost >= today ? boost : closesAt;
+    // The engine requires boostClosesAt >= closesAt (luckyDrawService): an
+    // entrant may finish their session AFTER entries close, up to the boost
+    // deadline, and the draw seals after that. The old `<=` accepted the
+    // opposite, so a model that read "boost ends before the draw closes" from
+    // a brief produced a config that printed that date in the T&Cs and then
+    // 422'd at draw creation.
+    out.boostClosesAt = boost && boost >= closesAt ? boost : closesAt;
     out.multiplier = cleanInt(raw.multiplier, 2, 100) ?? 10;
     if (!out.endDate) out.endDate = closesAt; // '' or absent → align to the close
   }

--- a/backend/src/utils/luckyDraw.js
+++ b/backend/src/utils/luckyDraw.js
@@ -83,9 +83,19 @@ export function derivePrizeSummary(prizes) {
     .slice(0, MAX_PRIZE_SUMMARY);
 }
 
-/** Σqty of a NORMALIZED luckyDraw's prizes; 0 when unstructured (legacy). */
+/**
+ * Σqty of a NORMALIZED luckyDraw's prizes — the number of winners this draw
+ * promises. Legacy docs carry no `prizes[]` but CAN carry a hand-set
+ * `winners` (normalizeLuckyDraw accepts 1..1000 in that branch), and the
+ * consumer page renders it verbatim ("3 winners, drawn in a witnessed
+ * process"). Returning 0 there let a legacy multi-winner draw walk straight
+ * past both multi-prize guards — assertDrawActivatable and createDraw — and
+ * activate, even though the engine is terminal after ONE claimed winner. The
+ * identical config expressed as prizes:[{qty:3}] was correctly refused.
+ */
 export function totalPrizeQuantity(ld) {
-  if (!ld || !Array.isArray(ld.prizes)) return 0;
+  if (!ld) return 0;
+  if (!Array.isArray(ld.prizes)) return Number.isInteger(ld.winners) ? ld.winners : 0;
   return ld.prizes.reduce((sum, p) => sum + (Number.isInteger(p?.qty) ? p.qty : 0), 0);
 }
 

--- a/backend/test/campaignDetailsAi.test.js
+++ b/backend/test/campaignDetailsAi.test.js
@@ -53,7 +53,7 @@ describe('sanitizeDetailsDraft', () => {
     multiplier: 10,
   };
 
-  it('clamps a full draw draft: whitespace, qty floor, 18+ floor, boost <= close', () => {
+  it('clamps a full draw draft: whitespace, qty floor, 18+ floor, boost >= close', () => {
     const out = sanitizeDetailsDraft(drawRaw, { draw: true, today: TODAY });
     expect(out.name).toBe('iPhone 17 Lucky Draw — August 2026');
     expect(out.minAge).toBe(18); // draw floor beats the model's 16
@@ -63,11 +63,20 @@ describe('sanitizeDetailsDraft', () => {
       { qty: 1, name: 'Zero qty coerces to 1' },
     ]);
     expect(out.closesAt).toBe('2026-08-31');
-    expect(out.boostClosesAt).toBe('2026-08-15');
+    // Direction CORRECTED: the engine requires boostClosesAt >= closesAt
+    // ('must not be before closesAt'), because an entrant may complete their
+    // session AFTER entries close. The fixture's 2026-08-15 is before the
+    // close, so it snaps up — it used to be kept, printed into the pinned
+    // T&Cs, and then 422'd at draw creation.
+    expect(out.boostClosesAt).toBe('2026-08-31');
   });
 
-  it('boost after close, or in the past, snaps to the close date', () => {
-    expect(sanitizeDetailsDraft({ ...drawRaw, boostClosesAt: '2026-09-15' }, { draw: true, today: TODAY }).boostClosesAt).toBe('2026-08-31');
+  it('a boost AFTER the close is legitimate and survives', () => {
+    expect(sanitizeDetailsDraft({ ...drawRaw, boostClosesAt: '2026-09-15' }, { draw: true, today: TODAY }).boostClosesAt).toBe('2026-09-15');
+  });
+
+  it('a boost before the close — or in the past — snaps up to the close date', () => {
+    expect(sanitizeDetailsDraft({ ...drawRaw, boostClosesAt: '2026-08-15' }, { draw: true, today: TODAY }).boostClosesAt).toBe('2026-08-31');
     expect(sanitizeDetailsDraft({ ...drawRaw, boostClosesAt: '2026-01-01' }, { draw: true, today: TODAY }).boostClosesAt).toBe('2026-08-31');
   });
 
@@ -96,8 +105,10 @@ describe('sanitizeDetailsDraft', () => {
   it('Codex folds: name truncates at the campaignCreate limit (100), same-day boost survives, age 0 falls back', () => {
     const long = sanitizeDetailsDraft({ name: 'x'.repeat(120) }, { draw: false, today: TODAY });
     expect(long.name).toHaveLength(100);
+    // A boost dated TODAY is necessarily before the close (closesAt must be
+    // in the future), so it snaps up to the close — the engine would refuse it.
     const sameDayBoost = sanitizeDetailsDraft({ ...drawRaw, boostClosesAt: TODAY }, { draw: true, today: TODAY });
-    expect(sameDayBoost.boostClosesAt).toBe(TODAY); // SGT day is open until 23:59
+    expect(sameDayBoost.boostClosesAt).toBe('2026-08-31');
     const zeroAges = sanitizeDetailsDraft({ name: 'Zero Ages', minAge: 0, maxAge: 0 }, { draw: false, today: TODAY });
     expect(zeroAges.minAge).toBe(18);
     expect(zeroAges.maxAge).toBe(65);

--- a/backend/test/luckyDraw.util.test.js
+++ b/backend/test/luckyDraw.util.test.js
@@ -146,7 +146,10 @@ describe('normalizeLuckyDraw — structured prizes', () => {
     expect(derivePrizeSummary([{ qty: 1, name: 'A' }])).toBe('A');
     expect(derivePrizeSummary(ROWS)).toBe('iPhone 17 Pro + 3× $100 FairPrice Voucher');
     expect(totalPrizeQuantity(normalizeLuckyDraw({ enabled: true, prizes: ROWS }))).toBe(4);
-    expect(totalPrizeQuantity(normalizeLuckyDraw({ enabled: true, prize: 'Manual', winners: 9 }))).toBe(0);
+    // WAS 0 — that was the bug: a legacy hand-set `winners` promised 9 winners
+    // on the consumer page and returned 0 to both multi-prize guards, so the
+    // draw activated while the engine stays terminal after ONE claimed winner.
+    expect(totalPrizeQuantity(normalizeLuckyDraw({ enabled: true, prize: 'Manual', winners: 9 }))).toBe(9);
     expect(totalPrizeQuantity(undefined)).toBe(0);
   });
 });
@@ -218,5 +221,28 @@ describe('sgtDayEndExclusiveMs', () => {
     for (const v of [null, undefined, 42, '2026-13-99', '12/07/2026', '2026-07-12T00:00:00Z', '2026-02-31']) {
       expect(sgtDayEndExclusiveMs(v)).toBeNull();
     }
+  });
+});
+
+describe('totalPrizeQuantity — legacy winners count as promised winners', () => {
+  it('a hand-set winners on a legacy (no prizes[]) draw is counted', () => {
+    expect(totalPrizeQuantity({ enabled: true, prize: '3 x iPhone 17', winners: 3 })).toBe(3);
+  });
+
+  it('structured prizes still win when both are present', () => {
+    expect(totalPrizeQuantity({ prizes: [{ qty: 2, name: 'A' }], winners: 99 })).toBe(2);
+  });
+
+  it('a legacy single-winner draw is still 1, and a shapeless one still 0', () => {
+    expect(totalPrizeQuantity({ prize: 'One trip', winners: 1 })).toBe(1);
+    expect(totalPrizeQuantity({ prize: 'One trip' })).toBe(0);
+    expect(totalPrizeQuantity(null)).toBe(0);
+  });
+
+  it('normalizeLuckyDraw + totalPrizeQuantity now REFUSE the legacy multi-winner shape the guards used to miss', () => {
+    const ld = normalizeLuckyDraw({ enabled: true, prize: '3 x iPhone 17', winners: 3, closesAt: '2026-09-02' });
+    expect(ld.winners).toBe(3);
+    // > 1 is what assertDrawActivatable and createDraw both gate on.
+    expect(totalPrizeQuantity(ld)).toBe(3);
   });
 });

--- a/src/components/campaigns/workspace/CampaignDetailsTab.jsx
+++ b/src/components/campaigns/workspace/CampaignDetailsTab.jsx
@@ -303,8 +303,19 @@ export default function CampaignDetailsTab({ initial, type, draw = false, isEdit
               </div>
               <div className="space-y-2">
                 <Label htmlFor="draw_boost">Session boost deadline</Label>
-                <Input id="draw_boost" type="date" value={form.drawBoostClosesAt} onChange={(e) => set('drawBoostClosesAt', e.target.value)} />
-                <p className="text-xs text-muted-foreground">Empty = same as close date.</p>
+                {/* min = the close date: the engine requires boostClosesAt >=
+                    closesAt (entrants may finish a session AFTER entries
+                    close). An earlier date used to be accepted here, printed
+                    into the pinned T&Cs, and then 422'd at draw creation. */}
+                <Input id="draw_boost" type="date" min={form.drawClosesAt || undefined} value={form.drawBoostClosesAt} onChange={(e) => set('drawBoostClosesAt', e.target.value)} />
+                <p className="text-xs text-muted-foreground">
+                  Empty = same as close date. Cannot be earlier than the close — sessions may finish after entries close.
+                </p>
+                {form.drawClosesAt && form.drawBoostClosesAt && form.drawBoostClosesAt < form.drawClosesAt ? (
+                  <p className="text-xs text-red-600">
+                    The boost deadline must be on or after {formatLongDate(form.drawClosesAt)}.
+                  </p>
+                ) : null}
               </div>
             </div>
             <div className="space-y-2 max-w-[160px]">

--- a/src/components/campaigns/workspace/__tests__/CampaignDetailsTab.test.jsx
+++ b/src/components/campaigns/workspace/__tests__/CampaignDetailsTab.test.jsx
@@ -216,12 +216,27 @@ describe('CampaignDetailsTab — lucky-draw create flow', () => {
       <CampaignDetailsTab initial={null} type="lead_generation" draw isEdit={false} saving={false} onSubmit={onSubmit} />
     );
     fillBasics();
-    fireEvent.change(screen.getByLabelText('Session boost deadline'), { target: { value: '2026-08-15' } });
+    // AFTER the close (fillBasics sets 2026-08-31): an entrant may complete
+    // their session after entries close — that is the whole point of a
+    // separate boost deadline, and the engine requires boost >= close.
+    fireEvent.change(screen.getByLabelText('Session boost deadline'), { target: { value: '2026-09-15' } });
     fireEvent.change(screen.getByLabelText('Session multiplier'), { target: { value: '20' } });
     fireEvent.click(screen.getByRole('button', { name: /Create draft/i }));
     const ld = onSubmit.mock.calls[0][0].design_config.luckyDraw;
-    expect(ld.boostClosesAt).toBe('2026-08-15');
+    expect(ld.boostClosesAt).toBe('2026-09-15');
     expect(ld.multiplier).toBe(20);
+  });
+
+  it('a boost deadline BEFORE the close is refused instead of 422-ing at draw creation', () => {
+    const onSubmit = vi.fn();
+    render(
+      <CampaignDetailsTab initial={null} type="lead_generation" draw isEdit={false} saving={false} onSubmit={onSubmit} />
+    );
+    fillBasics();
+    fireEvent.change(screen.getByLabelText('Session boost deadline'), { target: { value: '2026-08-15' } });
+    expect(screen.getByText(/must be on or after 31 August 2026/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Create draft/i }));
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
   it('refuses to submit without a named prize row or close date', () => {


### PR DESCRIPTION
Two config shapes the product happily accepts, advertises to consumers, and then cannot honour.

## 1. A legacy `winners: N` bypassed both multi-prize guards

`totalPrizeQuantity` returned `0` whenever `prizes[]` was absent — but `normalizeLuckyDraw` still accepts a hand-set `winners` of 1..1000 in that legacy branch, and the consumer page renders it verbatim: *"3 winners, drawn in a witnessed process."*

So `{ prize: "3 × iPhone 17", winners: 3 }` activated cleanly, collected entries under those terms, and the engine is terminal after **one** claimed winner. The identical config written as `prizes: [{qty: 3, …}]` is correctly refused with `DRAW_MULTI_PRIZE_UNSUPPORTED`.

Counting `winners` in the legacy branch fixes both call sites at once, since `assertDrawActivatable` and `createDraw` read the same helper. An existing assertion pinned the `0` — it encoded the bug, so it's updated with a note.

## 2. The boost deadline was offered in the wrong direction

The engine requires `boostClosesAt >= closesAt` — *"must not be before closesAt"* — because an entrant may complete their review session **after** entries close, and the draw seals after that window.

But the Details form let you pick an earlier date, the AI clamp actively *preferred* one (`boost <= closesAt`, with the prompt telling the model the same), and `buildDrawTermsHtml` printed that date into the T&Cs. Draw creation then 422'd, and the only ways out were editing the config (which re-pins new terms) or voiding the promise.

Now the date input carries `min={closesAt}` with an inline reason, and the AI clamp snaps *up* instead of down.

## Test changes worth reviewing

Three existing assertions encoded the old direction and are deliberately flipped (each with a comment explaining why):
- `boostClosesAt: '2026-08-15'` with a 08-31 close now snaps to 08-31 instead of being kept
- a boost *after* the close now survives instead of snapping back
- a boost dated today snaps to the close, since `closesAt` is always in the future

vitest 145 files / 1796 green; backend 6 suites / 136 green; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEWmDbzT8RbS2LNEt9Y5bk
