### PR TITLE
fix(marketplace): the sponsor clause could never render; the age label lied

### DIFF
--- a/backend/src/utils/marketplaceContent.js
+++ b/backend/src/utils/marketplaceContent.js
@@ -160,7 +160,21 @@ export function normalizeMarketplaceContent(raw) {
   } else if (isPlainObject(raw.sponsor)) {
     const kind = cleanString(raw.sponsor.kind, 40);
     const disclosure = cleanString(raw.sponsor.disclosure, 400);
-    if (kind || disclosure) out.sponsor = { ...(kind ? { kind } : {}), ...(disclosure ? { disclosure } : {}) };
+    // `name` is the KEY the consent chain runs on: isSponsoredCampaign
+    // (src/lib/consentCopy.js) requires a non-empty sponsor.name before the
+    // named third-party clause renders at all. Dropping it here meant every
+    // save silently erased it, so the clause could never appear, and the whole
+    // agree-all sponsored path — clause -> consent_third_party -> external
+    // evidence -> externally-eligible routing — was dead code. Fail-closed, so
+    // nothing was ever wrongly disclosed; it just could not work.
+    const name = cleanString(raw.sponsor.name, 120);
+    if (kind || disclosure || name) {
+      out.sponsor = {
+        ...(name ? { name } : {}),
+        ...(kind ? { kind } : {}),
+        ...(disclosure ? { disclosure } : {}),
+      };
+    }
   }
 
   const valueLine = cleanString(raw.value_line, 80);

--- a/backend/test/marketplaceContent.test.js
+++ b/backend/test/marketplaceContent.test.js
@@ -104,3 +104,31 @@ describe('CONSUMER_CATEGORY_DEFS (tracker "taxonomy" — the ONE category source
     expect(consumerCategoryLabel('unknown_thing')).toBe('unknown_thing');
   });
 });
+
+describe('sponsor.name survives the clamp (the named third-party consent key)', () => {
+  it('keeps name alongside kind and disclosure', () => {
+    const out = normalizeMarketplaceContent({
+      sponsor: { name: '  Prudential Singapore ', kind: 'insurer', disclosure: 'Shared with a licensed rep.' },
+    });
+    expect(out.sponsor).toEqual({
+      name: 'Prudential Singapore',
+      kind: 'insurer',
+      disclosure: 'Shared with a licensed rep.',
+    });
+  });
+
+  it('a name-only sponsor is enough to survive — it is what gates the clause', () => {
+    expect(normalizeMarketplaceContent({ sponsor: { name: 'Acme' } }).sponsor).toEqual({ name: 'Acme' });
+  });
+
+  it('is idempotent — the old clamp erased the name on every re-save', () => {
+    const once = normalizeMarketplaceContent({ sponsor: { name: 'Acme', kind: 'insurer' } });
+    const twice = normalizeMarketplaceContent(once);
+    expect(twice.sponsor).toEqual({ name: 'Acme', kind: 'insurer' });
+  });
+
+  it('explicit null still clears the sponsor, and a blank name is not kept', () => {
+    expect(normalizeMarketplaceContent({ sponsor: null }).sponsor).toBe(null);
+    expect(normalizeMarketplaceContent({ sponsor: { name: '   ' } }).sponsor).toBeUndefined();
+  });
+});

--- a/src/pages/marketplace/MarketplaceOffer.jsx
+++ b/src/pages/marketplace/MarketplaceOffer.jsx
@@ -115,7 +115,7 @@ export default function MarketplaceOffer() {
   const valueLine = composeValueLine(campaign);
   const days = (dc.availability?.days || []).join(' · ');
   const slots = (dc.availability?.slots || []).join(' / ');
-  const ageLabel = ageLabelOf(dc);
+  const ageLabel = ageLabelOf(dc, campaign);
   const locNames = (partner.locations || []).map((l) => l.name).filter(Boolean).join(' · ') || (dc.mode === 'online' ? 'Online — enter from anywhere' : '—');
   const otpLabel = dc.otpChannel === 'whatsapp' ? 'WhatsApp' : 'SMS';
   const relatedCards = related.filter((c) => c.slug !== slug).slice(0, 3);

--- a/src/pages/marketplace/__tests__/ageLabel.test.js
+++ b/src/pages/marketplace/__tests__/ageLabel.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { ageLabelOf } from '../content';
+
+/**
+ * "Who it's for" vs the range the funnel actually enforces. `age_range` is
+ * hand-entered marketplace content with no default anywhere; the gate is the
+ * campaigns.min_age/max_age columns. They were unlinked.
+ */
+describe('ageLabelOf — the label must match the gate', () => {
+  it('falls back to the ENFORCED range when no age_range was ever typed', () => {
+    // The standard case: defaults 18-65, age_range never filled. This used to
+    // render "Everyone" and then reject a 70-year-old at the DOB field.
+    expect(ageLabelOf({}, { min_age: 18, max_age: 65 })).toBe('Ages 18–65');
+  });
+
+  it('an explicit age_range still wins — an operator who typed one meant it', () => {
+    expect(ageLabelOf({ age_range: { min: 25, max: 40 } }, { min_age: 18, max_age: 65 })).toBe('Ages 25–40');
+  });
+
+  it('school levels still win over both', () => {
+    expect(ageLabelOf({ school_levels: ['P1', 'P6'] }, { min_age: 18, max_age: 65 })).toBe('P1–P6');
+  });
+
+  it('an open-ended enforced range reads as a floor, and 21+ gets the adult label', () => {
+    expect(ageLabelOf({}, { min_age: 18, max_age: null })).toBe('Ages 18+');
+    expect(ageLabelOf({}, { min_age: 21, max_age: null })).toBe('Adults (21+)');
+  });
+
+  it('no campaign and no age_range is still null (callers render "Everyone")', () => {
+    expect(ageLabelOf({})).toBe(null);
+    expect(ageLabelOf({}, {})).toBe(null);
+  });
+});

--- a/src/pages/marketplace/content.js
+++ b/src/pages/marketplace/content.js
@@ -244,12 +244,25 @@ export function composeValueLine(campaign) {
   return `Worth S$${ops.retail_value}${dc.activation?.required ? ' · free with activation' : ' · free'}`;
 }
 
-export function ageLabelOf(dc = {}) {
+/**
+ * "Who it's for". `age_range` is hand-entered marketplace content; the range
+ * the funnel actually ENFORCES is campaigns.min_age/max_age (client
+ * getAgeValidationError + the server gate in prospectService). They were
+ * unlinked, and age_range has no default anywhere — so the standard case
+ * (defaults 18-65, age_range never filled) advertised "Everyone" and then
+ * rejected a 70-year-old at the DOB field. Falling back to the enforced
+ * columns makes the label honest; an explicit age_range still wins, because
+ * an operator who typed one meant it.
+ */
+export function ageLabelOf(dc = {}, campaign = null) {
   const lv = dc.school_levels || [];
-  const ar = dc.age_range || {};
   if (lv.length) return lv.length > 1 ? `${lv[0]}–${lv[lv.length - 1]}` : lv[0];
+  const explicit = dc.age_range || {};
+  const ar = explicit.min != null
+    ? explicit
+    : { min: campaign?.min_age ?? null, max: campaign?.max_age ?? null };
   if (ar.min == null) return null;
-  if (ar.max >= 99) return ar.min >= 21 ? 'Adults (21+)' : `Ages ${ar.min}+`;
+  if (ar.max == null || ar.max >= 99) return ar.min >= 21 ? 'Adults (21+)' : `Ages ${ar.min}+`;
   return `Ages ${ar.min}–${ar.max}`;
 }
 


### PR DESCRIPTION
Two consumer-facing gaps from the same audit. Both are cases where the product says one thing and does another.

## 1. `sponsor.name` was erased on every save

`normalizeMarketplaceContent` kept only `kind` and `disclosure`. But `isSponsoredCampaign` (`src/lib/consentCopy.js`) requires a **non-empty `sponsor.name`** before the named third-party clause renders at all.

So the entire agree-all sponsored path was dead code:

> no clause → `consent_third_party` always `false` → no external consent evidence → a campaign flagged `externalEligible` can never route a lead externally

Fail-closed, so nothing was ever wrongly disclosed — it simply could not work. No editor exposes the field (the Studio calls sponsor "ops/JSON-managed"), and a hand-posted name was clamped away on the next write. Includes an idempotency test, since the erasure happened on *re-saves* too.

## 2. "Who it's for" was unlinked from the gate that runs

`ageLabelOf` read `design_config.age_range` — hand-entered marketplace content with **no default anywhere** — while both the client validator and `prospectService` gate on the `campaigns.min_age` / `max_age` columns.

The standard case (defaults 18–65, `age_range` never filled) advertised **"Who it's for: Everyone"** and then rejected a 70-year-old at the DOB field. The inverse was equally possible: `age_range {21,30}` typed by hand while the columns stayed 18–65, with the columns winning.

Now falls back to the enforced columns. An explicit `age_range` still wins — an operator who typed one meant it — and school levels still win over both.

vitest 146 files / 1800 green; backend 3 suites / 82 green; build clean.

## Not included

The remaining audit finding — the draw-terms version being pinned at **submit** rather than at **render**, so an entrant can accept text they never saw — is deliberately left out. It needs client→server plumbing of the displayed version plus a decision about what to do on mismatch, and it lands in the consent chain that has counsel review queued. Worth its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEWmDbzT8RbS2LNEt9Y5bk
