### PR TITLE
fix(redeem-ops): a business is worked by the person who owns it

### DIFF
--- a/backend/src/services/redeemOps/partnerService.js
+++ b/backend/src/services/redeemOps/partnerService.js
@@ -10,7 +10,7 @@ import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';
 import { makeRedeemOpsAuditService } from './auditService.js';
 import { makeDedupeService } from './dedupeService.js';
-import { hasCapability } from './permissions.js';
+import { hasCapability, canActOnPartnerRow } from './permissions.js';
 import { deriveMatchingKeys, postalDistrictOf } from './normalizers.js';
 import {
   PIPELINE_STAGES, STAGE_TRANSITIONS, PARTNER_AVAILABILITY,
@@ -51,12 +51,22 @@ export function makePartnerService(overrides = {}) {
   const LIVE = { mergedIntoId: null };
   const OWNER_INCLUDE = { model: d.User, as: 'owner', attributes: ['id', 'fullName', 'email'] };
 
-  /** Managers act on any row; everyone else must own it. */
-  function canActOnRow(user, partner) {
-    if (!user) return false;
-    if (user.role === 'admin') return true;
-    if (['super_admin', 'ops_admin', 'bdm'].includes(user.redeemOpsRole)) return true;
-    return partner.ownerUserId === user.id;
+  /**
+   * Admin tier acts on any row; everyone else — BDMs included — must own it,
+   * and an unowned row must be claimed first. Shared with the SPA's board and
+   * detail gating via permissions.js so the UI can't offer what this refuses.
+   */
+  const canActOnRow = canActOnPartnerRow;
+
+  /** 403 for a row that isn't yours — pointing at Claim when it's nobody's yet. */
+  function assertCanMoveRow(user, partner) {
+    if (canActOnRow(user, partner)) return;
+    throw new AppError(
+      partner.ownerUserId
+        ? 'You can only move businesses you own'
+        : 'Claim this business first, then you can move it',
+      403
+    );
   }
 
   async function getLivePartner(id, options = {}) {
@@ -265,9 +275,7 @@ export function makePartnerService(overrides = {}) {
       throw new AppError('A reason is required when marking a business as Lost', 400);
     }
     const partner = await getLivePartner(id, { transaction: t, lock: t.LOCK.UPDATE });
-    if (!canActOnRow(user, partner)) {
-      throw new AppError('You can only move businesses you own', 403);
-    }
+    assertCanMoveRow(user, partner);
     const fromStage = partner.pipelineStage;
     if (fromStage === toStage) return partner;
 
@@ -334,9 +342,7 @@ export function makePartnerService(overrides = {}) {
   async function undoStageChange(id, user, requestId = null) {
     return d.sequelize.transaction(async (t) => {
       const partner = await getLivePartner(id, { transaction: t, lock: t.LOCK.UPDATE });
-      if (!canActOnRow(user, partner)) {
-        throw new AppError('You can only move businesses you own', 403);
-      }
+      assertCanMoveRow(user, partner);
       const last = await d.PartnerStageEvent.findOne({
         where: { partnerOrganisationId: id },
         order: [['createdAt', 'DESC']],

--- a/backend/src/services/redeemOps/permissions.js
+++ b/backend/src/services/redeemOps/permissions.js
@@ -170,3 +170,25 @@ export function hasCapability(user, capability) {
 export function isRedeemOpsUser(user) {
   return !!user && (user.role === 'admin' || user.role === 'redeem_ops' || !!user.redeemOpsRole);
 }
+
+/** The tier that may act on a business it doesn't own. BDM is deliberately NOT here. */
+export const ROW_OVERRIDE_SUB_ROLES = ['super_admin', 'ops_admin'];
+
+/**
+ * Row-level gate: may this user write to THIS business? Covers stage moves,
+ * detail edits, contacts, locations and snooze — the actions that belong to
+ * whoever is working the deal.
+ *
+ * A business is worked by exactly one person, so only its owner may act on it;
+ * BDMs get no blanket override over a colleague's row (they keep their
+ * capability-gated powers — reassign, claim, tasks, pools — and may still log
+ * activity on any row via the `partners.reassign` escape hatch in the service).
+ * Admin tier overrides everything. An UNOWNED row is nobody's: it must be
+ * claimed first, which is why a null owner never matches.
+ */
+export function canActOnPartnerRow(user, partner) {
+  if (!user || !partner) return false;
+  if (user.role === 'admin') return true;
+  if (ROW_OVERRIDE_SUB_ROLES.includes(user.redeemOpsRole)) return true;
+  return !!partner.ownerUserId && partner.ownerUserId === user.id;
+}

--- a/backend/test/redeemOpsPartners.test.js
+++ b/backend/test/redeemOpsPartners.test.js
@@ -329,6 +329,78 @@ describe('stage machine + activities + row-level ownership', () => {
     expect(log.status).toBe(403);
   });
 
+  test('a BDM cannot move or edit a colleague’s business, but may still log activity', async () => {
+    const res = await createPartner(admin.token, { tradingName: `Colleague Deal ${Date.now()}` });
+    const id = res.body.data.partner.id;
+    await request(app).post(`/api/redeem-ops/partners/${id}/claim`).set(auth(execA.token));
+
+    // NEW → CONTACTED is a legal transition; the refusal is purely about ownership.
+    const move = await request(app)
+      .patch(`/api/redeem-ops/partners/${id}/stage`)
+      .set(auth(bdm.token))
+      .send({ toStage: 'CONTACTED' });
+    expect(move.status).toBe(403);
+    expect(await PartnerOrganisation.findByPk(id).then((r) => r.pipelineStage)).toBe('NEW');
+
+    const edit = await request(app)
+      .put(`/api/redeem-ops/partners/${id}`)
+      .set(auth(bdm.token))
+      .send({ tradingName: 'Renamed By Someone Else' });
+    expect(edit.status).toBe(403);
+
+    const contact = await request(app)
+      .post(`/api/redeem-ops/partners/${id}/contacts`)
+      .set(auth(bdm.token))
+      .send({ name: 'Not My Contact' });
+    expect(contact.status).toBe(403);
+
+    const location = await request(app)
+      .post(`/api/redeem-ops/partners/${id}/locations`)
+      .set(auth(bdm.token))
+      .send({ name: 'Not My Outlet', postalCode: '049483' });
+    expect(location.status).toBe(403);
+
+    const snooze = await request(app)
+      .post(`/api/redeem-ops/partners/${id}/snooze`)
+      .set(auth(bdm.token))
+      .send({ until: new Date(Date.now() + 7 * 86400000).toISOString() });
+    expect(snooze.status).toBe(403);
+
+    // Visibility is not the thing being restricted — a manager may still log a touch.
+    const log = await request(app)
+      .post(`/api/redeem-ops/partners/${id}/activities`)
+      .set(auth(bdm.token))
+      .send({ type: 'internal_note', summary: 'checked in with the team', direction: 'internal' });
+    expect(log.status).toBe(201);
+
+    // …and the owner is unaffected.
+    const owned = await request(app)
+      .patch(`/api/redeem-ops/partners/${id}/stage`)
+      .set(auth(execA.token))
+      .send({ toStage: 'CONTACTED' });
+    expect(owned.status).toBe(200);
+  });
+
+  test('an unowned business must be claimed before anyone can move it', async () => {
+    const res = await createPartner(admin.token, { tradingName: `Nobody's Deal ${Date.now()}` });
+    const id = res.body.data.partner.id;
+    expect(await PartnerOrganisation.findByPk(id).then((r) => r.ownerUserId)).toBeNull();
+
+    const denied = await request(app)
+      .patch(`/api/redeem-ops/partners/${id}/stage`)
+      .set(auth(bdm.token))
+      .send({ toStage: 'CONTACTED' });
+    expect(denied.status).toBe(403);
+    expect(denied.body.message).toMatch(/claim/i);
+
+    await request(app).post(`/api/redeem-ops/partners/${id}/claim`).set(auth(bdm.token));
+    const allowed = await request(app)
+      .patch(`/api/redeem-ops/partners/${id}/stage`)
+      .set(auth(bdm.token))
+      .send({ toStage: 'CONTACTED' });
+    expect(allowed.status).toBe(200);
+  });
+
   test('meaningful activity stamps firstOutreachAt/lastActivityAt; internal note does not', async () => {
     const note = await request(app)
       .post(`/api/redeem-ops/partners/${partnerId}/activities`)

--- a/src/lib/__tests__/redeemOpsPermissionsDrift.test.js
+++ b/src/lib/__tests__/redeemOpsPermissionsDrift.test.js
@@ -9,6 +9,28 @@ describe('redeem-ops permissions drift guard', () => {
     expect(mirror.REDEEM_OPS_SUB_ROLES).toEqual(backend.REDEEM_OPS_SUB_ROLES);
     expect(mirror.CAPABILITIES).toEqual(backend.CAPABILITIES);
     expect(mirror.ROLE_CAPABILITIES).toEqual(backend.ROLE_CAPABILITIES);
+    expect(mirror.ROW_OVERRIDE_SUB_ROLES).toEqual(backend.ROW_OVERRIDE_SUB_ROLES);
+  });
+
+  it('row-level partner gate agrees, and keeps BDM out of other people’s businesses', () => {
+    const bdm = { id: 'u-bdm', role: 'redeem_ops', redeemOpsRole: 'bdm' };
+    const rows = [
+      [{ role: 'admin', id: 'u-admin' }, { ownerUserId: 'someone-else' }, true],
+      [{ id: 'u-sa', redeemOpsRole: 'super_admin' }, { ownerUserId: 'someone-else' }, true],
+      [{ id: 'u-oa', redeemOpsRole: 'ops_admin' }, { ownerUserId: 'someone-else' }, true],
+      // A BDM manages the board but does not work a colleague's business.
+      [bdm, { ownerUserId: 'someone-else' }, false],
+      [bdm, { ownerUserId: 'u-bdm' }, true],
+      // Unowned is nobody's — it has to be claimed first.
+      [bdm, { ownerUserId: null }, false],
+      [{ id: 'u-oe', redeemOpsRole: 'outreach_exec' }, { ownerUserId: 'u-oe' }, true],
+      [{ id: 'u-oe', redeemOpsRole: 'outreach_exec' }, { ownerUserId: 'other' }, false],
+      [null, { ownerUserId: null }, false],
+    ];
+    for (const [user, partner, expected] of rows) {
+      expect(backend.canActOnPartnerRow(user, partner)).toBe(expected);
+      expect(mirror.canActOnPartnerRow(user, partner)).toBe(expected);
+    }
   });
 
   it('helper semantics agree on representative users', () => {

--- a/src/lib/redeemOpsPermissions.js
+++ b/src/lib/redeemOpsPermissions.js
@@ -161,3 +161,25 @@ export function hasCapability(user, capability) {
 export function isRedeemOpsUser(user) {
   return !!user && (user.role === 'admin' || user.role === 'redeem_ops' || !!user.redeemOpsRole);
 }
+
+/** The tier that may act on a business it doesn't own. BDM is deliberately NOT here. */
+export const ROW_OVERRIDE_SUB_ROLES = ['super_admin', 'ops_admin'];
+
+/**
+ * Row-level gate: may this user write to THIS business? Covers stage moves,
+ * detail edits, contacts, locations and snooze — the actions that belong to
+ * whoever is working the deal.
+ *
+ * A business is worked by exactly one person, so only its owner may act on it;
+ * BDMs get no blanket override over a colleague's row (they keep their
+ * capability-gated powers — reassign, claim, tasks, pools — and may still log
+ * activity on any row via the `partners.reassign` escape hatch in the service).
+ * Admin tier overrides everything. An UNOWNED row is nobody's: it must be
+ * claimed first, which is why a null owner never matches.
+ */
+export function canActOnPartnerRow(user, partner) {
+  if (!user || !partner) return false;
+  if (user.role === 'admin') return true;
+  if (ROW_OVERRIDE_SUB_ROLES.includes(user.redeemOpsRole)) return true;
+  return !!partner.ownerUserId && partner.ownerUserId === user.id;
+}

--- a/src/pages/redeemops/CLAUDE.md
+++ b/src/pages/redeemops/CLAUDE.md
@@ -27,6 +27,7 @@ and Outreach-style cadences. **Not** customer-facing.
 ## Conventions & gotchas
 
 - **UI language = Fresha** (PR #99). Design system "Redeem Ops Design System" on claude.ai/design. DesignSync gotcha: write `_ds_manifest.json` directly — `register_assets` doesn't update it.
+- **Row-level ownership**: capabilities answer "may this sub-role ever?", `canActOnPartnerRow` (in both permissions twins) answers "on THIS business?". Only the owner + admin tier (`admin`, `super_admin`, `ops_admin`) may move a stage, edit details, or touch contacts/locations/snooze — **`bdm` deliberately has NO override** (07-27), and an unowned row must be claimed first. Activity logging stays looser on purpose via the `partners.reassign` escape hatch in `logActivityTx`. TeamPipeline + PartnerDetail both gate on the shared helper; don't reintroduce `isOwner || canReassign` for row writes.
 - **Feature flags** gate most surfaces. `REDEEM_OPS_CADENCES_ENABLED` + `VITE_REDEEM_OPS_CADENCES_ENABLED` (cadences), plus a still-off **entitlements** flag. Discover is flag- + `APIFY_TOKEN`-gated. Check flag state on the live deploy before assuming a feature is on.
 - **ops.redeem.sg** needs Render rewrites; its Cloudflare CNAME must be **DNS-only** (not proxied).
 - **Google login on the ops origin** derives `redirect_uri` from the request origin; the Google OAuth client lives in the GCloud project **"MKTR Platform"** (not "MKTR Leads").

--- a/src/pages/redeemops/PartnerDetail.jsx
+++ b/src/pages/redeemops/PartnerDetail.jsx
@@ -4,7 +4,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { redeemOpsApi } from '@/api/redeemOps';
 import { useAuthStore } from '@/stores/authStore';
-import { hasCapability } from '@/lib/redeemOpsPermissions';
+import { hasCapability, canActOnPartnerRow } from '@/lib/redeemOpsPermissions';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
@@ -521,6 +521,10 @@ export default function PartnerDetail() {
   const isOwner = partner.ownerUserId === user?.id;
   const isUnowned = !partner.ownerUserId;
   const canReassign = hasCapability(user, 'partners.reassign');
+  // Writes that belong to whoever is working the deal — stage, details, contacts,
+  // locations, snooze. Owner or admin tier only; `canReassign` is NOT a way in
+  // (a BDM manages the board, they don't work a colleague's business for them).
+  const canActOnRow = canActOnPartnerRow(user, partner);
   const canOnboard = hasCapability(user, 'onboarding.manage');
   const allowedNext = constants.data?.stageTransitions?.[partner.pipelineStage] || [];
   const activityTypes = constants.data?.activityTypes || [];
@@ -538,7 +542,7 @@ export default function PartnerDetail() {
           <div className="min-w-0">
             <h1 className="ro-title text-[21px] md:text-[26px] inline-flex items-center gap-2 min-w-0">
               <span className="break-words min-w-0">{name}</span>
-              {hasCapability(user, 'partners.edit') && (isOwner || canReassign) && (
+              {hasCapability(user, 'partners.edit') && canActOnRow && (
                 <button
                   type="button"
                   className="ro-icon-circle shrink-0"
@@ -589,7 +593,7 @@ export default function PartnerDetail() {
           {hasCapability(user, 'tasks.manage') && (
             <Button variant="outline" className="flex-1 h-[42px]" onClick={() => setTaskOpen(true)}>Add task</Button>
           )}
-          {(isOwner || canReassign) && (
+          {(canActOnRow || canReassign) && (
             <DropdownMenu>
               <DropdownMenuTrigger
                 className="w-[42px] h-[42px] shrink-0 rounded-full border grid place-items-center outline-none"
@@ -602,10 +606,10 @@ export default function PartnerDetail() {
                 {canReassign && (
                   <DropdownMenuItem onClick={() => setAssignOpen(true)}>Assign to…</DropdownMenuItem>
                 )}
-                {allowedNext.length > 0 && (
+                {canActOnRow && allowedNext.length > 0 && (
                   <DropdownMenuItem onClick={() => setMoveOpen(true)}>Move stage…</DropdownMenuItem>
                 )}
-                {!['PARTNERED', 'LOST'].includes(partner.pipelineStage) && (
+                {canActOnRow && !['PARTNERED', 'LOST'].includes(partner.pipelineStage) && (
                   partner.availability === 'follow_up_later' ? (
                     <DropdownMenuItem onClick={() => unsnoozeMutation.mutate()}>Wake up</DropdownMenuItem>
                   ) : (
@@ -631,7 +635,7 @@ export default function PartnerDetail() {
               </SelectContent>
             </Select>
           )}
-          {(isOwner || canReassign) && allowedNext.length > 0 && (
+          {canActOnRow && allowedNext.length > 0 && (
             <Select
               value=""
               onValueChange={(toStage) => {
@@ -647,7 +651,7 @@ export default function PartnerDetail() {
               </SelectContent>
             </Select>
           )}
-          {(isOwner || canReassign) && !['PARTNERED', 'LOST'].includes(partner.pipelineStage) && (
+          {canActOnRow && !['PARTNERED', 'LOST'].includes(partner.pipelineStage) && (
             partner.availability === 'follow_up_later' ? (
               <Button variant="outline" onClick={() => unsnoozeMutation.mutate()}>Wake up</Button>
             ) : (
@@ -660,6 +664,9 @@ export default function PartnerDetail() {
           {hasCapability(user, 'tasks.manage') && (
             <Button variant="outline" onClick={() => setTaskOpen(true)}>Add task</Button>
           )}
+          {/* Deliberately looser than canActOnRow: logging a touch on a colleague's
+              business keeps team visibility, and the service allows it via the same
+              `partners.reassign` escape hatch. */}
           {(isOwner || canReassign) && (
             <Button variant="outline" onClick={() => setActivityOpen(true)}>Log activity</Button>
           )}
@@ -722,7 +729,7 @@ export default function PartnerDetail() {
                       {[c.roleTitle, c.mobile, c.email].filter(Boolean).join(' · ') || '—'}
                     </p>
                   </div>
-                  {(isOwner || canReassign) && (
+                  {canActOnRow && (
                     <span className="flex gap-1 shrink-0">
                       <Button
                         size="sm" variant="ghost" aria-label={`Edit ${c.name}`}
@@ -747,7 +754,7 @@ export default function PartnerDetail() {
                   )}
                 </div>
               ))}
-              {(isOwner || canReassign) && (
+              {canActOnRow && (
                 <div className="grid grid-cols-2 gap-2 pt-1">
                   <Input placeholder="Name *" value={contactForm.name} onChange={(e) => setContactForm((f) => ({ ...f, name: e.target.value }))} />
                   <Input placeholder="Role (e.g. Owner)" value={contactForm.roleTitle} onChange={(e) => setContactForm((f) => ({ ...f, roleTitle: e.target.value }))} />
@@ -781,7 +788,7 @@ export default function PartnerDetail() {
                   </div>
                 </div>
               ))}
-              {(isOwner || canReassign) && (
+              {canActOnRow && (
                 <div className="grid grid-cols-2 gap-2 pt-1">
                   <Input placeholder="Outlet name" value={locationForm.name} onChange={(e) => setLocationForm((f) => ({ ...f, name: e.target.value }))} />
                   <Input placeholder="Postal code" value={locationForm.postalCode} onChange={(e) => setLocationForm((f) => ({ ...f, postalCode: e.target.value }))} />

--- a/src/pages/redeemops/TeamPipeline.jsx
+++ b/src/pages/redeemops/TeamPipeline.jsx
@@ -15,6 +15,7 @@ import { Button } from '@/components/ui/button';
 import AlertTriangle from 'lucide-react/icons/alert-triangle';
 import Moon from 'lucide-react/icons/moon';
 import { RoAvatar, prettyEnum } from '@/components/redeemops/ui';
+import { canActOnPartnerRow, ROW_OVERRIDE_SUB_ROLES } from '@/lib/redeemOpsPermissions';
 
 const PIPELINE_KEY = ['redeem-ops', 'team-pipeline'];
 
@@ -50,14 +51,6 @@ function timeInStage(p) {
   if (hours < 1) return 'now';
   if (hours < 24) return `${hours}h`;
   return `${Math.floor(hours / 24)}d`;
-}
-
-/** Mirrors partnerService.canActOnRow — managers move any card, execs their own. */
-function canDragCard(user, p) {
-  if (!user) return false;
-  if (user.role === 'admin') return true;
-  if (['super_admin', 'ops_admin', 'bdm'].includes(user.redeemOpsRole)) return true;
-  return p.ownerUserId === user.id;
 }
 
 function CardInner({ p, dragging }) {
@@ -245,6 +238,10 @@ export default function TeamPipeline() {
     return map;
   }, [partners]);
 
+  // Admin tier drags anyone's card; everyone else only their own, so they get
+  // an extra line of explanation for the cards that won't lift.
+  const movesAnyCard = user?.role === 'admin' || ROW_OVERRIDE_SUB_ROLES.includes(user?.redeemOpsRole);
+
   const lostItems = byStage.LOST || [];
   const legalTargets = activeCard ? (transitions[activeCard.pipelineStage] || []) : [];
   // Earlier columns than the dragged card's stage: droppable behind a
@@ -303,6 +300,7 @@ export default function TeamPipeline() {
           <h1 className="ro-title">Team pipeline</h1>
           <p className="ro-sub">
           Drag a business forward — or onto the red bar to mark it Lost. Dragging back to an earlier column asks you to confirm.
+          {!movesAnyCard && ' You can move the businesses you own; claim an unowned one to work it.'}
           <span className="md:hidden"> Press and hold a card to drag; tap to open.</span>
           <span className="hidden md:inline"> Click to open.</span>
         </p>
@@ -334,7 +332,7 @@ export default function TeamPipeline() {
                   <BoardCard
                     key={p.id}
                     p={p}
-                    draggable={canDragCard(user, p)}
+                    draggable={canActOnPartnerRow(user, p)}
                     onOpen={(pid) => navigate(`/redeem-ops/partners/${pid}`)}
                   />
                 ))}
@@ -357,7 +355,7 @@ export default function TeamPipeline() {
                 <BoardCard
                   key={p.id}
                   p={p}
-                  draggable={canDragCard(user, p)}
+                  draggable={canActOnPartnerRow(user, p)}
                   onOpen={(pid) => navigate(`/redeem-ops/partners/${pid}`)}
                 />
               ))}

--- a/src/pages/redeemops/__tests__/PartnerDetail.ownership.test.jsx
+++ b/src/pages/redeemops/__tests__/PartnerDetail.ownership.test.jsx
@@ -1,0 +1,167 @@
+/**
+ * PartnerDetail row-level gating: a business is worked by whoever owns it.
+ * A BDM manages the board (assign, tasks, visibility) but does NOT get to move,
+ * rename or restructure a colleague's business — the UI must not offer what
+ * partnerService.canActOnRow would refuse with a 403.
+ * redeemOpsApi is fully mocked — no network.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+const api = vi.hoisted(() => ({
+  getPartner: vi.fn(),
+  getTimeline: vi.fn(),
+  getConstants: vi.fn(),
+  getTeam: vi.fn(),
+  listPartners: vi.fn(),
+  getPartnerCadence: vi.fn(),
+  listTasks: vi.fn(),
+  listCadences: vi.fn(),
+  getOnboarding: vi.fn(),
+}));
+vi.mock('@/api/redeemOps', () => ({ redeemOpsApi: api }));
+
+const toastMock = vi.hoisted(() => {
+  const t = vi.fn();
+  t.success = vi.fn();
+  t.error = vi.fn();
+  return t;
+});
+vi.mock('sonner', () => ({ toast: toastMock }));
+
+const authState = vi.hoisted(() => ({ user: null }));
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: (sel) => sel(authState),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useParams: () => ({ id: 'p-1' }) };
+});
+
+import PartnerDetail from '../PartnerDetail';
+
+const OWNER_ID = 'u-tyler';
+
+const basePartner = {
+  id: 'p-1',
+  tradingName: 'Secret Garden Nail Boutique',
+  pipelineStage: 'CONTACTED',
+  availability: 'owned',
+  ownerUserId: OWNER_ID,
+  owner: { id: OWNER_ID, fullName: 'Tyler Lim' },
+  contacts: [{ id: 'c-1', name: 'Shop Owner', mobile: '+6591230000' }],
+  locations: [],
+};
+
+function renderDetail(user, partner = basePartner) {
+  authState.user = user;
+  api.getPartner.mockResolvedValue(partner);
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter><PartnerDetail /></MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.getTimeline.mockResolvedValue([]);
+  api.getConstants.mockResolvedValue({
+    stageTransitions: { CONTACTED: ['MEETING', 'LOST'] },
+    lostReasons: ['not_interested'],
+    activityTypes: ['call_attempt'],
+  });
+  api.getTeam.mockResolvedValue([]);
+  api.listPartners.mockResolvedValue({ partners: [] });
+  api.getPartnerCadence.mockResolvedValue(null);
+  api.listTasks.mockResolvedValue([]);
+  api.listCadences.mockResolvedValue([]);
+  api.getOnboarding.mockResolvedValue([]);
+});
+
+/** Contacts/locations forms live in tabs that only mount when selected. */
+async function openTab(label) {
+  await userEvent.click(screen.getByRole('tab', { name: new RegExp(label, 'i') }));
+  return waitFor(() => expect(screen.getByRole('tabpanel')).toBeTruthy());
+}
+
+describe('PartnerDetail — only the owner works the business', () => {
+  it('hides move/edit/snooze from a non-owner BDM', async () => {
+    renderDetail({ id: 'u-jeremy', role: 'redeem_ops', redeemOpsRole: 'bdm' });
+    await screen.findByText('Secret Garden Nail Boutique');
+
+    expect(screen.queryByText('Move stage…')).toBeNull();
+    expect(screen.queryByRole('button', { name: /edit business details/i })).toBeNull();
+    expect(screen.queryByText('Snooze')).toBeNull();
+  });
+
+  it('hides contact + location editing from a non-owner BDM', async () => {
+    renderDetail({ id: 'u-jeremy', role: 'redeem_ops', redeemOpsRole: 'bdm' });
+    await screen.findByText('Secret Garden Nail Boutique');
+
+    await openTab('contacts');
+    // The contact is visible — it's editing it that's off limits.
+    expect(screen.getByText('Shop Owner')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /edit shop owner/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /remove shop owner/i })).toBeNull();
+    expect(screen.queryByPlaceholderText('Name *')).toBeNull();
+
+    await openTab('locations');
+    expect(screen.queryByPlaceholderText('Outlet name')).toBeNull();
+  });
+
+  it('gives the owner contact + location editing', async () => {
+    renderDetail({ id: OWNER_ID, role: 'redeem_ops', redeemOpsRole: 'bdm' });
+    await screen.findByText('Secret Garden Nail Boutique');
+
+    await openTab('contacts');
+    expect(screen.getByRole('button', { name: /edit shop owner/i })).toBeTruthy();
+    expect(screen.getByPlaceholderText('Name *')).toBeTruthy();
+
+    await openTab('locations');
+    expect(screen.getByPlaceholderText('Outlet name')).toBeTruthy();
+  });
+
+  it('still lets that BDM log activity — restricting writes is not hiding the deal', async () => {
+    renderDetail({ id: 'u-jeremy', role: 'redeem_ops', redeemOpsRole: 'bdm' });
+    await screen.findByText('Secret Garden Nail Boutique');
+
+    expect(screen.getAllByText('Log activity').length).toBeGreaterThan(0);
+  });
+
+  it('gives the owner the full set', async () => {
+    renderDetail({ id: OWNER_ID, role: 'redeem_ops', redeemOpsRole: 'bdm' });
+    await screen.findByText('Secret Garden Nail Boutique');
+
+    await waitFor(() => expect(screen.getAllByText('Move stage…').length).toBeGreaterThan(0));
+    expect(screen.getByRole('button', { name: /edit business details/i })).toBeTruthy();
+    expect(screen.getAllByText('Snooze').length).toBeGreaterThan(0);
+  });
+
+  it('gives an admin the full set on someone else’s business', async () => {
+    renderDetail({ id: 'u-shawn', role: 'admin' });
+    await screen.findByText('Secret Garden Nail Boutique');
+
+    await waitFor(() => expect(screen.getAllByText('Move stage…').length).toBeGreaterThan(0));
+    expect(screen.getByRole('button', { name: /edit business details/i })).toBeTruthy();
+  });
+
+  it('an unowned business offers Claim, not the working controls', async () => {
+    renderDetail(
+      { id: 'u-jeremy', role: 'redeem_ops', redeemOpsRole: 'bdm' },
+      { ...basePartner, ownerUserId: null, owner: null }
+    );
+    await screen.findByText('Secret Garden Nail Boutique');
+
+    expect(screen.getAllByText('Claim business').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Move stage…')).toBeNull();
+
+    await openTab('contacts');
+    expect(screen.queryByPlaceholderText('Name *')).toBeNull();
+  });
+});


### PR DESCRIPTION
## The bug

Every ops user in prod carries the `bdm` sub-role — Tyler, Jeremy, Emily, David, Lionel. Only `shawnleeapps` is `admin`.

`bdm` sat on the manager override inside `partnerService.canActOnRow`, so **in practice any ops user could drag any colleague's card across the pipeline**, rename their business, and rewrite its contacts and locations. The team board was a free-for-all wearing an ownership model.

## The change

Drop `bdm` from that override. Owner or admin tier (`admin`, `super_admin`, `ops_admin`) only, for the writes that belong to whoever is working the deal:

| Action on someone else's business | Before | After |
|---|---|---|
| Move stage (board drag + detail) | ✅ any BDM | ❌ owner/admin |
| Undo a stage move | ✅ any BDM | ❌ owner/admin |
| Rename / edit details | ✅ any BDM | ❌ owner/admin |
| Add/edit/remove contacts | ✅ any BDM | ❌ owner/admin |
| Add/edit locations | ✅ any BDM | ❌ owner/admin |
| Snooze / wake | ✅ any BDM | ❌ owner/admin |
| **Log a call or note** | ✅ | ✅ **unchanged** |
| Reassign / claim / tasks / pools | ✅ | ✅ **unchanged** (capability-gated) |

Activity logging stays deliberately looser via the existing `partners.reassign` escape hatch in `logActivityTx` — restricting writes shouldn't cost the team visibility into a colleague's deal.

**Unowned rows must be claimed first.** A null owner never matches, and the 403 now says `Claim this business first, then you can move it` instead of the unhelpful "you can only move businesses you own".

## Why the frontend had to move too

`PartnerDetail` gated its Move stage / Snooze / contacts / locations controls on `isOwner || canReassign` — and `partners.reassign` is a capability BDMs hold. Without this the UI would have kept offering exactly what the API had started refusing. The rule now lives once in the permissions twins (covered by the existing drift test) instead of being copy-pasted into the board.

Non-admins also get a line of explanation on the board: *"You can move the businesses you own; claim an unowned one to work it."*

## Verification

- Backend `test/redeemOps*`: **25 suites / 353 tests pass**, including 2 new ones — a BDM refused on move/edit/contacts/locations/snooze but allowed to log activity, and unowned-must-be-claimed.
- Frontend: **154 files / 1959 tests pass**, including 7 new `PartnerDetail.ownership` tests.
- Teeth check: temporarily restoring `bdm` to the override turns 3 of the new tests red, so the negative assertions aren't vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtL6Jqv4T8GwXVU6jiyTfw