### PR TITLE
feat(redeem-ops): Discover shows its filters, and names/handles link out

### DIFF
--- a/src/components/redeemops/__tests__/cadence.test.jsx
+++ b/src/components/redeemops/__tests__/cadence.test.jsx
@@ -314,6 +314,41 @@ describe('CadencePanel', () => {
     expect(screen.getByRole('button', { name: /stop/i })).toBeInTheDocument();
   });
 
+  it('links the cadence name through to its definition for anyone who can open the editor', async () => {
+    api.getPartnerCadence.mockResolvedValue({
+      enrollment: {
+        id: 'e-1', state: 'active',
+        cadence: { id: 'c-77', name: 'Pet Grooming IG-DM', version: 2, steps: [{ id: 's-1', stepOrder: 1 }] },
+        currentStep: { id: 's-1', stepOrder: 1 },
+      },
+      openTask: null,
+    });
+    useAuthStore.setState({ user: { id: 'u-1', role: 'user', redeemOpsRole: 'bdm' } });
+    wrap(<CadencePanel partner={{ id: 'p-1', ownerUserId: 'u-1', pipelineStage: 'NEW' }} />);
+
+    // Version-pinned: the link points at the exact version being run, not the
+    // cadence's latest — the editor loads with all=true so retired ones resolve.
+    expect(await screen.findByRole('link', { name: 'Pet Grooming IG-DM' }))
+      .toHaveAttribute('href', '/redeem-ops/cadences/c-77/edit');
+  });
+
+  it('leaves the cadence name as plain text for a viewer who cannot open the editor', async () => {
+    api.getPartnerCadence.mockResolvedValue({
+      enrollment: {
+        id: 'e-1', state: 'active',
+        cadence: { id: 'c-77', name: 'Pet Grooming IG-DM', version: 2, steps: [{ id: 's-1', stepOrder: 1 }] },
+        currentStep: { id: 's-1', stepOrder: 1 },
+      },
+      openTask: null,
+    });
+    // analyst has no tasks.manage — a link would only lead to a bounce.
+    useAuthStore.setState({ user: { id: 'u-2', role: 'user', redeemOpsRole: 'analyst' } });
+    wrap(<CadencePanel partner={{ id: 'p-1', ownerUserId: 'u-1', pipelineStage: 'NEW' }} />);
+
+    expect(await screen.findByText('Pet Grooming IG-DM')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Pet Grooming IG-DM' })).not.toBeInTheDocument();
+  });
+
   it('offers enrollment when there is no live cadence', async () => {
     api.getPartnerCadence.mockResolvedValue({ enrollment: null, openTask: null });
     wrap(<CadencePanel partner={{ id: 'p-1', ownerUserId: 'u-1', pipelineStage: 'NEW' }} />);

--- a/src/components/redeemops/cadence.jsx
+++ b/src/components/redeemops/cadence.jsx
@@ -90,6 +90,33 @@ async function copyTaskMessage(text) {
   }
 }
 
+/**
+ * A cadence's name, linking through to its definition for anyone who can open
+ * the editor (`tasks.manage` — non-authors land on its read-only view, so this
+ * is a "see the script" affordance, not an edit one).
+ *
+ * Enrollments are version-pinned, so this points at the EXACT version being
+ * run. That version may since have been retired by an edit; the editor loads
+ * its list with all=true, so a retired version still resolves.
+ */
+export function CadenceName({ cadence, className = '', style }) {
+  const authUser = useAuthStore((s) => s.user);
+  const label = cadence?.name || 'Cadence';
+  if (!CADENCES_ENABLED || !cadence?.id || !hasCapability(authUser, 'tasks.manage')) {
+    return <span className={className} style={style}>{label}</span>;
+  }
+  return (
+    <Link
+      to={`/redeem-ops/cadences/${cadence.id}/edit`}
+      title={`Open “${label}”`}
+      className={`hover:underline ${className}`}
+      style={{ color: 'inherit', ...style }}
+    >
+      {label}
+    </Link>
+  );
+}
+
 /** Small pill marking a task as cadence-driven: "⚡ F&B call-first · 3". */
 export function CadenceChip({ task }) {
   const step = task?.cadenceStep;
@@ -511,7 +538,7 @@ export function CadencePanel({ partner, canManage = true, variant = 'card', onAd
         <>
           <div className="flex items-baseline justify-between gap-2">
             <p className="text-[13.5px] font-semibold m-0 truncate">
-              {enrollment.cadence?.name}
+              <CadenceName cadence={enrollment.cadence} />
               <span className="font-normal" style={{ color: 'var(--ro-text-3)' }}> · v{enrollment.cadence?.version}</span>
             </p>
             {steps.length > 0 && (
@@ -677,7 +704,7 @@ export function CadencePanel({ partner, canManage = true, variant = 'card', onAd
     <p className="text-[13px] m-0" style={{ color: 'var(--ro-text-2)' }}>
       <Zap className="w-3.5 h-3.5 inline mr-1 -mt-0.5" aria-hidden="true" />
       <span className="font-semibold" style={{ color: 'var(--ro-bunker)' }}>
-        {enrollment.cadence?.name} · step {currentOrder}/{steps.length}
+        <CadenceName cadence={enrollment.cadence} /> · step {currentOrder}/{steps.length}
       </span>
       {paused ? ' · paused' : ' · scheduling next step…'}
     </p>

--- a/src/pages/redeemops/DiscoverPage.jsx
+++ b/src/pages/redeemops/DiscoverPage.jsx
@@ -14,7 +14,6 @@ import Sparkles from 'lucide-react/icons/sparkles';
 import Plus from 'lucide-react/icons/plus';
 import X from 'lucide-react/icons/x';
 import Check from 'lucide-react/icons/check';
-import ChevronRight from 'lucide-react/icons/chevron-right';
 import Instagram from 'lucide-react/icons/instagram';
 import Star from 'lucide-react/icons/star';
 import MapPin from 'lucide-react/icons/map-pin';
@@ -43,21 +42,6 @@ const SORTS = [
   { v: 'name', label: 'Name' },
 ];
 const POPULAR_AREAS = ['Tampines', 'Orchard', 'Jurong East', 'Katong', 'Bedok', 'Serangoon'];
-const MINSTAR_LABEL = { three: '3.0★+', threeAndHalf: '3.5★+', four: '4.0★+' };
-// Curated flavour for the common verticals; anything else falls back gracefully.
-const CURATED = {
-  'nail salon': { emoji: '💅', note: 'High density, strong IG reach' },
-  'facial & beauty': { emoji: '✨', note: 'Premium, high repeat value' },
-  'hair salon': { emoji: '💇', note: 'Owner-run, fast to reach' },
-  'lashes & brows': { emoji: '👁️', note: 'IG-native, easy yes' },
-  'massage & spa': { emoji: '🧖', note: 'Free-trial friendly' },
-  barbershop: { emoji: '💈', note: 'Owner-operated, quick yes' },
-  café: { emoji: '☕', note: 'High foot traffic' },
-  cafe: { emoji: '☕', note: 'High foot traffic' },
-  'dessert & bakery': { emoji: '🧁', note: 'Great consumer appeal' },
-  'gym & fitness': { emoji: '🏋️', note: 'Trial-offer playbook' },
-  'pet grooming': { emoji: '🐾', note: 'Loyal repeat customers' },
-};
 const num = (v) => (v == null ? -1 : v);
 const fmtFollowers = (n) => (n == null ? null : n >= 1000 ? `${(n / 1000).toFixed(1)}k` : `${n}`);
 // The exact query a run fired: #hashtags (IG) or comma-joined terms (Maps).
@@ -89,7 +73,6 @@ export default function DiscoverPage() {
   const [filter, setFilter] = useState('all');
   const [sort, setSort] = useState('followers');
   const [aiDesc, setAiDesc] = useState('');
-  const [showFilters, setShowFilters] = useState(false);
   const [showAi, setShowAi] = useState(false);
   // AI-suggested Google categories (Maps) — fill the pre-search filter AND arm a
   // one-time post-results facet cleanup for the run they were searched into.
@@ -113,11 +96,6 @@ export default function DiscoverPage() {
   const igEnabled = listQuery.data?.igEnabled === true;
   const aiEnabled = listQuery.data?.aiEnabled === true;
   const isIg = form.provider === IG_PROVIDER;
-  const categoriesQuery = useQuery({
-    queryKey: ['redeem-ops', 'categories'],
-    queryFn: () => redeemOpsApi.listCategories(),
-    staleTime: 60_000,
-  });
   const territoriesQuery = useQuery({
     queryKey: ['redeem-ops', 'territories'],
     queryFn: () => redeemOpsApi.listTerritories(),
@@ -244,14 +222,6 @@ export default function DiscoverPage() {
 
   const allSelected = selectableIds.length > 0 && selectableIds.every((id) => selected.has(id));
 
-  const suggestions = useMemo(() => {
-    const cats = (categoriesQuery.data || []).map((c) => c.name);
-    return cats.slice(0, 6).map((cat, i) => {
-      const meta = CURATED[cat.toLowerCase()] || { emoji: '📍', note: 'Prospect this vertical' };
-      return { category: cat, area: POPULAR_AREAS[i % POPULAR_AREAS.length], ...meta };
-    });
-  }, [categoriesQuery.data]);
-
   // ── Mutations ──────────────────────────────────────────────────────────
   const startMutation = useMutation({
     mutationFn: (body) => redeemOpsApi.startDiscovery(body),
@@ -304,7 +274,6 @@ export default function DiscoverPage() {
         ...(cats.length ? { filterWords: cats.join(', ') } : {}),
       }));
       setAiCats(cats);
-      if (cats.length) setShowFilters(true); // reveal the pre-filled category filter
       toast.success(
         `${terms.length} ${isIg ? 'hashtags' : 'phrases'}${cats.length ? ` + ${cats.length} categories` : ''} suggested`,
         { description: 'Review before searching — clear the categories to keep everything.' },
@@ -364,12 +333,6 @@ export default function DiscoverPage() {
   };
   const canSearch = form.area.trim() && parseCsv(form.adhoc).length > 0 && !startMutation.isPending;
   const canSuggest = aiDesc.trim().length >= 3 && !suggestMutation.isPending;
-  const filterWordCount = parseCsv(form.filterWords).length;
-  const activeFilterSummary = [
-    form.minStars !== 'any' && MINSTAR_LABEL[form.minStars],
-    form.skipClosed && 'closed excluded',
-    filterWordCount && `${filterWordCount} categor${filterWordCount === 1 ? 'y' : 'ies'}`,
-  ].filter(Boolean).join(' · ') || 'rating · closed · categories';
 
   return (
     <div className="p-4 md:p-8 max-w-5xl mx-auto space-y-6 pb-24">
@@ -481,47 +444,40 @@ export default function DiscoverPage() {
             </div>
             {!isIg && (
               <div className="mt-4 pt-4" style={{ borderTop: '1px solid var(--ro-border)' }}>
-                <button type="button" onClick={() => setShowFilters((v) => !v)} aria-expanded={showFilters}
-                  className="flex items-center gap-2 w-full text-left">
-                  <span className="text-[13px] font-bold">More filters</span>
-                  <ChevronRight className={`w-3.5 h-3.5 transition-transform ${showFilters ? 'rotate-90' : ''}`} style={{ color: 'var(--ro-text-3)' }} aria-hidden="true" />
-                  {!showFilters && <span className="ml-auto text-[12px]" style={{ color: 'var(--ro-text-3)' }}>{activeFilterSummary}</span>}
-                </button>
-                {showFilters && (
-                  <div className="mt-3 space-y-3">
-                    <div className="flex items-end gap-3">
-                      <div className="space-y-1">
-                        <Label>Min rating</Label>
-                        <Select value={form.minStars} onValueChange={(v) => setForm((f) => ({ ...f, minStars: v }))}>
-                          <SelectTrigger className="w-full min-w-[104px]"><SelectValue /></SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="any">Any</SelectItem>
-                            <SelectItem value="three">3.0★+</SelectItem>
-                            <SelectItem value="threeAndHalf">3.5★+</SelectItem>
-                            <SelectItem value="four">4.0★+</SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </div>
-                      <label className="flex items-center gap-2 h-9 px-1 text-[13px] font-semibold cursor-pointer whitespace-nowrap" style={{ color: 'var(--ro-text-2)' }}>
-                        <input type="checkbox" className="w-4 h-4 accent-[var(--ro-bunker)]"
-                          checked={form.skipClosed} onChange={(e) => setForm((f) => ({ ...f, skipClosed: e.target.checked }))} />
-                        Exclude closed businesses
-                      </label>
+                <span className="text-[13px] font-bold">Filters</span>
+                <div className="mt-3 space-y-3">
+                  <div className="flex items-end gap-3">
+                    <div className="space-y-1">
+                      <Label>Min rating</Label>
+                      <Select value={form.minStars} onValueChange={(v) => setForm((f) => ({ ...f, minStars: v }))}>
+                        <SelectTrigger className="w-full min-w-[104px]"><SelectValue /></SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="any">Any</SelectItem>
+                          <SelectItem value="three">3.0★+</SelectItem>
+                          <SelectItem value="threeAndHalf">3.5★+</SelectItem>
+                          <SelectItem value="four">4.0★+</SelectItem>
+                        </SelectContent>
+                      </Select>
                     </div>
-                    <div className="rounded-xl p-3" style={{ background: 'var(--ro-subtle)', border: '1px dashed var(--ro-border)' }}>
-                      <Label htmlFor="disc-filter-words" className="flex items-center gap-2 flex-wrap">
-                        <span className="text-[10.5px] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded" style={{ color: 'var(--ro-azure-dark)', background: 'var(--ro-azure-tint)' }}>Advanced</span>
-                        Restrict Google categories <span style={{ color: 'var(--ro-text-3)', fontWeight: 400 }}>before fetching · optional</span>
-                      </Label>
-                      <Input id="disc-filter-words" className="mt-2" value={form.filterWords}
-                        placeholder="learning center, education center"
-                        onChange={(e) => setForm((f) => ({ ...f, filterWords: e.target.value }))} />
-                      <p className="text-[11.5px] mt-1.5 mb-0" style={{ color: 'var(--ro-text-3)' }}>
-                        Cost control for big sweeps. Matches the Google <b>category</b>, not the name — may miss valid targets. Usually better to filter <b>after</b> the search, below.
-                      </p>
-                    </div>
+                    <label className="flex items-center gap-2 h-9 px-1 text-[13px] font-semibold cursor-pointer whitespace-nowrap" style={{ color: 'var(--ro-text-2)' }}>
+                      <input type="checkbox" className="w-4 h-4 accent-[var(--ro-bunker)]"
+                        checked={form.skipClosed} onChange={(e) => setForm((f) => ({ ...f, skipClosed: e.target.checked }))} />
+                      Exclude closed businesses
+                    </label>
                   </div>
-                )}
+                  <div className="rounded-xl p-3" style={{ background: 'var(--ro-subtle)', border: '1px dashed var(--ro-border)' }}>
+                    <Label htmlFor="disc-filter-words" className="flex items-center gap-2 flex-wrap">
+                      <span className="text-[10.5px] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded" style={{ color: 'var(--ro-azure-dark)', background: 'var(--ro-azure-tint)' }}>Advanced</span>
+                      Restrict Google categories <span style={{ color: 'var(--ro-text-3)', fontWeight: 400 }}>before fetching · optional</span>
+                    </Label>
+                    <Input id="disc-filter-words" className="mt-2" value={form.filterWords}
+                      placeholder="learning center, education center"
+                      onChange={(e) => setForm((f) => ({ ...f, filterWords: e.target.value }))} />
+                    <p className="text-[11.5px] mt-1.5 mb-0" style={{ color: 'var(--ro-text-3)' }}>
+                      Cost control for big sweeps. Matches the Google <b>category</b>, not the name — may miss valid targets. Usually better to filter <b>after</b> the search, below.
+                    </p>
+                  </div>
+                </div>
               </div>
             )}
             <div className="flex flex-wrap items-center gap-2 mt-3">
@@ -551,28 +507,6 @@ export default function DiscoverPage() {
               )}
             </div>
           </div>
-
-          {suggestions.length > 0 && (
-            <div>
-              <h2 className="text-[13px] font-bold mb-3" style={{ color: 'var(--ro-text-2)' }}>Suggested searches</h2>
-              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-                {suggestions.map((s) => (
-                  // Prefill only — Search (with its cost hint) is the single spend
-                  // affordance; a one-tap card must never fire a paid run.
-                  <button key={`${s.category}-${s.area}`} type="button"
-                    onClick={() => { setForm((f) => ({ ...f, adhoc: s.category, area: s.area, limit: '60' })); setAiCats([]); }}
-                    className="flex items-center gap-3 rounded-2xl border border-border bg-white p-4 text-left hover:bg-[var(--ro-subtle)]">
-                    <span className="w-10 h-10 rounded-xl grid place-items-center text-lg shrink-0" style={{ background: 'var(--ro-subtle)' }}>{s.emoji}</span>
-                    <span className="min-w-0">
-                      <b className="text-[14px] block truncate">{s.category} · {s.area}</b>
-                      <span className="text-[12.5px]" style={{ color: 'var(--ro-text-3)' }}>{s.note}</span>
-                    </span>
-                    <ChevronRight className="w-4 h-4 ml-auto shrink-0" style={{ color: 'var(--ro-text-3)' }} aria-hidden="true" />
-                  </button>
-                ))}
-              </div>
-            </div>
-          )}
 
           {recentRuns.length > 0 && (
             <div>

--- a/src/pages/redeemops/PartnerDetail.jsx
+++ b/src/pages/redeemops/PartnerDetail.jsx
@@ -47,6 +47,22 @@ function useDebounced(value, ms = 300) {
   return debounced;
 }
 
+/**
+ * Where the website chip points. Prefers the URL the rep actually typed (it may
+ * carry a path), but only ever emits http(s) — stored free text must never
+ * become a `javascript:` link — and falls back to the normalized domain.
+ */
+function websiteHref(partner) {
+  const raw = (partner.website || '').trim();
+  if (raw) {
+    try {
+      const url = new URL(/^https?:\/\//i.test(raw) ? raw : `https://${raw}`);
+      if (url.protocol === 'http:' || url.protocol === 'https:') return url.href;
+    } catch { /* unparseable — fall through to the derived domain */ }
+  }
+  return `https://${partner.websiteDomain}`;
+}
+
 /* Activity type → pastel icon circle (timeline card in the design system). */
 function timelineIcon(entry) {
   if (entry.kind === 'stage') {
@@ -562,10 +578,17 @@ export default function PartnerDetail() {
                 <span className="inline-flex items-center gap-1"><Phone className="w-3.5 h-3.5" aria-hidden="true" />{partner.primaryPhone}</span>
               )}
               {partner.websiteDomain && (
-                <span className="inline-flex items-center gap-1"><Globe className="w-3.5 h-3.5" aria-hidden="true" />{partner.websiteDomain}</span>
+                <a href={websiteHref(partner)} target="_blank" rel="noreferrer" title="Open website"
+                  className="inline-flex items-center gap-1 hover:underline" style={{ color: 'inherit' }}>
+                  <Globe className="w-3.5 h-3.5" aria-hidden="true" />{partner.websiteDomain}
+                </a>
               )}
               {partner.instagramHandle && (
-                <span className="inline-flex items-center gap-1"><Instagram className="w-3.5 h-3.5" aria-hidden="true" />@{partner.instagramHandle}</span>
+                <a href={`https://instagram.com/${partner.instagramHandle}`} target="_blank" rel="noreferrer"
+                  title="Open Instagram profile"
+                  className="inline-flex items-center gap-1 hover:underline" style={{ color: 'inherit' }}>
+                  <Instagram className="w-3.5 h-3.5" aria-hidden="true" />@{partner.instagramHandle}
+                </a>
               )}
               <RoStageTag stage={partner.pipelineStage} />
               {partner.pipelineStage === 'LOST' && partner.lostReason && (

--- a/src/pages/redeemops/__tests__/DiscoverPage.test.jsx
+++ b/src/pages/redeemops/__tests__/DiscoverPage.test.jsx
@@ -1,6 +1,6 @@
 /**
  * DiscoverPage — the three behaviors that guard real money / real data:
- * 1. suggestion cards PREFILL the form and never fire a paid search;
+ * 1. AI suggestions PREFILL the form and never fire a paid search;
  * 2. a candidate mid-enrichment shows "Enriching…" (not another paid action);
  * 3. dismiss hits the API and the undo toast's action restores.
  * redeemOpsApi is fully mocked — no network, no backend.
@@ -13,7 +13,6 @@ import { MemoryRouter } from 'react-router-dom';
 
 const api = vi.hoisted(() => ({
   listDiscoveryRuns: vi.fn(),
-  listCategories: vi.fn(),
   listTerritories: vi.fn(),
   getDiscoveryRun: vi.fn(),
   startDiscovery: vi.fn(),
@@ -71,18 +70,20 @@ async function openResults() {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  api.listCategories.mockResolvedValue([{ name: 'Nail Salon' }]);
   api.listTerritories.mockResolvedValue({ enabled: false, territories: [] });
   api.listDiscoveryRuns.mockResolvedValue({ runs: [], quota });
 });
 
 describe('DiscoverPage', () => {
-  it('suggestion cards prefill the form and never start a paid search', async () => {
+  it('shows every filter up front — nothing hidden behind an expander', async () => {
     renderPage();
-    const card = await screen.findByRole('button', { name: /Nail Salon · Tampines/i });
-    await userEvent.click(card);
-    expect(api.startDiscovery).not.toHaveBeenCalled();
-    expect(screen.getByPlaceholderText('Neighbourhood or district…')).toHaveValue('Tampines');
+    // No click: rating, closed-businesses and the category restriction are all
+    // on screen as soon as the form is.
+    expect(await screen.findByText('Filters')).toBeInTheDocument();
+    expect(screen.getByText('Min rating')).toBeInTheDocument();
+    expect(screen.getByText('Exclude closed businesses')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('learning center, education center')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /More filters/i })).not.toBeInTheDocument();
   });
 
   it('uses the territory picker with All Singapore only when the runtime flag is enabled', async () => {
@@ -111,7 +112,7 @@ describe('DiscoverPage', () => {
 
   it('hides the AI-assist row unless the backend reports aiEnabled', async () => {
     renderPage(); // beforeEach response has no aiEnabled
-    await screen.findByRole('button', { name: /Nail Salon · Tampines/i }); // page settled
+    await screen.findByRole('button', { name: /Search Google Maps/i }); // page settled
     expect(screen.queryByLabelText('Describe what you want to find')).not.toBeInTheDocument();
   });
 
@@ -134,7 +135,7 @@ describe('DiscoverPage', () => {
     expect(screen.getByPlaceholderText(/nail salon, taekwondo/)).toHaveValue(
       'taekwondo, martial arts school, kids karate',
     );
-    // categories are pre-filled into the now-revealed Restrict-categories field
+    // categories are pre-filled into the always-visible Restrict-categories field
     expect(screen.getByPlaceholderText('learning center, education center')).toHaveValue(
       'Martial arts school, Gym',
     );

--- a/src/pages/redeemops/__tests__/PartnerDetail.test.jsx
+++ b/src/pages/redeemops/__tests__/PartnerDetail.test.jsx
@@ -1,5 +1,7 @@
 /**
- * PartnerDetail row-level gating: a business is worked by whoever owns it.
+ * PartnerDetail — the header's row-level gating and its outbound links.
+ *
+ * Gating: a business is worked by whoever owns it.
  * A BDM manages the board (assign, tasks, visibility) but does NOT get to move,
  * rename or restructure a colleague's business — the UI must not offer what
  * partnerService.canActOnRow would refuse with a 403.
@@ -163,5 +165,49 @@ describe('PartnerDetail — only the owner works the business', () => {
 
     await openTab('contacts');
     expect(screen.queryByPlaceholderText('Name *')).toBeNull();
+  });
+});
+
+describe('PartnerDetail — header links', () => {
+  const linked = {
+    ...basePartner,
+    website: 'https://www.tumblejoygym.com/classes',
+    websiteDomain: 'tumblejoygym.com',
+    instagramHandle: 'tumblejoygymnastics',
+  };
+
+  it('the website chip opens the site and the handle opens Instagram', async () => {
+    renderDetail({ id: OWNER_ID, role: 'redeem_ops', redeemOpsRole: 'bdm' }, linked);
+    await screen.findByText('Secret Garden Nail Boutique');
+
+    // The chip reads as the bare domain but follows the full URL the rep saved.
+    expect(screen.getByRole('link', { name: /tumblejoygym\.com/ }))
+      .toHaveAttribute('href', 'https://www.tumblejoygym.com/classes');
+    expect(screen.getByRole('link', { name: /@tumblejoygymnastics/ }))
+      .toHaveAttribute('href', 'https://instagram.com/tumblejoygymnastics');
+  });
+
+  it('falls back to the normalized domain when no full URL was saved', async () => {
+    renderDetail({ id: OWNER_ID, role: 'redeem_ops', redeemOpsRole: 'bdm' }, { ...linked, website: null });
+    await screen.findByText('Secret Garden Nail Boutique');
+
+    expect(screen.getByRole('link', { name: /tumblejoygym\.com/ }))
+      .toHaveAttribute('href', 'https://tumblejoygym.com');
+  });
+
+  it('never emits a javascript: href from stored free text', async () => {
+    renderDetail({ id: OWNER_ID, role: 'redeem_ops', redeemOpsRole: 'bdm' }, { ...linked, website: 'javascript:alert(1)' });
+    await screen.findByText('Secret Garden Nail Boutique');
+
+    const href = screen.getByRole('link', { name: /tumblejoygym\.com/ }).getAttribute('href');
+    expect(href.startsWith('https://')).toBe(true);
+    expect(href).not.toMatch(/javascript/i);
+  });
+
+  it('renders nothing clickable when the business has neither', async () => {
+    renderDetail({ id: OWNER_ID, role: 'redeem_ops', redeemOpsRole: 'bdm' });
+    await screen.findByText('Secret Garden Nail Boutique');
+
+    expect(screen.queryByRole('link', { name: /instagram|\.com/i })).toBeNull();
   });
 });


### PR DESCRIPTION
Four small surface fixes, all frontend.

## Discover

**Removed "Suggested searches".** Six category×area cards generated from the taxonomy — guesses at what to prospect that nobody asked for, sitting directly above *Recent searches*, the list operators actually return to. Removing them also retires the page's now-unused `listCategories` fetch.

**Un-hid "More filters".** Min rating, Exclude closed businesses and the category restriction now render inline under a plain **Filters** heading. They were one click away behind an expander whose collapsed summary line had to be kept in sync with the form; a filter you can't see is a filter nobody applies. The summary and the reveal-on-AI-suggestion nudge go with it — there's nothing left to reveal.

## Partner header

The website chip and the `@handle` become links (new tab). The chip still reads as the bare domain but follows the full URL the rep saved, which may carry a path.

`websiteHref` only ever emits `http(s)`, so stored free text can't become a `javascript:` href, and it falls back to the normalized domain when no full URL was saved. There's a test for the `javascript:` case.

## Cadence name

The cadence shown on a business links to its definition for anyone with `tasks.manage` — non-authors already land on the editor's **read-only** view, so this is a "see the script" affordance, not an edit one. It stays plain text for everyone else rather than being a link into a bounce.

Enrollments are version-pinned, so the link targets the **exact version being run**, not the cadence's latest. That version may since have been retired by an edit; the editor lists with `all=true`, so a retired version still resolves.

## Verification

- Full frontend suite: **160 files / 2042 tests pass**, lint clean.
- 4 new header-link tests, 2 new cadence-name tests, 1 new always-visible-filters test; the suggestion-card test is retired with the feature.
- `PartnerDetail.ownership.test.jsx` → `PartnerDetail.test.jsx` — the file now covers the header's links alongside its row-level gating.
- Ported onto `main` as patches rather than file copies, because #306 (cadence dialog scroll) and #307 (row ownership) had both touched these files since this branch's base — verified both survive intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtL6Jqv4T8GwXVU6jiyTfw