### PR TITLE
feat(scoring): the AI writes the sheet, you approve it — Phase 1.6

### DIFF
--- a/docs/plans/campaign-scoring-editor.md
+++ b/docs/plans/campaign-scoring-editor.md
@@ -342,7 +342,8 @@ single authority.
 | **1** | Editor + campaign card + history + §4.1–4.8 + tests |
 | **1.5** | Rescore-now (bounded, explicit button; re-resolves version inside the fence; M7 race self-heals via version-mismatch staleness) |
 | **2** | Creation-time block (both surfaces) + duplicate-flow note + optional `discarded` status migration |
-| out | Product/global sheet screens · AI-propose UI (endpoint exists) · decay knobs · batch preview loaders unless §4.3's budget trips · agent-facing anything |
+| **1.6** | AI-propose button (SHIPPED 2026-07-31): "Draft with AI" on the card — optional steer sentence → /propose reads the brief and writes the sheet → the SAME draft/preview/approve gates; card re-simulates compareTo:'resolved' (never the propose response's stored-comparison sim) and renders the rationale; ANY edit invalidates the pending draft so approve can never ship a pre-edit doc |
+| out | Product/global sheet screens · decay knobs · batch preview loaders unless §4.3's budget trips · agent-facing anything |
 
 ## 10. Codex round-1 log (gpt-5.6-sol xhigh — FAIL)
 

--- a/src/api/adminV2.js
+++ b/src/api/adminV2.js
@@ -336,3 +336,15 @@ export async function approveScoringDraft(version, expectedLiveVersion) {
   const resp = await apiClient.post(`/admin/scoring-configs/${version}/approve`, { expectedLiveVersion });
   return resp?.data ?? null;
 }
+
+/** The AI author (campaign-scoring-editor Phase 1.6): reads the campaign's
+ *  brief server-side, writes a full sheet, returns {draft, rationale,
+ *  simulation}. The draft is inert like any other — same preview + approve
+ *  gates; the AI never makes anything live. `description` is the optional
+ *  one-line steer (sanitized + length-capped server-side). */
+export async function proposeScoringSheet(campaignId, description = '') {
+  const resp = await apiClient.post('/admin/scoring-configs/propose', {
+    campaignId, description,
+  });
+  return resp?.data ?? null;
+}

--- a/src/components/adminv2/CampaignScoringCard.jsx
+++ b/src/components/adminv2/CampaignScoringCard.jsx
@@ -16,7 +16,7 @@ import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useScoringSheet, useScoringHistory, useScoringProgress } from '@/hooks/queries/useAdminV2';
-import { createScoringDraft, simulateScoringDraft, approveScoringDraft, fetchScoringEdition } from '@/api/adminV2';
+import { createScoringDraft, simulateScoringDraft, approveScoringDraft, fetchScoringEdition, proposeScoringSheet } from '@/api/adminV2';
 import { Card, Chip, Skeleton, ErrorState } from '@/components/adminv2/primitives';
 import { fmtDateTime } from '@/lib/adminV2/format';
 import ScoringSheetEditor from '@/components/adminv2/ScoringSheetEditor';
@@ -96,6 +96,12 @@ export default function CampaignScoringCard({ campaignId }) {
   const [draft, setDraft] = useState(null);
   const [sim, setSim] = useState(null);
   const [confirming, setConfirming] = useState(false);
+  // AI authoring (Phase 1.6): the optional one-line steer + the returned
+  // rationale. The AI path lands in EXACTLY the manual flow's state — a
+  // draft with a preview — so approve stays the single gate.
+  const [aiAsking, setAiAsking] = useState(false);
+  const [aiNote, setAiNote] = useState('');
+  const [rationale, setRationale] = useState(null);
   const progress = useScoringProgress(campaignId, { enabled: !sheet.isError });
   const history = useScoringHistory(campaignId, historyOpen);
 
@@ -103,6 +109,18 @@ export default function CampaignScoringCard({ campaignId }) {
     qc.invalidateQueries({ queryKey: ['adminV2', 'scoringSheet', campaignId] });
     qc.invalidateQueries({ queryKey: ['adminV2', 'scoringHistory', campaignId] });
     qc.invalidateQueries({ queryKey: ['adminV2', 'scoringProgress', campaignId] });
+  };
+
+  // Callable only from rendered UI, so sheet.data is always present by then.
+  const openEditor = (seedDoc, from = null) => {
+    setDoc(seedDoc);
+    setBaseline(sheet.data.version);
+    setRestoredFrom(from);
+    setDraft(null);
+    setSim(null);
+    setConfirming(false);
+    setRationale(null);
+    setEditing(true);
   };
 
   const saveDraft = useMutation({
@@ -121,6 +139,28 @@ export default function CampaignScoringCard({ campaignId }) {
     onError: (e) => toast.error(e?.message || 'Save failed'),
   });
 
+  const propose = useMutation({
+    mutationFn: () => proposeScoringSheet(campaignId, aiNote.trim()),
+    onSuccess: async (res) => {
+      // Land in the SAME state the manual flow produces: editor open on the
+      // AI's document, a pending draft, and a resolved-comparison preview
+      // (we re-simulate with compareTo:'resolved' rather than trusting the
+      // propose response's stored-comparison sim — same semantics as manual).
+      openEditor(docFromSheet({ config: { ...sheet.data.config, ...res.draft.configJson } }), null);
+      setDraft(res.draft);
+      setRationale(res.rationale || null);
+      setAiAsking(false);
+      toast.success(`AI drafted edition #${res.draft.version} — preview it before it can go live`);
+      invalidate();
+      try {
+        setSim(await simulateScoringDraft(res.draft.version));
+      } catch (e) {
+        toast.error(e?.message || 'Preview failed — you can retry it');
+      }
+    },
+    onError: (e) => toast.error(e?.message || 'The AI author is unavailable — check AI Settings, or edit manually'),
+  });
+
   const approve = useMutation({
     mutationFn: ({ version }) => approveScoringDraft(version, baseline ?? sheet.data?.version ?? 0),
     onSuccess: (res) => {
@@ -134,6 +174,8 @@ export default function CampaignScoringCard({ campaignId }) {
       setSim(null);
       setConfirming(false);
       setRestoredFrom(null);
+      setRationale(null);
+      setAiAsking(false);
       invalidate();
     },
     onError: (e) => {
@@ -159,15 +201,6 @@ export default function CampaignScoringCard({ campaignId }) {
 
   const s = sheet.data;
   const p = progress.data;
-  const openEditor = (seedDoc, from = null) => {
-    setDoc(seedDoc);
-    setBaseline(s.version);
-    setRestoredFrom(from);
-    setDraft(null);
-    setSim(null);
-    setConfirming(false);
-    setEditing(true);
-  };
 
   return (
     <Card
@@ -175,9 +208,19 @@ export default function CampaignScoringCard({ campaignId }) {
       title="Lead scoring"
       meta={s.version > 0 ? `EDITION #${s.version}${s.activatedAt ? ` · LIVE SINCE ${fmtDateTime(s.activatedAt).toUpperCase()}` : ''}` : 'HOUSE DEFAULT'}
       action={!editing ? (
-        <button type="button" className="av2-btn av2-btn--sm" onClick={() => openEditor(docFromSheet(s))}>
-          Customise
-        </button>
+        <span style={{ display: 'inline-flex', gap: 6 }}>
+          <button
+            type="button" className="av2-btn av2-btn--sm"
+            disabled={propose.isPending}
+            title="The AI writes a full sheet from this campaign's brief — you still preview and approve"
+            onClick={() => setAiAsking((v) => !v)}
+          >
+            {propose.isPending ? 'Drafting…' : '✨ Draft with AI'}
+          </button>
+          <button type="button" className="av2-btn av2-btn--sm" onClick={() => openEditor(docFromSheet(s))}>
+            Customise
+          </button>
+        </span>
       ) : undefined}
     >
       <div style={{ padding: '12px 16px' }}>
@@ -192,6 +235,33 @@ export default function CampaignScoringCard({ campaignId }) {
                 : 'Scoring by the house rules — customising pins a sheet to this campaign only.'}
           </span>
         </div>
+
+        {/* The AI ask row: one optional steer sentence, then the same
+            draft → preview → approve flow as the manual path. */}
+        {aiAsking && !editing && (
+          <div style={{ marginTop: 10, display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+            <input
+              type="text"
+              aria-label="steer the AI (optional)"
+              placeholder="optional steer — e.g. “young families; the screening call matters most”"
+              value={aiNote}
+              maxLength={300}
+              onChange={(e) => setAiNote(e.target.value)}
+              style={{ flex: 1, minWidth: 260, padding: '7px 10px', borderRadius: 8, border: '1px solid var(--line-strong)', background: 'var(--surface)', color: 'var(--ink)', fontSize: 12.5 }}
+            />
+            <button
+              type="button" className="av2-btn av2-btn--primary av2-btn--sm"
+              disabled={propose.isPending}
+              onClick={() => propose.mutate()}
+            >
+              {propose.isPending ? 'Drafting…' : 'Write the sheet'}
+            </button>
+            <button type="button" className="av2-btn av2-btn--sm" onClick={() => setAiAsking(false)}>Cancel</button>
+            <span style={{ width: '100%', fontSize: 11, color: 'var(--ink-3)' }}>
+              Reads this campaign's brief (objective, product, audience). The result is a draft — nothing goes live without your approval.
+            </span>
+          </div>
+        )}
 
         {/* Regrade progress — visible only while the sweep still owes leads. */}
         {p && !p.complete && (
@@ -211,9 +281,26 @@ export default function CampaignScoringCard({ campaignId }) {
             <ScoringSheetEditor
               doc={doc}
               houseDefault={s.houseDefault}
-              onChange={setDoc}
+              onChange={(next) => {
+                setDoc(next);
+                // An edit INVALIDATES the pending draft — otherwise Approve
+                // would ship the pre-edit document while the screen shows the
+                // edited one. Editing sends you back through Save & preview.
+                if (draft) {
+                  setDraft(null);
+                  setSim(null);
+                  setConfirming(false);
+                  setRationale(null);
+                }
+              }}
               disabled={saveDraft.isPending || approve.isPending}
             />
+            {rationale && (
+              <div style={{ marginTop: 10, padding: '10px 12px', borderRadius: 10, background: 'var(--accent-soft)', border: '1px solid var(--line)' }}>
+                <div className="av2-microcaps">Why the AI chose this</div>
+                <div style={{ fontSize: 12.5, color: 'var(--ink-2)', marginTop: 4 }}>{rationale}</div>
+              </div>
+            )}
             <PreviewPanel sim={sim} />
             <div style={{ display: 'flex', gap: 8, marginTop: 12, alignItems: 'center' }}>
               {!draft ? (
@@ -252,7 +339,7 @@ export default function CampaignScoringCard({ campaignId }) {
               )}
               <button
                 type="button" className="av2-btn av2-btn--sm"
-                onClick={() => { setEditing(false); setDraft(null); setSim(null); setConfirming(false); setRestoredFrom(null); }}
+                onClick={() => { setEditing(false); setDraft(null); setSim(null); setConfirming(false); setRestoredFrom(null); setRationale(null); }}
               >Close</button>
               {draft && <span className="av2-caption">draft #{draft.version} — inert until approved</span>}
             </div>

--- a/src/components/adminv2/__tests__/CampaignScoringCard.test.jsx
+++ b/src/components/adminv2/__tests__/CampaignScoringCard.test.jsx
@@ -18,12 +18,13 @@ vi.mock('@/api/adminV2', () => ({
   createScoringDraft: vi.fn(),
   simulateScoringDraft: vi.fn(),
   approveScoringDraft: vi.fn(),
+  proposeScoringSheet: vi.fn(),
 }));
 
 import { toast } from 'sonner';
 import {
   fetchScoringSheet, fetchScoringHistory, fetchScoringProgress, fetchScoringEdition,
-  createScoringDraft, simulateScoringDraft, approveScoringDraft,
+  createScoringDraft, simulateScoringDraft, approveScoringDraft, proposeScoringSheet,
 } from '@/api/adminV2';
 
 const HOUSE = {
@@ -207,5 +208,71 @@ describe('history', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: 'Approve & apply' }));
     expect(screen.getByText(/This rolls back past edition #7/)).toBeInTheDocument();
+  });
+});
+
+describe('the AI author (Phase 1.6)', () => {
+  const AI_DRAFT = {
+    version: 11, status: 'draft',
+    configJson: {
+      components: {
+        engagement: { maxPoints: 15 }, contactability: { maxPoints: 12 }, market_fit: { maxPoints: 10 },
+        life_events: { maxPoints: 20 }, family_gap: { maxPoints: 18 }, capacity: { maxPoints: 10 },
+        age: { maxPoints: 8 }, coverage_headroom: { maxPoints: -6 },
+      },
+      leadComponents: { response: { maxPoints: 12 }, screening: { maxPoints: 24 } },
+    },
+  };
+
+  it('one click + one optional sentence → the SAME draft/preview/approve flow as manual', async () => {
+    fetchScoringSheet.mockResolvedValue(SHEET_CAMPAIGN);
+    proposeScoringSheet.mockResolvedValue({
+      draft: AI_DRAFT,
+      rationale: 'Screening is this campaign’s richest signal; capacity matters less for a draw audience.',
+      simulation: { comparedTo: 'stored' }, // deliberately ignored by the card
+    });
+    simulateScoringDraft.mockResolvedValue({ population: { examined: 12 }, diff: { meanDelta: 2, movedOver20: 1, becameNull: 0 } });
+    setup();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Draft with AI/ }));
+    fireEvent.change(screen.getByLabelText('steer the AI (optional)'), { target: { value: 'screening matters most' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Write the sheet' }));
+
+    await waitFor(() => expect(proposeScoringSheet).toHaveBeenCalledWith('camp-1', 'screening matters most'));
+    // The editor opens ON the AI's document…
+    expect(await screen.findByText('Why the AI chose this')).toBeInTheDocument();
+    expect(screen.getByLabelText('screening call weight')).toHaveValue(24);
+    // …the preview re-runs with the resolved comparison (never the propose sim)…
+    await waitFor(() => expect(simulateScoringDraft).toHaveBeenCalledWith(11));
+    // …and approve is the same gate, carrying the same baseline.
+    approveScoringDraft.mockResolvedValue({ version: 11, status: 'approved' });
+    fireEvent.click(await screen.findByRole('button', { name: 'Approve & apply' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, make it live' }));
+    await waitFor(() => expect(approveScoringDraft).toHaveBeenCalledWith(11, 7));
+  });
+
+  it('touching any knob INVALIDATES the pending draft — approve can never ship a pre-edit doc', async () => {
+    fetchScoringSheet.mockResolvedValue(SHEET_CAMPAIGN);
+    proposeScoringSheet.mockResolvedValue({ draft: AI_DRAFT, rationale: 'r' });
+    simulateScoringDraft.mockResolvedValue({ population: { examined: 3 }, diff: { meanDelta: 0, movedOver20: 0, becameNull: 0 } });
+    setup();
+    fireEvent.click(await screen.findByRole('button', { name: /Draft with AI/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Write the sheet' }));
+    await screen.findByRole('button', { name: 'Approve & apply' });
+
+    fireEvent.change(screen.getByLabelText('engagement weight'), { target: { value: '18' } });
+    // Back through Save & preview — the stale draft and its rationale are gone.
+    expect(screen.getByRole('button', { name: 'Save draft & preview' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Approve & apply' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Why the AI chose this')).not.toBeInTheDocument();
+  });
+
+  it('an unavailable AI degrades to a toast that points at AI Settings and the manual path', async () => {
+    fetchScoringSheet.mockResolvedValue(SHEET_CAMPAIGN);
+    proposeScoringSheet.mockRejectedValue(new Error('AI provider is not configured.'));
+    setup();
+    fireEvent.click(await screen.findByRole('button', { name: /Draft with AI/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Write the sheet' }));
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('AI provider is not configured.'));
   });
 });


### PR DESCRIPTION
## What

The answer to *"why need to edit all these myself?"* — you don't. #312's `/propose` endpoint (AI reads the campaign brief → writes a full sheet → returns draft + rationale) finally gets its button.

**"✨ Draft with AI"** beside Customise on the Lead scoring card → one optional steer sentence → the result lands in **exactly the manual flow's state**: editor open on the AI's document, inert draft, resolved-comparison preview, same Approve gate with the same `expectedLiveVersion` guard. The AI proposes; only you make it live.

- Card **re-simulates with `compareTo:'resolved'`** (ignores the propose response's stored-comparison sim) — one preview semantics everywhere: *this change only*
- **Rationale renders** above the preview — approvers read the argument, not just the distribution
- **Hardening both paths needed:** editing any knob while a draft is pending invalidates the draft (back through Save & preview) — approve can never ship a pre-edit document
- No AI provider configured → honest toast pointing at AI Settings; manual path unaffected

## Tests

Full click path (steer → propose → AI weights in editor → rationale → resolved re-simulate → approve with baseline), edit-invalidates-draft incl. rationale teardown, unavailable-AI toast. **140 adminv2 green**, lint clean. Plan doc updated (Phase 1.6 row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENWdGMue9uXqmKv3pRG6YF