### PR TITLE
feat(scoring): this campaign's customised sheet, on the lead

### DIFF
--- a/backend/src/routes/scoringConfigs.js
+++ b/backend/src/routes/scoringConfigs.js
@@ -182,7 +182,19 @@ router.get('/progress', asyncHandler(async (req, res) => {
 }));
 
 router.get('/:version', asyncHandler(async (req, res) => {
-  res.json({ success: true, data: await getScoringConfig(versionOf(req)) });
+  // houseDefault rides along (campaign-scoring-editor: the lead page's
+  // sheet-peek ghosts "house N" beside every weight, exactly like the
+  // editor) — server-owned values, never a frontend twin.
+  res.json({
+    success: true,
+    data: {
+      ...(await getScoringConfig(versionOf(req))),
+      houseDefault: {
+        ...normalizeConfig(DEFAULT_SCORING_CONFIG),
+        leadComponents: DEFAULT_LEAD_COMPONENTS,
+      },
+    },
+  });
 }));
 
 /** Hand-authored draft. Same validation path as the AI's output — there is no

--- a/backend/test/scoringConfigRoutes.test.js
+++ b/backend/test/scoringConfigRoutes.test.js
@@ -141,6 +141,16 @@ describe('authoring and listing', () => {
   test('GET /:version 404s on a version that does not exist', async () => {
     expect((await asAdmin(request(app).get(`${meta.path}/999999`))).status).toBe(404)
   })
+
+  test('GET /:version carries the houseDefault ghosts the lead-page sheet peek renders', async () => {
+    const draft = await createDraftConfig({ config: config(7), campaignId: campaign.id })
+    const res = await asAdmin(request(app).get(`${meta.path}/${draft.version}`))
+    expect(res.status).toBe(200)
+    expect(res.body.data.houseDefault.components.age.maxPoints)
+      .toBe(DEFAULT_SCORING_CONFIG.components.age.maxPoints)
+    // leadComponents defaulted the way the scorer defaults them.
+    expect(res.body.data.houseDefault.leadComponents.screening.maxPoints).toBe(20)
+  })
 })
 
 /** The observed live baseline for a scope — what the editor sends (§4.5). */

--- a/src/pages/adminv2/AdminV2LeadProfile.jsx
+++ b/src/pages/adminv2/AdminV2LeadProfile.jsx
@@ -20,7 +20,7 @@ import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'reac
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useProspectProfile, useAgentOptions } from '@/hooks/queries/useAdminV2';
-import { bulkAssign, bulkReturnToHeld, bulkDelete, fetchConsentCopy } from '@/api/adminV2';
+import { bulkAssign, bulkReturnToHeld, bulkDelete, fetchConsentCopy, fetchScoringEdition } from '@/api/adminV2';
 import { STATUS_LABELS, SOURCE_LABELS, heldLabel } from '@/lib/adminV2/constants';
 import { fmtDateTime, fmtDate, fmtDay, fmtSGDExact } from '@/lib/adminV2/format';
 import { Card, Chip, Skeleton, ErrorState, EmptyState } from '@/components/adminv2/primitives';
@@ -836,6 +836,143 @@ function EnrichmentCard({ enrichment }) {
 }
 
 /**
+ * THIS CAMPAIGN'S customised sheet, on the lead (the follow-up ask: "no i
+ * mean, the customised scoring metrics for this particular campaign").
+ *
+ * Shows the EXACT EDITION the stamp names — fetched lazily on first open,
+ * never the currently-resolved sheet: the campaign may have moved to a newer
+ * edition since this lead was scored, and captioning old points with new
+ * rules is the §4.4 lie all over again. Weights render beside their house
+ * values with a ↑/↓ marker on every deviation; the age curve and target
+ * segments come from the same document. Effective weights fall back to the
+ * breakdown's own maxPoints when an older edition's document omits a key.
+ */
+function CampaignSheetPeek({ edition, breakdown, campaignId }) {
+  const [state, setState] = useState({ status: 'idle', sheet: null });
+  if (edition == null) return null;
+
+  const load = async (e) => {
+    if (!e.currentTarget.open || state.status === 'ready' || state.status === 'loading') return;
+    setState({ status: 'loading', sheet: null });
+    try {
+      setState({ status: 'ready', sheet: await fetchScoringEdition(edition) });
+    } catch {
+      setState({ status: 'error', sheet: null });
+    }
+  };
+
+  const sheet = state.sheet;
+  const cfg = sheet?.configJson || {};
+  const house = sheet?.houseDefault || {};
+  const comps = breakdown?.components || {};
+  // Effective weight: the edition's document, else the breakdown's own max —
+  // which IS the weight that actually applied.
+  const weightFor = (name, leadGrain) => {
+    const map = leadGrain ? cfg.leadComponents : cfg.components;
+    return map?.[name]?.maxPoints ?? comps[name]?.maxPoints ?? null;
+  };
+  const houseFor = (name, leadGrain) => {
+    const map = leadGrain ? house.leadComponents : house.components;
+    return map?.[name]?.maxPoints ?? null;
+  };
+
+  // "peaks 30-44" from the curve: the segments at the curve's own maximum.
+  const curve = Array.isArray(cfg.ageCurve) ? cfg.ageCurve : [];
+  let peak = null;
+  if (curve.length) {
+    const top = Math.max(...curve.map((s) => s.value));
+    const ranges = [];
+    let lo = 0;
+    for (const seg of curve) {
+      const hi = seg.upTo == null ? null : seg.upTo;
+      if (seg.value === top) ranges.push(hi == null ? `${lo}+` : `${lo}–${hi}`);
+      lo = hi == null ? lo : hi + 1;
+    }
+    peak = ranges.join(', ');
+  }
+  const segments = Array.isArray(cfg.targetSegments) ? cfg.targetSegments : [];
+
+  const NAMES = [
+    ['meet', 'Reachability', [['engagement', false], ['contactability', false], ['market_fit', false], ['response', true], ['screening', true]]],
+    ['buy', 'Potential', [['life_events', false], ['family_gap', false], ['capacity', false], ['coverage_headroom', false], ['age', false]]],
+  ];
+
+  return (
+    <details style={{ borderTop: '1px solid var(--line)' }} onToggle={load}>
+      <summary style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '9px 16px', cursor: 'pointer', fontSize: 11.5, fontWeight: 700, color: 'var(--ink-2)' }}>
+        <span className="disc-caret" aria-hidden="true" style={{ color: 'var(--ink-3)', display: 'inline-block', transition: 'transform .12s ease' }}>▸</span>
+        This campaign's scoring sheet
+        <span style={{ flex: 1 }} />
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--ink-3)' }}>EDITION #{edition}</span>
+      </summary>
+      <div style={{ padding: '2px 16px 12px 36px' }}>
+        {state.status === 'loading' && <div style={{ fontSize: 12, color: 'var(--ink-3)', padding: '4px 0' }}>Loading the edition…</div>}
+        {state.status === 'error' && (
+          <div style={{ fontSize: 12, color: 'var(--ink-3)', padding: '4px 0' }}>
+            Couldn't load edition #{edition} — the weights in the breakdown above (the “/N” figures) are the ones that applied.
+          </div>
+        )}
+        {state.status === 'ready' && (
+          <>
+            {NAMES.map(([key, title, names]) => (
+              <div key={key}>
+                <div className="av2-microcaps" style={{ padding: '6px 0 2px' }}>{title}</div>
+                {names.map(([name, leadGrain]) => {
+                  const w = weightFor(name, leadGrain);
+                  const h = houseFor(name, leadGrain);
+                  const differs = w != null && h != null && w !== h;
+                  return (
+                    <div key={name} style={{ display: 'flex', alignItems: 'baseline', gap: 10, padding: '2px 0', fontSize: 12 }}>
+                      <span style={{ width: 148, flex: 'none', color: 'var(--ink-2)' }}>{COMPONENT_LABELS[name] || name}</span>
+                      <span className="av2-mono" style={{ width: 34, textAlign: 'right', flex: 'none', fontWeight: differs ? 800 : 500, color: differs ? 'var(--ink)' : 'var(--ink-2)' }}>
+                        {w ?? '—'}
+                      </span>
+                      <span className="av2-mono" style={{ fontSize: 10.5, color: 'var(--ink-3)' }}>
+                        house {h ?? '—'}
+                        {differs && (
+                          <span style={{ color: w > h ? 'var(--accent-text)' : 'var(--warn)', fontWeight: 700 }}>
+                            {' '}{w > h ? '↑' : '↓'} {w > h ? '+' : ''}{Math.round((w - h) * 10) / 10}
+                          </span>
+                        )}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            ))}
+            <div style={{ fontSize: 12, color: 'var(--ink-2)', paddingTop: 8 }}>
+              <span className="av2-microcaps" style={{ display: 'block', paddingBottom: 2 }}>Age dial</span>
+              {peak ? <>full weight at ages <span style={{ fontWeight: 700, color: 'var(--ink)' }}>{peak}</span>, ramping down outside</> : 'house curve'}
+            </div>
+            <div style={{ fontSize: 12, color: 'var(--ink-2)', paddingTop: 8 }}>
+              <span className="av2-microcaps" style={{ display: 'block', paddingBottom: 2 }}>Target market</span>
+              {segments.length
+                ? segments.map((s, i) => (
+                  <span key={i}>
+                    {i > 0 && ' · '}
+                    {[s.language && (SEGMENT_LANGUAGE_LABELS[s.language] || s.language), s.ethnicity].filter(Boolean).join(' / ')}
+                    {typeof s.weight === 'number' && s.weight !== 1 ? ` ×${s.weight}` : ''}
+                  </span>
+                ))
+                : 'everyone equally'}
+            </div>
+            {campaignId && (
+              <div style={{ paddingTop: 10 }}>
+                <Link to={`/admin/campaigns/${campaignId}`} style={{ fontSize: 11.5, fontWeight: 700 }}>
+                  Tune this sheet on the campaign page →
+                </Link>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </details>
+  );
+}
+
+const SEGMENT_LANGUAGE_LABELS = { en: 'English', zh: 'Mandarin', ms: 'Malay', ta: 'Tamil' };
+
+/**
  * The MECHANICS, on the page (asked for directly: "can you put somewhere,
  * the scoring mechanics on the lead?"). The same plain language the console
  * uses everywhere, tucked behind a disclosure so it teaches without
@@ -902,7 +1039,7 @@ function ScoringMechanicsNote({ edition }) {
  * stamp that means "scored", and an empty card would imply a verdict nobody
  * has reached.
  */
-function LeadScoreCard({ prospect, campaignName, hasPersonCard }) {
+function LeadScoreCard({ prospect, campaignName, campaignId, hasPersonCard }) {
   const bd = prospect?.scoreBreakdown || null;
   if (!bd || prospect.scoredConfigVersion == null) return null;
   const stamp = [
@@ -945,6 +1082,12 @@ function LeadScoreCard({ prospect, campaignName, hasPersonCard }) {
       <ScoreComponents breakdown={bd} />
 
       <ScoreEvents events={bd.events} scoredAt={prospect.scoreComputedAt} />
+
+      <CampaignSheetPeek
+        edition={prospect.scoredConfigVersion}
+        breakdown={bd}
+        campaignId={campaignId}
+      />
 
       <ScoringMechanicsNote edition={prospect.scoredConfigVersion} />
     </Card>
@@ -1692,6 +1835,7 @@ export default function AdminV2LeadProfile() {
               <LeadScoreCard
                 prospect={p}
                 campaignName={currentSignup?.campaign?.name || p.campaign?.name || null}
+                campaignId={currentSignup?.campaign?.id || p.campaign?.id || null}
                 hasPersonCard={Boolean(journey?.enrichment)}
               />
             )}

--- a/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
+++ b/src/pages/adminv2/__tests__/AdminV2LeadProfile.test.jsx
@@ -13,6 +13,7 @@ import AdminV2LeadProfile from '../AdminV2LeadProfile';
 
 vi.mock('@/api/adminV2', () => ({
   fetchProspectProfile: vi.fn(),
+  fetchScoringEdition: vi.fn(),
   fetchAgentOptions: vi.fn(async () => [{ id: 'agent-1', name: 'Marcus Wong' }]),
   bulkAssign: vi.fn(async () => ({ data: { affectedCount: 1 } })),
   bulkReturnToHeld: vi.fn(),
@@ -23,7 +24,7 @@ vi.mock('@/api/adminV2', () => ({
   })),
 }));
 
-import { fetchProspectProfile, bulkAssign, bulkReturnToHeld, bulkDelete, fetchConsentCopy } from '@/api/adminV2';
+import { fetchProspectProfile, fetchScoringEdition, bulkAssign, bulkReturnToHeld, bulkDelete, fetchConsentCopy } from '@/api/adminV2';
 
 const PROFILE = {
   id: 'p1',
@@ -826,5 +827,93 @@ describe('lead score breakdown (drill-in)', () => {
     setup();
     await screen.findByText(/This person was erased/);
     expect(screen.queryByText('Lead score')).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * The sheet peek: THIS campaign's customised metrics on the lead — the exact
+ * EDITION the stamp names, fetched lazily, never the currently-resolved sheet.
+ */
+describe('campaign sheet peek (drill-in)', () => {
+  const EDITION_3 = {
+    version: 3,
+    status: 'approved',
+    configJson: {
+      components: {
+        engagement: { maxPoints: 15 }, contactability: { maxPoints: 10 }, market_fit: { maxPoints: 15 },
+        life_events: { maxPoints: 25 }, family_gap: { maxPoints: 20 }, capacity: { maxPoints: 15 },
+        age: { maxPoints: 10 }, coverage_headroom: { maxPoints: -10 },
+      },
+      leadComponents: { response: { maxPoints: 10 }, screening: { maxPoints: 40 } },
+      ageCurve: [
+        { upTo: 24, value: 0.25 }, { upTo: 29, value: 0.55 }, { upTo: 34, value: 0.8 },
+        { upTo: 44, value: 1 }, { upTo: 49, value: 0.8 }, { upTo: 59, value: 0.55 }, { upTo: null, value: 0.3 },
+      ],
+      targetSegments: [{ language: 'zh', ethnicity: 'chinese', weight: 1 }],
+    },
+    houseDefault: {
+      components: {
+        engagement: { maxPoints: 15 }, contactability: { maxPoints: 10 }, market_fit: { maxPoints: 15 },
+        life_events: { maxPoints: 25 }, family_gap: { maxPoints: 20 }, capacity: { maxPoints: 15 },
+        age: { maxPoints: 10 }, coverage_headroom: { maxPoints: -10 },
+      },
+      leadComponents: { response: { maxPoints: 15 }, screening: { maxPoints: 20 } },
+    },
+  };
+  const SCORED_LEAD = () => {
+    const d = JSON.parse(JSON.stringify(PROFILE));
+    Object.assign(d.consumer.signups[0], { score: 48, scoredAt: '2026-07-27T16:14:35Z' });
+    return Object.assign(d, {
+      score: 48, meetScore: 50, buyScore: 16,
+      scoredConfigVersion: 3, scoringAlgorithmVersion: 'lead/v1',
+      scoreComputedAt: '2026-07-27T16:14:35Z',
+      scoreBreakdown: {
+        groups: { meet: { components: ['screening'] }, buy: { components: ['age'] } },
+        components: {
+          screening: { state: 'assessed', points: 40, maxPoints: 40 },
+          age: { state: 'assessed', points: 6.5, maxPoints: 10 },
+        },
+        completeness: { assessed: 2, total: 10 },
+        events: [],
+      },
+    });
+  };
+
+  it('is lazy: named collapsed with the edition, nothing fetched until opened', async () => {
+    fetchProspectProfile.mockResolvedValue(SCORED_LEAD());
+    setup();
+    await screen.findByText('Lead score');
+    expect(screen.getByText("This campaign's scoring sheet")).toBeInTheDocument();
+    expect(fetchScoringEdition).not.toHaveBeenCalled();
+  });
+
+  it('opens to the EDITION document: weights vs house with deviation markers, curve peak, target market', async () => {
+    fetchProspectProfile.mockResolvedValue(SCORED_LEAD());
+    fetchScoringEdition.mockResolvedValue(EDITION_3);
+    setup();
+    await screen.findByText('Lead score');
+    fireEvent.click(screen.getByText("This campaign's scoring sheet"));
+
+    await waitFor(() => expect(fetchScoringEdition).toHaveBeenCalledWith(3));
+    // The one big bet, marked: screening 40 vs house 20. ('40' also appears
+    // as the breakdown row's points, so the MARKER is the unique assertion.)
+    expect(await screen.findByText(/↑ \+20/)).toBeInTheDocument();
+    // The trim too: response 10 vs house 15.
+    expect(screen.getByText(/↓ -5/)).toBeInTheDocument();
+    // The curve as a sentence, not a JSON dump.
+    expect(screen.getByText('35–44')).toBeInTheDocument();
+    // Target market row + the door back to the editor.
+    expect(screen.getByText(/Mandarin \/ chinese/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Tune this sheet on the campaign page/ }))
+      .toHaveAttribute('href', '/admin/campaigns/camp-1');
+  });
+
+  it('a failed edition read falls back to the breakdown’s own maxima, stated plainly', async () => {
+    fetchProspectProfile.mockResolvedValue(SCORED_LEAD());
+    fetchScoringEdition.mockRejectedValue(new Error('nope'));
+    setup();
+    await screen.findByText('Lead score');
+    fireEvent.click(screen.getByText("This campaign's scoring sheet"));
+    expect(await screen.findByText(/the weights in the breakdown above/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What

The follow-up to #328: not the generic mechanics — the **actual customised rulebook** that graded this lead, on the lead page.

A lazy **"This campaign's scoring sheet — EDITION #N"** disclosure on the drill-in's Lead score card:

- fetches **the edition the stamp names** on first open — never the currently-resolved sheet (the campaign may have moved on; old points must not be captioned with new rules)
- every weight beside its house value with ↑/↓ deviation markers — edition #5 reads *"screening call 40 · house 20 ↑ +20"* at a glance
- the age dial as a sentence ("full weight at ages 35–44, ramping down outside")
- target market rows + **"Tune this sheet on the campaign page →"**
- failed edition read degrades honestly: the breakdown's own "/N" maxima are the applied weights, and the fallback says so

`GET /:version` grows the same server-owned `houseDefault` DTO the strict resolve serves, so the ghosts are never a frontend twin.

## Tests

Lazy-until-opened, both deviation directions, curve sentence, target row, campaign link, failed-read fallback + the route's houseDefault pin. LeadProfile 53 · adminv2 145 · routes 26 — green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENWdGMue9uXqmKv3pRG6YF