### PR TITLE
fix(wa): delivery truth — statuses webhook, UTILITY receipt twins, honest ✓

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -174,6 +174,24 @@ RETELL_SCREENING_ENABLED=false
 # 4 params — name, draw name, multiplier, prize; URL button = consent tap).
 # WHATSAPP_TEMPLATE_DRAW_CALLBACK=draw_callback_optin
 
+# WhatsApp delivery truth (docs/plans/wa-delivery-truth.md). The Meta status
+# webhook (POST /api/whatsapp/webhook) records sent/delivered/read/failed per
+# wamid — including the silent 131049 marketing-frequency-cap drops — and
+# honors STOP replies as the global unsubscribe.
+# Subscription handshake token (any random string; must match the value given
+# to Meta when subscribing the callback URL).
+# WHATSAPP_WEBHOOK_VERIFY_TOKEN=
+# MKTR_wa app secret (App Dashboard → Settings → Basic) — X-Hub-Signature-256
+# verification. PROD FAILS CLOSED without it: webhook answers 200 but drops
+# every payload.
+# WHATSAPP_APP_SECRET=
+# Pin callbacks to our WABA (entries for other WABAs are ignored).
+# WHATSAPP_WABA_ID=1912683432731970
+# UTILITY twins of the two MARKETING receipt templates (frequency-cap-exempt;
+# submitted 2026-07-26). Flip these once Meta approves them.
+# WHATSAPP_TEMPLATE_DRAW_BOOST=draw_boost_receipt_v2
+# WHATSAPP_TEMPLATE_VOUCHER=reward_voucher_v2
+
 # Webhook dispatch — MUST be "true" for leads to reach Lyfe
 WEBHOOK_ENABLED=false
 # Edge function URL for receive-mktr-lead

--- a/backend/scripts/submit-wa-marketing-templates.mjs
+++ b/backend/scripts/submit-wa-marketing-templates.mjs
@@ -20,6 +20,9 @@
  *   --text-only      submit/consider only the text-header set
  *   --images-only    submit/consider only the image-header set
  *   --callback-only  submit/consider only draw_callback_optin
+ *   --utility-only   submit/consider only the UTILITY receipt pack
+ *                    (draw_boost_receipt_v2 + reward_voucher_v2 — the
+ *                    frequency-cap-exempt twins; docs/plans/wa-delivery-truth.md)
  *   --token-stdin    read the token from stdin instead of WHATSAPP_TOKEN, so it
  *                    never lands in the command line or shell history:
  *                      pbpaste | node …/submit-wa-marketing-templates.mjs --token-stdin
@@ -253,6 +256,48 @@ export const IMAGE_TEMPLATES = TEMPLATES.map((t) => {
   };
 });
 
+// UTILITY receipts (2026-07-26) — transactional twins of two MARKETING
+// templates whose sends Meta silently drops under the per-user marketing
+// frequency cap (error 131049; docs/plans/wa-delivery-truth.md). Bodies are
+// byte-identical to the APPROVED originals — the register already reads as a
+// receipt; only the category (and with it the cap exemption) changes. Category
+// is immutable post-creation, hence the _v2 names. allow_category_change:
+// false — if Meta's classifier disagrees we want a visible INCORRECT_CATEGORY
+// rejection (editable on the REJECTED shell + resubmittable), never a silent
+// flip back to MARKETING that would quietly reinstate the cap.
+export const UTILITY_TEMPLATES = [
+  {
+    name: 'draw_boost_receipt_v2',
+    language: LANGUAGE,
+    category: 'UTILITY',
+    allow_category_change: false,
+    components: [
+      { type: 'HEADER', format: 'IMAGE', example: { header_handle: [HANDLE_PLACEHOLDER] } },
+      {
+        type: 'BODY',
+        text:
+          'Hi {{1}}, your completed review has been recorded — your entry to the {{2}} now holds {{3}} chances instead of one.\n\nNothing else to do — winners are contacted directly after the draw. We never ask you to pay to release a prize.',
+        example: { body_text: [['Shawn', 'iPhone 17 Pro Lucky Draw', '10']] },
+      },
+    ],
+  },
+  {
+    name: 'reward_voucher_v2',
+    language: LANGUAGE,
+    category: 'UTILITY',
+    allow_category_change: false,
+    components: [
+      { type: 'HEADER', format: 'IMAGE', example: { header_handle: [HANDLE_PLACEHOLDER] } },
+      {
+        type: 'BODY',
+        text:
+          "Hi {{1}}, Your {{2}} is activated. \n\nPresent the above QR to the merchant: https://redeem.sg/r/{{3}} \n\nIt's valid until {{4}}. Thank you!",
+        example: { body_text: [['Sarah', 'S$10 FairPrice voucher', 'a1b2c3d4e5f6', '17 Aug 2026']] },
+      },
+    ],
+  },
+];
+
 async function graphGet(path_, token) {
   const res = await fetch(`${BASE}${path_}`, { headers: { Authorization: `Bearer ${token}` } });
   const json = await res.json().catch(() => ({}));
@@ -446,13 +491,14 @@ function printStatusTable(existing, templates) {
 }
 
 function selectedSets() {
-  const only = ['--text-only', '--images-only', '--callback-only'].filter((f) => process.argv.includes(f));
+  const only = ['--text-only', '--images-only', '--callback-only', '--utility-only'].filter((f) => process.argv.includes(f));
   if (only.length > 1) throw new Error(`${only.join(' and ')} are mutually exclusive`);
   const all = only.length === 0;
   return {
     text: all || only[0] === '--text-only' ? TEMPLATES : [],
     callback: all || only[0] === '--callback-only' ? CALLBACK_TEMPLATES : [],
     image: all || only[0] === '--images-only' ? IMAGE_TEMPLATES : [],
+    utility: all || only[0] === '--utility-only' ? UTILITY_TEMPLATES : [],
   };
 }
 
@@ -487,8 +533,8 @@ async function postTemplate(wabaId, token, template) {
 }
 
 async function main() {
-  const { text, callback, image } = selectedSets();
-  const considered = [...text, ...callback, ...image];
+  const { text, callback, image, utility } = selectedSets();
+  const considered = [...text, ...callback, ...image, ...utility];
 
   if (process.argv.includes('--dry')) {
     console.log(JSON.stringify(considered, null, 2));
@@ -564,14 +610,17 @@ async function main() {
   await submitSet(text);
   await submitSet(callback);
 
-  if (image.length) {
-    const missing = image.filter((t) => !have.has(t.name));
+  // Image-header sets share one sample upload: the _img marketing twins and
+  // the UTILITY receipt pack both need a handle-bearing example.
+  const imageSets = [...image, ...utility];
+  if (imageSets.length) {
+    const missing = imageSets.filter((t) => !have.has(t.name));
     if (!missing.length) {
-      image.forEach((t) => console.log(`  ${t.name} already on the WABA — skipped (idempotent)`));
+      imageSets.forEach((t) => console.log(`  ${t.name} already on the WABA — skipped (idempotent)`));
     } else {
       try {
         const handle = await uploadSampleHandle(token, samplePathArg());
-        console.log('  sample image uploaded for the _img review examples');
+        console.log('  sample image uploaded for the image-header review examples');
         await submitSet(missing.map((t) => withHandle(t, handle)));
       } catch (err) {
         failed += missing.length;

--- a/backend/src/database/migrations/090-wa-message-statuses.js
+++ b/backend/src/database/migrations/090-wa-message-statuses.js
@@ -1,0 +1,35 @@
+/**
+ * 090 — WhatsApp delivery-status inbox (docs/plans/wa-delivery-truth.md).
+ *
+ * Meta reports per-message outcomes (sent/delivered/read/failed — including
+ * the silent 131049 marketing-frequency-cap drop this plan exists for) ONLY
+ * via a status webhook, and each transition only once. This table is the
+ * durable inbox those callbacks commit into BEFORE the webhook answers 200 —
+ * readers join it by wamid (redemption_events metadata.messageId) at read
+ * time, so receipt rows are never mutated and a status that arrives before
+ * its receipt commits still surfaces. recipientHash (sha256 of the E.164
+ * recipient, no raw phone) exists solely so PDPA erasure can delete a
+ * person's rows.
+ */
+export async function up(queryInterface) {
+  const q = (sql) => queryInterface.sequelize.query(sql);
+
+  await q(`CREATE TABLE IF NOT EXISTS wa_message_statuses (
+    wamid VARCHAR(128) PRIMARY KEY,
+    status VARCHAR(16) NOT NULL,
+    "errorCode" VARCHAR(16),
+    "errorTitle" VARCHAR(200),
+    "recipientHash" VARCHAR(64),
+    "occurredAt" TIMESTAMPTZ,
+    "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  )`);
+
+  await q(`CREATE INDEX IF NOT EXISTS idx_wms_recipient_hash
+    ON wa_message_statuses ("recipientHash")`);
+}
+
+export async function down(queryInterface) {
+  const q = (sql) => queryInterface.sequelize.query(sql);
+  await q('DROP TABLE IF EXISTS wa_message_statuses');
+}

--- a/backend/src/models/WaMessageStatus.js
+++ b/backend/src/models/WaMessageStatus.js
@@ -1,0 +1,37 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Durable inbox for Meta WhatsApp status callbacks (migration 090,
+ * docs/plans/wa-delivery-truth.md). One row per wamid, holding the FURTHEST
+ * delivery state Meta has reported (sent < delivered < read; failed terminal)
+ * — the webhook upserts with a rank guard in raw SQL so out-of-order and
+ * cross-instance callbacks can never downgrade a row. Receipts join this at
+ * read time via redemption_events metadata.messageId; receipt rows are never
+ * mutated. recipientHash is the erasure key (sha256 of the E.164 recipient,
+ * same recipe as consumers.phoneHash) — no raw phone is stored here.
+ */
+const WaMessageStatus = sequelize.define('WaMessageStatus', {
+  wamid: { type: DataTypes.STRING(128), primaryKey: true },
+  status: {
+    type: DataTypes.STRING(16),
+    allowNull: false,
+    comment: 'sent|delivered|read|failed — rank-guarded, never downgraded',
+  },
+  errorCode: { type: DataTypes.STRING(16), allowNull: true },
+  errorTitle: { type: DataTypes.STRING(200), allowNull: true },
+  recipientHash: {
+    type: DataTypes.STRING(64),
+    allowNull: true,
+    comment: 'sha256 hex of the E.164 recipient — PDPA erasure key, no raw phone',
+  },
+  occurredAt: { type: DataTypes.DATE, allowNull: true },
+}, {
+  tableName: 'wa_message_statuses',
+  timestamps: true,
+  indexes: [
+    { fields: ['recipientHash'], name: 'idx_wms_recipient_hash' },
+  ],
+});
+
+export default WaMessageStatus;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -395,7 +395,8 @@ export const {
   DiscoveryPlaceMemory, OutreachCadence, OutreachCadenceStep,
   OutreachCadenceTransition, OutreachCadenceEnrollment, OutreachSuppression,
   AiSettings, WalletLedger, Consumer, ConsentEvent, ConsumerSuppression,
-  SuppressionPropagation, Cohort, EmailBroadcast, EmailBroadcastRecipient
+  SuppressionPropagation, Cohort, EmailBroadcast, EmailBroadcastRecipient,
+  WaMessageStatus
 } = models;
 
 export { sequelize };

--- a/backend/src/routes/whatsappWebhook.js
+++ b/backend/src/routes/whatsappWebhook.js
@@ -1,0 +1,69 @@
+import express from 'express';
+import waWebhookService from '../services/redeemOps/waWebhookService.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Meta WhatsApp Cloud API webhook (docs/plans/wa-delivery-truth.md §B).
+ *
+ * PUBLIC, signature-authenticated — no bearer auth (Meta sends none). The
+ * global express.json verify captures req.rawBody for /api/whatsapp/ paths
+ * (server_internal.js) so X-Hub-Signature-256 (HMAC-SHA256 of the raw bytes
+ * with the MKTR_wa app secret) can be verified; the path also rides the
+ * limiter's server-to-server exemption — the HMAC check IS the rate gate
+ * (cheap reject before any processing).
+ *
+ * Security posture in production: WHATSAPP_APP_SECRET unset → answer 200 but
+ * process NOTHING (fail closed — receipt statuses and STOP suppressions must
+ * never be forgeable; the WABA repoint is gated on the secret being present
+ * anyway). Invalid signature → 401. Outside production the check relaxes to
+ * whatever is configured so unit tests and local tinkering can exercise the
+ * pipeline without Meta.
+ *
+ * 200 is sent ONLY after the inbox upsert commits (Meta's retry is the
+ * durability story: transient DB failure → 500 → Meta redelivers, and every
+ * write in the processor is idempotent).
+ */
+export const meta = { path: '/api/whatsapp' };
+
+const router = express.Router();
+
+router.get('/webhook', (req, res) => {
+  const expected = process.env.WHATSAPP_WEBHOOK_VERIFY_TOKEN;
+  if (
+    req.query['hub.mode'] === 'subscribe'
+    && expected
+    && req.query['hub.verify_token'] === expected
+  ) {
+    return res.status(200).send(String(req.query['hub.challenge'] ?? ''));
+  }
+  return res.sendStatus(403);
+});
+
+router.post('/webhook', async (req, res) => {
+  const secret = process.env.WHATSAPP_APP_SECRET;
+  const isProd = process.env.NODE_ENV === 'production';
+
+  if (!secret) {
+    if (isProd) {
+      logger.warn('redeem_ops.wa.webhook_unverifiable', { reason: 'WHATSAPP_APP_SECRET unset — payload dropped' });
+      return res.sendStatus(200);
+    }
+    // Non-prod without a secret: process unverified (local/test pipeline).
+  } else if (!waWebhookService.verifySignature(req.rawBody, req.get('x-hub-signature-256'), secret)) {
+    logger.warn('redeem_ops.wa.webhook_bad_signature', {});
+    return res.sendStatus(401);
+  }
+
+  try {
+    const counts = await waWebhookService.processPayload(req.body);
+    if (counts.statuses || counts.stops || counts.unmatchedForeign || counts.skippedEntries) {
+      logger.info('redeem_ops.wa.webhook_processed', counts);
+    }
+    return res.sendStatus(200);
+  } catch (err) {
+    logger.error('redeem_ops.wa.webhook_persist_failed', { error: err?.message });
+    return res.sendStatus(500);
+  }
+});
+
+export default router;

--- a/backend/src/server_internal.js
+++ b/backend/src/server_internal.js
@@ -108,14 +108,17 @@ export const init = async (app) => {
         ? parseInt(process.env.RATE_LIMIT_MAX_REQUESTS) || 200
         : parseInt(process.env.RATE_LIMIT_MAX_REQUESTS) || 1000000;
     },
-    // Exempt server-to-server webhooks under /api/integrations/lyfe/ and
-    // /api/external/ — they are HMAC-authenticated (not IP-based), and a
-    // Supabase pg_net burst or a reconciliation backfill must not be throttled
-    // by the public IP limiter.
+    // Exempt server-to-server webhooks under /api/integrations/lyfe/,
+    // /api/external/ and /api/whatsapp/ — they are HMAC-authenticated (not
+    // IP-based), and a Supabase pg_net burst, a reconciliation backfill or a
+    // Meta status-callback burst must not be throttled by the public IP
+    // limiter. The WhatsApp route rejects unsigned traffic with a cheap HMAC
+    // check before doing any work.
     skip: (req) =>
       !isProd ||
       req.originalUrl.startsWith('/api/integrations/lyfe/') ||
-      req.originalUrl.startsWith('/api/external/'),
+      req.originalUrl.startsWith('/api/external/') ||
+      req.originalUrl.startsWith('/api/whatsapp/'),
     message: 'Too many requests from this IP, please try again later.',
   });
   // Ensure we decode JWT (if present) before limiter so skip() can see admin
@@ -150,6 +153,7 @@ export const init = async (app) => {
   //   - /api/retell/         — Retell AI call webhooks (HMAC-signed)
   //   - /api/integrations/lyfe/ — Lyfe→MKTR push (notify_mktr_user_change trigger; HMAC since 2026-05-12)
   //   - /api/external/       — MKTR Leads buyer app → lead outcomes (HMAC, body-only)
+  //   - /api/whatsapp/       — Meta status/inbound webhook (X-Hub-Signature-256 over raw bytes)
   app.use(
     express.json({
       limit: '1mb',
@@ -157,7 +161,8 @@ export const init = async (app) => {
         if (
           req.originalUrl.startsWith('/api/retell/') ||
           req.originalUrl.startsWith('/api/integrations/lyfe/') ||
-          req.originalUrl.startsWith('/api/external/')
+          req.originalUrl.startsWith('/api/external/') ||
+          req.originalUrl.startsWith('/api/whatsapp/')
         ) {
           req.rawBody = buf;
         }

--- a/backend/src/services/erasureService.js
+++ b/backend/src/services/erasureService.js
@@ -479,11 +479,15 @@ export function makeErasureService(overrides = {}) {
           { replacements: { eids }, transaction: t }
         );
         report.redemptions = rowCount(rMeta);
+        // messageId/providerMessageId are provider correlation ids
+        // (wa-delivery-truth): dropping them here also unlinks the person's
+        // wa_message_statuses rows from any receipt — a late Meta callback
+        // can then never re-attach delivery detail to an erased person.
         const [, reMeta] = await d.sequelize.query(
           `UPDATE redemption_events
-              SET metadata = (metadata - 'to' - 'reason' - 'error')
+              SET metadata = (metadata - 'to' - 'reason' - 'error' - 'messageId' - 'providerMessageId')
             WHERE "entitlementId" IN (:eids) AND metadata IS NOT NULL
-              AND (metadata ? 'to' OR metadata ? 'reason' OR metadata ? 'error')`,
+              AND (metadata ?| array['to', 'reason', 'error', 'messageId', 'providerMessageId'])`,
           { replacements: { eids }, transaction: t }
         );
         report.redemptionEvents = rowCount(reMeta);
@@ -501,6 +505,19 @@ export function makeErasureService(overrides = {}) {
           { replacements: { auditEntityIds }, transaction: t }
         );
         report.auditReasons = rowCount(arMeta);
+      }
+
+      // 11b. WhatsApp status inbox (wa-delivery-truth): recipientHash shares
+      // consumers.phoneHash's recipe, so one keyed DELETE removes the person's
+      // delivery telemetry — including screening-callback sends, which have
+      // statuses but no entitlement receipt. Runs outside the eids guard for
+      // exactly that reason. Pure telemetry, so deletion (not scrubbing).
+      if (consumer.phoneHash) {
+        const [, wmsMeta] = await d.sequelize.query(
+          'DELETE FROM wa_message_statuses WHERE "recipientHash" = :ph',
+          { replacements: { ph: consumer.phoneHash }, transaction: t }
+        );
+        report.waMessageStatuses = rowCount(wmsMeta);
       }
 
       // 12. Draw entries (prospect join + phoneHash fallback — draw_entries

--- a/backend/src/services/leadProfileService.js
+++ b/backend/src/services/leadProfileService.js
@@ -94,20 +94,45 @@ export function makeLeadProfileService(overrides = {}) {
   async function deliveryReceipts(entitlementIds) {
     const map = new Map();
     if (!entitlementIds.length) return map;
+    // COALESCE inside DISTINCT ON so legacy channel-less rows group WITH email
+    // (not as a separate NULL group that JS then collapses over email), and
+    // id DESC as a deterministic tie-break for same-timestamp receipts. The
+    // LEFT JOIN pulls post-acceptance truth (Meta status inbox, keyed by the
+    // receipt's wamid) — null delivery means "accepted, nothing further heard",
+    // which is exactly what legacy rows and emails show today.
     const [rows] = await d.sequelize.query(
-      `SELECT DISTINCT ON ("entitlementId", metadata->>'channel')
-              "entitlementId", type, "createdAt",
-              metadata->>'channel' AS channel, metadata->>'kind' AS kind
-         FROM redemption_events
-        WHERE "entitlementId" IN (:ids) AND type IN ('notified', 'notify_failed')
-        ORDER BY "entitlementId", metadata->>'channel', "createdAt" DESC`,
+      `SELECT DISTINCT ON (re."entitlementId", COALESCE(re.metadata->>'channel', 'email'))
+              re."entitlementId", re.type, re."createdAt",
+              COALESCE(re.metadata->>'channel', 'email') AS channel,
+              re.metadata->>'kind' AS kind,
+              re.metadata->>'error' AS error,
+              s.status AS delivery_status, s."occurredAt" AS delivery_at,
+              s."errorCode" AS delivery_error_code, s."errorTitle" AS delivery_error_title
+         FROM redemption_events re
+         LEFT JOIN wa_message_statuses s ON s.wamid = re.metadata->>'messageId'
+        WHERE re."entitlementId" IN (:ids) AND re.type IN ('notified', 'notify_failed')
+        ORDER BY re."entitlementId", COALESCE(re.metadata->>'channel', 'email'),
+                 re."createdAt" DESC, re.id DESC`,
       { replacements: { ids: entitlementIds } }
     );
     for (const r of rows) {
       const key = String(r.entitlementId);
       if (!map.has(key)) map.set(key, { email: null, whatsapp: null });
       const channel = r.channel === 'whatsapp' ? 'whatsapp' : 'email';
-      map.get(key)[channel] = { kind: r.kind || null, at: r.createdAt, ok: r.type === 'notified' };
+      map.get(key)[channel] = {
+        kind: r.kind || null,
+        at: r.createdAt,
+        ok: r.type === 'notified',
+        ...(r.error ? { error: r.error } : {}),
+        delivery: r.delivery_status
+          ? {
+              status: r.delivery_status,
+              at: r.delivery_at,
+              errorCode: r.delivery_error_code,
+              errorTitle: r.delivery_error_title,
+            }
+          : null,
+      };
     }
     return map;
   }

--- a/backend/src/services/mailer.js
+++ b/backend/src/services/mailer.js
@@ -71,8 +71,18 @@ export async function sendEmail({ to, subject, html, text, context, from, attach
     // logs (docs/redeem-ops/MKTR_INTEGRATION.md §2).
     // `headers` (optional, nodemailer passthrough) carries List-Unsubscribe /
     // List-Unsubscribe-Post on consumer emails (PR B).
-    await transporter.sendMail({ from: resolvedFrom, to, subject, html, text, ...(attachments ? { attachments } : {}), ...(headers ? { headers } : {}) });
-    return { success: true };
+    const info = await transporter.sendMail({ from: resolvedFrom, to, subject, html, text, ...(attachments ? { attachments } : {}), ...(headers ? { headers } : {}) });
+    // Provider correlation id (wa-delivery-truth §C): SES answers
+    // "250 Ok <ses-message-id>" — that id is what SES event notifications key
+    // on, so it must survive here or delivery/bounce can never be tied back.
+    // Non-SES SMTP hosts get whatever their 250 line carries, labeled 'smtp'.
+    const isSes = /\.amazonaws\.com$/i.test(process.env.EMAIL_HOST || '');
+    const providerMessageId = (typeof info?.response === 'string' && info.response.match(/^250 Ok (\S+)/i)?.[1])
+      || info?.messageId || null;
+    return {
+      success: true,
+      ...(providerMessageId ? { providerMessageId, provider: isSes ? 'ses' : 'smtp' } : {}),
+    };
   } catch (err) {
     // Surface SES/SMTP rejection details — Nodemailer attaches `code`,
     // `responseCode`, and `response` (the full SMTP message). Without

--- a/backend/src/services/redeemOps/entitlementService.js
+++ b/backend/src/services/redeemOps/entitlementService.js
@@ -1,7 +1,7 @@
 import { Op } from 'sequelize';
 import {
   RewardEntitlement, RedemptionEvent, Redemption, Activation, ActivationIssuanceSkip, RewardOffer,
-  PartnerOrganisation, Prospect, User, Consumer, Campaign, sequelize,
+  PartnerOrganisation, Prospect, User, Consumer, Campaign, WaMessageStatus, sequelize,
 } from '../../models/index.js';
 import { phoneVerificationIsCurrent } from '../consumerService.js';
 import { AppError } from '../../middleware/errorHandler.js';
@@ -64,7 +64,7 @@ export async function flushDeliveries() {
 export function makeEntitlementService(overrides = {}) {
   const d = {
     RewardEntitlement, RedemptionEvent, Redemption, Activation, ActivationIssuanceSkip, RewardOffer,
-    PartnerOrganisation, Prospect, User, Consumer, Campaign, sequelize, logger,
+    PartnerOrganisation, Prospect, User, Consumer, Campaign, WaMessageStatus, sequelize, logger,
     inventory: makeInventoryService(),
     audit: makeRedeemOpsAuditService(),
     notifyUnlock: null, // injected by entitlementWiring (voucher email) — null-safe
@@ -218,6 +218,13 @@ export function makeEntitlementService(overrides = {}) {
           kind,
           channel,
           to: r.to || null, // already masked by the sender
+          // Provider correlation ids (docs/plans/wa-delivery-truth.md):
+          // messageId (wamid) keys the wa_message_statuses read-time join;
+          // providerMessageId is the SMTP/SES id for the future SES-events
+          // leg. Both are scrubbed by PDPA erasure.
+          ...(r.messageId ? { messageId: r.messageId } : {}),
+          ...(r.templateName ? { templateName: r.templateName } : {}),
+          ...(r.providerMessageId ? { providerMessageId: r.providerMessageId, provider: r.provider || null } : {}),
           ...(r.error ? { error: String(r.error).slice(0, 200) } : {}),
         },
       });
@@ -690,15 +697,25 @@ export function makeEntitlementService(overrides = {}) {
     const entitlement = await d.RewardEntitlement.findByPk(id);
     if (!entitlement) throw new AppError('Entitlement not found', 404);
 
-    const kind = entitlement.status === 'eligible' ? 'pass'
+    let kind = entitlement.status === 'eligible' ? 'pass'
       : entitlement.status === 'issued' ? 'voucher' : null;
     if (!kind) throw new AppError(`Entitlement is ${entitlement.status}`, 409);
     // Draw rails (PR-4/CX22): a recorded session holds NO voucher — rotating
     // tokenHash and mailing partner-redemption copy would mint the credential
-    // CX22 forbids. Re-sending the ENTRY PASS (eligible) stays fine.
-    const resendDrawCtx = await d.drawLink.drawContextForEntitlement(entitlement).catch(() => null);
-    if (kind === 'voucher' && resendDrawCtx) {
-      throw new AppError('This is a recorded lucky-draw session — there is no voucher to resend', 409);
+    // CX22 forbids. Its resend is the informational ×N BOOST RECEIPT: no
+    // token, no rotation, same audit shape (wa-delivery-truth — the capped
+    // 131049 receipt needed exactly this recovery). Classification fails
+    // CLOSED: a draw-lookup error on an issued row must retry later, never
+    // fall through to minting a voucher for what might be a draw session.
+    const resendDrawCtx = await d.drawLink.drawContextForEntitlement(entitlement).catch((err) => {
+      if (kind === 'voucher') {
+        throw new AppError(`Draw classification failed (${err?.message || 'lookup error'}) — retry shortly`, 503);
+      }
+      return null;
+    });
+    if (kind === 'voucher' && resendDrawCtx) kind = 'boost_receipt';
+    if (kind === 'boost_receipt' && channel === 'link') {
+      throw new AppError('A recorded draw session has no credential to share — resend the receipt by email or WhatsApp', 409);
     }
     if (entitlement.expiresAt && new Date(entitlement.expiresAt) <= new Date()) {
       throw new AppError('Reward has expired — nothing to resend', 409);
@@ -728,7 +745,7 @@ export function makeEntitlementService(overrides = {}) {
       order: [['createdAt', 'DESC']],
       limit: 10,
     });
-    const resendAction = kind === 'pass' ? 'resend_pass' : 'resend_voucher';
+    const resendAction = kind === 'pass' ? 'resend_pass' : kind === 'boost_receipt' ? 'resend_boost' : 'resend_voucher';
     const clash = recent.some((e) => {
       const m = e.metadata || {};
       if (e.type === 'manual_override') return m.action === resendAction || (m.action === 'auto_resend' && m.kind === kind);
@@ -738,21 +755,25 @@ export function makeEntitlementService(overrides = {}) {
       throw new AppError('A delivery for this reward was attempted less than a minute ago — wait and retry', 429);
     }
 
-    const fresh = mintToken();
-    const fields = kind === 'pass'
-      ? { presentationTokenHash: fresh.hash }
-      : { tokenHash: fresh.hash, tokenHint: tokenHintOf(fresh.raw) };
+    // boost_receipt carries NO credential — nothing to mint or rotate; the
+    // audit trail still gets its manual_override + audit rows.
+    const fresh = kind === 'boost_receipt' ? null : mintToken();
     await d.sequelize.transaction(async (t) => {
-      const [count] = await d.RewardEntitlement.update(fields, {
-        where: {
-          id,
-          status: entitlement.status, // conditional — unlock/redeem/cancel races lose here
-          [Op.or]: [{ expiresAt: null }, { expiresAt: { [Op.gt]: d.sequelize.literal('NOW()') } }],
-        },
-        transaction: t,
-      });
-      if (count === 0) {
-        throw new AppError('Reward state changed (unlocked, redeemed or expired) — refresh and retry', 409);
+      if (fresh) {
+        const fields = kind === 'pass'
+          ? { presentationTokenHash: fresh.hash }
+          : { tokenHash: fresh.hash, tokenHint: tokenHintOf(fresh.raw) };
+        const [count] = await d.RewardEntitlement.update(fields, {
+          where: {
+            id,
+            status: entitlement.status, // conditional — unlock/redeem/cancel races lose here
+            [Op.or]: [{ expiresAt: null }, { expiresAt: { [Op.gt]: d.sequelize.literal('NOW()') } }],
+          },
+          transaction: t,
+        });
+        if (count === 0) {
+          throw new AppError('Reward state changed (unlocked, redeemed or expired) — refresh and retry', 409);
+        }
       }
       await writeEvent(t, {
         entitlementId: id, type: 'manual_override', actorType: 'staff', actorUserId: user.id,
@@ -780,10 +801,12 @@ export function makeEntitlementService(overrides = {}) {
       });
       return { entitlement, kind, channel, emailQueued: false, ...bundle };
     }
+    // boost_receipt rides the same call: fresh is null so both tokens stay
+    // null, and queueDelivery's kind switch selects {entitlement, drawCtx}.
     const emailQueued = queueDelivery({
       entitlement, prospect, kind,
-      presentationToken: kind === 'pass' ? fresh.raw : null,
-      voucherToken: kind === 'voucher' ? fresh.raw : null,
+      presentationToken: kind === 'pass' && fresh ? fresh.raw : null,
+      voucherToken: kind === 'voucher' && fresh ? fresh.raw : null,
       drawCtx: resendDrawCtx,
       channels: [wantWa ? 'whatsapp' : null, wantEmail ? 'email' : null].filter(Boolean),
     });
@@ -1064,6 +1087,29 @@ export function makeEntitlementService(overrides = {}) {
       const key = `${e.entitlementId}:${e.metadata?.channel || 'email'}`;
       if (!latestReceipt.has(key)) latestReceipt.set(key, e); // DESC → first is latest
     }
+    // Post-acceptance truth (wa-delivery-truth): join the Meta status inbox by
+    // wamid so the console can distinguish accepted from delivered/failed.
+    const wamids = [...new Set(
+      [...latestReceipt.values()].map((e) => e.metadata?.messageId).filter(Boolean)
+    )];
+    const statusByWamid = new Map();
+    if (wamids.length) {
+      for (const s of await d.WaMessageStatus.findAll({ where: { wamid: { [Op.in]: wamids } } })) {
+        statusByWamid.set(s.wamid, s);
+      }
+    }
+    const receiptView = (e) => {
+      if (!e) return null;
+      const s = e.metadata?.messageId ? statusByWamid.get(e.metadata.messageId) : null;
+      return {
+        kind: e.metadata?.kind || null,
+        at: e.createdAt,
+        ok: e.type === 'notified',
+        delivery: s
+          ? { status: s.status, at: s.occurredAt, errorCode: s.errorCode, errorTitle: s.errorTitle }
+          : null,
+      };
+    };
 
     // Draw-linkage per activation (PR-4) — one lookup per distinct activation,
     // so the console can voice draw rows ("Session ×N") and offer Undo.
@@ -1087,11 +1133,9 @@ export function makeEntitlementService(overrides = {}) {
       // for transactional, 3sites) stays authoritative. Flag off ⇒ false
       // everywhere, so the console never offers a channel that can't fire.
       j.whatsappDeliverable = waEnabled() && Boolean(waRecipient(j.prospect?.phone));
-      const em = latestReceipt.get(`${j.id}:email`);
-      const wa = latestReceipt.get(`${j.id}:whatsapp`);
       j.delivery = {
-        email: em ? { kind: em.metadata?.kind || null, at: em.createdAt, ok: em.type === 'notified' } : null,
-        whatsapp: wa ? { kind: wa.metadata?.kind || null, at: wa.createdAt, ok: wa.type === 'notified' } : null,
+        email: receiptView(latestReceipt.get(`${j.id}:email`)),
+        whatsapp: receiptView(latestReceipt.get(`${j.id}:whatsapp`)),
       };
       if (j.prospect) {
         if (j.prospect.phone) j.prospect.phone = `••••${String(j.prospect.phone).slice(-4)}`;

--- a/backend/src/services/redeemOps/fulfilmentNotify.js
+++ b/backend/src/services/redeemOps/fulfilmentNotify.js
@@ -103,11 +103,18 @@ export function makeFulfilmentNotify(overrides = {}) {
     return { offer, activation, rewardName, partnerName };
   }
 
-  /** Wraps sendEmail into the normalized result — resolves, never throws. */
+  /** Wraps sendEmail into the normalized result — resolves, never throws.
+   * providerMessageId/provider ride through to the receipt (wa-delivery-truth
+   * §C: the SES id is the only handle a future bounce/delivery event has). */
   async function deliver(mail, to) {
     try {
       const r = await d.sendEmail(mail);
-      if (r?.success === true) return { sent: true, to: maskEmail(to) };
+      if (r?.success === true) {
+        return {
+          sent: true, to: maskEmail(to),
+          ...(r.providerMessageId ? { providerMessageId: r.providerMessageId, provider: r.provider || null } : {}),
+        };
+      }
       return { sent: false, to: maskEmail(to), error: r?.message || 'mailer not configured' };
     } catch (err) {
       return { sent: false, to: maskEmail(to), error: err?.message || 'send failed' };
@@ -152,7 +159,12 @@ export function makeFulfilmentNotify(overrides = {}) {
           { ...plain, campaign },
           { drawPass: { png: qrPng, link, deadlineLong: boostDeadlineLong(drawCtx.boostClosesAt) } }
         );
-        if (r?.success === true) return { sent: true, to: maskEmail(prospect.email) };
+        if (r?.success === true) {
+          return {
+            sent: true, to: maskEmail(prospect.email),
+            ...(r.providerMessageId ? { providerMessageId: r.providerMessageId, provider: r.provider || null } : {}),
+          };
+        }
         return { sent: false, to: maskEmail(prospect.email), error: r?.message || 'mailer not configured' };
       } catch (err) {
         return { sent: false, to: maskEmail(prospect.email), error: err?.message || 'send failed' };

--- a/backend/src/services/redeemOps/waWebhookService.js
+++ b/backend/src/services/redeemOps/waWebhookService.js
@@ -1,0 +1,191 @@
+import crypto from 'crypto';
+import { sequelize } from '../../database/connection.js';
+import Consumer from '../../models/Consumer.js';
+import { applyUnsubscribe } from '../consentService.js';
+import { phoneHashOf } from '../consumerService.js';
+import { normalizePhone } from '../prospectHelpers.js';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Meta WhatsApp webhook processing (docs/plans/wa-delivery-truth.md §B).
+ *
+ * Two payload species, both handled here:
+ *  - `statuses[]` — per-message delivery outcomes (sent/delivered/read/failed,
+ *    including the silent 131049 marketing-frequency-cap drop that motivated
+ *    this file). Each lands as a rank-guarded atomic upsert into the
+ *    wa_message_statuses inbox; readers join it by wamid. The upsert must
+ *    COMMIT before the route answers 200 — Meta's retry is our durability, so
+ *    a persistence failure must surface as a 5xx, never be swallowed.
+ *  - `messages[]` — inbound customer messages. The only ones acted on are the
+ *    marketing-pack STOP forms ("Stop promotions" quick-reply or typed
+ *    stop/unsubscribe/cancel), which map to the existing GLOBAL unsubscribe
+ *    (channel 'all' + reason 'unsubscribe', source 'wa_stop') — deliberately
+ *    NOT a new suppression channel: the model has no per-channel reason and
+ *    the existing resubscribe path must be able to lift it.
+ *    applyUnsubscribe is idempotent, so Meta redelivery is harmless.
+ *
+ * Payloads are bound to OUR assets: when WHATSAPP_WABA_ID /
+ * WHATSAPP_PHONE_NUMBER_ID are set, entries for any other WABA or sender
+ * number are skipped (a valid signature alone doesn't prove the callback is
+ * about our sender). Statuses with unknown wamids are logged and kept — a
+ * status can legitimately beat its receipt's commit; the read-time join
+ * resolves whenever the receipt lands.
+ */
+
+// Rank order is Meta's own lifecycle; failed is terminal and outranks read so
+// a post-hoc failure verdict always wins the row.
+const STATUS_RANK_SQL = `CASE %s WHEN 'sent' THEN 1 WHEN 'delivered' THEN 2 WHEN 'read' THEN 3 WHEN 'failed' THEN 4 ELSE 0 END`;
+const KNOWN_STATUSES = new Set(['sent', 'delivered', 'read', 'failed']);
+const STOP_FORMS = new Set(['stop', 'stop promotions', 'unsubscribe', 'cancel']);
+// Bound per-request work: Meta batches are small in practice; anything larger
+// than this is hostile or malformed and the tail is dropped (logged).
+const MAX_ITEMS = 200;
+
+export function makeWaWebhookService(overrides = {}) {
+  const d = {
+    sequelize,
+    Consumer,
+    applyUnsubscribe,
+    phoneHashOf,
+    normalizePhone,
+    logger,
+    ...overrides,
+  };
+
+  /** HMAC-SHA256 of the RAW body against X-Hub-Signature-256. */
+  function verifySignature(rawBody, header, secret) {
+    if (!secret) return false;
+    if (!rawBody || !header || typeof header !== 'string' || !header.startsWith('sha256=')) return false;
+    const theirs = Buffer.from(header.slice('sha256='.length), 'utf8');
+    const ours = Buffer.from(
+      crypto.createHmac('sha256', secret).update(rawBody).digest('hex'),
+      'utf8'
+    );
+    return theirs.length === ours.length && crypto.timingSafeEqual(theirs, ours);
+  }
+
+  /**
+   * Atomic, rank-guarded upsert. One SQL statement so concurrent callbacks
+   * (multi-instance deploys, Meta redelivery, out-of-order sent-after-read)
+   * can never lose or downgrade state. errorCode/errorTitle stick once set —
+   * a later non-failed transition must not blank the recorded failure detail.
+   */
+  async function upsertStatus({ wamid, status, errorCode = null, errorTitle = null, recipientHash = null, occurredAt = null }) {
+    if (!wamid || !KNOWN_STATUSES.has(status)) return false;
+    await d.sequelize.query(
+      `INSERT INTO wa_message_statuses
+         (wamid, status, "errorCode", "errorTitle", "recipientHash", "occurredAt", "createdAt", "updatedAt")
+       VALUES (:wamid, :status, :errorCode, :errorTitle, :recipientHash, :occurredAt, NOW(), NOW())
+       ON CONFLICT (wamid) DO UPDATE SET
+         status = EXCLUDED.status,
+         "errorCode" = COALESCE(EXCLUDED."errorCode", wa_message_statuses."errorCode"),
+         "errorTitle" = COALESCE(EXCLUDED."errorTitle", wa_message_statuses."errorTitle"),
+         "recipientHash" = COALESCE(EXCLUDED."recipientHash", wa_message_statuses."recipientHash"),
+         "occurredAt" = COALESCE(EXCLUDED."occurredAt", wa_message_statuses."occurredAt"),
+         "updatedAt" = NOW()
+       WHERE ${STATUS_RANK_SQL.replace('%s', 'EXCLUDED.status')}
+           > ${STATUS_RANK_SQL.replace('%s', 'wa_message_statuses.status')}`,
+      {
+        replacements: {
+          wamid: String(wamid).slice(0, 128),
+          status,
+          errorCode: errorCode != null ? String(errorCode).slice(0, 16) : null,
+          errorTitle: errorTitle != null ? String(errorTitle).slice(0, 200) : null,
+          recipientHash,
+          occurredAt,
+        },
+      }
+    );
+    return true;
+  }
+
+  /** The STOP text of an inbound message, or null. Quick-reply buttons carry
+   * their label in button.text (payload mirrors it); typed messages in
+   * text.body. */
+  function stopTextOf(message) {
+    const candidates = [message?.button?.text, message?.button?.payload, message?.text?.body];
+    for (const c of candidates) {
+      if (typeof c === 'string' && STOP_FORMS.has(c.trim().toLowerCase())) return c.trim();
+    }
+    return null;
+  }
+
+  async function handleStop(message) {
+    const waId = message?.from;
+    if (!waId || !/^\d{7,15}$/.test(String(waId))) return { handled: false, reason: 'bad_sender' };
+    const phone = d.normalizePhone(String(waId));
+    const consumer = await d.Consumer.findOne({ where: { phone } });
+    if (!consumer) {
+      d.logger.info('redeem_ops.wa.stop_unknown_phone', { phoneHash: d.phoneHashOf(phone) });
+      return { handled: false, reason: 'unknown_phone' };
+    }
+    const { alreadySuppressed } = await d.applyUnsubscribe(consumer, { source: 'wa_stop' });
+    d.logger.info('redeem_ops.wa.stop_applied', { consumerId: consumer.id, alreadySuppressed });
+    return { handled: true, alreadySuppressed };
+  }
+
+  /**
+   * Process a verified webhook body. Throws on persistence failure — the
+   * route maps that to 5xx so Meta retries; a thrown error after SOME items
+   * persisted is safe because every write here is idempotent.
+   */
+  async function processPayload(body) {
+    const counts = { statuses: 0, stops: 0, skippedEntries: 0, unmatchedForeign: 0 };
+    if (body?.object !== 'whatsapp_business_account' || !Array.isArray(body?.entry)) return counts;
+
+    const wantWaba = process.env.WHATSAPP_WABA_ID || null;
+    const wantPhoneId = process.env.WHATSAPP_PHONE_NUMBER_ID || null;
+    let budget = MAX_ITEMS;
+
+    for (const entry of body.entry.slice(0, 50)) {
+      if (wantWaba && String(entry?.id) !== String(wantWaba)) {
+        counts.unmatchedForeign += 1;
+        continue;
+      }
+      for (const change of (Array.isArray(entry?.changes) ? entry.changes : [])) {
+        if (change?.field !== 'messages') continue;
+        const value = change?.value || {};
+        if (wantPhoneId && value?.metadata?.phone_number_id
+            && String(value.metadata.phone_number_id) !== String(wantPhoneId)) {
+          counts.unmatchedForeign += 1;
+          continue;
+        }
+
+        for (const s of (Array.isArray(value.statuses) ? value.statuses : [])) {
+          if (budget-- <= 0) { counts.skippedEntries += 1; continue; }
+          const err = Array.isArray(s?.errors) ? s.errors[0] : null;
+          const ok = await upsertStatus({
+            wamid: s?.id,
+            status: s?.status,
+            errorCode: err?.code != null ? String(err.code) : null,
+            errorTitle: err?.title || err?.message || null,
+            recipientHash: s?.recipient_id ? d.phoneHashOf(d.normalizePhone(String(s.recipient_id))) : null,
+            occurredAt: s?.timestamp ? new Date(Number(s.timestamp) * 1000) : null,
+          });
+          if (ok) {
+            counts.statuses += 1;
+            d.logger.info('redeem_ops.wa.delivery_status', {
+              wamid: s?.id, status: s?.status,
+              ...(err ? { errorCode: err.code, errorTitle: err.title || err.message } : {}),
+            });
+          }
+        }
+
+        for (const m of (Array.isArray(value.messages) ? value.messages : [])) {
+          if (budget-- <= 0) { counts.skippedEntries += 1; continue; }
+          if (!stopTextOf(m)) continue;
+          const r = await handleStop(m);
+          if (r.handled) counts.stops += 1;
+        }
+      }
+    }
+    return counts;
+  }
+
+  return { verifySignature, upsertStatus, processPayload, stopTextOf };
+}
+
+const _default = makeWaWebhookService();
+export const verifySignature = _default.verifySignature;
+export const processPayload = _default.processPayload;
+export default _default;

--- a/backend/src/services/redeemOps/whatsappService.js
+++ b/backend/src/services/redeemOps/whatsappService.js
@@ -283,11 +283,23 @@ export function makeWhatsappService(overrides = {}) {
           const err = await res.json();
           detail = err?.error ? `${err.error.code || res.status}: ${err.error.message || ''}` : detail;
         } catch { /* non-JSON error body — keep the status */ }
-        return { sent: false, to: maskPhone(prospect.phone), error: `Meta API: ${detail}` };
+        return { sent: false, to: maskPhone(prospect.phone), templateName, error: `Meta API: ${detail}` };
       }
-      return { sent: true, to: maskPhone(prospect.phone) };
+      // The wamid keys the delivery-truth join (wa_message_statuses) — a 2xx
+      // without one is still a successful send ("accepted, untrackable"), so
+      // the parse must never throw a delivered message into the failed path.
+      let messageId = null;
+      try {
+        const json = await res.json();
+        messageId = json?.messages?.[0]?.id || null;
+      } catch { /* accepted, untrackable */ }
+      if (!messageId) d.logger.warn('redeem_ops.whatsapp.no_wamid', { template: templateName });
+      return {
+        sent: true, to: maskPhone(prospect.phone), templateName,
+        ...(messageId ? { messageId } : {}),
+      };
     } catch (err) {
-      return { sent: false, to: maskPhone(prospect.phone), error: err?.message || 'send failed' };
+      return { sent: false, to: maskPhone(prospect.phone), templateName, error: err?.message || 'send failed' };
     }
   }
 

--- a/backend/src/services/retellScreeningService.js
+++ b/backend/src/services/retellScreeningService.js
@@ -515,6 +515,10 @@ export function makeRetellScreeningService(overrides = {}) {
       });
       await patchWaCallback(prospect.id, {
         sent: result?.sent === true,
+        // wamid keys the wa_message_statuses inbox (wa-delivery-truth) — this
+        // send writes no entitlement receipt, so the id here is the ONLY
+        // handle for tying a later delivered/failed verdict to the invite.
+        ...(result?.messageId ? { messageId: result.messageId } : {}),
         ...(result?.skipped ? { skipped: result.skipped } : {}),
         ...(result?.error ? { error: String(result.error).slice(0, 200) } : {}),
       });

--- a/backend/src/tests/waWebhook.test.js
+++ b/backend/src/tests/waWebhook.test.js
@@ -1,0 +1,225 @@
+import crypto from 'crypto';
+import express from 'express';
+import request from 'supertest';
+import { jest } from '@jest/globals';
+import { makeWaWebhookService } from '../services/redeemOps/waWebhookService.js';
+
+/**
+ * wa-delivery-truth §B — the Meta status webhook, DB-free (sequelize/Consumer/
+ * applyUnsubscribe are DI fakes). Covers: signature verification, WABA/phone
+ * binding, the rank-guarded inbox upsert call shape, error propagation
+ * (Meta-retry contract), STOP normalization + the global-unsubscribe mapping,
+ * and the route's auth posture (prod fail-closed without a secret).
+ * Real rank arithmetic lives in SQL and is exercised against prod-shaped
+ * Postgres by the migration; here we assert the statement carries the guard.
+ */
+
+const silentLogger = { error: () => {}, warn: () => {}, info: () => {} };
+const SECRET = 'test-app-secret';
+
+function sign(raw, secret = SECRET) {
+  return `sha256=${crypto.createHmac('sha256', secret).update(raw).digest('hex')}`;
+}
+
+function statusPayload(overrides = {}) {
+  return {
+    object: 'whatsapp_business_account',
+    entry: [{
+      id: '1912683432731970',
+      changes: [{
+        field: 'messages',
+        value: {
+          metadata: { phone_number_id: '1202575549609564' },
+          statuses: [{
+            id: 'wamid.TEST1', status: 'failed', timestamp: '1785006378',
+            recipient_id: '6580129432',
+            errors: [{ code: 131049, title: 'This message was not delivered to maintain healthy ecosystem engagement.' }],
+          }],
+          ...overrides.value,
+        },
+      }],
+      ...overrides.entry,
+    }],
+    ...overrides.root,
+  };
+}
+
+function makeSvc(overrides = {}) {
+  const query = jest.fn(async () => [[], {}]);
+  const svc = makeWaWebhookService({
+    sequelize: { query },
+    Consumer: { findOne: jest.fn(async () => null) },
+    applyUnsubscribe: jest.fn(async () => ({ alreadySuppressed: false })),
+    logger: silentLogger,
+    ...overrides,
+  });
+  return { svc, query };
+}
+
+const ENV_KEYS = ['WHATSAPP_WABA_ID', 'WHATSAPP_PHONE_NUMBER_ID', 'WHATSAPP_APP_SECRET', 'WHATSAPP_WEBHOOK_VERIFY_TOKEN', 'NODE_ENV'];
+let savedEnv;
+beforeEach(() => {
+  savedEnv = {};
+  for (const k of ENV_KEYS) { savedEnv[k] = process.env[k]; delete process.env[k]; }
+});
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+describe('verifySignature', () => {
+  const { svc } = makeSvc();
+  const raw = Buffer.from('{"a":1}');
+
+  it('accepts the matching HMAC and rejects everything else', () => {
+    expect(svc.verifySignature(raw, sign(raw), SECRET)).toBe(true);
+    expect(svc.verifySignature(raw, sign(raw, 'other'), SECRET)).toBe(false);
+    expect(svc.verifySignature(raw, 'sha256=zz', SECRET)).toBe(false);
+    expect(svc.verifySignature(raw, undefined, SECRET)).toBe(false);
+    expect(svc.verifySignature(undefined, sign(raw), SECRET)).toBe(false);
+    expect(svc.verifySignature(raw, sign(raw), '')).toBe(false);
+  });
+});
+
+describe('processPayload — statuses', () => {
+  it('upserts a failed status with rank guard, error detail and recipient hash', async () => {
+    const { svc, query } = makeSvc();
+    const counts = await svc.processPayload(statusPayload());
+    expect(counts.statuses).toBe(1);
+    expect(query).toHaveBeenCalledTimes(1);
+    const [sql, opts] = query.mock.calls[0];
+    expect(sql).toContain('INSERT INTO wa_message_statuses');
+    expect(sql).toContain('ON CONFLICT (wamid) DO UPDATE');
+    // The monotonic guard: EXCLUDED rank must beat the stored rank.
+    expect(sql).toMatch(/WHERE CASE EXCLUDED\.status[\s\S]*> CASE wa_message_statuses\.status/);
+    expect(opts.replacements).toMatchObject({
+      wamid: 'wamid.TEST1', status: 'failed', errorCode: '131049',
+    });
+    expect(opts.replacements.errorTitle).toMatch(/healthy ecosystem/);
+    // sha256('+6580129432') — the consumers.phoneHash recipe.
+    expect(opts.replacements.recipientHash)
+      .toBe(crypto.createHash('sha256').update('+6580129432').digest('hex'));
+    expect(opts.replacements.occurredAt).toEqual(new Date(1785006378 * 1000));
+  });
+
+  it('ignores unknown statuses and missing wamids without querying', async () => {
+    const { svc, query } = makeSvc();
+    const counts = await svc.processPayload(statusPayload({
+      value: { statuses: [{ id: null, status: 'failed' }, { id: 'wamid.X', status: 'weird' }] },
+    }));
+    expect(counts.statuses).toBe(0);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('binds to our WABA and phone number id when the env pins them', async () => {
+    process.env.WHATSAPP_WABA_ID = 'someone-elses-waba';
+    const { svc, query } = makeSvc();
+    const counts = await svc.processPayload(statusPayload());
+    expect(counts.statuses).toBe(0);
+    expect(counts.unmatchedForeign).toBe(1);
+    expect(query).not.toHaveBeenCalled();
+
+    process.env.WHATSAPP_WABA_ID = '1912683432731970';
+    process.env.WHATSAPP_PHONE_NUMBER_ID = 'different-sender';
+    const second = makeSvc();
+    const counts2 = await second.svc.processPayload(statusPayload());
+    expect(counts2.statuses).toBe(0);
+    expect(counts2.unmatchedForeign).toBe(1);
+    expect(second.query).not.toHaveBeenCalled();
+  });
+
+  it('propagates persistence failures (Meta retry is the durability)', async () => {
+    const { svc } = makeSvc({ sequelize: { query: jest.fn(async () => { throw new Error('db down'); }) } });
+    await expect(svc.processPayload(statusPayload())).rejects.toThrow('db down');
+  });
+
+  it('ignores non-whatsapp objects and malformed bodies', async () => {
+    const { svc, query } = makeSvc();
+    expect(await svc.processPayload(null)).toMatchObject({ statuses: 0 });
+    expect(await svc.processPayload({ object: 'page', entry: [] })).toMatchObject({ statuses: 0 });
+    expect(await svc.processPayload({ object: 'whatsapp_business_account', entry: 'nope' }))
+      .toMatchObject({ statuses: 0 });
+    expect(query).not.toHaveBeenCalled();
+  });
+});
+
+describe('processPayload — inbound STOP', () => {
+  const stopMessage = (m) => statusPayload({
+    value: { statuses: [], messages: [m] },
+  });
+
+  it.each([
+    ['quick-reply button', { from: '6580129432', type: 'button', button: { text: 'Stop promotions', payload: 'Stop promotions' } }],
+    ['typed STOP', { from: '6580129432', type: 'text', text: { body: ' STOP ' } }],
+    ['typed unsubscribe', { from: '6580129432', type: 'text', text: { body: 'Unsubscribe' } }],
+  ])('applies the global unsubscribe for %s', async (_label, message) => {
+    const consumer = { id: 'c1' };
+    const findOne = jest.fn(async () => consumer);
+    const applyUnsubscribe = jest.fn(async () => ({ alreadySuppressed: false }));
+    const { svc } = makeSvc({ Consumer: { findOne }, applyUnsubscribe });
+
+    const counts = await svc.processPayload(stopMessage(message));
+    expect(counts.stops).toBe(1);
+    // Lookup by the normalized E.164 the spine stores.
+    expect(findOne).toHaveBeenCalledWith({ where: { phone: '+6580129432' } });
+    expect(applyUnsubscribe).toHaveBeenCalledWith(consumer, { source: 'wa_stop' });
+  });
+
+  it('ignores non-STOP chatter and unknown phones', async () => {
+    const applyUnsubscribe = jest.fn();
+    const { svc } = makeSvc({ applyUnsubscribe });
+    const chat = await svc.processPayload(stopMessage({ from: '6580129432', type: 'text', text: { body: 'hello, when is the draw?' } }));
+    expect(chat.stops).toBe(0);
+
+    const unknown = await svc.processPayload(stopMessage({ from: '6599999999', type: 'text', text: { body: 'stop' } }));
+    expect(unknown.stops).toBe(0);
+    expect(applyUnsubscribe).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/whatsapp/webhook route posture', () => {
+  let app;
+  beforeEach(async () => {
+    const { default: router } = await import('../routes/whatsappWebhook.js');
+    app = express();
+    // Mirror server_internal's raw-body capture for signature verification.
+    app.use(express.json({
+      verify: (req, _res, buf) => { req.rawBody = buf; },
+    }));
+    app.use('/api/whatsapp', router);
+  });
+
+  it('answers the Meta GET handshake only with the right verify token', async () => {
+    process.env.WHATSAPP_WEBHOOK_VERIFY_TOKEN = 'vt-1';
+    const ok = await request(app).get('/api/whatsapp/webhook')
+      .query({ 'hub.mode': 'subscribe', 'hub.verify_token': 'vt-1', 'hub.challenge': '12345' });
+    expect(ok.status).toBe(200);
+    expect(ok.text).toBe('12345');
+
+    const bad = await request(app).get('/api/whatsapp/webhook')
+      .query({ 'hub.mode': 'subscribe', 'hub.verify_token': 'wrong', 'hub.challenge': '12345' });
+    expect(bad.status).toBe(403);
+
+    delete process.env.WHATSAPP_WEBHOOK_VERIFY_TOKEN;
+    const unset = await request(app).get('/api/whatsapp/webhook')
+      .query({ 'hub.mode': 'subscribe', 'hub.verify_token': '', 'hub.challenge': '1' });
+    expect(unset.status).toBe(403);
+  });
+
+  it('fails closed in production without an app secret (200, nothing processed)', async () => {
+    process.env.NODE_ENV = 'production';
+    delete process.env.WHATSAPP_APP_SECRET;
+    const res = await request(app).post('/api/whatsapp/webhook').send(statusPayload());
+    expect(res.status).toBe(200); // Meta must not retry-storm an unconfigured endpoint
+  });
+
+  it('rejects a bad signature when the secret is set', async () => {
+    process.env.WHATSAPP_APP_SECRET = SECRET;
+    const res = await request(app).post('/api/whatsapp/webhook')
+      .set('x-hub-signature-256', 'sha256=deadbeef')
+      .send(statusPayload());
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/src/tests/whatsappService.test.js
+++ b/backend/src/tests/whatsappService.test.js
@@ -188,7 +188,7 @@ describe('QR-header send sequence (default: header ON)', () => {
     const card = cardRecorder();
     const svc = makeSvc({ fetch, qr, card });
     const r = await svc.sendReservationWhatsApp({ entitlement, prospect: consented, presentationToken: 'ptok-raw' });
-    expect(r).toEqual({ sent: true, to: '••••4567' });
+    expect(r).toEqual({ sent: true, to: '••••4567', templateName: 'reward_pass' });
     expect(card.calls.length).toBe(1);
     expect(card.calls[0]).toMatchObject({
       state: 'pass',
@@ -261,7 +261,7 @@ describe('QR-header send sequence (default: header ON)', () => {
     const card = async () => { throw new Error('resvg exploded'); };
     const svc = makeSvc({ fetch, qr, card });
     const r = await svc.sendReservationWhatsApp({ entitlement, prospect: consented, presentationToken: 'ptok-raw' });
-    expect(r).toEqual({ sent: true, to: '••••4567' });
+    expect(r).toEqual({ sent: true, to: '••••4567', templateName: 'reward_pass' });
     expect(qr.contents).toEqual(['https://redeem.sg/r/ptok-raw']); // bare QR took over
     expect(fetch.calls.length).toBe(2); // upload + send still happened
   });

--- a/docs/plans/wa-delivery-truth.md
+++ b/docs/plans/wa-delivery-truth.md
@@ -1,0 +1,233 @@
+# WhatsApp/email delivery truth — silent marketing-cap drops + receipt honesty
+
+**Incident (2026-07-26 03:06 SGT).** Shawn's test lead (`11a46df8-e1ca-4043-b9d9-7dc02ef1d876`,
++65 8012 9432) received the `draw_entry_pass` WhatsApp at 03:02 but never received the
+`draw_boost_receipt` WhatsApp at 03:06 — while the admin lead profile shows **both** as
+"boost receipt WhatsApp ✓". Yesterday's identical flow (25 Jul 16:04/16:07 SGT, other
+signup of the same person) delivered both.
+
+## Root cause — proven, three independent ways
+
+1. **Category split.** WABA `1912683432731970` templates:
+   `draw_entry_pass` = UTILITY (delivered both days), `draw_boost_receipt` = **MARKETING**
+   (delivered 25 Jul as first-in-window, dropped 26 Jul), `reward_voucher` = **MARKETING**
+   (same latent risk on real voucher deliveries), `draw_pass_receipt` = UTILITY,
+   `draw_callback_optin` = MARKETING (intentional). Meta applies a **per-user marketing
+   frequency cap**: a MARKETING template to a user who recently received one is accepted
+   by the API (HTTP 200 + message id) and then **silently dropped** (error 131049,
+   reported only via the statuses webhook). UTILITY templates are exempt.
+2. **WABA analytics.** Half-hour bucket 2026-07-25T19:00Z (03:00–03:30 SGT): `sent=1,
+   delivered=1` — but we made **two** 200-OK sends in that bucket (pass 19:02:15Z, boost
+   19:06:18Z). The boost message was never even counted as *sent*: dropped post-acceptance,
+   pre-send. Every message Meta actually sent in the last 3 days was delivered — this is
+   not a device/network problem.
+3. **Receipts.** `redemption_events` shows `notified{kind:boost_receipt, channel:whatsapp}`
+   at 19:06:18Z — our ✓ is written on Meta HTTP 200 (`whatsappService.js` `sendTemplate`
+   returns `{sent:true}` without reading the response body). The platform cannot currently
+   observe any post-acceptance outcome:
+   - **No statuses sink.** The WABA's `subscribed_apps` carries
+     `override_callback_uri = https://rciuejxgziqxrwtifpbo.supabase.co/functions/v1/wa-debug`
+     (a debug EF on the mktr-leads Supabase project, set during 07-23 template debugging) —
+     and its logs show **zero** status callbacks ever arrived (app-level webhook field
+     subscription for `messages` is missing/unconfirmable without the app secret;
+     `META_APP_SECRET` in Render env is NOT the MKTR_wa app's secret — `debug_token`
+     signature check fails).
+   - **Emails are the same shape of lie, milder.** `mailer.js` `deliver()` discards the
+     nodemailer `info` (SES SMTP `250 Ok <ses-message-id>`) and returns `{success:true}` —
+     "emailed ✓" = SES accepted the envelope. Bounces/complaints after acceptance are
+     invisible (no SES event destination configured).
+
+## Fix
+
+### A. Root cause — resubmit the two transactional templates as UTILITY
+
+Meta template category is immutable post-creation → new names, same (already
+flat-factual, receipt-register) copy. Precedent: `draw_pass_receipt` with near-identical
+register passed review as UTILITY.
+
+- `draw_boost_receipt_v2` — UTILITY, IMAGE header (Vault boost card sample), body verbatim
+  from the approved `draw_boost_receipt` (3 params). No footer, no buttons (matches current).
+- `reward_voucher_v2` — UTILITY, IMAGE header, body verbatim from approved `reward_voucher`
+  (4 params, keeps the `https://redeem.sg/r/{{3}}` in-body link). This one guards the core
+  product: a voucher that silently never arrives is a direct revenue/trust hit.
+- Submission: extend `backend/scripts/submit-wa-marketing-templates.mjs` with a
+  `--utility-pack` set (reuses its idempotent submit + resumable sample upload + `--status`
+  poll). `allow_category_change: false` — if Meta's classifier disagrees we want a visible
+  INCORRECT_CATEGORY rejection (editable + resubmittable), never a silent flip back to
+  MARKETING. Keep any rejected shells (deleting risks the 30-day name block).
+- After approval: flip Render env `WHATSAPP_TEMPLATE_DRAW_BOOST=draw_boost_receipt_v2`,
+  `WHATSAPP_TEMPLATE_VOUCHER=reward_voucher_v2` (env-only, no deploy; service restarts).
+- `draw_callback_optin` stays MARKETING deliberately (it is marketing; cap risk accepted).
+
+### B. WhatsApp truth layer — wamid capture + statuses webhook
+
+1. **Capture the message id.** `sendTemplate` success path: parse the response JSON,
+   return `{ sent: true, to, messageId: messages[0].id }`. `writeDeliveryReceipt` stores
+   `metadata.messageId`. (Also store `templateName` in the receipt metadata — lets the UI
+   and future audits distinguish which template actually carried the send.)
+2. **Webhook endpoint** `backend/src/routes/whatsappWebhook.js`, mounted publicly (no auth
+   middleware, before the JSON-body auth chain), rate-limit-exempt like other
+   server-to-server webhooks:
+   - `GET /api/whatsapp/webhook` — Meta subscription handshake: `hub.mode=subscribe` +
+     `hub.verify_token === process.env.WHATSAPP_WEBHOOK_VERIFY_TOKEN` → echo
+     `hub.challenge` (plain 200); else 403.
+   - `POST /api/whatsapp/webhook` — extend the existing raw-body capture (today only
+     `/api/retell/` paths) to `/api/whatsapp/` so `X-Hub-Signature-256` can be verified:
+     HMAC-SHA256(raw body, `WHATSAPP_APP_SECRET`), `crypto.timingSafeEqual`. If
+     `WHATSAPP_APP_SECRET` is unset: log one boot-time warn and accept (statuses are
+     low-sensitivity, unknown wamids are ignored, and nothing state-changing beyond
+     receipt metadata + suppressions happens); when set, fail closed on bad signature.
+     Always answer 200 fast (Meta retries + eventually disables noisy endpoints); all
+     processing wrapped so a bad payload can never 500.
+   - **Statuses** (`entry[].changes[].value.statuses[]`): for each
+     `{id, status: sent|delivered|read|failed, timestamp, errors}` find the receipt
+     `redemption_events` row (`type='notified'`, `metadata->>'messageId' = id`) and
+     `jsonb_set` a `delivery` object: `{status, at, errorCode?, errorTitle?}` with
+     **monotonic rank** (sent < delivered < read; failed terminal) so late/out-of-order
+     webhooks never downgrade. Structured log every transition
+     (`redeem_ops.wa.delivery_status`); unmatched wamids (e.g. screening-callback sends,
+     which write no entitlement receipt) log at info and are otherwise ignored.
+   - **Inbound STOP** (`value.messages[]`, `type=button` payload or text `STOP`): write the
+     existing PR-B suppression (`ConsumerSuppression`, marketing scope, channel whatsapp,
+     reason `wa_stop`) keyed by the normalized sender phone, via the consent service's
+     writer (exact call verified at implementation). Today the approved marketing pack's
+     "Reply STOP to unsubscribe" footer points into the void — this closes it before
+     wapush goes live.
+3. **Migration** `NNN-wa-delivery-status-index.js`: partial expression index on
+   `redemption_events ((metadata->>'messageId')) WHERE type = 'notified'` (btree) — the
+   webhook lookup path. Auto-runs on deploy.
+4. **Repoint the WABA webhook** (post-deploy, ordered): set env
+   (`WHATSAPP_WEBHOOK_VERIFY_TOKEN`, `WHATSAPP_APP_SECRET` once provided,
+   `WHATSAPP_WABA_ID=1912683432731970`), verify the endpoint answers the GET handshake,
+   then `POST /{waba}/subscribed_apps` with
+   `override_callback_uri=https://api.mktr.sg/api/whatsapp/webhook` + our verify token
+   (WHATSAPP_TOKEN suffices for this call). If statuses still don't flow (the app-level
+   `messages` field subscription may be absent — unverifiable without the app secret),
+   complete `POST /{app-id}/subscriptions` (object `whatsapp_business_account`, fields
+   `messages`, callback + verify token) using `941256445479495|WHATSAPP_APP_SECRET` —
+   requires Shawn pasting the MKTR_wa app secret into Render env (App Dashboard →
+   Settings → Basic). Empirical verify: fire a template send to Shawn's number, watch
+   `sent → delivered` land in the receipt row within seconds.
+
+### C. Email truth — capture what SES tells us, wire events later
+
+1. **Now (code):** `mailer.deliver()` keeps the nodemailer `info` and returns
+   `{ success: true, smtpResponse: info.response, sesMessageId: <parsed from "250 Ok <id>"> }`;
+   `fulfilmentNotify` senders thread `sesMessageId` into their `{sent:true}` results →
+   receipt `metadata.sesMessageId`. Zero behavior change, pure observability.
+2. **Phase 2 (AWS-side, runbook not code):** SES configuration set with event publishing
+   (Send/Delivery/Bounce/Complaint) → SNS HTTPS subscription →
+   `POST /api/ses/events` (SNS signature-verified) updating receipt `metadata.delivery`
+   keyed by `sesMessageId` — same shape as the WA layer. Requires AWS console/IAM access
+   the repo doesn't hold; endpoint code ships dark, runbook documents the 5-minute
+   console wiring. Out of this PR's live scope.
+
+### D. Admin UI — show the truth
+
+Traced end-to-end: `GET /api/prospects/:id?include=profile` →
+`prospectService` → `leadProfileService.enrichJourneyProfile` →
+**`deliveryReceipts()` (`backend/src/services/leadProfileService.js:94-113`)** builds
+`delivery.{email,whatsapp} = { kind, at, ok }` per entitlement (SQL `DISTINCT ON`
+latest-per-channel over `redemption_events` type `notified|notify_failed`; projects only
+`type/createdAt/channel/kind` — `metadata` error/status never crosses the wire). The
+frontend composes the label 100% client-side at
+**`src/pages/adminv2/AdminV2LeadProfile.jsx:172-175`**: `` `${kind} ${channel} ${ok ? '✓' : '✗ failed'}` ``.
+
+Changes:
+- `deliveryReceipts()` SELECT adds `metadata->>'error' AS error` and
+  `metadata->'delivery' AS delivery`; result object becomes
+  `{ kind, at, ok, error, delivery: {status, at, errorCode, errorTitle} | null }`.
+  Apply at **both** attach points — `enrichJourneyProfile` (`:243-254`) and the
+  consumer-less B4 path in `getSignupProfile` (`:321-339`).
+- `AdminV2LeadProfile.jsx:172-175` row label by precedence:
+  `delivery.status='failed'` → "✗ not delivered" + reason (131049 → "Meta marketing
+  frequency cap"), destructive styling; `delivered`/`read` → "✓✓"; `sent` or no
+  `delivery` (legacy rows, emails) → today's "✓" (meaning: accepted). Mirror the same
+  ok/failed suffix in `receiptBits()` (`:125-129`, campaign drill-in hero).
+- Tests: `backend/test/leadProfileService.test.js` +
+  `src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx` (fixture gains the
+  `delivery` sub-object).
+- Known pre-existing display gaps, deliberately untouched: latest-receipt-per-channel
+  collapses a failed→resent sequence to the resend; `buildHistory` skips delivery rows
+  for consumer-less leads (Rewards list covers them).
+
+## Rollout order
+
+1. Implement + unit tests (webhook route: handshake, signature, status ranking,
+   STOP suppression; sendTemplate wamid parse; mailer response capture) — in a
+   disposable worktree off `origin/main` (the main checkout carries unrelated WIP).
+2. Codex review of this plan + the diff; fold must-fixes.
+3. Push `main` → Render auto-deploy (verify via deploys API + `_migrations` row).
+4. Env: add `WHATSAPP_WEBHOOK_VERIFY_TOKEN` + `WHATSAPP_WABA_ID` (autonomous),
+   `WHATSAPP_APP_SECRET` (Shawn — one paste). Repoint `subscribed_apps` override to
+   api.mktr.sg; empirically verify statuses flow end-to-end.
+5. Submit `--utility-pack`; poll `--status`; on APPROVED flip the two template env vars.
+6. Remediate the missed message: resend the boost receipt (WhatsApp leg) for entitlement
+   `15fa630f-c5bc-4041-b2ea-b532aabe66ee` via the ops resend path — now carried by the
+   UTILITY template, and now with a delivery-status paper trail. Watch it hit `delivered`.
+7. Memory/tracker updates; note the reward_voucher exposure closed.
+
+## v2 — Codex review deltas (2026-07-26, 30 findings; accepted unless noted)
+
+**Design change (dissolves findings 5/7/8/9/10/11):** statuses land in a new
+**`wa_message_statuses` inbox table** (migration `090`, with `down()`): `wamid` PK,
+`status`, `errorCode`, `errorTitle`, `recipientHash` (sha256 of E.164 — no raw phone
+stored), `occurredAt`. Webhook = validate → **atomic rank-guarded upsert**
+(`INSERT … ON CONFLICT (wamid) DO UPDATE … WHERE` rank(new) > rank(old); sent=1 <
+delivered=2 < read=3 < failed=4 terminal) → 200 only after commit; DB failure → 500 so
+Meta retries. Receipts are **never mutated** — readers (`leadProfileService`,
+`entitlementService` ops projection) LEFT JOIN the inbox on `metadata->>'messageId'`.
+No expression index needed (join is receipt→PK); the old §B.3 migration is dropped.
+
+Other accepted deltas:
+- Signature **required in prod**: `WHATSAPP_APP_SECRET` unset → POST answers 200 but
+  processes nothing (warn); invalid signature → 401. Bind every payload:
+  `entry.id === WHATSAPP_WABA_ID`, `value.metadata.phone_number_id ===
+  WHATSAPP_PHONE_NUMBER_ID`; cap entries processed per request. Add `/api/whatsapp/`
+  to the global limiter skip (HMAC-first, cheap reject).
+- STOP = **global marketing unsubscribe** via existing `applyUnsubscribe(consumer,
+  {source:'wa_stop'})` (channel `all` + reason `unsubscribe` — the model has no
+  per-channel reason and the existing resubscribe lift path then applies). Accepted
+  forms: `stop`, `stop promotions`, `unsubscribe`, `cancel` (quick-reply button text
+  or plain text); idempotent writer makes Meta redelivery harmless. Unknown phone →
+  log + skip.
+- `sendTemplate` parses the send response **non-throwingly**: 2xx without
+  `messages[0].id` stays `sent:true, messageId:null` ("accepted, untrackable").
+  Receipts gain `metadata.messageId` + `templateName`. Screening-callback sends store
+  their wamid in the screening JSONB patch too.
+- **Resend remediation**: `resendEntitlement` currently rejects draw entitlements
+  (no voucher to rotate) — add a boost-receipt mode (issued draw entitlement → kind
+  `boost_receipt`, no token rotation, honors channel selection).
+- Email: `providerMessageId` + `provider` (SES only when the host says so), threaded
+  through BOTH `fulfilmentNotify` normalizers (`sendEmail` has no `deliver()`; two
+  duplicate normalizers exist). UI labels say "accepted", never implied-delivered.
+- Erasure: scrub `messageId`/`providerMessageId` from receipt metadata; delete inbox
+  rows by `recipientHash`.
+- Ops console (`RedemptionsPage`) receipt chips get the same delivery state, not just
+  the lead profile.
+- Legacy channel-less receipts: `COALESCE(metadata->>'channel','email')` inside
+  `DISTINCT ON` + `id DESC` tie-break.
+- Rollout checklist gains: `WHATSAPP_QR_HEADER` must not be `false` and
+  `WHATSAPP_TEMPLATE_LANG` must be unset/`en` before flipping template env names
+  (v2 templates are IMAGE-header, `en`).
+- Deferred, documented: `graphFetch` retry can double-send with a lost first wamid
+  (pre-existing; unmatched statuses simply rest in the inbox);
+  `reconcileMissedDeliveries` stays email-only (truth layer + UTILITY templates
+  remove the recurrence class; sweep extension is follow-up); rejected-shell
+  edit/resubmit tooling built only if Meta rejects (both v2 templates ACCEPTED
+  as PENDING/UTILITY on 2026-07-26).
+- Evidence provenance: template categories/analytics/subscription state are
+  **externally observed** via Graph API + prod SQL on 2026-07-26 (not code-derivable).
+
+## Risks / notes
+
+- Webhook is additive: no existing send path changes semantics; a webhook outage merely
+  leaves receipts at "accepted" (today's baseline).
+- `redemption_events` is append-only by design; enriching the SAME fact's row
+  (`metadata.delivery`) is a deliberate, documented exception (alternative — one event row
+  per status transition — triples history noise for every message; rejected).
+- If Meta rejects the UTILITY resubmissions (INCORRECT_CATEGORY), fallback: keep MARKETING
+  sends but the truth layer now surfaces every 131049 in the admin UI + logs, and ops
+  learns to space marketing sends; escalate copy edits on the rejected shells.
+- The 03:06 drop itself needs no data repair: entitlement state (`issued`, ×10 boost) is
+  correct; only the notification was lost.

--- a/src/pages/adminv2/AdminV2LeadProfile.jsx
+++ b/src/pages/adminv2/AdminV2LeadProfile.jsx
@@ -122,9 +122,36 @@ function heroFor(draw, rewards, diagnostic) {
   return { big: 'No outcome recorded', tail: '', tone: 'quiet', meta: null };
 }
 
+// Post-acceptance truth (wa-delivery-truth): a receipt's base ✓ means the
+// provider ACCEPTED the message — only the joined status inbox can prove
+// delivered/read, or surface Meta's silent drops (131049 = the per-user
+// marketing frequency cap that ate real boost receipts).
+function deliverySuffix(r) {
+  if (!r) return null;
+  if (!r.ok) return { ok: false, text: '✗ failed' };
+  const st = r.delivery?.status;
+  if (st === 'failed') {
+    const why = String(r.delivery?.errorCode) === '131049'
+      ? 'Meta marketing limit'
+      : (r.delivery?.errorTitle || null);
+    return { ok: false, text: `✗ not delivered${why ? ` — ${why}` : ''}` };
+  }
+  if (st === 'read') return { ok: true, text: '✓✓ read' };
+  if (st === 'delivered') return { ok: true, text: '✓✓ delivered' };
+  if (st === 'sent') return { ok: true, text: '✓ sent' };
+  return { ok: true, text: '✓' }; // accepted; nothing further heard (emails, legacy rows)
+}
+
 function receiptBits(delivery) {
   if (!delivery) return [];
-  const bit = (r, label) => (r ? { ok: r.ok, label: `${label}${r.ok ? '' : ' failed'}` } : null);
+  const bit = (r, label) => {
+    if (!r) return null;
+    if (!r.ok) return { ok: false, label: `${label} failed` };
+    const st = r.delivery?.status;
+    if (st === 'failed') return { ok: false, label: `${label} not delivered` };
+    if (st === 'read' || st === 'delivered') return { ok: true, label: `${label} ${st}` };
+    return { ok: true, label };
+  };
   return [bit(delivery.email, 'pass emailed'), bit(delivery.whatsapp, 'WhatsApp')].filter(Boolean);
 }
 
@@ -171,7 +198,9 @@ function buildHistory(p, journey) {
     if (e.redeemedAt) push(e.redeemedAt, 'Voucher redeemed ✓', { detail: ` — ${title}`, family: 'reward', tag });
     for (const ch of ['email', 'whatsapp']) {
       const r = e.delivery?.[ch];
-      if (r?.at) push(r.at, `${(r.kind || 'pass').replace(/_/g, ' ')} ${ch === 'email' ? 'emailed' : 'WhatsApp'} ${r.ok ? '✓' : '✗ failed'}`, { family: 'delivery', quiet: true, tag });
+      if (!r?.at) continue;
+      const s = deliverySuffix(r);
+      push(r.at, `${(r.kind || 'pass').replace(/_/g, ' ')} ${ch === 'email' ? 'emailed' : 'WhatsApp'} ${s.text}`, { family: 'delivery', quiet: true, tag });
     }
   }
   for (const b of journey?.broadcasts?.recent || []) {

--- a/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
@@ -224,3 +224,33 @@ describe('AdminV2LeadProfile — states', () => {
     expect(screen.getByText('ERASED')).toBeInTheDocument();
   });
 });
+
+describe('AdminV2LeadProfile — delivery truth (wa-delivery-truth)', () => {
+  it('renders post-acceptance states: 131049 as Meta marketing limit, delivered as ✓✓', async () => {
+    const profile = JSON.parse(JSON.stringify(PROFILE));
+    profile.consumer.entitlements[0].delivery = {
+      email: { ok: true, kind: 'boost_receipt', at: '2026-05-02T02:00:00Z', delivery: null },
+      whatsapp: {
+        ok: true, kind: 'boost_receipt', at: '2026-05-02T02:00:05Z',
+        delivery: { status: 'failed', errorCode: '131049', errorTitle: 'This message was not delivered to maintain healthy ecosystem engagement.', at: '2026-05-02T02:00:09Z' },
+      },
+    };
+    fetchProspectProfile.mockResolvedValue(profile);
+    setup('/admin/leads/p1?view=profile');
+    expect(await screen.findByText(/boost receipt WhatsApp ✗ not delivered — Meta marketing limit/)).toBeInTheDocument();
+    // Email has no provider verdict → the honest bare ✓ (accepted).
+    expect(screen.getByText(/boost receipt emailed ✓$/)).toBeInTheDocument();
+
+    const delivered = JSON.parse(JSON.stringify(PROFILE));
+    delivered.consumer.entitlements[0].delivery = {
+      email: null,
+      whatsapp: {
+        ok: true, kind: 'pass', at: '2026-05-02T02:00:05Z',
+        delivery: { status: 'delivered', errorCode: null, errorTitle: null, at: '2026-05-02T02:00:09Z' },
+      },
+    };
+    fetchProspectProfile.mockResolvedValue(delivered);
+    setup('/admin/leads/p1?view=profile');
+    expect(await screen.findByText(/pass WhatsApp ✓✓ delivered/)).toBeInTheDocument();
+  });
+});

--- a/src/pages/redeemops/RedemptionsPage.jsx
+++ b/src/pages/redeemops/RedemptionsPage.jsx
@@ -40,12 +40,29 @@ function parseRewardQr(raw) {
   return null;
 }
 
+const RECEIPT_NOUNS = { voucher: 'Voucher', boost_receipt: 'Boost receipt', pass: 'Pass' };
+
 /** Per-row delivery truth from the receipts the backend now records. */
 function deliveryStatus(e) {
+  // Post-acceptance drop (wa-delivery-truth status inbox): the provider
+  // ACCEPTED the send — the old ✓ — but Meta later reported failure (e.g.
+  // 131049, the per-user marketing frequency cap). That verdict outranks the
+  // happy email line: staff must see it to resend.
+  const wa = e.delivery?.whatsapp;
+  if (wa?.ok && wa.delivery?.status === 'failed') {
+    const noun = RECEIPT_NOUNS[wa.kind] || 'Pass';
+    const why = String(wa.delivery.errorCode) === '131049'
+      ? 'Meta marketing limit'
+      : (wa.delivery.errorTitle || 'reported failed');
+    return { text: `${noun} WhatsApp not delivered — ${why}`, tone: 'warn' };
+  }
   const em = e.delivery?.email;
   if (em) {
-    const noun = em.kind === 'voucher' ? 'Voucher' : 'Pass';
+    const noun = RECEIPT_NOUNS[em.kind] || 'Pass';
     if (em.ok) {
+      if (em.delivery?.status === 'failed') {
+        return { text: `${noun} email not delivered — ${em.delivery.errorTitle || 'provider reported failure'}`, tone: 'warn' };
+      }
       const at = new Date(em.at).toLocaleString('en-SG', {
         day: 'numeric', month: 'short', hour: 'numeric', minute: '2-digit',
       });
@@ -260,7 +277,10 @@ export default function RedemptionsPage() {
         redeemed: g.open.filter((e) => e.status === 'redeemed').length,
         closed: g.closed.length,
       },
-      deliveryIssues: g.open.filter((e) => e.delivery?.email && !e.delivery.email.ok).length,
+      deliveryIssues: g.open.filter((e) =>
+        (e.delivery?.email && (!e.delivery.email.ok || e.delivery.email.delivery?.status === 'failed'))
+        || (e.delivery?.whatsapp && (!e.delivery.whatsapp.ok || e.delivery.whatsapp.delivery?.status === 'failed'))
+      ).length,
       // Same condition as the old per-row badge: undeliverable NOW, regardless
       // of receipts — an email cleared after a send must keep warning.
       noEmail: g.open.filter(


### PR DESCRIPTION
## What happened

2026-07-26 03:06 SGT: a draw boost receipt showed **WhatsApp ✓** in the admin lead history but never reached the phone. Meta accepted the send (HTTP 200 — the only thing our ✓ ever meant) and silently dropped it: `draw_boost_receipt` is a **MARKETING**-category template and the recipient had already had a marketing template inside Meta's per-user frequency window (error 131049 — reported only via a status webhook we didn't have). `reward_voucher` (real customer vouchers!) shares the category and the risk. WABA analytics prove it: the 19:00Z half-hour bucket shows sent=1/delivered=1 against two 200-OK sends.

## What this PR does

- **`wa_message_statuses` inbox** (migration 090) + **`POST /api/whatsapp/webhook`**: X-Hub-Signature-256 verified (prod fails closed when `WHATSAPP_APP_SECRET` is unset), payloads bound to our WABA + sender id, rank-guarded atomic upsert (sent < delivered < read; failed terminal), 200 only after commit so Meta's retry is the durability. Receipts join the inbox **at read time** by wamid — receipt rows are never mutated, and a status that beats its receipt's commit still surfaces.
- `sendTemplate` records the **wamid** (+ templateName) on every receipt; the screening-callback invite stores its wamid in `screeningMetadata`.
- **STOP finally works**: quick-reply "Stop promotions" / typed stop / unsubscribe / cancel → the existing global unsubscribe (`source: wa_stop`), idempotent under Meta redelivery.
- **Email honesty**: mailer keeps the SES `250 Ok <id>` as `providerMessageId` (both fulfilmentNotify normalizers pass it through) — the hook the future SES-events leg needs.
- **resendDelivery boost mode**: issued draw entitlements resend the ×N receipt (no token mint) instead of 409ing; draw classification now fails closed.
- **UI truth** (lead profile history + Redemptions console): ✓ accepted · ✓ sent · ✓✓ delivered/read · ✗ not delivered — with 131049 spelled out as "Meta marketing limit".
- **Erasure** scrubs messageId/providerMessageId and deletes inbox rows by recipientHash (inbox stores a phone hash, never a raw phone).
- **`--utility-only` template pack**: `draw_boost_receipt_v2` + `reward_voucher_v2` — UTILITY twins with bodies verbatim from the approved originals, `allow_category_change: false`. Submitted 2026-07-26, accepted as UTILITY, PENDING review.

## Tests

- New: `backend/src/tests/waWebhook.test.js` (13 — signature, WABA/phone binding, rank-guard SQL shape, 5xx-on-persist-failure, STOP normalization + unsubscribe mapping, route posture incl. prod fail-closed).
- Updated: whatsappService (wamid contract), AdminV2LeadProfile (delivery states), migrations conformance (090 + down()).
- 81 backend tests across the four impacted suites green; FE suites green; the 2 failing suites (referralAttribution, campaignReadiness — 7 tests) fail identically on pristine origin/main (inherited red, baselined).

## Rollout (after merge)

1. Deploy runs migration 090 automatically.
2. Env: `WHATSAPP_WEBHOOK_VERIFY_TOKEN`, `WHATSAPP_WABA_ID` (autonomous); `WHATSAPP_APP_SECRET` needs a one-time paste from the MKTR_wa App Dashboard.
3. Repoint the WABA `subscribed_apps` override from the leftover wa-debug EF to `https://api.mktr.sg/api/whatsapp/webhook`; live-verify statuses land.
4. On template approval: set `WHATSAPP_TEMPLATE_DRAW_BOOST=draw_boost_receipt_v2`, `WHATSAPP_TEMPLATE_VOUCHER=reward_voucher_v2`; resend the missed boost receipt (entitlement `15fa630f`).

Plan + full evidence + Codex review log: `docs/plans/wa-delivery-truth.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VR83Z5ya6HNf3JJuxzkAQw