### PR TITLE
People directory — /AdminPeople + GET /api/consumers (+ the CI green-gate precursor)

### DIFF
--- a/backend/src/controllers/consumerController.js
+++ b/backend/src/controllers/consumerController.js
@@ -1,8 +1,23 @@
 import { asyncHandler, AppError } from '../middleware/errorHandler.js';
-import { getConsumerJourney } from '../services/consumerService.js';
+import { getConsumerJourney, listConsumers as listConsumersSvc } from '../services/consumerService.js';
 import { eraseConsumer as eraseConsumerSvc } from '../services/erasureService.js';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * People directory list (admin-people-directory §4.1). Route-gated to admin.
+ * Param strictness lives in the service (single source): non-numeric
+ * page/limit fall back, unknown sorts fall back, q is capped and LIKE-escaped.
+ */
+export const listConsumers = asyncHandler(async (req, res) => {
+  const data = await listConsumersSvc({
+    q: typeof req.query.q === 'string' ? req.query.q : '',
+    page: req.query.page,
+    limit: req.query.limit,
+    sort: typeof req.query.sort === 'string' ? req.query.sort : undefined,
+  });
+  res.json({ success: true, data });
+});
 
 /**
  * One person's cross-campaign journey (consumer spine). Route-gated to admin —

--- a/backend/src/routes/consumers.js
+++ b/backend/src/routes/consumers.js
@@ -6,6 +6,10 @@ export const meta = { path: '/api/consumers' };
 
 const router = express.Router();
 
+// People directory — the deduplicated person list. Same admin-only posture as
+// the journey below: person-grain data aggregates PII across campaigns.
+router.get('/', authenticateToken, requireAdmin, consumerController.listConsumers);
+
 // Cross-campaign person journey — ADMIN ONLY, explicitly. The prospects
 // detail route is deliberately looser (agents open their own leads); this one
 // aggregates a person's history across every campaign and must not be.

--- a/backend/src/services/consumerService.js
+++ b/backend/src/services/consumerService.js
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from 'crypto';
 import { Transaction } from 'sequelize';
 import { sequelize, Consumer, Prospect, RewardEntitlement, DrawEntry } from '../models/index.js';
 import { logger } from '../utils/logger.js';
+import { escapeLike } from '../utils/escapeLike.js';
 import { emailNormKey } from './repeatSignup.js';
 import { normalizePhone } from './prospectHelpers.js';
 
@@ -489,11 +490,102 @@ export function makeConsumerService(overrides = {}) {
     return result;
   }
 
+  /**
+   * The People directory page (admin-people-directory §4.1). Membership is
+   * ROW EXISTENCE — a consumer is listed iff a prospect links to it — never
+   * the signupCount counter (invariant 3: counters are a best-effort
+   * projection whose recompute failures are swallowed; rows are the truth).
+   * The page query's inner JOIN LATERAL enforces existence AND yields
+   * latestProspectId in one pass; the count query states it as EXISTS.
+   *
+   * Erased consumers pass the filter while their prospect skeletons remain,
+   * but never match a search — their identity columns are all null, which is
+   * the PDPA-correct asymmetry (browsable, not look-up-able).
+   */
+  async function listConsumers({ q = '', page = 1, limit = 25, sort = '-lastSeenAt' } = {}) {
+    // Strict positive int: parseInt would accept '2junk'/'2.5'/'1e2' (R2 #7).
+    const posInt = (v, fallback, min, max) => {
+      const s = String(v ?? '');
+      if (!/^\d+$/.test(s)) return fallback;
+      const n = Number(s);
+      if (!Number.isSafeInteger(n)) return fallback;
+      return Math.min(max, Math.max(min, n));
+    };
+    const lim = posInt(limit, 25, 1, 100);
+    const pg = posInt(page, 1, 1, 10_000);
+
+    const SORTS = {
+      '-lastSeenAt': 'c."lastSeenAt" DESC',
+      lastSeenAt: 'c."lastSeenAt" ASC',
+      '-signupCount': 'c."signupCount" DESC',
+      signupCount: 'c."signupCount" ASC',
+      '-firstSeenAt': 'c."firstSeenAt" DESC',
+      firstSeenAt: 'c."firstSeenAt" ASC',
+      // NULLS LAST both directions: DESC defaults to NULLS FIRST, which would
+      // float erased (all-null-name) rows to the top (R1 #13).
+      name: 'c."lastName" ASC NULLS LAST, c."firstName" ASC NULLS LAST',
+      '-name': 'c."lastName" DESC NULLS LAST, c."firstName" DESC NULLS LAST',
+    };
+    const orderBy = SORTS[sort] || SORTS['-lastSeenAt'];
+
+    const like = escapeLike(q);
+    const digits = String(q ?? '').replace(/\D/g, '');
+    const parts = [];
+    if (like) {
+      parts.push(
+        `c."firstName" ILIKE :like ESCAPE '\\'`,
+        `c."lastName" ILIKE :like ESCAPE '\\'`,
+        `concat_ws(' ', c."firstName", c."lastName") ILIKE :like ESCAPE '\\'`,
+        `c.email ILIKE :like ESCAPE '\\'`
+      );
+    }
+    if (digits.length >= 4) parts.push('c.phone LIKE :digitsLike');
+    const qClause = parts.length ? `AND (${parts.join(' OR ')})` : '';
+    const replacements = { like: `%${like}%`, digitsLike: `%${digits}%` };
+
+    // REPEATABLE READ so total and rows come from ONE snapshot — the
+    // connection sets no default isolation and READ COMMITTED re-snapshots
+    // per statement (R2 #1). Read-only, so no serialization retries needed.
+    return d.sequelize.transaction(
+      { isolationLevel: Transaction.ISOLATION_LEVELS.REPEATABLE_READ },
+      async (t) => {
+        const [countRows] = await d.sequelize.query(
+          `SELECT count(*)::int AS total FROM consumers c
+            WHERE EXISTS (SELECT 1 FROM prospects p WHERE p."consumerId" = c.id)
+            ${qClause}`,
+          { replacements, transaction: t }
+        );
+        const [rows] = await d.sequelize.query(
+          `SELECT c.id, c."firstName", c."lastName", c.email, c.phone,
+                  c."signupCount", c."verifiedSignupCount",
+                  c."firstSeenAt", c."lastSeenAt", c."erasedAt",
+                  lp.id AS "latestProspectId"
+             FROM consumers c
+             JOIN LATERAL (
+               SELECT p.id FROM prospects p
+                WHERE p."consumerId" = c.id
+                ORDER BY p."createdAt" DESC, p.id DESC
+                LIMIT 1
+             ) lp ON true
+            WHERE true ${qClause}
+            ORDER BY ${orderBy}, c.id DESC
+            LIMIT :limit OFFSET :offset`,
+          {
+            replacements: { ...replacements, limit: lim, offset: (pg - 1) * lim },
+            transaction: t,
+          }
+        );
+        return { total: countRows?.[0]?.total ?? 0, page: pg, limit: lim, rows };
+      }
+    );
+  }
+
   return {
     resolveConsumerForCaptureTx,
     recomputeConsumersByPhone,
     reconcileConsumerSpine,
     getConsumerJourney,
+    listConsumers,
   };
 }
 
@@ -502,3 +594,4 @@ export const resolveConsumerForCaptureTx = _default.resolveConsumerForCaptureTx;
 export const recomputeConsumersByPhone = _default.recomputeConsumersByPhone;
 export const reconcileConsumerSpine = _default.reconcileConsumerSpine;
 export const getConsumerJourney = _default.getConsumerJourney;
+export const listConsumers = _default.listConsumers;

--- a/backend/src/utils/escapeLike.js
+++ b/backend/src/utils/escapeLike.js
@@ -1,0 +1,15 @@
+/**
+ * LIKE/ILIKE-safe literal: trim → cap at 100 chars → escape backslash, %, _.
+ * The listProspects sanitizer (prospectService) escapes only %/_ and never
+ * trims — this is the corrected shared form (admin-people-directory §4.1).
+ * Pair every use with an explicit `ESCAPE '\'` clause so the contract is
+ * visible at the call site.
+ */
+export function escapeLike(raw) {
+  return String(raw ?? '')
+    .trim()
+    .slice(0, 100)
+    .replace(/\\/g, '\\\\')
+    .replace(/%/g, '\\%')
+    .replace(/_/g, '\\_');
+}

--- a/backend/test/consumersList.test.js
+++ b/backend/test/consumersList.test.js
@@ -1,0 +1,277 @@
+import request from 'supertest'
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect } from './helpers.js'
+import { Consumer } from '../src/models/index.js'
+
+/**
+ * GET /api/consumers — the People directory list (admin-people-directory §4.1).
+ *
+ * The load-bearing contracts: membership is prospect-ROW existence (never the
+ * signupCount counter — a drift victim with zeroed counts but linked rows must
+ * stay visible, a countless artifact must not), erased people are browsable
+ * but never identity-searchable, latestProspectId is the newest linked row,
+ * and the search escapes LIKE metacharacters for real.
+ *
+ * Fixtures share the DB with other suites (maxWorkers 1), so every scoped
+ * assertion narrows via the distinctive 'Peopledir' surname; the erased row
+ * (null identity, unsearchable by design) is located by walking pages.
+ */
+
+let app, adminToken, agentToken, campaign
+const HOUR = 3600 * 1000
+const now = Date.now()
+
+// Fixture consumers, keyed for assertions.
+const C = {}
+
+async function mkConsumer(key, fields) {
+  C[key] = await Consumer.create({
+    firstSeenAt: new Date(now - 10 * 24 * HOUR),
+    lastSeenAt: new Date(now - 6 * HOUR),
+    signupCount: 1,
+    verifiedSignupCount: 0,
+    ...fields,
+  })
+  return C[key]
+}
+
+function get(path, token = adminToken) {
+  const req = request(app).get(path)
+  return token ? req.set('Authorization', `Bearer ${token}`) : req
+}
+
+/** Erased rows can't be searched — walk pages to find a row by id. */
+async function findRowById(id, params = '') {
+  for (let page = 1; page <= 3; page += 1) {
+    const res = await get(`/api/consumers?limit=100&page=${page}${params}`)
+    expect(res.status).toBe(200)
+    const hit = res.body.data.rows.find((r) => r.id === id)
+    if (hit) return hit
+    if (res.body.data.rows.length < 100) return null
+  }
+  return null
+}
+
+beforeAll(async () => {
+  app = await getApp()
+  const admin = await createTestUser({ role: 'admin' })
+  adminToken = admin.token
+  const agent = await createTestUser({ role: 'agent' })
+  agentToken = agent.token
+  campaign = await createTestCampaign(admin.user.id)
+
+  // A — the repeat person: two signups, newest wins latestProspectId.
+  await mkConsumer('a', {
+    phone: '+6598111001', firstName: 'Zephyrine', lastName: 'Peopledir',
+    email: 'zephyrine@peopledir.test', signupCount: 2, verifiedSignupCount: 1,
+    lastSeenAt: new Date(now - 1 * HOUR),
+  })
+  C.aOld = await createTestProspect(campaign.id, {
+    consumerId: C.a.id, phone: '+6598111001', firstName: 'Zephyrine', lastName: 'Peopledir',
+    createdAt: new Date(now - 48 * HOUR),
+  })
+  C.aNew = await createTestProspect(campaign.id, {
+    consumerId: C.a.id, phone: '+6598111991', firstName: 'Zephyrine', lastName: 'Peopledir',
+    createdAt: new Date(now - 24 * HOUR),
+  })
+
+  // B — one signup.
+  await mkConsumer('b', {
+    phone: '+6598111002', firstName: 'Quorra', lastName: 'Peopledir',
+    email: 'quorra@peopledir.test', lastSeenAt: new Date(now - 2 * HOUR),
+  })
+  await createTestProspect(campaign.id, { consumerId: C.b.id, phone: '+6598111002' })
+
+  // Z — the pure edit-artifact: zero counts AND zero linked rows. Never listed.
+  await mkConsumer('artifact', {
+    phone: '+6598111003', firstName: 'Artifact', lastName: 'Peopledir',
+    signupCount: 0, verifiedSignupCount: 0,
+  })
+
+  // D — the drift victim: counter says 0, a prospect still links. MUST be
+  // listed (rows are the truth, the counter is a projection).
+  await mkConsumer('drift', {
+    phone: '+6598111004', firstName: 'Drifter', lastName: 'Peopledir',
+    signupCount: 0, verifiedSignupCount: 0, lastSeenAt: new Date(now - 3 * HOUR),
+  })
+  C.driftP = await createTestProspect(campaign.id, { consumerId: C.drift.id, phone: '+6598111004' })
+
+  // E — erased: identity nulled, stale counts survive, skeleton keeps the link.
+  await mkConsumer('erased', {
+    phone: null, phoneHash: null, firstName: null, lastName: null, email: null,
+    signupCount: 3, verifiedSignupCount: 2, erasedAt: new Date(now - 24 * HOUR),
+    lastSeenAt: new Date(now - 30 * 60 * 1000),
+  })
+  C.erasedP = await createTestProspect(campaign.id, {
+    consumerId: C.erased.id, phone: null, firstName: 'Erased', lastName: null, email: null,
+  })
+
+  // Escaping fixtures: literal %, _, and backslash in names, plus lookalike
+  // controls that a broken (unescaped) pattern WOULD match.
+  await mkConsumer('pct', { phone: '+6598111006', firstName: 'Wild%card', lastName: 'Peopledir' })
+  await createTestProspect(campaign.id, { consumerId: C.pct.id, phone: '+6598111006' })
+  await mkConsumer('pctCtl', { phone: '+6598111007', firstName: 'Wildzcard', lastName: 'Peopledir' })
+  await createTestProspect(campaign.id, { consumerId: C.pctCtl.id, phone: '+6598111007' })
+  await mkConsumer('und', { phone: '+6598111008', firstName: 'a_b', lastName: 'Peopledir' })
+  await createTestProspect(campaign.id, { consumerId: C.und.id, phone: '+6598111008' })
+  await mkConsumer('undCtl', { phone: '+6598111009', firstName: 'axb', lastName: 'Peopledir' })
+  await createTestProspect(campaign.id, { consumerId: C.undCtl.id, phone: '+6598111009' })
+  await mkConsumer('bs', { phone: '+6598111010', firstName: 'back\\slash', lastName: 'Peopledir' })
+  await createTestProspect(campaign.id, { consumerId: C.bs.id, phone: '+6598111010' })
+  await mkConsumer('bsCtl', { phone: '+6598111011', firstName: 'backslash', lastName: 'Peopledir' })
+  await createTestProspect(campaign.id, { consumerId: C.bsCtl.id, phone: '+6598111011' })
+}, 30000)
+
+afterAll(async () => {
+  await closeDb()
+})
+
+const scoped = (extra = '') => `/api/consumers?q=Peopledir${extra}`
+const ids = (res) => res.body.data.rows.map((r) => r.id)
+
+describe('GET /api/consumers — auth', () => {
+  it('401 without a token', async () => {
+    const res = await get('/api/consumers', null)
+    expect(res.status).toBe(401)
+  })
+
+  it('403 for a non-admin', async () => {
+    const res = await get('/api/consumers', agentToken)
+    expect(res.status).toBe(403)
+  })
+})
+
+describe('GET /api/consumers — membership is row existence', () => {
+  it('lists linked people with the full row shape', async () => {
+    const res = await get(scoped())
+    expect(res.status).toBe(200)
+    expect(typeof res.body.data.total).toBe('number')
+    const a = res.body.data.rows.find((r) => r.id === C.a.id)
+    expect(a).toBeDefined()
+    expect(Object.keys(a).sort()).toEqual([
+      'email', 'erasedAt', 'firstName', 'firstSeenAt', 'id', 'lastName',
+      'lastSeenAt', 'latestProspectId', 'phone', 'signupCount', 'verifiedSignupCount',
+    ])
+    expect(a).toMatchObject({
+      firstName: 'Zephyrine', lastName: 'Peopledir', phone: '+6598111001',
+      signupCount: 2, verifiedSignupCount: 1, erasedAt: null,
+    })
+  })
+
+  it('latestProspectId is the NEWEST linked prospect', async () => {
+    const res = await get(scoped())
+    const a = res.body.data.rows.find((r) => r.id === C.a.id)
+    expect(a.latestProspectId).toBe(C.aNew.id)
+  })
+
+  it('hides the zero-count artifact with no linked rows', async () => {
+    const res = await get(scoped())
+    expect(ids(res)).not.toContain(C.artifact.id)
+  })
+
+  it('lists the drift victim (counter 0, prospect still linked) — rows beat counters', async () => {
+    const res = await get(scoped())
+    const drift = res.body.data.rows.find((r) => r.id === C.drift.id)
+    expect(drift).toBeDefined()
+    expect(drift.signupCount).toBe(0)
+    expect(drift.latestProspectId).toBe(C.driftP.id)
+  })
+})
+
+describe('GET /api/consumers — erased people', () => {
+  it('browsable with null identity, stale counts, and a working click target', async () => {
+    const row = await findRowById(C.erased.id)
+    expect(row).not.toBeNull()
+    expect(row).toMatchObject({
+      firstName: null, lastName: null, email: null, phone: null,
+      signupCount: 3,
+    })
+    expect(row.erasedAt).toBeTruthy()
+    expect(row.latestProspectId).toBe(C.erasedP.id)
+  })
+
+  it('never matched by identity search (nothing left to match — by design)', async () => {
+    const byName = await get('/api/consumers?q=Erased')
+    expect(ids(byName)).not.toContain(C.erased.id)
+    const byOldPhone = await get('/api/consumers?q=98111005')
+    expect(ids(byOldPhone)).not.toContain(C.erased.id)
+  })
+})
+
+describe('GET /api/consumers — search', () => {
+  it('matches first name, email, and the concatenated full name', async () => {
+    for (const q of ['Zephyrine', 'zephyrine@peopledir.test', 'Zephyrine Peopledir']) {
+      const res = await get(`/api/consumers?q=${encodeURIComponent(q)}`)
+      expect(ids(res)).toContain(C.a.id)
+    }
+  })
+
+  it('matches digit-normalized phone fragments (≥4 digits)', async () => {
+    const res = await get(`/api/consumers?q=${encodeURIComponent('8111 001')}`)
+    expect(ids(res)).toContain(C.a.id)
+  })
+
+  it('a <4-digit fragment never falls through to the phone match', async () => {
+    const res = await get('/api/consumers?q=001')
+    expect(ids(res)).not.toContain(C.a.id)
+  })
+
+  it('escapes % — a literal-percent query only matches the literal name', async () => {
+    const res = await get(`/api/consumers?q=${encodeURIComponent('%card')}`)
+    expect(ids(res)).toContain(C.pct.id)
+    expect(ids(res)).not.toContain(C.pctCtl.id)
+  })
+
+  it('escapes _ — a_b does not match axb', async () => {
+    const res = await get(`/api/consumers?q=${encodeURIComponent('a_b')}`)
+    expect(ids(res)).toContain(C.und.id)
+    expect(ids(res)).not.toContain(C.undCtl.id)
+  })
+
+  it('escapes backslash — back\\slash matches the literal, not "backslash"', async () => {
+    const res = await get(`/api/consumers?q=${encodeURIComponent('back\\slash')}`)
+    expect(ids(res)).toContain(C.bs.id)
+    expect(ids(res)).not.toContain(C.bsCtl.id)
+  })
+})
+
+describe('GET /api/consumers — sort and pagination', () => {
+  it('default sort is lastSeenAt DESC; unknown sorts fall back to it', async () => {
+    for (const extra of ['', '&sort=junk']) {
+      const res = await get(scoped(extra))
+      expect(ids(res)[0]).toBe(C.a.id) // A has the most recent lastSeenAt in scope
+    }
+  })
+
+  it('-signupCount puts the repeat person first', async () => {
+    const res = await get(scoped('&sort=-signupCount'))
+    expect(ids(res)[0]).toBe(C.a.id)
+  })
+
+  it('-name keeps null-named (erased) rows LAST', async () => {
+    const rows = []
+    for (let page = 1; page <= 3; page += 1) {
+      const res = await get(`/api/consumers?limit=100&page=${page}&sort=-name`)
+      rows.push(...res.body.data.rows)
+      if (res.body.data.rows.length < 100) break
+    }
+    const idx = rows.findIndex((r) => r.id === C.erased.id)
+    expect(idx).toBeGreaterThan(-1)
+    expect(rows.slice(0, idx).every((r) => r.lastName !== null)).toBe(true)
+  })
+
+  it('clamps limit to 100 and rejects junk page/limit strictly', async () => {
+    const big = await get(scoped('&limit=999'))
+    expect(big.body.data.limit).toBe(100)
+    const junkPage = await get(scoped('&page=2junk&limit=2.5'))
+    expect(junkPage.body.data.page).toBe(1)
+    expect(junkPage.body.data.limit).toBe(25)
+  })
+
+  it('pages deterministically with the id tiebreak (no dup, no gap)', async () => {
+    const p1 = await get(scoped('&sort=name&limit=3&page=1'))
+    const p2 = await get(scoped('&sort=name&limit=3&page=2'))
+    const seen = [...ids(p1), ...ids(p2)]
+    expect(new Set(seen).size).toBe(seen.length)
+    expect(p1.body.data.total).toBe(p2.body.data.total)
+  })
+})

--- a/backend/test/prospectServiceBulkOps.test.js
+++ b/backend/test/prospectServiceBulkOps.test.js
@@ -62,6 +62,10 @@ function buildDeps(overrides = {}) {
     sequelize,
     buildProspectWhere: jest.fn().mockResolvedValue({}),
     deductLeadCredit: jest.fn().mockResolvedValue(),
+    // deleteProspect cancels live entitlements inside its transaction — the
+    // default dep lazy-imports the REAL service, which would run a real model
+    // query against this harness's fake transaction and kill the process.
+    cancelLiveEntitlementsForProspectTx: jest.fn().mockResolvedValue(0),
     dispatchEvent: jest.fn().mockResolvedValue(),
     persistEventDeliveries: jest.fn().mockResolvedValue([{ delivery: {}, subscriber: {} }]),
     flushDeliveries: jest.fn(),

--- a/backend/test/unit/consentGlobalGrant.test.js
+++ b/backend/test/unit/consentGlobalGrant.test.js
@@ -32,6 +32,10 @@ function captureHarness() {
       },
     },
     ConsentEvent: { bulkCreate: async (rows) => { created.push(...rows); return rows; } },
+    // The resubscribe lift reads suppressions inside the capture txn — without
+    // this stub the REAL model runs against the fake transaction and the whole
+    // suite dies at import-adjacent depth. No suppression → no lift.
+    ConsumerSuppression: { findOne: async () => null },
     logger: { warn: () => {} },
   });
   return { svc, created };

--- a/backend/test/unit/drawScanDoor.test.js
+++ b/backend/test/unit/drawScanDoor.test.js
@@ -143,10 +143,13 @@ describe('undoSessionUnlock (CX23)', () => {
 });
 
 describe('resendDelivery — draw guard (CX22)', () => {
-  it('a recorded session has NO voucher to resend', async () => {
+  it('a recorded session resends the boost receipt, never the partner voucher', async () => {
+    // wa-delivery-truth (#277) changed this contract: the draw-session resend
+    // now succeeds as the informational receipt instead of rejecting 409.
     const w = mkWorld({ status: 'issued' });
-    await expect(w.svc.resendDelivery('ent1', AGENT, { channel: 'email' }))
-      .rejects.toMatchObject({ statusCode: 409 });
+    const res = await w.svc.resendDelivery('ent1', AGENT, { channel: 'email' });
+    expect(res).toMatchObject({ kind: 'boost_receipt', channel: 'email', emailQueued: true });
+    expect(res.entitlement.tokenHash).toBeNull();
   });
 });
 

--- a/backend/test/unit/emailService.test.js
+++ b/backend/test/unit/emailService.test.js
@@ -78,9 +78,11 @@ describe('emailService (unit)', () => {
         html: '<p>Content</p>',
       });
 
+      // Recipient is PII-masked in logs (redactTokens.maskEmail) — assert the
+      // masked form so the test proves the redaction instead of fighting it.
       expect(logger.info).toHaveBeenCalledWith(
         expect.stringContaining('Email not sent'),
-        expect.objectContaining({ to: 'test@example.com', subject: 'Test Subject' })
+        expect.objectContaining({ to: 't•••@example.com', subject: 'Test Subject' })
       );
     });
   });

--- a/backend/test/unit/shortlinkService.test.js
+++ b/backend/test/unit/shortlinkService.test.js
@@ -33,6 +33,12 @@ function buildMocks() {
     literal: jest.fn((expr) => expr),
   };
 
+  // The service imports Prospect for getOrCreateProspectShareLinkById; a
+  // missing named export kills the whole ESM suite at import time.
+  const Prospect = {
+    findByPk: jest.fn().mockResolvedValue(null),
+  };
+
   const AppError = class extends Error {
     constructor(message, statusCode) {
       super(message);
@@ -40,7 +46,7 @@ function buildMocks() {
     }
   };
 
-  return { mockLink, ShortLink, ShortLinkClick, sequelize, AppError };
+  return { mockLink, ShortLink, ShortLinkClick, Prospect, sequelize, AppError };
 }
 
 let mocks;
@@ -52,6 +58,7 @@ beforeEach(async () => {
   jest.unstable_mockModule('../../src/models/index.js', () => ({
     ShortLink: mocks.ShortLink,
     ShortLinkClick: mocks.ShortLinkClick,
+    Prospect: mocks.Prospect,
     sequelize: mocks.sequelize,
   }));
 

--- a/src/api/__tests__/adminV2.api.test.js
+++ b/src/api/__tests__/adminV2.api.test.js
@@ -1,0 +1,38 @@
+/**
+ * adminV2 data-layer envelope contracts — the fetchers normalize each
+ * endpoint's REAL envelope so table components never learn per-endpoint
+ * shapes. fetchConsumers is the People directory's door (R2 #5: these
+ * assertions need a home that actually executes).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/api/client', () => ({ apiClient: { get: vi.fn() } }));
+
+import { apiClient } from '@/api/client';
+import { fetchConsumers } from '../adminV2.js';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('fetchConsumers', () => {
+  it('builds the querystring from non-empty params only and normalizes the envelope', async () => {
+    apiClient.get.mockResolvedValue({
+      data: { total: 5, page: 2, limit: 25, rows: [{ id: 'c1', latestProspectId: 'p1' }] },
+    });
+    const out = await fetchConsumers({ q: 'shawn lee', page: 2, limit: 25, sort: '-name', empty: '' });
+    expect(apiClient.get).toHaveBeenCalledTimes(1);
+    const url = apiClient.get.mock.calls[0][0];
+    expect(url.startsWith('/consumers?')).toBe(true);
+    const qs = new URLSearchParams(url.split('?')[1]);
+    expect(qs.get('q')).toBe('shawn lee');
+    expect(qs.get('page')).toBe('2');
+    expect(qs.get('sort')).toBe('-name');
+    expect(qs.has('empty')).toBe(false);
+    expect(out).toEqual({ total: 5, page: 2, limit: 25, rows: [{ id: 'c1', latestProspectId: 'p1' }] });
+  });
+
+  it('degrades to safe defaults on a malformed envelope', async () => {
+    apiClient.get.mockResolvedValue({});
+    const out = await fetchConsumers();
+    expect(out).toEqual({ rows: [], total: 0, page: 1, limit: 25 });
+  });
+});

--- a/src/api/adminV2.js
+++ b/src/api/adminV2.js
@@ -66,6 +66,26 @@ export async function fetchProspectProfile(id) {
   return resp?.data?.prospect ?? null;
 }
 
+/**
+ * People directory (/AdminPeople): the deduplicated person list. Rows carry
+ * latestProspectId, the profile click-through anchor. params: { q, page,
+ * limit, sort }.
+ */
+export async function fetchConsumers(params = {}) {
+  const qs = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined && v !== null && v !== '') qs.set(k, v);
+  }
+  const resp = await apiClient.get(`/consumers?${qs.toString()}`);
+  const data = resp?.data ?? {};
+  return {
+    rows: data.rows || [],
+    total: data.total ?? 0,
+    page: data.page ?? 1,
+    limit: data.limit ?? 25,
+  };
+}
+
 /** Campaign leaderboard source — extended admin list (B6). */
 export async function fetchCampaignsList(period) {
   const resp = await apiClient.get(`/campaigns?period=${encodeURIComponent(period)}&limit=100`);

--- a/src/components/adminv2/__tests__/GlobalSearch.test.jsx
+++ b/src/components/adminv2/__tests__/GlobalSearch.test.jsx
@@ -102,6 +102,14 @@ describe('GlobalSearch', () => {
     expect(screen.getByTestId('loc')).toHaveTextContent('/AdminWallets');
   });
 
+  it('the People directory rides the NAV-derived Pages group for free', async () => {
+    setup();
+    const input = openPalette();
+    fireEvent.change(input, { target: { value: 'people' } });
+    fireEvent.click(await screen.findByText('People'));
+    expect(screen.getByTestId('loc')).toHaveTextContent('/AdminPeople');
+  });
+
   it('arrow keys walk the flat list; the fallback row never dead-ends Enter', async () => {
     setup();
     const input = openPalette();

--- a/src/hooks/queries/useAdminV2.js
+++ b/src/hooks/queries/useAdminV2.js
@@ -2,10 +2,10 @@
  * Switchboard admin v2 — react-query hooks. Query keys carry period/filters so
  * period switches and filter changes are cache-correct by construction.
  */
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import {
   fetchOverview, fetchAttention, fetchSeries, fetchFunnel,
-  fetchProspects, fetchProspectDetail, fetchProspectProfile, fetchCampaignsList, fetchAgentOptions,
+  fetchProspects, fetchProspectDetail, fetchProspectProfile, fetchConsumers, fetchCampaignsList, fetchAgentOptions,
   fetchAgentsRoster, fetchCampaignSummary, fetchWallets, fetchWalletLedger, fetchAgentGroups,
 } from '@/api/adminV2';
 
@@ -52,7 +52,19 @@ export function useProspects(params) {
     queryKey: ['adminV2', 'prospects', params],
     queryFn: () => fetchProspects(params),
     staleTime: 10_000,
-    keepPreviousData: true,
+    // RQ v5: the v4 `keepPreviousData: true` flag was removed and silently
+    // ignored here — this is the working idiom (page flips keep prior rows).
+    placeholderData: keepPreviousData,
+  });
+}
+
+/** People directory list (/AdminPeople). */
+export function useConsumers(params) {
+  return useQuery({
+    queryKey: ['adminV2', 'consumers', params],
+    queryFn: () => fetchConsumers(params),
+    staleTime: 10_000,
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/src/lib/adminV2/__tests__/adminV2.test.js
+++ b/src/lib/adminV2/__tests__/adminV2.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { composeAttentionRows, composeHealthStrip, SEVERITY_ORDER } from '../attention.js';
 import { prospectsToCsv } from '../csv.js';
-import { fmtSGD, fmtSGDExact, fmtDateTime, fmtRelative, daysUntil, fmtNumber, fmtDay } from '../format.js';
+import { fmtSGD, fmtSGDExact, fmtDateTime, fmtRelative, daysUntil, fmtNumber, fmtDay, fmtPhone } from '../format.js';
 import { HELD_REASON_LABELS, STATUS_LABELS, STATUS_CHIP_CLASS, SOURCE_LABELS, LEAD_STATUSES, LEAD_SOURCES, heldLabel } from '../constants.js';
 
 describe('constants — vocabulary completeness', () => {
@@ -238,6 +238,14 @@ describe('formatters', () => {
   it('fmtNumber handles nullish', () => {
     expect(fmtNumber(1024)).toBe('1,024');
     expect(fmtNumber(undefined)).toBe('—');
+  });
+
+  it('fmtPhone renders the house +65 XXXX XXXX display; passes through everything else', () => {
+    expect(fmtPhone('+6591234567')).toBe('+65 9123 4567');
+    expect(fmtPhone('+65 9123 4567')).toBe('+65 9123 4567'); // already spaced — no double format
+    expect(fmtPhone('+123456789012')).toBe('+123456789012'); // non-SG stays raw
+    expect(fmtPhone(null)).toBeNull();
+    expect(fmtPhone('')).toBeNull();
   });
 
   it('fmtDay formats ISO day buckets without tz drift', () => {

--- a/src/lib/adminV2/format.js
+++ b/src/lib/adminV2/format.js
@@ -75,6 +75,12 @@ export function fmtAgoShort(value, now = Date.now()) {
   return new Date(t).toLocaleDateString('en-SG', { day: 'numeric', month: 'short', timeZone: SGT });
 }
 
+/** House phone display: +6591234567 → "+65 9123 4567" (root CLAUDE.md rule). */
+export function fmtPhone(v) {
+  const m = /^\+65(\d{4})(\d{4})$/.exec(String(v || ''));
+  return m ? `+65 ${m[1]} ${m[2]}` : (v || null);
+}
+
 /** "days until" for deadlines (SGT end-of-day strings or ISO dates). */
 export function daysUntil(value, now = Date.now()) {
   if (!value) return null;

--- a/src/lib/adminV2/nav.js
+++ b/src/lib/adminV2/nav.js
@@ -12,6 +12,8 @@ export const NAV = [
     label: 'Lead Generation',
     items: [
       { to: '/AdminProspects', label: 'Prospects' },
+      // Person-grain sibling of the signup-grain table above.
+      { to: '/AdminPeople', label: 'People' },
       { to: '/AdminCohorts', label: 'Cohorts' },
       { to: '/AdminBroadcasts', label: 'Email Pushes' },
       { to: '/AdminAgents', label: 'Agents' },

--- a/src/pages/adminv2/AdminV2LeadProfile.jsx
+++ b/src/pages/adminv2/AdminV2LeadProfile.jsx
@@ -272,6 +272,10 @@ function GlyphTile({ family, size = 22 }) {
 
 // ── the page ────────────────────────────────────────────────────────────────
 
+/** Back-link origins the profile honors (admin-people-directory §3.4). */
+const FROM_LABELS = { '/AdminProspects': 'Prospects', '/AdminPeople': 'People' };
+const COHORT_FROM_RE = /^\/admin\/cohorts\/[0-9a-f-]{36}$/;
+
 export default function AdminV2LeadProfile() {
   const { prospectId } = useParams();
   const [searchParams] = useSearchParams();
@@ -279,11 +283,15 @@ export default function AdminV2LeadProfile() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const view = searchParams.get('view') === 'profile' ? 'profile' : 'signup';
-  const [confirmDelete, setConfirmDelete] = useState(false);
-  // Assign menu: null | 'campaign' | 'agent'; target = the signup being assigned.
+  // Delete confirm: null | targetId — the picked signup, not always the URL's.
+  const [confirmDelete, setConfirmDelete] = useState(null);
+  // Command picker: stage null | 'campaign' | 'agent', with the ACTION it is
+  // picking for — assign advances campaign→agent, return/delete act on the
+  // picked campaign directly (§3.5: person-origin mutations pick explicitly).
   const [menu, setMenu] = useState(null);
+  const [menuAction, setMenuAction] = useState(null);
   const [menuTarget, setMenuTarget] = useState(null);
-  useEffect(() => { setMenu(null); }, [prospectId, view]);
+  useEffect(() => { setMenu(null); setMenuAction(null); }, [prospectId, view]);
   useEffect(() => {
     if (!menu) return undefined;
     const onKey = (e) => { if (e.key === 'Escape') setMenu(null); };
@@ -291,9 +299,23 @@ export default function AdminV2LeadProfile() {
     return () => window.removeEventListener('keydown', onKey);
   }, [menu]);
 
-  const from = typeof location.state?.from === 'string' && location.state.from.startsWith('/AdminProspects')
-    ? location.state.from
-    : '/AdminProspects';
+  // Canonical-equality validation: the raw state.from must equal its own
+  // parsed pathname+search (one comparison rules out dot segments,
+  // backslashes, //network-path refs and fragments — new URL() NORMALIZES
+  // dot segments, so an allowlist check alone could be walked into), then
+  // the pathname must match a known list page exactly.
+  const { from, fromLabel } = useMemo(() => {
+    const fallback = { from: '/AdminProspects', fromLabel: 'Prospects' };
+    const raw = location.state?.from;
+    if (typeof raw !== 'string' || !raw.startsWith('/')) return fallback;
+    let url;
+    try { url = new URL(raw, window.location.origin); } catch { return fallback; }
+    if (url.origin !== window.location.origin) return fallback;
+    if (raw !== `${url.pathname}${url.search}`) return fallback;
+    if (FROM_LABELS[url.pathname]) return { from: raw, fromLabel: FROM_LABELS[url.pathname] };
+    if (COHORT_FROM_RE.test(url.pathname)) return { from: raw, fromLabel: 'Cohort' };
+    return fallback;
+  }, [location.state]);
   const goSignup = useCallback((id) => navigate(`/admin/leads/${id}`, { state: { from } }), [navigate, from]);
   const goProfile = useCallback(() => navigate(`/admin/leads/${prospectId}?view=profile`, { state: { from } }), [navigate, prospectId, from]);
 
@@ -320,7 +342,7 @@ export default function AdminV2LeadProfile() {
     onError: (e) => toast.error(e?.message || 'Assign failed'),
   });
   const returnMutation = useMutation({
-    mutationFn: () => bulkReturnToHeld([prospectId]),
+    mutationFn: ({ targetId } = {}) => bulkReturnToHeld([targetId || prospectId]),
     onSuccess: (r) => {
       const n = r?.data?.returned ?? 0;
       if (n > 0) toast.success('Returned to held');
@@ -330,15 +352,19 @@ export default function AdminV2LeadProfile() {
     onError: (e) => toast.error(e?.message || 'Return failed'),
   });
   const deleteMutation = useMutation({
-    mutationFn: () => bulkDelete([prospectId]),
-    onSuccess: (r) => {
+    mutationFn: ({ targetId } = {}) => bulkDelete([targetId || prospectId]),
+    onSuccess: (r, vars) => {
       const n = r?.data?.deleted ?? 0;
-      setConfirmDelete(false);
+      setConfirmDelete(null);
       invalidate();
-      if (n > 0) { toast.success('Lead deleted'); navigate(from); }
-      else toast.warning('Nothing deleted');
+      if (n > 0) {
+        toast.success('Lead deleted');
+        // Leaving the page only makes sense when the URL's own anchor died;
+        // deleting a SIBLING signup from the profile view stays put.
+        if (!vars?.targetId || String(vars.targetId) === String(prospectId)) navigate(from);
+      } else toast.warning('Nothing deleted');
     },
-    onError: (e) => { toast.error(e?.message || 'Delete failed'); setConfirmDelete(false); },
+    onError: (e) => { toast.error(e?.message || 'Delete failed'); setConfirmDelete(null); },
   });
 
   // Rail rows: journey signups, else this prospect alone (consumer-less B4).
@@ -411,7 +437,7 @@ export default function AdminV2LeadProfile() {
   if (profile.isError || !p) {
     return (
       <div>
-        <Link to={from} className="av2-btn av2-btn--sm" style={{ textDecoration: 'none', marginBottom: 16, display: 'inline-flex' }}>← Prospects</Link>
+        <Link to={from} className="av2-btn av2-btn--sm" style={{ textDecoration: 'none', marginBottom: 16, display: 'inline-flex' }}>← {fromLabel}</Link>
         <ErrorState error={profile.error || new Error("Couldn't load this lead — it may have been deleted.")} onRetry={profile.refetch} />
       </div>
     );
@@ -432,12 +458,35 @@ export default function AdminV2LeadProfile() {
   const hasScreening = p.screeningVerdict || p.screeningMetadata || String(p.quarantineReason || '').startsWith('screening_');
 
   const assignButtonLabel = view === 'profile' ? 'Assign to agent ▾' : 'Assign this lead ▾';
-  const openAssign = () => {
-    if (menu) { setMenu(null); return; }
-    if (view === 'profile' && railSignups.length > 1) { setMenu('campaign'); setMenuTarget(null); }
-    else { setMenu('agent'); setMenuTarget(currentSignup?.prospectId || prospectId); }
+  // One opener for all three command-bar actions: in profile view with >1
+  // signup every action picks its campaign first (the URL's anchor is just
+  // the newest signup — not an operator choice); in drill-in the anchor IS
+  // the choice, so return/delete act directly and assign goes straight to
+  // the agent stage.
+  const openAction = (action) => {
+    if (menu) { setMenu(null); setMenuAction(null); return; }
+    if (view === 'profile' && railSignups.length > 1) {
+      setMenuAction(action); setMenu('campaign'); setMenuTarget(null);
+      return;
+    }
+    if (action === 'assign') {
+      setMenuAction('assign'); setMenu('agent');
+      setMenuTarget(currentSignup?.prospectId || prospectId);
+    } else if (action === 'return') {
+      returnMutation.mutate({ targetId: currentSignup?.prospectId || prospectId });
+    } else {
+      setConfirmDelete(currentSignup?.prospectId || prospectId);
+    }
+  };
+  const pickCampaign = (s) => {
+    if (menuAction === 'assign') { setMenu('agent'); setMenuTarget(s.prospectId); return; }
+    setMenu(null); setMenuAction(null);
+    if (menuAction === 'return') returnMutation.mutate({ targetId: s.prospectId });
+    else setConfirmDelete(s.prospectId);
   };
   const menuTargetSignup = railSignups.find((s) => String(s.prospectId) === String(menuTarget)) || null;
+  // Delete-confirm copy names the PICKED signup's campaign, not the URL's.
+  const confirmSignup = railSignups.find((s) => String(s.prospectId) === String(confirmDelete)) || currentSignup;
 
   const consentVersions = consent
     ? [...new Set(Object.values(consent).map((c) => c?.version).filter(Boolean))]
@@ -460,22 +509,29 @@ export default function AdminV2LeadProfile() {
     <div>
       {/* ── Sticky command bar (all views) ── */}
       <div style={{ position: 'sticky', top: 64, zIndex: 30, display: 'flex', alignItems: 'center', gap: 10, padding: '12px 0', background: 'var(--canvas)', borderBottom: '1px solid var(--line)', marginBottom: 16 }}>
-        <Link to={from} style={{ fontSize: 12.5, fontWeight: 700, color: 'var(--accent-text)', textDecoration: 'none', flex: 'none' }}>← Prospects</Link>
+        <Link to={from} style={{ fontSize: 12.5, fontWeight: 700, color: 'var(--accent-text)', textDecoration: 'none', flex: 'none' }}>← {fromLabel}</Link>
         <span aria-hidden="true" style={{ width: 1, height: 16, background: 'var(--line-strong)', flex: 'none' }} />
         <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, letterSpacing: '.08em', color: 'var(--ink-3)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
           {`${canonicalName.toUpperCase()}${phone ? ` · ${phone}` : ''}`}
         </span>
         <span style={{ flex: 1 }} />
-        <button type="button" className="av2-btn av2-btn--sm" style={{ borderColor: 'var(--line-strong)', color: 'var(--bad)' }} onClick={() => setConfirmDelete(true)}>Delete</button>
-        <button type="button" className="av2-btn av2-btn--sm" disabled={returnMutation.isPending} onClick={() => returnMutation.mutate()}>Return to held</button>
-        <div style={{ position: 'relative', flex: 'none' }}>
-          <button type="button" className="av2-btn av2-btn--sm av2-btn--primary" aria-haspopup="menu" aria-expanded={!!menu} disabled={assignMutation.isPending} onClick={openAssign}>
-            {assignButtonLabel}
-          </button>
+        <div style={{ position: 'relative', flex: 'none', display: 'flex', alignItems: 'center', gap: 8 }}>
+          <button type="button" className="av2-btn av2-btn--sm" style={{ borderColor: 'var(--line-strong)', color: 'var(--bad)' }} onClick={() => openAction('delete')}>Delete</button>
+          {/* Erased people cannot be re-dispatched — the backend bulk paths
+              don't fence this yet (tracker follow-up), so the controls that
+              would recreate operational records are suppressed here. */}
+          {!erased && (
+            <button type="button" className="av2-btn av2-btn--sm" disabled={returnMutation.isPending} onClick={() => openAction('return')}>Return to held</button>
+          )}
+          {!erased && (
+            <button type="button" className="av2-btn av2-btn--sm av2-btn--primary" aria-haspopup="menu" aria-expanded={!!menu} disabled={assignMutation.isPending} onClick={() => openAction('assign')}>
+              {assignButtonLabel}
+            </button>
+          )}
           {menu && (
             <>
               <div onClick={() => setMenu(null)} aria-hidden="true" style={{ position: 'fixed', inset: 0, zIndex: 60 }} />
-              <div role="menu" aria-label="Assign lead" style={{ position: 'absolute', right: 0, top: 40, zIndex: 70, width: 264, background: 'var(--surface)', border: '1px solid var(--line-strong)', borderRadius: 12, boxShadow: 'var(--shadow)', padding: 8, boxSizing: 'border-box' }}>
+              <div role="menu" aria-label={menuAction === 'return' ? 'Return lead' : menuAction === 'delete' ? 'Delete lead' : 'Assign lead'} style={{ position: 'absolute', right: 0, top: 40, zIndex: 70, width: 264, background: 'var(--surface)', border: '1px solid var(--line-strong)', borderRadius: 12, boxShadow: 'var(--shadow)', padding: 8, boxSizing: 'border-box' }}>
                 {menu === 'campaign' && (
                   <>
                     <div style={{ fontSize: 10.5, fontWeight: 700, letterSpacing: '.05em', textTransform: 'uppercase', color: 'var(--ink-2)', padding: '4px 10px 6px' }}>Which campaign's lead?</div>
@@ -484,7 +540,7 @@ export default function AdminV2LeadProfile() {
                         key={s.prospectId}
                         type="button"
                         role="menuitem"
-                        onClick={() => { setMenu('agent'); setMenuTarget(s.prospectId); }}
+                        onClick={() => pickCampaign(s)}
                         style={{ display: 'block', width: '100%', boxSizing: 'border-box', textAlign: 'left', background: 'transparent', border: 'none', borderRadius: 8, padding: '8px 10px', cursor: 'pointer', fontFamily: 'var(--font-ui)' }}
                       >
                         <span style={{ display: 'block', fontSize: 13, fontWeight: 700, color: 'var(--ink)' }}>{s.campaign?.name || 'No campaign'}</span>
@@ -872,18 +928,18 @@ export default function AdminV2LeadProfile() {
         </>
       )}
 
-      <AlertDialog open={confirmDelete} onOpenChange={setConfirmDelete}>
+      <AlertDialog open={!!confirmDelete} onOpenChange={(open) => { if (!open) setConfirmDelete(null); }}>
         <AlertDialogContent className="admin-v2" style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)' }}>
           <AlertDialogHeader>
             <AlertDialogTitle style={{ color: 'var(--ink)' }}>Delete this lead?</AlertDialogTitle>
             <AlertDialogDescription style={{ color: 'var(--ink-2)' }}>
-              This permanently removes the {currentSignup?.campaign?.name ? `${currentSignup.campaign.name} ` : ''}lead and its activity history. It cannot be undone.
+              This permanently removes the {confirmSignup?.campaign?.name ? `${confirmSignup.campaign.name} ` : ''}lead and its activity history. It cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
-              onClick={(e) => { e.preventDefault(); deleteMutation.mutate(); }}
+              onClick={(e) => { e.preventDefault(); deleteMutation.mutate({ targetId: confirmDelete }); }}
               disabled={deleteMutation.isPending}
               style={{ background: 'var(--bad)', color: '#fff' }}
             >

--- a/src/pages/adminv2/AdminV2People.jsx
+++ b/src/pages/adminv2/AdminV2People.jsx
@@ -1,0 +1,210 @@
+/**
+ * People — the deduplicated person directory (admin-people-directory §3).
+ * One row per PERSON (consumers with ≥1 linked signup row), searchable by
+ * name / email / phone digits, clicking through to the Lead Profile's PERSON
+ * view (/admin/leads/:latestProspectId?view=profile) with the state.from
+ * contract so the back link restores these exact filters. Deliberately lean:
+ * no selection, no bulk bar, no CSV — the signup-grain work lives on
+ * Prospects, this page finds the person.
+ */
+import { useMemo, useState, useEffect, useRef } from 'react';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { useConsumers } from '@/hooks/queries/useAdminV2';
+import { PAGE_SIZE } from '@/lib/adminV2/constants';
+import { fmtDateTime, fmtRelative, fmtPhone } from '@/lib/adminV2/format';
+import { Chip, PageHeader, Skeleton, ErrorState, EmptyState } from '@/components/adminv2/primitives';
+
+function readFilters(searchParams) {
+  return {
+    search: searchParams.get('q') || '',
+    sort: searchParams.get('sort') || '-lastSeenAt',
+    page: Math.max(1, parseInt(searchParams.get('page'), 10) || 1),
+  };
+}
+
+function SortHeader({ label, field, sort, onSort, width, align }) {
+  const active = sort === field || sort === `-${field}`;
+  const desc = sort === `-${field}`;
+  return (
+    <button
+      type="button"
+      onClick={() => onSort(active && !desc ? `-${field}` : field)}
+      className="av2-microcaps"
+      style={{
+        width, flex: width ? 'none' : 1, textAlign: align || 'left', background: 'none',
+        border: 'none', cursor: 'pointer', padding: 0, fontFamily: 'var(--font-ui)',
+        color: active ? 'var(--ink)' : 'var(--ink-2)',
+      }}
+      aria-sort={active ? (desc ? 'descending' : 'ascending') : 'none'}
+    >
+      {label}{active ? (desc ? ' ▼' : ' ▲') : ''}
+    </button>
+  );
+}
+
+export default function AdminV2People() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filters = useMemo(() => readFilters(searchParams), [searchParams]);
+  const [searchDraft, setSearchDraft] = useState(filters.search);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  // Live params ref for the debounce timer — RR v7's setSearchParams closes
+  // over ITS render's params (the AdminV2Prospects lesson): a stale updater
+  // would rewind filters clicked inside the debounce window.
+  const paramsRef = useRef(searchParams);
+  paramsRef.current = searchParams;
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      const prev = paramsRef.current;
+      if ((prev.get('q') || '') === searchDraft) return;
+      const next = new URLSearchParams(prev);
+      if (searchDraft) next.set('q', searchDraft);
+      else next.delete('q');
+      next.delete('page');
+      setSearchParams(next, { replace: true });
+    }, 350);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchDraft]);
+
+  // Back/forward (or a pasted URL) changes q outside the input — resync the
+  // draft unless the operator is mid-typing.
+  useEffect(() => {
+    if (document.activeElement?.getAttribute('aria-label') !== 'Search people' && filters.search !== searchDraft) {
+      setSearchDraft(filters.search);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filters.search]);
+
+  function patch(changes) {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      for (const [k, v] of Object.entries(changes)) {
+        if (v === null || v === '' || v === undefined) next.delete(k);
+        else next.set(k, v);
+      }
+      return next;
+    }, { replace: true });
+  }
+
+  const queryParams = useMemo(() => ({
+    page: filters.page,
+    limit: PAGE_SIZE,
+    ...(filters.search ? { q: filters.search } : {}),
+    sort: filters.sort,
+  }), [filters]);
+
+  const people = useConsumers(queryParams);
+  const rows = people.data?.rows || [];
+  const total = people.data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const rangeStart = total === 0 ? 0 : (filters.page - 1) * PAGE_SIZE + 1;
+  const rangeEnd = Math.min(filters.page * PAGE_SIZE, total);
+
+  // The person view of the existing profile — never a new detail surface.
+  const openPerson = (r) => {
+    if (!r.latestProspectId) return;
+    navigate(`/admin/leads/${r.latestProspectId}?view=profile`, {
+      state: { from: `${location.pathname}${location.search}` },
+    });
+  };
+
+  return (
+    <div>
+      <PageHeader title="People" meta={`${total.toLocaleString('en-SG')} LINKED PEOPLE · SERVER-SIDE 25/PAGE`} />
+
+      <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', marginBottom: 16 }}>
+        <div className="av2-input" style={{ maxWidth: 320 }}>
+          <span aria-hidden="true" style={{ color: 'var(--ink-3)' }}>⌕</span>
+          <input
+            value={searchDraft}
+            onChange={(e) => setSearchDraft(e.target.value)}
+            placeholder="Search name, phone, email"
+            aria-label="Search people"
+            style={{ border: 'none', outline: 'none', background: 'transparent', flex: 1, font: 'inherit', color: 'inherit' }}
+          />
+        </div>
+      </div>
+
+      <div className="av2-card" style={{ overflow: 'hidden' }}>
+        <div className="av2-thead">
+          <SortHeader label="Person" field="name" sort={filters.sort} onSort={(s) => patch({ sort: s, page: null })} />
+          <span className="av2-microcaps" style={{ width: 130, flex: 'none' }}>Phone</span>
+          <SortHeader label="Signups" field="signupCount" sort={filters.sort} onSort={(s) => patch({ sort: s, page: null })} width={170} />
+          <SortHeader label="Last seen" field="lastSeenAt" sort={filters.sort} onSort={(s) => patch({ sort: s, page: null })} width={100} align="right" />
+        </div>
+
+        {people.isLoading && [0, 1, 2, 3, 4].map((i) => (
+          <div key={i} className="av2-row" style={{ cursor: 'default' }}><Skeleton height={32} /></div>
+        ))}
+        {people.isError && <ErrorState error={people.error} onRetry={people.refetch} />}
+        {!people.isLoading && !people.isError && rows.length === 0 && (
+          <EmptyState
+            title={filters.search ? 'No people match this search' : 'No linked people yet'}
+            hint={filters.search
+              ? 'Search matches name, email, and phone digits. Erased people are browsable but never searchable.'
+              : 'People appear here once a signup links to the consumer spine.'}
+            action={filters.search && (
+              <button type="button" className="av2-btn av2-btn--sm" onClick={() => { setSearchDraft(''); patch({ q: null, page: null }); }}>Clear search</button>
+            )}
+          />
+        )}
+
+        {rows.map((r) => {
+          const erased = !!r.erasedAt;
+          const name = `${r.firstName || ''} ${r.lastName || ''}`.trim();
+          const clickable = !!r.latestProspectId;
+          return (
+            <div
+              key={r.id}
+              className="av2-row"
+              role={clickable ? 'button' : undefined}
+              tabIndex={clickable ? 0 : undefined}
+              style={clickable ? undefined : { cursor: 'default' }}
+              onClick={() => openPerson(r)}
+              onKeyDown={(e) => { if (clickable && (e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); openPerson(r); } }}
+            >
+              <span style={{ flex: 1, minWidth: 0 }}>
+                <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span style={{ fontSize: 13, fontWeight: 700, color: erased ? 'var(--ink-2)' : 'var(--ink)' }}>
+                    {erased ? 'Erased person' : (name || '—')}
+                  </span>
+                  {erased && <Chip tone="bad" glyph="⊘">erased</Chip>}
+                </span>
+                <span className="av2-mono" style={{ display: 'block', fontSize: 10, color: 'var(--ink-3)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {erased ? '—' : (r.email || '—')}
+                </span>
+              </span>
+              <span className="av2-mono" style={{ width: 130, flex: 'none', fontSize: 11, color: 'var(--ink-2)' }}>
+                {fmtPhone(r.phone) || '—'}
+              </span>
+              <span style={{ width: 170, flex: 'none', fontSize: 12, color: 'var(--ink-2)' }}>
+                {r.signupCount} signup{r.signupCount === 1 ? '' : 's'} ({r.verifiedSignupCount} verified)
+              </span>
+              <span className="av2-mono" style={{ width: 100, flex: 'none', fontSize: 10, color: 'var(--ink-3)', textAlign: 'right' }} title={fmtDateTime(r.lastSeenAt)}>
+                {fmtRelative(r.lastSeenAt)}
+              </span>
+            </div>
+          );
+        })}
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '10px 16px' }}>
+          <span className="av2-mono" style={{ fontSize: 11, color: 'var(--ink-3)' }}>
+            {rangeStart}–{rangeEnd} of {total.toLocaleString('en-SG')}
+          </span>
+          <span style={{ flex: 1 }} />
+          <button type="button" className="av2-btn av2-btn--sm" disabled={filters.page <= 1} onClick={() => patch({ page: String(filters.page - 1) })}>← Prev</button>
+          <button type="button" className="av2-btn av2-btn--sm" disabled={filters.page >= totalPages} onClick={() => patch({ page: String(filters.page + 1) })}>Next →</button>
+        </div>
+      </div>
+
+      {/* Persistent scope note — the total above is LINKED people, and that is
+          not everyone: voice/pre-spine leads have no person row (§3.1). */}
+      <div style={{ fontSize: 11.5, color: 'var(--ink-3)', marginTop: 10 }}>
+        Voice (Retell) and pre-spine leads have no linked person — find them in Prospects.
+      </div>
+    </div>
+  );
+}

--- a/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
@@ -5,7 +5,7 @@
  * and the command bar's two-step assign wires to bulkAssign for the picked
  * signup. Plus the consumer-less (Retell) and erased states.
  */
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -19,7 +19,7 @@ vi.mock('@/api/adminV2', () => ({
   bulkDelete: vi.fn(),
 }));
 
-import { fetchProspectProfile, bulkAssign } from '@/api/adminV2';
+import { fetchProspectProfile, bulkAssign, bulkReturnToHeld, bulkDelete } from '@/api/adminV2';
 
 const PROFILE = {
   id: 'p1',
@@ -88,14 +88,24 @@ function Loc() {
   return <div data-testid="loc">{location.pathname}{location.search}</div>;
 }
 
-function setup(initial = '/admin/leads/p1') {
+function setup(initial = '/admin/leads/p1', fromState) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const qIdx = initial.indexOf('?');
+  const entry = fromState === undefined
+    ? initial
+    : {
+      pathname: qIdx === -1 ? initial : initial.slice(0, qIdx),
+      search: qIdx === -1 ? '' : initial.slice(qIdx),
+      state: { from: fromState },
+    };
   render(
     <QueryClientProvider client={qc}>
-      <MemoryRouter initialEntries={[initial]}>
+      <MemoryRouter initialEntries={[entry]}>
         <Routes>
           <Route path="/admin/leads/:prospectId" element={<><AdminV2LeadProfile /><Loc /></>} />
-          <Route path="/AdminProspects" element={<div>LIST</div>} />
+          <Route path="/AdminProspects" element={<><div>LIST</div><Loc /></>} />
+          <Route path="/AdminPeople" element={<><div>PEOPLE LIST</div><Loc /></>} />
+          <Route path="/admin/cohorts/:id" element={<><div>COHORT PAGE</div><Loc /></>} />
         </Routes>
       </MemoryRouter>
     </QueryClientProvider>
@@ -222,6 +232,74 @@ describe('AdminV2LeadProfile — states', () => {
     await screen.findByText(/This person was erased/);
     expect(screen.getByText('⊘ Draw record unavailable')).toBeInTheDocument();
     expect(screen.getByText('ERASED')).toBeInTheDocument();
+  });
+
+  it('erased person: Assign and Return are suppressed, Delete stays', async () => {
+    const erased = JSON.parse(JSON.stringify(PROFILE));
+    erased.consumer.consumer.erasedAt = '2026-07-12T02:00:00Z';
+    fetchProspectProfile.mockResolvedValue(erased);
+    setup();
+    await screen.findByText(/This person was erased/);
+    expect(screen.queryByRole('button', { name: 'Return to held' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Assign/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+});
+
+describe('AdminV2LeadProfile — back-link origins (§3.4)', () => {
+  it('honors a People origin: label and destination keep the list query', async () => {
+    setup('/admin/leads/p1', '/AdminPeople?q=zep&sort=-signupCount');
+    fireEvent.click(await screen.findByRole('link', { name: '← People' }));
+    expect(screen.getByTestId('loc')).toHaveTextContent('/AdminPeople?q=zep&sort=-signupCount');
+  });
+
+  it('honors a cohort-detail origin with the Cohort label', async () => {
+    setup('/admin/leads/p1', '/admin/cohorts/123e4567-e89b-42d3-a456-426614174000');
+    expect(await screen.findByRole('link', { name: '← Cohort' })).toBeInTheDocument();
+  });
+
+  it('rejects prefix confusion — /AdminPeople-nope falls back to Prospects', async () => {
+    setup('/admin/leads/p1', '/AdminPeople-nope');
+    expect(await screen.findByRole('link', { name: '← Prospects' })).toBeInTheDocument();
+  });
+
+  it('rejects dot segments via canonical equality — the raw query never survives', async () => {
+    setup('/admin/leads/p1', '/AdminPeople/../AdminProspects?x=1');
+    fireEvent.click(await screen.findByRole('link', { name: '← Prospects' }));
+    expect(screen.getByTestId('loc')).toHaveTextContent('/AdminProspects');
+    expect(screen.getByTestId('loc')).not.toHaveTextContent('x=1');
+  });
+});
+
+describe('AdminV2LeadProfile — person-origin mutations pick their signup (§3.5)', () => {
+  it('profile-view Return is two-step: pick the campaign, then mutate THAT lead', async () => {
+    bulkReturnToHeld.mockResolvedValue({ data: { returned: 1 } });
+    setup('/admin/leads/p1?view=profile');
+    fireEvent.click(await screen.findByRole('button', { name: 'Return to held' }));
+    expect(screen.getByText("Which campaign's lead?")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('menuitem', { name: /NTUC Trial Reward/ }));
+    await waitFor(() => expect(bulkReturnToHeld).toHaveBeenCalledWith(['p2']));
+  });
+
+  it('profile-view Delete picks its signup, names it in the confirm, and stays on the page', async () => {
+    bulkDelete.mockResolvedValue({ data: { deleted: 1 } });
+    setup('/admin/leads/p1?view=profile');
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /NTUC Trial Reward/ }));
+    const dialog = await screen.findByRole('alertdialog');
+    expect(dialog).toHaveTextContent(/NTUC Trial Reward/);
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }));
+    await waitFor(() => expect(bulkDelete).toHaveBeenCalledWith(['p2']));
+    // Deleting a SIBLING signup keeps the operator on the person's page.
+    expect(screen.getByTestId('loc')).toHaveTextContent('/admin/leads/p1?view=profile');
+  });
+
+  it('drill-in Return stays one step on the URL anchor', async () => {
+    bulkReturnToHeld.mockResolvedValue({ data: { returned: 1 } });
+    setup();
+    fireEvent.click(await screen.findByRole('button', { name: 'Return to held' }));
+    expect(screen.queryByText("Which campaign's lead?")).not.toBeInTheDocument();
+    await waitFor(() => expect(bulkReturnToHeld).toHaveBeenCalledWith(['p1']));
   });
 });
 

--- a/src/pages/adminv2/__tests__/AdminV2People.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2People.test.jsx
@@ -1,0 +1,114 @@
+/**
+ * People directory — one row per PERSON: house phone display, the
+ * signups-voice cell, erased rows browsable with the ⊘ chip, row click lands
+ * on the profile's PERSON view carrying state.from (the back-link contract),
+ * defensive inert row when latestProspectId is missing, debounced search in
+ * the URL, and page flips that keep prior rows (v5 placeholderData).
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import AdminV2People from '../AdminV2People';
+
+vi.mock('@/api/adminV2', () => ({ fetchConsumers: vi.fn() }));
+
+import { fetchConsumers } from '@/api/adminV2';
+
+const DATA = {
+  total: 26, page: 1, limit: 25,
+  rows: [
+    {
+      id: 'c1', firstName: 'Shawn', lastName: 'Lee', email: 'shawn@x.com', phone: '+6591234567',
+      signupCount: 3, verifiedSignupCount: 2, firstSeenAt: '2026-05-01T08:40:00Z',
+      lastSeenAt: '2026-07-25T08:40:00Z', erasedAt: null, latestProspectId: 'p9',
+    },
+    {
+      id: 'c2', firstName: null, lastName: null, email: null, phone: null,
+      signupCount: 2, verifiedSignupCount: 1, firstSeenAt: '2026-04-01T08:40:00Z',
+      lastSeenAt: '2026-07-20T08:40:00Z', erasedAt: '2026-07-01T00:00:00Z', latestProspectId: 'p8',
+    },
+    {
+      id: 'c3', firstName: 'Null', lastName: 'Anchor', email: 'n@x.com', phone: '+6598887777',
+      signupCount: 1, verifiedSignupCount: 0, firstSeenAt: '2026-03-01T08:40:00Z',
+      lastSeenAt: '2026-07-10T08:40:00Z', erasedAt: null, latestProspectId: null,
+    },
+  ],
+};
+
+function Loc() {
+  const location = useLocation();
+  return <div data-testid="loc">{location.pathname}{location.search}|from:{String(location.state?.from)}</div>;
+}
+
+function setup(initial = '/AdminPeople') {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[initial]}>
+        <Routes>
+          <Route path="/AdminPeople" element={<><AdminV2People /><Loc /></>} />
+          <Route path="/admin/leads/:prospectId" element={<Loc />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchConsumers.mockResolvedValue(JSON.parse(JSON.stringify(DATA)));
+});
+
+describe('AdminV2People', () => {
+  it('renders linked people with the house phone display and the signups voice', async () => {
+    setup();
+    expect(await screen.findByText('Shawn Lee')).toBeInTheDocument();
+    expect(screen.getByText('+65 9123 4567')).toBeInTheDocument();
+    expect(screen.getByText('3 signups (2 verified)')).toBeInTheDocument();
+    expect(screen.getByText(/26 LINKED PEOPLE/)).toBeInTheDocument();
+    expect(screen.getByText(/no linked person — find them in Prospects/)).toBeInTheDocument();
+    expect(fetchConsumers).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 1, limit: 25, sort: '-lastSeenAt' })
+    );
+  });
+
+  it('row click opens the PERSON view of the profile, carrying the list URL as state.from', async () => {
+    setup('/AdminPeople?q=shawn');
+    fireEvent.click(await screen.findByRole('button', { name: /Shawn Lee/ }));
+    expect(screen.getByTestId('loc')).toHaveTextContent('/admin/leads/p9?view=profile|from:/AdminPeople?q=shawn');
+  });
+
+  it('erased people are browsable: ⊘ chip, dashed identity, still clickable', async () => {
+    setup();
+    const row = await screen.findByRole('button', { name: /Erased person/ });
+    expect(screen.getByText('erased')).toBeInTheDocument();
+    fireEvent.click(row);
+    expect(screen.getByTestId('loc')).toHaveTextContent('/admin/leads/p8?view=profile');
+  });
+
+  it('a row with no latestProspectId is inert — never a dead click', async () => {
+    setup();
+    await screen.findByText('Null Anchor');
+    expect(screen.queryByRole('button', { name: /Null Anchor/ })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('Null Anchor'));
+    expect(screen.getByTestId('loc')).toHaveTextContent('/AdminPeople');
+  });
+
+  it('search is debounced into the URL and drives the query', async () => {
+    setup();
+    await screen.findByText('Shawn Lee');
+    fireEvent.change(screen.getByLabelText('Search people'), { target: { value: 'lee' } });
+    await waitFor(() => expect(fetchConsumers).toHaveBeenCalledWith(
+      expect.objectContaining({ q: 'lee' })
+    ), { timeout: 1500 });
+  });
+
+  it('page flips keep the prior rows rendered (placeholderData, not a blank flash)', async () => {
+    setup();
+    await screen.findByText('Shawn Lee');
+    fetchConsumers.mockImplementation(() => new Promise(() => {})); // page 2 never resolves
+    fireEvent.click(screen.getByRole('button', { name: 'Next →' }));
+    expect(screen.getByText('Shawn Lee')).toBeInTheDocument();
+  });
+});

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -73,6 +73,7 @@ const ADMIN_V2 = import.meta.env.VITE_ADMIN_V2_ENABLED === 'true';
 const AdminV2Shell = lazy(() => import('@/components/adminv2/AdminV2Shell'));
 const AdminV2Dashboard = lazy(() => import('./adminv2/AdminV2Dashboard'));
 const AdminV2Prospects = lazy(() => import('./adminv2/AdminV2Prospects'));
+const AdminV2People = lazy(() => import('./adminv2/AdminV2People'));
 const AdminV2Cohorts = lazy(() => import('./adminv2/AdminV2Cohorts'));
 const AdminV2CohortDetail = lazy(() => import('./adminv2/AdminV2CohortDetail'));
 const AdminV2Broadcasts = lazy(() => import('./adminv2/AdminV2Broadcasts'));
@@ -362,6 +363,17 @@ function PagesContent() {
  <ProtectedRoute requiredRole="admin">
  <AdminV2Shell>
  <AdminV2LeadProfile />
+ </AdminV2Shell>
+ </ProtectedRoute>
+ }
+ />
+ )}
+ {ADMIN_V2 && (
+ <Route
+ path="/AdminPeople" element={
+ <ProtectedRoute requiredRole="admin">
+ <AdminV2Shell>
+ <AdminV2People />
  </AdminV2Shell>
  </ProtectedRoute>
  }


### PR DESCRIPTION
The deduplicated unique-person list the Prospects table deliberately isn't — audit P1 #6 first half, PR 1 of 2 from `docs/plans/admin-people-directory.md` (scoped, twice Codex-reviewed gpt-5.6-sol xhigh — R1: 20 findings/RETHINK → rewritten; R2: 9 findings/AMEND → amended; all dispositions in the plan's §8).

## Commit 1 — the CI precursor (mandatory, per plan §5 step 0)
The backend unit step was chronically red, and because a failing step skips the rest of the job, **no backend integration suite has been running in CI at all**. Root causes were four stale tests vs shipped source (missing `Prospect` export in the shortlink ESM mock — the chronic one — plus a resub-lift stub, a PII-masked log assertion, and the #277 boost-receipt resend contract). **`test/unit/` is now 98/98 suites, 1749/1749 tests locally** — the merge gate for this and future PRs hardens to "backend job green".

## Commit 2 — `GET /api/consumers`
Admin-gated list: one search box (name / `concat_ws` full name / email ILIKE with a corrected `escapeLike` — trims, caps, escapes `\`/`%`/`_` with explicit `ESCAPE` — plus digit-normalized phone fragments ≥4 digits), sort allowlist with `NULLS LAST` on names, strict `/^\d+$/` paging, `count(*)::int`, both statements in one REPEATABLE READ transaction. **Membership is prospect-row existence (inner `JOIN LATERAL`, which also yields `latestProspectId`), never the `signupCount` counter** — a drift victim stays visible, an edit-artifact never shows. Erased people: browsable, never identity-searchable (PII is nulled — by design). No migration: existing indexes cover current scale (129 consumers in prod).

## Commit 3 — the page + person-safe profile arrival
- **/AdminPeople**: person · phone (`+65 XXXX XXXX`) · `N signups (M verified)` · last seen; URL-driven debounced search + sorts; erased rows carry `⊘ erased`; row click → `/admin/leads/:latestProspectId?view=profile` with `state.from` carrying the exact list URL. Sidebar under Prospects; ⌘K palette picks it up from NAV automatically. Page flips keep prior rows (RQ v5 `placeholderData` — includes the one-line `useProspects` repair for the removed v4 flag).
- **Lead Profile**: back link now validates `state.from` by canonical equality (dot-segments and `/AdminPeople-nope` lookalikes fall back) against Prospects/People/cohort-detail with a derived label; **Return/Delete in profile view pick their campaign through the existing two-step menu** (the URL anchor is just the newest signup), the delete confirm names the picked signup, deleting a sibling stays on the page; **Assign/Return suppressed for erased people** (backend bulk fences are a named tracker follow-up).

## Evidence
- backend: `test/unit/` 98/98 · new `test/consumersList.test.js` 19/19 (auth, LIKE-escaping vs lookalike controls, existence-vs-counter incl. the drift row, erased browse/search asymmetry, latestProspectId, sorts incl. NULLS LAST, clamps)
- frontend: `vitest run src/pages/adminv2 src/lib/adminV2 src/components/adminv2 src/api src/hooks` → 22 files / 177 tests · `vite build` green · eslint clean on touched files
- PR 2 (cohort member click-through via `includeProspect`) follows after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8jF5ZxuAZD3NazPQQMEfV