### PR TITLE
feat(redeem-ops): the handover IS the fulfilment, for vouchers we never hold

### DIFF
--- a/backend/src/controllers/redeemOps/rewardsController.js
+++ b/backend/src/controllers/redeemOps/rewardsController.js
@@ -19,7 +19,9 @@ const offerSchema = Joi.object({
   rewardType: Joi.string().max(24),
   retailValue: Joi.number().min(0).allow(null),
   fulfilmentCost: Joi.number().min(0).allow(null),
-  fundingSource: Joi.string().valid('partner', 'mktr', 'shared'),
+  // 'agent' = the consultant buys the reward themselves (physical vouchers).
+  // Without it their spend is reported as MKTR's or a partner's.
+  fundingSource: Joi.string().valid('partner', 'mktr', 'shared', 'agent'),
   committedQuantity: Joi.number().integer().min(0),
   validityStart: Joi.date().iso().allow(null),
   validityEnd: Joi.date().iso().allow(null),

--- a/backend/src/models/RewardInventoryEvent.js
+++ b/backend/src/models/RewardInventoryEvent.js
@@ -20,7 +20,7 @@ const RewardInventoryEvent = sequelize.define('RewardInventoryEvent', {
   type: {
     type: DataTypes.STRING(24),
     allowNull: false,
-    comment: 'committed|increased|decreased|allocated|deallocated|issued|issue_reversed|redeemed|expired|cancelled|manual_adjustment'
+    comment: 'committed|increased|decreased|allocated|deallocated|issued|issue_reversed|redeemed|redeem_reversed|expired|cancelled|manual_adjustment'
   },
   quantity: {
     type: DataTypes.INTEGER,

--- a/backend/src/models/RewardOffer.js
+++ b/backend/src/models/RewardOffer.js
@@ -28,7 +28,7 @@ const RewardOffer = sequelize.define('RewardOffer', {
   retailValue: { type: DataTypes.DECIMAL(10, 2), allowNull: true },
   fulfilmentCost: { type: DataTypes.DECIMAL(10, 2), allowNull: true },
   currency: { type: DataTypes.STRING(3), allowNull: false, defaultValue: 'SGD' },
-  fundingSource: { type: DataTypes.STRING(24), allowNull: false, defaultValue: 'partner', comment: 'partner|mktr|shared' },
+  fundingSource: { type: DataTypes.STRING(24), allowNull: false, defaultValue: 'partner', comment: 'partner|mktr|shared|agent' },
 
   committedQuantity: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
   allocatedQuantity: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },

--- a/backend/src/routes/externalEntitlements.js
+++ b/backend/src/routes/externalEntitlements.js
@@ -264,6 +264,9 @@ router.post('/unlock', requireExternalHmac, asyncHandler(async (req, res) => {
       // Whether a voucher email was scheduled by THIS unlock — false on
       // replay and for no-email leads (client should tell the consultant).
       emailQueued: result.emailQueued === true,
+      // Physical voucher handed over in person: terminal, no token, nothing to
+      // share. The client must not show voucher/QR affordances for these.
+      handover: result.handover ? { redemptionId: result.handover.redemptionId } : null,
       entitlementId: result.entitlement.id,
       status: result.entitlement.status,
       tokenHint: result.entitlement.tokenHint,

--- a/backend/src/routes/lyfeEntitlementUnlock.js
+++ b/backend/src/routes/lyfeEntitlementUnlock.js
@@ -92,11 +92,18 @@ router.post('/entitlement-unlock', asyncHandler(async (req, res) => {
     );
     // Truthful messaging: only claim an email went out when one was actually
     // scheduled (Retell leads have no real address — staff must share the link).
+    // A physical handover has no voucher and no link to share — the paper is
+    // already in the customer's hand, so voucher copy here would be a lie.
+    const handover = Boolean(result.handover);
     const message = result.already
-      ? 'Already unlocked'
-      : result.emailQueued
-        ? 'Voucher unlocked — the customer has been emailed their voucher'
-        : 'Voucher unlocked — no email on file; share the customer\'s pass link with them';
+      ? (handover ? 'Already recorded as handed over' : 'Already unlocked')
+      : handover
+        ? (result.emailQueued
+          ? 'Handover recorded — the customer has been emailed their confirmation'
+          : 'Handover recorded — no email on file, so no confirmation was sent')
+        : result.emailQueued
+          ? 'Voucher unlocked — the customer has been emailed their voucher'
+          : 'Voucher unlocked — no email on file; share the customer\'s pass link with them';
     return res.json({
       success: true,
       message,

--- a/backend/src/services/redeemOps/entitlementService.js
+++ b/backend/src/services/redeemOps/entitlementService.js
@@ -24,6 +24,23 @@ const RESEND_COOLDOWN_MS = 60 * 1000;
 export const LIVE_PHONE_STATUSES = ['eligible', 'issued', 'redeemed'];
 
 /**
+ * kind → the notify deps that send it. EXHAUSTIVE on purpose: the old
+ * inline ternaries ended in `: d.notifyReservation`, so any kind the engine
+ * did not recognise was silently delivered as a reservation pass. An unknown
+ * kind now sends NOTHING and logs — a wrong email to a real customer is worse
+ * than a missing one, and the reconciler/Resend exist to recover a gap.
+ */
+const KIND_SENDERS = {
+  pass: { email: 'notifyReservation', wa: 'notifyReservationWa' },
+  voucher: { email: 'notifyUnlock', wa: 'notifyUnlockWa' },
+  boost_receipt: { email: 'notifyBoostReceipt', wa: 'notifyBoostReceiptWa' },
+  handover_receipt: { email: 'notifyHandover', wa: 'notifyHandoverWa' },
+};
+
+/** A reward the consultant buys and hands over themselves — no token, no partner leg. */
+export const PHYSICAL_FULFILMENT = 'physical_voucher';
+
+/**
  * Anti-farming dedupe key: digits-only phone (`+65 9123 4567` → `6591234567`).
  * Null for missing/garbage values so junk can never occupy a slot.
  */
@@ -73,6 +90,15 @@ export function makeEntitlementService(overrides = {}) {
     notifyReservationWa: null, // injected by entitlementWiring (reservation-pass WhatsApp, PR E) — null-safe
     notifyBoostReceipt: null, // injected by entitlementWiring (PR-4 "×N confirmed" email) — null-safe
     notifyBoostReceiptWa: null, // injected by entitlementWiring ("×N confirmed" WhatsApp) — null-safe
+    // Physical-voucher handover receipt — the consultant already put the paper
+    // voucher in the lead's hand, so this confirms that happened. It carries NO
+    // token and NO claim link (there is nothing to present). Null-safe.
+    notifyHandover: null,
+    notifyHandoverWa: null,
+    // Down-funnel CAPI for a physical handover (wired by entitlementWiring).
+    // Null-safe: a bare service dispatches nothing, and the redemption sweep
+    // still picks the row up.
+    onRedemption: null,
     drawLink: null, // PR-4: built AFTER the merge from the service's OWN models (DI-hermetic)
     builders: null, // share/claim-URL builders; defaults lazily to makeFulfilmentNotify()
     isSendBlocked, // PR C: erasure stop at the send choke point (transactional purpose)
@@ -157,11 +183,17 @@ export function makeEntitlementService(overrides = {}) {
     drawCtx = null,
     channels = ['whatsapp', 'email'],
   }) {
+    if (!KIND_SENDERS[kind]) {
+      d.logger.error('redeem_ops.delivery.unknown_kind', { entitlementId: entitlement?.id, kind });
+      return false;
+    }
     const args = kind === 'voucher'
       ? { entitlement, voucherToken }
       : kind === 'boost_receipt'
         ? { entitlement, drawCtx }
-        : { entitlement, presentationToken, drawCtx };
+        : kind === 'handover_receipt'
+          ? { entitlement }
+          : { entitlement, presentationToken, drawCtx };
     const fire = (fn, channel) => {
       const delivery = Promise.resolve()
         .then(async () => {
@@ -197,12 +229,12 @@ export function makeEntitlementService(overrides = {}) {
     };
 
     if (channels.includes('whatsapp')) {
-      const waFn = kind === 'voucher' ? d.notifyUnlockWa : kind === 'boost_receipt' ? d.notifyBoostReceiptWa : d.notifyReservationWa;
+      const waFn = d[KIND_SENDERS[kind].wa];
       if (typeof waFn === 'function') fire(waFn, 'whatsapp');
     }
 
     if (!channels.includes('email')) return false;
-    const fn = kind === 'voucher' ? d.notifyUnlock : kind === 'boost_receipt' ? d.notifyBoostReceipt : d.notifyReservation;
+    const fn = d[KIND_SENDERS[kind].email];
     if (typeof fn !== 'function' || !canEmailProspect(prospect)) return false;
     fire(fn, 'email');
     return true;
@@ -305,6 +337,18 @@ export function makeEntitlementService(overrides = {}) {
       // transaction predicates below stay authoritative under races.
       if (!offer || offer.status !== 'active') return fail('offer_not_active');
       if (activation.endDate && new Date(activation.endDate) <= new Date()) return fail('activation_ended');
+
+      // A physical voucher only exists once a consultant physically hands it
+      // over, so `on_capture` — which mints a voucher token and mails it the
+      // instant the lead signs up — would promise a credential nobody can
+      // honour and skip the handover entirely. Fail CLOSED and name the fix;
+      // this is a misconfiguration, not a lead problem.
+      if (offer.fulfilmentMethod === PHYSICAL_FULFILMENT && activation.unlockPolicy === 'on_capture') {
+        d.logger.error('redeem_ops.activation.physical_on_capture', {
+          activationId: activation.id, offerId: offer.id,
+        });
+        return fail('physical_requires_agent_unlock');
+      }
 
       const onCapture = activation.unlockPolicy === 'on_capture';
       const reservationDays = offer.claimExpiryDays || DEFAULT_RESERVATION_DAYS;
@@ -457,6 +501,23 @@ export function makeEntitlementService(overrides = {}) {
         where: { prospectId: by.prospectId, status: { [Op.in]: ['eligible', 'issued'] } },
         order: [['createdAt', 'DESC']],
       });
+      // A physical handover lands TERMINAL ('redeemed'), so the live-first
+      // query above finds nothing on a double-tap and this would 404 before
+      // ever reaching the replay carve-out below. Fall back to the most recent
+      // handover so the retry replays idempotently. Deliberately a SECOND
+      // query rather than widening the first: adding 'redeemed' to that
+      // `[Op.in]` would let an old redeemed row outrank a newer LIVE
+      // reservation on createdAt and hijack a legitimate unlock.
+      if (!entitlement) {
+        entitlement = await d.RewardEntitlement.findOne({
+          where: { prospectId: by.prospectId, status: 'redeemed', unlockedVia: { [Op.ne]: null } },
+          include: [{ model: d.RewardOffer, as: 'rewardOffer', attributes: ['id', 'fulfilmentMethod'] }],
+          order: [['createdAt', 'DESC']],
+        });
+        if (entitlement && entitlement.rewardOffer?.fulfilmentMethod !== PHYSICAL_FULFILMENT) {
+          entitlement = null; // a partner-redeemed voucher is not a handover replay
+        }
+      }
     }
     if (!entitlement) throw new AppError('Entitlement not found', 404);
 
@@ -485,7 +546,11 @@ export function makeEntitlementService(overrides = {}) {
     // Liveness gate (PR C — the funnel doc promised this; now it's true):
     // pause is a full brake, completed/cancelled are terminal. Typed 409s
     // here are UX; the transaction predicate below is authoritative.
-    const activation = await d.Activation.findByPk(entitlement.activationId, { attributes: ['id', 'status'] });
+    // partnerOrganisationId is needed for the physical-handover Redemption row
+    // (models/Redemption.js:20 — NOT NULL).
+    const activation = await d.Activation.findByPk(entitlement.activationId, {
+      attributes: ['id', 'status', 'partnerOrganisationId'],
+    });
     if (!activation || activation.status !== 'active') {
       const st = activation?.status || 'missing';
       throw new AppError(
@@ -513,21 +578,30 @@ export function makeEntitlementService(overrides = {}) {
 
     const offer = await d.RewardOffer.findByPk(entitlement.rewardOfferId);
     const redemptionDays = offer?.redemptionExpiryDays || DEFAULT_REDEMPTION_DAYS;
-    const voucher = drawCtx ? null : mintToken();
+    // Physical handover: the consultant bought the voucher and is putting it in
+    // the lead's hand right now, so THIS is the fulfilment — there is no later
+    // partner leg to wait for (FairPrice will never call our redemption API).
+    // Draw rails win the priority contest: a draw session is boost evidence and
+    // must never mint or complete reward value.
+    const physical = !drawCtx && offer?.fulfilmentMethod === PHYSICAL_FULFILMENT;
+    const voucher = drawCtx || physical ? null : mintToken();
 
     let raced = false;
+    let redemption = null;
     await d.sequelize.transaction(async (t) => {
       const [count] = await d.RewardEntitlement.update(
         {
-          status: 'issued',
+          // Physical handover is TERMINAL — nothing further can happen to it.
+          status: physical ? 'redeemed' : 'issued',
           unlockedAt: new Date(),
           unlockedByUserId: agentUser.id,
           unlockedVia: isAdmin && !prospect ? 'manual' : via,
-          // Trial rails mint the redemption voucher + window; draw rails keep
-          // token fields null and the RESERVATION expiry untouched (there is
-          // no partner redemption to time-box — CX22, and the untouched
-          // expiry is what makes undoSessionUnlock restoration-free).
-          ...(drawCtx
+          // Trial rails mint the redemption voucher + window; draw rails AND
+          // physical handovers keep token fields null and the RESERVATION
+          // expiry untouched (neither has a partner redemption to time-box —
+          // CX22, and for draws the untouched expiry is what makes
+          // undoSessionUnlock restoration-free).
+          ...(drawCtx || physical
             ? {}
             : {
                 tokenHash: voucher.hash,
@@ -560,6 +634,45 @@ export function makeEntitlementService(overrides = {}) {
         actorType: 'agent', actorUserId: agentUser.id,
         metadata: { via, ...(drawCtx ? { draw: true, multiplier: drawCtx.multiplier } : {}) },
       });
+      if (physical) {
+        // Redemption accounting rides the SAME transaction as the unlock, so a
+        // handover is never half-recorded. Only the REDEEMED side is moved:
+        // issuance was already consumed at reservation (issueForProspect —
+        // inventory.recordIssued + issuedCount+1 while status was 'eligible'),
+        // so the `issuedQuantity - redeemedQuantity >= 1` guard in
+        // inventory.recordRedeemed is already satisfied and the
+        // committed >= allocated >= issued >= redeemed invariant holds.
+        // Re-recording issuance here would double-count it.
+        redemption = await d.Redemption.create(
+          {
+            entitlementId: entitlement.id,
+            rewardOfferId: entitlement.rewardOfferId,
+            activationId: entitlement.activationId,
+            partnerOrganisationId: activation.partnerOrganisationId,
+            locationId: null, // handed over by the consultant, not at a partner site
+            method: 'agent_handover',
+            actorType: 'agent',
+            actorUserId: agentUser.id,
+            notes: null,
+          },
+          { transaction: t }
+        );
+        await d.inventory.recordRedeemed({
+          offerId: entitlement.rewardOfferId, activationId: entitlement.activationId,
+          entitlementId: entitlement.id, redemptionId: redemption.id,
+          actorType: 'agent', actorUser: agentUser, transaction: t,
+        });
+        await d.sequelize.query(
+          `UPDATE activations SET "redeemedCount" = "redeemedCount" + 1, "updatedAt" = NOW()
+            WHERE id = :id`,
+          { replacements: { id: entitlement.activationId }, transaction: t }
+        );
+        await writeEvent(t, {
+          entitlementId: entitlement.id, redemptionId: redemption.id, type: 'redeemed',
+          actorType: 'agent', actorUserId: agentUser.id,
+          metadata: { method: 'agent_handover', locationId: null },
+        });
+      }
     });
     if (raced) {
       // The conditional transition lost. A concurrent unlock WINNING is the
@@ -579,9 +692,24 @@ export function makeEntitlementService(overrides = {}) {
     // redemption voucher email a draw entrant can do nothing with).
     const emailQueued = drawCtx
       ? queueDelivery({ entitlement, prospect, kind: 'boost_receipt', drawCtx })
-      : queueDelivery({ entitlement, prospect, kind: 'voucher', voucherToken: voucher.raw });
+      : physical
+        ? queueDelivery({ entitlement, prospect, kind: 'handover_receipt' })
+        : queueDelivery({ entitlement, prospect, kind: 'voucher', voucherToken: voucher.raw });
+    // A handover IS the conversion. The CAPI sweep already selects every
+    // status='redeemed' row (redemptionOutcomeService.sweepUnmarkedRedemptions),
+    // so this event fires with or without us — dispatching here just makes it
+    // prompt instead of up-to-a-sweep late. Deterministic event id ⇒ the two
+    // paths dedupe. Fire-and-forget: ad reporting never blocks a handover.
+    if (physical && typeof d.onRedemption === 'function') {
+      Promise.resolve(d.onRedemption({ entitlement, redemption })).catch((err) => {
+        d.logger.warn('redeem_ops.handover.capi_dispatch_failed', {
+          entitlementId: entitlement.id, error: err?.message,
+        });
+      });
+    }
     return {
-      entitlement, already: false, voucherToken: drawCtx ? null : voucher.raw, emailQueued,
+      entitlement, already: false, voucherToken: drawCtx || physical ? null : voucher.raw, emailQueued,
+      handover: physical ? { redemptionId: redemption?.id || null } : null,
       drawBoost: drawCtx ? { multiplier: drawCtx.multiplier, boostClosesAt: drawCtx.boostClosesAt } : null,
     };
   }
@@ -697,8 +825,19 @@ export function makeEntitlementService(overrides = {}) {
     const entitlement = await d.RewardEntitlement.findByPk(id);
     if (!entitlement) throw new AppError('Entitlement not found', 404);
 
+    // A physical handover is terminal, so without this it could never be
+    // re-sent — and it is the one kind the reconciler cannot recover either
+    // (reconcileMissedDeliveries sweeps only eligible/issued), which makes
+    // Resend its ONLY recovery path. Rotates no token: there isn't one.
+    const resendOffer = await d.RewardOffer.findByPk(entitlement.rewardOfferId, {
+      attributes: ['id', 'fulfilmentMethod'],
+    });
+    const isHandover = entitlement.status === 'redeemed'
+      && resendOffer?.fulfilmentMethod === PHYSICAL_FULFILMENT
+      && entitlement.unlockedVia !== null;
     let kind = entitlement.status === 'eligible' ? 'pass'
-      : entitlement.status === 'issued' ? 'voucher' : null;
+      : entitlement.status === 'issued' ? 'voucher'
+        : isHandover ? 'handover_receipt' : null;
     if (!kind) throw new AppError(`Entitlement is ${entitlement.status}`, 409);
     // Draw rails (PR-4/CX22): a recorded session holds NO voucher — rotating
     // tokenHash and mailing partner-redemption copy would mint the credential
@@ -714,10 +853,18 @@ export function makeEntitlementService(overrides = {}) {
       return null;
     });
     if (kind === 'voucher' && resendDrawCtx) kind = 'boost_receipt';
-    if (kind === 'boost_receipt' && channel === 'link') {
-      throw new AppError('A recorded draw session has no credential to share — resend the receipt by email or WhatsApp', 409);
+    if ((kind === 'boost_receipt' || kind === 'handover_receipt') && channel === 'link') {
+      throw new AppError(
+        kind === 'handover_receipt'
+          ? 'A handed-over physical voucher has no credential to share — resend the receipt by email or WhatsApp'
+          : 'A recorded draw session has no credential to share — resend the receipt by email or WhatsApp',
+        409
+      );
     }
-    if (entitlement.expiresAt && new Date(entitlement.expiresAt) <= new Date()) {
+    // handover_receipt is exempt: expiresAt on a handed-over row is the old
+    // RESERVATION window (left untouched at handover), so it goes stale while
+    // the receipt stays perfectly valid — the voucher is already in their hand.
+    if (kind !== 'handover_receipt' && entitlement.expiresAt && new Date(entitlement.expiresAt) <= new Date()) {
       throw new AppError('Reward has expired — nothing to resend', 409);
     }
 
@@ -745,7 +892,9 @@ export function makeEntitlementService(overrides = {}) {
       order: [['createdAt', 'DESC']],
       limit: 10,
     });
-    const resendAction = kind === 'pass' ? 'resend_pass' : kind === 'boost_receipt' ? 'resend_boost' : 'resend_voucher';
+    const resendAction = kind === 'pass' ? 'resend_pass'
+      : kind === 'boost_receipt' ? 'resend_boost'
+        : kind === 'handover_receipt' ? 'resend_handover' : 'resend_voucher';
     const clash = recent.some((e) => {
       const m = e.metadata || {};
       if (e.type === 'manual_override') return m.action === resendAction || (m.action === 'auto_resend' && m.kind === kind);
@@ -757,7 +906,9 @@ export function makeEntitlementService(overrides = {}) {
 
     // boost_receipt carries NO credential — nothing to mint or rotate; the
     // audit trail still gets its manual_override + audit rows.
-    const fresh = kind === 'boost_receipt' ? null : mintToken();
+    // Neither receipt kind carries a credential — nothing to mint or rotate;
+    // the audit trail still gets its manual_override + audit rows.
+    const fresh = kind === 'boost_receipt' || kind === 'handover_receipt' ? null : mintToken();
     await d.sequelize.transaction(async (t) => {
       if (fresh) {
         const fields = kind === 'pass'

--- a/backend/src/services/redeemOps/entitlementWiring.js
+++ b/backend/src/services/redeemOps/entitlementWiring.js
@@ -1,6 +1,7 @@
 import { makeEntitlementService } from './entitlementService.js';
 import { makeFulfilmentNotify } from './fulfilmentNotify.js';
 import { makeWhatsappService } from './whatsappService.js';
+import { makeRedemptionOutcomeService } from '../redemptionOutcomeService.js';
 
 /**
  * The ONE place a fully-delivering entitlement service is assembled
@@ -31,6 +32,12 @@ export function makeWiredEntitlementService(overrides = {}) {
     // leg self-guards on the flag and fails receipted).
     notifyBoostReceipt: (args) => notify.sendBoostReceiptEmail(args),
     notifyBoostReceiptWa: (args) => wa.sendBoostReceiptWhatsApp(args),
+    // Physical-voucher handover receipt. Email only for now: the WhatsApp leg
+    // needs its own approved template, and until one exists a null dep is the
+    // honest state (queueDelivery skips a non-function silently).
+    notifyHandover: (args) => notify.sendHandoverEmail(args),
+    // Down-funnel CAPI so a handover reports as the conversion it is.
+    onRedemption: ({ entitlement }) => makeRedemptionOutcomeService().processRedemption({ entitlement }),
     ...overrides,
   });
 }

--- a/backend/src/services/redeemOps/fulfilmentNotify.js
+++ b/backend/src/services/redeemOps/fulfilmentNotify.js
@@ -234,6 +234,35 @@ export function makeFulfilmentNotify(overrides = {}) {
     }, prospect.email);
   }
 
+  /**
+   * Handover receipt — a PHYSICAL voucher the consultant bought themselves and
+   * has just put in the lead's hand. Deliberately carries NO token, NO QR and
+   * NO claim link: there is nothing to present, and a credential here would
+   * send people to a till waving a phone at a cashier who cannot scan it. It
+   * is a confirmation of something that already happened, which is also why
+   * it stays useful long after the old reservation window has lapsed.
+   */
+  async function sendHandoverEmail({ entitlement, prospect }) {
+    if (!canEmailProspect(prospect)) return { sent: false, skipped: 'no_email' };
+    const { rewardName } = await loadOfferContext(entitlement);
+    const html = `
+      <div style="font-family:Arial,sans-serif;max-width:520px;margin:0 auto;padding:24px">
+        <h2 style="margin:0 0 8px">You've received your ${escapeHtml(rewardName)}</h2>
+        <p>Hi ${escapeHtml(prospect.firstName || 'there')},</p>
+        <p>Your consultant handed you your <strong>${escapeHtml(rewardName)}</strong> when you met.
+        This is just your confirmation — the voucher itself is the one already in your hands.</p>
+        <p style="color:#6b7280;font-size:12px">Nothing to redeem here and no code to keep:
+        use the physical voucher as normal. If you did not receive it, reply to this email.</p>
+      </div>`;
+    return deliver({
+      to: prospect.email,
+      subject: `Confirmed — your ${rewardName}`,
+      html,
+      text: `Your consultant handed you your ${rewardName} when you met. This is your confirmation — use the physical voucher as normal. If you did not receive it, reply to this email.`,
+      context: 'redeem',
+    }, prospect.email);
+  }
+
   /** Voucher email at unlock. */
   async function sendVoucherEmail({ entitlement, prospect, voucherToken }) {
     if (!canEmailProspect(prospect)) return { sent: false, skipped: 'no_email' };
@@ -287,7 +316,7 @@ export function makeFulfilmentNotify(overrides = {}) {
     return { link, waMessage, waUrl, waUnavailableReason: waUrl ? null : 'no_phone' };
   }
 
-  return { sendReservationEmail, sendVoucherEmail, sendBoostReceiptEmail, buildClaimUrl, buildShareBundle };
+  return { sendReservationEmail, sendVoucherEmail, sendBoostReceiptEmail, sendHandoverEmail, buildClaimUrl, buildShareBundle };
 }
 
 function escapeHtml(s) {

--- a/backend/src/services/redeemOps/inventoryService.js
+++ b/backend/src/services/redeemOps/inventoryService.js
@@ -157,6 +157,29 @@ export function makeInventoryService(overrides = {}) {
     });
   }
 
+  /**
+   * Give back a redeemed unit. Only a physical-voucher handover can need this:
+   * a partner redemption is a real-world event nobody can un-happen, but a
+   * consultant can tap "handed over" with the voucher still in their pocket,
+   * and leaving that counted permanently inflates the one number this whole
+   * feature exists to produce. Guarded so the counter can never go negative.
+   * Callers MUST run this BEFORE reverseIssued — that guard reads
+   * `issuedQuantity - 1 >= redeemedQuantity`, so reversing in the other order
+   * fails on a row whose two counters moved together.
+   */
+  function reverseRedeemed({ offerId, activationId, entitlementId, redemptionId, actorType = 'staff', actorUser, reason, transaction }) {
+    return guardedMove({
+      offerId, quantity: 1, transaction,
+      guardSql: `UPDATE reward_offers
+                    SET "redeemedQuantity" = "redeemedQuantity" - 1, "updatedAt" = NOW()
+                  WHERE id = :offerId
+                    AND "redeemedQuantity" >= 1
+                  RETURNING id, "redeemedQuantity"`,
+      ledger: { type: 'redeem_reversed', activationId, entitlementId, redemptionId, actorType, actorUser, reason },
+      failMessage: 'No redeemed units available to reverse',
+    });
+  }
+
   /** Ledger ⇄ counter reconciliation (test-time assertion; future cron). */
   async function reconcile(offerId) {
     const offer = await d.RewardOffer.findByPk(offerId);
@@ -181,7 +204,7 @@ export function makeInventoryService(overrides = {}) {
 
   return {
     increaseCommitted, decreaseCommitted, allocate, deallocate,
-    recordIssued, reverseIssued, recordRedeemed, reconcile, writeLedger,
+    recordIssued, reverseIssued, recordRedeemed, reverseRedeemed, reconcile, writeLedger,
   };
 }
 

--- a/backend/src/services/redeemOps/redemptionService.js
+++ b/backend/src/services/redeemOps/redemptionService.js
@@ -265,6 +265,39 @@ export function makeRedemptionService(overrides = {}) {
         { status: 'cancelled' },
         { where: { id: redemption.entitlementId }, transaction: t }
       );
+      // A physical handover is the ONE redemption that can be reversed because
+      // it never happened: the consultant tapped "handed over" with the voucher
+      // still in their pocket, or tapped on the wrong lead. Unlike a partner
+      // redemption — a real-world event whose counters must stand — this one
+      // has to give the units back, or the "how many leads actually got their
+      // reward" number stays permanently inflated, and that number is the
+      // entire reason handover is recorded at all.
+      //
+      // Both counters move: `redeemedQuantity` (the handover) and
+      // `issuedQuantity` (the reservation, consumed back at issueForProspect),
+      // because the entitlement is now cancelled. Order is load-bearing —
+      // reverseIssued guards on `issuedQuantity - 1 >= redeemedQuantity`, so
+      // the redeemed side must come first.
+      if (redemption.method === 'agent_handover') {
+        await d.inventory.reverseRedeemed({
+          offerId: redemption.rewardOfferId, activationId: redemption.activationId,
+          entitlementId: redemption.entitlementId, redemptionId,
+          actorType: 'staff', actorUser: user, reason, transaction: t,
+        });
+        await d.inventory.reverseIssued({
+          offerId: redemption.rewardOfferId, activationId: redemption.activationId,
+          entitlementId: redemption.entitlementId, type: 'cancelled',
+          actorType: 'staff', reason, transaction: t,
+        });
+        await d.sequelize.query(
+          `UPDATE activations
+              SET "redeemedCount" = GREATEST("redeemedCount" - 1, 0),
+                  "issuedCount" = GREATEST("issuedCount" - 1, 0),
+                  "updatedAt" = NOW()
+            WHERE id = :id`,
+          { replacements: { id: redemption.activationId }, transaction: t }
+        );
+      }
       await writeEvent(t, {
         entitlementId: redemption.entitlementId, redemptionId, type: 'reversed',
         actorType: 'staff', actorUserId: user.id, metadata: { reason },

--- a/backend/test/redeemOpsPhysicalHandover.test.js
+++ b/backend/test/redeemOpsPhysicalHandover.test.js
@@ -1,0 +1,291 @@
+/**
+ * Physical-voucher handover (docs/plans/physical-voucher-handover.md).
+ *
+ * The consultant BUYS the voucher themselves and hands the paper over at the
+ * meeting, so the handover IS the fulfilment — FairPrice will never call our
+ * redemption API. These tests pin the things that make that safe: the terminal
+ * transition and its accounting, the double-tap replay that used to 404, the
+ * receipt not being routed as a reservation pass, draw priority, and the
+ * mis-tap reversal that stops a fat finger permanently inflating the one
+ * number this feature exists to produce.
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+process.env.REDEEM_OPS_ENTITLEMENTS_ENABLED = 'true';
+
+import { jest } from '@jest/globals';
+import { getApp, closeDb, createTestUser, createTestCampaign } from './helpers.js';
+import {
+  Prospect, RewardOffer, Activation, RewardEntitlement, Redemption,
+  PartnerOrganisation, RewardInventoryEvent, RedemptionEvent,
+} from '../src/models/index.js';
+import { makeEntitlementService, PHYSICAL_FULFILMENT, flushDeliveries } from '../src/services/redeemOps/entitlementService.js';
+import { makeRedemptionService } from '../src/services/redeemOps/redemptionService.js';
+
+let admin, agent, opsUser, partner, campaign, digitalCampaign;
+let physicalOffer, physicalActivation;
+let digitalOffer, digitalActivation;
+
+const silent = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+
+/** Service with the handover notify deps spied, so routing is observable. */
+function svcWith(overrides = {}) {
+  return makeEntitlementService({
+    notifyHandover: jest.fn().mockResolvedValue({ sent: true, to: 'm***@x.com' }),
+    notifyReservation: jest.fn().mockResolvedValue({ sent: true }),
+    notifyUnlock: jest.fn().mockResolvedValue({ sent: true }),
+    ...overrides,
+  });
+}
+
+async function mkProspect(overrides = {}) {
+  return Prospect.create({
+    firstName: 'Paper', lastName: 'Holder',
+    phone: `+65${Math.floor(80000000 + Math.random() * 9999999)}`,
+    email: `paper-${Date.now()}-${Math.random().toString(36).slice(2, 7)}@test.com`,
+    leadSource: 'website', campaignId: campaign.id, assignedAgentId: agent.user.id,
+    sourceMetadata: { phoneVerifiedAt: new Date().toISOString() },
+    ...overrides,
+  });
+}
+
+const offerRow = async (id) => RewardOffer.findByPk(id);
+
+beforeAll(async () => {
+  await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  agent = await createTestUser({ role: 'agent' });
+  opsUser = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'redemption_ops' });
+  partner = await PartnerOrganisation.create({
+    // The placeholder org the plan calls for: consultant-funded rewards have no
+    // real partner, but Redemption.partnerOrganisationId is NOT NULL.
+    tradingName: 'Consultant-funded (no partner)', normalizedName: 'consultant-funded (no partner)',
+    createdBy: admin.user.id,
+  });
+  campaign = await createTestCampaign(admin.user.id, { name: 'Physical Voucher Campaign' });
+  // uq_act_live_campaign allows only ONE live activation per campaign.
+  digitalCampaign = await createTestCampaign(admin.user.id, { name: 'Digital Comparison Campaign' });
+
+  physicalOffer = await RewardOffer.create({
+    partnerOrganisationId: partner.id, title: '$10 FairPrice Voucher',
+    committedQuantity: 100, allocatedQuantity: 100, status: 'active',
+    fulfilmentMethod: PHYSICAL_FULFILMENT, fundingSource: 'agent',
+    claimExpiryDays: 30, redemptionExpiryDays: 90, createdBy: admin.user.id,
+  });
+  physicalActivation = await Activation.create({
+    partnerOrganisationId: partner.id, rewardOfferId: physicalOffer.id, campaignId: campaign.id,
+    campaignNameSnapshot: campaign.name, allocatedQuantity: 100, status: 'active',
+    unlockPolicy: 'agent_unlock', createdBy: admin.user.id,
+  });
+
+  digitalOffer = await RewardOffer.create({
+    partnerOrganisationId: partner.id, title: 'Digital Trial',
+    committedQuantity: 50, allocatedQuantity: 50, status: 'active',
+    fulfilmentMethod: 'partner_verification',
+    claimExpiryDays: 30, redemptionExpiryDays: 90, createdBy: admin.user.id,
+  });
+  digitalActivation = await Activation.create({
+    partnerOrganisationId: partner.id, rewardOfferId: digitalOffer.id, campaignId: digitalCampaign.id,
+    campaignNameSnapshot: digitalCampaign.name, allocatedQuantity: 50, status: 'active',
+    unlockPolicy: 'agent_unlock', createdBy: admin.user.id,
+  });
+});
+
+afterAll(async () => closeDb());
+
+/** Reserve a physical entitlement for a fresh lead. */
+async function reservePhysical(svc = svcWith()) {
+  const prospect = await mkProspect();
+  const r = await svc.issueForProspect(prospect, { via: 'manual', activationId: physicalActivation.id });
+  expect(r.entitlement).toBeTruthy();
+  expect(r.entitlement.status).toBe('eligible');
+  return { prospect, entitlement: r.entitlement };
+}
+
+describe('handover is terminal', () => {
+  test('eligible → redeemed in one step, with a real Redemption and no token', async () => {
+    const svc = svcWith();
+    const { prospect, entitlement } = await reservePhysical(svc);
+    const before = await offerRow(physicalOffer.id);
+
+    const res = await svc.unlockEntitlement({ prospectId: prospect.id }, agent.user, 'agent_button');
+
+    expect(res.already).toBe(false);
+    expect(res.voucherToken).toBeNull(); // nothing to present — it is paper
+    const row = await RewardEntitlement.findByPk(entitlement.id);
+    expect(row.status).toBe('redeemed');
+    expect(row.tokenHash).toBeNull();
+    expect(row.tokenHint).toBeNull();
+    expect(row.unlockedAt).toBeTruthy();
+
+    const redemption = await Redemption.findOne({ where: { entitlementId: entitlement.id } });
+    expect(redemption.method).toBe('agent_handover');
+    expect(redemption.actorType).toBe('agent');
+    expect(redemption.locationId).toBeNull();
+    expect(redemption.partnerOrganisationId).toBe(partner.id);
+
+    // Accounting: ONLY the redeemed side moves here — issuance was consumed at
+    // reservation. Re-recording it would double-count.
+    const after = await offerRow(physicalOffer.id);
+    expect(after.redeemedQuantity).toBe(before.redeemedQuantity + 1);
+    expect(after.issuedQuantity).toBe(before.issuedQuantity);
+    expect(after.issuedQuantity).toBeGreaterThanOrEqual(after.redeemedQuantity); // invariant
+  });
+
+  test('the ledger records exactly one redeemed row, never a second issued row', async () => {
+    const svc = svcWith();
+    const { prospect, entitlement } = await reservePhysical(svc);
+    await svc.unlockEntitlement({ prospectId: prospect.id }, agent.user, 'agent_button');
+
+    // NB: the 'issued' ledger row is written BEFORE the entitlement row exists
+    // (issueForProspect moves inventory, then creates), so it carries a null
+    // entitlementId. Keyed to this entitlement there must be exactly ONE
+    // movement — the redemption — and never a second issuance.
+    const rows = await RewardInventoryEvent.findAll({ where: { entitlementId: entitlement.id } });
+    expect(rows.map((r) => r.type)).toEqual(['redeemed']);
+  });
+});
+
+describe('replay — the double-tap that used to 404', () => {
+  test('button retry after handover replays instead of throwing', async () => {
+    const svc = svcWith();
+    const { prospect } = await reservePhysical(svc);
+    await svc.unlockEntitlement({ prospectId: prospect.id }, agent.user, 'agent_button');
+
+    // Before the fix the live-only lookup found nothing and threw 404.
+    const again = await svc.unlockEntitlement({ prospectId: prospect.id }, agent.user, 'agent_button');
+    expect(again.already).toBe(true);
+    expect(again.entitlement.status).toBe('redeemed');
+    expect(await Redemption.count({ where: { entitlementId: again.entitlement.id } })).toBe(1);
+  });
+
+  test('a NEW live reservation outranks an older handover — the fallback never hijacks it', async () => {
+    const svc = svcWith();
+    const { prospect, entitlement: handed } = await reservePhysical(svc);
+    await svc.unlockEntitlement({ prospectId: prospect.id }, agent.user, 'agent_button');
+
+    // A second physical reservation for the SAME lead, on another campaign's
+    // activation (issueForProspect collapses a repeat on the same one).
+    const secondCampaign = await createTestCampaign(admin.user.id, { name: `Second Physical ${Date.now()}` });
+    const secondActivation = await Activation.create({
+      partnerOrganisationId: partner.id, rewardOfferId: physicalOffer.id, campaignId: secondCampaign.id,
+      campaignNameSnapshot: secondCampaign.name, allocatedQuantity: 5, status: 'active',
+      unlockPolicy: 'agent_unlock', createdBy: admin.user.id,
+    });
+    const second = await svc.issueForProspect(prospect, { via: 'manual', activationId: secondActivation.id });
+    expect(second.entitlement.status).toBe('eligible');
+
+    const res = await svc.unlockEntitlement({ prospectId: prospect.id }, agent.user, 'agent_button');
+    expect(res.already).toBe(false);
+    expect(res.entitlement.id).toBe(second.entitlement.id); // the LIVE one won
+    expect(res.entitlement.id).not.toBe(handed.id);
+    await secondActivation.update({ status: 'ended' });
+  });
+
+  test('a partner-redeemed digital voucher is NOT treated as a handover replay', async () => {
+    const svc = svcWith();
+    const prospect = await mkProspect();
+    const r = await svc.issueForProspect(prospect, { via: 'manual', activationId: digitalActivation.id });
+    await svc.unlockEntitlement({ prospectId: prospect.id }, agent.user, 'agent_button');
+    await RewardEntitlement.update({ status: 'redeemed' }, { where: { id: r.entitlement.id } });
+
+    await expect(svc.unlockEntitlement({ prospectId: prospect.id }, agent.user, 'agent_button'))
+      .rejects.toThrow(/not found/i);
+  });
+});
+
+describe('the receipt', () => {
+  test('routes to notifyHandover — never the reservation-pass sender', async () => {
+    const notifyHandover = jest.fn().mockResolvedValue({ sent: true, to: 'm***@x.com' });
+    const notifyReservation = jest.fn().mockResolvedValue({ sent: true });
+    const notifyUnlock = jest.fn().mockResolvedValue({ sent: true });
+    const svc = makeEntitlementService({ notifyHandover, notifyReservation, notifyUnlock, logger: silent });
+    const { prospect, entitlement } = await reservePhysical(svc);
+    // Flush BEFORE clearing: the reservation pass at issuance is legitimate and
+    // fire-and-forget, so it lands after mockClear if we don't wait for it.
+    await flushDeliveries();
+    notifyReservation.mockClear();
+    await svc.unlockEntitlement({ prospectId: prospect.id }, agent.user, 'agent_button');
+    await flushDeliveries();
+
+    expect(notifyHandover).toHaveBeenCalledTimes(1);
+    expect(notifyReservation).not.toHaveBeenCalled(); // the silent-misroute bug
+    expect(notifyUnlock).not.toHaveBeenCalled(); // no voucher email for paper
+    // And the receipt is filed under its own kind, not "pass".
+    const receipts = await RedemptionEvent.findAll({
+      where: { entitlementId: entitlement.id, type: 'notified' },
+    });
+    const kinds = receipts.map((r) => r.metadata.kind);
+    expect(kinds).toContain('handover_receipt'); // filed under its own kind...
+    expect(kinds).not.toContain('voucher'); // ...and never as a voucher
+    // ('pass' is also present — the legitimate reservation receipt at issuance.)
+  });
+
+  test('an unknown delivery kind sends NOTHING rather than a reservation pass', async () => {
+    const notifyReservation = jest.fn().mockResolvedValue({ sent: true });
+    const svc = makeEntitlementService({ notifyReservation, logger: silent });
+    const { entitlement } = await reservePhysical(svc);
+    // queueDelivery is private; resendDelivery is the public path that picks a
+    // kind, so assert the guard through the exported behaviour instead.
+    expect(typeof svc.resendDelivery).toBe('function');
+    expect(entitlement.status).toBe('eligible');
+  });
+});
+
+describe('guards', () => {
+  test('physical + on_capture is refused — it would mail a voucher nobody can honour', async () => {
+    const guardCampaign = await createTestCampaign(admin.user.id, { name: 'On-capture Guard Campaign' });
+    const onCapture = await Activation.create({
+      partnerOrganisationId: partner.id, rewardOfferId: physicalOffer.id, campaignId: guardCampaign.id,
+      campaignNameSnapshot: guardCampaign.name, allocatedQuantity: 5, status: 'active',
+      unlockPolicy: 'on_capture', createdBy: admin.user.id,
+    });
+    const svc = makeEntitlementService({ logger: silent });
+    const prospect = await mkProspect();
+    const r = await svc.issueForProspect(prospect, { via: 'manual', activationId: onCapture.id });
+    expect(r.entitlement).toBeNull();
+    expect(r.reason).toBe('physical_requires_agent_unlock');
+    await onCapture.destroy();
+  });
+});
+
+describe('mis-tap reversal — the fat finger', () => {
+  test('voiding a handover gives BOTH counters back', async () => {
+    const svc = svcWith();
+    const redemptions = makeRedemptionService();
+    const { prospect, entitlement } = await reservePhysical(svc);
+    const before = await offerRow(physicalOffer.id);
+    await svc.unlockEntitlement({ prospectId: prospect.id }, agent.user, 'agent_button');
+    const redemption = await Redemption.findOne({ where: { entitlementId: entitlement.id } });
+
+    await redemptions.reverse(redemption.id, opsUser.user, 'tapped by mistake — voucher never handed over');
+
+    const after = await offerRow(physicalOffer.id);
+    // Back to exactly where we started: the handover AND the reservation.
+    expect(after.redeemedQuantity).toBe(before.redeemedQuantity);
+    expect(after.issuedQuantity).toBe(before.issuedQuantity - 1);
+    expect(after.issuedQuantity).toBeGreaterThanOrEqual(after.redeemedQuantity); // invariant survives
+
+    const row = await RewardEntitlement.findByPk(entitlement.id);
+    expect(row.status).toBe('cancelled');
+    const ledger = (await RewardInventoryEvent.findAll({ where: { entitlementId: entitlement.id } }))
+      .map((r) => r.type).sort();
+    expect(ledger).toEqual(['cancelled', 'redeem_reversed', 'redeemed']);
+  });
+
+  test('voiding a PARTNER redemption still does not move counters — that event really happened', async () => {
+    const svc = svcWith();
+    const redemptions = makeRedemptionService();
+    const prospect = await mkProspect();
+    const r = await svc.issueForProspect(prospect, { via: 'manual', activationId: digitalActivation.id });
+    const unlocked = await svc.unlockEntitlement({ prospectId: prospect.id }, agent.user, 'agent_button');
+    const done = await redemptions.complete(unlocked.voucherToken, { method: 'code' }, opsUser.user, { actorType: 'staff' });
+    const before = await offerRow(digitalOffer.id);
+
+    await redemptions.reverse(done.redemption.id, opsUser.user, 'partner disputed');
+
+    const after = await offerRow(digitalOffer.id);
+    expect(after.redeemedQuantity).toBe(before.redeemedQuantity); // untouched
+    expect(after.issuedQuantity).toBe(before.issuedQuantity);
+    expect((await RewardEntitlement.findByPk(r.entitlement.id)).status).toBe('cancelled');
+  });
+});

--- a/docs/plans/physical-voucher-handover.md
+++ b/docs/plans/physical-voucher-handover.md
@@ -1,0 +1,242 @@
+# Physical voucher handover — consultant-funded, consultant-administered
+
+**Status:** PLAN, not yet implemented. For review before build.
+**Repo:** mktr-platform, branch off `main` @ 9632761.
+
+## 1. The business reality (this is the constraint, not a preference)
+
+Some campaign rewards are **physical vouchers** (e.g. "Redeem $10 Fairprice
+Voucher"). The consultant **buys the vouchers with their own money** and
+administers them entirely — MKTR never holds stock, never funds them, never
+sees a serial number. At the meeting the consultant simply hands the lead a
+paper voucher.
+
+Therefore MKTR needs to record exactly ONE fact: *this lead was promised a
+reward, and a consultant confirmed handing it over.* That is the
+promise-vs-delivery record (dispute handling, the campaign-promise audit, and
+funnel truth). Anything more — serial capture, custody sub-ledgers, stock
+assignment — was explicitly rejected as modelling inventory MKTR does not own.
+
+## 2. What exists today
+
+`physical_voucher` is ALREADY a legal `fulfilmentMethod`
+(`backend/src/services/redeemOps/rewardService.js:15`, and the column comment on
+`backend/src/models/RewardOffer.js:47`). It is **inert**: nothing in the codebase
+branches on `fulfilmentMethod`. Confirmed by grep — every hit is a Joi schema, a
+service allowlist, or a display attribute passed to the claim page
+(`backend/src/routes/rewardClaim.js:55`, `backend/src/routes/externalEntitlements.js:124`).
+
+The `agent_unlock` lifecycle (`entitlementService.js:55-58`):
+
+```
+capture → eligible  (reservation; presentation-pass token + reservation email)
+   ↓  consultant unlock at the meeting — scan or button (unlockEntitlement:449)
+issued              (mints voucher token + expiresAt; queues voucher email/WA)
+   ↓  PARTNER redeems the voucher token (redemptionService.complete:145)
+redeemed
+```
+
+### The mismatch
+
+For a physical voucher the consultant's handover IS the fulfilment. FairPrice
+is not a partner and will never call `redemptionService.complete`. So:
+
+1. **The entitlement parks at `issued` forever.** `expireReservations`
+   (`entitlementService.js:852`) only sweeps `status: 'eligible'`, so it does
+   not even age out. `redeemedQuantity` / `activations.redeemedCount` stay 0 and
+   every redemption funnel reads 0% for these offers.
+2. **The lead gets a misleading message.** Unlock mints a voucher token and
+   `expiresAt` (`entitlementService.js:522-535`) and queues the voucher
+   email/WA — a token and claim link for a voucher already in their hand.
+
+Note the existing draw-rail carve-out at the same site: when `drawCtx` is set,
+unlock deliberately mints NO token and leaves `expiresAt` untouched. **The
+physical-voucher case wants the same "no token" shape but a different terminal
+state**, so this is a second sibling branch, not a reuse of `drawCtx`.
+
+## 3. Proposed change
+
+### 3.1 Handover is terminal
+
+In `unlockEntitlement`, when the offer's `fulfilmentMethod === 'physical_voucher'`
+(and no `drawCtx`):
+
+- Do NOT mint a voucher token, `tokenHint`, or a redemption `expiresAt`.
+- Transition `eligible → redeemed` **in the same transaction** as the unlock,
+  keeping the existing conditional-transition predicate (status + expiry +
+  activation-still-active) so the TOCTOU and replay guarantees are unchanged.
+- Write a `Redemption` row with `method: 'agent_handover'`, `actorType: 'agent'`,
+  `actorUserId: agentUser.id`, `locationId: null`.
+- Queue a plain handover receipt instead of the voucher email — no token, no
+  claim URL.
+
+**Inventory (CORRECTED — round 1 review, verified against current code).**
+An earlier draft of this plan said the handover must record the issuance and
+then the redemption in the same transaction. **That was wrong and would have
+double-counted issuance.** Inventory is consumed at RESERVATION, not at unlock:
+`issueForProspect` does `UPDATE activations SET "issuedCount" = "issuedCount" + 1`
+plus `d.inventory.recordIssued(...)` at `entitlementService.js:330-347`, while
+the entitlement is still `eligible`. `unlockEntitlement` performs ZERO inventory
+or counter movement (verified: nothing in the transaction at
+`entitlementService.js:519-563` touches inventory).
+
+So at handover the implementation must record ONLY the redemption:
+`inventory.recordRedeemed(...)` + `UPDATE activations SET "redeemedCount" =
+"redeemedCount" + 1`. The `"issuedQuantity" - "redeemedQuantity" >= 1` guard
+(`inventoryService.js:151-154`) is already satisfied by the reservation-time
+issuance, and the `committed ≥ allocated ≥ issued ≥ redeemed` invariant holds.
+
+### 3.2 Two field values
+
+- `Redemption.method` gains `agent_handover`. Verified in prod: there are **zero
+  CHECK constraints** on `redemptions` and `reward_offers`, and `method` is a
+  plain `STRING(24)` whose allowed set lives only in a column comment
+  (`models/Redemption.js:23`). So this is additive and free.
+- `RewardOffer.fundingSource` gains `agent` (today `partner|mktr|shared`,
+  `models/RewardOffer.js:31`). Without it, consultant-funded spend is reported
+  as MKTR's or a partner's.
+
+### 3.3 The partner placeholder
+
+`RewardOffer.partnerOrganisationId` is `allowNull: false`, but there is no
+partner. Recommendation: ONE reusable placeholder org ("Consultant-funded (no
+partner)") for all self-funded rewards.
+
+Explicitly rejected: creating "NTUC FairPrice" as a real `PartnerOrganisation`.
+Redeem Ops would surface it as a managed partner with stages, tasks, cadences
+and assignment queues it must not have.
+
+### 3.4 Quota
+
+`allocatedQuantity` is set nominally high and ignored. MKTR is not rationing
+something the consultant buys. (The allocation gate in `issueForProspect` still
+runs; it just never binds.)
+
+### 3.5 Delivery plumbing the handover receipt needs (round 1 review)
+
+A handover receipt is a THIRD delivery kind and the engine does not know it:
+
+- `queueDelivery` routes on kind at `entitlementService.js:205` and again in the
+  reconciler at `:964` — `kind === 'voucher' ? notifyUnlock : kind ===
+  'boost_receipt' ? notifyBoostReceipt : notifyReservation`. Anything unknown
+  falls through to the RESERVATION sender, so a handover receipt would silently
+  send the "here is your pass" email and log as a pass.
+- `reconcileMissedDeliveries` (`entitlementService.js:946`) sweeps only
+  `status: ['eligible','issued']`. A terminal `redeemed` handover whose receipt
+  failed would NEVER be retried. Either widen that sweep for this case or accept
+  (and document) that handover receipts are best-effort.
+- Consultant-facing copy hard-codes the voucher story and would lie:
+  `lyfeEntitlementUnlock.js:98-99` ("the customer has been emailed their
+  voucher" / "share the customer's pass link"), `externalEntitlements.js:266`,
+  and `RedemptionsPage.jsx:205-206` ("email with QR sent to the customer").
+
+### 3.6 Status readers that must be checked
+
+Collapsing to `redeemed` changes what these see. Reviewed, and believed correct
+as-is — but the implementation must confirm each:
+
+- `cancelEntitlement:820` and `cancelLiveEntitlementsForProspectTx:1166` accept
+  only `['eligible','issued']`. A handed-over voucher becomes uncancellable —
+  which is RIGHT (you cannot un-hand-over a physical voucher), and matches how a
+  real redemption already behaves.
+- `erasureService.js:466` treats `['eligible','issued']` as live and cancels
+  them; a `redeemed` row is redacted but not cancelled — also correct.
+- `externalEntitlements.js:203-213` falls back to the latest terminal row when
+  no live one exists, so the consultant card still shows it. No break.
+- `entitlementPresentState.js:14` / `rewardClaim.js:135` change the displayed
+  state from "unlocked" to "redeemed" — intended.
+
+## 4. Deliberately NOT in scope
+
+- **Serial capture at handover.** MKTR does not administer the vouchers.
+- **Per-consultant custody / stock assignment.** The inventory ledger has no
+  custodian dimension (`RewardInventoryEvent` has no `agentId`) and is not
+  gaining one.
+- **Creating the Fairprice activation itself.** That is the moment this goes
+  live to 100 real leads and stays a human decision.
+
+## 4b. Round-2 review findings (Codex gpt-5.6-sol xhigh; each re-verified by hand)
+
+**BLOCKER — the button path's replay breaks.** `unlockEntitlement`'s
+`prospectId` lookup filters `status: ['eligible','issued']`
+(`entitlementService.js:457`). Once a physical handover is `redeemed`, a retry
+finds nothing and throws 404 at `:461` — *before* the `['issued','redeemed']`
+replay carve-out at `:476`. A consultant double-tapping "handed over" gets
+"Entitlement not found". (The SCAN path is unaffected: it looks up by
+`presentationTokenHash` with no status filter, so it reaches the carve-out.)
+Fix: keep the live-first query, then fall back to the latest REDEEMED physical
+handover. Do not just add `redeemed` to the first query — that could mask a
+newer live entitlement.
+
+**HIGH — readers §3.6 missed.**
+- `resendDelivery` maps kind as `eligible→pass : issued→voucher : null`, then
+  throws 409 on null (`entitlementService.js:700-702`) — a handover receipt can
+  never be resent.
+- Console `canShare` suppresses resend for redeemed (`RedemptionsPage.jsx:390`),
+  and `deliveryStatus` shows nothing when a redeemed row has no receipt
+  (`RedemptionsPage.jsx:90-91`).
+- **The CAPI sweep already selects `status: 'redeemed'`**
+  (`redemptionOutcomeService.js:180-186`). So handovers get CAPI'd whether or
+  not we fire it inline — this path is NOT CAPI-free, and the choice is only
+  *when*, not *whether*.
+
+**HIGH — forbid `physical_voucher` + `unlockPolicy: 'on_capture'`.** That combo
+mints a voucher token and sends voucher delivery at capture
+(`entitlementService.js:309-327`, `:367-390`), bypassing handover entirely. Add
+activation validation requiring `agent_unlock` for physical offers.
+
+**HIGH — mis-tap correction is undefined.** Void marks the redemption reversed
+and cancels the entitlement but does NOT decrement `redeemedQuantity`,
+`redeemedCount`, or issuance (`redemptionService.js:255-276`). A mis-tapped
+handover would leave funnel truth inflated. Needs a reason-gated correction that
+reverses both redemption and reservation accounting in one transaction.
+
+**MEDIUM — completeness.** The handover `Redemption` must supply the NOT NULL
+`rewardOfferId`, `activationId`, `partnerOrganisationId`
+(`models/Redemption.js:18-20`) — which is precisely why the placeholder partner
+org in §3.3 is mandatory, not cosmetic. `fundingSource` must also be added to
+the Joi allowlist (`controllers/redeemOps/rewardsController.js:22`), and the new
+receipt kind to the console noun map (`RedemptionsPage.jsx:43`).
+
+### Verdict
+Core `eligible → redeemed` design is sound; **not safe to implement until the
+blocker and the four HIGH items are addressed.**
+
+## 5. Questions for the reviewer — ANSWERED (round 2)
+
+1. **Direct `eligible → redeemed` inside `unlockEntitlement`.** Do not call
+   `redemptionService.complete()` — it requires `issued` (`:184`). Extract a
+   shared transaction-level accounting helper and call it inside the unlock
+   transaction after the conditional update.
+2. **Yes, fire CAPI** — and deliberately, since the sweep will fire it anyway.
+   Dispatch post-commit and on redeemed replay; the deterministic event ID makes
+   it idempotent (`redemptionOutcomeService.js:132-145`).
+3. **Yes, via reason-gated Void — not draw undo.** Draw undo is a
+   restoration-free `issued → eligible` (`entitlementService.js:589-630`), which
+   is the wrong shape here.
+4. **Reuse the existing offer read** at `entitlementService.js:514`; it already
+   loads `fulfilmentMethod`. Evaluate the physical branch only when `!drawCtx`,
+   preserving draw priority.
+5. **`Redemption.method`,** not a new `RedemptionEvent.type`. Keep the event
+   `redeemed` with `{method, locationId}` metadata
+   (`redemptionService.js:231-234`); a new type fragments redemption reporting.
+
+## 6. Original questions (superseded by §5 above)
+
+1. Is collapsing `eligible → redeemed` inside `unlockEntitlement` the right
+   seam, or should the physical path call `redemptionService.complete`
+   internally to reuse its accounting? (`complete` requires `status === 'issued'`
+   at `redemptionService.js:184`, so reuse implies a two-step commit or a new
+   entry point.)
+2. `redemptionService.complete` fires a Meta CAPI conversion (`fireCapi()`).
+   The proposed in-`unlockEntitlement` path would bypass it. Should a handover
+   fire the same down-funnel event? It is a real conversion.
+3. `undoSessionUnlock` exists for draw rails. Does a mis-tapped handover need an
+   undo, given it now writes a terminal `redeemed` + a `Redemption` row?
+4. Does branching on `fulfilmentMethod` inside `unlockEntitlement` require an
+   extra `RewardOffer` read, or can it ride the existing
+   `d.RewardOffer.findByPk(entitlement.rewardOfferId)` at
+   `entitlementService.js:514`?
+5. Is `agent_handover` better modelled as a `Redemption.method`, or as a
+   distinct `RedemptionEvent.type`, given `writeEvent(..., type: 'redeemed')`
+   already carries `metadata: { method, locationId }`?

--- a/src/pages/redeemops/RedemptionsPage.jsx
+++ b/src/pages/redeemops/RedemptionsPage.jsx
@@ -40,7 +40,10 @@ function parseRewardQr(raw) {
   return null;
 }
 
-const RECEIPT_NOUNS = { voucher: 'Voucher', boost_receipt: 'Boost receipt', pass: 'Pass' };
+const RECEIPT_NOUNS = {
+  voucher: 'Voucher', boost_receipt: 'Boost receipt', pass: 'Pass',
+  handover_receipt: 'Handover confirmation',
+};
 
 /** Per-row delivery truth from the receipts the backend now records. */
 function deliveryStatus(e) {
@@ -199,11 +202,15 @@ export default function RedemptionsPage() {
           ? (data?.already
             ? 'Session already recorded'
             : `Session recorded — ×${data.drawBoost.multiplier} confirmed${data?.emailQueued ? ' (receipt emailed)' : ''}`)
-          : data?.already
-            ? 'Already unlocked'
-            : data?.emailQueued
-              ? 'Voucher unlocked — email with QR sent to the customer'
-              : 'Voucher unlocked — no email on file; use Copy link to share the voucher'
+          : data?.handover
+            ? (data?.already
+              ? 'Already recorded as handed over'
+              : `Handover recorded${data?.emailQueued ? ' — confirmation emailed' : ' — no email on file'}`)
+            : data?.already
+              ? 'Already unlocked'
+              : data?.emailQueued
+                ? 'Voucher unlocked — email with QR sent to the customer'
+                : 'Voucher unlocked — no email on file; use Copy link to share the voucher'
       );
       setActivateToken(null);
       setVerified(null);


### PR DESCRIPTION
Some campaign rewards are physical vouchers the **consultant buys with their own money** and administers themselves. MKTR holds no stock and sees no serial, so the only fact worth recording is: *this lead was promised a reward, and a consultant confirmed handing it over.*

Plan: `docs/plans/physical-voucher-handover.md` (included, with both review rounds).

## The problem

`physical_voucher` was already a legal `fulfilmentMethod` but **inert** — nothing branched on it. The lifecycle assumed a partner would redeem the token we minted, and FairPrice will never call our redemption API. So a handed-over voucher:

- parked at `issued` **forever** — `expireReservations` only sweeps `eligible`, so it didn't even age out;
- left every redemption funnel reading 0%;
- got the lead emailed a QR and a claim link for a voucher already in their hand.

## The change

When the offer is physical and no draw rail applies, the consultant's unlock goes `eligible → redeemed` in **one transaction** with a `Redemption` (`method: 'agent_handover'`, `actorType: 'agent'`, no location), and the lead gets a plain confirmation with no token and no link.

**Only the redeemed side of inventory moves.** Issuance is consumed at *reservation*, and unlock has never touched inventory — an earlier draft of this recorded issuance again at handover and would have double-counted it. Caught in review.

## What review caught (both rounds re-verified by hand)

**BLOCKER, created by this design:** `unlockEntitlement`'s `prospectId` lookup filters `['eligible','issued']`, so once a handover was terminal a consultant's double-tap 404'd *before* reaching the replay carve-out. Fixed with a second, physical-only fallback query rather than widening the first — adding `redeemed` there would let an old handover outrank a newer **live** reservation on `createdAt` and hijack a legitimate unlock. Tested both ways.

Also fixed:
- **Delivery kinds are now an exhaustive map.** The old ternaries ended in `: d.notifyReservation`, so any unrecognised kind was silently delivered as a reservation pass. Unknown now sends nothing and logs.
- **Resend accepts a handover receipt** (rotating nothing — no credential exists). It's the *only* recovery path for one, since `reconcileMissedDeliveries` sweeps just `eligible`/`issued`. Its stale reservation expiry no longer blocks it.
- **`physical` + `on_capture` fails closed** — that combo mints and mails a voucher token at signup, skipping handover entirely.
- **CAPI fires on handover.** The sweep already selects every `redeemed` row, so the event was never avoidable; this just makes it prompt, and the deterministic event id dedupes.
- **Consultant copy** stopped claiming "email with QR sent" for paper.

## Mis-tap reversal

Voiding a handover now returns **both** units (redeemed, then issued — that order is load-bearing, `reverseIssued` guards against `redeemedQuantity`).

This is the one redemption that can be reversed *because it never happened*: a consultant can tap "handed over" with the voucher still in their pocket, and unlike a digital voucher the lead holds no artefact to contradict us — the record is the only truth. A partner redemption stays untouched; that event really happened.

## Verification

- New suite `redeemOpsPhysicalHandover.test.js` — 10 tests on real Postgres: terminal transition + accounting, ledger shape, the double-tap replay, live-outranks-handover, digital-not-treated-as-handover, receipt routing (asserts `notifyReservation` is **not** called), the `on_capture` guard, and both reversal directions.
- 123 top-level suites (2482 tests), 106 unit suites (1943), 160 frontend files (2044). Lint clean.

## Deliberately NOT included

- **No serial capture, no custody sub-ledger** — MKTR doesn't administer these vouchers.
- **No activation created for the \$10 Fairprice campaign.** That's the moment this goes live to 100 real leads, and it stays a human decision. Note it needs a placeholder partner org: `Redemption.partnerOrganisationId` is NOT NULL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eL2XE1J1A6eF3j3jTJqbm