### PR TITLE
fix(scoring): responses stop crossing campaigns — recency anchors to the newest signup (score/v2)

### DIFF
--- a/backend/src/database/migrations/094-scoring-recency-anchor.js
+++ b/backend/src/database/migrations/094-scoring-recency-anchor.js
@@ -1,0 +1,68 @@
+/**
+ * 094 — score/v2: engagement recency anchors to the newest signup
+ * (per-campaign-lead-scoring.md §16 B1 / §3.3-as-corrected).
+ *
+ * The algorithm change lives in code (consumerScoring.js v2: recency reads
+ * the newest prospect's createdAt, never consumers.lastSeenAt — lastSeenAt
+ * refreshes on per-campaign RESPONSE touches, which must not move the
+ * person-grain score). This migration exists because the EFFECTIVE algorithm
+ * version is `config.algorithmVersion || SCORING_ALGORITHM_VERSION`
+ * (consumerScoringService.js), and the live config row pins 'score/v1':
+ * bumping the code constant alone would recompute nothing. A new append-only
+ * config row carrying 'score/v2' makes findStaleConsumerIds see every stored
+ * score as config-stale, so the whole population recomputes on the next
+ * sweep and the change is visible in both stamps.
+ *
+ * The row COPIES the current highest configJson (weights untouched — this is
+ * an algorithm re-version, not a recalibration) and takes MAX(version)+1,
+ * per §7.2's append-only contract. Empty table (fresh DB pre-093, or a test
+ * schema before seeding) → inserts nothing; code defaults already carry v2.
+ * Idempotent: re-running after the highest row is already 'score/v2' is a
+ * no-op.
+ *
+ * "createdAt"/"updatedAt" are supplied EXPLICITLY — test schemas are built
+ * by sync({force:true}) from the models, where Sequelize emits them NOT NULL
+ * with NO database default, so a raw INSERT that omits them dies.
+ */
+
+export async function up(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.transaction(async (t) => {
+    await sequelize.query(
+      `INSERT INTO enrichment_scoring_configs
+         (version, "configJson", "activatedAt", "actorUserId", "createdAt", "updatedAt")
+       SELECT c.version + 1,
+              jsonb_set(c."configJson", '{algorithmVersion}', '"score/v2"'),
+              now(), NULL, now(), now()
+         FROM enrichment_scoring_configs c
+        WHERE c.version = (SELECT MAX(version) FROM enrichment_scoring_configs)
+          AND c."configJson"->>'algorithmVersion' IS DISTINCT FROM 'score/v2'
+       ON CONFLICT (version) DO NOTHING`,
+      { transaction: t }
+    );
+  });
+}
+
+export async function down(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.transaction(async (t) => {
+    // Remove only the row this migration appended: the highest version, and
+    // only if it is the v2 stamp row. A later human recalibration (also
+    // possibly stamped v2) is deliberately NOT matched by version arithmetic
+    // against the v1 seed — restrict to the immediate successor shape:
+    // highest row, algorithmVersion v2, weights identical to its predecessor.
+    await sequelize.query(
+      `DELETE FROM enrichment_scoring_configs c
+        WHERE c.version = (SELECT MAX(version) FROM enrichment_scoring_configs)
+          AND c."configJson"->>'algorithmVersion' = 'score/v2'
+          AND (c."configJson" - 'algorithmVersion') = (
+            SELECT p."configJson" - 'algorithmVersion'
+              FROM enrichment_scoring_configs p
+             WHERE p.version = c.version - 1
+          )`,
+      { transaction: t }
+    );
+  });
+}

--- a/backend/src/services/consumerScoringService.js
+++ b/backend/src/services/consumerScoringService.js
@@ -115,7 +115,19 @@ export async function loadObservations(consumerId) {
  */
 export async function loadTelemetry(consumerId) {
   const [[row]] = await sequelize.query(
-    `SELECT c."signupCount", c."verifiedSignupCount", c."lastSeenAt",
+    `SELECT c."signupCount", c."verifiedSignupCount",
+            -- Engagement recency anchors to the NEWEST signup, not lastSeenAt.
+            -- lastSeenAt refreshes on spine touches that are per-campaign
+            -- RESPONSES, and the capability-vs-response contract (§16 B1 of
+            -- per-campaign-lead-scoring.md) forbids a response on one campaign
+            -- from moving the person's standing everywhere. "Newest" is
+            -- (createdAt DESC, id DESC) — the house tiebreak (factResolver.js,
+            -- cohortService.js) — over ALL the person's prospects; erased
+            -- people never reach this query (the fence skips them).
+            (SELECT p."createdAt" FROM prospects p
+              WHERE p."consumerId" = c.id
+              ORDER BY p."createdAt" DESC, p.id DESC
+              LIMIT 1) AS "newestSignupAt",
             (c.email IS NOT NULL AND c.email <> '') AS "hasEmail",
             -- 'contact' IS the marketing-consent kind. The ledger's enum is
             -- contact | campaign_terms | third_party | dnc_override |
@@ -135,6 +147,15 @@ export async function loadTelemetry(consumerId) {
                     WHERE ce2."consumerId" = c.id AND ce2.kind = :consentKind
                  )
             ) AS "marketingConsent",
+            -- DELIBERATELY IN ('delivered','read') — do not "fix" to
+            -- delivered-only: wa_message_statuses keeps one row per wamid
+            -- holding the FURTHEST status (STATUS_RANK upsert,
+            -- redeemOps/waWebhookService.js), so a READ message no longer
+            -- reads as 'delivered' and dropping 'read' would un-reach exactly
+            -- the people with the strongest deliverability proof. A read
+            -- counts here ONLY as deliverability (a person-scoped CAPABILITY);
+            -- read-as-RESPONSE is lead-scoped and belongs to Phase 3
+            -- (per-campaign-lead-scoring.md §16 B1).
             EXISTS (
               SELECT 1 FROM wa_message_statuses w
                WHERE w."recipientHash" = c."phoneHash"
@@ -148,7 +169,7 @@ export async function loadTelemetry(consumerId) {
   return {
     signupCount: Number(row.signupCount) || 0,
     verifiedSignupCount: Number(row.verifiedSignupCount) || 0,
-    lastSeenAt: row.lastSeenAt,
+    newestSignupAt: row.newestSignupAt,
     hasEmail: Boolean(row.hasEmail),
     marketingConsent: Boolean(row.marketingConsent),
     whatsappReachable: Boolean(row.whatsappReachable),

--- a/backend/src/services/consumerScoringService.js
+++ b/backend/src/services/consumerScoringService.js
@@ -41,6 +41,17 @@ export function scoringEnabled() {
   return process.env.ENRICHMENT_SCORING_ENABLED === 'true';
 }
 
+/**
+ * The consent kind that means "may we market to them".
+ *
+ * EXPORTED so a test can assert it against ConsentEvent's own enum. It shipped
+ * as `'marketing'` — a kind that has never existed — which silently made
+ * marketingConsent false for every person in production. A bare literal inside
+ * a SQL string is unverifiable by any test that doesn't hit the database with
+ * the right fixture; a named export is checkable for free.
+ */
+export const MARKETING_CONSENT_KIND = 'contact';
+
 // Config is append-only and changes at most a few times a year; a short TTL
 // keeps a sweep of thousands of consumers from re-reading it per row while
 // still picking up a new calibration within the same night.
@@ -106,13 +117,22 @@ export async function loadTelemetry(consumerId) {
   const [[row]] = await sequelize.query(
     `SELECT c."signupCount", c."verifiedSignupCount", c."lastSeenAt",
             (c.email IS NOT NULL AND c.email <> '') AS "hasEmail",
+            -- 'contact' IS the marketing-consent kind. The ledger's enum is
+            -- contact | campaign_terms | third_party | dnc_override |
+            -- draw_terms (ConsentEvent.js:29); there is no 'marketing' row and
+            -- never has been. This filtered on a value that cannot exist, so
+            -- marketingConsent was FALSE for every person in production —
+            -- silently docking 0.45 of contactability from the 128 of 130
+            -- consumers who HAVE granted contact consent. The UI has always
+            -- labelled this kind "marketing" (AdminV2LeadProfile.jsx:1042),
+            -- which is exactly how the wrong literal got written.
             EXISTS (
               SELECT 1 FROM consent_events ce
-               WHERE ce."consumerId" = c.id AND ce.kind = 'marketing'
+               WHERE ce."consumerId" = c.id AND ce.kind = :consentKind
                  AND ce.granted = true
                  AND ce."occurredAt" = (
                    SELECT MAX(ce2."occurredAt") FROM consent_events ce2
-                    WHERE ce2."consumerId" = c.id AND ce2.kind = 'marketing'
+                    WHERE ce2."consumerId" = c.id AND ce2.kind = :consentKind
                  )
             ) AS "marketingConsent",
             EXISTS (
@@ -122,7 +142,7 @@ export async function loadTelemetry(consumerId) {
             ) AS "whatsappReachable"
        FROM consumers c
       WHERE c.id = :cid`,
-    { replacements: { cid: consumerId } }
+    { replacements: { cid: consumerId, consentKind: MARKETING_CONSENT_KIND } }
   );
   if (!row) return null;
   return {

--- a/backend/src/services/retellScreeningService.js
+++ b/backend/src/services/retellScreeningService.js
@@ -203,7 +203,13 @@ export function makeRetellScreeningService(overrides = {}) {
    * failure path leaves a consistent row for the sweep. Returns a status
    * object for logs/tests; never throws.
    */
-  async function startScreeningAttempt(prospect, { campaign = null, cfg = screeningConfig() } = {}) {
+  // `now` is injectable for the same reason inCallWindow/nextRetryAt take it:
+  // the window gate is time-of-day dependent (SGT), and a clock the tests
+  // cannot pin turns every dial-path test into a 23:59-SGT flake — the
+  // "always-open" '00:00-23:59' test window has an inexpressible final
+  // minute (parseWindow clamps at 23:59, inCallWindow is end-exclusive),
+  // which is exactly when the 26 Jul CI run started. Prod callers omit it.
+  async function startScreeningAttempt(prospect, { campaign = null, cfg = screeningConfig(), now = new Date() } = {}) {
     try {
       if (!cfg.configured) return { status: 'skipped', reason: 'not_configured' };
 
@@ -250,7 +256,6 @@ export function makeRetellScreeningService(overrides = {}) {
         return { status: 'deferred', reason: 'consent_lookup_failed' };
       }
 
-      const now = new Date();
       if (!inCallWindow(cfg, now)) {
         await deferAttempt(prospect, nextWindowOpen(cfg, now));
         return { status: 'deferred', reason: 'outside_window' };

--- a/backend/src/utils/consumerScoring.js
+++ b/backend/src/utils/consumerScoring.js
@@ -49,7 +49,15 @@
 
 import { MIN_LLM_CONFIDENCE } from './factTaxonomy.js';
 
-export const SCORING_ALGORITHM_VERSION = 'score/v1';
+/**
+ * v2: engagement recency anchors to the person's NEWEST signup
+ * (prospects.createdAt) instead of consumers.lastSeenAt. lastSeenAt refreshes
+ * on spine touches that are RESPONSES (per-campaign engagement), and the
+ * capability-vs-response contract (per-campaign-lead-scoring.md §3.2/§16 B1)
+ * says responses must not move the person-grain score. Migration 094 appends
+ * the config row that makes every stored score recompute under this version.
+ */
+export const SCORING_ALGORITHM_VERSION = 'score/v2';
 
 /** SGT is UTC+8 year-round (no DST) — the one offset this file needs. */
 const SGT_OFFSET_MS = 8 * 60 * 60 * 1000;
@@ -183,8 +191,11 @@ function scoreEngagement(telemetry, cfg, now) {
   }
   const depth = signups >= 4 ? 1.0 : { 1: 0.35, 2: 0.65, 3: 0.85 }[signups] ?? 1.0;
 
-  const lastSeen = telemetry?.lastSeenAt ? new Date(telemetry.lastSeenAt).getTime() : null;
-  const recency = lastSeen ? decayFactor(now - lastSeen, cfg.decay?.engagementHalfLifeDays) : 1;
+  // Recency anchors to the newest SIGNUP (capability-era anchor), never to
+  // lastSeenAt: lastSeenAt refreshes on response touches, and a response on
+  // one campaign must not refresh the person's standing everywhere (§16 B1).
+  const newestSignup = telemetry?.newestSignupAt ? new Date(telemetry.newestSignupAt).getTime() : null;
+  const recency = newestSignup ? decayFactor(now - newestSignup, cfg.decay?.engagementHalfLifeDays) : 1;
 
   // Verified signups are the ones that proved a live phone — they say more
   // about willingness to engage than a raw form submit does.
@@ -406,7 +417,7 @@ export function normalizeConfig(configJson) {
  *
  * @param {Object} input
  * @param {Object} input.facts      resolveCurrentFacts() output (key → {value, confidence, observationId, basis, …})
- * @param {Object} input.telemetry  {signupCount, verifiedSignupCount, lastSeenAt, marketingConsent, hasEmail, whatsappReachable}
+ * @param {Object} input.telemetry  {signupCount, verifiedSignupCount, newestSignupAt, marketingConsent, hasEmail, whatsappReachable}
  * @param {Object} input.config     configJson from enrichment_scoring_configs (merged over defaults)
  * @param {number} input.now        epoch ms — injected so scoring is reproducible in tests and backfills
  * @returns {{meetScore:number|null, buyScore:number|null, consumerScore:number|null,

--- a/backend/test/cohortService.test.js
+++ b/backend/test/cohortService.test.js
@@ -1,6 +1,6 @@
 import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect } from './helpers.js';
 import {
-  Consumer, ConsentEvent, ConsumerSuppression, Draw, DrawEntry,
+  sequelize, Consumer, ConsentEvent, ConsumerSuppression, Draw, DrawEntry,
 } from '../src/models/index.js';
 import {
   previewCohort, listCohortMembers, canMarketToBatch, getCohortFacets, normalizeDefinition,
@@ -468,7 +468,14 @@ describe('members → person click-through (includeProspect, admin-people-direct
     // newer one must win.
     const twice = await makeConsumer('TwoSignups', { verifiedSignupCount: 1 });
     const older = await signup(twice, campA);
-    await older.update({ createdAt: new Date('2026-06-01T00:00:00Z') }, { silent: true, fields: ['createdAt'] });
+    // Raw SQL, not instance.update: Sequelize quietly drops `createdAt` from
+    // an instance update, so the old `{silent:true, fields:['createdAt']}`
+    // backdate never happened. Both signups then landed in the same
+    // millisecond often enough (esp. under --runInBand) that "newest" fell to
+    // the id DESC tiebreak over two RANDOM UUIDs — a coin-flip flake.
+    await sequelize.query('UPDATE prospects SET "createdAt" = :ts WHERE id = :id', {
+      replacements: { ts: new Date('2026-06-01T00:00:00Z'), id: older.id },
+    });
     const newer = await signup(twice, campA, { phone: nextPhone() });
 
     const def = { filters: { campaignIds: [campA.id] } };

--- a/backend/test/scoringIsolation.test.js
+++ b/backend/test/scoringIsolation.test.js
@@ -1,0 +1,180 @@
+import { createHash } from 'crypto'
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect } from './helpers.js'
+import { sequelize, Consumer, ConsentEvent, WaMessageStatus } from '../src/models/index.js'
+import {
+  loadTelemetry, scoreOneConsumer, _resetConfigCache,
+} from '../src/services/consumerScoringService.js'
+
+/**
+ * The capability-vs-response contract, at the database
+ * (per-campaign-lead-scoring.md §3.2 / §16 B1; the Phase-0 fix).
+ *
+ * ONE person, TWO live leads on different campaigns. Both directions are
+ * pinned so neither future "fix" can silently invert the contract:
+ *
+ *   RESPONSES must NOT move the person score —
+ *     a WhatsApp READ adds nothing beyond deliverability (it IS proof of
+ *     deliverability, because the status upsert keeps only the furthest
+ *     status), and a lastSeenAt touch moves nothing at all (recency anchors
+ *     to the newest SIGNUP, and telemetry no longer even carries lastSeenAt).
+ *
+ *   CAPABILITIES must KEEP crossing campaigns —
+ *     a delivered/read status (deliverability) and a granted `contact`
+ *     consent (marketing authority) each raise the person score, wherever
+ *     they were earned. Asserting the positive direction is what catches a
+ *     future over-scoping "fix" that blanket-scopes telemetry per campaign.
+ */
+
+let admin, campA, campB
+let phoneSeq = Math.floor(Math.random() * 700000)
+
+const e164 = () => `+65${(81000000 + (phoneSeq += 1)).toString()}`
+const sha256hex = (s) => createHash('sha256').update(s).digest('hex')
+
+/** One person with two live leads on different campaigns. */
+async function personWithTwoLeads() {
+  const phone = e164()
+  const consumer = await Consumer.create({
+    phone,
+    phoneHash: sha256hex(phone),
+    firstSeenAt: new Date('2026-06-01T00:00:00Z'),
+    lastSeenAt: new Date('2026-06-01T00:00:00Z'),
+    signupCount: 2,
+    verifiedSignupCount: 1,
+    email: `iso-${phoneSeq}@example.com`,
+  })
+  // Raw SQL: Sequelize quietly drops `createdAt` from an instance update, and
+  // an un-backdated pair can share a millisecond, leaving "newest" to the id
+  // tiebreak over random UUIDs.
+  const older = await createTestProspect(campA.id, { consumerId: consumer.id, phone })
+  await sequelize.query('UPDATE prospects SET "createdAt" = :ts WHERE id = :id', {
+    replacements: { ts: new Date('2026-06-01T00:00:00Z'), id: older.id },
+  })
+  const newer = await createTestProspect(campB.id, { consumerId: consumer.id, phone: e164() })
+  return { consumer, older, newer }
+}
+
+const scoreOf = async (consumerId) => {
+  const r = await scoreOneConsumer(consumerId, { force: true })
+  expect(r.status).toBe('scored')
+  return r
+}
+
+beforeAll(async () => {
+  await getApp()
+  _resetConfigCache()
+  const made = await createTestUser({ role: 'admin' })
+  admin = made.user
+  campA = await createTestCampaign(admin.id, { name: `Iso A ${Date.now()}` })
+  campB = await createTestCampaign(admin.id, { name: `Iso B ${Date.now()}` })
+})
+
+afterAll(async () => {
+  await closeDb()
+})
+
+describe('telemetry shape', () => {
+  test('recency anchors to the NEWEST prospect (createdAt DESC, id DESC) and lastSeenAt is gone', async () => {
+    const { consumer, newer } = await personWithTwoLeads()
+    const t = await loadTelemetry(consumer.id)
+    expect(t.lastSeenAt).toBeUndefined()
+    expect(new Date(t.newestSignupAt).getTime()).toBe(new Date(newer.createdAt).getTime())
+  })
+})
+
+describe('responses do not cross campaigns', () => {
+  test('a WhatsApp READ adds nothing beyond deliverability — read and delivered score identically', async () => {
+    const { consumer } = await personWithTwoLeads()
+
+    await WaMessageStatus.create({
+      wamid: `wamid.iso.read.${phoneSeq}`,
+      status: 'read',
+      recipientHash: consumer.phoneHash,
+      occurredAt: new Date(),
+    })
+    const asRead = await scoreOf(consumer.id)
+
+    // Same person, same message — had the webhook only ever reached
+    // 'delivered', the score must be identical. (The upsert keeps only the
+    // FURTHEST status, so 'read' REPLACES 'delivered'; scoring 'read' higher
+    // would turn a lead-scoped response into person-scoped points.)
+    await WaMessageStatus.update(
+      { status: 'delivered' },
+      { where: { wamid: `wamid.iso.read.${phoneSeq}` } }
+    )
+    const asDelivered = await scoreOf(consumer.id)
+
+    expect(asRead.meetScore).toBe(asDelivered.meetScore)
+    expect(asRead.consumerScore).toBe(asDelivered.consumerScore)
+  })
+
+  test('a lastSeenAt touch (any response, anywhere) moves nothing', async () => {
+    const { consumer } = await personWithTwoLeads()
+    const before = await scoreOf(consumer.id)
+
+    // A response touch lands somewhere — the spine refreshes lastSeenAt.
+    await Consumer.update({ lastSeenAt: new Date() }, { where: { id: consumer.id } })
+
+    const after = await scoreOf(consumer.id)
+    expect(after.meetScore).toBe(before.meetScore)
+    expect(after.buyScore).toBe(before.buyScore)
+    expect(after.consumerScore).toBe(before.consumerScore)
+  })
+
+  test('the anchor is the newest SIGNUP: backdating it decays engagement', async () => {
+    const { consumer, older, newer } = await personWithTwoLeads()
+    const fresh = await scoreOf(consumer.id)
+
+    // Push the newest signup one engagement half-life into the past. Backdate
+    // BOTH leads (with only `newer` backdated, `older` would become the newest
+    // and the anchor would move less than a half-life), and do it in raw SQL —
+    // Sequelize quietly drops `createdAt` from an instance update.
+    const halfLifeAgo = new Date(Date.now() - 180 * 86_400_000)
+    await sequelize.query('UPDATE prospects SET "createdAt" = :ts WHERE id = :id', {
+      replacements: { ts: halfLifeAgo, id: newer.id },
+    })
+    await sequelize.query('UPDATE prospects SET "createdAt" = :ts WHERE id = :id', {
+      replacements: { ts: new Date(halfLifeAgo.getTime() - 86_400_000), id: older.id },
+    })
+
+    const t = await loadTelemetry(consumer.id)
+    expect(new Date(t.newestSignupAt).getTime()).toBe(halfLifeAgo.getTime())
+
+    const aged = await scoreOf(consumer.id)
+    expect(aged.meetScore).toBeLessThan(fresh.meetScore)
+  })
+})
+
+describe('capabilities DO cross campaigns — pinned so an over-scoping "fix" fails here', () => {
+  test('WhatsApp deliverability earned on ONE campaign raises the person score', async () => {
+    const { consumer } = await personWithTwoLeads()
+    const unreachable = await scoreOf(consumer.id)
+
+    await WaMessageStatus.create({
+      wamid: `wamid.iso.cap.${phoneSeq}`,
+      status: 'delivered',
+      recipientHash: consumer.phoneHash,
+      occurredAt: new Date(),
+    })
+    const reachable = await scoreOf(consumer.id)
+    expect(reachable.meetScore).toBeGreaterThan(unreachable.meetScore)
+  })
+
+  test('a `contact` consent granted via one campaign raises the person score', async () => {
+    const { consumer, older } = await personWithTwoLeads()
+    const before = await scoreOf(consumer.id)
+
+    await ConsentEvent.create({
+      consumerId: consumer.id,
+      prospectId: older.id,
+      campaignId: campA.id, // purpose-scoped row — authority is still person-grain
+      kind: 'contact',
+      granted: true,
+      version: 'test-v1',
+      source: 'signup',
+      occurredAt: new Date(),
+    })
+    const after = await scoreOf(consumer.id)
+    expect(after.meetScore).toBeGreaterThan(before.meetScore)
+  })
+})

--- a/backend/test/unit/consentKindContract.test.js
+++ b/backend/test/unit/consentKindContract.test.js
@@ -1,0 +1,52 @@
+import { MARKETING_CONSENT_KIND } from '../../src/services/consumerScoringService.js'
+import ConsentEvent from '../../src/models/ConsentEvent.js'
+
+/**
+ * The consent kind the scorer queries must be a kind that can actually exist.
+ *
+ * This guards a bug that shipped to production: `loadTelemetry` filtered on
+ * `ce.kind = 'marketing'`, which is not in ConsentEvent's enum and never has
+ * been. The query was valid SQL, returned no rows, and silently made
+ * marketingConsent FALSE for every consumer — docking 0.45 of contactability
+ * from the 128 of 130 people who HAD granted consent. Nothing failed; the
+ * scores were just quietly wrong.
+ *
+ * The literal lived inside a SQL string, so no unit test could see it and only
+ * an integration test with exactly the right fixture would have caught it.
+ * Hence the exported constant: the contract between the scorer and the ledger
+ * is now a value two modules can be compared on.
+ */
+
+/** Pull the allowed values straight off the model — never restate them here. */
+function allowedConsentKinds() {
+  const validate = ConsentEvent.rawAttributes.kind.validate
+  const isIn = validate?.isIn
+  // Sequelize accepts both `isIn: [[…]]` and `isIn: { args: [[…]] }`.
+  const list = Array.isArray(isIn) ? isIn[0] : isIn?.args?.[0]
+  return list
+}
+
+describe('marketing consent kind contract', () => {
+  test('the model actually declares an allowlist we can check against', () => {
+    const kinds = allowedConsentKinds()
+    expect(Array.isArray(kinds)).toBe(true)
+    expect(kinds.length).toBeGreaterThan(0)
+  })
+
+  test('the kind the scorer queries is one the ledger can store', () => {
+    expect(allowedConsentKinds()).toContain(MARKETING_CONSENT_KIND)
+  })
+
+  test("'marketing' is NOT a storable kind — the exact bug that shipped", () => {
+    // If someone ever adds a 'marketing' kind this test should be deleted,
+    // not silenced: the scorer would then need to decide which kind it means.
+    expect(allowedConsentKinds()).not.toContain('marketing')
+  })
+
+  test('the kind is `contact`, which the UI labels "marketing"', () => {
+    // The mismatch between the stored name and the displayed name is how the
+    // wrong literal got written in the first place. Pinned so the next person
+    // reads this instead of guessing.
+    expect(MARKETING_CONSENT_KIND).toBe('contact')
+  })
+})

--- a/backend/test/unit/consumerScoring.test.js
+++ b/backend/test/unit/consumerScoring.test.js
@@ -21,7 +21,7 @@ const NOW = Date.UTC(2026, 6, 26, 9, 0, 0) // 2026-07-26 17:00 SGT
 const fullTelemetry = {
   signupCount: 1,
   verifiedSignupCount: 1,
-  lastSeenAt: new Date(NOW).toISOString(),
+  newestSignupAt: new Date(NOW).toISOString(),
   hasEmail: true,
   marketingConsent: true,
   whatsappReachable: true,
@@ -78,6 +78,43 @@ describe('scoreability — a number is never invented from ignorance', () => {
     expect(r.breakdown.components.engagement.state).toBe('unknown')
     expect(r.meetScore).not.toBeNull()
     expect(r.buyScore).toBeNull()
+  })
+})
+
+describe('v2 recency anchor — newest signup, never lastSeenAt (§16 B1)', () => {
+  const HALF_LIFE_AGO = new Date(NOW - 180 * 86_400_000).toISOString() // one engagementHalfLifeDays
+
+  test('recency decays from newestSignupAt', () => {
+    const fresh = score({}, fullTelemetry)
+    const stale = score({}, { ...fullTelemetry, newestSignupAt: HALF_LIFE_AGO })
+    // depth(1 signup)=0.35; one half-life halves it; verified bonus 0.15 rides
+    // on top. Precision 1: stored breakdown points are rounded to 2dp.
+    expect(stale.breakdown.components.engagement.points)
+      .toBeCloseTo((0.35 * 0.5 + 0.15) * 15, 1)
+    expect(stale.breakdown.components.engagement.points)
+      .toBeLessThan(fresh.breakdown.components.engagement.points)
+  })
+
+  test('lastSeenAt is IGNORED — a response touch cannot refresh the person score', () => {
+    // Old signup + a lastSeenAt refreshed "now" (e.g. a WhatsApp read landed
+    // somewhere): the engine must score it identically to the old signup
+    // alone. This pins the v2 anchor so a regression back to lastSeenAt fails.
+    const anchorOnly = score({}, { ...fullTelemetry, newestSignupAt: HALF_LIFE_AGO })
+    const withTouch = score({}, {
+      ...fullTelemetry,
+      newestSignupAt: HALF_LIFE_AGO,
+      lastSeenAt: new Date(NOW).toISOString(),
+    })
+    expect(withTouch.breakdown.components.engagement.points)
+      .toBe(anchorOnly.breakdown.components.engagement.points)
+    expect(withTouch.meetScore).toBe(anchorOnly.meetScore)
+  })
+
+  test('missing newestSignupAt falls back to full recency, as lastSeen always did', () => {
+    const { newestSignupAt, ...rest } = fullTelemetry
+    const r = score({}, rest)
+    expect(r.breakdown.components.engagement.points)
+      .toBeCloseTo((0.35 + 0.15) * 15, 5)
   })
 })
 

--- a/backend/test/unit/retellScreening.test.js
+++ b/backend/test/unit/retellScreening.test.js
@@ -29,7 +29,11 @@ const CFG = {
   dryRun: false,
   maxAttempts: 3,
   retryMinutes: 120,
-  callWindow: '00:00-23:59', // always-open for tests
+  // NOT actually always-open: parseWindow cannot say 24:00 and inCallWindow
+  // is end-exclusive, so the 23:59 SGT minute is OUTSIDE this window — which
+  // is exactly when the 26 Jul CI run started, failing every dial-path test.
+  // Dial-path tests pass `now: IN_WINDOW` instead of trusting the wall clock.
+  callWindow: '00:00-23:59',
   maxConcurrent: 3,
   maxDialsPerDay: 50,
   staleCallMinutes: 30,
@@ -37,6 +41,10 @@ const CFG = {
   onUnreachable: 'release',
   sweepIntervalMinutes: 5,
 };
+
+/** A fixed instant inside CFG's window: 12:00 SGT. Keeps every dial-path
+ *  test hour-independent — the reason startScreeningAttempt takes `now`. */
+const IN_WINDOW = new Date('2026-07-23T04:00:00Z');
 
 function stampFor(phone) {
   return {
@@ -218,7 +226,7 @@ describe('startScreeningAttempt', () => {
       min_age: 25,
       max_age: 60,
     };
-    const out = await svc.startScreeningAttempt(pendingProspect(), { campaign: camp, cfg: CFG });
+    const out = await svc.startScreeningAttempt(pendingProspect(), { campaign: camp, cfg: CFG, now: IN_WINDOW });
     expect(out.status).toBe('dialed');
     expect(deps.retellClient.createPhoneCall).toHaveBeenCalledWith(expect.objectContaining({
       from_number: CFG.fromNumber,
@@ -288,6 +296,7 @@ describe('startScreeningAttempt', () => {
     const out = await svc.startScreeningAttempt(pendingProspect(), {
       campaign: screeningCampaign(),
       cfg: { ...CFG, callWindow: '10:00-10:01' },
+      now: IN_WINDOW, // 12:00 SGT — deterministically outside [10:00, 10:01)
     });
     expect(out).toMatchObject({ status: 'deferred', reason: 'outside_window' });
   });
@@ -295,18 +304,18 @@ describe('startScreeningAttempt', () => {
   it('daily budget and concurrency caps defer instead of dialing', async () => {
     const seqBudget = fakeSequelize([[[{}]], [[{ dialsToday: 50 }]], [[{ id: 'p' }]]]);
     const svcBudget = makeRetellScreeningService(dialerDeps(seqBudget));
-    expect((await svcBudget.startScreeningAttempt(pendingProspect(), { campaign: screeningCampaign(), cfg: CFG })).reason).toBe('budget_exhausted');
+    expect((await svcBudget.startScreeningAttempt(pendingProspect(), { campaign: screeningCampaign(), cfg: CFG, now: IN_WINDOW })).reason).toBe('budget_exhausted');
     expect(seqBudget.tx.rollback).toHaveBeenCalled();
 
     const seqConc = fakeSequelize([[[{}]], [[{ dialsToday: 0 }]], [[{ inFlight: 3 }]], [[{ id: 'p' }]]]);
     const svcConc = makeRetellScreeningService(dialerDeps(seqConc));
-    expect((await svcConc.startScreeningAttempt(pendingProspect(), { campaign: screeningCampaign(), cfg: CFG })).reason).toBe('concurrency_full');
+    expect((await svcConc.startScreeningAttempt(pendingProspect(), { campaign: screeningCampaign(), cfg: CFG, now: IN_WINDOW })).reason).toBe('concurrency_full');
   });
 
   it('dry run logs and never calls Retell', async () => {
     const deps = dialerDeps(fakeSequelize());
     const svc = makeRetellScreeningService(deps);
-    const out = await svc.startScreeningAttempt(pendingProspect(), { campaign: screeningCampaign(), cfg: { ...CFG, dryRun: true } });
+    const out = await svc.startScreeningAttempt(pendingProspect(), { campaign: screeningCampaign(), cfg: { ...CFG, dryRun: true }, now: IN_WINDOW });
     expect(out.reason).toBe('dry_run');
     expect(deps.retellClient.createPhoneCall).not.toHaveBeenCalled();
   });
@@ -319,7 +328,7 @@ describe('startScreeningAttempt', () => {
     const err = Object.assign(new Error('timeout'), { transient: true });
     const deps = dialerDeps(seq, { retellClient: { createPhoneCall: jest.fn().mockRejectedValue(err), getCall: jest.fn() } });
     const svc = makeRetellScreeningService(deps);
-    const out = await svc.startScreeningAttempt(pendingProspect(), { campaign: screeningCampaign(), cfg: CFG });
+    const out = await svc.startScreeningAttempt(pendingProspect(), { campaign: screeningCampaign(), cfg: CFG, now: IN_WINDOW });
     expect(out.status).toBe('dispatch_unknown');
     // No sentinel-clearing UPDATE ran after the claim (only evidence patches).
     const clearing = seq.calls.filter((c) => c.sql.includes(`SET "screeningActiveCallId" = NULL`));
@@ -336,7 +345,7 @@ describe('startScreeningAttempt', () => {
     const err = Object.assign(new Error('bad request'), { transient: false });
     const deps = dialerDeps(seq, { retellClient: { createPhoneCall: jest.fn().mockRejectedValue(err), getCall: jest.fn() } });
     const svc = makeRetellScreeningService(deps);
-    const out = await svc.startScreeningAttempt(pendingProspect(), { campaign: screeningCampaign(), cfg: CFG });
+    const out = await svc.startScreeningAttempt(pendingProspect(), { campaign: screeningCampaign(), cfg: CFG, now: IN_WINDOW });
     expect(out.status).toBe('dispatch_failed');
     expect(seq.calls.some((c) => c.sql.includes(`SET "screeningActiveCallId" = NULL`))).toBe(true);
   });


### PR DESCRIPTION
Phase 0 of the lead-scoring board: the live scoring defect + the clock flake keeping CI red. **Stacked on #292 — merge that first** (its branch is merged into this one; after #292 lands this PR's diff collapses to its own changes).

## Defect 1 — cross-campaign score bleed

Engagement recency read `consumers.lastSeenAt`, which refreshes on per-campaign **response** touches (`consumerService.js:151-158` GREATEST-upserts it on every linked signup and spine touch) — so engagement anywhere moved the one number an admin reads against every lead. The capability-vs-response contract (plan §3.2/§16 B1) now holds:

- **Recency anchors to the newest signup**: `loadTelemetry` returns `newestSignupAt` = the person's newest prospect `createdAt` (`createdAt DESC, id DESC` — the house tiebreak), and telemetry no longer carries `lastSeenAt` at all.
- **`whatsappReachable` deliberately KEEPS `IN ('delivered','read')`** — the webhook upsert stores only the furthest status per wamid (`waWebhookService.js:37,79-87`), so a READ message no longer reads as 'delivered'; dropping 'read' (the plan's §3.3 wording, refuted in §16 B1) would un-reach exactly the people with the strongest deliverability proof. A read counts only as deliverability; read-as-response is Phase 3, lead-scoped.
- **Migration 094** appends a config row stamped `score/v2` — necessary because the effective version is `config.algorithmVersion || SCORING_ALGORITHM_VERSION` (`consumerScoringService.js:187`) and the live row pins `score/v1`, so bumping the constant alone would recompute nothing. The append makes `findStaleConsumerIds` see every profile as config-stale → the next sweep recomputes all 130 and both stamps show it.

`test/scoringIsolation.test.js` pins both directions with one person holding two live leads: a read scores **identically** to delivered, and a `lastSeenAt` touch moves **nothing** (responses don't cross) — while a delivered status and a `contact` consent grant **raise** the score (capabilities DO cross; a future over-scoping "fix" fails loudly).

## Defect 2 — the 23:59-SGT clock flake (what turned main red on 26 Jul)

The five `startScreeningAttempt` tests read the wall clock, and the tests' "always-open" `00:00-23:59` window has an **inexpressible final minute** (`parseWindow` clamps at 23:59; `inCallWindow` is end-exclusive). The 26 Jul run started at exactly 23:59 SGT → all five deferred with `outside_window`. `startScreeningAttempt` now takes an injectable `now` (defaults to `new Date()`; prod callers unchanged), and dial-path tests pass a fixed in-window instant. Note for the session with uncommitted work on these files: this diff is deliberately minimal (signature + 8 test call-sites).

## Bonus — the cohort "flake" was real, and this is the actual mechanism

`{silent:true, fields:['createdAt']}` instance updates **silently drop `createdAt`** — Sequelize never writes it. So `cohortService.test.js`'s backdate fixture never happened; back-to-back creates can share a millisecond, and `DISTINCT ON … id DESC` over two **random UUIDs** is a coin flip. More likely under `--runInBand` (warm caches → same-ms creates), passes alone — matching the original symptom exactly. The backdate is now raw SQL; the same no-op was caught live by the isolation suite's `loadTelemetry` assert.

## Verification (local, CI-equivalent, per CLAUDE.md recipe)

- unit: **105/105 suites, 1865/1865**
- integration `--runInBand`: **127/127 suites, 2548 passed** (3 pre-existing skips)
- migrations: **30/30**
- `npx eslint src/ --quiet`: clean in `backend/` and at the repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127w4fTdWuoNTSZbBexNN8Z