### PR TITLE
fix(draw): declare drawPassTheme in the campaignUpdate schema

### DIFF
--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -136,7 +136,11 @@ export const schemas = {
     slug: Joi.string().max(80).optional().allow(null, ''),
     // PR 5 rollout escape hatch: admin-only explicit v1-snapshot restore over a
     // stored v2 doc (service enforces role + logs; see the rollout runbook).
-    confirmDesignRollback: Joi.boolean().optional()
+    confirmDesignRollback: Joi.boolean().optional(),
+    // Draw pass colourway — a narrow top-level field rather than a design_config
+    // write (a Studio-saved doc rejects an untagged one, and a display change
+    // must not read as a draw-fact edit). Service enforces admin + the enum.
+    drawPassTheme: Joi.string().max(16).optional()
   }).min(1),
 
   // Car schemas

--- a/backend/test/validation.test.js
+++ b/backend/test/validation.test.js
@@ -76,6 +76,14 @@ describe('schemas.campaignUpdate', () => {
     expect(ok).toBe(true);
   });
 
+  // The schema rejects unknown keys, so every new top-level field the UI sends
+  // has to be declared here too — a service-side implementation alone gets a
+  // 400 at the door. (drawPassTheme shipped without this and did exactly that.)
+  it('accepts the draw pass colourway', () => {
+    const { ok } = valid(schemas.campaignUpdate, { drawPassTheme: 'gold' });
+    expect(ok).toBe(true);
+  });
+
   it('rejects empty update body (.min(1))', () => {
     const { ok } = valid(schemas.campaignUpdate, {});
     expect(ok).toBe(false);


### PR DESCRIPTION
Saving the colourway on an existing draw 400'd at the door:

> Validation Error: "drawPassTheme" is not allowed

The `PUT /api/campaigns/:id` route runs Joi with unknown-key rejection, so a
field implemented only in the service never reaches it. #264 added the
service-side merge and the UI control but not the schema entry — each layer
looks correct in isolation, which is exactly why this slipped.

Adds the field (the service still owns admin-only + the enum clamp) plus a
schema test, and I verified every field the Details form sends is now declared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgWRx53DQBvoHAdi3pViGx