### PR TITLE
feat(redeem-ops): claim a whole page of businesses at once

### DIFF
--- a/backend/src/controllers/redeemOps/partnersController.js
+++ b/backend/src/controllers/redeemOps/partnersController.js
@@ -79,6 +79,27 @@ export const claimPartner = asyncHandler(async (req, res) => {
   res.json({ success: true, message: 'Business claimed', data: result });
 });
 
+/**
+ * Multi-select claim. Answers 200 with a per-row breakdown rather than a 409:
+ * losing a race on 3 of 10 is a normal outcome the console reports, not a
+ * failed request that should discard the 7 that worked.
+ */
+export const claimPartnersBulk = asyncHandler(async (req, res) => {
+  const schema = Joi.object({
+    partnerIds: Joi.array().items(Joi.string().uuid()).min(1).max(100).required(),
+  });
+  const body = validateBody(schema, req.body);
+  const result = await claimService.claimPartnersBulk(body.partnerIds, req.user, req.id);
+  const n = result.claimed.length;
+  res.json({
+    success: true,
+    message: n === body.partnerIds.length
+      ? `${n} business${n === 1 ? '' : 'es'} claimed`
+      : `${n} of ${body.partnerIds.length} claimed`,
+    data: result,
+  });
+});
+
 export const releasePartner = asyncHandler(async (req, res) => {
   await claimService.releasePartner(req.params.id, req.user, req.body?.reason || null, req.id);
   res.json({ success: true, message: 'Business released' });

--- a/backend/src/routes/redeemOpsPartners.js
+++ b/backend/src/routes/redeemOpsPartners.js
@@ -25,6 +25,9 @@ router.get('/partners/:id', requireRedeemOps('partners.view'), ctrl.getPartner);
 router.put('/partners/:id', requireRedeemOps('partners.edit'), ctrl.updatePartner);
 
 // Ownership
+// Bulk claim sits BEFORE the :id routes — 'bulk-claim' would otherwise match
+// as an :id and 404 on a uuid lookup.
+router.post('/partners/bulk-claim', requireRedeemOps('partners.claim'), ctrl.claimPartnersBulk);
 router.post('/partners/:id/claim', requireRedeemOps('partners.claim'), ctrl.claimPartner);
 router.post('/partners/:id/release', requireRedeemOps('partners.release'), ctrl.releasePartner);
 router.post('/partners/:id/assign', requireRedeemOps('partners.reassign'), ctrl.assignPartner);

--- a/backend/src/services/redeemOps/claimService.js
+++ b/backend/src/services/redeemOps/claimService.js
@@ -4,6 +4,10 @@ import { logger } from '../../utils/logger.js';
 import { makeRedeemOpsAuditService } from './auditService.js';
 import { fireCadenceHook } from './cadenceHooks.js';
 
+// Multi-select cap. Each row is its own transaction, so a huge batch would hold
+// a request open for a long time; the console's page size is well under this.
+const BULK_CLAIM_MAX = 100;
+
 /**
  * Business claiming / ownership (docs/redeem-ops/ERD.md §4.1, brief §15).
  *
@@ -88,6 +92,55 @@ export function makeClaimService(overrides = {}) {
     });
   }
 
+  /**
+   * Claim many at once (the Partners list's multi-select).
+   *
+   * Each row gets its OWN transaction, deliberately. Bulk claiming is
+   * partially-successful by nature — someone else may have taken one of them a
+   * second ago — and a single shared transaction would roll back nine good
+   * claims because of one lost race. The per-row conditional UPDATE is still
+   * the same atomic gate, so nothing here can double-claim.
+   *
+   * Reports per row rather than throwing, so the console can say "claimed 7,
+   * 3 already taken" and name who took them. An unexpected error on one row is
+   * caught and reported as a failure, never allowed to abandon the rest.
+   */
+  async function claimPartnersBulk(partnerIds, user, requestId = null) {
+    const ids = [...new Set((partnerIds || []).map(String))];
+    if (!ids.length) throw new AppError('Select at least one business to claim', 400);
+    if (ids.length > BULK_CLAIM_MAX) {
+      throw new AppError(`Claim up to ${BULK_CLAIM_MAX} businesses at a time`, 400);
+    }
+
+    const claimed = [];
+    const failed = [];
+    for (const partnerId of ids) {
+      try {
+        const row = await d.sequelize.transaction((t) => claimPartnerTx(partnerId, user, t, 'bulk_claim'));
+        if (row) {
+          claimed.push(partnerId);
+          continue;
+        }
+        const state = await conflictPayload(partnerId);
+        failed.push({
+          id: partnerId,
+          reason: !state ? 'not_found'
+            : state.claimedBy ? 'already_claimed'
+              : state.archived ? 'archived'
+                : state.merged ? 'merged' : 'unavailable',
+          claimedBy: state?.claimedBy || null,
+        });
+      } catch (err) {
+        d.logger.warn('redeem_ops.partner.bulk_claim_row_failed', { partnerId, error: err?.message });
+        failed.push({ id: partnerId, reason: 'error', claimedBy: null });
+      }
+    }
+    d.logger.info('redeem_ops.partner.bulk_claimed', {
+      requestId, actorUserId: user.id, requested: ids.length, claimed: claimed.length,
+    });
+    return { claimed, failed };
+  }
+
   /** Owner releases their claim back to the pool (row-level own check here). */
   async function releasePartner(partnerId, user, reason = null, requestId = null) {
     return d.sequelize.transaction(async (t) => {
@@ -159,10 +212,11 @@ export function makeClaimService(overrides = {}) {
     });
   }
 
-  return { claimPartner, claimPartnerTx, releasePartner, assignPartner };
+  return { claimPartner, claimPartnerTx, claimPartnersBulk, releasePartner, assignPartner };
 }
 
 const _default = makeClaimService();
 export const claimPartner = _default.claimPartner;
+export const claimPartnersBulk = _default.claimPartnersBulk;
 export const releasePartner = _default.releasePartner;
 export const assignPartner = _default.assignPartner;

--- a/backend/test/redeemOpsPartners.test.js
+++ b/backend/test/redeemOpsPartners.test.js
@@ -123,6 +123,57 @@ describe('claiming (concurrency-safe)', () => {
     expect(row.pipelineStage).toBe('NEW'); // ownership is not pipeline progress
   });
 
+  test('BULK claim: partial success — the taken one never rolls back the rest', async () => {
+    const free = [];
+    for (let i = 0; i < 3; i += 1) {
+      const r = await createPartner(admin.token, { tradingName: `Bulk Free ${i} ${randomBytes(3).toString('hex')}` });
+      free.push(r.body.data.partner.id);
+    }
+    // One of the batch is already owned (partnerId, claimed above) — a shared
+    // transaction would have discarded the three good claims with it.
+    const res = await request(app)
+      .post('/api/redeem-ops/partners/bulk-claim')
+      .set(auth(execB.token))
+      .send({ partnerIds: [...free, partnerId] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.claimed.sort()).toEqual([...free].sort());
+    expect(res.body.data.failed).toHaveLength(1);
+    expect(res.body.data.failed[0]).toMatchObject({ id: partnerId, reason: 'already_claimed' });
+    expect(res.body.data.failed[0].claimedBy).toBeTruthy(); // says WHO has it
+    expect(res.body.message).toMatch(/3 of 4/);
+
+    for (const id of free) {
+      const row = await PartnerOrganisation.findByPk(id);
+      expect(row.ownerUserId).toBe(execB.user.id);
+      expect(row.availability).toBe('owned');
+    }
+  });
+
+  test('BULK claim is concurrency-safe: two reps, one row, exactly one owner', async () => {
+    const r = await createPartner(admin.token, { tradingName: `Bulk Race ${randomBytes(3).toString('hex')}` });
+    const id = r.body.data.partner.id;
+    const svc = makeClaimService();
+    const [a, b] = await Promise.all([
+      svc.claimPartnersBulk([id], execA.user),
+      svc.claimPartnersBulk([id], bdm.user),
+    ]);
+    const winners = [a, b].filter((x) => x.claimed.length === 1);
+    expect(winners).toHaveLength(1); // the conditional UPDATE still arbitrates
+    const row = await PartnerOrganisation.findByPk(id);
+    expect([execA.user.id, bdm.user.id]).toContain(row.ownerUserId);
+  });
+
+  test('BULK claim rejects an empty or oversized batch', async () => {
+    const empty = await request(app).post('/api/redeem-ops/partners/bulk-claim')
+      .set(auth(execB.token)).send({ partnerIds: [] });
+    expect(empty.status).toBe(400);
+    const huge = await request(app).post('/api/redeem-ops/partners/bulk-claim')
+      .set(auth(execB.token))
+      .send({ partnerIds: Array.from({ length: 101 }, () => '00000000-0000-4000-8000-000000000000') });
+    expect(huge.status).toBe(400);
+  });
+
   test('claiming an owned business over HTTP → 409', async () => {
     const res = await request(app)
       .post(`/api/redeem-ops/partners/${partnerId}/claim`)

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -158,6 +158,11 @@ export const redeemOpsApi = {
     const res = await apiClient.post(`/redeem-ops/partners/${id}/claim`, {});
     return res.data;
   },
+  /** Multi-select claim → { claimed: [id], failed: [{ id, reason, claimedBy }] }. */
+  async claimPartnersBulk(partnerIds) {
+    const res = await apiClient.post('/redeem-ops/partners/bulk-claim', { partnerIds });
+    return res.data;
+  },
   async releasePartner(id, reason) {
     const res = await apiClient.post(`/redeem-ops/partners/${id}/release`, { reason });
     return res.data;

--- a/src/pages/redeemops/PartnersList.jsx
+++ b/src/pages/redeemops/PartnersList.jsx
@@ -75,6 +75,9 @@ export default function PartnersList() {
   const [category, setCategory] = useState('all');
   const [page, setPage] = useState(1);
   const debouncedSearch = useDebounced(search);
+  // Multi-select for bulk actions. Ids only — the row objects are re-fetched
+  // constantly, and holding them would go stale the moment a claim lands.
+  const [selected, setSelected] = useState(() => new Set());
 
   const constants = useQuery({
     queryKey: ['redeem-ops', 'constants'],
@@ -153,6 +156,7 @@ export default function PartnersList() {
   // backend surface, works for the list sizes a 3-person team imports.
   const user = useAuthStore((st) => st.user);
   const canImport = hasCapability(user, 'partners.import');
+  const canClaim = hasCapability(user, 'partners.claim');
   const [importOpen, setImportOpen] = useState(false);
   const [importState, setImportState] = useState(null); // null | {running, done, total, created, skipped, failed, errors[]}
 
@@ -207,6 +211,56 @@ export default function PartnersList() {
   const partners = listQuery.data?.partners || [];
   const pagination = listQuery.data?.pagination;
   const stages = constants.data?.pipelineStages || [];
+
+  // Only unowned, live rows can be claimed — the same predicate the server's
+  // conditional UPDATE enforces, so the UI never offers what the API refuses.
+  const claimable = (p) => !p.ownerUserId && p.availability === 'available' && !p.archivedAt && !p.mergedIntoId;
+  const claimableIds = partners.filter(claimable).map((p) => p.id);
+  const selectedIds = [...selected];
+  // Selection mode: once anything is ticked, the whole row becomes the
+  // checkbox. Navigating away mid-selection would silently discard the
+  // selection, so in this mode a row click NEVER opens the detail page —
+  // Clear (or unticking the last row) hands normal clicking back.
+  const selectionMode = canClaim && selected.size > 0;
+  const allSelected = claimableIds.length > 0 && claimableIds.every((id) => selected.has(id));
+  const toggleOne = (id) => setSelected((prev) => {
+    const next = new Set(prev);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    return next;
+  });
+  const toggleAllOnPage = () => setSelected((prev) => {
+    // Scoped to THIS page's claimable rows — never a silent "select all 2,000".
+    const next = new Set(prev);
+    if (allSelected) claimableIds.forEach((id) => next.delete(id));
+    else claimableIds.forEach((id) => next.add(id));
+    return next;
+  });
+
+  const bulkClaimMutation = useMutation({
+    mutationFn: (ids) => redeemOpsApi.claimPartnersBulk(ids),
+    onSuccess: ({ data, message }) => {
+      const lost = data?.failed || [];
+      // Partial success is the NORMAL outcome — someone else may have taken one
+      // a second ago — so name what happened instead of a flat "done".
+      if (lost.length === 0) toast.success(message);
+      else {
+        const taken = lost.filter((f) => f.reason === 'already_claimed');
+        toast.warning(message, {
+          description: taken.length
+            ? `${taken.length} already claimed${taken[0].claimedBy ? ` (e.g. by ${taken[0].claimedBy.fullName})` : ''}.`
+            : `${lost.length} could not be claimed.`,
+        });
+      }
+      // Clear only what actually landed, so a retry keeps the ones that didn't.
+      setSelected((prev) => {
+        const next = new Set(prev);
+        (data?.claimed || []).forEach((id) => next.delete(id));
+        return next;
+      });
+      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partners'] });
+    },
+    onError: (err) => toast.error('Could not claim', { description: err.message }),
+  });
   const needsOverride = (duplicates?.exact?.length || 0) > 0;
 
   const partnerName = (p) => p.tradingName || p.brandName || p.legalName;
@@ -300,10 +354,34 @@ export default function PartnersList() {
             </p>
           )}
         </div>
+        {canClaim && selectedIds.length > 0 && (
+          <div role="status"
+            className="hidden md:flex items-center gap-3 px-5 py-2.5 border-t border-border"
+            style={{ background: 'var(--ro-subtle)' }}>
+            <span className="text-[13px] font-semibold">
+              <span className="tabular-nums">{selectedIds.length}</span> selected
+            </span>
+            <Button size="sm" className="font-semibold"
+              disabled={bulkClaimMutation.isPending}
+              onClick={() => bulkClaimMutation.mutate(selectedIds)}>
+              {bulkClaimMutation.isPending ? 'Claiming…' : 'Claim'}
+            </Button>
+            <button type="button" className="ro-link text-[12.5px] font-semibold"
+              onClick={() => setSelected(new Set())}>Clear</button>
+          </div>
+        )}
         <div className="hidden md:block overflow-x-auto">
           <table className="w-full text-sm border-collapse">
             <thead>
               <tr className="text-left" style={{ color: 'var(--ro-text-2)' }}>
+                {canClaim && (
+                  <th className="w-10 pl-5 pr-0 py-3">
+                    <input type="checkbox" aria-label="Select all claimable on this page"
+                      checked={allSelected} disabled={claimableIds.length === 0}
+                      onChange={toggleAllOnPage}
+                      className="w-4 h-4 align-middle cursor-pointer disabled:opacity-40" />
+                  </th>
+                )}
                 <th className="font-semibold text-[12.5px] px-5 py-3">Business</th>
                 <th className="font-semibold text-[12.5px] px-3 py-3">Category</th>
                 <th className="font-semibold text-[12.5px] px-3 py-3">Stage</th>
@@ -315,9 +393,33 @@ export default function PartnersList() {
               {partners.map((p) => (
                 <tr
                   key={p.id}
-                  className="cursor-pointer border-t border-border hover:bg-[var(--ro-subtle)] transition-colors"
-                  onClick={() => navigate(`/redeem-ops/partners/${p.id}`)}
+                  aria-selected={selectionMode ? selected.has(p.id) : undefined}
+                  className={`border-t border-border transition-colors ${
+                    selectionMode && !claimable(p)
+                      ? 'cursor-default opacity-60'
+                      : 'cursor-pointer hover:bg-[var(--ro-subtle)]'
+                  }`}
+                  style={selected.has(p.id) ? { background: 'var(--ro-subtle)' } : undefined}
+                  onClick={() => {
+                    // In selection mode an unclaimable row is inert: it cannot be
+                    // ticked, and opening it would throw away the selection.
+                    if (!selectionMode) { navigate(`/redeem-ops/partners/${p.id}`); return; }
+                    if (claimable(p)) toggleOne(p.id);
+                  }}
                 >
+                  {canClaim && (
+                    // stopPropagation: the row itself navigates to the detail
+                    // page, and selecting must never take you off the list.
+                    <td className="w-10 pl-5 pr-0 py-2.5" onClick={(e) => e.stopPropagation()}>
+                      <input type="checkbox"
+                        aria-label={`Select ${partnerName(p)}`}
+                        checked={selected.has(p.id)}
+                        disabled={!claimable(p)}
+                        title={claimable(p) ? undefined : 'Already owned — release it first'}
+                        onChange={() => toggleOne(p.id)}
+                        className="w-4 h-4 align-middle cursor-pointer disabled:opacity-30" />
+                    </td>
+                  )}
                   <td className="px-5 py-2.5">
                     <span className="flex items-center gap-3 min-w-0">
                       <RoAvatar name={partnerName(p)} size={36} />

--- a/src/pages/redeemops/__tests__/PartnersList.selection.test.jsx
+++ b/src/pages/redeemops/__tests__/PartnersList.selection.test.jsx
@@ -1,0 +1,151 @@
+/**
+ * PartnersList — multi-select and bulk claim.
+ *
+ * The behaviours worth pinning: only claimable rows are selectable (the UI must
+ * never offer what the server's conditional UPDATE would refuse), selection
+ * mode turns the whole row into the checkbox so a stray click can't navigate
+ * away and silently discard the selection, and a partially-successful claim
+ * reports what actually happened instead of a flat "done".
+ * redeemOpsApi is fully mocked — no network.
+ */
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+const api = vi.hoisted(() => ({
+  listPartners: vi.fn(),
+  getConstants: vi.fn(),
+  listCategories: vi.fn(),
+  claimPartnersBulk: vi.fn(),
+}));
+vi.mock('@/api/redeemOps', () => ({ redeemOpsApi: api }));
+
+const toastMock = vi.hoisted(() => {
+  const t = vi.fn();
+  t.success = vi.fn();
+  t.error = vi.fn();
+  t.warning = vi.fn();
+  return t;
+});
+vi.mock('sonner', () => ({ toast: toastMock }));
+
+const authState = vi.hoisted(() => ({ user: null }));
+vi.mock('@/stores/authStore', () => ({ useAuthStore: (sel) => sel(authState) }));
+
+const navigateMock = vi.hoisted(() => vi.fn());
+vi.mock('react-router-dom', async (orig) => ({
+  ...(await orig()),
+  useNavigate: () => navigateMock,
+}));
+
+import PartnersList from '../PartnersList';
+
+const free = (id, name) => ({
+  id, tradingName: name, ownerUserId: null, availability: 'available',
+  archivedAt: null, mergedIntoId: null, pipelineStage: 'NEW', owner: null,
+  category: null, lastActivityAt: null,
+});
+const owned = (id, name) => ({
+  ...free(id, name), ownerUserId: 'u-other', availability: 'owned',
+  owner: { id: 'u-other', fullName: 'Someone Else' },
+});
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter><PartnersList /></MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authState.user = { role: 'redeem_ops', redeemOpsRole: 'outreach_exec' };
+  api.getConstants.mockResolvedValue({ pipelineStages: ['NEW'] });
+  api.listCategories.mockResolvedValue([]);
+  api.listPartners.mockResolvedValue({
+    partners: [free('p1', 'Free One'), free('p2', 'Free Two'), owned('p3', 'Taken Co')],
+    pagination: { page: 1, limit: 25, total: 3, totalPages: 1 },
+  });
+});
+
+// The page renders a mobile card list AND the desktop table, so the name
+// matches twice — scope to the row that lives inside the table.
+const rowFor = async (name) => {
+  const hits = await screen.findAllByText(name);
+  const row = hits.map((el) => el.closest('tr')).find(Boolean);
+  if (!row) throw new Error(`No table row for ${name}`);
+  return row;
+};
+
+it('only unowned rows are selectable — an owned one cannot be ticked', async () => {
+  renderPage();
+  const takenRow = await rowFor('Taken Co');
+  expect(within(takenRow).getByRole('checkbox')).toBeDisabled();
+  const freeRow = await rowFor('Free One');
+  expect(within(freeRow).getByRole('checkbox')).toBeEnabled();
+});
+
+it('with nothing selected, clicking a row opens the business', async () => {
+  renderPage();
+  await userEvent.click(await rowFor('Free One'));
+  expect(navigateMock).toHaveBeenCalledWith('/redeem-ops/partners/p1');
+});
+
+it('once something is selected, clicking rows selects instead of navigating', async () => {
+  renderPage();
+  const first = await rowFor('Free One');
+  await userEvent.click(within(first).getByRole('checkbox'));
+  navigateMock.mockClear();
+
+  // Selection mode: the whole row is now the checkbox. Navigating here would
+  // throw the selection away, which is the bug this pins.
+  await userEvent.click(await rowFor('Free Two'));
+  expect(navigateMock).not.toHaveBeenCalled();
+  expect(within(await rowFor('Free Two')).getByRole('checkbox')).toBeChecked();
+  expect(screen.getByText('2')).toBeInTheDocument(); // "2 selected"
+
+  // Clicking an UNCLAIMABLE row in selection mode is inert — it can neither be
+  // ticked nor yank the operator off the list.
+  await userEvent.click(await rowFor('Taken Co'));
+  expect(navigateMock).not.toHaveBeenCalled();
+
+  // Clearing hands normal navigation back.
+  await userEvent.click(screen.getByRole('button', { name: 'Clear' }));
+  await userEvent.click(await rowFor('Free One'));
+  expect(navigateMock).toHaveBeenCalledWith('/redeem-ops/partners/p1');
+});
+
+it('select-all covers only the claimable rows on the page', async () => {
+  renderPage();
+  await userEvent.click(await screen.findByLabelText(/Select all claimable/i));
+  expect(screen.getByText('2')).toBeInTheDocument(); // the owned row is excluded
+});
+
+it('claims the selection and reports a partial result honestly', async () => {
+  api.claimPartnersBulk.mockResolvedValue({
+    message: '1 of 2 claimed',
+    data: { claimed: ['p1'], failed: [{ id: 'p2', reason: 'already_claimed', claimedBy: { id: 'u9', fullName: 'Rival Rep' } }] },
+  });
+  renderPage();
+  await userEvent.click(await screen.findByLabelText(/Select all claimable/i));
+  await userEvent.click(screen.getByRole('button', { name: 'Claim' }));
+
+  await waitFor(() => expect(api.claimPartnersBulk).toHaveBeenCalledWith(['p1', 'p2']));
+  // Partial success is a warning that names the loss, not a success toast.
+  expect(toastMock.warning).toHaveBeenCalledWith('1 of 2 claimed', expect.objectContaining({
+    description: expect.stringContaining('Rival Rep'),
+  }));
+  // Only what landed is deselected, so a retry keeps the one that didn't.
+  await waitFor(() => expect(screen.getByText('1')).toBeInTheDocument());
+});
+
+it('hides the whole affordance from someone who cannot claim', async () => {
+  authState.user = { role: 'redeem_ops', redeemOpsRole: 'viewer' };
+  renderPage();
+  await screen.findAllByText('Free One');
+  expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+});


### PR DESCRIPTION
Claiming was one row at a time. A rep opening the **Unowned** filter on ten gymnastics studios had to click into ten businesses to take them.

The Partners list now multi-selects, with **Claim** as the first bulk action.

## Selection rules

- **Only unowned, live rows are selectable** — the same predicate the server's conditional UPDATE enforces, so the UI never offers what the API would refuse. An owned row's checkbox is disabled and says why on hover.
- **Select-all is scoped to the current page's** claimable rows. No silent "select all 2,000".
- The whole affordance is hidden from anyone without `partners.claim`.

## Selection mode

Once anything is ticked, the list enters selection mode and **the whole row becomes the checkbox**. Navigating to a business mid-selection would silently discard the selection, so in this mode a row click never opens the detail page, and an unclaimable row is simply inert rather than yanking you off the list. Clear — or unticking the last row — hands normal clicking straight back.

## Why each row gets its own transaction

Bulk claiming is **partially-successful by nature**: a colleague may have taken one of them a second ago. One shared transaction would roll back nine good claims because of a single lost race.

The per-row conditional UPDATE is still the only arbiter, so nothing here can double-claim — there's a test putting two reps on one row *through the bulk path* to prove it.

## Why it answers 200, not 409

Losing 3 of 10 is a normal outcome to report, not a failed request that should discard the 7 that worked. The endpoint returns a per-row breakdown; the console says "3 of 10 claimed" and names who holds one of the rest. **Only the ids that actually landed are deselected**, so a retry keeps exactly the ones that didn't.

Batch capped at 100.

## Verification

- Backend: 3 new tests in `redeemOpsPartners.test.js` — partial success (the taken one doesn't roll back the rest), the two-rep race through the bulk path, and empty/oversized rejection. 122 suites / 2475 tests green.
- Frontend: new `PartnersList.selection.test.jsx` — 6 tests covering selectability, navigate-vs-select in both modes, page-scoped select-all, the partial-result toast, and capability gating. 161 files / 2052 tests green. Lint clean.

Note: `POST /partners/bulk-claim` is registered **before** the `/partners/:id/*` routes — otherwise `bulk-claim` matches as an `:id` and 404s on a uuid lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eL2XE1J1A6eF3j3jTJqbm