### PR TITLE
feat(scoring): the campaign scoring editor — Phase 1

### DIFF
--- a/backend/src/routes/scoringConfigs.js
+++ b/backend/src/routes/scoringConfigs.js
@@ -5,10 +5,13 @@ import { validate } from '../middleware/validation.js';
 import { asyncHandler, AppError } from '../middleware/errorHandler.js';
 import { BRIEF_PRODUCT_IDS } from '../utils/campaignBrief.js';
 import { SCORING_CONFIG_STATUSES } from '../utils/scoringConfigValidation.js';
-import { getActiveScoringConfig } from '../services/consumerScoringService.js';
+import { getActiveScoringConfig, resolveScoringConfigStrict } from '../services/consumerScoringService.js';
+import { DEFAULT_SCORING_CONFIG, DEFAULT_LEAD_COMPONENTS, normalizeConfig } from '../utils/consumerScoring.js';
+import { sequelize } from '../models/index.js';
 import {
   listScoringConfigs, getScoringConfig, createDraftConfig, approveScoringConfig,
-  simulateConfig, proposeScoringConfig, MAX_DESCRIPTION_CHARS,
+  simulateConfig, proposeScoringConfig, scoringProgressForCampaign, MAX_DESCRIPTION_CHARS,
+  SIMULATION_SAMPLE_MAX,
 } from '../services/scoringConfigService.js';
 
 /**
@@ -53,6 +56,20 @@ const draftSchema = Joi.object({
   // likewise left to the service, which answers with a sentence rather than a
   // constraint name.
   config: Joi.object().required(),
+  // The editor's door (§4.1): treat `config` as a patch composed server-side
+  // onto the currently-winning RAW document.
+  composeOnResolved: Joi.boolean(),
+});
+
+const approveSchema = Joi.object({
+  // REQUIRED integer ≥ 0 — 0 is the legitimate "house default was live"
+  // baseline (round-3 B3). The optimistic-concurrency half of §4.5.
+  expectedLiveVersion: Joi.number().integer().min(0).required(),
+});
+
+const simulateSchema = Joi.object({
+  compareTo: Joi.string().valid('stored', 'resolved'),
+  sampleMax: Joi.number().integer().min(1).max(SIMULATION_SAMPLE_MAX),
 });
 
 const proposeSchema = Joi.object({
@@ -68,15 +85,31 @@ function versionOf(req) {
   return n;
 }
 
-/** Everything authored so far, newest first. */
+/** UUID shape enforced at the boundary — an invalid id is a 400 sentence,
+ *  never a Postgres cast error five layers down (round-2 B8). */
+function uuidQuery(req, name) {
+  const v = req.query[name];
+  if (v === undefined || v === null || v === '') return null;
+  const { error } = uuid.validate(v);
+  if (error) throw new AppError(`${name} must be a UUID.`, 400);
+  return v;
+}
+
+/** Everything authored so far, newest first — scope-filterable (§4.6). */
 router.get('/', asyncHandler(async (req, res) => {
-  const { status, limit } = req.query;
+  const { status, limit, productKey: pk, global } = req.query;
   if (status && !SCORING_CONFIG_STATUSES.includes(status)) {
     throw new AppError(`status must be one of: ${SCORING_CONFIG_STATUSES.join(', ')}.`, 400);
+  }
+  if (pk && !BRIEF_PRODUCT_IDS.includes(pk)) {
+    throw new AppError(`productKey must be one of: ${BRIEF_PRODUCT_IDS.join(', ')}.`, 400);
   }
   const rows = await listScoringConfigs({
     status: status || null,
     limit: Number(limit) || 50,
+    campaignId: uuidQuery(req, 'campaignId'),
+    productKey: pk || null,
+    global: global === '1' || global === 'true',
   });
   res.json({ success: true, data: rows });
 }));
@@ -85,17 +118,67 @@ router.get('/', asyncHandler(async (req, res) => {
  * What a given scope resolves to RIGHT NOW, and which tier won. This is the
  * answer to "why did this lead score like that" without re-deriving the
  * resolution by hand.
+ *
+ * `?strict=1` is the EDITOR's variant (§4.2): direct DB (no cache in either
+ * direction), 5xx on read failure instead of silent defaults, and the payload
+ * grows the activation metadata the panel captions (activatedAt, actorName)
+ * plus `houseDefault` — the server-owned ghost/reset values (round-2 B12).
  */
 router.get('/resolve', asyncHandler(async (req, res) => {
-  const { campaignId = null, productKey: pk = null } = req.query;
+  const campaignId = uuidQuery(req, 'campaignId');
+  const { productKey: pk = null, strict } = req.query;
   if (campaignId && pk) {
     throw new AppError('Resolve one scope at a time: campaignId or productKey, not both.', 400);
   }
   if (pk && !BRIEF_PRODUCT_IDS.includes(pk)) {
     throw new AppError(`productKey must be one of: ${BRIEF_PRODUCT_IDS.join(', ')}.`, 400);
   }
+  if (strict === '1' || strict === 'true') {
+    const resolved = await resolveScoringConfigStrict({ campaignId, productKey: pk });
+    let actorName = null;
+    if (resolved.actorUserId) {
+      const [[u]] = await sequelize.query(
+        `SELECT NULLIF(TRIM(COALESCE("firstName", '') || ' ' || COALESCE("lastName", '')), '') AS name
+           FROM users WHERE id = :id`,
+        { replacements: { id: resolved.actorUserId } }
+      );
+      actorName = u?.name || null;
+    }
+    res.json({
+      success: true,
+      data: {
+        version: resolved.version,
+        scope: resolved.scope,
+        // leadComponents defaulted the way normalizeLeadConfig defaults them
+        // for the scorer — the editor's ghosts must show what actually scores,
+        // and DEFAULT_SCORING_CONFIG carries no leadComponents key.
+        config: {
+          ...resolved.config,
+          leadComponents: { ...DEFAULT_LEAD_COMPONENTS, ...(resolved.config.leadComponents || {}) },
+        },
+        raw: resolved.raw,
+        activatedAt: resolved.activatedAt,
+        actorName,
+        houseDefault: {
+          ...normalizeConfig(DEFAULT_SCORING_CONFIG),
+          leadComponents: DEFAULT_LEAD_COMPONENTS,
+        },
+      },
+    });
+    return;
+  }
   const resolved = await getActiveScoringConfig({ campaignId, productKey: pk });
   res.json({ success: true, data: resolved });
+}));
+
+/**
+ * Regrade progress for one campaign (§4.8). REGISTERED BEFORE /:version —
+ * Express would otherwise read "progress" as a version number (round-3 B3).
+ */
+router.get('/progress', asyncHandler(async (req, res) => {
+  const campaignId = uuidQuery(req, 'campaignId');
+  if (!campaignId) throw new AppError('campaignId is required.', 400);
+  res.json({ success: true, data: await scoringProgressForCampaign(campaignId) });
 }));
 
 router.get('/:version', asyncHandler(async (req, res) => {
@@ -110,6 +193,7 @@ router.post('/', validate(draftSchema), asyncHandler(async (req, res) => {
     campaignId: req.body.campaignId || null,
     productKey: req.body.productKey || null,
     actorUserId: req.user?.id || null,
+    composeOnResolved: req.body.composeOnResolved === true,
   });
   res.status(201).json({ success: true, data: draft });
 }));
@@ -131,22 +215,31 @@ router.post('/propose', validate(proposeSchema), asyncHandler(async (req, res) =
 
 /**
  * The distribution diff for an existing draft, against the population that
- * draft's own scope governs. Writes nothing.
+ * draft's own scope governs. Writes nothing. `compareTo:'resolved'` re-scores
+ * the current config beside the draft at one fixed now (§4.3) so the delta is
+ * the config's doing, not drift.
  */
-router.post('/:version/simulate', asyncHandler(async (req, res) => {
+router.post('/:version/simulate', validate(simulateSchema), asyncHandler(async (req, res) => {
   const row = await getScoringConfig(versionOf(req));
   const simulation = await simulateConfig({
     config: row.configJson,
     campaignId: row.campaignId,
     productKey: row.productKey,
+    compareTo: req.body?.compareTo || 'stored',
+    ...(req.body?.sampleMax ? { sampleMax: req.body.sampleMax } : {}),
   });
   res.json({ success: true, data: simulation });
 }));
 
-/** The only door that makes a config live. */
-router.post('/:version/approve', asyncHandler(async (req, res) => {
+/**
+ * The only door that makes a config live. The no-op branch (§4.6) answers 200
+ * with `{ noOp: true, live, candidateVersion }` — the UI must say "already
+ * live — nothing changed", never imply an activation or a regrade.
+ */
+router.post('/:version/approve', validate(approveSchema), asyncHandler(async (req, res) => {
   const approved = await approveScoringConfig(versionOf(req), {
     actorUserId: req.user?.id || null,
+    expectedLiveVersion: req.body.expectedLiveVersion,
   });
   res.json({ success: true, data: approved });
 }));

--- a/backend/src/services/consumerScoringService.js
+++ b/backend/src/services/consumerScoringService.js
@@ -83,6 +83,7 @@ export function _resetConfigCache() {
  */
 const RESOLVE_SQL = `
   SELECT e.version, e."configJson", e."campaignId", e."productKey",
+         e."activatedAt", e."actorUserId",
          CASE WHEN e."campaignId" IS NOT NULL THEN 1
               WHEN e."productKey" IS NOT NULL THEN 2
               ELSE 3 END AS tier
@@ -95,12 +96,57 @@ const RESOLVE_SQL = `
    LIMIT 1`;
 
 /** The product this campaign's leads score under, or null. */
-async function loadCampaignProductKey(campaignId) {
+async function loadCampaignProductKey(campaignId, { transaction } = {}) {
   const [[row]] = await sequelize.query(
     'SELECT "targetAudience" FROM campaigns WHERE id = :cid',
-    { replacements: { cid: campaignId } }
+    { replacements: { cid: campaignId }, transaction }
   );
   return briefProductKey(row?.targetAudience);
+}
+
+/**
+ * The EDITOR's resolver (campaign-scoring-editor §4.2): the same walk as
+ * getActiveScoringConfig with every kindness stripped. Direct DB — no cache
+ * read, no cache write — and a read failure THROWS instead of dressing code
+ * defaults up as an answer: an admin about to edit from this baseline must
+ * never be seeded from defaults while a real configuration exists behind a
+ * query hiccup. `version: 0` therefore means the table GENUINELY resolves to
+ * nothing at this scope, which is the legitimate house-default baseline.
+ *
+ * Returns the winner's RAW `configJson` beside the normalized one — §4.1's
+ * composition base — plus the activation metadata the panel captions.
+ * `transaction` exists for §4.5: approve re-runs this under its advisory lock
+ * so the expectedLiveVersion comparison reads the same snapshot it writes.
+ */
+export async function resolveScoringConfigStrict({
+  campaignId = null, productKey = null, transaction,
+} = {}) {
+  const product = campaignId
+    ? await loadCampaignProductKey(campaignId, { transaction })
+    : productKey;
+  const [rows] = await sequelize.query(RESOLVE_SQL, {
+    replacements: { campaignId, productKey: product },
+    transaction,
+  });
+  const row = rows[0] || null;
+  if (!row) {
+    return {
+      version: 0,
+      scope: 'default',
+      config: normalizeConfig(DEFAULT_SCORING_CONFIG),
+      raw: {},
+      activatedAt: null,
+      actorUserId: null,
+    };
+  }
+  return {
+    version: row.version,
+    scope: row.campaignId ? 'campaign' : row.productKey ? 'product' : 'global',
+    config: normalizeConfig(row.configJson),
+    raw: row.configJson,
+    activatedAt: row.activatedAt,
+    actorUserId: row.actorUserId,
+  };
 }
 
 /**

--- a/backend/src/services/leadProfileService.js
+++ b/backend/src/services/leadProfileService.js
@@ -522,7 +522,26 @@ export function makeLeadProfileService(overrides = {}) {
   async function consumerEnrichment(consumerId) {
     if (!consumerId) return null;
     try {
-      const row = await d.ConsumerProfile.findByPk(consumerId);
+      // ONE statement — profile + source-lead stamps + campaign label in a
+      // single MVCC snapshot (campaign-scoring-editor §4.4). A lead rescore
+      // commits its stamps and the person projection atomically, so two
+      // separate reads here could pair an old projected breakdown with a
+      // newer source stamp; one statement cannot.
+      const [[row]] = await d.sequelize.query(
+        `SELECT cp."meetScore", cp."buyScore", cp."consumerScore", cp."scoreBreakdown",
+                cp."scoreComputedAt", cp."scoredConfigVersion", cp."scoringAlgorithmVersion",
+                cp."scoreSourceProspectId",
+                p.id AS "srcProspectId", p."campaignId" AS "srcCampaignId",
+                p."scoredConfigVersion" AS "srcConfigVersion",
+                p."scoringAlgorithmVersion" AS "srcAlgorithmVersion",
+                p."scoreComputedAt" AS "srcComputedAt",
+                cam.name AS "srcCampaignName"
+           FROM consumer_profiles cp
+           LEFT JOIN prospects p ON p.id = cp."scoreSourceProspectId"
+           LEFT JOIN campaigns cam ON cam.id = p."campaignId"
+          WHERE cp."consumerId" = :cid`,
+        { replacements: { cid: consumerId } }
+      );
       if (!row || row.scoredConfigVersion == null) return null;
 
       // The ledger, resolved the same way the scorer resolved it — the panel
@@ -556,39 +575,56 @@ export function makeLeadProfileService(overrides = {}) {
         d.logger.warn('[leadProfile] fact ledger read failed (omitted)', { error: err?.message });
       }
 
-      // WHICH lead these numbers were copied from (§4). They are the person's
-      // BEST lead's scores, and once a campaign carries its own weights "their
-      // best" without "at what" is a number nobody can act on. Absent until
-      // that person's next rescore — migration 101 deliberately did not
-      // backfill it rather than re-derive the tie-break in one-shot SQL.
-      let scoreSource = null;
-      if (row.scoreSourceProspectId) {
-        try {
-          const src = await d.Prospect.findByPk(row.scoreSourceProspectId, {
-            attributes: ['id', 'campaignId'],
-            include: [{ association: 'campaign', attributes: ['id', 'name'] }],
-          });
-          if (src) {
-            scoreSource = {
-              prospectId: String(src.id),
-              campaignId: src.campaignId ? String(src.campaignId) : null,
-              campaignName: src.campaign?.name || null,
-            };
-          }
-        } catch (err) {
-          // A missing label must never blank the scores beside it.
-          d.logger.warn('[leadProfile] score source read failed (omitted)', { error: err?.message });
+      // WHICH lead these numbers were copied from (§4) — already joined above.
+      // Absent until that person's next rescore: migration 101 deliberately
+      // did not backfill the pointer.
+      const sourceResolved = Boolean(row.srcProspectId);
+      const scoreSource = sourceResolved
+        ? {
+          prospectId: String(row.srcProspectId),
+          campaignId: row.srcCampaignId ? String(row.srcCampaignId) : null,
+          campaignName: row.srcCampaignName || null,
         }
-      }
+        : null;
+
+      // THE CAPTION STAMPS (campaign-scoring-editor §4.4). The projected
+      // breakdown is a copy of the winning LEAD's, but the person-pass
+      // re-stamps this row's own config/algorithm/time columns every consumer
+      // sweep — so under per-campaign sheets those columns caption a
+      // DIFFERENT document than the one shown. The stamps that describe the
+      // breakdown live on the source lead, read in the same snapshot above:
+      //   - source resolves → the source lead's stamps (older than the
+      //     person-pass is CORRECT: they caption the copy, not resolution);
+      //   - breakdown retained but source unresolvable (lead deleted, or a
+      //     pre-101 projection whose pointer was never backfilled — the two
+      //     are indistinguishable) → NO stamps, and the card says "score
+      //     source signup unavailable" rather than borrowing person-pass
+      //     numbers that describe nothing on screen;
+      //   - no breakdown at all → person-pass stamps, which then caption
+      //     exactly what they are: person-pass state.
+      const hasBreakdown = Boolean(row.scoreBreakdown);
+      const stampsUnavailable = hasBreakdown && !sourceResolved;
+      const stamps = sourceResolved
+        ? {
+          scoredAt: row.srcComputedAt || null,
+          configVersion: row.srcConfigVersion ?? null,
+          algorithmVersion: row.srcAlgorithmVersion || null,
+        }
+        : stampsUnavailable
+          ? { scoredAt: null, configVersion: null, algorithmVersion: null }
+          : {
+            scoredAt: row.scoreComputedAt || null,
+            configVersion: row.scoredConfigVersion ?? null,
+            algorithmVersion: row.scoringAlgorithmVersion || null,
+          };
 
       return {
         meetScore: row.meetScore ?? null,
         buyScore: row.buyScore ?? null,
         consumerScore: row.consumerScore ?? null,
         breakdown: row.scoreBreakdown || null,
-        scoredAt: row.scoreComputedAt || null,
-        configVersion: row.scoredConfigVersion ?? null,
-        algorithmVersion: row.scoringAlgorithmVersion || null,
+        ...stamps,
+        stampsUnavailable,
         scoreSource,
         facts,
       };
@@ -734,6 +770,7 @@ export function makeLeadProfileService(overrides = {}) {
 
   return {
     enrichJourneyProfile,
+    consumerEnrichment,
     getSignupProfile,
     getSessionContext,
     getLyfeDelivery,

--- a/backend/src/services/scoringConfigService.js
+++ b/backend/src/services/scoringConfigService.js
@@ -3,11 +3,13 @@ import { AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
 import { getRuntimeAiSettings } from './aiSettingsService.js';
 import { requestStructuredJson } from './guidedReviewAiService.js';
-import { getActiveScoringConfig } from './consumerScoringService.js';
+import { getActiveScoringConfig, resolveScoringConfigStrict } from './consumerScoringService.js';
 import { loadLeadTelemetry, loadLeadObservations } from './leadScoringService.js';
 import { bustScoringConfigCache } from './scoringConfigCache.js';
 import { resolveCurrentFacts } from '../utils/factResolver.js';
-import { scoreLead, DEFAULT_SCORING_CONFIG, SCOREABLE_COMPONENTS } from '../utils/consumerScoring.js';
+import {
+  scoreLead, DEFAULT_SCORING_CONFIG, SCOREABLE_COMPONENTS, LEAD_ALGORITHM_VERSION,
+} from '../utils/consumerScoring.js';
 import { validateScoringConfig, MAX_COMPONENT_POINTS } from '../utils/scoringConfigValidation.js';
 import { BRIEF_PRODUCT_IDS, briefPromptFacts, briefProductKey } from '../utils/campaignBrief.js';
 
@@ -95,21 +97,50 @@ const scopeOf = (row) => (row.campaignId ? 'campaign' : row.productKey ? 'produc
 
 // ─────────────────────────── reads ───────────────────────────
 
-export async function listScoringConfigs({ status = null, limit = 50 } = {}) {
+/**
+ * Everything authored, newest first — optionally SCOPE-FILTERED before the
+ * order/limit (campaign-scoring-editor §4.6 / round-2 M13: the campaign
+ * page's history must not be "the newest 50 rows system-wide, filtered
+ * client-side", which can omit every edition the page is about). One scope
+ * filter at a time, like every other door in this file. Actor id resolves to
+ * a NAME here — a safe DTO, never email/phone — because history is read by
+ * humans and `actorUserId` alone answers nothing.
+ */
+export async function listScoringConfigs({
+  status = null, limit = 50, campaignId = null, productKey = null, global = false,
+} = {}) {
+  if ([Boolean(campaignId), Boolean(productKey), Boolean(global)].filter(Boolean).length > 1) {
+    throw new AppError('Filter one scope at a time: campaignId, productKey, or global.', 422);
+  }
   const [rows] = await sequelize.query(
-    `SELECT version, status, "campaignId", "productKey", "actorUserId", "activatedAt", "createdAt"
-       FROM enrichment_scoring_configs
-      WHERE (:status::text IS NULL OR status = :status)
-      ORDER BY version DESC
+    `SELECT e.version, e.status, e."campaignId", e."productKey", e."actorUserId",
+            e."activatedAt", e."createdAt",
+            NULLIF(TRIM(COALESCE(u."firstName", '') || ' ' || COALESCE(u."lastName", '')), '') AS "actorName"
+       FROM enrichment_scoring_configs e
+       LEFT JOIN users u ON u.id = e."actorUserId"
+      WHERE (:status::text IS NULL OR e.status = :status)
+        AND (:campaignId::uuid IS NULL OR e."campaignId" = :campaignId)
+        AND (:productKey::text IS NULL OR e."productKey" = :productKey)
+        AND (NOT :global OR (e."campaignId" IS NULL AND e."productKey" IS NULL))
+      ORDER BY e.version DESC
       LIMIT :limit`,
-    { replacements: { status, limit: Math.min(200, Math.max(1, limit)) } }
+    {
+      replacements: {
+        status,
+        limit: Math.min(200, Math.max(1, limit)),
+        campaignId: campaignId || null,
+        productKey: productKey || null,
+        global: Boolean(global),
+      },
+    }
   );
   return rows.map((r) => ({ ...r, scope: scopeOf(r) }));
 }
 
 export async function getScoringConfig(version) {
   const [[row]] = await sequelize.query(
-    `SELECT version, status, "configJson", "campaignId", "productKey", "actorUserId", "activatedAt"
+    `SELECT version, status, "configJson", "campaignId", "productKey", "actorUserId",
+            "activatedAt", "createdAt"
        FROM enrichment_scoring_configs WHERE version = :v`,
     { replacements: { v: version } }
   );
@@ -120,15 +151,59 @@ export async function getScoringConfig(version) {
 // ─────────────────────────── writes ───────────────────────────
 
 /**
+ * Deep-merge for §4.1 composition: recursive for PLAIN OBJECTS only; arrays
+ * (ageCurve, targetSegments, groups.*) replace WHOLESALE — merging two curves
+ * element-wise would interleave unrelated segments into nonsense; `undefined`
+ * in the patch leaves the base key alone.
+ */
+export function composeConfigPatch(base, patch) {
+  const isObj = (x) => x !== null && typeof x === 'object' && !Array.isArray(x);
+  if (!isObj(base)) return patch;
+  if (!isObj(patch)) return patch === undefined ? base : patch;
+  const out = { ...base };
+  for (const [k, v] of Object.entries(patch)) {
+    if (v === undefined) continue;
+    out[k] = isObj(v) && isObj(base[k]) ? composeConfigPatch(base[k], v) : v;
+  }
+  return out;
+}
+
+/**
  * Insert a DRAFT. Every door into this table goes through here, AI or not, so
  * the semantic invariants cannot be bypassed by hand-posting JSON.
+ *
+ * `composeOnResolved` (campaign-scoring-editor §4.1, the EDITOR's door): the
+ * incoming `config` is treated as a PATCH and deep-merged onto the currently
+ * winning tier's RAW configJson before validation/storage. Onto the RAW doc,
+ * not the normalized one: normalizing would freeze today's code defaults for
+ * knobs nobody ever wrote, while the raw winner carries exactly the explicit
+ * choices (a product sheet's decay override, say) that a campaign override
+ * must not silently reset. Resolution picks ONE row — there is no read-time
+ * layering — so this write-time composition is the only place tiers combine.
  */
 export async function createDraftConfig({
   config, campaignId = null, productKey = null, actorUserId = null, source = 'manual',
+  composeOnResolved = false,
 }) {
   const scope = normalizeScope({ campaignId, productKey });
 
-  const check = validateScoringConfig(config);
+  // A no-FK snapshot table accepts any UUID — verify the campaign is real so
+  // a stray id cannot mint editions for a campaign that never existed (§4.6).
+  if (scope.campaignId) {
+    const [[campaign]] = await sequelize.query(
+      'SELECT 1 AS ok FROM campaigns WHERE id = :cid',
+      { replacements: { cid: scope.campaignId } }
+    );
+    if (!campaign) throw new AppError('Campaign not found for this scoring config.', 422);
+  }
+
+  let toStore = config;
+  if (composeOnResolved) {
+    const winner = await resolveScoringConfigStrict(scope);
+    toStore = composeConfigPatch(winner.raw, config);
+  }
+
+  const check = validateScoringConfig(toStore);
   if (!check.ok) throw new AppError(check.error, 422);
 
   // The RAW authored document is stored, not the normalized one: normalizing
@@ -142,7 +217,7 @@ export async function createDraftConfig({
      RETURNING version`,
     {
       replacements: {
-        cfg: JSON.stringify(config),
+        cfg: JSON.stringify(toStore),
         campaignId: scope.campaignId,
         productKey: scope.productKey,
         actor: actorUserId,
@@ -170,12 +245,64 @@ export async function createDraftConfig({
  * input, and every entry in the map may be inheriting from the row that just
  * moved — see scoringConfigCache.js for why that makes it whole-map.
  */
-export async function approveScoringConfig(version, { actorUserId = null } = {}) {
+/** One deterministic lock key per scope — the serialization unit for §4.5. */
+function scopeLockKey(row) {
+  if (row.campaignId) return `scoring-config:campaign:${row.campaignId}`;
+  if (row.productKey) return `scoring-config:product:${row.productKey}`;
+  return 'scoring-config:global';
+}
+
+export async function approveScoringConfig(version, { actorUserId = null, expectedLiveVersion } = {}) {
+  // REQUIRED, and 0 is legitimate: it says "the house default was live when I
+  // edited" — the baseline every fresh scope starts from (round-3 B3).
+  if (!Number.isInteger(expectedLiveVersion) || expectedLiveVersion < 0) {
+    throw new AppError('expectedLiveVersion must be an integer ≥ 0 (0 = house default was live).', 422);
+  }
   const row = await getScoringConfig(version);
   if (row.status === 'approved') throw new AppError('That config is already approved.', 409);
   if (row.status === 'superseded') throw new AppError('A superseded config cannot be re-approved.', 409);
 
-  await sequelize.transaction(async (t) => {
+  const result = await sequelize.transaction(async (t) => {
+    // The advisory lock serializes every lifecycle transition at this scope —
+    // two concurrent approvers used to both commit approved rows (the status
+    // check ran outside the txn and the promote UPDATE was unconditioned),
+    // leaving two live editions and letting a racing rollback silently not
+    // take. Same hashtext composition as the draw-boost provisioning lock.
+    await sequelize.query('SELECT pg_advisory_xact_lock(hashtext(:key))', {
+      replacements: { key: scopeLockKey(row) },
+      transaction: t,
+    });
+
+    // The RESOLVED winner for the candidate's scope, read under the lock —
+    // not merely "an approved row at the same tier": a campaign scope may be
+    // inheriting product or global, and THAT inherited version is what the
+    // editor showed the admin as live.
+    const live = await resolveScoringConfigStrict({
+      campaignId: row.campaignId, productKey: row.productKey, transaction: t,
+    });
+    if (live.version !== expectedLiveVersion) {
+      throw new AppError('The live sheet changed while you were editing — re-open preview.', 409);
+    }
+
+    // Content-equal → a stated NO-OP (§4.6): approving a byte-identical sheet
+    // would still mint a new resolved version, and the lead input hash
+    // includes configVersion — so every inheriting lead would go stale and
+    // regrade for nights over nothing. jsonb equality is semantic (key order
+    // and numeric form normalized), never string comparison. The candidate
+    // STAYS A DRAFT — round-3 M2: superseding it here would make it
+    // indistinguishable from a formerly-live edition, the exact corruption
+    // Discard was cut to avoid. No write happened, so no cache bust either.
+    if (live.version > 0) {
+      const [[eq]] = await sequelize.query(
+        `SELECT (SELECT "configJson" FROM enrichment_scoring_configs WHERE version = :live)
+              = (SELECT "configJson" FROM enrichment_scoring_configs WHERE version = :cand) AS same`,
+        { replacements: { live: live.version, cand: version }, transaction: t }
+      );
+      if (eq?.same === true) {
+        return { noOp: true, liveVersion: live.version, candidateVersion: version };
+      }
+    }
+
     await sequelize.query(
       `UPDATE enrichment_scoring_configs
           SET status = 'superseded', "updatedAt" = now()
@@ -188,14 +315,31 @@ export async function approveScoringConfig(version, { actorUserId = null } = {})
         transaction: t,
       }
     );
-    await sequelize.query(
+    // Status-predicated + RETURNING: only a row that is STILL a draft under
+    // the lock can be promoted; a concurrent transition loses loudly, not
+    // silently (round-2 M2).
+    const [promoted] = await sequelize.query(
       `UPDATE enrichment_scoring_configs
           SET status = 'approved', "activatedAt" = now(), "actorUserId" = COALESCE(:actor, "actorUserId"),
               "updatedAt" = now()
-        WHERE version = :v`,
+        WHERE version = :v AND status = 'draft'
+        RETURNING version`,
       { replacements: { v: version, actor: actorUserId }, transaction: t }
     );
+    if (!promoted.length) {
+      throw new AppError('That config is no longer a draft — reload and try again.', 409);
+    }
+    return { noOp: false };
   });
+
+  if (result.noOp) {
+    logger.info({ version, scope: row.scope, live: result.liveVersion }, 'scoring.config.approve_noop');
+    return {
+      noOp: true,
+      live: await getScoringConfig(result.liveVersion),
+      candidateVersion: result.candidateVersion,
+    };
+  }
 
   bustScoringConfigCache();
   logger.info({ version, scope: row.scope, actorUserId }, 'scoring.config.approved');
@@ -272,9 +416,42 @@ async function populationFor({ campaignId, productKey }, sampleMax) {
   return rows.map((r) => r.id);
 }
 
+/** Bounded-concurrency map — the §4.3 pool. Order-preserving, fail-fast. */
+async function mapPool(items, concurrency, fn) {
+  const out = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    for (;;) {
+      const i = next;
+      next += 1;
+      if (i >= items.length) return;
+      out[i] = await fn(items[i], i);
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, worker)
+  );
+  return out;
+}
+
+const SIMULATION_CONCURRENCY = 4;
+
 /**
  * Score the proposed config over the population it would govern and report the
- * distribution DIFF against what is stored today.
+ * distribution DIFF.
+ *
+ * Two comparison bases (campaign-scoring-editor §4.3):
+ *   - `compareTo: 'stored'` (default, the original behaviour): diff against
+ *     what is IN the table today. Cheap, but the delta conflates the config
+ *     change with drift — decay and facts that moved since each lead's last
+ *     rescore.
+ *   - `compareTo: 'resolved'` (the editor's preview): per lead, load inputs
+ *     ONCE and run scoreLead TWICE at one fixed `now` — the currently
+ *     resolved config vs the candidate — so the delta is the CONFIG'S doing
+ *     and nothing else. Stored scores still return, separately, as context.
+ *     CAMPAIGN SCOPE ONLY for now: the product/global population queries
+ *     include leads governed by campaign overrides (round-2 B9), which would
+ *     diff those leads against a config that does not actually score them.
  *
  * This is the control that catches what schema validation cannot: legal
  * weights that nonetheless score everyone 90+, or move half the book by 30
@@ -282,12 +459,27 @@ async function populationFor({ campaignId, productKey }, sampleMax) {
  */
 export async function simulateConfig({
   config, campaignId = null, productKey = null, now = Date.now(), sampleMax = SIMULATION_SAMPLE_MAX,
+  compareTo = 'stored',
 }) {
   const scope = normalizeScope({ campaignId, productKey });
+  if (!['stored', 'resolved'].includes(compareTo)) {
+    throw new AppError("compareTo must be 'stored' or 'resolved'.", 422);
+  }
+  if (compareTo === 'resolved' && !scope.campaignId) {
+    throw new AppError("compareTo:'resolved' is campaign-scope only — product and global "
+      + 'populations include campaign-overridden leads.', 422);
+  }
 
   const check = validateScoringConfig(config);
   if (!check.ok) throw new AppError(check.error, 422);
 
+  // Strict, not the fail-open resolver: a preview seeded from silent defaults
+  // would diff against a baseline nobody is actually scored by.
+  const resolved = compareTo === 'resolved'
+    ? await resolveScoringConfigStrict({ campaignId: scope.campaignId })
+    : null;
+
+  const startedAt = Date.now();
   const cap = Math.min(SIMULATION_SAMPLE_MAX, Math.max(1, sampleMax));
   const ids = await populationFor(scope, cap);
   const truncated = ids.length > cap;
@@ -296,34 +488,59 @@ export async function simulateConfig({
   const before = [];
   const after = [];
   const moves = [];
+  const storedScores = [];
   let becameNull = 0;
   let becameScored = 0;
   let skipped = 0;
 
-  for (const id of sample) {
+  const perLead = await mapPool(sample, SIMULATION_CONCURRENCY, async (id) => {
     const telemetry = await loadLeadTelemetry(id);
-    if (!telemetry) { skipped += 1; continue; }
+    if (!telemetry) return null;
     const observations = await loadLeadObservations({ prospectId: id, consumerId: telemetry.consumerId });
     const facts = resolveCurrentFacts(observations);
+    // Inputs loaded ONCE; scored once or twice at the SAME `now`.
     const proposed = scoreLead({ facts, telemetry, config, now });
-
+    const current = resolved ? scoreLead({ facts, telemetry, config: resolved.config, now }) : null;
     const [[stored]] = await sequelize.query('SELECT score FROM prospects WHERE id = :id', {
       replacements: { id },
     });
-    const wasScored = stored?.score !== null && stored?.score !== undefined;
+    return { proposed, current, storedScore: stored?.score ?? null };
+  });
+
+  for (const lead of perLead) {
+    if (!lead) { skipped += 1; continue; }
+    const { proposed, current, storedScore } = lead;
+    if (storedScore !== null) storedScores.push(storedScore);
+
+    // The comparison base: the re-scored current config (resolved mode), or
+    // the stored number (stored mode) — the original arithmetic, unchanged.
+    const baseScore = resolved ? current.score : storedScore;
+    const wasScored = baseScore !== null && baseScore !== undefined;
     const isScored = proposed.score !== null;
 
-    if (wasScored) before.push(stored.score);
+    if (wasScored) before.push(baseScore);
     if (isScored) after.push(proposed.score);
     if (wasScored && !isScored) becameNull += 1;
     if (!wasScored && isScored) becameScored += 1;
-    if (wasScored && isScored) moves.push(proposed.score - stored.score);
+    if (wasScored && isScored) moves.push(proposed.score - baseScore);
   }
 
   const bigMoves = moves.filter((d) => Math.abs(d) > BIG_MOVE_POINTS);
+  // The §4.3 budget is measured, not assumed: p95 over ~5s is the named
+  // trigger for the batch-loader fast-follow.
+  logger.info(
+    { ms: Date.now() - startedAt, examined: sample.length, compareTo, scope: scopeOf(scope) },
+    'scoring.config.simulated'
+  );
 
   return {
     scope: campaignId ? 'campaign' : productKey ? 'product' : 'global',
+    comparedTo: compareTo,
+    // Which edition "before" means in resolved mode — the caption's anchor.
+    ...(resolved ? { resolvedVersion: resolved.version } : {}),
+    // Stored scores as CONTEXT in resolved mode (labelled "includes drift
+    // since last rescore" by the UI) — never mixed into the config-only diff.
+    ...(resolved ? { stored: { scored: storedScores.length, mean: round1(mean(storedScores)) } } : {}),
     population: {
       // NO SILENT CAPS: when the sample is a slice, the response says how many
       // it looked at and that more exist, rather than presenting part as whole.
@@ -356,6 +573,56 @@ export async function simulateConfig({
       becameNull,
       becameScored,
     },
+  };
+}
+
+// ─────────────────────────── regrade progress (§4.8) ───────────────────────
+
+/**
+ * "X of Y leads on the edition that governs this campaign" — the campaign
+ * card's progress line while a regrade rolls through the nightly sweeps.
+ *
+ * `current` is the EXACT COMPLEMENT of findStaleLeadIds' staleness predicate
+ * (round-3 M4) — never a version match alone: a never-scored lead and a
+ * dirty-marked lead are stale even when their stamped edition is right, and a
+ * naive count would report 100% while the sweep still has them queued.
+ * Stamped-but-null SCORES count as done: scored-and-null is a result, not
+ * pending. `total` mirrors the sweep's own population rule (non-erased).
+ * One statement, one snapshot.
+ */
+export async function scoringProgressForCampaign(campaignId) {
+  if (!campaignId) throw new AppError('campaignId is required.', 422);
+  // Strict resolve — the editor surface never seeds from the fail-open path.
+  const resolved = await resolveScoringConfigStrict({ campaignId });
+  const [[row]] = await sequelize.query(
+    `SELECT count(*)::int AS total,
+            count(*) FILTER (
+              WHERE p."scoreComputedAt" IS NOT NULL
+                AND p."scoreDirtyAt" IS NULL
+                AND p."scoredConfigVersion" = :resolvedVersion
+                AND p."scoringAlgorithmVersion" = :algo
+            )::int AS current
+       FROM prospects p
+       LEFT JOIN consumers c ON c.id = p."consumerId"
+      WHERE p."campaignId" = :cid
+        AND (p."consumerId" IS NULL OR c."erasedAt" IS NULL)`,
+    {
+      replacements: {
+        cid: campaignId,
+        resolvedVersion: resolved.version,
+        algo: LEAD_ALGORITHM_VERSION,
+      },
+    }
+  );
+  const total = row?.total ?? 0;
+  const current = row?.current ?? 0;
+  return {
+    total,
+    current,
+    resolvedVersion: resolved.version,
+    scope: resolved.scope,
+    // An empty campaign is COMPLETE, not forever-pending (round-3 B3).
+    complete: total === 0 || current === total,
   };
 }
 

--- a/backend/src/utils/factTaxonomy.js
+++ b/backend/src/utils/factTaxonomy.js
@@ -37,8 +37,11 @@ export const MAX_EVIDENCE_CHARS = 300;
 export const MIN_LLM_CONFIDENCE = 0.5;
 
 const GENDERS = ['male', 'female'];
-const ETHNICITIES = ['chinese', 'malay', 'indian', 'eurasian', 'other'];
-const LANGUAGES = ['en', 'zh', 'ms', 'ta'];
+// Exported (campaign-scoring-editor §3.1/§4.7): the scoring-config validator
+// clamps targetSegments to THESE vocabularies, and the editor UI renders its
+// pickers from a parity-tested copy — one owner, here, for both.
+export const ETHNICITIES = ['chinese', 'malay', 'indian', 'eurasian', 'other'];
+export const LANGUAGES = ['en', 'zh', 'ms', 'ta'];
 const MARITAL = ['single', 'married', 'divorced', 'widowed'];
 const PROPERTY = ['hdb', 'condo', 'landed', 'none'];
 const EMPLOYMENT = ['employed', 'self_employed', 'unemployed', 'retired', 'nsf', 'student'];

--- a/backend/src/utils/scoringConfigValidation.js
+++ b/backend/src/utils/scoringConfigValidation.js
@@ -1,6 +1,7 @@
 import {
   SCOREABLE_COMPONENTS, DEFAULT_LEAD_COMPONENTS, normalizeConfig,
 } from './consumerScoring.js';
+import { LANGUAGES, ETHNICITIES } from './factTaxonomy.js';
 
 /**
  * SEMANTIC invariants for a scoring config
@@ -56,6 +57,26 @@ export const MAX_AGE_CURVE_SLOPE = 0.5;
 
 const MAX_AGE_CURVE_SEGMENTS = 24;
 
+/**
+ * Serialized-size ceiling, measured on the document as it would be STORED
+ * (after §4.1 composition, before the semantic checks below). Generous — the
+ * shipped default is ~1KB — but a bound: configJson is an unindexed jsonb
+ * column that rides every resolution read, and "the editor sent 40MB of
+ * segments" should be a 422, not a table problem.
+ */
+export const MAX_SCORING_CONFIG_BYTES = 64 * 1024;
+
+/**
+ * Sign map (campaign-scoring-editor §4.7). Penalties carry their sign in
+ * maxPoints (consumerScoring.js header) — so the sign IS the semantics, and a
+ * flipped one silently inverts the component: a positive coverage_headroom
+ * would pay people for being already insured. Everything not named here is a
+ * bonus and must not go negative.
+ */
+export const PENALTY_COMPONENTS = Object.freeze(new Set(['coverage_headroom']));
+
+const MAX_TARGET_SEGMENTS = 8;
+
 const isPlainObject = (x) => x !== null && typeof x === 'object' && !Array.isArray(x);
 const fail = (error) => ({ ok: false, error });
 const isFiniteNumber = (n) => typeof n === 'number' && Number.isFinite(n);
@@ -83,6 +104,17 @@ function checkComponentMap(raw, label) {
     if (!isFiniteNumber(def.maxPoints)) return `${label}.${name}.maxPoints must be a finite number.`;
     if (Math.abs(def.maxPoints) > MAX_COMPONENT_POINTS) {
       return `${label}.${name}.maxPoints must be within ±${MAX_COMPONENT_POINTS} (got ${def.maxPoints}).`;
+    }
+    // The sign is the semantics (§4.7): a penalty's negative max is what makes
+    // it subtract, so flipping it inverts the component rather than erroring.
+    // Zero is legal either way — it just switches the component off.
+    if (PENALTY_COMPONENTS.has(name) && def.maxPoints > 0) {
+      return `${label}.${name} is a penalty — its maxPoints must be ≤ 0 (got ${def.maxPoints}). `
+        + 'A positive value would REWARD what the component exists to subtract for.';
+    }
+    if (!PENALTY_COMPONENTS.has(name) && def.maxPoints < 0) {
+      return `${label}.${name}.maxPoints must be ≥ 0 (got ${def.maxPoints}) — only penalties `
+        + `(${[...PENALTY_COMPONENTS].join(', ')}) carry negative weight.`;
     }
   }
   return null;
@@ -192,6 +224,13 @@ function checkGroups(groups, components, leadComponents) {
 export function validateScoringConfig(raw) {
   if (!isPlainObject(raw)) return fail('A scoring config must be a JSON object.');
 
+  // Size FIRST: everything after this walks the document, and the walk itself
+  // should never be the DoS. Measured exactly as it would be stored.
+  const bytes = Buffer.byteLength(JSON.stringify(raw), 'utf8');
+  if (bytes > MAX_SCORING_CONFIG_BYTES) {
+    return fail(`Scoring config is ${bytes} bytes; the cap is ${MAX_SCORING_CONFIG_BYTES}.`);
+  }
+
   const KNOWN_TOP_LEVEL = [
     'algorithmVersion', 'groups', 'components', 'leadComponents',
     'ageCurve', 'targetSegments', 'decay', 'minFactConfidence',
@@ -218,13 +257,45 @@ export function validateScoringConfig(raw) {
 
   if (raw.targetSegments !== undefined) {
     if (!Array.isArray(raw.targetSegments)) return fail('targetSegments must be an array.');
+    if (raw.targetSegments.length > MAX_TARGET_SEGMENTS) {
+      return fail(`targetSegments has ${raw.targetSegments.length} rows; the cap is ${MAX_TARGET_SEGMENTS}.`);
+    }
+    const seenAxes = new Set();
     for (let i = 0; i < raw.targetSegments.length; i += 1) {
       const s = raw.targetSegments[i];
       if (!isPlainObject(s)) return fail(`targetSegments[${i}] must be an object.`);
+      const extra = Object.keys(s).filter((k) => !['language', 'ethnicity', 'weight'].includes(k));
+      if (extra.length) return fail(`targetSegments[${i}] has unknown keys: ${extra.join(', ')}.`);
+      // A row with neither axis can never match anyone — it is dead weight the
+      // scorer would silently skip forever.
+      if (s.language === undefined && s.ethnicity === undefined) {
+        return fail(`targetSegments[${i}] must name a language or an ethnicity.`);
+      }
+      if (s.language !== undefined && !LANGUAGES.includes(s.language)) {
+        return fail(`targetSegments[${i}].language must be one of: ${LANGUAGES.join(', ')}.`);
+      }
+      if (s.ethnicity !== undefined && !ETHNICITIES.includes(s.ethnicity)) {
+        return fail(`targetSegments[${i}].ethnicity must be one of: ${ETHNICITIES.join(', ')}.`);
+      }
       if (s.weight !== undefined && (!isFiniteNumber(s.weight) || s.weight < 0 || s.weight > 1)) {
         return fail(`targetSegments[${i}].weight must be a number in 0..1.`);
       }
+      // Two rows for the same (language, ethnicity) pair: only the heavier one
+      // could ever win, so the duplicate is either a mistake or a contradiction.
+      const axisKey = `${s.language ?? '*'}|${s.ethnicity ?? '*'}`;
+      if (seenAxes.has(axisKey)) return fail(`targetSegments[${i}] duplicates an earlier row's axes.`);
+      seenAxes.add(axisKey);
     }
+  }
+
+  // Exact keys on the RAW decay object — the normalized checks below cover the
+  // two known knobs' VALUES, but an unknown sibling key would ride into
+  // storage silently and read as meaningful forever.
+  if (raw.decay !== undefined) {
+    if (!isPlainObject(raw.decay)) return fail('decay must be an object.');
+    const extra = Object.keys(raw.decay)
+      .filter((k) => !['lifeEventHalfLifeDays', 'engagementHalfLifeDays'].includes(k));
+    if (extra.length) return fail(`decay has unknown keys: ${extra.join(', ')}.`);
   }
 
   // Normalize AFTER the raw-shape checks so the semantic rules below run over

--- a/backend/test/leadProfileService.test.js
+++ b/backend/test/leadProfileService.test.js
@@ -591,3 +591,93 @@ describe('consentTimeline — source-allowlisted contact events', () => {
     expect(await svc.consentTimeline(null)).toEqual([]);
   });
 });
+
+// ── consumerEnrichment: the caption stamps travel with the copied breakdown ──
+//
+// campaign-scoring-editor §4.4. The projected breakdown is a copy of the
+// winning LEAD's document, but consumer_profiles' own stamp columns are
+// re-written by the person pass every consumer sweep — so the caption must
+// come from the SOURCE LEAD, read in the same SQL snapshot, or show nothing.
+describe('consumerEnrichment caption stamps', () => {
+  const PROFILE_ROW = {
+    meetScore: 50, buyScore: 16, consumerScore: 48,
+    scoreBreakdown: { groups: {}, components: {}, events: [] },
+    // The person-pass stamps — under per-campaign sheets these describe a
+    // DIFFERENT document than the breakdown shown.
+    scoreComputedAt: '2026-07-30T00:00:00Z',
+    scoredConfigVersion: 3,
+    scoringAlgorithmVersion: 'score/v3',
+    scoreSourceProspectId: 'p-src',
+  };
+
+  function stampDeps(row) {
+    return makeLeadProfileService({
+      logger: silentLogger,
+      sequelize: {
+        query: jest.fn().mockImplementation(async (sql) => {
+          if (String(sql).includes('FROM consumer_profiles cp')) return [row ? [row] : []];
+          return [[]];
+        }),
+      },
+      loadObservations: jest.fn().mockResolvedValue([]),
+      resolveCurrentFacts: jest.fn().mockReturnValue({}),
+    });
+  }
+
+  it('prefers the SOURCE lead stamps when the join resolves — they caption the copy', async () => {
+    const svc = stampDeps({
+      ...PROFILE_ROW,
+      srcProspectId: 'p-src', srcCampaignId: 'camp-1', srcCampaignName: 'Tokyo Draw',
+      // Older than the person pass — CORRECT, not stale: it captions the
+      // copied breakdown, not current resolution (Codex round-3).
+      srcConfigVersion: 7, srcAlgorithmVersion: 'lead/v1', srcComputedAt: '2026-07-28T00:00:00Z',
+    });
+    const e = await svc.consumerEnrichment('con-1');
+    expect(e.configVersion).toBe(7);
+    expect(e.algorithmVersion).toBe('lead/v1');
+    expect(e.scoredAt).toBe('2026-07-28T00:00:00Z');
+    expect(e.stampsUnavailable).toBe(false);
+    expect(e.scoreSource).toEqual({ prospectId: 'p-src', campaignId: 'camp-1', campaignName: 'Tokyo Draw' });
+  });
+
+  it('a retained breakdown with an unresolvable source shows NO stamps — never person-pass ones', async () => {
+    // Deleted source lead AND the pre-migration-101 legacy projection both
+    // land here (null pointer, breakdown kept) — observationally identical,
+    // so the copy claims neither deletion nor a caption (round-5 B1).
+    const svc = stampDeps({
+      ...PROFILE_ROW,
+      scoreSourceProspectId: null,
+      srcProspectId: null, srcCampaignId: null, srcCampaignName: null,
+      srcConfigVersion: null, srcAlgorithmVersion: null, srcComputedAt: null,
+    });
+    const e = await svc.consumerEnrichment('con-1');
+    expect(e.stampsUnavailable).toBe(true);
+    expect(e.configVersion).toBeNull();
+    expect(e.scoredAt).toBeNull();
+    expect(e.algorithmVersion).toBeNull();
+    expect(e.scoreSource).toBeNull();
+    // The numbers themselves still render — only the caption is withheld.
+    expect(e.meetScore).toBe(50);
+    expect(e.breakdown).toEqual(PROFILE_ROW.scoreBreakdown);
+  });
+
+  it('no breakdown at all → person-pass stamps caption person-pass state', async () => {
+    const svc = stampDeps({
+      ...PROFILE_ROW,
+      scoreBreakdown: null, meetScore: null, buyScore: null, consumerScore: null,
+      scoreSourceProspectId: null,
+      srcProspectId: null, srcCampaignId: null, srcCampaignName: null,
+      srcConfigVersion: null, srcAlgorithmVersion: null, srcComputedAt: null,
+    });
+    const e = await svc.consumerEnrichment('con-1');
+    expect(e.stampsUnavailable).toBe(false);
+    expect(e.configVersion).toBe(3);
+    expect(e.algorithmVersion).toBe('score/v3');
+    expect(e.scoredAt).toBe('2026-07-30T00:00:00Z');
+  });
+
+  it('never person-scored (no stamp) stays null — the card is absent, not empty', async () => {
+    const svc = stampDeps({ ...PROFILE_ROW, scoredConfigVersion: null });
+    expect(await svc.consumerEnrichment('con-1')).toBeNull();
+  });
+});

--- a/backend/test/scoringConfigAuthoring.test.js
+++ b/backend/test/scoringConfigAuthoring.test.js
@@ -5,9 +5,11 @@ import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect
 import { sequelize, Consumer, Prospect } from '../src/models/index.js'
 import {
   createDraftConfig, approveScoringConfig, simulateConfig, proposeScoringConfig,
-  listScoringConfigs, sanitizeDescription, MAX_DESCRIPTION_CHARS,
+  listScoringConfigs, getScoringConfig, sanitizeDescription, MAX_DESCRIPTION_CHARS,
 } from '../src/services/scoringConfigService.js'
-import { getActiveScoringConfig, _resetConfigCache } from '../src/services/consumerScoringService.js'
+import {
+  getActiveScoringConfig, resolveScoringConfigStrict, _resetConfigCache,
+} from '../src/services/consumerScoringService.js'
 import { bustScoringConfigCache } from '../src/services/scoringConfigCache.js'
 import { scoreOneLead } from '../src/services/leadScoringService.js'
 import { DEFAULT_SCORING_CONFIG } from '../src/utils/consumerScoring.js'
@@ -43,6 +45,19 @@ const configWith = (agePoints) => ({
   ...DEFAULT_SCORING_CONFIG,
   components: { ...DEFAULT_SCORING_CONFIG.components, age: { maxPoints: agePoints } },
 })
+
+/**
+ * Approve against the CURRENT live baseline for the row's own scope — what the
+ * editor does (§4.5): resolve strictly, hand the observed version back. Tests
+ * that probe the concurrency guard itself pass expectedLiveVersion directly.
+ */
+async function approveLive(version, opts = {}) {
+  const row = await getScoringConfig(version)
+  const live = await resolveScoringConfigStrict({
+    campaignId: row.campaignId, productKey: row.productKey,
+  })
+  return approveScoringConfig(version, { expectedLiveVersion: live.version, ...opts })
+}
 
 /** The shape the provider is contracted to return. */
 const modelProposal = (over = {}) => ({
@@ -126,7 +141,7 @@ afterAll(async () => {
 
 describe('a proposal is a DRAFT, and a draft is not live (§8.3)', () => {
   test('proposing stores a draft that the resolver cannot see', async () => {
-    await createDraftConfig({ config: configWith(3) }).then((d) => approveScoringConfig(d.version))
+    await createDraftConfig({ config: configWith(3) }).then((d) => approveLive(d.version))
 
     const { draft } = await propose({ campaignId: campInsurance.id }, modelProposal())
     expect(draft.status).toBe('draft')
@@ -141,10 +156,10 @@ describe('a proposal is a DRAFT, and a draft is not live (§8.3)', () => {
 
   test('approving it is the single act that makes it live', async () => {
     const globalRow = await createDraftConfig({ config: configWith(3) })
-    await approveScoringConfig(globalRow.version)
+    await approveLive(globalRow.version)
 
     const { draft } = await propose({ campaignId: campInsurance.id }, modelProposal())
-    await approveScoringConfig(draft.version, { actorUserId: admin.id })
+    await approveLive(draft.version, { actorUserId: admin.id })
 
     bustScoringConfigCache()
     const live = await getActiveScoringConfig({ campaignId: campInsurance.id })
@@ -154,12 +169,12 @@ describe('a proposal is a DRAFT, and a draft is not live (§8.3)', () => {
 
   test('approving supersedes the previous approved row AT THE SAME SCOPE only', async () => {
     const oldGlobal = await createDraftConfig({ config: configWith(3) })
-    await approveScoringConfig(oldGlobal.version)
+    await approveLive(oldGlobal.version)
     const scoped = await createDraftConfig({ config: configWith(9), campaignId: campInsurance.id })
-    await approveScoringConfig(scoped.version)
+    await approveLive(scoped.version)
 
     const newGlobal = await createDraftConfig({ config: configWith(4) })
-    await approveScoringConfig(newGlobal.version)
+    await approveLive(newGlobal.version)
 
     const byVersion = Object.fromEntries(
       (await listScoringConfigs({ limit: 200 })).map((r) => [r.version, r.status])
@@ -172,23 +187,23 @@ describe('a proposal is a DRAFT, and a draft is not live (§8.3)', () => {
 
   test('a superseded row cannot be re-approved, and an approved one cannot be re-approved', async () => {
     const a = await createDraftConfig({ config: configWith(3) })
-    await approveScoringConfig(a.version)
-    await expect(approveScoringConfig(a.version)).rejects.toThrow(/already approved/)
+    await approveLive(a.version)
+    await expect(approveLive(a.version)).rejects.toThrow(/already approved/)
 
     const b = await createDraftConfig({ config: configWith(4) })
-    await approveScoringConfig(b.version)
-    await expect(approveScoringConfig(a.version)).rejects.toThrow(/superseded config cannot be re-approved/)
+    await approveLive(b.version)
+    await expect(approveLive(a.version)).rejects.toThrow(/superseded config cannot be re-approved/)
   })
 
   test('approving busts the cache, so the next lead scores under the new rules', async () => {
     const g = await createDraftConfig({ config: configWith(3) })
-    await approveScoringConfig(g.version)
+    await approveLive(g.version)
     const lead = await leadOn(campInsurance)
     await scoreOneLead(lead.id, { force: true })
     expect((await Prospect.findByPk(lead.id)).scoredConfigVersion).toBe(g.version)
 
     const scoped = await createDraftConfig({ config: configWith(22), campaignId: campInsurance.id })
-    await approveScoringConfig(scoped.version)
+    await approveLive(scoped.version)
 
     // No explicit _resetConfigCache: approve is contracted to bust it.
     await scoreOneLead(lead.id, { force: true })
@@ -280,7 +295,7 @@ describe('the AI never scores a lead — it only writes weights', () => {
   test('the prompt carries the brief and current weights, and no lead data at all', async () => {
     const capture = []
     const g = await createDraftConfig({ config: configWith(3) })
-    await approveScoringConfig(g.version)
+    await approveLive(g.version)
     const lead = await leadOn(campInsurance)
     await scoreOneLead(lead.id, { force: true })
 
@@ -297,7 +312,7 @@ describe('the AI never scores a lead — it only writes weights', () => {
 
   test('scoring the same lead twice under one config gives the same number', async () => {
     const { draft } = await propose({ campaignId: campInsurance.id }, modelProposal())
-    await approveScoringConfig(draft.version)
+    await approveLive(draft.version)
     const lead = await leadOn(campInsurance)
 
     const first = await scoreOneLead(lead.id, { force: true })
@@ -310,7 +325,7 @@ describe('the AI never scores a lead — it only writes weights', () => {
 describe('simulation before activation (§8.2)', () => {
   test('reports the distribution diff a schema check cannot see', async () => {
     const g = await createDraftConfig({ config: configWith(3) })
-    await approveScoringConfig(g.version)
+    await approveLive(g.version)
 
     const leads = [await leadOn(campInsurance), await leadOn(campInsurance)]
     for (const l of leads) await scoreOneLead(l.id, { force: true })
@@ -328,7 +343,7 @@ describe('simulation before activation (§8.2)', () => {
 
   test('a config that scores everyone high is visible as a mean shift', async () => {
     const g = await createDraftConfig({ config: configWith(3) })
-    await approveScoringConfig(g.version)
+    await approveLive(g.version)
     for (let i = 0; i < 3; i += 1) {
       const l = await leadOn(campRecruitment)
       await scoreOneLead(l.id, { force: true })
@@ -364,7 +379,7 @@ describe('simulation before activation (§8.2)', () => {
 
   test('it writes nothing — the stored scores are untouched afterwards', async () => {
     const g = await createDraftConfig({ config: configWith(3) })
-    await approveScoringConfig(g.version)
+    await approveLive(g.version)
     const lead = await leadOn(campInsurance)
     await scoreOneLead(lead.id, { force: true })
     const before = await Prospect.findByPk(lead.id)
@@ -379,7 +394,7 @@ describe('simulation before activation (§8.2)', () => {
 
   test('a truncated sample SAYS it is truncated rather than reading as the whole picture', async () => {
     const g = await createDraftConfig({ config: configWith(3) })
-    await approveScoringConfig(g.version)
+    await approveLive(g.version)
     for (let i = 0; i < 3; i += 1) await leadOn(campInsurance)
 
     const sim = await simulateConfig({
@@ -415,5 +430,197 @@ describe('scope hygiene', () => {
       { campaignId: '00000000-0000-4000-8000-000000000000' }, modelProposal(), capture
     )).rejects.toThrow(/Campaign not found/)
     expect(capture).toHaveLength(0)
+  })
+})
+
+// ── the editor's amendments (campaign-scoring-editor §4) ────────────────────
+
+describe('§4.1 composition: a campaign patch lands on the WINNING raw doc', () => {
+  test('explicit product-sheet extras survive; arrays replace wholesale', async () => {
+    // A product sheet that carries an EXPLICIT decay override — the kind of
+    // hidden knob a naive campaign override would silently reset to defaults.
+    const product = await createDraftConfig({
+      config: { ...configWith(5), decay: { engagementHalfLifeDays: 90, lifeEventHalfLifeDays: 365 } },
+      productKey: 'insurance',
+    })
+    await approveLive(product.version)
+
+    const curve = [{ upTo: 34, value: 0.6 }, { upTo: 44, value: 1 }, { upTo: null, value: 0.6 }]
+    const draft = await createDraftConfig({
+      config: { ageCurve: curve },
+      campaignId: campInsurance.id,
+      composeOnResolved: true,
+    })
+
+    // The stored document is the COMPOSED one: patch applied, extras kept.
+    expect(draft.configJson.decay.engagementHalfLifeDays).toBe(90)
+    expect(draft.configJson.components.age.maxPoints).toBe(5)
+    // Arrays replace wholesale — never element-merged into nonsense.
+    expect(draft.configJson.ageCurve).toEqual(curve)
+  })
+
+  test('version-0 base composes the patch alone', async () => {
+    const draft = await createDraftConfig({
+      config: { components: { age: { maxPoints: 8 } } },
+      campaignId: campInsurance.id,
+      composeOnResolved: true,
+    })
+    expect(draft.configJson.components.age.maxPoints).toBe(8)
+    // Nothing else was pinned — the base was {}, not a frozen default dump.
+    expect(draft.configJson.decay).toBeUndefined()
+  })
+
+  test('a draft for a campaign that does not exist is a 422, not a stray row', async () => {
+    await expect(createDraftConfig({
+      config: configWith(5), campaignId: '00000000-0000-4000-8000-000000000001',
+    })).rejects.toThrow(/Campaign not found/)
+  })
+})
+
+describe('§4.5/§4.6 approve: race guards and the content-equal no-op', () => {
+  test('a stale expectedLiveVersion is a 409 sentence', async () => {
+    const draft = await createDraftConfig({ config: configWith(6), campaignId: campInsurance.id })
+    await expect(approveScoringConfig(draft.version, { expectedLiveVersion: 999999 }))
+      .rejects.toThrow(/changed while you were editing/)
+  })
+
+  test('the baseline is the RESOLVED winner — a campaign inheriting global compares against global', async () => {
+    const g = await createDraftConfig({ config: configWith(3) })
+    await approveLive(g.version)
+    const draft = await createDraftConfig({ config: configWith(9), campaignId: campInsurance.id })
+    // The campaign has no row of its own; what the editor saw as live was the
+    // GLOBAL version. That is the number that must pass the guard.
+    const approved = await approveScoringConfig(draft.version, { expectedLiveVersion: g.version })
+    expect(approved.status).toBe('approved')
+  })
+
+  test('content-equal approve is a stated no-op: no new live version, candidate stays a draft', async () => {
+    const g = await createDraftConfig({ config: configWith(3) })
+    await approveLive(g.version)
+    // Same CONTENT at the same effective scope-resolution — jsonb equality.
+    const dup = await createDraftConfig({ config: configWith(3), campaignId: campInsurance.id })
+    const res = await approveScoringConfig(dup.version, { expectedLiveVersion: g.version })
+
+    expect(res.noOp).toBe(true)
+    expect(res.live.version).toBe(g.version)
+    expect(res.candidateVersion).toBe(dup.version)
+    // The candidate is STILL a draft — not superseded, which would make it
+    // indistinguishable from a formerly-live edition (round-3 M2).
+    expect((await getScoringConfig(dup.version)).status).toBe('draft')
+    // And the resolved version did not move → no regrade was triggered.
+    bustScoringConfigCache()
+    const live = await getActiveScoringConfig({ campaignId: campInsurance.id })
+    expect(live.version).toBe(g.version)
+  })
+
+  test('a row that stopped being a draft under the lock loses loudly', async () => {
+    const draft = await createDraftConfig({ config: configWith(7), campaignId: campInsurance.id })
+    // Simulate a concurrent transition committing first.
+    await sequelize.query(
+      `UPDATE enrichment_scoring_configs SET status = 'superseded' WHERE version = :v`,
+      { replacements: { v: draft.version } }
+    )
+    await expect(approveScoringConfig(draft.version, { expectedLiveVersion: 0 }))
+      .rejects.toThrow(/superseded config cannot be re-approved/)
+  })
+})
+
+describe('§4.7 validator strengthening', () => {
+  test('a flipped penalty sign is rejected, both directions', async () => {
+    await expect(createDraftConfig({
+      config: { ...configWith(5), components: { ...configWith(5).components, coverage_headroom: { maxPoints: 10 } } },
+    })).rejects.toThrow(/penalty/)
+    await expect(createDraftConfig({
+      config: configWith(-5),
+    })).rejects.toThrow(/only penalties/)
+  })
+
+  test('targetSegments are vocabulary-clamped, axis-required, duplicate-free', async () => {
+    const base = configWith(5)
+    await expect(createDraftConfig({ config: { ...base, targetSegments: [{ weight: 1 }] } }))
+      .rejects.toThrow(/must name a language or an ethnicity/)
+    await expect(createDraftConfig({ config: { ...base, targetSegments: [{ language: 'fr' }] } }))
+      .rejects.toThrow(/language must be one of/)
+    await expect(createDraftConfig({ config: { ...base, targetSegments: [{ language: 'zh', typo: 1 }] } }))
+      .rejects.toThrow(/unknown keys/)
+    await expect(createDraftConfig({
+      config: { ...base, targetSegments: [{ language: 'zh' }, { language: 'zh' }] },
+    })).rejects.toThrow(/duplicates/)
+  })
+
+  test('decay rejects unknown sibling keys; oversized configs are a 422', async () => {
+    await expect(createDraftConfig({
+      config: { ...configWith(5), decay: { engagementHalfLifeDays: 90, lifeEventHalfLifeDays: 365, typo: 1 } },
+    })).rejects.toThrow(/decay has unknown keys/)
+    await expect(createDraftConfig({
+      config: { ...configWith(5), targetSegments: [{ language: 'zh', ethnicity: 'chinese'.repeat(20000) }] },
+    })).rejects.toThrow(/bytes/)
+  })
+})
+
+describe("§4.3 simulate compareTo:'resolved' isolates the config's own impact", () => {
+  test('refuses non-campaign scopes while their populations include overridden leads', async () => {
+    await expect(simulateConfig({ config: configWith(5), productKey: 'insurance', compareTo: 'resolved' }))
+      .rejects.toThrow(/campaign-scope only/)
+  })
+
+  test('a candidate identical to the resolved config moves nobody, whatever drift the stored scores carry', async () => {
+    const g = await createDraftConfig({ config: configWith(3) })
+    await approveLive(g.version)
+    const lead = await leadOn(campInsurance)
+    await scoreOneLead(lead.id, { force: true })
+    // Poison the STORED score so a stored-comparison would show a huge move.
+    await sequelize.query('UPDATE prospects SET score = 1 WHERE id = :id', { replacements: { id: lead.id } })
+
+    const sim = await simulateConfig({
+      config: configWith(3), campaignId: campInsurance.id, compareTo: 'resolved',
+    })
+    expect(sim.comparedTo).toBe('resolved')
+    expect(sim.resolvedVersion).toBe(g.version)
+    // Config-only delta: identical config → zero movement, despite the poison.
+    expect(sim.diff.meanDelta === 0 || sim.diff.meanDelta === null).toBe(true)
+    expect(sim.diff.movedOver20).toBe(0)
+    // The drifted stored score is CONTEXT, not the comparison base.
+    expect(sim.stored.scored).toBeGreaterThan(0)
+  })
+
+  test('writes nothing', async () => {
+    const g = await createDraftConfig({ config: configWith(3) })
+    await approveLive(g.version)
+    const lead = await leadOn(campInsurance)
+    await scoreOneLead(lead.id, { force: true })
+    const beforeRow = (await sequelize.query('SELECT score, "scoreBreakdown" FROM prospects WHERE id = :id', { replacements: { id: lead.id } }))[0][0]
+    await simulateConfig({ config: configWith(9), campaignId: campInsurance.id, compareTo: 'resolved' })
+    const afterRow = (await sequelize.query('SELECT score, "scoreBreakdown" FROM prospects WHERE id = :id', { replacements: { id: lead.id } }))[0][0]
+    expect(afterRow).toEqual(beforeRow)
+  })
+})
+
+describe('§4.8 regrade progress is the complement of the sweep, never a version match alone', () => {
+  test('counts stamped-current leads; dirty and never-scored rows are NOT current; empty is complete', async () => {
+    const { scoringProgressForCampaign } = await import('../src/services/scoringConfigService.js')
+    const g = await createDraftConfig({ config: configWith(3) })
+    await approveLive(g.version)
+
+    const camp = await createTestCampaign(admin.id, {
+      name: `Progress ${Date.now()}`,
+      targetAudience: { objective: 'agent_leads', product: 'insurance' },
+    })
+    // Empty campaign: complete, not forever-pending (round-3 B3).
+    expect((await scoringProgressForCampaign(camp.id)).complete).toBe(true)
+
+    const a = await leadOn(camp) // scored current
+    const b = await leadOn(camp) // scored current but DIRTY → stale
+    const c = await leadOn(camp) // never scored → stale
+    await scoreOneLead(a.id, { force: true })
+    await scoreOneLead(b.id, { force: true })
+    await sequelize.query('UPDATE prospects SET "scoreDirtyAt" = now() WHERE id = :id', { replacements: { id: b.id } })
+
+    const p = await scoringProgressForCampaign(camp.id)
+    expect(p.total).toBe(3)
+    expect(p.current).toBe(1)
+    expect(p.resolvedVersion).toBe(g.version)
+    expect(p.complete).toBe(false)
+    expect(String(c.id)).toBeTruthy()
   })
 })

--- a/backend/test/scoringConfigRoutes.test.js
+++ b/backend/test/scoringConfigRoutes.test.js
@@ -143,10 +143,17 @@ describe('authoring and listing', () => {
   })
 })
 
+/** The observed live baseline for a scope — what the editor sends (§4.5). */
+async function liveVersionFor(query = '') {
+  const res = await asAdmin(request(app).get(`${meta.path}/resolve?${query}${query ? '&' : ''}strict=1`))
+  return res.body.data.version
+}
+
 describe('resolve answers "which config scores this campaign, and why"', () => {
   test('reports the winning tier', async () => {
     const g = await createDraftConfig({ config: config(3) })
     await asAdmin(request(app).post(`${meta.path}/${g.version}/approve`))
+      .send({ expectedLiveVersion: await liveVersionFor() })
 
     const res = await asAdmin(request(app).get(`${meta.path}/resolve?campaignId=${campaign.id}`))
     expect(res.status).toBe(200)
@@ -184,7 +191,16 @@ describe('simulate writes nothing, approve is the only door to live', () => {
 
   test('POST /:version/approve makes it live and is refused a second time', async () => {
     const draft = await createDraftConfig({ config: config(9), campaignId: campaign.id })
+    // The concurrency guard is REQUIRED at the route: no body → 400, wrong
+    // baseline → 409 with the re-open-preview sentence (§4.5).
+    expect((await asAdmin(request(app).post(`${meta.path}/${draft.version}/approve`)).send({})).status).toBe(400)
+    const stale = await asAdmin(request(app).post(`${meta.path}/${draft.version}/approve`))
+      .send({ expectedLiveVersion: 999999 })
+    expect(stale.status).toBe(409)
+    expect(stale.body.message).toMatch(/changed while you were editing/)
+
     const ok = await asAdmin(request(app).post(`${meta.path}/${draft.version}/approve`))
+      .send({ expectedLiveVersion: await liveVersionFor(`campaignId=${campaign.id}`) })
     expect(ok.status).toBe(200)
     expect(ok.body.data.status).toBe('approved')
 
@@ -193,6 +209,132 @@ describe('simulate writes nothing, approve is the only door to live', () => {
     expect(resolved.body.data.scope).toBe('campaign')
 
     const again = await asAdmin(request(app).post(`${meta.path}/${draft.version}/approve`))
+      .send({ expectedLiveVersion: draft.version })
     expect(again.status).toBe(409)
+  })
+})
+
+// ── the editor's wire additions (campaign-scoring-editor §3-§4) ─────────────
+
+describe('strict resolve is the editor read path', () => {
+  test('?strict=1 carries activation metadata, the raw doc, and houseDefault ghosts', async () => {
+    const g = await createDraftConfig({ config: config(3) })
+    await asAdmin(request(app).post(`${meta.path}/${g.version}/approve`))
+      .send({ expectedLiveVersion: await liveVersionFor() })
+
+    const res = await asAdmin(request(app).get(`${meta.path}/resolve?campaignId=${campaign.id}&strict=1`))
+    expect(res.status).toBe(200)
+    expect(res.body.data.version).toBe(g.version)
+    expect(res.body.data.scope).toBe('global')
+    expect(res.body.data.raw.components.age.maxPoints).toBe(3)
+    expect(res.body.data.activatedAt).toBeTruthy()
+    // The server-owned ghost/reset source (round-2 B12).
+    expect(res.body.data.houseDefault.components.age.maxPoints)
+      .toBe(DEFAULT_SCORING_CONFIG.components.age.maxPoints)
+  })
+
+  test('version 0 is the legitimate house-default baseline, raw {}', async () => {
+    const res = await asAdmin(request(app).get(`${meta.path}/resolve?campaignId=${campaign.id}&strict=1`))
+    expect(res.status).toBe(200)
+    expect(res.body.data.version).toBe(0)
+    expect(res.body.data.scope).toBe('default')
+    expect(res.body.data.raw).toEqual({})
+  })
+
+  test('a malformed campaignId is a 400 sentence, not a Postgres cast error', async () => {
+    const res = await asAdmin(request(app).get(`${meta.path}/resolve?campaignId=not-a-uuid&strict=1`))
+    expect(res.status).toBe(400)
+    expect(res.body.message).toMatch(/UUID/)
+  })
+})
+
+describe('GET /progress rides before /:version', () => {
+  test('the word "progress" is a route, not a version number', async () => {
+    const res = await asAdmin(request(app).get(`${meta.path}/progress?campaignId=${campaign.id}`))
+    expect(res.status).toBe(200)
+    expect(res.body.data).toHaveProperty('total')
+    expect(res.body.data).toHaveProperty('current')
+    expect(res.body.data).toHaveProperty('complete')
+  })
+
+  test('campaignId is required', async () => {
+    expect((await asAdmin(request(app).get(`${meta.path}/progress`))).status).toBe(400)
+  })
+})
+
+describe('the history list is scope-filterable server-side', () => {
+  test('campaignId filter applies BEFORE the limit, and rows carry createdAt + actor name', async () => {
+    // Noise: global editions that would crowd a client-side filter's window.
+    for (let i = 0; i < 3; i += 1) {
+      await createDraftConfig({ config: config(4 + i) })
+    }
+    const mine = await createDraftConfig({ config: config(9), campaignId: campaign.id })
+
+    const res = await asAdmin(request(app).get(`${meta.path}/?campaignId=${campaign.id}`))
+    expect(res.status).toBe(200)
+    expect(res.body.data).toHaveLength(1)
+    expect(res.body.data[0].version).toBe(mine.version)
+    expect(res.body.data[0]).toHaveProperty('createdAt')
+    expect(res.body.data[0]).toHaveProperty('actorName')
+  })
+
+  test('two scope filters at once is a 422', async () => {
+    const res = await asAdmin(request(app).get(`${meta.path}/?campaignId=${campaign.id}&productKey=insurance`))
+    expect(res.status).toBe(422)
+  })
+})
+
+describe('the editor draft door composes on the resolved winner', () => {
+  test('POST / with composeOnResolved merges the patch onto the live raw doc', async () => {
+    const g = await createDraftConfig({
+      config: { ...config(5), decay: { engagementHalfLifeDays: 90, lifeEventHalfLifeDays: 365 } },
+    })
+    await asAdmin(request(app).post(`${meta.path}/${g.version}/approve`))
+      .send({ expectedLiveVersion: await liveVersionFor() })
+
+    const res = await asAdmin(request(app).post(`${meta.path}/`))
+      .send({
+        campaignId: campaign.id,
+        composeOnResolved: true,
+        config: { components: { age: { maxPoints: 8 } } },
+      })
+    expect(res.status).toBe(201)
+    expect(res.body.data.configJson.components.age.maxPoints).toBe(8)
+    // The winner's explicit extras rode into the campaign edition.
+    expect(res.body.data.configJson.decay.engagementHalfLifeDays).toBe(90)
+    expect(res.body.data.configJson.components.engagement.maxPoints)
+      .toBe(DEFAULT_SCORING_CONFIG.components.engagement.maxPoints)
+  })
+})
+
+describe('the no-op approve contract (§4.6)', () => {
+  test('content-equal approve answers 200 {noOp:true} and the candidate stays a draft', async () => {
+    const g = await createDraftConfig({ config: config(3) })
+    await asAdmin(request(app).post(`${meta.path}/${g.version}/approve`))
+      .send({ expectedLiveVersion: await liveVersionFor() })
+
+    const dup = await createDraftConfig({ config: config(3), campaignId: campaign.id })
+    const res = await asAdmin(request(app).post(`${meta.path}/${dup.version}/approve`))
+      .send({ expectedLiveVersion: g.version })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.noOp).toBe(true)
+    expect(res.body.data.live.version).toBe(g.version)
+    expect(res.body.data.candidateVersion).toBe(dup.version)
+
+    const after = await asAdmin(request(app).get(`${meta.path}/${dup.version}`))
+    expect(after.body.data.status).toBe('draft')
+  })
+})
+
+describe("simulate's compareTo rides the route", () => {
+  test("body {compareTo:'resolved'} reaches the service and reports its base", async () => {
+    const draft = await createDraftConfig({ config: config(9), campaignId: campaign.id })
+    const res = await asAdmin(request(app).post(`${meta.path}/${draft.version}/simulate`))
+      .send({ compareTo: 'resolved', sampleMax: 50 })
+    expect(res.status).toBe(200)
+    expect(res.body.data.comparedTo).toBe('resolved')
+    expect(res.body.data).toHaveProperty('resolvedVersion')
+    expect(res.body.data).toHaveProperty('stored')
   })
 })

--- a/backend/test/scoringVocabParity.test.js
+++ b/backend/test/scoringVocabParity.test.js
@@ -1,0 +1,40 @@
+import { LANGUAGES, ETHNICITIES } from '../src/utils/factTaxonomy.js'
+import {
+  SEGMENT_LANGUAGES, SEGMENT_ETHNICITIES, buildAgeCurveFromBands,
+} from '../../src/lib/adminV2/scoringLabels.js'
+import { validateScoringConfig } from '../src/utils/scoringConfigValidation.js'
+import { DEFAULT_SCORING_CONFIG } from '../src/utils/consumerScoring.js'
+
+/**
+ * The editor's vocabulary mirrors the taxonomy's (campaign-scoring-editor
+ * §3.1, round-2 B4): factTaxonomy owns the enums; the frontend module carries
+ * a labelled copy for its pickers. This pin is what makes the copy safe — an
+ * enum added or renamed on either side fails here, not in a 422 an admin
+ * meets mid-edit.
+ *
+ * The age-preset builder is pinned against the REAL validator for every band
+ * combination (round-3 M3): presets must be slope-legal by construction, and
+ * this proves it against the rule itself, not a copied constant.
+ */
+
+test('the editor language and ethnicity pickers mirror the taxonomy exactly', () => {
+  expect(SEGMENT_LANGUAGES.map((l) => l.id)).toEqual(LANGUAGES)
+  expect(SEGMENT_ETHNICITIES.map((e) => e.id)).toEqual(ETHNICITIES)
+})
+
+test('every band-preset combination builds a curve the validator accepts', () => {
+  const bands = ['18-29', '30-44', '45-59', '60+']
+  // All 15 non-empty subsets.
+  for (let mask = 1; mask < 16; mask += 1) {
+    const picked = bands.filter((_, i) => mask & (1 << i))
+    const curve = buildAgeCurveFromBands(picked)
+    expect(curve[curve.length - 1].upTo).toBeNull()
+    const check = validateScoringConfig({ ...DEFAULT_SCORING_CONFIG, ageCurve: curve })
+    if (!check.ok) throw new Error(`bands ${picked.join('+')} built an invalid curve: ${check.error}`)
+  }
+})
+
+test('nothing selected builds nothing — the caller keeps its curve', () => {
+  expect(buildAgeCurveFromBands([])).toBeNull()
+  expect(buildAgeCurveFromBands(undefined)).toBeNull()
+})

--- a/docs/plans/campaign-scoring-editor.md
+++ b/docs/plans/campaign-scoring-editor.md
@@ -1,0 +1,412 @@
+# Campaign Scoring Editor — plan v5 (2026-07-30)
+
+**In one sentence:** the scoring-config backend already exists (PR #312 —
+draft → simulate → approve, AI propose, validator, dark behind
+`SCORING_CONFIG_ADMIN_ENABLED`); this project builds the **missing UI** on the
+campaign page and in the create flow, plus a set of service amendments the
+Codex reviews surfaced, then flips the flag.
+
+**History:** v1 (premise "no write path exists") — Codex round 1 FAIL, M1
+found #312's stack. v2 (rewritten around the stack) — round 2 FAIL: three
+pushbacks rejected with evidence, six new majors on the amendments' precision.
+v3 folded round 2 in — round 3 FAIL, narrowed to 4 majors + 4 wire details on
+the folds themselves (and confirmed §4.5's lock design and §4.4's caption
+semantics). v4 folded round 3 — round 4 (delta audit) FAIL with 1 major + 2
+minors, all contract precision. v5 folds round 4. Disposition logs:
+§10/§11/§12/§13.
+
+## 1. Ground truth
+
+- **Backend stack (PR #312, live-dark):** `routes/scoringConfigs.js`
+  (`/api/admin/scoring-configs`: list · resolve · get · draft · AI propose ·
+  simulate · approve; router unmounted until `SCORING_CONFIG_ADMIN_ENABLED`) ·
+  `services/scoringConfigService.js` (`createDraftConfig` stores the RAW doc,
+  normalize-at-read; `approveScoringConfig` supersedes-at-scope + whole-map
+  cache bust; `simulateConfig` cap 500, deciles, big-moves >20, became-null) ·
+  `utils/scoringConfigValidation.js` (finite numbers, 0.4 dominance cap,
+  ageCurve upTo 0..120 ascending + open tail) · 4 test suites.
+- **Resolution picks ONE row** (campaign → product → global, highest approved
+  at first matching tier); `normalizeConfig` fills unmentioned knobs from CODE
+  defaults, never from the losing tier.
+- **Approving an older draft = rollback** (supersede + max-approved agree) —
+  sequentially. Concurrently it does NOT converge: the status check runs
+  outside the txn, the approve UPDATE has no `status='draft'` predicate, and
+  two approvers can commit two approved rows (resolution still picks max, but
+  status-lineage corrupts and a racing rollback can silently not take) → §4.5.
+- **Sweep budget:** up to ~400 stale consumer+lead rows/night (80% of 500)
+  inside a 5-minute deadline, **consumers before leads** — which is why the
+  person-pass stamp overwrite (§4.4) matters.
+- `scoreOneConsumer` still stamps person-grain `scoredConfigVersion` /
+  `scoringAlgorithmVersion` / `scoreComputedAt` on `consumer_profiles` (its
+  staleness bookkeeping reads them back); the breakdown the profile card shows
+  is the winning LEAD's. Under campaign sheets those diverge → §4.4.
+- `computeLeadInputHash` includes `configVersion`: ANY new approved edition —
+  even byte-identical content — makes every inheriting lead stale and triggers
+  a full regrade → §4.6 idempotent-approve rule.
+- The brief (`campaignBrief.js` twins) carries product / `audience.ageBands`
+  (MULTI-select) / `audience.language`; `briefProductKey` already drives the
+  product tier. Two live create surfaces (`VITE_CAMPAIGN_WORKSPACE_ENABLED`):
+  workspace `CampaignDetailsTab` + classic `AdminCampaignForm`; BOTH navigate
+  away on create (classic → list, workspace → Design tab), so any post-create
+  scoring call must complete (or fail visibly) BEFORE navigation → §3.3.
+- `DEFAULT_SCORING_CONFIG` is backend-only; the UI's "house default" ghosts
+  come from the server (§4.2's strict resolve returns them), never a twin.
+
+## 2. What v3 builds
+
+1. **`ScoringSheetEditor`** (shared component) — §3.1.
+2. **"Lead scoring" card** on `AdminV2CampaignDetail` — §3.2.
+3. **Creation-time block** on both create surfaces — §3.3.
+4. **Service amendments** on the existing files — §4. One new read endpoint
+   (regrade progress), zero new services, zero migrations (Discard was cut to
+   keep that true — §4.6).
+5. **Rollout:** flip `SCORING_CONFIG_ADMIN_ENABLED` — §8.
+
+## 3. Product shape
+
+### 3.1 `ScoringSheetEditor` (shared)
+
+- **Weights, grouped Meet / Buy** (labels shared with the lead card via one
+  module): engagement /15 · contactability /10 · market fit /15 · message
+  response /15 · screening call /20 · life events /25 · family gap /20 ·
+  capacity /15 · age /10 · coverage headroom /−10. Steppers; signs fixed
+  per component and now ENFORCED by the validator (§4.7), not just the UI.
+  House default ghosted beside every knob from the server DTO; per-knob reset
+  pins the house VALUE explicitly.
+- **Age dial:** brief-band presets + advanced segment rows. **Multi-band
+  rule (deterministic, and slope-legal by construction):** each age's value
+  comes from its band-distance to the nearest SELECTED brief band — distance
+  0 → 1.0, 1 → 0.8, 2 → 0.55, 3+ → 0.3 — merged into the minimal ascending
+  `upTo` list ending in the open tail. The ladder's boundary jumps (≤0.25)
+  sit inside the validator's 0.5 adjacent-segment slope cap, which a naive
+  "selected = 1.0, everything else = house shoulder" rule violates (0.25 →
+  1.0 at age 18 would 422). Non-selected ages are therefore deliberately
+  ramped, not held at house values.
+- **Target segments:** language/ethnicity/weight rows; language vocab from
+  the campaignBrief twin; ethnicity constants EXPORTED from the backend
+  taxonomy (currently private) and pinned by a parity test. `language:'any'`
+  maps to no segment row.
+- **Prefill semantics (seed-once):** the editor prefills from the brief ONLY
+  when the campaign has no campaign-tier edition (draft or approved) and the
+  editor opens empty. Later brief edits never auto-touch scoring.
+
+### 3.2 After creation — "Lead scoring" card on `AdminV2CampaignDetail`
+
+- **Read state:** governing sheet — tier chip (campaign edition #N / product /
+  house default v0), activated when + by whom, dial summary, and **regrade
+  progress** ("X of Y leads on edition #N") from the new progress endpoint
+  (§4.8) whenever current ≠ 100%.
+- **Customise →** editor drawer seeded from strict resolve (§4.2). **Save
+  draft** → `POST /scoring-configs` with `campaignId` + `composeOnResolved`
+  (§4.1). **Preview impact** → simulate with `compareTo:'resolved'` (§4.3),
+  became-null count rendered as a blocking-style warning. **Approve & apply**
+  → approve with REQUIRED `expectedLiveVersion` (§4.5); the confirm restates
+  scope + big-mover count, and names rollback when approving an edition older
+  than the live one.
+- **History disclosure:** campaign-scoped list (server-side filter — §4.6),
+  newest 50 with "showing latest 50": drafts dated by `createdAt`, approved
+  rows by `activatedAt`, actor NAMES via a safe DTO. Row actions: view
+  (read-only editor via `GET /:version`); DRAFT rows → "Make live" (§4.5);
+  superseded/older editions → **"Restore as new draft"** (copies that
+  edition's `configJson` into a fresh draft) — approve is draft-only by
+  §4.5's status predicate, so a superseded row can never be re-approved
+  directly (round-3 B2). **Restore provenance is UI-transient by choice**
+  (round-4 B1): a restored draft is a NEW highest version, so the approve
+  confirm's "this rolls back past edition #N" wording applies only to
+  genuinely-older drafts (`candidateVersion < liveVersion`); a restored
+  draft instead carries "copied from edition #N" in the drawer at restore
+  time. Persisting provenance would need a migration or a configJson key the
+  validator rejects — declined, stated. **No Discard in v1** — drafts stay
+  visible and inert (§4.6); superseded markers explain themselves.
+- **Flag-off state:** any scoring call 404s (router unmounted) → the card
+  renders neutral copy: "Scoring controls unavailable on this backend" —
+  deliberately NOT claiming the flag is off (a 404 can also mean an old
+  deploy; B10).
+
+### 3.3 During creation (both surfaces)
+
+- Scoring block under the brief: "Leads will score with: *product sheet /
+  house default*" via strict `GET /resolve?productKey=` (no campaign id
+  needed). "Tailor scoring →" expands the shared editor prefilled per §3.1.
+- **On create, ordering is explicit:** campaign commits → the surface AWAITS
+  the scoring draft call (bounded timeout) BEFORE navigating; on failure it
+  shows "campaign created — scoring sheet not saved; set it up on the
+  campaign page" and navigates anyway. No sessionStorage/outbox machinery:
+  the trade (rare manual redo, zero new infra) is accepted and stated.
+  "Apply immediately" chains the approve call under the same await.
+- A retried draft producing a duplicate is inert and visible; a duplicate
+  APPROVE is made harmless by §4.6's content-equal no-op (it can no longer
+  trigger a spurious full regrade).
+- Creation is never blocked by scoring failures; flag-off shows the §3.2
+  neutral copy.
+
+## 4. Service amendments (existing files unless stated)
+
+### 4.1 Compose campaign overrides onto the winning raw doc (M3+B7)
+`createDraftConfig({ composeOnResolved: true })`: server deep-merges the
+editor's patch onto the **currently-winning tier's RAW `configJson`** (base =
+`{}` when resolution returns version 0). Merge is recursive for PLAIN OBJECTS
+ONLY; arrays (`ageCurve`, `targetSegments`, `groups.*`) replace wholesale.
+The editor always writes the full exposed set (all ten weights + ageCurve +
+targetSegments), so exposed knobs never float; UNEXPOSED knobs a product
+sheet carries explicitly (decay…) survive the merge; unexposed knobs nobody
+ever wrote continue to float to code defaults — stated, not hidden: a
+campaign edition pins what the admin SAW, which is the exposed set plus the
+winner's explicit extras.
+
+### 4.2 Strict resolve for the editor read path (M4+B8)
+New `resolveScoringConfigStrict({campaignId|productKey})`: **direct DB read,
+no cache read, no cache write, no fail-open** — a read failure is a 5xx. The
+scorer's fail-open `getActiveScoringConfig` is untouched. Route:
+`GET /resolve?strict=1`, which also gains the missing UUID validation on
+`campaignId`, and the strict response carries activation metadata (version,
+scope, activatedAt, actor name) + `houseDefault` (normalized
+`DEFAULT_SCORING_CONFIG`) as the ghost/reset source (B12).
+
+### 4.3 Simulate isolates config impact — with a costed budget (M5+M6+B9)
+`simulateConfig` gains `compareTo:'resolved'` (v1 scope: CAMPAIGN drafts
+only — product-scope populations include campaign-overridden leads, B9, so
+the mode refuses product/global scope until the population query excludes
+them): per sampled lead, load inputs ONCE, run `scoreLead` twice at one fixed
+`now` (resolved vs candidate), report the config-only delta; stored score
+returns separately labelled "includes drift since last rescore".
+**Cost, stated:** the per-lead loads are ~9 queries (telemetry + messages +
+canMarketTo chain + observations); v1 runs `sampleMax=100`, concurrency 4,
+logs duration, and the response carries `examined`/`truncated` — measured
+p95 > 5s triggers the named fast-follow (batch loaders for prospects,
+messages, consent, observations, stored scores). Not described as solved;
+described as bounded and measured.
+
+### 4.4 The person card's stamp — read it from the source lead (M8, reworked)
+Copying stamps in `projectPersonScore` is NOT enough: `scoreOneConsumer`
+re-stamps the same columns every consumer pass (its staleness bookkeeping
+reads them back), and the sweep runs consumers first — the copy would revert
+nightly. The fix is AT READ, in **one SQL statement** (round-3 M1): the
+profile row and the source lead's `scoredConfigVersion` /
+`scoringAlgorithmVersion` / `scoreComputedAt` come back from a single
+`consumer_profiles LEFT JOIN prospects ON id = "scoreSourceProspectId"` read
+— one MVCC snapshot, so a rescore committing mid-request can never pair an
+old projected breakdown with a newer source stamp (the two are written
+atomically on the write side). The card prefers the source stamps ONLY when
+the join resolves. **When a projected breakdown exists but the source lead is
+gone** (prospect delete nulls the pointer and deliberately keeps the stale
+projection — migration 101), the card shows NO stamp caption at all: "score
+source signup unavailable" — neutral wording, because a null pointer is NOT
+proof of deletion: migration 101 deliberately left pre-existing projections'
+pointers null, and the two states are observationally identical (round-5 B1).
+Never the person-pass stamps, which would caption the copied breakdown with
+an unrelated config/time (round-4 M1; the same lie this section exists to
+fix). A test pins the branch: breakdown retained + null source → neither
+source nor person-pass stamps. Person-pass stamps caption nothing but
+person-pass state. Older-than-person-pass source stamps are CORRECT, not
+stale — they caption the copied breakdown, not current resolution (round-3
+confirmed). Zero migrations, person-pass bookkeeping untouched. (`best IS
+NULL`: projection clears source + breakdown together, so there is nothing to
+caption.)
+
+### 4.5 Approve becomes race-safe (M2, accepted in full)
+`approveScoringConfig`: take a transaction-scoped **advisory lock keyed by
+scope** — `SELECT pg_advisory_xact_lock(hashtext(:key))` with key
+`scoring-config:campaign:<uuid>` / `scoring-config:product:<key>` /
+`scoring-config:global`, the same composition the repo already uses in draw
+boost provisioning; INSIDE the txn re-read the resolved winner for the
+candidate's scope (not merely same-tier approved — a campaign may inherit
+product/global) and compare against `expectedLiveVersion` (REQUIRED at the
+route, body `{expectedLiveVersion}`, validated as an **integer ≥ 0** — 0 is
+the legitimate "house default was live" baseline); supersede + approve with
+`WHERE status='draft' … RETURNING` so a non-draft can never be promoted. 409
+message stays a sentence: "the live sheet changed while you were editing —
+re-open preview".
+
+### 4.6 Lifecycle + read-API completions (M10/M12/M13)
+- **Idempotent approve:** when the candidate's `configJson` equals the live
+  row's at the same scope — compared IN SQL as `jsonb = jsonb`, which is
+  semantic equality (key order and numeric form normalized), never string
+  comparison — approve returns `{ noOp: true, live, candidateVersion }` and
+  **leaves the candidate as a draft**: no status change, no cache bust (no
+  write occurred), no new live version → no spurious full regrade. Round-3
+  M2 killed the v3 variant that superseded the draft (drafts carry
+  `activatedAt` from insert, so a superseded draft is indistinguishable from
+  a formerly-live edition). The stale duplicate stays visible in history as
+  what it is: a draft. **Route + UI contract (round-4 B2):** the approve
+  route returns 200 with the discriminated `{noOp:true, live,
+  candidateVersion}` body (the normal path keeps returning the approved
+  row); the UI toasts "already live — nothing changed, no regrade
+  triggered"; tests pin that a no-op busts no cache, changes no
+  `activatedAt`, and leaves the candidate a draft.
+- **Discard is CUT from v1** (three statuses only; drafts get `activatedAt`
+  at insert, so superseded-as-discard would corrupt history semantics).
+  Drafts stay visible and inert. A `discarded` status + `discardedAt` is a
+  Phase-2 migration if draft clutter ever hurts.
+- **`listScoringConfigs`** gains mutually-exclusive scope filters
+  (`campaignId` | `productKey` | `global:true`) applied BEFORE order/limit,
+  actor-name DTO (id → name join, no email/phone), and `createdAt` in both
+  list and `GET /:version`.
+- `createDraftConfig` verifies a given `campaignId` exists → 422 (no-FK
+  table otherwise accepts any UUID).
+
+### 4.7 Validator strengthening (M11 — extend, never fork)
+`validateScoringConfig` gains: per-component SIGN map (coverage_headroom ≤ 0,
+everything else ≥ 0); `targetSegments` exact key allowlist
+({language?, ethnicity?, weight}), at least one match axis per row, enum
+vocab from exported taxonomy constants, duplicate-axis rejection, ≤ 8 rows;
+exact `decay` key allowlist (the two known half-lives); serialized-size cap
+`MAX_SCORING_CONFIG_BYTES = 64 * 1024`, measured as
+`Buffer.byteLength(JSON.stringify(composedConfig), 'utf8')` AFTER §4.1
+composition and BEFORE semantic validation/storage (round-3 B4). Existing
+suites extend; no second validator anywhere.
+
+### 4.8 Regrade progress endpoint (M14 + round-3 M4/B3)
+`GET /api/admin/scoring-configs/progress?campaignId=` — registered BEFORE
+`GET /:version` or Express reads "progress" as a version (round-3 B3). One
+snapshot query: `total` = non-erased leads of the campaign (matches the
+sweep's own exclusion), and `current` is the exact COMPLEMENT of
+`findStaleLeadIds`' predicate, not a version match alone:
+
+```sql
+"scoreComputedAt" IS NOT NULL
+AND "scoreDirtyAt" IS NULL
+AND "scoredConfigVersion" = resolvedVersion
+AND "scoringAlgorithmVersion" = :leadAlgorithmVersion
+```
+
+(never-scored and dirty-marked rows are stale even on the right edition;
+stamped null SCORES still count — scored-and-null is a result, never
+`score IS NOT NULL`). Completion = `total === 0 || current === total`, so an
+empty campaign never polls forever. Card polls only while visible and
+incomplete. Index `(campaignId, scoredConfigVersion,
+scoringAlgorithmVersion)` noted as a follow-up if polling shows up in pg
+stats — not shipped speculatively.
+
+## 5. Validation & composition order
+
+Editor patch → §4.1 composition → §4.7 validator (sees the full stored
+document) → simulate gate (semantics: dominance, big moves, became-null) →
+approve (§4.5). Client-side bounds are UX mirrors only; the validator is the
+single authority.
+
+## 6. Invariants checklist
+
+1. `version` = one global sequence; stamps unambiguous.
+2. Append-only; nothing deleted; v1 has NO discard.
+3. Only approved resolves; drafts inert.
+4. RAW doc stored; §4.1 composition stores what the admin saw (exposed set +
+   winner's explicit extras); unwritten unexposed knobs float by design.
+5. Rollback = approving an older edition; UI names it; §4.5 makes it
+   race-safe.
+6. Content-equal approve is a no-op (never a spurious regrade).
+7. Whole-map cache bust on every write (unchanged rule).
+8. Duplication does NOT clone a custom sheet; duplicate flow notes it
+   (Phase 2 line).
+9. Both create surfaces or neither; scoring calls awaited-before-navigate,
+   never blocking creation on failure.
+10. Anonymous campaign endpoints never carry configs.
+11. Test DBs replay no migrations — suites mint their own rows.
+12. `{}` brief prefills nothing; prefill is seed-once (§3.1).
+13. Flag-off = neutral "unavailable" copy, never "the flag is off".
+
+## 7. Tests
+
+- **Backend (extend the four #312 suites + leadProfileService):**
+  composition (objects merge, arrays replace, version-0 base, winner's
+  explicit extras survive); strict resolve (no cache read/write, 5xx on DB
+  failure, UUID 400); simulate compareTo (config-only delta at fixed now,
+  loads once, campaign-scope-only refusal, zero writes); approve (advisory
+  lock serialization test, expectedLiveVersion 409, WHERE status='draft'
+  blocks non-drafts, content-equal no-op, resolved-winner comparison across
+  tiers); list scope filters + actor DTO + createdAt; campaign-existence 422;
+  progress counts (null-score stamped leads count as current; erased
+  excluded); profile-card stamp sourced from the source lead (M8).
+- **UI:** card states (unavailable / default / product / custom /
+  mid-regrade); editor prefill rules incl. multi-band curve + seed-once;
+  preview incl. became-null warning + truncated label; approve confirm incl.
+  rollback wording; history (createdAt vs activatedAt, no discard); create
+  flow on BOTH surfaces: await-then-navigate, failure toast + navigate,
+  flag-off neutral copy, creation never blocked.
+- **Wire fences:** strict-resolve, list, and progress payload shapes pinned.
+
+## 8. Rollout
+
+1. Ship code, flag off — router unmounted, UI shows neutral copy, zero
+   behavior change.
+2. Flip `SCORING_CONFIG_ADMIN_ENABLED=true` (Render env).
+3. First real use: author the iPhone-draw campaign's sheet, preview, approve;
+   watch regrade progress climb overnight.
+4. Rollback = flag off (authoring disappears; approved sheets keep scoring —
+   the flag gates authoring, not resolution).
+
+## 9. Phases
+
+| Phase | Ships |
+|---|---|
+| **1** | Editor + campaign card + history + §4.1–4.8 + tests |
+| **1.5** | Rescore-now (bounded, explicit button; re-resolves version inside the fence; M7 race self-heals via version-mismatch staleness) |
+| **2** | Creation-time block (both surfaces) + duplicate-flow note + optional `discarded` status migration |
+| out | Product/global sheet screens · AI-propose UI (endpoint exists) · decay knobs · batch preview loaders unless §4.3's budget trips · agent-facing anything |
+
+## 10. Codex round-1 log (gpt-5.6-sol xhigh — FAIL)
+
+M1 stack exists **CONFIRMED** (reframed) · M2 partial → superseded by round-2
+M2 (accepted in full, §4.5) · M3 **CONFIRMED** §4.1 · M4 **CONFIRMED** §4.2 ·
+M5 **CONFIRMED** §4.3 · M6 partial → round-2 rejection accepted (§4.3 costed)
+· M7 partial (self-healing; Phase 1.5) · M8 **CONFIRMED** → reworked §4.4 ·
+M9 resolved via existing /resolve + §3.1 prefill rules · M10 → round-2
+partial acceptance (§4.6 no-op approve + await-before-navigate) · M11
+**CONFIRMED** §4.7 · B1 corrected · B2 carried · B3 → §4.6 · B4 §3.1 · B5
+§4.6/§3.2 · B6 invariant 8.
+
+## 11. Codex round-2 log (gpt-5.6-sol xhigh — FAIL)
+
+| # | Verdict | Fold |
+|---|---|---|
+| M2 concurrent approve doesn't converge | **CONFIRMED** (unconditioned UPDATE, check outside txn, two-approved end-state, racing rollback can silently not take) | §4.5 advisory lock + required expectedLiveVersion + status-predicated UPDATE + resolved-winner comparison |
+| M6 pool-4/200 not adequately costed; index claim too strong | **CONFIRMED** | §4.3: cap 100, measured budget, named fast-follow; index claim withdrawn (order-by-id vs (campaignId,createdAt) noted) |
+| M8 projection copy reverted by consumer pass | **CONFIRMED** | §4.4 reworked to read-time sourcing via scoreSourceProspectId (zero-migration; neither Codex option needed) |
+| M10 identical double-approve → full regrade; retry state unmounts | **CONFIRMED** | §4.6 content-equal no-op; §3.3 await-before-navigate; outbox still declined |
+| M11 validator not binding for signs/segments/decay | **CONFIRMED** | §4.7 |
+| M12 discard corrupts lifecycle + races | **CONFIRMED** | Discard CUT from v1 (§4.6); Phase-2 migration option |
+| M13 history unimplementable from existing reads | **CONFIRMED** | §4.6 list filters + actor DTO + createdAt |
+| M14 progress has no contract | **CONFIRMED** | §4.8 endpoint + counting rules |
+| B7 merge precision | **CONFIRMED** | §4.1 (arrays wholesale; version-0 base; float caveat stated) |
+| B8 strict must bypass cache | **CONFIRMED** | §4.2 direct-DB |
+| B9 product-scope population | **CONFIRMED** | §4.3 campaign-scope-only in v1 |
+| B10 404 ≠ flag-off | **CONFIRMED** | §3.2 neutral copy |
+| B11 multi-band prefill | **CONFIRMED** | §3.1 deterministic rule + seed-once |
+| B12 ghost source | **CONFIRMED** | §4.2 houseDefault DTO |
+
+## 12. Codex round-3 log (gpt-5.6-sol xhigh — FAIL, narrowed to the folds)
+
+Confirmed sound by round 3: §4.5 lock design (key composition matches the
+existing draw-boost pattern) · §4.4's erased/best-IS-NULL paths and the
+older-stamp caption semantics ("exactly right") · §4.8's total predicate.
+
+| # | Finding | Fold |
+|---|---|---|
+| M1 | §4.4's two reads aren't one snapshot; a mid-request rescore pairs old breakdown with new stamp; deleted source lead unhandled | §4.4: single LEFT JOIN statement (one MVCC snapshot); source stamps only when the join resolves, else person-pass fallback |
+| M2 | v3's content-equal no-op superseded the draft — recreating the exact lifecycle corruption Discard was cut for | §4.6: candidate STAYS a draft; `{noOp:true, live, candidateVersion}`; no cache bust |
+| M3 | Naive presets violate the validator's 0.5 adjacent-slope cap (house 0.25 → selected 1.0 jumps 0.75) | §3.1: band-distance ladder 1.0/0.8/0.55/0.3 — slope-legal by construction |
+| M4 | "current" wasn't the complement of `findStaleLeadIds` (never-scored + dirty rows counted as done) | §4.8: exact complement predicate |
+| B1 | Equality predicate unspecified | §4.6: SQL `jsonb = jsonb` (semantic), never strings |
+| B2 | "Approve-as-rollback" impossible on superseded rows (approve is draft-only) | §3.2: drafts "Make live"; superseded/older "Restore as new draft" |
+| B3 | Route order (/progress vs /:version); expectedLiveVersion ≥ 0 incl. version-0 baseline; empty-campaign completion | §4.8 + §4.5 |
+| B4 | Size cap had no value/measurement rule | §4.7: 64 KiB, byteLength after composition |
+
+## 13. Codex round-4 log (gpt-5.6-sol xhigh, delta audit — FAIL: 1 major, 2 minors)
+
+| # | Finding | Fold |
+|---|---|---|
+| M1 | Deleted-source fallback captioned the copied breakdown with unrelated person-pass stamps (delete nulls the pointer, keeps the projection — migration 101) | §4.4: source-or-NOTHING — "scored under a signup since deleted", never person-pass stamps under a projected breakdown |
+| B1 | Restore-as-new-draft mints the newest version, so version-comparison rollback wording can't recognize it; no persisted provenance field exists | §3.2: rollback wording only for `candidateVersion < liveVersion`; restore provenance UI-transient by stated choice |
+| B2 | No-op approve had no route/UI contract | §4.6: 200 `{noOp:true, live, candidateVersion}`, toast copy, test pins (no bust, no activatedAt, stays draft) |
+
+## 14. Codex round-5 log (gpt-5.6-sol xhigh — **PASS-WITH-AMENDMENTS**, applied)
+
+Restore-provenance and no-op folds "internally consistent and implementable
+as written". One amendment, folded into §4.4: [B1] a null source pointer is
+observationally identical for a DELETED lead and a pre-migration-101 legacy
+projection (pointers were deliberately not backfilled) — fallback copy is
+now the neutral "score source signup unavailable", with a test pinning that
+the branch shows neither source nor person-pass stamps.
+
+**Plan status: PASSED (5 rounds: 17 → 14 → 8 → 3 → 1 findings). Phase 1
+implementable as written.**

--- a/src/api/adminV2.js
+++ b/src/api/adminV2.js
@@ -285,3 +285,54 @@ export async function fetchEmailBroadcastRecipients(id, { status = 'all', limit 
   const resp = await apiClient.get(`/email-broadcasts/${id}/recipients?${qs.toString()}`);
   return resp?.data ?? { total: 0, recipients: [] };
 }
+
+// ── campaign scoring sheets (campaign-scoring-editor §3-§4) ─────────────────
+// All ride /api/admin/scoring-configs, which is UNMOUNTED until the backend
+// flips SCORING_CONFIG_ADMIN_ENABLED — a 404 here therefore means "scoring
+// controls unavailable on this backend" (flag off OR an old deploy; the two
+// are indistinguishable and the UI must not claim to know which — B10).
+
+/** Strict resolve: the editor's read path. Never cached, never fail-open. */
+export async function fetchScoringSheet(campaignId) {
+  const resp = await apiClient.get(`/admin/scoring-configs/resolve?campaignId=${encodeURIComponent(campaignId)}&strict=1`);
+  return resp?.data ?? null;
+}
+
+export async function fetchScoringHistory(campaignId, { limit = 50 } = {}) {
+  const resp = await apiClient.get(`/admin/scoring-configs/?campaignId=${encodeURIComponent(campaignId)}&limit=${limit}`);
+  return resp?.data ?? [];
+}
+
+export async function fetchScoringEdition(version) {
+  const resp = await apiClient.get(`/admin/scoring-configs/${version}`);
+  return resp?.data ?? null;
+}
+
+export async function fetchScoringProgress(campaignId) {
+  const resp = await apiClient.get(`/admin/scoring-configs/progress?campaignId=${encodeURIComponent(campaignId)}`);
+  return resp?.data ?? null;
+}
+
+/** The editor's save door: the patch composes server-side onto the winning
+ *  RAW doc (§4.1) — the client never merges tiers itself. */
+export async function createScoringDraft(campaignId, patch) {
+  const resp = await apiClient.post('/admin/scoring-configs/', {
+    campaignId, config: patch, composeOnResolved: true,
+  });
+  return resp?.data ?? null;
+}
+
+export async function simulateScoringDraft(version, { sampleMax = 100 } = {}) {
+  const resp = await apiClient.post(`/admin/scoring-configs/${version}/simulate`, {
+    compareTo: 'resolved', sampleMax,
+  });
+  return resp?.data ?? null;
+}
+
+/** `expectedLiveVersion` is the §4.5 concurrency guard: the version the
+ *  editor SAW as live. A 409 means someone else moved the sheet meanwhile.
+ *  A 200 may still be `{noOp:true}` — content already live, no regrade. */
+export async function approveScoringDraft(version, expectedLiveVersion) {
+  const resp = await apiClient.post(`/admin/scoring-configs/${version}/approve`, { expectedLiveVersion });
+  return resp?.data ?? null;
+}

--- a/src/components/adminv2/CampaignScoringCard.jsx
+++ b/src/components/adminv2/CampaignScoringCard.jsx
@@ -1,0 +1,318 @@
+/**
+ * "Lead scoring" card on the campaign page (campaign-scoring-editor §3.2).
+ *
+ * Read state: which sheet governs this campaign right now (tier chip +
+ * activation meta) and, mid-regrade, how far the nightly sweeps have rolled
+ * the new edition out. Customise opens the ScoringSheetEditor inline; Save
+ * mints a DRAFT (composed server-side onto the winning raw doc), Preview
+ * re-scores a sample under draft-vs-current at one fixed now, and Approve —
+ * the only door to live — carries the §4.5 concurrency guard.
+ *
+ * Flag-off: the backend router is unmounted until SCORING_CONFIG_ADMIN_ENABLED
+ * flips, so every call 404s. The card then says "unavailable on this backend"
+ * — deliberately NOT "the flag is off": an old deploy 404s identically (B10).
+ */
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { useScoringSheet, useScoringHistory, useScoringProgress } from '@/hooks/queries/useAdminV2';
+import { createScoringDraft, simulateScoringDraft, approveScoringDraft, fetchScoringEdition } from '@/api/adminV2';
+import { Card, Chip, Skeleton, ErrorState } from '@/components/adminv2/primitives';
+import { fmtDateTime } from '@/lib/adminV2/format';
+import ScoringSheetEditor from '@/components/adminv2/ScoringSheetEditor';
+import { EXPOSED_COMPONENTS, weightOf } from '@/lib/adminV2/scoringLabels';
+
+const TIER_LABEL = {
+  campaign: 'campaign sheet',
+  product: 'product sheet',
+  global: 'house sheet',
+  default: 'house default',
+};
+
+/** The full exposed set as a patch — the editor always writes every exposed
+ *  knob (§4.1: exposed knobs never float), UI-only keys stripped. */
+function patchFromDoc(doc, houseDefault) {
+  const components = {};
+  const leadComponents = {};
+  for (const comp of EXPOSED_COMPONENTS) {
+    const value = weightOf(doc, comp) ?? weightOf(houseDefault, comp) ?? 0;
+    (comp.leadGrain ? leadComponents : components)[comp.name] = { maxPoints: value };
+  }
+  const patch = { components, leadComponents };
+  if (Array.isArray(doc?.ageCurve) && doc.ageCurve.length) patch.ageCurve = doc.ageCurve;
+  if (Array.isArray(doc?.targetSegments)) patch.targetSegments = doc.targetSegments;
+  return patch;
+}
+
+/** Seed the editor from the strict resolve: effective values only. */
+function docFromSheet(sheet) {
+  const cfg = sheet?.config || {};
+  return {
+    components: { ...(cfg.components || {}) },
+    leadComponents: { ...(cfg.leadComponents || {}) },
+    ageCurve: Array.isArray(cfg.ageCurve) ? cfg.ageCurve.map((s) => ({ ...s })) : [],
+    targetSegments: Array.isArray(cfg.targetSegments) ? cfg.targetSegments.map((s) => ({ ...s })) : [],
+    _ageBands: [],
+  };
+}
+
+function PreviewPanel({ sim }) {
+  if (!sim) return null;
+  const d = sim.diff || {};
+  return (
+    <div style={{ marginTop: 10, padding: '10px 12px', borderRadius: 10, background: 'var(--surface-2)', border: '1px solid var(--line)' }}>
+      <div className="av2-microcaps">Preview — this change only</div>
+      <div style={{ fontSize: 12.5, color: 'var(--ink-2)', marginTop: 4, display: 'grid', gap: 3 }}>
+        <span>
+          Average score {d.meanDelta > 0 ? 'rises' : d.meanDelta < 0 ? 'falls' : 'holds'}
+          {d.meanDelta ? ` by ${Math.abs(d.meanDelta)} points` : ''} across {sim.population?.examined ?? 0} sampled lead{(sim.population?.examined ?? 0) === 1 ? '' : 's'}
+          {sim.population?.truncated ? ' (a sample — the campaign holds more)' : ''}.
+        </span>
+        <span>{d.movedOver20 ?? 0} lead{(d.movedOver20 ?? 0) === 1 ? '' : 's'} would move more than 20 points.</span>
+        {(d.becameNull ?? 0) > 0 && (
+          <span style={{ color: 'var(--bad)', fontWeight: 700 }}>
+            ⚠ {d.becameNull} lead{d.becameNull === 1 ? '' : 's'} would lose their Buy score entirely under this sheet.
+          </span>
+        )}
+        {sim.stored && (
+          <span style={{ color: 'var(--ink-3)' }}>
+            Stored scores today: {sim.stored.scored} scored, mean {sim.stored.mean ?? '—'} — includes drift since each lead's last rescore.
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function CampaignScoringCard({ campaignId }) {
+  const qc = useQueryClient();
+  const sheet = useScoringSheet(campaignId);
+  const [editing, setEditing] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [doc, setDoc] = useState(null);
+  // The version the admin SAW as live when the editor opened — the §4.5 guard.
+  const [baseline, setBaseline] = useState(null);
+  const [restoredFrom, setRestoredFrom] = useState(null);
+  const [draft, setDraft] = useState(null);
+  const [sim, setSim] = useState(null);
+  const [confirming, setConfirming] = useState(false);
+  const progress = useScoringProgress(campaignId, { enabled: !sheet.isError });
+  const history = useScoringHistory(campaignId, historyOpen);
+
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['adminV2', 'scoringSheet', campaignId] });
+    qc.invalidateQueries({ queryKey: ['adminV2', 'scoringHistory', campaignId] });
+    qc.invalidateQueries({ queryKey: ['adminV2', 'scoringProgress', campaignId] });
+  };
+
+  const saveDraft = useMutation({
+    mutationFn: () => createScoringDraft(campaignId, patchFromDoc(doc, sheet.data?.houseDefault)),
+    onSuccess: async (row) => {
+      setDraft(row);
+      setSim(null);
+      toast.success(`Draft edition #${row.version} saved — preview it before it can go live`);
+      invalidate();
+      try {
+        setSim(await simulateScoringDraft(row.version));
+      } catch (e) {
+        toast.error(e?.message || 'Preview failed — you can retry it');
+      }
+    },
+    onError: (e) => toast.error(e?.message || 'Save failed'),
+  });
+
+  const approve = useMutation({
+    mutationFn: ({ version }) => approveScoringDraft(version, baseline ?? sheet.data?.version ?? 0),
+    onSuccess: (res) => {
+      if (res?.noOp) {
+        toast.info(`Already live — edition #${res.live?.version} has identical content. Nothing changed, no regrade triggered.`);
+      } else {
+        toast.success(`Edition #${res?.version} is live — leads regrade over the nightly runs`);
+      }
+      setEditing(false);
+      setDraft(null);
+      setSim(null);
+      setConfirming(false);
+      setRestoredFrom(null);
+      invalidate();
+    },
+    onError: (e) => {
+      if (e?.status === 409) toast.error(e?.message || 'The live sheet changed while you were editing — re-open preview.');
+      else toast.error(e?.message || 'Approve failed');
+    },
+  });
+
+  if (sheet.isLoading) return <Card span={12} title="Lead scoring"><div style={{ padding: 16 }}><Skeleton height={60} /></div></Card>;
+
+  // 404 = router unmounted (flag off) OR an old backend — indistinguishable,
+  // so the copy claims neither (round-2 B10).
+  if (sheet.isError && sheet.error?.status === 404) {
+    return (
+      <Card span={12} title="Lead scoring">
+        <div style={{ padding: '14px 16px', fontSize: 12.5, color: 'var(--ink-3)' }}>
+          Scoring controls are unavailable on this backend.
+        </div>
+      </Card>
+    );
+  }
+  if (sheet.isError) return <Card span={12} title="Lead scoring"><ErrorState error={sheet.error} onRetry={sheet.refetch} /></Card>;
+
+  const s = sheet.data;
+  const p = progress.data;
+  const openEditor = (seedDoc, from = null) => {
+    setDoc(seedDoc);
+    setBaseline(s.version);
+    setRestoredFrom(from);
+    setDraft(null);
+    setSim(null);
+    setConfirming(false);
+    setEditing(true);
+  };
+
+  return (
+    <Card
+      span={12}
+      title="Lead scoring"
+      meta={s.version > 0 ? `EDITION #${s.version}${s.activatedAt ? ` · LIVE SINCE ${fmtDateTime(s.activatedAt).toUpperCase()}` : ''}` : 'HOUSE DEFAULT'}
+      action={!editing ? (
+        <button type="button" className="av2-btn av2-btn--sm" onClick={() => openEditor(docFromSheet(s))}>
+          Customise
+        </button>
+      ) : undefined}
+    >
+      <div style={{ padding: '12px 16px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+          <Chip tone={s.scope === 'campaign' ? 'accent' : ''}>{TIER_LABEL[s.scope] || s.scope}</Chip>
+          {s.actorName && <span className="av2-caption">approved by {s.actorName}</span>}
+          <span style={{ fontSize: 12, color: 'var(--ink-3)' }}>
+            {s.scope === 'campaign'
+              ? 'This campaign scores by its own sheet.'
+              : s.scope === 'product'
+                ? 'Inherited from the product sheet — customising pins a sheet to this campaign only.'
+                : 'Scoring by the house rules — customising pins a sheet to this campaign only.'}
+          </span>
+        </div>
+
+        {/* Regrade progress — visible only while the sweep still owes leads. */}
+        {p && !p.complete && (
+          <div style={{ marginTop: 8, fontSize: 12, color: 'var(--ink-2)' }} data-testid="scoring-progress">
+            Regrading: <span className="av2-mono" style={{ fontWeight: 700 }}>{p.current} of {p.total}</span> leads
+            are on edition #{p.resolvedVersion} — the rest roll through the nightly runs.
+          </div>
+        )}
+
+        {editing && (
+          <div style={{ marginTop: 12, borderTop: '1px solid var(--line)', paddingTop: 10 }}>
+            {restoredFrom && (
+              <div style={{ fontSize: 12, color: 'var(--ink-2)', marginBottom: 6 }}>
+                Editing a copy of edition #{restoredFrom} — saving mints a NEW draft.
+              </div>
+            )}
+            <ScoringSheetEditor
+              doc={doc}
+              houseDefault={s.houseDefault}
+              onChange={setDoc}
+              disabled={saveDraft.isPending || approve.isPending}
+            />
+            <PreviewPanel sim={sim} />
+            <div style={{ display: 'flex', gap: 8, marginTop: 12, alignItems: 'center' }}>
+              {!draft ? (
+                <button type="button" className="av2-btn av2-btn--primary av2-btn--sm" disabled={saveDraft.isPending} onClick={() => saveDraft.mutate()}>
+                  {saveDraft.isPending ? 'Saving…' : 'Save draft & preview'}
+                </button>
+              ) : !confirming ? (
+                <button
+                  type="button"
+                  className="av2-btn av2-btn--primary av2-btn--sm"
+                  disabled={approve.isPending || !sim}
+                  title={!sim ? 'Preview must finish before this can go live' : undefined}
+                  onClick={() => setConfirming(true)}
+                >
+                  Approve & apply
+                </button>
+              ) : (
+                <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                  <span style={{ fontSize: 12.5, fontWeight: 700, color: 'var(--ink)' }}>
+                    Make edition #{draft.version} live?
+                    {draft.version < (s.version || 0) && (
+                      <span style={{ color: 'var(--warn)' }}> This rolls back past edition #{s.version}.</span>
+                    )}
+                    {(sim?.diff?.becameNull ?? 0) > 0 && (
+                      <span style={{ color: 'var(--bad)' }}> {sim.diff.becameNull} lead{sim.diff.becameNull === 1 ? '' : 's'} lose their Buy score.</span>
+                    )}
+                  </span>
+                  <button
+                    type="button" className="av2-btn av2-btn--primary av2-btn--sm" disabled={approve.isPending}
+                    onClick={() => approve.mutate({ version: draft.version })}
+                  >
+                    {approve.isPending ? 'Approving…' : 'Yes, make it live'}
+                  </button>
+                  <button type="button" className="av2-btn av2-btn--sm" onClick={() => setConfirming(false)}>Back</button>
+                </span>
+              )}
+              <button
+                type="button" className="av2-btn av2-btn--sm"
+                onClick={() => { setEditing(false); setDraft(null); setSim(null); setConfirming(false); setRestoredFrom(null); }}
+              >Close</button>
+              {draft && <span className="av2-caption">draft #{draft.version} — inert until approved</span>}
+            </div>
+          </div>
+        )}
+
+        {/* History: this campaign's editions only (server-side filter). */}
+        <details
+          style={{ marginTop: 12, borderTop: '1px solid var(--line)' }}
+          onToggle={(e) => setHistoryOpen(e.currentTarget.open)}
+        >
+          <summary style={{ padding: '8px 0 2px', cursor: 'pointer', fontSize: 11.5, fontWeight: 700, color: 'var(--ink-2)' }}>
+            Edition history
+          </summary>
+          {history.isLoading && <div style={{ padding: 8 }}><Skeleton height={30} /></div>}
+          {history.isSuccess && history.data.length === 0 && (
+            <div style={{ fontSize: 12, color: 'var(--ink-3)', padding: '6px 0' }}>No campaign editions yet — this campaign inherits.</div>
+          )}
+          {history.isSuccess && history.data.map((row) => (
+            <div key={row.version} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '5px 0', fontSize: 12.5 }}>
+              <span className="av2-mono" style={{ width: 40, flex: 'none', fontWeight: 700 }}>#{row.version}</span>
+              <Chip tone={row.status === 'approved' ? 'ok' : row.status === 'draft' ? '' : 'warn'}>{row.status}</Chip>
+              <span style={{ flex: 1, color: 'var(--ink-3)', fontFamily: 'var(--font-mono)', fontSize: 10.5 }}>
+                {/* Drafts date by creation; only approved rows ever activated. */}
+                {row.status === 'approved' && row.activatedAt ? `LIVE SINCE ${fmtDateTime(row.activatedAt).toUpperCase()}` : `DRAFTED ${fmtDateTime(row.createdAt).toUpperCase()}`}
+                {row.actorName ? ` · ${row.actorName.toUpperCase()}` : ''}
+              </span>
+              {row.status === 'draft' && !editing && (
+                <button
+                  type="button" className="av2-btn av2-btn--sm"
+                  onClick={async () => {
+                    try {
+                      const full = await fetchScoringEdition(row.version);
+                      openEditor(docFromSheet({ config: { ...s.config, ...full.configJson } }), null);
+                      setDraft(full);
+                      setSim(await simulateScoringDraft(row.version));
+                    } catch (e) {
+                      toast.error(e?.message || 'Could not load that draft');
+                    }
+                  }}
+                >Review & make live</button>
+              )}
+              {row.status !== 'draft' && !editing && (
+                <button
+                  type="button" className="av2-btn av2-btn--sm"
+                  title="Copies this edition's settings into a fresh draft"
+                  onClick={async () => {
+                    try {
+                      const full = await fetchScoringEdition(row.version);
+                      openEditor(docFromSheet({ config: { ...s.houseDefault, ...full.configJson } }), row.version);
+                    } catch (e) {
+                      toast.error(e?.message || 'Could not load that edition');
+                    }
+                  }}
+                >Restore as new draft</button>
+              )}
+            </div>
+          ))}
+        </details>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/adminv2/ScoringSheetEditor.jsx
+++ b/src/components/adminv2/ScoringSheetEditor.jsx
@@ -1,0 +1,216 @@
+/**
+ * ScoringSheetEditor — the curated controls over a campaign's scoring sheet
+ * (campaign-scoring-editor §3.1). Weights grouped the way the score cards
+ * group them, the age dial as brief-band presets over an advanced segment
+ * editor, and language/ethnicity target rows. NEVER raw JSON.
+ *
+ * The component edits an EFFECTIVE document (winner's raw values over the
+ * server's house defaults) and reports the full exposed set upward; the
+ * server composes that patch onto the winning raw doc (§4.1) and its
+ * validator stays the authority — bounds here are UX mirrors only.
+ */
+import { COMPONENT_LABELS, EXPOSED_COMPONENTS, MAX_WEIGHT, SEGMENT_LANGUAGES, SEGMENT_ETHNICITIES, AGE_BAND_ZONES, buildAgeCurveFromBands, weightOf } from '@/lib/adminV2/scoringLabels';
+
+const row = { display: 'flex', alignItems: 'center', gap: 10, padding: '4px 0' };
+const label = { width: 148, flex: 'none', fontSize: 12.5, color: 'var(--ink-2)' };
+const ghost = { fontFamily: 'var(--font-mono)', fontSize: 10.5, color: 'var(--ink-3)' };
+const numInput = {
+  width: 64, padding: '4px 8px', borderRadius: 8, border: '1px solid var(--line-strong)',
+  background: 'var(--surface)', color: 'var(--ink)', fontFamily: 'var(--font-mono)', fontSize: 12.5,
+};
+const selectStyle = { ...numInput, width: 150, fontFamily: 'var(--font-ui)' };
+
+function WeightRow({ comp, doc, houseDefault, onChange, disabled }) {
+  const house = weightOf(houseDefault, comp);
+  const value = weightOf(doc, comp);
+  const shown = value ?? house ?? 0;
+  const isDefault = value === undefined || value === house;
+  const min = comp.penalty ? -MAX_WEIGHT : 0;
+  const max = comp.penalty ? 0 : MAX_WEIGHT;
+  return (
+    <div style={row}>
+      <span style={label}>{COMPONENT_LABELS[comp.name]}</span>
+      <input
+        type="number"
+        aria-label={`${COMPONENT_LABELS[comp.name]} weight`}
+        style={numInput}
+        value={shown}
+        min={min}
+        max={max}
+        step={comp.penalty ? 1 : 0.5}
+        disabled={disabled}
+        onChange={(e) => {
+          const n = Number(e.target.value);
+          if (!Number.isFinite(n)) return;
+          // Sign is fixed per component — the input clamps to its own side of
+          // zero so a penalty can never be typed positive (§4.7 mirrors it
+          // bindingly server-side).
+          onChange(comp, Math.min(max, Math.max(min, n)));
+        }}
+      />
+      <span style={ghost}>
+        {comp.penalty ? 'penalty · ' : ''}house {house ?? '—'}
+      </span>
+      {!isDefault && (
+        <button
+          type="button"
+          className="av2-btn av2-btn--sm"
+          disabled={disabled}
+          title="Pin the house value explicitly"
+          onClick={() => onChange(comp, house)}
+        >reset</button>
+      )}
+    </div>
+  );
+}
+
+function AgeCurveEditor({ doc, onCurve, disabled }) {
+  const curve = Array.isArray(doc?.ageCurve) ? doc.ageCurve : [];
+  // Which preset bands the current curve corresponds to, if any — purely for
+  // highlighting; presets always REGENERATE the curve rather than toggling.
+  const setBands = (ids) => {
+    const built = buildAgeCurveFromBands(ids);
+    if (built) onCurve(built, ids);
+  };
+  return (
+    <div>
+      <div className="av2-microcaps" style={{ padding: '8px 0 4px' }}>Age dial</div>
+      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+        {AGE_BAND_ZONES.map((z) => {
+          const active = (doc?._ageBands || []).includes(z.id);
+          return (
+            <button
+              key={z.id}
+              type="button"
+              className="av2-btn av2-btn--sm"
+              disabled={disabled}
+              aria-pressed={active}
+              style={active ? { borderColor: 'var(--accent)', color: 'var(--accent-text)', fontWeight: 700 } : undefined}
+              onClick={() => {
+                const cur = doc?._ageBands || [];
+                setBands(active ? cur.filter((b) => b !== z.id) : [...cur, z.id]);
+              }}
+            >{z.id}</button>
+          );
+        })}
+        <span style={{ ...ghost, alignSelf: 'center' }}>
+          pick target bands — the curve ramps around them
+        </span>
+      </div>
+      <details style={{ marginTop: 6 }}>
+        <summary style={{ fontSize: 11.5, fontWeight: 700, color: 'var(--ink-2)', cursor: 'pointer' }}>
+          Advanced: the curve itself
+        </summary>
+        <div style={{ paddingTop: 4 }}>
+          {curve.map((seg, i) => (
+            <div key={i} style={row}>
+              <span style={{ ...label, width: 96 }}>
+                {i === curve.length - 1 ? 'and older' : `up to age`}
+              </span>
+              {i < curve.length - 1 ? (
+                <input
+                  type="number" style={numInput} value={seg.upTo ?? ''} min={0} max={120} disabled={disabled}
+                  aria-label={`segment ${i + 1} up to age`}
+                  onChange={(e) => {
+                    const next = curve.map((s, j) => (j === i ? { ...s, upTo: Number(e.target.value) } : s));
+                    onCurve(next, null);
+                  }}
+                />
+              ) : <span style={{ ...numInput, border: 'none', background: 'transparent' }}>∞</span>}
+              <input
+                type="number" style={numInput} value={seg.value} min={0} max={1} step={0.05} disabled={disabled}
+                aria-label={`segment ${i + 1} value`}
+                onChange={(e) => {
+                  const next = curve.map((s, j) => (j === i ? { ...s, value: Number(e.target.value) } : s));
+                  onCurve(next, null);
+                }}
+              />
+              <span style={ghost}>× of the age weight</span>
+            </div>
+          ))}
+        </div>
+      </details>
+    </div>
+  );
+}
+
+function TargetSegmentsEditor({ doc, onSegments, disabled }) {
+  const segments = Array.isArray(doc?.targetSegments) ? doc.targetSegments : [];
+  const patch = (i, key, value) => {
+    onSegments(segments.map((s, j) => {
+      if (j !== i) return s;
+      const next = { ...s };
+      if (value === '') delete next[key];
+      else next[key] = key === 'weight' ? Number(value) : value;
+      return next;
+    }));
+  };
+  return (
+    <div>
+      <div className="av2-microcaps" style={{ padding: '10px 0 4px' }}>Target market</div>
+      {segments.map((s, i) => (
+        <div key={i} style={row}>
+          <select style={selectStyle} value={s.language || ''} disabled={disabled} aria-label={`segment ${i + 1} language`} onChange={(e) => patch(i, 'language', e.target.value)}>
+            <option value="">any language</option>
+            {SEGMENT_LANGUAGES.map((l) => <option key={l.id} value={l.id}>{l.label}</option>)}
+          </select>
+          <select style={selectStyle} value={s.ethnicity || ''} disabled={disabled} aria-label={`segment ${i + 1} ethnicity`} onChange={(e) => patch(i, 'ethnicity', e.target.value)}>
+            <option value="">any ethnicity</option>
+            {SEGMENT_ETHNICITIES.map((x) => <option key={x.id} value={x.id}>{x.label}</option>)}
+          </select>
+          <input
+            type="number" style={numInput} min={0} max={1} step={0.1} value={s.weight ?? 1} disabled={disabled}
+            aria-label={`segment ${i + 1} weight`}
+            onChange={(e) => patch(i, 'weight', e.target.value)}
+          />
+          <button type="button" className="av2-btn av2-btn--sm" disabled={disabled} onClick={() => onSegments(segments.filter((_, j) => j !== i))}>remove</button>
+        </div>
+      ))}
+      {segments.length < 8 && (
+        <button
+          type="button" className="av2-btn av2-btn--sm" disabled={disabled}
+          onClick={() => onSegments([...segments, { language: 'en', weight: 1 }])}
+        >+ target segment</button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * @param {{doc:Object, houseDefault:Object, onChange:(doc:Object)=>void, disabled?:boolean}} props
+ * `doc` is the effective document being edited; `_ageBands` is a UI-only key
+ * (which preset chips light up) that the card strips before saving.
+ */
+export default function ScoringSheetEditor({ doc, houseDefault, onChange, disabled = false }) {
+  const setWeight = (comp, points) => {
+    const mapKey = comp.leadGrain ? 'leadComponents' : 'components';
+    onChange({
+      ...doc,
+      [mapKey]: { ...(doc?.[mapKey] || {}), [comp.name]: { maxPoints: points } },
+    });
+  };
+  const meet = EXPOSED_COMPONENTS.filter((c) => c.group === 'meet');
+  const buy = EXPOSED_COMPONENTS.filter((c) => c.group === 'buy');
+  return (
+    <div>
+      <div className="av2-microcaps" style={{ padding: '2px 0 4px' }}>Reachability (Meet)</div>
+      {meet.map((c) => (
+        <WeightRow key={c.name} comp={c} doc={doc} houseDefault={houseDefault} onChange={setWeight} disabled={disabled} />
+      ))}
+      <div className="av2-microcaps" style={{ padding: '10px 0 4px' }}>Potential (Buy)</div>
+      {buy.map((c) => (
+        <WeightRow key={c.name} comp={c} doc={doc} houseDefault={houseDefault} onChange={setWeight} disabled={disabled} />
+      ))}
+      <AgeCurveEditor
+        doc={doc}
+        disabled={disabled}
+        onCurve={(curve, bands) => onChange({ ...doc, ageCurve: curve, _ageBands: bands || doc?._ageBands || [] })}
+      />
+      <TargetSegmentsEditor
+        doc={doc}
+        disabled={disabled}
+        onSegments={(targetSegments) => onChange({ ...doc, targetSegments })}
+      />
+    </div>
+  );
+}

--- a/src/components/adminv2/__tests__/CampaignScoringCard.test.jsx
+++ b/src/components/adminv2/__tests__/CampaignScoringCard.test.jsx
@@ -1,0 +1,211 @@
+/**
+ * The Lead scoring card (campaign-scoring-editor §3.2): read states per tier,
+ * the flag-off neutral copy, regrade progress, the draft → preview → approve
+ * flow with its §4.5 baseline and no-op contract, and the history rows'
+ * date/action semantics.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import CampaignScoringCard from '../CampaignScoringCard';
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
+vi.mock('@/api/adminV2', () => ({
+  fetchScoringSheet: vi.fn(),
+  fetchScoringHistory: vi.fn(async () => []),
+  fetchScoringProgress: vi.fn(async () => ({ total: 0, current: 0, resolvedVersion: 0, complete: true })),
+  fetchScoringEdition: vi.fn(),
+  createScoringDraft: vi.fn(),
+  simulateScoringDraft: vi.fn(),
+  approveScoringDraft: vi.fn(),
+}));
+
+import { toast } from 'sonner';
+import {
+  fetchScoringSheet, fetchScoringHistory, fetchScoringProgress, fetchScoringEdition,
+  createScoringDraft, simulateScoringDraft, approveScoringDraft,
+} from '@/api/adminV2';
+
+const HOUSE = {
+  components: {
+    engagement: { maxPoints: 15 }, contactability: { maxPoints: 10 }, market_fit: { maxPoints: 15 },
+    life_events: { maxPoints: 25 }, family_gap: { maxPoints: 20 }, capacity: { maxPoints: 15 },
+    age: { maxPoints: 10 }, coverage_headroom: { maxPoints: -10 },
+  },
+  leadComponents: { response: { maxPoints: 15 }, screening: { maxPoints: 20 } },
+  ageCurve: [{ upTo: 24, value: 0.25 }, { upTo: 44, value: 1 }, { upTo: null, value: 0.3 }],
+  targetSegments: [{ language: 'zh', ethnicity: 'chinese', weight: 1 }],
+};
+
+const SHEET_DEFAULT = {
+  version: 0, scope: 'default', config: HOUSE, raw: {}, activatedAt: null, actorName: null, houseDefault: HOUSE,
+};
+const SHEET_CAMPAIGN = {
+  version: 7, scope: 'campaign', config: HOUSE, raw: { components: { age: { maxPoints: 8 } } },
+  activatedAt: '2026-07-30T04:00:00Z', actorName: 'Shawn Lee', houseDefault: HOUSE,
+};
+
+function setup() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <CampaignScoringCard campaignId="camp-1" />
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchScoringHistory.mockResolvedValue([]);
+  fetchScoringProgress.mockResolvedValue({ total: 0, current: 0, resolvedVersion: 0, complete: true });
+});
+
+describe('read states', () => {
+  it('a 404 backend renders the neutral unavailable copy — never "the flag is off"', async () => {
+    fetchScoringSheet.mockRejectedValue(Object.assign(new Error('Not found'), { status: 404 }));
+    setup();
+    expect(await screen.findByText(/Scoring controls are unavailable on this backend/)).toBeInTheDocument();
+    expect(screen.queryByText(/flag/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Customise' })).not.toBeInTheDocument();
+  });
+
+  it('house default reads as the fallback it is', async () => {
+    fetchScoringSheet.mockResolvedValue(SHEET_DEFAULT);
+    setup();
+    expect(await screen.findByText('house default')).toBeInTheDocument();
+    expect(screen.getByText('HOUSE DEFAULT')).toBeInTheDocument();
+    expect(screen.getByText(/customising pins a sheet to this campaign only/)).toBeInTheDocument();
+  });
+
+  it('a campaign edition names itself, its activation, and its approver', async () => {
+    fetchScoringSheet.mockResolvedValue(SHEET_CAMPAIGN);
+    setup();
+    expect(await screen.findByText('campaign sheet')).toBeInTheDocument();
+    expect(screen.getByText(/EDITION #7 · LIVE SINCE/)).toBeInTheDocument();
+    expect(screen.getByText(/approved by Shawn Lee/)).toBeInTheDocument();
+  });
+
+  it('shows regrade progress only while the sweep still owes leads', async () => {
+    fetchScoringSheet.mockResolvedValue(SHEET_CAMPAIGN);
+    fetchScoringProgress.mockResolvedValue({ total: 40, current: 12, resolvedVersion: 7, complete: false });
+    setup();
+    expect(await screen.findByTestId('scoring-progress')).toHaveTextContent('12 of 40');
+    expect(screen.getByTestId('scoring-progress')).toHaveTextContent('edition #7');
+  });
+});
+
+describe('draft → preview → approve', () => {
+  it('saves the FULL exposed set as the patch and auto-runs the preview', async () => {
+    fetchScoringSheet.mockResolvedValue(SHEET_DEFAULT);
+    createScoringDraft.mockResolvedValue({ version: 9, status: 'draft' });
+    simulateScoringDraft.mockResolvedValue({
+      comparedTo: 'resolved', resolvedVersion: 0,
+      population: { examined: 30, truncated: true },
+      diff: { meanDelta: 4.2, movedOver20: 3, becameNull: 2 },
+      stored: { scored: 28, mean: 21 },
+    });
+    setup();
+    fireEvent.click(await screen.findByRole('button', { name: 'Customise' }));
+
+    const engagement = screen.getByLabelText('engagement weight');
+    fireEvent.change(engagement, { target: { value: '20' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save draft & preview' }));
+
+    await waitFor(() => expect(createScoringDraft).toHaveBeenCalled());
+    const [cid, patch] = createScoringDraft.mock.calls[0];
+    expect(cid).toBe('camp-1');
+    // The full exposed set — exposed knobs never float (§4.1).
+    expect(Object.keys(patch.components)).toHaveLength(8);
+    expect(patch.components.engagement.maxPoints).toBe(20);
+    expect(patch.components.coverage_headroom.maxPoints).toBe(-10);
+    expect(patch.leadComponents).toEqual({ response: { maxPoints: 15 }, screening: { maxPoints: 20 } });
+    expect(Array.isArray(patch.ageCurve)).toBe(true);
+
+    // The preview states the sample, the movers, and the becameNull warning.
+    expect(await screen.findByText(/Average score rises by 4.2 points/)).toBeInTheDocument();
+    expect(screen.getByText(/a sample — the campaign holds more/)).toBeInTheDocument();
+    expect(screen.getByText(/3 leads would move more than 20 points/)).toBeInTheDocument();
+    expect(screen.getByText(/2 leads would lose their Buy score entirely/)).toBeInTheDocument();
+    expect(screen.getByText(/includes drift since each lead's last rescore/)).toBeInTheDocument();
+  });
+
+  it('approve carries the baseline the editor OPENED with, and lands the success toast', async () => {
+    fetchScoringSheet.mockResolvedValue(SHEET_CAMPAIGN);
+    createScoringDraft.mockResolvedValue({ version: 9, status: 'draft' });
+    simulateScoringDraft.mockResolvedValue({ population: { examined: 5 }, diff: { meanDelta: 0, movedOver20: 0, becameNull: 0 } });
+    approveScoringDraft.mockResolvedValue({ version: 9, status: 'approved' });
+    setup();
+    fireEvent.click(await screen.findByRole('button', { name: 'Customise' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save draft & preview' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Approve & apply' }));
+    // Inline confirm, then the commit.
+    expect(screen.getByText(/Make edition #9 live\?/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, make it live' }));
+    await waitFor(() => expect(approveScoringDraft).toHaveBeenCalledWith(9, 7));
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith(expect.stringMatching(/Edition #9 is live/)));
+  });
+
+  it('a no-op approve says nothing changed and no regrade was triggered', async () => {
+    fetchScoringSheet.mockResolvedValue(SHEET_CAMPAIGN);
+    createScoringDraft.mockResolvedValue({ version: 9, status: 'draft' });
+    simulateScoringDraft.mockResolvedValue({ population: { examined: 5 }, diff: { meanDelta: 0, movedOver20: 0, becameNull: 0 } });
+    approveScoringDraft.mockResolvedValue({ noOp: true, live: { version: 7 }, candidateVersion: 9 });
+    setup();
+    fireEvent.click(await screen.findByRole('button', { name: 'Customise' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save draft & preview' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Approve & apply' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, make it live' }));
+    await waitFor(() => expect(toast.info).toHaveBeenCalledWith(expect.stringMatching(/Already live.*no regrade/)));
+  });
+
+  it('a 409 surfaces the re-open-preview sentence', async () => {
+    fetchScoringSheet.mockResolvedValue(SHEET_CAMPAIGN);
+    createScoringDraft.mockResolvedValue({ version: 9, status: 'draft' });
+    simulateScoringDraft.mockResolvedValue({ population: { examined: 1 }, diff: { meanDelta: 0, movedOver20: 0, becameNull: 0 } });
+    approveScoringDraft.mockRejectedValue(Object.assign(new Error('The live sheet changed while you were editing — re-open preview.'), { status: 409 }));
+    setup();
+    fireEvent.click(await screen.findByRole('button', { name: 'Customise' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save draft & preview' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Approve & apply' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, make it live' }));
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(expect.stringMatching(/changed while you were editing/)));
+  });
+});
+
+describe('history', () => {
+  it('dates drafts by creation and live rows by activation; actions split draft vs superseded', async () => {
+    fetchScoringSheet.mockResolvedValue(SHEET_CAMPAIGN);
+    fetchScoringHistory.mockResolvedValue([
+      { version: 9, status: 'draft', createdAt: '2026-07-30T10:00:00Z', activatedAt: '2026-07-30T10:00:00Z', actorName: 'Shawn Lee' },
+      { version: 7, status: 'approved', createdAt: '2026-07-29T00:00:00Z', activatedAt: '2026-07-30T04:00:00Z', actorName: 'Shawn Lee' },
+      { version: 4, status: 'superseded', createdAt: '2026-07-20T00:00:00Z', activatedAt: '2026-07-21T00:00:00Z', actorName: null },
+    ]);
+    setup();
+    await screen.findByText('campaign sheet');
+    fireEvent.click(screen.getByText('Edition history'));
+
+    // Drafts get activatedAt AT INSERT (schema quirk) — the UI must not read
+    // it as an activation.
+    expect(await screen.findByText(/DRAFTED 30 JUL/)).toBeInTheDocument();
+    expect(screen.getAllByText(/LIVE SINCE/).length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: 'Review & make live' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Restore as new draft' }).length).toBe(2);
+    expect(screen.queryByRole('button', { name: /discard/i })).not.toBeInTheDocument();
+  });
+
+  it('reviewing an OLD draft warns about rollback in the confirm', async () => {
+    fetchScoringSheet.mockResolvedValue(SHEET_CAMPAIGN); // live = #7
+    fetchScoringHistory.mockResolvedValue([
+      { version: 5, status: 'draft', createdAt: '2026-07-28T00:00:00Z', activatedAt: '2026-07-28T00:00:00Z', actorName: null },
+    ]);
+    fetchScoringEdition.mockResolvedValue({ version: 5, status: 'draft', configJson: { components: { age: { maxPoints: 4 } } } });
+    simulateScoringDraft.mockResolvedValue({ population: { examined: 2 }, diff: { meanDelta: -1, movedOver20: 0, becameNull: 0 } });
+    setup();
+    await screen.findByText('campaign sheet');
+    fireEvent.click(screen.getByText('Edition history'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Review & make live' }));
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Approve & apply' }));
+    expect(screen.getByText(/This rolls back past edition #7/)).toBeInTheDocument();
+  });
+});

--- a/src/components/adminv2/__tests__/ScoringSheetEditor.test.jsx
+++ b/src/components/adminv2/__tests__/ScoringSheetEditor.test.jsx
@@ -1,0 +1,90 @@
+/**
+ * The curated controls (campaign-scoring-editor §3.1): sign-fixed weight
+ * inputs with house ghosts + per-knob reset, the band presets building
+ * slope-legal curves, and vocabulary-clamped target segments.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ScoringSheetEditor from '../ScoringSheetEditor';
+import { buildAgeCurveFromBands } from '@/lib/adminV2/scoringLabels';
+
+const HOUSE = {
+  components: {
+    engagement: { maxPoints: 15 }, contactability: { maxPoints: 10 }, market_fit: { maxPoints: 15 },
+    life_events: { maxPoints: 25 }, family_gap: { maxPoints: 20 }, capacity: { maxPoints: 15 },
+    age: { maxPoints: 10 }, coverage_headroom: { maxPoints: -10 },
+  },
+  leadComponents: { response: { maxPoints: 15 }, screening: { maxPoints: 20 } },
+};
+
+const DOC = {
+  components: { ...HOUSE.components, age: { maxPoints: 6 } },
+  leadComponents: { ...HOUSE.leadComponents },
+  ageCurve: [{ upTo: 44, value: 1 }, { upTo: null, value: 0.5 }],
+  targetSegments: [],
+  _ageBands: [],
+};
+
+function setup(onChange = vi.fn()) {
+  render(<ScoringSheetEditor doc={DOC} houseDefault={HOUSE} onChange={onChange} />);
+  return onChange;
+}
+
+describe('weights', () => {
+  it('shows every exposed component with its house ghost, in card language', () => {
+    setup();
+    expect(screen.getByLabelText('message response weight')).toBeInTheDocument();
+    expect(screen.getByLabelText('screening call weight')).toBeInTheDocument();
+    expect(screen.getByLabelText('coverage headroom weight')).toBeInTheDocument();
+    // The overridden knob offers a reset that pins the house value.
+    expect(screen.getByRole('button', { name: 'reset' })).toBeInTheDocument();
+  });
+
+  it('a penalty clamps to its own side of zero — it can never be typed positive', () => {
+    const onChange = setup();
+    fireEvent.change(screen.getByLabelText('coverage headroom weight'), { target: { value: '5' } });
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+      components: expect.objectContaining({ coverage_headroom: { maxPoints: 0 } }),
+    }));
+  });
+
+  it('a lead-grain weight lands in leadComponents, not components', () => {
+    const onChange = setup();
+    fireEvent.change(screen.getByLabelText('screening call weight'), { target: { value: '25' } });
+    const doc = onChange.mock.calls[0][0];
+    expect(doc.leadComponents.screening.maxPoints).toBe(25);
+    expect(doc.components.screening).toBeUndefined();
+  });
+
+  it('reset pins the house value explicitly', () => {
+    const onChange = setup();
+    fireEvent.click(screen.getByRole('button', { name: 'reset' }));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+      components: expect.objectContaining({ age: { maxPoints: 10 } }),
+    }));
+  });
+});
+
+describe('the age dial', () => {
+  it('a band preset regenerates the curve via the slope-legal ladder', () => {
+    const onChange = setup();
+    fireEvent.click(screen.getByRole('button', { name: '30-44' }));
+    const doc = onChange.mock.calls[0][0];
+    expect(doc.ageCurve).toEqual(buildAgeCurveFromBands(['30-44']));
+    expect(doc._ageBands).toEqual(['30-44']);
+    // The ladder ramps — no jump exceeds the validator's 0.5 cap.
+    for (let i = 1; i < doc.ageCurve.length; i += 1) {
+      expect(Math.abs(doc.ageCurve[i].value - doc.ageCurve[i - 1].value)).toBeLessThanOrEqual(0.5);
+    }
+  });
+});
+
+describe('target segments', () => {
+  it('adds rows up to the cap with vocabulary-only options', () => {
+    const onChange = setup();
+    fireEvent.click(screen.getByRole('button', { name: '+ target segment' }));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+      targetSegments: [{ language: 'en', weight: 1 }],
+    }));
+  });
+});

--- a/src/hooks/queries/useAdminV2.js
+++ b/src/hooks/queries/useAdminV2.js
@@ -7,6 +7,7 @@ import {
   fetchOverview, fetchAttention, fetchSeries, fetchFunnel,
   fetchProspects, fetchProspectDetail, fetchProspectProfile, fetchConsumers, fetchCampaignsList, fetchAgentOptions,
   fetchAgentsRoster, fetchCampaignSummary, fetchWallets, fetchWalletLedger, fetchAgentGroups,
+  fetchScoringSheet, fetchScoringHistory, fetchScoringProgress,
 } from '@/api/adminV2';
 
 const STALE_MS = 30_000;
@@ -99,4 +100,37 @@ export function useWalletLedger(agentId, page = 1) {
 
 export function useAgentGroups() {
   return useQuery({ queryKey: ['adminV2', 'agentGroups'], queryFn: fetchAgentGroups, staleTime: STALE_MS });
+}
+
+export function useScoringSheet(campaignId) {
+  return useQuery({
+    queryKey: ['adminV2', 'scoringSheet', campaignId],
+    queryFn: () => fetchScoringSheet(campaignId),
+    staleTime: STALE_MS,
+    enabled: !!campaignId,
+    // 404 = the surface is switched off — an answer, not a transient.
+    retry: (count, err) => err?.status !== 404 && count < 2,
+  });
+}
+
+export function useScoringHistory(campaignId, enabled) {
+  return useQuery({
+    queryKey: ['adminV2', 'scoringHistory', campaignId],
+    queryFn: () => fetchScoringHistory(campaignId),
+    staleTime: STALE_MS,
+    enabled: !!campaignId && enabled !== false,
+    retry: (count, err) => err?.status !== 404 && count < 2,
+  });
+}
+
+export function useScoringProgress(campaignId, { enabled = true } = {}) {
+  return useQuery({
+    queryKey: ['adminV2', 'scoringProgress', campaignId],
+    queryFn: () => fetchScoringProgress(campaignId),
+    enabled: !!campaignId && enabled,
+    // Poll only while the card is mounted AND the regrade is incomplete —
+    // the interval callback sees the latest payload and shuts itself off.
+    refetchInterval: (query) => (query.state.data && !query.state.data.complete ? 30_000 : false),
+    retry: (count, err) => err?.status !== 404 && count < 2,
+  });
 }

--- a/src/lib/adminV2/scoringLabels.js
+++ b/src/lib/adminV2/scoringLabels.js
@@ -1,0 +1,126 @@
+/**
+ * Scoring vocabulary shared by the admin surfaces
+ * (campaign-scoring-editor §3.1, round-2 B4).
+ *
+ * COMPONENT_LABELS names the ten scoring components in the same words on the
+ * Lead Profile card and in the sheet editor — extracted from
+ * AdminV2LeadProfile so the two can never drift. SEGMENT_* mirror the backend
+ * fact taxonomy's enums (backend/src/utils/factTaxonomy.js LANGUAGES /
+ * ETHNICITIES) and are pinned by a backend parity test
+ * (test/scoringVocabParity.test.js) — the taxonomy stays the one owner.
+ *
+ * VALUES are not here on purpose: house-default weights come from the server
+ * (`houseDefault` on the strict resolve), so the ghosts the editor shows are
+ * whatever the backend actually scores with, never a frontend copy.
+ */
+
+export const COMPONENT_LABELS = {
+  engagement: 'engagement',
+  contactability: 'contactability',
+  market_fit: 'market fit',
+  life_events: 'life events',
+  family_gap: 'family gap',
+  capacity: 'capacity',
+  coverage_headroom: 'coverage headroom',
+  age: 'age',
+  // The two LEAD-grain components (per-campaign-lead-scoring §4). Named for
+  // both grains: the person card renders a copy of the winning lead's
+  // breakdown, so these surface there too.
+  response: 'message response',
+  screening: 'screening call',
+};
+
+/**
+ * The editor's EXPOSED set — which knobs the sheet editor shows, in which
+ * group, and each one's sign. `leadGrain` components live in the stored doc's
+ * `leadComponents` map, the rest in `components`. Unexposed knobs (decay,
+ * confidence floors, group membership) are deliberately absent: the server
+ * composes edits onto the winning raw doc, so what isn't shown isn't touched.
+ */
+export const EXPOSED_COMPONENTS = [
+  { name: 'engagement', group: 'meet', leadGrain: false, penalty: false },
+  { name: 'contactability', group: 'meet', leadGrain: false, penalty: false },
+  { name: 'market_fit', group: 'meet', leadGrain: false, penalty: false },
+  { name: 'response', group: 'meet', leadGrain: true, penalty: false },
+  { name: 'screening', group: 'meet', leadGrain: true, penalty: false },
+  { name: 'life_events', group: 'buy', leadGrain: false, penalty: false },
+  { name: 'family_gap', group: 'buy', leadGrain: false, penalty: false },
+  { name: 'capacity', group: 'buy', leadGrain: false, penalty: false },
+  { name: 'age', group: 'buy', leadGrain: false, penalty: false },
+  { name: 'coverage_headroom', group: 'buy', leadGrain: false, penalty: true },
+];
+
+/** UI bounds — guidance only; scoringConfigValidation is the authority. */
+export const MAX_WEIGHT = 30;
+
+/** The effective weight for a component out of a config-shaped doc. */
+export function weightOf(doc, comp) {
+  const map = comp.leadGrain ? doc?.leadComponents : doc?.components;
+  return map?.[comp.name]?.maxPoints;
+}
+
+/** Mirror of factTaxonomy LANGUAGES / ETHNICITIES — parity-tested. */
+export const SEGMENT_LANGUAGES = [
+  { id: 'en', label: 'English' },
+  { id: 'zh', label: 'Chinese (Mandarin)' },
+  { id: 'ms', label: 'Malay' },
+  { id: 'ta', label: 'Tamil' },
+];
+export const SEGMENT_ETHNICITIES = [
+  { id: 'chinese', label: 'Chinese' },
+  { id: 'malay', label: 'Malay' },
+  { id: 'indian', label: 'Indian' },
+  { id: 'eurasian', label: 'Eurasian' },
+  { id: 'other', label: 'Other' },
+];
+
+/** The brief's age bands (campaignBrief BRIEF_AGE_BANDS), as curve zones.
+ * `under-18` is a pseudo-zone so the ladder can ramp below the first band. */
+export const AGE_BAND_ZONES = [
+  { id: '18-29', upTo: 29 },
+  { id: '30-44', upTo: 44 },
+  { id: '45-59', upTo: 59 },
+  { id: '60+', upTo: null },
+];
+
+/**
+ * Deterministic brief-bands → age curve (campaign-scoring-editor §3.1,
+ * round-3 M3). Each zone's value is a LADDER of its band-distance to the
+ * nearest SELECTED band: 0 → 1.0, 1 → 0.8, 2 → 0.55, 3+ → 0.3. Adjacent
+ * zones differ by at most one ladder step (≤0.25), so the result always
+ * clears the validator's 0.5 slope cap — the naive "selected = 1.0, rest =
+ * house shoulder" shape does not (0.25 → 1.0 at age 18 is a 0.75 cliff).
+ * The under-18 zone sits one step below the first band. Consecutive equal
+ * values merge into one segment; the last segment is always the open tail.
+ *
+ * Returns null when nothing is selected — the caller keeps its curve.
+ */
+export function buildAgeCurveFromBands(selectedIds) {
+  const selected = AGE_BAND_ZONES
+    .map((z, i) => (selectedIds?.includes(z.id) ? i : null))
+    .filter((i) => i !== null);
+  if (!selected.length) return null;
+
+  const LADDER = [1, 0.8, 0.55, 0.3];
+  const valueAt = (zoneIndex) => {
+    const dist = Math.min(...selected.map((s) => Math.abs(s - zoneIndex)));
+    return LADDER[Math.min(dist, LADDER.length - 1)];
+  };
+
+  // Zones in age order: under-18 (index -1, one step beyond band 0), then the
+  // four brief bands.
+  const zones = [
+    { upTo: 17, value: LADDER[Math.min(Math.min(...selected.map((s) => s + 1)), LADDER.length - 1)] },
+    ...AGE_BAND_ZONES.map((z, i) => ({ upTo: z.upTo, value: valueAt(i) })),
+  ];
+
+  // Merge runs of equal value; keep the open tail last.
+  const merged = [];
+  for (const z of zones) {
+    const prev = merged[merged.length - 1];
+    if (prev && prev.value === z.value) prev.upTo = z.upTo;
+    else merged.push({ ...z });
+  }
+  merged[merged.length - 1].upTo = null;
+  return merged;
+}

--- a/src/pages/adminv2/AdminV2CampaignDetail.jsx
+++ b/src/pages/adminv2/AdminV2CampaignDetail.jsx
@@ -15,6 +15,7 @@ import { fmtNumber, fmtSGD, fmtDate, fmtDateTime, fmtRelative, daysUntil } from 
 import { STATUS_LABELS, STATUS_CHIP_CLASS, heldLabel } from '@/lib/adminV2/constants';
 import { Card, Chip, PageHeader, Skeleton, ErrorState, EmptyState } from '@/components/adminv2/primitives';
 import { SeriesBarChart } from '@/components/adminv2/charts';
+import CampaignScoringCard from '@/components/adminv2/CampaignScoringCard';
 
 const WORKSPACE_ON = import.meta.env.VITE_CAMPAIGN_WORKSPACE_ENABLED === 'true';
 
@@ -176,6 +177,11 @@ export default function AdminV2CampaignDetail() {
             ))
           )}
         </Card>
+
+        {/* Which sheet grades this campaign's leads, and the door to tune it
+            (campaign-scoring-editor §3.2). Renders its own unavailable state
+            while the backend flag is off. */}
+        <CampaignScoringCard campaignId={c.id} />
       </div>
     </div>
   );

--- a/src/pages/adminv2/AdminV2LeadProfile.jsx
+++ b/src/pages/adminv2/AdminV2LeadProfile.jsx
@@ -24,6 +24,7 @@ import { bulkAssign, bulkReturnToHeld, bulkDelete, fetchConsentCopy } from '@/ap
 import { STATUS_LABELS, SOURCE_LABELS, heldLabel } from '@/lib/adminV2/constants';
 import { fmtDateTime, fmtDate, fmtDay, fmtSGDExact } from '@/lib/adminV2/format';
 import { Card, Chip, Skeleton, ErrorState, EmptyState } from '@/components/adminv2/primitives';
+import { COMPONENT_LABELS } from '@/lib/adminV2/scoringLabels';
 import { rowChipFor, drawWindowDay } from '@/lib/adminV2/outcome';
 import {
   AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle,
@@ -521,22 +522,9 @@ function ConsentKv({ label, state, legacy }) {
  * or is simply unknown — that distinction is the point, because "unknown
  * capacity" and "low capacity" must never render the same way.
  */
-const COMPONENT_LABELS = {
-  engagement: 'engagement',
-  contactability: 'contactability',
-  market_fit: 'market fit',
-  life_events: 'life events',
-  family_gap: 'family gap',
-  capacity: 'capacity',
-  coverage_headroom: 'coverage headroom',
-  age: 'age',
-  // The two LEAD-grain components (per-campaign-lead-scoring §4). Named here
-  // for both grains, not just the drill-in: the person's numbers are a copy of
-  // their winning lead's, breakdown included, so "response" and "screening"
-  // already surface on the profile card and were reading as bare column keys.
-  response: 'message response',
-  screening: 'screening call',
-};
+// COMPONENT_LABELS moved to @/lib/adminV2/scoringLabels — shared with the
+// sheet editor (campaign-scoring-editor §3.1) so the card and the editor
+// describe the same components in the same words.
 
 const FACT_LABELS = {
   'identity.gender': 'gender',
@@ -786,7 +774,14 @@ function EnrichmentCard({ enrichment }) {
   return (
     <Card
       title="Scoring"
-      meta={enrichment?.configVersion != null ? `CONFIG v${enrichment.configVersion}` : undefined}
+      // The caption stamps come from the SOURCE lead (campaign-scoring-editor
+      // §4.4). When a breakdown survives but its source signup is gone —
+      // deleted, or a projection older than the pointer column — there is no
+      // honest stamp to show, and borrowing the person-pass one would caption
+      // this breakdown with an unrelated config.
+      meta={enrichment?.stampsUnavailable
+        ? 'SCORE SOURCE SIGNUP UNAVAILABLE'
+        : enrichment?.configVersion != null ? `CONFIG v${enrichment.configVersion}` : undefined}
     >
       <div style={{ padding: '12px 18px 6px', display: 'flex', gap: 18 }}>
         <ScoreDial label="Meet" value={enrichment?.meetScore} hint="no signal yet" />

--- a/src/pages/adminv2/__tests__/AdminV2CampaignDetail.duplicate.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2CampaignDetail.duplicate.test.jsx
@@ -25,6 +25,12 @@ const CAMPAIGN = {
   end_date: null,
 };
 
+// Out of scope here: the scoring card owns its own queries + QueryClient
+// needs; its behavior is covered by CampaignScoringCard.test.jsx.
+vi.mock('@/components/adminv2/CampaignScoringCard', () => ({
+  default: () => <div data-testid="scoring-card-stub" />,
+}));
+
 vi.mock('@/hooks/queries/useAdminV2', () => ({
   useCampaignSummary: () => ({
     isLoading: false,

--- a/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
@@ -650,6 +650,18 @@ describe('scoring panel', () => {
     await screen.findByText('Campaigns');
     expect(screen.queryByText('Scoring')).not.toBeInTheDocument();
   });
+
+  it('a breakdown whose source signup is gone captions itself unavailable — never with person-pass stamps', async () => {
+    // campaign-scoring-editor §4.4: deleted source lead and pre-101 legacy
+    // projection are indistinguishable; the card claims neither a config nor
+    // a time it cannot stand behind.
+    const d = ENRICHED({ stampsUnavailable: true, configVersion: null, scoredAt: null, algorithmVersion: null });
+    fetchProspectProfile.mockResolvedValue(d);
+    setup('/admin/leads/p1?view=profile');
+    await screen.findByText('Scoring');
+    expect(screen.getByText('SCORE SOURCE SIGNUP UNAVAILABLE')).toBeInTheDocument();
+    expect(screen.queryByText(/CONFIG v/)).not.toBeInTheDocument();
+  });
 });
 
 /**


### PR DESCRIPTION
## What

The missing screen over #312's dark scoring-config backend, per **`docs/plans/campaign-scoring-editor.md`** (five Codex review rounds, 17 → 14 → 8 → 3 → 1 findings — full disposition logs in the doc §10–§14, committed here).

**The card** (campaign page): which sheet governs this campaign — tier chip, edition #, live-since, approver — plus "X of Y leads on edition #N" while a regrade rolls through the nightly sweeps. **Customise** opens the curated editor: ten weights grouped Meet/Buy with house values ghosted, per-knob reset that *pins* the house value, an age dial with brief-band presets (slope-legal by construction — proven against the real validator for all 15 band combinations), and vocabulary-clamped language/ethnicity targeting. Save mints a **draft** → the preview re-scores a sample **draft-vs-current at one fixed now** (config-only delta; drift shown separately) → **Approve**, behind an inline confirm that names rollbacks and lose-their-Buy-score counts, is the only door to live.

## The eight service amendments (each one a Codex finding)

1. **§4.1** editor patches compose server-side onto the winning tier's **raw** doc — a campaign tweak can't silently reset a product sheet's explicit extras
2. **§4.2** strict resolve: direct-DB, no cache, 5xx over silent defaults; carries activation metadata + the houseDefault ghost DTO
3. **§4.3** `compareTo:'resolved'` simulate — inputs once, scored twice at one now; campaign-scope only; cap 100/pool 4/duration logged
4. **§4.4** person-card caption stamps read from the **source lead in the same SQL snapshot**; unresolvable source → "score source signup unavailable", never borrowed stamps
5. **§4.5** race-safe approve: per-scope advisory lock + required `expectedLiveVersion` (0 = house baseline) vs the resolved winner + `WHERE status='draft' RETURNING`
6. **§4.6** content-equal approve = stated no-op (candidate stays a draft — no spurious multi-night regrade); list scope filters + actor names + createdAt; campaign-existence 422; **no Discard** (three statuses only)
7. **§4.7** validator strengthened in place: sign map, targetSegments vocab/axis/dup/cap, decay exact keys, 64KiB cap
8. **§4.8** `/progress` = the exact complement of `findStaleLeadIds` (never a bare version match), registered before `/:version`

## Ships dark

The router stays unmounted until `SCORING_CONFIG_ADMIN_ENABLED` flips — **zero behavior change in prod**. The card renders a neutral "unavailable on this backend" (a 404 can't distinguish the flag from an old deploy). Rollback = flip it off; approved sheets keep scoring (the flag gates authoring, not resolution).

## Tests

- Backend **208** across 8 suites: composition (incl. product-extras survival + arrays-replace), strict resolve, twice-scored simulate (writes nothing, poisoned-stored-score proof), approve lock/guards/no-op/status-predicate, list filters, existence 422, progress complement (dirty + never-scored excluded, stamped-null counts), caption stamps incl. null-source, vocab parity + 15-combination slope proof
- Frontend **2102**: card states incl. 404 neutral copy, full-exposed-set patch assertion, preview + became-null warning + truncated label, baseline-carrying approve, no-op toast, 409 sentence, history dating (drafts by createdAt) + rollback wording, editor sign-clamping + ladder curves

Phase 1.5 (rescore-now) and Phase 2 (create-flow block on both surfaces) follow per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENWdGMue9uXqmKv3pRG6YF