### PR TITLE
feat(enrichment): PR 2 — the MEET × BUY scoring engine (dark)

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -590,6 +590,17 @@ BEACON_RPS_PER_DEVICE=5
 # /api/admin/*, /api/fleet/*) — a leftover of the abandoned microservices split.
 ENABLE_DOMAIN_PREFIXES=false
 
+# -----------------------------------------------------------------------------
+# Consumer enrichment (docs/plans/consumer-profile-enrichment.md)
+# -----------------------------------------------------------------------------
+# Artifact-scoped map jobs (PR 0/1). Flip only AFTER the deploy carrying
+# migration 092 has fully rolled — old instances cannot process the new shape.
+ENRICHMENT_MAP_ARTIFACT_JOBS=false
+# MEET × BUY scoring sweep (PR 2). Off = the sweep is never scheduled and no
+# score is ever written; the ledger keeps filling either way. Flip after
+# migration 093 lands (it seeds scoring config v1). Restart to take effect.
+ENRICHMENT_SCORING_ENABLED=false
+
 # =============================================================================
 # CLI scripts only (not read by the server)
 # =============================================================================

--- a/backend/scripts/score-consumers.js
+++ b/backend/scripts/score-consumers.js
@@ -1,0 +1,57 @@
+/**
+ * Consumer scoring backfill — the separately-invoked catch-up mode
+ * (docs/plans/consumer-profile-enrichment.md §5, §7.3).
+ *
+ * Deliberately NOT folded into the nightly sweep: a one-off catch-up over
+ * the whole population must not consume the night's budget, and its stats
+ * must be readable on their own row (runType='backfill') rather than
+ * inflating a nightly's numbers into looking healthy.
+ *
+ * Shares the nightly's advisory lock, so this will decline to start while a
+ * sweep is mid-flight rather than double-scoring anyone. Idempotent: every
+ * consumer whose inputs are unchanged short-circuits on the score-input hash.
+ *
+ * Runs regardless of ENRICHMENT_SCORING_ENABLED — that flag gates the
+ * automatic scheduler, not a human deliberately invoking this. Migration 093
+ * must have run (it seeds scoring config v1); without it the script still
+ * works but stamps scoredConfigVersion 0 from the code defaults.
+ *
+ * Usage:
+ *   node scripts/score-consumers.js
+ *   node scripts/score-consumers.js --limit 200
+ *   node scripts/score-consumers.js --after <consumer-uuid>   # resume a slice
+ */
+import dotenv from 'dotenv';
+dotenv.config({ path: new URL('../.env', import.meta.url) });
+
+const arg = (name, fallback = null) => {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+};
+
+const { sequelize } = await import('../src/database/connection.js');
+const { runBackfill } = await import('../src/services/enrichmentSweepService.js');
+
+const rowBudget = Number(arg('limit', '5000'));
+const afterId = arg('after', null);
+
+try {
+  await sequelize.authenticate();
+  const result = await runBackfill({ rowBudget, afterId });
+
+  if (!result.ran) {
+    console.error(`[score-consumers] did not run: ${result.reason}`);
+    process.exit(1);
+  }
+
+  console.log('[score-consumers] done:', JSON.stringify(result.stats, null, 2));
+  if (result.cursor?.lastConsumerId) {
+    // Surfaced so an operator can slice a large backfill across sessions
+    // without re-walking what's already done.
+    console.log(`[score-consumers] resume with: --after ${result.cursor.lastConsumerId}`);
+  }
+  process.exit(0);
+} catch (err) {
+  console.error('[score-consumers] failed:', err?.message || err);
+  process.exit(1);
+}

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -261,6 +261,28 @@ export async function bootstrapDatabase() {
       logger.info('[RedemptionCapi] reconciliation sweep scheduled (6h interval)');
     }
 
+    // Consumer enrichment scoring sweep (consumer-profile-enrichment §7.3).
+    // Recomputes MEET × BUY for consumers whose facts, telemetry or scoring
+    // config moved. Ticks HOURLY but is fenced to one real run per SGT date
+    // by enrichment_sweep_runs — the frequent tick exists so a process that
+    // was down at the intended hour still sweeps that day rather than
+    // silently skipping it. Extra ticks cost one indexed SELECT.
+    // §13 pivot: this runs IN-PROCESS; the Mac/Ollama worker and its
+    // claim/renew/complete endpoints were dropped.
+    if (String(process.env.ENRICHMENT_SCORING_ENABLED || 'false').toLowerCase() === 'true') {
+      const runEnrichmentSweep = async () => {
+        try {
+          const { runNightlySweep } = await import('../services/enrichmentSweepService.js');
+          await runNightlySweep();
+        } catch (err) {
+          logger.warn('[EnrichmentScoring] sweep failed (non-fatal)', { error: err?.message });
+        }
+      };
+      setTimeout(runEnrichmentSweep, 150_000);
+      setInterval(runEnrichmentSweep, 60 * 60 * 1000);
+      logger.info('[EnrichmentScoring] scoring sweep scheduled (hourly tick, one run per SGT date)');
+    }
+
     // Redeem Ops claim-inactivity sweep (docs/redeem-ops/ERD.md §6). Flags
     // at-risk (48h no first outreach) and stale (14d no meaningful activity)
     // partners — NEVER auto-releases; managers act on the flags. In-process like

--- a/backend/src/database/migrations/093-consumer-scores.js
+++ b/backend/src/database/migrations/093-consumer-scores.js
@@ -1,0 +1,105 @@
+/**
+ * 093 — MEET × BUY sub-score columns + the seed scoring config
+ * (docs/plans/consumer-profile-enrichment.md §7.1b).
+ *
+ * 091 shipped the blended `consumerScore`; §7.1b splits the SAME component
+ * math into two sortable sub-scores, so both land as real columns rather
+ * than being dug out of scoreBreakdown JSON at sort time.
+ *
+ * The seed config is INLINED here, never imported from
+ * utils/consumerScoring.js. A migration is a frozen historical record: if it
+ * imported live code, editing today's defaults would retroactively rewrite
+ * what version 1 meant, and every stored breakdown stamped
+ * `scoredConfigVersion: 1` would start lying about the weights that produced
+ * it. Later calibrations are new append-only rows (§7.2), never edits here.
+ *
+ * Owned transaction + catalog guards + idempotent, like 091/092 — the runner
+ * executes migrations on pool connections and is NOT atomic on its own
+ * (Codex R3 #12), and sync({force:true})-built test schemas already carry
+ * the model-declared columns.
+ */
+
+// Config v1 — Shawn recalibrates via a version-2 row, not by editing this
+// (§11 step 4: he is ground truth at this scale; §18 A3: breakdown-first).
+const SEED_CONFIG_V1 = {
+  algorithmVersion: 'score/v1',
+  groups: {
+    meet: ['engagement', 'contactability', 'market_fit'],
+    buy: ['life_events', 'family_gap', 'capacity', 'coverage_headroom'],
+  },
+  components: {
+    engagement: { maxPoints: 15 },
+    contactability: { maxPoints: 10 },
+    market_fit: { maxPoints: 15 },
+    life_events: { maxPoints: 25 },
+    family_gap: { maxPoints: 20 },
+    capacity: { maxPoints: 15 },
+    coverage_headroom: { maxPoints: -10 },
+  },
+  targetSegments: [{ language: 'zh', ethnicity: 'chinese', weight: 1 }],
+  decay: { lifeEventHalfLifeDays: 365, engagementHalfLifeDays: 180 },
+  minFactConfidence: 0.5,
+};
+
+export async function up(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.transaction(async (t) => {
+    const q = (sql, replacements) => sequelize.query(sql, { transaction: t, replacements });
+
+    await q('ALTER TABLE consumer_profiles ADD COLUMN IF NOT EXISTS "meetScore" SMALLINT');
+    await q('ALTER TABLE consumer_profiles ADD COLUMN IF NOT EXISTS "buyScore" SMALLINT');
+
+    await q(`DO $$ BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_cprof_meet_score') THEN
+        ALTER TABLE consumer_profiles ADD CONSTRAINT chk_cprof_meet_score
+          CHECK ("meetScore" IS NULL OR ("meetScore" >= 0 AND "meetScore" <= 100));
+      END IF;
+    END $$`);
+    await q(`DO $$ BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_cprof_buy_score') THEN
+        ALTER TABLE consumer_profiles ADD CONSTRAINT chk_cprof_buy_score
+          CHECK ("buyScore" IS NULL OR ("buyScore" >= 0 AND "buyScore" <= 100));
+      END IF;
+    END $$`);
+
+    // Sort indexes for the People columns (PR 3). Partial: an unscoreable
+    // consumer renders "—" and is never in a score-ordered page.
+    await q(`CREATE INDEX IF NOT EXISTS idx_cprof_meet_score
+      ON consumer_profiles ("meetScore" DESC) WHERE "meetScore" IS NOT NULL`);
+    await q(`CREATE INDEX IF NOT EXISTS idx_cprof_buy_score
+      ON consumer_profiles ("buyScore" DESC) WHERE "buyScore" IS NOT NULL`);
+
+    // Re-score cursor: find profiles scored by a superseded config version
+    // (config change ⇒ full recompute, §7.1) without a sequential scan.
+    await q(`CREATE INDEX IF NOT EXISTS idx_cprof_scored_config
+      ON consumer_profiles ("scoredConfigVersion")`);
+
+    // Seed config v1 — ON CONFLICT DO NOTHING so a re-run never rewrites a
+    // version Shawn may already have recalibrated past.
+    await q(
+      `INSERT INTO enrichment_scoring_configs (version, "configJson", "activatedAt", "actorUserId")
+       VALUES (1, :cfg::jsonb, now(), NULL)
+       ON CONFLICT (version) DO NOTHING`,
+      { cfg: JSON.stringify(SEED_CONFIG_V1) }
+    );
+  });
+}
+
+export async function down(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.transaction(async (t) => {
+    const q = (sql) => sequelize.query(sql, { transaction: t });
+
+    await q('DROP INDEX IF EXISTS idx_cprof_meet_score');
+    await q('DROP INDEX IF EXISTS idx_cprof_buy_score');
+    await q('DROP INDEX IF EXISTS idx_cprof_scored_config');
+    await q('ALTER TABLE consumer_profiles DROP CONSTRAINT IF EXISTS chk_cprof_meet_score');
+    await q('ALTER TABLE consumer_profiles DROP CONSTRAINT IF EXISTS chk_cprof_buy_score');
+    await q('ALTER TABLE consumer_profiles DROP COLUMN IF EXISTS "meetScore"');
+    await q('ALTER TABLE consumer_profiles DROP COLUMN IF EXISTS "buyScore"');
+    // The seed config row is deliberately NOT deleted: stored breakdowns
+    // stamp scoredConfigVersion and must stay interpretable (§7.2).
+  });
+}

--- a/backend/src/models/ConsumerProfile.js
+++ b/backend/src/models/ConsumerProfile.js
@@ -40,6 +40,22 @@ const ConsumerProfile = sequelize.define('ConsumerProfile', {
     validate: { min: 0, max: 100 },
     comment: 'Server-computed only (consumerScoringService); NULL = unscoreable, renders "—"'
   },
+  // §7.1b — the SAME components grouped two ways. Real columns (migration
+  // 093), not scoreBreakdown lookups, because People sorts on them. Declared
+  // on the model as well as the migration: test boot builds schema via
+  // sync({force:true}) BEFORE migrations run (the Consumer.js index lesson).
+  meetScore: {
+    type: DataTypes.SMALLINT,
+    allowNull: true,
+    validate: { min: 0, max: 100 },
+    comment: 'Reachability: engagement + contactability + market fit. NULL = unscoreable'
+  },
+  buyScore: {
+    type: DataTypes.SMALLINT,
+    allowNull: true,
+    validate: { min: 0, max: 100 },
+    comment: 'Potential: life events + family gap + capacity + coverage headroom. NULL until ≥1 fact component is assessed'
+  },
   scoreBreakdown: {
     type: DataTypes.JSONB,
     allowNull: true,

--- a/backend/src/services/consumerScoringService.js
+++ b/backend/src/services/consumerScoringService.js
@@ -1,0 +1,290 @@
+import { sequelize, ConsumerProfile, EnrichmentScoringConfig } from '../models/index.js';
+import { withConsumerLock, ErasedConsumerError } from './enrichmentFence.js';
+import { resolveCurrentFacts } from '../utils/factResolver.js';
+import { canonicalJson, sha256 } from './factMapperService.js';
+import {
+  scoreConsumer, normalizeConfig, DEFAULT_SCORING_CONFIG, SCORING_ALGORITHM_VERSION,
+} from '../utils/consumerScoring.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Consumer scoring service — the I/O half of Phase C
+ * (docs/plans/consumer-profile-enrichment.md §7).
+ *
+ * The math lives in utils/consumerScoring.js (pure, no I/O). This file does
+ * exactly three things: gather the inputs, decide whether a re-score is
+ * warranted, and write the result behind the erasure fence.
+ *
+ * OBSERVATIONS ARE PROSPECT-ANCHORED (§2). The mapper writes
+ * `sourceProspectId` and never `consumerId`, because the spine reconciler
+ * relinks prospects between consumers without locking either one — anchoring
+ * to the prospect and joining through `prospects.consumerId` means a relink
+ * moves the facts with the person automatically. Manual facts (PR 3) are
+ * consumer-anchored instead, so the load is the union of both legs.
+ *
+ * WHY A HASH AND NOT A DIRTY BIT. `inputVersion`/`syncedInputVersion` is the
+ * SYNTHESIS dirtiness protocol (§6.3) — it drives the expensive AI call.
+ * Scoring is cheap and deterministic, so it uses a content hash instead: if
+ * the resolved facts, the telemetry, the config version and the algorithm
+ * version are all unchanged, the output provably cannot differ and we skip
+ * the write. That also gives §7.1's "config change ⇒ full recompute" for
+ * free — bumping the config version changes the hash for everyone at once.
+ *
+ * NULL IS A RESULT, NOT A FAILURE. An unscoreable consumer still gets
+ * `scoredConfigVersion`/`scoringAlgorithmVersion`/`scoreInputHash` stamped
+ * (§7.1, R3 #11). Without the stamp the sweep would re-examine the same
+ * unscoreable people every night forever.
+ */
+
+/** Scoring writes flag — read at call time (restart-to-flip), default OFF. */
+export function scoringEnabled() {
+  return process.env.ENRICHMENT_SCORING_ENABLED === 'true';
+}
+
+// Config is append-only and changes at most a few times a year; a short TTL
+// keeps a sweep of thousands of consumers from re-reading it per row while
+// still picking up a new calibration within the same night.
+const CONFIG_TTL_MS = 60_000;
+let configCache = null;
+
+export function _resetConfigCache() {
+  configCache = null;
+}
+
+/**
+ * Highest-versioned config row wins (§7.2). An empty table is legitimate on
+ * a fresh database that hasn't run 093 yet — fall back to the code defaults
+ * at version 0 so scoring degrades to "works, unstamped" rather than
+ * crashing the sweep.
+ */
+export async function getActiveScoringConfig({ now = Date.now() } = {}) {
+  if (configCache && now - configCache.loadedAt < CONFIG_TTL_MS) return configCache.value;
+
+  let row = null;
+  try {
+    row = await EnrichmentScoringConfig.findOne({ order: [['version', 'DESC']] });
+  } catch (err) {
+    logger.warn('[consumerScoring] config read failed — using defaults', { error: err.message });
+  }
+
+  const value = row
+    ? { version: row.version, config: normalizeConfig(row.configJson) }
+    : { version: 0, config: normalizeConfig(DEFAULT_SCORING_CONFIG) };
+
+  configCache = { value, loadedAt: now };
+  return value;
+}
+
+/**
+ * Every observation that speaks for this consumer: prospect-joined ∪
+ * consumer-anchored, superseded/retracted rows included so the resolver can
+ * apply its own precedence (it filters them itself — §3.4).
+ */
+export async function loadObservations(consumerId) {
+  const [rows] = await sequelize.query(
+    `SELECT o.id, o.key, o.value, o.confidence, o.source, o."sourceEventAt",
+            o."supersededAt", o."retractedAt"
+       FROM consumer_observations o
+       JOIN prospects p ON p.id = o."sourceProspectId"
+      WHERE p."consumerId" = :cid
+      UNION
+     SELECT o.id, o.key, o.value, o.confidence, o.source, o."sourceEventAt",
+            o."supersededAt", o."retractedAt"
+       FROM consumer_observations o
+      WHERE o."consumerId" = :cid`,
+    { replacements: { cid: consumerId } }
+  );
+  return rows;
+}
+
+/**
+ * Behavioral inputs for the Meet half. All of it is derived from tables the
+ * spine already maintains — none of it needs the person to answer anything,
+ * which is why Meet stays scoreable when the fact ledger is empty.
+ */
+export async function loadTelemetry(consumerId) {
+  const [[row]] = await sequelize.query(
+    `SELECT c."signupCount", c."verifiedSignupCount", c."lastSeenAt",
+            (c.email IS NOT NULL AND c.email <> '') AS "hasEmail",
+            EXISTS (
+              SELECT 1 FROM consent_events ce
+               WHERE ce."consumerId" = c.id AND ce.kind = 'marketing'
+                 AND ce.granted = true
+                 AND ce."occurredAt" = (
+                   SELECT MAX(ce2."occurredAt") FROM consent_events ce2
+                    WHERE ce2."consumerId" = c.id AND ce2.kind = 'marketing'
+                 )
+            ) AS "marketingConsent",
+            EXISTS (
+              SELECT 1 FROM wa_message_statuses w
+               WHERE w."recipientHash" = c."phoneHash"
+                 AND w.status IN ('delivered', 'read')
+            ) AS "whatsappReachable"
+       FROM consumers c
+      WHERE c.id = :cid`,
+    { replacements: { cid: consumerId } }
+  );
+  if (!row) return null;
+  return {
+    signupCount: Number(row.signupCount) || 0,
+    verifiedSignupCount: Number(row.verifiedSignupCount) || 0,
+    lastSeenAt: row.lastSeenAt,
+    hasEmail: Boolean(row.hasEmail),
+    marketingConsent: Boolean(row.marketingConsent),
+    whatsappReachable: Boolean(row.whatsappReachable),
+  };
+}
+
+/**
+ * The hash that decides whether a re-score is needed. Built from the
+ * RESOLVED facts (not the raw rows) so that a superseded duplicate or a
+ * re-ordered query result — neither of which can change the output — does
+ * not force a pointless rewrite.
+ */
+export function computeScoreInputHash({ facts, telemetry, configVersion, algorithmVersion }) {
+  const factDigest = Object.keys(facts).sort().map((k) => ({
+    k,
+    v: facts[k].value,
+    c: facts[k].confidence,
+    s: facts[k].source,
+  }));
+  return sha256(canonicalJson({
+    f: factDigest,
+    t: telemetry,
+    cv: configVersion,
+    av: algorithmVersion,
+  }));
+}
+
+/**
+ * Score one consumer and persist the result.
+ *
+ * @returns {{status:'scored'|'unchanged'|'skipped', reason?:string,
+ *            meetScore?:number|null, buyScore?:number|null, consumerScore?:number|null}}
+ */
+export async function scoreOneConsumer(consumerId, { force = false, now = Date.now() } = {}) {
+  const { version: configVersion, config } = await getActiveScoringConfig({ now });
+  const algorithmVersion = config.algorithmVersion || SCORING_ALGORITHM_VERSION;
+
+  const telemetry = await loadTelemetry(consumerId);
+  if (!telemetry) return { status: 'skipped', reason: 'consumer_gone' };
+
+  const observations = await loadObservations(consumerId);
+  const facts = resolveCurrentFacts(observations);
+  const inputHash = computeScoreInputHash({ facts, telemetry, configVersion, algorithmVersion });
+
+  const result = scoreConsumer({ facts, telemetry, config, now });
+
+  try {
+    return await withConsumerLock(consumerId, async (t) => {
+      // Re-read under the lock: another sweep worker may have scored this
+      // consumer between our read and our write.
+      const [[current]] = await sequelize.query(
+        `SELECT "scoreInputHash", "scoredConfigVersion", "scoringAlgorithmVersion"
+           FROM consumer_profiles WHERE "consumerId" = :cid FOR UPDATE`,
+        { replacements: { cid: consumerId }, transaction: t }
+      );
+
+      const alreadyCurrent = current
+        && current.scoreInputHash === inputHash
+        && current.scoredConfigVersion === configVersion
+        && current.scoringAlgorithmVersion === algorithmVersion;
+
+      if (alreadyCurrent && !force) {
+        return { status: 'unchanged', reason: 'input_hash_match' };
+      }
+
+      // UPSERT guarded on a live consumer — scoring must never resurrect a
+      // profile row for someone erased between the fence and this write.
+      await sequelize.query(
+        `INSERT INTO consumer_profiles
+           ("consumerId", "consumerScore", "meetScore", "buyScore", "scoreBreakdown",
+            "scoredConfigVersion", "scoringAlgorithmVersion", "scoreInputHash",
+            "scoreComputedAt", "inputVersion", "syncedInputVersion", "createdAt", "updatedAt")
+         SELECT c.id, :consumerScore, :meetScore, :buyScore, :breakdown::jsonb,
+                :configVersion, :algorithmVersion, :inputHash, now(), 0, 0, now(), now()
+           FROM consumers c
+          WHERE c.id = :cid AND c."erasedAt" IS NULL
+         ON CONFLICT ("consumerId") DO UPDATE SET
+           "consumerScore" = EXCLUDED."consumerScore",
+           "meetScore" = EXCLUDED."meetScore",
+           "buyScore" = EXCLUDED."buyScore",
+           "scoreBreakdown" = EXCLUDED."scoreBreakdown",
+           "scoredConfigVersion" = EXCLUDED."scoredConfigVersion",
+           "scoringAlgorithmVersion" = EXCLUDED."scoringAlgorithmVersion",
+           "scoreInputHash" = EXCLUDED."scoreInputHash",
+           "scoreComputedAt" = EXCLUDED."scoreComputedAt",
+           "updatedAt" = now()`,
+        {
+          replacements: {
+            cid: consumerId,
+            consumerScore: result.consumerScore,
+            meetScore: result.meetScore,
+            buyScore: result.buyScore,
+            breakdown: JSON.stringify(result.breakdown),
+            configVersion,
+            algorithmVersion,
+            inputHash,
+          },
+          transaction: t,
+        }
+      );
+
+      return {
+        status: 'scored',
+        meetScore: result.meetScore,
+        buyScore: result.buyScore,
+        consumerScore: result.consumerScore,
+      };
+    });
+  } catch (err) {
+    if (err instanceof ErasedConsumerError) return { status: 'skipped', reason: 'erased' };
+    throw err;
+  }
+}
+
+/**
+ * Consumers whose score is stale: never scored, scored by a superseded
+ * config, or scored by an older algorithm build. Ordered oldest-first so a
+ * budgeted sweep makes uniform progress instead of re-treading the same head
+ * of the table every night.
+ *
+ * Hash-level staleness (facts changed, config didn't) is NOT detectable in
+ * SQL — that is what the budgeted repair rotation in the sweep is for: it
+ * re-examines everyone on a cycle and the hash check makes the no-op cheap.
+ */
+export async function findStaleConsumerIds({ configVersion, algorithmVersion, limit = 200, afterId = null }) {
+  const [rows] = await sequelize.query(
+    `SELECT c.id
+       FROM consumers c
+       LEFT JOIN consumer_profiles cp ON cp."consumerId" = c.id
+      WHERE c."erasedAt" IS NULL
+        AND (:afterId::uuid IS NULL OR c.id > :afterId::uuid)
+        AND (
+          cp."consumerId" IS NULL
+          OR cp."scoredConfigVersion" IS DISTINCT FROM :configVersion
+          OR cp."scoringAlgorithmVersion" IS DISTINCT FROM :algorithmVersion
+        )
+      ORDER BY c.id
+      LIMIT :limit`,
+    { replacements: { configVersion, algorithmVersion, limit, afterId } }
+  );
+  return rows.map((r) => r.id);
+}
+
+/**
+ * Consumers to re-examine on the repair rotation, walking the id space from
+ * a durable cursor. Used when nothing is config-stale but facts may have
+ * moved under a still-current config.
+ */
+export async function findConsumerIdsAfter({ afterId = null, limit = 200 }) {
+  const [rows] = await sequelize.query(
+    `SELECT id FROM consumers
+      WHERE "erasedAt" IS NULL
+        AND (:afterId::uuid IS NULL OR id > :afterId::uuid)
+      ORDER BY id
+      LIMIT :limit`,
+    { replacements: { afterId, limit } }
+  );
+  return rows.map((r) => r.id);
+}

--- a/backend/src/services/enrichmentSweepService.js
+++ b/backend/src/services/enrichmentSweepService.js
@@ -1,0 +1,367 @@
+import { randomUUID } from 'crypto';
+import { sequelize } from '../models/index.js';
+import {
+  getActiveScoringConfig, findStaleConsumerIds, findConsumerIdsAfter,
+  scoreOneConsumer, scoringEnabled,
+} from './consumerScoringService.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Nightly enrichment sweep + backfill mode
+ * (docs/plans/consumer-profile-enrichment.md §7.3, §5; Codex R3 #9/#10).
+ *
+ * THREE INDEPENDENT GUARDS, because each stops a different failure:
+ *
+ * 1. A session-level `pg_try_advisory_lock` on a DEDICATED connection stops
+ *    two app instances sweeping at once. Session-level, not xact-level: the
+ *    sweep runs for minutes and must not hold a transaction open the whole
+ *    time. `try_` (never blocking) means the loser returns immediately
+ *    instead of piling up connections behind a lock.
+ * 2. The `enrichment_sweep_runs` row is a FENCE, not a log — one live
+ *    nightly per SGT date. `done` ends the date; `failed` may retry within
+ *    it. This is what makes a restart loop safe: a crashed process that
+ *    comes back up ten times does not sweep ten times.
+ * 3. `ownerToken` fences every stats/finalization write, so a zombie that
+ *    wakes up after its run was taken over cannot clobber its successor's
+ *    numbers.
+ *
+ * BUDGETED, ROTATING REPAIR (R3 #10). Config-stale consumers are scored
+ * first — those are provably wrong right now. Whatever budget remains goes
+ * to a rotation through the whole population from a durable cursor, because
+ * facts can change under a still-current config and no SQL predicate can
+ * detect that (the hash check inside scoreOneConsumer makes each no-op
+ * cheap). The cursor persists on the run row, so tonight resumes where last
+ * night stopped instead of re-treading the head of the table forever.
+ *
+ * Backfill is a SEPARATE, separately-observable mode (§5) — never folded
+ * into the nightly budget, so a one-off catch-up can't masquerade as a
+ * healthy nightly or silently consume the night's rows.
+ */
+
+const ADVISORY_LOCK_KEY = 870778093; // 093-series; distinct from the migration runner's
+const STALE_HEARTBEAT_MINUTES = 30;
+const HEARTBEAT_EVERY_ROWS = 25;
+
+const DEFAULT_ROW_BUDGET = 500;
+const DEFAULT_TIME_BUDGET_MS = 5 * 60 * 1000;
+
+/** YYYY-MM-DD in Asia/Singapore (UTC+8, no DST). */
+export function sgtDateString(now = Date.now()) {
+  return new Date(now + 8 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
+/**
+ * Run `fn` holding a session-scoped advisory lock on a dedicated connection.
+ * Returns {acquired: false} without calling fn when another holder exists.
+ * The unlock + release run in `finally` — a throwing fn must never leak the
+ * lock, or every subsequent night would no-op until the process restarts.
+ */
+export async function withAdvisoryLock(key, fn) {
+  const cm = sequelize.connectionManager;
+  const conn = await cm.getConnection({ type: 'write' });
+  const raw = (sql) => conn.query(sql);
+  let acquired = false;
+  try {
+    const res = await raw(`SELECT pg_try_advisory_lock(${key}) AS ok`);
+    acquired = Boolean(res?.rows?.[0]?.ok ?? res?.[0]?.ok);
+    if (!acquired) return { acquired: false };
+    return { acquired: true, value: await fn() };
+  } finally {
+    if (acquired) {
+      try {
+        await raw(`SELECT pg_advisory_unlock(${key})`);
+      } catch (err) {
+        logger.warn('[enrichmentSweep] advisory unlock failed', { error: err.message });
+      }
+    }
+    try {
+      await cm.releaseConnection(conn);
+    } catch {
+      // Pool already disposed (shutdown) — nothing useful left to do.
+    }
+  }
+}
+
+/**
+ * Claim tonight's nightly run: insert a fresh row, retry a previously
+ * `failed` one, or take over a `running` row whose owner has gone quiet.
+ * Returns null when the date is already `done` or another live owner holds it.
+ */
+export async function claimNightlyRun(dateSgt) {
+  const ownerToken = randomUUID();
+
+  const [inserted] = await sequelize.query(
+    `INSERT INTO enrichment_sweep_runs
+       (id, "runDateSgt", "runType", status, "ownerToken", "heartbeatAt", "createdAt", "updatedAt")
+     VALUES (gen_random_uuid(), :date, 'nightly', 'running', :token, now(), now(), now())
+     ON CONFLICT DO NOTHING
+     RETURNING id, "ownerToken", cursor`,
+    { replacements: { date: dateSgt, token: ownerToken } }
+  );
+  if (inserted?.length) return { id: inserted[0].id, ownerToken, cursor: inserted[0].cursor || null };
+
+  // Unique index only covers running|done — a failed row is retryable, and
+  // reviving it in place keeps one row per date instead of accreting rubble.
+  const [revived] = await sequelize.query(
+    `UPDATE enrichment_sweep_runs
+        SET status = 'running', "ownerToken" = :token, "heartbeatAt" = now(),
+            "finishedAt" = NULL, "updatedAt" = now()
+      WHERE "runDateSgt" = :date AND "runType" = 'nightly' AND status = 'failed'
+      RETURNING id, cursor`,
+    { replacements: { date: dateSgt, token: ownerToken } }
+  );
+  if (revived?.length) return { id: revived[0].id, ownerToken, cursor: revived[0].cursor || null };
+
+  // Stale-heartbeat takeover. The predicate is evaluated by the database
+  // inside the UPDATE, so two simultaneous takers cannot both win.
+  const [taken] = await sequelize.query(
+    `UPDATE enrichment_sweep_runs
+        SET "ownerToken" = :token, "heartbeatAt" = now(), "updatedAt" = now()
+      WHERE "runDateSgt" = :date AND "runType" = 'nightly' AND status = 'running'
+        AND "heartbeatAt" < now() - interval '${STALE_HEARTBEAT_MINUTES} minutes'
+      RETURNING id, cursor`,
+    { replacements: { date: dateSgt, token: ownerToken } }
+  );
+  if (taken?.length) {
+    logger.warn('[enrichmentSweep] took over a stale run', { dateSgt, runId: taken[0].id });
+    return { id: taken[0].id, ownerToken, cursor: taken[0].cursor || null };
+  }
+
+  return null; // already done, or a live owner is mid-sweep
+}
+
+/** Owner-token-fenced heartbeat. Returns false if we've been taken over. */
+export async function heartbeat(runId, ownerToken) {
+  const [rows] = await sequelize.query(
+    `UPDATE enrichment_sweep_runs SET "heartbeatAt" = now(), "updatedAt" = now()
+      WHERE id = :id AND "ownerToken" = :token RETURNING id`,
+    { replacements: { id: runId, token: ownerToken } }
+  );
+  return Boolean(rows?.length);
+}
+
+/** Owner-token-fenced finalization. A zombie's late write is a no-op. */
+export async function finalizeRun(runId, ownerToken, { status, stats, cursor }) {
+  const [rows] = await sequelize.query(
+    `UPDATE enrichment_sweep_runs
+        SET status = :status, stats = :stats::jsonb, cursor = :cursor::jsonb,
+            "finishedAt" = now(), "updatedAt" = now()
+      WHERE id = :id AND "ownerToken" = :token
+      RETURNING id`,
+    {
+      replacements: {
+        id: runId,
+        token: ownerToken,
+        status,
+        stats: JSON.stringify(stats || {}),
+        cursor: JSON.stringify(cursor || {}),
+      },
+    }
+  );
+  return Boolean(rows?.length);
+}
+
+/**
+ * Score a list of consumers, respecting the row + wall-time budget.
+ * One consumer's failure is logged and counted, never fatal — a single bad
+ * row must not cost the night's remaining budget.
+ */
+async function processBatch(ids, ctx) {
+  for (const id of ids) {
+    if (ctx.rowsUsed >= ctx.rowBudget) return 'row_budget';
+    if (Date.now() >= ctx.deadline) return 'time_budget';
+
+    try {
+      const res = await scoreOneConsumer(id, { now: Date.now() });
+      ctx.stats[res.status] = (ctx.stats[res.status] || 0) + 1;
+    } catch (err) {
+      ctx.stats.errors = (ctx.stats.errors || 0) + 1;
+      logger.error('[enrichmentSweep] scoring failed', { consumerId: id, error: err.message });
+    }
+
+    ctx.rowsUsed += 1;
+    ctx.lastId = id;
+
+    if (ctx.rowsUsed % HEARTBEAT_EVERY_ROWS === 0 && ctx.runId) {
+      const alive = await heartbeat(ctx.runId, ctx.ownerToken);
+      if (!alive) {
+        logger.warn('[enrichmentSweep] lost ownership mid-run — standing down', { runId: ctx.runId });
+        return 'taken_over';
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * The shared engine for both modes. Config-stale first, then the rotation.
+ */
+async function sweepConsumers({ runId, ownerToken, cursor, rowBudget, timeBudgetMs }) {
+  const { version: configVersion, config } = await getActiveScoringConfig();
+  const algorithmVersion = config.algorithmVersion;
+
+  const ctx = {
+    runId,
+    ownerToken,
+    rowBudget,
+    deadline: Date.now() + timeBudgetMs,
+    rowsUsed: 0,
+    lastId: null,
+    stats: { scored: 0, unchanged: 0, skipped: 0, errors: 0 },
+  };
+
+  // Phase 1 — provably-stale rows (never scored, or scored under an old
+  // config/algorithm). These are wrong right now, so they get first claim.
+  //
+  // The cursor must ADVANCE even though scoring a row normally clears its
+  // own staleness: a consumer that throws, or that comes back 'skipped'
+  // (erased mid-run, vanished), never gets stamped and would be handed back
+  // by the very next query. Without a monotonic cursor a single poison row
+  // would re-fail its way through the entire night's budget.
+  let stop = null;
+  let staleCursor = null;
+  for (;;) {
+    if (ctx.rowsUsed >= ctx.rowBudget || Date.now() >= ctx.deadline) break;
+    const batch = await findStaleConsumerIds({
+      configVersion,
+      algorithmVersion,
+      limit: Math.min(200, ctx.rowBudget - ctx.rowsUsed),
+      afterId: staleCursor,
+    });
+    if (!batch.length) break;
+    stop = await processBatch(batch, ctx);
+    staleCursor = ctx.lastId;
+    if (stop) break;
+  }
+
+  const staleScored = ctx.rowsUsed;
+
+  // Phase 2 — budgeted rotation for hash-level staleness. Resumes from the
+  // durable cursor and wraps to the start of the id space when exhausted.
+  let rotationCursor = cursor?.lastConsumerId || null;
+  if (!stop) {
+    for (;;) {
+      if (ctx.rowsUsed >= ctx.rowBudget || Date.now() >= ctx.deadline) break;
+      const batch = await findConsumerIdsAfter({
+        afterId: rotationCursor,
+        limit: Math.min(200, ctx.rowBudget - ctx.rowsUsed),
+      });
+      if (!batch.length) {
+        if (rotationCursor === null) break; // population fully walked this run
+        rotationCursor = null; // wrap around and keep going
+        continue;
+      }
+      stop = await processBatch(batch, ctx);
+      rotationCursor = ctx.lastId;
+      if (stop) break;
+    }
+  }
+
+  return {
+    stats: {
+      ...ctx.stats,
+      rowsUsed: ctx.rowsUsed,
+      staleScored,
+      rotationScored: ctx.rowsUsed - staleScored,
+      stoppedBy: stop || 'exhausted',
+      configVersion,
+      algorithmVersion,
+    },
+    cursor: { lastConsumerId: rotationCursor },
+    takenOver: stop === 'taken_over',
+  };
+}
+
+/**
+ * Nightly sweep. Safe to call repeatedly — the date fence makes extra calls
+ * no-ops once the night is done.
+ */
+export async function runNightlySweep({
+  rowBudget = DEFAULT_ROW_BUDGET,
+  timeBudgetMs = DEFAULT_TIME_BUDGET_MS,
+  now = Date.now(),
+} = {}) {
+  if (!scoringEnabled()) return { ran: false, reason: 'flag_off' };
+
+  const outcome = await withAdvisoryLock(ADVISORY_LOCK_KEY, async () => {
+    // Re-derive the date AFTER acquiring the lock: we may have waited across
+    // the SGT midnight boundary, and claiming yesterday would burn the fence
+    // for a night that is already over (§7.3 window re-check).
+    const dateSgt = sgtDateString(Date.now());
+
+    const claim = await claimNightlyRun(dateSgt);
+    if (!claim) return { ran: false, reason: 'already_done_or_running', dateSgt };
+
+    try {
+      const { stats, cursor, takenOver } = await sweepConsumers({
+        runId: claim.id,
+        ownerToken: claim.ownerToken,
+        cursor: claim.cursor,
+        rowBudget,
+        timeBudgetMs,
+      });
+      if (takenOver) return { ran: false, reason: 'taken_over', dateSgt };
+
+      await finalizeRun(claim.id, claim.ownerToken, { status: 'done', stats, cursor });
+      logger.info('[enrichmentSweep] nightly complete', { dateSgt, ...stats });
+      return { ran: true, dateSgt, stats };
+    } catch (err) {
+      logger.error('[enrichmentSweep] nightly failed', { dateSgt, error: err.message });
+      // 'failed' (not 'done') so tonight can still be retried — the unique
+      // index deliberately excludes failed rows.
+      await finalizeRun(claim.id, claim.ownerToken, {
+        status: 'failed', stats: { error: err.message }, cursor: claim.cursor,
+      });
+      throw err;
+    }
+  });
+
+  if (!outcome.acquired) return { ran: false, reason: 'lock_held' };
+  return outcome.value;
+}
+
+/**
+ * Backfill mode (§5) — a separately-invoked, separately-observable catch-up.
+ * Own runType, own budget, no date fence, and it always walks from the
+ * supplied cursor so an operator can restart it in slices.
+ */
+export async function runBackfill({
+  rowBudget = 5000,
+  timeBudgetMs = 30 * 60 * 1000,
+  afterId = null,
+} = {}) {
+  const outcome = await withAdvisoryLock(ADVISORY_LOCK_KEY, async () => {
+    const dateSgt = sgtDateString(Date.now());
+    const ownerToken = randomUUID();
+
+    const [rows] = await sequelize.query(
+      `INSERT INTO enrichment_sweep_runs
+         (id, "runDateSgt", "runType", status, "ownerToken", "heartbeatAt", "createdAt", "updatedAt")
+       VALUES (gen_random_uuid(), :date, 'backfill', 'running', :token, now(), now(), now())
+       RETURNING id`,
+      { replacements: { date: dateSgt, token: ownerToken } }
+    );
+    const runId = rows[0].id;
+
+    try {
+      const { stats, cursor } = await sweepConsumers({
+        runId,
+        ownerToken,
+        cursor: { lastConsumerId: afterId },
+        rowBudget,
+        timeBudgetMs,
+      });
+      await finalizeRun(runId, ownerToken, { status: 'done', stats, cursor });
+      logger.info('[enrichmentSweep] backfill complete', { ...stats });
+      return { ran: true, stats, cursor };
+    } catch (err) {
+      await finalizeRun(runId, ownerToken, {
+        status: 'failed', stats: { error: err.message }, cursor: { lastConsumerId: afterId },
+      });
+      throw err;
+    }
+  });
+
+  if (!outcome.acquired) return { ran: false, reason: 'lock_held' };
+  return outcome.value;
+}

--- a/backend/src/utils/consumerScoring.js
+++ b/backend/src/utils/consumerScoring.js
@@ -1,0 +1,499 @@
+/**
+ * Deterministic consumer scoring v1 — the MEET × BUY engine
+ * (docs/plans/consumer-profile-enrichment.md §7.1 + §7.1b).
+ *
+ * PURE: resolved facts + telemetry in → scores out. No I/O, no clock (the
+ * caller passes `now`), no database. Everything the sweep needs to be
+ * reproducible lives in the arguments, so a score can always be re-derived
+ * and explained from the stored breakdown.
+ *
+ * TWO SUB-SCORES, ONE PASS (§7.1b). "Will they meet the consultant" and
+ * "will they buy" are different questions with different drivers; the same
+ * component math is grouped two ways:
+ *
+ *   MEET = engagement 15 + contactability 10 + market fit 15  (raw 40) ×2.5
+ *   BUY  = life events 25 + family gap 20 + capacity 15
+ *          + coverage headroom −10..0                         (raw 60) /60
+ *   consumerScore = clamp(0, Σ all components, 100)  ← stored default sort
+ *
+ * WEIGHTS LIVE IN CONFIG, RULES LIVE IN CODE. `configJson` carries
+ * per-component `maxPoints`, the `groups` map, `targetSegments`, and the
+ * decay/confidence knobs (EnrichmentScoringConfig.js). Each rule here
+ * returns a normalized FRACTION in 0..1 meaning "how much of this
+ * component's max applies"; points = fraction × maxPoints. So recalibrating
+ * is one config row, and regrouping Meet/Buy is a config row too — neither
+ * is a deploy (§7.1b).
+ *
+ * PENALTIES CARRY THEIR SIGN IN `maxPoints`, NEVER IN THE FRACTION.
+ * coverage_headroom has maxPoints −10, so a fraction of 1 ("fully covered")
+ * yields −10. Signing the fraction as well would multiply two negatives into
+ * a bonus for already-insured people — precisely inverting the component.
+ *
+ * ROUND ONCE (§7.1). Fractions and points stay floating all the way
+ * through; clamping happens per sub-score and rounding happens exactly once,
+ * at the very end. Rounding intermediates would make the parts stop summing
+ * to the whole and make the breakdown a liar.
+ *
+ * SCOREABILITY (§7.1b) — a number must never be fabricated from ignorance:
+ *   - BUY is NULL unless ≥1 FACT component is assessed. Unknown capacity
+ *     must not read as "low capacity"; "—" is the honest answer.
+ *   - MEET always computes: engagement + contactability are behavioral and
+ *     always assessable. Market fit contributes only when the language or
+ *     ethnicity fact exists — its absence shrinks Meet's evidence, and the
+ *     breakdown says so rather than silently scoring zero.
+ *
+ * The unknown-vs-zero distinction is the whole point of `state` in the
+ * breakdown: `unknown` means we never asked, `assessed` means we know and
+ * this is the answer. A UI that renders them identically is a bug.
+ */
+
+import { MIN_LLM_CONFIDENCE } from './factTaxonomy.js';
+
+export const SCORING_ALGORITHM_VERSION = 'score/v1';
+
+/** SGT is UTC+8 year-round (no DST) — the one offset this file needs. */
+const SGT_OFFSET_MS = 8 * 60 * 60 * 1000;
+const DAY_MS = 86_400_000;
+
+/**
+ * Config v1 — Shawn calibrates these against his own closing intuition
+ * before agents ever see a number (§11 step 4, §18 A3). Shipped as the seed
+ * row in migration 093; every later calibration is an append-only row with
+ * a higher version, and old breakdowns stay interpretable because each
+ * stamps the version that scored it.
+ */
+export const DEFAULT_SCORING_CONFIG = {
+  algorithmVersion: SCORING_ALGORITHM_VERSION,
+  // Grouping is data, not code (§7.1b) — regrouping is a config insert.
+  groups: {
+    meet: ['engagement', 'contactability', 'market_fit'],
+    buy: ['life_events', 'family_gap', 'capacity', 'coverage_headroom'],
+  },
+  components: {
+    engagement: { maxPoints: 15 },
+    contactability: { maxPoints: 10 },
+    market_fit: { maxPoints: 15 },
+    life_events: { maxPoints: 25 },
+    family_gap: { maxPoints: 20 },
+    capacity: { maxPoints: 15 },
+    // Negative max: a penalty component. Range −10..0.
+    coverage_headroom: { maxPoints: -10 },
+  },
+  // Which market we're currently selling into. Retargeting = one new row.
+  targetSegments: [{ language: 'zh', ethnicity: 'chinese', weight: 1 }],
+  decay: {
+    lifeEventHalfLifeDays: 365, // a trigger a year old is worth half
+    engagementHalfLifeDays: 180,
+  },
+  minFactConfidence: MIN_LLM_CONFIDENCE,
+};
+
+/** Components whose evidence is FACTS (vs behavioral telemetry). */
+export const FACT_COMPONENTS = new Set([
+  'market_fit', 'life_events', 'family_gap', 'capacity', 'coverage_headroom',
+]);
+
+const clamp = (n, lo, hi) => Math.min(hi, Math.max(lo, n));
+
+/**
+ * Kill negative zero. A zero-fraction penalty computes 0 × −10 = −0, which
+ * is === 0 but survives into the stored breakdown JSON as `-0` and reads as
+ * a bug to anyone auditing a score.
+ */
+const noNegZero = (n) => (n === 0 ? 0 : n);
+
+/** Exponential half-life decay, floored at 0. */
+function decayFactor(ageMs, halfLifeDays) {
+  if (!(halfLifeDays > 0)) return 1;
+  if (!Number.isFinite(ageMs) || ageMs <= 0) return 1;
+  return Math.pow(0.5, ageMs / (halfLifeDays * DAY_MS));
+}
+
+/**
+ * End of a "YYYY-QN" quarter, in SGT, as an epoch ms.
+ * A life event dated 2026-Q1 stops being "recent" from the END of Q1 —
+ * decaying from the start would over-age an event that may have happened on
+ * the quarter's last day.
+ */
+export function quarterEndMs(when) {
+  const m = /^(\d{4})-Q([1-4])$/.exec(String(when || ''));
+  if (!m) return null;
+  const year = Number(m[1]);
+  const q = Number(m[2]);
+  // First instant of the NEXT quarter, SGT, minus 1ms.
+  const nextMonth = q * 3; // Q1→3 (Apr), Q2→6 (Jul), Q3→9 (Oct), Q4→12 (Jan+1)
+  const utcMs = Date.UTC(year + (nextMonth === 12 ? 1 : 0), nextMonth === 12 ? 0 : nextMonth, 1);
+  return utcMs - SGT_OFFSET_MS - 1;
+}
+
+/** Position on an ordered ladder → 0..1 fraction via an explicit table. */
+function ladder(table, value) {
+  return Object.prototype.hasOwnProperty.call(table, value) ? table[value] : null;
+}
+
+const INCOME_LADDER_ANNUAL = { '<40k': 0.10, '40-80k': 0.35, '80-120k': 0.60, '120-200k': 0.85, '>200k': 1.0 };
+const INCOME_LADDER_MONTHLY = { '<3k': 0.10, '3-6k': 0.35, '6-10k': 0.60, '10-15k': 0.85, '>15k': 1.0 };
+const PROPERTY_LADDER = { none: 0.10, hdb: 0.35, condo: 0.75, landed: 1.0 };
+const EMPLOYMENT_LADDER = {
+  unemployed: 0.10, student: 0.15, nsf: 0.20, retired: 0.40, employed: 0.80, self_employed: 0.90,
+};
+const CHILDREN_BAND_LADDER = { '0': 0.15, '1': 0.60, '2': 0.85, '3_plus': 1.0 };
+const MARITAL_LADDER = { single: 0.20, widowed: 0.50, divorced: 0.60, married: 0.80 };
+const LIFE_EVENT_WEIGHT = {
+  new_child: 1.0, marriage: 0.90, new_home: 0.80, bereavement: 0.75, divorce: 0.70, new_job: 0.60,
+};
+/** Coverage that actually closes the protection gap we sell into. */
+const CORE_COVERAGE = ['life', 'health', 'ci'];
+
+/**
+ * Blend several optional signals, renormalizing over the ones present.
+ * A consumer who only ever told us their income still gets the full 0..1
+ * range on capacity — missing signals must not drag a score toward zero,
+ * because that would be scoring ignorance as a negative.
+ */
+function blend(parts) {
+  const present = parts.filter((p) => p && p.fraction !== null && p.fraction !== undefined);
+  if (!present.length) return null;
+  const totalWeight = present.reduce((s, p) => s + p.weight, 0);
+  if (!(totalWeight > 0)) return null;
+  return present.reduce((s, p) => s + p.fraction * p.weight, 0) / totalWeight;
+}
+
+const unknown = (note) => ({ state: 'unknown', fraction: null, basis: [], note });
+const assessed = (fraction, basis, note) => ({ state: 'assessed', fraction, basis, note });
+
+/**
+ * A fact counts only if it clears the confidence floor (§7.1). LLM-extracted
+ * facts arrive with a confidence; form/manual facts are 1.0 by construction.
+ */
+function factOf(facts, key, minConfidence) {
+  const f = facts?.[key];
+  if (!f) return null;
+  if (typeof f.confidence === 'number' && f.confidence < minConfidence) return null;
+  return f;
+}
+
+// ── MEET components ────────────────────────────────────────────────────────
+
+function scoreEngagement(telemetry, cfg, now) {
+  const signups = Number(telemetry?.signupCount) || 0;
+  if (signups <= 0) {
+    // A consumer row exists but carries no signup — nothing behavioral yet.
+    return unknown('no signups recorded');
+  }
+  const depth = signups >= 4 ? 1.0 : { 1: 0.35, 2: 0.65, 3: 0.85 }[signups] ?? 1.0;
+
+  const lastSeen = telemetry?.lastSeenAt ? new Date(telemetry.lastSeenAt).getTime() : null;
+  const recency = lastSeen ? decayFactor(now - lastSeen, cfg.decay?.engagementHalfLifeDays) : 1;
+
+  // Verified signups are the ones that proved a live phone — they say more
+  // about willingness to engage than a raw form submit does.
+  const verified = Number(telemetry?.verifiedSignupCount) || 0;
+  const verifiedBonus = signups > 0 ? 0.15 * clamp(verified / signups, 0, 1) : 0;
+
+  const fraction = clamp(depth * recency + verifiedBonus, 0, 1);
+  return assessed(fraction, [], `${signups} signup(s), ${verified} verified`);
+}
+
+function scoreContactability(telemetry) {
+  // Every term is a channel we can actually reach them on today. This is
+  // always assessable: absence of consent IS the answer, not ignorance.
+  const marketing = telemetry?.marketingConsent ? 0.45 : 0;
+  const verified = (Number(telemetry?.verifiedSignupCount) || 0) > 0 ? 0.30 : 0;
+  const email = telemetry?.hasEmail ? 0.15 : 0;
+  const wa = telemetry?.whatsappReachable ? 0.10 : 0;
+  const fraction = clamp(marketing + verified + email + wa, 0, 1);
+  const have = [
+    telemetry?.marketingConsent && 'marketing consent',
+    verified && 'verified phone',
+    telemetry?.hasEmail && 'email',
+    telemetry?.whatsappReachable && 'WhatsApp',
+  ].filter(Boolean);
+  return assessed(fraction, [], have.length ? `reachable via ${have.join(', ')}` : 'no reachable channel');
+}
+
+/**
+ * Market fit — LANGUAGE-PRIMARY (§7.2). Language is what actually decides
+ * whether a Mandarin-speaking consultant can serve them; ethnicity is a
+ * weaker proxy and, per the taxonomy, is only ever self-declared.
+ */
+function scoreMarketFit(facts, cfg) {
+  const segments = Array.isArray(cfg.targetSegments) ? cfg.targetSegments : [];
+  if (!segments.length) return unknown('no target segment configured');
+
+  const min = cfg.minFactConfidence;
+  const lang = factOf(facts, 'identity.preferred_language', min);
+  const eth = factOf(facts, 'identity.ethnicity', min);
+  if (!lang && !eth) return unknown('no language or ethnicity fact');
+
+  let best = 0;
+  let matched = null;
+  for (const seg of segments) {
+    const weight = typeof seg.weight === 'number' ? clamp(seg.weight, 0, 1) : 1;
+    if (seg.language && lang?.value?.v === seg.language) {
+      if (weight > best) { best = weight; matched = `language ${seg.language}`; }
+      continue;
+    }
+    // Ethnicity alone is a half-strength signal — it suggests the market but
+    // doesn't establish the servicing language.
+    if (seg.ethnicity && eth?.value?.v === seg.ethnicity) {
+      const half = weight * 0.5;
+      if (half > best) { best = half; matched = `ethnicity ${seg.ethnicity}`; }
+    }
+  }
+  const basis = [lang?.observationId, eth?.observationId].filter(Boolean);
+  return assessed(best, basis, matched ? `matches ${matched}` : 'outside target segment');
+}
+
+// ── BUY components ─────────────────────────────────────────────────────────
+
+function scoreLifeEvents(facts, cfg, now) {
+  const min = cfg.minFactConfidence;
+  const ev = factOf(facts, 'life_event.recent', min);
+  if (!ev) return unknown('no recent life event on record');
+
+  const base = LIFE_EVENT_WEIGHT[ev.value?.v] ?? 0.5;
+  // Prefer the stated quarter; fall back to when we observed it.
+  const atMs = quarterEndMs(ev.value?.when) ?? new Date(ev.sourceEventAt).getTime();
+  const aged = decayFactor(now - atMs, cfg.decay?.lifeEventHalfLifeDays);
+  const fraction = clamp(base * aged, 0, 1);
+  const whenLabel = ev.value?.when ? ` (${ev.value.when})` : '';
+  return assessed(fraction, [ev.observationId].filter(Boolean), `${ev.value?.v}${whenLabel}`);
+}
+
+/**
+ * Family gap — who depends on this person's income. The detailed children
+ * array outranks the count band when both exist (the band is a lower bound
+ * for '3_plus'; the array carries actual composition) — taxonomy §4.
+ */
+function scoreFamilyGap(facts, cfg) {
+  const min = cfg.minFactConfidence;
+  const children = factOf(facts, 'family.children', min);
+  const band = factOf(facts, 'family.children_count_band', min);
+  const marital = factOf(facts, 'family.marital_status', min);
+  const parents = factOf(facts, 'family.parents_alive', min);
+
+  let childFraction = null;
+  const basis = [];
+  if (children && Array.isArray(children.value?.v) && (children.value.v.length || children.value?.complete)) {
+    const n = children.value.v.length;
+    childFraction = n >= 3 ? 1.0 : { 0: 0.15, 1: 0.60, 2: 0.85 }[n] ?? 1.0;
+    basis.push(...(children.basis || [children.observationId]).filter(Boolean));
+  } else if (band) {
+    childFraction = ladder(CHILDREN_BAND_LADDER, band.value?.v);
+    if (band.observationId) basis.push(band.observationId);
+  }
+
+  const maritalFraction = marital ? ladder(MARITAL_LADDER, marital.value?.v) : null;
+  if (marital?.observationId && maritalFraction !== null) basis.push(marital.observationId);
+
+  // Living parents are potential dependants in the SG sandwich-generation sense.
+  const parentsFraction = parents ? (parents.value?.v === true ? 0.7 : 0.1) : null;
+  if (parents?.observationId && parentsFraction !== null) basis.push(parents.observationId);
+
+  const fraction = blend([
+    { fraction: childFraction, weight: 0.60 },
+    { fraction: maritalFraction, weight: 0.30 },
+    { fraction: parentsFraction, weight: 0.10 },
+  ]);
+  if (fraction === null) return unknown('no family facts');
+
+  const notes = [
+    childFraction !== null && (children ? `${children.value.v.length} child(ren)` : `children ${band.value?.v}`),
+    maritalFraction !== null && marital.value?.v,
+    parentsFraction !== null && `parents ${parents.value?.v ? 'alive' : 'not living'}`,
+  ].filter(Boolean);
+  return assessed(clamp(fraction, 0, 1), basis, notes.join(', '));
+}
+
+/** Capacity — can they fund a policy. Annual income band is the PR 0 question. */
+function scoreCapacity(facts, cfg) {
+  const min = cfg.minFactConfidence;
+  const annual = factOf(facts, 'finance.annual_income_band', min);
+  const monthly = factOf(facts, 'finance.income_band', min);
+  const property = factOf(facts, 'assets.property', min);
+  const employment = factOf(facts, 'career.employment', min);
+
+  const basis = [];
+  let incomeFraction = null;
+  if (annual) {
+    incomeFraction = ladder(INCOME_LADDER_ANNUAL, annual.value?.v);
+    if (annual.observationId) basis.push(annual.observationId);
+  } else if (monthly) {
+    incomeFraction = ladder(INCOME_LADDER_MONTHLY, monthly.value?.v);
+    if (monthly.observationId) basis.push(monthly.observationId);
+  }
+
+  const propertyFraction = property ? ladder(PROPERTY_LADDER, property.value?.v) : null;
+  if (property?.observationId && propertyFraction !== null) basis.push(property.observationId);
+
+  const employmentFraction = employment ? ladder(EMPLOYMENT_LADDER, employment.value?.v) : null;
+  if (employment?.observationId && employmentFraction !== null) basis.push(employment.observationId);
+
+  const fraction = blend([
+    { fraction: incomeFraction, weight: 0.60 },
+    { fraction: propertyFraction, weight: 0.25 },
+    { fraction: employmentFraction, weight: 0.15 },
+  ]);
+  if (fraction === null) return unknown('no income, property or employment fact');
+
+  const notes = [
+    incomeFraction !== null && `income ${(annual ?? monthly).value?.v}`,
+    propertyFraction !== null && `property ${property.value?.v}`,
+    employmentFraction !== null && employment.value?.v,
+  ].filter(Boolean);
+  return assessed(clamp(fraction, 0, 1), basis, notes.join(', '));
+}
+
+/**
+ * Coverage headroom — a PENALTY (−10..0). Someone already carrying life +
+ * health + CI has little room left; someone explicitly carrying nothing has
+ * full headroom and takes no penalty.
+ *
+ * Only a COMPLETE coverage list can penalize: a partial list ("they
+ * mentioned health") cannot establish what they DON'T have, and penalizing
+ * on it would punish people for having said more.
+ */
+function scoreCoverageHeadroom(facts, cfg) {
+  const min = cfg.minFactConfidence;
+  const cov = factOf(facts, 'finance.existing_coverage', min);
+  if (!cov || !Array.isArray(cov.value?.v)) return unknown('no coverage fact');
+  if (cov.value?.complete !== true) return unknown('coverage list incomplete — cannot infer gaps');
+
+  const held = new Set(cov.value.v);
+  if (held.has('none') || cov.value.v.length === 0) {
+    return assessed(0, (cov.basis || [cov.observationId]).filter(Boolean), 'no existing coverage — full headroom');
+  }
+  const coreHeld = CORE_COVERAGE.filter((c) => held.has(c)).length;
+  // Positive fraction: 1 = all three core lines held. The minus lives in
+  // this component's maxPoints (−10), so points come out negative.
+  const fraction = clamp(coreHeld / CORE_COVERAGE.length, 0, 1);
+  return assessed(
+    fraction,
+    (cov.basis || [cov.observationId]).filter(Boolean),
+    coreHeld ? `holds ${CORE_COVERAGE.filter((c) => held.has(c)).join(', ')}` : 'no core coverage'
+  );
+}
+
+const RULES = {
+  engagement: (facts, telemetry, cfg, now) => scoreEngagement(telemetry, cfg, now),
+  contactability: (facts, telemetry) => scoreContactability(telemetry),
+  market_fit: (facts, telemetry, cfg) => scoreMarketFit(facts, cfg),
+  life_events: (facts, telemetry, cfg, now) => scoreLifeEvents(facts, cfg, now),
+  family_gap: (facts, telemetry, cfg) => scoreFamilyGap(facts, cfg),
+  capacity: (facts, telemetry, cfg) => scoreCapacity(facts, cfg),
+  coverage_headroom: (facts, telemetry, cfg) => scoreCoverageHeadroom(facts, cfg),
+};
+
+/** Merge a stored config over the defaults without losing unspecified knobs. */
+export function normalizeConfig(configJson) {
+  const c = configJson && typeof configJson === 'object' ? configJson : {};
+  return {
+    ...DEFAULT_SCORING_CONFIG,
+    ...c,
+    groups: { ...DEFAULT_SCORING_CONFIG.groups, ...(c.groups || {}) },
+    components: { ...DEFAULT_SCORING_CONFIG.components, ...(c.components || {}) },
+    decay: { ...DEFAULT_SCORING_CONFIG.decay, ...(c.decay || {}) },
+    targetSegments: Array.isArray(c.targetSegments) ? c.targetSegments : DEFAULT_SCORING_CONFIG.targetSegments,
+    minFactConfidence: typeof c.minFactConfidence === 'number'
+      ? c.minFactConfidence
+      : DEFAULT_SCORING_CONFIG.minFactConfidence,
+  };
+}
+
+/**
+ * Score one consumer.
+ *
+ * @param {Object} input
+ * @param {Object} input.facts      resolveCurrentFacts() output (key → {value, confidence, observationId, basis, …})
+ * @param {Object} input.telemetry  {signupCount, verifiedSignupCount, lastSeenAt, marketingConsent, hasEmail, whatsappReachable}
+ * @param {Object} input.config     configJson from enrichment_scoring_configs (merged over defaults)
+ * @param {number} input.now        epoch ms — injected so scoring is reproducible in tests and backfills
+ * @returns {{meetScore:number|null, buyScore:number|null, consumerScore:number|null,
+ *            breakdown:Object, algorithmVersion:string}}
+ */
+export function scoreConsumer({ facts = {}, telemetry = {}, config, now = Date.now() } = {}) {
+  const cfg = normalizeConfig(config);
+  const components = {};
+
+  for (const [name, def] of Object.entries(cfg.components)) {
+    const rule = RULES[name];
+    const maxPoints = Number(def?.maxPoints) || 0;
+    if (!rule) {
+      // A config naming a component this build doesn't implement must not
+      // silently vanish from the breakdown — an unexplained gap in the parts
+      // is worse than an explicit "not implemented here".
+      components[name] = {
+        state: 'unknown', points: 0, maxPoints, basisObservationIds: [], note: 'no rule for this component',
+      };
+      continue;
+    }
+    const res = rule(facts, telemetry, cfg, now);
+    components[name] = {
+      state: res.state,
+      points: res.state === 'assessed' ? noNegZero(res.fraction * maxPoints) : 0,
+      maxPoints,
+      basisObservationIds: res.basis || [],
+      note: res.note,
+    };
+  }
+
+  const sumGroup = (names) => names
+    .filter((n) => components[n])
+    .reduce((s, n) => s + components[n].points, 0);
+  const rawMaxOf = (names) => names
+    .filter((n) => components[n])
+    .reduce((s, n) => s + Math.max(0, components[n].maxPoints), 0);
+
+  const meetNames = cfg.groups.meet || [];
+  const buyNames = cfg.groups.buy || [];
+
+  // MEET: computes whenever ANY of its components is assessed (engagement +
+  // contactability are behavioral, so in practice always).
+  const meetAssessed = meetNames.some((n) => components[n]?.state === 'assessed');
+  const meetRawMax = rawMaxOf(meetNames);
+  const meetScore = meetAssessed && meetRawMax > 0
+    ? Math.round(clamp(sumGroup(meetNames) / meetRawMax, 0, 1) * 100)
+    : null;
+
+  // BUY: needs ≥1 assessed FACT component — unknown capacity must not fake a
+  // number (§7.1b). The headroom penalty alone counts as evidence: knowing
+  // someone is already fully covered is a real, scoreable finding.
+  const buyFactAssessed = buyNames.some(
+    (n) => FACT_COMPONENTS.has(n) && components[n]?.state === 'assessed'
+  );
+  const buyRawMax = rawMaxOf(buyNames);
+  const buyScore = buyFactAssessed && buyRawMax > 0
+    ? Math.round(clamp(sumGroup(buyNames) / buyRawMax, 0, 1) * 100)
+    : null;
+
+  // Blended total — the stored default sort key. NULL only when neither
+  // half could be scored at all.
+  const allNames = [...new Set([...meetNames, ...buyNames])];
+  const consumerScore = (meetScore === null && buyScore === null)
+    ? null
+    : Math.round(clamp(sumGroup(allNames), 0, 100));
+
+  return {
+    meetScore,
+    buyScore,
+    consumerScore,
+    algorithmVersion: cfg.algorithmVersion || SCORING_ALGORITHM_VERSION,
+    breakdown: {
+      algorithmVersion: cfg.algorithmVersion || SCORING_ALGORITHM_VERSION,
+      groups: {
+        meet: { score: meetScore, rawMax: meetRawMax, components: meetNames.filter((n) => components[n]) },
+        buy: { score: buyScore, rawMax: buyRawMax, components: buyNames.filter((n) => components[n]) },
+      },
+      // Points are rounded for DISPLAY only, to 2dp — the scores above were
+      // computed from the unrounded values (round-once, §7.1).
+      components: Object.fromEntries(
+        Object.entries(components).map(([n, c]) => [n, { ...c, points: noNegZero(Math.round(c.points * 100) / 100) }])
+      ),
+      completeness: {
+        assessed: Object.values(components).filter((c) => c.state === 'assessed').length,
+        total: Object.keys(components).length,
+      },
+    },
+  };
+}

--- a/backend/test/unit/consumerScoring.test.js
+++ b/backend/test/unit/consumerScoring.test.js
@@ -1,0 +1,316 @@
+import {
+  scoreConsumer, quarterEndMs, normalizeConfig, DEFAULT_SCORING_CONFIG,
+  SCORING_ALGORITHM_VERSION,
+} from '../../src/utils/consumerScoring.js'
+import { sgtDateString } from '../../src/services/enrichmentSweepService.js'
+
+/**
+ * MEET × BUY scoring engine — the pure half of PR 2
+ * (docs/plans/consumer-profile-enrichment.md §7.1, §7.1b).
+ *
+ * The load-bearing property under test is UNKNOWN ≠ ZERO. A person we never
+ * asked about income must not score the same as one who told us they earn
+ * under 40k, and Buy must refuse to produce a number at all until at least
+ * one fact component is assessed. Everything else here — decay, round-once,
+ * config overrides — exists to keep that distinction honest under change.
+ */
+
+const NOW = Date.UTC(2026, 6, 26, 9, 0, 0) // 2026-07-26 17:00 SGT
+
+/** Telemetry for a maximally reachable person — isolates the Buy half. */
+const fullTelemetry = {
+  signupCount: 1,
+  verifiedSignupCount: 1,
+  lastSeenAt: new Date(NOW).toISOString(),
+  hasEmail: true,
+  marketingConsent: true,
+  whatsappReachable: true,
+}
+
+const fact = (v, extra = {}) => ({
+  value: v, confidence: 1, source: 'form', sourceEventAt: new Date(NOW).toISOString(),
+  observationId: 'obs-1', basis: ['obs-1'], ...extra,
+})
+
+const score = (facts = {}, telemetry = fullTelemetry, config = undefined) =>
+  scoreConsumer({ facts, telemetry, config, now: NOW })
+
+describe('scoreability — a number is never invented from ignorance', () => {
+  test('Buy is NULL when no fact component is assessed', () => {
+    const r = score({})
+    expect(r.buyScore).toBeNull()
+    expect(r.breakdown.components.capacity.state).toBe('unknown')
+    expect(r.breakdown.components.family_gap.state).toBe('unknown')
+  })
+
+  test('Meet still computes with zero facts — engagement + contactability are behavioral', () => {
+    const r = score({})
+    expect(r.meetScore).toBeGreaterThan(0)
+    expect(r.breakdown.components.engagement.state).toBe('assessed')
+    expect(r.breakdown.components.contactability.state).toBe('assessed')
+    // Market fit needs a fact; its absence is unknown, NOT a zero-scoring miss.
+    expect(r.breakdown.components.market_fit.state).toBe('unknown')
+  })
+
+  test('one assessed fact component unlocks Buy', () => {
+    const r = score({ 'finance.annual_income_band': fact({ v: '>200k' }) })
+    expect(r.buyScore).not.toBeNull()
+    expect(r.breakdown.components.capacity.state).toBe('assessed')
+  })
+
+  test('unknown capacity does NOT read as low capacity', () => {
+    const unknownCapacity = score({ 'family.children_count_band': fact({ v: '2' }) })
+    const lowCapacity = score({
+      'family.children_count_band': fact({ v: '2' }),
+      'finance.annual_income_band': fact({ v: '<40k' }),
+    })
+    // Both are scoreable, but the one who told us "<40k" carries an assessed
+    // component the other lacks — the breakdown must distinguish them.
+    expect(unknownCapacity.breakdown.components.capacity.state).toBe('unknown')
+    expect(lowCapacity.breakdown.components.capacity.state).toBe('assessed')
+    expect(lowCapacity.buyScore).toBeGreaterThan(unknownCapacity.buyScore)
+  })
+
+  test('both scores NULL only when nothing at all is assessable', () => {
+    const r = scoreConsumer({ facts: {}, telemetry: { signupCount: 0 }, now: NOW })
+    // No signups ⇒ engagement unknown, but contactability is still assessed
+    // (absence of consent IS the answer), so Meet survives.
+    expect(r.breakdown.components.engagement.state).toBe('unknown')
+    expect(r.meetScore).not.toBeNull()
+    expect(r.buyScore).toBeNull()
+  })
+})
+
+describe('market fit is language-primary (§7.2)', () => {
+  test('language match scores full weight', () => {
+    const r = score({ 'identity.preferred_language': fact({ v: 'zh' }) })
+    const mf = r.breakdown.components.market_fit
+    expect(mf.state).toBe('assessed')
+    expect(mf.points).toBeCloseTo(15, 5)
+  })
+
+  test('ethnicity alone is a half-strength signal — it does not establish servicing language', () => {
+    const r = score({ 'identity.ethnicity': fact({ v: 'chinese' }) })
+    expect(r.breakdown.components.market_fit.points).toBeCloseTo(7.5, 5)
+  })
+
+  test('outside the target segment scores zero but is still ASSESSED', () => {
+    const r = score({ 'identity.preferred_language': fact({ v: 'ta' }) })
+    const mf = r.breakdown.components.market_fit
+    expect(mf.state).toBe('assessed')
+    expect(mf.points).toBe(0)
+  })
+
+  test('retargeting is a config change, not a deploy', () => {
+    const tamilMarket = { ...DEFAULT_SCORING_CONFIG, targetSegments: [{ language: 'ta', weight: 1 }] }
+    const r = score({ 'identity.preferred_language': fact({ v: 'ta' }) }, fullTelemetry, tamilMarket)
+    expect(r.breakdown.components.market_fit.points).toBeCloseTo(15, 5)
+  })
+})
+
+describe('life-event decay is SGT-quarter-anchored', () => {
+  test('quarterEndMs lands on the last instant of the quarter in SGT', () => {
+    // 2026-Q1 ends 31 Mar 2026 23:59:59.999 SGT = 15:59:59.999 UTC.
+    expect(quarterEndMs('2026-Q1')).toBe(Date.UTC(2026, 2, 31, 15, 59, 59, 999))
+    // Q4 must roll into the next year, not month 12 of the same one.
+    expect(quarterEndMs('2026-Q4')).toBe(Date.UTC(2026, 11, 31, 15, 59, 59, 999))
+    expect(quarterEndMs('nonsense')).toBeNull()
+  })
+
+  test('a fresh trigger outscores an old one of the same kind', () => {
+    const fresh = score({ 'life_event.recent': fact({ v: 'new_child', when: '2026-Q2' }) })
+    const old = score({ 'life_event.recent': fact({ v: 'new_child', when: '2022-Q1' }) })
+    expect(fresh.breakdown.components.life_events.points)
+      .toBeGreaterThan(old.breakdown.components.life_events.points)
+  })
+
+  test('one half-life halves the component', () => {
+    // Half-life is 365d; place the quarter end exactly 365d before NOW.
+    const cfg = { ...DEFAULT_SCORING_CONFIG, decay: { ...DEFAULT_SCORING_CONFIG.decay, lifeEventHalfLifeDays: 365 } }
+    const at = quarterEndMs('2025-Q2')
+    const ageDays = (NOW - at) / 86_400_000
+    const r = scoreConsumer({
+      facts: { 'life_event.recent': fact({ v: 'new_child', when: '2025-Q2' }) },
+      telemetry: fullTelemetry, config: cfg, now: NOW,
+    })
+    const expected = 25 * 1.0 * Math.pow(0.5, ageDays / 365)
+    expect(r.breakdown.components.life_events.points).toBeCloseTo(Math.round(expected * 100) / 100, 1)
+  })
+
+  test('an undated event decays from when we observed it', () => {
+    const r = score({
+      'life_event.recent': fact({ v: 'marriage' }, { sourceEventAt: new Date(NOW).toISOString() }),
+    })
+    // Observed now ⇒ no decay ⇒ full base weight for marriage (0.9).
+    expect(r.breakdown.components.life_events.points).toBeCloseTo(0.9 * 25, 5)
+  })
+})
+
+describe('coverage headroom is a penalty, and only a COMPLETE list may penalize', () => {
+  test('a partial coverage list cannot establish what they lack', () => {
+    const r = score({ 'finance.existing_coverage': fact({ v: ['health'], complete: false }) })
+    expect(r.breakdown.components.coverage_headroom.state).toBe('unknown')
+  })
+
+  test('explicitly no coverage takes no penalty and still counts as evidence', () => {
+    const r = score({ 'finance.existing_coverage': fact({ v: [], complete: true }) })
+    const ch = r.breakdown.components.coverage_headroom
+    expect(ch.state).toBe('assessed')
+    expect(ch.points).toBe(0)
+    // Knowing someone carries nothing is a real finding — it unlocks Buy.
+    expect(r.buyScore).not.toBeNull()
+  })
+
+  test('full core coverage applies the full negative', () => {
+    const r = score({ 'finance.existing_coverage': fact({ v: ['life', 'health', 'ci'], complete: true }) })
+    expect(r.breakdown.components.coverage_headroom.points).toBeCloseTo(-10, 5)
+  })
+
+  test('the penalty cannot drive a sub-score below zero', () => {
+    const r = score({ 'finance.existing_coverage': fact({ v: ['life', 'health', 'ci'], complete: true }) })
+    expect(r.buyScore).toBe(0)
+    expect(r.consumerScore).toBeGreaterThanOrEqual(0)
+  })
+})
+
+describe('arithmetic discipline', () => {
+  test('rounds exactly once — sub-scores derive from unrounded points', () => {
+    const r = score({
+      'finance.annual_income_band': fact({ v: '80-120k' }),
+      'family.children_count_band': fact({ v: '1' }),
+    })
+    // capacity = 0.60 × 15 = 9 ; family = 0.60 × 20 = 12 ⇒ 21/60 = 35%
+    expect(r.breakdown.components.capacity.points).toBeCloseTo(9, 5)
+    expect(r.breakdown.components.family_gap.points).toBeCloseTo(12, 5)
+    expect(r.buyScore).toBe(35)
+  })
+
+  test('scores stay inside 0..100', () => {
+    const maxed = score({
+      'identity.preferred_language': fact({ v: 'zh' }),
+      'life_event.recent': fact({ v: 'new_child', when: '2026-Q3' }),
+      'family.children_count_band': fact({ v: '3_plus' }),
+      'family.marital_status': fact({ v: 'married' }),
+      'finance.annual_income_band': fact({ v: '>200k' }),
+      'assets.property': fact({ v: 'landed' }),
+      'career.employment': fact({ v: 'self_employed' }),
+    })
+    expect(maxed.meetScore).toBeLessThanOrEqual(100)
+    expect(maxed.buyScore).toBeLessThanOrEqual(100)
+    expect(maxed.consumerScore).toBeLessThanOrEqual(100)
+    expect(maxed.consumerScore).toBeGreaterThan(50)
+  })
+
+  test('missing signals renormalize instead of dragging a component down', () => {
+    // Income-only capacity must reach the top of the range; blending against
+    // absent property/employment as if they were zero would cap it at 60%.
+    const r = score({ 'finance.annual_income_band': fact({ v: '>200k' }) })
+    expect(r.breakdown.components.capacity.points).toBeCloseTo(15, 5)
+  })
+
+  test('a low-confidence fact is ignored by the fact rules', () => {
+    const r = score({
+      'finance.annual_income_band': fact({ v: '>200k' }, { confidence: 0.2 }),
+    })
+    expect(r.breakdown.components.capacity.state).toBe('unknown')
+    expect(r.buyScore).toBeNull()
+  })
+
+  test('the detailed children array outranks the count band', () => {
+    const r = score({
+      'family.children_count_band': fact({ v: '0' }),
+      'family.children': fact({ v: [{ birth_year_band: '2015-2019' }, { birth_year_band: '2020-2024' }], complete: true }),
+    })
+    // 2 children ⇒ 0.85, not the band's 0.15.
+    expect(r.breakdown.components.family_gap.points).toBeCloseTo(0.85 * 20, 5)
+  })
+})
+
+describe('config drives weights and grouping (§7.1b)', () => {
+  test('maxPoints overrides recalibrate without a deploy', () => {
+    const heavier = {
+      ...DEFAULT_SCORING_CONFIG,
+      components: { ...DEFAULT_SCORING_CONFIG.components, capacity: { maxPoints: 60 } },
+    }
+    const r = score({ 'finance.annual_income_band': fact({ v: '>200k' }) }, fullTelemetry, heavier)
+    expect(r.breakdown.components.capacity.points).toBeCloseTo(60, 5)
+  })
+
+  test('regrouping is a config insert — capacity can move into Meet', () => {
+    const regrouped = {
+      ...DEFAULT_SCORING_CONFIG,
+      groups: { meet: ['engagement', 'contactability', 'capacity'], buy: ['life_events', 'family_gap'] },
+    }
+    const r = score({ 'finance.annual_income_band': fact({ v: '>200k' }) }, fullTelemetry, regrouped)
+    expect(r.breakdown.groups.meet.components).toContain('capacity')
+    // Buy now has no assessed fact component ⇒ correctly NULL.
+    expect(r.buyScore).toBeNull()
+  })
+
+  test('a component the config names but this build cannot score stays visible', () => {
+    const withGhost = {
+      ...DEFAULT_SCORING_CONFIG,
+      components: { ...DEFAULT_SCORING_CONFIG.components, future_signal: { maxPoints: 10 } },
+    }
+    const r = score({}, fullTelemetry, withGhost)
+    expect(r.breakdown.components.future_signal.state).toBe('unknown')
+    expect(r.breakdown.components.future_signal.note).toMatch(/no rule/)
+  })
+
+  test('normalizeConfig fills gaps without discarding overrides', () => {
+    const merged = normalizeConfig({ components: { capacity: { maxPoints: 99 } } })
+    expect(merged.components.capacity.maxPoints).toBe(99)
+    expect(merged.components.engagement.maxPoints).toBe(15)
+    expect(merged.decay.lifeEventHalfLifeDays).toBe(365)
+    expect(merged.algorithmVersion).toBe(SCORING_ALGORITHM_VERSION)
+  })
+})
+
+describe('breakdown is explainable', () => {
+  test('every assessed fact component cites the observations behind it', () => {
+    const r = score({ 'finance.annual_income_band': fact({ v: '40-80k' }, { observationId: 'obs-income' }) })
+    expect(r.breakdown.components.capacity.basisObservationIds).toContain('obs-income')
+  })
+
+  test('completeness counts what we actually know', () => {
+    const r = score({ 'finance.annual_income_band': fact({ v: '40-80k' }) })
+    // engagement + contactability + capacity assessed of 7 components.
+    expect(r.breakdown.completeness).toEqual({ assessed: 3, total: 7 })
+  })
+})
+
+describe('the first real consumer through the pipe', () => {
+  // Shavon Teo, prod 2026-07-26: the first signup to answer PR 0's profile
+  // questions. Her three observations are exactly what the live mapper wrote.
+  const shavon = {
+    'finance.annual_income_band': fact({ v: '<40k' }, { observationId: 'obs-income' }),
+    'family.children_count_band': fact({ v: '0' }, { observationId: 'obs-children' }),
+    'identity.birth_year_band': fact({ v: '1995-1999' }, { observationId: 'obs-birth' }),
+  }
+
+  test('scores on both halves', () => {
+    const r = score(shavon)
+    expect(r.meetScore).not.toBeNull()
+    expect(r.buyScore).not.toBeNull()
+    expect(r.consumerScore).not.toBeNull()
+  })
+
+  test('reads as reachable but early-stage — not a false hot lead', () => {
+    const r = score(shavon)
+    expect(r.meetScore).toBeGreaterThan(r.buyScore)
+    expect(r.buyScore).toBeLessThan(25)
+  })
+
+  test('market fit stays unknown until a language question is asked', () => {
+    // Her campaign enabled annual_income + children only — no language.
+    expect(score(shavon).breakdown.components.market_fit.state).toBe('unknown')
+  })
+})
+
+describe('SGT date helper', () => {
+  test('rolls at SGT midnight, not UTC midnight', () => {
+    // 2026-07-26 16:30 UTC = 2026-07-27 00:30 SGT.
+    expect(sgtDateString(Date.UTC(2026, 6, 26, 16, 30))).toBe('2026-07-27')
+    expect(sgtDateString(Date.UTC(2026, 6, 26, 15, 30))).toBe('2026-07-26')
+  })
+})


### PR DESCRIPTION
Facts have been landing in the ledger since PR 0/1 went live (Shavon Teo, 2026-07-26 — 3 observations, both map jobs `done`), but nothing turned them into a number. This is the deterministic half of Phase C.

## Two questions, not one (§7.1b)

```
MEET = engagement 15 + contactability 10 + market fit 15  (raw 40) ×2.5
BUY  = life events 25 + family gap 20 + capacity 15
       + coverage headroom −10..0                         (raw 60) /60
consumerScore = clamp(0, Σ all, 100) — retained as the sort key
```

**Unknown is never zero.** BUY refuses to produce a number until ≥1 FACT component is assessed — unknown capacity must not read as low capacity. MEET always computes (engagement + contactability are behavioral); market fit contributes only when the language/ethnicity facts exist, and the breakdown says so rather than scoring a silent zero.

## Weights in config, rules in code

Each rule returns a 0..1 fraction; `points = fraction × maxPoints`. Recalibrating is one append-only config row — so is regrouping Meet/Buy, or retargeting the market segment. Migration 093 seeds config v1 with the weights **inlined, never imported**: a migration is a frozen record, and importing live defaults would retroactively rewrite what version 1 meant for every stored breakdown.

Penalties carry their sign in `maxPoints` alone. Signing the fraction too made already-insured people score a **bonus** — caught by test during the build.

## Sweep (§7.3) — three independent guards

| Guard | Stops |
|---|---|
| Session-level advisory lock, dedicated connection | Two app instances sweeping at once |
| `enrichment_sweep_runs` date fence | A restart loop sweeping ten times |
| `ownerToken` on every finalization | A zombie clobbering its successor's stats |

Config-stale rows score first; leftover budget rotates through the population from a durable cursor (facts move under a current config, and no SQL predicate detects that). Phase 1's cursor advances monotonically so one poison row can't re-fail through the whole night's budget. Backfill is a separate mode + script, never folded into the nightly budget.

**§13 pivot honored:** no Mac worker, no launchd, no claim/renew/complete endpoints. The sweep runs in-process.

## Ships dark

`ENRICHMENT_SCORING_ENABLED` (default off) — flag off schedules nothing and writes no score. Migration 093 is additive; the ledger keeps filling either way.

PR 3 surfaces the chips + breakdown. **Its density gate is unchanged and not yet met** — 1 of 130 consumers currently carries any facts.

## Verification

- 32 new pure engine tests: scoreability both directions, language-primary market fit, SGT quarter-anchored decay incl. an exact half-life, complete-list-only penalty rule, round-once, renormalization, confidence floor, config override + regroup, and the first real consumer through the pipe.
- Backend unit suite green locally: **103 suites, 1848 tests**.
- The 115 DB-backed suites in `backend/test/` could not run locally (no Postgres, no Docker in this environment) — CI covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127w4fTdWuoNTSZbBexNN8Z