### PR TITLE
fix(idempotency): composite (scope,key) PK + expiry-aware claim (P2-13)

### DIFF
--- a/backend/src/database/migrations/104-idempotency-composite-pk.js
+++ b/backend/src/database/migrations/104-idempotency-composite-pk.js
@@ -1,0 +1,70 @@
+/**
+ * 104 — composite (scope, key) primary key on idempotency_keys (P2-13).
+ *
+ * `key` alone was the primary key while `scope` was a plain column — and every
+ * lookup in idempotencyProtocol filters by {key, scope}. So the same client
+ * idempotency key sent to two DIFFERENT scopes collided on insert, while the
+ * scoped replay lookup found nothing to replay: the second operation 500'd
+ * instead of running. The keyspace the code reasons about and the keyspace the
+ * database enforces were simply not the same one.
+ *
+ * Scope FIRST: the index then also serves scope-prefixed scans, which is what
+ * the old standalone `scope` index existed for — so that index goes too.
+ *
+ * Widening a PK cannot create a conflict here: every (scope, key) pair is at
+ * least as unique as the `key` it contained. The swap takes a brief ACCESS
+ * EXCLUSIVE lock, which is safe on this table by construction — rows carry a
+ * 24h TTL, so it stays small.
+ */
+
+export async function up(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.transaction(async (t) => {
+    const q = (sql) => sequelize.query(sql, { transaction: t });
+
+    const [[existing]] = await q(`
+      SELECT conname FROM pg_constraint
+       WHERE conrelid = 'idempotency_keys'::regclass AND contype = 'p'
+    `);
+    // Idempotent: a schema already built from the model (test sync) arrives
+    // with the composite PK in place.
+    const [[composite]] = await q(`
+      SELECT 1 AS ok FROM pg_constraint
+       WHERE conrelid = 'idempotency_keys'::regclass AND contype = 'p'
+         AND pg_get_constraintdef(oid) = 'PRIMARY KEY (scope, key)'
+    `);
+    if (composite) return;
+
+    if (existing) await q(`ALTER TABLE idempotency_keys DROP CONSTRAINT "${existing.conname}"`);
+    await q('ALTER TABLE idempotency_keys ADD PRIMARY KEY (scope, key)');
+
+    // Redundant now — scope is the PK's leading column.
+    await q('DROP INDEX IF EXISTS idempotency_keys_scope');
+  });
+}
+
+export async function down(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.transaction(async (t) => {
+    const q = (sql) => sequelize.query(sql, { transaction: t });
+
+    // Reverting NARROWS the key, so a cross-scope pair that only became
+    // possible under the composite PK would break it. Drop those rows' younger
+    // duplicates first — they are cache entries with a 24h TTL, not records.
+    await q(`
+      DELETE FROM idempotency_keys a
+       USING idempotency_keys b
+       WHERE a.key = b.key AND a.scope <> b.scope AND a."createdAt" > b."createdAt"
+    `);
+
+    const [[existing]] = await q(`
+      SELECT conname FROM pg_constraint
+       WHERE conrelid = 'idempotency_keys'::regclass AND contype = 'p'
+    `);
+    if (existing) await q(`ALTER TABLE idempotency_keys DROP CONSTRAINT "${existing.conname}"`);
+    await q('ALTER TABLE idempotency_keys ADD PRIMARY KEY (key)');
+    await q('CREATE INDEX IF NOT EXISTS idempotency_keys_scope ON idempotency_keys (scope)');
+  });
+}

--- a/backend/src/models/IdempotencyKey.js
+++ b/backend/src/models/IdempotencyKey.js
@@ -3,15 +3,23 @@ import { sequelize } from '../database/connection.js';
 
 class IdempotencyKey extends Model {}
 
+// Composite PK (scope, key) — P2-13, migration 104. `key` alone was the PK
+// while every protocol lookup filtered by {key, scope}, so the same client
+// idempotency key sent to two different scopes collided on insert while the
+// scoped replay lookup returned null: the second operation 500'd instead of
+// running. Scope FIRST so the index also serves scope-prefixed scans.
+// Declared here as well as in the migration because test boot builds the
+// schema from the MODELS via sync({force:true}) before migrations run.
 IdempotencyKey.init({
-  key: {
-    type: DataTypes.STRING,
-    primaryKey: true
-  },
   scope: {
     // e.g., 'beacon:heartbeat' or 'beacon:impression' or 'manifest'
     type: DataTypes.STRING,
+    primaryKey: true,
     allowNull: false
+  },
+  key: {
+    type: DataTypes.STRING,
+    primaryKey: true
   },
   deviceId: {
     type: DataTypes.UUID,
@@ -34,7 +42,7 @@ IdempotencyKey.init({
   modelName: 'IdempotencyKey',
   tableName: 'idempotency_keys',
   indexes: [
-    { fields: ['scope'] },
+    // No standalone `scope` index: it is the PK's leading column now.
     { fields: ['deviceId'] },
     { fields: ['expiresAt'] }
   ]

--- a/backend/src/services/idempotencyProtocol.js
+++ b/backend/src/services/idempotencyProtocol.js
@@ -22,6 +22,20 @@
 
 export const IDEMP_TTL_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * How long an UNFINISHED claim may sit before another caller may take it over
+ * (P2-13).
+ *
+ * claimOrReplay inserts a null-body row, runs the operation, then fills the
+ * result. A crash in between left that null row for the full 24h replay TTL,
+ * and every retry got `in_progress` forever — the key was poisoned by a
+ * process that no longer exists. No held-queue operation legitimately runs for
+ * minutes, so a claim older than this is an abandoned one, not a live one. A
+ * COMPLETED record still keeps the full 24h: that one is a real answer worth
+ * replaying.
+ */
+export const CLAIM_STALE_MS = 5 * 60 * 1000;
+
 export function makeIdempotencyOps(IdempotencyKey) {
   /** Non-claiming replay: the stored result iff present, unexpired and complete. */
   async function replayIfDone(scope, key) {
@@ -42,7 +56,30 @@ export function makeIdempotencyOps(IdempotencyKey) {
   async function claimOrReplay(scope, key) {
     if (!key) return { claimed: true };
     const existing = await IdempotencyKey.findOne({ where: { key, scope } });
-    if (existing) return { claimed: false, replay: existing.responseBody ?? { status: 'error', error: 'in_progress' } };
+    if (existing) {
+      const now = Date.now();
+      const unexpired = existing.expiresAt > new Date(now);
+      if (existing.responseBody && unexpired) {
+        return { claimed: false, replay: existing.responseBody };
+      }
+      // An unfinished claim is only authoritative while it could still be
+      // running. The claim instant is derivable from the TTL the claim wrote,
+      // so this needs no extra column.
+      const claimedAt = new Date(existing.expiresAt).getTime() - IDEMP_TTL_MS;
+      const abandoned = !existing.responseBody && now - claimedAt > CLAIM_STALE_MS;
+      if (!existing.responseBody && !abandoned) {
+        return { claimed: false, replay: { status: 'error', error: 'in_progress' } };
+      }
+      // Expired result, or a claim whose owner never came back: take it over.
+      // Guarded on the row we READ, so two reclaimers cannot both win.
+      const [reclaimed] = await IdempotencyKey.update(
+        { responseBody: null, responseCode: null, expiresAt: new Date(now + IDEMP_TTL_MS) },
+        { where: { key, scope, expiresAt: existing.expiresAt } },
+      );
+      if (reclaimed === 1) return { claimed: true };
+      const winner = await IdempotencyKey.findOne({ where: { key, scope } });
+      return { claimed: false, replay: winner?.responseBody ?? { status: 'error', error: 'in_progress' } };
+    }
     try {
       await IdempotencyKey.create({
         key, scope, responseBody: null, responseCode: null,

--- a/backend/src/services/walletService.js
+++ b/backend/src/services/walletService.js
@@ -33,8 +33,12 @@ export function makeWalletService(overrides = {}) {
   const d = { User, Campaign, LeadPackage, LeadPackageAssignment, WalletLedger, IdempotencyKey, sequelize, getSystemAgentId, logger, ...overrides };
 
   /**
-   * Money-op replay shield over the house IdempotencyKey table (key = PK, so
-   * keys are namespaced). The key row is created as the FIRST statement of the
+   * Money-op replay shield over the house IdempotencyKey table. The `key`
+   * string already namespaces itself (`${scope}:${agentId}:${requestId}`), so
+   * the lookup is by KEY — not findByPk, which since the composite (scope,key)
+   * primary key (P2-13) cannot resolve from one value and would silently
+   * return null, turning every legitimate replay into a 500. The key row is
+   * created as the FIRST statement of the
    * money transaction and its response stored in the SAME transaction — so a
    * stored row implies the op committed, and a concurrent duplicate aborts the
    * whole duplicate transaction on the PK collision (caught OUT here, never
@@ -46,13 +50,13 @@ export function makeWalletService(overrides = {}) {
       throw new AppError('requestId must be 8-64 chars of [A-Za-z0-9_-]', 400);
     }
     const key = `${scope}:${requestId}`;
-    const prior = await d.IdempotencyKey.findByPk(key);
+    const prior = await d.IdempotencyKey.findOne({ where: { key } });
     if (prior) return { ...(prior.responseBody || {}), replayed: true };
     try {
       return await run(key);
     } catch (err) {
       if (err?.name === 'SequelizeUniqueConstraintError') {
-        const winner = await d.IdempotencyKey.findByPk(key);
+        const winner = await d.IdempotencyKey.findOne({ where: { key } });
         if (winner) return { ...(winner.responseBody || {}), replayed: true };
       }
       throw err;

--- a/backend/test/externalLeadOutcomesRoute.test.js
+++ b/backend/test/externalLeadOutcomesRoute.test.js
@@ -88,7 +88,11 @@ describe('POST /api/external/lead-outcomes', () => {
     expect(activity).not.toBeNull();
     expect(activity.metadata).toMatchObject({ source: 'mktr-leads', mktrLeadsStatus: 'won' });
 
-    const key = await IdempotencyKey.findByPk(`external:outcome:${prospect.id}:won`);
+    // Composite (scope, key) PK since P2-13 — findByPk cannot resolve from one
+    // value, so the lookup names both parts.
+    const key = await IdempotencyKey.findOne({
+      where: { key: `external:outcome:${prospect.id}:won`, scope: 'external:outcome' },
+    });
     expect(key).not.toBeNull();
     expect(key.scope).toBe('external:outcome');
 

--- a/backend/test/idempotencyCompositeKey.test.js
+++ b/backend/test/idempotencyCompositeKey.test.js
@@ -1,0 +1,144 @@
+/**
+ * P2-13 regression: the keyspace the code reasons about is the one the
+ * database enforces.
+ *
+ * `key` alone was the primary key while `scope` was a plain column — and every
+ * lookup in idempotencyProtocol filters by {key, scope}. Two consequences:
+ *
+ *  (a) the same client idempotency key sent to two DIFFERENT scopes collided
+ *      on insert while the scoped replay lookup found nothing to replay, so the
+ *      second operation errored instead of running;
+ *  (b) claimOrReplay never looked at expiresAt, so a crash between the
+ *      null-body claim and recordClaimed left that row for the full 24h TTL and
+ *      every retry got `in_progress` — a key poisoned by a dead process.
+ */
+import { IdempotencyKey, sequelize } from '../src/models/index.js';
+import { makeIdempotencyOps, IDEMP_TTL_MS, CLAIM_STALE_MS } from '../src/services/idempotencyProtocol.js';
+import { getApp, closeDb } from './helpers.js';
+
+const ops = makeIdempotencyOps(IdempotencyKey);
+const KEY = 'client-supplied-key-p2-13';
+const SCOPE_A = 'held:release';
+const SCOPE_B = 'held:reassign';
+
+/** Write a claim as a PREVIOUS process would have — `agoMs` in the past. */
+const plantClaim = (scope, key, { agoMs, responseBody = null }) => IdempotencyKey.create({
+  scope, key, responseBody, responseCode: responseBody ? 200 : null,
+  expiresAt: new Date(Date.now() - agoMs + IDEMP_TTL_MS),
+});
+
+beforeAll(async () => { await getApp(); });
+
+beforeEach(async () => {
+  await IdempotencyKey.destroy({ where: { key: KEY } });
+});
+
+afterAll(async () => {
+  await IdempotencyKey.destroy({ where: { key: KEY } });
+  await closeDb();
+});
+
+describe('the same key in two scopes', () => {
+  it('claims independently — one does not block the other', async () => {
+    const first = await ops.claimOrReplay(SCOPE_A, KEY);
+    const second = await ops.claimOrReplay(SCOPE_B, KEY);
+
+    expect(first.claimed).toBe(true);
+    expect(second.claimed).toBe(true);
+  });
+
+  it('records and replays per scope, never crossing', async () => {
+    await ops.claimOrReplay(SCOPE_A, KEY);
+    await ops.recordClaimed(SCOPE_A, KEY, { status: 'ok', from: 'A' });
+    await ops.claimOrReplay(SCOPE_B, KEY);
+    await ops.recordClaimed(SCOPE_B, KEY, { status: 'ok', from: 'B' });
+
+    expect(await ops.replayIfDone(SCOPE_A, KEY)).toEqual({ status: 'ok', from: 'A' });
+    expect(await ops.replayIfDone(SCOPE_B, KEY)).toEqual({ status: 'ok', from: 'B' });
+  });
+
+  it('stores one row per scope', async () => {
+    await ops.claimOrReplay(SCOPE_A, KEY);
+    await ops.claimOrReplay(SCOPE_B, KEY);
+
+    const rows = await IdempotencyKey.findAll({ where: { key: KEY } });
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.scope).sort()).toEqual([SCOPE_B, SCOPE_A].sort());
+  });
+
+  it('enforces uniqueness WITHIN a scope — a replay is still a replay', async () => {
+    const first = await ops.claimOrReplay(SCOPE_A, KEY);
+    const second = await ops.claimOrReplay(SCOPE_A, KEY);
+
+    expect(first.claimed).toBe(true);
+    expect(second.claimed).toBe(false);
+    expect(second.replay).toEqual({ status: 'error', error: 'in_progress' });
+  });
+});
+
+describe('an abandoned claim does not poison the key', () => {
+  it('is reclaimable once it is older than the stale window', async () => {
+    await plantClaim(SCOPE_A, KEY, { agoMs: CLAIM_STALE_MS + 60_000 });
+
+    const retry = await ops.claimOrReplay(SCOPE_A, KEY);
+
+    expect(retry.claimed).toBe(true);
+  });
+
+  it('leaves a RECENT claim alone — that operation may still be running', async () => {
+    await plantClaim(SCOPE_A, KEY, { agoMs: 1_000 });
+
+    const retry = await ops.claimOrReplay(SCOPE_A, KEY);
+
+    expect(retry.claimed).toBe(false);
+    expect(retry.replay).toEqual({ status: 'error', error: 'in_progress' });
+  });
+
+  it('re-arms the TTL when it reclaims, so the next crash gets the same grace', async () => {
+    await plantClaim(SCOPE_A, KEY, { agoMs: CLAIM_STALE_MS + 60_000 });
+
+    await ops.claimOrReplay(SCOPE_A, KEY);
+
+    const row = await IdempotencyKey.findOne({ where: { key: KEY, scope: SCOPE_A } });
+    expect(row.expiresAt.getTime()).toBeGreaterThan(Date.now() + IDEMP_TTL_MS - 60_000);
+    expect(row.responseBody).toBeNull();
+  });
+
+  it('reclaims an EXPIRED completed record rather than replaying a dead answer', async () => {
+    await plantClaim(SCOPE_A, KEY, { agoMs: IDEMP_TTL_MS + 60_000, responseBody: { status: 'ok', stale: true } });
+
+    const retry = await ops.claimOrReplay(SCOPE_A, KEY);
+
+    expect(retry.claimed).toBe(true);
+  });
+
+  it('still replays an UNEXPIRED completed record', async () => {
+    await plantClaim(SCOPE_A, KEY, { agoMs: 1_000, responseBody: { status: 'ok', fresh: true } });
+
+    const retry = await ops.claimOrReplay(SCOPE_A, KEY);
+
+    expect(retry.claimed).toBe(false);
+    expect(retry.replay).toEqual({ status: 'ok', fresh: true });
+  });
+
+  it('only ONE of two concurrent reclaimers wins', async () => {
+    await plantClaim(SCOPE_A, KEY, { agoMs: CLAIM_STALE_MS + 60_000 });
+
+    const [a, b] = await Promise.all([
+      ops.claimOrReplay(SCOPE_A, KEY),
+      ops.claimOrReplay(SCOPE_A, KEY),
+    ]);
+
+    expect([a.claimed, b.claimed].filter(Boolean)).toHaveLength(1);
+  });
+});
+
+describe('schema', () => {
+  it('the primary key is (scope, key)', async () => {
+    const [[pk]] = await sequelize.query(`
+      SELECT pg_get_constraintdef(oid) AS def FROM pg_constraint
+       WHERE conrelid = 'idempotency_keys'::regclass AND contype = 'p'
+    `);
+    expect(pk.def.replace(/"/g, '')).toBe('PRIMARY KEY (scope, key)');
+  });
+});

--- a/backend/test/integration/erasure.test.js
+++ b/backend/test/integration/erasure.test.js
@@ -434,7 +434,11 @@ describe('PDPA erasure — full matrix', () => {
   });
 
   test('provider idempotency rows referencing the person are deleted', async () => {
-    expect(await IdempotencyKey.findByPk(`retell:call:call-in-${RUN}`)).toBeNull();
+    // Composite (scope, key) PK since P2-13: findByPk with one value returns
+    // null unconditionally, so this must name the scope or it proves nothing.
+    expect(await IdempotencyKey.findOne({
+      where: { key: `retell:call:call-in-${RUN}`, scope: 'retell:call' },
+    })).toBeNull();
   });
 
   test('in-memory phone caches evicted post-commit', () => {

--- a/backend/test/unit/walletService.test.js
+++ b/backend/test/unit/walletService.test.js
@@ -91,7 +91,9 @@ function build({
   };
   const getSystemAgentId = jest.fn(async () => 'sys-agent');
   const IdempotencyKey = {
-    findByPk: jest.fn(async () => null),
+    // The service looks up by KEY (findOne), not findByPk — the PK is composite
+    // (scope, key) since P2-13 and cannot resolve from one value.
+    findOne: jest.fn(async () => null),
     create: jest.fn(async (attrs) => attrs),
     update: jest.fn(async () => [1]),
   };
@@ -227,7 +229,7 @@ describe('walletService.commit', () => {
 
   test('idempotent commit replay: stored response returned, no money moves', async () => {
     const { svc, IdempotencyKey, WalletLedger, sequelize } = build({ campaign: activeCampaign() });
-    IdempotencyKey.findByPk.mockResolvedValueOnce({ responseBody: { assignmentId: 'asg-prior', totalCents: 1600 } });
+    IdempotencyKey.findOne.mockResolvedValueOnce({ responseBody: { assignmentId: 'asg-prior', totalCents: 1600 } });
     const r = await svc.commit('agent-1', 'c-1', 2, { requestId: 'req-abc-12345' });
     expect(r).toEqual({ assignmentId: 'asg-prior', totalCents: 1600, replayed: true });
     expect(sequelize.transaction).not.toHaveBeenCalled();
@@ -237,7 +239,7 @@ describe('walletService.commit', () => {
   test('concurrent duplicate: PK collision aborts the duplicate tx and returns the winner', async () => {
     const { svc, IdempotencyKey } = build({ campaign: activeCampaign() });
     IdempotencyKey.create.mockRejectedValueOnce(uniqueViolation());
-    IdempotencyKey.findByPk
+    IdempotencyKey.findOne
       .mockResolvedValueOnce(null) // pre-check: not yet written
       .mockResolvedValueOnce({ responseBody: { assignmentId: 'asg-winner' } }); // after collision
     const r = await svc.commit('agent-1', 'c-1', 2, { requestId: 'req-abc-12345' });


### PR DESCRIPTION
**Task P2-13** (medium — concurrency) · review round-2 queue

## Defect
`key` alone was the primary key while `scope` was a plain column — and **every** lookup in `idempotencyProtocol` filters by `{key, scope}`. The keyspace the code reasons about and the keyspace the database enforces were not the same one.

Two consequences, both verified against the live schema (`PRIMARY KEY (key)`):

1. **Cross-scope collision.** The same client idempotency key sent to two different scopes collided on insert, while the scoped replay lookup found nothing to replay — so the second operation errored instead of running, and its record was silently lost.
2. **Poisoned keys.** `claimOrReplay` never looked at `expiresAt`, so a crash between the null-body claim and `recordClaimed` left that row for the full 24h TTL. Every retry got `in_progress` — a key held hostage by a process that no longer exists.

## Fix
**Migration 104** makes the PK `(scope, key)`. Scope **first**, so the index also serves the scope-prefixed scans the now-redundant standalone `scope` index existed for. Widening a PK cannot create a conflict here: every `(scope, key)` pair is at least as unique as the `key` it contains. Idempotent (skips when the composite PK is already present, as it is on a model-built test schema), and declared on the model too per the `sync({force:true})`-before-migrations gotcha. The `down()` drops younger cross-scope duplicates first, since reverting *narrows* the key — they're 24h cache entries, not records.

**`claimOrReplay`** now treats an unfinished claim as authoritative only while it could still be running (`CLAIM_STALE_MS`, 5 min — no held-queue operation legitimately runs for minutes). Past that, or for an expired completed record, it takes the row over via a **guarded UPDATE on the row it read**, so two reclaimers cannot both win. A completed, unexpired record still replays for the full 24h — that one is a real answer. The claim instant is derived from the TTL the claim itself wrote, so this needs no new column.

## Test proof
`backend/test/idempotencyCompositeKey.test.js` (new, 11 cases). Each half was reverted **independently** so the proof is behavioural, not a missing-export error:

**Model reverted (PK half): 4 failed** — two scopes could not both claim (`Expected: true, Received: false`), scope B's record replayed as `null`, only **1 row** existed where 2 were written, and the PK read back as `PRIMARY KEY (key)`.

**Claim logic reverted (expiry half): 4 failed** — an abandoned claim was not reclaimable, the TTL was never re-armed, an expired completed record replayed a dead answer, and **zero** of two concurrent reclaimers won.

**Post-fix: `11 passed`** — including that a *recent* claim is still left alone (a live operation must not be stolen) and that within-scope replay still works.

Local: migration tier **23 passed**; `idempotencyCompositeKey`, `retell`, `externalHeldLeadsController`, `prospectServiceBulkOps`, `prospects` → **118 passed**; full unit tier **2202 passed / 129 suites**. `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)