### PR TITLE
feat(draw): the engine record is born with the launch — no more manual CLI step

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -159,6 +159,11 @@ RETELL_SCREENING_ENABLED=false
 # under 20% remaining. Kill switch defaults ON.
 # DRAW_BOOST_AUTOPROVISION_ENABLED=true
 # DRAW_BOOST_DEFAULT_ALLOCATION=10000
+# Draw ENGINE-RECORD auto-creation: launching a draw campaign (or the boot /
+# hourly reconciler, for campaigns already live) creates the draws row the
+# chances display and freeze/seal run on — replaces the manual
+# run-lucky-draw.js create step. Kill switch defaults ON.
+# DRAW_RECORD_AUTOCREATE_ENABLED=true
 # House partner that owns auto-provisioned review offers (falls back to the
 # MKTR PTE. LTD. partner row by legalName).
 # REDEEM_HOUSE_PARTNER_ORG_ID=

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -76,6 +76,15 @@ export async function bootstrapDatabase() {
     await sweepStaleBroadcasts();
   });
 
+  // Draw-record reconciler: every ACTIVE draw campaign with an open entry
+  // window gets its engine record ensured (creation still runs through
+  // createDraw's fail-closed validation). Heals campaigns launched before
+  // auto-creation existed — the manual run-lucky-draw.js create step is gone.
+  await safeRun('Draw record reconciler', async () => {
+    const { sweepDrawRecords } = await import('../services/luckyDrawService.js');
+    await sweepDrawRecords();
+  });
+
   // Poll for stale webhook retries every 60 seconds (skip in test mode)
   if (process.env.NODE_ENV !== 'test') {
     setInterval(async () => {
@@ -104,6 +113,18 @@ export async function bootstrapDatabase() {
     setInterval(async () => {
       const { reconcileSuppressionPropagation } = await import('../services/suppressionPropagationService.js');
       await reconcileSuppressionPropagation();
+    }, 3_600_000);
+
+    // Draw-record backstop every 60 minutes: a launch whose record ensure
+    // failed transiently, or a draw enabled by a path that skipped the hook,
+    // self-heals within the hour (sweepDrawRecords never throws internally).
+    setInterval(async () => {
+      try {
+        const { sweepDrawRecords } = await import('../services/luckyDrawService.js');
+        await sweepDrawRecords();
+      } catch (err) {
+        logger.warn('[LuckyDraw] record sweep failed', { error: err?.message });
+      }
     }, 3_600_000);
 
     // Purge expired idempotency keys every hour

--- a/backend/src/services/campaignService.js
+++ b/backend/src/services/campaignService.js
@@ -4,6 +4,7 @@ import { Campaign, QrTag, Prospect, Commission, Device, CampaignMediaItem, Campa
 import { getTenantId } from '../middleware/tenant.js';
 import { storageService } from './storage.js';
 import { AppError } from '../middleware/errorHandler.js';
+import { logger } from '../utils/logger.js';
 import { normalizeCustomerHostChoice } from '../utils/customerHost.js';
 import { sgtDayEndExclusiveMs } from '../utils/sgtTime.js';
 import { applyFeaturedDropPolicy } from '../utils/featuredDrop.js';
@@ -36,6 +37,28 @@ async function ensureRail(args) {
   if (_ensureDrawBoostRail) return _ensureDrawBoostRail(args);
   const mod = await import('./redeemOps/drawBoostProvisioningService.js');
   return mod.ensureDrawBoostRail(args);
+}
+/**
+ * Draw-RECORD ensure hook — the engine row chances/freeze/seal run on, born
+ * at the same arming moments as the rail so no operator ever runs the CLI
+ * create step by hand. BEST-EFFORT unlike the rail: a missing record loses
+ * nothing (evidence accrues independently; the boot reconciler retries), so
+ * this never throws and never blocks a save or launch. Same lazy-import +
+ * test-seam shape as ensureRail.
+ */
+let _ensureDrawRecord = null;
+export function setEnsureDrawRecord(fn) {
+  _ensureDrawRecord = typeof fn === 'function' ? fn : null;
+}
+async function ensureRecord(args) {
+  try {
+    if (_ensureDrawRecord) return await _ensureDrawRecord(args);
+    const mod = await import('./luckyDrawService.js');
+    return await mod.ensureDrawRecord(args);
+  } catch (err) {
+    logger.warn('[Campaign] draw-record ensure failed (reconciler will retry)', { error: err?.message });
+    return { created: false, reason: 'failed' };
+  }
 }
 /** Write the ensured activationId into the doc's stored luckyDraw (both doc
  * versions keep `luckyDraw` top-level — loss-ledger L5). No-op on null. */
@@ -559,6 +582,9 @@ export async function createCampaign(body, user) {
       }
     }
     await campaign.update({ design_config: withTerms });
+    // Born-active draw gets its engine record too — after the doc (stamped
+    // rail + pinned terms) is stored. Best-effort; the reconciler retries.
+    if (campaignData.is_active) await ensureRecord({ campaignId: campaign.id, user });
   }
 
   // Write agent assignments to join table
@@ -695,12 +721,14 @@ export async function updateCampaign(id, body, req) {
   // transitions ONLY — inactive→active with a draw, or the draw turning on
   // under an active campaign. Routine saves of a live draw campaign never
   // re-enter (a transient rail 422 must not block unrelated edits — CX16).
+  let armedDraw = false;
   {
     const nextDoc = updateData.design_config !== undefined ? updateData.design_config : campaign.design_config;
     const becomingActive = willBeActive && campaign.is_active !== true;
     const drawTurningOn =
       willBeActive && drawEnabledIn(nextDoc) && !drawEnabledIn(campaign.design_config);
     const arming = (becomingActive && drawEnabledIn(nextDoc)) || drawTurningOn;
+    armedDraw = arming;
 
     // Promise-consistency gate (PR-3/CX16): arming transitions AND active
     // saves that MODIFY a compared fact (ages, terms, material draw fields).
@@ -753,6 +781,9 @@ export async function updateCampaign(id, body, req) {
 
   try {
     await campaign.update(updateData);
+    // Draw record rides the arming moment, AFTER the doc (with its stamped
+    // rail + pinned terms) is stored — best-effort; the reconciler retries.
+    if (armedDraw) await ensureRecord({ campaignId: campaign.id, user: req.user });
   } catch (err) {
     if (err?.name === 'SequelizeUniqueConstraintError') {
       throw new AppError('That marketplace slug is already taken by another campaign.', 409);
@@ -900,6 +931,11 @@ export async function setCampaignLaunchState(id, state, req) {
     ...(stampedDoc ? { design_config: stampedDoc } : {}),
     ...(isActive && !campaign.firstActivatedAt ? { firstActivatedAt: new Date() } : {}),
   });
+  // The engine record is born with the launch (best-effort — a record hiccup
+  // must never un-launch a campaign; the boot reconciler retries).
+  if (isActive && drawEnabledIn(campaign.design_config)) {
+    await ensureRecord({ campaignId: campaign.id, user: req.user });
+  }
   invalidateMarketplaceCache();
   invalidateFeaturedDropsCache();
 

--- a/backend/src/services/luckyDrawService.js
+++ b/backend/src/services/luckyDrawService.js
@@ -10,6 +10,7 @@ import { AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
 import { sgtDayEndExclusiveMs } from '../utils/sgtTime.js';
 import { normalizeLuckyDraw, totalPrizeQuantity } from '../utils/luckyDraw.js';
+import { getSystemAgentId } from './systemAgent.js';
 
 /**
  * Lucky-draw lifecycle (docs/plans/lucky-draw-10x.md §4.2–§4.3).
@@ -129,6 +130,7 @@ export function makeLuckyDrawService(overrides = {}) {
     Campaign, Prospect, Activation, RewardEntitlement, RedemptionEvent,
     DrawTermsVersion,
     sequelize, logger,
+    getSystemAgentId,
     now: () => new Date(),
     mintSeed: () => crypto.randomBytes(32).toString('hex'),
     ...overrides,
@@ -1053,9 +1055,86 @@ export function makeLuckyDrawService(overrides = {}) {
     return out;
   }
 
+  /**
+   * Seamless draw-record ensure — the record used to be a manual CLI step
+   * (run-lucky-draw.js create) that every launched draw campaign needed an
+   * operator to remember; forgetting it left "Draw configured — no draw
+   * record yet" on every lead. Called from the SAME campaignService choke
+   * points that arm the boost rail, plus the boot/interval reconciler below.
+   *
+   * BEST-EFFORT by design, unlike the rail ensure: a missing record loses
+   * nothing (entry evidence and boost events accrue independently and count
+   * retroactively at freeze/seal), so record trouble must never block a
+   * launch — it logs, campaign readiness keeps complaining, and the
+   * reconciler retries. Fairness validation is NOT duplicated here: creation
+   * goes through createDraw, which fail-closes on multi-prize, missing
+   * closesAt, and rail conflicts. Never throws.
+   */
+  async function ensureDrawRecord({ campaignId, user = null } = {}) {
+    if (String(process.env.DRAW_RECORD_AUTOCREATE_ENABLED ?? 'true').toLowerCase() === 'false') {
+      return { created: false, reason: 'disabled' };
+    }
+    if (!campaignId) return { created: false, reason: 'no_campaign' };
+    const live = { [Op.in]: ['open', 'frozen', 'sealed', 'drawn'] };
+    try {
+      const existing = await d.Draw.findOne({ where: { campaignId, status: live } });
+      if (existing) return { created: false, reason: 'exists', drawId: existing.id };
+      const actorId = user?.id || await d.getSystemAgentId();
+      const draw = await createDraw({ campaignId }, { id: actorId });
+      d.logger.info('lucky_draw.record_auto_created', { drawId: draw.id, campaignId, actorId });
+      return { created: true, drawId: draw.id };
+    } catch (err) {
+      // Concurrent ensure lost the uq_draws_live_campaign race — adopt the winner.
+      if (err?.statusCode === 409 || /already has a live draw/i.test(err?.message || '')) {
+        const winner = await d.Draw.findOne({ where: { campaignId, status: live } }).catch(() => null);
+        return { created: false, reason: 'exists', drawId: winner?.id || null };
+      }
+      d.logger.warn('lucky_draw.record_auto_create_failed', { campaignId, error: err?.message });
+      return { created: false, reason: 'failed', error: err?.message };
+    }
+  }
+
+  /**
+   * Reconciler: every ACTIVE draw campaign whose configured entry window is
+   * still open gets its record ensured. Heals campaigns launched before
+   * auto-creation existed and any launch whose ensure failed transiently.
+   * Campaigns whose configured closesAt already passed are left to the CLI —
+   * minting a record for an already-closed window is an operator decision.
+   */
+  async function sweepDrawRecords() {
+    const campaigns = await d.Campaign.findAll({
+      where: { is_active: true },
+      attributes: ['id', 'design_config'],
+    });
+    const results = { checked: 0, created: 0, failed: 0 };
+    const nowMs = d.now().getTime();
+    for (const c of campaigns) {
+      const ld = c.design_config?.luckyDraw;
+      if (ld?.enabled !== true) continue;
+      const closesAtMs = ld.closesAt ? sgtDayEndExclusiveMs(ld.closesAt) : null;
+      if (!Number.isFinite(closesAtMs) || closesAtMs <= nowMs) continue;
+      results.checked += 1;
+      const r = await ensureDrawRecord({ campaignId: c.id });
+      if (r.created) results.created += 1;
+      else if (r.reason === 'failed') results.failed += 1;
+    }
+    if (results.created > 0 || results.failed > 0) {
+      d.logger.info('lucky_draw.record_sweep', results);
+    }
+    return results;
+  }
+
   return {
     createDraw, freezeDraw, listPendingBoostReviews, reviewBoost, sealDraw,
     runDrawAttempt, recordAttemptOutcome, markPublished, voidDraw,
     verifyDraw, getDrawState, getProspectDrawStatus,
+    ensureDrawRecord, sweepDrawRecords,
   };
 }
+
+// Default instance for the launch hooks (campaignService) and the bootstrap
+// reconciler — construction is deps-only, no I/O. The CLI keeps building its
+// own instance; tests inject overrides via makeLuckyDrawService.
+const _default = makeLuckyDrawService();
+export const ensureDrawRecord = (args) => _default.ensureDrawRecord(args);
+export const sweepDrawRecords = () => _default.sweepDrawRecords();

--- a/backend/test/drawRecordAutoCreate.test.js
+++ b/backend/test/drawRecordAutoCreate.test.js
@@ -1,0 +1,176 @@
+/**
+ * ensureDrawRecord + sweepDrawRecords (luckyDrawService, DI seam — no DB):
+ * the seamless replacement for the manual `run-lucky-draw.js create` step.
+ * Ensure is idempotent, adopts unique-race winners, uses the system agent
+ * when no operator is in scope, NEVER throws (best-effort by contract), and
+ * creation still flows through createDraw so every fail-closed validation
+ * (multi-prize, missing closesAt, rail conflicts) holds. The reconciler
+ * only touches ACTIVE draw campaigns whose entry window is still open.
+ */
+import { jest } from '@jest/globals';
+import { makeLuckyDrawService } from '../src/services/luckyDrawService.js';
+import { sgtDayEndExclusiveMs } from '../src/utils/sgtTime.js';
+
+const silentLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+const NOW = new Date('2026-07-25T04:00:00Z');
+const CAMPAIGN_ID = 'camp-1';
+
+const drawConfig = (over = {}) => ({
+  luckyDraw: {
+    enabled: true,
+    closesAt: '2026-09-30',
+    boostClosesAt: '2026-10-10',
+    multiplier: 10,
+    activationId: 'act-1',
+    termsVersionId: 'tv-1',
+    prize: 'iPhone 17 Pro',
+    winners: 1,
+    ...over,
+  },
+});
+
+function buildDeps({
+  existingDraw = null,
+  campaign = { id: CAMPAIGN_ID, design_config: drawConfig() },
+  activation = { id: 'act-1', campaignId: CAMPAIGN_ID, unlockPolicy: 'agent_unlock', status: 'active' },
+  activeCampaigns = [],
+  createImpl = null,
+} = {}) {
+  const deps = {
+    Draw: {
+      findOne: jest.fn().mockResolvedValue(existingDraw),
+      create: createImpl || jest.fn().mockImplementation(async (fields) => ({ id: 'draw-new', ...fields })),
+      findByPk: jest.fn(),
+      update: jest.fn(),
+      findAll: jest.fn().mockResolvedValue([]),
+    },
+    Campaign: {
+      findByPk: jest.fn().mockResolvedValue(campaign),
+      findAll: jest.fn().mockResolvedValue(activeCampaigns),
+    },
+    Activation: {
+      findByPk: jest.fn().mockResolvedValue(activation),
+      findOne: jest.fn().mockResolvedValue(activation),
+    },
+    DrawEntry: { findAll: jest.fn().mockResolvedValue([]) },
+    DrawAttempt: { findAll: jest.fn().mockResolvedValue([]) },
+    DrawBoostReview: { findAll: jest.fn().mockResolvedValue([]) },
+    DrawTermsVersion: { findAll: jest.fn().mockResolvedValue([{ id: 'tv-1' }]) },
+    RewardEntitlement: { findAll: jest.fn().mockResolvedValue([]) },
+    RedemptionEvent: { findAll: jest.fn().mockResolvedValue([]) },
+    Prospect: { findAll: jest.fn().mockResolvedValue([]) },
+    sequelize: { transaction: jest.fn().mockImplementation(async (cb) => cb({})) },
+    logger: silentLogger,
+    getSystemAgentId: jest.fn().mockResolvedValue('sys-agent-1'),
+    now: () => NOW,
+    mintSeed: () => 'a'.repeat(64),
+  };
+  return { deps, svc: makeLuckyDrawService(deps) };
+}
+
+describe('ensureDrawRecord', () => {
+  it('creates the record through createDraw, attributed to the system agent', async () => {
+    const { deps, svc } = buildDeps();
+    const r = await svc.ensureDrawRecord({ campaignId: CAMPAIGN_ID });
+    expect(r.created).toBe(true);
+    expect(deps.getSystemAgentId).toHaveBeenCalled();
+    const created = deps.Draw.create.mock.calls[0][0];
+    expect(created.createdBy).toBe('sys-agent-1');
+    expect(created.campaignId).toBe(CAMPAIGN_ID);
+    expect(created.multiplier).toBe(10);
+    expect(created.activationId).toBe('act-1');
+    // Dates become the engine's fixed SGT end-of-day-exclusive instants.
+    expect(created.closesAt.getTime()).toBe(sgtDayEndExclusiveMs('2026-09-30'));
+  });
+
+  it('uses the acting operator when one is in scope', async () => {
+    const { deps, svc } = buildDeps();
+    const r = await svc.ensureDrawRecord({ campaignId: CAMPAIGN_ID, user: { id: 'admin-1' } });
+    expect(r.created).toBe(true);
+    expect(deps.getSystemAgentId).not.toHaveBeenCalled();
+    expect(deps.Draw.create.mock.calls[0][0].createdBy).toBe('admin-1');
+  });
+
+  it('is a no-op when a live record already exists', async () => {
+    const { deps, svc } = buildDeps({ existingDraw: { id: 'draw-live', status: 'open' } });
+    const r = await svc.ensureDrawRecord({ campaignId: CAMPAIGN_ID });
+    expect(r).toMatchObject({ created: false, reason: 'exists', drawId: 'draw-live' });
+    expect(deps.Draw.create).not.toHaveBeenCalled();
+  });
+
+  it('adopts the winner when it loses the one-live-draw race', async () => {
+    const { deps, svc } = buildDeps({
+      createImpl: jest.fn().mockRejectedValue(
+        Object.assign(new Error('This campaign already has a live draw'), { statusCode: 409 })
+      ),
+    });
+    deps.Draw.findOne
+      .mockResolvedValueOnce(null) // pre-check: nothing yet
+      .mockResolvedValueOnce({ id: 'draw-winner', status: 'open' }); // post-race adopt
+    const r = await svc.ensureDrawRecord({ campaignId: CAMPAIGN_ID });
+    expect(r).toMatchObject({ created: false, reason: 'exists', drawId: 'draw-winner' });
+  });
+
+  it("never throws: createDraw's fail-closed validation surfaces as reason 'failed'", async () => {
+    // Missing closesAt → createDraw 422; the ensure absorbs it (launches must
+    // never be blocked by record trouble — the reconciler retries).
+    const { deps, svc } = buildDeps({
+      campaign: { id: CAMPAIGN_ID, design_config: drawConfig({ closesAt: null }) },
+    });
+    const r = await svc.ensureDrawRecord({ campaignId: CAMPAIGN_ID });
+    expect(r.created).toBe(false);
+    expect(r.reason).toBe('failed');
+    expect(deps.Draw.create).not.toHaveBeenCalled();
+  });
+
+  it('honours the kill switch', async () => {
+    process.env.DRAW_RECORD_AUTOCREATE_ENABLED = 'false';
+    try {
+      const { deps, svc } = buildDeps();
+      const r = await svc.ensureDrawRecord({ campaignId: CAMPAIGN_ID });
+      expect(r).toMatchObject({ created: false, reason: 'disabled' });
+      expect(deps.Draw.findOne).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.DRAW_RECORD_AUTOCREATE_ENABLED;
+    }
+  });
+});
+
+describe('sweepDrawRecords', () => {
+  it('ensures only ACTIVE draw campaigns with a still-open entry window', async () => {
+    const { deps, svc } = buildDeps({
+      activeCampaigns: [
+        { id: 'camp-1', design_config: drawConfig() }, // eligible → ensured
+        { id: 'camp-2', design_config: {} }, // not a draw → skipped
+        { id: 'camp-3', design_config: drawConfig({ closesAt: '2026-05-01' }) }, // window passed → CLI territory
+        { id: 'camp-4', design_config: drawConfig({ closesAt: 'not-a-date' }) }, // unparseable → skipped
+      ],
+    });
+    // The eligible campaign resolves through the normal ensure path.
+    deps.Campaign.findByPk.mockResolvedValue({ id: 'camp-1', design_config: drawConfig() });
+    const results = await svc.sweepDrawRecords();
+    expect(results).toMatchObject({ checked: 1, created: 1, failed: 0 });
+    expect(deps.Draw.create).toHaveBeenCalledTimes(1);
+    expect(deps.Draw.create.mock.calls[0][0].campaignId).toBe('camp-1');
+  });
+
+  it('counts a failing ensure without aborting the pass', async () => {
+    // No activationId stamp → createDraw resolves each campaign's own active
+    // rail; the first create blows up, the second succeeds.
+    const { deps, svc } = buildDeps({
+      activeCampaigns: [
+        { id: 'camp-bad', design_config: drawConfig({ activationId: null }) },
+        { id: 'camp-good', design_config: drawConfig({ activationId: null }) },
+      ],
+      createImpl: jest.fn()
+        .mockRejectedValueOnce(Object.assign(new Error('boom'), { statusCode: 500 }))
+        .mockImplementation(async (fields) => ({ id: 'draw-new', ...fields })),
+    });
+    deps.Campaign.findByPk.mockImplementation(async (id) => ({ id, design_config: drawConfig({ activationId: null }) }));
+    deps.Activation.findOne.mockImplementation(async ({ where }) => ({
+      id: `act-${where.campaignId}`, campaignId: where.campaignId, unlockPolicy: 'agent_unlock', status: 'active',
+    }));
+    const results = await svc.sweepDrawRecords();
+    expect(results).toMatchObject({ checked: 2, created: 1, failed: 1 });
+  });
+});


### PR DESCRIPTION
Kills the manual `run-lucky-draw.js create` step. The draw engine record — the row chances display and freeze/seal run on — now creates itself:

- **At launch**: `ensureDrawRecord` rides the same three campaignService arming choke points as the boost rail (born-active create, activating update, launch-state flip), after the doc with its stamped rail + pinned terms is stored.
- **Self-healing**: a boot-time reconciler + hourly backstop ensures every ACTIVE draw campaign with a still-open entry window — which auto-creates the **iPhone 17 Pro draw's** missing record on the first boot after this deploys, zero manual action. Past-window campaigns are deliberately left to the CLI.
- **Best-effort by contract** (unlike the rail's fail-closed revert): a missing record loses nothing — entry evidence and boost events accrue independently and count retroactively — so record trouble logs and retries instead of ever blocking a launch. Creation still flows through `createDraw`, so every fail-closed validation (multi-prize, missing closesAt, rail ownership) holds unchanged.
- Idempotent + race-safe (adopts the `uq_draws_live_campaign` winner), attributed to the acting operator or the system agent, kill switch `DRAW_RECORD_AUTOCREATE_ENABLED` (default ON).

Tests: 8 new (create/actor/no-op/race-adopt/fail-absorb/kill-switch + sweep filtering and mixed-outcome pass); draw + campaign suites green (7 suites, 152 tests). Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8jF5ZxuAZD3NazPQQMEfV