### PR TITLE
feat(draw): WhatsApp leg for the ×N boost receipt

### DIFF
--- a/backend/src/services/redeemOps/entitlementService.js
+++ b/backend/src/services/redeemOps/entitlementService.js
@@ -71,6 +71,7 @@ export function makeEntitlementService(overrides = {}) {
     notifyUnlockWa: null, // injected by entitlementWiring (voucher WhatsApp, PR E) — null-safe
     notifyReservationWa: null, // injected by entitlementWiring (reservation-pass WhatsApp, PR E) — null-safe
     notifyBoostReceipt: null, // injected by entitlementWiring (PR-4 "×N confirmed" email) — null-safe
+    notifyBoostReceiptWa: null, // injected by entitlementWiring ("×N confirmed" WhatsApp) — null-safe
     drawLink: null, // PR-4: built AFTER the merge from the service's OWN models (DI-hermetic)
     builders: null, // share/claim-URL builders; defaults lazily to makeFulfilmentNotify()
     isSendBlocked, // PR C: erasure stop at the send choke point (transactional purpose)
@@ -195,8 +196,7 @@ export function makeEntitlementService(overrides = {}) {
     };
 
     if (channels.includes('whatsapp')) {
-      // boost_receipt has no approved WA template yet — email-only (PR-4).
-      const waFn = kind === 'voucher' ? d.notifyUnlockWa : kind === 'boost_receipt' ? null : d.notifyReservationWa;
+      const waFn = kind === 'voucher' ? d.notifyUnlockWa : kind === 'boost_receipt' ? d.notifyBoostReceiptWa : d.notifyReservationWa;
       if (typeof waFn === 'function') fire(waFn, 'whatsapp');
     }
 
@@ -564,7 +564,7 @@ export function makeEntitlementService(overrides = {}) {
     // the "×N confirmed" receipt for draw rails (F13 — never the partner-
     // redemption voucher email a draw entrant can do nothing with).
     const emailQueued = drawCtx
-      ? queueDelivery({ entitlement, prospect, kind: 'boost_receipt', drawCtx, channels: ['email'] })
+      ? queueDelivery({ entitlement, prospect, kind: 'boost_receipt', drawCtx })
       : queueDelivery({ entitlement, prospect, kind: 'voucher', voucherToken: voucher.raw });
     return {
       entitlement, already: false, voucherToken: drawCtx ? null : voucher.raw, emailQueued,

--- a/backend/src/services/redeemOps/entitlementWiring.js
+++ b/backend/src/services/redeemOps/entitlementWiring.js
@@ -25,9 +25,11 @@ export function makeWiredEntitlementService(overrides = {}) {
     notifyUnlock: (args) => notify.sendVoucherEmail(args),
     notifyReservationWa: (args) => wa.sendReservationWhatsApp(args),
     notifyUnlockWa: (args) => wa.sendVoucherWhatsApp(args),
-    // PR-4: "×N confirmed" receipt at a recorded draw session (email-only —
-    // no approved WA template for it yet).
+    // "×N confirmed" receipt at a recorded draw session — email + WhatsApp
+    // (the `draw_boost_receipt` UTILITY template; the WA leg self-guards on
+    // the flag and fails receipted while the template is in review).
     notifyBoostReceipt: (args) => notify.sendBoostReceiptEmail(args),
+    notifyBoostReceiptWa: (args) => wa.sendBoostReceiptWhatsApp(args),
     ...overrides,
   });
 }

--- a/backend/src/services/redeemOps/whatsappService.js
+++ b/backend/src/services/redeemOps/whatsappService.js
@@ -334,7 +334,24 @@ export function makeWhatsappService(overrides = {}) {
     });
   }
 
-  return { sendReservationWhatsApp, sendVoucherWhatsApp };
+  /** "×N confirmed" receipt at a recorded draw session — the WA twin of
+   * sendBoostReceiptEmail, same register as the email body. Body-only
+   * APPROVED UTILITY template `draw_boost_receipt` (no header on purpose:
+   * the pass is consumed, there is nothing left to scan); 3 params =
+   * name, draw name, multiplier. */
+  async function sendBoostReceiptWhatsApp({ prospect, drawCtx }) {
+    return sendTemplate({
+      prospect,
+      templateName: process.env.WHATSAPP_TEMPLATE_DRAW_BOOST || 'draw_boost_receipt',
+      params: [
+        cleanParam(prospect?.firstName, 'there'),
+        cleanParam(drawCtx?.drawName, 'the lucky draw'),
+        String(drawCtx?.multiplier || 10),
+      ],
+    });
+  }
+
+  return { sendReservationWhatsApp, sendVoucherWhatsApp, sendBoostReceiptWhatsApp };
 }
 
 const _default = makeWhatsappService();

--- a/backend/test/unit/drawScanDoor.test.js
+++ b/backend/test/unit/drawScanDoor.test.js
@@ -63,6 +63,7 @@ function mkWorld({ draw = true, status = 'eligible', drawOver = {} } = {}) {
     notifyReservation: jest.fn(async () => ({ sent: true })),
     notifyUnlockWa: null,
     notifyReservationWa: null,
+    notifyBoostReceiptWa: jest.fn(async () => ({ sent: true, to: '••••9089' })),
     logger: silentLogger,
   };
   return { deps, row, entitlement, updates, events, svc: makeEntitlementService(deps) };
@@ -87,6 +88,9 @@ describe('unlockEntitlement — draw rail (CX22/CX7)', () => {
     await flushDeliveries();
     expect(w.deps.notifyBoostReceipt).toHaveBeenCalledTimes(1);
     expect(w.deps.notifyUnlock).not.toHaveBeenCalled();
+    // WhatsApp twin (draw_boost_receipt template) rides the same unlock.
+    expect(w.deps.notifyBoostReceiptWa).toHaveBeenCalledTimes(1);
+    expect(w.deps.notifyBoostReceiptWa.mock.calls[0][0].drawCtx).toMatchObject({ multiplier: 10 });
   });
 
   it('trial rails are byte-unchanged: voucher minted, redemption window set, voucher email', async () => {
@@ -100,6 +104,7 @@ describe('unlockEntitlement — draw rail (CX22/CX7)', () => {
     await flushDeliveries();
     expect(w.deps.notifyUnlock).toHaveBeenCalledTimes(1);
     expect(w.deps.notifyBoostReceipt).not.toHaveBeenCalled();
+    expect(w.deps.notifyBoostReceiptWa).not.toHaveBeenCalled();
   });
 
   it('REFUSES truthfully after the boost window closes — no unearned ×N confirmation (CX7)', async () => {


### PR DESCRIPTION
Consumers now get the "your chances are boosted" confirmation on **WhatsApp as well as email** after a consultant records their draw session.

- New WABA template **`draw_boost_receipt`** (UTILITY, body-only, `en`) submitted to the Redeem WABA — mirrors the boost-receipt email's register: *"Hi {{1}}, your completed review has been recorded — your entry to the {{2}} now holds {{3}} chances instead of one. Nothing else to do — winners are contacted directly after the draw. We never ask you to pay to release a prize."* Status at PR time: **PENDING** (Graph id `1517717636274602`).
- `sendBoostReceiptWhatsApp` in whatsappService (template name overridable via `WHATSAPP_TEMPLATE_DRAW_BOOST`), wired as `notifyBoostReceiptWa` through entitlementWiring, selected for `kind='boost_receipt'` in `queueDelivery`. The unlock's boost delivery loses its `channels: ['email']` override; the recovery sweep inherits both legs automatically.
- While the template is in review, a WA send fails **receipted** (`notify_failed`) — never silently; email is unaffected. Once Meta approves, delivery starts with no further deploy.
- Tests: drawScanDoor asserts the WA twin fires with `drawCtx` on draw unlocks and never on trial rails. Full affected set green: 4 suites, 50 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXwL8WBkMUAJdtjQUd5eQ8