### PR TITLE
fix(scoring): marketing consent never matched — every Meet score is low in prod

### DIFF
--- a/backend/src/services/consumerScoringService.js
+++ b/backend/src/services/consumerScoringService.js
@@ -41,6 +41,17 @@ export function scoringEnabled() {
   return process.env.ENRICHMENT_SCORING_ENABLED === 'true';
 }
 
+/**
+ * The consent kind that means "may we market to them".
+ *
+ * EXPORTED so a test can assert it against ConsentEvent's own enum. It shipped
+ * as `'marketing'` — a kind that has never existed — which silently made
+ * marketingConsent false for every person in production. A bare literal inside
+ * a SQL string is unverifiable by any test that doesn't hit the database with
+ * the right fixture; a named export is checkable for free.
+ */
+export const MARKETING_CONSENT_KIND = 'contact';
+
 // Config is append-only and changes at most a few times a year; a short TTL
 // keeps a sweep of thousands of consumers from re-reading it per row while
 // still picking up a new calibration within the same night.
@@ -106,13 +117,22 @@ export async function loadTelemetry(consumerId) {
   const [[row]] = await sequelize.query(
     `SELECT c."signupCount", c."verifiedSignupCount", c."lastSeenAt",
             (c.email IS NOT NULL AND c.email <> '') AS "hasEmail",
+            -- 'contact' IS the marketing-consent kind. The ledger's enum is
+            -- contact | campaign_terms | third_party | dnc_override |
+            -- draw_terms (ConsentEvent.js:29); there is no 'marketing' row and
+            -- never has been. This filtered on a value that cannot exist, so
+            -- marketingConsent was FALSE for every person in production —
+            -- silently docking 0.45 of contactability from the 128 of 130
+            -- consumers who HAVE granted contact consent. The UI has always
+            -- labelled this kind "marketing" (AdminV2LeadProfile.jsx:1042),
+            -- which is exactly how the wrong literal got written.
             EXISTS (
               SELECT 1 FROM consent_events ce
-               WHERE ce."consumerId" = c.id AND ce.kind = 'marketing'
+               WHERE ce."consumerId" = c.id AND ce.kind = :consentKind
                  AND ce.granted = true
                  AND ce."occurredAt" = (
                    SELECT MAX(ce2."occurredAt") FROM consent_events ce2
-                    WHERE ce2."consumerId" = c.id AND ce2.kind = 'marketing'
+                    WHERE ce2."consumerId" = c.id AND ce2.kind = :consentKind
                  )
             ) AS "marketingConsent",
             EXISTS (
@@ -122,7 +142,7 @@ export async function loadTelemetry(consumerId) {
             ) AS "whatsappReachable"
        FROM consumers c
       WHERE c.id = :cid`,
-    { replacements: { cid: consumerId } }
+    { replacements: { cid: consumerId, consentKind: MARKETING_CONSENT_KIND } }
   );
   if (!row) return null;
   return {

--- a/backend/test/unit/consentKindContract.test.js
+++ b/backend/test/unit/consentKindContract.test.js
@@ -1,0 +1,52 @@
+import { MARKETING_CONSENT_KIND } from '../../src/services/consumerScoringService.js'
+import ConsentEvent from '../../src/models/ConsentEvent.js'
+
+/**
+ * The consent kind the scorer queries must be a kind that can actually exist.
+ *
+ * This guards a bug that shipped to production: `loadTelemetry` filtered on
+ * `ce.kind = 'marketing'`, which is not in ConsentEvent's enum and never has
+ * been. The query was valid SQL, returned no rows, and silently made
+ * marketingConsent FALSE for every consumer — docking 0.45 of contactability
+ * from the 128 of 130 people who HAD granted consent. Nothing failed; the
+ * scores were just quietly wrong.
+ *
+ * The literal lived inside a SQL string, so no unit test could see it and only
+ * an integration test with exactly the right fixture would have caught it.
+ * Hence the exported constant: the contract between the scorer and the ledger
+ * is now a value two modules can be compared on.
+ */
+
+/** Pull the allowed values straight off the model — never restate them here. */
+function allowedConsentKinds() {
+  const validate = ConsentEvent.rawAttributes.kind.validate
+  const isIn = validate?.isIn
+  // Sequelize accepts both `isIn: [[…]]` and `isIn: { args: [[…]] }`.
+  const list = Array.isArray(isIn) ? isIn[0] : isIn?.args?.[0]
+  return list
+}
+
+describe('marketing consent kind contract', () => {
+  test('the model actually declares an allowlist we can check against', () => {
+    const kinds = allowedConsentKinds()
+    expect(Array.isArray(kinds)).toBe(true)
+    expect(kinds.length).toBeGreaterThan(0)
+  })
+
+  test('the kind the scorer queries is one the ledger can store', () => {
+    expect(allowedConsentKinds()).toContain(MARKETING_CONSENT_KIND)
+  })
+
+  test("'marketing' is NOT a storable kind — the exact bug that shipped", () => {
+    // If someone ever adds a 'marketing' kind this test should be deleted,
+    // not silenced: the scorer would then need to decide which kind it means.
+    expect(allowedConsentKinds()).not.toContain('marketing')
+  })
+
+  test('the kind is `contact`, which the UI labels "marketing"', () => {
+    // The mismatch between the stored name and the displayed name is how the
+    // wrong literal got written in the first place. Pinned so the next person
+    // reads this instead of guessing.
+    expect(MARKETING_CONSENT_KIND).toBe('contact')
+  })
+})


### PR DESCRIPTION
**Live bug in code merged this morning (#286).** Scoring is enabled in production, so this is affecting real numbers now.

```sql
WHERE ce.kind = 'marketing'     -- a kind that does not exist
```

`ConsentEvent`'s enum is `contact | campaign_terms | third_party | dnc_override | draw_terms` (`ConsentEvent.js:29`). There is no `'marketing'`.

Valid SQL. No error. Zero rows. **`marketingConsent` is FALSE for every person in the database**, docking 0.45 of the contactability component — roughly **11 points of Meet score missing from almost everyone**.

## Verified against prod

| | |
|---|---|
| `consent_events` with `kind='contact'`, granted | **177** |
| `consent_events` with `kind='marketing'` | **0** |
| Consumers with granted contact consent | **128 of 130** |

So 128 people should be scoring the marketing term and none of them are.

**This misled the read of the first live sweep.** I reported the 121-person cluster at Meet 15–16 as "your base is undifferentiated on reachability." Part of it was this bug.

## How it got written

The UI labels this consent kind **"marketing"** (`AdminV2LeadProfile.jsx:1042`); the ledger stores it as **`contact`**. The display name went into the query.

## The guard

The literal is now `MARKETING_CONSENT_KIND`, bound into the SQL as a replacement, with a test asserting it against `ConsentEvent`'s allowlist — read off the model, never restated. Three of the four cases pin the exact trap, including `expect(kinds).not.toContain('marketing')`.

**Verified the test fails on the old value** (2 of 4 cases) and passes on the fix.

A bare literal inside a SQL string is invisible to every test that doesn't hit the database with exactly the right fixture. A named export is checkable for free.

## Found by

Codex adversarial review of an unrelated *plan document* — not by any test, and not by me. Which is precisely why the regression guard is in this PR.

## Verification

- Backend: **230/231 suites, 4403 tests pass** (local Postgres 17)
- `eslint src/ --quiet` → exit 0
- The one failure is the known `cohortService` same-millisecond `createdAt` flake — passes 36/36 in isolation, untouched by this branch (which changes exactly one file). Separate follow-up.

## After merge

Scores don't self-correct immediately — the hash gate only re-scores when inputs change, and the consent value is *inside* the hash, so the change will propagate on the next nightly sweep. To see it sooner: `node backend/scripts/score-consumers.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127w4fTdWuoNTSZbBexNN8Z