### PR TITLE
fix(redeem-ops): running a cadence follows business ownership too

### DIFF
--- a/backend/src/services/redeemOps/cadenceService.js
+++ b/backend/src/services/redeemOps/cadenceService.js
@@ -6,7 +6,7 @@ import {
 } from '../../models/index.js';
 import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';
-import { hasCapability } from './permissions.js';
+import { hasCapability, canActOnPartnerRow } from './permissions.js';
 import { makeRedeemOpsAuditService } from './auditService.js';
 import { makeTaskService } from './taskService.js';
 import { makePartnerService } from './partnerService.js';
@@ -110,10 +110,17 @@ export function makeCadenceService(overrides = {}) {
     ...overrides,
   };
 
+  // Manager POWERS that aren't about a single business: overriding the per-owner
+  // enrollment cap, and completing a task assigned to someone else. Distinct
+  // from acting ON a business — see canActOnPartner directly below.
   const isManager = (user) =>
     user.role === 'admin' || ['super_admin', 'ops_admin', 'bdm'].includes(user.redeemOpsRole);
 
-  const canActOnPartner = (user, partner) => isManager(user) || partner.ownerUserId === user.id;
+  // Running a cadence IS working the deal: it queues outreach tasks and sends
+  // scripted messages under the owner's name. So enrolling, pausing, resuming
+  // and stopping follow the same rule as moving or editing the business —
+  // owner or admin tier, BDMs included in the restriction (#307).
+  const canActOnPartner = canActOnPartnerRow;
 
   // Drafts (publishedAt NULL) are private to their creator + admins. "Admins"
   // = the settings.manage tier — the set that could author everything before

--- a/backend/test/redeemOpsCadences.test.js
+++ b/backend/test/redeemOpsCadences.test.js
@@ -21,7 +21,7 @@ import { makeTaskService } from '../src/services/redeemOps/taskService.js';
 import { runRedeemOpsStaleSweep } from '../src/services/redeemOps/staleSweep.js';
 
 let app;
-let admin, execA, execB, analyst;
+let admin, execA, execB, analyst, bdm;
 const svc = makeCadenceService();
 const partnerSvc = makePartnerService();
 const claimSvc = makeClaimService();
@@ -36,6 +36,7 @@ beforeAll(async () => {
   execA = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
   execB = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
   analyst = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'analyst' }); // no tasks.manage
+  bdm = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'bdm' });
   // the app boot may have created the system agent already — don't collide
   await User.findOrCreate({
     where: { email: 'system@mktr.local' },
@@ -125,6 +126,26 @@ describe('enroll', () => {
     await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
     await expect(svc.enrollPartner(p.id, { cadenceKey: 'revival_60d' }, execA.user))
       .rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  test('a BDM cannot run a cadence on a colleague\u2019s business', async () => {
+    // Running a cadence queues outreach and sends scripted messages under the
+    // owner's name — it is working the deal, so it follows business ownership.
+    const p = await ownedPartner('Not My Cafe', execA);
+    await expect(svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, bdm.user))
+      .rejects.toMatchObject({ statusCode: 403 });
+
+    // …and the owner still can.
+    const { enrollment } = await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+    expect(enrollment.state).toBe('active');
+
+    // A live cadence on someone else's business is equally off limits.
+    await expect(svc.pauseEnrollment(p.id, bdm.user)).rejects.toMatchObject({ statusCode: 403 });
+    await expect(svc.stopEnrollment(p.id, bdm.user)).rejects.toMatchObject({ statusCode: 403 });
+
+    // Admin tier keeps its override.
+    const paused = await svc.pauseEnrollment(p.id, admin.user);
+    expect(paused.state).toBe('paused');
   });
 
   test('per-owner capacity cap: refused at cap, manager may override', async () => {

--- a/src/components/redeemops/__tests__/cadence.test.jsx
+++ b/src/components/redeemops/__tests__/cadence.test.jsx
@@ -349,6 +349,33 @@ describe('CadencePanel', () => {
     expect(screen.queryByRole('link', { name: 'Pet Grooming IG-DM' })).not.toBeInTheDocument();
   });
 
+  it('hides the cadence controls on a business the viewer does not own, keeping task controls', async () => {
+    api.getPartnerCadence.mockResolvedValue({
+      enrollment: {
+        id: 'e-1', state: 'active',
+        cadence: { id: 'c-1', name: 'F&B call-first', version: 1, steps: [{ id: 's-1', stepOrder: 1 }] },
+        currentStep: { id: 's-1', stepOrder: 1 },
+      },
+      openTask: null,
+    });
+    useAuthStore.setState({ user: { id: 'u-1', role: 'user', redeemOpsRole: 'bdm' } });
+    // canManage (tasks) stays true; canRunCadence (the deal) is false.
+    wrap(
+      <CadencePanel
+        partner={{ id: 'p-1', ownerUserId: 'someone-else', pipelineStage: 'NEW' }}
+        canManage
+        canRunCadence={false}
+        onAddTask={() => {}}
+      />
+    );
+
+    expect(await screen.findByText(/F&B call-first/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^pause$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^stop$/i })).not.toBeInTheDocument();
+    // Coordinating work on a colleague's business is still allowed.
+    expect(screen.getByRole('button', { name: /add task/i })).toBeInTheDocument();
+  });
+
   it('offers enrollment when there is no live cadence', async () => {
     api.getPartnerCadence.mockResolvedValue({ enrollment: null, openTask: null });
     wrap(<CadencePanel partner={{ id: 'p-1', ownerUserId: 'u-1', pipelineStage: 'NEW' }} />);

--- a/src/components/redeemops/cadence.jsx
+++ b/src/components/redeemops/cadence.jsx
@@ -405,7 +405,10 @@ function PartnerTaskRow({
  * passive "Next: …" line is gone; the task row replaced it.
  * `variant="summary"` renders the compact actionable mobile strip.
  */
-export function CadencePanel({ partner, canManage = true, variant = 'card', onAddTask, onEditTask }) {
+// canManage = may work TASKS here. canRunCadence = may start/pause/stop the
+// cadence, which is working the deal itself and so follows business ownership
+// (#307); it defaults to canManage so other call sites keep their behavior.
+export function CadencePanel({ partner, canManage = true, canRunCadence = canManage, variant = 'card', onAddTask, onEditTask }) {
   const queryClient = useQueryClient();
   const [enrollOpen, setEnrollOpen] = useState(false);
   const [stripExpanded, setStripExpanded] = useState(false);
@@ -509,7 +512,7 @@ export function CadencePanel({ partner, canManage = true, variant = 'card', onAd
     completingId,
   };
 
-  const enrollButton = CADENCES_ENABLED && canManage && !terminalStage && (
+  const enrollButton = CADENCES_ENABLED && canRunCadence && !terminalStage && (
     <Button
       size="sm"
       className={variant === 'summary' ? 'shrink-0' : 'w-full'}
@@ -568,7 +571,7 @@ export function CadencePanel({ partner, canManage = true, variant = 'card', onAd
               Paused — no tasks will be scheduled until resumed.
             </p>
           )}
-          {canManage && (
+          {canRunCadence && (
             <div className="flex gap-1.5 mt-3">
               {enrollment.state === 'active' ? (
                 <Button size="sm" variant="outline" disabled={pauseMutation.isPending} onClick={() => pauseMutation.mutate()}>Pause</Button>
@@ -611,7 +614,7 @@ export function CadencePanel({ partner, canManage = true, variant = 'card', onAd
       {rows.length === 0 && !tasksQuery.isLoading && (
         <p className="text-[12.5px] m-0 px-5 pb-3.5 leading-relaxed" style={{ color: 'var(--ro-text-3)' }}>
           {canManage && !terminalStage
-            ? `No open tasks — add one${CADENCES_ENABLED ? ' or start a cadence' : ''}.`
+            ? `No open tasks — add one${CADENCES_ENABLED && canRunCadence ? ' or start a cadence' : ''}.`
             : 'No open tasks.'}
         </p>
       )}

--- a/src/pages/redeemops/PartnerDetail.jsx
+++ b/src/pages/redeemops/PartnerDetail.jsx
@@ -707,6 +707,7 @@ export default function PartnerDetail() {
       <CadencePanel
         partner={partner}
         canManage={hasCapability(user, 'tasks.manage')}
+        canRunCadence={canActOnRow && hasCapability(user, 'tasks.manage')}
         variant="summary"
         onAddTask={() => setTaskOpen(true)}
         onEditTask={openTaskEdit}
@@ -862,6 +863,7 @@ export default function PartnerDetail() {
             <CadencePanel
               partner={partner}
               canManage={hasCapability(user, 'tasks.manage')}
+              canRunCadence={canActOnRow && hasCapability(user, 'tasks.manage')}
               onAddTask={() => setTaskOpen(true)}
               onEditTask={openTaskEdit}
             />


### PR DESCRIPTION
Follow-up to #307, found while checking why a partner page still showed every control.

## The miss

#307 moved the partner record behind owner-or-admin, but `cadenceService` kept **its own third copy** of the old rule:

```js
const isManager = (user) =>
  user.role === 'admin' || ['super_admin', 'ops_admin', 'bdm'].includes(user.redeemOpsRole);
const canActOnPartner = (user, partner) => isManager(user) || partner.ownerUserId === user.id;
```

Since **every ops user in prod is a `bdm`**, anyone could start / pause / resume / stop a cadence on a colleague's business — the surface that queues outreach tasks and sends scripted messages **under the owner's name**. That's working the deal, so it now follows the same rule as moving or editing it.

`canActOnPartner` now points at the shared `canActOnPartnerRow`. `isManager` stays for the two things it's actually about — overriding the per-owner enrollment cap, and completing a task assigned to someone else — neither of which is "acting on this business".

## Tasks stay open — deliberately

`createTask` has no ownership check at all, and that's the call: a manager handing a colleague work on their own business is normal coordination, and it happens in prod today (Emily → Shawn, 27 Jul 16:35 SGT).

So `CadencePanel` splits its single `canManage` into:

| prop | means | gated on |
|---|---|---|
| `canManage` | may work **tasks** here | `tasks.manage` |
| `canRunCadence` | may run **the cadence** | ownership **+** `tasks.manage` |

`canRunCadence` defaults to `canManage`, so other call sites are unchanged. Without the split the UI would keep offering Pause/Stop that the API had begun refusing — exactly the drift #307 ran into with `partners.reassign`.

## Verification

- Backend `test/redeemOps*`: **25 suites / 355 tests pass**, including a new one — a BDM refused on enroll/pause/stop for a colleague's business, the owner still allowed, admin override intact.
- Teeth check: restoring the old `canActOnPartner` turns that test red.
- Frontend: **160 files / 2043 tests pass**, including a new panel test asserting Pause/Stop are hidden while **Add task stays visible**.
- No new lint warnings (baseline identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtL6Jqv4T8GwXVU6jiyTfw