### PR TITLE
docs: campaign-brief + lead-scoring plans land on main, round-2 verdict recorded

### DIFF
--- a/docs/plans/campaign-brief.md
+++ b/docs/plans/campaign-brief.md
@@ -1,0 +1,207 @@
+# Campaign brief — asking what a campaign is FOR, at creation
+
+**Status:** v1 SCOPE — not reviewed, not approved, not built.
+**Author:** Claude, 2026-07-26 (from Shawn's ask: "during campaign creation we
+need to ask the user what the campaign target audience is, what is the end
+goal")
+**Related:** `consumer-profile-enrichment.md` (scoring), `studio-profile-questions.md`
+(PR 0 question library), `campaign-studio-rollout.md` (Studio AI)
+
+## 1. The problem
+
+Five systems currently guess at something only the campaign's creator knows.
+
+| System | What it guesses today |
+|---|---|
+| Studio AI "Fill everything" | Tone, audience, angle — inferred from campaign name + reward |
+| Profile questions (PR 0) | Which of the 5 to enable — hand-ticked per campaign, no rationale recorded |
+| Consumer scoring | One global market-fit segment (zh/chinese) for every campaign |
+| Ad targeting | Set in Meta/TikTok, never linked to the campaign record |
+| Measurement | Nothing — there is no stated goal to measure against |
+
+Each guess is independently reasonable and collectively incoherent: the AI
+writes copy for one audience while scoring assumes another and the ads target
+a third.
+
+**This becomes load-bearing at tens of campaigns** (Shawn, 2026-07-26). At six
+campaigns an operator holds the intent in their head. At forty they cannot,
+and neither can any of the five systems above.
+
+## 2. What already exists (verified 2026-07-26)
+
+| Field | Reality | Verdict |
+|---|---|---|
+| `campaigns.targetAudience` JSONB | Exists, `{}` on **all 7** prod campaigns, read by **nothing** (only the model + migration 016) | **Dead scaffolding — reuse it** |
+| `campaigns.type` ENUM | `lead_generation` \| `brand_awareness` \| `product_promotion` \| `event_marketing` \| `quiz` \| `guided_review`. **All 7 prod campaigns are the default `lead_generation`** | **DO NOT REPURPOSE** — see §6 |
+| `campaigns.callToAction` | NULL everywhere | Unused |
+| Create → Studio handoff | `OpenInStudioCard` → `/admin/campaigns/:id/studio?ai=full` auto-runs the AI fill | **The insertion point** |
+
+**`type` is a trap.** It conflates business objective (`lead_generation`,
+`brand_awareness`) with page mechanic (`quiz`, `guided_review`) — but
+`type = 'guided_review'` is load-bearing: it is the sole gate keeping the
+classic DesignEditor alive (`mktr-platform/CLAUDE.md`). Repurposing or
+re-enum-ing it would silently strand those campaigns. The brief adds new
+fields and leaves `type` alone.
+
+## 3. Design principles
+
+1. **Structured choices, never free text.** Same lesson PR 0 learned: free
+   text cannot deterministically drive a scoring config, a question set, or a
+   targeting hint. Free text is a comment, not an input. (One optional free-text
+   "notes" field is fine — explicitly advisory, consumed by nothing.)
+2. **Derive what you can; ask only what you can't.** The mechanic
+   (draw / reward / quiz / screening / plain form) is already knowable from
+   `design_config` + activation state. Asking the admin to restate it invites
+   contradiction between the answer and the truth.
+3. **Never block creation.** A campaign with no brief must still work exactly
+   as today. Seven prod campaigns have no brief and never will.
+4. **Advisory to AI, authoritative to config.** The brief *suggests* to the
+   Studio AI (which the admin can then override freely) but *determines* the
+   scoring segment (which must be deterministic and explainable).
+5. **Short enough to answer honestly.** A 15-question wizard gets clicked
+   through. Target: **4 questions, ~30 seconds**, all pickable.
+
+## 4. What to ask
+
+### 4.1 Objective — "what does success look like?" (single pick, required)
+
+| Value | Means | Success metric it implies |
+|---|---|---|
+| `agent_leads` | Collect leads for agents to call | Qualified leads delivered |
+| `screened_leads` | Qualify before an agent's time is spent | Screening pass rate |
+| `audience_build` | Grow a retargetable audience | Verified contacts gained |
+| `partner_footfall` | Drive redemption traffic to a partner | Redemptions |
+
+Not Meta's objective taxonomy — MKTR's. These are the four things a campaign
+here actually does.
+
+### 4.2 Audience — "who is this for?" (structured, all optional)
+
+- **Language / market** — `en` \| `zh` \| `ms` \| `ta` \| `any`
+  → **the single highest-value field**: feeds the scoring market-fit segment
+  per campaign, replacing today's one global zh/chinese assumption.
+- **Age band** — multi-select over the taxonomy's 5-year bands, collapsed to
+  ranges (`18-29`, `30-44`, `45-59`, `60+`).
+- **Life stage** — `young_single` \| `young_family` \| `established_family` \|
+  `pre_retiree` \| `retiree` \| `any`.
+- **Income band** — reuse `finance.annual_income_band`'s five bands, or `any`.
+
+Every axis maps onto an existing `factTaxonomy` key. That is deliberate: the
+brief states the audience in the SAME vocabulary the fact ledger uses, so
+"who we wanted" and "who we got" are directly comparable (§7).
+
+### 4.3 Target — "how many, by when?" (optional, two fields)
+
+A number and a date. Without it, §7's measurement is impossible; with it,
+every campaign becomes gradeable. Optional because a test campaign genuinely
+has no target.
+
+### 4.4 Derived, NOT asked
+
+`archetype` ∈ `draw` \| `reward` \| `quiz` \| `screening` \| `plain_form`,
+computed from `design_config` + activation + screening config. Stored
+denormalized on the campaign for query speed, recomputed on save. This is the
+field §6.3's scoring split consumes.
+
+## 5. Where it lives
+
+**Reuse `campaigns.targetAudience`**, widened to hold the whole brief:
+
+```
+targetAudience: {
+  objective: 'agent_leads',
+  audience: { language: 'zh', ageBands: ['30-44','45-59'],
+              lifeStage: 'established_family', incomeBand: 'any' },
+  target: { metric: 'qualified_leads', value: 200, byDate: '2026-09-30' },
+  archetype: 'draw',            // derived, recomputed on save
+  notes: '…',                   // free text, advisory, consumed by nothing
+  briefVersion: 1
+}
+```
+
+**Not `design_config`.** The brief is business metadata, not design. Putting
+it in `design_config` would drag it through the v2 clamp, the twin-file parity
+tests, and the public projection — three mechanisms that exist to protect
+*rendering*, none of which the brief needs. It would also risk leaking
+targeting data into the anonymous public payload, which must never happen.
+
+A dedicated `brief` column would be cleaner naming, but `targetAudience` is
+already there, already JSONB, already empty, and already named for the biggest
+part of the payload. One fewer column beats one better name.
+
+## 6. What consumes it — phased, each independently shippable
+
+### 6.1 Phase 1 — capture (no consumer)
+
+Schema + a create-flow step + an edit surface in Studio. Ships useful on day
+one purely as recorded intent: "what was this campaign for?" is currently
+unanswerable for all seven prod campaigns.
+
+Backfill: none. Existing campaigns keep `{}` and every consumer treats a
+missing brief as "no opinion", never as a default.
+
+### 6.2 Phase 2 — Studio AI (the biggest immediate win)
+
+Feed objective + audience into the "Fill everything" prompt. The AI currently
+infers audience from the campaign name; a `zh` / `pre_retiree` brief would
+change headline, tone, imagery, and the T&C register.
+
+Strictly advisory — the admin overrides anything, as today.
+
+### 6.3 Phase 3 — scoring (gated)
+
+Two things, both blocked on the layer split discussed 2026-07-26:
+
+- **Per-campaign market fit.** `audience.language` replaces the global segment
+  for leads from that campaign — a campaign aimed at Tamil speakers should not
+  score every lead down for not being Mandarin-speaking. This is a scoring-config
+  dimension, not a code change (`enrichment_scoring_configs` §7.2).
+- **Archetype intent weighting.** A `screening` lead who passed carries more
+  buying intent than a `reward` grab. This belongs to the **per-lead intent
+  score**, which does not exist yet.
+
+**Gate:** do not build until the person-score/lead-score split lands, and not
+before there are enough won leads to validate any weighting at all (prod
+2026-07-26: **zero** won leads — every weight is currently unvalidated).
+
+### 6.4 Phase 4 — profile-question suggestion
+
+The brief implies which of PR 0's five questions earn their conversion cost:
+an `audience_build` campaign wants `language` only; an `agent_leads` campaign
+targeting `pre_retiree` wants `retirement_age` and `annual_income`.
+
+**Suggest, never auto-enable.** Enabling a question changes a live funnel's
+conversion — that stays a human decision, consistent with the existing rule
+that AI "Fill everything" never enables questions on its own.
+
+### 6.5 Phase 5 — measurement
+
+"Did this campaign do what it said?" — stated target vs actual, and
+**intended audience vs the audience the fact ledger actually observed**. §4.2's
+shared vocabulary is what makes the second half computable: aimed at `zh`
+speakers, got 12% `zh`.
+
+That comparison is the real prize. It is also the one thing here that cannot
+be faked by intuition at forty campaigns.
+
+## 7. Open questions for Shawn
+
+1. **Objective list (§4.1)** — are those the right four? They are my read of
+   what MKTR campaigns actually do, not a taxonomy from anywhere.
+2. **Required or optional?** Recommendation: objective required, everything
+   else optional. Requiring the lot gets honest answers on campaign #1 and
+   clicked-through defaults by #20.
+3. **Retrofit the 7 existing campaigns?** ~5 minutes of clicking, and it makes
+   Phase 5 comparisons possible for current traffic. Recommendation: yes, by
+   hand, no migration.
+4. **Does `partner_footfall` belong here or in Redeem Ops?** Partner campaigns
+   may want their own brief shape entirely.
+
+## 8. Explicitly out of scope
+
+- Touching `campaigns.type` (§2 — `guided_review` gates the classic editor).
+- Pushing targeting to Meta/TikTok from the brief. The brief could *inform* a
+  targeting spec, but writing to ad platforms from campaign metadata is a
+  separate blast radius and a separate plan.
+- Free-text-driven anything (§3.1).
+- Auto-enabling profile questions (§6.4).

--- a/docs/plans/campaign-brief.md
+++ b/docs/plans/campaign-brief.md
@@ -1,6 +1,7 @@
 # Campaign brief — asking what a campaign is FOR, at creation
 
-**Status:** v1 SCOPE — not reviewed, not approved, not built.
+**Status:** v2 SCOPE — §7's four owner decisions RESOLVED (Shawn, 2026-07-26).
+Not Codex-reviewed, not built. Ready for review.
 **Author:** Claude, 2026-07-26 (from Shawn's ask: "during campaign creation we
 need to ask the user what the campaign target audience is, what is the end
 goal")
@@ -184,18 +185,24 @@ speakers, got 12% `zh`.
 That comparison is the real prize. It is also the one thing here that cannot
 be faked by intuition at forty campaigns.
 
-## 7. Open questions for Shawn
+## 7. Owner decisions (Shawn, 2026-07-26) — all four RESOLVED
 
-1. **Objective list (§4.1)** — are those the right four? They are my read of
-   what MKTR campaigns actually do, not a taxonomy from anywhere.
-2. **Required or optional?** Recommendation: objective required, everything
-   else optional. Requiring the lot gets honest answers on campaign #1 and
-   clicked-through defaults by #20.
-3. **Retrofit the 7 existing campaigns?** ~5 minutes of clicking, and it makes
-   Phase 5 comparisons possible for current traffic. Recommendation: yes, by
-   hand, no migration.
-4. **Does `partner_footfall` belong here or in Redeem Ops?** Partner campaigns
-   may want their own brief shape entirely.
+1. **Objective list — all four stand** (§4.1 unchanged): `agent_leads`,
+   `screened_leads`, `audience_build`, `partner_footfall`.
+2. **Objective REQUIRED; audience and target OPTIONAL.** Requiring everything
+   buys honest answers on campaign #1 and clicked-through defaults by #20.
+   Creation is blocked only on the one pick.
+3. **NO backfill.** The 7 existing campaigns keep `{}` forever. Consequence,
+   accepted knowingly: §6.5's aimed-at-vs-got comparison will not cover
+   today's traffic — including `Redeem $10 Fairprice Voucher`, which is
+   currently ~58 signups/month. Measurement starts with the next campaign
+   created. Reversible at any time by filling one in by hand.
+4. **`partner_footfall` STAYS.** Shawn does sometimes run campaigns where
+   delivering customers to a partner is the actual deliverable, not a side
+   effect of lead capture. It remains a first-class objective here rather
+   than moving to Redeem Ops. Open sub-question deferred: whether such a
+   campaign also needs partner-specific brief fields (which partner, what was
+   committed) — revisit when the first one is built.
 
 ## 8. Explicitly out of scope
 

--- a/docs/plans/per-campaign-lead-scoring.md
+++ b/docs/plans/per-campaign-lead-scoring.md
@@ -1,6 +1,6 @@
 # Per-campaign lead scoring — the admin describes the ideal lead, the score moves as things happen
 
-**Status:** v1 SCOPE — not reviewed, not approved, not built.
+**Status:** v2 SCOPE — isolation rule RESOLVED (Shawn, 2026-07-26), PR A specced to buildable detail (§10). Not Codex-reviewed, not built.
 **Author:** Claude, 2026-07-26, from Shawn's model:
 
 > "The admin, when creating campaigns, will say the ideal lead profile. The AI
@@ -178,31 +178,147 @@ waiting for the nightly.
 
 ## 7. Phasing
 
-1. **Events move the score** — screening outcome + WhatsApp read, against
-   today's single global config. Smallest change, needs no AI and no brief, and
-   it is the part an agent feels immediately: engaged leads rise in the queue.
-2. **Age curve + DOB backfill** — the biggest single accuracy win available,
-   independent of everything else.
-3. **Score moves to the lead** — `prospects.score`, per-campaign configs,
-   objective-level inheritance. The structural change.
-4. **AI authoring** — admin writes a description, AI proposes a config, admin
-   reviews it in plain language before it goes live.
-5. **Email opens** — tracking pixel, then wire in as an event.
+**Revised after Shawn's isolation decision (§8.1).** The original plan put
+"events move the score" first, against today's per-PERSON score. That is
+impossible: with one score per person, a screening refusal moves the number
+every campaign sees — precisely the cross-campaign bleed the isolation rule
+forbids. **Event scoring and the move to per-lead are one piece of work.**
 
-Steps 1 and 2 are useful on their own and do not depend on 3–5.
+1. **PR A — the lead score, with events** (§10). `prospects.score` +
+   breakdown, scored from person facts + that lead's OWN events, under the
+   campaign's config (falling back to today's global one). Isolation holds by
+   construction: a lead can only see its own campaign's evidence.
+2. **PR B — age curve + DOB backfill** (§5.3). The biggest single accuracy win
+   available, and fully independent of A.
+3. **PR C — per-campaign configs + objective inheritance** (§5.4).
+4. **PR D — AI authoring** (§5.2). Admin writes a description, AI proposes a
+   config, admin reviews it in plain language before it goes live.
+5. **PR E — email opens.** Tracking pixel first, then wire in as an event.
 
-## 8. Open questions
+A and B are independent of each other and of C–E.
 
-1. **Does a screening refusal on campaign A affect the person's score on
-   campaign B?** Argument for: it is real evidence about the human. Against: a
-   recruitment refusal says nothing about their insurance propensity.
-   Recommendation: **no cross-campaign event bleed in v1** — keep it simple,
-   revisit with data.
+## 8. Questions
+
+1. **RESOLVED (Shawn, 2026-07-26): NO cross-campaign event bleed.** A
+   screening refusal on a recruitment campaign must not drag the person's
+   insurance score down — the refusal is evidence about *that pitch*, not
+   about the human's propensity to buy. Consequence: §7 re-phased, since this
+   is unachievable while one score serves every campaign.
 2. **Should the admin see the AI's config as rules or as prose?** Prose is
    readable; rules are precise. Probably prose with the numbers shown.
 3. **Person-level score: keep as summary or retire?** (§4)
 4. **Recruitment as a campaign objective** — `campaign-brief.md` §4.1 is missing
    it and needs updating regardless of this plan.
+
+## 10. PR A in detail — the lead score with events
+
+### 10.1 The shape
+
+```
+leadScore = clamp(0, 100,  base + Σ eventAdjustments)
+
+base   = person facts scored under the campaign's config  (today's engine, unchanged)
+events = this lead's OWN evidence, decayed, bounded to ±EVENT_BAND
+```
+
+`base` reuses `consumerScoring.js` untouched — facts in, component points out.
+Only the wrapper is new.
+
+### 10.2 Storage
+
+| Column | Note |
+|---|---|
+| `prospects.score` | INTEGER 0–100, **already exists, dead since inception** — reuse |
+| `prospects.scoreBreakdown` | NEW JSONB — components + event entries, same shape PR 3's panel already renders |
+| `prospects.scoredConfigVersion` / `scoringAlgorithmVersion` / `scoreInputHash` / `scoreComputedAt` | NEW — same stamping contract as `consumer_profiles`, so unscoreable leads exit the re-score loop |
+
+`consumer_profiles.meetScore`/`buyScore` stay as the person-grain summary
+(§4 option a). PR 3's People columns keep working unchanged.
+
+### 10.3 Event sourcing — and how isolation is enforced
+
+**The isolation rule is enforced by the QUERY, not by a filter applied
+afterwards.** Each event is fetched already scoped to the lead:
+
+| Event | Source | Scoping |
+|---|---|---|
+| Screening qualified / not_qualified | `prospects.screeningVerdict` | **Same row as the lead.** Inherently isolated |
+| Agreed to meet, sentiment | `prospects.screeningMetadata.verdictDetail` | Same row |
+| WhatsApp read | `wa_message_statuses.status='read'` | Joined via `redemption_events.metadata.messageId = wamid` → entitlement → activation → **campaignId**, matched to the lead's campaign |
+
+That WhatsApp join already exists — `leadProfileService.deliveryReceipts()`
+uses exactly this path today. Nothing new to invent.
+
+**A read receipt on the person's phone from a different campaign is invisible
+to this lead.** Not scored down, not scored up — never fetched.
+
+### 10.4 Event weights (config, per campaign later)
+
+```
+events: {
+  band: 25,                    // total events may move the score at most ±25
+  halfLifeDays: 45,
+  weights: {
+    screening_qualified:    +12,
+    screening_agreed_meet:  +10,
+    screening_positive:      +5,
+    screening_neutral:        0,
+    screening_not_qualified: -12,
+    whatsapp_read:           +4,
+    whatsapp_unread_7d:      -2,   // delivered, never opened, a week gone
+  }
+}
+```
+
+**Bounded on purpose.** An unbounded event layer makes the facts decorative —
+one read receipt should not outrank knowing someone's income and family.
+Evidence adjusts a prior; it does not replace it.
+
+**Decay** for the same reason life events decay: a read three months ago is
+not evidence of interest today.
+
+### 10.5 Recompute triggers
+
+- **Immediate** on screening verdict write — the highest-value event, and an
+  agent watching a lead should see it move within seconds, not overnight.
+- **On WhatsApp status webhook** — cheap; the hash gate makes a no-op free.
+- **Nightly sweep** — catch-all for decay (an event's contribution shrinks with
+  time even when nothing happens) and for anything the live paths missed.
+
+Decay means a lead's score changes with no input event, so the hash must
+include a **decay epoch** (e.g. the SGT date) or the gate will suppress the
+recompute. Cheap, and easy to get wrong.
+
+### 10.6 Surfacing
+
+The breakdown gains an events section, rendered by the same PR 3 panel:
+
+```
+BASE (facts)                     46
+EVENTS                          +14
+  screening: agreed to meet     +10   24 Jul
+  screening: positive            +5   24 Jul
+  WhatsApp read                  +4   25 Jul
+  decay                          −5
+                                 ──
+                                 60
+```
+
+The point is an agent reading *"78 → 40 because they refused the screening
+call on 24 Jul"* — the number moving is only useful if the reason moves with it.
+
+### 10.7 Tests that must exist
+
+- A screening refusal on campaign A leaves the same person's campaign-B lead
+  **byte-identical** (§8.1 — the isolation rule, as an executable assertion).
+- Events cannot push a score outside 0–100, nor beyond ±band.
+- A qualified screening raises the score; a refusal lowers it; neutral moves
+  nothing.
+- Decay: the same event scores lower a month later, with no other change.
+- The hash gate re-scores across a decay-epoch boundary and no-ops within one.
+- A lead with no events scores exactly its base — the event layer is inert
+  until there is evidence.
+- Erased consumers: no lead score, no breakdown, consistent with §9 erasure.
 
 ## 9. Out of scope
 

--- a/docs/plans/per-campaign-lead-scoring.md
+++ b/docs/plans/per-campaign-lead-scoring.md
@@ -1,6 +1,6 @@
 # Per-campaign lead scoring — the admin describes the ideal lead, the score moves as things happen
 
-**Status:** v2 SCOPE — isolation rule RESOLVED (Shawn, 2026-07-26), PR A specced to buildable detail (§10). Not Codex-reviewed, not built.
+**Status:** v2 SCOPE — **Codex round 1: REWORK** (3 BLOCKER, 7 MAJOR; §11). All findings verified against code and accepted. NOT ready to build — v2 rework required.
 **Author:** Claude, 2026-07-26, from Shawn's model:
 
 > "The admin, when creating campaigns, will say the ideal lead profile. The AI
@@ -319,6 +319,79 @@ call on 24 Jul"* — the number moving is only useful if the reason moves with i
 - A lead with no events scores exactly its base — the event layer is inert
   until there is evidence.
 - Erased consumers: no lead score, no breakdown, consistent with §9 erasure.
+
+## 11. Codex adversarial review round 1 — REWORK (3 BLOCKER, 7 MAJOR)
+
+gpt-5.6-sol xhigh, 2026-07-26. Every finding below was independently verified
+against the code before being accepted. **All accepted; none disputed.**
+
+### The three blockers
+
+**B1 — Campaign isolation is already broken in the BASE layer, before events.**
+§10.3 claimed isolation is enforced by the event query. False. The base score
+consumes person-wide telemetry: `loadTelemetry()` computes `whatsappReachable`
+as `EXISTS(… WHERE w."recipientHash" = c."phoneHash" AND w.status IN
+('delivered','read'))` — **no campaign predicate at all**
+(`consumerScoringService.js:118-122`), and engagement uses consumer-level
+`signupCount`/`verifiedSignupCount`. A WhatsApp read sent for campaign A
+therefore raises campaign B's score today. The proposed isolation test
+(screening refusal only) would have PASSED while consent, delivery, read and
+signup activity all bled across campaigns.
+→ Isolation must be specified over **every telemetry input**, not just events.
+
+**B2 — The "already exists" WhatsApp→campaign join does not exist.**
+`deliveryReceipts()` joins `redemption_events → wa_message_statuses` on wamid
+and filters by a set of entitlement ids drawn from the whole person journey
+(`leadProfileService.js:105-119`). It never touches activations or campaigns.
+Worse: receipts store no immutable `campaignId`/`prospectId` snapshot, and
+activations can be relinked, so reconstructing ownership from the *current*
+activation can attribute a historical send to the wrong campaign. And
+screening-callback WhatsApps write no receipt at all — their wamid lives only
+in `prospects.screeningMetadata.waCallback`, invisible to the proposed join.
+→ Needs **immutable send-time ownership** (`prospectId`, `campaignId`, kind,
+`wamid`) recorded at send, not reconstructed later.
+
+**B3 — Erasure deliberately PRESERVES `prospects.score`.**
+The shipped contract states the skeleton keeps "ids, campaign,
+status/priority/**score**" (`erasureService.js:21-22`), and the allowlist
+rebuild never nulls it. A `scoreBreakdown` added beside it would survive
+erasure too — carrying event timestamps, inferred sentiment and observation
+ids. That is materially worse than preserving a bare integer, and deleting
+`consumer_profiles` does not help because the new data lives on `prospects`.
+→ §10.7's erasure test would have failed on day one.
+
+### The seven majors (all accepted)
+
+| # | Finding |
+|---|---|
+| M4 | Two drifting authorities. The existing scorer keeps overwriting `meetScore`/`buyScore` from the global model; calling them "a summary of lead scores" without retiring that writer or defining a real projection guarantees disagreement. **And "PR 3's UI already renders both grains" is false** — it renders person grain only, on the profile view; the Prospects queue has no score column at all. |
+| M5 | Spine relink invalidates `consumer_profiles.inputVersion` only. Prospect-grain scores need their own dirty marker, relink invalidation, owner-movement fence, and a prospect cursor in the sweep. |
+| M6 | A date-based decay epoch mechanically fixes the gate but forces a **full-population rewrite daily** under budget, and staggered decay above it. Also: "the hash gate makes a no-op free" is false — telemetry, observations, resolution, hashing and the full score all run *before* the comparison; the gate saves only the write. |
+| M7 | "Existing choke points already bump the input version" is false — neither the WA webhook nor the screening-verdict writers bump or re-score. This is new transactional wiring. **And there is no normalized `agreedToMeet` field**: verdictDetail is `reason`/`interestLevel`/`summary`/`sentiment`/recording (`retellScreeningService.js:666`). §6 specced an event on a field that does not exist. |
+| M8 | A closed *fact* vocabulary does not validate a *scoring config*. `normalizeConfig` permissively merges unknown components, and a non-positive half-life silently disables decay. A schema-valid AI config can still be absurd. Needs semantic invariants, bounded deltas, population simulation, distribution diffs, rollback. Also: `sourceDescription` free text contradicts `campaign-brief.md` §3.1, and Studio AI already treats campaign text as untrusted — this plan specified no equivalent isolation. **And "admin reviews it" is not a control**: the config table has no draft/approved state and the reader activates the highest version immediately. |
+| M9 | `enrichment_scoring_configs` has an integer PK and no campaign/objective/status/parent column; the reader caches one global config. Per-campaign inheritance needs real schema. **The two plans also disagree on objective names** — `insurance_sales`/`recruitment` here vs `agent_leads`/`screened_leads` in the brief. |
+| M10 | `campaign-brief.md`'s claim that every audience axis maps to the taxonomy is false — there is no `lifeStage` key, and the ledger stores 5-year **birth-year** bands, so an age curve needs a date-sensitive overlap rule and cannot use exact age. |
+
+### Disposition
+
+**REWORK accepted.** The plan asserted five things about existing code that are
+untrue (B2, M4's UI claim, M7's choke points, M7's `agreedToMeet`, M10's
+taxonomy mapping) — each written from reading rather than verification. The
+lesson for v2: **claims about existing behaviour get a file:line citation or
+they do not go in the plan.**
+
+The architecture (per-lead score, AI authors / code applies, bounded decaying
+events) was not challenged. What failed is the assumption that the substrate
+already supports it.
+
+v2 must, before any build:
+1. Define isolation over **every** input, and add send-time message ownership.
+2. Resolve the two-authority problem explicitly — one writer, one projection.
+3. Fix erasure for prospect-grain score + breakdown.
+4. Replace the decay-epoch hack with something that doesn't rewrite daily.
+5. Reconcile the objective vocabularies between the two plans.
+6. Specify semantic (not just structural) validation for AI configs, plus a
+   draft/approved state the reader honours.
 
 ## 9. Out of scope
 

--- a/docs/plans/per-campaign-lead-scoring.md
+++ b/docs/plans/per-campaign-lead-scoring.md
@@ -1,7 +1,7 @@
 # Per-campaign lead scoring — the admin describes the ideal lead, the score moves as things happen
 
-**Status:** v2 — REWORKED against Codex round 1 (REWORK: 3 BLOCKER / 7 MAJOR,
-all accepted, §12). Ready for round 2. **Not built.**
+**Status:** v2 — Codex round 2 returned REWORK: 4 of the 10 re-opened (§16).
+v3 required before build. **Not built.**
 **Author:** Claude, 2026-07-26, from Shawn's model:
 
 > "The admin, when creating campaigns, will say the ideal lead profile. The AI
@@ -340,3 +340,49 @@ scoring is not available and should not be promised.
 LLM scoring individual leads · cross-campaign response bleed · auto-activating
 an AI config without approval · fitting weights from outcomes (needs closed
 deals; prod has zero).
+
+## 16. Codex round 2 — REWORK (4 of the 10 re-opened)
+
+gpt-5.6-sol xhigh, run 2026-07-26 against the v2 text; log recorded here
+2026-07-27, each finding re-verified against code at `a7ac0a9` before
+acceptance. Six of round 1's ten findings stayed closed and are not to be
+reworked; four re-opened against v2 itself:
+
+1. **B1 (re-opened) — ISOLATION.** §3.2's capability-vs-response
+   classification does not survive the data. A `read` is simultaneously proof
+   of deliverability AND a lead response, and `wa_message_statuses` keeps only
+   the FURTHEST status per wamid (`STATUS_RANK_SQL` upsert,
+   `redeemOps/waWebhookService.js:37,79-87`; `wamid` is the PK,
+   `WaMessageStatus.js:15`) — so §3.3's "delivered-ever" predicate (dropping
+   `'read'`) makes a READ message stop counting as delivered. Prod today: 3
+   `delivered`, 1 `read`, 1 `failed` — the strongest deliverability proof in
+   the table would be the one dropped. Consent is also purpose-scoped in
+   schema (`ConsentEvent.campaignId`, `ConsentEvent.js:25` — "Purpose scope;
+   NULL = explicit global act"), not uniformly person-scoped as §3.2's table
+   asserts. Re-derive the model against what the tables actually store.
+
+2. **M6 (re-opened) — DECAY.** §6 stores "`baseScore` (facts + person
+   telemetry — time-independent)". False: engagement recency decays inside the
+   base (`consumerScoring.js:186-187`) and life-event facts decay inside the
+   base (`:257-259`) — `scoreConsumer` takes `now` and the base is
+   time-dependent. Separately, a freshly-decayed display over a
+   nightly-materialised sort column yields visibly misordered pages. Solve
+   ordering and freshness together, or state plainly which one is sacrificed.
+
+3. **M9 (re-opened) — CONFIG IDENTITY.** §7 says "`campaign-brief.md` gains a
+   required `product` field". The brief was never edited — it has no `product`
+   field in its §4 or §5. Either make the edit in the same change or stop
+   claiming it. And §9 is still a sketch: specify real schema for campaign →
+   product → global resolution, including how per-key caching invalidates
+   inherited entries (today: one process-wide slot with a 60s TTL,
+   `consumerScoringService.js:47-76`).
+
+4. **M10 (re-opened) — lifeStage.** §13.2 says drop `lifeStage` from the
+   brief; the brief still lists it in its §4.2 AND in its §5 example JSON, and
+   still claims "every axis maps onto an existing `factTaxonomy` key" — there
+   is no lifeStage key (`factTaxonomy.js` `FACT_KEYS`). Same rule: make the
+   edit, don't describe it.
+
+**Rule for v3** (the failure mode behind M9 and M10): if the plan describes an
+edit to another document, MAKE the edit in the same change. A described-but-
+unmade edit reads as done and hides the gap from every later reader.

--- a/docs/plans/per-campaign-lead-scoring.md
+++ b/docs/plans/per-campaign-lead-scoring.md
@@ -1,0 +1,213 @@
+# Per-campaign lead scoring — the admin describes the ideal lead, the score moves as things happen
+
+**Status:** v1 SCOPE — not reviewed, not approved, not built.
+**Author:** Claude, 2026-07-26, from Shawn's model:
+
+> "The admin, when creating campaigns, will say the ideal lead profile. The AI
+> will use that info to decide the scoring mechanics. Whenever a lead comes in,
+> the AI/programmatically decides the score. If the lead gets qualified (AI
+> screening call — positive/negative/neutral, agree to meet or not), or if they
+> read the WhatsApp/email, the score increases/decreases accordingly."
+
+**Supersedes part of:** `consumer-profile-enrichment.md` §7 (shipped 2026-07-26
+as PRs #286/#289 — see §4, this changes where the score lives).
+**Depends on:** `campaign-brief.md` (the ideal-lead description is a brief field).
+
+## 1. What changes
+
+Two shifts from what shipped today.
+
+| | Shipped (PR 2/3) | This |
+|---|---|---|
+| Whose rules | ONE global config for every campaign | **One per campaign**, AI-authored from the admin's description |
+| What moves it | Facts + signup history, recomputed nightly | **+ engagement events** — screening outcome, message reads |
+| Where it lives | The person | **The lead** (a person can be a great recruit and a poor buyer) |
+
+The reason it must move to the lead is Shawn's own example: a recruitment
+campaign wants a 25-year-old fresh grad; an insurance campaign wants 30–65. The
+facts are identical; the verdict is opposite. A single per-person number cannot
+express both, so the score becomes a property of **(person × campaign)** —
+which is exactly what a `prospect` row already is.
+
+## 2. The guardrail — AI authors, code applies
+
+**The AI writes the rules ONCE, at campaign creation. Plain code applies them
+to every lead, forever.** Not the AI scoring each lead as it arrives.
+
+Same output, but:
+- **Explainable.** The breakdown panel keeps working — every point traceable to
+  a rule and an observation. An LLM scoring each lead yields a number with no
+  auditable reason.
+- **Reproducible.** Two identical leads score identically, today and in six
+  months. Sampling temperature does not decide who gets called.
+- **Instant and free.** No API call on the capture hot path, no per-lead cost,
+  no failure mode where scoring is down.
+- **Correctable.** A bad rule is one config row to fix, not a prompt to coax.
+
+This is the single most important decision in this plan. Everything below
+assumes it.
+
+## 3. What already exists (verified against prod, 2026-07-26)
+
+| Piece | State |
+|---|---|
+| Versioned scoring config table (`enrichment_scoring_configs`, JSONB) | ✅ built — needs a campaign key |
+| Config-driven engine (`consumerScoring.js`) — weights are data, rules are code | ✅ built |
+| Fixed fact taxonomy (`factTaxonomy.js`) | ✅ built — **the AI's output vocabulary is closed and validatable** |
+| AI provider plumbing (`AiSettings`, as used by Studio AI) | ✅ built |
+| Re-score when inputs change (hash gate + sweep) | ✅ built |
+| **Screening outcome** — `prospects.screeningVerdict` (`qualified`/`not_qualified`) + `screeningMetadata.verdictDetail` (sentiment, reason) | ✅ captured |
+| **WhatsApp read receipts** — `wa_message_statuses.status = 'read'` | ✅ captured (1 read in prod today) |
+| `prospects.score` INTEGER 0–100, commented "Lead scoring from 0-100" | ✅ column exists, **written by nothing** — dead since inception |
+| **Email opens** | ❌ **NOT captured.** `EmailBroadcastRecipient` has `status`/`reason`/`sentAt`/`error` only — delivery, not engagement. Needs a tracking pixel before email reads can move anything. |
+
+## 4. Where the score lives — and what this supersedes
+
+**Reuse `prospects.score`** (dead since inception) + a new `scoreBreakdown`
+JSONB beside it. Same trick as the campaign brief reusing dead `targetAudience`.
+
+**What happens to PR 2's person-level score:** `consumer_profiles.meetScore` /
+`buyScore` were shipped today. Under this model they are no longer the
+actionable number — the lead score is. Options, decide at build time:
+
+- **(a)** Keep them as a cross-campaign summary on the People page (highest
+  lead score, or most recent), lead score drives the queue. Least disruption.
+- **(b)** Retire them; People shows the person's best lead score.
+
+Recommendation: **(a)** — the People page is a person index and wants a
+person-grain number; the Prospects queue wants the lead number. PR 3's UI
+already renders both grains, so the surfaces survive either way.
+
+**The fact ledger does not move.** Facts stay per person — that is the whole
+point of the spine, and it is what lets a recruitment lead and an insurance
+lead share one set of observations while scoring oppositely.
+
+## 5. The config — per campaign, AI-authored, admin-visible
+
+### 5.1 Shape
+
+Extends today's config with a campaign key and an event table:
+
+```
+{
+  campaignId: '…',              // null = the global default (today's behaviour)
+  inheritsFrom: 'insurance_sales',   // an objective-level default, §5.4
+  sourceDescription: 'fresh grads, 22-28, hungry, recruiting consultants',
+  authoredBy: 'ai' | 'admin',
+  components: { … maxPoints per component … },
+  ageCurve:  { '18-24': 1.0, '25-29': 0.9, '30-34': 0.5, … },  // §5.3
+  incomeDirection: 'positive' | 'negative' | 'ignore',
+  events: { … §6 … },
+  version: 3
+}
+```
+
+### 5.2 What the AI is allowed to emit
+
+**A closed vocabulary only** — component names, `maxPoints`, curve points,
+direction flags. It never emits code, never invents a fact key, never writes
+free text into scoring logic. Output is schema-validated against
+`factTaxonomy`; anything unrecognised is rejected and the admin sees a plain
+error, not a silently degraded config.
+
+This is why the fixed taxonomy from PR 0/1 matters here: it bounds what the AI
+can say.
+
+### 5.3 Age as a curve, not a range
+
+An age *range* ("25–65") cannot score — everyone inside scores identically and
+the boundary is a cliff. A *curve* can:
+
+- `insurance_sales`: peaks 35–44, low under 25
+- `recruitment`: peaks 22–28, falls after 35
+
+**Defined over AGE, not birth year**, or the config silently rots one band
+every five years. The taxonomy stores 5-year birth bands; age is derived at
+scoring time.
+
+**Age is the highest-coverage signal available** — 129 of 130 prod consumers
+have a date of birth, versus 1 with income. Today it contributes **zero** to
+the score. Fixing that is worth more than any other single component.
+
+**Prerequisite:** the ledger holds only 1 `birth_year_band` observation because
+the mapper runs at capture and predates the population. A backfill over the 129
+existing DOBs is required or the component scores NULL for everyone.
+
+### 5.4 Inheritance — so 40 campaigns don't mean 40 hand-built models
+
+Each campaign inherits from an **objective-level default** (`insurance_sales`,
+`recruitment`, `audience_build`, `partner_footfall` — the campaign brief's
+objective, §`campaign-brief.md` 4.1, plus recruitment which that plan is
+missing) and overrides only what the admin's description implies.
+
+A new campaign with no description scores exactly like its objective default.
+Twenty recruitment campaigns share one tuned model unless someone deliberately
+diverges.
+
+## 6. Events that move the score
+
+The static score is a prior. Engagement is evidence.
+
+| Event | Source | Direction |
+|---|---|---|
+| Screening: qualified | `screeningVerdict` | strong + |
+| Screening: agreed to meet | `verdictDetail` | strong + |
+| Screening: positive sentiment | `verdictDetail.sentiment` | + |
+| Screening: neutral | `verdictDetail.sentiment` | 0 |
+| Screening: not qualified / refused | `screeningVerdict` | strong − |
+| WhatsApp read | `wa_message_statuses` = `read` | + |
+| WhatsApp delivered, never read | `wa_message_statuses` | small − after a delay |
+| Email opened | ❌ **needs tracking pixel first** | + |
+
+**Rules:**
+- Event weights live in the same config, so they are per-campaign too — a read
+  receipt may matter more for a recruitment pitch than a voucher drop.
+- Events **decay**, like life events do today. A read three months ago is not
+  evidence of interest now.
+- Events are **evidence, not overrides.** A screening refusal should sink a
+  score, not zero it — the person may convert on a different campaign, and the
+  facts that made them promising are still true.
+- Every event appears in the breakdown with its timestamp, so an agent can see
+  *"78 → 40 because they refused the screening call on 24 Jul."*
+
+**Trigger:** these already flow through choke points that bump the enrichment
+input version, and the sweep's hash gate re-scores when inputs change. So
+"score moves on event" is mostly wiring existing events into the hash, plus an
+immediate re-score on the high-value ones (screening verdict) rather than
+waiting for the nightly.
+
+## 7. Phasing
+
+1. **Events move the score** — screening outcome + WhatsApp read, against
+   today's single global config. Smallest change, needs no AI and no brief, and
+   it is the part an agent feels immediately: engaged leads rise in the queue.
+2. **Age curve + DOB backfill** — the biggest single accuracy win available,
+   independent of everything else.
+3. **Score moves to the lead** — `prospects.score`, per-campaign configs,
+   objective-level inheritance. The structural change.
+4. **AI authoring** — admin writes a description, AI proposes a config, admin
+   reviews it in plain language before it goes live.
+5. **Email opens** — tracking pixel, then wire in as an event.
+
+Steps 1 and 2 are useful on their own and do not depend on 3–5.
+
+## 8. Open questions
+
+1. **Does a screening refusal on campaign A affect the person's score on
+   campaign B?** Argument for: it is real evidence about the human. Against: a
+   recruitment refusal says nothing about their insurance propensity.
+   Recommendation: **no cross-campaign event bleed in v1** — keep it simple,
+   revisit with data.
+2. **Should the admin see the AI's config as rules or as prose?** Prose is
+   readable; rules are precise. Probably prose with the numbers shown.
+3. **Person-level score: keep as summary or retire?** (§4)
+4. **Recruitment as a campaign objective** — `campaign-brief.md` §4.1 is missing
+   it and needs updating regardless of this plan.
+
+## 9. Out of scope
+
+- LLM scoring individual leads (§2).
+- Cross-campaign event bleed (§8.1) in v1.
+- Auto-applying an AI config without admin review.
+- Retraining/fitting weights from outcomes — a later concern, and one that
+  needs closed deals to fit against.

--- a/docs/plans/per-campaign-lead-scoring.md
+++ b/docs/plans/per-campaign-lead-scoring.md
@@ -1,6 +1,7 @@
 # Per-campaign lead scoring — the admin describes the ideal lead, the score moves as things happen
 
-**Status:** v2 SCOPE — **Codex round 1: REWORK** (3 BLOCKER, 7 MAJOR; §11). All findings verified against code and accepted. NOT ready to build — v2 rework required.
+**Status:** v2 — REWORKED against Codex round 1 (REWORK: 3 BLOCKER / 7 MAJOR,
+all accepted, §12). Ready for round 2. **Not built.**
 **Author:** Claude, 2026-07-26, from Shawn's model:
 
 > "The admin, when creating campaigns, will say the ideal lead profile. The AI
@@ -9,394 +10,333 @@
 > screening call — positive/negative/neutral, agree to meet or not), or if they
 > read the WhatsApp/email, the score increases/decreases accordingly."
 
-**Supersedes part of:** `consumer-profile-enrichment.md` §7 (shipped 2026-07-26
-as PRs #286/#289 — see §4, this changes where the score lives).
-**Depends on:** `campaign-brief.md` (the ideal-lead description is a brief field).
+**Supersedes part of:** `consumer-profile-enrichment.md` §7 (shipped 2026-07-26,
+PRs #286/#289).
+**Depends on:** `campaign-brief.md` — which v2 also amends (§7).
+
+**Every claim about existing code below carries a file:line citation.** v1
+asserted five things about the codebase that were false; that is what the
+citations exist to prevent.
 
 ## 1. What changes
 
-Two shifts from what shipped today.
-
 | | Shipped (PR 2/3) | This |
 |---|---|---|
-| Whose rules | ONE global config for every campaign | **One per campaign**, AI-authored from the admin's description |
-| What moves it | Facts + signup history, recomputed nightly | **+ engagement events** — screening outcome, message reads |
-| Where it lives | The person | **The lead** (a person can be a great recruit and a poor buyer) |
+| Whose rules | ONE global config | **One per campaign**, AI-authored, inheriting a product-level default |
+| What moves it | Facts + person telemetry, nightly | **+ lead-scoped engagement events**, decayed |
+| Where it lives | The person | **The lead** — one authority, person score becomes a defined projection (§4) |
 
-The reason it must move to the lead is Shawn's own example: a recruitment
-campaign wants a 25-year-old fresh grad; an insurance campaign wants 30–65. The
-facts are identical; the verdict is opposite. A single per-person number cannot
-express both, so the score becomes a property of **(person × campaign)** —
-which is exactly what a `prospect` row already is.
+A recruitment campaign wants a 25-year-old fresh grad; an insurance campaign
+wants 30–65. Identical facts, opposite verdict. The score is therefore a
+property of **(person × campaign)** — which is what a `prospect` row is.
 
 ## 2. The guardrail — AI authors, code applies
 
-**The AI writes the rules ONCE, at campaign creation. Plain code applies them
-to every lead, forever.** Not the AI scoring each lead as it arrives.
+The AI writes rules ONCE at campaign creation; plain code applies them to every
+lead forever. Not an LLM scoring each lead.
 
-Same output, but:
-- **Explainable.** The breakdown panel keeps working — every point traceable to
-  a rule and an observation. An LLM scoring each lead yields a number with no
-  auditable reason.
-- **Reproducible.** Two identical leads score identically, today and in six
-  months. Sampling temperature does not decide who gets called.
-- **Instant and free.** No API call on the capture hot path, no per-lead cost,
-  no failure mode where scoring is down.
-- **Correctable.** A bad rule is one config row to fix, not a prompt to coax.
+Explainable (every point traces to a rule and an observation), reproducible
+(two identical leads score identically in six months), free and instant on the
+capture path, and correctable by editing one config row.
 
-This is the single most important decision in this plan. Everything below
-assumes it.
+Unchallenged by review. Everything below assumes it.
 
-## 3. What already exists (verified against prod, 2026-07-26)
+## 3. THE ISOLATION MODEL (rewritten — Codex B1)
 
-| Piece | State |
-|---|---|
-| Versioned scoring config table (`enrichment_scoring_configs`, JSONB) | ✅ built — needs a campaign key |
-| Config-driven engine (`consumerScoring.js`) — weights are data, rules are code | ✅ built |
-| Fixed fact taxonomy (`factTaxonomy.js`) | ✅ built — **the AI's output vocabulary is closed and validatable** |
-| AI provider plumbing (`AiSettings`, as used by Studio AI) | ✅ built |
-| Re-score when inputs change (hash gate + sweep) | ✅ built |
-| **Screening outcome** — `prospects.screeningVerdict` (`qualified`/`not_qualified`) + `screeningMetadata.verdictDetail` (sentiment, reason) | ✅ captured |
-| **WhatsApp read receipts** — `wa_message_statuses.status = 'read'` | ✅ captured (1 read in prod today) |
-| `prospects.score` INTEGER 0–100, commented "Lead scoring from 0-100" | ✅ column exists, **written by nothing** — dead since inception |
-| **Email opens** | ❌ **NOT captured.** `EmailBroadcastRecipient` has `status`/`reason`/`sentAt`/`error` only — delivery, not engagement. Needs a tracking pixel before email reads can move anything. |
+### 3.1 What v1 got wrong
 
-## 4. Where the score lives — and what this supersedes
+v1 claimed isolation was enforced by the event query. It is not, because the
+**base** score already consumes person-wide telemetry. `loadTelemetry()`
+computes `whatsappReachable` as
+`EXISTS(… WHERE w."recipientHash" = c."phoneHash" AND w.status IN ('delivered','read'))`
+— no campaign predicate (`consumerScoringService.js:118-122`) — and engagement
+reads consumer-level `signupCount`/`verifiedSignupCount`
+(`consumerScoringService.js:107`). **A WhatsApp read for campaign A raises
+campaign B's score in production today.**
 
-**Reuse `prospects.score`** (dead since inception) + a new `scoreBreakdown`
-JSONB beside it. Same trick as the campaign brief reusing dead `targetAudience`.
+### 3.2 The correction — classify every input, don't blanket-scope
 
-**What happens to PR 2's person-level score:** `consumer_profiles.meetScore` /
-`buyScore` were shipped today. Under this model they are no longer the
-actionable number — the lead score is. Options, decide at build time:
+"Scope everything to the campaign" is the wrong fix. Some sharing is correct:
+if someone read a WhatsApp from campaign A, they demonstrably *are* reachable
+on WhatsApp, and campaign B may rely on that. What must not travel is
+**evidence about how they responded to a particular pitch**.
 
-- **(a)** Keep them as a cross-campaign summary on the People page (highest
-  lead score, or most recent), lead score drives the queue. Least disruption.
-- **(b)** Retire them; People shows the person's best lead score.
+So every input is classified, and the classification is the contract:
 
-Recommendation: **(a)** — the People page is a person index and wants a
-person-grain number; the Prospects queue wants the lead number. PR 3's UI
-already renders both grains, so the surfaces survive either way.
-
-**The fact ledger does not move.** Facts stay per person — that is the whole
-point of the spine, and it is what lets a recruitment lead and an insurance
-lead share one set of observations while scoring oppositely.
-
-## 5. The config — per campaign, AI-authored, admin-visible
-
-### 5.1 Shape
-
-Extends today's config with a campaign key and an event table:
-
-```
-{
-  campaignId: '…',              // null = the global default (today's behaviour)
-  inheritsFrom: 'insurance_sales',   // an objective-level default, §5.4
-  sourceDescription: 'fresh grads, 22-28, hungry, recruiting consultants',
-  authoredBy: 'ai' | 'admin',
-  components: { … maxPoints per component … },
-  ageCurve:  { '18-24': 1.0, '25-29': 0.9, '30-34': 0.5, … },  // §5.3
-  incomeDirection: 'positive' | 'negative' | 'ignore',
-  events: { … §6 … },
-  version: 3
-}
-```
-
-### 5.2 What the AI is allowed to emit
-
-**A closed vocabulary only** — component names, `maxPoints`, curve points,
-direction flags. It never emits code, never invents a fact key, never writes
-free text into scoring logic. Output is schema-validated against
-`factTaxonomy`; anything unrecognised is rejected and the admin sees a plain
-error, not a silently degraded config.
-
-This is why the fixed taxonomy from PR 0/1 matters here: it bounds what the AI
-can say.
-
-### 5.3 Age as a curve, not a range
-
-An age *range* ("25–65") cannot score — everyone inside scores identically and
-the boundary is a cliff. A *curve* can:
-
-- `insurance_sales`: peaks 35–44, low under 25
-- `recruitment`: peaks 22–28, falls after 35
-
-**Defined over AGE, not birth year**, or the config silently rots one band
-every five years. The taxonomy stores 5-year birth bands; age is derived at
-scoring time.
-
-**Age is the highest-coverage signal available** — 129 of 130 prod consumers
-have a date of birth, versus 1 with income. Today it contributes **zero** to
-the score. Fixing that is worth more than any other single component.
-
-**Prerequisite:** the ledger holds only 1 `birth_year_band` observation because
-the mapper runs at capture and predates the population. A backfill over the 129
-existing DOBs is required or the component scores NULL for everyone.
-
-### 5.4 Inheritance — so 40 campaigns don't mean 40 hand-built models
-
-Each campaign inherits from an **objective-level default** (`insurance_sales`,
-`recruitment`, `audience_build`, `partner_footfall` — the campaign brief's
-objective, §`campaign-brief.md` 4.1, plus recruitment which that plan is
-missing) and overrides only what the admin's description implies.
-
-A new campaign with no description scores exactly like its objective default.
-Twenty recruitment campaigns share one tuned model unless someone deliberately
-diverges.
-
-## 6. Events that move the score
-
-The static score is a prior. Engagement is evidence.
-
-| Event | Source | Direction |
+| Input | Scope | Why |
 |---|---|---|
-| Screening: qualified | `screeningVerdict` | strong + |
-| Screening: agreed to meet | `verdictDetail` | strong + |
-| Screening: positive sentiment | `verdictDetail.sentiment` | + |
-| Screening: neutral | `verdictDetail.sentiment` | 0 |
-| Screening: not qualified / refused | `screeningVerdict` | strong − |
-| WhatsApp read | `wa_message_statuses` = `read` | + |
-| WhatsApp delivered, never read | `wa_message_statuses` | small − after a delay |
-| Email opened | ❌ **needs tracking pixel first** | + |
+| All facts (income, family, language, age…) | **PERSON** | Properties of a human. The spine exists for this. |
+| Marketing consent | **PERSON** | "May we contact them" is about the human. |
+| Has email / phone verified | **PERSON** | Channel existence. |
+| WhatsApp **deliverability** ("a message has ever reached this number") | **PERSON** | Channel health, not interest. |
+| WhatsApp **read of a specific message** | **LEAD** | Interest in *this* pitch. |
+| Screening verdict / sentiment / interest | **LEAD** | Response to *this* pitch. |
+| Signup recency | **LEAD** | This signup's recency, not the person's newest anywhere. |
+| Signup count across campaigns | **PERSON** | Repeat engagement is a real person-level signal. |
 
-**Rules:**
-- Event weights live in the same config, so they are per-campaign too — a read
-  receipt may matter more for a recruitment pitch than a voucher drop.
-- Events **decay**, like life events do today. A read three months ago is not
-  evidence of interest now.
-- Events are **evidence, not overrides.** A screening refusal should sink a
-  score, not zero it — the person may convert on a different campaign, and the
-  facts that made them promising are still true.
-- Every event appears in the breakdown with its timestamp, so an agent can see
-  *"78 → 40 because they refused the screening call on 24 Jul."*
+**Rule:** a **capability** (can we reach them) is person-scoped; a **response**
+(did they engage, did they agree, did they refuse) is lead-scoped.
 
-**Trigger:** these already flow through choke points that bump the enrichment
-input version, and the sweep's hash gate re-scores when inputs change. So
-"score moves on event" is mostly wiring existing events into the hash, plus an
-immediate re-score on the high-value ones (screening verdict) rather than
-waiting for the nightly.
+### 3.3 Consequences for the shipped engine
 
-## 7. Phasing
+`loadTelemetry` must be split. `whatsappReachable` stays person-scoped but is
+redefined as *delivered-ever* (dropping `'read'` from the predicate, since read
+is now a lead-scoped response). Engagement's recency input changes from the
+consumer's `lastSeenAt` to **this prospect's** `createdAt`.
 
-**Revised after Shawn's isolation decision (§8.1).** The original plan put
-"events move the score" first, against today's per-PERSON score. That is
-impossible: with one score per person, a screening refusal moves the number
-every campaign sees — precisely the cross-campaign bleed the isolation rule
-forbids. **Event scoring and the move to per-lead are one piece of work.**
+This is a behaviour change to code shipped today, and it changes existing
+scores. It must land as a config/algorithm version bump so every stored score
+is recomputed and the change is visible in `scoringAlgorithmVersion`.
 
-1. **PR A — the lead score, with events** (§10). `prospects.score` +
-   breakdown, scored from person facts + that lead's OWN events, under the
-   campaign's config (falling back to today's global one). Isolation holds by
-   construction: a lead can only see its own campaign's evidence.
-2. **PR B — age curve + DOB backfill** (§5.3). The biggest single accuracy win
-   available, and fully independent of A.
-3. **PR C — per-campaign configs + objective inheritance** (§5.4).
-4. **PR D — AI authoring** (§5.2). Admin writes a description, AI proposes a
-   config, admin reviews it in plain language before it goes live.
-5. **PR E — email opens.** Tracking pixel first, then wire in as an event.
+### 3.4 The test contract (v1's was inadequate)
 
-A and B are independent of each other and of C–E.
+v1 proposed one test: a screening refusal on A leaves B unchanged. That would
+have passed while four other inputs bled. Required instead — **for each row of
+§3.2's table**, a test asserting the scope actually holds. Specifically, with
+one person holding two live leads on different campaigns:
 
-## 8. Questions
+- WhatsApp **read** on A's message → B byte-identical.
+- Screening refusal on A → B byte-identical.
+- A's signup being newer → does not change B's recency term.
+- WhatsApp **delivered** on A → B's contactability *does* rise (asserting the
+  person-scoped half deliberately, so a future "fix" to over-scope is caught).
+- Marketing consent granted via A → B's contactability rises.
 
-1. **RESOLVED (Shawn, 2026-07-26): NO cross-campaign event bleed.** A
-   screening refusal on a recruitment campaign must not drag the person's
-   insurance score down — the refusal is evidence about *that pitch*, not
-   about the human's propensity to buy. Consequence: §7 re-phased, since this
-   is unachievable while one score serves every campaign.
-2. **Should the admin see the AI's config as rules or as prose?** Prose is
-   readable; rules are precise. Probably prose with the numbers shown.
-3. **Person-level score: keep as summary or retire?** (§4)
-4. **Recruitment as a campaign objective** — `campaign-brief.md` §4.1 is missing
-   it and needs updating regardless of this plan.
+## 4. ONE AUTHORITY (rewritten — Codex M4)
 
-## 10. PR A in detail — the lead score with events
+v1 kept `consumer_profiles.meetScore`/`buyScore` as "a summary" while the
+existing writer kept overwriting them from the global model
+(`consumerScoringService.js:199-228`) — two authorities guaranteed to disagree.
 
-### 10.1 The shape
+**Decision: the LEAD score is the sole computed authority.**
 
-```
-leadScore = clamp(0, 100,  base + Σ eventAdjustments)
+- `scoreOneConsumer()` stops writing `meetScore`/`buyScore`/`consumerScore`.
+  Its fact-resolution and profile-row duties remain.
+- The person-grain numbers become a **projection, defined exactly**:
+  `meetScore` / `buyScore` = the values from the person's **highest-scoring
+  non-erased lead**, ties broken by most recent `prospects.createdAt` then
+  `prospects.id`. Recomputed whenever any of that person's leads is rescored.
+  Null when the person has no scoreable lead.
+- Because it is a projection, it can never disagree — it is a copy with a rule.
 
-base   = person facts scored under the campaign's config  (today's engine, unchanged)
-events = this lead's OWN evidence, decayed, bounded to ±EVENT_BAND
-```
+**v1's claim "PR 3's UI already renders both grains" was false** and is
+withdrawn. Verified: People renders person-grain columns only
+(`AdminV2People.jsx:171-186`); the profile card reads `journey.enrichment` from
+`ConsumerProfile` only (`leadProfileService.js:511`); the Prospects queue has
+no score column at all (`AdminV2Prospects.jsx:352`). So PR A must also ship:
+a score column on the Prospects queue, and an events section in the breakdown
+card. That work was invisible in v1's estimate.
 
-`base` reuses `consumerScoring.js` untouched — facts in, component points out.
-Only the wrapper is new.
+## 5. MESSAGE OWNERSHIP AT SEND TIME (new — Codex B2)
 
-### 10.2 Storage
+v1 claimed `deliveryReceipts()` already joins wamid → entitlement → activation
+→ campaign. **False.** It joins `redemption_events → wa_message_statuses` on
+wamid and filters by entitlement ids drawn from the person's whole journey
+(`leadProfileService.js:105-119`); it never touches activations or campaigns.
 
-| Column | Note |
-|---|---|
-| `prospects.score` | INTEGER 0–100, **already exists, dead since inception** — reuse |
-| `prospects.scoreBreakdown` | NEW JSONB — components + event entries, same shape PR 3's panel already renders |
-| `prospects.scoredConfigVersion` / `scoringAlgorithmVersion` / `scoreInputHash` / `scoreComputedAt` | NEW — same stamping contract as `consumer_profiles`, so unscoreable leads exit the re-score loop |
+Reconstructing ownership afterwards is also unsafe: receipts carry no immutable
+campaign snapshot (`redeemOps/entitlementService.js:211`), activations can be
+relinked (`redeemOps/activationService.js:117,153`), so a historical send can
+be attributed to the wrong campaign. And screening-callback WhatsApps write no
+receipt at all — their wamid lives only in `prospects.screeningMetadata.waCallback`
+(`retellScreeningService.js:516`).
 
-`consumer_profiles.meetScore`/`buyScore` stay as the person-grain summary
-(§4 option a). PR 3's People columns keep working unchanged.
-
-### 10.3 Event sourcing — and how isolation is enforced
-
-**The isolation rule is enforced by the QUERY, not by a filter applied
-afterwards.** Each event is fetched already scoped to the lead:
-
-| Event | Source | Scoping |
-|---|---|---|
-| Screening qualified / not_qualified | `prospects.screeningVerdict` | **Same row as the lead.** Inherently isolated |
-| Agreed to meet, sentiment | `prospects.screeningMetadata.verdictDetail` | Same row |
-| WhatsApp read | `wa_message_statuses.status='read'` | Joined via `redemption_events.metadata.messageId = wamid` → entitlement → activation → **campaignId**, matched to the lead's campaign |
-
-That WhatsApp join already exists — `leadProfileService.deliveryReceipts()`
-uses exactly this path today. Nothing new to invent.
-
-**A read receipt on the person's phone from a different campaign is invisible
-to this lead.** Not scored down, not scored up — never fetched.
-
-### 10.4 Event weights (config, per campaign later)
+**New table `wa_message_sends`** — ownership stamped at send, never derived:
 
 ```
-events: {
-  band: 25,                    // total events may move the score at most ±25
-  halfLifeDays: 45,
-  weights: {
-    screening_qualified:    +12,
-    screening_agreed_meet:  +10,
-    screening_positive:      +5,
-    screening_neutral:        0,
-    screening_not_qualified: -12,
-    whatsapp_read:           +4,
-    whatsapp_unread_7d:      -2,   // delivered, never opened, a week gone
-  }
-}
+wamid        VARCHAR(128) PRIMARY KEY
+prospectId   UUID NOT NULL        -- immutable: the lead this was sent for
+campaignId   UUID NOT NULL        -- snapshot, NOT a live FK lookup
+consumerId   UUID                 -- for erasure
+kind         VARCHAR(24)          -- 'reward' | 'screening_callback' | 'pass' | …
+sentAt       TIMESTAMPTZ NOT NULL
 ```
 
-**Bounded on purpose.** An unbounded event layer makes the facts decorative —
-one read receipt should not outrank knowing someone's income and family.
-Evidence adjusts a prior; it does not replace it.
+Written by every WhatsApp send path, including screening callbacks. The webhook
+keeps writing `wa_message_statuses` keyed by wamid, untouched
+(`redeemOps/waWebhookService.js:73,154`). Read scoping becomes a join on wamid
+— exact, immutable, and covering every send path.
 
-**Decay** for the same reason life events decay: a read three months ago is
-not evidence of interest today.
+Backfill: none possible for historical sends (ownership was never recorded).
+Pre-existing reads simply do not score. Stated, not hidden.
 
-### 10.5 Recompute triggers
+## 6. DECAY WITHOUT DAILY REWRITES (rewritten — Codex M6)
 
-- **Immediate** on screening verdict write — the highest-value event, and an
-  agent watching a lead should see it move within seconds, not overnight.
-- **On WhatsApp status webhook** — cheap; the hash gate makes a no-op free.
-- **Nightly sweep** — catch-all for decay (an event's contribution shrinks with
-  time even when nothing happens) and for anything the live paths missed.
+v1 proposed a decay epoch in the hash. Codex is right that this forces a
+full-population rewrite every day under budget, and staggered decay above it.
+Also correct: "the hash gate makes a no-op free" is false — telemetry,
+observations, resolution, hashing and the whole score all run before the
+comparison (`consumerScoringService.js:169-176`); the gate saves only the write.
 
-Decay means a lead's score changes with no input event, so the hash must
-include a **decay epoch** (e.g. the SGT date) or the gate will suppress the
-recompute. Cheap, and easy to get wrong.
+**Correction: never store a time-dependent number as if it were stable.**
 
-### 10.6 Surfacing
+- **Stored:** `baseScore` (facts + person telemetry — time-independent) and the
+  **event list with timestamps and undecayed weights**. Changes only when a real
+  input changes, so the hash gate works exactly as designed, unchanged.
+- **Displayed:** decay applied at READ time. Always fresh, never stale, no write.
+- **Sorted:** a materialized `score` column, refreshed by the nightly sweep,
+  used only for ORDER BY. Being up to 24h stale for *ordering* is acceptable;
+  showing a stale *number* is not.
 
-The breakdown gains an events section, rendered by the same PR 3 panel:
+**And the daily refresh set is small by construction:** only leads with at
+least one decaying event need re-materializing. A lead with no events has a
+static score forever. Today that would be a handful of rows, not 130.
 
-```
-BASE (facts)                     46
-EVENTS                          +14
-  screening: agreed to meet     +10   24 Jul
-  screening: positive            +5   24 Jul
-  WhatsApp read                  +4   25 Jul
-  decay                          −5
-                                 ──
-                                 60
-```
+## 7. OBJECTIVE VS PRODUCT — the vocabularies were confused (Codex M9)
 
-The point is an agent reading *"78 → 40 because they refused the screening
-call on 24 Jul"* — the number moving is only useful if the reason moves with it.
+Codex found the plans disagreeing: `insurance_sales`/`recruitment` here vs
+`agent_leads`/`screened_leads` in `campaign-brief.md:69`. The real problem is
+that these are **two orthogonal axes**, and v1 conflated them.
 
-### 10.7 Tests that must exist
+- **Objective** = what you want *out of* the campaign (leads, screened leads,
+  audience, partner footfall). Already in the brief.
+- **Product** = what you are *selling* (insurance, recruitment, a partner
+  offer). **Missing entirely**, and it is what determines who counts as good.
 
-- A screening refusal on campaign A leaves the same person's campaign-B lead
-  **byte-identical** (§8.1 — the isolation rule, as an executable assertion).
-- Events cannot push a score outside 0–100, nor beyond ±band.
-- A qualified screening raises the score; a refusal lowers it; neutral moves
-  nothing.
-- Decay: the same event scores lower a month later, with no other change.
-- The hash gate re-scores across a decay-epoch boundary and no-ops within one.
-- A lead with no events scores exactly its base — the event layer is inert
-  until there is evidence.
-- Erased consumers: no lead score, no breakdown, consistent with §9 erasure.
+You can run `agent_leads` for insurance *or* for recruitment, and they want
+opposite people. So:
 
-## 11. Codex adversarial review round 1 — REWORK (3 BLOCKER, 7 MAJOR)
+**`campaign-brief.md` gains a required `product` field**
+(`insurance` | `recruitment` | `partner_offer`), and **scoring profiles key off
+`product`, not `objective`.** This also resolves v1's separate observation that
+the brief was missing recruitment.
 
-gpt-5.6-sol xhigh, 2026-07-26. Every finding below was independently verified
-against the code before being accepted. **All accepted; none disputed.**
+## 8. AI CONFIG SAFETY (rewritten — Codex M8)
 
-### The three blockers
+v1 claimed a closed vocabulary made AI output safe. Codex is right that it does
+not: `factTaxonomy` validates *facts*, not scoring configs
+(`factTaxonomy.js:108`); `normalizeConfig` permissively merges unknown
+components and retains them as zero-point entries rather than rejecting
+(`consumerScoring.js:388,419`); a non-positive half-life silently disables decay
+(`consumerScoring.js:105`). A schema-valid config can still be absurd.
 
-**B1 — Campaign isolation is already broken in the BASE layer, before events.**
-§10.3 claimed isolation is enforced by the event query. False. The base score
-consumes person-wide telemetry: `loadTelemetry()` computes `whatsappReachable`
-as `EXISTS(… WHERE w."recipientHash" = c."phoneHash" AND w.status IN
-('delivered','read'))` — **no campaign predicate at all**
-(`consumerScoringService.js:118-122`), and engagement uses consumer-level
-`signupCount`/`verifiedSignupCount`. A WhatsApp read sent for campaign A
-therefore raises campaign B's score today. The proposed isolation test
-(screening refusal only) would have PASSED while consent, delivery, read and
-signup activity all bled across campaigns.
-→ Isolation must be specified over **every telemetry input**, not just events.
+Four controls, none of which existed in v1:
 
-**B2 — The "already exists" WhatsApp→campaign join does not exist.**
-`deliveryReceipts()` joins `redemption_events → wa_message_statuses` on wamid
-and filters by a set of entitlement ids drawn from the whole person journey
-(`leadProfileService.js:105-119`). It never touches activations or campaigns.
-Worse: receipts store no immutable `campaignId`/`prospectId` snapshot, and
-activations can be relinked, so reconstructing ownership from the *current*
-activation can attribute a historical send to the wrong campaign. And
-screening-callback WhatsApps write no receipt at all — their wamid lives only
-in `prospects.screeningMetadata.waCallback`, invisible to the proposed join.
-→ Needs **immutable send-time ownership** (`prospectId`, `campaignId`, kind,
-`wamid`) recorded at send, not reconstructed later.
+1. **Semantic invariants**, rejected at save: every weight within declared
+   bounds; no single component above 40% of the positive total; half-life
+   strictly positive; unknown component names **rejected, not zeroed** (a fix to
+   `normalizeConfig`); age curve values in [0,1] and bounded in slope.
+2. **Simulation before activation.** Run the proposed config over the existing
+   scored population and show the distribution diff — mean, spread, and the
+   count whose score moves more than 20 points. A config that scores everyone
+   90+ is obvious here and invisible to schema validation.
+3. **A real draft/approved state.** Today `EnrichmentScoringConfig` has no
+   status and the reader takes the highest version immediately
+   (`EnrichmentScoringConfig.js:18`, `consumerScoringService.js:60,65`) — so an
+   AI proposal inserted into that table would be **live before anyone read it**.
+   Add `status ∈ draft|approved|superseded`; the reader takes the highest
+   *approved* version only.
+4. **Untrusted-input handling for `sourceDescription`.** It is admin free text
+   reaching a prompt. Studio AI already treats campaign text as untrusted and
+   sanitizes server-side (`campaignCopyAiService.js:684,1077`); this reuses that
+   posture. The free text drives *only* the AI proposal and is never itself a
+   scoring input — which keeps `campaign-brief.md` §3.1's no-free-text rule
+   intact.
 
-**B3 — Erasure deliberately PRESERVES `prospects.score`.**
-The shipped contract states the skeleton keeps "ids, campaign,
-status/priority/**score**" (`erasureService.js:21-22`), and the allowlist
-rebuild never nulls it. A `scoreBreakdown` added beside it would survive
-erasure too — carrying event timestamps, inferred sentiment and observation
-ids. That is materially worse than preserving a bare integer, and deleting
-`consumer_profiles` does not help because the new data lives on `prospects`.
-→ §10.7's erasure test would have failed on day one.
+## 9. SCHEMA THE CONFIG STORE NEEDS (Codex M9)
 
-### The seven majors (all accepted)
+`enrichment_scoring_configs` today: integer PK, no campaign, objective, status,
+or parent column (`091-consumer-enrichment.js:212`), read through one
+process-wide cache selecting the global maximum
+(`consumerScoringService.js:47,65`). Putting `campaignId` inside `configJson`
+supplies none of what is needed. Required:
 
-| # | Finding |
-|---|---|
-| M4 | Two drifting authorities. The existing scorer keeps overwriting `meetScore`/`buyScore` from the global model; calling them "a summary of lead scores" without retiring that writer or defining a real projection guarantees disagreement. **And "PR 3's UI already renders both grains" is false** — it renders person grain only, on the profile view; the Prospects queue has no score column at all. |
-| M5 | Spine relink invalidates `consumer_profiles.inputVersion` only. Prospect-grain scores need their own dirty marker, relink invalidation, owner-movement fence, and a prospect cursor in the sweep. |
-| M6 | A date-based decay epoch mechanically fixes the gate but forces a **full-population rewrite daily** under budget, and staggered decay above it. Also: "the hash gate makes a no-op free" is false — telemetry, observations, resolution, hashing and the full score all run *before* the comparison; the gate saves only the write. |
-| M7 | "Existing choke points already bump the input version" is false — neither the WA webhook nor the screening-verdict writers bump or re-score. This is new transactional wiring. **And there is no normalized `agreedToMeet` field**: verdictDetail is `reason`/`interestLevel`/`summary`/`sentiment`/recording (`retellScreeningService.js:666`). §6 specced an event on a field that does not exist. |
-| M8 | A closed *fact* vocabulary does not validate a *scoring config*. `normalizeConfig` permissively merges unknown components, and a non-positive half-life silently disables decay. A schema-valid AI config can still be absurd. Needs semantic invariants, bounded deltas, population simulation, distribution diffs, rollback. Also: `sourceDescription` free text contradicts `campaign-brief.md` §3.1, and Studio AI already treats campaign text as untrusted — this plan specified no equivalent isolation. **And "admin reviews it" is not a control**: the config table has no draft/approved state and the reader activates the highest version immediately. |
-| M9 | `enrichment_scoring_configs` has an integer PK and no campaign/objective/status/parent column; the reader caches one global config. Per-campaign inheritance needs real schema. **The two plans also disagree on objective names** — `insurance_sales`/`recruitment` here vs `agent_leads`/`screened_leads` in the brief. |
-| M10 | `campaign-brief.md`'s claim that every audience axis maps to the taxonomy is false — there is no `lifeStage` key, and the ledger stores 5-year **birth-year** bands, so an age curve needs a date-sensitive overlap rule and cannot use exact age. |
+`campaignId` (nullable, FK) · `productKey` (nullable) · `status` · unique on
+(campaignId, version) · resolution order **campaign → product → global**, each
+step indexed · per-key caching instead of one global slot.
 
-### Disposition
+## 10. LEAD-GRAIN INVALIDATION (Codex M5)
 
-**REWORK accepted.** The plan asserted five things about existing code that are
-untrue (B2, M4's UI claim, M7's choke points, M7's `agreedToMeet`, M10's
-taxonomy mapping) — each written from reading rather than verification. The
-lesson for v2: **claims about existing behaviour get a file:line citation or
-they do not go in the plan.**
+Prospect-grain scores need their own invalidation; nothing existing covers them.
+The spine relinker bumps only `consumer_profiles.inputVersion`
+(`consumerService.js:317,336`), `bumpEnrichmentInputTx` upserts only
+`consumer_profiles` (`enrichmentFence.js:38-52`), and the sweep enumerates
+consumers calling `scoreOneConsumer` (`enrichmentSweepService.js:204,221`).
 
-The architecture (per-lead score, AI authors / code applies, bounded decaying
-events) was not challenged. What failed is the assumption that the substrate
-already supports it.
+PR A must add: a lead-grain dirty marker, relink invalidation for every affected
+prospect, owner-movement fencing (reuse `withConsumerFence`), and a **prospect
+cursor** in the sweep beside the consumer one.
 
-v2 must, before any build:
-1. Define isolation over **every** input, and add send-time message ownership.
-2. Resolve the two-authority problem explicitly — one writer, one projection.
-3. Fix erasure for prospect-grain score + breakdown.
-4. Replace the decay-epoch hack with something that doesn't rewrite daily.
-5. Reconcile the objective vocabularies between the two plans.
-6. Specify semantic (not just structural) validation for AI configs, plus a
-   draft/approved state the reader honours.
+## 11. Erasure (Codex B3)
 
-## 9. Out of scope
+Erasure today **deliberately preserves** the prospect skeleton including `score`
+(`erasureService.js:21-22`), and the allowlist rebuild never nulls it
+(`erasureService.js:306-310`). A `scoreBreakdown` beside it would survive too,
+carrying event timestamps, inferred sentiment and observation ids — materially
+worse than a bare integer.
 
-- LLM scoring individual leads (§2).
-- Cross-campaign event bleed (§8.1) in v1.
-- Auto-applying an AI config without admin review.
-- Retraining/fitting weights from outcomes — a later concern, and one that
-  needs closed deals to fit against.
+PR A must therefore: null `score`, `scoreBreakdown` and the stamps in the
+allowlist rebuild; delete the erased consumer's `wa_message_sends` rows; and
+test all of it. This is an amendment to a shipped, deliberate contract — it
+needs to be called out in review, not slipped in.
+
+## 12. Codex round 1 — REWORK (3 BLOCKER, 7 MAJOR), all accepted
+
+gpt-5.6-sol xhigh. Every finding verified against code before acceptance; none
+disputed. Blockers B1/B2/B3 → §3/§5/§11. Majors M4→§4, M5→§10, M6→§6, M7→§13.1,
+M8→§8, M9→§7+§9, M10→§13.2.
+
+**Five v1 claims about existing code were false** — the WhatsApp→campaign join,
+"PR 3 renders both grains", "choke points already bump", a normalized
+`agreedToMeet` field, and the brief's taxonomy mapping. Each was written from
+reading rather than verification. Hence this version's citation rule.
+
+The architecture (per-lead score, AI-authors/code-applies, bounded decaying
+events) was not challenged. The assumption that the substrate supported it was,
+and it lost — PR A is roughly double v1's implied size.
+
+## 13. Remaining corrections
+
+### 13.1 Screening events need a real contract (Codex M7)
+
+There is **no normalized `agreedToMeet`**. The verdict detail is `reason`,
+`interestLevel`, `summary`, `sentiment`, recording/transcript, plus an arbitrary
+provider `checks` object (`retellScreeningService.js:664-672`). v1 specced an
+event on a field that does not exist.
+
+PR A must define an explicit Retell analysis schema with a versioned, normalized
+boolean, and score only normalized fields — never raw `checks` keys. Until that
+exists, the scoreable screening events are `screeningVerdict` (which is a real
+column) and `sentiment`/`interestLevel` (present but provider-shaped).
+
+Also confirmed: neither the WA webhook (`waWebhookService.js:73,154`) nor the
+screening verdict writers (`screeningGate.js:336,361`) bump or re-score today.
+v1's "mostly wiring existing events" was wrong — this is new transactional
+wiring at both choke points.
+
+### 13.2 Age and life stage (Codex M10)
+
+`campaign-brief.md`'s claim that every audience axis maps to the taxonomy is
+false: there is **no `lifeStage` key** (`factTaxonomy.js:108-183`), and the
+ledger stores 5-year **birth-year** bands, the mapper having discarded exact DOB
+(`factMapperService.js:115`).
+
+Therefore: drop `lifeStage` from the brief (it is derivable from
+children + marital + age, and inventing a fact key for it is worse), and specify
+the age curve as **a function over birth-year bands evaluated against the
+current SGT year**, with an explicit overlap rule for a band straddling a curve
+boundary (weight by the fraction of the band in each segment). Exact-age
+scoring is not available and should not be promised.
+
+## 14. Build order (revised)
+
+1. **PR A₀ — isolation correction** (§3.3). Split telemetry, fix
+   `whatsappReachable`, switch recency to the lead. Small, ships against
+   today's person score, and stops a live cross-campaign bleed. **Do this first
+   regardless of everything else.**
+2. **PR A₁ — send-time ownership** (§5). `wa_message_sends` + every send path.
+   Independent, additive, no scoring changes.
+3. **PR A₂ — the lead score** (§4, §6, §10, §11). The structural one: authority,
+   projection, decay-at-read, invalidation, erasure, Prospects column, events UI.
+4. **PR B — age curve + DOB backfill** (§13.2). Independent of all the above and
+   still the largest accuracy gain available (129/130 have a DOB; it scores 0).
+5. **PR C — per-campaign configs** (§7, §9).
+6. **PR D — AI authoring** (§2, §8).
+7. **PR E — email opens.** Tracking pixel first; not captured today
+   (`EmailBroadcastRecipient` carries delivery only).
+
+## 15. Out of scope
+
+LLM scoring individual leads · cross-campaign response bleed · auto-activating
+an AI config without approval · fitting weights from outcomes (needs closed
+deals; prod has zero).


### PR DESCRIPTION
The Phase 2/3/4 build prompts tell agents to work from a fresh worktree off origin/main and read these two plan docs — which lived only on this branch, so a literal agent would find nothing. This merges them, plus a new §16 in the lead-scoring plan recording the Codex round-2 REWORK (4 of 10 findings re-opened: B1/M6/M9/M10, each re-verified against code at a7ac0a9) that was previously unrecorded anywhere — the committed doc still said 'Ready for round 2', making the Phase-3 gate unenforceable.

Docs-only: +604/−2 across two files in docs/plans/. No runtime code touched.

Known-flake note: Backend Tests will predictably fail on this PR if CI runs now — test/unit/retellScreening.test.js does not pin the clock and it is currently outside the SGT screening call window (same 5 outside_window/deferred failures that broke main's run on 26 Jul 23:59 SGT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127w4fTdWuoNTSZbBexNN8Z