### PR TITLE
fix(webhooks): bind timestamp into the default signature (v2) (P2-3)

### DIFF
--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -469,6 +469,18 @@ async function safeRun(label, fn) {
  * are forwarded to the Lyfe Edge Function automatically.
  * Reads URL and secret from env vars; skips silently if not configured.
  */
+/**
+ * Which signature scheme the two BOOTSTRAP-MANAGED live subscribers are signed
+ * with (P2-3). The sender defaults to v2 (timestamp-bound); these two are held
+ * on v1 because their receivers verify the body ALONE and would 401 every
+ * delivery the moment we flipped.
+ *
+ * THE CUTOVER IS THIS CONSTANT. Deploy the dual-accept receivers first, then
+ * change 'v1' → 'v2' here: the self-heal below re-pins both rows on the next
+ * boot. Full runbook: docs/plans/webhook-signature-v2-cutover.md.
+ */
+const LIVE_SUBSCRIBER_SIGNATURE_VERSION = 'v1';
+
 export async function ensureLyfeWebhookSubscriber() {
   const adapter = adapterRegistry.get('lyfe');
   const url = adapter.outboundWebhookUrl?.();
@@ -497,14 +509,19 @@ export async function ensureLyfeWebhookSubscriber() {
   if (existing) {
     const needsUpdate = existing.url !== url || existing.secret !== secret || !existing.enabled
       || JSON.stringify(existing.events?.sort()) !== JSON.stringify(requiredEvents.sort())
-      || existing.metadata?.destination !== 'lyfe';
+      || existing.metadata?.destination !== 'lyfe'
+      || existing.metadata?.signatureVersion !== LIVE_SUBSCRIBER_SIGNATURE_VERSION;
     if (needsUpdate) {
       await existing.update({
         url,
         secret,
         enabled: true,
         events: requiredEvents,
-        metadata: { ...(existing.metadata || {}), destination: 'lyfe' },
+        metadata: {
+          ...(existing.metadata || {}),
+          destination: 'lyfe',
+          signatureVersion: LIVE_SUBSCRIBER_SIGNATURE_VERSION,
+        },
       });
       logger.info('Lyfe webhook subscriber updated', { url, events: requiredEvents });
     } else {
@@ -520,7 +537,7 @@ export async function ensureLyfeWebhookSubscriber() {
     events: requiredEvents,
     enabled: true,
     description: 'Forward leads to Lyfe mobile app via Supabase Edge Function',
-    metadata: { destination: 'lyfe' },
+    metadata: { destination: 'lyfe', signatureVersion: LIVE_SUBSCRIBER_SIGNATURE_VERSION },
   });
 
   logger.info('Lyfe webhook subscriber registered', { url });
@@ -560,14 +577,19 @@ export async function ensureMktrLeadsWebhookSubscriber() {
   if (existing) {
     const needsUpdate = existing.url !== url || existing.secret !== secret || !existing.enabled
       || JSON.stringify(existing.events?.sort()) !== JSON.stringify(requiredEvents.sort())
-      || existing.metadata?.destination !== 'mktr_leads';
+      || existing.metadata?.destination !== 'mktr_leads'
+      || existing.metadata?.signatureVersion !== LIVE_SUBSCRIBER_SIGNATURE_VERSION;
     if (needsUpdate) {
       await existing.update({
         url,
         secret,
         enabled: true,
         events: requiredEvents,
-        metadata: { ...(existing.metadata || {}), destination: 'mktr_leads' },
+        metadata: {
+          ...(existing.metadata || {}),
+          destination: 'mktr_leads',
+          signatureVersion: LIVE_SUBSCRIBER_SIGNATURE_VERSION,
+        },
       });
       logger.info('mktr-leads webhook subscriber updated', { url, events: requiredEvents });
     } else {
@@ -583,7 +605,7 @@ export async function ensureMktrLeadsWebhookSubscriber() {
     events: requiredEvents,
     enabled: true,
     description: 'Forward leads to the mktr-leads app via Supabase Edge Function',
-    metadata: { destination: 'mktr_leads' },
+    metadata: { destination: 'mktr_leads', signatureVersion: LIVE_SUBSCRIBER_SIGNATURE_VERSION },
   });
 
   logger.info('mktr-leads webhook subscriber registered', { url });

--- a/backend/src/services/webhookSigning.js
+++ b/backend/src/services/webhookSigning.js
@@ -1,13 +1,42 @@
 import crypto from 'crypto';
 
-/** Only an explicit per-subscriber v2 opt-in changes the legacy wire format. */
+/**
+ * Webhook signature versions.
+ *
+ *   v1 — HMAC over the raw body ALONE.
+ *   v2 — HMAC over `${timestamp}.${rawBody}`.
+ *
+ * v1 sends X-Webhook-Timestamp but never mixes it into the HMAC, so the header
+ * is unauthenticated: anyone who captures one delivery can replay it with a
+ * freshly-rewritten timestamp and the body-only signature still validates —
+ * the receiver's 5-minute replay window is defeated by rewriting the very field
+ * it checks. For lead.created the blast radius is bounded by receiver-side
+ * idempotency, but lead.unassigned and lead.deleted are state-changing and have
+ * no such backstop.
+ *
+ * v2 binds the timestamp, so a rewritten one invalidates the signature (P2-3).
+ */
+
+/** v2 unless a subscriber explicitly pins itself to the legacy scheme. */
+export const DEFAULT_SIGNATURE_VERSION = 'v2';
+
+/**
+ * Which scheme to sign a given subscriber's deliveries with.
+ *
+ * `metadata.signatureVersion: 'v1'` is the explicit LEGACY OPT-OUT and exists
+ * for exactly one reason: a receiver that cannot yet verify v2. Both live
+ * subscribers are pinned that way by bootstrap until the receive-mktr-lead edge
+ * function accepts both schemes — see docs/plans/webhook-signature-v2-cutover.md.
+ * Anything unrecognised falls through to the secure default rather than
+ * silently downgrading.
+ */
 export function signatureVersionForSubscriber(subscriber) {
-  return subscriber?.metadata?.signatureVersion === 'v2' ? 'v2' : 'v1';
+  return subscriber?.metadata?.signatureVersion === 'v1' ? 'v1' : DEFAULT_SIGNATURE_VERSION;
 }
 
 /** Build the HMAC header for one delivery attempt. */
 export function signWebhookAttempt({ secret, rawBody, timestamp, signatureVersion }) {
-  const signedContent = signatureVersion === 'v2' ? `${timestamp}.${rawBody}` : rawBody;
+  const signedContent = signatureVersion === 'v1' ? rawBody : `${timestamp}.${rawBody}`;
   const digest = crypto.createHmac('sha256', secret).update(signedContent).digest('hex');
   return `sha256=${digest}`;
 }

--- a/backend/test/integration/pipelineE2E.test.js
+++ b/backend/test/integration/pipelineE2E.test.js
@@ -245,13 +245,20 @@ describe('Pipeline E2E: Retell webhook → Prospect → Webhook dispatch', () =>
     const payloads = await waitForPayloads(1);
     const received = payloads[0];
 
-    // Verify HMAC using subscriber secret
+    // Verify HMAC using subscriber secret. The default scheme is v2 (P2-3):
+    // the timestamp is BOUND into the digest, so a replay carrying a
+    // rewritten timestamp no longer validates. v1 signed the body alone.
+    expect(received.headers['x-webhook-signature-version']).toBe('v2');
     const expectedHmac = crypto
       .createHmac('sha256', SUBSCRIBER_SECRET)
-      .update(received.rawBody)
+      .update(`${received.headers['x-webhook-timestamp']}.${received.rawBody}`)
       .digest('hex');
 
     expect(received.headers['x-webhook-signature']).toBe(`sha256=${expectedHmac}`);
+
+    // ...and the body-only digest — what v1 produced — must NOT match.
+    const v1Hmac = crypto.createHmac('sha256', SUBSCRIBER_SECRET).update(received.rawBody).digest('hex');
+    expect(received.headers['x-webhook-signature']).not.toBe(`sha256=${v1Hmac}`);
   });
 
   it('creates Prospect + ProspectActivity + IdempotencyKey in one transaction', async () => {

--- a/backend/test/unit/webhookService.test.js
+++ b/backend/test/unit/webhookService.test.js
@@ -187,9 +187,12 @@ describe('webhookService (unit)', () => {
       expect(opts.headers['X-Webhook-Delivery-Id']).toBe('uuid-1');
       expect(opts.headers['X-Webhook-Timestamp']).toBeDefined();
 
-      // Verify HMAC signature
+      // Verify HMAC signature. The default scheme is v2 (P2-3): the timestamp
+      // is BOUND into the digest, so a replay with a rewritten timestamp no
+      // longer validates. v1 signed the body alone.
+      expect(opts.headers['X-Webhook-Signature-Version']).toBe('v2');
       const expectedHmac = crypto.createHmac('sha256', 'secret123')
-        .update(opts.body)
+        .update(`${opts.headers['X-Webhook-Timestamp']}.${opts.body}`)
         .digest('hex');
       expect(opts.headers['X-Webhook-Signature']).toBe(`sha256=${expectedHmac}`);
     });

--- a/backend/test/unit/webhookSignatureReplay.test.js
+++ b/backend/test/unit/webhookSignatureReplay.test.js
@@ -1,0 +1,87 @@
+/**
+ * P2-3 regression: the timestamp is part of what gets signed.
+ *
+ * v1 hashes the raw body ALONE. Every delivery carries X-Webhook-Timestamp and
+ * the receiver enforces a 5-minute freshness window on it — but that header
+ * never entered the HMAC, so it was unauthenticated. An attacker who captured
+ * one delivery could replay it forever by rewriting the timestamp: the
+ * body-only signature still validated, and the freshness check passed because
+ * the attacker controlled the field it reads.
+ *
+ * These model the receiver's own check — recompute the HMAC over what the
+ * scheme says is signed, and compare — so "rejected" here means "rejected on
+ * the wire".
+ */
+import '../setup.js';
+import crypto from 'crypto';
+import { signWebhookAttempt, signatureVersionForSubscriber } from '../../src/services/webhookSigning.js';
+
+const SECRET = 'shared-webhook-secret';
+const BODY = JSON.stringify({ event: 'lead.unassigned', deliveryId: 'd-1', data: { id: 'lead-9' } });
+const CAPTURED_AT = '2026-08-02T10:00:00.000Z';
+const REPLAYED_AT = '2026-08-02T18:30:00.000Z'; // hours later, inside nobody's window
+
+/** What a receiver does: recompute over the signed content for the claimed version. */
+function receiverAccepts({ signature, rawBody, timestamp, version }) {
+  const signed = version === 'v1' ? rawBody : `${timestamp}.${rawBody}`;
+  const expected = `sha256=${crypto.createHmac('sha256', SECRET).update(signed).digest('hex')}`;
+  return signature === expected;
+}
+
+describe('replaying a captured delivery with a fresh timestamp', () => {
+  it('is REJECTED under v2 — the timestamp is bound into the signature', () => {
+    const signature = signWebhookAttempt({
+      secret: SECRET, rawBody: BODY, timestamp: CAPTURED_AT, signatureVersion: 'v2',
+    });
+
+    // The attacker replays the captured body + signature, rewriting only the
+    // timestamp header so the receiver's freshness window passes.
+    expect(receiverAccepts({ signature, rawBody: BODY, timestamp: REPLAYED_AT, version: 'v2' })).toBe(false);
+
+    // ...and the original delivery still verifies, so this is not a blanket reject.
+    expect(receiverAccepts({ signature, rawBody: BODY, timestamp: CAPTURED_AT, version: 'v2' })).toBe(true);
+  });
+
+  it('was ACCEPTED under v1 — this is the hole being closed', () => {
+    const signature = signWebhookAttempt({
+      secret: SECRET, rawBody: BODY, timestamp: CAPTURED_AT, signatureVersion: 'v1',
+    });
+
+    expect(receiverAccepts({ signature, rawBody: BODY, timestamp: REPLAYED_AT, version: 'v1' })).toBe(true);
+  });
+
+  it('still rejects a tampered BODY under v2', () => {
+    const signature = signWebhookAttempt({
+      secret: SECRET, rawBody: BODY, timestamp: CAPTURED_AT, signatureVersion: 'v2',
+    });
+    const tampered = JSON.stringify({ event: 'lead.deleted', deliveryId: 'd-1', data: { id: 'lead-9' } });
+
+    expect(receiverAccepts({ signature, rawBody: tampered, timestamp: CAPTURED_AT, version: 'v2' })).toBe(false);
+  });
+
+  it('produces a different signature per timestamp for one body', () => {
+    const a = signWebhookAttempt({ secret: SECRET, rawBody: BODY, timestamp: CAPTURED_AT, signatureVersion: 'v2' });
+    const b = signWebhookAttempt({ secret: SECRET, rawBody: BODY, timestamp: REPLAYED_AT, signatureVersion: 'v2' });
+    expect(a).not.toBe(b);
+
+    // v1 cannot tell those two deliveries apart — the defect in one line.
+    const v1a = signWebhookAttempt({ secret: SECRET, rawBody: BODY, timestamp: CAPTURED_AT, signatureVersion: 'v1' });
+    const v1b = signWebhookAttempt({ secret: SECRET, rawBody: BODY, timestamp: REPLAYED_AT, signatureVersion: 'v1' });
+    expect(v1a).toBe(v1b);
+  });
+});
+
+describe('version selection', () => {
+  it('defaults to the timestamp-bound scheme', () => {
+    expect(signatureVersionForSubscriber({ metadata: {} })).toBe('v2');
+    expect(signatureVersionForSubscriber({})).toBe('v2');
+    expect(signatureVersionForSubscriber(undefined)).toBe('v2');
+  });
+
+  it('honours the explicit legacy opt-out and nothing else', () => {
+    expect(signatureVersionForSubscriber({ metadata: { signatureVersion: 'v1' } })).toBe('v1');
+    // A typo must not silently downgrade a subscriber to the replayable scheme.
+    expect(signatureVersionForSubscriber({ metadata: { signatureVersion: 'V1' } })).toBe('v2');
+    expect(signatureVersionForSubscriber({ metadata: { signatureVersion: 'typo' } })).toBe('v2');
+  });
+});

--- a/backend/test/unit/webhookSignatureVersions.test.js
+++ b/backend/test/unit/webhookSignatureVersions.test.js
@@ -28,7 +28,9 @@ describe('per-subscriber webhook signature versions', () => {
     name: 'Lyfe App',
     url: 'https://lyfe.example/webhook',
     secret: vector.secret,
-    metadata: { destination: 'lyfe' },
+    // Bootstrap pins the live subscribers to the legacy scheme until the
+            // receivers dual-accept (P2-3, docs/plans/webhook-signature-v2-cutover.md).
+    metadata: { destination: 'lyfe', signatureVersion: 'v1' },
   };
   const mktrLeads = {
     id: 'mktr-leads',
@@ -63,9 +65,11 @@ describe('per-subscriber webhook signature versions', () => {
     })).toBe(vector.v2Signature);
   });
 
-  it('defaults absent and unknown metadata to byte-identical v1 behavior', () => {
+  it('defaults to timestamp-bound v2 and honours only the explicit v1 pin', () => {
+    // P2-3 inverted this: v2 is the default, v1 is the deliberate legacy opt-out.
     expect(signatureVersionForSubscriber(lyfe)).toBe('v1');
-    expect(signatureVersionForSubscriber({ metadata: { signatureVersion: 'typo' } })).toBe('v1');
+    expect(signatureVersionForSubscriber({ metadata: { signatureVersion: 'typo' } })).toBe('v2');
+    expect(signatureVersionForSubscriber({ metadata: {} })).toBe('v2');
     expect(signatureVersionForSubscriber(mktrLeads)).toBe('v2');
   });
 

--- a/docs/plans/webhook-signature-v2-cutover.md
+++ b/docs/plans/webhook-signature-v2-cutover.md
@@ -1,0 +1,108 @@
+# Webhook signature v2 cutover (P2-3)
+
+**Status:** sender ready, live subscribers pinned to v1, receivers not yet dual-accepting.
+
+## Why
+
+The v1 signature is an HMAC over the raw body **alone**. Every delivery also carries
+`X-Webhook-Timestamp`, and the receiver enforces a 5-minute freshness window on it — but that
+header never enters the HMAC, so it is unauthenticated. Anyone who captures one delivery can
+replay it indefinitely by rewriting the timestamp: the body-only signature still validates, and the
+freshness check passes because the attacker controls the very field it reads.
+
+`lead.created` is bounded by receiver-side idempotency (`external_id` + `source_name='mktr'`).
+`lead.unassigned` and `lead.deleted` are **state-changing** and have no such backstop — a replayed
+`lead.unassigned` un-assigns a lead that was legitimately re-assigned since.
+
+v2 signs `${timestamp}.${rawBody}`, so a rewritten timestamp invalidates the signature.
+
+## Current state after this PR
+
+| Piece | State |
+|---|---|
+| `signatureVersionForSubscriber` | defaults to **v2**; `metadata.signatureVersion: 'v1'` is the explicit legacy opt-out |
+| Any NEW subscriber | v2, timestamp-bound, no action needed |
+| `Lyfe App` + `MKTR Leads App` | **pinned to v1** by `LIVE_SUBSCRIBER_SIGNATURE_VERSION` in `backend/src/database/bootstrap.js`, re-applied on every boot |
+
+The pin is deliberate. Both receivers verify the body alone today, so flipping them without
+deploying the receiver first would 401 **every** lead delivery — an outage, not a fix.
+
+## The cutover
+
+Strictly in this order. Each step is independently revertable.
+
+### 1. Make the receivers accept BOTH schemes
+
+`lyfe-app/supabase/functions/receive-mktr-lead/index.ts` — `verifySignature` currently hashes
+`rawBody` only. Make it accept either, selected by the header the sender already emits:
+
+```ts
+async function verifySignature(
+  rawBody: string,
+  signatureHeader: string,
+  secret: string,
+  timestamp: string | null,
+  version: string | null,
+): Promise<boolean> {
+  if (!signatureHeader.startsWith('sha256=')) return false;
+  const receivedHex = signatureHeader.slice(7);
+
+  // v2 binds the timestamp; v1 is the legacy body-only scheme. Accept both
+  // during the cutover, then delete the v1 branch (step 4).
+  const signed = version === 'v2' && timestamp ? `${timestamp}.${rawBody}` : rawBody;
+
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw', enc.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'],
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(signed));
+  const computedHex = Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, '0')).join('');
+
+  return timingSafeEqual(receivedHex, computedHex);
+}
+```
+
+Call site — read the timestamp **before** verifying, and pass both through:
+
+```ts
+const timestampHeader = req.headers.get('X-Webhook-Timestamp');
+const signatureVersion = req.headers.get('X-Webhook-Signature-Version');
+const valid = await verifySignature(rawBody, signatureHeader, webhookSecret, timestampHeader, signatureVersion);
+```
+
+Keep the existing mandatory-timestamp and 5-minute-window checks exactly as they are; under v2 they
+become meaningful rather than advisory.
+
+Deploy, and confirm live v1 traffic still succeeds — the version header is absent on v1 deliveries,
+so they take the legacy branch unchanged.
+
+Do the same for the mktr-leads receiver (separate repo, same shape).
+
+### 2. Flip the sender
+
+In `backend/src/database/bootstrap.js`:
+
+```js
+const LIVE_SUBSCRIBER_SIGNATURE_VERSION = 'v2';
+```
+
+One line. The self-heal in both `ensure*WebhookSubscriber` functions re-pins the existing rows on
+the next boot, so no manual DB edit is needed.
+
+### 3. Verify
+
+- A real lead capture reaches Lyfe (`leads` row created, push delivered).
+- `webhook_deliveries` shows `status: 'success'` for the new attempts — a scheme mismatch surfaces
+  as a 401 and a retry, not a silent drop.
+- Deliveries now carry `X-Webhook-Signature-Version: v2`.
+
+### 4. Retire v1
+
+Once both receivers have run on v2 for a soak period, delete the v1 branch from each
+`verifySignature` and drop the legacy opt-out from `signatureVersionForSubscriber`.
+
+## Rollback
+
+Revert step 2 (the constant back to `'v1'`) and redeploy the backend. The dual-accept receivers from
+step 1 keep working for both schemes, so rollback needs no receiver change.


### PR DESCRIPTION
**Task P2-3** (medium) · review round-2 queue

## Defect
v1 — the default and live scheme — hashes the raw body **alone**. Every delivery carries `X-Webhook-Timestamp`, and the receiver enforces a 5-minute freshness window on it, but that header never entered the HMAC. It was unauthenticated: capture one delivery, rewrite the timestamp, replay forever. The body-only signature still validates, and the freshness check passes *because the attacker controls the very field it reads*.

`lead.created` is bounded by receiver idempotency (`external_id` + `source_name='mktr'`). **`lead.unassigned` and `lead.deleted` are state-changing and have no such backstop** — a replayed `lead.unassigned` un-assigns a lead that was legitimately re-assigned since.

## Fix
`signatureVersionForSubscriber` now returns **v2 by default**. `'v1'` becomes the explicit legacy opt-out, and an unrecognised value (`'V1'`, a typo) resolves to **v2** rather than silently downgrading to the replayable scheme.

### The live subscribers are deliberately NOT flipped here
I read the receiver before changing the default: `receive-mktr-lead/index.ts` calls `verifySignature(rawBody, …)` and hashes the body alone — **no v2 branch, and it ignores `X-Webhook-Signature-Version` entirely**. Flipping the live subscribers today would 401 *every* lead delivery to Lyfe. That's an outage, not a fix, so:

- Bootstrap pins `Lyfe App` and `MKTR Leads App` to v1 via one named constant, `LIVE_SUBSCRIBER_SIGNATURE_VERSION`, and the existing self-heal re-applies it on every boot — so it also covers the rows already in production, which a create-only default would have missed and silently upgraded.
- **Live traffic is byte-identical after this PR.** What changes today: any *new* subscriber is timestamp-bound by default.

`docs/plans/webhook-signature-v2-cutover.md` carries the rest: the concrete dual-accept patch for the receiver's `verifySignature` (accept both, selected by the header the sender already sends), the ordering, verification steps, and a rollback that needs no receiver change. The cutover itself is then that single constant.

## Test proof
`backend/test/unit/webhookSignatureReplay.test.js` (new, 6 cases) models the receiver's own check — recompute the HMAC over what the scheme says is signed — so "rejected" means rejected on the wire.

- The replay (captured body + signature, rewritten timestamp) is **rejected under v2** and **accepted under v1** — the hole, demonstrated both ways in adjacent tests.
- A tampered body is still rejected; one body under two timestamps yields two different v2 signatures but **identical v1 signatures** — the defect in one assertion.

**Pre-fix: `2 failed, 4 passed`** — `signatureVersionForSubscriber({metadata:{}})` returned `v1` where v2 is now required (the replay math itself is version-parameterised, so those cases hold either way).

Two existing assertions encoded the old default and were updated in place with the reason: the version-contract suite (Lyfe now carries the explicit pin, as bootstrap writes it) and the header test (which recomputed the HMAC over the body alone).

Local: full unit tier **2188 passed / 128 suites**; `webhooks`, `webhookDeliveryClaim`, `prospects` → **110 passed**. `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)