### PR TITLE
feat(screening): WhatsApp callback leg — invite, consent tap, auto-dial

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -165,6 +165,9 @@ RETELL_SCREENING_ENABLED=false
 # Approved WA UTILITY template for draw entry passes (PR-4; 4 params —
 # name, draw name, pass link, boost deadline). Defaults to 'draw_entry_pass'.
 # WHATSAPP_TEMPLATE_DRAW_PASS=draw_entry_pass
+# Approved WA MARKETING template for the screening callback opt-in (§16.6;
+# 4 params — name, draw name, multiplier, prize; URL button = consent tap).
+# WHATSAPP_TEMPLATE_DRAW_CALLBACK=draw_callback_optin
 
 # Webhook dispatch — MUST be "true" for leads to reach Lyfe
 WEBHOOK_ENABLED=false

--- a/backend/src/routes/screeningCallback.js
+++ b/backend/src/routes/screeningCallback.js
@@ -1,0 +1,65 @@
+import express from 'express';
+import rateLimit from 'express-rate-limit';
+import { asyncHandler } from '../middleware/errorHandler.js';
+import { readWaCallbackContext, applyWaCallbackRequest } from '../services/retellScreeningService.js';
+
+/**
+ * PUBLIC screening-callback opt-in — backs redeem.sg/callback?t=<token>
+ * (docs/plans/retell-screening-calls.md §16.6), the landing page of the
+ * draw_callback_optin WhatsApp button.
+ *
+ * Token-authenticated like /api/reward-claim: the URL token IS the credential
+ * (128-bit, minted per lead when the invite is sent, expires with the
+ * screening hold). Responses carry the holder's first name + draw context
+ * only — never full lead PII. The POST is the customer's documented consent
+ * to be called: it schedules the ring-back; every dial guard (window, DNC,
+ * consent, budget, concurrency) still re-runs at dial time, so a tap can
+ * never bypass policy — and the attempt budget caps total dials.
+ *
+ * Deliberately OUTSIDE the host-blocked internal prefixes, so it is reachable
+ * from the redeem.sg static site (internalRouteHostGuard blocklist).
+ */
+export const meta = {
+  path: '/api/screening-callback',
+};
+
+const callbackLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 60, // generous for a human, hostile to token scanning (reward-claim parity)
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === 'test',
+  message: { success: false, message: 'Too many requests — try again later.' },
+});
+
+const router = express.Router();
+
+router.get('/:token', callbackLimiter, asyncHandler(async (req, res) => {
+  const raw = String(req.params.token || '').trim();
+  if (raw.length < 16 || raw.length > 64) {
+    return res.status(404).json({ success: false, message: 'Not found' });
+  }
+  const ctx = await readWaCallbackContext(raw);
+  if (ctx.state === 'invalid') {
+    return res.status(404).json({ success: false, message: 'Not found' });
+  }
+  return res.json({ success: true, data: ctx });
+}));
+
+router.post('/:token', callbackLimiter, asyncHandler(async (req, res) => {
+  const raw = String(req.params.token || '').trim();
+  if (raw.length < 16 || raw.length > 64) {
+    return res.status(404).json({ success: false, message: 'Not found' });
+  }
+  const result = await applyWaCallbackRequest(raw, req.body?.window, { ip: req.ip || null });
+  if (result.state === 'invalid') {
+    return res.status(404).json({ success: false, message: 'Not found' });
+  }
+  if (result.state === 'bad_window') {
+    return res.status(422).json({ success: false, message: 'Pick a valid time window.' });
+  }
+  // ok:false with done/in_flight is not an error — the page renders the state.
+  return res.json({ success: true, data: result });
+}));
+
+export default router;

--- a/backend/src/services/redeemOps/whatsappService.js
+++ b/backend/src/services/redeemOps/whatsappService.js
@@ -196,19 +196,21 @@ export function makeWhatsappService(overrides = {}) {
   }
 
   /** One template send. Resolves normalized result, never throws. */
-  async function sendTemplate({ prospect, templateName, params, qrContent, card }) {
+  async function sendTemplate({ prospect, templateName, params, qrContent, card, purpose = 'transactional', urlButtonParam = null }) {
     if (!waEnabled()) return { sent: false, skipped: 'disabled' };
     // Capability inline (not via canWhatsAppProspect) so each send costs ONE
     // ledger read and the receipt codes stay distinct: 'no_whatsapp' = phone
     // capability, 'suppressed' = ledger block.
     if (!prospect || !waRecipient(prospect.phone)) return { sent: false, skipped: 'no_whatsapp' };
-    // PR B suppression gate: these sends are TRANSACTIONAL (delivering the
+    // PR B suppression gate. Default purpose is TRANSACTIONAL (delivering the
     // reward the person claimed) — only an erasure-reason suppression blocks
-    // them; a marketing unsubscribe does not (D2 resolved — see
-    // canWhatsAppProspect). Future marketing templates must call with
-    // purpose:'marketing' instead. isSendBlocked fails OPEN for transactional
-    // on lookup errors, so DB-less unit runs are unaffected.
-    if (await d.isSendBlocked(prospect, { channel: 'whatsapp', purpose: 'transactional' })) {
+    // it; a marketing unsubscribe does not (D2 resolved — see
+    // canWhatsAppProspect). purpose:'marketing' (the screening-callback
+    // invite) runs the FULL canMarketTo gate instead — verified
+    // campaign-scoped grant + no suppression — and fails CLOSED on lookup
+    // errors, while transactional keeps failing OPEN (DB-less unit runs
+    // unaffected).
+    if (await d.isSendBlocked(prospect, { channel: 'whatsapp', purpose })) {
       return { sent: false, skipped: 'suppressed' };
     }
 
@@ -223,6 +225,17 @@ export function makeWhatsappService(overrides = {}) {
       const components = [
         { type: 'body', parameters: params.map((text) => ({ type: 'text', text })) },
       ];
+      // Dynamic-suffix URL button (house shape: url 'https://redeem.sg/{{1}}',
+      // the param is path + query). Only the CTA (index 0) carries a variable;
+      // the STOP quick-reply needs no component.
+      if (urlButtonParam) {
+        components.push({
+          type: 'button',
+          sub_type: 'url',
+          index: '0',
+          parameters: [{ type: 'text', text: urlButtonParam }],
+        });
+      }
       if (qrHeaderEnabled() && (qrContent || card?.state === 'boost')) {
         // Editorial voucher card (branded frame around the QR); any renderer
         // failure degrades to the plain QR — the credential always ships.
@@ -375,8 +388,36 @@ export function makeWhatsappService(overrides = {}) {
     });
   }
 
-  return { sendReservationWhatsApp, sendVoucherWhatsApp, sendBoostReceiptWhatsApp };
+  /** The screening-callback opt-in (`draw_callback_optin`, APPROVED
+   * 2026-07-25) — the WhatsApp leg of the AI screening gate for a lead a dial
+   * could not finish. MARKETING purpose (full canMarketTo, fails closed): the
+   * message itself is the ask; the URL button's tap is the person's consent to
+   * be called. Copy contract: ×N is the TOTAL and the boost lands when the
+   * consultant RECORDS the session — the campaign-page register, deliberately
+   * NOT the phone script's "N more chances".
+   * 4 params = name, draw name, multiplier, prize label ("at {{4}}"). */
+  async function sendDrawCallbackOptinWhatsApp({ prospect, drawName, multiplier, prize, token }) {
+    const rawPrize = cleanParam(prize, '');
+    const prizeLabel = !rawPrize
+      ? 'the grand prize'
+      : (/^(the|a|an)\s/i.test(rawPrize) ? rawPrize : `the ${rawPrize}`);
+    return sendTemplate({
+      prospect,
+      templateName: process.env.WHATSAPP_TEMPLATE_DRAW_CALLBACK || 'draw_callback_optin',
+      purpose: 'marketing',
+      urlButtonParam: `callback?t=${encodeURIComponent(token)}&utm_source=wa_screening`,
+      params: [
+        cleanParam(prospect?.firstName, 'there'),
+        cleanParam(drawName, 'the lucky draw'),
+        String(Number.isFinite(Number(multiplier)) && Number(multiplier) >= 2 ? Math.floor(Number(multiplier)) : 10),
+        prizeLabel,
+      ],
+    });
+  }
+
+  return { sendReservationWhatsApp, sendVoucherWhatsApp, sendBoostReceiptWhatsApp, sendDrawCallbackOptinWhatsApp };
 }
 
 const _default = makeWhatsappService();
 export default _default;
+export const sendDrawCallbackOptinWhatsApp = _default.sendDrawCallbackOptinWhatsApp;

--- a/backend/src/services/retellScreeningService.js
+++ b/backend/src/services/retellScreeningService.js
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-import { sequelize, Prospect, Campaign, IdempotencyKey } from '../models/index.js';
+import { sequelize, Prospect, Campaign, IdempotencyKey, ProspectActivity } from '../models/index.js';
 import {
   screeningConfig,
   screeningApplies,
@@ -27,6 +27,9 @@ import { logger } from '../utils/logger.js';
 const DIAL_LOCK_KEY = 'screening_dial';
 const BUDGET_SCOPE = 'screening:dial';
 const BUDGET_TTL_MS = 48 * 60 * 60 * 1000;
+// WhatsApp callback opt-in tokens (draw_callback_optin URL button) live in
+// idempotency_keys under this scope — key `wacb:<token>` → {prospectId}.
+const WA_CB_SCOPE = 'screening:wa_callback';
 const SGT_OFFSET_MS = 8 * 60 * 60 * 1000; // Asia/Singapore, no DST
 
 /** Retell disconnection reasons meaning "the consumer never conversed". */
@@ -46,12 +49,18 @@ const defaultDeps = {
   Prospect,
   Campaign,
   IdempotencyKey,
+  ProspectActivity,
   retellClient,
   dncEnforcement,
   hasValidDncConsent,
   canMarketTo,
   logger,
   gate: makeScreeningGate(),
+  // LAZY dynamic import (house pattern, prospectService.js:174): a top-level
+  // import would drag the whole redeemOps WhatsApp graph into every unit
+  // suite that mocks this module's deps.
+  sendDrawCallbackOptin: async (args) =>
+    (await import('./redeemOps/whatsappService.js')).sendDrawCallbackOptinWhatsApp(args),
 };
 
 // ---------------------------------------------------------------------------
@@ -101,6 +110,9 @@ export function nextRetryAt(cfg, attemptCount, now = new Date()) {
  * call ran, which is what the person meant.
  */
 const CALLBACK_DELAY_MINUTES = {
+  // 'asap' is never emitted by Retell (not in the analysis enum) — it exists
+  // for the WhatsApp tap page, where "call me now" is a live request.
+  asap: 10,
   later_today: 3 * 60,
   tomorrow: 12 * 60,
   this_week: 60 * 60,
@@ -418,7 +430,214 @@ export function makeRetellScreeningService(overrides = {}) {
       return { outcome: 'exhausted', kind, policy };
     }
     await deferAttempt(prospect, retryAt || nextRetryAt(cfg, attempts));
+    // WhatsApp callback invite (plan §16.6) — fire-and-forget, never on the
+    // webhook's critical path. Eligible when the lead is STILL HELD with
+    // attempts left (after exhaustion the release policy takes the row away)
+    // and either (a) a connected call ended with no verdict and NO voice-booked
+    // callback — "call me later" with no time, hung up early — or (b) the 2nd
+    // dial went unanswered (one dial before the release policy would fire).
+    // A voice-booked callback (retryAt) skips it: the promise is already made,
+    // and the template's "sorry we missed you" would misdescribe that call.
+    if (!retryAt && (kind === 'no_verdict' || attempts >= 2)) {
+      maybeSendWaCallbackInvite(prospect, { cfg }).catch(() => {});
+    }
     return { outcome: 'retry_scheduled', kind, attempts, ...(retryAt ? { callbackAt: retryAt.toISOString() } : {}) };
+  }
+
+  /**
+   * Send the draw_callback_optin WhatsApp AT MOST ONCE per lead. Cheap guards
+   * first (draw campaign, active, marketing consent — all no-query or mocked
+   * lookups), then a fenced metadata claim so replayed webhooks can't double-
+   * send, then token mint + send + receipt patch. Never throws.
+   */
+  async function maybeSendWaCallbackInvite(prospect, { cfg = screeningConfig() } = {}) {
+    try {
+      if (!cfg.configured || cfg.dryRun) return { sent: false, reason: 'not_configured' };
+      if (prospect.screeningMetadata?.waCallback) return { sent: false, reason: 'already_sent' };
+
+      const camp = prospect.campaignId ? await d.Campaign.findByPk(prospect.campaignId).catch(() => null) : null;
+      if (!camp || String(camp.status || 'active') !== 'active' || camp.is_active === false) {
+        return { sent: false, reason: 'campaign_inactive' };
+      }
+      // The approved template speaks draw language ("your lucky draw entry") —
+      // a non-draw screening campaign must never send it.
+      const ld = getStoredLuckyDraw(camp.design_config);
+      if (!ld) return { sent: false, reason: 'not_a_draw' };
+
+      // Same consent posture as the dialer; sendTemplate re-checks with
+      // purpose:'marketing' (fail-closed) at send time.
+      try {
+        const ok = await d.canMarketTo({
+          consumerId: prospect.consumerId || null,
+          phone: prospect.phone || null,
+          channel: 'whatsapp',
+          campaignId: prospect.campaignId || null,
+        });
+        if (ok !== true) return { sent: false, reason: 'no_marketing_consent' };
+      } catch {
+        return { sent: false, reason: 'consent_lookup_failed' };
+      }
+
+      // Fenced once-per-lead claim: the loser of a webhook-replay race no-ops.
+      const token = `wcb_${crypto.randomUUID().replace(/-/g, '')}`;
+      const now = new Date();
+      const [rows] = await d.sequelize.query(
+        `UPDATE prospects
+            SET "screeningMetadata" = jsonb_set(
+                  COALESCE("screeningMetadata", '{}'::jsonb),
+                  '{waCallback}', :seed::jsonb, true),
+                "updatedAt" = NOW()
+          WHERE id = :id AND "quarantineReason" = 'screening_pending'
+            AND ("screeningMetadata" -> 'waCallback') IS NULL
+          RETURNING id`,
+        { replacements: { id: prospect.id, seed: JSON.stringify({ token, sentAt: now.toISOString() }) } }
+      );
+      if (!Array.isArray(rows) || rows.length === 0) return { sent: false, reason: 'lost_claim' };
+
+      // Token row BEFORE the send: the tap must resolve even if our receipt
+      // patch later fails. Expiry = the same 2× hold ceiling the TTL sweep
+      // grants a promised callback — past that the lead has left the queue.
+      await d.IdempotencyKey.create({
+        key: `wacb:${token}`,
+        scope: WA_CB_SCOPE,
+        responseBody: { prospectId: prospect.id },
+        responseCode: 200,
+        expiresAt: new Date(now.getTime() + 2 * cfg.maxHoldHours * 60 * 60 * 1000),
+      });
+
+      const multiplier = drawExtraChances(camp) + 1;
+      const result = await d.sendDrawCallbackOptin({
+        prospect,
+        drawName: camp.name,
+        multiplier,
+        prize: ld.prize || null,
+        token,
+      });
+      await patchWaCallback(prospect.id, {
+        sent: result?.sent === true,
+        ...(result?.skipped ? { skipped: result.skipped } : {}),
+        ...(result?.error ? { error: String(result.error).slice(0, 200) } : {}),
+      });
+      d.logger.info('[Screening] WA callback invite', { prospectId: prospect.id, sent: result?.sent === true, skipped: result?.skipped || null });
+      return { sent: result?.sent === true, token };
+    } catch (err) {
+      d.logger.warn('[Screening] WA callback invite failed', { prospectId: prospect?.id, error: err?.message || String(err) });
+      return { sent: false, reason: 'error' };
+    }
+  }
+
+  /** Merge keys into screeningMetadata.waCallback (evidence only, non-fenced). */
+  async function patchWaCallback(prospectId, patch) {
+    await d.sequelize.query(
+      `UPDATE prospects
+          SET "screeningMetadata" = jsonb_set(
+                COALESCE("screeningMetadata", '{}'::jsonb),
+                '{waCallback}',
+                COALESCE("screeningMetadata" -> 'waCallback', '{}'::jsonb) || :patch::jsonb,
+                true),
+              "updatedAt" = NOW()
+        WHERE id = :id`,
+      { replacements: { id: prospectId, patch: JSON.stringify(patch) } }
+    ).catch((err) => d.logger.warn('[Screening] waCallback patch failed', { prospectId, error: err?.message }));
+  }
+
+  /** Resolve a wa-callback token → its prospect, or null. */
+  async function resolveWaCallbackToken(token) {
+    if (!/^wcb_[a-f0-9]{32}$/i.test(String(token || ''))) return null;
+    const row = await d.IdempotencyKey.findOne({ where: { key: `wacb:${token}`, scope: WA_CB_SCOPE } });
+    if (!row || (row.expiresAt && new Date(row.expiresAt) < new Date())) return null;
+    const prospectId = row.responseBody?.prospectId;
+    if (!UUID_RE.test(prospectId || '')) return null;
+    return d.Prospect.findByPk(prospectId);
+  }
+
+  function waCallbackStateOf(prospect) {
+    if (!prospect) return 'invalid';
+    if (prospect.quarantineReason !== 'screening_pending' || prospect.screeningVerdict) return 'done';
+    if (prospect.screeningActiveCallId) return 'in_flight';
+    return 'ready';
+  }
+
+  /**
+   * Page context for redeem.sg/callback?t=… — first name only, never full PII
+   * (reward-claim posture). `state`: ready | in_flight | done | invalid.
+   */
+  async function readWaCallbackContext(token) {
+    try {
+      const prospect = await resolveWaCallbackToken(token);
+      const state = waCallbackStateOf(prospect);
+      if (state === 'invalid') return { state };
+      if (state === 'done') return { state, firstName: prospect.firstName || null };
+      const camp = prospect.campaignId ? await d.Campaign.findByPk(prospect.campaignId).catch(() => null) : null;
+      const wa = prospect.screeningMetadata?.waCallback || {};
+      return {
+        state,
+        firstName: prospect.firstName || null,
+        drawName: camp?.name || 'the lucky draw',
+        multiplier: drawExtraChances(camp) + 1,
+        ...(wa.window ? { window: wa.window } : {}),
+        ...(prospect.screeningNextAttemptAt ? { scheduledFor: new Date(prospect.screeningNextAttemptAt).toISOString() } : {}),
+      };
+    } catch (err) {
+      d.logger.error('[Screening] readWaCallbackContext error', { error: err?.message || String(err) });
+      return { state: 'invalid' };
+    }
+  }
+
+  /**
+   * The tap (plan §16.6 step 3): consent to be called + a chosen window →
+   * fenced schedule write + the callback grant, then the sweep dials. Re-taps
+   * just move the time (the grant flag is already true — no extra attempt).
+   */
+  async function applyWaCallbackRequest(token, window, { cfg = screeningConfig(), ip = null } = {}) {
+    try {
+      const w = String(window || '').trim().toLowerCase();
+      if (!['asap', 'later_today', 'tomorrow', 'this_week'].includes(w)) {
+        return { ok: false, state: 'bad_window' };
+      }
+      const prospect = await resolveWaCallbackToken(token);
+      const state = waCallbackStateOf(prospect);
+      if (state !== 'ready') return { ok: false, state };
+
+      const at = callbackRetryAt(cfg, w, { quarantinedAt: prospect.quarantinedAt || null });
+      const waPatch = JSON.stringify({
+        tappedAt: new Date().toISOString(),
+        window: w,
+        scheduledFor: at.toISOString(),
+        ...(ip ? { ip: String(ip).slice(0, 45) } : {}),
+      });
+      const [rows] = await d.sequelize.query(
+        `UPDATE prospects
+            SET "screeningNextAttemptAt" = :at,
+                "screeningMetadata" = jsonb_set(
+                  COALESCE("screeningMetadata", '{}'::jsonb) || '{"callbackGranted":true}'::jsonb,
+                  '{waCallback}',
+                  COALESCE("screeningMetadata" -> 'waCallback', '{}'::jsonb) || :waPatch::jsonb,
+                  true),
+                "updatedAt" = NOW()
+          WHERE id = :id AND "quarantineReason" = 'screening_pending'
+            AND "screeningActiveCallId" IS NULL AND "screeningVerdict" IS NULL
+          RETURNING id`,
+        { replacements: { id: prospect.id, at, waPatch } }
+      );
+      if (!Array.isArray(rows) || rows.length === 0) {
+        // Fence lost between read and write — report the fresher state.
+        await prospect.reload().catch(() => {});
+        return { ok: false, state: waCallbackStateOf(prospect) };
+      }
+      await d.ProspectActivity.create({
+        prospectId: prospect.id,
+        type: 'updated',
+        actorUserId: null,
+        description: `Customer requested a screening callback via WhatsApp (${w}) — scheduled for ${at.toISOString()}`,
+        metadata: { waCallback: true, window: w, scheduledFor: at.toISOString() },
+      }).catch(() => {});
+      d.logger.info('[Screening] WA callback scheduled by customer', { prospectId: prospect.id, window: w, at: at.toISOString() });
+      return { ok: true, state: 'scheduled', scheduledFor: at.toISOString(), window: w };
+    } catch (err) {
+      d.logger.error('[Screening] applyWaCallbackRequest error', { error: err?.message || String(err) });
+      return { ok: false, state: 'error' };
+    }
   }
 
   /**
@@ -582,6 +801,9 @@ export function makeRetellScreeningService(overrides = {}) {
     resolveAttemptFailure,
     handleScreeningWebhook,
     dncDialClear,
+    maybeSendWaCallbackInvite,
+    readWaCallbackContext,
+    applyWaCallbackRequest,
   };
 }
 
@@ -590,3 +812,5 @@ const _default = makeRetellScreeningService();
 export const startScreeningAttempt = _default.startScreeningAttempt;
 export const applyCallOutcome = _default.applyCallOutcome;
 export const handleScreeningWebhook = _default.handleScreeningWebhook;
+export const readWaCallbackContext = _default.readWaCallbackContext;
+export const applyWaCallbackRequest = _default.applyWaCallbackRequest;

--- a/backend/src/tests/whatsappService.test.js
+++ b/backend/src/tests/whatsappService.test.js
@@ -391,3 +391,54 @@ describe('graphFetch retry — transient failures self-heal (prod 2026-07-20 vou
     expect(msgCalls(fetch)).toBe(2);
   });
 });
+
+describe('sendDrawCallbackOptinWhatsApp — screening callback opt-in (§16.6)', () => {
+  const prospect = { firstName: 'Shawn', phone: '+6596989089', campaignId: 'c1', consumerId: 'u1' };
+  const args = { prospect, drawName: 'iPhone 17 Pro Lucky Draw', multiplier: 10, prize: 'iPhone 17 Pro', token: 'wcb_deadbeef' };
+
+  it('sends the 4-param body + dynamic URL button, no header, MARKETING purpose', async () => {
+    enableWithCreds();
+    const gate = [];
+    const fetch = scriptedFetch([sendOk]);
+    const svc = makeSvc({ fetch, isSendBlocked: async (_p, opts) => { gate.push(opts); return false; } });
+    const r = await svc.sendDrawCallbackOptinWhatsApp(args);
+    expect(r.sent).toBe(true);
+    expect(gate).toEqual([{ channel: 'whatsapp', purpose: 'marketing' }]);
+
+    const body = JSON.parse(fetch.calls[0].opts.body);
+    expect(body.template.name).toBe('draw_callback_optin');
+    const byType = Object.fromEntries(body.template.components.map((c) => [c.type, c]));
+    expect(byType.header).toBeUndefined(); // TEXT header lives in the template, not the send
+    expect(byType.body.parameters.map((p) => p.text)).toEqual([
+      'Shawn', 'iPhone 17 Pro Lucky Draw', '10', 'the iPhone 17 Pro',
+    ]);
+    expect(byType.button).toEqual({
+      type: 'button', sub_type: 'url', index: '0',
+      parameters: [{ type: 'text', text: 'callback?t=wcb_deadbeef&utm_source=wa_screening' }],
+    });
+  });
+
+  it('marketing suppression blocks the send (fail-closed lane)', async () => {
+    enableWithCreds();
+    const fetch = scriptedFetch([sendOk]);
+    const svc = makeSvc({ fetch, isSendBlocked: async () => true });
+    const r = await svc.sendDrawCallbackOptinWhatsApp(args);
+    expect(r).toEqual({ sent: false, skipped: 'suppressed' });
+    expect(fetch.calls.length).toBe(0);
+  });
+
+  it('prize label keeps an existing article and falls back when empty or URL-ish', async () => {
+    enableWithCreds();
+    const paramAt = async (over) => {
+      const fetch = scriptedFetch([sendOk]);
+      const svc = makeSvc({ fetch, isSendBlocked: async () => false });
+      await svc.sendDrawCallbackOptinWhatsApp({ ...args, ...over });
+      return JSON.parse(fetch.calls[0].opts.body).template.components
+        .find((c) => c.type === 'body').parameters[3].text;
+    };
+    expect(await paramAt({ prize: 'a 4D3N trip for two to Tokyo' })).toBe('a 4D3N trip for two to Tokyo');
+    expect(await paramAt({ prize: 'The Grand Bundle' })).toBe('The Grand Bundle');
+    expect(await paramAt({ prize: null })).toBe('the grand prize');
+    expect(await paramAt({ prize: 'https://evil.example' })).toBe('the grand prize');
+  });
+});

--- a/backend/test/unit/retellScreening.test.js
+++ b/backend/test/unit/retellScreening.test.js
@@ -95,7 +95,8 @@ function dialerDeps(seq, over = {}) {
     sequelize: seq,
     Prospect: { findByPk: jest.fn(), findOne: jest.fn() },
     Campaign: { findByPk: jest.fn().mockResolvedValue(screeningCampaign()) },
-    IdempotencyKey: { create: jest.fn().mockResolvedValue({}) },
+    IdempotencyKey: { create: jest.fn().mockResolvedValue({}), findOne: jest.fn() },
+    ProspectActivity: { create: jest.fn().mockResolvedValue({}) },
     retellClient: {
       createPhoneCall: jest.fn().mockResolvedValue({ call_id: 'call_new1' }),
       getCall: jest.fn(),
@@ -111,9 +112,13 @@ function dialerDeps(seq, over = {}) {
       releaseScreenedLead: jest.fn().mockResolvedValue({ released: true }),
       transitionDncToScreening: jest.fn(),
     },
+    sendDrawCallbackOptin: jest.fn().mockResolvedValue({ sent: true, to: '••••4567' }),
     ...over,
   };
 }
+
+/** Flush the fire-and-forget WA-invite microtask chain. */
+const flushAsync = () => new Promise((r) => setTimeout(r, 0));
 
 // Happy-path query script for startScreeningAttempt:
 // [advisory lock], [budget count], [in-flight count], [claim], (commit), then post-dial swap.
@@ -562,6 +567,186 @@ describe('applyCallOutcome', () => {
       { cfg: CFG, finalIfNoAnalysis: true }
     );
     expect(outFinal).toMatchObject({ outcome: 'retry_scheduled', kind: 'no_verdict' });
+  });
+});
+
+describe('WhatsApp callback invite', () => {
+  const drawCampaign = () => ({
+    ...screeningCampaign({ luckyDraw: { multiplier: 10, prize: 'iPhone 17 Pro' } }),
+  });
+
+  it('verdict-less connected call (no voice booking) triggers the invite exactly once', async () => {
+    // resolveAttemptFailure: clear + defer; then the invite's claim + receipt patch.
+    const seq = fakeSequelize([
+      [[{ id: 'p' }]],                    // attempt evidence patch
+      [[{ screeningAttemptCount: 1 }]],   // fenced clear
+      [[{ id: 'p' }]],                    // deferAttempt
+      [[{ id: 'p' }]],                    // waCallback claim
+      [[{ id: 'p' }]],                    // receipt patch
+    ]);
+    const deps = dialerDeps(seq, { Campaign: { findByPk: jest.fn().mockResolvedValue(drawCampaign()) } });
+    const svc = makeRetellScreeningService(deps);
+    await svc.applyCallOutcome(
+      pendingProspect({ screeningActiveCallId: 'call_1', screeningAttemptCount: 1 }),
+      { call_id: 'call_1', metadata: { mktr: { kind: 'screening', attemptToken: 'att_abc' } },
+        call_analysis: { custom_analysis_data: { qualified: 'incomplete' } } },
+      { cfg: CFG }
+    );
+    await flushAsync();
+    expect(deps.sendDrawCallbackOptin).toHaveBeenCalledWith(expect.objectContaining({
+      drawName: 'Test Campaign',
+      multiplier: 10,
+      prize: 'iPhone 17 Pro',
+      token: expect.stringMatching(/^wcb_[a-f0-9]{32}$/),
+    }));
+    // Token row minted under the wa-callback scope, expiring with the 2× hold.
+    const tokenRow = deps.IdempotencyKey.create.mock.calls.find(([r]) => r.scope === 'screening:wa_callback');
+    expect(tokenRow[0].key).toMatch(/^wacb:wcb_/);
+    // The once-per-lead claim fences on the key's absence.
+    const claim = seq.calls.find((c) => String(c.sql).includes(`("screeningMetadata" -> 'waCallback') IS NULL`));
+    expect(claim).toBeTruthy();
+  });
+
+  it('a voice-booked callback suppresses the invite (the promise is already made)', async () => {
+    const seq = fakeSequelize([[[{ id: 'p' }]], [[{ screeningAttemptCount: 1 }]], [[{ id: 'p' }]]]);
+    const deps = dialerDeps(seq, { Campaign: { findByPk: jest.fn().mockResolvedValue(drawCampaign()) } });
+    const svc = makeRetellScreeningService(deps);
+    await svc.applyCallOutcome(
+      pendingProspect({ screeningActiveCallId: 'call_1', screeningAttemptCount: 1 }),
+      { call_id: 'call_1', metadata: { mktr: { kind: 'screening', attemptToken: 'att_abc' } },
+        call_analysis: { custom_analysis_data: { qualified: 'incomplete', callback_window: 'tomorrow' } } },
+      { cfg: CFG }
+    );
+    await flushAsync();
+    expect(deps.sendDrawCallbackOptin).not.toHaveBeenCalled();
+  });
+
+  it('unanswered dials: no invite on the 1st miss, invite on the 2nd', async () => {
+    const mkDeps = (results) => dialerDeps(fakeSequelize(results), { Campaign: { findByPk: jest.fn().mockResolvedValue(drawCampaign()) } });
+
+    const first = mkDeps([[[{ id: 'p' }]], [[{ screeningAttemptCount: 1 }]], [[{ id: 'p' }]]]);
+    await makeRetellScreeningService(first).applyCallOutcome(
+      pendingProspect({ screeningActiveCallId: 'call_1', screeningAttemptCount: 1 }),
+      { call_id: 'call_1', disconnection_reason: 'dial_no_answer', metadata: { mktr: { attemptToken: 'att_a' } } },
+      { cfg: CFG }
+    );
+    await flushAsync();
+    expect(first.sendDrawCallbackOptin).not.toHaveBeenCalled();
+
+    const second = mkDeps([
+      [[{ id: 'p' }]], [[{ screeningAttemptCount: 2 }]], [[{ id: 'p' }]],
+      [[{ id: 'p' }]], [[{ id: 'p' }]], // claim + receipt
+    ]);
+    await makeRetellScreeningService(second).applyCallOutcome(
+      pendingProspect({ screeningActiveCallId: 'call_1', screeningAttemptCount: 2 }),
+      { call_id: 'call_1', disconnection_reason: 'dial_no_answer', metadata: { mktr: { attemptToken: 'att_b' } } },
+      { cfg: CFG }
+    );
+    await flushAsync();
+    expect(second.sendDrawCallbackOptin).toHaveBeenCalled();
+  });
+
+  it('never sends for a non-draw campaign, a lead already invited, or without marketing consent', async () => {
+    // Non-draw: default screeningCampaign has no luckyDraw — zero queries run.
+    const nonDraw = dialerDeps(fakeSequelize([]));
+    const r1 = await makeRetellScreeningService(nonDraw).maybeSendWaCallbackInvite(pendingProspect(), { cfg: CFG });
+    expect(r1).toMatchObject({ sent: false, reason: 'not_a_draw' });
+
+    // Already invited: metadata short-circuit before any lookup.
+    const invited = dialerDeps(fakeSequelize([]));
+    const p = pendingProspect({ screeningMetadata: { attempts: {}, waCallback: { sentAt: 'x' } } });
+    const r2 = await makeRetellScreeningService(invited).maybeSendWaCallbackInvite(p, { cfg: CFG });
+    expect(r2).toMatchObject({ sent: false, reason: 'already_sent' });
+
+    // Consent refused.
+    const noConsent = dialerDeps(fakeSequelize([]), {
+      Campaign: { findByPk: jest.fn().mockResolvedValue(drawCampaign()) },
+      canMarketTo: jest.fn().mockResolvedValue(false),
+    });
+    const r3 = await makeRetellScreeningService(noConsent).maybeSendWaCallbackInvite(pendingProspect(), { cfg: CFG });
+    expect(r3).toMatchObject({ sent: false, reason: 'no_marketing_consent' });
+    expect(noConsent.sendDrawCallbackOptin).not.toHaveBeenCalled();
+  });
+
+  it('claim race: the loser never mints a token or sends', async () => {
+    const seq = fakeSequelize([[[]]]); // claim returns no rows
+    const deps = dialerDeps(seq, { Campaign: { findByPk: jest.fn().mockResolvedValue(drawCampaign()) } });
+    const out = await makeRetellScreeningService(deps).maybeSendWaCallbackInvite(pendingProspect(), { cfg: CFG });
+    expect(out).toMatchObject({ sent: false, reason: 'lost_claim' });
+    expect(deps.IdempotencyKey.create).not.toHaveBeenCalled();
+    expect(deps.sendDrawCallbackOptin).not.toHaveBeenCalled();
+  });
+});
+
+describe('WA callback tap (readWaCallbackContext / applyWaCallbackRequest)', () => {
+  const TOKEN = `wcb_${'a'.repeat(32)}`;
+  const tokenRow = (over = {}) => ({
+    key: `wacb:${TOKEN}`,
+    scope: 'screening:wa_callback',
+    responseBody: { prospectId: pendingProspect().id },
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    ...over,
+  });
+
+  function tapDeps(seq, { prospect = pendingProspect(), row = tokenRow(), campaign } = {}) {
+    return dialerDeps(seq, {
+      IdempotencyKey: { create: jest.fn(), findOne: jest.fn().mockResolvedValue(row) },
+      Prospect: { findByPk: jest.fn().mockResolvedValue(prospect), findOne: jest.fn() },
+      Campaign: { findByPk: jest.fn().mockResolvedValue(campaign ?? screeningCampaign({ luckyDraw: { multiplier: 10, prize: 'iPhone 17 Pro' } })) },
+    });
+  }
+
+  it('context: ready state carries first name, draw name, multiplier — nothing more', async () => {
+    const svc = makeRetellScreeningService(tapDeps(fakeSequelize([])));
+    const ctx = await svc.readWaCallbackContext(TOKEN);
+    expect(ctx).toEqual(expect.objectContaining({ state: 'ready', firstName: 'Jane', drawName: 'Test Campaign', multiplier: 10 }));
+    expect(ctx.phone).toBeUndefined();
+    expect(ctx.email).toBeUndefined();
+  });
+
+  it('context: bad/expired/unknown tokens are invalid; released leads read done; active call reads in_flight', async () => {
+    const svcBad = makeRetellScreeningService(tapDeps(fakeSequelize([])));
+    expect((await svcBad.readWaCallbackContext('nope')).state).toBe('invalid');
+
+    const svcExpired = makeRetellScreeningService(tapDeps(fakeSequelize([]), { row: tokenRow({ expiresAt: new Date(0) }) }));
+    expect((await svcExpired.readWaCallbackContext(TOKEN)).state).toBe('invalid');
+
+    const svcDone = makeRetellScreeningService(tapDeps(fakeSequelize([]), { prospect: pendingProspect({ quarantineReason: null }) }));
+    expect((await svcDone.readWaCallbackContext(TOKEN)).state).toBe('done');
+
+    const svcFlight = makeRetellScreeningService(tapDeps(fakeSequelize([]), { prospect: pendingProspect({ screeningActiveCallId: 'call_9' }) }));
+    expect((await svcFlight.readWaCallbackContext(TOKEN)).state).toBe('in_flight');
+  });
+
+  it('tap: schedules the chosen window, grants the callback bonus, logs an activity', async () => {
+    const seq = fakeSequelize([[[{ id: 'p' }]]]); // fenced schedule write
+    const deps = tapDeps(seq);
+    const svc = makeRetellScreeningService(deps);
+    const before = Date.now();
+    const out = await svc.applyWaCallbackRequest(TOKEN, 'asap', { cfg: CFG });
+    expect(out).toMatchObject({ ok: true, state: 'scheduled', window: 'asap' });
+    // asap ≈ +10 minutes (always-open test window, no clamping).
+    const at = new Date(out.scheduledFor).getTime();
+    expect(at - before).toBeGreaterThan(9 * 60 * 1000);
+    expect(at - before).toBeLessThan(11 * 60 * 1000);
+    const write = seq.calls[0];
+    expect(write.sql).toContain(`"screeningNextAttemptAt" = :at`);
+    expect(write.sql).toContain('"callbackGranted":true');
+    expect(write.sql).toContain(`"quarantineReason" = 'screening_pending'`);
+    expect(deps.ProspectActivity.create).toHaveBeenCalledWith(expect.objectContaining({
+      description: expect.stringContaining('requested a screening callback via WhatsApp (asap)'),
+    }));
+  });
+
+  it('tap: rejects unknown windows and reports the fresher state when the fence is lost', async () => {
+    const svc = makeRetellScreeningService(tapDeps(fakeSequelize([])));
+    expect((await svc.applyWaCallbackRequest(TOKEN, 'next_year', { cfg: CFG })).state).toBe('bad_window');
+
+    const lost = pendingProspect();
+    lost.reload = jest.fn().mockImplementation(() => { lost.screeningActiveCallId = 'call_5'; return Promise.resolve(); });
+    const svcLost = makeRetellScreeningService(tapDeps(fakeSequelize([[[]]]), { prospect: lost }));
+    const out = await svcLost.applyWaCallbackRequest(TOKEN, 'tomorrow', { cfg: CFG });
+    expect(out).toMatchObject({ ok: false, state: 'in_flight' });
   });
 });
 

--- a/docs/plans/retell-screening-calls.md
+++ b/docs/plans/retell-screening-calls.md
@@ -654,25 +654,43 @@ Not covered: nothing schedules the ring-back outside the 10:00–20:00 window, a
 a "next week" request is still clamped to the hold ceiling — past that, TTL
 releases the lead unscreened by policy (D1). WhatsApp fallback is §16.6.
 
-## §16.6 WhatsApp callback opt-in (submitted for review 2026-07-25)
+## §16.6 WhatsApp callback opt-in (BUILT 2026-07-25; template APPROVED same day)
 
-**Submitted 2026-07-25, template id 1587973386015533, status PENDING** (WABA
-1912683432731970 — resolved via the script's hardcoded Redeem-WABA fallback; the
-prod system-user token's granular scopes carry no target ids, so nothing is
-enumerable from the token alone).
+Template `draw_callback_optin` (MARKETING, id 1587973386015533, WABA
+1912683432731970) — the messaging leg for leads a dial cannot finish. The URL
+button's tap IS the consent: the person asking to be called is what makes the
+ring-back welcome. Copy follows the ×N-is-the-TOTAL contract, not the phone
+script's "N more chances" register. Definition + submitter:
+`backend/scripts/submit-wa-marketing-templates.mjs` (`--callback-only`).
 
-Template `draw_callback_optin` (MARKETING, `allow_category_change`) — the
-messaging leg for leads a dial cannot finish. URL button "Yes, call me" carries
-the consent: the tap is the person asking to be called, which is what makes the
-ring-back welcome. Copy follows the ×N-is-the-TOTAL contract and
-`DRAW_RECORD_PHRASE`, not the phone script's "N more chances" register.
-Definition + submitter: `backend/scripts/submit-wa-marketing-templates.mjs`
-(`--callback-only`).
+The full loop, all shipped:
 
-**Unbuilt before it can send:** the `/callback?t=…` landing page and its
-consent-capture endpoint (tap ⇒ record consent ⇒ schedule the next attempt), and
-a `purpose:'marketing'` send path in `whatsappService` — its sends are
-transactional today, so a marketing unsubscribe would not block this one.
+1. **Trigger** (`retellScreeningService.maybeSendWaCallbackInvite`, fired
+   fire-and-forget from `resolveAttemptFailure`): at most ONE invite per lead
+   (fenced `screeningMetadata.waCallback` claim), when the lead is still held
+   with attempts left and either a connected call ended verdict-less with NO
+   voice-booked callback, or the 2nd dial went unanswered (one dial before the
+   release policy would take the row away). Guards before the claim: draw
+   campaign only (the template speaks draw language), campaign active,
+   `canMarketTo` — and `sendTemplate` re-checks `purpose:'marketing'`
+   (full canMarketTo, fail-closed) at send time; a marketing unsubscribe
+   blocks it while transactional sends stay untouched.
+2. **Token**: `wcb_<32hex>` minted per invite, stored in `idempotency_keys`
+   (scope `screening:wa_callback`, key `wacb:<token>` → `{prospectId}`),
+   expiring at the same 2×maxHoldHours ceiling the TTL sweep grants a promise.
+3. **Page**: `redeem.sg/callback?t=<token>` (`src/pages/ScreeningCallback.jsx`,
+   Vault-pass palette). GET `/api/screening-callback/:token` returns first
+   name + draw context only; states ready / in_flight / done / invalid.
+4. **The tap**: POST with `window ∈ {asap(+10m), later_today, tomorrow}` →
+   `applyWaCallbackRequest`: fenced schedule write (`screeningNextAttemptAt` =
+   `callbackRetryAt`, window-clamped + ceiling-capped) + the SAME
+   `callbackGranted` bonus flag as the phone path (one bonus per lead total;
+   re-taps only move the time) + a ProspectActivity consent record with the
+   chosen window. The existing sweep then dials — every dial guard re-runs, so
+   a tap can never bypass window/DNC/consent/budget/concurrency.
+5. **Evidence**: drawer shows "wa invite <sent-at> · tapped (<window>)" and the
+   scheduled callback time. Route is public + rate-limited (60/15min,
+   reward-claim parity) and outside the redeem-host blocklist.
 
 ---
 

--- a/src/pages/ScreeningCallback.jsx
+++ b/src/pages/ScreeningCallback.jsx
@@ -1,0 +1,216 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { apiClient } from '@/api/client';
+
+/**
+ * Screening-callback opt-in — redeem.sg/callback?t=<token>
+ * (docs/plans/retell-screening-calls.md §16.6). Landing page of the
+ * draw_callback_optin WhatsApp button: the person we couldn't finish a
+ * screening call with picks a window, and that tap is their consent for the
+ * draw team to ring back. Public + token-authenticated; first-name-only PII
+ * (reward-claim posture). Visual language mirrors the Vault pass page
+ * (RewardClaim) — same palette, so the WhatsApp → page journey reads as one
+ * product.
+ */
+
+const WINDOWS = [
+  { key: 'asap', label: 'As soon as possible', hint: 'within the hour' },
+  { key: 'later_today', label: 'Later today', hint: 'in a few hours' },
+  { key: 'tomorrow', label: 'Tomorrow', hint: 'from 10am' },
+];
+
+function formatSgt(iso) {
+  if (!iso) return null;
+  try {
+    return new Intl.DateTimeFormat('en-SG', {
+      timeZone: 'Asia/Singapore',
+      weekday: 'short', day: 'numeric', month: 'short',
+      hour: 'numeric', minute: '2-digit',
+    }).format(new Date(iso));
+  } catch {
+    return null;
+  }
+}
+
+export default function ScreeningCallback() {
+  const [searchParams] = useSearchParams();
+  const token = (searchParams.get('t') || '').trim();
+
+  const [ctx, setCtx] = useState(null);      // GET payload
+  const [state, setState] = useState('loading'); // loading | ready | scheduled | in_flight | done | invalid
+  const [scheduledFor, setScheduledFor] = useState(null);
+  const [pickedWindow, setPickedWindow] = useState(null);
+  const [submitting, setSubmitting] = useState(null); // window key in flight
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!token || token.length < 16) { setState('invalid'); return undefined; }
+    (async () => {
+      try {
+        const res = await apiClient.get(`/screening-callback/${encodeURIComponent(token)}`);
+        if (cancelled) return;
+        const data = res.data || {};
+        setCtx(data);
+        setScheduledFor(data.scheduledFor || null);
+        setPickedWindow(data.window || null);
+        // A pre-existing customer-picked window renders as scheduled-with-change.
+        setState(data.state === 'ready' ? (data.window ? 'scheduled' : 'ready') : data.state);
+      } catch (err) {
+        if (!cancelled) setState(err?.status === 404 ? 'invalid' : 'error');
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [token]);
+
+  const choose = useCallback(async (windowKey) => {
+    if (submitting) return;
+    setSubmitting(windowKey);
+    try {
+      const res = await apiClient.post(`/screening-callback/${encodeURIComponent(token)}`, { window: windowKey });
+      const data = res.data || {};
+      if (data.ok) {
+        setScheduledFor(data.scheduledFor || null);
+        setPickedWindow(data.window || windowKey);
+        setState('scheduled');
+      } else {
+        setState(data.state === 'error' ? 'error' : data.state);
+      }
+    } catch (err) {
+      setState(err?.status === 404 ? 'invalid' : 'error');
+    } finally {
+      setSubmitting(null);
+    }
+  }, [token, submitting]);
+
+  const shell = (children) => (
+    <div className="min-h-screen bg-[#F5F0E6] flex items-center justify-center p-4 sm:p-6 font-sans text-[#1B1A17]">
+      <div className="w-full max-w-sm">
+        <div className="flex items-center justify-between mb-4">
+          <span className="text-lg font-bold tracking-tight">Redeem<span className="text-[#D6552B]">.</span></span>
+          <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[#6B6558]">Draw team</span>
+        </div>
+        <div className="bg-white rounded-2xl border border-[#E6E0D1] shadow-sm p-6">{children}</div>
+        <p className="mt-4 text-center text-[11px] leading-relaxed text-[#6B6558]">
+          Your draw entry stands either way. We never ask for payment to release a prize.
+        </p>
+      </div>
+    </div>
+  );
+
+  if (state === 'loading') {
+    return shell(
+      <div className="flex items-center justify-center py-10">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#D6552B]" />
+      </div>
+    );
+  }
+
+  if (state === 'invalid') {
+    return shell(
+      <>
+        <h1 className="text-xl font-bold">This link has expired</h1>
+        <p className="mt-2 text-sm leading-relaxed text-[#4A4640]">
+          No worries — your draw entry still stands. If we need anything else, we&apos;ll reach out.
+        </p>
+      </>
+    );
+  }
+
+  if (state === 'error') {
+    return shell(
+      <>
+        <h1 className="text-xl font-bold">Something went wrong</h1>
+        <p className="mt-2 text-sm leading-relaxed text-[#4A4640]">
+          Give it a moment and open the link again.
+        </p>
+      </>
+    );
+  }
+
+  if (state === 'done') {
+    return shell(
+      <>
+        <h1 className="text-xl font-bold">You&apos;re all set{ctx?.firstName ? `, ${ctx.firstName}` : ''}</h1>
+        <p className="mt-2 text-sm leading-relaxed text-[#4A4640]">
+          This one&apos;s already been handled — our team will be in touch if anything else is needed. Good luck for the draw!
+        </p>
+      </>
+    );
+  }
+
+  if (state === 'in_flight') {
+    return shell(
+      <>
+        <h1 className="text-xl font-bold">We&apos;re calling you right now</h1>
+        <p className="mt-2 text-sm leading-relaxed text-[#4A4640]">
+          Keep an eye on your phone — Sarah from the draw team is on the line.
+        </p>
+      </>
+    );
+  }
+
+  const sgt = formatSgt(scheduledFor);
+  const windowLabel = WINDOWS.find((w) => w.key === pickedWindow)?.label?.toLowerCase() || null;
+
+  if (state === 'scheduled') {
+    return shell(
+      <>
+        <h1 className="text-xl font-bold">Done{ctx?.firstName ? `, ${ctx.firstName}` : ''} — we&apos;ll call you</h1>
+        <p className="mt-2 text-sm leading-relaxed text-[#4A4640]">
+          {sgt
+            ? <>Expect our call around <span className="font-semibold text-[#1B1A17]">{sgt}</span>. Keep your phone handy — it takes under two minutes.</>
+            : <>Expect our call {windowLabel || 'soon'}. Keep your phone handy — it takes under two minutes.</>}
+        </p>
+        <div className="mt-5 pt-4 border-t border-[#E6E0D1]">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[#6B6558]">Need a different time?</p>
+          <div className="mt-2 grid gap-2">
+            {WINDOWS.map((w) => (
+              <button
+                key={w.key}
+                type="button"
+                disabled={!!submitting}
+                onClick={() => choose(w.key)}
+                className="w-full rounded-xl border border-[#E6E0D1] px-4 py-2.5 text-left text-sm font-medium hover:border-[#D6552B] disabled:opacity-50"
+              >
+                {submitting === w.key ? 'Saving…' : w.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  // ready — the pitch + the three windows
+  return shell(
+    <>
+      <h1 className="text-xl font-bold">
+        {ctx?.firstName ? `Hi ${ctx.firstName} — ` : ''}sorry we missed you
+      </h1>
+      <p className="mt-2 text-sm leading-relaxed text-[#4A4640]">
+        Pick a time and Sarah from the draw team will give you a quick ring about the{' '}
+        <span className="font-semibold text-[#1B1A17]">{ctx?.drawName || 'lucky draw'}</span> — three yes-or-no
+        questions, under two minutes, and it&apos;s the first step to turning your 1 entry into{' '}
+        <span className="font-semibold text-[#C89B3C]">×{ctx?.multiplier || 10} chances</span>.
+      </p>
+      <div className="mt-5 grid gap-2">
+        {WINDOWS.map((w) => (
+          <button
+            key={w.key}
+            type="button"
+            disabled={!!submitting}
+            onClick={() => choose(w.key)}
+            className="w-full rounded-xl bg-[#1B1A17] text-[#F5F0E6] px-4 py-3 text-left disabled:opacity-60"
+          >
+            <span className="block text-sm font-semibold">{submitting === w.key ? 'Saving…' : w.label}</span>
+            <span className="block text-[11px] text-[#F5F0E6]/70">{w.hint}</span>
+          </button>
+        ))}
+      </div>
+      <p className="mt-4 text-[11px] leading-relaxed text-[#6B6558]">
+        By picking a time you&apos;re agreeing to a call from the Redeem draw team (MKTR Pte. Ltd.) on this number
+        about your draw entry. Calls happen between 10am and 8pm Singapore time.
+      </p>
+    </>
+  );
+}

--- a/src/pages/__tests__/ScreeningCallback.test.jsx
+++ b/src/pages/__tests__/ScreeningCallback.test.jsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+// The page talks straight to apiClient — stub the whole module.
+vi.mock('@/api/client', () => ({
+  apiClient: { get: vi.fn(), post: vi.fn() },
+}));
+
+import { apiClient } from '@/api/client';
+import ScreeningCallback from '../ScreeningCallback';
+
+const TOKEN = `wcb_${'a'.repeat(32)}`;
+
+function renderAt(url) {
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <Routes>
+        <Route path="/callback" element={<ScreeningCallback />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ScreeningCallback (/callback?t=…)', () => {
+  it('ready state pitches ×N and books a window on tap', async () => {
+    apiClient.get.mockResolvedValue({
+      data: { state: 'ready', firstName: 'Shawn', drawName: 'iPhone 17 Pro Lucky Draw', multiplier: 10 },
+    });
+    apiClient.post.mockResolvedValue({
+      data: { ok: true, state: 'scheduled', window: 'tomorrow', scheduledFor: '2026-07-26T02:00:00.000Z' },
+    });
+    renderAt(`/callback?t=${TOKEN}`);
+
+    expect(await screen.findByText(/sorry we missed you/i)).toBeInTheDocument();
+    expect(screen.getByText(/×10 chances/)).toBeInTheDocument();
+    expect(screen.getByText('iPhone 17 Pro Lucky Draw')).toBeInTheDocument();
+    // The tap is the consent — the fine print must say so.
+    expect(screen.getByText(/agreeing to a call/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /tomorrow/i }));
+    await waitFor(() => expect(apiClient.post).toHaveBeenCalledWith(
+      `/screening-callback/${TOKEN}`, { window: 'tomorrow' },
+    ));
+    expect(await screen.findByText(/we'll call you/i)).toBeInTheDocument();
+    // 2026-07-26T02:00Z = 10:00 SGT — the shown time is SGT, not UTC.
+    expect(screen.getByText(/10:00/)).toBeInTheDocument();
+  });
+
+  it('missing or short token renders expired without calling the API', async () => {
+    renderAt('/callback?t=short');
+    expect(await screen.findByText(/link has expired/i)).toBeInTheDocument();
+    expect(screen.getByText(/entry still stands/i)).toBeInTheDocument();
+    expect(apiClient.get).not.toHaveBeenCalled();
+  });
+
+  it('404 renders expired; done and in_flight render their states', async () => {
+    apiClient.get.mockRejectedValueOnce(Object.assign(new Error('nf'), { status: 404 }));
+    renderAt(`/callback?t=${TOKEN}`);
+    expect(await screen.findByText(/link has expired/i)).toBeInTheDocument();
+
+    apiClient.get.mockResolvedValueOnce({ data: { state: 'done', firstName: 'Shawn' } });
+    renderAt(`/callback?t=${TOKEN}`);
+    expect(await screen.findByText(/all set, Shawn/i)).toBeInTheDocument();
+
+    apiClient.get.mockResolvedValueOnce({ data: { state: 'in_flight' } });
+    renderAt(`/callback?t=${TOKEN}`);
+    expect(await screen.findByText(/calling you right now/i)).toBeInTheDocument();
+  });
+});

--- a/src/pages/adminv2/AdminV2Prospects.jsx
+++ b/src/pages/adminv2/AdminV2Prospects.jsx
@@ -252,10 +252,20 @@ function LeadDrawer({ prospect, onClose, onOpenLead }) {
                 {verdictDetail.reason && <div className="av2-kv"><span>reason</span><span>{verdictDetail.reason}</span></div>}
                 {verdictDetail.sentiment && <div className="av2-kv"><span>sentiment</span><span>{verdictDetail.sentiment}</span></div>}
                 <div className="av2-kv"><span>attempts</span><span>{p.screeningAttemptCount || attempts.length || 0}</span></div>
-                {/* A time Sarah promised on the phone — the one screening date
-                    an operator must not silently miss. */}
+                {/* A time Sarah promised on the phone (or the customer picked
+                    via WhatsApp) — the one screening date an operator must not
+                    silently miss. */}
                 {sm.callbackGranted && p.screeningNextAttemptAt && (
                   <div className="av2-kv"><span>callback</span><span>{fmtDateTime(p.screeningNextAttemptAt)}</span></div>
+                )}
+                {sm.waCallback?.sentAt && (
+                  <div className="av2-kv">
+                    <span>wa invite</span>
+                    <span>
+                      {sm.waCallback.sent === false ? 'send failed' : fmtDateTime(sm.waCallback.sentAt)}
+                      {sm.waCallback.tappedAt ? ` · tapped (${String(sm.waCallback.window || '').replace(/_/g, ' ')})` : ''}
+                    </span>
+                  </div>
                 )}
                 {hasCost && (
                   <div className="av2-kv">

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -21,6 +21,7 @@ function LegacyDesignerRedirect() {
 const LeadCapture = lazy(() => import('./LeadCapture'));
 const LeadCaptureDemo = lazy(() => import('./LeadCaptureDemo'));
 const RewardClaim = lazy(() => import('./RewardClaim'));
+const ScreeningCallback = lazy(() => import('./ScreeningCallback'));
 const PublicPreview = lazy(() => import('./public/Preview'));
 const TrackRedirect = lazy(() => import('./TrackRedirect'));
 const ShareRedirect = lazy(() => import('./ShareRedirect'));
@@ -267,6 +268,8 @@ function PagesContent() {
  <Route path="/share/:slug" element={<ShareRedirect />} />
  {/* Consumer reward journey — reservation pass / voucher (docs/redeem-ops/ROUTE_MAP.md) */}
  <Route path="/r/:token" element={<RewardClaim />} />
+ {/* Screening-callback opt-in — the draw_callback_optin WhatsApp button lands here (?t=token) */}
+ <Route path="/callback" element={<ScreeningCallback />} />
 
  {/* Design exploration prototypes — mktr build only */}
  <Route path="/preview" element={IS_REDEEM_BUILD ? <MktrOnlyRedirect /> : <PreviewHub />} />


### PR DESCRIPTION
## What

Completes the missed-call loop (plan §16.6). A screening dial that couldn't finish now sends the **approved** `draw_callback_optin` WhatsApp; the customer's tap on **"Yes, call me"** is their consent and books the ring-back; the existing sweep auto-dials at the chosen time.

### Trigger (`maybeSendWaCallbackInvite`)
Fire-and-forget from `resolveAttemptFailure`, **at most once per lead** (fenced `screeningMetadata.waCallback` claim — replayed webhooks lose). Eligible only while the lead is still held with attempts left, and either a connected call ended verdict-less with **no** voice-booked callback, or the **2nd** dial went unanswered (one before the release policy takes the row away). Draw campaigns only (the template speaks draw language), campaign-active + `canMarketTo` guards.

### Send lane
`sendTemplate` grows `purpose` — `'marketing'` runs the full `canMarketTo` gate and **fails closed**, so a marketing unsubscribe blocks this send while transactional passes stay untouched — plus a dynamic URL-button component. Token `wcb_<32hex>` rides `idempotency_keys` (scope `screening:wa_callback`), expiring at the same 2× hold ceiling the TTL sweep grants a promise.

### Tap
Public `/api/screening-callback/:token` (60/15min limiter, reward-claim parity; outside the redeem-host blocklist). GET returns first-name-only context. POST `window ∈ {asap +10m, later_today, tomorrow}` → fenced schedule write via `callbackRetryAt` + the **same** `callbackGranted` bonus as the phone path (one per lead total; re-taps only move the time) + a ProspectActivity consent record. Every dial guard re-runs at dial time — a tap can never bypass window/DNC/consent/budget/concurrency.

### Page
`redeem.sg/callback?t=…` in the Vault-pass palette — ready / scheduled (with change-time) / calling-now / done / expired. The consent sentence sits under the buttons; times render in SGT.

### Drawer
`wa invite <sent-at> · tapped (<window>)` evidence row.

## Tests

134 backend + 29 frontend, all in-worktree on top of main; vite production build emits the lazy chunk. Coverage: trigger matrix (once-only claim race, voice-booked suppression, 1st-vs-2nd miss, non-draw / no-consent), tap flow (schedule+grant SQL, bad window, fence-lost freshness), sender payload (URL-button component, marketing fail-closed gate, prize-label article rules), page state machine incl. SGT rendering.

## Notes

- Template APPROVED by Meta 2026-07-25 (id 1587973386015533); `REDEEM_OPS_WHATSAPP_ENABLED` already live for the draw pass rail, so invites go live with this merge.
- Env: optional `WHATSAPP_TEMPLATE_DRAW_CALLBACK` override documented in env.example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgWRx53DQBvoHAdi3pViGx