### PR TITLE
chore(lint): arm no-undef for the whole backend (P3-5)

### DIFF
--- a/backend/test/config.test.js
+++ b/backend/test/config.test.js
@@ -2,11 +2,10 @@ import './setup.js'
 import { getApp, closeDb, createTestUser } from './helpers.js'
 import { Campaign, Prospect, QrTag } from '../src/models/index.js'
 
-let _app
 let adminUser
 
 beforeAll(async () => {
-  app = await getApp()
+  await getApp() // boot the app (models + DB) — nothing here hits HTTP routes
   const admin = await createTestUser({ role: 'admin' })
   adminUser = admin.user
 })

--- a/backend/test/redeemOpsPlaceCategories.test.js
+++ b/backend/test/redeemOpsPlaceCategories.test.js
@@ -1,4 +1,3 @@
-import { jest } from '@jest/globals';
 import {
   canonicalPlaceCategory,
   resolvePlaceCategoryWords,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,13 +47,14 @@ export default [
       ],
     },
   },
-  // Node environment for config and scripts
+  // Node environment for config and scripts. globals.node supplies
+  // __dirname/require/module/process — no-undef stays ON so a typo'd
+  // identifier anywhere in the backend fails lint (P3-5).
   {
     files: [
       'vite.config.js',
       'tailwind.config.js',
       '**/*.config.js',
-      'test-login.js',
       'backend/**/*.{js,jsx}',
     ],
     languageOptions: {
@@ -63,12 +64,8 @@ export default [
         Buffer: 'readonly',
       },
     },
-    rules: {
-      // Config files often use Node globals like __dirname/require/module
-      'no-undef': 'off',
-    },
   },
-  // Jest globals for backend tests
+  // Jest globals for backend tests (no-undef stays ON here too)
   {
     files: ['backend/**/*.test.js', 'backend/test/**/*.js'],
     languageOptions: {
@@ -76,9 +73,6 @@ export default [
         ...globals.jest,
         ...globals.node,
       },
-    },
-    rules: {
-      'no-undef': 'off',
     },
   },
   // UI primitives often use custom attributes from third-party libs


### PR DESCRIPTION
## .review P3-5 — Backend lint cannot catch undefined variables

Both `'no-undef': 'off'` blocks are removed from `eslint.config.js` — the shortcut wasn't even needed: `globals.node` (and `globals.jest` for tests) were **already configured** in those very blocks. Also removed the stale `test-login.js` files entry.

### What arming the rule surfaced
- **A real bug of exactly the class the rule exists for**: `test/config.test.js` declared `let _app` (renamed from `app` at some point to appease unused-vars) while `beforeAll` still assigned to the undeclared `app`. The variable is write-only, so the fix is `await getApp()` with no variable at all.
- One unused `jest` import.
- **`backend/src`: zero findings** — after the P2 teardown the production tree is genuinely clean under `no-undef`.

The error count was 2, so the "unmanageable count" escape hatch was not needed. No inline `eslint-disable`s added — the 17-occurrence baseline stands.

Out of scope, reported: `backend/scripts/` + `load/` carry 25 pre-existing `no-empty`-class errors (not `no-undef`); those dirs sit outside the CI lint patterns.

### Verification
- `npx eslint src/ test/ --quiet` clean in backend with the rule armed; frontend lint unchanged-clean.
- Both touched suites green (36 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y83Mpgkub5nZSD5UBNZM6V