### PR TITLE
refactor(wa): one Graph client for OTP + rewards — retry reaches the OTP path (P4-2)

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -182,6 +182,11 @@ SMS_QUOTA_SALT=
 # falls back to SMS.
 # From WhatsApp Manager → API setup. Requires an APPROVED Authentication
 # template (default 'auth_otp', language 'en_US') with an OTP button.
+# P4-2 sender unification: the OTP path reads THIS legacy pair FIRST (in prod
+# it is a deliberately separate sender number whose statuses the webhook
+# skips), falling back to the unified WHATSAPP_TOKEN/WHATSAPP_PHONE_NUMBER_ID
+# family below when unset. Existing deploys need NO changes; a fresh install
+# may set only the WHATSAPP_* pair for both OTP and reward delivery.
 META_WA_PHONE_NUMBER_ID=
 META_WA_ACCESS_TOKEN=
 # Optional overrides (code defaults shown)

--- a/backend/src/services/phoneMask.js
+++ b/backend/src/services/phoneMask.js
@@ -1,0 +1,21 @@
+/**
+ * Phone display-masking variants (P4-2). Three hand-rolled forms existed;
+ * they are DIFFERENT display contracts on purpose — named here, not merged:
+ *
+ *   maskPhoneDots     '+6591234567' → '••••4567'      (WA sends, ops payloads)
+ *   maskPhonePrefixed '+6591234567' → '+65****4567'   (OTP logs; '***' when
+ *                                                      too short to mask —
+ *                                                      mirrors lyfe-app's
+ *                                                      custom-sms-hook helper)
+ */
+import { phoneDigits } from './prospectHelpers.js';
+
+export function maskPhoneDots(phone) {
+  const digits = phoneDigits(phone);
+  return digits ? `••••${digits.slice(-4)}` : null;
+}
+
+export function maskPhonePrefixed(phone) {
+  const s = String(phone || '');
+  return s.length < 7 ? '***' : `${s.slice(0, 3)}****${s.slice(-4)}`;
+}

--- a/backend/src/services/redeemOps/entitlementService.js
+++ b/backend/src/services/redeemOps/entitlementService.js
@@ -14,6 +14,7 @@ import { canWhatsAppProspect, waEnabled, waRecipient } from './whatsappService.j
 import { isSendBlocked } from '../consentService.js';
 import { SCREENING_REASONS } from '../screeningConstants.js';
 import { makeDrawLink } from './drawLink.js';
+import { maskPhoneDots } from '../phoneMask.js';
 
 const DEFAULT_RESERVATION_DAYS = 30;
 const DEFAULT_REDEMPTION_DAYS = 90;
@@ -1303,7 +1304,7 @@ export function makeEntitlementService(overrides = {}) {
         whatsapp: receiptView(latestReceipt.get(`${j.id}:whatsapp`)),
       };
       if (j.prospect) {
-        if (j.prospect.phone) j.prospect.phone = `••••${String(j.prospect.phone).slice(-4)}`;
+        if (j.prospect.phone) j.prospect.phone = maskPhoneDots(j.prospect.phone);
         delete j.prospect.email;
       }
       // Surface the redemption id (+ whether it is already reversed) so the

--- a/backend/src/services/redeemOps/whatsappService.js
+++ b/backend/src/services/redeemOps/whatsappService.js
@@ -6,6 +6,8 @@ import { isSendBlocked } from '../consentService.js';
 import { boostDeadlineLong } from './drawLink.js';
 import { recordWaSend } from './waMessageOwnership.js';
 import { partnerDisplayName } from './partnerDisplayName.js';
+import { makeWaGraphClient, GRAPH_VERSION } from '../waGraphClient.js';
+import { maskPhoneDots } from '../phoneMask.js';
 
 /**
  * Consumer WhatsApp delivery for reward credentials (trial-reward PR E,
@@ -38,7 +40,6 @@ import { partnerDisplayName } from './partnerDisplayName.js';
  */
 
 // Version aligned with verificationService.js / metaCapiService.js.
-const META_GRAPH_VERSION = process.env.META_GRAPH_API_VERSION || 'v21.0';
 
 export function waEnabled() {
   return String(process.env.REDEEM_OPS_WHATSAPP_ENABLED || '').toLowerCase() === 'true';
@@ -101,11 +102,8 @@ export async function canWhatsAppProspect(prospect, { purpose = 'transactional' 
   return !(await isSendBlocked(prospect, { channel: 'whatsapp', purpose }));
 }
 
-/** `+6591234567` → `••••4567` — same masking idiom as the ops list payload. */
-function maskPhone(phone) {
-  const digits = String(phone || '').replace(/\D/g, '');
-  return digits ? `••••${digits.slice(-4)}` : null;
-}
+// `+6591234567` → `••••4567` — shared display mask (P4-2, phoneMask.js).
+const maskPhone = maskPhoneDots;
 
 /**
  * Meta rejects body params containing newlines/tabs/4+ spaces; URL-ish person
@@ -135,37 +133,9 @@ export function makeWhatsappService(overrides = {}) {
     fetch: (...args) => fetch(...args), sleep, isSendBlocked, recordWaSend, ...overrides,
   };
 
-  /**
-   * Graph API fetch with bounded retry on TRANSIENT failures only — a network
-   * throw ("fetch failed": no response received, so the request very likely
-   * never reached Meta) or a 5xx. 4xx (template/permission/bad-request) is
-   * deterministic and returned as-is for the caller to receipt. This closes
-   * the gap that silently lost a voucher WhatsApp on a single connection blip
-   * while email went through (prod, 2026-07-20): the send was fire-and-forget
-   * with no retry.
-   */
-  async function graphFetch(url, opts, { label, attempts = 3 } = {}) {
-    let lastErr;
-    for (let i = 1; i <= attempts; i += 1) {
-      try {
-        const res = await d.fetch(url, opts);
-        if (res.status >= 500 && i < attempts) {
-          d.logger.warn('redeem_ops.whatsapp.retry_5xx', { label, status: res.status, attempt: i });
-          await d.sleep(300 * i);
-          continue;
-        }
-        return res; // ok or 4xx — caller decides
-      } catch (err) {
-        lastErr = err;
-        if (i < attempts) {
-          d.logger.warn('redeem_ops.whatsapp.retry_network', { label, error: err?.message, attempt: i });
-          await d.sleep(300 * i);
-          continue;
-        }
-      }
-    }
-    throw lastErr;
-  }
+  // Shared retrying Graph transport (P4-2, waGraphClient.js) — built from
+  // this factory's own deps so tests keep injecting d.fetch/d.sleep.
+  const { graphFetch } = makeWaGraphClient({ fetch: d.fetch, sleep: d.sleep, logger: d.logger });
 
   async function offerContextOf(entitlement) {
     try {
@@ -193,7 +163,7 @@ export function makeWhatsappService(overrides = {}) {
     form.append('messaging_product', 'whatsapp');
     form.append('type', 'image/png');
     form.append('file', new Blob([buffer], { type: 'image/png' }), 'reward-qr.png');
-    const res = await graphFetch(`https://graph.facebook.com/${META_GRAPH_VERSION}/${phoneId}/media`, {
+    const res = await graphFetch(`https://graph.facebook.com/${GRAPH_VERSION}/${phoneId}/media`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}` },
       body: form,
@@ -297,7 +267,7 @@ export function makeWhatsappService(overrides = {}) {
         },
       };
 
-      const res = await graphFetch(`https://graph.facebook.com/${META_GRAPH_VERSION}/${phoneId}/messages`, {
+      const res = await graphFetch(`https://graph.facebook.com/${GRAPH_VERSION}/${phoneId}/messages`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
         body: JSON.stringify(body),

--- a/backend/src/services/verificationService.js
+++ b/backend/src/services/verificationService.js
@@ -1,5 +1,7 @@
 import crypto from 'crypto';
 import fetch from 'node-fetch';
+import { makeWaGraphClient, otpSender } from './waGraphClient.js';
+import { maskPhonePrefixed } from './phoneMask.js';
 import { Campaign, Verification } from '../models/index.js';
 import { SNSClient, PublishCommand } from '@aws-sdk/client-sns';
 import { AppError } from '../middleware/errorHandler.js';
@@ -48,7 +50,6 @@ const snsClient = new SNSClient({
 });
 
 // Meta WhatsApp Graph API config (version aligned with metaCapiService.js; all overridable via env)
-const META_GRAPH_VERSION = process.env.META_GRAPH_API_VERSION || 'v21.0';
 const WA_TEMPLATE_NAME = process.env.META_WA_TEMPLATE_NAME || 'auth_otp';
 const WA_TEMPLATE_LANG = process.env.META_WA_TEMPLATE_LANG || 'en_US';
 
@@ -63,10 +64,12 @@ const generateCode = () => crypto.randomInt(100000, 1000000).toString();
  * numbers out of them means there is nothing there to erase. Mirrors the same
  * helper in lyfe-app's custom-sms-hook.
  */
-const maskPhone = (phone) => {
-  const s = String(phone || '');
-  return s.length < 7 ? '***' : `${s.slice(0, 3)}****${s.slice(-4)}`;
-};
+// One shared Graph client for the OTP path — node-fetch injected so the
+// existing test seam (unstable_mockModule('node-fetch')) keeps working.
+const waClient = makeWaGraphClient({ fetch });
+
+// '+6591234567' → '+65****4567' — shared display mask (P4-2, phoneMask.js).
+const maskPhone = maskPhonePrefixed;
 
 // Helper to send WhatsApp via Meta Graph API.
 //
@@ -77,49 +80,30 @@ const maskPhone = (phone) => {
 // (waWebhookService.js:137,145-148). Full reasoning and the send-path
 // inventory: redeemOps/waMessageOwnership.js.
 const sendWhatsAppOtpMeta = async (phone, code) => {
-  const phoneId = process.env.META_WA_PHONE_NUMBER_ID;
-  const accessToken = process.env.META_WA_ACCESS_TOKEN;
+  // Sender resolution (P4-2): legacy META_WA_* pair first — it is a separate
+  // sender number in prod whose statuses the webhook skips — falling back to
+  // the unified WHATSAPP_* family. See waGraphClient.otpSender.
+  const { phoneId, token } = otpSender();
 
-  if (!phoneId || !accessToken) {
+  if (!phoneId || !token) {
     throw new Error('Meta WhatsApp credentials missing');
   }
 
   const to = phone.replace('+', '');
-  const url = `https://graph.facebook.com/${META_GRAPH_VERSION}/${phoneId}/messages`;
-
-  const body = {
-    messaging_product: "whatsapp",
-    to: to,
-    type: "template",
-    template: {
-      name: WA_TEMPLATE_NAME,
-      language: { code: WA_TEMPLATE_LANG },
-      components: [
-        {
-          type: "body",
-          parameters: [
-            { type: "text", text: code }
-          ]
-        },
-        {
-          type: "button",
-          sub_type: "url",
-          index: 0,
-          parameters: [
-            { type: "text", text: code }
-          ]
-        }
-      ]
-    }
-  };
-
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${accessToken}`,
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify(body)
+  // The shared client brings the 3-attempt 5xx/network retry the OTP path
+  // never had (the reward path gained it after the 2026-07-20 incident; a
+  // dropped OTP blocks signup, so it needs it MORE).
+  const response = await waClient.sendTemplate({
+    phoneId,
+    token,
+    to,
+    name: WA_TEMPLATE_NAME,
+    language: WA_TEMPLATE_LANG,
+    components: [
+      { type: 'body', parameters: [{ type: 'text', text: code }] },
+      { type: 'button', sub_type: 'url', index: 0, parameters: [{ type: 'text', text: code }] },
+    ],
+    label: 'otp_send',
   });
 
   if (!response.ok) {

--- a/backend/src/services/waGraphClient.js
+++ b/backend/src/services/waGraphClient.js
@@ -1,0 +1,113 @@
+/**
+ * THE Meta WhatsApp Cloud API (Graph) client (P4-2).
+ *
+ * Two independent clients used to exist: redeemOps/whatsappService (reward
+ * delivery — had 3-attempt retry, added after the 2026-07-20 lost-voucher
+ * incident) and verificationService (phone OTP — bare fetch, NO retry, on the
+ * more critical path). Both now share this one transport: same retry policy,
+ * same error surfacing, same template-payload construction. Each caller keeps
+ * its own fail-open/fail-closed posture and masking — only the transport is
+ * shared.
+ *
+ * ── Sender identities & env (coordinated with P3-1 env docs) ──────────────
+ * The unified family is WHATSAPP_TOKEN / WHATSAPP_PHONE_NUMBER_ID. The OTP
+ * path historically used META_WA_ACCESS_TOKEN / META_WA_PHONE_NUMBER_ID — and
+ * in production that is a DELIBERATELY SEPARATE sender number whose delivery
+ * statuses the webhook skips (waMessageOwnership.js), so the legacy pair is
+ * read FIRST for OTP as a sender override, falling back to the unified
+ * family. Nothing needs to change in Render today; to fully unify later, set
+ * only the WHATSAPP_* pair and delete META_WA_*.
+ */
+import { logger as defaultLogger } from '../utils/logger.js';
+
+export const GRAPH_VERSION = process.env.META_GRAPH_API_VERSION || 'v21.0';
+
+const defaultSleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Reward-delivery sender (redeemOps) — the unified family only. */
+export function rewardsSender() {
+  return {
+    phoneId: process.env.WHATSAPP_PHONE_NUMBER_ID || null,
+    token: process.env.WHATSAPP_TOKEN || null,
+  };
+}
+
+/**
+ * OTP sender — legacy META_WA_* pair FIRST (it is a separate sender number in
+ * prod; resolving the unified family first would silently flip the OTP sender
+ * and break the webhook's skip-foreign-statuses assumption), then the unified
+ * family as fallback for fresh installs that configure only WHATSAPP_*.
+ */
+export function otpSender() {
+  return {
+    phoneId: process.env.META_WA_PHONE_NUMBER_ID || process.env.WHATSAPP_PHONE_NUMBER_ID || null,
+    token: process.env.META_WA_ACCESS_TOKEN || process.env.WHATSAPP_TOKEN || null,
+  };
+}
+
+export function makeWaGraphClient(overrides = {}) {
+  const d = {
+    fetch: (...args) => fetch(...args),
+    sleep: defaultSleep,
+    logger: defaultLogger,
+    ...overrides,
+  };
+
+  /**
+   * Graph fetch with bounded retry on TRANSIENT failures only — a network
+   * throw (no response received, so the request very likely never reached
+   * Meta) or a 5xx. 4xx (template/permission/bad-request) is deterministic
+   * and returned as-is for the caller to receipt/handle.
+   */
+  async function graphFetch(url, opts, { label, attempts = 3 } = {}) {
+    let lastErr;
+    for (let i = 1; i <= attempts; i += 1) {
+      try {
+        const res = await d.fetch(url, opts);
+        if (res.status >= 500 && i < attempts) {
+          d.logger.warn('wa_graph.retry_5xx', { label, status: res.status, attempt: i });
+          await d.sleep(300 * i);
+          continue;
+        }
+        return res; // ok or 4xx — caller decides
+      } catch (err) {
+        lastErr = err;
+        if (i < attempts) {
+          d.logger.warn('wa_graph.retry_network', { label, error: err?.message, attempt: i });
+          await d.sleep(300 * i);
+          continue;
+        }
+      }
+    }
+    throw lastErr;
+  }
+
+  /** Build the standard template message body (components passed verbatim). */
+  function templateBody({ to, name, language, components }) {
+    return {
+      messaging_product: 'whatsapp',
+      to,
+      type: 'template',
+      template: { name, language: { code: language }, components },
+    };
+  }
+
+  /**
+   * One template send over the retrying transport. Returns the raw Response —
+   * callers keep their own posture: whatsappService receipts 4xx and never
+   * throws; the OTP path throws on !ok to trigger its SMS fallback.
+   */
+  async function sendTemplate({ phoneId, token, to, name, language, components, label }) {
+    return graphFetch(
+      `https://graph.facebook.com/${GRAPH_VERSION}/${phoneId}/messages`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify(templateBody({ to, name, language, components })),
+      },
+      { label }
+    );
+  }
+
+  return { graphFetch, sendTemplate };
+}

--- a/backend/test/unit/verificationService.test.js
+++ b/backend/test/unit/verificationService.test.js
@@ -124,6 +124,25 @@ describe('verificationService (unit)', () => {
       expect(snsClientSend).toHaveBeenCalled();  // SMS actually dispatched
     });
 
+    it('retries a transient 5xx on the WhatsApp OTP send and still delivers via WhatsApp (P4-2)', async () => {
+      // The OTP path historically had NO retry — the shared waGraphClient
+      // brings the reward path's 3-attempt policy. Two 500s then success:
+      // the send must recover WITHOUT falling back to SMS.
+      Campaign.findByPk.mockResolvedValue({ id: 'camp-1', design_config: { otpChannel: 'whatsapp' } });
+      fetchMock
+        .mockResolvedValueOnce({ status: 500, ok: false, json: () => Promise.resolve({}) })
+        .mockResolvedValueOnce({ status: 500, ok: false, json: () => Promise.resolve({}) })
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ messages: [{ id: 'wa-retry-ok' }] }) });
+
+      const result = await sendVerificationCode({ phone: '91234567', countryCode: '+65', campaignId: 'camp-1' });
+
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(result.status).toBe('pending');
+      expect(result.channel).toBe('whatsapp');
+      expect(result.messageId).toBe('wa-retry-ok');
+      expect(snsClientSend).not.toHaveBeenCalled(); // no SMS fallback needed
+    });
+
     it('uses SMS channel when no campaignId is provided', async () => {
       const result = await sendVerificationCode({ phone: '91234567' });
 


### PR DESCRIPTION
## .review P4-2 — Unify the two WhatsApp Cloud API clients

### The transport
`src/services/waGraphClient.js` is now the ONE Graph messages client: `graphFetch` (3-attempt retry on 5xx/network — the policy the reward path gained after the 2026-07-20 lost-voucher incident; 4xx returned for callers to receipt), shared template-payload construction, one `GRAPH_VERSION`. Both callers ride it; each keeps its own posture (whatsappService receipts-and-never-throws; the OTP path throws → SMS fallback) and its own masking.

**The OTP path — the more critical one — now retries.** New test proves it: two simulated 500s → three fetch calls → OTP delivered via WhatsApp, SMS fallback never dialed.

### The env judgment (deploy-critical, read this)
The two env families are **not** a duplicated account: `waMessageOwnership.js` documents the OTP deliberately going out on a **separate sender number** whose delivery statuses the webhook skips. Naive unification would have flipped the prod OTP sender. So:
- `otpSender()` = `META_WA_PHONE_NUMBER_ID`/`META_WA_ACCESS_TOKEN` **first** (prod-preserving), falling back to the unified `WHATSAPP_*` family.
- `rewardsSender()` = the unified `WHATSAPP_*` family.
- **Variables to set before deploy: NONE.** Existing Render values keep byte-identical behavior. A fresh install may set only the `WHATSAPP_*` pair for both paths. `env.example` documents the semantics (coordinates with P3-1).

### Masking consolidation (named variants, not merged)
`phoneMask.js`: `maskPhoneDots` ('••••4567' — whatsappService + entitlementService's former inline copy) and `maskPhonePrefixed` ('+65****4567' — OTP logs, incl. the short-input `***` case). The differing formats are deliberate display contracts and stay distinct.

### Verification
- verification + whatsapp suites: 64 tests green incl. the new retry proof.
- Unit + all redeemOps: 151 suites / 2,490 tests green; backend eslint clean.
- whatsappService's test seam (injected `d.fetch`/`d.sleep`) and verificationService's (`node-fetch` module mock) both preserved unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y83Mpgkub5nZSD5UBNZM6V