### PR TITLE
fix(prospects): admin assign paths join the transactional outbox (P4-5)

### DIFF
--- a/backend/src/services/prospectAssignmentService.js
+++ b/backend/src/services/prospectAssignmentService.js
@@ -108,61 +108,102 @@ export function makeAssignmentOps({ d, m }) {
         prospect.screeningMetadata?.alreadyCharged === true &&
         prospect.screeningMetadata?.chargeRefunded !== true;
 
-      const [releaseRows] = await d.sequelize.query(
-        `UPDATE prospects
-            SET "assignedAgentId" = :agentId, "lastContactDate" = NOW(),
-                "quarantinedAt" = NULL, "quarantineReason" = NULL, "updatedAt" = NOW()
-          WHERE id = :prospectId AND "quarantinedAt" IS NOT NULL
-          RETURNING id`,
-        { replacements: { agentId, prospectId: prospect.id } }
-      );
-      const released = Array.isArray(releaseRows) && releaseRows.length > 0;
-      await prospect.reload();
+      // Release + delivery intent are ONE transaction (transactional outbox —
+      // the same contract as releaseHeldProspect / returnProspectToHeld):
+      // either the hold clears AND the pending delivery rows exist, or
+      // neither. A crash between the state flip and the dispatch can no
+      // longer strand a released-but-never-queued lead; if the process dies
+      // after commit but before the flush, recoverPendingRetries() sends the
+      // committed rows.
+      const releaseDestination = destinationForAgent(agent);
+      const t = await d.sequelize.transaction();
+      let released = false;
+      let prospectWithCampaign = null;
+      let deliveryPairs = [];
+      try {
+        const [releaseRows] = await d.sequelize.query(
+          `UPDATE prospects
+              SET "assignedAgentId" = :agentId, "lastContactDate" = NOW(),
+                  "quarantinedAt" = NULL, "quarantineReason" = NULL, "updatedAt" = NOW()
+            WHERE id = :prospectId AND "quarantinedAt" IS NOT NULL
+            RETURNING id`,
+          { replacements: { agentId, prospectId: prospect.id }, transaction: t }
+        );
+        released = Array.isArray(releaseRows) && releaseRows.length > 0;
+
+        if (released) {
+          await prospect.reload({ transaction: t });
+
+          await m.ProspectActivity.create({
+            prospectId: prospect.id,
+            type: 'assigned',
+            actorUserId: user?.id || null,
+            description: `Released from hold and assigned to ${agent.firstName} ${agent.lastName}`.trim(),
+            metadata: {
+              assignedAgentId: agentId,
+              previousAgentId,
+              released: true,
+              ...(screeningOverride ? { screeningOverride: true } : {}),
+            },
+          }, { transaction: t });
+
+          prospectWithCampaign = await m.Prospect.findByPk(prospect.id, {
+            include: [
+              { association: 'campaign', attributes: ['id', 'name'] },
+              { association: 'qrTag', attributes: ['id', 'slug'] },
+            ],
+            transaction: t,
+          });
+
+          deliveryPairs = await d.persistEventDeliveries(
+            'lead.assigned',
+            () =>
+              withBatchContext(
+                buildLeadAssignedPayload(prospect, agent, prospectWithCampaign, {
+                  qrTag: prospectWithCampaign?.qrTag || null,
+                  routingMode: 'direct',
+                }),
+                batch
+              ),
+            { destination: releaseDestination },
+            t
+          );
+          // Fail closed (mirrors releaseHeldProspect and the bulk pre-flight):
+          // never release a held lead into a destinationed app we cannot
+          // durably deliver to — roll back so it stays held and visible
+          // instead of vanishing. A destination-less (local-only) agent
+          // expects no delivery and passes.
+          if (releaseDestination && deliveryPairs.length === 0) {
+            await t.rollback();
+            await prospect.reload();
+            throw new d.AppError(
+              "Lead delivery is not configured for this agent's app (webhooks disabled or no subscriber) — releasing this held lead would strand it. Fix webhook configuration and retry.",
+              409
+            );
+          }
+        }
+
+        await t.commit();
+      } catch (err) {
+        if (!t.finished) await t.rollback().catch(() => {});
+        throw err;
+      }
 
       if (!released) {
         // Lost the race — already released elsewhere. Do not double-deliver, and return
         // agent:null so the controller does not email an agent about a lead a concurrent
         // release/sweep already assigned (possibly to a different agent).
+        await prospect.reload();
         return { prospect, agent: null, prospectWithCampaign: prospect };
       }
 
-      await m.ProspectActivity.create({
-        prospectId: prospect.id,
-        type: 'assigned',
-        actorUserId: user?.id || null,
-        description: `Released from hold and assigned to ${agent.firstName} ${agent.lastName}`.trim(),
-        metadata: {
-          assignedAgentId: agentId,
-          previousAgentId,
-          released: true,
-          ...(screeningOverride ? { screeningOverride: true } : {}),
-        },
-      });
-
+      // Post-commit side-effects — never block or roll back the durable release.
       if (!screeningCaptureCharged) {
         await d
           .deductLeadCredit({ agentId, campaignId: prospect.campaignId || null })
           .catch((err) => d.logger.error('Failed to deduct credit', { error: err?.message || String(err) }));
       }
-
-      const prospectWithCampaign = await m.Prospect.findByPk(prospect.id, {
-        include: [
-          { association: 'campaign', attributes: ['id', 'name'] },
-          { association: 'qrTag', attributes: ['id', 'slug'] },
-        ],
-      });
-
-      const releaseDestination = destinationForAgent(agent);
-      d.dispatchEvent('lead.assigned', () =>
-        withBatchContext(
-          buildLeadAssignedPayload(prospect, agent, prospectWithCampaign, {
-            qrTag: prospectWithCampaign?.qrTag || null,
-            routingMode: 'direct',
-          }),
-          batch
-        ),
-        { destination: releaseDestination }
-      );
+      d.flushDeliveries(deliveryPairs);
 
       return { prospect, agent, prospectWithCampaign };
     }
@@ -291,10 +332,18 @@ export function makeAssignmentOps({ d, m }) {
     // cross-app release and leave the other app holding an active copy). RETURNING stays the
     // source of truth for WHICH rows changed, so per-campaign credit counting is exact. We
     // lock WITHOUT the campaign include — FOR UPDATE cannot be applied to the nullable side
-    // of an outer join — and fetch campaign data for the payloads afterwards.
+    // of an outer join — and fetch campaign data for the payloads inside the same
+    // transaction: the delivery rows are persisted IN-transaction too (transactional
+    // outbox, same contract as releaseHeldProspect), so the state flip and the delivery
+    // intent commit or roll back together — a crash after commit can no longer strand
+    // the batch (recoverPendingRetries flushes committed rows), and a crash before it
+    // leaves every lead exactly where it was.
     let result = [0, []];
     const lockedById = new Map();
     let requestedRows = [];
+    let deliveryPairs = [];
+    let full = [];
+    let batch = null;
     await d.sequelize.transaction(async (transaction) => {
       const locked = await m.Prospect.findAll({
         where: whereConditions,
@@ -320,6 +369,85 @@ export function makeAssignmentOps({ d, m }) {
         attributes: ['id', 'assignedAgentId', 'externalAgentId', 'quarantinedAt', 'quarantineReason'],
         transaction,
       });
+
+      // Persist the delivery intent for every newly-assigned lead (bulk-assign previously
+      // fired NO webhook at all, then fired fire-and-forget AFTER the commit — either way
+      // a crash stranded the batch). Mirror the single-assign path: lead.assigned to the
+      // new owner, plus — for a CROSS-app reassignment — lead.unassigned to the previous
+      // owner so its copy in the other app doesn't linger. One batch context for the whole
+      // fan-out: the mktr-leads receiver coalesces the N per-lead pushes into a single
+      // "{size} leads assigned to you" summary (Lyfe ignores batch for now).
+      const affectedNow = result[0];
+      const rowsNow = result[1] || [];
+      if (affectedNow > 0) {
+        batch = affectedNow > 1 ? { id: randomUUID(), size: affectedNow } : null;
+        const affectedIds = rowsNow.map((row) => row.id);
+        full = await m.Prospect.findAll({
+          where: { id: { [Op.in]: affectedIds } },
+          include: [
+            { association: 'campaign', attributes: ['id', 'name'] },
+            { association: 'qrTag', attributes: ['id', 'slug'] },
+          ],
+          transaction,
+        });
+
+        const prevOwnerIds = [
+          ...new Set(
+            affectedIds
+              .map((id) => lockedById.get(id)?.assignedAgentId)
+              .filter((prevId) => prevId && prevId !== agentId)
+          ),
+        ];
+        const prevAgentById = new Map();
+        if (prevOwnerIds.length > 0) {
+          const prevAgents = await m.User.findAll({
+            where: { id: { [Op.in]: prevOwnerIds } },
+            attributes: ['id', 'lyfeId', 'mktrLeadsId'],
+            transaction,
+          });
+          for (const a of prevAgents) prevAgentById.set(a.id, a);
+        }
+
+        for (const p of full) {
+          const pairs = await d.persistEventDeliveries(
+            'lead.assigned',
+            () =>
+              withBatchContext(
+                buildLeadAssignedPayload(p, agent, p, { qrTag: p.qrTag || null, routingMode: 'direct' }),
+                batch
+              ),
+            { destination: newDestination },
+            transaction
+          );
+          // Fail closed: the pre-flight above vouched a subscriber existed; if it
+          // vanished mid-flight (disabled between the check and this write), roll the
+          // whole batch back — assigned-in-MKTR-but-never-surfaced is the exact state
+          // this outbox exists to prevent. Destination-less agents expect no delivery.
+          if (newDestination && pairs.length === 0) {
+            throw new d.AppError(
+              "Lead delivery is not configured for this agent's app (webhooks disabled or no subscriber) — bulk assign would strand the leads. Fix webhook configuration and retry.",
+              409
+            );
+          }
+          deliveryPairs.push(...pairs);
+
+          const prevId = lockedById.get(p.id)?.assignedAgentId;
+          const prevAgent = prevId && prevId !== agentId ? prevAgentById.get(prevId) : null;
+          if (prevAgent) {
+            const prevDestination = destinationForAgent(prevAgent);
+            if (prevDestination && prevDestination !== newDestination) {
+              const previousAgentExternalId = externalIdForDestination(prevAgent, prevDestination);
+              const unPairs = await d.persistEventDeliveries(
+                'lead.unassigned',
+                () => buildLeadUnassignedPayload(p, previousAgentExternalId),
+                { destination: prevDestination },
+                transaction
+              );
+              deliveryPairs.push(...unPairs);
+            }
+          }
+        }
+      }
     });
 
     const affectedCount = result[0];
@@ -362,61 +490,8 @@ export function makeAssignmentOps({ d, m }) {
           .catch((err) => d.logger.error('Failed to deduct credits', { error: err?.message || String(err) }));
       }
 
-      // Deliver each newly-assigned lead (bulk-assign previously fired NO webhook at all, so
-      // bulk-assigned leads never reached the agent's app). Mirror the single-assign path:
-      // lead.assigned to the new owner, plus — for a CROSS-app reassignment — lead.unassigned
-      // to the previous owner so its copy in the other app doesn't linger. Payload rows are
-      // fetched with their campaign; previous owners come from the locked snapshot.
-      // One batch context for the whole fan-out: the mktr-leads receiver coalesces the N
-      // per-lead pushes into a single "{size} leads assigned to you" summary (Lyfe ignores
-      // batch for now — per-lead pushes, the pre-batch behavior).
-      const batch = affectedCount > 1 ? { id: randomUUID(), size: affectedCount } : null;
-      const affectedIds = affectedRows.map((row) => row.id);
-      const full = await m.Prospect.findAll({
-        where: { id: { [Op.in]: affectedIds } },
-        include: [
-          { association: 'campaign', attributes: ['id', 'name'] },
-          { association: 'qrTag', attributes: ['id', 'slug'] },
-        ],
-      });
-
-      const prevOwnerIds = [
-        ...new Set(
-          affectedIds
-            .map((id) => lockedById.get(id)?.assignedAgentId)
-            .filter((prevId) => prevId && prevId !== agentId)
-        ),
-      ];
-      const prevAgentById = new Map();
-      if (prevOwnerIds.length > 0) {
-        const prevAgents = await m.User.findAll({
-          where: { id: { [Op.in]: prevOwnerIds } },
-          attributes: ['id', 'lyfeId', 'mktrLeadsId'],
-        });
-        for (const a of prevAgents) prevAgentById.set(a.id, a);
-      }
-
-      for (const p of full) {
-        d.dispatchEvent('lead.assigned', () =>
-          withBatchContext(
-            buildLeadAssignedPayload(p, agent, p, { qrTag: p.qrTag || null, routingMode: 'direct' }),
-            batch
-          ),
-          { destination: newDestination }
-        );
-
-        const prevId = lockedById.get(p.id)?.assignedAgentId;
-        const prevAgent = prevId && prevId !== agentId ? prevAgentById.get(prevId) : null;
-        if (prevAgent) {
-          const prevDestination = destinationForAgent(prevAgent);
-          if (prevDestination && prevDestination !== newDestination) {
-            const previousAgentExternalId = externalIdForDestination(prevAgent, prevDestination);
-            d.dispatchEvent('lead.unassigned', () => buildLeadUnassignedPayload(p, previousAgentExternalId), {
-              destination: prevDestination,
-            });
-          }
-        }
-      }
+      // The delivery rows committed with the assignment — send them now.
+      d.flushDeliveries(deliveryPairs);
 
       // Log a ProspectActivity per newly-assigned lead so BULK assignment lands on the unified
       // timeline too — single-assign already logs (assignProspect), this path historically wrote

--- a/backend/test/integration/assignOutbox.test.js
+++ b/backend/test/integration/assignOutbox.test.js
@@ -1,0 +1,218 @@
+/**
+ * P4-5 — the admin assign paths are a transactional outbox.
+ *
+ * assignProspect's held-release and bulkAssignProspects used to flip state in
+ * an autocommit UPDATE and fire the webhook AFTER — a crash in between left a
+ * lead released-from-hold but never queued for delivery, invisibly. These
+ * tests pin the converged contract against real Postgres:
+ *
+ *   1. ATOMICITY — any failure between the state flip and the delivery-row
+ *      write (the crash window) rolls the release back: the lead stays held.
+ *   2. FAIL-CLOSED — a held lead is never released toward a destinationed app
+ *      that has no deliverable subscriber (409, hold intact) — the same
+ *      'undeliverable' contract releaseHeldProspect already had.
+ *   3. DURABILITY + RECOVERY — the delivery rows commit WITH the release, so
+ *      a crash after commit but before the flush leaves pending rows that
+ *      recoverPendingRetries() (the startup/60s poller) actually delivers.
+ */
+import { jest } from '@jest/globals';
+import {
+  getApp, closeDb,
+  createTestUser, createTestCampaign, createTestProspect,
+} from '../helpers.js';
+import { sequelize, ProspectActivity, WebhookSubscriber, WebhookDelivery } from '../../src/models/index.js';
+import { makeProspectService } from '../../src/services/prospectService.js';
+import { makeWebhookService } from '../../src/services/webhookService.js';
+
+const RUN = Date.now();
+
+let adminUser;
+let lyfeAgent;   // destinationed (lyfeId) — deliveries expected
+let campaign;
+let origWebhookEnabled;
+
+const admin = () => ({ id: adminUser.id, role: 'admin' });
+
+const heldProspect = () =>
+  createTestProspect(campaign.id, {
+    quarantinedAt: new Date(),
+    quarantineReason: 'returned_by_admin',
+    assignedAgentId: null,
+  });
+
+const deliveriesForLead = async (prospectId) =>
+  (await WebhookDelivery.findAll({ where: { eventType: 'lead.assigned' } }))
+    .filter((row) => row.payload?.data?.lead?.externalId === prospectId);
+
+beforeAll(async () => {
+  origWebhookEnabled = process.env.WEBHOOK_ENABLED;
+  await getApp();
+  adminUser = (await createTestUser({ role: 'admin' })).user;
+  lyfeAgent = (await createTestUser({
+    role: 'agent',
+    firstName: 'Outbox',
+    lastName: 'Agent',
+    lyfeId: `lyfe-outbox-${RUN}`,
+    phone: `+6591${String(RUN).slice(-6)}`,
+  })).user;
+  campaign = await createTestCampaign(adminUser.id, { name: `Outbox Test ${RUN}` });
+});
+
+afterAll(async () => {
+  process.env.WEBHOOK_ENABLED = origWebhookEnabled;
+  await closeDb();
+});
+
+afterEach(() => {
+  process.env.WEBHOOK_ENABLED = 'false';
+});
+
+describe('assignProspect held release — transactional outbox', () => {
+  it('rolls the release back when the process dies in the flip→dispatch window (lead stays held)', async () => {
+    const prospect = await heldProspect();
+    const svc = makeProspectService({
+      persistEventDeliveries: async () => {
+        throw new Error('simulated crash before the delivery rows were written');
+      },
+    });
+
+    await expect(svc.assignProspect(prospect.id, lyfeAgent.id, admin())).rejects.toThrow('simulated crash');
+
+    // The old code would have left the hold cleared with nothing queued —
+    // the exact stranding this outbox exists to prevent.
+    await prospect.reload();
+    expect(prospect.quarantinedAt).not.toBeNull();
+    expect(prospect.quarantineReason).toBe('returned_by_admin');
+    expect(prospect.assignedAgentId).toBeNull();
+
+    // The in-transaction activity row rolled back with it.
+    const acts = await ProspectActivity.findAll({ where: { prospectId: prospect.id, type: 'assigned' } });
+    expect(acts).toHaveLength(0);
+  });
+
+  it('fails closed (409) and keeps the hold when the destination has no deliverable subscriber', async () => {
+    process.env.WEBHOOK_ENABLED = 'true'; // enabled, but no lyfe-tagged subscriber exists
+    const prospect = await heldProspect();
+    const svc = makeProspectService();
+
+    await expect(svc.assignProspect(prospect.id, lyfeAgent.id, admin())).rejects.toMatchObject({
+      statusCode: 409,
+    });
+
+    await prospect.reload();
+    expect(prospect.quarantinedAt).not.toBeNull();
+    expect(prospect.assignedAgentId).toBeNull();
+  });
+
+  it('commits the delivery rows with the release; a crash before the flush is recovered by the poller', async () => {
+    process.env.WEBHOOK_ENABLED = 'true';
+    const subscriber = await WebhookSubscriber.create({
+      name: `Lyfe Outbox ${RUN}`,
+      url: `http://127.0.0.1:9/outbox-${RUN}`, // never actually hit — fetch is mocked below
+      secret: 'outbox-test-secret',
+      events: ['lead.assigned'],
+      enabled: true,
+      metadata: { destination: 'lyfe' },
+    });
+    try {
+      const prospect = await heldProspect();
+      // "Crash" after commit, before the fire-and-forget send: suppress the flush.
+      const svc = makeProspectService({ flushDeliveries: () => {} });
+
+      const res = await svc.assignProspect(prospect.id, lyfeAgent.id, admin());
+      expect(res.agent?.id).toBe(lyfeAgent.id);
+
+      await prospect.reload();
+      expect(prospect.quarantinedAt).toBeNull();
+      expect(prospect.assignedAgentId).toBe(lyfeAgent.id);
+
+      // The delivery intent survived the "crash": a pending row committed with the release.
+      const rows = await deliveriesForLead(prospect.id);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].status).toBe('pending');
+      expect(rows[0].attempts).toBe(0);
+
+      // Make the row look stale (the poller's stranded-first-attempt clause:
+      // status pending, nextRetryAt null, createdAt > 60s old) — raw SQL, since
+      // Sequelize silently drops createdAt writes.
+      await sequelize.query(
+        `UPDATE webhook_deliveries SET "createdAt" = NOW() - INTERVAL '2 minutes' WHERE id = :id`,
+        { replacements: { id: rows[0].id } }
+      );
+
+      // The recovery poller (runs at startup + every 60s in prod) picks it up and delivers.
+      const fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+      const wh = makeWebhookService({ fetch: fetchMock });
+      await wh.recoverPendingRetries();
+      // enqueueDelivery is fire-and-forget — wait for the attempt to land.
+      const delivery = rows[0];
+      for (let i = 0; i < 40 && (await delivery.reload()).status === 'pending'; i++) {
+        await new Promise((r) => setTimeout(r, 100));
+      }
+
+      expect(fetchMock).toHaveBeenCalledWith(subscriber.url, expect.objectContaining({ method: 'POST' }));
+      expect(delivery.status).toBe('success');
+      expect(delivery.attempts).toBe(1);
+    } finally {
+      await WebhookDelivery.destroy({ where: { subscriberId: subscriber.id } });
+      await subscriber.destroy();
+    }
+  });
+});
+
+describe('bulkAssignProspects — transactional outbox', () => {
+  it('rolls the WHOLE batch back when the process dies in the flip→dispatch window', async () => {
+    const held = await heldProspect();
+    const fresh = await createTestProspect(campaign.id);
+    const svc = makeProspectService({
+      hasDeliverableSubscriber: async () => true, // pre-flight passes; the crash happens after the flip
+      persistEventDeliveries: async () => {
+        throw new Error('simulated crash before the delivery rows were written');
+      },
+    });
+
+    await expect(svc.bulkAssignProspects([held.id, fresh.id], lyfeAgent.id, admin())).rejects.toThrow(
+      'simulated crash'
+    );
+
+    await held.reload();
+    await fresh.reload();
+    expect(held.quarantinedAt).not.toBeNull();
+    expect(held.assignedAgentId).toBeNull();
+    expect(fresh.assignedAgentId).toBeNull();
+    expect(await deliveriesForLead(held.id)).toHaveLength(0);
+    expect(await deliveriesForLead(fresh.id)).toHaveLength(0);
+  });
+
+  it('persists one pending delivery per assigned lead inside the assignment transaction', async () => {
+    process.env.WEBHOOK_ENABLED = 'true';
+    const subscriber = await WebhookSubscriber.create({
+      name: `Lyfe Outbox Bulk ${RUN}`,
+      url: `http://127.0.0.1:9/outbox-bulk-${RUN}`,
+      secret: 'outbox-test-secret',
+      events: ['lead.assigned'],
+      enabled: true,
+      metadata: { destination: 'lyfe' },
+    });
+    try {
+      const a = await heldProspect();
+      const b = await createTestProspect(campaign.id);
+      const svc = makeProspectService({ flushDeliveries: () => {} }); // crash after commit
+
+      const res = await svc.bulkAssignProspects([a.id, b.id], lyfeAgent.id, admin());
+      expect(res.affectedCount).toBe(2);
+      expect(res.releasedCount).toBe(1);
+
+      for (const p of [a, b]) {
+        const rows = await deliveriesForLead(p.id);
+        expect(rows).toHaveLength(1);
+        expect(rows[0].status).toBe('pending');
+        // Batch context rode into the committed payload (receiver-side coalescing).
+        expect(rows[0].payload?.data?.batch).toEqual({ id: expect.any(String), size: 2 });
+      }
+    } finally {
+      await WebhookDelivery.destroy({ where: { subscriberId: subscriber.id } });
+      await subscriber.destroy();
+    }
+  });
+});

--- a/backend/test/prospectServiceBulkOps.test.js
+++ b/backend/test/prospectServiceBulkOps.test.js
@@ -122,8 +122,12 @@ describe('bulkAssignProspects — held release, batch context, skip accounting',
     expect(updateArgs).toMatchObject({ assignedAgentId: 'agent-1', quarantinedAt: null, quarantineReason: null });
 
     // Every delivery is lead.assigned, batch-stamped, with qrTag + routing.mode parity.
-    const assignedCalls = deps.dispatchEvent.mock.calls.filter(([evt]) => evt === 'lead.assigned');
+    // P4-5: deliveries are persisted IN the assignment transaction (transactional
+    // outbox) and flushed after commit — assert the persist seam, not dispatchEvent.
+    const assignedCalls = deps.persistEventDeliveries.mock.calls.filter(([evt]) => evt === 'lead.assigned');
     expect(assignedCalls).toHaveLength(2);
+    for (const call of assignedCalls) expect(call[3]).toBeDefined(); // rode the txn
+    expect(deps.flushDeliveries).toHaveBeenCalled(); // sent only after commit
     const payloads = assignedCalls.map(([, builder]) => builder());
     for (const p of payloads) {
       expect(p.event).toBe('lead.assigned');
@@ -137,6 +141,7 @@ describe('bulkAssignProspects — held release, batch context, skip accounting',
       ])
     );
     expect(deps.dispatchEvent.mock.calls.some(([evt]) => evt === 'lead.created')).toBe(false);
+    expect(deps.persistEventDeliveries.mock.calls.some(([evt]) => evt === 'lead.created')).toBe(false);
 
     // Released row's activity is flagged for the timeline.
     const activityRows = deps.models.ProspectActivity.bulkCreate.mock.calls[0][0];
@@ -360,11 +365,16 @@ describe('assignProspect held release fires lead.assigned (never lead.created)',
 
     await svc.assignProspect('p1', 'agent-1', ADMIN);
 
-    const events = deps.dispatchEvent.mock.calls.map(([evt]) => evt);
+    // P4-5: the held release persists its delivery inside the release
+    // transaction (transactional outbox) and flushes post-commit.
+    const events = deps.persistEventDeliveries.mock.calls.map(([evt]) => evt);
     expect(events).toContain('lead.assigned');
     expect(events).not.toContain('lead.created');
-    const [, builder, opts] = deps.dispatchEvent.mock.calls.find(([evt]) => evt === 'lead.assigned');
+    expect(deps.dispatchEvent.mock.calls.map(([evt]) => evt)).not.toContain('lead.created');
+    const [, builder, opts, txn] = deps.persistEventDeliveries.mock.calls.find(([evt]) => evt === 'lead.assigned');
     expect(opts).toEqual({ destination: 'lyfe' });
+    expect(txn).toBeDefined(); // rode the release transaction
+    expect(deps.flushDeliveries).toHaveBeenCalled();
     const payload = builder();
     expect(payload.data.routing.mode).toBe('direct');
     expect(payload.data.qrTag).toEqual({ externalId: 'q1', slug: 's1' });

--- a/backend/test/unit/prospectAssignment.test.js
+++ b/backend/test/unit/prospectAssignment.test.js
@@ -93,7 +93,7 @@ function buildMocks() {
   };
 
   const sequelize = {
-    transaction: jest.fn(async (callback) => callback(mockTransaction)),
+    transaction: jest.fn(async (callback) => (typeof callback === 'function' ? callback(mockTransaction) : mockTransaction)),
     query: jest.fn().mockResolvedValue([[{ id: 'prospect-1' }]]),
     fn: jest.fn((fnName, col) => `${fnName}(${col})`),
     col: jest.fn((name) => name),
@@ -106,6 +106,10 @@ function buildMocks() {
   const chargeLeadCredit = jest.fn().mockResolvedValue(true);
   const buildProspectWhere = jest.fn().mockResolvedValue({});
   const dispatchEvent = jest.fn().mockResolvedValue(undefined);
+  // P4-5: held-release + bulk persist deliveries inside their transaction
+  // (transactional outbox) and flush after commit.
+  const persistEventDeliveries = jest.fn().mockResolvedValue([{ delivery: {}, subscriber: {} }]);
+  const flushDeliveries = jest.fn();
   // Bulk assign's webhook pre-flight — deliverable by default so assignment tests
   // exercise the assignment logic, not the misconfig guard.
   const hasDeliverableSubscriber = jest.fn().mockResolvedValue(true);
@@ -138,6 +142,8 @@ function buildMocks() {
     chargeLeadCredit,
     buildProspectWhere,
     dispatchEvent,
+    persistEventDeliveries,
+    flushDeliveries,
     hasDeliverableSubscriber,
     AppError,
     logger,
@@ -154,6 +160,8 @@ function makeService(mocks, overrides = {}) {
     chargeLeadCredit: mocks.chargeLeadCredit,
     buildProspectWhere: mocks.buildProspectWhere,
     dispatchEvent: mocks.dispatchEvent,
+    persistEventDeliveries: mocks.persistEventDeliveries,
+    flushDeliveries: mocks.flushDeliveries,
     hasDeliverableSubscriber: mocks.hasDeliverableSubscriber,
     AppError: mocks.AppError,
     logger: mocks.logger,
@@ -372,11 +380,15 @@ describe('prospectAssignment (unit)', () => {
 
       expect(mocks.sequelize.query).toHaveBeenCalled();
       expect(mocks.deductLeadCredit).toHaveBeenCalledWith({ agentId: 'agent-1', campaignId: 'camp-1' });
-      expect(mocks.dispatchEvent).toHaveBeenCalledWith('lead.assigned', expect.any(Function), expect.objectContaining({ destination: 'lyfe' }));
+      // P4-5: the release persists its delivery inside the release transaction
+      // (transactional outbox) — assert the persist seam, flushed post-commit.
+      expect(mocks.persistEventDeliveries).toHaveBeenCalledWith('lead.assigned', expect.any(Function), expect.objectContaining({ destination: 'lyfe' }), mocks.mockTransaction);
+      expect(mocks.flushDeliveries).toHaveBeenCalled();
       expect(mocks.dispatchEvent).not.toHaveBeenCalledWith('lead.created', expect.any(Function), expect.anything());
+      expect(mocks.persistEventDeliveries).not.toHaveBeenCalledWith('lead.created', expect.any(Function), expect.anything(), expect.anything());
       // Insert-parity payload: the destination app may not know this lead yet, so the
       // assigned payload carries the created payload's qrTag block + routing.mode.
-      const builder = mocks.dispatchEvent.mock.calls.find((c) => c[0] === 'lead.assigned')[1];
+      const builder = mocks.persistEventDeliveries.mock.calls.find((c) => c[0] === 'lead.assigned')[1];
       const payload = builder();
       expect(payload.data.qrTag).toEqual({ externalId: 'qr-9', slug: 'sl' });
       expect(payload.data.routing.mode).toBe('direct');
@@ -451,9 +463,11 @@ describe('prospectAssignment (unit)', () => {
 
       await service.bulkAssignProspects(['p-1', 'p-2'], 'agent-1', admin);
 
-      const assignedCalls = mocks.dispatchEvent.mock.calls.filter((c) => c[0] === 'lead.assigned');
+      // P4-5: bulk persists per-lead deliveries inside the assignment transaction.
+      const assignedCalls = mocks.persistEventDeliveries.mock.calls.filter((c) => c[0] === 'lead.assigned');
       expect(assignedCalls).toHaveLength(2);
-      expect(mocks.dispatchEvent).toHaveBeenCalledWith('lead.assigned', expect.any(Function), expect.objectContaining({ destination: 'lyfe' }));
+      expect(mocks.persistEventDeliveries).toHaveBeenCalledWith('lead.assigned', expect.any(Function), expect.objectContaining({ destination: 'lyfe' }), expect.anything());
+      expect(mocks.flushDeliveries).toHaveBeenCalled();
     });
 
     it('logs a ProspectActivity per bulk-assigned lead (so bulk assignment is on the timeline)', async () => {

--- a/backend/test/unit/prospectServiceScreening.test.js
+++ b/backend/test/unit/prospectServiceScreening.test.js
@@ -74,6 +74,9 @@ function buildDeps(overrides = {}) {
     getOrCreateProspectShareLink: jest.fn().mockResolvedValue({ url: '/share/x' }),
     buildProspectWhere: jest.fn().mockResolvedValue({}),
     dispatchEvent: jest.fn().mockResolvedValue(),
+    // P4-5: the held release persists its delivery inside the release txn.
+    persistEventDeliveries: jest.fn().mockResolvedValue([{ delivery: {}, subscriber: {} }]),
+    flushDeliveries: jest.fn(),
     onLeadCaptured: jest.fn().mockResolvedValue(),
     sendLeadEvent: jest.fn().mockResolvedValue({ sent: false }),
     sendCompleteRegistrationEvent: jest.fn().mockResolvedValue({ sent: false }),
@@ -261,7 +264,7 @@ describe('assignProspect — screening release override (deduct-skip, Codex #2)'
     expect(deps.deductLeadCredit).not.toHaveBeenCalled();
     const activity = deps.models.ProspectActivity.create.mock.calls[0][0];
     expect(activity.metadata.screeningOverride).toBe(true);
-    expect(deps.dispatchEvent.mock.calls.map((c) => c[0])).toContain('lead.assigned');
+    expect(deps.persistEventDeliveries.mock.calls.map((c) => c[0])).toContain('lead.assigned');
   });
 
   it('refunded screening_failed override deducts normally (single-charge invariant)', async () => {


### PR DESCRIPTION
## .review P4-5 — Converge admin assign paths onto the transactional outbox

The sibling release paths (releaseHeldProspect, returnProspectToHeld, deleteProspect, the DNC gate, the auto release-sweep) already write their `webhook_deliveries` rows INSIDE the state-flip transaction and flush after commit. The two admin paths did not: `assignProspect`'s held-release cleared the hold with an autocommit UPDATE and fired `dispatchEvent` after; `bulkAssignProspects` committed its batch UPDATE and dispatched per-row afterwards. A crash in between left leads released-from-hold but never queued for delivery — invisible, because nothing knew they should have been sent.

### What changed (`prospectAssignmentService.js`)
- **assignProspect held-release**: the conditional release UPDATE, activity row, payload fetch and `persistEventDeliveries(…, t)` are now one transaction; `flushDeliveries` runs post-commit (credit deduction stays post-commit best-effort, as the siblings do). **Fail-closed**: releasing a held lead toward a destinationed app with no deliverable subscriber rolls back with the same 409 the bulk pre-flight uses — the lead stays held and visible instead of vanishing. Destination-less (local-only) agents expect no delivery and pass, exactly like the bulk pre-flight.
- **bulkAssignProspects**: the per-lead `lead.assigned` (+ cross-app `lead.unassigned`) rows are persisted inside the existing lock-and-update transaction; the whole batch rolls back if the pre-flight's subscriber vanished mid-flight. Flush after commit. Response contracts (affectedCount/releasedCount/skipped, `{prospect, agent, prospectWithCampaign}`) unchanged; activity logging stays post-commit best-effort by design.

### Crash-window proof (`test/integration/assignOutbox.test.js`, real Postgres, 5 tests)
1. **Atomicity** — a simulated death between the flip and the delivery-row write rolls the release back: hold intact, no activity row, no delivery row (single + bulk).
2. **Fail-closed** — undeliverable destination → 409, hold intact.
3. **Durability + recovery** — with the flush suppressed ("crash after commit"), the release lands with a committed `pending` delivery row; after backdating it past the 60s threshold, **`recoverPendingRetries()` (the startup/60s poller) picks it up and delivers it** (mocked-200 fetch; row flips to `success`).

### Audit — remaining flip-state-then-dispatch-outside-txn sites (reported, not changed here)
| Site | Event(s) | Exposure if the process dies in the window |
|---|---|---|
| `prospectService.js` createProspect (~1176, ~1204) | lead.created / lead.held | captured lead committed but never queued — assigned leads would not reach the agent's app (admin still sees them) |
| `retellService.js` (~413, ~449) | lead.created / lead.held | same class, Retell captures |
| `prospectAssignmentService.js` unassign path (~54) | lead.unassigned | cross-app cosmetic drift: other app keeps a stale active copy |
| `prospectAssignmentService.js` normal reassign (~238, ~263) | lead.assigned / lead.unassigned | reassignment invisible to the new agent's app until the next event; lead never invisible (both apps hold a row) |

The capture paths (rows 1–2) are the ones worth converging next; the two assignment leftovers are drift-not-loss. All other hold-clearing paths verified already-outbox.

### Verification
- Unit-test fixtures whose assertions pinned the OLD mechanism (mock `dispatchEvent`) now assert the outbox seam (`persistEventDeliveries` + txn arg + `flushDeliveries`); payload/contract assertions unchanged.
- Backend + root eslint clean. Full unit tier 124 suites / 2,105 green. **Full DB tier 133 suites / 2,437 green (zero flakes).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y83Mpgkub5nZSD5UBNZM6V