### PR TITLE
feat(enrichment): the language question offers all four official languages

### DIFF
--- a/backend/src/utils/profileQuestionLibrary.js
+++ b/backend/src/utils/profileQuestionLibrary.js
@@ -26,9 +26,15 @@ export const PROFILE_QUESTION_LIBRARY = [
     multi: false,
     prompt: 'Which language do you prefer?',
     promptZh: '您偏好哪种语言？',
+    // Singapore's four official languages, each labelled in its own script.
+    // The taxonomy has always accepted en|zh|ms|ta (factTaxonomy LANGUAGES) —
+    // ms and ta were simply never offered, so no market-fit segment keyed to
+    // Malay or Tamil could ever match on language.
     options: [
       { id: 'en', label: 'English' },
       { id: 'zh', label: '中文' },
+      { id: 'ms', label: 'Bahasa Melayu' },
+      { id: 'ta', label: 'தமிழ்' },
     ],
   },
   {
@@ -95,7 +101,7 @@ export const getProfileQuestion = (id) => byId.get(id) || null;
 
 // Single-select answer → taxonomy value.
 const SINGLE_VALUES = {
-  language: { en: { v: 'en' }, zh: { v: 'zh' } },
+  language: { en: { v: 'en' }, zh: { v: 'zh' }, ms: { v: 'ms' }, ta: { v: 'ta' } },
   annual_income: {
     lt40: { v: '<40k' }, '40to80': { v: '40-80k' }, '80to120': { v: '80-120k' },
     '120to200': { v: '120-200k' }, gt200: { v: '>200k' },

--- a/backend/test/unit/profileQuestionLibrary.test.js
+++ b/backend/test/unit/profileQuestionLibrary.test.js
@@ -50,6 +50,13 @@ describe('profileQuestionLibrary', () => {
     expect(resolveAnswer('children', 'three_plus')).toEqual({ v: '3_plus' });
   });
 
+  test('language offers all four official languages, each resolving to its taxonomy code', () => {
+    const lang = getProfileQuestion('language');
+    expect(lang.options.map((o) => o.id)).toEqual(['en', 'zh', 'ms', 'ta']);
+    expect(resolveAnswer('language', 'ms')).toEqual({ v: 'ms' });
+    expect(resolveAnswer('language', 'ta')).toEqual({ v: 'ta' });
+  });
+
   test('pets multi: server composes the complete canonical collection', () => {
     expect(resolveAnswer('pets', ['cat', 'dog'])).toEqual({ v: ['cat', 'dog'], complete: true });
     expect(resolveAnswer('pets', ['dog', 'cat'])).toEqual({ v: ['cat', 'dog'], complete: true }); // canonical order

--- a/docs/plans/studio-profile-questions.md
+++ b/docs/plans/studio-profile-questions.md
@@ -47,7 +47,7 @@ from per-option values). [R1 #6]
 
 | id | factKey | Shape | resolveAnswer contract |
 |---|---|---|---|
-| `language` | `identity.preferred_language` | single | en/zh → `{v}` |
+| `language` | `identity.preferred_language` | single | en/zh/ms/ta → `{v}` (all four official languages, 2026-07-27; the taxonomy always allowed them) |
 | `annual_income` | `finance.annual_income_band` | single | 5 bands verbatim |
 | `children` | `family.children_count_band` (**new key**, §4) | single | none/1/2/3+ → `{v:'0'\|'1'\|'2'\|'3_plus'}` |
 | `pets` | `household.pets` | multi | dog/cat/other/none chips → canonical-ordered, deduped `{v:[…], complete:true}`; `none` EXCLUSIVE (none+dog ⇒ invalid answer, dropped); prompt copy is "select all that apply" so `complete:true` is honest |

--- a/src/components/campaigns/__tests__/CampaignSignupForm.test.jsx
+++ b/src/components/campaigns/__tests__/CampaignSignupForm.test.jsx
@@ -625,6 +625,13 @@ describe('CampaignSignupForm — profile questions block (studio-profile-questio
     expect(block.textContent).not.toContain('retire');
   });
 
+  it('offers all four official languages as chips', () => {
+    renderForm({ profileQuestions: PQ });
+    for (const label of ['English', '中文', 'Bahasa Melayu', 'தமிழ்']) {
+      expect(screen.getByRole('button', { name: label })).toBeTruthy();
+    }
+  });
+
   it('single-select toggles on and off (skippable by design)', () => {
     renderForm({ profileQuestions: PQ });
     const en = screen.getByRole('button', { name: 'English' });

--- a/src/lib/profileQuestionLibrary.js
+++ b/src/lib/profileQuestionLibrary.js
@@ -26,9 +26,15 @@ export const PROFILE_QUESTION_LIBRARY = [
     multi: false,
     prompt: 'Which language do you prefer?',
     promptZh: '您偏好哪种语言？',
+    // Singapore's four official languages, each labelled in its own script.
+    // The taxonomy has always accepted en|zh|ms|ta (factTaxonomy LANGUAGES) —
+    // ms and ta were simply never offered, so no market-fit segment keyed to
+    // Malay or Tamil could ever match on language.
     options: [
       { id: 'en', label: 'English' },
       { id: 'zh', label: '中文' },
+      { id: 'ms', label: 'Bahasa Melayu' },
+      { id: 'ta', label: 'தமிழ்' },
     ],
   },
   {
@@ -95,7 +101,7 @@ export const getProfileQuestion = (id) => byId.get(id) || null;
 
 // Single-select answer → taxonomy value.
 const SINGLE_VALUES = {
-  language: { en: { v: 'en' }, zh: { v: 'zh' } },
+  language: { en: { v: 'en' }, zh: { v: 'zh' }, ms: { v: 'ms' }, ta: { v: 'ta' } },
   annual_income: {
     lt40: { v: '<40k' }, '40to80': { v: '40-80k' }, '80to120': { v: '80-120k' },
     '120to200': { v: '120-200k' }, gt200: { v: '>200k' },


### PR DESCRIPTION
## Why

The profile question asks **"Which language do you prefer?"** and then offered only **English** and **中文**. A Malay- or Tamil-preferring lead had nothing honest to tap, and — because market fit is language-primary (`consumerScoring.js` §7.2) — no target segment keyed to `ms`/`ta` could ever match on language. It could only match on the half-strength ethnicity proxy.

The taxonomy has always accepted `en|zh|ms|ta` (`factTaxonomy.js` `LANGUAGES`). The **collection surface** was the entire gap.

## What

| File | Change |
|---|---|
| `src/lib/profileQuestionLibrary.js` ↔ `backend/src/utils/profileQuestionLibrary.js` | `{ id: 'ms', label: 'Bahasa Melayu' }` + `{ id: 'ta', label: 'தமிழ்' }` chips, plus their `SINGLE_VALUES` rows → `{v:'ms'}` / `{v:'ta'}`. Twins stay byte-identical (parity test enforces). |
| `backend/test/unit/profileQuestionLibrary.test.js` | Pins option order `en,zh,ms,ta`; asserts both new resolutions. The existing round-trip test now also drives them through `validateFact`. |
| `src/components/campaigns/__tests__/CampaignSignupForm.test.jsx` | Asserts all four chips render on the funnel. |
| `docs/plans/studio-profile-questions.md` §2 | Table row → `en/zh/ms/ta`. |

No change was needed in the Studio Form panel or the funnel renderer — both iterate the library instead of hardcoding chips.

## Two judgment calls

- **Labels are endonyms**, matching the existing `English` / `中文` convention. Albert Sans carries neither CJK nor Tamil, so both fall back to `system-ui` — the same path `中文` has always taken.
- **Prompt copy is untouched.** Translating prompts into four languages would collide with the specced locale rule (English + inline Chinese) and the `showZh` toggle, which is Chinese-specific. Separate decision if wanted.

## Safety

Purely additive. Existing `en`/`zh` answers resolve exactly as before, so the observation remap has nothing to re-derive — and the profile library is code-fixed, so re-resolution cannot drift (`factMapperService.js`). The Joi schema at `validation.js:290` already admits any `[a-z][a-z0-9_]{0,31}` option id; `resolveAnswer` remains the semantic gate.

## Verification

- Backend: `profileQuestionLibrary`, `factTaxonomy`, `factMapperSnapshot`, `consumerScoring` — **103 passed**
- Frontend: `CampaignSignupForm`, `editTargets` — **72 passed**
- `eslint` clean on both touched source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWFUedSiPDdyKp62vcYCdt