### PR TITLE
fix(draw): fail-closed on legacy winners:N configs (P2-9)

### DIFF
--- a/backend/src/services/campaignReadinessService.js
+++ b/backend/src/services/campaignReadinessService.js
@@ -349,7 +349,7 @@ export function computeReadiness(facts) {
 // Model-free static imports — the pure export above must stay import-light
 // (utils only, no model graph).
 import { readLegacyViewSafe, getStoredLuckyDraw, getStoredTermsHtml } from '../utils/designConfigV2Clamp.js';
-import { normalizeLuckyDraw, totalPrizeQuantity } from '../utils/luckyDraw.js';
+import { normalizeLuckyDraw, promisedWinnerCount } from '../utils/luckyDraw.js';
 import { sgtDayEndExclusiveMs } from '../utils/sgtTime.js';
 import { checkDrawConsistency, checkDrawRecordDrift } from '../utils/drawConsistency.js';
 
@@ -548,7 +548,9 @@ export async function loadCampaignReadiness(campaignId) {
     drawCloseMismatch,
     docDrawClosesAt,
     drawRecordClosesAt,
-    drawTotalPrizes: totalPrizeQuantity(ld),
+    // The PROMISE, not just the structured rows (P2-9) — a legacy winners:N
+    // config must raise the same critical a prizes[] one does.
+    drawTotalPrizes: promisedWinnerCount(ld),
     screeningConfigured,
     screeningGateOn,
     railActive,

--- a/backend/src/utils/luckyDraw.js
+++ b/backend/src/utils/luckyDraw.js
@@ -67,15 +67,31 @@ export function totalPrizeQuantity(ld) {
 }
 
 /**
+ * What the campaign PUBLICLY PROMISES, structured or not (P2-9).
+ *
+ * totalPrizeQuantity keys only on prizes[], so a LEGACY config carrying
+ * `winners: 5` with no prizes[] scored 0 — it passed the activation gate, went
+ * live, and published "5 winners" through publicLuckyDraw while the engine
+ * resolved exactly ONE. The promise the public reads is max(Σqty, winners), so
+ * that is what the guard has to weigh. For structured draws the two agree by
+ * construction (normalizeLuckyDraw derives winners from Σqty), so this changes
+ * nothing there.
+ */
+export function promisedWinnerCount(ld) {
+  const winners = Number.isInteger(ld?.winners) && ld.winners > 0 ? ld.winners : 0;
+  return Math.max(totalPrizeQuantity(ld), winners);
+}
+
+/**
  * THE multi-prize fail-closed guard (P4-1): the draw engine resolves exactly
- * ONE claimed winner today, so a NORMALIZED draw whose prizes total more than
- * one unit 422s with DRAW_MULTI_PRIZE_UNSUPPORTED. One code, one message
- * core; call sites append their own context via `suffix` (readiness keeps a
- * prose copy for tone — its lowercase issue code is a separate namespace).
+ * ONE claimed winner today, so a NORMALIZED draw that promises more than one
+ * 422s with DRAW_MULTI_PRIZE_UNSUPPORTED. One code, one message core; call
+ * sites append their own context via `suffix` (readiness keeps a prose copy
+ * for tone — its lowercase issue code is a separate namespace).
  * Phase 3 (multi-winner engine) removes this.
  */
 export function assertSingleWinnerDraw(ld, { suffix = '.' } = {}) {
-  const total = totalPrizeQuantity(ld);
+  const total = promisedWinnerCount(ld);
   if (total > 1) {
     const err = new AppError(
       `This draw promises ${total} prizes, but multi-winner draw execution isn't live yet${suffix}`,

--- a/backend/test/drawMultiPrizeGate.test.js
+++ b/backend/test/drawMultiPrizeGate.test.js
@@ -25,6 +25,35 @@ describe('assertDrawActivatable', () => {
     expect(thrown?.data?.code).toBe('DRAW_MULTI_PRIZE_UNSUPPORTED');
   });
 
+  /**
+   * P2-9. The guard keyed ONLY on prizes[], so a legacy config carrying
+   * `winners: 5` with no prizes[] scored 0, activated, and published "5
+   * winners" through publicLuckyDraw — while the engine resolves exactly one.
+   * The platform promised something it cannot honour.
+   */
+  it('422s for a LEGACY winners:N config with no prizes[]', () => {
+    let thrown;
+    try {
+      assertDrawActivatable({
+        luckyDraw: {
+          enabled: true, closesAt: '2026-10-30',
+          prize: '4D3N Tokyo getaway for two', winners: 5,
+        },
+      });
+    } catch (e) { thrown = e; }
+    expect(thrown?.statusCode).toBe(422);
+    expect(thrown?.data?.code).toBe('DRAW_MULTI_PRIZE_UNSUPPORTED');
+  });
+
+  it('still passes a legacy config that promises exactly one winner', () => {
+    expect(() => assertDrawActivatable({
+      luckyDraw: {
+        enabled: true, closesAt: '2026-10-30',
+        prize: '4D3N Tokyo getaway for two', winners: 1,
+      },
+    })).not.toThrow();
+  });
+
   it('passes for single-structured, legacy, disabled, and absent draws', () => {
     expect(() => assertDrawActivatable({
       luckyDraw: { enabled: true, closesAt: '2026-10-30', prizes: [{ qty: 1, name: 'iPhone 17 Pro' }] },
@@ -46,6 +75,13 @@ describe('computeReadiness — draw_multi_prize_unsupported', () => {
     const issue = out.issues.find((i) => i.code === 'draw_multi_prize_unsupported');
     expect(issue?.level).toBe('critical');
     expect(issue?.message).toContain('4 prizes');
+    expect(out.ready).toBe(false);
+  });
+
+  it('emits the same CRITICAL for a legacy winners:N campaign (P2-9)', () => {
+    const out = computeReadiness({ ...base, drawEnabled: true, drawTotalPrizes: 5 });
+    const issue = out.issues.find((i) => i.code === 'draw_multi_prize_unsupported');
+    expect(issue?.level).toBe('critical');
     expect(out.ready).toBe(false);
   });
 

--- a/backend/test/luckyDraw.util.test.js
+++ b/backend/test/luckyDraw.util.test.js
@@ -4,7 +4,7 @@
  * Mirrors featuredDrop.util.test.js — these values gate PUBLIC signup
  * enforcement, so the clamp is the security boundary.
  */
-import { normalizeLuckyDraw, applyLuckyDrawPolicy, derivePrizeSummary, totalPrizeQuantity } from '../src/utils/luckyDraw.js';
+import { normalizeLuckyDraw, applyLuckyDrawPolicy, derivePrizeSummary, totalPrizeQuantity, promisedWinnerCount } from '../src/utils/luckyDraw.js';
 import { sgtDayEndExclusiveMs } from '../src/utils/sgtTime.js';
 
 const UUID = '123e4567-e89b-42d3-a456-426614174000';
@@ -147,6 +147,23 @@ describe('normalizeLuckyDraw — structured prizes', () => {
     expect(derivePrizeSummary(ROWS)).toBe('iPhone 17 Pro + 3× $100 FairPrice Voucher');
     expect(totalPrizeQuantity(normalizeLuckyDraw({ enabled: true, prizes: ROWS }))).toBe(4);
     expect(totalPrizeQuantity(normalizeLuckyDraw({ enabled: true, prize: 'Manual', winners: 9 }))).toBe(0);
+  });
+
+  /**
+   * P2-9: totalPrizeQuantity answers "how many structured units", which is 0
+   * for a legacy config — and that zero is what let `winners: 5` activate and
+   * publish a promise the one-winner engine cannot honour.
+   */
+  it('promisedWinnerCount counts the PROMISE, structured or legacy', () => {
+    // Structured: winners is derived from Σqty, so the two agree.
+    expect(promisedWinnerCount(normalizeLuckyDraw({ enabled: true, prizes: ROWS }))).toBe(4);
+    // Legacy: the manual winners count IS the promise.
+    expect(promisedWinnerCount(normalizeLuckyDraw({ enabled: true, prize: 'Manual', winners: 9 }))).toBe(9);
+    // ...and one winner is still one.
+    expect(promisedWinnerCount(normalizeLuckyDraw({ enabled: true, prize: 'Manual', winners: 1 }))).toBe(1);
+    // No promise at all.
+    expect(promisedWinnerCount(normalizeLuckyDraw({ enabled: true, prize: 'Manual' }))).toBe(0);
+    expect(promisedWinnerCount(undefined)).toBe(0);
     expect(totalPrizeQuantity(undefined)).toBe(0);
   });
 });


### PR DESCRIPTION
**Task P2-9** (medium) · review round-2 queue

## Defect
`assertSingleWinnerDraw` → `totalPrizeQuantity` keys **only** on structured `prizes[]`. A legacy config carrying `winners: 5` with no `prizes[]` scores **0**, so it passes `assertDrawActivatable`, activates, and publishes `winners: 5` through `publicLuckyDraw` — while the engine resolves exactly **one** claimed winner.

The platform publicly promises five winners it cannot honour. The structured path is guarded; the legacy path — which is what every pre-`prizes[]` campaign uses — is not.

## Fix
`promisedWinnerCount(ld)` = `max(Σqty, winners)` — the number the public actually reads — and both the activation guard **and** the readiness critical now weigh that instead of the structured rows alone.

- For **structured** draws nothing changes: `normalizeLuckyDraw` already derives `winners` from `Σqty`, so the two agree by construction.
- For **legacy** draws, `winners: 5` now 422s with the existing `DRAW_MULTI_PRIZE_UNSUPPORTED`, and `winners: 1` still passes.
- `totalPrizeQuantity` keeps its narrow, documented meaning ("Σqty of structured rows") rather than being quietly redefined — the broader notion gets its own name.

Readiness is included because it reads the same source: without it, a legacy `winners: 5` campaign would be blocked at activation but show a clean readiness panel, which is the same bug wearing a different hat.

## Note on the task's twin warning
The task said `backend/src/utils/luckyDraw.js` has a frontend twin to keep byte-identical. **It does not** — I checked: there is no `src/lib/luckyDraw.js`, and the only thing the frontend shares from this area is `luckyDrawCaps.js` (imported directly by `drawTermsTemplate.js`). So there is no parity file to update; `backend/test/luckyDraw.util.test.js` is this util's own unit suite and is extended instead.

## Test proof
**Pre-fix, the discriminating case:** *"422s for a LEGACY winners:N config with no prizes[]"* → **`Expected: 422, Received: undefined`** — nothing was thrown at all; the config activates.

**Post-fix: `35 passed`** across both suites. Added: the legacy 422, a legacy `winners: 1` that must still pass, the matching readiness critical, and `promisedWinnerCount` unit coverage (structured agrees with Σqty, legacy uses `winners`, absent → 0).

Local: full unit tier **2196 passed / 128 suites**; all draw + campaign suites **195 passed**. `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)