### PR TITLE
feat(admin): mobile console — phone chrome + mobile layouts for every v2 screen

### DIFF
--- a/src/components/adminv2/AdminV2Shell.jsx
+++ b/src/components/adminv2/AdminV2Shell.jsx
@@ -6,13 +6,21 @@
  * attention bell, avatar menu). [data-theme] dark swap persisted to
  * localStorage. Wraps every v2 admin screen; legacy pages keep their own
  * shell until their PR lands.
+ *
+ * ≤767px the same shell renders the MOBILE chrome instead (design source
+ * 1694f8b2 "MKTR Ops Console Mobile"): 56px top bar (back/M tile · title ·
+ * search · bell · avatar→More) + fixed bottom tab bar (Home / Leads /
+ * Campaigns / Money / More). SGT clock + theme toggle move to /admin/more.
  */
-import { useEffect, useState } from 'react';
-import { Link, NavLink, useNavigate } from 'react-router-dom';
+import { useEffect, useMemo, useState } from 'react';
+import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
 import { NAV } from '@/lib/adminV2/nav';
 import GlobalSearch from './GlobalSearch';
 import NotificationsBell from './NotificationsBell';
+import MobileTabBar from './mobile/MobileTabBar';
+import { AdminV2ShellContext } from './mobile/shellContext';
+import { useAdminV2Mobile } from './mobile/useAdminV2Mobile';
 import '@/styles/adminV2.css';
 
 const THEME_KEY = 'mktr_admin_v2_theme';
@@ -45,13 +53,47 @@ function initialsOf(user) {
   return (user?.email || 'OP').slice(0, 2).toUpperCase();
 }
 
+/* Mobile top-bar identity per route: title, root (M tile, no back) or the
+   parent to fall back to when there's no in-app history to pop. Order
+   matters — first match wins, so /admin/campaigns/… specials precede :id. */
+const MOBILE_ROUTES = [
+  [/^\/admindashboard/, { title: 'MKTR', sub: 'OPS CONSOLE', root: true }],
+  [/^\/adminprospects/, { title: 'Leads', root: true }],
+  [/^\/admin\/leads\//, { title: 'Lead', parent: '/AdminProspects' }],
+  [/^\/admin\/campaigns\/(new|workspace)/, { title: 'Campaign', parent: '/AdminCampaigns' }],
+  [/^\/admin\/campaigns\/[^/]+\/(edit|workspace|studio)/, { title: 'Campaign', parent: '/AdminCampaigns' }],
+  [/^\/admin\/campaigns\//, { title: 'Campaign', parent: '/AdminCampaigns' }],
+  [/^\/admincampaigns/, { title: 'Campaigns', root: true }],
+  [/^\/adminwallets/, { title: 'Money', root: true }],
+  [/^\/adminagents/, { title: 'Money', root: true }],
+  [/^\/admin\/more/, { title: 'More', root: true }],
+  [/^\/adminpeople/, { title: 'People', parent: '/admin/more' }],
+  [/^\/admin\/cohorts\//, { title: 'Cohort', parent: '/AdminCohorts' }],
+  [/^\/admincohorts/, { title: 'Cohorts', parent: '/admin/more' }],
+  [/^\/admin\/broadcasts\//, { title: 'Push', parent: '/AdminBroadcasts' }],
+  [/^\/adminbroadcasts/, { title: 'Email Pushes', parent: '/admin/more' }],
+  [/^\/adminagentgroups/, { title: 'Agent Groups', parent: '/admin/more' }],
+  [/^\/adminqrcodes/, { title: 'QR Codes', parent: '/admin/more' }],
+  [/^\/adminshortlinks/, { title: 'Short Links', parent: '/admin/more' }],
+  [/^\/adminusers/, { title: 'Users', parent: '/admin/more' }],
+  [/^\/adminaisettings/, { title: 'AI Settings', parent: '/admin/more' }],
+];
+
+function mobileRouteInfo(pathname) {
+  const p = pathname.toLowerCase();
+  const hit = MOBILE_ROUTES.find(([rx]) => rx.test(p));
+  return hit ? hit[1] : { title: 'MKTR', sub: 'OPS CONSOLE', root: true };
+}
+
 export default function AdminV2Shell({ children, fullBleed = false, legacyBridge = false }) {
   const [theme, setTheme] = useAdminV2Theme();
   const [clock, setClock] = useState(sgtClock);
   const [menuOpen, setMenuOpen] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
   const logout = useAuthStore((s) => s.logout);
   const user = useAuthStore((s) => s.user);
+  const isMobile = useAdminV2Mobile();
 
   useEffect(() => {
     const t = setInterval(() => setClock(sgtClock()), 15_000);
@@ -82,7 +124,96 @@ export default function AdminV2Shell({ children, fullBleed = false, legacyBridge
     }
   };
 
+  const ctx = useMemo(
+    () => ({ theme, setTheme, signOut: handleSignOut, user, isMobile }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [theme, user, isMobile],
+  );
+
+  /* ── Mobile chrome ─────────────────────────────────────────────────── */
+  if (isMobile) {
+    const info = mobileRouteInfo(location.pathname);
+    const goBack = () => {
+      // RR7 tracks the in-app history depth on history.state.idx — pop when
+      // we navigated here, hard-fall to the parent on a cold deep link.
+      if (window.history.state?.idx > 0) navigate(-1);
+      else navigate(info.parent || '/AdminDashboard');
+    };
+    return (
+      <AdminV2ShellContext.Provider value={ctx}>
+        <div className={legacyBridge ? 'admin-v2 av2-legacy-bridge' : 'admin-v2'} data-theme={theme}>
+          <header
+            style={{
+              position: 'sticky', top: 0, zIndex: 50, boxSizing: 'border-box',
+              display: 'flex', alignItems: 'center', gap: 8,
+              height: 'calc(56px + env(safe-area-inset-top, 0px))',
+              padding: 'env(safe-area-inset-top, 0px) 10px 0 10px',
+              background: 'var(--canvas)', borderBottom: '1px solid var(--line)',
+            }}
+          >
+            {info.root ? (
+              <Link to="/AdminDashboard" aria-label="Dashboard" style={{ display: 'flex', flex: 'none' }}>
+                <span style={{ width: 32, height: 32, background: 'var(--accent)', color: 'var(--accent-ink)', borderRadius: 9, display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 800, fontSize: 15 }}>M</span>
+              </Link>
+            ) : (
+              <button
+                type="button"
+                onClick={goBack}
+                aria-label="Back"
+                style={{ width: 44, height: 44, flex: 'none', display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', marginLeft: -6, padding: 0 }}
+              >
+                <svg viewBox="0 0 24 24" style={{ width: 20, height: 20 }} aria-hidden="true">
+                  <path d="M14.5 5 8 12l6.5 7" fill="none" stroke="var(--ink)" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              </button>
+            )}
+            <span style={{ flex: 1, minWidth: 0 }}>
+              <span style={{ display: 'block', fontWeight: 800, fontSize: 16, letterSpacing: '-0.01em', lineHeight: 1.15, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', color: 'var(--ink)' }}>
+                {info.title}
+              </span>
+              {(info.sub || info.root) && (
+                <span className="av2-mono" style={{ display: 'block', fontSize: 9, letterSpacing: '.14em', color: 'var(--ink-3)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  {info.sub || 'ALL TIMES SGT · CURRENCY SGD'}
+                </span>
+              )}
+            </span>
+            <GlobalSearch variant="icon" />
+            <NotificationsBell />
+            <button
+              type="button"
+              onClick={() => navigate('/admin/more')}
+              title="Account"
+              aria-label="Account & more"
+              style={{
+                width: 32, height: 32, flex: 'none', borderRadius: '50%', border: 'none', cursor: 'pointer',
+                background: 'var(--ink)', color: 'var(--canvas)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 11, fontWeight: 700,
+                fontFamily: 'var(--font-ui)',
+              }}
+            >
+              {initialsOf(user)}
+            </button>
+          </header>
+
+          <main
+            className={legacyBridge ? 'av2-bridge-tokens' : undefined}
+            style={fullBleed
+              ? { width: '100%', minWidth: 0, minHeight: '60vh' }
+              : { width: '100%', boxSizing: 'border-box', minHeight: '60vh', padding: '10px 14px calc(120px + env(safe-area-inset-bottom, 0px))' }}
+          >
+            {children}
+          </main>
+
+          {/* Full-bleed editor surfaces keep their own footers clear of chrome. */}
+          {!fullBleed && <MobileTabBar />}
+        </div>
+      </AdminV2ShellContext.Provider>
+    );
+  }
+
+  /* ── Desktop chrome ────────────────────────────────────────────────── */
   return (
+    <AdminV2ShellContext.Provider value={ctx}>
     <div className={legacyBridge ? 'admin-v2 av2-legacy-bridge' : 'admin-v2'} data-theme={theme}>
       <div style={{ display: 'flex', minHeight: '100vh' }}>
         {/* ── Sidebar (228px fixed) ── */}
@@ -219,5 +350,6 @@ export default function AdminV2Shell({ children, fullBleed = false, legacyBridge
       {/* Toasts render through the app-wide sonner Toaster (App.jsx) — a second
           mount here would double-render every toast. */}
     </div>
+    </AdminV2ShellContext.Provider>
   );
 }

--- a/src/components/adminv2/CohortBuilder.jsx
+++ b/src/components/adminv2/CohortBuilder.jsx
@@ -118,7 +118,8 @@ export default function CohortBuilder({ cohort = null, onClose, onSaved }) {
     <Dialog open onOpenChange={(open) => { if (!open && !save.isPending) onClose(); }}>
       <DialogContent
         className="admin-v2"
-        style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)', maxWidth: 760, maxHeight: '86vh', display: 'flex', flexDirection: 'column' }}
+        variant="sheet"
+        style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)', maxWidth: 760, maxHeight: '86dvh', display: 'flex', flexDirection: 'column', overflowY: 'auto' }}
       >
         <DialogHeader>
           <DialogTitle style={{ color: 'var(--ink)', fontFamily: 'var(--font-ui)', fontSize: 15, fontWeight: 800, textAlign: 'left' }}>

--- a/src/components/adminv2/GlobalSearch.jsx
+++ b/src/components/adminv2/GlobalSearch.jsx
@@ -14,12 +14,15 @@ import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { fetchProspects, fetchCampaignsList, fetchAgentOptions } from '@/api/adminV2';
 import { NAV } from '@/lib/adminV2/nav';
+import { useAdminV2Mobile } from './mobile/useAdminV2Mobile';
 
 const MIN_QUERY = 2; // entity endpoints; page-label matching starts at 1 char
 const GROUP_LIMIT = 5;
 
-export default function GlobalSearch() {
+/** variant: 'pill' (desktop topbar search field) | 'icon' (mobile top bar). */
+export default function GlobalSearch({ variant = 'pill' }) {
   const [open, setOpen] = useState(false);
+  const isMobile = useAdminV2Mobile();
   const [q, setQ] = useState('');
   const [dq, setDq] = useState('');
   const [active, setActive] = useState(0);
@@ -181,31 +184,52 @@ export default function GlobalSearch() {
 
   return (
     <>
-      <button
-        ref={pillRef}
-        type="button"
-        onClick={() => setOpen(true)}
-        title="Search leads, campaigns, agents (⌘K)"
-        style={{
-          flex: '0 1 320px', height: 40, display: 'flex', alignItems: 'center', gap: 8, padding: '0 12px',
-          background: 'var(--surface)', border: '1px solid var(--line)', borderRadius: 10,
-          boxSizing: 'border-box', cursor: 'pointer', fontFamily: 'var(--font-ui)',
-        }}
-      >
-        <svg viewBox="0 0 24 24" style={{ width: 15, height: 15, flex: 'none' }} aria-hidden="true">
-          <path d="M10.5 3a7.5 7.5 0 1 1 0 15 7.5 7.5 0 0 1 0-15Z" fill="none" stroke="var(--ink-3)" strokeWidth="2" />
-          <path d="M16.2 16.2 21 21" fill="none" stroke="var(--ink-3)" strokeWidth="2" strokeLinecap="round" />
-        </svg>
-        <span style={{ flex: 1, fontSize: 13, color: 'var(--ink-3)', whiteSpace: 'nowrap', overflow: 'hidden', textAlign: 'left' }}>Search leads, campaigns, agents</span>
-        <span className="av2-mono" style={{ fontSize: 10, color: 'var(--ink-3)', border: '1px solid var(--line-strong)', borderRadius: 5, padding: '1px 5px' }}>⌘K</span>
-      </button>
+      {variant === 'icon' ? (
+        <button
+          ref={pillRef}
+          type="button"
+          onClick={() => setOpen(true)}
+          title="Search leads, campaigns, agents"
+          aria-label="Search"
+          style={{
+            width: 40, height: 40, flex: 'none', display: 'flex', alignItems: 'center', justifyContent: 'center',
+            background: 'transparent', border: 'none', borderRadius: 10, cursor: 'pointer', padding: 0,
+          }}
+        >
+          <svg viewBox="0 0 24 24" style={{ width: 18, height: 18 }} aria-hidden="true">
+            <path d="M10.5 3a7.5 7.5 0 1 1 0 15 7.5 7.5 0 0 1 0-15Z" fill="none" stroke="var(--ink-2)" strokeWidth="2" />
+            <path d="M16.2 16.2 21 21" fill="none" stroke="var(--ink-2)" strokeWidth="2" strokeLinecap="round" />
+          </svg>
+        </button>
+      ) : (
+        <button
+          ref={pillRef}
+          type="button"
+          onClick={() => setOpen(true)}
+          title="Search leads, campaigns, agents (⌘K)"
+          style={{
+            flex: '0 1 320px', height: 40, display: 'flex', alignItems: 'center', gap: 8, padding: '0 12px',
+            background: 'var(--surface)', border: '1px solid var(--line)', borderRadius: 10,
+            boxSizing: 'border-box', cursor: 'pointer', fontFamily: 'var(--font-ui)',
+          }}
+        >
+          <svg viewBox="0 0 24 24" style={{ width: 15, height: 15, flex: 'none' }} aria-hidden="true">
+            <path d="M10.5 3a7.5 7.5 0 1 1 0 15 7.5 7.5 0 0 1 0-15Z" fill="none" stroke="var(--ink-3)" strokeWidth="2" />
+            <path d="M16.2 16.2 21 21" fill="none" stroke="var(--ink-3)" strokeWidth="2" strokeLinecap="round" />
+          </svg>
+          <span style={{ flex: 1, fontSize: 13, color: 'var(--ink-3)', whiteSpace: 'nowrap', overflow: 'hidden', textAlign: 'left' }}>Search leads, campaigns, agents</span>
+          <span className="av2-mono" style={{ fontSize: 10, color: 'var(--ink-3)', border: '1px solid var(--line-strong)', borderRadius: 5, padding: '1px 5px' }}>⌘K</span>
+        </button>
+      )}
 
       {open && (
         // Plain fixed divs (no portal) so the palette stays inside the
         // .admin-v2 subtree and inherits the [data-theme] CSS variables.
         <div
           onMouseDown={() => setOpen(false)}
-          style={{ position: 'fixed', inset: 0, zIndex: 90, background: 'rgba(9, 11, 16, .42)', display: 'flex', justifyContent: 'center', alignItems: 'flex-start' }}
+          style={isMobile
+            ? { position: 'fixed', inset: 0, zIndex: 110, background: 'var(--canvas)', animation: 'av2m-fade-in .15s ease' }
+            : { position: 'fixed', inset: 0, zIndex: 90, background: 'rgba(9, 11, 16, .42)', display: 'flex', justifyContent: 'center', alignItems: 'flex-start' }}
         >
           <div
             role="dialog"
@@ -215,36 +239,56 @@ export default function GlobalSearch() {
             // The input is the dialog's only tab stop (options are pointer/
             // arrow-key targets) — swallow Tab so focus can't reach the page
             // behind the overlay.
-            onKeyDown={(e) => { if (e.key === 'Tab') e.preventDefault(); }}
-            style={{
-              width: 'min(600px, 92vw)', marginTop: '12vh', background: 'var(--surface)',
-              border: '1px solid var(--line-strong)', borderRadius: 14, boxShadow: 'var(--shadow)',
-              overflow: 'hidden', boxSizing: 'border-box',
-            }}
+            onKeyDown={(e) => { if (e.key === 'Tab' && !isMobile) e.preventDefault(); }}
+            style={isMobile
+              ? { width: '100%', height: '100dvh', background: 'var(--canvas)', display: 'flex', flexDirection: 'column', boxSizing: 'border-box' }
+              : {
+                width: 'min(600px, 92vw)', marginTop: '12vh', background: 'var(--surface)',
+                border: '1px solid var(--line-strong)', borderRadius: 14, boxShadow: 'var(--shadow)',
+                overflow: 'hidden', boxSizing: 'border-box',
+              }}
           >
-            <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '0 14px', height: 50, borderBottom: '1px solid var(--line)' }}>
-              <svg viewBox="0 0 24 24" style={{ width: 16, height: 16, flex: 'none' }} aria-hidden="true">
-                <path d="M10.5 3a7.5 7.5 0 1 1 0 15 7.5 7.5 0 0 1 0-15Z" fill="none" stroke="var(--ink-3)" strokeWidth="2" />
-                <path d="M16.2 16.2 21 21" fill="none" stroke="var(--ink-3)" strokeWidth="2" strokeLinecap="round" />
-              </svg>
-              <input
-                ref={inputRef}
-                autoFocus
-                value={q}
-                onChange={(e) => setQ(e.target.value)}
-                onKeyDown={onInputKey}
-                placeholder="Search leads, campaigns, agents…"
-                aria-label="Global search"
-                role="combobox"
-                aria-expanded="true"
-                aria-controls="av2-palette-list"
-                aria-activedescendant={flat[active]?.id}
-                style={{ flex: 1, border: 'none', outline: 'none', background: 'transparent', fontFamily: 'var(--font-ui)', fontSize: 14, color: 'var(--ink)' }}
-              />
-              <span className="av2-mono" style={{ fontSize: 10, color: 'var(--ink-3)', border: '1px solid var(--line-strong)', borderRadius: 5, padding: '1px 5px', flex: 'none' }}>esc</span>
+            <div style={isMobile
+              ? { display: 'flex', alignItems: 'center', gap: 8, padding: 'calc(10px + env(safe-area-inset-top, 0px)) 14px 10px', borderBottom: '1px solid var(--line)', flex: 'none' }
+              : { display: 'flex', alignItems: 'center', gap: 10, padding: '0 14px', height: 50, borderBottom: '1px solid var(--line)' }}
+            >
+              <div style={isMobile
+                ? { flex: 1, display: 'flex', alignItems: 'center', gap: 8, height: 44, padding: '0 12px', background: 'var(--surface)', border: '1px solid var(--line-strong)', borderRadius: 10, boxSizing: 'border-box' }
+                : { flex: 1, display: 'flex', alignItems: 'center', gap: 10 }}
+              >
+                <svg viewBox="0 0 24 24" style={{ width: 16, height: 16, flex: 'none' }} aria-hidden="true">
+                  <path d="M10.5 3a7.5 7.5 0 1 1 0 15 7.5 7.5 0 0 1 0-15Z" fill="none" stroke="var(--ink-3)" strokeWidth="2" />
+                  <path d="M16.2 16.2 21 21" fill="none" stroke="var(--ink-3)" strokeWidth="2" strokeLinecap="round" />
+                </svg>
+                <input
+                  ref={inputRef}
+                  autoFocus
+                  value={q}
+                  onChange={(e) => setQ(e.target.value)}
+                  onKeyDown={onInputKey}
+                  placeholder="Search leads, campaigns, agents…"
+                  aria-label="Global search"
+                  role="combobox"
+                  aria-expanded="true"
+                  aria-controls="av2-palette-list"
+                  aria-activedescendant={flat[active]?.id}
+                  style={{ flex: 1, minWidth: 0, border: 'none', outline: 'none', background: 'transparent', fontFamily: 'var(--font-ui)', fontSize: 14, color: 'var(--ink)' }}
+                />
+              </div>
+              {isMobile ? (
+                <button
+                  type="button"
+                  onClick={() => setOpen(false)}
+                  style={{ background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 13, fontWeight: 700, color: 'var(--accent-text)', padding: '10px 2px', flex: 'none' }}
+                >
+                  Cancel
+                </button>
+              ) : (
+                <span className="av2-mono" style={{ fontSize: 10, color: 'var(--ink-3)', border: '1px solid var(--line-strong)', borderRadius: 5, padding: '1px 5px', flex: 'none' }}>esc</span>
+              )}
             </div>
 
-            <div id="av2-palette-list" role="listbox" aria-label="Search results" style={{ maxHeight: 400, overflowY: 'auto', padding: 6 }}>
+            <div id="av2-palette-list" role="listbox" aria-label="Search results" style={isMobile ? { flex: 1, overflowY: 'auto', padding: '6px 10px calc(20px + env(safe-area-inset-bottom, 0px))' } : { maxHeight: 400, overflowY: 'auto', padding: 6 }}>
               {!searching && q.trim().length < 1 && (
                 <div className="av2-mono" style={{ padding: '18px 12px', fontSize: 11, color: 'var(--ink-3)', textAlign: 'center' }}>
                   Type to search leads, campaigns, agents and pages
@@ -298,11 +342,13 @@ export default function GlobalSearch() {
               })}
             </div>
 
-            <div className="av2-mono" style={{ padding: '8px 14px', borderTop: '1px solid var(--line)', fontSize: 10, color: 'var(--ink-3)', display: 'flex', gap: 14 }}>
-              <span>↑↓ navigate</span>
-              <span>↵ open</span>
-              <span>esc close</span>
-            </div>
+            {!isMobile && (
+              <div className="av2-mono" style={{ padding: '8px 14px', borderTop: '1px solid var(--line)', fontSize: 10, color: 'var(--ink-3)', display: 'flex', gap: 14 }}>
+                <span>↑↓ navigate</span>
+                <span>↵ open</span>
+                <span>esc close</span>
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/src/components/adminv2/NotificationsBell.jsx
+++ b/src/components/adminv2/NotificationsBell.jsx
@@ -14,13 +14,17 @@ import { fetchAttention } from '@/api/adminV2';
 import { composeAttentionRows, SEVERITY_GLYPH } from '@/lib/adminV2/attention';
 import { fmtRelative } from '@/lib/adminV2/format';
 import { Skeleton } from '@/components/adminv2/primitives';
+import { useAdminV2Mobile } from './mobile/useAdminV2Mobile';
 
 const ACTIONABLE = new Set(['incident', 'held', 'warning']);
 const TONE = { incident: 'var(--bad)', held: 'var(--hold)', warning: 'var(--warn)', watch: 'var(--ink-3)' };
+const SEV_SOFT = { incident: 'var(--bad-soft)', held: 'var(--hold-soft)', warning: 'var(--warn-soft)', watch: 'var(--accent-soft)' };
+const SEV_FG = { incident: 'var(--bad)', held: 'var(--hold)', warning: 'var(--warn)', watch: 'var(--accent-text)' };
 
 export default function NotificationsBell() {
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
+  const isMobile = useAdminV2Mobile();
 
   const attention = useQuery({
     queryKey: ['adminV2', 'attention'],
@@ -66,8 +70,9 @@ export default function NotificationsBell() {
         aria-expanded={open}
         style={{
           width: 40, height: 40, flex: 'none', display: 'flex', alignItems: 'center', justifyContent: 'center',
-          background: 'var(--surface)', border: '1px solid var(--line-strong)', borderRadius: 10, cursor: 'pointer',
-          position: 'relative',
+          background: isMobile ? 'transparent' : 'var(--surface)',
+          border: isMobile ? 'none' : '1px solid var(--line-strong)',
+          borderRadius: 10, cursor: 'pointer', position: 'relative', padding: 0,
         }}
       >
         <svg viewBox="0 0 24 24" style={{ width: 16, height: 16 }} aria-hidden="true">
@@ -90,7 +95,83 @@ export default function NotificationsBell() {
         )}
       </button>
 
-      {open && (
+      {open && isMobile && (
+        /* Full-screen takeover (design 1694f8b2): back chevron · title · count,
+           then card rows with severity-tinted icon squares + deep-link CTAs. */
+        <div
+          aria-label="Notifications"
+          style={{ position: 'fixed', inset: 0, zIndex: 110, background: 'var(--canvas)', display: 'flex', flexDirection: 'column', animation: 'av2m-fade-in .15s ease' }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, padding: 'calc(8px + env(safe-area-inset-top, 0px)) 10px 8px', borderBottom: '1px solid var(--line)', flex: 'none' }}>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              aria-label="Close notifications"
+              style={{ width: 44, height: 44, flex: 'none', display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0 }}
+            >
+              <svg viewBox="0 0 24 24" style={{ width: 20, height: 20 }} aria-hidden="true">
+                <path d="M14.5 5 8 12l6.5 7" fill="none" stroke="var(--ink)" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </button>
+            <span style={{ flex: 1, minWidth: 0 }}>
+              <span style={{ display: 'block', fontWeight: 800, fontSize: 16, letterSpacing: '-0.01em', color: 'var(--ink)' }}>Needs attention</span>
+              <span className="av2-mono" style={{ display: 'block', fontSize: 9, letterSpacing: '.14em', color: 'var(--ink-3)', textTransform: 'uppercase' }}>
+                {attention.dataUpdatedAt ? `updated ${fmtRelative(attention.dataUpdatedAt)}` : 'all times SGT'}
+              </span>
+            </span>
+            {rows.length > 0 && (
+              <span className="av2-mono" style={{ fontSize: 11, fontWeight: 600, background: 'var(--ink)', color: 'var(--canvas)', borderRadius: 6, padding: '2px 8px', marginRight: 8 }}>
+                {rows.length}
+              </span>
+            )}
+          </div>
+          <div style={{ flex: 1, overflowY: 'auto', padding: '10px 14px calc(20px + env(safe-area-inset-bottom, 0px))' }}>
+            {attention.isLoading && [0, 1, 2].map((i) => (
+              <div key={i} style={{ paddingBottom: 8 }}><Skeleton height={60} style={{ borderRadius: 14 }} /></div>
+            ))}
+            {attention.isError && (
+              <div style={{ padding: '20px 10px', display: 'grid', gap: 8, justifyItems: 'center' }}>
+                <span style={{ fontSize: 12.5, color: 'var(--ink-2)' }}>Couldn’t load alerts.</span>
+                <button type="button" className="av2-btn av2-btn--sm" onClick={() => attention.refetch()}>Retry</button>
+              </div>
+            )}
+            {!attention.isLoading && !attention.isError && rows.length === 0 && (
+              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8, padding: '60px 20px', textAlign: 'center' }}>
+                <svg viewBox="0 0 24 24" style={{ width: 40, height: 40 }} aria-hidden="true">
+                  <circle cx="12" cy="12" r="10" fill="var(--ok-soft)" />
+                  <path d="M7.5 12.5l3 3 6-6.5" fill="none" stroke="var(--ok)" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+                <div style={{ fontSize: 14, fontWeight: 800, color: 'var(--ink)' }}>All clear</div>
+                <div style={{ fontSize: 12.5, color: 'var(--ink-2)', maxWidth: '30ch', lineHeight: 1.5 }}>Nothing needs you. Deep links land here when something does.</div>
+              </div>
+            )}
+            {rows.map((r) => (
+              <button
+                key={r.id}
+                type="button"
+                onClick={() => go(r.href)}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 11, width: '100%', padding: '11px 12px',
+                  background: 'var(--surface)', border: '1px solid var(--line)', borderRadius: 14, marginBottom: 8,
+                  cursor: 'pointer', textAlign: 'left', fontFamily: 'var(--font-ui)', color: 'var(--ink)',
+                  boxShadow: 'var(--shadow)', minHeight: 60, boxSizing: 'border-box',
+                }}
+              >
+                <span aria-hidden="true" style={{ width: 34, height: 34, flex: 'none', borderRadius: 10, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 14, background: SEV_SOFT[r.severity] || 'var(--surface-2)', color: SEV_FG[r.severity] || 'var(--ink-2)' }}>
+                  {SEVERITY_GLYPH[r.severity] || '●'}
+                </span>
+                <span style={{ flex: 1, minWidth: 0 }}>
+                  <span style={{ display: 'block', fontSize: 13, fontWeight: 700, lineHeight: 1.35 }}>{r.title}</span>
+                  <span style={{ display: 'block', fontSize: 11, color: 'var(--ink-2)', marginTop: 1 }}>{r.detail}</span>
+                </span>
+                {r.cta && <span style={{ fontSize: 11.5, fontWeight: 700, color: 'var(--accent-text)', whiteSpace: 'nowrap', flex: 'none' }}>{r.cta} →</span>}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {open && !isMobile && (
         <>
           <div onClick={() => setOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 60 }} aria-hidden="true" />
           {/* Plain popover of buttons/links — deliberately NOT role="menu",

--- a/src/components/adminv2/mobile/MobileBars.jsx
+++ b/src/components/adminv2/mobile/MobileBars.jsx
@@ -1,0 +1,117 @@
+/**
+ * Fixed bottom bars for mobile screens (design source 1694f8b2):
+ * - MobileActionBar: primary action + ⋯ overflow, floats above the tab bar
+ *   on profile/detail screens.
+ * - MobileSelectBar: ink-filled multi-select bar that REPLACES the tab bar
+ *   while a selection exists (✕ · count · actions).
+ * - MobileFooterBar: full-width fixed footer for editor screens (live count
+ *   left, one primary right) — used where the tab bar is hidden.
+ */
+
+export function MobileActionBar({ children }) {
+  return (
+    <div
+      style={{
+        position: 'fixed', bottom: 'calc(59px + env(safe-area-inset-bottom, 0px))', left: 0, right: 0,
+        zIndex: 99, padding: '8px 12px 10px', display: 'flex', gap: 8, boxSizing: 'border-box',
+        background: 'linear-gradient(to top, var(--canvas) 62%, transparent)', pointerEvents: 'none',
+      }}
+    >
+      <div style={{ display: 'flex', gap: 8, flex: 1, pointerEvents: 'auto' }}>{children}</div>
+    </div>
+  );
+}
+
+export function MobilePrimaryBtn({ children, onClick, disabled }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        flex: 1, height: 48, background: 'var(--accent)', color: 'var(--accent-ink)', border: 'none',
+        borderRadius: 12, cursor: disabled ? 'not-allowed' : 'pointer', fontFamily: 'var(--font-ui)',
+        fontSize: 14, fontWeight: 700, boxShadow: 'var(--shadow)', opacity: disabled ? 0.55 : 1,
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function MobileMoreBtn({ onClick, label = 'More actions' }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      style={{
+        width: 48, height: 48, flex: 'none', background: 'var(--surface)', border: '1px solid var(--line-strong)',
+        borderRadius: 12, cursor: 'pointer', color: 'var(--ink)', fontSize: 17, fontWeight: 700, boxShadow: 'var(--shadow)',
+      }}
+    >
+      ⋯
+    </button>
+  );
+}
+
+export function MobileSelectBar({ count, onCancel, actions = [] }) {
+  return (
+    <div
+      className="av2m-selectbar"
+      style={{
+        position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 105,
+        background: 'var(--ink)', color: 'var(--canvas)',
+        padding: '10px 12px calc(12px + env(safe-area-inset-bottom, 0px))',
+        display: 'flex', alignItems: 'center', gap: 6, boxSizing: 'border-box',
+        animation: 'av2m-slide-up .2s ease',
+      }}
+    >
+      <button
+        type="button"
+        onClick={onCancel}
+        aria-label="Cancel selection"
+        style={{ width: 40, height: 40, flex: 'none', background: 'transparent', border: '1px solid var(--ink-2)', borderRadius: 10, color: 'var(--canvas)', cursor: 'pointer', fontSize: 14 }}
+      >
+        ✕
+      </button>
+      <span className="av2-mono" style={{ fontSize: 11, fontWeight: 600, flex: 'none', padding: '0 4px' }}>{count}</span>
+      <div style={{ flex: 1, display: 'flex', justifyContent: 'flex-end', gap: 6, overflowX: 'auto', paddingLeft: 4 }}>
+        {actions.map((a) => (
+          <button
+            key={a.label}
+            type="button"
+            onClick={a.run}
+            disabled={a.disabled}
+            style={{
+              height: 40, flex: 'none', padding: '0 11px', borderRadius: 10, cursor: a.disabled ? 'not-allowed' : 'pointer',
+              fontFamily: 'var(--font-ui)', fontSize: 12, fontWeight: 700, whiteSpace: 'nowrap',
+              background: a.tone === 'danger' ? 'var(--bad)' : a.tone === 'primary' ? 'var(--canvas)' : 'transparent',
+              color: a.tone === 'danger' ? '#fff' : a.tone === 'primary' ? 'var(--ink)' : 'var(--canvas)',
+              border: a.tone ? '1px solid transparent' : '1px solid var(--ink-2)',
+              opacity: a.disabled ? 0.5 : 1,
+            }}
+          >
+            {a.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function MobileFooterBar({ left, button }) {
+  return (
+    <div
+      style={{
+        position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 100,
+        background: 'var(--surface)', borderTop: '1px solid var(--line)',
+        padding: '10px 14px calc(12px + env(safe-area-inset-bottom, 0px))',
+        display: 'flex', alignItems: 'center', gap: 10, boxSizing: 'border-box',
+      }}
+    >
+      <span style={{ flex: 1, minWidth: 0 }}>{left}</span>
+      {button}
+    </div>
+  );
+}

--- a/src/components/adminv2/mobile/MobileSheet.jsx
+++ b/src/components/adminv2/mobile/MobileSheet.jsx
@@ -1,0 +1,124 @@
+/**
+ * Generic bottom sheet — the mobile replacement for every desktop dropdown,
+ * popover and dialog on the v2 surface (design source 1694f8b2). Plain fixed
+ * divs, no portal, so it stays inside the .admin-v2 subtree and inherits the
+ * [data-theme] token scope — same reasoning as GlobalSearch's overlay.
+ */
+import { useEffect } from 'react';
+
+export default function MobileSheet({ open, onClose, label, children, maxHeight = '84dvh' }) {
+  useEffect(() => {
+    if (!open) return undefined;
+    const onKey = (e) => { if (e.key === 'Escape') onClose?.(); };
+    window.addEventListener('keydown', onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div
+        onClick={onClose}
+        aria-hidden="true"
+        style={{ position: 'fixed', inset: 0, zIndex: 130, background: 'rgba(10, 12, 18, .5)', animation: 'av2m-fade-in .18s ease' }}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={label}
+        className="av2m-sheet"
+        style={{
+          position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 131,
+          background: 'var(--surface)', color: 'var(--ink)',
+          borderRadius: '18px 18px 0 0', boxShadow: '0 -8px 40px rgba(10, 12, 18, .25)',
+          animation: 'av2m-sheet-in .26s cubic-bezier(.32, .72, .35, 1)',
+          maxHeight, display: 'flex', flexDirection: 'column', boxSizing: 'border-box',
+        }}
+      >
+        <div style={{ padding: '9px 0 2px', display: 'flex', justifyContent: 'center', flex: 'none' }} aria-hidden="true">
+          <span style={{ width: 36, height: 4, borderRadius: 2, background: 'var(--line-strong)' }} />
+        </div>
+        <div style={{ overflowY: 'auto', padding: '6px 16px calc(18px + env(safe-area-inset-bottom, 0px))' }}>
+          {children}
+        </div>
+      </div>
+    </>
+  );
+}
+
+/** Sheet header block: bold title + optional mono kicker below. */
+export function SheetHead({ title, kicker, action }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, padding: '2px 0 12px' }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <h3 style={{ margin: 0, fontSize: 16, fontWeight: 800, color: 'var(--ink)' }}>{title}</h3>
+        {kicker && (
+          <div className="av2-mono" style={{ fontSize: 10, letterSpacing: '.1em', color: 'var(--ink-3)', marginTop: 3, textTransform: 'uppercase' }}>
+            {kicker}
+          </div>
+        )}
+      </div>
+      {action}
+    </div>
+  );
+}
+
+/** Menu-style sheet rows (overflow actions). */
+export function SheetMenuItem({ label, sub, danger, onClick }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        display: 'flex', alignItems: 'center', gap: 10, width: '100%', minHeight: 52,
+        padding: '8px 12px', background: 'var(--surface-2)', border: 'none', borderRadius: 12,
+        marginBottom: 7, cursor: 'pointer', textAlign: 'left', fontFamily: 'var(--font-ui)',
+      }}
+    >
+      <span style={{ flex: 1, minWidth: 0 }}>
+        <span style={{ display: 'block', fontSize: 13.5, fontWeight: 700, color: danger ? 'var(--bad)' : 'var(--ink)' }}>{label}</span>
+        {sub && <span style={{ display: 'block', fontSize: 11, color: 'var(--ink-3)', marginTop: 1 }}>{sub}</span>}
+      </span>
+      <span style={{ color: 'var(--ink-3)', flex: 'none' }} aria-hidden="true">›</span>
+    </button>
+  );
+}
+
+/** Destructive / decisive confirm body for a sheet. */
+export function SheetConfirm({ title, body, label, danger = true, onConfirm, onCancel }) {
+  return (
+    <>
+      <div style={{ padding: '4px 0 16px' }}>
+        <h3 style={{ margin: 0, fontSize: 16, fontWeight: 800, color: 'var(--ink)' }}>{title}</h3>
+        <div style={{ fontSize: 12.5, color: 'var(--ink-2)', marginTop: 6, lineHeight: 1.55 }}>{body}</div>
+      </div>
+      <button
+        type="button"
+        onClick={onConfirm}
+        style={{
+          width: '100%', height: 48, border: 'none', borderRadius: 12, cursor: 'pointer',
+          fontFamily: 'var(--font-ui)', fontSize: 14, fontWeight: 700,
+          background: danger ? 'var(--bad)' : 'var(--accent)', color: '#fff',
+        }}
+      >
+        {label}
+      </button>
+      <button
+        type="button"
+        onClick={onCancel}
+        style={{
+          width: '100%', height: 44, marginTop: 8, background: 'var(--surface-2)', color: 'var(--ink-2)',
+          border: 'none', borderRadius: 12, cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 13, fontWeight: 700,
+        }}
+      >
+        Cancel
+      </button>
+    </>
+  );
+}

--- a/src/components/adminv2/mobile/MobileTabBar.jsx
+++ b/src/components/adminv2/mobile/MobileTabBar.jsx
@@ -1,0 +1,65 @@
+/**
+ * Mobile bottom tab bar — the five root destinations of the ops console
+ * (design source 1694f8b2 "MKTR Ops Console Mobile"). Icons stay in the
+ * Switchboard geometric-glyph family (■●▲◆⋯), never a generic icon set.
+ * Money covers both /AdminWallets and /AdminAgents; everything reached from
+ * the More hub keeps the More tab lit.
+ */
+import { Link, useLocation } from 'react-router-dom';
+
+const TABS = [
+  { key: 'home', label: 'Home', to: '/AdminDashboard', icon: 'M5 5 h14 v14 H5 Z', match: [/^\/admindashboard/] },
+  { key: 'leads', label: 'Leads', to: '/AdminProspects', icon: 'M12 4 a8 8 0 1 1 0 16 a8 8 0 1 1 0 -16 Z', match: [/^\/adminprospects/, /^\/admin\/leads\//] },
+  { key: 'campaigns', label: 'Campaigns', to: '/AdminCampaigns', icon: 'M12 3 L22 20 L2 20 Z', match: [/^\/admincampaigns/, /^\/admin\/campaigns/] },
+  { key: 'money', label: 'Money', to: '/AdminWallets', icon: 'M12 2 L21 12 L12 22 L3 12 Z', match: [/^\/adminwallets/, /^\/adminagents/] },
+  {
+    key: 'more', label: 'More', to: '/admin/more',
+    icon: 'M6 10.3 a1.7 1.7 0 1 1 0 3.4 a1.7 1.7 0 1 1 0-3.4 M12 10.3 a1.7 1.7 0 1 1 0 3.4 a1.7 1.7 0 1 1 0-3.4 M18 10.3 a1.7 1.7 0 1 1 0 3.4 a1.7 1.7 0 1 1 0-3.4',
+    match: [/^\/admin\/more/, /^\/adminpeople/, /^\/admincohorts/, /^\/admin\/cohorts/, /^\/adminbroadcasts/, /^\/admin\/broadcasts/, /^\/adminagentgroups/, /^\/adminqrcodes/, /^\/adminshortlinks/, /^\/adminusers/, /^\/adminaisettings/],
+  },
+];
+
+export function activeTabKey(pathname) {
+  const p = pathname.toLowerCase();
+  const hit = TABS.find((t) => t.match.some((rx) => rx.test(p)));
+  return hit?.key || null;
+}
+
+export default function MobileTabBar() {
+  const { pathname } = useLocation();
+  const active = activeTabKey(pathname);
+
+  return (
+    <nav
+      aria-label="Tabs"
+      style={{
+        position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 80,
+        display: 'flex', background: 'var(--surface)', borderTop: '1px solid var(--line)',
+        padding: '4px 6px calc(6px + env(safe-area-inset-bottom, 0px))', boxSizing: 'border-box',
+      }}
+    >
+      {TABS.map((t) => {
+        const on = active === t.key;
+        return (
+          <Link
+            key={t.key}
+            to={t.to}
+            aria-current={on ? 'page' : undefined}
+            style={{
+              flex: 1, minHeight: 48, display: 'flex', flexDirection: 'column',
+              alignItems: 'center', justifyContent: 'center', gap: 3,
+              textDecoration: 'none', borderRadius: 10,
+            }}
+          >
+            <svg viewBox="0 0 24 24" style={{ width: 17, height: 17 }} aria-hidden="true">
+              <path d={t.icon} fill={on ? 'var(--accent)' : 'var(--ink-3)'} />
+            </svg>
+            <span style={{ fontSize: 10, fontWeight: on ? 800 : 500, color: on ? 'var(--ink)' : 'var(--ink-3)', letterSpacing: '.01em' }}>
+              {t.label}
+            </span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/adminv2/mobile/MoneySegments.jsx
+++ b/src/components/adminv2/mobile/MoneySegments.jsx
@@ -1,0 +1,27 @@
+/**
+ * Money tab segmented control (mobile) — the design's one Money screen maps to
+ * two routes here (/AdminWallets, /AdminAgents); this control cross-links them
+ * so the tab still feels like a single surface.
+ */
+import { useNavigate } from 'react-router-dom';
+
+export default function MoneySegments({ active }) {
+  const navigate = useNavigate();
+  const seg = (on) => ({
+    flex: 1, height: 36, border: 'none', borderRadius: 8, cursor: 'pointer',
+    fontFamily: 'var(--font-ui)', fontSize: 12.5, fontWeight: 700,
+    background: on ? 'var(--surface)' : 'transparent',
+    color: on ? 'var(--ink)' : 'var(--ink-3)',
+    boxShadow: on ? 'var(--shadow)' : 'none',
+  });
+  return (
+    <div role="tablist" aria-label="Money" style={{ display: 'flex', background: 'var(--surface-2)', border: '1px solid var(--line)', borderRadius: 11, padding: 3, marginBottom: 10 }}>
+      <button type="button" role="tab" aria-selected={active === 'wallets'} style={seg(active === 'wallets')} onClick={() => navigate('/AdminWallets')}>
+        Wallets &amp; commitments
+      </button>
+      <button type="button" role="tab" aria-selected={active === 'agents'} style={seg(active === 'agents')} onClick={() => navigate('/AdminAgents')}>
+        Agents
+      </button>
+    </div>
+  );
+}

--- a/src/components/adminv2/mobile/shellContext.js
+++ b/src/components/adminv2/mobile/shellContext.js
@@ -1,0 +1,13 @@
+/**
+ * Shell-owned state the mobile screens need to reach (theme toggle + sign-out
+ * live in the More screen on mobile, but the [data-theme] root and auth
+ * plumbing belong to AdminV2Shell). Separate file so pages can import the
+ * hook without pulling the whole shell into their chunk.
+ */
+import { createContext, useContext } from 'react';
+
+export const AdminV2ShellContext = createContext(null);
+
+export function useAdminV2Shell() {
+  return useContext(AdminV2ShellContext);
+}

--- a/src/components/adminv2/mobile/useAdminV2Mobile.js
+++ b/src/components/adminv2/mobile/useAdminV2Mobile.js
@@ -1,0 +1,27 @@
+/**
+ * Admin v2 mobile breakpoint — one boolean the whole v2 surface branches on.
+ * Same 768px line as src/hooks/use-mobile.jsx, but initialised synchronously
+ * so the first paint on a phone never flashes the desktop chrome.
+ */
+import { useEffect, useState } from 'react';
+
+const QUERY = '(max-width: 767px)';
+
+// jsdom (vitest) ships no matchMedia — treat that as desktop so the existing
+// component tests keep exercising the layout they were written against.
+const canMatch = () => typeof window !== 'undefined' && typeof window.matchMedia === 'function';
+
+export function useAdminV2Mobile() {
+  const [mobile, setMobile] = useState(() => canMatch() && window.matchMedia(QUERY).matches);
+
+  useEffect(() => {
+    if (!canMatch()) return undefined;
+    const mql = window.matchMedia(QUERY);
+    const onChange = () => setMobile(mql.matches);
+    mql.addEventListener('change', onChange);
+    onChange();
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
+
+  return mobile;
+}

--- a/src/components/adminv2/mobile/useLongPress.js
+++ b/src/components/adminv2/mobile/useLongPress.js
@@ -1,0 +1,30 @@
+/**
+ * Long-press (480ms) → enter select mode, mirroring the design source's
+ * touch semantics. Desktop right-click (contextmenu) does the same so the
+ * gesture is testable with a mouse. Returns props to spread on the row.
+ */
+import { useRef } from 'react';
+
+export function useLongPress(onPress) {
+  const timer = useRef(null);
+
+  const clear = () => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+  };
+
+  return {
+    onContextMenu: (e) => {
+      e.preventDefault();
+      onPress?.();
+    },
+    onTouchStart: () => {
+      clear();
+      timer.current = setTimeout(() => onPress?.(), 480);
+    },
+    onTouchEnd: clear,
+    onTouchMove: clear,
+  };
+}

--- a/src/pages/adminv2/AdminV2AISettings.jsx
+++ b/src/pages/adminv2/AdminV2AISettings.jsx
@@ -9,6 +9,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { apiClient } from '@/api/client';
 import { PageHeader, Card, Chip, Skeleton, ErrorState } from '@/components/adminv2/primitives';
+import { useAdminV2Mobile } from '@/components/adminv2/mobile/useAdminV2Mobile';
 
 const fetchSettings = async () => (await apiClient.get('/admin/ai/settings'))?.data?.settings ?? null;
 
@@ -23,7 +24,7 @@ function ProviderCard({ id, label, settings, form, setForm, onTest, testing }) {
   return (
     <Card span={6}>
       <div style={{ padding: 16 }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10, flexWrap: 'wrap' }}>
           <span className="av2-h2">{label}</span>
           {isDefault
             ? <Chip tone="accent">Default</Chip>
@@ -43,7 +44,7 @@ function ProviderCard({ id, label, settings, form, setForm, onTest, testing }) {
 
         <div className="av2-microcaps" style={{ marginBottom: 6 }}>API key</div>
         {!editingKey ? (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
             <span className="av2-mono" style={{ fontSize: 12, color: 'var(--ink-2)' }}>
               {status.configured
                 ? status.source === 'environment' ? 'from server environment' : `••••${status.hint || ''}`
@@ -94,6 +95,7 @@ export default function AdminV2AISettings() {
   const settings = useQuery({ queryKey: ['adminV2', 'aiSettings'], queryFn: fetchSettings });
   const [form, setForm] = useState(null);
   const [testing, setTesting] = useState('');
+  const mobile = useAdminV2Mobile();
 
   useEffect(() => {
     if (settings.data && !form) {
@@ -144,19 +146,33 @@ export default function AdminV2AISettings() {
   if (settings.isLoading || !form) {
     return (
       <div>
-        <PageHeader title="AI Settings" meta="PROVIDERS · KEYS · GUARDRAILS" />
-        <Skeleton height={220} />
+        {mobile ? (
+          <div className="av2-mono" style={{ fontSize: 10, letterSpacing: '.12em', color: 'var(--ink-3)', textTransform: 'uppercase', padding: '2px 2px 10px' }}>
+            providers · keys · guardrails
+          </div>
+        ) : (
+          <PageHeader title="AI Settings" meta="PROVIDERS · KEYS · GUARDRAILS" />
+        )}
+        <Skeleton height={220} style={mobile ? { borderRadius: 14 } : undefined} />
       </div>
     );
   }
 
   return (
     <div>
+      {/* Mobile: shell top bar titles the page — mono meta line only; the save
+          action moves to a full-width button at the bottom of the page. */}
+      {mobile ? (
+        <div className="av2-mono" style={{ fontSize: 10, letterSpacing: '.12em', color: 'var(--ink-3)', textTransform: 'uppercase', padding: '2px 2px 10px' }}>
+          providers · keys · guardrails · workstyle
+        </div>
+      ) : (
       <PageHeader title="AI Settings" meta="PROVIDERS · KEYS · GUARDRAILS · WORKSTYLE">
         <button type="button" className="av2-btn av2-btn--primary" disabled={save.isPending} onClick={() => save.mutate()}>
           {save.isPending ? 'Saving…' : 'Save changes'}
         </button>
       </PageHeader>
+      )}
 
       {settings.data.encryptionReady === false && (
         <div className="av2-caption" style={{ color: 'var(--bad)', marginBottom: 12 }}>
@@ -164,7 +180,7 @@ export default function AdminV2AISettings() {
         </div>
       )}
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 16 }}>
+      <div className="av2-grid12" style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: mobile ? 10 : 16 }}>
         <ProviderCard id="openai" label="OpenAI" settings={settings.data} form={form} setForm={setForm} onTest={testProvider} testing={testing === 'openai'} />
         <ProviderCard id="anthropic" label="Anthropic" settings={settings.data} form={form} setForm={setForm} onTest={testProvider} testing={testing === 'anthropic'} />
 
@@ -194,6 +210,19 @@ export default function AdminV2AISettings() {
           </div>
         </Card>
       </div>
+
+      {/* Mobile: the page action lives at the bottom, full width */}
+      {mobile && (
+        <button
+          type="button"
+          className="av2-btn av2-btn--primary"
+          disabled={save.isPending}
+          onClick={() => save.mutate()}
+          style={{ width: '100%', justifyContent: 'center', height: 46, borderRadius: 12, marginTop: 14 }}
+        >
+          {save.isPending ? 'Saving…' : 'Save changes'}
+        </button>
+      )}
     </div>
   );
 }

--- a/src/pages/adminv2/AdminV2AgentGroups.jsx
+++ b/src/pages/adminv2/AdminV2AgentGroups.jsx
@@ -11,13 +11,14 @@ import { useAgentGroups, useAgentOptions, useWallets } from '@/hooks/queries/use
 import { createAgentGroup, updateAgentGroup, deleteAgentGroup } from '@/api/adminV2';
 import { fmtNumber } from '@/lib/adminV2/format';
 import { Chip, PageHeader, Skeleton, ErrorState, EmptyState, StateRow } from '@/components/adminv2/primitives';
+import { useAdminV2Mobile } from '@/components/adminv2/mobile/useAdminV2Mobile';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import {
   AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle,
   AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction,
 } from '@/components/ui/alert-dialog';
 
-function GroupEditor({ group, onClose }) {
+function GroupEditor({ group, onClose, mobile }) {
   const isNew = !group?.id;
   const [name, setName] = useState(group?.name || '');
   const [description, setDescription] = useState(group?.description || '');
@@ -63,7 +64,13 @@ function GroupEditor({ group, onClose }) {
 
   return (
     <Sheet open onOpenChange={(open) => { if (!open) onClose(); }}>
-      <SheetContent side="right" className="admin-v2" style={{ width: 432, maxWidth: '90vw', padding: 0, background: 'var(--surface)', color: 'var(--ink)', borderLeft: '1px solid var(--line)', display: 'flex', flexDirection: 'column' }}>
+      <SheetContent
+        side={mobile ? 'bottom' : 'right'}
+        className="admin-v2"
+        style={mobile
+          ? { maxHeight: '84dvh', height: 'auto', padding: 0, background: 'var(--surface)', color: 'var(--ink)', borderTop: '1px solid var(--line)', borderRadius: '18px 18px 0 0', display: 'flex', flexDirection: 'column' }
+          : { width: 432, maxWidth: '90vw', padding: 0, background: 'var(--surface)', color: 'var(--ink)', borderLeft: '1px solid var(--line)', display: 'flex', flexDirection: 'column' }}
+      >
         <SheetHeader style={{ padding: '14px 16px', borderBottom: '1px solid var(--line)' }}>
           <SheetTitle style={{ fontSize: 15, fontWeight: 800, color: 'var(--ink)', fontFamily: 'var(--font-ui)', textAlign: 'left' }}>
             {isNew ? 'New agent group' : `Edit ${group.name}`}
@@ -131,9 +138,9 @@ function GroupEditor({ group, onClose }) {
             <div className="av2-caption" style={{ marginTop: 6 }}>Members are stored by phone; agents without a phone can’t join a group.</div>
           </div>
         </div>
-        <div style={{ padding: 16, borderTop: '1px solid var(--line)', display: 'flex', gap: 10, justifyContent: 'flex-end' }}>
-          <button type="button" className="av2-btn" onClick={onClose}>Cancel</button>
-          <button type="button" className="av2-btn av2-btn--primary" disabled={!name.trim() || save.isPending || agents.isError || agents.isLoading} onClick={() => save.mutate()}>
+        <div style={{ padding: mobile ? '12px 16px calc(12px + env(safe-area-inset-bottom, 0px))' : 16, borderTop: '1px solid var(--line)', display: 'flex', gap: 10, justifyContent: 'flex-end', flex: 'none' }}>
+          <button type="button" className="av2-btn" onClick={onClose} style={mobile ? { flex: 1, justifyContent: 'center' } : undefined}>Cancel</button>
+          <button type="button" className="av2-btn av2-btn--primary" disabled={!name.trim() || save.isPending || agents.isError || agents.isLoading} onClick={() => save.mutate()} style={mobile ? { flex: 2, justifyContent: 'center' } : undefined}>
             {save.isPending ? 'Saving…' : isNew ? 'Create group' : 'Save changes'}
           </button>
         </div>
@@ -148,6 +155,7 @@ export default function AdminV2AgentGroups() {
   const [editor, setEditor] = useState(null); // null | {} (new) | group
   const [confirmDelete, setConfirmDelete] = useState(null);
   const queryClient = useQueryClient();
+  const mobile = useAdminV2Mobile();
 
   const fundedIds = useMemo(
     () => new Set((wallets.data || []).filter((w) => w.walletBalanceCents > 0).map((w) => w.id)),
@@ -165,6 +173,114 @@ export default function AdminV2AgentGroups() {
   });
 
   const rows = groups.data || [];
+
+  // Shared overlays — the editor drawer (responsive side) + delete confirm,
+  // mounted by both branches.
+  const overlays = (
+    <>
+      {editor !== null && <GroupEditor group={editor.id ? editor : null} onClose={() => setEditor(null)} mobile={mobile} />}
+
+      <AlertDialog open={!!confirmDelete} onOpenChange={(open) => { if (!open) setConfirmDelete(null); }}>
+        <AlertDialogContent className="admin-v2" style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)' }}>
+          <AlertDialogHeader>
+            <AlertDialogTitle style={{ color: 'var(--ink)' }}>Delete “{confirmDelete?.name}”?</AlertDialogTitle>
+            <AlertDialogDescription style={{ color: 'var(--ink-2)' }}>
+              The group and its member list are removed. Agents themselves are untouched.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => { e.preventDefault(); remove.mutate(confirmDelete.id); }}
+              disabled={remove.isPending}
+              style={{ background: 'var(--bad)', color: '#fff' }}
+            >
+              {remove.isPending ? 'Deleting…' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+
+  /* ── Mobile (design 1694f8b2): meta row + group cards ── */
+  if (mobile) {
+    return (
+      <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '2px 2px 10px' }}>
+          <span className="av2-mono" style={{ flex: 1, minWidth: 0, fontSize: 10, letterSpacing: '.12em', color: 'var(--ink-3)', textTransform: 'uppercase', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {fmtNumber(rows.length)} group{rows.length === 1 ? '' : 's'} · named member collections
+          </span>
+          <button type="button" onClick={() => setEditor({})} style={{ flex: 'none', height: 38, display: 'flex', alignItems: 'center', gap: 5, padding: '0 12px', background: 'var(--accent)', color: 'var(--accent-ink)', border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 12.5, fontWeight: 700 }}>
+            + New group
+          </button>
+        </div>
+
+        {groups.isLoading && (
+          <div style={{ display: 'grid', gap: 8 }}>
+            {[0, 1, 2].map((i) => <Skeleton key={i} height={96} style={{ borderRadius: 14 }} />)}
+          </div>
+        )}
+        {groups.isError && <div className="av2-card"><ErrorState error={groups.error} onRetry={groups.refetch} /></div>}
+        {!groups.isLoading && !groups.isError && rows.length === 0 && (
+          <div className="av2-card">
+            <EmptyState title="No groups yet" hint="Groups are reusable agent pickers — create one to speed up assignment." action={<button type="button" className="av2-btn av2-btn--sm" onClick={() => setEditor({})}>New group</button>} />
+          </div>
+        )}
+
+        <div style={{ display: 'grid', gap: 8 }}>
+          {rows.map((g) => {
+            const members = g.members || [];
+            const funded = members.filter((m) => m.userId && fundedIds.has(m.userId)).length;
+            return (
+              <div
+                key={g.id}
+                className="av2-card"
+                role="button"
+                tabIndex={0}
+                onClick={() => setEditor(g)}
+                onKeyDown={(e) => { if (e.key === 'Enter' && e.target === e.currentTarget) setEditor(g); }}
+                style={{ padding: '12px 13px', cursor: 'pointer' }}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span style={{ flex: 1, minWidth: 0, fontSize: 13.5, fontWeight: 700, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{g.name}</span>
+                  <span style={{ flex: 'none' }}>
+                    {wallets.isLoading
+                      ? <span className="av2-mono" style={{ fontSize: 11, color: 'var(--ink-3)' }}>…</span>
+                      : wallets.isError
+                        ? <span className="av2-mono" title="Wallet data failed to load" style={{ fontSize: 11, color: 'var(--ink-3)' }}>—</span>
+                        : <Chip tone={funded < members.length && members.length > 0 ? 'warn' : 'ok'}>{funded}/{members.length} funded</Chip>}
+                  </span>
+                </div>
+                {g.description && (
+                  <div style={{ fontSize: 11.5, color: 'var(--ink-2)', marginTop: 3, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{g.description}</div>
+                )}
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 8 }}>
+                  <span className="av2-mono" style={{ flex: 1, minWidth: 0, fontSize: 10.5, letterSpacing: '.06em', color: 'var(--ink-3)', textTransform: 'uppercase' }}>
+                    {fmtNumber(members.length)} member{members.length === 1 ? '' : 's'}
+                  </span>
+                  <button
+                    type="button"
+                    className="av2-btn av2-btn--ghost av2-btn--sm"
+                    style={{ flex: 'none', color: 'var(--bad)' }}
+                    onClick={(e) => { e.stopPropagation(); setConfirmDelete(g); }}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="av2-caption" style={{ padding: '14px 4px 0', lineHeight: 1.5 }}>
+          “Funded” counts members holding wallet credits — external agents only in v1. Round-robin routing itself is driven by commitments, not group membership.
+        </div>
+
+        {overlays}
+      </div>
+    );
+  }
 
   return (
     <div>
@@ -217,28 +333,7 @@ export default function AdminV2AgentGroups() {
         “Funded” counts members holding wallet credits — external agents only in v1. Round-robin routing itself is driven by commitments, not group membership.
       </div>
 
-      {editor !== null && <GroupEditor group={editor.id ? editor : null} onClose={() => setEditor(null)} />}
-
-      <AlertDialog open={!!confirmDelete} onOpenChange={(open) => { if (!open) setConfirmDelete(null); }}>
-        <AlertDialogContent className="admin-v2" style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)' }}>
-          <AlertDialogHeader>
-            <AlertDialogTitle style={{ color: 'var(--ink)' }}>Delete “{confirmDelete?.name}”?</AlertDialogTitle>
-            <AlertDialogDescription style={{ color: 'var(--ink-2)' }}>
-              The group and its member list are removed. Agents themselves are untouched.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={(e) => { e.preventDefault(); remove.mutate(confirmDelete.id); }}
-              disabled={remove.isPending}
-              style={{ background: 'var(--bad)', color: '#fff' }}
-            >
-              {remove.isPending ? 'Deleting…' : 'Delete'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      {overlays}
     </div>
   );
 }

--- a/src/pages/adminv2/AdminV2Agents.jsx
+++ b/src/pages/adminv2/AdminV2Agents.jsx
@@ -14,20 +14,29 @@ import { fmtNumber, fmtSGD, fmtSGDExact, fmtRelative } from '@/lib/adminV2/forma
 import { Chip, PageHeader, PeriodSwitch, Skeleton, ErrorState, EmptyState, StateRow } from '@/components/adminv2/primitives';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import WalletLedgerList from '@/components/adminv2/WalletLedgerList';
+import { useAdminV2Mobile } from '@/components/adminv2/mobile/useAdminV2Mobile';
+import MoneySegments from '@/components/adminv2/mobile/MoneySegments';
 
 const LOW_WALLET_CENTS = 5000;
 
 const agentName = (a) => a.fullName || `${a.firstName || ''} ${a.lastName || ''}`.trim() || a.email;
 const isExternal = (a) => a.walletBalanceCents !== null && a.walletBalanceCents !== undefined;
+const initialsOf = (a) => agentName(a).split(/\s+/).map((x) => x[0]).slice(0, 2).join('').toUpperCase();
 
-function AgentDrawer({ agent, period, onClose }) {
+function AgentDrawer({ agent, period, onClose, mobile }) {
   if (!agent) return null;
   const external = isExternal(agent);
   const zero = external && agent.walletBalanceCents === 0;
   const breakdown = agent.owed_leads_breakdown || [];
   return (
     <Sheet open onOpenChange={(open) => { if (!open) onClose(); }}>
-      <SheetContent side="right" className="admin-v2" style={{ width: 432, maxWidth: '90vw', padding: 0, background: 'var(--surface)', color: 'var(--ink)', borderLeft: '1px solid var(--line)', display: 'flex', flexDirection: 'column' }}>
+      <SheetContent
+        side={mobile ? 'bottom' : 'right'}
+        className="admin-v2"
+        style={mobile
+          ? { maxHeight: '84dvh', height: 'auto', padding: 0, background: 'var(--surface)', color: 'var(--ink)', borderTop: '1px solid var(--line)', borderRadius: '18px 18px 0 0', display: 'flex', flexDirection: 'column' }
+          : { width: 432, maxWidth: '90vw', padding: 0, background: 'var(--surface)', color: 'var(--ink)', borderLeft: '1px solid var(--line)', display: 'flex', flexDirection: 'column' }}
+      >
         <SheetHeader style={{ padding: '14px 16px', borderBottom: '1px solid var(--line)' }}>
           <SheetTitle style={{ fontSize: 15, fontWeight: 800, color: 'var(--ink)', fontFamily: 'var(--font-ui)', textAlign: 'left' }}>
             {agentName(agent)}
@@ -104,6 +113,7 @@ export default function AdminV2Agents() {
   const urlSearch = searchParams.get('q') || '';
   const [search, setSearch] = useState(urlSearch);
   const [drawer, setDrawer] = useState(null);
+  const mobile = useAdminV2Mobile();
   const patch = (changes) => {
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev);
@@ -180,6 +190,112 @@ export default function AdminV2Agents() {
     `${fmtNumber(zeroCount)} WALLETS AT S$0`,
     `${fmtNumber(noCommitCount)} WITHOUT OPEN COMMITMENTS`,
   ].filter(Boolean).join(' · ');
+
+  /* ── Mobile (design 1694f8b2 Money tab · Agents segment): card roster ── */
+  if (mobile) {
+    return (
+      <div>
+        <div className="av2-mono" style={{ fontSize: 10, letterSpacing: '.12em', color: 'var(--ink-3)', textTransform: 'uppercase', padding: '2px 2px 10px', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          {meta.toLowerCase()}
+        </div>
+        <MoneySegments active="agents" />
+
+        <div style={{ display: 'flex', gap: 8, paddingBottom: 8 }}>
+          <div className="av2-input" style={{ flex: 1, height: 40, minWidth: 0 }}>
+            <span aria-hidden="true" style={{ color: 'var(--ink-3)' }}>⌕</span>
+            <input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search agents…"
+              aria-label="Search agents"
+              style={{ border: 'none', outline: 'none', background: 'transparent', flex: 1, minWidth: 0, font: 'inherit', color: 'inherit', fontSize: 13 }}
+            />
+          </div>
+          <div className="av2-seg" role="group" aria-label="Status" style={{ flex: 'none' }}>
+            {[['active', 'Active'], ['', 'All']].map(([v, label]) => (
+              <button key={v || 'all'} type="button" aria-pressed={status === v} onClick={() => setStatus(v)} style={{ height: 32, padding: '0 11px', fontSize: 11.5 }}>
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 5, paddingBottom: 10, overflowX: 'auto' }}>
+          {[['', 'All'], ['zero', 'At S$0'], ['nocommit', 'No commitments']].map(([v, label]) => {
+            const on = wFilter === v;
+            return (
+              <button key={v || 'all'} type="button" aria-pressed={on} onClick={() => setWFilter(v)} style={{ flex: 'none', minHeight: 32, padding: '0 12px', borderRadius: 9, cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 11.5, fontWeight: 700, whiteSpace: 'nowrap', background: on ? 'var(--ink)' : 'var(--surface)', color: on ? 'var(--canvas)' : 'var(--ink-2)', border: `1px solid ${on ? 'var(--ink)' : 'var(--line-strong)'}` }}>
+                {label}
+              </button>
+            );
+          })}
+          <span style={{ flex: 1 }} />
+          <PeriodSwitch value={period} onChange={setPeriod} />
+        </div>
+
+        {roster.isLoading && (
+          <div style={{ display: 'grid', gap: 8 }}>
+            {[0, 1, 2, 3].map((i) => <Skeleton key={i} height={92} style={{ borderRadius: 14 }} />)}
+          </div>
+        )}
+        {roster.isError && <div className="av2-card"><ErrorState error={roster.error} onRetry={roster.refetch} /></div>}
+        {!roster.isLoading && !roster.isError && visible.length === 0 && (
+          <div className="av2-card"><EmptyState title="No agents match" hint="Adjust the search or filters." /></div>
+        )}
+        <div style={{ display: 'grid', gap: 8 }}>
+          {visible.map((a) => {
+            const ext = isExternal(a);
+            const zero = ext && a.walletBalanceCents === 0;
+            const low = ext && a.walletBalanceCents > 0 && a.walletBalanceCents < LOW_WALLET_CENTS;
+            return (
+              <button
+                key={a.id}
+                type="button"
+                onClick={() => setDrawer(a)}
+                className="av2-card"
+                style={{ display: 'block', width: '100%', textAlign: 'left', padding: '11px 13px', cursor: 'pointer', fontFamily: 'var(--font-ui)', color: 'var(--ink)' }}
+              >
+                <span style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <span style={{ width: 36, height: 36, flex: 'none', borderRadius: '50%', background: 'var(--surface-2)', color: 'var(--ink-2)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, fontWeight: 700 }}>
+                    {initialsOf(a)}
+                  </span>
+                  <span style={{ flex: 1, minWidth: 0 }}>
+                    <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                      <span style={{ fontSize: 13.5, fontWeight: 700, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{agentName(a)}</span>
+                      {!a.isActive && <Chip tone="warn">Inactive</Chip>}
+                    </span>
+                    <span className="av2-mono" style={{ display: 'block', fontSize: 10, color: 'var(--ink-3)', marginTop: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                      {a.phone || a.email || '—'}
+                    </span>
+                  </span>
+                  <span style={{ flex: 'none', textAlign: 'right' }}>
+                    <span className="av2-mono" style={{ display: 'block', fontSize: 14, fontWeight: 600, color: zero ? 'var(--warn)' : low ? 'var(--warn)' : ext ? 'var(--ink)' : 'var(--ink-3)' }}>
+                      {ext ? fmtSGDExact(a.walletBalanceCents) : '—'}
+                    </span>
+                    {zero && (
+                      <span style={{ display: 'inline-block', fontSize: 9.5, fontWeight: 700, background: 'var(--warn-soft)', color: 'var(--warn)', borderRadius: 5, padding: '1px 6px', marginTop: 2 }}>Empty</span>
+                    )}
+                  </span>
+                </span>
+                <span style={{ display: 'flex', alignItems: 'center', gap: 5, margin: '8px 0 0 46px', flexWrap: 'wrap' }}>
+                  {ext
+                    ? (a.committedLeads > 0
+                      ? <Chip tone="accent">{fmtNumber(a.committedLeads)} committed · {fmtSGD(a.committedValueCents)}</Chip>
+                      : <Chip>No commitments</Chip>)
+                    : <Chip>Internal</Chip>}
+                  <span style={{ flex: 1 }} />
+                  <span className="av2-mono" style={{ fontSize: 9.5, color: 'var(--ink-3)', textTransform: 'uppercase' }}>
+                    {fmtNumber(a.assignedThisPeriod ?? 0)} assigned {period} · last {a.lastAssignedAt ? fmtRelative(a.lastAssignedAt) : '—'}
+                  </span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        <AgentDrawer agent={drawer} period={period} onClose={() => setDrawer(null)} mobile />
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/src/pages/adminv2/AdminV2BroadcastDetail.jsx
+++ b/src/pages/adminv2/AdminV2BroadcastDetail.jsx
@@ -23,6 +23,7 @@ import {
 } from '@/lib/adminV2/broadcasts';
 import { Card, Chip, PageHeader, Skeleton, ErrorState, EmptyState, StateRow } from '@/components/adminv2/primitives';
 import { BroadcastComposer } from './AdminV2Broadcasts';
+import { useAdminV2Mobile } from '@/components/adminv2/mobile/useAdminV2Mobile';
 import {
   AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle,
   AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction,
@@ -30,9 +31,9 @@ import {
 
 const PAGE_SIZE = 50;
 
-function Tile({ label, value, caption, tone }) {
+function Tile({ label, value, caption, tone, style }) {
   return (
-    <div style={{ flex: 1, padding: 16, borderRight: '1px solid var(--line)' }}>
+    <div style={{ flex: 1, padding: 16, borderRight: '1px solid var(--line)', boxSizing: 'border-box', ...style }}>
       <div className="av2-microcaps">{label}</div>
       <div className="av2-mono" style={{ fontSize: 20, fontWeight: 600, marginTop: 4, color: tone || 'var(--ink)' }}>{value}</div>
       {caption && <div className="av2-caption" style={{ marginTop: 2 }}>{caption}</div>}
@@ -48,6 +49,7 @@ export default function AdminV2BroadcastDetail() {
   const [editing, setEditing] = useState(false);
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const mobile = useAdminV2Mobile();
 
   const broadcast = useQuery({
     queryKey: ['adminV2', 'emailBroadcast', id],
@@ -110,8 +112,8 @@ export default function AdminV2BroadcastDetail() {
   if (broadcast.isLoading) {
     return (
       <div>
-        <Skeleton height={30} width={340} />
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 16, marginTop: 20 }}>
+        <Skeleton height={30} width={340} style={{ maxWidth: '100%' }} />
+        <div className="av2-grid12" style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 16, marginTop: 20 }}>
           {[12, 12].map((span, i) => <div key={i} style={{ gridColumn: `span ${span}` }}><Skeleton height={140} /></div>)}
         </div>
       </div>
@@ -122,75 +124,96 @@ export default function AdminV2BroadcastDetail() {
   const st = BROADCAST_STATUS_META[b.status] || { label: b.status, tone: '' };
   const counts = b.liveCounts || {};
   const remaining = (counts.pending || 0) + (counts.attempting || 0);
+  const metaLine = `${(b.cohort?.name || '—').toUpperCase()} → ${(b.campaign?.name || '—').toUpperCase()} · ${st.label.toUpperCase()}`;
 
-  return (
-    <div>
-      <PageHeader
-        title={b.subject}
-        meta={`${(b.cohort?.name || '—').toUpperCase()} → ${(b.campaign?.name || '—').toUpperCase()} · ${st.label.toUpperCase()}`}
-      >
-        <Link to="/AdminBroadcasts" className="av2-btn av2-btn--sm" style={{ textDecoration: 'none' }}>← All pushes</Link>
-        {b.status === 'draft' && (
-          <>
-            <button type="button" className="av2-btn av2-btn--sm" onClick={() => setEditing(true)}>Edit</button>
-            <button type="button" className="av2-btn av2-btn--sm" disabled={test.isPending} onClick={() => test.mutate()}>
-              {test.isPending ? 'Sending test…' : 'Send test to my email'}
-            </button>
-            <button
-              type="button"
-              className="av2-btn av2-btn--sm"
-              style={{ borderColor: 'var(--bad)', color: 'var(--bad)' }}
-              disabled={destroy.isPending}
-              onClick={() => destroy.mutate()}
-            >
-              Delete
-            </button>
-            <button type="button" className="av2-btn av2-btn--sm av2-btn--primary" onClick={() => setConfirmSend(true)}>Send…</button>
-          </>
-        )}
-        {active && (
+  // One set of header actions — PageHeader children on desktop, a wrap row of
+  // the same compact buttons under the title on mobile. Handlers identical.
+  const headerActions = (
+    <>
+      <Link to="/AdminBroadcasts" className="av2-btn av2-btn--sm" style={{ textDecoration: 'none' }}>← All pushes</Link>
+      {b.status === 'draft' && (
+        <>
+          <button type="button" className="av2-btn av2-btn--sm" onClick={() => setEditing(true)}>Edit</button>
+          <button type="button" className="av2-btn av2-btn--sm" disabled={test.isPending} onClick={() => test.mutate()}>
+            {test.isPending ? 'Sending test…' : 'Send test to my email'}
+          </button>
           <button
             type="button"
             className="av2-btn av2-btn--sm"
             style={{ borderColor: 'var(--bad)', color: 'var(--bad)' }}
-            disabled={cancel.isPending || b.status === 'cancelling'}
+            disabled={destroy.isPending}
+            onClick={() => destroy.mutate()}
+          >
+            Delete
+          </button>
+          <button type="button" className="av2-btn av2-btn--sm av2-btn--primary" onClick={() => setConfirmSend(true)}>Send…</button>
+        </>
+      )}
+      {active && (
+        <button
+          type="button"
+          className="av2-btn av2-btn--sm"
+          style={{ borderColor: 'var(--bad)', color: 'var(--bad)' }}
+          disabled={cancel.isPending || b.status === 'cancelling'}
+          onClick={() => cancel.mutate()}
+        >
+          {b.status === 'cancelling' ? 'Cancelling…' : 'Cancel send'}
+        </button>
+      )}
+      {(b.status === 'interrupted' || b.status === 'failed') && (
+        <>
+          {b.status === 'interrupted' && (
+            <button type="button" className="av2-btn av2-btn--sm av2-btn--primary" disabled={send.isPending} onClick={() => send.mutate({ resume: true })}>
+              Resume
+            </button>
+          )}
+          <button
+            type="button"
+            className="av2-btn av2-btn--sm"
+            style={{ borderColor: 'var(--bad)', color: 'var(--bad)' }}
+            disabled={cancel.isPending}
             onClick={() => cancel.mutate()}
           >
-            {b.status === 'cancelling' ? 'Cancelling…' : 'Cancel send'}
+            Cancel remaining
           </button>
-        )}
-        {(b.status === 'interrupted' || b.status === 'failed') && (
-          <>
-            {b.status === 'interrupted' && (
-              <button type="button" className="av2-btn av2-btn--sm av2-btn--primary" disabled={send.isPending} onClick={() => send.mutate({ resume: true })}>
-                Resume
-              </button>
-            )}
-            <button
-              type="button"
-              className="av2-btn av2-btn--sm"
-              style={{ borderColor: 'var(--bad)', color: 'var(--bad)' }}
-              disabled={cancel.isPending}
-              onClick={() => cancel.mutate()}
-            >
-              Cancel remaining
-            </button>
-          </>
-        )}
-      </PageHeader>
+        </>
+      )}
+    </>
+  );
 
-      {b.lastError && (
-        <div className="av2-caption" style={{ marginTop: -8, marginBottom: 14, color: 'var(--bad)' }}>{b.lastError}</div>
+  return (
+    <div>
+      {mobile ? (
+        <div style={{ padding: '2px 0 12px' }}>
+          <div style={{ fontSize: 18, fontWeight: 800, letterSpacing: '-0.015em', lineHeight: 1.25, color: 'var(--ink)' }}>{b.subject}</div>
+          <div className="av2-mono" style={{ fontSize: 10, letterSpacing: '.09em', color: 'var(--ink-3)', marginTop: 4, textTransform: 'uppercase' }}>{metaLine}</div>
+          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginTop: 10 }}>
+            {headerActions}
+          </div>
+        </div>
+      ) : (
+      <PageHeader
+        title={b.subject}
+        meta={metaLine}
+      >
+        {headerActions}
+      </PageHeader>
       )}
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 16 }}>
+      {b.lastError && (
+        <div className="av2-caption" style={{ marginTop: mobile ? 0 : -8, marginBottom: 14, color: 'var(--bad)' }}>{b.lastError}</div>
+      )}
+
+      <div className="av2-grid12" style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: mobile ? 10 : 16 }}>
         <Card span={12}>
-          <div style={{ display: 'flex' }}>
-            <Tile label="Recipients" value={b.status === 'draft' ? '—' : fmtNumber(b.totalRecipients)} caption={b.status === 'draft' ? 'resolved at send' : 'claimed at send start'} />
-            <Tile label="Sent" value={fmtNumber(counts.sent ?? b.sentCount)} tone="var(--ok)" caption="accepted by the mail server" />
-            <Tile label="Skipped" value={fmtNumber(counts.skipped ?? b.skippedCount)} tone="var(--warn)" caption="gate said no at send time" />
-            <Tile label="Failed" value={fmtNumber(counts.failed ?? b.failedCount)} tone={(counts.failed ?? b.failedCount) ? 'var(--bad)' : undefined} caption="transport errors" />
-            {active && <Tile label="Remaining" value={fmtNumber(remaining)} caption="throttled queue" />}
+          {/* Counter tiles — one row on desktop, a 2×2 grid on phones
+              (Remaining takes a full-width third row while a send runs) */}
+          <div style={{ display: 'flex', flexWrap: mobile ? 'wrap' : 'nowrap' }}>
+            <Tile label="Recipients" value={b.status === 'draft' ? '—' : fmtNumber(b.totalRecipients)} caption={b.status === 'draft' ? 'resolved at send' : 'claimed at send start'} style={mobile ? { flex: '1 1 50%', borderBottom: '1px solid var(--line)' } : undefined} />
+            <Tile label="Sent" value={fmtNumber(counts.sent ?? b.sentCount)} tone="var(--ok)" caption="accepted by the mail server" style={mobile ? { flex: '1 1 50%', borderRight: 'none', borderBottom: '1px solid var(--line)' } : undefined} />
+            <Tile label="Skipped" value={fmtNumber(counts.skipped ?? b.skippedCount)} tone="var(--warn)" caption="gate said no at send time" style={mobile ? { flex: '1 1 50%', ...(active ? { borderBottom: '1px solid var(--line)' } : {}) } : undefined} />
+            <Tile label="Failed" value={fmtNumber(counts.failed ?? b.failedCount)} tone={(counts.failed ?? b.failedCount) ? 'var(--bad)' : undefined} caption="transport errors" style={mobile ? { flex: '1 1 50%', borderRight: 'none', ...(active ? { borderBottom: '1px solid var(--line)' } : {}) } : undefined} />
+            {active && <Tile label="Remaining" value={fmtNumber(remaining)} caption="throttled queue" style={mobile ? { flex: '1 1 100%', borderRight: 'none' } : undefined} />}
           </div>
         </Card>
 
@@ -212,9 +235,9 @@ export default function AdminV2BroadcastDetail() {
             title="Send log"
             meta={recipients.data ? `${fmtNumber(recipients.data.total)} ${status === 'all' ? 'rows' : status}` : undefined}
             action={(
-              <div className="av2-seg" role="group" aria-label="Recipient status">
+              <div className="av2-seg" role="group" aria-label="Recipient status" style={mobile ? { minWidth: 0, maxWidth: '100%', overflowX: 'auto' } : undefined}>
                 {['all', 'sent', 'skipped', 'failed', 'pending'].map((s) => (
-                  <button key={s} type="button" aria-pressed={status === s} onClick={() => { setStatus(s); setPage(0); }}>
+                  <button key={s} type="button" aria-pressed={status === s} onClick={() => { setStatus(s); setPage(0); }} style={mobile ? { flex: 'none', padding: '0 10px', fontSize: 11.5 } : undefined}>
                     {s}
                   </button>
                 ))}
@@ -222,11 +245,11 @@ export default function AdminV2BroadcastDetail() {
             )}
           >
             <div role="table" aria-label="Send log">
-              <div className="av2-thead" role="row">
-                <span className="av2-microcaps" role="columnheader" style={{ flex: 1.6 }}>Email</span>
-                <span className="av2-microcaps" role="columnheader" style={{ width: 110, flex: 'none' }}>Status</span>
-                <span className="av2-microcaps" role="columnheader" style={{ flex: 1.4 }}>Why</span>
-                <span className="av2-microcaps" role="columnheader" style={{ width: 130, flex: 'none', textAlign: 'right' }}>When</span>
+              <div className="av2-thead" role="row" style={mobile ? { minWidth: 0 } : undefined}>
+                <span className="av2-microcaps" role="columnheader" style={{ flex: 1.6, minWidth: 0 }}>Email</span>
+                <span className="av2-microcaps" role="columnheader" style={{ width: mobile ? 84 : 110, flex: 'none' }}>Status</span>
+                <span className="av2-microcaps" role="columnheader" style={{ flex: 1.4, minWidth: 0 }}>Why</span>
+                <span className="av2-microcaps" role="columnheader" style={{ width: mobile ? 64 : 130, flex: 'none', textAlign: 'right' }}>When</span>
               </div>
 
               {recipients.isLoading && <StateRow><div style={{ padding: 12 }}><Skeleton height={60} /></div></StateRow>}
@@ -239,16 +262,16 @@ export default function AdminV2BroadcastDetail() {
                 const rst = RECIPIENT_STATUS_META[r.status] || { label: r.status, tone: '' };
                 const meta = r.reason ? broadcastReasonMeta(r.reason) : null;
                 return (
-                  <div key={r.id} className="av2-row" role="row" style={{ cursor: 'default' }}>
-                    <span role="cell" className="av2-mono" style={{ flex: 1.6, fontSize: 11.5, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  <div key={r.id} className="av2-row" role="row" style={{ cursor: 'default', minWidth: mobile ? 0 : undefined }}>
+                    <span role="cell" className="av2-mono" style={{ flex: 1.6, minWidth: 0, fontSize: 11.5, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                       {r.email || '—'}
                     </span>
-                    <span role="cell" style={{ width: 110, flex: 'none' }}><Chip tone={rst.tone}>{rst.label}</Chip></span>
-                    <span role="cell" style={{ flex: 1.4, display: 'flex', gap: 4, flexWrap: 'wrap', alignItems: 'center' }}>
+                    <span role="cell" style={{ width: mobile ? 84 : 110, flex: 'none' }}><Chip tone={rst.tone}>{rst.label}</Chip></span>
+                    <span role="cell" style={{ flex: 1.4, minWidth: 0, display: 'flex', gap: 4, flexWrap: 'wrap', alignItems: 'center' }}>
                       {r.reason ? <Chip tone={meta?.tone || ''}>{broadcastReasonLabel(r.reason)}</Chip> : <span className="av2-caption">—</span>}
-                      {r.error && <span className="av2-caption" style={{ color: 'var(--bad)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 260 }} title={r.error}>{r.error}</span>}
+                      {r.error && <span className="av2-caption" style={{ color: 'var(--bad)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: mobile ? 140 : 260 }} title={r.error}>{r.error}</span>}
                     </span>
-                    <span role="cell" className="av2-mono" style={{ width: 130, flex: 'none', fontSize: 10.5, color: 'var(--ink-3)', textAlign: 'right' }} title={r.sentAt ? fmtDateTime(r.sentAt) : ''}>
+                    <span role="cell" className="av2-mono" style={{ width: mobile ? 64 : 130, flex: 'none', fontSize: 10.5, color: 'var(--ink-3)', textAlign: 'right' }} title={r.sentAt ? fmtDateTime(r.sentAt) : ''}>
                       {r.sentAt ? fmtRelative(r.sentAt) : '—'}
                     </span>
                   </div>

--- a/src/pages/adminv2/AdminV2Broadcasts.jsx
+++ b/src/pages/adminv2/AdminV2Broadcasts.jsx
@@ -18,6 +18,7 @@ import { fmtNumber, fmtRelative } from '@/lib/adminV2/format';
 import { BROADCAST_STATUS_META } from '@/lib/adminV2/broadcasts';
 import { normalizeDefinitionShape } from '@/lib/adminV2/cohorts';
 import { PageHeader, Chip, Skeleton, ErrorState, EmptyState, StateRow } from '@/components/adminv2/primitives';
+import { useAdminV2Mobile } from '@/components/adminv2/mobile/useAdminV2Mobile';
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription,
 } from '@/components/ui/dialog';
@@ -81,7 +82,8 @@ export function BroadcastComposer({ broadcast = null, initialCohortId = null, on
     <Dialog open onOpenChange={(open) => { if (!open && !save.isPending) onClose(); }}>
       <DialogContent
         className="admin-v2"
-        style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)', maxWidth: 640, maxHeight: '86vh', display: 'flex', flexDirection: 'column' }}
+        variant="sheet"
+        style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)', maxWidth: 640, maxHeight: '86dvh', display: 'flex', flexDirection: 'column', overflowY: 'auto' }}
       >
         <DialogHeader>
           <DialogTitle style={{ color: 'var(--ink)', fontFamily: 'var(--font-ui)', fontSize: 15, fontWeight: 800, textAlign: 'left' }}>
@@ -154,8 +156,99 @@ export default function AdminV2Broadcasts() {
   const [composing, setComposing] = useState(() => !!prefillCohort);
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const mobile = useAdminV2Mobile();
 
   const rows = broadcasts.data?.rows || [];
+
+  // Composer mount shared by both branches — identical wiring either way.
+  const composer = composing && (
+    <BroadcastComposer
+      initialCohortId={prefillCohort}
+      onClose={() => {
+        setComposing(false);
+        if (prefillCohort) setSearchParams({}, { replace: true });
+      }}
+      onSaved={(b) => {
+        queryClient.invalidateQueries({ queryKey: ['adminV2', 'emailBroadcasts'] });
+        if (b?.id) navigate(`/admin/broadcasts/${b.id}`);
+      }}
+    />
+  );
+
+  /* ── Mobile (design 1694f8b2): meta row + push cards ── */
+  if (mobile) {
+    return (
+      <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '2px 2px 10px' }}>
+          <span className="av2-mono" style={{ flex: 1, minWidth: 0, fontSize: 10, letterSpacing: '.12em', color: 'var(--ink-3)', textTransform: 'uppercase', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {fmtNumber(rows.length)} push{rows.length === 1 ? '' : 'es'} · re-gated at send time
+          </span>
+          <button type="button" onClick={() => setComposing(true)} style={{ flex: 'none', height: 38, display: 'flex', alignItems: 'center', gap: 5, padding: '0 12px', background: 'var(--accent)', color: 'var(--accent-ink)', border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 12.5, fontWeight: 700 }}>
+            + New push
+          </button>
+        </div>
+
+        {broadcasts.isLoading && (
+          <div style={{ display: 'grid', gap: 8 }}>
+            {[0, 1, 2].map((i) => <Skeleton key={i} height={96} style={{ borderRadius: 14 }} />)}
+          </div>
+        )}
+        {broadcasts.isError && <div className="av2-card"><ErrorState error={broadcasts.error} onRetry={broadcasts.refetch} /></div>}
+        {!broadcasts.isLoading && !broadcasts.isError && rows.length === 0 && (
+          <div className="av2-card">
+            <EmptyState
+              title="No email pushes yet"
+              hint="Compose a subject/body/CTA about one campaign, pick a cohort, test it to yourself, then send."
+              action={<button type="button" className="av2-btn av2-btn--primary av2-btn--sm" onClick={() => setComposing(true)}>Compose the first one</button>}
+            />
+          </div>
+        )}
+
+        <div style={{ display: 'grid', gap: 8 }}>
+          {rows.map((b) => {
+            const st = BROADCAST_STATUS_META[b.status] || { label: b.status, tone: '' };
+            return (
+              <div
+                key={b.id}
+                className="av2-card"
+                role="button"
+                tabIndex={0}
+                onClick={() => navigate(`/admin/broadcasts/${b.id}`)}
+                onKeyDown={(e) => { if (e.key === 'Enter') navigate(`/admin/broadcasts/${b.id}`); }}
+                style={{ padding: '12px 13px', cursor: 'pointer' }}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span style={{ flex: 1, minWidth: 0, fontSize: 13.5, fontWeight: 700, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{b.subject}</span>
+                  <span style={{ flex: 'none' }}><Chip tone={st.tone}>{st.label}</Chip></span>
+                </div>
+                <div className="av2-mono" style={{ fontSize: 10, color: 'var(--ink-3)', marginTop: 3, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  {b.cohort?.name || '—'} · {b.campaign?.name || '—'}
+                </div>
+                <div className="av2-mono" style={{ display: 'flex', alignItems: 'baseline', gap: 5, marginTop: 8, fontSize: 12 }}>
+                  {b.status === 'draft' ? (
+                    <span style={{ color: 'var(--ink-3)' }}>—</span>
+                  ) : (
+                    <>
+                      <span style={{ color: 'var(--ok)', fontWeight: 700 }}>{fmtNumber(b.sentCount)} sent</span>
+                      <span style={{ color: 'var(--ink-3)' }}>· {fmtNumber(b.skippedCount)} skipped ·</span>
+                      <span style={{ color: b.failedCount ? 'var(--bad)' : 'var(--ink-3)', fontWeight: b.failedCount ? 700 : 400 }}>{fmtNumber(b.failedCount)} failed</span>
+                    </>
+                  )}
+                  <span style={{ marginLeft: 'auto', flex: 'none', fontSize: 10.5, color: 'var(--ink-3)' }}>{fmtRelative(b.createdAt)}</span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="av2-caption" style={{ padding: '14px 4px 0', lineHeight: 1.5 }}>
+          Sends are throttled, one push at a time, with the unsubscribe footer + one-click header on every message. Cohort membership never substitutes for the send-time consent check.
+        </div>
+
+        {composer}
+      </div>
+    );
+  }
 
   return (
     <div>
@@ -224,19 +317,7 @@ export default function AdminV2Broadcasts() {
         Sends are throttled, one push at a time, with the unsubscribe footer + one-click header on every message. Cohort membership never substitutes for the send-time consent check.
       </div>
 
-      {composing && (
-        <BroadcastComposer
-          initialCohortId={prefillCohort}
-          onClose={() => {
-            setComposing(false);
-            if (prefillCohort) setSearchParams({}, { replace: true });
-          }}
-          onSaved={(b) => {
-            queryClient.invalidateQueries({ queryKey: ['adminV2', 'emailBroadcasts'] });
-            if (b?.id) navigate(`/admin/broadcasts/${b.id}`);
-          }}
-        />
-      )}
+      {composer}
     </div>
   );
 }

--- a/src/pages/adminv2/AdminV2CampaignDetail.jsx
+++ b/src/pages/adminv2/AdminV2CampaignDetail.jsx
@@ -5,6 +5,7 @@
  * the existing designer/workspace — this screen observes, it never forks the
  * editing surface.
  */
+import { useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { getMarketplaceListedFromDoc } from '@/lib/designConfigV2';
 import { toast } from 'sonner';
@@ -16,12 +17,14 @@ import { STATUS_LABELS, STATUS_CHIP_CLASS, heldLabel } from '@/lib/adminV2/const
 import { Card, Chip, PageHeader, Skeleton, ErrorState, EmptyState } from '@/components/adminv2/primitives';
 import { SeriesBarChart } from '@/components/adminv2/charts';
 import CampaignScoringCard from '@/components/adminv2/CampaignScoringCard';
+import { useAdminV2Mobile } from '@/components/adminv2/mobile/useAdminV2Mobile';
+import MobileSheet, { SheetHead, SheetMenuItem } from '@/components/adminv2/mobile/MobileSheet';
 
 const WORKSPACE_ON = import.meta.env.VITE_CAMPAIGN_WORKSPACE_ENABLED === 'true';
 
-function Tile({ label, value, caption, tone }) {
+function Tile({ label, value, caption, tone, style }) {
   return (
-    <div style={{ flex: 1, padding: 16, borderRight: '1px solid var(--line)' }}>
+    <div style={{ flex: 1, padding: 16, borderRight: '1px solid var(--line)', boxSizing: 'border-box', ...style }}>
       <div className="av2-microcaps">{label}</div>
       <div className="av2-mono" style={{ fontSize: 20, fontWeight: 600, marginTop: 4, color: tone || 'var(--ink)' }}>{value}</div>
       {caption && <div className="av2-caption" style={{ marginTop: 2 }}>{caption}</div>}
@@ -32,6 +35,8 @@ function Tile({ label, value, caption, tone }) {
 export default function AdminV2CampaignDetail() {
   const { id } = useParams();
   const navigate = useNavigate();
+  const mobile = useAdminV2Mobile();
+  const [actionsOpen, setActionsOpen] = useState(false);
   const summary = useCampaignSummary(id);
   // Zero-commitment truth comes from /attention (wallet OR package funding —
   // a legacy-package-covered campaign must NOT get a false incident banner).
@@ -55,8 +60,8 @@ export default function AdminV2CampaignDetail() {
   if (summary.isLoading) {
     return (
       <div>
-        <Skeleton height={30} width={340} />
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 16, marginTop: 20 }}>
+        <Skeleton height={30} width={340} style={{ maxWidth: '100%' }} />
+        <div className="av2-grid12" style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 16, marginTop: 20 }}>
           {[5, 7, 6, 6].map((span, i) => <div key={i} style={{ gridColumn: `span ${span}` }}><Skeleton height={180} /></div>)}
         </div>
       </div>
@@ -74,11 +79,29 @@ export default function AdminV2CampaignDetail() {
   const editHref = WORKSPACE_ON ? `/admin/campaigns/${c.id}/workspace?tab=details` : `/admin/campaigns/${c.id}/edit`;
   const designHref = `/admin/campaigns/${c.id}/workspace?tab=design`;
 
+  const metaLine = `${(c.type || '').replace(/_/g, ' ').toUpperCase()} · ${fmtDate(c.start_date)} → ${c.end_date ? fmtDate(c.end_date) : 'OPEN-ENDED'} · AGES ${c.min_age ?? '—'}–${c.max_age ?? '—'}`;
+
   return (
     <div>
+      {mobile ? (
+        <div style={{ padding: '2px 0 12px', display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+          <span style={{ flex: 1, minWidth: 0 }}>
+            <span style={{ display: 'block', fontSize: 19, fontWeight: 800, letterSpacing: '-0.015em', lineHeight: 1.2, color: 'var(--ink)' }}>{c.name}</span>
+            <span className="av2-mono" style={{ display: 'block', fontSize: 10, letterSpacing: '.09em', color: 'var(--ink-3)', marginTop: 4, textTransform: 'uppercase' }}>{metaLine}</span>
+          </span>
+          <button
+            type="button"
+            onClick={() => setActionsOpen(true)}
+            aria-label="Campaign actions"
+            style={{ width: 40, height: 40, flex: 'none', background: 'var(--surface)', border: '1px solid var(--line-strong)', borderRadius: 10, cursor: 'pointer', color: 'var(--ink)', fontSize: 16, fontWeight: 700 }}
+          >
+            ⋯
+          </button>
+        </div>
+      ) : (
       <PageHeader
         title={c.name}
-        meta={`${(c.type || '').replace(/_/g, ' ').toUpperCase()} · ${fmtDate(c.start_date)} → ${c.end_date ? fmtDate(c.end_date) : 'OPEN-ENDED'} · AGES ${c.min_age ?? '—'}–${c.max_age ?? '—'}`}
+        meta={metaLine}
       >
         <Link to="/AdminCampaigns" className="av2-btn av2-btn--sm" style={{ textDecoration: 'none' }}>← All campaigns</Link>
         <button type="button" className="av2-btn av2-btn--sm" disabled={duplicate.isPending} onClick={handleDuplicate}>
@@ -87,6 +110,7 @@ export default function AdminV2CampaignDetail() {
         <Link to={designHref} className="av2-btn av2-btn--sm" style={{ textDecoration: 'none' }}>Open designer</Link>
         <Link to={editHref} className="av2-btn av2-btn--primary av2-btn--sm" style={{ textDecoration: 'none' }}>Edit details</Link>
       </PageHeader>
+      )}
 
       <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 16 }}>
         <Chip tone={c.status === 'active' ? 'ok' : c.status === 'paused' ? 'warn' : ''}>{c.status}</Chip>
@@ -95,22 +119,24 @@ export default function AdminV2CampaignDetail() {
         {zeroCommit && <Chip tone="bad" glyph="▲">0 open commitments — new leads will quarantine</Chip>}
       </div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 16 }}>
-        {/* KPI tiles */}
+      <div className="av2-grid12" style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: mobile ? 10 : 16 }}>
+        {/* KPI tiles — one row on desktop, a 2×2 grid on phones */}
         <Card span={12}>
-          <div style={{ display: 'flex' }}>
-            <Tile label="Leads · 30d" value={fmtNumber(summary.data.campaign ? (series?.total ?? 0) : 0)} caption={`${fmtNumber(series?.today ?? 0)} today`} />
+          <div style={{ display: 'flex', flexWrap: mobile ? 'wrap' : 'nowrap' }}>
+            <Tile label="Leads · 30d" value={fmtNumber(summary.data.campaign ? (series?.total ?? 0) : 0)} caption={`${fmtNumber(series?.today ?? 0)} today`} style={mobile ? { flex: '1 1 50%', borderBottom: '1px solid var(--line)' } : undefined} />
             <Tile
               label="Committed demand"
               value={priced ? fmtSGD(committedValueCents) : '—'}
               caption={priced ? `${fmtNumber(committedRemaining)} leads pre-sold` : 'campaign not priced'}
               tone={zeroCommit ? 'var(--bad)' : undefined}
+              style={mobile ? { flex: '1 1 50%', borderRight: 'none', borderBottom: '1px solid var(--line)' } : undefined}
             />
-            <Tile label="Lead price" value={priced ? fmtSGD(c.leadPriceCents) : '—'} caption={priced ? 'per lead, external agents' : 'closed to commitments'} />
+            <Tile label="Lead price" value={priced ? fmtSGD(c.leadPriceCents) : '—'} caption={priced ? 'per lead, external agents' : 'closed to commitments'} style={mobile ? { flex: '1 1 50%' } : undefined} />
             <Tile
               label={draw?.enabled ? 'Draw closes' : 'Ends'}
               value={draw?.enabled ? (drawDays !== null && drawDays > 0 ? `${drawDays}d` : 'closed') : (c.end_date ? fmtDate(c.end_date) : '—')}
               caption={draw?.enabled ? `${draw.winners || 1} winner${(draw.winners || 1) > 1 ? 's' : ''} · ×${draw.multiplier || 1} boost` : 'campaign end date'}
+              style={mobile ? { flex: '1 1 50%', borderRight: 'none' } : undefined}
             />
           </div>
         </Card>
@@ -183,6 +209,33 @@ export default function AdminV2CampaignDetail() {
             while the backend flag is off. */}
         <CampaignScoringCard campaignId={c.id} />
       </div>
+
+      {/* Mobile ⋯ actions sheet */}
+      {mobile && (
+        <MobileSheet open={actionsOpen} onClose={() => setActionsOpen(false)} label="Campaign actions">
+          <SheetHead title={c.name} kicker={c.status} />
+          <SheetMenuItem
+            label="Edit details"
+            sub="Dates, pricing, ages — opens the campaign workspace"
+            onClick={() => { setActionsOpen(false); navigate(editHref); }}
+          />
+          <SheetMenuItem
+            label="Open designer"
+            sub="Page design lives in Studio — best on desktop"
+            onClick={() => { setActionsOpen(false); navigate(designHref); }}
+          />
+          <SheetMenuItem
+            label={duplicate.isPending ? 'Duplicating…' : 'Duplicate'}
+            sub="New draft with the same design & scoring"
+            onClick={() => { if (!duplicate.isPending) { setActionsOpen(false); handleDuplicate(); } }}
+          />
+          <SheetMenuItem
+            label="All campaigns"
+            sub="Back to the campaign board"
+            onClick={() => { setActionsOpen(false); navigate('/AdminCampaigns'); }}
+          />
+        </MobileSheet>
+      )}
     </div>
   );
 }

--- a/src/pages/adminv2/AdminV2Campaigns.jsx
+++ b/src/pages/adminv2/AdminV2Campaigns.jsx
@@ -16,6 +16,10 @@ import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { toast } from 'sonner';
 import { queryClient } from '@/lib/queryClient';
 import * as campaignSvc from '@/services/campaignService';
+import { useAdminV2Mobile } from '@/components/adminv2/mobile/useAdminV2Mobile';
+import { useLongPress } from '@/components/adminv2/mobile/useLongPress';
+import MobileSheet from '@/components/adminv2/mobile/MobileSheet';
+import { MobileSelectBar } from '@/components/adminv2/mobile/MobileBars';
 
 /**
  * Bulk row actions (select → act). Eligibility mirrors the server rules:
@@ -51,6 +55,56 @@ const TYPE_LABELS = {
 const WORKSPACE_ON = import.meta.env.VITE_CAMPAIGN_WORKSPACE_ENABLED === 'true';
 export const newCampaignHref = () => (WORKSPACE_ON ? '/admin/campaigns/workspace' : '/admin/campaigns/new');
 
+/** Mobile campaign card (design 1694f8b2): tap opens, long-press selects. */
+function MobileCampaignRow({ c, priced, drawDays, zeroCommit, marketplace, period, selecting, isSelected, onTap, onLongPress }) {
+  const lp = useLongPress(onLongPress);
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onTap}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onTap(); } }}
+      {...lp}
+      className="av2-card"
+      style={{
+        display: 'block', width: '100%', textAlign: 'left', padding: '12px 13px', cursor: 'pointer',
+        background: isSelected ? 'var(--accent-soft)' : 'var(--surface)',
+        borderColor: isSelected ? 'var(--accent)' : 'var(--line)',
+        WebkitUserSelect: 'none', userSelect: 'none',
+      }}
+    >
+      <span style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+        {selecting && (
+          <span aria-hidden="true" style={{ width: 21, height: 21, flex: 'none', borderRadius: 6, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, boxSizing: 'border-box', border: `1.5px solid ${isSelected ? 'var(--accent)' : 'var(--line-strong)'}`, background: isSelected ? 'var(--accent)' : 'transparent', color: 'var(--accent-ink)' }}>
+            {isSelected ? '✓' : ''}
+          </span>
+        )}
+        <span style={{ flex: 1, minWidth: 0, fontSize: 13.5, fontWeight: 700, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{c.name}</span>
+        <Chip tone={STATUS_TONE[c.status] ?? ''}>{c.status}</Chip>
+      </span>
+      <span className="av2-mono" style={{ display: 'block', fontSize: 10, color: 'var(--ink-3)', margin: '5px 0 0', textTransform: 'uppercase' }}>
+        {(TYPE_LABELS[c.type] || c.type)} · {priced ? `${fmtSGD(c.leadPriceCents)}/lead` : 'not priced'} · {fmtNumber(c.qrTagCount || 0)} QR
+      </span>
+      {(zeroCommit || c.committedRemaining > 0 || (drawDays !== null && drawDays > 0) || marketplace) && (
+        <span style={{ display: 'flex', alignItems: 'center', gap: 5, margin: '7px 0 0', flexWrap: 'wrap' }}>
+          {zeroCommit && <Chip tone="bad" glyph="▲">0 commitments — leads will quarantine</Chip>}
+          {c.committedRemaining > 0 && <Chip tone="accent">{fmtNumber(c.committedRemaining)} committed · {fmtSGD(c.committedValueCents)}</Chip>}
+          {drawDays !== null && drawDays > 0 && <Chip tone="warn">Draw closes {drawDays}d</Chip>}
+          {marketplace && <Chip tone="accent">Marketplace</Chip>}
+        </span>
+      )}
+      <span style={{ display: 'flex', alignItems: 'baseline', gap: 6, margin: '8px 0 0' }}>
+        <span className="av2-mono" style={{ fontSize: 15, fontWeight: 600 }}>{fmtNumber(c.leadsThisPeriod || 0)}</span>
+        <span style={{ fontSize: 10.5, color: 'var(--ink-3)' }}>leads · {period}</span>
+        <span style={{ flex: 1 }} />
+        <span className="av2-mono" style={{ fontSize: 10, color: 'var(--ink-3)' }}>
+          {fmtNumber(c.leadsTotal ?? c.prospectCount ?? 0)} all-time · {c.end_date ? `ends ${fmtDate(c.end_date)}` : 'no end date'}
+        </span>
+      </span>
+    </div>
+  );
+}
+
 export default function AdminV2Campaigns() {
   // Filters live in the URL (shareable, back/forward safe) — same rule as Prospects.
   const [searchParams, setSearchParams] = useSearchParams();
@@ -76,8 +130,14 @@ export default function AdminV2Campaigns() {
   const [selected, setSelected] = useState(() => new Set());
   const [confirmAction, setConfirmAction] = useState(null); // BULK_ACTIONS entry | null
   const [bulkBusy, setBulkBusy] = useState(false);
+  const mobile = useAdminV2Mobile();
+  const [selectMode, setSelectMode] = useState(false);
+  // Mobile studio handoff: campaign design is a desktop surface — after the
+  // type pick, hand the operator a link instead of opening the workspace.
+  const [handoffType, setHandoffType] = useState(null);
   const handleCreateCampaign = (type) => {
     setTypeSelectOpen(false);
+    if (mobile) { setHandoffType(type); return; }
     navigate(`${newCampaignHref()}?type=${type}`);
   };
   const campaigns = useCampaignLeaderboard(period);
@@ -139,6 +199,168 @@ export default function AdminV2Campaigns() {
     setConfirmAction(null);
     setSelected(new Set());
   };
+
+  /* ── Mobile (design 1694f8b2): status pills + card list + select bar ── */
+  if (mobile) {
+    const selecting = selectMode || selected.size > 0;
+    const exitSelect = () => { setSelected(new Set()); setSelectMode(false); };
+    const handoffPath = handoffType ? `${newCampaignHref()}?type=${handoffType}` : '';
+    const handoffUrl = handoffType ? `${window.location.origin}${handoffPath}` : '';
+    return (
+      <div>
+        {/* Status pills + New */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <div style={{ flex: 1, display: 'flex', gap: 5, overflowX: 'auto', margin: '0 -2px', padding: 2, minWidth: 0 }}>
+            {statuses.map((s) => {
+              const on = statusFilter === s;
+              return (
+                <button
+                  key={s || 'all'}
+                  type="button"
+                  aria-pressed={on}
+                  onClick={() => setStatusFilter(s)}
+                  style={{ flex: 'none', minHeight: 34, padding: '0 12px', borderRadius: 9, cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 12, fontWeight: 700, whiteSpace: 'nowrap', textTransform: 'capitalize', background: on ? 'var(--ink)' : 'var(--surface)', color: on ? 'var(--canvas)' : 'var(--ink-2)', border: `1px solid ${on ? 'var(--ink)' : 'var(--line-strong)'}` }}
+                >
+                  {s || 'All'}
+                </button>
+              );
+            })}
+          </div>
+          <button type="button" onClick={() => setTypeSelectOpen(true)} style={{ flex: 'none', height: 38, display: 'flex', alignItems: 'center', gap: 5, padding: '0 12px', background: 'var(--accent)', color: 'var(--accent-ink)', border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 12.5, fontWeight: 700 }}>
+            + New
+          </button>
+        </div>
+
+        {attention.isError && (
+          <div className="av2-caption" style={{ color: 'var(--warn)', padding: '8px 2px 0' }}>
+            ▲ Attention feed unavailable — zero-commitment badges hidden.
+          </div>
+        )}
+
+        {/* Meta + period + select */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 2px 8px' }}>
+          <span className="av2-mono" style={{ fontSize: 10, letterSpacing: '.13em', color: 'var(--ink-3)', textTransform: 'uppercase', flex: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {fmtNumber(rows.length)} campaign{rows.length === 1 ? '' : 's'}
+          </span>
+          <PeriodSwitch value={period} onChange={setPeriod} />
+          <button type="button" onClick={() => (selecting ? exitSelect() : setSelectMode(true))} style={{ background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 12, fontWeight: 700, color: 'var(--accent-text)', padding: '4px 2px' }}>
+            {selecting ? 'Done' : 'Select'}
+          </button>
+        </div>
+
+        {/* Card list */}
+        {campaigns.isLoading && (
+          <div style={{ display: 'grid', gap: 8 }}>
+            {[0, 1, 2, 3].map((i) => <Skeleton key={i} height={110} style={{ borderRadius: 14 }} />)}
+          </div>
+        )}
+        {campaigns.isError && <div className="av2-card"><ErrorState error={campaigns.error} onRetry={campaigns.refetch} /></div>}
+        {!campaigns.isLoading && !campaigns.isError && rows.length === 0 && (
+          <div className="av2-card">
+            <EmptyState title="No campaigns match" hint={statusFilter ? 'Try a different status.' : 'Create your first campaign to start capturing leads.'} />
+          </div>
+        )}
+        <div style={{ display: 'grid', gap: 8 }}>
+          {rows.map((c) => {
+            const draw = c.design_config?.luckyDraw;
+            const drawDays = draw?.enabled ? daysUntil(draw.closesAt) : null;
+            const priced = Number.isInteger(c.leadPriceCents) && c.leadPriceCents > 0;
+            return (
+              <MobileCampaignRow
+                key={c.id}
+                c={c}
+                priced={priced}
+                drawDays={drawDays}
+                zeroCommit={attention.isSuccess && zeroCommitIds.has(c.id)}
+                marketplace={getMarketplaceListedFromDoc(c.design_config) === true}
+                period={period}
+                selecting={selecting}
+                isSelected={selected.has(c.id)}
+                onTap={() => { if (selecting) toggleSelected(c.id); else navigate(`/admin/campaigns/${c.id}`); }}
+                onLongPress={() => { if (!selecting) { setSelectMode(true); toggleSelected(c.id); } }}
+              />
+            );
+          })}
+        </div>
+
+        {/* Select-mode bar */}
+        {selecting && (
+          <MobileSelectBar
+            count={selected.size}
+            onCancel={exitSelect}
+            actions={BULK_ACTIONS.map((a) => ({
+              label: eligibleFor(a).length > 0 && eligibleFor(a).length !== selected.size ? `${a.label} (${eligibleFor(a).length})` : a.label,
+              tone: a.destructive ? 'danger' : undefined,
+              disabled: bulkBusy || eligibleFor(a).length === 0,
+              run: () => setConfirmAction(a),
+            }))}
+          />
+        )}
+
+        {/* Studio handoff — design happens on desktop */}
+        <MobileSheet open={!!handoffType} onClose={() => setHandoffType(null)} label="Design on desktop">
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center', padding: '14px 6px 4px' }}>
+            <span aria-hidden="true" style={{ width: 56, height: 56, borderRadius: 16, background: 'var(--accent-soft)', color: 'var(--accent-text)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 22, fontWeight: 800 }}>▧</span>
+            <div className="av2-mono" style={{ fontSize: 10, letterSpacing: '.14em', color: 'var(--ink-3)', textTransform: 'uppercase', marginTop: 14 }}>
+              {String(handoffType || '').replace(/_/g, ' ')} · picked
+            </div>
+            <h2 style={{ margin: '8px 0 0', fontSize: 20, fontWeight: 800, letterSpacing: '-0.02em', lineHeight: 1.25, maxWidth: '22ch', color: 'var(--ink)' }}>
+              Design opens in Studio on desktop
+            </h2>
+            <p style={{ margin: '10px 0 0', fontSize: 13, color: 'var(--ink-2)', lineHeight: 1.6, maxWidth: '34ch' }}>
+              Page design, quiz logic and draw setup live in the campaign workspace — open it on a bigger screen when you're back at your desk.
+            </p>
+            <div style={{ marginTop: 18, width: '100%', display: 'flex', alignItems: 'center', gap: 8, background: 'var(--surface-2)', border: '1px solid var(--line-strong)', borderRadius: 12, padding: '12px 14px', boxSizing: 'border-box' }}>
+              <span className="av2-mono" style={{ flex: 1, fontSize: 11.5, color: 'var(--ink-2)', textAlign: 'left', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{handoffUrl.replace(/^https?:\/\//, '')}</span>
+              <button
+                type="button"
+                onClick={() => { navigator.clipboard?.writeText(handoffUrl).then(() => toast.success('Link copied')).catch(() => toast.error('Copy failed')); }}
+                style={{ flex: 'none', height: 32, padding: '0 12px', background: 'var(--surface)', border: '1px solid var(--line-strong)', borderRadius: 8, cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 11.5, fontWeight: 700, color: 'var(--ink)' }}
+              >
+                Copy
+              </button>
+            </div>
+            <button type="button" onClick={() => { setHandoffType(null); navigate(handoffPath); }} style={{ marginTop: 10, width: '100%', height: 46, background: 'var(--accent)', color: 'var(--accent-ink)', border: 'none', borderRadius: 12, cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 13.5, fontWeight: 700 }}>
+              Open here anyway
+            </button>
+            <button type="button" onClick={() => setHandoffType(null)} style={{ marginTop: 8, width: '100%', height: 44, background: 'transparent', color: 'var(--ink-2)', border: 'none', borderRadius: 12, cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 13, fontWeight: 700 }}>
+              Back to campaigns
+            </button>
+          </div>
+        </MobileSheet>
+
+        <CampaignTypeSelectionDialog
+          open={typeSelectOpen}
+          onOpenChange={setTypeSelectOpen}
+          onSelect={handleCreateCampaign}
+        />
+        <ConfirmDialog
+          open={confirmAction != null}
+          onOpenChange={(open) => { if (!open && !bulkBusy) setConfirmAction(null); }}
+          title={confirmAction ? `${confirmAction.label} ${eligibleFor(confirmAction).length} campaign${eligibleFor(confirmAction).length === 1 ? '' : 's'}?` : ''}
+          description={confirmAction ? [
+            confirmAction.key === 'delete'
+              ? 'Permanent deletion cannot be undone. Campaigns with pending or approved commissions are refused by the server.'
+              : confirmAction.key === 'duplicate'
+                ? 'Each copy starts as a fresh draft named “… (Copy)”. Design, media, and agent assignments carry over, and a still-open lucky draw carries as the copy’s own draw with freshly minted terms. Leads, QR codes, lead pricing, and marketplace/homepage publication never carry.'
+                : confirmAction.key === 'archive'
+                  ? 'Archived campaigns stop accepting signups and move to the archived filter; restore them anytime.'
+                  : confirmAction.key === 'activate'
+                    ? 'Resumes paused campaigns. Drafts are never launched from here — use the campaign workspace.'
+                    : 'Paused campaigns stop accepting public signups until resumed.',
+            eligibleFor(confirmAction).length !== selected.size
+              ? ` ${selected.size - eligibleFor(confirmAction).length} of the selected campaigns are not eligible and will be skipped.`
+              : '',
+          ].join('') : ''}
+          onConfirm={() => confirmAction && runBulk(confirmAction)}
+          confirmText={confirmAction?.destructive ? 'Delete' : 'Continue'}
+          pending={bulkBusy}
+          pendingText='Working…'
+          destructive={confirmAction?.destructive === true}
+        />
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/src/pages/adminv2/AdminV2CohortDetail.jsx
+++ b/src/pages/adminv2/AdminV2CohortDetail.jsx
@@ -15,12 +15,14 @@ import { fmtNumber, fmtRelative, fmtDateTime } from '@/lib/adminV2/format';
 import { summarizeDefinition, REASON_ORDER, REASON_META, reasonLabel, CHANNEL_OPTIONS } from '@/lib/adminV2/cohorts';
 import { Card, Chip, PageHeader, Skeleton, ErrorState, EmptyState, StateRow } from '@/components/adminv2/primitives';
 import CohortBuilder from '@/components/adminv2/CohortBuilder';
+import { useAdminV2Mobile } from '@/components/adminv2/mobile/useAdminV2Mobile';
+import MobileSheet, { SheetHead, SheetMenuItem } from '@/components/adminv2/mobile/MobileSheet';
 
 const PAGE_SIZE = 50;
 
-function Tile({ label, value, caption, tone }) {
+function Tile({ label, value, caption, tone, style }) {
   return (
-    <div style={{ flex: 1, padding: 16, borderRight: '1px solid var(--line)' }}>
+    <div style={{ flex: 1, padding: 16, borderRight: '1px solid var(--line)', boxSizing: 'border-box', ...style }}>
       <div className="av2-microcaps">{label}</div>
       <div className="av2-mono" style={{ fontSize: 20, fontWeight: 600, marginTop: 4, color: tone || 'var(--ink)' }}>{value}</div>
       {caption && <div className="av2-caption" style={{ marginTop: 2 }}>{caption}</div>}
@@ -34,9 +36,11 @@ export default function AdminV2CohortDetail() {
   const [status, setStatus] = useState('excluded'); // the WHY view is the point — land on it
   const [page, setPage] = useState(0);
   const [editing, setEditing] = useState(false);
+  const [actionsOpen, setActionsOpen] = useState(false);
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const location = useLocation();
+  const mobile = useAdminV2Mobile();
 
   // refresh=1: recompute + persist the snapshot every time the screen opens.
   const cohort = useQuery({
@@ -72,8 +76,8 @@ export default function AdminV2CohortDetail() {
   if (cohort.isLoading) {
     return (
       <div>
-        <Skeleton height={30} width={340} />
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 16, marginTop: 20 }}>
+        <Skeleton height={30} width={340} style={{ maxWidth: '100%' }} />
+        <div className="av2-grid12" style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 16, marginTop: 20 }}>
           {[12, 5, 7].map((span, i) => <div key={i} style={{ gridColumn: `span ${span}` }}><Skeleton height={140} /></div>)}
         </div>
       </div>
@@ -82,12 +86,29 @@ export default function AdminV2CohortDetail() {
   if (cohort.isError) return <ErrorState error={cohort.error} onRetry={cohort.refetch} />;
 
   const c = cohort.data;
+  const metaLine = `${summarizeDefinition(c.definition, facets.data).toUpperCase()} · RESOLVED ${c.lastPreviewAt ? fmtRelative(c.lastPreviewAt) : 'NOW'}`;
 
   return (
     <div>
+      {mobile ? (
+        <div style={{ padding: '2px 0 12px', display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+          <span style={{ flex: 1, minWidth: 0 }}>
+            <span style={{ display: 'block', fontSize: 18, fontWeight: 800, letterSpacing: '-0.015em', lineHeight: 1.25, color: 'var(--ink)' }}>{c.name}</span>
+            <span className="av2-mono" style={{ display: 'block', fontSize: 10, letterSpacing: '.09em', color: 'var(--ink-3)', marginTop: 4, textTransform: 'uppercase' }}>{metaLine}</span>
+          </span>
+          <button
+            type="button"
+            onClick={() => setActionsOpen(true)}
+            aria-label="Cohort actions"
+            style={{ width: 40, height: 40, flex: 'none', background: 'var(--surface)', border: '1px solid var(--line-strong)', borderRadius: 10, cursor: 'pointer', color: 'var(--ink)', fontSize: 16, fontWeight: 700 }}
+          >
+            ⋯
+          </button>
+        </div>
+      ) : (
       <PageHeader
         title={c.name}
-        meta={`${summarizeDefinition(c.definition, facets.data).toUpperCase()} · RESOLVED ${c.lastPreviewAt ? fmtRelative(c.lastPreviewAt) : 'NOW'}`}
+        meta={metaLine}
       >
         <Link to="/AdminCohorts" className="av2-btn av2-btn--sm" style={{ textDecoration: 'none' }}>← All cohorts</Link>
         <Link to={`/AdminBroadcasts?cohort=${id}`} className="av2-btn av2-btn--sm av2-btn--primary" style={{ textDecoration: 'none' }}>Push email</Link>
@@ -102,19 +123,22 @@ export default function AdminV2CohortDetail() {
           {archive.isPending ? 'Archiving…' : 'Archive'}
         </button>
       </PageHeader>
+      )}
 
-      {c.description && <div className="av2-caption" style={{ marginTop: -8, marginBottom: 14 }}>{c.description}</div>}
+      {c.description && <div className="av2-caption" style={{ marginTop: mobile ? 0 : -8, marginBottom: 14 }}>{c.description}</div>}
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 16 }}>
+      <div className="av2-grid12" style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: mobile ? 10 : 16 }}>
         <Card span={12}>
-          <div style={{ display: 'flex' }}>
-            <Tile label="Match the filters" value={preview ? fmtNumber(preview.total) : '—'} caption="people in the group" />
-            <Tile label="Reachable" value={preview ? fmtNumber(preview.reachable) : '—'} tone="var(--ok)" caption="consented · verified · not unsubscribed · 18+" />
-            <Tile label="Excluded" value={excluded !== null ? fmtNumber(excluded) : '—'} tone={excluded ? 'var(--warn)' : undefined} caption="see why below" />
+          {/* KPI tiles — one row on desktop, a 2×2 grid on phones */}
+          <div style={{ display: 'flex', flexWrap: mobile ? 'wrap' : 'nowrap' }}>
+            <Tile label="Match the filters" value={preview ? fmtNumber(preview.total) : '—'} caption="people in the group" style={mobile ? { flex: '1 1 50%', borderBottom: '1px solid var(--line)' } : undefined} />
+            <Tile label="Reachable" value={preview ? fmtNumber(preview.reachable) : '—'} tone="var(--ok)" caption="consented · verified · not unsubscribed · 18+" style={mobile ? { flex: '1 1 50%', borderRight: 'none', borderBottom: '1px solid var(--line)' } : undefined} />
+            <Tile label="Excluded" value={excluded !== null ? fmtNumber(excluded) : '—'} tone={excluded ? 'var(--warn)' : undefined} caption="see why below" style={mobile ? { flex: '1 1 50%' } : undefined} />
             <Tile
               label="Gate"
               value={preview?.gate ? (preview.gate.campaignId ? 'campaign' : 'brand-wide') : '—'}
               caption={preview?.gate ? `ages ${preview.gate.minAge}${preview.gate.maxAge ? `–${preview.gate.maxAge}` : '+'} · channel ${preview.gate.channel}` : undefined}
+              style={mobile ? { flex: '1 1 50%', borderRight: 'none' } : undefined}
             />
           </div>
         </Card>
@@ -145,7 +169,7 @@ export default function AdminV2CohortDetail() {
           title="Members"
           meta={members.data ? `${fmtNumber(members.data.total)} ${status}` : undefined}
           action={(
-            <span style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+            <span style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: mobile ? 'wrap' : undefined, justifyContent: mobile ? 'flex-end' : undefined, minWidth: mobile ? 0 : undefined }}>
               <div className="av2-seg" role="group" aria-label="Member status">
                 {['reachable', 'excluded', 'all'].map((s) => (
                   <button key={s} type="button" aria-pressed={status === s} onClick={() => { setStatus(s); setPage(0); }}>
@@ -166,11 +190,11 @@ export default function AdminV2CohortDetail() {
           )}
         >
           <div role="table" aria-label="Cohort members">
-            <div className="av2-thead" role="row">
-              <span className="av2-microcaps" role="columnheader" style={{ flex: 1.2 }}>Person</span>
-              <span className="av2-microcaps" role="columnheader" style={{ width: 120, flex: 'none' }}>Phone</span>
-              <span className="av2-microcaps" role="columnheader" style={{ flex: 1.4 }}>{status === 'reachable' ? 'Email' : 'Why excluded'}</span>
-              <span className="av2-microcaps" role="columnheader" style={{ width: 80, flex: 'none', textAlign: 'right' }}>Seen</span>
+            <div className="av2-thead" role="row" style={mobile ? { minWidth: 0 } : undefined}>
+              <span className="av2-microcaps" role="columnheader" style={{ flex: 1.2, minWidth: 0 }}>Person</span>
+              <span className="av2-microcaps" role="columnheader" style={{ width: mobile ? 92 : 120, flex: 'none' }}>Phone</span>
+              <span className="av2-microcaps" role="columnheader" style={{ flex: 1.4, minWidth: 0 }}>{status === 'reachable' ? 'Email' : 'Why excluded'}</span>
+              <span className="av2-microcaps" role="columnheader" style={{ width: mobile ? 56 : 80, flex: 'none', textAlign: 'right' }}>Seen</span>
             </div>
 
             {members.isLoading && <StateRow><div style={{ padding: 12 }}><Skeleton height={60} /></div></StateRow>}
@@ -180,8 +204,8 @@ export default function AdminV2CohortDetail() {
             )}
 
             {(members.data?.members || []).map((m) => (
-              <div key={m.consumerId} className="av2-row" role="row" style={{ cursor: 'default' }}>
-                <span role="cell" style={{ flex: 1.2, fontSize: 12.5, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              <div key={m.consumerId} className="av2-row" role="row" style={{ cursor: 'default', minWidth: mobile ? 0 : undefined }}>
+                <span role="cell" style={{ flex: 1.2, minWidth: 0, fontSize: 12.5, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                   {/* Person cell links into the Lead Profile PERSON view when a
                       signup anchor exists — a Link inside the cell keeps the
                       table's row/cell roles intact (admin-people-directory
@@ -198,13 +222,13 @@ export default function AdminV2CohortDetail() {
                   ) : ((m.firstName || m.lastName) ? `${m.firstName || ''} ${m.lastName || ''}`.trim() : '—')}
                   {m.reachable && <Chip tone="ok">✓</Chip>}
                 </span>
-                <span role="cell" className="av2-mono" style={{ width: 120, flex: 'none', fontSize: 11.5 }}>{m.phone || '—'}</span>
-                <span role="cell" style={{ flex: 1.4, display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+                <span role="cell" className="av2-mono" style={{ width: mobile ? 92 : 120, flex: 'none', fontSize: 11.5, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{m.phone || '—'}</span>
+                <span role="cell" style={{ flex: 1.4, minWidth: 0, display: 'flex', gap: 4, flexWrap: 'wrap' }}>
                   {m.reachable
                     ? <span className="av2-mono" style={{ fontSize: 11, color: 'var(--ink-2)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{m.email || '—'}</span>
                     : (m.reasons || []).map((r) => <Chip key={r} tone={REASON_META[r]?.tone || ''}>{reasonLabel(r)}</Chip>)}
                 </span>
-                <span role="cell" className="av2-mono" style={{ width: 80, flex: 'none', fontSize: 10.5, color: 'var(--ink-3)', textAlign: 'right' }} title={m.lastSeenAt ? fmtDateTime(m.lastSeenAt) : ''}>
+                <span role="cell" className="av2-mono" style={{ width: mobile ? 56 : 80, flex: 'none', fontSize: 10.5, color: 'var(--ink-3)', textAlign: 'right' }} title={m.lastSeenAt ? fmtDateTime(m.lastSeenAt) : ''}>
                   {m.lastSeenAt ? fmtRelative(m.lastSeenAt) : '—'}
                 </span>
               </div>
@@ -229,6 +253,34 @@ export default function AdminV2CohortDetail() {
           onClose={() => setEditing(false)}
           onSaved={() => queryClient.invalidateQueries({ queryKey: ['adminV2', 'cohort', id] })}
         />
+      )}
+
+      {/* Mobile ⋯ actions sheet */}
+      {mobile && (
+        <MobileSheet open={actionsOpen} onClose={() => setActionsOpen(false)} label="Cohort actions">
+          <SheetHead title={c.name} kicker={`resolved ${c.lastPreviewAt ? fmtRelative(c.lastPreviewAt) : 'now'}`} />
+          <SheetMenuItem
+            label="Push email"
+            sub="Compose an email push to this cohort"
+            onClick={() => { setActionsOpen(false); navigate(`/AdminBroadcasts?cohort=${id}`); }}
+          />
+          <SheetMenuItem
+            label="Edit definition"
+            sub="Filters, age gate, consent scope"
+            onClick={() => { setActionsOpen(false); setEditing(true); }}
+          />
+          <SheetMenuItem
+            label={archive.isPending ? 'Archiving…' : 'Archive'}
+            sub="Hidden from the list — past sends keep their history"
+            danger
+            onClick={() => { if (!archive.isPending) { setActionsOpen(false); archive.mutate(); } }}
+          />
+          <SheetMenuItem
+            label="All cohorts"
+            sub="Back to the cohort list"
+            onClick={() => { setActionsOpen(false); navigate('/AdminCohorts'); }}
+          />
+        </MobileSheet>
       )}
     </div>
   );

--- a/src/pages/adminv2/AdminV2Cohorts.jsx
+++ b/src/pages/adminv2/AdminV2Cohorts.jsx
@@ -12,8 +12,9 @@ import { toast } from 'sonner';
 import { fetchCohorts, fetchCohortFacets, archiveCohort } from '@/api/adminV2';
 import { fmtNumber, fmtRelative } from '@/lib/adminV2/format';
 import { summarizeDefinition } from '@/lib/adminV2/cohorts';
-import { PageHeader, Skeleton, ErrorState, EmptyState, StateRow } from '@/components/adminv2/primitives';
+import { Chip, PageHeader, Skeleton, ErrorState, EmptyState, StateRow } from '@/components/adminv2/primitives';
 import CohortBuilder from '@/components/adminv2/CohortBuilder';
+import { useAdminV2Mobile } from '@/components/adminv2/mobile/useAdminV2Mobile';
 import {
   AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle,
   AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction,
@@ -26,6 +27,7 @@ export default function AdminV2Cohorts() {
   const [confirmArchive, setConfirmArchive] = useState(null);
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const mobile = useAdminV2Mobile();
 
   const archive = useMutation({
     mutationFn: (id) => archiveCohort(id),
@@ -38,6 +40,121 @@ export default function AdminV2Cohorts() {
   });
 
   const rows = cohorts.data?.rows || [];
+
+  // Shared overlays — mounted by both the mobile and desktop branches so the
+  // builder/confirm state machines stay single-sourced.
+  const overlays = (
+    <>
+      {building && <CohortBuilder onClose={() => setBuilding(false)} onSaved={(c) => { if (c?.id) navigate(`/admin/cohorts/${c.id}`); }} />}
+
+      <AlertDialog open={!!confirmArchive} onOpenChange={(open) => { if (!open) setConfirmArchive(null); }}>
+        <AlertDialogContent className="admin-v2" style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)' }}>
+          <AlertDialogHeader>
+            <AlertDialogTitle style={{ color: 'var(--ink)' }}>Archive “{confirmArchive?.name}”?</AlertDialogTitle>
+            <AlertDialogDescription style={{ color: 'var(--ink-2)' }}>
+              It disappears from this list. Nothing is deleted — past sends keep their history.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => { e.preventDefault(); archive.mutate(confirmArchive.id); }}
+              disabled={archive.isPending}
+              style={{ background: 'var(--bad)', color: '#fff' }}
+            >
+              {archive.isPending ? 'Archiving…' : 'Archive'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+
+  /* ── Mobile (design 1694f8b2): meta row + cohort cards ── */
+  if (mobile) {
+    return (
+      <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '2px 2px 10px' }}>
+          <span className="av2-mono" style={{ flex: 1, minWidth: 0, fontSize: 10, letterSpacing: '.12em', color: 'var(--ink-3)', textTransform: 'uppercase', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {fmtNumber(rows.length)} cohort{rows.length === 1 ? '' : 's'} · consent-gated
+          </span>
+          <button type="button" onClick={() => setBuilding(true)} style={{ flex: 'none', height: 38, display: 'flex', alignItems: 'center', gap: 5, padding: '0 12px', background: 'var(--accent)', color: 'var(--accent-ink)', border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 12.5, fontWeight: 700 }}>
+            + New cohort
+          </button>
+        </div>
+
+        {cohorts.isLoading && (
+          <div style={{ display: 'grid', gap: 8 }}>
+            {[0, 1, 2].map((i) => <Skeleton key={i} height={104} style={{ borderRadius: 14 }} />)}
+          </div>
+        )}
+        {cohorts.isError && <div className="av2-card"><ErrorState error={cohorts.error} onRetry={cohorts.refetch} /></div>}
+        {!cohorts.isLoading && !cohorts.isError && rows.length === 0 && (
+          <div className="av2-card">
+            <EmptyState
+              title="No cohorts yet"
+              hint="A cohort is a saved audience definition — “everyone from the Tokyo draw” — that stays current on its own."
+              action={<button type="button" className="av2-btn av2-btn--primary av2-btn--sm" onClick={() => setBuilding(true)}>Build the first one</button>}
+            />
+          </div>
+        )}
+
+        <div style={{ display: 'grid', gap: 8 }}>
+          {rows.map((c) => {
+            const hasSnap = c.lastReachableCount !== null && c.lastReachableCount !== undefined;
+            const totalSnap = c.lastTotalCount ?? 0;
+            const excludedSnap = hasSnap ? Math.max(0, totalSnap - c.lastReachableCount) : null;
+            const gate = c.definition?.marketingContext?.campaignId ? 'campaign' : 'brand-wide';
+            return (
+              <div
+                key={c.id}
+                className="av2-card"
+                role="button"
+                tabIndex={0}
+                onClick={() => navigate(`/admin/cohorts/${c.id}`)}
+                onKeyDown={(e) => { if (e.key === 'Enter' && e.target === e.currentTarget) navigate(`/admin/cohorts/${c.id}`); }}
+                style={{ padding: '12px 13px', cursor: 'pointer' }}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span style={{ flex: 1, minWidth: 0, fontSize: 13.5, fontWeight: 700, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{c.name}</span>
+                  <button
+                    type="button"
+                    className="av2-btn av2-btn--ghost av2-btn--sm"
+                    style={{ flex: 'none', color: 'var(--bad)' }}
+                    onClick={(e) => { e.stopPropagation(); setConfirmArchive(c); }}
+                  >
+                    Archive
+                  </button>
+                </div>
+                <div className="av2-mono" style={{ fontSize: 10, color: 'var(--ink-3)', marginTop: 3, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  {summarizeDefinition(c.definition, facets.data)} · {c.lastPreviewAt ? `snapshot ${fmtRelative(c.lastPreviewAt)}` : 'no snapshot yet'}
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 18, marginTop: 10 }}>
+                  {[
+                    ['match', hasSnap ? fmtNumber(totalSnap) : '—', 'var(--ink)'],
+                    ['reachable', hasSnap ? fmtNumber(c.lastReachableCount) : '—', 'var(--ok)'],
+                    ['excluded', hasSnap ? fmtNumber(excludedSnap) : '—', excludedSnap ? 'var(--warn)' : 'var(--ink-3)'],
+                  ].map(([label, value, color]) => (
+                    <span key={label}>
+                      <span className="av2-mono" style={{ display: 'block', fontSize: 14, fontWeight: 600, color }}>{value}</span>
+                      <span style={{ display: 'block', fontSize: 9.5, fontWeight: 700, letterSpacing: '.06em', textTransform: 'uppercase', color: 'var(--ink-3)', marginTop: 1 }}>{label}</span>
+                    </span>
+                  ))}
+                  <span style={{ marginLeft: 'auto', flex: 'none' }}><Chip tone="accent">{gate}</Chip></span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="av2-caption" style={{ padding: '14px 4px 0', lineHeight: 1.5 }}>
+          Reachable = consented ∧ phone-verified ∧ not unsubscribed ∧ 18+ (binding safeguard) — every send re-checks each person again at send time.
+        </div>
+
+        {overlays}
+      </div>
+    );
+  }
 
   return (
     <div>
@@ -118,28 +235,7 @@ export default function AdminV2Cohorts() {
         Reachable = consented ∧ phone-verified ∧ not unsubscribed ∧ 18+ (binding safeguard) — every send re-checks each person again at send time.
       </div>
 
-      {building && <CohortBuilder onClose={() => setBuilding(false)} onSaved={(c) => { if (c?.id) navigate(`/admin/cohorts/${c.id}`); }} />}
-
-      <AlertDialog open={!!confirmArchive} onOpenChange={(open) => { if (!open) setConfirmArchive(null); }}>
-        <AlertDialogContent className="admin-v2" style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)' }}>
-          <AlertDialogHeader>
-            <AlertDialogTitle style={{ color: 'var(--ink)' }}>Archive “{confirmArchive?.name}”?</AlertDialogTitle>
-            <AlertDialogDescription style={{ color: 'var(--ink-2)' }}>
-              It disappears from this list. Nothing is deleted — past sends keep their history.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={(e) => { e.preventDefault(); archive.mutate(confirmArchive.id); }}
-              disabled={archive.isPending}
-              style={{ background: 'var(--bad)', color: '#fff' }}
-            >
-              {archive.isPending ? 'Archiving…' : 'Archive'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      {overlays}
     </div>
   );
 }

--- a/src/pages/adminv2/AdminV2Dashboard.jsx
+++ b/src/pages/adminv2/AdminV2Dashboard.jsx
@@ -19,6 +19,7 @@ import { heldLabel } from '@/lib/adminV2/constants';
 import { prospectsToCsv, downloadCsv } from '@/lib/adminV2/csv';
 import { Card, PeriodSwitch, Skeleton, ErrorState } from '@/components/adminv2/primitives';
 import { SeriesLineChart } from '@/components/adminv2/charts';
+import { useAdminV2Mobile } from '@/components/adminv2/mobile/useAdminV2Mobile';
 
 const SEVERITY_STYLE = {
   incident: { bg: 'var(--bad-soft)', fg: 'var(--bad)' },
@@ -57,10 +58,37 @@ function dayLabel(isoDate) {
 
 function HealthStrip() {
   const attention = useAttention();
+  const mobile = useAdminV2Mobile();
   if (attention.isLoading) return <div style={{ gridColumn: 'span 12' }}><Skeleton height={74} style={{ borderRadius: 14 }} /></div>;
   if (attention.isError) return <Card span={12}><ErrorState error={attention.error} onRetry={attention.refetch} /></Card>;
 
   const strip = composeHealthStrip(attention.data);
+  if (mobile) {
+    // Tile grid (2 big + 3 small) instead of one five-segment row.
+    const spans = strip.length === 5 ? [3, 3, 2, 2, 2] : strip.map(() => 2);
+    return (
+      <div style={{ gridColumn: 'span 12', display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)', gap: 8 }}>
+        {strip.map((seg, i) => (
+          <Link
+            key={seg.id}
+            to={seg.href}
+            className="av2-card"
+            style={{ gridColumn: `span ${spans[i] || 2}`, display: 'flex', flexDirection: 'column', gap: 2, padding: '12px 12px 10px', color: 'var(--ink)', textDecoration: 'none', minWidth: 0 }}
+          >
+            <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <svg viewBox="0 0 24 24" style={{ width: 11, height: 11, flex: 'none' }} aria-hidden="true">
+                <path d={GLYPH_PATH[seg.shape]} fill={TONE_COLOR[seg.tone]} />
+              </svg>
+              <span className="av2-mono" style={{ fontSize: (spans[i] || 2) === 3 ? 19 : 14, fontWeight: 600, whiteSpace: 'nowrap', letterSpacing: '-0.02em', color: seg.valueTone ? TONE_COLOR[seg.valueTone] : 'var(--ink)' }}>
+                {seg.value}
+              </span>
+            </span>
+            <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--ink-2)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{seg.label}</span>
+          </Link>
+        ))}
+      </div>
+    );
+  }
   return (
     <div className="av2-card" style={{ gridColumn: 'span 12', display: 'flex', overflow: 'hidden' }}>
       {strip.map((seg, i) => (
@@ -142,6 +170,7 @@ function AttentionQueue() {
 function LeadFlow({ period }) {
   const series = useSeries(period);
   const funnel = useFunnel(period);
+  const mobile = useAdminV2Mobile();
   if (series.isLoading || funnel.isLoading) return <Card span={7} title="Lead flow" style={{ minHeight: 330 }}><div style={{ padding: 16 }}><Skeleton height={42} width={120} /><Skeleton height={118} style={{ marginTop: 14 }} /><Skeleton height={90} style={{ marginTop: 14 }} /></div></Card>;
   if (series.isError) return <Card span={7} title="Lead flow" style={{ minHeight: 330 }}><ErrorState error={series.error} onRetry={series.refetch} /></Card>;
   if (funnel.isError) return <Card span={7} title="Lead flow" style={{ minHeight: 330 }}><ErrorState error={funnel.error} onRetry={funnel.refetch} /></Card>;
@@ -179,29 +208,29 @@ function LeadFlow({ period }) {
     <section className="av2-card" style={{ gridColumn: 'span 7', minWidth: 0, display: 'flex', flexDirection: 'column', minHeight: 330 }}>
       <header style={{ display: 'flex', alignItems: 'baseline', gap: 10, padding: '13px 16px 0' }}>
         <h2 className="av2-h2" style={{ margin: 0 }}>Lead flow</h2>
-        <span style={{ fontSize: 11.5, color: 'var(--ink-3)' }}>OTP-verified submissions · {PERIOD_NOUN[period]}</span>
+        {!mobile && <span style={{ fontSize: 11.5, color: 'var(--ink-3)' }}>OTP-verified submissions · {PERIOD_NOUN[period]}</span>}
         <span style={{ flex: 1 }} />
         <span className="av2-mono" style={{ fontSize: 10.5, color: 'var(--ink-3)' }}>peak {fmtNumber(max)}/day</span>
       </header>
       <div style={{ padding: '10px 16px 16px', display: 'flex', flexDirection: 'column', gap: 8, flex: 1 }}>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 10, flexWrap: 'wrap' }}>
-          <span style={{ fontSize: 42, fontWeight: 800, letterSpacing: '-0.03em', lineHeight: 1 }}>{fmtNumber(s.today)}</span>
+          <span style={{ fontSize: mobile ? 36 : 42, fontWeight: 800, letterSpacing: '-0.03em', lineHeight: 1 }}>{fmtNumber(s.today)}</span>
           <span style={{ fontSize: 11.5, fontWeight: 700, borderRadius: 6, padding: '3px 8px', background: delta.bg, color: delta.fg }}>{delta.label}</span>
-          <span style={{ fontSize: 12, color: 'var(--ink-2)' }}>leads today (since 00:00 SGT)</span>
+          <span style={{ fontSize: mobile ? 11.5 : 12, color: 'var(--ink-2)' }}>leads today {mobile ? '· since 00:00 SGT' : '(since 00:00 SGT)'}</span>
         </div>
         <SeriesLineChart days={days} max={max} avgPerDay={s.avgPerDay} />
-        <div className="av2-mono" style={{ display: 'flex', justifyContent: 'space-between', fontSize: 10.5, color: 'var(--ink-3)' }}>
+        <div className="av2-mono" style={{ display: 'flex', justifyContent: 'space-between', fontSize: mobile ? 9.5 : 10.5, color: 'var(--ink-3)' }}>
           <span>{dayLabel(days[0].date)}</span><span>┄ avg {s.avgPerDay}/day</span><span>today</span>
         </div>
         <div style={{ borderTop: '1px solid var(--line)', paddingTop: 12, display: 'flex', flexDirection: 'column', gap: 8 }}>
           {funnelRows.map((r) => (
-            <div key={r.label} style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-              <span style={{ width: 170, flex: 'none', fontSize: 12, fontWeight: 600, color: 'var(--ink-2)' }}>{r.label}</span>
-              <span style={{ flex: 1, height: 18, background: 'var(--surface-2)', borderRadius: 5, overflow: 'hidden', display: 'block' }}>
+            <div key={r.label} style={{ display: 'flex', alignItems: 'center', gap: mobile ? 9 : 12 }}>
+              <span style={{ width: mobile ? 104 : 170, flex: 'none', fontSize: mobile ? 11 : 12, fontWeight: 600, color: 'var(--ink-2)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{r.label}</span>
+              <span style={{ flex: 1, height: mobile ? 16 : 18, background: 'var(--surface-2)', borderRadius: 5, overflow: 'hidden', display: 'block' }}>
                 <span style={{ display: 'block', height: '100%', width: `${r.pct}%`, background: r.color, borderRadius: 5 }} />
               </span>
-              <span className="av2-mono" style={{ width: 60, flex: 'none', textAlign: 'right', fontSize: 13, fontWeight: 600 }}>{fmtNumber(r.count)}</span>
-              <span style={{ width: 118, flex: 'none', textAlign: 'right', fontSize: 10.5, color: 'var(--ink-3)' }}>{r.conv}</span>
+              <span className="av2-mono" style={{ width: mobile ? 44 : 60, flex: 'none', textAlign: 'right', fontSize: mobile ? 12 : 13, fontWeight: 600 }}>{fmtNumber(r.count)}</span>
+              <span style={{ width: mobile ? 64 : 118, flex: 'none', textAlign: 'right', fontSize: mobile ? 9.5 : 10.5, color: 'var(--ink-3)', lineHeight: 1.25 }}>{r.conv}</span>
             </div>
           ))}
         </div>
@@ -212,6 +241,7 @@ function LeadFlow({ period }) {
 
 function RecentLeads() {
   const recent = useProspects({ limit: 8, sort: '-createdAt' });
+  const mobile = useAdminV2Mobile();
   if (recent.isLoading) return <Card span={7} title="Recent leads"><div style={{ padding: 16, display: 'grid', gap: 10 }}>{[0, 1, 2, 3].map((i) => <Skeleton key={i} height={38} />)}</div></Card>;
   if (recent.isError) return <Card span={7} title="Recent leads"><ErrorState error={recent.error} onRetry={recent.refetch} /></Card>;
 
@@ -239,6 +269,29 @@ function RecentLeads() {
             const held = !!p.quarantinedAt;
             const utm = p.sourceMetadata?.utm?.utm_source;
             const agent = p.assignedAgent ? `${p.assignedAgent.firstName || ''} ${p.assignedAgent.lastName || ''}`.trim() : '';
+            if (mobile) {
+              // Two-line row: name / phone · campaign, status chip + relative time right.
+              return (
+                <Link key={p.id} to={`/admin/leads/${p.id}`} className="av2-qrow" style={{ padding: '8px 14px', minHeight: 56 }}>
+                  <span style={{ flex: 1, minWidth: 0 }}>
+                    <span style={{ display: 'block', fontSize: 13, fontWeight: 700, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{p.firstName} {p.lastName}</span>
+                    <span className="av2-mono" style={{ display: 'block', fontSize: 10, color: 'var(--ink-3)', marginTop: 2, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                      {p.phone || '—'} · {p.campaign?.name || SOURCE_SHORT[p.leadSource] || p.leadSource}{utm ? ` · ${utm}` : ''}
+                    </span>
+                  </span>
+                  <span style={{ flex: 'none', display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 3 }}>
+                    {held ? (
+                      <span style={{ fontSize: 10.5, fontWeight: 700, background: 'var(--hold-soft)', color: 'var(--hold)', borderRadius: 6, padding: '2px 8px', whiteSpace: 'nowrap' }}>◆ {heldLabel(p).short}</span>
+                    ) : agent ? (
+                      <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--ink-2)', whiteSpace: 'nowrap' }}>{agent}</span>
+                    ) : (
+                      <span style={{ fontSize: 10.5, fontWeight: 700, background: 'var(--warn-soft)', color: 'var(--warn)', borderRadius: 6, padding: '2px 8px' }}>Unassigned</span>
+                    )}
+                    <span className="av2-mono" style={{ fontSize: 9.5, color: 'var(--ink-3)' }}>{fmtAgoShort(p.createdAt)}</span>
+                  </span>
+                </Link>
+              );
+            }
             return (
               <Link key={p.id} to={`/admin/leads/${p.id}`} className="av2-qrow" style={{ padding: '7px 16px', minHeight: 47 }}>
                 <span className="av2-mono" style={{ width: 38, flex: 'none', fontSize: 11, color: 'var(--ink-3)' }}>{fmtAgoShort(p.createdAt)}</span>
@@ -350,6 +403,7 @@ export default function AdminV2Dashboard() {
   const [exporting, setExporting] = useState(false);
   const queryClient = useQueryClient();
   const attention = useAttention();
+  const mobile = useAdminV2Mobile();
 
   // Re-render every 15s so "updated Xm ago" stays honest without refetching.
   const [, setTick] = useState(0);
@@ -383,6 +437,29 @@ export default function AdminV2Dashboard() {
 
   return (
     <div>
+      {mobile ? (
+        /* Phone header: live "updated" line doubles as the refresh control
+           (design 1694f8b2), period + export on one row below. */
+        <header style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 10 }}>
+          <button
+            type="button"
+            onClick={handleRefresh}
+            title="Re-fetch all widgets"
+            className="av2-mono"
+            style={{ display: 'flex', alignItems: 'center', gap: 7, background: 'transparent', border: 'none', cursor: 'pointer', padding: '2px 0 0', fontSize: 10, letterSpacing: '.13em', color: 'var(--ink-3)', textTransform: 'uppercase' }}
+          >
+            <span className="av2-pulse" aria-hidden="true" />
+            updated {attention.dataUpdatedAt ? fmtRelative(attention.dataUpdatedAt) : '—'} · tap to refresh
+          </button>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <PeriodSwitch value={period} onChange={setPeriod} />
+            <span style={{ flex: 1 }} />
+            <button type="button" className="av2-btn av2-btn--sm" onClick={handleExport} disabled={exporting} style={{ whiteSpace: 'nowrap' }}>
+              {exporting ? 'Exporting…' : 'Export CSV'}
+            </button>
+          </div>
+        </header>
+      ) : (
       <header style={{ display: 'flex', alignItems: 'flex-end', gap: 16, flexWrap: 'wrap', marginBottom: 16 }}>
         <div style={{ minWidth: 0 }}>
           <h1 className="av2-h1" style={{ margin: 0 }}>Dashboard</h1>
@@ -405,7 +482,8 @@ export default function AdminV2Dashboard() {
           {exporting ? 'Exporting…' : 'Export CSV'}
         </button>
       </header>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 16, alignItems: 'stretch' }}>
+      )}
+      <div className="av2-grid12" style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: mobile ? 10 : 16, alignItems: 'stretch' }}>
         <HealthStrip />
         <AttentionQueue />
         <LeadFlow period={period} />

--- a/src/pages/adminv2/AdminV2LeadProfile.jsx
+++ b/src/pages/adminv2/AdminV2LeadProfile.jsx
@@ -30,6 +30,9 @@ import {
   AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle,
   AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction,
 } from '@/components/ui/alert-dialog';
+import { useAdminV2Mobile } from '@/components/adminv2/mobile/useAdminV2Mobile';
+import MobileSheet, { SheetHead, SheetMenuItem } from '@/components/adminv2/mobile/MobileSheet';
+import { MobileActionBar, MobilePrimaryBtn, MobileMoreBtn } from '@/components/adminv2/mobile/MobileBars';
 
 // ── shared bits ─────────────────────────────────────────────────────────────
 
@@ -1138,6 +1141,9 @@ export default function AdminV2LeadProfile() {
   const [menu, setMenu] = useState(null);
   const [menuAction, setMenuAction] = useState(null);
   const [menuTarget, setMenuTarget] = useState(null);
+  const mobile = useAdminV2Mobile();
+  // Mobile ⋯ overflow sheet (Return to held / Delete live there on phones).
+  const [mobileMenu, setMobileMenu] = useState(false);
   // Consent-version click-through: null | { version, loading, clauses?, missing? }
   const [consentCopyView, setConsentCopyView] = useState(null);
   const openConsentCopy = useCallback(async (version) => {
@@ -1371,14 +1377,18 @@ export default function AdminV2LeadProfile() {
 
   return (
     <div>
-      {/* ── Sticky command bar (all views) ── */}
-      <div style={{ position: 'sticky', top: 64, zIndex: 30, display: 'flex', alignItems: 'center', gap: 10, padding: '12px 0', background: 'var(--canvas)', borderBottom: '1px solid var(--line)', marginBottom: 16 }}>
+      {/* ── Command bar: sticky under the desktop topbar; on mobile a plain
+             identity row (actions live in the bottom action bar instead) ── */}
+      <div style={mobile
+        ? { display: 'flex', alignItems: 'center', gap: 10, padding: '2px 0 10px', marginBottom: 12, borderBottom: '1px solid var(--line)' }
+        : { position: 'sticky', top: 64, zIndex: 30, display: 'flex', alignItems: 'center', gap: 10, padding: '12px 0', background: 'var(--canvas)', borderBottom: '1px solid var(--line)', marginBottom: 16 }}>
         <Link to={from} style={{ fontSize: 12.5, fontWeight: 700, color: 'var(--accent-text)', textDecoration: 'none', flex: 'none' }}>← {fromLabel}</Link>
         <span aria-hidden="true" style={{ width: 1, height: 16, background: 'var(--line-strong)', flex: 'none' }} />
         <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, letterSpacing: '.08em', color: 'var(--ink-3)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
           {`${canonicalName.toUpperCase()}${phone ? ` · ${phone}` : ''}`}
         </span>
         <span style={{ flex: 1 }} />
+        {!mobile && (
         <div style={{ position: 'relative', flex: 'none', display: 'flex', alignItems: 'center', gap: 8 }}>
           <button type="button" className="av2-btn av2-btn--sm" style={{ borderColor: 'var(--line-strong)', color: 'var(--bad)' }} onClick={() => openAction('delete')}>Delete</button>
           {/* Erased people cannot be re-dispatched — the backend bulk paths
@@ -1439,6 +1449,7 @@ export default function AdminV2LeadProfile() {
             </>
           )}
         </div>
+        )}
       </div>
 
       {/* ── Page-level banners ── */}
@@ -1840,6 +1851,91 @@ export default function AdminV2LeadProfile() {
               />
             )}
           </div>
+        </>
+      )}
+
+      {/* ── Mobile: fixed action bar + sheet variants of the command menus ── */}
+      {mobile && (
+        <>
+          <MobileActionBar>
+            {erased ? (
+              <button
+                type="button"
+                onClick={() => openAction('delete')}
+                style={{ flex: 1, height: 48, background: 'var(--surface)', color: 'var(--bad)', border: '1px solid var(--bad)', borderRadius: 12, cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 14, fontWeight: 700, boxShadow: 'var(--shadow)' }}
+              >
+                Delete
+              </button>
+            ) : (
+              <>
+                <MobilePrimaryBtn onClick={() => openAction('assign')} disabled={assignMutation.isPending}>
+                  {view === 'profile' ? 'Assign to agent' : currentSignup?.agentName ? 'Reassign' : 'Assign this lead'}
+                </MobilePrimaryBtn>
+                <MobileMoreBtn onClick={() => setMobileMenu(true)} />
+              </>
+            )}
+          </MobileActionBar>
+
+          <MobileSheet open={mobileMenu} onClose={() => setMobileMenu(false)} label="Lead actions">
+            <SheetHead title={canonicalName} kicker={phone || 'lead actions'} />
+            {!erased && (
+              <SheetMenuItem
+                label="Return to held"
+                sub="Pull back from the agent · refund the wallet charge"
+                onClick={() => { setMobileMenu(false); openAction('return'); }}
+              />
+            )}
+            <SheetMenuItem
+              label="Delete lead"
+              danger
+              sub="Removes the signup and its history · can't be undone"
+              onClick={() => { setMobileMenu(false); openAction('delete'); }}
+            />
+          </MobileSheet>
+
+          <MobileSheet open={!!menu} onClose={() => { setMenu(null); setMenuAction(null); }} label={menuAction === 'assign' ? 'Assign lead' : menuAction === 'return' ? 'Return lead' : 'Pick campaign'}>
+            {menu === 'campaign' && (
+              <>
+                <SheetHead title="Which campaign's lead?" kicker={menuAction === 'assign' ? 'then pick an agent' : `${menuAction} that signup`} />
+                {railSignups.map((s) => (
+                  <button
+                    key={s.prospectId}
+                    type="button"
+                    onClick={() => pickCampaign(s)}
+                    style={{ display: 'flex', alignItems: 'center', gap: 10, width: '100%', minHeight: 56, padding: '9px 12px', background: 'var(--surface-2)', border: '1px solid var(--line)', borderRadius: 12, marginBottom: 7, cursor: 'pointer', textAlign: 'left', fontFamily: 'var(--font-ui)', color: 'var(--ink)', boxSizing: 'border-box' }}
+                  >
+                    <span style={{ flex: 1, minWidth: 0 }}>
+                      <span style={{ display: 'block', fontSize: 13, fontWeight: 700, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{s.campaign?.name || 'No campaign'}</span>
+                      <span className="av2-mono" style={{ display: 'block', fontSize: 10.5, color: 'var(--ink-3)', marginTop: 1 }}>
+                        agent: {s.agentName || (s.externalBuyer ? 'external buyer' : 'unassigned')}
+                      </span>
+                    </span>
+                    <span style={{ color: 'var(--ink-3)', flex: 'none' }} aria-hidden="true">›</span>
+                  </button>
+                ))}
+              </>
+            )}
+            {menu === 'agent' && (
+              <>
+                <SheetHead title={`Assign ${menuTargetSignup?.campaign?.name || 'this'} lead`} kicker="wallet charged on assignment" />
+                {agentOptions.isLoading && <div style={{ padding: 8 }}><Skeleton height={44} /></div>}
+                {(agentOptions.data || []).map((a) => (
+                  <button
+                    key={a.id}
+                    type="button"
+                    onClick={() => { setMenu(null); assignMutation.mutate({ targetId: menuTarget || prospectId, agentId: a.id, agentName: a.name }); }}
+                    style={{ display: 'flex', alignItems: 'center', gap: 10, width: '100%', minHeight: 52, padding: '8px 4px', background: 'transparent', border: 'none', borderBottom: '1px solid var(--line)', cursor: 'pointer', textAlign: 'left', fontFamily: 'var(--font-ui)', color: 'var(--ink)' }}
+                  >
+                    <span style={{ width: 34, height: 34, flex: 'none', borderRadius: '50%', background: 'var(--surface-2)', color: 'var(--ink-2)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 11.5, fontWeight: 700 }}>
+                      {(a.name || '?').split(/\s+/).map((x) => x[0]).slice(0, 2).join('').toUpperCase()}
+                    </span>
+                    <span style={{ flex: 1, minWidth: 0, fontSize: 13.5, fontWeight: 700 }}>{a.name}</span>
+                    <span className="av2-mono" style={{ fontSize: 10, color: 'var(--ink-3)', flex: 'none' }}>LYFE</span>
+                  </button>
+                ))}
+              </>
+            )}
+          </MobileSheet>
         </>
       )}
 

--- a/src/pages/adminv2/AdminV2More.jsx
+++ b/src/pages/adminv2/AdminV2More.jsx
@@ -1,0 +1,139 @@
+/**
+ * More — the mobile hub tab (design source 1694f8b2 "MKTR Ops Console
+ * Mobile"). Everything that lives in the desktop sidebar but not on the four
+ * main tabs: the long-tail Lead Generation screens, System screens, plus the
+ * SGT clock, theme toggle and account block that the desktop topbar carries.
+ * Reachable on desktop too (harmless), but only linked from mobile chrome.
+ */
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAdminV2Shell } from '@/components/adminv2/mobile/shellContext';
+
+const GROUPS = [
+  {
+    label: 'Lead generation',
+    items: [
+      { label: 'People', to: '/AdminPeople' },
+      { label: 'Cohorts', to: '/AdminCohorts' },
+      { label: 'Email Pushes', to: '/AdminBroadcasts' },
+      { label: 'Agent Groups', to: '/AdminAgentGroups' },
+      { label: 'QR Codes', to: '/AdminQRCodes' },
+      { label: 'Short Links', to: '/AdminShortLinks' },
+    ],
+  },
+  {
+    label: 'System',
+    items: [
+      { label: 'Users', to: '/AdminUsers' },
+      { label: 'AI Settings', to: '/AdminAISettings' },
+    ],
+  },
+];
+
+function sgtClock() {
+  return new Intl.DateTimeFormat('en-SG', { timeZone: 'Asia/Singapore', hour: '2-digit', minute: '2-digit', hourCycle: 'h23' }).format(new Date());
+}
+
+function nameOf(user) {
+  return `${user?.firstName || ''} ${user?.lastName || ''}`.trim() || user?.fullName || 'Operator';
+}
+
+function initialsOf(user) {
+  const name = nameOf(user);
+  const parts = name.split(/\s+/);
+  return ((parts[0]?.[0] || '') + (parts[1]?.[0] || '')).toUpperCase() || (user?.email || 'OP').slice(0, 2).toUpperCase();
+}
+
+export default function AdminV2More() {
+  const navigate = useNavigate();
+  const shell = useAdminV2Shell();
+  const [clock, setClock] = useState(sgtClock);
+
+  useEffect(() => {
+    const t = setInterval(() => setClock(sgtClock()), 15_000);
+    return () => clearInterval(t);
+  }, []);
+
+  const theme = shell?.theme || 'light';
+  const dark = theme === 'dark';
+
+  return (
+    <div style={{ maxWidth: 560 }}>
+      {/* Status card: live SGT clock + theme toggle */}
+      <div className="av2-card" style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 14px' }}>
+        <span className="av2-pulse" aria-hidden="true" />
+        <span className="av2-mono" style={{ fontSize: 12, color: 'var(--ink-2)', flex: 1 }}>SGT {clock}</span>
+        <button
+          type="button"
+          onClick={() => shell?.setTheme?.(dark ? 'light' : 'dark')}
+          aria-label={`Switch to ${dark ? 'light' : 'dark'} theme`}
+          style={{
+            display: 'flex', alignItems: 'center', gap: 7, height: 36, padding: '0 12px',
+            background: 'var(--surface-2)', border: '1px solid var(--line)', borderRadius: 10,
+            cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 12, fontWeight: 700, color: 'var(--ink-2)',
+          }}
+        >
+          <span aria-hidden="true" style={{ fontSize: 12 }}>{dark ? '◗' : '○'}</span>
+          {dark ? 'Dark' : 'Light'}
+        </button>
+      </div>
+
+      {GROUPS.map((g) => (
+        <div key={g.label}>
+          <div className="av2-mono" style={{ fontSize: 10, fontWeight: 600, letterSpacing: '.13em', color: 'var(--ink-3)', textTransform: 'uppercase', padding: '16px 2px 6px' }}>
+            {g.label}
+          </div>
+          <div className="av2-card" style={{ overflow: 'hidden' }}>
+            {g.items.map((item, i) => (
+              <button
+                key={item.to}
+                type="button"
+                onClick={() => navigate(item.to)}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 10, width: '100%', minHeight: 52,
+                  padding: '8px 14px', background: 'transparent', border: 'none',
+                  borderBottom: i === g.items.length - 1 ? 'none' : '1px solid var(--line)',
+                  cursor: 'pointer', textAlign: 'left', fontFamily: 'var(--font-ui)', color: 'var(--ink)',
+                }}
+              >
+                <span style={{ fontSize: 13.5, fontWeight: 700, flex: 1 }}>{item.label}</span>
+                <span style={{ color: 'var(--ink-3)' }} aria-hidden="true">›</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+
+      <div className="av2-mono" style={{ fontSize: 10, fontWeight: 600, letterSpacing: '.13em', color: 'var(--ink-3)', textTransform: 'uppercase', padding: '16px 2px 6px' }}>
+        Account
+      </div>
+      <div className="av2-card" style={{ padding: '13px 14px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 11 }}>
+          <span style={{ width: 40, height: 40, flex: 'none', borderRadius: '50%', background: 'var(--ink)', color: 'var(--canvas)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 13, fontWeight: 700 }}>
+            {initialsOf(shell?.user)}
+          </span>
+          <span style={{ flex: 1, minWidth: 0 }}>
+            <span style={{ display: 'block', fontSize: 13.5, fontWeight: 700 }}>{nameOf(shell?.user)}</span>
+            <span className="av2-mono" style={{ display: 'block', fontSize: 10.5, color: 'var(--ink-3)', marginTop: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {shell?.user?.email || 'admin'} · ADMIN
+            </span>
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={() => shell?.signOut?.()}
+          style={{
+            width: '100%', height: 42, marginTop: 12, background: 'var(--surface-2)', border: 'none',
+            borderRadius: 10, cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 12.5, fontWeight: 700, color: 'var(--ink)',
+          }}
+        >
+          Sign out
+        </button>
+      </div>
+
+      <div className="av2-mono" style={{ fontSize: 9.5, letterSpacing: '.13em', color: 'var(--ink-3)', textAlign: 'center', padding: '20px 0 6px' }}>
+        MKTR OPS CONSOLE · ALL TIMES SGT
+      </div>
+    </div>
+  );
+}

--- a/src/pages/adminv2/AdminV2People.jsx
+++ b/src/pages/adminv2/AdminV2People.jsx
@@ -13,6 +13,7 @@ import { useConsumers } from '@/hooks/queries/useAdminV2';
 import { PAGE_SIZE } from '@/lib/adminV2/constants';
 import { fmtDateTime, fmtRelative, fmtPhone } from '@/lib/adminV2/format';
 import { Chip, PageHeader, Skeleton, ErrorState, EmptyState } from '@/components/adminv2/primitives';
+import { useAdminV2Mobile } from '@/components/adminv2/mobile/useAdminV2Mobile';
 
 function readFilters(searchParams) {
   return {
@@ -140,6 +141,7 @@ export default function AdminV2People() {
   }), [filters]);
 
   const people = useConsumers(queryParams);
+  const mobile = useAdminV2Mobile();
   const rows = people.data?.rows || [];
   const total = people.data?.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
@@ -153,6 +155,105 @@ export default function AdminV2People() {
       state: { from: `${location.pathname}${location.search}` },
     });
   };
+
+  /* ── Mobile (design 1694f8b2 "MKTR Ops Console Mobile"): search + person cards ── */
+  if (mobile) {
+    return (
+      <div>
+        <div className="av2-mono" style={{ fontSize: 10, letterSpacing: '.12em', color: 'var(--ink-3)', textTransform: 'uppercase', padding: '2px 2px 10px' }}>
+          {total.toLocaleString('en-SG')} people · deduplicated
+        </div>
+
+        <div className="av2-input" style={{ height: 44, marginBottom: 10 }}>
+          <span aria-hidden="true" style={{ color: 'var(--ink-3)' }}>⌕</span>
+          <input
+            value={searchDraft}
+            onChange={(e) => setSearchDraft(e.target.value)}
+            placeholder="Search name, phone, email"
+            aria-label="Search people"
+            style={{ border: 'none', outline: 'none', background: 'transparent', flex: 1, minWidth: 0, font: 'inherit', color: 'inherit', fontSize: 13 }}
+          />
+        </div>
+
+        {people.isLoading && (
+          <div style={{ display: 'grid', gap: 8 }}>
+            {[0, 1, 2, 3, 4].map((i) => <Skeleton key={i} height={90} style={{ borderRadius: 14 }} />)}
+          </div>
+        )}
+        {people.isError && <div className="av2-card"><ErrorState error={people.error} onRetry={people.refetch} /></div>}
+        {!people.isLoading && !people.isError && rows.length === 0 && (
+          <div className="av2-card">
+            <EmptyState
+              title={filters.search ? 'No people match this search' : 'No linked people yet'}
+              hint={filters.search
+                ? 'Search matches name, email, and phone digits. Erased people are browsable but never searchable.'
+                : 'People appear here once a signup links to the consumer spine.'}
+              action={filters.search && (
+                <button type="button" className="av2-btn av2-btn--sm" onClick={() => { setSearchDraft(''); patch({ q: null, page: null }); }}>Clear search</button>
+              )}
+            />
+          </div>
+        )}
+        <div style={{ display: 'grid', gap: 8 }}>
+          {rows.map((r) => {
+            const erased = !!r.erasedAt;
+            const name = `${r.firstName || ''} ${r.lastName || ''}`.trim();
+            const clickable = !!r.latestProspectId;
+            const meet = erased ? null : r.meetScore;
+            const buy = erased ? null : r.buyScore;
+            return (
+              <button
+                key={r.id}
+                type="button"
+                onClick={() => openPerson(r)}
+                className="av2-card"
+                style={{ display: 'block', width: '100%', textAlign: 'left', padding: '11px 13px', cursor: clickable ? 'pointer' : 'default', fontFamily: 'var(--font-ui)', color: 'var(--ink)' }}
+              >
+                <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span style={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: 7 }}>
+                    <span style={{ fontSize: 13.5, fontWeight: 700, color: erased ? 'var(--ink-2)' : 'var(--ink)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                      {erased ? 'Erased person' : (name || '—')}
+                    </span>
+                    {erased && <Chip tone="bad" glyph="⊘">Erased</Chip>}
+                  </span>
+                  <span className="av2-mono" style={{ flex: 'none', fontSize: 10, color: 'var(--ink-3)' }} title={fmtDateTime(r.lastSeenAt)}>
+                    {fmtRelative(r.lastSeenAt)}
+                  </span>
+                </span>
+                <span className="av2-mono" style={{ display: 'block', fontSize: 10, color: 'var(--ink-3)', marginTop: 2, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  {erased ? '—' : (r.email || '—')} · {fmtPhone(r.phone) || '—'}
+                </span>
+                <span style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 7 }}>
+                  <span style={{ flex: 1, minWidth: 0, fontSize: 11.5, color: 'var(--ink-2)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                    {r.signupCount} signup{r.signupCount === 1 ? '' : 's'} ({r.verifiedSignupCount} verified)
+                  </span>
+                  <span
+                    className="av2-mono"
+                    style={{ flex: 'none', fontSize: 10.5, color: 'var(--ink-2)' }}
+                    title={!erased && r.scoreSourceCampaignName ? `Scored on ${r.scoreSourceCampaignName}` : undefined}
+                  >
+                    M {meet ?? '—'} · B {buy ?? '—'}
+                  </span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 2px 0' }}>
+          <span className="av2-mono" style={{ flex: 1, fontSize: 10.5, color: 'var(--ink-3)' }}>
+            {rangeStart}–{rangeEnd} of {total.toLocaleString('en-SG')}
+          </span>
+          <button type="button" className="av2-btn av2-btn--sm" style={{ height: 38 }} disabled={filters.page <= 1} onClick={() => patch({ page: String(filters.page - 1) })}>← Prev</button>
+          <button type="button" className="av2-btn av2-btn--sm" style={{ height: 38 }} disabled={filters.page >= totalPages} onClick={() => patch({ page: String(filters.page + 1) })}>Next →</button>
+        </div>
+
+        <div style={{ fontSize: 11.5, color: 'var(--ink-3)', marginTop: 10 }}>
+          Voice (Retell) and pre-spine leads have no linked person — find them in Prospects.
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/src/pages/adminv2/AdminV2Prospects.jsx
+++ b/src/pages/adminv2/AdminV2Prospects.jsx
@@ -20,6 +20,10 @@ import { fmtDateTime, fmtRelative } from '@/lib/adminV2/format';
 import { prospectsToCsv, downloadCsv } from '@/lib/adminV2/csv';
 import { rowChipFor } from '@/lib/adminV2/outcome';
 import { Chip, PageHeader, Skeleton, ErrorState, EmptyState } from '@/components/adminv2/primitives';
+import { useAdminV2Mobile } from '@/components/adminv2/mobile/useAdminV2Mobile';
+import { useLongPress } from '@/components/adminv2/mobile/useLongPress';
+import MobileSheet, { SheetHead, SheetConfirm } from '@/components/adminv2/mobile/MobileSheet';
+import { MobileSelectBar } from '@/components/adminv2/mobile/MobileBars';
 import {
   DropdownMenu, DropdownMenuTrigger, DropdownMenuContent,
   DropdownMenuCheckboxItem, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator,
@@ -103,6 +107,105 @@ function LeadScoreCell({ value, scoredAt }) {
   );
 }
 
+/**
+ * Campaign-outcome chip cluster (plan: admin-prospects-outcome-column):
+ * held alarm → outcome in the campaign's own voice → pipeline status ONLY
+ * when it isn't the default 'new' → screening verdict. Shared by the desktop
+ * table cell and the mobile card row so the two can never disagree.
+ */
+function OutcomeChips({ p, held }) {
+  return (
+    <>
+      {held
+        ? <Chip tone="hold" glyph="◆">{heldLabel(p).short}</Chip>
+        : (() => {
+          const chip = rowChipFor(p.draw, p.reward ? [p.reward] : []);
+          const pipeline = p.leadStatus && p.leadStatus !== 'new' && (
+            <Chip tone={STATUS_CHIP_CLASS[p.leadStatus]?.replace('av2-chip--', '') || ''}>
+              {STATUS_LABELS[p.leadStatus] || p.leadStatus}
+            </Chip>
+          );
+          if (!chip && !pipeline) {
+            return <span className="av2-mono" aria-label="No outcome yet" style={{ fontSize: 11, color: 'var(--ink-3)', paddingTop: 2 }}>—</span>;
+          }
+          return (
+            <>
+              {chip && <Chip tone={chip.tone}>{chip.label}</Chip>}
+              {pipeline}
+            </>
+          );
+        })()}
+      {p.screeningVerdict && !String(p.quarantineReason || '').startsWith('screening_') && (
+        <span
+          title={p.screeningVerdict === 'qualified'
+            ? 'Passed the AI screening call — SG/PR, in age range, agreed to meet a consultant'
+            : p.screeningVerdict === 'not_qualified'
+              ? 'Did not pass the AI screening call'
+              : 'AI screening result'}
+          style={{ display: 'inline-flex' }}
+        >
+          <Chip
+            tone={p.screeningVerdict === 'qualified' ? 'ok' : p.screeningVerdict === 'not_qualified' ? 'bad' : 'warn'}
+            glyph={p.screeningVerdict === 'qualified' ? '✓' : p.screeningVerdict === 'not_qualified' ? '✗' : '☎'}
+          >
+            {p.screeningVerdict === 'qualified' ? 'AI qualified'
+              : p.screeningVerdict === 'not_qualified' ? 'AI failed'
+                : 'AI screen'}
+          </Chip>
+        </span>
+      )}
+    </>
+  );
+}
+
+/** Mobile lead card (design 1694f8b2): tap opens/toggles, long-press selects. */
+function MobileLeadRow({ p, selecting, isSelected, onTap, onLongPress }) {
+  const lp = useLongPress(onLongPress);
+  const held = !!p.quarantinedAt;
+  const agent = p.assignedAgent ? `${p.assignedAgent.firstName || ''} ${p.assignedAgent.lastName || ''}`.trim() : '';
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onTap}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onTap(); } }}
+      {...lp}
+      className="av2-card"
+      style={{
+        display: 'block', width: '100%', textAlign: 'left', padding: '11px 13px', cursor: 'pointer',
+        background: isSelected ? 'var(--accent-soft)' : 'var(--surface)',
+        borderColor: isSelected ? 'var(--accent)' : 'var(--line)',
+        WebkitUserSelect: 'none', userSelect: 'none',
+      }}
+    >
+      <span style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+        {selecting && <CheckboxGlyph checked={isSelected} />}
+        <span style={{ flex: 1, minWidth: 0, fontSize: 13.5, fontWeight: 700, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          {p.firstName} {p.lastName}
+        </span>
+        <span className="av2-mono" style={{ flex: 'none', fontSize: 9.5, color: 'var(--ink-3)' }}>{fmtRelative(p.createdAt)}</span>
+      </span>
+      <span style={{ display: 'flex', alignItems: 'center', gap: 7, marginTop: 4 }}>
+        <span className="av2-mono" style={{ fontSize: 10.5, color: 'var(--ink-3)', flex: 'none' }}>{p.phone || '—'}</span>
+        <span style={{ flex: 1, minWidth: 0, fontSize: 11, color: 'var(--ink-2)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          {p.campaign?.name || '—'}
+        </span>
+      </span>
+      <span style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 7, flexWrap: 'wrap' }}>
+        <OutcomeChips p={p} held={held} />
+        <span style={{ flex: 1, minWidth: 24, textAlign: 'right', fontSize: 11, fontWeight: 600, color: agent ? 'var(--ink-2)' : 'var(--warn)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          {agent || (p.externalAgentId ? 'External' : held ? '' : 'Unassigned')}
+        </span>
+        {p.score != null && (
+          <span className="av2-mono" style={{ flex: 'none', fontSize: 10.5, color: 'var(--ink-2)' }} title={`Lead score ${p.score}/100`}>
+            Score {p.score}
+          </span>
+        )}
+      </span>
+    </div>
+  );
+}
+
 function SortHeader({ label, field, sort, onSort, width, align }) {
   const active = sort === field || sort === `-${field}`;
   const desc = sort === `-${field}`;
@@ -133,6 +236,13 @@ export default function AdminV2Prospects() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const location = useLocation();
+  const mobile = useAdminV2Mobile();
+  // Mobile-only UI state: which bottom sheet is up, the filter draft it edits
+  // (applied to the URL in one patch), explicit select mode, agent search.
+  const [sheet, setSheet] = useState(null); // 'filters' | 'assign' | 'confirmDelete'
+  const [filterDraft, setFilterDraft] = useState(null);
+  const [selectMode, setSelectMode] = useState(false);
+  const [agentQ, setAgentQ] = useState('');
 
   // Open a lead's full-page profile, carrying the CURRENT list URL as
   // state.from so the page's back link restores these exact filters (§3.8).
@@ -311,6 +421,254 @@ export default function AdminV2Prospects() {
   const rangeStart = total === 0 ? 0 : (filters.page - 1) * PAGE_SIZE + 1;
   const rangeEnd = Math.min(filters.page * PAGE_SIZE, total);
 
+  /* ── Mobile (design 1694f8b2): card list, filter sheet, select mode ── */
+  if (mobile) {
+    const selecting = selectMode || selected.size > 0;
+    const filterCount = filters.status.length + filters.source.length + (filters.assignment ? 1 : 0);
+    const pillStyle = (on) => ({
+      minHeight: 36, padding: '0 13px', borderRadius: 9, cursor: 'pointer', fontFamily: 'var(--font-ui)',
+      fontSize: 12, fontWeight: 700, background: on ? 'var(--ink)' : 'var(--surface)',
+      color: on ? 'var(--canvas)' : 'var(--ink-2)', border: `1px solid ${on ? 'var(--ink)' : 'var(--line-strong)'}`,
+    });
+    const openFiltersSheet = () => {
+      setFilterDraft({ status: [...filters.status], source: [...filters.source], assignment: filters.assignment, sort: filters.sort });
+      setSheet('filters');
+    };
+    const draftToggle = (key, value) => setFilterDraft((d) => {
+      const cur = new Set(d[key]);
+      if (cur.has(value)) cur.delete(value); else cur.add(value);
+      return { ...d, [key]: [...cur] };
+    });
+    const applyDraft = () => {
+      patch({
+        status: filterDraft.status.join(',') || null,
+        source: filterDraft.source.join(',') || null,
+        assignment: filterDraft.assignment || null,
+        sort: filterDraft.sort === '-createdAt' ? null : filterDraft.sort,
+        page: null,
+      });
+      setSheet(null);
+    };
+    const exitSelect = () => { setSelected(new Set()); setSelectMode(false); };
+    const agentNeedle = agentQ.trim().toLowerCase();
+    const agentRows = (agentOptions.data || []).filter((a) => !agentNeedle
+      || [a.name, a.email, a.phone].filter(Boolean).some((s) => s.toLowerCase().includes(agentNeedle)));
+    const toggleSwitch = (on) => (
+      <span aria-hidden="true" style={{ width: 44, height: 26, flex: 'none', borderRadius: 13, position: 'relative', transition: 'background .15s', background: on ? 'var(--accent)' : 'var(--line-strong)' }}>
+        <span style={{ position: 'absolute', top: 3, width: 20, height: 20, borderRadius: '50%', background: '#fff', boxShadow: '0 1px 3px rgba(0,0,0,.25)', transition: 'left .15s', left: on ? 21 : 3 }} />
+      </span>
+    );
+
+    return (
+      <div>
+        {/* Search + Filters */}
+        <div style={{ display: 'flex', gap: 8 }}>
+          <div className="av2-input" style={{ flex: 1, height: 44, minWidth: 0 }}>
+            <span aria-hidden="true" style={{ color: 'var(--ink-3)' }}>⌕</span>
+            <input
+              value={searchDraft}
+              onChange={(e) => setSearchDraft(e.target.value)}
+              placeholder="Name, phone, email…"
+              aria-label="Search prospects"
+              style={{ border: 'none', outline: 'none', background: 'transparent', flex: 1, minWidth: 0, font: 'inherit', color: 'inherit', fontSize: 13.5 }}
+            />
+            {searchDraft && (
+              <button type="button" onClick={() => setSearchDraft('')} aria-label="Clear search" style={{ background: 'var(--surface-2)', border: 'none', borderRadius: '50%', width: 20, height: 20, cursor: 'pointer', color: 'var(--ink-2)', fontSize: 11, lineHeight: 1, flex: 'none', padding: 0 }}>✕</button>
+            )}
+          </div>
+          <button type="button" onClick={openFiltersSheet} style={{ height: 44, flex: 'none', display: 'flex', alignItems: 'center', gap: 7, padding: '0 13px', background: 'var(--surface)', border: '1px solid var(--line-strong)', borderRadius: 10, cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 12.5, fontWeight: 700, color: 'var(--ink)' }}>
+            <svg viewBox="0 0 24 24" style={{ width: 14, height: 14 }} aria-hidden="true">
+              <path d="M4 6h16M7 12h10M10 18h4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            </svg>
+            Filters
+            {filterCount > 0 && (
+              <span className="av2-mono" style={{ fontSize: 10, fontWeight: 600, background: 'var(--accent)', color: 'var(--accent-ink)', borderRadius: 6, padding: '1px 6px' }}>{filterCount}</span>
+            )}
+          </button>
+        </div>
+
+        {/* Applied filter chips — horizontal scroll */}
+        {activeChips.length > 0 && (
+          <div style={{ display: 'flex', gap: 6, overflowX: 'auto', padding: '9px 14px 1px', margin: '0 -14px' }}>
+            {activeChips.map((c) => (
+              <button key={c.key} type="button" className="av2-filterchip" onClick={c.clear} aria-label={`Remove filter ${c.label}`} style={{ flex: 'none', whiteSpace: 'nowrap' }}>
+                {c.label} ✕
+              </button>
+            ))}
+            <button
+              type="button" className="av2-filterchip" style={{ background: 'transparent', color: 'var(--ink-3)', flex: 'none', whiteSpace: 'nowrap' }}
+              onClick={() => { setSearchDraft(''); setSearchParams(new URLSearchParams(), { replace: true }); }}
+            >
+              Clear all
+            </button>
+          </div>
+        )}
+
+        {/* Meta + select toggle */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 2px 8px' }}>
+          <span className="av2-mono" style={{ fontSize: 10, letterSpacing: '.13em', color: 'var(--ink-3)', textTransform: 'uppercase', flex: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {total.toLocaleString('en-SG')} lead{total === 1 ? '' : 's'}{total > 0 ? ` · ${rangeStart}–${rangeEnd}` : ''}
+          </span>
+          <button type="button" onClick={() => (selecting ? exitSelect() : setSelectMode(true))} style={{ background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 12, fontWeight: 700, color: 'var(--accent-text)', padding: '4px 2px' }}>
+            {selecting ? 'Done' : 'Select'}
+          </button>
+        </div>
+
+        {/* Card list */}
+        {prospects.isLoading && (
+          <div style={{ display: 'grid', gap: 8 }}>
+            {[0, 1, 2, 3].map((i) => <Skeleton key={i} height={92} style={{ borderRadius: 14 }} />)}
+          </div>
+        )}
+        {prospects.isError && <div className="av2-card"><ErrorState error={prospects.error} onRetry={prospects.refetch} /></div>}
+        {!prospects.isLoading && !prospects.isError && rows.length === 0 && (
+          <div className="av2-card">
+            <EmptyState
+              title="No leads match"
+              hint="Loosen the filters or clear the search — nothing in the pipeline matches this slice."
+              action={activeChips.length > 0 && (
+                <button type="button" className="av2-btn av2-btn--sm" onClick={() => { setSearchDraft(''); setSearchParams(new URLSearchParams(), { replace: true }); }}>Clear filters</button>
+              )}
+            />
+          </div>
+        )}
+        <div style={{ display: 'grid', gap: 8 }}>
+          {rows.map((p) => (
+            <MobileLeadRow
+              key={p.id}
+              p={p}
+              selecting={selecting}
+              isSelected={selected.has(p.id)}
+              onTap={() => { if (selecting) toggleOne(p.id); else openLead(p.id); }}
+              onLongPress={() => { if (!selecting) { setSelectMode(true); toggleOne(p.id); } }}
+            />
+          ))}
+        </div>
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 2px' }}>
+            <span className="av2-mono" style={{ fontSize: 11, color: 'var(--ink-3)' }}>
+              {rangeStart}–{rangeEnd} of {total.toLocaleString('en-SG')}
+            </span>
+            <span style={{ flex: 1 }} />
+            <button type="button" className="av2-btn av2-btn--sm" disabled={filters.page <= 1} onClick={() => patch({ page: String(filters.page - 1) })}>← Prev</button>
+            <button type="button" className="av2-btn av2-btn--sm" disabled={filters.page >= totalPages} onClick={() => patch({ page: String(filters.page + 1) })}>Next →</button>
+          </div>
+        )}
+
+        {/* Select-mode action bar (replaces the tab bar while active) */}
+        {selecting && (
+          <MobileSelectBar
+            count={selected.size}
+            onCancel={exitSelect}
+            actions={[
+              { label: 'Assign', tone: 'primary', disabled: selected.size === 0 || assignMutation.isPending, run: () => { setAgentQ(''); setSheet('assign'); } },
+              { label: 'Return', disabled: selected.size === 0 || returnMutation.isPending, run: () => { returnMutation.mutate(); setSelectMode(false); } },
+              { label: 'CSV', disabled: selected.size === 0, run: exportSelection },
+              { label: 'Delete', tone: 'danger', disabled: selected.size === 0, run: () => setSheet('confirmDelete') },
+            ]}
+          />
+        )}
+
+        {/* Filters sheet */}
+        <MobileSheet open={sheet === 'filters' && !!filterDraft} onClose={() => setSheet(null)} label="Filters">
+          {filterDraft && (
+            <>
+              <SheetHead
+                title="Filters"
+                action={(
+                  <button type="button" onClick={() => setFilterDraft({ status: [], source: [], assignment: '', sort: '-createdAt' })} style={{ background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 12.5, fontWeight: 700, color: 'var(--ink-3)', padding: '6px 2px' }}>
+                    Clear all
+                  </button>
+                )}
+              />
+              <div className="av2-mono" style={{ fontSize: 10, fontWeight: 600, letterSpacing: '.12em', textTransform: 'uppercase', color: 'var(--ink-3)', paddingBottom: 7 }}>Status</div>
+              <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', paddingBottom: 14 }}>
+                {LEAD_STATUSES.map((s) => (
+                  <button key={s} type="button" aria-pressed={filterDraft.status.includes(s)} onClick={() => draftToggle('status', s)} style={pillStyle(filterDraft.status.includes(s))}>
+                    {STATUS_LABELS[s] || s}
+                  </button>
+                ))}
+              </div>
+              <div className="av2-mono" style={{ fontSize: 10, fontWeight: 600, letterSpacing: '.12em', textTransform: 'uppercase', color: 'var(--ink-3)', paddingBottom: 7 }}>Source</div>
+              <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', paddingBottom: 14 }}>
+                {LEAD_SOURCES.map((s) => (
+                  <button key={s} type="button" aria-pressed={filterDraft.source.includes(s)} onClick={() => draftToggle('source', s)} style={pillStyle(filterDraft.source.includes(s))}>
+                    {SOURCE_LABELS[s] || s}
+                  </button>
+                ))}
+              </div>
+              {[['held', '◆ Held only', 'Quarantined — no funded agent, screening, DNC'], ['unassigned', 'Unassigned only', 'Captured but not delivered to any agent']].map(([key, label, hint]) => (
+                <button key={key} type="button" onClick={() => setFilterDraft((d) => ({ ...d, assignment: d.assignment === key ? '' : key }))} style={{ display: 'flex', alignItems: 'center', gap: 10, width: '100%', minHeight: 48, padding: '4px 2px', background: 'transparent', border: 'none', borderTop: '1px solid var(--line)', cursor: 'pointer', textAlign: 'left', fontFamily: 'var(--font-ui)' }}>
+                  <span style={{ flex: 1 }}>
+                    <span style={{ display: 'block', fontSize: 13.5, fontWeight: 700, color: 'var(--ink)' }}>{label}</span>
+                    <span style={{ display: 'block', fontSize: 11, color: 'var(--ink-3)', marginTop: 1 }}>{hint}</span>
+                  </span>
+                  {toggleSwitch(filterDraft.assignment === key)}
+                </button>
+              ))}
+              <div className="av2-mono" style={{ fontSize: 10, fontWeight: 600, letterSpacing: '.12em', textTransform: 'uppercase', color: 'var(--ink-3)', padding: '12px 0 7px', borderTop: '1px solid var(--line)' }}>Sort</div>
+              <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', paddingBottom: 16 }}>
+                {[['-createdAt', 'Newest'], ['createdAt', 'Oldest'], ['-score', 'Score high'], ['firstName', 'Name A–Z']].map(([v, label]) => (
+                  <button key={v} type="button" aria-pressed={filterDraft.sort === v} onClick={() => setFilterDraft((d) => ({ ...d, sort: v }))} style={pillStyle(filterDraft.sort === v)}>
+                    {label}
+                  </button>
+                ))}
+              </div>
+              <button type="button" onClick={applyDraft} style={{ width: '100%', height: 48, background: 'var(--accent)', color: 'var(--accent-ink)', border: 'none', borderRadius: 12, cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 14, fontWeight: 700 }}>
+                Apply filters
+              </button>
+            </>
+          )}
+        </MobileSheet>
+
+        {/* Assign sheet */}
+        <MobileSheet open={sheet === 'assign'} onClose={() => setSheet(null)} label="Assign to agent">
+          <SheetHead title={`Assign ${selected.size} lead${selected.size === 1 ? '' : 's'}`} kicker="wallet charged on assignment" />
+          <div className="av2-input" style={{ height: 44, marginBottom: 10, background: 'var(--surface-2)' }}>
+            <span aria-hidden="true" style={{ color: 'var(--ink-3)' }}>⌕</span>
+            <input value={agentQ} onChange={(e) => setAgentQ(e.target.value)} placeholder="Search agents…" aria-label="Search agents" style={{ border: 'none', outline: 'none', background: 'transparent', flex: 1, minWidth: 0, font: 'inherit', color: 'inherit', fontSize: 13 }} />
+          </div>
+          {agentOptions.isLoading && <div style={{ padding: 8 }}><Skeleton height={44} /></div>}
+          {!agentOptions.isLoading && agentRows.length === 0 && (
+            <div className="av2-mono" style={{ padding: '16px 4px', fontSize: 11, color: 'var(--ink-3)', textAlign: 'center' }}>No agents match</div>
+          )}
+          {agentRows.map((a) => (
+            <button
+              key={a.id}
+              type="button"
+              onClick={() => { assignMutation.mutate({ agentId: a.id, agentName: a.name }); setSheet(null); setSelectMode(false); }}
+              style={{ display: 'flex', alignItems: 'center', gap: 10, width: '100%', minHeight: 56, padding: '8px 4px', background: 'transparent', border: 'none', borderBottom: '1px solid var(--line)', cursor: 'pointer', textAlign: 'left', fontFamily: 'var(--font-ui)', color: 'var(--ink)' }}
+            >
+              <span style={{ width: 34, height: 34, flex: 'none', borderRadius: '50%', background: 'var(--surface-2)', color: 'var(--ink-2)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 11.5, fontWeight: 700 }}>
+                {(a.name || '?').split(/\s+/).map((x) => x[0]).slice(0, 2).join('').toUpperCase()}
+              </span>
+              <span style={{ flex: 1, minWidth: 0 }}>
+                <span style={{ display: 'block', fontSize: 13.5, fontWeight: 700 }}>{a.name}</span>
+                <span className="av2-mono" style={{ display: 'block', fontSize: 10, color: 'var(--ink-3)', marginTop: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {[a.phone, a.email].filter(Boolean).join(' · ') || '—'}
+                </span>
+              </span>
+              <span style={{ color: 'var(--ink-3)', flex: 'none' }} aria-hidden="true">›</span>
+            </button>
+          ))}
+        </MobileSheet>
+
+        {/* Delete confirm sheet */}
+        <MobileSheet open={sheet === 'confirmDelete'} onClose={() => setSheet(null)} label="Delete leads">
+          <SheetConfirm
+            title={`Delete ${selected.size} lead${selected.size === 1 ? '' : 's'}?`}
+            body="This permanently removes the selected leads and their activity history. It cannot be undone."
+            label={deleteMutation.isPending ? 'Deleting…' : 'Delete'}
+            onConfirm={() => { deleteMutation.mutate(); setSheet(null); setSelectMode(false); }}
+            onCancel={() => setSheet(null)}
+          />
+        </MobileSheet>
+      </div>
+    );
+  }
+
   return (
     <div>
       <PageHeader title="Prospects" meta={`${total.toLocaleString('en-SG')} LEADS · SERVER-SIDE 25/PAGE`}>
@@ -450,52 +808,8 @@ export default function AdminV2Prospects() {
               </span>
               <span className="av2-mono" style={{ width: 110, flex: 'none', fontSize: 11, color: 'var(--ink-2)' }}>{p.phone || '—'}</span>
               <span style={{ width: 130, flex: 'none', display: 'flex', flexDirection: 'column', gap: 3, alignItems: 'flex-start' }}>
-                {/* Campaign-outcome precedence (plan: admin-prospects-outcome-column):
-                    held alarm → outcome in the campaign's own voice → pipeline
-                    status ONLY when it isn't the default 'new' → screening.
-                    A lead with nothing yet is silent (muted dash) — no "New" wall. */}
-                {held
-                  ? <Chip tone="hold" glyph="◆">{heldLabel(p).short}</Chip>
-                  : (() => {
-                    const chip = rowChipFor(p.draw, p.reward ? [p.reward] : []);
-                    const pipeline = p.leadStatus && p.leadStatus !== 'new' && (
-                      <Chip tone={STATUS_CHIP_CLASS[p.leadStatus]?.replace('av2-chip--', '') || ''}>
-                        {STATUS_LABELS[p.leadStatus] || p.leadStatus}
-                      </Chip>
-                    );
-                    if (!chip && !pipeline) {
-                      return <span className="av2-mono" aria-label="No outcome yet" style={{ fontSize: 11, color: 'var(--ink-3)', paddingTop: 2 }}>—</span>;
-                    }
-                    return (
-                      <>
-                        {chip && <Chip tone={chip.tone}>{chip.label}</Chip>}
-                        {pipeline}
-                      </>
-                    );
-                  })()}
-                {/* AI-screening verdict — a permanent fact independent of the
-                    pipeline status. Skipped when the row is already a screening
-                    HOLD (the hold chip conveys it); the useful case is a
-                    RELEASED lead that passed, which otherwise reads only silence. */}
-                {p.screeningVerdict && !String(p.quarantineReason || '').startsWith('screening_') && (
-                  <span
-                    title={p.screeningVerdict === 'qualified'
-                      ? 'Passed the AI screening call — SG/PR, in age range, agreed to meet a consultant'
-                      : p.screeningVerdict === 'not_qualified'
-                        ? 'Did not pass the AI screening call'
-                        : 'AI screening result'}
-                    style={{ display: 'inline-flex' }}
-                  >
-                    <Chip
-                      tone={p.screeningVerdict === 'qualified' ? 'ok' : p.screeningVerdict === 'not_qualified' ? 'bad' : 'warn'}
-                      glyph={p.screeningVerdict === 'qualified' ? '✓' : p.screeningVerdict === 'not_qualified' ? '✗' : '☎'}
-                    >
-                      {p.screeningVerdict === 'qualified' ? 'AI qualified'
-                        : p.screeningVerdict === 'not_qualified' ? 'AI failed'
-                          : 'AI screen'}
-                    </Chip>
-                  </span>
-                )}
+                {/* Chip cluster shared with the mobile card — see OutcomeChips. */}
+                <OutcomeChips p={p} held={held} />
               </span>
               <span style={{ flex: 1, fontSize: 12, color: 'var(--ink-2)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'flex', alignItems: 'center', gap: 6 }}>
                 {p.campaign && (

--- a/src/pages/adminv2/AdminV2QRCodes.jsx
+++ b/src/pages/adminv2/AdminV2QRCodes.jsx
@@ -13,6 +13,7 @@ import { useCampaignLeaderboard } from '@/hooks/queries/useAdminV2';
 import { fmtNumber, fmtRelative } from '@/lib/adminV2/format';
 import { Chip, PageHeader, Skeleton, ErrorState, EmptyState, StateRow } from '@/components/adminv2/primitives';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { useAdminV2Mobile } from '@/components/adminv2/mobile/useAdminV2Mobile';
 
 const fetchQrTags = async ({ search, campaignId }) => {
   const qs = new URLSearchParams({ limit: '200' });
@@ -64,7 +65,7 @@ function CreateDialog({ campaigns, onClose }) {
 
   return (
     <Dialog open onOpenChange={(open) => { if (!open && !create.isPending) onClose(); }}>
-      <DialogContent className="admin-v2" style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)', maxWidth: 460 }}>
+      <DialogContent variant="sheet" className="admin-v2" style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)', maxWidth: 460 }}>
         <DialogHeader>
           <DialogTitle style={{ color: 'var(--ink)', fontFamily: 'var(--font-ui)', fontSize: 15, fontWeight: 800, textAlign: 'left' }}>New promotional QR</DialogTitle>
           <DialogDescription style={{ color: 'var(--ink-2)', fontSize: 11.5, textAlign: 'left' }}>
@@ -115,6 +116,7 @@ export default function AdminV2QRCodes() {
     () => [...(tags.data?.rows || [])].sort((a, b) => (b.scanCount || 0) - (a.scanCount || 0)),
     [tags.data]
   );
+  const mobile = useAdminV2Mobile();
 
   const handleDownload = async (tag) => {
     setDownloading(tag.id);
@@ -126,6 +128,86 @@ export default function AdminV2QRCodes() {
       setDownloading('');
     }
   };
+
+  /* ── Mobile (design 1694f8b2 "MKTR Ops Console Mobile"): QR tag cards ── */
+  if (mobile) {
+    const total = tags.data?.total ?? 0;
+    return (
+      <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, paddingBottom: 10 }}>
+          <div className="av2-mono" style={{ flex: 1, minWidth: 0, fontSize: 10, letterSpacing: '.12em', color: 'var(--ink-3)', textTransform: 'uppercase', padding: '2px 2px', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {fmtNumber(total)} tags{total > rows.length && rows.length > 0 ? ` · showing first ${fmtNumber(rows.length)}` : ''} · sorted by scans
+          </div>
+          <button type="button" onClick={() => setCreating(true)} style={{ flex: 'none', height: 38, display: 'inline-flex', alignItems: 'center', padding: '0 14px', background: 'var(--accent)', color: 'var(--accent-ink)', border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 12.5, fontWeight: 700 }}>
+            + New QR
+          </button>
+        </div>
+
+        <div style={{ display: 'grid', gap: 8, paddingBottom: 10 }}>
+          <div className="av2-input" style={{ height: 44 }}>
+            <span aria-hidden="true" style={{ color: 'var(--ink-3)' }}>⌕</span>
+            <input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search label"
+              aria-label="Search QR tags"
+              style={{ border: 'none', outline: 'none', background: 'transparent', flex: 1, minWidth: 0, font: 'inherit', color: 'inherit', fontSize: 13 }}
+            />
+          </div>
+          <select
+            className="av2-input"
+            style={{ height: 44, appearance: 'auto' }}
+            value={campaignFilter}
+            onChange={(e) => setCampaignFilter(e.target.value)}
+            aria-label="Filter by campaign"
+          >
+            <option value="">All campaigns</option>
+            {campaignOptions.map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}
+          </select>
+        </div>
+
+        {tags.isLoading && (
+          <div style={{ display: 'grid', gap: 8 }}>
+            {[0, 1, 2, 3].map((i) => <Skeleton key={i} height={90} style={{ borderRadius: 14 }} />)}
+          </div>
+        )}
+        {tags.isError && <div className="av2-card"><ErrorState error={tags.error} onRetry={tags.refetch} /></div>}
+        {!tags.isLoading && !tags.isError && rows.length === 0 && (
+          <div className="av2-card"><EmptyState title="No QR tags match" hint="Create one, or clear the filters." /></div>
+        )}
+        <div style={{ display: 'grid', gap: 8 }}>
+          {rows.map((t) => (
+            <div key={t.id} className="av2-card" style={{ padding: '11px 13px' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <span aria-hidden="true" style={{ width: 38, height: 38, flex: 'none', borderRadius: 9, background: 'var(--surface-2)', color: 'var(--ink-2)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 15 }}>▦</span>
+                <span style={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: 7 }}>
+                  <span style={{ fontSize: 13.5, fontWeight: 700, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{t.label || t.name || t.slug}</span>
+                  {t.active === false && <Chip tone="warn">Inactive</Chip>}
+                </span>
+                <button
+                  type="button"
+                  aria-label={`Download ${t.label || t.name || t.slug} QR image`}
+                  disabled={downloading === t.id}
+                  onClick={() => handleDownload(t)}
+                  style={{ flex: 'none', width: 38, height: 38, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--surface-2)', border: 'none', borderRadius: 9, cursor: 'pointer', color: 'var(--ink)', fontSize: 15, opacity: downloading === t.id ? 0.5 : 1 }}
+                >
+                  ↓
+                </button>
+              </div>
+              <div className="av2-mono" style={{ margin: '7px 0 0 48px', fontSize: 10.5, color: 'var(--ink-2)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                {t.slug ? `/t/${t.slug} · ` : ''}{t.campaign?.name || '—'}
+              </div>
+              <div className="av2-mono" style={{ margin: '3px 0 0 48px', fontSize: 10, color: 'var(--ink-3)' }}>
+                {fmtNumber(t.scanCount || 0)} scans · {fmtNumber(t.uniqueScanCount || 0)} unique · last scan {t.lastScanned ? fmtRelative(t.lastScanned) : '—'}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {creating && <CreateDialog campaigns={campaignOptions} onClose={() => setCreating(false)} />}
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/src/pages/adminv2/AdminV2ShortLinks.jsx
+++ b/src/pages/adminv2/AdminV2ShortLinks.jsx
@@ -15,6 +15,7 @@ import {
   AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle,
   AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction,
 } from '@/components/ui/alert-dialog';
+import { useAdminV2Mobile } from '@/components/adminv2/mobile/useAdminV2Mobile';
 
 const fetchLinks = async () => {
   const resp = await apiClient.get('/shortlinks?limit=200');
@@ -41,7 +42,7 @@ function CreateDialog({ onClose }) {
 
   return (
     <Dialog open onOpenChange={(open) => { if (!open && !create.isPending) onClose(); }}>
-      <DialogContent className="admin-v2" style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)', maxWidth: 460 }}>
+      <DialogContent variant="sheet" className="admin-v2" style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)', maxWidth: 460 }}>
         <DialogHeader>
           <DialogTitle style={{ color: 'var(--ink)', fontFamily: 'var(--font-ui)', fontSize: 15, fontWeight: 800, textAlign: 'left' }}>New short link</DialogTitle>
           <DialogDescription style={{ color: 'var(--ink-2)', fontSize: 11.5, textAlign: 'left' }}>
@@ -87,6 +88,7 @@ export default function AdminV2ShortLinks() {
     },
     onError: (e) => { toast.error(e?.message || 'Delete failed'); setConfirmDelete(null); },
   });
+  const mobile = useAdminV2Mobile();
 
   const rows = links.data?.rows || [];
 
@@ -96,6 +98,92 @@ export default function AdminV2ShortLinks() {
       .then(() => toast.success(`Copied mktr.sg/share/${slug}`))
       .catch(() => toast.error('Copy failed'));
   };
+
+  /* ── Mobile (design 1694f8b2 "MKTR Ops Console Mobile"): link cards ── */
+  if (mobile) {
+    const total = links.data?.total ?? 0;
+    return (
+      <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, paddingBottom: 10 }}>
+          <div className="av2-mono" style={{ flex: 1, minWidth: 0, fontSize: 10, letterSpacing: '.12em', color: 'var(--ink-3)', textTransform: 'uppercase', padding: '2px 2px', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {fmtNumber(total)} links{total > rows.length && rows.length > 0 ? ` · showing newest ${fmtNumber(rows.length)}` : ''} · clicks are lifetime
+          </div>
+          <button type="button" onClick={() => setCreating(true)} style={{ flex: 'none', height: 38, display: 'inline-flex', alignItems: 'center', padding: '0 14px', background: 'var(--accent)', color: 'var(--accent-ink)', border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 12.5, fontWeight: 700 }}>
+            + New link
+          </button>
+        </div>
+
+        {links.isLoading && (
+          <div style={{ display: 'grid', gap: 8 }}>
+            {[0, 1, 2].map((i) => <Skeleton key={i} height={90} style={{ borderRadius: 14 }} />)}
+          </div>
+        )}
+        {links.isError && <div className="av2-card"><ErrorState error={links.error} onRetry={links.refetch} /></div>}
+        {!links.isLoading && !links.isError && rows.length === 0 && (
+          <div className="av2-card"><EmptyState title="No short links" hint="Create one for ads, print, or chat blasts." /></div>
+        )}
+        <div style={{ display: 'grid', gap: 8 }}>
+          {rows.map((l) => {
+            const active = isActive(l);
+            return (
+              <div key={l.id} className="av2-card" style={{ padding: '12px 13px' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+                  <span style={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: 7 }}>
+                    <span className="av2-mono" style={{ fontSize: 12.5, fontWeight: 600, color: 'var(--accent-text)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', minWidth: 0 }}>/share/{l.slug}</span>
+                    {!active && <Chip tone="warn">Expired</Chip>}
+                  </span>
+                  <button type="button" onClick={() => copy(l.slug)} style={{ flex: 'none', height: 32, padding: '0 12px', background: 'var(--surface-2)', border: 'none', borderRadius: 8, cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 11.5, fontWeight: 700, color: 'var(--ink)' }}>
+                    Copy
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`Delete /share/${l.slug}`}
+                    onClick={() => setConfirmDelete(l)}
+                    style={{ flex: 'none', width: 32, height: 32, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--surface-2)', border: 'none', borderRadius: 8, cursor: 'pointer', color: 'var(--bad)', fontSize: 13, fontWeight: 700, fontFamily: 'var(--font-ui)' }}
+                  >
+                    ✕
+                  </button>
+                </div>
+                <div className="av2-mono" style={{ marginTop: 7, fontSize: 10.5, color: 'var(--ink-2)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }} title={l.targetUrl}>
+                  → {l.targetUrl}
+                </div>
+                <div className="av2-mono" style={{ marginTop: 3, fontSize: 10, color: 'var(--ink-3)' }}>
+                  {fmtNumber(l.clickCount ?? l.clicks ?? 0)} clicks · last click {l.lastClickedAt ? fmtRelative(l.lastClickedAt) : '—'}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="av2-caption" style={{ padding: '12px 4px 0' }}>
+          Expiry: {`links live ${90} days by default`} — expired slugs stop redirecting but keep their click history here.
+        </div>
+
+        {creating && <CreateDialog onClose={() => setCreating(false)} />}
+
+        <AlertDialog open={!!confirmDelete} onOpenChange={(open) => { if (!open) setConfirmDelete(null); }}>
+          <AlertDialogContent className="admin-v2" style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)' }}>
+            <AlertDialogHeader>
+              <AlertDialogTitle style={{ color: 'var(--ink)' }}>Delete /{confirmDelete?.slug}?</AlertDialogTitle>
+              <AlertDialogDescription style={{ color: 'var(--ink-2)' }}>
+                Anything printed or posted with this link will dead-end immediately. Click history is removed with it.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={(e) => { e.preventDefault(); remove.mutate(confirmDelete.id); }}
+                disabled={remove.isPending}
+                style={{ background: 'var(--bad)', color: '#fff' }}
+              >
+                {remove.isPending ? 'Deleting…' : 'Delete'}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/src/pages/adminv2/AdminV2Users.jsx
+++ b/src/pages/adminv2/AdminV2Users.jsx
@@ -10,6 +10,7 @@ import { apiClient } from '@/api/client';
 import { fmtNumber, fmtRelative, fmtDate } from '@/lib/adminV2/format';
 import { Chip, PageHeader, Skeleton, ErrorState, EmptyState, StateRow } from '@/components/adminv2/primitives';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { useAdminV2Mobile } from '@/components/adminv2/mobile/useAdminV2Mobile';
 
 const fetchStaff = async () => {
   const resp = await apiClient.get('/users?role=admin&limit=100');
@@ -40,7 +41,7 @@ function InviteDialog({ onClose }) {
 
   return (
     <Dialog open onOpenChange={(open) => { if (!open && !invite.isPending) onClose(); }}>
-      <DialogContent className="admin-v2" style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)', maxWidth: 440 }}>
+      <DialogContent variant="sheet" className="admin-v2" style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)', maxWidth: 440 }}>
         <DialogHeader>
           <DialogTitle style={{ color: 'var(--ink)', fontFamily: 'var(--font-ui)', fontSize: 15, fontWeight: 800, textAlign: 'left' }}>Invite an admin</DialogTitle>
           <DialogDescription style={{ color: 'var(--ink-2)', fontSize: 11.5, textAlign: 'left' }}>
@@ -69,7 +70,61 @@ function InviteDialog({ onClose }) {
 export default function AdminV2Users() {
   const staff = useQuery({ queryKey: ['adminV2', 'staff'], queryFn: fetchStaff, staleTime: 30_000 });
   const [inviting, setInviting] = useState(false);
+  const mobile = useAdminV2Mobile();
   const rows = staff.data?.rows || [];
+
+  /* ── Mobile (design 1694f8b2 "MKTR Ops Console Mobile"): admin roster cards ── */
+  if (mobile) {
+    const total = staff.data?.total ?? 0;
+    return (
+      <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, paddingBottom: 10 }}>
+          <div className="av2-mono" style={{ flex: 1, minWidth: 0, fontSize: 10, letterSpacing: '.12em', color: 'var(--ink-3)', textTransform: 'uppercase', padding: '2px 2px', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {fmtNumber(total)} back-office admins{total > rows.length && rows.length > 0 ? ` · showing first ${fmtNumber(rows.length)}` : ''}
+          </div>
+          <button type="button" onClick={() => setInviting(true)} style={{ flex: 'none', height: 38, display: 'inline-flex', alignItems: 'center', padding: '0 14px', background: 'var(--accent)', color: 'var(--accent-ink)', border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 12.5, fontWeight: 700 }}>
+            + Invite admin
+          </button>
+        </div>
+
+        {staff.isLoading && (
+          <div style={{ display: 'grid', gap: 8 }}>
+            {[0, 1, 2].map((i) => <Skeleton key={i} height={80} style={{ borderRadius: 14 }} />)}
+          </div>
+        )}
+        {staff.isError && <div className="av2-card"><ErrorState error={staff.error} onRetry={staff.refetch} /></div>}
+        {!staff.isLoading && !staff.isError && rows.length === 0 && (
+          <div className="av2-card"><EmptyState title="No staff users" hint="Invite the first admin to share the console." /></div>
+        )}
+        <div style={{ display: 'grid', gap: 8 }}>
+          {rows.map((u) => {
+            const st = statusOf(u);
+            const name = u.fullName || `${u.firstName || ''} ${u.lastName || ''}`.trim() || u.email;
+            const initials = (name.split(/\s+/).map((x) => x[0]).filter(Boolean).slice(0, 2).join('') || '?').toUpperCase();
+            return (
+              <div key={u.id} className="av2-card" style={{ padding: '11px 13px' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <span aria-hidden="true" style={{ width: 36, height: 36, flex: 'none', borderRadius: '50%', background: 'var(--surface-2)', color: 'var(--ink-2)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, fontWeight: 700 }}>
+                    {initials}
+                  </span>
+                  <span style={{ flex: 1, minWidth: 0 }}>
+                    <span style={{ display: 'block', fontSize: 13.5, fontWeight: 700, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{name}</span>
+                    <span className="av2-mono" style={{ display: 'block', fontSize: 10, color: 'var(--ink-3)', marginTop: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{u.email}</span>
+                  </span>
+                  <span style={{ flex: 'none' }}><Chip tone={st.tone}>{st.label}</Chip></span>
+                </div>
+                <div className="av2-mono" style={{ margin: '8px 0 0 46px', fontSize: 10, color: 'var(--ink-3)' }}>
+                  last active {u.lastLogin ? fmtRelative(u.lastLogin) : st.label === 'Invited' ? 'never' : '—'} · joined {fmtDate(u.createdAt)}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {inviting && <InviteDialog onClose={() => setInviting(false)} />}
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/src/pages/adminv2/AdminV2Wallets.jsx
+++ b/src/pages/adminv2/AdminV2Wallets.jsx
@@ -16,8 +16,11 @@ import { Chip, PageHeader, Skeleton, ErrorState, EmptyState, StateRow } from '@/
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import WalletLedgerList from '@/components/adminv2/WalletLedgerList';
+import { useAdminV2Mobile } from '@/components/adminv2/mobile/useAdminV2Mobile';
+import MobileSheet, { SheetHead } from '@/components/adminv2/mobile/MobileSheet';
+import MoneySegments from '@/components/adminv2/mobile/MoneySegments';
 
-function AdjustDialog({ wallet, onClose }) {
+function AdjustDialog({ wallet, onClose, mobile }) {
   const [amount, setAmount] = useState('');
   const [direction, setDirection] = useState('credit');
   const [note, setNote] = useState('');
@@ -50,20 +53,8 @@ function AdjustDialog({ wallet, onClose }) {
     onError: (e) => toast.error(e?.message || 'Adjustment failed'),
   });
 
-  return (
-    <Dialog open onOpenChange={(open) => { if (!open && !mutation.isPending) onClose(); }}>
-      <DialogContent
-        className="admin-v2"
-        style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)', maxWidth: 440 }}
-        onInteractOutside={(e) => { if (mutation.isPending) e.preventDefault(); }}
-        onEscapeKeyDown={(e) => { if (mutation.isPending) e.preventDefault(); }}
-      >
-        <DialogHeader>
-          <DialogTitle style={{ color: 'var(--ink)', fontFamily: 'var(--font-ui)', fontSize: 15, fontWeight: 800, textAlign: 'left' }}>Manual adjustment</DialogTitle>
-          <DialogDescription style={{ color: 'var(--ink-2)', fontSize: 11.5, textAlign: 'left' }}>
-            {wallet.name} · balance {fmtSGDExact(wallet.walletBalanceCents)} — the exception path. Top-ups happen in the agent app; refunds only via campaign takedown.
-          </DialogDescription>
-        </DialogHeader>
+  const body = (
+    <>
         <div style={{ display: 'flex', gap: 8, marginBottom: 10 }}>
           {[['credit', '+ Credit'], ['debit', '\u2212 Debit']].map(([v, label]) => (
             <button
@@ -104,21 +95,60 @@ function AdjustDialog({ wallet, onClose }) {
           <input className="av2-input" value={note} onChange={(e) => setNote(e.target.value)} placeholder="e.g. duplicate delivery on 2 leads — goodwill credit" />
         </label>
         <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end' }}>
-          <button type="button" className="av2-btn" disabled={mutation.isPending} onClick={onClose}>Cancel</button>
-          <button type="button" className="av2-btn av2-btn--primary" disabled={!valid || mutation.isPending} onClick={() => mutation.mutate()}>
+          <button type="button" className="av2-btn" disabled={mutation.isPending} onClick={onClose} style={mobile ? { flex: 1, justifyContent: 'center' } : undefined}>Cancel</button>
+          <button type="button" className="av2-btn av2-btn--primary" disabled={!valid || mutation.isPending} onClick={() => mutation.mutate()} style={mobile ? { flex: 2, justifyContent: 'center' } : undefined}>
             {mutation.isPending ? 'Applying\u2026' : `Apply ${direction === 'credit' ? '+' : '\u2212'}${amountValid ? fmtSGDExact(cents) : ''}`}
           </button>
         </div>
+    </>
+  );
+
+  if (mobile) {
+    return (
+      <MobileSheet open onClose={() => { if (!mutation.isPending) onClose(); }} label="Manual adjustment">
+        <SheetHead
+          title="Manual adjustment"
+          kicker={`${wallet.name} \u00b7 balance ${fmtSGDExact(wallet.walletBalanceCents)}`}
+        />
+        <div style={{ fontSize: 11.5, color: 'var(--ink-2)', lineHeight: 1.5, paddingBottom: 12 }}>
+          The exception path. Top-ups happen in the agent app; refunds only via campaign takedown.
+        </div>
+        {body}
+      </MobileSheet>
+    );
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open && !mutation.isPending) onClose(); }}>
+      <DialogContent
+        className="admin-v2"
+        style={{ background: 'var(--surface)', color: 'var(--ink)', border: '1px solid var(--line)', maxWidth: 440 }}
+        onInteractOutside={(e) => { if (mutation.isPending) e.preventDefault(); }}
+        onEscapeKeyDown={(e) => { if (mutation.isPending) e.preventDefault(); }}
+      >
+        <DialogHeader>
+          <DialogTitle style={{ color: 'var(--ink)', fontFamily: 'var(--font-ui)', fontSize: 15, fontWeight: 800, textAlign: 'left' }}>Manual adjustment</DialogTitle>
+          <DialogDescription style={{ color: 'var(--ink-2)', fontSize: 11.5, textAlign: 'left' }}>
+            {wallet.name} \u00b7 balance {fmtSGDExact(wallet.walletBalanceCents)} \u2014 the exception path. Top-ups happen in the agent app; refunds only via campaign takedown.
+          </DialogDescription>
+        </DialogHeader>
+        {body}
       </DialogContent>
     </Dialog>
   );
 }
 
-function LedgerDrawer({ wallet, onClose }) {
+function LedgerDrawer({ wallet, onClose, mobile }) {
   if (!wallet) return null;
   return (
     <Sheet open onOpenChange={(open) => { if (!open) onClose(); }}>
-      <SheetContent side="right" className="admin-v2" style={{ width: 432, maxWidth: '90vw', padding: 0, background: 'var(--surface)', color: 'var(--ink)', borderLeft: '1px solid var(--line)', display: 'flex', flexDirection: 'column' }}>
+      <SheetContent
+        side={mobile ? 'bottom' : 'right'}
+        className="admin-v2"
+        style={mobile
+          ? { maxHeight: '84dvh', height: 'auto', padding: 0, background: 'var(--surface)', color: 'var(--ink)', borderTop: '1px solid var(--line)', borderRadius: '18px 18px 0 0', display: 'flex', flexDirection: 'column' }
+          : { width: 432, maxWidth: '90vw', padding: 0, background: 'var(--surface)', color: 'var(--ink)', borderLeft: '1px solid var(--line)', display: 'flex', flexDirection: 'column' }}
+      >
         <SheetHeader style={{ padding: '14px 16px', borderBottom: '1px solid var(--line)' }}>
           <SheetTitle style={{ fontSize: 15, fontWeight: 800, color: 'var(--ink)', fontFamily: 'var(--font-ui)', textAlign: 'left' }}>
             {wallet.name} — ledger
@@ -139,6 +169,7 @@ export default function AdminV2Wallets() {
   const wallets = useWallets();
   const [ledgerFor, setLedgerFor] = useState(null);
   const [adjustFor, setAdjustFor] = useState(null);
+  const mobile = useAdminV2Mobile();
 
   // ?focus=<agentId> deep-link (design contract — the Agents page "Ledger →"
   // lands here with that agent's drawer open). Closing clears the param so
@@ -165,6 +196,82 @@ export default function AdminV2Wallets() {
 
   const floatCents = rows.reduce((s, w) => s + (w.walletBalanceCents || 0), 0);
   const committedCents = rows.reduce((s, w) => s + (w.committedValueCents || 0), 0);
+
+  /* ── Mobile (design 1694f8b2 Money tab): segmented header + wallet cards ── */
+  if (mobile) {
+    return (
+      <div>
+        <div className="av2-mono" style={{ fontSize: 10, letterSpacing: '.12em', color: 'var(--ink-3)', textTransform: 'uppercase', padding: '2px 2px 10px' }}>
+          {fmtNumber(rows.length)} external agents · float {fmtSGD(floatCents)} · committed {fmtSGD(committedCents)}
+        </div>
+        <MoneySegments active="wallets" />
+
+        {wallets.isLoading && (
+          <div style={{ display: 'grid', gap: 8 }}>
+            {[0, 1, 2].map((i) => <Skeleton key={i} height={124} style={{ borderRadius: 14 }} />)}
+          </div>
+        )}
+        {wallets.isError && <div className="av2-card"><ErrorState error={wallets.error} onRetry={wallets.refetch} /></div>}
+        {!wallets.isLoading && !wallets.isError && rows.length === 0 && (
+          <div className="av2-card">
+            <EmptyState
+              title="No external agents yet"
+              hint="Wallets appear when mktr-leads agents are synced. Balances stay S$0 until the wallet goes live and agents top up."
+            />
+          </div>
+        )}
+        <div style={{ display: 'grid', gap: 8 }}>
+          {rows.map((w) => (
+            <div key={w.id} className="av2-card" style={{ padding: '12px 13px' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <span style={{ flex: 1, minWidth: 0 }}>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+                    <span style={{ fontSize: 13, fontWeight: 700, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{w.name}</span>
+                    {w.isActive === false && <Chip tone="warn">Inactive</Chip>}
+                  </span>
+                  <span className="av2-mono" style={{ display: 'block', fontSize: 9.5, color: 'var(--ink-3)', marginTop: 1, textTransform: 'uppercase' }}>
+                    last activity {w.lastActivityAt ? fmtRelative(w.lastActivityAt) : '—'}
+                  </span>
+                </span>
+                <span style={{ flex: 'none', textAlign: 'right' }}>
+                  <span className="av2-mono" style={{ display: 'block', fontSize: 17, fontWeight: 600, letterSpacing: '-0.02em', color: w.walletBalanceCents === 0 ? 'var(--warn)' : 'var(--ink)' }}>
+                    {fmtSGDExact(w.walletBalanceCents)}
+                  </span>
+                  {w.walletBalanceCents === 0 && (
+                    <span style={{ display: 'inline-block', fontSize: 9.5, fontWeight: 700, background: 'var(--warn-soft)', color: 'var(--warn)', borderRadius: 5, padding: '1px 6px', marginTop: 2 }}>Wallet empty</span>
+                  )}
+                </span>
+              </div>
+              <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap', marginTop: 9 }}>
+                {(w.openCommitments || []).length === 0
+                  ? <Chip>No open commitments</Chip>
+                  : (w.openCommitments || []).map((oc) => (
+                    <Chip key={oc.assignmentId} tone="accent">
+                      {oc.campaign || 'campaign'} · {fmtNumber(oc.remaining)} @ {fmtSGD(oc.unitPriceCents)}
+                    </Chip>
+                  ))}
+              </div>
+              <div style={{ display: 'flex', gap: 7, marginTop: 11 }}>
+                <button type="button" onClick={() => setLedgerFor(w)} style={{ flex: 1, height: 38, background: 'var(--surface-2)', border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 12, fontWeight: 700, color: 'var(--ink)' }}>
+                  Ledger
+                </button>
+                <button type="button" onClick={() => setAdjustFor(w)} style={{ flex: 1, height: 38, background: 'var(--accent-soft)', border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 12, fontWeight: 700, color: 'var(--accent-text)' }}>
+                  Adjust
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="av2-caption" style={{ padding: '14px 4px 0', lineHeight: 1.5 }}>
+          Top-ups happen in the agents’ own app and are non-refundable to cash; the only automatic refund is a campaign takedown returning undelivered commitments as credits.
+        </div>
+
+        <LedgerDrawer wallet={ledgerFor || focusWallet} onClose={() => { setLedgerFor(null); clearFocus(); }} mobile />
+        {adjustFor && <AdjustDialog wallet={adjustFor} onClose={() => setAdjustFor(null)} mobile />}
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -88,6 +88,8 @@ const AdminV2QRCodes = lazy(() => import('./adminv2/AdminV2QRCodes'));
 const AdminV2ShortLinks = lazy(() => import('./adminv2/AdminV2ShortLinks'));
 const AdminV2Users = lazy(() => import('./adminv2/AdminV2Users'));
 const AdminV2AISettings = lazy(() => import('./adminv2/AdminV2AISettings'));
+// Mobile hub tab — the sidebar long-tail lives here on phones (v2-only route).
+const AdminV2More = lazy(() => import('./adminv2/AdminV2More'));
 const AdminCampaigns = lazy(() => import('./AdminCampaigns'));
 const AdminCampaignForm = lazy(() => import('./AdminCampaignForm'));
 const AdminQRCodes = lazy(() => import('./AdminQRCodes'));
@@ -374,6 +376,17 @@ function PagesContent() {
  <ProtectedRoute requiredRole="admin">
  <AdminV2Shell>
  <AdminV2People />
+ </AdminV2Shell>
+ </ProtectedRoute>
+ }
+ />
+ )}
+ {ADMIN_V2 && (
+ <Route
+ path="/admin/more" element={
+ <ProtectedRoute requiredRole="admin">
+ <AdminV2Shell>
+ <AdminV2More />
  </AdminV2Shell>
  </ProtectedRoute>
  }

--- a/src/styles/adminV2.css
+++ b/src/styles/adminV2.css
@@ -306,6 +306,51 @@ body[data-theme='dark'] .admin-v2 {
   --ring: 232.6 100% 71.4%;
 }
 
+/* ── Mobile layer (≤767px) — design source 1694f8b2 "MKTR Ops Console Mobile" ──
+   The shell + pages branch in JS on useAdminV2Mobile(); this block only holds
+   what CSS must own: keyframes, the 12-col grid collapse, and a safety net
+   that keeps any not-yet-converted fake-table swipeable instead of clipped. */
+@keyframes av2m-sheet-in {
+  from { transform: translateY(100%); }
+  to { transform: translateY(0); }
+}
+@keyframes av2m-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@keyframes av2m-slide-up {
+  from { transform: translateY(14px); opacity: 0; }
+  to { transform: none; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .av2m-sheet, .av2m-selectbar { animation: none !important; }
+}
+
+@media (max-width: 767px) {
+  /* Desktop 12-col grids (dashboard, detail pages) stack to one column.
+     !important because the span lives in each child's inline style. */
+  .admin-v2 .av2-grid12 > * { grid-column: span 12 / span 12 !important; }
+
+  /* Fake-tables not yet given a mobile card layout: let the card scroll
+     sideways so the rightmost columns stay reachable (cards ship
+     overflow:hidden; rows would otherwise clip silently). */
+  .admin-v2 .av2-card:has(.av2-thead) { overflow-x: auto !important; }
+  .admin-v2 .av2-card:has(.av2-thead) .av2-thead,
+  .admin-v2 .av2-card:has(.av2-thead) .av2-row { min-width: max-content; }
+
+  /* Desktop floating bulk bar, if reached on mobile: full-width above the
+     tab bar instead of centre-floating off both edges. */
+  .admin-v2 .av2-bulkbar {
+    left: 10px; right: 10px; transform: none;
+    bottom: calc(70px + env(safe-area-inset-bottom, 0px));
+    flex-wrap: wrap; max-width: none;
+  }
+
+  /* Page headers tighten up on a phone. */
+  .admin-v2 .av2-h1 { font-size: 19px; }
+  .admin-v2 .av2-kpi { font-size: 34px; }
+}
+
 /* The design-editor PREVIEW renders the real customer page inline (no iframe —
    Radix portals must reach the top document). It must show the CUSTOMER look,
    never admin chrome: restore the app's original tokens + font. Safe outside


### PR DESCRIPTION
## What this is

The v2 admin ("Switchboard") was desktop-only by construction — fixed 228px sidebar, pixel-width fake-table columns that clip off-screen, 12-column grids with no breakpoint, and pinch-zoom disabled. This PR implements the **claude.ai/design project 1694f8b2 "MKTR Ops Console Mobile"**: at ≤767px the same routes render a phone-native console; at ≥768px every screen is byte-identical to before.

## Mobile chrome

- **Bottom tab bar** — Home / Leads / Campaigns / Money / More, Switchboard geometric glyphs (■●▲◆⋯), safe-area aware. Money covers Wallets+Agents (segmented cross-link on both pages); everything reached from More keeps the More tab lit.
- **Top bar** — back-or-M-tile · route title · search · bell · avatar→More. SGT clock + theme toggle move to **/admin/more** (new v2-only route) with the sidebar long-tail (People, Cohorts, Email Pushes, Agent Groups, QR, Short Links, Users, AI Settings) and the account block.
- **⌘K palette and attention bell** become full-screen takeovers on phones.

## Per-screen

All 17 v2 pages branch on `useAdminV2Mobile()` (initialised synchronously — no desktop flash). Same queries, mutations and URL params as desktop throughout:

- **Dashboard** — tap-to-refresh meta line, 2+3 health tiles, attention card, KPI + sparkline + compact funnel, two-line recent-lead rows.
- **Prospects** — card list; **filters bottom sheet** (status/source pills, held/unassigned toggles, sort) applied to the URL in one patch; **long-press select mode** with an ink action bar (Assign via searchable agent sheet · Return · CSV · Delete with confirm sheet); Prev/Next paging.
- **Lead Profile** — compact identity row; sticky bottom **Assign/Reassign** bar + ⋯ overflow sheet; the two-step campaign→agent picker renders as sheets.
- **Campaigns** — card board with signal chips, select-mode bulk bar (same eligibility rules + ConfirmDialog), "+ New" keeps the type picker then shows a **design-opens-on-desktop handoff** (copy link / open anyway).
- **Campaign detail / Cohort detail / Broadcast detail / AI Settings** — single-column stacks (`av2-grid12`), 2×2 tile strips, ⋯ action sheets.
- **Wallets & Agents** — money-first cards; ledger + agent drawers become bottom sheets; the manual Adjust dialog becomes a bottom sheet (same validation, idempotency and overdraft guard).
- **People / QR / Short Links / Users / Cohorts / Email Pushes / Agent Groups** — card lists; create/invite dialogs use the responsive `variant="sheet"` (bottom sheet <640px, unchanged centered card on desktop).
- Safety net: any not-yet-converted fake-table becomes horizontally swipeable on phones instead of clipping (CSS-only, `:has(.av2-thead)`).

## Verification

- `eslint src/` clean · **vitest: 164 files / 2,119 tests green** (`useAdminV2Mobile` treats jsdom's missing `matchMedia` as desktop, so the existing suites keep testing the layout they were written against).
- Playwright at **390×844** against a stubbed API: all 16 screens screenshot in **light + dark**, zero horizontal overflow, and the filter sheet / select mode / search / notifications takeovers driven end-to-end.
- **1440px desktop** screenshots (Dashboard, Prospects, Campaigns, Wallets): unchanged chrome and layout.

## Notes / deliberate scope cuts

- Campaign Studio / workspace editors stay desktop surfaces — mobile hands off with a link (per the design).
- Prospects keeps server-side Prev/Next on mobile (the design sketched load-more; paging preserves shareable `?page=` URLs).
- Pull-to-refresh not implemented (the updated-line is the refresh control); can follow up if wanted.
- No flag needed: pure responsive branch behind the existing `VITE_ADMIN_V2_ENABLED` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wRsA9xm9DfSvno6ecYk9p