### PR TITLE
fix(redeem-ops): the cadence picker scrolls its library instead of overflowing the viewport

### DIFF
--- a/src/components/redeemops/__tests__/cadence.test.jsx
+++ b/src/components/redeemops/__tests__/cadence.test.jsx
@@ -319,6 +319,35 @@ describe('CadencePanel', () => {
     wrap(<CadencePanel partner={{ id: 'p-1', ownerUserId: 'u-1', pipelineStage: 'NEW' }} />);
     expect(await screen.findByRole('button', { name: /start cadence/i })).toBeInTheDocument();
   });
+
+  it('the picker scrolls its library, keeping the heading and "New cadence" on screen', async () => {
+    api.getPartnerCadence.mockResolvedValue({ enrollment: null, openTask: null });
+    api.listCadences.mockResolvedValue({
+      cadences: Array.from({ length: 12 }, (_, i) => ({
+        id: `c-${i}`,
+        name: `Cadence ${i}`,
+        publishedAt: new Date().toISOString(),
+        steps: [{ id: `s-${i}`, stepOrder: 1, channel: 'call' }],
+      })),
+      aiEnabled: false,
+    });
+    useAuthStore.setState({ user: { id: 'u-1', role: 'user', redeemOpsRole: 'bdm' } });
+    const user = userEvent.setup();
+    wrap(<CadencePanel partner={{ id: 'p-1', ownerUserId: 'u-1', pipelineStage: 'NEW' }} />);
+    await user.click(await screen.findByRole('button', { name: /start cadence/i }));
+
+    // Every row shares one scroll container — a long library can't push the
+    // dialog past the viewport, which left it unreachable in both directions.
+    const scroller = (await screen.findByRole('button', { name: /Cadence 0/ })).parentElement;
+    expect(scroller.className).toMatch(/overflow-y-auto/);
+    expect(screen.getByRole('button', { name: /Cadence 11/ }).parentElement).toBe(scroller);
+    // The authoring escape hatch sits outside it, so it never scrolls away.
+    expect(scroller).not.toContainElement(screen.getByRole('link', { name: /New cadence/ }));
+  });
+
+  afterEach(() => {
+    useAuthStore.setState({ user: null });
+  });
 });
 
 /* ── The Cadence & Tasks rail section (Business Detail design) ── */

--- a/src/components/redeemops/cadence.jsx
+++ b/src/components/redeemops/cadence.jsx
@@ -209,18 +209,20 @@ export function CadenceOutcomeButton({ task, size = 'sm', disabled = false, disa
       </Dialog>
 
       <Dialog open={scriptOpen} onOpenChange={setScriptOpen}>
-        <DialogContent className="max-w-md">
-          <DialogHeader>
+        {/* A drafted script can run long — it scrolls inside the dialog so
+            Copy message never gets pushed off the bottom of the screen. */}
+        <DialogContent className="max-w-md flex flex-col max-h-[85dvh]">
+          <DialogHeader className="shrink-0">
             <DialogTitle>{task.title}</DialogTitle>
             {task.snapshotRecipient && (
               <DialogDescription>To: {task.snapshotRecipient}</DialogDescription>
             )}
           </DialogHeader>
-          <p className="text-sm whitespace-pre-wrap m-0" style={{ color: 'var(--ro-text-2)' }}>
+          <p className="text-sm whitespace-pre-wrap m-0 min-h-0 overflow-y-auto" style={{ color: 'var(--ro-text-2)' }}>
             {task.description || 'No script for this step.'}
           </p>
           {task.description && (
-            <DialogFooter>
+            <DialogFooter className="shrink-0">
               <Button variant="outline" onClick={() => copyTaskMessage(task.description)}>
                 <Copy className="w-3.5 h-3.5 mr-1.5" aria-hidden="true" /> Copy message
               </Button>
@@ -700,14 +702,17 @@ export function CadencePanel({ partner, canManage = true, variant = 'card', onAd
       )}
 
       <Dialog open={enrollOpen} onOpenChange={setEnrollOpen}>
-        <DialogContent className="max-w-md">
-          <DialogHeader>
+        {/* The library grows without bound, so the dialog is capped to the
+            viewport and only the list scrolls — the heading and the "New
+            cadence" escape hatch stay on screen at any library size. */}
+        <DialogContent className="max-w-md flex flex-col max-h-[85dvh]">
+          <DialogHeader className="shrink-0">
             <DialogTitle>Start a cadence</DialogTitle>
             <DialogDescription>
               Every step becomes a task in the owner's queue at the right time — replies and stage moves stop it automatically.
             </DialogDescription>
           </DialogHeader>
-          <div className="space-y-2">
+          <div className="space-y-2 min-h-0 overflow-y-auto">
             {cadenceDefs.map((c) => (
               <button
                 key={c.id}
@@ -737,15 +742,15 @@ export function CadencePanel({ partner, canManage = true, variant = 'card', onAd
             {!defsQuery.isLoading && cadenceDefs.length === 0 && (
               <p className="text-sm m-0" style={{ color: 'var(--ro-text-2)' }}>No cadences defined yet.</p>
             )}
-            {canAuthor && (
-              <Button size="sm" variant="ghost" className="w-full" asChild>
-                <Link to="/redeem-ops/cadences/new">
-                  <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" />
-                  New cadence — yours stays a private draft until you publish it
-                </Link>
-              </Button>
-            )}
           </div>
+          {canAuthor && (
+            <Button size="sm" variant="ghost" className="w-full shrink-0" asChild>
+              <Link to="/redeem-ops/cadences/new">
+                <Plus className="w-4 h-4 mr-1.5" aria-hidden="true" />
+                New cadence — yours stays a private draft until you publish it
+              </Link>
+            </Button>
+          )}
         </DialogContent>
       </Dialog>
     </>


### PR DESCRIPTION
## What broke

"Start a cadence" on a business with a grown cadence library rendered a dialog taller than the window **with nothing able to scroll**. `DialogContent` is fixed and vertically centred with no max-height and no overflow rule, so the heading spilled off the top of the screen, the last cadences off the bottom, and neither the dialog nor the page could reach either end. The "New cadence" link was unreachable.

Measured with 12 cadences in a 1000×720 viewport, against the real compiled stylesheet:

| | dialog top | dialog bottom | heading visible | CTA visible | list scrolls |
|---|---|---|---|---|---|
| before | −251px | 971px | ✗ | ✗ | ✗ |
| after | 54px | 666px | ✓ | ✓ | ✓ |

## The fix

Cap the dialog to `85dvh` as a flex column so **only the list scrolls**. The heading stays pinned, and the "New cadence" authoring link moves out of the scroll container so the escape hatch can't scroll away — it sits below the list at any library size.

Same treatment for the sibling "View script" dialog in this file, which fails identically on a long drafted script and pushes **Copy message** off-screen.

Two details worth flagging for review:

- `flex` beats the primitive's `grid` through the `twMerge` in `cn()` (verified). The display override is load-bearing — grid rows would not shrink under the max-height, so `max-h` alone would not have fixed it.
- `min-h-0` on the scroller is the usual flex-shrink guard.

## Consistency

The assign-owner dialog on this same page already scrolls its list this way (`PartnerDetail`, `max-h-[50dvh]`) — the picker had simply been missed.

**Wider gap, deliberately not fixed here:** most `DialogContent` call sites still declare no max-height, so this overflow is reachable elsewhere. Guarding it once in the shared primitive would fix them all, but that also touches the customer funnel on redeem.sg, so it deserves its own PR rather than riding along.

## Tests

Added a regression test asserting the rows share one `overflow-y-auto` container and that the authoring link sits outside it. Verified it genuinely catches the bug by reverting the fix and watching it fail. `cadence.test.jsx`: 22 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtL6Jqv4T8GwXVU6jiyTfw