### PR TITLE
fix(retell): scope call-recording fetch to owner/admin (P1-4)

### DIFF
--- a/backend/src/controllers/retellController.js
+++ b/backend/src/controllers/retellController.js
@@ -71,6 +71,6 @@ export const handleWebhook = asyncHandler(async (req, res) => {
  * First checks sourceMetadata, then fetches from Retell API if missing.
  */
 export const fetchRecordingUrl = asyncHandler(async (req, res) => {
-  const result = await getRecordingUrl(req.params.prospectId);
+  const result = await getRecordingUrl(req.params.prospectId, req.user);
   return res.json(result);
 });

--- a/backend/src/routes/retell.js
+++ b/backend/src/routes/retell.js
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { authenticateToken } from '../middleware/auth.js';
+import { authenticateToken, requireAgentOrAdmin } from '../middleware/auth.js';
 import * as retellController from '../controllers/retellController.js';
 
 export const meta = { path: '/api/retell' };
@@ -9,7 +9,9 @@ const router = Router();
 // POST /api/retell/webhook — Retell AI post-call webhook
 router.post('/webhook', retellController.handleWebhook);
 
-// GET /api/retell/recording/:prospectId — Retell call recording URL
-router.get('/recording/:prospectId', authenticateToken, retellController.fetchRecordingUrl);
+// GET /api/retell/recording/:prospectId — Retell call recording URL.
+// Role gate + owner scope (P1-4): a recording is PDPA-regulated call content,
+// so this matches the other prospect reads instead of accepting any session.
+router.get('/recording/:prospectId', authenticateToken, requireAgentOrAdmin, retellController.fetchRecordingUrl);
 
 export default router;

--- a/backend/src/services/retellService.js
+++ b/backend/src/services/retellService.js
@@ -10,6 +10,7 @@ import { AppError } from '../middleware/appError.js';
 import { logger } from '../utils/logger.js';
 import { CircuitBreaker } from '../utils/circuitBreaker.js';
 import { destinationForAgent, externalIdForDestination, buildLeadHeldPayload, buildLeadCreatedPayload } from './prospectHelpers.js';
+import { buildProspectWhere } from './prospectScope.js';
 import { dncCaptureGate } from './dncGate.js';
 import { dncEnforcement, formatDncNumber, checkAndRecord as dncCheckAndRecord } from './dncService.js';
 import { gateHeldDncLead } from './dncGate.js';
@@ -46,6 +47,7 @@ const defaultDeps = {
   formatDncNumber,
   dncCheckAndRecord,
   gateHeldDncLead,
+  buildProspectWhere,
   // Lazy (dynamic import) so existing unit suites that mock this module's
   // graph don't have to know the screening services. DI-overridable.
   handleScreeningWebhook: async (payload, event) =>
@@ -473,11 +475,21 @@ export function makeRetellService(overrides = {}) {
    * Get the Retell call recording URL for a prospect.
    * Checks sourceMetadata first, then fetches from Retell API and caches the result.
    *
+   * Owner-scoped (P1-4): this used to be the one prospect fetch in the domain
+   * that skipped buildProspectWhere, so any authenticated principal could walk
+   * UUIDs and pull PDPA-regulated call recordings. Out-of-scope prospects are
+   * indistinguishable from missing ones — same 404 as prospectReadService.
+   *
    * @param {string} prospectId
+   * @param {object} user — the authenticated caller
    * @returns {{ recordingUrl: string|null }}
    */
-  async function getRecordingUrl(prospectId) {
-    const prospect = await d.Prospect.findByPk(prospectId);
+  async function getRecordingUrl(prospectId, user) {
+    if (!user) {
+      throw new d.AppError('Not authorized', 401);
+    }
+    const scopeFilter = await d.buildProspectWhere(user);
+    const prospect = await d.Prospect.findOne({ where: { id: prospectId, ...scopeFilter } });
     if (!prospect) {
       throw new d.AppError('Prospect not found', 404);
     }

--- a/backend/test/retellRecordingScope.test.js
+++ b/backend/test/retellRecordingScope.test.js
@@ -1,0 +1,71 @@
+/**
+ * P1-4 regression: call recordings are owner-scoped.
+ *
+ * GET /api/retell/recording/:prospectId was gated by authenticateToken ONLY,
+ * and the service did a bare `Prospect.findByPk(prospectId)` — the one prospect
+ * fetch in the domain that skipped buildProspectWhere. Any authenticated
+ * principal, including a self-registered customer, could walk prospect UUIDs
+ * and receive PDPA-regulated recording URLs (which the route then caches).
+ *
+ * The route now carries the same role gate as the other prospect reads and the
+ * lookup runs through the scope filter, so out-of-scope prospects are
+ * indistinguishable from missing ones.
+ */
+import request from 'supertest';
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect } from './helpers.js';
+
+const RECORDING_URL = 'https://recordings.retell.ai/call-p1-4.mp3';
+
+let app, admin, owner, otherAgent, customer, prospect;
+
+beforeAll(async () => {
+  app = await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  owner = await createTestUser({ role: 'agent' });
+  otherAgent = await createTestUser({ role: 'agent' });
+  customer = await createTestUser({ role: 'customer' });
+
+  const campaign = await createTestCampaign(admin.user.id, { name: 'Recording Scope Campaign' });
+  prospect = await createTestProspect(campaign.id, {
+    assignedAgentId: owner.user.id,
+    leadSource: 'call_bot',
+    sourceMetadata: { retellCallId: 'call-p1-4', recordingUrl: RECORDING_URL },
+  });
+});
+
+afterAll(async () => { await closeDb(); });
+
+const get = (token) => request(app)
+  .get(`/api/retell/recording/${prospect.id}`)
+  .set('Authorization', `Bearer ${token}`);
+
+describe('GET /api/retell/recording/:prospectId', () => {
+  it('gives the owning agent the recording', async () => {
+    const res = await get(owner.token);
+    expect(res.status).toBe(200);
+    expect(res.body.recordingUrl).toBe(RECORDING_URL);
+  });
+
+  it('gives an admin the recording', async () => {
+    const res = await get(admin.token);
+    expect(res.status).toBe(200);
+    expect(res.body.recordingUrl).toBe(RECORDING_URL);
+  });
+
+  it('does not leak the recording to a different agent', async () => {
+    const res = await get(otherAgent.token);
+    expect(res.status).toBe(404);
+    expect(JSON.stringify(res.body)).not.toContain(RECORDING_URL);
+  });
+
+  it('refuses a customer session outright', async () => {
+    const res = await get(customer.token);
+    expect(res.status).toBe(403);
+    expect(JSON.stringify(res.body)).not.toContain(RECORDING_URL);
+  });
+
+  it('still requires authentication', async () => {
+    const res = await request(app).get(`/api/retell/recording/${prospect.id}`);
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/test/unit/retellService.test.js
+++ b/backend/test/unit/retellService.test.js
@@ -35,6 +35,9 @@ function buildMocks() {
   const Prospect = {
     create: jest.fn().mockResolvedValue(mockProspect),
     findByPk: jest.fn().mockResolvedValue(mockProspect),
+    // getRecordingUrl is owner-scoped (P1-4): it resolves through
+    // buildProspectWhere with findOne, never a bare findByPk.
+    findOne: jest.fn().mockResolvedValue(mockProspect),
   };
 
   const IdempotencyKey = {
@@ -537,31 +540,54 @@ describe('retellService (unit)', () => {
       });
     });
 
-    it('throws 404 when prospect not found', async () => {
-      mocks.Prospect.findByPk.mockResolvedValue(null);
+    // Owner scope (P1-4): every call carries the authenticated caller, and the
+    // lookup is a scoped findOne — an out-of-scope prospect is simply not found.
+    const admin = { id: 'admin-1', role: 'admin' };
 
-      await expect(service.getRecordingUrl('nonexistent'))
+    it('throws 404 when prospect not found (or is out of scope)', async () => {
+      mocks.Prospect.findOne.mockResolvedValue(null);
+
+      await expect(service.getRecordingUrl('nonexistent', admin))
         .rejects.toThrow('Prospect not found');
     });
 
+    it('throws 401 when no caller is supplied — never an unscoped read', async () => {
+      await expect(service.getRecordingUrl('prospect-1'))
+        .rejects.toThrow('Not authorized');
+      expect(mocks.Prospect.findOne).not.toHaveBeenCalled();
+    });
+
+    it('scopes the lookup with buildProspectWhere', async () => {
+      mocks.Prospect.findOne.mockResolvedValue({
+        sourceMetadata: { retellCallId: 'call123', recordingUrl: 'https://cached.url/recording.mp3' },
+      });
+      const agent = { id: 'agent-9', role: 'agent' };
+
+      await service.getRecordingUrl('prospect-1', agent);
+
+      expect(mocks.Prospect.findOne).toHaveBeenCalledWith({
+        where: { id: 'prospect-1', assignedAgentId: 'agent-9' },
+      });
+    });
+
     it('throws 404 when prospect has no retellCallId', async () => {
-      mocks.Prospect.findByPk.mockResolvedValue({
+      mocks.Prospect.findOne.mockResolvedValue({
         sourceMetadata: {},
       });
 
-      await expect(service.getRecordingUrl('prospect-1'))
+      await expect(service.getRecordingUrl('prospect-1', admin))
         .rejects.toThrow('Not a Retell prospect');
     });
 
     it('returns cached recordingUrl from sourceMetadata', async () => {
-      mocks.Prospect.findByPk.mockResolvedValue({
+      mocks.Prospect.findOne.mockResolvedValue({
         sourceMetadata: {
           retellCallId: 'call123',
           recordingUrl: 'https://cached.url/recording.mp3',
         },
       });
 
-      const result = await service.getRecordingUrl('prospect-1');
+      const result = await service.getRecordingUrl('prospect-1', admin);
       expect(result).toEqual({ recordingUrl: 'https://cached.url/recording.mp3' });
     });
   });


### PR DESCRIPTION
**Task P1-4** (high — release gate) · review round-2 queue

## Defect
`backend/src/routes/retell.js:13` mounted `GET /recording/:prospectId` with `authenticateToken` and **no role gate**. `retellController.js:74` passed `req.params.prospectId` straight through, and `retellService.js` did `Prospect.findByPk(prospectId)` with no scope filter — the only prospect fetch in the domain that skipped `buildProspectWhere`.

Any authenticated principal — including a self-registered `customer` — could enumerate prospect UUIDs and receive PDPA-regulated call-recording URLs. The handler then caches the fetched URL into `sourceMetadata`, so the first unauthorized caller also warms it for the next.

## Fix
- **Route**: adds `requireAgentOrAdmin`, the same guard `/api/prospects` uses for its agent/admin reads and writes.
- **Controller**: threads `req.user` into `getRecordingUrl(prospectId, user)`.
- **Service**: resolves the prospect via `findOne({ where: { id, ...await buildProspectWhere(user) } })`, so an out-of-scope prospect returns the same `404 Prospect not found` as a missing one (no existence oracle), matching `prospectReadService`. A missing user is a 401 rather than an unscoped read, so the service is safe even if a future route forgets the middleware.

`buildProspectWhere` is registered in the service's injectable deps, following the module's existing DI convention.

## Test proof
`backend/test/retellRecordingScope.test.js` (new, 5 cases).

**Pre-fix: `2 failed, 3 passed`**
- a different agent: **expected 404, received 200** — with the recording URL in the body
- a customer: **expected 403, received 200** — same leak

**Post-fix: `5 passed`** — owning agent 200, admin 200, other agent 404, customer 403, anonymous 401.

Local run: `retellRecordingScope`, `retell`, `rbac`, `prospects` → **235 passed**. `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)