### PR TITLE
refactor(pipeline): dedupe lead-routing + ad-event mirrors (P4-9)

### DIFF
--- a/backend/src/services/dncGate.js
+++ b/backend/src/services/dncGate.js
@@ -259,4 +259,20 @@ export async function gateHeldDncLead(prospect, overrides = {}) {
   return { outcome: 'held', status: result.status };
 }
 
+/**
+ * Capture-time DNC gate facts (P4-9): the five-line mode/number/applies
+ * computation createProspect and retellService each hand-rolled. 'off' unless
+ * scrubbing is configured AND the campaign opted in
+ * (design_config.dncCheckAtSubmit) AND the number is in DNC scope — scopes
+ * paid DNC API spend to opted-in campaigns; the global enforcement mode
+ * (block/flag) applies on top. `deps` = the caller's DI pair.
+ */
+export function dncCaptureGate(designView, phone, { dncEnforcement, formatDncNumber }) {
+  const dncMode = designView?.dncCheckAtSubmit === true ? dncEnforcement() : 'off';
+  const dncNumber = dncMode !== 'off' && phone ? formatDncNumber(phone) : null;
+  const dncBlockApplies = dncMode === 'block' && !!dncNumber;
+  const dncFlagApplies = dncMode === 'flag' && !!dncNumber;
+  return { dncMode, dncNumber, dncBlockApplies, dncFlagApplies, dncWillCheck: dncBlockApplies || dncFlagApplies };
+}
+
 export default { releaseDncClearedLead, gateHeldDncLead };

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -23,7 +23,7 @@ import {
 import { deductLeadCredit, chargeLeadCredit, deductExternalLeadBalance } from './leadCredits.js';
 import { decideAssignment } from './leadQuota.js';
 import { dncEnforcement, formatDncNumber, checkAndRecord as dncCheckAndRecord } from './dncService.js';
-import { gateHeldDncLead } from './dncGate.js';
+import { gateHeldDncLead, dncCaptureGate } from './dncGate.js';
 import { hasValidExternalConsent, buildExternalConsentEvidence } from './externalConsent.js';
 import { buildDncConsentEvidence } from './dncConsent.js';
 import { buildProspectWhere } from './prospectScope.js';
@@ -554,11 +554,9 @@ export function makeProspectService(overrides = {}) {
     // Per-campaign gate: only campaigns that opted in (design_config.dncCheckAtSubmit) ever
     // hit the paid DNC API — scopes credit spend (and the public create endpoint's exposure)
     // to opted-in campaigns. The global enforcement mode (block/flag) still applies on top.
-    const dncMode = sourceDesign.dncCheckAtSubmit === true ? d.dncEnforcement() : 'off';
-    const dncNumber = dncMode !== 'off' && incoming.phone ? d.formatDncNumber(incoming.phone) : null;
-    const dncBlockApplies = dncMode === 'block' && !!dncNumber;
-    const dncFlagApplies = dncMode === 'flag' && !!dncNumber;
-    const dncWillCheck = dncBlockApplies || dncFlagApplies;
+    const { dncBlockApplies, dncFlagApplies, dncWillCheck } = dncCaptureGate(
+      sourceDesign, incoming.phone, { dncEnforcement: d.dncEnforcement, formatDncNumber: d.formatDncNumber }
+    );
 
     // AI screening gate (docs/plans/retell-screening-calls.md §5): evaluated on
     // the INCOMING payload (the verified stamp was just written above iff the

--- a/backend/src/services/retellService.js
+++ b/backend/src/services/retellService.js
@@ -9,7 +9,8 @@ import { sendLeadAssignmentEmail } from './mailer.js';
 import { AppError } from '../middleware/appError.js';
 import { logger } from '../utils/logger.js';
 import { CircuitBreaker } from '../utils/circuitBreaker.js';
-import { destinationForAgent, externalIdForDestination, buildLeadHeldPayload, dncPayloadBlock } from './prospectHelpers.js';
+import { destinationForAgent, externalIdForDestination, buildLeadHeldPayload, buildLeadCreatedPayload } from './prospectHelpers.js';
+import { dncCaptureGate } from './dncGate.js';
 import { dncEnforcement, formatDncNumber, checkAndRecord as dncCheckAndRecord } from './dncService.js';
 import { gateHeldDncLead } from './dncGate.js';
 import { readLegacyViewSafe } from '../utils/designConfigV2Clamp.js';
@@ -277,11 +278,9 @@ export function makeRetellService(overrides = {}) {
     // Per-campaign gate — only campaigns opted into design_config.dncCheckAtSubmit hit the API.
     // Version-aware (v2: form.gates.dncCheck); fail-safe view treats the check as ENABLED.
     const campaignDesign = readLegacyViewSafe(campaign?.design_config, { dncCheckAtSubmit: true });
-    const dncMode = campaignDesign.dncCheckAtSubmit === true ? d.dncEnforcement() : 'off';
-    const dncNumber = dncMode !== 'off' && to_number ? d.formatDncNumber(to_number) : null;
-    const dncBlockApplies = dncMode === 'block' && !!dncNumber;
-    const dncFlagApplies = dncMode === 'flag' && !!dncNumber;
-    const dncWillCheck = dncBlockApplies || dncFlagApplies;
+    const { dncBlockApplies, dncFlagApplies, dncWillCheck } = dncCaptureGate(
+      campaignDesign, to_number, { dncEnforcement: d.dncEnforcement, formatDncNumber: d.formatDncNumber }
+    );
 
     // ── Create prospect in a transaction (with idempotency key) ──
     // Lead-quota gate: decideAssignment charges authoritatively for a funded gated
@@ -410,36 +409,14 @@ export function makeRetellService(overrides = {}) {
       }
 
       // Suppress the Lyfe delivery webhook for quarantined (held) leads.
-      if (!quarantined) d.dispatchEvent('lead.created', () => ({
-        event: 'lead.created',
-        timestamp: new Date().toISOString(),
-        data: {
-          lead: {
-            externalId: prospect.id,
-            firstName: prospect.firstName,
-            lastName: prospect.lastName,
-            phone: prospect.phone,
-            email: prospect.email,
-            leadSource: 'call_bot',
-            tags: ['retell', 'phone-call'],
-            notes: prospect.notes,
-            sourceMetadata: prospect.sourceMetadata,
-            recordingUrl: recording_url || null,
-            transcript: prospect.notes,
-            dnc: dncPayloadBlock(prospect),
-            createdAt: prospect.createdAt
-          },
-          routing: {
-            mode: 'retell_round_robin',
-            agentPhone: agentForWebhook?.phone || null,
-            agentEmail: agentForWebhook?.email || null,
-            agentName: agentForWebhook?.name || null,
-            agentExternalId: agentForWebhook?.id || assignedAgentId || null,
-          },
-          source: 'retell_webhook',
-          campaign: campaign ? { externalId: campaign.id, name: campaign.name } : null
-        }
-      }), { destination: retellDestination });
+      // P4-9: the SHARED builder replaces a hand-rolled inline copy that had
+      // drifted — no screening/qrTag blocks, a nullable campaign object, and a
+      // data.source key no receiver reads. A Retell lead now reaches Lyfe with
+      // exactly the form-lead shape (routing.mode stays 'retell_round_robin';
+      // recordingUrl/transcript derive from sourceMetadata.retellCallId).
+      if (!quarantined) d.dispatchEvent('lead.created', () =>
+        buildLeadCreatedPayload(prospect, 'retell_round_robin', agentForWebhook, assignedAgentId, campaign, null, null),
+      { destination: retellDestination });
 
       // Held → ping the mktr-leads admin held queue so a pending lead is never silent.
       // Explicitly require no_funded_agent (the only reason that lands in that queue) so

--- a/backend/src/services/systemAgent.js
+++ b/backend/src/services/systemAgent.js
@@ -69,93 +69,16 @@ export async function getSystemAgentId() {
  *
  * Returns { agentId, via } with via ∈ 'self' | 'admin' | 'qr' | 'package' | 'fallback'.
  * 'fallback' means nothing matched and agentId is the System Agent (or DEFAULT_AGENT_ID).
+ *
+ * P4-9: a thin wrapper over resolveLeadAssignment with allowExternal=false —
+ * the tiers were a near-verbatim copy that had started to drift. With the
+ * external pool off, the resolver never queries external tables, the ring is
+ * internal-only (pickFromRing's index === the old `(cursor-1) % len`), and
+ * the 'hold' branch is unreachable — selection is identical by construction.
  */
 export async function resolveLeadRouting({ reqUser, requestedAgentId, campaignId, qrTagId }) {
-  // 1) If requester is an agent, they self-assign
-  if (reqUser && reqUser.role === 'agent') {
-    return { agentId: reqUser.id, via: 'self' };
-  }
-
-  // 2) If requester is admin and provided a valid active agent, accept it
-  if (reqUser && reqUser.role === 'admin' && requestedAgentId) {
-    const valid = await User.findOne({ where: { id: requestedAgentId, role: 'agent', isActive: true } });
-    if (valid) return { agentId: valid.id, via: 'admin' };
-  }
-
-  // 3) Try the agent the QR is directly assigned to (admin sets this via
-  //    the QR edit/create form: agentAssignmentMode='direct' + assignedAgent*).
-  //    Prefer `assignedAgentId` (the field the admin UI actually writes).
-  //    Fall back to `ownerUserId` for legacy QRs created before
-  //    assignedAgentId was dual-written from the resolved phone match.
-  if (qrTagId) {
-    const qr = await QrTag.findByPk(qrTagId);
-    const candidateId = qr?.assignedAgentId || qr?.ownerUserId;
-    if (candidateId) {
-      const agent = await User.findOne({ where: { id: candidateId, role: 'agent', isActive: true } });
-      if (agent) return { agentId: agent.id, via: 'qr' };
-    }
-  }
-
-  // 4) Try active Lead Package Assignments with round-robin rotation
-  // This REPLACES the old manual 'assigned_agents' list.
-  // Agents are only in the pool if they have a purchased package for this campaign with leads remaining.
-  if (campaignId) {
-    // Find all active assignments for this campaign with credits > 0
-    const assignments = await LeadPackageAssignment.findAll({
-      where: {
-        status: 'active',
-        leadsRemaining: { [Op.gt]: 0 }
-      },
-      include: [{
-        model: LeadPackage,
-        as: 'package',
-        where: { campaignId },
-        required: true,
-        attributes: [] // Only need filtering
-      }],
-      attributes: ['agentId']
-    });
-
-    const candidateIds = [...new Set(assignments.map(a => a.agentId))];
-
-    if (candidateIds.length > 0) {
-      // Filter to active agents only
-      const activeAgents = (await User.findAll({
-        where: { id: candidateIds, role: 'agent', isActive: true },
-        attributes: ['id'],
-        order: [['createdAt', 'ASC']]
-      })).map(u => u.id);
-
-      if (activeAgents.length > 0) {
-        // Round-robin via a per-campaign MONOTONIC counter. The increment is a
-        // single atomic `UPDATE ... RETURNING` — correct under concurrent
-        // webhooks AND multiple backend instances. Modulo is applied only at
-        // READ time, so rotation stays fair when the agent roster grows/shrinks
-        // (storing the modulo'd value would pin the cursor to the smallest
-        // roster ever seen and starve later-added agents). enqueueCampaign still
-        // serializes in-process to reduce contention, but correctness no longer
-        // depends on it.
-        const result = await enqueueCampaign(campaignId, async () => {
-          // campaignId is UNIQUE on round_robin_cursor, so findOrCreate is race-safe.
-          await RoundRobinCursor.findOrCreate({
-            where: { campaignId },
-            defaults: { campaignId, cursor: 0 },
-          });
-          const [, [updated]] = await RoundRobinCursor.update(
-            { cursor: sequelize.literal('"cursor" + 1') },
-            { where: { campaignId }, returning: true }
-          );
-          const nextCursor = updated?.cursor ?? 1;
-          return activeAgents[(nextCursor - 1) % activeAgents.length];
-        });
-        if (result) return { agentId: result, via: 'package' };
-      }
-    }
-  }
-
-  // 5) Fallback to System Agent
-  const systemId = await getSystemAgentId();
-  return { agentId: systemId, via: 'fallback' };
+  const r = await resolveLeadAssignment({ reqUser, requestedAgentId, campaignId, qrTagId, allowExternal: false });
+  return { agentId: r.internalAgentId, via: r.via };
 }
 
 /**
@@ -165,31 +88,33 @@ export async function resolveLeadRouting({ reqUser, requestedAgentId, campaignId
  * tagged result so the caller knows which table the assignee lives in — which
  * also drives webhook destination (internal -> Lyfe app, external -> MKTR Leads).
  *
- * ADDITIVE: not yet wired into the live capture path. createProspect / retell /
- * meta are cut over in the Phase 0.7 + 0.5 change, where the external branch also
- * atomically deducts balance (deductExternalLeadBalance) and runs the consent
- * gate, and where an external campaign with no eligible paid buyer quarantines
- * the lead instead of dropping it onto the System Agent.
+ * THE single tier implementation (P4-9): resolveLeadRouting wraps this with
+ * allowExternal=false, so the tiers exist exactly once.
  *
  * `allowExternal` MUST be computed by the caller as
  *   (campaign.externalEligible === true) && hasValidExternalConsent(prospect)
  * and defaults to false. When false the external pool is not even queried, so
- * the resolver is byte-for-byte internal-only — identical to resolveAssignedAgentId
- * behavior. This is the fail-safe that keeps the live pipeline unchanged until a
- * caller opts a consented, external-eligible lead in.
+ * the resolver is byte-for-byte internal-only. This is the fail-safe that keeps
+ * the live pipeline unchanged unless a caller opts a consented,
+ * external-eligible lead in (createProspect does; retell/meta/sweeps do not).
  *
  * Every return also carries `via` (self | admin | qr | package | external | fallback)
  * so the caller threads a consistent route label into the lead-quota gate.
  *
  *   returns { kind: 'internal', internalAgentId, via } | { kind: 'external', externalAgentId, via }
  *
- * NOTE (external-activation parity, tracked in docs/plans/MKTR_LEADS_ACTIVATION_PLAN.md): the QR tier
- * here only covers direct assignedAgentId/ownerUserId — NOT QR round-robin groups or the
- * legacy assignedAgentPhone fallback that createProspect's QR-override block handles. Since
- * createProspect skips that block for external-eligible leads, QR round-robin/phone routing
- * must be folded into this resolver (or the block re-enabled per-tier) before external goes
- * live. Likewise, tier-5 still falls back to the System Agent; an external-eligible campaign
- * with no funded buyer must HOLD (W1b), not deliver internally.
+ * DELIBERATE tier-3 scope (P4-9 drift decision): the QR tier here covers only
+ * direct assignedAgentId/ownerUserId. QR round-robin GROUPS and the legacy
+ * assignedAgentPhone fallback live in createProspect's PRE-resolver QR-override
+ * block, and that is the CORRECT home: only form/QR captures carry a qrTagId
+ * (retell/meta/sweep callers pass qrTagId:null, so the richer QR handling is
+ * vacuous for them), and the override must run before quota/consent gating.
+ * NOTE (external-activation parity, docs/plans/MKTR_LEADS_ACTIVATION_PLAN.md):
+ * since createProspect skips that block for external-eligible leads, QR
+ * round-robin/phone routing must be folded into this resolver (or the block
+ * re-enabled per-tier) before external-QR goes live. Likewise an
+ * external-eligible campaign with no funded buyer HOLDs (W1b), never delivers
+ * internally.
  */
 export async function resolveLeadAssignment({ reqUser, requestedAgentId, campaignId, qrTagId, allowExternal = false }) {
   // 1) Requester is an agent → self-assign (internal)

--- a/backend/src/services/tiktokEventsService.js
+++ b/backend/src/services/tiktokEventsService.js
@@ -73,8 +73,12 @@ export function _buildPayload(prospect, ctx, options) {
   const url = ctx.eventSourceUrl || meta.eventSourceUrl || undefined;
 
   const eventData = {
+    // Down-funnel senders (which fire when an agent advances the lead days
+    // later) back-date event_time to when the status changed — the same
+    // ctx.eventTime passthrough metaCapiService honours (P4-9; this used to
+    // always stamp now). Submit-time events omit ctx.eventTime → now.
     event: eventName,
-    event_time: Math.floor(Date.now() / 1000),
+    event_time: ctx.eventTime || Math.floor(Date.now() / 1000),
     event_id: ctx.eventId,
     user: cleanUser,
     properties: {

--- a/backend/test/tiktokEventsService.test.js
+++ b/backend/test/tiktokEventsService.test.js
@@ -122,6 +122,15 @@ describe('_buildPayload', () => {
     expect(_buildPayload(webProspect(), { eventId: 'evt-xyz' }, {}).data[0].event_id).toBe('evt-xyz');
   });
 
+  it('honours ctx.eventTime for back-dated down-funnel events and defaults to now without it (P4-9 Meta parity)', () => {
+    const backdated = 1_722_500_000; // fixed unix seconds
+    expect(_buildPayload(webProspect(), { ...ctx, eventTime: backdated }, {}).data[0].event_time).toBe(backdated);
+    const before = Math.floor(Date.now() / 1000);
+    const stamped = _buildPayload(webProspect(), ctx, {}).data[0].event_time;
+    expect(stamped).toBeGreaterThanOrEqual(before);
+    expect(stamped).toBeLessThanOrEqual(Math.floor(Date.now() / 1000) + 1);
+  });
+
   it('hashes email and phone when ctx.marketingConsent is true (ledger-derived by the caller)', () => {
     const user = _buildPayload(webProspect(), { ...ctx, marketingConsent: true }, {}).data[0].user;
     expect(user.email).toMatch(/^[a-f0-9]{64}$/);

--- a/backend/test/unit/retellService.test.js
+++ b/backend/test/unit/retellService.test.js
@@ -19,7 +19,9 @@ function buildMocks() {
     tags: ['retell', 'phone-call'],
     campaignId: 'camp-1',
     assignedAgentId: 'agent-1',
-    sourceMetadata: { retellCallId: 'call123' },
+    // Mirrors what processRetellCall actually persists — the shared
+    // buildLeadCreatedPayload (P4-9) reads recordingUrl from the stored row.
+    sourceMetadata: { retellCallId: 'call123', recordingUrl: 'https://recordings.retell.ai/call123.mp3' },
     createdAt: new Date().toISOString(),
     toJSON: jest.fn(function () { return { ...this }; }),
   };


### PR DESCRIPTION
## .review P4-9 — Deduplicate lead-routing and the ad-event mirrors

Three problems, three commits.

### 1. One assignment-tier implementation
`resolveLeadRouting` and `resolveLeadAssignment` duplicated tiers 1–4 (self / admin-requested / QR-direct / package round-robin + cursor) nearly verbatim. `resolveLeadRouting` is now a thin wrapper over `resolveLeadAssignment` with `allowExternal: false` — with the external pool off, the ring is internal-only, `pickFromRing`'s index equals the old `(cursor-1) % len`, and the hold branch is unreachable, so selection is identical by construction. All seven callers keep their exact `{agentId, via}` contract; 141 routing-domain tests green unmodified.

**Drift decision (stated, as the task demands):** QR round-robin GROUPS and the legacy `assignedAgentPhone` fallback were never in either resolver — they live in `createProspect`'s pre-resolver QR-override block, and that is the **correct** home: only form/QR captures carry a `qrTagId` (retell/meta/sweep callers pass null, making the richer QR handling vacuous for them), and the override must run before quota/consent gating. The resolver keeps the simple direct-assignment tier 3; the surviving doc block records this decision plus the standing external-QR-parity warning.

### 2. Retell reuses the shared payload + DNC gate
- The hand-rolled inline `lead.created` payload had drifted: **no screening block, no qrTag block**, a nullable campaign object, and a `data.source` key no receiver reads (the EF maps `data.lead.*` only — verified). Retell now calls `buildLeadCreatedPayload(prospect, 'retell_round_robin', …)` — a Retell lead reaches Lyfe with exactly the proven form-lead shape (recordingUrl/transcript derive from the persisted `sourceMetadata.retellCallId`, same values as before).
- The five-line DNC block-mode compute ("mirrors prospectService.createProspect", per its own comment) is extracted to `dncGate.dncCaptureGate()` and used by **both** capture paths.
- One test fixture updated to model the persisted row faithfully (mock prospect now carries `sourceMetadata.recordingUrl`, which the real create always stores); all 10 retell/DNC suites green (215 tests).

### 3. TikTok honours `ctx.eventTime`
`_buildPayload` always stamped now; it now passes `ctx.eventTime` through exactly like Meta CAPI's back-dating (new parity test). **Product decision to make (reported, not changed):** the down-funnel senders (leadOutcomeService / redemptionOutcomeService) import **Meta only** — ConfirmedResident/ClosedWon never reach TikTok. If TikTok should optimise on down-funnel outcomes, those senders need the same dual-dispatch treatment; the passthrough is now correct ahead of that.

**makeAdEventSender factory: deliberately NOT extracted.** The ~35% shared transport scaffold is outweighed by genuine contract differences (TikTok's `body.code===0` success predicate vs HTTP status, header vs query-string auth, different payload envelopes) — the abstraction would obscure exactly the parts that differ, which is the task's own guardrail.

### Verification
- Backend + root eslint clean. Unit tier 123 suites / 2,100 green. CAPI/TikTok/outcome suites 142 green; retell+DNC 215 green; routing 141 green.
- Full DB tier: 132/134 — the two failures (`webhooks.test.js` 405-vs-403, `consentLedger.test.js` HTTP-parser "Parse Error") are same-process transients in files this PR doesn't touch: **both suites fully green re-run in isolation (39/39, 18/18)** and both passed P4-8's identical run minutes earlier.
- `meta-capi-smoke.js` requires prod credentials (absent locally by design); the Meta sender is untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y83Mpgkub5nZSD5UBNZM6V