### PR TITLE
fix(uploads): admin-gate file admin routes + host-guard + traversal fix (P1-5)

### DIFF
--- a/backend/src/middleware/internalRouteHostGuard.js
+++ b/backend/src/middleware/internalRouteHostGuard.js
@@ -32,6 +32,9 @@ const BLOCKED_PATH_PREFIXES = [
   '/api/webhooks',
   '/api/integrations',
   '/api/redeem-ops',
+  // File administration + staff uploads (P1-5): nothing on a consumer host
+  // uploads to or enumerates uploads/ — the only caller is the admin Studio.
+  '/api/uploads',
 ];
 
 const OPS_ALLOWED_PREFIXES = [

--- a/backend/src/routes/uploads.js
+++ b/backend/src/routes/uploads.js
@@ -3,7 +3,7 @@ import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
 import { v4 as uuidv4 } from 'uuid';
-import { authenticateToken } from '../middleware/auth.js';
+import { authenticateToken, requireAdmin } from '../middleware/auth.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
 import { sniffFileType, canonicalExtensionForMime } from '../utils/fileSignature.js';
@@ -168,10 +168,13 @@ router.post('/multiple',        authenticateToken, upload.array('files', 5),    
 router.post('/avatar',          authenticateToken, upload.single('avatar'),      verifyUploadedContent, uploadController.uploadAvatar);
 router.post('/campaign-assets', authenticateToken, upload.array('assets', 10),   verifyUploadedContent, uploadController.uploadCampaignAssets);
 router.post('/documents',       authenticateToken, upload.array('documents', 5), verifyUploadedContent, uploadController.uploadDocuments);
-router.delete('/:type/:filename',      authenticateToken, uploadController.deleteFile);
-router.get('/info/:type/:filename',    authenticateToken, uploadController.getFileInfo);
-router.get('/list/:type',              authenticateToken, uploadController.listFiles);
-router.get('/stats/usage',             authenticateToken, uploadController.getStorageUsage);
+// File ADMINISTRATION — enumerate, inspect and unlink anything under uploads/.
+// The service has no ownership concept, so a session alone is not enough: these
+// are admin-only (P1-5). Upload itself stays open to any authenticated staff.
+router.delete('/:type/:filename',      authenticateToken, requireAdmin, uploadController.deleteFile);
+router.get('/info/:type/:filename',    authenticateToken, requireAdmin, uploadController.getFileInfo);
+router.get('/list/:type',              authenticateToken, requireAdmin, uploadController.listFiles);
+router.get('/stats/usage',             authenticateToken, requireAdmin, uploadController.getStorageUsage);
 
 // --- Multer error handling middleware ---
 

--- a/backend/src/services/uploadService.js
+++ b/backend/src/services/uploadService.js
@@ -157,10 +157,19 @@ export async function processDocumentUpload(files, entityType, entityId, userId)
   return documents;
 }
 
-/** Resolve + traversal-check a path under uploads/. */
+/**
+ * Resolve + traversal-check a path under uploads/.
+ *
+ * The check is relative-path based, not prefix based (P1-5): a bare
+ * startsWith() accepts any SIBLING directory that merely shares the prefix —
+ * path.resolve('/app/uploads-x').startsWith('/app/uploads') is true — so
+ * type='../uploads-x' escaped the sandbox while passing the guard.
+ */
 function safeUploadsPath(...segments) {
-  const filePath = path.join(uploadsDir, ...segments);
-  if (!path.resolve(filePath).startsWith(path.resolve(uploadsDir))) {
+  const root = path.resolve(uploadsDir);
+  const filePath = path.resolve(path.join(uploadsDir, ...segments));
+  const relative = path.relative(root, filePath);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
     throw new AppError('Invalid file path', 400);
   }
   return filePath;

--- a/backend/test/uploadsAuthz.test.js
+++ b/backend/test/uploadsAuthz.test.js
@@ -1,0 +1,124 @@
+/**
+ * P1-5 regression: the file-administration half of /api/uploads.
+ *
+ * DELETE /:type/:filename, GET /info, GET /list and GET /stats carried
+ * authenticateToken and no role gate, and uploadService has no ownership
+ * concept — so any authenticated principal, including a self-registered
+ * customer, could enumerate every uploaded file and unlink any of them
+ * (campaign heroes, avatars, verification documents).
+ *
+ * Two more holes closed here: /api/uploads was missing from the internal-route
+ * host guard (reachable from the public redeem.sg origin), and the traversal
+ * check was prefix-only, so a SIBLING directory sharing the prefix
+ * (uploads-x vs uploads) passed it.
+ */
+import request from 'supertest';
+import fs from 'fs';
+import path from 'path';
+import { v4 as uuidv4 } from 'uuid';
+import { getApp, closeDb, createTestUser } from './helpers.js';
+import { deleteFile, getFileInfo, listFiles } from '../src/services/uploadService.js';
+
+let app, admin, agent, customer, filename;
+
+const uploadsDir = path.join(process.cwd(), 'uploads');
+const probes = [];
+
+beforeAll(async () => {
+  app = await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  agent = await createTestUser({ role: 'agent' });
+  customer = await createTestUser({ role: 'customer' });
+
+  const dir = path.join(uploadsDir, 'images');
+  fs.mkdirSync(dir, { recursive: true });
+  filename = `p1-5-probe-${uuidv4()}.png`;
+  const filePath = path.join(dir, filename);
+  fs.writeFileSync(filePath, Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+  probes.push(filePath);
+});
+
+afterAll(async () => {
+  for (const p of probes) {
+    try { fs.unlinkSync(p); } catch { /* already gone */ }
+  }
+  await closeDb();
+});
+
+const auth = (token) => ({ Authorization: `Bearer ${token}` });
+
+describe('file-administration routes are admin-only', () => {
+  it('a customer cannot list uploaded files', async () => {
+    const res = await request(app).get('/api/uploads/list/images').set(auth(customer.token));
+    expect(res.status).toBe(403);
+  });
+
+  it('an agent cannot list uploaded files', async () => {
+    const res = await request(app).get('/api/uploads/list/images').set(auth(agent.token));
+    expect(res.status).toBe(403);
+  });
+
+  it('a customer cannot read file info', async () => {
+    const res = await request(app).get(`/api/uploads/info/images/${filename}`).set(auth(customer.token));
+    expect(res.status).toBe(403);
+  });
+
+  it('a customer cannot read storage stats', async () => {
+    const res = await request(app).get('/api/uploads/stats/usage').set(auth(customer.token));
+    expect(res.status).toBe(403);
+  });
+
+  it('a customer cannot delete someone else’s file — and the file survives', async () => {
+    const res = await request(app).delete(`/api/uploads/images/${filename}`).set(auth(customer.token));
+    expect(res.status).toBe(403);
+    expect(fs.existsSync(path.join(uploadsDir, 'images', filename))).toBe(true);
+  });
+
+  it('an admin still gets the full surface', async () => {
+    const list = await request(app).get('/api/uploads/list/images').set(auth(admin.token));
+    expect(list.status).toBe(200);
+    expect(Array.isArray(list.body.data.files)).toBe(true);
+
+    const info = await request(app).get(`/api/uploads/info/images/${filename}`).set(auth(admin.token));
+    expect(info.status).toBe(200);
+    expect(info.body.data.file.filename).toBe(filename);
+
+    const stats = await request(app).get('/api/uploads/stats/usage').set(auth(admin.token));
+    expect(stats.status).toBe(200);
+
+    const del = await request(app).delete(`/api/uploads/images/${filename}`).set(auth(admin.token));
+    expect(del.status).toBe(200);
+    expect(fs.existsSync(path.join(uploadsDir, 'images', filename))).toBe(false);
+  });
+});
+
+describe('the internal-route host guard covers /api/uploads', () => {
+  it('rejects an uploads call arriving from the redeem.sg origin', async () => {
+    const res = await request(app)
+      .get('/api/uploads/stats/usage')
+      .set(auth(admin.token))
+      .set('Origin', 'https://redeem.sg')
+      .set('X-Forwarded-Host', 'redeem.sg');
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toMatch(/only available on mktr\.sg/i);
+  });
+});
+
+describe('traversal guard rejects sibling-directory escapes', () => {
+  // path.resolve('/app/uploads-x').startsWith('/app/uploads') is TRUE — the old
+  // prefix check let every one of these through to the filesystem.
+  it.each(['../uploads-x', '../../etc', '..'])('rejects type=%s', async (type) => {
+    await expect(getFileInfo(type, 'passwd')).rejects.toMatchObject({ statusCode: 400 });
+    await expect(deleteFile(type, 'passwd')).rejects.toMatchObject({ statusCode: 400 });
+    await expect(listFiles(type)).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it('rejects a filename that climbs out', async () => {
+    await expect(getFileInfo('images', '../../package.json')).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it('still allows a legitimate path inside uploads/', async () => {
+    await expect(listFiles('images')).resolves.toHaveProperty('files');
+  });
+});


### PR DESCRIPTION
**Task P1-5** (high — release gate) · review round-2 queue

## Defect
`backend/src/routes/uploads.js` mounted the four **file-administration** routes — `DELETE /:type/:filename`, `GET /info/:type/:filename`, `GET /list/:type`, `GET /stats/usage` — with `authenticateToken` and **no role gate**. `uploadService`'s `listFiles`/`deleteFile` have no ownership concept at all, so any authenticated principal, including a self-registered `customer`, could enumerate every uploaded file and unlink any of them: campaign heroes, avatars, verification documents.

Two more holes in the same surface:
- `/api/uploads` was absent from `internalRouteHostGuard`, so the namespace was reachable from the public `redeem.sg` origin.
- `safeUploadsPath` compared with `startsWith`, which is prefix matching, not containment: `path.resolve('/app/uploads-x').startsWith('/app/uploads')` is `true`, so `type='../uploads-x'` escaped the sandbox while passing the guard.

## Fix
- `requireAdmin` on the four administration routes. **Upload itself is untouched** — `POST /single|multiple|avatar|campaign-assets|documents` stay open to any authenticated staff, which is what the Studio (the only frontend caller of this API) uses.
- `/api/uploads` added to `BLOCKED_PATH_PREFIXES`. `ops.redeem.sg` was already denied by its strict allowlist, so this changes only the consumer host.
- `safeUploadsPath` now resolves both sides and rejects when `path.relative(root, target)` starts with `..` or is absolute.

## Test proof
`backend/test/uploadsAuthz.test.js` (new, 12 cases).

**Pre-fix: `8 failed, 4 passed`** — customer and agent both got `200` on list/info/stats/**delete**; the redeem.sg-origin call got `200`; the sibling-escape inputs resolved instead of throwing. The admin case then failed with `404` *because the customer's delete in the previous test had already removed the file* — the clearest possible demonstration of the hole.

**Post-fix: `12 passed`** — 403 for customer and agent, full surface for admin, 403 from the redeem.sg origin, `400 Invalid file path` for `../uploads-x`, `../../etc`, `..` and a climbing filename, and a legitimate in-sandbox list still resolves.

Local run: `uploadsAuthz`, `uploads`, `uploadContentGuard`, `middleware`, `redeemOpsHostGuard`, `customerHost` → **88 passed**. `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)