### PR TITLE
Remediate the 5 inherited integration suites — backend CI fully green

### DIFF
--- a/backend/test/analytics.test.js
+++ b/backend/test/analytics.test.js
@@ -114,33 +114,41 @@ describe('POST /api/analytics/referrals', () => {
     expect(res.body.success).toBe(true)
   })
 
-  it('returns 400 when campaignId is missing', async () => {
+  // e1fd8d7 made this endpoint deliberately LENIENT: the "Referred by" badge
+  // must work for a fresh referee with no session cookie, and a public beacon
+  // never leaks validation shape — bad/missing input degrades to a 200 with a
+  // null referrerName instead of 400/404.
+  it('degrades to 200 with a null name when campaignId is missing', async () => {
     const res = await request(app)
       .post('/api/analytics/referrals')
       .set('Origin', 'http://localhost:5173')
       .set('x-session-id', 'test-sid-ref-nocamp')
       .send({})
 
-    expect(res.status).toBe(400)
+    expect(res.status).toBe(200)
+    expect(res.body.success).toBe(true)
+    expect(res.body.data.referrerName ?? null).toBeNull()
   })
 
-  it('returns 404 for non-existent campaignId', async () => {
+  it('degrades to 200 with a null name for a non-existent campaignId', async () => {
     const res = await request(app)
       .post('/api/analytics/referrals')
       .set('Origin', 'http://localhost:5173')
       .set('x-session-id', 'test-sid-ref-bad')
       .send({ campaignId: '00000000-0000-0000-0000-000000000000' })
 
-    expect(res.status).toBe(404)
+    expect(res.status).toBe(200)
+    expect(res.body.data.referrerName ?? null).toBeNull()
   })
 
-  it('returns 400 when session id is missing', async () => {
+  it('works without a session — the fresh-referee case the badge exists for', async () => {
     const res = await request(app)
       .post('/api/analytics/referrals')
       .set('Origin', 'http://localhost:5173')
       .send({ campaignId: campaign.id })
 
-    expect(res.status).toBe(400)
+    expect(res.status).toBe(200)
+    expect(res.body.success).toBe(true)
   })
 
   it('returns 403 for disallowed origin', async () => {

--- a/backend/test/externalHeldLeadsController.test.js
+++ b/backend/test/externalHeldLeadsController.test.js
@@ -134,7 +134,9 @@ describe('externalHeldLeadsController.assignHeldLead', () => {
     const res = makeRes();
     await assignHeldLead(req, res);
 
-    expect(releaseMock).toHaveBeenCalledWith('p1', 'app-agent-1', { idempotencyKey: 'k1', actorUserId: null });
+    // batch: null = no bulk context on a single release (6ccae00 echoes an
+    // optional batch object into the delivery webhook; malformed/absent → null).
+    expect(releaseMock).toHaveBeenCalledWith('p1', 'app-agent-1', { idempotencyKey: 'k1', actorUserId: null, batch: null });
     expect(res.statusCode).toBe(200);
     expect(res.body).toMatchObject({ success: true, status: 'assigned', leadId: 'p1' });
   });

--- a/backend/test/integration/pipelineE2E.test.js
+++ b/backend/test/integration/pipelineE2E.test.js
@@ -134,11 +134,13 @@ afterAll(async () => {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
+// SDK-style signing (bc76365): the verifier computes hmac(body + timestamp),
+// concatenated — never the old `${ts}.${body}` shape these suites carried.
 function signRetellPayload(body, secret) {
   const timestamp = Math.floor(Date.now() / 1000).toString();
   const bodyStr = typeof body === 'string' ? body : JSON.stringify(body);
   const hmac = crypto.createHmac('sha256', secret)
-    .update(`${timestamp}.${bodyStr}`)
+    .update(`${bodyStr}${timestamp}`)
     .digest('hex');
   return `v=${timestamp},d=${hmac}`;
 }

--- a/backend/test/integration/retellWebhook.test.js
+++ b/backend/test/integration/retellWebhook.test.js
@@ -45,10 +45,12 @@ afterAll(async () => {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
+// SDK-style signing (bc76365): the verifier computes hmac(body + timestamp),
+// concatenated — never the old `${ts}.${body}` shape these suites carried.
 function signRetellPayload(body, secret) {
   const timestamp = Math.floor(Date.now() / 1000).toString();
   const bodyStr = typeof body === 'string' ? body : JSON.stringify(body);
-  const hmac = crypto.createHmac('sha256', secret).update(`${timestamp}.${bodyStr}`).digest('hex');
+  const hmac = crypto.createHmac('sha256', secret).update(`${bodyStr}${timestamp}`).digest('hex');
   return `v=${timestamp},d=${hmac}`;
 }
 

--- a/backend/test/retell.test.js
+++ b/backend/test/retell.test.js
@@ -16,10 +16,12 @@ afterAll(async () => {
   await closeDb()
 })
 
+// SDK-style signing (bc76365): the verifier computes hmac(body + timestamp),
+// concatenated — never the old `${ts}.${body}` shape these suites carried.
 function signRetellPayload(body, secret) {
   const timestamp = Math.floor(Date.now() / 1000).toString()
   const bodyStr = typeof body === 'string' ? body : JSON.stringify(body)
-  const hmac = crypto.createHmac('sha256', secret).update(`${timestamp}.${bodyStr}`).digest('hex')
+  const hmac = crypto.createHmac('sha256', secret).update(`${bodyStr}${timestamp}`).digest('hex')
   return `v=${timestamp},d=${hmac}`
 }
 


### PR DESCRIPTION
The follow-up #278 exposed: 28 pre-existing test failures across 5 suites that accumulated while the red unit step kept CI's integration step skipped. Every one is a stale test lagging a deliberate source change — **zero source files touched**:

| Group | Tests | Root cause | Fix |
|---|---|---|---|
| retell / retellWebhook / pipelineE2E | 24 | Signing helpers still used the retired `hmac(ts.body)`; verifier is SDK-style `hmac(body+ts)` since `bc76365` | Helpers sign the way the backend verifies |
| externalHeldLeadsController | 1 | `6ccae00` added the bulk `batch` option (absent → `null`) | Assertion gains `batch: null` |
| analytics referrals | 3 | `e1fd8d7` made the beacon deliberately lenient (badge works session-less; no 400/404 leakage) | Tests assert the lenient contract |

**Local evidence:** the five suites 54/54 · full CI integration pattern **125/125 suites, 2519 tests** · migrations step **30/30** · unit step already green since #278. All four backend CI steps (unit → integration → migrations → coverage) should pass on this PR — the first fully green backend job in weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8jF5ZxuAZD3NazPQQMEfV