### PR TITLE
test(suppression): settle the app's own post-commit reconcile before asserting

### DIFF
--- a/backend/test/integration/suppressionPropagation.test.js
+++ b/backend/test/integration/suppressionPropagation.test.js
@@ -85,6 +85,33 @@ const pairsOf = (subscriberId) => SuppressionPropagation.findAll({
   where: { subscriberId }, order: [['createdAt', 'ASC']],
 });
 
+/**
+ * Wait for the app's OWN post-commit reconcile to land.
+ *
+ * captureAgreeAll posts a REAL lead capture, and consentService fires
+ * reconcileSuppressionPropagation post-commit, fire-and-forget (consentService
+ * ~:196). That pass is NOT the spy'd service these tests drive: it creates its
+ * own delivery and REPOINTS pair.deliveryId. A test that snapshots the pair
+ * before it lands then forces the WRONG delivery to 'failed', and the pass
+ * under test correctly declines to requeue — which is exactly how this suite
+ * failed in CI (requeued 0) while passing on a faster local machine.
+ *
+ * So wait for the lift to be projected, then for the pointer to hold still.
+ */
+async function settleLifted(subscriberId, { quietMs = 60, timeoutMs = 8000 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let last = null;
+  for (;;) {
+    const [pair] = await pairsOf(subscriberId);
+    const key = pair ? `${pair.deliveryId}:${pair.deliveredState}` : null;
+    if (pair?.deliveredState === 'lifted' && key === last) return pair;
+    last = key;
+    if (Date.now() > deadline) return pair; // best effort — the assertions still speak
+    await new Promise((r) => setTimeout(r, quietMs));
+  }
+}
+
+
 beforeAll(async () => {
   app = await getApp();
   admin = await createTestUser({ role: 'admin' });
@@ -859,7 +886,9 @@ describe('resubscribe lift (plan v3)', () => {
     await svc.reconcileSuppressionPropagation({ consumerId: consumer.id });
     await captureAgreeAll(phone, campaign2);
     await svc.reconcileSuppressionPropagation({ consumerId: consumer.id });
-    const pair = (await pairsOf(s1.id))[0];
+    // The app's own post-commit pass may still be in flight and would repoint
+    // pair.deliveryId under us — settle before snapshotting it.
+    const pair = await settleLifted(s1.id);
     expect(pair.deliveredState).toBe('lifted');
 
     await WebhookDelivery.update({ status: 'failed' }, { where: { deliveryId: pair.deliveryId } });


### PR DESCRIPTION
**Unblocks the review-round-2 queue** — not one of the 32 tasks, but this flake failed `main` at `06bad9a` and both PR #376 and PR #377, so every subsequent PR inherits it.

## The flake
`resubscribe lift (plan v3) › a failed lead.unsuppressed delivery re-queues` fails intermittently in CI — `Expected: 1, Received: 0` — while passing **every** local run, including the full 141-suite integration tier.

## Cause
`captureAgreeAll` posts a **real** lead capture, and `consentService` (~:196) fires `reconcileSuppressionPropagation({ consumerId })` **post-commit, fire-and-forget**. That pass is *not* the spy'd service the test drives — it creates its own delivery and **repoints `pair.deliveryId`**.

The test snapshotted the pair immediately, then forced the (now stale) delivery to `'failed'`. The pass under test looked at the pair's *current* delivery, found it still `pending`, and **correctly declined to requeue**. So the assertion failed on a test-harness race, not on a product defect. A slower, contended runner loses that race far more often than a local machine — which is exactly the observed pattern.

This is pre-existing; P2-2's claim shifted timings slightly and made it surface, but the hazard predates it.

## Fix
The test now waits for the lift to be projected **and** for `pair.deliveryId` to hold still across two reads before snapshotting it.

Best-effort with an 8s budget: on timeout it returns whatever it has, so a genuine regression still fails the assertion rather than hanging the suite.

## Verification
The suite run **4× consecutively: `30 passed` each time**. Local runs passed before too, so CI is the real judge here — the change is aimed squarely at the mechanism above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)