### PR TITLE
fix(redeem-ops): Discover AI suggest — declare categories required (OpenAI strict mode)

### DIFF
--- a/backend/src/services/redeemOps/discoveryAiService.js
+++ b/backend/src/services/redeemOps/discoveryAiService.js
@@ -20,6 +20,11 @@ import { requestStructuredJson } from '../guidedReviewAiService.js';
 // Constraint-free on purpose: providers disagree on which JSON-Schema keywords
 // structured outputs accept (array bounds, string lengths), so the contract is
 // enforced in normalizeTerms() below instead.
+// EVERY property must also be listed in `required`: the OpenAI transport sends
+// these with strict:true, which rejects an optional property with a 400 before
+// the model runs. `categories` was optional here from #171 until 27 Jul, which
+// failed every suggestion on OpenAI. IG mode still returns it — as an empty
+// array per the prompt — and suggestTerms discards it there anyway.
 const TERMS_SCHEMA = {
   type: 'object',
   additionalProperties: false,
@@ -28,7 +33,7 @@ const TERMS_SCHEMA = {
     // Maps only — real Google category names the results can be filtered by.
     categories: { type: 'array', items: { type: 'string' } },
   },
-  required: ['terms'],
+  required: ['terms', 'categories'],
 };
 
 const SYSTEM_PROMPT = `

--- a/backend/test/redeemOpsDiscoveryAiSuggest.test.js
+++ b/backend/test/redeemOpsDiscoveryAiSuggest.test.js
@@ -99,6 +99,25 @@ describe('suggestTerms', () => {
     expect(call.schema.properties.terms.items.type).toBe('string');
   });
 
+  /* The OpenAI transport sends this schema with strict:true, which 400s the
+     request — before the model runs — for any property missing from `required`.
+     Mocking the transport hides that, so assert the contract on the schema:
+     an optional `categories` broke every prod suggestion from #171 to 27 Jul. */
+  test('the schema satisfies OpenAI strict mode — every property is required', async () => {
+    const violations = (schema, path = '$') => {
+      if (!schema || typeof schema !== 'object') return [];
+      const found = [];
+      for (const name of Object.keys(schema.properties || {})) {
+        if (!(schema.required || []).includes(name)) found.push(`${path}.${name}`);
+        found.push(...violations(schema.properties[name], `${path}.${name}`));
+      }
+      return found.concat(violations(schema.items, `${path}[]`));
+    };
+    const { svc, deps } = makeSvc();
+    await svc.suggestTerms({ description: 'kids martial arts', provider: 'google_maps' }, user);
+    expect(violations(deps.requestStructuredJson.mock.calls[0][0].schema)).toEqual([]);
+  });
+
   test('maps mode returns normalized categories alongside terms', async () => {
     const { svc } = makeSvc({
       requestStructuredJson: jest.fn(async () => ({


### PR DESCRIPTION
## What broke

Every Discover keyword suggestion has failed in prod since #171 (16 Jul), showing staff *"AI suggestion failed — try again shortly"*. It is not transient — the request is rejected before the model runs, so retrying can never succeed.

OpenAI structured outputs run with `strict: true`, which forbids optional properties: every key in `properties` must also appear in `required`. #171 added `categories` to `TERMS_SCHEMA` but left `required: ['terms']`, so the provider 400s the whole call:

```
Invalid schema for response_format 'discovery_term_suggestions': 'required' is
required to be supplied and to be an array including every key in properties.
Missing 'categories'.
```
<sub>prod log, 27 Jul 11:15Z, `openai/gpt-5.6-terra`, request `440e6ac9`</sub>

`providerError()` maps that 400 to a generic 502, which is why it reads as a flaky provider rather than a permanent schema bug. **Cadence AI drafting was never affected** — its `DRAFT_SCHEMA` lists every property in `required` at both levels, which is the asymmetry that made this confusing to diagnose.

## The fix

`required: ['terms']` → `required: ['terms', 'categories']`.

Requiring it — rather than dropping `categories` from the schema — is the fix that keeps the feature: the suggestion is meant to pre-fill the category filter and open the filters panel (`DiscoverPage` `suggestMutation.onSuccess`). Instagram mode still returns it as an empty array per the prompt, and `suggestTerms` discards it there regardless, so both modes stay correct.

## Why the tests missed it

The unit tests mock `requestStructuredJson`, so the schema never meets a provider. Added a guard that walks the schema and asserts every property appears in `required` — it fails with exactly `$.categories` on the old schema, matching what OpenAI said. Verified by reverting the fix and watching it go red.

`redeemOpsDiscoveryAiSuggest` + `redeemOpsCadenceAiSuggest`: 37 passed.

## Scope check

Audited the other four structured-output schemas (guided review, campaign details, campaign copy, cadences) — all keep `required` in lock-step with `properties`, including the conditional branches. This was the only violator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtL6Jqv4T8GwXVU6jiyTfw