### PR TITLE
feat(admin): the Prospects STATUS column speaks the campaign outcome

### DIFF
--- a/backend/src/services/leadProfileService.js
+++ b/backend/src/services/leadProfileService.js
@@ -124,6 +124,57 @@ export function makeLeadProfileService(overrides = {}) {
     return railIds;
   }
 
+  /**
+   * List-page outcome facts (docs/plans/admin-prospects-outcome-column.md):
+   * per-row draw standing (trimmed of drawHistory) plus the newest
+   * non-draw-linked entitlement's presentation state — the STATUS column's
+   * raw material. Batched for a 25-row page: the draw side is bounded per
+   * DISTINCT draw (getProspectDrawStatus), the reward side is one entitlement
+   * query (idx_re_prospect) plus the rail lookup.
+   * Returns Map<prospectId(string), { draw, reward }>.
+   */
+  async function getProspectOutcomes(prospects) {
+    const rows = (prospects || []).filter((p) => p && p.id);
+    const out = new Map();
+    if (rows.length === 0) return out;
+    const campaignIds = [...new Set(rows.map((p) => String(p.campaignId)).filter(Boolean))];
+
+    const [drawMap, railIds, entitlements] = await Promise.all([
+      d.getProspectDrawStatus(rows),
+      drawRailActivationIds(campaignIds),
+      d.RewardEntitlement.findAll({
+        where: { prospectId: { [Op.in]: rows.map((p) => p.id) } },
+        attributes: ['id', 'prospectId', 'status', 'expiresAt', 'activationId', 'createdAt'],
+        include: [{ association: 'rewardOffer', attributes: ['id', 'title', 'publicTitle'] }],
+        order: [['createdAt', 'DESC'], ['id', 'DESC']],
+      }),
+    ]);
+
+    // Newest non-draw-linked entitlement per prospect (DESC order → first
+    // eligible wins; draw passes are the boost rail, never the voucher voice).
+    const rewardByProspect = new Map();
+    for (const e of entitlements) {
+      const key = String(e.prospectId);
+      if (rewardByProspect.has(key)) continue;
+      if (e.activationId && railIds.has(String(e.activationId))) continue;
+      rewardByProspect.set(key, {
+        state: d.presentState(e, d.now()),
+        rewardTitle: e.rewardOffer ? (e.rewardOffer.publicTitle || e.rewardOffer.title) : null,
+      });
+    }
+
+    for (const p of rows) {
+      const block = drawMap.get(String(p.id)) ?? null;
+      let draw = block;
+      if (block && 'drawHistory' in block) {
+        const { drawHistory: _history, ...rest } = block;
+        draw = rest;
+      }
+      out.set(String(p.id), { draw, reward: rewardByProspect.get(String(p.id)) || null });
+    }
+    return out;
+  }
+
   /** Bounded person-level broadcast history: recent page + full status tallies. */
   async function broadcastHistory(consumerId) {
     try {
@@ -373,6 +424,7 @@ export function makeLeadProfileService(overrides = {}) {
     getSignupProfile,
     getSessionContext,
     getLyfeDelivery,
+    getProspectOutcomes,
     deriveRewardDiagnostic,
   };
 }
@@ -382,3 +434,4 @@ export const enrichJourneyProfile = _default.enrichJourneyProfile;
 export const getSignupProfile = _default.getSignupProfile;
 export const getSessionContext = _default.getSessionContext;
 export const getLyfeDelivery = _default.getLyfeDelivery;
+export const getProspectOutcomes = _default.getProspectOutcomes;

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -48,6 +48,7 @@ import { recordCaptureConsentEventsTx, canMarketTo } from './consentService.js';
 // imports only (models + sibling services); no cycle back into this module.
 import {
   enrichJourneyProfile, getSignupProfile, getSessionContext, getLyfeDelivery,
+  getProspectOutcomes,
 } from './leadProfileService.js';
 import { customerHostOrigin, normalizeCustomerHostChoice } from '../utils/customerHost.js';
 import { sgtDayEndExclusiveMs } from '../utils/sgtTime.js';
@@ -206,6 +207,7 @@ const defaultDeps = {
   getSignupProfile,
   getSessionContext,
   getLyfeDelivery,
+  getProspectOutcomes,
   recordCaptureConsentEventsTx,
   canMarketTo,
   onLeadCaptured: (prospect) => (_leadCapturedHook ? _leadCapturedHook(prospect) : null),
@@ -2346,6 +2348,25 @@ export function makeProspectService(overrides = {}) {
         prospects.map((p) => ({ id: p.id, phone: p.phone, email: p.email }))
       ).catch(() => new Map());
       for (const p of prospects) p.setDataValue('repeatSignupCount', counts.get(p.id) ?? null);
+    }
+
+    // Admin-only, OPT-IN (?include=outcome — the v2 list's STATUS column):
+    // per-row campaign outcome, the same contract discipline as
+    // ?include=profile. Byte-identical without the flag; agent MyProspects
+    // and the palette never pay for it. Resilient — a miss drops the chips,
+    // never the page.
+    const wantOutcome = user?.role === 'admin'
+      && String(params.include || '').split(',').map((s2) => s2.trim()).includes('outcome')
+      && prospects.length > 0;
+    if (wantOutcome) {
+      const outcomes = await d.getProspectOutcomes(prospects).catch(() => new Map());
+      for (const p of prospects) {
+        const o = outcomes.get(String(p.id));
+        if (o) {
+          p.setDataValue('draw', o.draw);
+          p.setDataValue('reward', o.reward);
+        }
+      }
     }
 
     return {

--- a/backend/test/leadProfileService.test.js
+++ b/backend/test/leadProfileService.test.js
@@ -277,6 +277,113 @@ describe('enrichJourneyProfile', () => {
   });
 });
 
+// ── getProspectOutcomes (the list's STATUS column raw material) ─────────────
+
+describe('getProspectOutcomes', () => {
+  const listRows = [
+    { id: 'p1', campaignId: 'camp-1' },
+    { id: 'p2', campaignId: 'camp-2' },
+    { id: 'p3', campaignId: 'camp-2' },
+  ];
+
+  function outcomeDeps() {
+    return makeLeadProfileService({
+      logger: silentLogger,
+      now: () => NOW,
+      getProspectDrawStatus: jest.fn().mockResolvedValue(new Map([
+        ['p1', { state: 'provisional_in', chances: 10, boosted: true, multiplier: 10, drawHistory: [{ drawId: 'old' }] }],
+      ])),
+      getConsentState: jest.fn(),
+      Draw: { findAll: jest.fn().mockResolvedValue([{ activationId: 'rail-1' }]) },
+      Activation: { findOne: jest.fn() },
+      RewardOffer: {},
+      RewardEntitlement: {
+        findOne: jest.fn(),
+        findAll: jest.fn().mockResolvedValue([
+          // Newest first (DESC): p2's newest is a DRAW PASS (rail-1) — skipped;
+          // its older voucher wins. p3 has only a voucher.
+          { id: 'e3', prospectId: 'p2', status: 'issued', expiresAt: FUTURE, activationId: 'rail-1', createdAt: NOW, rewardOffer: null },
+          { id: 'e2', prospectId: 'p2', status: 'redeemed', expiresAt: null, activationId: 'act-v', createdAt: PAST, rewardOffer: { title: 'Latte', publicTitle: '1-for-1 latte' } },
+          { id: 'e1', prospectId: 'p3', status: 'eligible', expiresAt: FUTURE, activationId: 'act-v', createdAt: PAST, rewardOffer: { title: 'Latte', publicTitle: null } },
+        ]),
+      },
+      ConsumerSuppression: { findAll: jest.fn() },
+      EmailBroadcastRecipient: { findAll: jest.fn() },
+      SessionVisit: { findAll: jest.fn() },
+      sequelize: { query: jest.fn(), fn: jest.fn(), col: jest.fn() },
+    });
+  }
+
+  it('attaches draw standing (history-trimmed) and the newest non-draw-linked reward', async () => {
+    const svc = outcomeDeps();
+    const map = await svc.getProspectOutcomes(listRows);
+
+    // Draw lead: block passed through minus drawHistory.
+    expect(map.get('p1').draw).toMatchObject({ state: 'provisional_in', chances: 10, boosted: true });
+    expect(map.get('p1').draw.drawHistory).toBeUndefined();
+    expect(map.get('p1').reward).toBeNull();
+
+    // p2: the newer entitlement is a draw pass (rail activation) — the older
+    // VOUCHER speaks: redeemed, public title preferred.
+    expect(map.get('p2').reward).toEqual({ state: 'redeemed', rewardTitle: '1-for-1 latte' });
+    expect(map.get('p2').draw).toBeNull();
+
+    // p3: eligible + future expiry → presentState 'reserved'; title falls back.
+    expect(map.get('p3').reward).toEqual({ state: 'reserved', rewardTitle: 'Latte' });
+  });
+
+  it('returns an empty map for an empty page', async () => {
+    const svc = outcomeDeps();
+    expect((await svc.getProspectOutcomes([])).size).toBe(0);
+  });
+});
+
+// ── the ?include=outcome boundary on listProspects ──────────────────────────
+
+describe('prospectService.listProspects include gating', () => {
+  function listService() {
+    const getProspectOutcomes = jest.fn().mockResolvedValue(new Map([
+      ['p1', { draw: { state: 'provisional_in' }, reward: null }],
+    ]));
+    const row = () => {
+      const data = {};
+      return { id: 'p1', phone: '+6591234567', email: null, setDataValue: jest.fn((k, v) => { data[k] = v; }), _set: data };
+    };
+    const findAndCountAll = jest.fn();
+    const svc = makeProspectService({
+      getProspectOutcomes,
+      buildProspectWhere: jest.fn().mockResolvedValue({}),
+      sequelize: { query: jest.fn().mockResolvedValue([[]]) },
+      models: { Prospect: { findAndCountAll } },
+    });
+    return { svc, getProspectOutcomes, findAndCountAll, row };
+  }
+
+  it('non-admins never reach the enrichment, whatever they send', async () => {
+    const { svc, getProspectOutcomes, findAndCountAll, row } = listService();
+    findAndCountAll.mockResolvedValue({ count: 1, rows: [row()] });
+    await svc.listProspects({ id: 'agent-1', role: 'agent' }, { include: 'outcome' });
+    expect(getProspectOutcomes).not.toHaveBeenCalled();
+  });
+
+  it('admin WITHOUT include gets the classic payload', async () => {
+    const { svc, getProspectOutcomes, findAndCountAll, row } = listService();
+    findAndCountAll.mockResolvedValue({ count: 1, rows: [row()] });
+    await svc.listProspects({ id: 'admin-1', role: 'admin' }, {});
+    expect(getProspectOutcomes).not.toHaveBeenCalled();
+  });
+
+  it('admin + include=outcome attaches draw/reward per row', async () => {
+    const { svc, getProspectOutcomes, findAndCountAll, row } = listService();
+    const r = row();
+    findAndCountAll.mockResolvedValue({ count: 1, rows: [r] });
+    await svc.listProspects({ id: 'admin-1', role: 'admin' }, { include: 'outcome' });
+    expect(getProspectOutcomes).toHaveBeenCalled();
+    expect(r._set.draw).toEqual({ state: 'provisional_in' });
+    expect(r._set.reward).toBeNull();
+  });
+});
+
 // ── the ?include=profile boundary on getProspect ────────────────────────────
 
 describe('prospectService.getProspect include gating', () => {

--- a/src/lib/adminV2/__tests__/adminV2.test.js
+++ b/src/lib/adminV2/__tests__/adminV2.test.js
@@ -182,7 +182,7 @@ describe('prospectsToCsv', () => {
   it('quotes RFC-4180 style and joins with CRLF', () => {
     const csv = prospectsToCsv([lead]);
     const [header, row] = csv.split('\r\n');
-    expect(header).toBe('id,first_name,last_name,email,phone,status,source,campaign,agent,held_reason,created_at');
+    expect(header).toBe('id,first_name,last_name,email,phone,status,outcome,source,campaign,agent,held_reason,created_at');
     expect(row).toContain('"Tokyo, ""Getaway"""');
     expect(row).toContain('Melvin Tan');
   });

--- a/src/lib/adminV2/__tests__/outcome.test.js
+++ b/src/lib/adminV2/__tests__/outcome.test.js
@@ -1,0 +1,53 @@
+/**
+ * The shared campaign-outcome voice (list STATUS column + profile campaign
+ * rows) and its CSV projection. Draw windows display the last INCLUDED
+ * instant (stored instants are SGT end-of-day exclusive).
+ */
+import { describe, it, expect } from 'vitest';
+import { rowChipFor, drawWindowDay } from '../outcome';
+import { prospectsToCsv } from '../csv';
+
+describe('rowChipFor', () => {
+  it('speaks the draw voice, boost included', () => {
+    expect(rowChipFor({ state: 'provisional_in', boosted: false, closesAt: '2026-09-30T16:00:00Z' }, []))
+      .toEqual({ label: 'open · closes 30 Sept', tone: '' });
+    expect(rowChipFor({ state: 'provisional_in', boosted: true, multiplier: 10, closesAt: '2026-09-30T16:00:00Z' }, []))
+      .toEqual({ label: '×10 · closes 30 Sept', tone: 'ok' });
+    expect(rowChipFor({ state: 'sealed', chances: 10, outcome: { status: 'selected_claimed' } }, []))
+      .toEqual({ label: '🏆 winner', tone: 'ok' });
+    expect(rowChipFor({ state: 'provisional_out' }, [])).toEqual({ label: 'not counted', tone: 'warn' });
+  });
+
+  it('speaks the reward voice when there is no draw', () => {
+    expect(rowChipFor(null, [{ state: 'redeemed' }])).toEqual({ label: '✓ redeemed', tone: 'ok' });
+    expect(rowChipFor(null, [{ state: 'reserved' }])).toEqual({ label: 'reserved', tone: 'accent' });
+    expect(rowChipFor(null, [{ state: 'unlocked' }])).toEqual({ label: 'unlocked', tone: 'ok' });
+  });
+
+  it('is silent when there is nothing to say', () => {
+    expect(rowChipFor(null, [])).toBeNull();
+    expect(rowChipFor(null, undefined)).toBeNull();
+  });
+});
+
+describe('drawWindowDay', () => {
+  it('shows the last included SGT day of an exclusive end-of-day instant', () => {
+    // 2026-09-30T16:00:00Z == 1 Oct 00:00 SGT (exclusive) → the window's day is
+    // 30 Sep — rendered '30 Sept' (en-SG abbreviates September to four letters,
+    // matching the house fmtDate/fmtDateTime).
+    expect(drawWindowDay('2026-09-30T16:00:00Z')).toBe('30 Sept');
+  });
+});
+
+describe('prospectsToCsv outcome column', () => {
+  it('exports the chip label', () => {
+    const csv = prospectsToCsv([{
+      id: 'p1', firstName: 'A', lastName: 'B', email: 'a@b.c', phone: '+65',
+      leadStatus: 'new', leadSource: 'website', campaign: { name: 'NTUC' },
+      assignedAgent: null, quarantinedAt: null, createdAt: 'x',
+      draw: null, reward: { state: 'redeemed' },
+    }]);
+    expect(csv.split('\r\n')[0]).toContain('outcome');
+    expect(csv).toContain('✓ redeemed');
+  });
+});

--- a/src/lib/adminV2/csv.js
+++ b/src/lib/adminV2/csv.js
@@ -3,6 +3,7 @@
  * RFC-4180 quoting; formula-injection guarded (a leading =+-@ gets a ' prefix
  * so a hostile lead name can never execute in Excel/Sheets).
  */
+import { rowChipFor } from './outcome';
 
 function csvCell(value) {
   if (value === null || value === undefined) return '';
@@ -22,6 +23,7 @@ const COLUMNS = [
   ['email', (p) => p.email],
   ['phone', (p) => p.phone],
   ['status', (p) => p.leadStatus],
+  ['outcome', (p) => rowChipFor(p.draw, p.reward ? [p.reward] : [])?.label ?? ''],
   ['source', (p) => p.leadSource],
   ['campaign', (p) => p.campaign?.name ?? ''],
   ['agent', (p) => (p.assignedAgent ? `${p.assignedAgent.firstName || ''} ${p.assignedAgent.lastName || ''}`.trim() : '')],

--- a/src/lib/adminV2/outcome.js
+++ b/src/lib/adminV2/outcome.js
@@ -1,0 +1,73 @@
+/**
+ * Campaign-outcome voice — THE one place the compact outcome chips are worded
+ * (docs/plans/admin-prospects-outcome-column.md). Consumed by the Prospects
+ * list's STATUS column and the Lead Profile's campaigns rail, so the two can
+ * never drift. Facts come from the backend (`draw` block per signup/row +
+ * newest non-draw-linked entitlement); this module only chooses words.
+ */
+
+const SGT = 'Asia/Singapore';
+
+/** "30 Sep" in SGT. */
+export const sgtDayMonth = (v) => new Date(v).toLocaleDateString('en-SG', { day: 'numeric', month: 'short', timeZone: SGT });
+
+/**
+ * Draw windows are stored as SGT end-of-day EXCLUSIVE instants (the first
+ * moment AFTER the window — sgtTime.js); the operator-facing day is the last
+ * INCLUDED instant, one ms earlier.
+ */
+export const drawWindowDay = (v) => sgtDayMonth(new Date(new Date(v).getTime() - 1));
+
+export const REWARD_STATE_COPY = {
+  reserved: { tone: 'accent', label: 'Reserved' },
+  unlocked: { tone: 'ok', label: 'Unlocked' },
+  redeemed: { tone: 'ok', label: 'Redeemed ✓' },
+  expired: { tone: '', label: 'Expired' },
+  cancelled: { tone: '', label: 'Cancelled' },
+  blocked: { tone: 'bad', label: 'Blocked' },
+};
+
+/**
+ * Compact status chip for a lead row: `{ label, tone }` in its campaign's own
+ * voice, or null when there is no outcome to speak of. Draw voice wins over
+ * reward voice (a draw campaign's entitlement is the entry pass, not a
+ * voucher — the backend already excludes draw-linked entitlements from
+ * `rewards`).
+ */
+export function rowChipFor(draw, rewards) {
+  if (draw) {
+    switch (draw.state) {
+      case 'provisional_in': {
+        const closes = draw.closesAt ? ` · closes ${drawWindowDay(draw.closesAt)}` : '';
+        // Boosted leads carry the multiplier — "open" alone hides the fact
+        // that the ×N is already earned.
+        return draw.boosted
+          ? { label: `×${draw.multiplier}${closes}`, tone: 'ok' }
+          : { label: `open${closes}`, tone: '' };
+      }
+      case 'provisional_out': return { label: 'not counted', tone: 'warn' };
+      case 'frozen_in': return { label: draw.boosted ? `in the pool · ×${draw.multiplier} at seal` : 'in the pool', tone: '' };
+      case 'excluded_at_freeze': return { label: 'excluded', tone: 'warn' };
+      case 'sealed': {
+        const s = draw.outcome?.status;
+        if (s === 'selected_claimed') return { label: '🏆 winner', tone: 'ok' };
+        if (s === 'selected_pending') return { label: 'selected', tone: 'accent' };
+        if (s === 'not_selected_final') return { label: 'not selected', tone: '' };
+        return { label: `sealed · ${draw.chances} chance${draw.chances === 1 ? '' : 's'}`, tone: '' };
+      }
+      case 'void': return { label: 'void', tone: '' };
+      case 'erased_draw_unavailable': return { label: '⊘ erased', tone: 'bad' };
+      case 'no_draw_record': return { label: 'no draw record', tone: 'warn' };
+      default: break;
+    }
+  }
+  const ent = rewards?.[0];
+  if (ent) {
+    const known = REWARD_STATE_COPY[ent.state];
+    if (known) {
+      return { label: known.label === 'Redeemed ✓' ? '✓ redeemed' : known.label.toLowerCase(), tone: known.tone };
+    }
+    return { label: ent.state || ent.status, tone: '' };
+  }
+  return null;
+}

--- a/src/pages/adminv2/AdminV2LeadProfile.jsx
+++ b/src/pages/adminv2/AdminV2LeadProfile.jsx
@@ -24,6 +24,7 @@ import { bulkAssign, bulkReturnToHeld, bulkDelete } from '@/api/adminV2';
 import { STATUS_LABELS, SOURCE_LABELS, heldLabel } from '@/lib/adminV2/constants';
 import { fmtDateTime, fmtDate, fmtDay, fmtSGDExact } from '@/lib/adminV2/format';
 import { Card, Chip, Skeleton, ErrorState, EmptyState } from '@/components/adminv2/primitives';
+import { rowChipFor, drawWindowDay } from '@/lib/adminV2/outcome';
 import {
   AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle,
   AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction,
@@ -36,11 +37,6 @@ const fullName = (o) => `${o?.firstName || ''} ${o?.lastName || ''}`.trim();
 const sameName = (a, b) => fullName(a).toLowerCase() === fullName(b).toLowerCase();
 const sgtTime = (v) => new Date(v).toLocaleTimeString('en-SG', { hour: '2-digit', minute: '2-digit', hour12: false, timeZone: SGT });
 const sgtDayKey = (v) => new Intl.DateTimeFormat('en-CA', { timeZone: SGT }).format(new Date(v));
-const sgtDayMonth = (v) => new Date(v).toLocaleDateString('en-SG', { day: 'numeric', month: 'short', timeZone: SGT });
-// Draw windows are stored as SGT end-of-day EXCLUSIVE instants (the first
-// moment AFTER the window — sgtTime.js); the operator-facing day is the last
-// INCLUDED instant, one ms earlier.
-const drawWindowDay = (v) => sgtDayMonth(new Date(new Date(v).getTime() - 1));
 const drawWindowDayUpper = (v) => drawWindowDay(v).toUpperCase();
 /** House phone display: +6591234567 → "+65 9123 4567" (root CLAUDE.md rule). */
 const fmtPhone = (v) => {
@@ -124,37 +120,6 @@ function heroFor(draw, rewards, diagnostic) {
       : { big: 'No reward', tail: ` — ${DIAGNOSTIC_COPY[diagnostic] || diagnostic}`, tone: 'quiet', meta: null };
   }
   return { big: 'No outcome recorded', tail: '', tone: 'quiet', meta: null };
-}
-
-/** Compact right-edge status chip on a campaigns-list row. */
-function rowChipFor(draw, rewards) {
-  if (draw) {
-    switch (draw.state) {
-      case 'provisional_in': return { label: draw.closesAt ? `open · closes ${drawWindowDay(draw.closesAt)}` : 'open', tone: '' };
-      case 'provisional_out': return { label: 'not counted', tone: 'warn' };
-      case 'frozen_in': return { label: 'in the pool', tone: '' };
-      case 'excluded_at_freeze': return { label: 'excluded', tone: 'warn' };
-      case 'sealed': {
-        const s = draw.outcome?.status;
-        if (s === 'selected_claimed') return { label: '🏆 winner', tone: 'ok' };
-        if (s === 'selected_pending') return { label: 'selected', tone: 'accent' };
-        if (s === 'not_selected_final') return { label: 'not selected', tone: '' };
-        return { label: 'sealed', tone: '' };
-      }
-      case 'void': return { label: 'void', tone: '' };
-      case 'erased_draw_unavailable': return { label: '⊘ erased', tone: 'bad' };
-      case 'no_draw_record': return { label: 'no draw record', tone: 'warn' };
-      default: break;
-    }
-  }
-  const ent = rewards?.[0];
-  if (ent) {
-    if (ent.state === 'redeemed') return { label: '✓ redeemed', tone: 'ok' };
-    if (ent.state === 'unlocked') return { label: 'unlocked', tone: 'ok' };
-    if (ent.state === 'reserved') return { label: 'reserved', tone: 'accent' };
-    return { label: ent.state || ent.status, tone: '' };
-  }
-  return null;
 }
 
 function receiptBits(delivery) {

--- a/src/pages/adminv2/AdminV2Prospects.jsx
+++ b/src/pages/adminv2/AdminV2Prospects.jsx
@@ -18,6 +18,7 @@ import {
 } from '@/lib/adminV2/constants';
 import { fmtDateTime, fmtRelative } from '@/lib/adminV2/format';
 import { prospectsToCsv, downloadCsv } from '@/lib/adminV2/csv';
+import { rowChipFor } from '@/lib/adminV2/outcome';
 import { Chip, PageHeader, Skeleton, ErrorState, EmptyState } from '@/components/adminv2/primitives';
 import {
   DropdownMenu, DropdownMenuTrigger, DropdownMenuContent,
@@ -146,6 +147,9 @@ export default function AdminV2Prospects() {
   const queryParams = useMemo(() => ({
     page: filters.page,
     limit: PAGE_SIZE,
+    // The STATUS column speaks the campaign-outcome voice — admin-only,
+    // opt-in enrichment (the palette and agent surfaces never send this).
+    include: 'outcome',
     ...(filters.status.length ? { leadStatus: filters.status.join(',') } : {}),
     ...(filters.source.length ? { leadSource: filters.source.join(',') } : {}),
     ...(filters.assignment ? { assignment: filters.assignment } : {}),
@@ -353,7 +357,9 @@ export default function AdminV2Prospects() {
           </button>
           <SortHeader label="Lead" field="firstName" sort={filters.sort} onSort={(s) => patch({ sort: s, page: null })} />
           <span className="av2-microcaps" style={{ width: 110, flex: 'none' }}>Phone</span>
-          <SortHeader label="Status" field="leadStatus" sort={filters.sort} onSort={(s) => patch({ sort: s, page: null })} width={130} />
+          {/* Outcome isn't a DB column — no sort affordance (ordering by
+              new/contacted was never useful anyway). */}
+          <span className="av2-microcaps" style={{ width: 130, flex: 'none' }}>Status</span>
           <span className="av2-microcaps" style={{ flex: 1 }}>Campaign</span>
           <span className="av2-microcaps" style={{ width: 100, flex: 'none' }}>Agent</span>
           <SortHeader label="Created" field="createdAt" sort={filters.sort} onSort={(s) => patch({ sort: s, page: null })} width={100} align="right" />
@@ -403,13 +409,33 @@ export default function AdminV2Prospects() {
               </span>
               <span className="av2-mono" style={{ width: 110, flex: 'none', fontSize: 11, color: 'var(--ink-2)' }}>{p.phone || '—'}</span>
               <span style={{ width: 130, flex: 'none', display: 'flex', flexDirection: 'column', gap: 3, alignItems: 'flex-start' }}>
+                {/* Campaign-outcome precedence (plan: admin-prospects-outcome-column):
+                    held alarm → outcome in the campaign's own voice → pipeline
+                    status ONLY when it isn't the default 'new' → screening.
+                    A lead with nothing yet is silent (muted dash) — no "New" wall. */}
                 {held
                   ? <Chip tone="hold" glyph="◆">{heldLabel(p).short}</Chip>
-                  : <Chip tone={STATUS_CHIP_CLASS[p.leadStatus]?.replace('av2-chip--', '') || ''}>{STATUS_LABELS[p.leadStatus] || p.leadStatus}</Chip>}
+                  : (() => {
+                    const chip = rowChipFor(p.draw, p.reward ? [p.reward] : []);
+                    const pipeline = p.leadStatus && p.leadStatus !== 'new' && (
+                      <Chip tone={STATUS_CHIP_CLASS[p.leadStatus]?.replace('av2-chip--', '') || ''}>
+                        {STATUS_LABELS[p.leadStatus] || p.leadStatus}
+                      </Chip>
+                    );
+                    if (!chip && !pipeline) {
+                      return <span className="av2-mono" aria-label="No outcome yet" style={{ fontSize: 11, color: 'var(--ink-3)', paddingTop: 2 }}>—</span>;
+                    }
+                    return (
+                      <>
+                        {chip && <Chip tone={chip.tone}>{chip.label}</Chip>}
+                        {pipeline}
+                      </>
+                    );
+                  })()}
                 {/* AI-screening verdict — a permanent fact independent of the
                     pipeline status. Skipped when the row is already a screening
                     HOLD (the hold chip conveys it); the useful case is a
-                    RELEASED lead that passed, which otherwise reads only "New". */}
+                    RELEASED lead that passed, which otherwise reads only silence. */}
                 {p.screeningVerdict && !String(p.quarantineReason || '').startsWith('screening_') && (
                   <span
                     title={p.screeningVerdict === 'qualified'
@@ -430,7 +456,12 @@ export default function AdminV2Prospects() {
                   </span>
                 )}
               </span>
-              <span style={{ flex: 1, fontSize: 12, color: 'var(--ink-2)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.campaign?.name || '—'}</span>
+              <span style={{ flex: 1, fontSize: 12, color: 'var(--ink-2)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'flex', alignItems: 'center', gap: 6 }}>
+                {p.campaign && (
+                  <span aria-hidden="true" style={{ width: 16, height: 16, flex: 'none', borderRadius: 5, background: p.draw ? 'var(--hold-soft)' : 'var(--surface-2)', color: p.draw ? 'var(--hold)' : 'var(--ink-3)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: 8 }}>◆</span>
+                )}
+                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.campaign?.name || '—'}</span>
+              </span>
               <span style={{ width: 100, flex: 'none', fontSize: 12, color: 'var(--ink-2)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                 {p.assignedAgent
                   ? `${p.assignedAgent.firstName || ''}`

--- a/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
@@ -153,8 +153,9 @@ describe('AdminV2LeadProfile — person profile view', () => {
     // Name used per signup (mono meta line) + the variant flag.
     expect(screen.getByText(/AS SHAWN TAN/)).toBeInTheDocument();
     expect(screen.getByText('name variant')).toBeInTheDocument();
-    // Compact outcome chips — no outcome machinery on rows.
-    expect(screen.getByText(/open · closes 30 Oct/)).toBeInTheDocument();
+    // Compact outcome chips — no outcome machinery on rows; a boosted lead
+    // carries its multiplier (the ×N is already earned).
+    expect(screen.getByText(/×10 · closes 30 Oct/)).toBeInTheDocument();
     expect(screen.getByText('✓ redeemed')).toBeInTheDocument();
     expect(screen.queryByText('On track for ×10')).not.toBeInTheDocument();
     // Agent segment: unassigned is warn-voiced; external buyer named as such.

--- a/src/pages/adminv2/__tests__/AdminV2Prospects.outcome.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2Prospects.outcome.test.jsx
@@ -1,0 +1,112 @@
+/**
+ * Prospects list STATUS column — the campaign-outcome precedence: held alarm →
+ * outcome chip in the campaign's voice → pipeline status only when ≠ new →
+ * screening; silence (muted dash) instead of a "New" wall. Plus the
+ * ?include=outcome request contract and the campaign-type glyph.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import AdminV2Prospects from '../AdminV2Prospects';
+
+vi.mock('@/api/adminV2', () => ({
+  fetchProspects: vi.fn(async () => ({
+    rows: [
+      { // draw lead, boosted — outcome chip carries the ×10; "New" suppressed
+        id: 'p1', firstName: 'Shawn', lastName: 'Lee', phone: '+6580129432', email: 's@x.com',
+        leadStatus: 'new', quarantinedAt: null, campaign: { name: 'iPhone 17 Pro Lucky Draw' },
+        assignedAgent: null, createdAt: '2026-07-25T08:00:00Z', screeningVerdict: 'qualified',
+        draw: { state: 'provisional_in', boosted: true, multiplier: 10, closesAt: '2026-09-30T16:00:00Z' },
+        reward: null,
+      },
+      { // reward lead, redeemed
+        id: 'p2', firstName: 'Sam', lastName: 'Tan', phone: '+6589279750', email: 'sam@x.com',
+        leadStatus: 'new', quarantinedAt: null, campaign: { name: 'Redeem $10 Fairprice Voucher' },
+        assignedAgent: null, createdAt: '2026-07-01T08:00:00Z',
+        draw: null, reward: { state: 'redeemed', rewardTitle: '$10 voucher' },
+      },
+      { // pipeline exception — Lyfe flipped it to won; no outcome data
+        id: 'p3', firstName: 'Mei', lastName: 'Lim', phone: '+6581112222', email: 'mei@x.com',
+        leadStatus: 'won', quarantinedAt: null, campaign: { name: 'Free Pet Hotel 1 Night Trial' },
+        assignedAgent: null, createdAt: '2026-06-01T08:00:00Z',
+        draw: null, reward: null,
+      },
+      { // nothing yet — silence, not "New"
+        id: 'p4', firstName: 'Jo', lastName: 'Ng', phone: '+6583334444', email: 'jo@x.com',
+        leadStatus: 'new', quarantinedAt: null, campaign: { name: 'Free Pet Hotel 1 Night Trial' },
+        assignedAgent: null, createdAt: '2026-06-02T08:00:00Z',
+        draw: null, reward: null,
+      },
+      { // held — the alarm still overrides everything
+        id: 'p5', firstName: 'Ken', lastName: 'Ong', phone: '+6585556666', email: 'ken@x.com',
+        leadStatus: 'new', quarantinedAt: '2026-07-20T08:00:00Z', quarantineReason: 'dnc_registered',
+        campaign: { name: 'Redeem $10 Fairprice Voucher' },
+        assignedAgent: null, createdAt: '2026-06-03T08:00:00Z',
+        draw: null, reward: { state: 'reserved' },
+      },
+    ],
+    total: 5, page: 1, totalPages: 1,
+  })),
+  fetchAgentOptions: vi.fn(async () => []),
+  bulkAssign: vi.fn(),
+  bulkReturnToHeld: vi.fn(),
+  bulkDelete: vi.fn(),
+}));
+
+import { fetchProspects } from '@/api/adminV2';
+
+function setup() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/AdminProspects']}>
+        <Routes>
+          <Route path="/AdminProspects" element={<AdminV2Prospects />} />
+          <Route path="/admin/leads/:prospectId" element={<div>PROFILE</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('AdminV2Prospects outcome column', () => {
+  it('requests the outcome enrichment', async () => {
+    setup();
+    await screen.findByText('Shawn Lee');
+    expect(fetchProspects).toHaveBeenCalledWith(expect.objectContaining({ include: 'outcome' }));
+  });
+
+  it('speaks each campaign voice and silences the "New" wall', async () => {
+    setup();
+    await screen.findByText('Shawn Lee');
+    // Draw lead: multiplier chip + screening secondary.
+    expect(screen.getByText('×10 · closes 30 Sept')).toBeInTheDocument();
+    expect(screen.getByText('AI qualified')).toBeInTheDocument();
+    // Reward lead: redeemed voice.
+    expect(screen.getByText('✓ redeemed')).toBeInTheDocument();
+    // Pipeline exception still shows (won ≠ new)…
+    expect(screen.getByText('✓ Won')).toBeInTheDocument();
+    // …but the default resting state is silence, never a chip.
+    expect(screen.queryByText('New')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('No outcome yet')).toBeInTheDocument();
+  });
+
+  it('held still overrides the outcome', async () => {
+    setup();
+    await screen.findByText('Ken Ong');
+    // p5 is held with a reserved reward — the alarm wins, the voice waits.
+    expect(screen.queryByText('reserved')).not.toBeInTheDocument();
+    expect(screen.getAllByText(/DNC|Held|◆/i).length).toBeGreaterThan(0);
+  });
+
+  it('status column no longer offers a sort control', async () => {
+    setup();
+    await screen.findByText('Shawn Lee');
+    // The filter dropdown ("Status ▾") stays; the exact-named sort button is gone.
+    expect(screen.queryByRole('button', { name: 'Status' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Status.*▾/ })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Implements `docs/plans/admin-prospects-outcome-column.md` (scoped + approved today). Kills the "New" wall: the STATUS cell now shows **the lead's outcome in its campaign's own voice**, with a strict precedence — `◆ held` → outcome chip (`✓ redeemed` / `reserved` / `unlocked` / `×10 · closes 30 Sept` / `open` / `🏆 winner` / `not counted`) → pipeline status **only when ≠ new** → screening chip as before → muted `—` when nothing has happened yet.

- **`?include=outcome`** on the list endpoint: admin-only opt-in, byte-identical payload otherwise (contract-tested — agent MyProspects and the palette hit the same endpoint). Per page it's the existing `getProspectDrawStatus` batch + one indexed entitlement query, draw-linked passes excluded from the voucher voice.
- **One voice, one place**: `rowChipFor` extracted to `src/lib/adminV2/outcome.js`, shared by the list and the Lead Profile — plus the amendment the list made obvious: a boosted lead's chip now carries its earned `×N` instead of reading plain "open".
- Campaign cell gains a draw/reward type glyph; the status column's sort control is gone (outcome isn't a DB column — the Status *filter* stays); CSV export gains an `outcome` column.

Tests: 14 new across backend batching/gating and frontend voice/precedence/contract; full vitest 1933/1933, backend suites 140/140 (incl. the DB-backed contract suite), build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8jF5ZxuAZD3NazPQQMEfV