### PR TITLE
refactor(rules): centralise seven duplicated business rules (P4-1)

### DIFF
--- a/backend/src/controllers/lyfeUsersWebhookController.js
+++ b/backend/src/controllers/lyfeUsersWebhookController.js
@@ -52,6 +52,7 @@ import User from '../models/User.js';
 import { logger } from '../utils/logger.js';
 import { adapterRegistry } from '../integrations/AdapterRegistry.js';
 import { recordSyncRun } from '../services/syncHealth.js';
+import { phoneDigits } from '../services/prospectHelpers.js';
 import '../integrations/index.js';
 
 const ASSIGNABLE_ROLES = new Set(['agent', 'manager', 'director']);
@@ -88,7 +89,7 @@ async function applyUpsert(adapter, lyfeUser) {
   const fullName = lyfeUser.full_name || null;
   const externalRole = lyfeUser.role || null;
   const email = lyfeUser.email || null;
-  const phone = lyfeUser.phone ? String(lyfeUser.phone).replace(/\D/g, '') : null;
+  const phone = lyfeUser.phone ? phoneDigits(lyfeUser.phone) : null;
   const isActive = lyfeUser.is_active !== false;
 
   const existing = await User.findOne({ where: { [localIdField]: externalId } });

--- a/backend/src/models/Campaign.js
+++ b/backend/src/models/Campaign.js
@@ -1,5 +1,6 @@
 import { DataTypes, Op } from 'sequelize';
 import { sequelize } from '../database/connection.js';
+import { SLUG_RE } from '../utils/slug.js';
 
 const Campaign = sequelize.define('Campaign', {
   id: {
@@ -212,7 +213,7 @@ const Campaign = sequelize.define('Campaign', {
   slug: {
     type: DataTypes.STRING(80),
     allowNull: true,
-    validate: { is: /^[a-z0-9-]{3,80}$/ },
+    validate: { is: SLUG_RE },
     comment: 'Marketplace URL handle (/offers/:slug, /flow/:slug only). Immutable once firstActivatedAt is set.'
   },
   firstActivatedAt: {

--- a/backend/src/routes/redeemOpsAnalytics.js
+++ b/backend/src/routes/redeemOpsAnalytics.js
@@ -2,6 +2,7 @@ import express from 'express';
 import { asyncHandler } from '../middleware/errorHandler.js';
 import { requireRedeemOps } from '../middleware/redeemOpsAuth.js';
 import analyticsService from '../services/redeemOps/analyticsService.js';
+import { TEAM_ANALYTICS_SUB_ROLES } from '../services/redeemOps/permissions.js';
 
 /**
  * Redeem Ops Phase 7 — analytics (docs/redeem-ops/ROUTE_MAP.md, brief §29).
@@ -18,7 +19,7 @@ const router = express.Router();
 
 router.get('/analytics/outreach', requireRedeemOps('analytics.view_own'), asyncHandler(async (req, res) => {
   const teamWide = req.user.role === 'admin'
-    || ['super_admin', 'ops_admin', 'bdm', 'campaign_ops', 'redemption_ops', 'analyst'].includes(req.user.redeemOpsRole);
+    || TEAM_ANALYTICS_SUB_ROLES.includes(req.user.redeemOpsRole);
   const ownerUserId = req.query.scope === 'me' || !teamWide ? req.user.id : null;
   const members = await analyticsService.outreachPerformance({ ownerUserId });
   res.json({ success: true, data: { members } });

--- a/backend/src/services/agentSyncService.js
+++ b/backend/src/services/agentSyncService.js
@@ -24,6 +24,7 @@ import { sequelize } from '../database/connection.js';
 import { logger } from '../utils/logger.js';
 import { adapterRegistry } from '../integrations/AdapterRegistry.js';
 import { recordSyncRun } from './syncHealth.js';
+import { phoneDigits } from './prospectHelpers.js';
 // Side-effect import: triggers LyfeAdapter self-registration. Without this
 // the registry is empty at first call and `adapterRegistry.get('lyfe')` throws.
 import '../integrations/index.js';
@@ -342,7 +343,7 @@ async function runSync(adapter, localIdField, startedAt) {
       continue;
     }
 
-    const normalizedPhone = ea.phone ? String(ea.phone).replace(/\D/g, '') : null;
+    const normalizedPhone = ea.phone ? phoneDigits(ea.phone) : null;
     const externalIdMatch = ea.externalId ? byExternalId.get(String(ea.externalId)) : null;
     const phoneEmailMatch =
       (normalizedPhone ? byPhone.get(normalizedPhone) : null) ||

--- a/backend/src/services/campaignCopyAiService.js
+++ b/backend/src/services/campaignCopyAiService.js
@@ -4,6 +4,7 @@ import { logger } from '../utils/logger.js';
 import { getRuntimeAiSettings } from './aiSettingsService.js';
 import { requestStructuredJson } from './guidedReviewAiService.js';
 import { withOrgStyle } from './redeemOps/aiSuggestShared.js';
+import { SLUG_RE } from '../utils/slug.js';
 import {
   LIMITS,
   TEMPLATE_IDS,
@@ -191,7 +192,6 @@ export const REC_TOPICS = [
 ];
 const REC_TOPIC_IDS = REC_TOPICS.map((t) => t.topic);
 const REC_LABELS = Object.fromEntries(REC_TOPICS.map((t) => [t.topic, t.label]));
-const SLUG_RE = /^[a-z0-9-]{3,80}$/;
 
 // ─────────────────────────── campaign context ───────────────────────────
 

--- a/backend/src/services/campaignDetailsAiService.js
+++ b/backend/src/services/campaignDetailsAiService.js
@@ -3,6 +3,7 @@ import { logger } from '../utils/logger.js';
 import { getRuntimeAiSettings } from './aiSettingsService.js';
 import { requestStructuredJson } from './guidedReviewAiService.js';
 import { withOrgStyle } from './redeemOps/aiSuggestShared.js';
+import { cleanYmd } from '../utils/sgtTime.js';
 
 /**
  * "Fill it for me" for the new-campaign Details form (workspace create flow):
@@ -16,17 +17,6 @@ import { withOrgStyle } from './redeemOps/aiSuggestShared.js';
  * canonical shape), the entry close, boost deadline, and multiplier.
  */
 
-const YMD_RE = /^\d{4}-\d{2}-\d{2}$/;
-
-/** Strict calendar YMD (2026-02-31 must not roll over) — luckyDraw.js rule. */
-function cleanYmd(v) {
-  if (typeof v !== 'string') return undefined;
-  const s = v.trim();
-  if (!YMD_RE.test(s)) return undefined;
-  const [y, m, d] = s.split('-').map(Number);
-  const dt = new Date(Date.UTC(y, m - 1, d));
-  return dt.getUTCFullYear() === y && dt.getUTCMonth() === m - 1 && dt.getUTCDate() === d ? s : undefined;
-}
 
 function cleanInt(v, min, max) {
   const n = Number(v);

--- a/backend/src/services/campaignService.js
+++ b/backend/src/services/campaignService.js
@@ -8,7 +8,7 @@ import { logger } from '../utils/logger.js';
 import { normalizeCustomerHostChoice } from '../utils/customerHost.js';
 import { sgtDayEndExclusiveMs } from '../utils/sgtTime.js';
 import { applyFeaturedDropPolicy } from '../utils/featuredDrop.js';
-import { applyLuckyDrawPolicy, normalizeLuckyDraw, totalPrizeQuantity } from '../utils/luckyDraw.js';
+import { applyLuckyDrawPolicy, normalizeLuckyDraw, assertSingleWinnerDraw } from '../utils/luckyDraw.js';
 import { PASS_THEMES } from '../utils/drawTheme.js';
 import { normalizeMarketplaceContent, applyMarketplacePolicy } from '../utils/marketplaceContent.js';
 import { normalizeBrief, deriveArchetype, hasBrief } from '../utils/campaignBrief.js';
@@ -474,15 +474,7 @@ export async function getCampaign(id, req) {
 export function assertDrawActivatable(designConfig) {
   const ld = normalizeLuckyDraw(getStoredLuckyDraw(designConfig));
   if (!ld || ld.enabled !== true) return;
-  const total = totalPrizeQuantity(ld);
-  if (total > 1) {
-    const err = new AppError(
-      `This draw promises ${total} prizes, but multi-winner draw execution isn't live yet — the campaign can stay a draft (or paused) but cannot be active.`,
-      422
-    );
-    err.data = { code: 'DRAW_MULTI_PRIZE_UNSUPPORTED' };
-    throw err;
-  }
+  assertSingleWinnerDraw(ld, { suffix: ' — the campaign can stay a draft (or paused) but cannot be active.' });
 }
 
 /**

--- a/backend/src/services/campaignService.js
+++ b/backend/src/services/campaignService.js
@@ -14,6 +14,7 @@ import { normalizeMarketplaceContent, applyMarketplacePolicy } from '../utils/ma
 import { normalizeBrief, deriveArchetype, hasBrief } from '../utils/campaignBrief.js';
 import { buildDrawTermsHtml } from '../utils/drawTermsTemplate.js';
 import { checkDrawConsistency } from '../utils/drawConsistency.js';
+import { SLUG_RE } from '../utils/slug.js';
 import {
   classifyDesignConfigVersion,
   clampDesignConfigV2,
@@ -100,7 +101,6 @@ const drawFactsOf = (doc) => {
   return JSON.stringify([ld.enabled, ld.prize, ld.prizes, ld.closesAt, ld.boostClosesAt, ld.multiplier]);
 };
 
-const SLUG_RE = /^[a-z0-9-]{3,80}$/;
 
 /**
  * Strip HTML tags from a user-supplied campaign name. The name is interpolated

--- a/backend/src/services/consumerService.js
+++ b/backend/src/services/consumerService.js
@@ -4,7 +4,7 @@ import { sequelize, Consumer, Prospect, RewardEntitlement, DrawEntry } from '../
 import { logger } from '../utils/logger.js';
 import { escapeLike } from '../utils/escapeLike.js';
 import { emailNormKey } from './repeatSignup.js';
-import { normalizePhone } from './prospectHelpers.js';
+import { normalizePhone, phoneDigits } from './prospectHelpers.js';
 // Enrichment input bumps on relink (consumer-profile-enrichment plan §6.3,
 // Codex R4-era #2): a moved prospect changes BOTH people's resolved facts.
 // Leaf import (models only) — no cycle.
@@ -629,7 +629,7 @@ export function makeConsumerService(overrides = {}) {
     const orderBy = SORTS[sort] || SORTS['-lastSeenAt'];
 
     const like = escapeLike(q);
-    const digits = String(q ?? '').replace(/\D/g, '');
+    const digits = phoneDigits(q);
     const parts = [];
     if (like) {
       parts.push(

--- a/backend/src/services/erasureService.js
+++ b/backend/src/services/erasureService.js
@@ -9,7 +9,7 @@ import { logger } from '../utils/logger.js';
 import { emailNormKey } from './repeatSignup.js';
 import { makeInventoryService } from './redeemOps/inventoryService.js';
 import { makeRedeemOpsAuditService } from './redeemOps/auditService.js';
-import { buildLeadDeletedPayload } from './prospectHelpers.js';
+import { buildLeadDeletedPayload, phoneDigits } from './prospectHelpers.js';
 import { flushDeliveries, historicallyTargetedSubscribers } from './webhookService.js';
 import { reconcileSuppressionPropagation } from './suppressionPropagationService.js';
 import { evictVerifiedPhone, forgetPhoneVerification } from './verifiedPhoneStore.js';
@@ -59,7 +59,7 @@ import { evictDncCheckCache } from './dncCheckService.js';
 /** draw_entries.phoneHash is NOT NULL — erasure writes this obviously-fake sentinel. */
 export const ERASED_PHONE_HASH = '0'.repeat(64);
 
-const digitsOf = (v) => String(v || '').replace(/\D/g, '');
+const digitsOf = phoneDigits;
 
 const defaultDeps = {
   sequelize, Consumer, Prospect, RewardEntitlement, RedemptionEvent,

--- a/backend/src/services/luckyDrawService.js
+++ b/backend/src/services/luckyDrawService.js
@@ -9,7 +9,7 @@ import {
 import { AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
 import { sgtDayEndExclusiveMs } from '../utils/sgtTime.js';
-import { normalizeLuckyDraw, totalPrizeQuantity } from '../utils/luckyDraw.js';
+import { normalizeLuckyDraw, assertSingleWinnerDraw } from '../utils/luckyDraw.js';
 import { getSystemAgentId } from './systemAgent.js';
 
 /**
@@ -169,15 +169,7 @@ export function makeLuckyDrawService(overrides = {}) {
     // Fail-closed until the multi-winner engine ships: this engine resolves
     // exactly ONE claimed winner per draw (a claimed attempt is terminal), so
     // a multi-prize config must not mint a record it cannot deliver.
-    const totalPrizes = totalPrizeQuantity(normalizeLuckyDraw(ld));
-    if (totalPrizes > 1) {
-      const err = new AppError(
-        `This draw promises ${totalPrizes} prizes, but multi-winner draw execution isn't live yet.`,
-        422
-      );
-      err.data = { code: 'DRAW_MULTI_PRIZE_UNSUPPORTED' };
-      throw err;
-    }
+    assertSingleWinnerDraw(normalizeLuckyDraw(ld));
     const closesAtMs = ld.closesAt ? sgtDayEndExclusiveMs(ld.closesAt) : null;
     if (closesAtMs === null) {
       throw new AppError('luckyDraw.closesAt (YYYY-MM-DD) is required to create a draw', 422);

--- a/backend/src/services/marketplaceService.js
+++ b/backend/src/services/marketplaceService.js
@@ -1,3 +1,4 @@
+import { isValidSlug } from '../utils/slug.js';
 /**
  * Marketplace read model — the public campaign list/detail behind
  * GET /api/marketplace/campaigns[/:slug] (redeem.sg consumer marketplace).
@@ -318,7 +319,7 @@ export async function listMarketplaceCampaigns({ now = Date.now() } = {}) {
  * ended/sold-out state).
  */
 export async function getMarketplaceCampaign(slug, { now = new Date() } = {}) {
-  if (typeof slug !== 'string' || !/^[a-z0-9-]{3,80}$/.test(slug)) return null;
+  if (!isValidSlug(slug)) return null;
   const campaign = await Campaign.findOne({ where: { slug }, attributes: CAMPAIGN_ATTRS });
   if (!campaign || !passesStaticGate(campaign)) return null;
   const ops = await composeOps(campaign.id, { now });
@@ -355,7 +356,7 @@ export async function previewMarketplaceCampaign(campaignId, { now = new Date(),
 
 /** Slug availability for the designer (authenticated). */
 export async function checkSlugAvailability(slug, { excludeCampaignId } = {}) {
-  if (typeof slug !== 'string' || !/^[a-z0-9-]{3,80}$/.test(slug)) {
+  if (!isValidSlug(slug)) {
     return { valid: false, available: false };
   }
   const where = { slug };

--- a/backend/src/services/prospectHelpers.js
+++ b/backend/src/services/prospectHelpers.js
@@ -9,6 +9,21 @@
  * Numbers starting with 65 and length 10 get + prefix.
  * All others get + prefix if missing.
  */
+/**
+ * THE raw digit-strip primitive (P4-1). The phone FORMATS in this codebase are
+ * deliberate, distinct contracts — do not flatten them into each other:
+ *   normalizePhone (here)            → E.164 storage form `+65XXXXXXXX`
+ *   Lyfe users mirror / agent sync   → bare `65XXXXXXXX` (Lyfe storage contract)
+ *   whatsappService.waRecipient      → Graph API digits `65XXXXXXXX`
+ *   dncService.formatDncNumber       → 8-digit local `XXXXXXXX`
+ *   entitlementService.phoneKeyOf    → dedupe digits (≥8)
+ *   the various maskPhone helpers    → display-only last-4 idioms
+ * Those named helpers keep their own guards; this is just the shared strip.
+ */
+export function phoneDigits(v) {
+  return String(v ?? '').replace(/\D/g, '');
+}
+
 export function normalizePhone(phone) {
   if (!phone) return phone;
   let p = String(phone).replace(/\s+/g, '');

--- a/backend/src/services/redeemOps/analyticsService.js
+++ b/backend/src/services/redeemOps/analyticsService.js
@@ -1,6 +1,7 @@
 import { Op, QueryTypes } from 'sequelize';
 import { sequelize, RewardOffer, Activation, RewardEntitlement } from '../../models/index.js';
 import { makeCampaignProjection } from './campaignProjection.js';
+import { partnerDisplayName, PARTNER_NAME_ATTRS } from './partnerDisplayName.js';
 
 /**
  * Redeem Ops analytics (brief §29) — plain SQL aggregates over OUR tables.
@@ -80,14 +81,14 @@ export function makeAnalyticsService(overrides = {}) {
   /** Reward supply performance — counters are already ledger-audited truth. */
   async function rewardPerformance() {
     const offers = await d.RewardOffer.findAll({
-      include: [{ association: 'partner', attributes: ['tradingName', 'legalName'] }],
+      include: [{ association: 'partner', attributes: PARTNER_NAME_ATTRS }],
       order: [['createdAt', 'DESC']],
       limit: 100,
     });
     return offers.map((o) => ({
       id: o.id,
       title: o.title,
-      partnerName: o.partner?.tradingName || o.partner?.legalName || null,
+      partnerName: partnerDisplayName(o.partner),
       status: o.status,
       committed: o.committedQuantity,
       allocated: o.allocatedQuantity,
@@ -102,7 +103,7 @@ export function makeAnalyticsService(overrides = {}) {
     const activations = await d.Activation.findAll({
       include: [
         { association: 'rewardOffer', attributes: ['title'] },
-        { association: 'partner', attributes: ['tradingName', 'legalName'] },
+        { association: 'partner', attributes: PARTNER_NAME_ATTRS },
       ],
       order: [['createdAt', 'DESC']],
       limit: 50,
@@ -136,7 +137,7 @@ export function makeAnalyticsService(overrides = {}) {
       funnels.push({
         id: a.id,
         rewardTitle: a.rewardOffer?.title,
-        partnerName: a.partner?.tradingName || a.partner?.legalName || null,
+        partnerName: partnerDisplayName(a.partner),
         campaignName: a.campaignNameSnapshot,
         status: a.status,
         renewalOutcome: a.renewalOutcome,

--- a/backend/src/services/redeemOps/cadenceService.js
+++ b/backend/src/services/redeemOps/cadenceService.js
@@ -6,7 +6,7 @@ import {
 } from '../../models/index.js';
 import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';
-import { hasCapability, canActOnPartnerRow } from './permissions.js';
+import { hasCapability, canActOnPartnerRow, isManagerTier } from './permissions.js';
 import { makeRedeemOpsAuditService } from './auditService.js';
 import { makeTaskService } from './taskService.js';
 import { makePartnerService } from './partnerService.js';
@@ -114,8 +114,7 @@ export function makeCadenceService(overrides = {}) {
   // Manager POWERS that aren't about a single business: overriding the per-owner
   // enrollment cap, and completing a task assigned to someone else. Distinct
   // from acting ON a business — see canActOnPartner directly below.
-  const isManager = (user) =>
-    user.role === 'admin' || ['super_admin', 'ops_admin', 'bdm'].includes(user.redeemOpsRole);
+  const isManager = isManagerTier;
 
   // Running a cadence IS working the deal: it queues outreach tasks and sends
   // scripted messages under the owner's name. So enrolling, pausing, resuming

--- a/backend/src/services/redeemOps/cadenceService.js
+++ b/backend/src/services/redeemOps/cadenceService.js
@@ -11,6 +11,7 @@ import { makeRedeemOpsAuditService } from './auditService.js';
 import { makeTaskService } from './taskService.js';
 import { makePartnerService } from './partnerService.js';
 import { normalizePhone } from '../prospectHelpers.js';
+import { partnerDisplayName } from './partnerDisplayName.js';
 import {
   CHANNEL_DISPOSITIONS, CADENCE_TERMINAL_DISPOSITIONS, CADENCE_WILDCARD_DISPOSITION,
   CADENCE_CHANNELS, CADENCE_TIME_WINDOWS, TASK_PRIORITIES, LOST_REASONS,
@@ -422,7 +423,7 @@ export function makeCadenceService(overrides = {}) {
       ? await d.User.findByPk(partner.ownerUserId, { attributes: ['firstName', 'fullName'], transaction: t })
       : null;
     const rendered = renderTemplate(step.scriptTemplate, {
-      partner_name: partner.tradingName || partner.brandName || partner.legalName || 'there',
+      partner_name: partnerDisplayName(partner, 'there'),
       contact_name: primaryContact?.name || 'there',
       category: partner.category || '',
       recipient: resolved.recipient || '',

--- a/backend/src/services/redeemOps/dedupeService.js
+++ b/backend/src/services/redeemOps/dedupeService.js
@@ -2,6 +2,7 @@ import { QueryTypes, Op } from 'sequelize';
 import { PartnerOrganisation, User, sequelize } from '../../models/index.js';
 import { logger } from '../../utils/logger.js';
 import { normalizeBusinessName, normalizeDomain, normalizeHandle, normalizeUen } from './normalizers.js';
+import { partnerDisplayName } from './partnerDisplayName.js';
 
 /**
  * Duplicate business detection (docs/redeem-ops/ERD.md §5, brief §14).
@@ -56,7 +57,7 @@ export function makeDedupeService(overrides = {}) {
     const domain = normalizeDomain(probe.website) || (probe.websiteDomain ? String(probe.websiteDomain).toLowerCase() : null);
     const instagram = normalizeHandle(probe.instagramHandle);
     const tiktok = normalizeHandle(probe.tiktokHandle);
-    const name = normalizeBusinessName(probe.tradingName || probe.brandName || probe.legalName || probe.name || '');
+    const name = normalizeBusinessName(partnerDisplayName(probe, probe.name || ''));
 
     const exact = [];
     const seen = new Set(excludeId ? [excludeId] : []);

--- a/backend/src/services/redeemOps/fulfilmentNotify.js
+++ b/backend/src/services/redeemOps/fulfilmentNotify.js
@@ -6,6 +6,7 @@ import { maskEmail } from '../../utils/redactTokens.js';
 import { customerHostOrigin, normalizeCustomerHostChoice } from '../../utils/customerHost.js';
 import { renderQrCardPng } from './qrCardRenderer.js';
 import { boostDeadlineLong } from './drawLink.js';
+import { partnerDisplayName } from './partnerDisplayName.js';
 
 /**
  * Consumer voucher delivery on unlock (docs/redeem-ops/MKTR_INTEGRATION.md §2).
@@ -99,7 +100,7 @@ export function makeFulfilmentNotify(overrides = {}) {
     });
     const activation = await d.Activation.findByPk(entitlement.activationId);
     const rewardName = offer?.publicTitle || offer?.title || 'your reward';
-    const partnerName = offer?.partner?.tradingName || offer?.partner?.brandName || offer?.partner?.legalName || 'our partner';
+    const partnerName = partnerDisplayName(offer?.partner, 'our partner');
     return { offer, activation, rewardName, partnerName };
   }
 

--- a/backend/src/services/redeemOps/normalizers.js
+++ b/backend/src/services/redeemOps/normalizers.js
@@ -1,3 +1,4 @@
+import { partnerDisplayName } from './partnerDisplayName.js';
 /**
  * Normalization for partner matching (docs/redeem-ops/ERD.md §5, brief §34).
  * Display values are stored as entered; these derive the SEPARATE matching keys.
@@ -83,7 +84,7 @@ export function postalDistrictOf(postalCode) {
  * keys can never drift from display values).
  */
 export function deriveMatchingKeys(body) {
-  const displayName = body.tradingName || body.brandName || body.legalName || '';
+  const displayName = partnerDisplayName(body, '');
   return {
     normalizedName: normalizeBusinessName(displayName),
     uen: normalizeUen(body.uen),

--- a/backend/src/services/redeemOps/partnerDisplayName.js
+++ b/backend/src/services/redeemOps/partnerDisplayName.js
@@ -1,0 +1,12 @@
+/**
+ * THE partner display-name rule (P4-1): tradingName → brandName → legalName,
+ * then the caller's fallback. Seven call sites carried hand-rolled copies and
+ * one (analyticsService) had drifted to trading→legal — a partner with only a
+ * brand name rendered null in analytics. Query helpers should select
+ * PARTNER_NAME_ATTRS so the chain always has its inputs loaded.
+ */
+export const PARTNER_NAME_ATTRS = ['tradingName', 'brandName', 'legalName'];
+
+export function partnerDisplayName(partner, fallback = null) {
+  return partner?.tradingName || partner?.brandName || partner?.legalName || fallback;
+}

--- a/backend/src/services/redeemOps/partnerService.js
+++ b/backend/src/services/redeemOps/partnerService.js
@@ -10,7 +10,7 @@ import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';
 import { makeRedeemOpsAuditService } from './auditService.js';
 import { makeDedupeService } from './dedupeService.js';
-import { hasCapability, canActOnPartnerRow } from './permissions.js';
+import { hasCapability, canActOnPartnerRow, isManagerTier, ROW_OVERRIDE_SUB_ROLES } from './permissions.js';
 import { deriveMatchingKeys, postalDistrictOf } from './normalizers.js';
 import { normaliseBulkIds } from './bulkIds.js';
 import {
@@ -282,7 +282,7 @@ export function makePartnerService(overrides = {}) {
     if (fromStage === toStage) return partner;
 
     const allowed = STAGE_TRANSITIONS[fromStage] || [];
-    const isForcer = user.role === 'admin' || ['super_admin', 'ops_admin'].includes(user.redeemOpsRole);
+    const isForcer = user.role === 'admin' || ROW_OVERRIDE_SUB_ROLES.includes(user.redeemOpsRole);
     if (!allowed.includes(toStage)) {
       // Backward corrections (mis-drop fixes) are open to whoever can act on
       // the row; every other off-map transition stays admin-only.
@@ -626,7 +626,7 @@ export function makePartnerService(overrides = {}) {
   async function editActivity(activityId, body, user, requestId = null) {
     const activity = await d.OutreachActivity.findByPk(activityId);
     if (!activity || activity.voidedAt) throw new AppError('Activity not found', 404);
-    const isManager = user.role === 'admin' || ['super_admin', 'ops_admin', 'bdm'].includes(user.redeemOpsRole);
+    const isManager = isManagerTier(user);
     if (!isManager && activity.actorUserId !== user.id) {
       throw new AppError('You can only edit your own activities', 403);
     }
@@ -652,7 +652,7 @@ export function makePartnerService(overrides = {}) {
     if (!reason || !String(reason).trim()) throw new AppError('A reason is required to void an activity', 400);
     const activity = await d.OutreachActivity.findByPk(activityId);
     if (!activity || activity.voidedAt) throw new AppError('Activity not found', 404);
-    const isManager = user.role === 'admin' || ['super_admin', 'ops_admin', 'bdm'].includes(user.redeemOpsRole);
+    const isManager = isManagerTier(user);
     if (!isManager && activity.actorUserId !== user.id) {
       throw new AppError('You can only void your own activities', 403);
     }

--- a/backend/src/services/redeemOps/partnerService.js
+++ b/backend/src/services/redeemOps/partnerService.js
@@ -21,6 +21,7 @@ import {
 import { makeOnboardingService } from './onboardingService.js';
 import { makeCategoryService } from './categoryService.js';
 import { fireCadenceHook } from './cadenceHooks.js';
+import { partnerDisplayName } from './partnerDisplayName.js';
 
 /**
  * Partner CRM core (docs/redeem-ops/ERD.md §3.1–3.6, brief §13–§18).
@@ -141,7 +142,7 @@ export function makePartnerService(overrides = {}) {
   // ── Create / update (dedupe-gated) ───────────────────────────────────────
 
   function displayNameOf(body) {
-    return body.tradingName || body.brandName || body.legalName || null;
+    return partnerDisplayName(body);
   }
 
   async function createPartner(body, user, requestId = null) {

--- a/backend/src/services/redeemOps/permissions.js
+++ b/backend/src/services/redeemOps/permissions.js
@@ -170,6 +170,25 @@ export function isRedeemOpsUser(user) {
 export const ROW_OVERRIDE_SUB_ROLES = ['super_admin', 'ops_admin'];
 
 /**
+ * THE manager tier (P4-1) — powers that aren't about a single business: cap
+ * overrides, completing someone else's task, bulk assign/return. Was
+ * hand-rolled at six sites (cadence/task/partner services). Platform admin
+ * always qualifies.
+ */
+export const MANAGER_TIER_SUB_ROLES = ['super_admin', 'ops_admin', 'bdm'];
+export function isManagerTier(user) {
+  return !!user && (user.role === 'admin' || MANAGER_TIER_SUB_ROLES.includes(user.redeemOpsRole));
+}
+
+/**
+ * Team-wide analytics visibility (routes/redeemOpsAnalytics): the manager tier
+ * PLUS the analyst-class sub-roles. Named here so the route stops rolling its
+ * own list — deliberately NOT hasCapability('analytics.view_team'), whose
+ * matrix is wider (outreach_exec has it) and would silently change scope.
+ */
+export const TEAM_ANALYTICS_SUB_ROLES = [...MANAGER_TIER_SUB_ROLES, 'campaign_ops', 'redemption_ops', 'analyst'];
+
+/**
  * Row-level gate: may this user write to THIS business? Covers stage moves,
  * detail edits, contacts, locations and snooze — the actions that belong to
  * whoever is working the deal.

--- a/backend/src/services/redeemOps/taskService.js
+++ b/backend/src/services/redeemOps/taskService.js
@@ -6,6 +6,7 @@ import {
 import { AppError } from '../../middleware/errorHandler.js';
 import { logger } from '../../utils/logger.js';
 import { TASK_STATUSES, TASK_PRIORITIES } from './constants.js';
+import { isManagerTier } from './permissions.js';
 
 const TASK_TYPES = ['follow_up', 'call', 'meeting', 'proposal', 'admin', 'other'];
 const SGT_OFFSET_MS = 8 * 60 * 60 * 1000;
@@ -42,7 +43,7 @@ export function makeTaskService(overrides = {}) {
   };
 
   const isManager = (user) =>
-    user.role === 'admin' || ['super_admin', 'ops_admin', 'bdm'].includes(user.redeemOpsRole);
+    isManagerTier(user);
 
   async function recomputeNextTaskAt(partnerOrganisationId, transaction = null) {
     const next = await d.OutreachTask.min('dueAt', {

--- a/backend/src/services/redeemOps/whatsappService.js
+++ b/backend/src/services/redeemOps/whatsappService.js
@@ -5,6 +5,7 @@ import { renderQrCardPng } from './qrCardRenderer.js';
 import { isSendBlocked } from '../consentService.js';
 import { boostDeadlineLong } from './drawLink.js';
 import { recordWaSend } from './waMessageOwnership.js';
+import { partnerDisplayName } from './partnerDisplayName.js';
 
 /**
  * Consumer WhatsApp delivery for reward credentials (trial-reward PR E,
@@ -174,7 +175,7 @@ export function makeWhatsappService(overrides = {}) {
       });
       return {
         rewardName: offer?.publicTitle || offer?.title || 'your reward',
-        partnerName: offer?.partner?.tradingName || offer?.partner?.brandName || offer?.partner?.legalName || null,
+        partnerName: partnerDisplayName(offer?.partner),
       };
     } catch {
       return { rewardName: 'your reward', partnerName: null };

--- a/backend/src/services/suppressionPropagationService.js
+++ b/backend/src/services/suppressionPropagationService.js
@@ -5,7 +5,7 @@ import {
   WebhookDelivery, SuppressionPropagation,
 } from '../models/index.js';
 import { logger } from '../utils/logger.js';
-import { buildLeadSuppressedPayload, buildLeadUnsuppressedPayload } from './prospectHelpers.js';
+import { buildLeadSuppressedPayload, buildLeadUnsuppressedPayload, phoneDigits } from './prospectHelpers.js';
 import { flushDeliveries, historicallyTargetedSubscribers } from './webhookService.js';
 
 /**
@@ -43,7 +43,7 @@ import { flushDeliveries, historicallyTargetedSubscribers } from './webhookServi
  * already implies stop-contact; capability alone never skips.
  */
 
-const digitsOf = (v) => String(v || '').replace(/\D/g, '');
+const digitsOf = phoneDigits;
 
 const EVENT_FOR_STATE = {
   suppressed: 'lead.suppressed',

--- a/backend/src/utils/campaignBrief.js
+++ b/backend/src/utils/campaignBrief.js
@@ -28,7 +28,7 @@
 
 export const BRIEF_VERSION = 1;
 
-const isPlainObject = (x) => x !== null && typeof x === 'object' && !Array.isArray(x);
+const isPlainObject = (x) => Object.prototype.toString.call(x) === '[object Object]';
 
 // ── the four questions' vocabularies ──
 

--- a/backend/src/utils/drawConsistency.js
+++ b/backend/src/utils/drawConsistency.js
@@ -1,4 +1,4 @@
-import { sgtDayEndExclusiveMs } from './sgtTime.js';
+import { sgtDayEndExclusiveMs, longDate } from './sgtTime.js';
 
 /**
  * drawConsistency — the promise-vs-facts lint for lucky-draw campaigns
@@ -27,18 +27,9 @@ import { sgtDayEndExclusiveMs } from './sgtTime.js';
  * DB and can run identically in the save gate and the readiness loader.
  */
 
-const MONTHS = [
-  'January', 'February', 'March', 'April', 'May', 'June',
-  'July', 'August', 'September', 'October', 'November', 'December',
-];
-
-/** '2026-09-30' → '30 September 2026' (the template's long-date shape). */
-export function longDate(ymd) {
-  const m = typeof ymd === 'string' ? ymd.match(/^(\d{4})-(\d{2})-(\d{2})$/) : null;
-  if (!m) return '';
-  const month = MONTHS[Number(m[2]) - 1];
-  return month ? `${Number(m[3])} ${month} ${m[1]}` : '';
-}
+// The long-date formatter lives in sgtTime.js (P4-1: this file carried a
+// verbatim drifted-in-waiting copy while already importing sgtTime).
+export { longDate };
 
 const NAMED_ENTITIES = {
   amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ',

--- a/backend/src/utils/drawTermsTemplate.js
+++ b/backend/src/utils/drawTermsTemplate.js
@@ -22,7 +22,13 @@ const MONTHS = [
   'July', 'August', 'September', 'October', 'November', 'December',
 ];
 
-/** '2026-10-30' → '30 October 2026' (string split — SGT calendar date). */
+/** '2026-10-30' → '30 October 2026' (string split — SGT calendar date).
+ * DELIBERATE copy of utils/sgtTime.longDate (P4-1 verified 2026-08-02): this
+ * file is a byte-parity twin of the frontend drawTermsTemplate.js, whose only
+ * allowed imports are twin siblings (luckyDrawCaps). Importing sgtTime here
+ * would force a frontend sgtTime twin — more twin surface than a 6-line
+ * formatter warrants. If the twin discipline ever ends, fold this into
+ * sgtTime.longDate. */
 export function formatLongDate(ymd) {
   const m = typeof ymd === 'string' ? ymd.match(/^(\d{4})-(\d{2})-(\d{2})$/) : null;
   if (!m) return '';

--- a/backend/src/utils/featuredDrop.js
+++ b/backend/src/utils/featuredDrop.js
@@ -1,3 +1,4 @@
+import { isPlainObject, cleanString } from './objects.js';
 /**
  * design_config.featuredDrop — the redeem.sg homepage publication settings.
  *
@@ -15,17 +16,6 @@ const MAX_VALUE_LABEL = 12;
 const MAX_EMOJI = 8;
 const MAX_CAP = 100000;
 const YMD_RE = /^\d{4}-\d{2}-\d{2}$/;
-
-function isPlainObject(v) {
-  return Object.prototype.toString.call(v) === '[object Object]';
-}
-
-function cleanString(v, max) {
-  if (typeof v !== 'string') return undefined;
-  const t = v.trim();
-  if (!t) return undefined;
-  return t.slice(0, max);
-}
 
 /**
  * Normalize a raw featuredDrop value into the canonical shape, or undefined

--- a/backend/src/utils/luckyDraw.js
+++ b/backend/src/utils/luckyDraw.js
@@ -77,6 +77,26 @@ export function totalPrizeQuantity(ld) {
 }
 
 /**
+ * THE multi-prize fail-closed guard (P4-1): the draw engine resolves exactly
+ * ONE claimed winner today, so a NORMALIZED draw whose prizes total more than
+ * one unit 422s with DRAW_MULTI_PRIZE_UNSUPPORTED. One code, one message
+ * core; call sites append their own context via `suffix` (readiness keeps a
+ * prose copy for tone — its lowercase issue code is a separate namespace).
+ * Phase 3 (multi-winner engine) removes this.
+ */
+export function assertSingleWinnerDraw(ld, { suffix = '.' } = {}) {
+  const total = totalPrizeQuantity(ld);
+  if (total > 1) {
+    const err = new AppError(
+      `This draw promises ${total} prizes, but multi-winner draw execution isn't live yet${suffix}`,
+      422
+    );
+    err.data = { code: 'DRAW_MULTI_PRIZE_UNSUPPORTED' };
+    throw err;
+  }
+}
+
+/**
  * Normalize a raw luckyDraw value into the canonical shape, or undefined when
  * the input isn't a plain object (caller should drop the key entirely).
  */

--- a/backend/src/utils/luckyDraw.js
+++ b/backend/src/utils/luckyDraw.js
@@ -22,6 +22,7 @@
 
 import { AppError } from '../middleware/appError.js';
 import { PASS_THEMES } from './drawTheme.js';
+import { cleanYmd } from './sgtTime.js';
 import { MAX_PRIZE_NAME, MAX_PRIZE_ROWS, MAX_PRIZE_QTY } from './luckyDrawCaps.js';
 
 const MAX_PRIZE = 80; // legacy manual `prize` cap — unchanged so stored rows never drift
@@ -32,7 +33,6 @@ const MAX_BOOKING_URL = 300;
 const MIN_MULTIPLIER = 2;
 const MAX_MULTIPLIER = 100;
 const DEFAULT_MULTIPLIER = 10;
-const YMD_RE = /^\d{4}-\d{2}-\d{2}$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const SHA256_RE = /^[0-9a-f]{64}$/i;
 
@@ -45,18 +45,6 @@ function cleanString(v, max) {
   const t = v.trim();
   if (!t) return undefined;
   return t.slice(0, max);
-}
-
-function cleanYmd(v) {
-  if (typeof v !== 'string') return undefined;
-  const s = v.trim();
-  if (!YMD_RE.test(s)) return undefined;
-  // Strict calendar check — Date.parse would silently roll 2026-02-31 into
-  // March; a draw date must be a real day.
-  const [y, m, day] = s.split('-').map(Number);
-  const dt = new Date(Date.UTC(y, m - 1, day));
-  if (dt.getUTCFullYear() !== y || dt.getUTCMonth() !== m - 1 || dt.getUTCDate() !== day) return undefined;
-  return s;
 }
 
 /** Valid structured rows only: plain objects with a non-empty name; qty coerced to 1..MAX_PRIZE_QTY. */

--- a/backend/src/utils/luckyDraw.js
+++ b/backend/src/utils/luckyDraw.js
@@ -24,6 +24,7 @@ import { AppError } from '../middleware/appError.js';
 import { PASS_THEMES } from './drawTheme.js';
 import { cleanYmd } from './sgtTime.js';
 import { MAX_PRIZE_NAME, MAX_PRIZE_ROWS, MAX_PRIZE_QTY } from './luckyDrawCaps.js';
+import { isPlainObject, cleanString } from './objects.js';
 
 const MAX_PRIZE = 80; // legacy manual `prize` cap — unchanged so stored rows never drift
 // Derived summaries are bounded by construction (8 × (4 + 80) + 7 × 3 = 693);
@@ -35,17 +36,6 @@ const MAX_MULTIPLIER = 100;
 const DEFAULT_MULTIPLIER = 10;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const SHA256_RE = /^[0-9a-f]{64}$/i;
-
-function isPlainObject(v) {
-  return Object.prototype.toString.call(v) === '[object Object]';
-}
-
-function cleanString(v, max) {
-  if (typeof v !== 'string') return undefined;
-  const t = v.trim();
-  if (!t) return undefined;
-  return t.slice(0, max);
-}
 
 /** Valid structured rows only: plain objects with a non-empty name; qty coerced to 1..MAX_PRIZE_QTY. */
 function cleanPrizes(raw) {

--- a/backend/src/utils/marketplaceContent.js
+++ b/backend/src/utils/marketplaceContent.js
@@ -1,3 +1,4 @@
+import { isPlainObject, cleanString } from './objects.js';
 /**
  * design_config marketplace keys — normalization + publication policy.
  *
@@ -58,17 +59,6 @@ const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 export const MARKETPLACE_CAMPAIGN_TYPES = ['lead_generation', 'brand_awareness', 'product_promotion', 'event_marketing'];
 
 const SLOT_RE = /^\d{2}:\d{2}$/;
-
-function isPlainObject(v) {
-  return Object.prototype.toString.call(v) === '[object Object]';
-}
-
-function cleanString(v, max) {
-  if (typeof v !== 'string') return undefined;
-  const t = v.trim();
-  if (!t) return undefined;
-  return t.slice(0, max);
-}
 
 function cleanEnum(v, allowed) {
   return typeof v === 'string' && allowed.includes(v) ? v : undefined;

--- a/backend/src/utils/objects.js
+++ b/backend/src/utils/objects.js
@@ -1,0 +1,19 @@
+/**
+ * Shared micro-helpers (P4-1). isPlainObject existed in FIVE utils with TWO
+ * different semantics — toString-based (strict: rejects Date/RegExp/Map) vs
+ * typeof-based (accepts them) — a latent divergence. The strict form is
+ * canonical. campaignBrief.js keeps a local copy by twin discipline
+ * (byte-parity with src/lib/campaignBrief.js, dependency-free) but its
+ * semantic is aligned to this one.
+ */
+export function isPlainObject(v) {
+  return Object.prototype.toString.call(v) === '[object Object]';
+}
+
+/** trim + cap; undefined for non-strings/empties — the config-clamp idiom. */
+export function cleanString(v, max) {
+  if (typeof v !== 'string') return undefined;
+  const t = v.trim();
+  if (!t) return undefined;
+  return t.slice(0, max);
+}

--- a/backend/src/utils/sgtTime.js
+++ b/backend/src/utils/sgtTime.js
@@ -42,14 +42,24 @@ export function shortDate(ymd) {
  * Returns null for anything that isn't a valid YYYY-MM-DD string.
  */
 export function sgtDayEndExclusiveMs(ymd) {
-  if (typeof ymd !== 'string') return null;
-  const s = ymd.trim();
-  if (!YMD_RE.test(s)) return null;
-  // Strict calendar check — Date.parse rolls impossible dates (2026-02-31 →
-  // March 3) instead of rejecting them.
-  const [y, m, day] = s.split('-').map(Number);
-  const dt = new Date(Date.UTC(y, m - 1, day));
-  if (dt.getUTCFullYear() !== y || dt.getUTCMonth() !== m - 1 || dt.getUTCDate() !== day) return null;
+  const s = cleanYmd(ymd);
+  if (!s) return null;
   const start = Date.parse(`${s}T00:00:00+08:00`);
   return Number.isNaN(start) ? null : start + DAY_MS;
+}
+
+/**
+ * THE strict calendar YYYY-MM-DD validator (P4-1) — trims, shape-checks, and
+ * rejects impossible dates instead of letting Date.parse roll them over
+ * (2026-02-31 must fail, not become March 3). Returns the trimmed string or
+ * undefined. Former copies: utils/luckyDraw.js, campaignDetailsAiService.js.
+ */
+export function cleanYmd(v) {
+  if (typeof v !== 'string') return undefined;
+  const s = v.trim();
+  if (!YMD_RE.test(s)) return undefined;
+  const [y, m, day] = s.split('-').map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, day));
+  if (dt.getUTCFullYear() !== y || dt.getUTCMonth() !== m - 1 || dt.getUTCDate() !== day) return undefined;
+  return s;
 }

--- a/backend/src/utils/slug.js
+++ b/backend/src/utils/slug.js
@@ -1,0 +1,11 @@
+/**
+ * THE campaign/marketplace slug contract (P4-1). One regex, five former
+ * copies (Campaign model validate, marketplaceService ×2, campaignService,
+ * campaignCopyAiService) — drift here silently breaks the slug-lock contract,
+ * so every consumer imports this.
+ */
+export const SLUG_RE = /^[a-z0-9-]{3,80}$/;
+
+export function isValidSlug(value) {
+  return typeof value === 'string' && SLUG_RE.test(value);
+}

--- a/src/lib/campaignBrief.js
+++ b/src/lib/campaignBrief.js
@@ -28,7 +28,7 @@
 
 export const BRIEF_VERSION = 1;
 
-const isPlainObject = (x) => x !== null && typeof x === 'object' && !Array.isArray(x);
+const isPlainObject = (x) => Object.prototype.toString.call(x) === '[object Object]';
 
 // ── the four questions' vocabularies ──
 


### PR DESCRIPTION
## .review P4-1 — Centralise rules duplicated across 3-7 sites

Eight separate commits, one per consolidation, each unit-tier-verified; the full DB tier (132 suites / 2,432 tests) is green on the final tree. Two of the seven turned out to be **real bug fixes**, and two "duplicates" were verified as deliberate and left documented.

| # | Rule | What happened |
|---|---|---|
| 1 | `SLUG_RE` | Five copies → `utils/slug.js` (`SLUG_RE` + `isValidSlug`); Campaign model, marketplaceService ×2, campaignService, campaignCopyAiService all import it. |
| 2 | SGT long-date | drawConsistency's verbatim copy (it already imported sgtTime!) → re-export. **drawTermsTemplate's copy verified as justified and kept**: it's a byte-parity twin of the frontend file whose only allowed imports are twin siblings — importing sgtTime would force a frontend sgtTime twin. Documented in place. drawPassRenderer's `compactDate` transforms longDate *output* (distinct display contract, single site) — left. |
| 3 | Strict calendar YMD | Three copies → `sgtTime.cleanYmd` (2026-02-31 must fail, not roll to March); sgtDayEndExclusiveMs now uses it internally. |
| 4 | Multi-prize fail-closed | `assertSingleWinnerDraw` in utils/luckyDraw — one 422 + one `DRAW_MULTI_PRIZE_UNSUPPORTED` code, call sites keep their context via suffix; readiness keeps its prose copy for tone (its lowercase issue code is a separate namespace) per the task. |
| 5 | Partner display name | **BUG FIXED**: analyticsService used trading→legal in BOTH its fallbacks and its loaded `attributes` — a partner with only a brandName rendered null in analytics. All seven chains → `partnerDisplayName()`; analytics loads `PARTNER_NAME_ATTRS`. |
| 6 | Manager tier | `isManagerTier` + `MANAGER_TIER_SUB_ROLES` in permissions.js replace six hand-rolled lists. partnerService's narrower `isForcer` repointed to the existing `ROW_OVERRIDE_SUB_ROLES` (it was that tier, not manager). The analytics route's longer list became `TEAM_ANALYTICS_SUB_ROLES` — deliberately NOT `hasCapability('analytics.view_team')`, whose matrix is wider (outreach_exec holds it) and would have silently changed scope. |
| 7 | Phone digit-strippers | **Not flattened**, per the task: the formats are deliberate distinct contracts. Added the one raw primitive `prospectHelpers.phoneDigits` with a contract map documenting every named format helper (E.164 storage / Lyfe 65X mirror / WA recipient / DNC 8-digit / dedupe key / display masks); folded the two verbatim `digitsOf` twins and three anonymous inline strips. All named contract helpers keep their own guards. |
| 8 | isPlainObject/cleanString | Strict toString-based pair canonicalised in `utils/objects.js` (3 utils import it). campaignBrief keeps its dependency-free twin copy but **both twin files** now use the strict semantic (`diff` = byte-identical) — the typeof variant accepted Date/RegExp/Map, a latent divergence (unreachable via JSON bodies, real for programmatic callers). |

### Behaviour changes found while consolidating (the task's ask)
- Item 5's analytics brandName drop — fixed.
- Item 8's isPlainObject divergence — aligned (frontend twin updated in the same commit; 1,779 frontend tests green).
- No other copy had drifted semantically; items 1-4 and 6-7 were byte- or semantics-identical.

### Verification
Per-commit unit tier (123 suites) green ×8; final full DB tier 132/132 (2,432 tests); frontend 1,779 tests + lint green; backend lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y83Mpgkub5nZSD5UBNZM6V