### PR TITLE
fix(scoring): stop the uninsured-buyer Buy=0 inversion (P2-5)

### DIFF
--- a/backend/src/utils/consumerScoring.js
+++ b/backend/src/utils/consumerScoring.js
@@ -197,7 +197,7 @@ function blend(parts) {
 }
 
 const unknown = (note) => ({ state: 'unknown', fraction: null, basis: [], note });
-const assessed = (fraction, basis, note) => ({ state: 'assessed', fraction, basis, note });
+const assessed = (fraction, basis, note, extras) => ({ state: 'assessed', fraction, basis, note, ...extras });
 
 /**
  * A fact counts only if it clears the confidence floor (§7.1). LLM-extracted
@@ -472,7 +472,18 @@ function scoreCoverageHeadroom(facts, cfg) {
 
   const held = new Set(cov.value.v);
   if (held.has('none') || cov.value.v.length === 0) {
-    return assessed(0, (cov.basis || [cov.observationId]).filter(Boolean), 'no existing coverage — full headroom');
+    // Assessed — we genuinely know the answer, and the breakdown should say
+    // so. But a zero PENALTY is the absence of a disqualifier, not evidence of
+    // capacity to buy, so it cannot be the sole thing that unlocks a Buy score
+    // (P2-5). Without this flag, a person whose only fact is "I'm uninsured" —
+    // the largest protection gap, i.e. the BEST buyer — scored Buy = 0/70 = 0,
+    // identical to a maxed-out non-buyer and worse than an honest "—".
+    return assessed(
+      0,
+      (cov.basis || [cov.observationId]).filter(Boolean),
+      'no existing coverage — full headroom',
+      { capacityEvidence: false }
+    );
   }
   const coreHeld = CORE_COVERAGE.filter((c) => held.has(c)).length;
   // Positive fraction: 1 = all three core lines held. The minus lives in
@@ -673,6 +684,9 @@ function computeScore({ cfg, facts, telemetry, now, algorithmVersion }) {
       maxPoints,
       basisObservationIds: res.basis || [],
       note: res.note,
+      // Assessed, but carrying no evidence of capacity to buy (P2-5) — only
+      // set when a rule says so, so every other component keeps its shape.
+      ...(res.capacityEvidence === false ? { capacityEvidence: false } : {}),
     };
   }
 
@@ -694,11 +708,16 @@ function computeScore({ cfg, facts, telemetry, now, algorithmVersion }) {
     ? Math.round(clamp(sumGroup(meetNames) / meetRawMax, 0, 1) * 100)
     : null;
 
-  // BUY: needs ≥1 assessed FACT component — unknown capacity must not fake a
-  // number (§7.1b). The headroom penalty alone counts as evidence: knowing
-  // someone is already fully covered is a real, scoreable finding.
+  // BUY: needs ≥1 assessed FACT component that actually carries evidence —
+  // unknown capacity must not fake a number (§7.1b). A headroom PENALTY still
+  // counts on its own: knowing someone is already fully covered is a real,
+  // scoreable finding. A headroom of ZERO does not (P2-5) — "they have no
+  // coverage" says nothing about their capacity to buy, and letting it stand
+  // alone scored the best protection-gap buyer at the bottom.
   const buyFactAssessed = buyNames.some(
-    (n) => FACT_COMPONENTS.has(n) && components[n]?.state === 'assessed'
+    (n) => FACT_COMPONENTS.has(n)
+      && components[n]?.state === 'assessed'
+      && components[n]?.capacityEvidence !== false
   );
   const buyRawMax = rawMaxOf(buyNames);
   const buyScore = buyFactAssessed && buyRawMax > 0

--- a/backend/test/unit/consumerScoring.test.js
+++ b/backend/test/unit/consumerScoring.test.js
@@ -189,13 +189,54 @@ describe('coverage headroom is a penalty, and only a COMPLETE list may penalize'
     expect(r.breakdown.components.coverage_headroom.state).toBe('unknown')
   })
 
-  test('explicitly no coverage takes no penalty and still counts as evidence', () => {
+  test('explicitly no coverage takes no penalty and is still ASSESSED', () => {
     const r = score({ 'finance.existing_coverage': fact({ v: [], complete: true }) })
     const ch = r.breakdown.components.coverage_headroom
     expect(ch.state).toBe('assessed')
     expect(ch.points).toBe(0)
-    // Knowing someone carries nothing is a real finding — it unlocks Buy.
+  })
+
+  /**
+   * P2-5. This block previously asserted that a zero-penalty headroom "unlocks
+   * Buy". It does not, and letting it inverted the score: a person whose ONLY
+   * fact is "I am uninsured" — the largest protection gap, i.e. the BEST buyer
+   * — computed Buy = (0 + unknowns)/70 = 0, identical to a maxed-out non-buyer
+   * and worse than an honest "—". A zero PENALTY is the absence of a
+   * disqualifier, not evidence of capacity to buy.
+   */
+  test('uninsured ALONE does not fabricate a Buy score — it reads unknown, not zero', () => {
+    const r = score({ 'finance.existing_coverage': fact({ v: ['none'], complete: true }) })
+    expect(r.breakdown.components.coverage_headroom.state).toBe('assessed')
+    expect(r.buyScore).toBeNull()
+    expect(r.buyScore).not.toBe(0)
+  })
+
+  test('an empty complete list reads the same as an explicit "none"', () => {
+    const r = score({ 'finance.existing_coverage': fact({ v: [], complete: true }) })
+    expect(r.buyScore).toBeNull()
+  })
+
+  test('a real capacity fact alongside uninsured DOES score — and scores well', () => {
+    const r = score({
+      'finance.existing_coverage': fact({ v: ['none'], complete: true }),
+      'finance.annual_income_band': fact({ v: '120-200k' }),
+    })
     expect(r.buyScore).not.toBeNull()
+    // No headroom penalty + real capacity: the protection-gap buyer must not
+    // land at the bottom, which is the inversion this task exists for.
+    expect(r.buyScore).toBeGreaterThan(0)
+  })
+
+  test('the uninsured buyer now outranks the fully-covered one on Buy', () => {
+    const uninsured = score({
+      'finance.existing_coverage': fact({ v: ['none'], complete: true }),
+      'finance.annual_income_band': fact({ v: '120-200k' }),
+    })
+    const covered = score({
+      'finance.existing_coverage': fact({ v: ['life', 'health', 'ci'], complete: true }),
+      'finance.annual_income_band': fact({ v: '120-200k' }),
+    })
+    expect(uninsured.buyScore).toBeGreaterThan(covered.buyScore)
   })
 
   test('full core coverage applies the full negative', () => {
@@ -203,7 +244,9 @@ describe('coverage headroom is a penalty, and only a COMPLETE list may penalize'
     expect(r.breakdown.components.coverage_headroom.points).toBeCloseTo(-10, 5)
   })
 
-  test('the penalty cannot drive a sub-score below zero', () => {
+  test('the penalty cannot drive a sub-score below zero — and still unlocks Buy alone', () => {
+    // Unchanged by P2-5: a headroom that actually BITES is a real finding
+    // about this person, so it remains sufficient evidence on its own.
     const r = score({ 'finance.existing_coverage': fact({ v: ['life', 'health', 'ci'], complete: true }) })
     expect(r.buyScore).toBe(0)
     expect(r.consumerScore).toBeGreaterThanOrEqual(0)


### PR DESCRIPTION
**Task P2-5** (medium — business-logic correctness) · review round-2 queue

*Confirmed `backend/src/utils/consumerScoring.js` is backend-only — no frontend twin.*

## Defect
`scoreCoverageHeadroom` returns `assessed(0, …)` for a complete `'none'` coverage list, and that alone flipped `buyFactAssessed` to true. So a person whose **only** fact is "I am uninsured" — the largest protection gap, i.e. the *best* buyer — computed:

```
buyScore = round(clamp((0 + unknowns) / 70)) = 0
```

Identical to a fully-covered no-capacity person, and **worse than an honest `null`**. That inverts the component and breaks the file's own unknown-vs-zero contract (§7.1b: *"Unknown capacity must not read as 'low capacity'; '—' is the honest answer"*).

## The choice, stated
**Uninsured-alone now yields `null`, not a high score.** A zero *penalty* is the absence of a disqualifier, not evidence of capacity to buy — we still know nothing about whether this person can afford anything, which is exactly what §7.1b says we owe a "—" for.

The alternative — making headroom a positive buy signal — was rejected: the component is documented as a penalty (−10..0), and the file header explicitly warns that signing its fraction "would multiply two negatives into a bonus for already-insured people — precisely inverting the component". Turning it positive means re-weighting the whole buy group, which is a product decision rather than a bug fix.

## Fix
The component stays **assessed** — we genuinely know the answer and the breakdown should say so — but carries `capacityEvidence: false`, which the Buy gate honours. The flag is attached only when a rule sets it, so every other component's breakdown shape is untouched.

A headroom that actually **bites** still unlocks Buy on its own: knowing someone is already fully covered is a real, scoreable finding. That behaviour is unchanged and pinned by a test.

## Test proof
`backend/test/unit/consumerScoring.test.js` (+4 cases).

**Pre-fix: `2 failed, 51 passed`** — uninsured-alone returned **`0`** where `null` is now required (both the explicit `['none']` and the empty-complete-list forms).

**Post-fix: `53 passed`**, including two that state the business outcome directly: uninsured + a real income fact scores **> 0**, and the uninsured buyer now **outranks** the fully-covered one on Buy.

One existing assertion encoded the inversion — *"Knowing someone carries nothing is a real finding — it unlocks Buy"* — and was rewritten with the reasoning in place.

Local: full unit tier **2186 passed / 127 suites**; `leadScoring`, `scoringIsolation`, `consumerEnrichment`, `scoringConfigResolution`, `scoringVocabParity` → **60 passed**. `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)