### PR TITLE
fix(enrichment): reap expired map-job leases (P2-6)

### DIFF
--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -273,6 +273,16 @@ export async function bootstrapDatabase() {
     if (String(process.env.ENRICHMENT_SCORING_ENABLED || 'false').toLowerCase() === 'true') {
       const runEnrichmentSweep = async () => {
         try {
+          // Reclaim orphaned map-job leases first (P2-6). drainMapJobs reaps on
+          // its own path, but that path only runs when a capture happens — a
+          // quiet period would leave a job stranded by a dead worker sitting
+          // 'leased' forever, and its person scored on incomplete evidence.
+          const { reapExpiredLeases } = await import('../services/factMapperService.js');
+          await reapExpiredLeases();
+        } catch (err) {
+          logger.warn('[EnrichmentScoring] lease reap failed (non-fatal)', { error: err?.message });
+        }
+        try {
           const { runNightlySweep } = await import('../services/enrichmentSweepService.js');
           await runNightlySweep();
         } catch (err) {

--- a/backend/src/services/factMapperService.js
+++ b/backend/src/services/factMapperService.js
@@ -380,7 +380,38 @@ async function processMapJob(job) {
  * lease). Returns per-outcome counts plus the claimed job ids so callers
  * (the remap script) can do cohort-scoped accounting.
  */
-export async function drainMapJobs({ limit = 20 } = {}) {
+/**
+ * Return expired leases to the queue (P2-6).
+ *
+ * drainMapJobs claims with a 5-minute internal lease but only ever selects
+ * status='pending', and nothing ever reset an expired 'leased' row. A worker
+ * that died between the claim and finish() therefore stranded its job
+ * PERMANENTLY: that person's facts never activate, and their score is computed
+ * forever on incomplete evidence — silently, because a stuck row looks
+ * identical to one in flight. The partial index idx_ejobs_lease_expiry
+ * (WHERE status='leased') was built for this sweep and had no caller.
+ *
+ * Bounded by the same lease the claim writes, so a job in flight is untouched.
+ * Returns the number of jobs reclaimed.
+ */
+export async function reapExpiredLeases() {
+  const [rows] = await sequelize.query(
+    `UPDATE enrichment_jobs
+        SET status = 'pending', "leaseToken" = NULL, "leaseExpiresAt" = NULL,
+            "workerId" = NULL, "updatedAt" = now()
+      WHERE status = 'leased' AND "leaseExpiresAt" < now()
+      RETURNING id`
+  );
+  if (rows.length) {
+    logger.warn('[FactMapper] reclaimed expired map-job leases', { count: rows.length });
+  }
+  return rows.length;
+}
+
+export async function drainMapJobs({ limit = 20, reap = true } = {}) {
+  // Reclaim first: an orphaned lease is invisible to the claim below, so
+  // without this the queue drains around it forever.
+  if (reap) await reapExpiredLeases();
   const leaseToken = randomUUID();
   const [claimed] = await sequelize.query(
     `WITH picked AS (

--- a/backend/test/enrichmentLeaseReaper.test.js
+++ b/backend/test/enrichmentLeaseReaper.test.js
@@ -1,0 +1,105 @@
+/**
+ * P2-6 regression: an expired map-job lease returns to the queue.
+ *
+ * drainMapJobs claims with a 5-minute internal lease but only ever selects
+ * status='pending', and nothing reset an expired 'leased' row. A worker that
+ * died between the claim and finish() stranded its job PERMANENTLY — that
+ * person's facts never activate and their score is computed forever on
+ * incomplete evidence, silently, because a stuck row is indistinguishable from
+ * one in flight. The partial index idx_ejobs_lease_expiry (WHERE
+ * status='leased') was built for a reaper that was never written.
+ */
+import { randomUUID } from 'crypto'
+import { EnrichmentJob, sequelize } from '../src/models/index.js'
+import { reapExpiredLeases, drainMapJobs } from '../src/services/factMapperService.js'
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect } from './helpers.js'
+
+let campaign, prospect
+const made = []
+
+/** A map job parked in 'leased' with a lease that expired `agoMs` ago. */
+async function leasedJob({ expiresInMs }) {
+  const job = await EnrichmentJob.create({
+    kind: 'map',
+    status: 'leased',
+    subjectProspectId: prospect.id,
+    pipelineVersion: 'test-reaper-v1',
+    leaseToken: randomUUID(), // the dead worker's token
+    leaseExpiresAt: new Date(Date.now() + expiresInMs),
+    workerId: 'in-process',
+  })
+  made.push(job.id)
+  return job
+}
+
+const statusOf = async (id) => (await EnrichmentJob.findByPk(id))?.status
+
+beforeAll(async () => {
+  await getApp()
+  const admin = await createTestUser({ role: 'admin' })
+  campaign = await createTestCampaign(admin.user.id, { name: 'Lease Reaper Campaign' })
+  prospect = await createTestProspect(campaign.id, {})
+})
+
+afterAll(async () => {
+  if (made.length) await EnrichmentJob.destroy({ where: { id: made } })
+  await closeDb()
+})
+
+describe('reapExpiredLeases', () => {
+  it('returns a job whose lease expired to pending', async () => {
+    const job = await leasedJob({ expiresInMs: -60_000 }) // expired a minute ago
+
+    const reaped = await reapExpiredLeases()
+
+    expect(reaped).toBeGreaterThanOrEqual(1)
+    expect(await statusOf(job.id)).toBe('pending')
+  })
+
+  it('clears the dead worker’s lease fields so the next claim owns it cleanly', async () => {
+    const job = await leasedJob({ expiresInMs: -60_000 })
+
+    await reapExpiredLeases()
+
+    const row = await EnrichmentJob.findByPk(job.id)
+    expect(row.leaseToken).toBeNull()
+    expect(row.leaseExpiresAt).toBeNull()
+    expect(row.workerId).toBeNull()
+  })
+
+  it('leaves a LIVE lease alone — a job in flight is not stolen', async () => {
+    const job = await leasedJob({ expiresInMs: 5 * 60_000 })
+
+    await reapExpiredLeases()
+
+    expect(await statusOf(job.id)).toBe('leased')
+  })
+
+  it('is a no-op when nothing has expired', async () => {
+    await sequelize.query(
+      `UPDATE enrichment_jobs SET "leaseExpiresAt" = now() + interval '10 minutes'
+        WHERE status = 'leased' AND "leaseExpiresAt" < now()`
+    )
+    await expect(reapExpiredLeases()).resolves.toBe(0)
+  })
+})
+
+describe('drainMapJobs reclaims before it claims', () => {
+  it('picks up a job orphaned by a dead worker instead of draining around it forever', async () => {
+    const job = await leasedJob({ expiresInMs: -60_000 })
+
+    // The drain's own claim only ever sees status='pending', so without the
+    // reap this orphan is invisible to it — permanently.
+    await drainMapJobs({ limit: 20 })
+
+    expect(await statusOf(job.id)).not.toBe('leased')
+  })
+
+  it('can be told not to reap, leaving the orphan untouched', async () => {
+    const job = await leasedJob({ expiresInMs: -60_000 })
+
+    await drainMapJobs({ limit: 20, reap: false })
+
+    expect(await statusOf(job.id)).toBe('leased')
+  })
+})


### PR DESCRIPTION
**Task P2-6** (medium) · review round-2 queue

## Defect
`drainMapJobs` claims jobs with a 5-minute internal lease (`status='leased'`, `leaseExpiresAt = now() + 5 min`) but its claim only ever selects `status = 'pending'` — and **nothing ever reset an expired `leased` row**.

A worker that died between the claim and `finish()` stranded its job **permanently**: the drain sees only pending rows, so it drained around the orphan forever. That person's facts never activate and their score is computed on incomplete evidence — silently, because a stuck row is indistinguishable from one in flight. The partial index `idx_ejobs_lease_expiry (WHERE status='leased')` was clearly built for this sweep and had no caller.

## Fix
`reapExpiredLeases()` returns expired rows to `'pending'` and clears the dead worker's `leaseToken` / `leaseExpiresAt` / `workerId` so the next claim owns them cleanly. It is bounded by the same lease the claim writes (`leaseExpiresAt < now()`), so a job genuinely in flight is never stolen.

Wired in **two** places on purpose:
- `drainMapJobs` reaps before it claims — the drain runs post-capture, so it's the frequent path.
- The hourly enrichment sweep reaps too — a quiet period with no captures would otherwise leave an orphan sitting until the next lead happened to arrive, which is exactly the "silent" part of the defect.

`drainMapJobs({ reap: false })` keeps the claim-only behaviour available.

## Test proof
`backend/test/enrichmentLeaseReaper.test.js` (new, 6 cases) against real Postgres.

The discriminating case is behavioural, not just a missing export: with `reapExpiredLeases` present but **not called from the drain**, `picks up a job orphaned by a dead worker` fails — `Expected: not "leased"` — because the claim genuinely cannot see the row. **Pre-fix: `1 failed, 5 passed`. Post-fix: `6 passed`.**

Also pinned: the reaper clears all three lease fields, a **live** lease is left alone, an empty sweep returns 0, and `reap: false` leaves the orphan untouched.

Local: `enrichmentLeaseReaper`, `consumerEnrichment`, `leadScoring` → **37 passed**; full unit tier **2182 passed / 127 suites**. `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)