### PR TITLE
feat(scoring): stamp who a WhatsApp was sent for, at send time (Phase 3, PR A₁)

### DIFF
--- a/backend/src/database/migrations/096-wa-message-sends.js
+++ b/backend/src/database/migrations/096-wa-message-sends.js
@@ -1,0 +1,64 @@
+/**
+ * 096 — WhatsApp send-time ownership (docs/plans/per-campaign-lead-scoring.md §5).
+ *
+ * Phase 3 scores a `read` as a response to ONE lead's pitch, so it must know
+ * which lead a message was sent for. Nothing recorded that. `deliveryReceipts`
+ * joins redemption_events → wa_message_statuses on wamid and filters by
+ * entitlement ids drawn from the person's whole journey
+ * (leadProfileService.js:100-119) — it never touches activations or campaigns.
+ * Reconstructing ownership afterwards is unsafe rather than merely missing:
+ * receipts carry no immutable campaign snapshot
+ * (redeemOps/entitlementService.js:211) and activations can be relinked
+ * (redeemOps/activationService.js:117,153), so a historical send can be
+ * attributed to the WRONG campaign. Screening-callback WhatsApps write no
+ * receipt at all — their wamid lives only in
+ * prospects.screeningMetadata.waCallback (retellScreeningService.js:521-529).
+ *
+ * So ownership is STAMPED AT SEND and never derived. The webhook keeps writing
+ * wa_message_statuses keyed by wamid, untouched
+ * (redeemOps/waWebhookService.js:73,154); scoping becomes a join on wamid.
+ *
+ * NO FOREIGN KEYS — snapshot semantics, the same reasoning §9 applies to the
+ * config's campaignId. Campaigns can be permanently deleted
+ * (campaignService.js:1032-1035) while their prospects survive with campaignId
+ * nulled (014-add-cascade-rules.js:87). A CASCADE would destroy the ownership
+ * of messages whose lead is still alive and still scoring; SET NULL would
+ * silently re-home a dead campaign's sends. A bare UUID does neither.
+ *
+ * BACKFILL: none is possible. Ownership was never recorded, and inferring it
+ * is precisely the unsafe operation this table exists to replace. Sends made
+ * before this migration simply do not score. Stated, not hidden.
+ *
+ * campaignId is NULLABLE and this is deliberate — see the model for why.
+ */
+export async function up(queryInterface) {
+  const q = (sql) => queryInterface.sequelize.query(sql);
+
+  await q(`CREATE TABLE IF NOT EXISTS wa_message_sends (
+    wamid VARCHAR(128) PRIMARY KEY,
+    "prospectId" UUID NOT NULL,
+    "campaignId" UUID,
+    "consumerId" UUID,
+    kind VARCHAR(24) NOT NULL,
+    "sentAt" TIMESTAMPTZ NOT NULL,
+    "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  )`);
+
+  // The scoring join: "every message owned by this lead".
+  await q(`CREATE INDEX IF NOT EXISTS idx_wa_sends_prospect
+    ON wa_message_sends ("prospectId")`);
+
+  // Erasure deletes by consumer. Plain, not partial, so the shape the model
+  // declares and the shape this migration builds are the same index — the
+  // test schema comes from sync({force:true}) on the MODEL, so a divergence
+  // here is a divergence nothing would catch (CLAUDE.md, "test schema ≠ prod
+  // schema").
+  await q(`CREATE INDEX IF NOT EXISTS idx_wa_sends_consumer
+    ON wa_message_sends ("consumerId")`);
+}
+
+export async function down(queryInterface) {
+  const q = (sql) => queryInterface.sequelize.query(sql);
+  await q('DROP TABLE IF EXISTS wa_message_sends');
+}

--- a/backend/src/models/WaMessageSend.js
+++ b/backend/src/models/WaMessageSend.js
@@ -1,0 +1,68 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * WhatsApp message OWNERSHIP, stamped at send time (migration 096,
+ * docs/plans/per-campaign-lead-scoring.md §5).
+ *
+ * The twin of WaMessageStatus: that table records what HAPPENED to a wamid
+ * (Meta's frontier — sent < delivered < read, failed terminal); this one
+ * records who it was FOR. Phase 3 scores a `read` as a response to one lead's
+ * pitch, and the two facts only combine over a wamid join.
+ *
+ * IMMUTABLE BY CONTRACT. Every column is a snapshot of the send, not a live
+ * pointer: rows are written once and never updated, so a later relink, a
+ * campaign delete, or an owner move cannot retroactively re-attribute a
+ * message that was already sent. That is the whole point — §5 rejected
+ * derived ownership because derivation gives a DIFFERENT answer later.
+ *
+ * NO FOREIGN KEYS, for the same reason (see the migration).
+ *
+ * campaignId is NULLABLE, deviating from the plan's sketch. A lead can
+ * legitimately carry no campaign at send time — the capture API treats
+ * campaignId as optional (validation.js:219, passed through as
+ * `campaignId || null` at prospectService.js:1066-1069) and a permanent
+ * campaign delete nulls it on surviving prospects
+ * (014-add-cascade-rules.js:87). NOT NULL would force the writer to drop the
+ * ownership row exactly when a campaignless lead is messaged, which loses the
+ * lead attribution (prospectId) to protect a snapshot that is only ever
+ * supporting evidence. prospectId is the ownership; campaignId is what keeps
+ * the row interpretable after the lead's own campaignId has moved on.
+ */
+const WaMessageSend = sequelize.define('WaMessageSend', {
+  wamid: {
+    type: DataTypes.STRING(128),
+    primaryKey: true,
+    comment: 'Meta message id — joins wa_message_statuses',
+  },
+  prospectId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    comment: 'The lead this message was sent for — immutable, never derived',
+  },
+  campaignId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    comment: "Campaign as of the send. NULL = the lead carried none; NOT a live lookup",
+  },
+  consumerId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    comment: 'Person as of the send — the PDPA erasure key for this table',
+  },
+  kind: {
+    type: DataTypes.STRING(24),
+    allowNull: false,
+    comment: 'pass | draw_pass | voucher | boost_receipt | screening_callback',
+  },
+  sentAt: { type: DataTypes.DATE, allowNull: false },
+}, {
+  tableName: 'wa_message_sends',
+  timestamps: true,
+  indexes: [
+    { fields: ['prospectId'], name: 'idx_wa_sends_prospect' },
+    { fields: ['consumerId'], name: 'idx_wa_sends_consumer' },
+  ],
+});
+
+export default WaMessageSend;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -415,7 +415,7 @@ export const {
   OutreachCadenceTransition, OutreachCadenceEnrollment, OutreachSuppression,
   AiSettings, WalletLedger, Consumer, ConsentEvent, ConsumerSuppression,
   SuppressionPropagation, Cohort, EmailBroadcast, EmailBroadcastRecipient,
-  WaMessageStatus, ConsumerObservation, ConsumerProfile, EnrichmentJob,
+  WaMessageStatus, WaMessageSend, ConsumerObservation, ConsumerProfile, EnrichmentJob,
   EnrichmentScoringConfig, EnrichmentSweepRun
 } = models;
 

--- a/backend/src/services/erasureService.js
+++ b/backend/src/services/erasureService.js
@@ -558,6 +558,26 @@ export function makeErasureService(overrides = {}) {
         report.waMessageStatuses = rowCount(wmsMeta);
       }
 
+      // 11c. WhatsApp send-time ownership (migration 096,
+      // per-campaign-lead-scoring.md §5). The twin of 11b: that table says what
+      // happened to a wamid, this one says which lead it was for. Deleted, not
+      // scrubbed — every column is about the person (which lead, which
+      // campaign, when they were messaged), so there is no non-personal
+      // skeleton worth keeping. Keyed on BOTH arms because consumerId is a
+      // send-time snapshot that pre-spine sends never carried, while the
+      // prospect arm catches those: an ownership row surviving its status row
+      // would leave a dangling "we messaged this lead on this date".
+      {
+        const sendsWhere = pids.length
+          ? '"consumerId" = :consumerId OR "prospectId" IN (:pids)'
+          : '"consumerId" = :consumerId';
+        const [, wsMeta] = await d.sequelize.query(
+          `DELETE FROM wa_message_sends WHERE ${sendsWhere}`,
+          { replacements: { consumerId, ...(pids.length ? { pids } : {}) }, transaction: t }
+        );
+        report.waMessageSends = rowCount(wsMeta);
+      }
+
       // 12. Draw entries (prospect join + phoneHash fallback — draw_entries
       // has no consumerId until tracker "drawlink"): unpickable + snapshot
       // scrubbed. phoneHash is NOT NULL ⇒ the all-zeros sentinel. Boost-review

--- a/backend/src/services/redeemOps/waMessageOwnership.js
+++ b/backend/src/services/redeemOps/waMessageOwnership.js
@@ -1,0 +1,116 @@
+import { sequelize } from '../../database/connection.js';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Send-time ownership writer (docs/plans/per-campaign-lead-scoring.md §5).
+ *
+ * ONE function, called by every WhatsApp send path that has a lead. It exists
+ * as its own module rather than inline in whatsappService so the screening
+ * callback, the reward rails and any future sender share exactly one writer —
+ * §5's rule is that ownership is stamped once, at send, by whoever sent it.
+ *
+ * THE SEND PATHS, enumerated (this is the whole list as of migration 096):
+ *
+ *   1-4. redeemOps/whatsappService.js `sendTemplate` — the single choke point
+ *        for reward_pass / draw_entry_pass (kind 'pass' | 'draw_pass'),
+ *        reward_voucher ('voucher'), draw_boost_receipt* ('boost_receipt')
+ *        and draw_callback_optin ('screening_callback'). All four senders
+ *        funnel through it (whatsappService.js:213), so one call site covers
+ *        them; the kind travels down from the sender.
+ *
+ *   5.   verificationService.js `sendWhatsAppOtpMeta` (:72-121) — the
+ *        pre-prospect OTP. DELIBERATELY WRITES NO ROW, for two independent
+ *        reasons. (a) There is no lead to own it: the OTP is what gates
+ *        capture, so at send time the prospect does not exist yet
+ *        (sendVerificationCode takes { phone, countryCode, campaignId } and no
+ *        prospect, :167). A row here would have to invent an owner, which is
+ *        the derivation §5 exists to forbid. (b) It is a different WhatsApp
+ *        sender entirely — META_WA_PHONE_NUMBER_ID / META_WA_ACCESS_TOKEN, a
+ *        separate credential pair from the WHATSAPP_* set the reward rails use
+ *        (backend/env.example:161-162) — and the status webhook binds to
+ *        WHATSAPP_PHONE_NUMBER_ID, skipping any other sender's entries as
+ *        unmatchedForeign (waWebhookService.js:137,145-148). So OTP wamids do
+ *        not reach wa_message_statuses in the first place and there is nothing
+ *        for an ownership row to scope. An unowned wamid never scores, which
+ *        is the correct outcome and the one the join gives for free.
+ *
+ * RESEND. Every send gets a fresh wamid from Meta, so a resend is a NEW row,
+ * not an update — `resendCredential` (entitlementService.js:792-806) re-reads
+ * the prospect and sends again, and both messages end up separately owned and
+ * separately scoreable. The ON CONFLICT DO NOTHING below is therefore not a
+ * resend mechanism; it is redelivery insurance, since a wamid is unique and a
+ * second insert of the same one can only be a repeat of the same send.
+ *
+ * FAILED SEND. No wamid, no row. A send that Meta rejects (4xx), that throws,
+ * or that is gated off never reaches this writer — the caller only invokes it
+ * on a 2xx carrying a message id. A 2xx WITHOUT one ("accepted, untrackable",
+ * whatsappService.js:302-310) also writes nothing: there is no key to own. In
+ * every one of those cases the message cannot appear in wa_message_statuses
+ * under an id we could have owned, so unowned-and-unscored is exact, not lossy.
+ *
+ * NEVER THROWS. The senders are fire-and-forget and must stay that way
+ * (whatsappService.js:26-28). A failure here loses the message's scoreability,
+ * never the message — so it is logged loudly and swallowed.
+ */
+
+/** The kinds a caller may stamp. Anything else is a programming error. */
+export const WA_SEND_KINDS = Object.freeze([
+  'pass', 'draw_pass', 'voucher', 'boost_receipt', 'screening_callback',
+]);
+
+export function makeWaMessageOwnership(overrides = {}) {
+  const d = { sequelize, logger, ...overrides };
+
+  /**
+   * Stamp one message's owner. Returns true iff a row was written.
+   *
+   * @param {object} args
+   * @param {string} args.wamid      Meta message id — the join key.
+   * @param {object} args.prospect   The lead the message was sent for.
+   * @param {string} args.kind       One of WA_SEND_KINDS.
+   * @param {Date}   [args.sentAt]
+   */
+  async function recordWaSend({ wamid, prospect, kind, sentAt = new Date() }) {
+    if (!wamid || !prospect?.id) return false;
+    if (!WA_SEND_KINDS.includes(kind)) {
+      d.logger.warn('redeem_ops.whatsapp.ownership_bad_kind', { kind, wamid });
+      return false;
+    }
+    try {
+      // Raw INSERT into a model-backed table ⇒ createdAt/updatedAt are named
+      // explicitly. Sequelize's sync() emits them NOT NULL with no database
+      // default while the migration declares DEFAULT now(), so omitting them
+      // passes in prod and dies in every test (CLAUDE.md, "test schema ≠ prod
+      // schema").
+      await d.sequelize.query(
+        `INSERT INTO wa_message_sends
+           (wamid, "prospectId", "campaignId", "consumerId", kind, "sentAt", "createdAt", "updatedAt")
+         VALUES (:wamid, :prospectId, :campaignId, :consumerId, :kind, :sentAt, NOW(), NOW())
+         ON CONFLICT (wamid) DO NOTHING`,
+        {
+          replacements: {
+            wamid: String(wamid).slice(0, 128),
+            prospectId: prospect.id,
+            campaignId: prospect.campaignId || null,
+            consumerId: prospect.consumerId || null,
+            kind,
+            sentAt,
+          },
+        }
+      );
+      return true;
+    } catch (err) {
+      // The message went out; only its scoreability is lost.
+      d.logger.error('redeem_ops.whatsapp.ownership_write_failed', {
+        wamid, prospectId: prospect.id, kind, error: err?.message,
+      });
+      return false;
+    }
+  }
+
+  return { recordWaSend };
+}
+
+const _default = makeWaMessageOwnership();
+export const recordWaSend = _default.recordWaSend;
+export default _default;

--- a/backend/src/services/redeemOps/whatsappService.js
+++ b/backend/src/services/redeemOps/whatsappService.js
@@ -4,6 +4,7 @@ import { logger } from '../../utils/logger.js';
 import { renderQrCardPng } from './qrCardRenderer.js';
 import { isSendBlocked } from '../consentService.js';
 import { boostDeadlineLong } from './drawLink.js';
+import { recordWaSend } from './waMessageOwnership.js';
 
 /**
  * Consumer WhatsApp delivery for reward credentials (trial-reward PR E,
@@ -130,7 +131,7 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 export function makeWhatsappService(overrides = {}) {
   const d = {
     RewardOffer, logger, QRCode, renderQrCard: renderQrCardPng,
-    fetch: (...args) => fetch(...args), sleep, isSendBlocked, ...overrides,
+    fetch: (...args) => fetch(...args), sleep, isSendBlocked, recordWaSend, ...overrides,
   };
 
   /**
@@ -209,8 +210,17 @@ export function makeWhatsappService(overrides = {}) {
     return json.id;
   }
 
-  /** One template send. Resolves normalized result, never throws. */
-  async function sendTemplate({ prospect, templateName, params, qrContent, card, purpose = 'transactional', urlButtonParam = null }) {
+  /**
+   * One template send. Resolves normalized result, never throws.
+   *
+   * `kind` is this send's OWNERSHIP label (§5 of
+   * docs/plans/per-campaign-lead-scoring.md). Every sender below passes one,
+   * and a 2xx carrying a wamid stamps `wa_message_sends` before resolving —
+   * this is the single choke point all four templates funnel through, which is
+   * why one call site here covers every rail. See waMessageOwnership.js for
+   * the full send-path inventory and the resend / failed-send contract.
+   */
+  async function sendTemplate({ prospect, templateName, params, qrContent, card, purpose = 'transactional', urlButtonParam = null, kind = null }) {
     if (!waEnabled()) return { sent: false, skipped: 'disabled' };
     // Capability inline (not via canWhatsAppProspect) so each send costs ONE
     // ledger read and the receipt codes stay distinct: 'no_whatsapp' = phone
@@ -308,6 +318,27 @@ export function makeWhatsappService(overrides = {}) {
         messageId = json?.messages?.[0]?.id || null;
       } catch { /* accepted, untrackable */ }
       if (!messageId) d.logger.warn('redeem_ops.whatsapp.no_wamid', { template: templateName });
+      // Ownership BEFORE resolving, so a caller that acts on the result (the
+      // screening callback patches its receipt straight after,
+      // retellScreeningService.js:521-529) can never observe a sent message
+      // whose owner is still unwritten.
+      //
+      // Its own try/catch, deliberately NOT the enclosing one: the message is
+      // already out of the building by this line, and letting a bookkeeping
+      // failure fall into the catch below would resolve `sent: false` for a
+      // message the recipient has. That mislabels the receipt and invites a
+      // duplicate resend — a far worse outcome than an unscoreable read. The
+      // real writer swallows its own errors already; this is the fence that
+      // holds if a future one doesn't.
+      if (messageId && kind) {
+        try {
+          await d.recordWaSend({ wamid: messageId, prospect, kind });
+        } catch (err) {
+          d.logger.error('redeem_ops.whatsapp.ownership_threw', {
+            template: templateName, wamid: messageId, error: err?.message,
+          });
+        }
+      }
       return {
         sent: true, to: maskPhone(prospect.phone), templateName,
         ...(messageId ? { messageId } : {}),
@@ -328,6 +359,7 @@ export function makeWhatsappService(overrides = {}) {
       return sendTemplate({
         prospect,
         templateName: process.env.WHATSAPP_TEMPLATE_DRAW_PASS || 'draw_entry_pass',
+        kind: 'draw_pass',
         qrContent: passLink,
         card: {
           state: 'pass', rewardName, partnerName, expiresAt: entitlement.expiresAt,
@@ -353,6 +385,7 @@ export function makeWhatsappService(overrides = {}) {
     return sendTemplate({
       prospect,
       templateName: process.env.WHATSAPP_TEMPLATE_PASS || 'reward_pass',
+      kind: 'pass',
       qrContent: passLink,
       card: { state: 'pass', rewardName, partnerName, expiresAt: entitlement.expiresAt },
       params: [
@@ -372,6 +405,7 @@ export function makeWhatsappService(overrides = {}) {
     return sendTemplate({
       prospect,
       templateName: process.env.WHATSAPP_TEMPLATE_VOUCHER || 'reward_voucher',
+      kind: 'voucher',
       qrContent: voucherToken,
       card: {
         state: 'voucher', rewardName, partnerName, expiresAt: entitlement.expiresAt,
@@ -412,6 +446,7 @@ export function makeWhatsappService(overrides = {}) {
     return sendTemplate({
       prospect,
       templateName,
+      kind: 'boost_receipt',
       card: {
         state: 'boost',
         rewardName: drawName,
@@ -448,6 +483,7 @@ export function makeWhatsappService(overrides = {}) {
     return sendTemplate({
       prospect,
       templateName: process.env.WHATSAPP_TEMPLATE_DRAW_CALLBACK || 'draw_callback_optin',
+      kind: 'screening_callback',
       purpose: 'marketing',
       urlButtonParam: `callback?t=${encodeURIComponent(token)}&utm_source=wa_screening`,
       params: [

--- a/backend/src/services/verificationService.js
+++ b/backend/src/services/verificationService.js
@@ -68,7 +68,14 @@ const maskPhone = (phone) => {
   return s.length < 7 ? '***' : `${s.slice(0, 3)}****${s.slice(-4)}`;
 };
 
-// Helper to send WhatsApp via Meta Graph API
+// Helper to send WhatsApp via Meta Graph API.
+//
+// This send deliberately writes NO wa_message_sends ownership row
+// (per-campaign-lead-scoring.md §5): the OTP is what gates capture, so no lead
+// exists yet to own it, and it goes out on the separate META_WA_* sender whose
+// statuses the webhook skips as unmatchedForeign anyway
+// (waWebhookService.js:137,145-148). Full reasoning and the send-path
+// inventory: redeemOps/waMessageOwnership.js.
 const sendWhatsAppOtpMeta = async (phone, code) => {
   const phoneId = process.env.META_WA_PHONE_NUMBER_ID;
   const accessToken = process.env.META_WA_ACCESS_TOKEN;

--- a/backend/src/tests/whatsappService.test.js
+++ b/backend/src/tests/whatsappService.test.js
@@ -65,10 +65,27 @@ function enableWithCreds() {
   process.env.WHATSAPP_PHONE_NUMBER_ID = '555000111';
 }
 
-function makeSvc({ fetch, qr = qrRecorder(), card = cardRecorder(), RewardOffer = offerFake, isSendBlocked } = {}) {
+/**
+ * DI fake for the send-time ownership writer (§5 of
+ * per-campaign-lead-scoring.md). Injected by default so this suite stays
+ * DB-free — the real writer opens a connection, and a DB-less jest run burns
+ * two minutes on connection retries rather than failing cleanly.
+ */
+function ownershipRecorder() {
+  const calls = [];
+  const fn = async (args) => { calls.push(args); return true; };
+  fn.calls = calls;
+  return fn;
+}
+
+function makeSvc({
+  fetch, qr = qrRecorder(), card = cardRecorder(), RewardOffer = offerFake,
+  isSendBlocked, recordWaSend = ownershipRecorder(),
+} = {}) {
   // Inject a no-op sleep so graphFetch's backoff doesn't slow tests.
   return makeWhatsappService({
     RewardOffer, fetch, QRCode: qr, renderQrCard: card, logger: silentLogger, sleep: async () => {},
+    recordWaSend,
     ...(isSendBlocked ? { isSendBlocked } : {}),
   });
 }
@@ -485,5 +502,119 @@ describe('sendDrawCallbackOptinWhatsApp — screening callback opt-in (§16.6)',
     expect(await paramAt({ prize: 'The Grand Bundle' })).toBe('The Grand Bundle');
     expect(await paramAt({ prize: null })).toBe('the grand prize');
     expect(await paramAt({ prize: 'https://evil.example' })).toBe('the grand prize');
+  });
+});
+
+describe('send-time ownership — wa_message_sends stamping (§5)', () => {
+  // A persisted lead: ownership needs an id, and carries the campaign/consumer
+  // it had AT SEND as a snapshot.
+  const lead = {
+    ...consented, id: 'p-1', campaignId: 'c-1', consumerId: 'u-1',
+  };
+  const sentWithWamid = { ok: true, json: async () => ({ messages: [{ id: 'wamid.ABC' }] }) };
+  // Header OFF throughout: it costs an extra /media round-trip that has
+  // nothing to do with ownership, and the header shape is covered above. With
+  // it off every sender makes exactly one call, so one scripted response fits
+  // all five.
+  const enableNoHeader = () => { enableWithCreds(); process.env.WHATSAPP_QR_HEADER = 'false'; };
+  const drawCtx = {
+    drawName: 'iPhone 17 Pro Lucky Draw', multiplier: 10, prize: 'iPhone 17 Pro',
+    drawOn: '2026-10-30', passTheme: 'vault', boostClosesAt: '2026-10-29T15:59:59.999Z',
+  };
+
+  /** Every sender, with the kind it must stamp. */
+  const senders = [
+    ['pass', (svc) => svc.sendReservationWhatsApp({ entitlement, prospect: lead, presentationToken: 'ptok' })],
+    ['draw_pass', (svc) => svc.sendReservationWhatsApp({ entitlement, prospect: lead, presentationToken: 'ptok', drawCtx })],
+    ['voucher', (svc) => svc.sendVoucherWhatsApp({ entitlement, prospect: lead, voucherToken: 'vtok' })],
+    ['boost_receipt', (svc) => svc.sendBoostReceiptWhatsApp({ prospect: lead, drawCtx })],
+    ['screening_callback', (svc) => svc.sendDrawCallbackOptinWhatsApp({
+      prospect: lead, drawName: 'D', multiplier: 10, prize: 'p', token: 'wcb_x',
+    })],
+  ];
+
+  it.each(senders)('%s stamps the lead, campaign and consumer of the send', async (kind, send) => {
+    enableNoHeader();
+    const recordWaSend = ownershipRecorder();
+    const svc = makeSvc({
+      fetch: scriptedFetch([sentWithWamid]),
+      recordWaSend,
+      isSendBlocked: async () => false,
+    });
+    const r = await send(svc);
+    expect(r.sent).toBe(true);
+    expect(recordWaSend.calls.length).toBe(1);
+    expect(recordWaSend.calls[0]).toMatchObject({ wamid: 'wamid.ABC', kind });
+    // The snapshot is taken off the prospect handed to the sender — never
+    // re-derived from the entitlement or activation (§5's whole point).
+    expect(recordWaSend.calls[0].prospect).toBe(lead);
+  });
+
+  it('a 2xx with no wamid owns nothing — there is no key to own', async () => {
+    enableNoHeader();
+    const recordWaSend = ownershipRecorder();
+    // sendOk resolves {} — "accepted, untrackable".
+    const svc = makeSvc({ fetch: scriptedFetch([sendOk]), recordWaSend, isSendBlocked: async () => false });
+    const r = await svc.sendDrawCallbackOptinWhatsApp({
+      prospect: lead, drawName: 'D', multiplier: 10, prize: 'p', token: 'wcb_x',
+    });
+    expect(r.sent).toBe(true);
+    expect(recordWaSend.calls.length).toBe(0);
+  });
+
+  it('a rejected send owns nothing', async () => {
+    enableNoHeader();
+    const recordWaSend = ownershipRecorder();
+    const svc = makeSvc({
+      fetch: scriptedFetch([{ ok: false, status: 400, json: async () => ({ error: { code: 132001 } }) }]),
+      recordWaSend,
+      isSendBlocked: async () => false,
+    });
+    const r = await svc.sendDrawCallbackOptinWhatsApp({
+      prospect: lead, drawName: 'D', multiplier: 10, prize: 'p', token: 'wcb_x',
+    });
+    expect(r.sent).toBe(false);
+    expect(recordWaSend.calls.length).toBe(0);
+  });
+
+  it('gated sends (flag off, suppressed) own nothing', async () => {
+    const recordWaSend = ownershipRecorder();
+    // Flag off — no creds enabled.
+    let svc = makeSvc({ fetch: scriptedFetch([sentWithWamid]), recordWaSend });
+    expect((await svc.sendVoucherWhatsApp({ entitlement, prospect: lead, voucherToken: 'v' })).skipped).toBe('disabled');
+
+    enableNoHeader();
+    svc = makeSvc({ fetch: scriptedFetch([sentWithWamid]), recordWaSend, isSendBlocked: async () => true });
+    expect((await svc.sendVoucherWhatsApp({ entitlement, prospect: lead, voucherToken: 'v' })).skipped).toBe('suppressed');
+    expect(recordWaSend.calls.length).toBe(0);
+  });
+
+  it('a resend is a SECOND owned message, not an overwrite — each send has its own wamid', async () => {
+    enableNoHeader();
+    const recordWaSend = ownershipRecorder();
+    const wamids = ['wamid.FIRST', 'wamid.SECOND'];
+    let n = 0;
+    const fetch = async () => ({ ok: true, json: async () => ({ messages: [{ id: wamids[n++] }] }) });
+    fetch.calls = [];
+    const svc = makeSvc({ fetch, recordWaSend, isSendBlocked: async () => false });
+    await svc.sendVoucherWhatsApp({ entitlement, prospect: lead, voucherToken: 'v' });
+    await svc.sendVoucherWhatsApp({ entitlement, prospect: lead, voucherToken: 'v' });
+    expect(recordWaSend.calls.map((c) => c.wamid)).toEqual(wamids);
+  });
+
+  it('an ownership write failure loses scoreability, never the message', async () => {
+    enableNoHeader();
+    const svc = makeSvc({
+      fetch: scriptedFetch([sentWithWamid]),
+      // The real writer swallows its own errors; this proves the send still
+      // reports the truth if a future one doesn't. Reporting sent:false here
+      // would mislabel the receipt for a message the recipient already has,
+      // and invite a duplicate resend.
+      recordWaSend: async () => { throw new Error('db down'); },
+      isSendBlocked: async () => false,
+    });
+    const r = await svc.sendVoucherWhatsApp({ entitlement, prospect: lead, voucherToken: 'v' });
+    expect(r).toMatchObject({ sent: true, messageId: 'wamid.ABC' });
+    expect(r.error).toBeUndefined();
   });
 });

--- a/backend/test/waMessageSends.test.js
+++ b/backend/test/waMessageSends.test.js
@@ -1,0 +1,170 @@
+import { createHash } from 'crypto'
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect } from './helpers.js'
+import { sequelize, Consumer, WaMessageSend } from '../src/models/index.js'
+import { recordWaSend, WA_SEND_KINDS } from '../src/services/redeemOps/waMessageOwnership.js'
+import { eraseConsumer } from '../src/services/erasureService.js'
+
+/**
+ * Send-time message ownership (per-campaign-lead-scoring.md §5, migration 096).
+ *
+ * Real Postgres: the value of this table is entirely in its write semantics —
+ * the ON CONFLICT, the snapshot columns and the erasure delete — none of which
+ * a mock can prove. The sender-side wiring (which kind each template stamps,
+ * and that a failed send stamps nothing) is DI-tested in
+ * src/tests/whatsappService.test.js.
+ */
+
+let admin, campA, campB
+let seq = Math.floor(Math.random() * 700000)
+const e164 = () => `+65${(81000000 + (seq += 1)).toString()}`
+const sha256hex = (s) => createHash('sha256').update(s).digest('hex')
+
+async function personWithLead(campaign = campA) {
+  const phone = e164()
+  const consumer = await Consumer.create({
+    phone,
+    phoneHash: sha256hex(phone),
+    firstSeenAt: new Date('2026-06-01T00:00:00Z'),
+    lastSeenAt: new Date('2026-06-01T00:00:00Z'),
+    signupCount: 1,
+    verifiedSignupCount: 1,
+  })
+  const prospect = await createTestProspect(campaign.id, { consumerId: consumer.id, phone })
+  return { consumer, prospect }
+}
+
+const rowFor = (wamid) => WaMessageSend.findByPk(wamid)
+
+beforeAll(async () => {
+  await getApp()
+  const made = await createTestUser({ role: 'admin' })
+  admin = made.user
+  campA = await createTestCampaign(admin.id, { name: `WaSends A ${Date.now()}` })
+  campB = await createTestCampaign(admin.id, { name: `WaSends B ${Date.now()}` })
+})
+
+afterAll(async () => {
+  await closeDb()
+})
+
+describe('recordWaSend — the ownership stamp', () => {
+  test('stamps lead, campaign and consumer as they were at send', async () => {
+    const { consumer, prospect } = await personWithLead()
+    const wamid = `wamid.OK.${seq}`
+    expect(await recordWaSend({ wamid, prospect, kind: 'draw_pass' })).toBe(true)
+
+    const row = await rowFor(wamid)
+    expect(row.prospectId).toBe(prospect.id)
+    expect(row.campaignId).toBe(campA.id)
+    expect(row.consumerId).toBe(consumer.id)
+    expect(row.kind).toBe('draw_pass')
+    expect(row.sentAt).toBeInstanceOf(Date)
+  })
+
+  test('the snapshot survives the lead moving campaign — ownership is not a live lookup', async () => {
+    const { prospect } = await personWithLead()
+    const wamid = `wamid.SNAP.${seq}`
+    await recordWaSend({ wamid, prospect, kind: 'voucher' })
+
+    // The lead is re-homed after the send. §5 exists because deriving
+    // ownership later would now answer campB for a message sent for campA.
+    await prospect.update({ campaignId: campB.id })
+
+    const row = await rowFor(wamid)
+    expect(row.campaignId).toBe(campA.id)
+    expect(row.prospectId).toBe(prospect.id)
+  })
+
+  test('a repeated wamid never re-homes an existing row (ON CONFLICT DO NOTHING)', async () => {
+    const { prospect } = await personWithLead()
+    const other = await personWithLead(campB)
+    const wamid = `wamid.DUP.${seq}`
+
+    await recordWaSend({ wamid, prospect, kind: 'pass' })
+    // Meta redelivery, or a second writer racing on the same id. The FIRST
+    // owner stands: a wamid is unique, so a second insert can only be a repeat.
+    expect(await recordWaSend({ wamid, prospect: other.prospect, kind: 'voucher' })).toBe(true)
+
+    const row = await rowFor(wamid)
+    expect(row.prospectId).toBe(prospect.id)
+    expect(row.kind).toBe('pass')
+    const [rows] = await sequelize.query('SELECT count(*)::int AS n FROM wa_message_sends WHERE wamid = :w', {
+      replacements: { w: wamid },
+    })
+    expect(rows[0].n).toBe(1)
+  })
+
+  test('a resend is a second owned row — each send owns its own wamid', async () => {
+    const { prospect } = await personWithLead()
+    const first = `wamid.RS1.${seq}`
+    const second = `wamid.RS2.${seq}`
+    await recordWaSend({ wamid: first, prospect, kind: 'voucher' })
+    await recordWaSend({ wamid: second, prospect, kind: 'voucher' })
+
+    const [rows] = await sequelize.query(
+      'SELECT wamid FROM wa_message_sends WHERE "prospectId" = :p ORDER BY wamid',
+      { replacements: { p: prospect.id } }
+    )
+    expect(rows.map((r) => r.wamid)).toEqual([first, second])
+  })
+
+  test('a lead with no campaign is still owned — prospectId is the ownership', async () => {
+    const { prospect } = await personWithLead()
+    await sequelize.query('UPDATE prospects SET "campaignId" = NULL WHERE id = :id', {
+      replacements: { id: prospect.id },
+    })
+    await prospect.reload()
+    const wamid = `wamid.NOCAMP.${seq}`
+    expect(await recordWaSend({ wamid, prospect, kind: 'pass' })).toBe(true)
+    const row = await rowFor(wamid)
+    expect(row.campaignId).toBeNull()
+    expect(row.prospectId).toBe(prospect.id)
+  })
+
+  test('writes nothing without a wamid, without a lead, or with an unknown kind', async () => {
+    const { prospect } = await personWithLead()
+    expect(await recordWaSend({ wamid: null, prospect, kind: 'pass' })).toBe(false)
+    expect(await recordWaSend({ wamid: `wamid.NOP.${seq}`, prospect: null, kind: 'pass' })).toBe(false)
+    // The pre-prospect OTP shape: a phone, no lead. It must never invent one.
+    expect(await recordWaSend({ wamid: `wamid.OTP.${seq}`, prospect: { phone: '+6591234567' }, kind: 'pass' })).toBe(false)
+    expect(await recordWaSend({ wamid: `wamid.BAD.${seq}`, prospect, kind: 'otp' })).toBe(false)
+
+    const [rows] = await sequelize.query(
+      `SELECT count(*)::int AS n FROM wa_message_sends WHERE wamid LIKE 'wamid.%${seq}' AND wamid <> ''`
+    )
+    expect(rows[0].n).toBe(0)
+  })
+
+  test('the kind vocabulary is closed', () => {
+    expect(WA_SEND_KINDS).toEqual(['pass', 'draw_pass', 'voucher', 'boost_receipt', 'screening_callback'])
+  })
+})
+
+describe('erasure', () => {
+  test('erasing the person deletes their ownership rows', async () => {
+    const { consumer, prospect } = await personWithLead()
+    const mine = `wamid.ERASE.${seq}`
+    await recordWaSend({ wamid: mine, prospect, kind: 'voucher' })
+
+    // A bystander's row, to prove the delete is keyed and not a truncate.
+    const bystander = await personWithLead()
+    const theirs = `wamid.KEEP.${seq}`
+    await recordWaSend({ wamid: theirs, prospect: bystander.prospect, kind: 'voucher' })
+
+    const report = await eraseConsumer(consumer.id, { actorUser: admin, reason: 'wa sends erasure test' })
+    expect(report.waMessageSends).toBe(1)
+    expect(await rowFor(mine)).toBeNull()
+    expect(await rowFor(theirs)).not.toBeNull()
+  })
+
+  test('a pre-spine row with no consumerId is still erased, via its lead', async () => {
+    const { consumer, prospect } = await personWithLead()
+    const wamid = `wamid.PRESPINE.${seq}`
+    // Ownership written before the spine linked this lead to a person.
+    await recordWaSend({ wamid, prospect: { id: prospect.id, campaignId: campA.id }, kind: 'pass' })
+    expect((await rowFor(wamid)).consumerId).toBeNull()
+
+    await eraseConsumer(consumer.id, { actorUser: admin, reason: 'wa sends pre-spine erasure' })
+    expect(await rowFor(wamid)).toBeNull()
+  })
+})


### PR DESCRIPTION
**Plan:** `docs/plans/per-campaign-lead-scoring.md` §5. First of two stacked PRs for Phase 3; **PR A₂ (`feat/lead-score`) is based on this branch** — merge this one first.

## Why

Phase 3 scores a WhatsApp `read` as a response to **one lead's** pitch, so it has to know which lead a message was sent for. Nothing recorded that, and reconstructing it afterwards is not merely missing — it is **unsafe**:

- `deliveryReceipts` joins `redemption_events → wa_message_statuses` on wamid and filters by entitlement ids drawn from the person's whole journey (`leadProfileService.js:100-119`) — it never touches activations or campaigns.
- Receipts carry no immutable campaign snapshot (`redeemOps/entitlementService.js:211`) and activations can be relinked (`redeemOps/activationService.js:117,153`), so a historical send can be attributed to the **wrong campaign**.
- Screening-callback WhatsApps write no receipt at all — their wamid lives only in `prospects.screeningMetadata.waCallback` (`retellScreeningService.js:521-529`).

So ownership is **stamped at send and never derived**.

## What

New table `wa_message_sends` (migration 096) keyed by wamid — the same key the status webhook already writes (`waWebhookService.js:73,154`), so scoping becomes a join and the status inbox is untouched.

**The send paths, enumerated.** All four templates funnel through `sendTemplate` (`whatsappService.js:213`), so one call site covers `reward_pass`/`draw_entry_pass`, `reward_voucher`, `draw_boost_receipt*` and `draw_callback_optin`; each sender passes its `kind`. The fifth path — `verificationService`'s **pre-prospect OTP** — deliberately writes nothing: the OTP is what gates capture, so no lead exists to own it, and it goes out on the separate `META_WA_*` sender whose statuses the webhook skips as `unmatchedForeign` anyway (`env.example:161-162`, `waWebhookService.js:137,145-148`). An unowned wamid never scores, which the join gives for free.

**Resend** = a fresh wamid = a second owned row, not an update. **Failed send**, or a 2xx with no wamid ("accepted, untrackable"), writes nothing — there is no key to own. The ownership write sits in **its own try/catch**: the message is already out by that line, so a bookkeeping failure must not resolve `sent: false` and invite a duplicate resend.

**No foreign keys** — snapshot semantics, the reasoning §9 applies to the config's campaignId. Campaigns can be permanently deleted (`campaignService.js:1032-1035`) while their prospects survive with campaignId nulled (`014-add-cascade-rules.js:87`); CASCADE would destroy ownership of messages whose lead still scores, SET NULL would silently re-home a dead campaign's sends.

**Erasure** deletes these rows on both arms (consumerId, and prospectId for pre-spine sends), beside the existing `wa_message_statuses` delete.

## Deviation from the plan (§18.1)

`campaignId` is **NULLABLE**, where §5 sketched NOT NULL. A lead can legitimately carry no campaign at send time (`validation.js:219`, `prospectService.js:1066-1069`, and the campaign-delete null-out above). NOT NULL would force the writer to drop the whole ownership row exactly when a campaignless lead is messaged — losing `prospectId`, which *is* the ownership, to protect a snapshot that is only supporting evidence.

## Backfill

None is possible: ownership was never recorded, and inferring it is precisely the unsafe operation this table replaces. **Pre-existing sends do not score.** Stated, not hidden.

## Verification

- `backend/test/waMessageSends.test.js` — 9 new DB-backed tests (snapshot survives a campaign move, ON CONFLICT never re-homes, resend = second row, campaignless lead still owned, erasure both arms).
- `backend/src/tests/whatsappService.test.js` — 44 pass, incl. per-kind stamping for all five kinds and the gated/failed/no-wamid cases.
- `test/integration/erasure.test.js` 25 pass · `npx eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENWdGMue9uXqmKv3pRG6YF