### PR TITLE
feat(admin): Lead Profile page — /admin/leads/:id replaces the drawer

### DIFF
--- a/src/api/adminV2.js
+++ b/src/api/adminV2.js
@@ -56,6 +56,16 @@ export async function fetchProspectDetail(id) {
   return resp?.data?.prospect ?? null;
 }
 
+/**
+ * Lead Profile page (/admin/leads/:id): the full admin enrichment —
+ * per-signup draw standing, scoped consent + reward diagnostics, delivery
+ * receipts, broadcasts, session, Lyfe delivery (?include=profile, PR #269).
+ */
+export async function fetchProspectProfile(id) {
+  const resp = await apiClient.get(`/prospects/${encodeURIComponent(id)}?include=profile`);
+  return resp?.data?.prospect ?? null;
+}
+
 /** Campaign leaderboard source — extended admin list (B6). */
 export async function fetchCampaignsList(period) {
   const resp = await apiClient.get(`/campaigns?period=${encodeURIComponent(period)}&limit=100`);

--- a/src/components/adminv2/GlobalSearch.jsx
+++ b/src/components/adminv2/GlobalSearch.jsx
@@ -95,7 +95,7 @@ export default function GlobalSearch() {
             id: `av2-opt-lead-${p.id}`,
             title: name,
             sub: [p.phone, p.campaign?.name].filter(Boolean).join(' · ') || p.email || '',
-            to: `/AdminProspects?q=${encodeURIComponent(p.phone || p.email || name)}&lead=${encodeURIComponent(p.id)}`,
+            to: `/admin/leads/${encodeURIComponent(p.id)}`,
           };
         }),
       });

--- a/src/components/adminv2/__tests__/GlobalSearch.test.jsx
+++ b/src/components/adminv2/__tests__/GlobalSearch.test.jsx
@@ -68,13 +68,13 @@ describe('GlobalSearch', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
-  it('typing surfaces lead results and Enter deep-links with the drawer param', async () => {
+  it('typing surfaces lead results and Enter opens the lead profile page', async () => {
     setup();
     const input = openPalette();
     fireEvent.change(input, { target: { value: 'sam' } });
     await screen.findByText('Sam Tan');
     fireEvent.keyDown(input, { key: 'Enter' });
-    expect(screen.getByTestId('loc')).toHaveTextContent('/AdminProspects?q=%2B6589279750&lead=p1');
+    expect(screen.getByTestId('loc')).toHaveTextContent('/admin/leads/p1');
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 

--- a/src/hooks/queries/useAdminV2.js
+++ b/src/hooks/queries/useAdminV2.js
@@ -5,17 +5,27 @@
 import { useQuery } from '@tanstack/react-query';
 import {
   fetchOverview, fetchAttention, fetchSeries, fetchFunnel,
-  fetchProspects, fetchProspectDetail, fetchCampaignsList, fetchAgentOptions,
+  fetchProspects, fetchProspectDetail, fetchProspectProfile, fetchCampaignsList, fetchAgentOptions,
   fetchAgentsRoster, fetchCampaignSummary, fetchWallets, fetchWalletLedger, fetchAgentGroups,
 } from '@/api/adminV2';
 
 const STALE_MS = 30_000;
 
-/** Full prospect detail for the drawer — includes the consumer-spine journey. */
+/** Full prospect detail — includes the consumer-spine journey. */
 export function useProspectDetail(id) {
   return useQuery({
     queryKey: ['adminV2', 'prospectDetail', id],
     queryFn: () => fetchProspectDetail(id),
+    staleTime: STALE_MS,
+    enabled: !!id,
+  });
+}
+
+/** Lead Profile page — detail + the ?include=profile enrichments. */
+export function useProspectProfile(id) {
+  return useQuery({
+    queryKey: ['adminV2', 'prospectProfile', id],
+    queryFn: () => fetchProspectProfile(id),
     staleTime: STALE_MS,
     enabled: !!id,
   });

--- a/src/pages/adminv2/AdminV2CampaignDetail.jsx
+++ b/src/pages/adminv2/AdminV2CampaignDetail.jsx
@@ -127,13 +127,13 @@ export default function AdminV2CampaignDetail() {
             <EmptyState title="No leads yet" hint="Submissions land here as they arrive." />
           ) : (
             recent.map((p) => (
-              <div key={p.id} className="av2-qrow" style={{ cursor: 'default' }}>
+              <Link key={p.id} to={`/admin/leads/${p.id}`} className="av2-qrow" style={{ textDecoration: 'none', color: 'inherit' }}>
                 <span style={{ flex: 1, fontSize: 13, fontWeight: 700 }}>{p.firstName} {p.lastName}</span>
                 {p.quarantinedAt
                   ? <Chip tone="hold" glyph="◆">{heldLabel(p).short}</Chip>
                   : <Chip tone={STATUS_CHIP_CLASS[p.leadStatus]?.replace('av2-chip--', '') || ''}>{STATUS_LABELS[p.leadStatus] || p.leadStatus}</Chip>}
                 <span className="av2-mono" style={{ fontSize: 10.5, color: 'var(--ink-3)', width: 70, textAlign: 'right' }} title={fmtDateTime(p.createdAt)}>{fmtRelative(p.createdAt)}</span>
-              </div>
+              </Link>
             ))
           )}
         </Card>

--- a/src/pages/adminv2/AdminV2Dashboard.jsx
+++ b/src/pages/adminv2/AdminV2Dashboard.jsx
@@ -239,9 +239,8 @@ function RecentLeads() {
             const held = !!p.quarantinedAt;
             const utm = p.sourceMetadata?.utm?.utm_source;
             const agent = p.assignedAgent ? `${p.assignedAgent.firstName || ''} ${p.assignedAgent.lastName || ''}`.trim() : '';
-            const search = p.phone || `${p.firstName || ''} ${p.lastName || ''}`.trim();
             return (
-              <Link key={p.id} to={`/AdminProspects?q=${encodeURIComponent(search)}`} className="av2-qrow" style={{ padding: '7px 16px', minHeight: 47 }}>
+              <Link key={p.id} to={`/admin/leads/${p.id}`} className="av2-qrow" style={{ padding: '7px 16px', minHeight: 47 }}>
                 <span className="av2-mono" style={{ width: 38, flex: 'none', fontSize: 11, color: 'var(--ink-3)' }}>{fmtAgoShort(p.createdAt)}</span>
                 <span style={{ flex: 1.2, minWidth: 0 }}>
                   <span style={{ display: 'block', fontSize: 13, fontWeight: 700, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{p.firstName} {p.lastName}</span>

--- a/src/pages/adminv2/AdminV2LeadProfile.jsx
+++ b/src/pages/adminv2/AdminV2LeadProfile.jsx
@@ -1,0 +1,724 @@
+/**
+ * Lead Profile — the full-page lead story (/admin/leads/:prospectId), replacing
+ * the Prospects drawer (docs/plans/admin-lead-profile-page.md §3).
+ *
+ * Person-first, prospect-anchored: the URL names one signup; the campaigns
+ * rail tells the whole person's story (name used per signup, draw standing OR
+ * reward state per campaign), and clicking another signup RE-ANCHORS by
+ * navigating to that prospect's URL (back/forward and sharing come free).
+ * Data: GET /prospects/:id?include=profile (PR #269) — one endpoint, admin-only
+ * enrichments; the classic payload fields render instantly for everyone else.
+ */
+import { useMemo, useState } from 'react';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { useProspectProfile, useAgentOptions } from '@/hooks/queries/useAdminV2';
+import { bulkAssign, bulkReturnToHeld, bulkDelete } from '@/api/adminV2';
+import {
+  STATUS_LABELS, STATUS_CHIP_CLASS, SOURCE_LABELS, heldLabel, UTM_LABELS,
+} from '@/lib/adminV2/constants';
+import { fmtDateTime, fmtRelative, fmtSGDExact } from '@/lib/adminV2/format';
+import { Card, Chip, PageHeader, Skeleton, ErrorState, EmptyState } from '@/components/adminv2/primitives';
+import {
+  DropdownMenu, DropdownMenuTrigger, DropdownMenuContent,
+  DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator,
+} from '@/components/ui/dropdown-menu';
+import {
+  AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction,
+} from '@/components/ui/alert-dialog';
+
+// ── voice helpers ───────────────────────────────────────────────────────────
+
+const fullName = (o) => `${o?.firstName || ''} ${o?.lastName || ''}`.trim();
+const sameName = (a, b) => fullName(a).toLowerCase() === fullName(b).toLowerCase();
+
+const NOT_ELIGIBLE_COPY = {
+  no_phone: 'no phone on record',
+  phone_unverified: 'phone unverified',
+  terms_not_pinned: 'draw terms not accepted',
+  signed_up_after_close: 'signed up after entries closed',
+};
+
+const BOOST_VIA_COPY = { agent_scan: 'consultant scan', agent_button: 'consultant confirmation' };
+
+/** One line of draw truth per lifecycle state — provisional voice before seal. */
+function drawLine(draw) {
+  if (!draw) return null;
+  const d = fmtDateTime;
+  switch (draw.state) {
+    case 'no_draw_record':
+      return { tone: 'warn', text: 'Draw configured — no draw record yet' };
+    case 'erased_draw_unavailable':
+      return { tone: '', text: 'Draw record unavailable (erased)' };
+    case 'void':
+      return { tone: '', text: 'Draw void' };
+    case 'provisional_out':
+      return {
+        tone: 'warn',
+        text: `Not counted yet — ${NOT_ELIGIBLE_COPY[draw.notEligibleReason] || draw.notEligibleReason || 'not eligible'}`,
+      };
+    case 'provisional_in': {
+      const close = draw.closesAt ? ` · closes ${d(draw.closesAt)}` : '';
+      if (draw.boosted) {
+        return { tone: 'ok', text: `On track for ×${draw.multiplier} — ${BOOST_VIA_COPY[draw.boostVia] || 'boost'} recorded${close}` };
+      }
+      const pending = draw.boostReviewPending ? ' · boost pending ops review' : '';
+      const boostBy = draw.boostClosesAt || draw.closesAt;
+      return { tone: '', text: `1 chance so far · boost window open${boostBy ? ` until ${d(boostBy)}` : ''}${pending}` };
+    }
+    case 'frozen_in': {
+      const pending = draw.boostReviewPending ? ' · boost pending ops review' : '';
+      return draw.boosted
+        ? { tone: 'ok', text: `In the pool — 1 chance · ×${draw.multiplier} boost applies at seal` }
+        : { tone: '', text: `In the pool — 1 chance${pending}` };
+    }
+    case 'excluded_at_freeze':
+      return { tone: 'warn', text: 'Excluded at freeze' };
+    case 'sealed': {
+      const n = draw.chances;
+      const base = `${n} chance${n === 1 ? '' : 's'}`;
+      const o = draw.outcome;
+      if (!o) return { tone: '', text: `${base} · sealed` };
+      switch (o.status) {
+        case 'selected_pending':
+          return { tone: 'accent', text: `Selected — claim by ${d(o.claimDeadline)}` };
+        case 'selected_claimed':
+          return { tone: 'ok', text: `🏆 Winner — claimed ${d(o.claimedAt)}` };
+        case 'selected_declined':
+        case 'selected_unreachable':
+        case 'selected_ineligible':
+        case 'selected_unclaimed':
+          return { tone: 'warn', text: `Selected — ${o.status.replace('selected_', '')}, redrawn` };
+        case 'not_selected_final':
+          return { tone: '', text: `Not selected (${base})` };
+        case 'not_selected_yet':
+        default:
+          return { tone: '', text: `${base} · draw in progress` };
+      }
+    }
+    default:
+      return null;
+  }
+}
+
+const REWARD_STATE_COPY = {
+  reserved: { tone: 'accent', label: 'Reserved' },
+  unlocked: { tone: 'ok', label: 'Unlocked' },
+  redeemed: { tone: 'ok', label: 'Redeemed ✓' },
+  expired: { tone: '', label: 'Expired' },
+  cancelled: { tone: '', label: 'Cancelled' },
+  blocked: { tone: 'bad', label: 'Blocked' },
+};
+
+const DIAGNOSTIC_COPY = {
+  no_active_activation: 'No reward attached to this campaign',
+  allocation_exhausted: 'No reward — quota full',
+  phone_not_verified: 'No reward — phone unverified',
+  no_phone: 'No reward — no phone on record',
+  duplicate_phone: 'No reward — this phone already holds one',
+  offer_not_active: 'No reward — offer paused',
+  activation_ended: 'No reward — activation ended',
+  quarantined: 'No reward — lead is held',
+  not_issued_yet: 'Reward pending — issuance sweep hasn’t landed',
+};
+
+/** One line of reward truth per entitlement (non-draw voice). */
+function rewardLine(ent) {
+  const s = REWARD_STATE_COPY[ent.state] || { tone: '', label: ent.state || ent.status };
+  const bits = [ent.rewardTitle].filter(Boolean);
+  if (ent.state === 'redeemed' && ent.redeemedAt) bits.push(`redeemed ${fmtDateTime(ent.redeemedAt)}`);
+  else if (ent.state === 'unlocked' && ent.expiresAt) bits.push(`voucher live until ${fmtDateTime(ent.expiresAt)}`);
+  else if (ent.state === 'reserved' && ent.expiresAt) bits.push(`expires ${fmtDateTime(ent.expiresAt)}`);
+  return { tone: s.tone, label: s.label, detail: bits.join(' · ') };
+}
+
+function receiptLine(delivery) {
+  if (!delivery) return null;
+  const part = (r, name) => (r ? `${name} ${r.ok ? '✓' : 'failed ✗'}` : null);
+  const bits = [part(delivery.email, 'emailed'), part(delivery.whatsapp, 'WhatsApp')].filter(Boolean);
+  return bits.length ? `pass ${bits.join(' · ')}` : null;
+}
+
+// ── history composition (client-side; the endpoint already has the facts) ────
+
+function buildHistory(p, journey) {
+  const events = [];
+  const push = (at, label, { scope = 'signup', campaign = null, prospectId = null } = {}) => {
+    const t = at ? Date.parse(at) : NaN;
+    if (!Number.isNaN(t)) events.push({ at: t, label, scope, campaign, prospectId });
+  };
+
+  // Lifecycle + engagement — the merged timeline when the EF answered, else
+  // the prospect's own activities (plan §3.6: env-gated fallback).
+  const rows = Array.isArray(p.timeline)
+    ? p.timeline.map((x) => ({
+      at: x.row?.createdAt || x.row?.created_at,
+      label: x.entry?.label || x.row?.description || x.row?.type || 'activity',
+    }))
+    : (p.activities || []).map((a) => ({ at: a.createdAt, label: a.description || a.type }));
+  for (const r of rows) push(r.at, r.label, { prospectId: p.id });
+
+  for (const s of journey?.signups || []) {
+    push(s.createdAt, `Signed up as ${fullName(s) || '—'}`, {
+      scope: 'person', campaign: s.campaign?.name, prospectId: s.prospectId,
+    });
+    if (s.draw?.boostedAt) {
+      push(s.draw.boostedAt, `Draw boost recorded — ${BOOST_VIA_COPY[s.draw.boostVia] || 'boost'}`, {
+        scope: 'person', campaign: s.campaign?.name, prospectId: s.prospectId,
+      });
+    }
+  }
+  for (const e of journey?.entitlements || []) {
+    const title = e.rewardTitle || 'reward';
+    push(e.createdAt, e.drawLinked ? 'Draw pass reserved' : `Reward reserved — ${title}`, { scope: 'person', campaign: e.campaignName });
+    if (e.unlockedAt) push(e.unlockedAt, e.drawLinked ? 'Draw boost confirmed' : `Voucher unlocked — ${title}`, { scope: 'person', campaign: e.campaignName });
+    if (e.redeemedAt) push(e.redeemedAt, `Redeemed — ${title}`, { scope: 'person', campaign: e.campaignName });
+    for (const ch of ['email', 'whatsapp']) {
+      const r = e.delivery?.[ch];
+      if (r?.at) push(r.at, `${r.kind || 'pass'} ${ch} ${r.ok ? 'sent ✓' : 'send failed ✗'}`, { scope: 'person', campaign: e.campaignName });
+    }
+  }
+  for (const b of journey?.broadcasts?.recent || []) {
+    push(b.sentAt || b.at, `Marketing email — ${b.status}${b.reason ? ` (${b.reason.replace(/_/g, ' ')})` : ''}`, { scope: 'person' });
+  }
+  for (const ld of p.lyfeDelivery || []) {
+    push(ld.at, `Lyfe ${ld.eventType.replace('lead.', '')} — ${ld.status}${ld.reason ? ` (${ld.reason.replace(/_/g, ' ')})` : ''}`, { prospectId: p.id });
+  }
+  if (p.session?.startedAt) {
+    push(p.session.startedAt, `Arrived — ${p.session.landingPath || 'landing page'}`, { prospectId: p.id });
+  }
+  const attempts = Object.values(p.screeningMetadata?.attempts || {}).filter((a) => a?.startedAt);
+  for (const a of attempts) push(a.startedAt, `AI screening call — ${(a.outcome || 'attempted').replace(/_/g, ' ')}`, { prospectId: p.id });
+
+  return events.sort((a, b) => b.at - a.at);
+}
+
+// ── small pieces ────────────────────────────────────────────────────────────
+
+function Kv({ k, children }) {
+  return <div className="av2-kv"><span>{k}</span><span>{children ?? '—'}</span></div>;
+}
+
+function SectionCaps({ children }) {
+  return <div className="av2-microcaps" style={{ marginBottom: 6 }}>{children}</div>;
+}
+
+function consentRow(state) {
+  if (!state) return '—';
+  return `${state.granted ? 'yes' : 'no'}${state.version ? ` · ${String(state.version).slice(0, 28)}` : ''}${state.scope === 'global' ? ' · global' : ''}`;
+}
+
+// ── the page ────────────────────────────────────────────────────────────────
+
+export default function AdminV2LeadProfile() {
+  const { prospectId } = useParams();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [historyScope, setHistoryScope] = useState('all');
+
+  // Back target: the list URL the operator came from (state.from contract,
+  // plan §3.8) — validated same-app path; reloads/direct links fall back.
+  const from = typeof location.state?.from === 'string' && location.state.from.startsWith('/AdminProspects')
+    ? location.state.from
+    : '/AdminProspects';
+  const reAnchor = (id) => navigate(`/admin/leads/${id}`, { state: { from } });
+
+  const profile = useProspectProfile(prospectId);
+  const p = profile.data;
+  const journey = p?.consumer || null;
+  const person = journey?.consumer || null;
+  const erased = Boolean(person?.erasedAt);
+
+  const agentOptions = useAgentOptions(true);
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ['adminV2', 'prospects'] });
+    queryClient.invalidateQueries({ queryKey: ['adminV2', 'prospectProfile'] });
+    queryClient.invalidateQueries({ queryKey: ['adminV2', 'prospectDetail'] });
+  };
+  const assignMutation = useMutation({
+    mutationFn: ({ agentId }) => bulkAssign([prospectId], agentId),
+    onSuccess: (r, { agentName }) => {
+      const n = r?.data?.affectedCount ?? 0;
+      if (n > 0) toast.success(`Assigned to ${agentName}`);
+      else toast.warning('Not assigned — lead not eligible');
+      invalidate();
+    },
+    onError: (e) => toast.error(e?.message || 'Assign failed'),
+  });
+  const returnMutation = useMutation({
+    mutationFn: () => bulkReturnToHeld([prospectId]),
+    onSuccess: (r) => {
+      const n = r?.data?.returned ?? 0;
+      if (n > 0) toast.success('Returned to held');
+      else toast.warning('Not returned — already held or not eligible');
+      invalidate();
+    },
+    onError: (e) => toast.error(e?.message || 'Return failed'),
+  });
+  const deleteMutation = useMutation({
+    mutationFn: () => bulkDelete([prospectId]),
+    onSuccess: (r) => {
+      const n = r?.data?.deleted ?? 0;
+      setConfirmDelete(false);
+      invalidate();
+      if (n > 0) { toast.success('Lead deleted'); navigate(from); }
+      else toast.warning('Nothing deleted');
+    },
+    onError: (e) => { toast.error(e?.message || 'Delete failed'); setConfirmDelete(false); },
+  });
+
+  // Entitlements grouped by campaign for the rail's reward slot; draw-linked
+  // rows speak in the DRAW slot (boost evidence), never as vouchers.
+  const rewardsByCampaign = useMemo(() => {
+    const map = new Map();
+    for (const e of journey?.entitlements || []) {
+      if (e.drawLinked || !e.campaignId) continue;
+      const k = String(e.campaignId);
+      if (!map.has(k)) map.set(k, []);
+      map.get(k).push(e);
+    }
+    return map;
+  }, [journey]);
+
+  const history = useMemo(() => (p ? buildHistory(p, journey) : []), [p, journey]);
+  const filteredHistory = useMemo(() => history.filter((e) => {
+    if (historyScope === 'all') return true;
+    if (historyScope === 'signup') return String(e.prospectId || '') === String(prospectId);
+    return e.scope === 'person';
+  }), [history, historyScope, prospectId]);
+
+  if (profile.isLoading) {
+    return (
+      <div>
+        <Skeleton height={30} width={340} />
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 16, marginTop: 20 }}>
+          {[7, 5, 12].map((span, i) => <div key={i} style={{ gridColumn: `span ${span}` }}><Skeleton height={i === 2 ? 120 : 260} /></div>)}
+        </div>
+      </div>
+    );
+  }
+  if (profile.isError || !p) {
+    return (
+      <div>
+        <PageHeader title="Lead">
+          <Link to={from} className="av2-btn av2-btn--sm" style={{ textDecoration: 'none' }}>← Prospects</Link>
+        </PageHeader>
+        <ErrorState error={profile.error || new Error('This lead may have been deleted.')} onRetry={profile.refetch} />
+      </div>
+    );
+  }
+
+  const held = !!p.quarantinedAt;
+  const canonicalName = fullName(person) || fullName(p) || 'Lead';
+  const utm = p.sourceMetadata?.utm || {};
+  const sm = p.screeningMetadata || {};
+  const screeningAttempts = Object.values(sm.attempts || {})
+    .filter((a) => a && a.startedAt)
+    .sort((a, b) => String(a.startedAt).localeCompare(String(b.startedAt)));
+  const screeningCostCents = screeningAttempts.reduce((s, a) => s + (Number(a.costCents) || 0), 0);
+  const hasScreening = p.screeningVerdict || p.screeningMetadata || String(p.quarantineReason || '').startsWith('screening_');
+  const verdictDetail = sm.verdictDetail || {};
+  const quiz = p.sourceMetadata?.quiz || null;
+  const isVoiceLead = p.leadSource === 'call_bot';
+
+  // Rail rows: the journey's signups, else this prospect alone (B4 fallback).
+  const railSignups = journey?.signups?.length
+    ? journey.signups
+    : [{
+      prospectId: p.id,
+      firstName: p.firstName,
+      lastName: p.lastName,
+      campaign: p.campaign ? { id: p.campaign.id, name: p.campaign.name, status: p.campaign.status } : null,
+      leadStatus: p.leadStatus,
+      leadSource: p.leadSource,
+      createdAt: p.createdAt,
+      held,
+      verified: false,
+      draw: p.signupProfile?.draw ?? null,
+      rewardDiagnostic: p.signupProfile?.rewardDiagnostic ?? null,
+      _fallback: true,
+    }];
+  const fallbackRewards = p.signupProfile?.entitlements?.filter((e) => !e.drawLinked) || [];
+
+  // Current-signup consent (ledger, scoped) with legacy-boolean fallback.
+  const currentSignup = journey?.signups?.find((s) => String(s.prospectId) === String(prospectId)) || null;
+  const consent = currentSignup?.consent || null;
+
+  return (
+    <div>
+      <PageHeader
+        title={canonicalName}
+        meta={[
+          person?.phone || p.phone || null,
+          person ? `${person.signupCount} SIGNUP${person.signupCount === 1 ? '' : 'S'} (${person.verifiedSignupCount} VERIFIED)` : null,
+          person?.firstSeenAt ? `FIRST SEEN ${fmtDateTime(person.firstSeenAt)}` : `CREATED ${fmtDateTime(p.createdAt)}`,
+        ].filter(Boolean).join(' · ')}
+      >
+        <Link to={from} className="av2-btn av2-btn--sm" style={{ textDecoration: 'none' }}>← Prospects</Link>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button type="button" className="av2-btn av2-btn--sm" disabled={assignMutation.isPending}>Assign to agent ▾</button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="admin-v2" align="end">
+            <DropdownMenuLabel>Assign to</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {(agentOptions.data || []).map((a) => (
+              <DropdownMenuItem key={a.id} onSelect={() => assignMutation.mutate({ agentId: a.id, agentName: a.name })}>
+                {a.name}
+              </DropdownMenuItem>
+            ))}
+            {agentOptions.isLoading && <DropdownMenuItem disabled>Loading agents…</DropdownMenuItem>}
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <button type="button" className="av2-btn av2-btn--sm" disabled={returnMutation.isPending} onClick={() => returnMutation.mutate()}>Return to held</button>
+        <button type="button" className="av2-btn av2-btn--sm" style={{ borderColor: 'var(--bad)', color: 'var(--bad)' }} onClick={() => setConfirmDelete(true)}>Delete</button>
+      </PageHeader>
+
+      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 16, marginTop: -6 }}>
+        <Chip tone={STATUS_CHIP_CLASS[p.leadStatus]?.replace('av2-chip--', '') || ''}>{STATUS_LABELS[p.leadStatus] || p.leadStatus}</Chip>
+        {held && <Chip tone="hold" glyph="◆">{heldLabel(p).full}</Chip>}
+        {!held && !p.assignedAgent && !p.externalAgentId && <Chip tone="warn">Unassigned</Chip>}
+        {p.screeningVerdict && (
+          <Chip tone={p.screeningVerdict === 'qualified' ? 'ok' : 'bad'} glyph={p.screeningVerdict === 'qualified' ? '✓' : '✗'}>
+            {p.screeningVerdict === 'qualified' ? 'AI qualified' : 'AI failed'}
+          </Chip>
+        )}
+        {p.priority && <Chip>{p.priority}</Chip>}
+        {Number.isFinite(Number(p.score)) && p.score !== null && <Chip>score {p.score}</Chip>}
+        {erased && <Chip tone="bad">erased</Chip>}
+      </div>
+
+      {erased && (
+        <div className="av2-card" style={{ padding: '10px 14px', marginBottom: 16, borderColor: 'var(--bad)' }}>
+          <span style={{ fontSize: 12.5, color: 'var(--ink-2)' }}>
+            This person was erased on {fmtDateTime(person.erasedAt)} — the profile shows only what the
+            allowlist rebuild kept. Draw entries are unjoinable by design.
+          </span>
+        </div>
+      )}
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 16 }}>
+        {/* ── Campaigns rail — the person's whole story ── */}
+        <Card
+          span={7}
+          title="Campaigns"
+          meta={journey ? `${railSignups.length} SIGNUP${railSignups.length === 1 ? '' : 'S'}` : undefined}
+        >
+          {!journey && (
+            <div className="av2-caption" style={{ padding: '8px 14px 0' }}>
+              {isVoiceLead
+                ? 'Retell voice lead — the call carries no caller phone, so there is no cross-campaign identity.'
+                : 'No linked person yet (phone unverified) — showing this signup only.'}
+            </div>
+          )}
+          <div style={{ display: 'grid', gap: 0 }}>
+            {railSignups.map((s) => {
+              const isCurrent = String(s.prospectId) === String(prospectId);
+              const nameVariant = person && fullName(s) && !sameName(s, person);
+              const dl = drawLine(s.draw);
+              const rewards = s._fallback
+                ? fallbackRewards
+                : (s.campaign ? rewardsByCampaign.get(String(s.campaign.id)) || [] : []);
+              const diagnostic = !dl && rewards.length === 0 ? (DIAGNOSTIC_COPY[s.rewardDiagnostic] || null) : null;
+              return (
+                <button
+                  key={s.prospectId}
+                  type="button"
+                  onClick={() => { if (!isCurrent) reAnchor(s.prospectId); }}
+                  aria-current={isCurrent ? 'page' : undefined}
+                  style={{
+                    textAlign: 'left', background: isCurrent ? 'var(--surface-2)' : 'none',
+                    border: 'none', borderTop: '1px solid var(--line)',
+                    borderLeft: isCurrent ? '3px solid var(--accent)' : '3px solid transparent',
+                    padding: '12px 14px', cursor: isCurrent ? 'default' : 'pointer',
+                    color: 'var(--ink)', fontFamily: 'var(--font-ui)', display: 'grid', gap: 5,
+                  }}
+                >
+                  <span style={{ display: 'flex', alignItems: 'baseline', gap: 8, flexWrap: 'wrap' }}>
+                    <span style={{ fontSize: 13.5, fontWeight: 800 }}>{s.campaign?.name || 'No campaign'}</span>
+                    {s.campaign?.status && s.campaign.status !== 'active' && <Chip>{s.campaign.status}</Chip>}
+                    {isCurrent && <Chip tone="accent">viewing</Chip>}
+                    <span style={{ flex: 1 }} />
+                    <span className="av2-mono" style={{ fontSize: 10.5, color: 'var(--ink-3)' }} title={fmtDateTime(s.createdAt)}>
+                      {fmtRelative(s.createdAt)}
+                    </span>
+                  </span>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap', fontSize: 12, color: 'var(--ink-2)' }}>
+                    <span>as <strong style={{ color: 'var(--ink)' }}>{fullName(s) || '—'}</strong></span>
+                    {nameVariant && <Chip tone="warn" glyph="⚠">name variant</Chip>}
+                    <Chip>{SOURCE_LABELS[s.leadSource] || s.leadSource}</Chip>
+                    {s.verified ? <Chip tone="ok" glyph="✓">verified</Chip> : <Chip>unverified</Chip>}
+                    {s.held && <Chip tone="hold" glyph="◆">held</Chip>}
+                  </span>
+                  {dl && (
+                    <span style={{ fontSize: 12.5, color: dl.tone === 'warn' ? 'var(--warn)' : dl.tone === 'ok' ? 'var(--ok)' : dl.tone === 'accent' ? 'var(--accent-text)' : 'var(--ink)' }}>
+                      🎟 {dl.text}
+                    </span>
+                  )}
+                  {rewards.map((e) => {
+                    const rl = rewardLine(e);
+                    const receipts = receiptLine(e.delivery);
+                    return (
+                      <span key={e.id} style={{ display: 'grid', gap: 2 }}>
+                        <span style={{ fontSize: 12.5 }}>
+                          🎁 <strong>{rl.label}</strong>{rl.detail ? ` — ${rl.detail}` : ''}
+                        </span>
+                        {receipts && <span className="av2-caption">{receipts}</span>}
+                      </span>
+                    );
+                  })}
+                  {diagnostic && <span className="av2-caption">{diagnostic}</span>}
+                </button>
+              );
+            })}
+          </div>
+        </Card>
+
+        {/* ── Right column ── */}
+        <div style={{ gridColumn: 'span 5', display: 'grid', gap: 16, alignContent: 'start' }}>
+          <Card title="This signup">
+            <div style={{ padding: '4px 14px 12px', display: 'grid', gap: 14 }}>
+              <section>
+                <SectionCaps>Contact</SectionCaps>
+                <Kv k="phone">
+                  {p.phone || '—'}
+                  {p.sourceMetadata?.phoneVerifiedAt && <span className="av2-caption" title={fmtDateTime(p.sourceMetadata.phoneVerifiedAt)}> · verified ✓</span>}
+                </Kv>
+                <Kv k="email">{p.email || '—'}</Kv>
+              </section>
+              <section>
+                <SectionCaps>Attribution</SectionCaps>
+                <Kv k="source">{SOURCE_LABELS[p.leadSource] || p.leadSource}</Kv>
+                {utm.utm_source && <Kv k="utm_source">{UTM_LABELS[utm.utm_source] || utm.utm_source}</Kv>}
+                {utm.utm_medium && <Kv k="utm_medium">{utm.utm_medium}</Kv>}
+                {utm.utm_campaign && <Kv k="utm_campaign">{utm.utm_campaign}</Kv>}
+                {p.session?.utm?.term && <Kv k="utm_term">{p.session.utm.term}</Kv>}
+                {p.session?.utm?.content && <Kv k="utm_content">{p.session.utm.content}</Kv>}
+                {p.session?.landingPath && <Kv k="landing">{p.session.landingPath}</Kv>}
+                {p.qrTag && <Kv k="qr tag">{p.qrTag.name}</Kv>}
+                <Kv k="campaign">
+                  {p.campaign
+                    ? <Link to={`/admin/campaigns/${p.campaign.id}`} style={{ color: 'var(--accent-text)', textDecoration: 'none', fontWeight: 700 }}>{p.campaign.name} ↗</Link>
+                    : '—'}
+                </Kv>
+              </section>
+              <section>
+                <SectionCaps>Routing</SectionCaps>
+                <Kv k="agent">
+                  {p.assignedAgent
+                    ? fullName(p.assignedAgent)
+                    : p.externalAgent
+                      ? `${p.externalAgent.fullName || 'External buyer'}${p.externalAgent.agency ? ` (${p.externalAgent.agency})` : ''}`
+                      : p.externalAgentId ? 'external buyer' : held ? 'held' : 'unassigned'}
+                </Kv>
+                {held && <Kv k="held since">{fmtDateTime(p.quarantinedAt)}</Kv>}
+                {held && <Kv k="reason">{heldLabel(p).full || p.quarantineReason || '—'}</Kv>}
+                <Kv k="lyfe delivery">
+                  {p.lyfeDelivery
+                    ? p.lyfeDelivery.map((ld) => `${ld.eventType.replace('lead.', '')}: ${ld.status === 'success' ? '✓ delivered' : ld.status === 'failed' ? `✗ failed ×${ld.attempts}${ld.reason ? ` (${ld.reason.replace(/_/g, ' ')})` : ''}` : '… pending'}`).join(' · ')
+                    : 'not sent — no app destination'}
+                </Kv>
+                {p.nextFollowUpDate && <Kv k="follow-up">{fmtDateTime(p.nextFollowUpDate)}</Kv>}
+                {(p.commissions || []).map((cm) => (
+                  <Kv key={cm.id} k="commission">{cm.type} · {cm.status}</Kv>
+                ))}
+              </section>
+            </div>
+          </Card>
+
+          {quiz && (
+            <Card title="Quiz">
+              <div style={{ padding: '4px 14px 12px' }}>
+                {Object.entries(quiz)
+                  .filter(([, v]) => ['string', 'number', 'boolean'].includes(typeof v))
+                  .slice(0, 12)
+                  .map(([k, v]) => <Kv key={k} k={k}>{String(v)}</Kv>)}
+              </div>
+            </Card>
+          )}
+
+          <Card title="Consent & reachability">
+            <div style={{ padding: '4px 14px 12px', display: 'grid', gap: 14 }}>
+              <section>
+                <SectionCaps>{consent ? 'Consent (ledger, this campaign + global)' : 'Consent (legacy flags)'}</SectionCaps>
+                {consent ? (
+                  <>
+                    <Kv k="marketing">{consentRow(consent.contact)}</Kv>
+                    <Kv k="terms">{consentRow(consent.campaign_terms)}</Kv>
+                    <Kv k="third-party">{consentRow(consent.third_party)}</Kv>
+                    {consent.draw_terms && <Kv k="draw terms">{consentRow(consent.draw_terms)}</Kv>}
+                  </>
+                ) : (
+                  <>
+                    <Kv k="marketing">{p.sourceMetadata?.consent_contact === true ? 'yes' : p.sourceMetadata?.consent_contact === false ? 'no' : '—'}</Kv>
+                    <Kv k="terms">{p.sourceMetadata?.consent_terms === true ? 'yes' : p.sourceMetadata?.consent_terms === false ? 'no' : '—'}</Kv>
+                    <Kv k="third-party">{p.sourceMetadata?.consent_third_party === true ? 'yes' : p.sourceMetadata?.consent_third_party === false ? 'no' : '—'}</Kv>
+                  </>
+                )}
+                {p.consentMetadata?.drawTerms?.termsVersionId && (
+                  <Kv k="draw terms pinned"><span className="av2-mono" style={{ fontSize: 11 }}>{String(p.consentMetadata.drawTerms.termsVersionId).slice(0, 8)}…</span></Kv>
+                )}
+              </section>
+              {(journey?.suppressions?.length > 0) && (
+                <section>
+                  <SectionCaps>Suppressions</SectionCaps>
+                  <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                    {journey.suppressions.map((s2, i) => (
+                      <Chip key={i} tone="bad">{s2.channel}: {s2.reason.replace(/_/g, ' ')}</Chip>
+                    ))}
+                  </div>
+                </section>
+              )}
+              <section>
+                <SectionCaps>DNC registry</SectionCaps>
+                <Kv k="status">{p.dncStatus || '—'}</Kv>
+                {(p.dncNoVoiceCall || p.dncNoTextMessage) && (
+                  <Kv k="blocked">{[p.dncNoVoiceCall && 'voice', p.dncNoTextMessage && 'SMS'].filter(Boolean).join(' + ')}</Kv>
+                )}
+                {p.dncCheckedAt && <Kv k="checked">{fmtDateTime(p.dncCheckedAt)}{p.dncValidUntil ? ` · valid until ${fmtDateTime(p.dncValidUntil)}` : ''}</Kv>}
+              </section>
+              {journey?.broadcasts && (
+                <section>
+                  <SectionCaps>Marketing touches</SectionCaps>
+                  <Kv k="broadcasts">
+                    {Object.keys(journey.broadcasts.counts).length
+                      ? Object.entries(journey.broadcasts.counts).map(([k, v]) => `${v} ${k}`).join(' · ')
+                      : 'none yet'}
+                  </Kv>
+                </section>
+              )}
+            </div>
+          </Card>
+
+          {hasScreening && (
+            <Card title="AI screening">
+              <div style={{ padding: '4px 14px 12px' }}>
+                <Kv k="verdict">
+                  {p.screeningVerdict === 'qualified' ? 'Qualified'
+                    : p.screeningVerdict === 'not_qualified' ? 'Not qualified'
+                      : sm.unreachable ? 'Unreachable' : 'Pending'}
+                </Kv>
+                {verdictDetail.reason && <Kv k="reason">{verdictDetail.reason}</Kv>}
+                {verdictDetail.sentiment && <Kv k="sentiment">{verdictDetail.sentiment}</Kv>}
+                <Kv k="attempts">{p.screeningAttemptCount || screeningAttempts.length || 0}</Kv>
+                {sm.callbackGranted && p.screeningNextAttemptAt && <Kv k="callback">{fmtDateTime(p.screeningNextAttemptAt)}</Kv>}
+                {screeningAttempts.some((a) => Number.isFinite(a.costCents)) && (
+                  <Kv k="call cost">{fmtSGDExact(screeningCostCents)}</Kv>
+                )}
+                {verdictDetail.summary && (
+                  <div style={{ marginTop: 6, fontSize: 12, color: 'var(--ink-2)', lineHeight: 1.5 }}>
+                    {String(verdictDetail.summary).slice(0, 600)}
+                  </div>
+                )}
+                {verdictDetail.transcript && (
+                  <details style={{ marginTop: 8 }}>
+                    <summary style={{ fontSize: 11, fontWeight: 700, color: 'var(--ink-2)', cursor: 'pointer', userSelect: 'none' }}>
+                      Call transcript
+                    </summary>
+                    <div style={{ marginTop: 6, maxHeight: 260, overflowY: 'auto', padding: '8px 10px', borderRadius: 8, background: 'var(--surface-2)', border: '1px solid var(--line)', fontSize: 12, lineHeight: 1.55, whiteSpace: 'pre-wrap', wordBreak: 'break-word', color: 'var(--ink-2)' }}>
+                      {String(verdictDetail.transcript).split('\n').map((line, i) => {
+                        const m = /^(Agent|User):\s?(.*)$/.exec(line);
+                        if (!m) return line ? <div key={i}>{line}</div> : <div key={i}>&nbsp;</div>;
+                        return (
+                          <div key={i} style={{ marginBottom: 3 }}>
+                            <span style={{ fontWeight: 700, color: m[1] === 'Agent' ? 'var(--accent-text)' : 'var(--ink)' }}>
+                              {m[1] === 'Agent' ? 'Sarah' : p.firstName || 'Lead'}:
+                            </span>{' '}
+                            {m[2]}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </details>
+                )}
+                {screeningAttempts.filter((a) => a.recordingUrl).map((a, i) => (
+                  <div key={a.token || i} style={{ marginTop: 8, display: 'grid', gap: 4 }}>
+                    <span style={{ fontSize: 12, color: 'var(--ink-2)' }}>Recording — attempt {i + 1} ({fmtDateTime(a.startedAt)})</span>
+                    <audio controls preload="none" src={a.recordingUrl} style={{ width: '100%', height: 34 }} />
+                  </div>
+                ))}
+              </div>
+            </Card>
+          )}
+
+          {isVoiceLead && (
+            <Card title="Voice call">
+              <div style={{ padding: '4px 14px 12px' }}>
+                <Kv k="from">{p.sourceMetadata?.fromNumber || '—'}</Kv>
+                <Kv k="sentiment">{p.sourceMetadata?.sentiment || '—'}</Kv>
+                {p.sourceMetadata?.durationMs && <Kv k="duration">{Math.round(p.sourceMetadata.durationMs / 1000)}s</Kv>}
+                {p.notes && (
+                  <div style={{ marginTop: 6, fontSize: 12, color: 'var(--ink-2)', lineHeight: 1.5, whiteSpace: 'pre-wrap' }}>
+                    {String(p.notes).slice(0, 800)}
+                  </div>
+                )}
+                {p.sourceMetadata?.recordingUrl && (
+                  <audio controls preload="none" src={p.sourceMetadata.recordingUrl} style={{ width: '100%', height: 34, marginTop: 8 }} />
+                )}
+              </div>
+            </Card>
+          )}
+        </div>
+
+        {/* ── History ── */}
+        <Card
+          span={12}
+          title="History"
+          action={(
+            <div className="av2-seg" role="group" aria-label="History scope">
+              {[['all', 'All'], ['signup', 'This signup'], ['person', 'Person']].map(([v, label]) => (
+                <button key={v} type="button" aria-pressed={historyScope === v} onClick={() => setHistoryScope(v)}>
+                  {label}
+                </button>
+              ))}
+            </div>
+          )}
+        >
+          {filteredHistory.length === 0 ? (
+            <EmptyState title="Nothing yet" hint="This lead was just captured — events land here as they happen." />
+          ) : (
+            <div style={{ padding: '4px 0 8px' }}>
+              {filteredHistory.slice(0, 80).map((e, i) => (
+                <div key={i} className="av2-qrow" style={{ cursor: 'default', minHeight: 36 }}>
+                  <span className="av2-mono" style={{ width: 130, flex: 'none', fontSize: 10.5, color: 'var(--ink-3)' }} title={fmtDateTime(new Date(e.at))}>
+                    {fmtDateTime(new Date(e.at))}
+                  </span>
+                  <span style={{ flex: 1, fontSize: 12.5 }}>{e.label}</span>
+                  {e.campaign && <span className="av2-caption" style={{ flex: 'none' }}>{e.campaign}</span>}
+                </div>
+              ))}
+              {filteredHistory.length > 80 && (
+                <div className="av2-caption" style={{ padding: '8px 14px' }}>Showing the latest 80 events.</div>
+              )}
+            </div>
+          )}
+        </Card>
+      </div>
+
+      <AlertDialog open={confirmDelete} onOpenChange={setConfirmDelete}>
+        <AlertDialogContent className="admin-v2" style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)' }}>
+          <AlertDialogHeader>
+            <AlertDialogTitle style={{ color: 'var(--ink)' }}>Delete this lead?</AlertDialogTitle>
+            <AlertDialogDescription style={{ color: 'var(--ink-2)' }}>
+              This permanently removes the lead and its activity history. It cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => { e.preventDefault(); deleteMutation.mutate(); }}
+              disabled={deleteMutation.isPending}
+              style={{ background: 'var(--bad)', color: '#fff' }}
+            >
+              {deleteMutation.isPending ? 'Deleting…' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/pages/adminv2/AdminV2Prospects.jsx
+++ b/src/pages/adminv2/AdminV2Prospects.jsx
@@ -1,24 +1,24 @@
 /**
  * Switchboard Prospects — the operator lead table. Filters live in the URL
  * (removable chips, shareable links, back/forward safe), pagination + sort are
- * server-side (Phase B contracts), the drawer tells the whole lead story, and
- * the bulk bar drives the REAL bulk endpoints (assign / return-to-held /
- * delete) plus a client-side CSV export.
+ * server-side (Phase B contracts), a row click opens the lead's full-page
+ * profile (/admin/leads/:id — the drawer's replacement), and the bulk bar
+ * drives the REAL bulk endpoints (assign / return-to-held / delete) plus a
+ * client-side CSV export.
  */
 import { useMemo, useState, useEffect, useRef } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { useProspects, useProspectDetail, useAgentOptions } from '@/hooks/queries/useAdminV2';
+import { useProspects, useAgentOptions } from '@/hooks/queries/useAdminV2';
 import { bulkAssign, bulkReturnToHeld, bulkDelete } from '@/api/adminV2';
 import {
   LEAD_STATUSES, LEAD_SOURCES, STATUS_LABELS, STATUS_CHIP_CLASS,
-  SOURCE_LABELS, heldLabel, UTM_LABELS, PAGE_SIZE,
+  SOURCE_LABELS, heldLabel, PAGE_SIZE,
 } from '@/lib/adminV2/constants';
-import { fmtDateTime, fmtRelative, fmtSGDExact } from '@/lib/adminV2/format';
+import { fmtDateTime, fmtRelative } from '@/lib/adminV2/format';
 import { prospectsToCsv, downloadCsv } from '@/lib/adminV2/csv';
 import { Chip, PageHeader, Skeleton, ErrorState, EmptyState } from '@/components/adminv2/primitives';
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import {
   DropdownMenu, DropdownMenuTrigger, DropdownMenuContent,
   DropdownMenuCheckboxItem, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator,
@@ -82,361 +82,22 @@ function SortHeader({ label, field, sort, onSort, width, align }) {
   );
 }
 
-function LeadDrawer({ prospect, onClose, onOpenLead }) {
-  // Detail fetch on open (consumer spine): the list row is a thin projection —
-  // the detail endpoint adds the admin enrichments (repeatSignup, timeline,
-  // the `consumer` journey for the Person card) and lets ?lead= deep-links
-  // open leads that aren't on the current page. Row data paints instantly;
-  // the detail enriches when it lands. Hook runs unconditionally (enabled
-  // gate), so the early return below stays hooks-safe.
-  const detail = useProspectDetail(prospect?.id);
-  // Row-level actions mirror the bulk bar but target this one lead. All hooks
-  // run BEFORE the null-guard return so hook order stays stable across
-  // open/close — the mutations simply never fire while `id` is undefined.
-  const queryClient = useQueryClient();
-  const agentOptions = useAgentOptions(!!prospect);
-  const [confirmDelete, setConfirmDelete] = useState(false);
-  const id = prospect?.id;
-  const invalidate = () => {
-    queryClient.invalidateQueries({ queryKey: ['adminV2', 'prospects'] });
-    queryClient.invalidateQueries({ queryKey: ['adminV2', 'prospectDetail'] });
-  };
-  const assignMutation = useMutation({
-    mutationFn: ({ agentId }) => bulkAssign([id], agentId),
-    onSuccess: (r, { agentName }) => {
-      const n = r?.data?.affectedCount ?? 0;
-      if (n > 0) toast.success(`Assigned to ${agentName}`);
-      else toast.warning('Not assigned — lead not eligible');
-      invalidate();
-    },
-    onError: (e) => toast.error(e?.message || 'Assign failed'),
-  });
-  const returnMutation = useMutation({
-    mutationFn: () => bulkReturnToHeld([id]),
-    onSuccess: (r) => {
-      const n = r?.data?.returned ?? 0;
-      if (n > 0) toast.success('Returned to held');
-      else toast.warning('Not returned — already held or not eligible');
-      invalidate();
-    },
-    onError: (e) => toast.error(e?.message || 'Return failed'),
-  });
-  const deleteMutation = useMutation({
-    mutationFn: () => bulkDelete([id]),
-    onSuccess: (r) => {
-      const n = r?.data?.deleted ?? 0;
-      setConfirmDelete(false);
-      invalidate();
-      if (n > 0) { toast.success('Lead deleted'); onClose(); }
-      else toast.warning('Nothing deleted');
-    },
-    onError: (e) => { toast.error(e?.message || 'Delete failed'); setConfirmDelete(false); },
-  });
-  if (!prospect) return null;
-  const p = detail.data || prospect;
-  const consumer = detail.data?.consumer || null;
-  const otherSignups = consumer ? consumer.signups.filter((s) => s.prospectId !== p.id) : [];
-  const utm = p.sourceMetadata?.utm || {};
-  const held = !!p.quarantinedAt;
-  return (
-    <Sheet open onOpenChange={(open) => { if (!open) onClose(); }}>
-      <SheetContent side="right" className="admin-v2" style={{ width: 432, maxWidth: '90vw', padding: 0, background: 'var(--surface)', color: 'var(--ink)', borderLeft: '1px solid var(--line)', display: 'flex', flexDirection: 'column', gap: 0 }}>
-        <SheetHeader style={{ padding: '14px 16px', borderBottom: '1px solid var(--line)', flexShrink: 0 }}>
-          <SheetTitle style={{ fontSize: 15, fontWeight: 800, color: 'var(--ink)', fontFamily: 'var(--font-ui)', textAlign: 'left' }}>
-            {(p.firstName || p.lastName)
-              ? `${p.firstName || ''} ${p.lastName || ''}`.trim()
-              : (detail.isLoading ? 'Loading…' : 'Lead')}
-          </SheetTitle>
-          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-            <Chip tone={STATUS_CHIP_CLASS[p.leadStatus]?.replace('av2-chip--', '') || ''}>{STATUS_LABELS[p.leadStatus] || p.leadStatus}</Chip>
-            {held && <Chip tone="hold" glyph="◆">{heldLabel(p).full}</Chip>}
-            {!held && !p.assignedAgent && <Chip tone="warn">Unassigned</Chip>}
-            {p.priority && <Chip>{p.priority}</Chip>}
-            {Number.isFinite(Number(p.score)) && p.score !== null && <Chip>score {p.score}</Chip>}
-          </div>
-        </SheetHeader>
-        <div style={{ padding: 16, overflowY: 'auto', display: 'grid', gap: 18, flex: 1, minHeight: 0 }}>
-          {detail.isError && !p.phone && (
-            <div className="av2-kv" style={{ color: 'var(--ink-2)' }}>
-              Couldn&apos;t load this lead — it may have been deleted.
-            </div>
-          )}
-          <section>
-            <div className="av2-microcaps" style={{ marginBottom: 6 }}>Contact</div>
-            <div className="av2-kv"><span>phone</span><span>{p.phone || '—'}</span></div>
-            <div className="av2-kv"><span>email</span><span>{p.email || '—'}</span></div>
-          </section>
-          <section>
-            <div className="av2-microcaps" style={{ marginBottom: 6 }}>Attribution</div>
-            <div className="av2-kv"><span>source</span><span>{SOURCE_LABELS[p.leadSource] || p.leadSource}</span></div>
-            {utm.utm_source && <div className="av2-kv"><span>utm_source</span><span>{UTM_LABELS[utm.utm_source] || utm.utm_source}</span></div>}
-            {utm.utm_medium && <div className="av2-kv"><span>utm_medium</span><span>{utm.utm_medium}</span></div>}
-            {utm.utm_campaign && <div className="av2-kv"><span>utm_campaign</span><span>{utm.utm_campaign}</span></div>}
-            {p.qrTag && <div className="av2-kv"><span>qr tag</span><span>{p.qrTag.name}</span></div>}
-            <div className="av2-kv"><span>campaign</span><span>{p.campaign?.name || '—'}</span></div>
-          </section>
-          {consumer && (
-            <section>
-              <div className="av2-microcaps" style={{ marginBottom: 6 }}>Person</div>
-              <div className="av2-kv">
-                <span>signups</span>
-                <span>
-                  {consumer.consumer.signupCount}
-                  {consumer.consumer.verifiedSignupCount !== consumer.consumer.signupCount
-                    ? ` (${consumer.consumer.verifiedSignupCount} verified)` : ''}
-                </span>
-              </div>
-              <div className="av2-kv"><span>first seen</span><span>{fmtDateTime(consumer.consumer.firstSeenAt)}</span></div>
-              {consumer.entitlements.length > 0 && (
-                <div className="av2-kv">
-                  <span>rewards</span>
-                  <span>{consumer.entitlements.length} · {consumer.entitlements.filter((e) => e.redeemedAt).length} redeemed</span>
-                </div>
-              )}
-              {consumer.drawEntries > 0 && (
-                <div className="av2-kv"><span>draw entries</span><span>{consumer.drawEntries}</span></div>
-              )}
-              {otherSignups.length > 0 && (
-                <div style={{ marginTop: 8, display: 'grid', gap: 4 }}>
-                  <div className="av2-microcaps" style={{ color: 'var(--ink-2)' }}>Also in</div>
-                  {otherSignups.map((s) => (
-                    <button
-                      key={s.prospectId}
-                      type="button"
-                      onClick={() => onOpenLead?.(s.prospectId)}
-                      style={{
-                        textAlign: 'left', background: 'none', border: '1px solid var(--line)',
-                        borderRadius: 8, padding: '6px 8px', cursor: 'pointer', color: 'var(--ink)',
-                        fontFamily: 'var(--font-ui)', fontSize: 12,
-                      }}
-                    >
-                      {s.campaign?.name || 'No campaign'} · {fmtRelative(s.createdAt)}
-                      {!s.verified && <span style={{ color: 'var(--ink-2)' }}> · unverified</span>}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </section>
-          )}
-          <section>
-            <div className="av2-microcaps" style={{ marginBottom: 6 }}>Routing</div>
-            <div className="av2-kv"><span>agent</span><span>{p.assignedAgent ? `${p.assignedAgent.firstName || ''} ${p.assignedAgent.lastName || ''}`.trim() : p.externalAgentId ? 'external buyer' : held ? 'held' : 'unassigned'}</span></div>
-            {held && <div className="av2-kv"><span>held since</span><span>{fmtDateTime(p.quarantinedAt)}</span></div>}
-            {held && <div className="av2-kv"><span>reason</span><span>{heldLabel(p).full || p.quarantineReason || '—'}</span></div>}
-          </section>
-          {(p.screeningVerdict || p.screeningMetadata || String(p.quarantineReason || '').startsWith('screening_')) && (() => {
-            const sm = p.screeningMetadata || {};
-            const verdictDetail = sm.verdictDetail || {};
-            const attempts = Object.values(sm.attempts || {})
-              .filter((a) => a && a.startedAt)
-              .sort((a, b) => String(a.startedAt).localeCompare(String(b.startedAt)));
-            // Cost is summed across every dial (the true per-lead screening
-            // spend); duration/version come from the latest call that carried
-            // them — the one that produced the verdict.
-            const costCents = attempts.reduce((s, a) => s + (Number(a.costCents) || 0), 0);
-            const hasCost = attempts.some((a) => Number.isFinite(a.costCents));
-            const lastWith = (key) => [...attempts].reverse().find((a) => a[key] != null);
-            const durationSeconds = lastWith('durationSeconds')?.durationSeconds ?? null;
-            const agentVersion = lastWith('agentVersion')?.agentVersion ?? null;
-            return (
-              <section>
-                <div className="av2-microcaps" style={{ marginBottom: 6 }}>AI Screening</div>
-                <div className="av2-kv">
-                  <span>verdict</span>
-                  <span>
-                    {p.screeningVerdict === 'qualified' ? 'Qualified'
-                      : p.screeningVerdict === 'not_qualified' ? 'Not qualified'
-                        : sm.unreachable ? 'Unreachable' : 'Pending'}
-                  </span>
-                </div>
-                {verdictDetail.reason && <div className="av2-kv"><span>reason</span><span>{verdictDetail.reason}</span></div>}
-                {verdictDetail.sentiment && <div className="av2-kv"><span>sentiment</span><span>{verdictDetail.sentiment}</span></div>}
-                <div className="av2-kv"><span>attempts</span><span>{p.screeningAttemptCount || attempts.length || 0}</span></div>
-                {/* A time Sarah promised on the phone (or the customer picked
-                    via WhatsApp) — the one screening date an operator must not
-                    silently miss. */}
-                {sm.callbackGranted && p.screeningNextAttemptAt && (
-                  <div className="av2-kv"><span>callback</span><span>{fmtDateTime(p.screeningNextAttemptAt)}</span></div>
-                )}
-                {sm.waCallback?.sentAt && (
-                  <div className="av2-kv">
-                    <span>wa invite</span>
-                    <span>
-                      {sm.waCallback.sent === false ? 'send failed' : fmtDateTime(sm.waCallback.sentAt)}
-                      {sm.waCallback.tappedAt ? ` · tapped (${String(sm.waCallback.window || '').replace(/_/g, ' ')})` : ''}
-                    </span>
-                  </div>
-                )}
-                {hasCost && (
-                  <div className="av2-kv">
-                    <span>call cost</span>
-                    <span>{fmtSGDExact(costCents)}{durationSeconds != null ? ` · ${durationSeconds}s` : ''}</span>
-                  </div>
-                )}
-                {agentVersion != null && <div className="av2-kv"><span>script</span><span>v{agentVersion}</span></div>}
-                {verdictDetail.summary && (
-                  <div style={{ marginTop: 6, fontSize: 12, color: 'var(--ink-2)', lineHeight: 1.5 }}>
-                    {String(verdictDetail.summary).slice(0, 600)}
-                  </div>
-                )}
-                {verdictDetail.transcript && (
-                  <details style={{ marginTop: 8 }}>
-                    <summary style={{ fontSize: 11, fontWeight: 700, color: 'var(--ink-2)', cursor: 'pointer', userSelect: 'none' }}>
-                      Call transcript
-                    </summary>
-                    <div
-                      style={{
-                        marginTop: 6,
-                        maxHeight: 260,
-                        overflowY: 'auto',
-                        padding: '8px 10px',
-                        borderRadius: 8,
-                        background: 'var(--surface-2)',
-                        border: '1px solid var(--line)',
-                        fontSize: 12,
-                        lineHeight: 1.55,
-                        whiteSpace: 'pre-wrap',
-                        wordBreak: 'break-word',
-                        color: 'var(--ink-2)',
-                      }}
-                    >
-                      {String(verdictDetail.transcript).split('\n').map((line, i) => {
-                        const m = /^(Agent|User):\s?(.*)$/.exec(line);
-                        if (!m) return line ? <div key={i}>{line}</div> : <div key={i}>&nbsp;</div>;
-                        return (
-                          <div key={i} style={{ marginBottom: 3 }}>
-                            <span style={{ fontWeight: 700, color: m[1] === 'Agent' ? 'var(--accent-text)' : 'var(--ink)' }}>
-                              {m[1] === 'Agent' ? 'Sarah' : p.firstName || 'Lead'}:
-                            </span>{' '}
-                            {m[2]}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </details>
-                )}
-                {/* Attempts that produced no verdict write no verdictDetail, so
-                    the block above says nothing about them. Their own evidence
-                    is the only record of WHY — e.g. a requested callback. */}
-                {attempts.some((a) => a.outcome === 'no_verdict' || a.outcome === 'unanswered') && (
-                  <div style={{ marginTop: 8, display: 'grid', gap: 3 }}>
-                    {attempts.map((a, i) => (
-                      (a.outcome === 'no_verdict' || a.outcome === 'unanswered') ? (
-                        <div key={a.token || i} style={{ fontSize: 12, color: 'var(--ink-2)', lineHeight: 1.45 }}>
-                          Attempt {i + 1} — {a.outcome === 'unanswered'
-                            ? String(a.disconnectionReason || 'no answer').replace(/_/g, ' ')
-                            : a.reason || 'no verdict'}
-                        </div>
-                      ) : null
-                    ))}
-                  </div>
-                )}
-                {attempts.some((a) => a.recordingUrl) && (
-                  <div style={{ marginTop: 6, display: 'grid', gap: 10 }}>
-                    {attempts.filter((a) => a.recordingUrl).map((a, i) => (
-                      <div key={a.token || i} style={{ display: 'grid', gap: 4 }}>
-                        <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 8 }}>
-                          <span style={{ fontSize: 12, color: 'var(--ink-2)' }}>
-                            Recording — attempt {i + 1} ({fmtDateTime(a.startedAt)})
-                          </span>
-                          {/* Download stays available; `download` is honoured for
-                              same-origin/blob, and for the cross-origin CDN URL the
-                              browser opens the file in a new tab — either way the raw
-                              file is one click away, separate from playback. */}
-                          <a
-                            href={a.recordingUrl}
-                            download={`screening-attempt-${i + 1}.wav`}
-                            target="_blank"
-                            rel="noreferrer"
-                            style={{ fontSize: 11, color: 'var(--ink)', textDecoration: 'underline', flex: 'none' }}
-                          >
-                            Download
-                          </a>
-                        </div>
-                        {/* Streams in-page; preload=none so opening the drawer
-                            never fetches audio until the operator hits play. */}
-                        <audio
-                          controls
-                          preload="none"
-                          src={a.recordingUrl}
-                          style={{ width: '100%', height: 34 }}
-                        >
-                          <a href={a.recordingUrl} target="_blank" rel="noreferrer">Play recording</a>
-                        </audio>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </section>
-            );
-          })()}
-          <section>
-            <div className="av2-microcaps" style={{ marginBottom: 6 }}>Consent</div>
-            <div className="av2-kv"><span>marketing</span><span>{p.sourceMetadata?.consent_contact === true ? 'yes' : p.sourceMetadata?.consent_contact === false ? 'no' : '—'}</span></div>
-            <div className="av2-kv"><span>terms</span><span>{p.sourceMetadata?.consent_terms === true ? 'yes' : p.sourceMetadata?.consent_terms === false ? 'no' : '—'}</span></div>
-            <div className="av2-kv"><span>third-party</span><span>{p.sourceMetadata?.consent_third_party === true ? 'yes' : p.sourceMetadata?.consent_third_party === false ? 'no' : '—'}</span></div>
-          </section>
-          <section>
-            <div className="av2-microcaps" style={{ marginBottom: 6 }}>Timeline</div>
-            <div className="av2-kv"><span>created</span><span>{fmtDateTime(p.createdAt)}</span></div>
-            <div className="av2-kv"><span>last contact</span><span>{fmtDateTime(p.lastContactDate)}</span></div>
-            <div className="av2-kv"><span>converted</span><span>{fmtDateTime(p.conversionDate)}</span></div>
-          </section>
-        </div>
-        {/* ── Action footer (pinned; mirrors the bulk bar for this one lead) ── */}
-        <div style={{ flex: 'none', display: 'flex', alignItems: 'center', gap: 8, padding: '12px 16px', borderTop: '1px solid var(--line)', background: 'var(--surface)' }}>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button type="button" className="av2-btn av2-btn--sm" disabled={assignMutation.isPending}>Assign to agent ▾</button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent className="admin-v2" align="start" side="top">
-              <DropdownMenuLabel>Assign to</DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              {(agentOptions.data || []).map((a) => (
-                <DropdownMenuItem key={a.id} onSelect={() => assignMutation.mutate({ agentId: a.id, agentName: a.name })}>
-                  {a.name}
-                </DropdownMenuItem>
-              ))}
-              {agentOptions.isLoading && <DropdownMenuItem disabled>Loading agents…</DropdownMenuItem>}
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <button type="button" className="av2-btn av2-btn--sm" disabled={returnMutation.isPending} onClick={() => returnMutation.mutate()}>Return to held</button>
-          <span style={{ flex: 1 }} />
-          <button type="button" className="av2-btn av2-btn--sm" style={{ borderColor: 'var(--bad)', color: 'var(--bad)' }} onClick={() => setConfirmDelete(true)}>Delete</button>
-        </div>
-        <AlertDialog open={confirmDelete} onOpenChange={setConfirmDelete}>
-          <AlertDialogContent className="admin-v2" style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)' }}>
-            <AlertDialogHeader>
-              <AlertDialogTitle style={{ color: 'var(--ink)' }}>Delete this lead?</AlertDialogTitle>
-              <AlertDialogDescription style={{ color: 'var(--ink-2)' }}>
-                This permanently removes the lead and its activity history. It cannot be undone.
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
-              <AlertDialogAction
-                onClick={(e) => { e.preventDefault(); deleteMutation.mutate(); }}
-                disabled={deleteMutation.isPending}
-                style={{ background: 'var(--bad)', color: '#fff' }}
-              >
-                {deleteMutation.isPending ? 'Deleting…' : 'Delete'}
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
-      </SheetContent>
-    </Sheet>
-  );
-}
 
 export default function AdminV2Prospects() {
   const [searchParams, setSearchParams] = useSearchParams();
   const filters = useMemo(() => readFilters(searchParams), [searchParams]);
   const [searchDraft, setSearchDraft] = useState(filters.search);
   const [selected, setSelected] = useState(() => new Set());
-  const [drawer, setDrawer] = useState(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  // Open a lead's full-page profile, carrying the CURRENT list URL as
+  // state.from so the page's back link restores these exact filters (§3.8).
+  const openLead = (id) => navigate(`/admin/leads/${id}`, {
+    state: { from: `${location.pathname}${location.search}` },
+  });
 
   // Live view of the params for timers created in older renders. RR v7's
   // setSearchParams closes over ITS render's params (even the functional
@@ -501,23 +162,22 @@ export default function AdminV2Prospects() {
   // Selection is per-page; changing the result set clears it.
   useEffect(() => { setSelected(new Set()); }, [queryParams]);
 
-  // Palette deep-link: /AdminProspects?q=…&lead=<id> auto-opens that lead's
-  // drawer once the row set arrives, then consumes the param (found or not —
-  // a stale id must not re-trigger on every later fetch). Guard on isFetching,
-  // not isLoading: when the palette navigates while this page is already
-  // mounted, only isFetching flips — isLoading is first-load-only in RQ v5,
-  // and matching against the previous filter's rows would eat the param.
-  // On error, keep the param so a retry can still open the drawer.
+  // Legacy deep-link: ?lead=<id> (the old drawer contract — saved links and
+  // any un-migrated caller still emit it) → redirect to the Lead Profile
+  // page. No need to wait for the row set: the page detail-fetches by id.
+  // The CLEANED list URL rides along as state.from for the back link.
   const leadParam = searchParams.get('lead');
   useEffect(() => {
-    if (!leadParam || prospects.isFetching || prospects.isError) return;
-    const hit = rows.find((r) => r.id === leadParam);
-    // Off-page ids open too: the drawer detail-fetches by id, so palette /
-    // Person-card deep-links work from any filter or page.
-    setDrawer(hit || { id: leadParam });
-    patch({ lead: null });
+    if (!leadParam) return;
+    const cleaned = new URLSearchParams(searchParams);
+    cleaned.delete('lead');
+    const qs = cleaned.toString();
+    navigate(`/admin/leads/${leadParam}`, {
+      replace: true,
+      state: { from: `/AdminProspects${qs ? `?${qs}` : ''}` },
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [leadParam, prospects.isFetching, prospects.isError]);
+  }, [leadParam]);
 
   const toggleList = (key, value) => {
     const current = new Set(filters[key]);
@@ -716,10 +376,17 @@ export default function AdminV2Prospects() {
         {rows.map((p) => {
           const held = !!p.quarantinedAt;
           const isSelected = selected.has(p.id);
+          // Selection mode: while ANY rows are selected, a row click toggles
+          // that row (Gmail-style) instead of navigating — navigation unmounts
+          // this component and would silently drop the whole selection.
+          const openRow = () => {
+            if (selected.size > 0) toggleOne(p.id);
+            else openLead(p.id);
+          };
           return (
             <div key={p.id} className="av2-row" data-selected={isSelected} role="button" tabIndex={0}
-              onClick={() => setDrawer(p)}
-              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setDrawer(p); } }}
+              onClick={openRow}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openRow(); } }}
             >
               <button
                 type="button"
@@ -837,11 +504,6 @@ export default function AdminV2Prospects() {
         </AlertDialogContent>
       </AlertDialog>
 
-      <LeadDrawer
-        prospect={drawer}
-        onClose={() => setDrawer(null)}
-        onOpenLead={(id) => setDrawer({ id })}
-      />
     </div>
   );
 }

--- a/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
@@ -1,0 +1,176 @@
+/**
+ * Lead Profile page — person-first rail (name-per-signup + variant flag),
+ * draw voice vs reward voice per campaign, re-anchor navigation, the
+ * consumer-less (B4) fallback, the erased banner, and history scope.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import AdminV2LeadProfile from '../AdminV2LeadProfile';
+
+vi.mock('@/api/adminV2', () => ({
+  fetchProspectProfile: vi.fn(),
+  fetchAgentOptions: vi.fn(async () => []),
+  bulkAssign: vi.fn(),
+  bulkReturnToHeld: vi.fn(),
+  bulkDelete: vi.fn(),
+}));
+
+import { fetchProspectProfile } from '@/api/adminV2';
+
+const PROFILE = {
+  id: 'p1',
+  firstName: 'Shawn', lastName: 'Lee', phone: '+6591234567', email: 's@x.com',
+  leadStatus: 'new', quarantinedAt: null, quarantineReason: null,
+  priority: null, score: null, leadSource: 'qr_code',
+  createdAt: '2026-07-20T02:00:00Z',
+  sourceMetadata: { utm: { utm_source: 'fb' }, phoneVerifiedAt: '2026-07-20T02:00:00Z' },
+  consentMetadata: {},
+  campaign: { id: 'camp-1', name: 'Tokyo Lucky Draw', status: 'active' },
+  assignedAgent: null, externalAgent: null, externalAgentId: null, qrTag: null,
+  commissions: [],
+  activities: [{ id: 'a1', type: 'created', description: 'Lead captured', createdAt: '2026-07-20T02:00:00Z' }],
+  session: null, lyfeDelivery: null, signupProfile: null,
+  consumer: {
+    consumer: {
+      id: 'con-1', phone: '+6591234567', firstName: 'Shawn', lastName: 'Lee',
+      signupCount: 2, verifiedSignupCount: 2, firstSeenAt: '2026-05-01T02:00:00Z', erasedAt: null,
+    },
+    signups: [
+      {
+        prospectId: 'p1', firstName: 'Shawn', lastName: 'Lee',
+        campaign: { id: 'camp-1', name: 'Tokyo Lucky Draw', status: 'active' },
+        leadStatus: 'new', leadSource: 'qr_code', createdAt: '2026-07-20T02:00:00Z',
+        held: false, verified: true,
+        draw: {
+          drawId: 'd1', drawStatus: 'open', state: 'provisional_in', provisional: true,
+          chances: 10, multiplier: 10, boosted: true, boostVia: 'agent_scan',
+          boostedAt: '2026-07-21T02:00:00Z', boostReviewPending: false,
+          closesAt: '2026-10-30T16:00:00Z', boostClosesAt: null, notEligibleReason: null,
+          outcome: null, drawHistory: [],
+        },
+        consent: { contact: { granted: true, version: '2026-07-21-agree-all-v1', scope: 'campaign' } },
+        rewardDiagnostic: null,
+      },
+      {
+        prospectId: 'p2', firstName: 'Shawn', lastName: 'Tan',
+        campaign: { id: 'camp-2', name: 'NTUC Trial', status: 'active' },
+        leadStatus: 'won', leadSource: 'website', createdAt: '2026-05-01T02:00:00Z',
+        held: false, verified: true, draw: null,
+        consent: { contact: { granted: false } }, rewardDiagnostic: null,
+      },
+    ],
+    entitlements: [{
+      id: 'ent-1', status: 'redeemed', state: 'redeemed',
+      createdAt: '2026-05-01T03:00:00Z', unlockedAt: '2026-05-02T03:00:00Z', expiresAt: null,
+      rewardTitle: '1-for-1 latte', campaignName: 'NTUC Trial', campaignId: 'camp-2',
+      redeemedAt: '2026-05-03T03:00:00Z', unlockedVia: 'agent_scan', tokenHint: '9876',
+      drawLinked: false,
+      delivery: { email: { ok: true, kind: 'voucher', at: '2026-05-02T03:05:00Z' }, whatsapp: null },
+    }],
+    drawEntries: 1,
+    suppressions: [],
+    broadcasts: {
+      counts: { sent: 1 },
+      recent: [{ broadcastId: 'b1', subject: 'Promo', status: 'sent', reason: null, sentAt: '2026-06-01T02:00:00Z', at: '2026-06-01T02:00:00Z' }],
+    },
+  },
+};
+
+function Loc() {
+  const location = useLocation();
+  return <div data-testid="loc">{location.pathname}</div>;
+}
+
+function setup(id = 'p1') {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[`/admin/leads/${id}`]}>
+        <Routes>
+          <Route path="/admin/leads/:prospectId" element={<><AdminV2LeadProfile /><Loc /></>} />
+          <Route path="/AdminProspects" element={<div>LIST</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchProspectProfile.mockResolvedValue(JSON.parse(JSON.stringify(PROFILE)));
+});
+
+describe('AdminV2LeadProfile', () => {
+  it('renders the person header and asks for the profile enrichment', async () => {
+    setup();
+    expect(await screen.findByRole('heading', { name: 'Shawn Lee' })).toBeInTheDocument();
+    expect(fetchProspectProfile).toHaveBeenCalledWith('p1');
+    expect(screen.getByText(/2 SIGNUPS \(2 VERIFIED\)/)).toBeInTheDocument();
+  });
+
+  it('tells each campaign story: name used, draw voice, reward voice', async () => {
+    setup();
+    await screen.findAllByText('Tokyo Lucky Draw');
+    // Name-per-signup with the variant flagged (Shawn Tan ≠ canonical Shawn Lee).
+    expect(screen.getByText('Shawn Tan')).toBeInTheDocument();
+    expect(screen.getByText('name variant')).toBeInTheDocument();
+    // Draw voice — provisional, never asserted.
+    expect(screen.getByText(/On track for ×10 — consultant scan recorded/)).toBeInTheDocument();
+    // Reward voice on the other campaign + delivery receipt microline
+    // (history rows repeat the reward name, so match all).
+    expect(screen.getAllByText(/Redeemed ✓/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/1-for-1 latte/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/pass emailed ✓/)).toBeInTheDocument();
+  });
+
+  it('re-anchors to another signup by navigating to its URL', async () => {
+    setup();
+    const cards = await screen.findAllByText('NTUC Trial');
+    fireEvent.click(cards[0]); // the rail card (history captions repeat the name)
+    expect(screen.getByTestId('loc')).toHaveTextContent('/admin/leads/p2');
+  });
+
+  it('shows the ledger-backed consent and marketing touches', async () => {
+    setup();
+    await screen.findByText('Consent & reachability');
+    expect(screen.getByText(/yes · 2026-07-21-agree-all-v1/)).toBeInTheDocument();
+    expect(screen.getByText('1 sent')).toBeInTheDocument();
+  });
+
+  it('falls back to the signup profile for consumer-less (Retell) leads', async () => {
+    fetchProspectProfile.mockResolvedValue({
+      ...JSON.parse(JSON.stringify(PROFILE)),
+      consumer: null,
+      leadSource: 'call_bot',
+      sourceMetadata: { sentiment: 'Positive', fromNumber: '+6562773210', durationMs: 61000 },
+      signupProfile: { draw: null, entitlements: [], rewardDiagnostic: 'no_active_activation' },
+    });
+    setup();
+    await screen.findByText(/Retell voice lead/);
+    expect(screen.getByText('No reward attached to this campaign')).toBeInTheDocument();
+    expect(screen.getByText('Voice call')).toBeInTheDocument();
+    expect(screen.getByText('Positive')).toBeInTheDocument();
+  });
+
+  it('flags erased people and drops their draw claims', async () => {
+    const erased = JSON.parse(JSON.stringify(PROFILE));
+    erased.consumer.consumer.erasedAt = '2026-07-01T02:00:00Z';
+    erased.consumer.signups[0].draw = { state: 'erased_draw_unavailable' };
+    fetchProspectProfile.mockResolvedValue(erased);
+    setup();
+    await screen.findByText(/This person was erased/);
+    expect(screen.getByText(/Draw record unavailable \(erased\)/)).toBeInTheDocument();
+  });
+
+  it('filters history by scope', async () => {
+    setup();
+    await screen.findByText('History');
+    // Person-scope events include the second signup.
+    expect(screen.getByText(/Signed up as Shawn Tan/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'This signup' }));
+    expect(screen.queryByText(/Signed up as Shawn Tan/)).not.toBeInTheDocument();
+    expect(screen.getByText('Lead captured')).toBeInTheDocument();
+  });
+});

--- a/src/pages/adminv2/__tests__/AdminV2Prospects.navigation.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2Prospects.navigation.test.jsx
@@ -1,0 +1,71 @@
+/**
+ * Prospects list → Lead Profile navigation contract (drawer replacement):
+ * row click navigates carrying state.from; selection mode makes row clicks
+ * TOGGLE instead (navigation would drop the selection); the legacy ?lead=
+ * deep-link redirects to the page.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import AdminV2Prospects from '../AdminV2Prospects';
+
+vi.mock('@/api/adminV2', () => ({
+  fetchProspects: vi.fn(async () => ({
+    rows: [
+      { id: 'p1', firstName: 'Sam', lastName: 'Tan', phone: '+6589279750', email: 's@x.com', leadStatus: 'new', quarantinedAt: null, campaign: { name: 'Tokyo' }, assignedAgent: null, createdAt: '2026-07-20T02:00:00Z' },
+      { id: 'p2', firstName: 'Mei', lastName: 'Lim', phone: '+6581112222', email: 'm@x.com', leadStatus: 'new', quarantinedAt: null, campaign: { name: 'NTUC' }, assignedAgent: null, createdAt: '2026-07-19T02:00:00Z' },
+    ],
+    total: 2, page: 1, totalPages: 1,
+  })),
+  fetchAgentOptions: vi.fn(async () => []),
+  bulkAssign: vi.fn(),
+  bulkReturnToHeld: vi.fn(),
+  bulkDelete: vi.fn(),
+}));
+
+function Loc() {
+  const location = useLocation();
+  return <div data-testid="loc">{location.pathname}{location.search}</div>;
+}
+
+function setup(initial = '/AdminProspects') {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[initial]}>
+        <Routes>
+          <Route path="/AdminProspects" element={<><AdminV2Prospects /><Loc /></>} />
+          <Route path="/admin/leads/:prospectId" element={<Loc />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('AdminV2Prospects navigation', () => {
+  it('row click opens the lead profile page', async () => {
+    setup('/AdminProspects?status=new');
+    fireEvent.click(await screen.findByText('Sam Tan'));
+    expect(screen.getByTestId('loc')).toHaveTextContent('/admin/leads/p1');
+  });
+
+  it('selection mode: row clicks toggle instead of navigating', async () => {
+    setup();
+    await screen.findByText('Sam Tan');
+    fireEvent.click(screen.getAllByLabelText('Select')[0]); // checkbox → selection mode
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Mei Lim')); // row click TOGGLES, no navigation
+    expect(screen.getByText('2 selected')).toBeInTheDocument();
+    expect(screen.getByTestId('loc')).toHaveTextContent('/AdminProspects');
+    fireEvent.click(screen.getByText('Mei Lim')); // toggles back off
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
+  });
+
+  it('legacy ?lead= deep-links redirect to the page', async () => {
+    setup('/AdminProspects?q=sam&lead=p9');
+    expect(await screen.findByTestId('loc')).toHaveTextContent('/admin/leads/p9');
+  });
+});

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -79,6 +79,7 @@ const AdminV2Broadcasts = lazy(() => import('./adminv2/AdminV2Broadcasts'));
 const AdminV2BroadcastDetail = lazy(() => import('./adminv2/AdminV2BroadcastDetail'));
 const AdminV2Campaigns = lazy(() => import('./adminv2/AdminV2Campaigns'));
 const AdminV2CampaignDetail = lazy(() => import('./adminv2/AdminV2CampaignDetail'));
+const AdminV2LeadProfile = lazy(() => import('./adminv2/AdminV2LeadProfile'));
 const AdminV2Agents = lazy(() => import('./adminv2/AdminV2Agents'));
 const AdminV2AgentGroups = lazy(() => import('./adminv2/AdminV2AgentGroups'));
 const AdminV2Wallets = lazy(() => import('./adminv2/AdminV2Wallets'));
@@ -350,6 +351,17 @@ function PagesContent() {
  <ProtectedRoute requiredRole="admin">
  <AdminV2Shell>
  <AdminV2CampaignDetail />
+ </AdminV2Shell>
+ </ProtectedRoute>
+ }
+ />
+ )}
+ {ADMIN_V2 && (
+ <Route
+ path="/admin/leads/:prospectId" element={
+ <ProtectedRoute requiredRole="admin">
+ <AdminV2Shell>
+ <AdminV2LeadProfile />
  </AdminV2Shell>
  </ProtectedRoute>
  }


### PR DESCRIPTION
PR 2 of 2 for the **Admin Lead Profile page** (`docs/plans/admin-lead-profile-page.md` §3). **Stacked on #269** (the backend contract) — merge #269 first; GitHub will retarget this to `main` when the base branch is deleted.

## The page

`/admin/leads/:prospectId` (ADMIN_V2-gated, `AdminV2Shell`) — the drawer's replacement, built on `GET /prospects/:id?include=profile`:

- **Header**: canonical person name (spine projection), phone · signups (verified) · first seen, status/held/screening/erased chips, and the drawer's row actions (Assign ▾ / Return to held / Delete — delete returns to the list).
- **Campaigns rail** (the centerpiece): one card per signup, current one highlighted — campaign + date, **"as Shawn Tan"** with a `⚠ name variant` chip when it differs from the canonical name, then the outcome slot:
  - **Draw voice**, lifecycle-honest: "On track for ×10 — consultant scan recorded · closes 30 Oct" (open, provisional), "In the pool — 1 chance · ×10 boost applies at seal" (frozen), "Selected — claim by 5 Nov" / "🏆 Winner — claimed", "Not counted yet — phone unverified", "Excluded at freeze", "Draw void", "Draw record unavailable (erased)".
  - **Reward voice**: Reserved/Unlocked/Redeemed ✓/Expired/Blocked with title + expiry, a delivery-receipts microline ("pass emailed ✓ · WhatsApp ✓"), and the read-time diagnostic when nothing was issued ("No reward — quota full").
  - Clicking a signup **re-anchors** to that prospect's URL (state.from rides along, browser back works).
- **Right column**: This signup (contact incl. verified-at, attribution with UTM term/content + landing page, routing with the **named external buyer** and the **Lyfe delivery** row incl. the System-Agent "not sent" case, commissions, follow-up), Quiz (conditional), **Consent & reachability** (ledger-backed per-campaign consent with versions + suppressions + **DNC registry** + pinned draw-terms + marketing-touches summary; legacy-boolean fallback), the AI-screening section ported intact, and a **Voice call** card for Retell leads (their page would otherwise be empty — B4 fallback covers their draw/reward too).
- **History**: All / This signup / Person scoped strip composed client-side from the merged timeline (falling back to `activities[]` when the Supabase EF env is unset), signups, entitlement transitions, delivery receipts, broadcasts, Lyfe deliveries, screening attempts, and draw boosts.

## Navigation swap

Row click → page (carrying `state.from` so ← restores the exact filters); **selection mode**: with any rows selected a row click toggles the row instead of navigating (navigation unmounts the list and would silently drop the selection); legacy `?lead=` deep-links redirect (cleaned URL becomes `state.from`); GlobalSearch results, dashboard recent-leads, and campaign-detail latest-leads all link straight to the page. **`LeadDrawer` is deleted** (−346 lines).

## Tests

10 new RTL tests (campaign voices, name-variant, re-anchor, consumer-less fallback, erased banner, history scoping, selection-mode toggling, `?lead=` redirect) + the GlobalSearch assertion updated to the new URL. **Full vitest suite: 1920/1920 green. `vite build` clean. ESLint clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8jF5ZxuAZD3NazPQQMEfV