### PR TITLE
feat(admin): Lead Profile v2 — master-detail redesign

### DIFF
--- a/backend/src/services/consumerService.js
+++ b/backend/src/services/consumerService.js
@@ -413,11 +413,17 @@ export function makeConsumerService(overrides = {}) {
         attributes: [
           'id', 'firstName', 'lastName', 'phone', 'campaignId', 'leadStatus', 'leadSource',
           'createdAt', 'conversionDate', 'quarantinedAt', 'quarantineReason', 'sourceMetadata',
+          'externalAgentId',
           // consentMetadata carries the pinned draw-terms acceptance the draw
           // eligibility preview reads — profile mode only.
           ...(includeRaw ? ['consentMetadata'] : []),
         ],
-        include: [{ association: 'campaign', attributes: ['id', 'name', 'status'] }],
+        include: [
+          { association: 'campaign', attributes: ['id', 'name', 'status'] },
+          // Per-signup routing for the Lead Profile page (design handoff: the
+          // campaign row's AGENT segment + the assign menu's sub-line).
+          { association: 'assignedAgent', attributes: ['id', 'firstName', 'lastName'] },
+        ],
         order: [['createdAt', 'DESC'], ['id', 'DESC']],
       }),
       d.RewardEntitlement.findAll({
@@ -461,6 +467,10 @@ export function makeConsumerService(overrides = {}) {
         held: !!s.quarantinedAt,
         heldReason: s.quarantineReason || null,
         verified: phoneVerificationIsCurrent(s),
+        agentName: s.assignedAgent
+          ? `${s.assignedAgent.firstName || ''} ${s.assignedAgent.lastName || ''}`.trim() || null
+          : null,
+        externalBuyer: Boolean(s.externalAgentId),
       })),
       entitlements: entitlements.map((e) => ({
         id: e.id,

--- a/src/pages/adminv2/AdminV2LeadProfile.jsx
+++ b/src/pages/adminv2/AdminV2LeadProfile.jsx
@@ -1,246 +1,322 @@
 /**
- * Lead Profile — the full-page lead story (/admin/leads/:prospectId), replacing
- * the Prospects drawer (docs/plans/admin-lead-profile-page.md §3).
+ * Lead Profile — master-detail (design handoff: Lead Profile — Redesign v2).
  *
- * Person-first, prospect-anchored: the URL names one signup; the campaigns
- * rail tells the whole person's story (name used per signup, draw standing OR
- * reward state per campaign), and clicking another signup RE-ANCHORS by
- * navigating to that prospect's URL (back/forward and sharing come free).
- * Data: GET /prospects/:id?include=profile (PR #269) — one endpoint, admin-only
- * enrichments; the classic payload fields render instantly for everyone else.
+ * One route, two URL-addressable views:
+ *   /admin/leads/:id               → the SIGNUP DRILL-IN for that lead (outcome
+ *                                    hero + signup detail + screening) — what a
+ *                                    Prospects row click lands on.
+ *   /admin/leads/:id?view=profile  → the PERSON PROFILE (identity + campaigns
+ *                                    list + person-wide history). Campaign rows
+ *                                    navigate to that signup's drill-in.
+ *
+ * A sticky command bar (back link · compact identity · Delete / Return to held /
+ * Assign) rides above both views; Assign is a two-step menu from the profile
+ * (which campaign's lead? → which agent?) and a one-step menu from a drill-in.
+ * Data: GET /prospects/:id?include=profile (PR #269) — outcome voices are the
+ * same lifecycle-honest strings the backend contract defines.
  */
-import { useMemo, useState } from 'react';
-import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useMemo, useState, useEffect, useCallback } from 'react';
+import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useProspectProfile, useAgentOptions } from '@/hooks/queries/useAdminV2';
 import { bulkAssign, bulkReturnToHeld, bulkDelete } from '@/api/adminV2';
-import {
-  STATUS_LABELS, STATUS_CHIP_CLASS, SOURCE_LABELS, heldLabel, UTM_LABELS,
-} from '@/lib/adminV2/constants';
-import { fmtDateTime, fmtRelative, fmtSGDExact } from '@/lib/adminV2/format';
-import { Card, Chip, PageHeader, Skeleton, ErrorState, EmptyState } from '@/components/adminv2/primitives';
-import {
-  DropdownMenu, DropdownMenuTrigger, DropdownMenuContent,
-  DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator,
-} from '@/components/ui/dropdown-menu';
+import { STATUS_LABELS, SOURCE_LABELS, heldLabel } from '@/lib/adminV2/constants';
+import { fmtDateTime, fmtDate, fmtDay, fmtSGDExact } from '@/lib/adminV2/format';
+import { Card, Chip, Skeleton, ErrorState, EmptyState } from '@/components/adminv2/primitives';
 import {
   AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle,
   AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction,
 } from '@/components/ui/alert-dialog';
 
-// ── voice helpers ───────────────────────────────────────────────────────────
+// ── shared bits ─────────────────────────────────────────────────────────────
 
+const SGT = 'Asia/Singapore';
 const fullName = (o) => `${o?.firstName || ''} ${o?.lastName || ''}`.trim();
 const sameName = (a, b) => fullName(a).toLowerCase() === fullName(b).toLowerCase();
+const sgtTime = (v) => new Date(v).toLocaleTimeString('en-SG', { hour: '2-digit', minute: '2-digit', hour12: false, timeZone: SGT });
+const sgtDayKey = (v) => new Intl.DateTimeFormat('en-CA', { timeZone: SGT }).format(new Date(v));
+const sgtDayMonth = (v) => new Date(v).toLocaleDateString('en-SG', { day: 'numeric', month: 'short', timeZone: SGT });
+// Draw windows are stored as SGT end-of-day EXCLUSIVE instants (the first
+// moment AFTER the window — sgtTime.js); the operator-facing day is the last
+// INCLUDED instant, one ms earlier.
+const drawWindowDay = (v) => sgtDayMonth(new Date(new Date(v).getTime() - 1));
+const drawWindowDayUpper = (v) => drawWindowDay(v).toUpperCase();
+/** House phone display: +6591234567 → "+65 9123 4567" (root CLAUDE.md rule). */
+const fmtPhone = (v) => {
+  const m = /^\+65(\d{4})(\d{4})$/.exec(String(v || ''));
+  return m ? `+65 ${m[1]} ${m[2]}` : (v || null);
+};
+/** "Tokyo Getaway Lucky Draw" → "TOKYO" — the history rows' where-tag. */
+const campaignTag = (name) => (String(name || '').trim().split(/\s+/)[0] || '').slice(0, 10).toUpperCase();
 
+const BOOST_VIA_COPY = { agent_scan: 'consultant scan', agent_button: 'consultant confirmation' };
 const NOT_ELIGIBLE_COPY = {
   no_phone: 'no phone on record',
   phone_unverified: 'phone unverified',
   terms_not_pinned: 'draw terms not accepted',
   signed_up_after_close: 'signed up after entries closed',
 };
-
-const BOOST_VIA_COPY = { agent_scan: 'consultant scan', agent_button: 'consultant confirmation' };
-
-/** One line of draw truth per lifecycle state — provisional voice before seal. */
-function drawLine(draw) {
-  if (!draw) return null;
-  const d = fmtDateTime;
-  switch (draw.state) {
-    case 'no_draw_record':
-      return { tone: 'warn', text: 'Draw configured — no draw record yet' };
-    case 'erased_draw_unavailable':
-      return { tone: '', text: 'Draw record unavailable (erased)' };
-    case 'void':
-      return { tone: '', text: 'Draw void' };
-    case 'provisional_out':
-      return {
-        tone: 'warn',
-        text: `Not counted yet — ${NOT_ELIGIBLE_COPY[draw.notEligibleReason] || draw.notEligibleReason || 'not eligible'}`,
-      };
-    case 'provisional_in': {
-      const close = draw.closesAt ? ` · closes ${d(draw.closesAt)}` : '';
-      if (draw.boosted) {
-        return { tone: 'ok', text: `On track for ×${draw.multiplier} — ${BOOST_VIA_COPY[draw.boostVia] || 'boost'} recorded${close}` };
-      }
-      const pending = draw.boostReviewPending ? ' · boost pending ops review' : '';
-      const boostBy = draw.boostClosesAt || draw.closesAt;
-      return { tone: '', text: `1 chance so far · boost window open${boostBy ? ` until ${d(boostBy)}` : ''}${pending}` };
-    }
-    case 'frozen_in': {
-      const pending = draw.boostReviewPending ? ' · boost pending ops review' : '';
-      return draw.boosted
-        ? { tone: 'ok', text: `In the pool — 1 chance · ×${draw.multiplier} boost applies at seal` }
-        : { tone: '', text: `In the pool — 1 chance${pending}` };
-    }
-    case 'excluded_at_freeze':
-      return { tone: 'warn', text: 'Excluded at freeze' };
-    case 'sealed': {
-      const n = draw.chances;
-      const base = `${n} chance${n === 1 ? '' : 's'}`;
-      const o = draw.outcome;
-      if (!o) return { tone: '', text: `${base} · sealed` };
-      switch (o.status) {
-        case 'selected_pending':
-          return { tone: 'accent', text: `Selected — claim by ${d(o.claimDeadline)}` };
-        case 'selected_claimed':
-          return { tone: 'ok', text: `🏆 Winner — claimed ${d(o.claimedAt)}` };
-        case 'selected_declined':
-        case 'selected_unreachable':
-        case 'selected_ineligible':
-        case 'selected_unclaimed':
-          return { tone: 'warn', text: `Selected — ${o.status.replace('selected_', '')}, redrawn` };
-        case 'not_selected_final':
-          return { tone: '', text: `Not selected (${base})` };
-        case 'not_selected_yet':
-        default:
-          return { tone: '', text: `${base} · draw in progress` };
-      }
-    }
-    default:
-      return null;
-  }
-}
-
-const REWARD_STATE_COPY = {
-  reserved: { tone: 'accent', label: 'Reserved' },
-  unlocked: { tone: 'ok', label: 'Unlocked' },
-  redeemed: { tone: 'ok', label: 'Redeemed ✓' },
-  expired: { tone: '', label: 'Expired' },
-  cancelled: { tone: '', label: 'Cancelled' },
-  blocked: { tone: 'bad', label: 'Blocked' },
-};
-
 const DIAGNOSTIC_COPY = {
-  no_active_activation: 'No reward attached to this campaign',
-  allocation_exhausted: 'No reward — quota full',
-  phone_not_verified: 'No reward — phone unverified',
-  no_phone: 'No reward — no phone on record',
-  duplicate_phone: 'No reward — this phone already holds one',
-  offer_not_active: 'No reward — offer paused',
-  activation_ended: 'No reward — activation ended',
-  quarantined: 'No reward — lead is held',
-  not_issued_yet: 'Reward pending — issuance sweep hasn’t landed',
+  no_active_activation: 'no reward attached to this campaign',
+  allocation_exhausted: 'quota full',
+  phone_not_verified: 'phone unverified',
+  no_phone: 'no phone on record',
+  duplicate_phone: 'this phone already holds one',
+  offer_not_active: 'offer paused',
+  activation_ended: 'activation ended',
+  quarantined: 'lead is held',
+  not_issued_yet: 'issuance sweep hasn’t landed',
 };
 
-/** One line of reward truth per entitlement (non-draw voice). */
-function rewardLine(ent) {
-  const s = REWARD_STATE_COPY[ent.state] || { tone: '', label: ent.state || ent.status };
-  const bits = [ent.rewardTitle].filter(Boolean);
-  if (ent.state === 'redeemed' && ent.redeemedAt) bits.push(`redeemed ${fmtDateTime(ent.redeemedAt)}`);
-  else if (ent.state === 'unlocked' && ent.expiresAt) bits.push(`voucher live until ${fmtDateTime(ent.expiresAt)}`);
-  else if (ent.state === 'reserved' && ent.expiresAt) bits.push(`expires ${fmtDateTime(ent.expiresAt)}`);
-  return { tone: s.tone, label: s.label, detail: bits.join(' · ') };
+/**
+ * The outcome hero — the loudest element of a drill-in (24px/800). Returns
+ * { big, tail, tone, meta } in the exact lifecycle-honest voices of the
+ * backend contract; `tone` ∈ ink | ok | quiet.
+ */
+function heroFor(draw, rewards, diagnostic) {
+  if (draw) {
+    switch (draw.state) {
+      case 'provisional_in':
+        return draw.boosted
+          ? { big: `On track for ×${draw.multiplier}`, tail: ` — ${BOOST_VIA_COPY[draw.boostVia] || 'boost'} recorded`, tone: 'ink', meta: draw.closesAt ? `CLOSES ${drawWindowDayUpper(draw.closesAt)}` : null }
+          : { big: '1 chance so far', tail: draw.boostReviewPending ? ' — boost pending ops review' : ' — boost window open', tone: 'ink', meta: (draw.boostClosesAt || draw.closesAt) ? `BOOST BY ${drawWindowDayUpper(draw.boostClosesAt || draw.closesAt)}` : null };
+      case 'provisional_out':
+        return { big: 'Not counted yet', tail: ` — ${NOT_ELIGIBLE_COPY[draw.notEligibleReason] || 'not eligible'}`, tone: 'quiet', meta: draw.closesAt ? `CLOSES ${drawWindowDayUpper(draw.closesAt)}` : null };
+      case 'frozen_in':
+        return { big: 'In the pool', tail: draw.boosted ? ` — ×${draw.multiplier} boost applies at seal` : ' — 1 chance', tone: 'ink', meta: 'FROZEN' };
+      case 'excluded_at_freeze':
+        return { big: 'Excluded at freeze', tail: '', tone: 'quiet', meta: null };
+      case 'sealed': {
+        const n = draw.chances;
+        const chances = `${n} chance${n === 1 ? '' : 's'}`;
+        const o = draw.outcome;
+        if (!o) return { big: chances, tail: ' — sealed', tone: 'ink', meta: 'SEALED' };
+        switch (o.status) {
+          case 'selected_pending': return { big: 'Selected', tail: ` — claim by ${fmtDate(o.claimDeadline)}`, tone: 'ink', meta: `ATTEMPT ${o.attemptNo}` };
+          case 'selected_claimed': return { big: '🏆 Winner', tail: ` — claimed ${fmtDate(o.claimedAt)}`, tone: 'ok', meta: null };
+          case 'not_selected_final': return { big: 'Not selected', tail: ` — ${chances}`, tone: 'quiet', meta: null };
+          case 'not_selected_yet': return { big: chances, tail: ' — draw in progress', tone: 'ink', meta: null };
+          default: return { big: `Selected — ${o.status.replace('selected_', '')}`, tail: ', redrawn', tone: 'quiet', meta: `ATTEMPT ${o.attemptNo}` };
+        }
+      }
+      case 'void': return { big: 'Draw void', tail: '', tone: 'quiet', meta: null };
+      case 'erased_draw_unavailable': return { big: '⊘ Draw record unavailable', tail: '', tone: 'quiet', meta: 'ERASED' };
+      case 'no_draw_record': return { big: 'Draw configured', tail: ' — no draw record yet', tone: 'quiet', meta: null };
+      default: break;
+    }
+  }
+  const ent = rewards?.[0];
+  if (ent) {
+    const title = ent.rewardTitle ? ` — ${ent.rewardTitle}` : '';
+    switch (ent.state) {
+      case 'reserved': return { big: 'Reserved', tail: title, tone: 'ink', meta: ent.expiresAt ? `EXPIRES ${fmtDate(ent.expiresAt).toUpperCase()}` : null };
+      case 'unlocked': return { big: 'Unlocked', tail: title, tone: 'ok', meta: ent.expiresAt ? `VOUCHER UNTIL ${fmtDate(ent.expiresAt).toUpperCase()}` : null };
+      case 'redeemed': return { big: 'Redeemed ✓', tail: title, tone: 'ok', meta: ent.redeemedAt ? fmtDate(ent.redeemedAt).toUpperCase() : null };
+      case 'expired': return { big: 'Expired', tail: title, tone: 'quiet', meta: null };
+      case 'blocked': return { big: 'Blocked', tail: title, tone: 'quiet', meta: null };
+      default: return { big: ent.state || ent.status, tail: title, tone: 'quiet', meta: null };
+    }
+  }
+  if (diagnostic) {
+    return diagnostic === 'not_issued_yet'
+      ? { big: 'Reward pending', tail: ` — ${DIAGNOSTIC_COPY[diagnostic]}`, tone: 'quiet', meta: null }
+      : { big: 'No reward', tail: ` — ${DIAGNOSTIC_COPY[diagnostic] || diagnostic}`, tone: 'quiet', meta: null };
+  }
+  return { big: 'No outcome recorded', tail: '', tone: 'quiet', meta: null };
 }
 
-function receiptLine(delivery) {
-  if (!delivery) return null;
-  const part = (r, name) => (r ? `${name} ${r.ok ? '✓' : 'failed ✗'}` : null);
-  const bits = [part(delivery.email, 'emailed'), part(delivery.whatsapp, 'WhatsApp')].filter(Boolean);
-  return bits.length ? `pass ${bits.join(' · ')}` : null;
+/** Compact right-edge status chip on a campaigns-list row. */
+function rowChipFor(draw, rewards) {
+  if (draw) {
+    switch (draw.state) {
+      case 'provisional_in': return { label: draw.closesAt ? `open · closes ${drawWindowDay(draw.closesAt)}` : 'open', tone: '' };
+      case 'provisional_out': return { label: 'not counted', tone: 'warn' };
+      case 'frozen_in': return { label: 'in the pool', tone: '' };
+      case 'excluded_at_freeze': return { label: 'excluded', tone: 'warn' };
+      case 'sealed': {
+        const s = draw.outcome?.status;
+        if (s === 'selected_claimed') return { label: '🏆 winner', tone: 'ok' };
+        if (s === 'selected_pending') return { label: 'selected', tone: 'accent' };
+        if (s === 'not_selected_final') return { label: 'not selected', tone: '' };
+        return { label: 'sealed', tone: '' };
+      }
+      case 'void': return { label: 'void', tone: '' };
+      case 'erased_draw_unavailable': return { label: '⊘ erased', tone: 'bad' };
+      case 'no_draw_record': return { label: 'no draw record', tone: 'warn' };
+      default: break;
+    }
+  }
+  const ent = rewards?.[0];
+  if (ent) {
+    if (ent.state === 'redeemed') return { label: '✓ redeemed', tone: 'ok' };
+    if (ent.state === 'unlocked') return { label: 'unlocked', tone: 'ok' };
+    if (ent.state === 'reserved') return { label: 'reserved', tone: 'accent' };
+    return { label: ent.state || ent.status, tone: '' };
+  }
+  return null;
 }
 
-// ── history composition (client-side; the endpoint already has the facts) ────
+function receiptBits(delivery) {
+  if (!delivery) return [];
+  const bit = (r, label) => (r ? { ok: r.ok, label: `${label}${r.ok ? '' : ' failed'}` } : null);
+  return [bit(delivery.email, 'pass emailed'), bit(delivery.whatsapp, 'WhatsApp')].filter(Boolean);
+}
+
+// ── history composition (family + tag per row; grouped by SGT day) ──────────
+
+const FAMILY_TILE = {
+  signup: { glyph: '●', bg: 'var(--accent-soft)', fg: 'var(--accent-text)' },
+  boost: { glyph: '◆', bg: 'var(--hold-soft)', fg: 'var(--hold)' },
+  reward: { glyph: '◆', bg: 'var(--ok-soft)', fg: 'var(--ok)' },
+  screening: { glyph: '✦', bg: 'var(--ok-soft)', fg: 'var(--ok)' },
+  delivery: { glyph: '✉', bg: 'var(--surface-2)', fg: 'var(--ink-2)' },
+  arrival: { glyph: '○', bg: 'var(--surface-2)', fg: 'var(--ink-3)' },
+  generic: { glyph: '○', bg: 'var(--surface-2)', fg: 'var(--ink-2)' },
+};
 
 function buildHistory(p, journey) {
   const events = [];
-  const push = (at, label, { scope = 'signup', campaign = null, prospectId = null } = {}) => {
+  const push = (at, title, { detail = null, family = 'generic', quiet = false, tag = null } = {}) => {
     const t = at ? Date.parse(at) : NaN;
-    if (!Number.isNaN(t)) events.push({ at: t, label, scope, campaign, prospectId });
+    if (!Number.isNaN(t)) events.push({ at: t, title, detail, family, quiet, tag });
   };
+  const anchorTag = campaignTag(p.campaign?.name);
 
-  // Lifecycle + engagement — the merged timeline when the EF answered, else
-  // the prospect's own activities (plan §3.6: env-gated fallback).
   const rows = Array.isArray(p.timeline)
     ? p.timeline.map((x) => ({
       at: x.row?.createdAt || x.row?.created_at,
       label: x.entry?.label || x.row?.description || x.row?.type || 'activity',
     }))
     : (p.activities || []).map((a) => ({ at: a.createdAt, label: a.description || a.type }));
-  for (const r of rows) push(r.at, r.label, { prospectId: p.id });
+  for (const r of rows) push(r.at, r.label, { quiet: true, tag: anchorTag });
 
   for (const s of journey?.signups || []) {
-    push(s.createdAt, `Signed up as ${fullName(s) || '—'}`, {
-      scope: 'person', campaign: s.campaign?.name, prospectId: s.prospectId,
-    });
+    const tag = campaignTag(s.campaign?.name);
+    push(s.createdAt, `Signed up as ${fullName(s) || '—'}`, { detail: s.campaign?.name ? ` — ${s.campaign.name}` : null, family: 'signup', tag });
     if (s.draw?.boostedAt) {
-      push(s.draw.boostedAt, `Draw boost recorded — ${BOOST_VIA_COPY[s.draw.boostVia] || 'boost'}`, {
-        scope: 'person', campaign: s.campaign?.name, prospectId: s.prospectId,
-      });
+      push(s.draw.boostedAt, 'Draw boost recorded', { detail: ` — ${BOOST_VIA_COPY[s.draw.boostVia] || 'boost'}`, family: 'boost', tag });
     }
   }
   for (const e of journey?.entitlements || []) {
+    const tag = campaignTag(e.campaignName);
     const title = e.rewardTitle || 'reward';
-    push(e.createdAt, e.drawLinked ? 'Draw pass reserved' : `Reward reserved — ${title}`, { scope: 'person', campaign: e.campaignName });
-    if (e.unlockedAt) push(e.unlockedAt, e.drawLinked ? 'Draw boost confirmed' : `Voucher unlocked — ${title}`, { scope: 'person', campaign: e.campaignName });
-    if (e.redeemedAt) push(e.redeemedAt, `Redeemed — ${title}`, { scope: 'person', campaign: e.campaignName });
+    push(e.createdAt, e.drawLinked ? 'Draw pass reserved' : 'Reward reserved', { detail: e.drawLinked ? null : ` — ${title}`, family: 'reward', quiet: true, tag });
+    if (e.unlockedAt) push(e.unlockedAt, e.drawLinked ? 'Draw boost confirmed' : 'Voucher unlocked', { detail: e.drawLinked ? null : ` — ${title}`, family: e.drawLinked ? 'boost' : 'reward', tag });
+    if (e.redeemedAt) push(e.redeemedAt, 'Voucher redeemed ✓', { detail: ` — ${title}`, family: 'reward', tag });
     for (const ch of ['email', 'whatsapp']) {
       const r = e.delivery?.[ch];
-      if (r?.at) push(r.at, `${r.kind || 'pass'} ${ch} ${r.ok ? 'sent ✓' : 'send failed ✗'}`, { scope: 'person', campaign: e.campaignName });
+      if (r?.at) push(r.at, `${(r.kind || 'pass').replace(/_/g, ' ')} ${ch === 'email' ? 'emailed' : 'WhatsApp'} ${r.ok ? '✓' : '✗ failed'}`, { family: 'delivery', quiet: true, tag });
     }
   }
   for (const b of journey?.broadcasts?.recent || []) {
-    push(b.sentAt || b.at, `Marketing email — ${b.status}${b.reason ? ` (${b.reason.replace(/_/g, ' ')})` : ''}`, { scope: 'person' });
+    push(b.sentAt || b.at, `Marketing email — ${b.status}${b.reason ? ` (${b.reason.replace(/_/g, ' ')})` : ''}`, { family: 'delivery', quiet: true });
   }
   for (const ld of p.lyfeDelivery || []) {
-    push(ld.at, `Lyfe ${ld.eventType.replace('lead.', '')} — ${ld.status}${ld.reason ? ` (${ld.reason.replace(/_/g, ' ')})` : ''}`, { prospectId: p.id });
+    push(ld.at, `Lyfe ${ld.eventType.replace('lead.', '')} — ${ld.status}${ld.reason ? ` (${ld.reason.replace(/_/g, ' ')})` : ''}`, { family: 'delivery', quiet: true, tag: anchorTag });
   }
   if (p.session?.startedAt) {
-    push(p.session.startedAt, `Arrived — ${p.session.landingPath || 'landing page'}`, { prospectId: p.id });
+    push(p.session.startedAt, `Arrived — ${p.session.landingPath || 'landing page'}`, { family: 'arrival', quiet: true, tag: anchorTag });
   }
-  const attempts = Object.values(p.screeningMetadata?.attempts || {}).filter((a) => a?.startedAt);
-  for (const a of attempts) push(a.startedAt, `AI screening call — ${(a.outcome || 'attempted').replace(/_/g, ' ')}`, { prospectId: p.id });
-
+  for (const a of Object.values(p.screeningMetadata?.attempts || {})) {
+    if (!a?.startedAt) continue;
+    const outcome = (a.outcome || 'attempted').replace(/_/g, ' ');
+    push(a.startedAt, `Screening call — ${outcome}`, { family: 'screening', quiet: a.outcome !== 'qualified', tag: anchorTag });
+  }
   return events.sort((a, b) => b.at - a.at);
 }
 
-// ── small pieces ────────────────────────────────────────────────────────────
+// ── small presentational pieces ─────────────────────────────────────────────
 
-function Kv({ k, children }) {
-  return <div className="av2-kv"><span>{k}</span><span>{children ?? '—'}</span></div>;
+function KvRow({ label, mono = true, children }) {
+  return (
+    <div style={{ display: 'flex', gap: 12, fontSize: 12.5, padding: '4px 0', alignItems: 'baseline' }}>
+      <span style={{ width: 96, flex: 'none', color: 'var(--ink-3)' }}>{label}</span>
+      <span style={{ fontFamily: mono ? 'var(--font-mono)' : 'var(--font-ui)', color: 'var(--ink)', minWidth: 0, overflowWrap: 'anywhere' }}>{children}</span>
+    </div>
+  );
 }
 
-function SectionCaps({ children }) {
-  return <div className="av2-microcaps" style={{ marginBottom: 6 }}>{children}</div>;
+function ConsentKv({ label, state, legacy }) {
+  const granted = state ? state.granted : legacy;
+  if (granted === undefined || granted === null) return null;
+  return (
+    <div style={{ display: 'flex', gap: 12, fontSize: 12.5, padding: '4px 0', alignItems: 'baseline' }}>
+      <span style={{ width: 96, flex: 'none', color: 'var(--ink-3)' }}>{label}</span>
+      <span style={{ color: 'var(--ink)', fontWeight: 600 }}>
+        <span style={{ color: granted ? 'var(--ok)' : 'var(--bad)' }}>{granted ? '✓' : '✗'}</span>
+        {' '}{granted ? 'granted' : 'denied'}
+        {state?.scope === 'global' && <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--ink-3)' }}> · global</span>}
+        {!state && <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--ink-3)' }}> · legacy</span>}
+      </span>
+    </div>
+  );
 }
 
-function consentRow(state) {
-  if (!state) return '—';
-  return `${state.granted ? 'yes' : 'no'}${state.version ? ` · ${String(state.version).slice(0, 28)}` : ''}${state.scope === 'global' ? ' · global' : ''}`;
+function Disclosure({ label, count, children, indent = 34 }) {
+  return (
+    <details style={{ borderTop: '1px solid var(--line)' }}>
+      <summary style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '9px 16px', cursor: 'pointer', fontSize: 11.5, fontWeight: 700, color: 'var(--ink-2)' }}>
+        <span className="disc-caret" aria-hidden="true" style={{ color: 'var(--ink-3)', display: 'inline-block', transition: 'transform .12s ease' }}>▸</span>
+        {label}
+        <span style={{ flex: 1 }} />
+        {count && <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--ink-3)' }}>{count}</span>}
+      </summary>
+      <div style={{ padding: `2px 16px 12px ${indent}px` }}>{children}</div>
+    </details>
+  );
+}
+
+function GlyphTile({ family, size = 22 }) {
+  const t = FAMILY_TILE[family] || FAMILY_TILE.generic;
+  return (
+    <span aria-hidden="true" style={{ width: size, height: size, flex: 'none', borderRadius: size > 24 ? 9 : 7, background: t.bg, color: t.fg, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: size > 24 ? 13 : 11 }}>
+      {t.glyph}
+    </span>
+  );
 }
 
 // ── the page ────────────────────────────────────────────────────────────────
 
 export default function AdminV2LeadProfile() {
   const { prospectId } = useParams();
+  const [searchParams] = useSearchParams();
   const location = useLocation();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const view = searchParams.get('view') === 'profile' ? 'profile' : 'signup';
   const [confirmDelete, setConfirmDelete] = useState(false);
-  const [historyScope, setHistoryScope] = useState('all');
+  // Assign menu: null | 'campaign' | 'agent'; target = the signup being assigned.
+  const [menu, setMenu] = useState(null);
+  const [menuTarget, setMenuTarget] = useState(null);
+  useEffect(() => { setMenu(null); }, [prospectId, view]);
+  useEffect(() => {
+    if (!menu) return undefined;
+    const onKey = (e) => { if (e.key === 'Escape') setMenu(null); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [menu]);
 
-  // Back target: the list URL the operator came from (state.from contract,
-  // plan §3.8) — validated same-app path; reloads/direct links fall back.
   const from = typeof location.state?.from === 'string' && location.state.from.startsWith('/AdminProspects')
     ? location.state.from
     : '/AdminProspects';
-  const reAnchor = (id) => navigate(`/admin/leads/${id}`, { state: { from } });
+  const goSignup = useCallback((id) => navigate(`/admin/leads/${id}`, { state: { from } }), [navigate, from]);
+  const goProfile = useCallback(() => navigate(`/admin/leads/${prospectId}?view=profile`, { state: { from } }), [navigate, prospectId, from]);
 
   const profile = useProspectProfile(prospectId);
   const p = profile.data;
   const journey = p?.consumer || null;
   const person = journey?.consumer || null;
   const erased = Boolean(person?.erasedAt);
-
   const agentOptions = useAgentOptions(true);
+
   const invalidate = () => {
     queryClient.invalidateQueries({ queryKey: ['adminV2', 'prospects'] });
     queryClient.invalidateQueries({ queryKey: ['adminV2', 'prospectProfile'] });
     queryClient.invalidateQueries({ queryKey: ['adminV2', 'prospectDetail'] });
   };
   const assignMutation = useMutation({
-    mutationFn: ({ agentId }) => bulkAssign([prospectId], agentId),
+    mutationFn: ({ targetId, agentId }) => bulkAssign([targetId], agentId),
     onSuccess: (r, { agentName }) => {
       const n = r?.data?.affectedCount ?? 0;
       if (n > 0) toast.success(`Assigned to ${agentName}`);
@@ -271,64 +347,11 @@ export default function AdminV2LeadProfile() {
     onError: (e) => { toast.error(e?.message || 'Delete failed'); setConfirmDelete(false); },
   });
 
-  // Entitlements grouped by campaign for the rail's reward slot; draw-linked
-  // rows speak in the DRAW slot (boost evidence), never as vouchers.
-  const rewardsByCampaign = useMemo(() => {
-    const map = new Map();
-    for (const e of journey?.entitlements || []) {
-      if (e.drawLinked || !e.campaignId) continue;
-      const k = String(e.campaignId);
-      if (!map.has(k)) map.set(k, []);
-      map.get(k).push(e);
-    }
-    return map;
-  }, [journey]);
-
-  const history = useMemo(() => (p ? buildHistory(p, journey) : []), [p, journey]);
-  const filteredHistory = useMemo(() => history.filter((e) => {
-    if (historyScope === 'all') return true;
-    if (historyScope === 'signup') return String(e.prospectId || '') === String(prospectId);
-    return e.scope === 'person';
-  }), [history, historyScope, prospectId]);
-
-  if (profile.isLoading) {
-    return (
-      <div>
-        <Skeleton height={30} width={340} />
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 16, marginTop: 20 }}>
-          {[7, 5, 12].map((span, i) => <div key={i} style={{ gridColumn: `span ${span}` }}><Skeleton height={i === 2 ? 120 : 260} /></div>)}
-        </div>
-      </div>
-    );
-  }
-  if (profile.isError || !p) {
-    return (
-      <div>
-        <PageHeader title="Lead">
-          <Link to={from} className="av2-btn av2-btn--sm" style={{ textDecoration: 'none' }}>← Prospects</Link>
-        </PageHeader>
-        <ErrorState error={profile.error || new Error('This lead may have been deleted.')} onRetry={profile.refetch} />
-      </div>
-    );
-  }
-
-  const held = !!p.quarantinedAt;
-  const canonicalName = fullName(person) || fullName(p) || 'Lead';
-  const utm = p.sourceMetadata?.utm || {};
-  const sm = p.screeningMetadata || {};
-  const screeningAttempts = Object.values(sm.attempts || {})
-    .filter((a) => a && a.startedAt)
-    .sort((a, b) => String(a.startedAt).localeCompare(String(b.startedAt)));
-  const screeningCostCents = screeningAttempts.reduce((s, a) => s + (Number(a.costCents) || 0), 0);
-  const hasScreening = p.screeningVerdict || p.screeningMetadata || String(p.quarantineReason || '').startsWith('screening_');
-  const verdictDetail = sm.verdictDetail || {};
-  const quiz = p.sourceMetadata?.quiz || null;
-  const isVoiceLead = p.leadSource === 'call_bot';
-
-  // Rail rows: the journey's signups, else this prospect alone (B4 fallback).
-  const railSignups = journey?.signups?.length
-    ? journey.signups
-    : [{
+  // Rail rows: journey signups, else this prospect alone (consumer-less B4).
+  const railSignups = useMemo(() => {
+    if (journey?.signups?.length) return journey.signups;
+    if (!p) return [];
+    return [{
       prospectId: p.id,
       firstName: p.firstName,
       lastName: p.lastName,
@@ -336,375 +359,531 @@ export default function AdminV2LeadProfile() {
       leadStatus: p.leadStatus,
       leadSource: p.leadSource,
       createdAt: p.createdAt,
-      held,
+      held: !!p.quarantinedAt,
       verified: false,
       draw: p.signupProfile?.draw ?? null,
       rewardDiagnostic: p.signupProfile?.rewardDiagnostic ?? null,
+      agentName: p.assignedAgent ? fullName(p.assignedAgent) : null,
+      externalBuyer: Boolean(p.externalAgentId),
       _fallback: true,
     }];
-  const fallbackRewards = p.signupProfile?.entitlements?.filter((e) => !e.drawLinked) || [];
+  }, [journey, p]);
 
-  // Current-signup consent (ledger, scoped) with legacy-boolean fallback.
-  const currentSignup = journey?.signups?.find((s) => String(s.prospectId) === String(prospectId)) || null;
-  const consent = currentSignup?.consent || null;
+  const rewardsByCampaign = useMemo(() => {
+    const map = new Map();
+    const list = journey?.entitlements || p?.signupProfile?.entitlements || [];
+    for (const e of list) {
+      if (e.drawLinked) continue;
+      const k = String(e.campaignId || (p?.signupProfile ? p?.campaign?.id : '') || '');
+      if (!k) continue;
+      if (!map.has(k)) map.set(k, []);
+      map.get(k).push(e);
+    }
+    return map;
+  }, [journey, p]);
+
+  const rewardsFor = useCallback(
+    (s) => (s.campaign ? rewardsByCampaign.get(String(s.campaign.id)) || [] : []),
+    [rewardsByCampaign],
+  );
+
+  const history = useMemo(() => (p ? buildHistory(p, journey) : []), [p, journey]);
+  const historyDays = useMemo(() => {
+    const days = [];
+    let current = null;
+    for (const e of history.slice(0, 120)) {
+      const key = sgtDayKey(e.at);
+      if (!current || current.key !== key) { current = { key, events: [] }; days.push(current); }
+      current.events.push(e);
+    }
+    return days;
+  }, [history]);
+
+  const currentSignup = railSignups.find((s) => String(s.prospectId) === String(prospectId)) || railSignups[0] || null;
+  const consent = journey?.signups?.find((s) => String(s.prospectId) === String(prospectId))?.consent
+    || currentSignup?.consent || null;
+
+  if (profile.isLoading) {
+    return (
+      <div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: 16 }}>
+          <Skeleton height={280} style={{ borderRadius: 14 }} />
+          <Skeleton height={280} style={{ borderRadius: 14 }} />
+          <div style={{ gridColumn: '1 / -1' }}><Skeleton height={300} style={{ borderRadius: 14 }} /></div>
+        </div>
+      </div>
+    );
+  }
+  if (profile.isError || !p) {
+    return (
+      <div>
+        <Link to={from} className="av2-btn av2-btn--sm" style={{ textDecoration: 'none', marginBottom: 16, display: 'inline-flex' }}>← Prospects</Link>
+        <ErrorState error={profile.error || new Error("Couldn't load this lead — it may have been deleted.")} onRetry={profile.refetch} />
+      </div>
+    );
+  }
+
+  const held = !!p.quarantinedAt;
+  const canonicalName = fullName(person) || fullName(p) || 'Lead';
+  const phone = fmtPhone(person?.phone || p.phone);
+  const isVoiceLead = p.leadSource === 'call_bot';
+  const dob = p.demographics?.dateOfBirth || null;
+  const quiz = p.sourceMetadata?.quiz || null;
+  const sm = p.screeningMetadata || {};
+  const verdictDetail = sm.verdictDetail || {};
+  const screeningAttempts = Object.values(sm.attempts || {})
+    .filter((a) => a && a.startedAt)
+    .sort((a, b) => String(a.startedAt).localeCompare(String(b.startedAt)));
+  const screeningCostCents = screeningAttempts.reduce((s, a) => s + (Number(a.costCents) || 0), 0);
+  const hasScreening = p.screeningVerdict || p.screeningMetadata || String(p.quarantineReason || '').startsWith('screening_');
+
+  const assignButtonLabel = view === 'profile' ? 'Assign to agent ▾' : 'Assign this lead ▾';
+  const openAssign = () => {
+    if (menu) { setMenu(null); return; }
+    if (view === 'profile' && railSignups.length > 1) { setMenu('campaign'); setMenuTarget(null); }
+    else { setMenu('agent'); setMenuTarget(currentSignup?.prospectId || prospectId); }
+  };
+  const menuTargetSignup = railSignups.find((s) => String(s.prospectId) === String(menuTarget)) || null;
+
+  const consentVersions = consent
+    ? [...new Set(Object.values(consent).map((c) => c?.version).filter(Boolean))]
+    : [];
+
+  // ── signup drill-in pieces ──
+  const currentDraw = currentSignup?.draw || null;
+  const currentRewards = currentSignup ? rewardsFor(currentSignup).length ? rewardsFor(currentSignup) : (p.signupProfile?.entitlements?.filter((e) => !e.drawLinked) || []) : [];
+  const hero = heroFor(currentDraw, currentRewards, currentSignup?.rewardDiagnostic);
+  const heroReceipts = [
+    ...receiptBits(currentRewards[0]?.delivery),
+    ...((journey?.entitlements || p?.signupProfile?.entitlements || [])
+      .filter((e) => e.drawLinked && String(e.campaignId || '') === String(currentSignup?.campaign?.id || ''))
+      .slice(0, 1)
+      .flatMap((e) => receiptBits(e.delivery))),
+  ];
+  const heroToneColor = hero.tone === 'ok' ? 'var(--ok)' : hero.tone === 'quiet' ? 'var(--ink-2)' : 'var(--ink)';
 
   return (
     <div>
-      <PageHeader
-        title={canonicalName}
-        meta={[
-          person?.phone || p.phone || null,
-          person ? `${person.signupCount} SIGNUP${person.signupCount === 1 ? '' : 'S'} (${person.verifiedSignupCount} VERIFIED)` : null,
-          person?.firstSeenAt ? `FIRST SEEN ${fmtDateTime(person.firstSeenAt)}` : `CREATED ${fmtDateTime(p.createdAt)}`,
-        ].filter(Boolean).join(' · ')}
-      >
-        <Link to={from} className="av2-btn av2-btn--sm" style={{ textDecoration: 'none' }}>← Prospects</Link>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button type="button" className="av2-btn av2-btn--sm" disabled={assignMutation.isPending}>Assign to agent ▾</button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent className="admin-v2" align="end">
-            <DropdownMenuLabel>Assign to</DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            {(agentOptions.data || []).map((a) => (
-              <DropdownMenuItem key={a.id} onSelect={() => assignMutation.mutate({ agentId: a.id, agentName: a.name })}>
-                {a.name}
-              </DropdownMenuItem>
-            ))}
-            {agentOptions.isLoading && <DropdownMenuItem disabled>Loading agents…</DropdownMenuItem>}
-          </DropdownMenuContent>
-        </DropdownMenu>
+      {/* ── Sticky command bar (all views) ── */}
+      <div style={{ position: 'sticky', top: 64, zIndex: 30, display: 'flex', alignItems: 'center', gap: 10, padding: '12px 0', background: 'var(--canvas)', borderBottom: '1px solid var(--line)', marginBottom: 16 }}>
+        <Link to={from} style={{ fontSize: 12.5, fontWeight: 700, color: 'var(--accent-text)', textDecoration: 'none', flex: 'none' }}>← Prospects</Link>
+        <span aria-hidden="true" style={{ width: 1, height: 16, background: 'var(--line-strong)', flex: 'none' }} />
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, letterSpacing: '.08em', color: 'var(--ink-3)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          {`${canonicalName.toUpperCase()}${phone ? ` · ${phone}` : ''}`}
+        </span>
+        <span style={{ flex: 1 }} />
+        <button type="button" className="av2-btn av2-btn--sm" style={{ borderColor: 'var(--line-strong)', color: 'var(--bad)' }} onClick={() => setConfirmDelete(true)}>Delete</button>
         <button type="button" className="av2-btn av2-btn--sm" disabled={returnMutation.isPending} onClick={() => returnMutation.mutate()}>Return to held</button>
-        <button type="button" className="av2-btn av2-btn--sm" style={{ borderColor: 'var(--bad)', color: 'var(--bad)' }} onClick={() => setConfirmDelete(true)}>Delete</button>
-      </PageHeader>
-
-      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 16, marginTop: -6 }}>
-        <Chip tone={STATUS_CHIP_CLASS[p.leadStatus]?.replace('av2-chip--', '') || ''}>{STATUS_LABELS[p.leadStatus] || p.leadStatus}</Chip>
-        {held && <Chip tone="hold" glyph="◆">{heldLabel(p).full}</Chip>}
-        {!held && !p.assignedAgent && !p.externalAgentId && <Chip tone="warn">Unassigned</Chip>}
-        {p.screeningVerdict && (
-          <Chip tone={p.screeningVerdict === 'qualified' ? 'ok' : 'bad'} glyph={p.screeningVerdict === 'qualified' ? '✓' : '✗'}>
-            {p.screeningVerdict === 'qualified' ? 'AI qualified' : 'AI failed'}
-          </Chip>
-        )}
-        {p.priority && <Chip>{p.priority}</Chip>}
-        {Number.isFinite(Number(p.score)) && p.score !== null && <Chip>score {p.score}</Chip>}
-        {erased && <Chip tone="bad">erased</Chip>}
+        <div style={{ position: 'relative', flex: 'none' }}>
+          <button type="button" className="av2-btn av2-btn--sm av2-btn--primary" aria-haspopup="menu" aria-expanded={!!menu} disabled={assignMutation.isPending} onClick={openAssign}>
+            {assignButtonLabel}
+          </button>
+          {menu && (
+            <>
+              <div onClick={() => setMenu(null)} aria-hidden="true" style={{ position: 'fixed', inset: 0, zIndex: 60 }} />
+              <div role="menu" aria-label="Assign lead" style={{ position: 'absolute', right: 0, top: 40, zIndex: 70, width: 264, background: 'var(--surface)', border: '1px solid var(--line-strong)', borderRadius: 12, boxShadow: 'var(--shadow)', padding: 8, boxSizing: 'border-box' }}>
+                {menu === 'campaign' && (
+                  <>
+                    <div style={{ fontSize: 10.5, fontWeight: 700, letterSpacing: '.05em', textTransform: 'uppercase', color: 'var(--ink-2)', padding: '4px 10px 6px' }}>Which campaign's lead?</div>
+                    {railSignups.map((s) => (
+                      <button
+                        key={s.prospectId}
+                        type="button"
+                        role="menuitem"
+                        onClick={() => { setMenu('agent'); setMenuTarget(s.prospectId); }}
+                        style={{ display: 'block', width: '100%', boxSizing: 'border-box', textAlign: 'left', background: 'transparent', border: 'none', borderRadius: 8, padding: '8px 10px', cursor: 'pointer', fontFamily: 'var(--font-ui)' }}
+                      >
+                        <span style={{ display: 'block', fontSize: 13, fontWeight: 700, color: 'var(--ink)' }}>{s.campaign?.name || 'No campaign'}</span>
+                        <span style={{ display: 'block', fontFamily: 'var(--font-mono)', fontSize: 10.5, color: 'var(--ink-3)', marginTop: 1 }}>
+                          agent: {s.agentName || (s.externalBuyer ? 'external buyer' : 'unassigned')}
+                        </span>
+                      </button>
+                    ))}
+                  </>
+                )}
+                {menu === 'agent' && (
+                  <>
+                    <div style={{ fontSize: 10.5, fontWeight: 700, letterSpacing: '.05em', textTransform: 'uppercase', color: 'var(--ink-2)', padding: '4px 10px 6px' }}>
+                      Assign {menuTargetSignup?.campaign?.name || 'this'} lead to
+                    </div>
+                    {(agentOptions.data || []).map((a) => (
+                      <button
+                        key={a.id}
+                        type="button"
+                        role="menuitem"
+                        onClick={() => { setMenu(null); assignMutation.mutate({ targetId: menuTarget || prospectId, agentId: a.id, agentName: a.name }); }}
+                        style={{ display: 'flex', alignItems: 'baseline', gap: 8, width: '100%', boxSizing: 'border-box', textAlign: 'left', background: 'transparent', border: 'none', borderRadius: 8, padding: '8px 10px', cursor: 'pointer', fontFamily: 'var(--font-ui)' }}
+                      >
+                        <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--ink)', flex: 1 }}>{a.name}</span>
+                        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--ink-3)' }}>LYFE</span>
+                      </button>
+                    ))}
+                    {agentOptions.isLoading && <div style={{ fontSize: 12, color: 'var(--ink-3)', padding: '8px 10px' }}>Loading agents…</div>}
+                  </>
+                )}
+              </div>
+            </>
+          )}
+        </div>
       </div>
 
+      {/* ── Page-level banners ── */}
       {erased && (
-        <div className="av2-card" style={{ padding: '10px 14px', marginBottom: 16, borderColor: 'var(--bad)' }}>
-          <span style={{ fontSize: 12.5, color: 'var(--ink-2)' }}>
-            This person was erased on {fmtDateTime(person.erasedAt)} — the profile shows only what the
-            allowlist rebuild kept. Draw entries are unjoinable by design.
-          </span>
+        <div role="status" style={{ display: 'flex', alignItems: 'center', gap: 10, background: 'var(--bad-soft)', color: 'var(--bad)', border: '1px solid var(--line)', borderRadius: 10, padding: '10px 14px', marginBottom: 16, fontSize: 12.5, fontWeight: 700 }}>
+          <span aria-hidden="true" style={{ flex: 'none' }}>⊘</span>
+          This person was erased on {fmtDate(person.erasedAt)} — profile shows only what the allowlist rebuild kept.
+        </div>
+      )}
+      {!journey && (
+        <div role="status" style={{ display: 'flex', alignItems: 'center', gap: 10, background: 'var(--surface)', color: 'var(--ink-2)', border: '1px solid var(--line-strong)', borderRadius: 10, padding: '10px 14px', marginBottom: 16, fontSize: 12.5, fontWeight: 600 }}>
+          <span aria-hidden="true" style={{ flex: 'none', color: 'var(--ink-3)' }}>{isVoiceLead ? '☏' : '○'}</span>
+          {isVoiceLead
+            ? 'Retell voice lead — the call carries no caller phone, so there is no cross-campaign identity.'
+            : 'No linked person yet (phone unverified) — showing this signup only.'}
         </div>
       )}
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 16 }}>
-        {/* ── Campaigns rail — the person's whole story ── */}
-        <Card
-          span={7}
-          title="Campaigns"
-          meta={journey ? `${railSignups.length} SIGNUP${railSignups.length === 1 ? '' : 'S'}` : undefined}
-        >
-          {!journey && (
-            <div className="av2-caption" style={{ padding: '8px 14px 0' }}>
-              {isVoiceLead
-                ? 'Retell voice lead — the call carries no caller phone, so there is no cross-campaign identity.'
-                : 'No linked person yet (phone unverified) — showing this signup only.'}
-            </div>
-          )}
-          <div style={{ display: 'grid', gap: 0 }}>
-            {railSignups.map((s) => {
-              const isCurrent = String(s.prospectId) === String(prospectId);
-              const nameVariant = person && fullName(s) && !sameName(s, person);
-              const dl = drawLine(s.draw);
-              const rewards = s._fallback
-                ? fallbackRewards
-                : (s.campaign ? rewardsByCampaign.get(String(s.campaign.id)) || [] : []);
-              const diagnostic = !dl && rewards.length === 0 ? (DIAGNOSTIC_COPY[s.rewardDiagnostic] || null) : null;
-              return (
-                <button
-                  key={s.prospectId}
-                  type="button"
-                  onClick={() => { if (!isCurrent) reAnchor(s.prospectId); }}
-                  aria-current={isCurrent ? 'page' : undefined}
-                  style={{
-                    textAlign: 'left', background: isCurrent ? 'var(--surface-2)' : 'none',
-                    border: 'none', borderTop: '1px solid var(--line)',
-                    borderLeft: isCurrent ? '3px solid var(--accent)' : '3px solid transparent',
-                    padding: '12px 14px', cursor: isCurrent ? 'default' : 'pointer',
-                    color: 'var(--ink)', fontFamily: 'var(--font-ui)', display: 'grid', gap: 5,
-                  }}
-                >
-                  <span style={{ display: 'flex', alignItems: 'baseline', gap: 8, flexWrap: 'wrap' }}>
-                    <span style={{ fontSize: 13.5, fontWeight: 800 }}>{s.campaign?.name || 'No campaign'}</span>
-                    {s.campaign?.status && s.campaign.status !== 'active' && <Chip>{s.campaign.status}</Chip>}
-                    {isCurrent && <Chip tone="accent">viewing</Chip>}
-                    <span style={{ flex: 1 }} />
-                    <span className="av2-mono" style={{ fontSize: 10.5, color: 'var(--ink-3)' }} title={fmtDateTime(s.createdAt)}>
-                      {fmtRelative(s.createdAt)}
-                    </span>
-                  </span>
-                  <span style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap', fontSize: 12, color: 'var(--ink-2)' }}>
-                    <span>as <strong style={{ color: 'var(--ink)' }}>{fullName(s) || '—'}</strong></span>
-                    {nameVariant && <Chip tone="warn" glyph="⚠">name variant</Chip>}
-                    <Chip>{SOURCE_LABELS[s.leadSource] || s.leadSource}</Chip>
-                    {s.verified ? <Chip tone="ok" glyph="✓">verified</Chip> : <Chip>unverified</Chip>}
-                    {s.held && <Chip tone="hold" glyph="◆">held</Chip>}
-                  </span>
-                  {dl && (
-                    <span style={{ fontSize: 12.5, color: dl.tone === 'warn' ? 'var(--warn)' : dl.tone === 'ok' ? 'var(--ok)' : dl.tone === 'accent' ? 'var(--accent-text)' : 'var(--ink)' }}>
-                      🎟 {dl.text}
-                    </span>
+      {view === 'profile' ? (
+        <>
+          {/* ── Person profile view ── */}
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: 16, alignItems: 'start', marginBottom: 16 }}>
+            <section className="av2-card">
+              <div style={{ padding: '16px 18px 14px', borderBottom: '1px solid var(--line)' }}>
+                <div className="av2-microcaps">Person</div>
+                <h1 style={{ margin: '6px 0 0', fontSize: 22, fontWeight: 800, letterSpacing: '-0.015em', color: 'var(--ink)', lineHeight: 1.1 }}>{canonicalName}</h1>
+                {phone && <div style={{ fontFamily: 'var(--font-mono)', fontSize: 13, color: 'var(--ink)', letterSpacing: '.02em', marginTop: 5 }}>{phone}</div>}
+                <div style={{ fontSize: 11.5, fontWeight: 600, color: 'var(--ink-2)', marginTop: 4 }}>
+                  {person
+                    ? `${person.signupCount} signup${person.signupCount === 1 ? '' : 's'} (${person.verifiedSignupCount} verified) · first seen ${fmtDate(person.firstSeenAt)}`
+                    : '1 signup · no cross-campaign identity'}
+                </div>
+                <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginTop: 8 }}>
+                  <Chip tone="accent">{STATUS_LABELS[p.leadStatus] || p.leadStatus}</Chip>
+                  {held && <Chip tone="hold" glyph="◆">{heldLabel(p).full}</Chip>}
+                  {p.screeningVerdict && (
+                    <Chip tone={p.screeningVerdict === 'qualified' ? 'ok' : 'bad'} glyph={p.screeningVerdict === 'qualified' ? '✓' : '✗'}>
+                      {p.screeningVerdict === 'qualified' ? 'AI qualified' : 'AI failed'}
+                    </Chip>
                   )}
-                  {rewards.map((e) => {
-                    const rl = rewardLine(e);
-                    const receipts = receiptLine(e.delivery);
-                    return (
-                      <span key={e.id} style={{ display: 'grid', gap: 2 }}>
-                        <span style={{ fontSize: 12.5 }}>
-                          🎁 <strong>{rl.label}</strong>{rl.detail ? ` — ${rl.detail}` : ''}
-                        </span>
-                        {receipts && <span className="av2-caption">{receipts}</span>}
-                      </span>
-                    );
-                  })}
-                  {diagnostic && <span className="av2-caption">{diagnostic}</span>}
-                </button>
-              );
-            })}
-          </div>
-        </Card>
-
-        {/* ── Right column ── */}
-        <div style={{ gridColumn: 'span 5', display: 'grid', gap: 16, alignContent: 'start' }}>
-          <Card title="This signup">
-            <div style={{ padding: '4px 14px 12px', display: 'grid', gap: 14 }}>
-              <section>
-                <SectionCaps>Contact</SectionCaps>
-                <Kv k="phone">
-                  {p.phone || '—'}
-                  {p.sourceMetadata?.phoneVerifiedAt && <span className="av2-caption" title={fmtDateTime(p.sourceMetadata.phoneVerifiedAt)}> · verified ✓</span>}
-                </Kv>
-                <Kv k="email">{p.email || '—'}</Kv>
-              </section>
-              <section>
-                <SectionCaps>Attribution</SectionCaps>
-                <Kv k="source">{SOURCE_LABELS[p.leadSource] || p.leadSource}</Kv>
-                {utm.utm_source && <Kv k="utm_source">{UTM_LABELS[utm.utm_source] || utm.utm_source}</Kv>}
-                {utm.utm_medium && <Kv k="utm_medium">{utm.utm_medium}</Kv>}
-                {utm.utm_campaign && <Kv k="utm_campaign">{utm.utm_campaign}</Kv>}
-                {p.session?.utm?.term && <Kv k="utm_term">{p.session.utm.term}</Kv>}
-                {p.session?.utm?.content && <Kv k="utm_content">{p.session.utm.content}</Kv>}
-                {p.session?.landingPath && <Kv k="landing">{p.session.landingPath}</Kv>}
-                {p.qrTag && <Kv k="qr tag">{p.qrTag.name}</Kv>}
-                <Kv k="campaign">
-                  {p.campaign
-                    ? <Link to={`/admin/campaigns/${p.campaign.id}`} style={{ color: 'var(--accent-text)', textDecoration: 'none', fontWeight: 700 }}>{p.campaign.name} ↗</Link>
-                    : '—'}
-                </Kv>
-              </section>
-              <section>
-                <SectionCaps>Routing</SectionCaps>
-                <Kv k="agent">
-                  {p.assignedAgent
-                    ? fullName(p.assignedAgent)
-                    : p.externalAgent
-                      ? `${p.externalAgent.fullName || 'External buyer'}${p.externalAgent.agency ? ` (${p.externalAgent.agency})` : ''}`
-                      : p.externalAgentId ? 'external buyer' : held ? 'held' : 'unassigned'}
-                </Kv>
-                {held && <Kv k="held since">{fmtDateTime(p.quarantinedAt)}</Kv>}
-                {held && <Kv k="reason">{heldLabel(p).full || p.quarantineReason || '—'}</Kv>}
-                <Kv k="lyfe delivery">
-                  {p.lyfeDelivery
-                    ? p.lyfeDelivery.map((ld) => `${ld.eventType.replace('lead.', '')}: ${ld.status === 'success' ? '✓ delivered' : ld.status === 'failed' ? `✗ failed ×${ld.attempts}${ld.reason ? ` (${ld.reason.replace(/_/g, ' ')})` : ''}` : '… pending'}`).join(' · ')
-                    : 'not sent — no app destination'}
-                </Kv>
-                {p.nextFollowUpDate && <Kv k="follow-up">{fmtDateTime(p.nextFollowUpDate)}</Kv>}
-                {(p.commissions || []).map((cm) => (
-                  <Kv key={cm.id} k="commission">{cm.type} · {cm.status}</Kv>
-                ))}
-              </section>
-            </div>
-          </Card>
-
-          {quiz && (
-            <Card title="Quiz">
-              <div style={{ padding: '4px 14px 12px' }}>
-                {Object.entries(quiz)
-                  .filter(([, v]) => ['string', 'number', 'boolean'].includes(typeof v))
-                  .slice(0, 12)
-                  .map(([k, v]) => <Kv key={k} k={k}>{String(v)}</Kv>)}
+                  {erased && <Chip tone="bad" glyph="⊘">erased</Chip>}
+                </div>
               </div>
-            </Card>
-          )}
+              <div style={{ padding: '10px 18px 8px' }}>
+                <div className="av2-microcaps" style={{ padding: '2px 0 4px' }}>Consent &amp; reachability</div>
+                {!erased && (p.email || person?.email) && <KvRow label="email">{p.email || person?.email}</KvRow>}
+                {!erased && dob && <KvRow label="date of birth">{fmtDate(dob)}</KvRow>}
+                <ConsentKv label="marketing" state={consent?.contact} legacy={p.sourceMetadata?.consent_contact} />
+                <ConsentKv label="terms" state={consent?.campaign_terms} legacy={p.sourceMetadata?.consent_terms} />
+                <ConsentKv label="third-party" state={consent?.third_party} legacy={p.sourceMetadata?.consent_third_party} />
+                {p.dncStatus && (
+                  <div style={{ display: 'flex', gap: 12, fontSize: 12.5, padding: '4px 0', alignItems: 'baseline' }}>
+                    <span style={{ width: 96, flex: 'none', color: 'var(--ink-3)' }}>DNC</span>
+                    <span style={{ color: 'var(--ink)', fontWeight: 600 }}>
+                      {(p.dncNoVoiceCall || p.dncNoTextMessage)
+                        ? `no ${[p.dncNoVoiceCall && 'voice', p.dncNoTextMessage && 'SMS'].filter(Boolean).join(' + ')}`
+                        : p.dncStatus}
+                      {p.dncCheckedAt && (
+                        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--ink-3)' }}>
+                          {' '}· checked {fmtDate(p.dncCheckedAt)}{p.dncValidUntil ? ` · valid to ${fmtDate(p.dncValidUntil)}` : ''}
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                )}
+                {journey?.broadcasts && Object.keys(journey.broadcasts.counts).length > 0 && (
+                  <div style={{ display: 'flex', gap: 12, fontSize: 12.5, padding: '4px 0', alignItems: 'baseline' }}>
+                    <span style={{ width: 96, flex: 'none', color: 'var(--ink-3)' }}>broadcasts</span>
+                    <span style={{ color: 'var(--ink)', fontWeight: 600 }}>
+                      {Object.values(journey.broadcasts.counts).reduce((a, b) => a + b, 0)} — {Object.entries(journey.broadcasts.counts).map(([k, v]) => `${v} ${k}`).join(' · ')}
+                      {journey.suppressions?.length > 0 && <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--ink-3)' }}> · suppressed</span>}
+                    </span>
+                  </div>
+                )}
+              </div>
+              {consentVersions.length > 0 && (
+                <Disclosure label="Raw consent versions" count={`${consentVersions.length} VERSION${consentVersions.length === 1 ? '' : 'S'}`} indent={36}>
+                  {Object.entries(consent || {}).filter(([, c]) => c?.version).map(([kind, c]) => (
+                    <div key={kind} style={{ fontSize: 12, color: 'var(--ink-2)', padding: '2px 0' }}>
+                      <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>{c.version}</span>
+                      {' '}· {kind.replace(/_/g, ' ')} · {c.scope} scope{c.occurredAt ? ` · ${fmtDate(c.occurredAt)}` : ''}
+                    </div>
+                  ))}
+                </Disclosure>
+              )}
+            </section>
 
-          <Card title="Consent & reachability">
-            <div style={{ padding: '4px 14px 12px', display: 'grid', gap: 14 }}>
-              <section>
-                <SectionCaps>{consent ? 'Consent (ledger, this campaign + global)' : 'Consent (legacy flags)'}</SectionCaps>
-                {consent ? (
-                  <>
-                    <Kv k="marketing">{consentRow(consent.contact)}</Kv>
-                    <Kv k="terms">{consentRow(consent.campaign_terms)}</Kv>
-                    <Kv k="third-party">{consentRow(consent.third_party)}</Kv>
-                    {consent.draw_terms && <Kv k="draw terms">{consentRow(consent.draw_terms)}</Kv>}
-                  </>
-                ) : (
-                  <>
-                    <Kv k="marketing">{p.sourceMetadata?.consent_contact === true ? 'yes' : p.sourceMetadata?.consent_contact === false ? 'no' : '—'}</Kv>
-                    <Kv k="terms">{p.sourceMetadata?.consent_terms === true ? 'yes' : p.sourceMetadata?.consent_terms === false ? 'no' : '—'}</Kv>
-                    <Kv k="third-party">{p.sourceMetadata?.consent_third_party === true ? 'yes' : p.sourceMetadata?.consent_third_party === false ? 'no' : '—'}</Kv>
-                  </>
-                )}
-                {p.consentMetadata?.drawTerms?.termsVersionId && (
-                  <Kv k="draw terms pinned"><span className="av2-mono" style={{ fontSize: 11 }}>{String(p.consentMetadata.drawTerms.termsVersionId).slice(0, 8)}…</span></Kv>
-                )}
-              </section>
-              {(journey?.suppressions?.length > 0) && (
-                <section>
-                  <SectionCaps>Suppressions</SectionCaps>
-                  <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-                    {journey.suppressions.map((s2, i) => (
-                      <Chip key={i} tone="bad">{s2.channel}: {s2.reason.replace(/_/g, ' ')}</Chip>
+            <Card title="Campaigns" meta={`${railSignups.length} SIGNUP${railSignups.length === 1 ? '' : 'S'}`}>
+              {railSignups.map((s, i) => {
+                const draw = s.draw || null;
+                const rewards = s._fallback ? (p.signupProfile?.entitlements?.filter((e) => !e.drawLinked) || []) : rewardsFor(s);
+                const chip = rowChipFor(draw, rewards);
+                const nameVariant = person && fullName(s) && !sameName(s, person);
+                const isDraw = Boolean(draw);
+                return (
+                  <button
+                    key={s.prospectId}
+                    type="button"
+                    onClick={() => goSignup(s.prospectId)}
+                    style={{ display: 'flex', alignItems: 'center', gap: 12, width: '100%', boxSizing: 'border-box', padding: '12px 16px', background: 'transparent', border: 'none', borderBottom: i < railSignups.length - 1 ? '1px solid var(--line)' : 'none', cursor: 'pointer', textAlign: 'left', fontFamily: 'var(--font-ui)' }}
+                  >
+                    <span aria-hidden="true" style={{ width: 32, height: 32, flex: 'none', borderRadius: 9, background: isDraw ? 'var(--hold-soft)' : 'var(--surface-2)', color: isDraw ? 'var(--hold)' : 'var(--ink-2)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 13 }}>◆</span>
+                    <span style={{ flex: 1, minWidth: 0 }}>
+                      <span style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                        <span style={{ fontSize: 13.5, fontWeight: 700, color: 'var(--ink)' }}>{s.campaign?.name || 'No campaign'}</span>
+                        <Chip tone={isDraw ? 'hold' : ''}>{isDraw ? 'draw' : 'reward'}</Chip>
+                        {nameVariant && <Chip tone="warn" glyph="⚠">name variant</Chip>}
+                      </span>
+                      <span style={{ display: 'block', fontFamily: 'var(--font-mono)', fontSize: 10.5, color: 'var(--ink-3)', marginTop: 3 }}>
+                        {fmtDateTime(s.createdAt).toUpperCase()} · {(SOURCE_LABELS[s.leadSource] || s.leadSource).toUpperCase()} · {s.verified ? 'VERIFIED ✓' : 'UNVERIFIED'}
+                        {fullName(s) ? ` · AS ${fullName(s).toUpperCase()}` : ''}
+                        {s.held ? <span style={{ color: 'var(--hold)' }}> · HELD</span> : null}
+                        {' · '}
+                        {s.agentName
+                          ? <span>AGENT: {s.agentName.toUpperCase()}</span>
+                          : s.externalBuyer
+                            ? <span>AGENT: EXTERNAL BUYER</span>
+                            : <span style={{ color: 'var(--warn)' }}>AGENT: UNASSIGNED</span>}
+                      </span>
+                    </span>
+                    {chip && <Chip tone={chip.tone}>{chip.label}</Chip>}
+                    <span aria-hidden="true" style={{ color: 'var(--ink-3)', fontSize: 14, flex: 'none' }}>›</span>
+                  </button>
+                );
+              })}
+            </Card>
+          </div>
+
+          <Card title="History" meta={`EVERY ACTION BY THIS PERSON · ${history.length} EVENT${history.length === 1 ? '' : 'S'}`}>
+            {historyDays.length === 0 ? (
+              <EmptyState title="Nothing yet" hint="Events land here as they happen." />
+            ) : (
+              <div style={{ padding: '10px 16px 14px', columnWidth: 340, columnGap: 32 }}>
+                {historyDays.map((day) => (
+                  <div key={day.key} style={{ breakInside: 'avoid' }}>
+                    <div style={{ fontFamily: 'var(--font-mono)', fontSize: 10, fontWeight: 600, letterSpacing: '.12em', color: 'var(--ink-3)', padding: '4px 0 2px' }}>
+                      {fmtDay(day.key).toUpperCase()}
+                    </div>
+                    {day.events.map((e, i) => (
+                      <div key={i} style={{ display: 'flex', alignItems: 'flex-start', gap: 10, padding: '6px 0' }}>
+                        <GlyphTile family={e.family} />
+                        <span style={{ flex: 1, minWidth: 0, fontSize: 12.5, color: e.quiet ? 'var(--ink-2)' : 'var(--ink)', fontWeight: e.quiet ? 500 : 600, lineHeight: 1.35 }}>
+                          {e.title}
+                          {e.detail && <span style={{ color: 'var(--ink-2)', fontWeight: 500 }}>{e.detail}</span>}
+                        </span>
+                        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--ink-3)', flex: 'none', paddingTop: 2 }}>
+                          {e.tag ? `${e.tag} · ` : ''}{sgtTime(e.at)}
+                        </span>
+                      </div>
                     ))}
                   </div>
-                </section>
-              )}
-              <section>
-                <SectionCaps>DNC registry</SectionCaps>
-                <Kv k="status">{p.dncStatus || '—'}</Kv>
-                {(p.dncNoVoiceCall || p.dncNoTextMessage) && (
-                  <Kv k="blocked">{[p.dncNoVoiceCall && 'voice', p.dncNoTextMessage && 'SMS'].filter(Boolean).join(' + ')}</Kv>
-                )}
-                {p.dncCheckedAt && <Kv k="checked">{fmtDateTime(p.dncCheckedAt)}{p.dncValidUntil ? ` · valid until ${fmtDateTime(p.dncValidUntil)}` : ''}</Kv>}
-              </section>
-              {journey?.broadcasts && (
-                <section>
-                  <SectionCaps>Marketing touches</SectionCaps>
-                  <Kv k="broadcasts">
-                    {Object.keys(journey.broadcasts.counts).length
-                      ? Object.entries(journey.broadcasts.counts).map(([k, v]) => `${v} ${k}`).join(' · ')
-                      : 'none yet'}
-                  </Kv>
-                </section>
-              )}
-            </div>
-          </Card>
-
-          {hasScreening && (
-            <Card title="AI screening">
-              <div style={{ padding: '4px 14px 12px' }}>
-                <Kv k="verdict">
-                  {p.screeningVerdict === 'qualified' ? 'Qualified'
-                    : p.screeningVerdict === 'not_qualified' ? 'Not qualified'
-                      : sm.unreachable ? 'Unreachable' : 'Pending'}
-                </Kv>
-                {verdictDetail.reason && <Kv k="reason">{verdictDetail.reason}</Kv>}
-                {verdictDetail.sentiment && <Kv k="sentiment">{verdictDetail.sentiment}</Kv>}
-                <Kv k="attempts">{p.screeningAttemptCount || screeningAttempts.length || 0}</Kv>
-                {sm.callbackGranted && p.screeningNextAttemptAt && <Kv k="callback">{fmtDateTime(p.screeningNextAttemptAt)}</Kv>}
-                {screeningAttempts.some((a) => Number.isFinite(a.costCents)) && (
-                  <Kv k="call cost">{fmtSGDExact(screeningCostCents)}</Kv>
-                )}
-                {verdictDetail.summary && (
-                  <div style={{ marginTop: 6, fontSize: 12, color: 'var(--ink-2)', lineHeight: 1.5 }}>
-                    {String(verdictDetail.summary).slice(0, 600)}
-                  </div>
-                )}
-                {verdictDetail.transcript && (
-                  <details style={{ marginTop: 8 }}>
-                    <summary style={{ fontSize: 11, fontWeight: 700, color: 'var(--ink-2)', cursor: 'pointer', userSelect: 'none' }}>
-                      Call transcript
-                    </summary>
-                    <div style={{ marginTop: 6, maxHeight: 260, overflowY: 'auto', padding: '8px 10px', borderRadius: 8, background: 'var(--surface-2)', border: '1px solid var(--line)', fontSize: 12, lineHeight: 1.55, whiteSpace: 'pre-wrap', wordBreak: 'break-word', color: 'var(--ink-2)' }}>
-                      {String(verdictDetail.transcript).split('\n').map((line, i) => {
-                        const m = /^(Agent|User):\s?(.*)$/.exec(line);
-                        if (!m) return line ? <div key={i}>{line}</div> : <div key={i}>&nbsp;</div>;
-                        return (
-                          <div key={i} style={{ marginBottom: 3 }}>
-                            <span style={{ fontWeight: 700, color: m[1] === 'Agent' ? 'var(--accent-text)' : 'var(--ink)' }}>
-                              {m[1] === 'Agent' ? 'Sarah' : p.firstName || 'Lead'}:
-                            </span>{' '}
-                            {m[2]}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </details>
-                )}
-                {screeningAttempts.filter((a) => a.recordingUrl).map((a, i) => (
-                  <div key={a.token || i} style={{ marginTop: 8, display: 'grid', gap: 4 }}>
-                    <span style={{ fontSize: 12, color: 'var(--ink-2)' }}>Recording — attempt {i + 1} ({fmtDateTime(a.startedAt)})</span>
-                    <audio controls preload="none" src={a.recordingUrl} style={{ width: '100%', height: 34 }} />
-                  </div>
                 ))}
               </div>
-            </Card>
-          )}
+            )}
+          </Card>
+        </>
+      ) : (
+        <>
+          {/* ── Campaign drill-in view ── */}
+          <button type="button" onClick={goProfile} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, background: 'none', border: 'none', padding: 0, margin: '0 0 12px', cursor: 'pointer', fontSize: 12.5, fontWeight: 700, color: 'var(--accent-text)', fontFamily: 'var(--font-ui)' }}>
+            ← {canonicalName} — profile
+          </button>
 
-          {isVoiceLead && (
-            <Card title="Voice call">
-              <div style={{ padding: '4px 14px 12px' }}>
-                <Kv k="from">{p.sourceMetadata?.fromNumber || '—'}</Kv>
-                <Kv k="sentiment">{p.sourceMetadata?.sentiment || '—'}</Kv>
-                {p.sourceMetadata?.durationMs && <Kv k="duration">{Math.round(p.sourceMetadata.durationMs / 1000)}s</Kv>}
-                {p.notes && (
-                  <div style={{ marginTop: 6, fontSize: 12, color: 'var(--ink-2)', lineHeight: 1.5, whiteSpace: 'pre-wrap' }}>
-                    {String(p.notes).slice(0, 800)}
-                  </div>
-                )}
-                {p.sourceMetadata?.recordingUrl && (
-                  <audio controls preload="none" src={p.sourceMetadata.recordingUrl} style={{ width: '100%', height: 34, marginTop: 8 }} />
-                )}
-              </div>
-            </Card>
-          )}
-        </div>
-
-        {/* ── History ── */}
-        <Card
-          span={12}
-          title="History"
-          action={(
-            <div className="av2-seg" role="group" aria-label="History scope">
-              {[['all', 'All'], ['signup', 'This signup'], ['person', 'Person']].map(([v, label]) => (
-                <button key={v} type="button" aria-pressed={historyScope === v} onClick={() => setHistoryScope(v)}>
-                  {label}
-                </button>
-              ))}
-            </div>
-          )}
-        >
-          {filteredHistory.length === 0 ? (
-            <EmptyState title="Nothing yet" hint="This lead was just captured — events land here as they happen." />
-          ) : (
-            <div style={{ padding: '4px 0 8px' }}>
-              {filteredHistory.slice(0, 80).map((e, i) => (
-                <div key={i} className="av2-qrow" style={{ cursor: 'default', minHeight: 36 }}>
-                  <span className="av2-mono" style={{ width: 130, flex: 'none', fontSize: 10.5, color: 'var(--ink-3)' }} title={fmtDateTime(new Date(e.at))}>
-                    {fmtDateTime(new Date(e.at))}
-                  </span>
-                  <span style={{ flex: 1, fontSize: 12.5 }}>{e.label}</span>
-                  {e.campaign && <span className="av2-caption" style={{ flex: 'none' }}>{e.campaign}</span>}
-                </div>
-              ))}
-              {filteredHistory.length > 80 && (
-                <div className="av2-caption" style={{ padding: '8px 14px' }}>Showing the latest 80 events.</div>
+          <section className="av2-card" style={{ padding: '16px 18px', marginBottom: 16 }}>
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, flexWrap: 'wrap' }}>
+              <h1 style={{ margin: 0, fontSize: 18, fontWeight: 800, letterSpacing: '-0.015em', color: 'var(--ink)' }}>{currentSignup?.campaign?.name || p.campaign?.name || 'No campaign'}</h1>
+              <Chip tone={currentDraw ? 'hold' : ''}>{currentDraw ? 'draw' : 'reward'}</Chip>
+              {(currentSignup?.campaign?.id || p.campaign?.id) && (
+                <Link to={`/admin/campaigns/${currentSignup?.campaign?.id || p.campaign.id}`} style={{ fontSize: 11.5, fontWeight: 700 }}>campaign page ↗</Link>
               )}
+              <span style={{ flex: 1 }} />
+              <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10.5, color: 'var(--ink-3)' }}>
+                SIGNED UP {fmtDateTime(p.createdAt).toUpperCase()} · {(SOURCE_LABELS[p.leadSource] || p.leadSource).toUpperCase()}
+              </span>
             </div>
-          )}
-        </Card>
-      </div>
+            <div style={{ fontSize: 24, fontWeight: 800, letterSpacing: '-0.015em', color: heroToneColor, lineHeight: 1.15, marginTop: 10 }}>
+              {hero.big}
+              {hero.tail && <span style={{ fontSize: 14, fontWeight: 600, color: 'var(--ink-2)' }}>{hero.tail}</span>}
+            </div>
+            {hero.meta && (
+              <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, letterSpacing: '.1em', color: 'var(--ink-3)', marginTop: 4 }}>{hero.meta}</div>
+            )}
+            {heroReceipts.length > 0 && (
+              <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--ink-2)', marginTop: 6 }}>
+                {heroReceipts.map((r, i) => (
+                  <span key={i}>
+                    {i > 0 && ' · '}
+                    <span style={{ color: r.ok ? 'var(--ok)' : 'var(--bad)' }}>{r.ok ? '✓' : '✗'}</span> {r.label}
+                  </span>
+                ))}
+              </div>
+            )}
+            {currentDraw?.drawHistory?.length > 0 && (
+              <div style={{ fontFamily: 'var(--font-mono)', fontSize: 10.5, color: 'var(--ink-3)', marginTop: 8 }}>
+                {currentDraw.drawHistory.length} earlier draw{currentDraw.drawHistory.length === 1 ? '' : 's'}: {currentDraw.drawHistory.map((h) => h.drawStatus).join(' · ')}
+              </div>
+            )}
+          </section>
+
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: 16, alignItems: 'start' }}>
+            <Card title="Signup detail" meta={fmtDateTime(p.createdAt).toUpperCase()}>
+              <div style={{ padding: '12px 16px 8px' }}>
+                <div style={{ display: 'flex', gap: 12, fontSize: 12.5, padding: '4px 0', alignItems: 'center' }}>
+                  <span style={{ width: 96, flex: 'none', color: 'var(--ink-3)' }}>name used</span>
+                  <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--ink)' }}>{fullName(p) || '—'}</span>
+                  {person && fullName(p) && !sameName(p, person) && <Chip tone="warn" glyph="⚠">name variant</Chip>}
+                </div>
+                {!erased && p.email && <KvRow label="email">{p.email}</KvRow>}
+                {p.sourceMetadata?.phoneVerifiedAt && (
+                  <KvRow label="verified"><span style={{ color: 'var(--ok)' }}>✓</span> {fmtDateTime(p.sourceMetadata.phoneVerifiedAt)}</KvRow>
+                )}
+                <KvRow label="source">
+                  {SOURCE_LABELS[p.leadSource] || p.leadSource}
+                  {p.session?.landingPath ? ` → ${p.session.landingPath}` : ''}
+                  {p.qrTag ? ` · ${p.qrTag.name}` : ''}
+                </KvRow>
+                {(p.sourceMetadata?.utm?.utm_source || p.session?.utm?.source) && (
+                  <KvRow label="utm">
+                    {[
+                      p.sourceMetadata?.utm?.utm_source || p.session?.utm?.source,
+                      p.sourceMetadata?.utm?.utm_medium || p.session?.utm?.medium,
+                      p.sourceMetadata?.utm?.utm_campaign || p.session?.utm?.campaign,
+                    ].filter(Boolean).join(' / ')}
+                  </KvRow>
+                )}
+                <div style={{ display: 'flex', gap: 12, fontSize: 12.5, padding: '4px 0', alignItems: 'center' }}>
+                  <span style={{ width: 96, flex: 'none', color: 'var(--ink-3)' }}>agent</span>
+                  {p.assignedAgent
+                    ? <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--ink)' }}>{fullName(p.assignedAgent)}</span>
+                    : p.externalAgent || p.externalAgentId
+                      ? <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--ink)' }}>{p.externalAgent?.fullName || 'External buyer'} <span style={{ color: 'var(--ink-3)' }}>· {p.externalAgent?.agency ? `${p.externalAgent.agency} · ` : ''}external buyer</span></span>
+                      : <Chip tone="warn" glyph="◆">unassigned</Chip>}
+                </div>
+                {held && <KvRow label="held" mono={false}><span style={{ fontWeight: 600 }}>{heldLabel(p).full || p.quarantineReason}</span> <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--ink-3)' }}>· since {fmtDate(p.quarantinedAt)}</span></KvRow>}
+                <KvRow label="Lyfe delivery">
+                  {p.lyfeDelivery
+                    ? p.lyfeDelivery.map((ld, i) => (
+                      <span key={ld.eventType}>
+                        {i > 0 && ' · '}
+                        {ld.eventType.replace('lead.', '')}: {ld.status === 'success'
+                          ? <><span style={{ color: 'var(--ok)' }}>✓</span> delivered</>
+                          : ld.status === 'failed'
+                            ? <><span style={{ color: 'var(--bad)' }}>✗</span> failed ×{ld.attempts}{ld.reason ? ` (${ld.reason.replace(/_/g, ' ')})` : ''}</>
+                            : '… pending'}
+                      </span>
+                    ))
+                    : <span style={{ color: 'var(--ink-2)' }}>not sent — no app destination</span>}
+                </KvRow>
+                {currentDraw && p.consentMetadata?.drawTerms?.termsVersionId && (
+                  <KvRow label="draw terms">pinned · {String(p.consentMetadata.drawTerms.termsVersionId).slice(0, 8)}</KvRow>
+                )}
+                {p.nextFollowUpDate && <KvRow label="follow-up">{fmtDateTime(p.nextFollowUpDate)}</KvRow>}
+              </div>
+              {p.session?.steps?.length > 0 && (
+                <Disclosure label="Session funnel" count={`${p.session.steps.length} STEP${p.session.steps.length === 1 ? '' : 'S'}`}>
+                  {p.session.steps.slice(0, 12).map((s2, i) => (
+                    <div key={i} style={{ fontSize: 12, color: 'var(--ink-2)', padding: '3px 0' }}>
+                      {s2.at && <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10.5, color: 'var(--ink-3)', marginRight: 8 }}>{sgtTime(s2.at)}</span>}
+                      {s2.type.replace(/_/g, ' ')}{s2.path ? ` — ${s2.path}` : ''}
+                    </div>
+                  ))}
+                </Disclosure>
+              )}
+              {quiz && (
+                <Disclosure label="Quiz answers" count={`${Object.keys(quiz).length}`}>
+                  {Object.entries(quiz)
+                    .filter(([, v]) => ['string', 'number', 'boolean'].includes(typeof v))
+                    .slice(0, 12)
+                    .map(([k, v]) => (
+                      <div key={k} style={{ fontSize: 12, color: 'var(--ink-2)', padding: '3px 0' }}>
+                        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10.5, color: 'var(--ink-3)', marginRight: 8 }}>{k}</span>{String(v)}
+                      </div>
+                    ))}
+                </Disclosure>
+              )}
+            </Card>
+
+            {hasScreening && (
+              <Card
+                title="AI screening"
+                action={(
+                  <Chip tone={p.screeningVerdict === 'qualified' ? 'ok' : p.screeningVerdict === 'not_qualified' ? 'bad' : 'warn'} glyph={p.screeningVerdict === 'qualified' ? '✓' : p.screeningVerdict === 'not_qualified' ? '✗' : '☎'}>
+                    {p.screeningVerdict === 'qualified' ? 'Qualified' : p.screeningVerdict === 'not_qualified' ? 'Not qualified' : sm.unreachable ? 'Unreachable' : 'Pending'}
+                  </Chip>
+                )}
+              >
+                <div style={{ padding: '12px 16px 10px' }}>
+                  {verdictDetail.reason && <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--ink)', lineHeight: 1.4 }}>“{verdictDetail.reason}”</div>}
+                  <div style={{ fontSize: 11.5, fontWeight: 600, color: 'var(--ink-2)', marginTop: verdictDetail.reason ? 4 : 0 }}>
+                    {[
+                      verdictDetail.sentiment && `${String(verdictDetail.sentiment).toLowerCase()} sentiment`,
+                      `${p.screeningAttemptCount || screeningAttempts.length || 0} attempt${(p.screeningAttemptCount || screeningAttempts.length) === 1 ? '' : 's'}`,
+                    ].filter(Boolean).join(' · ')}
+                    {screeningAttempts.some((a) => Number.isFinite(a.costCents)) && <> · <span style={{ fontFamily: 'var(--font-mono)' }}>{fmtSGDExact(screeningCostCents)}</span></>}
+                  </div>
+                  {sm.callbackGranted && p.screeningNextAttemptAt && (
+                    <div style={{ fontSize: 11.5, fontWeight: 600, color: 'var(--ink-2)', marginTop: 4 }}>callback promised · {fmtDateTime(p.screeningNextAttemptAt)}</div>
+                  )}
+                </div>
+                {(screeningAttempts.length > 0 || verdictDetail.transcript) && (
+                  <Disclosure label="Transcript & recordings" count={`${screeningAttempts.length} ATTEMPT${screeningAttempts.length === 1 ? '' : 'S'}`}>
+                    <div style={{ display: 'grid', gap: 6 }}>
+                      {screeningAttempts.map((a, i) => (
+                        <div key={a.token || i} style={{ fontSize: 12, color: 'var(--ink-2)' }}>
+                          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10.5, color: 'var(--ink-3)', marginRight: 8 }}>{fmtDateTime(a.startedAt).toUpperCase()}</span>
+                          Attempt {i + 1} — {(a.outcome || 'attempted').replace(/_/g, ' ')}
+                          {a.recordingUrl && (
+                            <audio controls preload="none" src={a.recordingUrl} style={{ width: '100%', height: 32, marginTop: 4 }} />
+                          )}
+                        </div>
+                      ))}
+                      {verdictDetail.transcript && (
+                        <div style={{ maxHeight: 240, overflowY: 'auto', padding: '8px 10px', borderRadius: 8, background: 'var(--surface-2)', border: '1px solid var(--line)', fontSize: 12, lineHeight: 1.55, whiteSpace: 'pre-wrap', wordBreak: 'break-word', color: 'var(--ink-2)' }}>
+                          {String(verdictDetail.transcript).split('\n').map((line, i) => {
+                            const m = /^(Agent|User):\s?(.*)$/.exec(line);
+                            if (!m) return line ? <div key={i}>{line}</div> : <div key={i}>&nbsp;</div>;
+                            return (
+                              <div key={i} style={{ marginBottom: 3 }}>
+                                <span style={{ fontWeight: 700, color: m[1] === 'Agent' ? 'var(--accent-text)' : 'var(--ink)' }}>
+                                  {m[1] === 'Agent' ? 'Sarah' : p.firstName || 'Lead'}:
+                                </span>{' '}
+                                {m[2]}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  </Disclosure>
+                )}
+              </Card>
+            )}
+
+            {isVoiceLead && (
+              <Card title="Voice call" meta={p.sourceMetadata?.durationMs ? `${Math.round(p.sourceMetadata.durationMs / 1000)}S` : undefined}>
+                <div style={{ padding: '12px 16px 12px' }}>
+                  {p.sourceMetadata?.fromNumber && <KvRow label="from">{p.sourceMetadata.fromNumber}</KvRow>}
+                  {p.sourceMetadata?.sentiment && <KvRow label="sentiment" mono={false}>{p.sourceMetadata.sentiment}</KvRow>}
+                  {p.notes && (
+                    <div style={{ marginTop: 6, fontSize: 12, color: 'var(--ink-2)', lineHeight: 1.5, whiteSpace: 'pre-wrap' }}>
+                      {String(p.notes).slice(0, 800)}
+                    </div>
+                  )}
+                  {p.sourceMetadata?.recordingUrl && (
+                    <audio controls preload="none" src={p.sourceMetadata.recordingUrl} style={{ width: '100%', height: 34, marginTop: 8 }} />
+                  )}
+                </div>
+              </Card>
+            )}
+          </div>
+        </>
+      )}
 
       <AlertDialog open={confirmDelete} onOpenChange={setConfirmDelete}>
         <AlertDialogContent className="admin-v2" style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)' }}>
           <AlertDialogHeader>
             <AlertDialogTitle style={{ color: 'var(--ink)' }}>Delete this lead?</AlertDialogTitle>
             <AlertDialogDescription style={{ color: 'var(--ink-2)' }}>
-              This permanently removes the lead and its activity history. It cannot be undone.
+              This permanently removes the {currentSignup?.campaign?.name ? `${currentSignup.campaign.name} ` : ''}lead and its activity history. It cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
@@ -1,9 +1,11 @@
 /**
- * Lead Profile page — person-first rail (name-per-signup + variant flag),
- * draw voice vs reward voice per campaign, re-anchor navigation, the
- * consumer-less (B4) fallback, the erased banner, and history scope.
+ * Lead Profile (master-detail redesign) — drill-in lands with the outcome hero,
+ * the profile view tells the person story (name-per-signup + variant flag,
+ * compact status chips, day-grouped history), the two views are URL-addressable,
+ * and the command bar's two-step assign wires to bulkAssign for the picked
+ * signup. Plus the consumer-less (Retell) and erased states.
  */
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -11,83 +13,86 @@ import AdminV2LeadProfile from '../AdminV2LeadProfile';
 
 vi.mock('@/api/adminV2', () => ({
   fetchProspectProfile: vi.fn(),
-  fetchAgentOptions: vi.fn(async () => []),
-  bulkAssign: vi.fn(),
+  fetchAgentOptions: vi.fn(async () => [{ id: 'agent-1', name: 'Marcus Wong' }]),
+  bulkAssign: vi.fn(async () => ({ data: { affectedCount: 1 } })),
   bulkReturnToHeld: vi.fn(),
   bulkDelete: vi.fn(),
 }));
 
-import { fetchProspectProfile } from '@/api/adminV2';
+import { fetchProspectProfile, bulkAssign } from '@/api/adminV2';
 
 const PROFILE = {
   id: 'p1',
-  firstName: 'Shawn', lastName: 'Lee', phone: '+6591234567', email: 's@x.com',
+  firstName: 'Shawn', lastName: 'Lee', phone: '+6591234567', email: 'shawn@x.com',
   leadStatus: 'new', quarantinedAt: null, quarantineReason: null,
   priority: null, score: null, leadSource: 'qr_code',
-  createdAt: '2026-07-20T02:00:00Z',
-  sourceMetadata: { utm: { utm_source: 'fb' }, phoneVerifiedAt: '2026-07-20T02:00:00Z' },
-  consentMetadata: {},
-  campaign: { id: 'camp-1', name: 'Tokyo Lucky Draw', status: 'active' },
+  createdAt: '2026-07-20T06:05:00Z',
+  sourceMetadata: { utm: { utm_source: 'fb', utm_medium: 'cpc', utm_campaign: 'aug-tokyo' }, phoneVerifiedAt: '2026-07-20T06:06:00Z' },
+  consentMetadata: { drawTerms: { termsVersionId: 'abcd1234-0000' } },
+  demographics: { dateOfBirth: '1988-03-12' },
+  campaign: { id: 'camp-1', name: 'Tokyo Getaway Lucky Draw', status: 'active' },
   assignedAgent: null, externalAgent: null, externalAgentId: null, qrTag: null,
   commissions: [],
-  activities: [{ id: 'a1', type: 'created', description: 'Lead captured', createdAt: '2026-07-20T02:00:00Z' }],
-  session: null, lyfeDelivery: null, signupProfile: null,
+  activities: [{ id: 'a1', type: 'created', description: 'Lead captured', createdAt: '2026-07-20T06:05:00Z' }],
+  session: { startedAt: '2026-07-20T06:02:00Z', landingPath: '/c/tokyo', utm: {}, steps: [{ type: 'page_view', at: '2026-07-20T06:02:00Z', path: '/c/tokyo' }], visitCount: 1 },
+  lyfeDelivery: [{ eventType: 'lead.created', status: 'success', attempts: 1, lastAttemptAt: '2026-07-20T06:06:00Z', responseCode: 200, reason: null, at: '2026-07-20T06:06:00Z' }],
+  signupProfile: null,
+  screeningVerdict: 'qualified',
+  screeningMetadata: { verdictDetail: { reason: 'Agreed to meet a consultant', sentiment: 'Positive' }, attempts: {} },
+  screeningAttemptCount: 2,
   consumer: {
     consumer: {
       id: 'con-1', phone: '+6591234567', firstName: 'Shawn', lastName: 'Lee',
-      signupCount: 2, verifiedSignupCount: 2, firstSeenAt: '2026-05-01T02:00:00Z', erasedAt: null,
+      signupCount: 2, verifiedSignupCount: 2, firstSeenAt: '2026-05-01T08:40:00Z', erasedAt: null,
     },
     signups: [
       {
         prospectId: 'p1', firstName: 'Shawn', lastName: 'Lee',
-        campaign: { id: 'camp-1', name: 'Tokyo Lucky Draw', status: 'active' },
-        leadStatus: 'new', leadSource: 'qr_code', createdAt: '2026-07-20T02:00:00Z',
-        held: false, verified: true,
+        campaign: { id: 'camp-1', name: 'Tokyo Getaway Lucky Draw', status: 'active' },
+        leadStatus: 'new', leadSource: 'qr_code', createdAt: '2026-07-20T06:05:00Z',
+        held: false, verified: true, agentName: null, externalBuyer: false,
         draw: {
           drawId: 'd1', drawStatus: 'open', state: 'provisional_in', provisional: true,
           chances: 10, multiplier: 10, boosted: true, boostVia: 'agent_scan',
-          boostedAt: '2026-07-21T02:00:00Z', boostReviewPending: false,
+          boostedAt: '2026-07-21T01:12:00Z', boostReviewPending: false,
           closesAt: '2026-10-30T16:00:00Z', boostClosesAt: null, notEligibleReason: null,
           outcome: null, drawHistory: [],
         },
-        consent: { contact: { granted: true, version: '2026-07-21-agree-all-v1', scope: 'campaign' } },
+        consent: { contact: { granted: true, version: '2026-07-21-agree-all-v1', scope: 'global', occurredAt: '2026-07-21T02:00:00Z' } },
         rewardDiagnostic: null,
       },
       {
         prospectId: 'p2', firstName: 'Shawn', lastName: 'Tan',
-        campaign: { id: 'camp-2', name: 'NTUC Trial', status: 'active' },
-        leadStatus: 'won', leadSource: 'website', createdAt: '2026-05-01T02:00:00Z',
-        held: false, verified: true, draw: null,
-        consent: { contact: { granted: false } }, rewardDiagnostic: null,
+        campaign: { id: 'camp-2', name: 'NTUC Trial Reward', status: 'active' },
+        leadStatus: 'won', leadSource: 'website', createdAt: '2026-05-01T08:40:00Z',
+        held: false, verified: true, agentName: null, externalBuyer: true,
+        draw: null, consent: { contact: { granted: false } }, rewardDiagnostic: null,
       },
     ],
     entitlements: [{
       id: 'ent-1', status: 'redeemed', state: 'redeemed',
-      createdAt: '2026-05-01T03:00:00Z', unlockedAt: '2026-05-02T03:00:00Z', expiresAt: null,
-      rewardTitle: '1-for-1 latte', campaignName: 'NTUC Trial', campaignId: 'camp-2',
-      redeemedAt: '2026-05-03T03:00:00Z', unlockedVia: 'agent_scan', tokenHint: '9876',
+      createdAt: '2026-05-01T09:00:00Z', unlockedAt: '2026-05-02T02:00:00Z', expiresAt: null,
+      rewardTitle: '1-for-1 latte', campaignName: 'NTUC Trial Reward', campaignId: 'camp-2',
+      redeemedAt: '2026-05-03T03:26:00Z', unlockedVia: 'agent_scan', tokenHint: '9876',
       drawLinked: false,
-      delivery: { email: { ok: true, kind: 'voucher', at: '2026-05-02T03:05:00Z' }, whatsapp: null },
+      delivery: { email: { ok: true, kind: 'voucher', at: '2026-05-02T02:00:00Z' }, whatsapp: null },
     }],
     drawEntries: 1,
     suppressions: [],
-    broadcasts: {
-      counts: { sent: 1 },
-      recent: [{ broadcastId: 'b1', subject: 'Promo', status: 'sent', reason: null, sentAt: '2026-06-01T02:00:00Z', at: '2026-06-01T02:00:00Z' }],
-    },
+    broadcasts: { counts: { sent: 1 }, recent: [] },
   },
 };
 
 function Loc() {
   const location = useLocation();
-  return <div data-testid="loc">{location.pathname}</div>;
+  return <div data-testid="loc">{location.pathname}{location.search}</div>;
 }
 
-function setup(id = 'p1') {
+function setup(initial = '/admin/leads/p1') {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   render(
     <QueryClientProvider client={qc}>
-      <MemoryRouter initialEntries={[`/admin/leads/${id}`]}>
+      <MemoryRouter initialEntries={[initial]}>
         <Routes>
           <Route path="/admin/leads/:prospectId" element={<><AdminV2LeadProfile /><Loc /></>} />
           <Route path="/AdminProspects" element={<div>LIST</div>} />
@@ -102,75 +107,119 @@ beforeEach(() => {
   fetchProspectProfile.mockResolvedValue(JSON.parse(JSON.stringify(PROFILE)));
 });
 
-describe('AdminV2LeadProfile', () => {
-  it('renders the person header and asks for the profile enrichment', async () => {
+describe('AdminV2LeadProfile — drill-in (default landing)', () => {
+  it('lands on the campaign drill-in with the outcome hero as the loudest fact', async () => {
     setup();
-    expect(await screen.findByRole('heading', { name: 'Shawn Lee' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Tokyo Getaway Lucky Draw' })).toBeInTheDocument();
     expect(fetchProspectProfile).toHaveBeenCalledWith('p1');
-    expect(screen.getByText(/2 SIGNUPS \(2 VERIFIED\)/)).toBeInTheDocument();
+    expect(screen.getByText('On track for ×10')).toBeInTheDocument();
+    expect(screen.getByText(/consultant scan recorded/)).toBeInTheDocument();
+    expect(screen.getByText(/CLOSES 30 OCT/)).toBeInTheDocument();
+    // Command bar identity + back-to-profile affordance.
+    expect(screen.getByText('SHAWN LEE · +65 9123 4567')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Shawn Lee — profile/ })).toBeInTheDocument();
   });
 
-  it('tells each campaign story: name used, draw voice, reward voice', async () => {
+  it('shows signup facts and Lyfe delivery in the detail card', async () => {
     setup();
-    await screen.findAllByText('Tokyo Lucky Draw');
-    // Name-per-signup with the variant flagged (Shawn Tan ≠ canonical Shawn Lee).
-    expect(screen.getByText('Shawn Tan')).toBeInTheDocument();
+    await screen.findByText('Signup detail');
+    expect(screen.getByText(/QR code → \/c\/tokyo/)).toBeInTheDocument();
+    expect(screen.getByText(/fb \/ cpc \/ aug-tokyo/)).toBeInTheDocument();
+    expect(screen.getByText('unassigned')).toBeInTheDocument();
+    expect(screen.getByText(/delivered/)).toBeInTheDocument();
+    expect(screen.getByText('“Agreed to meet a consultant”')).toBeInTheDocument();
+  });
+
+  it('back button opens the person profile view (URL-addressable)', async () => {
+    setup();
+    fireEvent.click(await screen.findByRole('button', { name: /Shawn Lee — profile/ }));
+    expect(screen.getByTestId('loc')).toHaveTextContent('/admin/leads/p1?view=profile');
+    expect(await screen.findByRole('heading', { name: 'Shawn Lee' })).toBeInTheDocument();
+  });
+
+  it('drill-in assign is one step and targets THIS lead', async () => {
+    setup();
+    fireEvent.click(await screen.findByRole('button', { name: 'Assign this lead ▾' }));
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Marcus Wong/ }));
+    await waitFor(() => expect(bulkAssign).toHaveBeenCalledWith(['p1'], 'agent-1'));
+  });
+});
+
+describe('AdminV2LeadProfile — person profile view', () => {
+  it('tells the person story: identity, per-signup names, compact status chips', async () => {
+    setup('/admin/leads/p1?view=profile');
+    expect(await screen.findByRole('heading', { name: 'Shawn Lee' })).toBeInTheDocument();
+    expect(screen.getByText(/2 signups \(2 verified\)/)).toBeInTheDocument();
+    // Name used per signup (mono meta line) + the variant flag.
+    expect(screen.getByText(/AS SHAWN TAN/)).toBeInTheDocument();
     expect(screen.getByText('name variant')).toBeInTheDocument();
-    // Draw voice — provisional, never asserted.
-    expect(screen.getByText(/On track for ×10 — consultant scan recorded/)).toBeInTheDocument();
-    // Reward voice on the other campaign + delivery receipt microline
-    // (history rows repeat the reward name, so match all).
-    expect(screen.getAllByText(/Redeemed ✓/).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/1-for-1 latte/).length).toBeGreaterThan(0);
-    expect(screen.getByText(/pass emailed ✓/)).toBeInTheDocument();
+    // Compact outcome chips — no outcome machinery on rows.
+    expect(screen.getByText(/open · closes 30 Oct/)).toBeInTheDocument();
+    expect(screen.getByText('✓ redeemed')).toBeInTheDocument();
+    expect(screen.queryByText('On track for ×10')).not.toBeInTheDocument();
+    // Agent segment: unassigned is warn-voiced; external buyer named as such.
+    expect(screen.getByText('AGENT: UNASSIGNED')).toBeInTheDocument();
+    expect(screen.getByText('AGENT: EXTERNAL BUYER')).toBeInTheDocument();
   });
 
-  it('re-anchors to another signup by navigating to its URL', async () => {
-    setup();
-    const cards = await screen.findAllByText('NTUC Trial');
-    fireEvent.click(cards[0]); // the rail card (history captions repeat the name)
+  it('campaign rows drill in by navigating to that signup URL', async () => {
+    setup('/admin/leads/p1?view=profile');
+    fireEvent.click(await screen.findByText('NTUC Trial Reward'));
     expect(screen.getByTestId('loc')).toHaveTextContent('/admin/leads/p2');
   });
 
-  it('shows the ledger-backed consent and marketing touches', async () => {
-    setup();
-    await screen.findByText('Consent & reachability');
-    expect(screen.getByText(/yes · 2026-07-21-agree-all-v1/)).toBeInTheDocument();
-    expect(screen.getByText('1 sent')).toBeInTheDocument();
+  it('history is day-grouped, person-wide, with no scope filter', async () => {
+    setup('/admin/leads/p1?view=profile');
+    await screen.findByText('History');
+    expect(screen.getByText(/Signed up as Shawn Tan/)).toBeInTheDocument();
+    expect(screen.getByText(/Voucher redeemed ✓/)).toBeInTheDocument();
+    expect(screen.getByText('MON 20 JUL')).toBeInTheDocument(); // SGT day header
+    expect(screen.queryByRole('button', { name: 'This signup' })).not.toBeInTheDocument();
   });
 
-  it('falls back to the signup profile for consumer-less (Retell) leads', async () => {
+  it('profile assign is two-step: pick the campaign, then the agent', async () => {
+    setup('/admin/leads/p1?view=profile');
+    fireEvent.click(await screen.findByRole('button', { name: 'Assign to agent ▾' }));
+    expect(screen.getByText("Which campaign's lead?")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('menuitem', { name: /NTUC Trial Reward/ }));
+    expect(screen.getByText(/Assign NTUC Trial Reward lead to/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('menuitem', { name: /Marcus Wong/ }));
+    await waitFor(() => expect(bulkAssign).toHaveBeenCalledWith(['p2'], 'agent-1'));
+  });
+
+  it('consent card reads the ledger with scope tags', async () => {
+    setup('/admin/leads/p1?view=profile');
+    await screen.findByText('Consent & reachability');
+    expect(screen.getByText('· global')).toBeInTheDocument();
+    expect(screen.getByText(/1 sent/)).toBeInTheDocument();
+  });
+});
+
+describe('AdminV2LeadProfile — states', () => {
+  it('consumer-less Retell lead: banner, single signup, voice-call card', async () => {
     fetchProspectProfile.mockResolvedValue({
       ...JSON.parse(JSON.stringify(PROFILE)),
       consumer: null,
       leadSource: 'call_bot',
+      screeningVerdict: null, screeningMetadata: null, screeningAttemptCount: 0,
       sourceMetadata: { sentiment: 'Positive', fromNumber: '+6562773210', durationMs: 61000 },
       signupProfile: { draw: null, entitlements: [], rewardDiagnostic: 'no_active_activation' },
     });
     setup();
     await screen.findByText(/Retell voice lead/);
-    expect(screen.getByText('No reward attached to this campaign')).toBeInTheDocument();
+    expect(screen.getByText('No reward')).toBeInTheDocument();
     expect(screen.getByText('Voice call')).toBeInTheDocument();
     expect(screen.getByText('Positive')).toBeInTheDocument();
   });
 
-  it('flags erased people and drops their draw claims', async () => {
+  it('erased person: banner and the honest draw hero', async () => {
     const erased = JSON.parse(JSON.stringify(PROFILE));
-    erased.consumer.consumer.erasedAt = '2026-07-01T02:00:00Z';
+    erased.consumer.consumer.erasedAt = '2026-07-12T02:00:00Z';
     erased.consumer.signups[0].draw = { state: 'erased_draw_unavailable' };
     fetchProspectProfile.mockResolvedValue(erased);
     setup();
     await screen.findByText(/This person was erased/);
-    expect(screen.getByText(/Draw record unavailable \(erased\)/)).toBeInTheDocument();
-  });
-
-  it('filters history by scope', async () => {
-    setup();
-    await screen.findByText('History');
-    // Person-scope events include the second signup.
-    expect(screen.getByText(/Signed up as Shawn Tan/)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'This signup' }));
-    expect(screen.queryByText(/Signed up as Shawn Tan/)).not.toBeInTheDocument();
-    expect(screen.getByText('Lead captured')).toBeInTheDocument();
+    expect(screen.getByText('⊘ Draw record unavailable')).toBeInTheDocument();
+    expect(screen.getByText('ERASED')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Implements the Claude Design handoff (`Lead Profile — Redesign v2.dc.html` + its README spec) — the master-detail recomposition of `/admin/leads/:id`.

## What changed

- **Person profile view** (`?view=profile`): Person card (22px identity, chips, ledger-backed consent + DNC + broadcasts reachability list, raw-consent-versions disclosure) · Campaigns card (one row per signup: glyph tile, name-variant flag, mono meta line with `AS SHAWN TAN` and a warn-voiced `AGENT: UNASSIGNED` segment, compact status chip — outcome machinery deliberately lives in the drill-in) · person-wide **History** in CSS columns, day-grouped (SGT), glyph families, loud/quiet rows, no scope filter.
- **Campaign drill-in** (default landing for `/admin/leads/:id`): outcome hero as the loudest element (24px/800 — draw voices stay lifecycle-honest, reward voices carry the title), deadline meta + delivery receipts as small print, Signup detail card (kv rows, session-funnel + quiz disclosures), AI screening card (only when data; transcript + recordings behind a disclosure), Voice-call card for Retell leads.
- **Sticky command bar** on both views: ← Prospects · compact mono identity · Delete / Return to held / **Assign** (the one primary). Assign is **two-step from the profile** (which campaign's lead? → agent) and one-step from a drill-in; wired to `bulkAssign` for the picked signup.
- **Both views are routes**: drill-in = the existing URL, profile = `?view=profile` — deep-linkable and back/forward-safe per the handoff's interaction spec; every existing entry point (Prospects rows, ⌘K, dashboard, `?lead=` redirects) lands on the drill-in unchanged.

## Correctness catches

- Draw `closesAt`/`boostClosesAt` are **SGT end-of-day exclusive instants** — rendering them naively displayed the *next* day ("closes 31 Oct" for a 30 Oct draw). Window dates now display the last included instant.
- Phones render in the house `+65 XXXX XXXX` display form (previously raw E.164).

## Backend (additive)

`getConsumerJourney` signups gain `agentName` + `externalBuyer` — the campaign rows' AGENT segment and the assign menu's sub-lines need per-signup routing (design handoff's recommended API addition).

## Deviations from the mock (noted deliberately)

- Drill-in assign button reads `Assign this lead ▾` (menu header carries the campaign name) — deriving a short campaign word for the label is brittle.
- Agent menu lists Lyfe agents only — external-buyer assignment is a different flow than `bulkAssign` and isn't offered.
- DOB renders from the anchored signup's `demographics.dateOfBirth` when present (the handoff's per-person DOB doesn't exist server-side).

## Tests

11 RTL tests rewritten for the composition (hero landing, URL-addressable view switch, two-step + scoped assign with `waitFor`, day-grouped history, ledger consent, Retell + erased states). **Full vitest 1924/1924 · jest 127/127 on touched suites · build + lint clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8jF5ZxuAZD3NazPQQMEfV