### PR TITLE
fix(scoring): the reason a component scored what it did stops being cut off

### DIFF
--- a/src/pages/adminv2/AdminV2LeadProfile.jsx
+++ b/src/pages/adminv2/AdminV2LeadProfile.jsx
@@ -208,6 +208,15 @@ function HoverHint({ label, hint, underline = true, color, ariaLabel }) {
       aria-label={ariaLabel || undefined}
       onMouseEnter={() => setOpen(true)}
       onMouseLeave={() => setOpen(false)}
+      // Focusable because the hint is now the ONLY place several of these
+      // reasons exist — the scoring card moved them off the row. A hint you
+      // can only reach with a mouse is a hint a keyboard user cannot read at
+      // all. Escape closes it without moving focus, so a reader who opened one
+      // by tabbing is not trapped reading it.
+      tabIndex={hint ? 0 : undefined}
+      onFocus={() => setOpen(true)}
+      onBlur={() => setOpen(false)}
+      onKeyDown={(e) => { if (e.key === 'Escape' && open) { e.stopPropagation(); setOpen(false); } }}
       style={{ position: 'relative', display: 'inline-block' }}
     >
       <span
@@ -590,21 +599,27 @@ function ComponentRow({ name, c }) {
   // the number. Unknown draws no bar at all — an empty bar would read as zero.
   const pct = assessed && max !== 0 ? Math.min(100, Math.abs(c.points / max) * 100) : 0;
   const penalty = max < 0;
+  const label = COMPONENT_LABELS[name] || name.replace(/_/g, ' ');
+  // The reason moved ONTO the label (dotted = there is more here). It used to
+  // ride in a trailing column that ellipsed nearly every row — "reachable via
+  // marketi…", "no recent life event…" — so the one part that explains the
+  // number was the one part you could not read. Nothing is lost: the full text
+  // is one hover away, and the space it freed goes to the bar, which is what
+  // makes two components comparable at a glance.
   return (
     <div style={{ display: 'flex', alignItems: 'baseline', gap: 10, padding: '3px 0', fontSize: 12 }}>
       <span style={{ width: 116, flex: 'none', color: assessed ? 'var(--ink-2)' : 'var(--ink-3)' }}>
-        {COMPONENT_LABELS[name] || name.replace(/_/g, ' ')}
+        {c.note
+          ? <HoverHint label={label} hint={c.note} ariaLabel={`${label}: ${c.note}`} />
+          : label}
       </span>
       <span style={{ width: 58, flex: 'none', fontFamily: 'var(--font-mono)', fontSize: 11, textAlign: 'right', color: assessed ? 'var(--ink)' : 'var(--ink-3)' }}>
         {assessed ? `${c.points}` : '—'}<span style={{ color: 'var(--ink-3)' }}>/{max}</span>
       </span>
-      <span aria-hidden="true" style={{ width: 46, flex: 'none', height: 4, borderRadius: 3, background: 'var(--surface-2)', overflow: 'hidden' }}>
+      <span aria-hidden="true" style={{ flex: 1, minWidth: 46, height: 4, borderRadius: 3, background: 'var(--surface-2)', overflow: 'hidden' }}>
         {assessed && pct > 0 && (
           <span style={{ display: 'block', width: `${pct}%`, height: '100%', background: penalty ? 'var(--bad)' : 'var(--accent-text)' }} />
         )}
-      </span>
-      <span style={{ flex: 1, minWidth: 0, fontSize: 11.5, color: 'var(--ink-3)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={c.note || ''}>
-        {c.note || (assessed ? '' : 'unknown')}
       </span>
     </div>
   );

--- a/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
@@ -559,12 +559,37 @@ describe('scoring panel', () => {
     fetchProspectProfile.mockResolvedValue(ENRICHED());
     setup('/admin/leads/p1?view=profile');
     await screen.findByText('Scoring');
-    // market_fit is unknown: its note explains why, and it shows no points.
-    expect(screen.getByText('no language or ethnicity fact')).toBeInTheDocument();
-    expect(screen.getByText('no recent life event on record')).toBeInTheDocument();
+    // The reason lives on the LABEL now, not in a trailing column that ellipsed
+    // it. It must still be reachable WITHOUT a mouse — the accessible name is
+    // the contract, because for several components this is the only place the
+    // explanation exists at all.
+    expect(screen.getByLabelText(/market fit: no language or ethnicity fact/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/life events: no recent life event on record/)).toBeInTheDocument();
     // The assessed ones DO show their points.
     expect(screen.getByText('7.5')).toBeInTheDocument();
     expect(screen.getByText('1.5')).toBeInTheDocument();
+  });
+
+  it('the reason opens on hover, and on keyboard focus', async () => {
+    fetchProspectProfile.mockResolvedValue(ENRICHED());
+    setup('/admin/leads/p1?view=profile');
+    await screen.findByText('Scoring');
+    const hint = screen.getByLabelText(/market fit: no language or ethnicity fact/);
+
+    // Nothing on screen until asked — that is the whole point of the change.
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+
+    fireEvent.mouseEnter(hint);
+    expect(screen.getByRole('tooltip')).toHaveTextContent('no language or ethnicity fact');
+    fireEvent.mouseLeave(hint);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+
+    // A mouse-only hint would hide these reasons from a keyboard reader
+    // entirely, now that they are not printed on the row.
+    fireEvent.focus(hint);
+    expect(screen.getByRole('tooltip')).toHaveTextContent('no language or ethnicity fact');
+    fireEvent.keyDown(hint, { key: 'Escape' });
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
   });
 
   it('names the unknowns as unasked questions, not as low scores', async () => {


### PR DESCRIPTION
Reported from the console, with a screenshot: every reason in the scoring card was ellipsed.

```
engagement      7.47/15  ▮▮▮▯  1 signup(s), 1 verified
contactability    10/10  ▮▮▮▮  reachable via marketi…
market fit         —/15  ▯▯▯▯  no language or eth…
response           —/15  ▯▯▯▯  no message owned…
screening        20/20   ▮▮▮▮  qualified, sentiment…
life events        —/25  ▯▯▯▯  no recent life event…
age              6.5/10  ▮▮▮▯  born 1995-1999 — …
```

The column that explains the number was the one column you could not read — and it was spending 40% of the row width to do it.

## The change

The reason moves **onto the component label**, with a dotted underline — the affordance this file already uses for the draw and delivery-receipt hints — and the trailing column goes away.

Ten rows of half-sentences become ten labels. The full text is one hover away instead of one ellipsis away, and the card is quieter for it.

The freed width goes to the **progress bar**, fixed at 46px until now. That bar is the only part of the card readable at a glance, and at 46px it could not separate `7.47/15` from `10/10` — which is the exact comparison it exists to make. It now fills the row.

## HoverHint becomes keyboard-reachable

This is not polish. The card just made the hint the **only** place several reasons exist, so a mouse-only tooltip would hide them from a keyboard reader completely.

- Focus opens it, blur closes it, `Escape` closes it without moving focus
- The wrapper carries `aria-label="<component>: <reason>"`, so the reason is in the **accessible name** whether or not the tooltip is open — that is what the updated test asserts, because it is the durable contract
- The three pre-existing HoverHints inherit the same, which they should have had already

## Verification

- Frontend — **161 files / 2057 tests** green. Two new: the reason survives without a mouse, and the tooltip opens on hover *and* on focus, closing on Escape.
- `npx eslint src/ --quiet` exit 0 at both roots.
- No backend file touched.

The one pre-existing test that asserted the note text was on screen now asserts it via the accessible name instead — same guarantee, and it no longer depends on the reason being printed in full on the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENWdGMue9uXqmKv3pRG6YF
