### PR TITLE
feat(wa-push): headline-led bodies for the _img template twins (watemplates)

### DIFF
--- a/backend/scripts/submit-wa-marketing-templates.mjs
+++ b/backend/scripts/submit-wa-marketing-templates.mjs
@@ -153,18 +153,44 @@ export const TEMPLATES = [
   },
 ];
 
-// Image-header twins: same body/footer/buttons, the text header becomes an
-// IMAGE header whose content is a send-time parameter ({link} or {id}). The
-// example handle is injected at submit time after the sample upload.
+// Image-header twins: footer/buttons unchanged, the text header becomes an
+// IMAGE header whose content is a send-time parameter ({link} or {id}), and
+// the body opens with a bold headline line — the text header carried the
+// headline in the text set, so without this the image twins had none (Shawn's
+// Manager adaptation, 2026-07-23). {{1}} stays the first name across the whole
+// pack; the headline reuses the title var. The example handle is injected at
+// submit time after the sample upload.
 const HANDLE_PLACEHOLDER = '<sample-handle-uploaded-at-submit>';
-export const IMAGE_TEMPLATES = TEMPLATES.map((t) => ({
-  ...t,
-  name: `${t.name}_img`,
-  components: [
-    { type: 'HEADER', format: 'IMAGE', example: { header_handle: [HANDLE_PLACEHOLDER] } },
-    ...t.components.filter((c) => c.type !== 'HEADER'),
-  ],
-}));
+const IMG_BODIES = {
+  marketing_new_campaign_img: {
+    text:
+      "*New reward: {{2}}*\n\nHi {{1}}, a new reward just went live on Redeem: *{{2}}*, from *{{3}}*.\n\nQuantities are limited and available on a first-come, first-served basis.\n\nTap below to view the reward and claim yours in about a minute.",
+    example: { body_text: [['Shawn', 'FairPrice $20 Voucher', 'FairPrice']] },
+  },
+  marketing_new_draw_img: {
+    text:
+      '*Now open: {{2}}*\n\nHi {{1}}, the {{2}} is open for entries — stand a chance to win *{{3}}*. Entries close {{4}}, and entering takes about a minute.\n\nGood luck 🍀',
+    example: { body_text: [['Shawn', 'Tokyo Getaway Lucky Draw', 'a 4D3N trip for two to Tokyo', '30 Oct 2026']] },
+  },
+  marketing_offer_img: {
+    text:
+      "*A little something for you*\n\nHi {{1}}, here's something we think you'll like: {{2}}. {{3}}.\n\nTap below to see the details — it takes less than a minute.",
+    example: { body_text: [['Shawn', 'a $10 GrabFood voucher when you sign up this week', 'Available while stocks last']] },
+  },
+};
+export const IMAGE_TEMPLATES = TEMPLATES.map((t) => {
+  const name = `${t.name}_img`;
+  return {
+    ...t,
+    name,
+    components: [
+      { type: 'HEADER', format: 'IMAGE', example: { header_handle: [HANDLE_PLACEHOLDER] } },
+      ...t.components
+        .filter((c) => c.type !== 'HEADER')
+        .map((c) => (c.type === 'BODY' ? { ...c, ...IMG_BODIES[name] } : c)),
+    ],
+  };
+});
 
 async function graphGet(path_, token) {
   const res = await fetch(`${BASE}${path_}`, { headers: { Authorization: `Bearer ${token}` } });

--- a/docs/plans/wa-marketing-template-pack.md
+++ b/docs/plans/wa-marketing-template-pack.md
@@ -83,7 +83,7 @@ Same body, footer, and buttons as their text twins; the header becomes **format 
 
 - **The image is a send-time parameter.** Meta reviews only a *sample*; every push can then attach that campaign's own hero (Tokyo art for the Tokyo draw, partner hero for a partner reward) with **no re-approval**. Prod precedent: `reward_pass`/`reward_voucher` already send a per-customer QR card PNG as an IMAGE header through `whatsappService.uploadQrPng`.
 - **Sample asset:** `backend/scripts/assets/wa-marketing-sample.png` — 1200×628 (Meta-recommended ~1.91:1), Editorial voucher-card palette/fonts (terracotta + Fraunces), generated with the same satori→resvg pipeline as the QR cards. Reviewers see this; it is also what Manager shows as the template preview.
-- **Trade-off vs text twins:** the text headline ("New reward: X") is lost — the hero must carry that job, and the body still names the offer. WhatsApp renders the image above the body; chat-list preview crops to ~1.91:1, so heroes should keep key content centered.
+- **Headline moves into the body** (Shawn's Manager adaptation, 2026-07-23): the text header is gone, so each `_img` body opens with a bold headline line — `*New reward: {{2}}*` / `*Now open: {{2}}*` / `*A little something for you*` — followed by the same sentences. `{{1}}` stays the first name across the whole pack; in the campaign/draw twins the headline reuses the title variable, so for `marketing_new_campaign_img` `{{2}}` is the **reward title** (e.g. "FairPrice $20 Voucher"), not the lowercase offer phrase the text twin uses. Variables may appear out of numeric order in the text (`{{2}}` before `{{1}}`) — Meta requires the *set* {{1}}…{{n}} with samples, not appearance order (Manager accepts it; verified live 2026-07-23). WhatsApp renders the image above the body; chat-list preview crops to ~1.91:1, so heroes should keep key content centered.
 
 Send-time header parameter (the `wapush` side): `{ type: 'image', image: { link: heroUrl } }` with a **public HTTPS JPEG/PNG ≤5 MB** (campaign heroes under `/uploads/` qualify), or upload-then-`{ id }` exactly like the QR path. WhatsApp does **not** take webp — if a stored hero is webp, `wapush` must transcode or fall back to the text twin.
 
@@ -134,7 +134,9 @@ Idempotent (skips names already on the WABA), auto-resolves the WABA id from the
 5. Paste body and footer; fill a sample for every body variable (samples are mandatory).
 6. Buttons → **Visit website**, label from §2, URL type **Dynamic**, `https://redeem.sg/{{1}}`, sample = a full LeadCapture URL. Then **Custom** quick reply `Stop promotions`.
 7. Submit. Repeat for `marketing_new_draw` and `marketing_offer` (§2.3 has a static header — skip the variable).
-8. For the `_img` twins: same steps but Header = **Image**, and drag-drop `backend/scripts/assets/wa-marketing-sample.png` as the sample. Everything else (body, samples, footer, buttons) is identical to the text twin.
+8. For the `_img` twins: attach **Media sample → Image** (drag-drop `backend/scripts/assets/wa-marketing-sample.png` — the actual PNG, not a screenshot of it) and leave the text Header **empty**; attaching media *is* what makes it an image-header template. Use the §2.4 headline-led bodies. Footer and buttons as the text twin.
+
+New-UI gotchas (seen live 2026-07-23): "Type of variable" stays **Number** (positional `{{n}}`, what the sender code passes); the CTA's **URL type must be Dynamic** — with Static selected, `{{1}}` in the URL is not a variable and the per-campaign suffix never attaches (flip to Dynamic, then fill the sample-URL field it reveals with a full LeadCapture URL); watch for accidental duplicate lines when pasting the body.
 
 ## 6. Approval: expected wait & tracking
 


### PR DESCRIPTION
Backports Shawn's live WhatsApp Manager adaptation into the canonical pack: the `_img` twins previously reused the text-set bodies unchanged, which lost the headline when the TEXT header was replaced by the image. Each `_img` body now opens with a bold headline line (`*New reward: {{2}}*` / `*Now open: {{2}}*` / `*A little something for you*`). `{{1}}` remains the first name across the pack; campaign-twin `{{2}}` becomes the reward **title**.

Doc updates: §2.4 headline contract + variable-order note (Meta validates the set {{1}}…{{n}}, not appearance order — confirmed live in Manager), §5B new-UI gotchas from the manual run (media sample ⇒ image header, **URL type must be Dynamic**, variable type Number).

Verification: `node --check` OK; `--dry` machine-lint across all 6 payloads incl. headline-presence assertion on the 3 twins — pass. Script-only; no runtime imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDco6HwKLHpmRgE5YR8Za2