### PR TITLE
docs: the scoring engine and profile questions land in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Studio is the **permanent** campaign design surface at `/admin/campaigns/:id/stu
 
 - **Twins:** `src/lib/designConfigV2.js` ↔ `backend/src/utils/designConfigV2.js` (+ `designConfigV2Clamp.js`) must stay in step — the backend clamp is the security boundary for anything a customer page renders.
 - **AI assist** fills every slot: copy, looks, distribution picks, sign-up field selection, and T&C drafting. Draw campaigns use the deterministic `drawTermsTemplate` facts, **never LLM-written legal text**. Publication recommendations are advisory and never auto-applied.
+- **Profile questions** — a campaign can slide enrichment questions into its signup funnel from a **fixed library** (`profileQuestionLibrary`: language, annual income, children, pets, retirement age), each with a per-question Required toggle and a per-campaign Chinese-inline-text toggle. Admins pick questions, never author them: free text would need LLM parsing and would poison the deterministic fact ledger. Answers map to taxonomy fact keys server-side and feed [lead scoring](#lead-scoring--meet--buy). The library is a byte-identical twin — `src/lib/profileQuestionLibrary.js` ↔ `backend/src/utils/profileQuestionLibrary.js`, enforced by a parity test.
 - **Readiness gates** (`campaignReadinessService`) block activation on server-verifiable problems — OTP send-path misconfiguration, missing draw records, close-date drift, promise-vs-enforcement mismatches.
 - The classic `DesignEditor` survives only as the `guided_review` designer; the standalone `/AdminCampaignDesigner` page is retired and redirects into the workspace Design tab.
 - `DESIGN_CONFIG_V2_WRITES_ENABLED` (backend) is the emergency brake on v2 writes.
@@ -216,11 +217,32 @@ Deep-dive: [`src/pages/redeemops/CLAUDE.md`](src/pages/redeemops/CLAUDE.md) and 
 ## 🧾 People, consent & compliance
 
 - **Consumer spine** — `Consumer` deduplicates a real person across campaigns; every prospect links to one (`prospects.consumerId`). Admin surfaces: the people directory (`/AdminPeople`) and the per-person lead profile (`/admin/leads/:prospectId`).
+- **Enrichment ledger** — every fact learned about a person is appended to `ConsumerObservation` with its provenance, then resolved into `ConsumerProfile` by `factMapperService` through an outbox of `EnrichmentJob` rows. Nothing overwrites: the ledger is the audit trail, the profile is the current view.
 - **Consent ledger** — `ConsentEvent` records each grant with its versioned copy (`consentCopyRegistry`, `GET /api/consent-copy/:version`), so any downstream use can prove what the person actually agreed to. Meta/TikTok PII hashing is gated on a ledger-derived marketing-consent flag.
 - **Suppression & erasure** — `ConsumerSuppression` + `SuppressionPropagation` carry unsubscribes outward (`lead.suppressed`, per-destination opt-in); `erasureService` cascades deletion; `/api/unsubscribe` and WhatsApp `STOP` both land in the same place.
 - **Cohorts & broadcasts** — `Cohort` builds cross-campaign audiences; `EmailBroadcast` sends to them with per-recipient tracking and interrupted-run resume (nothing auto-sends on a deploy or restart).
 - **DNC scrubbing** — every captured phone is checked against the Singapore PDPC Do-Not-Call registry (`DNC_API_ENABLED`, RSA-signed, fixed-IP egress proxy), enforced as `block` or `flag`, with a backfill job for checks that errored.
 - **SMS sender compliance** — OTP SMS ships under the SSIR-registered `MKTR` sender ID with per-phone and global daily caps plus threshold alerts (`smsQuota`, `RateCounter`).
+
+### Lead scoring — MEET × BUY
+
+`utils/consumerScoring.js` turns resolved facts plus behavioural telemetry into two sub-scores, so "will they meet a consultant" and "will they buy" stay separate questions:
+
+```
+MEET = engagement 15 + contactability 10 + market fit 15        (raw 40) ×2.5
+BUY  = life events 25 + family gap 20 + capacity 15
+       + coverage headroom −10..0                               (raw 60) /60
+consumerScore = clamp(0, Σ all components, 100)                 ← default sort
+```
+
+The design points worth knowing:
+
+- **The engine is pure.** Facts and telemetry in, scores out — no I/O, no clock (the caller passes `now`). Any score can be re-derived and explained from its stored breakdown, which is what the dials on the lead profile render.
+- **Weights are config, rules are code.** `EnrichmentScoringConfig` carries per-component `maxPoints`, the Meet/Buy `groups` map, and `targetSegments`; each rule returns a 0..1 fraction of its component's max. Recalibrating — or regrouping which components feed Meet vs Buy — is a config row, not a deploy.
+- **Unknown ≠ zero.** BUY is `null` unless at least one fact component is assessable, because an unknown income must not read as low capacity. MEET always computes (engagement and contactability are behavioural), but market fit only contributes when the language or ethnicity fact exists, and the breakdown says so.
+- **Penalties carry their sign in `maxPoints`, never in the fraction** — `coverage_headroom` has `maxPoints −10`, so "fully covered" scores −10 rather than inverting into a bonus.
+
+Scoring runs in-process behind `ENRICHMENT_SCORING_ENABLED`: an hourly tick fenced by `EnrichmentSweepRun` to one real sweep per SGT date, so an instance that was down at the intended hour still sweeps that day. Design: [`docs/plans/consumer-profile-enrichment.md`](docs/plans/consumer-profile-enrichment.md) and [`docs/plans/per-campaign-lead-scoring.md`](docs/plans/per-campaign-lead-scoring.md).
 
 ---
 
@@ -300,11 +322,11 @@ mktr-platform/
 │       ├── server_internal.js# real app init: middleware stack, health, route auto-loader
 │       ├── routes/           # 66 auto-discovered route modules (each exports `meta`)
 │       ├── controllers/      # 44 request handlers
-│       ├── services/         # 96 top-level + 39 under redeemOps/
+│       ├── services/         # 98 top-level + 39 under redeemOps/
 │       ├── models/           # 90 Sequelize models + index.js (associations)
 │       ├── middleware/       # auth, internalRouteHostGuard, prospectScope, validation, …
 │       ├── integrations/     # adapter registry + Lyfe / mktr-leads adapters
-│       ├── database/         # connection, bootstrap, runMigrations, migrations/ (89), seed
+│       ├── database/         # connection, bootstrap, runMigrations, migrations/ (92), seed
 │       ├── utils/ config/ schemas/ scripts/ tests/
 │       └── uploads/          # local asset storage (dev / fallback)
 │
@@ -333,6 +355,7 @@ The backend owns its **own PostgreSQL database** (Sequelize), separate from Lyfe
 - `Prospect` — the lead record: `leadSource` / `leadStatus` / `priority` enums, scoring, JSON `demographics` / `budget` / `consentMetadata` / `sourceMetadata`, `retellCallId`, routing state (`assignedAgentId` **xor** `externalAgentId`, `quarantinedAt` / `quarantineReason`), the DNC block (`dncStatus`, `dncNoVoiceCall`, `dncValidUntil`, …), the screening block (`screeningVerdict`, `screeningAttemptCount`, `screeningNextAttemptAt`, …), and `consumerId` / `enrichmentRevision`.
 - `ProspectActivity` — audit trail. `Attribution` / `SessionVisit` — QR-scan → session → lead attribution chain.
 - `Consumer`, `ConsentEvent`, `ConsumerSuppression`, `SuppressionPropagation`, `Cohort`, `EmailBroadcast` / `EmailBroadcastRecipient` — the person spine, consent ledger, and marketing surfaces.
+- `ConsumerObservation` (append-only fact ledger), `ConsumerProfile` (resolved view + `meetScore` / `buyScore` / `consumerScore` and their breakdown), `EnrichmentJob` (mapper outbox), `EnrichmentScoringConfig` (weights, groups, target segments), `EnrichmentSweepRun` (per-SGT-date sweep fence).
 
 **Campaigns**
 - `Campaign` — `type` (`lead_generation` | `brand_awareness` | `product_promotion` | `event_marketing` | `quiz` | `guided_review`), `status`, `design_config` (the v2 document), `slug`, `min_age`/`max_age`, `metaPixelId`/`tiktokPixelId`, `leadPriceCents`, `firstActivatedAt`, and the routing gates `enforceLeadQuota` + `externalEligible`.
@@ -490,7 +513,8 @@ The backend runs migrations automatically on boot (and, in `NODE_ENV=test`, forc
 | Meta CAPI | `META_CAPI_ENABLED`, `META_PIXEL_ID`, `META_CAPI_ACCESS_TOKEN`, `META_TEST_EVENT_CODE`, `META_EVENT_QUALIFIED`, `META_EVENT_WON` |
 | TikTok | `TIKTOK_EVENTS_API_ENABLED`, `TIKTOK_PIXEL_ID`, `TIKTOK_ACCESS_TOKEN`, `TIKTOK_TEST_EVENT_CODE` |
 | OTP / SMS | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `AWS_SNS_SENDER_ID`, `SNS_AWS_*`, `SMS_DAILY_CAP_PER_PHONE`, `SMS_DAILY_GLOBAL_CAP`, `SMS_DAILY_ALERT_THRESHOLD`, `SMS_ALERT_EMAIL`, `SMS_QUOTA_SALT` |
-| WhatsApp | `WHATSAPP_PROVIDER`, `META_WA_PHONE_NUMBER_ID`, `META_WA_ACCESS_TOKEN`, `META_WA_BUSINESS_ACCOUNT_ID`, `WHATSAPP_WEBHOOK_VERIFY_TOKEN`, `WHATSAPP_APP_SECRET`, `WHATSAPP_WABA_ID`, `WHATSAPP_TEMPLATE_*` |
+| WhatsApp | `META_WA_PHONE_NUMBER_ID`, `META_WA_ACCESS_TOKEN` (OTP); `WHATSAPP_TOKEN`, `WHATSAPP_PHONE_NUMBER_ID`, `WHATSAPP_TEMPLATE_*` (Redeem Ops sends — a **different** credential pair); `WHATSAPP_WEBHOOK_VERIFY_TOKEN`, `WHATSAPP_APP_SECRET`, `WHATSAPP_WABA_ID` (status webhook) |
+| Enrichment | `ENRICHMENT_MAP_ARTIFACT_JOBS` (artifact-scoped map jobs — flip only after migration 092 has fully rolled), `ENRICHMENT_SCORING_ENABLED` (the MEET × BUY sweep; off = no score is ever written, the ledger fills either way) |
 | Campaign Studio | `DESIGN_CONFIG_V2_WRITES_ENABLED` (emergency brake on v2 writes) |
 | Marketplace | `MARKETPLACE_PUBLIC_API_ENABLED`, `MARKETPLACE_INHERIT_ENABLED` |
 | Redeem Ops | `REDEEM_OPS_ENABLED`, `REDEEM_OPS_ENTITLEMENTS_ENABLED`, `REDEEM_OPS_CADENCES_ENABLED`, `DISCOVERY_ENABLED`, `APIFY_TOKEN`, `DISCOVERY_CANDIDATE_TTL_DAYS`, `REDEEM_HOUSE_PARTNER_ORG_ID` |
@@ -589,6 +613,7 @@ It then schedules the recurring in-process jobs (all skipped under `NODE_ENV=tes
 | Redeem Ops fulfilment sweep | 15 min |
 | Redeem Ops stale sweep + cadence reconcile | 30 min |
 | Idempotency-key purge · suppression-propagation backstop · draw-record backstop | hourly |
+| Enrichment scoring sweep (`ENRICHMENT_SCORING_ENABLED`) — hourly tick, fenced to one real run per SGT date | hourly, first ~150 s after boot |
 | Redemption CAPI reconciliation | 6 h |
 | Redeemed-audience sync to Meta | `REDEEMED_AUDIENCE_SYNC_INTERVAL_HOURS` (default 24 h) |
 | DNC backfill (`DNC_BACKFILL_ENABLED`) · Discover retention purge | `DNC_BACKFILL_INTERVAL_MINUTES` · daily |

--- a/backend/README.md
+++ b/backend/README.md
@@ -56,6 +56,7 @@ It then schedules the recurring in-process jobs (all skipped under `NODE_ENV=tes
 | Redeem Ops fulfilment sweep | 15 min |
 | Redeem Ops stale sweep + cadence reconcile | 30 min |
 | Idempotency-key purge · suppression-propagation backstop · draw-record backstop | hourly |
+| Enrichment scoring sweep (`ENRICHMENT_SCORING_ENABLED`) — fenced to one real run per SGT date by `enrichment_sweep_runs` | hourly, first ~150 s after boot |
 | Redemption CAPI reconciliation | 6 h |
 | Redeemed-audience sync to Meta | `REDEEMED_AUDIENCE_SYNC_INTERVAL_HOURS` (default 24 h) |
 | DNC backfill (`DNC_BACKFILL_ENABLED`) · Discover retention purge | `DNC_BACKFILL_INTERVAL_MINUTES` · daily |
@@ -127,11 +128,13 @@ Base URL: `https://api.mktr.sg/api` (prod) · `http://localhost:3001/api` (dev).
 
 ## Data model
 
-The backend owns its **own** PostgreSQL database (separate from Lyfe's Supabase) — 90 Sequelize models in `src/models/` with associations in `src/models/index.js`, and 89 migrations under `src/database/migrations/`.
+The backend owns its **own** PostgreSQL database (separate from Lyfe's Supabase) — 90 Sequelize models in `src/models/` with associations in `src/models/index.js`, and 92 migrations under `src/database/migrations/`.
 
 Pipeline-central: `User`, `Prospect`, `ProspectActivity`, `Campaign`, `LeadPackage` / `LeadPackageAssignment`, `RoundRobinCursor`, `WalletLedger`, `Payment`, `QrTag` / `QrScan`, `ShortLink`, `Attribution`, `ExternalAgent` / `ExternalCampaignAgent`, `WebhookSubscriber` / `WebhookDelivery`, `IdempotencyKey`.
 
 Person spine & consent: `Consumer`, `ConsentEvent`, `ConsumerSuppression`, `SuppressionPropagation`, `Cohort`, `EmailBroadcast` / `EmailBroadcastRecipient`.
+
+Enrichment & scoring: `ConsumerObservation` (append-only fact ledger), `ConsumerProfile` (resolved view + `meetScore` / `buyScore` / `consumerScore` + breakdown), `EnrichmentJob` (mapper outbox), `EnrichmentScoringConfig` (weights / groups / target segments), `EnrichmentSweepRun` (per-SGT-date sweep fence). The scoring math is pure and lives in `utils/consumerScoring.js` — see the [README section](../README.md#lead-scoring--meet--buy).
 
 Rewards, draws & Redeem Ops: `RewardOffer` / `RewardEntitlement` / `Redemption`, `Activation`, `Draw` / `DrawEntry` / `DrawAttempt` / `DrawBoostReview` / `DrawTermsVersion`, the `Partner*` / `Outreach*` / `Discovery*` families.
 
@@ -155,7 +158,8 @@ Retired but still in the schema: `Device`, `Vehicle`, `Car`, `FleetOwner`, `Driv
 | Meta | `META_CAPI_ENABLED`, `META_PIXEL_ID`, `META_CAPI_ACCESS_TOKEN`, `META_TEST_EVENT_CODE`; `META_EVENT_QUALIFIED`, `META_EVENT_WON`, `META_EVENT_REDEEMED` |
 | TikTok | `TIKTOK_EVENTS_API_ENABLED`, `TIKTOK_PIXEL_ID`, `TIKTOK_ACCESS_TOKEN`, `TIKTOK_TEST_EVENT_CODE` |
 | Retell screening | `RETELL_SCREENING_ENABLED`, `RETELL_SCREENING_AGENT_ID`, `RETELL_SCREENING_FROM_NUMBER`, `SCREENING_*` (attempts, window, concurrency, TTL, alerts) |
-| OTP | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `AWS_SNS_SENDER_ID`; `SNS_AWS_ACCESS_KEY_ID` / `SNS_AWS_SECRET_ACCESS_KEY` (preferred SNS-only pair — set both or neither); `WHATSAPP_PROVIDER`, `META_WA_PHONE_NUMBER_ID`, `META_WA_ACCESS_TOKEN`, `META_WA_BUSINESS_ACCOUNT_ID` |
+| OTP | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `AWS_SNS_SENDER_ID`; `SNS_AWS_ACCESS_KEY_ID` / `SNS_AWS_SECRET_ACCESS_KEY` (preferred SNS-only pair — set both or neither); `META_WA_PHONE_NUMBER_ID`, `META_WA_ACCESS_TOKEN`. The WhatsApp OTP channel is chosen per campaign by `design_config.otpChannel`, not by an env var. |
+| Enrichment | `ENRICHMENT_MAP_ARTIFACT_JOBS`, `ENRICHMENT_SCORING_ENABLED` |
 | SMS caps (SSIR) | `SMS_DAILY_CAP_PER_PHONE` (7), `SMS_DAILY_GLOBAL_CAP` (500), `SMS_DAILY_ALERT_THRESHOLD` (250), `SMS_ALERT_EMAIL`, `SMS_QUOTA_SALT` — guard the registered `MKTR` sender ID; see `docs/reference/sms-sender-id-compliance.md` |
 | WhatsApp sends | `REDEEM_OPS_WHATSAPP_ENABLED`, `WHATSAPP_TOKEN`, `WHATSAPP_PHONE_NUMBER_ID`, `WHATSAPP_TEMPLATE_*` — **a different credential pair from the `META_WA_*` OTP set above** |
 | WhatsApp webhook | `WHATSAPP_WEBHOOK_VERIFY_TOKEN`, `WHATSAPP_APP_SECRET` (**prod fails closed without it**), `WHATSAPP_WABA_ID` |

--- a/backend/env.example
+++ b/backend/env.example
@@ -161,12 +161,14 @@ SMS_QUOTA_SALT=
 # -----------------------------------------------------------------------------
 # NOTE: these META_WA_* credentials are SEPARATE from the WHATSAPP_* pair further
 # down. This set drives OTP; that set drives Redeem Ops reward/draw sends.
-WHATSAPP_PROVIDER=meta
+#
+# There is no provider switch: the channel is chosen PER CAMPAIGN by
+# design_config.otpChannel ('sms' | 'whatsapp'), and a failed WhatsApp send
+# falls back to SMS.
 # From WhatsApp Manager → API setup. Requires an APPROVED Authentication
 # template (default 'auth_otp', language 'en_US') with an OTP button.
 META_WA_PHONE_NUMBER_ID=
 META_WA_ACCESS_TOKEN=
-META_WA_BUSINESS_ACCOUNT_ID=
 # Optional overrides (code defaults shown)
 # META_WA_TEMPLATE_NAME=auth_otp
 # META_WA_TEMPLATE_LANG=en_US
@@ -436,8 +438,9 @@ REDEEMED_AUDIENCE_SYNC_ENABLED=false
 META_ADS_MANAGEMENT_TOKEN=
 # Target Customer-List audience id.
 META_REDEEMED_AUDIENCE_ID=
-# Ad account id (numeric, no act_ prefix). Needed only to create the audience or
-# run a permission probe — the sync itself is audience-scoped.
+# Ad account id (numeric, no act_ prefix). NOT read by the server — recorded
+# here because creating the audience or running a permission probe by hand
+# needs it. The sync itself is audience-scoped.
 META_AD_ACCOUNT_ID=
 # "add" (additive POST /users — default, verified) or "replace" (POST
 # /usersreplace — authoritative full replace; probe before relying on it).
@@ -549,12 +552,15 @@ DNC_CHECK_ON_BEHALF=N
 # DNC_HTTPS_PROXY=http://user:pass@dnc-egress-host:8888
 # block = withhold DNC-registered leads; flag = deliver with a Do-Not-Call flag.
 DNC_ENFORCEMENT=block
-# Allow recorded consent to override a DNC hit (must be evidence-backed).
-DNC_CONSENT_OVERRIDES=false
 # Background re-scrub / retry job (recovers dnc_pending leads that errored).
 DNC_BACKFILL_ENABLED=false
 DNC_BACKFILL_INTERVAL_MINUTES=30
-# Re-check this many days before a result's validity expires (not yet wired).
+# ── Declared but NOT YET READ BY ANY CODE ────────────────────────────────────
+# Both are part of the DNC design that has not been implemented. Setting them
+# changes nothing today; they are kept so the intent survives.
+# Allow recorded consent to override a DNC hit (must be evidence-backed).
+DNC_CONSENT_OVERRIDES=false
+# Re-check this many days before a result's validity expires.
 DNC_REVALIDATE_DAYS=5
 # Per-call timeout (ms).
 DNC_TIMEOUT_MS=5000


### PR DESCRIPTION
Re-audited `main` after 10 commits (#284–#294) added the MEET × BUY scoring engine, Studio profile questions, and migrations 092–094. **Docs + env template only — no code touched.**

## Counts that drifted

migrations **89 → 92** · backend services **96 → 98**. Everything else still holds: 66 route modules, 90 models, 39 redeemOps services, 44 controllers, 13 middleware.

## Newly documented

**Lead scoring — MEET × BUY** gets its own section: the component formula, plus the four design properties that are easy to get wrong reading the code cold —

- the engine is **pure** (facts + telemetry in, no I/O, no clock), so any score re-derives from its stored breakdown;
- **weights are config, rules are code** — recalibrating or regrouping Meet/Buy is a config row, not a deploy;
- **unknown ≠ zero** — BUY is `null` unless a fact component is assessable, because unknown income must not read as low capacity;
- **penalties carry their sign in `maxPoints`**, never in the fraction, or `coverage_headroom` would invert into a bonus for already-insured people.

Also added: the **enrichment ledger** (ConsumerObservation → EnrichmentJob outbox → ConsumerProfile, nothing overwrites), and **Studio profile questions** — the fixed five-question library, per-question Required toggle, per-campaign Chinese-inline toggle, and why admins pick rather than author them (free text would need LLM parsing and would poison the deterministic ledger). Noted the byte-identical twin + parity test.

The data model gained the five enrichment models, the boot table gained the scoring sweep (hourly tick fenced to one real run per SGT date), and the env tables gained `ENRICHMENT_MAP_ARTIFACT_JOBS` + `ENRICHMENT_SCORING_ENABLED`.

> Both new env vars were **already** in `backend/env.example` — the one-canonical-file convention from #283 held through ten commits of new work.

## Correcting my own carry-over from #283

Five vars I moved into the consolidated template are read by **no code**. I verified the forward direction then (nothing the code reads was missing) but not the reverse, so these rode along from the old files:

| Var | Action |
|---|---|
| `WHATSAPP_PROVIDER` | **Removed.** There is no provider switch — the OTP channel is chosen per campaign by `design_config.otpChannel`, with SMS fallback. Also removed from `backend/README.md` and `README.md`. |
| `META_WA_BUSINESS_ACCOUNT_ID` | **Removed.** Vestigial; the webhook uses `WHATSAPP_WABA_ID`. |
| `META_AD_ACCOUNT_ID` | **Kept**, now labelled "NOT read by the server" — genuinely needed to create the audience or probe permissions by hand. |
| `DNC_CONSENT_OVERRIDES`, `DNC_REVALIDATE_DAYS` | **Kept** under an explicit "declared but NOT YET READ BY ANY CODE" heading. Both belong to unimplemented parts of the DNC design. |

## Verification

Env coverage now checked in **both** directions: 226 vars read, 223 documented, **zero read-but-undocumented**, and every documented-but-unread var annotated as such.

The six `SCREENING_*` vars a literal grep flags as unread are read through the `intEnv()` helper in `screeningGate.js:78-86` — false positives, confirmed individually.

All anchor links and file links re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgWRx53DQBvoHAdi3pViGx