### PR TITLE
feat(redeem-ops): the rest of the bulk partner actions, and the claim result actually being read

### DIFF
--- a/backend/src/controllers/redeemOps/partnersController.js
+++ b/backend/src/controllers/redeemOps/partnersController.js
@@ -3,7 +3,8 @@ import { asyncHandler, AppError } from '../../middleware/errorHandler.js';
 import partnerService from '../../services/redeemOps/partnerService.js';
 import { makeClaimService } from '../../services/redeemOps/claimService.js';
 import { makeDedupeService } from '../../services/redeemOps/dedupeService.js';
-import { LOST_REASONS } from '../../services/redeemOps/constants.js';
+import { BULK_MAX } from '../../services/redeemOps/bulkIds.js';
+import { LOST_REASONS, PIPELINE_STAGES } from '../../services/redeemOps/constants.js';
 
 const claimService = makeClaimService();
 const dedupeService = makeDedupeService();
@@ -113,6 +114,77 @@ export const assignPartner = asyncHandler(async (req, res) => {
   const body = validateBody(schema, req.body);
   const partner = await claimService.assignPartner(req.params.id, body.toUserId, req.user, body.reason || null, req.id);
   res.json({ success: true, data: { partner } });
+});
+
+/**
+ * The rest of the multi-select family. Each mirrors its single-row sibling's
+ * capability at the route and answers 200 with a per-row breakdown: a batch
+ * where some rows moved on since the page loaded is a normal outcome to report,
+ * not a failed request that should discard the rows that did work.
+ */
+const bulkIdsSchema = Joi.array().items(Joi.string().uuid()).min(1).max(BULK_MAX).required();
+
+/** "7 businesses released" / "7 of 10 released" — one phrasing for all of them. */
+function bulkMessage(done, requested, verb) {
+  return done === requested
+    ? `${done} business${done === 1 ? '' : 'es'} ${verb}`
+    : `${done} of ${requested} ${verb}`;
+}
+
+export const releasePartnersBulk = asyncHandler(async (req, res) => {
+  const schema = Joi.object({
+    partnerIds: bulkIdsSchema,
+    reason: Joi.string().max(255).allow('', null),
+  });
+  const body = validateBody(schema, req.body);
+  const result = await claimService.releasePartnersBulk(
+    body.partnerIds, req.user, body.reason || null, req.id
+  );
+  res.json({
+    success: true,
+    message: bulkMessage(result.released.length, body.partnerIds.length, 'released'),
+    data: result,
+  });
+});
+
+export const assignPartnersBulk = asyncHandler(async (req, res) => {
+  const schema = Joi.object({
+    partnerIds: bulkIdsSchema,
+    toUserId: Joi.string().uuid().required(),
+    reason: Joi.string().max(255).allow('', null),
+  });
+  const body = validateBody(schema, req.body);
+  const result = await claimService.assignPartnersBulk(
+    body.partnerIds, body.toUserId, req.user, body.reason || null, req.id
+  );
+  res.json({
+    success: true,
+    message: bulkMessage(result.assigned.length, body.partnerIds.length, 'assigned'),
+    data: result,
+  });
+});
+
+export const changeStageBulk = asyncHandler(async (req, res) => {
+  const schema = Joi.object({
+    partnerIds: bulkIdsSchema,
+    toStage: Joi.string().valid(...PIPELINE_STAGES).required(),
+    reason: Joi.string().max(255).allow('', null),
+    // Same rule as the single-row move, enforced BEFORE the loop so a LOST
+    // batch can't half-apply and then trip on a missing reason.
+    lostReason: Joi.string().valid(...LOST_REASONS).allow(null)
+      .when('toStage', { is: 'LOST', then: Joi.required() }),
+  });
+  const body = validateBody(schema, req.body);
+  const result = await partnerService.changeStageBulk(body.partnerIds, body.toStage, req.user, {
+    reason: body.reason || null,
+    lostReason: body.lostReason || null,
+    requestId: req.id,
+  });
+  res.json({
+    success: true,
+    message: bulkMessage(result.moved.length, body.partnerIds.length, 'moved'),
+    data: result,
+  });
 });
 
 export const changeStage = asyncHandler(async (req, res) => {

--- a/backend/src/routes/redeemOpsPartners.js
+++ b/backend/src/routes/redeemOpsPartners.js
@@ -25,14 +25,20 @@ router.get('/partners/:id', requireRedeemOps('partners.view'), ctrl.getPartner);
 router.put('/partners/:id', requireRedeemOps('partners.edit'), ctrl.updatePartner);
 
 // Ownership
-// Bulk claim sits BEFORE the :id routes — 'bulk-claim' would otherwise match
-// as an :id and 404 on a uuid lookup.
+// The bulk-* routes sit BEFORE the :id routes — 'bulk-claim' would otherwise
+// match as an :id and 404 on a uuid lookup. Each carries the SAME capability as
+// its single-row sibling, so multi-select can never be a way around a gate.
 router.post('/partners/bulk-claim', requireRedeemOps('partners.claim'), ctrl.claimPartnersBulk);
+router.post('/partners/bulk-release', requireRedeemOps('partners.release'), ctrl.releasePartnersBulk);
+router.post('/partners/bulk-assign', requireRedeemOps('partners.reassign'), ctrl.assignPartnersBulk);
 router.post('/partners/:id/claim', requireRedeemOps('partners.claim'), ctrl.claimPartner);
 router.post('/partners/:id/release', requireRedeemOps('partners.release'), ctrl.releasePartner);
 router.post('/partners/:id/assign', requireRedeemOps('partners.reassign'), ctrl.assignPartner);
 
 // Pipeline
+// POST, not PATCH like the single-row move: this is one action over many rows,
+// and it keeps the whole bulk-* family on one verb.
+router.post('/partners/bulk-stage', requireRedeemOps('pipeline.move'), ctrl.changeStageBulk);
 router.patch('/partners/:id/stage', requireRedeemOps('pipeline.move'), ctrl.changeStage);
 router.post('/partners/:id/stage/undo', requireRedeemOps('pipeline.move'), ctrl.undoStage);
 router.post('/partners/:id/snooze', requireRedeemOps('pipeline.move'), ctrl.snoozePartner);

--- a/backend/src/services/redeemOps/bulkIds.js
+++ b/backend/src/services/redeemOps/bulkIds.js
@@ -1,0 +1,25 @@
+import { AppError } from '../../middleware/errorHandler.js';
+
+/**
+ * The shared front door for every Partners multi-select action (claim, release,
+ * assign, stage). Its own module rather than a helper inside one service,
+ * because claimService and partnerService both need it and importing one into
+ * the other would risk a cycle through the cadence hooks.
+ *
+ * Multi-select cap: each row in a bulk action gets its OWN transaction, so a
+ * huge batch would hold a request open for a long time. The console's page size
+ * is well under this.
+ */
+export const BULK_MAX = 100;
+
+/**
+ * Dedupe + cap the ids a bulk action was handed, so a bad batch is refused
+ * before the first write rather than halfway through it. `verb` only shapes the
+ * empty-selection message ("…to claim" / "…to release").
+ */
+export function normaliseBulkIds(partnerIds, verb) {
+  const ids = [...new Set((partnerIds || []).map(String))];
+  if (!ids.length) throw new AppError(`Select at least one business to ${verb}`, 400);
+  if (ids.length > BULK_MAX) throw new AppError(`Select up to ${BULK_MAX} businesses at a time`, 400);
+  return ids;
+}

--- a/backend/src/services/redeemOps/claimService.js
+++ b/backend/src/services/redeemOps/claimService.js
@@ -3,10 +3,7 @@ import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';
 import { makeRedeemOpsAuditService } from './auditService.js';
 import { fireCadenceHook } from './cadenceHooks.js';
-
-// Multi-select cap. Each row is its own transaction, so a huge batch would hold
-// a request open for a long time; the console's page size is well under this.
-const BULK_CLAIM_MAX = 100;
+import { normaliseBulkIds } from './bulkIds.js';
 
 /**
  * Business claiming / ownership (docs/redeem-ops/ERD.md §4.1, brief §15).
@@ -106,11 +103,7 @@ export function makeClaimService(overrides = {}) {
    * caught and reported as a failure, never allowed to abandon the rest.
    */
   async function claimPartnersBulk(partnerIds, user, requestId = null) {
-    const ids = [...new Set((partnerIds || []).map(String))];
-    if (!ids.length) throw new AppError('Select at least one business to claim', 400);
-    if (ids.length > BULK_CLAIM_MAX) {
-      throw new AppError(`Claim up to ${BULK_CLAIM_MAX} businesses at a time`, 400);
-    }
+    const ids = normaliseBulkIds(partnerIds, 'claim');
 
     const claimed = [];
     const failed = [];
@@ -173,12 +166,64 @@ export function makeClaimService(overrides = {}) {
     });
   }
 
-  /** Manager assign/reassign to any active staff member (capability-gated at the route). */
-  async function assignPartner(partnerId, toUserId, actor, reason = null, requestId = null) {
+  /**
+   * Release many at once. Same per-row-transaction reasoning as the bulk claim:
+   * a rep handing back an estate will have rows that moved on since the page
+   * loaded, and one 403 must not undo the releases that were legitimate.
+   *
+   * The row-level gate is unchanged (`ownerUserId = :userId`), so this can only
+   * ever release the caller's OWN rows — a manager clearing someone else's book
+   * still has to reassign, exactly as on the detail page.
+   */
+  async function releasePartnersBulk(partnerIds, user, reason = null, requestId = null) {
+    const ids = normaliseBulkIds(partnerIds, 'release');
+    const released = [];
+    const failed = [];
+    for (const partnerId of ids) {
+      try {
+        await releasePartner(partnerId, user, reason, requestId);
+        released.push(partnerId);
+      } catch (err) {
+        if (err?.statusCode === 403) {
+          // releasePartner cannot tell "gone" from "not yours" — its UPDATE
+          // matches neither — so read the state to report the real reason.
+          const state = await conflictPayload(partnerId);
+          failed.push({
+            id: partnerId,
+            reason: !state ? 'not_found'
+              : state.claimedBy ? 'owned_by_other'
+                : state.archived ? 'archived'
+                  : state.merged ? 'merged' : 'not_owned',
+            claimedBy: state?.claimedBy || null,
+          });
+        } else {
+          d.logger.warn('redeem_ops.partner.bulk_release_row_failed', { partnerId, error: err?.message });
+          failed.push({ id: partnerId, reason: 'error', claimedBy: null });
+        }
+      }
+    }
+    d.logger.info('redeem_ops.partner.bulk_released', {
+      requestId, actorUserId: user.id, requested: ids.length, released: released.length,
+    });
+    return { released, failed };
+  }
+
+  /**
+   * The assignee rule, shared by the single-row assign and the bulk one so a
+   * batch can reject a bad target ONCE, before any row is written, instead of
+   * failing every row with the same message.
+   */
+  async function assertAssignableUser(toUserId) {
     const target = await d.User.findByPk(toUserId);
     if (!target || !target.isActive || !(target.role === 'redeem_ops' || target.role === 'admin' || target.redeemOpsRole)) {
       throw new AppError('Assignee must be an active Redeem Ops staff member', 400);
     }
+    return target;
+  }
+
+  /** Manager assign/reassign to any active staff member (capability-gated at the route). */
+  async function assignPartner(partnerId, toUserId, actor, reason = null, requestId = null) {
+    await assertAssignableUser(toUserId);
     return d.sequelize.transaction(async (t) => {
       const partner = await d.PartnerOrganisation.findByPk(partnerId, { transaction: t, lock: t.LOCK.UPDATE });
       if (!partner || partner.archivedAt || partner.mergedIntoId) {
@@ -212,11 +257,46 @@ export function makeClaimService(overrides = {}) {
     });
   }
 
-  return { claimPartner, claimPartnerTx, claimPartnersBulk, releasePartner, assignPartner };
+  /**
+   * Hand many businesses to one person — the manager's move when a rep leaves
+   * or a territory changes hands. The assignee is validated once up front (a
+   * bad target is the manager's mistake, not the rows'), then each row is its
+   * own transaction like every other bulk action.
+   */
+  async function assignPartnersBulk(partnerIds, toUserId, actor, reason = null, requestId = null) {
+    const ids = normaliseBulkIds(partnerIds, 'assign');
+    await assertAssignableUser(toUserId);
+    const assigned = [];
+    const failed = [];
+    for (const partnerId of ids) {
+      try {
+        await assignPartner(partnerId, toUserId, actor, reason, requestId);
+        assigned.push(partnerId);
+      } catch (err) {
+        const notFound = err?.statusCode === 404;
+        if (!notFound) {
+          d.logger.warn('redeem_ops.partner.bulk_assign_row_failed', { partnerId, error: err?.message });
+        }
+        failed.push({ id: partnerId, reason: notFound ? 'not_found' : 'error', claimedBy: null });
+      }
+    }
+    d.logger.info('redeem_ops.partner.bulk_assigned', {
+      requestId, actorUserId: actor.id, toUserId, requested: ids.length, assigned: assigned.length,
+    });
+    return { assigned, failed };
+  }
+
+  return {
+    claimPartner, claimPartnerTx, claimPartnersBulk,
+    releasePartner, releasePartnersBulk,
+    assignPartner, assignPartnersBulk, assertAssignableUser,
+  };
 }
 
 const _default = makeClaimService();
 export const claimPartner = _default.claimPartner;
 export const claimPartnersBulk = _default.claimPartnersBulk;
 export const releasePartner = _default.releasePartner;
+export const releasePartnersBulk = _default.releasePartnersBulk;
 export const assignPartner = _default.assignPartner;
+export const assignPartnersBulk = _default.assignPartnersBulk;

--- a/backend/src/services/redeemOps/partnerService.js
+++ b/backend/src/services/redeemOps/partnerService.js
@@ -12,6 +12,7 @@ import { makeRedeemOpsAuditService } from './auditService.js';
 import { makeDedupeService } from './dedupeService.js';
 import { hasCapability, canActOnPartnerRow } from './permissions.js';
 import { deriveMatchingKeys, postalDistrictOf } from './normalizers.js';
+import { normaliseBulkIds } from './bulkIds.js';
 import {
   PIPELINE_STAGES, STAGE_TRANSITIONS, PARTNER_AVAILABILITY,
   ACTIVITY_TYPES, MEANINGFUL_ACTIVITY_TYPES, LOST_REASONS,
@@ -328,6 +329,45 @@ export function makePartnerService(overrides = {}) {
   async function changeStage(id, toStage, user, reason = null, requestId = null, lostReason = null) {
     return d.sequelize.transaction(async (t) =>
       changeStageTx(id, toStage, user, t, { reason, requestId, lostReason }));
+  }
+
+  /**
+   * Move many rows to one stage — the list's multi-select after a roadshow,
+   * where twenty businesses were all contacted in one afternoon.
+   *
+   * Per-row transactions, like every other bulk action, but the refusals matter
+   * more here than anywhere else: the stage machine legitimately rejects rows
+   * for FOUR different reasons (not the caller's row, illegal jump from where it
+   * happens to sit, a backward move with no reason given, PARTNERED entry
+   * requirements unmet), and each carries a message the operator can act on. So
+   * every failure keeps the machine's own words rather than being flattened to
+   * a code — a batch that moves 12 of 20 has to say why the other 8 stayed.
+   */
+  async function changeStageBulk(partnerIds, toStage, user, opts = {}) {
+    const { reason = null, lostReason = null, requestId = null } = opts;
+    const ids = normaliseBulkIds(partnerIds, 'move');
+    const moved = [];
+    const failed = [];
+    for (const id of ids) {
+      try {
+        await changeStage(id, toStage, user, reason, requestId, lostReason);
+        moved.push(id);
+      } catch (err) {
+        const code = err?.statusCode;
+        const reasonCode = code === 403 ? 'not_owner'
+          : code === 404 ? 'not_found'
+            : code === 422 ? 'entry_requirements'
+              : code === 400 ? 'rejected' : 'error';
+        if (reasonCode === 'error') {
+          d.logger.warn('redeem_ops.partner.bulk_stage_row_failed', { partnerId: id, error: err?.message });
+        }
+        failed.push({ id, reason: reasonCode, message: reasonCode === 'error' ? null : err?.message || null });
+      }
+    }
+    d.logger.info('redeem_ops.partner.bulk_stage_changed', {
+      requestId, actorUserId: user.id, toStage, requested: ids.length, moved: moved.length,
+    });
+    return { moved, failed };
   }
 
   // ── Timeline & activities ────────────────────────────────────────────────
@@ -929,7 +969,7 @@ export function makePartnerService(overrides = {}) {
   }
 
   return {
-    listPartners, getPartner, createPartner, updatePartner, changeStage, undoStageChange,
+    listPartners, getPartner, createPartner, updatePartner, changeStage, changeStageBulk, undoStageChange,
     snoozePartner, unsnoozePartner,
     importPartners, getTimeline, logActivity, editActivity, voidActivity,
     addContact, updateContact, archiveContact, addLocation, updateLocation,

--- a/backend/test/redeemOpsPartners.test.js
+++ b/backend/test/redeemOpsPartners.test.js
@@ -11,6 +11,7 @@ import request from 'supertest';
 import { getApp, closeDb, createTestUser, seedRedeemOpsCategory } from './helpers.js';
 import {
   PartnerOrganisation, PartnerContact, OutreachActivity,
+  PartnerAssignmentEvent, PartnerStageEvent,
   RewardOffer, Activation, RewardEntitlement, Redemption, RewardInventoryEvent,
   RedeemOpsAuditEvent,
 } from '../src/models/index.js';
@@ -214,6 +215,187 @@ describe('claiming (concurrency-safe)', () => {
     expect(ok.status).toBe(200);
     const row = await PartnerOrganisation.findByPk(partnerId);
     expect(row.ownerUserId).toBe(execB.user.id);
+  });
+});
+
+/**
+ * The rest of the multi-select family. Same contract as the bulk claim: a
+ * PARTIAL batch is a success reported per row, the row-level gates are the same
+ * ones the single-row routes enforce, and every applied row still writes its own
+ * assignment/stage event.
+ */
+describe('bulk release / assign / stage', () => {
+  const bulkUrl = (action) => `/api/redeem-ops/partners/bulk-${action}`;
+  const byId = (rows) => Object.fromEntries(rows.map((r) => [r.id, r]));
+
+  /** A fresh unowned row (random name so the dedupe gate never fires). */
+  async function freshPartner(label) {
+    const res = await createPartner(admin.token, {
+      tradingName: `${label} ${randomBytes(4).toString('hex')}`,
+    });
+    expect(res.status).toBe(201);
+    return res.body.data.partner.id;
+  }
+  const claimAs = (id, who) => request(app)
+    .post(`/api/redeem-ops/partners/${id}/claim`).set(auth(who.token));
+
+  test('BULK release: only the caller’s own rows go back to the pool', async () => {
+    const mine = await freshPartner('Bulk Release Mine');
+    const theirs = await freshPartner('Bulk Release Theirs');
+    const unowned = await freshPartner('Bulk Release Unowned');
+    await claimAs(mine, execA);
+    await claimAs(theirs, execB);
+
+    const res = await request(app).post(bulkUrl('release')).set(auth(execA.token))
+      .send({ partnerIds: [mine, theirs, unowned], reason: 'handover' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.released).toEqual([mine]);
+    expect(res.body.message).toMatch(/1 of 3/);
+    const failed = byId(res.body.data.failed);
+    // A teammate's row names the teammate; an unowned one just isn't owned.
+    expect(failed[theirs]).toMatchObject({ reason: 'owned_by_other' });
+    expect(failed[theirs].claimedBy.fullName).toBe(execB.user.fullName);
+    expect(failed[unowned]).toMatchObject({ reason: 'not_owned' });
+
+    const mineRow = await PartnerOrganisation.findByPk(mine);
+    expect(mineRow.ownerUserId).toBeNull();
+    expect(mineRow.availability).toBe('available');
+    expect((await PartnerAssignmentEvent.findOne({
+      where: { partnerOrganisationId: mine, kind: 'release' },
+    })).reason).toBe('handover');
+    // The one that wasn't the caller's is untouched.
+    expect((await PartnerOrganisation.findByPk(theirs)).ownerUserId).toBe(execB.user.id);
+  });
+
+  test('BULK assign: a mixed batch lands on one person, each row recording from → to', async () => {
+    const owned = await freshPartner('Bulk Assign Owned');
+    const free = await freshPartner('Bulk Assign Free');
+    await claimAs(owned, execA);
+
+    const res = await request(app).post(bulkUrl('assign')).set(auth(bdm.token))
+      .send({ partnerIds: [owned, free], toUserId: execB.user.id, reason: 'territory swap' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.assigned.sort()).toEqual([owned, free].sort());
+    expect(res.body.data.failed).toHaveLength(0);
+    for (const id of [owned, free]) {
+      expect((await PartnerOrganisation.findByPk(id)).ownerUserId).toBe(execB.user.id);
+    }
+    const reassign = await PartnerAssignmentEvent.findOne({
+      where: { partnerOrganisationId: owned, kind: 'reassign' },
+    });
+    expect(reassign.fromUserId).toBe(execA.user.id);
+    expect(reassign.toUserId).toBe(execB.user.id);
+    // The unowned one is an assign, not a reassign — there was no 'from'.
+    expect((await PartnerAssignmentEvent.findOne({
+      where: { partnerOrganisationId: free, kind: 'assign' },
+    })).fromUserId).toBeNull();
+  });
+
+  test('BULK assign to someone who is not ops staff fails the request, writing nothing', async () => {
+    const id = await freshPartner('Bulk Assign Outsider');
+    const outsider = await createTestUser({ role: 'agent' });
+    const res = await request(app).post(bulkUrl('assign')).set(auth(bdm.token))
+      .send({ partnerIds: [id], toUserId: outsider.user.id });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/active Redeem Ops staff/i);
+    expect((await PartnerOrganisation.findByPk(id)).ownerUserId).toBeNull();
+  });
+
+  test('BULK stage: legal moves land, refusals keep the machine’s own words', async () => {
+    const moves = await freshPartner('Bulk Stage Moves');
+    const already = await freshPartner('Bulk Stage Already');
+    const notMine = await freshPartner('Bulk Stage Not Mine');
+    await claimAs(moves, execA);
+    await claimAs(already, execA);
+    await claimAs(notMine, execB);
+    await request(app).patch(`/api/redeem-ops/partners/${already}/stage`)
+      .set(auth(execA.token)).send({ toStage: 'CONTACTED' });
+
+    const res = await request(app).post(bulkUrl('stage')).set(auth(execA.token))
+      .send({ partnerIds: [moves, already, notMine], toStage: 'CONTACTED' });
+
+    expect(res.status).toBe(200);
+    // The already-there row is a no-op, not a failure.
+    expect(res.body.data.moved.sort()).toEqual([moves, already].sort());
+    const failed = byId(res.body.data.failed);
+    expect(failed[notMine].reason).toBe('not_owner');
+    expect(failed[notMine].message).toMatch(/only move businesses you own/i);
+
+    expect((await PartnerOrganisation.findByPk(moves)).pipelineStage).toBe('CONTACTED');
+    expect((await PartnerStageEvent.findOne({
+      where: { partnerOrganisationId: moves, toStage: 'CONTACTED' },
+    })).actorUserId).toBe(execA.user.id);
+    expect((await PartnerOrganisation.findByPk(notMine)).pipelineStage).toBe('NEW');
+  });
+
+  test('BULK stage: an illegal jump is a reported skip, never a 500', async () => {
+    const id = await freshPartner('Bulk Stage Leap');
+    await claimAs(id, execA);
+    const res = await request(app).post(bulkUrl('stage')).set(auth(execA.token))
+      .send({ partnerIds: [id], toStage: 'PARTNERED' }); // NEW → PARTNERED
+    expect(res.status).toBe(200);
+    expect(res.body.data.moved).toHaveLength(0);
+    expect(res.body.data.failed[0].reason).toBe('rejected');
+    expect((await PartnerOrganisation.findByPk(id)).pipelineStage).toBe('NEW');
+  });
+
+  test('BULK stage → LOST needs a reason, and records it', async () => {
+    const id = await freshPartner('Bulk Stage Lost');
+    await claimAs(id, execA);
+
+    const bad = await request(app).post(bulkUrl('stage')).set(auth(execA.token))
+      .send({ partnerIds: [id], toStage: 'LOST' });
+    expect(bad.status).toBe(400); // refused BEFORE any row is written
+    expect((await PartnerOrganisation.findByPk(id)).pipelineStage).toBe('NEW');
+
+    const ok = await request(app).post(bulkUrl('stage')).set(auth(execA.token))
+      .send({ partnerIds: [id], toStage: 'LOST', lostReason: 'not_interested' });
+    expect(ok.status).toBe(200);
+    const row = await PartnerOrganisation.findByPk(id);
+    expect(row.pipelineStage).toBe('LOST');
+    expect(row.lostReason).toBe('not_interested');
+    expect(row.availability).toBe('disqualified'); // leaves the working pool
+  });
+
+  test('each bulk route carries its single-row sibling’s capability', async () => {
+    const id = await freshPartner('Bulk Caps');
+    await claimAs(id, execA);
+    // An outreach exec claims and releases but never reassigns.
+    expect((await request(app).post(bulkUrl('release')).set(auth(execA.token))
+      .send({ partnerIds: [id] })).status).toBe(200);
+    expect((await request(app).post(bulkUrl('assign')).set(auth(execA.token))
+      .send({ partnerIds: [id], toUserId: execB.user.id })).status).toBe(403);
+    // An analyst can see partners and do none of it.
+    const analyst = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'analyst' });
+    for (const [action, body] of [
+      ['release', { partnerIds: [id] }],
+      ['assign', { partnerIds: [id], toUserId: execB.user.id }],
+      ['stage', { partnerIds: [id], toStage: 'CONTACTED' }],
+    ]) {
+      expect((await request(app).post(bulkUrl(action)).set(auth(analyst.token))
+        .send(body)).status).toBe(403);
+    }
+  });
+
+  test('every bulk route refuses an empty or oversized batch', async () => {
+    const id = await freshPartner('Bulk Shape');
+    for (const [action, extra] of [
+      ['release', {}],
+      ['assign', { toUserId: bdm.user.id }],
+      ['stage', { toStage: 'CONTACTED' }],
+    ]) {
+      const empty = await request(app).post(bulkUrl(action)).set(auth(admin.token))
+        .send({ partnerIds: [], ...extra });
+      expect(empty.status).toBe(400);
+      const huge = await request(app).post(bulkUrl(action)).set(auth(admin.token))
+        .send({ partnerIds: Array.from({ length: 101 }, (_, i) => `00000000-0000-4000-8000-${String(i).padStart(12, '0')}`), ...extra });
+      expect(huge.status).toBe(400);
+    }
+    // …and the ids must be uuids.
+    expect((await request(app).post(bulkUrl('release')).set(auth(admin.token))
+      .send({ partnerIds: [id, 'not-a-uuid'] })).status).toBe(400);
   });
 });
 

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -158,10 +158,30 @@ export const redeemOpsApi = {
     const res = await apiClient.post(`/redeem-ops/partners/${id}/claim`, {});
     return res.data;
   },
-  /** Multi-select claim → { claimed: [id], failed: [{ id, reason, claimedBy }] }. */
+  /**
+   * The multi-select family. Every one of these returns the INNER data object
+   * (apiClient resolves `{ success, message, data }` and we hand back `data`),
+   * so a caller reads `{ claimed }` / `{ released }` directly — there is no
+   * `.data` or `.message` inside what comes back. A batch is routinely partial:
+   * read both lists, never assume everything applied.
+   */
   async claimPartnersBulk(partnerIds) {
     const res = await apiClient.post('/redeem-ops/partners/bulk-claim', { partnerIds });
-    return res.data;
+    return res.data; // { claimed: [id], failed: [{ id, reason, claimedBy }] }
+  },
+  async releasePartnersBulk(partnerIds, reason) {
+    const res = await apiClient.post('/redeem-ops/partners/bulk-release', { partnerIds, reason });
+    return res.data; // { released: [id], failed: [{ id, reason, claimedBy }] }
+  },
+  async assignPartnersBulk(partnerIds, toUserId, reason) {
+    const res = await apiClient.post('/redeem-ops/partners/bulk-assign', { partnerIds, toUserId, reason });
+    return res.data; // { assigned: [id], failed: [{ id, reason }] }
+  },
+  async changeStageBulk(partnerIds, toStage, { reason, lostReason } = {}) {
+    const res = await apiClient.post('/redeem-ops/partners/bulk-stage', {
+      partnerIds, toStage, reason, lostReason,
+    });
+    return res.data; // { moved: [id], failed: [{ id, reason, message }] }
   },
   async releasePartner(id, reason) {
     const res = await apiClient.post(`/redeem-ops/partners/${id}/release`, { reason });

--- a/src/pages/redeemops/PartnersList.jsx
+++ b/src/pages/redeemops/PartnersList.jsx
@@ -78,6 +78,13 @@ export default function PartnersList() {
   // Multi-select for bulk actions. Ids only — the row objects are re-fetched
   // constantly, and holding them would go stale the moment a claim lands.
   const [selected, setSelected] = useState(() => new Set());
+  // Bulk actions that need a target or a reason ask for it first.
+  const [assignOpen, setAssignOpen] = useState(false);
+  const [stageOpen, setStageOpen] = useState(false);
+  const [releaseOpen, setReleaseOpen] = useState(false);
+  const [stagePick, setStagePick] = useState(null);
+  const [bulkLostReason, setBulkLostReason] = useState(null);
+  const [bulkReason, setBulkReason] = useState('');
 
   const constants = useQuery({
     queryKey: ['redeem-ops', 'constants'],
@@ -156,7 +163,13 @@ export default function PartnersList() {
   // backend surface, works for the list sizes a 3-person team imports.
   const user = useAuthStore((st) => st.user);
   const canImport = hasCapability(user, 'partners.import');
+  // One capability per bulk action, each the same one its single-row button
+  // answers to — an outreach exec claims and releases, only a BDM+ reassigns.
   const canClaim = hasCapability(user, 'partners.claim');
+  const canRelease = hasCapability(user, 'partners.release');
+  const canReassign = hasCapability(user, 'partners.reassign');
+  const canMoveStage = hasCapability(user, 'pipeline.move');
+  const canBulk = canClaim || canRelease || canReassign || canMoveStage;
   const [importOpen, setImportOpen] = useState(false);
   const [importState, setImportState] = useState(null); // null | {running, done, total, created, skipped, failed, errors[]}
 
@@ -212,55 +225,144 @@ export default function PartnersList() {
   const pagination = listQuery.data?.pagination;
   const stages = constants.data?.pipelineStages || [];
 
-  // Only unowned, live rows can be claimed — the same predicate the server's
-  // conditional UPDATE enforces, so the UI never offers what the API refuses.
-  const claimable = (p) => !p.ownerUserId && p.availability === 'available' && !p.archivedAt && !p.mergedIntoId;
-  const claimableIds = partners.filter(claimable).map((p) => p.id);
+  // A live row is selectable. Claiming is still gated on being UNOWNED — the
+  // same predicate the server's conditional UPDATE enforces — but the other
+  // three actions apply precisely to rows that ARE owned, so "unclaimable" can
+  // no longer mean "unselectable": releasing and reassigning would be
+  // unreachable from the list otherwise.
+  const selectable = (p) => !p.archivedAt && !p.mergedIntoId;
+  const claimable = (p) => selectable(p) && !p.ownerUserId && p.availability === 'available';
+  const selectableIds = partners.filter(selectable).map((p) => p.id);
   const selectedIds = [...selected];
   // Selection mode: once anything is ticked, the whole row becomes the
   // checkbox. Navigating away mid-selection would silently discard the
   // selection, so in this mode a row click NEVER opens the detail page —
   // Clear (or unticking the last row) hands normal clicking back.
-  const selectionMode = canClaim && selected.size > 0;
-  const allSelected = claimableIds.length > 0 && claimableIds.every((id) => selected.has(id));
+  const selectionMode = canBulk && selected.size > 0;
+  const allSelected = selectableIds.length > 0 && selectableIds.every((id) => selected.has(id));
   const toggleOne = (id) => setSelected((prev) => {
     const next = new Set(prev);
     if (next.has(id)) next.delete(id); else next.add(id);
     return next;
   });
   const toggleAllOnPage = () => setSelected((prev) => {
-    // Scoped to THIS page's claimable rows — never a silent "select all 2,000".
+    // Scoped to THIS page — never a silent "select all 2,000".
     const next = new Set(prev);
-    if (allSelected) claimableIds.forEach((id) => next.delete(id));
-    else claimableIds.forEach((id) => next.add(id));
+    if (allSelected) selectableIds.forEach((id) => next.delete(id));
+    else selectableIds.forEach((id) => next.add(id));
     return next;
   });
 
+  // How many of the selection each action can actually touch. Rows selected on
+  // an earlier page aren't held in memory (ids only), so they're counted as
+  // eligible and the server reports back on them — the alternative is greying
+  // out a button over rows it would have happily acted on.
+  const selectedOnPage = partners.filter((p) => selected.has(p.id));
+  const offPage = selected.size - selectedOnPage.length;
+  const countFor = (pred) => selectedOnPage.filter(pred).length + offPage;
+  const claimCount = countFor(claimable);
+  const releaseCount = countFor((p) => p.ownerUserId && p.ownerUserId === user?.id);
+
+  /**
+   * Every bulk action lands here. A batch is routinely PARTIAL — someone else
+   * took one a second ago, one isn't yours to move — so the toast names what
+   * happened and only the ids that ACTUALLY landed are deselected, leaving a
+   * retry holding exactly the ones that didn't.
+   */
+  const bulkOutcome = ({ done, failed, verb, describe }) => {
+    const n = done.length;
+    const headline = failed.length === 0
+      ? `${n} business${n === 1 ? '' : 'es'} ${verb}`
+      : `${n} of ${n + failed.length} ${verb}`;
+    if (failed.length === 0) toast.success(headline);
+    else toast.warning(headline, { description: describe(failed) });
+    setSelected((prev) => {
+      const next = new Set(prev);
+      done.forEach((id) => next.delete(id));
+      return next;
+    });
+    queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partners'] });
+  };
+
   const bulkClaimMutation = useMutation({
     mutationFn: (ids) => redeemOpsApi.claimPartnersBulk(ids),
-    onSuccess: ({ data, message }) => {
-      const lost = data?.failed || [];
-      // Partial success is the NORMAL outcome — someone else may have taken one
-      // a second ago — so name what happened instead of a flat "done".
-      if (lost.length === 0) toast.success(message);
-      else {
+    // NOTE: the api method hands back the INNER data object, so the result is
+    // { claimed, failed } — reading a nested `.data`/`.message` here silently
+    // left the toast blank and never cleared the selection.
+    onSuccess: ({ claimed = [], failed = [] }) => bulkOutcome({
+      done: claimed, failed, verb: 'claimed',
+      describe: (lost) => {
         const taken = lost.filter((f) => f.reason === 'already_claimed');
-        toast.warning(message, {
-          description: taken.length
-            ? `${taken.length} already claimed${taken[0].claimedBy ? ` (e.g. by ${taken[0].claimedBy.fullName})` : ''}.`
-            : `${lost.length} could not be claimed.`,
-        });
-      }
-      // Clear only what actually landed, so a retry keeps the ones that didn't.
-      setSelected((prev) => {
-        const next = new Set(prev);
-        (data?.claimed || []).forEach((id) => next.delete(id));
-        return next;
-      });
-      queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partners'] });
-    },
+        return taken.length
+          ? `${taken.length} already claimed${taken[0].claimedBy ? ` (e.g. by ${taken[0].claimedBy.fullName})` : ''}.`
+          : `${lost.length} could not be claimed.`;
+      },
+    }),
     onError: (err) => toast.error('Could not claim', { description: err.message }),
   });
+
+  const bulkReleaseMutation = useMutation({
+    mutationFn: ({ ids, reason }) => redeemOpsApi.releasePartnersBulk(ids, reason),
+    onSuccess: ({ released = [], failed = [] }) => {
+      bulkOutcome({
+        done: released, failed, verb: 'released',
+        describe: (lost) => {
+          const notYours = lost.filter((f) => f.reason === 'owned_by_other' || f.reason === 'not_owned');
+          return notYours.length
+            ? `${notYours.length} not yours to release — reassign those instead.`
+            : `${lost.length} could not be released.`;
+        },
+      });
+      setReleaseOpen(false);
+      setBulkReason('');
+    },
+    onError: (err) => toast.error('Could not release', { description: err.message }),
+  });
+
+  const bulkAssignMutation = useMutation({
+    mutationFn: ({ ids, toUserId, reason }) => redeemOpsApi.assignPartnersBulk(ids, toUserId, reason),
+    onSuccess: ({ assigned = [], failed = [] }) => {
+      bulkOutcome({
+        done: assigned, failed, verb: 'assigned',
+        describe: (lost) => `${lost.length} could not be assigned.`,
+      });
+      setAssignOpen(false);
+      setBulkReason('');
+    },
+    onError: (err) => toast.error('Could not assign', { description: err.message }),
+  });
+
+  const bulkStageMutation = useMutation({
+    mutationFn: ({ ids, toStage, reason, lostReason }) => (
+      redeemOpsApi.changeStageBulk(ids, toStage, { reason, lostReason })
+    ),
+    onSuccess: ({ moved = [], failed = [] }) => {
+      bulkOutcome({
+        done: moved, failed, verb: 'moved',
+        // The stage machine refuses rows for four different reasons, each with
+        // wording the operator can act on — so quote it rather than count it.
+        describe: (lost) => {
+          const first = lost.find((f) => f.message)?.message;
+          return first ? `${lost.length} stayed put — ${first}` : `${lost.length} could not be moved.`;
+        },
+      });
+      setStageOpen(false);
+      setStagePick(null);
+      setBulkLostReason(null);
+      setBulkReason('');
+    },
+    onError: (err) => toast.error('Could not move', { description: err.message }),
+  });
+
+  const bulkBusy = bulkClaimMutation.isPending || bulkReleaseMutation.isPending
+    || bulkAssignMutation.isPending || bulkStageMutation.isPending;
+
+  const teamQuery = useQuery({
+    queryKey: ['redeem-ops', 'team'],
+    queryFn: redeemOpsApi.getTeam,
+    enabled: canReassign,
+  });
+  const assignees = (teamQuery.data || []).filter((m) => m.isActive);
   const needsOverride = (duplicates?.exact?.length || 0) > 0;
 
   const partnerName = (p) => p.tradingName || p.brandName || p.legalName;
@@ -354,18 +456,45 @@ export default function PartnersList() {
             </p>
           )}
         </div>
-        {canClaim && selectedIds.length > 0 && (
+        {canBulk && selectedIds.length > 0 && (
           <div role="status"
-            className="hidden md:flex items-center gap-3 px-5 py-2.5 border-t border-border"
+            className="hidden md:flex items-center gap-3 flex-wrap px-5 py-2.5 border-t border-border"
             style={{ background: 'var(--ro-subtle)' }}>
             <span className="text-[13px] font-semibold">
               <span className="tabular-nums">{selectedIds.length}</span> selected
             </span>
-            <Button size="sm" className="font-semibold"
-              disabled={bulkClaimMutation.isPending}
-              onClick={() => bulkClaimMutation.mutate(selectedIds)}>
-              {bulkClaimMutation.isPending ? 'Claiming…' : 'Claim'}
-            </Button>
+            {canClaim && (
+              // The count is the honest one: claiming skips rows that already
+              // have an owner, so the button says how many it can take.
+              <Button size="sm" className="font-semibold"
+                disabled={bulkBusy || claimCount === 0}
+                onClick={() => bulkClaimMutation.mutate(selectedIds)}>
+                {bulkClaimMutation.isPending ? 'Claiming…' : `Claim ${claimCount}`}
+              </Button>
+            )}
+            {canReassign && (
+              <Button size="sm" variant="outline" className="font-semibold"
+                disabled={bulkBusy}
+                onClick={() => { setBulkReason(''); setAssignOpen(true); }}>
+                Assign to…
+              </Button>
+            )}
+            {canMoveStage && (
+              <Button size="sm" variant="outline" className="font-semibold"
+                disabled={bulkBusy}
+                onClick={() => {
+                  setStagePick(null); setBulkLostReason(null); setBulkReason(''); setStageOpen(true);
+                }}>
+                Move stage
+              </Button>
+            )}
+            {canRelease && (
+              <Button size="sm" variant="outline" className="font-semibold"
+                disabled={bulkBusy || releaseCount === 0}
+                onClick={() => { setBulkReason(''); setReleaseOpen(true); }}>
+                {`Release ${releaseCount}`}
+              </Button>
+            )}
             <button type="button" className="ro-link text-[12.5px] font-semibold"
               onClick={() => setSelected(new Set())}>Clear</button>
           </div>
@@ -374,10 +503,10 @@ export default function PartnersList() {
           <table className="w-full text-sm border-collapse">
             <thead>
               <tr className="text-left" style={{ color: 'var(--ro-text-2)' }}>
-                {canClaim && (
+                {canBulk && (
                   <th className="w-10 pl-5 pr-0 py-3">
-                    <input type="checkbox" aria-label="Select all claimable on this page"
-                      checked={allSelected} disabled={claimableIds.length === 0}
+                    <input type="checkbox" aria-label="Select all on this page"
+                      checked={allSelected} disabled={selectableIds.length === 0}
                       onChange={toggleAllOnPage}
                       className="w-4 h-4 align-middle cursor-pointer disabled:opacity-40" />
                   </th>
@@ -395,27 +524,26 @@ export default function PartnersList() {
                   key={p.id}
                   aria-selected={selectionMode ? selected.has(p.id) : undefined}
                   className={`border-t border-border transition-colors ${
-                    selectionMode && !claimable(p)
+                    selectionMode && !selectable(p)
                       ? 'cursor-default opacity-60'
                       : 'cursor-pointer hover:bg-[var(--ro-subtle)]'
                   }`}
                   style={selected.has(p.id) ? { background: 'var(--ro-subtle)' } : undefined}
                   onClick={() => {
-                    // In selection mode an unclaimable row is inert: it cannot be
-                    // ticked, and opening it would throw away the selection.
+                    // In selection mode a non-selectable row is inert: it cannot
+                    // be ticked, and opening it would throw away the selection.
                     if (!selectionMode) { navigate(`/redeem-ops/partners/${p.id}`); return; }
-                    if (claimable(p)) toggleOne(p.id);
+                    if (selectable(p)) toggleOne(p.id);
                   }}
                 >
-                  {canClaim && (
+                  {canBulk && (
                     // stopPropagation: the row itself navigates to the detail
                     // page, and selecting must never take you off the list.
                     <td className="w-10 pl-5 pr-0 py-2.5" onClick={(e) => e.stopPropagation()}>
                       <input type="checkbox"
                         aria-label={`Select ${partnerName(p)}`}
                         checked={selected.has(p.id)}
-                        disabled={!claimable(p)}
-                        title={claimable(p) ? undefined : 'Already owned — release it first'}
+                        disabled={!selectable(p)}
                         onChange={() => toggleOne(p.id)}
                         className="w-4 h-4 align-middle cursor-pointer disabled:opacity-30" />
                     </td>
@@ -470,6 +598,148 @@ export default function PartnersList() {
           </div>
         )}
       </div>
+
+      <Dialog open={assignOpen} onOpenChange={setAssignOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>
+              Assign {selectedIds.length} business{selectedIds.length === 1 ? '' : 'es'}
+            </DialogTitle>
+            <DialogDescription>
+              Hands ownership over, whoever holds them now. Each row gets its own
+              timeline entry naming who it came from.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-1.5">
+            <Label>Reason (optional)</Label>
+            <Input value={bulkReason} onChange={(e) => setBulkReason(e.target.value)}
+              placeholder="e.g. territory swap" />
+          </div>
+          <div className="flex flex-col gap-1.5 max-h-[45dvh] overflow-y-auto">
+            {assignees.map((m) => (
+              <button
+                key={m.id}
+                type="button"
+                disabled={bulkBusy}
+                className="h-[44px] px-4 rounded-xl text-[13.5px] font-semibold border text-left cursor-pointer flex items-center gap-2.5 disabled:opacity-50"
+                style={{ background: '#fff', borderColor: 'var(--ro-border-strong)', color: 'var(--ro-bunker)' }}
+                onClick={() => bulkAssignMutation.mutate({
+                  ids: selectedIds, toUserId: m.id, reason: bulkReason.trim() || null,
+                })}
+              >
+                <RoAvatar name={m.fullName || m.email} size={26} />
+                <span className="truncate">{m.fullName || m.email}</span>
+              </button>
+            ))}
+            {assignees.length === 0 && (
+              <p className="text-sm m-0" style={{ color: 'var(--ro-text-2)' }}>
+                No active team members to assign to.
+              </p>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={stageOpen} onOpenChange={setStageOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>
+              Move {selectedIds.length} business{selectedIds.length === 1 ? '' : 'es'}
+            </DialogTitle>
+            <DialogDescription>
+              Each row is checked against the stage it sits in now. Anything that
+              can’t make the jump — or isn’t yours to move — stays put and is named.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-1.5">
+            {stages.map((st) => (
+              <button
+                key={st}
+                type="button"
+                onClick={() => { setStagePick(st); if (st !== 'LOST') setBulkLostReason(null); }}
+                className="h-[42px] px-4 rounded-xl text-[13px] font-semibold border text-left cursor-pointer"
+                style={st === stagePick
+                  ? { background: 'var(--ro-bunker)', borderColor: 'var(--ro-bunker)', color: '#fff' }
+                  : st === 'LOST'
+                    ? { background: '#fff', borderColor: 'var(--ro-tag-red-fg)', color: 'var(--ro-tag-red-fg)' }
+                    : { background: '#fff', borderColor: 'var(--ro-border-strong)', color: 'var(--ro-bunker)' }}
+              >
+                {prettyEnum(st)}
+              </button>
+            ))}
+          </div>
+          {stagePick === 'LOST' && (
+            <div className="space-y-1.5">
+              <Label>Why lost? (required)</Label>
+              <div className="flex flex-wrap gap-1.5">
+                {(constants.data?.lostReasons || []).map((r) => (
+                  <button
+                    key={r}
+                    type="button"
+                    onClick={() => setBulkLostReason(r)}
+                    className="h-[34px] px-3 rounded-full text-[12.5px] font-semibold border cursor-pointer"
+                    style={r === bulkLostReason
+                      ? { background: 'var(--ro-bunker)', borderColor: 'var(--ro-bunker)', color: '#fff' }
+                      : { background: '#fff', borderColor: 'var(--ro-border-strong)', color: 'var(--ro-bunker)' }}
+                  >
+                    {prettyEnum(r)}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+          <div className="space-y-1.5">
+            <Label>Reason (required for a backward move)</Label>
+            <Input value={bulkReason} onChange={(e) => setBulkReason(e.target.value)}
+              placeholder="e.g. mis-dropped after the roadshow" />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setStageOpen(false)}>Cancel</Button>
+            <Button
+              disabled={!stagePick || bulkBusy || (stagePick === 'LOST' && !bulkLostReason)}
+              onClick={() => bulkStageMutation.mutate({
+                ids: selectedIds,
+                toStage: stagePick,
+                reason: bulkReason.trim() || null,
+                lostReason: stagePick === 'LOST' ? bulkLostReason : null,
+              })}
+            >
+              {bulkStageMutation.isPending ? 'Moving…' : `Move ${selectedIds.length}`}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={releaseOpen} onOpenChange={setReleaseOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>
+              Release {releaseCount} business{releaseCount === 1 ? '' : 'es'}
+            </DialogTitle>
+            <DialogDescription>
+              Hands them back to the unowned pool for anyone to claim. Only rows you
+              own can be released — a teammate’s stay with them.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-1.5">
+            <Label>Reason (optional)</Label>
+            <Input value={bulkReason} onChange={(e) => setBulkReason(e.target.value)}
+              placeholder="e.g. handing the estate over" />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setReleaseOpen(false)}>Cancel</Button>
+            <Button
+              variant="destructive"
+              disabled={bulkBusy}
+              onClick={() => bulkReleaseMutation.mutate({
+                ids: selectedIds, reason: bulkReason.trim() || null,
+              })}
+            >
+              {bulkReleaseMutation.isPending ? 'Releasing…' : 'Release'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={importOpen} onOpenChange={(open) => { if (!open && !importState?.running) { setImportOpen(false); setImportState(null); } }}>
         <DialogContent className="max-w-md">

--- a/src/pages/redeemops/__tests__/PartnersList.selection.test.jsx
+++ b/src/pages/redeemops/__tests__/PartnersList.selection.test.jsx
@@ -1,12 +1,19 @@
 /**
- * PartnersList — multi-select and bulk claim.
+ * PartnersList — multi-select and the four bulk actions.
  *
- * The behaviours worth pinning: only claimable rows are selectable (the UI must
- * never offer what the server's conditional UPDATE would refuse), selection
- * mode turns the whole row into the checkbox so a stray click can't navigate
- * away and silently discard the selection, and a partially-successful claim
- * reports what actually happened instead of a flat "done".
- * redeemOpsApi is fully mocked — no network.
+ * The behaviours worth pinning:
+ * - selection mode turns the whole row into the checkbox, so a stray click
+ *   can't navigate away and silently discard the selection;
+ * - every live row is selectable, because release and reassign apply precisely
+ *   to rows that ARE owned — but each button counts only the rows IT can touch,
+ *   so the UI still never promises what the server would refuse;
+ * - a partially-successful batch reports what actually happened, and only the
+ *   ids that landed are deselected;
+ * - each action is behind its own capability.
+ *
+ * The api mocks resolve the SHAPE THE REAL CLIENT RETURNS — the inner data
+ * object, `{ claimed }` not `{ data: { claimed } }`. Mocking the envelope is how
+ * a blank toast and a selection that never cleared went unnoticed.
  */
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -18,7 +25,11 @@ const api = vi.hoisted(() => ({
   listPartners: vi.fn(),
   getConstants: vi.fn(),
   listCategories: vi.fn(),
+  getTeam: vi.fn(),
   claimPartnersBulk: vi.fn(),
+  releasePartnersBulk: vi.fn(),
+  assignPartnersBulk: vi.fn(),
+  changeStageBulk: vi.fn(),
 }));
 vi.mock('@/api/redeemOps', () => ({ redeemOpsApi: api }));
 
@@ -51,6 +62,10 @@ const owned = (id, name) => ({
   ...free(id, name), ownerUserId: 'u-other', availability: 'owned',
   owner: { id: 'u-other', fullName: 'Someone Else' },
 });
+const mine = (id, name) => ({
+  ...free(id, name), ownerUserId: 'u-me', availability: 'owned',
+  owner: { id: 'u-me', fullName: 'Me Myself' },
+});
 
 function renderPage() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -63,9 +78,14 @@ function renderPage() {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  authState.user = { role: 'redeem_ops', redeemOpsRole: 'outreach_exec' };
-  api.getConstants.mockResolvedValue({ pipelineStages: ['NEW'] });
+  // outreach_exec: claims, releases and moves stages — never reassigns.
+  authState.user = { id: 'u-me', role: 'redeem_ops', redeemOpsRole: 'outreach_exec' };
+  api.getConstants.mockResolvedValue({
+    pipelineStages: ['NEW', 'CONTACTED', 'LOST'],
+    lostReasons: ['not_interested', 'no_response'],
+  });
   api.listCategories.mockResolvedValue([]);
+  api.getTeam.mockResolvedValue([{ id: 'u-mate', fullName: 'Rachel Ho', isActive: true }]);
   api.listPartners.mockResolvedValue({
     partners: [free('p1', 'Free One'), free('p2', 'Free Two'), owned('p3', 'Taken Co')],
     pagination: { page: 1, limit: 25, total: 3, totalPages: 1 },
@@ -80,13 +100,19 @@ const rowFor = async (name) => {
   if (!row) throw new Error(`No table row for ${name}`);
   return row;
 };
+const bar = () => screen.getByRole('status');
+const tickAll = async () => userEvent.click(await screen.findByLabelText(/Select all on this page/i));
 
-it('only unowned rows are selectable — an owned one cannot be ticked', async () => {
+it('every live row is selectable, but Claim counts only the unowned ones', async () => {
   renderPage();
+  // An owned row can be ticked — releasing and reassigning are what you'd tick
+  // it FOR — while Claim's own count leaves it out.
   const takenRow = await rowFor('Taken Co');
-  expect(within(takenRow).getByRole('checkbox')).toBeDisabled();
-  const freeRow = await rowFor('Free One');
-  expect(within(freeRow).getByRole('checkbox')).toBeEnabled();
+  expect(within(takenRow).getByRole('checkbox')).toBeEnabled();
+
+  await tickAll();
+  expect(within(bar()).getByText('3')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Claim 2' })).toBeEnabled();
 });
 
 it('with nothing selected, clicking a row opens the business', async () => {
@@ -106,12 +132,7 @@ it('once something is selected, clicking rows selects instead of navigating', as
   await userEvent.click(await rowFor('Free Two'));
   expect(navigateMock).not.toHaveBeenCalled();
   expect(within(await rowFor('Free Two')).getByRole('checkbox')).toBeChecked();
-  expect(screen.getByText('2')).toBeInTheDocument(); // "2 selected"
-
-  // Clicking an UNCLAIMABLE row in selection mode is inert — it can neither be
-  // ticked nor yank the operator off the list.
-  await userEvent.click(await rowFor('Taken Co'));
-  expect(navigateMock).not.toHaveBeenCalled();
+  expect(within(bar()).getByText('2')).toBeInTheDocument();
 
   // Clearing hands normal navigation back.
   await userEvent.click(screen.getByRole('button', { name: 'Clear' }));
@@ -119,32 +140,130 @@ it('once something is selected, clicking rows selects instead of navigating', as
   expect(navigateMock).toHaveBeenCalledWith('/redeem-ops/partners/p1');
 });
 
-it('select-all covers only the claimable rows on the page', async () => {
-  renderPage();
-  await userEvent.click(await screen.findByLabelText(/Select all claimable/i));
-  expect(screen.getByText('2')).toBeInTheDocument(); // the owned row is excluded
-});
-
 it('claims the selection and reports a partial result honestly', async () => {
   api.claimPartnersBulk.mockResolvedValue({
-    message: '1 of 2 claimed',
-    data: { claimed: ['p1'], failed: [{ id: 'p2', reason: 'already_claimed', claimedBy: { id: 'u9', fullName: 'Rival Rep' } }] },
+    claimed: ['p1'],
+    failed: [{ id: 'p2', reason: 'already_claimed', claimedBy: { id: 'u9', fullName: 'Rival Rep' } }],
   });
   renderPage();
-  await userEvent.click(await screen.findByLabelText(/Select all claimable/i));
-  await userEvent.click(screen.getByRole('button', { name: 'Claim' }));
+  await userEvent.click(within(await rowFor('Free One')).getByRole('checkbox'));
+  await userEvent.click(within(await rowFor('Free Two')).getByRole('checkbox'));
+  await userEvent.click(screen.getByRole('button', { name: 'Claim 2' }));
 
   await waitFor(() => expect(api.claimPartnersBulk).toHaveBeenCalledWith(['p1', 'p2']));
-  // Partial success is a warning that names the loss, not a success toast.
-  expect(toastMock.warning).toHaveBeenCalledWith('1 of 2 claimed', expect.objectContaining({
+  // Partial success is a warning that names the loss, not a success toast — and
+  // the headline is real text, not `undefined`.
+  await waitFor(() => expect(toastMock.warning).toHaveBeenCalledWith('1 of 2 claimed', expect.objectContaining({
     description: expect.stringContaining('Rival Rep'),
-  }));
+  })));
   // Only what landed is deselected, so a retry keeps the one that didn't.
-  await waitFor(() => expect(screen.getByText('1')).toBeInTheDocument());
+  await waitFor(() => expect(within(bar()).getByText('1')).toBeInTheDocument());
+  expect(within(await rowFor('Free Two')).getByRole('checkbox')).toBeChecked();
 });
 
-it('hides the whole affordance from someone who cannot claim', async () => {
-  authState.user = { role: 'redeem_ops', redeemOpsRole: 'viewer' };
+it('a clean claim says so and empties the selection', async () => {
+  api.claimPartnersBulk.mockResolvedValue({ claimed: ['p1'], failed: [] });
+  renderPage();
+  await userEvent.click(within(await rowFor('Free One')).getByRole('checkbox'));
+  await userEvent.click(screen.getByRole('button', { name: 'Claim 1' }));
+
+  await waitFor(() => expect(toastMock.success).toHaveBeenCalledWith('1 business claimed'));
+  await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+});
+
+it('Release counts only the rows the operator owns, and sends the reason', async () => {
+  api.listPartners.mockResolvedValue({
+    partners: [mine('p1', 'My Studio'), owned('p3', 'Taken Co')],
+    pagination: { page: 1, limit: 25, total: 2, totalPages: 1 },
+  });
+  api.releasePartnersBulk.mockResolvedValue({
+    released: ['p1'],
+    failed: [{ id: 'p3', reason: 'owned_by_other', claimedBy: { id: 'u-other', fullName: 'Someone Else' } }],
+  });
+  renderPage();
+  await tickAll();
+
+  // Two selected, one releasable — the teammate's row is not offered.
+  expect(within(bar()).getByText('2')).toBeInTheDocument();
+  await userEvent.click(screen.getByRole('button', { name: 'Release 1' }));
+  const dialog = await screen.findByRole('dialog');
+  await userEvent.type(within(dialog).getByPlaceholderText(/handing the estate/i), 'left the team');
+  await userEvent.click(within(dialog).getByRole('button', { name: 'Release' }));
+
+  await waitFor(() => expect(api.releasePartnersBulk).toHaveBeenCalledWith(['p1', 'p3'], 'left the team'));
+  await waitFor(() => expect(toastMock.warning).toHaveBeenCalledWith('1 of 2 released', expect.objectContaining({
+    description: expect.stringContaining('not yours to release'),
+  })));
+});
+
+it('Release is unavailable when nothing selected is the operator’s', async () => {
+  renderPage();
+  await tickAll(); // p1/p2 unowned, p3 someone else's — none are mine
+  expect(screen.getByRole('button', { name: /^Release/ })).toBeDisabled();
+});
+
+it('an outreach exec is not offered Assign to…', async () => {
+  renderPage();
+  await tickAll();
+  expect(screen.queryByRole('button', { name: 'Assign to…' })).not.toBeInTheDocument();
+  expect(api.getTeam).not.toHaveBeenCalled(); // no roster fetch it can't use
+});
+
+it('a BDM assigns the whole selection to one teammate', async () => {
+  authState.user = { id: 'u-me', role: 'redeem_ops', redeemOpsRole: 'bdm' };
+  api.assignPartnersBulk.mockResolvedValue({ assigned: ['p1', 'p2', 'p3'], failed: [] });
+  renderPage();
+  await tickAll();
+  await userEvent.click(screen.getByRole('button', { name: 'Assign to…' }));
+
+  const dialog = await screen.findByRole('dialog');
+  await userEvent.type(within(dialog).getByPlaceholderText(/territory swap/i), 'her patch now');
+  await userEvent.click(within(dialog).getByRole('button', { name: /Rachel Ho/ }));
+
+  await waitFor(() => expect(api.assignPartnersBulk)
+    .toHaveBeenCalledWith(['p1', 'p2', 'p3'], 'u-mate', 'her patch now'));
+  await waitFor(() => expect(toastMock.success).toHaveBeenCalledWith('3 businesses assigned'));
+});
+
+it('a bulk move needs a stage, and LOST needs a reason before it will send', async () => {
+  api.changeStageBulk.mockResolvedValue({ moved: ['p1'], failed: [] });
+  renderPage();
+  await userEvent.click(within(await rowFor('Free One')).getByRole('checkbox'));
+  await userEvent.click(screen.getByRole('button', { name: 'Move stage' }));
+
+  const dialog = await screen.findByRole('dialog');
+  expect(within(dialog).getByRole('button', { name: 'Move 1' })).toBeDisabled();
+
+  await userEvent.click(within(dialog).getByRole('button', { name: 'Lost' }));
+  expect(within(dialog).getByRole('button', { name: 'Move 1' })).toBeDisabled(); // no reason yet
+
+  await userEvent.click(within(dialog).getByRole('button', { name: 'Not interested' }));
+  await userEvent.click(within(dialog).getByRole('button', { name: 'Move 1' }));
+
+  await waitFor(() => expect(api.changeStageBulk).toHaveBeenCalledWith(['p1'], 'LOST', {
+    reason: null, lostReason: 'not_interested',
+  }));
+});
+
+it('a move that some rows refuse quotes the machine’s reason', async () => {
+  api.changeStageBulk.mockResolvedValue({
+    moved: ['p1'],
+    failed: [{ id: 'p3', reason: 'not_owner', message: 'You can only move businesses you own' }],
+  });
+  renderPage();
+  await tickAll();
+  await userEvent.click(screen.getByRole('button', { name: 'Move stage' }));
+  const dialog = await screen.findByRole('dialog');
+  await userEvent.click(within(dialog).getByRole('button', { name: 'Contacted' }));
+  await userEvent.click(within(dialog).getByRole('button', { name: 'Move 3' }));
+
+  await waitFor(() => expect(toastMock.warning).toHaveBeenCalledWith('1 of 2 moved', expect.objectContaining({
+    description: expect.stringContaining('only move businesses you own'),
+  })));
+});
+
+it('hides the whole affordance from someone who can do none of it', async () => {
+  authState.user = { id: 'u-me', role: 'redeem_ops', redeemOpsRole: 'analyst' };
   renderPage();
   await screen.findAllByText('Free One');
   expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();


### PR DESCRIPTION
Follow-up to #316, which shipped multi-select with **Claim**. Two things were left over.

## 1. A live bug in #316's claim result

`redeemOpsApi.claimPartnersBulk` returns the **inner** data object — `{ claimed, failed }` — and `PartnersList` destructured `{ data, message }` off it. Both are `undefined` in production:

| Promised in #316 | What actually happens today |
|---|---|
| "3 of 10 claimed" toast | blank toast (`toast.success(undefined)`) |
| names who holds the ones you lost | nothing — `failed` is never read |
| "only the ids that landed are deselected" | nothing is deselected; ticks stay after a successful claim |

The claim itself works server-side; only the reporting is broken. The test passed because it mocked the **envelope** the api method never returns. Mocking the real shape fails 2 tests against the old code and passes here — verified by putting the old nesting back:

```
×  claims the selection and reports a partial result honestly
×  a clean claim says so and empties the selection
   → restored: 12 passed
```

## 2. Assign to… / Move stage / Release

Each behind the same capability as its single-row sibling (`partners.reassign` / `pipeline.move` / `partners.release`), each a `POST /partners/bulk-*` beside `bulk-claim`, and each a fan-out over the **same service the detail page calls** — so every applied row keeps its own transaction, assignment/stage event, audit row and cadence hook. There is one implementation of each action, so bulk cannot drift from single-row.

**Selectability widens, reversing one #316 decision.** #316 made only *unowned* rows tickable so the UI never offered what the server would refuse. But release and reassign apply precisely to rows that **are** owned — under four actions they'd be unreachable from the list. So every live row is selectable now, and that promise moves to the buttons: **Claim** counts only unowned rows in the selection, **Release** only the ones you own, both disabled at zero. Rows ticked on an earlier page aren't held in memory (ids only, per #316), so they count as eligible and the server reports back on them.

**Partial batches stay the normal outcome.** Release separates "a teammate has it" (names them — the fix is a reassign) from "nobody does" (nothing to fix). The stage machine refuses rows for four different reasons, each with actionable wording, so failures quote the machine rather than a flattened code; a LOST batch is refused up front if no reason was picked instead of half-applying.

`normaliseBulkIds` + `BULK_MAX` move to their own module — both services need them and importing one into the other risks a cycle through the cadence hooks.

## Verification

- Backend redeem-ops: **27 suites / 393 tests** green (8 new — per-row refusals, every route's capability, a bad assignee writing nothing).
- Frontend: **161 files / 2065 tests** green (12 in this file, 5 new).
- eslint clean at both roots; production build clean.

Multi-select is still **desktop-only**, as #316 left it — the mobile card list has no selection affordance; that's separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eL2XE1J1A6eF3j3jTJqbm