### PR TITLE
feat(scoring): make age count — curve over the current SGT year, fed by the existing DOB backfill (score/v3)

### DIFF
--- a/backend/src/database/migrations/095-scoring-age-curve.js
+++ b/backend/src/database/migrations/095-scoring-age-curve.js
@@ -1,0 +1,110 @@
+/**
+ * 095 — score/v3: the age component (per-campaign-lead-scoring.md §13.2 /
+ * PR B — "age curve + DOB backfill").
+ *
+ * The rule lives in code (consumerScoring.js scoreAge: a piecewise curve
+ * over AGE evaluated against the current SGT year, band-straddle weighted by
+ * the fraction of the band in each segment). This migration exists because
+ * the EFFECTIVE algorithm version is `config.algorithmVersion ||
+ * SCORING_ALGORITHM_VERSION` (consumerScoringService.js) and the live config
+ * row pins 'score/v2': bumping the code constant alone would recompute
+ * nothing, and the stored groups.buy would leave the new component ungrouped
+ * (computed but contributing to no sub-score). The appended row makes
+ * findStaleConsumerIds see every stored score as config-stale, so the whole
+ * population recomputes on the next sweep with age placed in Buy.
+ *
+ * The row COPIES the current highest configJson (existing weights untouched)
+ * and takes MAX(version)+1, per §7.2's append-only contract, then:
+ *   - algorithmVersion → 'score/v3'
+ *   - components.age   → { maxPoints: 10 }  (LOW: age is a prior — known
+ *                        income/children must dominate it)
+ *   - groups.buy       → + 'age' (before coverage_headroom's position
+ *                        doesn't matter — grouping is a set)
+ *   - ageCurve         → the seed curve below
+ *
+ * The curve is INLINED, never imported from consumerScoring.js — a migration
+ * is a frozen historical record (093's rule): later tuning is a new
+ * append-only row, not an edit here. Empty table (fresh DB pre-093, or a
+ * test schema before seeding) → inserts nothing; code defaults already carry
+ * v3 + the curve. Idempotent: re-running after the highest row is already
+ * 'score/v3' is a no-op.
+ *
+ * "createdAt"/"updatedAt" are supplied EXPLICITLY — test schemas are built
+ * by sync({force:true}) from the models, where Sequelize emits them NOT NULL
+ * with NO database default, so a raw INSERT that omits them dies.
+ */
+
+// Seed curve v1 (§13.2 shape): under 25 low, rising through 25-29, peaking
+// 35-44, easing off after 50. `upTo: null` = open tail. Values are fractions
+// of components.age.maxPoints.
+const SEED_AGE_CURVE = [
+  { upTo: 24, value: 0.25 },
+  { upTo: 29, value: 0.55 },
+  { upTo: 34, value: 0.8 },
+  { upTo: 44, value: 1 },
+  { upTo: 49, value: 0.8 },
+  { upTo: 59, value: 0.55 },
+  { upTo: null, value: 0.3 },
+];
+
+export async function up(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.transaction(async (t) => {
+    await sequelize.query(
+      `INSERT INTO enrichment_scoring_configs
+         (version, "configJson", "activatedAt", "actorUserId", "createdAt", "updatedAt")
+       SELECT c.version + 1,
+              jsonb_set(
+                jsonb_set(
+                  jsonb_set(
+                    jsonb_set(c."configJson", '{algorithmVersion}', '"score/v3"'),
+                    '{components,age}', '{"maxPoints": 10}'::jsonb
+                  ),
+                  '{ageCurve}', :curve::jsonb, true
+                ),
+                '{groups,buy}',
+                CASE WHEN COALESCE(c."configJson"->'groups'->'buy' ? 'age', false)
+                     THEN c."configJson"->'groups'->'buy'
+                     ELSE COALESCE(c."configJson"->'groups'->'buy', '[]'::jsonb) || '["age"]'::jsonb
+                END
+              ),
+              now(), NULL, now(), now()
+         FROM enrichment_scoring_configs c
+        WHERE c.version = (SELECT MAX(version) FROM enrichment_scoring_configs)
+          AND c."configJson"->>'algorithmVersion' IS DISTINCT FROM 'score/v3'
+       ON CONFLICT (version) DO NOTHING`,
+      { transaction: t, replacements: { curve: JSON.stringify(SEED_AGE_CURVE) } }
+    );
+  });
+}
+
+export async function down(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.transaction(async (t) => {
+    // Remove only the row this migration appended: the highest version,
+    // stamped v3, and — with this migration's four additions stripped —
+    // byte-identical to its predecessor. A later human recalibration (also
+    // stamped v3) fails the strip-compare and is deliberately left alone.
+    await sequelize.query(
+      `DELETE FROM enrichment_scoring_configs c
+        WHERE c.version = (SELECT MAX(version) FROM enrichment_scoring_configs)
+          AND c."configJson"->>'algorithmVersion' = 'score/v3'
+          AND jsonb_set(
+                (c."configJson" - 'algorithmVersion' - 'ageCurve') #- '{components,age}',
+                '{groups,buy}',
+                COALESCE((c."configJson"->'groups'->'buy') - 'age', '[]'::jsonb)
+              ) = (
+                SELECT jsonb_set(
+                         p."configJson" - 'algorithmVersion',
+                         '{groups,buy}',
+                         COALESCE(p."configJson"->'groups'->'buy', '[]'::jsonb)
+                       )
+                  FROM enrichment_scoring_configs p
+                 WHERE p.version = c.version - 1
+              )`,
+      { transaction: t }
+    );
+  });
+}

--- a/backend/src/utils/consumerScoring.js
+++ b/backend/src/utils/consumerScoring.js
@@ -12,9 +12,10 @@
  * component math is grouped two ways:
  *
  *   MEET = engagement 15 + contactability 10 + market fit 15  (raw 40) ×2.5
- *   BUY  = life events 25 + family gap 20 + capacity 15
- *          + coverage headroom −10..0                         (raw 60) /60
+ *   BUY  = life events 25 + family gap 20 + capacity 15 + age 10
+ *          + coverage headroom −10..0                         (raw 70) /70
  *   consumerScore = clamp(0, Σ all components, 100)  ← stored default sort
+ *                   (raw ceiling is 110 since v3 — the clamp absorbs it)
  *
  * WEIGHTS LIVE IN CONFIG, RULES LIVE IN CODE. `configJson` carries
  * per-component `maxPoints`, the `groups` map, `targetSegments`, and the
@@ -56,8 +57,14 @@ import { MIN_LLM_CONFIDENCE } from './factTaxonomy.js';
  * capability-vs-response contract (per-campaign-lead-scoring.md §3.2/§16 B1)
  * says responses must not move the person-grain score. Migration 094 appends
  * the config row that makes every stored score recompute under this version.
+ *
+ * v3: the age component (per-campaign-lead-scoring.md §13.2 / PR B). A CURVE
+ * over age — not a band match — fed by identity.birth_year_band, weighted low
+ * (10 vs family_gap's 20) because age is a prior: once income and children
+ * are actually known they should dominate. Migration 095 appends the config
+ * row (curve + weight + grouping) that makes every stored score recompute.
  */
-export const SCORING_ALGORITHM_VERSION = 'score/v2';
+export const SCORING_ALGORITHM_VERSION = 'score/v3';
 
 /** SGT is UTC+8 year-round (no DST) — the one offset this file needs. */
 const SGT_OFFSET_MS = 8 * 60 * 60 * 1000;
@@ -75,7 +82,7 @@ export const DEFAULT_SCORING_CONFIG = {
   // Grouping is data, not code (§7.1b) — regrouping is a config insert.
   groups: {
     meet: ['engagement', 'contactability', 'market_fit'],
-    buy: ['life_events', 'family_gap', 'capacity', 'coverage_headroom'],
+    buy: ['life_events', 'family_gap', 'capacity', 'age', 'coverage_headroom'],
   },
   components: {
     engagement: { maxPoints: 15 },
@@ -84,9 +91,31 @@ export const DEFAULT_SCORING_CONFIG = {
     life_events: { maxPoints: 25 },
     family_gap: { maxPoints: 20 },
     capacity: { maxPoints: 15 },
+    // Deliberately LOW: age is a prior, not evidence. When income/children
+    // are actually known those components (15/20) must dominate it.
+    age: { maxPoints: 10 },
     // Negative max: a penalty component. Range −10..0.
     coverage_headroom: { maxPoints: -10 },
   },
+  /**
+   * The age curve (§13.2) — piecewise-constant over AGE IN YEARS, evaluated
+   * against the current SGT year. Defined over age, NEVER over birth-year
+   * band strings: a band-keyed table silently rots one band every five years
+   * as the population ages through it. Each segment applies to ages up to
+   * and including `upTo`; the final `upTo: null` segment is the open tail.
+   * Values are fractions in 0..1 of the component's maxPoints. Shape (owner
+   * tunes via a config row, not a deploy): under 25 low, rising through
+   * 25-29, peaking 35-44, easing off after 50.
+   */
+  ageCurve: [
+    { upTo: 24, value: 0.25 },
+    { upTo: 29, value: 0.55 },
+    { upTo: 34, value: 0.8 },
+    { upTo: 44, value: 1 },
+    { upTo: 49, value: 0.8 },
+    { upTo: 59, value: 0.55 },
+    { upTo: null, value: 0.3 },
+  ],
   // Which market we're currently selling into. Retargeting = one new row.
   targetSegments: [{ language: 'zh', ethnicity: 'chinese', weight: 1 }],
   decay: {
@@ -98,7 +127,7 @@ export const DEFAULT_SCORING_CONFIG = {
 
 /** Components whose evidence is FACTS (vs behavioral telemetry). */
 export const FACT_COMPONENTS = new Set([
-  'market_fit', 'life_events', 'family_gap', 'capacity', 'coverage_headroom',
+  'market_fit', 'life_events', 'family_gap', 'capacity', 'age', 'coverage_headroom',
 ]);
 
 const clamp = (n, lo, hi) => Math.min(hi, Math.max(lo, n));
@@ -356,6 +385,76 @@ function scoreCapacity(facts, cfg) {
   return assessed(clamp(fraction, 0, 1), basis, notes.join(', '));
 }
 
+/** Calendar year at `now` in SGT — the year ages are evaluated against. */
+function sgtYear(now) {
+  return new Date(now + SGT_OFFSET_MS).getUTCFullYear();
+}
+
+/**
+ * Piecewise-constant curve lookup. Segments are scanned in order; the first
+ * with `age <= upTo` (or the `upTo: null` open tail) wins. Values are
+ * clamped into 0..1 — the fraction contract belongs to the engine, and a
+ * mis-authored config row must not leak a >1 fraction into points. Returns
+ * null when no segment covers the age (a curve authored without a tail).
+ */
+function curveValueAt(curve, age) {
+  for (const seg of curve) {
+    if (seg == null) continue;
+    const upTo = seg.upTo;
+    if (upTo === null || upTo === undefined || age <= Number(upTo)) {
+      const v = Number(seg.value);
+      return Number.isFinite(v) ? clamp(v, 0, 1) : null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Age — a PRIOR on life stage, from identity.birth_year_band (the ledger
+ * never stores exact ages — they go stale; bands don't). A curve, not a
+ * range match: a range scores everyone inside it identically and puts a
+ * cliff at the boundary.
+ *
+ * The band spans 5 birth years and the curve is segmented over AGE, so a
+ * band can straddle a segment boundary. Overlap rule (§13.2): every birth
+ * year in the band contributes equally (1/5th), so each curve segment is
+ * weighted by the fraction of the band's years that fall inside it. Ages
+ * are (SGT year − birth year) — band-granularity data doesn't support
+ * birthday precision, and evaluating against `now` is what keeps the curve
+ * from rotting as the population ages through fixed bands.
+ */
+function scoreAge(facts, cfg, now) {
+  const min = cfg.minFactConfidence;
+  const band = factOf(facts, 'identity.birth_year_band', min);
+  if (!band) return unknown('no birth-year band on record');
+
+  const m = /^(\d{4})-(\d{4})$/.exec(String(band.value?.v || ''));
+  if (!m) return unknown('unparseable birth-year band');
+  const start = Number(m[1]);
+  const end = Number(m[2]);
+  // Ledger bands are taxonomy-validated to exactly 5 years; tolerate any
+  // sane span, but refuse to iterate a corrupt one.
+  if (end < start || end - start > 100) return unknown('unparseable birth-year band');
+
+  const curve = Array.isArray(cfg.ageCurve) ? cfg.ageCurve : [];
+  const year = sgtYear(now);
+  const values = [];
+  for (let y = start; y <= end; y += 1) {
+    // Future birth years (a not-yet-complete band edge) clamp to age 0 and
+    // take the curve's youngest segment rather than inventing negative ages.
+    const v = curveValueAt(curve, Math.max(0, year - y));
+    if (v !== null) values.push(v);
+  }
+  if (!values.length) return unknown('no usable age curve configured');
+
+  const fraction = clamp(values.reduce((s, v) => s + v, 0) / values.length, 0, 1);
+  return assessed(
+    fraction,
+    [band.observationId].filter(Boolean),
+    `born ${band.value.v} — age ${Math.max(0, year - end)}-${Math.max(0, year - start)} in ${year}`
+  );
+}
+
 /**
  * Coverage headroom — a PENALTY (−10..0). Someone already carrying life +
  * health + CI has little room left; someone explicitly carrying nothing has
@@ -393,6 +492,7 @@ const RULES = {
   life_events: (facts, telemetry, cfg, now) => scoreLifeEvents(facts, cfg, now),
   family_gap: (facts, telemetry, cfg) => scoreFamilyGap(facts, cfg),
   capacity: (facts, telemetry, cfg) => scoreCapacity(facts, cfg),
+  age: (facts, telemetry, cfg, now) => scoreAge(facts, cfg, now),
   coverage_headroom: (facts, telemetry, cfg) => scoreCoverageHeadroom(facts, cfg),
 };
 
@@ -405,6 +505,12 @@ export function normalizeConfig(configJson) {
     groups: { ...DEFAULT_SCORING_CONFIG.groups, ...(c.groups || {}) },
     components: { ...DEFAULT_SCORING_CONFIG.components, ...(c.components || {}) },
     decay: { ...DEFAULT_SCORING_CONFIG.decay, ...(c.decay || {}) },
+    // Top-level like decay/targetSegments, NOT inside components.age: the
+    // shallow components merge would let a later `{age:{maxPoints}}`
+    // recalibration row silently drop a curve nested there.
+    ageCurve: Array.isArray(c.ageCurve) && c.ageCurve.length
+      ? c.ageCurve
+      : DEFAULT_SCORING_CONFIG.ageCurve,
     targetSegments: Array.isArray(c.targetSegments) ? c.targetSegments : DEFAULT_SCORING_CONFIG.targetSegments,
     minFactConfidence: typeof c.minFactConfidence === 'number'
       ? c.minFactConfidence

--- a/backend/test/consumerEnrichment.test.js
+++ b/backend/test/consumerEnrichment.test.js
@@ -429,3 +429,38 @@ describe('relink bumps (§6.3)', () => {
     expect(loser).toBeTruthy()
   })
 })
+
+describe('the band reaches the Buy score (score/v3 — PR B seam)', () => {
+  it('a DOB-only capture scores Buy from age alone, under the migrated config, citing the band', async () => {
+    const prospect = await capture()
+    await drainAndQuiesce(prospect.id)
+
+    const { scoreOneConsumer, _resetConfigCache } = await import('../src/services/consumerScoringService.js')
+    _resetConfigCache()
+    const result = await scoreOneConsumer(prospect.consumerId, { force: true })
+    expect(result.status).toBe('scored')
+    // Pre-v3 this person was buyScore NULL — no fact component assessable.
+    expect(result.buyScore).not.toBeNull()
+
+    const profile = await ConsumerProfile.findByPk(prospect.consumerId)
+    // v3 semantics hold whether the config came from the 095 row (fresh-DB
+    // boot) or the code defaults (reused DB — migrations skip, table empty);
+    // the 095 row's own content is pinned by migration095ScoringAgeConfig.
+    expect(profile.scoringAlgorithmVersion).toBe('score/v3')
+    expect(profile.scoreBreakdown.groups.buy.components).toContain('age')
+
+    const comps = profile.scoreBreakdown.components
+    expect(comps.age.state).toBe('assessed')
+    const band = await ConsumerObservation.findOne({
+      where: { sourceProspectId: prospect.id, key: 'identity.birth_year_band', supersededAt: null },
+    })
+    expect(comps.age.basisObservationIds).toContain(band.id)
+
+    // Almost-everyone-scoreable must still read THIN: age is the only
+    // assessed Buy fact, and completeness says so.
+    expect(comps.capacity.state).toBe('unknown')
+    expect(comps.family_gap.state).toBe('unknown')
+    expect(profile.scoreBreakdown.completeness.total).toBe(8)
+    expect(profile.scoreBreakdown.completeness.assessed).toBeLessThan(4)
+  })
+})

--- a/backend/test/migration095ScoringAgeConfig.test.js
+++ b/backend/test/migration095ScoringAgeConfig.test.js
@@ -1,0 +1,137 @@
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { getApp, closeDb } from './helpers.js'
+import { sequelize } from '../src/models/index.js'
+import { normalizeConfig } from '../src/utils/consumerScoring.js'
+
+/**
+ * Migration 095 — the score/v3 config row (age curve, §13.2 / PR B).
+ *
+ * The append is what makes the change REAL in prod: the effective algorithm
+ * version comes from the config row, and the stored groups.buy decides
+ * whether age contributes to any sub-score at all. These tests pin the
+ * mutation (curve + weight + grouping added, predecessor weights preserved),
+ * idempotency, the dedupe guard on groups.buy, the down() surgical delete,
+ * and the empty-table no-op.
+ *
+ * SELF-CONTAINED STATE: boot only seeds config rows on the FIRST boot of a
+ * fresh database — `_migrations` bookkeeping is not a model table, so it
+ * survives sync({force:true}) while the re-created config table comes back
+ * empty and runMigrations() skips everything (runMigrations.js). So this
+ * file wipes the table and replays the 093→094→095 chain itself; every
+ * assertion is against state it built.
+ */
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const migrationsDir = path.join(__dirname, '../src/database/migrations')
+
+let up093, up094, up, down, queryInterface
+
+const rows = async () => {
+  const [r] = await sequelize.query(
+    'SELECT version, "configJson" FROM enrichment_scoring_configs ORDER BY version ASC'
+  )
+  return r
+}
+const top = async () => (await rows()).at(-1)
+
+beforeAll(async () => {
+  await getApp()
+  ;({ up: up093 } = await import(path.join(migrationsDir, '093-consumer-scores.js')))
+  ;({ up: up094 } = await import(path.join(migrationsDir, '094-scoring-recency-anchor.js')))
+  ;({ up, down } = await import(path.join(migrationsDir, '095-scoring-age-curve.js')))
+  queryInterface = sequelize.getQueryInterface()
+
+  await sequelize.query('DELETE FROM enrichment_scoring_configs')
+  await up093(queryInterface) // seeds v1 (score/v1); DDL is IF-NOT-EXISTS-safe
+  await up094(queryInterface) // appends v2 (score/v2)
+  await up(queryInterface) // appends v3 — the row under test
+})
+
+afterAll(async () => {
+  await closeDb()
+})
+
+describe('migration 095 — score/v3 age config row', () => {
+  it('the 093→095 chain leaves the v3 row on top: curve + age weight + Buy grouping, predecessor weights intact', async () => {
+    const all = await rows()
+    expect(all.map((r) => r.configJson.algorithmVersion)).toEqual(['score/v1', 'score/v2', 'score/v3'])
+
+    const v3 = all.at(-1).configJson
+    expect(v3.components.age).toEqual({ maxPoints: 10 })
+    expect(v3.groups.buy).toContain('age')
+    expect(v3.groups.buy.filter((n) => n === 'age')).toHaveLength(1)
+    expect(Array.isArray(v3.ageCurve)).toBe(true)
+    expect(v3.ageCurve.at(-1)).toEqual({ upTo: null, value: 0.3 })
+
+    // An algorithm re-version + one added component — every predecessor
+    // weight rides along untouched.
+    const v2 = all.at(-2).configJson
+    for (const [name, def] of Object.entries(v2.components)) {
+      expect(v3.components[name]).toEqual(def)
+    }
+    expect(v3.targetSegments).toEqual(v2.targetSegments)
+    expect(v3.decay).toEqual(v2.decay)
+
+    // The stored row survives the reader's merge with age grouped exactly once.
+    const merged = normalizeConfig(v3)
+    expect(merged.groups.buy.filter((n) => n === 'age')).toHaveLength(1)
+    expect(merged.ageCurve).toEqual(v3.ageCurve)
+  })
+
+  it('up() is idempotent — the highest row already carries score/v3', async () => {
+    const before = await rows()
+    await up(queryInterface)
+    expect(await rows()).toEqual(before)
+  })
+
+  it('down() deletes exactly the appended row; up() re-appends at MAX+1', async () => {
+    const before = await rows()
+    expect(before).toHaveLength(3)
+
+    await down(queryInterface)
+    const afterDown = await rows()
+    expect(afterDown).toHaveLength(2)
+    expect(afterDown.at(-1).configJson.algorithmVersion).toBe('score/v2')
+
+    await down(queryInterface) // no v3 on top — must touch nothing
+    expect(await rows()).toEqual(afterDown)
+
+    await up(queryInterface)
+    const restored = await top()
+    expect(restored.configJson).toEqual(before.at(-1).configJson)
+  })
+
+  it('does not duplicate age when the predecessor already grouped it', async () => {
+    const t = await top()
+    // A synthetic later calibration that already lists age but pins an older
+    // algorithm version (as a human recalibration row could).
+    const crafted = { ...t.configJson, algorithmVersion: 'score/v2' }
+    await sequelize.query(
+      `INSERT INTO enrichment_scoring_configs
+         (version, "configJson", "activatedAt", "actorUserId", "createdAt", "updatedAt")
+       VALUES (:v, :cfg::jsonb, now(), NULL, now(), now())`,
+      { replacements: { v: t.version + 1, cfg: JSON.stringify(crafted) } }
+    )
+
+    await up(queryInterface)
+    const appended = await top()
+    expect(appended.version).toBe(t.version + 2)
+    expect(appended.configJson.algorithmVersion).toBe('score/v3')
+    expect(appended.configJson.groups.buy.filter((n) => n === 'age')).toHaveLength(1)
+
+    await sequelize.query(
+      'DELETE FROM enrichment_scoring_configs WHERE version > :v',
+      { replacements: { v: t.version } }
+    )
+  })
+
+  it('an empty table inserts nothing — code defaults already carry v3', async () => {
+    // Runs LAST: it empties the table. Later-booting files see an empty
+    // table anyway (see the header) and the reader falls back to code
+    // defaults, so nothing leaks past this file.
+    await sequelize.query('DELETE FROM enrichment_scoring_configs')
+    await up(queryInterface)
+    expect(await rows()).toHaveLength(0)
+  })
+})

--- a/backend/test/unit/consumerScoring.test.js
+++ b/backend/test/unit/consumerScoring.test.js
@@ -210,16 +210,125 @@ describe('coverage headroom is a penalty, and only a COMPLETE list may penalize'
   })
 })
 
+describe('age is a curve over the current SGT year (§13.2)', () => {
+  test('a band inside the peak scores the full component', () => {
+    // 1985-1989 at 2026 ⇒ ages 37-41, all inside the 35-44 peak segment.
+    const r = score({ 'identity.birth_year_band': fact({ v: '1985-1989' }) })
+    const age = r.breakdown.components.age
+    expect(age.state).toBe('assessed')
+    expect(age.points).toBeCloseTo(10, 5)
+    expect(age.note).toMatch(/age 37-41 in 2026/)
+  })
+
+  test('a band straddling a boundary weights each segment by its share of the band', () => {
+    // 1995-1999 at 2026 ⇒ ages 27-31: three years in 25-29 (0.55), two in
+    // 30-34 (0.80) ⇒ (3×0.55 + 2×0.80)/5 = 0.65. A range match would have
+    // scored all five years identically with a cliff at 30.
+    const r = score({ 'identity.birth_year_band': fact({ v: '1995-1999' }) })
+    expect(r.breakdown.components.age.points).toBeCloseTo(6.5, 5)
+  })
+
+  test('the curve is defined over AGE — the same band scores differently as years pass', () => {
+    // A band-keyed table would freeze this and silently rot one band every
+    // five years; evaluating (SGT year − birth year) against `now` cannot.
+    const band = { 'identity.birth_year_band': fact({ v: '2000-2004' }) }
+    const at2026 = score(band)
+    const at2036 = scoreConsumer({ facts: band, telemetry: fullTelemetry, now: Date.UTC(2036, 6, 26, 9, 0, 0) })
+    // 2026: ages 22-26 ⇒ (3×0.25 + 2×0.55)/5 = 0.37.
+    // 2036: ages 32-36 ⇒ (3×0.80 + 2×1.00)/5 = 0.88.
+    expect(at2026.breakdown.components.age.points).toBeCloseTo(3.7, 5)
+    expect(at2036.breakdown.components.age.points).toBeCloseTo(8.8, 5)
+  })
+
+  test('the year rolls at SGT midnight, not UTC', () => {
+    // 2026-12-31 16:30 UTC is already 2027-01-01 00:30 SGT.
+    const band = { 'identity.birth_year_band': fact({ v: '2000-2004' }) }
+    const beforeSgt = scoreConsumer({ facts: band, telemetry: fullTelemetry, now: Date.UTC(2026, 11, 31, 15, 30) })
+    const afterSgt = scoreConsumer({ facts: band, telemetry: fullTelemetry, now: Date.UTC(2026, 11, 31, 16, 30) })
+    expect(beforeSgt.breakdown.components.age.note).toMatch(/in 2026/)
+    expect(afterSgt.breakdown.components.age.note).toMatch(/in 2027/)
+    // Ages 23-27 in 2027 ⇒ (2×0.25 + 3×0.55)/5 = 0.43, vs 0.37 in 2026.
+    expect(beforeSgt.breakdown.components.age.points).toBeCloseTo(3.7, 5)
+    expect(afterSgt.breakdown.components.age.points).toBeCloseTo(4.3, 5)
+  })
+
+  test('the default shape: low under 25, peak 35-44, easing after 50', () => {
+    const at = (b) => score({ 'identity.birth_year_band': fact({ v: b }) }).breakdown.components.age.points
+    const young = at('2005-2009') // ages 17-21 ⇒ 2.5
+    const rising = at('1995-1999') // ages 27-31 ⇒ 6.5
+    const peak = at('1985-1989') // ages 37-41 ⇒ 10
+    const easing = at('1975-1979') // ages 47-51 ⇒ 7
+    const older = at('1960-1964') // ages 62-66 ⇒ 3
+    expect(young).toBeLessThan(rising)
+    expect(rising).toBeLessThan(peak)
+    expect(peak).toBeGreaterThan(easing)
+    expect(easing).toBeGreaterThan(older)
+  })
+
+  test('age alone unlocks Buy — thin, low, and honest about it', () => {
+    const r = score({ 'identity.birth_year_band': fact({ v: '1985-1989' }) })
+    // The best-covered signal in the ledger must produce a number…
+    expect(r.buyScore).toBe(14) // 10 of raw 70
+    // …but even peak age stays low absent real evidence, and the breakdown
+    // still says how thin this is.
+    expect(r.breakdown.completeness).toEqual({ assessed: 3, total: 8 })
+    expect(r.breakdown.components.age.basisObservationIds).toContain('obs-1')
+  })
+
+  test('age is a prior — known family + income dominate it', () => {
+    const r = score({
+      'identity.birth_year_band': fact({ v: '1985-1989' }), // 10
+      'family.children_count_band': fact({ v: '2' }), // 0.85 × 20 = 17
+      'finance.annual_income_band': fact({ v: '80-120k' }), // 0.60 × 15 = 9
+    })
+    const c = r.breakdown.components
+    expect(c.family_gap.points + c.capacity.points).toBeGreaterThan(2 * c.age.points)
+  })
+
+  test('no band ⇒ unknown, never a fabricated middle-aged default', () => {
+    const r = score({})
+    expect(r.breakdown.components.age.state).toBe('unknown')
+    expect(r.buyScore).toBeNull()
+  })
+
+  test('a low-confidence band is ignored', () => {
+    const r = score({ 'identity.birth_year_band': fact({ v: '1985-1989' }, { confidence: 0.2 }) })
+    expect(r.breakdown.components.age.state).toBe('unknown')
+  })
+
+  test('curve values from config are clamped into 0..1', () => {
+    const wild = { ...DEFAULT_SCORING_CONFIG, ageCurve: [{ upTo: null, value: 3 }] }
+    const r = score({ 'identity.birth_year_band': fact({ v: '1985-1989' }) }, fullTelemetry, wild)
+    expect(r.breakdown.components.age.points).toBeCloseTo(10, 5) // 1.0 × 10, never 3 × 10
+  })
+
+  test('the curve is config, not code — a replacement row takes effect without a deploy', () => {
+    const flat = { ...DEFAULT_SCORING_CONFIG, ageCurve: [{ upTo: null, value: 0.5 }] }
+    const r = score({ 'identity.birth_year_band': fact({ v: '1985-1989' }) }, fullTelemetry, flat)
+    expect(r.breakdown.components.age.points).toBeCloseTo(5, 5)
+  })
+
+  test('a curve with no open tail leaves out-of-range ages unknown, not zero', () => {
+    const capped = { ...DEFAULT_SCORING_CONFIG, ageCurve: [{ upTo: 44, value: 1 }] }
+    // 1960-1964 at 2026 ⇒ ages 62-66, beyond every segment.
+    const r = score({ 'identity.birth_year_band': fact({ v: '1960-1964' }) }, fullTelemetry, capped)
+    expect(r.breakdown.components.age.state).toBe('unknown')
+    expect(r.breakdown.components.age.note).toMatch(/no usable age curve/)
+  })
+})
+
 describe('arithmetic discipline', () => {
   test('rounds exactly once — sub-scores derive from unrounded points', () => {
     const r = score({
       'finance.annual_income_band': fact({ v: '80-120k' }),
       'family.children_count_band': fact({ v: '1' }),
     })
-    // capacity = 0.60 × 15 = 9 ; family = 0.60 × 20 = 12 ⇒ 21/60 = 35%
+    // capacity = 0.60 × 15 = 9 ; family = 0.60 × 20 = 12 ⇒ 21/70 = 30%
+    // (raw max is 70 since v3 added age — unknown age dilutes, same as
+    // unknown market_fit always has on the Meet side).
     expect(r.breakdown.components.capacity.points).toBeCloseTo(9, 5)
     expect(r.breakdown.components.family_gap.points).toBeCloseTo(12, 5)
-    expect(r.buyScore).toBe(35)
+    expect(r.buyScore).toBe(30)
   })
 
   test('scores stay inside 0..100', () => {
@@ -311,8 +420,8 @@ describe('breakdown is explainable', () => {
 
   test('completeness counts what we actually know', () => {
     const r = score({ 'finance.annual_income_band': fact({ v: '40-80k' }) })
-    // engagement + contactability + capacity assessed of 7 components.
-    expect(r.breakdown.completeness).toEqual({ assessed: 3, total: 7 })
+    // engagement + contactability + capacity assessed of 8 components.
+    expect(r.breakdown.completeness).toEqual({ assessed: 3, total: 8 })
   })
 })
 
@@ -341,6 +450,15 @@ describe('the first real consumer through the pipe', () => {
   test('market fit stays unknown until a language question is asked', () => {
     // Her campaign enabled annual_income + children only — no language.
     expect(score(shavon).breakdown.components.market_fit.state).toBe('unknown')
+  })
+
+  test('her band contributes as a prior — the v3 gain over scoring it zero', () => {
+    const r = score(shavon)
+    const age = r.breakdown.components.age
+    expect(age.state).toBe('assessed')
+    // 1995-1999 at 2026 ⇒ ages 27-31 straddling 25-29/30-34 ⇒ 0.65 × 10.
+    expect(age.points).toBeCloseTo(6.5, 5)
+    expect(age.basisObservationIds).toContain('obs-birth')
   })
 })
 


### PR DESCRIPTION
Phase 1 of per-campaign lead scoring (§13.2 / §14 "PR B — age curve + DOB backfill"): age is the best-covered signal in the database — 129 of 130 consumers have a DOB — and until now it contributed zero. This PR makes it count, through the ledger, without a new backfill path.

## The engine change (`score/v3`)

New `age` component in `consumerScoring.js`, following every engine convention (pure, no I/O, `now` injected, fraction 0..1 × config `maxPoints`, sign only ever in `maxPoints`):

- **A curve, not a range match.** Piecewise segments over **age in years**, evaluated against the **current SGT year** — never over birth-year-band strings, which would silently rot one band every five years as the population ages through it. Same band, different year ⇒ different score (pinned by test).
- **Band-straddle rule (§13.2):** the ledger stores 5-year birth bands, so a band can straddle a segment boundary. Each birth year in the band contributes equally (1/5th) — i.e. each segment is weighted by the fraction of the band inside it. `1995-1999` in 2026 ⇒ ages 27–31 ⇒ 3/5 × 0.55 + 2/5 × 0.80 = 0.65.
- **Weighted as a prior:** `maxPoints: 10` vs family_gap 20 / capacity 15 — when income and children are actually known, they dominate.
- **Curve lives in config**, top-level `ageCurve` beside `decay`/`targetSegments` (not nested in `components.age`, where the shallow components merge would let a later `{age:{maxPoints}}` recalibration row silently drop it). Seed shape: under-25 low → rising 25-29 → peak 35-44 → easing after 50. Engine clamps stored curve values into 0..1.
- Grouped into **Buy** and into `FACT_COMPONENTS`, so a band alone unlocks the Buy score.

**Deliberate consequence:** Buy was NULL for 129/130 people (no fact component assessed). After the backfill nearly everyone becomes scoreable — a peak-age band alone yields Buy 14/100, and the breakdown stays honest about thinness: age's raw max dilutes like any other unknown, completeness reads `3 of 8 components assessed`, and the profile UI already renders that verbatim (`AdminV2LeadProfile.jsx:625-628`) plus "the unknowns above are questions nobody has been asked". No frontend change needed (component label falls back to `age`).

## Migration 095 — the row that makes it real

The effective algorithm version comes from the **stored config row** (`consumerScoringService.js:208`), and the live row pins `score/v2` — bumping the code constant alone would recompute nothing, and the stored `groups.buy` would leave age ungrouped. 095 follows 094's append-only pattern: copy the highest row, stamp `score/v3`, add `components.age`, append `age` to `groups.buy` (dedupe-guarded), add `ageCurve`. Explicit `createdAt`/`updatedAt` (sync-from-models trap). `down()` deletes exactly the appended row via strip-compare against its predecessor. Every stored score then recomputes as config-stale on the next nightly sweep.

## Step 1 — the backfill needed no new code (verified, not assumed)

`backend/scripts/remap-observations.mjs` already re-derives mapper observations for the existing population through the normal path: `buildFactSnapshot` maps `demographics.dateOfBirth` → `birthYearToBand` → `identity.birth_year_band` (`factMapperService.js:115-119`, `factTaxonomy.js:198-203`), erasure runs through `withConsumerFence` (job → `cancelled`), and the artifact unique index spans `pipelineVersion`, so re-runs are idempotent and pre-pipeline prospects get fresh jobs.

**Prod audit (read-only, 27 Jul):** all 135 prospect DOB values are strict `YYYY-MM-DD`, years 1960–2001 — inside `birthYearToBand`'s 1920–2029 window, every one maps. 130 live consumers, 0 erased, 129 with a DOB-bearing prospect, exactly 1 active band observation, and only 2 map jobs ever (both `done` at current `mapper/v1.1+tax-v2`).

**Live-fire rehearsal (local Postgres, the actual script):** seeded the pre-question shape (DOB-bearing prospects, zero jobs/observations, incl. one erased consumer) —
- flag off ⇒ refuses (exit 1); `--dry-run` ⇒ scans, enqueues nothing
- real run ⇒ `scanned=6 enqueued=6 done=5 cancelled=1`; all 5 bands minted with capture-identical provenance (`source=form`, `confidence=1`, `pipeline=mapper`, `form:<prospectId>` artifact)
- erased consumer ⇒ 0 observations, job `cancelled/consumer erased`
- second run ⇒ mints nothing; then `scoreOneConsumer` on a backfilled band alone ⇒ `buy=14`

## Test plan (all against local Postgres per CLAUDE.md)

- unit: **1878/1878, exit 0** (12 new age tests: straddle math, SGT-midnight year roll, same-band-different-year, prior-vs-facts dominance, clamping, no-tail curve ⇒ unknown, low-confidence ignored, Buy-unlock + honest completeness; Shavon's real fixture now pins the band path)
- integration + root suites in band: **128/128 suites, 2554 passed / 3 skipped, exit 0** (new e2e seam test: capture → drain → band → `score/v3` Buy with the band observation in `basisObservationIds`; new self-contained migration-095 suite: chain replay, idempotency, dedupe guard, surgical down, empty-table no-op)
- migrations suite: **30/30, exit 0** · `eslint src/ --quiet` exit 0 in `backend/` and repo root
- retellScreening: fully green at ~02:00 SGT — outside the call window — so the known time-of-day flake did not fire this run (consistent with the Phase-0 fix having landed in #294). One first-pass red did occur — `redeemOpsPartners.test.js`, 8 × superagent `Parse Error: Expected HTTP/` while two full eslint passes ran concurrently on the same machine; it passed 28/28 in isolation and the full in-band step re-run alone was 128/128 with zero parse errors, so it was local load, not a regression (and no causal path exists from a pure scoring change to an HTTP-parse failure in the partner CRM).

## Deploy / backfill runbook

1. Merge → deploy (migration 095 runs on boot; sweep starts recomputing everyone under v3 — Buy stays NULL for the 129 until the backfill lands their bands).
2. On the backend service (`ENRICHMENT_MAP_ARTIFACT_JOBS` already true in prod since #284 — verify before running): `node scripts/remap-observations.mjs --dry-run`, review counts, then run it for real. Expect ~135 scanned / ~129 consumers gaining `identity.birth_year_band`.
3. Next 00:02 SGT sweep (or `scoreOneConsumer --force` spot checks) materializes Buy for the backfilled population.
4. Rollback: revert + `down()` removes only the appended config row; backfilled observations are plain ledger rows — additive and harmless under v2 scoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127w4fTdWuoNTSZbBexNN8Z
