### PR TITLE
fix(observability): scrub PII from exception messages + breadcrumbs (P2-11)

### DIFF
--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -1,15 +1,19 @@
 import { ValidationError, DatabaseError, ConnectionError } from 'sequelize';
 import { logger } from '../utils/logger.js';
 import { maskTokenUrl } from '../utils/redactTokens.js';
+import { scrubText } from '../utils/sentryScrub.js';
 
 export const errorHandler = (err, req, res, _next) => {
   let error = { ...err };
   error.message = err.message;
 
   // Structured error logging via pino (replaces console.error)
+  // The message and stack are FREE TEXT — an identifier interpolated into a
+  // thrown Error lands here verbatim, and the pino stream sits OUTSIDE the
+  // PDPA erasure matrix, so nothing can take it back later (P2-11).
   logger.error(
     {
-      err: { message: err.message, statusCode: err.statusCode, stack: err.stack },
+      err: { message: scrubText(err.message), statusCode: err.statusCode, stack: scrubText(err.stack) },
       req: { method: req.method, url: maskTokenUrl(req.originalUrl), id: req.id },
     },
     'Request error'

--- a/backend/src/utils/sentryScrub.js
+++ b/backend/src/utils/sentryScrub.js
@@ -7,6 +7,44 @@ import { maskTokenUrl } from './redactTokens.js';
 
 const PII_KEY_PATTERN = /phone|email|nric|name|token|jwt|address|otp|password|signature|secret|private_?key|authorization/i;
 
+/**
+ * VALUE-level PII, for free text where there is no key to match on (P2-11).
+ *
+ * scrubObject only ever looked at key NAMES, and scrubEvent never touched
+ * event.message or event.exception at all — so `throw new Error(\`User
+ * ${email} not found\`)` landed verbatim in Sentry, and the same string went
+ * to pino, which sits OUTSIDE the PDPA erasure matrix. A key-based scrubber
+ * cannot help here: the identifier is inside a sentence.
+ *
+ * Deliberately eager. An 8-digit number beginning 3/6/8/9 is an SG mobile, and
+ * redacting the occasional row count or id that happens to look like one is a
+ * trade we take: the stack trace still says WHERE, and privacy beats one line
+ * of convenience. Keep these in step with lyfe-sg / lyfe-app if they gain a
+ * value-level pass.
+ */
+const PII_VALUE_PATTERNS = [
+  [/[\w.+-]+@[\w-]+\.[\w.-]+/g, '[email]'],
+  // SPACED display form first (`+65 9123 4567` — the format this platform
+  // renders everywhere), else the contiguous patterns below eat its prefix and
+  // leave the last four digits sitting in the log.
+  [/\+?65[\s-]?[3689]\d{3}[\s-]\d{4}\b/g, '[phone]'],
+  [/\+?65[\s-]?[3689]\d{7}\b/g, '[phone]'],
+  [/\b[3689]\d{3}[\s-]\d{4}\b/g, '[phone]'],
+  [/\b[3689]\d{7}\b/g, '[phone]'],
+  [/\b[STFGM]\d{7}[A-Z]\b/gi, '[nric]'],
+];
+
+/**
+ * Redact identifiers embedded in free text, then mask URL-borne credentials.
+ * Non-strings pass through untouched.
+ */
+export function scrubText(text) {
+  if (typeof text !== 'string' || text.length === 0) return text;
+  let out = text;
+  for (const [pattern, replacement] of PII_VALUE_PATTERNS) out = out.replace(pattern, replacement);
+  return maskTokenUrl(out);
+}
+
 export function scrubObject(input) {
   if (input == null || typeof input !== 'object') return input;
   if (Array.isArray(input)) return input.map(scrubObject);
@@ -34,6 +72,12 @@ export function scrubEvent(event) {
   if (typeof event.request?.url === 'string') event.request.url = maskTokenUrl(event.request.url);
   // Strip user PII — only id is allowed.
   if (event.user) event.user = { id: event.user.id };
+  // The message and the thrown value are FREE TEXT — no key to match on, and
+  // the most likely place a real identifier appears (P2-11).
+  if (typeof event.message === 'string') event.message = scrubText(event.message);
+  for (const entry of event.exception?.values || []) {
+    if (typeof entry?.value === 'string') entry.value = scrubText(entry.value);
+  }
   return event;
 }
 
@@ -43,6 +87,6 @@ export function scrubBreadcrumb(breadcrumb) {
     breadcrumb.data = scrubObject(breadcrumb.data);
     if (typeof breadcrumb.data.url === 'string') breadcrumb.data.url = maskTokenUrl(breadcrumb.data.url);
   }
-  if (typeof breadcrumb.message === 'string') breadcrumb.message = maskTokenUrl(breadcrumb.message);
+  if (typeof breadcrumb.message === 'string') breadcrumb.message = scrubText(breadcrumb.message);
   return breadcrumb;
 }

--- a/backend/test/sentryScrub.test.js
+++ b/backend/test/sentryScrub.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import { scrubObject, scrubEvent, scrubBreadcrumb } from '../src/utils/sentryScrub.js';
+import { scrubObject, scrubEvent, scrubBreadcrumb, scrubText } from '../src/utils/sentryScrub.js';
 
 describe('sentryScrub', () => {
   describe('scrubObject', () => {
@@ -90,6 +90,74 @@ describe('sentryScrub', () => {
     it('returns crumb unchanged when no data', () => {
       const crumb = { category: 'http' };
       expect(scrubBreadcrumb(crumb)).toBe(crumb);
+    });
+  });
+
+  /**
+   * P2-11. scrubObject matches KEY NAMES, and scrubEvent never touched
+   * event.message or event.exception at all — so an identifier interpolated
+   * into a thrown Error ("User a@b.com not found") reached Sentry verbatim, and
+   * the same string reached pino, which sits OUTSIDE the PDPA erasure matrix.
+   * A key-based scrubber cannot help when the identifier is inside a sentence.
+   */
+  describe('scrubText — value-level PII in free text', () => {
+    it.each([
+      ['User shawn@example.com not found', 'User [email] not found'],
+      ['Lead +65 9123 4567 blocked', 'Lead [phone] blocked'],
+      ['dial +6591234567 failed', 'dial [phone] failed'],
+      ['holder 6591234567 duplicate', 'holder [phone] duplicate'],
+      ['sms to 91234567 bounced', 'sms to [phone] bounced'],
+      ['display 9123 4567 rejected', 'display [phone] rejected'],
+      ['NRIC S1234567A rejected', 'NRIC [nric] rejected'],
+    ])('redacts %s', (input, expected) => {
+      expect(scrubText(input)).toBe(expected);
+    });
+
+    it('still masks URL-borne credentials', () => {
+      expect(scrubText('GET /api/reward-claim/live-secret failed'))
+        .toBe('GET /api/reward-claim/[token] failed');
+    });
+
+    it('leaves non-identifier numbers alone', () => {
+      expect(scrubText('deleted 12345678 rows')).toBe('deleted 12345678 rows');
+      expect(scrubText('order 4567 of 8')).toBe('order 4567 of 8');
+      expect(scrubText('no pii here, id 42')).toBe('no pii here, id 42');
+    });
+
+    it('passes non-strings through untouched', () => {
+      expect(scrubText(undefined)).toBeUndefined();
+      expect(scrubText(null)).toBeNull();
+      expect(scrubText(42)).toBe(42);
+    });
+  });
+
+  describe('scrubEvent — exception values and message (P2-11)', () => {
+    it('scrubs an identifier thrown inside an Error message', () => {
+      const event = scrubEvent({
+        exception: {
+          values: [{ type: 'AppError', value: 'Lead shawn@example.com (+65 9123 4567) not found' }],
+        },
+      });
+      expect(event.exception.values[0].value).toBe('Lead [email] ([phone]) not found');
+      // The class name is not PII and stays readable.
+      expect(event.exception.values[0].type).toBe('AppError');
+    });
+
+    it('scrubs event.message', () => {
+      const event = scrubEvent({ message: 'failed for a@b.com' });
+      expect(event.message).toBe('failed for [email]');
+    });
+
+    it('handles events with no exception/message', () => {
+      expect(() => scrubEvent({ extra: { keep: 1 } })).not.toThrow();
+      expect(scrubEvent({ exception: { values: [] } }).exception.values).toEqual([]);
+    });
+  });
+
+  describe('scrubBreadcrumb — message PII (P2-11)', () => {
+    it('redacts an identifier in the breadcrumb text, not just the URL', () => {
+      const out = scrubBreadcrumb({ message: 'sent otp to +6591234567 via /r/tok3n' });
+      expect(out.message).toBe('sent otp to [phone] via /r/[token]');
     });
   });
 });

--- a/backend/test/unit/errorHandlerScrub.test.js
+++ b/backend/test/unit/errorHandlerScrub.test.js
@@ -1,0 +1,90 @@
+/**
+ * P2-11 regression: the ERROR LOG is scrubbed too.
+ *
+ * errorHandler logged raw `err.message` and `err.stack` to pino. An identifier
+ * interpolated into a thrown Error therefore landed verbatim in the log
+ * stream — and that stream sits OUTSIDE the PDPA erasure matrix, so a later
+ * erasure request cannot take it back. The Sentry half of this task is
+ * covered in test/sentryScrub.test.js; this is the half nobody can delete.
+ */
+import { jest } from '@jest/globals';
+import '../setup.js';
+
+const logs = [];
+const logger = {
+  error: jest.fn((payload, msg) => logs.push({ payload, msg })),
+  warn: jest.fn(), info: jest.fn(), debug: jest.fn(),
+};
+
+jest.unstable_mockModule('../../src/utils/logger.js', () => ({ logger }));
+
+const { errorHandler } = await import('../../src/middleware/errorHandler.js');
+
+const runHandler = (err) => {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+  errorHandler(err, { method: 'POST', originalUrl: '/api/prospects', id: 'req-1' }, res, () => {});
+  return res;
+};
+
+beforeEach(() => {
+  logs.length = 0;
+  jest.clearAllMocks();
+});
+
+describe('errorHandler PII scrubbing', () => {
+  it('scrubs an email interpolated into the thrown message', () => {
+    runHandler(new Error('Lead shawn@example.com not found'));
+
+    const { err } = logs[0].payload;
+    expect(err.message).toBe('Lead [email] not found');
+    expect(err.message).not.toContain('shawn@example.com');
+  });
+
+  it('scrubs a phone number in every format the platform renders', () => {
+    runHandler(new Error('dial +65 9123 4567 / +6591234567 / 91234567 failed'));
+
+    expect(logs[0].payload.err.message).toBe('dial [phone] / [phone] / [phone] failed');
+  });
+
+  it('scrubs the STACK as well — the message is repeated in its first line', () => {
+    runHandler(new Error('holder S1234567A rejected'));
+
+    const { err } = logs[0].payload;
+    expect(err.stack).toContain('[nric]');
+    expect(err.stack).not.toContain('S1234567A');
+  });
+
+  it('still masks URL-borne credentials in the request line', () => {
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+    errorHandler(
+      new Error('boom'),
+      { method: 'GET', originalUrl: '/api/reward-claim/live-secret', id: 'req-2' },
+      res,
+      () => {}
+    );
+
+    expect(logs[0].payload.req.url).toBe('/api/reward-claim/[token]');
+  });
+
+  it('leaves a PII-free message intact — no over-redaction of ordinary errors', () => {
+    runHandler(new Error('Campaign not found'));
+
+    expect(logs[0].payload.err.message).toBe('Campaign not found');
+  });
+
+  it('carries the status code through unchanged', () => {
+    const err = new Error('Lead a@b.com blocked');
+    err.statusCode = 409;
+
+    runHandler(err);
+
+    expect(logs[0].payload.err.statusCode).toBe(409);
+    expect(logs[0].payload.err.message).toBe('Lead [email] blocked');
+  });
+});


### PR DESCRIPTION
**Task P2-11** (medium — observability/privacy) · review round-2 queue

## Defect
`scrubObject` matches **key names**, and `scrubEvent` never touched `event.message` or `event.exception` at all. So `throw new Error(\`User ${email} not found\`)` reached Sentry **verbatim** — a key-based scrubber has nothing to match on when the identifier is inside a sentence.

`errorHandler` logged the same raw `err.message` and `err.stack` to pino. **That stream sits outside the PDPA erasure matrix**, so unlike a database row, an erasure request can never take it back. That's the half that matters most.

`scrubBreadcrumb` ran `maskTokenUrl` over its message but not the PII pattern.

## Fix
`scrubText` adds a **value-level** pass, applied to `event.message`, every `event.exception[].value`, `breadcrumb.message`, and both `err.message` and `err.stack` on the log path:

- **email**
- **SG phone in every format the platform renders** — `+65 9123 4567`, `+6591234567`, `6591234567`, `91234567`, `9123 4567`
- **NRIC**
- then `maskTokenUrl` as before, so URL-borne credentials stay masked

Two deliberate calls:

- **Eager on phones.** An 8-digit number beginning 3/6/8/9 *is* an SG mobile, so the occasional row count that looks like one gets redacted. The stack trace still says *where*; privacy beats one line of convenience. Verified against controls: `deleted 12345678 rows`, `order 4567 of 8` and `id 42` all pass through untouched.
- **Spaced form matched first.** Otherwise the contiguous pattern eats the `+65` prefix and leaves the last four digits sitting in the log — a partial redaction that reads as safe but isn't.

## Test proof
`backend/test/sentryScrub.test.js` (+15 cases) and `backend/test/unit/errorHandlerScrub.test.js` (new, 6 cases).

**Pre-fix** (call sites reverted, so it fails behaviourally rather than on a missing import): **6 failed** across both surfaces —

- Sentry: `Received: "Lead shawn@example.com (+65 9123 4567) not found"`
- Log: `Received: "dial +65 9123 4567 / +6591234567 / 91234567 failed"`, and the stack still contained `S1234567A`

**Post-fix: `29 passed`** across the two suites. Also pinned: the exception `type` (class name) stays readable, a PII-free message is not over-redacted, the status code passes through, and events with no exception/message don't throw.

Local: full unit tier **2202 passed / 129 suites**; `sentryScrub`, `tokenRedaction`, `middleware`, `security`, `routes` → **104 passed**. `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)