### PR TITLE
feat(scoring): say WHICH campaign the person's score came from

### DIFF
--- a/backend/src/database/migrations/101-score-source-prospect.js
+++ b/backend/src/database/migrations/101-score-source-prospect.js
@@ -1,0 +1,61 @@
+/**
+ * 101 — record WHICH lead the person's score was copied from
+ * (docs/plans/per-campaign-lead-scoring.md §4).
+ *
+ * The person's meet/buy/consumerScore are a PROJECTION of their highest-scoring
+ * lead — `projectPersonScore` already picks that lead and then throws its
+ * identity away. That was survivable while every campaign shared one global
+ * rulebook: prod's six multi-signup people have scores 0–1 points apart, so it
+ * did not matter which one won.
+ *
+ * Phase 4 (migration 100) makes it matter. Once a campaign has its own weights,
+ * the same person genuinely scores differently on recruitment than on
+ * insurance, and "their best" silently becomes "their best at something you
+ * cannot see" — worst of all on the People directory, whose Meet/Buy columns
+ * are SORTABLE and name no campaign at all.
+ *
+ * So the projection keeps the receipt. One nullable column, written by the same
+ * statement that already chooses the winner; no second copy of the tie-break
+ * rule to drift out of sync with the first.
+ *
+ * ON DELETE SET NULL, not a snapshot. Unlike the config table's `campaignId`
+ * (migration 100), nothing has to stay RESOLVABLE here — this is a pointer to a
+ * live row, used only to name a campaign in the UI. If the winning lead is
+ * deleted the label should disappear rather than name a lead that no longer
+ * exists; the stale score beside it is the pre-existing behaviour of a
+ * projection that only refreshes when some lead of that person is rescored.
+ */
+
+export async function up(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.transaction(async (t) => {
+    const q = (sql) => sequelize.query(sql, { transaction: t });
+
+    await q('ALTER TABLE consumer_profiles ADD COLUMN IF NOT EXISTS "scoreSourceProspectId" UUID');
+
+    await q(`DO $$ BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_cprof_score_source') THEN
+        ALTER TABLE consumer_profiles ADD CONSTRAINT fk_cprof_score_source
+          FOREIGN KEY ("scoreSourceProspectId") REFERENCES prospects(id) ON DELETE SET NULL;
+      END IF;
+    END $$`);
+
+    // NO BACKFILL, deliberately. Recomputing the winner here would duplicate
+    // projectPersonScore's tie-break in SQL that then never runs again — the
+    // exact drift this column exists to avoid. Every person's projection is
+    // rewritten the next time any of their leads is scored, which the nightly
+    // sweep does for the whole population; until then the label is simply
+    // absent, which reads as "not known yet" rather than as a wrong campaign.
+  });
+}
+
+export async function down(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.transaction(async (t) => {
+    const q = (sql) => sequelize.query(sql, { transaction: t });
+    await q('ALTER TABLE consumer_profiles DROP CONSTRAINT IF EXISTS fk_cprof_score_source');
+    await q('ALTER TABLE consumer_profiles DROP COLUMN IF EXISTS "scoreSourceProspectId"');
+  });
+}

--- a/backend/src/models/ConsumerProfile.js
+++ b/backend/src/models/ConsumerProfile.js
@@ -61,6 +61,11 @@ const ConsumerProfile = sequelize.define('ConsumerProfile', {
     allowNull: true,
     comment: 'Per component: {state: unknown|assessed, points, maxPoints, basisObservationIds, note}'
   },
+  // WHICH lead the three scores above were copied from (§4's projection,
+  // migration 101). The numbers are their best lead's; without this the UI can
+  // only say "their best" and never "their best at WHAT" — which stops being a
+  // detail the moment a campaign has weights of its own.
+  scoreSourceProspectId: { type: DataTypes.UUID, allowNull: true },
   scoredConfigVersion: { type: DataTypes.INTEGER, allowNull: true },
   scoringAlgorithmVersion: { type: DataTypes.STRING(16), allowNull: true },
   scoreInputHash: { type: DataTypes.STRING(64), allowNull: true },

--- a/backend/src/services/consumerService.js
+++ b/backend/src/services/consumerService.js
@@ -667,7 +667,13 @@ export function makeConsumerService(overrides = {}) {
                   c."firstSeenAt", c."lastSeenAt", c."erasedAt",
                   lp.id AS "latestProspectId",
                   cp."meetScore", cp."buyScore", cp."consumerScore",
-                  cp."scoredConfigVersion"
+                  cp."scoredConfigVersion",
+                  -- These Meet/Buy columns are SORTABLE and name no campaign,
+                  -- while the numbers are the person's BEST lead's (§4). Once a
+                  -- campaign has weights of its own that is a ranking nobody
+                  -- can act on — "70" could be 70 for recruitment and 5 for
+                  -- what the reader actually sells. So the row says which.
+                  sc.name AS "scoreSourceCampaignName"
              FROM consumers c
              JOIN LATERAL (
                SELECT p.id FROM prospects p
@@ -676,6 +682,8 @@ export function makeConsumerService(overrides = {}) {
                 LIMIT 1
              ) lp ON true
              LEFT JOIN consumer_profiles cp ON cp."consumerId" = c.id
+             LEFT JOIN prospects sp ON sp.id = cp."scoreSourceProspectId"
+             LEFT JOIN campaigns sc ON sc.id = sp."campaignId"
             WHERE true ${qClause}
             ORDER BY ${orderBy}, c.id DESC
             LIMIT :limit OFFSET :offset`,

--- a/backend/src/services/leadProfileService.js
+++ b/backend/src/services/leadProfileService.js
@@ -2,7 +2,7 @@ import { Op } from 'sequelize';
 import {
   Draw, RewardEntitlement, Activation, RewardOffer, ConsumerSuppression,
   EmailBroadcastRecipient, SessionVisit, ProspectActivity, User, ExternalAgent,
-  RedemptionEvent, ConsentEvent, ConsumerProfile, sequelize,
+  RedemptionEvent, ConsentEvent, ConsumerProfile, Prospect, sequelize,
 } from '../models/index.js';
 import { logger } from '../utils/logger.js';
 import { presentState } from '../utils/entitlementPresentState.js';
@@ -40,7 +40,7 @@ export function makeLeadProfileService(overrides = {}) {
   const d = {
     Draw, RewardEntitlement, Activation, RewardOffer, ConsumerSuppression,
     EmailBroadcastRecipient, SessionVisit, ProspectActivity, User, ExternalAgent,
-    RedemptionEvent, ConsentEvent, ConsumerProfile, sequelize, logger,
+    RedemptionEvent, ConsentEvent, ConsumerProfile, Prospect, sequelize, logger,
     getProspectDrawStatus: null, // defaults to a lucky-draw service built below
     getConsentState,
     presentState,
@@ -556,6 +556,31 @@ export function makeLeadProfileService(overrides = {}) {
         d.logger.warn('[leadProfile] fact ledger read failed (omitted)', { error: err?.message });
       }
 
+      // WHICH lead these numbers were copied from (§4). They are the person's
+      // BEST lead's scores, and once a campaign carries its own weights "their
+      // best" without "at what" is a number nobody can act on. Absent until
+      // that person's next rescore — migration 101 deliberately did not
+      // backfill it rather than re-derive the tie-break in one-shot SQL.
+      let scoreSource = null;
+      if (row.scoreSourceProspectId) {
+        try {
+          const src = await d.Prospect.findByPk(row.scoreSourceProspectId, {
+            attributes: ['id', 'campaignId'],
+            include: [{ association: 'campaign', attributes: ['id', 'name'] }],
+          });
+          if (src) {
+            scoreSource = {
+              prospectId: String(src.id),
+              campaignId: src.campaignId ? String(src.campaignId) : null,
+              campaignName: src.campaign?.name || null,
+            };
+          }
+        } catch (err) {
+          // A missing label must never blank the scores beside it.
+          d.logger.warn('[leadProfile] score source read failed (omitted)', { error: err?.message });
+        }
+      }
+
       return {
         meetScore: row.meetScore ?? null,
         buyScore: row.buyScore ?? null,
@@ -564,6 +589,7 @@ export function makeLeadProfileService(overrides = {}) {
         scoredAt: row.scoreComputedAt || null,
         configVersion: row.scoredConfigVersion ?? null,
         algorithmVersion: row.scoringAlgorithmVersion || null,
+        scoreSource,
         facts,
       };
     } catch (err) {

--- a/backend/src/services/leadScoringService.js
+++ b/backend/src/services/leadScoringService.js
@@ -200,12 +200,14 @@ export async function projectPersonScore(t, consumerId) {
   await sequelize.query(
     `INSERT INTO consumer_profiles
        ("consumerId", "consumerScore", "meetScore", "buyScore", "scoreBreakdown",
+        "scoreSourceProspectId",
         "inputVersion", "syncedInputVersion", "createdAt", "updatedAt")
      SELECT c.id, best.score, best."meetScore", best."buyScore", best."scoreBreakdown",
+            best.id,
             0, 0, now(), now()
        FROM consumers c
        LEFT JOIN LATERAL (
-         SELECT p.score, p."meetScore", p."buyScore", p."scoreBreakdown"
+         SELECT p.id, p.score, p."meetScore", p."buyScore", p."scoreBreakdown"
            FROM prospects p
           WHERE p."consumerId" = c.id AND p.score IS NOT NULL
           ORDER BY p.score DESC, p."createdAt" DESC, p.id DESC
@@ -217,6 +219,10 @@ export async function projectPersonScore(t, consumerId) {
        "meetScore" = EXCLUDED."meetScore",
        "buyScore" = EXCLUDED."buyScore",
        "scoreBreakdown" = EXCLUDED."scoreBreakdown",
+       -- The receipt travels with the numbers it explains (migration 101).
+       -- Written by the SAME statement that picks the winner, so there is no
+       -- second copy of the tie-break to drift out of step with this one.
+       "scoreSourceProspectId" = EXCLUDED."scoreSourceProspectId",
        "updatedAt" = now()`,
     { replacements: { cid: consumerId }, transaction: t }
   );

--- a/backend/test/consumersList.test.js
+++ b/backend/test/consumersList.test.js
@@ -150,10 +150,19 @@ describe('GET /api/consumers — membership is row existence', () => {
     // + the four MEET × BUY projections (§8). Pinned deliberately: this row
     // shape is the People page's contract, so widening it is a decision, not
     // a side effect.
+    //
+    // WIDENED 2026-07-28 by one key, and this is that decision: Meet and Buy
+    // here are the person's BEST lead's scores (per-campaign-lead-scoring.md
+    // §4) and this column sorts on them while naming no campaign. Harmless
+    // while every campaign shared one rulebook — prod's six multi-signup
+    // people scored 0-1 points apart — but migration 100 lets a campaign carry
+    // its own weights, at which point "70" could be 70 for recruitment and 5
+    // for whatever the reader sells. `scoreSourceCampaignName` is what stops
+    // that ranking being unreadable.
     expect(Object.keys(a).sort()).toEqual([
       'buyScore', 'consumerScore', 'email', 'erasedAt', 'firstName', 'firstSeenAt',
       'id', 'lastName', 'lastSeenAt', 'latestProspectId', 'meetScore', 'phone',
-      'scoredConfigVersion', 'signupCount', 'verifiedSignupCount',
+      'scoreSourceCampaignName', 'scoredConfigVersion', 'signupCount', 'verifiedSignupCount',
     ])
     expect(a).toMatchObject({
       firstName: 'Zephyrine', lastName: 'Peopledir', phone: '+6598111001',

--- a/backend/test/leadScoring.test.js
+++ b/backend/test/leadScoring.test.js
@@ -399,3 +399,36 @@ describe('the score reaches the page that is about the lead', () => {
     expect(signup.scoredAt).toBeNull()
   })
 })
+
+describe('the person score says WHICH lead it was copied from', () => {
+  test('the projection records the winning lead, and follows it when it changes', async () => {
+    const { consumer, a, b } = await personWithTwoLeads()
+    // Give b the higher score: a read it owns is a response a cannot borrow.
+    await sendAndStatus(b, consumer, 'read')
+    await scoreOf(a.id)
+    await scoreOf(b.id)
+
+    const winner = await sequelize.query(
+      `SELECT cp."scoreSourceProspectId" AS src, cp."consumerScore" AS score
+         FROM consumer_profiles cp WHERE cp."consumerId" = :cid`,
+      { replacements: { cid: consumer.id }, type: sequelize.QueryTypes.SELECT }
+    )
+    const bRow = await rowOf(b.id)
+    expect(bRow.score).toBeGreaterThan((await rowOf(a.id)).score)
+    // The receipt points at the lead whose numbers were actually copied — not
+    // merely "some lead of this person".
+    expect(String(winner[0].src)).toBe(String(b.id))
+    expect(winner[0].score).toBe(bRow.score)
+  })
+
+  test('a person with no scoreable lead records no source', async () => {
+    const { consumer } = await personWithTwoLeads()
+    const [[row]] = await sequelize.query(
+      'SELECT "scoreSourceProspectId" AS src FROM consumer_profiles WHERE "consumerId" = :cid',
+      { replacements: { cid: consumer.id } }
+    )
+    // Either no profile row yet, or one that names nobody — never a lead that
+    // did not win.
+    expect(row?.src ?? null).toBeNull()
+  })
+})

--- a/src/pages/adminv2/AdminV2LeadProfile.jsx
+++ b/src/pages/adminv2/AdminV2LeadProfile.jsx
@@ -756,6 +756,20 @@ function EnrichmentCard({ enrichment }) {
         />
       </div>
 
+      {/* A person does not have one worth — a fresh grad is a strong recruit
+          and a weak policyholder. These numbers are their BEST lead's (§4's
+          projection), so naming that lead is the difference between a number a
+          reader can act on and one they will misread the moment two campaigns
+          score the same person differently. */}
+      {enrichment?.scoreSource?.campaignName && (
+        <div style={{ padding: '0 18px 8px', fontSize: 11.5, color: 'var(--ink-3)' }}>
+          their best campaign —{' '}
+          <span style={{ color: 'var(--ink-2)', fontWeight: 600 }}>
+            {enrichment.scoreSource.campaignName}
+          </span>
+        </div>
+      )}
+
       <div style={{ padding: '4px 18px 12px' }}>
         {meetNames.length > 0 && (
           <>

--- a/src/pages/adminv2/AdminV2People.jsx
+++ b/src/pages/adminv2/AdminV2People.jsx
@@ -50,7 +50,7 @@ function SortHeader({ label, field, sort, onSort, width, align }) {
  * says which kind of nothing it is. Buy is NULL for anyone with no fact
  * component assessed, which today is nearly everyone.
  */
-function ScoreCell({ value, scored, kind }) {
+function ScoreCell({ value, scored, kind, source }) {
   if (value == null) {
     return (
       <span
@@ -75,7 +75,10 @@ function ScoreCell({ value, scored, kind }) {
         fontWeight: strong ? 700 : 500,
         color: strong ? 'var(--ink)' : 'var(--ink-2)',
       }}
-      title={`${kind} ${value}/100`}
+      // Always names the campaign when it is known, even for a single-signup
+      // person where the row above stays quiet — the number is a projection
+      // either way, and a reader asking "of what?" should not have to leave.
+      title={source ? `${kind} ${value}/100 — their best campaign: ${source}` : `${kind} ${value}/100`}
     >
       {value}
     </span>
@@ -224,11 +227,21 @@ export default function AdminV2People() {
               </span>
               <span style={{ width: 150, flex: 'none', fontSize: 12, color: 'var(--ink-2)' }}>
                 {r.signupCount} signup{r.signupCount === 1 ? '' : 's'} ({r.verifiedSignupCount} verified)
+                {/* Meet and Buy below are this person's BEST lead's scores
+                    (§4), and this column SORTS on them while naming no
+                    campaign. With one signup there is nothing to disambiguate;
+                    with several, "70" might be 70 for recruitment and 5 for
+                    what the reader sells, so the winner is named. */}
+                {!erased && r.signupCount > 1 && r.scoreSourceCampaignName && (
+                  <span style={{ display: 'block', fontSize: 10.5, color: 'var(--ink-3)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    scored on {r.scoreSourceCampaignName}
+                  </span>
+                )}
               </span>
               {/* Erased people keep no profile row (§9) — show nothing rather
                   than a stale number. */}
-              <ScoreCell value={erased ? null : r.meetScore} scored={!erased && r.scoredConfigVersion != null} kind="Meet" />
-              <ScoreCell value={erased ? null : r.buyScore} scored={!erased && r.scoredConfigVersion != null} kind="Buy" />
+              <ScoreCell value={erased ? null : r.meetScore} scored={!erased && r.scoredConfigVersion != null} kind="Meet" source={r.scoreSourceCampaignName} />
+              <ScoreCell value={erased ? null : r.buyScore} scored={!erased && r.scoredConfigVersion != null} kind="Buy" source={r.scoreSourceCampaignName} />
               <span className="av2-mono" style={{ width: 100, flex: 'none', fontSize: 10, color: 'var(--ink-3)', textAlign: 'right' }} title={fmtDateTime(r.lastSeenAt)}>
                 {fmtRelative(r.lastSeenAt)}
               </span>

--- a/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
@@ -570,6 +570,29 @@ describe('scoring panel', () => {
     expect(screen.getByText('1.5')).toBeInTheDocument();
   });
 
+  it('names the campaign the person\'s numbers were copied from', async () => {
+    const d = ENRICHED();
+    d.consumer.enrichment.scoreSource = {
+      prospectId: 'p2', campaignId: 'camp-2', campaignName: 'NTUC Trial Reward',
+    };
+    fetchProspectProfile.mockResolvedValue(d);
+    setup('/admin/leads/p1?view=profile');
+    await screen.findByText('Scoring');
+    // "50" alone invites the reader to treat it as a verdict on the PERSON.
+    // It is their best campaign's number, and which campaign is the difference
+    // between actionable and misleading once weights differ per campaign.
+    expect(screen.getByText(/their best campaign/)).toBeInTheDocument();
+  });
+
+  it('says nothing when the winning lead is not known yet', async () => {
+    // Migration 101 deliberately did not backfill, so every person carries no
+    // source until their next rescore. Silence beats naming the wrong campaign.
+    fetchProspectProfile.mockResolvedValue(ENRICHED());
+    setup('/admin/leads/p1?view=profile');
+    await screen.findByText('Scoring');
+    expect(screen.queryByText(/their best campaign/)).not.toBeInTheDocument();
+  });
+
   it('the reason opens on hover, and on keyboard focus', async () => {
     fetchProspectProfile.mockResolvedValue(ENRICHED());
     setup('/admin/leads/p1?view=profile');


### PR DESCRIPTION
Asked directly, looking at a person card: **is it right to use her best lead's score?**

## Checked before answering

All six multi-signup people in prod have leads within **1 point** of each other:

| Leads | Worst | Best | Shown |
|---|---|---|---|
| 2 | 23 | 24 | 24 |
| 2 | 51 | 51 | 51 |
| 2 | 17 | 17 | 17 |
| …three more, spread 0 | | | |

So today the choice of aggregate changes nothing — and that is **only** because every campaign still shares one rulebook. Migration 100 lets a campaign carry its own weights. From the first approved per-campaign config, the same person genuinely scores differently on recruitment than on insurance, and "their best" starts meaning "their best at something you cannot see".

## The rule stays; the silence goes

**MAX is right** for the question the card asks — *is there an opportunity with this person at all?* An average belongs to no real lead and is traceable to nothing. A min is pessimistic nonsense.

Its one honest weakness: it is a max over a **growing** set, so more signups means more chances at a high number. Negligible at six people; worth watching if repeat signups grow.

What was actually wrong is that nothing said **which** lead won. Sharpest on the People directory, whose Meet/Buy columns **sort** on these numbers and name no campaign: a reader selling insurance sorts by Meet, sees 70, and is not told it is 70 for recruitment and 5 for them.

## The change

`projectPersonScore` already picks the winner and threw its identity away. Migration 101 adds one nullable column, written by **that same statement** — so there is no second copy of the tie-break to drift out of step with the first.

- **Person card** — `their best campaign — <name>` under the Meet/Buy dials
- **People rows** — `scored on <name>`, but only where `signupCount > 1`. With one signup there is nothing to disambiguate and it would be noise on 123 of 129 rows. The Meet/Buy tooltips name it either way.

## Two decisions worth reviewing

**No backfill.** Re-deriving the winner in one-shot SQL would duplicate exactly the logic this column exists to stop duplicating. Every person gets a label on their next rescore; until then the UI stays silent, which reads as "not known yet" rather than as a wrong campaign. Both states are tested.

**`ON DELETE SET NULL`, not the config table's no-FK snapshot.** Nothing here has to stay *resolvable* — it is a pointer to a live row used to name a campaign. If the winning lead is deleted the label should vanish, not name a ghost.

## Verification

- Backend unit — **107 suites / 1980 tests, no database reachable**
- Backend integration — **138 suites / 2699 tests**, private database
- `npx eslint src/ --quiet` exit 0 at both roots
- Frontend — **161 files / 2059 tests**
- Migration numbering re-checked against `origin/main` at naming and again before commit — 100 was still highest

`consumersList.test.js` pins the People row shape with a comment saying widening it is a decision, not a side effect. It caught this exactly as intended; the decision is recorded in that test rather than the guard loosened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENWdGMue9uXqmKv3pRG6YF
