### PR TITLE
feat(scoring): the score moves to the lead, and engagement moves it (Phase 3, PR A₂)

### DIFF
--- a/backend/src/database/migrations/097-lead-score.js
+++ b/backend/src/database/migrations/097-lead-score.js
@@ -1,0 +1,80 @@
+/**
+ * 097 — the score moves to the lead (per-campaign-lead-scoring.md §4, §6, §10).
+ *
+ * A fresh grad is a great recruit and a poor insurance buyer: identical facts,
+ * opposite verdict. One number per PERSON cannot hold both, so the score
+ * becomes a property of (person × campaign) — which is what a prospect row
+ * already is.
+ *
+ * `prospects.score` already exists (INTEGER 0-100, Prospect.js:75-83) and has
+ * been dead since inception: written by nothing, and the prospect-update
+ * endpoint's field allowlist excludes it. It becomes the lead score. Around it
+ * go the same stamps consumer_profiles carries
+ * (consumerScoringService.js:240-258) so a stored breakdown stays
+ * interpretable, plus the two sub-scores §4's person-grain projection reads.
+ *
+ * ONE STORED NUMBER, DECAYED AT WRITE TIME (§6). Engagement recency and
+ * life-event facts both decay INSIDE the base (consumerScoring.js:226-227,
+ * :297-298), so there is no time-independent base to store and decay at read;
+ * and a freshly-decayed display over a nightly-materialised sort column shows
+ * visibly misordered pages. So sort, display and API all read `score`, and
+ * nothing decays at read anywhere. The sacrifice, stated: pure-time freshness
+ * between rescores.
+ *
+ * `scoreDirtyAt` is the lead-grain dirty marker (§10). Nothing existing covers
+ * lead-grain invalidation: the spine relinker bumps only
+ * consumer_profiles.inputVersion (consumerService.js:326-338),
+ * bumpEnrichmentInputTx upserts only consumer_profiles
+ * (enrichmentFence.js:38-52), and the sweep enumerates consumers
+ * (enrichmentSweepService.js:249,278). Prospect.enrichmentRevision exists but
+ * feeds map jobs — it is not a scanned dirty flag. A dirty lead is PROVABLY
+ * stale, so it rides the sweep's stale-FIRST phase.
+ *
+ * Nullable throughout: an unscored lead is a real state, and a NOT NULL with a
+ * default would claim every one of the 138 existing leads had been scored.
+ */
+export async function up(queryInterface) {
+  const q = (sql) => queryInterface.sequelize.query(sql);
+
+  await q(`ALTER TABLE prospects
+    ADD COLUMN IF NOT EXISTS "meetScore" INTEGER,
+    ADD COLUMN IF NOT EXISTS "buyScore" INTEGER,
+    ADD COLUMN IF NOT EXISTS "scoreBreakdown" JSONB,
+    ADD COLUMN IF NOT EXISTS "scoreComputedAt" TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS "scoredConfigVersion" INTEGER,
+    ADD COLUMN IF NOT EXISTS "scoringAlgorithmVersion" VARCHAR(24),
+    ADD COLUMN IF NOT EXISTS "scoreInputHash" VARCHAR(64),
+    ADD COLUMN IF NOT EXISTS "scoreDirtyAt" TIMESTAMPTZ`);
+
+  // The stale-lead query's predicate: never scored, scored by a superseded
+  // config/algorithm, or explicitly dirtied. Ordered by id, so the index
+  // carries id to keep the cursor walk index-only where it can be.
+  await q(`CREATE INDEX IF NOT EXISTS idx_prospects_score_stale
+    ON prospects ("scoredConfigVersion", "scoringAlgorithmVersion", id)`);
+
+  // Dirty leads are a small set by construction — partial keeps it that way.
+  await q(`CREATE INDEX IF NOT EXISTS idx_prospects_score_dirty
+    ON prospects ("scoreDirtyAt") WHERE "scoreDirtyAt" IS NOT NULL`);
+
+  // §4's projection: the person's highest-scoring non-erased lead, ties by
+  // createdAt then id. One index serves the lookup and the tiebreak.
+  await q(`CREATE INDEX IF NOT EXISTS idx_prospects_consumer_score
+    ON prospects ("consumerId", score DESC, "createdAt" DESC, id DESC)`);
+}
+
+export async function down(queryInterface) {
+  const q = (sql) => queryInterface.sequelize.query(sql);
+  await q('DROP INDEX IF EXISTS idx_prospects_consumer_score');
+  await q('DROP INDEX IF EXISTS idx_prospects_score_dirty');
+  await q('DROP INDEX IF EXISTS idx_prospects_score_stale');
+  // `score` predates this migration — it is NOT dropped.
+  await q(`ALTER TABLE prospects
+    DROP COLUMN IF EXISTS "meetScore",
+    DROP COLUMN IF EXISTS "buyScore",
+    DROP COLUMN IF EXISTS "scoreBreakdown",
+    DROP COLUMN IF EXISTS "scoreComputedAt",
+    DROP COLUMN IF EXISTS "scoredConfigVersion",
+    DROP COLUMN IF EXISTS "scoringAlgorithmVersion",
+    DROP COLUMN IF EXISTS "scoreInputHash",
+    DROP COLUMN IF EXISTS "scoreDirtyAt"`);
+}

--- a/backend/src/database/migrations/099-lead-score.js
+++ b/backend/src/database/migrations/099-lead-score.js
@@ -1,5 +1,5 @@
 /**
- * 097 — the score moves to the lead (per-campaign-lead-scoring.md §4, §6, §10).
+ * 099 — the score moves to the lead (per-campaign-lead-scoring.md §4, §6, §10).
  *
  * A fresh grad is a great recruit and a poor insurance buyer: identical facts,
  * opposite verdict. One number per PERSON cannot hold both, so the score

--- a/backend/src/models/Prospect.js
+++ b/backend/src/models/Prospect.js
@@ -72,6 +72,11 @@ const Prospect = sequelize.define('Prospect', {
     type: DataTypes.ENUM('low', 'medium', 'high', 'urgent'),
     defaultValue: 'medium'
   },
+  // ── The lead score (per-campaign-lead-scoring.md §4/§6, migration 097) ────
+  // The score is a property of (person × campaign) — this row. `score` is the
+  // blended total and the default sort key; meet/buy are the two sub-scores
+  // §4's person-grain projection copies up. All of it is written by
+  // leadScoringService and by nothing else.
   score: {
     type: DataTypes.INTEGER,
     allowNull: true,
@@ -79,7 +84,47 @@ const Prospect = sequelize.define('Prospect', {
       min: 0,
       max: 100
     },
-    comment: 'Lead scoring from 0-100'
+    comment: 'Lead score 0-100 as of scoreComputedAt — decayed at WRITE time, never at read (§6)'
+  },
+  meetScore: {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+    comment: '"Will they meet a consultant", 0-100. NULL = not scoreable, which is not the same as 0.'
+  },
+  buyScore: {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+    comment: '"Will they buy", 0-100. NULL until ≥1 fact component is assessed — ignorance must never read as a low score.'
+  },
+  scoreBreakdown: {
+    type: DataTypes.JSONB,
+    allowNull: true,
+    comment: 'Per-component evidence + the response events, with their timestamps and undecayed weights. Rendered "as of scoreComputedAt".'
+  },
+  scoreComputedAt: {
+    type: DataTypes.DATE,
+    allowNull: true,
+    comment: 'When the stored number was computed. The decay is baked in as of this instant.'
+  },
+  scoredConfigVersion: {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+    comment: 'enrichment_scoring_configs.version that produced the score — keeps old breakdowns interpretable.'
+  },
+  scoringAlgorithmVersion: {
+    type: DataTypes.STRING(24),
+    allowNull: true,
+    comment: 'Algorithm build that produced the score (e.g. lead/v1).'
+  },
+  scoreInputHash: {
+    type: DataTypes.STRING(64),
+    allowNull: true,
+    comment: 'Content hash of the scored inputs — half of the write gate (§6).'
+  },
+  scoreDirtyAt: {
+    type: DataTypes.DATE,
+    allowNull: true,
+    comment: 'Lead-grain dirty marker (§10). Set by every choke-point writer; cleared by a rescore. A dirty lead is provably stale, so it rides the sweep\'s stale-first phase.'
   },
   interests: {
     type: DataTypes.TEXT,
@@ -324,6 +369,28 @@ const Prospect = sequelize.define('Prospect', {
 }, {
   tableName: 'prospects',
   indexes: [
+    // Lead-score indexes (migration 097). Mirrored here deliberately: the test
+    // schema is built by sync({force:true}) from this model, so an index that
+    // lives only in the migration is absent from every test — the same lesson
+    // Consumer.js's mirrored indexes exist for.
+    {
+      name: 'idx_prospects_score_stale',
+      fields: ['scoredConfigVersion', 'scoringAlgorithmVersion', 'id']
+    },
+    {
+      name: 'idx_prospects_score_dirty',
+      fields: ['scoreDirtyAt'],
+      where: { scoreDirtyAt: { [Op.ne]: null } }
+    },
+    {
+      name: 'idx_prospects_consumer_score',
+      fields: [
+        'consumerId',
+        { name: 'score', order: 'DESC' },
+        { name: 'createdAt', order: 'DESC' },
+        { name: 'id', order: 'DESC' }
+      ]
+    },
     {
       fields: ['email']
     },

--- a/backend/src/models/Prospect.js
+++ b/backend/src/models/Prospect.js
@@ -72,7 +72,7 @@ const Prospect = sequelize.define('Prospect', {
     type: DataTypes.ENUM('low', 'medium', 'high', 'urgent'),
     defaultValue: 'medium'
   },
-  // ── The lead score (per-campaign-lead-scoring.md §4/§6, migration 097) ────
+  // ── The lead score (per-campaign-lead-scoring.md §4/§6, migration 099) ────
   // The score is a property of (person × campaign) — this row. `score` is the
   // blended total and the default sort key; meet/buy are the two sub-scores
   // §4's person-grain projection copies up. All of it is written by
@@ -369,7 +369,7 @@ const Prospect = sequelize.define('Prospect', {
 }, {
   tableName: 'prospects',
   indexes: [
-    // Lead-score indexes (migration 097). Mirrored here deliberately: the test
+    // Lead-score indexes (migration 099). Mirrored here deliberately: the test
     // schema is built by sync({force:true}) from this model, so an index that
     // lives only in the migration is absent from every test — the same lesson
     // Consumer.js's mirrored indexes exist for.

--- a/backend/src/services/consumerScoringService.js
+++ b/backend/src/services/consumerScoringService.js
@@ -237,20 +237,26 @@ export async function scoreOneConsumer(consumerId, { force = false, now = Date.n
 
       // UPSERT guarded on a live consumer — scoring must never resurrect a
       // profile row for someone erased between the fence and this write.
+      //
+      // THE NUMBERS ARE NOT WRITTEN HERE ANY MORE (per-campaign-lead-scoring.md
+      // §4). consumerScore/meetScore/buyScore — and the breakdown they have to
+      // agree with — are a PROJECTION of the person's highest-scoring lead,
+      // written by leadScoringService.projectPersonScore. Two writers for one
+      // number is two authorities that are guaranteed to disagree, which is
+      // exactly what this pass used to do: overwrite every night from the
+      // global model while the lead grain said something else.
+      //
+      // What remains is this pass's real job: resolve the facts, keep the
+      // profile row alive, and stamp what scored it — the stamps are what stop
+      // findStaleConsumerIds re-examining the same unscoreable people forever.
       await sequelize.query(
         `INSERT INTO consumer_profiles
-           ("consumerId", "consumerScore", "meetScore", "buyScore", "scoreBreakdown",
-            "scoredConfigVersion", "scoringAlgorithmVersion", "scoreInputHash",
+           ("consumerId", "scoredConfigVersion", "scoringAlgorithmVersion", "scoreInputHash",
             "scoreComputedAt", "inputVersion", "syncedInputVersion", "createdAt", "updatedAt")
-         SELECT c.id, :consumerScore, :meetScore, :buyScore, :breakdown::jsonb,
-                :configVersion, :algorithmVersion, :inputHash, now(), 0, 0, now(), now()
+         SELECT c.id, :configVersion, :algorithmVersion, :inputHash, now(), 0, 0, now(), now()
            FROM consumers c
           WHERE c.id = :cid AND c."erasedAt" IS NULL
          ON CONFLICT ("consumerId") DO UPDATE SET
-           "consumerScore" = EXCLUDED."consumerScore",
-           "meetScore" = EXCLUDED."meetScore",
-           "buyScore" = EXCLUDED."buyScore",
-           "scoreBreakdown" = EXCLUDED."scoreBreakdown",
            "scoredConfigVersion" = EXCLUDED."scoredConfigVersion",
            "scoringAlgorithmVersion" = EXCLUDED."scoringAlgorithmVersion",
            "scoreInputHash" = EXCLUDED."scoreInputHash",
@@ -259,10 +265,6 @@ export async function scoreOneConsumer(consumerId, { force = false, now = Date.n
         {
           replacements: {
             cid: consumerId,
-            consumerScore: result.consumerScore,
-            meetScore: result.meetScore,
-            buyScore: result.buyScore,
-            breakdown: JSON.stringify(result.breakdown),
             configVersion,
             algorithmVersion,
             inputHash,
@@ -271,6 +273,8 @@ export async function scoreOneConsumer(consumerId, { force = false, now = Date.n
         }
       );
 
+      // Returned, not stored: callers and tests still want to see what the
+      // person-grain model computed, and the projection is what lands.
       return {
         status: 'scored',
         meetScore: result.meetScore,

--- a/backend/src/services/consumerService.js
+++ b/backend/src/services/consumerService.js
@@ -9,6 +9,7 @@ import { normalizePhone } from './prospectHelpers.js';
 // Codex R4-era #2): a moved prospect changes BOTH people's resolved facts.
 // Leaf import (models only) — no cycle.
 import { bumpManyEnrichmentInputsTx } from './enrichmentFence.js';
+import { markLeadsDirtyTx } from './leadScoreDirty.js';
 
 /**
  * Consumer spine (docs/plans/consumer-spine-and-consent-ledger.md §2).
@@ -378,12 +379,18 @@ export function makeConsumerService(overrides = {}) {
            FROM prospects oldp
           WHERE oldp.id = p.id
             AND p."leadSource" = 'call_bot' AND p."consumerId" IS NOT NULL
-        RETURNING oldp."consumerId" AS old_cid`,
+        RETURNING p.id AS pid, oldp."consumerId" AS old_cid`,
         { transaction: t }
       );
       stats.callBotUnlinked = cbMeta?.rowCount ?? 0;
       if (cbMoved?.length) {
         await bumpManyEnrichmentInputsTx(t, cbMoved.map((r) => r.old_cid));
+        // The unlinked lead itself must be dirtied BY ID: it now has no
+        // consumerId, so the consumer-keyed dirtying inside the bump above
+        // cannot reach it — and losing the person is exactly the kind of
+        // change that moves its score (every person-wide capability term
+        // vanishes with the link).
+        await markLeadsDirtyTx(t, cbMoved.map((r) => r.pid));
       }
 
       // A phone cleared to null/empty (PUT-to-blank) takes its link with it
@@ -394,12 +401,13 @@ export function makeConsumerService(overrides = {}) {
            FROM prospects oldp
           WHERE oldp.id = p.id
             AND p."consumerId" IS NOT NULL AND (p.phone IS NULL OR p.phone = '')
-        RETURNING oldp."consumerId" AS old_cid`,
+        RETURNING p.id AS pid, oldp."consumerId" AS old_cid`,
         { transaction: t }
       );
       stats.emptyPhoneUnlinked = epMeta?.rowCount ?? 0;
       if (epMoved?.length) {
         await bumpManyEnrichmentInputsTx(t, epMoved.map((r) => r.old_cid));
+        await markLeadsDirtyTx(t, epMoved.map((r) => r.pid));
       }
 
       const [, reP] = await d.sequelize.query(

--- a/backend/src/services/enrichmentFence.js
+++ b/backend/src/services/enrichmentFence.js
@@ -1,4 +1,5 @@
 import { sequelize, Consumer, Prospect, ConsumerProfile } from '../models/index.js';
+import { markConsumerLeadsDirtyTx } from './leadScoreDirty.js';
 import { logger } from '../utils/logger.js';
 
 /**
@@ -37,6 +38,12 @@ export class ErasedConsumerError extends Error {
  */
 export async function bumpEnrichmentInputTx(t, consumerId) {
   if (!consumerId) return;
+  // Lead-grain invalidation rides the SAME call (per-campaign-lead-scoring.md
+  // §10). Every writer that feeds the score already calls this, so dirtying
+  // here is what makes the lead grain inherit the whole existing invalidation
+  // surface instead of needing each writer taught separately. A fact is
+  // person-wide, so it dirties every one of that person's leads.
+  await markConsumerLeadsDirtyTx(t, [consumerId]);
   // INSERT…SELECT guarded on the live consumer: a bump must never mint a
   // profile row for an erased (or vanished) person — erasure deletes the
   // profile and this would quietly resurrect it.

--- a/backend/src/services/enrichmentSweepService.js
+++ b/backend/src/services/enrichmentSweepService.js
@@ -4,6 +4,10 @@ import {
   getActiveScoringConfig, findStaleConsumerIds, findConsumerIdsAfter,
   scoreOneConsumer, scoringEnabled,
 } from './consumerScoringService.js';
+import {
+  findStaleLeadIds, findLeadIdsAfter, scoreOneLead,
+} from './leadScoringService.js';
+import { LEAD_ALGORITHM_VERSION } from '../utils/consumerScoring.js';
 import { logger } from '../utils/logger.js';
 
 /**
@@ -166,17 +170,21 @@ export async function finalizeRun(runId, ownerToken, { status, stats, cursor }) 
  * One consumer's failure is logged and counted, never fatal — a single bad
  * row must not cost the night's remaining budget.
  */
-async function processBatch(ids, ctx) {
+async function processBatch(ids, ctx, { scoreOne, rowCap, deadline, grain } = {}) {
+  const score = scoreOne || ctx.scoreOne;
+  const cap = rowCap ?? ctx.rowBudget;
+  const by = deadline ?? ctx.deadline;
+
   for (const id of ids) {
-    if (ctx.rowsUsed >= ctx.rowBudget) return 'row_budget';
-    if (Date.now() >= ctx.deadline) return 'time_budget';
+    if (ctx.rowsUsed >= cap) return 'row_budget';
+    if (Date.now() >= by) return 'time_budget';
 
     try {
-      const res = await ctx.scoreOne(id, { now: Date.now() });
+      const res = await score(id, { now: Date.now() });
       ctx.stats[res.status] = (ctx.stats[res.status] || 0) + 1;
     } catch (err) {
       ctx.stats.errors = (ctx.stats.errors || 0) + 1;
-      logger.error('[enrichmentSweep] scoring failed', { consumerId: id, error: err.message });
+      logger.error('[enrichmentSweep] scoring failed', { grain: grain || 'consumer', id, error: err.message });
     }
 
     ctx.rowsUsed += 1;
@@ -207,6 +215,8 @@ export async function sweepConsumers({
   const getConfig = deps.getActiveScoringConfig || getActiveScoringConfig;
   const findStale = deps.findStaleConsumerIds || findStaleConsumerIds;
   const findAfter = deps.findConsumerIdsAfter || findConsumerIdsAfter;
+  const findStaleLeads = deps.findStaleLeadIds || findStaleLeadIds;
+  const findLeadsAfter = deps.findLeadIdsAfter || findLeadIdsAfter;
 
   const { version: configVersion, config } = await getConfig();
   const algorithmVersion = config.algorithmVersion;
@@ -219,8 +229,29 @@ export async function sweepConsumers({
     rowsUsed: 0,
     lastId: null,
     scoreOne: deps.scoreOneConsumer || scoreOneConsumer,
+    scoreOneLeadFn: deps.scoreOneLead || scoreOneLead,
     heartbeatFn: deps.heartbeat || heartbeat,
     stats: { scored: 0, unchanged: 0, skipped: 0, errors: 0 },
+  };
+
+  /**
+   * THE ROTATION RESERVATION (§6, Codex round 3a/3b).
+   *
+   * A row-count reservation alone guarantees nothing. The deadline is checked
+   * before every row (processBatch above) and the rotation runs only when no
+   * stop occurred, so a wall-clock stop inside the stale phase yields ZERO
+   * rotation — and on a population whose stale backlog recurs nightly (config
+   * churn), the rotation would starve indefinitely.
+   *
+   * So the reservation is two-dimensional: the stale phases stop ADMITTING at
+   * 80% of the row cap AND 80% of the deadline, leaving the rotation the final
+   * 20% admission window of each. ADMISSION is what is reserved, not literal
+   * wall-clock — an in-flight row can still overrun the moment of the check.
+   */
+  const ROTATION_RESERVE = 0.2;
+  const staleLimits = {
+    rowCap: Math.max(1, Math.floor(rowBudget * (1 - ROTATION_RESERVE))),
+    deadline: Date.now() + Math.max(1, Math.floor(timeBudgetMs * (1 - ROTATION_RESERVE))),
   };
 
   // Phase 1 — provably-stale rows (never scored, or scored under an old
@@ -235,30 +266,78 @@ export async function sweepConsumers({
   // signal an operator has for whether a run finished its work or merely ran
   // out of room, and those demand opposite responses (ignore vs raise the
   // budget). Breaking out silently reported both as "exhausted".
-  const budgetSpent = () => {
-    if (ctx.rowsUsed >= ctx.rowBudget) return 'row_budget';
-    if (Date.now() >= ctx.deadline) return 'time_budget';
+  const budgetSpent = (limits = {}) => {
+    const cap = limits.rowCap ?? ctx.rowBudget;
+    const by = limits.deadline ?? ctx.deadline;
+    if (ctx.rowsUsed >= cap) return 'row_budget';
+    if (Date.now() >= by) return 'time_budget';
     return null;
   };
 
-  let stop = null;
-  let staleCursor = null;
-  for (;;) {
-    stop = budgetSpent();
-    if (stop) break;
-    const batch = await findStale({
-      configVersion,
-      algorithmVersion,
-      limit: Math.min(200, ctx.rowBudget - ctx.rowsUsed),
-      afterId: staleCursor,
+  /** One provably-stale phase, bounded by the reserved stale window. */
+  async function stalePhase({ find, scoreOne, grain, findArgs }) {
+    let phaseCursor = null;
+    for (;;) {
+      const spent = budgetSpent(staleLimits);
+      if (spent) return spent;
+      const batch = await find({
+        ...findArgs,
+        limit: Math.min(200, Math.max(1, staleLimits.rowCap - ctx.rowsUsed)),
+        afterId: phaseCursor,
+      });
+      if (!batch.length) return null;
+      const stop = await processBatch(batch, ctx, { scoreOne, grain, ...staleLimits });
+      phaseCursor = ctx.lastId;
+      if (stop) return stop;
+    }
+  }
+
+  /** One rotation phase, against the FULL budget, from a durable cursor. */
+  async function rotationPhase({ find, scoreOne, grain, startCursor }) {
+    let phaseCursor = startCursor;
+    for (;;) {
+      const spent = budgetSpent();
+      if (spent) return { stop: spent, cursor: phaseCursor, wrapped: false };
+      const batch = await find({
+        afterId: phaseCursor,
+        limit: Math.min(200, ctx.rowBudget - ctx.rowsUsed),
+      });
+      if (!batch.length) {
+        // End of the id space. Reset so the next run starts from the top.
+        return { stop: null, cursor: null, wrapped: true };
+      }
+      const stop = await processBatch(batch, ctx, { scoreOne, grain });
+      phaseCursor = ctx.lastId;
+      if (stop) return { stop, cursor: phaseCursor, wrapped: false };
+    }
+  }
+
+  // Phase 1 — provably-stale CONSUMERS, then provably-stale LEADS. Both are
+  // wrong right now, so they share first claim on the budget; the lead phase
+  // includes every dirty-marked lead (§10), which is how an event-driven move
+  // that outlived its in-process rescore still lands the same night.
+  let staleStop = await stalePhase({
+    find: findStale, scoreOne: ctx.scoreOne, grain: 'consumer',
+    findArgs: { configVersion, algorithmVersion },
+  });
+  const consumerStaleScored = ctx.rowsUsed;
+
+  if (staleStop !== 'taken_over') {
+    const leadStop = await stalePhase({
+      find: findStaleLeads, scoreOne: ctx.scoreOneLeadFn, grain: 'lead',
+      findArgs: { configVersion },
     });
-    if (!batch.length) break;
-    stop = await processBatch(batch, ctx);
-    staleCursor = ctx.lastId;
-    if (stop) break;
+    staleStop = leadStop === 'taken_over' ? leadStop : (staleStop || leadStop);
   }
 
   const staleScored = ctx.rowsUsed;
+  const leadStaleScored = staleScored - consumerStaleScored;
+
+  // A stale phase that stopped on its RESERVED window has not spent the run's
+  // budget — only a takeover ends the night early. This is the whole point of
+  // the reservation: 'row_budget' here means "the stale slice is full", not
+  // "there is no room left".
+  let stop = staleStop === 'taken_over' ? 'taken_over' : null;
 
   // Phase 2 — budgeted rotation for hash-level staleness (facts can move
   // under a still-current config, and no SQL predicate detects that).
@@ -270,25 +349,34 @@ export async function sweepConsumers({
   // cursor is durable, so stopping at the end and resuming next run covers
   // the same ground without the churn.
   let rotationCursor = cursor?.lastConsumerId || null;
+  let leadRotationCursor = cursor?.lastProspectId || null;
   let rotationWrapped = false;
+  let leadRotationWrapped = false;
+  let consumerRotationScored = 0;
+
   if (!stop) {
-    for (;;) {
-      stop = budgetSpent();
-      if (stop) break;
-      const batch = await findAfter({
-        afterId: rotationCursor,
-        limit: Math.min(200, ctx.rowBudget - ctx.rowsUsed),
-      });
-      if (!batch.length) {
-        // End of the id space. Reset so the next run starts from the top.
-        rotationCursor = null;
-        rotationWrapped = true;
-        break;
-      }
-      stop = await processBatch(batch, ctx);
-      rotationCursor = ctx.lastId;
-      if (stop) break;
-    }
+    const r = await rotationPhase({
+      find: findAfter, scoreOne: ctx.scoreOne, grain: 'consumer',
+      startCursor: rotationCursor,
+    });
+    rotationCursor = r.cursor;
+    rotationWrapped = r.wrapped;
+    stop = r.stop;
+    consumerRotationScored = ctx.rowsUsed - staleScored;
+  }
+
+  if (stop !== 'taken_over') {
+    // Safe to call unconditionally: an exhausted budget makes this return on
+    // its first check. Each grain keeps its OWN cursor, so a run that only
+    // had room for consumers does not silently advance the lead rotation past
+    // leads it never looked at.
+    const r = await rotationPhase({
+      find: findLeadsAfter, scoreOne: ctx.scoreOneLeadFn, grain: 'lead',
+      startCursor: leadRotationCursor,
+    });
+    leadRotationCursor = r.cursor;
+    leadRotationWrapped = r.wrapped;
+    stop = r.stop || stop;
   }
 
   return {
@@ -296,14 +384,22 @@ export async function sweepConsumers({
       ...ctx.stats,
       rowsUsed: ctx.rowsUsed,
       staleScored,
+      consumerStaleScored,
+      leadStaleScored,
       rotationScored: ctx.rowsUsed - staleScored,
-      // 'exhausted' now means what it says: no stale rows and the rotation
-      // reached the end of the population within budget.
-      stoppedBy: stop || (rotationWrapped ? 'exhausted' : 'no_work'),
+      consumerRotationScored,
+      leadRotationScored: ctx.rowsUsed - staleScored - consumerRotationScored,
+      // 'exhausted' means what it says: no stale rows left and BOTH rotations
+      // reached the end of their population within budget. These per-phase
+      // numbers are the measured throughput §6 promises instead of a
+      // calendar — the rotation period is population ÷ this, and a starving
+      // rotation shows up here as a persistent zero.
+      stoppedBy: stop || (rotationWrapped && leadRotationWrapped ? 'exhausted' : 'no_work'),
       configVersion,
       algorithmVersion,
+      leadAlgorithmVersion: LEAD_ALGORITHM_VERSION,
     },
-    cursor: { lastConsumerId: rotationCursor },
+    cursor: { lastConsumerId: rotationCursor, lastProspectId: leadRotationCursor },
     takenOver: stop === 'taken_over',
   };
 }

--- a/backend/src/services/erasureService.js
+++ b/backend/src/services/erasureService.js
@@ -311,7 +311,7 @@ export function makeErasureService(overrides = {}) {
         // THE SCORE NOW GOES TOO (per-campaign-lead-scoring.md §11). It used
         // to be retained — named in the skeleton above and never touched here
         // — which was defensible while it was a dead column written by
-        // nothing. Since 097 it is a live judgement about the person, and its
+        // nothing. Since 099 it is a live judgement about the person, and its
         // breakdown is materially worse than the bare integer: the response
         // events carry the timestamps of when they read our messages, the
         // normalized screening signal carries inferred sentiment and interest,

--- a/backend/src/services/erasureService.js
+++ b/backend/src/services/erasureService.js
@@ -19,7 +19,7 @@ import { evictDncCheckCache } from './dncCheckService.js';
  * PDPA person-level erasure (PR C, docs/plans/consumer-spine-and-consent-ledger.md §4).
  *
  * ERASURE = ALLOWLIST REBUILD, NOT A SCRUB LIST: a prospect row keeps only its
- * non-personal skeleton (ids, campaign, status/priority/score, quarantine,
+ * non-personal skeleton (ids, campaign, status/priority, quarantine,
  * conversionDate, utm source labels) and EVERYTHING else goes — including the
  * copies PII leaked into over its lifetime: activity update-snapshots,
  * commission descriptions, webhook delivery payloads, draw-entry masked-name
@@ -304,11 +304,27 @@ export function makeErasureService(overrides = {}) {
         }
 
         // 7. Prospect allowlist rebuild. KEPT: id, campaignId, consumerId,
-        // leadSource, leadStatus, priority, score, conversionDate, agent/qr
+        // leadSource, leadStatus, priority, conversionDate, agent/qr
         // refs, quarantine fields, timestamps (business-records basis).
         // Everything else is PII or a PII pointer and goes.
+        //
+        // THE SCORE NOW GOES TOO (per-campaign-lead-scoring.md §11). It used
+        // to be retained — named in the skeleton above and never touched here
+        // — which was defensible while it was a dead column written by
+        // nothing. Since 097 it is a live judgement about the person, and its
+        // breakdown is materially worse than the bare integer: the response
+        // events carry the timestamps of when they read our messages, the
+        // normalized screening signal carries inferred sentiment and interest,
+        // and basisObservationIds point straight at fact rows this same
+        // erasure deletes. Nulling the stamps alongside is what stops the
+        // sweep re-scoring the row straight back — though findStaleLeadIds
+        // excludes erased people too, so this is belt and braces.
         const [, pMeta] = await d.sequelize.query(
           `UPDATE prospects SET
+              score = NULL, "meetScore" = NULL, "buyScore" = NULL,
+              "scoreBreakdown" = NULL, "scoreComputedAt" = NULL,
+              "scoredConfigVersion" = NULL, "scoringAlgorithmVersion" = NULL,
+              "scoreInputHash" = NULL, "scoreDirtyAt" = NULL,
               "firstName" = 'Erased', "lastName" = NULL, email = NULL, phone = NULL,
               company = NULL, "jobTitle" = NULL, industry = NULL,
               interests = '[]', budget = NULL, location = NULL, demographics = NULL,

--- a/backend/src/services/leadScoreDirty.js
+++ b/backend/src/services/leadScoreDirty.js
@@ -1,0 +1,74 @@
+import { sequelize } from '../database/connection.js';
+
+/**
+ * The lead-grain dirty marker (per-campaign-lead-scoring.md §10).
+ *
+ * Its OWN module, not part of leadScoringService, purely to keep the import
+ * graph acyclic: enrichmentFence must be able to dirty leads, and
+ * leadScoringService already imports the fence.
+ *
+ * Nothing existing covered lead-grain invalidation. The spine relinker bumps
+ * only consumer_profiles.inputVersion (consumerService.js:326-338),
+ * bumpEnrichmentInputTx upserts only consumer_profiles
+ * (enrichmentFence.js:38-52), and the sweep enumerated consumers.
+ * Prospect.enrichmentRevision exists but feeds map jobs — it is not a scanned
+ * dirty flag.
+ *
+ * ALWAYS CALLED IN THE MUTATION'S OWN TRANSACTION. The marker is the durable
+ * half of the contract: the post-commit rescore is an optimisation, and if it
+ * dies with the process the marker still makes the lead provably stale, so it
+ * rides the sweep's stale-FIRST phase with first claim on the next run's
+ * budget.
+ *
+ * COALESCE keeps the OLDEST pending instant. The marker answers "how long has
+ * this been waiting"; refreshing it on every touch would let a repeatedly
+ * touched lead look permanently fresh and hide a starving rotation.
+ */
+
+/** Dirty specific leads. */
+export async function markLeadsDirtyTx(t, prospectIds) {
+  const ids = [...new Set((prospectIds || []).filter(Boolean))];
+  if (!ids.length) return 0;
+  const [, meta] = await sequelize.query(
+    `UPDATE prospects
+        SET "scoreDirtyAt" = COALESCE("scoreDirtyAt", now()), "updatedAt" = now()
+      WHERE id IN (:ids)`,
+    { replacements: { ids }, transaction: t }
+  );
+  return meta?.rowCount ?? 0;
+}
+
+/**
+ * Dirty every lead of these people — the shape a fact write or a relink has.
+ * A fact is person-wide, so it moves every one of that person's leads; which
+ * of them it moves BY HOW MUCH is the scorer's business, not this marker's.
+ */
+export async function markConsumerLeadsDirtyTx(t, consumerIds) {
+  const ids = [...new Set((consumerIds || []).filter(Boolean))];
+  if (!ids.length) return 0;
+  const [, meta] = await sequelize.query(
+    `UPDATE prospects
+        SET "scoreDirtyAt" = COALESCE("scoreDirtyAt", now()), "updatedAt" = now()
+      WHERE "consumerId" IN (:ids)`,
+    { replacements: { ids }, transaction: t }
+  );
+  return meta?.rowCount ?? 0;
+}
+
+/**
+ * Dirty the lead that owns a WhatsApp message (§5's join), by wamid.
+ * Returns the prospect ids touched, so the caller can fire post-commit
+ * rescores for exactly those leads.
+ */
+export async function markLeadDirtyByWamidTx(t, wamid) {
+  if (!wamid) return [];
+  const [rows] = await sequelize.query(
+    `UPDATE prospects p
+        SET "scoreDirtyAt" = COALESCE(p."scoreDirtyAt", now()), "updatedAt" = now()
+       FROM wa_message_sends s
+      WHERE s.wamid = :wamid AND p.id = s."prospectId"
+      RETURNING p.id`,
+    { replacements: { wamid: String(wamid).slice(0, 128) }, transaction: t }
+  );
+  return (rows || []).map((r) => r.id);
+}

--- a/backend/src/services/leadScoringService.js
+++ b/backend/src/services/leadScoringService.js
@@ -1,0 +1,380 @@
+import { sequelize } from '../models/index.js';
+import { withConsumerFence, ErasedConsumerError } from './enrichmentFence.js';
+import { resolveCurrentFacts } from '../utils/factResolver.js';
+import { canonicalJson, sha256 } from './factMapperService.js';
+import { getActiveScoringConfig, loadObservations } from './consumerScoringService.js';
+import { scoreLead, LEAD_ALGORITHM_VERSION } from '../utils/consumerScoring.js';
+import { normalizeScreeningSignal } from '../utils/screeningSignal.js';
+import { canMarketTo } from './consentService.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Lead scoring — the I/O half of per-campaign-lead-scoring.md §4/§6/§10.
+ *
+ * THE SCORE IS A PROPERTY OF (person × campaign). A fresh grad is a great
+ * recruit and a poor insurance buyer: identical facts, opposite verdict. A
+ * prospect row already IS that pair, so the score lives on it.
+ *
+ * ONE AUTHORITY (§4). The lead score is the sole computed number. The
+ * person-grain meet/buy/consumerScore become a PROJECTION of it —
+ * `projectPersonScore` below — so the two grains cannot disagree: one is a
+ * copy of the other with a stated rule. scoreOneConsumer no longer writes
+ * them (see its own header).
+ *
+ * ISOLATION (§3.2), enforced by what this file reads:
+ *   - person-wide CAPABILITY, shared by every lead by design: signup counts,
+ *     email on file, the WhatsApp deliverability frontier.
+ *   - lead-scoped RESPONSE, never crossing campaigns: reads of messages THIS
+ *     lead owns (wa_message_sends, §5 — ownership stamped at send, never
+ *     derived), this lead's own screening outcome, this lead's own signup
+ *     recency, and consent read at (consumer, campaign) scope.
+ * A `read` on campaign A's message therefore legitimately moves BOTH grains —
+ * it advances the person's frontier AND is a response for lead A — but it can
+ * never appear as a response on lead B.
+ *
+ * DECAY AT WRITE TIME (§6). One stored number; sort, display and API all read
+ * it; nothing decays at read anywhere. The sacrifice, stated: pure-time
+ * freshness between rescores. The write gate is therefore weaker than the
+ * person-grain one by exactly one clause — skip the write iff the input hash
+ * matches AND the recomputed integers equal the stored ones — so a pure-decay
+ * rewrite still happens the moment it changes an integer, and not before.
+ */
+
+/** Reuses the person-grain flag: one switch for the whole scoring subsystem. */
+export { scoringEnabled } from './consumerScoringService.js';
+
+/**
+ * Every message this lead owns, with whatever Meta has said about it.
+ *
+ * The join is on wamid — exact and immutable, because ownership was stamped
+ * at SEND (§5). `occurredAt` is Meta's own timestamp and is nullable, so it
+ * falls back to when we recorded the status.
+ *
+ * 'read' is an equality here and NOT a rank predicate, unlike the
+ * deliverability check: the frontier's ranks are ordered
+ * sent < delivered < read < failed (waWebhookService.js:37), so `= 'read'` is
+ * exactly "reached read and has not since failed". A read-then-failed row
+ * forfeits its response, the same accepted forfeit §3.3 states for
+ * deliverability.
+ */
+export async function loadOwnedMessages(prospectId) {
+  const [rows] = await sequelize.query(
+    `SELECT s.wamid, s.kind, s."sentAt", st.status,
+            COALESCE(st."occurredAt", st."updatedAt") AS "statusAt"
+       FROM wa_message_sends s
+       LEFT JOIN wa_message_statuses st ON st.wamid = s.wamid
+      WHERE s."prospectId" = :pid
+      ORDER BY s."sentAt"`,
+    { replacements: { pid: prospectId } }
+  );
+  return rows;
+}
+
+/**
+ * Everything the lead scorer needs, at the grain §3.4 assigns each input.
+ * Returns null when the prospect is gone.
+ */
+export async function loadLeadTelemetry(prospectId) {
+  const [[row]] = await sequelize.query(
+    `SELECT p.id, p."consumerId", p."campaignId", p."createdAt" AS "ownSignupAt",
+            p."screeningVerdict", p."screeningMetadata",
+            c."signupCount", c."verifiedSignupCount",
+            (c.email IS NOT NULL AND c.email <> '') AS "hasEmail",
+            -- Person-wide CAPABILITY (§3.3): a rank predicate, never an
+            -- equality. wa_message_statuses keeps one row per wamid holding
+            -- the FURTHEST status, so a read message IS a delivered message
+            -- whose frontier moved on — dropping 'read' would un-reach
+            -- exactly the people with the strongest proof.
+            EXISTS (
+              SELECT 1 FROM wa_message_statuses w
+               WHERE w."recipientHash" = c."phoneHash"
+                 AND w.status IN ('delivered', 'read')
+            ) AS "whatsappReachable"
+       FROM prospects p
+       LEFT JOIN consumers c ON c.id = p."consumerId"
+      WHERE p.id = :pid`,
+    { replacements: { pid: prospectId } }
+  );
+  if (!row) return null;
+
+  const owned = await loadOwnedMessages(prospectId);
+
+  // Consent is read through the ledger's OWN derivation — never re-scoped
+  // here (§3.3). canMarketTo is the same gate every marketing send calls
+  // (consentService.js:434-441), so the score can never advertise a
+  // reachability the gate would refuse. Unlinked leads have no consumer to
+  // resolve, and it fails closed.
+  const marketingConsent = row.consumerId
+    ? await canMarketTo({ consumerId: row.consumerId, campaignId: row.campaignId || null })
+    : false;
+
+  return {
+    consumerId: row.consumerId || null,
+    campaignId: row.campaignId || null,
+
+    // Person-wide capability — shared by every one of this person's leads.
+    signupCount: Number(row.signupCount) || 0,
+    verifiedSignupCount: Number(row.verifiedSignupCount) || 0,
+    hasEmail: Boolean(row.hasEmail),
+    whatsappReachable: Boolean(row.whatsappReachable),
+
+    // Lead-scoped. Recency anchors to THIS lead's signup, not the person's
+    // newest: a second signup on another campaign must not refresh this
+    // lead's standing (§3.4).
+    newestSignupAt: row.ownSignupAt,
+    marketingConsent,
+    ownedMessageCount: owned.length,
+    readAt: owned.filter((m) => m.status === 'read' && m.statusAt).map((m) => m.statusAt),
+    screening: normalizeScreeningSignal({
+      screeningVerdict: row.screeningVerdict,
+      screeningMetadata: row.screeningMetadata,
+    }),
+  };
+}
+
+/**
+ * Facts for a lead. The spine exists so every lead reads the PERSON's facts
+ * (§3.4); an unlinked lead falls back to its own prospect-anchored rows,
+ * which is what the mapper wrote before the spine linked it.
+ */
+export async function loadLeadObservations({ prospectId, consumerId }) {
+  if (consumerId) return loadObservations(consumerId);
+  const [rows] = await sequelize.query(
+    `SELECT o.id, o.key, o.value, o.confidence, o.source, o."sourceEventAt",
+            o."supersededAt", o."retractedAt"
+       FROM consumer_observations o
+      WHERE o."sourceProspectId" = :pid`,
+    { replacements: { pid: prospectId } }
+  );
+  return rows;
+}
+
+/**
+ * The hash half of the write gate. Built from the RESOLVED facts and the
+ * telemetry, so a superseded duplicate or a re-ordered query result — neither
+ * of which can change the output — does not force a rewrite.
+ *
+ * `now` is deliberately NOT in it. Time is what the integer comparison in
+ * scoreOneLead covers: including a clock here would make every lead stale
+ * every instant, and omitting the integer check would make a decayed score
+ * never rewrite at all — the person-grain gate's unbounded drift
+ * (consumerScoringService.js:185-198 vs :229-234).
+ */
+export function computeLeadInputHash({ facts, telemetry, configVersion, algorithmVersion }) {
+  const factDigest = Object.keys(facts).sort().map((k) => ({
+    k, v: facts[k].value, c: facts[k].confidence, s: facts[k].source,
+  }));
+  // consumerId/campaignId are identity, not inputs — they are already implied
+  // by the row this hash is stored on, and including them would churn the
+  // hash on a relink that changed no scoreable value.
+  const { consumerId, campaignId, ...scoreable } = telemetry;
+  return sha256(canonicalJson({
+    f: factDigest, t: scoreable, cv: configVersion, av: algorithmVersion,
+  }));
+}
+
+/**
+ * §4's projection, computed under the caller's consumer lock.
+ *
+ * The person's numbers are the winning lead's numbers: highest `score`, ties
+ * broken by most recent createdAt then id — the house tiebreak
+ * (factResolver.js, consumerScoringService.js:119-130). NULL when the person
+ * has no scoreable lead.
+ *
+ * The BREAKDOWN travels with the numbers, extending §4's three columns by
+ * one. It has to: the profile card renders `groups.meet`/`groups.buy`
+ * component rows straight out of scoreBreakdown
+ * (AdminV2LeadProfile.jsx:589-624), so numbers from the winning lead beside a
+ * breakdown from the retired person-grain pass would render components that
+ * visibly do not sum to the score shown above them.
+ *
+ * SERIALISATION: every caller holds the Consumer row FOR UPDATE (the fence,
+ * enrichmentFence.js:87-93), so two of this person's leads can never project
+ * concurrently — the second waits, then reads the first's committed score and
+ * picks the true winner. Erased people are excluded by the guard on the
+ * INSERT…SELECT, which is what stops a projection resurrecting a deleted
+ * profile row.
+ */
+export async function projectPersonScore(t, consumerId) {
+  if (!consumerId) return null;
+  await sequelize.query(
+    `INSERT INTO consumer_profiles
+       ("consumerId", "consumerScore", "meetScore", "buyScore", "scoreBreakdown",
+        "inputVersion", "syncedInputVersion", "createdAt", "updatedAt")
+     SELECT c.id, best.score, best."meetScore", best."buyScore", best."scoreBreakdown",
+            0, 0, now(), now()
+       FROM consumers c
+       LEFT JOIN LATERAL (
+         SELECT p.score, p."meetScore", p."buyScore", p."scoreBreakdown"
+           FROM prospects p
+          WHERE p."consumerId" = c.id AND p.score IS NOT NULL
+          ORDER BY p.score DESC, p."createdAt" DESC, p.id DESC
+          LIMIT 1
+       ) best ON true
+      WHERE c.id = :cid AND c."erasedAt" IS NULL
+     ON CONFLICT ("consumerId") DO UPDATE SET
+       "consumerScore" = EXCLUDED."consumerScore",
+       "meetScore" = EXCLUDED."meetScore",
+       "buyScore" = EXCLUDED."buyScore",
+       "scoreBreakdown" = EXCLUDED."scoreBreakdown",
+       "updatedAt" = now()`,
+    { replacements: { cid: consumerId }, transaction: t }
+  );
+  return true;
+}
+
+/**
+ * Score one lead and persist the result.
+ *
+ * @returns {{status:'scored'|'unchanged'|'skipped', reason?:string,
+ *            score?:number|null, meetScore?:number|null, buyScore?:number|null}}
+ */
+export async function scoreOneLead(prospectId, { force = false, now = Date.now() } = {}) {
+  const { version: configVersion, config } = await getActiveScoringConfig({ now });
+
+  const telemetry = await loadLeadTelemetry(prospectId);
+  if (!telemetry) return { status: 'skipped', reason: 'prospect_gone' };
+
+  const observations = await loadLeadObservations({
+    prospectId, consumerId: telemetry.consumerId,
+  });
+  const facts = resolveCurrentFacts(observations);
+  const inputHash = computeLeadInputHash({
+    facts, telemetry, configVersion, algorithmVersion: LEAD_ALGORITHM_VERSION,
+  });
+
+  const result = scoreLead({ facts, telemetry, config, now });
+
+  try {
+    return await withConsumerFence(prospectId, async (t, { prospect, consumer }) => {
+      // The gate. Both clauses, because either alone is wrong: the hash has no
+      // clock in it, so decay would never rewrite; the integers alone would
+      // rewrite on every no-op fact churn.
+      const unchanged = !force
+        && prospect.scoreInputHash === inputHash
+        && prospect.scoredConfigVersion === configVersion
+        && prospect.scoringAlgorithmVersion === LEAD_ALGORITHM_VERSION
+        && prospect.score === result.score
+        && prospect.meetScore === result.meetScore
+        && prospect.buyScore === result.buyScore
+        && prospect.scoreDirtyAt === null;
+
+      if (unchanged) return { status: 'unchanged', reason: 'input_hash_and_integers_match' };
+
+      await sequelize.query(
+        `UPDATE prospects SET
+            score = :score,
+            "meetScore" = :meetScore,
+            "buyScore" = :buyScore,
+            "scoreBreakdown" = :breakdown::jsonb,
+            "scoredConfigVersion" = :configVersion,
+            "scoringAlgorithmVersion" = :algorithmVersion,
+            "scoreInputHash" = :inputHash,
+            "scoreComputedAt" = now(),
+            -- Cleared unconditionally: this rescore has just consumed whatever
+            -- dirtied it. A marker set DURING this transaction cannot be lost,
+            -- because every dirtier takes the same consumer lock.
+            "scoreDirtyAt" = NULL,
+            "updatedAt" = now()
+          WHERE id = :pid`,
+        {
+          replacements: {
+            pid: prospectId,
+            score: result.score,
+            meetScore: result.meetScore,
+            buyScore: result.buyScore,
+            breakdown: JSON.stringify(result.breakdown),
+            configVersion,
+            algorithmVersion: LEAD_ALGORITHM_VERSION,
+            inputHash,
+          },
+          transaction: t,
+        }
+      );
+
+      // The person's numbers follow, in the same transaction and under the
+      // same lock — so a reader can never see a lead score without the
+      // projection that is defined to equal it.
+      await projectPersonScore(t, consumer?.id || null);
+
+      return {
+        status: 'scored',
+        score: result.score,
+        meetScore: result.meetScore,
+        buyScore: result.buyScore,
+      };
+    });
+  } catch (err) {
+    if (err instanceof ErasedConsumerError) return { status: 'skipped', reason: 'erased' };
+    throw err;
+  }
+}
+
+/**
+ * Leads whose score is provably stale: never scored, scored by a superseded
+ * config or algorithm, or explicitly dirtied by a choke-point writer (§10).
+ *
+ * Erased people are excluded — their leads keep a nulled score by design
+ * (§11), and re-scoring one would write the number straight back.
+ *
+ * Hash-level staleness (facts moved, config didn't) is NOT expressible in
+ * SQL; that is what the sweep's rotation is for.
+ */
+export async function findStaleLeadIds({ configVersion, limit = 200, afterId = null }) {
+  const [rows] = await sequelize.query(
+    `SELECT p.id
+       FROM prospects p
+       LEFT JOIN consumers c ON c.id = p."consumerId"
+      WHERE (p."consumerId" IS NULL OR c."erasedAt" IS NULL)
+        AND (:afterId::uuid IS NULL OR p.id > :afterId::uuid)
+        AND (
+          p."scoreComputedAt" IS NULL
+          OR p."scoreDirtyAt" IS NOT NULL
+          OR p."scoredConfigVersion" IS DISTINCT FROM :configVersion
+          OR p."scoringAlgorithmVersion" IS DISTINCT FROM :algorithmVersion
+        )
+      ORDER BY p.id
+      LIMIT :limit`,
+    {
+      replacements: {
+        configVersion, algorithmVersion: LEAD_ALGORITHM_VERSION, limit, afterId,
+      },
+    }
+  );
+  return rows.map((r) => r.id);
+}
+
+/** Leads to re-examine on the rotation, walking the id space from a cursor. */
+export async function findLeadIdsAfter({ afterId = null, limit = 200 }) {
+  const [rows] = await sequelize.query(
+    `SELECT p.id
+       FROM prospects p
+       LEFT JOIN consumers c ON c.id = p."consumerId"
+      WHERE (p."consumerId" IS NULL OR c."erasedAt" IS NULL)
+        AND (:afterId::uuid IS NULL OR p.id > :afterId::uuid)
+      ORDER BY p.id
+      LIMIT :limit`,
+    { replacements: { afterId, limit } }
+  );
+  return rows.map((r) => r.id);
+}
+
+// The dirty markers live in leadScoreDirty.js (import-cycle reasons — the
+// fence needs them too). Re-exported here so the choke points have one door.
+export {
+  markLeadsDirtyTx, markConsumerLeadsDirtyTx, markLeadDirtyByWamidTx,
+} from './leadScoreDirty.js';
+
+/**
+ * Post-commit rescore attempt (§6, "event-driven moves don't wait for the
+ * rotation"). Fire-and-forget by contract: the dirty marker is the durable
+ * half, so a failure here costs latency, never correctness.
+ */
+export function rescoreLeadSoon(prospectId) {
+  if (!prospectId) return;
+  Promise.resolve()
+    .then(() => scoreOneLead(prospectId))
+    .catch((err) => logger.warn('[leadScoring] post-commit rescore failed', {
+      prospectId, error: err?.message,
+    }));
+}

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -1,5 +1,5 @@
 import { randomUUID, createHash } from 'crypto';
-import { Op, Transaction, fn as sqlFn, col as sqlCol, where as sqlWhere } from 'sequelize';
+import { Op, Transaction, fn as sqlFn, col as sqlCol, where as sqlWhere, literal as sqlLiteral } from 'sequelize';
 import {
   Prospect,
   User,
@@ -104,8 +104,17 @@ const VALID_LEAD_SOURCES = ['qr_code', 'website', 'referral', 'social_media', 'a
 // List-endpoint sort whitelist (admin rebuild Phase B). `-` prefix = DESC.
 // Anything outside the map falls back to the default — never a 500, never an
 // unindexed free-form ORDER BY.
-const PROSPECT_SORT_FIELDS = ['firstName', 'leadStatus', 'createdAt'];
+const PROSPECT_SORT_FIELDS = ['firstName', 'leadStatus', 'createdAt', 'score'];
 const DEFAULT_PROSPECT_SORT = '-createdAt';
+
+/**
+ * Sorts where NULL means "not scored yet" rather than "lowest". Postgres
+ * orders NULLs FIRST on DESC, so `-score` would lead every page with the
+ * unscored leads — the exact opposite of what "sort by best lead" means. Both
+ * directions get NULLS LAST, the same rule and the same reasoning as the
+ * People list's score sorts (consumerService.js:561-571).
+ */
+const NULLS_LAST_SORT_FIELDS = new Set(['score']);
 
 /**
  * Comma-list enum filter: split, trim, dedupe, whitelist. Returns
@@ -129,7 +138,12 @@ function parseProspectSort(sort) {
   const desc = raw.startsWith('-');
   const field = desc ? raw.slice(1) : raw;
   if (!PROSPECT_SORT_FIELDS.includes(field)) return [['createdAt', 'DESC']];
-  return [[field, desc ? 'DESC' : 'ASC']];
+  const dir = desc ? 'DESC' : 'ASC';
+  if (NULLS_LAST_SORT_FIELDS.has(field)) {
+    // Column name comes from the whitelist above, never from the request.
+    return [[sqlLiteral(`"Prospect"."${field}" ${dir} NULLS LAST`)]];
+  }
+  return [[field, dir]];
 }
 
 // Hold reasons a MANUAL admin (re)assign may release. Everything else is fenced:

--- a/backend/src/services/redeemOps/waWebhookService.js
+++ b/backend/src/services/redeemOps/waWebhookService.js
@@ -4,6 +4,8 @@ import Consumer from '../../models/Consumer.js';
 import { applyUnsubscribe } from '../consentService.js';
 import { phoneHashOf } from '../consumerService.js';
 import { normalizePhone } from '../prospectHelpers.js';
+import { markLeadDirtyByWamidTx } from '../leadScoreDirty.js';
+import { rescoreLeadSoon } from '../leadScoringService.js';
 import { logger } from '../../utils/logger.js';
 
 /**
@@ -41,6 +43,25 @@ const STOP_FORMS = new Set(['stop', 'stop promotions', 'unsubscribe', 'cancel'])
 // than this is hostile or malformed and the tail is dropped (logged).
 const MAX_ITEMS = 200;
 
+/**
+ * Default lead-score reaction to a status. Dirty the owning lead (durable),
+ * then attempt an immediate rescore (best effort). Returns how many leads were
+ * dirtied so the caller can count them. Swallows its own errors: losing a
+ * rescore costs freshness, losing the status costs delivery truth, and only
+ * one of those is this webhook's job.
+ */
+async function defaultOnMessageRead(wamid, status) {
+  if (status !== 'read' || !wamid) return 0;
+  try {
+    const ids = await sequelize.transaction((t) => markLeadDirtyByWamidTx(t, wamid));
+    for (const id of ids) rescoreLeadSoon(id);
+    return ids.length;
+  } catch (err) {
+    logger.warn('redeem_ops.wa.read_invalidation_failed', { wamid, error: err?.message });
+    return 0;
+  }
+}
+
 export function makeWaWebhookService(overrides = {}) {
   const d = {
     sequelize,
@@ -48,6 +69,7 @@ export function makeWaWebhookService(overrides = {}) {
     applyUnsubscribe,
     phoneHashOf,
     normalizePhone,
+    onMessageRead: defaultOnMessageRead,
     logger,
     ...overrides,
   };
@@ -130,7 +152,7 @@ export function makeWaWebhookService(overrides = {}) {
    * persisted is safe because every write here is idempotent.
    */
   async function processPayload(body) {
-    const counts = { statuses: 0, stops: 0, skippedEntries: 0, unmatchedForeign: 0 };
+    const counts = { statuses: 0, stops: 0, skippedEntries: 0, unmatchedForeign: 0, leadsDirtied: 0 };
     if (body?.object !== 'whatsapp_business_account' || !Array.isArray(body?.entry)) return counts;
 
     const wantWaba = process.env.WHATSAPP_WABA_ID || null;
@@ -168,6 +190,15 @@ export function makeWaWebhookService(overrides = {}) {
               wamid: s?.id, status: s?.status,
               ...(err ? { errorCode: err.code, errorTitle: err.title || err.message } : {}),
             });
+            // A read is a RESPONSE to the lead that owns this message
+            // (per-campaign-lead-scoring.md §3.2/§10). Dirty that lead and
+            // fire a post-commit rescore, so the score moves within seconds
+            // rather than waiting for the nightly rotation. Only 'read':
+            // sent/delivered feed the person's capability frontier, which the
+            // scorer reads live and needs no invalidation. Never fatal — the
+            // webhook's job is to persist the status, and Meta's retry is our
+            // durability for THAT.
+            counts.leadsDirtied += await d.onMessageRead(s?.id, s?.status);
           }
         }
 

--- a/backend/src/services/screeningGate.js
+++ b/backend/src/services/screeningGate.js
@@ -1,5 +1,6 @@
 import { sequelize, Prospect, ProspectActivity, User, Campaign } from '../models/index.js';
 import { chargeLeadCredit, refundLeadCredit, deductLeadCredit } from './leadCredits.js';
+import { rescoreLeadSoon } from './leadScoringService.js';
 import { persistEventDeliveries, flushDeliveries } from './webhookService.js';
 import { buildLeadCreatedPayload, destinationForAgent, externalIdForDestination } from './prospectHelpers.js';
 import { resolveLeadRouting } from './systemAgent.js';
@@ -39,6 +40,7 @@ const defaultDeps = {
   Campaign,
   chargeLeadCredit,
   refundLeadCredit,
+  rescoreLeadSoon,
   deductLeadCredit,
   persistEventDeliveries,
   flushDeliveries,
@@ -340,6 +342,12 @@ export function makeScreeningGate(overrides = {}) {
           SET "screeningVerdict" = 'qualified',
               "screeningActiveCallId" = NULL,
               "screeningNextAttemptAt" = NULL,
+              -- The verdict is a lead-scoped RESPONSE, so it dirties the lead
+              -- score (per-campaign-lead-scoring.md §10). Set in the SAME
+              -- statement as the verdict rather than a follow-up write: the
+              -- two can then never disagree, and there is no window in which
+              -- a verdict exists with no pending rescore.
+              "scoreDirtyAt" = COALESCE("scoreDirtyAt", NOW()),
               ${metaMergeSql()},
               "updatedAt" = NOW()
         WHERE id = :id AND "quarantineReason" = 'screening_pending'
@@ -348,6 +356,7 @@ export function makeScreeningGate(overrides = {}) {
       { replacements: { id: prospect.id, callId, metaPatch } }
     );
     if (!Array.isArray(rows) || rows.length === 0) return { outcome: 'stale', applied: false };
+    d.rescoreLeadSoon(prospect.id);
     await prospect.reload().catch(() => {});
     const rel = await releaseScreenedLead({ prospect });
     return { outcome: rel.released ? 'released' : 'qualified_pending_delivery', applied: true, release: rel };
@@ -373,6 +382,10 @@ export function makeScreeningGate(overrides = {}) {
                 "screeningVerdict" = 'not_qualified',
                 "screeningActiveCallId" = NULL,
                 "screeningNextAttemptAt" = NULL,
+                -- Same contract as the qualified arm: the verdict and its
+                -- rescore marker land together (§10). not_qualified is the
+                -- strongest negative response the lead grain has.
+                "scoreDirtyAt" = COALESCE("scoreDirtyAt", NOW()),
                 notes = COALESCE(notes, '') || :notesAppend,
                 ${metaMergeSql()},
                 "updatedAt" = NOW()
@@ -410,6 +423,9 @@ export function makeScreeningGate(overrides = {}) {
       );
 
       await t.commit();
+      // POST-commit: the marker is already durable inside the transaction
+      // above, so this is only the latency optimisation (§6).
+      d.rescoreLeadSoon(prospect.id);
       await prospect.reload().catch(() => {});
       d.logger.info('[Screening] lead failed screening — held', { prospectId: prospect.id, callId, refunded: needsRefund });
       return { outcome: 'failed', applied: true };

--- a/backend/src/utils/consumerScoring.js
+++ b/backend/src/utils/consumerScoring.js
@@ -485,6 +485,87 @@ function scoreCoverageHeadroom(facts, cfg) {
   );
 }
 
+// ── LEAD-GRAIN components (per-campaign-lead-scoring.md §3.2) ──────────────
+//
+// These read RESPONSE inputs: evidence attributed to (person, THIS campaign).
+// They exist only in the lead scorer — a response on campaign A must never
+// enter campaign B's response terms, and the way that is guaranteed is that
+// the person-grain scorer has no rule for them at all.
+
+/**
+ * Response to THIS pitch — WhatsApp reads of messages this lead owns
+ * (wa_message_sends ⋈ wa_message_statuses, §5).
+ *
+ * UNKNOWN vs ZERO is the whole subtlety. Never having messaged someone is not
+ * evidence that they ignore us, so a lead that owns no message is `unknown`.
+ * A lead we DID message and who never read is `assessed` at 0 — that is a
+ * real, negative finding.
+ *
+ * Depth then recency, mirroring scoreEngagement: reading more than once says
+ * more than reading once, and a read from last year says less than one from
+ * yesterday. Decayed at WRITE time against the caller's `now` (§6).
+ */
+function scoreResponse(telemetry, cfg, now) {
+  const sent = Number(telemetry?.ownedMessageCount) || 0;
+  if (sent <= 0) return unknown('no message owned by this lead yet');
+
+  const reads = Array.isArray(telemetry?.readAt) ? telemetry.readAt : [];
+  if (!reads.length) {
+    return assessed(0, [], `${sent} message(s) sent, none read`);
+  }
+
+  const depth = reads.length >= 3 ? 1 : { 1: 0.6, 2: 0.85 }[reads.length] ?? 1;
+  const newest = Math.max(...reads.map((r) => new Date(r).getTime()).filter(Number.isFinite));
+  const recency = Number.isFinite(newest)
+    ? decayFactor(now - newest, cfg.decay?.engagementHalfLifeDays)
+    : 1;
+
+  const fraction = clamp(depth * recency, 0, 1);
+  return assessed(fraction, [], `${reads.length} of ${sent} message(s) read`);
+}
+
+/**
+ * The AI screening call's outcome for THIS lead (§13.1).
+ *
+ * Reads ONLY the normalized signal (utils/screeningSignal.js) — never the raw
+ * provider `checks` object, whose keys are whatever an operator last typed
+ * into the Retell console.
+ *
+ * Blended so a missing sub-signal doesn't drag the component down: interest
+ * is optional in the agent config and `agreedToMeet` has no configured check
+ * at all today, so renormalizing over what is present is the difference
+ * between "we didn't ask" and "they said no".
+ */
+function scoreScreening(telemetry) {
+  const s = telemetry?.screening;
+  if (!s || (s.verdict === null && s.interest === null && s.sentiment === null && s.agreedToMeet === null)) {
+    return unknown('no screening call outcome');
+  }
+
+  // A not_qualified verdict is terminal — the lead never reaches an agent
+  // (screeningGate.markScreeningFailed) — so it dominates rather than blends.
+  if (s.verdict === 'not_qualified') {
+    return assessed(0, [], 'screening verdict: not qualified');
+  }
+
+  const fraction = blend([
+    { fraction: s.verdict === 'qualified' ? 1 : null, weight: 0.4 },
+    { fraction: s.agreedToMeet === null ? null : (s.agreedToMeet ? 1 : 0), weight: 0.3 },
+    { fraction: s.interest, weight: 0.2 },
+    { fraction: s.sentiment, weight: 0.1 },
+  ]);
+  if (fraction === null) return unknown('no scoreable screening signal');
+
+  const said = [
+    s.verdict === 'qualified' && 'qualified',
+    s.labels?.interest && `interest ${s.labels.interest}`,
+    s.labels?.sentiment && `sentiment ${s.labels.sentiment}`,
+    s.agreedToMeet === true && 'agreed to meet',
+    s.agreedToMeet === false && 'declined to meet',
+  ].filter(Boolean);
+  return assessed(clamp(fraction, 0, 1), [], said.join(', ') || 'screened');
+}
+
 const RULES = {
   engagement: (facts, telemetry, cfg, now) => scoreEngagement(telemetry, cfg, now),
   contactability: (facts, telemetry) => scoreContactability(telemetry),
@@ -494,6 +575,11 @@ const RULES = {
   capacity: (facts, telemetry, cfg) => scoreCapacity(facts, cfg),
   age: (facts, telemetry, cfg, now) => scoreAge(facts, cfg, now),
   coverage_headroom: (facts, telemetry, cfg) => scoreCoverageHeadroom(facts, cfg),
+  // Lead-grain only. Present in this shared map because computeScore looks
+  // rules up by name, but reachable only when the config carries the
+  // component — which normalizeLeadConfig does and normalizeConfig does not.
+  response: (facts, telemetry, cfg, now) => scoreResponse(telemetry, cfg, now),
+  screening: (facts, telemetry) => scoreScreening(telemetry),
 };
 
 /** Merge a stored config over the defaults without losing unspecified knobs. */
@@ -531,6 +617,16 @@ export function normalizeConfig(configJson) {
  */
 export function scoreConsumer({ facts = {}, telemetry = {}, config, now = Date.now() } = {}) {
   const cfg = normalizeConfig(config);
+  return computeScore({ cfg, facts, telemetry, now, algorithmVersion: cfg.algorithmVersion });
+}
+
+/**
+ * The shared engine behind scoreConsumer and scoreLead. `cfg.components` and
+ * `cfg.groups` decide what is computed and how it is grouped, so the two
+ * grains differ only in the config handed in — the math, the round-once rule
+ * and the unknown-vs-zero contract are the same code for both.
+ */
+function computeScore({ cfg, facts, telemetry, now, algorithmVersion }) {
   const components = {};
 
   for (const [name, def] of Object.entries(cfg.components)) {
@@ -595,9 +691,9 @@ export function scoreConsumer({ facts = {}, telemetry = {}, config, now = Date.n
     meetScore,
     buyScore,
     consumerScore,
-    algorithmVersion: cfg.algorithmVersion || SCORING_ALGORITHM_VERSION,
+    algorithmVersion: algorithmVersion || SCORING_ALGORITHM_VERSION,
     breakdown: {
-      algorithmVersion: cfg.algorithmVersion || SCORING_ALGORITHM_VERSION,
+      algorithmVersion: algorithmVersion || SCORING_ALGORITHM_VERSION,
       groups: {
         meet: { score: meetScore, rawMax: meetRawMax, components: meetNames.filter((n) => components[n]) },
         buy: { score: buyScore, rawMax: buyRawMax, components: buyNames.filter((n) => components[n]) },
@@ -613,4 +709,134 @@ export function scoreConsumer({ facts = {}, telemetry = {}, config, now = Date.n
       },
     },
   };
+}
+
+// ── THE LEAD GRAIN (per-campaign-lead-scoring.md §4) ───────────────────────
+
+/**
+ * lead/v1. Stamped on prospects.scoringAlgorithmVersion, and deliberately a
+ * SEPARATE lineage from SCORING_ALGORITHM_VERSION: the two grains answer
+ * different questions over different inputs, so a person-grain recalibration
+ * should not silently claim to have rescored every lead, nor the reverse.
+ */
+export const LEAD_ALGORITHM_VERSION = 'lead/v1';
+
+/**
+ * The response components, defaulted IN CODE rather than seeded by a config
+ * migration. There is nothing to recompute: every lead starts unscored, so
+ * the first sweep scores the whole population anyway, and a migration whose
+ * only job is to trigger a recompute that is already happening buys a frozen
+ * historical row for nothing. Recalibrating later is an ordinary append-only
+ * config row carrying `leadComponents`, exactly like any other weight change.
+ *
+ * They sit in MEET, not Buy: reading a message and taking a screening call
+ * are evidence about whether this person will engage a consultant, not about
+ * what they can afford. Buy stays fact-driven, which is what keeps the
+ * fresh-grad-vs-buyer split (§1) meaningful.
+ */
+export const DEFAULT_LEAD_COMPONENTS = {
+  response: { maxPoints: 15 },
+  screening: { maxPoints: 20 },
+};
+
+/**
+ * Merge the lead-grain components into a config. Kept separate from
+ * `components` in the stored JSON so the person-grain scorer never sees them:
+ * grouping them into `groups.meet` for everyone would put their maxPoints
+ * into the consumer's Meet denominator while the consumer can never assess
+ * them, deflating every person score by construction.
+ */
+export function normalizeLeadConfig(configJson) {
+  const base = normalizeConfig(configJson);
+  const c = configJson && typeof configJson === 'object' ? configJson : {};
+  const leadComponents = { ...DEFAULT_LEAD_COMPONENTS, ...(c.leadComponents || {}) };
+  const meet = [...(base.groups.meet || [])];
+  for (const name of Object.keys(leadComponents)) {
+    if (!meet.includes(name)) meet.push(name);
+  }
+  return {
+    ...base,
+    components: { ...base.components, ...leadComponents },
+    groups: { ...base.groups, meet },
+  };
+}
+
+/**
+ * Score one LEAD — (person × campaign).
+ *
+ * Same facts as the person (the spine exists so every lead can read them),
+ * plus telemetry that is lead-scoped where §3.4 says it must be:
+ *   - `newestSignupAt` is THIS lead's own createdAt, not the person's newest
+ *   - `marketingConsent` is canMarketTo semantics at (consumer, campaign)
+ *   - `ownedMessageCount` / `readAt` cover only messages this lead owns (§5)
+ *   - `screening` is this lead's own normalized call outcome (§13.1)
+ * Person-wide capability terms (signup counts, email, WhatsApp frontier) are
+ * shared by every lead BY DESIGN — capability travels, responses do not.
+ *
+ * @returns {{meetScore:number|null, buyScore:number|null, score:number|null,
+ *            breakdown:Object, algorithmVersion:string}}
+ */
+export function scoreLead({ facts = {}, telemetry = {}, config, now = Date.now() } = {}) {
+  const cfg = normalizeLeadConfig(config);
+  const r = computeScore({ cfg, facts, telemetry, now, algorithmVersion: LEAD_ALGORITHM_VERSION });
+  // `score` rather than `consumerScore`: same number, named for the column it
+  // lands in (prospects.score).
+  return {
+    meetScore: r.meetScore,
+    buyScore: r.buyScore,
+    score: r.consumerScore,
+    algorithmVersion: r.algorithmVersion,
+    breakdown: { ...r.breakdown, events: leadEvents(telemetry, cfg, now) },
+  };
+}
+
+/**
+ * The response events behind the score, with their timestamps and UNDECAYED
+ * weights (§6). Undecayed on purpose: the stored number already has the decay
+ * baked in as of scoreComputedAt, so repeating a decayed figure here would
+ * just be the same number twice. What a reader needs is what happened, when,
+ * and how much it was worth at full strength — from which the decay between
+ * `at` and `scoreComputedAt` explains the difference.
+ *
+ * Newest first, and bounded: a lead with hundreds of reads must not turn the
+ * breakdown into an unbounded jsonb column.
+ */
+const MAX_STORED_EVENTS = 50;
+
+function leadEvents(telemetry, cfg, now) {
+  const events = [];
+
+  for (const at of (Array.isArray(telemetry?.readAt) ? telemetry.readAt : [])) {
+    const ms = new Date(at).getTime();
+    if (!Number.isFinite(ms)) continue;
+    events.push({
+      type: 'wa_read',
+      at: new Date(ms).toISOString(),
+      component: 'response',
+      undecayedWeight: Number(cfg.components?.response?.maxPoints) || 0,
+      ageDays: Math.max(0, Math.round((now - ms) / DAY_MS)),
+    });
+  }
+
+  const s = telemetry?.screening;
+  if (s && (s.verdict || s.interest !== null || s.sentiment !== null || s.agreedToMeet !== null)) {
+    const ms = s.decidedAt ? new Date(s.decidedAt).getTime() : NaN;
+    events.push({
+      type: 'screening',
+      at: Number.isFinite(ms) ? new Date(ms).toISOString() : null,
+      component: 'screening',
+      undecayedWeight: Number(cfg.components?.screening?.maxPoints) || 0,
+      verdict: s.verdict,
+      // Labels, not the raw provider keys — §13.1's whole point.
+      interest: s.labels?.interest || null,
+      sentiment: s.labels?.sentiment || null,
+      agreedToMeet: s.agreedToMeet,
+      schemaVersion: s.schemaVersion || null,
+      ...(Number.isFinite(ms) ? { ageDays: Math.max(0, Math.round((now - ms) / DAY_MS)) } : {}),
+    });
+  }
+
+  return events
+    .sort((a, b) => String(b.at || '').localeCompare(String(a.at || '')))
+    .slice(0, MAX_STORED_EVENTS);
 }

--- a/backend/src/utils/screeningSignal.js
+++ b/backend/src/utils/screeningSignal.js
@@ -1,0 +1,125 @@
+/**
+ * The screening signal contract (per-campaign-lead-scoring.md §13.1).
+ *
+ * WHY THIS EXISTS. v1 of the plan specced a scoring event on `agreedToMeet`.
+ * There is no such field. The stored verdict detail is `reason`,
+ * `interestLevel`, `summary`, `sentiment`, `recordingUrl`, `transcript`, plus
+ * the provider's whole `custom_analysis_data` object under `checks`
+ * (retellScreeningService.js:671-686). Scoring straight off `checks` would
+ * bind the score to whatever an operator last typed into the Retell console:
+ * rename a check, and every lead silently re-scores. So the scorer reads ONLY
+ * the normalized shape below, and the normalization is versioned.
+ *
+ * WHAT IS ACTUALLY AVAILABLE, verified rather than assumed. The configured
+ * agent's `post_call_analysis_data` is exactly three fields
+ * (docs/plans/retell-screening-calls.md:524-527):
+ *   - `qualified`            boolean, required  → already a real COLUMN,
+ *                            prospects.screeningVerdict (Prospect.js:308-312),
+ *                            so it is read from there, not from checks.
+ *   - `qualification_reason` string             → free text, never scored.
+ *   - `interest_level`       enum, OPTIONAL, choices hot | warm | cold.
+ * Plus Retell's own `call_analysis.user_sentiment`, whose vocabulary is
+ * Positive | Neutral | Negative (retellService.js:235-238).
+ *
+ * THERE IS NO MEET SIGNAL TODAY. `meet_consultant` (and `sg_pr`,
+ * `age_in_range`) appear in this codebase in exactly one place — an
+ * illustrative comment at retellScreeningService.js:682 — and in no agent
+ * configuration. `agreedToMeet` is therefore a declared slot that normalizes
+ * to null until a real check produces it, NOT a field invented to satisfy a
+ * plan. When one is configured, add its key to MEET_CHECK_KEYS and bump the
+ * schema version; nothing else changes.
+ *
+ * VERSIONED because the mapping is a judgement (warm → 0.6 is a choice, not a
+ * fact). A stored breakdown records which mapping produced it, so an old score
+ * stays explainable after the vocabulary moves — the same contract
+ * scoredConfigVersion gives the weights.
+ */
+
+export const SCREENING_SIGNAL_VERSION = 'screening/v1';
+
+/** Retell's interest_level enum → an ordered strength in 0..1. */
+const INTEREST_LADDER = { hot: 1, warm: 0.6, cold: 0.15 };
+
+/** Retell's user_sentiment enum → an ordered strength in 0..1. */
+const SENTIMENT_LADDER = { positive: 1, neutral: 0.5, negative: 0 };
+
+/**
+ * Provider check keys that would mean "they agreed to meet a consultant".
+ * EMPTY BY DESIGN — see the header. Adding one here is the whole change.
+ */
+export const MEET_CHECK_KEYS = Object.freeze([]);
+
+/** Coerce Retell's loose booleans (true, 'true') without accepting garbage. */
+function asBool(v) {
+  if (v === true || v === 'true') return true;
+  if (v === false || v === 'false') return false;
+  return null;
+}
+
+/**
+ * Normalize one lead's screening state into the scoreable shape.
+ *
+ * @param {object} prospect  needs `screeningVerdict` and `screeningMetadata`
+ * @returns {{
+ *   schemaVersion: string,
+ *   verdict: 'qualified'|'not_qualified'|null,
+ *   interest: number|null,   // 0..1, from interest_level
+ *   sentiment: number|null,  // 0..1, from user_sentiment
+ *   agreedToMeet: boolean|null,
+ *   decidedAt: string|null,
+ *   labels: {interest: string|null, sentiment: string|null},
+ * }}
+ */
+export function normalizeScreeningSignal(prospect) {
+  const detail = prospect?.screeningMetadata?.verdictDetail || null;
+
+  // The verdict comes from the COLUMN, never from checks.qualified: the column
+  // is what the state machine actually transitioned on (screeningGate.js
+  // applyQualifiedVerdict / markScreeningFailed), and the raw check is only
+  // the evidence that produced it.
+  const raw = prospect?.screeningVerdict;
+  const verdict = raw === 'qualified' || raw === 'not_qualified' ? raw : null;
+
+  const interestLabel = typeof detail?.interestLevel === 'string'
+    ? detail.interestLevel.trim().toLowerCase()
+    : null;
+  const sentimentLabel = typeof detail?.sentiment === 'string'
+    ? detail.sentiment.trim().toLowerCase()
+    : null;
+
+  // An unrecognized label scores as UNKNOWN (null), never as its lowest rung —
+  // a renamed enum must not read as "cold".
+  const interest = interestLabel && Object.prototype.hasOwnProperty.call(INTEREST_LADDER, interestLabel)
+    ? INTEREST_LADDER[interestLabel]
+    : null;
+  const sentiment = sentimentLabel && Object.prototype.hasOwnProperty.call(SENTIMENT_LADDER, sentimentLabel)
+    ? SENTIMENT_LADDER[sentimentLabel]
+    : null;
+
+  let agreedToMeet = null;
+  for (const key of MEET_CHECK_KEYS) {
+    const v = asBool(detail?.checks?.[key]);
+    if (v !== null) { agreedToMeet = v; break; }
+  }
+
+  return {
+    schemaVersion: SCREENING_SIGNAL_VERSION,
+    verdict,
+    interest,
+    sentiment,
+    agreedToMeet,
+    decidedAt: typeof detail?.decidedAt === 'string' ? detail.decidedAt : null,
+    labels: {
+      interest: interest === null ? null : interestLabel,
+      sentiment: sentiment === null ? null : sentimentLabel,
+    },
+  };
+}
+
+/** True when there is anything at all to score. */
+export function hasScreeningSignal(signal) {
+  return Boolean(
+    signal && (signal.verdict !== null || signal.interest !== null
+      || signal.sentiment !== null || signal.agreedToMeet !== null)
+  );
+}

--- a/backend/test/consumerEnrichment.test.js
+++ b/backend/test/consumerEnrichment.test.js
@@ -447,9 +447,22 @@ describe('the band reaches the Buy score (score/v3 — PR B seam)', () => {
     // boot) or the code defaults (reused DB — migrations skip, table empty);
     // the 095 row's own content is pinned by migration095ScoringAgeConfig.
     expect(profile.scoringAlgorithmVersion).toBe('score/v3')
-    expect(profile.scoreBreakdown.groups.buy.components).toContain('age')
 
-    const comps = profile.scoreBreakdown.components
+    // THE BREAKDOWN NOW LIVES ON THE LEAD (per-campaign-lead-scoring.md §4).
+    // scoreOneConsumer still resolves the facts and stamps what scored them —
+    // that is what the assertion above checks — but the numbers and the
+    // breakdown they must agree with are written by the lead scorer and
+    // PROJECTED up, so that is where this contract is now pinned.
+    const { scoreOneLead } = await import('../src/services/leadScoringService.js')
+    const leadResult = await scoreOneLead(prospect.id, { force: true })
+    expect(leadResult.status).toBe('scored')
+    expect(leadResult.buyScore).not.toBeNull()
+
+    const lead = await Prospect.findByPk(prospect.id)
+    expect(lead.scoringAlgorithmVersion).toBe('lead/v1')
+    expect(lead.scoreBreakdown.groups.buy.components).toContain('age')
+
+    const comps = lead.scoreBreakdown.components
     expect(comps.age.state).toBe('assessed')
     const band = await ConsumerObservation.findOne({
       where: { sourceProspectId: prospect.id, key: 'identity.birth_year_band', supersededAt: null },
@@ -457,10 +470,20 @@ describe('the band reaches the Buy score (score/v3 — PR B seam)', () => {
     expect(comps.age.basisObservationIds).toContain(band.id)
 
     // Almost-everyone-scoreable must still read THIN: age is the only
-    // assessed Buy fact, and completeness says so.
+    // assessed Buy fact, and completeness says so. Ten components now, not
+    // eight — the lead grain adds `response` and `screening`, both unknown
+    // for a lead nobody has messaged or called.
     expect(comps.capacity.state).toBe('unknown')
     expect(comps.family_gap.state).toBe('unknown')
-    expect(profile.scoreBreakdown.completeness.total).toBe(8)
-    expect(profile.scoreBreakdown.completeness.assessed).toBeLessThan(4)
+    expect(comps.response.state).toBe('unknown')
+    expect(comps.screening.state).toBe('unknown')
+    expect(lead.scoreBreakdown.completeness.total).toBe(10)
+    expect(lead.scoreBreakdown.completeness.assessed).toBeLessThan(4)
+
+    // §4's projection: the person's numbers ARE the winning lead's numbers.
+    await profile.reload()
+    expect(profile.buyScore).toBe(leadResult.buyScore)
+    expect(profile.meetScore).toBe(leadResult.meetScore)
+    expect(profile.consumerScore).toBe(leadResult.score)
   })
 })

--- a/backend/test/leadScoring.test.js
+++ b/backend/test/leadScoring.test.js
@@ -1,0 +1,368 @@
+import { createHash } from 'crypto'
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect } from './helpers.js'
+import {
+  sequelize, Consumer, ConsentEvent, ConsumerProfile, Prospect,
+} from '../src/models/index.js'
+import {
+  scoreOneLead, loadLeadTelemetry, findStaleLeadIds,
+} from '../src/services/leadScoringService.js'
+import { markLeadsDirtyTx } from '../src/services/leadScoreDirty.js'
+import { recordWaSend } from '../src/services/redeemOps/waMessageOwnership.js'
+import { _resetConfigCache, getActiveScoringConfig } from '../src/services/consumerScoringService.js'
+import { eraseConsumer } from '../src/services/erasureService.js'
+import { LEAD_ALGORITHM_VERSION } from '../src/utils/consumerScoring.js'
+
+/**
+ * The LEAD-GRAIN contract (per-campaign-lead-scoring.md §3.5), at the database.
+ *
+ * One person, two live leads on different campaigns. §3.2's rule is "one
+ * event, two projections": a `read` on campaign A's message advances the
+ * PERSON's WhatsApp frontier (capability — B may rely on it) AND is a response
+ * for lead A, but it must never appear as a response on lead B.
+ *
+ * Every isolation test asserts B is BYTE-IDENTICAL rather than merely
+ * "unchanged score": two different breakdowns that happen to round to the same
+ * integer would pass a score-only assertion and still be a leak.
+ */
+
+let admin, campA, campB
+let seq = Math.floor(Math.random() * 700000)
+const e164 = () => `+65${(81000000 + (seq += 1)).toString()}`
+const sha256hex = (s) => createHash('sha256').update(s).digest('hex')
+
+/** One person, one live lead on each campaign. A is the OLDER signup. */
+async function personWithTwoLeads() {
+  const phone = e164()
+  const consumer = await Consumer.create({
+    phone,
+    phoneHash: sha256hex(phone),
+    firstSeenAt: new Date('2026-06-01T00:00:00Z'),
+    lastSeenAt: new Date('2026-06-01T00:00:00Z'),
+    signupCount: 2,
+    verifiedSignupCount: 1,
+    email: `lead-${seq}@example.com`,
+  })
+  const a = await createTestProspect(campA.id, { consumerId: consumer.id, phone })
+  const b = await createTestProspect(campB.id, { consumerId: consumer.id, phone: e164() })
+  // Raw SQL: Sequelize silently drops `createdAt` from an instance update, and
+  // two rows created in the same millisecond leave "newest" to a UUID coin flip.
+  await sequelize.query('UPDATE prospects SET "createdAt" = :ts WHERE id = :id', {
+    replacements: { ts: new Date('2026-06-01T00:00:00Z'), id: a.id },
+  })
+  await sequelize.query('UPDATE prospects SET "createdAt" = :ts WHERE id = :id', {
+    replacements: { ts: new Date('2026-07-01T00:00:00Z'), id: b.id },
+  })
+  return { consumer, a: await a.reload(), b: await b.reload() }
+}
+
+/** Send a message owned by `prospect`, then post Meta's status for it. */
+async function sendAndStatus(prospect, consumer, status, { at = new Date(), kind = 'pass' } = {}) {
+  const wamid = `wamid.LS.${seq += 1}`
+  await recordWaSend({ wamid, prospect, kind })
+  await sequelize.query(
+    `INSERT INTO wa_message_statuses
+       (wamid, status, "recipientHash", "occurredAt", "createdAt", "updatedAt")
+     VALUES (:wamid, :status, :hash, :at, NOW(), NOW())
+     ON CONFLICT (wamid) DO UPDATE SET status = EXCLUDED.status, "occurredAt" = EXCLUDED."occurredAt"`,
+    { replacements: { wamid, status, hash: consumer.phoneHash, at } }
+  )
+  return wamid
+}
+
+const scoreOf = async (id) => {
+  const r = await scoreOneLead(id, { force: true })
+  expect(['scored', 'unchanged']).toContain(r.status)
+  return r
+}
+const rowOf = (id) => Prospect.findByPk(id)
+/** The full stored judgement — what "byte-identical" means here. */
+const judgementOf = async (id) => {
+  const p = await rowOf(id)
+  return JSON.stringify({
+    score: p.score, meet: p.meetScore, buy: p.buyScore, bd: p.scoreBreakdown,
+  })
+}
+
+beforeAll(async () => {
+  await getApp()
+  _resetConfigCache()
+  const made = await createTestUser({ role: 'admin' })
+  admin = made.user
+  campA = await createTestCampaign(admin.id, { name: `Lead A ${Date.now()}` })
+  campB = await createTestCampaign(admin.id, { name: `Lead B ${Date.now()}` })
+})
+
+afterAll(async () => {
+  await closeDb()
+})
+
+describe('responses do not cross campaigns', () => {
+  test('a read on A, when the person already has ≥delivered proof elsewhere, leaves B byte-identical', async () => {
+    const { consumer, a, b } = await personWithTwoLeads()
+    // Deliverability already proven by an UNOWNED message, so the read below
+    // adds no capability — it can only act as a response.
+    await sequelize.query(
+      `INSERT INTO wa_message_statuses (wamid, status, "recipientHash", "occurredAt", "createdAt", "updatedAt")
+       VALUES (:w, 'delivered', :h, NOW(), NOW(), NOW())`,
+      { replacements: { w: `wamid.PRE.${seq += 1}`, h: consumer.phoneHash } }
+    )
+    await scoreOf(a.id)
+    await scoreOf(b.id)
+    const beforeB = await judgementOf(b.id)
+
+    await sendAndStatus(a, consumer, 'read')
+    await scoreOf(a.id)
+    await scoreOf(b.id)
+
+    expect(await judgementOf(b.id)).toBe(beforeB)
+    const aRow = await rowOf(a.id)
+    expect(aRow.scoreBreakdown.components.response.state).toBe('assessed')
+    expect(aRow.scoreBreakdown.events.some((e) => e.type === 'wa_read')).toBe(true)
+    // And B has no response event at all — it owns no message.
+    const bRow = await rowOf(b.id)
+    expect(bRow.scoreBreakdown.components.response.state).toBe('unknown')
+    expect(bRow.scoreBreakdown.events).toEqual([])
+  })
+
+  test("a read that is the person's FIRST proof raises B's capability but gives B no response", async () => {
+    const { consumer, a, b } = await personWithTwoLeads()
+    await scoreOf(b.id)
+    const bBefore = await rowOf(b.id)
+    expect(bBefore.scoreBreakdown.components.contactability.note).not.toContain('WhatsApp')
+
+    await sendAndStatus(a, consumer, 'read')
+    await scoreOf(b.id)
+
+    const bAfter = await rowOf(b.id)
+    // Capability travels BY DESIGN — pinned so an over-scoping "fix" fails here.
+    expect(bAfter.scoreBreakdown.components.contactability.note).toContain('WhatsApp')
+    expect(bAfter.scoreBreakdown.components.contactability.points)
+      .toBeGreaterThan(bBefore.scoreBreakdown.components.contactability.points)
+    // …but the RESPONSE stays with the lead that owns the message.
+    expect(bAfter.scoreBreakdown.components.response.state).toBe('unknown')
+    expect(bAfter.scoreBreakdown.events).toEqual([])
+  })
+
+  test('a screening refusal on A leaves B byte-identical', async () => {
+    const { a, b } = await personWithTwoLeads()
+    await scoreOf(b.id)
+    const beforeB = await judgementOf(b.id)
+
+    await sequelize.query(
+      `UPDATE prospects SET "screeningVerdict" = 'not_qualified',
+          "screeningMetadata" = :meta::jsonb WHERE id = :id`,
+      {
+        replacements: {
+          id: a.id,
+          meta: JSON.stringify({
+            verdictDetail: {
+              interestLevel: 'cold', sentiment: 'Negative',
+              decidedAt: new Date().toISOString(),
+              checks: { qualified: false, meet_consultant: false },
+            },
+          }),
+        },
+      }
+    )
+    await scoreOf(a.id)
+    await scoreOf(b.id)
+
+    expect(await judgementOf(b.id)).toBe(beforeB)
+    const aRow = await rowOf(a.id)
+    expect(aRow.scoreBreakdown.components.screening.state).toBe('assessed')
+    expect(aRow.scoreBreakdown.components.screening.points).toBe(0)
+  })
+
+  test("each lead's recency is its OWN signup — a newer sibling does not refresh A", async () => {
+    const { a, b } = await personWithTwoLeads()
+    const ta = await loadLeadTelemetry(a.id)
+    const tb = await loadLeadTelemetry(b.id)
+    expect(new Date(ta.newestSignupAt).toISOString()).toBe(new Date('2026-06-01T00:00:00Z').toISOString())
+    expect(new Date(tb.newestSignupAt).toISOString()).toBe(new Date('2026-07-01T00:00:00Z').toISOString())
+    // B is a month younger, so its engagement recency must be strictly higher.
+    await scoreOf(a.id)
+    await scoreOf(b.id)
+    const [ra, rb] = [await rowOf(a.id), await rowOf(b.id)]
+    expect(rb.scoreBreakdown.components.engagement.points)
+      .toBeGreaterThan(ra.scoreBreakdown.components.engagement.points)
+  })
+})
+
+describe('consent is read at (consumer, campaign) scope — canMarketTo semantics', () => {
+  const grant = (consumer, campaignId) => ConsentEvent.create({
+    consumerId: consumer.id,
+    campaignId,
+    kind: 'contact',
+    granted: true,
+    verified: true,
+    version: 'test-v1',
+    occurredAt: new Date(),
+    source: 'signup',
+  })
+
+  test('a grant scoped to A feeds A only; a global act feeds both', async () => {
+    const { consumer, a, b } = await personWithTwoLeads()
+    await grant(consumer, campA.id)
+    expect((await loadLeadTelemetry(a.id)).marketingConsent).toBe(true)
+    expect((await loadLeadTelemetry(b.id)).marketingConsent).toBe(false)
+
+    // The brand-era capture mints the NULL-campaign twin, which every scope
+    // merges — so it lifts B too, without B ever having its own grant.
+    await grant(consumer, null)
+    expect((await loadLeadTelemetry(a.id)).marketingConsent).toBe(true)
+    expect((await loadLeadTelemetry(b.id)).marketingConsent).toBe(true)
+  })
+
+  test('a global revoke zeroes them all', async () => {
+    const { consumer, a, b } = await personWithTwoLeads()
+    await grant(consumer, campA.id)
+    await grant(consumer, null)
+    await ConsentEvent.create({
+      consumerId: consumer.id,
+      campaignId: null,
+      kind: 'contact',
+      granted: false,
+      verified: true,
+      version: 'test-v1',
+      occurredAt: new Date(Date.now() + 1000),
+      source: 'unsubscribe',
+    })
+    expect((await loadLeadTelemetry(a.id)).marketingConsent).toBe(false)
+    expect((await loadLeadTelemetry(b.id)).marketingConsent).toBe(false)
+  })
+})
+
+describe('one authority — the person score is a projection (§4)', () => {
+  test('the person takes the highest-scoring lead, and follows it when that changes', async () => {
+    const { consumer, a, b } = await personWithTwoLeads()
+    // Give A a screening qualification so it outscores B decisively.
+    await sequelize.query(
+      `UPDATE prospects SET "screeningVerdict" = 'qualified',
+          "screeningMetadata" = :meta::jsonb WHERE id = :id`,
+      {
+        replacements: {
+          id: a.id,
+          meta: JSON.stringify({
+            verdictDetail: { interestLevel: 'hot', sentiment: 'Positive', decidedAt: new Date().toISOString() },
+          }),
+        },
+      }
+    )
+    const ra = await scoreOf(a.id)
+    const rb = await scoreOf(b.id)
+    expect(ra.score).toBeGreaterThan(rb.score)
+
+    const profile = await ConsumerProfile.findByPk(consumer.id)
+    expect(profile.consumerScore).toBe(ra.score)
+    expect(profile.meetScore).toBe(ra.meetScore)
+    expect(profile.buyScore).toBe(ra.buyScore)
+    // The breakdown travels with the numbers, or the card would render
+    // components that don't sum to the score above them.
+    expect(profile.scoreBreakdown.groups.meet.score).toBe(ra.meetScore)
+  })
+
+  test('scoreOneConsumer no longer writes the numbers — only the lead scorer does', async () => {
+    const { consumer, a } = await personWithTwoLeads()
+    await scoreOf(a.id)
+    const before = await ConsumerProfile.findByPk(consumer.id)
+
+    const { scoreOneConsumer } = await import('../src/services/consumerScoringService.js')
+    const r = await scoreOneConsumer(consumer.id, { force: true })
+    expect(r.status).toBe('scored')
+
+    const after = await ConsumerProfile.findByPk(consumer.id)
+    // It still computes and returns a person-grain view, and still stamps what
+    // scored it — but the stored numbers are the projection's, untouched.
+    expect(after.consumerScore).toBe(before.consumerScore)
+    expect(after.meetScore).toBe(before.meetScore)
+    expect(after.buyScore).toBe(before.buyScore)
+    expect(after.scoredConfigVersion).not.toBeNull()
+  })
+})
+
+describe('the write gate (§6)', () => {
+  test('a second pass with nothing moved does not rewrite', async () => {
+    const { a } = await personWithTwoLeads()
+    expect((await scoreOneLead(a.id)).status).toBe('scored')
+    const first = await rowOf(a.id)
+    const second = await scoreOneLead(a.id)
+    expect(second.status).toBe('unchanged')
+    expect((await rowOf(a.id)).scoreComputedAt.toISOString())
+      .toBe(first.scoreComputedAt.toISOString())
+  })
+
+  test('decay that moves the integer DOES rewrite, at the same inputs', async () => {
+    const { consumer, a } = await personWithTwoLeads()
+    await sendAndStatus(a, consumer, 'read', { at: new Date('2026-07-01T00:00:00Z') })
+    await scoreOneLead(a.id, { now: new Date('2026-07-02T00:00:00Z').getTime() })
+    const fresh = await rowOf(a.id)
+
+    // Two years later: identical facts, identical config, identical hash —
+    // only the clock moved. The person-grain gate would skip this forever.
+    const r = await scoreOneLead(a.id, { now: new Date('2028-07-02T00:00:00Z').getTime() })
+    expect(r.status).toBe('scored')
+    const aged = await rowOf(a.id)
+    expect(aged.scoreInputHash).toBe(fresh.scoreInputHash)
+    expect(aged.score).toBeLessThan(fresh.score)
+  })
+
+  test('a dirty marker forces a rewrite and is cleared by it', async () => {
+    const { a } = await personWithTwoLeads()
+    await scoreOneLead(a.id)
+    expect((await scoreOneLead(a.id)).status).toBe('unchanged')
+
+    await sequelize.transaction((t) => markLeadsDirtyTx(t, [a.id]))
+    expect((await rowOf(a.id)).scoreDirtyAt).not.toBeNull()
+    // Dirty ⇒ provably stale ⇒ first claim on the sweep's budget.
+    expect(await findStaleLeadIds({ configVersion: (await getActiveScoringConfig()).version, limit: 500 }))
+      .toContain(a.id)
+
+    expect((await scoreOneLead(a.id)).status).toBe('scored')
+    expect((await rowOf(a.id)).scoreDirtyAt).toBeNull()
+  })
+
+  test('the algorithm version is the lead lineage, not the person one', async () => {
+    const { a } = await personWithTwoLeads()
+    await scoreOneLead(a.id)
+    expect((await rowOf(a.id)).scoringAlgorithmVersion).toBe(LEAD_ALGORITHM_VERSION)
+    expect(LEAD_ALGORITHM_VERSION).toBe('lead/v1')
+  })
+})
+
+describe('erasure (§11)', () => {
+  test('erasing the person nulls the score, the breakdown and every stamp', async () => {
+    const { consumer, a, b } = await personWithTwoLeads()
+    await sendAndStatus(a, consumer, 'read')
+    await scoreOf(a.id)
+    await scoreOf(b.id)
+    expect((await rowOf(a.id)).score).not.toBeNull()
+    expect((await rowOf(a.id)).scoreBreakdown.events.length).toBeGreaterThan(0)
+
+    await eraseConsumer(consumer.id, { actorUser: admin, reason: 'lead score erasure test' })
+
+    for (const id of [a.id, b.id]) {
+      const p = await rowOf(id)
+      expect(p.score).toBeNull()
+      expect(p.meetScore).toBeNull()
+      expect(p.buyScore).toBeNull()
+      // The breakdown is the sharp end: it carried read timestamps and the
+      // inferred screening sentiment.
+      expect(p.scoreBreakdown).toBeNull()
+      expect(p.scoreComputedAt).toBeNull()
+      expect(p.scoredConfigVersion).toBeNull()
+      expect(p.scoringAlgorithmVersion).toBeNull()
+      expect(p.scoreInputHash).toBeNull()
+      expect(p.scoreDirtyAt).toBeNull()
+    }
+  })
+
+  test('an erased person\'s leads are not handed back by the stale query', async () => {
+    const { consumer, a } = await personWithTwoLeads()
+    await scoreOf(a.id)
+    await eraseConsumer(consumer.id, { actorUser: admin, reason: 'lead score erasure fence' })
+    const stale = await findStaleLeadIds({
+      configVersion: (await getActiveScoringConfig()).version, limit: 1000,
+    })
+    expect(stale).not.toContain(a.id)
+  })
+})

--- a/backend/test/unit/enrichmentSweep.test.js
+++ b/backend/test/unit/enrichmentSweep.test.js
@@ -21,12 +21,36 @@ function population(all) {
   }
 }
 
-function harness({ stale = [], all = [], rowBudget = 500, timeBudgetMs = 60_000, cursor = null, scoreImpl } = {}) {
+/** A fake stale query that stops returning an id once it has been scored. */
+function staleQuery(remaining) {
+  return async ({ afterId = null, limit = 200 }) => {
+    const list = [...remaining].sort()
+    const start = afterId === null ? 0 : list.findIndex((x) => x > afterId)
+    if (start === -1) return []
+    return list.slice(start, start + limit)
+  }
+}
+
+/**
+ * EVERY grain's deps are injected, including the LEAD ones
+ * (per-campaign-lead-scoring.md §10). This suite is deliberately DB-free, and
+ * an un-injected finder falls through to the real query — which passes on a
+ * developer machine that happens to have Postgres up and dies in CI, where
+ * the unit step has no database. Leaving lead deps out is exactly how that
+ * happened once.
+ */
+function harness({
+  stale = [], all = [], staleLeads = [], allLeads = [],
+  rowBudget = 500, timeBudgetMs = 60_000, cursor = null, scoreImpl, scoreLeadImpl,
+} = {}) {
   const scored = []
+  const scoredLeads = []
   // Stale ids clear once scored — the real query stops returning them.
   const remainingStale = new Set(stale)
+  const remainingStaleLeads = new Set(staleLeads)
   return {
     scored,
+    scoredLeads,
     run: () => sweepConsumers({
       runId: null,
       ownerToken: 't',
@@ -35,17 +59,20 @@ function harness({ stale = [], all = [], rowBudget = 500, timeBudgetMs = 60_000,
       timeBudgetMs,
       deps: {
         getActiveScoringConfig: async () => ({ version: 1, config: { algorithmVersion: 'score/v1' } }),
-        findStaleConsumerIds: async ({ afterId = null, limit = 200 }) => {
-          const list = [...remainingStale].sort()
-          const start = afterId === null ? 0 : list.findIndex((x) => x > afterId)
-          if (start === -1) return []
-          return list.slice(start, start + limit)
-        },
+        findStaleConsumerIds: staleQuery(remainingStale),
         findConsumerIdsAfter: population(all),
         scoreOneConsumer: async (id) => {
           scored.push(id)
           if (scoreImpl) return scoreImpl(id)
           remainingStale.delete(id)
+          return { status: 'scored' }
+        },
+        findStaleLeadIds: staleQuery(remainingStaleLeads),
+        findLeadIdsAfter: population(allLeads),
+        scoreOneLead: async (id) => {
+          scoredLeads.push(id)
+          if (scoreLeadImpl) return scoreLeadImpl(id)
+          remainingStaleLeads.delete(id)
           return { status: 'scored' }
         },
         heartbeat: async () => true,
@@ -147,5 +174,71 @@ describe('SGT date fence', () => {
   test('rolls at SGT midnight, not UTC midnight', () => {
     expect(sgtDateString(Date.UTC(2026, 6, 26, 16, 30))).toBe('2026-07-27')
     expect(sgtDateString(Date.UTC(2026, 6, 26, 15, 30))).toBe('2026-07-26')
+  })
+})
+
+/**
+ * The lead grain (per-campaign-lead-scoring.md §6/§10). Same phase engine,
+ * its own population and its own cursor.
+ */
+describe('lead phases run beside the consumer ones', () => {
+  test('both grains are swept, stale-first, each from its own cursor', async () => {
+    const h = harness({
+      stale: ['c0001'], all: ids(3),
+      staleLeads: ['p0002'], allLeads: ids(4, 'p'),
+    })
+    const { stats, cursor } = await h.run()
+
+    expect(h.scored).toContain('c0001')
+    expect(h.scoredLeads).toContain('p0002')
+    expect(stats.consumerStaleScored).toBe(1)
+    expect(stats.leadStaleScored).toBe(1)
+    // Each grain keeps its OWN cursor — a run that only had room for one must
+    // not advance the other past rows it never looked at.
+    expect(cursor).toEqual({ lastConsumerId: null, lastProspectId: null })
+    expect(stats.stoppedBy).toBe('exhausted')
+  })
+
+  test('a lead population larger than the budget leaves a resumable cursor', async () => {
+    const h = harness({ allLeads: ids(50, 'p'), rowBudget: 10 })
+    const { cursor, stats } = await h.run()
+    expect(h.scoredLeads.length).toBeGreaterThan(0)
+    expect(cursor.lastProspectId).not.toBeNull()
+    expect(stats.stoppedBy).toBe('row_budget')
+  })
+
+  test('leads dirtied while nothing else is stale still get scored', async () => {
+    // The dirty marker is what puts an event-driven move into the stale-FIRST
+    // phase rather than leaving it to the rotation.
+    const h = harness({ staleLeads: ['p0007'], allLeads: [] })
+    await h.run()
+    expect(h.scoredLeads).toEqual(['p0007'])
+  })
+})
+
+describe('the rotation reservation is two-dimensional (§6)', () => {
+  test('a stale backlog bigger than the budget still leaves the rotation room', async () => {
+    // 500 stale leads against a 100-row budget. A row-only reserve would be
+    // spent entirely on the stale phase and the rotation would starve — the
+    // failure mode Codex round 3b found. The stale phases stop ADMITTING at
+    // 80%, so the last 20% belongs to the rotation.
+    const h = harness({
+      staleLeads: ids(500, 'p'),
+      all: ids(50),
+      rowBudget: 100,
+    })
+    const { stats } = await h.run()
+
+    expect(stats.leadStaleScored).toBeLessThanOrEqual(80)
+    expect(stats.rotationScored).toBeGreaterThan(0)
+    expect(stats.rowsUsed).toBeLessThanOrEqual(100)
+  })
+
+  test('a stale phase that fills its reserved slice does not end the night', async () => {
+    const h = harness({ stale: ids(500), allLeads: ids(20, 'p'), rowBudget: 100 })
+    const { stats } = await h.run()
+    // Consumers ate their 80%; the leads' rotation still ran.
+    expect(h.scoredLeads.length).toBeGreaterThan(0)
+    expect(stats.stoppedBy).not.toBe('no_work')
   })
 })

--- a/docs/plans/per-campaign-lead-scoring.md
+++ b/docs/plans/per-campaign-lead-scoring.md
@@ -4,7 +4,8 @@
 (re-derived against the tables), M6 → §6 (rewritten), M9 → §7 verified
 shipped + §9 specified, M10 verified shipped. **Codex round 3: PASS**
 (3a REWORK → 3b REWORK → 3c PASS, log in §17). Phase 3 build UNGATED.
-**Not built** (Phase 0 / PR A₀ and PR B shipped separately — §14).
+**BUILT 2026-07-27: PR A₁ and PR A₂ (§14) — §18 records what shipped and the
+three places the build had to deviate from this text.** PR C/D/E remain.
 **Author:** Claude, 2026-07-26, from Shawn's model:
 
 > "The admin, when creating campaigns, will say the ideal lead profile. The AI
@@ -589,10 +590,14 @@ the band-straddle equal-weight rule at `:442-450`; migration
    (`consumerScoringService.js:119-163`), pinned by
    `backend/test/scoringIsolation.test.js`.
 2. **PR A₁ — send-time ownership** (§5). `wa_message_sends` + every send path.
-   Independent, additive, no scoring changes.
+   Independent, additive, no scoring changes. **SHIPPED 2026-07-27** —
+   migration `096-wa-message-sends.js`, `services/redeemOps/waMessageOwnership.js`,
+   stamped at the single `sendTemplate` choke point; §18.1 for the deviation.
 3. **PR A₂ — the lead score** (§4, §6, §10, §11). The structural one: authority,
    projection, write-time decay + the integer write-gate, invalidation,
-   erasure, Prospects column, events UI.
+   erasure, Prospects column, events UI. **SHIPPED 2026-07-27** — migration
+   `097-lead-score.js`, `services/leadScoringService.js`,
+   `services/leadScoreDirty.js`, `utils/screeningSignal.js`, `lead/v1`.
 4. **PR B — age curve + DOB backfill** (§13.2). **SHIPPED 2026-07-27**
    (score/v3 #296, migration `095-scoring-age-curve.js`; prod remap minted
    135 band observations and the same night's backfill scored 130 with Buy
@@ -776,3 +781,71 @@ an in-flight row can overrun the pre-row deadline check
 (`enrichmentSweepService.js:169-172`); (3) §6's cursor described as
 monotonic WITHIN a rotation — it deliberately resets at the end of the
 population (`:282-286`).
+
+## 18. What shipped, and where the build deviated (2026-07-27)
+
+PR A₁ + PR A₂ built off `origin/main` at 26bda82. Backend unit + integration +
+migration suites green against local Postgres (130 suites / 2580 tests, 30
+migration tests), `npx eslint src/ --quiet` clean at both roots, frontend
+vitest 159 files / 2025 tests green. `test/unit/retellScreening.test.js`
+passed at 05:09 SGT — outside the 10:00–20:00 call window — so the recorded
+time-of-day flake did not reproduce on this run.
+
+Three places the substrate did not match this text. Each is a deviation the
+plan should own rather than a silent divergence in code.
+
+### 18.1 `wa_message_sends.campaignId` is NULLABLE (§5 said NOT NULL)
+
+A lead can legitimately carry no campaign at send time: `campaignId` is
+optional at the capture edge (`validation.js:219`, passed through as
+`campaignId || null`, `prospectService.js:1066-1069`), and a permanent
+campaign delete nulls it on surviving prospects
+(`014-add-cascade-rules.js:87`). NOT NULL would force the writer to DROP the
+whole ownership row exactly when a campaignless lead is messaged — losing
+`prospectId`, which IS the ownership, to protect a snapshot that is only
+supporting evidence. Nullable keeps the row.
+
+### 18.2 The person-grain projection carries the BREAKDOWN too (§4 named three columns)
+
+§4 retires `meetScore`/`buyScore`/`consumerScore` as computed values and makes
+them a projection of the winning lead. The breakdown had to follow them: the
+profile card renders `groups.meet`/`groups.buy` component rows straight out of
+`scoreBreakdown` (`AdminV2LeadProfile.jsx:589-624`), so the winning lead's
+numbers beside a breakdown from the retired person-grain pass would render
+components that visibly do not sum to the score above them. `scoreOneConsumer`
+therefore stops writing all four; it keeps its fact-resolution, profile-row and
+stamping duties exactly as §4 says.
+
+### 18.3 There is NO meet signal to normalize (§13.1 assumed one rode in `checks`)
+
+§13.1 said the meet signal "rides un-normalized (e.g. `meet_consultant`)".
+Verified false. The configured agent's `post_call_analysis_data` is exactly
+three fields — `qualified` (boolean, required), `qualification_reason`
+(string), `interest_level` (enum hot|warm|cold, optional)
+(`retell-screening-calls.md:524-527`) — plus Retell's own `user_sentiment`
+(Positive|Neutral|Negative, `retellService.js:235-238`). `meet_consultant`,
+`sg_pr` and `age_in_range` appear in this codebase in exactly ONE place: an
+illustrative comment at `retellScreeningService.js:682`. They are in no agent
+configuration.
+
+So `utils/screeningSignal.js` declares `agreedToMeet` as a slot that
+normalizes to `null`, backed by an intentionally EMPTY `MEET_CHECK_KEYS`, and
+the scorer blends over what is actually present rather than inventing the
+field the plan named. Configuring a real check is a one-line addition to that
+array plus a schema-version bump. What is scoreable today is exactly what
+§13.1's fallback sentence predicted: the `screeningVerdict` column, plus
+`interest_level` and `user_sentiment` mapped through closed vocabularies —
+never raw provider `checks` keys, whose names are whatever an operator last
+typed into the Retell console.
+
+### 18.4 Two things §6/§9 called for that were deliberately NOT built
+
+- **No config migration for the lead components.** `response` and `screening`
+  default in code (`DEFAULT_LEAD_COMPONENTS`). 095's migration existed to force
+  a recompute of already-scored rows; every lead starts unscored, so the first
+  sweep scores the whole population regardless, and a frozen historical row
+  buys nothing. Recalibrating later is an ordinary append-only row carrying
+  `leadComponents`.
+- **§9's per-campaign config store is untouched** — that is PR C, and nothing
+  in A₂ depends on it. Lead scoring resolves the same single global config the
+  person grain does.

--- a/docs/plans/per-campaign-lead-scoring.md
+++ b/docs/plans/per-campaign-lead-scoring.md
@@ -596,7 +596,7 @@ the band-straddle equal-weight rule at `:442-450`; migration
 3. **PR A₂ — the lead score** (§4, §6, §10, §11). The structural one: authority,
    projection, write-time decay + the integer write-gate, invalidation,
    erasure, Prospects column, events UI. **SHIPPED 2026-07-27** — migration
-   `097-lead-score.js`, `services/leadScoringService.js`,
+   `099-lead-score.js`, `services/leadScoringService.js`,
    `services/leadScoreDirty.js`, `utils/screeningSignal.js`, `lead/v1`.
 4. **PR B — age curve + DOB backfill** (§13.2). **SHIPPED 2026-07-27**
    (score/v3 #296, migration `095-scoring-age-curve.js`; prod remap minted

--- a/src/pages/MyProspects.jsx
+++ b/src/pages/MyProspects.jsx
@@ -44,6 +44,31 @@ import ProspectDetails from"@/components/prospects/ProspectDetails";
 import normalizeProspect, { sourceLine } from"@/utils/normalizeProspect";
 import { getStatusColor, formatStatus } from"@/constants/statusConfig";
 
+/**
+ * The lead score an agent sees (per-campaign-lead-scoring.md §4/§6).
+ *
+ * It is the score for THIS lead on THIS campaign, not a verdict on the person:
+ * the same someone can be a strong recruit and a weak insurance buyer, which
+ * is the whole reason the number moved onto the lead.
+ *
+ * NULL renders as a dash, never a zero — an unscored lead is not a bad lead.
+ * The value is already decayed as of when it was written, so nothing here
+ * recomputes anything (§6: nothing decays at read, anywhere).
+ */
+function LeadScore({ value }) {
+  if (value == null) {
+    return <span className="text-sm text-muted-foreground" title="Not scored yet">—</span>;
+  }
+  return (
+    <span
+      className={`text-sm tabular-nums ${value >= 60 ? 'font-semibold text-foreground' : 'text-muted-foreground'}`}
+      title={`Lead score ${value}/100`}
+    >
+      {value}
+    </span>
+  );
+}
+
 export default function MyProspects() {
  const [searchQuery, setSearchQuery] = useState("");
  const [selectedProspect, setSelectedProspect] = useState(null);
@@ -184,6 +209,7 @@ export default function MyProspects() {
  <TableHead>Status</TableHead>
  <TableHead>Contact Info</TableHead>
  <TableHead>Campaign</TableHead>
+ <TableHead className="text-right w-[70px]">Score</TableHead>
  <TableHead>Assigned Date</TableHead>
  <TableHead className="text-right">Actions</TableHead>
  </TableRow>
@@ -191,7 +217,7 @@ export default function MyProspects() {
  <TableBody>
  {loading ? (
  <TableRow>
- <TableCell colSpan={6} className="h-32 text-center">
+ <TableCell colSpan={7} className="h-32 text-center">
  <div className="flex flex-col items-center justify-center text-muted-foreground">
  <Loader2 className="w-6 h-6 animate-spin mb-2"/>
  <p>Loading prospects...</p>
@@ -200,7 +226,7 @@ export default function MyProspects() {
  </TableRow>
  ) : filteredProspects.length === 0 ? (
  <TableRow>
- <TableCell colSpan={6} className="h-64 text-center">
+ <TableCell colSpan={7} className="h-64 text-center">
  <div className="flex flex-col items-center justify-center text-muted-foreground">
  <div className="w-12 h-12 bg-muted rounded-full flex items-center justify-center mb-4">
  <User className="w-6 h-6 text-muted-foreground"/>
@@ -254,6 +280,9 @@ export default function MyProspects() {
  <p className="font-medium text-foreground">{prospect.campaign?.name || 'Unknown Campaign'}</p>
  <p className="text-xs text-muted-foreground">{sourceLine(prospect)}</p>
  </div>
+ </TableCell>
+ <TableCell className="text-right">
+ <LeadScore value={prospect.score} />
  </TableCell>
  <TableCell>
  <div className="flex items-center text-sm text-muted-foreground">

--- a/src/pages/adminv2/AdminV2LeadProfile.jsx
+++ b/src/pages/adminv2/AdminV2LeadProfile.jsx
@@ -610,6 +610,72 @@ function ComponentRow({ name, c }) {
   );
 }
 
+/**
+ * What actually happened, and when (per-campaign-lead-scoring.md §6).
+ *
+ * The components above say how much each thing is worth right now; this says
+ * what the "thing" was. Weights are shown UNDECAYED — the score already has
+ * the decay baked in as of `scoredAt`, so the gap between an event's full
+ * weight and its contribution IS the age shown beside it. Rendering a decayed
+ * figure here would just repeat the score twice and explain nothing.
+ *
+ * Absent for a lead nobody has messaged or called, which is most of them —
+ * an empty section would read as "no response" rather than "no contact".
+ */
+function ScoreEvents({ events, scoredAt }) {
+  const rows = Array.isArray(events) ? events : [];
+  if (!rows.length) return null;
+
+  const label = (e) => {
+    if (e.type === 'wa_read') return 'Read a WhatsApp from this campaign';
+    if (e.type === 'screening') {
+      const bits = [
+        e.verdict === 'qualified' ? 'Screening call: qualified'
+          : e.verdict === 'not_qualified' ? 'Screening call: not qualified'
+            : 'Screening call',
+        e.interest && `interest ${e.interest}`,
+        e.sentiment && `sentiment ${e.sentiment}`,
+        e.agreedToMeet === true && 'agreed to meet',
+        e.agreedToMeet === false && 'declined to meet',
+      ].filter(Boolean);
+      return bits.join(' · ');
+    }
+    return e.type;
+  };
+
+  return (
+    <Disclosure
+      label="Response events"
+      count={`${rows.length} EVENT${rows.length === 1 ? '' : 'S'}`}
+      indent={36}
+    >
+      {rows.map((e, i) => (
+        <div
+          key={`${e.type}-${e.at || i}`}
+          style={{ display: 'flex', alignItems: 'baseline', gap: 8, padding: '3px 0', fontSize: 12 }}
+        >
+          <span style={{ flex: 1, color: 'var(--ink-2)' }}>{label(e)}</span>
+          <span className="av2-mono" style={{ fontSize: 10.5, color: 'var(--ink-3)', flex: 'none' }}>
+            {e.at ? fmtDateTime(e.at) : 'undated'}
+            {Number.isFinite(e.ageDays) && ` · ${e.ageDays}d`}
+          </span>
+          <span
+            className="av2-mono"
+            style={{ width: 44, textAlign: 'right', flex: 'none', fontSize: 10.5, color: 'var(--ink-3)' }}
+            title="Full weight before decay"
+          >
+            {e.undecayedWeight != null ? `${e.undecayedWeight > 0 ? '+' : ''}${e.undecayedWeight}` : '—'}
+          </span>
+        </div>
+      ))}
+      <div style={{ fontSize: 11, color: 'var(--ink-3)', paddingTop: 6 }}>
+        Weights are shown at full strength; the score above applies decay as of{' '}
+        {scoredAt ? fmtDateTime(scoredAt) : 'the last rescore'}.
+      </div>
+    </Disclosure>
+  );
+}
+
 function EnrichmentCard({ enrichment }) {
   const bd = enrichment?.breakdown;
   const comps = bd?.components || {};
@@ -653,6 +719,8 @@ function EnrichmentCard({ enrichment }) {
           </div>
         )}
       </div>
+
+      <ScoreEvents events={bd?.events} scoredAt={enrichment?.scoredAt} />
 
       {facts.length > 0 && (
         <Disclosure label="Fact ledger" count={`${facts.length} FACT${facts.length === 1 ? '' : 'S'}`} indent={36}>

--- a/src/pages/adminv2/AdminV2Prospects.jsx
+++ b/src/pages/adminv2/AdminV2Prospects.jsx
@@ -63,6 +63,46 @@ function CheckboxGlyph({ checked }) {
   );
 }
 
+/**
+ * The LEAD score — (person × campaign), not the person
+ * (docs/plans/per-campaign-lead-scoring.md §4). The same number the queue
+ * sorts by, because there is only one: it is decayed at WRITE time and stored,
+ * so sort and display can never disagree (§6).
+ *
+ * NULL is not zero. It means this lead has not been scored yet, and rendering
+ * it as a low number would rank a brand-new lead below a genuinely poor one.
+ * Mirrors AdminV2People's ScoreCell idiom so the two queues read alike.
+ */
+function LeadScoreCell({ value, scoredAt }) {
+  if (value == null) {
+    return (
+      <span
+        className="av2-mono"
+        style={{ width: 52, flex: 'none', fontSize: 11, color: 'var(--ink-3)', textAlign: 'right' }}
+        title="Not scored yet"
+      >
+        —
+      </span>
+    );
+  }
+  // Weight only the top of the range: a faint ramp reads as ranking without
+  // implying precision the number doesn't have.
+  const strong = value >= 60;
+  return (
+    <span
+      className="av2-mono"
+      style={{
+        width: 52, flex: 'none', fontSize: 12, textAlign: 'right',
+        fontWeight: strong ? 700 : 500,
+        color: strong ? 'var(--ink)' : 'var(--ink-2)',
+      }}
+      title={`Lead score ${value}/100${scoredAt ? ` · as of ${fmtDateTime(scoredAt)}` : ''}`}
+    >
+      {value}
+    </span>
+  );
+}
+
 function SortHeader({ label, field, sort, onSort, width, align }) {
   const active = sort === field || sort === `-${field}`;
   const desc = sort === `-${field}`;
@@ -362,6 +402,7 @@ export default function AdminV2Prospects() {
           <span className="av2-microcaps" style={{ width: 130, flex: 'none' }}>Status</span>
           <span className="av2-microcaps" style={{ flex: 1 }}>Campaign</span>
           <span className="av2-microcaps" style={{ width: 100, flex: 'none' }}>Agent</span>
+          <SortHeader label="Score" field="score" sort={filters.sort} onSort={(s) => patch({ sort: s, page: null })} width={52} align="right" />
           <SortHeader label="Created" field="createdAt" sort={filters.sort} onSort={(s) => patch({ sort: s, page: null })} width={100} align="right" />
         </div>
 
@@ -469,6 +510,7 @@ export default function AdminV2Prospects() {
                     ? <Chip tone="accent">External</Chip>
                     : held ? '—' : <Chip tone="warn">none</Chip>}
               </span>
+              <LeadScoreCell value={p.score} scoredAt={p.scoreComputedAt} />
               <span className="av2-mono" style={{ width: 100, flex: 'none', fontSize: 10, color: 'var(--ink-3)', textAlign: 'right' }} title={fmtDateTime(p.createdAt)}>
                 {fmtRelative(p.createdAt)}
               </span>


### PR DESCRIPTION
**Plan:** `docs/plans/per-campaign-lead-scoring.md` §4/§6/§10/§11/§13.1. **Stacked on #302 — merge that first.** Base is `feat/wa-send-ownership`, so this diff shows only A₂; GitHub will retarget to `main` once #302 merges.

> ⚠️ Deleting #302's branch on merge closes this PR. Merge #302, let this retarget, then merge.

## Why

A fresh grad is a great recruit and a poor insurance buyer. Same facts, opposite verdict. One number per *person* cannot hold both, so the score becomes a property of **(person × campaign)** — which is what a `prospect` row already is.

`prospects.score` (INTEGER 0-100, `Prospect.js:75-83`) has been **dead since inception**: written by nothing, and the update endpoint's field allowlist excludes it. Migration 097 makes it the lead score, with the same stamps `consumer_profiles` carries, plus meet/buy and a breakdown.

## One authority (§4)

`scoreOneConsumer` **stops writing** `consumerScore`/`meetScore`/`buyScore` — two writers for one number is two authorities guaranteed to disagree, which is what it did nightly. The person-grain numbers become an **exact projection** of the person's highest-scoring non-erased lead, ties by `createdAt` then `id`.

Concurrency: the projection runs in the scoring transaction under the **consumer lock** (`enrichmentFence.js:87-93`), so two of a person's leads can never project concurrently — the second waits, reads the first's committed score, and picks the true winner.

## Isolation (§3.2), enforced by what the extractor reads

| | reads |
|---|---|
| **Capability** (shared by every lead, by design) | signup counts, email, WhatsApp frontier — a **rank predicate** `IN ('delivered','read')`, never an equality |
| **Response** (never crosses campaigns) | reads of messages *this lead owns* (A₁'s stamp), this lead's screening outcome, its **own** `createdAt` for recency, consent via `canMarketTo` at (consumer, campaign) scope |

Consent goes through the same gate every marketing send calls (`consentService.js:434-441`), so the score can never advertise a reachability the gate would refuse. A read on campaign A moves both grains and lands as a response on exactly one lead — pinned **byte-identical**, not merely score-identical, because two different breakdowns that round to the same integer would still be a leak.

## Decay at write time (§6)

One stored number; sort, display and API all read it; nothing decays at read anywhere. The write gate is weaker than the person-grain one by exactly one clause: **skip iff the hash matches AND the recomputed integers match**. A pure-decay rewrite therefore happens the moment it moves an integer and not before — the person-grain gate skips those *forever* (its hash omits `now`), which is the unbounded drift this replaces. Tested with a two-year clock jump at identical inputs.

## Invalidation (§10)

New `scoreDirtyAt`. `bumpEnrichmentInputTx` dirties the person's leads, so the lead grain inherits the **whole existing fact-write surface** in one change. The relinker's two UNLINK branches dirty **by id** — the lead they move ends with no `consumerId` to key on. The WA webhook dirties the owning lead on `read`; both screening verdict writers dirty **in the same statement as the verdict**. Each fires a post-commit rescore, with the marker as the durable half.

**Sweep:** lead stale + lead rotation phases beside the consumer ones, each with its own cursor. The rotation reservation is **two-dimensional** per §6 — the stale phases stop *admitting* at 80% of the row cap **and** 80% of the deadline, because a row-count reserve alone yields zero rotation whenever a wall-clock stop lands inside the stale phase.

## ⚠️ Erasure — amendment to a shipped, deliberate contract (§11)

Erasure **preserved** `prospects.score`: named in the retained skeleton (`erasureService.js:21-23`) and never touched by the allowlist rebuild. Defensible for a dead column; **not** for a live judgement whose breakdown carries read timestamps, inferred screening sentiment, and `basisObservationIds` pointing at fact rows the same erasure deletes. All nine columns are now nulled and tested. **This one wants a human look.**

## A plan claim that was false (§13.1 → §18.3)

§13.1 said the meet signal rides un-normalized as e.g. `meet_consultant`. **It does not exist.** The configured agent's `post_call_analysis_data` is exactly `qualified` / `qualification_reason` / `interest_level` (`retell-screening-calls.md:524-527`), plus Retell's `user_sentiment`. `meet_consultant`, `sg_pr` and `age_in_range` appear in one illustrative comment (`retellScreeningService.js:682`) and in no agent config.

`utils/screeningSignal.js` therefore declares `agreedToMeet` as a slot backed by an intentionally **empty** `MEET_CHECK_KEYS`, and scores only closed vocabularies — never raw provider `checks` keys, whose names are whatever an operator last typed into the Retell console. Configuring a real check is one array entry plus a schema-version bump.

## Surfaces

Score column on the admin queue (sortable, **NULLS LAST both directions** — Postgres would otherwise lead a `-score` page with the unscored) and on the agent queue. A **Response events** section in the breakdown card showing what happened, when, and its **undecayed** weight — the score already has decay baked in as of `scoreComputedAt`, so repeating a decayed figure would explain nothing.

## Verification

All green against local Postgres: **130 integration suites / 2580 tests**, all unit suites, **30 migration tests**; `npx eslint src/ --quiet` clean at both roots; frontend vitest **159 files / 2025 tests**.

`test/unit/retellScreening.test.js` **passed at 05:09 SGT** — outside the 10:00–20:00 call window — so the recorded time-of-day flake did not reproduce. No cohort failures.

One existing test changed: `consumerEnrichment.test.js`'s "band reaches the Buy score" now asserts at the new authority (the lead) and additionally pins the projection. Its intent — age reaches Buy, cites the band, reads thin — is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENWdGMue9uXqmKv3pRG6YF