### PR TITLE
feat(scoring): rescore now + scoring born at creation (Phases 1.5 + 2)

### DIFF
--- a/backend/src/routes/scoringConfigs.js
+++ b/backend/src/routes/scoringConfigs.js
@@ -10,8 +10,8 @@ import { DEFAULT_SCORING_CONFIG, DEFAULT_LEAD_COMPONENTS, normalizeConfig } from
 import { sequelize } from '../models/index.js';
 import {
   listScoringConfigs, getScoringConfig, createDraftConfig, approveScoringConfig,
-  simulateConfig, proposeScoringConfig, scoringProgressForCampaign, MAX_DESCRIPTION_CHARS,
-  SIMULATION_SAMPLE_MAX,
+  simulateConfig, proposeScoringConfig, scoringProgressForCampaign, rescoreCampaignNow,
+  MAX_DESCRIPTION_CHARS, SIMULATION_SAMPLE_MAX,
 } from '../services/scoringConfigService.js';
 
 /**
@@ -223,6 +223,17 @@ router.post('/propose', validate(proposeSchema), asyncHandler(async (req, res) =
     actorUserId: req.user?.id || null,
   });
   res.status(201).json({ success: true, data: result });
+}));
+
+/**
+ * Rescore-now (Phase 1.5): the campaign's stale leads, re-graded inside this
+ * one response — bounded by rows AND time; whatever is left belongs to the
+ * sweep or another press. Registered before the /:version subtree like every
+ * other single-segment POST.
+ */
+const rescoreSchema = Joi.object({ campaignId: uuid.required() });
+router.post('/rescore', validate(rescoreSchema), asyncHandler(async (req, res) => {
+  res.json({ success: true, data: await rescoreCampaignNow(req.body.campaignId) });
 }));
 
 /**

--- a/backend/src/services/leadScoringService.js
+++ b/backend/src/services/leadScoringService.js
@@ -368,7 +368,10 @@ const RESOLVED_VERSION_SQL = `COALESCE(
  * Hash-level staleness (facts moved, config didn't) is NOT expressible in
  * SQL; that is what the sweep's rotation is for.
  */
-export async function findStaleLeadIds({ limit = 200, afterId = null } = {}) {
+export async function findStaleLeadIds({ limit = 200, afterId = null, campaignId = null } = {}) {
+  // `campaignId` narrows the SAME predicate to one campaign — rescore-now
+  // (campaign-scoring-editor Phase 1.5) must agree with the sweep about what
+  // "stale" means, so it filters this query rather than writing its own.
   const [rows] = await sequelize.query(
     `SELECT p.id
        FROM prospects p
@@ -376,6 +379,7 @@ export async function findStaleLeadIds({ limit = 200, afterId = null } = {}) {
        LEFT JOIN campaigns cam ON cam.id = p."campaignId"
       WHERE (p."consumerId" IS NULL OR c."erasedAt" IS NULL)
         AND (:afterId::uuid IS NULL OR p.id > :afterId::uuid)
+        AND (:campaignId::uuid IS NULL OR p."campaignId" = :campaignId)
         AND (
           p."scoreComputedAt" IS NULL
           OR p."scoreDirtyAt" IS NOT NULL
@@ -385,7 +389,7 @@ export async function findStaleLeadIds({ limit = 200, afterId = null } = {}) {
       ORDER BY p.id
       LIMIT :limit`,
     {
-      replacements: { algorithmVersion: LEAD_ALGORITHM_VERSION, limit, afterId },
+      replacements: { algorithmVersion: LEAD_ALGORITHM_VERSION, limit, afterId, campaignId },
     }
   );
   return rows.map((r) => r.id);

--- a/backend/src/services/scoringConfigService.js
+++ b/backend/src/services/scoringConfigService.js
@@ -4,7 +4,9 @@ import { logger } from '../utils/logger.js';
 import { getRuntimeAiSettings } from './aiSettingsService.js';
 import { requestStructuredJson } from './guidedReviewAiService.js';
 import { getActiveScoringConfig, resolveScoringConfigStrict } from './consumerScoringService.js';
-import { loadLeadTelemetry, loadLeadObservations } from './leadScoringService.js';
+import {
+  loadLeadTelemetry, loadLeadObservations, findStaleLeadIds, scoreOneLead,
+} from './leadScoringService.js';
 import { bustScoringConfigCache } from './scoringConfigCache.js';
 import { resolveCurrentFacts } from '../utils/factResolver.js';
 import {
@@ -573,6 +575,95 @@ export async function simulateConfig({
       becameNull,
       becameScored,
     },
+  };
+}
+
+// ─────────────────────────── rescore now (Phase 1.5) ───────────────────────
+
+/** Rescore-now is a REQUEST, not a job system — both bounds keep it inside
+ *  one honest HTTP response. Whatever is left stays stale-marked and belongs
+ *  to the nightly sweep (or another press of the button). */
+export const RESCORE_NOW_MAX = 500;
+const RESCORE_NOW_DEADLINE_MS = 25_000;
+
+/**
+ * "See the new sheet's numbers now, not after 2am." Synchronous and DOUBLY
+ * bounded (rows + time) — the M10 review killed the outbox/job design, and a
+ * response that says exactly how far it got beats a toast pointing at a job
+ * id. Selection reuses findStaleLeadIds' predicate verbatim (campaign-
+ * filtered), so this and the sweep can never disagree about what needed
+ * doing; scoring goes through scoreOneLead, so every write takes the same
+ * consumer fence and the same write-gate as the sweep's.
+ *
+ * The cache is busted FIRST: the M7 race (a worker scoring under a config
+ * cached moments before an approve) self-heals via version-mismatch
+ * staleness, but the whole point of this button is "the sheet I just
+ * approved" — starting from a warm stale cache would rescore onto the OLD
+ * edition and report success.
+ */
+export async function rescoreCampaignNow(campaignId, {
+  limit = RESCORE_NOW_MAX, deadlineMs = RESCORE_NOW_DEADLINE_MS, now = Date.now,
+} = {}) {
+  // The clock starts HERE — lookup and selection spend the same budget the
+  // scoring loop does, or a slow selection could push the response past the
+  // advertised bound before a single lead was admitted. The bound's honest
+  // shape: no NEW lead is admitted after the deadline; the one in flight may
+  // overrun it (per-lead transactions, no cancellation) — that is the widest
+  // overrun possible, one lead, not a tail of them.
+  const startedAt = now();
+  if (!campaignId) throw new AppError('campaignId is required.', 422);
+  const [[campaign]] = await sequelize.query(
+    'SELECT 1 AS ok FROM campaigns WHERE id = :cid',
+    { replacements: { cid: campaignId } }
+  );
+  if (!campaign) throw new AppError('Campaign not found.', 422);
+
+  bustScoringConfigCache();
+
+  // DELIBERATELY NOT taking the nightly sweep's advisory lock (review B4):
+  // the sweep TRY-locks and skips its run when the lock is held, so holding
+  // it here for up to 25s at exactly 02:00 could cost the whole night. The
+  // accepted overlap cost runs the other way and is bounded: if both select
+  // the same rows, the second scorer's write-gate answers `unchanged` with
+  // no write — a few budget rows spent re-checking, never corruption.
+  const cap = Math.min(RESCORE_NOW_MAX, Math.max(1, limit));
+  // One extra row is the whole evidence for "there are more than the cap" —
+  // the populationFor pattern.
+  const ids = await findStaleLeadIds({ campaignId, limit: cap + 1 });
+  const overCap = ids.length > cap;
+  const queue = ids.slice(0, cap);
+  let rescored = 0;
+  let unchanged = 0;
+  let skipped = 0;
+  let examined = 0;
+  for (const id of queue) {
+    if (now() - startedAt >= deadlineMs) break;
+    examined += 1;
+    // Sequential ON PURPOSE: every rescore takes that lead's consumer fence;
+    // a pool here would just queue on the locks while holding HTTP open.
+    const result = await scoreOneLead(id, { now: now() });
+    if (result.status === 'scored') rescored += 1;
+    else if (result.status === 'unchanged') unchanged += 1;
+    else skipped += 1;
+  }
+
+  const remaining = queue.length - examined;
+  logger.info(
+    { campaignId, examined, rescored, unchanged, skipped, remaining, more: overCap, ms: now() - startedAt },
+    'scoring.rescore_now'
+  );
+  return {
+    examined,
+    rescored,
+    unchanged,
+    skipped,
+    // NO SILENT CAPS: `remaining` is what the deadline left un-examined of
+    // this batch; `more` says the campaign held more stale leads than the cap
+    // could even LIST. Either way the card says "press again or let tonight's
+    // sweep finish" instead of presenting a slice as done.
+    remaining,
+    more: overCap,
+    complete: remaining === 0 && !overCap,
   };
 }
 

--- a/backend/test/scoringConfigAuthoring.test.js
+++ b/backend/test/scoringConfigAuthoring.test.js
@@ -6,6 +6,7 @@ import { sequelize, Consumer, Prospect } from '../src/models/index.js'
 import {
   createDraftConfig, approveScoringConfig, simulateConfig, proposeScoringConfig,
   listScoringConfigs, getScoringConfig, sanitizeDescription, MAX_DESCRIPTION_CHARS,
+  rescoreCampaignNow,
 } from '../src/services/scoringConfigService.js'
 import {
   getActiveScoringConfig, resolveScoringConfigStrict, _resetConfigCache,
@@ -622,5 +623,82 @@ describe('§4.8 regrade progress is the complement of the sweep, never a version
     expect(p.resolvedVersion).toBe(g.version)
     expect(p.complete).toBe(false)
     expect(String(c.id)).toBeTruthy()
+  })
+})
+
+describe('Phase 1.5 rescore-now: same-day, bounded, sweep-agreeing', () => {
+  const freshCampaign = () => createTestCampaign(admin.id, {
+    name: `Rescore ${Date.now()}-${seq += 1}`,
+    targetAudience: { objective: 'agent_leads', product: 'insurance' },
+  })
+
+  test('re-grades ONLY the target campaign onto the freshly-approved edition — no manual cache reset', async () => {
+    const g = await createDraftConfig({ config: configWith(3) })
+    await approveLive(g.version)
+    const campA = await freshCampaign()
+    const campB = await freshCampaign()
+    const a = await leadOn(campA)
+    const b = await leadOn(campB)
+    await scoreOneLead(a.id, { force: true })
+    await scoreOneLead(b.id, { force: true })
+
+    // A campaign-scoped edition for A: its lead goes stale, B's stays current.
+    const draft = await createDraftConfig({ config: configWith(9), campaignId: campA.id })
+    await approveScoringConfig(draft.version, { expectedLiveVersion: g.version })
+
+    // Deliberately NO _resetConfigCache() here. HONESTY NOTE (review B5):
+    // in ONE process, approve's own bust already cleared the map, so this
+    // test cannot distinguish rescore's bust from approve's — rescore's
+    // exists for the OTHER processes (web vs cron) where approve's bust
+    // never ran, which no single-process test can exercise. What this test
+    // DOES pin: the whole chain lands the fresh edition with no manual
+    // cache intervention anywhere.
+    const res = await rescoreCampaignNow(campA.id)
+    expect(res.rescored).toBe(1)
+    expect(res.complete).toBe(true)
+
+    const [[rowA]] = await sequelize.query(
+      'SELECT "scoredConfigVersion" FROM prospects WHERE id = :id', { replacements: { id: a.id } }
+    )
+    const [[rowB]] = await sequelize.query(
+      'SELECT "scoredConfigVersion" FROM prospects WHERE id = :id', { replacements: { id: b.id } }
+    )
+    expect(rowA.scoredConfigVersion).toBe(draft.version)
+    expect(rowB.scoredConfigVersion).toBe(g.version)
+  })
+
+  test('the row cap is honest: examined stops at the cap and `more` says the list was longer', async () => {
+    const g = await createDraftConfig({ config: configWith(3) })
+    await approveLive(g.version)
+    const camp = await freshCampaign()
+    await leadOn(camp)
+    await leadOn(camp)
+    // Never-scored leads ARE stale — same predicate as the sweep.
+    const res = await rescoreCampaignNow(camp.id, { limit: 1 })
+    expect(res.examined).toBe(1)
+    expect(res.more).toBe(true)
+    expect(res.complete).toBe(false)
+  })
+
+  test('the deadline stops the loop MID-QUEUE and reports the leftover — a real clock, not a zero', async () => {
+    const g = await createDraftConfig({ config: configWith(3) })
+    await approveLive(g.version)
+    const camp = await freshCampaign()
+    await leadOn(camp)
+    await leadOn(camp)
+    // An injected monotonic clock: every observation advances 10 "seconds",
+    // so the 25s budget survives exactly the first lead's admission check
+    // and expires before the second's — deterministic, no sleeps.
+    let tick = 0
+    const fakeNow = () => { tick += 10_000; return tick }
+    const res = await rescoreCampaignNow(camp.id, { now: fakeNow, deadlineMs: 25_000 })
+    expect(res.examined).toBe(1)
+    expect(res.remaining).toBe(1)
+    expect(res.complete).toBe(false)
+  })
+
+  test('an unknown campaign is a 422 sentence, not a silent empty run', async () => {
+    await expect(rescoreCampaignNow('00000000-0000-4000-8000-000000000002'))
+      .rejects.toThrow(/Campaign not found/)
   })
 })

--- a/backend/test/scoringConfigRoutes.test.js
+++ b/backend/test/scoringConfigRoutes.test.js
@@ -348,3 +348,19 @@ describe("simulate's compareTo rides the route", () => {
     expect(res.body.data).toHaveProperty('stored')
   })
 })
+
+describe('POST /rescore (Phase 1.5)', () => {
+  test('runs bounded and reports the honest counts', async () => {
+    const res = await asAdmin(request(app).post(`${meta.path}/rescore`))
+      .send({ campaignId: campaign.id })
+    expect(res.status).toBe(200)
+    expect(res.body.data).toHaveProperty('rescored')
+    expect(res.body.data).toHaveProperty('remaining')
+    expect(res.body.data).toHaveProperty('complete')
+  })
+
+  test('campaignId is required and must be a UUID', async () => {
+    expect((await asAdmin(request(app).post(`${meta.path}/rescore`)).send({})).status).toBe(400)
+    expect((await asAdmin(request(app).post(`${meta.path}/rescore`)).send({ campaignId: 'nope' })).status).toBe(400)
+  })
+})

--- a/docs/plans/campaign-scoring-editor.md
+++ b/docs/plans/campaign-scoring-editor.md
@@ -340,8 +340,8 @@ single authority.
 | Phase | Ships |
 |---|---|
 | **1** | Editor + campaign card + history + §4.1–4.8 + tests |
-| **1.5** | Rescore-now (bounded, explicit button; re-resolves version inside the fence; M7 race self-heals via version-mismatch staleness) |
-| **2** | Creation-time block (both surfaces) + duplicate-flow note + optional `discarded` status migration |
+| **1.5** | Rescore-now (SHIPPED 2026-07-31): POST /rescore — cache-busted, campaign-filtered via findStaleLeadIds' own predicate (sweep-agreeing by construction), scoreOneLead per row under a row cap (500) AND a 25s deadline, honest {examined, rescored, remaining, more} response; card button on the progress line. M7 hardening = the up-front cache bust; residual races self-heal via version-mismatch staleness |
+| **2** | Creation-time block (SHIPPED 2026-07-31, both surfaces): CreateScoringBlock under the brief — strict product-tier resolve line, "Tailor scoring →" opens the shared editor prefilled from the brief picks (bands → ladder curve, language → segment; seed-once), "apply immediately" approves with the pre-create baseline as expectedLiveVersion; both create flows AWAIT submit(campaignId) before navigating, failures toast + navigate (creation never blocked); untouched block mints nothing; 404 → neutral line + no-op. Duplicate-flow note + optional `discarded` migration remain future |
 | **1.6** | AI-propose button (SHIPPED 2026-07-31): "Draft with AI" on the card — optional steer sentence → /propose reads the brief and writes the sheet → the SAME draft/preview/approve gates; card re-simulates compareTo:'resolved' (never the propose response's stored-comparison sim) and renders the rationale; ANY edit invalidates the pending draft so approve can never ship a pre-edit doc |
 | out | Product/global sheet screens · decay knobs · batch preview loaders unless §4.3's budget trips · agent-facing anything |
 

--- a/src/api/adminV2.js
+++ b/src/api/adminV2.js
@@ -348,3 +348,21 @@ export async function proposeScoringSheet(campaignId, description = '') {
   });
   return resp?.data ?? null;
 }
+
+/** Rescore-now (Phase 1.5): re-grade this campaign's stale leads inside one
+ *  bounded request. The response says exactly how far it got — `remaining`
+ *  and `more` are the honest leftovers for another press or the sweep. */
+export async function rescoreCampaignScoring(campaignId) {
+  const resp = await apiClient.post('/admin/scoring-configs/rescore', { campaignId });
+  return resp?.data ?? null;
+}
+
+/** Pre-create resolve (Phase 2): what a NEW campaign with this product would
+ *  score under — no campaign id exists yet, so the walk starts at the
+ *  product tier (or global when no product is picked). Strict, like every
+ *  editor read. */
+export async function fetchScoringSheetForProduct(productKey) {
+  const qs = productKey ? `productKey=${encodeURIComponent(productKey)}&strict=1` : 'strict=1';
+  const resp = await apiClient.get(`/admin/scoring-configs/resolve?${qs}`);
+  return resp?.data ?? null;
+}

--- a/src/components/adminv2/CampaignScoringCard.jsx
+++ b/src/components/adminv2/CampaignScoringCard.jsx
@@ -16,45 +16,14 @@ import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useScoringSheet, useScoringHistory, useScoringProgress } from '@/hooks/queries/useAdminV2';
-import { createScoringDraft, simulateScoringDraft, approveScoringDraft, fetchScoringEdition, proposeScoringSheet } from '@/api/adminV2';
+import { createScoringDraft, simulateScoringDraft, approveScoringDraft, fetchScoringEdition, proposeScoringSheet, rescoreCampaignScoring } from '@/api/adminV2';
 import { Card, Chip, Skeleton, ErrorState } from '@/components/adminv2/primitives';
 import { fmtDateTime } from '@/lib/adminV2/format';
 import ScoringSheetEditor from '@/components/adminv2/ScoringSheetEditor';
-import { EXPOSED_COMPONENTS, weightOf } from '@/lib/adminV2/scoringLabels';
+import { TIER_LABEL, patchFromDoc, docFromSheet } from '@/lib/adminV2/scoringLabels';
 
-const TIER_LABEL = {
-  campaign: 'campaign sheet',
-  product: 'product sheet',
-  global: 'house sheet',
-  default: 'house default',
-};
-
-/** The full exposed set as a patch — the editor always writes every exposed
- *  knob (§4.1: exposed knobs never float), UI-only keys stripped. */
-function patchFromDoc(doc, houseDefault) {
-  const components = {};
-  const leadComponents = {};
-  for (const comp of EXPOSED_COMPONENTS) {
-    const value = weightOf(doc, comp) ?? weightOf(houseDefault, comp) ?? 0;
-    (comp.leadGrain ? leadComponents : components)[comp.name] = { maxPoints: value };
-  }
-  const patch = { components, leadComponents };
-  if (Array.isArray(doc?.ageCurve) && doc.ageCurve.length) patch.ageCurve = doc.ageCurve;
-  if (Array.isArray(doc?.targetSegments)) patch.targetSegments = doc.targetSegments;
-  return patch;
-}
-
-/** Seed the editor from the strict resolve: effective values only. */
-function docFromSheet(sheet) {
-  const cfg = sheet?.config || {};
-  return {
-    components: { ...(cfg.components || {}) },
-    leadComponents: { ...(cfg.leadComponents || {}) },
-    ageCurve: Array.isArray(cfg.ageCurve) ? cfg.ageCurve.map((s) => ({ ...s })) : [],
-    targetSegments: Array.isArray(cfg.targetSegments) ? cfg.targetSegments.map((s) => ({ ...s })) : [],
-    _ageBands: [],
-  };
-}
+// TIER_LABEL / patchFromDoc / docFromSheet moved to @/lib/adminV2/scoringLabels
+// — shared with the create-flow scoring block (Phase 2).
 
 function PreviewPanel({ sim }) {
   if (!sim) return null;
@@ -161,6 +130,18 @@ export default function CampaignScoringCard({ campaignId }) {
     onError: (e) => toast.error(e?.message || 'The AI author is unavailable — check AI Settings, or edit manually'),
   });
 
+  const rescore = useMutation({
+    mutationFn: () => rescoreCampaignScoring(campaignId),
+    onSuccess: (r) => {
+      const bits = [`Re-graded ${r.rescored} lead${r.rescored === 1 ? '' : 's'}`];
+      if (r.unchanged) bits.push(`${r.unchanged} already current`);
+      if (r.remaining > 0 || r.more) bits.push(`${r.more ? 'more' : r.remaining} still queued — press again or let tonight's sweep finish`);
+      toast.success(bits.join(' · '));
+      invalidate();
+    },
+    onError: (e) => toast.error(e?.message || 'Rescore failed — the nightly sweep will still catch up'),
+  });
+
   const approve = useMutation({
     mutationFn: ({ version }) => approveScoringDraft(version, baseline ?? sheet.data?.version ?? 0),
     onSuccess: (res) => {
@@ -263,11 +244,23 @@ export default function CampaignScoringCard({ campaignId }) {
           </div>
         )}
 
-        {/* Regrade progress — visible only while the sweep still owes leads. */}
+        {/* Regrade progress — visible only while the sweep still owes leads.
+            "Rescore now" (Phase 1.5) is the same-day alternative to waiting
+            for 2am: bounded, honest about leftovers, safe to press again. */}
         {p && !p.complete && (
-          <div style={{ marginTop: 8, fontSize: 12, color: 'var(--ink-2)' }} data-testid="scoring-progress">
-            Regrading: <span className="av2-mono" style={{ fontWeight: 700 }}>{p.current} of {p.total}</span> leads
-            are on edition #{p.resolvedVersion} — the rest roll through the nightly runs.
+          <div style={{ marginTop: 8, fontSize: 12, color: 'var(--ink-2)', display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }} data-testid="scoring-progress">
+            <span>
+              Regrading: <span className="av2-mono" style={{ fontWeight: 700 }}>{p.current} of {p.total}</span> leads
+              are on edition #{p.resolvedVersion}.
+            </span>
+            <button
+              type="button" className="av2-btn av2-btn--sm"
+              disabled={rescore.isPending}
+              title="Re-grade this campaign's stale leads now instead of waiting for the nightly run"
+              onClick={() => rescore.mutate()}
+            >
+              {rescore.isPending ? 'Rescoring…' : 'Rescore now'}
+            </button>
           </div>
         )}
 

--- a/src/components/adminv2/CreateScoringBlock.jsx
+++ b/src/components/adminv2/CreateScoringBlock.jsx
@@ -1,0 +1,188 @@
+/**
+ * The creation-time scoring block (campaign-scoring-editor §3.3, Phase 2).
+ *
+ * Sits under the brief fields on BOTH create surfaces. Always says which
+ * sheet a new campaign with these picks would score under (pre-create there
+ * is no campaign id, so the strict resolve starts at the PRODUCT tier);
+ * "Tailor scoring →" opens the shared editor prefilled from the brief's own
+ * picks — age bands become the dial's curve, a specific language becomes the
+ * target segment (seed-once: later brief edits never overwrite the doc).
+ *
+ * The parent create flow calls `ref.submit(campaignId)` AFTER the campaign
+ * row commits and AWAITS it before navigating (§3.3's ordering): untouched →
+ * nothing is minted and it resolves null; tailored → a draft composed
+ * server-side, approved in the same breath when "apply immediately" is
+ * ticked. Errors THROW — the caller toasts and navigates anyway, because
+ * scoring must never block creation.
+ *
+ * Flag-off backends 404 the resolve; the block degrades to one neutral line
+ * and submit() becomes a no-op.
+ */
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+  fetchScoringSheetForProduct, createScoringDraft, approveScoringDraft,
+} from '@/api/adminV2';
+import ScoringSheetEditor from '@/components/adminv2/ScoringSheetEditor';
+import {
+  TIER_LABEL, patchFromDoc, docFromSheet, buildAgeCurveFromBands,
+} from '@/lib/adminV2/scoringLabels';
+
+/** One bound per call — the client's fetch carries no signal of its own. */
+const SUBMIT_TIMEOUT_MS = 30_000;
+
+const CreateScoringBlock = forwardRef(function CreateScoringBlock({ product, ageBands, language }, ref) {
+  const sheet = useQuery({
+    queryKey: ['adminV2', 'scoringSheetSeed', product || 'global'],
+    queryFn: () => fetchScoringSheetForProduct(product || null),
+    staleTime: 30_000,
+    retry: (count, err) => err?.status !== 404 && count < 2,
+  });
+  const [open, setOpen] = useState(false);
+  const [doc, setDoc] = useState(null);
+  const [applyNow, setApplyNow] = useState(true);
+  // The baseline CAPTURED WHEN TAILORING OPENED (review M3): submit must
+  // carry the version the admin actually saw beside the document they
+  // edited — reading the live query at submit time would let a background
+  // refetch or a product-pick change advance the expected version under an
+  // old-product document, and the §4.5 guard would wave through an approve
+  // it exists to 409.
+  const seededRef = useRef(null);
+
+  const unavailable = sheet.isError && sheet.error?.status === 404;
+
+  const seed = () => {
+    const base = docFromSheet(sheet.data);
+    // The brief already answered the audience questions — prefill, don't
+    // re-ask. Deterministic and slope-legal by construction (§3.1).
+    const curve = buildAgeCurveFromBands(ageBands || []);
+    if (curve) {
+      base.ageCurve = curve;
+      base._ageBands = [...ageBands];
+    }
+    if (language === 'any') {
+      // An EXPLICIT "any language" clears inherited targeting — keeping a
+      // Chinese-targeted market_fit under an any-language brief contradicts
+      // the pick (review B2). Unanswered stays "no prefill": inherit.
+      base.targetSegments = [];
+    } else if (language) {
+      base.targetSegments = [{ language, weight: 1 }];
+    }
+    seededRef.current = {
+      version: sheet.data?.version ?? 0,
+      houseDefault: sheet.data?.houseDefault,
+    };
+    return base;
+  };
+
+  useImperativeHandle(ref, () => ({
+    /** Mint (and optionally activate) the tailored sheet for the campaign
+     *  that was JUST created. Untouched block → null, nothing written.
+     *  THROWS on failure — with `draftVersion` attached when the draft
+     *  landed but activation did not, so callers can say which half. */
+    async submit(campaignId) {
+      // SNAPSHOT EVERYTHING BEFORE THE FIRST AWAIT (round-2 M1): the page
+      // stays interactive during the awaits — "Skip tailoring" nulls the
+      // ref and a reopen replaces it — so every later read must come from
+      // these captures, never from live state.
+      const seeded = seededRef.current;
+      const submittedDoc = doc;
+      const apply = applyNow;
+      if (!campaignId || unavailable || !open || !submittedDoc || !seeded) return null;
+      // The apiClient declares a timeout it never attaches to fetch (review
+      // M2) — without our own bound a stalled call would hold the create
+      // flow's navigation hostage forever.
+      const withTimeout = (promise, label) => Promise.race([
+        promise,
+        new Promise((_, reject) => {
+          setTimeout(() => reject(new Error(`${label} did not confirm within 30s — check the campaign page's scoring card.`)), SUBMIT_TIMEOUT_MS);
+        }),
+      ]);
+      const draft = await withTimeout(
+        createScoringDraft(campaignId, patchFromDoc(submittedDoc, seeded.houseDefault)),
+        'Saving the scoring sheet'
+      );
+      if (apply) {
+        try {
+          await withTimeout(
+            approveScoringDraft(draft.version, seeded.version),
+            'Activating the scoring sheet'
+          );
+        } catch (err) {
+          // Partial success is a DIFFERENT message (review B3): the draft
+          // exists — a blind retry would mint a duplicate. NOTE the copy is
+          // "didn't confirm", not "not applied" (round-2 B1): a timed-out
+          // race leaves the request running, and a slow approve may still
+          // land after this rejection.
+          const e = err instanceof Error ? err : new Error('Activation failed');
+          e.draftVersion = draft.version;
+          throw e;
+        }
+      }
+      return draft;
+    },
+  }), [open, doc, applyNow, unavailable]);
+
+  if (unavailable) {
+    // Neutral by contract (review B1): the flag gates AUTHORING, not
+    // resolution — approved sheets keep scoring — and a 404 cannot even
+    // distinguish the flag from an old deploy. Claim nothing.
+    return (
+      <div style={{ marginTop: 14, fontSize: 12, color: 'var(--ink-3)' }}>
+        Lead scoring: controls are unavailable on this backend.
+      </div>
+    );
+  }
+
+  const s = sheet.data;
+  return (
+    <div style={{ marginTop: 14, borderTop: '1px solid var(--line)', paddingTop: 10 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        <span className="av2-microcaps">Lead scoring</span>
+        <span style={{ fontSize: 12.5, color: 'var(--ink-2)' }}>
+          {sheet.isLoading
+            ? 'checking which rules apply…'
+            : s
+              ? <>Leads will score with the <span style={{ fontWeight: 700, color: 'var(--ink)' }}>{TIER_LABEL[s.scope] || s.scope}</span>{s.version > 0 ? ` (edition #${s.version})` : ''}.</>
+              : 'scoring rules unavailable right now.'}
+        </span>
+        {s && !open && (
+          <button
+            type="button" className="av2-btn av2-btn--sm"
+            onClick={() => { setDoc(seed()); setOpen(true); }}
+          >
+            Tailor scoring for this campaign →
+          </button>
+        )}
+        {open && (
+          <button
+            type="button" className="av2-btn av2-btn--sm"
+            title="Drop the tailored sheet — the campaign will inherit instead"
+            onClick={() => { setOpen(false); setDoc(null); seededRef.current = null; }}
+          >
+            Skip tailoring
+          </button>
+        )}
+      </div>
+
+      {open && doc && (
+        <div style={{ marginTop: 10 }}>
+          <ScoringSheetEditor doc={doc} houseDefault={s?.houseDefault} onChange={setDoc} />
+          <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6, marginTop: 10, fontSize: 12.5, color: 'var(--ink-2)', cursor: 'pointer' }}>
+            <input
+              type="checkbox"
+              checked={applyNow}
+              onChange={(e) => setApplyNow(e.target.checked)}
+            />
+            Apply immediately on create (otherwise it waits as a draft on the campaign page)
+          </label>
+          <div style={{ fontSize: 11, color: 'var(--ink-3)', marginTop: 4 }}>
+            Saved as this campaign's own sheet when you create — other campaigns are untouched.
+          </div>
+        </div>
+      )}
+    </div>
+  );
+});
+
+export default CreateScoringBlock;

--- a/src/components/adminv2/__tests__/CampaignScoringCard.test.jsx
+++ b/src/components/adminv2/__tests__/CampaignScoringCard.test.jsx
@@ -19,12 +19,14 @@ vi.mock('@/api/adminV2', () => ({
   simulateScoringDraft: vi.fn(),
   approveScoringDraft: vi.fn(),
   proposeScoringSheet: vi.fn(),
+  rescoreCampaignScoring: vi.fn(),
 }));
 
 import { toast } from 'sonner';
 import {
   fetchScoringSheet, fetchScoringHistory, fetchScoringProgress, fetchScoringEdition,
   createScoringDraft, simulateScoringDraft, approveScoringDraft, proposeScoringSheet,
+  rescoreCampaignScoring,
 } from '@/api/adminV2';
 
 const HOUSE = {
@@ -274,5 +276,34 @@ describe('the AI author (Phase 1.6)', () => {
     fireEvent.click(await screen.findByRole('button', { name: /Draft with AI/ }));
     fireEvent.click(screen.getByRole('button', { name: 'Write the sheet' }));
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith('AI provider is not configured.'));
+  });
+});
+
+describe('rescore now (Phase 1.5)', () => {
+  it('rides the progress line while a regrade is owed, and reports the honest counts', async () => {
+    fetchScoringSheet.mockResolvedValue(SHEET_CAMPAIGN);
+    fetchScoringProgress.mockResolvedValue({ total: 40, current: 12, resolvedVersion: 7, complete: false });
+    rescoreCampaignScoring.mockResolvedValue({ examined: 28, rescored: 25, unchanged: 3, skipped: 0, remaining: 0, more: false, complete: true });
+    setup();
+    fireEvent.click(await screen.findByRole('button', { name: 'Rescore now' }));
+    await waitFor(() => expect(rescoreCampaignScoring).toHaveBeenCalledWith('camp-1'));
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith(expect.stringMatching(/Re-graded 25 leads · 3 already current/)));
+  });
+
+  it('says when the bounds left work behind — press again or wait for the sweep', async () => {
+    fetchScoringSheet.mockResolvedValue(SHEET_CAMPAIGN);
+    fetchScoringProgress.mockResolvedValue({ total: 900, current: 0, resolvedVersion: 7, complete: false });
+    rescoreCampaignScoring.mockResolvedValue({ examined: 500, rescored: 500, unchanged: 0, skipped: 0, remaining: 0, more: true, complete: false });
+    setup();
+    fireEvent.click(await screen.findByRole('button', { name: 'Rescore now' }));
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith(expect.stringMatching(/still queued — press again or let tonight's sweep finish/)));
+  });
+
+  it('is absent once the regrade is complete', async () => {
+    fetchScoringSheet.mockResolvedValue(SHEET_CAMPAIGN);
+    fetchScoringProgress.mockResolvedValue({ total: 40, current: 40, resolvedVersion: 7, complete: true });
+    setup();
+    await screen.findByText('campaign sheet');
+    expect(screen.queryByRole('button', { name: 'Rescore now' })).not.toBeInTheDocument();
   });
 });

--- a/src/components/adminv2/__tests__/CreateScoringBlock.test.jsx
+++ b/src/components/adminv2/__tests__/CreateScoringBlock.test.jsx
@@ -1,0 +1,204 @@
+/**
+ * The creation-time scoring block (campaign-scoring-editor §3.3): the always-
+ * on resolve line, brief-pick prefill, the untouched-block no-op, the
+ * draft(+approve) submit contract, and the flag-off neutral state.
+ */
+import { createRef } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import CreateScoringBlock from '../CreateScoringBlock';
+import { buildAgeCurveFromBands } from '@/lib/adminV2/scoringLabels';
+
+vi.mock('@/api/adminV2', () => ({
+  fetchScoringSheetForProduct: vi.fn(),
+  createScoringDraft: vi.fn(),
+  approveScoringDraft: vi.fn(),
+}));
+
+import { fetchScoringSheetForProduct, createScoringDraft, approveScoringDraft } from '@/api/adminV2';
+
+const HOUSE = {
+  components: {
+    engagement: { maxPoints: 15 }, contactability: { maxPoints: 10 }, market_fit: { maxPoints: 15 },
+    life_events: { maxPoints: 25 }, family_gap: { maxPoints: 20 }, capacity: { maxPoints: 15 },
+    age: { maxPoints: 10 }, coverage_headroom: { maxPoints: -10 },
+  },
+  leadComponents: { response: { maxPoints: 15 }, screening: { maxPoints: 20 } },
+  ageCurve: [{ upTo: 44, value: 1 }, { upTo: null, value: 0.3 }],
+  targetSegments: [],
+};
+const PRODUCT_SHEET = {
+  version: 6, scope: 'product', config: HOUSE, raw: {}, activatedAt: '2026-07-30T00:00:00Z',
+  actorName: 'Shawn Lee', houseDefault: HOUSE,
+};
+
+// createRef objects are sealed by React — the rerender handle rides beside
+// the ref, not on it.
+let lastRerender = null;
+function setup(props = {}, ref = createRef()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const view = render(
+    <QueryClientProvider client={qc}>
+      <CreateScoringBlock ref={ref} product="insurance" ageBands={['30-44']} language="zh" {...props} />
+    </QueryClientProvider>
+  );
+  lastRerender = (nextProps = {}) => view.rerender(
+    <QueryClientProvider client={qc}>
+      <CreateScoringBlock ref={ref} product="insurance" ageBands={['30-44']} language="zh" {...props} {...nextProps} />
+    </QueryClientProvider>
+  );
+  return ref;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('the resolve line', () => {
+  it('says which sheet a new campaign with these picks would inherit', async () => {
+    fetchScoringSheetForProduct.mockResolvedValue(PRODUCT_SHEET);
+    setup();
+    expect(await screen.findByText('product sheet')).toBeInTheDocument();
+    expect(screen.getByText(/edition #6/)).toBeInTheDocument();
+    expect(fetchScoringSheetForProduct).toHaveBeenCalledWith('insurance');
+  });
+
+  it('a 404 backend degrades to one neutral line and a no-op submit', async () => {
+    fetchScoringSheetForProduct.mockRejectedValue(Object.assign(new Error('nf'), { status: 404 }));
+    const ref = setup();
+    expect(await screen.findByText(/controls are unavailable on this backend/)).toBeInTheDocument();
+    expect(await ref.current.submit('camp-9')).toBeNull();
+    expect(createScoringDraft).not.toHaveBeenCalled();
+  });
+});
+
+describe('tailoring', () => {
+  it('prefills from the brief picks: bands → the slope-legal curve, language → a segment', async () => {
+    fetchScoringSheetForProduct.mockResolvedValue(PRODUCT_SHEET);
+    setup();
+    fireEvent.click(await screen.findByRole('button', { name: /Tailor scoring for this campaign/ }));
+    // The band chip the brief picked is already pressed…
+    expect(screen.getByRole('button', { name: '30-44' })).toHaveAttribute('aria-pressed', 'true');
+    // …and the language pick became the target segment.
+    expect(screen.getByLabelText('segment 1 language')).toHaveValue('zh');
+  });
+
+  it('an untouched block mints NOTHING on submit', async () => {
+    fetchScoringSheetForProduct.mockResolvedValue(PRODUCT_SHEET);
+    const ref = setup();
+    await screen.findByText('product sheet');
+    expect(await ref.current.submit('camp-9')).toBeNull();
+    expect(createScoringDraft).not.toHaveBeenCalled();
+    expect(approveScoringDraft).not.toHaveBeenCalled();
+  });
+
+  it('a tailored block drafts AND approves on submit, carrying the pre-create baseline', async () => {
+    fetchScoringSheetForProduct.mockResolvedValue(PRODUCT_SHEET);
+    createScoringDraft.mockResolvedValue({ version: 12, status: 'draft' });
+    approveScoringDraft.mockResolvedValue({ version: 12, status: 'approved' });
+    const ref = setup();
+    fireEvent.click(await screen.findByRole('button', { name: /Tailor scoring for this campaign/ }));
+
+    const draft = await ref.current.submit('camp-9');
+    expect(draft.version).toBe(12);
+    const [cid, patch] = createScoringDraft.mock.calls[0];
+    expect(cid).toBe('camp-9');
+    // The full exposed set + the brief-derived curve and segment.
+    expect(Object.keys(patch.components)).toHaveLength(8);
+    expect(patch.ageCurve).toEqual(buildAgeCurveFromBands(['30-44']));
+    expect(patch.targetSegments).toEqual([{ language: 'zh', weight: 1 }]);
+    // The §4.5 guard rides along: the version the admin SAW pre-create.
+    expect(approveScoringDraft).toHaveBeenCalledWith(12, 6);
+  });
+
+  it('unticking "apply immediately" leaves it a draft', async () => {
+    fetchScoringSheetForProduct.mockResolvedValue(PRODUCT_SHEET);
+    createScoringDraft.mockResolvedValue({ version: 12, status: 'draft' });
+    const ref = setup();
+    fireEvent.click(await screen.findByRole('button', { name: /Tailor scoring for this campaign/ }));
+    fireEvent.click(screen.getByRole('checkbox'));
+    await ref.current.submit('camp-9');
+    expect(createScoringDraft).toHaveBeenCalled();
+    expect(approveScoringDraft).not.toHaveBeenCalled();
+  });
+
+  it('"Skip tailoring" collapses back to inherit-only — submit mints nothing again', async () => {
+    fetchScoringSheetForProduct.mockResolvedValue(PRODUCT_SHEET);
+    const ref = setup();
+    fireEvent.click(await screen.findByRole('button', { name: /Tailor scoring for this campaign/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Skip tailoring' }));
+    expect(await ref.current.submit('camp-9')).toBeNull();
+    expect(createScoringDraft).not.toHaveBeenCalled();
+  });
+
+  it('a failing save THROWS to the caller — creation flows toast and navigate anyway', async () => {
+    fetchScoringSheetForProduct.mockResolvedValue(PRODUCT_SHEET);
+    createScoringDraft.mockRejectedValue(new Error('422 something'));
+    const ref = setup();
+    fireEvent.click(await screen.findByRole('button', { name: /Tailor scoring for this campaign/ }));
+    await expect(ref.current.submit('camp-9')).rejects.toThrow('422 something');
+  });
+});
+
+describe('the review folds (M2/M3/B2/B3)', () => {
+  it("language 'any' CLEARS inherited targeting; unanswered inherits (B2)", async () => {
+    const inherited = { ...PRODUCT_SHEET, config: { ...HOUSE, targetSegments: [{ language: 'zh', weight: 1 }] } };
+    fetchScoringSheetForProduct.mockResolvedValue(inherited);
+    createScoringDraft.mockResolvedValue({ version: 12, status: 'draft' });
+    approveScoringDraft.mockResolvedValue({ version: 12 });
+    const ref = setup({ language: 'any' });
+    fireEvent.click(await screen.findByRole('button', { name: /Tailor scoring for this campaign/ }));
+    await ref.current.submit('camp-9');
+    expect(createScoringDraft.mock.calls[0][1].targetSegments).toEqual([]);
+  });
+
+  it('the approve baseline is CAPTURED at open — a product switch after opening cannot advance it (M3)', async () => {
+    fetchScoringSheetForProduct.mockResolvedValue(PRODUCT_SHEET); // v6
+    createScoringDraft.mockResolvedValue({ version: 12, status: 'draft' });
+    approveScoringDraft.mockResolvedValue({ version: 12 });
+    const ref = setup();
+    fireEvent.click(await screen.findByRole('button', { name: /Tailor scoring for this campaign/ }));
+
+    // The pick changes AFTER tailoring opened: a NEW resolve (v9) loads…
+    fetchScoringSheetForProduct.mockResolvedValue({ ...PRODUCT_SHEET, version: 9 });
+    lastRerender({ product: 'property' });
+    await screen.findByText(/edition #9/);
+
+    // …but submit still carries the version the admin actually saw: 6.
+    await ref.current.submit('camp-9');
+    expect(approveScoringDraft).toHaveBeenCalledWith(12, 6);
+  });
+
+  it('an approve failure after a saved draft throws WITH the draft version — partial success is nameable (B3)', async () => {
+    fetchScoringSheetForProduct.mockResolvedValue(PRODUCT_SHEET);
+    createScoringDraft.mockResolvedValue({ version: 12, status: 'draft' });
+    approveScoringDraft.mockRejectedValue(Object.assign(new Error('changed while you were editing'), { status: 409 }));
+    const ref = setup();
+    fireEvent.click(await screen.findByRole('button', { name: /Tailor scoring for this campaign/ }));
+    await expect(ref.current.submit('camp-9')).rejects.toMatchObject({ draftVersion: 12 });
+  });
+
+  it('a stalled call rejects at the 30s bound instead of holding navigation hostage (M2)', async () => {
+    // Render + open under REAL timers (RTL's polling needs them), then fake
+    // the clock ONLY for the submit whose setTimeout we mean to fast-forward.
+    fetchScoringSheetForProduct.mockResolvedValue(PRODUCT_SHEET);
+    createScoringDraft.mockReturnValue(new Promise(() => {})); // never settles
+    const ref = setup();
+    fireEvent.click(await screen.findByRole('button', { name: /Tailor scoring for this campaign/ }));
+    vi.useFakeTimers();
+    try {
+      const pending = ref.current.submit('camp-9');
+      const assertion = expect(pending).rejects.toThrow(/did not confirm within 30s — check the campaign page/);
+      await vi.advanceTimersByTimeAsync(30_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('no Tailor button while the resolve is still loading — nothing to seed from yet', async () => {
+    fetchScoringSheetForProduct.mockReturnValue(new Promise(() => {}));
+    setup();
+    expect(await screen.findByText(/checking which rules apply/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Tailor scoring/ })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/campaigns/workspace/CampaignDetailsTab.jsx
+++ b/src/components/campaigns/workspace/CampaignDetailsTab.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -10,6 +10,7 @@ import { toast } from 'sonner';
 import { apiClient } from '@/api/client';
 import { buildDrawTermsHtml, formatLongDate } from './drawTermsTemplate';
 import CampaignBriefFields, { briefDraftFromCampaign, briefDraftComplete, briefDraftToPayload } from './CampaignBriefFields';
+import CreateScoringBlock from '@/components/adminv2/CreateScoringBlock';
 
 const toDateInput = (v) => {
   if (!v) return '';
@@ -78,6 +79,7 @@ export default function CampaignDetailsTab({ initial, type, draw = false, drawEd
   // Campaign brief (campaign-brief.md): objective + product gate creation;
   // on edit the pickers show the stored brief and save with the details.
   const [brief, setBrief] = useState(() => briefDraftFromCampaign(initial?.targetAudience));
+  const scoringRef = useRef(null);
 
   // "Fill it for me" — one brief drafts every field below (create mode only).
   // The server clamps the model output (dates/ages/prize rows); this merge
@@ -244,7 +246,11 @@ export default function CampaignDetailsTab({ initial, type, draw = false, drawEd
       })(),
       metaPixelId: form.metaPixelId.trim() || null,
       tiktokPixelId: form.tiktokPixelId.trim() || null,
-    }, aiBrief.trim());
+    }, aiBrief.trim(),
+    // Third arg (create only): the scoring block's submit, for the workspace
+    // to AWAIT after the campaign row commits and BEFORE navigating (§3.3) —
+    // a failure is the caller's toast, never a blocked create.
+    (campaignId) => scoringRef.current?.submit(campaignId));
   };
 
   return (
@@ -276,6 +282,18 @@ export default function CampaignDetailsTab({ initial, type, draw = false, drawEd
       )}
 
       <CampaignBriefFields draft={brief} onChange={setBrief} isEdit={isEdit} />
+
+      {/* Phase 2 (campaign-scoring-editor §3.3): which sheet a new campaign
+          with these picks would score under, and the door to tailor one —
+          create only; existing campaigns tune from their campaign page. */}
+      {!isEdit && (
+        <CreateScoringBlock
+          ref={scoringRef}
+          product={brief.product || null}
+          ageBands={brief.ageBands}
+          language={brief.language || null}
+        />
+      )}
 
       <Card>
         <CardHeader>

--- a/src/components/campaigns/workspace/__tests__/CampaignDetailsTab.test.jsx
+++ b/src/components/campaigns/workspace/__tests__/CampaignDetailsTab.test.jsx
@@ -1,5 +1,12 @@
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// Out of scope here: the create-flow scoring block owns its own queries and
+// QueryClient needs; its contract is covered by CreateScoringBlock.test.jsx.
+vi.mock('@/components/adminv2/CreateScoringBlock', () => ({
+  default: () => <div data-testid="create-scoring-stub" />,
+}));
+
 vi.mock('@/api/client', () => ({ apiClient: { post: vi.fn(), get: vi.fn() } }));
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 

--- a/src/components/forms/__tests__/CampaignForm.test.jsx
+++ b/src/components/forms/__tests__/CampaignForm.test.jsx
@@ -13,6 +13,13 @@ globalThis.ResizeObserver =
 
 // Mock dependencies
 const mockNavigate = vi.fn();
+
+// Out of scope here: the create-flow scoring block owns its own queries and
+// QueryClient needs; its contract is covered by CreateScoringBlock.test.jsx.
+vi.mock('@/components/adminv2/CreateScoringBlock', () => ({
+  default: () => <div data-testid="create-scoring-stub" />,
+}));
+
 vi.mock('react-router-dom', async () => {
  const actual = await vi.importActual('react-router-dom');
  return {

--- a/src/lib/adminV2/scoringLabels.js
+++ b/src/lib/adminV2/scoringLabels.js
@@ -124,3 +124,39 @@ export function buildAgeCurveFromBands(selectedIds) {
   merged[merged.length - 1].upTo = null;
   return merged;
 }
+
+/** Sheet-tier chip labels, shared by the campaign card and the create block. */
+export const TIER_LABEL = {
+  campaign: 'campaign sheet',
+  product: 'product sheet',
+  global: 'house sheet',
+  default: 'house default',
+};
+
+/** The full exposed set as a patch — an editor doc always writes every
+ *  exposed knob (campaign-scoring-editor §4.1: exposed knobs never float),
+ *  UI-only keys stripped. */
+export function patchFromDoc(doc, houseDefault) {
+  const components = {};
+  const leadComponents = {};
+  for (const comp of EXPOSED_COMPONENTS) {
+    const value = weightOf(doc, comp) ?? weightOf(houseDefault, comp) ?? 0;
+    (comp.leadGrain ? leadComponents : components)[comp.name] = { maxPoints: value };
+  }
+  const patch = { components, leadComponents };
+  if (Array.isArray(doc?.ageCurve) && doc.ageCurve.length) patch.ageCurve = doc.ageCurve;
+  if (Array.isArray(doc?.targetSegments)) patch.targetSegments = doc.targetSegments;
+  return patch;
+}
+
+/** Seed an editor doc from a strict-resolve payload: effective values only. */
+export function docFromSheet(sheet) {
+  const cfg = sheet?.config || {};
+  return {
+    components: { ...(cfg.components || {}) },
+    leadComponents: { ...(cfg.leadComponents || {}) },
+    ageCurve: Array.isArray(cfg.ageCurve) ? cfg.ageCurve.map((s) => ({ ...s })) : [],
+    targetSegments: Array.isArray(cfg.targetSegments) ? cfg.targetSegments.map((s) => ({ ...s })) : [],
+    _ageBands: [],
+  };
+}

--- a/src/pages/AdminCampaignForm.jsx
+++ b/src/pages/AdminCampaignForm.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { Campaign } from '@/api/entities';
 import { integrations } from '@/api/client';
@@ -13,6 +13,7 @@ import { format, parseISO } from 'date-fns';
 import { Calendar as CalendarIcon, ArrowLeft, Upload, Trash2, Loader2, Video, Image as ImageIcon } from 'lucide-react';
 import { toast } from 'sonner';
 import CampaignBriefFields, { briefDraftFromCampaign, briefDraftComplete, briefDraftToPayload } from '@/components/campaigns/workspace/CampaignBriefFields';
+import CreateScoringBlock from '@/components/adminv2/CreateScoringBlock';
 
 export default function AdminCampaignForm() {
  const { id } = useParams();
@@ -43,6 +44,7 @@ export default function AdminCampaignForm() {
  const [uploading, setUploading] = useState(false);
  // Campaign brief — objective + product gate creation (the server 422s without them).
  const [brief, setBrief] = useState(() => briefDraftFromCampaign(null));
+ const scoringRef = useRef(null);
 
  useEffect(() => {
  if (isEditMode) {
@@ -169,8 +171,21 @@ export default function AdminCampaignForm() {
  await Campaign.update(id, formattedData);
  toast.success('Campaign updated successfully');
  } else {
- await Campaign.create(formattedData);
+ const created = await Campaign.create(formattedData);
  toast.success('Campaign created successfully');
+ // The tailored scoring sheet (campaign-scoring-editor §3.3): awaited
+ // BEFORE navigation, non-fatal — scoring never blocks a created campaign.
+ const newId = created?.id || created?.campaign?.id;
+ if (newId && scoringRef.current) {
+ try {
+ await scoringRef.current.submit(newId);
+ } catch (err) {
+ // Partial success is its own message (review B3) — see CreateScoringBlock.
+ toast.warning(err?.draftVersion
+ ? `Campaign created — scoring sheet saved as draft #${err.draftVersion}, but activation didn’t confirm. Check the campaign page.`
+ : 'Campaign created — the scoring sheet wasn’t confirmed. Check the campaign page’s scoring card.');
+ }
+ }
  }
  navigate('/AdminCampaigns');
  } catch (error) {
@@ -290,6 +305,16 @@ export default function AdminCampaignForm() {
  </Card>
 
  <CampaignBriefFields draft={brief} onChange={setBrief} isEdit={isEditMode} />
+
+ {/* Phase 2 (campaign-scoring-editor §3.3) — create only. */}
+ {!isEditMode && (
+ <CreateScoringBlock
+ ref={scoringRef}
+ product={brief.product || null}
+ ageBands={brief.ageBands}
+ language={brief.language || null}
+ />
+ )}
 
  <Card>
  <CardHeader>

--- a/src/pages/AdminCampaignWorkspace.jsx
+++ b/src/pages/AdminCampaignWorkspace.jsx
@@ -95,7 +95,7 @@ export default function AdminCampaignWorkspace() {
     }
   };
 
-  const handleSaveDetails = async (payload, brief) => {
+  const handleSaveDetails = async (payload, brief, scoringSubmit) => {
     setSavingDetails(true);
     try {
       if (isCreate) {
@@ -112,6 +112,21 @@ export default function AdminCampaignWorkspace() {
         const trimmedBrief = typeof brief === 'string' ? brief.trim() : '';
         if (newId && trimmedBrief) {
           await autoDesignCampaign(newId, created?.design_config ?? payload.design_config, trimmedBrief);
+        }
+        // The tailored scoring sheet (§3.3): AWAITED before navigation so the
+        // block's pending editor state is never unmounted mid-flight — and
+        // non-fatal, because scoring must never block a created campaign.
+        if (newId && scoringSubmit) {
+          try {
+            await scoringSubmit(newId);
+          } catch (err) {
+            // Partial success is its own message (review B3): a saved-but-
+            // not-applied draft must not invite a blind retry that would
+            // mint a duplicate.
+            toast.warning(err?.draftVersion
+              ? `Campaign created — scoring sheet saved as draft #${err.draftVersion}, but activation didn’t confirm. Check the campaign page.`
+              : 'Campaign created — the scoring sheet wasn’t confirmed. Check the campaign page’s scoring card.');
+          }
         }
         if (newId) navigate(`/admin/campaigns/${newId}/workspace?tab=design`);
         else navigate('/AdminCampaigns');

--- a/src/pages/__tests__/AdminCampaignWorkspace.test.jsx
+++ b/src/pages/__tests__/AdminCampaignWorkspace.test.jsx
@@ -6,6 +6,23 @@ import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 const mockUseCampaign = vi.fn(() => ({ data: undefined, isLoading: false }));
 const mockUseSetLaunchState = vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false }));
 
+
+// The scoring block's INTERNALS are covered by CreateScoringBlock.test.jsx;
+// here it is stubbed to a ref that delegates submit to a controllable mock —
+// exactly enough surface to pin the WIRING (round-2 B2): submit(newId) is
+// awaited BEFORE navigation, and its failures produce the differentiated
+// toasts without ever blocking the create.
+const mockScoringSubmit = vi.fn();
+vi.mock('@/components/adminv2/CreateScoringBlock', async () => {
+  const React = await import('react');
+  return {
+    default: React.forwardRef(function CreateScoringStub(_props, ref) {
+      React.useImperativeHandle(ref, () => ({ submit: mockScoringSubmit }));
+      return <div data-testid="create-scoring-stub" />;
+    }),
+  };
+});
+
 vi.mock('@/hooks/queries/useCampaignsQuery', () => ({
   useCampaign: (...a) => mockUseCampaign(...a),
   useSetCampaignLaunchState: (...a) => mockUseSetLaunchState(...a),
@@ -144,5 +161,39 @@ describe('AdminCampaignWorkspace — auto-design on create', () => {
     expect(Campaign.create).toHaveBeenCalledTimes(1);
     expect(apiClient.post).not.toHaveBeenCalled(); // never touched copy-draft or details-draft
     expect(Campaign.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('AdminCampaignWorkspace — the scoring block wiring (§3.3)', () => {
+  it('awaits scoring submit for the NEW campaign before navigating', async () => {
+    let release;
+    mockScoringSubmit.mockImplementation(() => new Promise((res) => { release = res; }));
+    renderCreate();
+    await createWith({});
+
+    await waitFor(() => expect(mockScoringSubmit).toHaveBeenCalledWith('new-1'));
+    // Navigation is HELD while the scoring submit is in flight…
+    expect(screen.queryByTestId('loc')).not.toBeInTheDocument();
+    release(null);
+    // …and proceeds the moment it settles.
+    await waitFor(() => expect(screen.getByTestId('loc')).toHaveTextContent('/admin/campaigns/new-1/workspace?tab=design'));
+  });
+
+  it('a partial success (draft saved, activation unconfirmed) gets its own toast — and still navigates', async () => {
+    mockScoringSubmit.mockRejectedValue(Object.assign(new Error('409'), { draftVersion: 7 }));
+    renderCreate();
+    await createWith({});
+
+    await waitFor(() => expect(screen.getByTestId('loc')).toHaveTextContent('/admin/campaigns/new-1/workspace?tab=design'));
+    expect(toast.warning).toHaveBeenCalledWith(expect.stringMatching(/saved as draft #7, but activation didn’t confirm/));
+  });
+
+  it('an unknown-state failure warns without claiming anything — and still navigates', async () => {
+    mockScoringSubmit.mockRejectedValue(new Error('network'));
+    renderCreate();
+    await createWith({});
+
+    await waitFor(() => expect(screen.getByTestId('loc')).toHaveTextContent('/admin/campaigns/new-1/workspace?tab=design'));
+    expect(toast.warning).toHaveBeenCalledWith(expect.stringMatching(/wasn’t confirmed. Check the campaign page/));
   });
 });


### PR DESCRIPTION
## What

The last two phases of `docs/plans/campaign-scoring-editor.md`, hardened through **two Codex xhigh review rounds** (all confirmed findings folded; one suggestion rejected with evidence — details in the commit).

**Phase 1.5 — Rescore now.** Approve a sheet at 2pm, see numbers at 2pm. `POST /scoring-configs/rescore`: campaign-filtered via `findStaleLeadIds`' own predicate (sweep-agreeing by construction), `scoreOneLead` per row (same fence, same write-gate), cache busted first, doubly bounded (500 rows + 25s entry-anchored deadline), honest `{examined, rescored, remaining, more}`. Card button on the progress line. Deliberately does NOT take the sweep's advisory lock — the sweep try-locks and skips, so a 25s press at 02:00 could void the night; the bounded overlap cost (cheap `unchanged` re-checks) is documented instead.

**Phase 2 — Scoring at creation.** `CreateScoringBlock` under the brief on both create surfaces: strict product-tier resolve line → "Tailor scoring →" prefilled from the brief picks (bands → slope-legal curve; specific language → segment; explicit 'any' clears; unanswered inherits) → "apply immediately" approves with the **snapshotted** pre-create baseline as `expectedLiveVersion`. Both flows await `submit(campaignId)` before navigating; failures toast + navigate (creation never blocked); both calls carry their own 30s bound (the apiClient's declared timeout is never attached to fetch); partial success throws with `draftVersion` and toasts *"saved as draft #N, but activation didn't confirm"*.

## Tests

Frontend **2129** · backend scoring suites **86** — including: campaign-isolated rescore onto a freshly-approved edition, real-clock deadline (injected monotonic clock, stops mid-queue), baseline captured across a product switch, partial-success `draftVersion`, 30s fake-timer rejection, and workspace wiring pinned with a ref-exposing stub (submit awaited before navigation, both failure toasts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENWdGMue9uXqmKv3pRG6YF