### PR TITLE
fix(data): Payment timestamp defaults match prod schema (P2-18)

### DIFF
--- a/backend/src/models/AgentGroupMember.js
+++ b/backend/src/models/AgentGroupMember.js
@@ -1,4 +1,4 @@
-import { DataTypes } from 'sequelize';
+import { DataTypes, Sequelize } from 'sequelize';
 import { sequelize } from '../database/connection.js';
 
 const AgentGroupMember = sequelize.define('AgentGroupMember', {
@@ -43,7 +43,20 @@ const AgentGroupMember = sequelize.define('AgentGroupMember', {
     type: DataTypes.INTEGER,
     allowNull: false,
     defaultValue: 0
-  }
+  },
+  // Explicit timestamp defaults so the MODEL-built schema (test boot's
+  // sync({force:true})) matches what migration 023 created in prod. Without a DB
+  // default here Sequelize emits these NOT NULL with NO default: a raw INSERT
+  // that omits them succeeds in prod and dies in every test (CLAUDE.md's
+  // "test schema != prod schema"). The ORM still fills them on create/update —
+  // this only makes the database agree.
+  //
+  // fn('NOW'), NOT DataTypes.NOW: the latter is an ORM-side default only and
+  // emits no DEFAULT clause at all (verified against this Sequelize version),
+  // so it would have looked like a fix and changed nothing. This is the same
+  // expression the migration uses.
+  createdAt: { type: DataTypes.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
+  updatedAt: { type: DataTypes.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') }
 }, {
   tableName: 'agent_group_members',
   indexes: [

--- a/backend/src/models/ExternalAgent.js
+++ b/backend/src/models/ExternalAgent.js
@@ -1,4 +1,4 @@
-import { DataTypes } from 'sequelize';
+import { DataTypes, Sequelize } from 'sequelize';
 import { sequelize } from '../database/connection.js';
 
 /**
@@ -45,7 +45,20 @@ const ExternalAgent = sequelize.define('ExternalAgent', {
     defaultValue: 0,
     validate: { min: 0 },
     comment: 'Global prepaid lead balance; decremented atomically by 1 per external assignment.'
-  }
+  },
+  // Explicit timestamp defaults so the MODEL-built schema (test boot's
+  // sync({force:true})) matches what migration 027 created in prod. Without a DB
+  // default here Sequelize emits these NOT NULL with NO default: a raw INSERT
+  // that omits them succeeds in prod and dies in every test (CLAUDE.md's
+  // "test schema != prod schema"). The ORM still fills them on create/update —
+  // this only makes the database agree.
+  //
+  // fn('NOW'), NOT DataTypes.NOW: the latter is an ORM-side default only and
+  // emits no DEFAULT clause at all (verified against this Sequelize version),
+  // so it would have looked like a fix and changed nothing. This is the same
+  // expression the migration uses.
+  createdAt: { type: DataTypes.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
+  updatedAt: { type: DataTypes.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') }
 }, {
   tableName: 'external_agents',
   timestamps: true

--- a/backend/src/models/ExternalCampaignAgent.js
+++ b/backend/src/models/ExternalCampaignAgent.js
@@ -1,4 +1,4 @@
-import { DataTypes } from 'sequelize';
+import { DataTypes, Sequelize } from 'sequelize';
 import { sequelize } from '../database/connection.js';
 
 /**
@@ -29,7 +29,20 @@ const ExternalCampaignAgent = sequelize.define('ExternalCampaignAgent', {
     type: DataTypes.BOOLEAN,
     allowNull: false,
     defaultValue: true
-  }
+  },
+  // Explicit timestamp defaults so the MODEL-built schema (test boot's
+  // sync({force:true})) matches what migration 030 created in prod. Without a DB
+  // default here Sequelize emits these NOT NULL with NO default: a raw INSERT
+  // that omits them succeeds in prod and dies in every test (CLAUDE.md's
+  // "test schema != prod schema"). The ORM still fills them on create/update —
+  // this only makes the database agree.
+  //
+  // fn('NOW'), NOT DataTypes.NOW: the latter is an ORM-side default only and
+  // emits no DEFAULT clause at all (verified against this Sequelize version),
+  // so it would have looked like a fix and changed nothing. This is the same
+  // expression the migration uses.
+  createdAt: { type: DataTypes.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
+  updatedAt: { type: DataTypes.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') }
 }, {
   tableName: 'external_campaign_agents',
   indexes: [

--- a/backend/src/models/Payment.js
+++ b/backend/src/models/Payment.js
@@ -1,4 +1,4 @@
-import { DataTypes, Op } from 'sequelize';
+import { DataTypes, Op, Sequelize } from 'sequelize';
 import { sequelize } from '../database/connection.js';
 
 /**
@@ -130,6 +130,19 @@ const Payment = sequelize.define('Payment', {
     type: DataTypes.JSON,
     allowNull: true,
   },
+  // Explicit timestamp defaults so the MODEL-built schema (test boot's
+  // sync({force:true})) matches what migration 040 created in prod. Without a DB
+  // default here Sequelize emits these NOT NULL with NO default: a raw INSERT
+  // that omits them succeeds in prod and dies in every test (CLAUDE.md's
+  // "test schema != prod schema"). The ORM still fills them on create/update —
+  // this only makes the database agree.
+  //
+  // fn('NOW'), NOT DataTypes.NOW: the latter is an ORM-side default only and
+  // emits no DEFAULT clause at all (verified against this Sequelize version),
+  // so it would have looked like a fix and changed nothing. This is the same
+  // expression the migration uses.
+  createdAt: { type: DataTypes.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
+  updatedAt: { type: DataTypes.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') }
 }, {
   tableName: 'payments',
   indexes: [

--- a/backend/src/models/WaitlistSignup.js
+++ b/backend/src/models/WaitlistSignup.js
@@ -1,4 +1,4 @@
-import { DataTypes, Model } from 'sequelize';
+import { DataTypes, Model, Sequelize } from 'sequelize';
 import { sequelize } from '../database/connection.js';
 
 /**
@@ -46,7 +46,20 @@ WaitlistSignup.init({
     // when the admin notification email was successfully sent (null = not sent)
     type: DataTypes.DATE,
     allowNull: true
-  }
+  },
+  // Explicit timestamp defaults so the MODEL-built schema (test boot's
+  // sync({force:true})) matches what migration 033 created in prod. Without a DB
+  // default here Sequelize emits these NOT NULL with NO default: a raw INSERT
+  // that omits them succeeds in prod and dies in every test (CLAUDE.md's
+  // "test schema != prod schema"). The ORM still fills them on create/update —
+  // this only makes the database agree.
+  //
+  // fn('NOW'), NOT DataTypes.NOW: the latter is an ORM-side default only and
+  // emits no DEFAULT clause at all (verified against this Sequelize version),
+  // so it would have looked like a fix and changed nothing. This is the same
+  // expression the migration uses.
+  createdAt: { type: DataTypes.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
+  updatedAt: { type: DataTypes.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') }
 }, {
   sequelize,
   modelName: 'WaitlistSignup',

--- a/backend/test/schemaTimestampParity.test.js
+++ b/backend/test/schemaTimestampParity.test.js
@@ -1,0 +1,83 @@
+/**
+ * P2-18 regression: the model-built schema agrees with prod on timestamps.
+ *
+ * Test boot runs sync({force:true}) from the MODELS and only THEN replays
+ * migrations, so a table's shape in test comes from its model. Sequelize emits
+ * implicit createdAt/updatedAt as NOT NULL with NO database default (it fills
+ * them in the ORM), while the migrations that created these tables declare
+ * DEFAULT NOW(). The two schemas therefore disagree, and the disagreement is
+ * invisible until someone writes a raw INSERT: it succeeds in prod and dies in
+ * every test — on `payments`, the most financially consequential table here.
+ *
+ * Nothing trips it today (no raw INSERT omits the timestamps), so this is a
+ * trap being closed, not an outage being fixed. These assert the parity
+ * directly against the live test schema.
+ */
+import { sequelize } from '../src/models/index.js';
+import { getApp, closeDb } from './helpers.js';
+
+/** Every table whose migration declares DEFAULT NOW() on its timestamps. */
+const TABLES = [
+  'payments',
+  'agent_group_members',
+  'external_agents',
+  'external_campaign_agents',
+  'waitlist_signups',
+];
+
+const defaultsFor = async (table) => {
+  const [rows] = await sequelize.query(
+    `SELECT column_name, column_default, is_nullable
+       FROM information_schema.columns
+      WHERE table_name = :table AND column_name IN ('createdAt', 'updatedAt')`,
+    { replacements: { table } }
+  );
+  return Object.fromEntries(rows.map((r) => [r.column_name, r]));
+};
+
+beforeAll(async () => { await getApp(); });
+afterAll(async () => { await closeDb(); });
+
+describe('timestamp defaults match the production schema', () => {
+  it.each(TABLES)('%s carries a DB-level default on both timestamps', async (table) => {
+    const cols = await defaultsFor(table);
+
+    expect(cols.createdAt).toBeDefined();
+    expect(cols.updatedAt).toBeDefined();
+    // The point: a default EXISTS, so the column does not depend on the ORM.
+    expect(cols.createdAt.column_default).not.toBeNull();
+    expect(cols.updatedAt.column_default).not.toBeNull();
+    expect(cols.createdAt.is_nullable).toBe('NO');
+    expect(cols.updatedAt.is_nullable).toBe('NO');
+  });
+});
+
+describe('a raw INSERT that omits the timestamps succeeds', () => {
+  it('inserts a payment without naming createdAt/updatedAt', async () => {
+    // The exact shape that passed in prod and died in test.
+    const [rows] = await sequelize.query(
+      `INSERT INTO payments (id, amount, "leadCount", currency, status, source)
+       VALUES (gen_random_uuid(), 15.00, 1, 'SGD', 'pending', 'web')
+       RETURNING id, "createdAt", "updatedAt"`
+    );
+
+    const row = rows[0];
+    expect(row.createdAt).not.toBeNull();
+    expect(row.updatedAt).not.toBeNull();
+
+    await sequelize.query('DELETE FROM payments WHERE id = :id', { replacements: { id: row.id } });
+  });
+
+  it('inserts a waitlist signup without naming them either', async () => {
+    const [rows] = await sequelize.query(
+      `INSERT INTO waitlist_signups (id, email)
+       VALUES (gen_random_uuid(), 'timestamp-parity@test.com')
+       RETURNING id, "createdAt", "updatedAt"`
+    );
+
+    const row = rows[0];
+    expect(row.createdAt).not.toBeNull();
+
+    await sequelize.query('DELETE FROM waitlist_signups WHERE id = :id', { replacements: { id: row.id } });
+  });
+});


### PR DESCRIPTION
**P2-18** — `backend/src/models/Payment.js`

## The defect

Test boot builds the schema from the MODELS via `sync({force:true})` and only then replays migrations, so a table's shape in test comes from its model. Sequelize emits implicit `createdAt`/`updatedAt` as **NOT NULL with no database default** (it fills them in the ORM), while the migrations that created these tables declare `DEFAULT NOW()`. Any raw INSERT that omits the timestamps therefore succeeds in prod and dies in every test — on `payments`, the most financially consequential table in this repo.

Nothing trips it today (no raw INSERT omits them), so this closes a trap rather than fixing an outage.

## The prescribed fix does not work

The task says to use `defaultValue: DataTypes.NOW`, citing WalletLedger as "the pattern that got this right". I probed it before shipping: `DataTypes.NOW` is an **ORM-side default only** and emits no `DEFAULT` clause at all — a probe table built from such a model comes back with `column_default: null`. It would have looked like a fix and changed nothing. (WalletLedger has the same non-default; the precedent is not a precedent.)

`Sequelize.fn('NOW')` is what actually emits the default, and it is the same expression the migrations already use.

## Scope

The grep the task asked for found four more model-backed tables with the identical divergence, all fixed the same way:

| Model | Table | Migration that declared `DEFAULT NOW()` |
|---|---|---|
| `Payment` | `payments` | 040 |
| `AgentGroupMember` | `agent_group_members` | 023 |
| `ExternalAgent` | `external_agents` | 027 |
| `ExternalCampaignAgent` | `external_campaign_agents` | 030 |
| `WaitlistSignup` | `waitlist_signups` | 033 |

The ORM still fills these on create/update — this only makes the database agree.

## Test proof

`backend/test/schemaTimestampParity.test.js` (7 cases): five assert `information_schema.columns.column_default` is non-null on both timestamps; two drive the failure shape directly with a raw INSERT that names neither column.

- **Pre-fix** (models reverted): **7 failed** — `column_default` came back `Received: null` for all five tables, and both raw INSERTs errored.
- **Post-fix**: **7 passed**.

## Verification

- Unit tier: 129 suites / 2202 tests pass
- DB suites `schemaTimestampParity`, `migrations`, `agentGroups`, `leadPackages`, `externalEntitlementsAgentSurface`: 5 suites / 107 tests pass
- `npx eslint src/ --quiet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)