### PR TITLE
feat(draw): the Vault pass + Onyx email — one colourway paints both messages of the draw journey

### DIFF
--- a/backend/scripts/preview-draw-email.js
+++ b/backend/scripts/preview-draw-email.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Renders the Onyx draw confirmation email to HTML files (one per colourway)
+ * so it can be opened in a browser or pasted into a client-preview tool.
+ * Goes through the real renderLeadConfirmation path, so what you see here is
+ * byte-identical to what sendLeadConfirmationEmail puts on the wire.
+ *
+ *   node scripts/preview-draw-email.js [outDir]
+ */
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { renderLeadConfirmation } from '../src/services/email-templates/leadConfirmation.js';
+import { PASS_THEMES } from '../src/utils/drawTheme.js';
+
+const outDir = path.resolve(process.argv[2] || 'tmp/draw-email-preview');
+
+const SAMPLE = {
+  titanium: { name: 'iPhone 17 Pro Lucky Draw', prize: 'iPhone 17 Pro 256GB', multiplier: 10, drawOn: '2026-10-22', firstName: 'Shawn' },
+  gold: { name: '$5,000 Cash Lucky Draw', prize: '$5,000 cash', multiplier: 10, drawOn: '2026-11-30', firstName: 'Priya' },
+  emerald: { name: 'Bali Escape Lucky Draw', prize: 'a Bali escape for two', multiplier: 5, drawOn: '2026-12-15', firstName: 'Marcus' },
+  // No drawOn — proves the third stat falls back to the entry close date.
+  sapphire: { name: 'PS5 Pro Bundle Lucky Draw', prize: 'the PS5 Pro bundle', multiplier: 7, closesAt: '2027-01-05', firstName: 'Aisha' },
+};
+
+await mkdir(outDir, { recursive: true });
+
+for (const theme of PASS_THEMES) {
+  const s = SAMPLE[theme];
+  const { html, text } = renderLeadConfirmation({
+    firstName: s.firstName,
+    campaignName: s.name,
+    isMktrHost: false,
+    shareUrl: 'https://redeem.sg/share/niyooei0',
+    unsubscribeUrl: 'https://api.mktr.sg/api/unsubscribe?t=demo',
+    unsubscribeTextLine: 'Unsubscribe from marketing messages: https://api.mktr.sg/api/unsubscribe?t=demo',
+    luckyDraw: {
+      enabled: true, passTheme: theme, prize: s.prize, multiplier: s.multiplier,
+      drawOn: s.drawOn, closesAt: s.closesAt,
+    },
+  });
+  const left = html.match(/\{\{\w+\}\}/g);
+  if (left) console.warn(`  ! ${theme}: unsubstituted placeholders ${[...new Set(left)].join(', ')}`);
+  await writeFile(path.join(outDir, `${theme}.html`), html);
+  await writeFile(path.join(outDir, `${theme}.txt`), text);
+  console.log(`${path.join(outDir, `${theme}.html`)}  ${(html.length / 1024).toFixed(1)}kB`);
+}

--- a/backend/scripts/preview-draw-pass.js
+++ b/backend/scripts/preview-draw-pass.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * Renders the Vault lucky-draw pass to PNGs so the artwork can be eyeballed
+ * without sending a WhatsApp. Both messages, every colorway.
+ *
+ *   node scripts/preview-draw-pass.js [outDir] [multiplier]
+ *
+ * Defaults to ./tmp/draw-pass-preview and ×10. Pass a different multiplier to
+ * check the hero numeral's auto-fit (2 → "2×" … 100 → "100×").
+ */
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { renderDrawPassPng, PASS_THEMES } from '../src/services/redeemOps/drawPassRenderer.js';
+
+const outDir = path.resolve(process.argv[2] || 'tmp/draw-pass-preview');
+const multiplier = Number(process.argv[3]) || 10;
+
+const SAMPLE = {
+  titanium: { prize: 'the iPhone 17 Pro', firstName: 'Shawn', drawDateLong: '30 October 2026' },
+  gold: { prize: '$5,000 cash', firstName: 'Priya', drawDateLong: '30 November 2026' },
+  emerald: { prize: 'a Bali escape for two', firstName: 'Marcus', drawDateLong: '15 December 2026' },
+  sapphire: { prize: 'the PS5 Pro bundle', firstName: 'Aisha', drawDateLong: '5 January 2027' },
+};
+
+await mkdir(outDir, { recursive: true });
+
+for (const theme of PASS_THEMES) {
+  const s = SAMPLE[theme];
+  for (const variant of ['pass', 'boost']) {
+    const png = await renderDrawPassPng({
+      variant,
+      theme,
+      multiplier,
+      qrContent: `https://redeem.sg/r/${'x'.repeat(43)}`,
+      deadlineLong: '30 September 2026',
+      ...s,
+    });
+    const file = path.join(outDir, `${theme}-${variant}.png`);
+    await writeFile(file, png);
+    console.log(`${file}  ${(png.length / 1024).toFixed(0)}kB`);
+  }
+}

--- a/backend/src/services/email-templates/confirmation-email-draw.html
+++ b/backend/src/services/email-templates/confirmation-email-draw.html
@@ -6,12 +6,16 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="x-apple-disable-message-reformatting">
 <meta name="format-detection" content="telephone=no, date=no, address=no, email=no">
-<meta name="color-scheme" content="light only">
-<meta name="supported-color-schemes" content="light only">
-<title>Your request is confirmed</title>
-<!-- Display serif: progressive enhancement. Apple Mail / iOS Mail render Fraunces; other clients fall back to Georgia. -->
+<!-- This design IS dark. Declaring dark support stops Apple Mail / Outlook
+     force-inverting it into a washed-out light approximation. -->
+<meta name="color-scheme" content="dark">
+<meta name="supported-color-schemes" content="dark">
+<title>You&rsquo;re in the draw</title>
+<!-- Display serif + mono: progressive enhancement. Apple Mail / iOS Mail render
+     Spectral and JetBrains Mono; every other client falls back to Georgia and
+     the system monospace stack, which the layout is measured for. -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
-<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,300;0,400;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <!--[if mso]>
 <noscript><xml><o:OfficeDocumentSettings><o:PixelsPerInch>96</o:PixelsPerInch></o:OfficeDocumentSettings></xml></noscript>
 <![endif]-->
@@ -22,77 +26,60 @@
   table, td { mso-table-lspace: 0pt !important; mso-table-rspace: 0pt !important; border-collapse: collapse !important; }
   img { -ms-interpolation-mode: bicubic; border: 0; height: auto; line-height: 100%; outline: none; text-decoration: none; display: block; }
   a { text-decoration: none; }
-  body { background-color: #FBF7F0; }
-  .body-link a { color: #A85822; text-decoration: underline; }
+  body { background-color: {{c_page}}; }
 
-  /* ---------- Force light, sensible behaviour under dark mode ---------- */
-  :root { color-scheme: light only; supported-color-schemes: light only; }
-  u + .body { background-color: #FBF7F0; }
-
-  /* ---------- Button hover (supporting clients) ---------- */
-  .btn-a:hover { background-color: #8F4A1C !important; }
-  .soc-a:hover { background-color: #FBF3E6 !important; border-color: #D8C29A !important; }
-  .copy-btn:hover { background-color: #2A1607 !important; }
-  .ghost:hover { color: #8F4A1C !important; }
+  /* ---------- Hover (supporting clients only) ---------- */
+  .soc-a:hover { border-color: {{c_pillBorder}} !important; color: #ffffff !important; }
+  .unsub-a:hover { color: #ffffff !important; }
 
   /* ---------- Responsive ---------- */
   @media only screen and (max-width: 600px) {
     .container { width: 100% !important; }
     .px { padding-left: 24px !important; padding-right: 24px !important; }
-    .pt { padding-top: 32px !important; }
-    .pb { padding-bottom: 32px !important; }
-    .h1 { font-size: 30px !important; line-height: 36px !important; }
-    .card-px { padding-left: 22px !important; padding-right: 22px !important; }
-    .card-py { padding-top: 26px !important; padding-bottom: 26px !important; }
-    .btn-a { display: block !important; width: 100% !important; box-sizing: border-box !important; }
+    .h1 { font-size: 34px !important; line-height: 38px !important; }
+    .bignum { font-size: 62px !important; }
+    .card-px { padding-left: 20px !important; padding-right: 20px !important; }
     .soc-a { padding-left: 2px !important; padding-right: 2px !important; }
-    .full { width: 100% !important; }
   }
 
   /* ---------- Motion: progressive enhancement only ----------
-     Every animated element's RESTING state (its inline style) is the
-     final, fully-visible state. Keyframes only run in clients that both
-     support CSS animation and honour prefers-reduced-motion, so any
-     client that strips this block simply shows the finished layout. */
+     Every animated element's RESTING state (its inline style) is the final,
+     fully-visible state, so a client that strips this block shows the finished
+     layout. */
   @media (prefers-reduced-motion: no-preference) {
-    @keyframes riseIn { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: translateY(0); } }
-    @keyframes sealIn { from { opacity: 0; transform: scale(0.86); } to { opacity: 1; transform: scale(1); } }
-    .anim-seal { animation: sealIn 0.6s cubic-bezier(0.2, 0.7, 0.2, 1) both; }
+    @keyframes riseIn { from { opacity: 0; transform: translateY(14px); } to { opacity: 1; transform: translateY(0); } }
     .anim-1 { animation: riseIn 0.7s cubic-bezier(0.2, 0.7, 0.2, 1) 0.05s both; }
-    .anim-2 { animation: riseIn 0.7s cubic-bezier(0.2, 0.7, 0.2, 1) 0.16s both; }
-    .anim-3 { animation: riseIn 0.7s cubic-bezier(0.2, 0.7, 0.2, 1) 0.28s both; }
+    .anim-2 { animation: riseIn 0.7s cubic-bezier(0.2, 0.7, 0.2, 1) 0.18s both; }
+    .anim-3 { animation: riseIn 0.7s cubic-bezier(0.2, 0.7, 0.2, 1) 0.30s both; }
   }
 </style>
 </head>
-<body class="body" style="margin:0; padding:0; width:100%; background-color:#FBF7F0; -webkit-font-smoothing:antialiased;">
+<body class="body" style="margin:0; padding:0; width:100%; background-color:{{c_page}}; -webkit-font-smoothing:antialiased;">
 
   <!-- Preheader: shown in inbox preview, hidden in the body -->
-  <div style="display:none; max-height:0; overflow:hidden; mso-hide:all; font-size:1px; line-height:1px; color:#FBF7F0; opacity:0;">
-    You&rsquo;re in the draw. Complete your session to multiply your chances &times;{{multiplier}}.
+  <div style="display:none; max-height:0; overflow:hidden; mso-hide:all; font-size:1px; line-height:1px; color:{{c_page}}; opacity:0;">
+    You&rsquo;re in the draw. Complete your session and your entry becomes &times;{{multiplier}}.
     &#847; &zwnj; &nbsp; &#847; &zwnj; &nbsp; &#847; &zwnj; &nbsp; &#847; &zwnj; &nbsp; &#847; &zwnj; &nbsp; &#847; &zwnj; &nbsp;
   </div>
 
-  <!-- Full-bleed background -->
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#FBF7F0;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:{{c_page}};">
     <tr>
       <td align="center" style="padding:32px 12px;">
 
         <!--[if mso]><table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0"><tr><td><![endif]-->
-        <table role="presentation" class="container" width="600" cellpadding="0" cellspacing="0" border="0" style="width:600px; max-width:600px; margin:0 auto;">
+        <table role="presentation" class="container" width="600" cellpadding="0" cellspacing="0" border="0" bgcolor="{{c_panelSolid}}" style="width:600px; max-width:600px; margin:0 auto; background-color:{{c_panelSolid}}; background-image:linear-gradient(180deg,{{c_panelTop}} 0%,{{c_panelSolid}} 42%,{{c_panelBottom}} 100%); border:1px solid {{c_border}}; border-radius:22px;">
 
-          <!-- ============ HEADER / LETTERHEAD ============ -->
+          <!-- ============ LETTERHEAD ============ -->
           <tr>
-            <td align="center" bgcolor="#3D1F0B" style="background-color:#3D1F0B; border-radius:18px 18px 0 0; padding:42px 40px 34px 40px;">
+            <td class="px" style="padding:30px 40px 0 40px;">
               <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
                 <tr>
-                  <td align="center" style="color:#FFFCF7;">
-                    {{heroLogo}}
-                  </td>
-                </tr>
-                <tr>
-                  <td align="center" style="padding-top:18px;">
+                  <td align="left" valign="middle">{{drawHeroLogo}}</td>
+                  <td align="right" valign="middle">
                     <table role="presentation" cellpadding="0" cellspacing="0" border="0"><tr>
-                      <td style="font-size:0; line-height:0; height:2px; width:54px; background-color:#D17029; border-radius:2px;">&nbsp;</td>
+                      <td style="border:1px solid {{c_pillBorder}}; border-radius:999px; padding:6px 12px; font-family:'JetBrains Mono','SFMono-Regular',Consolas,Menlo,monospace; font-size:10px; letter-spacing:0.16em; color:{{c_pillText}}; white-space:nowrap;">
+                        ENTRY CONFIRMED &#10003;
+                      </td>
                     </tr></table>
                   </td>
                 </tr>
@@ -100,139 +87,125 @@
             </td>
           </tr>
 
+          <!-- Hairline -->
+          <tr>
+            <td class="px" style="padding:26px 40px 0 40px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"><tr>
+                <td style="font-size:0; line-height:0; height:1px; background-color:{{c_hair}};">&nbsp;</td>
+              </tr></table>
+            </td>
+          </tr>
+
           <!-- ============ HERO ============ -->
           <tr>
-            <td bgcolor="#FFFFFF" class="px pt" style="background-color:#FFFFFF; padding:44px 56px 8px 56px;">
-              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+            <td class="px anim-1" style="padding:34px 40px 0 40px;">
+              <div style="font-family:'JetBrains Mono','SFMono-Regular',Consolas,Menlo,monospace; font-size:11px; letter-spacing:0.2em; color:{{c_eyebrow}}; padding-bottom:16px;">YOU&rsquo;RE IN THE DRAW</div>
+              <div class="h1" style="font-family:'Spectral',Georgia,'Times New Roman',serif; font-size:44px; line-height:46px; color:{{c_h1}}; letter-spacing:-0.015em;">You&rsquo;re in the draw.</div>
+              <div style="font-family:'Spectral',Georgia,'Times New Roman',serif; font-size:17px; line-height:27px; color:{{c_body}}; padding-top:16px;">
+                Hello {{firstName}}, your entry is in for <span style="color:{{c_bodyStrong}}; font-weight:600;">{{campaignName}}</span> &mdash; {{prize}}.
+              </div>
+            </td>
+          </tr>
 
-                <!-- Confirmation seal (pure CSS, no image required) -->
+          <!-- ============ THE METER: 1x now, Nx after the review ============ -->
+          <tr>
+            <td class="px" style="padding:30px 40px 0 40px;">
+              <table role="presentation" class="anim-2" width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="{{c_boxBg}}" style="background-color:{{c_boxBg}}; border:1px solid {{c_boxBorder}}; border-radius:16px;">
                 <tr>
-                  <td align="center" style="padding-bottom:26px;">
-                    <table role="presentation" class="anim-seal" cellpadding="0" cellspacing="0" border="0">
+                  <td class="card-px" style="padding:24px 28px 22px 28px;">
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
                       <tr>
-                        <td align="center" valign="middle" width="74" height="74" bgcolor="#FBF3E6" style="width:74px; height:74px; background-color:#FBF3E6; border-radius:50%; text-align:center; vertical-align:middle; font-family:Georgia,'Times New Roman',serif; font-size:34px; line-height:74px; color:#A85822;">
-                          &#10003;
-                        </td>
+                        <td align="left" style="font-family:'JetBrains Mono','SFMono-Regular',Consolas,Menlo,monospace; font-size:10px; letter-spacing:0.18em; color:{{c_meterLabel}}; padding-bottom:6px;">RIGHT NOW</td>
+                        <td align="right" style="font-family:'JetBrains Mono','SFMono-Regular',Consolas,Menlo,monospace; font-size:10px; letter-spacing:0.18em; color:{{c_meterLabel}}; padding-bottom:6px;">AFTER YOUR REVIEW</td>
                       </tr>
                     </table>
-                  </td>
-                </tr>
-
-                <!-- Kicker -->
-                <tr>
-                  <td align="center" class="anim-1" style="padding-bottom:12px;">
-                    <span style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:12px; font-weight:600; letter-spacing:0.22em; text-transform:uppercase; color:#A85822;">Entry confirmed</span>
-                  </td>
-                </tr>
-
-                <!-- Focal headline -->
-                <tr>
-                  <td align="center" class="anim-1 h1" style="font-family:'Fraunces',Georgia,'Times New Roman',serif; font-size:38px; line-height:44px; font-weight:600; color:#3D1F0B; padding-bottom:18px;">
-                    You&rsquo;re in the draw.
-                  </td>
-                </tr>
-
-                <!-- Greeting, campaign name (own row), body -->
-                <tr>
-                  <td align="center" class="anim-2" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:16px; line-height:26px; color:#5A301A; padding-bottom:8px;">
-                    Hello {{firstName}}, your entry is in for
-                  </td>
-                </tr>
-                <tr>
-                  <td align="center" class="anim-2" style="font-family:'Fraunces',Georgia,'Times New Roman',serif; font-size:21px; line-height:28px; font-weight:600; color:#3D1F0B; padding:0 4px 4px 4px;">
-                    {{campaignName}}.
-                  </td>
-                </tr>
-                <tr>
-                  <td align="center" class="anim-2" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:16px; line-height:26px; color:#5A301A; padding:14px 8px 0 8px;">
-                    You&rsquo;re in the running for <strong>{{prize}}</strong>. Want {{multiplier}}&times; the chances? Complete your complimentary financial review session &mdash; when your consultant records it, your entry is multiplied. If you win, we contact you directly after the draw &mdash; and we never ask for payment to release a prize.
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                      <tr>
+                        <td align="left" valign="middle" style="font-family:'Spectral',Georgia,'Times New Roman',serif; font-size:46px; line-height:50px; color:{{c_n1}}; white-space:nowrap;">1&times;</td>
+                        <!-- width 100% makes this the cell that absorbs the row; the
+                             two numerals stay at their intrinsic width and the rule
+                             stretches between them. -->
+                        <td valign="middle" width="100%" style="padding:0 18px;">
+                          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"><tr>
+                            <td style="font-size:0; line-height:0; height:1px; background-color:{{c_arrowTo}};">&nbsp;</td>
+                          </tr></table>
+                        </td>
+                        <!-- The hero numeral is SOLID, not a clipped gradient: a client that
+                             keeps -webkit-text-fill-color while stripping background-image
+                             would render the whole promise invisible. The metal gradient
+                             lives on the WhatsApp card, where we own the renderer. -->
+                        <td align="right" valign="middle" class="bignum" style="font-family:'Spectral',Georgia,'Times New Roman',serif; font-size:88px; line-height:88px; font-weight:600; letter-spacing:-0.03em; color:{{c_metalSolid}}; white-space:nowrap;">{{multiplier}}&times;</td>
+                      </tr>
+                    </table>
+                    <div style="font-family:'Spectral',Georgia,'Times New Roman',serif; font-style:italic; font-size:18px; line-height:25px; color:{{c_meterSub}}; padding-top:8px;">
+                      chances to win <span style="font-style:normal; font-weight:600; color:{{c_meterSubStrong}};">{{prize}}</span>
+                    </div>
                   </td>
                 </tr>
               </table>
             </td>
           </tr>
 
-          <!-- Divider -->
+          <!-- ============ WHAT TO DO ============ -->
           <tr>
-            <td bgcolor="#FFFFFF" class="px" style="background-color:#FFFFFF; padding:34px 56px 0 56px;">
-              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"><tr>
-                <td style="font-size:0; line-height:0; height:1px; background-color:#EFE3CC;">&nbsp;</td>
-              </tr></table>
+            <td class="px" style="padding:26px 40px 0 40px; font-family:'Spectral',Georgia,'Times New Roman',serif; font-size:16px; line-height:28px; color:{{c_para}};">
+              Want {{multiplier}}&times; the chances? Complete your complimentary financial review session &mdash; when your consultant records it, your entry is multiplied. If you win, we contact you directly after the draw, and we never ask for payment to release a prize.
             </td>
           </tr>
 
-          <!-- ============ REFERRAL REWARD CARD ============ -->
+          <!-- ============ STANDING ============ -->
           <tr>
-            <td bgcolor="#FFFFFF" class="px" style="background-color:#FFFFFF; padding:34px 56px 8px 56px;">
-              <table role="presentation" class="anim-3" width="100%" cellpadding="0" cellspacing="0" border="0" style="border:1px solid #EAD9B6; border-radius:16px; background-color:#FFFAF0;">
+            <td class="px" style="padding:28px 40px 0 40px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-top:1px solid {{c_hair}};">
                 <tr>
-                  <td class="card-px card-py" style="padding:30px 32px 32px 32px;">
-                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
-                      <tr>
-                        <td align="center" style="padding-bottom:10px;">
-                          <span style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:12px; font-weight:600; letter-spacing:0.2em; text-transform:uppercase; color:#A85822;">Share &amp; get credited</span>
-                        </td>
-                      </tr>
-                      <tr>
-                        <td align="center" style="font-family:'Fraunces',Georgia,'Times New Roman',serif; font-size:24px; line-height:30px; font-weight:600; color:#3D1F0B; padding-bottom:12px;">
-                          Refer a friend, share the joy.
-                        </td>
-                      </tr>
-                      <tr>
-                        <td align="center" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:15px; line-height:24px; color:#5A301A; padding-bottom:22px;">
-                          Share your personal link with friends. When someone signs up through it, you are credited as their referrer.
-                        </td>
-                      </tr>
+                  <td width="{{statWidth}}" valign="top" style="padding:20px 12px 0 0;">
+                    <div style="font-family:'JetBrains Mono','SFMono-Regular',Consolas,Menlo,monospace; font-size:10px; letter-spacing:0.16em; color:{{c_statKey}}; padding-bottom:7px;">ENTRANT</div>
+                    <div style="font-family:'Spectral',Georgia,'Times New Roman',serif; font-size:17px; line-height:22px; color:{{c_statVal}};">{{firstName}}</div>
+                  </td>
+                  <td width="{{statWidth}}" valign="top" style="padding:20px 12px 0 0;">
+                    <div style="font-family:'JetBrains Mono','SFMono-Regular',Consolas,Menlo,monospace; font-size:10px; letter-spacing:0.16em; color:{{c_statKey}}; padding-bottom:7px;">STATUS</div>
+                    <div style="font-family:'Spectral',Georgia,'Times New Roman',serif; font-size:17px; line-height:22px; color:{{c_statVal}};">In the draw</div>
+                  </td>
+                  {{stat3Cell}}
+                </tr>
+              </table>
+            </td>
+          </tr>
 
-                      <!-- Visible, selectable referral link as plain text (NOT a link, so tapping it
-                           does not navigate away). Email clients strip JS, so a true clipboard copy
-                           cannot run in the message: long-press on mobile or select on desktop to copy.
-                           The share buttons below are the one-tap actions. Works with images off. -->
-                      <tr>
-                        <td style="padding-bottom:18px;">
-                          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#FBF3E6; border:1px solid #E8D7B8; border-radius:10px;">
-                            <tr>
-                              <td valign="middle" align="center" style="padding:13px 18px;">
-                                <span class="copy-url" style="font-family:'SFMono-Regular',Consolas,'Liberation Mono',Menlo,Courier,monospace; font-size:14px; line-height:20px; color:#3D1F0B; word-break:break-all;">{{shareUrl}}</span>
-                              </td>
-                            </tr>
-                          </table>
-                        </td>
-                      </tr>
+          <!-- ============ REFERRAL ============ -->
+          <tr>
+            <td class="px" style="padding:30px 40px 0 40px;">
+              <table role="presentation" class="anim-3" width="100%" cellpadding="0" cellspacing="0" border="0" style="border:1px solid {{c_boxBorder}}; border-radius:16px;">
+                <tr>
+                  <td class="card-px" style="padding:26px 28px 26px 28px;">
+                    <div style="font-family:'JetBrains Mono','SFMono-Regular',Consolas,Menlo,monospace; font-size:10px; letter-spacing:0.2em; color:{{c_eyebrow}}; padding-bottom:12px;">SHARE &amp; GET CREDITED</div>
+                    <div style="font-family:'Spectral',Georgia,'Times New Roman',serif; font-size:26px; line-height:32px; color:{{c_h1}}; letter-spacing:-0.01em;">Refer a friend, share the joy.</div>
+                    <div style="font-family:'Spectral',Georgia,'Times New Roman',serif; font-size:15.5px; line-height:26px; color:{{c_para}}; padding-top:10px;">Share your personal link with friends. When someone signs up through it, you are credited as their referrer.</div>
 
-                      <!-- Social share buttons: real platform logos (hosted PNG) + label. With images off, the bordered pill and label remain. -->
+                    <!-- Visible, selectable referral link as plain text (NOT a link, so tapping it
+                         does not navigate away). Email clients strip JS, so a true clipboard copy
+                         cannot run in the message: long-press on mobile or select on desktop to
+                         copy. The share buttons below are the one-tap actions. -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-top:18px; border:1px dashed {{c_dashBorder}}; border-radius:10px;">
                       <tr>
-                        <td>
-                          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
-                            <tr>
-                              <td width="33.33%" valign="top" style="padding:0 5px 0 0;">
-                                <a href="https://wa.me/?text=I%20just%20signed%20up%20with%20{{brandName}}.%20Take%20a%20look%3A%20{{shareUrl}}" class="soc-a" style="display:block; text-align:center; background-color:#FFFAF0; border:1px solid #E8D7B8; border-radius:12px; padding:15px 4px 13px 4px; text-decoration:none;">
-                                  <img src="https://redeem.sg/email/social/whatsapp.png" width="30" height="30" alt="" style="display:block; margin:0 auto 7px auto; border:0; outline:none;">
-                                  <span style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:12px; font-weight:600; letter-spacing:0.01em; color:#5A301A;">WhatsApp</span>
-                                </a>
-                              </td>
-                              <td width="33.33%" valign="top" style="padding:0 5px;">
-                                <a href="https://www.facebook.com/sharer/sharer.php?u={{shareUrl}}" class="soc-a" style="display:block; text-align:center; background-color:#FFFAF0; border:1px solid #E8D7B8; border-radius:12px; padding:15px 4px 13px 4px; text-decoration:none;">
-                                  <img src="https://redeem.sg/email/social/facebook.png" width="30" height="30" alt="" style="display:block; margin:0 auto 7px auto; border:0; outline:none;">
-                                  <span style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:12px; font-weight:600; letter-spacing:0.01em; color:#5A301A;">Facebook</span>
-                                </a>
-                              </td>
-                              <td width="33.33%" valign="top" style="padding:0 0 0 5px;">
-                                <a href="https://twitter.com/intent/tweet?text=I%20just%20signed%20up%20with%20{{brandName}}.%20Take%20a%20look%3A&amp;url={{shareUrl}}" class="soc-a" style="display:block; text-align:center; background-color:#FFFAF0; border:1px solid #E8D7B8; border-radius:12px; padding:15px 4px 13px 4px; text-decoration:none;">
-                                  <img src="https://redeem.sg/email/social/x.png" width="30" height="30" alt="" style="display:block; margin:0 auto 7px auto; border:0; outline:none;">
-                                  <span style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:12px; font-weight:600; letter-spacing:0.01em; color:#5A301A;">X</span>
-                                </a>
-                              </td>
-                            </tr>
-                          </table>
-                        </td>
+                        <td align="center" style="padding:14px 16px; font-family:'JetBrains Mono','SFMono-Regular',Consolas,Menlo,monospace; font-size:13px; line-height:20px; color:{{c_linkText}}; word-break:break-all;">{{shareUrl}}</td>
                       </tr>
+                    </table>
+
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-top:12px;">
                       <tr>
-                        <td align="center" style="padding-top:16px; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:13px; line-height:18px; color:#9A7E5E;">
-                          Tap a button to share, or copy the link above.
+                        <td width="33.33%" valign="top" style="padding:0 5px 0 0;">
+                          <a href="https://wa.me/?text=I%20just%20signed%20up%20with%20{{brandName}}.%20Take%20a%20look%3A%20{{shareUrl}}" class="soc-a" style="display:block; text-align:center; border:1px solid {{c_btnBorder}}; border-radius:10px; padding:13px 0 12px 0; font-family:'JetBrains Mono','SFMono-Regular',Consolas,Menlo,monospace; font-size:11px; letter-spacing:0.12em; color:{{c_btnText}}; text-decoration:none;">WHATSAPP</a>
+                        </td>
+                        <td width="33.33%" valign="top" style="padding:0 5px;">
+                          <a href="https://www.facebook.com/sharer/sharer.php?u={{shareUrl}}" class="soc-a" style="display:block; text-align:center; border:1px solid {{c_btnBorder}}; border-radius:10px; padding:13px 0 12px 0; font-family:'JetBrains Mono','SFMono-Regular',Consolas,Menlo,monospace; font-size:11px; letter-spacing:0.12em; color:{{c_btnText}}; text-decoration:none;">FACEBOOK</a>
+                        </td>
+                        <td width="33.33%" valign="top" style="padding:0 0 0 5px;">
+                          <a href="https://twitter.com/intent/tweet?text=I%20just%20signed%20up%20with%20{{brandName}}.%20Take%20a%20look%3A&amp;url={{shareUrl}}" class="soc-a" style="display:block; text-align:center; border:1px solid {{c_btnBorder}}; border-radius:10px; padding:13px 0 12px 0; font-family:'JetBrains Mono','SFMono-Regular',Consolas,Menlo,monospace; font-size:11px; letter-spacing:0.12em; color:{{c_btnText}}; text-decoration:none;">X</a>
                         </td>
                       </tr>
                     </table>
+                    <div style="padding-top:12px; text-align:center; font-family:'JetBrains Mono','SFMono-Regular',Consolas,Menlo,monospace; font-size:10px; letter-spacing:0.1em; color:{{c_hint}};">TAP A BUTTON TO SHARE, OR COPY THE LINK ABOVE</div>
                   </td>
                 </tr>
               </table>
@@ -241,57 +214,27 @@
 
           <!-- ============ REASSURANCE + SIGN-OFF ============ -->
           <tr>
-            <td bgcolor="#FFFFFF" class="px pb" style="background-color:#FFFFFF; padding:30px 56px 44px 56px; border-radius:0 0 0 0;">
-              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
-                <tr>
-                  <td align="center" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:13px; line-height:20px; color:#9A7E5E; padding-bottom:26px;">
-                    Did not request this? No action is needed. You can safely ignore this email.
-                  </td>
-                </tr>
-                <tr>
-                  <td align="center" style="font-family:'Fraunces',Georgia,'Times New Roman',serif; font-size:16px; line-height:22px; color:#5A301A; font-style:italic;">
-                    Warm regards,
-                  </td>
-                </tr>
-                <tr>
-                  <td align="center" style="font-family:'Fraunces',Georgia,'Times New Roman',serif; font-size:17px; line-height:24px; color:#3D1F0B; padding-top:4px;">
-                    The {{brandName}} team
-                  </td>
-                </tr>
-              </table>
+            <td class="px" align="center" style="padding:30px 40px 0 40px; font-family:'Spectral',Georgia,'Times New Roman',serif; font-size:14px; line-height:21px; color:{{c_quiet}};">
+              Did not request this? No action is needed &mdash; you can safely ignore this email.
+            </td>
+          </tr>
+          <tr>
+            <td class="px" align="center" style="padding:24px 40px 34px 40px;">
+              <div style="font-family:'Spectral',Georgia,'Times New Roman',serif; font-style:italic; font-size:16px; line-height:22px; color:{{c_signItalic}};">Warm regards,</div>
+              <div style="font-family:'Spectral',Georgia,'Times New Roman',serif; font-size:19px; line-height:26px; color:{{c_signName}}; padding-top:2px;">The {{brandName}} team</div>
             </td>
           </tr>
 
           <!-- ============ FOOTER ============ -->
           <tr>
-            <td bgcolor="#F4EAD8" class="px" style="background-color:#F4EAD8; border-radius:0 0 18px 18px; padding:28px 48px 32px 48px;">
-              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
-                <tr>
-                  <td align="center" style="font-family:'Fraunces',Georgia,'Times New Roman',serif; font-size:16px; line-height:20px; font-weight:600; color:#7A5230; letter-spacing:0.02em; padding-bottom:12px;">
-                    {{brandWordmark}}
-                  </td>
-                </tr>
-                <tr>
-                  <td align="center" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:12px; line-height:18px; color:#8A6B49; padding-bottom:6px;">
-                    You are receiving this because you submitted a request to {{brandName}}.
-                  </td>
-                </tr>
-                <tr>
-                  <td align="center" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:12px; line-height:18px; color:#8A6B49; padding-bottom:6px;">
-                    {{unsubscribeLine}}
-                  </td>
-                </tr>
-                <tr>
-                  <td align="center" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:12px; line-height:18px; color:#8A6B49;">
-                    {{footerEntity}}
-                  </td>
-                </tr>
-                <tr>
-                  <td align="center" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; font-size:12px; line-height:18px; color:#A98A66; padding-top:6px;">
-                    &copy; {{year}} {{brandName}}. All rights reserved.
-                  </td>
-                </tr>
-              </table>
+            <td class="px" align="center" bgcolor="{{c_footBg}}" style="background-color:{{c_footBg}}; border-top:1px solid {{c_footBorder}}; border-radius:0 0 22px 22px; padding:26px 40px 30px 40px;">
+              <div style="font-family:'Spectral',Georgia,'Times New Roman',serif; font-size:17px; line-height:22px; color:{{c_footWord}}; padding-bottom:12px;">{{brandWordmark}}</div>
+              <div style="font-family:'JetBrains Mono','SFMono-Regular',Consolas,Menlo,monospace; font-size:10.5px; line-height:21px; letter-spacing:0.06em; text-transform:uppercase; color:{{c_footText}};">
+                YOU ARE RECEIVING THIS BECAUSE YOU SUBMITTED A REQUEST TO {{brandName}}.<br>
+                {{unsubscribeLine}}<br>
+                {{footerEntity}}<br>
+                &copy; {{year}} {{brandName}}. ALL RIGHTS RESERVED.
+              </div>
             </td>
           </tr>
 

--- a/backend/src/services/email-templates/confirmation-email-draw.txt
+++ b/backend/src/services/email-templates/confirmation-email-draw.txt
@@ -4,7 +4,13 @@ Hello {{firstName}},
 
 Your entry for {{campaignName}} is in — you're in the running for {{prize}}.
 
+RIGHT NOW: 1x    AFTER YOUR REVIEW: {{multiplier}}x
+{{multiplier}}x chances to win {{prize}}.
+
 Want {{multiplier}}x the chances? Complete your complimentary financial review session — when your consultant records it, your entry is multiplied.
+
+Entrant: {{firstName}}
+Status: In the draw{{stat3Text}}
 
 If you win, we contact you directly after the draw — and we never ask for payment to release a prize.
 

--- a/backend/src/services/email-templates/leadConfirmation.js
+++ b/backend/src/services/email-templates/leadConfirmation.js
@@ -1,0 +1,139 @@
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { emailPalette } from '../../utils/drawTheme.js';
+import { shortDate } from '../../utils/sgtTime.js';
+
+/**
+ * Lead-capture confirmation email: the designer's production, table-based HTML.
+ * Read once at boot from the co-located copies so they ship with the backend
+ * regardless of the deploy root. Do NOT reformat or sanitize them; the inline
+ * styles and MSO conditional comments are deliberate email-client requirements.
+ *
+ * Two pairs:
+ *  - confirmation-email.*      trial rewards — cream "Editorial" frame
+ *  - confirmation-email-draw.* lucky draws — dark "Onyx" frame, the inbox twin
+ *    of the Vault WhatsApp pass, recoloured per campaign from the SAME
+ *    `luckyDraw.passTheme` enum (utils/drawTheme.js). The palette arrives as
+ *    `c_*` merge fields rather than four near-identical template files.
+ *
+ * This module is deliberately IO-free apart from those boot reads — no models,
+ * no DB — so the render is unit-testable and previewable
+ * (scripts/preview-draw-email.js) without standing anything up.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CONFIRMATION_EMAIL_HTML = readFileSync(join(__dirname, 'confirmation-email.html'), 'utf8');
+const CONFIRMATION_EMAIL_TXT = readFileSync(join(__dirname, 'confirmation-email.txt'), 'utf8');
+const CONFIRMATION_EMAIL_DRAW_HTML = readFileSync(join(__dirname, 'confirmation-email-draw.html'), 'utf8');
+const CONFIRMATION_EMAIL_DRAW_TXT = readFileSync(join(__dirname, 'confirmation-email-draw.txt'), 'utf8');
+
+const MONO_STACK = "'JetBrains Mono','SFMono-Regular',Consolas,Menlo,monospace";
+const SERIF_STACK = "'Spectral',Georgia,'Times New Roman',serif";
+
+export function escapeHtml(value) {
+  if (value == null) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * The draw-only merge fields for the Onyx email: the palette, the letterhead
+ * wordmark, and the third "standing" stat.
+ *
+ * The third stat follows the honest-date rule from the pass artwork (#252, one
+ * date per surface). `drawOn` is the draw day and is stated as such; without one
+ * we fall back to when ENTRIES CLOSE, a different and equally true fact — the
+ * boost deadline is never dressed up as a draw date. With neither, the cell
+ * disappears and the two remaining stats split the row.
+ */
+function drawFields({ luckyDraw, campaignName, palette, isMktrHost }) {
+  const drawOn = shortDate(luckyDraw.drawOn);
+  const closesAt = shortDate(luckyDraw.closesAt);
+  const stat3 = drawOn
+    ? { key: 'DRAW DATE', val: drawOn }
+    : closesAt
+      ? { key: 'ENTRIES CLOSE', val: closesAt }
+      : null;
+
+  return {
+    ...palette,
+    prize: luckyDraw.prize || campaignName,
+    multiplier: luckyDraw.multiplier || 10,
+    // Small, left-aligned letterhead — the Onyx header is a rule of thirds, not
+    // the centred hero block the trial-reward email uses.
+    drawHeroLogo: isMktrHost
+      ? '<img src="https://mktr.sg/email/new-mktr-wordmark-light.png" width="106" height="37" alt="MKTR" style="display:block;border:0;outline:none;">'
+      : `<span style="font-family:${SERIF_STACK};font-size:27px;line-height:32px;color:${palette.c_word};letter-spacing:0.01em;">Redeem</span>`,
+    statWidth: stat3 ? '33%' : '50%',
+    stat3Cell: stat3
+      ? '<td width="33%" valign="top" style="padding:20px 0 0 0;">'
+        + `<div style="font-family:${MONO_STACK};font-size:10px;letter-spacing:0.16em;color:${palette.c_statKey};padding-bottom:7px;">${stat3.key}</div>`
+        + `<div style="font-family:${SERIF_STACK};font-size:17px;line-height:22px;color:${palette.c_statVal};">${stat3.val}</div>`
+        + '</td>'
+      : '',
+    stat3Text: stat3 ? `\n${stat3.key.charAt(0)}${stat3.key.slice(1).toLowerCase()}: ${stat3.val}` : '',
+  };
+}
+
+/**
+ * Merge-field substitution for the confirmation pair — the whole render, with
+ * no IO in it, so the sender and the preview produce byte-identical email.
+ * Unknown placeholders are left intact so a render check can flag them.
+ *
+ * firstName, campaignName, shareUrl and prize are user- or operator-derived and
+ * are HTML-escaped; the letterhead, palette and unsubscribe link are deliberate
+ * markup built here and pass through raw. The plain-text part is never escaped.
+ */
+export function renderLeadConfirmation({
+  firstName, campaignName, luckyDraw, isMktrHost,
+  shareUrl = '', unsubscribeUrl = '', unsubscribeTextLine = '',
+}) {
+  const isDraw = luckyDraw?.enabled === true;
+  const brandName = isMktrHost ? 'MKTR' : 'Redeem';
+  // Resolved BEFORE the merge fields because several of them (the wordmark, the
+  // unsubscribe link, the third stat cell) are markup carrying an
+  // already-resolved colour: substitution runs ONCE, so a placeholder nested
+  // inside a substituted value would survive into the inbox.
+  const palette = isDraw ? emailPalette(luckyDraw.passTheme) : {};
+
+  const fields = {
+    firstName,
+    campaignName,
+    shareUrl: shareUrl || '',
+    unsubscribeLine: unsubscribeUrl
+      ? `<a href="${escapeHtml(unsubscribeUrl)}" class="unsub-a" style="color:${isDraw ? palette.c_unsub : 'inherit'};text-decoration:underline;">Unsubscribe from marketing messages</a>`
+      : '',
+    unsubscribeTextLine,
+    brandName,
+    brandWordmark: isMktrHost ? 'MKTR' : 'Redeem.',
+    footerEntity: isMktrHost
+      ? 'MKTR PTE. LTD. (UEN 202507548M)'
+      : 'Redeem, a service of MKTR PTE. LTD. (UEN 202507548M)',
+    year: new Date().getFullYear(),
+    // heroLogo is the trial-reward email's centred letterhead; the draw email
+    // uses the smaller left-aligned drawHeroLogo instead.
+    heroLogo: isMktrHost
+      ? '<img src="https://mktr.sg/email/new-mktr-wordmark-light.png" width="150" height="53" alt="MKTR" style="display:block;margin:0 auto;border:0;outline:none;">'
+      : '<span style="font-family:\'Fraunces\',Georgia,\'Times New Roman\',serif;font-size:38px;line-height:42px;font-weight:600;letter-spacing:0.005em;color:#FFFCF7;">RedeemSG</span>',
+    ...(isDraw ? drawFields({ luckyDraw, campaignName, palette, isMktrHost }) : {}),
+  };
+
+  const escapeFields = new Set(['firstName', 'campaignName', 'shareUrl', 'prize']);
+  const htmlTemplate = isDraw ? CONFIRMATION_EMAIL_DRAW_HTML : CONFIRMATION_EMAIL_HTML;
+  const textTemplate = isDraw ? CONFIRMATION_EMAIL_DRAW_TXT : CONFIRMATION_EMAIL_TXT;
+  return {
+    html: htmlTemplate.replace(/\{\{(\w+)\}\}/g, (_, k) =>
+      k in fields ? (escapeFields.has(k) ? escapeHtml(fields[k]) : String(fields[k])) : `{{${k}}}`
+    ),
+    text: textTemplate.replace(/\{\{(\w+)\}\}/g, (_, k) =>
+      k in fields ? String(fields[k]) : `{{${k}}}`
+    ),
+  };
+}
+
+export default { renderLeadConfirmation, escapeHtml };

--- a/backend/src/services/mailer.js
+++ b/backend/src/services/mailer.js
@@ -1,25 +1,10 @@
 import nodemailer from 'nodemailer';
-import { readFileSync } from 'fs';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
 import { logger } from '../utils/logger.js';
 import { maskEmail } from '../utils/redactTokens.js';
 import { normalizeCustomerHostChoice, customerHostOrigin } from '../utils/customerHost.js';
 import { getOrCreateProspectShareLink } from './shortlinkService.js';
 import { ensureUnsubToken } from './consentService.js';
-
-// Lead-capture confirmation email: the designer's production, table-based HTML email
-// (design_handoff_lead_confirmation_email). Read once at boot from the co-located copy so it
-// ships with the backend regardless of the deploy root. Do NOT reformat or sanitize it; the
-// inline styles and MSO conditional comments are deliberate email-client requirements.
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const CONFIRMATION_EMAIL_HTML = readFileSync(join(__dirname, 'email-templates/confirmation-email.html'), 'utf8');
-const CONFIRMATION_EMAIL_TXT = readFileSync(join(__dirname, 'email-templates/confirmation-email.txt'), 'utf8');
-// Lucky-draw variant (docs/plans/lucky-draw-10x.md §4.5): draw campaigns must
-// not promise the generic "gift + call within 24 hours" — they confirm the
-// entry and pitch the ×N session multiplier instead.
-const CONFIRMATION_EMAIL_DRAW_HTML = readFileSync(join(__dirname, 'email-templates/confirmation-email-draw.html'), 'utf8');
-const CONFIRMATION_EMAIL_DRAW_TXT = readFileSync(join(__dirname, 'email-templates/confirmation-email-draw.txt'), 'utf8');
+import { renderLeadConfirmation } from './email-templates/leadConfirmation.js';
 
 // D12: per-origin from-address. Lead-capture confirmations sent from the
 // redeem.sg flow use noreply@redeem.sg; admin / agent emails keep the
@@ -253,15 +238,6 @@ function getModernTemplate(title, content, action, options = {}) {
   `;
 }
 
-function escapeHtml(value) {
-  if (value == null) return '';
-  return String(value)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
 
 export async function sendLeadConfirmationEmail(prospect, { shareUrl: shareUrlOverride } = {}) {
   if (!prospect?.email) {
@@ -296,15 +272,6 @@ export async function sendLeadConfirmationEmail(prospect, { shareUrl: shareUrlOv
   const hostChoice = normalizeCustomerHostChoice(prospect.campaign?.design_config?.customerHost);
   const isMktrHost = hostChoice === 'mktr';
   const brandName = isMktrHost ? 'MKTR' : 'Redeem';
-  const brandWordmark = isMktrHost ? 'MKTR' : 'Redeem.';
-  const footerEntity = isMktrHost
-    ? 'MKTR PTE. LTD. (UEN 202507548M)'
-    : 'Redeem, a service of MKTR PTE. LTD. (UEN 202507548M)';
-  // heroLogo is the only brand-conditional merge field that is HTML (Redeem = Fraunces text
-  // wordmark, MKTR = the hosted wordmark image), so it is NOT escaped in the substitution.
-  const heroLogo = isMktrHost
-    ? '<img src="https://mktr.sg/email/new-mktr-wordmark-light.png" width="150" height="53" alt="MKTR" style="display:block;margin:0 auto;border:0;outline:none;">'
-    : '<span style="font-family:\'Fraunces\',Georgia,\'Times New Roman\',serif;font-size:38px;line-height:42px;font-weight:600;letter-spacing:0.005em;color:#FFFCF7;">RedeemSG</span>';
 
   // Referral link: prefer the canonical shareUrl minted at prospect creation (identical to
   // the in-app share dialog). Only self-derive as a fallback when the caller didn't pass it
@@ -325,11 +292,6 @@ export async function sendLeadConfirmationEmail(prospect, { shareUrl: shareUrlOv
       shareUrl = `${origin}/LeadCapture?campaign_id=${prospect.campaign.id}&ref=${prospect.id}`;
     }
   }
-  // Render the designer's production template (design_handoff_lead_confirmation_email) by
-  // substituting merge fields. firstName, campaignName and shareUrl are user or operator
-  // derived, so they are HTML-escaped exactly as before; heroLogo is intentional markup and
-  // the brand literals and year are controlled, so they pass through raw. The plain-text part
-  // is never escaped. Unknown placeholders are left intact so a render check can flag them.
   // Unsubscribe plumbing (PR B, plan §3.4): consumer-linked leads get a
   // working List-Unsubscribe header pair + footer link. The deterministic
   // token means every email rebuilds the same URL, and the URL carries ONLY
@@ -346,9 +308,6 @@ export async function sendLeadConfirmationEmail(prospect, { shareUrl: shareUrlOv
       logger.warn('Unsubscribe link mint failed (email sends without it)', { err: err?.message });
     }
   }
-  const unsubscribeLine = unsubscribeUrl
-    ? `<a href="${escapeHtml(unsubscribeUrl)}" style="color:inherit;text-decoration:underline;">Unsubscribe from marketing messages</a>`
-    : '';
   const unsubscribeTextLine = unsubscribeUrl
     ? `Unsubscribe from marketing messages: ${unsubscribeUrl}`
     : '';
@@ -359,30 +318,9 @@ export async function sendLeadConfirmationEmail(prospect, { shareUrl: shareUrlOv
       }
     : undefined;
 
-  const fields = {
-    firstName,
-    campaignName,
-    shareUrl: shareUrl || '',
-    unsubscribeLine,
-    unsubscribeTextLine,
-    brandName,
-    brandWordmark,
-    footerEntity,
-    year: new Date().getFullYear(),
-    heroLogo,
-    ...(isDraw
-      ? { prize: luckyDraw.prize || campaignName, multiplier: luckyDraw.multiplier || 10 }
-      : {}),
-  };
-  const escapeFields = new Set(['firstName', 'campaignName', 'shareUrl', 'prize']);
-  const htmlTemplate = isDraw ? CONFIRMATION_EMAIL_DRAW_HTML : CONFIRMATION_EMAIL_HTML;
-  const textTemplate = isDraw ? CONFIRMATION_EMAIL_DRAW_TXT : CONFIRMATION_EMAIL_TXT;
-  const html = htmlTemplate.replace(/\{\{(\w+)\}\}/g, (_, k) =>
-    k in fields ? (escapeFields.has(k) ? escapeHtml(fields[k]) : String(fields[k])) : `{{${k}}}`
-  );
-  const text = textTemplate.replace(/\{\{(\w+)\}\}/g, (_, k) =>
-    k in fields ? String(fields[k]) : `{{${k}}}`
-  );
+  const { html, text } = renderLeadConfirmation({
+    firstName, campaignName, luckyDraw, isMktrHost, shareUrl, unsubscribeUrl, unsubscribeTextLine,
+  });
 
   logger.info('Sending lead confirmation email', { to: prospect.email, prospectId: prospect.id, campaign: campaignName, brand: brandName });
 

--- a/backend/src/services/redeemOps/cardEngine.js
+++ b/backend/src/services/redeemOps/cardEngine.js
@@ -1,0 +1,63 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Shared satori/resvg engine for the consumer card compositors — the Editorial
+ * voucher card (qrCardRenderer.js) and the Vault lucky-draw pass
+ * (drawPassRenderer.js). Both draw from ONE lazily-loaded font cache: the seven
+ * TTFs are ~1.5MB and a per-renderer copy would double that for no reason.
+ *
+ * Text is rendered to paths with the bundled fonts, so nothing here depends on
+ * a system font being installed on the Render box. Callers treat any throw as
+ * "fall back to the bare QR (or no image at all)" — a broken native dep must
+ * degrade delivery QUALITY, never delivery itself.
+ */
+
+const FONT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../assets/fonts');
+
+let enginePromise = null;
+
+/** @returns {Promise<{satori: Function, Resvg: Function, fonts: Array}>} */
+export async function loadEngine() {
+  if (!enginePromise) {
+    enginePromise = (async () => {
+      const [{ default: satori }, { Resvg }] = await Promise.all([
+        import('satori'),
+        import('@resvg/resvg-js'),
+      ]);
+      const font = (file) => readFile(path.join(FONT_DIR, file));
+      const fonts = [
+        { name: 'Fraunces', data: await font('fraunces-600.ttf'), weight: 600, style: 'normal' },
+        { name: 'Fraunces', data: await font('fraunces-italic-400.ttf'), weight: 400, style: 'italic' },
+        { name: 'Fraunces', data: await font('fraunces-italic-600.ttf'), weight: 600, style: 'italic' },
+        { name: 'Albert Sans', data: await font('albertsans-400.ttf'), weight: 400, style: 'normal' },
+        { name: 'Albert Sans', data: await font('albertsans-600.ttf'), weight: 600, style: 'normal' },
+        { name: 'Albert Sans', data: await font('albertsans-800.ttf'), weight: 800, style: 'normal' },
+        { name: 'JetBrains Mono', data: await font('jetbrainsmono-600.ttf'), weight: 600, style: 'normal' },
+      ];
+      return { satori, Resvg, fonts };
+    })();
+    // A transient failure (e.g. fonts unreadable mid-deploy) must not poison the cache.
+    enginePromise.catch(() => { enginePromise = null; });
+  }
+  return enginePromise;
+}
+
+export const el = (style, children) => ({ type: 'div', props: { style: { display: 'flex', ...style }, children } });
+export const txt = (style, text) => ({ type: 'div', props: { style, children: text } });
+
+/** Meta/WhatsApp-safe single-line text: collapse whitespace, cap length. */
+export function clean(value, max, fallback = '') {
+  const s = String(value ?? '').replace(/\s+/g, ' ').trim().slice(0, max);
+  return s || fallback;
+}
+
+/** Renders a satori element tree to a PNG buffer at the given square size. */
+export async function renderSquarePng(tree, size, { satori, Resvg, fonts }) {
+  const svg = await satori(tree, { width: size, height: size, fonts });
+  const png = new Resvg(svg, { fitTo: { mode: 'original' } }).render().asPng();
+  return Buffer.from(png);
+}
+
+export default { loadEngine, el, txt, clean, renderSquarePng };

--- a/backend/src/services/redeemOps/drawLink.js
+++ b/backend/src/services/redeemOps/drawLink.js
@@ -1,7 +1,7 @@
 import { Activation, Campaign } from '../../models/index.js';
 import { getStoredLuckyDraw } from '../../utils/designConfigV2Clamp.js';
 import { normalizeLuckyDraw } from '../../utils/luckyDraw.js';
-import { sgtDayEndExclusiveMs } from '../../utils/sgtTime.js';
+import { sgtDayEndExclusiveMs, longDate } from '../../utils/sgtTime.js';
 
 /**
  * drawLink — the ONE way every fulfilment surface answers "is this
@@ -21,18 +21,8 @@ import { sgtDayEndExclusiveMs } from '../../utils/sgtTime.js';
  * and terms template use), so `now >= boostCutoffMs` ⇒ window closed.
  */
 
-const MONTHS = [
-  'January', 'February', 'March', 'April', 'May', 'June',
-  'July', 'August', 'September', 'October', 'November', 'December',
-];
-
-/** '2026-09-30' → '30 September 2026' (WA/email/card display). */
-export function boostDeadlineLong(ymd) {
-  const m = typeof ymd === 'string' ? ymd.match(/^(\d{4})-(\d{2})-(\d{2})$/) : null;
-  if (!m) return '';
-  const month = MONTHS[Number(m[2]) - 1];
-  return month ? `${Number(m[3])} ${month} ${m[1]}` : '';
-}
+/** '2026-09-30' → '30 September 2026' (WA/email/card display). @see utils/sgtTime.longDate */
+export const boostDeadlineLong = longDate;
 
 export function makeDrawLink(overrides = {}) {
   // Drop undefined override VALUES: a caller forwarding a dep it doesn't have
@@ -45,7 +35,7 @@ export function makeDrawLink(overrides = {}) {
   );
   const d = { Activation, Campaign, ...definedOverrides };
 
-  /** @returns {Promise<null | {campaignId, drawName, multiplier, boostClosesAt, boostCutoffMs}>} */
+  /** @returns {Promise<null | {campaignId, drawName, multiplier, prize, drawOn, passTheme, boostClosesAt, boostCutoffMs}>} */
   async function drawContextForActivation(activationOrId) {
     const activation = typeof activationOrId === 'object' && activationOrId !== null
       ? activationOrId
@@ -68,6 +58,14 @@ export function makeDrawLink(overrides = {}) {
       campaignId: campaign.id,
       drawName: campaign.name || 'the lucky draw',
       multiplier: Number.isInteger(ld.multiplier) ? ld.multiplier : 10,
+      // Card/email facts. `prize` is the normalizer's display summary; `drawOn`
+      // is the ONLY honest "draw date" — it is deliberately NOT defaulted to
+      // boostClosesAt (the boost deadline promises nothing about draw day), so
+      // a campaign without one simply renders no date. `passTheme` is already
+      // clamped to the enum by utils/luckyDraw.js.
+      prize: ld.prize || null,
+      drawOn: ld.drawOn || null,
+      passTheme: ld.passTheme || null,
       boostClosesAt: anchor,
       boostCutoffMs,
     };

--- a/backend/src/services/redeemOps/drawPassRenderer.js
+++ b/backend/src/services/redeemOps/drawPassRenderer.js
@@ -1,0 +1,308 @@
+import QRCode from 'qrcode';
+import { loadEngine, el, txt, clean, renderSquarePng } from './cardEngine.js';
+import { PASS_THEMES, DEFAULT_PASS_THEME, resolvePassTheme } from '../../utils/drawTheme.js';
+
+/**
+ * "Vault" lucky-draw pass compositor — the two images of the draw journey
+ * (claude.ai artifact 45c3006d, "Lucky Draw Pass — the two-message journey").
+ * Trial-reward credentials keep the cream/terracotta Editorial card
+ * (qrCardRenderer.js); a draw entry is a different promise and gets its own
+ * dark, metallic frame.
+ *
+ *   variant 'pass'  — WhatsApp/email #1, sent BEFORE the appointment. A
+ *                     before→after meter (1× right now → N× after you scan)
+ *                     over the QR the consultant scans at the session.
+ *   variant 'boost'  — WhatsApp/email #2, sent AFTER the consultant records the
+ *                     session. QR-LESS by design: the pass is consumed, so the
+ *                     frame is one giant N× and the entrant's standing. A
+ *                     scannable-looking receipt would only invite dead scans.
+ *
+ * The palette is the ONLY thing that changes per campaign — four colorways
+ * (titanium/gold/emerald/sapphire) over one layout, picked by
+ * `design_config.luckyDraw.passTheme` and clamped to the enum before it ever
+ * reaches here.
+ *
+ * 1080×1080 so the title and the QR/×N both sit inside the middle band that
+ * WhatsApp's chat-bubble crop preserves. Pipeline and failure posture are the
+ * shared engine's (cardEngine.js): senders treat a throw as "ship without the
+ * image", never as a failed delivery.
+ */
+
+const SIZE = 1080;
+/** The artwork was drawn at 460px with container units; 1cq = 1% of the card. */
+const cq = (n) => Math.round(n * (SIZE / 100));
+
+// The QR well is bigger than the artwork's 40cq: a 43-char token puts the pass
+// link at QR version 5 (37 modules), and the consultant scans this off a phone
+// screen. 408px over 39 units (37 + the SVG's own 1-module margin each side) is
+// ~10.5px/module with a ~5-module quiet zone — comfortably inside spec.
+const QR_WELL = 496;
+const QR_PAD = 44;
+const QR_IMG = QR_WELL - QR_PAD * 2;
+
+const MONTH_ABBR = {
+  january: 'JAN', february: 'FEB', march: 'MAR', april: 'APR', may: 'MAY', june: 'JUN',
+  july: 'JUL', august: 'AUG', september: 'SEP', october: 'OCT', november: 'NOV', december: 'DEC',
+};
+
+/** '30 September 2026' → '30 SEP 2026' — the footer line has one line to live in. */
+function compactDate(long) {
+  return String(long)
+    .split(/\s+/)
+    .map((word) => MONTH_ABBR[word.toLowerCase()] || word.toUpperCase())
+    .join(' ');
+}
+
+export { PASS_THEMES, DEFAULT_PASS_THEME };
+
+/**
+ * Colorway tokens, ported 1:1 from the artifact. `metal` is the gradient the
+ * hero numeral is clipped to — the thing that makes the number read as struck
+ * metal rather than coloured text.
+ */
+const THEMES = {
+  titanium: {
+    ground: 'radial-gradient(122% 94% at 50% 2%, #1b1e26 0%, #0b0d11 58%)',
+    groundFlat: '#0b0d11',
+    metal: 'linear-gradient(168deg, #ffffff 2%, #d6dbe1 28%, #8b9199 54%, #f4f6f9 92%)',
+    tx: '#eef0f4', sub: '#d9dce2', muted2: '#9aa0aa', dim: '#7c828c', n1: '#868c96',
+    hair: 'rgba(255,255,255,.26)', sealbd: 'rgba(255,255,255,.2)', arrow: 'rgba(255,255,255,.5)',
+  },
+  gold: {
+    ground: 'radial-gradient(122% 94% at 50% 2%, #241f13 0%, #0c0a05 60%)',
+    groundFlat: '#0c0a05',
+    metal: 'linear-gradient(168deg, #fff7e4 2%, #f2d590 26%, #b6853a 54%, #ffe7ad 92%)',
+    tx: '#f4edde', sub: '#e7dabc', muted2: '#c6b285', dim: '#93815d', n1: '#9c8b64',
+    hair: 'rgba(255,226,160,.26)', sealbd: 'rgba(255,226,160,.22)', arrow: 'rgba(255,232,180,.55)',
+  },
+  emerald: {
+    ground: 'radial-gradient(122% 94% at 50% 2%, #0f2419 0%, #050f0a 60%)',
+    groundFlat: '#050f0a',
+    metal: 'linear-gradient(168deg, #f4fff8 2%, #c2ecd2 26%, #5ea07d 54%, #eafff2 92%)',
+    tx: '#e7f2ea', sub: '#cfe8d9', muted2: '#9cc4ac', dim: '#6e9481', n1: '#6f9a82',
+    hair: 'rgba(180,255,214,.24)', sealbd: 'rgba(180,255,214,.2)', arrow: 'rgba(200,255,224,.5)',
+  },
+  sapphire: {
+    ground: 'radial-gradient(122% 94% at 50% 2%, #121c30 0%, #060a15 60%)',
+    groundFlat: '#060a15',
+    metal: 'linear-gradient(168deg, #f4f8ff 2%, #c6d6f2 26%, #6f89bb 54%, #eaf1ff 92%)',
+    tx: '#e8eef9', sub: '#ccd7ec', muted2: '#a2b0cc', dim: '#77839e', n1: '#7686a6',
+    hair: 'rgba(190,214,255,.26)', sealbd: 'rgba(190,214,255,.2)', arrow: 'rgba(210,226,255,.55)',
+  },
+};
+
+/**
+ * Approximate advance width (in em) of the hero numeral in Albert Sans 800.
+ * The artifact was drawn around "9×"; "10×" is half again as wide and "100×"
+ * twice, so a fixed font-size would overrun the card the moment a campaign
+ * runs a multiplier the mockup never showed. Digits ≈ .60em, '×' ≈ .86em.
+ */
+function heroEmWidth(text) {
+  return [...text].reduce((w, ch) => w + (ch === '×' ? 0.86 : 0.6), 0);
+}
+
+/** Largest size at or below `base` that keeps `text` inside `maxPx`. */
+function fitHero(text, maxPx, base) {
+  return Math.max(48, Math.min(base, Math.floor(maxPx / heroEmWidth(text))));
+}
+
+/** Arrow head as vector — satori renders border-trick triangles unreliably. */
+function arrowHeadSrc(color, w, h) {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">`
+    + `<path d="M0 0 L${w} ${h / 2} L0 ${h} Z" fill="${color}"/></svg>`;
+  return `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`;
+}
+
+/** Card chrome shared by both variants: wordmark left, state seal right, hairline under. */
+function chrome(t, mark, seal) {
+  return [
+    el({ justifyContent: 'space-between', alignItems: 'center' }, [
+      txt({ fontFamily: 'Fraunces', fontWeight: 600, fontSize: cq(5.8), lineHeight: 1.1, color: t.tx }, mark),
+      txt(
+        {
+          fontFamily: 'JetBrains Mono', fontWeight: 600, fontSize: cq(2.45), letterSpacing: 4.7,
+          color: t.muted2, border: `2px solid ${t.sealbd}`, borderRadius: 999,
+          padding: `${cq(1.4)}px ${cq(2.8)}px`,
+        },
+        seal,
+      ),
+    ]),
+    el({ height: 2, marginTop: cq(2.6), backgroundImage: `linear-gradient(90deg, transparent, ${t.hair}, transparent)` }, []),
+  ];
+}
+
+/**
+ * "chances to win <prize>" — the promise line. Serif italic lead-in with the
+ * prize itself set upright and semibold, wrapping as one paragraph.
+ */
+function promiseLine(t, prize, size) {
+  return el({ marginTop: cq(1.6), flexWrap: 'wrap', alignItems: 'baseline' }, [
+    txt({ fontFamily: 'Fraunces', fontStyle: 'italic', fontWeight: 400, fontSize: size, lineHeight: 1.16, color: t.sub, marginRight: Math.round(size * 0.26) }, 'chances to win'),
+    txt({ fontFamily: 'Fraunces', fontWeight: 600, fontSize: size, lineHeight: 1.16, color: t.tx }, prize),
+  ]);
+}
+
+/** Message 1 — the meter and the QR the consultant scans. */
+function passBody(t, { multText, prize, first, qrSrc, deadline }) {
+  const copyWidth = SIZE - cq(3.8) * 2 - QR_WELL - 40;
+  // The right-hand numeral gets whatever the "1×" block and the arrow leave.
+  const heroSize = fitHero(multText, 600, cq(32));
+
+  return [
+    el({ marginTop: cq(2.4), alignItems: 'flex-end' }, [
+      el({ flexDirection: 'column', alignItems: 'flex-start', flexShrink: 0 }, [
+        txt({ fontFamily: 'JetBrains Mono', fontWeight: 600, fontSize: cq(2.35), letterSpacing: 3.8, color: t.dim }, 'RIGHT NOW'),
+        txt({ fontWeight: 800, fontSize: cq(16), lineHeight: 0.7, letterSpacing: -3, color: t.n1, marginTop: cq(2), paddingBottom: cq(2) }, '1×'),
+      ]),
+      el({ flexGrow: 1, alignItems: 'center', marginBottom: cq(6.5), padding: `0 ${cq(3)}px` }, [
+        el({ flexGrow: 1, height: 2, backgroundImage: `linear-gradient(90deg, transparent, ${t.arrow})` }, []),
+        { type: 'img', props: { src: arrowHeadSrc(t.arrow, cq(2.7), cq(3)), width: cq(2.7), height: cq(3) } },
+      ]),
+      el({ flexDirection: 'column', alignItems: 'flex-start', flexShrink: 0 }, [
+        txt({ fontFamily: 'JetBrains Mono', fontWeight: 600, fontSize: cq(2.35), letterSpacing: 3.8, color: t.dim }, 'AFTER YOU SCAN'),
+        txt(
+          {
+            fontWeight: 800, fontSize: heroSize, lineHeight: 0.7, letterSpacing: Math.round(heroSize * -0.035),
+            marginTop: cq(2), paddingBottom: cq(2),
+            backgroundImage: t.metal, backgroundClip: 'text', WebkitBackgroundClip: 'text', color: 'transparent',
+          },
+          multText,
+        ),
+      ]),
+    ]),
+    promiseLine(t, prize, cq(5)),
+    el({ marginTop: 'auto', paddingTop: cq(1.6), alignItems: 'center' }, [
+      el(
+        {
+          width: QR_WELL, height: QR_WELL, flexShrink: 0, padding: QR_PAD,
+          backgroundColor: '#FFFFFF', borderRadius: cq(2.6),
+          alignItems: 'center', justifyContent: 'center',
+          boxShadow: '0 0 0 2px rgba(255,255,255,.14), 0 22px 43px rgba(0,0,0,.5)',
+        },
+        [{
+          type: 'img',
+          props: { src: qrSrc, width: QR_IMG, height: QR_IMG, style: { width: QR_IMG, height: QR_IMG } },
+        }],
+      ),
+      el({ flexDirection: 'column', width: copyWidth, marginLeft: 40 }, [
+        txt({ fontFamily: 'JetBrains Mono', fontWeight: 600, fontSize: cq(2.6), letterSpacing: 4.5, color: t.muted2 }, `${first}’S ENTRY`),
+        txt({ fontWeight: 600, fontSize: 34, lineHeight: 1.22, letterSpacing: -0.3, color: t.tx, marginTop: cq(1.9) }, 'Scan at your appointment to unlock.'),
+        ...(deadline
+          ? [txt({ fontFamily: 'JetBrains Mono', fontWeight: 600, fontSize: cq(2.55), letterSpacing: 2.8, color: t.dim, marginTop: cq(2.4) }, `SCAN BY ${deadline}`)]
+          : []),
+      ]),
+    ]),
+  ];
+}
+
+/** Message 2 — the boost is live; nothing left to scan. */
+function boostBody(t, { multText, prize, first, drawDate }) {
+  const heroSize = fitHero(multText, SIZE - cq(3.8) * 2, cq(57));
+  const stats = [
+    ['ENTRANT', first],
+    ['STATUS', 'Unlocked'],
+    ...(drawDate ? [['DRAW DATE', drawDate]] : []),
+  ];
+
+  return [
+    el({ flexDirection: 'column', alignItems: 'flex-start', marginTop: cq(3.4) }, [
+      txt({ fontFamily: 'JetBrains Mono', fontWeight: 600, fontSize: cq(2.9), letterSpacing: 5, color: t.dim }, 'YOU’RE NOW IN THE DRAW WITH'),
+      txt(
+        {
+          fontWeight: 800, fontSize: heroSize, lineHeight: 0.72, letterSpacing: Math.round(heroSize * -0.04),
+          marginTop: cq(1.6), paddingBottom: cq(3),
+          backgroundImage: t.metal, backgroundClip: 'text', WebkitBackgroundClip: 'text', color: 'transparent',
+        },
+        multText,
+      ),
+      promiseLine(t, prize, cq(5.4)),
+    ]),
+    el({ flexDirection: 'column', marginTop: 'auto' }, [
+      txt({ fontFamily: 'Fraunces', fontStyle: 'italic', fontWeight: 400, fontSize: cq(3.5), lineHeight: 1.2, color: t.sub }, 'We’ll message you the moment the draw is held.'),
+      el({ marginTop: cq(3.4), paddingTop: cq(3.4), borderTop: `2px solid ${t.hair}` },
+        stats.map(([k, v]) => el({ flexDirection: 'column', flexGrow: 1, flexBasis: 0, minWidth: 0, paddingRight: cq(3) }, [
+          txt({ fontFamily: 'JetBrains Mono', fontWeight: 600, fontSize: cq(2.2), letterSpacing: 2.9, color: t.dim }, k),
+          txt({ fontWeight: 600, fontSize: cq(3.3), color: t.tx, marginTop: cq(1.3) }, v),
+        ]))),
+    ]),
+  ];
+}
+
+/**
+ * Renders a Vault lucky-draw pass as a 1080×1080 PNG buffer.
+ *
+ * @param {object} opts
+ * @param {'pass'|'boost'} opts.variant
+ * @param {string} [opts.qrContent]   the claim link — required for 'pass', ignored for 'boost'
+ * @param {number} [opts.multiplier]  ×N total chances after the session (NOT "N more")
+ * @param {string} [opts.prize]       luckyDraw.prize summary
+ * @param {string} [opts.firstName]
+ * @param {string} [opts.deadlineLong]  boost deadline, long form — message 1 only
+ * @param {string} [opts.drawDateLong]  draw day, long form — message 2 only; omitted when unknown
+ * @param {string} [opts.theme]       one of PASS_THEMES
+ * @param {string} [opts.wordmark]    brand wordmark, e.g. 'Redeem.'
+ */
+export async function renderDrawPassPng({
+  variant,
+  qrContent,
+  multiplier,
+  prize,
+  firstName,
+  deadlineLong,
+  drawDateLong,
+  theme,
+  wordmark = 'Redeem.',
+}) {
+  if (variant !== 'pass' && variant !== 'boost') throw new Error(`unknown draw pass variant: ${variant}`);
+  if (variant === 'pass' && !qrContent) throw new Error('qrContent required for the draw entry pass');
+  const { satori, Resvg, fonts } = await loadEngine();
+  const t = THEMES[resolvePassTheme(theme)];
+
+  // ×N is the TOTAL after the session (1 chance × N), not N extra — every
+  // surface in the draw rails says it that way and the two must never drift.
+  const mult = Number.isInteger(multiplier) && multiplier >= 2 ? multiplier : 10;
+  const multText = `${mult}×`;
+  // The prize summary can be a multi-row string ("iPhone 17 Pro + 3× $100
+  // voucher"); the card carries the headline, the T&Cs carry the full list.
+  const prizeText = clean(prize, 58, 'the prize');
+  const first = clean(firstName, 14, 'You').toUpperCase();
+
+  let qrSrc = null;
+  if (variant === 'pass') {
+    // margin:1 puts one module of quiet zone inside the SVG; the white well's
+    // 50px padding adds ~4 more, clearing the ≥4-module scan requirement even
+    // if a longer link pushes the QR to a denser version.
+    const qrSvg = await QRCode.toString(qrContent, {
+      type: 'svg',
+      margin: 1,
+      color: { dark: '#111318', light: '#FFFFFF' },
+    });
+    // qrcode emits a viewBox-only root; satori needs explicit intrinsic dimensions.
+    const sized = qrSvg.replace('<svg ', `<svg width="${QR_IMG}" height="${QR_IMG}" `);
+    qrSrc = `data:image/svg+xml;base64,${Buffer.from(sized).toString('base64')}`;
+  }
+
+  const mark = clean(wordmark, 16, 'Redeem.');
+  const markBase = mark.endsWith('.') ? mark.slice(0, -1) : mark;
+
+  const card = el(
+    {
+      width: SIZE, height: SIZE, flexDirection: 'column',
+      padding: cq(3.8),
+      backgroundColor: t.groundFlat,
+      backgroundImage: t.ground,
+      fontFamily: 'Albert Sans',
+      overflow: 'hidden',
+    },
+    [
+      ...chrome(t, markBase, variant === 'pass' ? 'LUCKY DRAW PASS' : 'BOOST UNLOCKED'),
+      ...(variant === 'pass'
+        ? passBody(t, { multText, prize: prizeText, first, qrSrc, deadline: deadlineLong ? compactDate(deadlineLong) : null })
+        : boostBody(t, { multText, prize: prizeText, first: clean(firstName, 18, 'You'), drawDate: drawDateLong || null })),
+    ],
+  );
+
+  return renderSquarePng(card, SIZE, { satori, Resvg, fonts });
+}
+
+export default { renderDrawPassPng, PASS_THEMES, DEFAULT_PASS_THEME };

--- a/backend/src/services/redeemOps/fulfilmentNotify.js
+++ b/backend/src/services/redeemOps/fulfilmentNotify.js
@@ -36,7 +36,21 @@ export function makeFulfilmentNotify(overrides = {}) {
   };
 
   /**
-   * Editorial voucher-card PNG for the email's inline QR; a renderer failure
+   * The facts the Vault draw card renders. One place, so the pass and the boost
+   * receipt can never disagree about the prize, the colourway or the draw day.
+   */
+  function drawCardFacts(drawCtx) {
+    return {
+      multiplier: drawCtx.multiplier,
+      prize: drawCtx.prize,
+      drawOn: drawCtx.drawOn,
+      passTheme: drawCtx.passTheme,
+      boostDeadlineLong: boostDeadlineLong(drawCtx.boostClosesAt),
+    };
+  }
+
+  /**
+   * Credential-card PNG for the email's inline image; a renderer failure
    * degrades to the plain QR so delivery itself never rides on the compositor.
    */
   async function cardOrBareQr({ state, qrContent, entitlement, prospect, rewardName, partnerName, shortCode, hostChoice, draw = null }) {
@@ -107,7 +121,7 @@ export function makeFulfilmentNotify(overrides = {}) {
 
     const qrPng = await cardOrBareQr({
       state: 'pass', qrContent: link, entitlement, prospect, rewardName, partnerName, hostChoice,
-      draw: drawCtx ? { multiplier: drawCtx.multiplier, boostDeadlineLong: boostDeadlineLong(drawCtx.boostClosesAt) } : null,
+      draw: drawCtx ? drawCardFacts(drawCtx) : null,
     });
     // Draw voice (PR-4, F13/D5): an entrant who just joined a lucky draw must
     // read DRAW copy — "1 chance now, ×N when you meet the consultant" — not
@@ -150,12 +164,30 @@ export function makeFulfilmentNotify(overrides = {}) {
     if (!canEmailProspect(prospect)) return { sent: false, skipped: 'no_email' };
     const m = drawCtx?.multiplier || 10;
     const drawName = drawCtx?.drawName || 'the lucky draw';
+    // The Vault 'boost' card — the same image the WhatsApp twin carries, so a
+    // person on both channels sees one artefact twice, not two designs. There
+    // is no QR to fall back to here, so a renderer failure simply drops the
+    // image: the receipt itself must still land.
+    let cardPng = null;
+    if (drawCtx) {
+      try {
+        cardPng = await d.renderQrCard({
+          state: 'boost',
+          rewardName: drawName,
+          customerFirstName: prospect?.firstName,
+          draw: drawCardFacts(drawCtx),
+        });
+      } catch (err) {
+        d.logger.warn('redeem_ops.fulfilment.boost_card_skipped', { entitlementId: entitlement?.id, error: err?.message });
+      }
+    }
     const html = `
       <div style="font-family:Arial,sans-serif;max-width:520px;margin:0 auto;padding:24px">
         <h2 style="margin:0 0 8px">×${m} confirmed 🎉</h2>
         <p>Hi ${escapeHtml(prospect.firstName || 'there')},</p>
         <p>Your consultant has recorded your completed review — your entry to
         <strong>${escapeHtml(drawName)}</strong> now holds <strong>${m} chances</strong> instead of one.</p>
+        ${cardPng ? '<p style="text-align:center;margin:20px 0"><img src="cid:boost-card" width="320" height="320" style="max-width:100%" alt="Boost unlocked"/></p>' : ''}
         <p style="color:#6b7280;font-size:12px">Nothing else to do — winners are contacted directly after the draw.
         We never ask you to pay to release a prize.</p>
       </div>`;
@@ -165,6 +197,7 @@ export function makeFulfilmentNotify(overrides = {}) {
       html,
       text: `Your completed review has been recorded — your entry to ${drawName} now holds ${m} chances instead of one.`,
       context: 'redeem',
+      ...(cardPng ? { attachments: [{ filename: 'boost-unlocked.png', content: cardPng, cid: 'boost-card' }] } : {}),
     }, prospect.email);
   }
 

--- a/backend/src/services/redeemOps/qrCardRenderer.js
+++ b/backend/src/services/redeemOps/qrCardRenderer.js
@@ -8,10 +8,14 @@ import QRCode from 'qrcode';
  * "Editorial" frame (claude.ai/design "QR Card Frames" family 1c) so the PNG
  * that lands in WhatsApp / email reads as a voucher, not a bare code.
  *
- * Two states of one card: 'pass' (cream, gold "Reserved.") before unlock,
- * 'voucher' (full terracotta, "Unlocked.") after. 1080×1080, QR on a 594px
- * white panel (55% width, quiet zone ≥4 modules) with the title and QR inside
- * the middle band WhatsApp's chat-bubble crop preserves.
+ * Three states of one card: 'pass' (cream, gold "Reserved.") before unlock,
+ * 'voucher' (full terracotta, "Unlocked.") after, and 'boost' (terracotta,
+ * "Boosted.") for the recorded draw session — the ONLY QR-less state: the
+ * pass is consumed, so the white panel carries a giant ×N instead of a code
+ * (a scannable-looking image on a receipt would invite pointless scanning).
+ * 1080×1080, QR (or the ×N) on a 594px white panel (55% width, quiet zone
+ * ≥4 modules) with the title and panel inside the middle band WhatsApp's
+ * chat-bubble crop preserves.
  *
  * Pipeline: satori (layout + text→paths with the bundled Tropic fonts, so no
  * system-font dependency) → resvg (SVG→PNG). Engine + fonts load lazily and
@@ -57,6 +61,8 @@ const PALETTE = {
     powered: 'rgba(247,231,220,.8)',
   },
 };
+// The boost receipt celebrates like the voucher does — same terracotta frame.
+PALETTE.boost = PALETTE.voucher;
 
 let enginePromise = null;
 async function loadEngine() {
@@ -104,8 +110,8 @@ function formatExpiry(expiresAt) {
  * Renders the Editorial QR card as a 1080×1080 PNG buffer.
  *
  * @param {object} opts
- * @param {'pass'|'voucher'} opts.state
- * @param {string} opts.qrContent    encoded verbatim (claim link for the pass, raw token for the voucher)
+ * @param {'pass'|'voucher'|'boost'} opts.state
+ * @param {string} [opts.qrContent]  encoded verbatim (claim link for the pass, raw token for the voucher); unused and optional for 'boost'
  * @param {string} [opts.rewardName]
  * @param {string} [opts.partnerName]
  * @param {string} [opts.customerFirstName]
@@ -128,21 +134,28 @@ export async function renderQrCardPng({
   // absent.
   draw = null,
 }) {
-  if (state !== 'pass' && state !== 'voucher') throw new Error(`unknown card state: ${state}`);
-  if (!qrContent) throw new Error('qrContent required');
+  if (state !== 'pass' && state !== 'voucher' && state !== 'boost') {
+    throw new Error(`unknown card state: ${state}`);
+  }
+  const isBoost = state === 'boost';
+  if (!qrContent && !isBoost) throw new Error('qrContent required');
   const { satori, Resvg, fonts } = await loadEngine();
   const c = PALETTE[state];
 
   // QR as crisp vector modules; the 594px white panel supplies a ~72px quiet
-  // zone (>4 modules), so the QR itself renders margin-free at 450px.
-  const qrSvg = await QRCode.toString(qrContent, {
-    type: 'svg',
-    margin: 0,
-    color: { dark: '#1B1A17', light: '#FFFFFF' },
-  });
-  // qrcode emits a viewBox-only root; satori needs explicit intrinsic dimensions.
-  const qrSized = qrSvg.replace('<svg ', '<svg width="450" height="450" ');
-  const qrSrc = `data:image/svg+xml;base64,${Buffer.from(qrSized).toString('base64')}`;
+  // zone (>4 modules), so the QR itself renders margin-free at 450px. The
+  // boost receipt is QR-less by design — nothing left to scan.
+  let qrSrc = null;
+  if (!isBoost) {
+    const qrSvg = await QRCode.toString(qrContent, {
+      type: 'svg',
+      margin: 0,
+      color: { dark: '#1B1A17', light: '#FFFFFF' },
+    });
+    // qrcode emits a viewBox-only root; satori needs explicit intrinsic dimensions.
+    const qrSized = qrSvg.replace('<svg ', '<svg width="450" height="450" ');
+    qrSrc = `data:image/svg+xml;base64,${Buffer.from(qrSized).toString('base64')}`;
+  }
 
   const title = clean(rewardName, 70, 'Your reward');
   const partner = clean(partnerName, 48).toUpperCase();
@@ -155,24 +168,31 @@ export async function renderQrCardPng({
   const isPass = state === 'pass';
   const isDraw = !!draw;
   const drawMult = isDraw && Number.isInteger(draw.multiplier) ? draw.multiplier : 10;
-  const kicker = isDraw ? 'LUCKY DRAW PASS' : isPass ? 'RESERVATION PASS' : 'VOUCHER · UNLOCKED';
-  const displayWord = isDraw ? "You're in." : isPass ? 'Reserved.' : 'Unlocked.';
-  const statusLine = isDraw
-    ? `Held for ${first} — 1 chance in the draw now`
-    : isPass
-      ? `Held for ${first} — unlock at your appointment`
-      : 'Unlocked — present once to redeem';
-  const codeLine = isDraw
-    ? `${drawMult}X YOUR CHANCES WHEN YOU MEET A CONSULTANT`
-    : isPass
-      ? 'CODE · REVEALED ON UNLOCK'
-      : (code ? `CODE ${code}` : 'ONE-TIME VOUCHER');
+  const kicker = isBoost ? 'SESSION RECORDED' : isDraw ? 'LUCKY DRAW PASS' : isPass ? 'RESERVATION PASS' : 'VOUCHER · UNLOCKED';
+  const displayWord = isBoost ? 'Boosted.' : isDraw ? "You're in." : isPass ? 'Reserved.' : 'Unlocked.';
+  const statusLine = isBoost
+    ? `Recorded for ${first} — review completed`
+    : isDraw
+      ? `Held for ${first} — 1 chance in the draw now`
+      : isPass
+        ? `Held for ${first} — unlock at your appointment`
+        : 'Unlocked — present once to redeem';
+  const codeLine = isBoost
+    ? `WAS 1 CHANCE · NOW ${drawMult}`
+    : isDraw
+      ? `${drawMult}X YOUR CHANCES WHEN YOU MEET A CONSULTANT`
+      : isPass
+        ? 'CODE · REVEALED ON UNLOCK'
+        : (code ? `CODE ${code}` : 'ONE-TIME VOUCHER');
   // One-date-per-surface (#252): the draw card carries the USER-relevant
   // deadline (complete the review by boostClosesAt); the internal reservation
-  // expiry never prints on it.
-  const expiryLine = isDraw
-    ? (draw.boostDeadlineLong ? `COMPLETE YOUR REVIEW BY ${String(draw.boostDeadlineLong).toUpperCase()}` : null)
-    : expiry ? (isPass ? `EXPIRES ${expiry}` : `VALID TILL ${expiry}`).toUpperCase() : null;
+  // expiry never prints on it. The boost receipt carries NO date at all —
+  // the review is done, and boostClosesAt is not a promise about draw day.
+  const expiryLine = isBoost
+    ? null
+    : isDraw
+      ? (draw.boostDeadlineLong ? `COMPLETE YOUR REVIEW BY ${String(draw.boostDeadlineLong).toUpperCase()}` : null)
+      : expiry ? (isPass ? `EXPIRES ${expiry}` : `VALID TILL ${expiry}`).toUpperCase() : null;
 
   const card = el(
     {
@@ -219,7 +239,12 @@ export async function renderQrCardPng({
           alignItems: 'center',
           justifyContent: 'center',
         },
-        [{ type: 'img', props: { src: qrSrc, width: 450, height: 450, style: { width: 450, height: 450 } } }],
+        isBoost
+          ? [el({ flexDirection: 'column', alignItems: 'center' }, [
+              txt({ fontFamily: 'Fraunces', fontStyle: 'italic', fontWeight: 600, fontSize: 290, lineHeight: 1, color: '#1B1A17' }, `${drawMult}×`),
+              txt({ fontWeight: 600, fontSize: 30, letterSpacing: 6, color: '#6B6558', marginTop: 10 }, 'CHANCES IN THE DRAW'),
+            ])]
+          : [{ type: 'img', props: { src: qrSrc, width: 450, height: 450, style: { width: 450, height: 450 } } }],
       ),
       // Status line
       el({ marginTop: 10, justifyContent: 'center', alignItems: 'center' }, [
@@ -232,7 +257,7 @@ export async function renderQrCardPng({
         ...(expiryLine
           ? [txt({ fontWeight: 600, fontSize: 24, letterSpacing: 3.4, color: c.expiry, marginBottom: 5 }, expiryLine)]
           : []),
-        txt({ fontSize: 24, color: c.finePrint, marginBottom: 5 }, 'Present once. Non-transferable.'),
+        txt({ fontSize: 24, color: c.finePrint, marginBottom: 5 }, isBoost ? 'Winners are contacted after the draw closes.' : 'Present once. Non-transferable.'),
         txt({ fontFamily: 'JetBrains Mono', fontWeight: 600, fontSize: 24, letterSpacing: 2.9, color: c.powered }, 'POWERED BY MKTR'),
       ]),
     ],

--- a/backend/src/services/redeemOps/qrCardRenderer.js
+++ b/backend/src/services/redeemOps/qrCardRenderer.js
@@ -1,29 +1,29 @@
-import { readFile } from 'node:fs/promises';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import QRCode from 'qrcode';
+import { loadEngine, el, txt, clean, renderSquarePng } from './cardEngine.js';
+import { renderDrawPassPng } from './drawPassRenderer.js';
+import { longDate } from '../../utils/sgtTime.js';
 
 /**
  * Editorial voucher-card compositor — wraps the reward QR in the branded
  * "Editorial" frame (claude.ai/design "QR Card Frames" family 1c) so the PNG
  * that lands in WhatsApp / email reads as a voucher, not a bare code.
  *
- * Three states of one card: 'pass' (cream, gold "Reserved.") before unlock,
- * 'voucher' (full terracotta, "Unlocked.") after, and 'boost' (terracotta,
- * "Boosted.") for the recorded draw session — the ONLY QR-less state: the
- * pass is consumed, so the white panel carries a giant ×N instead of a code
- * (a scannable-looking image on a receipt would invite pointless scanning).
- * 1080×1080, QR (or the ×N) on a 594px white panel (55% width, quiet zone
- * ≥4 modules) with the title and panel inside the middle band WhatsApp's
- * chat-bubble crop preserves.
+ * Two states of one card: 'pass' (cream, gold "Reserved.") before unlock and
+ * 'voucher' (full terracotta, "Unlocked.") after. 1080×1080, QR on a 594px
+ * white panel (55% width, quiet zone ≥4 modules) with the title and QR inside
+ * the middle band WhatsApp's chat-bubble crop preserves.
+ *
+ * THIS FRAME IS FOR TRIAL REWARDS. A lucky-draw entitlement is a different
+ * promise — no partner, no voucher, a multiplier instead of a code — so when a
+ * `draw` context is present every state routes to the dark "Vault" frame in
+ * drawPassRenderer.js instead. Callers keep ONE entry point; the branch lives
+ * here so no sender has to know which artwork it is asking for.
  *
  * Pipeline: satori (layout + text→paths with the bundled Tropic fonts, so no
  * system-font dependency) → resvg (SVG→PNG). Engine + fonts load lazily and
- * cache; senders treat any throw here as "fall back to the bare QR", so a
- * broken native dep degrades delivery quality, never delivery.
+ * cache (cardEngine.js); senders treat any throw here as "fall back to the
+ * bare QR", so a broken native dep degrades delivery quality, never delivery.
  */
-
-const FONT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../assets/fonts');
 
 const PALETTE = {
   pass: {
@@ -61,43 +61,6 @@ const PALETTE = {
     powered: 'rgba(247,231,220,.8)',
   },
 };
-// The boost receipt celebrates like the voucher does — same terracotta frame.
-PALETTE.boost = PALETTE.voucher;
-
-let enginePromise = null;
-async function loadEngine() {
-  if (!enginePromise) {
-    enginePromise = (async () => {
-      const [{ default: satori }, { Resvg }] = await Promise.all([
-        import('satori'),
-        import('@resvg/resvg-js'),
-      ]);
-      const font = (file) => readFile(path.join(FONT_DIR, file));
-      const fonts = [
-        { name: 'Fraunces', data: await font('fraunces-600.ttf'), weight: 600, style: 'normal' },
-        { name: 'Fraunces', data: await font('fraunces-italic-400.ttf'), weight: 400, style: 'italic' },
-        { name: 'Fraunces', data: await font('fraunces-italic-600.ttf'), weight: 600, style: 'italic' },
-        { name: 'Albert Sans', data: await font('albertsans-400.ttf'), weight: 400, style: 'normal' },
-        { name: 'Albert Sans', data: await font('albertsans-600.ttf'), weight: 600, style: 'normal' },
-        { name: 'Albert Sans', data: await font('albertsans-800.ttf'), weight: 800, style: 'normal' },
-        { name: 'JetBrains Mono', data: await font('jetbrainsmono-600.ttf'), weight: 600, style: 'normal' },
-      ];
-      return { satori, Resvg, fonts };
-    })();
-    // A transient failure (e.g. fonts unreadable mid-deploy) must not poison the cache.
-    enginePromise.catch(() => { enginePromise = null; });
-  }
-  return enginePromise;
-}
-
-const el = (style, children) => ({ type: 'div', props: { style: { display: 'flex', ...style }, children } });
-const txt = (style, text) => ({ type: 'div', props: { style, children: text } });
-
-/** Meta/WhatsApp-safe single-line text: collapse whitespace, cap length. */
-function clean(value, max, fallback = '') {
-  const s = String(value ?? '').replace(/\s+/g, ' ').trim().slice(0, max);
-  return s || fallback;
-}
 
 function formatExpiry(expiresAt) {
   if (!expiresAt) return null;
@@ -107,10 +70,11 @@ function formatExpiry(expiresAt) {
 }
 
 /**
- * Renders the Editorial QR card as a 1080×1080 PNG buffer.
+ * Renders the consumer credential card as a 1080×1080 PNG buffer — the
+ * Editorial frame for trial rewards, the Vault frame when `draw` is present.
  *
  * @param {object} opts
- * @param {'pass'|'voucher'|'boost'} opts.state
+ * @param {'pass'|'voucher'|'boost'} opts.state  'boost' is draw-only (the receipt at a recorded session)
  * @param {string} [opts.qrContent]  encoded verbatim (claim link for the pass, raw token for the voucher); unused and optional for 'boost'
  * @param {string} [opts.rewardName]
  * @param {string} [opts.partnerName]
@@ -118,6 +82,7 @@ function formatExpiry(expiresAt) {
  * @param {string} [opts.shortCode]  voucher manual-fallback code (tokenHint)
  * @param {Date|string|null} [opts.expiresAt]
  * @param {string} [opts.wordmark]   brand wordmark incl. trailing period, e.g. 'Redeem.'
+ * @param {null|{multiplier, prize, boostClosesAt, drawOn, passTheme}} [opts.draw]
  */
 export async function renderQrCardPng({
   state,
@@ -128,34 +93,51 @@ export async function renderQrCardPng({
   shortCode,
   expiresAt,
   wordmark = 'Redeem.',
-  // PR-4 (D5): lucky-draw voice — {multiplier, boostDeadlineLong}. The frame
-  // strings swap to the D5 line-set ("LUCKY DRAW PASS" / "You're in." / plain
-  // "Nx your chances…"); everything trial-shaped stays byte-identical when
+  // Lucky-draw context. Presence routes the whole render to the Vault frame
+  // (drawPassRenderer.js); everything trial-shaped stays byte-identical when
   // absent.
   draw = null,
 }) {
   if (state !== 'pass' && state !== 'voucher' && state !== 'boost') {
     throw new Error(`unknown card state: ${state}`);
   }
-  const isBoost = state === 'boost';
-  if (!qrContent && !isBoost) throw new Error('qrContent required');
+
+  if (draw) {
+    // 'voucher' cannot happen on a draw rail (a boost mints no redeemable
+    // token) — if it ever does, the entry pass is the honest artwork.
+    return renderDrawPassPng({
+      variant: state === 'boost' ? 'boost' : 'pass',
+      qrContent,
+      multiplier: draw.multiplier,
+      prize: draw.prize,
+      firstName: customerFirstName,
+      // Accept either the raw YMD or a pre-formatted long date, so callers that
+      // already formatted for their own copy don't have to unformat.
+      deadlineLong: draw.boostDeadlineLong || longDate(draw.boostClosesAt) || null,
+      drawDateLong: draw.drawDateLong || longDate(draw.drawOn) || null,
+      theme: draw.passTheme,
+      wordmark,
+    });
+  }
+
+  // 'boost' only exists on the draw rails — reaching here means a caller lost
+  // its draw context, and a terracotta "Boosted." card would be a lie about a
+  // partner voucher. Throw so the sender ships without an image instead.
+  if (state === 'boost') throw new Error('boost cards require a draw context');
+  if (!qrContent) throw new Error('qrContent required');
   const { satori, Resvg, fonts } = await loadEngine();
   const c = PALETTE[state];
 
   // QR as crisp vector modules; the 594px white panel supplies a ~72px quiet
-  // zone (>4 modules), so the QR itself renders margin-free at 450px. The
-  // boost receipt is QR-less by design — nothing left to scan.
-  let qrSrc = null;
-  if (!isBoost) {
-    const qrSvg = await QRCode.toString(qrContent, {
-      type: 'svg',
-      margin: 0,
-      color: { dark: '#1B1A17', light: '#FFFFFF' },
-    });
-    // qrcode emits a viewBox-only root; satori needs explicit intrinsic dimensions.
-    const qrSized = qrSvg.replace('<svg ', '<svg width="450" height="450" ');
-    qrSrc = `data:image/svg+xml;base64,${Buffer.from(qrSized).toString('base64')}`;
-  }
+  // zone (>4 modules), so the QR itself renders margin-free at 450px.
+  const qrSvg = await QRCode.toString(qrContent, {
+    type: 'svg',
+    margin: 0,
+    color: { dark: '#1B1A17', light: '#FFFFFF' },
+  });
+  // qrcode emits a viewBox-only root; satori needs explicit intrinsic dimensions.
+  const qrSized = qrSvg.replace('<svg ', '<svg width="450" height="450" ');
+  const qrSrc = `data:image/svg+xml;base64,${Buffer.from(qrSized).toString('base64')}`;
 
   const title = clean(rewardName, 70, 'Your reward');
   const partner = clean(partnerName, 48).toUpperCase();
@@ -166,33 +148,15 @@ export async function renderQrCardPng({
   const markBase = mark.endsWith('.') ? mark.slice(0, -1) : mark;
 
   const isPass = state === 'pass';
-  const isDraw = !!draw;
-  const drawMult = isDraw && Number.isInteger(draw.multiplier) ? draw.multiplier : 10;
-  const kicker = isBoost ? 'SESSION RECORDED' : isDraw ? 'LUCKY DRAW PASS' : isPass ? 'RESERVATION PASS' : 'VOUCHER · UNLOCKED';
-  const displayWord = isBoost ? 'Boosted.' : isDraw ? "You're in." : isPass ? 'Reserved.' : 'Unlocked.';
-  const statusLine = isBoost
-    ? `Recorded for ${first} — review completed`
-    : isDraw
-      ? `Held for ${first} — 1 chance in the draw now`
-      : isPass
-        ? `Held for ${first} — unlock at your appointment`
-        : 'Unlocked — present once to redeem';
-  const codeLine = isBoost
-    ? `WAS 1 CHANCE · NOW ${drawMult}`
-    : isDraw
-      ? `${drawMult}X YOUR CHANCES WHEN YOU MEET A CONSULTANT`
-      : isPass
-        ? 'CODE · REVEALED ON UNLOCK'
-        : (code ? `CODE ${code}` : 'ONE-TIME VOUCHER');
-  // One-date-per-surface (#252): the draw card carries the USER-relevant
-  // deadline (complete the review by boostClosesAt); the internal reservation
-  // expiry never prints on it. The boost receipt carries NO date at all —
-  // the review is done, and boostClosesAt is not a promise about draw day.
-  const expiryLine = isBoost
-    ? null
-    : isDraw
-      ? (draw.boostDeadlineLong ? `COMPLETE YOUR REVIEW BY ${String(draw.boostDeadlineLong).toUpperCase()}` : null)
-      : expiry ? (isPass ? `EXPIRES ${expiry}` : `VALID TILL ${expiry}`).toUpperCase() : null;
+  const kicker = isPass ? 'RESERVATION PASS' : 'VOUCHER · UNLOCKED';
+  const displayWord = isPass ? 'Reserved.' : 'Unlocked.';
+  const statusLine = isPass
+    ? `Held for ${first} — unlock at your appointment`
+    : 'Unlocked — present once to redeem';
+  const codeLine = isPass
+    ? 'CODE · REVEALED ON UNLOCK'
+    : (code ? `CODE ${code}` : 'ONE-TIME VOUCHER');
+  const expiryLine = expiry ? (isPass ? `EXPIRES ${expiry}` : `VALID TILL ${expiry}`).toUpperCase() : null;
 
   const card = el(
     {
@@ -239,12 +203,7 @@ export async function renderQrCardPng({
           alignItems: 'center',
           justifyContent: 'center',
         },
-        isBoost
-          ? [el({ flexDirection: 'column', alignItems: 'center' }, [
-              txt({ fontFamily: 'Fraunces', fontStyle: 'italic', fontWeight: 600, fontSize: 290, lineHeight: 1, color: '#1B1A17' }, `${drawMult}×`),
-              txt({ fontWeight: 600, fontSize: 30, letterSpacing: 6, color: '#6B6558', marginTop: 10 }, 'CHANCES IN THE DRAW'),
-            ])]
-          : [{ type: 'img', props: { src: qrSrc, width: 450, height: 450, style: { width: 450, height: 450 } } }],
+        [{ type: 'img', props: { src: qrSrc, width: 450, height: 450, style: { width: 450, height: 450 } } }],
       ),
       // Status line
       el({ marginTop: 10, justifyContent: 'center', alignItems: 'center' }, [
@@ -257,15 +216,13 @@ export async function renderQrCardPng({
         ...(expiryLine
           ? [txt({ fontWeight: 600, fontSize: 24, letterSpacing: 3.4, color: c.expiry, marginBottom: 5 }, expiryLine)]
           : []),
-        txt({ fontSize: 24, color: c.finePrint, marginBottom: 5 }, isBoost ? 'Winners are contacted after the draw closes.' : 'Present once. Non-transferable.'),
+        txt({ fontSize: 24, color: c.finePrint, marginBottom: 5 }, 'Present once. Non-transferable.'),
         txt({ fontFamily: 'JetBrains Mono', fontWeight: 600, fontSize: 24, letterSpacing: 2.9, color: c.powered }, 'POWERED BY MKTR'),
       ]),
     ],
   );
 
-  const svg = await satori(card, { width: 1080, height: 1080, fonts });
-  const png = new Resvg(svg, { fitTo: { mode: 'original' } }).render().asPng();
-  return Buffer.from(png);
+  return renderSquarePng(card, 1080, { satori, Resvg, fonts });
 }
 
 export default { renderQrCardPng };

--- a/backend/src/services/redeemOps/whatsappService.js
+++ b/backend/src/services/redeemOps/whatsappService.js
@@ -223,9 +223,12 @@ export function makeWhatsappService(overrides = {}) {
       const components = [
         { type: 'body', parameters: params.map((text) => ({ type: 'text', text })) },
       ];
-      if (qrHeaderEnabled() && qrContent) {
+      if (qrHeaderEnabled() && (qrContent || card?.state === 'boost')) {
         // Editorial voucher card (branded frame around the QR); any renderer
         // failure degrades to the plain QR — the credential always ships.
+        // The boost receipt is the QR-less card state: with no qrContent
+        // there is no bare-QR fallback, so a renderer failure is a receipted
+        // send failure (an image-header template cannot send headerless).
         let png = null;
         try {
           png = await d.renderQrCard({
@@ -236,6 +239,7 @@ export function makeWhatsappService(overrides = {}) {
         } catch (err) {
           d.logger.warn('redeem_ops.whatsapp.qr_card_fallback', { template: templateName, error: err?.message });
         }
+        if (!png && !qrContent) throw new Error('boost card render failed — image-header template needs its header');
         if (!png) png = await d.QRCode.toBuffer(qrContent, { width: 512, margin: 2 });
         const mediaId = await uploadQrPng(phoneId, token, png);
         components.unshift({
@@ -335,14 +339,20 @@ export function makeWhatsappService(overrides = {}) {
   }
 
   /** "×N confirmed" receipt at a recorded draw session — the WA twin of
-   * sendBoostReceiptEmail, same register as the email body. Body-only
-   * APPROVED UTILITY template `draw_boost_receipt` (no header on purpose:
-   * the pass is consumed, there is nothing left to scan); 3 params =
-   * name, draw name, multiplier. */
+   * sendBoostReceiptEmail, same register as the email body. The
+   * `draw_boost_receipt` template carries the Editorial 'boost' card as its
+   * IMAGE header — the QR-less celebration state (giant ×N; the pass is
+   * consumed, nothing left to scan); 3 params = name, draw name, multiplier. */
   async function sendBoostReceiptWhatsApp({ prospect, drawCtx }) {
     return sendTemplate({
       prospect,
       templateName: process.env.WHATSAPP_TEMPLATE_DRAW_BOOST || 'draw_boost_receipt',
+      card: {
+        state: 'boost',
+        rewardName: cleanParam(drawCtx?.drawName, 'the lucky draw'),
+        partnerName: 'Lucky draw',
+        draw: { multiplier: drawCtx?.multiplier },
+      },
       params: [
         cleanParam(prospect?.firstName, 'there'),
         cleanParam(drawCtx?.drawName, 'the lucky draw'),

--- a/backend/src/services/redeemOps/whatsappService.js
+++ b/backend/src/services/redeemOps/whatsappService.js
@@ -292,7 +292,16 @@ export function makeWhatsappService(overrides = {}) {
         qrContent: passLink,
         card: {
           state: 'pass', rewardName, partnerName, expiresAt: entitlement.expiresAt,
-          draw: { multiplier: drawCtx.multiplier, boostDeadlineLong: boostDeadlineLong(drawCtx.boostClosesAt) },
+          // Presence of `draw` routes the render to the Vault frame; the prize,
+          // draw day and colourway are what make it this campaign's pass rather
+          // than a generic one.
+          draw: {
+            multiplier: drawCtx.multiplier,
+            prize: drawCtx.prize,
+            drawOn: drawCtx.drawOn,
+            passTheme: drawCtx.passTheme,
+            boostDeadlineLong: boostDeadlineLong(drawCtx.boostClosesAt),
+          },
         },
         params: [
           cleanParam(prospect?.firstName, 'there'),
@@ -340,9 +349,9 @@ export function makeWhatsappService(overrides = {}) {
 
   /** "×N confirmed" receipt at a recorded draw session — the WA twin of
    * sendBoostReceiptEmail, same register as the email body. The
-   * `draw_boost_receipt` template carries the Editorial 'boost' card as its
-   * IMAGE header — the QR-less celebration state (giant ×N; the pass is
-   * consumed, nothing left to scan); 3 params = name, draw name, multiplier. */
+   * `draw_boost_receipt` template carries the Vault 'boost' card as its IMAGE
+   * header — the QR-less celebration state (giant ×N; the pass is consumed,
+   * nothing left to scan); 3 params = name, draw name, multiplier. */
   async function sendBoostReceiptWhatsApp({ prospect, drawCtx }) {
     return sendTemplate({
       prospect,
@@ -351,7 +360,12 @@ export function makeWhatsappService(overrides = {}) {
         state: 'boost',
         rewardName: cleanParam(drawCtx?.drawName, 'the lucky draw'),
         partnerName: 'Lucky draw',
-        draw: { multiplier: drawCtx?.multiplier },
+        draw: {
+          multiplier: drawCtx?.multiplier,
+          prize: drawCtx?.prize,
+          drawOn: drawCtx?.drawOn,
+          passTheme: drawCtx?.passTheme,
+        },
       },
       params: [
         cleanParam(prospect?.firstName, 'there'),

--- a/backend/src/utils/drawTheme.js
+++ b/backend/src/utils/drawTheme.js
@@ -1,0 +1,118 @@
+/**
+ * The lucky-draw colourway — ONE enum shared by every customer-facing draw
+ * surface, so a campaign can never be titanium on WhatsApp and gold in the
+ * inbox. Stored as `design_config.luckyDraw.passTheme` (admin-only, clamped by
+ * utils/luckyDraw.js) and consumed by:
+ *
+ *   - services/redeemOps/drawPassRenderer.js — the 1080×1080 "Vault" WhatsApp
+ *     card (its own tokens: gradients over a PNG canvas)
+ *   - services/email-templates/confirmation-email-draw.html via `emailPalette`
+ *     below — the "Onyx" entry-confirmation email
+ *
+ * The two token sets are deliberately separate — a PNG can lean on rgba and
+ * `background-clip:text`, an email cannot — but they are cut from the same
+ * four palettes and must stay recognisably the same brand.
+ *
+ * EMAIL TOKENS ARE SOLID HEX ON PURPOSE. Outlook drops rgba() borders and
+ * gradient backgrounds entirely, so every value here is the already-blended
+ * colour. There is deliberately no metal GRADIENT among them: the email's hero
+ * numeral is `metalSolid`, because a client that keeps -webkit-text-fill-color
+ * while stripping background-image would render the whole promise invisible.
+ * The clipped-gradient numeral lives on the card, where we own the renderer.
+ */
+
+export const PASS_THEMES = ['titanium', 'gold', 'emerald', 'sapphire'];
+export const DEFAULT_PASS_THEME = 'titanium';
+
+/** Unknown/absent theme falls back rather than throwing — a bad enum must never cost a send. */
+export function resolvePassTheme(name) {
+  const key = String(name || '').trim().toLowerCase();
+  return PASS_THEMES.includes(key) ? key : DEFAULT_PASS_THEME;
+}
+
+const EMAIL_PALETTES = {
+  titanium: {
+    page: '#08090b',
+    panelTop: '#14161a', panelBottom: '#0a0b0d', panelSolid: '#101216',
+    border: '#1d2025', hair: '#23262b',
+    word: '#f4f5f7', pillText: '#c9ced6', pillBorder: '#3a3e44',
+    eyebrow: '#797e86', h1: '#fbfcfd',
+    body: '#a9aeb6', bodyStrong: '#eef0f3',
+    boxBorder: '#22252a', boxBg: '#111317',
+    meterLabel: '#71767e', n1: '#6e737b',
+    metalSolid: '#e6e9ee',
+    meterSub: '#cfd3d9', meterSubStrong: '#fbfcfd',
+    para: '#9ba0a8',
+    statKey: '#6e737b', statVal: '#eef0f3',
+    dashBorder: '#33373d', linkText: '#dfe3e9',
+    btnBorder: '#2c3036', btnText: '#c9ced6', hint: '#6b7078',
+    arrowFrom: '#2a2d33', arrowTo: '#6b7078',
+    quiet: '#74797f', signItalic: '#9ba0a8', signName: '#eef0f3',
+    footBorder: '#1c1f23', footBg: '#0b0c0f', footWord: '#c9ced6', footText: '#6b7078', unsub: '#a9aeb6',
+  },
+  gold: {
+    page: '#0a0805',
+    panelTop: '#1d1708', panelBottom: '#0a0a08', panelSolid: '#13100a',
+    border: '#2a2312', hair: '#2e2714',
+    word: '#f6f2e8', pillText: '#e3c98f', pillBorder: '#4a3f22',
+    eyebrow: '#9a8556', h1: '#fdfaf3',
+    body: '#ada79a', bodyStrong: '#f2ead9',
+    boxBorder: '#2f2814', boxBg: '#17130b',
+    meterLabel: '#8d7a4f', n1: '#8a7748',
+    metalSolid: '#ecd49a',
+    meterSub: '#d6cdb6', meterSubStrong: '#fdfaf3',
+    para: '#a09a8c',
+    statKey: '#8d7a4f', statVal: '#f2ead9',
+    dashBorder: '#453a20', linkText: '#ecdcb9',
+    btnBorder: '#3a3119', btnText: '#e0c893', hint: '#857346',
+    arrowFrom: '#342c17', arrowTo: '#8d7a4f',
+    quiet: '#7c7566', signItalic: '#a09a8c', signName: '#f2ead9',
+    footBorder: '#241e10', footBg: '#0d0b07', footWord: '#d3c19a', footText: '#857346', unsub: '#bda870',
+  },
+  emerald: {
+    page: '#050a07',
+    panelTop: '#0c1a13', panelBottom: '#060a08', panelSolid: '#0a130e',
+    border: '#16281d', hair: '#192c21',
+    word: '#eff6f1', pillText: '#a9d6bb', pillBorder: '#2b4636',
+    eyebrow: '#6f9781', h1: '#f7fcf8',
+    body: '#9fada4', bodyStrong: '#e6f1e9',
+    boxBorder: '#1a2e22', boxBg: '#0c1711',
+    meterLabel: '#67907a', n1: '#648d77',
+    metalSolid: '#cfe6d8',
+    meterSub: '#c6d4cb', meterSubStrong: '#f7fcf8',
+    para: '#94a29a',
+    statKey: '#67907a', statVal: '#e6f1e9',
+    dashBorder: '#27412f', linkText: '#d6ebdd',
+    btnBorder: '#1f3527', btnText: '#b3d9c1', hint: '#628b74',
+    arrowFrom: '#1c3225', arrowTo: '#67907a',
+    quiet: '#728177', signItalic: '#94a29a', signName: '#e6f1e9',
+    footBorder: '#142418', footBg: '#070d09', footWord: '#b9d5c4', footText: '#628b74', unsub: '#96c2a7',
+  },
+  sapphire: {
+    page: '#06070d',
+    panelTop: '#0f1729', panelBottom: '#07090f', panelSolid: '#0c1220',
+    border: '#1c2436', hair: '#1e2739',
+    word: '#f0f3fa', pillText: '#b7c6e8', pillBorder: '#333f5a',
+    eyebrow: '#7d8cb0', h1: '#f8fafd',
+    body: '#a2a9bb', bodyStrong: '#e8edf8',
+    boxBorder: '#202a3e', boxBg: '#0e1421',
+    meterLabel: '#7786ab', n1: '#7484a8',
+    metalSolid: '#dbe3f5',
+    meterSub: '#c9d0e0', meterSubStrong: '#f8fafd',
+    para: '#969db0',
+    statKey: '#7786ab', statVal: '#e8edf8',
+    dashBorder: '#2d3850', linkText: '#dae2f5',
+    btnBorder: '#262f45', btnText: '#bcc9e6', hint: '#71809f',
+    arrowFrom: '#242e44', arrowTo: '#7786ab',
+    quiet: '#757c8f', signItalic: '#969db0', signName: '#e8edf8',
+    footBorder: '#171e2c', footBg: '#080b12', footWord: '#c2cde6', footText: '#71809f', unsub: '#9dadd4',
+  },
+};
+
+/** Onyx email tokens for a theme, as `{ c_<token>: value }` merge fields. */
+export function emailPalette(theme) {
+  const p = EMAIL_PALETTES[resolvePassTheme(theme)];
+  return Object.fromEntries(Object.entries(p).map(([k, v]) => [`c_${k}`, v]));
+}
+
+export default { PASS_THEMES, DEFAULT_PASS_THEME, resolvePassTheme, emailPalette };

--- a/backend/src/utils/luckyDraw.js
+++ b/backend/src/utils/luckyDraw.js
@@ -21,6 +21,7 @@
  */
 
 import { AppError } from '../middleware/appError.js';
+import { PASS_THEMES } from './drawTheme.js';
 
 const MAX_PRIZE = 80; // legacy manual `prize` cap — unchanged so stored rows never drift
 const MAX_PRIZE_NAME = 80;
@@ -121,6 +122,14 @@ export function normalizeLuckyDraw(raw) {
     Number.isInteger(multiplier) && multiplier >= MIN_MULTIPLIER && multiplier <= MAX_MULTIPLIER
       ? multiplier
       : DEFAULT_MULTIPLIER;
+
+  // Colourway for the customer-facing draw surfaces — the Vault WhatsApp pass
+  // and the Onyx confirmation email (utils/drawTheme.js). Display-only: no draw
+  // mechanic reads it. Clamped to the enum HERE so no render path ever
+  // interpolates campaign JSON into a palette lookup; absent stays absent so
+  // legacy rows round-trip byte-identical and the renderers apply the default.
+  const passTheme = cleanString(raw.passTheme, 16)?.toLowerCase();
+  if (passTheme && PASS_THEMES.includes(passTheme)) out.passTheme = passTheme;
 
   // Session-booking link for the success screen's "Book your 20-min review"
   // CTA (drawTemplates.jsx). Display-only — no draw mechanics read it. Absent

--- a/backend/src/utils/sgtTime.js
+++ b/backend/src/utils/sgtTime.js
@@ -6,6 +6,34 @@
 const DAY_MS = 24 * 60 * 60 * 1000;
 const YMD_RE = /^\d{4}-\d{2}-\d{2}$/;
 
+const MONTHS = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+/**
+ * '2026-09-30' → '30 September 2026'; '' for anything that isn't a YMD.
+ * The one display formatter for draw dates (WhatsApp, email, card artwork) —
+ * re-exported by redeemOps/drawLink.js as `boostDeadlineLong` for the callers
+ * that grew up with that name. It lives here, next to the other date rules and
+ * away from the model imports, so the card renderers can format without
+ * pulling Sequelize into a PNG.
+ */
+export function longDate(ymd) {
+  const m = typeof ymd === 'string' ? ymd.match(YMD_RE) && ymd.match(/^(\d{4})-(\d{2})-(\d{2})$/) : null;
+  if (!m) return '';
+  const month = MONTHS[Number(m[2]) - 1];
+  return month ? `${Number(m[3])} ${month} ${m[1]}` : '';
+}
+
+/** '2026-10-22' → '22 Oct 2026' — for narrow columns where the long month won't fit. */
+export function shortDate(ymd) {
+  const long = longDate(ymd);
+  if (!long) return '';
+  const [day, month, year] = long.split(' ');
+  return `${day} ${month.slice(0, 3)} ${year}`;
+}
+
 /**
  * EXCLUSIVE end-of-day instant for a YYYY-MM-DD in SGT: the first millisecond
  * of the NEXT day. An instant t falls on or before the day iff

--- a/backend/test/unit/drawPassRenderer.test.js
+++ b/backend/test/unit/drawPassRenderer.test.js
@@ -1,0 +1,112 @@
+/**
+ * Vault lucky-draw pass artwork — the two images of the draw journey.
+ *
+ * These are real satori→resvg renders (~150ms each), not mocks: the whole point
+ * of the module is that it produces a PNG on the Render box without a system
+ * font, and a mocked engine would prove nothing. What's asserted is the
+ * contract every sender depends on — a decodable PNG comes back, the QR-less
+ * state needs no qrContent, a bad colourway degrades instead of throwing, and a
+ * multiplier the mockup never showed doesn't blow the layout.
+ */
+import { renderDrawPassPng } from '../../src/services/redeemOps/drawPassRenderer.js';
+import { renderQrCardPng } from '../../src/services/redeemOps/qrCardRenderer.js';
+import { PASS_THEMES } from '../../src/utils/drawTheme.js';
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+const LINK = `https://redeem.sg/r/${'x'.repeat(43)}`;
+
+const base = {
+  qrContent: LINK,
+  multiplier: 10,
+  prize: 'iPhone 17 Pro 256GB',
+  firstName: 'Shawn',
+  deadlineLong: '30 September 2026',
+  drawDateLong: '22 October 2026',
+};
+
+/** A 1080×1080 PNG: magic bytes + the IHDR width/height big-endian at 16..24. */
+function expectSquarePng(buf, size = 1080) {
+  expect(buf.subarray(0, 4)).toEqual(PNG_MAGIC);
+  expect(buf.readUInt32BE(16)).toBe(size);
+  expect(buf.readUInt32BE(20)).toBe(size);
+  expect(buf.length).toBeGreaterThan(10_000);
+}
+
+describe.each(PASS_THEMES)('colourway %s', (theme) => {
+  test('renders both messages of the journey', async () => {
+    const pass = await renderDrawPassPng({ ...base, variant: 'pass', theme });
+    const boost = await renderDrawPassPng({ ...base, variant: 'boost', theme, qrContent: undefined });
+    expectSquarePng(pass);
+    expectSquarePng(boost);
+    // Same layout, different artwork — the meter+QR message must not be
+    // byte-identical to the QR-less receipt.
+    expect(pass.equals(boost)).toBe(false);
+  });
+});
+
+test('each colourway is actually a different image', async () => {
+  const renders = await Promise.all(
+    PASS_THEMES.map((theme) => renderDrawPassPng({ ...base, variant: 'boost', qrContent: undefined, theme }))
+  );
+  const digests = new Set(renders.map((b) => b.toString('base64').slice(0, 512)));
+  expect(digests.size).toBe(PASS_THEMES.length);
+});
+
+test('an unknown colourway falls back to titanium instead of throwing', async () => {
+  const bogus = await renderDrawPassPng({ ...base, variant: 'boost', qrContent: undefined, theme: 'chartreuse' });
+  const titanium = await renderDrawPassPng({ ...base, variant: 'boost', qrContent: undefined, theme: 'titanium' });
+  expect(bogus.equals(titanium)).toBe(true);
+});
+
+test('the boost receipt needs no QR; the entry pass insists on one', async () => {
+  await expect(renderDrawPassPng({ ...base, variant: 'boost', qrContent: undefined })).resolves.toBeInstanceOf(Buffer);
+  await expect(renderDrawPassPng({ ...base, variant: 'pass', qrContent: undefined })).rejects.toThrow(/qrContent/);
+});
+
+test('an unknown variant throws rather than guessing', async () => {
+  await expect(renderDrawPassPng({ ...base, variant: 'sideways' })).rejects.toThrow(/variant/);
+});
+
+// The mockup was drawn around "9×". A campaign may run any multiplier from 2 to
+// 100, and a fixed font-size would push "100×" off the card.
+test.each([2, 10, 100])('a ×%i multiplier still renders', async (multiplier) => {
+  const boost = await renderDrawPassPng({ ...base, variant: 'boost', qrContent: undefined, multiplier });
+  expectSquarePng(boost);
+});
+
+test('a missing draw date drops the stat rather than borrowing another date', async () => {
+  const withDate = await renderDrawPassPng({ ...base, variant: 'boost', qrContent: undefined });
+  const without = await renderDrawPassPng({ ...base, variant: 'boost', qrContent: undefined, drawDateLong: null });
+  expect(withDate.equals(without)).toBe(false);
+});
+
+describe('renderQrCardPng routing', () => {
+  const draw = { multiplier: 10, prize: 'iPhone 17 Pro', drawOn: '2026-10-22', passTheme: 'gold', boostClosesAt: '2026-09-30' };
+
+  test('a draw context routes to the Vault, not the Editorial frame', async () => {
+    const vault = await renderQrCardPng({ state: 'pass', qrContent: LINK, rewardName: 'Lucky draw entry', draw });
+    const editorial = await renderQrCardPng({ state: 'pass', qrContent: LINK, rewardName: 'Lucky draw entry' });
+    expectSquarePng(vault);
+    expectSquarePng(editorial);
+    expect(vault.equals(editorial)).toBe(false);
+    // The Vault is a dark, near-photographic frame; the Editorial one is flat
+    // cream. Compressed size is a crude but stable proxy for "different design".
+    expect(vault.length).toBeGreaterThan(editorial.length);
+  });
+
+  test('trial rewards are untouched by the draw work', async () => {
+    const voucher = await renderQrCardPng({ state: 'voucher', qrContent: 'tok', rewardName: 'Free coffee', partnerName: 'Cafe', shortCode: 'AB12' });
+    expectSquarePng(voucher);
+  });
+
+  // A boost card without draw context would render a partner-voucher frame
+  // celebrating a reward that does not exist. Senders catch this and ship
+  // without an image instead.
+  test('a boost card without draw context throws', async () => {
+    await expect(renderQrCardPng({ state: 'boost' })).rejects.toThrow(/draw context/);
+  });
+
+  test('an unknown state throws', async () => {
+    await expect(renderQrCardPng({ state: 'gift', qrContent: 'x' })).rejects.toThrow(/unknown card state/);
+  });
+});

--- a/backend/test/unit/drawPassTheme.test.js
+++ b/backend/test/unit/drawPassTheme.test.js
@@ -1,0 +1,96 @@
+/**
+ * The colourway contract, end to end: what an operator may store
+ * (utils/luckyDraw normalizer) → what the email palette resolves to
+ * (utils/drawTheme) → what drawLink hands the renderers.
+ *
+ * One enum drives the WhatsApp pass AND the confirmation email, so the campaign
+ * can never be titanium in the chat and gold in the inbox. The clamp matters
+ * for more than tidiness: `passTheme` reaches a palette lookup and a style
+ * attribute, so anything but the enum must be dropped at the door.
+ */
+import { normalizeLuckyDraw, applyLuckyDrawPolicy } from '../../src/utils/luckyDraw.js';
+import { emailPalette, resolvePassTheme, PASS_THEMES, DEFAULT_PASS_THEME } from '../../src/utils/drawTheme.js';
+import { makeDrawLink } from '../../src/services/redeemOps/drawLink.js';
+
+describe('normalizer', () => {
+  test.each(PASS_THEMES)('keeps the %s colourway', (theme) => {
+    expect(normalizeLuckyDraw({ enabled: true, passTheme: theme }).passTheme).toBe(theme);
+  });
+
+  test('is case-insensitive about what the operator typed', () => {
+    expect(normalizeLuckyDraw({ enabled: true, passTheme: '  Gold ' }).passTheme).toBe('gold');
+  });
+
+  test.each([
+    ['off-enum', 'chartreuse'],
+    ['style injection', 'red;background:url(http://evil)'],
+    ['non-string', 42],
+    ['empty', ''],
+  ])('drops a %s value entirely', (_label, value) => {
+    expect(normalizeLuckyDraw({ enabled: true, passTheme: value })).not.toHaveProperty('passTheme');
+  });
+
+  // Legacy rows must round-trip byte-identical: absent stays absent and the
+  // renderers apply the default, rather than the normalizer stamping one in.
+  test('never invents a colourway for a campaign that has none', () => {
+    expect(normalizeLuckyDraw({ enabled: true, prize: 'x' })).not.toHaveProperty('passTheme');
+  });
+
+  test('is admin-only like the rest of luckyDraw', () => {
+    const stored = { enabled: true, passTheme: 'gold' };
+    const incoming = { enabled: true, passTheme: 'emerald' };
+    expect(applyLuckyDrawPolicy({ incoming, stored, role: 'admin' }).passTheme).toBe('emerald');
+    expect(applyLuckyDrawPolicy({ incoming, stored, role: 'agent' }).passTheme).toBe('gold');
+  });
+});
+
+describe('palette', () => {
+  test.each(PASS_THEMES)('%s resolves a full set of solid tokens', (theme) => {
+    const p = emailPalette(theme);
+    expect(Object.keys(p).length).toBeGreaterThan(20);
+    // Outlook drops rgba() and gradients; every token must already be blended.
+    for (const [key, value] of Object.entries(p)) {
+      expect(`${key}=${value}`).toMatch(/=#[0-9a-f]{6}$/i);
+    }
+  });
+
+  test('colourways are actually different', () => {
+    const grounds = new Set(PASS_THEMES.map((t) => emailPalette(t).c_panelSolid));
+    expect(grounds.size).toBe(PASS_THEMES.length);
+  });
+
+  test.each([undefined, null, '', 'chartreuse', 42])('%p falls back to the default', (bad) => {
+    expect(resolvePassTheme(bad)).toBe(DEFAULT_PASS_THEME);
+    expect(emailPalette(bad)).toEqual(emailPalette(DEFAULT_PASS_THEME));
+  });
+});
+
+describe('drawLink carries the card facts', () => {
+  const campaignOf = (luckyDraw) => ({ id: 'c1', name: 'iPhone 17 Pro Lucky Draw', design_config: { luckyDraw } });
+  const link = makeDrawLink({ Activation: null, Campaign: null });
+
+  test('prize, draw day and colourway reach the renderers', () => {
+    const ctx = link.drawContextForCampaign(campaignOf({
+      enabled: true, prize: 'iPhone 17 Pro 256GB', multiplier: 10,
+      drawOn: '2026-10-22', boostClosesAt: '2026-09-30', passTheme: 'sapphire',
+    }));
+    expect(ctx).toMatchObject({
+      multiplier: 10, prize: 'iPhone 17 Pro 256GB', drawOn: '2026-10-22', passTheme: 'sapphire',
+    });
+  });
+
+  // The boost deadline is a promise about the SESSION, not about draw day —
+  // borrowing it for a "draw date" would invent a date we never committed to.
+  test('a draw with no drawOn reports none rather than borrowing the boost deadline', () => {
+    const ctx = link.drawContextForCampaign(campaignOf({
+      enabled: true, prize: 'x', multiplier: 10, boostClosesAt: '2026-09-30',
+    }));
+    expect(ctx.drawOn).toBeNull();
+    expect(ctx.boostClosesAt).toBe('2026-09-30');
+  });
+
+  test('a campaign with no colourway reports none (renderers default it)', () => {
+    const ctx = link.drawContextForCampaign(campaignOf({ enabled: true, prize: 'x', multiplier: 10 }));
+    expect(ctx.passTheme).toBeNull();
+  });
+});

--- a/backend/test/unit/leadConfirmationOnyx.test.js
+++ b/backend/test/unit/leadConfirmationOnyx.test.js
@@ -1,0 +1,125 @@
+/**
+ * The Onyx draw confirmation email — the inbox twin of the Vault WhatsApp pass.
+ *
+ * The render is pure substitution over a hand-authored, email-client-safe
+ * template, so what's worth asserting is exactly what substitution can get
+ * wrong: an unresolved placeholder shipping to a customer, a palette that
+ * doesn't follow the campaign, an unescaped prize name, and the honest-date
+ * rule for the third stat.
+ */
+import { renderLeadConfirmation } from '../../src/services/email-templates/leadConfirmation.js';
+import { emailPalette, PASS_THEMES } from '../../src/utils/drawTheme.js';
+
+const drawOf = (over = {}) => ({
+  enabled: true, prize: 'iPhone 17 Pro 256GB', multiplier: 10,
+  drawOn: '2026-10-22', closesAt: '2026-10-20', passTheme: 'titanium', ...over,
+});
+
+const render = (over = {}) => renderLeadConfirmation({
+  firstName: 'Shawn',
+  campaignName: 'iPhone 17 Pro Lucky Draw',
+  isMktrHost: false,
+  shareUrl: 'https://redeem.sg/share/abc123',
+  unsubscribeUrl: 'https://api.mktr.sg/api/unsubscribe?t=tok',
+  unsubscribeTextLine: 'Unsubscribe: https://api.mktr.sg/api/unsubscribe?t=tok',
+  luckyDraw: drawOf(),
+  ...over,
+});
+
+describe('substitution', () => {
+  test.each(PASS_THEMES)('%s leaves no placeholder behind', (passTheme) => {
+    const { html, text } = render({ luckyDraw: drawOf({ passTheme }) });
+    expect(html).not.toMatch(/\{\{\w+\}\}/);
+    expect(text).not.toMatch(/\{\{\w+\}\}/);
+  });
+
+  test('the trial-reward email is untouched by the draw redesign', () => {
+    const { html } = render({ luckyDraw: undefined });
+    expect(html).not.toMatch(/\{\{\w+\}\}/);
+    expect(html).toContain('RedeemSG');        // the Editorial letterhead
+    expect(html).not.toContain('YOU&rsquo;RE IN THE DRAW');
+  });
+});
+
+describe('colourway', () => {
+  test.each(PASS_THEMES)('%s paints the frame', (passTheme) => {
+    const { html } = render({ luckyDraw: drawOf({ passTheme }) });
+    const p = emailPalette(passTheme);
+    expect(html).toContain(p.c_panelSolid);
+    expect(html).toContain(p.c_metalSolid);
+    // Solid bgcolor attribute alongside the gradient — Outlook ignores the latter.
+    expect(html).toContain(`bgcolor="${p.c_panelSolid}"`);
+  });
+
+  test('two campaigns on different colourways do not render the same frame', () => {
+    expect(render({ luckyDraw: drawOf({ passTheme: 'gold' }) }).html)
+      .not.toEqual(render({ luckyDraw: drawOf({ passTheme: 'emerald' }) }).html);
+  });
+
+  test('an off-enum colourway still renders, in the default palette', () => {
+    const { html } = render({ luckyDraw: drawOf({ passTheme: 'chartreuse' }) });
+    expect(html).not.toMatch(/\{\{\w+\}\}/);
+    expect(html).toContain(emailPalette('titanium').c_panelSolid);
+  });
+});
+
+describe('the multiplier is the TOTAL, not the extra', () => {
+  test('the meter reads 1x now against Nx after the review', () => {
+    const { html } = render({ luckyDraw: drawOf({ multiplier: 10 }) });
+    expect(html).toContain('>1&times;<');
+    expect(html).toContain('10&times;');
+    expect(html).toContain('chances to win');
+    // "more chances" would promise 11 total on a x10 draw.
+    expect(html).not.toContain('more chances');
+  });
+
+  test('a campaign multiplier drives every mention', () => {
+    const { html, text } = render({ luckyDraw: drawOf({ multiplier: 5 }) });
+    expect(html).toContain('Want 5&times; the chances?');
+    expect(text).toContain('5x chances to win');
+  });
+});
+
+describe('the third stat follows the honest-date rule', () => {
+  test('a draw day is stated as the draw date', () => {
+    const { html, text } = render({ luckyDraw: drawOf({ drawOn: '2026-10-22' }) });
+    expect(html).toContain('DRAW DATE');
+    expect(html).toContain('22 Oct 2026');
+    expect(text).toContain('Draw date: 22 Oct 2026');
+  });
+
+  test('without a draw day it falls back to when entries close — never the boost deadline', () => {
+    const { html } = render({ luckyDraw: drawOf({ drawOn: undefined, closesAt: '2027-01-05', boostClosesAt: '2026-09-30' }) });
+    expect(html).toContain('ENTRIES CLOSE');
+    expect(html).toContain('5 Jan 2027');
+    expect(html).not.toContain('DRAW DATE');
+    expect(html).not.toContain('30 Sep 2026');
+  });
+
+  test('with neither date the cell disappears and the row rebalances', () => {
+    const { html } = render({ luckyDraw: drawOf({ drawOn: undefined, closesAt: undefined }) });
+    expect(html).not.toContain('DRAW DATE');
+    expect(html).not.toContain('ENTRIES CLOSE');
+    expect(html).toContain('width="50%"');
+    expect(html).not.toContain('width="33%"');
+  });
+});
+
+describe('escaping', () => {
+  test('an operator-authored prize cannot inject markup', () => {
+    const { html } = render({ luckyDraw: drawOf({ prize: '<script>alert(1)</script>' }) });
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  test('a campaign name with an apostrophe survives intact', () => {
+    const { html } = render({ campaignName: "Shawn's Draw" });
+    expect(html).toContain('Shawn&#39;s Draw');
+  });
+});
+
+test('the mktr.sg host gets its own letterhead', () => {
+  const { html } = render({ isMktrHost: true });
+  expect(html).toContain('new-mktr-wordmark-light.png');
+  expect(html).toContain('MKTR PTE. LTD. (UEN 202507548M)');
+});

--- a/src/components/campaigns/workspace/CampaignDetailsTab.jsx
+++ b/src/components/campaigns/workspace/CampaignDetailsTab.jsx
@@ -18,6 +18,17 @@ const toDateInput = (v) => {
 
 const MAX_PRIZE_ROWS = 8; // mirrors backend utils/luckyDraw.js
 
+// The four draw colourways (backend utils/drawTheme.js). One choice paints both
+// customer surfaces: the Vault WhatsApp pass and the Onyx confirmation email.
+// The swatch is that palette's hero-numeral tone over its ground, so the chip
+// looks like the thing it produces. The backend clamps to this enum regardless.
+const PASS_THEMES = [
+  { id: 'titanium', swatch: 'linear-gradient(140deg,#e6e9ee,#8b9199 70%,#14161a)' },
+  { id: 'gold', swatch: 'linear-gradient(140deg,#f2d590,#b6853a 70%,#1d1708)' },
+  { id: 'emerald', swatch: 'linear-gradient(140deg,#c2ecd2,#5ea07d 70%,#0c1a13)' },
+  { id: 'sapphire', swatch: 'linear-gradient(140deg,#c6d6f2,#6f89bb 70%,#0f1729)' },
+];
+
 const clampQty = (v) => {
   const n = Math.floor(Number(v));
   if (!Number.isFinite(n)) return 1;
@@ -57,6 +68,7 @@ export default function CampaignDetailsTab({ initial, type, draw = false, isEdit
     drawClosesAt: '',
     drawBoostClosesAt: '',
     drawMultiplier: 10,
+    drawPassTheme: 'titanium',
   });
   const set = (k, v) => setForm((f) => ({ ...f, [k]: v }));
 
@@ -146,6 +158,7 @@ export default function CampaignDetailsTab({ initial, type, draw = false, isEdit
               closesAt: form.drawClosesAt,
               boostClosesAt: form.drawBoostClosesAt || form.drawClosesAt,
               multiplier: Number(form.drawMultiplier) || 10,
+              passTheme: form.drawPassTheme,
             },
             // Starter T&C generated from these details; the server pins it as
             // draw_terms_versions v1. Edit in the designer before launch —
@@ -309,10 +322,32 @@ export default function CampaignDetailsTab({ initial, type, draw = false, isEdit
                 <p className="text-xs text-muted-foreground">Empty = same as close date.</p>
               </div>
             </div>
-            <div className="space-y-2 max-w-[160px]">
-              <Label htmlFor="draw_multiplier">Session multiplier</Label>
-              <Input id="draw_multiplier" type="number" min={2} max={100} value={form.drawMultiplier} onChange={(e) => set('drawMultiplier', e.target.value)} />
-              <p className="text-xs text-muted-foreground">A completed, consultant-scanned review session multiplies the entry.</p>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2 max-w-[160px]">
+                <Label htmlFor="draw_multiplier">Session multiplier</Label>
+                <Input id="draw_multiplier" type="number" min={2} max={100} value={form.drawMultiplier} onChange={(e) => set('drawMultiplier', e.target.value)} />
+                <p className="text-xs text-muted-foreground">A completed, consultant-scanned review session multiplies the entry.</p>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="draw_theme">Pass colourway</Label>
+                <div className="flex flex-wrap gap-2" id="draw_theme">
+                  {PASS_THEMES.map((t) => (
+                    <button
+                      key={t.id}
+                      type="button"
+                      aria-pressed={form.drawPassTheme === t.id}
+                      onClick={() => set('drawPassTheme', t.id)}
+                      className={`flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs capitalize transition ${
+                        form.drawPassTheme === t.id ? 'border-foreground' : 'border-input text-muted-foreground hover:border-foreground/40'
+                      }`}
+                    >
+                      <span className="h-3.5 w-3.5 rounded-full border border-black/20" style={{ background: t.swatch }} />
+                      {t.id}
+                    </button>
+                  ))}
+                </div>
+                <p className="text-xs text-muted-foreground">Colours the entry pass on WhatsApp and the confirmation email. Pick what suits the prize.</p>
+              </div>
             </div>
             {form.drawClosesAt ? (
               <p className="text-xs text-muted-foreground">

--- a/src/components/campaigns/workspace/__tests__/CampaignDetailsTab.test.jsx
+++ b/src/components/campaigns/workspace/__tests__/CampaignDetailsTab.test.jsx
@@ -122,6 +122,7 @@ describe('CampaignDetailsTab — lucky-draw create flow', () => {
       closesAt: '2026-08-31',
       boostClosesAt: '2026-08-31',
       multiplier: 10,
+      passTheme: 'titanium',
     });
     expect(payload.design_config.termsContent).toContain('iPhone Lucky Draw');
     expect(payload.design_config.termsContent).toContain('iPhone 17 Pro');
@@ -131,6 +132,17 @@ describe('CampaignDetailsTab — lucky-draw create flow', () => {
     expect(payload.design_config.termsContent).toContain('never ask you to pay a fee');
     // end_date empty → aligned to the draw close
     expect(payload.end_date).toBe(new Date('2026-08-31').toISOString());
+  });
+
+  it('arms the chosen pass colourway — one choice paints the WhatsApp pass and the email', () => {
+    const onSubmit = vi.fn();
+    render(
+      <CampaignDetailsTab initial={null} type="lead_generation" draw isEdit={false} saving={false} onSubmit={onSubmit} />
+    );
+    fillBasics();
+    fireEvent.click(screen.getByRole('button', { name: /gold/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Create draft/i }));
+    expect(onSubmit.mock.calls[0][0].design_config.luckyDraw.passTheme).toBe('gold');
   });
 
   it('the seeded eligibility clause states THIS campaign age floor, not the template default', () => {


### PR DESCRIPTION
The draw journey is two messages, and until now they were three designs: a cream
Editorial pass on WhatsApp, a terracotta Editorial boost receipt, and a cream
confirmation email. This ports the claude.ai artwork so a draw entrant sees
**one thing twice**.

| | Before appointment | After the consultant |
|---|---|---|
| **WhatsApp** | Vault pass — `1× → N×` meter over the scannable QR | Vault receipt — giant `N×`, no QR |
| **Email** | Onyx confirmation — same meter, same standing row | boost receipt now carries the same card inline |

Four colourways (titanium / gold / emerald / sapphire) selected once per campaign.

## What changed

- **`drawPassRenderer` (new)** — the dark Vault 1080×1080 card. The hero numeral
  auto-fits: the mockup was drawn around `9×`, and a fixed font-size pushes
  `100×` off the card. The QR well is 496px over 37 modules (~11.5px/module,
  ~5-module quiet zone) — deliberately larger than the artwork's 40cq, because
  this gets scanned off a phone screen at an appointment.
- **`qrCardRenderer`** routes to the Vault whenever a draw context is present and
  keeps the Editorial frame for trial rewards, so senders keep one entry point.
  A `boost` card with no draw context now throws rather than rendering a
  terracotta card celebrating a partner voucher that does not exist.
- **`confirmation-email-draw.html` rebuilt as Onyx** — authored as email-safe
  **tables** (the canvas file is flex/grid, which Outlook drops) with solid hex
  tokens (it drops rgba and gradients too). The hero numeral is deliberately
  *not* a clipped gradient: a client that keeps `-webkit-text-fill-color` while
  stripping `background-image` would render the whole promise invisible.
- **`utils/drawTheme`** — the colourway enum + email palette. One
  `luckyDraw.passTheme` drives both surfaces, clamped in the normalizer so
  campaign JSON never reaches a palette lookup or a style attribute. Absent stays
  absent, so legacy rows round-trip byte-identical.
- **`drawCtx` carries prize / drawOn / passTheme.** `drawOn` is the only honest
  draw date and is never defaulted from `boostClosesAt` (that promises a session,
  not a draw day). Without one the email falls back to when **entries close**,
  then drops the cell entirely rather than inventing a date.
- **`renderLeadConfirmation` extracted IO-free**, so the email render is
  unit-testable and previewable without a DB (`scripts/preview-draw-*.js`).

## The ×N question

`×N` is the **total** after the session (1 chance × N), not N extra. "more
chances" is gone from every surface — on a ×10 draw it would promise 11.

## Testing

- 59 new tests: artwork (real satori→resvg renders across all four colourways
  and both variants), the enum contract (normalizer clamp → palette → drawLink),
  and the email render (substitution, escaping, the honest-date rule).
- 230 green across every suite that touches a changed module.
- `emailService`'s dev-fallback failure is **inherited** — it fails identically
  on a clean tree.
- Frontend build + `CampaignDetailsTab` suite green.

## Deploy note

Carried over from the first commit: the `draw_boost_receipt` template was edited
on the WABA to add its IMAGE header, and Meta reclassified it UTILITY→MARKETING
on edit. **Deploy after that edit is approved** — the live approved version is
body-only until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgWRx53DQBvoHAdi3pViGx