### PR TITLE
feat(draw): commit-reveal on the winner seed (P2-8)

### DIFF
--- a/backend/src/database/migrations/103-draw-seed-commitment.js
+++ b/backend/src/database/migrations/103-draw-seed-commitment.js
@@ -1,0 +1,49 @@
+/**
+ * 103 — commit-reveal on the draw seed (P2-8).
+ *
+ * `pickWinner` is a pure function of (seed, entries). The pool was already
+ * committed at seal (poolHash), but the SEED was minted at draw time and used
+ * immediately, with nothing committing it beforehand — so an operator could
+ * re-mint and re-run the pick until it landed on a chosen entry, then persist
+ * only that attempt. Nothing in the record would show the discarded rolls.
+ *
+ * The seed is now minted inside the one-way frozen→sealed transition and only
+ * its hash is published as the commitment. Because the pool is committed by the
+ * same statement, the winner is fixed at the seal instant: there is no later
+ * moment to re-roll, and any substituted seed fails verifyDraw.
+ *
+ * Both columns are NULLABLE on purpose. Draws sealed before this existed keep
+ * working — they mint at draw time as they always did, and verifyDraw reports
+ * the missing commitment rather than implying a guarantee they never had.
+ */
+
+export async function up(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.transaction(async (t) => {
+    const q = (sql) => sequelize.query(sql, { transaction: t });
+
+    await q('ALTER TABLE draws ADD COLUMN IF NOT EXISTS "seedCommitment" VARCHAR(64)');
+    await q('ALTER TABLE draws ADD COLUMN IF NOT EXISTS "sealedSeed" VARCHAR(64)');
+
+    await q(`COMMENT ON COLUMN draws."seedCommitment" IS
+      'sha256(sealedSeed) — committed at seal, before any pick is computed (P2-8)'`);
+    await q(`COMMENT ON COLUMN draws."sealedSeed" IS
+      'The seed committed at seal and revealed at draw; every attempt must hash to seedCommitment'`);
+
+    // NO BACKFILL, deliberately. Minting a seed now for an already-sealed draw
+    // would manufacture a commitment that commits to nothing — the pick it
+    // would "prove" was made under the old rules. An absent commitment is the
+    // honest record, and verifyDraw says so explicitly.
+  });
+}
+
+export async function down(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.transaction(async (t) => {
+    const q = (sql) => sequelize.query(sql, { transaction: t });
+    await q('ALTER TABLE draws DROP COLUMN IF EXISTS "sealedSeed"');
+    await q('ALTER TABLE draws DROP COLUMN IF EXISTS "seedCommitment"');
+  });
+}

--- a/backend/src/models/Draw.js
+++ b/backend/src/models/Draw.js
@@ -44,7 +44,24 @@ const Draw = sequelize.define('Draw', {
   poolHash: {
     type: DataTypes.STRING(64),
     allowNull: true,
-    comment: 'sha256 over the canonical ordered entry tuples (id|prospectId|phoneHash|chances|boostVia) — committed at seal, BEFORE any seed exists'
+    comment: 'sha256 over the canonical ordered entry tuples (id|prospectId|phoneHash|chances|boostVia) — committed at seal'
+  },
+  // Commit-reveal on the SEED (P2-8, migration 103). The pool was already
+  // committed at seal, but the seed was minted at DRAW time and used
+  // immediately — and pickWinner is a pure function of (seed, entries), so an
+  // operator could re-mint and re-run until the pick landed on a chosen entry,
+  // then persist that attempt. Committing hash(seed) in the same one-way
+  // frozen→sealed transition fixes the winner at the seal instant; any later
+  // substitution fails verifyDraw.
+  seedCommitment: {
+    type: DataTypes.STRING(64),
+    allowNull: true,
+    comment: 'sha256(sealedSeed) — committed at seal, before any pick is computed'
+  },
+  sealedSeed: {
+    type: DataTypes.STRING(64),
+    allowNull: true,
+    comment: 'The seed committed at seal and REVEALED at draw; every attempt must hash to seedCommitment'
   },
   witnessedByUserId: { type: DataTypes.UUID, allowNull: true, references: { model: 'users', key: 'id' }, onDelete: 'SET NULL' },
   notes: { type: DataTypes.TEXT, allowNull: true },

--- a/backend/src/services/luckyDrawService.js
+++ b/backend/src/services/luckyDrawService.js
@@ -527,6 +527,13 @@ export function makeLuckyDrawService(overrides = {}) {
       }
     }
     const poolHash = computePoolHash(entries);
+    // Commit-reveal (P2-8): the seed is minted HERE, inside the one-way
+    // frozen→sealed transition, and only its hash is the commitment. Because
+    // the pool is committed in the same statement, the winner is determined at
+    // the seal instant — there is no later moment at which an operator can
+    // re-roll and keep a favourable pick.
+    const sealedSeed = d.mintSeed();
+    const seedCommitment = sha256Hex(sealedSeed);
 
     await d.sequelize.transaction(async (t) => {
       for (const entry of boosted) {
@@ -535,14 +542,14 @@ export function makeLuckyDrawService(overrides = {}) {
           { where: { id: entry.id }, transaction: t }
         );
       }
-      await transition(draw.id, 'frozen', 'sealed', { poolHash }, t);
+      await transition(draw.id, 'frozen', 'sealed', { poolHash, seedCommitment, sealedSeed }, t);
     });
 
     const totalChances = entries.reduce((n, e) => n + e.chances, 0);
     d.logger.info('lucky_draw.sealed', {
-      drawId: draw.id, entries: entries.length, boosted: boosted.length, totalChances, poolHash,
+      drawId: draw.id, entries: entries.length, boosted: boosted.length, totalChances, poolHash, seedCommitment,
     });
-    return { drawId: draw.id, entries: entries.length, boosted: boosted.length, totalChances, poolHash };
+    return { drawId: draw.id, entries: entries.length, boosted: boosted.length, totalChances, poolHash, seedCommitment };
   }
 
   /**
@@ -596,7 +603,15 @@ export function makeLuckyDrawService(overrides = {}) {
 
     const totalChances = eligible.reduce((n, e) => n + e.chances, 0);
     const eligibleHash = computeEligibleHash(eligible);
-    const seed = d.mintSeed();
+    // REVEAL, don't re-mint (P2-8). A draw sealed before commit-reveal existed
+    // has no commitment; it keeps the legacy mint so historical draws stay
+    // drawable, and verifyDraw reports the gap rather than pretending.
+    const seed = draw.sealedSeed || d.mintSeed();
+    if (draw.seedCommitment && sha256Hex(seed) !== draw.seedCommitment) {
+      // Fail CLOSED: a seed that doesn't match its commitment is the exact
+      // substitution this mechanism exists to catch.
+      throw new AppError('Sealed seed does not match its commitment — refusing to draw', 409);
+    }
     const picked = pickWinner(seed, eligible);
     const drawnAt = d.now();
 
@@ -748,8 +763,30 @@ export function makeLuckyDrawService(overrides = {}) {
       if (!ok) report.ok = false;
     }
 
+    // Commit-reveal on the seed (P2-8). poolHash proves WHAT was drawn from;
+    // this proves the pick was not re-rolled until it landed somewhere chosen.
+    if (draw.seedCommitment) {
+      const recomputed = draw.sealedSeed ? sha256Hex(draw.sealedSeed) : null;
+      const ok = recomputed === draw.seedCommitment;
+      report.checks.push({ check: 'seedCommitment', ok, expected: draw.seedCommitment, recomputed });
+      if (!ok) report.ok = false;
+    } else if (attempts.length) {
+      // Sealed before commit-reveal existed: say so rather than reporting a
+      // clean bill of health the evidence does not support.
+      report.checks.push({
+        check: 'seedCommitment', ok: true, note: 'sealed before commit-reveal — seed was minted at draw time, not committed',
+      });
+    }
+
     const pickedBefore = new Set();
     for (const attempt of attempts) {
+      if (draw.seedCommitment && sha256Hex(attempt.seed) !== draw.seedCommitment) {
+        report.checks.push({
+          check: `attempt#${attempt.attemptNo}.seedRevealed`, ok: false,
+          note: 'the seed this attempt was drawn with does not hash to the sealed commitment',
+        });
+        report.ok = false;
+      }
       const eligible = orderedEntries(entries).filter(
         (e) => e.prospectId != null && !pickedBefore.has(String(e.id))
       );

--- a/backend/test/luckyDrawService.test.js
+++ b/backend/test/luckyDrawService.test.js
@@ -658,3 +658,122 @@ describe('verifyDraw', () => {
     expect(report.checks.some((c) => c.check.includes('eligibleSet') && !c.ok)).toBe(true);
   });
 });
+
+// ── P2-8: commit-reveal on the seed ────────────────────────────────────────
+
+/**
+ * pickWinner is a pure function of (seed, entries), and the seed used to be
+ * minted at DRAW time and used immediately. The pool was committed at seal, but
+ * nothing committed the seed — so an operator could re-mint and re-run the pick
+ * until it landed on a chosen entry and persist only that attempt. Nothing in
+ * the record would show the discarded rolls.
+ *
+ * The seed is now minted inside the one-way frozen→sealed transition; only its
+ * hash is published. The pool is committed by the same statement, so the winner
+ * is fixed at the seal instant.
+ */
+describe('seed commit-reveal', () => {
+  const entries = [
+    entryRow('e1', 'p1', '+6591111111', 1),
+    entryRow('e2', 'p2', '+6592222222', 10, 'agent_scan'),
+    entryRow('e3', 'p3', '+6593333333', 1),
+  ];
+
+  it('commits hash(seed) at SEAL, before any pick exists', async () => {
+    const { deps, state } = boostScenario();
+    const sealed = await makeLuckyDrawService(deps).sealDraw(DRAW_ID, ADMIN);
+
+    expect(sealed.seedCommitment).toMatch(/^[0-9a-f]{64}$/);
+    expect(state.draw.sealedSeed).toMatch(/^[0-9a-f]{64}$/);
+    expect(state.draw.seedCommitment).toBe(sha(state.draw.sealedSeed));
+    // No attempt has been made yet — the commitment precedes the pick.
+    expect(state.attempts).toHaveLength(0);
+  });
+
+  it('draws with the REVEALED sealed seed rather than a fresh one', async () => {
+    const sealedSeed = 'a'.repeat(64);
+    const { deps, state } = buildDeps({
+      draw: {
+        ...openDraw, status: 'sealed', poolHash: computePoolHash(entries),
+        sealedSeed, seedCommitment: sha(sealedSeed),
+      },
+      entries,
+    });
+    // A mint that would betray itself if it were used.
+    deps.mintSeed = () => 'f'.repeat(64);
+
+    const { attempt } = await makeLuckyDrawService(deps).runDrawAttempt(DRAW_ID, {}, ADMIN);
+
+    expect(attempt.seed).toBe(sealedSeed);
+    expect(state.attempts[0].seed).toBe(sealedSeed);
+  });
+
+  it('REFUSES to draw when the sealed seed does not match its commitment', async () => {
+    const { deps } = buildDeps({
+      draw: {
+        ...openDraw, status: 'sealed', poolHash: computePoolHash(entries),
+        sealedSeed: 'b'.repeat(64), seedCommitment: sha('a'.repeat(64)), // substituted
+      },
+      entries,
+    });
+
+    await expect(makeLuckyDrawService(deps).runDrawAttempt(DRAW_ID, {}, ADMIN))
+      .rejects.toMatchObject({ statusCode: 409, message: expect.stringMatching(/does not match its commitment/i) });
+  });
+
+  it('verifyDraw passes a normal sealed→drawn round trip', async () => {
+    const sealedSeed = 'c'.repeat(64);
+    const { deps } = buildDeps({
+      draw: {
+        ...openDraw, status: 'sealed', poolHash: computePoolHash(entries),
+        sealedSeed, seedCommitment: sha(sealedSeed),
+      },
+      entries,
+    });
+    const svc = makeLuckyDrawService(deps);
+    await svc.runDrawAttempt(DRAW_ID, {}, ADMIN);
+
+    const report = await svc.verifyDraw(DRAW_ID);
+
+    expect(report.ok).toBe(true);
+    expect(report.checks.find((c) => c.check === 'seedCommitment')).toMatchObject({ ok: true });
+  });
+
+  it('verifyDraw REJECTS a revealed seed that does not hash to the commitment', async () => {
+    const sealedSeed = 'd'.repeat(64);
+    const { deps, state } = buildDeps({
+      draw: {
+        ...openDraw, status: 'sealed', poolHash: computePoolHash(entries),
+        sealedSeed, seedCommitment: sha(sealedSeed),
+      },
+      entries,
+    });
+    const svc = makeLuckyDrawService(deps);
+    await svc.runDrawAttempt(DRAW_ID, {}, ADMIN);
+
+    // The operator swaps in the seed that produced the winner they wanted.
+    state.draw.sealedSeed = 'e'.repeat(64);
+    state.attempts[0].seed = 'e'.repeat(64);
+
+    const report = await svc.verifyDraw(DRAW_ID);
+
+    expect(report.ok).toBe(false);
+    expect(report.checks.find((c) => c.check === 'seedCommitment')).toMatchObject({ ok: false });
+    expect(report.checks.some((c) => c.check === 'attempt#1.seedRevealed' && c.ok === false)).toBe(true);
+  });
+
+  it('a draw sealed BEFORE commit-reveal still draws, and verifyDraw says the commitment is absent', async () => {
+    const { deps } = buildDeps({
+      draw: { ...openDraw, status: 'sealed', poolHash: computePoolHash(entries) }, // no commitment
+      entries,
+    });
+    const svc = makeLuckyDrawService(deps);
+    await svc.runDrawAttempt(DRAW_ID, {}, ADMIN);
+
+    const report = await svc.verifyDraw(DRAW_ID);
+
+    expect(report.ok).toBe(true);
+    expect(report.checks.find((c) => c.check === 'seedCommitment').note)
+      .toMatch(/sealed before commit-reveal/i);
+  });
+});


### PR DESCRIPTION
**Task P2-8** (medium — integrity) · review round-2 queue

## Defect
`pickWinner` is a **pure function of `(seed, entries)`**. The pool was already committed at seal (`poolHash`), but the **seed** was minted at draw time (`crypto.randomBytes(32)`) and used immediately, with nothing committing it beforehand.

So a malicious operator could re-mint and re-run the pick until it landed on a chosen entry, then persist only that attempt. Nothing in the record would show the discarded rolls — the stored attempt verifies perfectly, because the seed it names is the one that produced it.

## Fix — commit at seal, reveal at draw
The seed is minted **inside the one-way `frozen → sealed` transition**, and only `sha256(seed)` is published as the commitment. Because the pool is committed by the *same statement*, the winner is determined at the seal instant: there is no later moment at which a re-roll can be kept, and `sealDraw` cannot re-run (the transition is one-way).

- `runDrawAttempt` **reveals** `draw.sealedSeed` instead of minting, and **fails closed** (409) if it no longer hashes to the commitment.
- `verifyDraw` gains two checks: the sealed pair (`sha256(sealedSeed) === seedCommitment`), and every attempt's revealed seed against that same commitment.
- Re-draws (attempt #2+) reuse the sealed seed against a pool that excludes prior picks — so the *whole sequence* of possible winners is fixed at seal, not just the first.

**Migration 103** adds both columns nullable and **deliberately does not backfill**: minting a seed now for an already-sealed draw would manufacture a commitment that commits to nothing — it would "prove" a pick made under the old rules. Those draws keep working on the legacy mint, and `verifyDraw` reports the absent commitment explicitly rather than implying a guarantee they never had. Columns are declared on the model too, per the `sync({force:true})` gotcha.

## Test proof
`backend/test/luckyDrawService.test.js` (+6 cases). **Pre-fix: all 6 fail.** The two that matter:

- *draws with the REVEALED sealed seed* — pre-fix it used the fresh mint (`ffff…`) instead of the sealed `aaaa…`.
- *verifyDraw REJECTS a revealed seed that does not hash to the commitment* — pre-fix `report.ok` is **`true`**: swapping the seed after the fact is completely undetectable. That is the defect, stated as an assertion.

**Post-fix: `34 passed`.** Also covered: the commitment exists at seal *before any attempt*, a mismatched sealed seed refuses to draw, a normal round trip verifies, and a legacy pre-commit draw still draws while `verifyDraw` names the gap.

Local: migration tier **23 passed**; all seven draw suites **119 passed**; full unit tier **2190 passed / 127 suites**. `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)