### PR TITLE
fix(redeem-ops): idempotent WA status upsert stops rescore storm (P2-4)

### DIFF
--- a/backend/src/services/redeemOps/waWebhookService.js
+++ b/backend/src/services/redeemOps/waWebhookService.js
@@ -94,7 +94,7 @@ export function makeWaWebhookService(overrides = {}) {
    */
   async function upsertStatus({ wamid, status, errorCode = null, errorTitle = null, recipientHash = null, occurredAt = null }) {
     if (!wamid || !KNOWN_STATUSES.has(status)) return false;
-    await d.sequelize.query(
+    const [rows] = await d.sequelize.query(
       `INSERT INTO wa_message_statuses
          (wamid, status, "errorCode", "errorTitle", "recipientHash", "occurredAt", "createdAt", "updatedAt")
        VALUES (:wamid, :status, :errorCode, :errorTitle, :recipientHash, :occurredAt, NOW(), NOW())
@@ -106,7 +106,8 @@ export function makeWaWebhookService(overrides = {}) {
          "occurredAt" = COALESCE(EXCLUDED."occurredAt", wa_message_statuses."occurredAt"),
          "updatedAt" = NOW()
        WHERE ${STATUS_RANK_SQL.replace('%s', 'EXCLUDED.status')}
-           > ${STATUS_RANK_SQL.replace('%s', 'wa_message_statuses.status')}`,
+           > ${STATUS_RANK_SQL.replace('%s', 'wa_message_statuses.status')}
+       RETURNING wamid`,
       {
         replacements: {
           wamid: String(wamid).slice(0, 128),
@@ -118,7 +119,11 @@ export function makeWaWebhookService(overrides = {}) {
         },
       }
     );
-    return true;
+    // Did the row ACTUALLY advance? The rank guard makes a redelivery a no-op,
+    // and returning true regardless meant every one of Meta's retries counted
+    // as new: counts.statuses over-counted and — worse — each redelivered
+    // 'read' re-dirtied the lead and fired another rescore (P2-4).
+    return Array.isArray(rows) && rows.length > 0;
   }
 
   /** The STOP text of an inbound message, or null. Quick-reply buttons carry

--- a/backend/test/unit/waWebhook.test.js
+++ b/backend/test/unit/waWebhook.test.js
@@ -44,8 +44,16 @@ function statusPayload(overrides = {}) {
   };
 }
 
+/**
+ * The upsert is rank-guarded and now RETURNING wamid, so its result MEANS
+ * something (P2-4): a row back = the status actually advanced; no row = a Meta
+ * redelivery the guard turned into a no-op. The default fake advances.
+ */
+const advanced = (wamid = 'wamid.TEST1') => [[{ wamid }], {}];
+const noOp = () => [[], {}];
+
 function makeSvc(overrides = {}) {
-  const query = jest.fn(async () => [[], {}]);
+  const query = jest.fn(async () => advanced());
   const svc = makeWaWebhookService({
     sequelize: { query },
     Consumer: { findOne: jest.fn(async () => null) },
@@ -55,6 +63,7 @@ function makeSvc(overrides = {}) {
   });
   return { svc, query };
 }
+
 
 const ENV_KEYS = ['WHATSAPP_WABA_ID', 'WHATSAPP_PHONE_NUMBER_ID', 'WHATSAPP_APP_SECRET', 'WHATSAPP_WEBHOOK_VERIFY_TOKEN', 'NODE_ENV'];
 let savedEnv;
@@ -221,5 +230,81 @@ describe('POST /api/whatsapp/webhook route posture', () => {
       .set('x-hub-signature-256', 'sha256=deadbeef')
       .send(statusPayload());
     expect(res.status).toBe(401);
+  });
+});
+
+/**
+ * P2-4 — Meta redelivers. The rank-guarded upsert makes a repeat a no-op in
+ * SQL, but upsertStatus used to return `true` unconditionally, so every retry
+ * still counted as new: counts.statuses over-counted, and each redelivered
+ * 'read' re-dirtied the lead and fired ANOTHER rescore. Under Meta's retry
+ * schedule that is a rescore storm driven by an external party.
+ */
+describe('processPayload — redelivery idempotency (P2-4)', () => {
+  const readPayload = () => statusPayload({
+    value: {
+      statuses: [{ id: 'wamid.READ1', status: 'read', timestamp: '1785006378', recipient_id: '6580129432' }],
+    },
+  });
+
+  it('counts a read once and rescores once when the row advances', async () => {
+    const onMessageRead = jest.fn(async () => 1);
+    const { svc } = makeSvc({ onMessageRead });
+
+    const counts = await svc.processPayload(readPayload());
+
+    expect(counts.statuses).toBe(1);
+    expect(counts.leadsDirtied).toBe(1);
+    expect(onMessageRead).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT rescore or count when the guard made it a no-op', async () => {
+    const onMessageRead = jest.fn(async () => 1);
+    const { svc } = makeSvc({ sequelize: { query: jest.fn(async () => noOp()) }, onMessageRead });
+
+    const counts = await svc.processPayload(readPayload());
+
+    expect(counts.statuses).toBe(0);
+    expect(counts.leadsDirtied).toBe(0);
+    expect(onMessageRead).not.toHaveBeenCalled();
+  });
+
+  it('rescores once across a first delivery and four redeliveries', async () => {
+    const onMessageRead = jest.fn(async () => 1);
+    // Meta's retry schedule: the same 'read' arrives five times; only the
+    // first advances the row.
+    const query = jest.fn()
+      .mockResolvedValueOnce(advanced('wamid.READ1'))
+      .mockResolvedValue(noOp());
+    const { svc } = makeSvc({ sequelize: { query }, onMessageRead });
+
+    let statuses = 0;
+    let dirtied = 0;
+    for (let i = 0; i < 5; i += 1) {
+      const counts = await svc.processPayload(readPayload());
+      statuses += counts.statuses;
+      dirtied += counts.leadsDirtied;
+    }
+
+    expect(query).toHaveBeenCalledTimes(5); // the upsert still runs every time
+    expect(statuses).toBe(1);
+    expect(dirtied).toBe(1);
+    expect(onMessageRead).toHaveBeenCalledTimes(1);
+  });
+
+  it('still persists — and still reports — a genuine status ADVANCE', async () => {
+    // sent → delivered → read: three real transitions, three counted.
+    const query = jest.fn(async () => advanced('wamid.SEQ1'));
+    const { svc } = makeSvc({ sequelize: { query } });
+
+    let statuses = 0;
+    for (const status of ['sent', 'delivered', 'read']) {
+      const counts = await svc.processPayload(statusPayload({
+        value: { statuses: [{ id: 'wamid.SEQ1', status, timestamp: '1785006378', recipient_id: '6580129432' }] },
+      }));
+      statuses += counts.statuses;
+    }
+
+    expect(statuses).toBe(3);
   });
 });


### PR DESCRIPTION
**Task P2-4** (medium) · review round-2 queue

## Defect
`upsertStatus` runs a rank-guarded upsert — `WHERE rank(EXCLUDED.status) > rank(existing.status)` — so a Meta **redelivery is already a no-op at the row level**. But the function returned `true` *unconditionally*: no `RETURNING`, no rowcount check.

Callers therefore treated every retry as new. `counts.statuses` over-counted, and — the real damage — each redelivered `'read'` re-dirtied the owning lead and fired another `rescoreLeadSoon`. Meta's retry schedule turned one read receipt into a rescore storm, driven by an external party we don't control.

## Fix
The statement now ends `RETURNING wamid`, and `upsertStatus` reports whether the row **actually advanced**. `onMessageRead` and the counters run only on a genuine transition. The upsert itself still runs on every delivery — the SQL guard, not the caller, decides what's new, so out-of-order and concurrent callbacks keep behaving exactly as before.

## Test proof
Added to `backend/test/unit/waWebhook.test.js` (+4 cases). The suite's DI fake returned an empty result because nothing read it; it now models both outcomes (`advanced()` / `noOp()`), which is what makes the redelivery case expressible at all.

**Pre-fix: `2 failed, 15 passed`**
- a guard no-op still counted and rescored: **expected 0, received 1**
- one delivery + four redeliveries: **expected 1 rescore, received 5** — the storm, measured

**Post-fix: `17 passed`** — one read counts once and rescores once; five redeliveries still issue five upserts but yield exactly one rescore; a genuine `sent → delivered → read` progression still counts all three.

Local: full unit tier **2186 passed / 127 suites**; `waMessageSends`, `redeemOpsFulfilmentDelivery` → **33 passed**. `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)