### PR TITLE
fix(draw): key the boost receipt's param order to the template name, not the deploy

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -190,13 +190,23 @@ WHATSAPP_PHONE_NUMBER_ID=
 # WHATSAPP_CLAIM_ORIGIN=https://redeem.sg
 # Send the voucher QR as an image header (default true; "false" = text only)
 # WHATSAPP_QR_HEADER=true
-# Approved template names — override only if renamed in WhatsApp Manager.
+# Approved template NAMES — override only if renamed in WhatsApp Manager.
+# Every WHATSAPP_TEMPLATE_* below takes a template name, never true/false: the
+# value goes to Meta verbatim as template.name, so "true" makes every send on
+# that rail fail with 132001 (template not found). Only WHATSAPP_QR_HEADER
+# above is a boolean. Confirm the name AND its category first with:
+#   pbpaste | node backend/scripts/submit-wa-marketing-templates.mjs --all --token-stdin
+# MARKETING templates are accepted (HTTP 200) and then silently dropped under
+# Meta's per-user frequency cap (131049) — the whole reason the _v2 pair exists.
 # WHATSAPP_TEMPLATE_PASS=reward_pass
-# WHATSAPP_TEMPLATE_VOUCHER=reward_voucher
+# WHATSAPP_TEMPLATE_VOUCHER=reward_voucher_v2
 # Draw entry pass — UTILITY, 4 params (name, draw, pass link, boost deadline)
 # WHATSAPP_TEMPLATE_DRAW_PASS=draw_entry_pass
-# Draw ×N boost receipt
-# WHATSAPP_TEMPLATE_DRAW_BOOST=draw_boost_receipt
+# Draw ×N boost receipt — UTILITY, 3 params whose ORDER follows the body, which
+# is keyed by name in whatsappService (re-read the live body before adding one):
+#   draw_boost_receipt, draw_session_receipt → (name, draw, chances)
+#   draw_boost_receipt_v2 and newer          → (name, chances, draw)
+# WHATSAPP_TEMPLATE_DRAW_BOOST=draw_boost_receipt_v2
 # Screening callback opt-in — MARKETING, 4 params; URL button = consent tap
 # WHATSAPP_TEMPLATE_DRAW_CALLBACK=draw_callback_optin
 

--- a/backend/src/services/redeemOps/whatsappService.js
+++ b/backend/src/services/redeemOps/whatsappService.js
@@ -47,6 +47,20 @@ function qrHeaderEnabled() {
   return String(process.env.WHATSAPP_QR_HEADER ?? 'true').toLowerCase() !== 'false';
 }
 
+/**
+ * Boost-receipt bodies that name the draw at {{2}} and the chances count at
+ * {{3}} — the older phrasing ("your entry to the {{2}} now holds {{3}} chances",
+ * "Campaign: {{2}} / Entry total after this session: ×{{3}}"). Everything since
+ * says it the way people say it — "you now have ×10 chances for the iPhone 17
+ * Pro Lucky Draw" — so the count comes second and unlisted names get that
+ * order, the direction of travel. Verified against the live bodies on
+ * 2026-07-27; `draw_boost_receipt_v2` is deliberately NOT here.
+ * See sendBoostReceiptWhatsApp for why the order is keyed by name at all.
+ */
+const BOOST_TEMPLATES_DRAW_NAME_SECOND = new Set([
+  'draw_boost_receipt', 'draw_session_receipt',
+]);
+
 /** Host baked into the templates' body link — the WA channel standardizes on redeem.sg. */
 function claimOrigin() {
   return process.env.WHATSAPP_CLAIM_ORIGIN || 'https://redeem.sg';
@@ -378,24 +392,29 @@ export function makeWhatsappService(overrides = {}) {
    * IMAGE header — the QR-less celebration state (giant ×N; the pass is
    * consumed, nothing left to scan); 3 params = name, multiplier, draw name.
    *
-   * THE ORDER IS THE TEMPLATE'S, NOT OURS. v2 reads "You now have *{{2}}
-   * chances* for the {{3}}" — the reverse of the retired MARKETING original
-   * ("your entry to the {{2}} now holds {{3}} chances"). Params are positional
-   * with no per-template remap, so the default name and this array must move
-   * together: pointing WHATSAPP_TEMPLATE_DRAW_BOOST back at the original, or
-   * at any future reworded twin, silently swaps the draw name and the
-   * multiplier in the customer's message. It shipped that way to two
-   * recipients on 2026-07-26 ("*iPhone 17 Pro Lucky Draw chances* for the 10")
-   * because the v2 rewording that won the UTILITY category moved the
-   * placeholders and nothing here followed. Re-read the live body before
-   * flipping the env name. */
+   * THE ORDER IS THE TEMPLATE'S, NOT OURS, so it is keyed by the RESOLVED NAME
+   * rather than fixed per deploy. v2 reads "You now have *{{2}} chances* for
+   * the {{3}}" — the reverse of the retired MARKETING original ("your entry to
+   * the {{2}} now holds {{3}} chances"). Params are positional with no
+   * per-template remap, and Meta's approval and the Render env flip are two
+   * manual steps that cannot be made simultaneous: binding the order to the
+   * name is what keeps every intermediate state correct, instead of whichever
+   * half lands first sending "*iPhone 17 Pro Lucky Draw chances* for the 10" —
+   * which is exactly what two recipients got on 2026-07-26, when the rewording
+   * that won v2 the UTILITY category moved the placeholders and nothing here
+   * followed. Re-read the live body (`--all` on the submit script, or Graph
+   * `fields=components`) before adding a name; assuming a twin inherited its
+   * predecessor's wording is the mistake that caused this. */
   async function sendBoostReceiptWhatsApp({ prospect, drawCtx }) {
+    const templateName = process.env.WHATSAPP_TEMPLATE_DRAW_BOOST || 'draw_boost_receipt_v2';
+    const drawName = cleanParam(drawCtx?.drawName, 'the lucky draw');
+    const multiplier = String(drawCtx?.multiplier || 10);
     return sendTemplate({
       prospect,
-      templateName: process.env.WHATSAPP_TEMPLATE_DRAW_BOOST || 'draw_boost_receipt_v2',
+      templateName,
       card: {
         state: 'boost',
-        rewardName: cleanParam(drawCtx?.drawName, 'the lucky draw'),
+        rewardName: drawName,
         partnerName: 'Lucky draw',
         draw: {
           multiplier: drawCtx?.multiplier,
@@ -406,8 +425,9 @@ export function makeWhatsappService(overrides = {}) {
       },
       params: [
         cleanParam(prospect?.firstName, 'there'),
-        String(drawCtx?.multiplier || 10),
-        cleanParam(drawCtx?.drawName, 'the lucky draw'),
+        ...(BOOST_TEMPLATES_DRAW_NAME_SECOND.has(templateName)
+          ? [drawName, multiplier]
+          : [multiplier, drawName]),
       ],
     });
   }

--- a/backend/src/tests/whatsappService.test.js
+++ b/backend/src/tests/whatsappService.test.js
@@ -261,11 +261,32 @@ describe('QR-header send sequence (default: header ON)', () => {
     // comes BEFORE the draw name. Reversing these renders "*iPhone 17 Pro Lucky
     // Draw chances* for the 10", which is what two recipients actually got on
     // 2026-07-26: the template was reworded to win the UTILITY category and the
-    // caller kept the MARKETING original's order. Positional params, no remap —
-    // so the name on the line above and this array are one decision.
+    // caller kept the MARKETING original's order.
     expect(send.body.template.components[1].parameters.map((p) => p.text)).toEqual([
       'Sarah', '10', 'iPhone 17 Pro Lucky Draw',
     ]);
+  });
+
+  // Meta approval and the Render env flip are two manual steps that cannot land
+  // at the same instant, so BOTH orders have to be correct while the rails are
+  // mid-migration — that is the whole reason the order is keyed by name.
+  it.each([
+    ['draw_boost_receipt', ['Sarah', 'iPhone 17 Pro Lucky Draw', '10']],   // legacy: draw name {{2}}
+    ['draw_session_receipt', ['Sarah', 'iPhone 17 Pro Lucky Draw', '10']], // "Campaign: {{2}} / ×{{3}}"
+    ['draw_boost_receipt_v2', ['Sarah', '10', 'iPhone 17 Pro Lucky Draw']],
+    ['draw_boost_receipt_v9', ['Sarah', '10', 'iPhone 17 Pro Lucky Draw']], // unknown → newer order
+  ])('boost receipt: %s gets the param order its body asks for', async (name, expected) => {
+    enableWithCreds();
+    process.env.WHATSAPP_TEMPLATE_DRAW_BOOST = name;
+    const fetch = fetchRecorder();
+    const svc = makeSvc({ fetch, card: cardRecorder() });
+    await svc.sendBoostReceiptWhatsApp({
+      prospect: consented,
+      drawCtx: { drawName: 'iPhone 17 Pro Lucky Draw', multiplier: 10 },
+    });
+    const send = fetch.calls[1];
+    expect(send.body.template.name).toBe(name);
+    expect(send.body.template.components[1].parameters.map((p) => p.text)).toEqual(expected);
   });
 
   it('WHATSAPP_CLAIM_ORIGIN overrides the pass-QR host (and the card wordmark follows)', async () => {


### PR DESCRIPTION
Follow-up to #291, adopting the better half of the sibling branch `feat/wa-boost-receipt-v3` (`7c65d68`), which found the same bug independently.

## Why #291 wasn't enough

It hardcoded the new param order. That's only correct while every environment points at the same template — and Meta's approval and the Render env flip are two manual steps that can't land at the same instant. During that window a single order is wrong, and being wrong here means the customer reads:

> You now have **iPhone 17 Pro Lucky Draw chances** for the 10.

## What changes

Order follows the resolved template name:

| Template | `{{2}}` | `{{3}}` |
|---|---|---|
| `draw_boost_receipt`, `draw_session_receipt` | draw name | chances |
| `draw_boost_receipt_v2` and newer (default) | chances | draw name |

Unlisted names take the newer order, so a future twin is right by default and only the legacy pair needs naming.

## The one correction to the sibling branch

Its set puts `draw_boost_receipt_v2` on the legacy side. The live body disagrees — read from Graph twice on 2026-07-27:

```
draw_boost_receipt_v2 [UTILITY/APPROVED]
  "Hi {{1}}, your completed review has been recorded. \n\nYou now have *{{2}} chances* for the {{3}}. …"
```

So `v2` moves to the newer side and the default stays `_v2` (the UTILITY template that survives the 131049 frequency cap; the original is MARKETING). `draw_session_receipt` was checked the same way and genuinely is legacy-ordered — `Campaign: {{2}} / Entry total after this session: ×{{3}}`.

Worth noting for whoever owns that branch: `draw_boost_receipt_v3`'s body is `v2`'s copy verbatim bar one whitespace, and it's MARKETING/PENDING against `v2`'s UTILITY/APPROVED — so there's no state where wiring v3 beats v2.

## Test

Table-driven over all four cases including an unknown name. The failure mode is a template nobody re-read, so the guard has to be the mapping itself, not one representative path.

## Verification

- `jest src/tests/whatsappService.test.js` — 33/33
- `jest test/unit/drawScanDoor.test.js src/tests/entitlementDeliveryFanout.test.js` — 19/19
- `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWFUedSiPDdyKp62vcYCdt
