### PR TITLE
fix(scoring): show the lead score on the page that is about the lead

### DIFF
--- a/backend/src/services/consumerService.js
+++ b/backend/src/services/consumerService.js
@@ -492,6 +492,10 @@ export function makeConsumerService(overrides = {}) {
           'id', 'firstName', 'lastName', 'phone', 'campaignId', 'leadStatus', 'leadSource',
           'createdAt', 'conversionDate', 'quarantinedAt', 'quarantineReason', 'sourceMetadata',
           'externalAgentId',
+          // The LEAD score — a property of (person × campaign), so it belongs on
+          // the signup and not beside the person's name. Without it the campaign
+          // drill-in is the one page that cannot show the number it is about.
+          'score', 'scoreComputedAt',
           // consentMetadata carries the pinned draw-terms acceptance the draw
           // eligibility preview reads — profile mode only.
           ...(includeRaw ? ['consentMetadata'] : []),
@@ -552,6 +556,12 @@ export function makeConsumerService(overrides = {}) {
           ? `${s.assignedAgent.firstName || ''} ${s.assignedAgent.lastName || ''}`.trim() || null
           : null,
         externalBuyer: Boolean(s.externalAgentId),
+        // NULL means "not scored yet", which the UI must show differently from
+        // a zero — the sweep stamps scoreComputedAt even when the score itself
+        // comes back null, so the two together distinguish "no opinion yet"
+        // from "scored, and the answer is nothing".
+        score: s.score ?? null,
+        scoredAt: s.scoreComputedAt || null,
       })),
       entitlements: entitlements.map((e) => ({
         id: e.id,

--- a/backend/test/leadScoring.test.js
+++ b/backend/test/leadScoring.test.js
@@ -367,3 +367,35 @@ describe('erasure (§11)', () => {
     expect(stale).not.toContain(a.id)
   })
 })
+
+describe('the score reaches the page that is about the lead', () => {
+  test('each signup in the journey carries its OWN score, not the person\'s best', async () => {
+    const { consumer, a, b } = await personWithTwoLeads()
+    await scoreOf(a.id)
+    await scoreOf(b.id)
+
+    const { getConsumerJourney } = await import('../src/services/consumerService.js')
+    const journey = await getConsumerJourney(consumer.id)
+
+    const byId = new Map(journey.signups.map((s) => [String(s.prospectId), s]))
+    expect(byId.size).toBe(2)
+
+    for (const id of [a.id, b.id]) {
+      const signup = byId.get(String(id))
+      const row = await rowOf(id)
+      // The whole point: the drill-in for THIS campaign can show THIS
+      // campaign's number. A person-grain projection cannot express two.
+      expect(signup.score).toBe(row.score)
+      expect(signup.scoredAt).toBeTruthy()
+    }
+  })
+
+  test('an unscored lead reports null, never 0 — the UI must tell them apart', async () => {
+    const { consumer, a } = await personWithTwoLeads()
+    const { getConsumerJourney } = await import('../src/services/consumerService.js')
+    const journey = await getConsumerJourney(consumer.id)
+    const signup = journey.signups.find((s) => String(s.prospectId) === String(a.id))
+    expect(signup.score).toBeNull()
+    expect(signup.scoredAt).toBeNull()
+  })
+})

--- a/src/pages/adminv2/AdminV2LeadProfile.jsx
+++ b/src/pages/adminv2/AdminV2LeadProfile.jsx
@@ -611,6 +611,48 @@ function ComponentRow({ name, c }) {
 }
 
 /**
+ * THIS campaign's score for THIS person (per-campaign-lead-scoring.md §4).
+ *
+ * The scoring card on the person profile shows the WINNING lead's numbers — the
+ * projection. For anyone with a single signup those are the same number, but a
+ * person with two campaigns has two scores and only one of them surfaces there.
+ * The drill-in is the page about one lead, so it is where that lead's own score
+ * belongs.
+ *
+ * NULL is not zero. A lead the sweep has not reached yet says so in words
+ * rather than showing a 0 nobody computed.
+ */
+function LeadScoreBadge({ signup }) {
+  if (!signup) return null;
+  const scored = signup.score !== null && signup.score !== undefined;
+  if (!scored) {
+    return (
+      <span
+        className="av2-mono"
+        style={{ fontSize: 10.5, color: 'var(--ink-3)', flex: 'none' }}
+        title="The nightly sweep has not reached this lead yet."
+      >
+        NOT SCORED YET
+      </span>
+    );
+  }
+  return (
+    <span
+      style={{ display: 'inline-flex', alignItems: 'baseline', gap: 5, flex: 'none' }}
+      title={signup.scoredAt ? `Scored ${fmtDateTime(signup.scoredAt)}` : 'Lead score'}
+    >
+      <span className="av2-microcaps" style={{ color: 'var(--ink-3)' }}>lead score</span>
+      <span
+        className="av2-mono"
+        style={{ fontSize: 15, fontWeight: 800, color: 'var(--ink)', fontVariantNumeric: 'tabular-nums' }}
+      >
+        {signup.score}
+      </span>
+    </span>
+  );
+}
+
+/**
  * What actually happened, and when (per-campaign-lead-scoring.md §6).
  *
  * The components above say how much each thing is worth right now; this says
@@ -895,6 +937,11 @@ export default function AdminV2LeadProfile() {
       rewardDiagnostic: p.signupProfile?.rewardDiagnostic ?? null,
       agentName: p.assignedAgent ? fullName(p.assignedAgent) : null,
       externalBuyer: Boolean(p.externalAgentId),
+      // Consumer-less leads ARE scored — findStaleLeadIds admits them
+      // explicitly — so the fallback must carry the score too, or the one
+      // page about a Retell voice lead claims it was never scored.
+      score: p.score ?? null,
+      scoredAt: p.scoreComputedAt ?? null,
       _fallback: true,
     }];
   }, [journey, p]);
@@ -1218,6 +1265,9 @@ export default function AdminV2LeadProfile() {
                       </span>
                     </span>
                     {chip && <Chip tone={chip.tone}>{chip.label}</Chip>}
+                    {/* Per-row, because each signup carries its OWN score and the
+                        card above this one can only ever show the winning lead's. */}
+                    <LeadScoreBadge signup={s} />
                     <span aria-hidden="true" style={{ color: 'var(--ink-3)', fontSize: 14, flex: 'none' }}>›</span>
                   </button>
                 );
@@ -1278,6 +1328,7 @@ export default function AdminV2LeadProfile() {
                 <Link to={`/admin/campaigns/${currentSignup?.campaign?.id || p.campaign.id}`} style={{ fontSize: 11.5, fontWeight: 700 }}>campaign page ↗</Link>
               )}
               <span style={{ flex: 1 }} />
+              <LeadScoreBadge signup={currentSignup} />
               <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10.5, color: 'var(--ink-3)' }}>
                 SIGNED UP {fmtDateTime(p.createdAt).toUpperCase()} · {(SOURCE_LABELS[p.leadSource] || p.leadSource).toUpperCase()}
               </span>

--- a/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
@@ -225,6 +225,57 @@ describe('AdminV2LeadProfile — person profile view', () => {
   });
 });
 
+describe('AdminV2LeadProfile — the lead score belongs to the campaign', () => {
+  /** The fixture's two signups, given DIFFERENT scores — the case the person
+   *  card cannot express, because it can only show the winning lead's number. */
+  const twoScored = () => {
+    const d = JSON.parse(JSON.stringify(PROFILE));
+    Object.assign(d.consumer.signups[0], { score: 48, scoredAt: '2026-07-27T16:14:35Z' });
+    Object.assign(d.consumer.signups[1], { score: 12, scoredAt: '2026-07-27T16:14:35Z' });
+    return d;
+  };
+
+  it('the drill-in shows THIS campaign\'s score, not the person\'s best', async () => {
+    fetchProspectProfile.mockResolvedValue(twoScored());
+    setup('/admin/leads/p2');
+    await screen.findByText('NTUC Trial Reward');
+    // 12 is this lead's own score; 48 belongs to the other campaign and must
+    // not be what a reader sees on this page.
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.queryByText('48')).not.toBeInTheDocument();
+  });
+
+  it('the campaign rail scores every row, so both signups are comparable', async () => {
+    fetchProspectProfile.mockResolvedValue(twoScored());
+    setup('/admin/leads/p1?view=profile');
+    await screen.findByText('NTUC Trial Reward');
+    expect(screen.getByText('48')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+  });
+
+  it('an unscored lead says so — NULL is never rendered as a zero', async () => {
+    const d = JSON.parse(JSON.stringify(PROFILE));
+    d.consumer.signups[0].score = null;
+    fetchProspectProfile.mockResolvedValue(d);
+    setup();
+    expect(await screen.findByText('NOT SCORED YET')).toBeInTheDocument();
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+  });
+
+  it('a consumer-less lead still shows its score — those are scored too', async () => {
+    fetchProspectProfile.mockResolvedValue({
+      ...JSON.parse(JSON.stringify(PROFILE)),
+      consumer: null,
+      score: 33,
+      scoreComputedAt: '2026-07-27T16:14:35Z',
+      signupProfile: { draw: null, entitlements: [], rewardDiagnostic: null },
+    });
+    setup();
+    expect(await screen.findByText('33')).toBeInTheDocument();
+    expect(screen.queryByText('NOT SCORED YET')).not.toBeInTheDocument();
+  });
+});
+
 describe('AdminV2LeadProfile — states', () => {
   it('consumer-less Retell lead: banner, single signup, voice-call card', async () => {
     fetchProspectProfile.mockResolvedValue({


### PR DESCRIPTION
Reported from the console: a lead scored **48**, with nothing on screen saying so.

Phase 3 made the score a property of **(person × campaign)** — which is exactly what the campaign drill-in shows — and then that page became the one place you could not see it. The number renders on three list screens and on the person card. Never on the signup itself.

## The person card is not a substitute

It shows the **winning** lead's numbers by design (§4's projection). For anyone with two signups, the lower-scoring campaign's score is currently unreachable anywhere in the UI.

**6 of 129 people in prod are in that position today.** For the other 123 the two numbers are identical, which is exactly why this went unnoticed.

## The change

`score` + `scoredAt` ride each journey signup — two more attributes on a query that already selects eleven — and render in two places:

- the **drill-in header**, beside `SIGNED UP …`
- every **campaign rail row** on the person page, so two signups compare at a glance without opening both

## Three things worth reviewing

**NULL is not zero.** A lead the sweep has not reached says `NOT SCORED YET` in words. Rendering a `0` nobody computed would be a verdict we have not reached — the same distinction `consumerEnrichment` already draws between "no profile row" and "scored, answer is null".

**Consumer-less leads needed the fallback too.** Retell voice / pre-spine / unverified leads synthesize their rail row client-side from the prospect payload, so without this they'd have claimed "not scored yet" forever — while `findStaleLeadIds` admits `consumerId IS NULL` rows explicitly and scores them. Caught by walking that path rather than assuming it shared the journey shape.

**The drill-in reads `currentSignup`, never the projection**, so the number on screen always belongs to the campaign named above it. A test drives `/admin/leads/p2` and asserts the *other* lead's 48 is absent from the document.

## Verification

- Backend unit — **107 suites / 1980 tests, no database reachable**
- Backend integration — **138 suites / 2697 tests**, on a **private** database (the shared `mktr_test` gets force-synced by sibling worktrees mid-run, which produces a blank `addIndex` error that reads exactly like a regression)
- `npx eslint src/ --quiet` exit 0 at both roots
- Frontend — **161 files / 2056 tests** (4 new on the lead profile, 2 new on backend scoring)

`test/redeemOpsCategories.test.js` failed the integration run on a `socket hang up` for a request the server had already answered **201**, and passes 23/23 alone. Transport, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENWdGMue9uXqmKv3pRG6YF
