### PR TITLE
feat(discover): describing what you want IS the search

### DIFF
--- a/src/pages/redeemops/DiscoverPage.jsx
+++ b/src/pages/redeemops/DiscoverPage.jsx
@@ -73,7 +73,16 @@ export default function DiscoverPage() {
   const [filter, setFilter] = useState('all');
   const [sort, setSort] = useState('followers');
   const [aiDesc, setAiDesc] = useState('');
-  const [showAi, setShowAi] = useState(false);
+  // Search mode. AI is the DEFAULT way to search: describing who you want finds
+  // better niches than guessing Google's own phrasing, and the derived terms
+  // stay visible + editable below so nothing is spent on a black box.
+  //
+  // null = "operator hasn't chosen", which matters because `aiEnabled` arrives
+  // asynchronously with the runs list — seeding useState from it would latch
+  // the first (undefined → false) render into keyword mode forever. Resolving
+  // at render instead means the default follows the flag whenever it lands,
+  // and an explicit choice still wins. AI off ⇒ always keyword mode.
+  const [modeChoice, setModeChoice] = useState(null);
   // AI-suggested Google categories (Maps) — fill the pre-search filter AND arm a
   // one-time post-results facet cleanup for the run they were searched into.
   const [aiCats, setAiCats] = useState([]);
@@ -95,6 +104,9 @@ export default function DiscoverPage() {
   const resultsQuota = quota?.resultsRemaining != null;
   const igEnabled = listQuery.data?.igEnabled === true;
   const aiEnabled = listQuery.data?.aiEnabled === true;
+  // Keyword mode is the unconditional fallback when AI isn't configured — the
+  // page must never depend on an LLM being reachable to run a search.
+  const aiMode = aiEnabled && (modeChoice ?? 'ai') === 'ai';
   const isIg = form.provider === IG_PROVIDER;
   const territoriesQuery = useQuery({
     queryKey: ['redeem-ops', 'territories'],
@@ -380,41 +392,67 @@ export default function DiscoverPage() {
             )}
             <div className="space-y-1.5">
               <div className="flex items-center justify-between gap-2">
-                <Label htmlFor="disc-terms">{isIg ? 'Hashtags' : 'Search phrases'}</Label>
+                <Label htmlFor={aiMode ? 'disc-ai-desc' : 'disc-terms'}>
+                  {aiMode
+                    ? 'Describe who you\'re looking for'
+                    : (isIg ? 'Hashtags' : 'Search phrases')}
+                </Label>
                 {aiEnabled && (
-                  <button type="button" onClick={() => setShowAi((v) => !v)} aria-expanded={showAi}
+                  <button type="button" onClick={() => setModeChoice(aiMode ? 'terms' : 'ai')}
                     className="ro-link inline-flex items-center gap-1 text-[12.5px] font-semibold">
-                    <Sparkles className="w-3.5 h-3.5" aria-hidden="true" />{showAi ? 'Hide AI' : 'Get AI suggestions'}
+                    {aiMode
+                      ? <>Type {isIg ? 'hashtags' : 'phrases'} myself</>
+                      : <><Sparkles className="w-3.5 h-3.5" aria-hidden="true" />Describe it instead</>}
                   </button>
                 )}
               </div>
-              <Input id="disc-terms" value={form.adhoc}
-                placeholder={isIg ? 'sgnails, biabsg, homebasednailssg' : 'nail salon, taekwondo, kopitiam'}
-                onChange={(e) => { setForm((f) => ({ ...f, adhoc: e.target.value })); if (aiCats.length) setAiCats([]); }}
-                onKeyDown={(e) => { if (e.key === 'Enter' && canSearch) runSearch(); }} />
-              <p className="text-[12px] m-0" style={{ color: 'var(--ro-text-3)' }}>
-                {isIg
-                  ? 'Each hashtag is scanned on Instagram. The # is optional. Separate with commas.'
-                  : 'Each phrase is sent to Google Maps as its own search. Separate with commas.'}
-              </p>
-              {aiEnabled && showAi && (
-                <div className="flex items-center gap-2 mt-1 rounded-xl px-3 py-1.5"
-                  style={{ background: 'var(--ro-subtle)', border: '1px dashed var(--ro-border)' }}>
-                  <Sparkles className="w-4 h-4 shrink-0" aria-hidden="true" style={{ color: 'var(--ro-text-2)' }} />
-                  <Input value={aiDesc}
-                    placeholder={isIg
-                      ? 'Describe the niche — e.g. "home-based bakers"'
-                      : 'Describe who you\'re looking for — e.g. "after-school activities for kids"'}
-                    aria-label="Describe what you want to find"
-                    className="h-8 border-0 bg-transparent shadow-none focus-visible:ring-0 px-0"
-                    onChange={(e) => setAiDesc(e.target.value)}
-                    onKeyDown={(e) => { if (e.key === 'Enter' && canSuggest) suggestMutation.mutate(); }} />
-                  <Button variant="ghost" size="sm" className="shrink-0 font-semibold" disabled={!canSuggest}
-                    onClick={() => suggestMutation.mutate()}>
-                    {suggestMutation.isPending ? 'Suggesting…' : 'Suggest'}
-                  </Button>
-                </div>
+
+              {aiMode && (
+                <>
+                  <div className="flex items-center gap-2 rounded-xl px-3 py-1.5"
+                    style={{ background: 'var(--ro-subtle)', border: '1px solid var(--ro-border)' }}>
+                    <Sparkles className="w-4 h-4 shrink-0" aria-hidden="true" style={{ color: 'var(--ro-text-2)' }} />
+                    <Input id="disc-ai-desc" value={aiDesc}
+                      placeholder={isIg
+                        ? 'e.g. home-based bakers who post their menu'
+                        : 'e.g. after-school activities for primary school kids'}
+                      className="h-8 border-0 bg-transparent shadow-none focus-visible:ring-0 px-0"
+                      onChange={(e) => setAiDesc(e.target.value)}
+                      onKeyDown={(e) => { if (e.key === 'Enter' && canSuggest) suggestMutation.mutate(); }} />
+                    <Button variant="ghost" size="sm" className="shrink-0 font-semibold" disabled={!canSuggest}
+                      onClick={() => suggestMutation.mutate()}>
+                      {suggestMutation.isPending ? 'Thinking…' : 'Find terms'}
+                    </Button>
+                  </div>
+                  <p className="text-[12px] m-0" style={{ color: 'var(--ro-text-3)' }}>
+                    Plain English. We turn it into {isIg ? 'hashtags' : 'Google Maps phrases'} you can check before spending anything.
+                  </p>
+                </>
               )}
+
+              {/* The terms that ACTUALLY run stay visible and editable in both
+                  modes — a search spends real Apify budget and result quota, so
+                  it must never be a black box the operator can't inspect. */}
+              <div className={aiMode ? 'pt-1' : ''}>
+                {aiMode && (
+                  <Label htmlFor="disc-terms" className="text-[12px] font-semibold"
+                    style={{ color: 'var(--ro-text-2)' }}>
+                    {isIg ? 'Hashtags' : 'Search phrases'} to run
+                  </Label>
+                )}
+                <Input id="disc-terms" value={form.adhoc}
+                  className={aiMode ? 'mt-1' : ''}
+                  placeholder={aiMode
+                    ? (isIg ? 'Describe a niche above, or type hashtags here' : 'Describe who you want above, or type phrases here')
+                    : (isIg ? 'sgnails, biabsg, homebasednailssg' : 'nail salon, taekwondo, kopitiam')}
+                  onChange={(e) => { setForm((f) => ({ ...f, adhoc: e.target.value })); if (aiCats.length) setAiCats([]); }}
+                  onKeyDown={(e) => { if (e.key === 'Enter' && canSearch) runSearch(); }} />
+                <p className="text-[12px] m-0 mt-1" style={{ color: 'var(--ro-text-3)' }}>
+                  {isIg
+                    ? 'Each hashtag is scanned on Instagram. The # is optional. Separate with commas.'
+                    : 'Each phrase is sent to Google Maps as its own search. Separate with commas.'}
+                </p>
+              </div>
             </div>
 
             <div className="grid gap-3 md:grid-cols-[1fr_120px_auto] md:items-end mt-4">

--- a/src/pages/redeemops/__tests__/DiscoverPage.test.jsx
+++ b/src/pages/redeemops/__tests__/DiscoverPage.test.jsx
@@ -110,10 +110,31 @@ describe('DiscoverPage', () => {
     expect(screen.getByText('Popular areas')).toBeInTheDocument();
   });
 
-  it('hides the AI-assist row unless the backend reports aiEnabled', async () => {
+  it('falls back to keyword search when the backend reports no aiEnabled', async () => {
     renderPage(); // beforeEach response has no aiEnabled
     await screen.findByRole('button', { name: /Search Google Maps/i }); // page settled
-    expect(screen.queryByLabelText('Describe what you want to find')).not.toBeInTheDocument();
+    // No LLM configured must never leave the page unable to run a search.
+    expect(screen.queryByLabelText(/Describe who you're looking for/i)).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/nail salon, taekwondo/)).toBeInTheDocument();
+  });
+
+  it('AI is the DEFAULT mode once the backend reports aiEnabled — no reveal needed', async () => {
+    api.listDiscoveryRuns.mockResolvedValue({ runs: [], quota, aiEnabled: true });
+    renderPage();
+    // Present on first paint, not behind a "Get AI suggestions" toggle. The
+    // flag arrives async with the runs list, so this also pins that the default
+    // follows it rather than latching the first (undefined) render.
+    expect(await screen.findByLabelText(/Describe who you're looking for/i)).toBeInTheDocument();
+    // ...and the terms that will actually run are still on screen and editable.
+    expect(screen.getByLabelText(/Search phrases to run/i)).toBeInTheDocument();
+  });
+
+  it('an operator can still switch to typing phrases themselves', async () => {
+    api.listDiscoveryRuns.mockResolvedValue({ runs: [], quota, aiEnabled: true });
+    renderPage();
+    await userEvent.click(await screen.findByRole('button', { name: /Type phrases myself/i }));
+    expect(screen.queryByLabelText(/Describe who you're looking for/i)).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/nail salon, taekwondo/)).toBeInTheDocument();
   });
 
   it('AI suggest populates the terms field and never starts a paid search', async () => {
@@ -123,16 +144,17 @@ describe('DiscoverPage', () => {
       categories: ['Martial arts school', 'Gym'],
     });
     renderPage();
-    // AI is now a reveal — open it first.
-    await userEvent.click(await screen.findByRole('button', { name: /Get AI suggestions/i }));
-    const aiInput = await screen.findByLabelText('Describe what you want to find');
+    // AI is the DEFAULT mode — the description box is there without revealing it.
+    const aiInput = await screen.findByLabelText('Describe who you\'re looking for');
     await userEvent.type(aiInput, 'martial arts for kids');
-    await userEvent.click(screen.getByRole('button', { name: 'Suggest' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Find terms' }));
     await waitFor(() => expect(api.suggestDiscoveryTerms).toHaveBeenCalledWith({
       description: 'martial arts for kids',
       provider: 'google_maps',
     }));
-    expect(screen.getByPlaceholderText(/nail salon, taekwondo/)).toHaveValue(
+    // The terms that will actually run stay visible and editable in AI mode —
+    // a search spends Apify budget, so it is never a black box.
+    expect(screen.getByLabelText(/Search phrases to run/i)).toHaveValue(
       'taekwondo, martial arts school, kids karate',
     );
     // categories are pre-filled into the always-visible Restrict-categories field
@@ -156,9 +178,8 @@ describe('DiscoverPage', () => {
       ],
     });
     renderPage();
-    await userEvent.click(await screen.findByRole('button', { name: /Get AI suggestions/i }));
-    await userEvent.type(await screen.findByLabelText('Describe what you want to find'), 'robotics for kids');
-    await userEvent.click(screen.getByRole('button', { name: 'Suggest' }));
+    await userEvent.type(await screen.findByLabelText('Describe who you\'re looking for'), 'robotics for kids');
+    await userEvent.click(screen.getByRole('button', { name: 'Find terms' }));
     await screen.findByDisplayValue('children robotics, coding enrichment');
     await userEvent.type(screen.getByPlaceholderText('Neighbourhood or district…'), 'All Singapore');
     await userEvent.click(screen.getByRole('button', { name: /Search Google Maps/i }));


### PR DESCRIPTION
AI was a reveal — a "Get AI suggestions" link that opened a dashed box — so the default way to search Discover was still guessing at Google's own phrasing.

Describing the niche finds sub-niches an operator wouldn't think to type, and the run's result budget is **shared across terms**, so a handful of diverse phrases beats one broad guess. That should be the front door, not an opt-in.

## What changed

The plain-language box is now the primary input, and **the terms it derives stay visible and editable right below it**. That part is deliberate: a search spends Apify budget and result quota, so what actually runs can never be a black box the operator can't inspect or correct. Nothing auto-runs either — suggest, review, then search, exactly as before.

## Two ways out, because a default isn't a cage

- **"Type phrases myself"** switches to the old keyword-first form.
- Keyword mode is **forced** whenever the backend reports `aiEnabled: false` — the page must never need an LLM to be reachable in order to run a search.

## One subtle bit

Mode is resolved at render from `modeChoice ?? 'ai'` rather than seeded into `useState`, because `aiEnabled` arrives asynchronously with the runs list — seeding would latch the first (`undefined` → false) render into keyword mode permanently. An explicit operator choice still wins over the default. There's a test pinning that the default follows the flag when it lands.

## Verification

17 tests in `DiscoverPage.test.jsx` (3 new: the default, the AI-off fallback, and the manual switch). Full frontend suite 160 files / 2046 tests. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eL2XE1J1A6eF3j3jTJqbm