### PR TITLE
feat(admin): Lead Profile backend — draw standing, reward diagnostics, comms receipts behind ?include=profile

### DIFF
--- a/backend/src/controllers/prospectController.js
+++ b/backend/src/controllers/prospectController.js
@@ -94,7 +94,11 @@ export const createProspect = asyncHandler(async (req, res) => {
 });
 
 export const getProspect = asyncHandler(async (req, res) => {
-  const prospect = await prospectService.getProspect(req.params.id, req.user);
+  // ?include=profile → Lead Profile enrichments; admin-gated inside the
+  // service (non-admins get the classic payload whatever they send).
+  const prospect = await prospectService.getProspect(req.params.id, req.user, {
+    include: req.query.include,
+  });
 
   res.json({
     success: true,

--- a/backend/src/database/migrations/089-lead-profile-indexes.js
+++ b/backend/src/database/migrations/089-lead-profile-indexes.js
@@ -1,0 +1,28 @@
+/**
+ * 089 — Lead Profile page read-path indexes (docs/plans/admin-lead-profile-page.md §4).
+ *
+ * Two person-first lookups the page needs that nothing served before:
+ *  - webhook_deliveries by the lead id inside the payload (Lyfe delivery
+ *    status). Partial: only the two event types the page asks about — the
+ *    purge path deletes failed rows only, so successful rows grow unbounded
+ *    and an unindexed JSON-path scan would degrade with the table.
+ *  - email_broadcast_recipients by consumer (broadcast history). Existing
+ *    indexes lead on broadcastId and cannot serve a person lookup.
+ * Both additive; no backfill.
+ */
+export async function up(queryInterface) {
+  const q = (sql) => queryInterface.sequelize.query(sql);
+
+  await q(`CREATE INDEX IF NOT EXISTS idx_wd_lead_external_created
+    ON webhook_deliveries (((payload::jsonb #>> '{data,lead,externalId}')), "createdAt" DESC)
+    WHERE "eventType" IN ('lead.created', 'lead.assigned')`);
+
+  await q(`CREATE INDEX IF NOT EXISTS idx_ebr_consumer_created
+    ON email_broadcast_recipients ("consumerId", "createdAt" DESC)`);
+}
+
+export async function down(queryInterface) {
+  const q = (sql) => queryInterface.sequelize.query(sql);
+  await q('DROP INDEX IF EXISTS idx_wd_lead_external_created');
+  await q('DROP INDEX IF EXISTS idx_ebr_consumer_created');
+}

--- a/backend/src/models/EmailBroadcastRecipient.js
+++ b/backend/src/models/EmailBroadcastRecipient.js
@@ -42,6 +42,9 @@ const EmailBroadcastRecipient = sequelize.define('EmailBroadcastRecipient', {
     // Mirrored on the model (sync({force:true}) test boot — Cohort.js lesson).
     { unique: true, fields: ['broadcastId', 'consumerId'], name: 'uq_ebr_broadcast_consumer' },
     { fields: ['broadcastId', 'status'], name: 'idx_ebr_broadcast_status' },
+    // Person-first history for the Lead Profile page (migration 089) — the
+    // broadcastId-leading indexes above can't serve a consumer lookup.
+    { fields: ['consumerId', 'createdAt'], name: 'idx_ebr_consumer_created' },
   ]
 });
 

--- a/backend/src/services/consumerService.js
+++ b/backend/src/services/consumerService.js
@@ -397,8 +397,13 @@ export function makeConsumerService(overrides = {}) {
    * consumer doesn't exist. Deliberately returns DERIVED fields only — no raw
    * sourceMetadata (agents/admins get PII-heavy metadata elsewhere; this
    * endpoint aggregates cross-campaign and stays lean).
+   *
+   * `includeRaw` (Lead Profile page only): attaches the raw signup rows as
+   * `_rawSignups` for leadProfileService.enrichJourneyProfile, which consumes
+   * and strips them — the underscore key never reaches a response. Without it
+   * the payload is byte-identical to before the option existed.
    */
-  async function getConsumerJourney(consumerId) {
+  async function getConsumerJourney(consumerId, { includeRaw = false } = {}) {
     const consumer = await d.Consumer.findByPk(consumerId);
     if (!consumer) return null;
 
@@ -408,6 +413,9 @@ export function makeConsumerService(overrides = {}) {
         attributes: [
           'id', 'firstName', 'lastName', 'phone', 'campaignId', 'leadStatus', 'leadSource',
           'createdAt', 'conversionDate', 'quarantinedAt', 'quarantineReason', 'sourceMetadata',
+          // consentMetadata carries the pinned draw-terms acceptance the draw
+          // eligibility preview reads — profile mode only.
+          ...(includeRaw ? ['consentMetadata'] : []),
         ],
         include: [{ association: 'campaign', attributes: ['id', 'name', 'status'] }],
         order: [['createdAt', 'DESC'], ['id', 'DESC']],
@@ -428,7 +436,7 @@ export function makeConsumerService(overrides = {}) {
       ? await d.DrawEntry.count({ where: { prospectId: signups.map((s) => s.id) } })
       : 0;
 
-    return {
+    const result = {
       consumer: {
         id: consumer.id,
         phone: consumer.phone,
@@ -467,6 +475,8 @@ export function makeConsumerService(overrides = {}) {
       })),
       drawEntries,
     };
+    if (includeRaw) result._rawSignups = signups;
+    return result;
   }
 
   return {

--- a/backend/src/services/leadProfileService.js
+++ b/backend/src/services/leadProfileService.js
@@ -1,0 +1,384 @@
+import { Op } from 'sequelize';
+import {
+  Draw, RewardEntitlement, Activation, RewardOffer, ConsumerSuppression,
+  EmailBroadcastRecipient, SessionVisit, sequelize,
+} from '../models/index.js';
+import { logger } from '../utils/logger.js';
+import { presentState } from '../utils/entitlementPresentState.js';
+import { makeLuckyDrawService } from './luckyDrawService.js';
+import { getConsentState } from './consentService.js';
+import { phoneKeyOf, LIVE_PHONE_STATUSES } from './redeemOps/entitlementService.js';
+import { phoneVerificationIsCurrent } from './consumerService.js';
+import { SCREENING_REASONS } from './screeningConstants.js';
+
+/**
+ * Lead Profile enrichment (docs/plans/admin-lead-profile-page.md §4) — the
+ * admin-only, `?include=profile`-gated composer behind /admin/leads/:id.
+ * READ-ONLY over other domains' tables; every projection here is bounded
+ * (LIMITs, DISTINCT ON, allowlists) because it runs on a detail hot path.
+ *
+ * Boundary contract: prospectService calls this ONLY inside its admin branch
+ * and only when the request opted in — nothing here may become load-bearing
+ * for agent or public payloads.
+ */
+
+const BROADCAST_LIMIT = 20; // recent rows; counts carry the full totals
+const SESSION_STEP_LIMIT = 50;
+// responseCode → operator-safe reason. Derived from the receive-mktr-lead
+// contract (401 bad sig / 400 bad payload / 422 agent-not-found). Raw
+// responseBody text is NEVER surfaced — receiver output is not ours to echo.
+const LYFE_DELIVERY_REASONS = {
+  422: 'agent_not_found',
+  401: 'signature_rejected',
+  400: 'bad_payload',
+};
+
+export function makeLeadProfileService(overrides = {}) {
+  const d = {
+    Draw, RewardEntitlement, Activation, RewardOffer, ConsumerSuppression,
+    EmailBroadcastRecipient, SessionVisit, sequelize, logger,
+    getProspectDrawStatus: null, // defaults to a lucky-draw service built below
+    getConsentState,
+    presentState,
+    phoneKeyOf,
+    phoneVerificationIsCurrent,
+    now: () => new Date(),
+    ...overrides,
+  };
+  if (!d.getProspectDrawStatus) {
+    d.getProspectDrawStatus = makeLuckyDrawService().getProspectDrawStatus;
+  }
+
+  /**
+   * Read-time "why does this signup have no reward?" — re-runs the same
+   * checks issueForProspect applies, in the same order, against LIVE state.
+   * Deliberately NOT the ActivationIssuanceSkip ledger: skip rows carry no
+   * prospect/consumer anchor (by design) and purge after 30 days, so
+   * attributing a campaign's latest skip to this person can be flat wrong.
+   * 'not_issued_yet' = every gate passes and the sweep just hasn't landed.
+   */
+  async function deriveRewardDiagnostic(prospect) {
+    if (!prospect?.campaignId) return null;
+    if (prospect.quarantinedAt && !SCREENING_REASONS.includes(prospect.quarantineReason)) {
+      return 'quarantined';
+    }
+    if (!d.phoneVerificationIsCurrent(prospect)) return 'phone_not_verified';
+    const activation = await d.Activation.findOne({
+      where: { campaignId: prospect.campaignId, status: 'active' },
+      include: [{ model: d.RewardOffer, as: 'rewardOffer' }],
+    });
+    if (!activation) return 'no_active_activation';
+    const phoneKey = d.phoneKeyOf(prospect.phone);
+    if (!phoneKey) return 'no_phone';
+    const liveOnPhone = await d.RewardEntitlement.findOne({
+      where: {
+        activationId: activation.id,
+        phoneKey,
+        status: { [Op.in]: LIVE_PHONE_STATUSES },
+      },
+    });
+    if (liveOnPhone) return 'duplicate_phone';
+    const offer = activation.rewardOffer;
+    if (!offer || offer.status !== 'active') return 'offer_not_active';
+    if (activation.endDate && new Date(activation.endDate) <= d.now()) return 'activation_ended';
+    if (activation.issuedCount >= activation.allocatedQuantity) return 'allocation_exhausted';
+    return 'not_issued_yet';
+  }
+
+  /**
+   * Latest delivery receipt per (entitlement, channel) in ONE bounded query —
+   * DISTINCT ON, not the redeemOps in-memory reduce (that one loads every
+   * historical receipt and was written for a paginated list). Legacy receipts
+   * without metadata.channel group under email, matching the ops console.
+   */
+  async function deliveryReceipts(entitlementIds) {
+    const map = new Map();
+    if (!entitlementIds.length) return map;
+    const [rows] = await d.sequelize.query(
+      `SELECT DISTINCT ON ("entitlementId", metadata->>'channel')
+              "entitlementId", type, "createdAt",
+              metadata->>'channel' AS channel, metadata->>'kind' AS kind
+         FROM redemption_events
+        WHERE "entitlementId" IN (:ids) AND type IN ('notified', 'notify_failed')
+        ORDER BY "entitlementId", metadata->>'channel', "createdAt" DESC`,
+      { replacements: { ids: entitlementIds } }
+    );
+    for (const r of rows) {
+      const key = String(r.entitlementId);
+      if (!map.has(key)) map.set(key, { email: null, whatsapp: null });
+      const channel = r.channel === 'whatsapp' ? 'whatsapp' : 'email';
+      map.get(key)[channel] = { kind: r.kind || null, at: r.createdAt, ok: r.type === 'notified' };
+    }
+    return map;
+  }
+
+  /** Draw rails across a campaign set — entitlements on one speak the draw voice. */
+  async function drawRailActivationIds(campaignIds) {
+    const railIds = new Set();
+    if (!campaignIds.length) return railIds;
+    const rows = await d.Draw.findAll({
+      where: { campaignId: { [Op.in]: campaignIds } },
+      attributes: ['activationId'],
+    });
+    for (const r of rows) if (r.activationId) railIds.add(String(r.activationId));
+    return railIds;
+  }
+
+  /** Bounded person-level broadcast history: recent page + full status tallies. */
+  async function broadcastHistory(consumerId) {
+    try {
+      const [rows, tallies] = await Promise.all([
+        d.EmailBroadcastRecipient.findAll({
+          where: { consumerId },
+          include: [{ association: 'broadcast', attributes: ['id', 'subject'] }],
+          order: [['createdAt', 'DESC'], ['id', 'DESC']],
+          limit: BROADCAST_LIMIT,
+        }),
+        d.EmailBroadcastRecipient.findAll({
+          where: { consumerId },
+          attributes: ['status', [d.sequelize.fn('COUNT', d.sequelize.col('id')), 'n']],
+          group: ['status'],
+          raw: true,
+        }),
+      ]);
+      const counts = {};
+      for (const t of tallies) counts[t.status] = Number(t.n);
+      return {
+        counts,
+        recent: rows.map((r) => ({
+          broadcastId: r.broadcastId,
+          subject: r.broadcast?.subject || null,
+          status: r.status,
+          reason: r.reason || null,
+          sentAt: r.sentAt || null,
+          at: r.createdAt,
+        })),
+      };
+    } catch (err) {
+      d.logger.warn('[leadProfile] broadcast history failed (omitted)', { error: err?.message });
+      return { counts: {}, recent: [] };
+    }
+  }
+
+  /**
+   * Enrich a `getConsumerJourney(..., { includeRaw: true })` payload in place:
+   * per-signup draw standing + campaign-scoped consent + reward diagnostic,
+   * entitlement presentation extras + delivery receipts, person suppressions,
+   * bounded broadcast history. Consumes and strips `_rawSignups`.
+   */
+  async function enrichJourneyProfile(journey) {
+    if (!journey) return journey;
+    const raw = Array.isArray(journey._rawSignups) ? journey._rawSignups : [];
+    delete journey._rawSignups;
+    const erased = Boolean(journey.consumer?.erasedAt);
+    const campaignIds = [...new Set(raw.map((p) => String(p.campaignId)).filter(Boolean))];
+
+    const [drawMap, railIds] = await Promise.all([
+      d.getProspectDrawStatus(raw, { erased }),
+      drawRailActivationIds(campaignIds),
+    ]);
+
+    // Presentation extras the lean journey projection doesn't carry — one
+    // bounded re-read by id (the journey stays byte-identical without profile).
+    const entIds = journey.entitlements.map((e) => e.id);
+    const extraById = new Map();
+    if (entIds.length) {
+      const rows = await d.RewardEntitlement.findAll({
+        where: { id: { [Op.in]: entIds } },
+        attributes: ['id', 'status', 'expiresAt', 'unlockedVia', 'tokenHint', 'activationId'],
+      });
+      for (const r of rows) extraById.set(String(r.id), r);
+    }
+    const receipts = await deliveryReceipts(entIds);
+    journey.entitlements = journey.entitlements.map((e) => {
+      const extra = extraById.get(String(e.id));
+      return {
+        ...e,
+        state: extra ? d.presentState(extra, d.now()) : null,
+        unlockedVia: extra?.unlockedVia || null,
+        tokenHint: extra?.tokenHint || null,
+        drawLinked: Boolean(extra?.activationId && railIds.has(String(extra.activationId))),
+        delivery: receipts.get(String(e.id)) || { email: null, whatsapp: null },
+      };
+    });
+
+    // Consent is SCOPED — resolve per signup campaign (campaign + global
+    // latest-wins), never one person-wide last-per-kind map.
+    const consentByCampaign = new Map();
+    await Promise.all(campaignIds.map(async (cid) => {
+      const state = await d.getConsentState(journey.consumer.id, { campaignId: cid })
+        .catch(() => null);
+      consentByCampaign.set(cid, state);
+    }));
+
+    const entitledCampaigns = new Set(
+      journey.entitlements.map((e) => String(e.campaignId)).filter(Boolean)
+    );
+    const rawById = new Map(raw.map((p) => [String(p.id), p]));
+    journey.signups = await Promise.all(journey.signups.map(async (s) => {
+      const cid = s.campaign ? String(s.campaign.id) : null;
+      const consent = cid ? consentByCampaign.get(cid) : null;
+      const { suppressions: _drop, ...consentKinds } = consent || {};
+      const wantDiagnostic = cid && !entitledCampaigns.has(cid) && !erased;
+      return {
+        ...s,
+        draw: drawMap.get(String(s.prospectId)) ?? null,
+        consent: consent ? consentKinds : null,
+        rewardDiagnostic: wantDiagnostic
+          ? await deriveRewardDiagnostic(rawById.get(String(s.prospectId))).catch(() => null)
+          : null,
+      };
+    }));
+
+    journey.suppressions = await d.ConsumerSuppression.findAll({ where: { consumerId: journey.consumer.id } })
+      .then((rows) => rows.map((r) => ({ channel: r.channel, reason: r.reason })))
+      .catch(() => []);
+    journey.broadcasts = await broadcastHistory(journey.consumer.id);
+    return journey;
+  }
+
+  /**
+   * B4 fallback — the same draw/reward standing for a prospect with NO
+   * consumer link (Retell voice leads, pre-spine rows, unverified phones), so
+   * their page still tells their own campaign's story.
+   */
+  async function getSignupProfile(prospect) {
+    const plain = {
+      id: prospect.id,
+      campaignId: prospect.campaignId,
+      phone: prospect.phone,
+      createdAt: prospect.createdAt,
+      quarantinedAt: prospect.quarantinedAt,
+      quarantineReason: prospect.quarantineReason,
+      sourceMetadata: prospect.sourceMetadata,
+      consentMetadata: prospect.consentMetadata,
+    };
+    const [drawMap, railIds, entitlements] = await Promise.all([
+      d.getProspectDrawStatus([plain], { erased: plain.sourceMetadata?.erased === true }),
+      drawRailActivationIds(plain.campaignId ? [String(plain.campaignId)] : []),
+      d.RewardEntitlement.findAll({
+        where: { prospectId: prospect.id },
+        attributes: ['id', 'status', 'createdAt', 'unlockedAt', 'expiresAt', 'unlockedVia', 'tokenHint', 'activationId'],
+        include: [
+          { association: 'rewardOffer', attributes: ['id', 'title', 'publicTitle'] },
+          { association: 'activation', attributes: ['id', 'campaignId', 'campaignNameSnapshot'] },
+          { association: 'redemption', attributes: ['id', 'redeemedAt', 'status'] },
+        ],
+        order: [['createdAt', 'DESC'], ['id', 'DESC']],
+      }),
+    ]);
+    const receipts = await deliveryReceipts(entitlements.map((e) => e.id));
+    return {
+      draw: drawMap.get(String(prospect.id)) ?? null,
+      entitlements: entitlements.map((e) => ({
+        id: e.id,
+        status: e.status,
+        state: d.presentState(e, d.now()),
+        createdAt: e.createdAt,
+        unlockedAt: e.unlockedAt,
+        expiresAt: e.expiresAt,
+        rewardTitle: e.rewardOffer ? (e.rewardOffer.publicTitle || e.rewardOffer.title) : null,
+        campaignName: e.activation?.campaignNameSnapshot || null,
+        campaignId: e.activation?.campaignId || null,
+        redeemedAt: e.redemption?.redeemedAt || null,
+        unlockedVia: e.unlockedVia || null,
+        tokenHint: e.tokenHint || null,
+        drawLinked: Boolean(e.activationId && railIds.has(String(e.activationId))),
+        delivery: receipts.get(String(e.id)) || { email: null, whatsapp: null },
+      })),
+      rewardDiagnostic: entitlements.length
+        ? null
+        : await deriveRewardDiagnostic(plain).catch(() => null),
+    };
+  }
+
+  /**
+   * How this lead arrived: merged view over ALL session_visits rows for the
+   * sessionId (the write path is findOne-then-append and the index is
+   * non-unique — duplicates exist; never findOne). Funnel steps are an
+   * ALLOWLISTED projection — eventsJson is arbitrary public beacon input and
+   * must not be reflected raw into the admin UI.
+   */
+  async function getSessionContext(sessionId) {
+    if (!sessionId) return null;
+    const visits = await d.SessionVisit.findAll({
+      where: { sessionId },
+      order: [['startedAt', 'ASC'], ['id', 'ASC']],
+    });
+    if (!visits.length) return null;
+    const first = visits[0];
+    const steps = [];
+    for (const v of visits) {
+      const events = Array.isArray(v.eventsJson) ? v.eventsJson : [];
+      for (const ev of events) {
+        if (typeof ev?.type !== 'string') continue;
+        steps.push({
+          type: ev.type.slice(0, 64),
+          at: typeof ev.ts === 'string' ? ev.ts : null,
+          path: typeof ev.meta?.path === 'string' ? ev.meta.path.slice(0, 200) : null,
+        });
+      }
+    }
+    return {
+      startedAt: first.startedAt,
+      landingPath: first.landingPath || null,
+      utm: {
+        source: first.utmSource || null,
+        medium: first.utmMedium || null,
+        campaign: first.utmCampaign || null,
+        term: first.utmTerm || null,
+        content: first.utmContent || null,
+      },
+      steps: steps.slice(0, SESSION_STEP_LIMIT),
+      stepsTruncated: steps.length > SESSION_STEP_LIMIT,
+      visitCount: visits.length,
+    };
+  }
+
+  /**
+   * Did this lead reach the Lyfe app? Latest delivery per event type, filtered
+   * to the Lyfe-destination subscriber (deliveries are per-subscriber; an
+   * MKTR-Leads row is NOT Lyfe delivery). Returns null when nothing was ever
+   * queued — a System-Agent lead's null destination is default-denied and
+   * writes no row at all, so "no rows" is itself the signal the UI voices.
+   * Served by the partial expression index idx_wd_lead_external_created (089).
+   */
+  async function getLyfeDelivery(prospectId) {
+    const [rows] = await d.sequelize.query(
+      `SELECT DISTINCT ON (wd."eventType")
+              wd."eventType", wd.status, wd.attempts, wd."lastAttemptAt",
+              wd."responseCode", wd."createdAt"
+         FROM webhook_deliveries wd
+         JOIN webhook_subscribers ws ON ws.id = wd."subscriberId"
+        WHERE wd."eventType" IN ('lead.created', 'lead.assigned')
+          AND (wd.payload::jsonb #>> '{data,lead,externalId}') = :pid
+          AND ws.metadata->>'destination' = 'lyfe'
+        ORDER BY wd."eventType", wd."createdAt" DESC`,
+      { replacements: { pid: String(prospectId) } }
+    );
+    if (!rows.length) return null;
+    return rows.map((r) => ({
+      eventType: r.eventType,
+      status: r.status,
+      attempts: r.attempts,
+      lastAttemptAt: r.lastAttemptAt,
+      responseCode: r.responseCode ?? null,
+      reason: LYFE_DELIVERY_REASONS[r.responseCode] || null,
+      at: r.createdAt,
+    }));
+  }
+
+  return {
+    enrichJourneyProfile,
+    getSignupProfile,
+    getSessionContext,
+    getLyfeDelivery,
+    deriveRewardDiagnostic,
+  };
+}
+
+const _default = makeLeadProfileService();
+export const enrichJourneyProfile = _default.enrichJourneyProfile;
+export const getSignupProfile = _default.getSignupProfile;
+export const getSessionContext = _default.getSessionContext;
+export const getLyfeDelivery = _default.getLyfeDelivery;

--- a/backend/src/services/luckyDrawService.js
+++ b/backend/src/services/luckyDrawService.js
@@ -103,6 +103,26 @@ function orderedEntries(entries) {
   return [...entries].sort((a, b) => String(a.id).localeCompare(String(b.id)));
 }
 
+/**
+ * THE pool-entry predicate, shared by freezeDraw and the admin read path
+ * (getProspectDrawStatus) so the page can never disagree with the engine
+ * about who a freeze would admit. Deliberately stricter than
+ * phoneVerificationIsCurrent: freeze requires BOTH stamp fields present and
+ * bound to the current phone (legacy unbounded stamps don't enter a draw).
+ */
+export function entryEligibility(prospect, validVersionIds) {
+  const sm = prospect?.sourceMetadata || {};
+  const verified =
+    typeof sm.phoneVerifiedAt === 'string' &&
+    typeof sm.phoneVerifiedFor === 'string' &&
+    sm.phoneVerifiedFor === sha256Hex(String(prospect?.phone || ''));
+  const dt = prospect?.consentMetadata?.drawTerms;
+  const hasTerms =
+    typeof dt?.termsVersionId === 'string' &&
+    validVersionIds.has(dt.termsVersionId.toLowerCase());
+  return { verified, hasTerms, eligible: verified && hasTerms };
+}
+
 export function makeLuckyDrawService(overrides = {}) {
   const d = {
     Draw, DrawEntry, DrawAttempt, DrawBoostReview,
@@ -277,17 +297,7 @@ export function makeLuckyDrawService(overrides = {}) {
       });
       const validVersionIds = new Set(versionRows.map((v) => String(v.id).toLowerCase()));
 
-      const eligible = prospects.filter((p) => {
-        const sm = p.sourceMetadata || {};
-        const dt = p.consentMetadata?.drawTerms;
-        return (
-          typeof sm.phoneVerifiedAt === 'string' &&
-          typeof sm.phoneVerifiedFor === 'string' &&
-          sm.phoneVerifiedFor === sha256Hex(p.phone) &&
-          typeof dt?.termsVersionId === 'string' &&
-          validVersionIds.has(dt.termsVersionId.toLowerCase())
-        );
-      });
+      const eligible = prospects.filter((p) => entryEligibility(p, validVersionIds).eligible);
 
       // Version-cohort audit (CX18): entrants may have accepted DIFFERENT
       // pinned versions (terms were corrected mid-flight). Surfaced, never
@@ -299,13 +309,8 @@ export function makeLuckyDrawService(overrides = {}) {
         termsCohorts[v] = (termsCohorts[v] || 0) + 1;
       }
       excludedNoConsent = prospects.filter((p) => {
-        const sm = p.sourceMetadata || {};
-        const verified =
-          typeof sm.phoneVerifiedAt === 'string' &&
-          typeof sm.phoneVerifiedFor === 'string' &&
-          sm.phoneVerifiedFor === sha256Hex(p.phone);
-        const dt = p.consentMetadata?.drawTerms;
-        return verified && !(typeof dt?.termsVersionId === 'string' && validVersionIds.has(dt.termsVersionId.toLowerCase()));
+        const e = entryEligibility(p, validVersionIds);
+        return e.verified && !e.hasTerms;
       }).length;
 
       rows = eligible.map((p) => ({
@@ -417,11 +422,11 @@ export function makeLuckyDrawService(overrides = {}) {
       const key = String(ent.prospectId);
       if (via === 'agent_scan') {
         // Token-backed scan — the strongest evidence; always wins for the prospect.
-        byProspect.set(key, { via, eventId: ev.id });
+        byProspect.set(key, { via, eventId: ev.id, at: ev.createdAt });
       } else if (via === 'agent_button' || via === 'manual') {
         const decision = reviewByEntitlement.get(String(ev.entitlementId));
         if (decision === 'approved') {
-          if (!byProspect.has(key)) byProspect.set(key, { via: 'agent_button', eventId: ev.id });
+          if (!byProspect.has(key)) byProspect.set(key, { via: 'agent_button', eventId: ev.id, at: ev.createdAt });
         } else if (decision !== 'rejected') {
           undecidedButtons.push({ entitlementId: ent.id, prospectId: ent.prospectId, eventId: ev.id, via });
         }
@@ -781,9 +786,276 @@ export function makeLuckyDrawService(overrides = {}) {
     };
   }
 
+  /**
+   * Admin READ path for the Lead Profile page (docs/plans/admin-lead-profile-page.md
+   * §4): per-prospect draw standing, batched across campaigns. Never writes.
+   *
+   * Three lifecycle branches — because freeze WRITES the pool:
+   *  - open:   nothing is persisted yet; derive a PROVISIONAL preview from the
+   *            live prospect via the same entryEligibility predicate freeze
+   *            will apply, plus provisional boost evidence.
+   *  - frozen: membership comes ONLY from the persisted DrawEntry rows (a
+   *            post-freeze phone/consent edit must not make this view disagree
+   *            with the actual pool); boost weighting stays provisional until
+   *            seal replaces chances with the multiplier.
+   *  - sealed+: stored truth — DrawEntry.chances/boostVia and the DrawAttempt
+   *            redraw ledger ("Winner" is only ever the claimed attempt).
+   *
+   * Draw selection is deterministic: the campaign's single live draw
+   * (open|frozen|sealed|drawn — uq_draws_live_campaign) if one exists, else
+   * the newest terminal draw; older terminal draws return as drawHistory[].
+   *
+   * Bounded queries: 1 draws + ≤1 campaigns + ≤1 terms + ≤1 entries + ≤1
+   * attempts + 3 per DISTINCT open/frozen draw (collectBoostEvidence) + 1
+   * status re-read. Lifecycle consistency: statuses are re-read after the
+   * collection pass and the whole read retries ONCE on any flip, so a
+   * freeze/seal landing mid-read can't mix provisional and frozen data.
+   *
+   * Returns Map<prospectId(string), drawBlock|null> — null when the campaign
+   * has no draw and no enabled luckyDraw config.
+   */
+  async function getProspectDrawStatus(prospects, { erased = false } = {}) {
+    const LIVE_STATUSES = ['open', 'frozen', 'sealed', 'drawn'];
+    const ENTRY_STATUSES = ['frozen', 'sealed', 'drawn', 'published', 'claimed'];
+    const ATTEMPT_STATUSES = ['sealed', 'drawn', 'published', 'claimed'];
+
+    const list = (prospects || []).filter((p) => p && p.id && p.campaignId);
+    const out = new Map();
+    if (list.length === 0) return out;
+    const campaignIds = [...new Set(list.map((p) => String(p.campaignId)))];
+    const prospectIds = list.map((p) => String(p.id));
+
+    const collect = async () => {
+      const draws = await d.Draw.findAll({
+        where: { campaignId: { [Op.in]: campaignIds } },
+        order: [['createdAt', 'DESC'], ['id', 'DESC']],
+      });
+      const byCampaign = new Map();
+      for (const dr of draws) {
+        const k = String(dr.campaignId);
+        if (!byCampaign.has(k)) byCampaign.set(k, []);
+        byCampaign.get(k).push(dr);
+      }
+      const selected = new Map(); // campaignId -> { draw, history[] }
+      for (const [k, rows] of byCampaign) {
+        const live = rows.find((r) => LIVE_STATUSES.includes(r.status));
+        const chosen = live || rows[0]; // rows are newest-first
+        selected.set(k, {
+          draw: chosen,
+          history: rows
+            .filter((r) => String(r.id) !== String(chosen.id))
+            .map((r) => ({ drawId: r.id, drawStatus: r.status, closesAt: r.closesAt })),
+        });
+      }
+
+      // Campaigns with no draw row at all: enabled config = readiness drift.
+      const configEnabled = new Set();
+      const noDrawCampaigns = campaignIds.filter((k) => !selected.has(k));
+      if (noDrawCampaigns.length > 0) {
+        const campaigns = await d.Campaign.findAll({
+          where: { id: { [Op.in]: noDrawCampaigns } },
+          attributes: ['id', 'design_config'],
+        });
+        for (const c of campaigns) {
+          if (c.design_config?.luckyDraw?.enabled === true) configEnabled.add(String(c.id));
+        }
+      }
+
+      const selectedDraws = [...selected.values()].map((s) => s.draw);
+      const openDraws = selectedDraws.filter((dr) => dr.status === 'open');
+      const entryDraws = selectedDraws.filter((dr) => ENTRY_STATUSES.includes(dr.status));
+      const attemptDraws = selectedDraws.filter((dr) => ATTEMPT_STATUSES.includes(dr.status));
+
+      const termsByCampaign = new Map(); // campaignId -> Set(lowercased version ids)
+      if (openDraws.length > 0) {
+        const versionRows = await d.DrawTermsVersion.findAll({
+          where: { campaignId: { [Op.in]: openDraws.map((dr) => dr.campaignId) } },
+          attributes: ['id', 'campaignId'],
+        });
+        for (const v of versionRows) {
+          const k = String(v.campaignId);
+          if (!termsByCampaign.has(k)) termsByCampaign.set(k, new Set());
+          termsByCampaign.get(k).add(String(v.id).toLowerCase());
+        }
+      }
+
+      const entryByDrawProspect = new Map(); // `${drawId}:${prospectId}` -> entry
+      if (entryDraws.length > 0) {
+        const entryRows = await d.DrawEntry.findAll({
+          where: {
+            drawId: { [Op.in]: entryDraws.map((dr) => dr.id) },
+            prospectId: { [Op.in]: prospectIds },
+          },
+        });
+        for (const e of entryRows) {
+          entryByDrawProspect.set(`${e.drawId}:${e.prospectId}`, e);
+        }
+      }
+
+      const attemptsByDraw = new Map(); // drawId -> attempts ASC by attemptNo
+      if (attemptDraws.length > 0) {
+        const attemptRows = await d.DrawAttempt.findAll({
+          where: { drawId: { [Op.in]: attemptDraws.map((dr) => dr.id) } },
+          order: [['attemptNo', 'ASC']],
+        });
+        for (const a of attemptRows) {
+          const k = String(a.drawId);
+          if (!attemptsByDraw.has(k)) attemptsByDraw.set(k, []);
+          attemptsByDraw.get(k).push(a);
+        }
+      }
+
+      // Provisional boost evidence — open draws over the live prospects,
+      // frozen draws over their FROZEN entries only (engine parity).
+      const evidenceByDraw = new Map();
+      for (const dr of selectedDraws) {
+        if (dr.status !== 'open' && dr.status !== 'frozen') continue;
+        const campProspects = list.filter((p) => String(p.campaignId) === String(dr.campaignId));
+        const entryLike = dr.status === 'frozen'
+          ? campProspects
+            .filter((p) => entryByDrawProspect.has(`${dr.id}:${p.id}`))
+            .map((p) => ({ prospectId: p.id }))
+          : campProspects.map((p) => ({ prospectId: p.id }));
+        evidenceByDraw.set(String(dr.id), await collectBoostEvidence(dr, entryLike));
+      }
+
+      return { selected, configEnabled, termsByCampaign, entryByDrawProspect, attemptsByDraw, evidenceByDraw };
+    };
+
+    let data = await collect();
+    // One consistency retry: a freeze/seal that landed mid-collection flips
+    // the status — re-collect once from the fresh lifecycle state.
+    const selectedIds = [...data.selected.values()].map((s) => String(s.draw.id));
+    if (selectedIds.length > 0) {
+      const fresh = await d.Draw.findAll({
+        where: { id: { [Op.in]: selectedIds } },
+        attributes: ['id', 'status'],
+      });
+      const statusNow = new Map(fresh.map((f) => [String(f.id), f.status]));
+      const flipped = [...data.selected.values()].some(
+        (s) => statusNow.has(String(s.draw.id)) && statusNow.get(String(s.draw.id)) !== s.draw.status
+      );
+      if (flipped) data = await collect();
+    }
+
+    for (const p of list) {
+      const pid = String(p.id);
+      const sel = data.selected.get(String(p.campaignId));
+      if (!sel) {
+        out.set(pid, data.configEnabled.has(String(p.campaignId)) ? { state: 'no_draw_record' } : null);
+        continue;
+      }
+      const dr = sel.draw;
+      const block = {
+        drawId: dr.id,
+        drawStatus: dr.status,
+        activationId: dr.activationId || null,
+        multiplier: dr.multiplier,
+        closesAt: dr.closesAt,
+        boostClosesAt: dr.boostClosesAt,
+        provisional: dr.status === 'open' || dr.status === 'frozen',
+        chances: 0,
+        boosted: false,
+        boostVia: null,
+        boostedAt: null,
+        boostReviewPending: false,
+        notEligibleReason: null,
+        outcome: null,
+        drawHistory: sel.history,
+      };
+
+      const isErased = erased || p.sourceMetadata?.erased === true;
+      if (isErased) {
+        // Erasure nulls DrawEntry.prospectId and sentinels the phone hash —
+        // the entry is unjoinable BY DESIGN. Saying "not eligible"/"no entry"
+        // would rewrite history; say the truth instead.
+        out.set(pid, { ...block, state: 'erased_draw_unavailable' });
+        continue;
+      }
+      if (dr.status === 'void') {
+        out.set(pid, { ...block, state: 'void' });
+        continue;
+      }
+
+      if (dr.status === 'open') {
+        const versions = data.termsByCampaign.get(String(dr.campaignId)) || new Set();
+        const elig = entryEligibility(p, versions);
+        const inWindow = new Date(p.createdAt).getTime() < new Date(dr.closesAt).getTime();
+        let notEligibleReason = null;
+        if (!p.phone) notEligibleReason = 'no_phone';
+        else if (!elig.verified) notEligibleReason = 'phone_unverified';
+        else if (!elig.hasTerms) notEligibleReason = 'terms_not_pinned';
+        else if (!inWindow) notEligibleReason = 'signed_up_after_close';
+
+        const evidence = data.evidenceByDraw.get(String(dr.id));
+        const boost = evidence?.byProspect.get(pid) || null;
+        const pendingReview = (evidence?.undecidedButtons || []).some((u) => String(u.prospectId) === pid);
+        out.set(pid, {
+          ...block,
+          state: notEligibleReason ? 'provisional_out' : 'provisional_in',
+          chances: notEligibleReason ? 0 : (boost ? dr.multiplier : 1),
+          boosted: !notEligibleReason && Boolean(boost),
+          boostVia: boost?.via || null,
+          boostedAt: boost?.at || null,
+          boostReviewPending: pendingReview && !boost,
+          notEligibleReason,
+        });
+        continue;
+      }
+
+      const entry = data.entryByDrawProspect.get(`${dr.id}:${p.id}`);
+      if (!entry) {
+        out.set(pid, { ...block, state: 'excluded_at_freeze' });
+        continue;
+      }
+
+      if (dr.status === 'frozen') {
+        const evidence = data.evidenceByDraw.get(String(dr.id));
+        const boost = evidence?.byProspect.get(pid) || null;
+        const pendingReview = (evidence?.undecidedButtons || []).some((u) => String(u.prospectId) === pid);
+        out.set(pid, {
+          ...block,
+          state: 'frozen_in',
+          chances: entry.chances, // 1 until seal applies the multiplier
+          boosted: Boolean(boost), // provisional — applies at seal
+          boostVia: boost?.via || null,
+          boostedAt: boost?.at || null,
+          boostReviewPending: pendingReview && !boost,
+        });
+        continue;
+      }
+
+      // sealed | drawn | published | claimed — stored truth + redraw ledger.
+      const attempts = data.attemptsByDraw.get(String(dr.id)) || [];
+      const mine = attempts.filter((a) => String(a.pickedEntryId) === String(entry.id));
+      const anyClaimed = dr.status === 'claimed' || attempts.some((a) => a.outcome === 'claimed');
+      let outcome = null;
+      if (mine.length > 0) {
+        const last = mine[mine.length - 1];
+        outcome = {
+          status: last.outcome === 'pending' ? 'selected_pending' : `selected_${last.outcome}`,
+          attemptNo: last.attemptNo,
+          claimDeadline: last.claimDeadline || null,
+          claimedAt: last.claimedAt || null,
+        };
+      } else if (attempts.length > 0) {
+        outcome = { status: anyClaimed ? 'not_selected_final' : 'not_selected_yet' };
+      }
+      out.set(pid, {
+        ...block,
+        state: 'sealed',
+        chances: entry.chances,
+        boosted: Boolean(entry.boostVia),
+        boostVia: entry.boostVia || null,
+        outcome,
+      });
+    }
+    return out;
+  }
+
   return {
     createDraw, freezeDraw, listPendingBoostReviews, reviewBoost, sealDraw,
     runDrawAttempt, recordAttemptOutcome, markPublished, voidDraw,
-    verifyDraw, getDrawState,
+    verifyDraw, getDrawState, getProspectDrawStatus,
   };
 }

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -44,6 +44,11 @@ import {
   getConsumerJourney,
 } from './consumerService.js';
 import { recordCaptureConsentEventsTx, canMarketTo } from './consentService.js';
+// Lead Profile page composer (admin-only, ?include=profile — plan §4). Leaf
+// imports only (models + sibling services); no cycle back into this module.
+import {
+  enrichJourneyProfile, getSignupProfile, getSessionContext, getLyfeDelivery,
+} from './leadProfileService.js';
 import { customerHostOrigin, normalizeCustomerHostChoice } from '../utils/customerHost.js';
 import { sgtDayEndExclusiveMs } from '../utils/sgtTime.js';
 
@@ -197,6 +202,10 @@ const defaultDeps = {
   resolveConsumerForCaptureTx,
   recomputeConsumersByPhone,
   getConsumerJourney,
+  enrichJourneyProfile,
+  getSignupProfile,
+  getSessionContext,
+  getLyfeDelivery,
   recordCaptureConsentEventsTx,
   canMarketTo,
   onLeadCaptured: (prospect) => (_leadCapturedHook ? _leadCapturedHook(prospect) : null),
@@ -1375,8 +1384,15 @@ export function makeProspectService(overrides = {}) {
 
   /**
    * Get a single prospect by ID, scoped to user access.
+   *
+   * `include: 'profile'` (Lead Profile page, plan §4) is ADMIN-ONLY and
+   * opt-in: non-admins and callers that don't ask get a byte-identical
+   * payload to before the option existed — the flag simply never reaches the
+   * enrichment branch for them.
    */
-  async function getProspect(id, user) {
+  async function getProspect(id, user, { include = '' } = {}) {
+    const wantProfile = user?.role === 'admin'
+      && String(include).split(',').map((s) => s.trim()).includes('profile');
     const scopeFilter = await d.buildProspectWhere(user);
     const whereConditions = { id, ...scopeFilter };
 
@@ -1399,6 +1415,13 @@ export function makeProspectService(overrides = {}) {
           association: 'commissions',
           attributes: ['id', 'type', 'amount', 'status', 'earnedDate'],
         },
+        // Named external buyer — profile mode only (the association exists but
+        // was never loaded; keep the classic payload byte-identical). Name and
+        // agency ONLY: never phone/email/balance on an admin lead view.
+        ...(wantProfile ? [{
+          association: 'externalAgent',
+          attributes: ['id', 'fullName', 'agency'],
+        }] : []),
         {
           association: 'activities',
           // Newest-first, so the Activity Timeline UI (which renders this array
@@ -1434,16 +1457,33 @@ export function makeProspectService(overrides = {}) {
     // view, and the timeline degrades to ProspectActivity-only on a Supabase miss).
     if (user?.role === 'admin') {
       const wantTimeline = !!process.env.SUPABASE_LEAD_ACTIVITIES_URL;
-      const [repeatSignup, timelineFetch, consumerJourney] = await Promise.all([
+      const [repeatSignup, timelineFetch, consumerJourney, session, lyfeDelivery, signupProfile] = await Promise.all([
         repeatSignupDetail(d.sequelize, { phone: prospect.phone, email: prospect.email }).catch(() => null),
         wantTimeline
           ? fetchLeadActivitiesFromSupabase(prospect.id).catch(() => ({ rows: [], ok: false }))
           : Promise.resolve(null),
         // Consumer spine: the person's cross-campaign journey (signups +
         // rewards) for the admin drawer's Person card. Resilient like its
-        // siblings — a miss never breaks the detail view.
+        // siblings — a miss never breaks the detail view. Profile mode
+        // (Lead Profile page) enriches the same journey in place: per-signup
+        // draw standing + scoped consent + reward diagnostics, entitlement
+        // presentation extras, suppressions, broadcast history.
         prospect.consumerId
-          ? d.getConsumerJourney(prospect.consumerId).catch(() => null)
+          ? d.getConsumerJourney(prospect.consumerId, wantProfile ? { includeRaw: true } : undefined)
+            .then((j) => (wantProfile && j ? d.enrichJourneyProfile(j) : j))
+            .catch(() => null)
+          : Promise.resolve(null),
+        // Profile-only extras (each resilient, each bounded — plan §4 B6/B7).
+        wantProfile
+          ? d.getSessionContext(prospect.sessionId).catch(() => null)
+          : Promise.resolve(null),
+        wantProfile
+          ? d.getLyfeDelivery(prospect.id).catch(() => null)
+          : Promise.resolve(null),
+        // B4: a consumer-less lead (Retell, pre-spine, unverified) still gets
+        // its OWN campaign's draw/reward standing.
+        wantProfile && !prospect.consumerId
+          ? d.getSignupProfile(prospect).catch(() => null)
           : Promise.resolve(null),
       ]);
       if (repeatSignup) prospect.setDataValue('repeatSignup', repeatSignup);
@@ -1454,6 +1494,9 @@ export function makeProspectService(overrides = {}) {
           mergeProspectTimeline(prospect.activities || [], timelineFetch.rows, { ok: timelineFetch.ok }),
         );
       }
+      if (session) prospect.setDataValue('session', session);
+      if (lyfeDelivery) prospect.setDataValue('lyfeDelivery', lyfeDelivery);
+      if (signupProfile) prospect.setDataValue('signupProfile', signupProfile);
     }
 
     return prospect;

--- a/backend/src/services/redeemOps/entitlementService.js
+++ b/backend/src/services/redeemOps/entitlementService.js
@@ -19,8 +19,9 @@ const DEFAULT_RESERVATION_DAYS = 30;
 const DEFAULT_REDEMPTION_DAYS = 90;
 const RESEND_COOLDOWN_MS = 60 * 1000;
 // Statuses that hold the per-phone slot (matches uq_re_activation_phone's
-// partial WHERE) — expired/cancelled rows free it.
-const LIVE_PHONE_STATUSES = ['eligible', 'issued', 'redeemed'];
+// partial WHERE) — expired/cancelled rows free it. Exported for the Lead
+// Profile diagnostic, which mirrors issueForProspect's duplicate-phone check.
+export const LIVE_PHONE_STATUSES = ['eligible', 'issued', 'redeemed'];
 
 /**
  * Anti-farming dedupe key: digits-only phone (`+65 9123 4567` → `6591234567`).

--- a/backend/src/utils/entitlementPresentState.js
+++ b/backend/src/utils/entitlementPresentState.js
@@ -1,0 +1,16 @@
+/**
+ * The ONE DB-status → UI-state mapper for reward entitlements. Extracted for
+ * the Lead Profile page from routes/externalEntitlements.js (which keeps its
+ * own copy for now — consolidating the HMAC surfaces is deliberately out of
+ * this PR's blast radius; docs/plans/admin-lead-profile-page.md §4 B2).
+ *
+ * `<=` (not `<`) so presentation can never say "valid" for an instant the
+ * unlock transaction's `expiresAt > now` predicate would reject. The status
+ * column itself can hold 'expired' (sweep) — passed through.
+ */
+export function presentState(entitlement, now = new Date()) {
+  const expired = entitlement.expiresAt && new Date(entitlement.expiresAt) <= now;
+  if (entitlement.status === 'eligible') return expired ? 'expired' : 'reserved';
+  if (entitlement.status === 'issued') return expired ? 'expired' : 'unlocked';
+  return entitlement.status; // redeemed | expired | cancelled | blocked
+}

--- a/backend/test/leadProfileService.test.js
+++ b/backend/test/leadProfileService.test.js
@@ -1,0 +1,356 @@
+/**
+ * leadProfileService (DI seam — no DB) + the ?include=profile boundary on
+ * prospectService.getProspect. Covers: the read-time reward diagnostic's
+ * issueForProspect-parity order, receipt DISTINCT-ON mapping, the allowlisted
+ * session projection over duplicate visit rows, Lyfe-delivery reason mapping,
+ * journey enrichment (scoped consent, drawLinked, _rawSignups hygiene), and
+ * that non-admins / non-opted callers get the classic payload untouched.
+ * docs/plans/admin-lead-profile-page.md §4-§5.
+ */
+import { jest } from '@jest/globals';
+import { makeLeadProfileService } from '../src/services/leadProfileService.js';
+import { makeProspectService } from '../src/services/prospectService.js';
+import { presentState } from '../src/utils/entitlementPresentState.js';
+import { SCREENING_REASONS } from '../src/services/screeningConstants.js';
+
+const silentLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+const NOW = new Date('2026-07-25T04:00:00Z');
+const FUTURE = new Date('2026-08-25T04:00:00Z');
+const PAST = new Date('2026-07-01T04:00:00Z');
+
+// ── presentState (the shared status → UI-state mapper) ──────────────────────
+
+describe('presentState', () => {
+  it('maps the lifecycle with expiry override', () => {
+    expect(presentState({ status: 'eligible', expiresAt: FUTURE }, NOW)).toBe('reserved');
+    expect(presentState({ status: 'eligible', expiresAt: PAST }, NOW)).toBe('expired');
+    expect(presentState({ status: 'issued', expiresAt: FUTURE }, NOW)).toBe('unlocked');
+    expect(presentState({ status: 'issued', expiresAt: NOW }, NOW)).toBe('expired'); // <= not <
+    expect(presentState({ status: 'redeemed', expiresAt: PAST }, NOW)).toBe('redeemed');
+    expect(presentState({ status: 'cancelled', expiresAt: null }, NOW)).toBe('cancelled');
+  });
+});
+
+// ── deriveRewardDiagnostic ──────────────────────────────────────────────────
+
+function diagDeps(overrides = {}) {
+  return makeLeadProfileService({
+    logger: silentLogger,
+    now: () => NOW,
+    getProspectDrawStatus: jest.fn().mockResolvedValue(new Map()),
+    getConsentState: jest.fn().mockResolvedValue(null),
+    Draw: { findAll: jest.fn().mockResolvedValue([]) },
+    Activation: { findOne: jest.fn().mockResolvedValue(null) },
+    RewardOffer: {},
+    RewardEntitlement: { findOne: jest.fn().mockResolvedValue(null), findAll: jest.fn().mockResolvedValue([]) },
+    ConsumerSuppression: { findAll: jest.fn().mockResolvedValue([]) },
+    EmailBroadcastRecipient: { findAll: jest.fn().mockResolvedValue([]) },
+    SessionVisit: { findAll: jest.fn().mockResolvedValue([]) },
+    sequelize: { query: jest.fn().mockResolvedValue([[]]), fn: jest.fn(), col: jest.fn() },
+    ...overrides,
+  });
+}
+
+const verifiedProspect = {
+  id: 'p1', campaignId: 'camp-1', phone: '+6591234567',
+  sourceMetadata: { phoneVerifiedAt: '2026-07-01T00:00:00Z' }, // legacy unbounded stamp is valid here
+  quarantinedAt: null, quarantineReason: null,
+};
+
+const liveActivation = (over = {}) => ({
+  id: 'act-1', campaignId: 'camp-1', status: 'active',
+  issuedCount: 3, allocatedQuantity: 10, endDate: null,
+  rewardOffer: { id: 'ro-1', status: 'active' },
+  ...over,
+});
+
+describe('deriveRewardDiagnostic (issueForProspect parity)', () => {
+  it('walks the gates in order', async () => {
+    const svc = diagDeps();
+    expect(await svc.deriveRewardDiagnostic({ ...verifiedProspect, campaignId: null })).toBeNull();
+    expect(await svc.deriveRewardDiagnostic({
+      ...verifiedProspect, quarantinedAt: NOW, quarantineReason: 'quota_hold',
+    })).toBe('quarantined');
+    expect(await svc.deriveRewardDiagnostic({
+      ...verifiedProspect, sourceMetadata: {},
+    })).toBe('phone_not_verified');
+    expect(await svc.deriveRewardDiagnostic(verifiedProspect)).toBe('no_active_activation');
+  });
+
+  it('screening holds are reward-eligible (the AI gate withholds delivery, not the reward)', async () => {
+    const svc = diagDeps({
+      Activation: { findOne: jest.fn().mockResolvedValue(liveActivation()) },
+    });
+    expect(await svc.deriveRewardDiagnostic({
+      ...verifiedProspect, quarantinedAt: NOW, quarantineReason: SCREENING_REASONS[0],
+    })).toBe('not_issued_yet');
+  });
+
+  it('duplicate phone, paused offer, ended activation, exhausted allocation', async () => {
+    const dup = diagDeps({
+      Activation: { findOne: jest.fn().mockResolvedValue(liveActivation()) },
+      RewardEntitlement: { findOne: jest.fn().mockResolvedValue({ id: 'ent-x' }), findAll: jest.fn() },
+    });
+    expect(await dup.deriveRewardDiagnostic(verifiedProspect)).toBe('duplicate_phone');
+
+    const paused = diagDeps({
+      Activation: { findOne: jest.fn().mockResolvedValue(liveActivation({ rewardOffer: { status: 'paused' } })) },
+    });
+    expect(await paused.deriveRewardDiagnostic(verifiedProspect)).toBe('offer_not_active');
+
+    const ended = diagDeps({
+      Activation: { findOne: jest.fn().mockResolvedValue(liveActivation({ endDate: PAST })) },
+    });
+    expect(await ended.deriveRewardDiagnostic(verifiedProspect)).toBe('activation_ended');
+
+    const exhausted = diagDeps({
+      Activation: { findOne: jest.fn().mockResolvedValue(liveActivation({ issuedCount: 10 })) },
+    });
+    expect(await exhausted.deriveRewardDiagnostic(verifiedProspect)).toBe('allocation_exhausted');
+  });
+});
+
+// ── session context (allowlist + duplicate rows) ────────────────────────────
+
+describe('getSessionContext', () => {
+  it('aggregates duplicate visit rows and allowlists steps', async () => {
+    const events = Array.from({ length: 30 }, (_, i) => ({
+      type: `step_${i}`, ts: '2026-07-20T00:00:00Z',
+      meta: { path: '/lead-capture', fbc: 'SECRET', nested: { junk: true } },
+    }));
+    const svc = diagDeps({
+      SessionVisit: {
+        findAll: jest.fn().mockResolvedValue([
+          {
+            startedAt: PAST, landingPath: '/c/tokyo', utmSource: 'fb', utmMedium: 'cpc',
+            utmCampaign: 'aug', utmTerm: 't', utmContent: 'c',
+            eventsJson: [...events, { notype: true }, { type: 42 }],
+          },
+          { startedAt: NOW, landingPath: '/other', eventsJson: events }, // race-duplicate row
+        ]),
+      },
+    });
+    const ctx = await svc.getSessionContext('sess-1');
+    expect(ctx.landingPath).toBe('/c/tokyo'); // earliest row wins
+    expect(ctx.utm).toEqual({ source: 'fb', medium: 'cpc', campaign: 'aug', term: 't', content: 'c' });
+    expect(ctx.visitCount).toBe(2);
+    expect(ctx.steps.length).toBe(50); // 60 valid events capped
+    expect(ctx.stepsTruncated).toBe(true);
+    // Allowlist: type/at/path only — beacon meta never reflected into admin UI.
+    expect(Object.keys(ctx.steps[0]).sort()).toEqual(['at', 'path', 'type']);
+    expect(JSON.stringify(ctx)).not.toContain('SECRET');
+  });
+
+  it('returns null for missing session or no rows', async () => {
+    const svc = diagDeps();
+    expect(await svc.getSessionContext(null)).toBeNull();
+    expect(await svc.getSessionContext('sess-x')).toBeNull();
+  });
+});
+
+// ── Lyfe delivery ───────────────────────────────────────────────────────────
+
+describe('getLyfeDelivery', () => {
+  it('maps receiver codes to operator-safe reasons', async () => {
+    const svc = diagDeps({
+      sequelize: {
+        query: jest.fn().mockResolvedValue([[
+          { eventType: 'lead.created', status: 'failed', attempts: 3, lastAttemptAt: NOW, responseCode: 422, createdAt: PAST },
+          { eventType: 'lead.assigned', status: 'success', attempts: 1, lastAttemptAt: NOW, responseCode: 200, createdAt: NOW },
+        ]]),
+        fn: jest.fn(), col: jest.fn(),
+      },
+    });
+    const rows = await svc.getLyfeDelivery('p1');
+    expect(rows[0]).toMatchObject({ eventType: 'lead.created', status: 'failed', reason: 'agent_not_found' });
+    expect(rows[1]).toMatchObject({ status: 'success', reason: null });
+  });
+
+  it('returns null when nothing was ever queued (System-Agent default-deny)', async () => {
+    const svc = diagDeps();
+    expect(await svc.getLyfeDelivery('p1')).toBeNull();
+  });
+});
+
+// ── journey enrichment ──────────────────────────────────────────────────────
+
+describe('enrichJourneyProfile', () => {
+  function journeyFixture() {
+    return {
+      consumer: { id: 'con-1', erasedAt: null },
+      signups: [
+        { prospectId: 'p1', campaign: { id: 'camp-1', name: 'Tokyo Draw' } },
+        { prospectId: 'p2', campaign: { id: 'camp-2', name: 'NTUC Trial' } },
+      ],
+      entitlements: [{
+        id: 'ent-1', status: 'issued', campaignId: 'camp-1',
+        expiresAt: FUTURE, createdAt: PAST, unlockedAt: PAST,
+      }],
+      drawEntries: 1,
+      _rawSignups: [
+        { id: 'p1', campaignId: 'camp-1', phone: '+6591234567', sourceMetadata: {}, consentMetadata: {} },
+        // Verified (legacy unbounded stamp) so the diagnostic walks PAST the
+        // phone gate and reaches the activation lookup.
+        { id: 'p2', campaignId: 'camp-2', phone: '+6591234567', sourceMetadata: { phoneVerifiedAt: '2026-07-01T00:00:00Z' }, consentMetadata: {} },
+      ],
+    };
+  }
+
+  function enrichDeps() {
+    const drawBlock = { state: 'provisional_in', chances: 10, drawId: 'd1' };
+    return {
+      drawBlock,
+      svc: makeLeadProfileService({
+        logger: silentLogger,
+        now: () => NOW,
+        getProspectDrawStatus: jest.fn().mockResolvedValue(new Map([['p1', drawBlock], ['p2', null]])),
+        getConsentState: jest.fn().mockImplementation(async (_cid, { campaignId }) => ({
+          contact: { granted: campaignId === 'camp-1', scope: 'campaign' },
+          suppressions: [{ channel: 'email', reason: 'unsubscribed' }],
+        })),
+        Draw: { findAll: jest.fn().mockResolvedValue([{ activationId: 'act-9' }]) },
+        Activation: { findOne: jest.fn().mockResolvedValue(null) },
+        RewardOffer: {},
+        RewardEntitlement: {
+          findOne: jest.fn().mockResolvedValue(null),
+          findAll: jest.fn().mockResolvedValue([
+            { id: 'ent-1', status: 'issued', expiresAt: FUTURE, unlockedVia: 'agent_scan', tokenHint: '1234', activationId: 'act-9' },
+          ]),
+        },
+        ConsumerSuppression: {
+          findAll: jest.fn().mockResolvedValue([{ channel: 'email', reason: 'unsubscribed' }]),
+        },
+        EmailBroadcastRecipient: {
+          findAll: jest.fn()
+            .mockResolvedValueOnce([{
+              broadcastId: 'b1', broadcast: { subject: 'Aug promo' },
+              status: 'skipped', reason: 'suppressed', sentAt: null, createdAt: NOW,
+            }])
+            .mockResolvedValueOnce([{ status: 'skipped', n: '1' }]),
+        },
+        SessionVisit: { findAll: jest.fn().mockResolvedValue([]) },
+        sequelize: {
+          query: jest.fn().mockResolvedValue([[
+            { entitlementId: 'ent-1', type: 'notified', channel: 'whatsapp', kind: 'voucher', createdAt: NOW },
+          ]]),
+          fn: jest.fn(), col: jest.fn(),
+        },
+      }),
+    };
+  }
+
+  it('attaches draw, scoped consent, diagnostics, receipts — and strips _rawSignups', async () => {
+    const { svc, drawBlock } = enrichDeps();
+    const journey = await svc.enrichJourneyProfile(journeyFixture());
+
+    expect(journey._rawSignups).toBeUndefined();
+    expect(journey.signups[0].draw).toBe(drawBlock);
+    expect(journey.signups[1].draw).toBeNull();
+
+    // Consent is campaign-scoped and stripped of the suppressions key.
+    expect(journey.signups[0].consent.contact.granted).toBe(true);
+    expect(journey.signups[1].consent.contact.granted).toBe(false);
+    expect(journey.signups[0].consent.suppressions).toBeUndefined();
+
+    // Diagnostic ONLY where the campaign has no entitlement.
+    expect(journey.signups[0].rewardDiagnostic).toBeNull();
+    expect(journey.signups[1].rewardDiagnostic).toBe('no_active_activation');
+
+    // Entitlement extras: presentation state, draw voice, receipts.
+    expect(journey.entitlements[0]).toMatchObject({
+      state: 'unlocked', unlockedVia: 'agent_scan', tokenHint: '1234', drawLinked: true,
+    });
+    expect(journey.entitlements[0].delivery.whatsapp).toMatchObject({ ok: true, kind: 'voucher' });
+    expect(journey.entitlements[0].delivery.email).toBeNull();
+
+    expect(journey.suppressions).toEqual([{ channel: 'email', reason: 'unsubscribed' }]);
+    expect(journey.broadcasts.recent[0]).toMatchObject({ subject: 'Aug promo', status: 'skipped', reason: 'suppressed' });
+    expect(journey.broadcasts.counts).toEqual({ skipped: 1 });
+  });
+
+  it('erased people get no reward diagnostics (their state is the erasure)', async () => {
+    const { svc } = enrichDeps();
+    const journey = journeyFixture();
+    journey.consumer.erasedAt = NOW;
+    const out = await svc.enrichJourneyProfile(journey);
+    expect(out.signups[1].rewardDiagnostic).toBeNull();
+  });
+});
+
+// ── the ?include=profile boundary on getProspect ────────────────────────────
+
+describe('prospectService.getProspect include gating', () => {
+  function gatedService() {
+    const calls = {
+      getConsumerJourney: jest.fn().mockResolvedValue({ consumer: { id: 'con-1' }, signups: [], entitlements: [], drawEntries: 0 }),
+      enrichJourneyProfile: jest.fn().mockImplementation(async (j) => ({ ...j, enriched: true })),
+      getSessionContext: jest.fn().mockResolvedValue({ landingPath: '/x' }),
+      getLyfeDelivery: jest.fn().mockResolvedValue([{ eventType: 'lead.created' }]),
+      getSignupProfile: jest.fn().mockResolvedValue({ draw: null, entitlements: [], rewardDiagnostic: null }),
+    };
+    const prospectRow = (consumerId) => {
+      const data = {};
+      return {
+        id: 'p1', phone: '+6591234567', email: null, consumerId, sessionId: 'sess-1', activities: [],
+        setDataValue: jest.fn().mockImplementation((k, v) => { data[k] = v; }),
+        _set: data,
+      };
+    };
+    const findOne = jest.fn();
+    const svc = makeProspectService({
+      ...calls,
+      buildProspectWhere: jest.fn().mockResolvedValue({}),
+      sequelize: { query: jest.fn().mockResolvedValue([[]]) },
+      models: { Prospect: { findOne } },
+    });
+    return { svc, calls, findOne, prospectRow };
+  }
+
+  it('non-admins never reach any profile enrichment, whatever they send', async () => {
+    const { svc, calls, findOne, prospectRow } = gatedService();
+    findOne.mockResolvedValue(prospectRow('con-1'));
+    await svc.getProspect('p1', { id: 'agent-1', role: 'agent' }, { include: 'profile' });
+    expect(calls.getConsumerJourney).not.toHaveBeenCalled();
+    expect(calls.getSessionContext).not.toHaveBeenCalled();
+    expect(calls.getLyfeDelivery).not.toHaveBeenCalled();
+    // The externalAgent include must not appear either (classic payload).
+    const include = findOne.mock.calls[0][0].include;
+    expect(include.some((i) => i.association === 'externalAgent')).toBe(false);
+  });
+
+  it('admin WITHOUT include gets the classic journey — no raw rows, no extras', async () => {
+    const { svc, calls, findOne, prospectRow } = gatedService();
+    findOne.mockResolvedValue(prospectRow('con-1'));
+    await svc.getProspect('p1', { id: 'admin-1', role: 'admin' }, {});
+    expect(calls.getConsumerJourney).toHaveBeenCalledWith('con-1', undefined);
+    expect(calls.enrichJourneyProfile).not.toHaveBeenCalled();
+    expect(calls.getSessionContext).not.toHaveBeenCalled();
+    expect(calls.getLyfeDelivery).not.toHaveBeenCalled();
+    expect(calls.getSignupProfile).not.toHaveBeenCalled();
+  });
+
+  it('admin + include=profile enriches the journey and attaches the extras', async () => {
+    const { svc, calls, findOne, prospectRow } = gatedService();
+    const row = prospectRow('con-1');
+    findOne.mockResolvedValue(row);
+    await svc.getProspect('p1', { id: 'admin-1', role: 'admin' }, { include: 'profile' });
+    expect(calls.getConsumerJourney).toHaveBeenCalledWith('con-1', { includeRaw: true });
+    expect(calls.enrichJourneyProfile).toHaveBeenCalled();
+    expect(row._set.consumer).toMatchObject({ enriched: true });
+    expect(row._set.session).toEqual({ landingPath: '/x' });
+    expect(row._set.lyfeDelivery).toEqual([{ eventType: 'lead.created' }]);
+    expect(calls.getSignupProfile).not.toHaveBeenCalled(); // consumer exists
+    const include = findOne.mock.calls[0][0].include;
+    expect(include.some((i) => i.association === 'externalAgent')).toBe(true);
+  });
+
+  it('admin + include=profile on a consumer-less lead falls back to signupProfile (B4)', async () => {
+    const { svc, calls, findOne, prospectRow } = gatedService();
+    const row = prospectRow(null);
+    findOne.mockResolvedValue(row);
+    await svc.getProspect('p1', { id: 'admin-1', role: 'admin' }, { include: 'profile' });
+    expect(calls.getConsumerJourney).not.toHaveBeenCalled();
+    expect(calls.getSignupProfile).toHaveBeenCalled();
+    expect(row._set.signupProfile).toEqual({ draw: null, entitlements: [], rewardDiagnostic: null });
+  });
+});

--- a/backend/test/prospectDrawStatus.test.js
+++ b/backend/test/prospectDrawStatus.test.js
@@ -1,0 +1,466 @@
+/**
+ * getProspectDrawStatus (luckyDrawService, DI seam — no DB): the Lead Profile
+ * page's per-prospect draw standing. Three lifecycle branches (open derives,
+ * frozen reads the persisted pool, sealed+ reads stored chances + the redraw
+ * ledger), deterministic draw selection over terminal history, the full boost
+ * predicate (manual-issuance exclusion, supersede, review gating), erasure
+ * honesty, bounded query counts, and the status-flip consistency retry.
+ * docs/plans/admin-lead-profile-page.md §4.
+ */
+import crypto from 'crypto';
+import { jest } from '@jest/globals';
+import { makeLuckyDrawService, entryEligibility } from '../src/services/luckyDrawService.js';
+import { sgtDayEndExclusiveMs } from '../src/utils/sgtTime.js';
+
+const sha = (s) => crypto.createHash('sha256').update(s).digest('hex');
+const silentLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+
+const NOW = new Date('2026-09-15T04:00:00Z');
+const CLOSES_AT = new Date(sgtDayEndExclusiveMs('2026-08-31'));
+const BOOST_CLOSES_AT = new Date(sgtDayEndExclusiveMs('2026-09-10'));
+
+// Sequelize Op conditions arrive as symbol-keyed objects — unwrap the first
+// symbol value ({ [Op.in]: [...] } → [...], { [Op.ne]: 'x' } → 'x').
+const symVal = (cond) => {
+  const syms = Object.getOwnPropertySymbols(cond || {});
+  return syms.length ? cond[syms[0]] : undefined;
+};
+const asList = (cond) => (Array.isArray(cond) ? cond : symVal(cond) ?? [cond]);
+
+function prospect(id, campaignId, phone, {
+  verified = true, terms = 'tv-1', createdAt = '2026-08-01T00:00:00Z', erased = false,
+} = {}) {
+  return {
+    id,
+    campaignId,
+    phone,
+    createdAt: new Date(createdAt),
+    sourceMetadata: {
+      ...(verified && phone
+        ? { phoneVerifiedAt: '2026-08-01T00:00:00Z', phoneVerifiedFor: sha(phone) }
+        : {}),
+      ...(erased ? { erased: true } : {}),
+    },
+    consentMetadata: terms ? { drawTerms: { termsVersionId: terms } } : {},
+  };
+}
+
+function drawRow(id, campaignId, status, extra = {}) {
+  return {
+    id, campaignId, status,
+    closesAt: CLOSES_AT, boostClosesAt: BOOST_CLOSES_AT,
+    multiplier: 10, activationId: 'act-1',
+    createdAt: new Date('2026-07-01T00:00:00Z'),
+    ...extra,
+  };
+}
+
+/**
+ * Where-clause-honest mocks: each findAll filters its fixtures the way the
+ * real query would, so the manual-issuance exclusion, the supersede logic and
+ * the cutoff all get exercised for real rather than pre-filtered by the test.
+ */
+function buildDeps({
+  draws = [], campaigns = [], termsVersions = [{ id: 'tv-1', campaignId: 'camp-1' }],
+  entries = [], attempts = [], entitlements = [], events = [], reviews = [],
+} = {}) {
+  const deps = {
+    Draw: {
+      findAll: jest.fn().mockImplementation(async ({ where }) => {
+        let rows = draws;
+        if (where?.campaignId) {
+          const ids = asList(where.campaignId).map(String);
+          rows = rows.filter((r) => ids.includes(String(r.campaignId)));
+        }
+        if (where?.id) {
+          const ids = asList(where.id).map(String);
+          rows = rows.filter((r) => ids.includes(String(r.id)));
+        }
+        return [...rows]
+          .sort((a, b) => (b.createdAt - a.createdAt) || String(b.id).localeCompare(String(a.id)))
+          .map((r) => ({ ...r }));
+      }),
+      findByPk: jest.fn(),
+      update: jest.fn(),
+    },
+    Campaign: {
+      findAll: jest.fn().mockImplementation(async ({ where }) => {
+        const ids = asList(where.id).map(String);
+        return campaigns.filter((c) => ids.includes(String(c.id))).map((c) => ({ ...c }));
+      }),
+      findByPk: jest.fn(),
+    },
+    DrawTermsVersion: {
+      findAll: jest.fn().mockImplementation(async ({ where }) => {
+        const ids = asList(where.campaignId).map(String);
+        return termsVersions.filter((v) => ids.includes(String(v.campaignId)));
+      }),
+    },
+    DrawEntry: {
+      findAll: jest.fn().mockImplementation(async ({ where }) => {
+        const drawIds = asList(where.drawId).map(String);
+        const prospectIds = asList(where.prospectId).map(String);
+        return entries
+          .filter((e) => drawIds.includes(String(e.drawId)) && prospectIds.includes(String(e.prospectId)))
+          .map((e) => ({ ...e }));
+      }),
+    },
+    DrawAttempt: {
+      findAll: jest.fn().mockImplementation(async ({ where }) => {
+        const drawIds = asList(where.drawId).map(String);
+        return attempts
+          .filter((a) => drawIds.includes(String(a.drawId)))
+          .sort((a, b) => a.attemptNo - b.attemptNo)
+          .map((a) => ({ ...a }));
+      }),
+    },
+    RewardEntitlement: {
+      findAll: jest.fn().mockImplementation(async ({ where }) => {
+        const prospectIds = asList(where.prospectId).map(String);
+        const excluded = symVal(where.issuedVia); // Op.ne 'manual'
+        return entitlements
+          .filter((e) => String(e.activationId) === String(where.activationId)
+            && prospectIds.includes(String(e.prospectId))
+            && (excluded === undefined || e.issuedVia !== excluded))
+          .map((e) => ({ ...e }));
+      }),
+    },
+    RedemptionEvent: {
+      findAll: jest.fn().mockImplementation(async ({ where }) => {
+        const entIds = asList(where.entitlementId).map(String);
+        const types = asList(where.type);
+        const cutoff = symVal(where.createdAt); // Op.lt
+        return events
+          .filter((e) => entIds.includes(String(e.entitlementId))
+            && types.includes(e.type)
+            && (!cutoff || e.createdAt < cutoff))
+          .sort((a, b) => a.createdAt - b.createdAt)
+          .map((e) => ({ ...e }));
+      }),
+    },
+    DrawBoostReview: {
+      findAll: jest.fn().mockImplementation(async ({ where }) => reviews
+        .filter((r) => String(r.drawId) === String(where.drawId))
+        .map((r) => ({ ...r }))),
+    },
+    Prospect: { findAll: jest.fn() },
+    Activation: { findByPk: jest.fn(), findOne: jest.fn() },
+    sequelize: { transaction: jest.fn().mockImplementation(async (cb) => cb({})) },
+    logger: silentLogger,
+    now: () => NOW,
+    mintSeed: () => 'a'.repeat(64),
+  };
+  return { deps, svc: makeLuckyDrawService(deps) };
+}
+
+const unlockEvent = (id, entitlementId, via, at = '2026-09-01T00:00:00Z') => ({
+  id, entitlementId, type: 'unlocked', metadata: { via }, createdAt: new Date(at),
+});
+
+// ── entryEligibility (pure, shared with freeze) ─────────────────────────────
+
+describe('entryEligibility', () => {
+  const versions = new Set(['tv-1']);
+  it('accepts a bound stamp + pinned terms', () => {
+    expect(entryEligibility(prospect('p1', 'c', '+6591234567'), versions))
+      .toEqual({ verified: true, hasTerms: true, eligible: true });
+  });
+  it('rejects a stamp bound to a DIFFERENT phone (staff edit)', () => {
+    const p = prospect('p1', 'c', '+6591234567');
+    p.phone = '+6598765432';
+    expect(entryEligibility(p, versions).verified).toBe(false);
+  });
+  it('rejects missing terms pinning and unknown versions', () => {
+    expect(entryEligibility(prospect('p1', 'c', '+6591234567', { terms: null }), versions).hasTerms).toBe(false);
+    expect(entryEligibility(prospect('p1', 'c', '+6591234567', { terms: 'tv-9' }), versions).hasTerms).toBe(false);
+  });
+});
+
+// ── open: provisional derivation ────────────────────────────────────────────
+
+describe('getProspectDrawStatus — open draws (provisional preview)', () => {
+  it('eligible signup previews 1 provisional chance', async () => {
+    const { svc } = buildDeps({ draws: [drawRow('d1', 'camp-1', 'open')] });
+    const map = await svc.getProspectDrawStatus([prospect('p1', 'camp-1', '+6591110001')]);
+    expect(map.get('p1')).toMatchObject({
+      state: 'provisional_in', chances: 1, provisional: true,
+      boosted: false, drawStatus: 'open', multiplier: 10,
+    });
+  });
+
+  it('names the blocking reason, in predicate order', async () => {
+    const { svc } = buildDeps({ draws: [drawRow('d1', 'camp-1', 'open')] });
+    const cases = [
+      [prospect('p1', 'camp-1', null), 'no_phone'],
+      [prospect('p2', 'camp-1', '+6591110002', { verified: false }), 'phone_unverified'],
+      [prospect('p3', 'camp-1', '+6591110003', { terms: null }), 'terms_not_pinned'],
+      [prospect('p4', 'camp-1', '+6591110004', { createdAt: '2026-09-05T00:00:00Z' }), 'signed_up_after_close'],
+    ];
+    const map = await svc.getProspectDrawStatus(cases.map(([p]) => p));
+    for (const [p, reason] of cases) {
+      expect(map.get(p.id)).toMatchObject({ state: 'provisional_out', chances: 0, notEligibleReason: reason });
+    }
+  });
+
+  it('agent_scan unlock previews the multiplier', async () => {
+    const { svc } = buildDeps({
+      draws: [drawRow('d1', 'camp-1', 'open')],
+      entitlements: [{ id: 'ent-1', activationId: 'act-1', prospectId: 'p1', issuedVia: 'hook' }],
+      events: [unlockEvent('ev-1', 'ent-1', 'agent_scan')],
+    });
+    const map = await svc.getProspectDrawStatus([prospect('p1', 'camp-1', '+6591110001')]);
+    expect(map.get('p1')).toMatchObject({
+      state: 'provisional_in', chances: 10, boosted: true, boostVia: 'agent_scan',
+    });
+    expect(map.get('p1').boostedAt).toEqual(new Date('2026-09-01T00:00:00Z'));
+  });
+
+  it('a superseded unlock earns nothing; a fresh re-scan boosts again', async () => {
+    const base = {
+      draws: [drawRow('d1', 'camp-1', 'open')],
+      entitlements: [{ id: 'ent-1', activationId: 'act-1', prospectId: 'p1', issuedVia: 'hook' }],
+    };
+    const reversed = {
+      id: 'ev-2', entitlementId: 'ent-1', type: 'unlock_reversed',
+      metadata: { supersedesEventId: 'ev-1' }, createdAt: new Date('2026-09-02T00:00:00Z'),
+    };
+    const p = prospect('p1', 'camp-1', '+6591110001');
+
+    const undone = buildDeps({ ...base, events: [unlockEvent('ev-1', 'ent-1', 'agent_scan'), reversed] });
+    expect((await undone.svc.getProspectDrawStatus([p])).get('p1'))
+      .toMatchObject({ chances: 1, boosted: false });
+
+    const rescanned = buildDeps({
+      ...base,
+      events: [
+        unlockEvent('ev-1', 'ent-1', 'agent_scan'), reversed,
+        unlockEvent('ev-3', 'ent-1', 'agent_scan', '2026-09-03T00:00:00Z'),
+      ],
+    });
+    expect((await rescanned.svc.getProspectDrawStatus([p])).get('p1'))
+      .toMatchObject({ chances: 10, boosted: true });
+  });
+
+  it('agent_button: approved boosts, undecided flags boostReviewPending, rejected does neither', async () => {
+    const base = {
+      draws: [drawRow('d1', 'camp-1', 'open')],
+      entitlements: [{ id: 'ent-1', activationId: 'act-1', prospectId: 'p1', issuedVia: 'hook' }],
+      events: [unlockEvent('ev-1', 'ent-1', 'agent_button')],
+    };
+    const p = prospect('p1', 'camp-1', '+6591110001');
+
+    const approved = buildDeps({ ...base, reviews: [{ drawId: 'd1', entitlementId: 'ent-1', decision: 'approved' }] });
+    expect((await approved.svc.getProspectDrawStatus([p])).get('p1'))
+      .toMatchObject({ chances: 10, boosted: true, boostVia: 'agent_button', boostReviewPending: false });
+
+    const undecided = buildDeps(base);
+    expect((await undecided.svc.getProspectDrawStatus([p])).get('p1'))
+      .toMatchObject({ chances: 1, boosted: false, boostReviewPending: true });
+
+    const rejected = buildDeps({ ...base, reviews: [{ drawId: 'd1', entitlementId: 'ent-1', decision: 'rejected' }] });
+    expect((await rejected.svc.getProspectDrawStatus([p])).get('p1'))
+      .toMatchObject({ chances: 1, boosted: false, boostReviewPending: false });
+  });
+
+  it('a manually-ISSUED entitlement never boosts, even with an approved review', async () => {
+    const { svc } = buildDeps({
+      draws: [drawRow('d1', 'camp-1', 'open')],
+      entitlements: [{ id: 'ent-1', activationId: 'act-1', prospectId: 'p1', issuedVia: 'manual' }],
+      events: [unlockEvent('ev-1', 'ent-1', 'manual')],
+      reviews: [{ drawId: 'd1', entitlementId: 'ent-1', decision: 'approved' }],
+    });
+    const map = await svc.getProspectDrawStatus([prospect('p1', 'camp-1', '+6591110001')]);
+    expect(map.get('p1')).toMatchObject({ chances: 1, boosted: false, boostReviewPending: false });
+  });
+
+  it('an unlock at/after the boost cutoff is out of window', async () => {
+    const { svc } = buildDeps({
+      draws: [drawRow('d1', 'camp-1', 'open')],
+      entitlements: [{ id: 'ent-1', activationId: 'act-1', prospectId: 'p1', issuedVia: 'hook' }],
+      events: [unlockEvent('ev-1', 'ent-1', 'agent_scan', BOOST_CLOSES_AT.toISOString())],
+    });
+    const map = await svc.getProspectDrawStatus([prospect('p1', 'camp-1', '+6591110001')]);
+    expect(map.get('p1')).toMatchObject({ chances: 1, boosted: false });
+  });
+});
+
+// ── frozen: the pool is written ─────────────────────────────────────────────
+
+describe('getProspectDrawStatus — frozen draws (persisted membership)', () => {
+  const frozen = drawRow('d1', 'camp-1', 'frozen');
+  const entry = { id: 'e1', drawId: 'd1', prospectId: 'p1', chances: 1, boostVia: null };
+
+  it('an entry row means frozen_in even if the prospect was edited AFTER freeze', async () => {
+    // Verification stripped post-freeze — the live prospect would fail the
+    // predicate, but membership is the snapshot, and the page must agree
+    // with the pool, not with today's row.
+    const { svc } = buildDeps({ draws: [frozen], entries: [entry] });
+    const editedAfterFreeze = prospect('p1', 'camp-1', '+6591110001', { verified: false, terms: null });
+    const map = await svc.getProspectDrawStatus([editedAfterFreeze]);
+    expect(map.get('p1')).toMatchObject({ state: 'frozen_in', chances: 1, provisional: true });
+  });
+
+  it('no entry row means excluded_at_freeze, never a re-derived verdict', async () => {
+    const { svc } = buildDeps({ draws: [frozen], entries: [] });
+    const map = await svc.getProspectDrawStatus([prospect('p1', 'camp-1', '+6591110001')]);
+    expect(map.get('p1')).toMatchObject({ state: 'excluded_at_freeze', chances: 0 });
+  });
+
+  it('boost evidence over the frozen pool stays provisional until seal', async () => {
+    const { svc } = buildDeps({
+      draws: [frozen],
+      entries: [entry],
+      entitlements: [{ id: 'ent-1', activationId: 'act-1', prospectId: 'p1', issuedVia: 'hook' }],
+      events: [unlockEvent('ev-1', 'ent-1', 'agent_scan')],
+    });
+    const map = await svc.getProspectDrawStatus([prospect('p1', 'camp-1', '+6591110001')]);
+    expect(map.get('p1')).toMatchObject({
+      state: 'frozen_in', chances: 1, boosted: true, boostVia: 'agent_scan', provisional: true,
+    });
+  });
+});
+
+// ── sealed+: stored truth + the redraw ledger ───────────────────────────────
+
+describe('getProspectDrawStatus — sealed and drawn (redraw ledger)', () => {
+  const entries = [
+    { id: 'e1', drawId: 'd1', prospectId: 'p1', chances: 10, boostVia: 'agent_scan' },
+    { id: 'e2', drawId: 'd1', prospectId: 'p2', chances: 1, boostVia: null },
+    { id: 'e3', drawId: 'd1', prospectId: 'p3', chances: 1, boostVia: null },
+  ];
+  const people = [
+    prospect('p1', 'camp-1', '+6591110001'),
+    prospect('p2', 'camp-1', '+6591110002'),
+    prospect('p3', 'camp-1', '+6591110003'),
+  ];
+
+  it('sealed with no attempts reads the frozen chances', async () => {
+    const { svc } = buildDeps({ draws: [drawRow('d1', 'camp-1', 'sealed')], entries });
+    const map = await svc.getProspectDrawStatus(people);
+    expect(map.get('p1')).toMatchObject({
+      state: 'sealed', chances: 10, boosted: true, boostVia: 'agent_scan', provisional: false, outcome: null,
+    });
+    expect(map.get('p2')).toMatchObject({ chances: 1, outcome: null });
+  });
+
+  it('a declined pick is selected_declined; the next pick pending; the rest not_selected_yet', async () => {
+    const { svc } = buildDeps({
+      draws: [drawRow('d1', 'camp-1', 'drawn')],
+      entries,
+      attempts: [
+        { id: 'a1', drawId: 'd1', attemptNo: 1, pickedEntryId: 'e1', outcome: 'declined', claimDeadline: new Date('2026-09-20T00:00:00Z') },
+        { id: 'a2', drawId: 'd1', attemptNo: 2, pickedEntryId: 'e2', outcome: 'pending', claimDeadline: new Date('2026-09-29T00:00:00Z') },
+      ],
+    });
+    const map = await svc.getProspectDrawStatus(people);
+    expect(map.get('p1').outcome).toMatchObject({ status: 'selected_declined', attemptNo: 1 });
+    expect(map.get('p2').outcome).toMatchObject({ status: 'selected_pending', attemptNo: 2 });
+    expect(map.get('p3').outcome).toMatchObject({ status: 'not_selected_yet' });
+  });
+
+  it('a claimed attempt finalizes: winner selected_claimed, the rest not_selected_final', async () => {
+    const { svc } = buildDeps({
+      draws: [drawRow('d1', 'camp-1', 'claimed')],
+      entries,
+      attempts: [
+        { id: 'a1', drawId: 'd1', attemptNo: 1, pickedEntryId: 'e1', outcome: 'declined' },
+        { id: 'a2', drawId: 'd1', attemptNo: 2, pickedEntryId: 'e2', outcome: 'claimed', claimedAt: new Date('2026-09-25T00:00:00Z') },
+      ],
+    });
+    const map = await svc.getProspectDrawStatus(people);
+    expect(map.get('p2').outcome).toMatchObject({ status: 'selected_claimed' });
+    expect(map.get('p2').outcome.claimedAt).toEqual(new Date('2026-09-25T00:00:00Z'));
+    expect(map.get('p1').outcome).toMatchObject({ status: 'selected_declined' });
+    expect(map.get('p3').outcome).toMatchObject({ status: 'not_selected_final' });
+  });
+});
+
+// ── selection, drift, erasure, void ─────────────────────────────────────────
+
+describe('getProspectDrawStatus — draw selection and honesty states', () => {
+  it('a live draw wins over terminal history; history is summarized', async () => {
+    const { svc } = buildDeps({
+      draws: [
+        drawRow('d-old', 'camp-1', 'claimed', { createdAt: new Date('2026-05-01T00:00:00Z') }),
+        drawRow('d-new', 'camp-1', 'open', { createdAt: new Date('2026-07-01T00:00:00Z') }),
+      ],
+    });
+    const map = await svc.getProspectDrawStatus([prospect('p1', 'camp-1', '+6591110001')]);
+    const block = map.get('p1');
+    expect(block.drawId).toBe('d-new');
+    expect(block.drawHistory).toEqual([
+      expect.objectContaining({ drawId: 'd-old', drawStatus: 'claimed' }),
+    ]);
+  });
+
+  it('void draws say void; erased people get erased_draw_unavailable', async () => {
+    const { svc } = buildDeps({
+      draws: [drawRow('d1', 'camp-1', 'void'), drawRow('d2', 'camp-2', 'frozen')],
+    });
+    const map = await svc.getProspectDrawStatus([
+      prospect('p1', 'camp-1', '+6591110001'),
+      prospect('p2', 'camp-2', '+6591110002', { erased: true }),
+    ]);
+    expect(map.get('p1').state).toBe('void');
+    expect(map.get('p2').state).toBe('erased_draw_unavailable');
+  });
+
+  it('config-enabled without a draw record is no_draw_record; disabled is null', async () => {
+    const { svc } = buildDeps({
+      draws: [],
+      campaigns: [
+        { id: 'camp-1', design_config: { luckyDraw: { enabled: true } } },
+        { id: 'camp-2', design_config: {} },
+      ],
+    });
+    const map = await svc.getProspectDrawStatus([
+      prospect('p1', 'camp-1', '+6591110001'),
+      prospect('p2', 'camp-2', '+6591110002'),
+    ]);
+    expect(map.get('p1')).toEqual({ state: 'no_draw_record' });
+    expect(map.get('p2')).toBeNull();
+  });
+
+  it('stays query-bounded across campaigns (per-draw, never per-signup)', async () => {
+    const { svc, deps } = buildDeps({
+      draws: [drawRow('d1', 'camp-1', 'open'), drawRow('d2', 'camp-2', 'frozen', { activationId: 'act-2' })],
+      entries: [{ id: 'e1', drawId: 'd2', prospectId: 'p3', chances: 1, boostVia: null }],
+    });
+    await svc.getProspectDrawStatus([
+      prospect('p1', 'camp-1', '+6591110001'),
+      prospect('p2', 'camp-1', '+6591110002'),
+      prospect('p3', 'camp-2', '+6591110003'),
+      prospect('p4', 'camp-2', '+6591110004'),
+    ]);
+    expect(deps.Draw.findAll.mock.calls.length).toBeLessThanOrEqual(2); // campaign query + consistency re-read
+    expect(deps.DrawEntry.findAll.mock.calls.length).toBeLessThanOrEqual(1);
+    expect(deps.DrawAttempt.findAll.mock.calls.length).toBeLessThanOrEqual(1);
+    // Boost evidence: ≤3 queries per DISTINCT open/frozen draw.
+    expect(deps.RewardEntitlement.findAll.mock.calls.length).toBeLessThanOrEqual(2);
+    expect(deps.RedemptionEvent.findAll.mock.calls.length).toBeLessThanOrEqual(2);
+    expect(deps.DrawBoostReview.findAll.mock.calls.length).toBeLessThanOrEqual(2);
+  });
+
+  it('re-collects once when a freeze lands mid-read (status flip)', async () => {
+    const openFirst = drawRow('d1', 'camp-1', 'open');
+    const frozenNow = drawRow('d1', 'camp-1', 'frozen');
+    const entries = [{ id: 'e1', drawId: 'd1', prospectId: 'p1', chances: 1, boostVia: null }];
+    const { deps } = (() => {
+      const built = buildDeps({ draws: [openFirst], entries });
+      let campaignCalls = 0;
+      built.deps.Draw.findAll = jest.fn().mockImplementation(async ({ where }) => {
+        if (where?.campaignId) {
+          campaignCalls += 1;
+          return campaignCalls === 1 ? [{ ...openFirst }] : [{ ...frozenNow }];
+        }
+        return [{ id: 'd1', status: 'frozen' }]; // the consistency re-read sees the flip
+      });
+      return built;
+    })();
+    const svc = makeLuckyDrawService(deps);
+    const map = await svc.getProspectDrawStatus([prospect('p1', 'camp-1', '+6591110001')]);
+    // Second collection ran and landed on the FROZEN branch (entry-backed).
+    expect(map.get('p1')).toMatchObject({ state: 'frozen_in', drawStatus: 'frozen' });
+    expect(deps.Draw.findAll.mock.calls.length).toBe(3); // collect + verify + re-collect
+  });
+});


### PR DESCRIPTION
PR 1 of 2 for the **Admin Lead Profile page** (`docs/plans/admin-lead-profile-page.md`, Codex-reviewed v2 — 22 findings dispositioned in §8). This is the backend contract; PR 2 builds `/admin/leads/:prospectId` on top and deletes the drawer.

## What this adds

`GET /api/prospects/:id?include=profile` — **admin-only, opt-in**. Without the param (or for any non-admin, whatever they send) the payload is **byte-identical to today**; contract covered by tests.

**Per-signup draw standing** (`consumer.signups[].draw`) via new `luckyDrawService.getProspectDrawStatus`:
- Three lifecycle branches, because freeze WRITES the pool: `open` derives a *provisional* preview through the same `entryEligibility` predicate freeze applies (extracted from `freezeDraw` — single source, no drift); `frozen` reads ONLY the persisted `DrawEntry` rows (a post-freeze edit can't make the page disagree with the pool); `sealed+` reads stored chances plus the `DrawAttempt` redraw ledger — "Winner" is only ever the claimed attempt (`selected_pending/declined/…`, `not_selected_yet` vs `not_selected_final`).
- Full boost predicate reused, not re-implemented: `issuedVia != 'manual'`, `unlock_reversed` supersede, `boostClosesAt || closesAt` cutoff, `agent_scan` auto vs `agent_button` behind approved review (`boostReviewPending` exposed).
- Deterministic draw selection (live draw first, else newest terminal; older terminal draws as `drawHistory[]`), `void` said plainly, erased people get `erased_draw_unavailable` (their entries are unjoinable by design), `no_draw_record` for config-enabled campaigns without a draw row.
- Bounded queries (per DISTINCT draw, never per signup) + one consistency retry on a mid-read status flip. Both tested.

**Reward truth** (`leadProfileService`):
- Entitlements gain `state` (shared `presentState`), `unlockedVia`, `tokenHint`, `drawLinked` (draw-rail entitlements speak the boost voice, not the voucher voice), and per-channel delivery receipts via one `DISTINCT ON` query.
- `rewardDiagnostic` — read-time "why no reward" mirroring `issueForProspect`'s gates in order. Deliberately NOT the `ActivationIssuanceSkip` ledger (unanchored by design + 30-day purge — attributing it per-lead can name the wrong person).
- Per-signup **campaign-scoped consent** via `getConsentState(consumerId, {campaignId})` + person `suppressions[]` + bounded broadcast history (recent 20 + full tallies).

**Prospect-level extras**: allowlisted session context (landing page, full UTM, funnel steps — public beacon input never reflected raw; aggregates duplicate session rows), Lyfe delivery status (latest per event type, **filtered to the `destination='lyfe'` subscriber**; a System-Agent lead writes no row and that absence is the signal; reasons from `responseCode` only), named `externalAgent` (`id`/`fullName`/`agency` — never phone/email/balance), and a B4 `signupProfile` fallback so consumer-less leads (Retell, unverified) still show their own campaign story.

**Migration 089** (prerequisites, additive): partial expression index on `webhook_deliveries` payload lead-id for `lead.created|lead.assigned`, and `email_broadcast_recipients (consumerId, createdAt DESC)`.

## Tests

- 63 new DI-seam tests (`test/prospectDrawStatus.test.js`, `test/leadProfileService.test.js`): every lifecycle branch, manual-issuance exclusion, supersede/re-scan, review gating, redraw ledger finality, erased/void/no-record states, query-count bound, status-flip retry, diagnostic gate order, session allowlist (secrets never serialized), Lyfe reason mapping, and the four include-gating contracts.
- Regression: `luckyDrawService` (freeze refactor), `prospects`, `prospectServiceDrawGate`, `entitlementUnlockVia`, `externalEntitlementsAgentSurface` — **170 tests green** against local Postgres. ESLint clean (0 errors; 7 pre-existing warnings untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8jF5ZxuAZD3NazPQQMEfV