### PR TITLE
fix(data): preserve redemption audit history on entitlement delete (P2-17)

### DIFF
--- a/backend/src/database/migrations/105-redemption-events-restrict.js
+++ b/backend/src/database/migrations/105-redemption-events-restrict.js
@@ -1,0 +1,79 @@
+/**
+ * 105 — the redemption audit trail stops CASCADE-deleting (P2-17).
+ *
+ * RedemptionEvent's own header calls it "Append-only fulfilment history", but
+ * both its foreign keys were ON DELETE CASCADE. Deleting an entitlement — or a
+ * redemption — silently took its audit trail with it. An append-only record
+ * that disappears when its subject does is not a record; it is a cache.
+ *
+ * RESTRICT matches what migration 102 did for reward_inventory_events, and for
+ * the same reason: the history has to outlive the thing it describes, or it
+ * cannot answer the one question it exists for — what happened to this
+ * voucher, and who did it.
+ *
+ * The one path that legitimately purges (partnerService's admin-gated
+ * force-delete) now clears these rows explicitly first, exactly as it already
+ * did for reward_inventory_events. RESTRICT is here to stop the INCIDENTAL
+ * delete, not the deliberate one.
+ *
+ * SET NULL was the alternative and is not available: redemption_events
+ * .entitlementId is NOT NULL, and widening it would make "which voucher?"
+ * unanswerable for the very rows this is meant to protect.
+ */
+
+const FKS = [
+  { column: 'entitlementId', refTable: 'reward_entitlements', name: 'fk_rde_entitlement' },
+  { column: 'redemptionId', refTable: 'redemptions', name: 'fk_rde_redemption' },
+];
+
+/** Drop whatever FK currently guards `column`, whatever Sequelize named it. */
+async function dropExistingFk(q, column) {
+  const [rows] = await q(`
+    SELECT conname FROM pg_constraint
+     WHERE conrelid = 'redemption_events'::regclass
+       AND contype = 'f'
+       AND conkey = ARRAY[(
+         SELECT attnum FROM pg_attribute
+          WHERE attrelid = 'redemption_events'::regclass AND attname = '${column}'
+       )]::smallint[]
+  `);
+  for (const row of rows) {
+    await q(`ALTER TABLE redemption_events DROP CONSTRAINT "${row.conname}"`);
+  }
+}
+
+export async function up(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.transaction(async (t) => {
+    const q = (sql) => sequelize.query(sql, { transaction: t });
+
+    for (const { column, refTable, name } of FKS) {
+      await dropExistingFk(q, column);
+      // NOT VALID → VALIDATE (migration 014): the rewrite of an existing FK
+      // must not hold ACCESS EXCLUSIVE while it re-scans the table.
+      await q(`
+        ALTER TABLE redemption_events ADD CONSTRAINT "${name}"
+        FOREIGN KEY ("${column}") REFERENCES "${refTable}"(id) ON DELETE RESTRICT NOT VALID
+      `);
+      await q(`ALTER TABLE redemption_events VALIDATE CONSTRAINT "${name}"`);
+    }
+  });
+}
+
+export async function down(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.transaction(async (t) => {
+    const q = (sql) => sequelize.query(sql, { transaction: t });
+
+    for (const { column, refTable, name } of FKS) {
+      await q(`ALTER TABLE redemption_events DROP CONSTRAINT IF EXISTS "${name}"`);
+      await q(`
+        ALTER TABLE redemption_events
+        ADD CONSTRAINT "redemption_events_${column}_fkey"
+        FOREIGN KEY ("${column}") REFERENCES "${refTable}"(id) ON DELETE CASCADE
+      `);
+    }
+  });
+}

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -271,8 +271,15 @@ function defineAssociations() {
   RewardInventoryEvent.belongsTo(Activation, { foreignKey: 'activationId', as: 'activation', onDelete: 'RESTRICT' });
   RewardInventoryEvent.belongsTo(RewardEntitlement, { foreignKey: 'entitlementId', as: 'entitlement', onDelete: 'RESTRICT' });
   RewardInventoryEvent.belongsTo(Redemption, { foreignKey: 'redemptionId', as: 'redemption', onDelete: 'RESTRICT' });
-  RedemptionEvent.belongsTo(RewardEntitlement, { foreignKey: 'entitlementId', as: 'entitlement', onDelete: 'CASCADE' });
-  RedemptionEvent.belongsTo(Redemption, { foreignKey: 'redemptionId', as: 'redemption', onDelete: 'CASCADE' });
+  // RESTRICT, not CASCADE (P2-17, migration 105). This table's own header calls
+  // it "Append-only fulfilment history" — and CASCADE meant deleting an
+  // entitlement silently took its redemption audit trail with it. An
+  // append-only record that disappears when its subject does is not a record.
+  // The one path that legitimately purges (partnerService force-delete) now
+  // clears these rows explicitly, the same way it already does for
+  // RewardInventoryEvent.
+  RedemptionEvent.belongsTo(RewardEntitlement, { foreignKey: 'entitlementId', as: 'entitlement', onDelete: 'RESTRICT' });
+  RedemptionEvent.belongsTo(Redemption, { foreignKey: 'redemptionId', as: 'redemption', onDelete: 'RESTRICT' });
 
   // Lucky-draw ledger (docs/plans/lucky-draw-10x.md §4.3)
   const { Draw, DrawEntry, DrawAttempt, DrawBoostReview } = models;

--- a/backend/src/services/redeemOps/partnerService.js
+++ b/backend/src/services/redeemOps/partnerService.js
@@ -3,7 +3,7 @@ import {
   PartnerOrganisation, PartnerLocation, PartnerContact, PartnerAssignmentEvent,
   PartnerStageEvent, OutreachActivity, OutreachTask, ProspectingPoolMember,
   PartnerOnboardingItem, RewardOffer, Activation,
-  RewardEntitlement, Redemption, RewardInventoryEvent, Draw,
+  RewardEntitlement, Redemption, RewardInventoryEvent, RedemptionEvent, Draw,
   RedeemOpsAuditEvent, User, sequelize,
 } from '../../models/index.js';
 import { AppError } from '../../middleware/appError.js';
@@ -40,7 +40,7 @@ export function makePartnerService(overrides = {}) {
     PartnerOrganisation, PartnerLocation, PartnerContact, PartnerAssignmentEvent,
     PartnerStageEvent, OutreachActivity, OutreachTask, ProspectingPoolMember,
     PartnerOnboardingItem, RewardOffer, Activation,
-    RewardEntitlement, Redemption, RewardInventoryEvent, Draw,
+    RewardEntitlement, Redemption, RewardInventoryEvent, RedemptionEvent, Draw,
     RedeemOpsAuditEvent, User, sequelize, logger,
     audit: makeRedeemOpsAuditService(),
     dedupe: makeDedupeService(),
@@ -958,6 +958,23 @@ export function makePartnerService(overrides = {}) {
       }
 
       if (force && hasChain) {
+        // The redemption audit trail is RESTRICT-protected (P2-17), so an
+        // explicit purge must clear it FIRST — mirroring how this block
+        // already handles RewardInventoryEvent below. Deliberate and
+        // admin-gated; RESTRICT exists to stop the INCIDENTAL delete, not this
+        // one. Events reference both sides of the chain, so they go before
+        // either.
+        if (entitlements > 0 || redemptions > 0) {
+          const doomed = await d.RewardEntitlement.findAll({
+            where: entitlementWhere, attributes: ['id'], transaction: t,
+          });
+          const entitlementIds = doomed.map((r) => r.id);
+          if (entitlementIds.length > 0) {
+            await d.RedemptionEvent.destroy({
+              where: { entitlementId: { [Op.in]: entitlementIds } }, transaction: t,
+            });
+          }
+        }
         if (redemptions > 0) {
           await d.Redemption.destroy({ where: { partnerOrganisationId: id }, transaction: t });
         }

--- a/backend/test/redemptionAuditRestrict.test.js
+++ b/backend/test/redemptionAuditRestrict.test.js
@@ -1,0 +1,114 @@
+/**
+ * P2-17 regression: the redemption audit trail outlives its subject.
+ *
+ * RedemptionEvent's own header calls it "Append-only fulfilment history", but
+ * both its foreign keys were ON DELETE CASCADE — so deleting an entitlement
+ * silently took its audit trail with it. An append-only record that disappears
+ * when its subject does is not a record.
+ *
+ * RESTRICT is the same choice migration 102 made for reward_inventory_events:
+ * the history has to survive, or it cannot answer the question it exists for.
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+process.env.REDEEM_OPS_ENTITLEMENTS_ENABLED = 'true';
+
+import { randomBytes } from 'crypto';
+import { getApp, closeDb, createTestUser, createTestCampaign } from './helpers.js';
+import {
+  RewardOffer, Activation, RewardEntitlement, RedemptionEvent, PartnerOrganisation, sequelize,
+} from '../src/models/index.js';
+
+let admin, partner, campaign, offer, activation;
+let phoneSeq = 77000000;
+
+async function entitlementWithHistory() {
+  const entitlement = await RewardEntitlement.create({
+    rewardOfferId: offer.id, activationId: activation.id,
+    partnerOrganisationId: partner.id, status: 'issued',
+    phoneKey: `6590${String(phoneSeq++).padStart(6, '0')}`,
+    presentationTokenHash: randomBytes(32).toString('hex'),
+  });
+  const event = await RedemptionEvent.create({
+    entitlementId: entitlement.id, type: 'unlocked', actorType: 'staff',
+  });
+  return { entitlement, event };
+}
+
+beforeAll(async () => {
+  await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  partner = await PartnerOrganisation.create({
+    tradingName: 'Audit Restrict Spa', normalizedName: 'audit restrict spa', createdBy: admin.user.id,
+  });
+  campaign = await createTestCampaign(admin.user.id, { name: 'Audit Restrict Campaign' });
+  offer = await RewardOffer.create({
+    partnerOrganisationId: partner.id, title: 'Audit Restrict Reward', status: 'active',
+    committedQuantity: 100, allocatedQuantity: 50, claimExpiryDays: 30,
+    redemptionExpiryDays: 90, createdBy: admin.user.id,
+  });
+  activation = await Activation.create({
+    partnerOrganisationId: partner.id, rewardOfferId: offer.id, campaignId: campaign.id,
+    campaignNameSnapshot: campaign.name, allocatedQuantity: 20, status: 'active',
+    unlockPolicy: 'agent_unlock', createdBy: admin.user.id,
+  });
+});
+
+afterAll(async () => { await closeDb(); });
+
+describe('deleting an entitlement cannot erase its history', () => {
+  it('is REFUSED while redemption events reference it', async () => {
+    const { entitlement } = await entitlementWithHistory();
+
+    await expect(entitlement.destroy()).rejects.toThrow(/foreign key constraint/i);
+  });
+
+  it('leaves both the entitlement and its events intact after the refusal', async () => {
+    const { entitlement, event } = await entitlementWithHistory();
+
+    await entitlement.destroy().catch(() => {});
+
+    expect(await RewardEntitlement.findByPk(entitlement.id)).not.toBeNull();
+    expect(await RedemptionEvent.findByPk(event.id)).not.toBeNull();
+  });
+
+  it('allows the delete once the history is deliberately cleared first', async () => {
+    // What partnerService's admin-gated force-purge does: clear the audit rows
+    // explicitly, then delete. RESTRICT stops the INCIDENTAL delete, not this.
+    const { entitlement, event } = await entitlementWithHistory();
+
+    await RedemptionEvent.destroy({ where: { entitlementId: entitlement.id } });
+    await expect(entitlement.destroy()).resolves.toBeDefined();
+
+    expect(await RedemptionEvent.findByPk(event.id)).toBeNull();
+    expect(await RewardEntitlement.findByPk(entitlement.id)).toBeNull();
+  });
+
+  it('an entitlement with no history still deletes freely', async () => {
+    const entitlement = await RewardEntitlement.create({
+      rewardOfferId: offer.id, activationId: activation.id,
+      partnerOrganisationId: partner.id, status: 'issued',
+      phoneKey: `6590${String(phoneSeq++).padStart(6, '0')}`,
+      presentationTokenHash: randomBytes(32).toString('hex'),
+    });
+
+    await expect(entitlement.destroy()).resolves.toBeDefined();
+  });
+});
+
+describe('schema', () => {
+  it('both redemption_events foreign keys are ON DELETE RESTRICT', async () => {
+    const [rows] = await sequelize.query(`
+      SELECT pg_get_constraintdef(oid) AS def FROM pg_constraint
+       WHERE conrelid = 'redemption_events'::regclass AND contype = 'f'
+    `);
+    const refs = rows.map((r) => r.def);
+
+    const entitlementFk = refs.find((d) => d.includes('entitlementId'));
+    const redemptionFk = refs.find((d) => d.includes('redemptionId'));
+
+    expect(entitlementFk).toMatch(/ON DELETE RESTRICT/);
+    expect(redemptionFk).toMatch(/ON DELETE RESTRICT/);
+    // ...and specifically NOT the cascade this task removed.
+    for (const def of refs) expect(def).not.toMatch(/ON DELETE CASCADE/);
+  });
+});


### PR DESCRIPTION
**Task P2-17** (medium — data integrity) · review round-2 queue

## Defect
`RedemptionEvent`'s own header calls it **"Append-only fulfilment history"** — and both its foreign keys were `ON DELETE CASCADE`. Deleting an entitlement (or a redemption) silently took its audit trail with it.

An append-only record that disappears when its subject does is not a record; it's a cache.

## Fix
**Migration 105** rewrites both FKs to `RESTRICT` — the same choice migration 102 made for `reward_inventory_events`, for the same reason: the history has to outlive the thing it describes, or it can't answer the one question it exists for — *what happened to this voucher, and who did it*.

- Declared on the associations too, per the `sync({force:true})`-before-migrations gotcha.
- `NOT VALID → VALIDATE`, so replacing an existing FK never holds `ACCESS EXCLUSIVE` through a table scan. The drop finds the current constraint by column rather than by a guessed Sequelize name.
- **`SET NULL` was the alternative and isn't available**: `redemption_events.entitlementId` is `NOT NULL`, and widening it would make "which voucher?" unanswerable for exactly the rows this protects.

### The one path that legitimately deletes
`partnerService`'s admin-gated **force-purge** destroys entitlements, so it now clears these rows explicitly first — mirroring what it already did for `RewardInventoryEvent` after P1-8. Events reference *both* sides of the chain, so they're cleared before either. **RESTRICT is here to stop the incidental delete, not the deliberate one** — and `redeemOpsPartners` passing confirms that path still works.

## Test proof
`backend/test/redemptionAuditRestrict.test.js` (new, 5 cases).

**Pre-fix (CASCADE association restored): `3 failed, 2 passed`**
- `is REFUSED while redemption events reference it` → **"Received promise resolved instead of rejected"** — the delete went through
- the audit event read back as **`null`** — silently erased
- the FK read back as `ON DELETE CASCADE`

**Post-fix: `5 passed`** — the delete is refused, both rows survive the refusal, a deliberate clear-then-delete still works, an entitlement with no history still deletes freely, and neither FK carries CASCADE any more.

Local: migration tier **23 passed**; `redemptionAuditRestrict`, `redeemOpsPartners`, `redeemOpsFulfilment`, `redeemOpsFulfilmentDelivery`, `redeemOpsVoidRedemption`, `integration/erasure` → **111 passed**; full unit tier **2202 passed / 129 suites**. `eslint src/ --quiet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)