### PR TITLE
Cohort members click through to the person profile

### DIFF
--- a/backend/src/controllers/cohortController.js
+++ b/backend/src/controllers/cohortController.js
@@ -113,6 +113,9 @@ export const members = asyncHandler(async (req, res) => {
     status: req.query.status || 'all',
     limit: req.query.limit,
     offset: req.query.offset,
+    // The admin members table clicks through to the Lead Profile person view;
+    // the flag stays service-level so the broadcast fan-out caller never pays.
+    includeProspect: true,
   });
   res.json({ success: true, data: { cohortId: cohort.id, name: cohort.name, ...result } });
 });

--- a/backend/src/services/cohortService.js
+++ b/backend/src/services/cohortService.js
@@ -474,7 +474,7 @@ export function makeCohortService(overrides = {}) {
    * person excluded" surface). status: all | reachable | excluded.
    */
   async function listCohortMembers(definition, {
-    channel, status = 'all', limit = 50, offset = 0,
+    channel, status = 'all', limit = 50, offset = 0, includeProspect = false,
   } = {}) {
     const def = normalizeDefinition(definition);
     const ch = normalizeChannel(channel);
@@ -498,6 +498,22 @@ export function makeCohortService(overrides = {}) {
        LIMIT :limit OFFSET :offset`,
       { replacements: { ...replacements, limit: lim, offset: off } });
 
+    // People click-through (admin-people-directory §3.6): resolve each page
+    // member's NEWEST linked prospect in one batch — opt-in so the broadcast
+    // send fan-out (this function's other caller) never pays for it, and the
+    // flag-off member shape stays byte-identical.
+    let latestByConsumer = null;
+    if (includeProspect && rows.length) {
+      const [lp] = await d.sequelize.query(
+        `SELECT DISTINCT ON ("consumerId") "consumerId", id
+           FROM prospects
+          WHERE "consumerId" IN (:consumerIds)
+          ORDER BY "consumerId", "createdAt" DESC, id DESC`,
+        { replacements: { consumerIds: rows.map((r) => r.id) } },
+      );
+      latestByConsumer = new Map(lp.map((p) => [p.consumerId, p.id]));
+    }
+
     return {
       total: count,
       limit: lim,
@@ -512,6 +528,7 @@ export function makeCohortService(overrides = {}) {
         lastSeenAt: r.lastSeenAt,
         reachable: r.reachable === true,
         reasons: r.reachable === true ? [] : reasonsForRow(r, ch),
+        ...(includeProspect ? { latestProspectId: latestByConsumer?.get(r.id) ?? null } : {}),
       })),
     };
   }

--- a/backend/test/cohortRoutes.test.js
+++ b/backend/test/cohortRoutes.test.js
@@ -157,8 +157,17 @@ describe('CRUD lifecycle', () => {
       .set(auth(adminToken));
     expect(res.status).toBe(200);
     expect(res.body.data.total).toBe(1);
-    expect(res.body.data.members[0].reachable).toBe(true);
-    expect(res.body.data.members[0].reasons).toEqual([]);
+    const member = res.body.data.members[0];
+    expect(member.reachable).toBe(true);
+    expect(member.reasons).toEqual([]);
+    // Full member-shape pin (this endpoint's rows were unpinned before the
+    // click-through field landed — additive changes must show up here).
+    expect(Object.keys(member).sort()).toEqual([
+      'consumerId', 'email', 'firstName', 'lastName', 'lastSeenAt',
+      'latestProspectId', 'phone', 'reachable', 'reasons', 'verifiedSignupCount',
+    ]);
+    // The fixture consumer has a linked prospect — the click target resolves.
+    expect(typeof member.latestProspectId).toBe('string');
 
     const bad = await request(app)
       .get(`/api/cohorts/${cohortId}/members?status=weird`)

--- a/backend/test/cohortService.test.js
+++ b/backend/test/cohortService.test.js
@@ -4,6 +4,7 @@ import {
 } from '../src/models/index.js';
 import {
   previewCohort, listCohortMembers, canMarketToBatch, getCohortFacets, normalizeDefinition,
+  makeCohortService,
 } from '../src/services/cohortService.js';
 import { canMarketTo } from '../src/services/consentService.js';
 import { hashPhone } from '../src/utils/piiHashing.js';
@@ -451,6 +452,47 @@ describe('members paging', () => {
     const walked = [...page1.members, ...page2.members, ...page3.members].map((m) => m.consumerId);
     expect(walked).toEqual(all.members.map((m) => m.consumerId));
     expect(page1.total).toBe(13);
+  });
+});
+
+describe('members → person click-through (includeProspect, admin-people-directory §3.6)', () => {
+  test('flag off: member shape is byte-identical (no latestProspectId key)', async () => {
+    const def = { filters: { campaignIds: [campA.id] } };
+    const { members } = await listCohortMembers(def, { limit: 200 });
+    expect(members.length).toBeGreaterThan(0);
+    for (const m of members) expect(Object.keys(m)).not.toContain('latestProspectId');
+  });
+
+  test('flag on: full member shape pinned, and the id is the NEWEST linked prospect', async () => {
+    // A dedicated consumer with TWO signups at controlled createdAt — the
+    // newer one must win.
+    const twice = await makeConsumer('TwoSignups', { verifiedSignupCount: 1 });
+    const older = await signup(twice, campA);
+    await older.update({ createdAt: new Date('2026-06-01T00:00:00Z') }, { silent: true, fields: ['createdAt'] });
+    const newer = await signup(twice, campA, { phone: nextPhone() });
+
+    const def = { filters: { campaignIds: [campA.id] } };
+    const { members } = await listCohortMembers(def, { limit: 200, includeProspect: true });
+    const mine = members.find((m) => m.consumerId === twice.id);
+    expect(mine).toBeDefined();
+    expect(Object.keys(mine).sort()).toEqual([
+      'consumerId', 'email', 'firstName', 'lastName', 'lastSeenAt',
+      'latestProspectId', 'phone', 'reachable', 'reasons', 'verifiedSignupCount',
+    ]);
+    expect(mine.latestProspectId).toBe(newer.id);
+  });
+
+  test('flag off issues NO prospect-batch SQL — the broadcast fan-out never pays', async () => {
+    const { sequelize } = await import('../src/models/index.js');
+    const calls = [];
+    const svc = makeCohortService({
+      sequelize: { query: (...a) => { calls.push(String(a[0])); return sequelize.query(...a); } },
+    });
+    const def = { filters: { campaignIds: [campA.id] } };
+    await svc.listCohortMembers(def, { limit: 5 });
+    expect(calls.some((sql) => sql.includes('DISTINCT ON ("consumerId")'))).toBe(false);
+    await svc.listCohortMembers(def, { limit: 5, includeProspect: true });
+    expect(calls.some((sql) => sql.includes('DISTINCT ON ("consumerId")'))).toBe(true);
   });
 });
 

--- a/src/pages/adminv2/AdminV2CohortDetail.jsx
+++ b/src/pages/adminv2/AdminV2CohortDetail.jsx
@@ -7,7 +7,7 @@
  * per channel (email needs an address, WhatsApp needs a phone…).
  */
 import { useMemo, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { fetchCohort, fetchCohortMembers, fetchCohortFacets, archiveCohort } from '@/api/adminV2';
@@ -36,6 +36,7 @@ export default function AdminV2CohortDetail() {
   const [editing, setEditing] = useState(false);
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const location = useLocation();
 
   // refresh=1: recompute + persist the snapshot every time the screen opens.
   const cohort = useQuery({
@@ -181,7 +182,20 @@ export default function AdminV2CohortDetail() {
             {(members.data?.members || []).map((m) => (
               <div key={m.consumerId} className="av2-row" role="row" style={{ cursor: 'default' }}>
                 <span role="cell" style={{ flex: 1.2, fontSize: 12.5, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                  {(m.firstName || m.lastName) ? `${m.firstName || ''} ${m.lastName || ''}`.trim() : '—'}
+                  {/* Person cell links into the Lead Profile PERSON view when a
+                      signup anchor exists — a Link inside the cell keeps the
+                      table's row/cell roles intact (admin-people-directory
+                      §3.6). state.from brings the operator back here. */}
+                  {m.latestProspectId ? (
+                    <Link
+                      to={`/admin/leads/${m.latestProspectId}?view=profile`}
+                      state={{ from: `${location.pathname}${location.search}` }}
+                      title="Open person profile"
+                      style={{ color: 'var(--accent-text)', textDecoration: 'none' }}
+                    >
+                      {(m.firstName || m.lastName) ? `${m.firstName || ''} ${m.lastName || ''}`.trim() : '—'}
+                    </Link>
+                  ) : ((m.firstName || m.lastName) ? `${m.firstName || ''} ${m.lastName || ''}`.trim() : '—')}
                   {m.reachable && <Chip tone="ok">✓</Chip>}
                 </span>
                 <span role="cell" className="av2-mono" style={{ width: 120, flex: 'none', fontSize: 11.5 }}>{m.phone || '—'}</span>

--- a/src/pages/adminv2/__tests__/AdminV2CohortDetail.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2CohortDetail.test.jsx
@@ -33,10 +33,10 @@ vi.mock('@/api/adminV2', () => ({
     draws: [],
   })),
   fetchCohortMembers: vi.fn(async (id, { status }) => (status === 'reachable'
-    ? { total: 1, limit: 50, offset: 0, members: [{ consumerId: 'u2', firstName: 'Ready', lastName: 'Person', phone: '+6591112222', email: 'ready@x.com', lastSeenAt: new Date().toISOString(), reachable: true, reasons: [] }] }
+    ? { total: 1, limit: 50, offset: 0, members: [{ consumerId: 'u2', firstName: 'Ready', lastName: 'Person', phone: '+6591112222', email: 'ready@x.com', lastSeenAt: new Date().toISOString(), reachable: true, reasons: [], latestProspectId: 'p42' }] }
     : { total: 2, limit: 50, offset: 0, members: [
-        { consumerId: 'u1', firstName: 'Blocked', lastName: 'Person', phone: '+6590001111', email: null, lastSeenAt: new Date().toISOString(), reachable: false, reasons: ['not_consented'] },
-        { consumerId: 'u3', firstName: 'Silent', lastName: 'Minor', phone: '+6590002222', email: null, lastSeenAt: new Date().toISOString(), reachable: false, reasons: ['age_ineligible', 'not_verified'] },
+        { consumerId: 'u1', firstName: 'Blocked', lastName: 'Person', phone: '+6590001111', email: null, lastSeenAt: new Date().toISOString(), reachable: false, reasons: ['not_consented'], latestProspectId: 'p41' },
+        { consumerId: 'u3', firstName: 'Silent', lastName: 'Minor', phone: '+6590002222', email: null, lastSeenAt: new Date().toISOString(), reachable: false, reasons: ['age_ineligible', 'not_verified'], latestProspectId: null },
       ] })),
   archiveCohort: vi.fn(async () => ({ success: true })),
   previewCohortDefinition: vi.fn(async () => ({ total: 212, reachable: 180, excluded: 32, byReason: {}, gate: { channel: 'all', campaignId: null, minAge: 18, maxAge: null } })),
@@ -98,5 +98,18 @@ describe('AdminV2CohortDetail', () => {
     fireEvent.click(screen.getByRole('button', { name: 'reachable' }));
     expect(await screen.findByText('Ready Person')).toBeInTheDocument();
     await waitFor(() => expect(fetchCohortMembers).toHaveBeenLastCalledWith('co1', expect.objectContaining({ status: 'reachable' })));
+  });
+
+  it('member rows with a signup anchor link into the person profile; rows without stay inert', async () => {
+    setup();
+    await screen.findByText('Blocked Person');
+    // Linked member: the Person cell is a real link to the profile's PERSON
+    // view, carrying state.from back to this cohort page (table roles intact).
+    const link = screen.getByRole('link', { name: 'Blocked Person' });
+    expect(link).toHaveAttribute('href', '/admin/leads/p41?view=profile');
+    expect(screen.getAllByRole('row').length).toBeGreaterThan(1); // roles preserved
+    // Unlinked member: plain text, no link.
+    expect(screen.getByText('Silent Minor')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Silent Minor' })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
PR 2 of 2 from `docs/plans/admin-people-directory.md` (§3.6/§4.2) — the fast-follow #278 unlocked.

- `listCohortMembers({ includeProspect })`: one `DISTINCT ON ("consumerId")` batch per page resolves each member's **newest** linked prospect; the admin members endpoint opts in, the **broadcast send fan-out stays untouched** — proven by a query-spy test (no prospect-batch SQL on the flag-off path) and a byte-identical flag-off shape test.
- Full member-shape contract pin added at both service and route level (the member payload was previously unpinned).
- `AdminV2CohortDetail`: the Person cell links to `/admin/leads/:latestProspectId?view=profile` with `state.from` returning to the cohort page (the profile's origin validator learned `/admin/cohorts/:id` in #278); table `row`/`cell` roles preserved (Link-in-cell, not row-as-button); unlinked members stay plain text.

Evidence: backend `cohortService` + `cohortRoutes` + `emailBroadcastService` suites 79/79 · `vitest run src/pages/adminv2` 63/63 · `vite build` green. Merge gate per #278: unit step green + integration completes with the known inherited 5-suite set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8jF5ZxuAZD3NazPQQMEfV