### PR TITLE
feat(admin): logo icon replaces the M tile on mobile roots

### DIFF
--- a/src/components/adminv2/AdminV2Shell.jsx
+++ b/src/components/adminv2/AdminV2Shell.jsx
@@ -19,6 +19,7 @@ import { NAV } from '@/lib/adminV2/nav';
 import GlobalSearch from './GlobalSearch';
 import NotificationsBell from './NotificationsBell';
 import MktrWordmark from '@/components/brand/MktrWordmark';
+import MktrMark from '@/components/brand/MktrMark';
 import MobileTabBar from './mobile/MobileTabBar';
 import { AdminV2ShellContext } from './mobile/shellContext';
 import { useAdminV2Mobile } from './mobile/useAdminV2Mobile';
@@ -153,11 +154,12 @@ export default function AdminV2Shell({ children, fullBleed = false, legacyBridge
             }}
           >
             {info.root ? (
-              // The brand root draws the wordmark as its title — an M tile
-              // beside it would say the same thing twice.
+              // The brand root draws the wordmark as its title — a logo tile
+              // beside it would say the brand twice. Other roots lead with the
+              // app-icon mark as the home button.
               info.brand ? null : (
                 <Link to="/AdminDashboard" aria-label="Dashboard" style={{ display: 'flex', flex: 'none' }}>
-                  <span style={{ width: 32, height: 32, background: 'var(--accent)', color: 'var(--accent-ink)', borderRadius: 9, display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 800, fontSize: 15 }}>M</span>
+                  <MktrMark size={32} />
                 </Link>
               )
             ) : (

--- a/src/components/brand/MktrMark.jsx
+++ b/src/components/brand/MktrMark.jsx
@@ -1,0 +1,26 @@
+/**
+ * The MKTR brand mark — the square app icon (terracotta chevron on the
+ * warm-dark tile), mirroring public/mktr-logo-icon.svg. Fixed palette by
+ * design: this is the logo, so it does not follow theme vars. The chevron
+ * is a drawn path (no font dependency), so it renders identically at any
+ * size on any surface.
+ *
+ * Decorative by default (aria-hidden) — place it inside a labelled link or
+ * pass aria props via rest when it stands alone.
+ */
+const MktrMark = ({ size = 32, style, ...rest }) => (
+  <svg
+    viewBox="0 0 64 64"
+    width={size}
+    height={size}
+    style={{ display: 'block', flex: 'none', ...style }}
+    aria-hidden="true"
+    focusable="false"
+    {...rest}
+  >
+    <rect width="64" height="64" rx="12" fill="#1B1A17" />
+    <path d="M 20 18 L 44 32 L 20 46" fill="none" stroke="#D6552B" strokeWidth="6" strokeLinecap="square" strokeLinejoin="miter" />
+  </svg>
+);
+
+export default MktrMark;


### PR DESCRIPTION
Second half of the #340 brand cleanup — the commit was pushed two minutes after #340 was squash-merged, so it missed the train (same race as #339). Cherry-picked onto main.

New `MktrMark` brand component: the square app icon (terracotta chevron on the warm-dark tile), drawn as an inline vector path mirroring `public/mktr-logo-icon.svg`, fixed logo palette by design. The mobile home button on non-brand roots (Leads / Campaigns / Money / More) renders it instead of the letter-M accent tile; the dashboard root stays tile-less since its title is already the wordmark.

Verified with Playwright screenshots (mobile Leads light + dark, dashboard + desktop unchanged); CI for this exact tree ran green on #340's branch (run 30707213736 covered d6939b7; this commit adds the icon component + one JSX swap, lint clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wRsA9xm9DfSvno6ecYk9p