### PR TITLE
feat(profile-questions): per-question Required toggle + Chinese-text toggle

### DIFF
--- a/backend/src/utils/designConfigV2Clamp.js
+++ b/backend/src/utils/designConfigV2Clamp.js
@@ -61,7 +61,7 @@ import { PROFILE_QUESTION_IDS, MAX_PROFILE_QUESTIONS } from './profileQuestionLi
  */
 function clampProfileQuestions(raw) {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
-    return { enabled: false, questionIds: [] };
+    return { enabled: false, questionIds: [], requiredIds: [], showZh: true };
   }
   const seen = new Set();
   const questionIds = [];
@@ -71,7 +71,17 @@ function clampProfileQuestions(raw) {
     questionIds.push(id);
     if (questionIds.length >= MAX_PROFILE_QUESTIONS) break;
   }
-  return { enabled: raw.enabled === true && questionIds.length > 0, questionIds };
+  // requiredIds ⊆ questionIds (a question can't be required if it isn't
+  // asked); showZh defaults ON (hide the inline Chinese only on explicit
+  // false) — owner controls added 2026-07-26.
+  const requiredIds = [...new Set(Array.isArray(raw.requiredIds) ? raw.requiredIds : [])]
+    .filter((id) => questionIds.includes(id));
+  return {
+    enabled: raw.enabled === true && questionIds.length > 0,
+    questionIds,
+    requiredIds,
+    showZh: raw.showZh !== false,
+  };
 }
 
 /**

--- a/backend/src/utils/publicDesignConfig.js
+++ b/backend/src/utils/publicDesignConfig.js
@@ -115,7 +115,12 @@ function buildPublicDesignConfigV2(dc) {
   const pq = dc.profileQuestions;
   if (pq && typeof pq === 'object' && pq.enabled === true
     && Array.isArray(pq.questionIds) && pq.questionIds.length) {
-    out.profileQuestions = { enabled: true, questionIds: [...pq.questionIds] };
+    out.profileQuestions = {
+      enabled: true,
+      questionIds: [...pq.questionIds],
+      requiredIds: Array.isArray(pq.requiredIds) ? [...pq.requiredIds] : [],
+      showZh: pq.showZh !== false,
+    };
   }
   // media WITHOUT the internal legacy shadow (v1-URL bookkeeping for downgrade).
   const media = pick(dc.content?.media, ['kind', 'src', 'alt']);

--- a/backend/test/unit/profileQuestionLibrary.test.js
+++ b/backend/test/unit/profileQuestionLibrary.test.js
@@ -76,18 +76,18 @@ describe('clampDesignConfigV2 — profileQuestions subtree (§3)', () => {
 
   test('unknown ids dropped, order preserved, deduped, capped', () => {
     expect(clamp({ enabled: true, questionIds: ['pets', 'bogus', 'language', 'pets'] }))
-      .toEqual({ enabled: true, questionIds: ['pets', 'language'] });
+      .toEqual({ enabled: true, questionIds: ['pets', 'language'], requiredIds: [], showZh: true });
   });
 
   test('enabled with zero valid ids clamps to disabled', () => {
     expect(clamp({ enabled: true, questionIds: ['bogus'] }))
-      .toEqual({ enabled: false, questionIds: [] });
-    expect(clamp({ enabled: true })).toEqual({ enabled: false, questionIds: [] });
+      .toEqual({ enabled: false, questionIds: [], requiredIds: [], showZh: true });
+    expect(clamp({ enabled: true })).toEqual({ enabled: false, questionIds: [], requiredIds: [], showZh: true });
   });
 
   test('garbage shapes sanitize to disabled; absent stays absent (upgrade preservation)', () => {
-    expect(clamp('yes please')).toEqual({ enabled: false, questionIds: [] });
-    expect(clamp([1, 2])).toEqual({ enabled: false, questionIds: [] });
+    expect(clamp('yes please')).toEqual({ enabled: false, questionIds: [], requiredIds: [], showZh: true });
+    expect(clamp([1, 2])).toEqual({ enabled: false, questionIds: [], requiredIds: [], showZh: true });
     const out = clampDesignConfigV2(base, undefined, 'admin');
     expect(out.profileQuestions).toBeUndefined();
   });
@@ -98,6 +98,17 @@ describe('clampDesignConfigV2 — profileQuestions subtree (§3)', () => {
       undefined,
       'admin'
     );
-    expect(out.profileQuestions).toEqual({ enabled: true, questionIds: ['language'] });
+    expect(out.profileQuestions).toEqual({ enabled: true, questionIds: ['language'], requiredIds: [], showZh: true });
+  });
+
+  test('requiredIds must be a subset of asked questions; dupes dropped (owner controls 07-26)', () => {
+    expect(clamp({ enabled: true, questionIds: ['language', 'pets'], requiredIds: ['pets', 'pets', 'children', 'bogus'] }))
+      .toEqual({ enabled: true, questionIds: ['language', 'pets'], requiredIds: ['pets'], showZh: true });
+  });
+
+  test('showZh: only explicit false hides the Chinese copy', () => {
+    expect(clamp({ enabled: true, questionIds: ['language'], showZh: false }).showZh).toBe(false);
+    expect(clamp({ enabled: true, questionIds: ['language'], showZh: 'nope' }).showZh).toBe(true);
+    expect(clamp({ enabled: true, questionIds: ['language'] }).showZh).toBe(true);
   });
 });

--- a/docs/plans/studio-profile-questions.md
+++ b/docs/plans/studio-profile-questions.md
@@ -19,9 +19,18 @@ on the signup funnel as **optional, structured choices** (never free
 text); answers flow through capture into map-job snapshots and land as
 `consumer_observations` with `form`-grade provenance. No AI anywhere.
 
-Product rules (owner decisions): fixed library only (§2), everything
-skippable, per-campaign selection is Shawn's conversion-vs-data call — the
-AI "Fill everything" flow NEVER enables questions on its own.
+Product rules (owner decisions): fixed library only (§2); per-campaign
+selection is Shawn's conversion-vs-data call — the AI "Fill everything"
+flow NEVER enables questions on its own.
+
+**Owner revision (2026-07-26, post-launch):** questions are skippable BY
+DEFAULT, with two per-campaign controls added the same day: (1)
+`requiredIds ⊆ questionIds` — required questions get an asterisk and the
+funnel blocks submit until answered (CLIENT-side gate only; the server
+keeps its drop-not-fail policy as the net); (2) `showZh` (default true) —
+explicit false renders English-only prompts. Both clamp-sanitized,
+leaf-picked into the public payload, and edited via the Studio card
+(per-question Required toggle + a "Show Chinese text" master toggle).
 
 ## 2. Question library v1 — twins with server-side answer resolution
 

--- a/src/components/campaignPage/funnelAdapter.js
+++ b/src/components/campaignPage/funnelAdapter.js
@@ -61,7 +61,12 @@ export function deriveFunnelProps(adapted, { onSubmit, previewMode = false, prev
     // nothing.
     profileQuestions: isV2Doc && doc.profileQuestions?.enabled === true
       && Array.isArray(doc.profileQuestions?.questionIds) && doc.profileQuestions.questionIds.length
-      ? { enabled: true, questionIds: doc.profileQuestions.questionIds }
+      ? {
+        enabled: true,
+        questionIds: doc.profileQuestions.questionIds,
+        requiredIds: Array.isArray(doc.profileQuestions.requiredIds) ? doc.profileQuestions.requiredIds : [],
+        showZh: doc.profileQuestions.showZh !== false,
+      }
       : undefined,
   };
 }

--- a/src/components/campaigns/CampaignSignupForm.jsx
+++ b/src/components/campaigns/CampaignSignupForm.jsx
@@ -312,6 +312,19 @@ export default function CampaignSignupForm({
       setError('Last drawn salary is required.');
       return;
     }
+
+    // Required profile questions (owner control, 2026-07-26): client-side
+    // gate only — the server keeps its drop-not-fail policy as the net.
+    for (const requiredId of profileQuestions?.requiredIds || []) {
+      const q = getProfileQuestion(requiredId);
+      if (!q) continue;
+      const answer = profileAnswers[requiredId];
+      const answered = q.multi ? Array.isArray(answer) && answer.length > 0 : Boolean(answer);
+      if (!answered) {
+        setError(`Please answer: ${q.prompt}`);
+        return;
+      }
+    }
     if (!consentAll) {
       setError(CONSENT_BLOCK_HELPER);
       return;
@@ -950,11 +963,14 @@ export default function CampaignSignupForm({
               fontSize: 12, color: TOKENS.muted, marginBottom: 10,
               fontFamily: 'Albert Sans, system-ui, sans-serif',
             }}>
-              Optional — helps us serve you better
+              {(profileQuestions.requiredIds || []).length === 0
+                ? 'Optional — helps us serve you better'
+                : 'Helps us serve you better'}
             </div>
             {profileQuestions.questionIds.map((qid) => {
               const q = getProfileQuestion(qid);
               if (!q) return null;
+              const isRequired = (profileQuestions.requiredIds || []).includes(q.id);
               const current = profileAnswers[q.id];
               const isSelected = (optId) => (q.multi
                 ? Array.isArray(current) && current.includes(optId)
@@ -982,7 +998,11 @@ export default function CampaignSignupForm({
                     fontSize: 13.5, fontWeight: 600, color: TOKENS.body, marginBottom: 8,
                     fontFamily: 'Albert Sans, system-ui, sans-serif',
                   }}>
-                    {q.prompt}{q.promptZh ? <span style={{ fontWeight: 400, color: TOKENS.muted }}> · {q.promptZh}</span> : null}
+                    {q.prompt}
+                    {q.promptZh && profileQuestions.showZh !== false
+                      ? <span style={{ fontWeight: 400, color: TOKENS.muted }}> · {q.promptZh}</span>
+                      : null}
+                    {isRequired ? <span aria-hidden="true" style={{ color: themeColor || TOKENS.body }}> *</span> : null}
                   </div>
                   <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
                     {q.options.map((opt) => {

--- a/src/components/campaigns/__tests__/CampaignSignupForm.test.jsx
+++ b/src/components/campaigns/__tests__/CampaignSignupForm.test.jsx
@@ -653,3 +653,34 @@ describe('CampaignSignupForm — profile questions block (studio-profile-questio
     expect(none).toHaveAttribute('aria-pressed', 'false');
   });
 });
+
+describe('CampaignSignupForm — profile question controls (required + showZh)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('hides the inline Chinese when showZh is false', () => {
+    renderForm({ profileQuestions: { enabled: true, questionIds: ['language'], requiredIds: [], showZh: false } });
+    const block = document.querySelector('[data-se="profileQuestions"]');
+    expect(block.textContent).toContain('Which language do you prefer?');
+    expect(block.textContent).not.toContain('您偏好哪种语言');
+  });
+
+  it('shows the Chinese by default (showZh omitted)', () => {
+    renderForm({ profileQuestions: { enabled: true, questionIds: ['language'] } });
+    expect(document.querySelector('[data-se="profileQuestions"]').textContent).toContain('您偏好哪种语言');
+  });
+
+  it('required questions get an asterisk and the header drops "Optional"', () => {
+    renderForm({ profileQuestions: { enabled: true, questionIds: ['language', 'pets'], requiredIds: ['language'], showZh: true } });
+    const block = document.querySelector('[data-se="profileQuestions"]');
+    expect(block.textContent).toContain('*');
+    expect(block.textContent).toContain('Helps us serve you better');
+    expect(block.textContent).not.toContain('Optional — helps us serve you better');
+  });
+
+  it('all-optional keeps the Optional header and no asterisk', () => {
+    renderForm({ profileQuestions: { enabled: true, questionIds: ['language'], requiredIds: [] } });
+    const block = document.querySelector('[data-se="profileQuestions"]');
+    expect(block.textContent).toContain('Optional — helps us serve you better');
+    expect(block.textContent).not.toContain('*');
+  });
+});

--- a/src/components/studio/panels/FormPanel.jsx
+++ b/src/components/studio/panels/FormPanel.jsx
@@ -203,22 +203,59 @@ export default function FormPanel({ doc, setPath, mut, whatsappOtpConfigured }) 
             };
           })}
         />
-        {doc.profileQuestions?.enabled === true && PROFILE_QUESTION_LIBRARY.map((q) => (
+        {doc.profileQuestions?.enabled === true && (
           <ToggleRow
-            key={q.id}
-            id={`studio-pq-${q.id}`}
-            label={q.prompt}
-            hint={q.promptZh}
-            checked={(doc.profileQuestions?.questionIds || []).includes(q.id)}
+            id="studio-pq-showzh"
+            label="Show Chinese text"
+            hint="Off = English-only prompts on the funnel"
+            checked={doc.profileQuestions?.showZh !== false}
             onChange={(v) => mut((d) => {
-              const cur = d.profileQuestions || { enabled: true, questionIds: [] };
-              const set = new Set(cur.questionIds || []);
-              if (v) set.add(q.id); else set.delete(q.id);
-              // Canonical library order, deduped — mirrors the clamp.
-              d.profileQuestions = { ...cur, questionIds: PROFILE_QUESTION_IDS.filter((id) => set.has(id)) };
+              d.profileQuestions = { ...(d.profileQuestions || { enabled: true, questionIds: [] }), showZh: v === true };
             })}
           />
-        ))}
+        )}
+        {doc.profileQuestions?.enabled === true && PROFILE_QUESTION_LIBRARY.map((q) => {
+          const asked = (doc.profileQuestions?.questionIds || []).includes(q.id);
+          return (
+            <div key={q.id}>
+              <ToggleRow
+                id={`studio-pq-${q.id}`}
+                label={q.prompt}
+                hint={q.promptZh}
+                checked={asked}
+                onChange={(v) => mut((d) => {
+                  const cur = d.profileQuestions || { enabled: true, questionIds: [] };
+                  const set = new Set(cur.questionIds || []);
+                  if (v) set.add(q.id); else set.delete(q.id);
+                  // Canonical library order, deduped — mirrors the clamp,
+                  // which also drops a requiredId whose question is unasked.
+                  const questionIds = PROFILE_QUESTION_IDS.filter((id) => set.has(id));
+                  const requiredIds = (cur.requiredIds || []).filter((id) => questionIds.includes(id));
+                  d.profileQuestions = { ...cur, questionIds, requiredIds };
+                })}
+              />
+              {asked && (
+                <div style={{ paddingLeft: 16 }}>
+                  <ToggleRow
+                    id={`studio-pq-${q.id}-required`}
+                    label="Required"
+                    hint="Signup blocked until answered (this campaign only)"
+                    checked={(doc.profileQuestions?.requiredIds || []).includes(q.id)}
+                    onChange={(v) => mut((d) => {
+                      const cur = d.profileQuestions || { enabled: true, questionIds: [] };
+                      const set = new Set(cur.requiredIds || []);
+                      if (v) set.add(q.id); else set.delete(q.id);
+                      d.profileQuestions = {
+                        ...cur,
+                        requiredIds: PROFILE_QUESTION_IDS.filter((id) => set.has(id) && (cur.questionIds || []).includes(id)),
+                      };
+                    })}
+                  />
+                </div>
+              )}
+            </div>
+          );
+        })}
       </PanelSection>
 
       <PanelSection title="ELIGIBILITY GATES">


### PR DESCRIPTION
Two owner controls for the profile-questions block shipped in #284 (plan §1 revision):

- **Required per question** — asterisk on the funnel, submit blocked until answered (client-side gate; server keeps its drop-not-fail policy as the net). `requiredIds ⊆ questionIds`, clamp-enforced; unticking a question in Studio clears its required flag.
- **Show Chinese text per campaign** — `showZh` (default on); off renders English-only prompts.

Both flow clamp → public payload → funnel adapter → form; Studio card gains the master toggle + indented per-question Required rows. No schema/migration changes; no stored configs existed yet, so the shape evolves cleanly.

Tests: clamp subset/dedupe/coercion matrix + 4 new form tests. Local: frontend 1967 · backend unit 1816 · parity/golden/enrichment green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFPDaSG4m1LM6CDrLMVaRu