### PR TITLE
feat(enrichment): PR 0 — Studio profile questions + artifact-scoped mapper v1.1

### DIFF
--- a/backend/scripts/remap-observations.mjs
+++ b/backend/scripts/remap-observations.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * Enrichment remap — re-derive mapper observations for the EXISTING
+ * population at the CURRENT pipeline version
+ * (docs/plans/studio-profile-questions.md §5.3).
+ *
+ * Bumping MAPPER_PIPELINE_VERSION creates no work by itself (the nightly
+ * sweep is PR 2); this script is the explicit, observable backfill:
+ *
+ *   node scripts/remap-observations.mjs [--dry-run] [--batch=200]
+ *
+ * Design (Codex PR0 R2 #5):
+ * - FROZEN COHORT: a (createdAt, id) watermark is fixed up front; only
+ *   prospects at-or-before it are enumerated. Post-watermark captures
+ *   self-enqueue at the new version anyway.
+ * - COHORT-SCOPED ACCOUNTING: only jobs THIS RUN inserted are counted —
+ *   drainMapJobs claims any pending map job, so raw drain counts would
+ *   swallow live capture traffic.
+ * - Quiz artifacts: NEVER remapped from live definitions (Studio edits
+ *   quizzes without minting versions — that could mint facts the person
+ *   never stated). Form/profile sections re-derive from the prospect row;
+ *   quiz stays whatever its frozen capture-time job produced. Prospects
+ *   whose quiz facts cannot be re-proven are reported as skipped.
+ * - Idempotent for live-unique statuses (pending/leased/done); previously
+ *   stale/dead/cancelled jobs re-enqueue by design (they left the unique).
+ * - PRECONDITION: every serving instance runs artifact-aware code (the 092
+ *   expand step is deployed) before this starts.
+ *
+ * Requires ENRICHMENT_MAP_ARTIFACT_JOBS=true (the artifact-scoped writes
+ * flag) — refuses to run otherwise.
+ */
+import { sequelize } from '../src/database/connection.js';
+import '../src/models/index.js';
+import {
+  buildFactSnapshot, enqueueMapJobsTx, drainMapJobs, artifactJobsEnabled,
+  MAPPER_PIPELINE_VERSION,
+} from '../src/services/factMapperService.js';
+import { getProfileQuestion, resolveAnswer } from '../src/utils/profileQuestionLibrary.js';
+import { logger } from '../src/utils/logger.js';
+
+/**
+ * Re-derive profile facts from the durable canonical answer ids
+ * (sourceMetadata.profileAnswers). SAFE to re-resolve — the profile library
+ * is code-fixed, unlike Studio quiz definitions (§5.2): flag-off captures
+ * during the deploy window stored answers without minting facts, and this
+ * is where those catch up.
+ */
+function profileFactsFrom(sourceMetadata) {
+  const answers = sourceMetadata?.profileAnswers;
+  if (!answers || typeof answers !== 'object') return undefined;
+  const facts = [];
+  for (const [qid, provided] of Object.entries(answers)) {
+    const q = getProfileQuestion(qid);
+    if (!q) continue;
+    const value = resolveAnswer(qid, provided);
+    if (value) facts.push({ key: q.factKey, value });
+  }
+  return facts.length ? facts : undefined;
+}
+
+const args = process.argv.slice(2);
+const DRY = args.includes('--dry-run');
+const BATCH = Number((args.find((a) => a.startsWith('--batch=')) || '').split('=')[1]) || 200;
+
+async function main() {
+  if (!artifactJobsEnabled()) {
+    console.error('ENRICHMENT_MAP_ARTIFACT_JOBS is not true — flip the flag (post-deploy) first.');
+    process.exit(1);
+  }
+
+  // Watermark: freeze the cohort before any work.
+  const [[wm]] = await sequelize.query(
+    'SELECT max("createdAt") AS ts FROM prospects'
+  );
+  const watermark = wm?.ts;
+  if (!watermark) {
+    console.log('No prospects — nothing to remap.');
+    process.exit(0);
+  }
+  console.log(`[remap] pipeline=${MAPPER_PIPELINE_VERSION} watermark=${new Date(watermark).toISOString()} dryRun=${DRY}`);
+
+  const insertedJobIds = new Set();
+  let cursor = { createdAt: new Date(0).toISOString(), id: '00000000-0000-0000-0000-000000000000' };
+  let scanned = 0;
+  let enqueued = 0;
+  let quizSkipped = 0;
+
+  for (;;) {
+    const [rows] = await sequelize.query(
+      `SELECT id, "createdAt", demographics, "sourceMetadata", "enrichmentRevision"
+         FROM prospects
+        WHERE ("createdAt", id) > (:ts, :id) AND "createdAt" <= :wm
+        ORDER BY "createdAt", id
+        LIMIT :batch`,
+      { replacements: { ts: cursor.createdAt, id: cursor.id, wm: watermark, batch: BATCH } }
+    );
+    if (!rows.length) break;
+
+    for (const p of rows) {
+      scanned += 1;
+      // Quiz: frozen-payload-only (§5.2). If the prospect has server-scored
+      // quiz answers, its capture-time job already carries the resolved
+      // facts; we do NOT rebuild them here — and report that we didn't.
+      if (p.sourceMetadata?.quiz?.scoredBy === 'server') quizSkipped += 1;
+
+      const snapshot = buildFactSnapshot({
+        demographics: p.demographics || {},
+        profileFacts: profileFactsFrom(p.sourceMetadata),
+      });
+      if (DRY) continue;
+      await sequelize.transaction(async (t) => {
+        const ids = await enqueueMapJobsTx(t, {
+          prospectId: p.id,
+          formRevision: Number(p.enrichmentRevision || 1),
+          snapshot,
+        });
+        for (const id of ids) insertedJobIds.add(id);
+        enqueued += ids.length;
+      });
+    }
+
+    const last = rows[rows.length - 1];
+    cursor = { createdAt: new Date(last.createdAt).toISOString(), id: last.id };
+    console.log(`[remap] scanned=${scanned} enqueued=${enqueued}`);
+
+    if (!DRY) await drainMapJobs({ limit: BATCH });
+  }
+
+  // Drain to quiet, then account for OUR jobs only.
+  if (!DRY) {
+    for (let i = 0; i < 50; i += 1) {
+      const res = await drainMapJobs({ limit: 50 });
+      if (res.claimed === 0) break;
+    }
+  }
+
+  let outcome = {};
+  if (insertedJobIds.size) {
+    const [counts] = await sequelize.query(
+      'SELECT status, count(*)::int AS n FROM enrichment_jobs WHERE id IN (:ids) GROUP BY status',
+      { replacements: { ids: [...insertedJobIds] } }
+    );
+    outcome = Object.fromEntries(counts.map((r) => [r.status, r.n]));
+  }
+
+  console.log('[remap] COMPLETE', JSON.stringify({
+    scanned,
+    enqueuedByThisRun: insertedJobIds.size,
+    outcomesForThisRun: outcome,
+    quizArtifactsLeftFrozen: quizSkipped,
+    dryRun: DRY,
+  }, null, 2));
+  await sequelize.close();
+}
+
+main().catch((err) => {
+  logger.error('[remap] failed', { error: err?.message || String(err) });
+  console.error(err);
+  process.exit(1);
+});

--- a/backend/src/database/migrations/092-map-jobs-artifact-scope.js
+++ b/backend/src/database/migrations/092-map-jobs-artifact-scope.js
@@ -1,0 +1,68 @@
+/**
+ * 092 — Artifact-scoped map jobs, EXPAND step
+ * (docs/plans/studio-profile-questions.md §5.1, Codex PR0 R2 #1 / R3).
+ *
+ * Rolling deploys run old + new instances together, and legacy map jobs of
+ * every status carry sourceArtifactId NULL with possibly COMBINED
+ * form+quiz payloads. So this migration only EXPANDS:
+ *   - chk_ejobs_kind now accepts BOTH map shapes (legacy-null and
+ *     artifact-bearing);
+ *   - the legacy map unique is re-scoped to NULL-artifact rows;
+ *   - an artifact-scoped unique is added for the new shape.
+ * Writers keep emitting the legacy shape until
+ * ENRICHMENT_MAP_ARTIFACT_JOBS flips post-deploy (restart), so old
+ * processors never see a new-shape job. The CONTRACT step (require
+ * artifact on non-terminal map jobs, drop the legacy unique) is a later
+ * migration, after live legacy jobs drain to zero.
+ *
+ * Idempotent + owned transaction, like 091.
+ */
+export async function up(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+  await sequelize.transaction(async (t) => {
+    const q = (sql) => sequelize.query(sql, { transaction: t });
+
+    await q('ALTER TABLE enrichment_jobs DROP CONSTRAINT IF EXISTS chk_ejobs_kind');
+    await q(`DO $$ BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_ejobs_kind') THEN
+        ALTER TABLE enrichment_jobs ADD CONSTRAINT chk_ejobs_kind CHECK (
+          (kind = 'map' AND "subjectProspectId" IS NOT NULL AND "subjectConsumerId" IS NULL
+            AND "sourceRevisionId" IS NOT NULL AND "sourceContentHash" IS NOT NULL
+            AND "inputHash" IS NULL AND "promptVersion" IS NULL)
+          OR
+          (kind = 'extract' AND "subjectProspectId" IS NOT NULL AND "subjectConsumerId" IS NULL
+            AND "sourceArtifactId" IS NOT NULL AND "sourceRevisionId" IS NOT NULL
+            AND "sourceContentHash" IS NOT NULL AND "inputHash" IS NULL
+            AND "promptVersion" IS NULL AND payload IS NULL)
+          OR
+          (kind = 'synthesize' AND "subjectConsumerId" IS NOT NULL AND "subjectProspectId" IS NULL
+            AND "inputHash" IS NOT NULL AND "promptVersion" IS NOT NULL
+            AND "sourceArtifactId" IS NULL AND "sourceRevisionId" IS NULL
+            AND "sourceContentHash" IS NULL AND payload IS NULL)
+        );
+      END IF;
+    END $$`);
+
+    // Legacy unique re-scoped to NULL-artifact rows (partition, no overlap).
+    await q('DROP INDEX IF EXISTS uq_ejobs_map');
+    await q(`CREATE UNIQUE INDEX IF NOT EXISTS uq_ejobs_map
+      ON enrichment_jobs (kind, "subjectProspectId", "sourceRevisionId", "pipelineVersion")
+      WHERE kind = 'map' AND "sourceArtifactId" IS NULL AND status IN ('pending','leased','done')`);
+
+    await q(`CREATE UNIQUE INDEX IF NOT EXISTS uq_ejobs_map_artifact
+      ON enrichment_jobs (kind, "subjectProspectId", "sourceArtifactId", "sourceRevisionId", "pipelineVersion")
+      WHERE kind = 'map' AND "sourceArtifactId" IS NOT NULL AND status IN ('pending','leased','done')`);
+  });
+}
+
+export async function down(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+  await sequelize.transaction(async (t) => {
+    const q = (sql) => sequelize.query(sql, { transaction: t });
+    await q('DROP INDEX IF EXISTS uq_ejobs_map_artifact');
+    await q('DROP INDEX IF EXISTS uq_ejobs_map');
+    await q(`CREATE UNIQUE INDEX IF NOT EXISTS uq_ejobs_map
+      ON enrichment_jobs (kind, "subjectProspectId", "sourceRevisionId", "pipelineVersion")
+      WHERE kind = 'map' AND status IN ('pending','leased','done')`);
+  });
+}

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -280,6 +280,24 @@ export const schemas = {
       })).max(50).optional(),
       result: Joi.object().optional()
     }).optional(),
+    // Enrichment profile questions (studio-profile-questions §5.4 step 1).
+    // Nested-strict by design: the route's global stripUnknown would
+    // otherwise silently REMOVE a pattern-failed key instead of 400ing
+    // (Codex PR0 R2 #6). Keys are question ids; values are a single option
+    // id or a bounded option-id array (multi questions). Structural abuse
+    // ⇒ 400 (for requests the rate limiter admits — limiter runs first).
+    // Campaign-scoped semantic validation happens in prospectService.
+    profileAnswers: Joi.object()
+      .pattern(
+        Joi.string().pattern(/^[a-z][a-z0-9_]{0,31}$/),
+        Joi.alternatives().try(
+          Joi.string().max(32),
+          Joi.array().items(Joi.string().max(32)).max(8).unique()
+        )
+      )
+      .max(5)
+      .unknown(false)
+      .optional(),
     // Ad attribution (IG/TikTok). Captured from the landing URL, stashed in
     // sourceMetadata.utm for per-ad-set reporting. Previously dropped (the
     // schema rejected unknown keys), so these were lost before this change.

--- a/backend/src/models/EnrichmentJob.js
+++ b/backend/src/models/EnrichmentJob.js
@@ -71,7 +71,13 @@ const EnrichmentJob = sequelize.define('EnrichmentJob', {
       unique: true,
       fields: ['kind', 'subjectProspectId', 'sourceRevisionId', 'pipelineVersion'],
       name: 'uq_ejobs_map',
-      where: { kind: 'map', status: { [Op.in]: ['pending', 'leased', 'done'] } }
+      where: { kind: 'map', sourceArtifactId: null, status: { [Op.in]: ['pending', 'leased', 'done'] } }
+    },
+    {
+      unique: true,
+      fields: ['kind', 'subjectProspectId', 'sourceArtifactId', 'sourceRevisionId', 'pipelineVersion'],
+      name: 'uq_ejobs_map_artifact',
+      where: { kind: 'map', sourceArtifactId: { [Op.ne]: null }, status: { [Op.in]: ['pending', 'leased', 'done'] } }
     },
     {
       unique: true,

--- a/backend/src/services/factMapperService.js
+++ b/backend/src/services/factMapperService.js
@@ -6,28 +6,44 @@ import { validateFact, birthYearToBand, clampSourceEventAt, TAXONOMY_VERSION } f
 import { logger } from '../utils/logger.js';
 
 /**
- * Deterministic fact mapper — structured capture data → consumer_observations
- * (docs/plans/consumer-profile-enrichment.md §5). No AI anywhere in this file.
+ * Deterministic fact mapper v1.1 — structured capture data →
+ * consumer_observations (consumer-profile-enrichment §5 +
+ * studio-profile-questions §5.1–§5.2). No AI anywhere in this file.
  *
- * Durability shape (Codex R1 #5): capture writes a `map` JOB inside the
- * capture transaction (the outbox — crash between commit and drain loses
- * nothing), an opportunistic post-commit drain processes it, and the nightly
- * sweep re-drains anything missed. The Redeem Ops capture hook is untouched.
- *
- * Snapshot semantics (Codex R3-era #10): facts are normalized + validated AT
- * ENQUEUE and frozen into the job payload — the mapper never reads mutable
- * live rows, so a staff edit between enqueue and drain cannot smuggle new
- * data under an old revision. Edits mint prospects.enrichmentRevision++ and
- * a NEW job; activation supersedes the old revision's rows (§3.1). The
- * payload holds only taxonomy-relevant normalized values (never contact
- * data), capped at 8 KB serialized.
+ * v1.1 (Codex PR0 rounds 1–3):
+ * - Map work is ARTIFACT-SCOPED: one job per (form|quiz|profile) artifact,
+ *   each with its own revision gate — a demographics edit can no longer
+ *   supersede quiz/profile facts, and a pending quiz job survives a form
+ *   revision bump. Revisions: form = prospects.enrichmentRevision;
+ *   quiz/profile = pinned 1 (capture-immutable in this release — a future
+ *   edit surface must mint per-artifact counters first).
+ * - Deploy choreography: artifact-scoped WRITES sit behind
+ *   ENRICHMENT_MAP_ARTIFACT_JOBS (default OFF). Until the flag flips
+ *   (post-deploy restart, once old instances are gone), writers emit the
+ *   LEGACY combined shape; this processor handles BOTH — a legacy job's
+ *   payload is split per artifact, never single-artifact-activated.
+ * - Quiz wire shape fixed: real Studio quizzes are steps[].questions[] and
+ *   real submissions are [{qid, value}] — the flat shapes the v1 mapper
+ *   read never occur in production data.
+ * - Quiz mapping is FROZEN at enqueue: the job payload carries the resolved
+ *   facts; nothing ever re-reads the live quiz definition after capture
+ *   (Studio edits quizzes without minting versions — remapping old answers
+ *   against today's definition could mint facts the person never stated).
  */
 
 export const MAPPER_PIPELINE = 'mapper';
-// COMPOSITE semantic version (R3 #6): mapper code + taxonomy in one string.
-export const MAPPER_PIPELINE_VERSION = `mapper/v1+tax-${TAXONOMY_VERSION}`;
+// COMPOSITE semantic version (code + taxonomy) — R3 #6 / PR0 R1 #8.
+export const MAPPER_PIPELINE_VERSION = `mapper/v1.1+tax-${TAXONOMY_VERSION}`;
 const MAX_SNAPSHOT_BYTES = 8 * 1024;
 const INTERNAL_LEASE_MINUTES = 5;
+
+export const ARTIFACT_KINDS = ['form', 'quiz', 'profile'];
+const PINNED_REVISION_ARTIFACTS = new Set(['quiz', 'profile']);
+
+/** Artifact-scoped writes flag — read at call time (restart-to-flip). */
+export function artifactJobsEnabled() {
+  return process.env.ENRICHMENT_MAP_ARTIFACT_JOBS === 'true';
+}
 
 /** Canonical JSON — stable key order at every depth (hash stability). */
 export function canonicalJson(x) {
@@ -40,100 +56,208 @@ export function canonicalJson(x) {
 
 export const sha256 = (s) => crypto.createHash('sha256').update(s).digest('hex');
 
-/**
- * Build the minimized, fully-normalized fact snapshot for a prospect-shaped
- * object. Returns { facts: [{ key, value, artifact: 'form'|'quiz' }] } —
- * every entry already taxonomy-valid; invalid candidates are skipped + logged
- * (never block capture over a bad mapping).
- *
- * Sources today: demographics.dateOfBirth → identity.birth_year_band.
- * Quiz answers map ONLY when server-scored (scoredBy === 'server' — Codex
- * R1 #12) AND the campaign quiz definition carries per-question factKey +
- * factValues (answerId → taxonomy value object); that authoring surface is
- * PR 0 — the contract ships here so the mapper is ready the day a campaign
- * uses it.
- */
-export function buildFactSnapshot({ demographics, sourceMetadata, quizDefinition } = {}) {
-  const facts = [];
+/** Real Studio quizzes nest questions in steps[]; accept legacy flat too. */
+export function flattenQuizQuestions(quizDefinition) {
+  if (!quizDefinition) return [];
+  if (Array.isArray(quizDefinition.steps)) {
+    return quizDefinition.steps.flatMap((s) => (Array.isArray(s?.questions) ? s.questions : []));
+  }
+  return Array.isArray(quizDefinition.questions) ? quizDefinition.questions : [];
+}
 
-  const dob = demographics?.dateOfBirth;
-  if (dob) {
-    const year = new Date(dob).getFullYear();
-    const band = birthYearToBand(year);
-    if (band) {
-      const value = { v: band };
-      const check = validateFact('identity.birth_year_band', value);
-      if (check.ok) facts.push({ key: 'identity.birth_year_band', value, artifact: 'form' });
+/** Real submissions are [{qid, value}]; accept a plain object map too. */
+export function indexQuizAnswers(answers) {
+  const map = new Map();
+  if (Array.isArray(answers)) {
+    for (const a of answers) {
+      if (a && a.qid !== undefined && a.value !== undefined) map.set(String(a.qid), a.value);
     }
+  } else if (answers && typeof answers === 'object') {
+    for (const [k, v] of Object.entries(answers)) map.set(String(k), v);
+  }
+  return map;
+}
+
+// Monthly SGD from the free-entry salary field → finance.income_band.
+function incomeToBand(raw) {
+  // Strip formatting only ($, commas, spaces) — a stray minus must stay a
+  // minus, not vanish into a positive number.
+  const n = Number(String(raw).replace(/[,$\s]/g, ''));
+  if (!Number.isFinite(n) || n <= 0 || n > 1_000_000) return null;
+  if (n < 3000) return '<3k';
+  if (n < 6000) return '3-6k';
+  if (n < 10000) return '6-10k';
+  if (n < 15000) return '10-15k';
+  return '>15k';
+}
+
+/**
+ * Build the minimized, fully-normalized, SECTION-KEYED fact snapshot.
+ * A section PRESENT (even with zero facts) will activate + supersede its
+ * artifact; a section ABSENT means "not re-observed — leave that artifact
+ * alone". Returns { sections: { form?, quiz?, profile? } } where each
+ * section is { facts: [{ key, value }] }. Every fact is already
+ * taxonomy-valid; invalid candidates are skipped (never block capture).
+ *
+ * - form: always present when demographics were observed (capture + edits).
+ * - quiz: present iff a server-scored submission existed at capture —
+ *   resolution happens HERE, at enqueue, freezing the mapping.
+ * - profile: present iff capture validation produced accepted facts
+ *   (studio-profile-questions §5.4 — pre-resolved [{key, value}]).
+ */
+export function buildFactSnapshot({ demographics, sourceMetadata, quizDefinition, profileFacts } = {}) {
+  const sections = {};
+
+  // form — present whenever a demographics object was observed (an empty
+  // one still re-observes the artifact: a cleared DOB must supersede).
+  if (demographics && typeof demographics === 'object') {
+    const facts = [];
+    if (demographics.dateOfBirth) {
+      const band = birthYearToBand(new Date(demographics.dateOfBirth).getFullYear());
+      if (band && validateFact('identity.birth_year_band', { v: band }).ok) {
+        facts.push({ key: 'identity.birth_year_band', value: { v: band } });
+      }
+    }
+    if (demographics.income !== undefined && demographics.income !== null && demographics.income !== '') {
+      const band = incomeToBand(demographics.income);
+      if (band && validateFact('finance.income_band', { v: band }).ok) {
+        facts.push({ key: 'finance.income_band', value: { v: band } });
+      }
+    }
+    sections.form = { facts };
   }
 
   const quiz = sourceMetadata?.quiz;
-  if (quiz?.scoredBy === 'server' && Array.isArray(quizDefinition?.questions)) {
-    const answers = quiz.submission?.answers || quiz.answers || {};
-    for (const q of quizDefinition.questions) {
-      if (!q?.factKey || !q?.id) continue;
-      const answerId = answers[q.id];
-      if (answerId === undefined || answerId === null) continue;
-      const value = q.factValues?.[String(answerId)];
+  if (quiz?.scoredBy === 'server' && quizDefinition?.enabled) {
+    const answerByQid = indexQuizAnswers(quiz.answers);
+    const facts = [];
+    for (const q of flattenQuizQuestions(quizDefinition)) {
+      const qid = q?.qid ?? q?.id;
+      if (!q?.factKey || qid === undefined) continue;
+      const answered = answerByQid.get(String(qid));
+      if (answered === undefined || answered === null) continue;
+      const value = q.factValues?.[String(answered)];
       if (!value) continue;
       const check = validateFact(q.factKey, value);
       if (!check.ok) {
-        logger.warn('[factMapper] invalid quiz factKey mapping skipped', {
-          factKey: q.factKey, error: check.error,
-        });
+        logger.warn('[factMapper] invalid quiz factKey mapping skipped', { factKey: q.factKey, error: check.error });
         continue;
       }
-      facts.push({ key: q.factKey, value, artifact: 'quiz' });
+      facts.push({ key: q.factKey, value });
     }
+    sections.quiz = { facts };
   }
 
-  return { facts };
+  if (Array.isArray(profileFacts) && profileFacts.length) {
+    const facts = profileFacts.filter((f) => f?.key && validateFact(f.key, f.value).ok)
+      .map((f) => ({ key: f.key, value: f.value }));
+    if (facts.length) sections.profile = { facts };
+  }
+
+  return { sections };
+}
+
+function insertJobSql() {
+  return `INSERT INTO enrichment_jobs
+       (id, kind, "subjectProspectId", "sourceArtifactId", "sourceRevisionId", "sourceContentHash",
+        payload, "taxonomyVersion", "pipelineVersion", status, attempts, "createdAt", "updatedAt")
+     VALUES (:id, 'map', :pid, :artifact, :rev, :hash, :payload::jsonb, :tax, :pv, 'pending', 0, now(), now())
+     ON CONFLICT DO NOTHING
+     RETURNING id`;
 }
 
 /**
- * Outbox: enqueue the map job INSIDE the capture (or edit) transaction.
- * Never throws — savepoint-isolated by the caller pattern; a lost enqueue is
- * healed by the sweep. Empty snapshots enqueue only when revision > 1 (a
- * cleared field must still supersede its old observation — zero-claim
- * activation, §3.1); at capture (revision 1) there is nothing to supersede.
+ * Outbox: enqueue map work INSIDE the capture/edit transaction.
+ * Flag ON  → one artifact-scoped job per PRESENT section.
+ * Flag OFF → one legacy combined job (deploy-window compatibility —
+ *            old processors may still be running; they must never see the
+ *            new shape).
+ * Zero-fact sections skip at revision 1 (nothing to supersede yet);
+ * at revision > 1 they enqueue — a cleared field must kill its old fact.
  */
-export async function enqueueMapJobTx(t, { prospectId, enrichmentRevision, snapshot }) {
-  const payloadJson = canonicalJson(snapshot);
-  if (Buffer.byteLength(payloadJson, 'utf8') > MAX_SNAPSHOT_BYTES) {
-    logger.error('[factMapper] snapshot over cap — not enqueued', { prospectId });
-    return null;
-  }
-  if (!snapshot.facts.length && enrichmentRevision <= 1) return null;
+export async function enqueueMapJobsTx(t, { prospectId, formRevision = 1, snapshot }) {
+  const sections = snapshot?.sections || {};
+  const inserted = [];
 
-  const [rows] = await sequelize.query(
-    `INSERT INTO enrichment_jobs
-       (id, kind, "subjectProspectId", "sourceRevisionId", "sourceContentHash",
-        payload, "taxonomyVersion", "pipelineVersion", status, attempts, "createdAt", "updatedAt")
-     VALUES (:id, 'map', :pid, :rev, :hash, :payload::jsonb, :tax, :pv, 'pending', 0, now(), now())
-     ON CONFLICT DO NOTHING
-     RETURNING id`,
-    {
+  if (!artifactJobsEnabled()) {
+    // Deploy-window shape: OLD processors may claim this job, and they only
+    // know form/quiz buckets — profile-tagged facts would be misattributed
+    // to the form artifact (the exact supersession bug class v1.1 kills).
+    // So legacy-shaped jobs NEVER carry profile facts; the canonical answer
+    // ids are already durable in sourceMetadata.profileAnswers, and the
+    // post-flip remap re-derives them safely (the profile library is
+    // code-fixed — unlike Studio quizzes, re-resolution cannot drift).
+    const facts = ['form', 'quiz'].flatMap((kind) =>
+      (sections[kind]?.facts || []).map((f) => ({ ...f, artifact: kind })));
+    if (!facts.length && formRevision <= 1) return inserted;
+    const payload = { facts };
+    const payloadJson = canonicalJson(payload);
+    if (Buffer.byteLength(payloadJson, 'utf8') > MAX_SNAPSHOT_BYTES) {
+      logger.error('[factMapper] snapshot over cap — not enqueued', { prospectId });
+      return inserted;
+    }
+    const [rows] = await sequelize.query(insertJobSql(), {
       replacements: {
-        id: randomUUID(),
-        pid: prospectId,
-        rev: enrichmentRevision,
-        hash: sha256(payloadJson),
-        payload: JSON.stringify(snapshot),
-        tax: TAXONOMY_VERSION,
-        pv: MAPPER_PIPELINE_VERSION,
+        id: randomUUID(), pid: prospectId, artifact: null, rev: formRevision,
+        hash: sha256(payloadJson), payload: JSON.stringify(payload),
+        tax: TAXONOMY_VERSION, pv: MAPPER_PIPELINE_VERSION,
       },
       transaction: t,
+    });
+    if (rows?.[0]?.id) inserted.push(rows[0].id);
+    return inserted;
+  }
+
+  for (const kind of ARTIFACT_KINDS) {
+    const section = sections[kind];
+    if (!section) continue; // absent = not re-observed
+    const revision = kind === 'form' ? formRevision : 1;
+    if (!section.facts.length && revision <= 1) continue;
+    const payload = { facts: section.facts };
+    const payloadJson = canonicalJson(payload);
+    if (Buffer.byteLength(payloadJson, 'utf8') > MAX_SNAPSHOT_BYTES) {
+      logger.error('[factMapper] snapshot over cap — section skipped', { prospectId, kind });
+      continue;
     }
-  );
-  return rows?.[0]?.id || null;
+    const [rows] = await sequelize.query(insertJobSql(), {
+      replacements: {
+        id: randomUUID(), pid: prospectId, artifact: `${kind}:${prospectId}`, rev: revision,
+        hash: sha256(payloadJson), payload: JSON.stringify(payload),
+        tax: TAXONOMY_VERSION, pv: MAPPER_PIPELINE_VERSION,
+      },
+      transaction: t,
+    });
+    if (rows?.[0]?.id) inserted.push(rows[0].id);
+  }
+  return inserted;
+}
+
+/** Backward-compat alias used by older call sites/tests (single legacy job). */
+export async function enqueueMapJobTx(t, { prospectId, enrichmentRevision = 1, snapshot }) {
+  // Legacy flat snapshot {facts:[{key,value,artifact}]} → sections.
+  if (snapshot && !snapshot.sections && Array.isArray(snapshot.facts)) {
+    const sections = {};
+    for (const f of snapshot.facts) {
+      const kind = ARTIFACT_KINDS.includes(f.artifact) ? f.artifact : 'form';
+      (sections[kind] ||= { facts: [] }).facts.push({ key: f.key, value: f.value });
+    }
+    if (!sections.form) sections.form = { facts: [] };
+    snapshot = { sections };
+  }
+  const ids = await enqueueMapJobsTx(t, { prospectId, formRevision: enrichmentRevision, snapshot });
+  return ids[0] || null;
+}
+
+/** Expected current revision for an artifact kind (v1: quiz/profile pinned). */
+function expectedRevision(kind, prospect) {
+  return PINNED_REVISION_ARTIFACTS.has(kind) ? 1 : Number(prospect.enrichmentRevision || 1);
 }
 
 /**
- * Revision activation for one artifact family under the fence (§3.1, R4 #2):
- * gate on artifact-current revision + server-current pipeline, supersede ALL
- * other active rows for the artifact (any revision, any pipelineVersion —
- * including keys the new result omits), then insert. Zero-fact results still
- * supersede (a cleared DOB kills the old band).
+ * Revision activation for ONE artifact under the fence (§3.1 parent plan):
+ * supersede every other active mapper row for the artifact (any revision,
+ * any pipelineVersion — including keys the new result omits), then insert.
+ * Zero-fact results still activate.
  */
 async function activateArtifactTx(t, { artifactId, revision, contentHash, prospect, facts, source }) {
   await sequelize.query(
@@ -143,12 +267,8 @@ async function activateArtifactTx(t, { artifactId, revision, contentHash, prospe
         AND pipeline = :pipeline
         AND "supersededAt" IS NULL
         AND ("sourceRevisionId" <> :rev OR "pipelineVersion" <> :pv)`,
-    {
-      replacements: { artifact: artifactId, pipeline: MAPPER_PIPELINE, rev: revision, pv: MAPPER_PIPELINE_VERSION },
-      transaction: t,
-    }
+    { replacements: { artifact: artifactId, pipeline: MAPPER_PIPELINE, rev: revision, pv: MAPPER_PIPELINE_VERSION }, transaction: t }
   );
-
   for (const f of facts) {
     await sequelize.query(
       `INSERT INTO consumer_observations
@@ -160,17 +280,10 @@ async function activateArtifactTx(t, { artifactId, revision, contentHash, prospe
        ON CONFLICT DO NOTHING`,
       {
         replacements: {
-          id: randomUUID(),
-          pid: prospect.id,
-          key: f.key,
-          value: JSON.stringify(f.value),
-          source,
-          artifact: artifactId,
-          rev: revision,
-          hash: contentHash,
+          id: randomUUID(), pid: prospect.id, key: f.key, value: JSON.stringify(f.value),
+          source, artifact: artifactId, rev: revision, hash: contentHash,
           eventAt: clampSourceEventAt(prospect.createdAt),
-          pipeline: MAPPER_PIPELINE,
-          pv: MAPPER_PIPELINE_VERSION,
+          pipeline: MAPPER_PIPELINE, pv: MAPPER_PIPELINE_VERSION,
         },
         transaction: t,
       }
@@ -178,14 +291,15 @@ async function activateArtifactTx(t, { artifactId, revision, contentHash, prospe
   }
 }
 
-/** Process one leased map job to completion (done/stale/dead). */
+const SOURCE_BY_KIND = { form: 'form', quiz: 'quiz', profile: 'form' };
+
+/** Process one leased map job (dual-shape) to done/stale/dead/cancelled. */
 async function processMapJob(job) {
   const finish = (status, lastError = null) =>
     EnrichmentJob.update(
       {
         status,
         lastError,
-        ...(status === 'pending' ? {} : {}),
         ...(status === 'dead' || status === 'pending' ? { attempts: sequelize.literal('attempts + 1') } : {}),
       },
       { where: { id: job.id, leaseToken: job.leaseToken } }
@@ -193,36 +307,49 @@ async function processMapJob(job) {
 
   try {
     const result = await withConsumerFence(job.subjectProspectId, async (t, { prospect, consumer }) => {
-      // Gate (R4 #2): only the artifact-CURRENT revision at the CURRENT
-      // pipeline activates. A late old-revision job can never insert.
-      if (Number(job.sourceRevisionId) !== Number(prospect.enrichmentRevision)
-        || job.pipelineVersion !== MAPPER_PIPELINE_VERSION) {
-        return { outcome: 'stale' };
-      }
+      if (job.pipelineVersion !== MAPPER_PIPELINE_VERSION) return { outcome: 'stale' };
 
-      const snapshot = job.payload || { facts: [] };
-      const byArtifact = new Map([
-        [`form:${prospect.id}`, []],
-        [`quiz:${prospect.id}`, []],
-      ]);
-      for (const f of snapshot.facts || []) {
-        const check = validateFact(f.key, f.value);
-        if (!check.ok) throw Object.assign(new Error(`invalid fact ${f.key}: ${check.error}`), { code: 'INVALID_FACT' });
-        const artifactId = f.artifact === 'quiz' ? `quiz:${prospect.id}` : `form:${prospect.id}`;
-        byArtifact.get(artifactId).push(f);
-      }
-
-      const source = { form: 'form', quiz: 'quiz' };
-      for (const [artifactId, facts] of byArtifact) {
-        const kind = artifactId.startsWith('quiz:') ? 'quiz' : 'form';
+      if (job.sourceArtifactId) {
+        // Artifact-scoped job.
+        const kind = String(job.sourceArtifactId).split(':')[0];
+        if (!ARTIFACT_KINDS.includes(kind)) {
+          throw Object.assign(new Error(`unknown artifact kind ${kind}`), { code: 'INVALID_FACT' });
+        }
+        if (Number(job.sourceRevisionId) !== expectedRevision(kind, prospect)) return { outcome: 'stale' };
+        const facts = (job.payload?.facts || []);
+        for (const f of facts) {
+          const check = validateFact(f.key, f.value);
+          if (!check.ok) throw Object.assign(new Error(`invalid fact ${f.key}: ${check.error}`), { code: 'INVALID_FACT' });
+        }
         await activateArtifactTx(t, {
-          artifactId,
+          artifactId: job.sourceArtifactId,
           revision: Number(job.sourceRevisionId),
           contentHash: job.sourceContentHash,
           prospect,
           facts,
-          source: source[kind],
+          source: SOURCE_BY_KIND[kind],
         });
+      } else {
+        // LEGACY combined job (deploy-window / pre-v1.1 rows): split the
+        // payload per artifact and activate form+quiz families — the legacy
+        // writer always observed both at capture. Never single-artifact.
+        if (Number(job.sourceRevisionId) !== Number(prospect.enrichmentRevision || 1)) return { outcome: 'stale' };
+        const buckets = { form: [], quiz: [] };
+        for (const f of job.payload?.facts || []) {
+          const check = validateFact(f.key, f.value);
+          if (!check.ok) throw Object.assign(new Error(`invalid fact ${f.key}: ${check.error}`), { code: 'INVALID_FACT' });
+          (buckets[f.artifact === 'quiz' ? 'quiz' : 'form']).push({ key: f.key, value: f.value });
+        }
+        for (const kind of ['form', 'quiz']) {
+          await activateArtifactTx(t, {
+            artifactId: `${kind}:${prospect.id}`,
+            revision: Number(job.sourceRevisionId),
+            contentHash: job.sourceContentHash,
+            prospect,
+            facts: buckets[kind],
+            source: SOURCE_BY_KIND[kind],
+          });
+        }
       }
 
       await bumpEnrichmentInputTx(t, consumer?.id || null);
@@ -248,9 +375,10 @@ async function processMapJob(job) {
 }
 
 /**
- * Claim + process pending map jobs (post-commit drain and sweep re-drain).
- * Multi-instance safe: SKIP LOCKED claim to `leased` with a short internal
- * lease; expired internal leases are reclaimed by the sweep like any other.
+ * Claim + process pending map jobs (post-commit drain, remap script, and
+ * the PR 2 sweep). Multi-instance safe (SKIP LOCKED + short internal
+ * lease). Returns per-outcome counts plus the claimed job ids so callers
+ * (the remap script) can do cohort-scoped accounting.
  */
 export async function drainMapJobs({ limit = 20 } = {}) {
   const leaseToken = randomUUID();
@@ -271,11 +399,13 @@ export async function drainMapJobs({ limit = 20 } = {}) {
   );
 
   const outcomes = { done: 0, stale: 0, retry: 0, dead: 0, cancelled: 0 };
+  const jobIds = [];
   for (const row of claimed) {
+    jobIds.push(row.id);
     const outcome = await processMapJob({ ...row, leaseToken });
     if (outcomes[outcome] !== undefined) outcomes[outcome] += 1;
   }
-  return { claimed: claimed.length, ...outcomes };
+  return { claimed: claimed.length, jobIds, ...outcomes };
 }
 
 export { ConsumerObservation, Prospect };

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -46,8 +46,11 @@ import {
 import { recordCaptureConsentEventsTx, canMarketTo } from './consentService.js';
 // Enrichment mapper (docs/plans/consumer-profile-enrichment.md §5): leaf
 // imports only (models + fence + taxonomy) — no cycle back into this module.
-import { buildFactSnapshot, enqueueMapJobTx, drainMapJobs } from './factMapperService.js';
+import { buildFactSnapshot, enqueueMapJobsTx, drainMapJobs } from './factMapperService.js';
 import { bumpEnrichmentInputTx } from './enrichmentFence.js';
+import { getProfileQuestion, resolveAnswer as resolveProfileAnswer } from '../utils/profileQuestionLibrary.js';
+import { validateFact } from '../utils/factTaxonomy.js';
+import { isV2 as isV2DesignConfig } from '../utils/designConfigV2.js';
 // Lead Profile page composer (admin-only, ?include=profile — plan §4). Leaf
 // imports only (models + sibling services); no cycle back into this module.
 import {
@@ -215,7 +218,7 @@ const defaultDeps = {
   recordCaptureConsentEventsTx,
   canMarketTo,
   buildFactSnapshot,
-  enqueueMapJobTx,
+  enqueueMapJobsTx,
   drainMapJobs,
   bumpEnrichmentInputTx,
   onLeadCaptured: (prospect) => (_leadCapturedHook ? _leadCapturedHook(prospect) : null),
@@ -785,6 +788,55 @@ export function makeProspectService(overrides = {}) {
       incoming.sourceMetadata = { ...(incoming.sourceMetadata || {}), quiz: quizMeta };
     }
 
+    // --- Enrichment profile questions (studio-profile-questions §5.4) ---
+    // Three-leg eligibility gate, ALL legs or the whole object is ignored
+    // (Codex PR0 R2 #3 — backend eligibility must equal rendering
+    // eligibility): raw config is v2 AND profileQuestions.enabled AND not
+    // guided_review. Then iterate the CAMPAIGN'S configured question ids
+    // (never attacker keys), resolve server-side, re-validate, and stash
+    // only canonical accepted answer ids (erasure's sourceMetadata rebuild
+    // removes them). A bad answer never costs a lead.
+    let acceptedProfileFacts = [];
+    {
+      const rawAnswers = safeBody.profileAnswers;
+      const dcRaw = sourceCampaign?.design_config;
+      const pq = dcRaw?.profileQuestions;
+      const eligible = rawAnswers && typeof rawAnswers === 'object' && !Array.isArray(rawAnswers)
+        && isV2DesignConfig(dcRaw)
+        && pq?.enabled === true
+        && dcRaw?.template?.id !== 'guided_review'
+        && Array.isArray(pq?.questionIds);
+      if (eligible) {
+        const acceptedIds = {};
+        const dropped = [];
+        for (const qid of pq.questionIds) {
+          const q = getProfileQuestion(qid);
+          if (!q) continue;
+          const provided = rawAnswers[qid];
+          if (provided === undefined || provided === null || provided === '') continue;
+          const value = resolveProfileAnswer(qid, provided);
+          if (!value || !validateFact(q.factKey, value).ok) {
+            dropped.push(qid);
+            continue;
+          }
+          acceptedProfileFacts.push({ key: q.factKey, value });
+          acceptedIds[qid] = provided;
+        }
+        if (dropped.length) {
+          d.logger.warn('[enrichment] profile answers dropped (invalid)', {
+            campaignId: incoming.campaignId, dropped,
+          });
+        }
+        if (Object.keys(acceptedIds).length) {
+          incoming.sourceMetadata = { ...(incoming.sourceMetadata || {}), profileAnswers: acceptedIds };
+        }
+      } else if (rawAnswers && typeof rawAnswers === 'object' && Object.keys(rawAnswers).length) {
+        d.logger.warn('[enrichment] profile answers ignored (campaign not eligible)', {
+          campaignId: incoming.campaignId,
+        });
+      }
+    }
+
     // --- Quiz funnel: re-score server-side (anti-tamper) and stash on the lead ---
     // The client sends raw answers (+ an advisory result we ignore). We recompute
     // the authoritative profile/readiness/leadScore from the campaign's own quiz
@@ -1036,10 +1088,11 @@ export function makeProspectService(overrides = {}) {
             demographics: newProspect.demographics,
             sourceMetadata: newProspect.sourceMetadata,
             quizDefinition: sourceCampaign?.design_config?.quiz,
+            profileFacts: acceptedProfileFacts,
           });
-          await d.enqueueMapJobTx(sp, {
+          await d.enqueueMapJobsTx(sp, {
             prospectId: newProspect.id,
-            enrichmentRevision: newProspect.enrichmentRevision || 1,
+            formRevision: newProspect.enrichmentRevision || 1,
             snapshot,
           });
         });
@@ -1662,14 +1715,14 @@ export function makeProspectService(overrides = {}) {
         await d.sequelize.transaction(async (t) => {
           const rev = (prospect.enrichmentRevision || 1) + 1;
           await prospect.update({ enrichmentRevision: rev }, { transaction: t });
+          // FORM section only: quiz/profile artifacts are capture-immutable —
+          // absent sections mean "leave those artifacts alone" (§5.1).
           const snapshot = d.buildFactSnapshot({
-            demographics: prospect.demographics,
-            sourceMetadata: prospect.sourceMetadata,
-            quizDefinition: null, // quiz answers are capture-time only; edits never change them
+            demographics: prospect.demographics || {},
           });
-          await d.enqueueMapJobTx(t, {
+          await d.enqueueMapJobsTx(t, {
             prospectId: prospect.id,
-            enrichmentRevision: rev,
+            formRevision: rev,
             snapshot,
           });
         });

--- a/backend/src/utils/designConfigV2.js
+++ b/backend/src/utils/designConfigV2.js
@@ -168,7 +168,7 @@ export const V1_CONSUMED_KEYS = [
 ];
 
 /** Top-level v2 schema keys (used by downgrade + the clamp's alias scrub). */
-export const V2_TOP_KEYS = ['version', 'template', 'theme', 'content', 'form', 'distribution', 'ai'];
+export const V2_TOP_KEYS = ['version', 'template', 'theme', 'content', 'form', 'distribution', 'ai', 'profileQuestions'];
 
 // ───────────────────────── helpers (dependency-free) ─────────────────────────
 

--- a/backend/src/utils/designConfigV2Clamp.js
+++ b/backend/src/utils/designConfigV2Clamp.js
@@ -50,6 +50,29 @@ import { applyLuckyDrawPolicy } from './luckyDraw.js';
 import { applyMarketplacePolicy, normalizeMarketplaceContent } from './marketplaceContent.js';
 import { normalizeCustomerHostChoice } from './customerHost.js';
 import { validateFact } from './factTaxonomy.js';
+import { PROFILE_QUESTION_IDS, MAX_PROFILE_QUESTIONS } from './profileQuestionLibrary.js';
+
+/**
+ * Enrichment profile-questions subtree (studio-profile-questions §3):
+ * unknown ids dropped, order preserved, deduped, capped; enabled only with
+ * ≥1 valid id. Sanitize-never-reject, like everything else in this clamp.
+ * profileQuestions is a V2_TOP_KEY, so the unknown-passthrough below can
+ * never overwrite this sanitized value with raw input (Codex PR0 R1 #7).
+ */
+function clampProfileQuestions(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { enabled: false, questionIds: [] };
+  }
+  const seen = new Set();
+  const questionIds = [];
+  for (const id of Array.isArray(raw.questionIds) ? raw.questionIds : []) {
+    if (typeof id !== 'string' || seen.has(id) || !PROFILE_QUESTION_IDS.includes(id)) continue;
+    seen.add(id);
+    questionIds.push(id);
+    if (questionIds.length >= MAX_PROFILE_QUESTIONS) break;
+  }
+  return { enabled: raw.enabled === true && questionIds.length > 0, questionIds };
+}
 
 /**
  * Enrichment factKey save-gate (consumer-profile-enrichment plan §5): a quiz
@@ -59,8 +82,15 @@ import { validateFact } from './factTaxonomy.js';
  * at map time, so nothing invalid can reach the ledger through either door.
  */
 function clampQuizFactKeys(quiz) {
-  if (!quiz || typeof quiz !== 'object' || !Array.isArray(quiz.questions)) return quiz;
-  for (const q of quiz.questions) {
+  if (!quiz || typeof quiz !== 'object') return quiz;
+  // Real Studio quizzes nest questions in steps[] (quizScoringService);
+  // accept the legacy flat questions[] too — Codex PR0 R1 #3.
+  const questionLists = [];
+  if (Array.isArray(quiz.steps)) {
+    for (const s of quiz.steps) if (Array.isArray(s?.questions)) questionLists.push(s.questions);
+  }
+  if (Array.isArray(quiz.questions)) questionLists.push(quiz.questions);
+  for (const q of questionLists.flat()) {
     if (!q || typeof q !== 'object' || q.factKey === undefined) continue;
     const values = q.factValues && typeof q.factValues === 'object' && !Array.isArray(q.factValues)
       ? Object.values(q.factValues)
@@ -455,6 +485,12 @@ export function clampDesignConfigV2(incoming, storedConfig, role) {
     ? (isPlainObject(dc.ai) ? clone(dc.ai) : undefined)
     : getStoredAi(storedConfig);
   if (ai !== undefined) out.ai = ai;
+
+  // Enrichment profile questions — explicit sanitize (absent stays absent:
+  // upgrade preservation for docs that never touched the feature).
+  if (dc.profileQuestions !== undefined) {
+    out.profileQuestions = clampProfileQuestions(dc.profileQuestions);
+  }
 
   // Derived legacy mirror — ALWAYS from the clamped host, never from incoming.
   out.customerHost = host;

--- a/backend/src/utils/factTaxonomy.js
+++ b/backend/src/utils/factTaxonomy.js
@@ -20,7 +20,7 @@
  * the directly-scored market-fit signal).
  */
 
-export const TAXONOMY_VERSION = 'v1';
+export const TAXONOMY_VERSION = 'v2'; // v2: + family.children_count_band (PR 0)
 
 // Explicitness rank for resolveCurrentFacts (§3.4) — higher wins.
 export const SOURCE_RANK = {
@@ -148,6 +148,12 @@ export const FACT_KEYS = {
     },
   },
   'family.parents_alive': { collection: false, validate: boolShape() },
+  // Form answers can state a COUNT but never invent ages — the band lives
+  // beside the detailed family.children array (transcript-fed). Resolution
+  // precedence: a fresh complete children array outranks the band; the band
+  // entails a LOWER BOUND when '3_plus' (never an exact count) — parent plan
+  // §6.4 dependants rule. (studio-profile-questions §4, Codex R1 #8.)
+  'family.children_count_band': { collection: false, validate: enumShape(['0', '1', '2', '3_plus']) },
   'household.pets': { collection: 'strings', validate: vocabListShape(PETS, 8) },
   'assets.car_owner': { collection: false, validate: boolShape() },
   'assets.property': { collection: false, validate: enumShape(PROPERTY) },

--- a/backend/src/utils/profileQuestionLibrary.js
+++ b/backend/src/utils/profileQuestionLibrary.js
@@ -1,0 +1,141 @@
+/**
+ * Profile question library v1 — the FIXED set of enrichment questions a
+ * campaign may slide into its signup funnel
+ * (docs/plans/studio-profile-questions.md §2).
+ *
+ * TWIN FILE: src/lib/profileQuestionLibrary.js ↔
+ * backend/src/utils/profileQuestionLibrary.js must stay BYTE-IDENTICAL
+ * (parity test enforces). Dependency-free by design. The frontend renders
+ * from prompts/options and NEVER calls resolveAnswer; the backend calls
+ * resolveAnswer to compose the complete taxonomy value server-side —
+ * per-option value fragments are not composable for multi-selects
+ * (Codex PR0 R1 #6 / R2 #4).
+ *
+ * Copy rule (one, deterministic): English prompt with the Chinese inline
+ * where provided — there is no campaign-locale mechanism and none is
+ * assumed (Codex PR0 R1 #9).
+ *
+ * Admins pick questions; they never author them. Free-text answers would
+ * need LLM parsing and would poison the deterministic ledger.
+ */
+
+export const PROFILE_QUESTION_LIBRARY = [
+  {
+    id: 'language',
+    factKey: 'identity.preferred_language',
+    multi: false,
+    prompt: 'Which language do you prefer?',
+    promptZh: '您偏好哪种语言？',
+    options: [
+      { id: 'en', label: 'English' },
+      { id: 'zh', label: '中文' },
+    ],
+  },
+  {
+    id: 'annual_income',
+    factKey: 'finance.annual_income_band',
+    multi: false,
+    prompt: 'What is your annual income range?',
+    promptZh: '您的年收入范围？',
+    options: [
+      { id: 'lt40', label: 'Below $40k' },
+      { id: '40to80', label: '$40k – $80k' },
+      { id: '80to120', label: '$80k – $120k' },
+      { id: '120to200', label: '$120k – $200k' },
+      { id: 'gt200', label: 'Above $200k' },
+    ],
+  },
+  {
+    id: 'children',
+    factKey: 'family.children_count_band',
+    multi: false,
+    prompt: 'Do you have children?',
+    promptZh: '您有孩子吗？',
+    options: [
+      { id: 'none', label: 'None' },
+      { id: 'one', label: '1' },
+      { id: 'two', label: '2' },
+      { id: 'three_plus', label: '3 or more' },
+    ],
+  },
+  {
+    id: 'pets',
+    factKey: 'household.pets',
+    multi: true,
+    prompt: 'Do you have pets? Select all that apply.',
+    promptZh: '您养宠物吗？可多选。',
+    options: [
+      { id: 'dog', label: 'Dog' },
+      { id: 'cat', label: 'Cat' },
+      { id: 'other', label: 'Other' },
+      { id: 'none', label: 'No pets' },
+    ],
+  },
+  {
+    id: 'retirement_age',
+    factKey: 'finance.retirement_age_band',
+    multi: false,
+    prompt: 'At what age do you plan to retire?',
+    promptZh: '您计划几岁退休？',
+    options: [
+      { id: 'lt55', label: 'Before 55' },
+      { id: '55to59', label: '55 – 59' },
+      { id: '60to64', label: '60 – 64' },
+      { id: '65to69', label: '65 – 69' },
+      { id: '70plus', label: '70 or later' },
+    ],
+  },
+];
+
+export const PROFILE_QUESTION_IDS = PROFILE_QUESTION_LIBRARY.map((q) => q.id);
+export const MAX_PROFILE_QUESTIONS = 5;
+
+const byId = new Map(PROFILE_QUESTION_LIBRARY.map((q) => [q.id, q]));
+export const getProfileQuestion = (id) => byId.get(id) || null;
+
+// Single-select answer → taxonomy value.
+const SINGLE_VALUES = {
+  language: { en: { v: 'en' }, zh: { v: 'zh' } },
+  annual_income: {
+    lt40: { v: '<40k' }, '40to80': { v: '40-80k' }, '80to120': { v: '80-120k' },
+    '120to200': { v: '120-200k' }, gt200: { v: '>200k' },
+  },
+  children: {
+    none: { v: '0' }, one: { v: '1' }, two: { v: '2' }, three_plus: { v: '3_plus' },
+  },
+  retirement_age: {
+    lt55: { v: '<55' }, '55to59': { v: '55-59' }, '60to64': { v: '60-64' },
+    '65to69': { v: '65-69' }, '70plus': { v: '70+' },
+  },
+};
+
+const PET_VALUES = { dog: 'dog', cat: 'cat', other: 'other' };
+
+/**
+ * Compose the COMPLETE taxonomy value for a question from the selected
+ * option id(s). Returns null for anything invalid — unknown ids, wrong
+ * single/multi shape, duplicates, or `none`-exclusivity violations
+ * (none + dog is a contradiction, not a preference). The server re-checks
+ * the output with validateFact regardless (belt + braces).
+ */
+export function resolveAnswer(questionId, selectedIds) {
+  const q = byId.get(questionId);
+  if (!q) return null;
+
+  if (!q.multi) {
+    if (typeof selectedIds !== 'string') return null;
+    return SINGLE_VALUES[questionId]?.[selectedIds] || null;
+  }
+
+  // multi (pets)
+  if (!Array.isArray(selectedIds) || selectedIds.length === 0) return null;
+  if (new Set(selectedIds).size !== selectedIds.length) return null;
+  if (!selectedIds.every((s) => q.options.some((o) => o.id === s))) return null;
+  if (selectedIds.includes('none')) {
+    if (selectedIds.length !== 1) return null; // exclusive
+    return { v: [], complete: true };
+  }
+  const values = [...new Set(selectedIds.map((s) => PET_VALUES[s]).filter(Boolean))].sort();
+  if (values.length !== selectedIds.length) return null;
+  return { v: values, complete: true };
+}

--- a/backend/src/utils/publicDesignConfig.js
+++ b/backend/src/utils/publicDesignConfig.js
@@ -107,6 +107,16 @@ function buildPublicDesignConfigV2(dc) {
     'trustRow', 'scamLine', 'winnersNote', 'ctaSubline', 'freeEntryTag', 'boostBody',
   ]);
   if (drawCopy) content.drawCopy = drawCopy;
+
+  // Enrichment profile questions — explicit leaf-pick (unknown top-level V2
+  // keys are deliberately excluded from the anonymous payload; nothing is
+  // "automatically additive" — studio-profile-questions §3, Codex PR0 R1 #4).
+  // Exposed only when enabled: disabled ⇒ absent ⇒ funnel renders nothing.
+  const pq = dc.profileQuestions;
+  if (pq && typeof pq === 'object' && pq.enabled === true
+    && Array.isArray(pq.questionIds) && pq.questionIds.length) {
+    out.profileQuestions = { enabled: true, questionIds: [...pq.questionIds] };
+  }
   // media WITHOUT the internal legacy shadow (v1-URL bookkeeping for downgrade).
   const media = pick(dc.content?.media, ['kind', 'src', 'alt']);
   if (media) content.media = media;

--- a/backend/test/consumerEnrichment.test.js
+++ b/backend/test/consumerEnrichment.test.js
@@ -251,6 +251,154 @@ describe('erasure cascade (§9)', () => {
   })
 })
 
+describe('profile questions PR 0 (studio-profile-questions §5)', () => {
+  let pqCampaign
+  const V2_PQ = {
+    version: 2,
+    template: { id: 'express' },
+    profileQuestions: { enabled: true, questionIds: ['language', 'pets', 'children'] },
+  }
+
+  beforeAll(async () => {
+    pqCampaign = await createTestCampaign(admin.id, {
+      name: `PQ IT ${Date.now()}`,
+      design_config: V2_PQ,
+    })
+  })
+
+  afterEach(() => {
+    delete process.env.ENRICHMENT_MAP_ARTIFACT_JOBS
+  })
+
+  it('flag OFF (deploy window): answers persist as evidence; legacy job carries NO profile facts', async () => {
+    const prospect = await capture({
+      campaignId: pqCampaign.id,
+      profileAnswers: { language: 'zh', pets: ['dog', 'cat'] },
+    })
+    expect(prospect.sourceMetadata.profileAnswers).toEqual({ language: 'zh', pets: ['dog', 'cat'] })
+
+    const jobs = await EnrichmentJob.findAll({ where: { kind: 'map', subjectProspectId: prospect.id } })
+    expect(jobs).toHaveLength(1)
+    expect(jobs[0].sourceArtifactId).toBeNull() // legacy shape
+    const artifacts = (jobs[0].payload.facts || []).map((f) => f.artifact)
+    expect(artifacts).not.toContain('profile')
+
+    await drainAndQuiesce(prospect.id)
+    // Post-flip remap re-derives profile facts from the durable answers.
+    process.env.ENRICHMENT_MAP_ARTIFACT_JOBS = 'true'
+    const { getProfileQuestion, resolveAnswer } = await import('../src/utils/profileQuestionLibrary.js')
+    const profileFacts = Object.entries(prospect.sourceMetadata.profileAnswers)
+      .map(([qid, provided]) => ({ key: getProfileQuestion(qid).factKey, value: resolveAnswer(qid, provided) }))
+    const { buildFactSnapshot, enqueueMapJobsTx } = await import('../src/services/factMapperService.js')
+    await sequelize.transaction(async (t) => {
+      await enqueueMapJobsTx(t, {
+        prospectId: prospect.id,
+        formRevision: 1,
+        snapshot: buildFactSnapshot({ profileFacts }),
+      })
+    })
+    await drainAndQuiesce(prospect.id)
+    const obs = await ConsumerObservation.findAll({
+      where: { sourceProspectId: prospect.id, sourceArtifactId: `profile:${prospect.id}`, supersededAt: null },
+    })
+    expect(obs.map((o) => o.key).sort()).toEqual(['household.pets', 'identity.preferred_language'])
+    expect(obs.find((o) => o.key === 'household.pets').value).toEqual({ v: ['cat', 'dog'], complete: true })
+  })
+
+  it('flag ON: artifact-scoped capture → profile observations; demographics edit leaves them UNTOUCHED (the #281 regression)', async () => {
+    process.env.ENRICHMENT_MAP_ARTIFACT_JOBS = 'true'
+    const prospect = await capture({
+      campaignId: pqCampaign.id,
+      profileAnswers: { language: 'en', children: 'two' },
+    })
+    const jobs = await EnrichmentJob.findAll({ where: { kind: 'map', subjectProspectId: prospect.id } })
+    expect(jobs.every((j) => j.sourceArtifactId !== null)).toBe(true)
+    expect(jobs.map((j) => j.sourceArtifactId).sort()).toEqual([
+      `form:${prospect.id}`, `profile:${prospect.id}`,
+    ])
+
+    await drainAndQuiesce(prospect.id)
+    const before = await ConsumerObservation.findAll({
+      where: { sourceProspectId: prospect.id, sourceArtifactId: `profile:${prospect.id}`, supersededAt: null },
+    })
+    expect(before.map((o) => o.key).sort()).toEqual(['family.children_count_band', 'identity.preferred_language'])
+
+    // The regression that motivated v1.1: a staff demographics edit must
+    // supersede ONLY the form artifact.
+    const service = makeProspectService()
+    await service.updateProspect(prospect.id, { demographics: { dateOfBirth: '1990-05-05', age: 36 } }, admin)
+    await drainAndQuiesce(prospect.id)
+
+    const profileAfter = await ConsumerObservation.findAll({
+      where: { sourceProspectId: prospect.id, sourceArtifactId: `profile:${prospect.id}`, supersededAt: null },
+    })
+    expect(profileAfter).toHaveLength(2) // untouched
+    const formActive = await ConsumerObservation.findAll({
+      where: { sourceProspectId: prospect.id, sourceArtifactId: `form:${prospect.id}`, supersededAt: null },
+    })
+    expect(formActive).toHaveLength(1)
+    expect(formActive[0].value).toEqual({ v: '1990-1994' })
+  })
+
+  it('ineligible campaigns ignore answers entirely (disabled subtree / not v2)', async () => {
+    const plain = await createTestCampaign(admin.id, { name: `PQ plain ${Date.now()}` })
+    const p1 = await capture({ campaignId: plain.id, profileAnswers: { language: 'zh' } })
+    expect(p1.sourceMetadata?.profileAnswers).toBeUndefined()
+
+    const disabled = await createTestCampaign(admin.id, {
+      name: `PQ disabled ${Date.now()}`,
+      design_config: { version: 2, template: { id: 'express' }, profileQuestions: { enabled: false, questionIds: ['language'] } },
+    })
+    const p2 = await capture({ campaignId: disabled.id, profileAnswers: { language: 'zh' } })
+    expect(p2.sourceMetadata?.profileAnswers).toBeUndefined()
+  })
+
+  it('invalid answers dropped per-question; valid siblings survive; none-exclusivity enforced', async () => {
+    const prospect = await capture({
+      campaignId: pqCampaign.id,
+      profileAnswers: { language: 'zh', pets: ['none', 'dog'], children: 'seventeen' },
+    })
+    expect(prospect.sourceMetadata.profileAnswers).toEqual({ language: 'zh' })
+  })
+
+  it('legacy combined job (form+quiz) splits per artifact — never single-artifact-activated', async () => {
+    const prospect = await capture()
+    await drainAndQuiesce(prospect.id)
+    // Hand-insert a legacy combined job (as an old writer would have):
+    // form + quiz facts in one payload. Revision 2 — capture's own rev-1
+    // legacy job is done and owns the rev-1 slot in the legacy unique.
+    await Prospect.update({ enrichmentRevision: 2 }, { where: { id: prospect.id } })
+    const { MAPPER_PIPELINE_VERSION: PV } = await import('../src/services/factMapperService.js')
+    const { randomUUID } = await import('crypto')
+    await sequelize.query(
+      `INSERT INTO enrichment_jobs
+         (id, kind, "subjectProspectId", "sourceRevisionId", "sourceContentHash",
+          payload, "taxonomyVersion", "pipelineVersion", status, attempts, "createdAt", "updatedAt")
+       VALUES (:id, 'map', :pid, 2, 'legacyhash', :payload::jsonb, 'v2', :pv, 'pending', 0, now(), now())`,
+      {
+        replacements: {
+          id: randomUUID(),
+          pid: prospect.id,
+          payload: JSON.stringify({
+            facts: [
+              { key: 'identity.birth_year_band', value: { v: '1985-1989' }, artifact: 'form' },
+              { key: 'assets.car_owner', value: { v: true }, artifact: 'quiz' },
+            ],
+          }),
+          pv: PV,
+        },
+      }
+    )
+    await drainAndQuiesce(prospect.id)
+    const quizObs = await ConsumerObservation.findAll({
+      where: { sourceProspectId: prospect.id, sourceArtifactId: `quiz:${prospect.id}`, supersededAt: null },
+    })
+    expect(quizObs).toHaveLength(1)
+    expect(quizObs[0].key).toBe('assets.car_owner')
+    expect(quizObs[0].source).toBe('quiz')
+  })
+})
+
 describe('relink bumps (§6.3)', () => {
   it('recomputeConsumersByPhone dirties both sides when a prospect moves', async () => {
     const prospect = await capture()

--- a/backend/test/unit/factMapperSnapshot.test.js
+++ b/backend/test/unit/factMapperSnapshot.test.js
@@ -1,107 +1,148 @@
-import { buildFactSnapshot, canonicalJson, sha256, MAPPER_PIPELINE_VERSION } from '../../src/services/factMapperService.js';
+import {
+  buildFactSnapshot, canonicalJson, sha256, MAPPER_PIPELINE_VERSION,
+  flattenQuizQuestions, indexQuizAnswers,
+} from '../../src/services/factMapperService.js';
 
 /**
- * The pure half of the fact mapper (consumer-profile-enrichment plan §5):
- * snapshot building (normalized-at-enqueue, minimized) and canonical
- * hashing. DB paths (outbox, drain, activation) live in the integration
- * suite.
+ * The pure half of fact mapper v1.1 (studio-profile-questions §5.1–§5.2):
+ * SECTION-KEYED snapshots (present = re-observed, absent = leave alone),
+ * the REAL quiz wire shapes (steps[].questions[] + [{qid,value}] — the flat
+ * shapes v1 read never occur in production), and canonical hashing. DB
+ * paths live in the integration suite.
  */
-describe('factMapperService (pure)', () => {
-  test('pipelineVersion is the composite semantic version (R3 #6)', () => {
-    expect(MAPPER_PIPELINE_VERSION).toBe('mapper/v1+tax-v1');
+describe('factMapperService v1.1 (pure)', () => {
+  test('pipelineVersion is the composite semantic version (mapper v1.1 + taxonomy v2)', () => {
+    expect(MAPPER_PIPELINE_VERSION).toBe('mapper/v1.1+tax-v2');
   });
 
   describe('canonicalJson', () => {
-    test('is key-order independent at every depth', () => {
+    test('key-order independent at every depth; array order still data', () => {
       const a = { b: 1, a: { d: [1, 2], c: 'x' } };
       const b = { a: { c: 'x', d: [1, 2] }, b: 1 };
       expect(canonicalJson(a)).toBe(canonicalJson(b));
       expect(sha256(canonicalJson(a))).toBe(sha256(canonicalJson(b)));
-    });
-
-    test('array order still matters (arrays are data, not sets)', () => {
       expect(canonicalJson({ v: [1, 2] })).not.toBe(canonicalJson({ v: [2, 1] }));
     });
   });
 
-  describe('buildFactSnapshot', () => {
-    test('demographics.dateOfBirth → identity.birth_year_band as a form fact', () => {
-      const { facts } = buildFactSnapshot({ demographics: { dateOfBirth: '1988-06-15', age: 38 } });
-      expect(facts).toEqual([
-        { key: 'identity.birth_year_band', value: { v: '1985-1989' }, artifact: 'form' },
+  const REAL_QUIZ_DEF = {
+    enabled: true,
+    steps: [
+      {
+        id: 's1',
+        questions: [
+          { qid: 'q1', factKey: 'assets.car_owner', factValues: { yes: { v: true }, no: { v: false } } },
+          { qid: 'q2' }, // scoring-only
+        ],
+      },
+      {
+        id: 's2',
+        questions: [
+          { qid: 'q3', factKey: 'finance.annual_income_band', factValues: { a: { v: '<40k' }, b: { v: '40-80k' } } },
+        ],
+      },
+    ],
+  };
+  const REAL_ANSWERS = [{ qid: 'q1', value: 'yes' }, { qid: 'q2', value: 'x' }, { qid: 'q3', value: 'b' }];
+
+  test('flattenQuizQuestions reads steps[].questions[] (real) and flat questions[] (legacy)', () => {
+    expect(flattenQuizQuestions(REAL_QUIZ_DEF).map((q) => q.qid)).toEqual(['q1', 'q2', 'q3']);
+    expect(flattenQuizQuestions({ questions: [{ id: 'a' }] })).toHaveLength(1);
+    expect(flattenQuizQuestions(null)).toEqual([]);
+  });
+
+  test('indexQuizAnswers reads [{qid,value}] (real) and object maps (legacy)', () => {
+    expect(indexQuizAnswers(REAL_ANSWERS).get('q3')).toBe('b');
+    expect(indexQuizAnswers({ q1: 'yes' }).get('q1')).toBe('yes');
+    expect(indexQuizAnswers(undefined).size).toBe(0);
+  });
+
+  describe('buildFactSnapshot — section semantics', () => {
+    test('form section present whenever demographics observed; facts normalized', () => {
+      const { sections } = buildFactSnapshot({ demographics: { dateOfBirth: '1988-06-15', income: '4500' } });
+      expect(sections.form.facts).toEqual([
+        { key: 'identity.birth_year_band', value: { v: '1985-1989' } },
+        { key: 'finance.income_band', value: { v: '3-6k' } },
       ]);
+      expect(sections.quiz).toBeUndefined();
+      expect(sections.profile).toBeUndefined();
     });
 
-    test('no demographics → empty snapshot (nothing invented)', () => {
-      expect(buildFactSnapshot({}).facts).toEqual([]);
-      expect(buildFactSnapshot({ demographics: { age: 38 } }).facts).toEqual([]);
-      expect(buildFactSnapshot({ demographics: { dateOfBirth: 'not-a-date' } }).facts).toEqual([]);
+    test('empty demographics still re-observes the form artifact (cleared DOB must supersede)', () => {
+      const { sections } = buildFactSnapshot({ demographics: {} });
+      expect(sections.form).toEqual({ facts: [] });
     });
 
-    const quizDefinition = {
-      enabled: true,
-      questions: [
-        {
-          id: 'q1',
-          factKey: 'assets.car_owner',
-          factValues: { yes: { v: true }, no: { v: false } },
-        },
-        {
-          id: 'q2',
-          factKey: 'finance.annual_income_band',
-          factValues: { a: { v: '<40k' }, b: { v: '40-80k' } },
-        },
-        { id: 'q3' }, // no factKey — scoring-only question
-      ],
-    };
+    test('no demographics object ⇒ form section ABSENT (edit choke: leave alone)', () => {
+      expect(buildFactSnapshot({}).sections.form).toBeUndefined();
+    });
 
-    test('server-scored quiz answers map through factKey/factValues', () => {
-      const { facts } = buildFactSnapshot({
-        sourceMetadata: { quiz: { scoredBy: 'server', answers: { q1: 'yes', q2: 'b', q3: 'whatever' } } },
-        quizDefinition,
+    test('income bands map at the boundaries; garbage never mints', () => {
+      const band = (income) => buildFactSnapshot({ demographics: { income } }).sections.form.facts
+        .find((f) => f.key === 'finance.income_band')?.value?.v;
+      expect(band('2999')).toBe('<3k');
+      expect(band('3000')).toBe('3-6k');
+      expect(band('$12,000')).toBe('10-15k');
+      expect(band('15000')).toBe('>15k');
+      expect(band('a lot')).toBeUndefined();
+      expect(band('-5')).toBeUndefined();
+    });
+
+    test('server-scored REAL quiz submissions map through steps + qid answers', () => {
+      const { sections } = buildFactSnapshot({
+        sourceMetadata: { quiz: { scoredBy: 'server', answers: REAL_ANSWERS } },
+        quizDefinition: REAL_QUIZ_DEF,
       });
-      expect(facts).toEqual([
-        { key: 'assets.car_owner', value: { v: true }, artifact: 'quiz' },
-        { key: 'finance.annual_income_band', value: { v: '40-80k' }, artifact: 'quiz' },
+      expect(sections.quiz.facts).toEqual([
+        { key: 'assets.car_owner', value: { v: true } },
+        { key: 'finance.annual_income_band', value: { v: '40-80k' } },
       ]);
     });
 
     test('client-unverified quiz answers NEVER map (Codex R1 #12)', () => {
-      const { facts } = buildFactSnapshot({
-        sourceMetadata: { quiz: { scoredBy: 'client-unverified', answers: { q1: 'yes' } } },
-        quizDefinition,
+      const { sections } = buildFactSnapshot({
+        sourceMetadata: { quiz: { scoredBy: 'client-unverified', answers: REAL_ANSWERS } },
+        quizDefinition: REAL_QUIZ_DEF,
       });
-      expect(facts).toEqual([]);
+      expect(sections.quiz).toBeUndefined();
     });
 
-    test('invalid factKey mappings are skipped, valid siblings survive', () => {
-      const { facts } = buildFactSnapshot({
-        sourceMetadata: { quiz: { scoredBy: 'server', answers: { q1: 'yes', qBad: 'x' } } },
+    test('invalid factKey mappings are skipped; valid siblings survive', () => {
+      const { sections } = buildFactSnapshot({
+        sourceMetadata: { quiz: { scoredBy: 'server', answers: [{ qid: 'q1', value: 'yes' }, { qid: 'qBad', value: 'x' }] } },
         quizDefinition: {
-          questions: [
-            { id: 'q1', factKey: 'assets.car_owner', factValues: { yes: { v: true } } },
-            { id: 'qBad', factKey: 'identity.shoe_size', factValues: { x: { v: 42 } } },
-          ],
+          enabled: true,
+          steps: [{
+            questions: [
+              { qid: 'q1', factKey: 'assets.car_owner', factValues: { yes: { v: true } } },
+              { qid: 'qBad', factKey: 'identity.shoe_size', factValues: { x: { v: 42 } } },
+            ],
+          }],
         },
       });
-      expect(facts).toEqual([{ key: 'assets.car_owner', value: { v: true }, artifact: 'quiz' }]);
+      expect(sections.quiz.facts).toEqual([{ key: 'assets.car_owner', value: { v: true } }]);
     });
 
-    test('unanswered factKey questions contribute nothing', () => {
-      const { facts } = buildFactSnapshot({
-        sourceMetadata: { quiz: { scoredBy: 'server', answers: {} } },
-        quizDefinition,
+    test('profile section from pre-resolved capture facts; invalid dropped', () => {
+      const { sections } = buildFactSnapshot({
+        profileFacts: [
+          { key: 'identity.preferred_language', value: { v: 'zh' } },
+          { key: 'identity.shoe_size', value: { v: 42 } },
+        ],
       });
-      expect(facts).toEqual([]);
+      expect(sections.profile.facts).toEqual([
+        { key: 'identity.preferred_language', value: { v: 'zh' } },
+      ]);
     });
 
     test('snapshot carries ONLY taxonomy facts — no contact data, ever', () => {
       const snapshot = buildFactSnapshot({
         demographics: { dateOfBirth: '1990-01-01' },
-        sourceMetadata: { quiz: { scoredBy: 'server', answers: {} }, referral: { code: 'x' } },
+        sourceMetadata: { quiz: { scoredBy: 'server', answers: [] }, referral: { code: 'x' } },
+        quizDefinition: REAL_QUIZ_DEF,
       });
       const json = canonicalJson(snapshot);
-      expect(Object.keys(snapshot)).toEqual(['facts']);
+      expect(Object.keys(snapshot)).toEqual(['sections']);
       expect(json).not.toMatch(/phone|email|firstName|lastName|referral/i);
     });
   });

--- a/backend/test/unit/factTaxonomy.test.js
+++ b/backend/test/unit/factTaxonomy.test.js
@@ -11,7 +11,7 @@ import {
  */
 describe('factTaxonomy', () => {
   test('exports a stable version and ranked sources', () => {
-    expect(TAXONOMY_VERSION).toBe('v1');
+    expect(TAXONOMY_VERSION).toBe('v2'); // v2: + family.children_count_band (PR 0)
     expect(SOURCE_RANK.manual).toBeGreaterThan(SOURCE_RANK.form);
     expect(SOURCE_RANK.form).toBeGreaterThan(SOURCE_RANK.quiz);
     expect(SOURCE_RANK.quiz).toBeGreaterThan(SOURCE_RANK.screening_transcript);
@@ -26,6 +26,7 @@ describe('factTaxonomy', () => {
     'family.marital_status': { v: 'divorced' },
     'family.children': { v: [{ birth_year_band: '2015-2019', gender: 'male' }], complete: true },
     'family.parents_alive': { v: true },
+    'family.children_count_band': { v: '3_plus' },
     'household.pets': { v: ['dog'], complete: false },
     'assets.car_owner': { v: false },
     'assets.property': { v: 'hdb' },
@@ -71,6 +72,8 @@ describe('factTaxonomy', () => {
     ['career.job_title', { v: 'x'.repeat(81) }],
     ['finance.annual_income_band', { v: '90k' }],
     ['finance.retirement_age_band', { v: '62' }],
+    ['family.children_count_band', { v: 3 }],
+    ['family.children_count_band', { v: '3+' }],
     ['life_event.recent', { v: 'won_lottery' }],
     ['life_event.recent', { v: 'divorce', when: 'last year' }],
     ['interests.tags', { v: ['cars', 'crypto-moonshots'] }],

--- a/backend/test/unit/profileQuestionLibrary.test.js
+++ b/backend/test/unit/profileQuestionLibrary.test.js
@@ -1,0 +1,103 @@
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import {
+  PROFILE_QUESTION_LIBRARY, PROFILE_QUESTION_IDS, MAX_PROFILE_QUESTIONS,
+  getProfileQuestion, resolveAnswer,
+} from '../../src/utils/profileQuestionLibrary.js';
+import { validateFact, FACT_KEYS } from '../../src/utils/factTaxonomy.js';
+import { clampDesignConfigV2 } from '../../src/utils/designConfigV2Clamp.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Profile question library (studio-profile-questions §2) — twin byte
+ * parity, server-side answer resolution, and the clamp's subtree
+ * sanitizer (§3).
+ */
+describe('profileQuestionLibrary', () => {
+  test('TWIN PARITY: backend and frontend copies are byte-identical', () => {
+    const backend = readFileSync(path.join(__dirname, '../../src/utils/profileQuestionLibrary.js'), 'utf8');
+    const frontend = readFileSync(path.join(__dirname, '../../../src/lib/profileQuestionLibrary.js'), 'utf8');
+    expect(backend).toBe(frontend);
+  });
+
+  test('every question maps to a real taxonomy key; ids unique; cap honest', () => {
+    expect(PROFILE_QUESTION_IDS).toHaveLength(new Set(PROFILE_QUESTION_IDS).size);
+    expect(PROFILE_QUESTION_LIBRARY.length).toBeLessThanOrEqual(MAX_PROFILE_QUESTIONS);
+    for (const q of PROFILE_QUESTION_LIBRARY) {
+      expect(FACT_KEYS[q.factKey]).toBeDefined();
+      expect(q.options.length).toBeGreaterThanOrEqual(2);
+      expect(q.options).toHaveLength(new Set(q.options.map((o) => o.id)).size);
+    }
+  });
+
+  test('every resolvable answer round-trips validateFact', () => {
+    for (const q of PROFILE_QUESTION_LIBRARY) {
+      for (const opt of q.options) {
+        const value = resolveAnswer(q.id, q.multi ? [opt.id] : opt.id);
+        expect(value).not.toBeNull();
+        expect(validateFact(q.factKey, value)).toEqual({ ok: true });
+      }
+    }
+  });
+
+  test('single-select shapes: wrong shape, unknown option, unknown question → null', () => {
+    expect(resolveAnswer('language', 'en')).toEqual({ v: 'en' });
+    expect(resolveAnswer('language', ['en'])).toBeNull();
+    expect(resolveAnswer('language', 'fr')).toBeNull();
+    expect(resolveAnswer('star_sign', 'leo')).toBeNull();
+    expect(resolveAnswer('children', 'three_plus')).toEqual({ v: '3_plus' });
+  });
+
+  test('pets multi: server composes the complete canonical collection', () => {
+    expect(resolveAnswer('pets', ['cat', 'dog'])).toEqual({ v: ['cat', 'dog'], complete: true });
+    expect(resolveAnswer('pets', ['dog', 'cat'])).toEqual({ v: ['cat', 'dog'], complete: true }); // canonical order
+    expect(resolveAnswer('pets', ['none'])).toEqual({ v: [], complete: true });
+  });
+
+  test('pets multi: none is EXCLUSIVE; dupes and strings rejected', () => {
+    expect(resolveAnswer('pets', ['none', 'dog'])).toBeNull();
+    expect(resolveAnswer('pets', ['dog', 'dog'])).toBeNull();
+    expect(resolveAnswer('pets', 'dog')).toBeNull();
+    expect(resolveAnswer('pets', [])).toBeNull();
+    expect(resolveAnswer('pets', ['dragon'])).toBeNull();
+  });
+
+  test('getProfileQuestion lookup', () => {
+    expect(getProfileQuestion('pets')?.multi).toBe(true);
+    expect(getProfileQuestion('nope')).toBeNull();
+  });
+});
+
+describe('clampDesignConfigV2 — profileQuestions subtree (§3)', () => {
+  const base = { version: 2, template: { id: 'express' }, theme: {}, content: {}, form: {} };
+  const clamp = (pq) => clampDesignConfigV2({ ...base, profileQuestions: pq }, undefined, 'admin').profileQuestions;
+
+  test('unknown ids dropped, order preserved, deduped, capped', () => {
+    expect(clamp({ enabled: true, questionIds: ['pets', 'bogus', 'language', 'pets'] }))
+      .toEqual({ enabled: true, questionIds: ['pets', 'language'] });
+  });
+
+  test('enabled with zero valid ids clamps to disabled', () => {
+    expect(clamp({ enabled: true, questionIds: ['bogus'] }))
+      .toEqual({ enabled: false, questionIds: [] });
+    expect(clamp({ enabled: true })).toEqual({ enabled: false, questionIds: [] });
+  });
+
+  test('garbage shapes sanitize to disabled; absent stays absent (upgrade preservation)', () => {
+    expect(clamp('yes please')).toEqual({ enabled: false, questionIds: [] });
+    expect(clamp([1, 2])).toEqual({ enabled: false, questionIds: [] });
+    const out = clampDesignConfigV2(base, undefined, 'admin');
+    expect(out.profileQuestions).toBeUndefined();
+  });
+
+  test('raw unknown-passthrough can never overwrite the sanitized value', () => {
+    const out = clampDesignConfigV2(
+      { ...base, profileQuestions: { enabled: true, questionIds: ['language'], smuggled: 'x' } },
+      undefined,
+      'admin'
+    );
+    expect(out.profileQuestions).toEqual({ enabled: true, questionIds: ['language'] });
+  });
+});

--- a/docs/plans/studio-profile-questions.md
+++ b/docs/plans/studio-profile-questions.md
@@ -1,0 +1,329 @@
+# Studio profile questions — the PR 0 collection block (consumer enrichment)
+
+**Status:** v4 — **APPROVED, Codex round 4 (gpt-5.6-sol xhigh),
+2026-07-26** ("§5.1 steps 2–3 close the window… §7's replacement tests
+align… No legacy-job stamping remains"). Convergence: 4B/4M/1mod →
+2B/3M/1mod → 1 residual → APPROVE; logs §10–§12. **READY TO BUILD**
+pending Shawn's §9 calls (launch enablement; children question copy).
+**Author:** Claude, 2026-07-26
+**Parent:** `docs/plans/consumer-profile-enrichment.md` §11 PR 0
+**Depends on:** enrichment PR 1 (#281 MERGED — this plan also repairs two
+of its latent defects, §5.1/§5.2)
+
+## 1. Why and what
+
+The enrichment pipeline is live but starving: prod funnels collect one
+taxonomy fact. This adds the collection surface — a **"Profile questions"
+block** a campaign opts into in Campaign Studio. Selected questions render
+on the signup funnel as **optional, structured choices** (never free
+text); answers flow through capture into map-job snapshots and land as
+`consumer_observations` with `form`-grade provenance. No AI anywhere.
+
+Product rules (owner decisions): fixed library only (§2), everything
+skippable, per-campaign selection is Shawn's conversion-vs-data call — the
+AI "Fill everything" flow NEVER enables questions on its own.
+
+## 2. Question library v1 — twins with server-side answer resolution
+
+`src/lib/profileQuestionLibrary.js` ↔
+`backend/src/utils/profileQuestionLibrary.js` (twin pair + byte-parity
+test). Frontend consumes `{ id, prompt, promptZh, multi, options: [{ id,
+label, labelZh }] }` for rendering ONLY. **Both twins carry** the
+per-question pure function **`resolveAnswer(selectedIds) → taxonomy value
+| null`** — identical bytes, dependency-free; the frontend simply never
+calls it (byte parity and a backend-only method cannot both be true —
+R2 #4). The server composes the complete fact value; option rows never
+carry composable fragments (a multi-select's value cannot be assembled
+from per-option values). [R1 #6]
+
+| id | factKey | Shape | resolveAnswer contract |
+|---|---|---|---|
+| `language` | `identity.preferred_language` | single | en/zh → `{v}` |
+| `annual_income` | `finance.annual_income_band` | single | 5 bands verbatim |
+| `children` | `family.children_count_band` (**new key**, §4) | single | none/1/2/3+ → `{v:'0'\|'1'\|'2'\|'3_plus'}` |
+| `pets` | `household.pets` | multi | dog/cat/other/none chips → canonical-ordered, deduped `{v:[…], complete:true}`; `none` EXCLUSIVE (none+dog ⇒ invalid answer, dropped); prompt copy is "select all that apply" so `complete:true` is honest |
+| `retirement_age` | `finance.retirement_age_band` | single | 5 bands verbatim |
+
+**Locale rule (one, deterministic):** prompts always render English with
+the Chinese inline where provided ("Annual income range · 年收入范围").
+There is no campaign-locale mechanism in the funnel and none is built
+here. [R1 #9]
+
+## 3. design_config v2 — `profileQuestions` subtree (three surfaces, not one)
+
+```
+profileQuestions: { enabled: boolean=false, questionIds: string[] ⊆ library, ≤5, ordered, deduped }
+```
+
+All three surfaces change in lockstep, each with tests: [R1 #7]
+
+1. **Twins:** `profileQuestions` added to `V2_TOP_KEYS` in BOTH
+   `src/lib/designConfigV2.js` and `backend/src/utils/designConfigV2.js`
+   (upgrade-preservation + parity tests).
+2. **Clamp** (`designConfigV2Clamp.js`): an explicit
+   `clampProfileQuestions` sanitizer — unknown ids dropped, cap 5, dedupe,
+   zero-valid ⇒ disabled — wired BEFORE the unknown-top-level passthrough
+   so raw input can never overwrite the sanitized value.
+3. **Public projection:** `buildPublicDesignConfigV2` explicitly
+   leaf-picks `{enabled, questionIds}` — unknown top-level keys are
+   deliberately excluded from the anonymous payload
+   (`publicDesignConfig.js`), so nothing is "automatically additive".
+   [R1 #4]
+
+**guided_review exclusion is enforced by architecture, stated for tests:**
+guided_review campaigns have no v2 funnel — the block renders only in the
+v2 renderer, and capture validation reads the campaign's RAW v2 config
+(§5), which guided_review campaigns don't carry. A direct-API write of the
+subtree onto such a campaign is inert, and a test proves it. [R1 #7]
+
+**Flag preflight:** `DESIGN_CONFIG_V2_WRITES_ENABLED` must be `true` in
+prod for Studio to persist the subtree (it is — all 12 campaigns are v2 —
+but the rollout checklist verifies before announcing). [R1 #7]
+
+**Studio editor:** the card lives in **FormPanel** (the rail is
+Page/Form/Quiz/Theme/Distribution — no "Content panel" exists), with a
+real `section: 'form'` click-to-edit target per the extension recipe
+(attr + map entry + matrix row). [R1 #9]
+
+## 4. Taxonomy — `family.children_count_band` + honest versioning
+
+- New key `family.children_count_band` `{v: '0'|'1'|'2'|'3_plus'}` —
+  a form answer can't invent ages, and `3+` cannot truthfully be an exact
+  integer. [R1 #8]
+- **Precedence vs `family.children`:** scoring/entailment read the
+  detailed array when it has an active `complete:true` resolution,
+  else the band; the parent plan's dependants entailment gains the
+  band-as-lower-bound rule (`3_plus` ⇒ ≥3, never exact). [R1 #8]
+- **`TAXONOMY_VERSION` bumps to `v2`** (the version must mean something);
+  mapper becomes `mapper/v1.1+tax-v2`. Historical observations keep their
+  stored rows, but the remap (§5.3) supersedes old-pipeline actives —
+  "existing observations unaffected" is explicitly NOT claimed. [R1 #8]
+
+## 5. Capture → artifact-scoped jobs → observations
+
+### 5.1 Mapper v1.1 — ARTIFACT-SCOPED map jobs (repairs #281 latent bug №1)
+
+Round 1 confirmed the shipped bug (a demographics edit activates an empty
+quiz artifact and supersedes its rows) AND showed the v1 section-wrapper
+fix is insufficient — jobs are prospect-wide, so a form edit at rev 2
+stales a pending rev-1 capture job wholesale, LOSING its quiz/profile
+facts instead of protecting them. [R1 #1]
+
+Fix — map work becomes per-artifact, mirroring the extract shape:
+
+- **Migration 092 — expand/contract, not a flip** (rolling deploys run
+  old + new instances together; and legacy map jobs of EVERY status carry
+  `sourceArtifactId NULL` with possibly COMBINED form+quiz payloads —
+  stamping one `form:` would misattribute or discard quiz facts): [R2 #1]
+  1. **Expand (092):** `chk_ejobs_kind` accepts BOTH map shapes
+     (legacy-null and artifact-bearing); the artifact-scoped unique is
+     added for artifact-bearing rows while the legacy unique stays for
+     null rows. Old writers keep inserting legally; new writers insert
+     artifact-scoped.
+  2. **Deploy dual-shape code with artifact-scoped WRITES OFF** — writers
+     keep emitting legacy-shaped jobs; the new processor handles BOTH
+     shapes (splits a legacy combined payload per artifact — never
+     single-artifact-activates it). Old processors therefore never see a
+     new-shape job during the rollout window: none exist yet. [R3]
+  3. **Flip `ENRICHMENT_MAP_ARTIFACT_JOBS=true` + restart** once the
+     deploy has fully replaced old instances (house restart-to-flip
+     convention) — writers switch to artifact-scoped jobs; only
+     dual-shape processors are alive to claim them.
+  4. **Drain to zero live legacy jobs** (tiny volume; verified by query),
+     leaving terminal legacy nulls in place, explicitly permitted.
+  5. **Contract (093, follow-up migration):** require artifact on
+     non-terminal map jobs; drop the legacy unique.
+- **Per-artifact revisions:** `form:` uses `prospects.enrichmentRevision`
+  (unchanged); `quiz:` and `profile:` are capture-immutable in v1 ⇒
+  revision pinned 1 (a future edit surface mints its own counter).
+- **Capture** enqueues up to three jobs (form / quiz / profile), each only
+  when its source exists; **edits** enqueue a form job ONLY — other
+  artifacts' jobs and rows are untouched by construction. A form job with
+  zero facts at revision > 1 still enqueues (cleared DOB must supersede);
+  zero-fact revision-1 jobs are skipped for ALL artifacts (nothing to
+  supersede — consistent with, not contradicting, zero-claim activation,
+  which governs activation of an ACCEPTED result, and `enqueueMapJobTx`'s
+  skip rule is now documented as such). [R1 #1]
+- **`processMapJob` activates only its own artifact**; the stale gate
+  compares the job's revision to THAT artifact's current revision.
+- Race tests: pending capture quiz-job survives a form edit; form-only
+  job coexists with a later remap at the same prospect.
+
+### 5.2 Quiz wire-shape repair (repairs #281 latent bug №2)
+
+The shipped mapper + `clampQuizFactKeys` read `quiz.questions[]` and an
+object-indexed answer map — but real Studio quizzes are
+`quiz.steps[].questions[]` (`quizScoringService.js`) and real submissions
+are `[{qid, value}]` (`validation.js`). Real quiz campaigns would mint
+zero facts. Both functions flatten `steps[].questions[]` and index
+answers by `qid`; fabricated flat-shape fixtures are replaced with real
+Studio quiz fixtures. [R1 #3]
+
+**Immutable mapping input (R2 #2):** Studio edits quiz definitions
+without minting versions, so remapping an old `[{qid, value}]` against
+TODAY'S definition could mint facts the person never answered. Fix:
+capture now freezes the RESOLVED quiz facts + a hash of the exact
+factKey/factValues mapping subset into the quiz map-job snapshot (the
+job payload is already the frozen source of truth — quiz mapping simply
+stops re-reading the live definition after capture). The remap script
+(§5.3) re-maps quiz artifacts ONLY from retained frozen payloads;
+quiz artifacts with no provable captured mapping are **skipped and
+reported, never guessed**. (Today that skip set is empty — no factKey
+campaign has ever existed.)
+
+### 5.3 Remap script (no phantom reconciliation) [R1 #2]
+
+Bumping the pipeline version creates no work by itself — the nightly
+sweep is PR 2. PR 0 ships `scripts/remap-observations.mjs`:
+
+- **Frozen cohort:** the run fixes a `(createdAt, id)` watermark up
+  front; only prospects at-or-before it are enumerated (post-watermark
+  captures self-enqueue at the new version anyway). [R2 #5]
+- **Cohort-scoped accounting:** the script records every job id IT
+  inserts and computes done/stale/dead outcomes from that set only —
+  `drainMapJobs` claims any pending map job, so raw drain counts would
+  swallow live capture traffic. Completion = an artifact-level coverage
+  query over the frozen cohort. [R2 #5]
+- Idempotency claim narrowed: re-runs are no-ops **for live-unique
+  statuses**; previously stale/dead/cancelled jobs re-enqueue by design
+  (they exited the unique). [R2 #5]
+- Quiz artifacts: frozen-payload-only, skip-and-report (§5.2).
+- **Precondition:** every serving instance runs artifact-aware code
+  (expand step done) before the script starts.
+- Keyset batches, resumable, per-batch progress. Run once post-deploy;
+  the rollout checklist owns sequencing. The §5.1/§5.2 fixes are inert
+  for existing data until this runs.
+
+### 5.4 profileAnswers wire contract (abuse-bounded, ordered) [R1 #5]
+
+`POST /api/prospects` gains `profileAnswers`, validated in this exact
+order:
+
+1. **Joi** (the public capture schema — the route's global
+   `stripUnknown:true` would otherwise silently erase the field, and a
+   pattern-length-failed key is silently REMOVED unless the nested object
+   itself rejects unknowns): `profileAnswers` is declared
+   **`.unknown(false)`** with an explicit bounded key pattern (≤ 32
+   chars), ≤ 5 keys, values string (≤ 32) or string-array (≤ 8, unique).
+   Structural violations ⇒ 400 — **for requests the rate limiter admits**
+   (limiter runs first; over-limit garbage gets 429, and that ordering
+   stays). [R2 #6]
+2. Destructure `profileAnswers` out before the Sequelize input object is
+   built (never mass-assigned).
+3. Load the campaign's RAW v2 config (not the legacy view).
+4. **Eligibility gate, all three legs, else ignore the whole object and
+   enqueue no profile job:** raw config classifies as v2 AND
+   `profileQuestions.enabled === true` AND campaign type is not
+   `guided_review` — backend eligibility must equal rendering
+   eligibility; a disabled subtree can retain stale ids, guided_review
+   branches before the v2 adapter, and campaign save doesn't restrict v2
+   docs by type, so "inert by architecture" is only true WITH this gate.
+   Then iterate the CAMPAIGN'S configured `questionIds` — never
+   attacker-provided keys. [R2 #3]
+5. Enforce single-vs-multi shape per question; unknown option ids,
+   `none`-exclusivity violations, dupes ⇒ that answer dropped.
+6. `resolveAnswer` → taxonomy value → `validateFact` (belt + braces).
+7. Persist accepted canonical answer ids to
+   `sourceMetadata.profileAnswers` (erasure's allowlist rebuild already
+   removes it — verified: the rebuild keeps only selected UTM fields +
+   `erased:true`).
+8. One aggregated log line for dropped answers (never per-key logging an
+   attacker controls).
+
+Policy: structural abuse fails the request (400); stale/retired/
+un-configured question ids are ignored — a bad answer never costs a lead.
+Accepted facts join the capture's `profile:` map-job snapshot
+(`artifact: 'profile'`, source `form`, confidence 1.0).
+
+## 6. Funnel rendering — the REAL owners [R1 #4]
+
+- The signup form is owned by
+  `src/components/campaigns/CampaignSignupForm.jsx` — the block mounts
+  there, between the core fields and consent/CTA, theme-token styled,
+  chip-selects, every question skippable, "Optional — helps us serve you
+  better" reassurance line. Mobile 390×844 no-overflow.
+- `funnelAdapter.js` downgrades v2 → legacy view for the funnel: the
+  `profileQuestions` subtree is extracted and passed through BEFORE the
+  downgrade (own prop, not smuggled through the legacy shape).
+- `LeadCapture.jsx` builds the submission payload explicitly —
+  `profileAnswers` is added to that construction (local form state alone
+  goes nowhere).
+- Test: anonymous public-campaign endpoint → adapter → form renders
+  enabled questions → POST carries `profileAnswers` (the full path, not
+  unit islands).
+
+## 7. Tests
+
+Library twin byte-parity + every resolveAnswer output round-trips
+`validateFact`; pets exclusivity/canonical order. Clamp: sanitizer bounds
++ ordering vs unknown-passthrough + zero-valid disable + parity/golden
+suites untouched. Capture: the §5.4 matrix (Joi 400s, campaign-scoped
+iteration, drop-vs-fail policy, sourceMetadata persistence, mass-assign
+proof). Mapper: artifact-scoped enqueue/activation, edit-leaves-quiz-alone
+regression (THE #281 bug), pending-quiz-job survives form edit,
+real-Studio-quiz-shape mapping (steps[].questions[] + [{qid,value}]),
+zero-fact rev>1 supersession, A→B→A per artifact. Remap script:
+cohort-scoped counts, resume, narrowed idempotency. Renderer: full-path
+test (§6) + disabled renders nothing + guided_review inert. Migration
+092 + choreography: **mixed-shape coexistence** (legacy + artifact jobs
+under both uniques), **combined-legacy-payload split** by the dual-shape
+processor, writes-flag off ⇒ legacy emission, on ⇒ artifact emission —
+no stamping of legacy jobs anywhere. Idempotent re-run of 092.
+
+## 8. Rollout
+
+One PR, naturally dark (nothing renders until a campaign enables it):
+migration 092, library twins, config twins + clamp + public projection,
+Studio FormPanel card + click-edit target, CampaignSignupForm block +
+adapter/LeadCapture plumbing, capture validation, mapper v1.1 + quiz
+wire fix, taxonomy v2, remap script, tests. Post-deploy: run
+`remap-observations.mjs`; verify `DESIGN_CONFIG_V2_WRITES_ENABLED`;
+Shawn enables questions per campaign in Studio (that moment starts
+filling PR 2's volume gate).
+
+## 9. Open questions (Shawn)
+
+1. Launch enablement: language-only on all live campaigns, or the full
+   five on the Tokyo draw as pilot?
+2. `children` copy: single-step count ("Do you have children? None/1/2/
+   3+") proposed — OK?
+
+## 10. Codex round 1 — disposition log (REWORK 4B/4M/1mod, all adopted)
+
+| # | Finding | Disposition |
+|---|---|---|
+| 1 | Section-wrapper fix insufficient — jobs prospect-wide; rev bump stales pending quiz facts wholesale; bug confirmed real in shipped code | **Adopted** — artifact-scoped map jobs + per-artifact revisions + migration 092 (§5.1). |
+| 2 | "Version-keyed sweep remaps the world" doesn't exist in this PR era | **Adopted** — explicit idempotent remap script ships in PR 0; sweep stays PR 2 (§5.3). |
+| 3 | Shipped quiz mapper + clamp read a wire shape real quizzes never produce | **Adopted** — steps[].questions[] flattening + [{qid,value}] indexing + real fixtures (§5.2). |
+| 4 | Subtree doesn't reach the anonymous funnel or POST (public builder leaf-picks; funnelAdapter downgrades; LeadCapture explicit payload; form owner is CampaignSignupForm) | **Adopted** — all four plumbing points named + full-path test (§3, §6). |
+| 5 | No abuse-bounded validation contract; Joi stripUnknown erases the field | **Adopted** — 8-step ordered contract, 400-vs-ignore policy, aggregated logging (§5.4). |
+| 6 | Multi-answer mapping not executable from per-option values | **Adopted** — server-side `resolveAnswer` per question; pets exclusivity + canonical composition (§2). |
+| 7 | Three config surfaces (V2_TOP_KEYS twins, clamp-before-passthrough, public whitelist) + flag preflight + guided_review enforcement | **Adopted** — §3. |
+| 8 | children_count `{v:3}` dishonest for 3+; taxonomy version must move; "observations unaffected" overclaimed | **Adopted** — `children_count_band` w/ `3_plus`, precedence + lower-bound entailment, tax-v2, claim narrowed (§4). |
+| 9 | No locale mechanism; no "Content panel" in the Studio rail | **Adopted** — EN-with-ZH-inline rule; FormPanel + section:'form' target (§2, §3). |
+
+## 11. Codex round 2 — disposition log (REWORK 2B/3M/1mod, all adopted)
+
+Quiz wire-shape + public/funnel plumbing closures CONFIRMED; per-artifact
+revision pinning (quiz/profile = 1) CONFIRMED sound for this release
+(sourceMetadata is not in the update allowlist — any future edit surface
+must add a persisted per-artifact counter first).
+
+| # | Finding | Disposition |
+|---|---|---|
+| 1 | Migration 092 flip unsafe under rolling deploys + combined legacy payloads | **Adopted** — expand/contract choreography; combined legacy jobs split per artifact by the new processor, never stamped `form:`; terminal legacy nulls permitted until contract step (§5.1). |
+| 2 | Historical quiz remap has no immutable mapping input (Studio edits quizzes unversioned) | **Adopted** — quiz mapping freezes resolved facts + mapping hash into the job payload at capture; remap = frozen-payloads-only, skip-and-report (§5.2). |
+| 3 | Backend eligibility weaker than rendering eligibility (disabled subtree retains ids; guided_review not type-restricted at save) | **Adopted** — three-leg gate in §5.4 step 4 + tests for disabled-with-ids and direct-API guided_review. |
+| 4 | Backend-only resolveAnswer contradicts byte parity | **Adopted** — resolveAnswer in BOTH twins, frontend never calls (§2). |
+| 5 | Remap counts swallow live traffic; "re-runs no-ops" false for stale/dead | **Adopted** — watermark cohort + run-inserted job-id accounting + coverage query + narrowed idempotency claim (§5.3). |
+| 6 | Real middleware order (limiter first ⇒ 429) + stripUnknown silently removes pattern-failed keys | **Adopted** — nested `.unknown(false)` + bounded key pattern; 400 contract scoped to limiter-admitted requests (§5.4). |
+
+## 12. Codex round 3 — disposition log (REWORK, 1 residual + 1 stale test)
+
+Five of six R2 fixes confirmed closed as written; no other new
+wrong-behavior found.
+
+| # | Finding | Disposition |
+|---|---|---|
+| 1 | New writers can emit artifact-scoped jobs while OLD processors still run (rolling window) — old processor claims them prospect-wide, reintroducing sibling supersession | **Adopted** — dual-shape processor ships with writes OFF; `ENRICHMENT_MAP_ARTIFACT_JOBS` flips post-deploy (restart), so old processors never coexist with new-shape jobs (§5.1 steps 2–3). |
+| 2 | §7 "pending-job stamping" test contradicts the no-stamping choreography | **Adopted** — replaced with mixed-shape coexistence + combined-payload-split + flag-emission tests (§7). |

--- a/src/components/campaignPage/funnelAdapter.js
+++ b/src/components/campaignPage/funnelAdapter.js
@@ -54,5 +54,14 @@ export function deriveFunnelProps(adapted, { onSubmit, previewMode = false, prev
     // Studio jump fixture (preview-only; the form gates consumption on
     // previewMode itself — this is just plumbing).
     ...(previewFixture ? { previewFixture } : {}),
+    // Enrichment profile questions — extracted from the v2 doc BEFORE the
+    // legacy downgrade (the legacy view deliberately excludes v2 top keys;
+    // nothing reaches the funnel "automatically" — studio-profile-questions
+    // §6, Codex PR0 R1 #4). Disabled/absent ⇒ undefined ⇒ block renders
+    // nothing.
+    profileQuestions: isV2Doc && doc.profileQuestions?.enabled === true
+      && Array.isArray(doc.profileQuestions?.questionIds) && doc.profileQuestions.questionIds.length
+      ? { enabled: true, questionIds: doc.profileQuestions.questionIds }
+      : undefined,
   };
 }

--- a/src/components/campaigns/CampaignSignupForm.jsx
+++ b/src/components/campaigns/CampaignSignupForm.jsx
@@ -13,6 +13,7 @@ import {
 } from '@/lib/consentCopy';
 import { formatDateInput, getAgeValidationError, getAgeRestrictionHint, displayPhone } from '@/components/campaigns/signup/dateUtils';
 import { LIMITS } from '@/lib/designConfigV2';
+import { getProfileQuestion } from '@/lib/profileQuestionLibrary';
 import { trackFunnelEvent } from '@/lib/pixelCustom';
 
 /**
@@ -42,6 +43,10 @@ export default function CampaignSignupForm({
   // feeds the UNSAVED doc, which can carry junk mid-edit. Absent → 16 (the
   // frozen v1 size).
   ctaFontSize,
+  // v2 (Campaign Studio) profileQuestions — enrichment questions from the
+  // FIXED library (studio-profile-questions §6). Undefined/disabled ⇒ the
+  // block renders nothing; every question is skippable by design.
+  profileQuestions,
   previewMode = false,
   // v2 (Campaign Studio) content.advertiserName — the DNC gate's advertiser
   // display; defaults to the campaign name exactly as v1 behaves.
@@ -88,6 +93,10 @@ export default function CampaignSignupForm({
     ...(fx?.formData || {}),
   }));
   const [otp, setOtp] = useState('');
+  // Enrichment profile answers — { [questionId]: optionId | optionId[] }.
+  // Skippable by design: tapping a selected chip clears it; the key is
+  // simply absent from the payload when unanswered.
+  const [profileAnswers, setProfileAnswers] = useState({});
   const [otpState, setOtpState] = useState(fx?.otpState ?? 'idle');
   // DNC consent gate (inert unless dncCheckAtSubmit). 'unknown' | 'checking' | 'on_dnc' | 'clear'.
   const [dncStatus, setDncStatus] = useState(fx?.dncStatus ?? 'unknown');
@@ -344,6 +353,10 @@ export default function CampaignSignupForm({
       // DNC consent intent (the server builds the authoritative evidence). Only sent when
       // the gate was actually shown for this lead.
       ...(dncCheckAtSubmit && dncStatus === 'on_dnc' ? { consent_dnc: dncConsent } : {}),
+      // Enrichment profile answers — canonical option ids only; the server
+      // validates against the campaign's configured questions and resolves
+      // taxonomy values itself (studio-profile-questions §5.4).
+      ...(Object.keys(profileAnswers).length ? { profileAnswers } : {}),
     };
 
     // Preview: stop here — never call onSubmit (which would create a real
@@ -924,6 +937,82 @@ export default function CampaignSignupForm({
             }}
           >
             {previewNotice}
+          </div>
+        )}
+
+        {/* Enrichment profile questions (studio-profile-questions §6) —
+            optional chips between the core fields and consent; every
+            question skippable (tap again to clear). data-se marks the
+            Studio click-to-edit jump target; inert on live pages. */}
+        {Array.isArray(profileQuestions?.questionIds) && profileQuestions.questionIds.length > 0 && (
+          <div data-se="profileQuestions" style={{ marginTop: 18 }}>
+            <div style={{
+              fontSize: 12, color: TOKENS.muted, marginBottom: 10,
+              fontFamily: 'Albert Sans, system-ui, sans-serif',
+            }}>
+              Optional — helps us serve you better
+            </div>
+            {profileQuestions.questionIds.map((qid) => {
+              const q = getProfileQuestion(qid);
+              if (!q) return null;
+              const current = profileAnswers[q.id];
+              const isSelected = (optId) => (q.multi
+                ? Array.isArray(current) && current.includes(optId)
+                : current === optId);
+              const toggle = (optId) => setProfileAnswers((prev) => {
+                const next = { ...prev };
+                if (!q.multi) {
+                  if (prev[q.id] === optId) delete next[q.id];
+                  else next[q.id] = optId;
+                } else {
+                  let arr = Array.isArray(prev[q.id]) ? [...prev[q.id]] : [];
+                  if (optId === 'none') {
+                    arr = arr.includes('none') ? [] : ['none'];
+                  } else {
+                    arr = arr.filter((x) => x !== 'none');
+                    arr = arr.includes(optId) ? arr.filter((x) => x !== optId) : [...arr, optId];
+                  }
+                  if (arr.length) next[q.id] = arr; else delete next[q.id];
+                }
+                return next;
+              });
+              return (
+                <div key={q.id} style={{ marginBottom: 14 }}>
+                  <div style={{
+                    fontSize: 13.5, fontWeight: 600, color: TOKENS.body, marginBottom: 8,
+                    fontFamily: 'Albert Sans, system-ui, sans-serif',
+                  }}>
+                    {q.prompt}{q.promptZh ? <span style={{ fontWeight: 400, color: TOKENS.muted }}> · {q.promptZh}</span> : null}
+                  </div>
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                    {q.options.map((opt) => {
+                      const on = isSelected(opt.id);
+                      return (
+                        <button
+                          key={opt.id}
+                          type="button"
+                          onClick={() => toggle(opt.id)}
+                          aria-pressed={on}
+                          style={{
+                            padding: '9px 14px',
+                            borderRadius: 999,
+                            border: `1px solid ${on ? (themeColor || TOKENS.body) : TOKENS.hairline}`,
+                            backgroundColor: on ? (themeColor || TOKENS.body) : (TOKENS.inputBg || '#ffffff'),
+                            color: on ? '#ffffff' : TOKENS.body,
+                            fontSize: 13.5,
+                            fontWeight: 600,
+                            cursor: 'pointer',
+                            fontFamily: 'Albert Sans, system-ui, sans-serif',
+                          }}
+                        >
+                          {opt.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
           </div>
         )}
 

--- a/src/components/campaigns/__tests__/CampaignSignupForm.test.jsx
+++ b/src/components/campaigns/__tests__/CampaignSignupForm.test.jsx
@@ -603,3 +603,53 @@ describe('CampaignSignupForm — DNC consent gate advertiser', () => {
     expect(screen.queryByText('{Advertiser}')).not.toBeInTheDocument();
   });
 });
+
+describe('CampaignSignupForm — profile questions block (studio-profile-questions §6)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const PQ = { enabled: true, questionIds: ['language', 'pets'] };
+
+  it('renders nothing without the prop (v1 docs / disabled subtree)', () => {
+    renderForm();
+    expect(document.querySelector('[data-se="profileQuestions"]')).toBeNull();
+  });
+
+  it('renders enabled questions with bilingual prompts and skippable chips', () => {
+    renderForm({ profileQuestions: PQ });
+    const block = document.querySelector('[data-se="profileQuestions"]');
+    expect(block).toBeTruthy();
+    expect(block.textContent).toContain('Which language do you prefer?');
+    expect(block.textContent).toContain('您偏好哪种语言');
+    expect(block.textContent).toContain('Optional — helps us serve you better');
+    // Unknown ids render nothing (defense against stale configs).
+    expect(block.textContent).not.toContain('retire');
+  });
+
+  it('single-select toggles on and off (skippable by design)', () => {
+    renderForm({ profileQuestions: PQ });
+    const en = screen.getByRole('button', { name: 'English' });
+    fireEvent.click(en);
+    expect(en).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(screen.getByRole('button', { name: '中文' }));
+    expect(en).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(screen.getByRole('button', { name: '中文' }));
+    expect(screen.getByRole('button', { name: '中文' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('multi-select enforces none-exclusivity client-side (mirrors the server rule)', () => {
+    renderForm({ profileQuestions: PQ });
+    const dog = screen.getByRole('button', { name: 'Dog' });
+    const cat = screen.getByRole('button', { name: 'Cat' });
+    const none = screen.getByRole('button', { name: 'No pets' });
+    fireEvent.click(dog);
+    fireEvent.click(cat);
+    expect(dog).toHaveAttribute('aria-pressed', 'true');
+    expect(cat).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(none);
+    expect(none).toHaveAttribute('aria-pressed', 'true');
+    expect(dog).toHaveAttribute('aria-pressed', 'false');
+    expect(cat).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(dog);
+    expect(none).toHaveAttribute('aria-pressed', 'false');
+  });
+});

--- a/src/components/studio/__tests__/editTargets.test.jsx
+++ b/src/components/studio/__tests__/editTargets.test.jsx
@@ -20,6 +20,7 @@ vi.mock('@/api/integrations', () => ({ UploadFile: vi.fn() }));
 import CanvasPageSubject from '../CanvasPageSubject';
 import StudioCanvas from '../StudioCanvas';
 import PagePanel from '../panels/PagePanel';
+import FormPanel from '../panels/FormPanel';
 import { STUDIO_SECTIONS } from '../StudioRail';
 import { STUDIO_EDIT_TARGETS, useEditTargetFocus } from '../studioEditTargets';
 import { upgradeDesignConfig } from '@/lib/designConfigV2';
@@ -275,21 +276,27 @@ describe('useEditTargetFocus choreography', () => {
   });
 });
 
-describe('map ↔ PagePanel contract', () => {
+describe('map ↔ panel contract', () => {
   it('every edit target resolves to a rendered element in its section panel', () => {
-    // Express so the trust-line param field renders; every other target is
-    // unconditional in PagePanel. Every current target lives in the Page
-    // panel — a target declaring another section MUST extend this test with
-    // that section's panel harness (diff review #4).
+    // Express so the trust-line param field renders; every other page target
+    // is unconditional in PagePanel. A target declaring another section MUST
+    // extend this test with that section's panel harness (diff review #4) —
+    // 'form' mounts FormPanel (profileQuestions master toggle renders
+    // unconditionally inside its section).
     const doc = docFor('express');
     doc.luckyDraw = { enabled: true, prize: 'P', closesAt: '2099-12-30', boostClosesAt: '2099-12-30', multiplier: 10, winners: 1 };
-    const { container } = render(
+    const { container: pageContainer } = render(
       <PagePanel doc={doc} setPath={vi.fn()} mut={vi.fn()} />
     );
+    const { container: formContainer } = render(
+      <FormPanel doc={doc} setPath={vi.fn()} mut={vi.fn()} />
+    );
+    const harnesses = { page: pageContainer, form: formContainer };
     for (const [path, target] of Object.entries(STUDIO_EDIT_TARGETS)) {
       expect(STUDIO_SECTIONS.map(([id]) => id)).toContain(target.section);
-      expect(target.section, `no panel harness for section "${target.section}" (${path})`).toBe('page');
-      expect(container.querySelector(`#${target.id}`), `missing #${target.id} for ${path}`).toBeTruthy();
+      const harness = harnesses[target.section];
+      expect(harness, `no panel harness for section "${target.section}" (${path})`).toBeTruthy();
+      expect(harness.querySelector(`#${target.id}`), `missing #${target.id} for ${path}`).toBeTruthy();
     }
   });
 });

--- a/src/components/studio/panels/FormPanel.jsx
+++ b/src/components/studio/panels/FormPanel.jsx
@@ -1,4 +1,5 @@
 import { makeBind, PanelSection, TextField, TextAreaField, Seg, ToggleRow, WarnNote } from './panelKit';
+import { PROFILE_QUESTION_LIBRARY, PROFILE_QUESTION_IDS } from '@/lib/profileQuestionLibrary';
 
 /**
  * Form panel (Studio PR 3) — fields order/visibility/required with 2-col
@@ -181,6 +182,43 @@ export default function FormPanel({ doc, setPath, mut, whatsappOtpConfigured }) 
         {verification === 'whatsapp' && whatsappOtpConfigured === true ? (
           <WarnNote tone="info">✓ WhatsApp credentials are configured on the server.</WarnNote>
         ) : null}
+      </PanelSection>
+
+      <PanelSection title="PROFILE QUESTIONS">
+        {/* Enrichment collection block (studio-profile-questions §3): fixed
+            library only — admins pick, never author; answers are structured
+            choices that build the customer profile. All skippable on the
+            funnel. The AI Fill-everything flow never enables this on its
+            own (conversion-vs-data is the owner's per-campaign call). */}
+        <ToggleRow
+          id="studio-profile-questions"
+          label="Ask profile questions"
+          hint="Optional questions after the signup fields — answers build the customer profile"
+          checked={doc.profileQuestions?.enabled === true}
+          onChange={(v) => mut((d) => {
+            const cur = d.profileQuestions || {};
+            d.profileQuestions = {
+              enabled: v === true,
+              questionIds: Array.isArray(cur.questionIds) ? cur.questionIds : [],
+            };
+          })}
+        />
+        {doc.profileQuestions?.enabled === true && PROFILE_QUESTION_LIBRARY.map((q) => (
+          <ToggleRow
+            key={q.id}
+            id={`studio-pq-${q.id}`}
+            label={q.prompt}
+            hint={q.promptZh}
+            checked={(doc.profileQuestions?.questionIds || []).includes(q.id)}
+            onChange={(v) => mut((d) => {
+              const cur = d.profileQuestions || { enabled: true, questionIds: [] };
+              const set = new Set(cur.questionIds || []);
+              if (v) set.add(q.id); else set.delete(q.id);
+              // Canonical library order, deduped — mirrors the clamp.
+              d.profileQuestions = { ...cur, questionIds: PROFILE_QUESTION_IDS.filter((id) => set.has(id)) };
+            })}
+          />
+        ))}
       </PanelSection>
 
       <PanelSection title="ELIGIBILITY GATES">

--- a/src/components/studio/studioEditTargets.js
+++ b/src/components/studio/studioEditTargets.js
@@ -32,6 +32,9 @@ export const STUDIO_EDIT_TARGETS = {
   'content.drawCopy.ctaSubline': { section: 'page', id: 'studio-draw-ctasubline' },
   'content.drawCopy.freeEntryTag': { section: 'page', id: 'studio-draw-freeentry' },
   'content.drawCopy.boostBody': { section: 'page', id: 'studio-draw-boostbody' },
+  // Profile-questions block (studio-profile-questions §3) — the whole block
+  // jumps to its FormPanel master toggle; no caret focus (it's a switch).
+  'profileQuestions': { section: 'form', id: 'studio-profile-questions', focus: false },
 };
 
 /** Scroll + focus (caret at end) + flash one inspector field, by target. */

--- a/src/lib/designConfigV2.js
+++ b/src/lib/designConfigV2.js
@@ -143,7 +143,7 @@ export const V1_CONSUMED_KEYS = [
 ];
 
 /** Top-level v2 schema keys (used by downgrade + the clamp's alias scrub). */
-export const V2_TOP_KEYS = ['version', 'template', 'theme', 'content', 'form', 'distribution', 'ai'];
+export const V2_TOP_KEYS = ['version', 'template', 'theme', 'content', 'form', 'distribution', 'ai', 'profileQuestions'];
 
 // ───────────────────────── helpers (dependency-free) ─────────────────────────
 

--- a/src/lib/profileQuestionLibrary.js
+++ b/src/lib/profileQuestionLibrary.js
@@ -1,0 +1,141 @@
+/**
+ * Profile question library v1 — the FIXED set of enrichment questions a
+ * campaign may slide into its signup funnel
+ * (docs/plans/studio-profile-questions.md §2).
+ *
+ * TWIN FILE: src/lib/profileQuestionLibrary.js ↔
+ * backend/src/utils/profileQuestionLibrary.js must stay BYTE-IDENTICAL
+ * (parity test enforces). Dependency-free by design. The frontend renders
+ * from prompts/options and NEVER calls resolveAnswer; the backend calls
+ * resolveAnswer to compose the complete taxonomy value server-side —
+ * per-option value fragments are not composable for multi-selects
+ * (Codex PR0 R1 #6 / R2 #4).
+ *
+ * Copy rule (one, deterministic): English prompt with the Chinese inline
+ * where provided — there is no campaign-locale mechanism and none is
+ * assumed (Codex PR0 R1 #9).
+ *
+ * Admins pick questions; they never author them. Free-text answers would
+ * need LLM parsing and would poison the deterministic ledger.
+ */
+
+export const PROFILE_QUESTION_LIBRARY = [
+  {
+    id: 'language',
+    factKey: 'identity.preferred_language',
+    multi: false,
+    prompt: 'Which language do you prefer?',
+    promptZh: '您偏好哪种语言？',
+    options: [
+      { id: 'en', label: 'English' },
+      { id: 'zh', label: '中文' },
+    ],
+  },
+  {
+    id: 'annual_income',
+    factKey: 'finance.annual_income_band',
+    multi: false,
+    prompt: 'What is your annual income range?',
+    promptZh: '您的年收入范围？',
+    options: [
+      { id: 'lt40', label: 'Below $40k' },
+      { id: '40to80', label: '$40k – $80k' },
+      { id: '80to120', label: '$80k – $120k' },
+      { id: '120to200', label: '$120k – $200k' },
+      { id: 'gt200', label: 'Above $200k' },
+    ],
+  },
+  {
+    id: 'children',
+    factKey: 'family.children_count_band',
+    multi: false,
+    prompt: 'Do you have children?',
+    promptZh: '您有孩子吗？',
+    options: [
+      { id: 'none', label: 'None' },
+      { id: 'one', label: '1' },
+      { id: 'two', label: '2' },
+      { id: 'three_plus', label: '3 or more' },
+    ],
+  },
+  {
+    id: 'pets',
+    factKey: 'household.pets',
+    multi: true,
+    prompt: 'Do you have pets? Select all that apply.',
+    promptZh: '您养宠物吗？可多选。',
+    options: [
+      { id: 'dog', label: 'Dog' },
+      { id: 'cat', label: 'Cat' },
+      { id: 'other', label: 'Other' },
+      { id: 'none', label: 'No pets' },
+    ],
+  },
+  {
+    id: 'retirement_age',
+    factKey: 'finance.retirement_age_band',
+    multi: false,
+    prompt: 'At what age do you plan to retire?',
+    promptZh: '您计划几岁退休？',
+    options: [
+      { id: 'lt55', label: 'Before 55' },
+      { id: '55to59', label: '55 – 59' },
+      { id: '60to64', label: '60 – 64' },
+      { id: '65to69', label: '65 – 69' },
+      { id: '70plus', label: '70 or later' },
+    ],
+  },
+];
+
+export const PROFILE_QUESTION_IDS = PROFILE_QUESTION_LIBRARY.map((q) => q.id);
+export const MAX_PROFILE_QUESTIONS = 5;
+
+const byId = new Map(PROFILE_QUESTION_LIBRARY.map((q) => [q.id, q]));
+export const getProfileQuestion = (id) => byId.get(id) || null;
+
+// Single-select answer → taxonomy value.
+const SINGLE_VALUES = {
+  language: { en: { v: 'en' }, zh: { v: 'zh' } },
+  annual_income: {
+    lt40: { v: '<40k' }, '40to80': { v: '40-80k' }, '80to120': { v: '80-120k' },
+    '120to200': { v: '120-200k' }, gt200: { v: '>200k' },
+  },
+  children: {
+    none: { v: '0' }, one: { v: '1' }, two: { v: '2' }, three_plus: { v: '3_plus' },
+  },
+  retirement_age: {
+    lt55: { v: '<55' }, '55to59': { v: '55-59' }, '60to64': { v: '60-64' },
+    '65to69': { v: '65-69' }, '70plus': { v: '70+' },
+  },
+};
+
+const PET_VALUES = { dog: 'dog', cat: 'cat', other: 'other' };
+
+/**
+ * Compose the COMPLETE taxonomy value for a question from the selected
+ * option id(s). Returns null for anything invalid — unknown ids, wrong
+ * single/multi shape, duplicates, or `none`-exclusivity violations
+ * (none + dog is a contradiction, not a preference). The server re-checks
+ * the output with validateFact regardless (belt + braces).
+ */
+export function resolveAnswer(questionId, selectedIds) {
+  const q = byId.get(questionId);
+  if (!q) return null;
+
+  if (!q.multi) {
+    if (typeof selectedIds !== 'string') return null;
+    return SINGLE_VALUES[questionId]?.[selectedIds] || null;
+  }
+
+  // multi (pets)
+  if (!Array.isArray(selectedIds) || selectedIds.length === 0) return null;
+  if (new Set(selectedIds).size !== selectedIds.length) return null;
+  if (!selectedIds.every((s) => q.options.some((o) => o.id === s))) return null;
+  if (selectedIds.includes('none')) {
+    if (selectedIds.length !== 1) return null; // exclusive
+    return { v: [], complete: true };
+  }
+  const values = [...new Set(selectedIds.map((s) => PET_VALUES[s]).filter(Boolean))].sort();
+  if (values.length !== selectedIds.length) return null;
+  return { v: values, complete: true };
+}

--- a/src/pages/LeadCapture.jsx
+++ b/src/pages/LeadCapture.jsx
@@ -324,6 +324,9 @@ export default function LeadCapture() {
         // dncConsent); omitting it here stranded consented DNC-registered leads
         // in the held state until 2026-07-17.
         consent_dnc: formData.consent_dnc,
+        // Enrichment profile answers (canonical option ids) — undefined when
+        // none answered, dropped by JSON.stringify like consent_dnc above.
+        profileAnswers: formData.profileAnswers,
         leadSource: isReferral ? 'referral' : qrTag?.id ? 'qr_code' : 'website',
         campaignId: campaign?.id,
         qrTagId: qrTag?.id,


### PR DESCRIPTION
## What

The collection surface for the consumer-enrichment pipeline (plan: `docs/plans/studio-profile-questions.md` — **APPROVED** after 4 adversarial Codex rounds, logs §10–§12). Campaigns can now slide optional profile questions from a fixed 5-question library (language · annual income · children · pets · retirement age) into their signup funnel via a Campaign Studio FormPanel card; answers land as deterministic facts in the consumer observation ledger (#281).

**Naturally dark** — nothing renders until a campaign enables the block in Studio.

## Highlights

- **Fixed library twins** (byte-identical, parity-tested); answer→fact resolution happens server-side (`resolveAnswer`), never composed from per-option fragments; pets multi-select is none-exclusive with server-canonical ordering.
- **Three config surfaces wired explicitly** (nothing is 'automatically additive'): V2_TOP_KEYS both twins, clamp sanitizer, public-projection leaf-pick.
- **Capture hardening**: nested-strict Joi (the route's stripUnknown would otherwise silently erase the field), three-leg eligibility gate (v2 + enabled + not guided_review — a crafted direct-API POST can't sneak answers past a disabled subtree), campaign-scoped iteration, drop-not-fail policy.
- **Repairs two latent #281 defects** (found by this plan's review, inert in prod until now):
  1. the quiz mapper read `quiz.questions[]`/object answers — real Studio quizzes are `steps[].questions[]` with `[{qid,value}]` submissions (would have minted zero facts);
  2. prospect-wide map jobs let a demographics edit supersede quiz/profile facts — map work is now **artifact-scoped** (expand migration 092 + `ENRICHMENT_MAP_ARTIFACT_JOBS` restart-flip choreography so old processors never meet new-shape jobs; dual-shape processor splits legacy combined payloads).
- **Taxonomy v2**: `family.children_count_band` (`3_plus` = lower bound, never exact). Bonus: the existing `monthly_income` field now mints `finance.income_band`.
- **`scripts/remap-observations.mjs`**: watermark-frozen cohort, run-inserted-job-id accounting (live traffic can't pollute counts), profile facts re-derived from durable canonical answer ids.

## Tests

Local CI mirror fully green: **frontend 1963 · backend unit 1814 · integration 2537 (126 suites) · migrations 30.** New coverage: library parity + resolveAnswer matrix, clamp subtree bounds, capture eligibility/drop matrix, the edit-leaves-profile-alone regression (the #281 bug), legacy-payload split, flag-off evidence-only + post-flip re-derivation, editTargets matrix extended with the FormPanel harness, form-block render/toggle/none-exclusivity.

## Post-merge sequence (plan §8)

1. Deploy (dual-shape processor live, artifact writes still off)
2. Flip `ENRICHMENT_MAP_ARTIFACT_JOBS=true` + restart once old instances are gone
3. Run `node backend/scripts/remap-observations.mjs`
4. Enable questions on the test campaigns in Studio (all five, per owner decision — all campaigns are test campaigns today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFPDaSG4m1LM6CDrLMVaRu