### PR TITLE
fix(enrichment): unbreak main — migration 093 crashed every integration suite

### DIFF
--- a/backend/src/database/migrations/093-consumer-scores.js
+++ b/backend/src/database/migrations/093-consumer-scores.js
@@ -77,9 +77,19 @@ export async function up(queryInterface) {
 
     // Seed config v1 — ON CONFLICT DO NOTHING so a re-run never rewrites a
     // version Shawn may already have recalibrated past.
+    // Seed config v1 — ON CONFLICT DO NOTHING so a re-run never rewrites a
+    // version Shawn may already have recalibrated past.
+    //
+    // "createdAt"/"updatedAt" are supplied EXPLICITLY. 091 declares them
+    // DEFAULT now(), but test schemas are built by sync({force:true}) from
+    // the models, where Sequelize emits them NOT NULL with NO database
+    // default — it fills timestamps at the ORM layer, and a raw INSERT that
+    // omits them dies on the not-null constraint. Any raw INSERT into a
+    // model-backed table must name them.
     await q(
-      `INSERT INTO enrichment_scoring_configs (version, "configJson", "activatedAt", "actorUserId")
-       VALUES (1, :cfg::jsonb, now(), NULL)
+      `INSERT INTO enrichment_scoring_configs
+         (version, "configJson", "activatedAt", "actorUserId", "createdAt", "updatedAt")
+       VALUES (1, :cfg::jsonb, now(), NULL, now(), now())
        ON CONFLICT (version) DO NOTHING`,
       { cfg: JSON.stringify(SEED_CONFIG_V1) }
     );

--- a/backend/src/services/consumerScoringService.js
+++ b/backend/src/services/consumerScoringService.js
@@ -1,4 +1,4 @@
-import { sequelize, ConsumerProfile, EnrichmentScoringConfig } from '../models/index.js';
+import { sequelize, EnrichmentScoringConfig } from '../models/index.js';
 import { withConsumerLock, ErasedConsumerError } from './enrichmentFence.js';
 import { resolveCurrentFacts } from '../utils/factResolver.js';
 import { canonicalJson, sha256 } from './factMapperService.js';

--- a/backend/src/services/enrichmentSweepService.js
+++ b/backend/src/services/enrichmentSweepService.js
@@ -276,10 +276,12 @@ async function sweepConsumers({ runId, ownerToken, cursor, rowBudget, timeBudget
  * Nightly sweep. Safe to call repeatedly — the date fence makes extra calls
  * no-ops once the night is done.
  */
+// No `now` parameter by design: the SGT date is deliberately re-derived
+// INSIDE the lock (below), so a caller-supplied clock read from before the
+// wait could name a night that is already over.
 export async function runNightlySweep({
   rowBudget = DEFAULT_ROW_BUDGET,
   timeBudgetMs = DEFAULT_TIME_BUDGET_MS,
-  now = Date.now(),
 } = {}) {
   if (!scoringEnabled()) return { ran: false, reason: 'flag_off' };
 


### PR DESCRIPTION
#286 merged before CI finished. Two defects landed on `main`; this PR carries both fixes.

## 1. Migration 093 crashed every DB-backed suite (the serious one)

```
null value in column "createdAt" of relation "enrichment_scoring_configs"
violates not-null constraint
```

The migration runner aborts boot on a throw, so **all 115 integration suites failed** regardless of subject. Backend Tests on main is red for this single reason.

The trap is a schema divergence, not the SQL:

| Path | `createdAt` shape |
|---|---|
| Migration 091 (`CREATE TABLE`) — what prod has | `NOT NULL DEFAULT now()` |
| `sync({force:true})` from the model — what tests have | `NOT NULL`, **no default** (Sequelize fills it at the ORM layer) |

Tests sync from the models *first*, so 091's `CREATE TABLE IF NOT EXISTS` is a no-op and the table keeps the defaultless shape. My seed INSERT omitted the timestamps and died. **Prod would have applied it cleanly** — this was only ever reachable via the test path.

Fix: name `"createdAt"`/`"updatedAt"` explicitly. The rule it encodes is in the code comment — *any* raw INSERT into a model-backed table must name them.

## 2. Lint error

```
backend/src/services/consumerScoringService.js
  1:21  error  'ConsumerProfile' is defined but never used
```

The service writes through raw SQL (the UPSERT needs `ON CONFLICT`), so the model import was dead on arrival. Also drops `runNightlySweep`'s now-unused `now` param, with a comment on why it must not come back.

## Verification

I brought up a real **Postgres 17** locally and built the database exactly the way CI does (`sync({force:true})` → migrations):

- Migration 093 **applies cleanly**; `consumerEnrichment.test.js` → **12/12 pass** (was 12/12 failing).
- `cd backend && npx eslint src/ --quiet` → **exit 0** (CI's exact command); confirmed it fails on `origin/main`.
- Scoring engine unit tests: **32/32**.
- Migration-test suite shows an identical 19-failed/11-passed **with and without 093 removed** — those are local-environment artifacts on PG17, unrelated to this change.

Full integration run against local Postgres is finishing now; I'll confirm before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127w4fTdWuoNTSZbBexNN8Z