### PR TITLE
feat(draw): pick the pass colourway on an existing draw, not just at create

### DIFF
--- a/backend/src/services/campaignService.js
+++ b/backend/src/services/campaignService.js
@@ -8,6 +8,7 @@ import { normalizeCustomerHostChoice } from '../utils/customerHost.js';
 import { sgtDayEndExclusiveMs } from '../utils/sgtTime.js';
 import { applyFeaturedDropPolicy } from '../utils/featuredDrop.js';
 import { applyLuckyDrawPolicy, normalizeLuckyDraw, totalPrizeQuantity } from '../utils/luckyDraw.js';
+import { PASS_THEMES } from '../utils/drawTheme.js';
 import { normalizeMarketplaceContent, applyMarketplacePolicy } from '../utils/marketplaceContent.js';
 import { checkDrawConsistency } from '../utils/drawConsistency.js';
 import {
@@ -726,6 +727,27 @@ export async function updateCampaign(id, body, req) {
       const rail = await ensureRail({ campaign, designConfig: nextDoc, user: req.user });
       const stamped = stampRailActivationId(nextDoc, rail.activationId);
       if (stamped !== nextDoc) updateData.design_config = stamped;
+    }
+  }
+
+  // Draw pass colourway — a NARROW, top-level field rather than a design_config
+  // write, for two reasons. A Studio-saved (v2) campaign rejects an untagged
+  // design_config outright (the conflict guard above), and passTheme is pure
+  // display: routing it through the doc would make a palette change look like a
+  // draw-fact edit and re-run the promise gate on a live campaign. Applied here,
+  // AFTER every draw gate, so it can never block or alter a save.
+  if (body.drawPassTheme !== undefined && req.user?.role === 'admin') {
+    const nextDoc = updateData.design_config !== undefined ? updateData.design_config : campaign.design_config;
+    // Spread the RAW stored draw (conservative — it is already normalized by the
+    // save path) but decide on the normalized copy, so a hand-written row can't
+    // fake `enabled`.
+    const ld = getStoredLuckyDraw(nextDoc);
+    if (drawEnabledIn(nextDoc)) {
+      const theme = String(body.drawPassTheme || '').trim().toLowerCase();
+      if (!PASS_THEMES.includes(theme)) {
+        throw new AppError(`drawPassTheme must be one of: ${PASS_THEMES.join(', ')}.`, 422);
+      }
+      updateData.design_config = { ...nextDoc, luckyDraw: { ...ld, passTheme: theme } };
     }
   }
 

--- a/backend/test/unit/campaignService.test.js
+++ b/backend/test/unit/campaignService.test.js
@@ -547,6 +547,58 @@ describe('campaignService (unit)', () => {
       expect(Device.findAll).toHaveBeenCalled();
     });
 
+    // The draw pass colourway is a NARROW top-level field, deliberately not a
+    // design_config write: a Studio-saved (v2) campaign rejects an untagged
+    // design_config, and routing a pure-display change through the doc would
+    // make it look like a draw-fact edit on a live campaign.
+    describe('drawPassTheme', () => {
+      const drawCampaign = (luckyDraw) => makeCampaignInstance({
+        is_active: false,
+        design_config: { luckyDraw, page: { hero: 'keep me' } },
+      });
+      const storedDraw = { enabled: true, prize: 'iPhone 17 Pro', multiplier: 10, closesAt: '2026-09-30', activationId: 'a1' };
+
+      it('merges into the stored draw without touching the rest of the design', async () => {
+        const inst = drawCampaign(storedDraw);
+        Campaign.findOne.mockResolvedValue(inst);
+
+        await campaignService.updateCampaign('camp-1', { drawPassTheme: 'gold' }, makeReq());
+
+        const saved = inst.update.mock.calls[0][0].design_config;
+        expect(saved.luckyDraw.passTheme).toBe('gold');
+        // Everything else survives — prize, multiplier, the rail stamp, the page.
+        expect(saved.luckyDraw).toMatchObject(storedDraw);
+        expect(saved.page).toEqual({ hero: 'keep me' });
+      });
+
+      it('rejects an off-enum colourway rather than writing it', async () => {
+        const inst = drawCampaign(storedDraw);
+        Campaign.findOne.mockResolvedValue(inst);
+
+        await expect(campaignService.updateCampaign('camp-1', { drawPassTheme: 'chartreuse' }, makeReq()))
+          .rejects.toThrow(/drawPassTheme must be one of/);
+        expect(inst.update).not.toHaveBeenCalled();
+      });
+
+      it('is admin-only, like every other luckyDraw change', async () => {
+        const inst = drawCampaign(storedDraw);
+        Campaign.findOne.mockResolvedValue(inst);
+
+        await campaignService.updateCampaign('camp-1', { drawPassTheme: 'gold' }, makeReq({ user: { id: 'u2', role: 'agent' } }));
+
+        expect(inst.update.mock.calls[0][0].design_config).toBeUndefined();
+      });
+
+      it('is a no-op on a campaign that is not a draw', async () => {
+        const inst = makeCampaignInstance({ design_config: { page: { hero: 'x' } } });
+        Campaign.findOne.mockResolvedValue(inst);
+
+        await campaignService.updateCampaign('camp-1', { drawPassTheme: 'gold' }, makeReq());
+
+        expect(inst.update.mock.calls[0][0].design_config).toBeUndefined();
+      });
+    });
+
     it('syncs agent assignments when assigned_agents provided', async () => {
       Campaign.findOne.mockResolvedValue(makeCampaignInstance());
 

--- a/src/components/campaigns/workspace/CampaignDetailsTab.jsx
+++ b/src/components/campaigns/workspace/CampaignDetailsTab.jsx
@@ -49,7 +49,7 @@ const prizeSummary = (rows) =>
  * (enforceLeadQuota) and per-campaign tracking pixels. Controlled form; the
  * workspace owns create-vs-update. PHV tablet media stays in the classic editor.
  */
-export default function CampaignDetailsTab({ initial, type, draw = false, isEdit, saving, designing = false, onSubmit }) {
+export default function CampaignDetailsTab({ initial, type, draw = false, drawEdit = false, isEdit, saving, designing = false, onSubmit }) {
   const campaignType = initial?.type || type || 'lead_generation';
   const [form, setForm] = useState({
     name: initial?.name || '',
@@ -68,7 +68,9 @@ export default function CampaignDetailsTab({ initial, type, draw = false, isEdit
     drawClosesAt: '',
     drawBoostClosesAt: '',
     drawMultiplier: 10,
-    drawPassTheme: 'titanium',
+    // On edit this is the only draw field that is safe to change on a LIVE draw
+    // — pure display, no bearing on entries, dates or the accepted T&Cs.
+    drawPassTheme: initial?.design_config?.luckyDraw?.passTheme || 'titanium',
   });
   const set = (k, v) => setForm((f) => ({ ...f, [k]: v }));
 
@@ -131,6 +133,31 @@ export default function CampaignDetailsTab({ initial, type, draw = false, isEdit
   const removePrizeRow = (i) =>
     setForm((f) => ({ ...f, drawPrizes: f.drawPrizes.filter((_, idx) => idx !== i) }));
 
+  // Shared by the create block and the edit-only card below — one control, so
+  // the two paths can never drift on what the colourway means.
+  const themePicker = (
+    <div className="space-y-2">
+      <Label htmlFor="draw_theme">Pass colourway</Label>
+      <div className="flex flex-wrap gap-2" id="draw_theme">
+        {PASS_THEMES.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            aria-pressed={form.drawPassTheme === t.id}
+            onClick={() => set('drawPassTheme', t.id)}
+            className={`flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs capitalize transition ${
+              form.drawPassTheme === t.id ? 'border-foreground' : 'border-input text-muted-foreground hover:border-foreground/40'
+            }`}
+          >
+            <span className="h-3.5 w-3.5 rounded-full border border-black/20" style={{ background: t.swatch }} />
+            {t.id}
+          </button>
+        ))}
+      </div>
+      <p className="text-xs text-muted-foreground">Colours the entry pass on WhatsApp and the confirmation email. Pick what suits the prize.</p>
+    </div>
+  );
+
   const prizeRows = cleanPrizeRows(form.drawPrizes);
   const totalPrizeQty = prizeRows.reduce((sum, p) => sum + p.qty, 0);
 
@@ -185,6 +212,10 @@ export default function CampaignDetailsTab({ initial, type, draw = false, isEdit
     // page after create — it is transient input, never persisted as a field.
     onSubmit({
       ...drawConfig,
+      // Narrow top-level field on edit, NOT a design_config write: a
+      // Studio-saved campaign rejects an untagged design_config outright, and
+      // the server merges this into the stored luckyDraw after every draw gate.
+      ...(drawEdit ? { drawPassTheme: form.drawPassTheme } : {}),
       name: form.name.trim(),
       type: campaignType,
       min_age: Number(form.min_age) || 18,
@@ -328,26 +359,7 @@ export default function CampaignDetailsTab({ initial, type, draw = false, isEdit
                 <Input id="draw_multiplier" type="number" min={2} max={100} value={form.drawMultiplier} onChange={(e) => set('drawMultiplier', e.target.value)} />
                 <p className="text-xs text-muted-foreground">A completed, consultant-scanned review session multiplies the entry.</p>
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="draw_theme">Pass colourway</Label>
-                <div className="flex flex-wrap gap-2" id="draw_theme">
-                  {PASS_THEMES.map((t) => (
-                    <button
-                      key={t.id}
-                      type="button"
-                      aria-pressed={form.drawPassTheme === t.id}
-                      onClick={() => set('drawPassTheme', t.id)}
-                      className={`flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs capitalize transition ${
-                        form.drawPassTheme === t.id ? 'border-foreground' : 'border-input text-muted-foreground hover:border-foreground/40'
-                      }`}
-                    >
-                      <span className="h-3.5 w-3.5 rounded-full border border-black/20" style={{ background: t.swatch }} />
-                      {t.id}
-                    </button>
-                  ))}
-                </div>
-                <p className="text-xs text-muted-foreground">Colours the entry pass on WhatsApp and the confirmation email. Pick what suits the prize.</p>
-              </div>
+              {themePicker}
             </div>
             {form.drawClosesAt ? (
               <p className="text-xs text-muted-foreground">
@@ -355,6 +367,20 @@ export default function CampaignDetailsTab({ initial, type, draw = false, isEdit
               </p>
             ) : null}
           </CardContent>
+        </Card>
+      )}
+
+      {/* Editing a LIVE draw: the colourway is the ONLY draw setting exposed
+          here. Prizes, dates and the multiplier are promises entrants already
+          accepted in the pinned T&Cs — changing those is a deliberate ops act,
+          not a details-tab edit. This one is pure display. */}
+      {drawEdit && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Draw pass &amp; email</CardTitle>
+            <CardDescription>How this draw&apos;s entry pass and confirmation email look to entrants.</CardDescription>
+          </CardHeader>
+          <CardContent>{themePicker}</CardContent>
         </Card>
       )}
 

--- a/src/components/campaigns/workspace/__tests__/CampaignDetailsTab.test.jsx
+++ b/src/components/campaigns/workspace/__tests__/CampaignDetailsTab.test.jsx
@@ -134,6 +134,37 @@ describe('CampaignDetailsTab — lucky-draw create flow', () => {
     expect(payload.end_date).toBe(new Date('2026-08-31').toISOString());
   });
 
+  // Editing a live draw: the colourway is the only draw setting exposed, and it
+  // rides as a narrow top-level field (a design_config write would 409 against a
+  // Studio-saved campaign).
+  it('offers the colourway when editing an existing draw, seeded from the stored theme', () => {
+    const onSubmit = vi.fn();
+    render(
+      <CampaignDetailsTab
+        initial={{ name: 'iPhone 17 Pro Lucky Draw', design_config: { luckyDraw: { enabled: true, passTheme: 'gold' } } }}
+        type="lead_generation"
+        drawEdit
+        isEdit
+        saving={false}
+        onSubmit={onSubmit}
+      />
+    );
+    expect(screen.getByRole('button', { name: /gold/i })).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(screen.getByRole('button', { name: /sapphire/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Save details/i }));
+    const payload = onSubmit.mock.calls[0][0];
+    expect(payload.drawPassTheme).toBe('sapphire');
+    // Never a design_config write on this path.
+    expect(payload.design_config).toBeUndefined();
+  });
+
+  it('does not offer the colourway on a non-draw campaign', () => {
+    render(
+      <CampaignDetailsTab initial={{ name: 'Trial reward' }} type="lead_generation" isEdit saving={false} onSubmit={vi.fn()} />
+    );
+    expect(screen.queryByText(/Pass colourway/i)).toBeNull();
+  });
+
   it('arms the chosen pass colourway — one choice paints the WhatsApp pass and the email', () => {
     const onSubmit = vi.fn();
     render(

--- a/src/pages/AdminCampaignWorkspace.jsx
+++ b/src/pages/AdminCampaignWorkspace.jsx
@@ -251,6 +251,7 @@ export default function AdminCampaignWorkspace() {
               initial={isCreate ? null : campaign}
               type={typeParam}
               draw={isDrawCreate}
+              drawEdit={!isCreate && campaign?.design_config?.luckyDraw?.enabled === true}
               isEdit={!isCreate}
               saving={savingDetails}
               designing={designingPage}


### PR DESCRIPTION
The colourway shipped in #263 on the **create form only** — the draw settings
block is gated on `isDrawCreate`, so every existing campaign (i.e. every live
draw) had no way to reach it. Opening the live iPhone draw's Details tab shows
no draw section at all.

## What this exposes

Exactly **one** draw setting on edit: the colourway. Prizes, dates and the
multiplier stay create-only on purpose — those are promises entrants already
accepted in the pinned T&Cs, and changing them is a deliberate ops act, not a
details-tab edit. The colourway is pure display; no draw mechanic reads it.

## Why a narrow field instead of a design_config write

A `design_config` write from this tab is wrong twice over:

1. A **Studio-saved (v2)** campaign rejects an untagged doc outright with
   `DESIGN_CONFIG_VERSION_CONFLICT` — and all 12 campaigns are on v2.
2. Routing a display-only change through the doc would make it register as a
   **draw-fact edit** (`factsChanged`) and re-run the promise-consistency gate
   on a live campaign.

So it rides as a top-level `drawPassTheme`, merged into the stored `luckyDraw`
on the server **after every draw gate** — it can never block or alter a save.
Admin-only, like every other `luckyDraw` change, and clamped to the enum.

## Testing

Backend (hermetic, mocked models):
- merges into the stored draw while preserving prize, multiplier, the rail
  `activationId` **and** the rest of `design_config` (the page)
- off-enum → 422, with no write at all
- non-admin → no-op; non-draw campaign → no-op

Frontend:
- the edit card seeds from the stored theme, submits `drawPassTheme`, and never
  sends `design_config`
- absent on non-draw campaigns

152 green across the affected backend suites; 25 green on the tab. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgWRx53DQBvoHAdi3pViGx