### PR TITLE
feat(enrichment): PR 1 — consumer observation ledger, mapper outbox, erasure cascade (dark)

### DIFF
--- a/backend/src/database/migrations/091-consumer-enrichment.js
+++ b/backend/src/database/migrations/091-consumer-enrichment.js
@@ -1,0 +1,277 @@
+/**
+ * 091 — Consumer profile enrichment: observation ledger + profiles + job
+ * queue + scoring configs + sweep fence (docs/plans/consumer-profile-enrichment.md §3).
+ *
+ * Five tables + prospects.enrichmentRevision. ALL statements run inside ONE
+ * migration-owned transaction (plan §11 / Codex R3 #12 — the runner executes
+ * migrations on pool connections and is NOT atomic on its own), and every
+ * object is additionally guarded so a re-run after partial failure or a
+ * sync({force:true})-built test schema is safe (the 084 pattern).
+ *
+ * Ships DARK: nothing reads these tables until the mapper (this PR, flag-off
+ * writers) and the enrichment routes (PR 2, ENRICHMENT_ENABLED) land.
+ * Retention: owner decision 2026-07-26 — customer data kept forever; erasure
+ * remains the sole deletion path (erasureService cascade, this PR).
+ */
+export async function up(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.transaction(async (t) => {
+    const q = (sql) => sequelize.query(sql, { transaction: t });
+
+    // ── consumer_observations — append-only, revisioned fact ledger (§3.1) ──
+    await q(`CREATE TABLE IF NOT EXISTS consumer_observations (
+      id UUID PRIMARY KEY,
+      "sourceProspectId" UUID,
+      "consumerId" UUID,
+      key VARCHAR(64) NOT NULL,
+      value JSONB NOT NULL,
+      confidence REAL NOT NULL,
+      source VARCHAR(24) NOT NULL,
+      "sourceArtifactId" VARCHAR(80),
+      "sourceRevisionId" BIGINT,
+      "sourceContentHash" VARCHAR(64),
+      "sourceEventAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+      pipeline VARCHAR(24) NOT NULL,
+      "pipelineVersion" VARCHAR(48) NOT NULL,
+      evidence TEXT,
+      "supersededAt" TIMESTAMP WITH TIME ZONE,
+      "retractedAt" TIMESTAMP WITH TIME ZONE,
+      "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+      "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+    )`);
+
+    // Guarded FKs (sync-built test schemas already carry them from the model).
+    await q(`DO $$ BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_cobs_prospect') THEN
+        ALTER TABLE consumer_observations ADD CONSTRAINT fk_cobs_prospect
+          FOREIGN KEY ("sourceProspectId") REFERENCES prospects(id) ON DELETE CASCADE;
+      END IF;
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_cobs_consumer') THEN
+        ALTER TABLE consumer_observations ADD CONSTRAINT fk_cobs_consumer
+          FOREIGN KEY ("consumerId") REFERENCES consumers(id) ON DELETE CASCADE;
+      END IF;
+    END $$`);
+
+    // Source-aware anchor CHECK (plan §3.1, R2 #7 / R3 #6): manual rows are
+    // consumer-anchored; every other source is prospect-anchored WITH full
+    // artifact identity (nullable identity columns cannot guard uniqueness).
+    await q(`DO $$ BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_cobs_anchor') THEN
+        ALTER TABLE consumer_observations ADD CONSTRAINT chk_cobs_anchor CHECK (
+          (source = 'manual' AND "consumerId" IS NOT NULL AND "sourceProspectId" IS NULL)
+          OR
+          (source <> 'manual' AND "consumerId" IS NULL AND "sourceProspectId" IS NOT NULL
+            AND "sourceArtifactId" IS NOT NULL AND "sourceRevisionId" IS NOT NULL
+            AND "sourceContentHash" IS NOT NULL)
+        );
+      END IF;
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_cobs_source') THEN
+        ALTER TABLE consumer_observations ADD CONSTRAINT chk_cobs_source CHECK (
+          source IN ('form','quiz','retell_analysis','screening_transcript','manual')
+        );
+      END IF;
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_cobs_confidence') THEN
+        ALTER TABLE consumer_observations ADD CONSTRAINT chk_cobs_confidence CHECK (
+          confidence >= 0 AND confidence <= 1
+        );
+      END IF;
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_cobs_evidence_len') THEN
+        ALTER TABLE consumer_observations ADD CONSTRAINT chk_cobs_evidence_len CHECK (
+          evidence IS NULL OR char_length(evidence) <= 300
+        );
+      END IF;
+    END $$`);
+
+    // Idempotency identity (R3 #3: revision, not content hash, is identity).
+    await q(`CREATE UNIQUE INDEX IF NOT EXISTS uq_cobs_artifact_revision_key
+      ON consumer_observations ("sourceArtifactId", "sourceRevisionId", pipeline, "pipelineVersion", key)
+      WHERE "sourceArtifactId" IS NOT NULL`);
+    await q(`CREATE INDEX IF NOT EXISTS idx_cobs_prospect_key
+      ON consumer_observations ("sourceProspectId", key) WHERE "sourceProspectId" IS NOT NULL`);
+    await q(`CREATE INDEX IF NOT EXISTS idx_cobs_consumer_key
+      ON consumer_observations ("consumerId", key) WHERE "consumerId" IS NOT NULL`);
+    await q(`CREATE INDEX IF NOT EXISTS idx_cobs_artifact
+      ON consumer_observations ("sourceArtifactId") WHERE "sourceArtifactId" IS NOT NULL`);
+
+    // ── consumer_profiles — one row per person (§3.2) ──
+    await q(`CREATE TABLE IF NOT EXISTS consumer_profiles (
+      "consumerId" UUID PRIMARY KEY,
+      summary TEXT,
+      "profileJson" JSONB,
+      "consumerScore" SMALLINT,
+      "scoreBreakdown" JSONB,
+      "scoredConfigVersion" INTEGER,
+      "scoringAlgorithmVersion" VARCHAR(16),
+      "scoreInputHash" VARCHAR(64),
+      "inputVersion" BIGINT NOT NULL DEFAULT 0,
+      "syncedInputVersion" BIGINT NOT NULL DEFAULT 0,
+      "profileInputHash" VARCHAR(64),
+      "modelVersion" VARCHAR(48),
+      "summaryGeneratedAt" TIMESTAMP WITH TIME ZONE,
+      "scoreComputedAt" TIMESTAMP WITH TIME ZONE,
+      "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+      "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+    )`);
+
+    await q(`DO $$ BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_cprof_consumer') THEN
+        ALTER TABLE consumer_profiles ADD CONSTRAINT fk_cprof_consumer
+          FOREIGN KEY ("consumerId") REFERENCES consumers(id) ON DELETE CASCADE;
+      END IF;
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_cprof_score') THEN
+        ALTER TABLE consumer_profiles ADD CONSTRAINT chk_cprof_score CHECK (
+          "consumerScore" IS NULL OR ("consumerScore" >= 0 AND "consumerScore" <= 100)
+        );
+      END IF;
+    END $$`);
+
+    // Dirty discovery: inputVersion > syncedInputVersion (§6.3).
+    await q(`CREATE INDEX IF NOT EXISTS idx_cprof_dirty
+      ON consumer_profiles ("consumerId") WHERE "inputVersion" > "syncedInputVersion"`);
+
+    // ── enrichment_jobs — durable queue (§3.3) ──
+    await q(`CREATE TABLE IF NOT EXISTS enrichment_jobs (
+      id UUID PRIMARY KEY,
+      kind VARCHAR(12) NOT NULL,
+      "subjectProspectId" UUID,
+      "subjectConsumerId" UUID,
+      "sourceArtifactId" VARCHAR(80),
+      "sourceRevisionId" BIGINT,
+      "sourceContentHash" VARCHAR(64),
+      "inputHash" VARCHAR(64),
+      "promptVersion" VARCHAR(32),
+      payload JSONB,
+      "taxonomyVersion" VARCHAR(16),
+      "pipelineVersion" VARCHAR(48) NOT NULL,
+      status VARCHAR(12) NOT NULL DEFAULT 'pending',
+      "leaseToken" UUID,
+      "leaseExpiresAt" TIMESTAMP WITH TIME ZONE,
+      "workerId" VARCHAR(80),
+      attempts SMALLINT NOT NULL DEFAULT 0,
+      "lastError" TEXT,
+      "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+      "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+    )`);
+
+    await q(`DO $$ BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_ejobs_prospect') THEN
+        ALTER TABLE enrichment_jobs ADD CONSTRAINT fk_ejobs_prospect
+          FOREIGN KEY ("subjectProspectId") REFERENCES prospects(id) ON DELETE CASCADE;
+      END IF;
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_ejobs_consumer') THEN
+        ALTER TABLE enrichment_jobs ADD CONSTRAINT fk_ejobs_consumer
+          FOREIGN KEY ("subjectConsumerId") REFERENCES consumers(id) ON DELETE CASCADE;
+      END IF;
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_ejobs_status') THEN
+        ALTER TABLE enrichment_jobs ADD CONSTRAINT chk_ejobs_status CHECK (
+          status IN ('pending','leased','done','stale','dead','cancelled')
+        );
+      END IF;
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_ejobs_kind') THEN
+        ALTER TABLE enrichment_jobs ADD CONSTRAINT chk_ejobs_kind CHECK (
+          (kind = 'map' AND "subjectProspectId" IS NOT NULL AND "subjectConsumerId" IS NULL
+            AND "sourceRevisionId" IS NOT NULL AND "sourceContentHash" IS NOT NULL
+            AND "sourceArtifactId" IS NULL AND "inputHash" IS NULL AND "promptVersion" IS NULL)
+          OR
+          (kind = 'extract' AND "subjectProspectId" IS NOT NULL AND "subjectConsumerId" IS NULL
+            AND "sourceArtifactId" IS NOT NULL AND "sourceRevisionId" IS NOT NULL
+            AND "sourceContentHash" IS NOT NULL AND "inputHash" IS NULL
+            AND "promptVersion" IS NULL AND payload IS NULL)
+          OR
+          (kind = 'synthesize' AND "subjectConsumerId" IS NOT NULL AND "subjectProspectId" IS NULL
+            AND "inputHash" IS NOT NULL AND "promptVersion" IS NOT NULL
+            AND "sourceArtifactId" IS NULL AND "sourceRevisionId" IS NULL
+            AND "sourceContentHash" IS NULL AND payload IS NULL)
+        );
+      END IF;
+    END $$`);
+
+    // Durable queue identities (R2 #5 / R4 #1): map+extract dedupe across
+    // pending/leased/done; synthesize across ACTIVE only — a done synth job
+    // must never block re-enqueueing a hash that recurs (A→B→A convergence).
+    await q(`CREATE UNIQUE INDEX IF NOT EXISTS uq_ejobs_map
+      ON enrichment_jobs (kind, "subjectProspectId", "sourceRevisionId", "pipelineVersion")
+      WHERE kind = 'map' AND status IN ('pending','leased','done')`);
+    await q(`CREATE UNIQUE INDEX IF NOT EXISTS uq_ejobs_extract
+      ON enrichment_jobs (kind, "subjectProspectId", "sourceArtifactId", "sourceRevisionId", "pipelineVersion")
+      WHERE kind = 'extract' AND status IN ('pending','leased','done')`);
+    await q(`CREATE UNIQUE INDEX IF NOT EXISTS uq_ejobs_synthesize
+      ON enrichment_jobs (kind, "subjectConsumerId", "inputHash", "promptVersion")
+      WHERE kind = 'synthesize' AND status IN ('pending','leased')`);
+
+    await q(`CREATE INDEX IF NOT EXISTS idx_ejobs_pending
+      ON enrichment_jobs (kind, "createdAt") WHERE status = 'pending'`);
+    await q(`CREATE INDEX IF NOT EXISTS idx_ejobs_lease_expiry
+      ON enrichment_jobs ("leaseExpiresAt") WHERE status = 'leased'`);
+    await q(`CREATE INDEX IF NOT EXISTS idx_ejobs_subject_consumer
+      ON enrichment_jobs ("subjectConsumerId") WHERE "subjectConsumerId" IS NOT NULL`);
+    await q(`CREATE INDEX IF NOT EXISTS idx_ejobs_subject_prospect
+      ON enrichment_jobs ("subjectProspectId") WHERE "subjectProspectId" IS NOT NULL`);
+
+    // ── enrichment_scoring_configs — immutable versioned rows (§7.2) ──
+    await q(`CREATE TABLE IF NOT EXISTS enrichment_scoring_configs (
+      version INTEGER PRIMARY KEY,
+      "configJson" JSONB NOT NULL,
+      "activatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+      "actorUserId" UUID,
+      "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+      "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+    )`);
+    await q(`DO $$ BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_escfg_actor') THEN
+        ALTER TABLE enrichment_scoring_configs ADD CONSTRAINT fk_escfg_actor
+          FOREIGN KEY ("actorUserId") REFERENCES users(id) ON DELETE SET NULL;
+      END IF;
+    END $$`);
+
+    // ── enrichment_sweep_runs — nightly fence + repair cursor (§7.3, R4-era R3 #9) ──
+    await q(`CREATE TABLE IF NOT EXISTS enrichment_sweep_runs (
+      id UUID PRIMARY KEY,
+      "runDateSgt" VARCHAR(10) NOT NULL,
+      "runType" VARCHAR(12) NOT NULL DEFAULT 'nightly',
+      status VARCHAR(10) NOT NULL,
+      "ownerToken" UUID NOT NULL,
+      "heartbeatAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+      "finishedAt" TIMESTAMP WITH TIME ZONE,
+      stats JSONB,
+      cursor JSONB,
+      "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+      "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+    )`);
+    await q(`DO $$ BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_esruns_status') THEN
+        ALTER TABLE enrichment_sweep_runs ADD CONSTRAINT chk_esruns_status CHECK (
+          status IN ('running','done','failed')
+        );
+      END IF;
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_esruns_type') THEN
+        ALTER TABLE enrichment_sweep_runs ADD CONSTRAINT chk_esruns_type CHECK (
+          "runType" IN ('nightly','backfill')
+        );
+      END IF;
+    END $$`);
+    // One nightly fence per SGT date (done ends the date; failed may retry);
+    // backfill runs are unfenced by date.
+    await q(`CREATE UNIQUE INDEX IF NOT EXISTS uq_esruns_nightly_date
+      ON enrichment_sweep_runs ("runDateSgt")
+      WHERE "runType" = 'nightly' AND status IN ('running','done')`);
+
+    // ── prospects.enrichmentRevision — per-form-artifact revision counter (§3.1/§5) ──
+    await q(`ALTER TABLE prospects
+      ADD COLUMN IF NOT EXISTS "enrichmentRevision" INTEGER NOT NULL DEFAULT 1`);
+  });
+}
+
+export async function down(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+  await sequelize.transaction(async (t) => {
+    const q = (sql) => sequelize.query(sql, { transaction: t });
+    await q('DROP TABLE IF EXISTS enrichment_sweep_runs');
+    await q('DROP TABLE IF EXISTS enrichment_scoring_configs');
+    await q('DROP TABLE IF EXISTS enrichment_jobs');
+    await q('DROP TABLE IF EXISTS consumer_profiles');
+    await q('DROP TABLE IF EXISTS consumer_observations');
+    await q('ALTER TABLE prospects DROP COLUMN IF EXISTS "enrichmentRevision"');
+  });
+}

--- a/backend/src/models/ConsumerObservation.js
+++ b/backend/src/models/ConsumerObservation.js
@@ -1,0 +1,106 @@
+import { DataTypes, Op } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Append-only, revisioned fact ledger — one row = one observation of one
+ * person-attribute from one source-artifact revision
+ * (docs/plans/consumer-profile-enrichment.md §3.1).
+ *
+ * Anchoring (Codex R1 #2): source-derived rows anchor to the PROSPECT and
+ * resolve their owner through the live prospects.consumerId link at read
+ * time — the spine reconciler relinks prospects without ceremony, and
+ * prospect-anchored rows follow for free. Only `manual` rows anchor to the
+ * consumer directly (they survive relinks, die on that consumer's erasure).
+ *
+ * NEVER UPDATE rows: corrections supersede (revision activation sets
+ * `supersededAt`) or retract (`retractedAt`). Supersession is permanent —
+ * retracting a superseding row revives nothing (§3.4). Identity for
+ * idempotent inserts is (artifact, revision, pipeline, pipelineVersion, key)
+ * — revision, not content hash: A→B→A staff edits mint revision 3 and must
+ * never collide with revision 1's superseded rows (R3 #3).
+ */
+const ConsumerObservation = sequelize.define('ConsumerObservation', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  sourceProspectId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    comment: 'Anchor for source-derived rows; owner = live prospects.consumerId at read'
+  },
+  consumerId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    comment: 'Anchor for manual person-level facts ONLY (chk_cobs_anchor)'
+  },
+  key: {
+    type: DataTypes.STRING(64),
+    allowNull: false,
+    comment: 'Allowlisted taxonomy key (factTaxonomy.js) — never free-form'
+  },
+  value: {
+    type: DataTypes.JSONB,
+    allowNull: false,
+    comment: 'Per-key schema; supports negatives ({v:false}) and {complete} collections'
+  },
+  confidence: {
+    type: DataTypes.REAL,
+    allowNull: false,
+    validate: { min: 0, max: 1 }
+  },
+  source: {
+    type: DataTypes.STRING(24),
+    allowNull: false,
+    validate: { isIn: [['form', 'quiz', 'retell_analysis', 'screening_transcript', 'manual']] },
+    comment: 'Doubles as the explicitness rank in resolveCurrentFacts (§3.4)'
+  },
+  sourceArtifactId: {
+    type: DataTypes.STRING(80),
+    allowNull: true,
+    comment: 'e.g. form:<prospectId>, quiz:<prospectId>, screening:<callId>'
+  },
+  sourceRevisionId: {
+    type: DataTypes.BIGINT,
+    allowNull: true,
+    comment: 'Monotonic per-artifact revision minted by the SOURCE mutation txn (R3 #3)'
+  },
+  sourceContentHash: {
+    type: DataTypes.STRING(64),
+    allowNull: true,
+    comment: 'sha256 of the exact artifact content — integrity/audit, NOT identity'
+  },
+  sourceEventAt: {
+    type: DataTypes.DATE,
+    allowNull: false,
+    comment: 'Artifact time (call end / capture) clamped to now()+24h skew — never extraction time'
+  },
+  pipeline: { type: DataTypes.STRING(24), allowNull: false },
+  pipelineVersion: {
+    type: DataTypes.STRING(48),
+    allowNull: false,
+    comment: 'COMPOSITE semantic version of the pipeline (code+prompt+taxonomy) — R3 #6'
+  },
+  evidence: {
+    type: DataTypes.TEXT,
+    allowNull: true,
+    validate: { len: [0, 300] },
+    comment: 'Server-verified substring of normalized source text; kept for the row lifetime'
+  },
+  supersededAt: { type: DataTypes.DATE, allowNull: true },
+  retractedAt: { type: DataTypes.DATE, allowNull: true, comment: 'Admin "that\'s wrong" (§9)' }
+}, {
+  tableName: 'consumer_observations',
+  indexes: [
+    // Mirrored on the model — test boot builds schema via sync({force:true})
+    // BEFORE migrations (the Consumer.js / RewardEntitlement.js pattern).
+    {
+      unique: true,
+      fields: ['sourceArtifactId', 'sourceRevisionId', 'pipeline', 'pipelineVersion', 'key'],
+      name: 'uq_cobs_artifact_revision_key',
+      where: { sourceArtifactId: { [Op.ne]: null } }
+    },
+    { fields: ['sourceProspectId', 'key'], name: 'idx_cobs_prospect_key', where: { sourceProspectId: { [Op.ne]: null } } },
+    { fields: ['consumerId', 'key'], name: 'idx_cobs_consumer_key', where: { consumerId: { [Op.ne]: null } } },
+    { fields: ['sourceArtifactId'], name: 'idx_cobs_artifact', where: { sourceArtifactId: { [Op.ne]: null } } },
+  ]
+});
+
+export default ConsumerObservation;

--- a/backend/src/models/ConsumerProfile.js
+++ b/backend/src/models/ConsumerProfile.js
@@ -1,0 +1,64 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * One row per person: the AI persona summary + the deterministic
+ * consumerScore (docs/plans/consumer-profile-enrichment.md §3.2).
+ *
+ * Naming: `consumerScore`, never bare `score` — that word is owned by the
+ * per-prospect lead field (Prospect.js:75) and the two must not blur.
+ *
+ * Discovery protocol (Codex R2 #2 / R4-era): `inputVersion` is a monotonic
+ * counter bumped transactionally (UPSERT — first-time consumers must not
+ * lose bumps) by every writer that feeds the synthesis DTO or the score:
+ * observation revision activation, retraction, manual facts, consent
+ * events, WA delivery, draw entries, screening verdicts, prospect
+ * lifecycle mutations, and spine relinks (BOTH consumers). Dirty ⇔
+ * inputVersion > syncedInputVersion. `profileInputHash` is set from the
+ * completed job's inputHash — never compared against a NEW hash (R4 #1).
+ *
+ * `scoredConfigVersion` is stamped on every scoring pass EVEN WHEN
+ * consumerScore stays NULL, so unscoreable profiles exit the re-score loop
+ * (R3 #11). Erasure DELETES this row entirely (§9) — no scrubbed husk.
+ */
+const ConsumerProfile = sequelize.define('ConsumerProfile', {
+  consumerId: { type: DataTypes.UUID, primaryKey: true },
+  summary: {
+    type: DataTypes.TEXT,
+    allowNull: true,
+    validate: { len: [0, 1200] },
+    comment: 'Plain text, generated ONLY from validated claims (§6.4); never rendered as HTML'
+  },
+  profileJson: {
+    type: DataTypes.JSONB,
+    allowNull: true,
+    comment: 'Structured claims w/ basisObservationIds + server-checked entailment (§6.4)'
+  },
+  consumerScore: {
+    type: DataTypes.SMALLINT,
+    allowNull: true,
+    validate: { min: 0, max: 100 },
+    comment: 'Server-computed only (consumerScoringService); NULL = unscoreable, renders "—"'
+  },
+  scoreBreakdown: {
+    type: DataTypes.JSONB,
+    allowNull: true,
+    comment: 'Per component: {state: unknown|assessed, points, maxPoints, basisObservationIds, note}'
+  },
+  scoredConfigVersion: { type: DataTypes.INTEGER, allowNull: true },
+  scoringAlgorithmVersion: { type: DataTypes.STRING(16), allowNull: true },
+  scoreInputHash: { type: DataTypes.STRING(64), allowNull: true },
+  inputVersion: { type: DataTypes.BIGINT, allowNull: false, defaultValue: 0 },
+  syncedInputVersion: { type: DataTypes.BIGINT, allowNull: false, defaultValue: 0 },
+  profileInputHash: { type: DataTypes.STRING(64), allowNull: true },
+  modelVersion: { type: DataTypes.STRING(48), allowNull: true },
+  summaryGeneratedAt: { type: DataTypes.DATE, allowNull: true },
+  scoreComputedAt: { type: DataTypes.DATE, allowNull: true }
+}, {
+  tableName: 'consumer_profiles'
+  // idx_cprof_dirty (partial, inputVersion > syncedInputVersion) is
+  // migration-only: column-to-column predicates don't express in model
+  // index `where`, and it's a perf index — behavior doesn't depend on it.
+});
+
+export default ConsumerProfile;

--- a/backend/src/models/EnrichmentJob.js
+++ b/backend/src/models/EnrichmentJob.js
@@ -1,0 +1,95 @@
+import { DataTypes, Op } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Durable enrichment work queue (docs/plans/consumer-profile-enrichment.md §3.3).
+ *
+ * One job per (kind, subject, source revision, pipeline version) — versions
+ * are stamped at ENQUEUE (R2 #5), so reconciliation can see which pipeline a
+ * pending job serves and deploy-era claimers can't reinterpret work.
+ *
+ * kind-shape contract (chk_ejobs_kind in migration 091):
+ *   map        — subjectProspectId + sourceRevisionId + sourceContentHash;
+ *                payload = the MINIMIZED capture snapshot (taxonomy-relevant
+ *                normalized fields only, ≤ 8 KB serialized, never contact
+ *                data) frozen at enqueue — the mapper never reads mutable
+ *                live rows (R3 #4/#10-era).
+ *   extract    — subjectProspectId + sourceArtifactId + sourceRevisionId +
+ *                sourceContentHash; NO payload — text is fetched at claim by
+ *                artifact + hash.
+ *   synthesize — subjectConsumerId + inputHash + promptVersion; NO payload —
+ *                the DTO is REBUILT at claim under the fence and handed out
+ *                only when its hash equals inputHash (R4 #1).
+ *
+ * Dedupe lifecycle (R4-era finding 1): map/extract uniques span
+ * pending/leased/done; the synthesize unique spans pending/leased ONLY — a
+ * done synth job must never block re-enqueueing a recurring input hash
+ * (A→B→A convergence). Completion replay is validated by job id + lease
+ * token (done rows keep their leaseToken until the 30-day queue prune).
+ *
+ * Erasure nulls payload + lastError across EVERY status for both subject
+ * addressings — done/dead rows outlive the person otherwise (R3 #4, R4 #4).
+ */
+const EnrichmentJob = sequelize.define('EnrichmentJob', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  kind: {
+    type: DataTypes.STRING(12),
+    allowNull: false,
+    validate: { isIn: [['map', 'extract', 'synthesize']] }
+  },
+  subjectProspectId: { type: DataTypes.UUID, allowNull: true },
+  subjectConsumerId: { type: DataTypes.UUID, allowNull: true },
+  sourceArtifactId: { type: DataTypes.STRING(80), allowNull: true },
+  sourceRevisionId: { type: DataTypes.BIGINT, allowNull: true },
+  sourceContentHash: { type: DataTypes.STRING(64), allowNull: true },
+  inputHash: { type: DataTypes.STRING(64), allowNull: true },
+  promptVersion: { type: DataTypes.STRING(32), allowNull: true },
+  payload: { type: DataTypes.JSONB, allowNull: true },
+  taxonomyVersion: { type: DataTypes.STRING(16), allowNull: true },
+  pipelineVersion: { type: DataTypes.STRING(48), allowNull: false },
+  status: {
+    type: DataTypes.STRING(12),
+    allowNull: false,
+    defaultValue: 'pending',
+    validate: { isIn: [['pending', 'leased', 'done', 'stale', 'dead', 'cancelled']] }
+  },
+  leaseToken: { type: DataTypes.UUID, allowNull: true },
+  leaseExpiresAt: { type: DataTypes.DATE, allowNull: true },
+  workerId: { type: DataTypes.STRING(80), allowNull: true },
+  attempts: {
+    type: DataTypes.SMALLINT,
+    allowNull: false,
+    defaultValue: 0,
+    comment: 'Lease expiry AND payload-validation failures both increment; ≥3 → dead (R2 #6)'
+  },
+  lastError: { type: DataTypes.TEXT, allowNull: true }
+}, {
+  tableName: 'enrichment_jobs',
+  indexes: [
+    // Mirrored on the model (sync-before-migrations test boot).
+    {
+      unique: true,
+      fields: ['kind', 'subjectProspectId', 'sourceRevisionId', 'pipelineVersion'],
+      name: 'uq_ejobs_map',
+      where: { kind: 'map', status: { [Op.in]: ['pending', 'leased', 'done'] } }
+    },
+    {
+      unique: true,
+      fields: ['kind', 'subjectProspectId', 'sourceArtifactId', 'sourceRevisionId', 'pipelineVersion'],
+      name: 'uq_ejobs_extract',
+      where: { kind: 'extract', status: { [Op.in]: ['pending', 'leased', 'done'] } }
+    },
+    {
+      unique: true,
+      fields: ['kind', 'subjectConsumerId', 'inputHash', 'promptVersion'],
+      name: 'uq_ejobs_synthesize',
+      where: { kind: 'synthesize', status: { [Op.in]: ['pending', 'leased'] } }
+    },
+    { fields: ['kind', 'createdAt'], name: 'idx_ejobs_pending', where: { status: 'pending' } },
+    { fields: ['leaseExpiresAt'], name: 'idx_ejobs_lease_expiry', where: { status: 'leased' } },
+    { fields: ['subjectConsumerId'], name: 'idx_ejobs_subject_consumer', where: { subjectConsumerId: { [Op.ne]: null } } },
+    { fields: ['subjectProspectId'], name: 'idx_ejobs_subject_prospect', where: { subjectProspectId: { [Op.ne]: null } } },
+  ]
+});
+
+export default EnrichmentJob;

--- a/backend/src/models/EnrichmentScoringConfig.js
+++ b/backend/src/models/EnrichmentScoringConfig.js
@@ -1,0 +1,27 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Immutable, versioned consumer-scoring configuration
+ * (docs/plans/consumer-profile-enrichment.md §7.2) — NOT AiSettings, which
+ * is a fixed-column singleton whose route schema strips unknown keys
+ * (Codex R1 #15).
+ *
+ * Rows are append-only; the highest version wins. configJson carries
+ * component weight overrides + targetSegments, e.g.
+ *   { targetSegments: [{ language: 'zh', ethnicity: 'chinese', weight: 1 }] }
+ * Retargeting to a different market segment is ONE new row here — no deploy.
+ * Any config change recomputes ALL score components on the next sweep, and
+ * scoreBreakdown rows record which version scored them, so historical
+ * breakdowns stay interpretable forever (R3 #11).
+ */
+const EnrichmentScoringConfig = sequelize.define('EnrichmentScoringConfig', {
+  version: { type: DataTypes.INTEGER, primaryKey: true },
+  configJson: { type: DataTypes.JSONB, allowNull: false },
+  activatedAt: { type: DataTypes.DATE, allowNull: false, defaultValue: DataTypes.NOW },
+  actorUserId: { type: DataTypes.UUID, allowNull: true }
+}, {
+  tableName: 'enrichment_scoring_configs'
+});
+
+export default EnrichmentScoringConfig;

--- a/backend/src/models/EnrichmentSweepRun.js
+++ b/backend/src/models/EnrichmentSweepRun.js
@@ -1,0 +1,50 @@
+import { DataTypes, Op } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Nightly sweep fence + durable repair-scan cursor
+ * (docs/plans/consumer-profile-enrichment.md §7.3, Codex R3 #9/#10).
+ *
+ * A FENCE, not a log: the partial unique on (runDateSgt) for
+ * runType='nightly' AND status IN (running, done) means one live nightly
+ * per SGT date — `done` ends the date, `failed` may retry within it.
+ * Takeover of a `running` row is permitted only when heartbeatAt is stale
+ * (> 30 min): the taker swaps in its own ownerToken, and every
+ * stats/finalization update is ownerToken-fenced so a zombie can't clobber
+ * its successor. Repair-scan progress lives in `cursor` with a fixed
+ * row/wall-time budget per night, rotating through the population across
+ * runs. Backfill runs use runType='backfill' (unfenced by date, separately
+ * observable — plan §5).
+ */
+const EnrichmentSweepRun = sequelize.define('EnrichmentSweepRun', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  runDateSgt: { type: DataTypes.STRING(10), allowNull: false, comment: 'YYYY-MM-DD in Asia/Singapore' },
+  runType: {
+    type: DataTypes.STRING(12),
+    allowNull: false,
+    defaultValue: 'nightly',
+    validate: { isIn: [['nightly', 'backfill']] }
+  },
+  status: {
+    type: DataTypes.STRING(10),
+    allowNull: false,
+    validate: { isIn: [['running', 'done', 'failed']] }
+  },
+  ownerToken: { type: DataTypes.UUID, allowNull: false },
+  heartbeatAt: { type: DataTypes.DATE, allowNull: false, defaultValue: DataTypes.NOW },
+  finishedAt: { type: DataTypes.DATE, allowNull: true },
+  stats: { type: DataTypes.JSONB, allowNull: true },
+  cursor: { type: DataTypes.JSONB, allowNull: true }
+}, {
+  tableName: 'enrichment_sweep_runs',
+  indexes: [
+    {
+      unique: true,
+      fields: ['runDateSgt'],
+      name: 'uq_esruns_nightly_date',
+      where: { runType: 'nightly', status: { [Op.in]: ['running', 'done'] } }
+    },
+  ]
+});
+
+export default EnrichmentSweepRun;

--- a/backend/src/models/Prospect.js
+++ b/backend/src/models/Prospect.js
@@ -314,6 +314,12 @@ const Prospect = sequelize.define('Prospect', {
     type: DataTypes.JSONB,
     allowNull: true,
     comment: 'Evidence only (state lives in the discrete columns): { intendedAgentId, alreadyCharged, chargeRefunded, attempts: {<token>: {…}}, verdictDetail }. Excluded from list projections (transcripts are detail-only).'
+  },
+  enrichmentRevision: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    defaultValue: 1,
+    comment: 'Monotonic revision of this prospect\'s FORM artifact (capture=1; each staff edit to mapped fields increments + enqueues a new map job). Revision identity for consumer_observations — plan §3.1/§5.'
   }
 }, {
   tableName: 'prospects',

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -97,6 +97,25 @@ function defineAssociations() {
   Consumer.hasMany(ConsumerSuppression, { foreignKey: 'consumerId', as: 'suppressions', onDelete: 'RESTRICT' });
   ConsumerSuppression.belongsTo(Consumer, { foreignKey: 'consumerId', as: 'consumer', onDelete: 'RESTRICT' });
 
+  // Consumer profile enrichment (migration 091,
+  // docs/plans/consumer-profile-enrichment.md). Source-derived observations
+  // anchor to the PROSPECT (owner resolved through the live consumerId link —
+  // relinks are free); only manual observations anchor to the consumer.
+  // CASCADEs here are the test-world safety net — prod erasure deletes
+  // observations/profile rows explicitly (consumers are never hard-deleted).
+  const {
+    ConsumerObservation, ConsumerProfile, EnrichmentJob, EnrichmentScoringConfig
+  } = models;
+  Prospect.hasMany(ConsumerObservation, { foreignKey: 'sourceProspectId', as: 'observations', onDelete: 'CASCADE' });
+  ConsumerObservation.belongsTo(Prospect, { foreignKey: 'sourceProspectId', as: 'sourceProspect', onDelete: 'CASCADE' });
+  Consumer.hasMany(ConsumerObservation, { foreignKey: 'consumerId', as: 'manualObservations', onDelete: 'CASCADE' });
+  ConsumerObservation.belongsTo(Consumer, { foreignKey: 'consumerId', as: 'consumer', onDelete: 'CASCADE' });
+  Consumer.hasOne(ConsumerProfile, { foreignKey: 'consumerId', as: 'profile', onDelete: 'CASCADE' });
+  ConsumerProfile.belongsTo(Consumer, { foreignKey: 'consumerId', as: 'consumer', onDelete: 'CASCADE' });
+  EnrichmentJob.belongsTo(Prospect, { foreignKey: 'subjectProspectId', as: 'subjectProspect', onDelete: 'CASCADE' });
+  EnrichmentJob.belongsTo(Consumer, { foreignKey: 'subjectConsumerId', as: 'subjectConsumer', onDelete: 'CASCADE' });
+  EnrichmentScoringConfig.belongsTo(User, { foreignKey: 'actorUserId', as: 'actor', onDelete: 'SET NULL' });
+
   // Saved cohorts (tracker "cohortapi") — definitions only, resolved live.
   const { Cohort } = models;
   Cohort.belongsTo(User, { foreignKey: 'createdBy', as: 'creator', onDelete: 'SET NULL' });
@@ -396,7 +415,8 @@ export const {
   OutreachCadenceTransition, OutreachCadenceEnrollment, OutreachSuppression,
   AiSettings, WalletLedger, Consumer, ConsentEvent, ConsumerSuppression,
   SuppressionPropagation, Cohort, EmailBroadcast, EmailBroadcastRecipient,
-  WaMessageStatus
+  WaMessageStatus, ConsumerObservation, ConsumerProfile, EnrichmentJob,
+  EnrichmentScoringConfig, EnrichmentSweepRun
 } = models;
 
 export { sequelize };

--- a/backend/src/services/consumerService.js
+++ b/backend/src/services/consumerService.js
@@ -5,6 +5,10 @@ import { logger } from '../utils/logger.js';
 import { escapeLike } from '../utils/escapeLike.js';
 import { emailNormKey } from './repeatSignup.js';
 import { normalizePhone } from './prospectHelpers.js';
+// Enrichment input bumps on relink (consumer-profile-enrichment plan §6.3,
+// Codex R4-era #2): a moved prospect changes BOTH people's resolved facts.
+// Leaf import (models only) — no cycle.
+import { bumpManyEnrichmentInputsTx } from './enrichmentFence.js';
 
 /**
  * Consumer spine (docs/plans/consumer-spine-and-consent-ledger.md §2).
@@ -215,14 +219,24 @@ export function makeConsumerService(overrides = {}) {
           continue;
         }
         await upsertProjection(phone, buildProjection(rows), transaction);
-        await d.sequelize.query(
+        // Self-join reads the PRE-update row so RETURNING can surface the old
+        // owner — both sides of a relink go enrichment-dirty (plan §6.3).
+        const [moved] = await d.sequelize.query(
           `UPDATE prospects p SET "consumerId" = c.id
-             FROM consumers c
+             FROM consumers c, prospects oldp
             WHERE c.phone = :phone AND p.phone = :phone
+              AND oldp.id = p.id
               AND p."leadSource" <> 'call_bot'
-              AND p."consumerId" IS DISTINCT FROM c.id`,
+              AND p."consumerId" IS DISTINCT FROM c.id
+          RETURNING oldp."consumerId" AS old_cid, c.id AS new_cid`,
           { replacements: { phone }, transaction }
         );
+        if (moved?.length) {
+          await bumpManyEnrichmentInputsTx(
+            transaction,
+            moved.flatMap((r) => [r.old_cid, r.new_cid])
+          );
+        }
       }
     } catch (err) {
       d.logger.warn('[consumer] recompute failed (reconciler heals)', {
@@ -307,31 +321,50 @@ export function makeConsumerService(overrides = {}) {
         const values = slice.map((_, j) => `(:p${j}::uuid, :c${j}::uuid)`).join(',');
         const repl = {};
         slice.forEach(([pid, cid], j) => { repl[`p${j}`] = pid; repl[`c${j}`] = cid; });
-        const [, meta] = await d.sequelize.query(
+        // Self-join surfaces the pre-update owner: relinks dirty BOTH sides'
+        // enrichment inputs (plan §6.3 — a moved signup changes two people).
+        const [movedRows, meta] = await d.sequelize.query(
           `UPDATE prospects AS p SET "consumerId" = v.cid
-             FROM (VALUES ${values}) AS v(pid, cid)
-            WHERE p.id = v.pid AND p."consumerId" IS DISTINCT FROM v.cid`,
+             FROM (VALUES ${values}) AS v(pid, cid), prospects AS oldp
+            WHERE p.id = v.pid AND oldp.id = p.id
+              AND p."consumerId" IS DISTINCT FROM v.cid
+          RETURNING oldp."consumerId" AS old_cid, v.cid AS new_cid`,
           { replacements: repl, transaction: t }
         );
         stats.prospectsLinked += meta?.rowCount ?? 0;
+        if (movedRows?.length) {
+          await bumpManyEnrichmentInputsTx(t, movedRows.flatMap((r) => [r.old_cid, r.new_cid]));
+        }
       }
 
-      const [, cbMeta] = await d.sequelize.query(
-        `UPDATE prospects SET "consumerId" = NULL
-          WHERE "leadSource" = 'call_bot' AND "consumerId" IS NOT NULL`,
+      const [cbMoved, cbMeta] = await d.sequelize.query(
+        `UPDATE prospects p SET "consumerId" = NULL
+           FROM prospects oldp
+          WHERE oldp.id = p.id
+            AND p."leadSource" = 'call_bot' AND p."consumerId" IS NOT NULL
+        RETURNING oldp."consumerId" AS old_cid`,
         { transaction: t }
       );
       stats.callBotUnlinked = cbMeta?.rowCount ?? 0;
+      if (cbMoved?.length) {
+        await bumpManyEnrichmentInputsTx(t, cbMoved.map((r) => r.old_cid));
+      }
 
       // A phone cleared to null/empty (PUT-to-blank) takes its link with it
       // (Codex R2 #4). Invalid-but-present phones are NOT touched: those are
       // capture-linked raw-format rows (Meta) whose links are healed above.
-      const [, epMeta] = await d.sequelize.query(
-        `UPDATE prospects SET "consumerId" = NULL
-          WHERE "consumerId" IS NOT NULL AND (phone IS NULL OR phone = '')`,
+      const [epMoved, epMeta] = await d.sequelize.query(
+        `UPDATE prospects p SET "consumerId" = NULL
+           FROM prospects oldp
+          WHERE oldp.id = p.id
+            AND p."consumerId" IS NOT NULL AND (p.phone IS NULL OR p.phone = '')
+        RETURNING oldp."consumerId" AS old_cid`,
         { transaction: t }
       );
       stats.emptyPhoneUnlinked = epMeta?.rowCount ?? 0;
+      if (epMoved?.length) {
+        await bumpManyEnrichmentInputsTx(t, epMoved.map((r) => r.old_cid));
+      }
 
       const [, reP] = await d.sequelize.query(
         `UPDATE reward_entitlements re SET "consumerId" = p."consumerId"

--- a/backend/src/services/enrichmentFence.js
+++ b/backend/src/services/enrichmentFence.js
@@ -1,0 +1,139 @@
+import { sequelize, Consumer, Prospect, ConsumerProfile } from '../models/index.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * The enrichment write fence + input-version bump
+ * (docs/plans/consumer-profile-enrichment.md §9, §6.3).
+ *
+ * WHY (Codex R2 #3): observation ownership is resolved through the MUTABLE
+ * prospects.consumerId link, and the spine reconciler relinks prospects
+ * without locking either consumer. A consumer-lock alone therefore fences
+ * nothing: mapper reads owner A → reconciler moves the prospect to B → B is
+ * erased → mapper locks A and inserts, resurrecting enrichment on an erased
+ * person. The fence closes this by re-verifying ownership AFTER locking:
+ *
+ *   read owner → lock that Consumer FOR UPDATE → reject erased →
+ *   lock + reload the Prospect → owner unchanged? → write
+ *
+ * Owner moved ⇒ release (rollback) and retry against the new owner.
+ * Erasure itself locks consumer-first (erasureService.js), so a writer that
+ * holds the consumer lock cannot interleave with an erasure of that person.
+ */
+
+export class ErasedConsumerError extends Error {
+  constructor(consumerId) {
+    super(`consumer ${consumerId} is erased`);
+    this.name = 'ErasedConsumerError';
+    this.code = 'CONSUMER_ERASED';
+  }
+}
+
+/**
+ * Transactionally bump a consumer's enrichment input version — an UPSERT so
+ * first-time consumers can never lose bumps (Codex R4-era #2). Call from
+ * EVERY writer that feeds the synthesis DTO or the score, in the SAME
+ * transaction as the mutation. No-op when consumerId is null (unlinked
+ * prospects surface later via the repair scan).
+ */
+export async function bumpEnrichmentInputTx(t, consumerId) {
+  if (!consumerId) return;
+  // INSERT…SELECT guarded on the live consumer: a bump must never mint a
+  // profile row for an erased (or vanished) person — erasure deletes the
+  // profile and this would quietly resurrect it.
+  await sequelize.query(
+    `INSERT INTO consumer_profiles ("consumerId", "inputVersion", "syncedInputVersion", "createdAt", "updatedAt")
+     SELECT c.id, 1, 0, now(), now()
+       FROM consumers c
+      WHERE c.id = :cid AND c."erasedAt" IS NULL
+     ON CONFLICT ("consumerId")
+     DO UPDATE SET "inputVersion" = consumer_profiles."inputVersion" + 1, "updatedAt" = now()`,
+    { replacements: { cid: consumerId }, transaction: t }
+  );
+}
+
+/** Bump a set of consumer ids (dedup + null-safe) in one transaction. */
+export async function bumpManyEnrichmentInputsTx(t, consumerIds) {
+  const unique = [...new Set((consumerIds || []).filter(Boolean))];
+  for (const cid of unique) {
+    await bumpEnrichmentInputTx(t, cid);
+  }
+}
+
+/**
+ * Run `fn(t, { prospect, consumer })` under the relink-aware fence.
+ *
+ * - `consumer` is null for unlinked prospects (call_bot / cleared phone):
+ *   the write proceeds prospect-anchored with no bump.
+ * - Erased owner ⇒ throws ErasedConsumerError (callers translate to a
+ *   skip/cancel, never a write).
+ * - Owner moved between the unlocked read and the locked reload ⇒ retry
+ *   (fresh transaction) against the new owner, up to `maxRetries`.
+ *
+ * fn runs INSIDE the transaction; do all writes on `t` and call
+ * bumpEnrichmentInputTx(t, consumer?.id) alongside them.
+ */
+export async function withConsumerFence(prospectId, fn, { maxRetries = 3 } = {}) {
+  let lastErr;
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+    try {
+      return await sequelize.transaction(async (t) => {
+        const unlocked = await Prospect.findByPk(prospectId, {
+          attributes: ['id', 'consumerId'],
+          transaction: t,
+        });
+        if (!unlocked) return { skipped: 'prospect_gone' };
+
+        let consumer = null;
+        if (unlocked.consumerId) {
+          consumer = await Consumer.findByPk(unlocked.consumerId, {
+            transaction: t,
+            lock: t.LOCK.UPDATE,
+          });
+          if (!consumer) return { skipped: 'consumer_gone' };
+          if (consumer.erasedAt) throw new ErasedConsumerError(consumer.id);
+        }
+
+        const prospect = await Prospect.findByPk(prospectId, {
+          transaction: t,
+          lock: t.LOCK.UPDATE,
+        });
+        if (!prospect) return { skipped: 'prospect_gone' };
+
+        if ((prospect.consumerId || null) !== (unlocked.consumerId || null)) {
+          // Owner moved under us — retry the whole fence against the new owner.
+          const moved = new Error('fence_owner_moved');
+          moved.code = 'FENCE_OWNER_MOVED';
+          throw moved;
+        }
+
+        return await fn(t, { prospect, consumer });
+      });
+    } catch (err) {
+      if (err?.code === 'FENCE_OWNER_MOVED' && attempt < maxRetries) {
+        lastErr = err;
+        continue;
+      }
+      throw err;
+    }
+  }
+  logger.error('[enrichmentFence] owner kept moving — giving up', { prospectId });
+  throw lastErr;
+}
+
+/**
+ * Manual/consumer-anchored variant: lock the consumer directly (no prospect
+ * leg). Used by manual facts, retraction, and synthesis completion (PR 2).
+ */
+export async function withConsumerLock(consumerId, fn) {
+  return sequelize.transaction(async (t) => {
+    const consumer = await Consumer.findByPk(consumerId, {
+      transaction: t,
+      lock: t.LOCK.UPDATE,
+    });
+    if (!consumer) return { skipped: 'consumer_gone' };
+    if (consumer.erasedAt) throw new ErasedConsumerError(consumer.id);
+    return fn(t, { consumer });
+  });
+}
+
+export { ConsumerProfile };

--- a/backend/src/services/erasureService.js
+++ b/backend/src/services/erasureService.js
@@ -319,6 +319,7 @@ export function makeErasureService(overrides = {}) {
               "dncNoFax" = NULL, "dncCheckedAt" = NULL, "dncValidUntil" = NULL,
               "dncMetadata" = NULL,
               "consentMetadata" = '{"erased":true}'::jsonb,
+              "screeningMetadata" = NULL, "screeningActiveCallId" = NULL,
               "consumerId" = :consumerId,
               "updatedAt" = now()
             WHERE id IN (:pids)`,
@@ -333,6 +334,43 @@ export function makeErasureService(overrides = {}) {
             'UPDATE prospects SET "sourceMetadata" = :sm WHERE id = :id',
             { replacements: { sm: JSON.stringify(erasedSourceMetadata(p.sourceMetadata)), id: p.id }, transaction: t }
           );
+        }
+
+        // Enrichment cascade (consumer-profile-enrichment plan §9): the fact
+        // ledger + persona profile carry raw PII (evidence quotes, summaries)
+        // — DELETE, never redact. Prospects are scrubbed (not deleted) and the
+        // consumer row survives with erasedAt, so no FK cascade fires: these
+        // must be explicit. Jobs of EVERY status lose payload + lastError for
+        // BOTH subject addressings (synth jobs are consumer-subject; their
+        // lastError can carry model-output text — Codex R3 #4 / R4 #4); live
+        // ones are cancelled.
+        {
+          const obsWhere = pids.length
+            ? '"sourceProspectId" IN (:pids) OR "consumerId" = :consumerId'
+            : '"consumerId" = :consumerId';
+          const [, obsMeta] = await d.sequelize.query(
+            `DELETE FROM consumer_observations WHERE ${obsWhere}`,
+            { replacements: { pids, consumerId }, transaction: t }
+          );
+          report.observations = rowCount(obsMeta);
+
+          const [, profMeta] = await d.sequelize.query(
+            'DELETE FROM consumer_profiles WHERE "consumerId" = :consumerId',
+            { replacements: { consumerId }, transaction: t }
+          );
+          report.profileDeleted = rowCount(profMeta) > 0;
+
+          const jobsWhere = pids.length
+            ? '"subjectConsumerId" = :consumerId OR "subjectProspectId" IN (:pids)'
+            : '"subjectConsumerId" = :consumerId';
+          const [, jobsMeta] = await d.sequelize.query(
+            `UPDATE enrichment_jobs SET
+                status = CASE WHEN status IN ('pending','leased') THEN 'cancelled' ELSE status END,
+                payload = NULL, "lastError" = NULL, "updatedAt" = now()
+              WHERE ${jobsWhere}`,
+            { replacements: { pids, consumerId }, transaction: t }
+          );
+          report.enrichmentJobs = rowCount(jobsMeta);
         }
 
         // The person's browsing records (Codex R1 #9): sessions + attribution

--- a/backend/src/services/factMapperService.js
+++ b/backend/src/services/factMapperService.js
@@ -1,0 +1,281 @@
+import crypto from 'crypto';
+import { randomUUID } from 'crypto';
+import { sequelize, Prospect, EnrichmentJob, ConsumerObservation } from '../models/index.js';
+import { withConsumerFence, bumpEnrichmentInputTx, ErasedConsumerError } from './enrichmentFence.js';
+import { validateFact, birthYearToBand, clampSourceEventAt, TAXONOMY_VERSION } from '../utils/factTaxonomy.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Deterministic fact mapper — structured capture data → consumer_observations
+ * (docs/plans/consumer-profile-enrichment.md §5). No AI anywhere in this file.
+ *
+ * Durability shape (Codex R1 #5): capture writes a `map` JOB inside the
+ * capture transaction (the outbox — crash between commit and drain loses
+ * nothing), an opportunistic post-commit drain processes it, and the nightly
+ * sweep re-drains anything missed. The Redeem Ops capture hook is untouched.
+ *
+ * Snapshot semantics (Codex R3-era #10): facts are normalized + validated AT
+ * ENQUEUE and frozen into the job payload — the mapper never reads mutable
+ * live rows, so a staff edit between enqueue and drain cannot smuggle new
+ * data under an old revision. Edits mint prospects.enrichmentRevision++ and
+ * a NEW job; activation supersedes the old revision's rows (§3.1). The
+ * payload holds only taxonomy-relevant normalized values (never contact
+ * data), capped at 8 KB serialized.
+ */
+
+export const MAPPER_PIPELINE = 'mapper';
+// COMPOSITE semantic version (R3 #6): mapper code + taxonomy in one string.
+export const MAPPER_PIPELINE_VERSION = `mapper/v1+tax-${TAXONOMY_VERSION}`;
+const MAX_SNAPSHOT_BYTES = 8 * 1024;
+const INTERNAL_LEASE_MINUTES = 5;
+
+/** Canonical JSON — stable key order at every depth (hash stability). */
+export function canonicalJson(x) {
+  if (Array.isArray(x)) return `[${x.map(canonicalJson).join(',')}]`;
+  if (x !== null && typeof x === 'object') {
+    return `{${Object.keys(x).sort().map((k) => `${JSON.stringify(k)}:${canonicalJson(x[k])}`).join(',')}}`;
+  }
+  return JSON.stringify(x);
+}
+
+export const sha256 = (s) => crypto.createHash('sha256').update(s).digest('hex');
+
+/**
+ * Build the minimized, fully-normalized fact snapshot for a prospect-shaped
+ * object. Returns { facts: [{ key, value, artifact: 'form'|'quiz' }] } —
+ * every entry already taxonomy-valid; invalid candidates are skipped + logged
+ * (never block capture over a bad mapping).
+ *
+ * Sources today: demographics.dateOfBirth → identity.birth_year_band.
+ * Quiz answers map ONLY when server-scored (scoredBy === 'server' — Codex
+ * R1 #12) AND the campaign quiz definition carries per-question factKey +
+ * factValues (answerId → taxonomy value object); that authoring surface is
+ * PR 0 — the contract ships here so the mapper is ready the day a campaign
+ * uses it.
+ */
+export function buildFactSnapshot({ demographics, sourceMetadata, quizDefinition } = {}) {
+  const facts = [];
+
+  const dob = demographics?.dateOfBirth;
+  if (dob) {
+    const year = new Date(dob).getFullYear();
+    const band = birthYearToBand(year);
+    if (band) {
+      const value = { v: band };
+      const check = validateFact('identity.birth_year_band', value);
+      if (check.ok) facts.push({ key: 'identity.birth_year_band', value, artifact: 'form' });
+    }
+  }
+
+  const quiz = sourceMetadata?.quiz;
+  if (quiz?.scoredBy === 'server' && Array.isArray(quizDefinition?.questions)) {
+    const answers = quiz.submission?.answers || quiz.answers || {};
+    for (const q of quizDefinition.questions) {
+      if (!q?.factKey || !q?.id) continue;
+      const answerId = answers[q.id];
+      if (answerId === undefined || answerId === null) continue;
+      const value = q.factValues?.[String(answerId)];
+      if (!value) continue;
+      const check = validateFact(q.factKey, value);
+      if (!check.ok) {
+        logger.warn('[factMapper] invalid quiz factKey mapping skipped', {
+          factKey: q.factKey, error: check.error,
+        });
+        continue;
+      }
+      facts.push({ key: q.factKey, value, artifact: 'quiz' });
+    }
+  }
+
+  return { facts };
+}
+
+/**
+ * Outbox: enqueue the map job INSIDE the capture (or edit) transaction.
+ * Never throws — savepoint-isolated by the caller pattern; a lost enqueue is
+ * healed by the sweep. Empty snapshots enqueue only when revision > 1 (a
+ * cleared field must still supersede its old observation — zero-claim
+ * activation, §3.1); at capture (revision 1) there is nothing to supersede.
+ */
+export async function enqueueMapJobTx(t, { prospectId, enrichmentRevision, snapshot }) {
+  const payloadJson = canonicalJson(snapshot);
+  if (Buffer.byteLength(payloadJson, 'utf8') > MAX_SNAPSHOT_BYTES) {
+    logger.error('[factMapper] snapshot over cap — not enqueued', { prospectId });
+    return null;
+  }
+  if (!snapshot.facts.length && enrichmentRevision <= 1) return null;
+
+  const [rows] = await sequelize.query(
+    `INSERT INTO enrichment_jobs
+       (id, kind, "subjectProspectId", "sourceRevisionId", "sourceContentHash",
+        payload, "taxonomyVersion", "pipelineVersion", status, attempts, "createdAt", "updatedAt")
+     VALUES (:id, 'map', :pid, :rev, :hash, :payload::jsonb, :tax, :pv, 'pending', 0, now(), now())
+     ON CONFLICT DO NOTHING
+     RETURNING id`,
+    {
+      replacements: {
+        id: randomUUID(),
+        pid: prospectId,
+        rev: enrichmentRevision,
+        hash: sha256(payloadJson),
+        payload: JSON.stringify(snapshot),
+        tax: TAXONOMY_VERSION,
+        pv: MAPPER_PIPELINE_VERSION,
+      },
+      transaction: t,
+    }
+  );
+  return rows?.[0]?.id || null;
+}
+
+/**
+ * Revision activation for one artifact family under the fence (§3.1, R4 #2):
+ * gate on artifact-current revision + server-current pipeline, supersede ALL
+ * other active rows for the artifact (any revision, any pipelineVersion —
+ * including keys the new result omits), then insert. Zero-fact results still
+ * supersede (a cleared DOB kills the old band).
+ */
+async function activateArtifactTx(t, { artifactId, revision, contentHash, prospect, facts, source }) {
+  await sequelize.query(
+    `UPDATE consumer_observations
+        SET "supersededAt" = now(), "updatedAt" = now()
+      WHERE "sourceArtifactId" = :artifact
+        AND pipeline = :pipeline
+        AND "supersededAt" IS NULL
+        AND ("sourceRevisionId" <> :rev OR "pipelineVersion" <> :pv)`,
+    {
+      replacements: { artifact: artifactId, pipeline: MAPPER_PIPELINE, rev: revision, pv: MAPPER_PIPELINE_VERSION },
+      transaction: t,
+    }
+  );
+
+  for (const f of facts) {
+    await sequelize.query(
+      `INSERT INTO consumer_observations
+         (id, "sourceProspectId", key, value, confidence, source,
+          "sourceArtifactId", "sourceRevisionId", "sourceContentHash",
+          "sourceEventAt", pipeline, "pipelineVersion", "createdAt", "updatedAt")
+       VALUES (:id, :pid, :key, :value::jsonb, 1.0, :source, :artifact, :rev, :hash,
+               :eventAt, :pipeline, :pv, now(), now())
+       ON CONFLICT DO NOTHING`,
+      {
+        replacements: {
+          id: randomUUID(),
+          pid: prospect.id,
+          key: f.key,
+          value: JSON.stringify(f.value),
+          source,
+          artifact: artifactId,
+          rev: revision,
+          hash: contentHash,
+          eventAt: clampSourceEventAt(prospect.createdAt),
+          pipeline: MAPPER_PIPELINE,
+          pv: MAPPER_PIPELINE_VERSION,
+        },
+        transaction: t,
+      }
+    );
+  }
+}
+
+/** Process one leased map job to completion (done/stale/dead). */
+async function processMapJob(job) {
+  const finish = (status, lastError = null) =>
+    EnrichmentJob.update(
+      {
+        status,
+        lastError,
+        ...(status === 'pending' ? {} : {}),
+        ...(status === 'dead' || status === 'pending' ? { attempts: sequelize.literal('attempts + 1') } : {}),
+      },
+      { where: { id: job.id, leaseToken: job.leaseToken } }
+    );
+
+  try {
+    const result = await withConsumerFence(job.subjectProspectId, async (t, { prospect, consumer }) => {
+      // Gate (R4 #2): only the artifact-CURRENT revision at the CURRENT
+      // pipeline activates. A late old-revision job can never insert.
+      if (Number(job.sourceRevisionId) !== Number(prospect.enrichmentRevision)
+        || job.pipelineVersion !== MAPPER_PIPELINE_VERSION) {
+        return { outcome: 'stale' };
+      }
+
+      const snapshot = job.payload || { facts: [] };
+      const byArtifact = new Map([
+        [`form:${prospect.id}`, []],
+        [`quiz:${prospect.id}`, []],
+      ]);
+      for (const f of snapshot.facts || []) {
+        const check = validateFact(f.key, f.value);
+        if (!check.ok) throw Object.assign(new Error(`invalid fact ${f.key}: ${check.error}`), { code: 'INVALID_FACT' });
+        const artifactId = f.artifact === 'quiz' ? `quiz:${prospect.id}` : `form:${prospect.id}`;
+        byArtifact.get(artifactId).push(f);
+      }
+
+      const source = { form: 'form', quiz: 'quiz' };
+      for (const [artifactId, facts] of byArtifact) {
+        const kind = artifactId.startsWith('quiz:') ? 'quiz' : 'form';
+        await activateArtifactTx(t, {
+          artifactId,
+          revision: Number(job.sourceRevisionId),
+          contentHash: job.sourceContentHash,
+          prospect,
+          facts,
+          source: source[kind],
+        });
+      }
+
+      await bumpEnrichmentInputTx(t, consumer?.id || null);
+      return { outcome: 'done' };
+    });
+
+    if (result?.skipped) {
+      await finish('cancelled', `skipped: ${result.skipped}`);
+      return result.skipped;
+    }
+    await finish(result.outcome === 'stale' ? 'stale' : 'done');
+    return result.outcome;
+  } catch (err) {
+    if (err instanceof ErasedConsumerError) {
+      await finish('cancelled', 'consumer erased');
+      return 'cancelled';
+    }
+    const attempts = (job.attempts || 0) + 1;
+    await finish(attempts >= 3 ? 'dead' : 'pending', String(err?.message || err).slice(0, 500));
+    logger.error('[factMapper] map job failed', { jobId: job.id, error: err?.message });
+    return attempts >= 3 ? 'dead' : 'retry';
+  }
+}
+
+/**
+ * Claim + process pending map jobs (post-commit drain and sweep re-drain).
+ * Multi-instance safe: SKIP LOCKED claim to `leased` with a short internal
+ * lease; expired internal leases are reclaimed by the sweep like any other.
+ */
+export async function drainMapJobs({ limit = 20 } = {}) {
+  const leaseToken = randomUUID();
+  const [claimed] = await sequelize.query(
+    `WITH picked AS (
+       SELECT id FROM enrichment_jobs
+        WHERE status = 'pending' AND kind = 'map'
+        ORDER BY "createdAt"
+        LIMIT :limit
+        FOR UPDATE SKIP LOCKED)
+     UPDATE enrichment_jobs j
+        SET status = 'leased', "leaseToken" = :token,
+            "leaseExpiresAt" = now() + interval '${INTERNAL_LEASE_MINUTES} minutes',
+            "workerId" = 'in-process', "updatedAt" = now()
+       FROM picked WHERE j.id = picked.id
+     RETURNING j.*`,
+    { replacements: { limit, token: leaseToken } }
+  );
+
+  const outcomes = { done: 0, stale: 0, retry: 0, dead: 0, cancelled: 0 };
+  for (const row of claimed) {
+    const outcome = await processMapJob({ ...row, leaseToken });
+    if (outcomes[outcome] !== undefined) outcomes[outcome] += 1;
+  }
+  return { claimed: claimed.length, ...outcomes };
+}
+
+export { ConsumerObservation, Prospect };

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -44,6 +44,10 @@ import {
   getConsumerJourney,
 } from './consumerService.js';
 import { recordCaptureConsentEventsTx, canMarketTo } from './consentService.js';
+// Enrichment mapper (docs/plans/consumer-profile-enrichment.md §5): leaf
+// imports only (models + fence + taxonomy) — no cycle back into this module.
+import { buildFactSnapshot, enqueueMapJobTx, drainMapJobs } from './factMapperService.js';
+import { bumpEnrichmentInputTx } from './enrichmentFence.js';
 // Lead Profile page composer (admin-only, ?include=profile — plan §4). Leaf
 // imports only (models + sibling services); no cycle back into this module.
 import {
@@ -210,6 +214,10 @@ const defaultDeps = {
   getProspectOutcomes,
   recordCaptureConsentEventsTx,
   canMarketTo,
+  buildFactSnapshot,
+  enqueueMapJobTx,
+  drainMapJobs,
+  bumpEnrichmentInputTx,
   onLeadCaptured: (prospect) => (_leadCapturedHook ? _leadCapturedHook(prospect) : null),
   AppError,
   logger,
@@ -1017,6 +1025,30 @@ export function makeProspectService(overrides = {}) {
         drawTerms: incoming.consentMetadata?.drawTerms || null,
       });
 
+      // Enrichment outbox (docs/plans/consumer-profile-enrichment.md §5):
+      // freeze the normalized fact snapshot and enqueue the map job IN THIS
+      // transaction (crash-safe — Codex R1 #5), savepoint-isolated like the
+      // spine resolver: enrichment must never fail capture; the nightly
+      // sweep re-drains anything a crash or savepoint rollback loses.
+      try {
+        await d.sequelize.transaction({ transaction: t }, async (sp) => {
+          const snapshot = d.buildFactSnapshot({
+            demographics: newProspect.demographics,
+            sourceMetadata: newProspect.sourceMetadata,
+            quizDefinition: sourceCampaign?.design_config?.quiz,
+          });
+          await d.enqueueMapJobTx(sp, {
+            prospectId: newProspect.id,
+            enrichmentRevision: newProspect.enrichmentRevision || 1,
+            snapshot,
+          });
+        });
+      } catch (enrichErr) {
+        d.logger.warn('[enrichment] map-job outbox failed (sweep heals)', {
+          error: enrichErr?.message || String(enrichErr),
+        });
+      }
+
       const campaignName = sourceCampaign?.name || 'Unknown Campaign';
       // Source-aware phrase ("via TikTok ad" / "via web form" / "via {name} QR
       // code" …) instead of the old hardcoded "via {qr} QR code", which
@@ -1330,6 +1362,12 @@ export function makeProspectService(overrides = {}) {
       }
     }
 
+    // Enrichment: opportunistic post-commit drain of the map-job outbox —
+    // fire-and-forget (the job row is already durable; the sweep re-drains).
+    d.drainMapJobs({ limit: 5 }).catch((err) => {
+      d.logger.warn('[enrichment] post-capture drain failed', { error: err?.message || String(err) });
+    });
+
     // Pre-load agent + prospect-with-campaign for the caller's fire-and-forget
     // email side-effects. The campaign's design_config.customerHost drives the
     // confirmation-email brand, so load the campaign (with design_config) for
@@ -1613,6 +1651,49 @@ export function makeProspectService(overrides = {}) {
       await prospect.reload().catch(() => {});
     }
 
+    // Enrichment choke points (docs/plans/consumer-profile-enrichment.md §5,
+    // §6.3 — Codex R4-era #2). Best-effort: the sweep's repair scan heals.
+    // (a) demographics is a mapped field — a staff edit mints the next form-
+    //     artifact revision + a new map job whose activation supersedes the
+    //     old revision's observations (including a CLEARED DOB — zero-fact
+    //     snapshots at revision > 1 still supersede).
+    if (safeUpdates.demographics !== undefined) {
+      try {
+        await d.sequelize.transaction(async (t) => {
+          const rev = (prospect.enrichmentRevision || 1) + 1;
+          await prospect.update({ enrichmentRevision: rev }, { transaction: t });
+          const snapshot = d.buildFactSnapshot({
+            demographics: prospect.demographics,
+            sourceMetadata: prospect.sourceMetadata,
+            quizDefinition: null, // quiz answers are capture-time only; edits never change them
+          });
+          await d.enqueueMapJobTx(t, {
+            prospectId: prospect.id,
+            enrichmentRevision: rev,
+            snapshot,
+          });
+        });
+        d.drainMapJobs({ limit: 2 }).catch(() => {});
+      } catch (enrichErr) {
+        d.logger.warn('[enrichment] edit revision/outbox failed (sweep heals)', {
+          error: enrichErr?.message || String(enrichErr),
+        });
+      }
+    }
+    // (b) prospect lifecycle fields feed the score/DTO — bump the owner's
+    //     input version so the profile goes dirty (no observation write here).
+    if (safeUpdates.leadStatus !== undefined && safeUpdates.leadStatus !== oldStatus && prospect.consumerId) {
+      try {
+        await d.sequelize.transaction(async (t) => {
+          await d.bumpEnrichmentInputTx(t, prospect.consumerId);
+        });
+      } catch (enrichErr) {
+        d.logger.warn('[enrichment] leadStatus input bump failed', {
+          error: enrichErr?.message || String(enrichErr),
+        });
+      }
+    }
+
     // (Reassignment / unassignment is handled exclusively by assignProspect — see the
     // PROSPECT_UPDATE_FIELDS note — so PUT no longer needs unassignment side-effects.)
 
@@ -1705,6 +1786,12 @@ export function makeProspectService(overrides = {}) {
         }
       }
 
+      // Enrichment: a deleted signup CASCADE-deletes its observations, which
+      // changes the owner's resolved facts — dirty their profile in the same
+      // txn (plan §6.3 choke list; erased consumers are skipped by the bump).
+      if (prospect.consumerId) {
+        await d.bumpEnrichmentInputTx(t, prospect.consumerId);
+      }
       await prospect.destroy({ transaction: t });
     });
 

--- a/backend/src/utils/designConfigV2Clamp.js
+++ b/backend/src/utils/designConfigV2Clamp.js
@@ -49,6 +49,32 @@ import { applyFeaturedDropPolicy } from './featuredDrop.js';
 import { applyLuckyDrawPolicy } from './luckyDraw.js';
 import { applyMarketplacePolicy, normalizeMarketplaceContent } from './marketplaceContent.js';
 import { normalizeCustomerHostChoice } from './customerHost.js';
+import { validateFact } from './factTaxonomy.js';
+
+/**
+ * Enrichment factKey save-gate (consumer-profile-enrichment plan §5): a quiz
+ * question may carry { factKey, factValues: { answerId → taxonomy value } }
+ * so server-scored answers mint consumer observations. Invalid pairs are
+ * STRIPPED here (clamp style: sanitize, never reject) — the mapper re-checks
+ * at map time, so nothing invalid can reach the ledger through either door.
+ */
+function clampQuizFactKeys(quiz) {
+  if (!quiz || typeof quiz !== 'object' || !Array.isArray(quiz.questions)) return quiz;
+  for (const q of quiz.questions) {
+    if (!q || typeof q !== 'object' || q.factKey === undefined) continue;
+    const values = q.factValues && typeof q.factValues === 'object' && !Array.isArray(q.factValues)
+      ? Object.values(q.factValues)
+      : [];
+    const valid = typeof q.factKey === 'string'
+      && values.length > 0
+      && values.every((v) => validateFact(q.factKey, v).ok);
+    if (!valid) {
+      delete q.factKey;
+      delete q.factValues;
+    }
+  }
+  return quiz;
+}
 
 const isPlainObject = (v) => !!v && typeof v === 'object' && !Array.isArray(v);
 const clone = (v) => (v === undefined ? v : JSON.parse(JSON.stringify(v)));
@@ -383,8 +409,11 @@ export function clampDesignConfigV2(incoming, storedConfig, role) {
     form: clampForm(dc.form),
   };
 
-  // quiz / guidedReview — verbatim passthrough (documented v1-parity exceptions).
-  if (dc.quiz !== undefined) out.quiz = clone(dc.quiz);
+  // quiz / guidedReview — verbatim passthrough (documented v1-parity exceptions)
+  // EXCEPT enrichment factKey mappings, validated against the fact taxonomy
+  // at save time (consumer-profile-enrichment plan §5, Codex R3 #13): invalid
+  // factKey/factValues pairs are stripped so the mapper never sees them.
+  if (dc.quiz !== undefined) out.quiz = clampQuizFactKeys(clone(dc.quiz));
   if (dc.guidedReview !== undefined) out.guidedReview = clone(dc.guidedReview);
 
   // Admin-gated subtrees, stored state read from the stored doc's OWN version.

--- a/backend/src/utils/factResolver.js
+++ b/backend/src/utils/factResolver.js
@@ -1,0 +1,140 @@
+import { SOURCE_RANK, FACT_KEYS, FRESH_WINDOW_DAYS } from './factTaxonomy.js';
+
+/**
+ * resolveCurrentFacts — the total, deterministic "what do we currently
+ * believe about this person" function
+ * (docs/plans/consumer-profile-enrichment.md §3.4).
+ *
+ * Pure: rows in → resolved map out. No I/O, no clock — callers pass rows
+ * already scoped to one consumer (prospect-join ∪ manual rows, non-deleted).
+ *
+ * Precedence (Codex R2 #8 / R3 #8 — total order, fresh-scoped THROUGHOUT):
+ *   1. Drop superseded/retracted rows (activation §3.1 guarantees only the
+ *      current revision/pipeline rows remain active — never inferred here).
+ *   2. Per key: newest = max sourceEventAt; the FRESH SET = rows within
+ *      FRESH_WINDOW_DAYS of newest. Every later step draws only from it —
+ *      this IS the recency override: an old explicit answer loses
+ *      eligibility rather than a tie-break (lives change).
+ *   3. Scalars: winner = max by (source rank, confidence, sourceEventAt, id).
+ *      The id tiebreak (string compare) makes the order total.
+ *   4. Collections: baseline = fresh complete:true winner by the same tuple
+ *      ({v:[], complete:true} = explicitly none). Partials = fresh,
+ *      non-complete, sourceEventAt AFTER the baseline's, sorted by the
+ *      tuple, first-wins dedupe; baseline entries win dupes. No baseline ⇒
+ *      deduped union of fresh partials. Output ordering is canonical so
+ *      resolution is order-independent.
+ */
+
+const rankOf = (o) => SOURCE_RANK[o.source] ?? 0;
+const timeOf = (o) => new Date(o.sourceEventAt).getTime();
+
+/** Total-order comparator: rank, then confidence, then sourceEventAt, then id. */
+function tupleCompare(a, b) {
+  if (rankOf(a) !== rankOf(b)) return rankOf(a) - rankOf(b);
+  if (a.confidence !== b.confidence) return a.confidence - b.confidence;
+  if (timeOf(a) !== timeOf(b)) return timeOf(a) - timeOf(b);
+  return String(a.id) < String(b.id) ? -1 : String(a.id) > String(b.id) ? 1 : 0;
+}
+
+const childDedupeKey = (c) => `${c.birth_year_band ?? 'unknown'}|${c.gender ?? 'unknown'}`;
+
+function canonicalChildren(children) {
+  return [...children].sort((a, b) => {
+    const ka = `${a.birth_year_band ?? '~'}|${a.gender ?? '~'}`;
+    const kb = `${b.birth_year_band ?? '~'}|${b.gender ?? '~'}`;
+    return ka < kb ? -1 : ka > kb ? 1 : 0;
+  });
+}
+
+function resolveCollection(kind, fresh) {
+  const completes = fresh.filter((o) => o.value?.complete === true);
+  const baseline = completes.length ? completes.reduce((a, b) => (tupleCompare(a, b) >= 0 ? a : b)) : null;
+  const partials = fresh
+    .filter((o) => o.value?.complete !== true)
+    .filter((o) => (baseline ? timeOf(o) > timeOf(baseline) : true))
+    .sort((a, b) => tupleCompare(b, a)); // strongest first — first-wins dedupe
+
+  const basis = [];
+  if (kind === 'children') {
+    const seen = new Map(); // dedupeKey → child
+    if (baseline) {
+      basis.push(baseline.id);
+      for (const c of baseline.value.v) seen.set(childDedupeKey(c), c);
+    }
+    for (const p of partials) {
+      let contributed = false;
+      for (const c of p.value.v) {
+        const k = childDedupeKey(c);
+        if (!seen.has(k)) { seen.set(k, c); contributed = true; }
+      }
+      if (contributed) basis.push(p.id);
+    }
+    return { merged: { v: canonicalChildren([...seen.values()]), complete: Boolean(baseline?.value?.complete) }, baseline, basis };
+  }
+
+  // 'strings' collections (pets, coverage, interest tags)
+  const seen = new Set();
+  if (baseline) {
+    basis.push(baseline.id);
+    for (const s of baseline.value.v) seen.add(s);
+  }
+  for (const p of partials) {
+    let contributed = false;
+    for (const s of p.value.v) {
+      if (!seen.has(s)) { seen.add(s); contributed = true; }
+    }
+    if (contributed) basis.push(p.id);
+  }
+  return { merged: { v: [...seen].sort(), complete: Boolean(baseline?.value?.complete) }, baseline, basis };
+}
+
+/**
+ * @param {Array} observations — rows for ONE consumer (plain objects or model
+ *   instances; needs id, key, value, confidence, source, sourceEventAt,
+ *   supersededAt, retractedAt).
+ * @returns {Object} key → { value, source, confidence, sourceEventAt,
+ *   observationId, basis: [ids…] } — collections carry the merged value, the
+ *   baseline's meta (or the strongest partial's when no baseline), and every
+ *   contributing id in basis.
+ */
+export function resolveCurrentFacts(observations) {
+  const active = observations.filter((o) => !o.supersededAt && !o.retractedAt && FACT_KEYS[o.key]);
+  const byKey = new Map();
+  for (const o of active) {
+    if (!byKey.has(o.key)) byKey.set(o.key, []);
+    byKey.get(o.key).push(o);
+  }
+
+  const resolved = {};
+  for (const [key, rows] of byKey) {
+    const newest = Math.max(...rows.map(timeOf));
+    const fresh = rows.filter((o) => newest - timeOf(o) <= FRESH_WINDOW_DAYS * 86_400_000);
+    const kind = FACT_KEYS[key].collection;
+
+    if (!kind) {
+      const winner = fresh.reduce((a, b) => (tupleCompare(a, b) >= 0 ? a : b));
+      resolved[key] = {
+        value: winner.value,
+        source: winner.source,
+        confidence: winner.confidence,
+        sourceEventAt: winner.sourceEventAt,
+        observationId: winner.id,
+        basis: [winner.id],
+      };
+      continue;
+    }
+
+    const { merged, baseline, basis } = resolveCollection(kind, fresh);
+    if (!basis.length) continue; // e.g. only complete:false rows all pre-baseline — cannot happen, but stay safe
+    const meta = baseline ?? fresh.filter((o) => basis.includes(o.id)).sort((a, b) => tupleCompare(b, a))[0];
+    resolved[key] = {
+      value: merged,
+      source: meta.source,
+      confidence: meta.confidence,
+      sourceEventAt: meta.sourceEventAt,
+      observationId: meta.id,
+      basis,
+    };
+  }
+  return resolved;
+}

--- a/backend/src/utils/factTaxonomy.js
+++ b/backend/src/utils/factTaxonomy.js
@@ -1,0 +1,204 @@
+/**
+ * Fact taxonomy v1 — THE single source of truth for consumer-observation
+ * keys, value shapes, and source ranks
+ * (docs/plans/consumer-profile-enrichment.md §4).
+ *
+ * Everything that touches facts derives from this module: the observations
+ * API rejects keys/values it doesn't validate, the mapper normalizes into
+ * it, the extraction prompt (PR 2) is GENERATED from it so prompt and
+ * validator can't drift, and the resolver ranks sources by SOURCE_RANK.
+ *
+ * Never free-form keys. Values are always small objects: `{ v: … }` plus
+ * per-key extras (`complete` on collections, `when` on life events).
+ * Booleans support negatives ({v:false} — someone can sell the car);
+ * collections support explicit emptiness ({v:[], complete:true} = "none").
+ * Ages are NEVER stored — birth-year bands only (ages go stale).
+ *
+ * identity.ethnicity: accepted from form/manual/explicit self-identification
+ * ONLY — never inferred from call language (owner decision + Codex R1 #14:
+ * language inference mints identity.preferred_language instead, which is
+ * the directly-scored market-fit signal).
+ */
+
+export const TAXONOMY_VERSION = 'v1';
+
+// Explicitness rank for resolveCurrentFacts (§3.4) — higher wins.
+export const SOURCE_RANK = {
+  manual: 5,
+  form: 4,
+  quiz: 3,
+  screening_transcript: 2,
+  retell_analysis: 1, // reserved — unused in v1 (call_bot prospects are consumer-unlinked)
+};
+
+export const FRESH_WINDOW_DAYS = 180;
+export const EVENT_SKEW_MS = 24 * 60 * 60 * 1000; // clamp future-dated sourceEventAt (R3 #8)
+export const MAX_EVIDENCE_CHARS = 300;
+export const MIN_LLM_CONFIDENCE = 0.5;
+
+const GENDERS = ['male', 'female'];
+const ETHNICITIES = ['chinese', 'malay', 'indian', 'eurasian', 'other'];
+const LANGUAGES = ['en', 'zh', 'ms', 'ta'];
+const MARITAL = ['single', 'married', 'divorced', 'widowed'];
+const PROPERTY = ['hdb', 'condo', 'landed', 'none'];
+const EMPLOYMENT = ['employed', 'self_employed', 'unemployed', 'retired', 'nsf', 'student'];
+const INCOME_BANDS = ['<3k', '3-6k', '6-10k', '10-15k', '>15k']; // monthly SGD
+const ANNUAL_INCOME_BANDS = ['<40k', '40-80k', '80-120k', '120-200k', '>200k']; // PR 0 question
+const RETIREMENT_BANDS = ['<55', '55-59', '60-64', '65-69', '70+']; // PR 0 question
+const COVERAGE = ['life', 'health', 'ci', 'pa', 'motor', 'home', 'travel', 'none'];
+const LIFE_EVENTS = ['new_child', 'marriage', 'divorce', 'new_job', 'new_home', 'bereavement'];
+const PETS = ['dog', 'cat', 'bird', 'fish', 'rabbit', 'hamster', 'reptile', 'other'];
+const INTEREST_VOCAB = [
+  'cars', 'travel', 'food', 'fitness', 'gaming', 'investing',
+  'parenting', 'pets', 'property', 'fashion', 'tech', 'sports',
+];
+
+const BIRTH_YEAR_BAND_RE = /^(19[2-9]\d|20[0-2]\d)-(19[2-9]\d|20[0-2]\d)$/;
+const WHEN_RE = /^20\d{2}-Q[1-4]$/;
+
+const isPlainObject = (x) => x !== null && typeof x === 'object' && !Array.isArray(x);
+
+function enumShape(allowed) {
+  return (value) => {
+    if (!isPlainObject(value)) return 'value must be an object';
+    if (!allowed.includes(value.v)) return `v must be one of ${allowed.join('|')}`;
+    if (Object.keys(value).length !== 1) return 'only {v} allowed';
+    return true;
+  };
+}
+
+function boolShape() {
+  return (value) => {
+    if (!isPlainObject(value)) return 'value must be an object';
+    if (typeof value.v !== 'boolean') return 'v must be boolean';
+    if (Object.keys(value).length !== 1) return 'only {v} allowed';
+    return true;
+  };
+}
+
+function stringShape(maxLen) {
+  return (value) => {
+    if (!isPlainObject(value)) return 'value must be an object';
+    if (typeof value.v !== 'string' || !value.v.trim()) return 'v must be a non-empty string';
+    if (value.v.length > maxLen) return `v exceeds ${maxLen} chars`;
+    if (Object.keys(value).length !== 1) return 'only {v} allowed';
+    return true;
+  };
+}
+
+// String-array collection from a fixed vocabulary; {v:[], complete:true} = "none".
+function vocabListShape(vocab, maxItems) {
+  return (value) => {
+    if (!isPlainObject(value)) return 'value must be an object';
+    if (!Array.isArray(value.v)) return 'v must be an array';
+    if (value.v.length > maxItems) return `v exceeds ${maxItems} items`;
+    if (!value.v.every((s) => vocab.includes(s))) return `items must be from ${vocab.join('|')}`;
+    if (new Set(value.v).size !== value.v.length) return 'duplicate items';
+    for (const k of Object.keys(value)) {
+      if (k !== 'v' && k !== 'complete') return `unknown prop ${k}`;
+    }
+    if ('complete' in value && typeof value.complete !== 'boolean') return 'complete must be boolean';
+    return true;
+  };
+}
+
+/**
+ * key → { collection: false | 'strings' | 'children', validate(value) → true | errorString }
+ */
+export const FACT_KEYS = {
+  'identity.gender': { collection: false, validate: enumShape(GENDERS) },
+  'identity.birth_year_band': {
+    collection: false,
+    validate: (value) => {
+      if (!isPlainObject(value)) return 'value must be an object';
+      if (typeof value.v !== 'string' || !BIRTH_YEAR_BAND_RE.test(value.v)) {
+        return 'v must be "YYYY-YYYY" (e.g. 1985-1989)';
+      }
+      const [a, b] = value.v.split('-').map(Number);
+      if (b - a !== 4) return 'band must span exactly 5 years (e.g. 1985-1989)';
+      if (a % 5 !== 0) return 'band must start on a multiple of 5';
+      if (Object.keys(value).length !== 1) return 'only {v} allowed';
+      return true;
+    },
+  },
+  'identity.ethnicity': { collection: false, validate: enumShape(ETHNICITIES) },
+  'identity.preferred_language': { collection: false, validate: enumShape(LANGUAGES) },
+  'family.marital_status': { collection: false, validate: enumShape(MARITAL) },
+  'family.children': {
+    collection: 'children',
+    validate: (value) => {
+      if (!isPlainObject(value)) return 'value must be an object';
+      if (!Array.isArray(value.v)) return 'v must be an array';
+      if (value.v.length > 12) return 'v exceeds 12 children';
+      for (const c of value.v) {
+        if (!isPlainObject(c)) return 'children must be objects';
+        for (const k of Object.keys(c)) {
+          if (k !== 'birth_year_band' && k !== 'gender') return `unknown child prop ${k}`;
+        }
+        if ('birth_year_band' in c && (typeof c.birth_year_band !== 'string' || !BIRTH_YEAR_BAND_RE.test(c.birth_year_band))) {
+          return 'child birth_year_band must be "YYYY-YYYY"';
+        }
+        if ('gender' in c && !GENDERS.includes(c.gender)) return 'child gender invalid';
+      }
+      for (const k of Object.keys(value)) {
+        if (k !== 'v' && k !== 'complete') return `unknown prop ${k}`;
+      }
+      if ('complete' in value && typeof value.complete !== 'boolean') return 'complete must be boolean';
+      return true;
+    },
+  },
+  'family.parents_alive': { collection: false, validate: boolShape() },
+  'household.pets': { collection: 'strings', validate: vocabListShape(PETS, 8) },
+  'assets.car_owner': { collection: false, validate: boolShape() },
+  'assets.property': { collection: false, validate: enumShape(PROPERTY) },
+  'career.job_title': { collection: false, validate: stringShape(80) },
+  'career.industry': { collection: false, validate: stringShape(40) },
+  'career.employment': { collection: false, validate: enumShape(EMPLOYMENT) },
+  'finance.income_band': { collection: false, validate: enumShape(INCOME_BANDS) },
+  'finance.annual_income_band': { collection: false, validate: enumShape(ANNUAL_INCOME_BANDS) },
+  'finance.retirement_age_band': { collection: false, validate: enumShape(RETIREMENT_BANDS) },
+  'finance.existing_coverage': { collection: 'strings', validate: vocabListShape(COVERAGE, 8) },
+  'life_event.recent': {
+    collection: false,
+    validate: (value) => {
+      if (!isPlainObject(value)) return 'value must be an object';
+      if (!LIFE_EVENTS.includes(value.v)) return `v must be one of ${LIFE_EVENTS.join('|')}`;
+      for (const k of Object.keys(value)) {
+        if (k !== 'v' && k !== 'when') return `unknown prop ${k}`;
+      }
+      if ('when' in value && (typeof value.when !== 'string' || !WHEN_RE.test(value.when))) {
+        return 'when must be "YYYY-QN"';
+      }
+      return true;
+    },
+  },
+  'interests.tags': { collection: 'strings', validate: vocabListShape(INTEREST_VOCAB, 10) },
+  'residency.status': { collection: false, validate: enumShape(['citizen', 'pr', 'foreigner']) },
+};
+
+/** Validate a (key, value) pair against the taxonomy. → { ok, error? } */
+export function validateFact(key, value) {
+  const def = FACT_KEYS[key];
+  if (!def) return { ok: false, error: `unknown key ${key}` };
+  const res = def.validate(value);
+  return res === true ? { ok: true } : { ok: false, error: res };
+}
+
+export function isCollectionKey(key) {
+  return Boolean(FACT_KEYS[key]?.collection);
+}
+
+/** Birth year → canonical 5-year band ("1988" → "1985-1989"). */
+export function birthYearToBand(year) {
+  const y = Number(year);
+  if (!Number.isInteger(y) || y < 1920 || y > 2029) return null;
+  const start = Math.floor(y / 5) * 5;
+  return `${start}-${start + 4}`;
+}
+
+/** Clamp a source-event timestamp to now + EVENT_SKEW_MS (R3 #8). */
+export function clampSourceEventAt(ts, now = Date.now()) {
+  const t = new Date(ts).getTime();
+  if (!Number.isFinite(t)) return new Date(now);
+  return new Date(Math.min(t, now + EVENT_SKEW_MS));
+}

--- a/backend/test/consumerEnrichment.test.js
+++ b/backend/test/consumerEnrichment.test.js
@@ -1,0 +1,283 @@
+import request from 'supertest'
+import { getApp, closeDb, createTestUser, createTestCampaign } from './helpers.js'
+import {
+  sequelize, Prospect, Consumer, ConsumerObservation, ConsumerProfile, EnrichmentJob,
+} from '../src/models/index.js'
+import { drainMapJobs, MAPPER_PIPELINE_VERSION } from '../src/services/factMapperService.js'
+import { bumpEnrichmentInputTx } from '../src/services/enrichmentFence.js'
+import { makeErasureService } from '../src/services/erasureService.js'
+import { makeProspectService } from '../src/services/prospectService.js'
+
+/**
+ * Consumer enrichment PR 1 — the DB half
+ * (docs/plans/consumer-profile-enrichment.md §3, §5, §9).
+ *
+ * Covers the load-bearing lifecycle: capture writes the map-job OUTBOX in
+ * the capture transaction → drain activates revision 1 observations + bumps
+ * the input version → a staff demographics edit mints revision 2 whose
+ * activation SUPERSEDES revision 1 (a cleared DOB kills the old band via a
+ * zero-fact snapshot) → erasure deletes ledger + profile, nulls job
+ * payloads/lastError, and scrubs screeningMetadata (the pre-existing PII
+ * gap this PR closes).
+ */
+
+let app, admin, adminToken, campaign
+const phoneFor = (n) => `65${(80000000 + n).toString()}`
+let phoneSeq = Math.floor(Math.random() * 800000)
+
+async function capture(overrides = {}) {
+  phoneSeq += 1
+  const res = await request(app)
+    .post('/api/prospects')
+    .send({
+      firstName: 'Enrich',
+      lastName: 'Case',
+      email: `enrich-${phoneSeq}@example.com`,
+      phone: phoneFor(phoneSeq),
+      leadSource: 'website',
+      campaignId: campaign.id,
+      date_of_birth: '1988-06-15',
+      ...overrides,
+    })
+  expect(res.status).toBe(201)
+  return Prospect.findByPk(res.body.data.prospect.id)
+}
+
+beforeAll(async () => {
+  app = await getApp()
+  const made = await createTestUser({ role: 'admin' })
+  admin = made.user
+  adminToken = made.token
+  campaign = await createTestCampaign(admin.id, { name: `Enrichment IT ${Date.now()}` })
+})
+
+// The service fires opportunistic post-commit drains (capture + staff edits).
+// Those RACE any drain the test runs itself: the async drain can hold the
+// job leased while the test's drain sees nothing pending, and the assertion
+// then reads pre-activation state. Quiesce = drain + wait until no live map
+// job remains for the prospect.
+async function drainAndQuiesce(prospectId, { timeoutMs = 3000 } = {}) {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    await drainMapJobs({ limit: 10 })
+    const live = await EnrichmentJob.count({
+      where: { kind: 'map', subjectProspectId: prospectId, status: ['pending', 'leased'] },
+    })
+    if (live === 0) return
+    if (Date.now() > deadline) throw new Error(`map jobs never quiesced for ${prospectId}`)
+    await new Promise((r) => setTimeout(r, 50))
+  }
+}
+
+afterAll(async () => {
+  await closeDb()
+})
+
+describe('capture outbox → drain → observations', () => {
+  it('capture enqueues a map job (revision 1) and the drain mints the birth-year band', async () => {
+    const prospect = await capture()
+    expect(prospect.enrichmentRevision).toBe(1)
+    expect(prospect.consumerId).toBeTruthy()
+
+    // The outbox row is durable regardless of the post-commit drain's timing.
+    const job = await EnrichmentJob.findOne({
+      where: { kind: 'map', subjectProspectId: prospect.id, sourceRevisionId: 1 },
+    })
+    expect(job).toBeTruthy()
+    expect(job.pipelineVersion).toBe(MAPPER_PIPELINE_VERSION)
+    expect(job.payload.facts).toEqual([
+      { key: 'identity.birth_year_band', value: { v: '1985-1989' }, artifact: 'form' },
+    ])
+
+    // Post-capture drain may have already processed it — drain to certainty.
+    await drainAndQuiesce(prospect.id)
+    const obs = await ConsumerObservation.findAll({
+      where: { sourceProspectId: prospect.id, key: 'identity.birth_year_band' },
+    })
+    expect(obs).toHaveLength(1)
+    expect(obs[0].value).toEqual({ v: '1985-1989' })
+    expect(obs[0].source).toBe('form')
+    expect(obs[0].supersededAt).toBeNull()
+    expect(obs[0].sourceArtifactId).toBe(`form:${prospect.id}`)
+    expect(Number(obs[0].sourceRevisionId)).toBe(1)
+
+    // The owner's profile went dirty via the bump upsert.
+    const profile = await ConsumerProfile.findByPk(prospect.consumerId)
+    expect(profile).toBeTruthy()
+    expect(Number(profile.inputVersion)).toBeGreaterThan(Number(profile.syncedInputVersion))
+
+    // Drain is idempotent: nothing new on a second pass.
+    await drainMapJobs({ limit: 10 })
+    expect(await ConsumerObservation.count({ where: { sourceProspectId: prospect.id } })).toBe(1)
+  })
+
+  it('a staff demographics edit mints revision 2 whose activation supersedes revision 1', async () => {
+    const prospect = await capture()
+    // Revision 1 must be ACTIVATED (not merely enqueued) before the edit —
+    // otherwise the rev bump correctly stales the rev-1 job and only one row
+    // ever exists.
+    await drainAndQuiesce(prospect.id)
+
+    const service = makeProspectService()
+    await service.updateProspect(prospect.id, { demographics: { dateOfBirth: '1995-02-02', age: 31 } }, admin)
+    await drainAndQuiesce(prospect.id)
+
+    const all = await ConsumerObservation.findAll({
+      where: { sourceProspectId: prospect.id, key: 'identity.birth_year_band' },
+      order: [['sourceRevisionId', 'ASC']],
+    })
+    expect(all).toHaveLength(2)
+    expect(all[0].supersededAt).not.toBeNull() // revision 1 superseded
+    expect(all[1].supersededAt).toBeNull()
+    expect(all[1].value).toEqual({ v: '1995-1999' })
+    expect(Number(all[1].sourceRevisionId)).toBe(2)
+
+    // Clearing the DOB entirely: zero-fact snapshot still ACTIVATES (§3.1) —
+    // revision 3 supersedes revision 2's band and inserts nothing.
+    await service.updateProspect(prospect.id, { demographics: {} }, admin)
+    await drainAndQuiesce(prospect.id)
+    const active = await ConsumerObservation.findAll({
+      where: { sourceProspectId: prospect.id, supersededAt: null },
+    })
+    expect(active).toHaveLength(0)
+  })
+
+  it('a stale-revision job can never activate (late rev-1 after rev-2)', async () => {
+    const prospect = await capture()
+    // Freeze the rev-1 job in pending (kill the auto-drain's claim if any by
+    // resetting), then advance the prospect to revision 2 and drain BOTH.
+    await EnrichmentJob.update(
+      { status: 'pending', leaseToken: null, leaseExpiresAt: null },
+      { where: { subjectProspectId: prospect.id, kind: 'map' } }
+    )
+    const service = makeProspectService()
+    await service.updateProspect(prospect.id, { demographics: { dateOfBirth: '2000-03-03', age: 26 } }, admin)
+    await drainAndQuiesce(prospect.id)
+
+    const jobs = await EnrichmentJob.findAll({
+      where: { subjectProspectId: prospect.id, kind: 'map' },
+      order: [['sourceRevisionId', 'ASC']],
+    })
+    expect(jobs.map((j) => j.status).sort()).toEqual(['done', 'stale'])
+    const active = await ConsumerObservation.findAll({
+      where: { sourceProspectId: prospect.id, supersededAt: null },
+    })
+    expect(active).toHaveLength(1)
+    expect(active[0].value).toEqual({ v: '2000-2004' })
+  })
+
+  it('deleting the prospect cascades its observations away', async () => {
+    const prospect = await capture()
+    await drainMapJobs({ limit: 10 })
+    const service = makeProspectService()
+    await service.deleteProspect(prospect.id, admin)
+    expect(await ConsumerObservation.count({ where: { sourceProspectId: prospect.id } })).toBe(0)
+  })
+})
+
+describe('erasure cascade (§9)', () => {
+  it('deletes observations + profile, nulls job payloads/lastError, scrubs screeningMetadata', async () => {
+    const prospect = await capture()
+    await drainMapJobs({ limit: 10 })
+    const consumerId = prospect.consumerId
+
+    // Seed the pre-existing-gap fields + a manual observation + job lastError.
+    await prospect.update({
+      screeningMetadata: { attempts: { tok1: { transcript: 'User: I have two kids aged 5 and 8' } } },
+      screeningActiveCallId: 'call_abc123',
+    })
+    await ConsumerObservation.create({
+      consumerId,
+      key: 'assets.car_owner',
+      value: { v: true },
+      confidence: 1,
+      source: 'manual',
+      sourceEventAt: new Date(),
+      pipeline: 'manual',
+      pipelineVersion: 'manual/v1',
+    })
+    await EnrichmentJob.update(
+      { lastError: 'validation: invalid fact about the person' },
+      { where: { subjectProspectId: prospect.id } }
+    )
+
+    const erasure = makeErasureService()
+    const out = await erasure.eraseConsumer(consumerId, { reason: 'test' })
+    expect(out?.report ?? out).toBeTruthy()
+
+    expect(await ConsumerObservation.count({ where: { sourceProspectId: prospect.id } })).toBe(0)
+    expect(await ConsumerObservation.count({ where: { consumerId } })).toBe(0)
+    expect(await ConsumerProfile.findByPk(consumerId)).toBeNull()
+
+    const scrubbed = await Prospect.findByPk(prospect.id)
+    expect(scrubbed.screeningMetadata).toBeNull()
+    expect(scrubbed.screeningActiveCallId).toBeNull()
+
+    const jobs = await EnrichmentJob.findAll({ where: { subjectProspectId: prospect.id } })
+    expect(jobs.length).toBeGreaterThan(0)
+    for (const j of jobs) {
+      expect(j.payload).toBeNull()
+      expect(j.lastError).toBeNull()
+      expect(['cancelled', 'done', 'stale', 'dead']).toContain(j.status)
+    }
+
+    // The bump upsert must NEVER resurrect a profile for an erased person.
+    await sequelize.transaction(async (t) => {
+      await bumpEnrichmentInputTx(t, consumerId)
+    })
+    expect(await ConsumerProfile.findByPk(consumerId)).toBeNull()
+  })
+
+  it('post-erasure drain cancels the person’s pending map jobs instead of writing', async () => {
+    const prospect = await capture()
+    const consumerId = prospect.consumerId
+    // Hold the job pending, erase, THEN drain.
+    await EnrichmentJob.update(
+      { status: 'pending', leaseToken: null, leaseExpiresAt: null },
+      { where: { subjectProspectId: prospect.id, kind: 'map' } }
+    )
+    await ConsumerObservation.destroy({ where: { sourceProspectId: prospect.id } })
+
+    const erasure = makeErasureService()
+    await erasure.eraseConsumer(consumerId, { reason: 'test' })
+
+    // Erasure already cancelled the pending job; a drain finds nothing to do
+    // and writes nothing.
+    await drainMapJobs({ limit: 10 })
+    expect(await ConsumerObservation.count({ where: { sourceProspectId: prospect.id } })).toBe(0)
+    const jobs = await EnrichmentJob.findAll({ where: { subjectProspectId: prospect.id } })
+    for (const j of jobs) expect(j.status).not.toBe('leased')
+    expect(await ConsumerProfile.findByPk(consumerId)).toBeNull()
+  })
+})
+
+describe('relink bumps (§6.3)', () => {
+  it('recomputeConsumersByPhone dirties both sides when a prospect moves', async () => {
+    const prospect = await capture()
+    await drainMapJobs({ limit: 10 })
+    const oldConsumerId = prospect.consumerId
+
+    // Point the row at a synthetic wrong owner, then let recompute heal it.
+    const stray = await Consumer.create({
+      phone: `+${phoneFor(phoneSeq + 500000)}`,
+      firstSeenAt: new Date(),
+      lastSeenAt: new Date(),
+      signupCount: 0,
+      verifiedSignupCount: 0,
+    })
+    await Prospect.update({ consumerId: stray.id }, { where: { id: prospect.id } })
+
+    const { recomputeConsumersByPhone } = await import('../src/services/consumerService.js')
+    await recomputeConsumersByPhone([prospect.phone])
+
+    const healed = await Prospect.findByPk(prospect.id)
+    expect(healed.consumerId).toBe(oldConsumerId)
+
+    // Both the regained owner and the stray loser went dirty.
+    const winner = await ConsumerProfile.findByPk(oldConsumerId)
+    expect(winner).toBeTruthy()
+    expect(Number(winner.inputVersion)).toBeGreaterThan(Number(winner.syncedInputVersion))
+    const loser = await ConsumerProfile.findByPk(stray.id)
+    expect(loser).toBeTruthy()
+  })
+})

--- a/backend/test/unit/factMapperSnapshot.test.js
+++ b/backend/test/unit/factMapperSnapshot.test.js
@@ -1,0 +1,108 @@
+import { buildFactSnapshot, canonicalJson, sha256, MAPPER_PIPELINE_VERSION } from '../../src/services/factMapperService.js';
+
+/**
+ * The pure half of the fact mapper (consumer-profile-enrichment plan §5):
+ * snapshot building (normalized-at-enqueue, minimized) and canonical
+ * hashing. DB paths (outbox, drain, activation) live in the integration
+ * suite.
+ */
+describe('factMapperService (pure)', () => {
+  test('pipelineVersion is the composite semantic version (R3 #6)', () => {
+    expect(MAPPER_PIPELINE_VERSION).toBe('mapper/v1+tax-v1');
+  });
+
+  describe('canonicalJson', () => {
+    test('is key-order independent at every depth', () => {
+      const a = { b: 1, a: { d: [1, 2], c: 'x' } };
+      const b = { a: { c: 'x', d: [1, 2] }, b: 1 };
+      expect(canonicalJson(a)).toBe(canonicalJson(b));
+      expect(sha256(canonicalJson(a))).toBe(sha256(canonicalJson(b)));
+    });
+
+    test('array order still matters (arrays are data, not sets)', () => {
+      expect(canonicalJson({ v: [1, 2] })).not.toBe(canonicalJson({ v: [2, 1] }));
+    });
+  });
+
+  describe('buildFactSnapshot', () => {
+    test('demographics.dateOfBirth → identity.birth_year_band as a form fact', () => {
+      const { facts } = buildFactSnapshot({ demographics: { dateOfBirth: '1988-06-15', age: 38 } });
+      expect(facts).toEqual([
+        { key: 'identity.birth_year_band', value: { v: '1985-1989' }, artifact: 'form' },
+      ]);
+    });
+
+    test('no demographics → empty snapshot (nothing invented)', () => {
+      expect(buildFactSnapshot({}).facts).toEqual([]);
+      expect(buildFactSnapshot({ demographics: { age: 38 } }).facts).toEqual([]);
+      expect(buildFactSnapshot({ demographics: { dateOfBirth: 'not-a-date' } }).facts).toEqual([]);
+    });
+
+    const quizDefinition = {
+      enabled: true,
+      questions: [
+        {
+          id: 'q1',
+          factKey: 'assets.car_owner',
+          factValues: { yes: { v: true }, no: { v: false } },
+        },
+        {
+          id: 'q2',
+          factKey: 'finance.annual_income_band',
+          factValues: { a: { v: '<40k' }, b: { v: '40-80k' } },
+        },
+        { id: 'q3' }, // no factKey — scoring-only question
+      ],
+    };
+
+    test('server-scored quiz answers map through factKey/factValues', () => {
+      const { facts } = buildFactSnapshot({
+        sourceMetadata: { quiz: { scoredBy: 'server', answers: { q1: 'yes', q2: 'b', q3: 'whatever' } } },
+        quizDefinition,
+      });
+      expect(facts).toEqual([
+        { key: 'assets.car_owner', value: { v: true }, artifact: 'quiz' },
+        { key: 'finance.annual_income_band', value: { v: '40-80k' }, artifact: 'quiz' },
+      ]);
+    });
+
+    test('client-unverified quiz answers NEVER map (Codex R1 #12)', () => {
+      const { facts } = buildFactSnapshot({
+        sourceMetadata: { quiz: { scoredBy: 'client-unverified', answers: { q1: 'yes' } } },
+        quizDefinition,
+      });
+      expect(facts).toEqual([]);
+    });
+
+    test('invalid factKey mappings are skipped, valid siblings survive', () => {
+      const { facts } = buildFactSnapshot({
+        sourceMetadata: { quiz: { scoredBy: 'server', answers: { q1: 'yes', qBad: 'x' } } },
+        quizDefinition: {
+          questions: [
+            { id: 'q1', factKey: 'assets.car_owner', factValues: { yes: { v: true } } },
+            { id: 'qBad', factKey: 'identity.shoe_size', factValues: { x: { v: 42 } } },
+          ],
+        },
+      });
+      expect(facts).toEqual([{ key: 'assets.car_owner', value: { v: true }, artifact: 'quiz' }]);
+    });
+
+    test('unanswered factKey questions contribute nothing', () => {
+      const { facts } = buildFactSnapshot({
+        sourceMetadata: { quiz: { scoredBy: 'server', answers: {} } },
+        quizDefinition,
+      });
+      expect(facts).toEqual([]);
+    });
+
+    test('snapshot carries ONLY taxonomy facts — no contact data, ever', () => {
+      const snapshot = buildFactSnapshot({
+        demographics: { dateOfBirth: '1990-01-01' },
+        sourceMetadata: { quiz: { scoredBy: 'server', answers: {} }, referral: { code: 'x' } },
+      });
+      const json = canonicalJson(snapshot);
+      expect(Object.keys(snapshot)).toEqual(['facts']);
+      expect(json).not.toMatch(/phone|email|firstName|lastName|referral/i);
+    });
+  });
+});

--- a/backend/test/unit/factResolver.test.js
+++ b/backend/test/unit/factResolver.test.js
@@ -1,0 +1,165 @@
+import { resolveCurrentFacts } from '../../src/utils/factResolver.js';
+
+/**
+ * resolveCurrentFacts (consumer-profile-enrichment plan §3.4) — the total,
+ * deterministic precedence function. These are the Codex R2 #8 / R3 #8 /
+ * R4-era matrix cases: fresh-window eligibility, tuple total order,
+ * collection baseline/augment/dedupe, supersession/retraction, and
+ * order-independence.
+ */
+
+const DAY = 86_400_000;
+const T0 = Date.UTC(2026, 0, 1);
+let seq = 0;
+
+function obs(key, value, { source = 'form', confidence = 1, daysAgo = 0, id, supersededAt = null, retractedAt = null } = {}) {
+  seq += 1;
+  return {
+    id: id || `obs-${String(seq).padStart(4, '0')}`,
+    key,
+    value,
+    confidence,
+    source,
+    sourceEventAt: new Date(T0 + 400 * DAY - daysAgo * DAY),
+    supersededAt,
+    retractedAt,
+  };
+}
+
+describe('resolveCurrentFacts', () => {
+  test('unknown keys and superseded/retracted rows never resolve', () => {
+    const out = resolveCurrentFacts([
+      obs('identity.gender', { v: 'male' }, { supersededAt: new Date() }),
+      obs('identity.gender', { v: 'female' }, { retractedAt: new Date() }),
+      { ...obs('identity.gender', { v: 'male' }), key: 'not.a.key' },
+    ]);
+    expect(out).toEqual({});
+  });
+
+  test('within the fresh window, source rank beats confidence beats recency', () => {
+    const out = resolveCurrentFacts([
+      obs('family.marital_status', { v: 'single' }, { source: 'screening_transcript', confidence: 0.9, daysAgo: 1 }),
+      obs('family.marital_status', { v: 'married' }, { source: 'form', confidence: 1, daysAgo: 100 }),
+    ]);
+    expect(out['family.marital_status'].value).toEqual({ v: 'married' });
+    expect(out['family.marital_status'].source).toBe('form');
+  });
+
+  test('the 180-day fresh window is eligibility, not a tie-break: stale explicit answers lose', () => {
+    const out = resolveCurrentFacts([
+      obs('family.marital_status', { v: 'married' }, { source: 'form', daysAgo: 200 }),
+      obs('family.marital_status', { v: 'divorced' }, { source: 'screening_transcript', confidence: 0.7, daysAgo: 0 }),
+    ]);
+    expect(out['family.marital_status'].value).toEqual({ v: 'divorced' });
+  });
+
+  test('exactly-180-days-old still competes (boundary is inclusive)', () => {
+    const out = resolveCurrentFacts([
+      obs('family.marital_status', { v: 'married' }, { source: 'form', daysAgo: 180 }),
+      obs('family.marital_status', { v: 'single' }, { source: 'quiz', daysAgo: 0 }),
+    ]);
+    expect(out['family.marital_status'].value).toEqual({ v: 'married' });
+  });
+
+  test('same rank: higher confidence wins; then newer; then id (total order)', () => {
+    const byConf = resolveCurrentFacts([
+      obs('assets.car_owner', { v: true }, { source: 'screening_transcript', confidence: 0.6, daysAgo: 0 }),
+      obs('assets.car_owner', { v: false }, { source: 'screening_transcript', confidence: 0.9, daysAgo: 5 }),
+    ]);
+    expect(byConf['assets.car_owner'].value).toEqual({ v: false });
+
+    const byTime = resolveCurrentFacts([
+      obs('assets.car_owner', { v: true }, { source: 'form', daysAgo: 3 }),
+      obs('assets.car_owner', { v: false }, { source: 'form', daysAgo: 1 }),
+    ]);
+    expect(byTime['assets.car_owner'].value).toEqual({ v: false });
+
+    const a = obs('assets.car_owner', { v: true }, { source: 'form', daysAgo: 2, id: 'obs-aaaa' });
+    const b = { ...obs('assets.car_owner', { v: false }, { source: 'form', daysAgo: 2, id: 'obs-bbbb' }), sourceEventAt: a.sourceEventAt };
+    expect(resolveCurrentFacts([a, b])['assets.car_owner'].observationId).toBe('obs-bbbb');
+  });
+
+  test('negatives win like any other value (sold the car)', () => {
+    const out = resolveCurrentFacts([
+      obs('assets.car_owner', { v: true }, { source: 'form', daysAgo: 90 }),
+      obs('assets.car_owner', { v: false }, { source: 'form', daysAgo: 1 }),
+    ]);
+    expect(out['assets.car_owner'].value).toEqual({ v: false });
+  });
+
+  describe('collections (family.children)', () => {
+    test('complete baseline + later partial augments; earlier partial is ignored', () => {
+      const earlierPartial = obs('family.children', { v: [{ birth_year_band: '2010-2014', gender: 'female' }], complete: false }, { source: 'screening_transcript', confidence: 0.8, daysAgo: 40 });
+      const baseline = obs('family.children', { v: [{ birth_year_band: '2015-2019', gender: 'male' }], complete: true }, { source: 'form', daysAgo: 30 });
+      const laterPartial = obs('family.children', { v: [{ birth_year_band: '2020-2024', gender: 'female' }], complete: false }, { source: 'screening_transcript', confidence: 0.8, daysAgo: 5 });
+      const out = resolveCurrentFacts([earlierPartial, baseline, laterPartial]);
+      expect(out['family.children'].value.v).toEqual([
+        { birth_year_band: '2015-2019', gender: 'male' },
+        { birth_year_band: '2020-2024', gender: 'female' },
+      ]);
+      expect(out['family.children'].value.complete).toBe(true);
+      expect(out['family.children'].basis).toEqual([baseline.id, laterPartial.id]);
+    });
+
+    test('a partial mention can never SHRINK the set ("my daughter is eight")', () => {
+      const baseline = obs('family.children', {
+        v: [{ birth_year_band: '2015-2019', gender: 'male' }, { birth_year_band: '2015-2019', gender: 'female' }],
+        complete: true,
+      }, { source: 'form', daysAgo: 20 });
+      const partial = obs('family.children', { v: [{ birth_year_band: '2015-2019', gender: 'female' }], complete: false }, { source: 'screening_transcript', confidence: 0.9, daysAgo: 2 });
+      const out = resolveCurrentFacts([baseline, partial]);
+      expect(out['family.children'].value.v).toHaveLength(2);
+    });
+
+    test('empty-complete = explicitly no children; later partials still augment', () => {
+      const none = obs('family.children', { v: [], complete: true }, { source: 'form', daysAgo: 50 });
+      const newborn = obs('family.children', { v: [{ birth_year_band: '2025-2029' }], complete: false }, { source: 'screening_transcript', confidence: 0.9, daysAgo: 1 });
+      const out = resolveCurrentFacts([none, newborn]);
+      expect(out['family.children'].value.v).toEqual([{ birth_year_band: '2025-2029' }]);
+    });
+
+    test('no baseline: deduped union of fresh partials, canonical order', () => {
+      const p1 = obs('family.children', { v: [{ birth_year_band: '2020-2024', gender: 'male' }] }, { source: 'screening_transcript', confidence: 0.7, daysAgo: 9 });
+      const p2 = obs('family.children', { v: [{ birth_year_band: '2020-2024', gender: 'male' }, { birth_year_band: '2015-2019', gender: 'female' }] }, { source: 'screening_transcript', confidence: 0.8, daysAgo: 3 });
+      const out = resolveCurrentFacts([p1, p2]);
+      expect(out['family.children'].value.v).toEqual([
+        { birth_year_band: '2015-2019', gender: 'female' },
+        { birth_year_band: '2020-2024', gender: 'male' },
+      ]);
+      expect(out['family.children'].value.complete).toBe(false);
+    });
+
+    test('stale partials outside the fresh window never resurface', () => {
+      const old = obs('family.children', { v: [{ birth_year_band: '2005-2009' }] }, { source: 'screening_transcript', confidence: 0.9, daysAgo: 300 });
+      const fresh = obs('family.children', { v: [{ birth_year_band: '2020-2024' }] }, { source: 'screening_transcript', confidence: 0.6, daysAgo: 1 });
+      const out = resolveCurrentFacts([old, fresh]);
+      expect(out['family.children'].value.v).toEqual([{ birth_year_band: '2020-2024' }]);
+    });
+  });
+
+  test('string collections union with baseline-wins dedupe (pets)', () => {
+    const baseline = obs('household.pets', { v: ['dog'], complete: true }, { source: 'form', daysAgo: 10 });
+    const partial = obs('household.pets', { v: ['dog', 'cat'] }, { source: 'screening_transcript', confidence: 0.8, daysAgo: 1 });
+    const out = resolveCurrentFacts([baseline, partial]);
+    expect(out['household.pets'].value.v).toEqual(['cat', 'dog']);
+    expect(out['household.pets'].basis).toEqual([baseline.id, partial.id]);
+  });
+
+  test('resolution is order-independent (property)', () => {
+    const rows = [
+      obs('family.marital_status', { v: 'married' }, { source: 'form', daysAgo: 100 }),
+      obs('family.marital_status', { v: 'single' }, { source: 'quiz', confidence: 0.9, daysAgo: 60 }),
+      obs('family.children', { v: [{ birth_year_band: '2015-2019' }], complete: true }, { source: 'form', daysAgo: 30 }),
+      obs('family.children', { v: [{ birth_year_band: '2020-2024' }] }, { source: 'screening_transcript', confidence: 0.7, daysAgo: 2 }),
+      obs('assets.car_owner', { v: false }, { source: 'manual', daysAgo: 5 }),
+      obs('assets.car_owner', { v: true }, { source: 'form', daysAgo: 3 }),
+    ];
+    const base = resolveCurrentFacts(rows);
+    for (let i = 0; i < 6; i += 1) {
+      const shuffled = [...rows].sort(() => (((i * 7919) % 13) / 13) - 0.5);
+      expect(resolveCurrentFacts(shuffled)).toEqual(base);
+    }
+    // manual outranks form even when older
+    expect(base['assets.car_owner'].value).toEqual({ v: false });
+  });
+});

--- a/backend/test/unit/factTaxonomy.test.js
+++ b/backend/test/unit/factTaxonomy.test.js
@@ -1,0 +1,116 @@
+import {
+  validateFact, birthYearToBand, clampSourceEventAt, isCollectionKey,
+  FACT_KEYS, SOURCE_RANK, TAXONOMY_VERSION, EVENT_SKEW_MS,
+} from '../../src/utils/factTaxonomy.js';
+
+/**
+ * Fact taxonomy v1 (consumer-profile-enrichment plan §4) — the allowlist +
+ * per-key value schemas every fact writer validates against. The matrix
+ * below is the drift alarm: a key added to FACT_KEYS without shape coverage
+ * fails the round-trip test.
+ */
+describe('factTaxonomy', () => {
+  test('exports a stable version and ranked sources', () => {
+    expect(TAXONOMY_VERSION).toBe('v1');
+    expect(SOURCE_RANK.manual).toBeGreaterThan(SOURCE_RANK.form);
+    expect(SOURCE_RANK.form).toBeGreaterThan(SOURCE_RANK.quiz);
+    expect(SOURCE_RANK.quiz).toBeGreaterThan(SOURCE_RANK.screening_transcript);
+    expect(SOURCE_RANK.screening_transcript).toBeGreaterThan(SOURCE_RANK.retell_analysis);
+  });
+
+  const VALID = {
+    'identity.gender': { v: 'female' },
+    'identity.birth_year_band': { v: '1985-1989' },
+    'identity.ethnicity': { v: 'chinese' },
+    'identity.preferred_language': { v: 'zh' },
+    'family.marital_status': { v: 'divorced' },
+    'family.children': { v: [{ birth_year_band: '2015-2019', gender: 'male' }], complete: true },
+    'family.parents_alive': { v: true },
+    'household.pets': { v: ['dog'], complete: false },
+    'assets.car_owner': { v: false },
+    'assets.property': { v: 'hdb' },
+    'career.job_title': { v: 'Software Engineer' },
+    'career.industry': { v: 'Technology' },
+    'career.employment': { v: 'self_employed' },
+    'finance.income_band': { v: '6-10k' },
+    'finance.annual_income_band': { v: '80-120k' },
+    'finance.retirement_age_band': { v: '60-64' },
+    'finance.existing_coverage': { v: ['life', 'health'] },
+    'life_event.recent': { v: 'divorce', when: '2026-Q1' },
+    'interests.tags': { v: ['cars', 'travel'] },
+    'residency.status': { v: 'citizen' },
+  };
+
+  test('every taxonomy key has a passing example (round-trip)', () => {
+    for (const key of Object.keys(FACT_KEYS)) {
+      expect(VALID[key]).toBeDefined();
+      expect(validateFact(key, VALID[key])).toEqual({ ok: true });
+    }
+    // and the matrix carries no orphans
+    for (const key of Object.keys(VALID)) expect(FACT_KEYS[key]).toBeDefined();
+  });
+
+  test('unknown keys are rejected — never free-form', () => {
+    expect(validateFact('identity.shoe_size', { v: 42 }).ok).toBe(false);
+    expect(validateFact('', { v: 1 }).ok).toBe(false);
+  });
+
+  test.each([
+    ['identity.gender', { v: 'other' }],
+    ['identity.gender', { v: 'male', extra: 1 }],
+    ['identity.birth_year_band', { v: '1985-1990' }], // 6-year span
+    ['identity.birth_year_band', { v: '1986-1990' }], // not multiple of 5
+    ['identity.birth_year_band', { v: '85-89' }],
+    ['family.children', { v: [{ birth_year_band: 'bad' }] }],
+    ['family.children', { v: [{ nickname: 'Ah Boy' }] }],
+    ['family.children', { v: {}, complete: true }],
+    ['household.pets', { v: ['dragon'] }],
+    ['household.pets', { v: ['dog', 'dog'] }],
+    ['assets.car_owner', { v: 'yes' }],
+    ['career.job_title', { v: '' }],
+    ['career.job_title', { v: 'x'.repeat(81) }],
+    ['finance.annual_income_band', { v: '90k' }],
+    ['finance.retirement_age_band', { v: '62' }],
+    ['life_event.recent', { v: 'won_lottery' }],
+    ['life_event.recent', { v: 'divorce', when: 'last year' }],
+    ['interests.tags', { v: ['cars', 'crypto-moonshots'] }],
+    ['residency.status', { v: 'tourist' }],
+  ])('rejects bad shape %s %j', (key, value) => {
+    expect(validateFact(key, value).ok).toBe(false);
+  });
+
+  test('negatives and explicit emptiness are first-class', () => {
+    expect(validateFact('assets.car_owner', { v: false })).toEqual({ ok: true });
+    expect(validateFact('family.parents_alive', { v: false })).toEqual({ ok: true });
+    expect(validateFact('family.children', { v: [], complete: true })).toEqual({ ok: true });
+    expect(validateFact('household.pets', { v: [], complete: true })).toEqual({ ok: true });
+  });
+
+  test('collection keys are flagged for the resolver', () => {
+    expect(isCollectionKey('family.children')).toBe(true);
+    expect(isCollectionKey('household.pets')).toBe(true);
+    expect(isCollectionKey('finance.existing_coverage')).toBe(true);
+    expect(isCollectionKey('interests.tags')).toBe(true);
+    expect(isCollectionKey('identity.gender')).toBe(false);
+  });
+
+  test('birthYearToBand: canonical 5-year bands, never ages', () => {
+    expect(birthYearToBand(1988)).toBe('1985-1989');
+    expect(birthYearToBand(1990)).toBe('1990-1994');
+    expect(birthYearToBand('2004')).toBe('2000-2004');
+    expect(birthYearToBand(1900)).toBeNull();
+    expect(birthYearToBand(2040)).toBeNull();
+    expect(birthYearToBand('soon')).toBeNull();
+  });
+
+  test('clampSourceEventAt: future timestamps beyond skew are clamped (R3 #8)', () => {
+    const now = Date.UTC(2026, 6, 26);
+    const past = new Date(now - 1000);
+    expect(clampSourceEventAt(past, now).getTime()).toBe(past.getTime());
+    const nearFuture = new Date(now + EVENT_SKEW_MS - 1000);
+    expect(clampSourceEventAt(nearFuture, now).getTime()).toBe(nearFuture.getTime());
+    const farFuture = new Date(now + 30 * 86400000);
+    expect(clampSourceEventAt(farFuture, now).getTime()).toBe(now + EVENT_SKEW_MS);
+    expect(clampSourceEventAt('garbage', now).getTime()).toBe(now);
+  });
+});

--- a/docs/plans/consumer-profile-enrichment.md
+++ b/docs/plans/consumer-profile-enrichment.md
@@ -1,0 +1,423 @@
+# Consumer Profile Enrichment — person-level facts, AI summary, consumer score
+
+**Status:** v5 — **APPROVED, Codex round 5 (gpt-5.6-sol xhigh), 2026-07-26**
+("all four R4 findings closed as written; no new wrong-behavior; no changes
+required"). Convergence: REWORK 8B/12M → 6B/9M/1m → 5B/8M → 2B/1M/1m →
+APPROVE; disposition logs §14–§17. **READY TO BUILD** pending Shawn's two
+§13 calls (retention numbers; retraction suppression list).
+**Author:** Claude, 2026-07-26
+**Depends on:** Consumer spine (LIVE), erasure (LIVE), People directory
+(`docs/plans/admin-people-directory.md`, ready-to-build)
+**⚠ Implementation checkout:** authored on a stale branch —
+`AdminV2LeadProfile.jsx` + People-plan citations exist on `origin/main` only.
+**Build from a fresh `origin/main` worktree.**
+
+## 1. Goal
+
+Per **consumer** (not per signup):
+
+1. **An observation ledger** — typed, provenance-carrying observations
+   accumulated across all signups ("2 children, ages ~5 and ~8", "divorced",
+   "car owner", "prefers Mandarin", "ethnicity: Chinese").
+2. **An AI-written persona summary** — generated only from validated
+   structured claims (§6.4).
+3. **A consumer score (0–100)** — deterministic, explainable; includes a
+   **market-fit component** (current target: Chinese/Mandarin market;
+   retargeting = config insert, §7.2). Named `consumerScore` everywhere
+   (bare `score` = the per-prospect lead field, `Prospect.js:75`).
+
+All AI inference self-hosted and $0: Ollama on Shawn's Mac, nightly batch
+worker against authenticated backend endpoints.
+
+**Surfacing (owner decision, Shawn 2026-07-26): person-level surfaces ONLY**
+(`/AdminPeople` + person drill-in). Prospects surfaces get nothing.
+
+### Non-goals (v1)
+
+- No trained ML model; no real-time scoring; no customer-facing surface; no
+  score-triggered automation.
+- **No inbound-Retell (`call_bot`) enrichment** — reconciler deliberately
+  null-links call_bot rows; `retell_analysis` source enum reserved, unused.
+- No per-campaign scoring contexts (one global active segment config; v1.1).
+
+## 2. Existing substrate (verified across rounds)
+
+| Piece | Reality | Consequence |
+|---|---|---|
+| Identity spine | Reconciler **relinks prospects without locking consumers** (`consumerService.js:302-314`); unlinks call_bot; capture link nullable. | Prospect-anchored observations; relink-aware fence; relink bumps both consumers (§6.3, §9). |
+| Capture txn | Managed txn `prospectService.js:888`; `Prospect.create` `:971-988`; commit by `:1107-1112`. | Map-job outbox joins `t` after create; drain post-commit. Confirmed feasible (R2). |
+| `demographics` | Written by ordinary form capture (`:704-727`) and **staff-editable** (`:135-154`); staff PUT has **no body schema** (`routes/prospects.js:37`, 1 MB global cap). | Maps as `form` from a **minimized, capped snapshot** frozen at enqueue; edits mint a new source revision (§3.3, §5). |
+| Journey | `getConsumerJourney` = derived fields only. | Dedicated DTOs. |
+| Screening text | Flat `Agent:`/`User:` transcript per attempt (`retellScreeningService.js:662-676`), lands days late, multi-attempt; **no identity-confirmation marker**; event time from Retell's own timestamp (`:693`). | Per-artifact revision jobs; `User:`-turns slicing; timestamp skew clamp (§3.4). |
+| Quiz | `scoredBy: 'server'` or `'client-unverified'`; **quiz config is cloned verbatim in the clamp today (`designConfigV2Clamp.js:386`) — `factKey` validation does NOT exist and is a new PR 1 deliverable** (§5). [R3 #13] | Server-scored only; save-time + map-time validation both new code. |
+| Capture hook | Single callback owned by Redeem Ops. | Untouched; outbox instead. |
+| Sweeps | `setInterval`, no guards; migration runner shows the advisory-lock wrapper (`runMigrations.js:22-32`); **runner executes `mod.up` on pool connections — migrations are NOT atomic by default**. | Session-lock sweep (§7.3); migration 089 wraps all DDL in its own explicit transaction + catalog guards (§3, §11). [R3 #12] |
+| Erasure | Consumer-first lock (`erasureService.js:138-180`); scrub misses `screeningMetadata`/`screeningActiveCallId`. | PR 1 fixes; writers use the fence; **erasure also nulls enrichment job payloads of ALL statuses** (§9). [R3 #4] |
+| Config home / flags / limiter / auth / People target | As v3: dedicated configs table; startup-mounted flag; global limiter 200/15 min before routes; sha256+timingSafeEqual; `?view=profile` on origin/main. | §6.2 limiter design revised [R3 #11]. |
+
+## 3. Data model — migration `089-consumer-enrichment.js`
+
+Five tables + erasure fix. **The migration opens one explicit transaction it
+owns and runs every DDL statement on it** (the runner won't); every object is
+additionally catalog-guarded so a re-run after partial failure is safe.
+Models/associations/exports in PR 1; DDL must agree with `sync({force:true})`
+test boot. [R3 #12]
+
+### 3.1 `consumer_observations` (append-only, revisioned)
+
+| Column | Notes |
+|---|---|
+| `id` UUID PK | |
+| `sourceProspectId` FK prospects CASCADE / `consumerId` FK consumers CASCADE | Source-aware CHECK: manual ⇒ consumerId only; non-manual ⇒ sourceProspectId only **AND `sourceArtifactId`, `sourceRevisionId`, `sourceContentHash` all NOT NULL** (nullable identity columns can't guard uniqueness — multiple NULLs pass UNIQUE). [R3 #6] |
+| `key`, `value`, `confidence`, `source`, `evidence`, `sourceEventAt` | As v3 (allowlist; per-key schema; negatives + `complete`; CHECK 0–1; rank enum; verified substring ≤ 300; artifact time). **`sourceEventAt` clamped to `now() + 24 h` server skew at insert** — a future-dated Retell timestamp must not hijack the fresh window. [R3 #8] |
+| `sourceRevisionId` BIGINT | **The revision identity** — a monotonic per-artifact counter minted by the SOURCE mutation transaction (capture=1; each staff edit / screening attempt patch increments an `enrichmentRevision` counter stored beside the artifact). Content hash is NOT identity: A→B→A must produce revision 3, not collide with revision 1's rows (which stay superseded with their original event times). [R3 #3] |
+| `sourceContentHash` | Integrity/audit only. |
+| `pipeline`/`pipelineVersion` | **`pipelineVersion` is DEFINED as the composite semantic version** of its pipeline (prompt + taxonomy + code for extract; mapper code + taxonomy for map). One version string to compare, no separate taxonomy dimension in identities. [R3 #6] |
+| `supersededAt`, `retractedAt`, `createdAt` | Supersession permanent; retraction independent. |
+
+UNIQUE `(sourceArtifactId, sourceRevisionId, pipeline, pipelineVersion, key)`
+partial (non-manual); `ON CONFLICT DO NOTHING`. **Revision activation
+(gated + total):** under the fence (prospect row locked), activation first
+validates `job.sourceRevisionId ==` the artifact's CURRENT
+`enrichmentRevision` AND `job.pipelineVersion ==` the server's current
+pipeline version — mismatch ⇒ job `stale`, nothing written (a late rev-1
+completing after rev-2 activated can never insert). On acceptance it
+supersedes **every** prior active row for that (artifact, pipeline) — any
+revision, any pipelineVersion, including keys the new result omits — then
+inserts the new rows. **Zero-claim results still activate** (supersede all,
+insert none), so "current revision" never has to be inferred from surviving
+rows. Re-runs of the same accepted revision are no-ops. [R4 #2]
+Read path: UNION ALL (prospect-join + manual consumerId rows), excluding
+superseded/retracted. Manual facts survive relinks, die on their consumer's
+erasure.
+
+### 3.2 `consumer_profiles`
+
+As v3: summary ≤ 1200; profileJson (claim schema §6.4); consumerScore CHECK
+0–100 NULL; scoreBreakdown; `scoredConfigVersion` (stamped even when NULL);
+`scoringAlgorithmVersion`; `scoreInputHash`; **`inputVersion` BIGINT +
+`syncedInputVersion`** (dirty ⇔ >); `profileInputHash`; modelVersion +
+timestamps.
+
+### 3.3 `enrichment_jobs`
+
+| Column | Notes |
+|---|---|
+| `kind` ENUM(`map`,`extract`,`synthesize`), subjects, `sourceArtifactId`, `sourceRevisionId`, `sourceContentHash`, `inputHash`, `promptVersion`, `payload`, `pipelineVersion` (composite, enqueue-stamped), `status`, lease columns, `attempts`, `lastError` | Kind-aware CHECKs: each kind's identity columns NOT NULL, irrelevant ones NULL. [R3 #6] |
+
+**Map payload = minimized snapshot:** only normalized taxonomy-relevant
+fields (never contact data, free-text notes, or unrelated form fields),
+serialized cap 8 KB (reject + log over-cap keys). Synthesis jobs carry **no
+DTO payload** — the DTO is rebuilt at claim (§6.3). **Erasure nulls
+`payload` + `lastError` on jobs of EVERY status** (done/dead/cancelled rows
+survive 30 days for replay — their PII must not; prospects are scrubbed, not
+deleted, so FK cascade never fires). [R3 #4]
+
+Status enum gains `stale` (`pending`,`leased`,`done`,`stale`,`dead`,
+`cancelled`). Kind-scoped partial UNIQUEs:
+map `(kind, subjectProspectId, sourceRevisionId, pipelineVersion)` and
+extract `(kind, subjectProspectId, sourceArtifactId, sourceRevisionId,
+pipelineVersion)` — pending/leased/done participate (dead/cancelled/stale
+don't);
+synthesize `(kind, subjectConsumerId, inputHash, promptVersion)` —
+**pending/leased ONLY**: a `done` synth job must never block re-enqueueing a
+hash that recurs (profile flows A→B→A within the 30-day retention would
+otherwise be stuck at B forever). Synth completion replay is validated by
+job id + lease token, not the unique. Test: completed-A → completed-B →
+A-again re-enqueues and converges. [R4 #1]
+
+Claim SQL (CTE + `FOR UPDATE SKIP LOCKED`), 15-min leases,
+`POST /jobs/renew`, atomic expiry reclaim (`attempts++`), retained lease
+tokens: as v3. **Renewal during inference:** the worker runs a 5-minute
+heartbeat timer WHILE the model call is in flight (not just between items —
+one slow item can outlive the lease); renewal failure aborts the item and
+its result is not submitted. [R3 #7]
+
+### 3.4 `resolveCurrentFacts` — total comparator (fresh-scoped throughout) [R3 #8]
+
+1. Candidates: non-superseded, non-retracted rows (activation §3.1
+   guarantees only the current revision/pipeline's rows remain active — no
+   "latest" inference from surviving rows is ever needed).
+2. `newest` = max clamped `sourceEventAt`; **fresh set** = within 180 days of
+   it. **Every subsequent step draws ONLY from the fresh set** — scalars,
+   collection baselines, AND partials.
+3. Scalar winner: max by `(rank, confidence, sourceEventAt, id)`.
+4. Collections: baseline = fresh `complete:true` winner by the same tuple
+   (`v:[]` = explicitly none). Partials: fresh, `sourceEventAt` after the
+   baseline's, sorted by the total tuple, first-wins dedupe on
+   `(birth_year_band, gender ?? 'unknown')`; baseline entries win dupes.
+   Output ordering canonical: by `birth_year_band` then gender. No baseline ⇒
+   deduped union of fresh partials.
+5. Supersession permanent; retracting a superseding row revives nothing.
+
+Property tests: total order, order-independence, fresh-boundary exact edge,
+old-complete/new-partial, duplicate partials, future-dated clamp.
+
+## 4. Fact taxonomy v1
+
+Unchanged (v2 §4): allowlist + per-key schemas + normalizers +
+`TAXONOMY_VERSION` (feeds composite pipeline versions); ethnicity only from
+form/manual/explicit self-identification; `preferred_language` = **the
+preferred contact language** (not demonstrated ability — defined for
+entailment §6.4); engagement is telemetry, not observations.
+
+## 5. Phase A — deterministic mapper
+
+- Outbox map job inside capture `t` (after create, drain post-commit).
+- **Snapshot:** minimized (§3.3), frozen at enqueue with
+  `sourceRevisionId = 1`. Staff edits to mapped fields (the `updateProspect`
+  choke point — new body-schema validation for those fields rides along)
+  increment the prospect's enrichment revision + enqueue a new map job;
+  activation supersedes old rows. Ordinary-capture `demographics` = `form`,
+  confidence 1.0.
+- **Quiz `factKey`:** save-time validation added to the campaign clamp
+  (currently verbatim-clones quiz config — this is NEW code, PR 1);
+  map-time re-validation skips + logs invalid pre-existing mappings.
+  [R3 #13]
+- Backfill = reconciliation sweep enqueuing map jobs at current
+  `(pipelineVersion, sourceRevisionId)`, **run as a separately-invoked,
+  observable backfill mode** (not silently inside the nightly sweep).
+  [R3 #10]
+
+## 6. Phase B — extraction + synthesis worker
+
+### 6.1 Worker
+
+As v3, plus the in-flight 5-min heartbeat (§3.3). Launchd ≥ 1 h after the
+server sweep window.
+
+### 6.2 API (claim / renew / complete / status)
+
+As v3 (per-job SAVEPOINTs, deterministic per-job statuses, idempotent
+replay, `User:`-turns slicing, hashed-key timingSafeEqual auth), with the
+limiter redesigned: [R3 #11]
+
+- The global limiter **fully exempts `/api/enrichment/*`** — middleware
+  limits compose to the MINIMUM, so leaving the 200/15-min pre-route bucket
+  in place would cap the worker no matter how generous the later one is
+  (and let anyone sharing the worker's IP exhaust its budget). [R4 #3]
+- The router mounts two local limiters instead: a **small IP-keyed bucket
+  charged only to requests that FAIL auth** (invalid/unauthenticated traffic
+  is bounded), and the **generous budget keyed on the constant worker-key
+  ID** (sha256 prefix of the configured key — never the presented bearer
+  string, which would let attackers mint unbounded keys and would write
+  secrets into limiter storage). Test: bad keys hit the small cap; a valid
+  worker sails past it.
+
+### 6.3 Input versioning + synthesis binding [R3 #1, #2]
+
+- `bumpEnrichmentInput(consumerId, tx)` = **UPSERT** on `consumer_profiles`
+  (first-time consumers can't lose bumps). Choke points: revision
+  activation, retraction, manual facts, consent events, WA delivery, draw
+  entry/boost, screening verdict, spine relink (both consumers), **and
+  prospect lifecycle mutations that feed the DTO/score — `leadStatus`,
+  `conversionDate`, prospect delete** (staff-editable today,
+  `prospectService.js:1474`). The DTO builder documents its exact field
+  list; every listed field's writer bumps in the same transaction. [R3 #2]
+- **Enqueue:** sweep locks the profile row, reads `inputVersion` V, builds
+  the DTO, hashes H, inserts the synthesize job keyed by H.
+- **Claim binding:** claim REBUILDS the DTO under the fence and compares its
+  hash to `job.inputHash` — **the worker only ever receives a DTO whose hash
+  equals the job's**; mismatch marks the job `stale` immediately. The output
+  is therefore provably generated from the job's input, closing the A→B→A
+  window at claim. [R3 #1]
+- **Completion CAS:** lock profile row FOR UPDATE → read `inputVersion` V →
+  rebuild DTO/hash → require hash `=== job.inputHash` → write outputs with a
+  **conditional update `WHERE inputVersion = V`** (an engagement commit
+  between rebuild and write fails the update → job `stale`). Sets
+  `profileInputHash = job.inputHash`, `syncedInputVersion = V`. A→B→A race
+  test required. [R3 #1, #2]
+
+### 6.4 Output guards — entailment table, then prose [R3 #5]
+
+`profileJson` claim types with **exact server-checked predicates**:
+
+| Claim | Predicate |
+|---|---|
+| `dependants: {count: n, exact: bool}` | `exact:true` requires a resolved complete `family.children` baseline of size n (+ dependant parents if counted); partials-only resolution entails only `exact:false` (lower bound ≥ observed). |
+| `lifeStage` enum | Derived table over resolved `family.marital_status` + children presence + `identity.birth_year_band` — server can compute it; the model's value must match the derivation (or `unknown`). |
+| `languages` | = resolved `identity.preferred_language` (definition §4), verbatim. |
+| `insuranceTriggers[]` | **Server-derived, not model-asserted:** deterministic rules over resolved `life_event.recent` + family/coverage facts produce the trigger labels; the model may only order and reference them. |
+| `talkingAngles[]` | Schema-labeled `suggestions`; creative; rendered under "suggested angles"; outside all traceability promises. |
+
+Prose step unchanged: summary generated ONLY from validated claims +
+derived triggers; ≤ 1200 chars; lint. Untrusted-source framing + injection
+fixtures unchanged.
+
+## 7. Phase C — deterministic scoring
+
+As v3 (§7.1 math: clamp/round-once, min-confidence for fact rules, telemetry
+confidence 1.0, config-change ⇒ full recompute, scoreability rule, SGT
+decay, `scoreInputHash`/`scoringAlgorithmVersion`/`scoredConfigVersion`
+stamped even when NULL; §7.2 configs table + language-primary fit).
+
+### 7.3 Sweep [R3 #9, #10]
+
+Session-level `pg_try_advisory_lock` on a dedicated connection + `finally`
+unlock; window re-check after acquisition. **`enrichment_sweep_runs` is a
+fence, not a log:** UNIQUE `runDateSgt`, `status`
+(`running`/`done`/`failed`), `ownerToken`, `heartbeatAt`, `finishedAt`,
+`stats`. Takeover permitted only when `status='running'` AND `heartbeatAt`
+stale > 30 min (new owner token; finalization updates are owner-token
+fenced). A `failed` run may be retried within the same window; `done` ends
+the date. **Repair scan is budgeted:** durable cursor on the runs row, fixed
+row + wall-time budget per night, rotating through the population across
+runs; lag/coverage counters in `stats` (and `/status`). Initial backfill =
+the separate mode (§5), never the nightly budget.
+
+## 8. Phase D — admin surfacing (People only — NOT Prospects)
+
+Unchanged from v3. `/AdminPeople` sortable `consumerScore` (NULL = "—");
+person drill-in (`?view=profile`, origin/main) gets score chip + breakdown +
+completeness, summary card, observations panel + retraction, suggested
+angles under their own header. PR 3 stacks on the People build, fresh
+worktree.
+
+## 9. Erasure, consent, retention
+
+As v3 (screeningMetadata scrub fix; cascade deletes observations + profile
+row + cancels jobs; retrying owner-recheck fence, relink writer lock order;
+eligibility; v1 retraction), **with the retention set REPLACED by owner
+decision (Shawn 2026-07-26): customer data is kept FOREVER** — no TTLs on
+observations (active/superseded/retracted), evidence, or screening
+transcripts; erasure-on-request stays the sole deletion path for personal
+data. The only surviving prune is queue hygiene: `done`/`dead`/`cancelled`
+**jobs** (plumbing; payloads minimized) after 30 days, lease tokens living
+that long for replay [supersedes the R2 #15 TTLs] — **plus:** erasure nulls `payload` +
+`lastError` on enrichment jobs of every status addressed **either** by
+`subjectConsumerId = :consumerId` **or** by prospect/artifact subjects
+belonging to the erased consumer — synth jobs are consumer-subject, not
+prospect-subject, and their `lastError` can carry validation/model-output
+text (test covers it) (§3.3). [R3 #4, R4 #4]
+
+## 10. Failure modes
+
+V3 set, plus: A→B→A staff edits mint revision 3 (never collide with
+revision 1); claim-time DTO binding closes the stale-generation window;
+conditional-version write closes the stamp race; single-item model overruns
+survive via in-flight heartbeat; over-cap snapshots rejected at enqueue with
+named keys logged; sweep crash → stale-heartbeat takeover; unauthenticated
+enrichment traffic rate-limited pre-auth.
+
+## 11. Rollout
+
+1. **PR 0 (upstream — the real bottleneck, §18 A1). Owner decision
+   2026-07-26: a per-campaign "profile questions" block in the Campaign
+   Studio designer** (doesn't exist yet — new Studio feature, spec to
+   follow as its own plan). Admin slides selected questions from a FIXED
+   question library into a campaign's signup funnel; answers are structured
+   choices (never free text) that map deterministically to taxonomy keys.
+   Shawn's launch set: annual income range (`finance.annual_income_band` —
+   new key), "Do you have a pet?" (`household.pets`), "Do you have
+   children?" (`family.children`, partial), expected retirement age
+   (`finance.retirement_age_band` — new key), + language preference
+   (`identity.preferred_language`). Without this the pipeline automates an
+   empty pipe (prod 2026-07-26: taxonomy coverage of existing data = ONE
+   key, `birth_year_band`).
+2. **PR 1** — migration 089 (owned-transaction DDL + catalog guards), models,
+   taxonomy, resolver, mapper + outbox + revision counters (home:
+   `prospects.enrichmentRevision` for the form artifact; per-attempt token
+   counter for screening) + staff-edit choke point + quiz factKey save/map
+   validation, fence helper, relink bump, erasure cascade (+ job-payload
+   nulling), tests. Dark. Ship soon regardless of volume — carries the live
+   screeningMetadata erasure fix.
+3. **PR 2** — routes (claim/renew/complete/status + two-stage limiter),
+   worker + launchd, scoring + aggregator + configs, sweep + runs fence +
+   backfill mode. Flag off. **Volume gate:** build when ≥50 transcript
+   artifacts exist OR PR 0 questions are live and flowing. v1 QA loop =
+   review EVERY LLM-extracted fact weekly (feasible for months at current
+   volume), not spot-checks.
+4. **PR 3** — People UI (People directory is LIVE since 07-26 — extends the
+   live `/api/consumers` endpoint; fresh origin/main worktree). **Density
+   gate for the score column:** median scoreable consumer has ≥2 assessed
+   components; facts panel + summary can ship ahead of the score. Breakdown
+   leads the UI; the number follows. Shawn calibrates scoring-config v1
+   against his own closing intuition before agents see it (§18 A3).
+5. Flip flag (restart), backfill mode, first full run, review, announce.
+
+Preconditions: install Ollama + pull the model on the Mac (M5 Pro/48 GB —
+verified ample, 2026-07-26); `pmset` wake schedule or accept
+queue-tolerated skipped nights.
+
+Env unchanged.
+
+## 12. Testing
+
+V3 list, plus: A→B→A revision tests (incl. omitted keys + event times);
+claim-time DTO-hash mismatch → stale; completion conditional-version race;
+bump-upsert on first-time consumer; leadStatus-edit bumps; entailment
+predicate table (exact vs lower-bound dependants, lifeStage derivation
+match, server-derived triggers); snapshot minimization + cap; erasure nulls
+done-job payloads; sweep takeover on stale heartbeat + owner-token fencing;
+repair-scan budget + cursor resume; fresh-scoped collection edges (§3.4);
+synth A→B→A re-enqueue convergence; rev2-before-rev1 rejected as stale;
+same-revision pipeline upgrade supersedes omitted keys; zero-claim
+activation; bad keys hit the small IP cap while a valid worker exceeds it;
+synth-job `lastError` nulled on erasure.
+
+## 13. Questions
+
+**Resolved:** failed-screening extraction; children array + complete flag;
+nightly cadence; evidence = observation lifetime; `preferred_language`
+definition; triggers server-derived.
+**Open for Shawn before PR 1:** retention numbers (24 mo / 12 mo);
+retraction suppression list (v1 ships without); **PR 0 question set** —
+which fact-bearing questions go into which funnels (language toggle is the
+no-brainer; income/family asks trade conversion for data — Shawn's call
+per funnel).
+
+## 14. Codex round 1 — REWORK (8B/12M), all 20 adopted/adapted
+
+Inlined as [R1 #n]; full log in git history (v2).
+
+## 15. Codex round 2 — REWORK (6B/9M/1m), all adopted
+
+Inlined as [R2 #n]; full log in git history (v3). Architecture + capture
+outbox confirmed feasible.
+
+## 16. Codex round 3 — REWORK (5B/8M), all adopted
+
+| # | Finding | Disposition |
+|---|---|---|
+| 1 | CAS doesn't bind output to the DTO that produced it (A→B→A at claim/complete) | **Adopted** — claim rebuilds DTO under the fence and only hands it out if hash = job.inputHash; completion re-verifies + conditional write (§6.3). |
+| 2 | inputVersion stamp race; bump list missing prospect lifecycle fields; non-upsert bump | **Adopted** — profile-row lock + `WHERE inputVersion = V` write; bump = upsert; DTO field list enumerated with leadStatus/conversion/delete choke points (§6.3). |
+| 3 | Content hash isn't revision identity under A→B→A | **Adopted** — monotonic `sourceRevisionId` minted by source mutation txns; content hash demoted to integrity (§3.1, §3.3). |
+| 4 | Map-payload PII survives erasure; snapshot unbounded | **Adopted** — minimized snapshot, 8 KB cap; erasure nulls payloads of ALL job statuses; synthesis jobs carry no DTO (§3.3, §9). |
+| 5 | Entailment not implementable from stated claim types | **Adopted** — per-claim predicate table; exact counts need complete baselines else lower-bound; lifeStage server-derivable; triggers server-derived; languages defined (§6.4). |
+| 6 | Partial uniques undermined by NULLs / missing version dims | **Adopted** — kind/source-aware NOT-NULL CHECKs; `pipelineVersion` defined as the composite semantic version (§3.1, §3.3). |
+| 7 | Renewal doesn't cover a single slow item | **Adopted** — in-flight 5-min heartbeat; renewal failure aborts the item (§3.3). |
+| 8 | Collection resolution not fresh-scoped/total; future-dated timestamps | **Adopted** — fresh-scoped everywhere, tuple-sorted first-wins partials, canonical ordering, 24 h skew clamp (§3.4). |
+| 9 | Sweep-runs row isn't a fence | **Adopted** — unique runDateSgt + status + ownerToken + heartbeat + stale takeover (§7.3). |
+| 10 | Repair scan unbounded | **Adopted** — durable cursor + row/time budget + rotation; backfill = separate mode (§7.3, §5). |
+| 11 | Limiter carve-out leaves invalid creds unlimited / raw-token keying | **Adopted** — pre-auth IP bucket stays; post-auth generous limiter keyed on constant key ID (§6.2). |
+| 12 | Migration runner isn't atomic | **Adopted** — migration owns one explicit transaction for all DDL + catalog guards (§3, §11). |
+| 13 | Quiz factKey save-validation doesn't exist in repo | **Adopted** — reclassified as NEW PR 1 deliverable in the clamp; invalid legacy configs logged + skipped (§2, §5). |
+
+## 17. Codex round 4 — REWORK (2B/1M/1m), all adopted
+
+All five R3 blockers verified closed; "no other wrong-behavior findings";
+no architectural reopening. The four residuals:
+
+| # | Finding | Disposition |
+|---|---|---|
+| 1 | Done synth jobs block A→B→A re-enqueue (unique includes done, 30-day retention) | **Adopted** — synth unique restricted to pending/leased; replay validated by job id + lease token; `stale` added to status enum (§3.3). |
+| 2 | Revision activation not monotonic / pipeline-replacement-safe; zero-claim results leave no "latest" trace | **Adopted** — activation gated on artifact-current revision + server-current pipeline (else stale); supersede-all-prior incl. same-revision older-pipeline rows; zero-claim results activate (§3.1, §3.4). |
+| 3 | Pre-auth global limiter composes to the minimum — worker capped at 200/15 min anyway | **Adopted** — full global exemption; route-local failed-auth IP bucket + worker-key-ID budget (§6.2). |
+| 4 | Erasure job scope ambiguous — synth jobs are consumer-subject; lastError carries text | **Adopted** — both subject addressings, every status, lastError included (§9). |
+
+## 18. Claude adversarial review (Fable 5, 2026-07-26) — product/ops axes Codex was scoped away from
+
+Protocol machinery accepted as-is (5-round Codex convergence stands).
+Verdict on the product layer: **APPROVE-WITH-CHANGES** — all folded into §11.
+
+Grounding data (prod, 2026-07-26): 129 consumers, 6 repeat signups (0 with
+3+), 2 screening transcripts, 0 quiz submissions, `demographics` = exactly
+`{dateOfBirth, age}` on 134/137 prospects.
+
+| # | Finding | Resolution |
+|---|---|---|
+| A1 | **Score inputs are never collected.** Market fit reads `preferred_language`/`ethnicity`; NO live funnel captures either (nor income/marital/children/property). Taxonomy coverage of existing data = 1 of 18 keys. Built as-specced, ~all 129 consumers score NULL and summaries are husks. | **PR 0 added** (§11): fact-bearing questions into live funnels — the actual bottleneck is upstream collection, not downstream plumbing. "Form locale" removed as a language source (doesn't exist on redeem.sg). |
+| A2 | No volume gates — worker/queue infra could ship against 2 artifacts. | Volume gate on PR 2 (≥50 artifacts or PR 0 live), density gate on PR 3's score column; PR 1 ships early regardless (carries the erasure fix). |
+| A3 | Invented weights + 4 outcome labels = authoritative-looking astrology; risk of steering agent effort wrongly. | Breakdown-first UI; Shawn calibrates config v1 (he IS ground truth at this scale); score-vs-outcome logging from day one. |
+| A4 | Ollama not installed; lid-closed Mac runs nothing at 4 a.m.; no fact-precision gate before agent exposure. | Preconditions block in §11; queue tolerates skipped nights by design (credit); v1 QA = review ALL extracted facts weekly while volume permits. |
+| A5 | Pins: revision-counter home unstated; `User:` line-slicing may drop multi-line turns; People endpoint now LIVE (#278/#279). | Counter homes named in §11 PR 1; slice on prefix boundaries not lines; PR 3 language updated. |


### PR DESCRIPTION
## What

Step 1 of the consumer-profile-enrichment build (plan: `docs/plans/consumer-profile-enrichment.md` — **APPROVED** after 5 adversarial Codex rounds + a Claude product-layer review; every finding's disposition is logged in the plan §14–§18).

Ships **dark**: no routes, no LLM calls, no scoring. What lands:

- **Migration 091** (one owned transaction, catalog-guarded — the runner itself is not atomic): `consumer_observations` (append-only, prospect-anchored, revision-identified fact ledger), `consumer_profiles` (inputVersion dirty-discovery), `enrichment_jobs` (durable queue, kind-scoped partial uniques, lease columns), `enrichment_scoring_configs`, `enrichment_sweep_runs`, and `prospects.enrichmentRevision`.
- **Fact taxonomy v1** (18 allowlisted keys incl. Shawn's PR 0 question set) + **resolveCurrentFacts** — fresh-window total comparator, collection baseline/augment/dedupe, supersession semantics. Property-tested.
- **Deterministic mapper**: map jobs with snapshots frozen at enqueue, written INSIDE the capture transaction (outbox — crash-safe); post-commit drain; staff demographics edits mint artifact revisions whose activation supersedes all prior rows (A→B→A safe, zero-fact snapshots still supersede); quiz `factKey` mappings validated at campaign save (clamp) and again at map time (server-scored answers only).
- **Relink-aware write fence** (owner-recheck + retry — the spine reconciler relinks prospects without locking consumers) + input bumps on relinks (both sides), lead-status edits, prospect deletion.
- **Erasure**: closes the pre-existing `screeningMetadata`/`screeningActiveCallId` PII gap (transcripts survived erasure until now) and cascades enrichment — observations + profile deleted, jobs cancelled with payload/lastError nulled across every status and both subject addressings.

## Tests

- 3 new unit suites (49 tests): taxonomy matrix, resolver precedence/property tests, snapshot purity (no contact data ever enters a job payload).
- `consumerEnrichment.test.js` integration (7): outbox → drain → observations; revision supersession incl. cleared-DOB; stale-revision gate; delete cascade; full erasure cascade incl. bump-can't-resurrect; post-erasure drain cancellation; relink dirties both sides.
- Local CI mirror fully green: unit 1798 · integration 2528 (126 suites) · migrations 30.

## What this does NOT do (by design)

PR 2 = enrichment routes + Ollama worker + scoring engine (volume-gated: ≥50 transcript artifacts or PR 0 questions live). PR 3 = People-page UI (density-gated). PR 0 = Studio profile-questions block (spec next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFPDaSG4m1LM6CDrLMVaRu