### PR TITLE
fix(auth): gate OAuth soft-link on verified email + verify email changes (P1-7)

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -170,7 +170,7 @@ export const getProfile = asyncHandler(async (req, res) => {
 export const updateProfile = asyncHandler(async (req, res) => {
   const { firstName, lastName, phone, avatar, dateOfBirth, companyName, email } = req.body;
 
-  const user = await authService.updateProfile(req.user, {
+  const { user, emailVerificationToken } = await authService.updateProfile(req.user, {
     firstName,
     lastName,
     phone,
@@ -182,8 +182,12 @@ export const updateProfile = asyncHandler(async (req, res) => {
 
   res.json({
     success: true,
-    message: 'Profile updated successfully',
-    data: { user: user.toJSON() },
+    // A changed address is unverified until its token comes back (P1-7), so say
+    // so rather than reporting a clean success the user would misread.
+    message: emailVerificationToken
+      ? 'Profile updated. Check your new email address to verify it.'
+      : 'Profile updated successfully',
+    data: { user: user.toJSON(), emailVerificationPending: Boolean(emailVerificationToken) },
   });
 });
 

--- a/backend/src/services/authService.js
+++ b/backend/src/services/authService.js
@@ -138,8 +138,15 @@ export async function getProfile(userId) {
  * Update user profile fields.
  */
 export async function updateProfile(user, { firstName, lastName, phone, avatar, dateOfBirth, companyName, email }) {
-  // If email is changing, ensure uniqueness
-  if (email && email !== user.email) {
+  // An email CHANGE is an ownership claim, not a profile field (P1-7). It used
+  // to need nothing but uniqueness, and left emailVerified alone — so anyone
+  // could park a stranger's address on their own row in a "verified" state and
+  // wait for the real owner to arrive via Google. The new address is therefore
+  // unverified until its own token comes back.
+  const emailChanging = Boolean(email) && email !== user.email;
+  let emailVerificationToken = null;
+
+  if (emailChanging) {
     if (user.googleSub && user.role !== 'admin') {
       throw new AppError('Email for Google-linked account cannot be changed. Contact support.', 400);
     }
@@ -147,6 +154,7 @@ export async function updateProfile(user, { firstName, lastName, phone, avatar, 
     if (existing) {
       throw new AppError('Email is already in use', 400);
     }
+    emailVerificationToken = uuidv4();
   }
 
   await user.update({
@@ -157,9 +165,32 @@ export async function updateProfile(user, { firstName, lastName, phone, avatar, 
     avatar: avatar || user.avatar,
     dateOfBirth: dateOfBirth || user.dateOfBirth,
     companyName: companyName || user.companyName,
+    ...(emailChanging ? { emailVerified: false, emailVerificationToken } : {}),
   });
 
-  return user;
+  return { user, emailVerificationToken };
+}
+
+/**
+ * Guard the EMAIL branch of Google identity resolution (P1-7).
+ *
+ * Matching a local row by email alone is a soft link: it trusts that whoever
+ * owns the row owns the address. Registration is open and — until this change —
+ * a self-service email change needed no proof, so an attacker could park a
+ * victim's address on their own row and wait. When the victim then signed in
+ * with Google, the soft link bound their Google identity into the attacker's
+ * row and minted a token for it, leaving the attacker's password on the account.
+ *
+ * A row that never verified its address has not proved the claim, so it is not
+ * linkable. The failure is deliberately indistinguishable from any other auth
+ * failure — no account-existence oracle. (P0-3 hardened the googleSub MISMATCH
+ * case; this is the surviving googleSub IS NULL half.)
+ */
+function assertSoftLinkable(user) {
+  if (user && !user.googleSub && !user.emailVerified) {
+    logger.warn('Refusing Google soft-link into an unverified-email account', { userId: user.id });
+    throw new AppError('Authentication failed', 401);
+  }
 }
 
 /**
@@ -168,7 +199,16 @@ export async function updateProfile(user, { firstName, lastName, phone, avatar, 
  * @returns {{ user: object, token: string }}
  */
 export async function googleIdTokenLogin({ email, googleSub, name, picture }) {
-  let user = await User.findOne({ where: { email } });
+  // Same two-step as googleOAuthCallback: the sub is the hard link; matching on
+  // email alone is a soft link and only binds into a row that proved it owns
+  // the address (P1-7).
+  // `where: { googleSub: undefined }` would drop the clause and match an
+  // arbitrary row, so the hard-link lookup only runs with a real sub.
+  let user = googleSub ? await User.findOne({ where: { googleSub } }) : null;
+  if (!user) {
+    user = await User.findOne({ where: { email } });
+    assertSoftLinkable(user);
+  }
 
   if (!user) {
     const fullName = name || '';
@@ -285,12 +325,13 @@ export async function googleOAuthCallback(code, origin) {
   const googleUser = await userResponse.json();
   logger.debug('Google user info retrieved successfully');
 
-  // Find or create user — check googleSub (hard link) OR email (soft link)
-  let user = await User.findOne({
-    where: {
-      [Op.or]: [{ googleSub: googleUser.id }, { email: googleUser.email }],
-    },
-  });
+  // Hard link first: the stored sub is the only identity claim we minted
+  // ourselves. Email is a SOFT link and is tried second, gated below (P1-7).
+  let user = googleUser.id ? await User.findOne({ where: { googleSub: googleUser.id } }) : null;
+  if (!user) {
+    user = await User.findOne({ where: { email: googleUser.email } });
+    assertSoftLinkable(user);
+  }
 
   if (!user) {
     const nameParts = (googleUser.name || '').split(' ');

--- a/backend/test/unit/authService.test.js
+++ b/backend/test/unit/authService.test.js
@@ -1004,6 +1004,140 @@ describe('authService (unit)', () => {
         authService.updateProfile(user, { email: 'taken@example.com' })
       ).rejects.toThrow('Email is already in use');
     });
+
+    // P1-7: an email change is an ownership CLAIM. It used to need nothing but
+    // uniqueness and left emailVerified alone, which is what let an attacker
+    // park a victim's address on their own row in a "verified" state.
+    it('un-verifies the account and mints a token when the email changes', async () => {
+      const user = {
+        ...mocks.mockUser,
+        email: 'old@example.com',
+        emailVerified: true,
+        googleSub: null,
+        role: 'customer',
+        update: jest.fn().mockResolvedValue(true),
+      };
+      mocks.User.findOne.mockResolvedValue(null); // address is free
+
+      const { emailVerificationToken } = await authService.updateProfile(user, { email: 'new@example.com' });
+
+      expect(emailVerificationToken).toEqual(expect.any(String));
+      expect(user.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'new@example.com',
+          emailVerified: false,
+          emailVerificationToken,
+        })
+      );
+    });
+
+    it('leaves verification alone when the email is unchanged', async () => {
+      const user = {
+        ...mocks.mockUser,
+        email: 'same@example.com',
+        emailVerified: true,
+        googleSub: null,
+        role: 'customer',
+        update: jest.fn().mockResolvedValue(true),
+      };
+
+      const { emailVerificationToken } = await authService.updateProfile(user, {
+        email: 'same@example.com',
+        firstName: 'Renamed',
+      });
+
+      expect(emailVerificationToken).toBeNull();
+      const payload = user.update.mock.calls[0][0];
+      expect(payload).not.toHaveProperty('emailVerified');
+      expect(payload).not.toHaveProperty('emailVerificationToken');
+    });
+  });
+
+  // ────────────────────────────────────────────────
+  // P1-7 — Google soft-link pre-hijack
+  // ────────────────────────────────────────────────
+
+  describe('Google soft-link is gated on a verified email', () => {
+    // These queue per-call resolutions; drain them so a partially-consumed
+    // queue can never leak into a later suite.
+    afterEach(() => {
+      mocks.User.findOne.mockReset();
+      mocks.User.findOne.mockResolvedValue(null);
+      mocks.User.create.mockReset();
+      mocks.User.create.mockResolvedValue(mocks.mockUser);
+    });
+
+    const unverifiedSquatter = () => ({
+      ...mocks.mockUser,
+      id: 'attacker-row',
+      email: 'victim@example.com',
+      googleSub: null,          // never linked
+      emailVerified: false,     // never proved it owns the address
+      isActive: true,
+      save: jest.fn().mockResolvedValue(true),
+      update: jest.fn().mockResolvedValue(true),
+    });
+
+    it('refuses to bind a Google identity into an unverified-email row (id-token door)', async () => {
+      const squatter = unverifiedSquatter();
+      mocks.User.findOne
+        .mockResolvedValueOnce(null)      // no row holds this googleSub
+        .mockResolvedValueOnce(squatter); // ...but one holds the address
+
+      await expect(
+        authService.googleIdTokenLogin({ email: 'victim@example.com', googleSub: 'victim-google-sub' })
+      ).rejects.toMatchObject({ statusCode: 401, message: 'Authentication failed' });
+
+      expect(squatter.googleSub).toBeNull();
+      expect(squatter.save).not.toHaveBeenCalled();
+      expect(mocks.generateToken).not.toHaveBeenCalled();
+    });
+
+    it('still binds when the matched row DID verify its address', async () => {
+      const legitimate = {
+        ...unverifiedSquatter(),
+        id: 'legit-row',
+        emailVerified: true,
+      };
+      mocks.User.findOne
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(legitimate);
+
+      const result = await authService.googleIdTokenLogin({
+        email: 'victim@example.com',
+        googleSub: 'victim-google-sub',
+      });
+
+      expect(legitimate.googleSub).toBe('victim-google-sub');
+      expect(result.token).toBe('jwt-token-123');
+    });
+
+    it('a hard googleSub match is unaffected by the email flag', async () => {
+      const linked = {
+        ...unverifiedSquatter(),
+        id: 'linked-row',
+        googleSub: 'victim-google-sub',
+      };
+      mocks.User.findOne.mockResolvedValueOnce(linked); // hard link hits first
+
+      const result = await authService.googleIdTokenLogin({
+        email: 'victim@example.com',
+        googleSub: 'victim-google-sub',
+      });
+
+      expect(result.token).toBe('jwt-token-123');
+      expect(linked.save).toHaveBeenCalled();
+    });
+
+    it('looks the sub up FIRST, so email is only ever a fallback', async () => {
+      mocks.User.findOne.mockResolvedValue(null);
+      mocks.User.create.mockResolvedValue({ ...mocks.mockUser, isActive: true });
+
+      await authService.googleIdTokenLogin({ email: 'fresh@example.com', googleSub: 'fresh-sub' });
+
+      expect(mocks.User.findOne).toHaveBeenNthCalledWith(1, { where: { googleSub: 'fresh-sub' } });
+      expect(mocks.User.findOne).toHaveBeenNthCalledWith(2, { where: { email: 'fresh@example.com' } });
+    });
   });
 
   // ────────────────────────────────────────────────


### PR DESCRIPTION
**Task P1-7** (high — release gate) · review round-2 queue

## Defect — confirmed in code (was reviewer-reported)
Two halves of one account pre-hijack:

1. `authService.updateProfile` changed a user's email with **only a uniqueness check** — no ownership proof, `emailVerified` untouched. Registration is open (`POST /auth/register`), so anyone could park a stranger's address on their own row while it still read as verified.
2. Both Google doors resolved the account by `googleSub` **OR** `email` and, when the matched row had no `googleSub`, bound the incoming Google identity into it.

Chain: attacker registers → sets their row's email to a victim address that has no MKTR account → victim later signs in with Google → the email branch matches the **attacker's** row → the soft link binds and mints a token for it, with the attacker's password still on the account. P0-3 hardened the `googleSub` *mismatch* case; this is the surviving `googleSub IS NULL` half. `googleIdTokenLogin` had the identical hole.

## Fix
- **`assertSoftLinkable`** — both Google doors now look the **sub up first** (the only identity claim we minted ourselves) and fall back to email; a matched row that never verified its address is refused with `401 Authentication failed`, deliberately identical to any other auth failure so there's no account-existence oracle.
- **Email change is an ownership claim** — it now mints an `emailVerificationToken` and sets `emailVerified: false`, mirroring `register()`. A parked address can therefore never sit in a linkable state. The controller reports `emailVerificationPending` and says so in the message rather than reporting a clean success.
- Guarded the hard-link lookup so a missing sub can't produce `where: { googleSub: undefined }` (which drops the clause and matches an arbitrary row).

**Accepted consequence:** a self-registered user who never verified their address can no longer claim it via Google sign-in — they still have their password and their verification link. Invited staff get `emailVerified: true` on `acceptInvite`, so agents/admins/directors are unaffected. Token *delivery* mirrors `register()`'s existing path; wiring the outbound mail is out of scope for this task.

## Test proof
`backend/test/unit/authService.test.js` (+6 cases, plus mock hygiene so the queued resolutions can't leak into later suites).

**Pre-fix: 5 failed** — the change kept `emailVerified` untouched and minted nothing; the unverified squatter row was bound and a token issued; the sub was never looked up first. **Post-fix: 59 passed.**

Local: full unit tier **2145 passed / 125 suites**; `authRoutes`, `rbac`, `users`, `security`, `invitations` → **252 passed**. `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)