### PR TITLE
fix(scoring): the lead score shows its working, like the person score does

### DIFF
--- a/backend/src/services/leadScoringService.js
+++ b/backend/src/services/leadScoringService.js
@@ -183,10 +183,11 @@ export function computeLeadInputHash({ facts, telemetry, configVersion, algorith
  *
  * The BREAKDOWN travels with the numbers, extending §4's three columns by
  * one. It has to: the profile card renders `groups.meet`/`groups.buy`
- * component rows straight out of scoreBreakdown
- * (AdminV2LeadProfile.jsx:589-624), so numbers from the winning lead beside a
- * breakdown from the retired person-grain pass would render components that
- * visibly do not sum to the score shown above them.
+ * component rows straight out of scoreBreakdown (AdminV2LeadProfile.jsx,
+ * ScoreComponents — the renderer the person card and the lead card share),
+ * so numbers from the winning lead beside a breakdown from the retired
+ * person-grain pass would render components that visibly do not sum to the
+ * score shown above them.
  *
  * SERIALISATION: every caller holds the Consumer row FOR UPDATE (the fence,
  * enrichmentFence.js:87-93), so two of this person's leads can never project

--- a/backend/test/prospects.test.js
+++ b/backend/test/prospects.test.js
@@ -1134,3 +1134,46 @@ describe('Prospect CAPI meta-fields (Phase 2)', () => {
     expect(p.sourceMetadata?.fbp).toBe('fbp-strip')
   })
 })
+
+describe('Lead score on the detail payload — the drill-in card\'s wire contract', () => {
+  // The Lead Profile page renders prospects.scoreBreakdown / meetScore /
+  // buyScore straight off GET /api/prospects/:id?include=profile
+  // (AdminV2LeadProfile.jsx, LeadScoreCard). That worked by omission — the
+  // detail read serializes the whole model because nothing excludes anything —
+  // and every UI test mocks the fetch, so a future "slim the detail payload"
+  // attributes exclusion (the list read already has one for screeningMetadata)
+  // would blank the card with the whole frontend suite still green. This is
+  // the fence.
+  it('GET /api/prospects/:id?include=profile ships the score columns', async () => {
+    const campaign = await createTestCampaign(adminUser.id)
+    const p = await createTestProspect(campaign.id, {
+      score: 48,
+      meetScore: 50,
+      buyScore: 16,
+      scoreBreakdown: {
+        algorithmVersion: 'lead/v1',
+        groups: { meet: { score: 50, rawMax: 75, components: ['screening'] } },
+        components: { screening: { state: 'assessed', points: 20, maxPoints: 20, note: 'qualified' } },
+        completeness: { assessed: 1, total: 1 },
+        events: [],
+      },
+      scoredConfigVersion: 3,
+      scoringAlgorithmVersion: 'lead/v1',
+      scoreComputedAt: new Date('2026-07-27T16:14:35Z'),
+    })
+
+    const res = await request(app)
+      .get(`/api/prospects/${p.id}?include=profile`)
+      .set('Authorization', `Bearer ${adminToken}`)
+
+    expect(res.status).toBe(200)
+    const got = res.body.data.prospect
+    expect(got.score).toBe(48)
+    expect(got.meetScore).toBe(50)
+    expect(got.buyScore).toBe(16)
+    expect(got.scoredConfigVersion).toBe(3)
+    expect(got.scoreComputedAt).toBeTruthy()
+    expect(got.scoreBreakdown.groups.meet.components).toEqual(['screening'])
+    expect(got.scoreBreakdown.components.screening.points).toBe(20)
+  })
+})

--- a/src/components/adminv2/AdminV2Shell.jsx
+++ b/src/components/adminv2/AdminV2Shell.jsx
@@ -30,7 +30,10 @@ export function useAdminV2Theme() {
 }
 
 function sgtClock() {
-  return new Intl.DateTimeFormat('en-SG', { timeZone: 'Asia/Singapore', hour: '2-digit', minute: '2-digit', hour12: false }).format(new Date());
+  // hourCycle 'h23', not hour12:false — old-ICU runtimes map the latter to
+  // h24, which would tick this clock "24:00" at midnight (fmtDateTime has the
+  // full story).
+  return new Intl.DateTimeFormat('en-SG', { timeZone: 'Asia/Singapore', hour: '2-digit', minute: '2-digit', hourCycle: 'h23' }).format(new Date());
 }
 
 function initialsOf(user) {

--- a/src/lib/adminV2/format.js
+++ b/src/lib/adminV2/format.js
@@ -29,7 +29,11 @@ export function fmtDateTime(value) {
   const d = value instanceof Date ? value : new Date(value);
   if (Number.isNaN(d.getTime())) return '—';
   const date = d.toLocaleDateString('en-SG', { day: 'numeric', month: 'short', timeZone: SGT });
-  const time = d.toLocaleTimeString('en-SG', { hour: '2-digit', minute: '2-digit', hour12: false, timeZone: SGT });
+  // hourCycle 'h23', NOT hour12:false — ICU versions disagree on what
+  // hour12:false means for en-SG (Node 20 resolves it to h24, Node 24 to
+  // h23), so midnight rendered "24:14" or "00:14" depending on the runtime.
+  // h23 pins it: midnight is 00:xx everywhere, CI included.
+  const time = d.toLocaleTimeString('en-SG', { hour: '2-digit', minute: '2-digit', hourCycle: 'h23', timeZone: SGT });
   return `${date} ${time}`;
 }
 

--- a/src/pages/adminv2/AdminV2LeadProfile.jsx
+++ b/src/pages/adminv2/AdminV2LeadProfile.jsx
@@ -526,6 +526,13 @@ const COMPONENT_LABELS = {
   family_gap: 'family gap',
   capacity: 'capacity',
   coverage_headroom: 'coverage headroom',
+  age: 'age',
+  // The two LEAD-grain components (per-campaign-lead-scoring §4). Named here
+  // for both grains, not just the drill-in: the person's numbers are a copy of
+  // their winning lead's, breakdown included, so "response" and "screening"
+  // already surface on the profile card and were reading as bare column keys.
+  response: 'message response',
+  screening: 'screening call',
 };
 
 const FACT_LABELS = {
@@ -621,6 +628,42 @@ function ComponentRow({ name, c }) {
           <span style={{ display: 'block', width: `${pct}%`, height: '100%', background: penalty ? 'var(--bad)' : 'var(--accent-text)' }} />
         )}
       </span>
+    </div>
+  );
+}
+
+/**
+ * The parts, grouped the way the config groups them. Shared by both grains
+ * BECAUSE the two breakdowns are the same shape — the person's is literally a
+ * copy of their winning lead's (`projectPersonScore`), so a reader who learns
+ * to read one has learned to read the other.
+ */
+function ScoreComponents({ breakdown }) {
+  const comps = breakdown?.components || {};
+  const groups = breakdown?.groups || {};
+  const completeness = breakdown?.completeness;
+  const meetNames = groups.meet?.components || [];
+  const buyNames = groups.buy?.components || [];
+  return (
+    <div style={{ padding: '4px 18px 12px' }}>
+      {meetNames.length > 0 && (
+        <>
+          <div className="av2-microcaps" style={{ padding: '6px 0 2px' }}>Reachability</div>
+          {meetNames.map((n) => comps[n] && <ComponentRow key={n} name={n} c={comps[n]} />)}
+        </>
+      )}
+      {buyNames.length > 0 && (
+        <>
+          <div className="av2-microcaps" style={{ padding: '10px 0 2px' }}>Potential</div>
+          {buyNames.map((n) => comps[n] && <ComponentRow key={n} name={n} c={comps[n]} />)}
+        </>
+      )}
+      {completeness && (
+        <div style={{ fontSize: 11.5, color: 'var(--ink-3)', paddingTop: 10 }}>
+          {completeness.assessed} of {completeness.total} components assessed
+          {completeness.assessed < completeness.total && ' — the unknowns above are questions nobody has been asked'}
+        </div>
+      )}
     </div>
   );
 }
@@ -735,11 +778,6 @@ function ScoreEvents({ events, scoredAt }) {
 
 function EnrichmentCard({ enrichment }) {
   const bd = enrichment?.breakdown;
-  const comps = bd?.components || {};
-  const groups = bd?.groups || {};
-  const completeness = bd?.completeness;
-  const meetNames = groups.meet?.components || [];
-  const buyNames = groups.buy?.components || [];
   const facts = enrichment?.facts || [];
 
   return (
@@ -770,26 +808,7 @@ function EnrichmentCard({ enrichment }) {
         </div>
       )}
 
-      <div style={{ padding: '4px 18px 12px' }}>
-        {meetNames.length > 0 && (
-          <>
-            <div className="av2-microcaps" style={{ padding: '6px 0 2px' }}>Reachability</div>
-            {meetNames.map((n) => comps[n] && <ComponentRow key={n} name={n} c={comps[n]} />)}
-          </>
-        )}
-        {buyNames.length > 0 && (
-          <>
-            <div className="av2-microcaps" style={{ padding: '10px 0 2px' }}>Potential</div>
-            {buyNames.map((n) => comps[n] && <ComponentRow key={n} name={n} c={comps[n]} />)}
-          </>
-        )}
-        {completeness && (
-          <div style={{ fontSize: 11.5, color: 'var(--ink-3)', paddingTop: 10 }}>
-            {completeness.assessed} of {completeness.total} components assessed
-            {completeness.assessed < completeness.total && ' — the unknowns above are questions nobody has been asked'}
-          </div>
-        )}
-      </div>
+      <ScoreComponents breakdown={bd} />
 
       <ScoreEvents events={bd?.events} scoredAt={enrichment?.scoredAt} />
 
@@ -812,6 +831,70 @@ function EnrichmentCard({ enrichment }) {
           ))}
         </Disclosure>
       )}
+    </Card>
+  );
+}
+
+/**
+ * WHY this lead scored what it scored — the drill-in's own breakdown.
+ *
+ * The hero line states the number; this states the working, in the same parts
+ * and the same order as the person card, because the two breakdowns are the
+ * same shape.
+ *
+ * It reads the PROSPECT ROW, which is the only per-lead source on this page:
+ * `journey.enrichment` is the person's projection of their best lead (§4), so
+ * on anyone's second campaign it would explain a number this page is not
+ * showing. `?include=profile` already serializes the whole prospect model, so
+ * the breakdown, both halves and the config stamp arrive with no extra request.
+ *
+ * Absent until the sweep has scored this lead — `scoredConfigVersion` is the
+ * stamp that means "scored", and an empty card would imply a verdict nobody
+ * has reached.
+ */
+function LeadScoreCard({ prospect, campaignName, hasPersonCard }) {
+  const bd = prospect?.scoreBreakdown || null;
+  if (!bd || prospect.scoredConfigVersion == null) return null;
+  const stamp = [
+    `CONFIG v${prospect.scoredConfigVersion}`,
+    prospect.scoreComputedAt ? `SCORED ${fmtDateTime(prospect.scoreComputedAt).toUpperCase()}` : null,
+  ].filter(Boolean).join(' · ');
+  return (
+    <Card title="Lead score" meta={stamp}>
+      <div style={{ padding: '12px 18px 6px', display: 'flex', gap: 18 }}>
+        <ScoreDial label="Meet" value={prospect.meetScore} hint="no signal yet" />
+        <ScoreDial label="Buy" value={prospect.buyScore} hint="no facts to judge" />
+      </div>
+
+      {/* The total is NOT an average of the two halves — average 50 and 16 and
+          you get 33, not the 48 in the hero. It is the points below, added up
+          and capped. Stated here because this is the one place the parts and
+          the whole are on screen together, which is exactly where a reader
+          tries the arithmetic and concludes the page is lying. */}
+      {prospect.score != null && (
+        <div style={{ padding: '0 18px 4px', fontSize: 11.5, color: 'var(--ink-3)' }}>
+          <span className="av2-mono" style={{ color: 'var(--ink-2)', fontWeight: 700 }}>{prospect.score}</span>
+          {' = the points below, added up and capped at 100 — not an average of the two halves.'}
+        </div>
+      )}
+
+      {/* §4: the profile card shows this person's BEST lead. On a second
+          campaign that is a different lead with different numbers, so the two
+          cards disagreeing is the system working — say so before a reader
+          reads it as a bug. But only when that card exists: a consumer-less
+          (or never-person-scored) lead has no profile scoring card, and
+          pointing at one would send the reader hunting for a surface that
+          isn't there. */}
+      <div style={{ padding: '0 18px 8px', fontSize: 11.5, color: 'var(--ink-3)' }}>
+        {campaignName
+          ? <><span style={{ color: 'var(--ink-2)', fontWeight: 600 }}>{campaignName}</span>{' only'}</>
+          : 'This campaign only'}
+        {hasPersonCard ? ' — the profile card scores their best campaign.' : '.'}
+      </div>
+
+      <ScoreComponents breakdown={bd} />
+
+      <ScoreEvents events={bd.events} scoredAt={prospect.scoreComputedAt} />
     </Card>
   );
 }
@@ -1547,6 +1630,18 @@ export default function AdminV2LeadProfile() {
                   )}
                 </div>
               </Card>
+            )}
+
+            {/* Last in the grid on purpose: this is the page's explanation, not
+                its news. Gone for an erased person, whose lead-score columns are
+                nulled by the erasure rebuild — the guard is belt-and-braces, so
+                a later change to that rebuild cannot turn this into a leak. */}
+            {!erased && (
+              <LeadScoreCard
+                prospect={p}
+                campaignName={currentSignup?.campaign?.name || p.campaign?.name || null}
+                hasPersonCard={Boolean(journey?.enrichment)}
+              />
             )}
           </div>
         </>

--- a/src/pages/adminv2/AdminV2LeadProfile.jsx
+++ b/src/pages/adminv2/AdminV2LeadProfile.jsx
@@ -35,7 +35,10 @@ import {
 const SGT = 'Asia/Singapore';
 const fullName = (o) => `${o?.firstName || ''} ${o?.lastName || ''}`.trim();
 const sameName = (a, b) => fullName(a).toLowerCase() === fullName(b).toLowerCase();
-const sgtTime = (v) => new Date(v).toLocaleTimeString('en-SG', { hour: '2-digit', minute: '2-digit', hour12: false, timeZone: SGT });
+// hourCycle 'h23', not hour12:false — ICU versions map the latter to h24 or
+// h23 depending on runtime, so midnight was "24:xx" on some (fmtDateTime has
+// the full story).
+const sgtTime = (v) => new Date(v).toLocaleTimeString('en-SG', { hour: '2-digit', minute: '2-digit', hourCycle: 'h23', timeZone: SGT });
 const sgtDayKey = (v) => new Intl.DateTimeFormat('en-CA', { timeZone: SGT }).format(new Date(v));
 const drawWindowDayUpper = (v) => drawWindowDay(v).toUpperCase();
 /** House phone display: +6591234567 → "+65 9123 4567" (root CLAUDE.md rule). */

--- a/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
@@ -651,3 +651,148 @@ describe('scoring panel', () => {
     expect(screen.queryByText('Scoring')).not.toBeInTheDocument();
   });
 });
+
+/**
+ * The LEAD score's own breakdown (per-campaign-lead-scoring §4/§6).
+ *
+ * The drill-in used to state the number and stop there, so the one page about
+ * one lead was the one page that could not say why. The breakdown it shows is
+ * the LEAD's — read off the prospect row — because the person's card is a copy
+ * of their winning lead's and would explain a different number entirely.
+ */
+describe('lead score breakdown (drill-in)', () => {
+  /** Shaped on a real prod row: two lead-grain components, one screening event,
+   *  a negative-max penalty, and four unknowns. */
+  const SCORED = (over = {}) => {
+    const d = JSON.parse(JSON.stringify(PROFILE));
+    Object.assign(d.consumer.signups[0], { score: 48, scoredAt: '2026-07-27T16:14:35Z' });
+    return Object.assign(d, {
+      score: 48,
+      meetScore: 50,
+      buyScore: 16,
+      scoredConfigVersion: 3,
+      scoringAlgorithmVersion: 'lead/v1',
+      scoreComputedAt: '2026-07-27T16:14:35Z',
+      scoreBreakdown: {
+        algorithmVersion: 'lead/v1',
+        groups: {
+          meet: { score: 50, rawMax: 75, components: ['engagement', 'contactability', 'market_fit', 'response', 'screening'] },
+          buy: { score: 16, rawMax: 70, components: ['life_events', 'family_gap', 'capacity', 'coverage_headroom', 'age'] },
+        },
+        components: {
+          engagement: { state: 'assessed', points: 7.47, maxPoints: 15, basisObservationIds: [], note: '1 signup(s), 1 verified' },
+          contactability: { state: 'assessed', points: 10, maxPoints: 10, basisObservationIds: [], note: 'reachable via marketing consent, verified phone, email, WhatsApp' },
+          market_fit: { state: 'unknown', points: 0, maxPoints: 15, basisObservationIds: [], note: 'no language or ethnicity fact' },
+          response: { state: 'unknown', points: 0, maxPoints: 15, basisObservationIds: [], note: 'no message owned by this lead yet' },
+          screening: { state: 'assessed', points: 20, maxPoints: 20, basisObservationIds: [], note: 'qualified, sentiment positive' },
+          life_events: { state: 'unknown', points: 0, maxPoints: 25, basisObservationIds: [], note: 'no recent life event on record' },
+          family_gap: { state: 'assessed', points: 3, maxPoints: 20, basisObservationIds: ['o2'], note: 'children 0' },
+          capacity: { state: 'assessed', points: 1.5, maxPoints: 15, basisObservationIds: ['o1'], note: 'income <40k' },
+          coverage_headroom: { state: 'unknown', points: 0, maxPoints: -10, basisObservationIds: [], note: 'no coverage fact' },
+          age: { state: 'assessed', points: 6.5, maxPoints: 10, basisObservationIds: ['o3'], note: 'born 1995-1999 — age 27-31 in 2026' },
+        },
+        completeness: { assessed: 6, total: 10 },
+        events: [{
+          type: 'screening', at: '2026-07-26T09:25:51Z', ageDays: 1, component: 'screening',
+          verdict: 'qualified', interest: null, sentiment: 'positive', agreedToMeet: null,
+          undecayedWeight: 20, schemaVersion: 'screening/v1',
+        }],
+      },
+      ...over,
+    });
+  };
+
+  it('states the working, not just the number: both halves, config, campaign', async () => {
+    fetchProspectProfile.mockResolvedValue(SCORED());
+    setup();
+    expect(await screen.findByText('Lead score')).toBeInTheDocument();
+    expect(screen.getByTitle('Meet 50/100')).toHaveTextContent('50');
+    expect(screen.getByTitle('Buy 16/100')).toHaveTextContent('16');
+    // SGT, like every other timestamp on the page: 16:14Z is 00:14 on the 28th.
+    expect(screen.getByText('CONFIG v3 · SCORED 28 JUL 00:14')).toBeInTheDocument();
+    // This fixture's person has never been person-scored (no enrichment), so
+    // the page has no profile scoring card — the copy must not point the
+    // reader at a comparison surface that is not there. Function matcher:
+    // the campaign name is a nested span, so the sentence spans elements.
+    expect(screen.getByText((_, el) => el?.textContent === 'Tokyo Getaway Lucky Draw only.')).toBeInTheDocument();
+    expect(screen.queryByText(/profile card scores their best campaign/)).not.toBeInTheDocument();
+  });
+
+  it('says the total is a capped sum — a reader who averages 50 and 16 gets 33', async () => {
+    fetchProspectProfile.mockResolvedValue(SCORED());
+    setup();
+    await screen.findByText('Lead score');
+    expect(screen.getByText(/= the points below, added up and capped at 100/)).toBeInTheDocument();
+    expect(screen.getByText(/not an average of the two halves/)).toBeInTheDocument();
+    // The hero's number and the number the parts add to are the SAME number.
+    expect(screen.getAllByText('48')).toHaveLength(2);
+  });
+
+  it('groups the parts and prices each one against its own maximum', async () => {
+    fetchProspectProfile.mockResolvedValue(SCORED());
+    setup();
+    await screen.findByText('Lead score');
+    expect(screen.getByText('Reachability')).toBeInTheDocument();
+    expect(screen.getByText('Potential')).toBeInTheDocument();
+    expect(screen.getByText('7.47')).toBeInTheDocument();
+    expect(screen.getByText('6.5')).toBeInTheDocument();
+    expect(screen.getByText(/6 of 10 components assessed/)).toBeInTheDocument();
+    // The penalty keeps its negative maximum — a reader must be able to see
+    // that coverage headroom can only ever subtract.
+    expect(screen.getByText('/-10')).toBeInTheDocument();
+  });
+
+  it('names the two lead-grain components instead of printing column keys', async () => {
+    fetchProspectProfile.mockResolvedValue(SCORED());
+    setup();
+    await screen.findByText('Lead score');
+    expect(screen.getByLabelText(/screening call: qualified, sentiment positive/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/message response: no message owned by this lead yet/)).toBeInTheDocument();
+    expect(screen.queryByText('screening')).not.toBeInTheDocument();
+  });
+
+  it('lists what happened, when, and what it was worth at full strength', async () => {
+    fetchProspectProfile.mockResolvedValue(SCORED());
+    setup();
+    await screen.findByText('Lead score');
+    expect(screen.getByText('Response events')).toBeInTheDocument();
+    expect(screen.getByText('Screening call: qualified · sentiment positive')).toBeInTheDocument();
+    expect(screen.getByText('+20')).toBeInTheDocument();
+    expect(screen.getByText(/Weights are shown at full strength/)).toBeInTheDocument();
+  });
+
+  it('explains THIS lead, never the person\'s projection of their best one', async () => {
+    const d = SCORED();
+    // The person's card would say Meet 32 — their best lead's, which on a
+    // second campaign is a different lead entirely.
+    d.consumer.enrichment = {
+      meetScore: 32, buyScore: 8, consumerScore: 17, configVersion: 3,
+      scoredAt: '2026-07-27T16:14:35Z', breakdown: { groups: {}, components: {} }, facts: [],
+    };
+    fetchProspectProfile.mockResolvedValue(d);
+    setup();
+    await screen.findByText('Lead score');
+    expect(screen.getByTitle('Meet 50/100')).toBeInTheDocument();
+    expect(screen.queryByTitle('Meet 32/100')).not.toBeInTheDocument();
+    // The person's own card belongs to the person's own view.
+    expect(screen.queryByText('Scoring')).not.toBeInTheDocument();
+    // But since that card EXISTS for this person, the drill-in names the §4
+    // relationship, so the two cards disagreeing does not read as a bug.
+    expect(screen.getByText(/only — the profile card scores their best campaign\./)).toBeInTheDocument();
+  });
+
+  it('is absent until the sweep has scored this lead', async () => {
+    setup();
+    await screen.findByText('Signup detail');
+    expect(screen.queryByText('Lead score')).not.toBeInTheDocument();
+  });
+
+  it('is absent for an erased person, whose score columns are nulled', async () => {
+    const d = SCORED();
+    d.consumer.consumer.erasedAt = '2026-07-28T02:00:00Z';
+    fetchProspectProfile.mockResolvedValue(d);
+    setup();
+    await screen.findByText(/This person was erased/);
+    expect(screen.queryByText('Lead score')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

The campaign drill-in said **LEAD SCORE 48** and stopped — the one page about one lead was the one page that couldn't explain its own number, while the person profile card lays out every component, reason and unknown. (Reported from the console on a live lead.)

This adds a **Lead score** card to the drill-in: Meet/Buy dials, the Reachability/Potential component rows with hover reasons, completeness, and the response-events disclosure — deliberately the *same* card as the person's, rendered by a shared `ScoreComponents`, because the person's breakdown IS a copy of their winning lead's (`projectPersonScore`). No backend change for the data: `?include=profile` already serialized the whole prospect row; the parts have been on the wire since migration 099 with nothing rendering them.

Two sentences the shared parts couldn't say:

- **48 is a capped sum, not an average** — average 50 and 16 and you get 33; a reader who tries that arithmetic concludes the page is lying.
- **This campaign only** — the profile card scores their *best* campaign (§4's projection), so under per-campaign weights (migration 100) the two cards will legitimately disagree. Said only when that card exists: consumer-less / never-person-scored leads have no profile card to disagree with.

Also: `response` and `screening` were rendering as bare column keys on both surfaces — now "message response" / "screening call".

## Adversarial review, applied

- **Serialization fence** (the one untested seam): new backend test pins `score` / `meetScore` / `buyScore` / `scoredConfigVersion` / `scoreComputedAt` / `scoreBreakdown` to `GET /api/prospects/:id?include=profile` — the card worked by omission, and a future "slim the detail payload" exclusion would have blanked it with every UI test still green (they mock the fetch).
- **§4 comment re-anchored** in `leadScoringService.js` to `ScoreComponents` by name — the refactor moved the lines its old line-number ref pointed at.
- Noted, not fixed: ms-window hero/card read race (two unsynchronized reads, self-heals on refetch); ±1 display-rounding pedantry in the sum line (round-once is by design).

## Guards

- Absent until the sweep has scored the lead (`scoredConfigVersion` is the stamp) — never an empty card implying a verdict.
- Absent for erased people (belt-and-braces over the erasure rebuild's column nulling).
- NULL never renders as zero — unscored halves say "no signal yet" / "no facts to judge".

## Tests

- Frontend: 8 new cases (this-lead-not-projection, capped-sum copy, gated §4 sentence both ways, lead-grain labels, events, unscored-absent, erased-absent); adminv2 suites **94/94**, full frontend **2073 green**.
- Backend: fence test verified against local PG 5433 — `test/prospects.test.js` **65/65**, new test also run in isolation.
- Rendered check: card screenshotted from a real prod row's numbers (48 / meet 50 / buy 16, config v3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENWdGMue9uXqmKv3pRG6YF