### PR TITLE
refactor(campaigns): split campaignService + type/template registries (P4-4)

### DIFF
--- a/backend/src/config/swagger.js
+++ b/backend/src/config/swagger.js
@@ -1,4 +1,5 @@
 import swaggerJsdoc from 'swagger-jsdoc';
+import { CAMPAIGN_TYPE_IDS, DEFAULT_CAMPAIGN_TYPE } from '../utils/campaignTypes.js';
 
 const options = {
   definition: {
@@ -20,6 +21,13 @@ const options = {
         },
       },
       schemas: {
+        // Derived from the campaign-type registry — route docs $ref this
+        // instead of restating the enum.
+        CampaignType: {
+          type: 'string',
+          enum: CAMPAIGN_TYPE_IDS,
+          default: DEFAULT_CAMPAIGN_TYPE,
+        },
         Error: {
           type: 'object',
           properties: {

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -2,6 +2,7 @@ import { Op } from 'sequelize';
 import { sequelize } from './connection.js';
 import { initSystemAgent } from '../services/systemAgent.js';
 import { validateEnv } from '../config/envValidation.js';
+import { DEFAULT_CAMPAIGN_TYPE } from '../utils/campaignTypes.js';
 import { validateGoogleOAuthConfig } from '../controllers/authController.js';
 import { runMigrations } from './runMigrations.js';
 import { logger } from '../utils/logger.js';
@@ -631,7 +632,7 @@ async function ensureRetellCampaigns() {
 
     await Campaign.create({
       name: campaignName,
-      type: 'lead_generation',
+      type: DEFAULT_CAMPAIGN_TYPE,
       status: 'active',
       is_active: true,
       description: `Auto-created campaign for Retell AI agent: ${agent.name}. Leads from successful phone calls are captured here automatically.`,

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 import { logger } from '../utils/logger.js';
+import { CAMPAIGN_TYPE_IDS } from '../utils/campaignTypes.js';
 
 // Validation middleware.
 //
@@ -93,7 +94,7 @@ export const schemas = {
   // cached bundle that still sends it doesn't 400 — the service never sees it.
   campaignCreate: Joi.object({
     name: Joi.string().min(1).max(100).required(),
-    type: Joi.string().valid('lead_generation', 'brand_awareness', 'product_promotion', 'event_marketing', 'quiz', 'guided_review').optional(),
+    type: Joi.string().valid(...CAMPAIGN_TYPE_IDS).optional(),
     // Campaign brief (campaigns.targetAudience) — shape + required picks are
     // enforced by the service via normalizeBrief (utils/campaignBrief.js);
     // format-only here, same split as design_config/slug.
@@ -118,7 +119,7 @@ export const schemas = {
 
   campaignUpdate: Joi.object({
     name: Joi.string().min(1).max(100).optional(),
-    type: Joi.string().valid('lead_generation', 'brand_awareness', 'product_promotion', 'event_marketing', 'quiz', 'guided_review').optional(),
+    type: Joi.string().valid(...CAMPAIGN_TYPE_IDS).optional(),
     // Campaign brief — omit to leave the stored brief untouched; when present
     // the service enforces a full valid brief (there is no clearing door).
     targetAudience: Joi.object().optional(),

--- a/backend/src/models/Campaign.js
+++ b/backend/src/models/Campaign.js
@@ -1,6 +1,7 @@
 import { DataTypes, Op } from 'sequelize';
 import { sequelize } from '../database/connection.js';
 import { SLUG_RE } from '../utils/slug.js';
+import { CAMPAIGN_TYPE_IDS, DEFAULT_CAMPAIGN_TYPE } from '../utils/campaignTypes.js';
 
 const Campaign = sequelize.define('Campaign', {
   id: {
@@ -24,9 +25,9 @@ const Campaign = sequelize.define('Campaign', {
     defaultValue: 'draft'
   },
   type: {
-    type: DataTypes.ENUM('lead_generation', 'brand_awareness', 'product_promotion', 'event_marketing', 'quiz', 'guided_review'),
+    type: DataTypes.ENUM(...CAMPAIGN_TYPE_IDS),
     allowNull: true,
-    defaultValue: 'lead_generation'
+    defaultValue: DEFAULT_CAMPAIGN_TYPE
   },
   budget: {
     type: DataTypes.DECIMAL(10, 2),

--- a/backend/src/routes/adminAi.js
+++ b/backend/src/routes/adminAi.js
@@ -3,6 +3,7 @@ import rateLimit from 'express-rate-limit';
 import Joi from 'joi';
 import { authenticateToken, requireAdmin } from '../middleware/auth.js';
 import { validate } from '../middleware/validation.js';
+import { AI_CAMPAIGN_TYPE_IDS, DEFAULT_CAMPAIGN_TYPE } from '../utils/campaignTypes.js';
 import * as aiController from '../controllers/aiController.js';
 import { TEMPLATE_IDS } from '../utils/designConfigV2.js';
 
@@ -54,8 +55,8 @@ const briefSchema = Joi.object({
 // 'lucky_draw' is the create-flow pseudo-type → draw fields included).
 const detailsDraftSchema = Joi.object({
   type: Joi.string()
-    .valid('lead_generation', 'quiz', 'guided_review', 'brand_awareness', 'product_promotion', 'event_marketing', 'lucky_draw')
-    .default('lead_generation'),
+    .valid(...AI_CAMPAIGN_TYPE_IDS)
+    .default(DEFAULT_CAMPAIGN_TYPE),
   brief: Joi.string().trim().min(5).max(2000).required(),
 });
 

--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -78,7 +78,7 @@ router.get('/', authenticateToken, campaignController.listCampaigns);
  *             required: [name, type]
  *             properties:
  *               name: { type: string }
- *               type: { type: string, enum: [lead_generation, brand_awareness, product_promotion, event_marketing, quiz, guided_review] }
+ *               type: { $ref: '#/components/schemas/CampaignType' }
  *               start_date: { type: string, format: date }
  *               end_date: { type: string, format: date }
  *               is_active: { type: boolean }

--- a/backend/src/services/campaignCopyAiService.js
+++ b/backend/src/services/campaignCopyAiService.js
@@ -1,5 +1,6 @@
 import { Campaign } from '../models/index.js';
 import { AppError } from '../middleware/errorHandler.js';
+import { DEFAULT_CAMPAIGN_TYPE } from '../utils/campaignTypes.js';
 import { logger } from '../utils/logger.js';
 import { getRuntimeAiSettings } from './aiSettingsService.js';
 import { requestStructuredJson } from './guidedReviewAiService.js';
@@ -205,7 +206,7 @@ export function computeMarketplaceGate(campaign, ops) {
     active: campaign.is_active === true && campaign.status === 'active',
     marketplaceListed: getStoredMarketplaceListed(campaign.design_config) === true,
     redeemHost: getStoredHostChoice(campaign.design_config) === 'redeem',
-    supportedType: MARKETPLACE_CAMPAIGN_TYPES.includes(campaign.type || 'lead_generation'),
+    supportedType: MARKETPLACE_CAMPAIGN_TYPES.includes(campaign.type || DEFAULT_CAMPAIGN_TYPE),
     opsResolvable: !!ops,
   };
 }
@@ -232,7 +233,7 @@ export function buildCampaignContext(campaign, gate = null) {
   const blocks = isObj(legacy.content_blocks) ? legacy.content_blocks : {};
   return {
     campaignName: campaign.name || '',
-    campaignType: campaign.type || 'lead_generation',
+    campaignType: campaign.type || DEFAULT_CAMPAIGN_TYPE,
     // The STORED campaign brief (campaigns.targetAudience) as fixed enum→
     // phrase facts — the AI's only durable audience signal (the campaign name
     // was the whole signal before this). null = pre-brief campaign, no

--- a/backend/src/services/campaignDetailsAiService.js
+++ b/backend/src/services/campaignDetailsAiService.js
@@ -4,6 +4,7 @@ import { getRuntimeAiSettings } from './aiSettingsService.js';
 import { requestStructuredJson } from './guidedReviewAiService.js';
 import { withOrgStyle } from './redeemOps/aiSuggestShared.js';
 import { cleanYmd } from '../utils/sgtTime.js';
+import { AI_TYPE_LABELS, DEFAULT_CAMPAIGN_TYPE } from '../utils/campaignTypes.js';
 
 /**
  * "Fill it for me" for the new-campaign Details form (workspace create flow):
@@ -29,15 +30,9 @@ export function sgtToday(now = Date.now()) {
   return new Date(now + 8 * 3600e3).toISOString().slice(0, 10);
 }
 
-const TYPE_LABELS = {
-  lead_generation: 'standard lead-generation campaign',
-  quiz: 'interactive personality-quiz campaign for paid social',
-  guided_review: 'long-form guided-review campaign that qualifies intent before a consultation',
-  brand_awareness: 'brand-awareness campaign',
-  product_promotion: 'product-promotion campaign',
-  event_marketing: 'event-marketing campaign',
-  lucky_draw: 'lucky-draw campaign (verified entries, one winner pool, optional session boost)',
-};
+// The prompt-context labels live in the type registry (utils/campaignTypes.js)
+// alongside the enum they describe.
+const TYPE_LABELS = AI_TYPE_LABELS;
 
 export function detailsDraftSchema(draw) {
   const properties = {
@@ -74,7 +69,7 @@ export function buildDetailsDraftPrompts({ type, draw, brief, today, settings = 
   const base = [
     "You draft the setup fields for a Singapore consumer campaign on MKTR's redeem.sg platform.",
     `Today is ${today} (Singapore time). All dates are YYYY-MM-DD calendar dates.`,
-    `The operator is creating a ${TYPE_LABELS[type] || TYPE_LABELS.lead_generation}.`,
+    `The operator is creating a ${TYPE_LABELS[type] || TYPE_LABELS[DEFAULT_CAMPAIGN_TYPE]}.`,
     'Fill every schema field from the brief. Be concrete and faithful to the brief — never invent an offer the brief does not imply.',
     'name: internal but presentable — the offer plus a timeframe when one is implied (e.g. "iPhone 17 Lucky Draw — August 2026").',
     'startDate: today unless the brief implies a later start. endDate: only when the brief implies one; otherwise return an empty string.',
@@ -157,7 +152,7 @@ export async function generateCampaignDetailsDraft(body, userId, overrides = {})
     now: () => Date.now(),
     ...overrides,
   };
-  const type = body.type || 'lead_generation';
+  const type = body.type || DEFAULT_CAMPAIGN_TYPE;
   const draw = type === 'lucky_draw';
   const today = sgtToday(d.now());
 

--- a/backend/src/services/campaignDrawGuards.js
+++ b/backend/src/services/campaignDrawGuards.js
@@ -1,0 +1,211 @@
+import crypto from 'crypto';
+import { DrawTermsVersion, Draw } from '../models/index.js';
+import { AppError } from '../middleware/errorHandler.js';
+import { logger } from '../utils/logger.js';
+import { sgtDayEndExclusiveMs } from '../utils/sgtTime.js';
+import { normalizeLuckyDraw, assertSingleWinnerDraw } from '../utils/luckyDraw.js';
+import { checkDrawConsistency } from '../utils/drawConsistency.js';
+import { getStoredTermsHtml, getStoredLuckyDraw } from '../utils/designConfigV2Clamp.js';
+
+/**
+ * Draw launch guards + terms versioning (P4-4, split out of campaignService).
+ * Everything that decides whether a draw campaign may save/arm/launch lives
+ * here: the closesAt/terms requirements, the promise-consistency gate, the
+ * multi-prize activation gate, the append-only terms pin, and the boost-rail
+ * / draw-record ensure hooks that ride the arming moments. campaignService
+ * composes these around its CRUD; it re-exports the public ones so existing
+ * importers (tests, controller namespace) keep their path.
+ */
+
+/**
+ * Boost-rail ensure hook (PR-2, draw-launch-integrity §5.1 / old-plan F2).
+ * Lazy dynamic import: campaignService's static graph feeds many unit suites
+ * that never touch draws — the redeemOps model surface must not enter it.
+ */
+export async function ensureRail(args) {
+  const mod = await import('./redeemOps/drawBoostProvisioningService.js');
+  return mod.ensureDrawBoostRail(args);
+}
+
+/**
+ * Draw-RECORD ensure hook — the engine row chances/freeze/seal run on, born
+ * at the same arming moments as the rail so no operator ever runs the CLI
+ * create step by hand. BEST-EFFORT unlike the rail: a missing record loses
+ * nothing (evidence accrues independently; the boot reconciler retries), so
+ * this never throws and never blocks a save or launch. Same lazy-import +
+ * test-seam shape as ensureRail.
+ */
+let _ensureDrawRecord = null;
+export function setEnsureDrawRecord(fn) {
+  _ensureDrawRecord = typeof fn === 'function' ? fn : null;
+}
+export async function ensureRecord(args) {
+  try {
+    if (_ensureDrawRecord) return await _ensureDrawRecord(args);
+    const mod = await import('./luckyDrawService.js');
+    return await mod.ensureDrawRecord(args);
+  } catch (err) {
+    logger.warn('[Campaign] draw-record ensure failed (reconciler will retry)', { error: err?.message });
+    return { created: false, reason: 'failed' };
+  }
+}
+
+/** Write the ensured activationId into the doc's stored luckyDraw (both doc
+ * versions keep `luckyDraw` top-level — loss-ledger L5). No-op on null. */
+export function stampRailActivationId(designConfig, activationId) {
+  if (!activationId || !designConfig || typeof designConfig !== 'object') return designConfig;
+  if (!designConfig.luckyDraw || typeof designConfig.luckyDraw !== 'object') return designConfig;
+  return { ...designConfig, luckyDraw: { ...designConfig.luckyDraw, activationId } };
+}
+
+export const drawEnabledIn = (doc) => normalizeLuckyDraw(getStoredLuckyDraw(doc))?.enabled === true;
+
+/**
+ * The two draw REQUIREMENTS, each with its one typed 422 (PR 5: typed codes,
+ * write-gate precedent). Deduped here — createCampaign's pre-create block and
+ * ensureDrawTermsVersion both enforce them, in their own order (create checks
+ * before the row exists; the terms pin checks around its live-draw lock), so
+ * the ORDERING stays per-site while the messages/codes live once.
+ */
+export function assertDrawClosesAt(ld) {
+  // An enabled draw without a close date would accept public entries forever
+  // while createDraw refuses the config — never persistable (normalization
+  // already dropped any malformed date, so absence here means absence/invalid).
+  if (!ld?.closesAt) {
+    const err = new AppError(
+      'Lucky-draw campaigns need a valid luckyDraw.closesAt (YYYY-MM-DD) before they can be enabled.',
+      422
+    );
+    err.data = { code: 'DRAW_CLOSES_AT_REQUIRED' };
+    throw err;
+  }
+}
+
+/** Version-aware terms read (v1 termsContent / v2 form.terms.html); returns
+ * the trimmed content the terms pin hashes. */
+export function assertDrawTermsContent(designConfig) {
+  const content = getStoredTermsHtml(designConfig).trim();
+  if (!content) {
+    const err = new AppError(
+      'Lucky-draw campaigns need Terms & Conditions content (designer → Terms & Conditions) before they can be enabled.',
+      422
+    );
+    err.data = { code: 'DRAW_TERMS_REQUIRED' };
+    throw err;
+  }
+  return content;
+}
+
+/**
+ * Promise-consistency gate (PR-3, draw-launch-integrity §3 / Codex R1
+ * CX15/CX16): HARD contradictions between the campaign's facts and its
+ * pinned-at-save T&Cs (prize, age bounds) 422 the ARMING and fact-touching
+ * saves — the iPad-vs-iPhone / 21-vs-25 incident becomes unshippable. SOFT
+ * findings (unparseable/ambiguous clauses, marketing divergence) surface via
+ * readiness only, never block. Remediation is always regeneration through
+ * the terms flow (a new pinned version) — `fix: 'regenerate_terms'`.
+ */
+export function assertDrawPromiseConsistency({ minAge, maxAge, designConfig }) {
+  const ld = normalizeLuckyDraw(getStoredLuckyDraw(designConfig));
+  if (ld?.enabled !== true) return;
+  const content = designConfig?.content || {};
+  const { hard } = checkDrawConsistency({
+    minAge: Number.isInteger(minAge) ? minAge : null,
+    maxAge: Number.isInteger(maxAge) ? maxAge : null,
+    luckyDraw: ld,
+    termsHtml: getStoredTermsHtml(designConfig),
+    contentHeadline: content.headline ?? designConfig?.formHeadline ?? '',
+    contentStory: content.story ?? designConfig?.storyText ?? '',
+  });
+  if (hard.length > 0) {
+    const err = new AppError(hard[0].message, 422);
+    err.data = { code: hard[0].code, fix: 'regenerate_terms', issues: hard };
+    throw err;
+  }
+}
+
+/** Material draw facts for the fact-touching-save detector (PR-3/CX16). */
+export const drawFactsOf = (doc) => {
+  const ld = normalizeLuckyDraw(getStoredLuckyDraw(doc)) || {};
+  return JSON.stringify([ld.enabled, ld.prize, ld.prizes, ld.closesAt, ld.boostClosesAt, ld.multiplier]);
+};
+
+/**
+ * Fail-closed activation gate (docs/plans/lucky-draw-multi-prize-plan.md §3.5):
+ * the draw engine resolves exactly ONE claimed winner per campaign
+ * (luckyDrawService — a claimed attempt is terminal), so a campaign whose
+ * structured prizes total more than one unit must not BE active: it would
+ * collect entries under T&Cs the platform cannot honour. Enforced at the
+ * service layer on every path that can leave a campaign active (create /
+ * update / setCampaignLaunchState) plus createDraw — the launch `force` flag
+ * only skips READINESS, never this. Phase 3 (multi-winner engine) removes it.
+ */
+export function assertDrawActivatable(designConfig) {
+  const ld = normalizeLuckyDraw(getStoredLuckyDraw(designConfig));
+  if (!ld || ld.enabled !== true) return;
+  assertSingleWinnerDraw(ld, { suffix: ' — the campaign can stay a draft (or paused) but cannot be active.' });
+}
+
+/**
+ * Draw-terms versioning (docs/plans/lucky-draw-10x.md §4.6). For an enabled
+ * lucky draw, pin the CURRENT designer T&C content as an append-only
+ * draw_terms_versions row and stamp its id + hash into luckyDraw, so each
+ * entrant's acceptance (consentMetadata.drawTerms) references immutable
+ * content — editing termsContent later mints a NEW version instead of
+ * rewriting what earlier entrants agreed to.
+ *
+ * Canonical bytes = the TRIMMED raw designer HTML (design_config.termsContent).
+ * Idempotent: unchanged content re-resolves to the existing version row.
+ * Exported for tests; `d` is a DI seam (defaults to the real model).
+ */
+export async function ensureDrawTermsVersion(designConfig, campaignId, userId, d = { DrawTermsVersion, Draw }) {
+  const ld = designConfig?.luckyDraw;
+  if (!ld || ld.enabled !== true) return designConfig;
+  assertDrawClosesAt(ld);
+  // PR 5 (Codex plan F3): while a LIVE draw record exists, the doc close date
+  // is LOCKED to the record's cutoff. Entry acceptance follows the DOC while
+  // the pool freeze follows the RECORD — letting the doc drift would accept
+  // entrants the frozen pool silently excludes. Intentional changes go
+  // through ops (void + recreate the draw), never a designer save.
+  const DrawModel = d.Draw ?? Draw;
+  const liveDraw = await DrawModel.findOne({
+    where: { campaignId, status: ['open', 'frozen', 'sealed', 'drawn'] },
+    attributes: ['id', 'closesAt'],
+  });
+  if (liveDraw) {
+    const docEndMs = sgtDayEndExclusiveMs(ld.closesAt);
+    const recordMs = new Date(liveDraw.closesAt).getTime();
+    if (docEndMs !== null && Number.isFinite(recordMs) && docEndMs !== recordMs) {
+      const err = new AppError(
+        'The draw close date is locked while a live draw record exists — void and recreate the draw (Redeem Ops → Draws) to change it.',
+        422
+      );
+      err.data = { code: 'DRAW_CLOSES_AT_LOCKED' };
+      throw err;
+    }
+  }
+  const content = assertDrawTermsContent(designConfig);
+  const contentSha256 = crypto.createHash('sha256').update(content).digest('hex');
+  let row = await d.DrawTermsVersion.findOne({
+    where: { campaignId, contentSha256 },
+    order: [['version', 'DESC']],
+  });
+  if (!row) {
+    const latest = await d.DrawTermsVersion.max('version', { where: { campaignId } });
+    try {
+      row = await d.DrawTermsVersion.create({
+        campaignId,
+        version: (Number.isInteger(latest) ? latest : 0) + 1,
+        content,
+        contentSha256,
+        createdBy: userId,
+      });
+    } catch (err) {
+      // Concurrent save minted the same version number — the content row we
+      // need either exists now (same hash) or the retry below surfaces the error.
+      row = await d.DrawTermsVersion.findOne({ where: { campaignId, contentSha256 } });
+      if (!row) throw err;
+    }
+  }
+  return { ...designConfig, luckyDraw: { ...ld, termsVersionId: row.id, termsHash: contentSha256 } };
+}

--- a/backend/src/services/campaignScope.js
+++ b/backend/src/services/campaignScope.js
@@ -1,0 +1,54 @@
+import { Op } from 'sequelize';
+import { Campaign } from '../models/index.js';
+import { getTenantId } from '../middleware/tenant.js';
+
+/**
+ * Campaign query scoping (P4-4, split out of campaignService): the two
+ * tenant/role WHERE-builders every campaign read/write path starts from.
+ *
+ * buildCampaignWhere — VISIBILITY scope: non-admins see their own campaigns
+ *   plus public ones (list/get/analytics/duplicate).
+ * buildOwnerWhere — OWNERSHIP scope: non-admins may only MUTATE their own
+ *   (update/archive/restore/delete/launch/metrics/summary).
+ */
+
+export function buildCampaignWhere(req, extra = {}) {
+  const where = { ...extra };
+
+  try {
+    const hasTenantId = !!Campaign.rawAttributes.tenant_id;
+    if (hasTenantId) {
+      where.tenant_id = getTenantId(req);
+    }
+  } catch (_) { /* skip in dev */ }
+
+  if (req.user.role !== 'admin') {
+    // The role scope lives inside Op.and — never as a bare where[Op.or] — so a
+    // later filter that also needs an OR group (e.g. the search filter) cannot
+    // overwrite it. Assigning the same symbol key twice silently drops the
+    // first group, which leaked every campaign to any authenticated user.
+    where[Op.and] = [
+      ...(where[Op.and] || []),
+      { [Op.or]: [{ createdBy: req.user.id }, { isPublic: true }] }
+    ];
+  }
+
+  return where;
+}
+
+export function buildOwnerWhere(req, extra = {}) {
+  const where = { ...extra };
+
+  try {
+    const hasTenantId = !!Campaign.rawAttributes.tenant_id;
+    if (hasTenantId) {
+      where.tenant_id = getTenantId(req);
+    }
+  } catch (_) { /* tenant column may not exist */ }
+
+  if (req.user.role !== 'admin') {
+    where.createdBy = req.user.id;
+  }
+
+  return where;
+}

--- a/backend/src/services/campaignService.js
+++ b/backend/src/services/campaignService.js
@@ -1,7 +1,7 @@
 import { Op } from 'sequelize';
 import { Campaign, QrTag, Prospect, CampaignAgentAssignment, sequelize } from '../models/index.js';
-import { getTenantId } from '../middleware/tenant.js';
 import { storageService } from './storage.js';
+import { buildCampaignWhere, buildOwnerWhere } from './campaignScope.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
 import { normalizeCustomerHostChoice } from '../utils/customerHost.js';
@@ -157,50 +157,6 @@ export async function computeCampaignMetrics(campaignId) {
     clicks: scans,
     referrals: 0,
   };
-}
-
-/**
- * Build tenant-aware WHERE clause for campaigns, scoped by user role.
- */
-function buildCampaignWhere(req, extra = {}) {
-  const where = { ...extra };
-
-  try {
-    const hasTenantId = !!Campaign.rawAttributes.tenant_id;
-    if (hasTenantId) {
-      where.tenant_id = getTenantId(req);
-    }
-  } catch (_) { /* skip in dev */ }
-
-  if (req.user.role !== 'admin') {
-    // The role scope lives inside Op.and — never as a bare where[Op.or] — so a
-    // later filter that also needs an OR group (e.g. the search filter) cannot
-    // overwrite it. Assigning the same symbol key twice silently drops the
-    // first group, which leaked every campaign to any authenticated user.
-    where[Op.and] = [
-      ...(where[Op.and] || []),
-      { [Op.or]: [{ createdBy: req.user.id }, { isPublic: true }] }
-    ];
-  }
-
-  return where;
-}
-
-function buildOwnerWhere(req, extra = {}) {
-  const where = { ...extra };
-
-  try {
-    const hasTenantId = !!Campaign.rawAttributes.tenant_id;
-    if (hasTenantId) {
-      where.tenant_id = getTenantId(req);
-    }
-  } catch (_) { /* tenant column may not exist */ }
-
-  if (req.user.role !== 'admin') {
-    where.createdBy = req.user.id;
-  }
-
-  return where;
 }
 
 /**

--- a/backend/src/services/campaignService.js
+++ b/backend/src/services/campaignService.js
@@ -12,6 +12,7 @@ import { applyLuckyDrawPolicy, normalizeLuckyDraw, assertSingleWinnerDraw } from
 import { PASS_THEMES } from '../utils/drawTheme.js';
 import { normalizeMarketplaceContent, applyMarketplacePolicy } from '../utils/marketplaceContent.js';
 import { normalizeBrief, deriveArchetype, hasBrief } from '../utils/campaignBrief.js';
+import { DEFAULT_CAMPAIGN_TYPE } from '../utils/campaignTypes.js';
 import { buildDrawTermsHtml } from '../utils/drawTermsTemplate.js';
 import { checkDrawConsistency } from '../utils/drawConsistency.js';
 import { SLUG_RE } from '../utils/slug.js';
@@ -494,7 +495,7 @@ export async function createCampaign(body, user) {
     is_active: is_active !== undefined ? is_active : true,
     createdBy: user.id,
     status: is_active ? 'active' : 'draft',
-    type: body.type || 'lead_generation'
+    type: body.type || DEFAULT_CAMPAIGN_TYPE
   };
   if (campaignData.is_active) campaignData.firstActivatedAt = new Date();
   if (body.slug !== undefined && body.slug !== null && body.slug !== '') {

--- a/backend/src/services/campaignService.js
+++ b/backend/src/services/campaignService.js
@@ -1,6 +1,5 @@
-import crypto from 'crypto';
 import { Op } from 'sequelize';
-import { Campaign, QrTag, Prospect, CampaignAgentAssignment, DrawTermsVersion, Draw, sequelize } from '../models/index.js';
+import { Campaign, QrTag, Prospect, CampaignAgentAssignment, sequelize } from '../models/index.js';
 import { getTenantId } from '../middleware/tenant.js';
 import { storageService } from './storage.js';
 import { AppError } from '../middleware/errorHandler.js';
@@ -8,13 +7,12 @@ import { logger } from '../utils/logger.js';
 import { normalizeCustomerHostChoice } from '../utils/customerHost.js';
 import { sgtDayEndExclusiveMs } from '../utils/sgtTime.js';
 import { applyFeaturedDropPolicy } from '../utils/featuredDrop.js';
-import { applyLuckyDrawPolicy, normalizeLuckyDraw, assertSingleWinnerDraw } from '../utils/luckyDraw.js';
+import { applyLuckyDrawPolicy, normalizeLuckyDraw } from '../utils/luckyDraw.js';
 import { PASS_THEMES } from '../utils/drawTheme.js';
 import { normalizeMarketplaceContent, applyMarketplacePolicy } from '../utils/marketplaceContent.js';
 import { normalizeBrief, deriveArchetype, hasBrief } from '../utils/campaignBrief.js';
 import { DEFAULT_CAMPAIGN_TYPE } from '../utils/campaignTypes.js';
 import { buildDrawTermsHtml } from '../utils/drawTermsTemplate.js';
-import { checkDrawConsistency } from '../utils/drawConsistency.js';
 import { SLUG_RE } from '../utils/slug.js';
 import {
   classifyDesignConfigVersion,
@@ -23,85 +21,27 @@ import {
   getStoredTermsHtml,
   getStoredLuckyDraw,
 } from '../utils/designConfigV2Clamp.js';
+import {
+  ensureRail,
+  ensureRecord,
+  setEnsureDrawRecord,
+  stampRailActivationId,
+  drawEnabledIn,
+  assertDrawClosesAt,
+  assertDrawTermsContent,
+  assertDrawPromiseConsistency,
+  drawFactsOf,
+  assertDrawActivatable,
+  ensureDrawTermsVersion,
+} from './campaignDrawGuards.js';
 import { invalidateMarketplaceCache } from './marketplaceCache.js';
 import { invalidateFeaturedDropsCache } from './featuredDropsService.js';
 import { bustScoringConfigCache } from './scoringConfigCache.js';
 import { refundCampaignCommitments } from './walletService.js';
 
-/**
- * Boost-rail ensure hook (PR-2, draw-launch-integrity §5.1 / old-plan F2).
- * Lazy dynamic import: campaignService's static graph feeds many unit suites
- * that never touch draws — the redeemOps model surface must not enter it.
- */
-async function ensureRail(args) {
-  const mod = await import('./redeemOps/drawBoostProvisioningService.js');
-  return mod.ensureDrawBoostRail(args);
-}
-/**
- * Draw-RECORD ensure hook — the engine row chances/freeze/seal run on, born
- * at the same arming moments as the rail so no operator ever runs the CLI
- * create step by hand. BEST-EFFORT unlike the rail: a missing record loses
- * nothing (evidence accrues independently; the boot reconciler retries), so
- * this never throws and never blocks a save or launch. Same lazy-import +
- * test-seam shape as ensureRail.
- */
-let _ensureDrawRecord = null;
-export function setEnsureDrawRecord(fn) {
-  _ensureDrawRecord = typeof fn === 'function' ? fn : null;
-}
-async function ensureRecord(args) {
-  try {
-    if (_ensureDrawRecord) return await _ensureDrawRecord(args);
-    const mod = await import('./luckyDrawService.js');
-    return await mod.ensureDrawRecord(args);
-  } catch (err) {
-    logger.warn('[Campaign] draw-record ensure failed (reconciler will retry)', { error: err?.message });
-    return { created: false, reason: 'failed' };
-  }
-}
-/** Write the ensured activationId into the doc's stored luckyDraw (both doc
- * versions keep `luckyDraw` top-level — loss-ledger L5). No-op on null. */
-function stampRailActivationId(designConfig, activationId) {
-  if (!activationId || !designConfig || typeof designConfig !== 'object') return designConfig;
-  if (!designConfig.luckyDraw || typeof designConfig.luckyDraw !== 'object') return designConfig;
-  return { ...designConfig, luckyDraw: { ...designConfig.luckyDraw, activationId } };
-}
-const drawEnabledIn = (doc) => normalizeLuckyDraw(getStoredLuckyDraw(doc))?.enabled === true;
-
-/**
- * Promise-consistency gate (PR-3, draw-launch-integrity §3 / Codex R1
- * CX15/CX16): HARD contradictions between the campaign's facts and its
- * pinned-at-save T&Cs (prize, age bounds) 422 the ARMING and fact-touching
- * saves — the iPad-vs-iPhone / 21-vs-25 incident becomes unshippable. SOFT
- * findings (unparseable/ambiguous clauses, marketing divergence) surface via
- * readiness only, never block. Remediation is always regeneration through
- * the terms flow (a new pinned version) — `fix: 'regenerate_terms'`.
- */
-function assertDrawPromiseConsistency({ minAge, maxAge, designConfig }) {
-  const ld = normalizeLuckyDraw(getStoredLuckyDraw(designConfig));
-  if (ld?.enabled !== true) return;
-  const content = designConfig?.content || {};
-  const { hard } = checkDrawConsistency({
-    minAge: Number.isInteger(minAge) ? minAge : null,
-    maxAge: Number.isInteger(maxAge) ? maxAge : null,
-    luckyDraw: ld,
-    termsHtml: getStoredTermsHtml(designConfig),
-    contentHeadline: content.headline ?? designConfig?.formHeadline ?? '',
-    contentStory: content.story ?? designConfig?.storyText ?? '',
-  });
-  if (hard.length > 0) {
-    const err = new AppError(hard[0].message, 422);
-    err.data = { code: hard[0].code, fix: 'regenerate_terms', issues: hard };
-    throw err;
-  }
-}
-
-/** Material draw facts for the fact-touching-save detector (PR-3/CX16). */
-const drawFactsOf = (doc) => {
-  const ld = normalizeLuckyDraw(getStoredLuckyDraw(doc)) || {};
-  return JSON.stringify([ld.enabled, ld.prize, ld.prizes, ld.closesAt, ld.boostClosesAt, ld.multiplier]);
-};
-
+// Draw guards moved to campaignDrawGuards.js (P4-4); re-exported so existing
+// importers (tests, the controller's namespace import) keep their path.
+export { ensureDrawTermsVersion, assertDrawActivatable, setEnsureDrawRecord };
 
 /**
  * Strip HTML tags from a user-supplied campaign name. The name is interpolated
@@ -197,91 +137,6 @@ export function clampDesignConfig(incoming, storedConfig, role) {
   if (listed === undefined) delete clamped.marketplaceListed;
   else clamped.marketplaceListed = listed;
   return clamped;
-}
-
-/**
- * Draw-terms versioning (docs/plans/lucky-draw-10x.md §4.6). For an enabled
- * lucky draw, pin the CURRENT designer T&C content as an append-only
- * draw_terms_versions row and stamp its id + hash into luckyDraw, so each
- * entrant's acceptance (consentMetadata.drawTerms) references immutable
- * content — editing termsContent later mints a NEW version instead of
- * rewriting what earlier entrants agreed to.
- *
- * Canonical bytes = the TRIMMED raw designer HTML (design_config.termsContent).
- * Idempotent: unchanged content re-resolves to the existing version row.
- * Exported for tests; `d` is a DI seam (defaults to the real model).
- */
-export async function ensureDrawTermsVersion(designConfig, campaignId, userId, d = { DrawTermsVersion, Draw }) {
-  const ld = designConfig?.luckyDraw;
-  if (!ld || ld.enabled !== true) return designConfig;
-  // An enabled draw without a close date would accept public entries forever
-  // while createDraw refuses the config — never persistable (normalization
-  // already dropped any malformed date, so absence here means absence/invalid).
-  // PR 5: draw 422s carry typed codes (write-gate precedent) so the Studio can
-  // classify without message-sniffing.
-  if (!ld.closesAt) {
-    const err = new AppError(
-      'Lucky-draw campaigns need a valid luckyDraw.closesAt (YYYY-MM-DD) before they can be enabled.',
-      422
-    );
-    err.data = { code: 'DRAW_CLOSES_AT_REQUIRED' };
-    throw err;
-  }
-  // PR 5 (Codex plan F3): while a LIVE draw record exists, the doc close date
-  // is LOCKED to the record's cutoff. Entry acceptance follows the DOC while
-  // the pool freeze follows the RECORD — letting the doc drift would accept
-  // entrants the frozen pool silently excludes. Intentional changes go
-  // through ops (void + recreate the draw), never a designer save.
-  const DrawModel = d.Draw ?? Draw;
-  const liveDraw = await DrawModel.findOne({
-    where: { campaignId, status: ['open', 'frozen', 'sealed', 'drawn'] },
-    attributes: ['id', 'closesAt'],
-  });
-  if (liveDraw) {
-    const docEndMs = sgtDayEndExclusiveMs(ld.closesAt);
-    const recordMs = new Date(liveDraw.closesAt).getTime();
-    if (docEndMs !== null && Number.isFinite(recordMs) && docEndMs !== recordMs) {
-      const err = new AppError(
-        'The draw close date is locked while a live draw record exists — void and recreate the draw (Redeem Ops → Draws) to change it.',
-        422
-      );
-      err.data = { code: 'DRAW_CLOSES_AT_LOCKED' };
-      throw err;
-    }
-  }
-  // Version-aware terms read: v1 termsContent / v2 form.terms.html.
-  const content = getStoredTermsHtml(designConfig).trim();
-  if (!content) {
-    const err = new AppError(
-      'Lucky-draw campaigns need Terms & Conditions content (designer → Terms & Conditions) before they can be enabled.',
-      422
-    );
-    err.data = { code: 'DRAW_TERMS_REQUIRED' };
-    throw err;
-  }
-  const contentSha256 = crypto.createHash('sha256').update(content).digest('hex');
-  let row = await d.DrawTermsVersion.findOne({
-    where: { campaignId, contentSha256 },
-    order: [['version', 'DESC']],
-  });
-  if (!row) {
-    const latest = await d.DrawTermsVersion.max('version', { where: { campaignId } });
-    try {
-      row = await d.DrawTermsVersion.create({
-        campaignId,
-        version: (Number.isInteger(latest) ? latest : 0) + 1,
-        content,
-        contentSha256,
-        createdBy: userId,
-      });
-    } catch (err) {
-      // Concurrent save minted the same version number — the content row we
-      // need either exists now (same hash) or the retry below surfaces the error.
-      row = await d.DrawTermsVersion.findOne({ where: { campaignId, contentSha256 } });
-      if (!row) throw err;
-    }
-  }
-  return { ...designConfig, luckyDraw: { ...ld, termsVersionId: row.id, termsHash: contentSha256 } };
 }
 
 /**
@@ -463,22 +318,6 @@ export async function getCampaign(id, req) {
 }
 
 /**
- * Fail-closed activation gate (docs/plans/lucky-draw-multi-prize-plan.md §3.5):
- * the draw engine resolves exactly ONE claimed winner per campaign
- * (luckyDrawService — a claimed attempt is terminal), so a campaign whose
- * structured prizes total more than one unit must not BE active: it would
- * collect entries under T&Cs the platform cannot honour. Enforced at the
- * service layer on every path that can leave a campaign active (create /
- * update / setCampaignLaunchState) plus createDraw — the launch `force` flag
- * only skips READINESS, never this. Phase 3 (multi-winner engine) removes it.
- */
-export function assertDrawActivatable(designConfig) {
-  const ld = normalizeLuckyDraw(getStoredLuckyDraw(designConfig));
-  if (!ld || ld.enabled !== true) return;
-  assertSingleWinnerDraw(ld, { suffix: ' — the campaign can stay a draft (or paused) but cannot be active.' });
-}
-
-/**
  * Create a new campaign.
  */
 export async function createCampaign(body, user) {
@@ -538,23 +377,8 @@ export async function createCampaign(body, user) {
   // between Campaign.create and the terms pin below still self-heals: the next
   // design_config save re-runs ensureDrawTermsVersion idempotently.)
   if (campaignData.design_config?.luckyDraw?.enabled === true) {
-    if (!campaignData.design_config.luckyDraw.closesAt) {
-      const err = new AppError(
-        'Lucky-draw campaigns need a valid luckyDraw.closesAt (YYYY-MM-DD) before they can be enabled.',
-        422
-      );
-      err.data = { code: 'DRAW_CLOSES_AT_REQUIRED' };
-      throw err;
-    }
-    const terms = getStoredTermsHtml(campaignData.design_config).trim();
-    if (!terms) {
-      const err = new AppError(
-        'Lucky-draw campaigns need Terms & Conditions content (designer → Terms & Conditions) before they can be enabled.',
-        422
-      );
-      err.data = { code: 'DRAW_TERMS_REQUIRED' };
-      throw err;
-    }
+    assertDrawClosesAt(campaignData.design_config.luckyDraw);
+    assertDrawTermsContent(campaignData.design_config);
   }
   // is_active DEFAULTS TO TRUE when omitted (above) — an API create of a
   // multi-prize draw must be an explicit draft (the workspace sends

--- a/backend/src/services/marketplaceService.js
+++ b/backend/src/services/marketplaceService.js
@@ -1,4 +1,5 @@
 import { isValidSlug } from '../utils/slug.js';
+import { DEFAULT_CAMPAIGN_TYPE } from '../utils/campaignTypes.js';
 /**
  * Marketplace read model — the public campaign list/detail behind
  * GET /api/marketplace/campaigns[/:slug] (redeem.sg consumer marketplace).
@@ -217,7 +218,7 @@ export function passesStaticGate(campaign) {
   // / distribution.host — accessors never throw).
   if (getStoredMarketplaceListed(dc) !== true) return false;
   if (getStoredHostChoice(dc) !== 'redeem') return false;
-  const type = campaign.type || 'lead_generation';
+  const type = campaign.type || DEFAULT_CAMPAIGN_TYPE;
   if (!MARKETPLACE_CAMPAIGN_TYPES.includes(type)) return false;
   return true;
 }
@@ -348,7 +349,7 @@ export async function previewMarketplaceCampaign(campaignId, { now = new Date(),
     active: campaign.is_active === true && campaign.status === 'active',
     marketplaceListed: getStoredMarketplaceListed(campaign.design_config) === true,
     redeemHost: getStoredHostChoice(campaign.design_config) === 'redeem',
-    supportedType: MARKETPLACE_CAMPAIGN_TYPES.includes(campaign.type || 'lead_generation'),
+    supportedType: MARKETPLACE_CAMPAIGN_TYPES.includes(campaign.type || DEFAULT_CAMPAIGN_TYPE),
     opsResolvable: !!ops,
   };
   return dto;

--- a/backend/src/utils/campaignTypes.js
+++ b/backend/src/utils/campaignTypes.js
@@ -1,0 +1,50 @@
+/**
+ * THE campaign-type registry (P4-4). Adding a campaign type = one entry here;
+ * every enum site derives: the Sequelize ENUM + default (models/Campaign.js),
+ * both Joi validators (middleware/validation.js), the OpenAPI CampaignType
+ * schema (config/swagger.js), the marketplace-eligible subset (re-exported by
+ * utils/marketplaceContent.js), the AI-drafting type enum + context labels
+ * (routes/adminAi.js / campaignDetailsAiService.js), and the create default.
+ *
+ * Key order matters: it IS the Sequelize ENUM declaration order (test DBs
+ * sync the enum from the model; prod's enum order is owned by migrations).
+ *
+ * Per-type flags:
+ *   marketplace — the campaign can be listed on redeem.sg /offers. quiz and
+ *     guided_review stay false: they have their own qualification funnels the
+ *     generic marketplace flow would silently bypass.
+ *   aiLabel — the context line the AI drafting prompts describe this type with.
+ *
+ * NOTE genuinely type-specific BEHAVIOR stays where it lives (readiness's
+ * quiz/guided-review warnings, funnel rendering) — the registry removes the
+ * scattered enum lists, not per-type product logic.
+ */
+export const CAMPAIGN_TYPES = {
+  lead_generation: { marketplace: true, aiLabel: 'standard lead-generation campaign' },
+  brand_awareness: { marketplace: true, aiLabel: 'brand-awareness campaign' },
+  product_promotion: { marketplace: true, aiLabel: 'product-promotion campaign' },
+  event_marketing: { marketplace: true, aiLabel: 'event-marketing campaign' },
+  quiz: { marketplace: false, aiLabel: 'interactive personality-quiz campaign for paid social' },
+  guided_review: { marketplace: false, aiLabel: 'long-form guided-review campaign that qualifies intent before a consultation' },
+};
+
+export const CAMPAIGN_TYPE_IDS = Object.keys(CAMPAIGN_TYPES);
+
+export const DEFAULT_CAMPAIGN_TYPE = 'lead_generation';
+
+export const MARKETPLACE_CAMPAIGN_TYPES = CAMPAIGN_TYPE_IDS.filter(
+  (id) => CAMPAIGN_TYPES[id].marketplace
+);
+
+/**
+ * The AI drafting surface accepts one PSEUDO-type on top of the real enum:
+ * 'lucky_draw' is not a campaigns.type value (a draw is a lead_generation
+ * campaign with luckyDraw config) but the drafting prompts need its distinct
+ * context, and the workspace create flow offers it as a first-class pick.
+ */
+export const AI_CAMPAIGN_TYPE_IDS = [...CAMPAIGN_TYPE_IDS, 'lucky_draw'];
+
+export const AI_TYPE_LABELS = {
+  ...Object.fromEntries(CAMPAIGN_TYPE_IDS.map((id) => [id, CAMPAIGN_TYPES[id].aiLabel])),
+  lucky_draw: 'lucky-draw campaign (verified entries, one winner pool, optional session boost)',
+};

--- a/backend/src/utils/designConfigV2.js
+++ b/backend/src/utils/designConfigV2.js
@@ -41,33 +41,108 @@
 
 export const DESIGN_CONFIG_VERSION = 2;
 
-export const TEMPLATE_IDS = [
-  'editorial', 'poster', 'split', 'spotlight', 'express', 'journey',
-  // Draw-focused directions (drawTemplates.jsx, design review 2026-07-22).
-  'postcard', 'gazette', 'nightfall', 'stub', 'checklist',
-];
+/** Server/editor length + range limits per v2 key (Phase 5 handoff §01). */
+export const LIMITS = {
+  wordmark: 40, headline: 80, subheadline: 150, story: 1200, emphasis: 160,
+  heroCtaLabel: 40, submitLabel: 40, advertiserName: 60, regulatory: 1000,
+  brand: 80, terms: 10000, dropTitle: 40, dropValue: 12, dropEmoji: 8,
+  mkTitle: 120, mkValue: 80, mkAlt: 120, mkNote: 400, quizIntroH: 80,
+  quizIntroS: 160, quizStart: 40, qPrompt: 140, qOption: 80, pTitle: 40,
+  pDesc: 400, pCta: 40, pAngle: 80,
+  mediaAlt: 120, formWidthMin: 300, formWidthMax: 600, trustLine: 80,
+  // Draw-chrome copy overrides (content.drawCopy — v2-only, dropped on downgrade)
+  drawTrustRow: 80, drawScamLine: 120, drawWinnersNote: 120,
+  drawCtaSubline: 90, drawFreeEntryTag: 40, drawBoostBody: 280,
+  // Submit CTA font size in px (content.submitFontSize — v2-only, L7)
+  submitFontSizeMin: 12, submitFontSizeMax: 24,
+};
+
+/**
+ * THE template registry (P4-4): adding a template = ONE entry here (mirrored
+ * in the twin). Key order IS template order — TEMPLATE_IDS derives from it.
+ *
+ *   draw   — draw-focused direction (drawTemplates.jsx); DRAW_TEMPLATE_IDS
+ *            derives from this flag.
+ *   params — the editor-seed parameter defaults. One bag, every template
+ *            persists its params across switches; first Studio use seeds
+ *            these. Migration seeds the bag but copies editorial.formWidth
+ *            ONLY when v1 stored one (v1's RENDER default when absent is 480,
+ *            not the editor-seed 400 — omitting preserves it).
+ *   rules  — declarative refinements the server clamp interprets on top of
+ *            its generic type-of-default pass (designConfigV2Clamp.js,
+ *            backend-only; the mirror carries them inertly for parity):
+ *              oneOf: [...]        enum membership, else the param default
+ *              maxLen: N           length-capped string, else the default
+ *              range: [min, max]   rounded int clamp; optional: true means
+ *                                  absent/junk DROPS the key entirely
+ *            Params without a rule get generic typing only.
+ */
+export const TEMPLATE_REGISTRY = {
+  editorial: {
+    params: { formWidth: 400, cardStyle: 'raised' },
+    rules: { formWidth: { range: [LIMITS.formWidthMin, LIMITS.formWidthMax], optional: true } },
+  },
+  poster: {
+    params: { overlay: 'dusk', formReveal: 'inline' },
+    rules: { overlay: { oneOf: ['dusk', 'plain'] } },
+  },
+  split: {
+    params: { mediaSide: 'left', mediaFit: 'cover' },
+    rules: { mediaSide: { oneOf: ['left', 'right'] }, mediaFit: { oneOf: ['cover', 'contain'] } },
+  },
+  spotlight: {
+    params: { introStyle: 'immersive', revealArt: 'meter' },
+    rules: { introStyle: { oneOf: ['immersive', 'card'] }, revealArt: { oneOf: ['meter', 'plain'] } },
+  },
+  express: {
+    params: { trustLine: '', storyFold: false },
+    rules: { trustLine: { maxLen: LIMITS.trustLine } },
+  },
+  journey: {
+    params: { sectionRhythm: 'alternate', stickyCta: true },
+    rules: { sectionRhythm: { oneOf: ['alternate', 'stacked'] } },
+  },
+  postcard: {
+    draw: true,
+    params: { mediaSide: 'left', cardStyle: 'float', factStyle: 'numbered' },
+    rules: {
+      mediaSide: { oneOf: ['left', 'right'] },
+      cardStyle: { oneOf: ['float', 'flush'] },
+      factStyle: { oneOf: ['numbered', 'inline'] },
+    },
+  },
+  gazette: {
+    draw: true,
+    params: { ruleDensity: 'airy', accentUse: 'fill', showSerial: true },
+    rules: { ruleDensity: { oneOf: ['airy', 'dense'] }, accentUse: { oneOf: ['text', 'fill'] } },
+  },
+  nightfall: {
+    draw: true,
+    params: { overlayTone: 'ink', showCountdown: true, ctaStyle: 'bar' },
+    rules: { overlayTone: { oneOf: ['dusk', 'ink'] }, ctaStyle: { oneOf: ['bar', 'pill'] } },
+  },
+  stub: {
+    draw: true,
+    params: { ticketTone: 'paper', showSerial: true, stubEdge: 'bottom' },
+    rules: { ticketTone: { oneOf: ['paper', 'accent'] }, stubEdge: { oneOf: ['top', 'bottom'] } },
+  },
+  checklist: {
+    draw: true,
+    params: { boostStep: 'inline', heroBand: true, railStyle: 'line' },
+    rules: { boostStep: { oneOf: ['inline', 'footnote'] }, railStyle: { oneOf: ['line', 'dots'] } },
+  },
+};
+
+export const TEMPLATE_IDS = Object.keys(TEMPLATE_REGISTRY);
 
 /** The draw-focused subset — canonical source for every consumer (PagePanel,
  * AI look gating); drawTemplates.jsx's registry is test-pinned to equal it. */
-export const DRAW_TEMPLATE_IDS = ['postcard', 'gazette', 'nightfall', 'stub', 'checklist'];
+export const DRAW_TEMPLATE_IDS = TEMPLATE_IDS.filter((id) => TEMPLATE_REGISTRY[id].draw === true);
 
-/** Per-template parameter defaults — one bag, every template persists its
- * params across switches; first Studio use seeds these. Migration seeds the
- * bag but copies editorial.formWidth ONLY when v1 stored one (v1's RENDER
- * default when absent is 480, not the editor-seed 400 — omitting preserves it). */
-export const TEMPLATE_PARAM_DEFAULTS = {
-  editorial: { formWidth: 400, cardStyle: 'raised' },
-  poster: { overlay: 'dusk', formReveal: 'inline' },
-  split: { mediaSide: 'left', mediaFit: 'cover' },
-  spotlight: { introStyle: 'immersive', revealArt: 'meter' },
-  express: { trustLine: '', storyFold: false },
-  journey: { sectionRhythm: 'alternate', stickyCta: true },
-  postcard: { mediaSide: 'left', cardStyle: 'float', factStyle: 'numbered' },
-  gazette: { ruleDensity: 'airy', accentUse: 'fill', showSerial: true },
-  nightfall: { overlayTone: 'ink', showCountdown: true, ctaStyle: 'bar' },
-  stub: { ticketTone: 'paper', showSerial: true, stubEdge: 'bottom' },
-  checklist: { boostStep: 'inline', heroBand: true, railStyle: 'line' },
-};
+/** Per-template parameter defaults, derived from the registry (see above). */
+export const TEMPLATE_PARAM_DEFAULTS = Object.fromEntries(
+  TEMPLATE_IDS.map((id) => [id, TEMPLATE_REGISTRY[id].params])
+);
 
 export const THEME_RADIUS_IDS = ['soft', 'sharp', 'round'];
 export const THEME_BACKGROUNDS = ['plain', 'wash', 'grain'];
@@ -100,22 +175,6 @@ export const THEME_PRESETS = [
 ];
 
 export const PRESET_IDS = THEME_PRESETS.map((p) => p.id);
-
-/** Server/editor length + range limits per v2 key (Phase 5 handoff §01). */
-export const LIMITS = {
-  wordmark: 40, headline: 80, subheadline: 150, story: 1200, emphasis: 160,
-  heroCtaLabel: 40, submitLabel: 40, advertiserName: 60, regulatory: 1000,
-  brand: 80, terms: 10000, dropTitle: 40, dropValue: 12, dropEmoji: 8,
-  mkTitle: 120, mkValue: 80, mkAlt: 120, mkNote: 400, quizIntroH: 80,
-  quizIntroS: 160, quizStart: 40, qPrompt: 140, qOption: 80, pTitle: 40,
-  pDesc: 400, pCta: 40, pAngle: 80,
-  mediaAlt: 120, formWidthMin: 300, formWidthMax: 600, trustLine: 80,
-  // Draw-chrome copy overrides (content.drawCopy — v2-only, dropped on downgrade)
-  drawTrustRow: 80, drawScamLine: 120, drawWinnersNote: 120,
-  drawCtaSubline: 90, drawFreeEntryTag: 40, drawBoostBody: 280,
-  // Submit CTA font size in px (content.submitFontSize — v2-only, L7)
-  submitFontSizeMin: 12, submitFontSizeMax: 24,
-};
 
 /** v2 field ids (array order = render order) and the v1 long-id mapping. */
 export const FIELD_IDS = ['name', 'email', 'phone', 'dob', 'postal', 'education', 'salary'];

--- a/backend/src/utils/designConfigV2Clamp.js
+++ b/backend/src/utils/designConfigV2Clamp.js
@@ -36,8 +36,7 @@ import {
   marketplaceToV1,
   PRESET_IDS,
   readLegacyView,
-  TEMPLATE_IDS,
-  TEMPLATE_PARAM_DEFAULTS,
+  TEMPLATE_REGISTRY,
   THEME_BACKGROUNDS,
   THEME_PRESETS,
   THEME_RADIUS_IDS,
@@ -194,11 +193,27 @@ export function getStoredAi(doc) {
 
 // ───────────────────────── v2 subtree clamps ─────────────────────────
 
-function clampTemplate(raw) {
-  const id = cleanEnum(isPlainObject(raw) ? raw.id : undefined, TEMPLATE_IDS, 'editorial');
+/**
+ * Template params clamp — driven ENTIRELY by TEMPLATE_REGISTRY (P4-4). The
+ * generic pass types every param from its default (boolean strict-true,
+ * number via Number(), string via typeof), then the entry's declarative
+ * `rules` refine:
+ *   oneOf  — enum membership, else the param default
+ *   maxLen — length-capped string read from the RAW input, else the default
+ *   range  — [min, max] rounded-integer clamp; `optional: true` means
+ *            absent/junk DROPS the key (the render default applies) instead
+ *            of pinning to a bound (editorial.formWidth's absent-stays-absent
+ *            contract — render default 480, not the editor seed).
+ * Adding a template (or a rule) is one registry entry — nothing here changes.
+ * The registry parameter is a test seam (registry-extension test).
+ */
+export function clampTemplate(raw, registry = TEMPLATE_REGISTRY) {
+  const ids = Object.keys(registry);
+  const id = cleanEnum(isPlainObject(raw) ? raw.id : undefined, ids, ids[0]);
   const incomingParams = isPlainObject(raw) && isPlainObject(raw.params) ? raw.params : {};
   const params = {};
-  for (const [tpl, defaults] of Object.entries(TEMPLATE_PARAM_DEFAULTS)) {
+  for (const [tpl, entry] of Object.entries(registry)) {
+    const defaults = entry.params;
     const inc = isPlainObject(incomingParams[tpl]) ? incomingParams[tpl] : {};
     const out = {};
     for (const [key, def] of Object.entries(defaults)) {
@@ -209,46 +224,17 @@ function clampTemplate(raw) {
         out[key] = Number.isFinite(n) ? n : def;
       } else out[key] = typeof v === 'string' ? v : def;
     }
-    // editorial.formWidth range + express.trustLine length — the only
-    // non-enum params with server limits.
-    if (tpl === 'editorial') {
-      const n = Number(inc.formWidth);
-      if (Number.isFinite(n)) out.formWidth = Math.min(LIMITS.formWidthMax, Math.max(LIMITS.formWidthMin, Math.round(n)));
-      else delete out.formWidth; // absent stays absent (render default 480)
-    }
-    if (tpl === 'poster') out.overlay = cleanEnum(out.overlay, ['dusk', 'plain'], 'dusk');
-    if (tpl === 'split') {
-      out.mediaSide = cleanEnum(out.mediaSide, ['left', 'right'], 'left');
-      out.mediaFit = cleanEnum(out.mediaFit, ['cover', 'contain'], 'cover');
-    }
-    if (tpl === 'spotlight') {
-      out.introStyle = cleanEnum(out.introStyle, ['immersive', 'card'], 'immersive');
-      out.revealArt = cleanEnum(out.revealArt, ['meter', 'plain'], 'meter');
-    }
-    if (tpl === 'express') out.trustLine = cleanString(inc.trustLine, LIMITS.trustLine) ?? '';
-    if (tpl === 'journey') out.sectionRhythm = cleanEnum(out.sectionRhythm, ['alternate', 'stacked'], 'alternate');
-    // Draw-focused templates (drawTemplates.jsx) — booleans (showSerial,
-    // showCountdown, heroBand) are already typed by the generic pass above.
-    if (tpl === 'postcard') {
-      out.mediaSide = cleanEnum(out.mediaSide, ['left', 'right'], 'left');
-      out.cardStyle = cleanEnum(out.cardStyle, ['float', 'flush'], 'float');
-      out.factStyle = cleanEnum(out.factStyle, ['numbered', 'inline'], 'numbered');
-    }
-    if (tpl === 'gazette') {
-      out.ruleDensity = cleanEnum(out.ruleDensity, ['airy', 'dense'], 'airy');
-      out.accentUse = cleanEnum(out.accentUse, ['text', 'fill'], 'fill');
-    }
-    if (tpl === 'nightfall') {
-      out.overlayTone = cleanEnum(out.overlayTone, ['dusk', 'ink'], 'ink');
-      out.ctaStyle = cleanEnum(out.ctaStyle, ['bar', 'pill'], 'bar');
-    }
-    if (tpl === 'stub') {
-      out.ticketTone = cleanEnum(out.ticketTone, ['paper', 'accent'], 'paper');
-      out.stubEdge = cleanEnum(out.stubEdge, ['top', 'bottom'], 'bottom');
-    }
-    if (tpl === 'checklist') {
-      out.boostStep = cleanEnum(out.boostStep, ['inline', 'footnote'], 'inline');
-      out.railStyle = cleanEnum(out.railStyle, ['line', 'dots'], 'line');
+    for (const [key, rule] of Object.entries(entry.rules || {})) {
+      if (rule.oneOf) {
+        out[key] = cleanEnum(out[key], rule.oneOf, defaults[key]);
+      } else if (rule.maxLen !== undefined) {
+        out[key] = cleanString(inc[key], rule.maxLen) ?? defaults[key];
+      } else if (rule.range) {
+        const n = Number(inc[key]);
+        if (Number.isFinite(n)) out[key] = Math.min(rule.range[1], Math.max(rule.range[0], Math.round(n)));
+        else if (rule.optional) delete out[key];
+        else out[key] = defaults[key];
+      }
     }
     params[tpl] = out;
   }

--- a/backend/src/utils/marketplaceContent.js
+++ b/backend/src/utils/marketplaceContent.js
@@ -54,9 +54,10 @@ export const MODES = ['physical', 'online', 'hybrid'];
 export const QR_ENTRIES = ['direct', 'detail'];
 const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
-/** Campaign types that can be marketplace-listed. quiz/guided_review have
- * their own qualification funnels the generic flow would silently bypass. */
-export const MARKETPLACE_CAMPAIGN_TYPES = ['lead_generation', 'brand_awareness', 'product_promotion', 'event_marketing'];
+/** Campaign types that can be marketplace-listed — derived from the type
+ * registry's `marketplace` flag; re-exported here so existing importers keep
+ * their path. */
+export { MARKETPLACE_CAMPAIGN_TYPES } from './campaignTypes.js';
 
 const SLOT_RE = /^\d{2}:\d{2}$/;
 

--- a/backend/test/unit/templateRegistry.test.js
+++ b/backend/test/unit/templateRegistry.test.js
@@ -1,0 +1,111 @@
+import '../setup.js';
+import {
+  TEMPLATE_REGISTRY,
+  TEMPLATE_IDS,
+  DRAW_TEMPLATE_IDS,
+  TEMPLATE_PARAM_DEFAULTS,
+} from '../../src/utils/designConfigV2.js';
+import { clampTemplate } from '../../src/utils/designConfigV2Clamp.js';
+
+/**
+ * P4-4 — the template registry IS the single source: ids, draw subset and
+ * param defaults derive from it, and the server clamp interprets its `rules`
+ * declaratively. The extension test below is the task's success criterion
+ * made durable: a hypothetical new template needs ONE registry entry and
+ * zero code edits anywhere else.
+ */
+
+describe('TEMPLATE_REGISTRY derivations', () => {
+  it('TEMPLATE_IDS is exactly the registry key order', () => {
+    expect(TEMPLATE_IDS).toEqual(Object.keys(TEMPLATE_REGISTRY));
+  });
+
+  it('DRAW_TEMPLATE_IDS is exactly the draw-flagged subset, in order', () => {
+    expect(DRAW_TEMPLATE_IDS).toEqual(
+      Object.keys(TEMPLATE_REGISTRY).filter((id) => TEMPLATE_REGISTRY[id].draw === true)
+    );
+  });
+
+  it('TEMPLATE_PARAM_DEFAULTS is exactly the per-entry params', () => {
+    expect(TEMPLATE_PARAM_DEFAULTS).toEqual(
+      Object.fromEntries(Object.keys(TEMPLATE_REGISTRY).map((id) => [id, TEMPLATE_REGISTRY[id].params]))
+    );
+  });
+
+  it('every rule refines a param that exists (no orphan rules)', () => {
+    for (const [id, entry] of Object.entries(TEMPLATE_REGISTRY)) {
+      for (const key of Object.keys(entry.rules || {})) {
+        expect(Object.keys(entry.params)).toContain(key);
+      }
+    }
+  });
+
+  it('every oneOf rule lists its own default (fallback is always legal)', () => {
+    for (const entry of Object.values(TEMPLATE_REGISTRY)) {
+      for (const [key, rule] of Object.entries(entry.rules || {})) {
+        if (rule.oneOf) expect(rule.oneOf).toContain(entry.params[key]);
+      }
+    }
+  });
+});
+
+describe('clampTemplate interprets rules declaratively', () => {
+  it('enum junk falls back to the param default', () => {
+    const r = clampTemplate({ id: 'poster', params: { poster: { overlay: 'neon-vaporwave' } } });
+    expect(r.params.poster.overlay).toBe('dusk');
+  });
+
+  it('editorial.formWidth: range-clamped when numeric, DROPPED when absent/junk', () => {
+    expect(clampTemplate({ params: { editorial: { formWidth: 9999 } } }).params.editorial.formWidth).toBe(600);
+    expect(clampTemplate({ params: { editorial: { formWidth: 10 } } }).params.editorial.formWidth).toBe(300);
+    expect('formWidth' in clampTemplate({ params: {} }).params.editorial).toBe(false);
+    expect('formWidth' in clampTemplate({ params: { editorial: { formWidth: 'wide' } } }).params.editorial).toBe(false);
+  });
+
+  it('express.trustLine: length-capped from the raw input', () => {
+    const r = clampTemplate({ params: { express: { trustLine: 'x'.repeat(200) } } });
+    expect(r.params.express.trustLine).toHaveLength(80);
+  });
+
+  it('unknown template id falls back to the first registry entry', () => {
+    expect(clampTemplate({ id: 'no-such-template' }).id).toBe('editorial');
+  });
+});
+
+describe('SUCCESS CRITERION — adding a template is one registry entry', () => {
+  // A hypothetical direction, declared exactly the way a real entry would be.
+  // No clamp code, no id list, no defaults bag is touched anywhere.
+  const EXTENDED = {
+    ...TEMPLATE_REGISTRY,
+    neon: {
+      draw: true,
+      params: { glow: 'soft', ticker: true, tagline: '' },
+      rules: { glow: { oneOf: ['soft', 'hard'] }, tagline: { maxLen: 12 } },
+    },
+  };
+
+  it('the new id is accepted and its params clamp per its rules', () => {
+    const r = clampTemplate(
+      {
+        id: 'neon',
+        params: { neon: { glow: 'blinding', ticker: 'yes', tagline: 'way-too-long-tagline', junk: 1 } },
+      },
+      EXTENDED
+    );
+    expect(r.id).toBe('neon');
+    expect(r.params.neon.glow).toBe('soft'); // enum junk → default
+    expect(r.params.neon.ticker).toBe(false); // strict-boolean typing
+    expect(r.params.neon.tagline).toBe('way-too-long'); // maxLen 12
+    expect('junk' in r.params.neon).toBe(false); // unknown params never persist
+  });
+
+  it('the derived views pick the entry up with no other edits', () => {
+    const ids = Object.keys(EXTENDED);
+    expect(ids).toContain('neon');
+    expect(ids.filter((id) => EXTENDED[id].draw === true)).toContain('neon');
+    // Every EXISTING template's clamp output is untouched by the extension.
+    const base = clampTemplate({ id: 'poster', params: {} });
+    const extended = clampTemplate({ id: 'poster', params: {} }, EXTENDED);
+    for (const id of TEMPLATE_IDS) expect(extended.params[id]).toEqual(base.params[id]);
+  });
+});

--- a/src/lib/designConfigV2.js
+++ b/src/lib/designConfigV2.js
@@ -16,33 +16,108 @@
 
 export const DESIGN_CONFIG_VERSION = 2;
 
-export const TEMPLATE_IDS = [
-  'editorial', 'poster', 'split', 'spotlight', 'express', 'journey',
-  // Draw-focused directions (drawTemplates.jsx, design review 2026-07-22).
-  'postcard', 'gazette', 'nightfall', 'stub', 'checklist',
-];
+/** Server/editor length + range limits per v2 key (Phase 5 handoff §01). */
+export const LIMITS = {
+  wordmark: 40, headline: 80, subheadline: 150, story: 1200, emphasis: 160,
+  heroCtaLabel: 40, submitLabel: 40, advertiserName: 60, regulatory: 1000,
+  brand: 80, terms: 10000, dropTitle: 40, dropValue: 12, dropEmoji: 8,
+  mkTitle: 120, mkValue: 80, mkAlt: 120, mkNote: 400, quizIntroH: 80,
+  quizIntroS: 160, quizStart: 40, qPrompt: 140, qOption: 80, pTitle: 40,
+  pDesc: 400, pCta: 40, pAngle: 80,
+  mediaAlt: 120, formWidthMin: 300, formWidthMax: 600, trustLine: 80,
+  // Draw-chrome copy overrides (content.drawCopy — v2-only, dropped on downgrade)
+  drawTrustRow: 80, drawScamLine: 120, drawWinnersNote: 120,
+  drawCtaSubline: 90, drawFreeEntryTag: 40, drawBoostBody: 280,
+  // Submit CTA font size in px (content.submitFontSize — v2-only, L7)
+  submitFontSizeMin: 12, submitFontSizeMax: 24,
+};
+
+/**
+ * THE template registry (P4-4): adding a template = ONE entry here (mirrored
+ * in the twin). Key order IS template order — TEMPLATE_IDS derives from it.
+ *
+ *   draw   — draw-focused direction (drawTemplates.jsx); DRAW_TEMPLATE_IDS
+ *            derives from this flag.
+ *   params — the editor-seed parameter defaults. One bag, every template
+ *            persists its params across switches; first Studio use seeds
+ *            these. Migration seeds the bag but copies editorial.formWidth
+ *            ONLY when v1 stored one (v1's RENDER default when absent is 480,
+ *            not the editor-seed 400 — omitting preserves it).
+ *   rules  — declarative refinements the server clamp interprets on top of
+ *            its generic type-of-default pass (designConfigV2Clamp.js,
+ *            backend-only; the mirror carries them inertly for parity):
+ *              oneOf: [...]        enum membership, else the param default
+ *              maxLen: N           length-capped string, else the default
+ *              range: [min, max]   rounded int clamp; optional: true means
+ *                                  absent/junk DROPS the key entirely
+ *            Params without a rule get generic typing only.
+ */
+export const TEMPLATE_REGISTRY = {
+  editorial: {
+    params: { formWidth: 400, cardStyle: 'raised' },
+    rules: { formWidth: { range: [LIMITS.formWidthMin, LIMITS.formWidthMax], optional: true } },
+  },
+  poster: {
+    params: { overlay: 'dusk', formReveal: 'inline' },
+    rules: { overlay: { oneOf: ['dusk', 'plain'] } },
+  },
+  split: {
+    params: { mediaSide: 'left', mediaFit: 'cover' },
+    rules: { mediaSide: { oneOf: ['left', 'right'] }, mediaFit: { oneOf: ['cover', 'contain'] } },
+  },
+  spotlight: {
+    params: { introStyle: 'immersive', revealArt: 'meter' },
+    rules: { introStyle: { oneOf: ['immersive', 'card'] }, revealArt: { oneOf: ['meter', 'plain'] } },
+  },
+  express: {
+    params: { trustLine: '', storyFold: false },
+    rules: { trustLine: { maxLen: LIMITS.trustLine } },
+  },
+  journey: {
+    params: { sectionRhythm: 'alternate', stickyCta: true },
+    rules: { sectionRhythm: { oneOf: ['alternate', 'stacked'] } },
+  },
+  postcard: {
+    draw: true,
+    params: { mediaSide: 'left', cardStyle: 'float', factStyle: 'numbered' },
+    rules: {
+      mediaSide: { oneOf: ['left', 'right'] },
+      cardStyle: { oneOf: ['float', 'flush'] },
+      factStyle: { oneOf: ['numbered', 'inline'] },
+    },
+  },
+  gazette: {
+    draw: true,
+    params: { ruleDensity: 'airy', accentUse: 'fill', showSerial: true },
+    rules: { ruleDensity: { oneOf: ['airy', 'dense'] }, accentUse: { oneOf: ['text', 'fill'] } },
+  },
+  nightfall: {
+    draw: true,
+    params: { overlayTone: 'ink', showCountdown: true, ctaStyle: 'bar' },
+    rules: { overlayTone: { oneOf: ['dusk', 'ink'] }, ctaStyle: { oneOf: ['bar', 'pill'] } },
+  },
+  stub: {
+    draw: true,
+    params: { ticketTone: 'paper', showSerial: true, stubEdge: 'bottom' },
+    rules: { ticketTone: { oneOf: ['paper', 'accent'] }, stubEdge: { oneOf: ['top', 'bottom'] } },
+  },
+  checklist: {
+    draw: true,
+    params: { boostStep: 'inline', heroBand: true, railStyle: 'line' },
+    rules: { boostStep: { oneOf: ['inline', 'footnote'] }, railStyle: { oneOf: ['line', 'dots'] } },
+  },
+};
+
+export const TEMPLATE_IDS = Object.keys(TEMPLATE_REGISTRY);
 
 /** The draw-focused subset — canonical source for every consumer (PagePanel,
  * AI look gating); drawTemplates.jsx's registry is test-pinned to equal it. */
-export const DRAW_TEMPLATE_IDS = ['postcard', 'gazette', 'nightfall', 'stub', 'checklist'];
+export const DRAW_TEMPLATE_IDS = TEMPLATE_IDS.filter((id) => TEMPLATE_REGISTRY[id].draw === true);
 
-/** Per-template parameter defaults — one bag, every template persists its
- * params across switches; first Studio use seeds these. Migration seeds the
- * bag but copies editorial.formWidth ONLY when v1 stored one (v1's RENDER
- * default when absent is 480, not the editor-seed 400 — omitting preserves it). */
-export const TEMPLATE_PARAM_DEFAULTS = {
-  editorial: { formWidth: 400, cardStyle: 'raised' },
-  poster: { overlay: 'dusk', formReveal: 'inline' },
-  split: { mediaSide: 'left', mediaFit: 'cover' },
-  spotlight: { introStyle: 'immersive', revealArt: 'meter' },
-  express: { trustLine: '', storyFold: false },
-  journey: { sectionRhythm: 'alternate', stickyCta: true },
-  postcard: { mediaSide: 'left', cardStyle: 'float', factStyle: 'numbered' },
-  gazette: { ruleDensity: 'airy', accentUse: 'fill', showSerial: true },
-  nightfall: { overlayTone: 'ink', showCountdown: true, ctaStyle: 'bar' },
-  stub: { ticketTone: 'paper', showSerial: true, stubEdge: 'bottom' },
-  checklist: { boostStep: 'inline', heroBand: true, railStyle: 'line' },
-};
+/** Per-template parameter defaults, derived from the registry (see above). */
+export const TEMPLATE_PARAM_DEFAULTS = Object.fromEntries(
+  TEMPLATE_IDS.map((id) => [id, TEMPLATE_REGISTRY[id].params])
+);
 
 export const THEME_RADIUS_IDS = ['soft', 'sharp', 'round'];
 export const THEME_BACKGROUNDS = ['plain', 'wash', 'grain'];
@@ -75,22 +150,6 @@ export const THEME_PRESETS = [
 ];
 
 export const PRESET_IDS = THEME_PRESETS.map((p) => p.id);
-
-/** Server/editor length + range limits per v2 key (Phase 5 handoff §01). */
-export const LIMITS = {
-  wordmark: 40, headline: 80, subheadline: 150, story: 1200, emphasis: 160,
-  heroCtaLabel: 40, submitLabel: 40, advertiserName: 60, regulatory: 1000,
-  brand: 80, terms: 10000, dropTitle: 40, dropValue: 12, dropEmoji: 8,
-  mkTitle: 120, mkValue: 80, mkAlt: 120, mkNote: 400, quizIntroH: 80,
-  quizIntroS: 160, quizStart: 40, qPrompt: 140, qOption: 80, pTitle: 40,
-  pDesc: 400, pCta: 40, pAngle: 80,
-  mediaAlt: 120, formWidthMin: 300, formWidthMax: 600, trustLine: 80,
-  // Draw-chrome copy overrides (content.drawCopy — v2-only, dropped on downgrade)
-  drawTrustRow: 80, drawScamLine: 120, drawWinnersNote: 120,
-  drawCtaSubline: 90, drawFreeEntryTag: 40, drawBoostBody: 280,
-  // Submit CTA font size in px (content.submitFontSize — v2-only, L7)
-  submitFontSizeMin: 12, submitFontSizeMax: 24,
-};
 
 /** v2 field ids (array order = render order) and the v1 long-id mapping. */
 export const FIELD_IDS = ['name', 'email', 'phone', 'dob', 'postal', 'education', 'salary'];


### PR DESCRIPTION
## .review P4-4 — Split campaignService and make campaign types extensible

Refactor only — behavior unchanged, **zero test modifications** (one new test file). campaignService: 1,336 → 1,117 lines with three focused modules beside it.

### 1. One campaign-type registry (`backend/src/utils/campaignTypes.js`)
Adding a campaign type touched ≥5 files / 7 sites with no registry. Now every site derives from `CAMPAIGN_TYPES`:
- Sequelize ENUM + default (`models/Campaign.js`)
- both Joi validators (`middleware/validation.js`)
- the OpenAPI enum — now a real derived `CampaignType` schema in `config/swagger.js`, `$ref`'d from the route doc instead of a restated comment enum
- `MARKETPLACE_CAMPAIGN_TYPES` (derived from the `marketplace` flag; re-exported from its old `marketplaceContent.js` path so importers keep working)
- the AI drafting enum + prompt-context labels (`adminAi.js` / `campaignDetailsAiService.js`), including the `lucky_draw` **pseudo-type** kept explicit as `AI_CAMPAIGN_TYPE_IDS`
- the create default (service, bootstrap, marketplace/copy-AI fallbacks)

Registry key order = the ENUM declaration order, so test-DB sync shapes are unchanged.

### 2. TEMPLATE_REGISTRY in the designConfigV2 twins
`clampTemplate` was an 11-branch hand-written if-chain. Now `TEMPLATE_REGISTRY` (in **both** twins, applied identically — shared surface diffed byte-identical) holds `{ draw, params, rules }` per template; `TEMPLATE_IDS` / `DRAW_TEMPLATE_IDS` / `TEMPLATE_PARAM_DEFAULTS` derive from it (verified structurally equal to the old literals), and the backend clamp interprets `rules` declaratively (`oneOf` / `maxLen` / `range`+`optional` — the last encodes editorial.formWidth's absent-stays-absent contract).

**Success criterion demonstrated durably**: `test/unit/templateRegistry.test.js` adds a hypothetical `neon` template as ONE registry entry via the clamp's registry seam and proves enum/boolean/length clamping + derived views pick it up with zero code edits — plus derivation identities and rule self-consistency checks. Lockstep + fuzz twin tests untouched and green.

### 3. Draw guards → `campaignDrawGuards.js`
The rail/record ensure hooks, promise-consistency gate, multi-prize activation gate, and `ensureDrawTermsVersion` move out of the service. The `DRAW_CLOSES_AT_REQUIRED` / `DRAW_TERMS_REQUIRED` 422s that were copy-pasted between createCampaign's pre-create block and `ensureDrawTermsVersion` now live once (`assertDrawClosesAt` / `assertDrawTermsContent`) — each site keeps its own **ordering** (the terms pin checks around its live-draw lock; create checks before the row exists), which is a deliberate error-precedence contract. `ensureDrawTermsVersion` / `assertDrawActivatable` / `setEnsureDrawRecord` re-exported from campaignService so existing importers keep their path.

### 4. Query scopes → `campaignScope.js`
`buildCampaignWhere` (visibility) / `buildOwnerWhere` (ownership) extracted verbatim, including the Op.and-nesting comment from the P0-1 leak fix.

### Verification
- Backend + root eslint clean (armed no-undef as the mechanical-refactor net).
- Full unit tier: 124 suites / 2,105 tests green (+1 suite = the new registry test).
- Full frontend vitest: 141 files / 1,779 tests green (lockstep + studio + renderer).
- Full DB tier: 131/132 suites — sole failure `rbac.test.js` "Parse Error" (HTTP-parser transient, same flake class as the known socket-hang-up); **149/149 green re-run in isolation**.
- Campaign/draw domain suites: 313 tests green pre-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y83Mpgkub5nZSD5UBNZM6V