### PR TITLE
fix(auth): durable, client-scoped login lockout (P2-10)

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -4,6 +4,7 @@ import { asyncHandler, AppError } from '../middleware/errorHandler.js';
 import { logger } from '../utils/logger.js';
 import * as authService from '../services/authService.js';
 import { setAuthCookie, clearAuthCookie } from '../utils/authCookie.js';
+import { clientKey } from '../middleware/pgRateLimitStore.js';
 
 const OAUTH_STATE_COOKIE = 'oauth_state';
 const OAUTH_STATE_MAX_AGE = 10 * 60 * 1000; // 10 minutes
@@ -146,7 +147,9 @@ export const register = asyncHandler(async (req, res) => {
 export const login = asyncHandler(async (req, res) => {
   const { email, password } = req.body;
 
-  const result = await authService.login(email, password);
+  // The lockout is client-scoped (P2-10) — same resolved visitor key the
+  // rate limiters use, so a Cloudflare edge address never stands in for a user.
+  const result = await authService.login(email, password, { clientKey: clientKey(req) });
 
   setAuthCookie(res, result.token);
   res.json({

--- a/backend/src/services/authService.js
+++ b/backend/src/services/authService.js
@@ -5,11 +5,58 @@ import { generateToken } from '../middleware/auth.js';
 import { AppError } from '../middleware/appError.js';
 import { logger } from '../utils/logger.js';
 import { isAllowedPublicHost } from '../utils/publicHost.js';
+import { bump, peek, reset, blindIdentifier } from './rateCounter.js';
 
-// Simple in-memory login attempt tracker (resets on server restart)
-const loginAttempts = new Map();
+/**
+ * Login lockout (P2-10).
+ *
+ * This was `new Map()`: per-process, so every Render deploy reset it and the
+ * 5-attempt limit was trivially cleared; keyed on the attacker-suppliable
+ * email ALONE, so five bad passwords locked a known victim out of their own
+ * account; and never evicted, so a few million distinct probe emails grew it
+ * without bound.
+ *
+ * It now rides the same durable Postgres counter the rate limiters use, keyed
+ * on (email × client) so one attacker cannot lock a victim, with the window's
+ * TTL doing the eviction. The email is HMAC-blinded — rate_counters is
+ * deliberately PII-free.
+ */
 const MAX_ATTEMPTS = 5;
 const LOCKOUT_MS = 15 * 60 * 1000; // 15 minutes
+
+const lockoutKey = (email, clientKey) =>
+  `auth:login:${blindIdentifier(String(email).toLowerCase())}:${blindIdentifier(clientKey || 'unknown')}`;
+
+/**
+ * Read the current strike count. FAILS OPEN on a database error: the limiter
+ * store takes the same posture, and a Postgres blip must not lock every user
+ * out of the platform.
+ */
+async function lockoutStrikes(key) {
+  try {
+    const { count } = await peek(key);
+    return count;
+  } catch (err) {
+    logger.warn('auth.lockout_store_unavailable_failing_open', { error: err?.message });
+    return 0;
+  }
+}
+
+async function recordFailedAttempt(key) {
+  try {
+    await bump(key, new Date(Date.now() + LOCKOUT_MS));
+  } catch (err) {
+    logger.warn('auth.lockout_bump_failed', { error: err?.message });
+  }
+}
+
+async function clearAttempts(key) {
+  try {
+    await reset(key);
+  } catch (err) {
+    logger.warn('auth.lockout_reset_failed', { error: err?.message });
+  }
+}
 
 /**
  * Register a new user.
@@ -43,17 +90,13 @@ export async function register({ email, password, firstName, lastName, fullName,
  * Authenticate a user with email + password.
  * @returns {{ user: object, token: string }}
  */
-export async function login(email, password) {
-  // Check login lockout
-  const normalizedEmail = email.toLowerCase();
-  const attempts = loginAttempts.get(normalizedEmail);
-  if (attempts && attempts.count >= MAX_ATTEMPTS) {
-    const elapsed = Date.now() - attempts.lastAttempt;
-    if (elapsed < LOCKOUT_MS) {
-      throw new AppError('Too many login attempts. Please try again in 15 minutes.', 429);
-    }
-    // Lockout expired, reset
-    loginAttempts.delete(normalizedEmail);
+export async function login(email, password, { clientKey = null } = {}) {
+  // Lockout is scoped to (email × client): five bad guesses from ONE client
+  // stop that client, and cannot lock the account's real owner out from
+  // theirs. The window's TTL expires the strikes — no eviction pass needed.
+  const key = lockoutKey(email, clientKey);
+  if (await lockoutStrikes(key) >= MAX_ATTEMPTS) {
+    throw new AppError('Too many login attempts. Please try again in 15 minutes.', 429);
   }
 
   const user = await User.scope('withPassword').findOne({
@@ -61,22 +104,18 @@ export async function login(email, password) {
   });
 
   if (!user) {
-    // Increment failed attempts
-    const current = loginAttempts.get(normalizedEmail) || { count: 0, lastAttempt: 0 };
-    loginAttempts.set(normalizedEmail, { count: current.count + 1, lastAttempt: Date.now() });
+    await recordFailedAttempt(key);
     throw new AppError('Invalid email or password', 401);
   }
 
   const isValidPassword = await user.comparePassword(password);
   if (!isValidPassword) {
-    // Increment failed attempts
-    const current = loginAttempts.get(normalizedEmail) || { count: 0, lastAttempt: 0 };
-    loginAttempts.set(normalizedEmail, { count: current.count + 1, lastAttempt: Date.now() });
+    await recordFailedAttempt(key);
     throw new AppError('Invalid email or password', 401);
   }
 
-  // Successful login — clear attempts
-  loginAttempts.delete(normalizedEmail);
+  // Successful login — clear this client's strikes
+  await clearAttempts(key);
 
   if (!user.isActive) {
     throw new AppError('Account is deactivated', 401);

--- a/backend/src/services/rateCounter.js
+++ b/backend/src/services/rateCounter.js
@@ -36,9 +36,14 @@ export function nextSgtMidnight(now = new Date()) {
  * reversible — this is keyed. Keeping the table PII-free means person-level
  * erasure (PR C) has nothing to rebuild here.
  */
-export function blindPhone(phone) {
+export function blindIdentifier(value) {
   const secret = process.env.SMS_QUOTA_SALT || process.env.JWT_SECRET || 'mktr-dev-salt';
-  return crypto.createHmac('sha256', secret).update(String(phone)).digest('hex').slice(0, 32);
+  return crypto.createHmac('sha256', secret).update(String(value)).digest('hex').slice(0, 32);
+}
+
+/** Phone-shaped alias of {@link blindIdentifier} — same bytes, named for its original caller. */
+export function blindPhone(phone) {
+  return blindIdentifier(phone);
 }
 
 const BUMP_SQL = `

--- a/backend/test/authLockoutDurable.test.js
+++ b/backend/test/authLockoutDurable.test.js
@@ -1,0 +1,135 @@
+/**
+ * P2-10 regression: the login lockout is durable and client-scoped.
+ *
+ * It used to be `const loginAttempts = new Map()`:
+ *   - PER-PROCESS, so every Render deploy reset it and the 5-attempt limit was
+ *     trivially cleared by waiting for the next deploy;
+ *   - keyed on the attacker-suppliable EMAIL alone, so five bad passwords
+ *     locked a known victim out of their own account from anywhere;
+ *   - never evicted, so a few million distinct probe emails grew it without
+ *     bound.
+ *
+ * It now rides the same durable Postgres counter as the rate limiters, keyed on
+ * (email × client), with the window's TTL doing the eviction.
+ */
+import { login } from '../src/services/authService.js';
+import { peek, reset, bump, blindIdentifier } from '../src/services/rateCounter.js';
+import { sequelize } from '../src/models/index.js';
+import { getApp, closeDb, createTestUser } from './helpers.js';
+
+const CLIENT_A = '203.0.113.7';
+const CLIENT_B = '198.51.100.4';
+const PASSWORD = 'TestPassword123!';
+
+let user;
+
+const keyFor = (email, client) =>
+  `auth:login:${blindIdentifier(String(email).toLowerCase())}:${blindIdentifier(client)}`;
+
+const failFrom = (email, client) =>
+  login(email, 'wrong-password', { clientKey: client }).catch((e) => e);
+
+beforeAll(async () => {
+  await getApp();
+  ({ user } = await createTestUser({ role: 'agent', password: PASSWORD }));
+});
+
+afterEach(async () => {
+  await reset(keyFor(user.email, CLIENT_A));
+  await reset(keyFor(user.email, CLIENT_B));
+});
+
+afterAll(async () => { await closeDb(); });
+
+describe('lockout is durable, not per-process', () => {
+  it('locks after 5 failures from one client', async () => {
+    for (let i = 0; i < 5; i += 1) {
+      const err = await failFrom(user.email, CLIENT_A);
+      expect(err.statusCode).toBe(401);
+    }
+
+    const locked = await failFrom(user.email, CLIENT_A);
+    expect(locked.statusCode).toBe(429);
+    expect(locked.message).toMatch(/Too many login attempts/i);
+  });
+
+  it('survives a process restart — the strikes live in Postgres, not in a Map', async () => {
+    // What a PREVIOUS process left behind. A module-local Map could not see
+    // this; the durable counter does.
+    const key = keyFor(user.email, CLIENT_A);
+    for (let i = 0; i < 5; i += 1) await bump(key, new Date(Date.now() + 15 * 60_000));
+
+    // This process has recorded nothing itself, yet the lock holds.
+    const locked = await failFrom(user.email, CLIENT_A);
+    expect(locked.statusCode).toBe(429);
+  });
+
+  it('even a CORRECT password is refused while the client is locked', async () => {
+    for (let i = 0; i < 5; i += 1) await failFrom(user.email, CLIENT_A);
+
+    const err = await login(user.email, PASSWORD, { clientKey: CLIENT_A }).catch((e) => e);
+    expect(err.statusCode).toBe(429);
+  });
+});
+
+describe('lockout cannot be used to lock a victim out', () => {
+  it('a different client is NOT locked by the attacker’s strikes', async () => {
+    for (let i = 0; i < 6; i += 1) await failFrom(user.email, CLIENT_A);
+    expect((await failFrom(user.email, CLIENT_A)).statusCode).toBe(429);
+
+    // The real owner, on their own connection, still gets in.
+    const result = await login(user.email, PASSWORD, { clientKey: CLIENT_B });
+    expect(result.token).toBeTruthy();
+    expect(result.user.id).toBe(user.id);
+  });
+
+  it('keys on the email too — one client attacking two accounts locks each separately', async () => {
+    const other = await createTestUser({ role: 'agent', password: PASSWORD });
+    for (let i = 0; i < 6; i += 1) await failFrom(user.email, CLIENT_A);
+
+    // Same client, different account: its own budget.
+    const err = await failFrom(other.user.email, CLIENT_A);
+    expect(err.statusCode).toBe(401);
+    await reset(keyFor(other.user.email, CLIENT_A));
+  });
+});
+
+describe('entries expire and clear', () => {
+  it('a successful login clears that client’s strikes', async () => {
+    for (let i = 0; i < 3; i += 1) await failFrom(user.email, CLIENT_A);
+    expect((await peek(keyFor(user.email, CLIENT_A))).count).toBe(3);
+
+    await login(user.email, PASSWORD, { clientKey: CLIENT_A });
+
+    expect((await peek(keyFor(user.email, CLIENT_A))).count).toBe(0);
+  });
+
+  it('an expired window frees the client — no unbounded growth, no permanent lock', async () => {
+    const key = keyFor(user.email, CLIENT_A);
+    for (let i = 0; i < 5; i += 1) await failFrom(user.email, CLIENT_A);
+    expect((await failFrom(user.email, CLIENT_A)).statusCode).toBe(429);
+
+    // Age the window past its TTL — what 15 minutes of wall clock would do.
+    await sequelize.query(
+      `UPDATE rate_counters SET "expiresAt" = now() - interval '1 minute' WHERE key = :key`,
+      { replacements: { key } }
+    );
+
+    expect((await peek(key)).count).toBe(0);
+    const afterExpiry = await failFrom(user.email, CLIENT_A);
+    expect(afterExpiry.statusCode).toBe(401); // ordinary refusal, not a lock
+  });
+
+  it('stores no readable email — rate_counters stays PII-free', async () => {
+    await failFrom(user.email, CLIENT_A);
+
+    const [rows] = await sequelize.query(
+      `SELECT key FROM rate_counters WHERE key LIKE 'auth:login:%'`
+    );
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(row.key).not.toContain(user.email);
+      expect(row.key).not.toContain(CLIENT_A);
+    }
+  });
+});

--- a/backend/test/unit/authService.test.js
+++ b/backend/test/unit/authService.test.js
@@ -71,6 +71,7 @@ let authService;
 // Since authService uses top-level imports, we use jest.unstable_mockModule.
 
 let _User, _generateToken, _AppError, _logger;
+const _counters = new Map();
 
 beforeAll(async () => {
   mocks = buildMocks();
@@ -93,6 +94,26 @@ beforeAll(async () => {
 
   jest.unstable_mockModule('../../src/utils/logger.js', () => ({
     logger: _logger,
+  }));
+
+  // P2-10: the lockout now lives in the durable Postgres counter. Model it as
+  // an in-memory map here so the unit tier stays DB-free while still exercising
+  // the real key derivation and the real strike/expiry logic.
+  jest.unstable_mockModule('../../src/services/rateCounter.js', () => ({
+    blindIdentifier: (v) => `b(${String(v)})`,
+    peek: async (key) => {
+      const row = _counters.get(key);
+      if (!row || row.expiresAt <= Date.now()) return { count: 0, expiresAt: null };
+      return { count: row.count, expiresAt: new Date(row.expiresAt) };
+    },
+    bump: async (key, expiresAt) => {
+      const row = _counters.get(key);
+      const fresh = !row || row.expiresAt <= Date.now();
+      const next = { count: fresh ? 1 : row.count + 1, expiresAt: new Date(expiresAt).getTime() };
+      _counters.set(key, next);
+      return { count: next.count, expiresAt: new Date(next.expiresAt) };
+    },
+    reset: async (key) => { _counters.delete(key); },
   }));
 
   authService = await import('../../src/services/authService.js');


### PR DESCRIPTION
**Task P2-10** (medium) · review round-2 queue · *pairs with P1-6's shared limiter — reuses the same durable store*

## Defect
`const loginAttempts = new Map()` — three problems in one line:

1. **Per-process.** Render deploys are frequent, and each one reset the map. The advertised "5 attempts per 15 minutes" was really "5 per instance, until the next deploy".
2. **Keyed on the email alone.** The email is attacker-supplied, so five bad passwords **locked a known victim out of their own account**, from anywhere. A denial-of-service against any user whose address you know.
3. **Never evicted.** A few million distinct probe emails grow the map without bound — memory exhaustion.

## Fix
The lockout moves onto the same durable Postgres counter the rate limiters use, keyed on **(email × client)**:

- **Durable** — strikes survive a restart because they're rows, not process memory.
- **Client-scoped** — five failures from an attacker stop *that attacker*; the account's real owner still logs in from their own connection.
- **Self-evicting** — the counter's window TTL expires strikes; no eviction pass, no unbounded growth.
- **PII-free** — both the email and the client key are HMAC-blinded through the counter module's existing primitive, because `rate_counters` is deliberately free of personal data.
- **Fails open** on a database error, matching `PostgresRateLimitStore`'s documented posture. A Postgres blip must not lock every user out of the platform.

`blindPhone` becomes a named alias of a now-generic `blindIdentifier` — same HMAC, same secret, same slice — so existing SMS-quota keys are byte-identical.

## Test proof
`backend/test/authLockoutDurable.test.js` (new, 8 cases) against real Postgres.

**Pre-fix: `4 failed, 4 passed`.** The headline is *"a different client is NOT locked by the attacker's strikes"* — it fails, because pre-fix **the victim is locked out of their own account**. Also failing: an expired window still returned 429 (permanent lock), a successful login didn't clear the durable strikes, and no counter row existed at all.

**Post-fix: `8 passed`** — including durability proven the honest way: strikes are written as a *previous process* would have, and this process, which recorded nothing itself, still refuses. Plus: a correct password is refused while locked, one client attacking two accounts gets a separate budget per account, and no row key contains the email or the IP.

The existing `authService` unit tests now model the store in memory (mocked module), so the unit tier stays DB-free while still exercising the real key derivation and strike logic.

Local: full unit tier **2196 passed / 128 suites**; `authLockoutDurable`, `authRoutes`, `security`, `rbac`, `users`, `invitations` → **260 passed**. `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)