### PR TITLE
fix(redeem-ops): explicit verification override on manual issue (P2-7)

### DIFF
--- a/backend/src/controllers/redeemOps/fulfilmentController.js
+++ b/backend/src/controllers/redeemOps/fulfilmentController.js
@@ -122,6 +122,14 @@ export const issueManual = asyncHandler(async (req, res) => {
     Joi.object({
       activationId: Joi.string().uuid().required(),
       prospectId: Joi.string().uuid().required(),
+      // Issuing to an UNVERIFIED phone is a deliberate act, not a side effect
+      // (P2-7): it must be asked for, and it must carry a reason for the audit.
+      overrideVerification: Joi.boolean().default(false),
+      overrideReason: Joi.when('overrideVerification', {
+        is: true,
+        then: Joi.string().trim().min(3).max(255).required(),
+        otherwise: Joi.string().allow('', null).optional(),
+      }),
     }),
     req.body
   );

--- a/backend/src/services/redeemOps/entitlementService.js
+++ b/backend/src/services/redeemOps/entitlementService.js
@@ -273,7 +273,7 @@ export function makeEntitlementService(overrides = {}) {
    * without it, issueManual could issue/email a different activation than the
    * audit row claims (Codex blocker, 2026-07-16).
    */
-  async function issueForProspect(prospect, { via = 'hook', activationId = null } = {}) {
+  async function issueForProspect(prospect, { via = 'hook', activationId = null, overrideVerification = false } = {}) {
     // Function-scoped so the unique-constraint catch can attribute skips.
     let resolvedActivation = null;
     // Skip recording (migration 076): every funnel-relevant refusal writes one
@@ -290,7 +290,10 @@ export function makeEntitlementService(overrides = {}) {
       // earned by verified signup; the AI gate withholds AGENT delivery only.
       // Quota / DNC / external holds stay excluded.
       if (prospect?.quarantinedAt && !SCREENING_REASONS.includes(prospect.quarantineReason)) return fail('quarantined');
-      if (!verificationStampOf(prospect)) return fail('phone_not_verified');
+      // The stamp is server-written and is the anti-farming gate. The ONLY way
+      // past it is an authorized, reasoned override from issueManual (P2-7) —
+      // never a fabricated stamp on the prospect JSON.
+      if (!verificationStampOf(prospect) && !overrideVerification) return fail('phone_not_verified');
 
       let activation;
       if (activationId) {
@@ -787,8 +790,21 @@ export function makeEntitlementService(overrides = {}) {
     return { entitlement, supersededEventId: lastUnlock?.id || null };
   }
 
-  /** Manual issue by redemption_ops (requires an existing lead). */
-  async function issueManual({ activationId, prospectId }, user, requestId = null) {
+  /**
+   * Manual issue by redemption_ops (requires an existing lead).
+   *
+   * The phone-verification stamp is the core anti-farming gate, and it is
+   * SERVER-stamped for exactly that reason. This path used to synthesize
+   * `phoneVerifiedAt: … || new Date()` onto the prospect JSON before issuing,
+   * which defeated the gate SILENTLY: capability-gated and audited, yes, but
+   * nothing in the request said "issue to an unverified phone" and nothing in
+   * the audit trail recorded that it had happened (P2-7).
+   *
+   * Now the bypass is a deliberate, reasoned act — `overrideVerification: true`
+   * plus a reason — and it lands in the audit `after`. Without it the real
+   * stamp decides, so an unverified phone is refused like any other.
+   */
+  async function issueManual({ activationId, prospectId, overrideVerification = false, overrideReason = null }, user, requestId = null) {
     const activation = await d.Activation.findByPk(activationId, {
       include: [{ model: d.RewardOffer, as: 'rewardOffer' }],
     });
@@ -799,9 +815,23 @@ export function makeEntitlementService(overrides = {}) {
     // activationId is threaded through so the SELECTED activation is the one
     // issued + emailed + audited (issueForProspect would otherwise re-resolve
     // by the prospect's campaign and could pick a different activation).
+    const reason = String(overrideReason || '').trim();
+    if (overrideVerification && !reason) {
+      throw new AppError('A reason is required to override phone verification', 400);
+    }
+    const alreadyVerified = Boolean(verificationStampOf(prospect));
+    if (overrideVerification && !alreadyVerified) {
+      d.logger?.warn?.('[RedeemOps] manual issue overriding phone verification', {
+        prospectId, activationId, actorUserId: user?.id, reason,
+      });
+    }
+
+    // The prospect is passed THROUGH — never with a fabricated stamp. The
+    // override is carried as an explicit flag so issueForProspect's gate can
+    // see an authorized decision rather than a forged fact.
     const result = await issueForProspect(
-      { ...prospect.toJSON(), sourceMetadata: { ...(prospect.sourceMetadata || {}), phoneVerifiedAt: prospect.sourceMetadata?.phoneVerifiedAt || new Date().toISOString() } },
-      { via: 'manual', activationId }
+      prospect.toJSON(),
+      { via: 'manual', activationId, overrideVerification: overrideVerification === true }
     );
     if (!result.entitlement) throw new AppError(`Cannot issue: ${result.reason}`, 409);
     if (result.reason === 'duplicate_phone') {
@@ -811,7 +841,16 @@ export function makeEntitlementService(overrides = {}) {
     }
     await d.audit.recordAuditEvent({
       actorUser: user, action: 'entitlement.issued_manual', entityType: 'reward_entitlement',
-      entityId: result.entitlement.id, after: { activationId, prospectId }, requestId,
+      entityId: result.entitlement.id,
+      after: {
+        activationId, prospectId,
+        // Record the bypass, not just the issue: "who minted a reward for an
+        // unverified phone, and why" must be answerable from the audit alone.
+        overrideVerification: overrideVerification === true,
+        ...(overrideVerification === true ? { overrideReason: reason, phoneWasVerified: alreadyVerified } : {}),
+      },
+      ...(overrideVerification === true ? { reason } : {}),
+      requestId,
     });
     return result;
   }

--- a/backend/test/redeemOpsManualIssueOverride.test.js
+++ b/backend/test/redeemOpsManualIssueOverride.test.js
@@ -1,0 +1,138 @@
+/**
+ * P2-7 regression: manual issue may not forge the phone-verification stamp.
+ *
+ * The stamp is SERVER-written and is the core anti-farming gate — one live
+ * reward per verified phone. issueManual used to set
+ * `phoneVerifiedAt: … || new Date()` onto the prospect JSON before issuing,
+ * so a redemption_ops user minted live rewards for unverified phones as a side
+ * effect of the ordinary call. Capability-gated and audited, yes — but nothing
+ * in the request said "bypass verification" and nothing in the audit trail
+ * recorded that it had happened. A silent bypass is not an authorized one.
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+process.env.REDEEM_OPS_ENTITLEMENTS_ENABLED = 'true';
+
+import { getApp, closeDb, createTestUser, createTestCampaign } from './helpers.js';
+import {
+  Prospect, RewardOffer, Activation, PartnerOrganisation, RedeemOpsAuditEvent,
+} from '../src/models/index.js';
+import { makeEntitlementService } from '../src/services/redeemOps/entitlementService.js';
+
+const svc = makeEntitlementService();
+
+let admin, agent, partner, campaign, activation;
+let phoneSeq = 88000000;
+const freshPhone = () => `+65${phoneSeq++}`;
+
+/** `verified: false` = no server stamp — the state the gate exists to refuse. */
+async function makeProspect({ verified }) {
+  return Prospect.create({
+    firstName: 'Manual', lastName: 'Issue', phone: freshPhone(),
+    email: `manual-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@test.com`,
+    leadSource: 'website', campaignId: campaign.id, assignedAgentId: agent.user.id,
+    sourceMetadata: verified ? { phoneVerifiedAt: new Date().toISOString() } : {},
+  });
+}
+
+const auditFor = async (entitlementId) => RedeemOpsAuditEvent.findOne({
+  where: { entityId: entitlementId, action: 'entitlement.issued_manual' },
+});
+
+beforeAll(async () => {
+  await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  agent = await createTestUser({ role: 'agent' });
+  partner = await PartnerOrganisation.create({
+    tradingName: 'Manual Issue Studio', normalizedName: 'manual issue studio', createdBy: admin.user.id,
+  });
+  campaign = await createTestCampaign(admin.user.id, { name: 'Manual Issue Campaign' });
+  const offer = await RewardOffer.create({
+    partnerOrganisationId: partner.id, title: 'Manual Issue Reward', status: 'active',
+    committedQuantity: 200, allocatedQuantity: 150, claimExpiryDays: 30,
+    redemptionExpiryDays: 90, createdBy: admin.user.id,
+  });
+  activation = await Activation.create({
+    partnerOrganisationId: partner.id, rewardOfferId: offer.id, campaignId: campaign.id,
+    campaignNameSnapshot: campaign.name, allocatedQuantity: 60, status: 'active',
+    unlockPolicy: 'agent_unlock', createdBy: admin.user.id,
+  });
+});
+
+afterAll(async () => { await closeDb(); });
+
+describe('manual issue respects the verification stamp by default', () => {
+  it('REFUSES an unverified phone when no override is asked for', async () => {
+    const prospect = await makeProspect({ verified: false });
+
+    await expect(
+      svc.issueManual({ activationId: activation.id, prospectId: prospect.id }, admin.user)
+    ).rejects.toMatchObject({ statusCode: 409, message: expect.stringContaining('phone_not_verified') });
+  });
+
+  it('still issues normally for a genuinely verified phone', async () => {
+    const prospect = await makeProspect({ verified: true });
+
+    const result = await svc.issueManual(
+      { activationId: activation.id, prospectId: prospect.id }, admin.user
+    );
+
+    expect(result.entitlement).toBeTruthy();
+    const audit = await auditFor(result.entitlement.id);
+    expect(audit.after.overrideVerification).toBe(false);
+  });
+
+  it('does not write a stamp onto a prospect that never had one', async () => {
+    const prospect = await makeProspect({ verified: false });
+
+    await svc.issueManual({ activationId: activation.id, prospectId: prospect.id }, admin.user)
+      .catch(() => {});
+
+    // The old code fabricated the stamp in the JSON it passed on; the row must
+    // stay untouched either way, so a later hook/sweep still sees the truth.
+    const row = await Prospect.findByPk(prospect.id);
+    expect(row.sourceMetadata?.phoneVerifiedAt).toBeUndefined();
+  });
+});
+
+describe('the override is explicit, reasoned and audited', () => {
+  it('issues to an unverified phone WITH an override and records why', async () => {
+    const prospect = await makeProspect({ verified: false });
+
+    const result = await svc.issueManual({
+      activationId: activation.id,
+      prospectId: prospect.id,
+      overrideVerification: true,
+      overrideReason: 'verified by phone at the counter — OTP SMS never arrived',
+    }, admin.user);
+
+    expect(result.entitlement).toBeTruthy();
+
+    const audit = await auditFor(result.entitlement.id);
+    expect(audit.after.overrideVerification).toBe(true);
+    expect(audit.after.overrideReason).toContain('OTP SMS never arrived');
+    expect(audit.after.phoneWasVerified).toBe(false);
+    expect(audit.reason).toContain('OTP SMS never arrived');
+  });
+
+  it('refuses an override with no reason — a bypass must be explainable', async () => {
+    const prospect = await makeProspect({ verified: false });
+
+    await expect(
+      svc.issueManual({
+        activationId: activation.id, prospectId: prospect.id, overrideVerification: true,
+      }, admin.user)
+    ).rejects.toMatchObject({ statusCode: 400, message: expect.stringMatching(/reason is required/i) });
+  });
+
+  it('marks the override false in the audit when the phone was verified anyway', async () => {
+    const prospect = await makeProspect({ verified: true });
+
+    const result = await svc.issueManual(
+      { activationId: activation.id, prospectId: prospect.id }, admin.user
+    );
+
+    const audit = await auditFor(result.entitlement.id);
+    expect(audit.after).toMatchObject({ overrideVerification: false });
+    expect(audit.after.overrideReason).toBeUndefined();
+  });
+});


### PR DESCRIPTION
**Task P2-7** (medium — authorization) · review round-2 queue

## Defect
`issueManual` set `phoneVerifiedAt: prospect.sourceMetadata?.phoneVerifiedAt || new Date().toISOString()` onto the prospect JSON before calling `issueForProspect` — fabricating the stamp whenever one was missing.

That stamp is **server-written** and is the core anti-farming gate (one live reward per *verified* phone). The path was capability-gated (`entitlements.issue_manual`) and audited, but the bypass was **silent**: nothing in the request said "issue to an unverified phone", and nothing in the audit trail recorded that it had happened. A `redemption_ops` user minted live rewards for unverified phones as an ordinary side effect of the normal call. A silent bypass is not an authorized one.

## Fix
- **The stamp is never fabricated.** The prospect is passed through as it is.
- Bypassing requires **`overrideVerification: true` AND `overrideReason`** (Joi-enforced at the controller, re-checked in the service). `issueForProspect` takes the override as an explicit argument, so its gate sees an authorized decision rather than a forged fact.
- The audit `after` records `overrideVerification` **always** (so "no override" is affirmative, not merely absent), plus `overrideReason` and `phoneWasVerified` when it fires, and the reason lands on the audit row's own `reason` column. "Who minted a reward for an unverified phone, and why" is answerable from the audit alone.
- A warn-level log line marks each real bypass.

## Test proof
`backend/test/redeemOpsManualIssueOverride.test.js` (new, 6 cases).

**Pre-fix: `5 failed, 1 passed`** — the headline being *"REFUSES an unverified phone when no override is asked for"* → **"Received promise resolved instead of rejected"**: it issued, silently. The audit assertions all returned `undefined` because the field didn't exist.

**Post-fix: `6 passed`** — unverified + no override is a typed 409 `phone_not_verified`; with override it issues and the audit carries the reason and `phoneWasVerified: false`; an override with no reason is a 400; a verified phone is unchanged; and the prospect row is never written with a stamp it didn't earn.

**Every existing manual-issue fixture passes untouched** — `redeemOpsPhoneDedupe`, `redeemOpsFulfilment`, `redeemOpsFulfilmentDelivery`, `redeemOpsEntitlementRecovery`, `entitlementUnlockVia`, `redeemOpsPermissions` → **72 passed**. That's the useful signal: the fabricated stamp was pure bypass surface, not load-bearing.

Full unit tier **2190 passed / 127 suites**. `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)