### PR TITLE
fix(workspace): kill the 800px of dead scroll under the campaign workspace

### DIFF
--- a/src/pages/AdminCampaignWorkspace.jsx
+++ b/src/pages/AdminCampaignWorkspace.jsx
@@ -243,8 +243,12 @@ export default function AdminCampaignWorkspace() {
         })}
       </div>
 
-      {/* Tab content */}
-      <div className="flex-1 min-h-0 overflow-y-auto">
+      {/* Tab content. `relative` is load-bearing: Radix Switch renders a hidden
+          position:absolute bubble input, and with no positioned ancestor its
+          containing block was the viewport — so overflow-y-auto never clipped
+          it and it stretched the DOCUMENT to the switch's offset (~800px of
+          dead scroll below the shell). */}
+      <div className="relative flex-1 min-h-0 overflow-y-auto">
         {activeTab === 'details' && (
           <div className="p-4 lg:p-6">
             <CampaignDetailsTab


### PR DESCRIPTION
## The symptom

On `/admin/campaigns/workspace`, the page scrolls ~800px below the app shell into blank white space — white, not dark, because you scroll clean past the shell into the bare body background.

## The cause

The workspace is a fixed one-viewport column (`h-[calc(100vh-4rem)]`) whose tab body is the only scroller. That part measured correct in prod: shell = 769px = viewport. But `document.scrollingElement.scrollHeight` reported **1581px**.

The **"Enforce paid lead quota"** Switch is why. Radix Switch renders a hidden `position: absolute` bubble input behind the visible thumb. An absolutely-positioned box anchors to its nearest *positioned* ancestor — and nothing in the chain (scroller → page root → `<main>` → shell) was positioned, so its containing block resolved to the initial containing block, i.e. the viewport.

`overflow-y: auto` only clips descendants it is the containing block for. So the scroller never clipped this input, and the browser grew the **document** tall enough to reach an invisible 36×20 checkbox parked at y=1561.

## The fix

`relative` on the tab body, so the bubble input has a local containing block and gets clipped like everything else.

## Verification

Measured live in prod DOM before/after applying `position: relative` to that container:

| | document scrollHeight |
|---|---|
| before | 1581px |
| after | 769px (== viewport) |

`src/pages/__tests__/AdminCampaignWorkspace.test.jsx` — 4/4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ies6SzVmBMhWDhFtaPWff