### PR TITLE
fix(consent): correct the ledger's verified annotation by APPEND + unbreak main

### DIFF
--- a/backend/src/database/migrations/098-correct-backfilled-consent-verified.js
+++ b/backend/src/database/migrations/098-correct-backfilled-consent-verified.js
@@ -1,0 +1,102 @@
+/**
+ * 098 — the consent ledger's `verified` annotation, corrected by APPEND.
+ *
+ * Migration 081 derived ledger rows from prospects with
+ * `verified = phoneVerificationIsCurrent(p)`. For every pre-2026-07-09 signup
+ * that was false — not because the lead skipped OTP, but because the server
+ * did not yet persist the stamp (see 097). `verified` is what mints marketing
+ * authority: canMarketTo requires `granted === true && verified === true`, and
+ * its docstring is unambiguous that every marketing send and audience upload
+ * goes through it. So 129 people who ticked the box and passed OTP are
+ * currently unmarketable on a technicality of our own record-keeping.
+ *
+ * 097 fixed the prospects, but it cannot fix these rows: backfillConsentEvents
+ * skips nothing and re-derives correctly, yet `uq_ce_backfill` (prospectId,
+ * kind) + ignoreDuplicates makes a healing rerun a DB no-op. The stale
+ * annotation would sit there forever.
+ *
+ * WHY APPEND AND NOT UPDATE. consent_events is append-only — the model says
+ * "Never UPDATE or DELETE rows" — because it is the evidentiary record of what
+ * a person agreed to and when. That invariant holds even when the row is ours
+ * to correct, so this writes a NEW event per affected row and leaves the
+ * original intact and auditable.
+ *
+ * The correction carries the ORIGINAL `occurredAt`. That is the load-bearing
+ * detail. Both readers (getConsentState and getMarketableGrantMap) order by
+ * `occurredAt DESC, createdAt DESC, id DESC`, so preserving occurredAt means
+ * the correction beats exactly one row — its own twin, on the later createdAt
+ * — and can never leapfrog a genuinely later act. An unsubscribe recorded
+ * after the original grant still wins, which is the whole reason not to date
+ * these `now()`. It also keeps the ledger honest about WHEN consent was given:
+ * this is a correction to evidence about a past act, not a new act.
+ *
+ * `granted` is COPIED, never set. The two `granted = false` contact rows in
+ * production are deliberately untouched: a denial is a denial whether or not
+ * the phone was verified, the flag is inert there, and appending anything to
+ * an opted-out person's ledger is precisely what one does not do.
+ *
+ * source = 'admin' because chk_ce_source admits no 'correction' value and
+ * widening a compliance constraint to label one backfill is a bad trade;
+ * metadata carries the real provenance (`correctionOf` + reason + migration),
+ * which is also the idempotency key and what down() matches on.
+ *
+ * Scope is keyed to `phoneVerifiedSource = 'backfill_gate_inference'` — the
+ * marker 097 writes — so this can only ever touch rows whose prospect that
+ * migration stamped. Prod dry run: 319 corrections (131 campaign_terms + 129
+ * contact + 59 third_party), 2 denials skipped.
+ */
+
+const CORRECTION_REASON = 'phone_verification_backfill';
+const MIGRATION_TAG = '098';
+
+export async function up(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.transaction(async (t) => {
+    await sequelize.query(
+      `INSERT INTO consent_events (
+         id, "consumerId", "prospectId", "campaignId", kind, granted, channels,
+         version, source, "sourceUrl", verified, "actorUserId", metadata,
+         "occurredAt", "createdAt", "updatedAt"
+       )
+       SELECT gen_random_uuid(), ce."consumerId", ce."prospectId", ce."campaignId",
+              ce.kind, ce.granted, ce.channels, ce.version, 'admin', ce."sourceUrl",
+              TRUE, NULL,
+              COALESCE(ce.metadata, '{}'::jsonb) || jsonb_build_object(
+                'correctionOf', ce.id::text,
+                'reason', :reason,
+                'migration', :tag
+              ),
+              ce."occurredAt", now(), now()
+         FROM consent_events ce
+         JOIN prospects p ON p.id = ce."prospectId"
+        WHERE ce.source = 'backfill'
+          AND ce.verified = FALSE
+          AND ce.granted = TRUE
+          AND p."sourceMetadata" IS NOT NULL
+          AND p."sourceMetadata"::jsonb ->> 'phoneVerifiedSource' = 'backfill_gate_inference'
+          AND NOT EXISTS (
+            SELECT 1 FROM consent_events x
+             WHERE x.metadata ->> 'correctionOf' = ce.id::text
+          )`,
+      { replacements: { reason: CORRECTION_REASON, tag: MIGRATION_TAG }, transaction: t }
+    );
+  });
+}
+
+export async function down(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.transaction(async (t) => {
+    // Removes only the events this migration authored — they are the only rows
+    // carrying the tag. The originals were never modified, so the ledger
+    // returns exactly to its prior state.
+    await sequelize.query(
+      `DELETE FROM consent_events
+        WHERE source = 'admin'
+          AND metadata ->> 'migration' = :tag
+          AND metadata ->> 'reason' = :reason`,
+      { replacements: { reason: CORRECTION_REASON, tag: MIGRATION_TAG }, transaction: t }
+    );
+  });
+}

--- a/backend/test/migration098ConsentVerifiedCorrection.test.js
+++ b/backend/test/migration098ConsentVerifiedCorrection.test.js
@@ -1,0 +1,143 @@
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect } from './helpers.js';
+import { randomUUID } from 'crypto';
+import { sequelize, Consumer, ConsentEvent } from '../src/models/index.js';
+import { up, down } from '../src/database/migrations/098-correct-backfilled-consent-verified.js';
+import { makeConsentService } from '../src/services/consentService.js';
+
+/**
+ * 098 on real Postgres. The migration touches a compliance ledger, so the
+ * tests that matter are the ones about what it must NOT do: never flip a
+ * denial, never resurrect consent past an unsubscribe, never modify an
+ * original row, never touch a prospect 097 did not stamp.
+ */
+
+const BEFORE = new Date('2026-07-01T15:35:19Z');
+const STAMPED = {
+  clientUserAgent: 'Mozilla/5.0', eventSourceUrl: 'https://redeem.sg/c/a', consent_contact: true,
+  phoneVerifiedAt: '2026-07-01T15:35:19.000Z',
+  phoneVerifiedFor: 'deadbeef',
+  phoneVerifiedSource: 'backfill_gate_inference',
+};
+const UNSTAMPED = { clientUserAgent: 'Mozilla/5.0', eventSourceUrl: 'https://redeem.sg/c/a' };
+
+let admin; let campaignId; let svc; let seq = 0;
+
+beforeAll(async () => {
+  await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  const campaign = await createTestCampaign(admin.user.id, { name: 'Consent 098' });
+  campaignId = campaign.id;
+  svc = makeConsentService();
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+/** A linked prospect + consumer with one backfilled contact grant. */
+async function seed({ sourceMetadata, granted = true, verified = false }) {
+  seq += 1;
+  const phone = `+6597${String(100000 + seq).slice(-6)}`;
+  const consumer = await Consumer.create({ phone, firstSeenAt: BEFORE, lastSeenAt: BEFORE });
+  const p = await createTestProspect(campaignId, {
+    phone, leadSource: 'website', sourceMetadata, consumerId: consumer.id,
+  });
+  await sequelize.query('UPDATE prospects SET "createdAt" = :c WHERE id = :id', {
+    replacements: { c: BEFORE, id: p.id },
+  });
+  const ev = await ConsentEvent.create({
+    id: randomUUID(), consumerId: consumer.id, prospectId: p.id, campaignId,
+    kind: 'contact', granted, channels: ['phone', 'email'], version: 'legacy-backfill',
+    source: 'backfill', sourceUrl: 'https://redeem.sg/c/a', verified,
+    occurredAt: BEFORE, metadata: null,
+  });
+  return { consumer, prospect: p, event: ev };
+}
+
+const latestContact = async (consumerId) => {
+  const rows = await ConsentEvent.findAll({
+    where: { consumerId, kind: 'contact' },
+    order: [['occurredAt', 'DESC'], ['createdAt', 'DESC'], ['id', 'DESC']],
+  });
+  return rows[0];
+};
+
+test('corrects a stamped grant by APPENDING, leaving the original untouched', async () => {
+  const { consumer, event } = await seed({ sourceMetadata: STAMPED });
+
+  await up({ sequelize });
+
+  const original = await ConsentEvent.findByPk(event.id);
+  expect(original.verified).toBe(false); // never mutated
+  expect(original.source).toBe('backfill');
+
+  const latest = await latestContact(consumer.id);
+  expect(latest.id).not.toBe(event.id);
+  expect(latest.verified).toBe(true);
+  expect(latest.granted).toBe(true);
+  expect(latest.source).toBe('admin');
+  expect(latest.metadata.correctionOf).toBe(event.id);
+  expect(latest.metadata.reason).toBe('phone_verification_backfill');
+  // The load-bearing detail: the act is NOT redated.
+  expect(new Date(latest.occurredAt).getTime()).toBe(BEFORE.getTime());
+  expect(latest.channels).toEqual(['phone', 'email']); // evidence copied verbatim
+  expect(latest.version).toBe('legacy-backfill');
+});
+
+test('does NOT resurrect consent for someone who unsubscribed afterwards', async () => {
+  const { consumer, prospect } = await seed({ sourceMetadata: STAMPED });
+  // A genuine later withdrawal, global scope, as unsubscribe writes it.
+  const unsubAt = new Date('2026-07-15T00:00:00Z');
+  await ConsentEvent.create({
+    id: randomUUID(), consumerId: consumer.id, prospectId: prospect.id, campaignId: null,
+    kind: 'contact', granted: false, channels: null, version: 'unsub-v1',
+    source: 'unsubscribe', verified: true, occurredAt: unsubAt, metadata: null,
+  });
+
+  await up({ sequelize });
+
+  const latest = await latestContact(consumer.id);
+  expect(latest.source).toBe('unsubscribe');
+  expect(latest.granted).toBe(false); // withdrawal still wins on occurredAt
+});
+
+test('never flips a denial, and never touches an unstamped prospect', async () => {
+  const denial = await seed({ sourceMetadata: STAMPED, granted: false });
+  const unstamped = await seed({ sourceMetadata: UNSTAMPED });
+
+  await up({ sequelize });
+
+  for (const s of [denial, unstamped]) {
+    const rows = await ConsentEvent.findAll({ where: { consumerId: s.consumer.id } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].verified).toBe(false);
+  }
+});
+
+test('idempotent, and down() removes only what it wrote', async () => {
+  const { consumer, event } = await seed({ sourceMetadata: STAMPED });
+
+  await up({ sequelize });
+  const afterFirst = await ConsentEvent.count({ where: { consumerId: consumer.id } });
+  await up({ sequelize });
+  expect(await ConsentEvent.count({ where: { consumerId: consumer.id } })).toBe(afterFirst);
+
+  await down({ sequelize });
+  const rows = await ConsentEvent.findAll({ where: { consumerId: consumer.id } });
+  expect(rows).toHaveLength(1);
+  expect(rows[0].id).toBe(event.id);
+  expect(rows[0].verified).toBe(false); // original survived the round trip intact
+});
+
+test('the marketing gate opens for the corrected person, in their campaign scope only', async () => {
+  const { consumer } = await seed({ sourceMetadata: STAMPED });
+  const consent = svc;
+
+  expect(await consent.canMarketTo({ consumerId: consumer.id, campaignId })).toBe(false);
+
+  await up({ sequelize });
+
+  expect(await consent.canMarketTo({ consumerId: consumer.id, campaignId })).toBe(true);
+  // Legacy-era rows stay campaign-locked — the correction must not widen scope.
+  expect(await consent.canMarketTo({ consumerId: consumer.id, campaignId: null })).toBe(false);
+});

--- a/backend/test/migrations.test.js
+++ b/backend/test/migrations.test.js
@@ -61,13 +61,18 @@ describe('Migration static validation', () => {
   });
 
   test('migration numbering has no duplicates', () => {
-    // 083 is a HISTORICAL duplicate: 083-suppression-propagation (#220) and
-    // 083-sms-rate-counters (#221) were built in parallel sessions and BOTH
-    // are applied in prod's _migrations under these exact filenames. The
-    // runner keys strictly by filename, so renaming either would re-run it
-    // (forward-safe but a rollback footgun — Codex resub-round #10). The
-    // duplicate number is frozen as-is; nothing else may join this list.
-    const HISTORICAL_DUPLICATES = new Set(['083']);
+    // HISTORICAL duplicates, frozen because the runner keys STRICTLY BY
+    // FILENAME: both members of each pair are already applied in prod's
+    // _migrations under these exact names, so renaming either re-runs it
+    // (forward-safe but a rollback footgun — Codex resub-round #10).
+    //  - 083: 083-suppression-propagation (#220) + 083-sms-rate-counters
+    //    (#221), built in parallel sessions.
+    //  - 096: 096-phone-verification-markers (#300) + 096-wa-message-sends
+    //    (PR A₁), same story — merged hours apart on 2026-07-27, and prod
+    //    applied BOTH the same day. Verified in _migrations before freezing.
+    // Do not add to this list to dodge a collision you can still rename your
+    // way out of: a number is only frozen once prod has applied both files.
+    const HISTORICAL_DUPLICATES = new Set(['083', '096']);
     const numbers = migrationFiles
       .map(f => f.split('-')[0])
       .filter(n => !HISTORICAL_DUPLICATES.has(n));


### PR DESCRIPTION
Two things, one urgent.

## 1. `main` is RED right now — duplicate migration 096

#300 and PR A₁ (`wa-message-sends`) were built in parallel and both claimed **096**. They merged hours apart today, so neither PR's own CI could see the collision. Main's first post-merge run failed on `migration numbering has no duplicates` (expected 93, received 94).

Prod has **already applied both** under their exact filenames (`096-phone-verification-markers.js` + `096-wa-message-sends.js`, both `2026-07-26` in `_migrations` — verified before writing this). The runner keys strictly by filename, so renaming either would re-run it. That's precisely the `083` precedent, so 096 gets the same treatment: frozen and documented, not renamed. The comment now also states when *not* to use the escape hatch.

## 2. The consent correction (migration 098) — the tail of #300

This commit was pushed to #300 minutes after it was squash-merged, so it never landed.

`consent_events.verified` is what mints marketing authority (`canMarketTo` = `granted && verified`, and *"Every marketing send/upload calls this — no exceptions"*), and migration 081 derived it as `phoneVerificationIsCurrent(p)` — false for every pre-epoch signup. **129 people who ticked the box and passed OTP are unmarketable.**

097 (now live) fixed the prospects but cannot reach these rows: `backfillConsentEvents` re-derives correctly, yet `uq_ce_backfill` + `ignoreDuplicates` makes a healing rerun a DB no-op.

### Append, not update

`consent_events` is append-only — *"Never UPDATE or DELETE rows"* — so this writes a **new** event per affected row, leaving the original intact and auditable.

The correction carries the **original `occurredAt`**, which is the detail everything hinges on. Both readers order by `occurredAt DESC, createdAt DESC, id DESC`, so it beats exactly one row — its own twin, on the later `createdAt` — and never leapfrogs a genuinely later act. **An unsubscribe recorded after the original grant still wins**; dating these `now()` would have silently resurrected consent for anyone who has since unsubscribed. Tests cover both that and the fact that a legacy-era row's campaign scope does not widen.

`granted` is copied, never set — the 2 `granted=false` rows are deliberately skipped.

### Expected effect

097 is already live and stamped **131 prospects** in prod (confirmed: `by_backfill = 131`, `stamped_total = 135` of 138). So 098's projected write is now firm: **319 corrections** — 131 `campaign_terms` + 129 `contact` + 59 `third_party` — plus 2 denials skipped.

Suites: 120/120 top-level (2437 tests), 106/106 unit (1938), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eL2XE1J1A6eF3j3jTJqbm