### PR TITLE
feat(screening): delivery integrity — provenance-aware hold targets, self-healing releases, loud alarms (PR-1)

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -150,6 +150,9 @@ RETELL_SCREENING_ENABLED=false
 # SCREENING_ON_UNREACHABLE=release
 # SCREENING_SWEEP_INTERVAL_MINUTES=5
 # SCREENING_DRY_RUN=false
+# Ops email for "qualified lead stuck — no deliverable agent" alerts
+# (throttled 1/campaign/24h). Falls back to SMS_ALERT_EMAIL when unset.
+# SCREENING_ALERT_EMAIL=ops@example.com
 
 # Webhook dispatch — MUST be "true" for leads to reach Lyfe
 WEBHOOK_ENABLED=false

--- a/backend/src/services/campaignReadinessService.js
+++ b/backend/src/services/campaignReadinessService.js
@@ -73,10 +73,20 @@ export function computeReadiness(facts) {
     hasDrawRecord = false,
     hasLiveDraw = false,
     drawIntakeOpen = false,
+    drawClosesPastDue = false,
     drawCloseMismatch = false,
     docDrawClosesAt = null,
     drawRecordClosesAt = null,
     drawTotalPrizes = 0,
+    // Screening facts (PR-1, draw-launch-integrity §2.3) default SILENT — the
+    // row only means anything when the feature is configured AND the campaign
+    // opted in.
+    screeningConfigured = false,
+    screeningGateOn = false,
+    // Funded-pool credit facts (PR-1): sums over the same assignments that
+    // produce assignableAgents. Default 0/0 = row silent.
+    poolCreditsRemaining = 0,
+    poolCreditsTotal = 0,
   } = facts || {};
 
   // Brand-awareness (PHV tablet) campaigns don't capture leads → readiness N/A.
@@ -96,6 +106,36 @@ export function computeReadiness(facts) {
       code: 'no_agent_pool',
       message:
         'No agent has an active lead package for this campaign — leads will sit with the System Agent, undelivered, until a package is assigned (they stay in MKTR and can be reassigned later). Fine for reward-only or test campaigns; assign a package before real ad spend.',
+    });
+  }
+
+  // Screening × funding (PR-1, Codex R1 CX3+/CX19 — specializes no_agent_pool,
+  // never duplicates it silently): with the screening gate on and NO funded
+  // agent, every entrant is dialed and qualified into a hold nobody can
+  // receive. Since PR-1's provenance-aware bake the hold SELF-HEALS once a
+  // package is funded, so pre-launch this is a warning; on a LIVE campaign it
+  // is the top go-live risk and shows critical. Deliberately NOT a launch
+  // 422 (decision D7): the pre-launch level is warning, so activation is never
+  // newly blocked.
+  if (screeningConfigured && screeningGateOn && assignableAgents === 0) {
+    issues.push({
+      level: isActive ? 'critical' : 'warning',
+      code: 'screening_no_funded_route',
+      message: isActive
+        ? 'AI screening is ON but no agent has a funded lead package — entrants are being called and qualified into a held queue nobody can receive. Fund a package now; held leads auto-deliver within ~5 minutes once funded.'
+        : 'AI screening is ON but no agent has a funded lead package yet — qualified leads will wait held (they auto-deliver once a package is funded). Fund one before real traffic.',
+    });
+  }
+
+  // WARNING — funded pool is nearly dry on a screening/draw campaign. At zero
+  // the rows above take over; this is the tripwire BEFORE the dead-end re-arms
+  // (Codex R1 G26: the 07-24 fix wears off silently at 0 credits).
+  if ((screeningGateOn || drawEnabled) && poolCreditsTotal > 0 && poolCreditsRemaining > 0
+      && poolCreditsRemaining * 5 < poolCreditsTotal) {
+    issues.push({
+      level: 'warning',
+      code: 'lead_credits_low',
+      message: `The funded lead pool is nearly exhausted (${poolCreditsRemaining} of ${poolCreditsTotal} credits left). At zero, new screened/draw leads hold undelivered until a package is topped up.`,
     });
   }
 
@@ -198,6 +238,17 @@ export function computeReadiness(facts) {
         'The lucky draw is enabled but no draw record exists. Entries are being accepted, but ops cannot freeze the pool or pick a winner until a draw is created (Redeem Ops → Draws).',
     });
   }
+  // ESCALATION (PR-1, CX19): past the close date with still no (non-void) draw
+  // record, the T&C's promised witnessed draw cannot run — entries have closed
+  // into nothing. Critical so it cannot be missed; hasDrawRecord already
+  // excludes void records (a voided draw does not satisfy the promise).
+  if (drawEnabled && !hasDrawRecord && drawClosesPastDue) {
+    issues.push({
+      level: 'critical',
+      code: 'draw_record_missing',
+      message: `Entries closed${docDrawClosesAt ? ` on ${docDrawClosesAt}` : ''} but NO draw record exists — the witnessed draw promised in the T&C cannot run. Create and freeze it now (backend/scripts/run-lucky-draw.js).`,
+    });
+  }
   if (drawEnabled && hasLiveDraw && drawCloseMismatch) {
     issues.push({
       level: 'warning',
@@ -255,7 +306,7 @@ export async function loadCampaignReadiness(campaignId) {
   const { Op } = await import('sequelize');
 
   const campaign = await Campaign.findByPk(campaignId, {
-    attributes: ['id', 'name', 'type', 'is_active', 'design_config'],
+    attributes: ['id', 'name', 'type', 'is_active', 'status', 'design_config'],
   });
   if (!campaign) {
     return {
@@ -272,12 +323,14 @@ export async function loadCampaignReadiness(campaignId) {
   const assignments = await LeadPackageAssignment.findAll({
     where: { status: 'active', leadsRemaining: { [Op.gt]: 0 } },
     include: [{ model: LeadPackage, as: 'package', where: { campaignId }, required: true, attributes: [] }],
-    attributes: ['agentId'],
+    attributes: ['agentId', 'leadsRemaining', 'leadsTotal'],
   });
   const candidateIds = [...new Set(assignments.map((a) => a.agentId))];
 
   let assignableAgents = 0;
   let agentsMissingPhone = 0;
+  let poolCreditsRemaining = 0;
+  let poolCreditsTotal = 0;
   if (candidateIds.length > 0) {
     const agents = await User.findAll({
       where: { id: candidateIds, role: 'agent', isActive: true },
@@ -285,6 +338,14 @@ export async function loadCampaignReadiness(campaignId) {
     });
     assignableAgents = agents.length;
     agentsMissingPhone = agents.filter((a) => !a.phone || String(a.phone).trim() === '').length;
+    // Credit sums over the SAME pool the router draws from (active-agent
+    // assignments only) — the lead_credits_low tripwire (PR-1).
+    const activeIds = new Set(agents.map((a) => a.id));
+    for (const a of assignments) {
+      if (!activeIds.has(a.agentId)) continue;
+      poolCreditsRemaining += Number(a.leadsRemaining) || 0;
+      poolCreditsTotal += Number(a.leadsTotal) || 0;
+    }
   }
 
   // v2-safe as-is: quiz + guidedReview are top-level verbatim-passthrough keys
@@ -307,7 +368,16 @@ export async function loadCampaignReadiness(campaignId) {
     );
   });
   const webhookEnabled = process.env.WEBHOOK_ENABLED === 'true';
-  const isActive = campaign.is_active !== false;
+  // BOTH signals (PR-1, Codex R1 CX19): archive flips `status` but not always
+  // `is_active` — reading the flag alone showed archived campaigns as live.
+  const isActive = campaign.is_active !== false
+    && (campaign.status == null || String(campaign.status) === 'active');
+
+  // Screening facts (PR-1): feature-configured (env) × campaign gate (design).
+  // Lazy import keeps the pure export's import graph model-free.
+  const { screeningConfig } = await import('./screeningGate.js');
+  const screeningConfigured = screeningConfig().configured === true;
+  const screeningGateOn = readLegacyViewSafe(design, {}).screeningCallAtSubmit === true;
 
   // OTP send-path facts (PR 5). Channel byte-mirrors verificationService's
   // resolution; cred booleans are explicitly coerced — raw env strings must
@@ -330,9 +400,12 @@ export async function loadCampaignReadiness(campaignId) {
   let drawCloseMismatch = false;
   let docDrawClosesAt = null;
   let drawRecordClosesAt = null;
+  let drawClosesPastDue = false;
   if (drawEnabled) {
+    // Void records don't count (PR-1, CX19): a voided draw does not satisfy the
+    // "witnessed draw" promise, so it must not suppress draw_record_missing.
     const record = await Draw.findOne({
-      where: { campaignId },
+      where: { campaignId, status: { [Op.ne]: 'void' } },
       order: [['createdAt', 'DESC']],
       attributes: ['id', 'status', 'closesAt'],
     });
@@ -341,6 +414,7 @@ export async function loadCampaignReadiness(campaignId) {
     const docEndMs = ld?.closesAt ? sgtDayEndExclusiveMs(ld.closesAt) : null;
     docDrawClosesAt = ld?.closesAt || null;
     drawIntakeOpen = docEndMs !== null && docEndMs > Date.now();
+    drawClosesPastDue = docEndMs !== null && docEndMs <= Date.now();
     if (hasLiveDraw && docEndMs !== null) {
       const recordMs = new Date(record.closesAt).getTime();
       drawCloseMismatch = Number.isFinite(recordMs) && recordMs !== docEndMs;
@@ -371,10 +445,15 @@ export async function loadCampaignReadiness(campaignId) {
     hasDrawRecord,
     hasLiveDraw,
     drawIntakeOpen,
+    drawClosesPastDue,
     drawCloseMismatch,
     docDrawClosesAt,
     drawRecordClosesAt,
     drawTotalPrizes: totalPrizeQuantity(ld),
+    screeningConfigured,
+    screeningGateOn,
+    poolCreditsRemaining,
+    poolCreditsTotal,
   });
 
   return {

--- a/backend/src/services/dncGate.js
+++ b/backend/src/services/dncGate.js
@@ -65,6 +65,9 @@ const defaultDeps = {
   // Injectable so gateHeldDncLead can be unit-tested without the release tx (the real
   // function is hoisted and bound below).
   releaseDncClearedLead: (...args) => releaseDncClearedLead(...args),
+  // Lazy (dynamic-import) like screeningHandoff: dncGate's static import graph
+  // must stay untouched for the existing unit-suite mocks (PR-1, Codex R1 CX1).
+  resolveLeadRouting: async (args) => (await import('./systemAgent.js')).resolveLeadRouting(args),
 };
 
 /**
@@ -76,6 +79,18 @@ const defaultDeps = {
  */
 export async function releaseDncClearedLead({ prospect, agentId, alreadyCharged = false }, overrides = {}) {
   const d = { ...defaultDeps, ...overrides };
+  if (!agentId && prospect.campaignId) {
+    // PR-1 (draw-launch-integrity §9.1 CX1): a null-baked target (fallback
+    // route at capture — no deliverable agent existed) re-resolves at release
+    // time, exactly like screeningGate's release. Refuse fallback results: the
+    // provenance-less System Agent would fail delivery downstream anyway
+    // (destination null → default-deny). Held leads therefore AUTO-HEAL once a
+    // funded package appears — the DNC backfill retries this path.
+    const routing = await d.resolveLeadRouting({
+      reqUser: null, requestedAgentId: null, campaignId: prospect.campaignId, qrTagId: null,
+    }).catch(() => null);
+    if (routing?.agentId && routing.via !== 'fallback') agentId = routing.agentId;
+  }
   if (!agentId) {
     d.logger.warn('[DNC] cleared lead has no intended agent — left held for backfill/admin', { prospectId: prospect.id });
     return { released: false, reason: 'no_intended_agent' };

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -901,12 +901,30 @@ export function makeProspectService(overrides = {}) {
         });
       }
 
+      // Hold-target bake rule (PR-1, draw-launch-integrity §9.1 CX3+): a
+      // fallback-routed hold may only bake a target that can actually be
+      // DELIVERED to later. The System Agent has no lyfeId/mktrLeadsId, so a
+      // release to it default-denies (null destination) and the lead loops
+      // held forever — the 07-24 prod incident. A provenance-carrying
+      // DEFAULT_AGENT_ID also arrives via='fallback' and MUST keep its bake
+      // (it delivers fine), so the rule is provenance-based, not via-based.
+      // Null bake ⇒ release-time re-resolution ⇒ the hold self-heals the
+      // moment a funded package appears. Non-fallback routes are untouched.
+      const bakeIntendedAgentId = async (candidateId) => {
+        if (!candidateId || routeVia !== 'fallback') return candidateId ?? null;
+        const u = await m.User.findByPk(candidateId, {
+          attributes: ['id', 'lyfeId', 'mktrLeadsId'],
+          transaction: t,
+        }).catch(() => null);
+        return u && (u.lyfeId || u.mktrLeadsId) ? candidateId : null;
+      };
+
       // DNC block-mode gate: a normally-assignable INTERNAL lead is HELD pending a DNC
       // check (released post-commit on clear). Never overrides an existing quarantine
       // (quota / external) or an external-buyer route. The credit is charged on release
       // (unless decideAssignment already charged a funded gated route → dncAlreadyCharged).
       if (dncBlockApplies && decision.action !== 'quarantine' && !externalAgentId) {
-        dncIntendedAgentId = decision.assignedAgentId ?? assignedAgentId ?? null;
+        dncIntendedAgentId = await bakeIntendedAgentId(decision.assignedAgentId ?? assignedAgentId ?? null);
         dncAlreadyCharged = decision.charged === true;
         dncHeld = true;
         decision = { action: 'quarantine', quarantineReason: 'dnc_pending', charged: dncAlreadyCharged, via: routeVia };
@@ -919,7 +937,7 @@ export function makeProspectService(overrides = {}) {
       let screeningIntendedAgentId = null;
       let screeningAlreadyCharged = false;
       if (screeningWanted && decision.action !== 'quarantine' && !externalAgentId) {
-        screeningIntendedAgentId = decision.assignedAgentId ?? assignedAgentId ?? null;
+        screeningIntendedAgentId = await bakeIntendedAgentId(decision.assignedAgentId ?? assignedAgentId ?? null);
         screeningAlreadyCharged = decision.charged === true;
         screeningHeld = true;
         decision = { action: 'quarantine', quarantineReason: 'screening_pending', charged: screeningAlreadyCharged, via: routeVia };

--- a/backend/src/services/retellScreeningService.js
+++ b/backend/src/services/retellScreeningService.js
@@ -172,7 +172,12 @@ export function makeRetellScreeningService(overrides = {}) {
       if (!screeningApplies({ campaign: camp, prospect }, cfg)) {
         return { status: 'skipped', reason: 'gate_not_applicable' };
       }
-      if (camp && !['active'].includes(String(camp.status || 'active')) && camp.is_active === false) {
+      // Either signal alone stops NEW dials (PR-1, Codex R1 CX20 — the old
+      // `&&` let an archived campaign that kept is_active=true keep dialing).
+      // Delivery of already-QUALIFIED holds is deliberately state-independent
+      // (drain philosophy): dialing is new spend + a customer touch on a
+      // stopped campaign; releasing a captured, qualified lead is fulfilment.
+      if (camp && (String(camp.status || 'active') !== 'active' || camp.is_active === false)) {
         return { status: 'skipped', reason: 'campaign_inactive' };
       }
       if (prospect.quarantineReason !== 'screening_pending' || prospect.screeningActiveCallId || prospect.screeningVerdict) {

--- a/backend/src/services/screeningAlerts.js
+++ b/backend/src/services/screeningAlerts.js
@@ -1,0 +1,132 @@
+import { sequelize, ProspectActivity } from '../models/index.js';
+import IdempotencyKey from '../models/IdempotencyKey.js';
+import { sendEmail } from './mailer.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * screeningAlerts — loud-failure surfacing for the undeliverable-hold state
+ * (docs/plans/draw-launch-integrity-scope.md §2.2, Codex R1 CX-fold).
+ *
+ * The state it alarms: a lead PASSED the AI screening call but release keeps
+ * failing (`no_intended_agent` / `no_subscriber`) because the campaign has no
+ * funded, provenance-carrying agent. Before PR-1 this looped as one warn line
+ * per 5-min sweep pass, forever, visible only in Render logs — the exact
+ * silent state the 07-24 prod incident sat in for hours.
+ *
+ * Two channels, both idempotent:
+ *  - ONE ProspectActivity per lead ("fund a package"), so the admin drawer
+ *    shows WHY the lead is stuck without log access.
+ *  - ONE ops email per campaign per 24h (throttled via idempotency_keys —
+ *    `key` is the table's PRIMARY KEY, so the throttle key embeds the scope
+ *    prefix and an expired row is refreshed in place, never insert-raced).
+ *
+ * Only alarms holds older than MIN_HOLD_ALERT_MS: a capture-time transient
+ * (subscriber briefly disabled, race with funding) must not page anyone —
+ * the 5-min sweep retries reach here again once the hold is genuinely stale.
+ */
+
+const MIN_HOLD_ALERT_MS = 30 * 60 * 1000; // 30 min held-and-qualified before alarming
+const EMAIL_THROTTLE_MS = 24 * 60 * 60 * 1000; // one ops email per campaign per day
+const ACTIVITY_ALERT_TAG = 'screening_undeliverable';
+const THROTTLE_SCOPE = 'screening:undeliverable-alert';
+
+function alertRecipient() {
+  return process.env.SCREENING_ALERT_EMAIL || process.env.SMS_ALERT_EMAIL || null;
+}
+
+const defaultDeps = {
+  sequelize,
+  ProspectActivity,
+  IdempotencyKey,
+  sendEmail,
+  logger,
+  now: () => Date.now(),
+};
+
+/**
+ * Fire-and-forget alarm for one undeliverable qualified hold. Never throws.
+ * Returns a status object for tests/logs.
+ */
+export async function notifyUndeliverableHold({ prospect, reason, campaign = null }, overrides = {}) {
+  const d = { ...defaultDeps, ...overrides };
+  try {
+    const heldAt = prospect?.quarantinedAt ? new Date(prospect.quarantinedAt).getTime() : NaN;
+    if (!Number.isFinite(heldAt) || d.now() - heldAt < MIN_HOLD_ALERT_MS) {
+      return { alerted: false, reason: 'too_fresh' };
+    }
+
+    // Once-per-lead activity. metadata->>'alert' is the dedup tag — checked
+    // with a raw indexed-enough probe (small per-prospect activity sets).
+    const [rows] = await d.sequelize.query(
+      `SELECT 1 FROM prospect_activities
+        WHERE "prospectId" = :id AND metadata->>'alert' = :tag LIMIT 1`,
+      { replacements: { id: prospect.id, tag: ACTIVITY_ALERT_TAG } }
+    );
+    const activityExists = Array.isArray(rows) && rows.length > 0;
+    if (!activityExists) {
+      await d.ProspectActivity.create({
+        prospectId: prospect.id,
+        type: 'updated',
+        actorUserId: null,
+        description:
+          'Held — passed AI screening but has no deliverable agent. Fund a lead package for this campaign; the sweep auto-delivers within ~5 minutes once funded.',
+        metadata: { alert: ACTIVITY_ALERT_TAG, reason },
+      });
+    }
+
+    // Per-campaign 24h email throttle. `key` is the PK — no row expiry job
+    // exists, so an expired throttle row is UPDATEd back to life rather than
+    // re-created (insert would PK-collide forever after the first day).
+    const to = alertRecipient();
+    if (!to) return { alerted: !activityExists, email: 'unconfigured' };
+
+    const throttleKey = `${THROTTLE_SCOPE}:${prospect.campaignId || 'none'}`;
+    const nowMs = d.now();
+    const existing = await d.IdempotencyKey.findOne({ where: { key: throttleKey } });
+    if (existing && new Date(existing.expiresAt).getTime() > nowMs) {
+      return { alerted: !activityExists, email: 'throttled' };
+    }
+    if (existing) {
+      await existing.update({ expiresAt: new Date(nowMs + EMAIL_THROTTLE_MS) });
+    } else {
+      await d.IdempotencyKey.create({
+        key: throttleKey,
+        scope: THROTTLE_SCOPE,
+        responseBody: { campaignId: prospect.campaignId || null },
+        responseCode: 200,
+        expiresAt: new Date(nowMs + EMAIL_THROTTLE_MS),
+      }).catch((err) => {
+        // Lost a same-instant race — the winner sends; treat as throttled.
+        if (err?.name === 'SequelizeUniqueConstraintError') return null;
+        throw err;
+      });
+    }
+
+    const campaignName = campaign?.name || prospect.campaignId || 'unknown campaign';
+    const heldMins = Math.round((nowMs - heldAt) / 60000);
+    await d.sendEmail({
+      to,
+      subject: `[MKTR] Qualified lead stuck ${heldMins}m — no deliverable agent (${campaignName})`,
+      text: [
+        `A lead passed the AI screening call but cannot be delivered (${reason}).`,
+        '',
+        `Campaign: ${campaignName} (${prospect.campaignId || '-'})`,
+        `Lead: ${prospect.id} — held since ${new Date(heldAt).toISOString()} (${heldMins} min)`,
+        '',
+        'Action: assign a funded lead package to this campaign (mktr.sg admin → Packages).',
+        'The screening sweep retries every 5 minutes and will deliver automatically once a funded agent exists.',
+        'Further leads on this campaign will hit the same wall until then; this alert is throttled to one per campaign per 24h.',
+      ].join('\n'),
+    });
+    d.logger.info('[Screening] undeliverable-hold alert emailed', { prospectId: prospect.id, campaignId: prospect.campaignId, to });
+    return { alerted: true, email: 'sent' };
+  } catch (err) {
+    d.logger.warn('[Screening] undeliverable-hold alert failed (non-blocking)', {
+      prospectId: prospect?.id,
+      error: err?.message || String(err),
+    });
+    return { alerted: false, error: err?.message };
+  }
+}
+
+export default { notifyUndeliverableHold };

--- a/backend/src/services/screeningGate.js
+++ b/backend/src/services/screeningGate.js
@@ -4,6 +4,7 @@ import { persistEventDeliveries, flushDeliveries } from './webhookService.js';
 import { buildLeadCreatedPayload, destinationForAgent, externalIdForDestination } from './prospectHelpers.js';
 import { resolveLeadRouting } from './systemAgent.js';
 import { phoneVerificationIsCurrent } from './consumerService.js';
+import { notifyUndeliverableHold } from './screeningAlerts.js';
 import { readLegacyViewSafe } from '../utils/designConfigV2Clamp.js';
 import { SCREENING_REASONS } from './screeningConstants.js';
 import { logger } from '../utils/logger.js';
@@ -45,6 +46,7 @@ const defaultDeps = {
   destinationForAgent,
   externalIdForDestination,
   resolveLeadRouting,
+  notifyUndeliverableHold,
   logger,
 };
 
@@ -187,10 +189,26 @@ export function makeScreeningGate(overrides = {}) {
   async function releaseScreenedLead({ prospect, unscreened = false, via = 'screening_qualified' }) {
     const meta = prospect.screeningMetadata || {};
     const campaign = await loadCampaignFor(prospect, d);
+    const alreadyCharged = meta.alreadyCharged === true && meta.chargeRefunded !== true;
 
     let agentId = meta.intendedAgentId || null;
+    // Stale-route revalidation (Codex R1 CX4): a target baked at capture may
+    // have been deactivated or role-changed since. Only for UNCHARGED leads —
+    // a charged lead's refund bookkeeping is keyed to its charged agent, so a
+    // stale-but-charged target keeps its id (PR-2's chargedAgentId split owns
+    // the recharge story).
+    if (agentId && !alreadyCharged) {
+      const current = await d.User.findByPk(agentId, { attributes: ['id', 'role', 'isActive'] }).catch(() => null);
+      if (!current || current.role !== 'agent' || current.isActive !== true) {
+        d.logger.warn('[Screening] release: stored agent no longer valid — re-resolving', {
+          prospectId: prospect.id, staleAgentId: agentId,
+        });
+        agentId = null;
+      }
+    }
     if (!agentId && prospect.campaignId) {
-      // Intended agent gone (deactivated, joined later, quota re-shuffle) —
+      // Intended agent gone (deactivated, joined later, quota re-shuffle) or
+      // deliberately null-baked at capture (fallback route, PR-1) —
       // re-resolve. Only a real funded route may receive the lead; the
       // System-Agent fallback would recreate the known delivery gap.
       const routing = await d.resolveLeadRouting({
@@ -200,10 +218,13 @@ export function makeScreeningGate(overrides = {}) {
     }
     if (!agentId) {
       d.logger.warn('[Screening] release: no deliverable agent — left held', { prospectId: prospect.id });
+      // Loud-failure surfacing (§2.2): once-per-lead activity + throttled ops
+      // email once the hold is stale. Fire-and-forget — alarms never block or
+      // reorder the release path.
+      Promise.resolve(d.notifyUndeliverableHold?.({ prospect, reason: 'no_intended_agent', campaign }))
+        .catch(() => {});
       return { released: false, reason: 'no_intended_agent' };
     }
-
-    const alreadyCharged = meta.alreadyCharged === true && meta.chargeRefunded !== true;
     const quotaEnforced = campaign?.enforceLeadQuota === true
       || (Number.isInteger(campaign?.leadPriceCents) && campaign.leadPriceCents > 0);
 
@@ -288,6 +309,10 @@ export function makeScreeningGate(overrides = {}) {
       if (!deliveryPairs || deliveryPairs.length === 0) {
         await t.rollback();
         d.logger.warn('[Screening] release: no delivery subscriber — re-holding', { prospectId: prospect.id, destination });
+        // Same loud-failure surfacing as no_intended_agent: this branch is the
+        // provenance-less-assignee dead-end (destination null → default-deny).
+        Promise.resolve(d.notifyUndeliverableHold?.({ prospect, reason: 'no_subscriber', campaign }))
+          .catch(() => {});
         return { released: false, reason: 'no_subscriber' };
       }
 

--- a/backend/test/unit/campaignReadinessRows.test.js
+++ b/backend/test/unit/campaignReadinessRows.test.js
@@ -1,0 +1,87 @@
+/**
+ * computeReadiness — PR-1 rows (draw-launch-integrity §2.3, Codex R1 CX19).
+ * Pure-function tests, no DB: screening_no_funded_route (level follows live
+ * state), lead_credits_low (tripwire before the dead-end re-arms at zero),
+ * and the draw_record_missing past-due escalation.
+ */
+import { computeReadiness } from '../../src/services/campaignReadinessService.js';
+
+const codes = (r) => r.issues.map((i) => `${i.level}:${i.code}`);
+
+const BASE = {
+  type: 'lead_generation',
+  isActive: true,
+  webhookEnabled: true,
+  smsOtpConfigured: true,
+  assignableAgents: 1,
+  poolCreditsRemaining: 10,
+  poolCreditsTotal: 10,
+};
+
+describe('screening_no_funded_route', () => {
+  it('LIVE campaign + gate on + configured + zero funded agents → CRITICAL', () => {
+    const r = computeReadiness({ ...BASE, assignableAgents: 0, poolCreditsRemaining: 0, poolCreditsTotal: 0, screeningConfigured: true, screeningGateOn: true });
+    expect(codes(r)).toContain('critical:screening_no_funded_route');
+    expect(r.ready).toBe(false);
+    // The generic pool row still fires alongside — specialization, not replacement.
+    expect(codes(r)).toContain('warning:no_agent_pool');
+  });
+
+  it('pre-launch (inactive) → WARNING only, never blocks activation (D7)', () => {
+    const r = computeReadiness({ ...BASE, isActive: false, assignableAgents: 0, poolCreditsRemaining: 0, poolCreditsTotal: 0, screeningConfigured: true, screeningGateOn: true });
+    expect(codes(r)).toContain('warning:screening_no_funded_route');
+    expect(codes(r)).not.toContain('critical:screening_no_funded_route');
+    expect(r.ready).toBe(true);
+  });
+
+  it('silent when the feature is dark, the gate is off, or a funded agent exists', () => {
+    const dark = computeReadiness({ ...BASE, assignableAgents: 0, screeningConfigured: false, screeningGateOn: true });
+    const gateOff = computeReadiness({ ...BASE, assignableAgents: 0, screeningConfigured: true, screeningGateOn: false });
+    const funded = computeReadiness({ ...BASE, screeningConfigured: true, screeningGateOn: true });
+    for (const r of [dark, gateOff, funded]) {
+      expect(codes(r).join()).not.toContain('screening_no_funded_route');
+    }
+  });
+});
+
+describe('lead_credits_low', () => {
+  it('fires under 20% on a screening campaign', () => {
+    const r = computeReadiness({ ...BASE, screeningGateOn: true, screeningConfigured: true, poolCreditsRemaining: 1, poolCreditsTotal: 10 });
+    expect(codes(r)).toContain('warning:lead_credits_low');
+  });
+
+  it('fires for draw campaigns too, and stays quiet at exactly 20%', () => {
+    const low = computeReadiness({ ...BASE, drawEnabled: true, poolCreditsRemaining: 19, poolCreditsTotal: 100 });
+    const at20 = computeReadiness({ ...BASE, drawEnabled: true, poolCreditsRemaining: 20, poolCreditsTotal: 100 });
+    expect(codes(low)).toContain('warning:lead_credits_low');
+    expect(codes(at20).join()).not.toContain('lead_credits_low');
+  });
+
+  it('silent at ZERO remaining (the zero-state rows own that) and on plain campaigns', () => {
+    const zero = computeReadiness({ ...BASE, screeningGateOn: true, poolCreditsRemaining: 0, poolCreditsTotal: 10 });
+    const plain = computeReadiness({ ...BASE, poolCreditsRemaining: 1, poolCreditsTotal: 10 });
+    expect(codes(zero).join()).not.toContain('lead_credits_low');
+    expect(codes(plain).join()).not.toContain('lead_credits_low');
+  });
+});
+
+describe('draw_record_missing escalation', () => {
+  it('intake open + no record → the existing WARNING (unchanged)', () => {
+    const r = computeReadiness({ ...BASE, drawEnabled: true, hasDrawRecord: false, drawIntakeOpen: true });
+    expect(codes(r)).toContain('warning:draw_record_missing');
+    expect(r.ready).toBe(true);
+  });
+
+  it('PAST DUE + still no record → CRITICAL (the witnessed-draw promise cannot run)', () => {
+    const r = computeReadiness({ ...BASE, drawEnabled: true, hasDrawRecord: false, drawIntakeOpen: false, drawClosesPastDue: true, docDrawClosesAt: '2026-09-30' });
+    const row = r.issues.find((i) => i.code === 'draw_record_missing');
+    expect(row.level).toBe('critical');
+    expect(row.message).toContain('2026-09-30');
+    expect(r.ready).toBe(false);
+  });
+
+  it('a record existing silences both levels', () => {
+    const r = computeReadiness({ ...BASE, drawEnabled: true, hasDrawRecord: true, drawClosesPastDue: true });
+    expect(codes(r).join()).not.toContain('draw_record_missing');
+  });
+});

--- a/backend/test/unit/dncGate.test.js
+++ b/backend/test/unit/dncGate.test.js
@@ -142,6 +142,9 @@ describe('releaseDncClearedLead', () => {
         buildLeadCreatedPayload: jest.fn(() => ({ event: 'lead.created' })),
         destinationForAgent: jest.fn(() => 'lyfe'),
         externalIdForDestination: jest.fn(() => 'L1'),
+        // PR-1: null-agent releases re-resolve; default to an unfundable pool
+        // (fallback) so pre-PR-1 cases keep their exact outcomes hermetically.
+        resolveLeadRouting: jest.fn().mockResolvedValue({ agentId: 'sys', via: 'fallback' }),
         logger: baseLogger,
         ...over,
       },
@@ -159,11 +162,30 @@ describe('releaseDncClearedLead', () => {
     expect(deps.flushDeliveries).toHaveBeenCalled();
   });
 
-  it('no intended agent → not released, no transaction opened', async () => {
+  it('no intended agent + only the fallback pool → not released, no transaction opened', async () => {
     const { deps } = mkDeps();
     const res = await gate.releaseDncClearedLead({ prospect: prospect(), agentId: null }, deps);
     expect(res).toMatchObject({ released: false, reason: 'no_intended_agent' });
+    expect(deps.resolveLeadRouting).toHaveBeenCalledTimes(1); // PR-1: it DID try to re-resolve
     expect(deps.sequelize.transaction).not.toHaveBeenCalled();
+  });
+
+  it('PR-1 (CX1): null-baked agent + funded package appeared → re-resolves, charges, releases', async () => {
+    const { tx, deps } = mkDeps({
+      resolveLeadRouting: jest.fn().mockResolvedValue({ agentId: 'a9', via: 'package' }),
+    });
+    const res = await gate.releaseDncClearedLead({ prospect: prospect(), agentId: null, alreadyCharged: false }, deps);
+    expect(res).toEqual({ released: true });
+    expect(deps.chargeLeadCredit).toHaveBeenCalledWith('a9', 'c1', tx);
+    expect(deps.sequelize.query.mock.calls[0][1].replacements.agentId).toBe('a9');
+    expect(tx.commit).toHaveBeenCalled();
+  });
+
+  it('PR-1 (CX1): re-resolution never resurrects the System-Agent fallback', async () => {
+    const { deps } = mkDeps(); // default routing mock IS the fallback
+    const res = await gate.releaseDncClearedLead({ prospect: prospect(), agentId: null }, deps);
+    expect(res).toMatchObject({ released: false, reason: 'no_intended_agent' });
+    expect(deps.chargeLeadCredit).not.toHaveBeenCalled();
   });
 
   it('lost claim (already released) → rolls back', async () => {

--- a/backend/test/unit/prospectServiceScreening.test.js
+++ b/backend/test/unit/prospectServiceScreening.test.js
@@ -168,6 +168,60 @@ describe('createProspect — screening gate decision table', () => {
   });
 });
 
+describe('createProspect — provenance-aware hold-target bake (PR-1, draw-launch-integrity §9.1)', () => {
+  const fallbackRoute = () => ({
+    resolveLeadRouting: jest.fn().mockResolvedValue({ agentId: 'sys-1', via: 'fallback' }),
+    decideAssignment: jest.fn().mockResolvedValue({ action: 'assign', assignedAgentId: 'sys-1', charged: false, via: 'fallback' }),
+  });
+
+  it('fallback route + provenance-less System Agent → intendedAgentId baked NULL (release re-resolves; self-healing)', async () => {
+    const deps = buildDeps(fallbackRoute());
+    deps.models.User.findByPk.mockResolvedValue({ id: 'sys-1', lyfeId: null, mktrLeadsId: null });
+    const svc = makeProspectService(deps);
+    await svc.createProspect({ ...baseBody }, null, {});
+    expect(deps.createdProspects[0].quarantineReason).toBe('screening_pending');
+    expect(deps.createdProspects[0].screeningMetadata.intendedAgentId).toBeNull();
+  });
+
+  it('fallback route + provenance-carrying DEFAULT_AGENT → bake KEPT (regression guard: CX3+ nuance)', async () => {
+    const deps = buildDeps(fallbackRoute());
+    deps.models.User.findByPk.mockResolvedValue({ id: 'sys-1', lyfeId: 'lyfe-9', mktrLeadsId: null });
+    const svc = makeProspectService(deps);
+    await svc.createProspect({ ...baseBody }, null, {});
+    expect(deps.createdProspects[0].screeningMetadata.intendedAgentId).toBe('sys-1');
+  });
+
+  it('non-fallback (package) route never pays the provenance lookup and bakes verbatim', async () => {
+    const deps = buildDeps(); // default: via 'package', agent-1
+    const svc = makeProspectService(deps);
+    await svc.createProspect({ ...baseBody }, null, {});
+    expect(deps.createdProspects[0].screeningMetadata.intendedAgentId).toBe('agent-1');
+    expect(deps.models.User.findByPk).not.toHaveBeenCalled();
+  });
+
+  it('DNC mirror gets the same rule: fallback + no provenance → dncMetadata.intendedAgentId NULL', async () => {
+    const deps = buildDeps({
+      ...fallbackRoute(),
+      screeningApplies: jest.fn().mockResolvedValue(false),
+      dncEnforcement: jest.fn().mockReturnValue('block'),
+      formatDncNumber: jest.fn().mockReturnValue('+6591234567'),
+      gateHeldDncLead: jest.fn().mockResolvedValue({ outcome: 'held', status: 'pending' }),
+    });
+    // The DNC gate arms off the campaign's own design flag — the suite default
+    // only opts into screening.
+    deps.models.Campaign.findByPk.mockResolvedValue({
+      ...CAMPAIGN,
+      design_config: { screeningCallAtSubmit: false, dncCheckAtSubmit: true },
+    });
+    deps.models.User.findByPk.mockResolvedValue({ id: 'sys-1', lyfeId: null, mktrLeadsId: null });
+    const svc = makeProspectService(deps);
+    await svc.createProspect({ ...baseBody }, null, {});
+    const row = deps.createdProspects[0];
+    expect(row.quarantineReason).toBe('dnc_pending');
+    expect(row.dncMetadata.intendedAgentId).toBeNull();
+  });
+});
+
 describe('assignProspect — screening release override (deduct-skip, Codex #2)', () => {
   function heldProspect(screeningMetadata) {
     return {

--- a/backend/test/unit/retellScreening.test.js
+++ b/backend/test/unit/retellScreening.test.js
@@ -206,6 +206,16 @@ describe('startScreeningAttempt', () => {
     expect(deps.retellClient.createPhoneCall).not.toHaveBeenCalled();
   });
 
+  it('PR-1 (CX20): EITHER inactivity signal alone stops new dials — archived campaign with is_active=true no longer dials', async () => {
+    const deps = dialerDeps(fakeSequelize());
+    const svc = makeRetellScreeningService(deps);
+    const archivedButFlagOn = { ...screeningCampaign(), status: 'archived', is_active: true };
+    expect((await svc.startScreeningAttempt(pendingProspect(), { campaign: archivedButFlagOn, cfg: CFG })).reason).toBe('campaign_inactive');
+    const activeStatusFlagOff = { ...screeningCampaign(), status: 'active', is_active: false };
+    expect((await svc.startScreeningAttempt(pendingProspect(), { campaign: activeStatusFlagOff, cfg: CFG })).reason).toBe('campaign_inactive');
+    expect(deps.retellClient.createPhoneCall).not.toHaveBeenCalled();
+  });
+
   it('skips a lead that is not cleanly pending (active call / verdict / other reason)', async () => {
     const svc = makeRetellScreeningService(dialerDeps(fakeSequelize()));
     expect((await svc.startScreeningAttempt(pendingProspect({ screeningActiveCallId: 'call_x' }), { campaign: screeningCampaign(), cfg: CFG })).reason).toBe('not_pending');

--- a/backend/test/unit/screeningAlerts.test.js
+++ b/backend/test/unit/screeningAlerts.test.js
@@ -1,0 +1,140 @@
+/**
+ * screeningAlerts unit tests (PR-1, draw-launch-integrity §2.2) — the
+ * loud-failure surfacing for undeliverable qualified holds. Pure DI, no live
+ * Postgres, no module mocks. Covers the 30-min freshness fence, the
+ * once-per-lead activity guard, and the per-campaign 24h email throttle
+ * (including the expired-PK-row refresh — idempotency_keys.key is a PRIMARY
+ * KEY with no cleanup job, so a stale row must be UPDATEd back to life, never
+ * insert-raced into a permanent PK collision).
+ */
+import { jest } from '@jest/globals';
+import { notifyUndeliverableHold } from '../../src/services/screeningAlerts.js';
+
+const silentLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+
+const T0 = Date.parse('2026-07-24T12:00:00Z');
+const HELD_45M_AGO = new Date(T0 - 45 * 60 * 1000).toISOString();
+
+function prospectRow(over = {}) {
+  return {
+    id: 'p1',
+    campaignId: 'c1',
+    quarantinedAt: HELD_45M_AGO,
+    ...over,
+  };
+}
+
+function deps(over = {}) {
+  return {
+    sequelize: { query: jest.fn().mockResolvedValue([[]]) }, // no prior alert activity
+    ProspectActivity: { create: jest.fn().mockResolvedValue({}) },
+    IdempotencyKey: {
+      findOne: jest.fn().mockResolvedValue(null),
+      create: jest.fn().mockResolvedValue({}),
+    },
+    sendEmail: jest.fn().mockResolvedValue({}),
+    logger: silentLogger,
+    now: () => T0,
+    ...over,
+  };
+}
+
+const ENV_KEYS = ['SCREENING_ALERT_EMAIL', 'SMS_ALERT_EMAIL'];
+const envBackup = {};
+beforeEach(() => {
+  ENV_KEYS.forEach((k) => { envBackup[k] = process.env[k]; delete process.env[k]; });
+  process.env.SCREENING_ALERT_EMAIL = 'ops@test.local';
+});
+afterEach(() => {
+  ENV_KEYS.forEach((k) => { if (envBackup[k] === undefined) delete process.env[k]; else process.env[k] = envBackup[k]; });
+});
+
+describe('notifyUndeliverableHold', () => {
+  it('fresh hold (<30 min) → silent: capture-time transients never page anyone', async () => {
+    const d = deps();
+    const out = await notifyUndeliverableHold(
+      { prospect: prospectRow({ quarantinedAt: new Date(T0 - 5 * 60 * 1000).toISOString() }), reason: 'no_intended_agent' },
+      d
+    );
+    expect(out).toMatchObject({ alerted: false, reason: 'too_fresh' });
+    expect(d.ProspectActivity.create).not.toHaveBeenCalled();
+    expect(d.sendEmail).not.toHaveBeenCalled();
+  });
+
+  it('stale hold → writes the activity ONCE and emails with campaign context', async () => {
+    const d = deps();
+    const out = await notifyUndeliverableHold(
+      { prospect: prospectRow(), reason: 'no_intended_agent', campaign: { name: 'iPhone Draw' } },
+      d
+    );
+    expect(out).toMatchObject({ alerted: true, email: 'sent' });
+    expect(d.ProspectActivity.create).toHaveBeenCalledTimes(1);
+    expect(d.ProspectActivity.create.mock.calls[0][0].metadata).toMatchObject({ alert: 'screening_undeliverable' });
+    expect(d.IdempotencyKey.create).toHaveBeenCalledTimes(1);
+    const mail = d.sendEmail.mock.calls[0][0];
+    expect(mail.to).toBe('ops@test.local');
+    expect(mail.subject).toContain('iPhone Draw');
+    expect(mail.text).toContain('p1');
+  });
+
+  it('activity already written for this lead → not duplicated (email logic still runs)', async () => {
+    const d = deps({ sequelize: { query: jest.fn().mockResolvedValue([[{ 1: 1 }]]) } });
+    await notifyUndeliverableHold({ prospect: prospectRow(), reason: 'no_subscriber' }, d);
+    expect(d.ProspectActivity.create).not.toHaveBeenCalled();
+    expect(d.sendEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('live throttle row for the campaign → email suppressed', async () => {
+    const d = deps({
+      IdempotencyKey: {
+        findOne: jest.fn().mockResolvedValue({ expiresAt: new Date(T0 + 60 * 60 * 1000) }),
+        create: jest.fn(),
+      },
+    });
+    const out = await notifyUndeliverableHold({ prospect: prospectRow(), reason: 'no_subscriber' }, d);
+    expect(out.email).toBe('throttled');
+    expect(d.sendEmail).not.toHaveBeenCalled();
+    expect(d.IdempotencyKey.create).not.toHaveBeenCalled();
+  });
+
+  it('EXPIRED throttle row → refreshed in place (PK has no cleanup job) and the email re-sends', async () => {
+    const update = jest.fn().mockResolvedValue({});
+    const d = deps({
+      IdempotencyKey: {
+        findOne: jest.fn().mockResolvedValue({ expiresAt: new Date(T0 - 1000), update }),
+        create: jest.fn(),
+      },
+    });
+    const out = await notifyUndeliverableHold({ prospect: prospectRow(), reason: 'no_subscriber' }, d);
+    expect(out.email).toBe('sent');
+    expect(update).toHaveBeenCalledTimes(1); // UPDATEd, never re-created
+    expect(d.IdempotencyKey.create).not.toHaveBeenCalled();
+    expect(d.sendEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('no recipient configured → activity still lands, email marked unconfigured', async () => {
+    delete process.env.SCREENING_ALERT_EMAIL;
+    const d = deps();
+    const out = await notifyUndeliverableHold({ prospect: prospectRow(), reason: 'no_intended_agent' }, d);
+    expect(out.email).toBe('unconfigured');
+    expect(d.ProspectActivity.create).toHaveBeenCalledTimes(1);
+    expect(d.sendEmail).not.toHaveBeenCalled();
+  });
+
+  it('SMS_ALERT_EMAIL is the fallback recipient', async () => {
+    delete process.env.SCREENING_ALERT_EMAIL;
+    process.env.SMS_ALERT_EMAIL = 'fallback@test.local';
+    const d = deps();
+    await notifyUndeliverableHold({ prospect: prospectRow(), reason: 'no_intended_agent' }, d);
+    expect(d.sendEmail.mock.calls[0][0].to).toBe('fallback@test.local');
+  });
+
+  it('never throws — a broken activity write degrades to a logged skip', async () => {
+    const d = deps({
+      ProspectActivity: { create: jest.fn().mockRejectedValue(new Error('db down')) },
+    });
+    const out = await notifyUndeliverableHold({ prospect: prospectRow(), reason: 'no_intended_agent' }, d);
+    expect(out.alerted).toBe(false);
+    expect(out.error).toBe('db down');
+  });
+});

--- a/backend/test/unit/screeningGate.test.js
+++ b/backend/test/unit/screeningGate.test.js
@@ -60,8 +60,11 @@ function releaseDeps(seq, over = {}) {
     Prospect: { findByPk: jest.fn().mockResolvedValue({ id: 'p1', campaign: { id: 'c1', name: 'Camp' } }) },
     ProspectActivity: { create: jest.fn().mockResolvedValue({}) },
     User: {
-      findByPk: jest.fn().mockResolvedValue({ id: 'a1', lyfeId: 'L1', phone: '+6super', email: 'a@x.co', firstName: 'A', lastName: 'G' }),
+      // role/isActive serve the PR-1 stale-route revalidation; the rest serves
+      // the webhook agent load. One mock, both reads.
+      findByPk: jest.fn().mockResolvedValue({ id: 'a1', role: 'agent', isActive: true, lyfeId: 'L1', phone: '+6super', email: 'a@x.co', firstName: 'A', lastName: 'G' }),
     },
+    notifyUndeliverableHold: jest.fn().mockResolvedValue({ alerted: false }),
     Campaign: { findByPk: jest.fn().mockResolvedValue({ id: 'c1', enforceLeadQuota: true, leadPriceCents: null }) },
     chargeLeadCredit: jest.fn().mockResolvedValue(true),
     refundLeadCredit: jest.fn().mockResolvedValue(true),
@@ -248,6 +251,78 @@ describe('releaseScreenedLead', () => {
     const p = prospectRow({ screeningMetadata: { intendedAgentId: null } });
     const out = await gate.releaseScreenedLead({ prospect: p });
     expect(out).toMatchObject({ released: true, agentId: 'a2' });
+  });
+
+  it('PR-1: null-baked lead AUTO-HEALS the moment a funded package appears (the 07-24 prod heal, as a test)', async () => {
+    const seq = fakeSequelize([[[{ id: 'p1' }]]]);
+    const deps = releaseDeps(seq, {
+      resolveLeadRouting: jest.fn().mockResolvedValue({ agentId: 'funded-1', via: 'package' }),
+      Campaign: { findByPk: jest.fn().mockResolvedValue({ id: 'c1', enforceLeadQuota: false, leadPriceCents: null }) },
+    });
+    const gate = makeScreeningGate(deps);
+    const p = prospectRow({ screeningMetadata: { intendedAgentId: null, alreadyCharged: false } });
+    const out = await gate.releaseScreenedLead({ prospect: p });
+    expect(out).toMatchObject({ released: true, agentId: 'funded-1' });
+    expect(deps.deductLeadCredit).toHaveBeenCalledTimes(1); // soft campaign: best-effort deduct
+    expect(deps.notifyUndeliverableHold).not.toHaveBeenCalled();
+  });
+
+  it('PR-1 (CX4): STALE stored agent (deactivated) on an UNCHARGED lead re-resolves instead of delivering blind', async () => {
+    const seq = fakeSequelize([[[{ id: 'p1' }]]]);
+    const deps = releaseDeps(seq, {
+      User: {
+        findByPk: jest.fn()
+          // 1st call = revalidation of stored a1 → deactivated
+          .mockResolvedValueOnce({ id: 'a1', role: 'agent', isActive: false })
+          // 2nd call = webhook load of the re-resolved agent
+          .mockResolvedValue({ id: 'a2', role: 'agent', isActive: true, lyfeId: 'L2', phone: '+65x', email: 'b@x.co', firstName: 'B', lastName: 'H' }),
+      },
+      resolveLeadRouting: jest.fn().mockResolvedValue({ agentId: 'a2', via: 'package' }),
+    });
+    const gate = makeScreeningGate(deps);
+    const out = await gate.releaseScreenedLead({ prospect: prospectRow() }); // intendedAgentId 'a1', uncharged
+    expect(out).toMatchObject({ released: true, agentId: 'a2' });
+    expect(seq.calls[0].opts.replacements.agentId).toBe('a2');
+  });
+
+  it('PR-1 (CX4): a CHARGED lead keeps its stored agent — revalidation is skipped (refund bookkeeping stays keyed)', async () => {
+    const seq = fakeSequelize([[[{ id: 'p1' }]]]);
+    const deps = releaseDeps(seq, {
+      // Role-less mock: if revalidation RAN it would null the agent and this
+      // release would fail — success proves the skip.
+      User: { findByPk: jest.fn().mockResolvedValue({ id: 'a1', lyfeId: 'L1', phone: '+65x', email: 'a@x.co', firstName: 'A', lastName: 'G' }) },
+    });
+    const gate = makeScreeningGate(deps);
+    const p = prospectRow({ screeningMetadata: { intendedAgentId: 'a1', alreadyCharged: true } });
+    const out = await gate.releaseScreenedLead({ prospect: p });
+    expect(out).toMatchObject({ released: true, agentId: 'a1' });
+    expect(deps.chargeLeadCredit).not.toHaveBeenCalled();
+    expect(deps.deductLeadCredit).not.toHaveBeenCalled();
+  });
+
+  it('PR-1 (§2.2): undeliverable outcomes fire the loud-failure notifier (both reasons), release path unchanged', async () => {
+    // no_intended_agent
+    const seq1 = fakeSequelize([]);
+    const deps1 = releaseDeps(seq1, {
+      resolveLeadRouting: jest.fn().mockResolvedValue({ agentId: 'sys', via: 'fallback' }),
+    });
+    const gate1 = makeScreeningGate(deps1);
+    const p1 = prospectRow({ screeningMetadata: { intendedAgentId: null } });
+    await gate1.releaseScreenedLead({ prospect: p1 });
+    expect(deps1.notifyUndeliverableHold).toHaveBeenCalledWith(
+      expect.objectContaining({ prospect: p1, reason: 'no_intended_agent' })
+    );
+
+    // no_subscriber (destination default-denied) → rollback + notify
+    const seq2 = fakeSequelize([[[{ id: 'p1' }]]]);
+    const deps2 = releaseDeps(seq2, { persistEventDeliveries: jest.fn().mockResolvedValue([]) });
+    const gate2 = makeScreeningGate(deps2);
+    const p2 = prospectRow();
+    const out2 = await gate2.releaseScreenedLead({ prospect: p2 });
+    expect(out2).toMatchObject({ released: false, reason: 'no_subscriber' });
+    expect(deps2.notifyUndeliverableHold).toHaveBeenCalledWith(
+      expect.objectContaining({ prospect: p2, reason: 'no_subscriber' })
+    );
   });
 
   it('unscreened release fences on verdict IS NULL and stamps unreachable', async () => {

--- a/docs/plans/draw-boost-rail-auto-provision.md
+++ b/docs/plans/draw-boost-rail-auto-provision.md
@@ -1,0 +1,205 @@
+# Draw ×N boost rail — adversarial review + auto-provision plan
+
+> **⚠️ 07-24 ADDENDUM — read `draw-launch-integrity-scope.md` FIRST.** The August twin `bbd2c577…` was DELETED 07-24 (G1/G10/G19 + every "31 Aug" deadline here are stale); the surviving iPhone draw is `ac7b03c0…` (closes 30 Sep, ages 25–65, screening gate ON — a failure surface this plan predates). Phase 0 below is EXECUTED and must NOT be re-run; its receipts (activation `92dd875f`, offer `16eff8dd`) survived the deletion and were re-attached to the survivor 07-24. Phases 1–2 are adopted as PR-2/PR-4 of the scope doc, with one amendment: D4's strip-ceilings rule is superseded (max_age IS enforced at capture — scope doc G27/D8).
+
+**Date:** 2026-07-23 · **Author:** Claude (Fable 5, adversarial pass over the 2026-07-23 four-point sketch) · **Status:** PLAN — awaiting Codex review · **07-24: consolidated into `draw-launch-integrity-scope.md` (PR-2 + PR-4)**
+**Trigger:** iPhone 17 Pro draw went live promising ×10 with no rail behind it; Shawn's requirement: *every* creation path — manual chooser AND the AI "Write it for me" / create-everything flows — must arm the ×10 automatically.
+
+---
+
+## 0. Verdict
+
+The original four-point sketch (SQL the iPhone rail · stamp activationId · seal-time by-campaign fallback · launch gate) is **directionally right but wrong at three layers**: it fixes one campaign instead of the creation choke point, it puts the fallback at the wrong stage (seal instead of createDraw), and its "block launch when no rail" gate would deadlock the very auto-provisioning Shawn asked for (activation can only link to a campaign that already exists). The adversarial pass also surfaced **two defects the sketch missed entirely** — no shipped UI has ever produced boost-grade unlock evidence (all 7 prod unlocks are `via=manual`), and an open Studio session can silently wipe the `activationId` stamp on its next save.
+
+Ground rule kept throughout: **the backend is the choke point.** Manual create, AI details-draft (#233), and headless create-and-design (#239) all converge on `createCampaign`/`setCampaignLaunchState` — provisioning there covers "Write it for me" with zero AI-layer changes.
+
+---
+
+## 1. Verified ground truth (evidence anchors)
+
+| # | Fact | Evidence |
+|---|---|---|
+| G1 | iPhone draw (`bbd2c577…`) is `active`, multiplier 10, **no `luckyDraw.activationId`**, terms v1 (`c8c83215…`) promise "10 entries instead of one" | prod `campaigns` row; `draw_terms_versions` body |
+| G2 | Prod has exactly 2 activations (Tokyo `ba4fbd05…`, Pet Hotel), both `agent_unlock`, both `endDate NULL`; none for iPhone | prod `activations ⋈ reward_offers ⋈ partner_organisations` |
+| G3 | Boost evidence = `redemption_events type='unlocked'`, `createdAt < draw.boostClosesAt` (exclusive), on `draw.activationId` only; entitlements with `issuedVia='manual'` excluded wholesale; via whitelist: `agent_scan` auto-boosts, `agent_button`/`manual` need an approved `DrawBoostReview`, `auto_on_capture` never counts | `luckyDrawService.js:287-344` |
+| G4 | `collectBoostEvidence` returns empty when `draw.activationId` is null; `createDraw` only reads the stamp (`ld.activationId`), validates ownership, never falls back | `luckyDrawService.js:165-172, 288` |
+| G5 | **All 7 prod `unlocked` events ever are `via='manual'`** — zero `agent_scan`, zero `agent_button`. No scan surface has ever fired | prod `redemption_events` group-by |
+| G6 | Internal ops unlock hardcodes `via='manual'` even when called with a `presentationToken` | `controllers/redeemOps/fulfilmentController.js:21-31` |
+| G7 | External HMAC unlock (mktr-leads) + Lyfe envelope routes derive `agent_scan` (token) / `agent_button` (prospectId) server-side — but the consultant-app scan screens (Phase 4) are unbuilt, so nothing calls them | `routes/externalEntitlements.js:20-21,231`; memory 07-22 re-audit |
+| G8 | Capture hook issues passes by `Activation.findOne({campaignId, status:'active'})` — no stamp needed at issue time; gated by `REDEEM_OPS_ENTITLEMENTS_ENABLED` (ON in prod) | `entitlementService.js:223-252`; `bootstrap.js:271-283` |
+| G9 | `reconcileMissedLeads` sweep back-issues missed entrants only `sinceHours=48`, every 15 min | `entitlementService.js:733-744`; `bootstrap.js:301-303` |
+| G10 | iPhone's single entrant landed `2026-07-22T17:47:22Z` → **sweep window closes ≈ 2026-07-24 17:47 UTC (07-25 01:47 SGT)** | prod `prospects` row + G9 |
+| G11 | `normalizeLuckyDraw` always emits `multiplier` (default 10, clamp 2..100) — a "no boost" draw is unrepresentable; terms template writes the ×N session clause unconditionally | `utils/luckyDraw.js:33-35,119-123`; `drawTermsTemplate.js:93-94` |
+| G12 | `applyLuckyDrawPolicy` (admin path): **incoming wins wholesale** — an admin save whose `luckyDraw` lacks `activationId` erases the stored stamp | `utils/luckyDraw.js:150-175` |
+| G13 | Gate sites precedent (multi-prize): `createCampaign` (is_active defaults **true** on bare API), `updateCampaign` willBeActive, `setCampaignLaunchState`, `createDraw`; readiness has `critical` row precedent | `campaignService.js:459, 600-605, 733`; `campaignReadinessService.js:212-222` |
+| G14 | Activation lifecycle service functions exist and are audited: `createActivation`, `linkCampaign`, `changeAllocation`, `setStatus` (LIVE statuses require campaignId) | `activationService.js:78-236` |
+| G15 | House partner exists: `partner_organisations 00d28744-b374-48d4-adf0-471b113173a4` (legalName MKTR PTE. LTD., brand Redeem, verified, `pipelineStage='LOST'` — deliberate, keeps it out of BD pipelines; no gate reads pipelineStage) | prod query |
+| G16 | Tokyo offer: `claimExpiryDays=110`, committed/allocated 500; Tokyo issuedCount 0 (0 entries so far) | prod query |
+| G17 | iPhone featured drop has **no `endsAt`** → homepage card stays "live" past 31 Aug (Tokyo's flips via `sgtDayEndExclusiveMs` + 7d retention) | prod row; `featuredDropsService.js:65-75` |
+| G18 | `publicDesignConfig` strips `activationId`/terms internals — stamping is invisible to the public payload; no cache/pixel impact | `utils/publicDesignConfig.js:7` |
+| G19 | iPhone entrant routed to Shawn's own consultant mirror (`6707439d…`, Lee Yi Heng, mktrLeadsId set) — the System-Agent fear didn't materialize (likely `DEFAULT_AGENT_ID`); campaign `external_eligible=false`, no lead packages | prod queries |
+
+---
+
+## 2. Adversarial findings
+
+**F1 — The sketch fixed a campaign, not the factory. (BLOCKER, redesigned)**
+Point-fix SQL for iPhone leaves the next UI/AI-created draw in the same state: G11 means every draw is born promising ×N, and nothing provisions the rail. Shawn's requirement is explicit: creation flows must arm it automatically. → Plan centerpiece becomes `ensureDrawBoostRail()` at the backend choke point (Phase 1); the SQL survives only as Phase 0 remediation for the already-live campaign (deploys take hours; the sweep deadline G10 doesn't wait).
+
+**F2 — "Block launch when no reward linked" deadlocks auto-provisioning. (BLOCKER, redesigned)**
+`linkCampaign` requires an existing campaign row (G14), so a hard gate at create/launch can never be satisfied a priori. The gate must be an **ensure** (provision-or-throw), not an assert. Sequencing per site: `updateCampaign`/`setCampaignLaunchState` ensure **before** flipping active (fail-closed, no compensation); `createCampaign` born-active (bare API defaults `is_active=true`, G13) ensures **after** row creation with a compensating revert to draft + 422 on failure. A leftover activation from a failed later step is harmless — ensure is idempotent and adopts it on retry.
+
+**F3 — Seal-time fallback is the wrong layer. (accepted, moved)**
+Falling back by campaign inside `collectBoostEvidence` leaves `draw.activationId` null forever — publish/outcome/verify payloads (`luckyDrawService.js:678`) lose the activation identity and the audit trail weakens. → The fallback belongs in `createDraw`: resolve `Activation.findOne({campaignId, status:'active'})` when the stamp is absent, **422 on ambiguity** (two active activations → operator must stamp explicitly), write-through the resolved id onto the draw row as today. Seal keeps reading `draw.activationId` only.
+
+**F4 — Nothing on any shipped surface can produce an auto-boost. (CRITICAL — new finding, the sketch missed it)**
+G5+G6+G7: the only routes that mint `agent_scan` evidence are the external HMAC/Lyfe surfaces no app calls yet; the one unlock button that exists (ops console) hardcodes `via='manual'`, which is review-gated and — worse — rides entitlements that are boost-eligible only if *issued* non-manually (G3). Both live draws would seal with zero automatic boosts no matter what consultants do in the field. Tokyo has until 30 Oct; **iPhone has until 31 Aug.** → Phase 2: minimal ops-side scan front door — when the internal unlock is called with a `presentationToken` that resolves, derive `via='agent_scan'` (same token-backed evidence standard the external route already trusts); plain prospectId/admin-override calls stay `manual`. UI: the existing Redemptions camera scanner gains a "Record session (×N boost)" action for `eligible` passes on draw-linked activations. mktr-leads Phase-4 screens remain the real field tool (separate repo, out of scope).
+*Trust trade-off, flagged once:* this widens auto-boost minting from HMAC'd consultants to redeem-ops staff holding `entitlements.issue_manual`. The token is identical evidence; actor is audited (`actorUserId`). Recommended: accept. Conservative alternative (env-selectable): label ops scans `agent_button` → review-gated.
+
+**F5 — An open Studio tab can wipe the stamp. (HIGH — new finding)**
+G12: admin saves send the whole `luckyDraw` object; a session loaded pre-stamp omits `activationId`, and the admin path takes incoming wholesale → stamp gone. F3's createDraw fallback makes this non-fatal, but the config shouldn't lie. → `applyLuckyDrawPolicy` carries forward **stored `activationId` when the incoming object omits it** (operational key, editor-invisible by design; explicit `activationId: null` from an admin still clears). Terms keys stay as-is — re-pin logic owns them.
+
+**F6 — Retroactive repair has a hard 48-hour cliff. (URGENT operational fact)**
+G3+G9: past the sweep window, the only back-issue path is `issueManual` — whose entitlements are **permanently boost-ineligible** (`issuedVia='manual'` excluded at the entitlement level, not the event level). For the existing iPhone entrant that cliff is ≈ **07-25 01:47 SGT** (G10). Phase 0 today makes the 15-min sweep issue their pass cleanly (`via='sweep'` ≠ manual → boost-capable). Miss it and the honest fixes are ugly (widen `sinceHours` in code, or accept a review-gated manual path for that entrant).
+
+**F7 — Allocation and claim-window sizing are foot-guns, not defaults. (MEDIUM)**
+The unique entitlement index has no status filter — an expired reservation **blocks reissue** — so `claimExpiryDays` must cover signup→boostClosesAt with margin; and allocation exhaustion halts issuance with only the 48h reconcile to recover late top-ups. → Provisioning computes `claimExpiryDays = clamp(daysUntil(boostClosesAt) + 21, 30, 400)` and allocates `DRAW_BOOST_DEFAULT_ALLOCATION` (default **1000**; env-tunable). Exhaustion monitoring stays the existing ActivationDetail 24h skip breakdown + `changeAllocation` runbook; auto-top-up parked (Phase 3).
+
+**F8 — Double-provision race. (MEDIUM)**
+Two concurrent go-active flips (Studio + API) could mint two active activations → F3's ambiguity 422 at createDraw, months later. No unique index on `activations.campaignId` (multiple activations per campaign is legitimate for non-draw use). → `pg_advisory_xact_lock(hashtext('draw-boost:'||campaignId))` around ensure; find-active-first inside the lock.
+
+**F9 — Homepage card immortality. (LOW, folded in)**
+G17. → Phase 0 data-fix (`endsAt='2026-08-31'`) + Phase 1 clamp default: draw campaigns with `featuredDrop.enabled` and no `endsAt` inherit `luckyDraw.closesAt`. Explicit admin `endsAt` always wins.
+
+**F10 — "No-boost draw" mode: correctly out of scope. (REJECTED as scope)**
+G11 makes 1×-only draws unrepresentable (terms clause unconditional, chrome renders boost off `multiplier` alone, min clamp 2). Building the mode means conditional terms, chrome gating, email copy, clamp changes — a feature, not a fix, and contrary to the product stance (boost = the growth mechanic). Parked in Phase 3 with the multi-winner engine.
+
+**F11 — Sweep double-fire safety on ensure-at-launch. (verified non-issue)**
+Hook + sweep + ensure all funnel into `issueForProspect`, which is exactly-once via the `(activationId, prospectId)` anchor + phone-key partial unique (G8). Provisioning mid-traffic is safe: entrants captured pre-ensure are picked up by the next 15-min sweep (≤48h), entrants post-ensure by the hook.
+
+**F12 — Evidence-window integrity. (verified non-issue)**
+The sketch worried late scans could boost after `boostClosesAt`; G3 shows the exclusive `createdAt < boostClosesAt` bound already exists. No change.
+
+**F13 (EXPANDED 07-23 evening — prod evidence from Shawn's own signup) — the ENTIRE entitlement-delivery voice is trial-funnel, at every step, not just unlock.**
+Original finding: `unlockEntitlement` unconditionally queues the `kind:'voucher'` delivery (`entitlementService.js:~510`) — partner-redemption copy, nonsense for a draw scan. **Shawn's test signup surfaced the same disease one step earlier**: the signup-time reservation delivery (satori card `qrCardRenderer.js` + WA body `whatsappService.js:160` + email `fulfilmentNotify.js:84` + claim page `consumerService.js:463`) leads with the OFFER title — the entrant who just joined an iPhone draw got *"Reserved. / Complimentary financial review"*. Nobody entering a draw cares about the review; it reads like bait-and-switch. Full voice matrix needing a draw branch: **reservation card · reservation WA body · reservation email · claim page (`/r/…`) · unlock voucher email**. All five key off the draw-linked activation.
+Mitigation SHIPPED same evening (data-only), TWICE: first pass *"…Draw ×10 Booster Pass"* — **rejected by Shawn within the hour (D5): "Booster Pass" is jargon; SG audience won't parse it. The message must be plain: you have 1 draw chance now, ×10 when you meet the consultant.** Final interim titles: *"iPhone 17 Pro Lucky Draw Entry Pass" / "Tokyo Getaway Lucky Draw Entry Pass"*. Fixed frame strings ("Reserved.", "RESERVATION PASS", "unlock at your appointment", "CODE · REVEALED ON UNLOCK") remain trial-voiced until Phase 2.
+
+**D5 — pass-copy voice (Shawn, 07-23 evening): plain numbers, no coined nouns; his line verbatim: "10x your chances when you meet with a consultant." Draw card line-set (Phase 2 spec, maps 1:1 onto the existing satori frame):**
+| Current (trial voice) | Draw branch |
+|---|---|
+| RESERVATION PASS | LUCKY DRAW PASS |
+| Reserved. | You're in. |
+| {publicTitle} | {draw name, e.g. iPhone 17 Pro Lucky Draw} |
+| Held for {name} — unlock at your appointment | Held for {name} — 1 chance in the draw now |
+| CODE · REVEALED ON UNLOCK | 10X YOUR CHANCES WHEN YOU MEET A CONSULTANT |
+| EXPIRES {entitlement expiry} | COMPLETE YOUR REVIEW BY {boostClosesAt} — the user-relevant date (one-date-per-surface rule, #252); entitlement expiry is internal |
+| Present once. Non-transferable. | (unchanged) |
+
+**WA template APPROVED 07-23 — `draw_entry_pass` id `2818476365205485`, FINAL CATEGORY = UTILITY** (verified twice ~22:30 SGT: WhatsApp Manager UI "Utility / Active" + Graph API `category=UTILITY`). The receipt-tone body with the full 10x line got utility approval outright — Shawn's exact goal, no appeal needed. Record note: an API poll mid-review transiently reported `category=MARKETING` at the 15–18-min mark; that was pipeline churn, not the outcome — trust post-approval reads, not mid-review ones. Consequences of UTILITY: utility per-message pricing, no STOP-rail requirement, no marketing frequency caps. **`draw_entry_pass` is the Phase 2 primary** (`WHATSAPP_TEMPLATE_DRAW_PASS || 'draw_entry_pass'`).
+
+**Utility twin `draw_pass_receipt` (id `1384079383631712`) — submitted 07-23 while `draw_entry_pass` transiently read as MARKETING; NOW REDUNDANT** (the primary got utility on its own). Body = pure-receipt clone of the `reward_pass` register with the 10x living on the card image. **APPROVED 07-24 (Utility, Active — Manager UI)** — parked as the plainer fallback; no sender work targets it. Final template inventory: `draw_entry_pass` (Utility, PRIMARY, full 10x text) · `draw_pass_receipt` (Utility, fallback) · `lucky_draw_pass` (Rejected shell — never delete, 30-day name block). No appeal was ever filed (the dispute flow is Manager-UI-only, and it proved unnecessary). Submission saga (classifier lessons for the repo): v1 UTILITY with exclamation-mark copy → instant REJECTED `INCORRECT_CATEGORY` (promo register); fresh `lucky_draw_pass` as MARKETING + STOP rails → ALSO rejected `INCORRECT_CATEGORY` (Meta polices both directions since the pricing split — pass delivery is utility DNA); fix = **receipt-tone components edit on the original UTILITY slot** (component edits are allowed on REJECTED templates; the `category` field is immutable post-creation — its error message misleadingly says "approved"). The `lucky_draw_pass` rejected shell stays parked (deleting risks the 30-day name block). Approved body (4 vars: name, draw name, pass link, boost deadline; paragraph-spaced per Shawn):
+> Hi {{1}}, your entry to the {{2}} is confirmed — you hold 1 chance in the draw right now.
+>
+> 10x your chances when you meet with a consultant: complete your complimentary 20-minute financial review and they will scan this pass at the session.
+>
+> Your pass: {{3}}
+>
+> Reviews must be completed by {{4}} to count. Good luck.
+
+Shawn's D5 line survives verbatim as the para-2 opener; exclamation marks dropped to match the approved `reward_pass` register (flat-factual is what passes the classifier). Phase 2 sender: `WHATSAPP_TEMPLATE_DRAW_PASS || 'draw_entry_pass'`, image header = live card PNG per send. Reservation email body branches to the same voice. **`WHATSAPP_WABA_ID=1912683432731970` now persisted on mktr-backend-jo6r** (Render REST PUT via the CLI api key — the CLI-key→`GET /v1/services/{id}/env-vars` trick also beats the "creds are Render-only" wall documented in the watemplates seed; `render ssh` is TUI-only and unscriptable).
+→ Phase 2 (grown): implement the already-designed **Draw Entry Card** (`Draw Entry Card.dc.html`, claude.ai/design project "Design Review: Three Colorways") as the issuance-time credential for draw activations — "You're in the draw for {prize}" framing, QR as the ×N booster, close date on card; draw claim-page variant; unlock sends "×N confirmed — your entries are now N" (suppress voucher); optional dedicated WA template via the watemplates pipeline (until approved, the existing template + draw-framed variable reads fine).
+
+**F15 — prospect deletion treats live passes inconsistently (LOW severity, HIGH confusion; observed in prod 07-23).** Shawn's test loop (signup → delete → re-signup ×3, same phone) left: passes #1 and #2 `cancelled` on prospect deletion, but pass #3 **orphaned yet still `eligible`** (`prospectId=NULL`, phone slot still held by the anti-farm unique). Two delete paths apparently differ (single vs bulk lead ops?) — one cancels entitlements, one just nulls the FK. Consequences: a re-signup on that phone `duplicate_phone`-skips and sends nothing (looks broken to a tester), and an orphaned live pass could still be scanned at seal time with no prospect → boost evidence pointing at a deleted person (frozen entries require a prospect, so it's noise, not corruption — but verify). → Phase 1: unify the delete path (cancel live entitlements when their prospect is deleted, both single and bulk); test both paths. The 2 `duplicate_phone` skips in the log are the anti-farm gate working as designed.
+
+**F14 — `agent_scan` evidence is irreversible today. (HIGH, given decision D2 below)**
+Shawn's requirement: instant count but reversible on error. Nothing supports that: review rows only gate `agent_button`/`manual` — a scan "always wins" (`collectBoostEvidence`); cancelling the entitlement doesn't un-boost (the evidence query has **no status filter** — deliberately cancel-proof — and cancel would kill the person's pass anyway); `DrawBoostReview` can't host reversals (rows key on `drawId`, and the draw record doesn't exist until freeze — an August mistake would have no home until 31 Aug). → Phase 2 reversal design, append-only like everything else:
+- New counter-event `unlock_reversed` (metadata: reason, actor, prior `expiresAt`) + guarded status flip `issued→eligible` (conditional update: only while unredeemed; restore reservation expiry from stashed value).
+- Evidence rule becomes **latest event wins** per entitlement: an `unlocked` with no later `unlock_reversed` boosts; reversed then genuinely re-scanned later → new `unlocked` event → boosts again. Ordering by `createdAt, id`.
+- Ops "Undo session" button next to the scan action; same capability (`entitlements.issue_manual`), fully audited.
+
+---
+
+## 3. Plan
+
+### Phase 0 — TODAY, prod data (no deploy; beats the F6 cliff)
+
+> **EXECUTED 2026-07-23 (atomic CTE, single statement, verified):** offer `16eff8dd-420d-4d2d-a97c-24c899573a17` (active, 10000/10000, claimExpiryDays 60) · activation `92dd875f-4293-4305-9a5f-293f8930bd61` (active, `agent_unlock`, 10000, linked) · ledger `committed`+`allocated` events (service vocabulary — NOT the 07-22 `increased` variant) · campaign stamped (`luckyDraw.activationId`, `featuredDrop.endsAt=2026-08-31`, story "aged 21 and above"; termsHash + template byte-checked untouched) · bonus: Tokyo offer `allocatedQuantity` 0→500 (07-22 SQL had skipped the service-maintained counter). **Sweep receipt CONFIRMED ~7.5 min post-provision:** entrant `b84424dd…` got its pass via `issuedVia='sweep'` (≠ manual → **boost-capable**, F6 defused), email + WhatsApp delivered. The F6 deadline is dead. **Same evening:** Shawn deleted that test entry and re-signed-up with the same number → new prospect `7d17429d…`, pass issued `via='hook'` **180ms after signup** — both delivery paths (instant hook + catch-up sweep) now prod-proven. His screenshot of the pass card triggered the F13 expansion below. Context note: campaign is active but **no ads are running yet** — zero page traffic; the lone entrant was the only outbound-message recipient.
+
+Mirror the Tokyo CTE (atomic; `partnerSince` is a smallint year; **`unlockPolicy='agent_unlock'` explicit** — `on_capture` would mint `auto_on_capture` events that never boost, G3):
+
+1. House partner: reuse `00d28744-b374-48d4-adf0-471b113173a4` (G15). No new partner.
+2. Offer: `Complimentary financial review (20 min) — iPhone 17 Pro Draw Aug 2026`, publicTitle `Complimentary financial review (20 min)`, status `active`, `fundingSource='mktr'`, `committedQuantity=10000`, `claimExpiryDays=60` (39d to 31 Aug + 21 margin, F7).
+3. Inventory ledger: increase +10000, allocate 10000 (mirror `RewardInventoryEvent` rows the service writes). Per D1 (effectively unlimited): 10k start + the Phase-1 auto-top-up means exhaustion can't occur in practice.
+4. Activation: status `active`, `campaignId=bbd2c577…`, `campaignNameSnapshot`, `allocatedQuantity=10000`, `unlockPolicy='agent_unlock'`, `endDate NULL`.
+5. Stamp `design_config.luckyDraw.activationId` (jsonb update; public payload unaffected, G18).
+6. `distribution.featuredDrop.endsAt='2026-08-31'` (F9).
+7. **Verify within 30 min:** sweep log `[RedeemOps]` issuance, `reward_entitlements` row for prospect `b84424dd…` with `issuedVia ∈ {hook,sweep}` (NOT manual), reservation email/WA delivery receipt, `activation_issuance_skips` empty for this activation.
+8. Copy fix (Studio, non-blocking): story says "aged 21 to 65" — correct to "21 and above" (matches `min_age=21` + the pinned terms; nothing enforces a ceiling). Systemic derivation lands in Phase 1 (D4).
+
+Rollback: `UPDATE activations SET status='paused'` + remove stamp. No code involved.
+
+### Phase 1 — backend auto-provision + gates (one PR)
+
+**New `backend/src/services/redeemOps/drawBoostProvisioningService.js`** — `ensureDrawBoostRail(campaign, user, { requestId })`:
+- Kill switch `DRAW_BOOST_AUTOPROVISION_ENABLED` (default `true`); throws typed 422 `DRAW_BOOST_RAIL_UNAVAILABLE` if `REDEEM_OPS_ENTITLEMENTS_ENABLED` is off (armed promise would be undeliverable platform-wide).
+- Inside `pg_advisory_xact_lock` (F8): adopt existing active activation for campaignId (stamp if missing) → else find-or-create house partner (env `REDEEM_HOUSE_PARTNER_ORG_ID` → fallback by legalName → create verified) → create per-campaign offer (F7 sizing) → inventory increase+allocate (`DRAW_BOOST_DEFAULT_ALLOCATION`, default 1000) → `createActivation`+`linkCampaign`+`setStatus('active')` composed from `activationService` (keeps audit trail, G14) → stamp `luckyDraw.activationId`.
+- Idempotent at every step; safe to re-run after partial failure.
+
+**Call sites** (mirror the multi-prize gate topology, G13; only when `luckyDraw.enabled === true`):
+- `setCampaignLaunchState('active')` — ensure **before** the flip (F2).
+- `updateCampaign` — on transition inactive→active, and on `luckyDraw` becoming enabled while active.
+- `createCampaign` with `is_active` truthy — ensure post-create; on failure revert to draft + rethrow (F2).
+- **This is the line that satisfies "Write it for me arms ×10 automatically":** #233 drafts and #239 create-and-design both land on these paths; no AI-layer changes. Optional UI garnish: Details draw section hint "×N session boost is armed automatically at launch."
+
+**`luckyDrawService.createDraw`** — F3: stamp absent → resolve active activation by campaignId (order `createdAt ASC`), 422 on two+ active (`DRAW_BOOST_RAIL_AMBIGUOUS`), 422 when none resolvable (`DRAW_BOOST_RAIL_MISSING`) with CLI override `--allow-no-boost` for emergencies.
+
+**`applyLuckyDrawPolicy`** — F5 carry-forward of stored `activationId` when incoming omits it (admin path only; explicit null clears).
+
+**`campaignReadinessService`** — new row `draw_boost_rail_missing`: `critical` when campaign is active with no linked active activation (today's iPhone state becomes visible), `warning` pre-launch ("will be armed automatically at launch").
+
+**Clamp** — F9 default: draw campaign + `featuredDrop.enabled` + no `endsAt` → inherit `closesAt`.
+
+**Allocation auto-top-up** (promoted from Phase 3 per D1 — "effectively unlimited"): the existing 15-min fulfilment sweep checks each active draw-linked activation; when `allocatedQuantity − issuedCount < 20%` of `DRAW_BOOST_DEFAULT_ALLOCATION` (default **10000**), it runs `changeAllocation(+DEFAULT)` — inventory increase + allocate, audited like a human top-up, log line per event. Literal "unlimited" is rejected: the inventory model, ops UI counters, and capacity displays all assume integers; auto-top-up delivers the same guarantee with zero semantic surgery.
+
+**Age-copy derivation** (D4 — "not hard-coded; all campaigns reflect correctly"): single source of truth = `min_age`. The terms template already derives (`buildDrawTermsHtml({minAge})` ✓). Close the remaining leaks: `sanitizeDetailsDraft` (AI details-draft) and the Studio AI copy contract get an age lint — any age mention in story/subheadline/headline must equal the campaign's `min_age` floor, phrased "aged N and above"; **upper bounds are stripped** (no max-age enforcement exists; suitability screening is Retell's job per D3). Fold into the promise-vs-enforcement thread (#243/#246-#248) rather than a parallel mechanism if Codex prefers.
+
+### Phase 2 — scan front door + undo (separate PR; F4, F13, F14)
+
+- `fulfilmentController.unlockEntitlement`: `presentationToken` present + resolves → pass `via='agent_scan'`; prospectId-only and admin-override stay `'manual'`. External HMAC/Lyfe surfaces untouched. (D2 resolved 07-23: instant count — the review-gated `agent_button` alternative is rejected; no env knob.)
+- Redemptions scanner UI: scanned pass in `eligible` state on a draw-linked activation → "Record session (×N boost)" action → that endpoint. Next to it, **"Undo session"** per the F14 design (`unlock_reversed` counter-event + guarded `issued→eligible` flip + latest-event-wins evidence; re-scannable after undo; audited; same capability).
+- Draw-aware unlock side-effects (F13): draw-linked activation → suppress the partner-voucher email, send the "×N confirmed — your entries are now N" receipt pair instead; undo sends nothing (silent correction; the entrant never saw a wrong state if undone promptly — copy review at build).
+- Covers iPhone-in-August fully (all entrants route to one consultant today, G19). Tokyo field-scale scanning = mktr-leads Phase-4 screens, separate repo, before ~mid-Oct.
+
+### Phase 3 — parked, explicitly
+Multi-winner engine (deletes the 4 `DRAW_MULTI_PRIZE_UNSUPPORTED` gates) · boost-review UI (CLI bridges the remaining `agent_button`/`manual` review lane) · no-boost mode (F10) · max-age enforcement (rejected for now — Retell screening owns suitability, D3) · winners-page automation · mktr-leads scan screens (other repo).
+
+---
+
+## 4. Tests (Phases 1–2 PRs)
+
+DI suites, throwaway-pg pattern (5433/5561 precedent). Phase 1: ensure happy-path chain + adopt-existing + stamp-only; kill-switch off → typed 422; entitlements-flag off → 422; launch-state blocks before flip; create-born-active compensates to draft; advisory-lock double-call mints one activation; createDraw fallback resolves / ambiguity 422s / missing 422s / `--allow-no-boost`; policy carry-forward (omit → kept, null → cleared, non-admin unchanged); readiness critical/warning; clamp endsAt default + explicit-wins; sizing math boundaries (clamp 30/400); auto-top-up fires under 20% + is audited + never fires for non-draw activations; AI age lint (floor rewritten to min_age, ceiling stripped, no age mention → untouched). Phase 2: token unlock → `agent_scan` + boost counted; prospectId unlock stays `manual`; undo flips state + restores expiry + evidence excludes; undo→re-scan boosts again (event ordering); redeemed entitlement refuses undo; draw-linked unlock sends receipt not voucher (and trial funnel byte-identical); seal parity on a mixed evidence set. Baseline: 67 backend draw tests + full sweep vs origin/main (6 chronic reds only).
+
+## 5. Deploy + verify
+
+Render auto-deploy watch (`list_deploys`, re-trigger recipe if webhook drops). Probes: readiness API shows `draw_boost_rail_missing` resolved for iPhone + absent for Tokyo; create a draft draw via API → launch → activation auto-appears linked + stamped (then pause + strip in prod, or run on local pg); unlock 401 probe still mounted; sweep log clean.
+
+## 6. Rollback
+
+`DRAW_BOOST_AUTOPROVISION_ENABLED=false` restores pre-PR launch behavior (gates dormant — readiness row stays informational). Provisioned rows are ordinary ops data: `setStatus('paused')` disarms; stamp removal is safe post-F3 (createDraw falls back). Phase 2 rollback = env `DRAW_OPS_SCAN_VIA=agent_button` or revert (evidence already written is append-only and review-gated where labeled button/manual).
+
+## 7. Decisions (Shawn, 2026-07-23) + remaining items
+
+- **D1 — Session passes effectively unlimited.** No literal-∞ redesign; 10k initial + sweep auto-top-up at <20% (Phase 1). Real costs at scale: ~cents/entrant WhatsApp delivery + consultant time (self-limiting); infra negligible.
+- **D2 — Ops scans count instantly (`agent_scan`), reversible.** Reversal = F14 append-only design; undo any time before seal; re-scannable.
+- **D3 — Routing deferred.** Retell will screen all lucky-draw entrants for consultant-meeting fitness before booking; entry passes + boost mechanics are routing-independent, so nothing here blocks that work. Revisit spread/packages when screening ships.
+- **D4 — Age copy derives from `min_age` everywhere, never hard-coded.** Terms already derive; Phase 1 adds the AI-draft lint + strips unenforceable ceilings; Phase 0 corrects the live iPhone story.
+
+Remaining, non-blocking:
+- **Go/no-go on Phase 0 today** — note: within ~15 min of provisioning, the existing entrant receives their entry-pass email/WhatsApp (that is the fix working, but it is an outbound customer message).
+- `bookingUrl` unset on both draws (success-page CTA hidden) — leave until Retell screening defines the booking flow (D3).
+- FYI: iPhone draw is homepage-card only, not listed on /explore (`marketplace.listed` unset) — Studio Distribution toggle if wanted; no code needed.
+- Tokyo hero still the 30MB third-party CDN PNG — web-sized JPG already handed off for Studio upload (pre-existing item, unchanged).
+
+---
+
+*Cross-refs: `docs/plans/lucky-draw-10x.md` (engine design) · `docs/plans/lucky-draw-multi-prize-plan.md` (Σqty gates) · memory `project-lucky-draw-campaign`, `project-tokyo-lucky-draw-live`.*

--- a/docs/plans/draw-launch-integrity-scope.md
+++ b/docs/plans/draw-launch-integrity-scope.md
@@ -1,0 +1,175 @@
+# Draw launch integrity — consolidated scope (boost rail + gates + screening interaction)
+
+**Date:** 2026-07-24 · **Author:** Claude (Fable 5) · **Status:** SCOPE — **Codex R1 folded (§9)**: PR-0/PR-1 amended-and-GO (reduced), PR-2/PR-3/PR-4 carry redesign notes that must be resolved in the implementation PRs. Where §§2–5 conflict with §9, **§9 wins.**
+**Supersedes/extends:** `draw-boost-rail-auto-provision.md` (07-23, "awaiting Codex review") — that plan's Phases 1–2 are adopted here verbatim as PR-2 and PR-4; its ground truth is partially stale (see §0). Read that doc for F1–F15/G1–G19 and D1–D5; this doc continues the numbering (G20+, F16+, D6+).
+**Trigger:** 07-24 full-funnel trace of the live iPhone draw (`ac7b03c0-57bf-409e-bd7b-740e1d180e09`) surfaced a class of silent failures the 07-23 plan predates — a lead that passed AI screening looped un-deliverable forever, the reward rail was detached, and the page/terms contradicted each other on prize and age. Root principle for everything below: **a draw campaign must not be able to run while promising something the platform cannot deliver — and when it does, it must fail loudly, not silently.**
+
+---
+
+## 0. What changed since the 07-23 plan was written
+
+| # | Fact | Consequence for the old plan |
+|---|---|---|
+| G20 | Shawn **deleted the August twin `bbd2c577…`** (0 leads). Sole iPhone draw is now `ac7b03c0…` — active, closes **2026-09-30** (boostClosesAt same), ages **25–65**, `form.gates.screeningCall=true` | G1/G10/G19 + "iPhone has until 31 Aug" are stale. Phase-0 receipts (activation `92dd875f`, offer `16eff8dd`) survived the deletion — campaign FK was set-null'd, not cascaded |
+| G21 | 07-24 remediation already executed on the survivor: activation `92dd875f` **re-attached** (active, 10000/1 issued); prize corrected iPad→**iPhone 17 Pro 256GB** in `luckyDraw.prize`, `prizes[0].name`, and terms; terms age "21 and above"→"aged 25 to 65"; **terms v3 minted properly** (`draw_terms_versions` v3 `fd7972a2…`, sha256 `6b031f79…`, `termsVersionId`+`termsHash` re-stamped, hash-chain verified) | The old plan's Phase-0 "re-run for the survivor" is NOT needed — except the stamp, G22 |
+| G22 | **Survivor has NO `luckyDraw.activationId` stamp** (verified 07-24: key absent). `createDraw` today reads only the stamp (old G4) — the F3 fallback is unbuilt | Without PR-0 §4.1 or PR-2, the September draw would be created with `activationId=null` → `collectBoostEvidence` returns empty → **every entrant seals at 1×** |
+| G23 | **Pass-expiry foot-gun is live again (old F7, new dates):** offer `claimExpiryDays=60` was sized for the twin's Aug-31 close. Survivor's boost window ends Sep 30; the existing pass (`78fc83b3…`) **expires 2026-09-22** — 8 days inside the window. `expireReservations` will kill it; expired rows block reissue (unique has no status filter) | PR-0 §4.2 resizes; formula (old F7) demands `daysUntil(boostClosesAt)+21 ≈ 90` |
+| G24 | **Retell screening SHIPPED and is ON in prod** (`RETELL_SCREENING_ENABLED=true`, agent `agent_4ea24f4a…`, from `+6562773210`; window 10:00–20:00 SGT; sweep 5-min). Old D3 treated it as a future initiative | A brand-new failure surface the old plan never considered — G25 |
+| G25 | **Screening × no-funded-agent = permanent silent dead-end (observed live).** Capture bakes `screeningMetadata.intendedAgentId` from the routing decision even when `via='fallback'` (System Agent). System Agent has no `lyfeId`/`mktrLeadsId` → `destinationForAgent`=null → `persistEventDeliveries` default-denies → `releaseScreenedLead` rolls back `no_subscriber` → sweep job 1 retries **every 5 min forever**. TTL/drain jobs only match `screeningVerdict IS NULL`, so a QUALIFIED lead is unrescuable by design. Prod evidence: lead `f95fe2cf…` (Shawn's test, qualified 11:48Z) still looping; log line `[Screening] release: no delivery subscriber — re-holding` every 5 min since | PR-1 fixes the bake + adds the alarm; readiness gains a funding row. NOTE: `releaseScreenedLead` already re-resolves when `intendedAgentId` is null and **refuses** `via='fallback'` results — the null-bake fix makes stuck leads auto-heal the moment funding lands, no new release code |
+| G26 | Shawn funded the survivor 07-24: mktr-leads agent `6707439d…` ("Basic Package", **10 credits**). Future leads route `via='package'` and deliver on qualify | The dead-end is dormant, not dead: it re-arms silently at 0 credits. Hence `lead_credits_low` readiness + the PR-1 alert |
+| G27 | **`max_age` IS enforced at capture** (`prospectService` age gate 422s above it; survivor 25–65 live). Old D4's premise "no max-age enforcement exists → strip ceilings" is **wrong for campaigns with `max_age` set** | D4 amended (D8): age copy derives BOTH bounds when `max_age` is set — "aged {min} to {max}"; ceilingless only when `max_age` is null. Retell screening likewise already speaks both bounds (`{{age_min}}–{{age_max}}`) |
+| G28 | The prize/age contradictions shipped through Studio AI: terms said iPad + 21 while page said iPhone + 25–65, and the T&C is the **hashed, consent-pinned** artifact. `drawTermsTemplate.buildDrawTermsHtml` derives from `minAge` (floor-18) — the drift arose because stored terms are never re-checked against later campaign edits | PR-3: consistency lint compares STORED terms/copy against current campaign facts; fix path = regenerate via template + `ensureDrawTermsVersion` mint (never in-place edits) |
+| G29 | Survivor `distribution = {host:'redeem'}` only — **no featuredDrop, not marketplace-listed**. Reachable by direct link only; old F9/G17 (card immortality) do not apply to it | Fine for testing; a Distribution decision is needed before ads (D9) |
+| G30 | Success page + WA/email pass promise chain is now TRUE end-to-end for the survivor (pass issues at signup via hook; sweep as backstop — both prod-proven). The remaining promise gaps are ×10 evidence (old F4) and the draw record itself | PR-4 (scan door) + the readiness `draw_record_missing` row (PR-1) |
+
+---
+
+## 1. Workstream → PR map
+
+The old plan's structure is kept; new work slots around it. **Backend remains the choke point** (old ground rule) — every gate/ensure lands in `campaignService` + services, never in the AI layer.
+
+| PR | Contents | Origin | Size |
+|---|---|---|---|
+| **PR-0** | Prod data ops, no deploy (§4) — stamp, expiry resize, stuck-lead heal, title tidy | new | ops-only, today |
+| **PR-1** | Screening×draw integrity: null-bake fix, loud alarms, readiness rows (funding / credits / draw-record) | new | **S–M** |
+| **PR-2** | `ensureDrawBoostRail` auto-provision + createDraw fallback + stamp carry-forward + delete-path unification + auto-top-up + featuredDrop clamp + age-lint (amended per D8) | old plan **Phase 1**, adopted verbatim + D8 amendment | **M–L** |
+| **PR-3** | Draw promise-consistency lint (prize / age / dates / multiplier vs stored terms & copy) at gate sites + readiness + Studio surfacing | new | **S–M** |
+| **PR-4** | Boost scan front door (`agent_scan` via token) + Undo (F14) + draw-voiced delivery (F13/D5 card, `draw_entry_pass` template) + 2 cosmetic nits (§5.4) | old plan **Phase 2**, adopted verbatim + nits | **M–L** |
+
+Sequencing: PR-0 today → PR-1 first code PR (stops the live silent-failure class; smallest) → PR-2 (the centerpiece; already fully specced) → PR-3 (can develop in parallel with PR-2; both touch `campaignService` gate sites — rebase PR-3 on PR-2's merged gate topology to avoid conflict) → PR-4 before any ad spend on the ×10 promise (the door must exist before the first consultant session; there is no shipped way to earn ×10 today — old G5).
+
+---
+
+## 2. PR-1 — screening × draw integrity (new; the "fail loudly" PR)
+
+**2.1 Null-bake fix (the one-line root fix).** In `createProspect`, when the routing decision that feeds the screening hold has `via==='fallback'` (System Agent), store `screeningMetadata.intendedAgentId = null` instead of the System Agent id. Same for the DNC-hold mirror (`dncMetadata.intendedAgentId`) — it hands off into screening (G25 note: `releaseScreenedLead` already re-resolves null and refuses fallback, so held leads **auto-heal when funding arrives** via the existing 5-min sweep; no release-side change).
+- Files: `backend/src/services/prospectService.js` (~2 lines at the bake sites), tests in the existing screening DI suites.
+
+**2.2 Loud, rate-limited alarm on the un-deliverable state.** `releaseScreenedLead`'s `no_subscriber` / `no_intended_agent` returns today log a warn per 5-min sweep pass, forever, and nothing else. Add: (a) one ProspectActivity ("Held — qualified but no deliverable agent (fund a package)") written ONCE per lead (guard: only if last activity isn't already it); (b) an ops email via the existing alert-mail pattern (`SMS_ALERT_EMAIL` precedent) when a qualified lead has been held >30 min, throttled to one email per campaign per 24 h.
+- Files: `screeningGate.js`, `screeningSweepService.js`, small helper; DI tests for the once-only guard + throttle.
+
+**2.3 Readiness rows** (extend `campaignReadinessService`, precedent old G13):
+- `screening_no_funded_route` — **critical** when `form.gates.screeningCall=true` on an active campaign AND zero funded package assignments for it AND no `DEFAULT_AGENT_ID`; **warning** pre-launch.
+- `lead_credits_low` — **warning** when a screening or draw campaign's funded pool has <20% credits remaining (mirrors the auto-top-up threshold aesthetic; G26 makes this the re-arm tripwire).
+- `draw_record_missing` — **warning** when `luckyDraw.enabled` and now > `closesAt − 7d` with no draw row; **critical** past `closesAt` with none (the "witnessed draw that never happens" T&C breach). Execution itself stays manual/witnessed via `run-lucky-draw.js` — this row is the reminder, not automation (parked, §6).
+
+**2.4 Non-goals for PR-1:** no hard launch block on funding (D7 recommends readiness-critical only — the null-bake fix makes under-funding self-healing rather than lead-corrupting, and blocking would fight the "fund after launch" workflow).
+
+---
+
+## 3. PR-3 — draw promise-consistency lint (new)
+
+**3.1 `assertDrawConsistency(campaign, designConfig)`** in `campaignService`, called at the same sites as the multi-prize gate (create-born-active / `updateCampaign` willBeActive / `setCampaignLaunchState('active')`) for `luckyDraw.enabled` docs. Checks, each with a typed 422 code:
+- **Prize parity** (`DRAW_PRIZE_MISMATCH`): normalized `luckyDraw.prize` must appear in the terms `Prize:` clause; `prizes[0].name` must equal `luckyDraw.prize` (single-prize era). Content headline/story get a **warning-level** readiness row, not a 422 (marketing copy may legitimately shorthand — "Win an iPhone 17 PRO" vs "iPhone 17 Pro 256GB" must not block).
+- **Age parity** (`DRAW_TERMS_AGE_MISMATCH`): the terms eligibility clause must state the campaign's current `min_age`(+`max_age` when set, per D8). Implementation: regex the stored clause (`aged N( to M| and above)`) and compare numbers — not string-equality with the template (operator-authored terms are legal).
+- **Date parity** (`DRAW_TERMS_DATE_MISMATCH`): terms close-date mention vs `luckyDraw.closesAt`; multiplier mention ("N entries/chances") vs `luckyDraw.multiplier` — warning-level both (dates in prose are format-varied; false-422s on live funnels are worse than a warning).
+- **Remediation path:** the 422 payload carries `{fix: 'regenerate_terms'}`; Studio's existing terms flow re-runs `buildDrawTermsHtml` with current facts and `ensureDrawTermsVersion` mints the new version (the ONLY sanctioned fix — never in-place; the 07-24 manual v3 mint is the worked example, G21).
+- **Readiness mirror:** same checks as a `draw_promise_inconsistent` row (critical when live) so an already-active drifted campaign becomes visible without waiting for its next save (today's iPad case would have lit up).
+
+**3.2 Files:** `campaignService.js` (gate + helper), `campaignReadinessService.js`, Studio readiness panel row (frontend, small), fixture-driven unit suite — the literal iPad/21-vs-25 production doc as the regression fixture.
+
+**3.3 Interaction with PR-2:** PR-2's D4-amended age lint governs what the AI **writes**; PR-3 governs what the campaign **is** at launch regardless of author (AI, admin, or SQL). Complementary, not duplicate — keep both, share the clause-parsing helper.
+
+---
+
+## 4. PR-0 — prod ops today (no deploy)
+
+1. **Stamp the survivor:** `design_config.luckyDraw.activationId = '92dd875f-4293-4305-9a5f-293f8930bd61'` (jsonb_set; public payload strips it — old G18). Removes the G22 seal-at-1× time bomb independent of PR-2's fallback shipping.
+2. **Resize the pass window (G23):** offer `16eff8dd` `claimExpiryDays` 60→**90** (covers signup→Sep 30 + 21d margin); extend live entitlement `78fc83b3` `expiresAt` → **2026-10-14** (boostClosesAt + 14d claim buffer). Also tidy the internal title "…Draw Aug 2026" → "…Draw Sep 2026" (`publicTitle` already correct: "iPhone 17 Pro Lucky Draw Entry Pass").
+3. **Heal the stuck test lead (needs D6):** set `screeningMetadata.intendedAgentId = null` on `f95fe2cf…` → next 5-min sweep re-resolves to the funded agent `6707439d…`, charges 1 credit, fires `lead.created` to mktr-leads — the full pipeline proven end-to-end. Alternative: delete the test lead (its pass then needs the F15 caveat checked). **Recommend deliver.**
+4. **Verify:** skips table stays empty for the activation; the 5-min re-hold log line stops; entitlement expiry reads Oct 14; readiness (manual SQL until PR-1) shows a funded route.
+
+Rollback: every item is a plain UPDATE with the prior value recorded in this doc's PR-0 execution note (append receipts on execution, house style).
+
+---
+
+## 5. Adopted-verbatim summaries (details live in the old plan)
+
+- **5.1 PR-2 = old Phase 1.** `ensureDrawBoostRail()` (advisory-locked, idempotent, kill-switch `DRAW_BOOST_AUTOPROVISION_ENABLED`) at `setCampaignLaunchState` / `updateCampaign` / `createCampaign`-born-active (ensure-not-assert, old F2); `createDraw` by-campaign fallback + ambiguity 422 (F3); `applyLuckyDrawPolicy` stamp carry-forward (F5); prospect-delete entitlement unification (F15); allocation auto-top-up at <20% (D1); featuredDrop `endsAt` clamp (F9); AI age-copy lint **amended by D8** (derive both bounds when `max_age` set — G27 kills the strip-ceilings rationale). Note for Codex: old plan's Phase 0 is DONE and must not be re-run; the survivor's rail exists (G21) and PR-0 stamps it.
+- **5.2 PR-4 = old Phase 2.** Ops unlock derives `agent_scan` from a resolving `presentationToken` (D2: instant, no review); "Record session (×N boost)" + **"Undo session"** (F14 append-only reversal, latest-event-wins); draw-voiced delivery: Draw Entry Card (D5 line-set), unlock receipt "×N confirmed" suppressing the partner-voucher email (F13), WA sender `WHATSAPP_TEMPLATE_DRAW_PASS || 'draw_entry_pass'` (approved UTILITY).
+- **5.3 Hard external dependency held by PR-4:** until it ships, **no shipped surface can mint a countable boost** (old G5 — all 7 prod unlocks are `manual`, review-gated). Do not start paid traffic promising ×10 before PR-4 is live, or change the promise copy.
+- **5.4 Cosmetic nits folded into PR-4's frontend touch:** `ShareCampaignDialog.jsx:100` missing spaces (`Share"{name}"with others.`); `LeadCaptureOutcomes.jsx:184-198` public error screen's only CTA is `→ /Dashboard` ("Back to Safe Zone") — point it at the campaign page or redeem.sg home.
+
+---
+
+## 6. Parked (unchanged from old plan §Phase 3, plus)
+
+Multi-winner engine · boost-review UI · no-boost mode (F10) · winners-page automation · mktr-leads Phase-4 scan screens (separate repo; Tokyo field-scale) · **draw execution automation** (freeze/seal/draw stay manual+witnessed per T&C; PR-1's readiness row is the forget-proofing) · booking flow / `bookingUrl` (D3 — Retell screening owns the meet-arrangement UX; success-page CTA stays hidden until then).
+
+---
+
+## 7. Test + rollback summary
+
+- **PR-1:** DI suites — fallback-bake nulls id (screening + DNC mirror); null-id release re-resolves and refuses fallback; auto-heal on funding (sweep pass delivers after a package appears); once-only activity guard; alert throttle; 3 readiness rows over fixture states. Rollback: revert — no data shape changes (`intendedAgentId:null` is already a legal state the release path handles).
+- **PR-2:** old plan §4 list verbatim. Rollback: `DRAW_BOOST_AUTOPROVISION_ENABLED=false`.
+- **PR-3:** fixture matrix incl. the live iPad/21 doc as regression; 422 only on launch transitions; warning-not-block cases proven. Rollback: gate no-ops behind `DRAW_CONSISTENCY_GATE_ENABLED` (default true).
+- **PR-4:** old plan §4 list verbatim (+ nit snapshots). Rollback: old plan §6.
+- All PRs: baseline = full sweep vs origin/main, chronic reds only (per repo memory).
+
+---
+
+## 8. Decisions needed (Shawn)
+
+- **D6 — stuck test lead `f95fe2cf`:** deliver via re-resolve (recommended; proves pipeline; spends 1 credit; notifies your consultant mirror + mktr-leads app) or delete.
+- **D7 — screening funding gate strength:** readiness-**critical** only (recommended; null-bake makes under-funding self-healing) vs hard 422 block on activation.
+- **D8 — age-copy rule (amends old D4):** derive BOTH bounds when `max_age` is set — "aged 25 to 65" (recommended; matches live enforcement, G27) vs old strip-ceilings rule.
+- **D9 — distribution before ads:** survivor is direct-link-only today (G29). Decide featuredDrop/marketplace listing when ad traffic starts; no code needed.
+
+---
+
+## 9. Codex R1 (2026-07-24, gpt-5.6-sol xhigh) — verified dispositions + amendments
+
+24 findings; NO-GO on PR-0 as originally written. Every load-bearing claim was re-verified against this repo (Codex's file:line cites were frequently mangled — `frontend/src/features/…`, `backend/src/constants/…` don't exist — but the substance checked out in **every** pivotal case). Dispositions below; **amendments here supersede the conflicting §§2–5 text.**
+
+### 9.1 Verified-and-accepted (with amendments)
+
+| CX# | Finding | Verified evidence (this repo) | Amendment |
+|---|---|---|---|
+| 1 | **BLOCKER — DNC release path never re-resolves.** `releaseDncClearedLead` returns `no_intended_agent` and leaves the lead held when `agentId` is null; `gateHeldDncLead` passes the stored bake straight through. A null-baked DNC lead whose screening handoff declines (campaign gone, gate off, module failure) strands | `dncGate.js:77-82,216` | **PR-1 §2.1 amended:** add same-campaign re-resolution (refusing fallback) to `releaseDncClearedLead`, mirroring screening's. The doc's "no release-side changes" claim is withdrawn. (Not live-reachable today — survivor has `dncCheck:false` — but correctness, not urgency, is the point) |
+| 3+ | **DEFAULT_AGENT_ID nuance — both my doc AND Codex's fix are wrong.** A configured `DEFAULT_AGENT_ID` resolves `via:'fallback'` (`systemAgent.js:27-37,83`) so release re-resolution refuses it — Codex right that my readiness exception is broken. But Codex's "remove the exception" misses: TODAY a provenance-carrying default agent works via the **non-null bake** (destination resolves, delivery succeeds) — an unconditional null-bake would REGRESS that setup | `systemAgent.js` + `screeningGate.js:196-199` + `prospectHelpers.js` destination logic | **PR-1 §2.1 amended:** bake null iff `via==='fallback'` AND the resolved agent has no `lyfeId`/`mktrLeadsId` (one User lookup, held path only). Readiness row drops the DEFAULT_AGENT_ID clause entirely (prod has none set anyway — verified env list) |
+| 2 | Null-safety of refunds holds only via the undocumented invariant *fallback ⇒ `charged:false`* (`leadQuota.js`: soft→assign uncharged; quota+fallback→quarantine `no_funded_agent` before screening applies) | `leadQuota.js` decideAssignment (verified pre-Codex, independently) | **PR-1:** encode the invariant as a test; consider `chargedAgentId` split in PR-2's refund touching, not PR-1 |
+| 4 | Stale NON-null routes unvalidated at release (agent deactivated/defunded since capture); soft-quota deduct result ignored | `screeningGate.js:206,245-248,264` | **PR-1 (small):** on release, when un-charged, validate the stored agent (active + role) and re-resolve if invalid — same refuse-fallback rule |
+| 5 | "Charge exactly one credit" overclaimed — soft campaign ⇒ best-effort `deductLeadCredit`, not authoritative | `screeningGate.js:206-248`, verified survivor `enforce_lead_quota=false`, `leadPriceCents` null | **§4.3 wording amended:** "one best-effort deduction attempt." Preflight list → §9.3. All preflight facts for the stuck lead were gathered live this session (agent active+`mktrLeadsId` ✓, package active 10 credits ✓, `mktr_leads` subscriber enabled with `lead.created` ✓, `WEBHOOK_ENABLED=true` ✓, lead still `screening_pending`+qualified+no active call ✓) |
+| 6 | Stamp is save-fragile: `applyLuckyDrawPolicy` replaces `luckyDraw` wholesale; ONLY the terms keys are re-ensured on save (`ensureDrawTermsVersion`), `activationId` is not — any stale Studio/admin tab save wipes it until PR-2's F5 carry-forward lands | `utils/luckyDraw.js` + `campaignService.js:584` | **§4.1 amended:** stamp anyway (harmless, and createDraw is a September task PR-2 precedes), but it is a STOPGAP any save can undo — re-verify + re-stamp immediately before `createDraw`; PR-2's F5 + createDraw fallback are the real fix |
+| 7 | **Oct-14 expiry creates a false-success window**: unlock gates only on `expiresAt > now` (verified in the conditional UPDATE's WHERE), while boost evidence requires `createdAt < boostClosesAt` — a scan Oct 1–14 says "×N confirmed" and earns nothing | `entitlementService.js` unlock WHERE + `luckyDrawService.js` evidence bound | **§4.2 amended:** existing pass `expiresAt` → **2026-09-30 SGT day-end** (not Oct 14). `claimExpiryDays`→90 stays (else early-signup passes die BEFORE the cutoff — the worse failure). The residual false-window for future passes (issue+90d > Sep 30) is closed by a code clamp `min(issue+claimDays, boostClosesAt-end)` for draw-linked activations — added to **PR-4** (with the scan-time cutoff check); until then, ops discipline: no scans after Sep 30 |
+| 8 | Test lead enters the September pool either way (freeze filters only campaign/phone/time/verified-stamp — no test flag exists on prospects, none on DrawEntry) | `luckyDrawService.js` freeze (verified pre-Codex) | **D6 rewritten** (§9.4) |
+| 9,10 | **PR-2 lifecycle as adopted CANNOT work via the services:** `createOffer` 422s unless partner `pipelineStage==='PARTNERED'` (house partner is `LOST` — old G15's "no gate reads pipelineStage" is now false); offers are born `draft` and `createOffer` never activates; activation transitions are `draft→preparing→active` (no direct `draft→active`), `active` requires campaignId | `redeemOps/rewardService.js:77`, `RewardOffer` model, `activationService.js:11-17,215` | **PR-2 redesign note:** provisioning must either (a) require an env-pinned, stage-validated PARTNERED house partner + compose the real transition chain (offer create→activate; activation draft→preparing→active with campaign linked), or (b) be a first-class provisioning service doing model-level writes with its own audit rows. Phase-0 SQL worked precisely because it bypassed these gates |
+| 11 | "Adopt any active activation" unsafe **but for a different reason than old-F8**: partial unique `uq_act_live_campaign` (preparing/active/paused, campaignId≠null) means ONE live per campaign — old plan's "two active rails" ambiguity is impossible/stale. Real risk: the one live activation may be `on_capture` (mints `auto_on_capture`, never boost evidence) and a second can't be created | `Activation.js` indexes (verified) | **PR-2 redesign note:** adopt only if `unlockPolicy==='agent_unlock'` + offer active; else FAIL the ensure loudly (typed 422 naming the conflicting activation). Add durable idempotency marker (offer `internalRef` is non-unique) |
+| 12 | Auto-top-up as written under-specified: `changeAllocation` only allocates from committed capacity (invariant committed≥allocated); increasing committed is a separate op; the 15-min sweep has no cross-instance lock | `inventoryService.js:14,60,88` | **PR-2 redesign note:** top-up = advisory-locked recheck → increase committed → allocate → ledger+audit, atomically. Resolve 1000-vs-10000 default (old plan drifted; D1 says 10000) |
+| 13 | Old F15 "two differing delete paths" stale — bulk loops single; NEITHER cancels entitlements (FK `SET NULL` orphans them) | `prospectService.js` delete + `models/index.js:282` | **PR-2 scope simplified:** add live-entitlement cancellation (+ inventory reversal) to the single-delete tx; bulk inherits |
+| 14 | D8 correct but conditional: `max_age` enforced only when a usable DOB was submitted; DOB-required is a form choice; terms template accepts only `minAge` ("and above") | `prospectService.js` age gate + `drawTermsTemplate.js:71,103` (both verified) | **D8 expanded:** bounded-age draws require `fields.dob.required=true` as an activation invariant (readiness critical); template + AI facts + callers extended to carry both bounds |
+| 15,16 | PR-3 regexes brittle (`<strong>Prize:</strong>` markup, `&mdash;`/`&times;`/`&amp;` entities); and "same gate sites" would 422 EVERY save of a live campaign (the multi-prize gate provably runs on every active-state save — `willBeActive` includes unchanged-active), not just launch transitions | `drawTermsTemplate.js` output + `campaignService.js:598-605` (verified) | **PR-3 redesign note:** normalize HTML→text (decode entities, collapse whitespace, casefold) before comparing; hard-422 only on launch transitions AND fact-touching saves with high-confidence contradictions; everything else = readiness warnings; ship the regenerate-terms action (typed `fix:'regenerate_terms'` + preview-confirm) in the same PR |
+| 17 | Live-draw divergence: only `closesAt` is locked while a draw record exists; multiplier/boostClosesAt/terms/stamp can drift from the draw's snapshot and PR-3 would bless the drifted config | `campaignService.js:131-152` (verified — DRAW_CLOSES_AT_LOCKED covers closesAt only) | **PR-3 redesign note:** when a live draw row exists, parity target = the DRAW ROW's snapshot (multiplier, boostClosesAt, activationId, pinned terms), not just the config |
+| 18 | Freeze admits verified entrants with NO draw-terms consent (enabling a draw on an already-running campaign sweeps in pre-draw leads) and never audits per-entrant accepted versions | `luckyDrawService.js` freeze filter (verified pre-Codex) | **PR-2 addition:** freeze requires per-entrant `consentMetadata.drawTerms` evidence; group by accepted version and surface cohorts whose material facts differ (the survivor's iPad-era v2 acceptors vs v3 is the live example — the ONE existing entrant accepted v2) |
+| 19 | Readiness rows partially duplicate: `draw_record_missing` EXISTS (warning, line 196); `no_agent_pool` exists (warning); active-state read uses `is_active` only; void draws count as "has record" | `campaignReadinessService.js:96,196,231,257` (verified) | **PR-1 §2.3 amended:** modify/specialize existing rows (escalate `draw_record_missing` near close; screening-aware `no_agent_pool` variant), add only `lead_credits_low` + `screening_no_funded_route` as new; fix status-vs-is_active read; exclude void draws |
+| 20 | Lifecycle incoherence incl. a real dial-guard bug: `!['active'].includes(status) && is_active===false` — an archived campaign with `is_active=true` still dials; qualified-release sweep ignores campaign state | `retellScreeningService.js:175` (verified pre-Codex) | **PR-1:** fix the guard to OR-semantics. Job-1 qualified-release stays deliberately state-INDEPENDENT (build decision, deviates from Codex's suggestion): dialing is new spend + a customer touch on a stopped campaign, but releasing an already-captured, qualified lead is fulfilment — same philosophy as the drain job. Full lifecycle matrix → PR-2 |
+| 21 | Screening-FAILED entrants keep a 1× entry + a live pass they can theoretically still ×10 (entitlement quarantine-eligibility includes all three screening reasons; unlock needs an assigned consultant which failed leads lack — but admin/manual paths exist) | `entitlementService.js` + `screeningConstants.js` | **New decision D10** (§9.4) |
+| 22 | PR-4 "record session" mints a REAL redeemable voucher (token, issued state, claim page renders redeemable, redemption accepts it) — email suppression doesn't change the state machine | `entitlementService.js` unlock (verified: mints token, overwrites expiry) | **PR-4 redesign note:** draw-linked rails need a purpose-aware branch: append boost evidence + receipt WITHOUT minting a redeemable credential (no token), and claim/redemption reject draw-only rails |
+| 23 | Undo races seal (evidence read pre-transaction) and can't restore state (unlock overwrites `expiresAt`, event metadata is `{via}` only) | `luckyDrawService.js:386` + unlock UPDATE (verified) | **PR-4 redesign note:** stash prior expiry + superseded-event id in the reversal event; serialize undo vs seal (advisory lock or seal re-read inside tx); undo cutoff = `boostClosesAt` |
+| 24 | PR-0 prod predicates must be preflighted transactionally | — | **§9.3 checklist** (all already gathered live this session; re-run at execution time) |
+
+### 9.2 Codex claims corrected/rejected
+
+- **CX3's fix as stated** (drop the exception, full stop) — replaced by the provenance-aware bake (see 9.1 row 3+). 
+- **Old-plan F8** ("no unique index on activations.campaignId → double-provision race") — STALE, Codex right: `uq_act_live_campaign` exists. The advisory-lock in PR-2 remains for find-then-create atomicity, but the failure mode is a constraint violation, not silent duplication.
+- No Codex finding was verified FALSE. Its file paths were unreliable; its reasoning was not.
+
+### 9.3 PR-0 REDUCED — EXECUTED 2026-07-24 ~23:00 SGT (receipts)
+
+> **All items done + verified.** (1) `luckyDraw.activationId` stamped = `92dd875f…` (STOPGAP — any Studio/admin save can wipe until PR-2's F5; re-verify before createDraw). (2) Offer `16eff8dd`: `claimExpiryDays` 60→**90**, title →"…Sep 2026". (3) Pass expiry → `2026-09-30 15:59:59.999+00` (SGT day-end = boost cutoff). (4) Preflight: all 6 checks true pre-execution. (5) **D6 heal→verify→delete EXECUTED:** nulled `intendedAgentId` 22:53 SGT → sweep released **22:57:12** to funded agent `6707439d` — credit charged 10→**9** (best-effort deduct, soft campaign), `lead.created` → MKTR Leads App **success/1 attempt**, activity "Released after AI screening (qualified)…" written. Pipeline proven END-TO-END (capture→screen→qualify→heal→release→deliver→charge). (6) Cleanup via SERVICE paths (minted admin JWT, user `c4a0f57a`): pass cancelled w/ audited reason + `issuedCount` reverted 1→**0** (inventory reversal ran), prospect deleted via `DELETE /api/prospects/:id` → `lead.deleted` → MKTR Leads App **success/1 attempt** (mirror cleaned, no ghost). Post-state: campaign has **0 prospects, 0 live passes** — phone + dup slots freed for re-testing; September pool starts clean (CX8/CX18 test-pollution moot). Residual known state: 1 charged credit (9 remaining) reflects the real delivered test lead in the mktr-leads app history — lead itself soft-deleted there by the mirror.
+
+Original checklist (for re-runs):
+
+1. Stamp `luckyDraw.activationId` (stopgap — any save can wipe; re-verify before createDraw). 2. Offer `claimExpiryDays` 60→90 + internal title "Aug→Sep". 3. Existing pass `78fc83b3` `expiresAt` → 2026-09-30 SGT day-end. 4. Preflight re-run at execution: lead `screening_pending`+`qualified`+`screeningActiveCallId IS NULL`; agent `6707439d` active+`mktrLeadsId`; package assignment active, `leadsRemaining>0`; `mktr_leads` subscriber enabled incl. `lead.created`; `WEBHOOK_ENABLED=true`; entitlement still `eligible`. 5. Item: heal stuck lead — **blocked on D6 only.** 6. After any heal: verify decrement (`leadsRemaining` 10→9), delivery row destination `mktr_leads`, activity trail; record before/after in this doc.
+
+### 9.4 Decisions — updated set
+
+- **D6 (rewritten):** stuck test lead `f95fe2cf` — it WILL be in the September pool if it exists at freeze (no test-flag mechanism). Options: (a) **heal → verify pipeline end-to-end → then delete the prospect + manually cancel its orphaned pass before freeze** (recommended — proves everything, pollutes nothing; note delete today orphans the pass, CX13, so the cancel is manual); (b) heal and keep as a genuine entrant (it's Shawn's own number — winning your own draw is a bad look); (c) delete now unproven.
+- **D7:** unchanged (readiness-critical, no hard block) — reinforced by the provenance-aware null-bake making under-funding self-healing.
+- **D8 (expanded):** both-bounds age copy + DOB-required as a hard invariant for bounded-age draws (CX14).
+- **D9:** unchanged.
+- **D10 (new, from CX21):** screening-FAILED entrants — choose: keep 1× + cancel their boost pass (draw promise stays, ×10 path honestly closed), or leave the pass live (they can still book/be scanned via admin paths). Recommend cancel-on-fail with T&C wording check.
+
+---
+
+*Cross-refs: `draw-boost-rail-auto-provision.md` (F/G/D 1-series, Phases → PR-2/PR-4) · `lucky-draw-10x.md` (engine) · `retell-screening-calls.md` (gate §5, release §9) · memory `project-lucky-draw-campaign` (07-24 addendum), `project-retell-screening-calls`. Codex R1 raw output: session scratchpad `codex_review_out.md` (2026-07-24).*


### PR DESCRIPTION
## What

PR-1 of `docs/plans/draw-launch-integrity-scope.md` (Codex R1 reviewed — §9 amendments folded). Makes the 07-24 "qualified lead loops held forever" incident structurally impossible and turns every silent screening failure loud.

- **Provenance-aware hold-target bake** (`prospectService`): `via='fallback'` holds bake `intendedAgentId: null` unless the agent carries `lyfeId`/`mktrLeadsId` (a deliverable `DEFAULT_AGENT_ID` keeps its bake). Both mirrors: screening + DNC.
- **Self-healing releases**: `releaseDncClearedLead` gains the same null re-resolve (refusing fallback) screening already had (CX1). Held leads auto-deliver within one sweep pass of a package being funded — prod-proven 07-24 (22:57 heal), now a regression test.
- **Stale-route revalidation** (CX4): uncharged stored agents are validated (role+active) at release; invalid → re-resolve. Charged leads keep their agent.
- **Loud alarms** (§2.2): once-per-lead activity + ops email (`SCREENING_ALERT_EMAIL || SMS_ALERT_EMAIL`, throttled 1/campaign/24h, ≥30-min holds only) on `no_intended_agent`/`no_subscriber`.
- **Dial-guard OR-fix** (CX20): archived-but-`is_active` campaigns no longer place new calls. Qualified-release stays state-independent by design (fulfilment ≠ new spend).
- **Readiness rows** (§2.3/CX19): `screening_no_funded_route` (critical live / warning pre-launch — never blocks activation, D7), `lead_credits_low` (<20% tripwire), `draw_record_missing` escalates critical past close (void records excluded), status-aware active read.

## Tests

- 2 new suites + cases across 4 existing (27 new tests). Unit sweep **88/90** — the 2 reds (shortlink, email) are the documented inherited chronics; the `consentGlobalGrant` crasher is byte-identical to `origin/main`.
- Backend-only; no frontend/bundle changes (Studio renders the new readiness rows generically).

## Rollback

Revert — no data-shape changes (`intendedAgentId: null` is a state the release paths already handle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)