### PR TITLE
fix(redeem-ops): timeouts + unified retry for Apify/WhatsApp (P2-1)

### DIFF
--- a/backend/src/services/redeemOps/discovery/apifyClient.js
+++ b/backend/src/services/redeemOps/discovery/apifyClient.js
@@ -1,4 +1,5 @@
 import { logger } from '../../../utils/logger.js';
+import { retryingFetch, DEFAULT_TIMEOUT_MS } from '../../../utils/externalFetch.js';
 
 /**
  * Thin Apify API v2 wrapper for the Discover tool. Start an actor run, re-fetch
@@ -29,6 +30,8 @@ export function makeApifyClient(overrides = {}) {
     baseUrl: APIFY_BASE,
     fetchImpl: (...args) => globalThis.fetch(...args),
     logger,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    attempts: 3,
     ...overrides,
   };
 
@@ -43,10 +46,21 @@ export function makeApifyClient(overrides = {}) {
     for (const [k, v] of Object.entries(query || {})) {
       if (v !== undefined && v !== null) url.searchParams.set(k, String(v));
     }
-    const res = await d.fetchImpl(url.toString(), {
+    // Bounded + retried on transient failures, same policy as waGraphClient
+    // (P2-1). startRun is awaited INLINE on the operator's request, so an
+    // unbounded fetch here hung the request until the platform killed it — and
+    // this dependency, the one that costs money per run, had zero retries
+    // while WhatsApp had three.
+    const res = await retryingFetch(d.fetchImpl, url.toString(), {
       method,
       headers: body ? { 'Content-Type': 'application/json' } : undefined,
       body: body ? JSON.stringify(body) : undefined,
+    }, {
+      label: `apify ${method} ${path}`,
+      attempts: d.attempts,
+      timeoutMs: d.timeoutMs,
+      logger: d.logger,
+      logPrefix: 'apify',
     });
     if (!res.ok) {
       const text = await res.text().catch(() => '');

--- a/backend/src/services/waGraphClient.js
+++ b/backend/src/services/waGraphClient.js
@@ -19,6 +19,7 @@
  * only the WHATSAPP_* pair and delete META_WA_*.
  */
 import { logger as defaultLogger } from '../utils/logger.js';
+import { retryingFetch, DEFAULT_TIMEOUT_MS } from '../utils/externalFetch.js';
 
 export const GRAPH_VERSION = process.env.META_GRAPH_API_VERSION || 'v21.0';
 
@@ -50,6 +51,7 @@ export function makeWaGraphClient(overrides = {}) {
     fetch: (...args) => fetch(...args),
     sleep: defaultSleep,
     logger: defaultLogger,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
     ...overrides,
   };
 
@@ -58,28 +60,15 @@ export function makeWaGraphClient(overrides = {}) {
    * throw (no response received, so the request very likely never reached
    * Meta) or a 5xx. 4xx (template/permission/bad-request) is deterministic
    * and returned as-is for the caller to receipt/handle.
+   *
+   * The policy now lives in utils/externalFetch so Apify runs the same one
+   * (P2-1); this call also gains the bounded timeout it never had.
    */
   async function graphFetch(url, opts, { label, attempts = 3 } = {}) {
-    let lastErr;
-    for (let i = 1; i <= attempts; i += 1) {
-      try {
-        const res = await d.fetch(url, opts);
-        if (res.status >= 500 && i < attempts) {
-          d.logger.warn('wa_graph.retry_5xx', { label, status: res.status, attempt: i });
-          await d.sleep(300 * i);
-          continue;
-        }
-        return res; // ok or 4xx — caller decides
-      } catch (err) {
-        lastErr = err;
-        if (i < attempts) {
-          d.logger.warn('wa_graph.retry_network', { label, error: err?.message, attempt: i });
-          await d.sleep(300 * i);
-          continue;
-        }
-      }
-    }
-    throw lastErr;
+    return retryingFetch(d.fetch, url, opts, {
+      label, attempts, timeoutMs: d.timeoutMs,
+      sleep: d.sleep, logger: d.logger, logPrefix: 'wa_graph',
+    });
   }
 
   /** Build the standard template message body (components passed verbatim). */

--- a/backend/src/utils/externalFetch.js
+++ b/backend/src/utils/externalFetch.js
@@ -1,0 +1,90 @@
+/**
+ * The transport rules for calling somebody else's server (P2-1).
+ *
+ * Two problems this exists for:
+ *
+ *  1. NO TIMEOUT. `fetch` has none by default, so a hung TCP connection hangs
+ *     the caller until the platform kills it. Apify's startRun is awaited
+ *     INLINE on the operator's request, so "Apify is slow" read as "Discovery
+ *     is broken" with no error to show for it.
+ *  2. INCONSISTENT RETRY. WhatsApp retried three times; Apify — the more
+ *     expensive dependency, and the one whose runs cost money — retried zero.
+ *
+ * The retry policy is the one waGraphClient already used and is worth keeping:
+ * retry only TRANSIENT failures — a network throw (no response, so the request
+ * very likely never landed) or a 5xx. A 4xx is deterministic and comes back
+ * as-is for the caller to handle; retrying it just spends quota to be told the
+ * same thing.
+ */
+
+/** Long enough for a slow-but-alive provider, short enough that a hang is not a hostage. */
+export const DEFAULT_TIMEOUT_MS = 12_000;
+
+const defaultSleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const noopLogger = { warn: () => {}, error: () => {}, info: () => {} };
+
+/** True for the errors that mean "try again" rather than "this request is wrong". */
+export function isTransientFetchError(err) {
+  return err?.name === 'AbortError' || err?.name === 'TimeoutError' || err instanceof TypeError || !err?.status;
+}
+
+/**
+ * One fetch, bounded by an AbortController. A timeout surfaces as an Error with
+ * `name: 'AbortError'` and `timeout: true`, which the retry layer treats as
+ * transient — the request may never have reached the provider.
+ */
+export async function fetchWithTimeout(fetchImpl, url, opts = {}, { timeoutMs = DEFAULT_TIMEOUT_MS, label } = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetchImpl(url, { ...opts, signal: controller.signal });
+  } catch (err) {
+    if (controller.signal.aborted) {
+      const timeoutErr = new Error(`${label || 'external request'} timed out after ${timeoutMs}ms`);
+      timeoutErr.name = 'AbortError';
+      timeoutErr.timeout = true;
+      timeoutErr.cause = err;
+      throw timeoutErr;
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * `fetchWithTimeout` plus bounded retry on transient failures.
+ * Returns the Response — ok or 4xx. Throws the last error when every attempt
+ * failed to produce a response at all.
+ */
+export async function retryingFetch(fetchImpl, url, opts = {}, {
+  label,
+  attempts = 3,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  sleep = defaultSleep,
+  logger = noopLogger,
+  logPrefix = 'external_fetch',
+} = {}) {
+  let lastErr;
+  for (let i = 1; i <= attempts; i += 1) {
+    try {
+      const res = await fetchWithTimeout(fetchImpl, url, opts, { timeoutMs, label });
+      if (res.status >= 500 && i < attempts) {
+        logger.warn(`${logPrefix}.retry_5xx`, { label, status: res.status, attempt: i });
+        await sleep(300 * i);
+        continue;
+      }
+      return res; // ok or 4xx — caller decides
+    } catch (err) {
+      lastErr = err;
+      if (i < attempts) {
+        logger.warn(`${logPrefix}.retry_network`, {
+          label, error: err?.message, timeout: Boolean(err?.timeout), attempt: i,
+        });
+        await sleep(300 * i);
+        continue;
+      }
+    }
+  }
+  throw lastErr;
+}

--- a/backend/test/unit/externalFetch.test.js
+++ b/backend/test/unit/externalFetch.test.js
@@ -1,0 +1,164 @@
+/**
+ * P2-1 regression: every external call is bounded and retried the same way.
+ *
+ * Both clients called bare `fetch` with NO timeout. Apify's startRun is awaited
+ * INLINE on the operator's request (discoveryService), so a hung TCP connection
+ * hung the request until the platform killed it. And the retry posture was
+ * backwards: WhatsApp retried 3×, Apify — the dependency that costs money per
+ * run — retried 0×.
+ */
+import { jest } from '@jest/globals';
+import '../setup.js';
+import { fetchWithTimeout, retryingFetch, DEFAULT_TIMEOUT_MS } from '../../src/utils/externalFetch.js';
+import { makeApifyClient } from '../../src/services/redeemOps/discovery/apifyClient.js';
+import { makeWaGraphClient } from '../../src/services/waGraphClient.js';
+
+const ok = (body = {}) => ({ ok: true, status: 200, json: async () => body, text: async () => JSON.stringify(body) });
+const boom = (status) => ({ ok: false, status, json: async () => ({}), text: async () => 'upstream said no' });
+
+/** A fetch that never settles until its signal aborts — the hang this bounds. */
+const hangingFetch = jest.fn((_url, opts) => new Promise((_resolve, reject) => {
+  opts.signal.addEventListener('abort', () => {
+    const err = new Error('The operation was aborted');
+    err.name = 'AbortError';
+    reject(err);
+  });
+}));
+
+const silent = { warn: jest.fn(), error: jest.fn(), info: jest.fn() };
+const noSleep = () => Promise.resolve();
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('fetchWithTimeout', () => {
+  it('aborts a request that never resolves', async () => {
+    await expect(
+      fetchWithTimeout(hangingFetch, 'https://example.test', {}, { timeoutMs: 20, label: 'probe' })
+    ).rejects.toMatchObject({ name: 'AbortError', timeout: true });
+  });
+
+  it('names the caller and the budget in the error', async () => {
+    await expect(
+      fetchWithTimeout(hangingFetch, 'https://example.test', {}, { timeoutMs: 20, label: 'apify POST /runs' })
+    ).rejects.toThrow(/apify POST \/runs timed out after 20ms/);
+  });
+
+  it('passes a signal through so the socket is actually released', async () => {
+    const spy = jest.fn(async () => ok());
+    await fetchWithTimeout(spy, 'https://example.test', { method: 'POST' });
+    expect(spy.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal);
+    expect(spy.mock.calls[0][1].method).toBe('POST');
+  });
+
+  it('does not disturb a response that arrives in time', async () => {
+    const res = await fetchWithTimeout(async () => ok({ hi: true }), 'https://example.test', {}, { timeoutMs: 500 });
+    expect(res.status).toBe(200);
+  });
+
+  it('defaults to a bounded budget rather than none', () => {
+    expect(DEFAULT_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(DEFAULT_TIMEOUT_MS).toBeLessThanOrEqual(15_000);
+  });
+});
+
+describe('retryingFetch', () => {
+  it('retries a 5xx and returns the eventual success', async () => {
+    const fetchImpl = jest.fn()
+      .mockResolvedValueOnce(boom(500))
+      .mockResolvedValueOnce(ok({ recovered: true }));
+
+    const res = await retryingFetch(fetchImpl, 'https://example.test', {}, { sleep: noSleep, logger: silent });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(res.status).toBe(200);
+  });
+
+  it('returns a 4xx as-is — retrying a deterministic answer just spends quota', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(boom(400));
+
+    const res = await retryingFetch(fetchImpl, 'https://example.test', {}, { sleep: noSleep, logger: silent });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(400);
+  });
+
+  it('retries a network throw, then gives up with the last error', async () => {
+    const fetchImpl = jest.fn().mockRejectedValue(new TypeError('socket hang up'));
+
+    await expect(
+      retryingFetch(fetchImpl, 'https://example.test', {}, { attempts: 3, sleep: noSleep, logger: silent })
+    ).rejects.toThrow('socket hang up');
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('treats a timeout as transient and retries it', async () => {
+    const fetchImpl = jest.fn()
+      .mockImplementationOnce(hangingFetch)
+      .mockResolvedValueOnce(ok({ second: true }));
+
+    const res = await retryingFetch(fetchImpl, 'https://example.test', {}, {
+      attempts: 2, timeoutMs: 20, sleep: noSleep, logger: silent,
+    });
+
+    expect(res.status).toBe(200);
+    expect(silent.warn).toHaveBeenCalledWith(
+      expect.stringContaining('retry_network'),
+      expect.objectContaining({ timeout: true })
+    );
+  });
+});
+
+describe('apifyClient transport', () => {
+  const client = (fetchImpl, over = {}) => makeApifyClient({
+    token: 'test-token', fetchImpl, logger: silent, ...over,
+  });
+
+  it('retries a 500 once and succeeds — it used to have no retry at all', async () => {
+    const fetchImpl = jest.fn()
+      .mockResolvedValueOnce(boom(500))
+      .mockResolvedValueOnce(ok({ data: { id: 'run-1', defaultDatasetId: 'ds-1', status: 'RUNNING' } }));
+
+    const run = await client(fetchImpl).startRun('actor~id', { q: 'spa' });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(run).toMatchObject({ runId: 'run-1', datasetId: 'ds-1' });
+  });
+
+  it('bounds a hung run-start instead of hanging the operator request', async () => {
+    await expect(
+      client(hangingFetch, { timeoutMs: 20, attempts: 1 }).startRun('actor~id', {})
+    ).rejects.toMatchObject({ name: 'AbortError', timeout: true });
+  });
+
+  it('surfaces a 4xx without burning retries', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(boom(404));
+
+    await expect(client(fetchImpl).startRun('missing~actor', {})).rejects.toThrow(/404/);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('waGraphClient transport', () => {
+  it('keeps its 3-attempt 5xx retry and now bounds each attempt', async () => {
+    const fetchImpl = jest.fn()
+      .mockResolvedValueOnce(boom(500))
+      .mockResolvedValueOnce(ok({ messages: [{ id: 'wamid.1' }] }));
+
+    const res = await makeWaGraphClient({ fetch: fetchImpl, sleep: noSleep, logger: silent })
+      .sendTemplate({ phoneId: '1', token: 't', to: '6591234567', name: 'tpl', language: 'en', components: [] });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(res.status).toBe(200);
+    expect(fetchImpl.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('still returns a 4xx for the caller to receipt', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(boom(400));
+
+    const res = await makeWaGraphClient({ fetch: fetchImpl, sleep: noSleep, logger: silent })
+      .sendTemplate({ phoneId: '1', token: 't', to: '6591234567', name: 'tpl', language: 'en', components: [] });
+
+    expect(res.status).toBe(400);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
**Task P2-1** (medium) · review round-2 queue

## Defect
`apifyClient.js` and `waGraphClient.js` both called bare `fetch` with **no timeout**. `fetch` has none by default, so a hung TCP connection hangs the caller until the platform kills it — and Apify's `startRun` is awaited **inline on the operator's request** (`discoveryService`), so "Apify is slow" surfaced as "Discovery is broken", with no error to show for it.

The retry posture was also backwards: WhatsApp retried 3×; Apify — the dependency that costs money per run — retried **0×**.

## Fix
**New `backend/src/utils/externalFetch.js`** owns both rules:
- `fetchWithTimeout` wraps every call in an `AbortController` (12s default) and reports a timeout as an `AbortError` carrying `timeout: true`, which the retry layer treats as transient — a request that never got a response very likely never landed.
- `retryingFetch` is the policy `waGraphClient` already had and which is worth keeping: retry a **network throw** or a **5xx**; return a **4xx as-is**, because retrying a deterministic answer only spends quota to be told the same thing.

Both clients route through it. Apify gains bounding *and* 3-attempt retry; WhatsApp keeps its exact retry behaviour (same log keys under the `wa_graph` prefix, same `300 * i` backoff, same injected `sleep`/`logger` seams) and gains the timeout it never had. `timeoutMs` and `attempts` are injectable on both.

**On the circuit breaker** (the task marked it optional): not wired here. `utils/circuitBreaker.js` wraps a single long-lived function, while these are per-call factories with injected transports — a breaker would need to be module-global and would then be shared across test instances. Bounding every attempt removes the failure mode that actually mattered; a breaker is a separate, larger change.

## Test proof
`backend/test/unit/externalFetch.test.js` (new, 14 cases) — a fake fetch that never settles until its signal aborts, plus scripted 500→200 and 4xx responses, driven through both real clients.

**Pre-fix: `3 failed, 11 passed`**
- Apify 500→200: **not retried** (1 call, error thrown)
- Apify hung run-start: **not bounded** — no `signal` reaches the transport at all
- WhatsApp: `fetch.mock.calls[0][1].signal` was **undefined**

**Post-fix: `14 passed`.**

Local: full unit tier **2182 passed / 127 suites**; `redeemOpsDiscovery`, `redeemOpsDiscoveryInstagram`, `redeemOpsDiscoveryUsage`, `waMessageSends` → **85 passed**. `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)