### PR TITLE
perf(request-path): halve auth DB lookups, bound the agent-detail loads, stream uploads (P4-10)

### DIFF
--- a/backend/src/controllers/uploadController.js
+++ b/backend/src/controllers/uploadController.js
@@ -91,7 +91,7 @@ export const uploadDocuments = asyncHandler(async (req, res) => {
 // --- Delete file ---
 export const deleteFile = asyncHandler(async (req, res) => {
   const { type, filename } = req.params;
-  uploadService.deleteFile(type, filename);
+  await uploadService.deleteFile(type, filename);
 
   res.json({
     success: true,
@@ -102,7 +102,7 @@ export const deleteFile = asyncHandler(async (req, res) => {
 // --- Get file info ---
 export const getFileInfo = asyncHandler(async (req, res) => {
   const { type, filename } = req.params;
-  const fileInfo = uploadService.getFileInfo(type, filename);
+  const fileInfo = await uploadService.getFileInfo(type, filename);
 
   res.json({
     success: true,
@@ -114,7 +114,7 @@ export const getFileInfo = asyncHandler(async (req, res) => {
 export const listFiles = asyncHandler(async (req, res) => {
   const { type } = req.params;
   const { page = 1, limit = 20 } = req.query;
-  const result = uploadService.listFiles(type, page, limit);
+  const result = await uploadService.listFiles(type, page, limit);
 
   res.json({
     success: true,
@@ -124,7 +124,7 @@ export const listFiles = asyncHandler(async (req, res) => {
 
 // --- Storage usage stats ---
 export const getStorageUsage = asyncHandler(async (req, res) => {
-  const result = uploadService.getStorageUsage();
+  const result = await uploadService.getStorageUsage();
 
   res.json({
     success: true,

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -92,6 +92,24 @@ export const authenticateToken = async (req, res, next) => {
       return res.status(401).json({ success: false, message: 'Access token required' });
     }
 
+    // P4-10: optionalAuth (mounted app-wide so the rate limiter can see the
+    // role) already verified this EXACT token and loaded the user — reuse
+    // instead of paying jwt.verify + User.findByPk twice per request. Only a
+    // successful optionalAuth populates the cache, and only an identical
+    // token string reuses it; every other case (absent, different, invalid,
+    // inactive) takes the full verify below and is rejected there.
+    if (req._verifiedAuth?.token === token && req._verifiedAuth.user?.isActive) {
+      const cachedUser = req._verifiedAuth.user;
+      // Debounce lastLogin writes — only update if stale by 5+ minutes
+      const fiveMinutes = 5 * 60 * 1000;
+      if (!cachedUser.lastLogin || Date.now() - new Date(cachedUser.lastLogin).getTime() > fiveMinutes) {
+        cachedUser.lastLogin = new Date();
+        cachedUser.save().catch(() => {}); // fire-and-forget, don't block the request
+      }
+      req.user = cachedUser;
+      return next();
+    }
+
     if (getRemoteJwks()) {
       try {
         const { payload } = await jwtVerify(token, getRemoteJwks(), {
@@ -193,7 +211,15 @@ export const optionalAuth = async (req, res, next) => {
           /* expected: token verification may fail */
         }
       }
-      if (user && user.isActive) req.user = user;
+      if (user && user.isActive) {
+        req.user = user;
+        // P4-10: cache the VERIFIED (token → user) pair so authenticateToken
+        // (which runs next on protected routes) can skip the second
+        // jwt.verify + User.findByPk. Cached ONLY on success — an invalid
+        // token never populates this, so authenticateToken's own verify still
+        // rejects it properly.
+        req._verifiedAuth = { token, user };
+      }
     }
 
     next();

--- a/backend/src/services/agentService.js
+++ b/backend/src/services/agentService.js
@@ -159,22 +159,17 @@ export async function getAgentDetail(agentId, requestingUser) {
     throw new AppError('Access denied', 403);
   }
 
+  // P4-10: the stats come from grouped COUNTs instead of eager-loading EVERY
+  // assigned prospect (with campaign join) and every created campaign with all
+  // its prospects — unbounded memory per request, growing with the agent's
+  // history. The raw arrays are dropped from the response: no consumer read
+  // them (AdminAgentDetail fetches prospects via the paginated
+  // /agents/:id/prospects endpoint), only `stats` counts. assignedPackages
+  // stays — bounded and part of the packages panel contract.
   const agent = await User.findOne({
     where: { id: agentId, role: 'agent' },
     attributes: { exclude: ['password'] },
     include: [
-      {
-        association: 'assignedProspects',
-        include: [
-          { association: 'campaign', attributes: ['id', 'name'] }
-        ]
-      },
-      {
-        association: 'createdCampaigns',
-        include: [
-          { association: 'prospects', attributes: ['id', 'leadStatus'] }
-        ]
-      },
       {
         association: 'assignedPackages',
         include: [
@@ -188,15 +183,29 @@ export async function getAgentDetail(agentId, requestingUser) {
     throw new AppError('Agent not found', 404);
   }
 
-  // Calculate detailed statistics
-  const totalProspects = agent.assignedProspects.length;
-  const prospectsByStatus = agent.assignedProspects.reduce((acc, prospect) => {
-    acc[prospect.leadStatus] = (acc[prospect.leadStatus] || 0) + 1;
-    return acc;
-  }, {});
+  const [statusRows, campaignRows, monthlyPerformance] = await Promise.all([
+    sequelize.query(
+      `SELECT "leadStatus", COUNT(*)::int AS count
+         FROM prospects WHERE "assignedAgentId" = :agentId GROUP BY "leadStatus"`,
+      { replacements: { agentId }, type: sequelize.QueryTypes.SELECT }
+    ),
+    sequelize.query(
+      `SELECT COUNT(*)::int AS total,
+              COUNT(*) FILTER (WHERE c.status = 'active')::int AS active,
+              COALESCE(SUM((SELECT COUNT(*) FROM prospects p WHERE p."campaignId" = c.id)), 0)::int AS "totalLeads"
+         FROM campaigns c WHERE c."createdBy" = :agentId`,
+      { replacements: { agentId }, type: sequelize.QueryTypes.SELECT }
+    ),
+    getAgentMonthlyPerformance(agentId),
+  ]);
 
-  // Monthly performance (last 12 months)
-  const monthlyPerformance = await getAgentMonthlyPerformance(agentId);
+  const prospectsByStatus = {};
+  let totalProspects = 0;
+  for (const row of statusRows) {
+    prospectsByStatus[row.leadStatus] = row.count;
+    totalProspects += row.count;
+  }
+  const campaignStats = campaignRows[0] || { total: 0, active: 0, totalLeads: 0 };
 
   return {
     ...agent.toJSON(),
@@ -207,9 +216,9 @@ export async function getAgentDetail(agentId, requestingUser) {
         conversionRate: totalProspects > 0 ? (prospectsByStatus.won || 0) / totalProspects * 100 : 0
       },
       campaigns: {
-        total: agent.createdCampaigns.length,
-        active: agent.createdCampaigns.filter(c => c.status === 'active').length,
-        totalLeads: agent.createdCampaigns.reduce((sum, c) => sum + c.prospects.length, 0)
+        total: campaignStats.total,
+        active: campaignStats.active,
+        totalLeads: campaignStats.totalLeads
       },
       monthlyPerformance
     }

--- a/backend/src/services/agentStatsHelpers.js
+++ b/backend/src/services/agentStatsHelpers.js
@@ -1,34 +1,24 @@
-import { Op } from 'sequelize';
-import { LeadPackage, LeadPackageAssignment, sequelize } from '../models/index.js';
+import { sequelize } from '../models/index.js';
 
 /**
  * Fetch counts of unique campaigns each agent is assigned to via active lead packages.
  * Returns an object keyed by agent ID string, with integer counts as values.
  */
 export async function getAssignedCampaignCounts() {
-  const allAssignments = await LeadPackageAssignment.findAll({
-    where: { status: 'active', leadsRemaining: { [Op.gt]: 0 } },
-    include: [{
-      model: LeadPackage,
-      as: 'package',
-      attributes: ['campaignId'],
-      required: true
-    }]
-  });
-
+  // One grouped COUNT(DISTINCT) instead of loading every active assignment row
+  // into JS on each listAgents page render (P4-10; getAgentPackageBreakdowns
+  // below set the pattern).
+  const rows = await sequelize.query(
+    `SELECT a."agentId", COUNT(DISTINCT p."campaignId")::int AS "campaignCount"
+       FROM lead_package_assignments a
+       JOIN lead_packages p ON p.id = a."leadPackageId"
+      WHERE a.status = 'active' AND a."leadsRemaining" > 0
+        AND p."campaignId" IS NOT NULL
+      GROUP BY a."agentId"`,
+    { type: sequelize.QueryTypes.SELECT }
+  );
   const assignedCounts = {};
-  for (const assignment of allAssignments) {
-    if (assignment.package && assignment.package.campaignId) {
-      const agentId = String(assignment.agentId);
-      if (!assignedCounts[agentId]) assignedCounts[agentId] = new Set();
-      assignedCounts[agentId].add(assignment.package.campaignId);
-    }
-  }
-  // Convert Sets to counts
-  Object.keys(assignedCounts).forEach(k => {
-    assignedCounts[k] = assignedCounts[k].size;
-  });
-
+  for (const row of rows) assignedCounts[String(row.agentId)] = row.campaignCount;
   return assignedCounts;
 }
 

--- a/backend/src/services/redeemOps/analyticsService.js
+++ b/backend/src/services/redeemOps/analyticsService.js
@@ -128,12 +128,19 @@ export function makeAnalyticsService(overrides = {}) {
       entitlementsByActivation.set(r.activationId, m);
     }
 
+    // P4-10: metrics per DISTINCT campaign, in parallel — this used to await
+    // one heavy computeCampaignMetrics per activation SEQUENTIALLY (up to a
+    // page of 50), repeating shared campaigns.
+    const metricCampaignIds = [...new Set(activations.map((a) => a.campaignId).filter(Boolean))];
+    const metricsByCampaign = new Map(
+      await Promise.all(
+        metricCampaignIds.map(async (cid) => [cid, await d.campaigns.getCampaignMetrics(cid).catch(() => null)])
+      )
+    );
+
     const funnels = [];
     for (const a of activations) {
-      let acquisition = null;
-      if (a.campaignId) {
-        acquisition = await d.campaigns.getCampaignMetrics(a.campaignId).catch(() => null);
-      }
+      const acquisition = a.campaignId ? (metricsByCampaign.get(a.campaignId) ?? null) : null;
       funnels.push({
         id: a.id,
         rewardTitle: a.rewardOffer?.title,

--- a/backend/src/services/redeemOps/entitlementService.js
+++ b/backend/src/services/redeemOps/entitlementService.js
@@ -1279,10 +1279,14 @@ export function makeEntitlementService(overrides = {}) {
 
     // Draw-linkage per activation (PR-4) — one lookup per distinct activation,
     // so the console can voice draw rows ("Session ×N") and offer Undo.
-    const drawByActivation = new Map();
-    for (const actId of [...new Set(rows.map((r) => r.activationId))]) {
-      drawByActivation.set(actId, await d.drawLink.drawContextForActivation(actId).catch(() => null));
-    }
+    const drawByActivation = new Map(
+      await Promise.all(
+        [...new Set(rows.map((r) => r.activationId))].map(async (actId) => [
+          actId,
+          await d.drawLink.drawContextForActivation(actId).catch(() => null),
+        ])
+      )
+    );
 
     // Mask phones by default (redemptions.verify unmasks at the console)
     const nowMs = Date.now();

--- a/backend/src/services/storage.js
+++ b/backend/src/services/storage.js
@@ -59,6 +59,25 @@ export const storageService = {
     }));
     return publicUrl(cleanKey);
   },
+  /** Stream a file body to storage (P4-10) — PutObject on S3-compatible
+   * Spaces needs an explicit ContentLength for stream bodies, so callers pass
+   * the byte size (stat the file at send time; a transcoded upload's multer
+   * `file.size` is stale). */
+  async uploadStream(key, stream, contentType = 'application/octet-stream', contentLength, cacheControl = 'public, max-age=31536000') {
+    const s3 = getS3();
+    if (!s3) throw new Error('Spaces not configured');
+    const cleanKey = key.replace(/^\//, '');
+    await s3.send(new PutObjectCommand({
+      Bucket: spacesConfig.bucket,
+      Key: cleanKey,
+      Body: stream,
+      ContentType: contentType,
+      ContentLength: contentLength,
+      ACL: 'public-read',
+      CacheControl: cacheControl
+    }));
+    return publicUrl(cleanKey);
+  },
   async deleteObject(key) {
     const s3 = getS3();
     if (!s3) throw new Error('Spaces not configured');

--- a/backend/src/services/uploadService.js
+++ b/backend/src/services/uploadService.js
@@ -5,8 +5,25 @@ import { storageService } from './storage.js';
 import { transcodeUploadedVideoToMp4 } from './videoService.js';
 import { AppError } from '../middleware/appError.js';
 
+// fs.promises off the same module so the unit suite mocks ONE target.
+const fsp = fs.promises;
+
 // Base uploads directory
 const uploadsDir = path.join(process.cwd(), 'uploads');
+
+/**
+ * Stream an on-disk upload to cloud storage, then remove the temp file.
+ * P4-10: the old path fs.readFileSync'd the ENTIRE upload (including
+ * transcoded video) into memory on the request path, blocking the event
+ * loop. The size is stat'ed at send time — multer's `file.size` goes stale
+ * once the transcode step rewrites the file on disk.
+ */
+async function uploadFileToStorage(key, file) {
+  const { size } = await fsp.stat(file.path);
+  const url = await storageService.uploadStream(key, fs.createReadStream(file.path), file.mimetype, size);
+  await fsp.unlink(file.path).catch(() => {});
+  return url;
+}
 
 /**
  * Upload a single file to cloud storage (if enabled) or keep local.
@@ -20,10 +37,7 @@ export async function processSingleUpload(file, type = 'general', userId) {
   let fileUrl = `/uploads/${type}/${file.filename}`;
 
   if (storageService.isEnabled()) {
-    const key = `${type}/${file.filename}`;
-    const buffer = fs.readFileSync(file.path);
-    fileUrl = await storageService.uploadBuffer(key, buffer, file.mimetype);
-    try { fs.unlinkSync(file.path); } catch (err) { void err; }
+    fileUrl = await uploadFileToStorage(`${type}/${file.filename}`, file);
   }
 
   return {
@@ -63,10 +77,7 @@ export async function processAvatarUpload(file, user) {
 
   let avatarUrl = `/uploads/avatars/${file.filename}`;
   if (storageService.isEnabled()) {
-    const key = `avatars/${file.filename}`;
-    const buffer = fs.readFileSync(file.path);
-    avatarUrl = await storageService.uploadBuffer(key, buffer, file.mimetype);
-    try { fs.unlinkSync(file.path); } catch (err) { void err; }
+    avatarUrl = await uploadFileToStorage(`avatars/${file.filename}`, file);
   }
 
   await user.update({ avatar: avatarUrl });
@@ -88,15 +99,11 @@ export async function processCampaignAssets(files, campaignId, userId) {
   for (const file of files) {
     let url = `/uploads/campaigns/${campaignId}/${file.filename}`;
     if (storageService.isEnabled()) {
-      const key = `campaigns/${campaignId}/${file.filename}`;
-      const buffer = fs.readFileSync(file.path);
-      url = await storageService.uploadBuffer(key, buffer, file.mimetype);
-      try { fs.unlinkSync(file.path); } catch (err) { void err; }
+      url = await uploadFileToStorage(`campaigns/${campaignId}/${file.filename}`, file);
     } else {
       const campaignDir = path.join(uploadsDir, 'campaigns', campaignId);
-      if (!fs.existsSync(campaignDir)) fs.mkdirSync(campaignDir, { recursive: true });
-      const newPath = path.join(campaignDir, file.filename);
-      fs.renameSync(file.path, newPath);
+      await fsp.mkdir(campaignDir, { recursive: true });
+      await fsp.rename(file.path, path.join(campaignDir, file.filename));
     }
     assets.push({
       id: uuidv4(),
@@ -127,14 +134,11 @@ export async function processDocumentUpload(files, entityType, entityId, userId)
   }
 
   const entityDir = path.join(uploadsDir, 'documents', entityType, entityId);
-  if (!fs.existsSync(entityDir)) {
-    fs.mkdirSync(entityDir, { recursive: true });
-  }
+  await fsp.mkdir(entityDir, { recursive: true });
 
   const documents = [];
   for (const file of files) {
-    const newPath = path.join(entityDir, file.filename);
-    fs.renameSync(file.path, newPath);
+    await fsp.rename(file.path, path.join(entityDir, file.filename));
 
     documents.push({
       id: uuidv4(),
@@ -153,28 +157,25 @@ export async function processDocumentUpload(files, entityType, entityId, userId)
   return documents;
 }
 
+/** Resolve + traversal-check a path under uploads/. */
+function safeUploadsPath(...segments) {
+  const filePath = path.join(uploadsDir, ...segments);
+  if (!path.resolve(filePath).startsWith(path.resolve(uploadsDir))) {
+    throw new AppError('Invalid file path', 400);
+  }
+  return filePath;
+}
+
 /**
  * Delete a file by type and filename.
  * Validates the path stays within the uploads directory.
  */
-export function deleteFile(type, filename) {
-  const filePath = path.join(uploadsDir, type, filename);
-
-  // Security check - ensure file is within uploads directory
-  const resolvedPath = path.resolve(filePath);
-  const uploadsPath = path.resolve(uploadsDir);
-
-  if (!resolvedPath.startsWith(uploadsPath)) {
-    throw new AppError('Invalid file path', 400);
-  }
-
-  if (!fs.existsSync(filePath)) {
-    throw new AppError('File not found', 404);
-  }
-
+export async function deleteFile(type, filename) {
+  const filePath = safeUploadsPath(type, filename);
   try {
-    fs.unlinkSync(filePath);
+    await fsp.unlink(filePath);
   } catch (error) {
+    if (error?.code === 'ENOENT') throw new AppError('File not found', 404);
     throw new AppError('Failed to delete file', 500);
   }
 }
@@ -183,22 +184,14 @@ export function deleteFile(type, filename) {
  * Get file info (stats) by type and filename.
  * Validates the path stays within the uploads directory.
  */
-export function getFileInfo(type, filename) {
-  const filePath = path.join(uploadsDir, type, filename);
-
-  // Security check
-  const resolvedPath = path.resolve(filePath);
-  const uploadsPath = path.resolve(uploadsDir);
-
-  if (!resolvedPath.startsWith(uploadsPath)) {
-    throw new AppError('Invalid file path', 400);
-  }
-
-  if (!fs.existsSync(filePath)) {
+export async function getFileInfo(type, filename) {
+  const filePath = safeUploadsPath(type, filename);
+  let stats;
+  try {
+    stats = await fsp.stat(filePath);
+  } catch {
     throw new AppError('File not found', 404);
   }
-
-  const stats = fs.statSync(filePath);
   return {
     filename,
     type,
@@ -213,36 +206,39 @@ export function getFileInfo(type, filename) {
  * List files in a type directory with pagination.
  * Returns { files, pagination }.
  */
-export function listFiles(type, page = 1, limit = 20) {
-  const dirPath = path.join(uploadsDir, type);
+export async function listFiles(type, page = 1, limit = 20) {
+  const dirPath = safeUploadsPath(type);
 
-  // Path traversal check — ensure resolved path stays within uploads directory
-  const resolvedPath = path.resolve(dirPath);
-  if (!resolvedPath.startsWith(path.resolve(uploadsDir))) {
-    throw new AppError('Invalid path', 400);
-  }
-
-  if (!fs.existsSync(dirPath)) {
+  let names;
+  try {
+    names = await fsp.readdir(dirPath);
+  } catch {
     return {
       files: [],
       pagination: { currentPage: 1, totalPages: 0, totalItems: 0 }
     };
   }
 
-  const files = fs.readdirSync(dirPath)
-    .filter(file => !file.startsWith('.'))
-    .map(filename => {
-      const filePath = path.join(dirPath, filename);
-      const stats = fs.statSync(filePath);
-      return {
-        filename,
-        type,
-        size: stats.size,
-        url: `/uploads/${type}/${filename}`,
-        createdAt: stats.birthtime,
-        modifiedAt: stats.mtime
-      };
-    })
+  const files = (await Promise.all(
+    names
+      .filter((file) => !file.startsWith('.'))
+      .map(async (filename) => {
+        try {
+          const stats = await fsp.stat(path.join(dirPath, filename));
+          return {
+            filename,
+            type,
+            size: stats.size,
+            url: `/uploads/${type}/${filename}`,
+            createdAt: stats.birthtime,
+            modifiedAt: stats.mtime
+          };
+        } catch {
+          return null; // deleted between readdir and stat
+        }
+      })
+  ))
+    .filter(Boolean)
     .sort((a, b) => b.createdAt - a.createdAt);
 
   const pageNum = parseInt(page);
@@ -265,24 +261,29 @@ export function listFiles(type, page = 1, limit = 20) {
  * Calculate storage usage statistics across all upload types.
  * Returns { totalUsage, byType }.
  */
-export function getStorageUsage() {
-  const getDirectorySize = (dirPath) => {
-    if (!fs.existsSync(dirPath)) return 0;
-
+export async function getStorageUsage() {
+  const getDirectorySize = async (dirPath) => {
+    let names;
+    try {
+      names = await fsp.readdir(dirPath);
+    } catch {
+      return 0;
+    }
     let totalSize = 0;
-    const files = fs.readdirSync(dirPath);
-
-    for (const file of files) {
+    for (const file of names) {
       const filePath = path.join(dirPath, file);
-      const stats = fs.statSync(filePath);
-
+      let stats;
+      try {
+        stats = await fsp.stat(filePath);
+      } catch {
+        continue;
+      }
       if (stats.isDirectory()) {
-        totalSize += getDirectorySize(filePath);
+        totalSize += await getDirectorySize(filePath);
       } else {
         totalSize += stats.size;
       }
     }
-
     return totalSize;
   };
 
@@ -291,7 +292,7 @@ export function getStorageUsage() {
   let totalUsage = 0;
 
   for (const type of types) {
-    const size = getDirectorySize(path.join(uploadsDir, type));
+    const size = await getDirectorySize(path.join(uploadsDir, type));
     usage[type] = {
       size,
       sizeFormatted: (size / (1024 * 1024)).toFixed(2) + ' MB'

--- a/backend/test/unit/agentStatsHelpers.test.js
+++ b/backend/test/unit/agentStatsHelpers.test.js
@@ -13,7 +13,7 @@ jest.unstable_mockModule('../../src/models/index.js', () => ({
 
 const { getAssignedCampaignCounts, computeAgentStats, computeAgentStatsFromCounts } =
   await import('../../src/services/agentStatsHelpers.js');
-const { LeadPackageAssignment } = await import('../../src/models/index.js');
+const { sequelize } = await import('../../src/models/index.js');
 
 describe('agentStatsHelpers', () => {
   // ──────────────────────────────────────────────
@@ -23,36 +23,33 @@ describe('agentStatsHelpers', () => {
   describe('getAssignedCampaignCounts', () => {
     beforeEach(() => jest.clearAllMocks());
 
-    it('returns empty object when no active assignments exist', async () => {
-      LeadPackageAssignment.findAll.mockResolvedValue([]);
+    // P4-10: one grouped COUNT(DISTINCT) replaced loading every assignment
+    // row into JS — dedupe and the null-campaign skip now live in the SQL,
+    // so the unit asserts the query's guards plus the row→object mapping.
+    it('returns empty object when the grouped query yields no rows', async () => {
+      sequelize.query.mockResolvedValue([]);
       const result = await getAssignedCampaignCounts();
       expect(result).toEqual({});
     });
 
-    it('counts unique campaigns per agent', async () => {
-      LeadPackageAssignment.findAll.mockResolvedValue([
-        { agentId: 'a-1', package: { campaignId: 'c-1' } },
-        { agentId: 'a-1', package: { campaignId: 'c-2' } },
-        { agentId: 'a-1', package: { campaignId: 'c-1' } }, // duplicate campaign
-        { agentId: 'a-2', package: { campaignId: 'c-3' } },
+    it('maps grouped rows to per-agent integer counts', async () => {
+      sequelize.query.mockResolvedValue([
+        { agentId: 'a-1', campaignCount: 2 },
+        { agentId: 'a-2', campaignCount: 1 },
       ]);
 
       const result = await getAssignedCampaignCounts();
-      expect(result['a-1']).toBe(2);
-      expect(result['a-2']).toBe(1);
+      expect(result).toEqual({ 'a-1': 2, 'a-2': 1 });
     });
 
-    it('skips assignments with null package or null campaignId', async () => {
-      LeadPackageAssignment.findAll.mockResolvedValue([
-        { agentId: 'a-1', package: null },
-        { agentId: 'a-2', package: { campaignId: null } },
-        { agentId: 'a-3', package: { campaignId: 'c-1' } },
-      ]);
-
-      const result = await getAssignedCampaignCounts();
-      expect(result['a-1']).toBeUndefined();
-      expect(result['a-2']).toBeUndefined();
-      expect(result['a-3']).toBe(1);
+    it('the SQL dedupes campaigns and excludes null campaignIds + inactive/spent assignments', async () => {
+      sequelize.query.mockResolvedValue([]);
+      await getAssignedCampaignCounts();
+      const sql = sequelize.query.mock.calls[0][0];
+      expect(sql).toContain('COUNT(DISTINCT p."campaignId")');
+      expect(sql).toContain('"campaignId" IS NOT NULL');
+      expect(sql).toContain("a.status = 'active'");
+      expect(sql).toContain('a."leadsRemaining" > 0');
     });
   });
 

--- a/backend/test/unit/uploadService.test.js
+++ b/backend/test/unit/uploadService.test.js
@@ -2,20 +2,26 @@ import { jest } from '@jest/globals';
 import '../setup.js';
 
 // ── Mock dependencies ──
+// P4-10: uploadService streams from disk via fs.createReadStream +
+// fs.promises (single 'fs' mock target) and calls storageService.uploadStream
+// with a stat'ed length — the old readFileSync/uploadBuffer surface is gone.
 
 const storageService = {
   isEnabled: jest.fn(),
-  uploadBuffer: jest.fn(),
+  uploadStream: jest.fn(),
+};
+
+const mockFsp = {
+  stat: jest.fn(),
+  unlink: jest.fn(),
+  readdir: jest.fn(),
+  mkdir: jest.fn(),
+  rename: jest.fn(),
 };
 
 const mockFs = {
-  readFileSync: jest.fn(),
-  unlinkSync: jest.fn(),
-  existsSync: jest.fn(),
-  statSync: jest.fn(),
-  readdirSync: jest.fn(),
-  mkdirSync: jest.fn(),
-  renameSync: jest.fn(),
+  createReadStream: jest.fn().mockReturnValue('mock-stream'),
+  promises: mockFsp,
 };
 
 const AppError = class extends Error {
@@ -26,7 +32,7 @@ const AppError = class extends Error {
 };
 
 jest.unstable_mockModule('../../src/services/storage.js', () => ({ storageService }));
-jest.unstable_mockModule('../../src/middleware/errorHandler.js', () => ({ AppError }));
+jest.unstable_mockModule('../../src/middleware/appError.js', () => ({ AppError }));
 jest.unstable_mockModule('fs', () => ({ default: mockFs, ...mockFs }));
 jest.unstable_mockModule('uuid', () => ({ v4: jest.fn().mockReturnValue('mock-uuid') }));
 
@@ -54,16 +60,18 @@ describe('uploadService (unit)', () => {
     mockUser = { id: 'user-1', update: jest.fn().mockResolvedValue(true) };
 
     storageService.isEnabled.mockReturnValue(false);
-    storageService.uploadBuffer.mockResolvedValue('https://cdn.example.com/photo-123.jpg');
-    mockFs.readFileSync.mockReturnValue(Buffer.from('file-content'));
-    mockFs.existsSync.mockReturnValue(true);
-    mockFs.statSync.mockReturnValue({
-      size: 1024,
+    storageService.uploadStream.mockResolvedValue('https://cdn.example.com/photo-123.jpg');
+    mockFs.createReadStream.mockReturnValue('mock-stream');
+    mockFsp.stat.mockResolvedValue({
+      size: 2048, // ≠ multer's file.size — proves the send-time stat is used
       birthtime: new Date('2025-01-01'),
       mtime: new Date('2025-01-02'),
       isDirectory: () => false,
     });
-    mockFs.readdirSync.mockReturnValue(['file1.jpg', 'file2.png']);
+    mockFsp.unlink.mockResolvedValue(undefined);
+    mockFsp.readdir.mockResolvedValue(['file1.jpg', 'file2.png']);
+    mockFsp.mkdir.mockResolvedValue(undefined);
+    mockFsp.rename.mockResolvedValue(undefined);
   });
 
   // ── processSingleUpload ──
@@ -78,16 +86,17 @@ describe('uploadService (unit)', () => {
       expect(result.uploadedBy).toBe('user-1');
     });
 
-    it('uploads to cloud storage when enabled', async () => {
+    it('STREAMS to cloud storage with the stat-time length (never buffers, never trusts stale file.size)', async () => {
       storageService.isEnabled.mockReturnValue(true);
 
       const result = await processSingleUpload(mockFile, 'general', 'user-1');
 
-      expect(storageService.uploadBuffer).toHaveBeenCalledWith(
-        'general/photo-123.jpg', expect.any(Buffer), 'image/jpeg'
+      expect(mockFs.createReadStream).toHaveBeenCalledWith('/tmp/uploads/photo-123.jpg');
+      expect(storageService.uploadStream).toHaveBeenCalledWith(
+        'general/photo-123.jpg', 'mock-stream', 'image/jpeg', 2048
       );
       expect(result.url).toBe('https://cdn.example.com/photo-123.jpg');
-      expect(mockFs.unlinkSync).toHaveBeenCalledWith('/tmp/uploads/photo-123.jpg');
+      expect(mockFsp.unlink).toHaveBeenCalledWith('/tmp/uploads/photo-123.jpg');
     });
   });
 
@@ -130,55 +139,61 @@ describe('uploadService (unit)', () => {
   // ── deleteFile ──
 
   describe('deleteFile', () => {
-    it('deletes file within uploads directory', () => {
-      deleteFile('general', 'photo-123.jpg');
+    it('deletes file within uploads directory', async () => {
+      await deleteFile('general', 'photo-123.jpg');
 
-      expect(mockFs.unlinkSync).toHaveBeenCalled();
+      expect(mockFsp.unlink).toHaveBeenCalled();
     });
 
-    it('throws 404 when file does not exist', () => {
-      mockFs.existsSync.mockReturnValue(false);
+    it('throws 404 when file does not exist', async () => {
+      mockFsp.unlink.mockRejectedValue(Object.assign(new Error('nope'), { code: 'ENOENT' }));
 
-      expect(() => deleteFile('general', 'nonexistent.jpg')).toThrow('File not found');
+      await expect(deleteFile('general', 'nonexistent.jpg')).rejects.toThrow('File not found');
+    });
+
+    it('throws 500 on any other unlink failure', async () => {
+      mockFsp.unlink.mockRejectedValue(Object.assign(new Error('disk'), { code: 'EIO' }));
+
+      await expect(deleteFile('general', 'photo-123.jpg')).rejects.toThrow('Failed to delete file');
     });
   });
 
   // ── getFileInfo ──
 
   describe('getFileInfo', () => {
-    it('returns file stats for existing file', () => {
-      const result = getFileInfo('general', 'photo-123.jpg');
+    it('returns file stats for existing file', async () => {
+      const result = await getFileInfo('general', 'photo-123.jpg');
 
       expect(result.filename).toBe('photo-123.jpg');
       expect(result.type).toBe('general');
-      expect(result.size).toBe(1024);
+      expect(result.size).toBe(2048);
       expect(result.url).toBe('/uploads/general/photo-123.jpg');
     });
 
-    it('throws 404 when file does not exist', () => {
-      mockFs.existsSync.mockReturnValue(false);
+    it('throws 404 when file does not exist', async () => {
+      mockFsp.stat.mockRejectedValue(Object.assign(new Error('nope'), { code: 'ENOENT' }));
 
-      expect(() => getFileInfo('general', 'nonexistent.jpg')).toThrow('File not found');
+      await expect(getFileInfo('general', 'nonexistent.jpg')).rejects.toThrow('File not found');
     });
   });
 
   // ── listFiles ──
 
   describe('listFiles', () => {
-    it('returns paginated file list', () => {
-      mockFs.readdirSync.mockReturnValue(['a.jpg', 'b.jpg', 'c.jpg']);
+    it('returns paginated file list', async () => {
+      mockFsp.readdir.mockResolvedValue(['a.jpg', 'b.jpg', 'c.jpg']);
 
-      const result = listFiles('general', 1, 2);
+      const result = await listFiles('general', 1, 2);
 
       expect(result.files).toHaveLength(2);
       expect(result.pagination.totalItems).toBe(3);
       expect(result.pagination.totalPages).toBe(2);
     });
 
-    it('returns empty list when directory does not exist', () => {
-      mockFs.existsSync.mockReturnValue(false);
+    it('returns empty list when directory does not exist', async () => {
+      mockFsp.readdir.mockRejectedValue(Object.assign(new Error('nope'), { code: 'ENOENT' }));
 
-      const result = listFiles('nonexistent');
+      const result = await listFiles('nonexistent');
 
       expect(result.files).toEqual([]);
       expect(result.pagination.totalItems).toBe(0);
@@ -188,11 +203,11 @@ describe('uploadService (unit)', () => {
   // ── getStorageUsage ──
 
   describe('getStorageUsage', () => {
-    it('returns storage usage by type', () => {
-      mockFs.readdirSync.mockReturnValue(['file1.jpg']);
-      mockFs.statSync.mockReturnValue({ size: 1048576, isDirectory: () => false });
+    it('returns storage usage by type', async () => {
+      mockFsp.readdir.mockResolvedValue(['file1.jpg']);
+      mockFsp.stat.mockResolvedValue({ size: 1048576, isDirectory: () => false });
 
-      const result = getStorageUsage();
+      const result = await getStorageUsage();
 
       expect(result.totalUsage.bytes).toBeGreaterThan(0);
       expect(result.byType.general).toBeDefined();


### PR DESCRIPTION
## .review P4-10 — Reduce request-path overhead

Five commits, measured where the task demanded it.

### 1. Double authentication — MEASURED
`server_internal.js` mounts `optionalAuth` app-wide purely so the rate limiter can see the role; every protected route then ran `authenticateToken` doing the identical verify + `User.findByPk` again. Now `optionalAuth` caches the **verified (token → user) pair** on the request, and `authenticateToken` reuses it only when the exact token string matches. Rejection semantics intact by construction: only a successful optionalAuth populates the cache, so absent/different/invalid/inactive tokens all take the full verify and are rejected there (220 auth/RBAC tests green unmodified). The lastLogin debounce is preserved on the cached path.

**Benchmark** (300 sequential authed `GET /api/campaigns?limit=1` against the real app, local Postgres, warm-up excluded):
| | findByPk calls | per request | total ms | avg ms |
|---|---|---|---|---|
| before | 600 | **2.0** | 473 | 1.58 |
| after | 300 | **1.0** | 430 | 1.43 |

The duplicated DB lookup is gone (2→1 exactly). Wall-time delta is ~9% on loopback; on Render the eliminated lookup is a network round-trip, so the real saving is larger.

### 2. Agent detail/list — grouped COUNTs (unbounded loads gone)
`getAgentDetail` eager-loaded ALL assignedProspects (with campaign join) and ALL createdCampaigns **with all their prospects**, then reduced to counts in JS — memory growing with the agent's history. Now: one grouped `COUNT(*) GROUP BY leadStatus` + one campaign aggregate (with a per-campaign lead-count subquery), in parallel with the monthly series. The raw arrays are dropped from the response — **no consumer read them** (AdminAgentDetail renders basics + fetches prospects via the paginated `/agents/:id/prospects` endpoint); `stats` shapes unchanged; bounded `assignedPackages` stays. The commissions eager-load was already gone (P2-9). `getAssignedCampaignCounts` (every listAgents render) likewise: one `COUNT(DISTINCT)` grouped query instead of loading every active assignment row into JS — its unit suite now asserts the SQL seam (dedupe + null-campaign + active/spent guards) plus the row mapping.

### 3. Uploads — stream, don't buffer
`processSingleUpload`/avatar/campaign-assets `readFileSync`'d entire uploads (including transcoded video) into memory on the request path. Now `fs.createReadStream` → new `storageService.uploadStream` (PutObject with explicit ContentLength). **Hazard caught while converting:** the transcode step rewrites the file on disk, so multer's `file.size` is stale — the length is `stat`'ed at send time (a unit test pins this by making stat-size ≠ file.size). All remaining sync fs calls (`renameSync`/`statSync`/`readdirSync`/`unlinkSync`/`existsSync`) converted to `fs.promises`; the four read/delete endpoints became async (controller awaits added); TOCTOU existsSync checks replaced by ENOENT mapping with the same 400/404/500 contracts.

### 4. RedeemOps batching
- analyticsService awaited one heavy `getCampaignMetrics` per activation **sequentially** (up to a 50-row page, repeating shared campaigns) → per-**distinct**-campaign, in parallel.
- entitlementService's per-activation `drawContextForActivation` loop → parallel over the distinct set.

### Verification
- Backend + root eslint clean. Unit tier 123 suites / 2,101 green. Upload suites 41 green (HTTP layer included); agent suites 83 green unmodified; auth/RBAC 220 green unmodified; redeemOps analytics/fulfilment/entitlement 48 green.
- Full DB tier 133/134 — sole failure the known "socket hang up" supertest transient in an untouched pagination test; **65/65 green re-run in isolation**.
- Two unit files adapted to intentional seam changes (uploadService mocks → stream surface; agentStatsHelpers → SQL seam). Zero behavioral test changes elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y83Mpgkub5nZSD5UBNZM6V