### PR TITLE
fix(redeem-ops): serialize redemption reverse on its own state (P1-1)

### DIFF
--- a/backend/src/services/redeemOps/redemptionService.js
+++ b/backend/src/services/redeemOps/redemptionService.js
@@ -262,55 +262,75 @@ export function makeRedemptionService(overrides = {}) {
     if (!redemption) throw new AppError('Redemption not found', 404);
     if (redemption.status === 'reversed') return redemption;
 
-    await d.sequelize.transaction(async (t) => {
-      await redemption.update({ status: 'reversed', notes: [redemption.notes, `REVERSED: ${reason}`].filter(Boolean).join('\n') }, { transaction: t });
-      // Terminal for the entitlement (ERD.md §3.17): cancel it; re-fulfilment = manual re-issue.
-      await d.RewardEntitlement.update(
-        { status: 'cancelled' },
-        { where: { id: redemption.entitlementId }, transaction: t }
-      );
-      // A physical handover is the ONE redemption that can be reversed because
-      // it never happened: the consultant tapped "handed over" with the voucher
-      // still in their pocket, or tapped on the wrong lead. Unlike a partner
-      // redemption — a real-world event whose counters must stand — this one
-      // has to give the units back, or the "how many leads actually got their
-      // reward" number stays permanently inflated, and that number is the
-      // entire reason handover is recorded at all.
-      //
-      // Both counters move: `redeemedQuantity` (the handover) and
-      // `issuedQuantity` (the reservation, consumed back at issueForProspect),
-      // because the entitlement is now cancelled. Order is load-bearing —
-      // reverseIssued guards on `issuedQuantity - 1 >= redeemedQuantity`, so
-      // the redeemed side must come first.
-      if (redemption.method === 'agent_handover') {
-        await d.inventory.reverseRedeemed({
-          offerId: redemption.rewardOfferId, activationId: redemption.activationId,
-          entitlementId: redemption.entitlementId, redemptionId,
-          actorType: 'staff', actorUser: user, reason, transaction: t,
-        });
-        await d.inventory.reverseIssued({
-          offerId: redemption.rewardOfferId, activationId: redemption.activationId,
-          entitlementId: redemption.entitlementId, type: 'cancelled',
-          actorType: 'staff', reason, transaction: t,
-        });
-        await d.sequelize.query(
-          `UPDATE activations
-              SET "redeemedCount" = GREATEST("redeemedCount" - 1, 0),
-                  "issuedCount" = GREATEST("issuedCount" - 1, 0),
-                  "updatedAt" = NOW()
-            WHERE id = :id`,
-          { replacements: { id: redemption.activationId }, transaction: t }
+    try {
+      await d.sequelize.transaction(async (t) => {
+        // Conditional state transition — the concurrency gate, same shape as
+        // complete() above. The status check before this transaction reads
+        // outside it, so two concurrent voids of one redemption both reach
+        // here; only the call that actually flips completed→reversed may go on
+        // to move inventory counters, which guard on the aggregate offer totals
+        // and would otherwise happily move twice (P1-1).
+        const [count] = await d.Redemption.update(
+          { status: 'reversed', notes: [redemption.notes, `REVERSED: ${reason}`].filter(Boolean).join('\n') },
+          { where: { id: redemptionId, status: 'completed' }, transaction: t }
         );
-      }
-      await writeEvent(t, {
-        entitlementId: redemption.entitlementId, redemptionId, type: 'reversed',
-        actorType: 'staff', actorUserId: user.id, metadata: { reason },
+        if (count === 0) {
+          throw Object.assign(new Error('already'), { _already: true });
+        }
+        // Terminal for the entitlement (ERD.md §3.17): cancel it; re-fulfilment = manual re-issue.
+        await d.RewardEntitlement.update(
+          { status: 'cancelled' },
+          { where: { id: redemption.entitlementId }, transaction: t }
+        );
+        // A physical handover is the ONE redemption that can be reversed because
+        // it never happened: the consultant tapped "handed over" with the voucher
+        // still in their pocket, or tapped on the wrong lead. Unlike a partner
+        // redemption — a real-world event whose counters must stand — this one
+        // has to give the units back, or the "how many leads actually got their
+        // reward" number stays permanently inflated, and that number is the
+        // entire reason handover is recorded at all.
+        //
+        // Both counters move: `redeemedQuantity` (the handover) and
+        // `issuedQuantity` (the reservation, consumed back at issueForProspect),
+        // because the entitlement is now cancelled. Order is load-bearing —
+        // reverseIssued guards on `issuedQuantity - 1 >= redeemedQuantity`, so
+        // the redeemed side must come first.
+        if (redemption.method === 'agent_handover') {
+          await d.inventory.reverseRedeemed({
+            offerId: redemption.rewardOfferId, activationId: redemption.activationId,
+            entitlementId: redemption.entitlementId, redemptionId,
+            actorType: 'staff', actorUser: user, reason, transaction: t,
+          });
+          await d.inventory.reverseIssued({
+            offerId: redemption.rewardOfferId, activationId: redemption.activationId,
+            entitlementId: redemption.entitlementId, type: 'cancelled',
+            actorType: 'staff', reason, transaction: t,
+          });
+          await d.sequelize.query(
+            `UPDATE activations
+                SET "redeemedCount" = GREATEST("redeemedCount" - 1, 0),
+                    "issuedCount" = GREATEST("issuedCount" - 1, 0),
+                    "updatedAt" = NOW()
+              WHERE id = :id`,
+            { replacements: { id: redemption.activationId }, transaction: t }
+          );
+        }
+        await writeEvent(t, {
+          entitlementId: redemption.entitlementId, redemptionId, type: 'reversed',
+          actorType: 'staff', actorUserId: user.id, metadata: { reason },
+        });
+        await d.audit.recordAuditEvent({
+          actorUser: user, action: 'redemption.overridden', entityType: 'redemption',
+          entityId: redemptionId, reason, requestId, transaction: t,
+        });
       });
-      await d.audit.recordAuditEvent({
-        actorUser: user, action: 'redemption.overridden', entityType: 'redemption',
-        entityId: redemptionId, reason, requestId, transaction: t,
-      });
-    });
+    } catch (err) {
+      // Lost the race: the other caller already reversed it. Reply with the row
+      // it wrote — idempotent, and no counters moved a second time.
+      if (err?._already) return d.Redemption.findByPk(redemptionId);
+      throw err;
+    }
+    await redemption.reload();
     return redemption;
   }
 

--- a/backend/test/redeemOpsReverseRace.test.js
+++ b/backend/test/redeemOpsReverseRace.test.js
@@ -1,0 +1,158 @@
+/**
+ * P1-1 regression: two concurrent voids of ONE redemption must move inventory
+ * exactly once.
+ *
+ * reverse() reads the redemption and checks `status === 'reversed'` OUTSIDE its
+ * transaction, so both callers pass that check. Before the fix the flip itself
+ * was an unconditional `redemption.update({status:'reversed'})` — no WHERE
+ * guard, no rowcount check — so both bodies ran and both called
+ * reverseRedeemed/reverseIssued, which guard on the offer's AGGREGATE counters
+ * and cannot see that this particular redemption was already given back. Result:
+ * a handover reversed once, counters credited twice.
+ *
+ * The race is made deterministic by holding the winning transaction open (a slow
+ * injected audit writer) so the loser's pre-transaction read is guaranteed to
+ * observe 'completed'.
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+process.env.REDEEM_OPS_ENTITLEMENTS_ENABLED = 'true';
+
+import { randomBytes } from 'crypto';
+import { getApp, closeDb, createTestUser, createTestCampaign } from './helpers.js';
+import {
+  RewardOffer, Activation, RewardEntitlement, Redemption, RedemptionEvent,
+  RewardInventoryEvent, PartnerOrganisation,
+} from '../src/models/index.js';
+import { makeRedemptionService } from '../src/services/redeemOps/redemptionService.js';
+import { makeRedeemOpsAuditService } from '../src/services/redeemOps/auditService.js';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const redemptions = makeRedemptionService();
+
+// A service whose transaction stays open long enough for the second caller to
+// read the still-'completed' row — the exact interleaving the fix must survive.
+const realAudit = makeRedeemOpsAuditService();
+const slowRedemptions = makeRedemptionService({
+  audit: {
+    ...realAudit,
+    recordAuditEvent: async (args) => {
+      await sleep(300);
+      return realAudit.recordAuditEvent(args);
+    },
+  },
+});
+
+let admin, agent, partner, campaign, offer, activation;
+let phoneSeq = 100000;
+
+/** A handover redemption sitting on an offer with counter headroom, so a double
+ *  reverse is arithmetically POSSIBLE — otherwise the guards mask the bug. */
+async function makeHandoverRedemption() {
+  const entitlement = await RewardEntitlement.create({
+    rewardOfferId: offer.id, activationId: activation.id,
+    partnerOrganisationId: partner.id, status: 'redeemed',
+    phoneKey: `6590${String(phoneSeq++).padStart(6, '0')}`,
+    presentationTokenHash: randomBytes(32).toString('hex'),
+  });
+  const redemption = await Redemption.create({
+    entitlementId: entitlement.id, rewardOfferId: offer.id, activationId: activation.id,
+    partnerOrganisationId: partner.id, method: 'agent_handover',
+    actorType: 'staff', actorUserId: agent.user.id, status: 'completed',
+  });
+  return { entitlement, redemption };
+}
+
+const offerRow = async () => RewardOffer.findByPk(offer.id);
+
+beforeAll(async () => {
+  await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  agent = await createTestUser({ role: 'agent' });
+  partner = await PartnerOrganisation.create({
+    tradingName: 'Reverse Race Studio', normalizedName: 'reverse race studio', createdBy: admin.user.id,
+  });
+  campaign = await createTestCampaign(admin.user.id, { name: 'Reverse Race Campaign' });
+  offer = await RewardOffer.create({
+    partnerOrganisationId: partner.id, title: 'Race Handover Voucher',
+    committedQuantity: 200, allocatedQuantity: 150, status: 'active',
+    claimExpiryDays: 30, redemptionExpiryDays: 90, createdBy: admin.user.id,
+    // Headroom on BOTH counters: reverseRedeemed needs redeemedQuantity >= 1 and
+    // reverseIssued needs issuedQuantity - 1 >= redeemedQuantity, so with these
+    // totals a second (wrong) reversal succeeds instead of being masked.
+    issuedQuantity: 20, redeemedQuantity: 10,
+  });
+  activation = await Activation.create({
+    partnerOrganisationId: partner.id, rewardOfferId: offer.id, campaignId: campaign.id,
+    campaignNameSnapshot: campaign.name, allocatedQuantity: 60, status: 'active',
+    unlockPolicy: 'agent_unlock', createdBy: admin.user.id,
+    issuedCount: 20, redeemedCount: 10,
+  });
+});
+
+afterAll(async () => { await closeDb(); });
+
+describe('concurrent reverse of one redemption', () => {
+  test('moves inventory exactly once and answers the loser idempotently', async () => {
+    const { entitlement, redemption } = await makeHandoverRedemption();
+    const before = await offerRow();
+
+    const [winner, loser] = await Promise.all([
+      slowRedemptions.reverse(redemption.id, admin.user, 'first void — the real one'),
+      redemptions.reverse(redemption.id, admin.user, 'second void — same click, twice'),
+    ]);
+
+    // Both callers get the reversed row; neither throws.
+    expect(winner.status).toBe('reversed');
+    expect(loser.status).toBe('reversed');
+    expect(winner.id).toBe(redemption.id);
+    expect(loser.id).toBe(redemption.id);
+
+    // Counters moved ONCE — this is what double-reversing corrupted.
+    const after = await offerRow();
+    expect(after.redeemedQuantity).toBe(before.redeemedQuantity - 1);
+    expect(after.issuedQuantity).toBe(before.issuedQuantity - 1);
+
+    // ...and the ledger says so too: one give-back of each kind, not two.
+    const ledger = await RewardInventoryEvent.findAll({ where: { entitlementId: entitlement.id } });
+    expect(ledger.filter((e) => e.type === 'redeem_reversed')).toHaveLength(1);
+    expect(ledger.filter((e) => e.type === 'cancelled')).toHaveLength(1);
+
+    const events = await RedemptionEvent.findAll({ where: { redemptionId: redemption.id, type: 'reversed' } });
+    expect(events).toHaveLength(1);
+
+    expect((await RewardEntitlement.findByPk(entitlement.id)).status).toBe('cancelled');
+    expect((await Redemption.findByPk(redemption.id)).status).toBe('reversed');
+
+    const activationRow = await Activation.findByPk(activation.id);
+    expect(activationRow.redeemedCount).toBe(10 - 1);
+    expect(activationRow.issuedCount).toBe(20 - 1);
+  });
+
+  test('a sequential second void stays a no-op (unchanged behaviour)', async () => {
+    const { redemption } = await makeHandoverRedemption();
+
+    await redemptions.reverse(redemption.id, admin.user, 'void it');
+    const mid = await offerRow();
+    const again = await redemptions.reverse(redemption.id, admin.user, 'void it again');
+    const after = await offerRow();
+
+    expect(again.status).toBe('reversed');
+    expect(after.redeemedQuantity).toBe(mid.redeemedQuantity);
+    expect(after.issuedQuantity).toBe(mid.issuedQuantity);
+  });
+
+  test('a genuine single void still gives both counters back', async () => {
+    const { entitlement, redemption } = await makeHandoverRedemption();
+    const before = await offerRow();
+
+    const result = await redemptions.reverse(redemption.id, admin.user, 'mis-tap');
+
+    const after = await offerRow();
+    expect(result.status).toBe('reversed');
+    expect(result.notes).toContain('REVERSED: mis-tap');
+    expect(after.redeemedQuantity).toBe(before.redeemedQuantity - 1);
+    expect(after.issuedQuantity).toBe(before.issuedQuantity - 1);
+    expect((await RewardEntitlement.findByPk(entitlement.id)).status).toBe('cancelled');
+  });
+});


### PR DESCRIPTION
**Task P1-1** (high — release gate) · review round-2 queue

## Defect
`backend/src/services/redeemOps/redemptionService.js` `reverse()` read the redemption with an unlocked `findByPk`, checked `status === 'reversed'` **outside** the transaction, then inside the transaction flipped it with an unconditional `redemption.update({status:'reversed'})` — no `WHERE status` guard, no affected-row check.

Two concurrent voids of one redemption both pass the early check and both run the body. For an `agent_handover` redemption that means `reverseRedeemed` + `reverseIssued` fire twice: those guard on the offer's **aggregate** counters (`redeemedQuantity >= 1`, `issuedQuantity - 1 >= redeemedQuantity`), so as long as the offer has any headroom they happily move a second time. One reversal, two credits.

## Fix
The flip becomes the conditional transition `complete()` already uses a few lines above in the same file:

```js
const [count] = await d.Redemption.update(
  { status: 'reversed', notes: … },
  { where: { id: redemptionId, status: 'completed' }, transaction: t }
);
if (count === 0) throw Object.assign(new Error('already'), { _already: true });
```

Zero rows means another caller won the race, so we return the row it wrote (idempotent, no throw) and never touch counters. Nothing writes `status: 'flagged'` anywhere in the codebase, so gating on `'completed'` narrows no live path. Independently revertable — touches only `reverse()`, no shared helper with P1-2 or P1-8.

## Test proof
`backend/test/redeemOpsReverseRace.test.js` (new, 3 cases). The race is made **deterministic**, not timing-dependent: the winning call is a service instance whose injected audit writer sleeps 300 ms inside the transaction, so the loser's pre-transaction read is guaranteed to observe `completed`. The offer is seeded with counter headroom (issued 20 / redeemed 10) so a double reversal is arithmetically possible rather than masked by the guards.

- **Pre-fix:** `1 failed, 2 passed` — `redeemedQuantity` **expected 9, received 8** (the double decrement).
- **Post-fix:** `3 passed`. Ledger asserts exactly one `redeem_reversed` and one `cancelled`; one `reversed` RedemptionEvent; activation counters move once.

Full local run: `redeemOpsReverseRace`, `redeemOpsVoidRedemption`, `redeemOpsPhysicalHandover`, `redeemOpsFulfilment`, `redeemOpsFulfilmentDelivery`, `redeemOpsEntitlementRecovery`, `redemptionOutcomeService` → **70 passed**. `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)