### PR TITLE
fix(admin-v2): use v5 placeholderData so lists don't flash empty (P2-16)

### DIFF
--- a/src/hooks/queries/__tests__/placeholderData.test.jsx
+++ b/src/hooks/queries/__tests__/placeholderData.test.jsx
@@ -1,0 +1,92 @@
+/**
+ * P2-16 regression: paginated lists hold their rows across a param change.
+ *
+ * `keepPreviousData: true` is the React-Query **v4** flag. v5 removed it and
+ * ignores it SILENTLY — no warning, no type error, nothing at runtime. So
+ * useAgentsRoster, useWalletLedger and the QR-codes list flashed empty on every
+ * page / agent / filter switch while the next request was in flight, and the
+ * file four lines above them already documented the correct v5 idiom.
+ *
+ * The behavioural half is asserted through a real QueryClient; the source scan
+ * guards the property that decays — that the dead flag does not creep back.
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, useQuery, keepPreviousData } from '@tanstack/react-query';
+import { describe, it, expect, vi } from 'vitest';
+
+import useAdminV2Source from '../useAdminV2.js?raw';
+import qrCodesSource from '../../../pages/adminv2/AdminV2QRCodes.jsx?raw';
+
+const SOURCES = [
+  ['useAdminV2', useAdminV2Source],
+  ['AdminV2QRCodes', qrCodesSource],
+];
+
+/** The literal that v5 ignores — matched only as an OPTION, not in prose. */
+const DEAD_FLAG = /^\s*keepPreviousData:\s*true\s*,?\s*$/m;
+
+describe('no v4 keepPreviousData flag survives', () => {
+  for (const [name, src] of SOURCES) {
+    it(`${name} passes no bare keepPreviousData: true`, () => {
+      expect(src).not.toMatch(DEAD_FLAG);
+    });
+
+    it(`${name} imports the v5 keepPreviousData sentinel it uses`, () => {
+      if (!src.includes('placeholderData: keepPreviousData')) return;
+      expect(src).toMatch(/import \{[^}]*keepPreviousData[^}]*\} from ['"]@tanstack\/react-query['"]/);
+    });
+  }
+});
+
+describe('placeholderData: keepPreviousData holds prior rows', () => {
+  const wrapper = (client) => function Wrapper({ children }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+
+  it('keeps the previous page visible while the next one loads', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const fetchPage = vi.fn(async (page) => ({ rows: [`row-${page}`] }));
+
+    const { result, rerender } = renderHook(
+      ({ page }) => useQuery({
+        queryKey: ['roster', page],
+        queryFn: () => fetchPage(page),
+        placeholderData: keepPreviousData,
+      }),
+      { wrapper: wrapper(client), initialProps: { page: 1 } }
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual({ rows: ['row-1'] }));
+
+    rerender({ page: 2 });
+
+    // THE property: page 1's rows are still on screen while page 2 is in
+    // flight — no empty flash. Without the v5 idiom this is undefined here.
+    expect(result.current.data).toEqual({ rows: ['row-1'] });
+    expect(result.current.isPlaceholderData).toBe(true);
+
+    await waitFor(() => expect(result.current.data).toEqual({ rows: ['row-2'] }));
+    expect(result.current.isPlaceholderData).toBe(false);
+  });
+
+  it('the removed v4 flag does NOT hold rows — this is what the hooks were doing', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const fetchPage = vi.fn(async (page) => ({ rows: [`row-${page}`] }));
+
+    const { result, rerender } = renderHook(
+      ({ page }) => useQuery({
+        queryKey: ['legacy', page],
+        queryFn: () => fetchPage(page),
+        keepPreviousData: true, // v4 flag — v5 ignores it silently
+      }),
+      { wrapper: wrapper(client), initialProps: { page: 1 } }
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual({ rows: ['row-1'] }));
+
+    rerender({ page: 2 });
+
+    // The empty flash, demonstrated.
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/src/hooks/queries/useAdminV2.js
+++ b/src/hooks/queries/useAdminV2.js
@@ -78,7 +78,9 @@ export function useAgentOptions(enabled) {
 }
 
 export function useAgentsRoster(params) {
-  return useQuery({ queryKey: ['adminV2', 'agentsRoster', params], queryFn: () => fetchAgentsRoster(params), staleTime: STALE_MS, keepPreviousData: true });
+  // placeholderData, not the removed v4 `keepPreviousData: true` (P2-16) —
+  // see useProspects above for the same idiom.
+  return useQuery({ queryKey: ['adminV2', 'agentsRoster', params], queryFn: () => fetchAgentsRoster(params), staleTime: STALE_MS, placeholderData: keepPreviousData });
 }
 
 export function useCampaignSummary(id) {
@@ -94,7 +96,7 @@ export function useWalletLedger(agentId, page = 1) {
     queryKey: ['adminV2', 'walletLedger', agentId, page],
     queryFn: () => fetchWalletLedger(agentId, { page }),
     enabled: !!agentId,
-    keepPreviousData: true,
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/src/pages/adminv2/AdminV2QRCodes.jsx
+++ b/src/pages/adminv2/AdminV2QRCodes.jsx
@@ -6,7 +6,7 @@
  * link can't work).
  */
 import { useMemo, useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { apiClient } from '@/api/client';
 import { useCampaignLeaderboard } from '@/hooks/queries/useAdminV2';
@@ -104,7 +104,9 @@ export default function AdminV2QRCodes() {
     queryKey: ['adminV2', 'qrTags', { search, campaignFilter }],
     queryFn: () => fetchQrTags({ search, campaignId: campaignFilter }),
     staleTime: 30_000,
-    keepPreviousData: true,
+    // v4's `keepPreviousData: true` is removed in v5 and silently ignored, so
+    // this list flashed empty on every search/filter change (P2-16).
+    placeholderData: keepPreviousData,
   });
   const campaigns = useCampaignLeaderboard('30d');
   const campaignOptions = useMemo(


### PR DESCRIPTION
**Task P2-16** (medium — data-fetching) · review round-2 queue

## Defect
`keepPreviousData: true` is the React-Query **v4** flag. v5 removed it and **ignores it silently** — no warning, no type error, nothing at runtime. So `useAgentsRoster`, `useWalletLedger` and the QR-codes list flashed empty on every page / agent / filter switch while the next request was in flight.

The same file documents and uses the correct v5 idiom **four lines above** the first offender (`placeholderData: keepPreviousData`, on `useProspects`), which is what made this survivable-looking and easy to miss.

## Fix
All three sites now pass `placeholderData: keepPreviousData`.

The grep the task asked for turned up a **third** site the review hadn't listed — `AdminV2QRCodes.jsx:107` — which also needed the `keepPreviousData` import added. `PartnersList` and `TasksPage` were already correct.

## Test proof
`src/hooks/queries/__tests__/placeholderData.test.jsx` (new, 6 cases).

**Pre-fix: `2 failed, 4 passed`** — both source files still carried a bare `keepPreviousData: true`.

**Post-fix: `6 passed`.**

The behavioural half runs a real `QueryClient` through a page change and asserts both directions, so this isn't only a lint-by-regex:
- with `placeholderData: keepPreviousData`, page 1's rows are **still present** while page 2 is in flight (`isPlaceholderData === true`), then swap in;
- with the v4 flag, `data` is **`undefined`** at that same moment — the empty flash, demonstrated rather than described.

The source scan matches the flag only as an *option line* (anchored regex), so the explanatory comments mentioning it in prose don't trip it.

Local: full frontend suite **1803 passed / 143 files**. `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)