### PR TITLE
feat(screening): honor "call me back later" — callback-aware retries + attempt evidence

### DIFF
--- a/backend/scripts/submit-wa-marketing-templates.mjs
+++ b/backend/scripts/submit-wa-marketing-templates.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
- * Submit the cohort-push MARKETING template pack to the Redeem WABA
- * (tracker item "watemplates"; pack doc: docs/plans/wa-marketing-template-pack.md).
+ * Submit the MARKETING template packs to the Redeem WABA — the cohort-push pack
+ * (tracker item "watemplates"; pack doc: docs/plans/wa-marketing-template-pack.md)
+ * plus the screening-callback opt-in (docs/plans/retell-screening-calls.md).
  *
  * The Cloud API creds live ONLY on Render (mktr-backend-jo6r → Environment tab),
  * so run this with the token pasted inline — it is never printed — or from the
@@ -10,13 +11,23 @@
  *   WHATSAPP_TOKEN=…  node backend/scripts/submit-wa-marketing-templates.mjs
  *
  * Modes:
- *   (default)      idempotent submit of all 6 templates (3 text-header + 3
- *                  image-header variants) — reads existing templates first,
- *                  POSTs only the missing ones, then prints a status table
- *   --status       read-only status poll (use while waiting on Meta review)
- *   --dry          print the exact JSON payloads, no network, no token needed
- *   --text-only    submit/consider only the text-header set
- *   --images-only  submit/consider only the image-header set
+ *   (default)        idempotent submit of all 7 templates (3 text-header + 3
+ *                    image-header variants + the screening callback) — reads
+ *                    existing templates first, POSTs only the missing ones,
+ *                    then prints a status table
+ *   --status         read-only status poll (use while waiting on Meta review)
+ *   --dry            print the exact JSON payloads, no network, no token needed
+ *   --text-only      submit/consider only the text-header set
+ *   --images-only    submit/consider only the image-header set
+ *   --callback-only  submit/consider only draw_callback_optin
+ *   --token-stdin    read the token from stdin instead of WHATSAPP_TOKEN, so it
+ *                    never lands in the command line or shell history:
+ *                      pbpaste | node …/submit-wa-marketing-templates.mjs --token-stdin
+ *   --whoami         print the token's app/type/scopes and the WABAs reachable
+ *                    from it — first stop when WABA resolution fails
+ *   --business <id>  resolve the WABA through this Business (system-user tokens
+ *                    carry a business id, not a WABA id)
+ *   --waba <id>      skip resolution entirely
  *   --sample <p>   sample image for the image-header review examples
  *                  (default: backend/scripts/assets/wa-marketing-sample.png)
  *
@@ -153,6 +164,52 @@ export const TEMPLATES = [
   },
 ];
 
+/**
+ * Screening-callback opt-in (2026-07-25) — the WhatsApp leg of the AI screening
+ * gate: when the call could not reach a verdict (no answer, or "call me back
+ * later"), messaging beats a third dial. The URL button is the consent: tapping
+ * it is the person ASKING to be called, which is the only thing that makes the
+ * ring-back welcome rather than pestering.
+ *
+ * Copy contract: the boost is earned when the consultant RECORDS the completed
+ * session (src/lib/drawCopy.js DRAW_RECORD_PHRASE) and ×N is the TOTAL, not N
+ * extra — the same promise the campaign page, the Vault pass and the boost
+ * receipt make. Do not reword to "N more chances" here; that is the phone
+ * script's register, and the two must not drift into different promises.
+ *
+ * NOT SENDABLE YET: the `/callback` landing page and its consent-capture
+ * endpoint do not exist, and whatsappService must call this one with
+ * purpose:'marketing' (its sends are transactional today). Approval first,
+ * wiring second.
+ */
+export const CALLBACK_TEMPLATES = [
+  {
+    name: 'draw_callback_optin',
+    language: LANGUAGE,
+    category: 'MARKETING',
+    allow_category_change: true,
+    components: [
+      { type: 'HEADER', format: 'TEXT', text: 'About your lucky draw entry' },
+      {
+        type: 'BODY',
+        text:
+          "Hi {{1}}, it's the Redeem draw team about the {{2}} — sorry we missed you on the phone!\n\nYour entry is in with 1 chance. Meet one of our licensed financial consultants for a short, no-obligation session, and when your consultant records your completed session, your 1 entry becomes {{3}} — that's ×{{3}} chances at {{4}}.\n\nTap below and we'll ring you to arrange it, at a time that suits you.",
+        example: {
+          body_text: [['Shawn', 'iPhone 17 Pro Lucky Draw', '10', 'an iPhone 17 Pro']],
+        },
+      },
+      { type: 'FOOTER', text: FOOTER },
+      {
+        type: 'BUTTONS',
+        buttons: [
+          cta('Yes, call me', 'callback?t=8f3c1d9a2b&utm_source=wa_screening'),
+          STOP_BUTTON,
+        ],
+      },
+    ],
+  },
+];
+
 // Image-header twins: footer/buttons unchanged, the text header becomes an
 // IMAGE header whose content is a send-time parameter ({link} or {id}), and
 // the body opens with a bold headline line — the text header carried the
@@ -210,21 +267,64 @@ async function inspectToken(token) {
   return debugTokenCache;
 }
 
-/**
- * WABA id: env override → debug_token granular scopes. With several WABAs on
- * the token, WHATSAPP_PHONE_NUMBER_ID picks the one that owns our sender.
- */
-async function resolveWabaId(token) {
-  if (process.env.WHATSAPP_WABA_ID) return process.env.WHATSAPP_WABA_ID;
-  const dbg = await inspectToken(token);
-  const scopes = dbg?.data?.granular_scopes || [];
-  const ids = [
+function argValue(flag) {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 && process.argv[i + 1] && !process.argv[i + 1].startsWith('--') ? process.argv[i + 1] : null;
+}
+
+function targetIdsFor(dbg, scopeNames) {
+  return [
     ...new Set(
-      scopes
-        .filter((s) => ['whatsapp_business_management', 'whatsapp_business_messaging'].includes(s.scope))
+      (dbg?.data?.granular_scopes || [])
+        .filter((s) => scopeNames.includes(s.scope))
         .flatMap((s) => s.target_ids || []),
     ),
   ];
+}
+
+/** WABAs a Business owns or is a client of (needs business_management). */
+async function wabasOfBusiness(businessId, token) {
+  const edges = ['owned_whatsapp_business_accounts', 'client_whatsapp_business_accounts'];
+  const found = [];
+  for (const edge of edges) {
+    const json = await graphGet(`/${businessId}/${edge}?fields=id,name&limit=50`, token).catch(() => null);
+    for (const w of json?.data || []) found.push(w);
+  }
+  return found;
+}
+
+/**
+ * The Redeem sender WABA. An asset id, not a secret — the same value persisted
+ * on Render as WHATSAPP_WABA_ID (docs/plans/draw-boost-rail-auto-provision.md).
+ * Needed as a local fallback because the prod system-user token's granular
+ * scopes carry NO target ids (verified 2026-07-25 via --whoami), so nothing can
+ * be enumerated from the token alone. The end-of-run sanity check (reward_pass /
+ * reward_voucher present) still proves every submission landed on this WABA.
+ */
+const REDEEM_WABA_ID = '1912683432731970';
+
+/**
+ * WABA id: env/flag override → debug_token granular scopes → the Business's
+ * owned/client WABAs → the known Redeem WABA. With several candidates,
+ * WHATSAPP_PHONE_NUMBER_ID picks the one that owns our sender.
+ */
+async function resolveWabaId(token) {
+  const override = process.env.WHATSAPP_WABA_ID || argValue('--waba');
+  if (override) return override;
+
+  const dbg = await inspectToken(token);
+  let ids = targetIdsFor(dbg, ['whatsapp_business_management', 'whatsapp_business_messaging']);
+
+  if (ids.length === 0) {
+    const businessIds = [argValue('--business'), ...targetIdsFor(dbg, ['business_management'])].filter(Boolean);
+    const wabas = [];
+    for (const bizId of [...new Set(businessIds)]) {
+      for (const w of await wabasOfBusiness(bizId, token)) wabas.push(w);
+    }
+    if (wabas.length) console.log(`  WABAs via business: ${wabas.map((w) => `${w.name || '?'} (${w.id})`).join(', ')}`);
+    ids = [...new Set(wabas.map((w) => w.id))];
+  }
+
   if (ids.length === 1) return ids[0];
   const phoneId = process.env.WHATSAPP_PHONE_NUMBER_ID;
   if (ids.length > 1 && phoneId) {
@@ -233,11 +333,37 @@ async function resolveWabaId(token) {
       if (phones?.data?.some((p) => p.id === phoneId)) return id;
     }
   }
-  throw new Error(
-    ids.length
-      ? `Token spans ${ids.length} WABAs (${ids.join(', ')}) — set WHATSAPP_WABA_ID or WHATSAPP_PHONE_NUMBER_ID.`
-      : 'Could not auto-resolve the WABA from the token — set WHATSAPP_WABA_ID (WhatsApp Manager URL shows it as asset_id).',
-  );
+  if (ids.length > 1) {
+    throw new Error(`Token spans ${ids.length} WABAs (${ids.join(', ')}) — pass --waba <id> or set WHATSAPP_PHONE_NUMBER_ID.`);
+  }
+  // Nothing enumerable from the token — fall back to the known Redeem WABA,
+  // but PROVE it first (a token for some other WABA must fail loudly here,
+  // not submit templates into the wrong account).
+  const probe = await graphGet(`/${REDEEM_WABA_ID}?fields=id,name`, token).catch((err) => {
+    throw new Error(
+      `Could not auto-resolve the WABA, and the token cannot read the known Redeem WABA ${REDEEM_WABA_ID} `
+        + `(${err?.message || err}) — pass --waba <id> (WhatsApp Manager URL shows it as asset_id), or run --whoami.`,
+    );
+  });
+  console.log(`  WABA auto-resolution found nothing on the token — using the known Redeem WABA "${probe.name || '?'}" (${probe.id})`);
+  return probe.id;
+}
+
+/** Token diagnostic: what identity/scopes/assets does this token actually carry? */
+async function whoami(token) {
+  const dbg = await inspectToken(token);
+  const d = dbg?.data || {};
+  console.log(`app_id       ${d.app_id || '—'}`);
+  console.log(`type         ${d.type || '—'}${d.expires_at ? ` (expires ${new Date(d.expires_at * 1000).toISOString()})` : ' (no expiry)'}`);
+  console.log(`scopes       ${(d.scopes || []).join(', ') || '—'}`);
+  for (const s of d.granular_scopes || []) {
+    console.log(`  ${s.scope.padEnd(32)} ${(s.target_ids || []).join(', ') || '(no target ids)'}`);
+  }
+  const businessIds = [argValue('--business'), ...targetIdsFor(dbg, ['business_management'])].filter(Boolean);
+  for (const bizId of [...new Set(businessIds)]) {
+    const wabas = await wabasOfBusiness(bizId, token);
+    console.log(`business ${bizId} → ${wabas.length ? wabas.map((w) => `${w.name || '?'} (${w.id})`).join(', ') : 'no WABAs visible'}`);
+  }
 }
 
 /**
@@ -316,18 +442,30 @@ function printStatusTable(existing, templates) {
 }
 
 function selectedSets() {
-  const textOnly = process.argv.includes('--text-only');
-  const imagesOnly = process.argv.includes('--images-only');
-  if (textOnly && imagesOnly) throw new Error('--text-only and --images-only are mutually exclusive');
+  const only = ['--text-only', '--images-only', '--callback-only'].filter((f) => process.argv.includes(f));
+  if (only.length > 1) throw new Error(`${only.join(' and ')} are mutually exclusive`);
+  const all = only.length === 0;
   return {
-    text: !imagesOnly ? TEMPLATES : [],
-    image: !textOnly ? IMAGE_TEMPLATES : [],
+    text: all || only[0] === '--text-only' ? TEMPLATES : [],
+    callback: all || only[0] === '--callback-only' ? CALLBACK_TEMPLATES : [],
+    image: all || only[0] === '--images-only' ? IMAGE_TEMPLATES : [],
   };
 }
 
 function samplePathArg() {
   const i = process.argv.indexOf('--sample');
   return i >= 0 && process.argv[i + 1] ? path.resolve(process.argv[i + 1]) : DEFAULT_SAMPLE;
+}
+
+/**
+ * Token via stdin (`--token-stdin`), so the secret never appears in the command
+ * line, the shell history, or a placeholder the caller has to hand-substitute:
+ *   pbpaste | node backend/scripts/submit-wa-marketing-templates.mjs --token-stdin
+ */
+async function readStdinToken() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf8').trim();
 }
 
 async function postTemplate(wabaId, token, template) {
@@ -345,15 +483,17 @@ async function postTemplate(wabaId, token, template) {
 }
 
 async function main() {
-  const { text, image } = selectedSets();
-  const considered = [...text, ...image];
+  const { text, callback, image } = selectedSets();
+  const considered = [...text, ...callback, ...image];
 
   if (process.argv.includes('--dry')) {
     console.log(JSON.stringify(considered, null, 2));
     return;
   }
 
-  const token = process.env.WHATSAPP_TOKEN;
+  const token = process.argv.includes('--token-stdin')
+    ? await readStdinToken()
+    : process.env.WHATSAPP_TOKEN;
   if (!token) {
     console.error(
       'WHATSAPP_TOKEN not set. Copy it from Render → mktr-backend-jo6r → Environment → WHATSAPP_TOKEN, then:\n' +
@@ -363,8 +503,33 @@ async function main() {
     );
     process.exit(1);
   }
+  // Pasting the command with its "…" placeholder intact otherwise dies deep in
+  // fetch with "Cannot convert argument to a ByteString" — a header-encoding
+  // error that says nothing about the actual mistake.
+  if (!/^[\x21-\x7e]+$/.test(token)) {
+    console.error(
+      'WHATSAPP_TOKEN is not a usable token — it must be the raw value from Render, not the "…" placeholder.\n' +
+        '  WHATSAPP_TOKEN=EAAG…the-real-token node backend/scripts/submit-wa-marketing-templates.mjs --callback-only',
+    );
+    process.exit(1);
+  }
 
-  const wabaId = await resolveWabaId(token);
+  if (process.argv.includes('--whoami')) {
+    await whoami(token);
+    return;
+  }
+
+  // Resolution failure prints the token diagnostic itself: re-running with
+  // --whoami would mean copying another command, and on macOS that clobbers the
+  // very clipboard the token was piped from.
+  let wabaId;
+  try {
+    wabaId = await resolveWabaId(token);
+  } catch (err) {
+    console.error(`${err?.message || err}\n\nWhat this token actually carries:`);
+    await whoami(token).catch((e) => console.error(`  (diagnostic failed: ${e?.message || e})`));
+    process.exit(1);
+  }
   console.log(`WABA ${wabaId} (Graph ${VERSION})`);
   let existing = await fetchExisting(wabaId, token);
 
@@ -393,6 +558,7 @@ async function main() {
   };
 
   await submitSet(text);
+  await submitSet(callback);
 
   if (image.length) {
     const missing = image.filter((t) => !have.has(t.name));

--- a/backend/src/services/retellScreeningService.js
+++ b/backend/src/services/retellScreeningService.js
@@ -95,6 +95,35 @@ export function nextRetryAt(cfg, attemptCount, now = new Date()) {
 }
 
 /**
+ * `callback_window` (Retell post-call analysis, script v9) → how long to wait
+ * before ringing back. "tomorrow" is deliberately +12h rather than +24h: the
+ * window clamp then lands it at the NEXT morning's open however late the first
+ * call ran, which is what the person meant.
+ */
+const CALLBACK_DELAY_MINUTES = {
+  later_today: 3 * 60,
+  tomorrow: 12 * 60,
+  this_week: 60 * 60,
+};
+
+/**
+ * The instant we promised to call back, or null when no callback was asked for.
+ * Clamped into the call window, and never scheduled past the point the TTL
+ * sweep may release the lead unscreened (the same 2× hold the sweep grants a
+ * promised callback) — a promise we cannot keep is worse than an earlier call.
+ */
+export function callbackRetryAt(cfg, rawWindow, { now = new Date(), quarantinedAt = null } = {}) {
+  const minutes = CALLBACK_DELAY_MINUTES[String(rawWindow || '').trim().toLowerCase()];
+  if (!minutes) return null;
+  let at = new Date(now.getTime() + minutes * 60 * 1000);
+  if (quarantinedAt) {
+    const ceiling = new Date(new Date(quarantinedAt).getTime() + 2 * cfg.maxHoldHours * 60 * 60 * 1000);
+    if (at > ceiling) at = ceiling;
+  }
+  return inCallWindow(cfg, at) ? at : nextWindowOpen(cfg, at);
+}
+
+/**
  * Additional draw chances the consultant meet-up earns, from the campaign's
  * stored luckyDraw.multiplier (mirrors normalizeLuckyDraw's default-10 /
  * clamp-2..100 without importing the draw graph). Non-draw campaigns fall
@@ -355,25 +384,41 @@ export function makeRetellScreeningService(overrides = {}) {
   /**
    * Resolve a failed/unanswered attempt: fenced clear of the active id, then
    * retry-or-policy. `activeId` is the CURRENT sentinel or bound call id.
+   *
+   * `retryAt` (a callback the person asked for) replaces the blind exponential
+   * backoff AND buys ONE bonus attempt per lead: they picked up and asked us to
+   * ring back, which is not a failed reach. The grant rides the same fenced
+   * statement that clears the active id, so a replayed webhook can never grant
+   * twice, and a lead that keeps deferring still runs out at maxAttempts + 1.
    */
-  async function resolveAttemptFailure(prospect, activeId, { cfg = screeningConfig(), kind = 'no_answer' } = {}) {
+  async function resolveAttemptFailure(prospect, activeId, { cfg = screeningConfig(), kind = 'no_answer', retryAt = null } = {}) {
+    const granting = !!retryAt && prospect.screeningMetadata?.callbackGranted !== true;
     const [rows] = await d.sequelize.query(
       `UPDATE prospects
-          SET "screeningActiveCallId" = NULL, "updatedAt" = NOW()
+          SET "screeningActiveCallId" = NULL,
+              "screeningMetadata" = COALESCE("screeningMetadata", '{}'::jsonb) || :metaPatch::jsonb,
+              "updatedAt" = NOW()
         WHERE id = :id AND "screeningActiveCallId" = :activeId
         RETURNING "screeningAttemptCount"`,
-      { replacements: { id: prospect.id, activeId } }
+      {
+        replacements: {
+          id: prospect.id,
+          activeId,
+          metaPatch: JSON.stringify(granting ? { callbackGranted: true } : {}),
+        },
+      }
     );
     if (!Array.isArray(rows) || rows.length === 0) return { outcome: 'stale' };
     const attempts = rows[0].screeningAttemptCount ?? prospect.screeningAttemptCount ?? 0;
 
     await prospect.reload().catch(() => {});
-    if (attempts >= cfg.maxAttempts) {
+    const granted = granting || prospect.screeningMetadata?.callbackGranted === true;
+    if (attempts >= cfg.maxAttempts + (granted ? 1 : 0)) {
       const policy = await d.gate.applyUnreachablePolicy(prospect, { cfg });
       return { outcome: 'exhausted', kind, policy };
     }
-    await deferAttempt(prospect, nextRetryAt(cfg, attempts));
-    return { outcome: 'retry_scheduled', kind, attempts };
+    await deferAttempt(prospect, retryAt || nextRetryAt(cfg, attempts));
+    return { outcome: 'retry_scheduled', kind, attempts, ...(retryAt ? { callbackAt: retryAt.toISOString() } : {}) };
   }
 
   /**
@@ -391,6 +436,29 @@ export function makeRetellScreeningService(overrides = {}) {
     const disconnection = call.disconnection_reason || null;
     const unanswered = UNANSWERED_REASONS.has(disconnection) || call.in_voicemail === true;
     const analysis = call.call_analysis || null;
+    const checks = analysis?.custom_analysis_data || null;
+    const rawQualified = checks?.qualified;
+    const hasVerdict = rawQualified === true || rawQualified === 'true'
+      || rawQualified === false || rawQualified === 'false';
+    const detail = analysis
+      ? {
+          reason: checks?.qualification_reason || null,
+          interestLevel: checks?.interest_level || null,
+          summary: analysis.call_summary || null,
+          sentiment: analysis.user_sentiment || null,
+          recordingUrl: call.recording_url || null,
+          // Verbatim turn-by-turn script Retell returns ("Agent: …\nUser: …").
+          // Capped so a pathologically long call can't bloat the jsonb row; the
+          // recording remains the unabridged source of truth. Admin-only surface.
+          transcript: typeof call.transcript === 'string' ? call.transcript.slice(0, 20000) : null,
+          // Full per-check evidence (sg_pr / age_in_range / meet_consultant …) —
+          // small object; lets the admin drawer show WHICH check failed.
+          checks,
+        }
+      : null;
+    const attemptOutcome = unanswered ? 'unanswered'
+      : hasVerdict ? (rawQualified === true || rawQualified === 'true' ? 'qualified' : 'not_qualified')
+        : analysis ? 'no_verdict' : null;
 
     if (token) {
       // Per-call economics + provenance, all straight off the Retell call
@@ -417,6 +485,21 @@ export function makeRetellScreeningService(overrides = {}) {
         ...(Number.isInteger(call.agent_version) ? { agentVersion: call.agent_version } : {}),
         ...(analysis && typeof analysis.in_voicemail === 'boolean' ? { inVoicemail: analysis.in_voicemail } : {}),
         ...(analysis && typeof analysis.call_successful === 'boolean' ? { callSuccessful: analysis.call_successful } : {}),
+        ...(attemptOutcome ? { outcome: attemptOutcome } : {}),
+        // A connected call that produced NO verdict (hung up early, wrong
+        // person, "call me back later") never reaches a verdict transition, so
+        // this patch is the only place its evidence can land. Verdict-bearing
+        // calls skip it — verdictDetail already carries the same fields, and
+        // duplicating a 20k transcript per attempt bloats the row for nothing.
+        ...(detail && !hasVerdict
+          ? {
+              reason: detail.reason,
+              summary: detail.summary,
+              sentiment: detail.sentiment,
+              transcript: detail.transcript,
+              checks: detail.checks,
+            }
+          : {}),
       });
     }
 
@@ -430,30 +513,20 @@ export function makeRetellScreeningService(overrides = {}) {
     }
 
     if (analysis) {
-      const rawQualified = analysis.custom_analysis_data?.qualified;
-      const detail = {
-        reason: analysis.custom_analysis_data?.qualification_reason || null,
-        interestLevel: analysis.custom_analysis_data?.interest_level || null,
-        summary: analysis.call_summary || null,
-        sentiment: analysis.user_sentiment || null,
-        recordingUrl: call.recording_url || null,
-        // Verbatim turn-by-turn script Retell returns ("Agent: …\nUser: …").
-        // Capped so a pathologically long call can't bloat the jsonb row; the
-        // recording remains the unabridged source of truth. Admin-only surface.
-        transcript: typeof call.transcript === 'string' ? call.transcript.slice(0, 20000) : null,
-        // Full per-check evidence (sg_pr / age_in_range / meet_consultant …) —
-        // small object; lets the admin drawer show WHICH check failed.
-        checks: analysis.custom_analysis_data || null,
-      };
       if (rawQualified === true || rawQualified === 'true') {
         return d.gate.applyQualifiedVerdict(prospect, { callId, detail });
       }
       if (rawQualified === false || rawQualified === 'false') {
         return d.gate.markScreeningFailed(prospect, { callId, detail });
       }
-      // Analysis arrived without our schema field — a connected call with no
-      // usable verdict. Never guessed from sentiment (plan §8.4).
-      return resolveAttemptFailure(prospect, callId, { cfg, kind: 'no_verdict' });
+      // Connected, but no usable verdict — hung up early, wrong person, or
+      // asked us to ring back. Never guessed from sentiment (plan §8.4). When
+      // they named a better time, that time replaces the blind backoff.
+      return resolveAttemptFailure(prospect, callId, {
+        cfg,
+        kind: 'no_verdict',
+        retryAt: callbackRetryAt(cfg, checks?.callback_window, { quarantinedAt: prospect.quarantinedAt || null }),
+      });
     }
 
     if (finalIfNoAnalysis) {

--- a/backend/src/services/screeningSweepService.js
+++ b/backend/src/services/screeningSweepService.js
@@ -1,4 +1,4 @@
-import { Op } from 'sequelize';
+import { Op, literal } from 'sequelize';
 import { sequelize, Prospect, Campaign } from '../models/index.js';
 import { screeningConfig, makeScreeningGate } from './screeningGate.js';
 import { makeRetellScreeningService } from './retellScreeningService.js';
@@ -27,6 +27,14 @@ import { logger } from '../utils/logger.js';
 
 const JOB_LOCK_KEY = 'screening_sweep';
 const MAX_PER_RUN = 100;
+
+/**
+ * A lead that asked us to ring back at a stated time (retellScreeningService).
+ * COALESCE is load-bearing: without it the key's absence yields NULL, and the
+ * TTL predicate below (`NOT (… AND …)`) would evaluate to NULL — silently
+ * sparing every ordinary lead that happens to have a future retry scheduled.
+ */
+const CALLBACK_GRANTED_SQL = `COALESCE("screeningMetadata"->>'callbackGranted', 'false') = 'true'`;
 
 let running = false;
 
@@ -98,7 +106,12 @@ async function processPass(d, cfg) {
 
   // ── 3. TTL: no lead holds longer than maxHoldHours. Verdict-less rows hit
   //       the unreachable policy; qualified rows were job 1's (and stay so).
+  //       A lead we PROMISED to ring back at a stated time is spared until that
+  //       call has fired — releasing it unscreened would break the promise the
+  //       agent made on the phone. Bounded by a hard 2× hold ceiling, which is
+  //       also what callbackRetryAt clamps the promised time to.
   const ttlCutoff = new Date(now.getTime() - cfg.maxHoldHours * 60 * 60 * 1000);
+  const callbackGraceHours = Math.max(1, Math.floor(cfg.maxHoldHours * 2));
   const expired = await d.Prospect.findAll({
     where: {
       quarantineReason: 'screening_pending',
@@ -106,6 +119,12 @@ async function processPass(d, cfg) {
       screeningVerdict: null,
       quarantinedAt: { [Op.lt]: ttlCutoff },
       id: { [Op.notIn]: [...touched].length ? [...touched] : ['00000000-0000-0000-0000-000000000000'] },
+      [Op.and]: [
+        literal(`NOT (${CALLBACK_GRANTED_SQL}
+                      AND "screeningNextAttemptAt" IS NOT NULL
+                      AND "screeningNextAttemptAt" > NOW()
+                      AND "quarantinedAt" > NOW() - INTERVAL '${callbackGraceHours} hours')`),
+      ],
     },
     limit: MAX_PER_RUN,
   });
@@ -150,14 +169,21 @@ async function processPass(d, cfg) {
   // ── 5. Due retries LAST. startScreeningAttempt re-runs every dial guard
   //       (stamp, DNC, consent, window, budget, concurrency).
   if (cfg.configured && !cfg.dryRun) {
+    // The attempt cap mirrors resolveAttemptFailure: maxAttempts, plus the one
+    // bonus dial a stated callback earns. Without the OR the promised call
+    // would be scheduled and then never picked up.
+    const maxAttempts = Math.max(1, Math.floor(cfg.maxAttempts));
     const due = await d.Prospect.findAll({
       where: {
         quarantineReason: 'screening_pending',
         screeningActiveCallId: null,
         screeningVerdict: null,
         screeningNextAttemptAt: { [Op.lte]: now },
-        screeningAttemptCount: { [Op.lt]: cfg.maxAttempts },
         id: { [Op.notIn]: [...touched].length ? [...touched] : ['00000000-0000-0000-0000-000000000000'] },
+        [Op.and]: [
+          literal(`("screeningAttemptCount" < ${maxAttempts}
+                    OR (${CALLBACK_GRANTED_SQL} AND "screeningAttemptCount" < ${maxAttempts + 1}))`),
+        ],
       },
       order: [['screeningNextAttemptAt', 'ASC']],
       limit: Math.min(MAX_PER_RUN, cfg.maxConcurrent * 2),

--- a/backend/test/unit/retellScreening.test.js
+++ b/backend/test/unit/retellScreening.test.js
@@ -7,11 +7,13 @@
  */
 import { createHash } from 'crypto';
 import { jest } from '@jest/globals';
+import { Op } from 'sequelize';
 import {
   makeRetellScreeningService,
   inCallWindow,
   nextWindowOpen,
   nextRetryAt,
+  callbackRetryAt,
   drawExtraChances,
   UNANSWERED_REASONS,
 } from '../../src/services/retellScreeningService.js';
@@ -141,6 +143,37 @@ describe('call-window helpers', () => {
     expect(first.toISOString()).toBe('2026-07-23T05:00:00.000Z'); // +2h, in window
     const second = nextRetryAt({ ...cfgWin, retryMinutes: 120 }, 2, base); // +4h → 15:00 SGT ok
     expect(second.toISOString()).toBe('2026-07-23T07:00:00.000Z');
+  });
+});
+
+describe('callbackRetryAt', () => {
+  const cfgWin = { ...CFG, callWindow: '10:00-20:00' };
+  const noon = new Date('2026-07-23T04:00:00Z'); // 12:00 SGT
+
+  it('maps the stated window onto a real instant, clamped into the call window', () => {
+    // later today → +3h → 15:00 SGT, inside the window.
+    expect(callbackRetryAt(cfgWin, 'later_today', { now: noon }).toISOString()).toBe('2026-07-23T07:00:00.000Z');
+    // tomorrow → +12h lands at 00:00 SGT (shut) → next open, 10:00 SGT.
+    expect(callbackRetryAt(cfgWin, 'tomorrow', { now: noon }).toISOString()).toBe('2026-07-24T02:00:00.000Z');
+    // this week → +60h → 00:00 SGT on the 26th (shut) → 10:00 SGT that day.
+    expect(callbackRetryAt(cfgWin, 'this_week', { now: noon }).toISOString()).toBe('2026-07-26T02:00:00.000Z');
+  });
+
+  it('never schedules past the hold ceiling the TTL sweep grants a promise', () => {
+    // Captured at 11:00 SGT; 2 × 24h hold ⇒ nothing may be promised beyond the
+    // 25th 11:00 SGT, so "this week" collapses onto that day's window.
+    const at = callbackRetryAt(cfgWin, 'this_week', { now: noon, quarantinedAt: new Date('2026-07-23T03:00:00Z') });
+    expect(at.toISOString()).toBe('2026-07-25T03:00:00.000Z'); // 11:00 SGT, still inside the window
+  });
+
+  it('no callback asked for (or an unknown value) → null, so the blind backoff stands', () => {
+    for (const v of [undefined, null, '', 'none', 'unspecified', 'next_year']) {
+      expect(callbackRetryAt(cfgWin, v, { now: noon })).toBeNull();
+    }
+  });
+
+  it('is case- and whitespace-tolerant (the analysis model is not a schema)', () => {
+    expect(callbackRetryAt(cfgWin, ' Later_Today ', { now: noon }).toISOString()).toBe('2026-07-23T07:00:00.000Z');
   });
 });
 
@@ -430,6 +463,90 @@ describe('applyCallOutcome', () => {
     expect(depsMissing.gate.applyQualifiedVerdict).not.toHaveBeenCalled();
   });
 
+  it('a verdict-less call keeps its evidence on the attempt (the only record it gets)', async () => {
+    const seq = fakeSequelize([[[{ id: 'p' }]], [[{ screeningAttemptCount: 1 }]], [[{ id: 'p' }]]]);
+    const svc = makeRetellScreeningService(dialerDeps(seq));
+    await svc.applyCallOutcome(
+      pendingProspect({ screeningActiveCallId: 'call_1', screeningAttemptCount: 1 }),
+      call({
+        call_analysis: {
+          custom_analysis_data: { qualified: 'incomplete', qualification_reason: 'Asked to be called back', sg_pr: 'unanswered' },
+          call_summary: 'Could not talk',
+          user_sentiment: 'Neutral',
+        },
+        transcript: 'Agent: Is now a good time?\nUser: Call me later',
+      }),
+      { cfg: CFG }
+    );
+    const patch = JSON.parse(seq.calls.find((c) => String(c.sql).includes('{attempts,')).opts.replacements.patch);
+    expect(patch).toMatchObject({
+      outcome: 'no_verdict',
+      reason: 'Asked to be called back',
+      summary: 'Could not talk',
+      sentiment: 'Neutral',
+      transcript: 'Agent: Is now a good time?\nUser: Call me later',
+      checks: { qualified: 'incomplete', sg_pr: 'unanswered' },
+    });
+  });
+
+  it('a verdict-bearing call does NOT duplicate the transcript onto the attempt', async () => {
+    const seq = fakeSequelize([[[{ id: 'p' }]]]);
+    const svc = makeRetellScreeningService(dialerDeps(seq));
+    await svc.applyCallOutcome(pendingProspect({ screeningActiveCallId: 'call_1' }), call({
+      call_analysis: { custom_analysis_data: { qualified: true, qualification_reason: 'All three yes' } },
+      transcript: 'Agent: Hi\nUser: Yes',
+    }), { cfg: CFG });
+    const patch = JSON.parse(seq.calls.find((c) => String(c.sql).includes('{attempts,')).opts.replacements.patch);
+    expect(patch.outcome).toBe('qualified');
+    expect(patch.transcript).toBeUndefined();   // verdictDetail carries it
+    expect(patch.checks).toBeUndefined();
+  });
+
+  it('a stated callback replaces the blind backoff and grants one bonus attempt', async () => {
+    const seq = fakeSequelize([[[{ id: 'p' }]], [[{ screeningAttemptCount: 1 }]], [[{ id: 'p' }]]]);
+    const svc = makeRetellScreeningService(dialerDeps(seq));
+    const before = Date.now();
+    const out = await svc.applyCallOutcome(
+      pendingProspect({ screeningActiveCallId: 'call_1', screeningAttemptCount: 1 }),
+      call({ call_analysis: { custom_analysis_data: { qualified: 'incomplete', callback_window: 'later_today' } } }),
+      { cfg: CFG }
+    );
+    expect(out).toMatchObject({ outcome: 'retry_scheduled', kind: 'no_verdict' });
+    // ~3h out, not the 2h first-step backoff.
+    const at = new Date(out.callbackAt).getTime();
+    expect(at - before).toBeGreaterThan(2.9 * 60 * 60 * 1000);
+    expect(at - before).toBeLessThan(3.1 * 60 * 60 * 1000);
+    // The grant rides the fenced clear, and the deferral uses the promised time.
+    const clear = seq.calls.find((c) => String(c.sql).includes('SET "screeningActiveCallId" = NULL'));
+    expect(JSON.parse(clear.opts.replacements.metaPatch)).toEqual({ callbackGranted: true });
+    const defer = seq.calls.find((c) => String(c.sql).includes('"screeningNextAttemptAt" = :at'));
+    expect(new Date(defer.opts.replacements.at).toISOString()).toBe(out.callbackAt);
+  });
+
+  it('the bonus is one per lead: a granted lead survives attempt 3 but not attempt 4', async () => {
+    const granted = () => pendingProspect({
+      screeningActiveCallId: 'call_1',
+      screeningMetadata: { intendedAgentId: 'a1', alreadyCharged: false, attempts: {}, callbackGranted: true },
+    });
+    const cb = call({ call_analysis: { custom_analysis_data: { qualified: 'incomplete', callback_window: 'tomorrow' } } });
+
+    const seqThird = fakeSequelize([[[{ id: 'p' }]], [[{ screeningAttemptCount: 3 }]], [[{ id: 'p' }]]]);
+    const depsThird = dialerDeps(seqThird);
+    const third = await makeRetellScreeningService(depsThird)
+      .applyCallOutcome(granted(), cb, { cfg: CFG }); // maxAttempts 3 + granted bonus
+    expect(third.outcome).toBe('retry_scheduled');
+    expect(depsThird.gate.applyUnreachablePolicy).not.toHaveBeenCalled();
+    // Already granted ⇒ the fenced clear must not re-write the grant.
+    expect(JSON.parse(seqThird.calls.find((c) => String(c.sql).includes('SET "screeningActiveCallId" = NULL')).opts.replacements.metaPatch)).toEqual({});
+
+    const seqFourth = fakeSequelize([[[{ id: 'p' }]], [[{ screeningAttemptCount: 4 }]]]);
+    const depsFourth = dialerDeps(seqFourth);
+    const fourth = await makeRetellScreeningService(depsFourth)
+      .applyCallOutcome(granted(), cb, { cfg: CFG });
+    expect(fourth.outcome).toBe('exhausted');
+    expect(depsFourth.gate.applyUnreachablePolicy).toHaveBeenCalled();
+  });
+
   it('connected call_ended without analysis waits for call_analyzed (unless final)', async () => {
     const deps = dialerDeps(fakeSequelize([[[{ id: 'p' }]]]));
     const svc = makeRetellScreeningService(deps);
@@ -564,6 +681,25 @@ describe('screeningSweepService', () => {
     const out = await runScreeningSweep(deps);
     expect(out.ttl).toBe(1);
     expect(deps.gate.applyUnreachablePolicy).toHaveBeenCalledWith(old, expect.objectContaining({ via: 'screening_ttl' }));
+  });
+
+  it('spares a promised callback from the TTL and lets it take its bonus dial', async () => {
+    const deps = sweepDeps({});
+    await runScreeningSweep(deps);
+    const [ttlQuery, dueQuery] = [deps.Prospect.findAll.mock.calls[2][0], deps.Prospect.findAll.mock.calls[4][0]];
+    // TTL skips a granted lead whose promised time has not arrived, bounded by
+    // a hard 2× hold ceiling.
+    const ttlSql = String(ttlQuery.where[Op.and][0].val);
+    // COALESCE is not cosmetic: a bare `->>' = 'true'` is NULL when the key is
+    // absent, which makes NOT(…) NULL and spares ordinary leads from the TTL.
+    expect(ttlSql).toContain(`COALESCE("screeningMetadata"->>'callbackGranted', 'false') = 'true'`);
+    expect(ttlSql).toContain('"screeningNextAttemptAt" > NOW()');
+    expect(ttlSql).toContain(`INTERVAL '48 hours'`); // 2 × maxHoldHours
+    // The due-retry cap mirrors resolveAttemptFailure: 3, or 4 once granted.
+    const dueSql = String(dueQuery.where[Op.and][0].val);
+    expect(dueSql).toContain('"screeningAttemptCount" < 3');
+    expect(dueSql).toContain('"screeningAttemptCount" < 4');
+    expect(dueQuery.where.screeningAttemptCount).toBeUndefined(); // superseded by the literal
   });
 
   it('drain mode (feature off, backlog present) releases pending rows unscreened', async () => {

--- a/docs/plans/retell-screening-calls.md
+++ b/docs/plans/retell-screening-calls.md
@@ -611,6 +611,71 @@ stays (additive).
 
 ---
 
+## §16.5 Callback handling — script v9 (2026-07-25, post-soak)
+
+The opener asks "is now a good time?", so "call me later" is the single most
+likely first-turn answer. v8 treated it as a HARD-NO ESCAPE (hang up, no
+rebuttal, no time captured), and the backend then redialled on the blind
+`retryMinutes × 2^(n−1)` ladder regardless of what the person had asked for.
+Worse, a verdict-less call wrote NO evidence: `verdictDetail` is only written by
+the qualified/not-qualified transitions (§9.1, §9.3), so the reason, summary and
+transcript were discarded and the drawer showed nothing but an attempt count and
+an audio file.
+
+Now:
+
+1. **Script v9** (agent `agent_4ea24f4a01e44f5c7ad14f3638` v9, LLM v9). Timing
+   is split out of the hard-no escape: ONE light "three quick yes-or-no
+   questions, thirty seconds" attempt, then — if they still can't — "later today
+   or tomorrow?", acknowledge, end. Never negotiates a clock time. Driving / in a
+   meeting / annoyed / firm no / wrong person still escape immediately.
+2. **New analysis field** `callback_window ∈ {none, later_today, tomorrow,
+   this_week}`, alongside `qualified: 'incomplete'` (which already covers a call
+   that never reached all three checks).
+3. **`callbackRetryAt(cfg, window, {now, quarantinedAt})`** maps it onto an
+   instant: +3h / +12h / +60h, clamped into the call window (so "tomorrow" lands
+   at the next open) and never past `quarantinedAt + 2 × maxHoldHours`.
+4. **One bonus attempt per lead.** `resolveAttemptFailure` takes `retryAt`; when
+   present it replaces the backoff and — first time only — writes
+   `screeningMetadata.callbackGranted`, lifting that lead's cap to
+   `maxAttempts + 1`. Someone who answers and asks for a ring-back has not
+   burned a reach; someone who keeps deferring still runs out. The grant rides
+   the fenced clear, so a replayed webhook cannot grant twice.
+5. **TTL respects the promise** (sweep job 3): a granted lead whose
+   `screeningNextAttemptAt` is still in the future is skipped, bounded by the
+   same 2× hold ceiling. Job 5's attempt cap carries the matching `+1`.
+6. **Evidence.** A verdict-less attempt now stores `outcome` (`no_verdict` /
+   `unanswered` / `qualified` / `not_qualified`) plus reason, summary, sentiment,
+   transcript and the raw checks — but only when no verdict transition will
+   capture them, so a 20k transcript is never duplicated. The drawer prints a
+   per-attempt line and, for a granted callback, the promised time.
+
+Not covered: nothing schedules the ring-back outside the 10:00–20:00 window, and
+a "next week" request is still clamped to the hold ceiling — past that, TTL
+releases the lead unscreened by policy (D1). WhatsApp fallback is §16.6.
+
+## §16.6 WhatsApp callback opt-in (submitted for review 2026-07-25)
+
+**Submitted 2026-07-25, template id 1587973386015533, status PENDING** (WABA
+1912683432731970 — resolved via the script's hardcoded Redeem-WABA fallback; the
+prod system-user token's granular scopes carry no target ids, so nothing is
+enumerable from the token alone).
+
+Template `draw_callback_optin` (MARKETING, `allow_category_change`) — the
+messaging leg for leads a dial cannot finish. URL button "Yes, call me" carries
+the consent: the tap is the person asking to be called, which is what makes the
+ring-back welcome. Copy follows the ×N-is-the-TOTAL contract and
+`DRAW_RECORD_PHRASE`, not the phone script's "N more chances" register.
+Definition + submitter: `backend/scripts/submit-wa-marketing-templates.mjs`
+(`--callback-only`).
+
+**Unbuilt before it can send:** the `/callback?t=…` landing page and its
+consent-capture endpoint (tap ⇒ record consent ⇒ schedule the next attempt), and
+a `purpose:'marketing'` send path in `whatsappService` — its sends are
+transactional today, so a marketing unsubscribe would not block this one.
+
+---
+
 ## §17 Open decisions
 
 - **D1 Unreachable default** — **`release` unscreened** (no-answer ≠ bad lead). |

--- a/src/pages/adminv2/AdminV2Prospects.jsx
+++ b/src/pages/adminv2/AdminV2Prospects.jsx
@@ -252,6 +252,11 @@ function LeadDrawer({ prospect, onClose, onOpenLead }) {
                 {verdictDetail.reason && <div className="av2-kv"><span>reason</span><span>{verdictDetail.reason}</span></div>}
                 {verdictDetail.sentiment && <div className="av2-kv"><span>sentiment</span><span>{verdictDetail.sentiment}</span></div>}
                 <div className="av2-kv"><span>attempts</span><span>{p.screeningAttemptCount || attempts.length || 0}</span></div>
+                {/* A time Sarah promised on the phone — the one screening date
+                    an operator must not silently miss. */}
+                {sm.callbackGranted && p.screeningNextAttemptAt && (
+                  <div className="av2-kv"><span>callback</span><span>{fmtDateTime(p.screeningNextAttemptAt)}</span></div>
+                )}
                 {hasCost && (
                   <div className="av2-kv">
                     <span>call cost</span>
@@ -299,6 +304,22 @@ function LeadDrawer({ prospect, onClose, onOpenLead }) {
                       })}
                     </div>
                   </details>
+                )}
+                {/* Attempts that produced no verdict write no verdictDetail, so
+                    the block above says nothing about them. Their own evidence
+                    is the only record of WHY — e.g. a requested callback. */}
+                {attempts.some((a) => a.outcome === 'no_verdict' || a.outcome === 'unanswered') && (
+                  <div style={{ marginTop: 8, display: 'grid', gap: 3 }}>
+                    {attempts.map((a, i) => (
+                      (a.outcome === 'no_verdict' || a.outcome === 'unanswered') ? (
+                        <div key={a.token || i} style={{ fontSize: 12, color: 'var(--ink-2)', lineHeight: 1.45 }}>
+                          Attempt {i + 1} — {a.outcome === 'unanswered'
+                            ? String(a.disconnectionReason || 'no answer').replace(/_/g, ' ')
+                            : a.reason || 'no verdict'}
+                        </div>
+                      ) : null
+                    ))}
+                  </div>
                 )}
                 {attempts.some((a) => a.recordingUrl) && (
                   <div style={{ marginTop: 6, display: 'grid', gap: 10 }}>


### PR DESCRIPTION
## What

"Call me later" is the single most likely answer to Sarah's opener ("Is now a good time?") — and until now it was treated as a hard no on the call, redialled on a blind 2h/4h backoff by the backend, and left **zero** written evidence (only the qualified/failed transitions persist `verdictDetail`, so a verdict-less call's reason/summary/transcript were discarded).

### Backend
- **`callbackRetryAt(cfg, window, {now, quarantinedAt})`** — maps the new `callback_window` analysis enum (`later_today` / `tomorrow` / `this_week`, script v9) onto a real instant: +3h / +12h / +60h, clamped into the 10:00–20:00 SGT call window (so "tomorrow" lands at the next morning's open), never past `quarantinedAt + 2×maxHoldHours`.
- **`resolveAttemptFailure` accepts `retryAt`** — replaces the exponential backoff and grants **one bonus attempt per lead** (`screeningMetadata.callbackGranted`, written inside the fenced clear so a replayed webhook can't double-grant). Dead numbers still get exactly `maxAttempts` dials; only someone who answered and asked for a ring-back earns the +1.
- **TTL sweep spares a promised-but-unfired callback** (bounded by the same 2× ceiling); the due-dial query carries the matching `maxAttempts+1`. `COALESCE(…,'false')` on the jsonb key is load-bearing: `->>'k' = 'true'` is NULL when the key is absent, and `NOT(NULL AND …)` would have silently spared **every** ordinary row from the TTL — caught by truth-tabling the predicate against prod before commit.
- **Verdict-less attempts keep their evidence** — `outcome` / `reason` / `summary` / `sentiment` / `transcript` / `checks` land on the attempt entry (skipped when a verdict transition captures them, so a 20k transcript is never stored twice).

### Admin drawer
Per-attempt outcome lines ("Attempt 1 — Asked to be called back") + the promised callback time when one is scheduled.

### WhatsApp
`draw_callback_optin` template — URL button **"Yes, call me"** is the customer's consent to be called; copy follows the ×N-is-the-TOTAL + `DRAW_RECORD_PHRASE` contract. **Submitted to Meta 2026-07-25, id 1587973386015533, PENDING.** Submit-script hardening: `--token-stdin`, `--whoami` diagnostic auto-printed on resolve failure, `--business`/`--waba`, probe-verified Redeem-WABA fallback (the prod system-user token's granular scopes enumerate nothing).

## Deploy order

Independent of the Retell publish: agent v9 (`callback_window` + hold-the-line opener) is saved but **unpublished**; an absent field just means the old backoff applies, so either order is safe. Not yet built (follow-up): the `/callback` landing page + consent endpoint, and a `purpose:'marketing'` send lane in whatsappService.

## Tests

- 102 backend (jest): new `callbackRetryAt` window/ceiling cases, callback-grants-bonus-attempt, one-grant-per-lead (3rd survives / 4th exhausts), no-verdict evidence persistence, no-transcript-duplication, sweep predicate SQL (COALESCE + `+1` cap)
- 26 frontend (vitest) adminv2 — green
- eslint clean; sweep predicate truth-tabled against prod Postgres (5 row shapes)

Design log: `docs/plans/retell-screening-calls.md` §16.5–§16.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgWRx53DQBvoHAdi3pViGx