### PR TITLE
fix(webhooks): claim delivery row before send to stop double-dispatch (P2-2)

### DIFF
--- a/backend/src/models/WebhookDelivery.js
+++ b/backend/src/models/WebhookDelivery.js
@@ -33,7 +33,9 @@ const WebhookDelivery = sequelize.define('WebhookDelivery', {
     allowNull: false,
     defaultValue: 'pending',
     validate: {
-      isIn: [['pending', 'success', 'failed']]
+      // 'sending' = claimed by a worker and in flight (P2-2). Plain STRING
+      // column, no DB-level enum, so no migration is needed to widen it.
+      isIn: [['pending', 'sending', 'success', 'failed']]
     }
   },
   attempts: {

--- a/backend/src/services/webhookService.js
+++ b/backend/src/services/webhookService.js
@@ -48,6 +48,9 @@ export function makeWebhookService(overrides = {}) {
   // Concurrency limiter for webhook deliveries to avoid exhausting the connection pool
   const MAX_CONCURRENT_DELIVERIES = 3;
   const MAX_QUEUE_DEPTH = 100;
+  // A send is bounded at 10s; anything claimed for longer than this lost its
+  // process mid-flight and must be released back to the queue (P2-2).
+  const STALE_SENDING_MS = 120_000;
   let activeDeliveries = 0;
   let droppedDeliveries = 0;
   const deliveryQueue = [];
@@ -229,6 +232,30 @@ export function makeWebhookService(overrides = {}) {
         });
         return;
       }
+
+      // CLAIM the row before sending (P2-2). A failed delivery schedules its
+      // retry on a setTimeout while the row stays 'pending', and the 60s
+      // recovery poll selects exactly those rows — so once nextRetryAt passed,
+      // the timer and the poll could both enqueue the same delivery and the
+      // receiver got it twice. Only the caller whose UPDATE actually moves
+      // pending→sending may send; the loser skips.
+      //
+      // `attempts` increments HERE, column-relative, so the counter can never
+      // be built from a stale read: an attempt made is an attempt counted, even
+      // if the process dies mid-fetch.
+      const [claimed, rows] = await d.WebhookDelivery.update(
+        { status: 'sending', attempts: d.sequelize.literal('attempts + 1'), lastAttemptAt: new Date() },
+        { where: { id: delivery.id, status: 'pending' }, returning: true }
+      );
+      if (!claimed) {
+        d.logger.info('[Webhook] delivery skipped (claimed by another worker)', {
+          deliveryId: delivery.deliveryId,
+        });
+        return;
+      }
+      // Carry the authoritative attempt count onto the in-memory copy.
+      delivery.attempts = rows?.[0]?.attempts ?? delivery.attempts + 1;
+      delivery.status = 'sending';
     }
     const rawBody = JSON.stringify(delivery.payload);
     const timestamp = new Date().toISOString();
@@ -267,7 +294,9 @@ export function makeWebhookService(overrides = {}) {
           status: 'success',
           responseCode: response.status,
           lastAttemptAt: new Date(),
-          attempts: delivery.attempts + 1
+          // The claim already incremented `attempts` for a real row; an
+          // injected fake (no reload()) never went through it (P2-2).
+          ...(delivery.status === 'sending' ? {} : { attempts: delivery.attempts + 1 })
         });
       } else {
         let responseBody = '';
@@ -293,10 +322,13 @@ export function makeWebhookService(overrides = {}) {
   }
 
   async function handleFailure(delivery, subscriber, { responseCode, responseBody, errorMessage }) {
-    const newAttempts = delivery.attempts + 1;
+    // The claim already incremented `attempts` for a real row; an injected fake
+    // (no reload()) never went through it, so it still counts its own.
+    const claimed = delivery.status === 'sending';
+    const newAttempts = claimed ? delivery.attempts : delivery.attempts + 1;
 
     const updateData = {
-      attempts: newAttempts,
+      ...(claimed ? {} : { attempts: newAttempts }),
       lastAttemptAt: new Date(),
       responseCode,
       responseBody,
@@ -307,6 +339,9 @@ export function makeWebhookService(overrides = {}) {
       // Exponential backoff: 1s, 4s, 16s
       const delayMs = Math.pow(4, newAttempts - 1) * 1000;
       updateData.nextRetryAt = new Date(Date.now() + delayMs);
+      // Back to 'pending' explicitly — the claim moved it to 'sending', and a
+      // row left there would be invisible to both the timer and the poll.
+      updateData.status = 'pending';
       await delivery.update(updateData);
 
       // Schedule the retry through the concurrency limiter so retries respect
@@ -522,6 +557,26 @@ export function makeWebhookService(overrides = {}) {
    */
   async function recoverPendingRetries() {
     const now = new Date();
+
+    // Reclaim rows stranded in 'sending' (P2-2): the claim is what stops the
+    // timer and this poll from double-sending, but a process that dies
+    // mid-fetch leaves the row claimed and therefore invisible to both. The
+    // send itself is bounded at 10s, so anything still 'sending' well past
+    // that is a corpse, not a flight in progress.
+    const [, reclaimed] = await d.WebhookDelivery.update(
+      { status: 'pending' },
+      {
+        where: {
+          status: 'sending',
+          lastAttemptAt: { [Op.lt]: new Date(now.getTime() - STALE_SENDING_MS) },
+        },
+        returning: true,
+      }
+    );
+    if (reclaimed?.length) {
+      d.logger.warn('[Webhook] reclaimed stranded in-flight deliveries', { count: reclaimed.length });
+    }
+
     const staleDeliveries = await d.WebhookDelivery.findAll({
       where: {
         status: 'pending',

--- a/backend/test/unit/models.test.js
+++ b/backend/test/unit/models.test.js
@@ -238,11 +238,13 @@ describe('Sequelize Models (definitions & validations)', () => {
   // ──────────────────────────────────────────────
 
   describe('WebhookDelivery', () => {
-    it('has status field with isIn validation for pending, success, failed', () => {
+    it('has status field with isIn validation for pending, sending, success, failed', () => {
       const statusAttr = attrs(WebhookDelivery).status;
       expect(statusAttr).toBeDefined();
       expect(statusAttr.defaultValue).toBe('pending');
-      expect(statusAttr.validate.isIn).toEqual([['pending', 'success', 'failed']]);
+      // 'sending' = claimed and in flight (P2-2) — the state that makes the
+      // pending→sending claim able to exclude a second dispatcher.
+      expect(statusAttr.validate.isIn).toEqual([['pending', 'sending', 'success', 'failed']]);
     });
 
     it('defaults attempts to 0', () => {

--- a/backend/test/unit/webhookService.test.js
+++ b/backend/test/unit/webhookService.test.js
@@ -275,9 +275,12 @@ describe('webhookService (unit)', () => {
 
       await service.attemptDelivery(delivery, mocks.mockSubscriber);
 
-      // Status should NOT be 'failed' since we haven't exhausted maxAttempts
+      // Status should NOT be 'failed' since we haven't exhausted maxAttempts.
+      // It is now set to 'pending' EXPLICITLY (P2-2): the claim moved the row
+      // to 'sending', and a row left there would be invisible to both the
+      // retry timer and the recovery poll.
       const updateCall = delivery.update.mock.calls[0][0];
-      expect(updateCall.status).toBeUndefined(); // status not set to 'failed' when retries remain
+      expect(updateCall.status).toBe('pending');
       expect(updateCall.attempts).toBe(1);
       expect(updateCall.nextRetryAt).toBeDefined();
     });

--- a/backend/test/webhookDeliveryClaim.test.js
+++ b/backend/test/webhookDeliveryClaim.test.js
@@ -1,0 +1,171 @@
+/**
+ * P2-2 regression: one pending delivery is sent ONCE.
+ *
+ * A failed delivery scheduled its retry on a setTimeout while leaving the row
+ * `status: 'pending'` with `nextRetryAt` set — and recoverPendingRetries (boot
+ * + every 60s) selects exactly those rows, with no claim and no lock. Once
+ * nextRetryAt passed, the in-process timer and the poll could both enqueue the
+ * same delivery: the receiver got the webhook twice, and the read-modify-write
+ * `attempts` counter over- or under-shot maxAttempts.
+ *
+ * The fix is a conditional pending→sending claim that also increments attempts
+ * column-relative, so only the winner sends. These drive the real service
+ * against real Postgres.
+ */
+import { randomUUID } from 'crypto'
+import { WebhookSubscriber, WebhookDelivery } from '../src/models/index.js'
+import { makeWebhookService } from '../src/services/webhookService.js'
+import { getApp, closeDb } from './helpers.js'
+
+let subscriber
+
+const silent = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }
+
+/** A delivery already scheduled for retry — pending, its backoff elapsed. */
+async function pendingDelivery(over = {}) {
+  return WebhookDelivery.create({
+    subscriberId: subscriber.id,
+    deliveryId: randomUUID(),
+    eventType: 'lead.created',
+    payload: { event: 'lead.created', data: { id: 'lead-1' } },
+    status: 'pending',
+    attempts: 1,
+    maxAttempts: 3,
+    nextRetryAt: new Date(Date.now() - 1000),
+    ...over,
+  })
+}
+
+beforeAll(async () => {
+  await getApp()
+  subscriber = await WebhookSubscriber.create({
+    name: 'Claim Test Receiver',
+    url: 'https://receiver.test/hook',
+    secret: 'shhh',
+    events: ['lead.created'],
+    enabled: true,
+  })
+})
+
+afterAll(async () => {
+  await WebhookDelivery.destroy({ where: { subscriberId: subscriber.id } })
+  await subscriber.destroy()
+  await closeDb()
+})
+
+describe('concurrent dispatch of one pending delivery', () => {
+  it('sends exactly once and counts exactly one attempt', async () => {
+    const row = await pendingDelivery()
+    const sends = []
+    const svc = makeWebhookService({
+      logger: silent,
+      fetch: async (url) => {
+        sends.push(url)
+        // Hold the flight open so the second dispatcher is guaranteed to
+        // overlap — the interleaving the claim has to survive.
+        await new Promise((r) => setTimeout(r, 150))
+        return { ok: true, status: 200, text: async () => 'ok' }
+      },
+    })
+
+    // The lost setTimeout retry and the recovery poll, racing on one row.
+    const a = await WebhookDelivery.findByPk(row.id)
+    const b = await WebhookDelivery.findByPk(row.id)
+    await Promise.all([
+      svc.attemptDelivery(a, subscriber),
+      svc.attemptDelivery(b, subscriber),
+    ])
+
+    expect(sends).toHaveLength(1)
+
+    const after = await WebhookDelivery.findByPk(row.id)
+    expect(after.status).toBe('success')
+    expect(after.attempts).toBe(2) // started at 1, exactly one attempt added
+  })
+
+  it('leaves the loser a no-op — no second attempt is charged', async () => {
+    const row = await pendingDelivery({ attempts: 2, maxAttempts: 3 })
+    let calls = 0
+    const svc = makeWebhookService({
+      logger: silent,
+      fetch: async () => {
+        calls += 1
+        await new Promise((r) => setTimeout(r, 120))
+        return { ok: true, status: 200, text: async () => 'ok' }
+      },
+    })
+
+    const a = await WebhookDelivery.findByPk(row.id)
+    const b = await WebhookDelivery.findByPk(row.id)
+    await Promise.all([
+      svc.attemptDelivery(a, subscriber),
+      svc.attemptDelivery(b, subscriber),
+    ])
+
+    expect(calls).toBe(1)
+    // 3 would have tripped maxAttempts and failed the delivery outright.
+    expect((await WebhookDelivery.findByPk(row.id)).attempts).toBe(3)
+  })
+
+  it('returns a retryable failure to pending so the queue can pick it up again', async () => {
+    const row = await pendingDelivery({ attempts: 0 })
+    const svc = makeWebhookService({
+      logger: silent,
+      fetch: async () => ({ ok: false, status: 503, text: async () => 'upstream down' }),
+    })
+
+    const live = await WebhookDelivery.findByPk(row.id)
+    await svc.attemptDelivery(live, subscriber)
+
+    const after = await WebhookDelivery.findByPk(row.id)
+    expect(after.status).toBe('pending') // NOT stranded in 'sending'
+    expect(after.attempts).toBe(1)
+    expect(after.nextRetryAt).toBeInstanceOf(Date)
+  })
+
+  it('marks the delivery failed once attempts are exhausted', async () => {
+    const row = await pendingDelivery({ attempts: 2, maxAttempts: 3 })
+    const svc = makeWebhookService({
+      logger: silent,
+      fetch: async () => ({ ok: false, status: 500, text: async () => 'nope' }),
+    })
+
+    const live = await WebhookDelivery.findByPk(row.id)
+    await svc.attemptDelivery(live, subscriber)
+
+    const after = await WebhookDelivery.findByPk(row.id)
+    expect(after.status).toBe('failed')
+    expect(after.attempts).toBe(3)
+  })
+})
+
+describe('crash recovery', () => {
+  it('reclaims a delivery stranded in flight and re-sends it', async () => {
+    // A process that died mid-fetch: claimed, never resolved, long past the 10s
+    // send budget. Without reclamation this row is invisible to timer AND poll.
+    const row = await pendingDelivery({
+      status: 'sending',
+      lastAttemptAt: new Date(Date.now() - 5 * 60_000),
+    })
+
+    const svc = makeWebhookService({
+      logger: silent,
+      fetch: async () => ({ ok: true, status: 200, text: async () => 'ok' }),
+    })
+
+    await svc.recoverPendingRetries()
+    await new Promise((r) => setTimeout(r, 400)) // let the queue drain
+
+    const after = await WebhookDelivery.findByPk(row.id)
+    expect(after.status).toBe('success')
+  })
+
+  it('does not touch a delivery that is legitimately still in flight', async () => {
+    const row = await pendingDelivery({ status: 'sending', lastAttemptAt: new Date() })
+
+    const svc = makeWebhookService({ logger: silent, fetch: async () => ({ ok: true, status: 200, text: async () => 'ok' }) })
+    await svc.recoverPendingRetries()
+
+    expect((await WebhookDelivery.findByPk(row.id)).status).toBe('sending')
+  })
+})


### PR DESCRIPTION
**Task P2-2** (medium) · review round-2 queue

## Defect
A failed delivery scheduled its retry on a `setTimeout` while leaving the row `status: 'pending'` with `nextRetryAt` set. `recoverPendingRetries` — boot and every 60s — selects exactly those rows, **with no claim and no lock**. Once `nextRetryAt` passed, the in-process timer and the poll could both enqueue the same delivery: the receiver got the webhook **twice**, and the read-modify-write `attempts` counter over- or under-shot `maxAttempts`.

## Fix
`attemptDelivery` claims the row before sending — a conditional `pending → sending` UPDATE that also increments `attempts` **column-relative in the same statement**, so the counter can never be built from a stale read. Only the caller whose claim actually moves a row may send; the loser logs and returns.

Two consequences handled deliberately:
- **A retryable failure returns the row to `pending` explicitly.** It was implicit before (the row never left `pending`); now it's in `sending`, and a row left there would be invisible to *both* the timer and the poll.
- **The new state needs its own crash recovery.** A process that dies mid-fetch leaves the row claimed forever, so the poll now first releases rows stranded in `sending` past 120s (the send itself is bounded at 10s, so anything older lost its process). Without this the claim would trade a double-send for a lost lead — strictly worse.

`sending` is a plain `STRING` column with an app-level validator, so no migration is needed to widen it. The existing DI seam is preserved: injected fakes without `.reload()` skip the claim and keep counting their own attempts, exactly as before.

## Test proof
`backend/test/webhookDeliveryClaim.test.js` (new, 6 cases) against real Postgres — two dispatchers racing one row, with the fetch held open 150ms so the overlap is guaranteed rather than hoped for.

**Pre-fix: `4 failed, 2 passed`**
- `sends exactly once`: **received 2** — `["https://receiver.test/hook", "https://receiver.test/hook"]`, the double-send itself
- `attempts` charged **twice** (1 → 3, tripping maxAttempts)
- both crash-recovery cases fail (no `sending` state existed)

**Post-fix: `6 passed`.**

Three existing unit assertions encoded the old contract and were updated with the reason in place: the model's `isIn` list gains `sending`, and the retry case now expects `status: 'pending'` explicitly instead of `undefined` (its stated intent — "not `failed` when retries remain" — is unchanged).

Local: full unit tier **2168 passed / 126 suites**; `webhookDeliveryClaim`, `webhooks`, `prospects`, `externalHeldLeadsController` → **123 passed**. `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)