### PR TITLE
fix(draw): the ×N and the draw name were swapped in every boost receipt WhatsApp

### DIFF
--- a/backend/src/services/redeemOps/entitlementWiring.js
+++ b/backend/src/services/redeemOps/entitlementWiring.js
@@ -26,8 +26,9 @@ export function makeWiredEntitlementService(overrides = {}) {
     notifyReservationWa: (args) => wa.sendReservationWhatsApp(args),
     notifyUnlockWa: (args) => wa.sendVoucherWhatsApp(args),
     // "×N confirmed" receipt at a recorded draw session — email + WhatsApp
-    // (the `draw_boost_receipt` UTILITY template; the WA leg self-guards on
-    // the flag and fails receipted while the template is in review).
+    // (the `draw_boost_receipt_v2` UTILITY template — the MARKETING original
+    // it replaced was silently dropped by the per-user frequency cap; the WA
+    // leg self-guards on the flag and fails receipted).
     notifyBoostReceipt: (args) => notify.sendBoostReceiptEmail(args),
     notifyBoostReceiptWa: (args) => wa.sendBoostReceiptWhatsApp(args),
     ...overrides,

--- a/backend/src/services/redeemOps/whatsappService.js
+++ b/backend/src/services/redeemOps/whatsappService.js
@@ -374,13 +374,25 @@ export function makeWhatsappService(overrides = {}) {
 
   /** "×N confirmed" receipt at a recorded draw session — the WA twin of
    * sendBoostReceiptEmail, same register as the email body. The
-   * `draw_boost_receipt` template carries the Vault 'boost' card as its IMAGE
-   * header — the QR-less celebration state (giant ×N; the pass is consumed,
-   * nothing left to scan); 3 params = name, draw name, multiplier. */
+   * `draw_boost_receipt_v2` template carries the Vault 'boost' card as its
+   * IMAGE header — the QR-less celebration state (giant ×N; the pass is
+   * consumed, nothing left to scan); 3 params = name, multiplier, draw name.
+   *
+   * THE ORDER IS THE TEMPLATE'S, NOT OURS. v2 reads "You now have *{{2}}
+   * chances* for the {{3}}" — the reverse of the retired MARKETING original
+   * ("your entry to the {{2}} now holds {{3}} chances"). Params are positional
+   * with no per-template remap, so the default name and this array must move
+   * together: pointing WHATSAPP_TEMPLATE_DRAW_BOOST back at the original, or
+   * at any future reworded twin, silently swaps the draw name and the
+   * multiplier in the customer's message. It shipped that way to two
+   * recipients on 2026-07-26 ("*iPhone 17 Pro Lucky Draw chances* for the 10")
+   * because the v2 rewording that won the UTILITY category moved the
+   * placeholders and nothing here followed. Re-read the live body before
+   * flipping the env name. */
   async function sendBoostReceiptWhatsApp({ prospect, drawCtx }) {
     return sendTemplate({
       prospect,
-      templateName: process.env.WHATSAPP_TEMPLATE_DRAW_BOOST || 'draw_boost_receipt',
+      templateName: process.env.WHATSAPP_TEMPLATE_DRAW_BOOST || 'draw_boost_receipt_v2',
       card: {
         state: 'boost',
         rewardName: cleanParam(drawCtx?.drawName, 'the lucky draw'),
@@ -394,8 +406,8 @@ export function makeWhatsappService(overrides = {}) {
       },
       params: [
         cleanParam(prospect?.firstName, 'there'),
-        cleanParam(drawCtx?.drawName, 'the lucky draw'),
         String(drawCtx?.multiplier || 10),
+        cleanParam(drawCtx?.drawName, 'the lucky draw'),
       ],
     });
   }

--- a/backend/src/tests/whatsappService.test.js
+++ b/backend/src/tests/whatsappService.test.js
@@ -9,7 +9,7 @@ import { makeWhatsappService, canWhatsAppProspect, waRecipient } from '../servic
 const ENV_KEYS = [
   'REDEEM_OPS_WHATSAPP_ENABLED', 'WHATSAPP_TOKEN', 'WHATSAPP_PHONE_NUMBER_ID',
   'WHATSAPP_TEMPLATE_PASS', 'WHATSAPP_TEMPLATE_VOUCHER', 'WHATSAPP_TEMPLATE_LANG',
-  'WHATSAPP_QR_HEADER', 'WHATSAPP_CLAIM_ORIGIN',
+  'WHATSAPP_QR_HEADER', 'WHATSAPP_CLAIM_ORIGIN', 'WHATSAPP_TEMPLATE_DRAW_BOOST',
 ];
 let savedEnv;
 beforeEach(() => {
@@ -243,6 +243,29 @@ describe('QR-header send sequence (default: header ON)', () => {
     expect(params.length).toBe(4);
     expect(params[2]).toBe('vtok-raw');
     expect(params[3]).toBe('17 Aug 2026');
+  });
+
+  it('boost receipt: body params follow the v2 sentence — name, MULTIPLIER, draw name', async () => {
+    enableWithCreds();
+    const fetch = fetchRecorder();
+    const card = cardRecorder();
+    const svc = makeSvc({ fetch, card });
+    const r = await svc.sendBoostReceiptWhatsApp({
+      prospect: consented,
+      drawCtx: { drawName: 'iPhone 17 Pro Lucky Draw', multiplier: 10, prize: 'an iPhone 17 Pro' },
+    });
+    expect(r.sent).toBe(true);
+    const send = fetch.calls[1];
+    expect(send.body.template.name).toBe('draw_boost_receipt_v2');
+    // v2's body is "You now have *{{2}} chances* for the {{3}}" — the multiplier
+    // comes BEFORE the draw name. Reversing these renders "*iPhone 17 Pro Lucky
+    // Draw chances* for the 10", which is what two recipients actually got on
+    // 2026-07-26: the template was reworded to win the UTILITY category and the
+    // caller kept the MARKETING original's order. Positional params, no remap —
+    // so the name on the line above and this array are one decision.
+    expect(send.body.template.components[1].parameters.map((p) => p.text)).toEqual([
+      'Sarah', '10', 'iPhone 17 Pro Lucky Draw',
+    ]);
   });
 
   it('WHATSAPP_CLAIM_ORIGIN overrides the pass-QR host (and the card wordmark follows)', async () => {


### PR DESCRIPTION
## What broke

`draw_boost_receipt_v2` was reworded to win back the UTILITY category (the fix for the 131049 silent drops). The rewording moved the placeholders:

| | `{{1}}` | `{{2}}` | `{{3}}` |
|---|---|---|---|
| `draw_boost_receipt` (MARKETING, retired) | name | draw name | multiplier |
| `draw_boost_receipt_v2` (UTILITY, live) | name | **multiplier** | **draw name** |
| `sendBoostReceiptWhatsApp` sent | name | draw name | multiplier |

`WHATSAPP_TEMPLATE_DRAW_BOOST` was flipped to v2 in prod, the param array was not, and `sendTemplate` maps params positionally with no per-template remap. Both receipts that delivered on 2026-07-26 rendered:

> You now have **iPhone 17 Pro Lucky Draw chances** for the 10.

One went to a real lead (entitlement `fb7d7dec…`, agent unlock 17:28 SGT); the other was the remediation resend for `15fa630f…`.

## Why the code and not the template

Editing an approved template re-enters review, and Meta's 2026 approve-and-flip would put the just-won UTILITY category back at risk — which is the entire reason v2 exists. The code default moves to `draw_boost_receipt_v2` in the same commit as the new order, so an unset env name can't silently swap them the other way.

## Test

The param shape only ever existed in Meta's live copy, so a rewording there could not fail anything here. A unit test now pins the order to the template's sentence and names the failure mode it guards.

## Verification

- `jest src/tests/whatsappService.test.js` — 29/29
- `jest test/unit/drawScanDoor.test.js src/tests/entitlementDeliveryFanout.test.js` — 19/19
- `eslint` clean on all three files

Follow-up (not in this PR): a boost resend on `fb7d7dec…` once this is live, to correct that lead's message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWFUedSiPDdyKp62vcYCdt
