### PR TITLE
fix(ci): the backend suite ran out of heap, not out of passing tests

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -12,6 +12,15 @@ export default {
   testTimeout: 60000,
   // maxWorkers=1 avoids DB contention between test suites
   maxWorkers: 1,
+  // ...but one worker means ONE heap for every suite in the run: each suite's
+  // models, Express app and module graph stay resident, so peak memory grows
+  // monotonically with the suite count. That is how the integration step
+  // (test/integration/ + every top-level test/*.test.js) reached "Ineffective
+  // mark-compacts near heap limit" and killed CI with exit 134 on 2026-07-28 —
+  // no test failed, the process died. Recycling the worker once it passes this
+  // threshold releases the accumulated heap between suites, which BOUNDS the
+  // growth instead of just raising the ceiling until the next suite breaks it.
+  workerIdleMemoryLimit: '1GB',
   // forceExit needed: Express + morgan + process.on handlers keep Node alive
   forceExit: true,
   // Set env vars before any modules are loaded (JWT_SECRET, NODE_ENV)

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "nodemon src/server.js",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test": "NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=6144\" jest",
     "test:legacy-safe": "node scripts/legacy-safe-harness.js",
     "load:smoke": "node load/run-local-load.js",
     "load:spike": "LOAD_PROFILE=spike node load/run-local-load.js",


### PR DESCRIPTION
**main is red and this fixes it.** It went red at `8565b84` (#313) and stayed red through #315 and #316 — all three of mine. `02b6c09` was the last green commit, so this is my breakage.

## No test failed

The "Run integration tests" step died with **exit 134**:

```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
```

~14 minutes in, ~3.3GB used, partway through the suite list. The suites that had run were all passing.

## The cause is structural — #313 was only the last straw

`jest.config.js` sets `maxWorkers: 1` to avoid DB contention between suites. That means **one heap for the entire run**: every suite's models, Express app and module graph stay resident, so peak memory grows monotonically with the suite count.

The integration step is the biggest list (`test/integration/` + every top-level `test/*.test.js`), it was already close to the ceiling — the same OOM reproduces locally on that pattern — and adding one more DB-backed suite tipped it over.

## Fixed at the mechanism, not the symptom

`workerIdleMemoryLimit: '1GB'` recycles the worker once it crosses the threshold, releasing the accumulated heap between suites. That **bounds** growth rather than raising a ceiling the next suite would breach again. The `NODE_OPTIONS` heap bump is the safety margin underneath it (and fixes the same OOM when running the whole backend suite locally).

## Verified

CI's exact pattern, run locally: **138 suites run to completion, 2691 passed**, where the run previously died mid-list.

The one suite failing in that local run — `emailBroadcastRoutes` — passes in isolation and is the known cross-suite transport flake: a different random suite each time, always `Parse Error: Expected HTTP/, RTSP/ or ICE/`, never an assertion. Measured at **2 failures / 5 runs on a clean `origin/main`** earlier today, so it predates all of this. Root cause looks like `test/devices.test.js` leaking a `setTimeout` that dynamic-imports after teardown and corrupts the next suite's socket — its own task, and not what turned main red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eL2XE1J1A6eF3j3jTJqbm