### PR TITLE
fix(draw): un-clobber drawLink's Campaign model — every prod unlock was 500ing

### DIFF
--- a/backend/src/services/redeemOps/drawLink.js
+++ b/backend/src/services/redeemOps/drawLink.js
@@ -35,7 +35,15 @@ export function boostDeadlineLong(ymd) {
 }
 
 export function makeDrawLink(overrides = {}) {
-  const d = { Activation, Campaign, ...overrides };
+  // Drop undefined override VALUES: a caller forwarding a dep it doesn't have
+  // (`{ Campaign: d.Campaign }` with no Campaign in its deps) must fall back
+  // to the real model, not clobber it — that exact shape took down every
+  // production unlock on 2026-07-25. Deliberate absence in a hermetic test
+  // should use a throwing stub or null, never undefined.
+  const definedOverrides = Object.fromEntries(
+    Object.entries(overrides ?? {}).filter(([, value]) => value !== undefined)
+  );
+  const d = { Activation, Campaign, ...definedOverrides };
 
   /** @returns {Promise<null | {campaignId, drawName, multiplier, boostClosesAt, boostCutoffMs}>} */
   async function drawContextForActivation(activationOrId) {

--- a/backend/src/services/redeemOps/entitlementService.js
+++ b/backend/src/services/redeemOps/entitlementService.js
@@ -1,7 +1,7 @@
 import { Op } from 'sequelize';
 import {
   RewardEntitlement, RedemptionEvent, Redemption, Activation, ActivationIssuanceSkip, RewardOffer,
-  PartnerOrganisation, Prospect, User, Consumer, sequelize,
+  PartnerOrganisation, Prospect, User, Consumer, Campaign, sequelize,
 } from '../../models/index.js';
 import { phoneVerificationIsCurrent } from '../consumerService.js';
 import { AppError } from '../../middleware/errorHandler.js';
@@ -63,7 +63,7 @@ export async function flushDeliveries() {
 export function makeEntitlementService(overrides = {}) {
   const d = {
     RewardEntitlement, RedemptionEvent, Redemption, Activation, ActivationIssuanceSkip, RewardOffer,
-    PartnerOrganisation, Prospect, User, Consumer, sequelize, logger,
+    PartnerOrganisation, Prospect, User, Consumer, Campaign, sequelize, logger,
     inventory: makeInventoryService(),
     audit: makeRedeemOpsAuditService(),
     notifyUnlock: null, // injected by entitlementWiring (voucher email) — null-safe
@@ -898,7 +898,10 @@ export function makeEntitlementService(overrides = {}) {
    * to `maxAttempts` per kind; rows younger than `minAgeMinutes` are skipped so
    * an in-flight fire-and-forget send isn't pointlessly rotated. Requires the
    * notify deps to be wired — a bare instance returns 0 (never rotate a
-   * credential we cannot deliver).
+   * credential we cannot deliver). Issued DRAW sessions are token-free by
+   * design: their recovery is the "×N confirmed" boost receipt, never a
+   * voucher mint, and draw classification fails closed (skip, retry next
+   * sweep) so a lookup error can never reclassify a draw rail.
    */
   async function reconcileMissedDeliveries({ maxAttempts = 3, minAgeMinutes = 10 } = {}) {
     const cutoff = new Date(Date.now() - minAgeMinutes * 60 * 1000);
@@ -914,11 +917,24 @@ export function makeEntitlementService(overrides = {}) {
     let recovered = 0;
     for (const ent of candidates) {
       try {
-        const kind = ent.status === 'eligible' ? 'pass' : 'voucher';
-        const fn = kind === 'voucher' ? d.notifyUnlock : d.notifyReservation;
+        // Draw classification comes BEFORE the kind decision, and it fails
+        // CLOSED: an issued draw session's missed delivery is the ×N boost
+        // receipt — recovering it as a voucher would mint the redeemable
+        // credential draw rails must never carry (the 2026-07-25 clobber
+        // outage nearly did exactly that). A lookup error skips the row
+        // (retried next sweep) rather than risking that misclassification.
+        let drawCtx;
+        try {
+          drawCtx = await d.drawLink.drawContextForEntitlement(ent);
+        } catch (err) {
+          d.logger.warn('redeem_ops.delivery.recover_draw_lookup_failed', { id: ent.id, error: err?.message });
+          continue;
+        }
+        const kind = ent.status === 'eligible' ? 'pass' : drawCtx ? 'boost_receipt' : 'voucher';
+        const fn = kind === 'voucher' ? d.notifyUnlock : kind === 'boost_receipt' ? d.notifyBoostReceipt : d.notifyReservation;
         if (typeof fn !== 'function') continue; // unwired — never rotate undeliverably
         if (!canEmailProspect(ent.prospect)) continue; // link-channel-only customer
-        const stateSince = kind === 'voucher' ? (ent.unlockedAt || ent.createdAt) : ent.createdAt;
+        const stateSince = kind === 'pass' ? ent.createdAt : (ent.unlockedAt || ent.createdAt);
         if (new Date(stateSince) > cutoff) continue; // give the in-flight send its window
 
         const receipts = await d.RedemptionEvent.findAll({
@@ -930,34 +946,44 @@ export function makeEntitlementService(overrides = {}) {
         if (forKind.some((e) => e.type === 'notified')) continue; // delivered
         if (forKind.length >= maxAttempts) continue; // gave up — visible on the console
 
-        const fresh = mintToken();
-        const fields = kind === 'pass'
-          ? { presentationTokenHash: fresh.hash }
-          : { tokenHash: fresh.hash, tokenHint: tokenHintOf(fresh.raw) };
-        let rotated = false;
-        await d.sequelize.transaction(async (t) => {
-          const [count] = await d.RewardEntitlement.update(fields, {
-            where: {
-              id: ent.id,
-              status: ent.status,
-              [Op.or]: [{ expiresAt: null }, { expiresAt: { [Op.gt]: d.sequelize.literal('NOW()') } }],
-            },
-            transaction: t,
+        // boost_receipt carries NO credential — nothing to rotate. Its resend
+        // is the informational "×N confirmed" email plus the same audit row;
+        // pass/voucher keep the rotate-inside-a-guarded-transaction shape.
+        const fresh = kind === 'boost_receipt' ? null : mintToken();
+        if (fresh) {
+          const fields = kind === 'pass'
+            ? { presentationTokenHash: fresh.hash }
+            : { tokenHash: fresh.hash, tokenHint: tokenHintOf(fresh.raw) };
+          let rotated = false;
+          await d.sequelize.transaction(async (t) => {
+            const [count] = await d.RewardEntitlement.update(fields, {
+              where: {
+                id: ent.id,
+                status: ent.status,
+                [Op.or]: [{ expiresAt: null }, { expiresAt: { [Op.gt]: d.sequelize.literal('NOW()') } }],
+              },
+              transaction: t,
+            });
+            if (count === 0) return;
+            rotated = true;
+            await writeEvent(t, {
+              entitlementId: ent.id, type: 'manual_override', actorType: 'system',
+              metadata: { action: 'auto_resend', kind, channel: 'email' },
+            });
           });
-          if (count === 0) return;
-          rotated = true;
-          await writeEvent(t, {
+          if (!rotated) continue;
+          await ent.reload();
+        } else {
+          await writeEvent(null, {
             entitlementId: ent.id, type: 'manual_override', actorType: 'system',
             metadata: { action: 'auto_resend', kind, channel: 'email' },
           });
-        });
-        if (!rotated) continue;
-        await ent.reload();
+        }
         queueDelivery({
           entitlement: ent, prospect: ent.prospect, kind,
-          presentationToken: kind === 'pass' ? fresh.raw : null,
-          voucherToken: kind === 'voucher' ? fresh.raw : null,
-          drawCtx: await d.drawLink.drawContextForEntitlement(ent).catch(() => null),
+          presentationToken: kind === 'pass' && fresh ? fresh.raw : null,
+          voucherToken: kind === 'voucher' && fresh ? fresh.raw : null,
+          drawCtx,
         });
         recovered += 1;
       } catch (err) {

--- a/backend/test/redeemOpsFulfilmentDelivery.test.js
+++ b/backend/test/redeemOpsFulfilmentDelivery.test.js
@@ -384,6 +384,72 @@ describe('sweeps deliver', () => {
   });
 });
 
+describe('draw-rail recovery (2026-07-25 regression: the sweep must never mint a voucher on a draw session)', () => {
+  let drawCampaign, drawActivation;
+
+  beforeAll(async () => {
+    drawCampaign = await createTestCampaign(admin.user.id, {
+      name: 'Draw Recovery Campaign',
+      design_config: { luckyDraw: { enabled: true, closesAt: '2027-06-30', multiplier: 10 } },
+    });
+    drawActivation = await Activation.create({
+      partnerOrganisationId: partner.id, rewardOfferId: offer.id, campaignId: drawCampaign.id,
+      campaignNameSnapshot: drawCampaign.name, allocatedQuantity: 5, status: 'active',
+      unlockPolicy: 'agent_unlock', createdBy: admin.user.id,
+    });
+  });
+
+  test('recovery of an issued draw session resends the boost receipt — no token mint, no voucher event', async () => {
+    const prospect = await makeProspect({ campaignId: drawCampaign.id });
+    const issue = await svc.issueForProspect(prospect);
+    expect(issue.reason).toBeNull();
+    expect(issue.entitlement.activationId).toBe(drawActivation.id);
+    await settle();
+
+    // Draw unlock: issued + token-free; arm the boost-receipt email to FAIL
+    // so the sweep sees a stranded delivery.
+    sendEmailMock.mockClear();
+    sendEmailMock.mockResolvedValueOnce({ success: false, message: 'mailer down' });
+    const unlock = await svc.unlockEntitlement(
+      { presentationToken: issue.presentationToken }, agentExt.user, 'agent_scan'
+    );
+    expect(unlock.drawBoost).toMatchObject({ multiplier: 10 });
+    expect(unlock.voucherToken).toBeNull();
+    await settle();
+
+    const failed = await RedemptionEvent.findAll({
+      where: { entitlementId: issue.entitlement.id, type: 'notify_failed' },
+    });
+    expect(failed.map((e) => e.metadata?.kind)).toContain('boost_receipt');
+
+    await backdateHistory(issue.entitlement.id, 15);
+    // The sweep's in-flight window for issued rows keys off unlockedAt.
+    await sequelize.query(
+      `UPDATE reward_entitlements SET "unlockedAt" = NOW() - INTERVAL '15 minutes' WHERE id = :id`,
+      { replacements: { id: issue.entitlement.id } }
+    );
+    sendEmailMock.mockClear();
+
+    const recovered = await svc.reconcileMissedDeliveries();
+    expect(recovered).toBeGreaterThanOrEqual(1);
+    await settle();
+
+    // The resent email is the ×N receipt for THIS prospect…
+    const mine = sendEmailMock.mock.calls.map((c) => c[0]).find((m) => m.to === prospect.email);
+    expect(mine).toBeTruthy();
+    // …and the row NEVER acquired voucher credentials.
+    const row = await RewardEntitlement.findByPk(issue.entitlement.id);
+    expect(row.status).toBe('issued');
+    expect(row.tokenHash).toBeNull();
+    expect(row.tokenHint).toBeNull();
+
+    const events = await RedemptionEvent.findAll({ where: { entitlementId: issue.entitlement.id } });
+    expect(events.filter((e) => e.metadata?.kind === 'voucher')).toHaveLength(0);
+    const resend = events.find((e) => e.type === 'manual_override' && e.metadata?.action === 'auto_resend');
+    expect(resend?.metadata?.kind).toBe('boost_receipt');
+  });
+});
+
 describe('resend / share', () => {
   async function issueBackdated(overrides = {}) {
     const prospect = await makeProspect(overrides);

--- a/backend/test/unit/drawLink.test.js
+++ b/backend/test/unit/drawLink.test.js
@@ -1,0 +1,44 @@
+/**
+ * makeDrawLink override hygiene — regression for the 2026-07-25 outage.
+ *
+ * entitlementService forwarded `Campaign: d.Campaign` while `Campaign` wasn't
+ * in its deps, so the overrides spread clobbered drawLink's own valid model
+ * with undefined and EVERY production unlock 500'd at d.Campaign.findByPk.
+ * Contract under test: undefined override VALUES fall back to the module's
+ * real imports; defined overrides still win; a null overrides bag is
+ * tolerated. Deliberate absence in a hermetic test must use a throwing stub
+ * or null — never undefined.
+ */
+import { jest } from '@jest/globals';
+import { makeDrawLink } from '../../src/services/redeemOps/drawLink.js';
+import { Activation, Campaign } from '../../src/models/index.js';
+
+afterEach(() => jest.restoreAllMocks());
+
+test('undefined override values fall back to the real models (the clobber shape)', async () => {
+  jest.spyOn(Activation, 'findByPk').mockResolvedValue({ id: 'act1', campaignId: 'c1' });
+  const campaignSpy = jest.spyOn(Campaign, 'findByPk').mockResolvedValue(null);
+
+  const link = makeDrawLink({ Activation: undefined, Campaign: undefined });
+  const ctx = await link.drawContextForActivation('act1');
+
+  // Pre-fix this threw "Cannot read properties of undefined (reading 'findByPk')".
+  expect(campaignSpy).toHaveBeenCalledWith('c1', expect.anything());
+  expect(ctx).toBeNull(); // campaign row absent — clean null, never a TypeError
+});
+
+test('a null overrides bag is tolerated', () => {
+  expect(() => makeDrawLink(null)).not.toThrow();
+});
+
+test('defined overrides still win over the module imports', async () => {
+  const fakeActivation = { findByPk: jest.fn(async () => null) };
+  const realSpy = jest.spyOn(Activation, 'findByPk').mockResolvedValue({ id: 'x', campaignId: 'c9' });
+
+  const link = makeDrawLink({ Activation: fakeActivation });
+  const ctx = await link.drawContextForActivation('missing');
+
+  expect(fakeActivation.findByPk).toHaveBeenCalled();
+  expect(realSpy).not.toHaveBeenCalled();
+  expect(ctx).toBeNull();
+});


### PR DESCRIPTION
## Incident

Since PR-4 (#257) deployed at 2026-07-25 00:30 SGT, **every fresh gift unlock in production returned 500** — external app (scan and button), lyfe integration, and the redeem-ops console:

```
TypeError: Cannot read properties of undefined (reading 'findByPk')
    at drawContextForActivation (src/services/redeemOps/drawLink.js:46)
    at async Object.unlockEntitlement (src/services/redeemOps/entitlementService.js:490)
```

## Root cause

`entitlementService` builds its drawLink with `makeDrawLink({ Activation: d.Activation, Campaign: d.Campaign })` — but `Campaign` was never imported there and isn't in its deps, so the overrides spread **clobbered drawLink's own valid `Campaign` import with `undefined`**. First campaign-linked unlock → `d.Campaign.findByPk` → TypeError. The crash fires before the luckyDraw-enabled check, so ALL campaign-linked unlocks died, not just draw campaigns.

The five fulfilment DB suites pin this exact TypeError (5 failures on the parent commit) — standing-red CI let the merge through.

## Fixes

1. **`entitlementService`**: import `Campaign` + add it to the deps object.
2. **`makeDrawLink` hardening**: drop `undefined` override values (null-safe) — a forwarded-but-absent dep now falls back to the real model instead of clobbering it.
3. **`reconcileMissedDeliveries` (independent PR-4 defect)**: `kind` was decided purely by status (`issued ⇒ voucher`) with no draw check — the 15-min sweep would have **minted a redeemable voucher token onto issued draw sessions** (their boost receipt never writes a `voucher` receipt, so they always look like missed voucher deliveries). Draw classification now happens before the kind decision and **fails closed** (skip, retry next sweep); issued draw sessions recover the ×N boost receipt with no credential mint.

## Tests

- `test/unit/drawLink.test.js` — override hygiene battery (clobber shape, null bag, defined overrides win).
- `redeemOpsFulfilmentDelivery.test.js` — regression: recovery of an issued draw session resends the boost receipt, never writes `tokenHash`/`tokenHint` or a `voucher` event.
- Full fulfilment set green: 6 suites, 87 tests (5 fail with the prod TypeError without this fix).

## Post-merge

- Verify the Render deploy actually picks up this commit (this workspace has a history of missed auto-deploys).
- Audit the bad-deploy window for repairs: unclamped draw-pass expiries, trial-voiced draw sends, any sweep-minted voucher credentials on draw rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXwL8WBkMUAJdtjQUd5eQ8