### PR TITLE
feat(data): CHECK constraints + audit-ledger FKs for money/inventory invariants (P1-8)

### DIFF
--- a/backend/src/database/migrations/102-inventory-invariant-constraints.js
+++ b/backend/src/database/migrations/102-inventory-invariant-constraints.js
@@ -1,0 +1,125 @@
+/**
+ * 102 — put the money/inventory invariants in the DATABASE (P1-8).
+ *
+ * `committedQuantity ≥ allocatedQuantity ≥ issuedQuantity ≥ redeemedQuantity`
+ * is stated in RewardOffer.js and enforced only by application-level guarded
+ * UPDATEs; `walletBalanceCents ≥ 0` likewise. Every one of those guards is
+ * correct today, but they are the ONLY thing standing between a future code
+ * path — a new admin tool, a backfill script, a psql session — and silently
+ * over-issued inventory or a negative wallet. A CHECK constraint costs nothing
+ * per write and cannot be forgotten by the next writer.
+ *
+ * The append-only ledger has the mirror problem: reward_inventory_events
+ * declared activationId/entitlementId/redemptionId as bare UUIDs, no
+ * references, no associations. That table is the reconciliation source of
+ * truth (inventoryService.reconcile derives the counters from it), so a
+ * dangling pointer there is an audit trail that cannot be re-walked. RESTRICT,
+ * not CASCADE: an append-only record must never be silently erased by deleting
+ * something it points at.
+ *
+ * Two-step, per migration 014: ADD ... NOT VALID takes only a SHARE ROW
+ * EXCLUSIVE lock, then VALIDATE re-scans under SHARE UPDATE EXCLUSIVE so reads
+ * and writes keep flowing. Note a NOT VALID constraint is ALREADY enforced for
+ * new and updated rows — validation only concerns rows that predate it. So if
+ * legacy data violates an invariant we log the offenders and leave the
+ * constraint NOT VALID rather than failing the deploy: new writes are protected
+ * either way, and a data-repair decision belongs to a human, not to a migration.
+ */
+
+const CHECKS = [
+  {
+    table: 'reward_offers',
+    name: 'chk_reward_offers_quantity_ordering',
+    expression: `"committedQuantity" >= "allocatedQuantity"
+             AND "allocatedQuantity" >= "issuedQuantity"
+             AND "issuedQuantity" >= "redeemedQuantity"
+             AND "redeemedQuantity" >= 0`,
+  },
+  {
+    table: 'activations',
+    name: 'chk_activations_quantity_ordering',
+    expression: `"allocatedQuantity" >= "issuedCount"
+             AND "issuedCount" >= "redeemedCount"
+             AND "redeemedCount" >= 0`,
+  },
+  {
+    table: 'users',
+    name: 'chk_users_wallet_balance_non_negative',
+    expression: '"walletBalanceCents" >= 0',
+  },
+];
+
+const LEDGER_FKS = [
+  { column: 'activationId', refTable: 'activations', name: 'fk_rie_activation' },
+  { column: 'entitlementId', refTable: 'reward_entitlements', name: 'fk_rie_entitlement' },
+  { column: 'redemptionId', refTable: 'redemptions', name: 'fk_rie_redemption' },
+];
+
+export async function up(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+  const q = (sql) => sequelize.query(sql);
+  const exists = async (name) => {
+    const [rows] = await q(`SELECT 1 FROM pg_constraint WHERE conname = '${name}'`);
+    return rows.length > 0;
+  };
+
+  // ── (a) Quantity ordering + non-negative wallet ────────────────────────────
+  for (const { table, name, expression } of CHECKS) {
+    if (!(await exists(name))) {
+      await q(`ALTER TABLE "${table}" ADD CONSTRAINT "${name}" CHECK (${expression}) NOT VALID`);
+    }
+
+    const [offenders] = await q(`SELECT COUNT(*)::int AS n FROM "${table}" WHERE NOT (${expression})`);
+    const n = offenders[0]?.n ?? 0;
+    if (n > 0) {
+       
+      console.warn(
+        `[migration 102] ${table}: ${n} pre-existing row(s) violate ${name}. ` +
+        'Constraint left NOT VALID — it already blocks new and updated rows; ' +
+        'repair the legacy rows then run: ' +
+        `ALTER TABLE "${table}" VALIDATE CONSTRAINT "${name}";`
+      );
+      continue;
+    }
+    await q(`ALTER TABLE "${table}" VALIDATE CONSTRAINT "${name}"`);
+  }
+
+  // ── (b) Audit-ledger pointers become real references ───────────────────────
+  for (const { column, refTable, name } of LEDGER_FKS) {
+    if (!(await exists(name))) {
+      await q(`
+        ALTER TABLE reward_inventory_events ADD CONSTRAINT "${name}"
+        FOREIGN KEY ("${column}") REFERENCES "${refTable}"(id) ON DELETE RESTRICT NOT VALID
+      `);
+    }
+
+    const [orphans] = await q(`
+      SELECT COUNT(*)::int AS n FROM reward_inventory_events e
+       WHERE e."${column}" IS NOT NULL
+         AND NOT EXISTS (SELECT 1 FROM "${refTable}" r WHERE r.id = e."${column}")
+    `);
+    const n = orphans[0]?.n ?? 0;
+    if (n > 0) {
+       
+      console.warn(
+        `[migration 102] reward_inventory_events.${column}: ${n} dangling pointer(s). ` +
+        `Constraint left NOT VALID — new rows are checked. Repair, then: ` +
+        `ALTER TABLE reward_inventory_events VALIDATE CONSTRAINT "${name}";`
+      );
+      continue;
+    }
+    await q(`ALTER TABLE reward_inventory_events VALIDATE CONSTRAINT "${name}"`);
+  }
+}
+
+export async function down(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+  const q = (sql) => sequelize.query(sql);
+
+  for (const { name } of LEDGER_FKS) {
+    await q(`ALTER TABLE reward_inventory_events DROP CONSTRAINT IF EXISTS "${name}"`);
+  }
+  for (const { table, name } of CHECKS) {
+    await q(`ALTER TABLE "${table}" DROP CONSTRAINT IF EXISTS "${name}"`);
+  }
+}

--- a/backend/src/models/RewardInventoryEvent.js
+++ b/backend/src/models/RewardInventoryEvent.js
@@ -14,9 +14,25 @@ const RewardInventoryEvent = sequelize.define('RewardInventoryEvent', {
     allowNull: false,
     references: { model: 'reward_offers', key: 'id' }
   },
-  activationId: { type: DataTypes.UUID, allowNull: true },
-  entitlementId: { type: DataTypes.UUID, allowNull: true },
-  redemptionId: { type: DataTypes.UUID, allowNull: true },
+  // Real references, not bare UUIDs (P1-8, migration 102): this ledger is the
+  // reconciliation source of truth, so a dangling pointer is an audit trail
+  // that cannot be re-walked. Mirrored here because test boot builds the schema
+  // from the MODELS via sync({force:true}) before migrations run.
+  activationId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    references: { model: 'activations', key: 'id' }
+  },
+  entitlementId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    references: { model: 'reward_entitlements', key: 'id' }
+  },
+  redemptionId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    references: { model: 'redemptions', key: 'id' }
+  },
   type: {
     type: DataTypes.STRING(24),
     allowNull: false,

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -266,6 +266,11 @@ function defineAssociations() {
   Redemption.belongsTo(PartnerOrganisation, { foreignKey: 'partnerOrganisationId', as: 'partner', onDelete: 'RESTRICT' });
   Redemption.belongsTo(PartnerLocation, { foreignKey: 'locationId', as: 'location', onDelete: 'SET NULL' });
   Redemption.belongsTo(User, { foreignKey: 'actorUserId', as: 'actor', onDelete: 'SET NULL' });
+  // RESTRICT on all three (P1-8): an append-only audit row must never be
+  // silently orphaned — or erased — by deleting what it points at.
+  RewardInventoryEvent.belongsTo(Activation, { foreignKey: 'activationId', as: 'activation', onDelete: 'RESTRICT' });
+  RewardInventoryEvent.belongsTo(RewardEntitlement, { foreignKey: 'entitlementId', as: 'entitlement', onDelete: 'RESTRICT' });
+  RewardInventoryEvent.belongsTo(Redemption, { foreignKey: 'redemptionId', as: 'redemption', onDelete: 'RESTRICT' });
   RedemptionEvent.belongsTo(RewardEntitlement, { foreignKey: 'entitlementId', as: 'entitlement', onDelete: 'CASCADE' });
   RedemptionEvent.belongsTo(Redemption, { foreignKey: 'redemptionId', as: 'redemption', onDelete: 'CASCADE' });
 

--- a/backend/test/migration102InventoryInvariants.test.js
+++ b/backend/test/migration102InventoryInvariants.test.js
@@ -1,0 +1,195 @@
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { getApp, closeDb, createTestUser } from './helpers.js'
+import { sequelize } from '../src/models/index.js'
+import { RewardOffer, Activation, PartnerOrganisation } from '../src/models/index.js'
+
+/**
+ * Migration 102 — the money/inventory invariants, in the DATABASE (P1-8).
+ *
+ * `committed ≥ allocated ≥ issued ≥ redeemed` and `walletBalanceCents ≥ 0` were
+ * enforced ONLY by application-level guarded UPDATEs, and the append-only
+ * ledger's activationId/entitlementId/redemptionId were bare UUIDs — so the
+ * reconciliation source of truth could hold pointers to rows that never existed.
+ *
+ * What matters here: a write that breaks an invariant is REFUSED BY POSTGRES,
+ * whatever issued it — service, script or psql session.
+ *
+ * SELF-CONTAINED: replays its own chain. `_migrations` survives
+ * sync({force:true}), so on a reused test database the runner skips 102 while
+ * the tables come back model-shaped.
+ */
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const migrationsDir = path.join(__dirname, '../src/database/migrations')
+
+let up, down, queryInterface, partner, adminId
+
+const constraintExists = async (name) => {
+  const [[r]] = await sequelize.query(
+    'SELECT 1 AS ok FROM pg_constraint WHERE conname = :name', { replacements: { name } }
+  )
+  return Boolean(r)
+}
+
+const constraintValidated = async (name) => {
+  const [[r]] = await sequelize.query(
+    'SELECT convalidated FROM pg_constraint WHERE conname = :name', { replacements: { name } }
+  )
+  return r?.convalidated ?? null
+}
+
+const makeOffer = (over = {}) => RewardOffer.create({
+  partnerOrganisationId: partner.id, title: 'Invariant Reward', status: 'active',
+  committedQuantity: 100, allocatedQuantity: 50, issuedQuantity: 20, redeemedQuantity: 10,
+  claimExpiryDays: 30, redemptionExpiryDays: 90, createdBy: adminId, ...over,
+})
+
+beforeAll(async () => {
+  await getApp()
+  ;({ up, down } = await import(path.join(migrationsDir, '102-inventory-invariant-constraints.js')))
+  queryInterface = sequelize.getQueryInterface()
+  await up(queryInterface) // idempotent; the runner may already have applied it
+  const admin = await createTestUser({ role: 'admin' })
+  adminId = admin.user.id
+  partner = await PartnerOrganisation.create({
+    tradingName: 'Invariant Spa', normalizedName: 'invariant spa', createdBy: adminId,
+  })
+})
+
+afterAll(async () => { await closeDb() })
+
+describe('migration 102 — up()', () => {
+  it('creates every constraint, VALIDATED against clean data', async () => {
+    for (const name of [
+      'chk_reward_offers_quantity_ordering',
+      'chk_activations_quantity_ordering',
+      'chk_users_wallet_balance_non_negative',
+      'fk_rie_activation',
+      'fk_rie_entitlement',
+      'fk_rie_redemption',
+    ]) {
+      expect(await constraintExists(name)).toBe(true)
+      expect(await constraintValidated(name)).toBe(true)
+    }
+  })
+
+  it('is idempotent — a second run adds nothing and throws nothing', async () => {
+    await expect(up(queryInterface)).resolves.not.toThrow()
+    expect(await constraintExists('chk_reward_offers_quantity_ordering')).toBe(true)
+  })
+})
+
+describe('reward_offers quantity ordering', () => {
+  it('accepts a well-ordered offer', async () => {
+    await expect(makeOffer()).resolves.toBeDefined()
+  })
+
+  it.each([
+    ['allocated above committed', { committedQuantity: 10, allocatedQuantity: 20, issuedQuantity: 0, redeemedQuantity: 0 }],
+    ['issued above allocated', { committedQuantity: 100, allocatedQuantity: 10, issuedQuantity: 20, redeemedQuantity: 0 }],
+    ['redeemed above issued', { committedQuantity: 100, allocatedQuantity: 50, issuedQuantity: 5, redeemedQuantity: 9 }],
+    ['negative redeemed', { committedQuantity: 100, allocatedQuantity: 50, issuedQuantity: 20, redeemedQuantity: -1 }],
+  ])('refuses %s', async (_label, quantities) => {
+    await expect(makeOffer(quantities)).rejects.toThrow(/chk_reward_offers_quantity_ordering/)
+  })
+
+  it('refuses an UPDATE that breaks the ordering — not just an INSERT', async () => {
+    const offer = await makeOffer()
+    await expect(
+      sequelize.query('UPDATE reward_offers SET "redeemedQuantity" = 999 WHERE id = :id', {
+        replacements: { id: offer.id },
+      })
+    ).rejects.toThrow(/chk_reward_offers_quantity_ordering/)
+  })
+})
+
+describe('activations quantity ordering', () => {
+  const makeActivation = (over = {}) => Activation.create({
+    partnerOrganisationId: partner.id, rewardOfferId: over.rewardOfferId, campaignId: null,
+    allocatedQuantity: 20, issuedCount: 10, redeemedCount: 5, status: 'draft',
+    unlockPolicy: 'agent_unlock', createdBy: adminId, ...over,
+  })
+
+  it('accepts a well-ordered activation', async () => {
+    const offer = await makeOffer()
+    await expect(makeActivation({ rewardOfferId: offer.id })).resolves.toBeDefined()
+  })
+
+  it('refuses issuing past the allocation', async () => {
+    const offer = await makeOffer()
+    await expect(
+      makeActivation({ rewardOfferId: offer.id, allocatedQuantity: 5, issuedCount: 6, redeemedCount: 0 })
+    ).rejects.toThrow(/chk_activations_quantity_ordering/)
+  })
+
+  it('refuses redeeming more than was issued', async () => {
+    const offer = await makeOffer()
+    await expect(
+      makeActivation({ rewardOfferId: offer.id, allocatedQuantity: 20, issuedCount: 3, redeemedCount: 4 })
+    ).rejects.toThrow(/chk_activations_quantity_ordering/)
+  })
+})
+
+describe('users wallet balance', () => {
+  it('refuses a negative balance', async () => {
+    const { user } = await createTestUser({ role: 'agent' })
+    await expect(
+      sequelize.query('UPDATE users SET "walletBalanceCents" = -1 WHERE id = :id', {
+        replacements: { id: user.id },
+      })
+    ).rejects.toThrow(/chk_users_wallet_balance_non_negative/)
+  })
+
+  it('still allows zero', async () => {
+    const { user } = await createTestUser({ role: 'agent' })
+    await expect(
+      sequelize.query('UPDATE users SET "walletBalanceCents" = 0 WHERE id = :id', {
+        replacements: { id: user.id },
+      })
+    ).resolves.toBeDefined()
+  })
+})
+
+describe('audit-ledger pointers', () => {
+  const insertLedger = (column, value, offerId) => sequelize.query(
+    `INSERT INTO reward_inventory_events (id, "rewardOfferId", "${column}", type, quantity, "actorType", "createdAt")
+     VALUES (gen_random_uuid(), :offerId, :value, 'allocated', 1, 'staff', now())`,
+    { replacements: { offerId, value } }
+  )
+
+  // Two constraints guard each column in TEST and one in PROD: the model now
+  // declares references, so sync({force:true}) emits its own
+  // reward_inventory_events_<col>_fkey, while the migration adds fk_rie_<x> for
+  // the production table sync never touches. Either name is a pass — what this
+  // asserts is that the dangling write is REFUSED, and that the migration's own
+  // constraint exists and is validated (first describe block).
+  it.each(['activationId', 'entitlementId', 'redemptionId'])('refuses a dangling %s', async (column) => {
+    const offer = await makeOffer()
+    await expect(
+      insertLedger(column, '00000000-0000-4000-8000-000000000000', offer.id)
+    ).rejects.toThrow(new RegExp(`foreign key constraint.*${column}|${column}.*foreign key`, 'i'))
+  })
+
+  it('still accepts NULL pointers — most ledger rows have no activation', async () => {
+    const offer = await makeOffer()
+    await expect(insertLedger('activationId', null, offer.id)).resolves.toBeDefined()
+  })
+})
+
+describe('migration 102 — down()', () => {
+  it('removes every constraint it added, then up() restores them', async () => {
+    await down(queryInterface)
+    expect(await constraintExists('chk_reward_offers_quantity_ordering')).toBe(false)
+    expect(await constraintExists('fk_rie_redemption')).toBe(false)
+
+    // ...and without the CHECK, the broken write Postgres just refused goes in.
+    const bad = await makeOffer({ committedQuantity: 1, allocatedQuantity: 99, issuedQuantity: 0, redeemedQuantity: 0 })
+    expect(bad.allocatedQuantity).toBe(99)
+    await bad.destroy()
+
+    await up(queryInterface)
+    expect(await constraintExists('chk_reward_offers_quantity_ordering')).toBe(true)
+    expect(await constraintExists('fk_rie_redemption')).toBe(true)
+  })
+})


### PR DESCRIPTION
**Task P1-8** (high — release gate) · review round-2 queue

## Defect
`committedQuantity ≥ allocatedQuantity ≥ issuedQuantity ≥ redeemedQuantity` is *stated* in `RewardOffer.js`, and `walletBalanceCents ≥ 0` is assumed everywhere — but both were enforced **only** by application-level guarded UPDATEs. Those guards are correct today; they're also the only thing standing between a future admin tool, a backfill script or a psql session and silently over-issued inventory or a negative wallet.

`RewardInventoryEvent` — the append-only ledger `inventoryService.reconcile()` derives the counters from — declared `activationId`, `entitlementId` and `redemptionId` as bare `DataTypes.UUID` with no `references` and no associations. The reconciliation source of truth could hold pointers to rows that never existed.

## Fix
**Migration 102** (next free number; 101 is the highest on main and no open PR claims 102):
- `chk_reward_offers_quantity_ordering` — the full ordering plus non-negativity
- `chk_activations_quantity_ordering` — `allocated ≥ issuedCount ≥ redeemedCount ≥ 0`
- `chk_users_wallet_balance_non_negative`
- `fk_rie_activation` / `fk_rie_entitlement` / `fk_rie_redemption`, all **ON DELETE RESTRICT** — an append-only record must never be silently erased by deleting what it points at

**NOT VALID → VALIDATE**, per migration 014, so neither step takes an ACCESS EXCLUSIVE lock. A key property: *a NOT VALID constraint already blocks new and updated rows* — validation only concerns pre-existing ones. So when legacy data violates an invariant the migration **logs the offending count plus the exact `VALIDATE CONSTRAINT` statement to run and continues**, rather than failing the deploy. New writes are protected either way, and repairing historical rows is a human decision. Idempotent throughout (`pg_constraint` name guards), with a `down()` that removes everything.

**Repo gotcha handled:** test boot runs `sync({force:true})` from the models *before* migrations, so the FK `references` are mirrored on `RewardInventoryEvent` and the three `belongsTo` associations added to `index.js` — placed after `Redemption`'s own associations, since `RewardEntitlement`/`Redemption` are in the temporal dead zone at the earlier definition site.

## Test proof
`backend/test/migration102InventoryInvariants.test.js` (new, 18 cases): every constraint exists **and is validated**; `up()` is idempotent; ordering violations are refused on INSERT *and* UPDATE; a negative wallet is refused while zero is allowed; each dangling ledger pointer is refused; NULL pointers still insert.

The **before/after runs inside the suite**: `down()` drops the constraints, and the exact write Postgres just refused (`allocated 99` against `committed 1`) is then accepted — the pre-fix behaviour, demonstrated, before `up()` restores the guard.

In tests each ledger column ends up with two constraints (sync's `..._fkey` plus the migration's `fk_rie_*`); in production only the migration's exists. The assertion matches the column rather than a constraint name so it holds in both.

Local: migration tier **23 passed**; `migration102` + `redeemOpsRewards`/`Fulfilment`/`PhysicalHandover`/`VoidRedemption` + `leadPackages` → **112 passed**; full unit tier **2139 passed**. `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)