### PR TITLE
chore(redeem-ops): resolve the four uncalled endpoints — keep all, wire inventory reconcile (P2-11)

### DIFF
--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -362,6 +362,21 @@ export async function bootstrapDatabase() {
             // active draw rails under 20% remaining get another default block.
             const { topUpDrawBoostAllocations } = await import('../services/redeemOps/drawBoostProvisioningService.js');
             await topUpDrawBoostAllocations();
+            // Inventory ledger ⇄ counter reconciliation (P2-11): a pure
+            // detector — logs drift loudly, never mutates (self-healing would
+            // hide the bug that caused it). This is the sweep that would have
+            // caught the redemption-reverse counter asymmetry.
+            const { default: inventory } = await import('../services/redeemOps/inventoryService.js');
+            const { RewardOffer } = await import('../models/index.js');
+            const offers = await RewardOffer.findAll({ attributes: ['id', 'title'] });
+            for (const offer of offers) {
+              const { consistent, derived, actual } = await inventory.reconcile(offer.id);
+              if (!consistent) {
+                logger.warn('[RedeemOps] inventory ledger/counter drift detected', {
+                  offerId: offer.id, offerTitle: offer.title, derived, actual,
+                });
+              }
+            }
           } catch (err) {
             logger.warn('[RedeemOps] fulfilment sweep failed (non-fatal)', { error: err?.message });
           }

--- a/backend/src/services/redeemOps/inventoryService.js
+++ b/backend/src/services/redeemOps/inventoryService.js
@@ -180,7 +180,8 @@ export function makeInventoryService(overrides = {}) {
     });
   }
 
-  /** Ledger ⇄ counter reconciliation (test-time assertion; future cron). */
+  /** Ledger ⇄ counter reconciliation — asserted in tests and swept every
+   *  15 min by the fulfilment sweep (bootstrap.js), which logs any drift. */
   async function reconcile(offerId) {
     const offer = await d.RewardOffer.findByPk(offerId);
     if (!offer) throw new AppError('Reward offer not found', 404);

--- a/docs/redeem-ops/ROUTE_MAP.md
+++ b/docs/redeem-ops/ROUTE_MAP.md
@@ -24,7 +24,7 @@
 | POST `/partners/:id/merge` | partners.merge | `{ duplicateId, reason }` — re-points children, audits. |
 | GET `/partners/:id/timeline` | partners.view | Activities + stage events + assignment events, chronological, paginated (lazy-load). |
 | POST `/partners/:id/activities` | activities.log | Log outreach activity (type/direction/summary/outcome/occurredAt/contactId). |
-| PATCH `/activities/:id` | activities.edit (own) | Correction (audited before/after); DELETE not exposed — `POST /activities/:id/void`. |
+| PATCH `/activities/:id` | activities.edit (own) | Correction (audited before/after); DELETE not exposed — `POST /activities/:id/void`. **API-only today: no SPA edit/void affordance yet** (P2-11 keep — designed correction path, UI never landed). |
 | GET/POST `/partners/:id/contacts`, PATCH/`archive` `/contacts/:id` | contacts.manage | |
 | GET/POST `/partners/:id/locations`, PATCH `/locations/:id` | locations.manage | |
 | GET/PATCH `/partners/:id/onboarding` | onboarding.manage | Checklist read/update (Phase 4). |
@@ -48,7 +48,7 @@
 | GET `/tasks` | tasks.manage (own scope) | Filters: assignee (bdm+ may query others), status, due window (`today|overdue|upcoming`), partner. |
 | POST `/tasks` | tasks.manage | Create (title, partnerId, contactId?, assignee, dueAt, priority, type). |
 | PATCH `/tasks/:id` | tasks.manage (own/team) | Edit / status transitions; completion stamps completedAt/By. |
-| GET `/pools` · POST `/pools` · PATCH `/pools/:id` | pools.manage (GET: claim_next) | Pool CRUD. |
+| GET `/pools` · POST `/pools` · PATCH `/pools/:id` | pools.manage (GET: claim_next) | Pool CRUD. **PATCH is API-only today: the SPA has no rename/retire affordance yet** (P2-11 keep). |
 | POST `/pools/:id/members` | pools.manage | Add partners (bulk ids). |
 | POST `/pools/:id/claim-next` | pools.claim_next | **SKIP LOCKED** next eligible prospect → atomic claim; `204` when pool exhausted. |
 | GET `/team/pipeline` | pipeline.view_team | Manager board: stage × owner counts + drill-down list. |
@@ -80,7 +80,7 @@
 | Method & path | Capability |
 |---|---|
 | GET `/entitlements` (filters: activation, status, expiring) | entitlements.view |
-| POST `/entitlements` (manual issue `{activationId, prospectId}`) | entitlements.issue_manual |
+| POST `/entitlements` (manual issue `{activationId, prospectId}`) — **API-only today: RedemptionsPage checks the capability but the issuance form never landed** (P2-11 keep) | entitlements.issue_manual |
 | PATCH `/entitlements/:id/cancel` | entitlements.issue_manual |
 | POST `/redemptions/verify` (`{token}` → entitlement summary + validity; idempotent) | redemptions.verify |
 | POST `/redemptions/complete` (`{token, locationId?, method}` → atomic issued→redeemed) | redemptions.verify |


### PR DESCRIPTION
## .review P2-11 — Resolve uncalled Redeem Ops endpoints

The task asked for a judgment call per endpoint rather than reflexive deletion. Fresh greps confirm zero SPA callers for all four; `git log -S` over `src/` shows **no UI ever existed** — these were API-first builds whose UI never landed.

### The reasoning, per endpoint (all four KEPT)
| Endpoint | Verdict | Why |
|---|---|---|
| `POST /redeem-ops/entitlements` (issueManual) | **Keep — missing feature** | RedemptionsPage already computes `entitlements.issue_manual` and gates share/unlock with it; ROUTE_MAP documents manual issue `{activationId, prospectId}`. The intent shipped everywhere except the form. |
| `PATCH /redeem-ops/activities/:id` | **Keep — missing feature** | ROUTE_MAP specifies the audited correction design: "Correction (audited before/after); DELETE not exposed — void instead". The SPA renders activities read-only; ops staff have no correction door yet. |
| `POST /redeem-ops/activities/:id/void` | **Keep** | Sibling of the above — the deliberate void-not-delete design. |
| `PATCH /redeem-ops/pools/:poolId` | **Keep** | ROUTE_MAP documents pool CRUD; without PATCH a typo'd pool name or pool retirement (`isActive`) has no UI path. |

Each row in `docs/redeem-ops/ROUTE_MAP.md` is now annotated **API-only today** with the P2-11 keep note, so the missing UIs are discoverable intent rather than silent drift.

### The concrete build: inventory reconcile in the fulfilment sweep
`inventoryService.reconcile()` was documented "test-time assertion; future cron" with a single test caller. It now runs inside the existing 15-minute fulfilment sweep (`bootstrap.js`) as a **pure drift detector** — it logs ledger⇄counter mismatches per offer and never mutates (self-healing counters would hide the bug that caused the drift). This is the sweep that would have caught the redemption-reverse inventory asymmetry the audit found.

Verified by executing the exact sweep loop against the test DB: 4 offers reconciled, 0 drift — a run that also caught a wiring bug before it shipped (`reward_offers` has `title`, not `name`; the crash would have degraded the whole sweep to its catch block every 15 minutes).

### Verification
- Backend eslint clean; redeemOps Rewards/Fulfilment/FulfilmentDelivery/Work/Partners suites green (99 tests).
- No frontend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y83Mpgkub5nZSD5UBNZM6V