### PR TITLE
fix(forms): one shared SG-mobile validator across funnels (P2-14)

### DIFF
--- a/src/components/campaigns/CampaignSignupForm.jsx
+++ b/src/components/campaigns/CampaignSignupForm.jsx
@@ -15,6 +15,7 @@ import { formatDateInput, getAgeValidationError, getAgeRestrictionHint, displayP
 import { LIMITS } from '@/lib/designConfigV2';
 import { getProfileQuestion } from '@/lib/profileQuestionLibrary';
 import { trackFunnelEvent } from '@/lib/pixelCustom';
+import { isValidSgMobile } from '@/utils/validation';
 
 /**
  * Public lead-capture form. Visual style is locked to the warm-cream/Fraunces
@@ -156,12 +157,11 @@ export default function CampaignSignupForm({
   };
 
   const handleSendOtp = async () => {
-    if (formData.phone.length !== 8) {
-      setError('Please enter a valid 8-digit Singapore phone number.');
-      return;
-    }
-    if (!['3', '6', '8', '9'].includes(formData.phone[0])) {
-      setError('Invalid number. Must start with 3, 6, 8, or 9.');
+    // ONE validator across both public funnels (P2-14). This used to accept
+    // 3/6 too — but an OTP is sent to this number, and VoIP/landline numbers
+    // never receive it, so the form was taking leads it could not verify.
+    if (!isValidSgMobile(formData.phone)) {
+      setError('Enter an 8-digit Singapore mobile starting with 8 or 9.');
       return;
     }
 

--- a/src/pages/marketplace/MarketplaceFlow.jsx
+++ b/src/pages/marketplace/MarketplaceFlow.jsx
@@ -23,6 +23,7 @@ import {
   initTikTokPixel, trackTikTokViewContent, trackTikTokLead,
 } from '@/lib/tiktokPixel';
 import { getOrCreateVcState, markVcFired } from '@/lib/pixelSession';
+import { isValidSgMobile } from '@/utils/validation';
 
 /**
  * Marketplace redemption flow (/flow/:slug) — the step machine from the
@@ -237,7 +238,7 @@ export default function MarketplaceFlow() {
         continue;
       }
       if (key === 'name' && v.length < 2) errs.name = 'Please enter your full name.';
-      if (key === 'phone' && !/^[89]\d{7}$/.test(v.replace(/\s/g, ''))) errs.phone = 'Enter an 8-digit Singapore mobile starting with 8 or 9.';
+      if (key === 'phone' && !isValidSgMobile(v.replace(/\s/g, ''))) errs.phone = 'Enter an 8-digit Singapore mobile starting with 8 or 9.';
       if (key === 'email' && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v)) errs.email = 'Enter a valid email address.';
       if (key === 'postal_code' && !/^\d{6}$/.test(v)) errs.postal_code = 'Enter a 6-digit Singapore postal code.';
       if (key === 'dob') {

--- a/src/utils/__tests__/sgMobileParity.test.js
+++ b/src/utils/__tests__/sgMobileParity.test.js
@@ -1,0 +1,64 @@
+/**
+ * P2-14 regression: both public funnels validate SG mobiles the SAME way.
+ *
+ * CampaignSignupForm accepted a first digit of 3/6/8/9 inline; MarketplaceFlow
+ * required /^[89]\d{7}$/. The same design_config therefore accepted a lead on
+ * one customer surface and rejected it on the other, and both feed one backend
+ * pipeline. A shared isValidSgMobile already existed in src/utils/validation.js
+ * — and nothing imported it.
+ *
+ * The unit behaviour lives in validation.test.js. What this file guards is the
+ * property that actually decays: that the funnels keep using the shared rule
+ * instead of growing another private copy.
+ */
+import { describe, it, expect } from 'vitest';
+import { isValidSgMobile } from '../validation';
+// `?raw` gives Vite's own read of the file — no fs, no path, no node globals,
+// and it tracks the module graph rather than a hand-built path.
+import campaignSignupFormSource from '../../components/campaigns/CampaignSignupForm.jsx?raw';
+import marketplaceFlowSource from '../../pages/marketplace/MarketplaceFlow.jsx?raw';
+
+const FUNNELS = [
+  ['CampaignSignupForm', campaignSignupFormSource],
+  ['MarketplaceFlow', marketplaceFlowSource],
+];
+
+describe('both funnels use the shared validator', () => {
+  for (const [name, src] of FUNNELS) {
+    it(`${name} imports isValidSgMobile`, () => {
+      expect(src).toMatch(/import \{[^}]*isValidSgMobile[^}]*\} from ['"]@\/utils\/validation['"]/);
+    });
+
+    it(`${name} carries no private SG-mobile regex or digit list`, () => {
+      // The two shapes that diverged: an inline first-digit allowlist and a
+      // hand-rolled 8-digit pattern.
+      expect(src).not.toMatch(/\[\s*'3'\s*,\s*'6'\s*,\s*'8'\s*,\s*'9'\s*\]/);
+      expect(src).not.toMatch(/\/\^\[[3689]+\]\\d\{7\}\$\//);
+    });
+  }
+});
+
+describe('the shared rule is mobile-only', () => {
+  it.each(['81234567', '91234567', '80000000', '99999999'])('accepts %s', (n) => {
+    expect(isValidSgMobile(n)).toBe(true);
+  });
+
+  it.each([
+    ['61234567', 'fixed-line — cannot receive the OTP'],
+    ['31234567', 'VoIP — cannot receive the OTP'],
+    ['11234567', 'not an SG number'],
+    ['8123456', 'too short'],
+    ['812345678', 'too long'],
+    ['+6581234567', 'country code included'],
+    ['8123 4567', 'unstripped spaces'],
+    ['', 'empty'],
+  ])('rejects %s (%s)', (n) => {
+    expect(isValidSgMobile(n)).toBe(false);
+  });
+
+  it('agrees with the marketplace rule that was already correct', () => {
+    for (const n of ['81234567', '91234567', '61234567', '31234567', '11234567']) {
+      expect(isValidSgMobile(n)).toBe(/^[89]\d{7}$/.test(n));
+    }
+  });
+});

--- a/src/utils/__tests__/validation.test.js
+++ b/src/utils/__tests__/validation.test.js
@@ -61,12 +61,21 @@ describe('isValidSgMobile', () => {
  expect(isValidSgMobile('91234567')).toBe(true);
  });
 
- it('accepts number starting with 6', () => {
- expect(isValidSgMobile('61234567')).toBe(true);
+ /**
+  * P2-14: this asserted 3/6 were valid MOBILES. They are not — 6 is
+  * fixed-line, 3 is VoIP, and neither receives the OTP both public funnels
+  * send before a lead can proceed. Accepting them offered a dead end.
+  */
+ it('rejects a fixed-line number starting with 6 — it cannot receive an OTP', () => {
+ expect(isValidSgMobile('61234567')).toBe(false);
  });
 
- it('accepts number starting with 3', () => {
- expect(isValidSgMobile('31234567')).toBe(true);
+ it('rejects a VoIP number starting with 3', () => {
+ expect(isValidSgMobile('31234567')).toBe(false);
+ });
+
+ it('formatSgPhone still accepts the wider set — storing a landline is fine', () => {
+ expect(formatSgPhone('61234567')).toBe('+6561234567');
  });
 
  it('rejects number starting with 1', () => {

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -12,8 +12,18 @@ export function formatSgPhone(raw) {
 }
 
 /**
- * Check if a string is a valid 8-digit SG mobile number (no country code).
+ * Check if a string is a valid 8-digit SG MOBILE number (no country code).
+ *
+ * Mobile means 8xxxxxxx or 9xxxxxxx. 6 is fixed-line and 3 is VoIP — neither
+ * receives SMS, and both public funnels send an OTP to this number before a
+ * lead can proceed. Accepting them offered the customer a dead end: the form
+ * took the number, the OTP never arrived, and the lead was lost silently
+ * (P2-14). `formatSgPhone` keeps the wider [3689] set on purpose — formatting
+ * a landline for storage is fine; treating one as a mobile is not.
+ *
+ * This matches redeemOps/whatsappService's recipient rule, which has always
+ * been mobile-only for the same reason.
  */
 export function isValidSgMobile(eightDigits) {
- return /^[3689]\d{7}$/.test(eightDigits);
+ return /^[89]\d{7}$/.test(eightDigits);
 }


### PR DESCRIPTION
**Task P2-14** (medium — DRY + correctness) · review round-2 queue

## Defect
`CampaignSignupForm.jsx` accepted a first digit of `['3','6','8','9']` inline; `MarketplaceFlow.jsx` required `/^[89]\d{7}$/`. The same `design_config` therefore **accepted a lead on one customer surface and rejected it on the other**, and both feed the same backend pipeline.

A shared `isValidSgMobile` already existed in `src/utils/validation.js` — with its own tests — and **nothing imported it**. Dead code beside two private copies.

## The rule, stated
**Mobile means `8xxxxxxx` or `9xxxxxxx`.** `6` is fixed-line, `3` is VoIP; neither receives SMS — and *both* funnels send an OTP to this number before a lead can proceed. Accepting 3/6 offered the customer a dead end: the form took the number, the code never arrived, the lead was lost silently.

I checked this against the codebase rather than assuming: the backend's `normalizePhone` accepts `[3689]` (correct — it formats *any* SG number for storage) and `dncService` uses `[3689]` (correct — DNC covers all numbers), but `redeemOps/whatsappService` has always used `[89]` for recipients, for exactly this reason. The function's own **name** says mobile; its regex disagreed with it.

**This tightens the classic funnel** — 3/6 numbers are now refused up front instead of after a silent OTP failure. `formatSgPhone` keeps the wider `[3689]` set on purpose: formatting a landline for storage is fine, treating one as a mobile is not.

## Test proof
`src/utils/__tests__/sgMobileParity.test.js` (new, 17 cases) plus updates to the existing validator tests.

**Pre-fix: `7 failed, 10 passed`** — neither funnel imported the shared validator, both still carried a private rule, and `61234567`/`31234567` were accepted as mobiles.

**Post-fix: `17 passed`.**

The parity file guards the property that actually decays: it reads each funnel's own source (via Vite `?raw`, so it tracks the module graph rather than a hand-built path) and asserts the import is present **and** that no private digit-list or 8-digit regex has grown back.

The two existing tests that asserted 3/6 were valid mobiles were rewritten with the reasoning in place, and a new one pins that `formatSgPhone` still accepts the wider set.

Local: full frontend suite **1797 passed / 142 files**. `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)