### PR TITLE
ci(coverage): real ratchet thresholds — the grep gate enforced nothing (P3-6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,11 @@ jobs:
         run: cd backend && npm test -- --testPathPattern="test/migrations"
 
       - name: Check coverage
-        run: cd backend && npm test -- --coverage --testPathPattern="test/(unit/|integration/)" 2>&1 | tee /tmp/coverage.txt; grep "All files" /tmp/coverage.txt
+        # jest.config.js coverageThreshold is the gate — jest exits non-zero
+        # when global coverage drops below the ratchet. (The old
+        # `| tee; grep "All files"` passed whenever ANY table was printed and
+        # the pipe masked jest's exit code — it enforced nothing.)
+        run: cd backend && npm test -- --coverage --testPathPattern="test/(unit/|integration/)"
 
   frontend-test:
     name: Frontend Tests

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -31,4 +31,16 @@ export default {
     '!src/database/seed/**',
   ],
   coverageReporters: ['text', 'text-summary', 'lcov'],
+  // Ratchet, not aspiration (P3-6): measured 2026-08-02 on the CI coverage
+  // pattern test/(unit/|integration/) at 50.78/42.13/43.87/53.06 — set ~1.5
+  // points under so coverage can never silently halve while CI stays green.
+  // Raise as real coverage rises; never lower to make a red build pass.
+  coverageThreshold: {
+    global: {
+      statements: 49,
+      branches: 41,
+      functions: 42,
+      lines: 51,
+    },
+  },
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -119,6 +119,15 @@ export default defineConfig(({ mode: _mode }) => ({
       reporter: ['text', 'text-summary', 'lcov'],
       include: ['src/**/*.{js,jsx}'],
       exclude: ['src/test/**', 'src/components/ui/**', 'src/dev/**'],
+      // Ratchet, not aspiration (P3-6): measured 2026-08-02 at 49.4/47.6/39.7/51.5
+      // — set ~1.5 points under so coverage can never silently halve. Raise as
+      // real coverage rises; never lower to make a red build pass.
+      thresholds: {
+        statements: 48,
+        branches: 46,
+        functions: 38,
+        lines: 50,
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
## .review P3-6 — CI coverage gate enforces nothing

The old step: `npm test -- --coverage … | tee /tmp/coverage.txt; grep "All files" /tmp/coverage.txt` — passes whenever a table was printed, and the unguarded pipe masks jest's exit code. Coverage could halve with CI green.

### Measured first, then ratcheted (numbers, as the task asked)
| Tree | Statements | Branches | Functions | Lines | Ratchet set |
|---|---|---|---|---|---|
| Backend (CI pattern `test/(unit/\|integration/)`, 135 suites green) | 50.78% | 42.13% | 43.87% | 53.06% | **49 / 41 / 42 / 51** |
| Frontend (full vitest suite) | 49.44% | 47.61% | 39.71% | 51.46% | **48 / 46 / 38 / 50** |

Ratchets sit ~1.5 points **under** today's reality — a floor against silent regression, not an aspiration the suite can't meet.

### Changes
- `backend/jest.config.js`: `coverageThreshold.global` added; the CI "Check coverage" step becomes a plain run so **jest's own exit code is the gate** (tee/grep gone).
- **Frontend verdict: worth gating now**, not "not yet" — its CI step *already* runs `vitest run --coverage`, so a `coverage.thresholds` block in `vite.config.js` enforces with zero extra CI runtime. The 0.3:1 test ratio argues for more tests, but a ratchet's job is preventing regression at any level.

### Fail-verification (both mechanisms observed failing)
- Backend at statements:99 → `Jest: "global" coverage threshold for statements (99%) not met: 0.19%` (non-zero exit).
- Frontend at statements:99 → `ERROR: Coverage for statements (0.26%) does not meet global threshold (99%)`.
- Both configs then restored to the ratchet values; **this PR's own CI run is the pass-proof.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y83Mpgkub5nZSD5UBNZM6V