### PR TITLE
fix(retell): share bakeIntendedAgentId so DNC-held voice leads auto-heal (P1-3)

### DIFF
--- a/backend/src/services/dncGate.js
+++ b/backend/src/services/dncGate.js
@@ -42,6 +42,30 @@ async function defaultScreeningHandoff(prospect, { intendedAgentId, alreadyCharg
 }
 
 /**
+ * Hold-target bake rule (PR-1, draw-launch-integrity §9.1 CX3+): a
+ * fallback-routed hold may only bake a target that can actually be DELIVERED
+ * to later. The System Agent has no lyfeId/mktrLeadsId, so a release to it
+ * default-denies (null destination) and the lead loops held forever — the
+ * 07-24 prod incident. A provenance-carrying DEFAULT_AGENT_ID also arrives
+ * via='fallback' and MUST keep its bake (it delivers fine), so the rule is
+ * provenance-based, not via-based. Null bake ⇒ release-time re-resolution ⇒
+ * the hold self-heals the moment a funded package appears. Non-fallback routes
+ * are untouched.
+ *
+ * Shared by BOTH capture paths (P1-3): web capture had it inline in
+ * prospectService while the Retell path baked its target un-nulled, so a voice
+ * lead held on a campaign with no funded agent never auto-healed.
+ */
+export async function bakeHoldTargetAgentId(candidateId, { routeVia, User: UserModel = User, transaction = null } = {}) {
+  if (!candidateId || routeVia !== 'fallback') return candidateId ?? null;
+  const user = await UserModel.findByPk(candidateId, {
+    attributes: ['id', 'lyfeId', 'mktrLeadsId'],
+    transaction,
+  }).catch(() => null);
+  return user && (user.lyfeId || user.mktrLeadsId) ? candidateId : null;
+}
+
+/**
  * dncGate — the "born-held-pending, release-on-clear" state machine for the create path.
  * Design: docs/plans/dnc-scrubbing.md §5.3–§5.5. Modeled on releaseSweep.js (atomic
  * reason-scoped claim + in-tx authoritative charge + persistEventDeliveries outbox + flush),

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -23,7 +23,7 @@ import {
 import { deductLeadCredit, chargeLeadCredit, deductExternalLeadBalance } from './leadCredits.js';
 import { decideAssignment } from './leadQuota.js';
 import { dncEnforcement, formatDncNumber, checkAndRecord as dncCheckAndRecord } from './dncService.js';
-import { gateHeldDncLead, dncCaptureGate } from './dncGate.js';
+import { gateHeldDncLead, dncCaptureGate, bakeHoldTargetAgentId } from './dncGate.js';
 import { hasValidExternalConsent, buildExternalConsentEvidence } from './externalConsent.js';
 import { buildDncConsentEvidence } from './dncConsent.js';
 import { buildProspectWhere } from './prospectScope.js';
@@ -873,23 +873,10 @@ export function makeProspectService(overrides = {}) {
         });
       }
 
-      // Hold-target bake rule (PR-1, draw-launch-integrity §9.1 CX3+): a
-      // fallback-routed hold may only bake a target that can actually be
-      // DELIVERED to later. The System Agent has no lyfeId/mktrLeadsId, so a
-      // release to it default-denies (null destination) and the lead loops
-      // held forever — the 07-24 prod incident. A provenance-carrying
-      // DEFAULT_AGENT_ID also arrives via='fallback' and MUST keep its bake
-      // (it delivers fine), so the rule is provenance-based, not via-based.
-      // Null bake ⇒ release-time re-resolution ⇒ the hold self-heals the
-      // moment a funded package appears. Non-fallback routes are untouched.
-      const bakeIntendedAgentId = async (candidateId) => {
-        if (!candidateId || routeVia !== 'fallback') return candidateId ?? null;
-        const u = await m.User.findByPk(candidateId, {
-          attributes: ['id', 'lyfeId', 'mktrLeadsId'],
-          transaction: t,
-        }).catch(() => null);
-        return u && (u.lyfeId || u.mktrLeadsId) ? candidateId : null;
-      };
+      // Hold-target bake rule — shared with the Retell capture path (P1-3);
+      // the rule itself is documented on bakeHoldTargetAgentId in dncGate.js.
+      const bakeIntendedAgentId = (candidateId) =>
+        bakeHoldTargetAgentId(candidateId, { routeVia, User: m.User, transaction: t });
 
       // DNC block-mode gate: a normally-assignable INTERNAL lead is HELD pending a DNC
       // check (released post-commit on clear). Never overrides an existing quarantine

--- a/backend/src/services/retellService.js
+++ b/backend/src/services/retellService.js
@@ -12,7 +12,7 @@ import { CircuitBreaker } from '../utils/circuitBreaker.js';
 import { destinationForAgent, externalIdForDestination, buildLeadHeldPayload, buildLeadCreatedPayload } from './prospectHelpers.js';
 import { dncCaptureGate } from './dncGate.js';
 import { dncEnforcement, formatDncNumber, checkAndRecord as dncCheckAndRecord } from './dncService.js';
-import { gateHeldDncLead } from './dncGate.js';
+import { gateHeldDncLead, bakeHoldTargetAgentId } from './dncGate.js';
 import { readLegacyViewSafe } from '../utils/designConfigV2Clamp.js';
 
 const IDEMPOTENCY_SCOPE = 'retell:call';
@@ -307,7 +307,14 @@ export function makeRetellService(overrides = {}) {
       let dncIntendedAgentId = null;
       let dncAlreadyCharged = false;
       if (dncBlockApplies && !quarantined) {
-        dncIntendedAgentId = assignedAgentId;
+        // Same hold-target bake rule the web path uses (P1-3): a fallback route
+        // with no deliverable agent must bake NULL so release re-resolves.
+        // Baking the System-Agent id here made agentId truthy at release,
+        // skipping re-resolution — the voice lead then failed delivery to a
+        // destination-less agent and looped held forever.
+        dncIntendedAgentId = await bakeHoldTargetAgentId(assignedAgentId, {
+          routeVia, User: d.User, transaction: t,
+        });
         dncAlreadyCharged = decision.charged === true;
         dncHeld = true;
         quarantined = true;

--- a/backend/test/unit/dncGate.test.js
+++ b/backend/test/unit/dncGate.test.js
@@ -218,3 +218,43 @@ describe('releaseDncClearedLead', () => {
     expect(tx.rollback).toHaveBeenCalled();
   });
 });
+
+/**
+ * P1-3: the hold-target bake rule, now shared by BOTH capture paths (web via
+ * prospectService, voice via retellService) instead of living inline in one.
+ */
+describe('bakeHoldTargetAgentId', () => {
+  const userWith = (attrs) => ({ findByPk: jest.fn().mockResolvedValue(attrs) });
+
+  it('nulls a fallback target with no delivery provenance (the System Agent)', async () => {
+    const User = userWith({ id: 'sys', lyfeId: null, mktrLeadsId: null });
+    await expect(gate.bakeHoldTargetAgentId('sys', { routeVia: 'fallback', User })).resolves.toBeNull();
+  });
+
+  it('keeps a fallback target that carries a lyfeId', async () => {
+    const User = userWith({ id: 'a1', lyfeId: 'lyfe-1', mktrLeadsId: null });
+    await expect(gate.bakeHoldTargetAgentId('a1', { routeVia: 'fallback', User })).resolves.toBe('a1');
+  });
+
+  it('keeps a fallback target that carries an mktrLeadsId', async () => {
+    const User = userWith({ id: 'a2', lyfeId: null, mktrLeadsId: 'ml-2' });
+    await expect(gate.bakeHoldTargetAgentId('a2', { routeVia: 'fallback', User })).resolves.toBe('a2');
+  });
+
+  it('leaves non-fallback routes alone without a lookup', async () => {
+    const User = userWith(null);
+    await expect(gate.bakeHoldTargetAgentId('a3', { routeVia: 'package', User })).resolves.toBe('a3');
+    expect(User.findByPk).not.toHaveBeenCalled();
+  });
+
+  it('normalises a missing candidate to null', async () => {
+    const User = userWith(null);
+    await expect(gate.bakeHoldTargetAgentId(undefined, { routeVia: 'fallback', User })).resolves.toBeNull();
+    await expect(gate.bakeHoldTargetAgentId(null, { routeVia: 'package', User })).resolves.toBeNull();
+  });
+
+  it('nulls the bake when the lookup itself fails — never bake an unverified target', async () => {
+    const User = { findByPk: jest.fn().mockRejectedValue(new Error('db down')) };
+    await expect(gate.bakeHoldTargetAgentId('a4', { routeVia: 'fallback', User })).resolves.toBeNull();
+  });
+});

--- a/backend/test/unit/retellDncHoldBake.test.js
+++ b/backend/test/unit/retellDncHoldBake.test.js
@@ -1,0 +1,131 @@
+/**
+ * P1-3 regression: a DNC-held VOICE lead must bake a hold target it can
+ * actually be delivered to.
+ *
+ * The web capture path nulls a fallback-routed target that carries no
+ * lyfeId/mktrLeadsId, so releaseDncClearedLead re-resolves on clear and the
+ * lead self-heals once a funded package appears. The Retell path set
+ * `dncIntendedAgentId = assignedAgentId` with no such nulling, so a [Retell]
+ * campaign with dncCheckAtSubmit=block and no funded agent baked the
+ * System-Agent id. On release that id is truthy, re-resolution is skipped,
+ * delivery to the destination-less System Agent fails — and the lead loops held
+ * forever. Same shape as the 07-24 prod incident, on the path that never got
+ * the fix.
+ */
+import { jest } from '@jest/globals';
+import '../setup.js';
+import { makeRetellService } from '../../src/services/retellService.js';
+
+const SYSTEM_AGENT = { id: 'system-agent-id', lyfeId: null, mktrLeadsId: null, phone: null, email: 'system@mktr.local', firstName: 'System', lastName: 'Agent' };
+const REAL_AGENT = { id: 'real-agent-id', lyfeId: 'lyfe-77', mktrLeadsId: null, phone: '+6590001234', email: 'agent@test.com', firstName: 'Real', lastName: 'Agent' };
+
+function buildDeps({ routing, agentRow }) {
+  const created = [];
+  const campaign = {
+    id: 'camp-retell',
+    name: '[Retell] Voice Bot',
+    is_active: true,
+    design_config: { dncCheckAtSubmit: true },
+  };
+
+  return {
+    created,
+    deps: {
+      Prospect: {
+        create: jest.fn(async (payload) => {
+          created.push(payload);
+          return { id: 'prospect-held', ...payload, toJSON() { return { ...payload }; } };
+        }),
+        findByPk: jest.fn().mockResolvedValue(null),
+      },
+      IdempotencyKey: { findOne: jest.fn().mockResolvedValue(null), create: jest.fn().mockResolvedValue({}) },
+      User: { findByPk: jest.fn(async (id) => (id === agentRow.id ? agentRow : null)), findOne: jest.fn().mockResolvedValue(null) },
+      Campaign: {
+        findByPk: jest.fn().mockResolvedValue(campaign),
+        findOne: jest.fn().mockResolvedValue(campaign),
+        findAll: jest.fn().mockResolvedValue([campaign]),
+      },
+      ProspectActivity: { create: jest.fn().mockResolvedValue({}) },
+      sequelize: {
+        transaction: jest.fn().mockResolvedValue({
+          commit: jest.fn().mockResolvedValue(undefined),
+          rollback: jest.fn().mockResolvedValue(undefined),
+        }),
+      },
+      resolveLeadRouting: jest.fn().mockResolvedValue(routing),
+      getSystemAgentId: jest.fn().mockResolvedValue(SYSTEM_AGENT.id),
+      chargeLeadCredit: jest.fn().mockResolvedValue(true),
+      // No funded package: the route stands as resolved, nothing charged.
+      decideAssignment: jest.fn(async ({ routing: r }) => ({
+        action: 'assign', assignedAgentId: r.agentId, charged: false, via: r.via,
+      })),
+      // Campaign opts into the DNC check and the registry is in block mode.
+      dncEnforcement: jest.fn(() => 'block'),
+      formatDncNumber: jest.fn(() => '91234567'),
+      dncCheckAndRecord: jest.fn().mockResolvedValue({ status: 'clear' }),
+      gateHeldDncLead: jest.fn().mockResolvedValue({ outcome: 'held' }),
+      dispatchEvent: jest.fn().mockResolvedValue(undefined),
+      sendLeadAssignmentEmail: jest.fn().mockResolvedValue(undefined),
+      logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+    },
+  };
+}
+
+const payload = (callId) => ({
+  call_id: callId,
+  call_status: 'ended',
+  call_analysis: { call_successful: true, user_sentiment: 'Positive', call_summary: 'Good call', custom_analysis_data: {} },
+  retell_llm_dynamic_variables: { name: 'Jane Tan' },
+  to_number: '+6591234567',
+  from_number: '+6590000000',
+  transcript: 'hello',
+  duration_ms: 30000,
+  disconnection_reason: 'agent_hangup',
+  agent_id: 'retell-agent-1',
+  agent_name: 'Voice Bot',
+});
+
+describe('Retell DNC hold — intended-agent bake', () => {
+  it('bakes NULL when the only route is the destination-less System Agent', async () => {
+    const { created, deps } = buildDeps({
+      routing: { agentId: SYSTEM_AGENT.id, via: 'fallback' },
+      agentRow: SYSTEM_AGENT,
+    });
+
+    const res = await makeRetellService(deps).processRetellCall(payload('call-sys'));
+
+    expect(res.status).toBe('quarantined'); // born held pending the DNC check
+    expect(created).toHaveLength(1);
+    const row = created[0];
+    expect(row.quarantineReason).toBe('dnc_pending');
+    // The whole point: null ⇒ release-time re-resolution ⇒ the hold self-heals.
+    expect(row.dncMetadata).toEqual({ intendedAgentId: null, alreadyCharged: false });
+    expect(deps.gateHeldDncLead).toHaveBeenCalled();
+  });
+
+  it('keeps a fallback bake that CAN be delivered (provenance-carrying default agent)', async () => {
+    const { created, deps } = buildDeps({
+      routing: { agentId: REAL_AGENT.id, via: 'fallback' },
+      agentRow: REAL_AGENT,
+    });
+
+    await makeRetellService(deps).processRetellCall(payload('call-default'));
+
+    expect(created[0].dncMetadata.intendedAgentId).toBe(REAL_AGENT.id);
+  });
+
+  it('leaves a non-fallback route untouched', async () => {
+    const { created, deps } = buildDeps({
+      routing: { agentId: REAL_AGENT.id, via: 'package' },
+      agentRow: REAL_AGENT,
+    });
+
+    await makeRetellService(deps).processRetellCall(payload('call-package'));
+
+    expect(created[0].dncMetadata.intendedAgentId).toBe(REAL_AGENT.id);
+    // A non-fallback route never needs the deliverability lookup.
+    expect(deps.User.findByPk).not.toHaveBeenCalledWith(REAL_AGENT.id, expect.objectContaining({
+      attributes: ['id', 'lyfeId', 'mktrLeadsId'],
+    }));
+  });
+});


### PR DESCRIPTION
**Task P1-3** (high — release gate) · review round-2 queue

## Defect
The web capture path defines `bakeIntendedAgentId` inline in `prospectService.js`: for a `via: 'fallback'` route it returns **null** unless the candidate agent carries a `lyfeId` or `mktrLeadsId`. That null is what makes a DNC hold self-healing — `releaseDncClearedLead` re-resolves routing when `agentId` is falsy and refuses fallback results, so the lead stays held for backfill and delivers the moment a funded package appears.

`retellService.js` set `dncIntendedAgentId = assignedAgentId` with no such nulling. On a `[Retell]` campaign with `dncCheckAtSubmit=block` and no funded package agent, the route resolves to the System Agent and that id gets baked. At release `agentId` is truthy → re-resolution skipped → delivery to an agent with no destination → the lead loops held forever. Same failure as the 07-24 prod incident, on the path that never got the fix.

## Fix
The rule moves to `dncGate.js` as an exported `bakeHoldTargetAgentId(candidateId, { routeVia, User, transaction })`, carrying its original comment. `dncGate.js` is already imported by both capture services, so this adds no edge to the import graph (P4-7's zero-cycle property holds). `prospectService` now delegates — same lookup, same `m.User` DI seam, same behaviour — and the Retell DNC gate calls it before baking.

Lookup failures resolve to null (never bake a target we couldn't verify), matching the original `.catch(() => null)`.

## Test proof
- `backend/test/unit/retellDncHoldBake.test.js` (new, 3 cases) drives `processRetellCall` through the DNC-block gate with injected deps and asserts the persisted `dncMetadata`.
- `backend/test/unit/dncGate.test.js` (+6 cases) pins the extracted helper directly: nulls the provenance-less fallback, keeps `lyfeId`/`mktrLeadsId` bakes, skips the lookup for non-fallback routes, null-safe, and fails closed on a lookup error.

Reverting **only** the Retell call site (leaving the helper and the web rewire in place) flips the discriminating case: `Expected: null, Received: "system-agent-id"` — `1 failed, 2 passed`. With the fix: `3 passed`.

Local run: `retellDncHoldBake`, `dncGate`, `retellService`, `prospectServiceScreening` → **66 passed**. `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)