### PR TITLE
feat(enrichment): PR 3 — the scores get a face, and it shows its working

### DIFF
--- a/backend/src/services/consumerService.js
+++ b/backend/src/services/consumerService.js
@@ -558,6 +558,16 @@ export function makeConsumerService(overrides = {}) {
       // float erased (all-null-name) rows to the top (R1 #13).
       name: 'c."lastName" ASC NULLS LAST, c."firstName" ASC NULLS LAST',
       '-name': 'c."lastName" DESC NULLS LAST, c."firstName" DESC NULLS LAST',
+      // MEET × BUY (consumer-profile-enrichment §8). NULLS LAST in BOTH
+      // directions for the same reason as name: an unscoreable person renders
+      // "—" and must never lead a score-ordered page — ascending by Buy should
+      // surface the lowest real score, not the 129 people we can't score.
+      '-meetScore': 'cp."meetScore" DESC NULLS LAST',
+      meetScore: 'cp."meetScore" ASC NULLS LAST',
+      '-buyScore': 'cp."buyScore" DESC NULLS LAST',
+      buyScore: 'cp."buyScore" ASC NULLS LAST',
+      '-consumerScore': 'cp."consumerScore" DESC NULLS LAST',
+      consumerScore: 'cp."consumerScore" ASC NULLS LAST',
     };
     const orderBy = SORTS[sort] || SORTS['-lastSeenAt'];
 
@@ -589,10 +599,18 @@ export function makeConsumerService(overrides = {}) {
           { replacements, transaction: t }
         );
         const [rows] = await d.sequelize.query(
+          // LEFT JOIN, never INNER: a person with no profile row (never swept,
+          // or scoring has never been enabled) must still be listed — the
+          // People directory is the person index, not the scored index.
+          // scoredConfigVersion distinguishes "scored, unscoreable ⇒ —" from
+          // "never scored", which the column renders identically but the
+          // profile page does not.
           `SELECT c.id, c."firstName", c."lastName", c.email, c.phone,
                   c."signupCount", c."verifiedSignupCount",
                   c."firstSeenAt", c."lastSeenAt", c."erasedAt",
-                  lp.id AS "latestProspectId"
+                  lp.id AS "latestProspectId",
+                  cp."meetScore", cp."buyScore", cp."consumerScore",
+                  cp."scoredConfigVersion"
              FROM consumers c
              JOIN LATERAL (
                SELECT p.id FROM prospects p
@@ -600,6 +618,7 @@ export function makeConsumerService(overrides = {}) {
                 ORDER BY p."createdAt" DESC, p.id DESC
                 LIMIT 1
              ) lp ON true
+             LEFT JOIN consumer_profiles cp ON cp."consumerId" = c.id
             WHERE true ${qClause}
             ORDER BY ${orderBy}, c.id DESC
             LIMIT :limit OFFSET :offset`,

--- a/backend/src/services/leadProfileService.js
+++ b/backend/src/services/leadProfileService.js
@@ -2,7 +2,7 @@ import { Op } from 'sequelize';
 import {
   Draw, RewardEntitlement, Activation, RewardOffer, ConsumerSuppression,
   EmailBroadcastRecipient, SessionVisit, ProspectActivity, User, ExternalAgent,
-  RedemptionEvent, ConsentEvent, sequelize,
+  RedemptionEvent, ConsentEvent, ConsumerProfile, sequelize,
 } from '../models/index.js';
 import { logger } from '../utils/logger.js';
 import { presentState } from '../utils/entitlementPresentState.js';
@@ -10,6 +10,8 @@ import { makeLuckyDrawService } from './luckyDrawService.js';
 import { getConsentState } from './consentService.js';
 import { phoneKeyOf, LIVE_PHONE_STATUSES } from './redeemOps/entitlementService.js';
 import { phoneVerificationIsCurrent } from './consumerService.js';
+import { loadObservations } from './consumerScoringService.js';
+import { resolveCurrentFacts } from '../utils/factResolver.js';
 import { SCREENING_REASONS } from './screeningConstants.js';
 
 /**
@@ -38,12 +40,14 @@ export function makeLeadProfileService(overrides = {}) {
   const d = {
     Draw, RewardEntitlement, Activation, RewardOffer, ConsumerSuppression,
     EmailBroadcastRecipient, SessionVisit, ProspectActivity, User, ExternalAgent,
-    RedemptionEvent, ConsentEvent, sequelize, logger,
+    RedemptionEvent, ConsentEvent, ConsumerProfile, sequelize, logger,
     getProspectDrawStatus: null, // defaults to a lucky-draw service built below
     getConsentState,
     presentState,
     phoneKeyOf,
     phoneVerificationIsCurrent,
+    loadObservations,
+    resolveCurrentFacts,
     now: () => new Date(),
     ...overrides,
   };
@@ -485,7 +489,76 @@ export function makeLeadProfileService(overrides = {}) {
       .then((rows) => rows.map((r) => ({ channel: r.channel, reason: r.reason })))
       .catch(() => []);
     journey.broadcasts = await broadcastHistory(journey.consumer.id);
+    journey.enrichment = erased ? null : await consumerEnrichment(journey.consumer.id);
     return journey;
+  }
+
+  /**
+   * MEET × BUY standing + the fact ledger behind it
+   * (consumer-profile-enrichment §8). Read-only: the scores are written by the
+   * sweep (consumerScoringService) and this only projects them.
+   *
+   * Returns null when the person has never been scored — a profile row is
+   * minted by the input-version bump before any sweep runs, so "row exists"
+   * does NOT mean "scored". `scoredConfigVersion` is the stamp that does, and
+   * it is set even when both scores come back NULL (§7.1), which is exactly
+   * the state the UI must distinguish from "we have no opinion yet".
+   *
+   * Erased people are skipped by the caller: erasure DELETES the profile row
+   * and cascades the ledger, so there is nothing to read and asking would
+   * only risk resurrecting a shape.
+   */
+  async function consumerEnrichment(consumerId) {
+    if (!consumerId) return null;
+    try {
+      const row = await d.ConsumerProfile.findByPk(consumerId);
+      if (!row || row.scoredConfigVersion == null) return null;
+
+      // The ledger, resolved the same way the scorer resolved it — the panel
+      // must agree with the breakdown it sits next to, so it goes through
+      // resolveCurrentFacts rather than reading rows directly.
+      //
+      // This is the one read here that carries no LIMIT, deliberately.
+      // Resolution is a TOTAL function over a key's rows (§3.4): freshness
+      // windows and collection baselines are computed across the whole set,
+      // so a truncated input doesn't return fewer facts — it returns WRONG
+      // ones, silently. Per-person ledgers are inherently small (a bounded
+      // taxonomy, one active row per key plus superseded history), so the
+      // honest trade is an unbounded read over a naturally small set rather
+      // than a bounded read over a corrupted one.
+      let facts = [];
+      try {
+        const observations = await d.loadObservations(consumerId);
+        const resolved = d.resolveCurrentFacts(observations);
+        facts = Object.entries(resolved)
+          .map(([key, f]) => ({
+            key,
+            value: f.value,
+            source: f.source,
+            confidence: f.confidence,
+            observedAt: f.sourceEventAt,
+            observationIds: f.basis || [],
+          }))
+          .sort((a, b) => (a.key < b.key ? -1 : 1));
+      } catch (err) {
+        // A ledger read failure must not blank the scores beside it.
+        d.logger.warn('[leadProfile] fact ledger read failed (omitted)', { error: err?.message });
+      }
+
+      return {
+        meetScore: row.meetScore ?? null,
+        buyScore: row.buyScore ?? null,
+        consumerScore: row.consumerScore ?? null,
+        breakdown: row.scoreBreakdown || null,
+        scoredAt: row.scoreComputedAt || null,
+        configVersion: row.scoredConfigVersion ?? null,
+        algorithmVersion: row.scoringAlgorithmVersion || null,
+        facts,
+      };
+    } catch (err) {
+      d.logger.warn('[leadProfile] enrichment read failed (omitted)', { error: err?.message });
+      return null;
+    }
   }
 
   /**

--- a/backend/test/consumersList.test.js
+++ b/backend/test/consumersList.test.js
@@ -147,9 +147,13 @@ describe('GET /api/consumers — membership is row existence', () => {
     expect(typeof res.body.data.total).toBe('number')
     const a = res.body.data.rows.find((r) => r.id === C.a.id)
     expect(a).toBeDefined()
+    // + the four MEET × BUY projections (§8). Pinned deliberately: this row
+    // shape is the People page's contract, so widening it is a decision, not
+    // a side effect.
     expect(Object.keys(a).sort()).toEqual([
-      'email', 'erasedAt', 'firstName', 'firstSeenAt', 'id', 'lastName',
-      'lastSeenAt', 'latestProspectId', 'phone', 'signupCount', 'verifiedSignupCount',
+      'buyScore', 'consumerScore', 'email', 'erasedAt', 'firstName', 'firstSeenAt',
+      'id', 'lastName', 'lastSeenAt', 'latestProspectId', 'meetScore', 'phone',
+      'scoredConfigVersion', 'signupCount', 'verifiedSignupCount',
     ])
     expect(a).toMatchObject({
       firstName: 'Zephyrine', lastName: 'Peopledir', phone: '+6598111001',
@@ -273,5 +277,74 @@ describe('GET /api/consumers — sort and pagination', () => {
     const seen = [...ids(p1), ...ids(p2)]
     expect(new Set(seen).size).toBe(seen.length)
     expect(p1.body.data.total).toBe(p2.body.data.total)
+  })
+})
+
+/**
+ * MEET × BUY columns (consumer-profile-enrichment §8).
+ *
+ * The load-bearing contract is that the LEFT JOIN must not change WHO is
+ * listed: the People directory is the person index, not the scored index, so
+ * an unscored person stays on the page with null scores. And NULLS LAST has
+ * to hold in BOTH sort directions — ascending by Buy should surface the
+ * lowest real score, not the crowd of people we cannot score at all.
+ */
+describe('GET /api/consumers — scores', () => {
+  let scoredId
+
+  beforeAll(async () => {
+    const { ConsumerProfile } = await import('../src/models/index.js')
+    // 'a' is the ordinary linked fixture — score exactly that one so every
+    // other Peopledir row stays a live example of the unscored case.
+    scoredId = C.a.id
+    await ConsumerProfile.upsert({
+      consumerId: scoredId,
+      meetScore: 71,
+      buyScore: 44,
+      consumerScore: 58,
+      scoredConfigVersion: 1,
+      scoringAlgorithmVersion: 'score/v1',
+      scoreInputHash: 'x'.repeat(64),
+      scoreBreakdown: { completeness: { assessed: 5, total: 7 } },
+      scoreComputedAt: new Date(),
+      inputVersion: 1,
+      syncedInputVersion: 0,
+    })
+  })
+
+  it('projects the scores onto the listed rows', async () => {
+    const res = await get(scoped('&limit=100'))
+    expect(res.status).toBe(200)
+    const row = res.body.data.rows.find((r) => r.id === scoredId)
+    expect(row).toBeTruthy()
+    expect(row.meetScore).toBe(71)
+    expect(row.buyScore).toBe(44)
+    expect(row.scoredConfigVersion).toBe(1)
+  })
+
+  it('keeps unscored people on the page with null scores (LEFT JOIN, not INNER)', async () => {
+    const res = await get(scoped('&limit=100'))
+    const unscored = res.body.data.rows.filter((r) => r.id !== scoredId)
+    expect(unscored.length).toBeGreaterThan(0)
+    for (const r of unscored) {
+      expect(r.meetScore).toBeNull()
+      expect(r.scoredConfigVersion).toBeNull()
+    }
+  })
+
+  it('sorts by Meet desc with the scored person first', async () => {
+    const res = await get(scoped('&limit=100&sort=-meetScore'))
+    expect(res.body.data.rows[0].id).toBe(scoredId)
+  })
+
+  it('ASCENDING by Buy still puts NULLs last — an unscoreable person never leads', async () => {
+    const res = await get(scoped('&limit=100&sort=buyScore'))
+    expect(res.body.data.rows[0].id).toBe(scoredId)
+    expect(res.body.data.rows[res.body.data.rows.length - 1].buyScore).toBeNull()
+  })
+
+  it('an unknown sort still falls back rather than erroring', async () => {
+    const res = await get(scoped('&sort=notAColumn'))
+    expect(res.status).toBe(200)
   })
 })

--- a/src/pages/adminv2/AdminV2LeadProfile.jsx
+++ b/src/pages/adminv2/AdminV2LeadProfile.jsx
@@ -478,6 +478,181 @@ function ConsentKv({ label, state, legacy }) {
   );
 }
 
+/* ── MEET × BUY scoring (consumer-profile-enrichment §7.1b, §8) ───────────
+ * The BREAKDOWN LEADS and the number follows (plan §11 step 4): these weights
+ * are a v1 calibration, so the panel has to show its working or it is just an
+ * authoritative-looking guess. Every component states whether it was assessed
+ * or is simply unknown — that distinction is the point, because "unknown
+ * capacity" and "low capacity" must never render the same way.
+ */
+const COMPONENT_LABELS = {
+  engagement: 'engagement',
+  contactability: 'contactability',
+  market_fit: 'market fit',
+  life_events: 'life events',
+  family_gap: 'family gap',
+  capacity: 'capacity',
+  coverage_headroom: 'coverage headroom',
+};
+
+const FACT_LABELS = {
+  'identity.gender': 'gender',
+  'identity.birth_year_band': 'born',
+  'identity.ethnicity': 'ethnicity',
+  'identity.preferred_language': 'language',
+  'family.marital_status': 'marital status',
+  'family.children': 'children',
+  'family.children_count_band': 'children',
+  'family.parents_alive': 'parents alive',
+  'household.pets': 'pets',
+  'assets.car_owner': 'car owner',
+  'assets.property': 'property',
+  'career.job_title': 'job title',
+  'career.industry': 'industry',
+  'career.employment': 'employment',
+  'finance.income_band': 'monthly income',
+  'finance.annual_income_band': 'annual income',
+  'finance.retirement_age_band': 'retirement age',
+  'finance.existing_coverage': 'existing coverage',
+  'life_event.recent': 'recent life event',
+  'interests.tags': 'interests',
+  'residency.status': 'residency',
+};
+
+/** Taxonomy values are always {v: …} plus per-key extras — render them flat. */
+function factText(value) {
+  if (!value || typeof value !== 'object') return '—';
+  const v = value.v;
+  let body;
+  if (Array.isArray(v)) {
+    body = v.length
+      ? v.map((x) => (x && typeof x === 'object' ? Object.values(x).filter(Boolean).join(' ') : String(x))).join(', ')
+      : 'none';
+  } else if (typeof v === 'boolean') {
+    body = v ? 'yes' : 'no';
+  } else {
+    body = String(v ?? '—');
+  }
+  if (value.when) body += ` (${value.when})`;
+  // complete:false means "at least these" — say so rather than implying a
+  // closed list the ledger never claimed.
+  if (Array.isArray(v) && value.complete === false) body += ' — partial';
+  return body;
+}
+
+function ScoreDial({ label, value, hint }) {
+  const known = value != null;
+  return (
+    <div style={{ flex: 1, minWidth: 96 }}>
+      <div className="av2-microcaps" style={{ color: 'var(--ink-3)' }}>{label}</div>
+      <div
+        style={{ display: 'flex', alignItems: 'baseline', gap: 6, marginTop: 2 }}
+        title={known ? `${label} ${value}/100` : hint}
+      >
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 26, fontWeight: 800, lineHeight: 1, color: known ? 'var(--ink)' : 'var(--ink-3)' }}>
+          {known ? value : '—'}
+        </span>
+        {known && <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--ink-3)' }}>/100</span>}
+      </div>
+      {!known && <div style={{ fontSize: 11, color: 'var(--ink-3)', marginTop: 3 }}>{hint}</div>}
+    </div>
+  );
+}
+
+function ComponentRow({ name, c }) {
+  const assessed = c.state === 'assessed';
+  const max = Number(c.maxPoints) || 0;
+  // A penalty component's magnitude is what fills the bar; its sign shows in
+  // the number. Unknown draws no bar at all — an empty bar would read as zero.
+  const pct = assessed && max !== 0 ? Math.min(100, Math.abs(c.points / max) * 100) : 0;
+  const penalty = max < 0;
+  return (
+    <div style={{ display: 'flex', alignItems: 'baseline', gap: 10, padding: '3px 0', fontSize: 12 }}>
+      <span style={{ width: 116, flex: 'none', color: assessed ? 'var(--ink-2)' : 'var(--ink-3)' }}>
+        {COMPONENT_LABELS[name] || name.replace(/_/g, ' ')}
+      </span>
+      <span style={{ width: 58, flex: 'none', fontFamily: 'var(--font-mono)', fontSize: 11, textAlign: 'right', color: assessed ? 'var(--ink)' : 'var(--ink-3)' }}>
+        {assessed ? `${c.points}` : '—'}<span style={{ color: 'var(--ink-3)' }}>/{max}</span>
+      </span>
+      <span aria-hidden="true" style={{ width: 46, flex: 'none', height: 4, borderRadius: 3, background: 'var(--surface-2)', overflow: 'hidden' }}>
+        {assessed && pct > 0 && (
+          <span style={{ display: 'block', width: `${pct}%`, height: '100%', background: penalty ? 'var(--bad)' : 'var(--accent-text)' }} />
+        )}
+      </span>
+      <span style={{ flex: 1, minWidth: 0, fontSize: 11.5, color: 'var(--ink-3)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={c.note || ''}>
+        {c.note || (assessed ? '' : 'unknown')}
+      </span>
+    </div>
+  );
+}
+
+function EnrichmentCard({ enrichment }) {
+  const bd = enrichment?.breakdown;
+  const comps = bd?.components || {};
+  const groups = bd?.groups || {};
+  const completeness = bd?.completeness;
+  const meetNames = groups.meet?.components || [];
+  const buyNames = groups.buy?.components || [];
+  const facts = enrichment?.facts || [];
+
+  return (
+    <Card
+      title="Scoring"
+      meta={enrichment?.configVersion != null ? `CONFIG v${enrichment.configVersion}` : undefined}
+    >
+      <div style={{ padding: '12px 18px 6px', display: 'flex', gap: 18 }}>
+        <ScoreDial label="Meet" value={enrichment?.meetScore} hint="no signal yet" />
+        <ScoreDial
+          label="Buy"
+          value={enrichment?.buyScore}
+          hint="no facts to judge"
+        />
+      </div>
+
+      <div style={{ padding: '4px 18px 12px' }}>
+        {meetNames.length > 0 && (
+          <>
+            <div className="av2-microcaps" style={{ padding: '6px 0 2px' }}>Reachability</div>
+            {meetNames.map((n) => comps[n] && <ComponentRow key={n} name={n} c={comps[n]} />)}
+          </>
+        )}
+        {buyNames.length > 0 && (
+          <>
+            <div className="av2-microcaps" style={{ padding: '10px 0 2px' }}>Potential</div>
+            {buyNames.map((n) => comps[n] && <ComponentRow key={n} name={n} c={comps[n]} />)}
+          </>
+        )}
+        {completeness && (
+          <div style={{ fontSize: 11.5, color: 'var(--ink-3)', paddingTop: 10 }}>
+            {completeness.assessed} of {completeness.total} components assessed
+            {completeness.assessed < completeness.total && ' — the unknowns above are questions nobody has been asked'}
+          </div>
+        )}
+      </div>
+
+      {facts.length > 0 && (
+        <Disclosure label="Fact ledger" count={`${facts.length} FACT${facts.length === 1 ? '' : 'S'}`} indent={36}>
+          {facts.map((f) => (
+            <div key={f.key} style={{ display: 'flex', gap: 10, fontSize: 12, padding: '3px 0', alignItems: 'baseline' }}>
+              <span style={{ width: 116, flex: 'none', color: 'var(--ink-3)' }}>{FACT_LABELS[f.key] || f.key}</span>
+              <span style={{ flex: 1, minWidth: 0, color: 'var(--ink)', fontWeight: 600, overflowWrap: 'anywhere' }}>
+                {factText(f.value)}
+              </span>
+              <span
+                className="av2-mono"
+                style={{ flex: 'none', fontSize: 10, color: 'var(--ink-3)' }}
+                title={`${f.source} · confidence ${f.confidence}${f.observedAt ? ` · ${fmtDate(f.observedAt)}` : ''}`}
+              >
+                {f.source}
+              </span>
+            </div>
+          ))}
+        </Disclosure>
+      )}
+    </Card>
+  );
+}
+
 function Disclosure({ label, count, children, indent = 34 }) {
   return (
     <details style={{ borderTop: '1px solid var(--line)' }}>
@@ -908,6 +1083,11 @@ export default function AdminV2LeadProfile() {
                 </Disclosure>
               )}
             </section>
+
+            {/* Absent until the sweep has scored this person (and gone for
+                erased people, whose profile row is deleted) — an empty
+                scoring card would imply a verdict we haven't reached. */}
+            {journey?.enrichment && <EnrichmentCard enrichment={journey.enrichment} />}
 
             <Card title="Campaigns" meta={`${railSignups.length} SIGNUP${railSignups.length === 1 ? '' : 'S'}`}>
               {railSignups.map((s, i) => {

--- a/src/pages/adminv2/AdminV2People.jsx
+++ b/src/pages/adminv2/AdminV2People.jsx
@@ -42,6 +42,46 @@ function SortHeader({ label, field, sort, onSort, width, align }) {
   );
 }
 
+/**
+ * A MEET or BUY score (consumer-profile-enrichment §7.1b).
+ *
+ * NULL is not zero and must never look like a low score — it means we lack
+ * the evidence to judge, so it renders as a dim em-dash with a title that
+ * says which kind of nothing it is. Buy is NULL for anyone with no fact
+ * component assessed, which today is nearly everyone.
+ */
+function ScoreCell({ value, scored, kind }) {
+  if (value == null) {
+    return (
+      <span
+        className="av2-mono"
+        style={{ width: 58, flex: 'none', fontSize: 11, color: 'var(--ink-3)', textAlign: 'right' }}
+        title={scored
+          ? `Not enough evidence to score ${kind} — open the person to see what's missing`
+          : 'Not scored yet'}
+      >
+        —
+      </span>
+    );
+  }
+  // Weight only the top of the range: a faint ramp reads as ranking without
+  // implying precision the number doesn't have.
+  const strong = value >= 60;
+  return (
+    <span
+      className="av2-mono"
+      style={{
+        width: 58, flex: 'none', fontSize: 12, textAlign: 'right',
+        fontWeight: strong ? 700 : 500,
+        color: strong ? 'var(--ink)' : 'var(--ink-2)',
+      }}
+      title={`${kind} ${value}/100`}
+    >
+      {value}
+    </span>
+  );
+}
+
 export default function AdminV2People() {
   const [searchParams, setSearchParams] = useSearchParams();
   const filters = useMemo(() => readFilters(searchParams), [searchParams]);
@@ -132,7 +172,9 @@ export default function AdminV2People() {
         <div className="av2-thead">
           <SortHeader label="Person" field="name" sort={filters.sort} onSort={(s) => patch({ sort: s, page: null })} />
           <span className="av2-microcaps" style={{ width: 130, flex: 'none' }}>Phone</span>
-          <SortHeader label="Signups" field="signupCount" sort={filters.sort} onSort={(s) => patch({ sort: s, page: null })} width={170} />
+          <SortHeader label="Signups" field="signupCount" sort={filters.sort} onSort={(s) => patch({ sort: s, page: null })} width={150} />
+          <SortHeader label="Meet" field="meetScore" sort={filters.sort} onSort={(s) => patch({ sort: s, page: null })} width={58} align="right" />
+          <SortHeader label="Buy" field="buyScore" sort={filters.sort} onSort={(s) => patch({ sort: s, page: null })} width={58} align="right" />
           <SortHeader label="Last seen" field="lastSeenAt" sort={filters.sort} onSort={(s) => patch({ sort: s, page: null })} width={100} align="right" />
         </div>
 
@@ -180,9 +222,13 @@ export default function AdminV2People() {
               <span className="av2-mono" style={{ width: 130, flex: 'none', fontSize: 11, color: 'var(--ink-2)' }}>
                 {fmtPhone(r.phone) || '—'}
               </span>
-              <span style={{ width: 170, flex: 'none', fontSize: 12, color: 'var(--ink-2)' }}>
+              <span style={{ width: 150, flex: 'none', fontSize: 12, color: 'var(--ink-2)' }}>
                 {r.signupCount} signup{r.signupCount === 1 ? '' : 's'} ({r.verifiedSignupCount} verified)
               </span>
+              {/* Erased people keep no profile row (§9) — show nothing rather
+                  than a stale number. */}
+              <ScoreCell value={erased ? null : r.meetScore} scored={!erased && r.scoredConfigVersion != null} kind="Meet" />
+              <ScoreCell value={erased ? null : r.buyScore} scored={!erased && r.scoredConfigVersion != null} kind="Buy" />
               <span className="av2-mono" style={{ width: 100, flex: 'none', fontSize: 10, color: 'var(--ink-3)', textAlign: 'right' }} title={fmtDateTime(r.lastSeenAt)}>
                 {fmtRelative(r.lastSeenAt)}
               </span>

--- a/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
@@ -408,3 +408,114 @@ describe('AdminV2LeadProfile — delivery truth (wa-delivery-truth)', () => {
     expect(screen.getAllByText('delivered').length).toBeGreaterThan(0);
   });
 });
+
+/**
+ * MEET × BUY scoring panel (consumer-profile-enrichment §7.1b, §8).
+ *
+ * The breakdown leads and the number follows, so these tests are mostly about
+ * the panel telling the truth about what it does NOT know: an unknown
+ * component must never render like a scored zero, and an unscoreable Buy must
+ * say why instead of showing a figure.
+ */
+describe('scoring panel', () => {
+  const ENRICHED = (over = {}) => {
+    const p = JSON.parse(JSON.stringify(PROFILE));
+    p.consumer.enrichment = {
+      meetScore: 32,
+      buyScore: 8,
+      consumerScore: 17,
+      configVersion: 1,
+      algorithmVersion: 'score/v1',
+      scoredAt: '2026-07-26T10:30:41Z',
+      breakdown: {
+        groups: {
+          meet: { score: 32, rawMax: 40, components: ['engagement', 'contactability', 'market_fit'] },
+          buy: { score: 8, rawMax: 60, components: ['life_events', 'family_gap', 'capacity', 'coverage_headroom'] },
+        },
+        components: {
+          engagement: { state: 'assessed', points: 7.5, maxPoints: 15, basisObservationIds: [], note: '1 signup(s), 1 verified' },
+          contactability: { state: 'assessed', points: 5.5, maxPoints: 10, basisObservationIds: [], note: 'reachable via verified phone, email' },
+          market_fit: { state: 'unknown', points: 0, maxPoints: 15, basisObservationIds: [], note: 'no language or ethnicity fact' },
+          life_events: { state: 'unknown', points: 0, maxPoints: 25, basisObservationIds: [], note: 'no recent life event on record' },
+          family_gap: { state: 'assessed', points: 3, maxPoints: 20, basisObservationIds: ['o2'], note: 'children 0' },
+          capacity: { state: 'assessed', points: 1.5, maxPoints: 15, basisObservationIds: ['o1'], note: 'income <40k' },
+          coverage_headroom: { state: 'unknown', points: 0, maxPoints: -10, basisObservationIds: [], note: 'no coverage fact' },
+        },
+        completeness: { assessed: 4, total: 7 },
+      },
+      facts: [
+        { key: 'finance.annual_income_band', value: { v: '<40k' }, source: 'form', confidence: 1, observedAt: '2026-07-26T09:10:24Z', observationIds: ['o1'] },
+        { key: 'family.children_count_band', value: { v: '0' }, source: 'form', confidence: 1, observedAt: '2026-07-26T09:10:24Z', observationIds: ['o2'] },
+        { key: 'household.pets', value: { v: ['dog', 'cat'], complete: false }, source: 'screening_transcript', confidence: 0.8, observedAt: '2026-07-26T09:10:24Z', observationIds: ['o3'] },
+      ],
+      ...over,
+    };
+    return p;
+  };
+
+  it('shows both scores with the config version that produced them', async () => {
+    fetchProspectProfile.mockResolvedValue(ENRICHED());
+    setup('/admin/leads/p1?view=profile');
+    expect(await screen.findByText('Scoring')).toBeInTheDocument();
+    expect(screen.getByTitle('Meet 32/100')).toHaveTextContent('32');
+    expect(screen.getByTitle('Buy 8/100')).toHaveTextContent('8');
+    expect(screen.getByText('CONFIG v1')).toBeInTheDocument();
+  });
+
+  it('groups components under reachability and potential', async () => {
+    fetchProspectProfile.mockResolvedValue(ENRICHED());
+    setup('/admin/leads/p1?view=profile');
+    expect(await screen.findByText('Reachability')).toBeInTheDocument();
+    expect(screen.getByText('Potential')).toBeInTheDocument();
+    expect(screen.getByText('engagement')).toBeInTheDocument();
+    expect(screen.getByText('coverage headroom')).toBeInTheDocument();
+  });
+
+  it('an unknown component reads "—", never a scored zero', async () => {
+    fetchProspectProfile.mockResolvedValue(ENRICHED());
+    setup('/admin/leads/p1?view=profile');
+    await screen.findByText('Scoring');
+    // market_fit is unknown: its note explains why, and it shows no points.
+    expect(screen.getByText('no language or ethnicity fact')).toBeInTheDocument();
+    expect(screen.getByText('no recent life event on record')).toBeInTheDocument();
+    // The assessed ones DO show their points.
+    expect(screen.getByText('7.5')).toBeInTheDocument();
+    expect(screen.getByText('1.5')).toBeInTheDocument();
+  });
+
+  it('names the unknowns as unasked questions, not as low scores', async () => {
+    fetchProspectProfile.mockResolvedValue(ENRICHED());
+    setup('/admin/leads/p1?view=profile');
+    expect(await screen.findByText(/4 of 7 components assessed/)).toBeInTheDocument();
+    expect(screen.getByText(/questions nobody has been asked/)).toBeInTheDocument();
+  });
+
+  it('an unscoreable Buy explains itself instead of showing a number', async () => {
+    fetchProspectProfile.mockResolvedValue(ENRICHED({ buyScore: null }));
+    setup('/admin/leads/p1?view=profile');
+    await screen.findByText('Scoring');
+    expect(screen.getByText('no facts to judge')).toBeInTheDocument();
+    expect(screen.queryByTitle('Buy 0/100')).not.toBeInTheDocument();
+  });
+
+  it('renders the fact ledger with provenance, flagging partial collections', async () => {
+    fetchProspectProfile.mockResolvedValue(ENRICHED());
+    setup('/admin/leads/p1?view=profile');
+    await screen.findByText('Scoring');
+    expect(screen.getByText(/3 FACTS/)).toBeInTheDocument();
+    expect(screen.getByText('annual income')).toBeInTheDocument();
+    expect(screen.getByText('<40k')).toBeInTheDocument();
+    // A non-complete collection must not imply a closed list.
+    expect(screen.getByText('dog, cat — partial')).toBeInTheDocument();
+    expect(screen.getByText('screening_transcript')).toBeInTheDocument();
+  });
+
+  it('is absent entirely when the person has never been scored', async () => {
+    const p = JSON.parse(JSON.stringify(PROFILE));
+    p.consumer.enrichment = null;
+    fetchProspectProfile.mockResolvedValue(p);
+    setup('/admin/leads/p1?view=profile');
+    await screen.findByText('Campaigns');
+    expect(screen.queryByText('Scoring')).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/adminv2/__tests__/AdminV2People.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2People.test.jsx
@@ -111,4 +111,56 @@ describe('AdminV2People', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Next →' }));
     expect(screen.getByText('Shawn Lee')).toBeInTheDocument();
   });
+
+  // ── MEET × BUY columns (consumer-profile-enrichment §8) ──
+  describe('score columns', () => {
+    const scored = () => {
+      const d = JSON.parse(JSON.stringify(DATA));
+      d.rows[0] = { ...d.rows[0], meetScore: 72, buyScore: 41, scoredConfigVersion: 1 };
+      // Scored, but no fact component assessed ⇒ Buy is honestly NULL.
+      d.rows[2] = { ...d.rows[2], meetScore: 16, buyScore: null, scoredConfigVersion: 1 };
+      return d;
+    };
+
+    it('renders both scores, and an unscoreable Buy as "—" rather than a zero', async () => {
+      fetchConsumers.mockResolvedValue(scored());
+      setup();
+      await screen.findByText('Shawn Lee');
+      expect(screen.getByTitle('Meet 72/100')).toHaveTextContent('72');
+      expect(screen.getByTitle('Buy 41/100')).toHaveTextContent('41');
+      // The unscoreable one must not read as a low score.
+      expect(screen.getByTitle(/Not enough evidence to score Buy/)).toHaveTextContent('—');
+      expect(screen.queryByTitle('Buy 0/100')).not.toBeInTheDocument();
+    });
+
+    it('distinguishes "never scored" from "scored but unscoreable"', async () => {
+      fetchConsumers.mockResolvedValue(scored()); // row 2 (erased) has no score fields at all
+      setup();
+      await screen.findByText('Shawn Lee');
+      expect(screen.getAllByTitle('Not scored yet').length).toBeGreaterThan(0);
+    });
+
+    it('erased people show no score even if a row somehow carries one', async () => {
+      const d = scored();
+      d.rows[1] = { ...d.rows[1], meetScore: 99, buyScore: 99, scoredConfigVersion: 1 };
+      fetchConsumers.mockResolvedValue(d);
+      setup();
+      await screen.findByText('Erased person');
+      expect(screen.queryByTitle('Meet 99/100')).not.toBeInTheDocument();
+    });
+
+    it('Meet and Buy headers sort through the URL', async () => {
+      fetchConsumers.mockResolvedValue(scored());
+      setup();
+      await screen.findByText('Shawn Lee');
+      fireEvent.click(screen.getByRole('button', { name: /^Meet/ }));
+      await waitFor(() => expect(fetchConsumers).toHaveBeenCalledWith(
+        expect.objectContaining({ sort: 'meetScore' })
+      ));
+      fireEvent.click(screen.getByRole('button', { name: /^Buy/ }));
+      await waitFor(() => expect(fetchConsumers).toHaveBeenCalledWith(
+        expect.objectContaining({ sort: 'buyScore' })
+      ));
+    });
+  });
 });


### PR DESCRIPTION
PR 2 computes MEET × BUY; nothing read it. This surfaces it on the two person-grain surfaces §8 allows — the People columns and the profile drill-in. Prospects gets nothing, as decided.

## The breakdown leads, the number follows

These weights are a v1 calibration Shawn hasn't tuned yet, so a bare `32` would be an authoritative-looking guess. The profile card shows its working:

```
Meet  32/100        Buy  8/100                    CONFIG v1

REACHABILITY
 engagement       7.5/15  ▓▓▓░░   1 signup(s), 1 verified
 contactability   5.5/10  ▓▓▓░░   reachable via verified phone, email
 market fit         —/15          no language or ethnicity fact

POTENTIAL
 life events        —/25          no recent life event on record
 family gap         3/20  ▓░░░░   children 0
 capacity         1.5/15  ▓░░░░   income <40k
 coverage headroom  —/-10         no coverage fact

 4 of 7 components assessed — the unknowns above are
 questions nobody has been asked

▸ Fact ledger                                        3 FACTS
```

That last line is the point: the panel tells you which questions to add to earn a real score.

## Unknown never looks like zero

The distinction PR 2 was built around had to survive into pixels:

- An **unknown component draws no bar at all** — an empty bar reads as a scored zero.
- A **NULL column cell** is a dim `—` whose title says *which kind of nothing*: "not scored yet" vs "not enough evidence to score Buy".

This matters enormously right now: **Buy is NULL for 129 of 130 people in prod.** Rendering those as `0` would invent a verdict on everyone.

## Other load-bearing choices

| Choice | Why |
|---|---|
| **LEFT** join, never INNER | The People directory is the person index, not the scored index — an unscored person stays listed |
| NULLS LAST in **both** sort directions | Ascending by Buy should surface the lowest *real* score, not the crowd we can't score |
| Ledger via `resolveCurrentFacts` | The panel provably agrees with the breakdown beside it, rather than re-deriving from raw rows |
| Ledger read has **no LIMIT** | Resolution is a *total* function over a key's rows (§3.4) — truncating returns *wrong* facts, not fewer. Per-person ledgers are naturally small |
| Partial collections render `— partial` | Never imply a closed list the ledger didn't claim |
| Erased ⇒ no card, no scores | Erasure deletes the profile row (§9); a stale number would outlive the erasure |

## Verification (local Postgres 17, before pushing)

| | |
|---|---|
| Backend integration | **126 suites / 2542 tests** ✅ |
| Backend unit | **103 suites / 1848 tests** ✅ |
| Frontend | **157 files / 1978 tests** ✅ |
| `eslint src/ --quiet` (both) | exit 0 ✅ |

16 new tests. The existing **row-shape contract test caught my 4 new keys** — re-pinned deliberately, not loosened.

## Gate note

§11's density gate is per-score, and I'd been applying Buy's failure to both. Checked against real data: **Meet's gate is met** (median 2 assessed components, all 130 people); Buy's is not (1 of 130). Buy ships as an honest `—` column rather than being hidden, since the plan wants the breakdown visible regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127w4fTdWuoNTSZbBexNN8Z