### PR TITLE
feat(draw): one signup, one email — the entry pass rides the Onyx confirmation

### DIFF
--- a/backend/scripts/preview-draw-email.js
+++ b/backend/scripts/preview-draw-email.js
@@ -18,9 +18,26 @@ const SAMPLE = {
   titanium: { name: 'iPhone 17 Pro Lucky Draw', prize: 'iPhone 17 Pro 256GB', multiplier: 10, drawOn: '2026-10-22', firstName: 'Shawn' },
   gold: { name: '$5,000 Cash Lucky Draw', prize: '$5,000 cash', multiplier: 10, drawOn: '2026-11-30', firstName: 'Priya' },
   emerald: { name: 'Bali Escape Lucky Draw', prize: 'a Bali escape for two', multiplier: 5, drawOn: '2026-12-15', firstName: 'Marcus' },
-  // No drawOn — proves the third stat falls back to the entry close date.
+  // No drawOn — proves the standing stat falls back to the entry close date.
   sapphire: { name: 'PS5 Pro Bundle Lucky Draw', prize: 'the PS5 Pro bundle', multiplier: 7, closesAt: '2027-01-05', firstName: 'Aisha' },
 };
+
+// The merged pass block (2026-07-25): titanium previews the full card slot,
+// emerald previews the no-image degrade (link only), the rest preview the
+// fallback confirmation an entitlement-less signup gets (no pass block).
+const PASS_SAMPLE = {
+  titanium: { link: 'https://redeem.sg/r/previewtoken', deadlineLong: '30 September 2026', hasImage: true },
+  emerald: { link: 'https://redeem.sg/r/previewtoken', deadlineLong: '15 December 2026', hasImage: false },
+};
+
+// Browsers cannot resolve cid: attachments — swap in a neutral stand-in so the
+// preview shows the slot. The wire HTML (and the placeholder check) is untouched.
+const CARD_STUB = Buffer.from(
+  '<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="1080">'
+  + '<rect width="100%" height="100%" fill="#15161a"/>'
+  + '<text x="50%" y="50%" fill="#8a7748" font-family="monospace" font-size="52" text-anchor="middle">VAULT CARD PREVIEW</text>'
+  + '</svg>'
+).toString('base64');
 
 await mkdir(outDir, { recursive: true });
 
@@ -37,10 +54,14 @@ for (const theme of PASS_THEMES) {
       enabled: true, passTheme: theme, prize: s.prize, multiplier: s.multiplier,
       drawOn: s.drawOn, closesAt: s.closesAt,
     },
+    drawPass: PASS_SAMPLE[theme] || null,
   });
   const left = html.match(/\{\{\w+\}\}/g);
   if (left) console.warn(`  ! ${theme}: unsubstituted placeholders ${[...new Set(left)].join(', ')}`);
-  await writeFile(path.join(outDir, `${theme}.html`), html);
+  await writeFile(
+    path.join(outDir, `${theme}.html`),
+    html.replace('src="cid:draw-pass"', `src="data:image/svg+xml;base64,${CARD_STUB}"`)
+  );
   await writeFile(path.join(outDir, `${theme}.txt`), text);
   console.log(`${path.join(outDir, `${theme}.html`)}  ${(html.length / 1024).toFixed(1)}kB`);
 }

--- a/backend/src/controllers/prospectController.js
+++ b/backend/src/controllers/prospectController.js
@@ -49,7 +49,7 @@ export const createProspect = asyncHandler(async (req, res) => {
     ttp: req.body?.ttp,
   };
 
-  const { prospect, assignedAgentId, assignedAgent, prospectWithCampaign, shareUrl } = await prospectService.createProspect(
+  const { prospect, assignedAgentId, assignedAgent, prospectWithCampaign, shareUrl, leadCapturedOutcome } = await prospectService.createProspect(
     req.body,
     req.user,
     { cookies: req.cookies, headers: req.headers, meta }
@@ -66,9 +66,19 @@ export const createProspect = asyncHandler(async (req, res) => {
   // the function itself filters out synthetic Retell emails and missing fields.
   // Pass the canonical shareUrl minted at creation so the email's "Refer a friend"
   // link is byte-identical to the one the SPA shows post-submit.
-  sendLeadConfirmationEmail(prospectWithCampaign || prospect, { shareUrl }).catch(err =>
-    console.error(`Failed to send confirmation email to lead for prospect ${prospect.id}:`, err.message || err)
-  );
+  // ONE email per signup: chained on the entitlement hook's outcome — when the
+  // hook queued the merged draw confirmation (Onyx + entry pass, sent by
+  // fulfilmentNotify), this generic send would be its near-duplicate, so it is
+  // skipped. Any other outcome (no draw, issuance skipped, hook off/failed)
+  // falls through to sending, exactly as before the 2026-07-25 merge.
+  Promise.resolve(leadCapturedOutcome ?? null)
+    .then((outcome) => {
+      if (outcome?.drawEmailQueued) return null;
+      return sendLeadConfirmationEmail(prospectWithCampaign || prospect, { shareUrl });
+    })
+    .catch(err =>
+      console.error(`Failed to send confirmation email to lead for prospect ${prospect.id}:`, err.message || err)
+    );
 
   // Public, unauthenticated endpoint: echo only what the SPA needs — the id
   // drives the post-submit referral share link. Returning the full row would

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -296,9 +296,10 @@ export async function bootstrapDatabase() {
           // INSIDE the wired service now — one choke point for hook, sweep and
           // manual issuance (trial-reward-funnel-hardening PR A).
           const entitlements = makeWiredEntitlementService();
-          registerLeadCapturedHook(async (prospect) => {
-            await entitlements.issueForProspect(prospect, { via: 'hook' });
-          });
+          // The issuance result flows BACK through the hook: the controller
+          // chains its confirmation email on it and skips the send when the
+          // merged draw email (drawEmailQueued) already covers it.
+          registerLeadCapturedHook((prospect) => entitlements.issueForProspect(prospect, { via: 'hook' }));
           logger.info('[RedeemOps] entitlement capture hook registered');
         });
 

--- a/backend/src/services/email-templates/confirmation-email-draw.html
+++ b/backend/src/services/email-templates/confirmation-email-draw.html
@@ -99,10 +99,11 @@
           <!-- ============ HERO ============ -->
           <tr>
             <td class="px anim-1" style="padding:34px 40px 0 40px;">
-              <div style="font-family:'JetBrains Mono','SFMono-Regular',Consolas,Menlo,monospace; font-size:11px; letter-spacing:0.2em; color:{{c_eyebrow}}; padding-bottom:16px;">YOU&rsquo;RE IN THE DRAW</div>
+              <!-- No eyebrow kicker: the CONFIRMED pill and the H1 already say it —
+                   a third repetition above the headline was cut 2026-07-25. -->
               <div class="h1" style="font-family:'Spectral',Georgia,'Times New Roman',serif; font-size:44px; line-height:46px; color:{{c_h1}}; letter-spacing:-0.015em;">You&rsquo;re in the draw.</div>
               <div style="font-family:'Spectral',Georgia,'Times New Roman',serif; font-size:17px; line-height:27px; color:{{c_body}}; padding-top:16px;">
-                Hello {{firstName}}, your entry is in for <span style="color:{{c_bodyStrong}}; font-weight:600;">{{campaignName}}</span> &mdash; {{prize}}.
+                Hello {{firstName}}, your entry is in for <span style="color:{{c_bodyStrong}}; font-weight:600;">{{campaignName}}</span>.
               </div>
             </td>
           </tr>
@@ -153,28 +154,18 @@
             </td>
           </tr>
 
-          <!-- ============ STANDING ============ -->
-          <tr>
-            <td class="px" style="padding:28px 40px 0 40px;">
-              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-top:1px solid {{c_hair}};">
-                <tr>
-                  <td width="{{statWidth}}" valign="top" style="padding:20px 12px 0 0;">
-                    <div style="font-family:'JetBrains Mono','SFMono-Regular',Consolas,Menlo,monospace; font-size:10px; letter-spacing:0.16em; color:{{c_statKey}}; padding-bottom:7px;">ENTRANT</div>
-                    <div style="font-family:'Spectral',Georgia,'Times New Roman',serif; font-size:17px; line-height:22px; color:{{c_statVal}};">{{firstName}}</div>
-                  </td>
-                  <td width="{{statWidth}}" valign="top" style="padding:20px 12px 0 0;">
-                    <div style="font-family:'JetBrains Mono','SFMono-Regular',Consolas,Menlo,monospace; font-size:10px; letter-spacing:0.16em; color:{{c_statKey}}; padding-bottom:7px;">STATUS</div>
-                    <div style="font-family:'Spectral',Georgia,'Times New Roman',serif; font-size:17px; line-height:22px; color:{{c_statVal}};">In the draw</div>
-                  </td>
-                  {{stat3Cell}}
-                </tr>
-              </table>
-            </td>
-          </tr>
+          <!-- ============ ENTRY PASS (only when the send carries one) ============ -->
+          {{passRow}}
+
+          <!-- ============ STANDING ============
+               One honest date, or nothing — the entrant/status echo cells were
+               cut 2026-07-25: the greeting names the entrant, the H1 states the
+               status. -->
+          {{standingRow}}
 
           <!-- ============ REFERRAL ============ -->
           <tr>
-            <td class="px" style="padding:30px 40px 0 40px;">
+            <td class="px" style="padding:30px 40px 36px 40px;">
               <table role="presentation" class="anim-3" width="100%" cellpadding="0" cellspacing="0" border="0" style="border:1px solid {{c_boxBorder}}; border-radius:16px;">
                 <tr>
                   <td class="card-px" style="padding:26px 28px 26px 28px;">
@@ -205,25 +196,15 @@
                         </td>
                       </tr>
                     </table>
-                    <div style="padding-top:12px; text-align:center; font-family:'JetBrains Mono','SFMono-Regular',Consolas,Menlo,monospace; font-size:10px; letter-spacing:0.1em; color:{{c_hint}};">TAP A BUTTON TO SHARE, OR COPY THE LINK ABOVE</div>
                   </td>
                 </tr>
               </table>
             </td>
           </tr>
 
-          <!-- ============ REASSURANCE + SIGN-OFF ============ -->
-          <tr>
-            <td class="px" align="center" style="padding:30px 40px 0 40px; font-family:'Spectral',Georgia,'Times New Roman',serif; font-size:14px; line-height:21px; color:{{c_quiet}};">
-              Did not request this? No action is needed &mdash; you can safely ignore this email.
-            </td>
-          </tr>
-          <tr>
-            <td class="px" align="center" style="padding:24px 40px 34px 40px;">
-              <div style="font-family:'Spectral',Georgia,'Times New Roman',serif; font-style:italic; font-size:16px; line-height:22px; color:{{c_signItalic}};">Warm regards,</div>
-              <div style="font-family:'Spectral',Georgia,'Times New Roman',serif; font-size:19px; line-height:26px; color:{{c_signName}}; padding-top:2px;">The {{brandName}} team</div>
-            </td>
-          </tr>
+          <!-- No reassurance line or warm-regards block above the footer: both
+               duplicated the footer's receiving-because line and wordmark — cut
+               2026-07-25. The footer is the single sign-off. -->
 
           <!-- ============ FOOTER ============ -->
           <tr>

--- a/backend/src/services/email-templates/confirmation-email-draw.txt
+++ b/backend/src/services/email-templates/confirmation-email-draw.txt
@@ -2,15 +2,13 @@ You're in the draw.
 
 Hello {{firstName}},
 
-Your entry for {{campaignName}} is in — you're in the running for {{prize}}.
+Your entry for {{campaignName}} is in.
 
 RIGHT NOW: 1x    AFTER YOUR REVIEW: {{multiplier}}x
 {{multiplier}}x chances to win {{prize}}.
 
 Want {{multiplier}}x the chances? Complete your complimentary financial review session — when your consultant records it, your entry is multiplied.
-
-Entrant: {{firstName}}
-Status: In the draw{{stat3Text}}
+{{passText}}{{standingText}}
 
 If you win, we contact you directly after the draw — and we never ask for payment to release a prize.
 
@@ -22,12 +20,6 @@ Share your personal link with friends. When someone signs up through it, you are
 
 Your referral link:
 {{shareUrl}}
-
-------------------------------------------------------------
-
-Did not request this? No action is needed. You can safely ignore this email.
-
-The {{brandName}} team
 
 ------------------------------------------------------------
 

--- a/backend/src/services/email-templates/leadConfirmation.js
+++ b/backend/src/services/email-templates/leadConfirmation.js
@@ -43,15 +43,22 @@ export function escapeHtml(value) {
 
 /**
  * The draw-only merge fields for the Onyx email: the palette, the letterhead
- * wordmark, and the third "standing" stat.
+ * wordmark, the optional entry-pass block, and the single "standing" stat.
  *
- * The third stat follows the honest-date rule from the pass artwork (#252, one
- * date per surface). `drawOn` is the draw day and is stated as such; without one
- * we fall back to when ENTRIES CLOSE, a different and equally true fact — the
- * boost deadline is never dressed up as a draw date. With neither, the cell
- * disappears and the two remaining stats split the row.
+ * The standing stat follows the honest-date rule from the pass artwork (#252,
+ * one date per surface). `drawOn` is the draw day and is stated as such;
+ * without one we fall back to when ENTRIES CLOSE, a different and equally true
+ * fact — the boost deadline is never dressed up as a draw date. With neither,
+ * the whole standing row disappears. ENTRANT and STATUS were cut 2026-07-25:
+ * the greeting already names the entrant and the H1 already states the status.
+ *
+ * `drawPass` is what makes this ONE email instead of two: when the send
+ * carries a pass ({ link, deadlineLong, hasImage }), the pass block renders
+ * inline — the card as a cid:draw-pass image plus the live /r/ link — and the
+ * standalone reservation email is not sent at all. A confirmation without an
+ * entitlement (no activation, issuance skipped) simply omits the block.
  */
-function drawFields({ luckyDraw, campaignName, palette, isMktrHost }) {
+function drawFields({ luckyDraw, campaignName, palette, isMktrHost, drawPass }) {
   const drawOn = shortDate(luckyDraw.drawOn);
   const closesAt = shortDate(luckyDraw.closesAt);
   const stat3 = drawOn
@@ -59,6 +66,30 @@ function drawFields({ luckyDraw, campaignName, palette, isMktrHost }) {
     : closesAt
       ? { key: 'ENTRIES CLOSE', val: closesAt }
       : null;
+
+  const passLink = drawPass?.link ? escapeHtml(drawPass.link) : '';
+  const deadline = drawPass?.deadlineLong ? escapeHtml(drawPass.deadlineLong) : '';
+  const passCaption = deadline
+    ? `Your consultant scans this at your session &mdash; reviews recorded by ${deadline} count.`
+    : 'Your consultant scans this at your session.';
+  // The card can be absent (renderer failure never blocks a send) — the block
+  // then leads with the link, so the pass still reaches the inbox.
+  const passRow = passLink
+    ? '<tr>\n            <td class="px" style="padding:26px 40px 0 40px;">\n              '
+      + `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="${palette.c_boxBg}" style="background-color:${palette.c_boxBg}; border:1px solid ${palette.c_boxBorder}; border-radius:16px;"><tr>`
+      + '<td class="card-px" align="center" style="padding:24px 28px 24px 28px;">'
+      + `<div style="font-family:${MONO_STACK};font-size:10px;letter-spacing:0.2em;color:${palette.c_eyebrow};padding-bottom:14px;">YOUR ENTRY PASS</div>`
+      + (drawPass.hasImage
+        ? '<img src="cid:draw-pass" width="300" alt="Your lucky draw entry pass" style="display:block;margin:0 auto;width:300px;max-width:100%;height:auto;border-radius:14px;">'
+        : '')
+      + `<div style="padding-top:${drawPass.hasImage ? 16 : 2}px;"><a href="${passLink}" style="font-family:${MONO_STACK};font-size:11px;letter-spacing:0.12em;color:${palette.c_linkText};text-decoration:underline;">VIEW YOUR ENTRY PASS</a></div>`
+      + `<div style="padding-top:12px;font-family:${SERIF_STACK};font-size:14px;line-height:21px;color:${palette.c_quiet};">${passCaption}</div>`
+      + '</td></tr></table>\n            </td>\n          </tr>'
+    : '';
+  const passText = drawPass?.link
+    ? `\n\nYour entry pass (your consultant scans it at your session):\n${drawPass.link}`
+      + (drawPass.deadlineLong ? `\nReviews recorded by ${drawPass.deadlineLong} count.` : '')
+    : '';
 
   return {
     ...palette,
@@ -69,14 +100,17 @@ function drawFields({ luckyDraw, campaignName, palette, isMktrHost }) {
     drawHeroLogo: isMktrHost
       ? '<img src="https://mktr.sg/email/new-mktr-wordmark-light.png" width="106" height="37" alt="MKTR" style="display:block;border:0;outline:none;">'
       : `<span style="font-family:${SERIF_STACK};font-size:27px;line-height:32px;color:${palette.c_word};letter-spacing:0.01em;">Redeem</span>`,
-    statWidth: stat3 ? '33%' : '50%',
-    stat3Cell: stat3
-      ? '<td width="33%" valign="top" style="padding:20px 0 0 0;">'
+    passRow,
+    passText,
+    standingRow: stat3
+      ? '<tr>\n            <td class="px" style="padding:28px 40px 0 40px;">\n              '
+        + `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-top:1px solid ${palette.c_hair};"><tr>`
+        + '<td valign="top" style="padding:20px 0 0 0;">'
         + `<div style="font-family:${MONO_STACK};font-size:10px;letter-spacing:0.16em;color:${palette.c_statKey};padding-bottom:7px;">${stat3.key}</div>`
         + `<div style="font-family:${SERIF_STACK};font-size:17px;line-height:22px;color:${palette.c_statVal};">${stat3.val}</div>`
-        + '</td>'
+        + '</td></tr></table>\n            </td>\n          </tr>'
       : '',
-    stat3Text: stat3 ? `\n${stat3.key.charAt(0)}${stat3.key.slice(1).toLowerCase()}: ${stat3.val}` : '',
+    standingText: stat3 ? `\n\n${stat3.key.charAt(0)}${stat3.key.slice(1).toLowerCase()}: ${stat3.val}` : '',
   };
 }
 
@@ -92,6 +126,7 @@ function drawFields({ luckyDraw, campaignName, palette, isMktrHost }) {
 export function renderLeadConfirmation({
   firstName, campaignName, luckyDraw, isMktrHost,
   shareUrl = '', unsubscribeUrl = '', unsubscribeTextLine = '',
+  drawPass = null,
 }) {
   const isDraw = luckyDraw?.enabled === true;
   const brandName = isMktrHost ? 'MKTR' : 'Redeem';
@@ -120,7 +155,7 @@ export function renderLeadConfirmation({
     heroLogo: isMktrHost
       ? '<img src="https://mktr.sg/email/new-mktr-wordmark-light.png" width="150" height="53" alt="MKTR" style="display:block;margin:0 auto;border:0;outline:none;">'
       : '<span style="font-family:\'Fraunces\',Georgia,\'Times New Roman\',serif;font-size:38px;line-height:42px;font-weight:600;letter-spacing:0.005em;color:#FFFCF7;">RedeemSG</span>',
-    ...(isDraw ? drawFields({ luckyDraw, campaignName, palette, isMktrHost }) : {}),
+    ...(isDraw ? drawFields({ luckyDraw, campaignName, palette, isMktrHost, drawPass }) : {}),
   };
 
   const escapeFields = new Set(['firstName', 'campaignName', 'shareUrl', 'prize']);

--- a/backend/src/services/mailer.js
+++ b/backend/src/services/mailer.js
@@ -239,7 +239,14 @@ function getModernTemplate(title, content, action, options = {}) {
 }
 
 
-export async function sendLeadConfirmationEmail(prospect, { shareUrl: shareUrlOverride } = {}) {
+/**
+ * The ONE confirmation email per signup. `drawPass` ({ png, link, deadlineLong })
+ * is how a draw signup's entry pass rides INSIDE this email instead of as a
+ * second, near-duplicate send: fulfilmentNotify passes it when it owns the
+ * delivery (entitlement issued at capture), and the standalone reservation
+ * email is not sent for draws at all (2026-07-25 merge).
+ */
+export async function sendLeadConfirmationEmail(prospect, { shareUrl: shareUrlOverride, drawPass = null } = {}) {
   if (!prospect?.email) {
     logger.warn('Skipping lead confirmation email: prospect has no email', { prospectId: prospect?.id });
     return { success: false, message: 'Missing prospect email' };
@@ -318,11 +325,16 @@ export async function sendLeadConfirmationEmail(prospect, { shareUrl: shareUrlOv
       }
     : undefined;
 
+  // The pass only exists on the draw template; the card PNG rides as a
+  // CID-inline attachment (renders with remote images blocked; the pass token
+  // stays out of image-proxy logs, same rationale as fulfilmentNotify).
+  const pass = isDraw && drawPass?.link ? drawPass : null;
   const { html, text } = renderLeadConfirmation({
     firstName, campaignName, luckyDraw, isMktrHost, shareUrl, unsubscribeUrl, unsubscribeTextLine,
+    drawPass: pass ? { link: pass.link, deadlineLong: pass.deadlineLong || '', hasImage: Boolean(pass.png) } : null,
   });
 
-  logger.info('Sending lead confirmation email', { to: prospect.email, prospectId: prospect.id, campaign: campaignName, brand: brandName });
+  logger.info('Sending lead confirmation email', { to: prospect.email, prospectId: prospect.id, campaign: campaignName, brand: brandName, withPass: Boolean(pass) });
 
   return sendEmail({
     to: prospect.email,
@@ -331,6 +343,7 @@ export async function sendLeadConfirmationEmail(prospect, { shareUrl: shareUrlOv
     text,
     context: hostChoice,
     ...(unsubHeaders ? { headers: unsubHeaders } : {}),
+    ...(pass?.png ? { attachments: [{ filename: 'entry-pass.png', content: pass.png, cid: 'draw-pass' }] } : {}),
   });
 }
 

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -1296,13 +1296,23 @@ export function makeProspectService(overrides = {}) {
     // Screening holds ARE reward-eligible (plan D8): the consumer earned the
     // signup reward by verified signup — screening gates AGENT delivery, not
     // consumer rewards. Quota/DNC/external holds stay excluded as before.
+    // The hook's ISSUANCE result is kept as an always-resolving promise for the
+    // caller: the controller chains the confirmation email on it so a queued
+    // merged draw email (drawEmailQueued) suppresses the near-duplicate generic
+    // confirmation — an observed outcome, never a prediction, so a skip can
+    // never orphan a signup with zero emails. Still fire-and-forget for the
+    // capture path itself (errors resolve to null, logged as before).
+    let leadCapturedOutcome = null;
     if (!quarantined || heldReason === 'screening_pending') {
       try {
         const hookResult = d.onLeadCaptured?.(prospect);
-        if (hookResult && typeof hookResult.catch === 'function') {
-          hookResult.catch((err) =>
-            d.logger.error('[RedeemOps] onLeadCaptured error', { error: err?.message || String(err) })
-          );
+        if (hookResult && typeof hookResult.then === 'function') {
+          leadCapturedOutcome = hookResult.catch((err) => {
+            d.logger.error('[RedeemOps] onLeadCaptured error', { error: err?.message || String(err) });
+            return null;
+          });
+        } else if (hookResult != null) {
+          leadCapturedOutcome = Promise.resolve(hookResult);
         }
       } catch (err) {
         d.logger.error('[RedeemOps] onLeadCaptured error', { error: err?.message || String(err) });
@@ -1360,7 +1370,7 @@ export function makeProspectService(overrides = {}) {
       );
     }
 
-    return { prospect, assignedAgentId, assignedAgent, prospectWithCampaign, quarantined, shareUrl };
+    return { prospect, assignedAgentId, assignedAgent, prospectWithCampaign, quarantined, shareUrl, leadCapturedOutcome };
   }
 
   /**

--- a/backend/src/services/redeemOps/entitlementService.js
+++ b/backend/src/services/redeemOps/entitlementService.js
@@ -394,6 +394,12 @@ export function makeEntitlementService(overrides = {}) {
         presentationToken: presentation.raw,
         voucherToken: voucher ? voucher.raw : null,
         emailQueued,
+        // A queued draw-pass email IS the lead-confirmation email (the merged
+        // Onyx send, 2026-07-25) — the capture controller chains on this flag
+        // to skip its own confirmation instead of double-sending. Only the
+        // reservation kind qualifies: an on_capture voucher email confirms a
+        // reward, not a draw entry.
+        drawEmailQueued: Boolean(!onCapture && drawCtx && emailQueued),
       };
     } catch (err) {
       if (err?._soft) return fail(err.message);

--- a/backend/src/services/redeemOps/fulfilmentNotify.js
+++ b/backend/src/services/redeemOps/fulfilmentNotify.js
@@ -1,6 +1,6 @@
 import QRCode from 'qrcode';
 import { RewardOffer, PartnerOrganisation, Campaign, Activation } from '../../models/index.js';
-import { sendEmail } from '../mailer.js';
+import { sendEmail, sendLeadConfirmationEmail } from '../mailer.js';
 import { logger } from '../../utils/logger.js';
 import { maskEmail } from '../../utils/redactTokens.js';
 import { customerHostOrigin, normalizeCustomerHostChoice } from '../../utils/customerHost.js';
@@ -31,7 +31,8 @@ export function canEmailProspect(prospect) {
 
 export function makeFulfilmentNotify(overrides = {}) {
   const d = {
-    RewardOffer, PartnerOrganisation, Campaign, Activation, sendEmail, logger, QRCode,
+    RewardOffer, PartnerOrganisation, Campaign, Activation, sendEmail, sendLeadConfirmationEmail,
+    logger, QRCode,
     renderQrCard: renderQrCardPng, ...overrides,
   };
 
@@ -113,7 +114,19 @@ export function makeFulfilmentNotify(overrides = {}) {
     }
   }
 
-  /** Reservation-pass email at capture (agent_unlock policy). */
+  /**
+   * Reservation-pass email at capture (agent_unlock policy).
+   *
+   * Draw rails do NOT get a standalone pass email any more (2026-07-25): a
+   * draw signup used to land TWO near-identical "You're in the draw" emails in
+   * the same minute — this one and the controller's Onyx confirmation, with
+   * the same subject, threading together in Gmail. Now the ONE Onyx
+   * confirmation carries the pass (card + /r/ link) and this sender delegates
+   * to it; the controller skips its own send whenever this leg was queued
+   * (issueForProspect returns drawEmailQueued). The delegated send still
+   * resolves the normalized `{ sent, to?, error? }` so receipts — and the
+   * missed-delivery sweep that re-sends on notify_failed — keep working.
+   */
   async function sendReservationEmail({ entitlement, prospect, presentationToken, drawCtx = null }) {
     if (!canEmailProspect(prospect)) return { sent: false, skipped: 'no_email' };
     const { activation, rewardName, partnerName } = await loadOfferContext(entitlement);
@@ -123,19 +136,30 @@ export function makeFulfilmentNotify(overrides = {}) {
       state: 'pass', qrContent: link, entitlement, prospect, rewardName, partnerName, hostChoice,
       draw: drawCtx ? drawCardFacts(drawCtx) : null,
     });
-    // Draw voice (PR-4, F13/D5): an entrant who just joined a lucky draw must
-    // read DRAW copy — "1 chance now, ×N when you meet the consultant" — not
-    // partner-reward reservation copy (Shawn's D5 line, verbatim register).
-    const html = drawCtx ? `
-      <div style="font-family:Arial,sans-serif;max-width:520px;margin:0 auto;padding:24px">
-        <h2 style="margin:0 0 8px">You're in the draw 🎉</h2>
-        <p>Hi ${escapeHtml(prospect.firstName || 'there')},</p>
-        <p>Your entry to <strong>${escapeHtml(drawCtx.drawName)}</strong> is confirmed — you hold <strong>1 chance</strong> in the draw right now.</p>
-        <p><strong>${drawCtx.multiplier}x your chances when you meet with a consultant:</strong> complete your complimentary 20-minute financial review and they will scan this pass at the session.</p>
-        <p style="text-align:center;margin:20px 0"><img src="cid:reservation-qr" width="320" height="320" style="max-width:100%" alt="Entry pass QR"/></p>
-        <p style="text-align:center"><a href="${link}" style="color:#2563eb">View your entry pass</a></p>
-        <p style="color:#6b7280;font-size:12px">Reviews must be completed by ${escapeHtml(boostDeadlineLong(drawCtx.boostClosesAt) || 'the close date')} to count. We never ask you to pay to release a prize.</p>
-      </div>` : `
+
+    if (drawCtx) {
+      const campaign = drawCtx.campaignId
+        ? await d.Campaign.findByPk(drawCtx.campaignId, { attributes: ['id', 'name', 'design_config'] })
+        : null;
+      if (!campaign) {
+        // Unreachable in practice (drawCtx was derived from this campaign) —
+        // fail receipted rather than silently, so the sweep retries.
+        return { sent: false, to: maskEmail(prospect.email), error: 'draw campaign missing' };
+      }
+      const plain = typeof prospect.get === 'function' ? prospect.get({ plain: true }) : { ...prospect };
+      try {
+        const r = await d.sendLeadConfirmationEmail(
+          { ...plain, campaign },
+          { drawPass: { png: qrPng, link, deadlineLong: boostDeadlineLong(drawCtx.boostClosesAt) } }
+        );
+        if (r?.success === true) return { sent: true, to: maskEmail(prospect.email) };
+        return { sent: false, to: maskEmail(prospect.email), error: r?.message || 'mailer not configured' };
+      } catch (err) {
+        return { sent: false, to: maskEmail(prospect.email), error: err?.message || 'send failed' };
+      }
+    }
+
+    const html = `
       <div style="font-family:Arial,sans-serif;max-width:520px;margin:0 auto;padding:24px">
         <h2 style="margin:0 0 8px">Your ${escapeHtml(rewardName)} is reserved 🎁</h2>
         <p>Hi ${escapeHtml(prospect.firstName || 'there')},</p>
@@ -148,13 +172,11 @@ export function makeFulfilmentNotify(overrides = {}) {
       </div>`;
     return deliver({
       to: prospect.email,
-      subject: drawCtx ? `You're in the draw — ${drawCtx.drawName}` : `Reserved for you: ${rewardName}`,
+      subject: `Reserved for you: ${rewardName}`,
       html,
-      text: drawCtx
-        ? `Your entry to ${drawCtx.drawName} is confirmed — 1 chance now. ${drawCtx.multiplier}x your chances when you meet with a consultant (scan this pass at the session): ${link}`
-        : `Your ${rewardName} from ${partnerName} is reserved. Show this link's QR to your consultant at your review to unlock it: ${link}`,
+      text: `Your ${rewardName} from ${partnerName} is reserved. Show this link's QR to your consultant at your review to unlock it: ${link}`,
       context: hostChoice === 'mktr' ? 'mktr' : 'redeem',
-      attachments: [{ filename: drawCtx ? 'entry-pass.png' : 'reservation.png', content: qrPng, cid: 'reservation-qr' }],
+      attachments: [{ filename: 'reservation.png', content: qrPng, cid: 'reservation-qr' }],
     }, prospect.email);
   }
 

--- a/backend/test/unit/drawConfirmationMerge.test.js
+++ b/backend/test/unit/drawConfirmationMerge.test.js
@@ -1,0 +1,157 @@
+/**
+ * One draw signup, ONE email (2026-07-25 merge): the entry pass rides inside
+ * the Onyx confirmation instead of shipping as a second, same-subject email
+ * that Gmail threads into an apparent duplicate. Two seams make that true:
+ *
+ *  - fulfilmentNotify.sendReservationEmail with drawCtx DELEGATES to
+ *    sendLeadConfirmationEmail — campaign hydrated, card + /r/ link riding as
+ *    drawPass — while keeping the normalized `{ sent, to?, error? }` receipt
+ *    contract the delivery sweep depends on. Trial rails keep the standalone
+ *    reservation email byte-unchanged.
+ *
+ *  - issueForProspect surfaces `drawEmailQueued` so the capture controller
+ *    can skip its own confirmation on an OBSERVED outcome, never a
+ *    prediction — a skipped issuance still gets the plain confirmation.
+ */
+import { jest } from '@jest/globals';
+import { makeFulfilmentNotify } from '../../src/services/redeemOps/fulfilmentNotify.js';
+import { makeEntitlementService, flushDeliveries } from '../../src/services/redeemOps/entitlementService.js';
+
+const silentLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+
+const DRAW_CTX = {
+  campaignId: 'c1', drawName: 'iPhone 17 Pro Lucky Draw', multiplier: 10,
+  prize: 'iPhone 17 Pro 256GB', drawOn: '2026-10-22', passTheme: 'titanium',
+  boostClosesAt: '2026-09-30', boostCutoffMs: Date.now() + 30 * 864e5,
+};
+
+describe('fulfilmentNotify.sendReservationEmail — the merged draw send', () => {
+  const entitlement = { id: 'ent1', rewardOfferId: 'off1', activationId: 'act1', expiresAt: new Date(Date.now() + 7 * 864e5) };
+  const prospect = { id: 'p1', email: 'lai@example.com', firstName: 'lai', consumerId: 'con1', campaignId: 'c1' };
+
+  function world(over = {}) {
+    const deps = {
+      RewardOffer: { findByPk: jest.fn(async () => ({ id: 'off1', publicTitle: 'Lucky Draw Entry', partner: { tradingName: 'MKTR' } })) },
+      Activation: { findByPk: jest.fn(async () => ({ id: 'act1', campaignId: 'c1' })) },
+      Campaign: {
+        findByPk: jest.fn(async () => ({
+          id: 'c1', name: 'iPhone 17 Pro Lucky Draw',
+          design_config: { customerHost: 'redeem', luckyDraw: { enabled: true, passTheme: 'titanium', prize: 'iPhone 17 Pro 256GB', multiplier: 10 } },
+        })),
+      },
+      renderQrCard: jest.fn(async () => Buffer.from('vault-card-png')),
+      sendEmail: jest.fn(async () => ({ success: true })),
+      sendLeadConfirmationEmail: jest.fn(async () => ({ success: true })),
+      logger: silentLogger,
+      ...over,
+    };
+    return { deps, notify: makeFulfilmentNotify(deps) };
+  }
+
+  it('draw: ONE merged Onyx send — campaign hydrated, pass card + /r/ link attached, no standalone email', async () => {
+    const w = world();
+    const res = await w.notify.sendReservationEmail({ entitlement, prospect, presentationToken: 'tok123', drawCtx: DRAW_CTX });
+
+    expect(res.sent).toBe(true);
+    expect(w.deps.sendLeadConfirmationEmail).toHaveBeenCalledTimes(1);
+    const [mailedProspect, opts] = w.deps.sendLeadConfirmationEmail.mock.calls[0];
+    expect(mailedProspect.email).toBe('lai@example.com');
+    expect(mailedProspect.campaign).toMatchObject({ id: 'c1', name: 'iPhone 17 Pro Lucky Draw' });
+    expect(opts.drawPass.link).toContain('/r/tok123');
+    expect(Buffer.isBuffer(opts.drawPass.png)).toBe(true);
+    expect(opts.drawPass.deadlineLong).toContain('September');
+    // The old standalone "You're in the draw 🎉" email must NOT also fire.
+    expect(w.deps.sendEmail).not.toHaveBeenCalled();
+  });
+
+  it('draw: a mailer failure resolves sent:false with the reason — receipts stay truthful, the sweep can re-send', async () => {
+    const w = world({ sendLeadConfirmationEmail: jest.fn(async () => ({ success: false, message: 'SMTP down' })) });
+    const res = await w.notify.sendReservationEmail({ entitlement, prospect, presentationToken: 'tok123', drawCtx: DRAW_CTX });
+    expect(res).toMatchObject({ sent: false, error: 'SMTP down' });
+  });
+
+  it('trial rails keep the standalone reservation email, byte-unchanged by the merge', async () => {
+    const w = world();
+    const res = await w.notify.sendReservationEmail({ entitlement, prospect, presentationToken: 'tok123', drawCtx: null });
+    expect(res.sent).toBe(true);
+    expect(w.deps.sendLeadConfirmationEmail).not.toHaveBeenCalled();
+    expect(w.deps.sendEmail).toHaveBeenCalledTimes(1);
+    expect(w.deps.sendEmail.mock.calls[0][0].subject).toContain('Reserved for you');
+  });
+
+  it('synthetic Retell address: skipped before anything loads', async () => {
+    const w = world();
+    const res = await w.notify.sendReservationEmail({
+      entitlement, prospect: { ...prospect, email: 'retell-abc@calls.mktr.sg' }, presentationToken: 't', drawCtx: DRAW_CTX,
+    });
+    expect(res).toEqual({ sent: false, skipped: 'no_email' });
+    expect(w.deps.sendLeadConfirmationEmail).not.toHaveBeenCalled();
+    expect(w.deps.sendEmail).not.toHaveBeenCalled();
+  });
+});
+
+describe('issueForProspect — the drawEmailQueued signal', () => {
+  function issueWorld({ draw = true, unlockPolicy = 'agent_unlock', email = 'lai@example.com' } = {}) {
+    const offer = { id: 'off1', status: 'active', claimExpiryDays: 7, redemptionExpiryDays: 30 };
+    const activation = { id: 'act1', campaignId: 'c1', status: 'active', unlockPolicy, endDate: null, rewardOffer: offer };
+    const prospect = {
+      id: 'p1', campaignId: 'c1', phone: '+6591234567', email, firstName: 'lai', consumerId: 'con1',
+      sourceMetadata: { phoneVerifiedAt: '2026-07-25T00:00:00Z' },
+    };
+    const deps = {
+      Activation: { findOne: jest.fn(async () => activation), findByPk: jest.fn(async () => activation) },
+      RewardOffer: {}, // model ref for the include clause only
+      RewardEntitlement: {
+        findOne: jest.fn(async () => null),
+        create: jest.fn(async (row) => ({ id: 'ent1', ...row })),
+      },
+      ActivationIssuanceSkip: { create: jest.fn(async () => ({})) },
+      Consumer: { findOne: jest.fn(async () => null) },
+      Prospect: { findByPk: jest.fn(async () => prospect) },
+      RedemptionEvent: { create: jest.fn(async (e) => e) },
+      sequelize: { transaction: jest.fn(async (cb) => cb({})), query: jest.fn(async () => [[{ id: 'act1' }]]) },
+      inventory: { recordIssued: jest.fn() },
+      isSendBlocked: jest.fn(async () => false),
+      drawLink: { drawContextForActivation: jest.fn(async () => (draw ? DRAW_CTX : null)) },
+      notifyReservation: jest.fn(async () => ({ sent: true })),
+      notifyUnlock: jest.fn(async () => ({ sent: true })),
+      notifyReservationWa: null,
+      notifyUnlockWa: null,
+      logger: silentLogger,
+    };
+    return { deps, prospect, svc: makeEntitlementService(deps) };
+  }
+
+  it('draw + agent_unlock + emailable → drawEmailQueued: the merged email owns the confirmation', async () => {
+    const w = issueWorld();
+    const res = await w.svc.issueForProspect(w.prospect, { via: 'hook' });
+    expect(res.reason).toBeNull();
+    expect(res.emailQueued).toBe(true);
+    expect(res.drawEmailQueued).toBe(true);
+    await flushDeliveries();
+    expect(w.deps.notifyReservation).toHaveBeenCalledTimes(1);
+  });
+
+  it('non-draw issuance never claims the confirmation', async () => {
+    const w = issueWorld({ draw: false });
+    const res = await w.svc.issueForProspect(w.prospect, { via: 'hook' });
+    expect(res.reason).toBeNull();
+    expect(res.drawEmailQueued).toBe(false);
+    await flushDeliveries();
+  });
+
+  it('a no-email lead cannot mark the confirmation covered (its WhatsApp leg may still fire)', async () => {
+    const w = issueWorld({ email: 'retell-abc@calls.mktr.sg' });
+    const res = await w.svc.issueForProspect(w.prospect, { via: 'hook' });
+    expect(res.emailQueued).toBe(false);
+    expect(res.drawEmailQueued).toBe(false);
+    await flushDeliveries();
+  });
+
+  it('an on_capture voucher rail never claims it either — it confirms a reward, not a draw entry', async () => {
+    const w = issueWorld({ unlockPolicy: 'on_capture' });
+    const res = await w.svc.issueForProspect(w.prospect, { via: 'hook' });
+    expect(res.drawEmailQueued).toBe(false);
+    await flushDeliveries();
+  });
+});

--- a/backend/test/unit/leadConfirmationOnyx.test.js
+++ b/backend/test/unit/leadConfirmationOnyx.test.js
@@ -80,7 +80,7 @@ describe('the multiplier is the TOTAL, not the extra', () => {
   });
 });
 
-describe('the third stat follows the honest-date rule', () => {
+describe('the standing stat follows the honest-date rule', () => {
   test('a draw day is stated as the draw date', () => {
     const { html, text } = render({ luckyDraw: drawOf({ drawOn: '2026-10-22' }) });
     expect(html).toContain('DRAW DATE');
@@ -96,12 +96,60 @@ describe('the third stat follows the honest-date rule', () => {
     expect(html).not.toContain('30 Sep 2026');
   });
 
-  test('with neither date the cell disappears and the row rebalances', () => {
-    const { html } = render({ luckyDraw: drawOf({ drawOn: undefined, closesAt: undefined }) });
+  test('with neither date the standing row disappears entirely', () => {
+    const { html, text } = render({ luckyDraw: drawOf({ drawOn: undefined, closesAt: undefined }) });
     expect(html).not.toContain('DRAW DATE');
     expect(html).not.toContain('ENTRIES CLOSE');
-    expect(html).toContain('width="50%"');
-    expect(html).not.toContain('width="33%"');
+    expect(text).not.toContain('Draw date:');
+    expect(html).not.toMatch(/\{\{\w+\}\}/);
+  });
+});
+
+describe('the entry pass rides the confirmation (2026-07-25 one-email merge)', () => {
+  const pass = { link: 'https://redeem.sg/r/tok123', deadlineLong: '30 September 2026', hasImage: true };
+
+  test('with a pass: cid card, live link and the review deadline — in both parts', () => {
+    const { html, text } = render({ drawPass: pass });
+    expect(html).toContain('YOUR ENTRY PASS');
+    expect(html).toContain('cid:draw-pass');
+    expect(html).toContain('https://redeem.sg/r/tok123');
+    expect(html).toContain('30 September 2026');
+    expect(text).toContain('https://redeem.sg/r/tok123');
+    expect(text).toContain('30 September 2026');
+    expect(html).not.toMatch(/\{\{\w+\}\}/);
+    expect(text).not.toMatch(/\{\{\w+\}\}/);
+  });
+
+  test('a failed card render degrades to the link — never a broken image', () => {
+    const { html } = render({ drawPass: { ...pass, hasImage: false } });
+    expect(html).not.toContain('cid:draw-pass');
+    expect(html).toContain('https://redeem.sg/r/tok123');
+    expect(html).toContain('YOUR ENTRY PASS');
+  });
+
+  test('without a pass the block is absent, with no placeholder residue', () => {
+    const { html, text } = render();
+    expect(html).not.toContain('YOUR ENTRY PASS');
+    expect(html).not.toContain('cid:draw-pass');
+    expect(html).not.toMatch(/\{\{\w+\}\}/);
+    expect(text).not.toMatch(/\{\{\w+\}\}/);
+  });
+});
+
+describe('the 2026-07-25 copy cuts stay cut', () => {
+  test('one prize mention (the meter), no eyebrow dup, no entrant/status echo, no double sign-off', () => {
+    const { html, text } = render({ luckyDraw: drawOf({ prize: 'PRIZE-SENTINEL' }) });
+    expect((html.match(/PRIZE-SENTINEL/g) || []).length).toBe(1);
+    expect((text.match(/PRIZE-SENTINEL/g) || []).length).toBe(1);
+    expect(html).not.toContain('YOU&rsquo;RE IN THE DRAW'); // uppercase eyebrow above the H1
+    expect(html).not.toContain('ENTRANT');
+    expect(html).not.toContain('STATUS');
+    expect(html).not.toContain('TAP A BUTTON TO SHARE');
+    expect(html).not.toContain('Warm regards');
+    expect(html).not.toContain('Did not request this?');
+    expect(text).not.toContain('Did not request this?');
+    expect(text).not.toContain('Entrant:');
+    expect(text).not.toContain('Status:');
   });
 });
 

--- a/backend/test/unit/prospectService.test.js
+++ b/backend/test/unit/prospectService.test.js
@@ -165,7 +165,7 @@ function buildMocks() {
   };
 }
 
-function makeService(mocks) {
+function makeService(mocks, extra = {}) {
   return makeProspectService({
     models: mocks.models,
     sequelize: mocks.sequelize,
@@ -181,6 +181,7 @@ function makeService(mocks) {
     processLeadOutcome: mocks.processLeadOutcome,
     // PR-2 (CX13): stub the lazy default — the real one reaches the live DB.
     cancelLiveEntitlementsForProspectTx: mocks.cancelLiveEntitlementsForProspectTx,
+    ...extra,
   });
 }
 
@@ -585,6 +586,45 @@ describe('prospectService (unit)', () => {
   // ────────────────────────────────────────────────
   // assignProspect
   // ────────────────────────────────────────────────
+
+  // ────────────────────────────────────────────────
+  // createProspect → leadCapturedOutcome (the draw one-email dedupe seam:
+  // the controller chains its confirmation send on this observed outcome)
+  // ────────────────────────────────────────────────
+
+  describe('createProspect — leadCapturedOutcome', () => {
+    const user = { id: 'admin-1', role: 'admin' };
+    const body = { firstName: 'Test', phone: '91234567', campaignId: 'camp-1' };
+
+    it('hands the hook result back as an always-resolving promise', async () => {
+      const onLeadCaptured = jest.fn(async () => ({ drawEmailQueued: true }));
+      service = makeService(mocks, { onLeadCaptured });
+
+      const res = await service.createProspect(body, user, {});
+
+      expect(onLeadCaptured).toHaveBeenCalledTimes(1);
+      await expect(res.leadCapturedOutcome).resolves.toEqual({ drawEmailQueued: true });
+    });
+
+    it('a hook failure resolves null (logged) — the caller then sends the plain confirmation', async () => {
+      service = makeService(mocks, {
+        onLeadCaptured: jest.fn(async () => { throw new Error('redeem ops down'); }),
+      });
+
+      const res = await service.createProspect(body, user, {});
+
+      await expect(res.leadCapturedOutcome).resolves.toBeNull();
+      expect(mocks.logger.error).toHaveBeenCalledWith(
+        '[RedeemOps] onLeadCaptured error',
+        expect.objectContaining({ error: 'redeem ops down' })
+      );
+    });
+
+    it('without a registered hook the outcome is null', async () => {
+      const res = await service.createProspect(body, user, {});
+      expect(res.leadCapturedOutcome).toBeNull();
+    });
+  });
 
   describe('assignProspect', () => {
     const user = { id: 'admin-1', role: 'admin', firstName: 'Admin' };


### PR DESCRIPTION
## Problem

One draw signup fired **three messages inside a minute**: the Onyx confirmation email, a plain pass email with the *same subject* (they thread together in Gmail and read as a glitch), and the WhatsApp Vault card. The two emails repeated each other almost line for line — and the beautiful Onyx email was missing the one thing the entrant needs at the session (the pass), while the pass email duplicated everything else.

## Change

The journey is now **1 WhatsApp (the operative pass) + 1 email**:

- `fulfilmentNotify.sendReservationEmail` with `drawCtx` **delegates to `sendLeadConfirmationEmail`** — the Vault card rides as `cid:draw-pass` with the live `/r/` link inside the Onyx confirmation. The normalized `{ sent, to?, error? }` receipt contract is kept, so `reconcileMissedDeliveries` still re-sends on failure. **Trial rails keep the standalone reservation email untouched.**
- `issueForProspect` returns `drawEmailQueued`; the capture hook hands the issuance result back (`bootstrap` → `prospectService.leadCapturedOutcome`) and the controller chains its confirmation on that **observed outcome** — it skips only when the merged email was actually queued. A skipped issuance (no activation, dup, no email) still gets the plain confirmation; no signup can end up with zero emails. WhatsApp leg unchanged.

### Copy cuts (Onyx template, both HTML + text)

- eyebrow kicker that repeated the H1 verbatim
- prize named 3× in the top third → once, in the meter
- ENTRANT/STATUS echo cells → standing keeps the one honest date (draw date, else entries-close)
- "TAP A BUTTON TO SHARE…" hint, "Did not request this?" line, "Warm regards" double sign-off
- footer (receiving-because + unsubscribe + entity) is the single sign-off; List-Unsubscribe plumbing intact

## Proof

- `drawConfirmationMerge.test.js` (new): delegation w/ card+link, receipt truthfulness on mailer failure, trial-rail untouched, Retell skip; `drawEmailQueued` ×4 (draw/non-draw/no-email/on_capture)
- `leadConfirmationOnyx.test.js`: pass block (cid, link, deadline, degrade, absence), standing honest-date, cut-copy guards
- `prospectService.test.js`: `leadCapturedOutcome` always-resolving (result / hook-failure→null / no hook)
- 7 affected suites green (142 tests). Full unit dir: 1703 pass; the 24 failures in `emailService`/`shortlinkService` are **byte-identical on pristine origin/main** (inherited stale masking expectations), `consentGlobalGrant` needs local Postgres as documented.
- `scripts/preview-draw-email.js` renders the pass slot (titanium: card, emerald: link-only degrade) — verified visually in all four colourways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VR83Z5ya6HNf3JJuxzkAQw