### PR TITLE
fix(funnel): every customer modal slides up/down like a native phone sheet

### DIFF
--- a/src/components/campaignPage/drawTemplates.jsx
+++ b/src/components/campaignPage/drawTemplates.jsx
@@ -565,19 +565,33 @@ function Nightfall({ t, content, params, luckyDraw, funnel, formAnchorRef, mobil
         )}
         <div style={{ fontSize: 11, color: NF.faint }}>{content.regulatory}</div>
       </div>
-      {sheetOpen && (
-        <div
-          onClick={() => setSheetOpen(false)}
-          style={{ position: 'fixed', inset: 0, background: 'rgba(10,11,18,.55)', zIndex: 40 }}
-        />
-      )}
+      {/* Backdrop + sheet stay MOUNTED across open/close (the funnel's typed
+          fields + OTP state must survive a close/reopen) and animate like a
+          native phone sheet: slide up on open, slide back down on close.
+          visibility flips only after the slide-down so the closed sheet stays
+          out of the a11y tree / tab order exactly as display:none did. */}
+      <div
+        onClick={() => setSheetOpen(false)}
+        aria-hidden="true"
+        style={{
+          position: 'fixed', inset: 0, background: 'rgba(10,11,18,.55)', zIndex: 40,
+          opacity: sheetOpen ? 1 : 0,
+          pointerEvents: sheetOpen ? 'auto' : 'none',
+          transition: 'opacity 300ms cubic-bezier(0.25, 1, 0.5, 1)',
+        }}
+      />
       <div
         style={{
           position: 'fixed', left: 0, right: 0, bottom: 0, zIndex: 41,
           background: NF.card, color: NF.ink, borderRadius: '18px 18px 0 0',
           padding: '18px 20px 22px', boxShadow: '0 -12px 40px rgba(0,0,0,.4)',
           maxHeight: '88vh', overflowY: 'auto',
-          display: sheetOpen ? 'flex' : 'none', flexDirection: 'column', gap: 14,
+          display: 'flex', flexDirection: 'column', gap: 14,
+          transform: sheetOpen ? 'translateY(0)' : 'translateY(100%)',
+          visibility: sheetOpen ? 'visible' : 'hidden',
+          transition: sheetOpen
+            ? 'transform 300ms cubic-bezier(0.16, 1, 0.3, 1)'
+            : 'transform 300ms cubic-bezier(0.16, 1, 0.3, 1), visibility 0s linear 300ms',
         }}
       >
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 10 }}>

--- a/src/components/campaigns/ShareCampaignDialog.jsx
+++ b/src/components/campaigns/ShareCampaignDialog.jsx
@@ -13,6 +13,19 @@ export default function ShareCampaignDialog({ open, onOpenChange, campaignName, 
  const [shortening, setShortening] = useState(false);
  const [shortShareUrl, setShortShareUrl] = useState('');
  const [copied, setCopied] = useState(false);
+ // Presence: keep rendering through the close so the sheet can slide back
+ // down (phone-style) instead of vanishing. `open` drives enter/exit classes;
+ // `render` unmounts once the slide-down finishes (animationend + a safety
+ // timeout for environments that never fire it).
+ const [render, setRender] = useState(open);
+ useEffect(() => {
+ if (open) setRender(true);
+ }, [open]);
+ useEffect(() => {
+ if (open || !render) return undefined;
+ const t = setTimeout(() => setRender(false), 400);
+ return () => clearTimeout(t);
+ }, [open, render]);
 
  // Generate a shortlink when the dialog opens — UNLESS the backend already handed us the
  // canonical link at submit (serverShareUrl), which we then use directly. The fallback mint
@@ -56,7 +69,7 @@ export default function ShareCampaignDialog({ open, onOpenChange, campaignName, 
 
  const shareUrl = serverShareUrl || shortShareUrl || longShareUrl;
 
- if (!open) return null;
+ if (!render) return null;
 
  const close = () => {
  onOpenChange(false);
@@ -64,12 +77,22 @@ export default function ShareCampaignDialog({ open, onOpenChange, campaignName, 
  };
 
  return (
- <div ref={sheetRef} role="dialog" aria-modal="true" aria-label="Share campaign" className="fixed inset-0 z-50 flex items-end sm:items-center justify-center">
+ <div ref={sheetRef} role="dialog" aria-modal="true" aria-label="Share campaign" className={`fixed inset-0 z-50 flex items-end sm:items-center justify-center ${open ? '' : 'pointer-events-none'}`}>
  {/* Backdrop */}
- <button type="button" aria-label="Close share dialog" className="absolute inset-0 bg-foreground/60 cursor-default" onClick={close} />
+ <button
+ type="button"
+ aria-label="Close share dialog"
+ className={`absolute inset-0 bg-foreground/60 cursor-default duration-base ${open ? 'animate-in fade-in-0' : 'animate-out fade-out-0 fill-mode-forwards'}`}
+ onClick={close}
+ />
 
- {/* Sheet */}
- <div className="relative z-10 w-full sm:max-w-sm bg-card rounded-t-2xl sm:rounded-2xl shadow-2xl animate-in slide-in-from-bottom duration-200 max-h-[85vh] overflow-y-auto">
+ {/* Sheet — slides up on open and back down on close (phone-style) */}
+ <div
+ onAnimationEnd={() => {
+ if (!open) setRender(false);
+ }}
+ className={`relative z-10 w-full sm:max-w-sm bg-card rounded-t-2xl sm:rounded-2xl shadow-2xl duration-base ease-out-expo max-h-[85vh] overflow-y-auto ${open ? 'animate-in slide-in-from-bottom sm:fade-in-0' : 'animate-out slide-out-to-bottom fill-mode-forwards sm:fade-out-0'}`}
+ >
  {/* Header */}
  <div className="flex items-center justify-between px-5 pt-5 pb-3">
  <div className="flex-1">

--- a/src/components/campaigns/signup/ConsentAgreementDialog.jsx
+++ b/src/components/campaigns/signup/ConsentAgreementDialog.jsx
@@ -45,13 +45,16 @@ export default function ConsentAgreementDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
+      {/* Phone-style sheet under 640px (slides up/down from the bottom edge),
+          centered card from sm up. Width + radius live in responsive classes —
+          inline styles can't branch on viewport — with the themed modal radius
+          threaded through a CSS var. */}
       <DialogContent
-        className="border-0 p-0 gap-0"
+        variant="sheet"
+        className="border-0 p-0 gap-0 rounded-t-[var(--consent-modal-r)] rounded-b-none sm:rounded-[var(--consent-modal-r)] sm:w-[calc(100vw-32px)] sm:max-w-[520px]"
         style={{
+          '--consent-modal-r': `${RADIUS.modal}px`,
           backgroundColor: TOKENS.modal,
-          borderRadius: RADIUS.modal,
-          maxWidth: 520,
-          width: 'calc(100vw - 32px)',
           maxHeight: '85vh',
           padding: 0,
           boxShadow: TOKENS.colorScheme === 'dark'

--- a/src/components/ui/dialog.jsx
+++ b/src/components/ui/dialog.jsx
@@ -26,7 +26,20 @@ const DialogOverlay = React.forwardRef(({ className, ...props }, ref) => (
 ))
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
-const DialogContent = React.forwardRef(({ className, children, hideClose, ...props }, ref) => {
+// `variant="sheet"` (customer-funnel modals): phone-style bottom sheet under
+// 640px — slides up from the bottom edge on open and back down on close — and
+// a centered card with a soft rise/settle (no zoom) from sm up. The classes
+// are swapped wholesale rather than merged because tailwindcss-animate's
+// slide-* utilities all write the same --tw-enter/exit vars, so stylesheet
+// order (not className order) would decide a merge.
+const dialogContentVariants = {
+ default:
+ "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-micro data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+ sheet:
+ "fixed inset-x-0 bottom-0 top-auto z-50 grid w-full max-w-full gap-4 border bg-background p-6 shadow-lg rounded-t-2xl duration-base ease-out-expo data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-bottom sm:inset-x-auto sm:left-[50%] sm:top-[50%] sm:bottom-auto sm:max-w-lg sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg sm:data-[state=open]:fade-in-0 sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:slide-in-from-left-1/2 sm:data-[state=closed]:slide-out-to-left-1/2 sm:data-[state=open]:slide-in-from-top-[46%] sm:data-[state=closed]:slide-out-to-top-[46%]",
+}
+
+const DialogContent = React.forwardRef(({ className, children, hideClose, variant = "default", ...props }, ref) => {
  // Containment override for trees rendered inside the Studio DeviceFrame
  // iframe; undefined (the default everywhere else) keeps Radix's own
  // document.body portal, byte-identical to before.
@@ -37,7 +50,7 @@ const DialogContent = React.forwardRef(({ className, children, hideClose, ...pro
  <DialogPrimitive.Content
  ref={ref}
  className={cn(
- "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-micro data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+ dialogContentVariants[variant] ?? dialogContentVariants.default,
  className
  )}
  {...props}>


### PR DESCRIPTION
## What

The customer funnel's modals didn't move like phone sheets (report: "the modal doesnt slide up like phone. it should slide up and down, for all modals" — screenshot was the Nightfall draw template's entry sheet on redeem.sg). Three modals, three defects:

| Modal | Before | After |
|---|---|---|
| Nightfall entry sheet (`drawTemplates.jsx`) | `display: none/flex` flip — pops open/shut | 300ms out-expo slide up/down + backdrop fade |
| Consent agreement dialog (T&C agree-all) | centered zoom on every viewport | full-width bottom sheet sliding from the bottom edge under 640px; centered soft rise/settle (no zoom) from `sm` up |
| Share dialog (post-submit) | slid in, but `return null` on close = instant vanish | stays rendered through a slide-down + fade exit, then unmounts |

## How

- **`ui/dialog.jsx`**: opt-in `variant="sheet"` on `DialogContent`. Class strings are swapped wholesale, not merged — tailwindcss-animate's `slide-*` utilities all write the same `--tw-enter/exit` vars, so stylesheet order (not className order) would win a merge. **Default variant is byte-identical; admin dialogs untouched.**
- **Nightfall sheet**: transform/visibility transitions; the sheet stays mounted (typed fields + OTP state must survive close/reopen — unchanged invariant), `visibility` flips only after the slide-down so the closed sheet stays out of the a11y tree / tab order exactly as `display:none` did.
- **`ConsentAgreementDialog`**: adopts the sheet variant; width/radius move from inline styles to responsive classes (inline can't branch on viewport), themed modal radius rides a CSS var.
- **`ShareCampaignDialog`**: small presence state — `open` drives enter/exit classes, unmount on `animationend` with a 400ms safety timeout.

## Verification

- Full frontend suite: **1797/1797** vitest green (145 files). Nightfall sheet test still holds: closed sheet's close-button is out of the a11y tree, funnel mounted throughout.
- Playwright drive on **both brand builds** (redeem + mktr, 390×844), API stubbed, computed-style asserts:
  - closed sheet at rest: `translateY(306px)` + `visibility: hidden`, transitioning `transform, visibility`; open: `translateY(0)` + visible
  - consent dialog: `data-state=open`, bottom-anchored, full-width (390), enter animation, themed top-only radius
  - share dialog: mounted → `exit` animation → unmounted; mid-frame screenshots show each sheet half-risen / half-descended
  - no horizontal overflow (0px)
- `VITE_BRAND=redeem` and `VITE_BRAND=mktr` production builds green; all new Tailwind utilities present in the emitted CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqsFKDVK45eCqwTQJuyEbo